### PR TITLE
chore: enable nx caching for build test lint typecheck

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -52,7 +52,20 @@
     }
   ],
   "targetDefaults": {
+    "build": {
+      "cache": true,
+      "outputs": ["{projectRoot}/dist"]
+    },
     "knip": {
+      "cache": true
+    },
+    "lint": {
+      "cache": true
+    },
+    "test": {
+      "cache": true
+    },
+    "typecheck": {
       "cache": true
     }
   }


### PR DESCRIPTION
## Why

Local and CI task runs for `build`, `test`, `lint`, and `typecheck` were not opted into Nx caching, so repeated runs re-executed even when inputs were unchanged. Aligning with the previous workspace setup restores incremental task caching for those targets.

## What Changed

Enabled `cache: true` in `nx.json` `targetDefaults` for `build`, `lint`, `test`, and `typecheck`, and declared `{projectRoot}/dist` as the build output so Nx can restore build artifacts from cache.