### PR TITLE
feat(cli): add harness-cli with local repo inspect

### DIFF
--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -1,0 +1,28 @@
+# @ready-for-agent/cli
+
+CLI for the ready-for-agent harness.
+
+## Usage
+
+From the repo root:
+
+```bash
+bun run harness-cli add /path/to/local/repo
+```
+
+Inspects a local git repository and prints the harness Repository fields (owner/repo, path, bare, paused). Persistence is not wired yet. The path must be a git repo with a GitHub remote; new repositories are reported as paused.
+
+Example:
+
+```bash
+bun run harness-cli add ~/src/pf/monorepo/
+# Added repository processfocus/monorepo
+#   local path: /home/berend/src/pf/monorepo
+#   bare: true
+#   paused: true
+```
+
+```bash
+bun run harness-cli --help
+bun run harness-cli add --help
+```

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@ready-for-agent/cli",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "bun test",
+    "typecheck": "tsc --noEmit -p tsconfig.app.json"
+  },
+  "nx": {
+    "name": "cli",
+    "targets": {
+      "test": {
+        "command": "bun test",
+        "options": {
+          "cwd": "{projectRoot}"
+        }
+      }
+    }
+  },
+  "dependencies": {
+    "@effect/platform-bun": "^4.0.0-beta.97",
+    "effect": "^4.0.0-beta.97"
+  }
+}

--- a/apps/cli/src/cli.ts
+++ b/apps/cli/src/cli.ts
@@ -1,0 +1,26 @@
+import { Console, Effect } from "effect"
+import { Argument, Command } from "effect/unstable/cli"
+import { LocalGit } from "./services/local-git.ts"
+
+const pathArg = Argument.string("path").pipe(
+  Argument.withDescription("Path to a local git repository"),
+)
+
+const addCommand = Command.make("add", { path: pathArg }, ({ path }) =>
+  Effect.gen(function* () {
+    const localGit = yield* LocalGit
+    const repository = yield* localGit.inspect(path)
+
+    yield* Console.log(
+      `Added repository ${repository.githubOwner}/${repository.githubRepo}`,
+    )
+    yield* Console.log(`  local path: ${repository.localPath}`)
+    yield* Console.log(`  bare: ${repository.isBare}`)
+    yield* Console.log(`  paused: ${repository.paused}`)
+  }),
+).pipe(Command.withDescription("Add a local repository to the harness"))
+
+export const cli = Command.make("harness-cli").pipe(
+  Command.withDescription("CLI for the ready-for-agent harness"),
+  Command.withSubcommands([addCommand]),
+)

--- a/apps/cli/src/domain.ts
+++ b/apps/cli/src/domain.ts
@@ -1,0 +1,7 @@
+export interface LocalRepository {
+  readonly githubOwner: string
+  readonly githubRepo: string
+  readonly localPath: string
+  readonly isBare: boolean
+  readonly paused: true
+}

--- a/apps/cli/src/main.ts
+++ b/apps/cli/src/main.ts
@@ -1,0 +1,13 @@
+import { BunRuntime, BunServices } from "@effect/platform-bun"
+import { Effect, Layer } from "effect"
+import { Command } from "effect/unstable/cli"
+import { cli } from "./cli.ts"
+import { LocalGit } from "./services/local-git.ts"
+
+const MainLive = LocalGit.layer.pipe(Layer.provideMerge(BunServices.layer))
+
+const program = Command.run(cli, { version: "0.0.0" }).pipe(
+  Effect.provide(MainLive),
+)
+
+BunRuntime.runMain(program)

--- a/apps/cli/src/parse-github-remote.test.ts
+++ b/apps/cli/src/parse-github-remote.test.ts
@@ -1,0 +1,69 @@
+import { Option } from "effect"
+import { parseGitHubRemote } from "./parse-github-remote.ts"
+import { describe, expect, test } from "bun:test"
+
+const expectRemote = (url: string, owner: string, repo: string): void => {
+  const result = parseGitHubRemote(url)
+  expect(Option.isSome(result)).toBe(true)
+  if (Option.isSome(result)) {
+    expect(result.value).toEqual({ owner, repo })
+  }
+}
+
+const expectNone = (url: string): void => {
+  expect(Option.isNone(parseGitHubRemote(url))).toBe(true)
+}
+
+describe("parseGitHubRemote", () => {
+  test("ssh scp-style", () => {
+    expectRemote("git@github.com:owner/repo.git", "owner", "repo")
+    expectRemote("git@github.com:owner/repo", "owner", "repo")
+  })
+
+  test("ssh host aliases (multi-account ~/.ssh/config)", () => {
+    expectRemote("git@github.com-work:acme/widget.git", "acme", "widget")
+    expectRemote("git@github.com-personal:me/dotfiles", "me", "dotfiles")
+  })
+
+  test("https", () => {
+    expectRemote("https://github.com/owner/repo.git", "owner", "repo")
+    expectRemote("https://github.com/owner/repo", "owner", "repo")
+    expectRemote("https://www.github.com/owner/repo.git", "owner", "repo")
+    expectRemote("http://github.com/owner/repo.git", "owner", "repo")
+  })
+
+  test("https with embedded credentials", () => {
+    expectRemote(
+      "https://user:token@github.com/owner/repo.git",
+      "owner",
+      "repo",
+    )
+    expectRemote(
+      "https://x-access-token:ghs_abc123@github.com/org/app.git",
+      "org",
+      "app",
+    )
+  })
+
+  test("ssh:// URLs", () => {
+    expectRemote("ssh://git@github.com/owner/repo.git", "owner", "repo")
+    expectRemote("ssh://git@github.com-work/owner/repo.git", "owner", "repo")
+  })
+
+  test("git:// URLs", () => {
+    expectRemote("git://github.com/owner/repo.git", "owner", "repo")
+  })
+
+  test("trims whitespace and strips trailing slash", () => {
+    expectRemote("  git@github.com:owner/repo.git  ", "owner", "repo")
+    expectRemote("https://github.com/owner/repo/", "owner", "repo")
+  })
+
+  test("rejects non-GitHub remotes", () => {
+    expectNone("git@gitlab.com:owner/repo.git")
+    expectNone("https://gitlab.com/owner/repo.git")
+    expectNone("https://bitbucket.org/owner/repo.git")
+    expectNone("not-a-url")
+    expectNone("")
+  })
+})

--- a/apps/cli/src/parse-github-remote.ts
+++ b/apps/cli/src/parse-github-remote.ts
@@ -1,0 +1,35 @@
+import { Option } from "effect"
+
+export type GitHubRemote = {
+  readonly owner: string
+  readonly repo: string
+}
+
+const githubRemotePatterns = [
+  // git@github.com:owner/repo.git
+  // git@github.com-work:owner/repo.git (SSH host alias)
+  /^git@[^:]*(?:github\.com)[^:]*:([^/]+)\/(.+?)(?:\.git)?\/?$/,
+  // https://github.com/owner/repo.git
+  // https://user:token@github.com/owner/repo.git
+  // https://www.github.com/owner/repo
+  /^https?:\/\/(?:[^@/\s]+@)?(?:www\.)?github\.com\/([^/]+)\/(.+?)(?:\.git)?\/?$/,
+  // ssh://git@github.com/owner/repo.git
+  // ssh://git@github.com-work/owner/repo.git
+  /^ssh:\/\/[^/]*(?:github\.com)[^/]*\/([^/]+)\/(.+?)(?:\.git)?\/?$/,
+  // git://github.com/owner/repo.git
+  /^git:\/\/(?:www\.)?github\.com\/([^/]+)\/(.+?)(?:\.git)?\/?$/,
+] as const
+
+export const parseGitHubRemote = (url: string): Option.Option<GitHubRemote> => {
+  const trimmed = url.trim()
+  for (const pattern of githubRemotePatterns) {
+    const match = pattern.exec(trimmed)
+    if (match?.[1] && match[2]) {
+      return Option.some({
+        owner: match[1],
+        repo: match[2].replace(/\.git$/, ""),
+      })
+    }
+  }
+  return Option.none()
+}

--- a/apps/cli/src/services/local-git.ts
+++ b/apps/cli/src/services/local-git.ts
@@ -1,0 +1,160 @@
+import {
+  Context,
+  Effect,
+  FileSystem,
+  Layer,
+  Option,
+  Path,
+  Schema,
+} from "effect"
+import type { PlatformError } from "effect/PlatformError"
+import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process"
+import type { LocalRepository } from "../domain.ts"
+import { parseGitHubRemote } from "../parse-github-remote.ts"
+
+class PathNotFound extends Schema.TaggedErrorClass<PathNotFound>()(
+  "PathNotFound",
+  { path: Schema.String },
+) {
+  override get message() {
+    return `Path not found: ${this.path}`
+  }
+}
+
+class NotADirectory extends Schema.TaggedErrorClass<NotADirectory>()(
+  "NotADirectory",
+  { path: Schema.String },
+) {
+  override get message() {
+    return `Not a directory: ${this.path}`
+  }
+}
+
+class NotAGitRepository extends Schema.TaggedErrorClass<NotAGitRepository>()(
+  "NotAGitRepository",
+  { path: Schema.String },
+) {
+  override get message() {
+    return `Not a git repository: ${this.path}`
+  }
+}
+
+class NoGitHubRemote extends Schema.TaggedErrorClass<NoGitHubRemote>()(
+  "NoGitHubRemote",
+  { path: Schema.String },
+) {
+  override get message() {
+    return `No GitHub remote found for: ${this.path}`
+  }
+}
+
+type LocalGitError =
+  | PathNotFound
+  | NotADirectory
+  | NotAGitRepository
+  | NoGitHubRemote
+  | PlatformError
+
+export class LocalGit extends Context.Service<
+  LocalGit,
+  {
+    readonly inspect: (
+      path: string,
+    ) => Effect.Effect<LocalRepository, LocalGitError>
+  }
+>()("@ready-for-agent/cli/LocalGit") {
+  static readonly layer = Layer.effect(
+    LocalGit,
+    Effect.gen(function* () {
+      const fs = yield* FileSystem.FileSystem
+      const pathService = yield* Path.Path
+      const spawner = yield* ChildProcessSpawner.ChildProcessSpawner
+
+      const gitString = (cwd: string, args: ReadonlyArray<string>) =>
+        spawner
+          .string(ChildProcess.make("git", args, { cwd }))
+          .pipe(Effect.map((output) => output.trim()))
+
+      const gitExitCode = (cwd: string, args: ReadonlyArray<string>) =>
+        spawner.exitCode(
+          ChildProcess.make("git", args, {
+            cwd,
+            stdout: "ignore",
+            stderr: "ignore",
+          }),
+        )
+
+      const inspect = Effect.fn("LocalGit.inspect")(function* (
+        inputPath: string,
+      ) {
+        const absolutePath = pathService.resolve(inputPath)
+        const exists = yield* fs.exists(absolutePath)
+        if (!exists) {
+          return yield* new PathNotFound({ path: absolutePath })
+        }
+
+        const info = yield* fs.stat(absolutePath)
+        if (info.type !== "Directory") {
+          return yield* new NotADirectory({ path: absolutePath })
+        }
+
+        const localPath = yield* fs.realPath(absolutePath)
+
+        const gitDirCode = yield* gitExitCode(localPath, [
+          "rev-parse",
+          "--git-dir",
+        ])
+        if (gitDirCode !== 0) {
+          return yield* new NotAGitRepository({ path: localPath })
+        }
+
+        const isBareOutput = yield* gitString(localPath, [
+          "rev-parse",
+          "--is-bare-repository",
+        ])
+        const isBare = isBareOutput === "true"
+
+        const originExit = yield* gitExitCode(localPath, [
+          "remote",
+          "get-url",
+          "origin",
+        ])
+
+        const remoteUrl =
+          originExit === 0
+            ? yield* gitString(localPath, ["remote", "get-url", "origin"])
+            : yield* gitString(localPath, ["remote", "-v"]).pipe(
+                Effect.map((output) => {
+                  const line = output
+                    .split("\n")
+                    .map((entry) => entry.trim())
+                    .find((entry) => entry.includes("github.com"))
+                  if (!line) {
+                    return undefined
+                  }
+                  return line.split(/\s+/)[1]
+                }),
+              )
+
+        if (!remoteUrl) {
+          return yield* new NoGitHubRemote({ path: localPath })
+        }
+
+        const github = parseGitHubRemote(remoteUrl)
+        if (Option.isNone(github)) {
+          return yield* new NoGitHubRemote({ path: localPath })
+        }
+
+        return {
+          githubOwner: github.value.owner,
+          githubRepo: github.value.repo,
+          localPath,
+          isBare,
+          paused: true as const,
+        }
+      })
+
+      return { inspect }
+    }),
+  )
+}

--- a/apps/cli/tsconfig.app.json
+++ b/apps/cli/tsconfig.app.json
@@ -1,0 +1,18 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "allowImportingTsExtensions": true,
+    "composite": false,
+    "declaration": false,
+    "declarationMap": false,
+    "emitDeclarationOnly": false,
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
+    "noEmit": true,
+    "rootDir": "src",
+    "tsBuildInfoFile": "./out-tsc/app/tsconfig.app.tsbuildinfo",
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/**/*.test.ts"]
+}

--- a/apps/cli/tsconfig.json
+++ b/apps/cli/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.app.json"
+    }
+  ]
+}

--- a/apps/harness/README.md
+++ b/apps/harness/README.md
@@ -1,0 +1,11 @@
+# Harness
+
+## Development
+
+From the repository root, start the Vite development server with:
+
+```bash
+bunx nx dev harness
+```
+
+The application is available at http://localhost:4200.

--- a/apps/harness/project.json
+++ b/apps/harness/project.json
@@ -1,0 +1,14 @@
+{
+  "name": "harness",
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "targets": {
+    "dev": {
+      "continuous": true,
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "vite",
+        "cwd": "apps/harness"
+      }
+    }
+  }
+}

--- a/bun.lock
+++ b/bun.lock
@@ -24,6 +24,14 @@
         "typescript": "npm:@typescript/typescript6@^6.0.2",
       },
     },
+    "apps/cli": {
+      "name": "@ready-for-agent/cli",
+      "version": "0.0.0",
+      "dependencies": {
+        "@effect/platform-bun": "^4.0.0-beta.97",
+        "effect": "^4.0.0-beta.97",
+      },
+    },
     "apps/harness": {
       "name": "@ready-for-agent/harness",
       "version": "0.0.0",
@@ -321,7 +329,7 @@
 
     "@effect/language-service": ["@effect/language-service@0.86.4", "", { "bin": { "effect-language-service": "cli.js" } }, "sha512-XzAPsbwCdm0gRh0E8wJu3wXECb00QraE3LnbObA4RgHn8u2TEbwAjmBadRnwSgOIElfzZjbsRqNR706/V54hDg=="],
 
-    "@effect/platform-bun": ["@effect/platform-bun@4.0.0-beta.59", "", { "dependencies": { "@effect/platform-node-shared": "^4.0.0-beta.59" }, "peerDependencies": { "effect": "^4.0.0-beta.59" } }, "sha512-1jXCIx34X80ojiK9ACO9Q7RST9CXudRmlAbsP4kPqjUo6aqOuGSWXq9ueBO4LbaIZiioRxtTciom35U9ldfTkQ=="],
+    "@effect/platform-bun": ["@effect/platform-bun@4.0.0-beta.97", "", { "dependencies": { "@effect/platform-node-shared": "^4.0.0-beta.97" }, "peerDependencies": { "effect": "^4.0.0-beta.97" } }, "sha512-WYjC7nKiWfNywIz1zeBEXnrpuHJM86DOi3lSZSSBeHCPz8HYw7IT2FL7u+aaJHHsJCyFiZVAgg2KFS8aMFSJBQ=="],
 
     "@effect/platform-node-shared": ["@effect/platform-node-shared@4.0.0-beta.97", "", { "dependencies": { "@types/ws": "^8.18.1", "ws": "^8.21.0" }, "peerDependencies": { "effect": "^4.0.0-beta.97" } }, "sha512-sAlygOlDLLERk7fC24f7Aa4G3wkEbGyyMEileHTHU2fThiPYSGMqNRK1LLnNr17m2+JR7BHbycwXkJkM18BAQw=="],
 
@@ -524,6 +532,8 @@
     "@oxc-resolver/binding-win32-x64-msvc": ["@oxc-resolver/binding-win32-x64-msvc@11.21.3", "", { "os": "win32", "cpu": "x64" }, "sha512-H7BCt/VnS9hnmMp42eGhZ99izSCRvlnWwy/N71K1/J8QoExwY4262Z8QiEkMDtduRJrztayDxETTckmUuAVL9Q=="],
 
     "@phenomnomnominal/tsquery": ["@phenomnomnominal/tsquery@6.2.0", "", { "dependencies": { "@types/esquery": "^1.5.4", "esquery": "^1.7.0" }, "peerDependencies": { "typescript": ">3.0.0" } }, "sha512-Vo9nkhfZxDB/sBiqIY3pjDC4mOSyure+AFlEW5hcy/tRE82MqCXjRN4InnVNMldinRt0dLYqg4HAU2XPq5e1LA=="],
+
+    "@ready-for-agent/cli": ["@ready-for-agent/cli@workspace:apps/cli"],
 
     "@ready-for-agent/db-schema": ["@ready-for-agent/db-schema@workspace:packages/db-schema"],
 
@@ -821,7 +831,7 @@
 
     "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
 
-    "effect": ["effect@4.0.0-beta.59", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "fast-check": "^4.6.0", "find-my-way-ts": "^0.1.6", "ini": "^6.0.0", "kubernetes-types": "^1.30.0", "msgpackr": "^1.11.9", "multipasta": "^0.2.7", "toml": "^4.1.1", "uuid": "^13.0.0", "yaml": "^2.8.3" } }, "sha512-xyUDLeHSe8d6lWGOvR6Fgn2HL6gYeTZ/S4Jzk9uc4ZUxMPPsNZlNXrvk0C7/utQFzeX7uAWcVnG2BjbA0SRoAA=="],
+    "effect": ["effect@4.0.0-beta.97", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "fast-check": "^4.9.0", "find-my-way-ts": "^0.1.6", "ini": "^7.0.0", "kubernetes-types": "^1.30.0", "msgpackr": "^2.0.4", "multipasta": "^0.2.8", "toml": "^4.1.2", "uuid": "^14.0.1", "yaml": "^2.9.0" } }, "sha512-pK03HpQVxGZOWdwDAy/iwvV8u3KYcUf2mOWyWqaut2zau8V2u6ejWP7b4BELjyUIiZWW1fl/s/VJpgZUcTjThg=="],
 
     "effect-solutions": ["effect-solutions@0.5.3", "", { "dependencies": { "@effect/platform-bun": "4.0.0-beta.59", "effect": "4.0.0-beta.59", "gray-matter": "^4.0.3", "picocolors": "^1.1.1" }, "bin": { "effect-solutions": "bin.js" } }, "sha512-JIG7XV0gJF5eVV+9un5Yp7MEFMGNfuTYxbiV/HzS80zH/9qx9ZOoXd6Mlw0FXdbC41LGcpWYZJG3MnzxYawEWg=="],
 
@@ -941,7 +951,7 @@
 
     "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
 
-    "ini": ["ini@6.0.0", "", {}, "sha512-IBTdIkzZNOpqm7q3dRqJvMaldXjDHWkEDfrwGEQTs5eaQMWV+djAhR+wahyNNMAa+qpbDUhBMVt4ZKNwpPm7xQ=="],
+    "ini": ["ini@7.0.0", "", {}, "sha512-ifK0CgjALofS5bkrcTy4RaQ9Vx2Knf/eLeIO+NaswQEpH1UblrtTSCIvN71qQDMq0PeQ/SSPojvEJp9vvvfr+w=="],
 
     "is-arrayish": ["is-arrayish@0.2.1", "", {}, "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg=="],
 
@@ -1017,7 +1027,7 @@
 
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
-    "msgpackr": ["msgpackr@1.12.1", "", { "optionalDependencies": { "msgpackr-extract": "^3.0.2" } }, "sha512-4EUH9tQHnMmEgzW/MdAP0KIfa1T9AF+htl0ffe2n5vb2EKn9y2co8ccpgWko6S52Jy1PQZKwRnx5/KkYjtd9MQ=="],
+    "msgpackr": ["msgpackr@2.0.4", "", { "optionalDependencies": { "msgpackr-extract": "^3.0.4" } }, "sha512-o1C5KRmuRt+apqMr1HuGSqWStZoRBUpEsCsl15uM9VdAF1qHLtvMOU2En747EnTyEl6c4pzPewRMFF31s1CNbA=="],
 
     "msgpackr-extract": ["msgpackr-extract@3.0.4", "", { "dependencies": { "node-gyp-build-optional-packages": "5.2.2" }, "optionalDependencies": { "@msgpackr-extract/msgpackr-extract-darwin-arm64": "3.0.4", "@msgpackr-extract/msgpackr-extract-darwin-x64": "3.0.4", "@msgpackr-extract/msgpackr-extract-linux-arm": "3.0.4", "@msgpackr-extract/msgpackr-extract-linux-arm64": "3.0.4", "@msgpackr-extract/msgpackr-extract-linux-x64": "3.0.4", "@msgpackr-extract/msgpackr-extract-win32-x64": "3.0.4" }, "bin": { "download-msgpackr-prebuilds": "bin/download-prebuilds.js" } }, "sha512-4kmO/MdyUIkLIvTPr8VHLil4AtoKIoniWPIEk5+CDy0xnWC84azhSFmuJ7PxZdsYtiP5kEeQsORAVIeMgxT+Hw=="],
 
@@ -1211,7 +1221,7 @@
 
     "util-deprecate": ["util-deprecate@1.0.2", "", {}, "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="],
 
-    "uuid": ["uuid@13.0.2", "", { "bin": { "uuid": "dist-node/bin/uuid" } }, "sha512-vzi9uRZ926x4XV73S/4qQaTwPXM2JBj6/6lI/byHH1jOpCzb0zDbfytgA9LcN/hzb2l7WQSQnxITOVx5un/wGw=="],
+    "uuid": ["uuid@14.0.1", "", { "bin": { "uuid": "dist-node/bin/uuid" } }, "sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew=="],
 
     "vite": ["vite@7.3.6", "", { "dependencies": { "esbuild": "^0.27.0 || ^0.28.0", "fdir": "^6.5.0", "picomatch": "^4.0.3", "postcss": "^8.5.6", "rollup": "^4.43.0", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "jiti": ">=1.21.0", "less": "^4.0.0", "lightningcss": "^1.21.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-4XP60spRGjSZFf1qYH+dJIkK2znL3zQfl9KkOV9MkkRR/3Dls0dxaBsQPTloEc5BLXWPL9vsOxopxyKoMmDueg=="],
 
@@ -1279,6 +1289,12 @@
 
     "cosmiconfig-typescript-loader/jiti": ["jiti@2.6.1", "", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ=="],
 
+    "effect-solutions/@effect/platform-bun": ["@effect/platform-bun@4.0.0-beta.59", "", { "dependencies": { "@effect/platform-node-shared": "^4.0.0-beta.59" }, "peerDependencies": { "effect": "^4.0.0-beta.59" } }, "sha512-1jXCIx34X80ojiK9ACO9Q7RST9CXudRmlAbsP4kPqjUo6aqOuGSWXq9ueBO4LbaIZiioRxtTciom35U9ldfTkQ=="],
+
+    "effect-solutions/effect": ["effect@4.0.0-beta.59", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "fast-check": "^4.6.0", "find-my-way-ts": "^0.1.6", "ini": "^6.0.0", "kubernetes-types": "^1.30.0", "msgpackr": "^1.11.9", "multipasta": "^0.2.7", "toml": "^4.1.1", "uuid": "^13.0.0", "yaml": "^2.8.3" } }, "sha512-xyUDLeHSe8d6lWGOvR6Fgn2HL6gYeTZ/S4Jzk9uc4ZUxMPPsNZlNXrvk0C7/utQFzeX7uAWcVnG2BjbA0SRoAA=="],
+
+    "global-directory/ini": ["ini@6.0.0", "", {}, "sha512-IBTdIkzZNOpqm7q3dRqJvMaldXjDHWkEDfrwGEQTs5eaQMWV+djAhR+wahyNNMAa+qpbDUhBMVt4ZKNwpPm7xQ=="],
+
     "import-fresh/resolve-from": ["resolve-from@4.0.0", "", {}, "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="],
 
     "js-yaml/argparse": ["argparse@1.0.10", "", { "dependencies": { "sprintf-js": "~1.0.2" } }, "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg=="],
@@ -1308,6 +1324,12 @@
     "@oxc-resolver/binding-wasm32-wasi/@napi-rs/wasm-runtime/@tybys/wasm-util": ["@tybys/wasm-util@0.10.3", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg=="],
 
     "babel-plugin-macros/cosmiconfig/yaml": ["yaml@1.10.3", "", {}, "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA=="],
+
+    "effect-solutions/effect/ini": ["ini@6.0.0", "", {}, "sha512-IBTdIkzZNOpqm7q3dRqJvMaldXjDHWkEDfrwGEQTs5eaQMWV+djAhR+wahyNNMAa+qpbDUhBMVt4ZKNwpPm7xQ=="],
+
+    "effect-solutions/effect/msgpackr": ["msgpackr@1.12.1", "", { "optionalDependencies": { "msgpackr-extract": "^3.0.2" } }, "sha512-4EUH9tQHnMmEgzW/MdAP0KIfa1T9AF+htl0ffe2n5vb2EKn9y2co8ccpgWko6S52Jy1PQZKwRnx5/KkYjtd9MQ=="],
+
+    "effect-solutions/effect/uuid": ["uuid@13.0.2", "", { "bin": { "uuid": "dist-node/bin/uuid" } }, "sha512-vzi9uRZ926x4XV73S/4qQaTwPXM2JBj6/6lI/byHH1jOpCzb0zDbfytgA9LcN/hzb2l7WQSQnxITOVx5un/wGw=="],
 
     "tsx/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.28.1", "", { "os": "aix", "cpu": "ppc64" }, "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ=="],
 

--- a/knip.json
+++ b/knip.json
@@ -3,6 +3,10 @@
   "ignoreDependencies": ["@swc/helpers", "nx"],
   "ignoreBinaries": ["skills"],
   "workspaces": {
+    "apps/cli": {
+      "entry": ["src/main.ts", "src/**/*.test.ts"],
+      "project": ["src/**/*.ts"]
+    },
     "packages/*": {
       "entry": ["src/index.ts", "test/**/*.{test,spec}.ts"],
       "project": ["src/**/*.{ts,tsx}", "test/**/*.ts"]

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "license": "MIT",
   "scripts": {
     "commitlint": "commitlint",
+    "harness-cli": "bun apps/cli/src/main.ts",
     "knip": "knip --no-config-hints",
     "lint": "biome check .",
     "prepare": "bash scripts/install-git-hooks.sh && (effect-language-service patch || true)"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,9 @@
   "files": [],
   "references": [
     {
+      "path": "./apps/cli"
+    },
+    {
       "path": "./apps/harness"
     },
     {


### PR DESCRIPTION
## Why

The harness onboarding flow starts with adding a local git checkout (`bun run harness-cli add /path/to/local/repo`). That CLI did not exist yet. This introduces the Effect-based CLI and the first `add` command so we can validate local repos and surface the Repository fields the harness will store later.

## What Changed

- New `@ready-for-agent/cli` app under `apps/cli`, runnable as `bun run harness-cli`
- Effect CLI with `add <path>` that inspects a local git repo: resolves path, detects bare vs working tree, parses GitHub owner/repo from remotes
- GitHub remote parsing supports scp-style SSH, HTTPS (including embedded credentials), `ssh://` / `git://`, and SSH host aliases like `github.com-work`
- Unit tests for remote URL parsing
- Root script, tsconfig reference, and knip workspace entry for the CLI
- Harness README + `project.json` for the existing SPA app

DB persistence is intentionally deferred until a client package exists; `add` currently prints the resolved Repository fields (including `paused: true`).