### PR TITLE
feat: add Turso-backed job queue packages

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -4,7 +4,7 @@
 - API is graphql (genql)
 - Database is Turso database (sqlite)
 - Backend is Effect TS
-- ulids for ids.
+- Prefixed ULID ids (`{type}-{ulid}`); see `docs/adr/0002-branded-entity-ids.md`.
 - Services are implemented as Effect TS
 - Separate job worker who handles jobs
 - UI is responsive: anything that takes long is put in a queue and handled by the job worker

--- a/bun.lock
+++ b/bun.lock
@@ -51,16 +51,74 @@
         "vite": "^7.0.0",
       },
     },
+    "packages/db": {
+      "name": "@ready-for-agent/db",
+      "version": "0.0.1",
+      "dependencies": {
+        "@effect/sql": "^0.51.1",
+        "@effect/sql-drizzle": "^0.50.0",
+        "@ready-for-agent/db-schema": "workspace:*",
+        "@ready-for-agent/layer-turso-local": "workspace:*",
+        "drizzle-orm": "1.0.0-rc.4-5d5b77c",
+        "effect": "^3.21.4",
+        "tslib": "^2.3.0",
+      },
+      "devDependencies": {
+        "@effect/sql-sqlite-bun": "^0.52.0",
+        "@types/bun": "^1.3.0",
+      },
+    },
     "packages/db-schema": {
       "name": "@ready-for-agent/db-schema",
       "version": "0.0.1",
       "dependencies": {
-        "drizzle-orm": "^1.0.0-rc.4",
+        "drizzle-orm": "1.0.0-rc.4-5d5b77c",
         "tslib": "^2.3.0",
         "ulidx": "^2.4.1",
       },
       "devDependencies": {
-        "drizzle-kit": "^1.0.0-rc.4",
+        "drizzle-kit": "1.0.0-rc.4-5d5b77c",
+      },
+    },
+    "packages/layer-turso-local": {
+      "name": "@ready-for-agent/layer-turso-local",
+      "version": "0.0.1",
+      "dependencies": {
+        "@effect/experimental": "^0.60.0",
+        "@effect/sql": "^0.51.1",
+        "@tursodatabase/database": "0.7.0-pre.13",
+        "effect": "^3.21.4",
+        "tslib": "^2.3.0",
+      },
+      "devDependencies": {
+        "@types/bun": "^1.3.0",
+      },
+    },
+    "packages/queue-service": {
+      "name": "@ready-for-agent/queue-service",
+      "version": "0.0.1",
+      "dependencies": {
+        "effect": "^3.21.4",
+        "tslib": "^2.3.0",
+      },
+      "devDependencies": {
+        "@types/bun": "^1.3.0",
+      },
+    },
+    "packages/sqlite-queue-service": {
+      "name": "@ready-for-agent/sqlite-queue-service",
+      "version": "0.0.1",
+      "dependencies": {
+        "@effect/sql": "^0.51.1",
+        "@ready-for-agent/db": "workspace:*",
+        "@ready-for-agent/db-schema": "workspace:*",
+        "@ready-for-agent/queue-service": "workspace:*",
+        "drizzle-orm": "1.0.0-rc.4-5d5b77c",
+        "effect": "^3.21.4",
+        "tslib": "^2.3.0",
+      },
+      "devDependencies": {
+        "@types/bun": "^1.3.0",
       },
     },
   },
@@ -325,13 +383,23 @@
 
     "@conventional-changelog/template": ["@conventional-changelog/template@1.2.1", "", {}, "sha512-TzlTVpKPjaqW6qOYjQcYUDuGsLCNsvFHVBXkYGTAnf5V37jCWrE5haKNXzz0WZUtVHjrpV76L1buANjwXMfT8w=="],
 
-    "@drizzle-team/brocli": ["@drizzle-team/brocli@0.12.0", "", {}, "sha512-mlUE+rZ8CatQekLhnaiN91Iemdd+e2gFKooGlnRB3oPTL3VghLfX24dx7HrzMNeC1JrIB/0kpsfyty3f5HNfxQ=="],
+    "@drizzle-team/brocli": ["@drizzle-team/brocli@0.11.0", "", {}, "sha512-hD3pekGiPg0WPCCGAZmusBBJsDqGUR66Y452YgQsZOnkdQ7ViEPKuyP4huUGEZQefp8g34RRodXYmJ2TbCH+tg=="],
+
+    "@effect/experimental": ["@effect/experimental@0.60.0", "", { "dependencies": { "uuid": "^11.0.3" }, "peerDependencies": { "@effect/platform": "^0.96.0", "effect": "^3.21.0", "ioredis": "^5", "lmdb": "^3" }, "optionalPeers": ["ioredis", "lmdb"] }, "sha512-i5zIg7Xup2KgHyqHlYtkgqSE1bNzCL0GbbTQxrpIzKF0q/ebknOk/ox8B/gIq2vImjoEE81h/oxU+6i1NH210g=="],
 
     "@effect/language-service": ["@effect/language-service@0.86.4", "", { "bin": { "effect-language-service": "cli.js" } }, "sha512-XzAPsbwCdm0gRh0E8wJu3wXECb00QraE3LnbObA4RgHn8u2TEbwAjmBadRnwSgOIElfzZjbsRqNR706/V54hDg=="],
+
+    "@effect/platform": ["@effect/platform@0.96.2", "", { "dependencies": { "find-my-way-ts": "^0.1.6", "msgpackr": "^1.11.10", "multipasta": "^0.2.7" }, "peerDependencies": { "effect": "^3.21.4" } }, "sha512-oJm3UztdzZvK7BXkFSV3IdyGuqQrhLmViG/hMDZh99ski7aADesNuv19z4R0heH3bAXnSt/Nb8O9KJQ886C0Tg=="],
 
     "@effect/platform-bun": ["@effect/platform-bun@4.0.0-beta.97", "", { "dependencies": { "@effect/platform-node-shared": "^4.0.0-beta.97" }, "peerDependencies": { "effect": "^4.0.0-beta.97" } }, "sha512-WYjC7nKiWfNywIz1zeBEXnrpuHJM86DOi3lSZSSBeHCPz8HYw7IT2FL7u+aaJHHsJCyFiZVAgg2KFS8aMFSJBQ=="],
 
     "@effect/platform-node-shared": ["@effect/platform-node-shared@4.0.0-beta.97", "", { "dependencies": { "@types/ws": "^8.18.1", "ws": "^8.21.0" }, "peerDependencies": { "effect": "^4.0.0-beta.97" } }, "sha512-sAlygOlDLLERk7fC24f7Aa4G3wkEbGyyMEileHTHU2fThiPYSGMqNRK1LLnNr17m2+JR7BHbycwXkJkM18BAQw=="],
+
+    "@effect/sql": ["@effect/sql@0.51.1", "", { "dependencies": { "uuid": "^11.0.3" }, "peerDependencies": { "@effect/experimental": "^0.60.0", "@effect/platform": "^0.96.1", "effect": "^3.21.2" } }, "sha512-iPDAefrJcI0HcTk9keP9Gq8Pg08K1HmpnmZZt85AqyTcvorhoNsXDFiKBbPldfV2CortwVkacX8KjO9GPpSYCA=="],
+
+    "@effect/sql-drizzle": ["@effect/sql-drizzle@0.50.0", "", { "peerDependencies": { "@effect/sql": "^0.51.0", "drizzle-orm": ">=0.43.1 <0.50", "effect": "^3.21.0" } }, "sha512-XcI+g9EvXhEFzj3/tyF3adpnHcKQP5KZn+1GKCjXk0D2GOU8bhFQXM5/dCZEzx8qVlO985E7C/G4Lo4G8l1ivA=="],
+
+    "@effect/sql-sqlite-bun": ["@effect/sql-sqlite-bun@0.52.0", "", { "peerDependencies": { "@effect/experimental": "^0.60.0", "@effect/platform": "^0.96.0", "@effect/sql": "^0.51.0", "effect": "^3.21.0" } }, "sha512-iqQ7SvSNxq0HLjKW5IQ29FsCTzOD1CuX1wuBEuPLLgPCvuEykEHLn4zDrs2qJ+O3CBEUm4kiCy29tmfHE7uAdw=="],
 
     "@emnapi/core": ["@emnapi/core@1.4.5", "", { "dependencies": { "@emnapi/wasi-threads": "1.0.4", "tslib": "^2.4.0" } }, "sha512-XsLw1dEOpkSX/WucdqUhPWP7hDxSvZiY+fsUC14h+FtQ2Ifni4znbBt8punRX+Uj2JG/uDb8nEHVKvrVlvdZ5Q=="],
 
@@ -535,9 +603,17 @@
 
     "@ready-for-agent/cli": ["@ready-for-agent/cli@workspace:apps/cli"],
 
+    "@ready-for-agent/db": ["@ready-for-agent/db@workspace:packages/db"],
+
     "@ready-for-agent/db-schema": ["@ready-for-agent/db-schema@workspace:packages/db-schema"],
 
     "@ready-for-agent/harness": ["@ready-for-agent/harness@workspace:apps/harness"],
+
+    "@ready-for-agent/layer-turso-local": ["@ready-for-agent/layer-turso-local@workspace:packages/layer-turso-local"],
+
+    "@ready-for-agent/queue-service": ["@ready-for-agent/queue-service@workspace:packages/queue-service"],
+
+    "@ready-for-agent/sqlite-queue-service": ["@ready-for-agent/sqlite-queue-service@workspace:packages/sqlite-queue-service"],
 
     "@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-rc.3", "", {}, "sha512-eybk3TjzzzV97Dlj5c+XrBFW57eTNhzod66y9HrBlzJ6NsCrWCp/2kaPS3K9wJmurBC0Tdw4yPjXKZqlznim3Q=="],
 
@@ -629,6 +705,18 @@
 
     "@tanstack/virtual-file-routes": ["@tanstack/virtual-file-routes@1.162.0", "", {}, "sha512-uhOeFyxLcU41HzvrxsGpiWdcMbScY1EDgbZ5K7DVRMYInbLYWAC0EA/kx9wXAoSM8q82bUG2hRl8+EAjE6XAbA=="],
 
+    "@tursodatabase/database": ["@tursodatabase/database@0.7.0-pre.13", "", { "dependencies": { "@tursodatabase/database-common": "^0.7.0-pre.13" }, "optionalDependencies": { "@tursodatabase/database-darwin-arm64": "0.7.0-pre.13", "@tursodatabase/database-linux-arm64-gnu": "0.7.0-pre.13", "@tursodatabase/database-linux-x64-gnu": "0.7.0-pre.13", "@tursodatabase/database-win32-x64-msvc": "0.7.0-pre.13" } }, "sha512-Ma8wb5GSWczSHhYOJsAm0eVR8UMHrTxJU/upa5/HxB0dr8I7q5M6uApf00cfoBMZ6uvTX832+gp8RaWbQvHWow=="],
+
+    "@tursodatabase/database-common": ["@tursodatabase/database-common@0.7.0-pre.17", "", {}, "sha512-ySvzDPl7Npdeg23LT5ptnwSa5nQZxQ/w9SszpgNWGTKjI/MY1VnVe5nInoq6xJj/f73tOJ7wdNdNgxROEG+AaA=="],
+
+    "@tursodatabase/database-darwin-arm64": ["@tursodatabase/database-darwin-arm64@0.7.0-pre.13", "", { "os": "darwin", "cpu": "arm64" }, "sha512-WTnG1QdYrE8qSfO9sLBQZ4l7nnPI8cp/fLPqfoErDAXXHm7Y3MH8bcC4JKRe737UATLhMVHsKlyj+Fd5A6sEfA=="],
+
+    "@tursodatabase/database-linux-arm64-gnu": ["@tursodatabase/database-linux-arm64-gnu@0.7.0-pre.13", "", { "os": "linux", "cpu": "arm64" }, "sha512-EyklrNkHBpEFkcj7kspsyG6a7biOoV3uUc/ySoYZJpOW4x4e6q03k44w1xL1OnnhRKJuqOMF2QoBON+8sMfXHA=="],
+
+    "@tursodatabase/database-linux-x64-gnu": ["@tursodatabase/database-linux-x64-gnu@0.7.0-pre.13", "", { "os": "linux", "cpu": "x64" }, "sha512-EtC3GIyI2bqu0WZhl+uujwX8FDepj/VKs38sdqbnBqGSD0a55U7rHxkaFIVLQerpeEnBM5MbEIUplNo+R3SlBw=="],
+
+    "@tursodatabase/database-win32-x64-msvc": ["@tursodatabase/database-win32-x64-msvc@0.7.0-pre.13", "", { "os": "win32", "cpu": "x64" }, "sha512-8s0meTAWThobb6p/gxJKr3R1x6OsMN55gEdQNJa3uJoFW8QV9QHq9pDCQS8dsJAtf5IxzlNn6/6eiRGIlN9IlQ=="],
+
     "@tybys/wasm-util": ["@tybys/wasm-util@0.9.0", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-6+7nlbMVX/PVDCwaIQ8nTOPveOcFLSt8GcXdx8hD0bt39uWxYT88uXzqTd4fTvqta7oeUJqudepapKNt2DYJFw=="],
 
     "@types/babel__core": ["@types/babel__core@7.20.5", "", { "dependencies": { "@babel/parser": "^7.20.7", "@babel/types": "^7.20.7", "@types/babel__generator": "*", "@types/babel__template": "*", "@types/babel__traverse": "*" } }, "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA=="],
@@ -638,6 +726,8 @@
     "@types/babel__template": ["@types/babel__template@7.4.4", "", { "dependencies": { "@babel/parser": "^7.1.0", "@babel/types": "^7.0.0" } }, "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A=="],
 
     "@types/babel__traverse": ["@types/babel__traverse@7.28.0", "", { "dependencies": { "@babel/types": "^7.28.2" } }, "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q=="],
+
+    "@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
 
     "@types/esquery": ["@types/esquery@1.5.4", "", { "dependencies": { "@types/estree": "*" } }, "sha512-yYO4Q8H+KJHKW1rEeSzHxcZi90durqYgWVfnh5K6ZADVBjBv2e1NEveYX5yT2bffgN7RqzH3k9930m+i2yBoMA=="],
 
@@ -757,6 +847,8 @@
 
     "buffer-from": ["buffer-from@1.1.2", "", {}, "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="],
 
+    "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
+
     "call-bind-apply-helpers": ["call-bind-apply-helpers@1.0.2", "", { "dependencies": { "es-errors": "^1.3.0", "function-bind": "^1.1.2" } }, "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ=="],
 
     "call-bound": ["call-bound@1.0.4", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "get-intrinsic": "^1.3.0" } }, "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg=="],
@@ -825,9 +917,9 @@
 
     "dotenv-expand": ["dotenv-expand@12.0.3", "", { "dependencies": { "dotenv": "^16.4.5" } }, "sha512-uc47g4b+4k/M/SeaW1y4OApx+mtLWl92l5LMPP0GNXctZqELk+YGgOPIIC5elYmUH4OuoK3JLhuRUYegeySiFA=="],
 
-    "drizzle-kit": ["drizzle-kit@1.0.0-rc.4", "", { "dependencies": { "@drizzle-team/brocli": "^0.12.0", "@js-temporal/polyfill": "^0.5.1", "esbuild": "^0.25.10", "get-tsconfig": "^4.13.6", "jiti": "^2.6.1" }, "bin": { "drizzle-kit": "bin.cjs" } }, "sha512-KZCpjRyu+oYHLj/UJogfFlOkWhHVkaEI2EOT1U3NDVXUzLoTyPjqwFxwOrlQxsY6jzRyxcz4EacqboGfhEeYrA=="],
+    "drizzle-kit": ["drizzle-kit@1.0.0-rc.4-5d5b77c", "", { "dependencies": { "@drizzle-team/brocli": "^0.11.0", "@js-temporal/polyfill": "^0.5.1", "esbuild": "^0.25.10", "get-tsconfig": "^4.13.6", "jiti": "^2.6.1" }, "bin": { "drizzle-kit": "bin.cjs" } }, "sha512-cDQOQXacxeaQl0Ib18EfPwVMyfvvybuOBj/f/WclmuGZtxHOTOMTpJ/3qEpoXe8+lCDRagCpS3w1wYQyUmT9wg=="],
 
-    "drizzle-orm": ["drizzle-orm@1.0.0-rc.4", "", { "peerDependencies": { "@aws-sdk/client-rds-data": ">=3", "@cloudflare/workers-types": ">=4", "@effect/sql-d1": ">=4.0.0-beta.83 || >=4.0.0", "@effect/sql-libsql": ">=4.0.0-beta.83 || >=4.0.0", "@effect/sql-mysql2": ">=4.0.0-beta.83 || >=4.0.0", "@effect/sql-pg": ">=4.0.0-beta.83 || >=4.0.0", "@effect/sql-pglite": ">=4.0.0-beta.83 || >=4.0.0", "@effect/sql-sqlite-bun": ">=4.0.0-beta.83 || >=4.0.0", "@effect/sql-sqlite-do": ">=4.0.0-beta.83 || >=4.0.0", "@effect/sql-sqlite-node": ">=4.0.0-beta.83 || >=4.0.0", "@effect/sql-sqlite-wasm": ">=4.0.0-beta.83 || >=4.0.0", "@electric-sql/pglite": ">=0.2.0", "@libsql/client": ">=0.10.0", "@libsql/client-wasm": ">=0.10.0", "@neondatabase/serverless": ">=0.10.0", "@op-engineering/op-sqlite": ">=2", "@opentelemetry/api": "^1.4.1", "@planetscale/database": ">=1.13", "@sinclair/typebox": ">=0.34.8", "@sqlitecloud/drivers": ">=1.0.653", "@tidbcloud/serverless": "*", "@tursodatabase/database": ">=0.6.0-pre.28 || >=0.6.0", "@tursodatabase/database-common": ">=0.6.0-pre.28 || >=0.6.0", "@tursodatabase/database-wasm": ">=0.6.0-pre.28 || >=0.6.0", "@tursodatabase/serverless": ">=1.1.3", "@tursodatabase/sync": ">=0.6.0-pre.28 || >=0.6.0", "@types/better-sqlite3": "*", "@types/mssql": "^9.1.4", "@types/pg": "*", "@types/sql.js": "*", "@upstash/redis": ">=1.34.7", "@vercel/postgres": ">=0.8.0", "@xata.io/client": "*", "arktype": ">=2.0.0", "better-sqlite3": ">=9.3.0", "bun-types": "*", "effect": ">=4.0.0-beta.83 || >=4.0.0", "expo-sqlite": ">=14.0.0", "mssql": "^11.0.1", "mysql2": ">=2", "pg": ">=8", "postgres": ">=3", "sql.js": ">=1", "sqlite3": ">=5", "typebox": ">=1.0.0", "valibot": ">=1.0.0-beta.7", "zod": "^3.25.0 || ^4.0.0" }, "optionalPeers": ["@aws-sdk/client-rds-data", "@cloudflare/workers-types", "@effect/sql-d1", "@effect/sql-libsql", "@effect/sql-mysql2", "@effect/sql-pg", "@effect/sql-pglite", "@effect/sql-sqlite-bun", "@effect/sql-sqlite-do", "@effect/sql-sqlite-node", "@effect/sql-sqlite-wasm", "@electric-sql/pglite", "@libsql/client", "@libsql/client-wasm", "@neondatabase/serverless", "@op-engineering/op-sqlite", "@opentelemetry/api", "@planetscale/database", "@sinclair/typebox", "@sqlitecloud/drivers", "@tidbcloud/serverless", "@tursodatabase/database", "@tursodatabase/database-common", "@tursodatabase/database-wasm", "@tursodatabase/serverless", "@tursodatabase/sync", "@types/better-sqlite3", "@types/mssql", "@types/pg", "@types/sql.js", "@upstash/redis", "@vercel/postgres", "@xata.io/client", "arktype", "better-sqlite3", "bun-types", "effect", "expo-sqlite", "mssql", "mysql2", "pg", "postgres", "sql.js", "sqlite3", "typebox", "valibot", "zod"] }, "sha512-BT+pf+qoiYHqltoA88Jmf6ilGMXPlpfE0hEJKc2adRtMCAl25Swk/t5gXcWxZNAwdtf3F5gCd2FpeOyP/pT0Hw=="],
+    "drizzle-orm": ["drizzle-orm@1.0.0-rc.4-5d5b77c", "", { "peerDependencies": { "@aws-sdk/client-rds-data": ">=3", "@cloudflare/workers-types": ">=4", "@effect/sql-pg": ">=4.0.0-beta.58 || >=4.0.0", "@electric-sql/pglite": ">=0.2.0", "@libsql/client": ">=0.10.0", "@libsql/client-wasm": ">=0.10.0", "@neondatabase/serverless": ">=0.10.0", "@op-engineering/op-sqlite": ">=2", "@opentelemetry/api": "^1.4.1", "@planetscale/database": ">=1.13", "@sinclair/typebox": ">=0.34.8", "@sqlitecloud/drivers": ">=1.0.653", "@tidbcloud/serverless": "*", "@tursodatabase/database": ">=0.2.1", "@tursodatabase/database-common": ">=0.2.1", "@tursodatabase/database-wasm": ">=0.2.1", "@types/better-sqlite3": "*", "@types/mssql": "^9.1.4", "@types/pg": "*", "@types/sql.js": "*", "@upstash/redis": ">=1.34.7", "@vercel/postgres": ">=0.8.0", "@xata.io/client": "*", "arktype": ">=2.0.0", "better-sqlite3": ">=9.3.0", "bun-types": "*", "effect": ">=4.0.0-beta.58 || >=4.0.0", "expo-sqlite": ">=14.0.0", "mssql": "^11.0.1", "mysql2": ">=2", "pg": ">=8", "postgres": ">=3", "sql.js": ">=1", "sqlite3": ">=5", "typebox": ">=1.0.0", "valibot": ">=1.0.0-beta.7", "zod": "^3.25.0 || ^4.0.0" }, "optionalPeers": ["@aws-sdk/client-rds-data", "@cloudflare/workers-types", "@effect/sql-pg", "@electric-sql/pglite", "@libsql/client", "@libsql/client-wasm", "@neondatabase/serverless", "@op-engineering/op-sqlite", "@opentelemetry/api", "@planetscale/database", "@sinclair/typebox", "@sqlitecloud/drivers", "@tidbcloud/serverless", "@tursodatabase/database", "@tursodatabase/database-common", "@tursodatabase/database-wasm", "@types/better-sqlite3", "@types/mssql", "@types/pg", "@types/sql.js", "@upstash/redis", "@vercel/postgres", "@xata.io/client", "arktype", "better-sqlite3", "bun-types", "effect", "expo-sqlite", "mssql", "mysql2", "pg", "postgres", "sql.js", "sqlite3", "typebox", "valibot", "zod"] }, "sha512-Oq9W4B11PracWY9cuCLTFT+JA5kXqR6rBmWcM8oh0xwLgCviVl9wh6ZuWX7Zpv1Jir/8W+M37syvjSYtj1f5iA=="],
 
     "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
 
@@ -1267,6 +1359,22 @@
 
     "@babel/preset-env/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
+    "@effect/experimental/effect": ["effect@3.21.4", "", { "dependencies": { "@standard-schema/spec": "^1.0.0", "fast-check": "^3.23.1" } }, "sha512-B89v/xSgPbl1J2Ai2u18jxq3odpFauU1rC6/eSs4FeNHi72kwKdJp12VGigvRV2lK+kRnx+OOz41XV8guZd4gQ=="],
+
+    "@effect/experimental/uuid": ["uuid@11.1.1", "", { "bin": { "uuid": "dist/esm/bin/uuid" } }, "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ=="],
+
+    "@effect/platform/effect": ["effect@3.21.4", "", { "dependencies": { "@standard-schema/spec": "^1.0.0", "fast-check": "^3.23.1" } }, "sha512-B89v/xSgPbl1J2Ai2u18jxq3odpFauU1rC6/eSs4FeNHi72kwKdJp12VGigvRV2lK+kRnx+OOz41XV8guZd4gQ=="],
+
+    "@effect/platform/msgpackr": ["msgpackr@1.12.1", "", { "optionalDependencies": { "msgpackr-extract": "^3.0.2" } }, "sha512-4EUH9tQHnMmEgzW/MdAP0KIfa1T9AF+htl0ffe2n5vb2EKn9y2co8ccpgWko6S52Jy1PQZKwRnx5/KkYjtd9MQ=="],
+
+    "@effect/sql/effect": ["effect@3.21.4", "", { "dependencies": { "@standard-schema/spec": "^1.0.0", "fast-check": "^3.23.1" } }, "sha512-B89v/xSgPbl1J2Ai2u18jxq3odpFauU1rC6/eSs4FeNHi72kwKdJp12VGigvRV2lK+kRnx+OOz41XV8guZd4gQ=="],
+
+    "@effect/sql/uuid": ["uuid@11.1.1", "", { "bin": { "uuid": "dist/esm/bin/uuid" } }, "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ=="],
+
+    "@effect/sql-drizzle/effect": ["effect@3.21.4", "", { "dependencies": { "@standard-schema/spec": "^1.0.0", "fast-check": "^3.23.1" } }, "sha512-B89v/xSgPbl1J2Ai2u18jxq3odpFauU1rC6/eSs4FeNHi72kwKdJp12VGigvRV2lK+kRnx+OOz41XV8guZd4gQ=="],
+
+    "@effect/sql-sqlite-bun/effect": ["effect@3.21.4", "", { "dependencies": { "@standard-schema/spec": "^1.0.0", "fast-check": "^3.23.1" } }, "sha512-B89v/xSgPbl1J2Ai2u18jxq3odpFauU1rC6/eSs4FeNHi72kwKdJp12VGigvRV2lK+kRnx+OOz41XV8guZd4gQ=="],
+
     "@oxc-parser/binding-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.11.1", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.2", "tslib": "^2.4.0" } }, "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ=="],
 
     "@oxc-parser/binding-wasm32-wasi/@emnapi/runtime": ["@emnapi/runtime@1.11.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw=="],
@@ -1278,6 +1386,14 @@
     "@oxc-resolver/binding-wasm32-wasi/@emnapi/runtime": ["@emnapi/runtime@1.11.0", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-55coeOFKHv1ywEcUXJtWU5f+Jr/W5tZDvZig8DLKSwUN1JpROQ4rk/SNOQiFWmaR/VKF4zuFyW1B8JduOSv6Pg=="],
 
     "@oxc-resolver/binding-wasm32-wasi/@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.6", "", { "dependencies": { "@tybys/wasm-util": "^0.10.3" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" } }, "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg=="],
+
+    "@ready-for-agent/db/effect": ["effect@3.21.4", "", { "dependencies": { "@standard-schema/spec": "^1.0.0", "fast-check": "^3.23.1" } }, "sha512-B89v/xSgPbl1J2Ai2u18jxq3odpFauU1rC6/eSs4FeNHi72kwKdJp12VGigvRV2lK+kRnx+OOz41XV8guZd4gQ=="],
+
+    "@ready-for-agent/layer-turso-local/effect": ["effect@3.21.4", "", { "dependencies": { "@standard-schema/spec": "^1.0.0", "fast-check": "^3.23.1" } }, "sha512-B89v/xSgPbl1J2Ai2u18jxq3odpFauU1rC6/eSs4FeNHi72kwKdJp12VGigvRV2lK+kRnx+OOz41XV8guZd4gQ=="],
+
+    "@ready-for-agent/queue-service/effect": ["effect@3.21.4", "", { "dependencies": { "@standard-schema/spec": "^1.0.0", "fast-check": "^3.23.1" } }, "sha512-B89v/xSgPbl1J2Ai2u18jxq3odpFauU1rC6/eSs4FeNHi72kwKdJp12VGigvRV2lK+kRnx+OOz41XV8guZd4gQ=="],
+
+    "@ready-for-agent/sqlite-queue-service/effect": ["effect@3.21.4", "", { "dependencies": { "@standard-schema/spec": "^1.0.0", "fast-check": "^3.23.1" } }, "sha512-B89v/xSgPbl1J2Ai2u18jxq3odpFauU1rC6/eSs4FeNHi72kwKdJp12VGigvRV2lK+kRnx+OOz41XV8guZd4gQ=="],
 
     "babel-plugin-macros/cosmiconfig": ["cosmiconfig@7.1.0", "", { "dependencies": { "@types/parse-json": "^4.0.0", "import-fresh": "^3.2.1", "parse-json": "^5.0.0", "path-type": "^4.0.0", "yaml": "^1.10.0" } }, "sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA=="],
 
@@ -1315,6 +1431,16 @@
 
     "yargs/yargs-parser": ["yargs-parser@22.0.0", "", {}, "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw=="],
 
+    "@effect/experimental/effect/fast-check": ["fast-check@3.23.2", "", { "dependencies": { "pure-rand": "^6.1.0" } }, "sha512-h5+1OzzfCC3Ef7VbtKdcv7zsstUQwUDlYpUTvjeUsJAssPgLn7QzbboPtL5ro04Mq0rPOsMzl7q5hIbRs2wD1A=="],
+
+    "@effect/platform/effect/fast-check": ["fast-check@3.23.2", "", { "dependencies": { "pure-rand": "^6.1.0" } }, "sha512-h5+1OzzfCC3Ef7VbtKdcv7zsstUQwUDlYpUTvjeUsJAssPgLn7QzbboPtL5ro04Mq0rPOsMzl7q5hIbRs2wD1A=="],
+
+    "@effect/sql-drizzle/effect/fast-check": ["fast-check@3.23.2", "", { "dependencies": { "pure-rand": "^6.1.0" } }, "sha512-h5+1OzzfCC3Ef7VbtKdcv7zsstUQwUDlYpUTvjeUsJAssPgLn7QzbboPtL5ro04Mq0rPOsMzl7q5hIbRs2wD1A=="],
+
+    "@effect/sql-sqlite-bun/effect/fast-check": ["fast-check@3.23.2", "", { "dependencies": { "pure-rand": "^6.1.0" } }, "sha512-h5+1OzzfCC3Ef7VbtKdcv7zsstUQwUDlYpUTvjeUsJAssPgLn7QzbboPtL5ro04Mq0rPOsMzl7q5hIbRs2wD1A=="],
+
+    "@effect/sql/effect/fast-check": ["fast-check@3.23.2", "", { "dependencies": { "pure-rand": "^6.1.0" } }, "sha512-h5+1OzzfCC3Ef7VbtKdcv7zsstUQwUDlYpUTvjeUsJAssPgLn7QzbboPtL5ro04Mq0rPOsMzl7q5hIbRs2wD1A=="],
+
     "@oxc-parser/binding-wasm32-wasi/@emnapi/core/@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.2.2", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA=="],
 
     "@oxc-parser/binding-wasm32-wasi/@napi-rs/wasm-runtime/@tybys/wasm-util": ["@tybys/wasm-util@0.10.3", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg=="],
@@ -1322,6 +1448,14 @@
     "@oxc-resolver/binding-wasm32-wasi/@emnapi/core/@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.2.2", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA=="],
 
     "@oxc-resolver/binding-wasm32-wasi/@napi-rs/wasm-runtime/@tybys/wasm-util": ["@tybys/wasm-util@0.10.3", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg=="],
+
+    "@ready-for-agent/db/effect/fast-check": ["fast-check@3.23.2", "", { "dependencies": { "pure-rand": "^6.1.0" } }, "sha512-h5+1OzzfCC3Ef7VbtKdcv7zsstUQwUDlYpUTvjeUsJAssPgLn7QzbboPtL5ro04Mq0rPOsMzl7q5hIbRs2wD1A=="],
+
+    "@ready-for-agent/layer-turso-local/effect/fast-check": ["fast-check@3.23.2", "", { "dependencies": { "pure-rand": "^6.1.0" } }, "sha512-h5+1OzzfCC3Ef7VbtKdcv7zsstUQwUDlYpUTvjeUsJAssPgLn7QzbboPtL5ro04Mq0rPOsMzl7q5hIbRs2wD1A=="],
+
+    "@ready-for-agent/queue-service/effect/fast-check": ["fast-check@3.23.2", "", { "dependencies": { "pure-rand": "^6.1.0" } }, "sha512-h5+1OzzfCC3Ef7VbtKdcv7zsstUQwUDlYpUTvjeUsJAssPgLn7QzbboPtL5ro04Mq0rPOsMzl7q5hIbRs2wD1A=="],
+
+    "@ready-for-agent/sqlite-queue-service/effect/fast-check": ["fast-check@3.23.2", "", { "dependencies": { "pure-rand": "^6.1.0" } }, "sha512-h5+1OzzfCC3Ef7VbtKdcv7zsstUQwUDlYpUTvjeUsJAssPgLn7QzbboPtL5ro04Mq0rPOsMzl7q5hIbRs2wD1A=="],
 
     "babel-plugin-macros/cosmiconfig/yaml": ["yaml@1.10.3", "", {}, "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA=="],
 
@@ -1442,6 +1576,24 @@
     "yargs/string-width/emoji-regex": ["emoji-regex@10.6.0", "", {}, "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="],
 
     "yargs/string-width/strip-ansi": ["strip-ansi@7.2.0", "", { "dependencies": { "ansi-regex": "^6.2.2" } }, "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w=="],
+
+    "@effect/experimental/effect/fast-check/pure-rand": ["pure-rand@6.1.0", "", {}, "sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA=="],
+
+    "@effect/platform/effect/fast-check/pure-rand": ["pure-rand@6.1.0", "", {}, "sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA=="],
+
+    "@effect/sql-drizzle/effect/fast-check/pure-rand": ["pure-rand@6.1.0", "", {}, "sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA=="],
+
+    "@effect/sql-sqlite-bun/effect/fast-check/pure-rand": ["pure-rand@6.1.0", "", {}, "sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA=="],
+
+    "@effect/sql/effect/fast-check/pure-rand": ["pure-rand@6.1.0", "", {}, "sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA=="],
+
+    "@ready-for-agent/db/effect/fast-check/pure-rand": ["pure-rand@6.1.0", "", {}, "sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA=="],
+
+    "@ready-for-agent/layer-turso-local/effect/fast-check/pure-rand": ["pure-rand@6.1.0", "", {}, "sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA=="],
+
+    "@ready-for-agent/queue-service/effect/fast-check/pure-rand": ["pure-rand@6.1.0", "", {}, "sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA=="],
+
+    "@ready-for-agent/sqlite-queue-service/effect/fast-check/pure-rand": ["pure-rand@6.1.0", "", {}, "sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA=="],
 
     "yargs/cliui/strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
 

--- a/docs/adr/0002-branded-entity-ids.md
+++ b/docs/adr/0002-branded-entity-ids.md
@@ -1,0 +1,7 @@
+# Prefixed ULID entity IDs
+
+Primary keys are **type-prefixed ULIDs**: `{prefix}-{ulid}` (e.g. `qjob-01H…`, `cj-01H…`). The prefix is a short stable type code (Xplain-style), not a display label. Bare ULIDs on early tables (e.g. `repository`) are legacy; new tables use prefixes, and existing tables may migrate when convenient.
+
+**Why:** IDs stay sortable/unique like plain ULIDs, but logs, FKs, and queue payloads are self-describing (no “what table is this id from?”). Rejected alternatives: bare ULID everywhere (cheaper, harder to debug); UUID v4 (no sort); integer PKs (Turso/distributed-unfriendly).
+
+**TypeScript brands** (e.g. `Schema.brand("JobId")`) are optional at call sites; the **stored** form is always the prefixed string.

--- a/nx.json
+++ b/nx.json
@@ -54,7 +54,9 @@
   "targetDefaults": {
     "build": {
       "cache": true,
-      "outputs": ["{projectRoot}/dist"]
+      "outputs": [
+        "{projectRoot}/dist"
+      ]
     },
     "knip": {
       "cache": true

--- a/packages/db-schema/drizzle/20260713001702_conscious_maggott/migration.sql
+++ b/packages/db-schema/drizzle/20260713001702_conscious_maggott/migration.sql
@@ -1,0 +1,22 @@
+CREATE TABLE `completed_job` (
+	`id` text PRIMARY KEY,
+	`queue` text NOT NULL,
+	`job_id` text NOT NULL,
+	`created_at` integer NOT NULL,
+	`updated_at` integer NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE `job_queue` (
+	`id` text PRIMARY KEY,
+	`queue` text NOT NULL,
+	`job_payload` text NOT NULL,
+	`job_attempts` integer DEFAULT 0 NOT NULL,
+	`job_retry_limit` integer DEFAULT 5 NOT NULL,
+	`available_at` integer NOT NULL,
+	`locked_until` integer,
+	`created_at` integer NOT NULL,
+	`updated_at` integer NOT NULL
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `completed_job_queue_job_id_uidx` ON `completed_job` (`queue`,`job_id`);--> statement-breakpoint
+CREATE INDEX `job_queue_ready_idx` ON `job_queue` (`queue`,`locked_until`,`job_attempts`,`available_at`);

--- a/packages/db-schema/drizzle/20260713001702_conscious_maggott/snapshot.json
+++ b/packages/db-schema/drizzle/20260713001702_conscious_maggott/snapshot.json
@@ -1,0 +1,341 @@
+{
+  "version": "7",
+  "dialect": "sqlite",
+  "id": "1b31d30a-0fe7-4e3a-8ee4-e9552defc416",
+  "prevIds": [
+    "a1442403-19e5-45e7-b49b-f9a7a594beee"
+  ],
+  "ddl": [
+    {
+      "name": "completed_job",
+      "entityType": "tables"
+    },
+    {
+      "name": "job_queue",
+      "entityType": "tables"
+    },
+    {
+      "name": "repository",
+      "entityType": "tables"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "completed_job"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "queue",
+      "entityType": "columns",
+      "table": "completed_job"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "job_id",
+      "entityType": "columns",
+      "table": "completed_job"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "completed_job"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "completed_job"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "job_queue"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "queue",
+      "entityType": "columns",
+      "table": "job_queue"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "job_payload",
+      "entityType": "columns",
+      "table": "job_queue"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "0",
+      "generated": null,
+      "name": "job_attempts",
+      "entityType": "columns",
+      "table": "job_queue"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "5",
+      "generated": null,
+      "name": "job_retry_limit",
+      "entityType": "columns",
+      "table": "job_queue"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "available_at",
+      "entityType": "columns",
+      "table": "job_queue"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "locked_until",
+      "entityType": "columns",
+      "table": "job_queue"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "job_queue"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "job_queue"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "repository"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "github_owner",
+      "entityType": "columns",
+      "table": "repository"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "github_repo",
+      "entityType": "columns",
+      "table": "repository"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "local_path",
+      "entityType": "columns",
+      "table": "repository"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "is_bare",
+      "entityType": "columns",
+      "table": "repository"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "true",
+      "generated": null,
+      "name": "paused",
+      "entityType": "columns",
+      "table": "repository"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "repository"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "repository"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "completed_job_pk",
+      "table": "completed_job",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "job_queue_pk",
+      "table": "job_queue",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "repository_pk",
+      "table": "repository",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        {
+          "value": "queue",
+          "isExpression": false
+        },
+        {
+          "value": "job_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "origin": "manual",
+      "name": "completed_job_queue_job_id_uidx",
+      "entityType": "indexes",
+      "table": "completed_job"
+    },
+    {
+      "columns": [
+        {
+          "value": "queue",
+          "isExpression": false
+        },
+        {
+          "value": "locked_until",
+          "isExpression": false
+        },
+        {
+          "value": "job_attempts",
+          "isExpression": false
+        },
+        {
+          "value": "available_at",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "job_queue_ready_idx",
+      "entityType": "indexes",
+      "table": "job_queue"
+    },
+    {
+      "columns": [
+        {
+          "value": "lower(\"github_owner\")",
+          "isExpression": true
+        },
+        {
+          "value": "lower(\"github_repo\")",
+          "isExpression": true
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "origin": "manual",
+      "name": "repository_github_owner_repo_lower_uidx",
+      "entityType": "indexes",
+      "table": "repository"
+    },
+    {
+      "columns": [
+        "local_path"
+      ],
+      "nameExplicit": false,
+      "name": "repository_local_path_unique",
+      "entityType": "uniques",
+      "table": "repository"
+    }
+  ],
+  "renames": []
+}

--- a/packages/db-schema/src/schema.ts
+++ b/packages/db-schema/src/schema.ts
@@ -1,5 +1,11 @@
 import { sql } from "drizzle-orm"
-import { integer, snakeCase, text, uniqueIndex } from "drizzle-orm/sqlite-core"
+import {
+  index,
+  integer,
+  snakeCase,
+  text,
+  uniqueIndex,
+} from "drizzle-orm/sqlite-core"
 import { ulid } from "ulidx"
 
 export const repository = snakeCase.table(
@@ -26,4 +32,63 @@ export const repository = snakeCase.table(
       sql`lower(${t.githubRepo})`,
     ),
   ],
+)
+
+/**
+ * Background job queue (SQS-style visibility timeout semantics).
+ * See xplain: type job queue "qjob"
+ */
+export const jobQueue = snakeCase.table(
+  "job_queue",
+  {
+    id: text()
+      .primaryKey()
+      .$defaultFn(() => `qjob-${ulid()}`),
+    queue: text().notNull(),
+    jobPayload: text({ mode: "json" })
+      .$type<Record<string, unknown>>()
+      .notNull(),
+    jobAttempts: integer({ mode: "number" }).notNull().default(0),
+    jobRetryLimit: integer({ mode: "number" }).notNull().default(5),
+    availableAt: integer({ mode: "number" })
+      .notNull()
+      .$defaultFn(() => Date.now()),
+    lockedUntil: integer({ mode: "number" }),
+    createdAt: integer({ mode: "number" })
+      .notNull()
+      .$defaultFn(() => Date.now()),
+    updatedAt: integer({ mode: "number" })
+      .notNull()
+      .$defaultFn(() => Date.now()),
+  },
+  (t) => [
+    index("job_queue_ready_idx").on(
+      t.queue,
+      t.lockedUntil,
+      t.jobAttempts,
+      t.availableAt,
+    ),
+  ],
+)
+
+/**
+ * Tracks completed jobs for at-least-once delivery / 2PC with workers.
+ * See xplain: type completed job "cj"
+ */
+export const completedJob = snakeCase.table(
+  "completed_job",
+  {
+    id: text()
+      .primaryKey()
+      .$defaultFn(() => `cj-${ulid()}`),
+    queue: text().notNull(),
+    jobId: text().notNull(),
+    createdAt: integer({ mode: "number" })
+      .notNull()
+      .$defaultFn(() => Date.now()),
+    updatedAt: integer({ mode: "number" })
+      .notNull()
+      .$defaultFn(() => Date.now()),
+  },
+  (t) => [uniqueIndex("completed_job_queue_job_id_uidx").on(t.queue, t.jobId)],
 )

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -1,0 +1,40 @@
+{
+  "name": "@ready-for-agent/db",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    "./package.json": "./package.json",
+    ".": {
+      "@ready-for-agent/source": "./src/index.ts",
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    },
+    "./test": {
+      "@ready-for-agent/source": "./src/lib/database-test.ts",
+      "types": "./dist/lib/database-test.d.ts",
+      "import": "./dist/lib/database-test.js",
+      "default": "./dist/lib/database-test.js"
+    }
+  },
+  "nx": {
+    "name": "db"
+  },
+  "dependencies": {
+    "@effect/sql": "^0.51.1",
+    "@effect/sql-drizzle": "^0.50.0",
+    "@ready-for-agent/db-schema": "workspace:*",
+    "@ready-for-agent/layer-turso-local": "workspace:*",
+    "drizzle-orm": "1.0.0-rc.4-5d5b77c",
+    "effect": "^3.21.4",
+    "tslib": "^2.3.0"
+  },
+  "devDependencies": {
+    "@effect/sql-sqlite-bun": "^0.52.0",
+    "@types/bun": "^1.3.0"
+  }
+}

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -1,0 +1,6 @@
+// Side-effect: patches QueryPromise/SelectBase as Effect at runtime
+import "@effect/sql-drizzle/Sqlite"
+
+export * from "./lib/database-live.js"
+export * from "./lib/run-drizzle.js"
+export * from "./lib/typed-drizzle.js"

--- a/packages/db/src/lib/database-live.ts
+++ b/packages/db/src/lib/database-live.ts
@@ -1,0 +1,12 @@
+import { Layer } from "effect"
+import { TursoLive } from "@ready-for-agent/layer-turso-local"
+import { TypedSqliteDrizzleLayer } from "./typed-drizzle.js"
+
+/**
+ * Production database layer: Turso local SQL client + typed Drizzle.
+ *
+ * Requires SQLITE_DATABASE_PATH in the environment / ConfigProvider.
+ */
+export const DatabaseLive = TypedSqliteDrizzleLayer.pipe(
+  Layer.provideMerge(TursoLive),
+)

--- a/packages/db/src/lib/database-test.ts
+++ b/packages/db/src/lib/database-test.ts
@@ -1,0 +1,48 @@
+import { dirname, join } from "node:path"
+import { fileURLToPath } from "node:url"
+import { SqlClient } from "@effect/sql"
+import { SqliteClient } from "@effect/sql-sqlite-bun"
+import { Config, Context, Effect, Layer } from "effect"
+import { runSqliteTestMigrations } from "./test-migrations.js"
+import { TypedSqliteDrizzleLayer } from "./typed-drizzle.js"
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = dirname(__filename)
+const defaultMigrationsFolder = join(__dirname, "../../../db-schema/drizzle")
+
+/**
+ * Config for the migrations folder path.
+ * Override with ConfigProvider.fromMap({ MIGRATIONS_FOLDER: "/custom/path" })
+ */
+export const MigrationsFolderConfig = Config.string("MIGRATIONS_FOLDER").pipe(
+  Config.withDefault(defaultMigrationsFolder),
+)
+
+const runPragmas = (ctx: Context.Context<SqlClient.SqlClient>) =>
+  Effect.gen(function* () {
+    const sql = Context.get(ctx, SqlClient.SqlClient)
+    yield* sql`PRAGMA foreign_keys = ON`
+  })
+
+/**
+ * In-memory SQLite client for tests.
+ */
+export const SqliteTest = SqliteClient.layer({
+  filename: ":memory:",
+}).pipe(Layer.tap(runPragmas))
+
+const DrizzleTest = TypedSqliteDrizzleLayer.pipe(Layer.provide(SqliteTest))
+
+const MigrationLayer = Layer.effectDiscard(
+  Effect.gen(function* () {
+    const migrationsFolder = yield* MigrationsFolderConfig
+    yield* runSqliteTestMigrations(migrationsFolder)
+  }),
+)
+
+/**
+ * Full test database layer: in-memory SQLite + migrations + typed Drizzle.
+ */
+export const DatabaseTest = MigrationLayer.pipe(
+  Layer.provideMerge(Layer.mergeAll(SqliteTest, DrizzleTest)),
+)

--- a/packages/db/src/lib/run-drizzle.ts
+++ b/packages/db/src/lib/run-drizzle.ts
@@ -1,0 +1,13 @@
+import type { SqlError } from "@effect/sql/SqlError"
+import type { Effect } from "effect"
+
+/**
+ * Cast a Drizzle query builder to Effect.
+ *
+ * At runtime `@effect/sql-drizzle` patches QueryPromise/SelectBase so they are
+ * real Effects. TypeScript module augmentation does not reliably merge onto
+ * Drizzle's class re-exports after builder `Omit` chains, so we cast here.
+ */
+export const runDrizzle = <A>(
+  query: PromiseLike<A>,
+): Effect.Effect<A, SqlError> => query as unknown as Effect.Effect<A, SqlError>

--- a/packages/db/src/lib/test-migrations.ts
+++ b/packages/db/src/lib/test-migrations.ts
@@ -1,0 +1,39 @@
+import { SqliteClient } from "@effect/sql-sqlite-bun"
+import { readMigrationFiles } from "drizzle-orm/migrator"
+import { Effect } from "effect"
+
+const rawSql = (query: string) => Object.assign([query], { raw: [query] })
+
+export const runSqliteTestMigrations = (migrationsFolder: string) =>
+  Effect.gen(function* () {
+    const sql = yield* SqliteClient.SqliteClient
+    const migrations = readMigrationFiles({ migrationsFolder })
+
+    yield* sql`
+      CREATE TABLE IF NOT EXISTS __drizzle_migrations (
+        id INTEGER PRIMARY KEY,
+        hash text NOT NULL,
+        created_at numeric,
+        name text,
+        applied_at TEXT
+      )
+    `
+
+    for (const migration of migrations) {
+      for (const query of migration.sql) {
+        if (query.trim().length > 0) {
+          yield* sql(rawSql(query))
+        }
+      }
+
+      yield* sql`
+        INSERT INTO __drizzle_migrations (hash, created_at, name, applied_at)
+        VALUES (
+          ${migration.hash},
+          ${migration.folderMillis},
+          ${migration.name},
+          ${new Date().toISOString()}
+        )
+      `
+    }
+  })

--- a/packages/db/src/lib/typed-drizzle.ts
+++ b/packages/db/src/lib/typed-drizzle.ts
@@ -1,0 +1,30 @@
+import * as SqliteDrizzle from "@effect/sql-drizzle/Sqlite"
+import type { SqliteRemoteDatabase } from "drizzle-orm/sqlite-proxy"
+import { Context, Effect, Layer } from "effect"
+import * as schema from "@ready-for-agent/db-schema"
+
+type TypedSqliteDatabase = SqliteRemoteDatabase<typeof schema>
+type SqliteDrizzleConfig = Parameters<
+  typeof SqliteDrizzle.make<typeof schema>
+>[0]
+
+// @effect/sql-drizzle types lag Drizzle v1 schema generics slightly
+const sqliteDrizzleConfig = { schema } as SqliteDrizzleConfig
+
+/**
+ * Tag for typed Drizzle ORM database service over the harness schema.
+ */
+export class TypedSqliteDrizzle extends Context.Tag(
+  "@ready-for-agent/db/TypedSqliteDrizzle",
+)<TypedSqliteDrizzle, TypedSqliteDatabase>() {}
+
+/**
+ * Layer that provides TypedSqliteDrizzle.
+ * Requires a SQL client (SqliteClient / LibsqlClient) in the environment.
+ */
+export const TypedSqliteDrizzleLayer = Layer.effect(
+  TypedSqliteDrizzle,
+  SqliteDrizzle.make<typeof schema>(sqliteDrizzleConfig).pipe(
+    Effect.map((db) => db as unknown as TypedSqliteDatabase),
+  ),
+)

--- a/packages/db/tsconfig.json
+++ b/packages/db/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ]
+}

--- a/packages/db/tsconfig.lib.json
+++ b/packages/db/tsconfig.lib.json
@@ -1,0 +1,20 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "tsBuildInfoFile": "dist/tsconfig.lib.tsbuildinfo",
+    "emitDeclarationOnly": false,
+    "forceConsistentCasingInFileNames": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"],
+  "references": [
+    {
+      "path": "../db-schema/tsconfig.lib.json"
+    },
+    {
+      "path": "../layer-turso-local/tsconfig.lib.json"
+    }
+  ]
+}

--- a/packages/layer-turso-local/package.json
+++ b/packages/layer-turso-local/package.json
@@ -1,0 +1,48 @@
+{
+  "name": "@ready-for-agent/layer-turso-local",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    "./package.json": "./package.json",
+    ".": {
+      "@ready-for-agent/source": "./src/index.ts",
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    }
+  },
+  "nx": {
+    "name": "layer-turso-local",
+    "targets": {
+      "test": {
+        "executor": "nx:run-commands",
+        "options": {
+          "cwd": "{projectRoot}",
+          "command": "bun test"
+        },
+        "inputs": [
+          "default",
+          "^production"
+        ],
+        "cache": true,
+        "dependsOn": [
+          "^build"
+        ]
+      }
+    }
+  },
+  "dependencies": {
+    "@effect/experimental": "^0.60.0",
+    "@effect/sql": "^0.51.1",
+    "@tursodatabase/database": "0.7.0-pre.13",
+    "effect": "^3.21.4",
+    "tslib": "^2.3.0"
+  },
+  "devDependencies": {
+    "@types/bun": "^1.3.0"
+  }
+}

--- a/packages/layer-turso-local/src/index.ts
+++ b/packages/layer-turso-local/src/index.ts
@@ -1,0 +1,2 @@
+export * from "./lib/client-live.js"
+export * from "./lib/database-path.js"

--- a/packages/layer-turso-local/src/lib/client-live.ts
+++ b/packages/layer-turso-local/src/lib/client-live.ts
@@ -1,0 +1,325 @@
+import * as Reactivity from "@effect/experimental/Reactivity"
+import * as Client from "@effect/sql/SqlClient"
+import type { Connection } from "@effect/sql/SqlConnection"
+import { SqlError } from "@effect/sql/SqlError"
+import * as Statement from "@effect/sql/Statement"
+import { type Database, connect } from "@tursodatabase/database"
+import * as Config from "effect/Config"
+import type { ConfigError } from "effect/ConfigError"
+import * as Context from "effect/Context"
+import * as Effect from "effect/Effect"
+import * as Exit from "effect/Exit"
+import * as Layer from "effect/Layer"
+import * as Option from "effect/Option"
+import * as Scope from "effect/Scope"
+import {
+  DatabaseConnectionInfo,
+  DatabasePathConfig,
+  normalizeDatabasePath,
+  toTursoDatabasePath,
+} from "./database-path.js"
+
+const ATTR_DB_SYSTEM_NAME = "db.system.name"
+
+export const isSqliteBusyError = (error: SqlError): boolean => {
+  if (
+    error.message.includes("SQLITE_BUSY") ||
+    error.message.includes("database is locked") ||
+    error.message.includes("CONCURRENT")
+  ) {
+    return true
+  }
+
+  let current: unknown = error.cause
+  while (current) {
+    if (current instanceof Error) {
+      if (
+        current.message.includes("SQLITE_BUSY") ||
+        current.message.includes("database is locked") ||
+        current.message.includes("CONCURRENT")
+      ) {
+        return true
+      }
+      current = current.cause
+    } else if (
+      typeof current === "string" &&
+      (current.includes("SQLITE_BUSY") ||
+        current.includes("database is locked") ||
+        current.includes("CONCURRENT"))
+    ) {
+      return true
+    } else {
+      break
+    }
+  }
+
+  return false
+}
+
+const ConnectionInfoLayer = Layer.effect(
+  DatabaseConnectionInfo,
+  DatabasePathConfig.pipe(Config.map(normalizeDatabasePath)),
+)
+
+const TursoTransaction = Context.GenericTag<
+  readonly [TursoConnection, counter: number]
+>("@ready-for-agent/layer-turso-local/TursoTransaction")
+
+interface TursoConnection extends Connection {
+  readonly beginTransaction: Effect.Effect<TursoConnection, SqlError>
+  readonly commit: Effect.Effect<void, SqlError>
+  readonly rollback: Effect.Effect<void, SqlError>
+  readonly close: Effect.Effect<void, never>
+}
+
+export interface TursoClientOptions {
+  readonly busy_timeout?: number
+  readonly defaultQueryTimeout?: number
+}
+
+type TursoValue = string | number | bigint | boolean | Uint8Array | null
+type TursoRow = Record<string, TursoValue>
+
+const tursoRowValues = (row: TursoRow): TursoValue[] => {
+  // Turso exposes positional values as stringified numeric keys for values-mode
+  // rows; named keys alone cannot preserve duplicate-column ordering.
+  const values: TursoValue[] = []
+  for (let index = 0; Object.hasOwn(row, String(index)); index++) {
+    values.push(row[String(index)] ?? null)
+  }
+
+  return values.length > 0 ? values : Object.values(row)
+}
+
+const makeDatabase = (
+  path: string,
+  options: TursoClientOptions | undefined,
+): Effect.Effect<Database, SqlError> =>
+  Effect.tryPromise({
+    try: () => {
+      const databaseOptions: NonNullable<Parameters<typeof connect>[1]> = {
+        experimental: ["multiprocess_wal"],
+      }
+      if (options?.defaultQueryTimeout !== undefined) {
+        databaseOptions.defaultQueryTimeout = options.defaultQueryTimeout
+      }
+
+      return connect(path, databaseOptions)
+    },
+    catch: (cause) =>
+      new SqlError({ cause, message: "Failed to open database" }),
+  })
+
+const closeDatabase = (db: Database): Effect.Effect<void, never> =>
+  Effect.promise(() => db.close()).pipe(Effect.ignore)
+
+const makeClient = (
+  path: string,
+  options?: TursoClientOptions,
+): Effect.Effect<
+  Client.SqlClient,
+  SqlError,
+  Scope.Scope | Reactivity.Reactivity
+> =>
+  Effect.gen(function* () {
+    const compiler = Statement.makeCompilerSqlite()
+    const spanAttributes: Array<[string, unknown]> = [
+      [ATTR_DB_SYSTEM_NAME, "sqlite"],
+    ]
+    const rootDb = yield* makeDatabase(path, options)
+    yield* Effect.addFinalizer(() => closeDatabase(rootDb))
+
+    class TursoConnectionImpl implements TursoConnection {
+      private pragmasExecuted = false
+
+      constructor(
+        private readonly db: Database,
+        private readonly runPragmas: boolean,
+      ) {}
+
+      private ensurePragmas(): Effect.Effect<void, SqlError> {
+        if (this.pragmasExecuted || !this.runPragmas) {
+          return Effect.void
+        }
+
+        return Effect.gen(this, function* () {
+          yield* this.runDirect("PRAGMA foreign_keys = ON", [])
+          yield* this.runDirect("PRAGMA journal_mode = wal", [])
+          const timeout = options?.busy_timeout ?? 1500
+          if (timeout > 0) {
+            yield* this.runDirect(`PRAGMA busy_timeout = ${timeout}`, [])
+          }
+          this.pragmasExecuted = true
+        })
+      }
+
+      private runDirect(sql: string, params: ReadonlyArray<unknown>) {
+        return Effect.tryPromise({
+          try: () => this.db.all(sql, [...params]) as Promise<TursoRow[]>,
+          catch: (cause) =>
+            new SqlError({ cause, message: "Failed to execute statement" }),
+        })
+      }
+
+      private runValuesDirect(sql: string, params: ReadonlyArray<unknown>) {
+        return Effect.tryPromise({
+          try: async () =>
+            ((await this.db.all(sql, [...params])) as TursoRow[]).map((row) =>
+              tursoRowValues(row),
+            ),
+          catch: (cause) =>
+            new SqlError({ cause, message: "Failed to execute statement" }),
+        })
+      }
+
+      private runValues(sql: string, params: ReadonlyArray<unknown> = []) {
+        return Effect.gen(this, function* () {
+          yield* this.ensurePragmas()
+          return yield* this.runValuesDirect(sql, params)
+        })
+      }
+
+      run(sql: string, params: ReadonlyArray<unknown> = []) {
+        return Effect.gen(this, function* () {
+          yield* this.ensurePragmas()
+          return yield* this.runDirect(sql, params)
+        })
+      }
+
+      runRaw(sql: string, params: ReadonlyArray<unknown> = []) {
+        return this.run(sql, params)
+      }
+
+      execute(
+        sql: string,
+        params: ReadonlyArray<unknown>,
+        transformRows:
+          | (<A extends object>(row: ReadonlyArray<A>) => ReadonlyArray<A>)
+          | undefined,
+      ) {
+        return transformRows
+          ? Effect.map(this.run(sql, params), transformRows)
+          : this.run(sql, params)
+      }
+
+      executeRaw(sql: string, params: ReadonlyArray<unknown>) {
+        return this.runRaw(sql, params)
+      }
+
+      executeValues(sql: string, params: ReadonlyArray<unknown>) {
+        return this.runValues(sql, params)
+      }
+
+      executeUnprepared(
+        sql: string,
+        params: ReadonlyArray<unknown>,
+        transformRows:
+          | (<A extends object>(row: ReadonlyArray<A>) => ReadonlyArray<A>)
+          | undefined,
+      ) {
+        return this.execute(sql, params, transformRows)
+      }
+
+      executeStream() {
+        return Effect.dieMessage("executeStream not implemented")
+      }
+
+      get beginTransaction(): Effect.Effect<TursoConnection, SqlError> {
+        return Effect.gen(this, function* () {
+          const transactionDb = yield* makeDatabase(path, options)
+          const connection = new TursoConnectionImpl(transactionDb, true)
+          yield* connection.ensurePragmas()
+          // IMMEDIATE acquires the write lock up front (needed for queue claims
+          // and other atomic RMW). Turso multiprocess_wal supports it.
+          yield* connection.executeRaw("BEGIN IMMEDIATE", [])
+          return connection
+        })
+      }
+
+      get commit() {
+        return this.executeRaw("COMMIT", [])
+      }
+
+      get rollback() {
+        return this.executeRaw("ROLLBACK", [])
+      }
+
+      get close() {
+        return closeDatabase(this.db)
+      }
+    }
+
+    const connection = new TursoConnectionImpl(rootDb, true)
+    const semaphore = yield* Effect.makeSemaphore(1)
+
+    const withTransaction = Client.makeWithTransaction({
+      transactionTag: TursoTransaction,
+      spanAttributes,
+      acquireConnection: Effect.uninterruptibleMask((restore) =>
+        Scope.make().pipe(
+          Effect.flatMap((scope) =>
+            restore(connection.beginTransaction).pipe(
+              Effect.tap((conn) => Scope.addFinalizer(scope, conn.close)),
+              Effect.map((conn) => [scope, conn] as const),
+              Effect.tapError(() => Scope.close(scope, Exit.void)),
+            ),
+          ),
+        ),
+      ),
+      begin: () => Effect.void,
+      savepoint: (conn, id) =>
+        conn.executeRaw(`SAVEPOINT effect_sql_${id};`, []),
+      commit: (conn) => conn.commit,
+      rollback: (conn) => conn.rollback,
+      rollbackSavepoint: (conn, id) =>
+        conn.executeRaw(`ROLLBACK TO SAVEPOINT effect_sql_${id};`, []),
+    })
+
+    const acquirer = Effect.flatMap(
+      Effect.serviceOption(TursoTransaction),
+      Option.match({
+        onNone: () =>
+          semaphore.withPermits(1)(
+            Effect.succeed(connection as TursoConnection),
+          ),
+        onSome: ([conn]) => Effect.succeed(conn),
+      }),
+    )
+
+    return Object.assign(
+      yield* Client.make({
+        acquirer,
+        compiler,
+        spanAttributes,
+      }),
+      { withTransaction },
+    )
+  })
+
+const makeBaseTursoLive = (options?: TursoClientOptions) =>
+  Layer.scopedContext(
+    Effect.gen(function* () {
+      const dbPath = yield* DatabasePathConfig
+      const normalizedPath = normalizeDatabasePath(dbPath)
+      const client = yield* makeClient(
+        toTursoDatabasePath(normalizedPath),
+        options,
+      )
+
+      return Context.make(Client.SqlClient, client)
+    }),
+  ).pipe(Layer.provide(Reactivity.layer))
+
+export const makeTursoLive = (
+  options?: TursoClientOptions,
+): Layer.Layer<
+  Client.SqlClient | DatabaseConnectionInfo,
+  ConfigError | SqlError,
+  never
+> => makeBaseTursoLive(options).pipe(Layer.provideMerge(ConnectionInfoLayer))
+
+export const TursoLive: Layer.Layer<
+  Client.SqlClient | DatabaseConnectionInfo,
+  ConfigError | SqlError,
+  never
+> = makeTursoLive()

--- a/packages/layer-turso-local/src/lib/database-path.ts
+++ b/packages/layer-turso-local/src/lib/database-path.ts
@@ -1,0 +1,51 @@
+import { Context, Layer } from "effect"
+import * as Config from "effect/Config"
+import * as ConfigProvider from "effect/ConfigProvider"
+
+/**
+ * Human-readable database connection info for logging.
+ * Examples: "file://./data/app.db", "./data/app.db"
+ */
+export class DatabaseConnectionInfo extends Context.Tag(
+  "@ready-for-agent/layer-turso-local/DatabaseConnectionInfo",
+)<DatabaseConnectionInfo, string>() {}
+
+export const normalizeDatabasePath = (path: string): string =>
+  /^[a-z]+:/.test(path) ? path : `file://${path}`
+
+export const isLocalFilePath = (path: string): boolean => {
+  const protocol = path.match(/^([a-z]+):/)?.[1]
+  return protocol === undefined || protocol === "file"
+}
+
+export const toTursoDatabasePath = (path: string): string => {
+  if (path.startsWith("file://")) {
+    return path.slice("file://".length)
+  }
+
+  if (path.startsWith("file:")) {
+    return path.slice("file:".length)
+  }
+
+  return path
+}
+
+/**
+ * Effect Config for the database path (SQLITE_DATABASE_PATH).
+ */
+export const DatabasePathConfig: Config.Config<string> = Config.string(
+  "SQLITE_DATABASE_PATH",
+)
+
+export const DATABASE_PATH_NOT_CONFIGURED =
+  "Database path not configured. Set SQLITE_DATABASE_PATH environment variable."
+
+/**
+ * Layer providing a ConfigProvider with the given database path.
+ */
+export const makeDatabaseConfigLayer = (databasePath: string) =>
+  Layer.setConfigProvider(
+    ConfigProvider.fromMap(
+      new Map([["SQLITE_DATABASE_PATH", databasePath]]),
+    ).pipe(ConfigProvider.orElse(() => ConfigProvider.fromEnv())),
+  )

--- a/packages/layer-turso-local/test/concurrent-transaction.spec.ts
+++ b/packages/layer-turso-local/test/concurrent-transaction.spec.ts
@@ -1,0 +1,174 @@
+import { unlink } from "node:fs/promises"
+import * as SqlClient from "@effect/sql/SqlClient"
+import { ConfigProvider, Effect, Layer } from "effect"
+import { makeTursoLive } from "../src/index.js"
+import { describe, expect, it } from "bun:test"
+
+const tempDbPath = () =>
+  `/tmp/test-turso-${Date.now()}-${Math.random().toString(36).slice(2)}.db`
+
+const sqlQuery = (sql: string) => Object.assign([sql], { raw: [sql] })
+
+const cleanupDb = async (dbPath: string) => {
+  await unlink(dbPath).catch(() => {})
+  await unlink(`${dbPath}-wal`).catch(() => {})
+  await unlink(`${dbPath}-shm`).catch(() => {})
+}
+
+describe("makeTursoLive", () => {
+  it("uses BEGIN IMMEDIATE (write lock) transactions", async () => {
+    const dbPath = tempDbPath()
+    const ConfigLayer = Layer.setConfigProvider(
+      ConfigProvider.fromMap(new Map([["SQLITE_DATABASE_PATH", dbPath]])),
+    )
+    const TestLayer = makeTursoLive().pipe(Layer.provide(ConfigLayer))
+
+    try {
+      const rows = await Effect.runPromise(
+        Effect.gen(function* () {
+          const sql = yield* SqlClient.SqlClient
+
+          yield* sql(sqlQuery("CREATE TABLE test_values (value TEXT NOT NULL)"))
+          yield* sql.withTransaction(
+            Effect.gen(function* () {
+              yield* sql(
+                sqlQuery("INSERT INTO test_values (value) VALUES ('ok')"),
+              )
+            }),
+          )
+
+          return yield* sql(sqlQuery("SELECT value FROM test_values"))
+        }).pipe(Effect.provide(TestLayer)),
+      )
+
+      expect(rows).toEqual([{ value: "ok" }])
+    } finally {
+      await cleanupDb(dbPath)
+    }
+  })
+
+  it("makes writes visible across long-lived clients", async () => {
+    const dbPath = tempDbPath()
+    const ConfigLayer = Layer.setConfigProvider(
+      ConfigProvider.fromMap(new Map([["SQLITE_DATABASE_PATH", dbPath]])),
+    )
+    const WriterLayer = makeTursoLive().pipe(Layer.provide(ConfigLayer))
+    const ReaderLayer = makeTursoLive().pipe(Layer.provide(ConfigLayer))
+
+    try {
+      await Effect.runPromise(
+        Effect.gen(function* () {
+          const sql = yield* SqlClient.SqlClient
+
+          yield* sql(sqlQuery("CREATE TABLE visible (value TEXT NOT NULL)"))
+        }).pipe(Effect.provide(WriterLayer)),
+      )
+
+      const readVisible = () =>
+        Effect.runPromise(
+          Effect.gen(function* () {
+            const sql = yield* SqlClient.SqlClient
+
+            return yield* sql(sqlQuery("SELECT value FROM visible"))
+          }).pipe(Effect.provide(ReaderLayer)),
+        )
+
+      expect(await readVisible()).toEqual([])
+
+      await Effect.runPromise(
+        Effect.gen(function* () {
+          const sql = yield* SqlClient.SqlClient
+
+          yield* sql.withTransaction(
+            Effect.gen(function* () {
+              yield* sql(sqlQuery("INSERT INTO visible (value) VALUES ('ok')"))
+            }),
+          )
+        }).pipe(Effect.provide(WriterLayer)),
+      )
+
+      expect(await readVisible()).toEqual([{ value: "ok" }])
+    } finally {
+      await cleanupDb(dbPath)
+    }
+  })
+
+  it("supports partial unique-index upserts", async () => {
+    const dbPath = tempDbPath()
+    const ConfigLayer = Layer.setConfigProvider(
+      ConfigProvider.fromMap(new Map([["SQLITE_DATABASE_PATH", dbPath]])),
+    )
+    const TestLayer = makeTursoLive().pipe(Layer.provide(ConfigLayer))
+
+    try {
+      const rows = await Effect.runPromise(
+        Effect.gen(function* () {
+          const sql = yield* SqlClient.SqlClient
+
+          yield* sql(
+            sqlQuery(
+              "CREATE TABLE items (path TEXT NOT NULL, _deleted INTEGER NOT NULL DEFAULT 0, value TEXT NOT NULL)",
+            ),
+          )
+          yield* sql(
+            sqlQuery(
+              "CREATE UNIQUE INDEX items_path_active ON items(path) WHERE _deleted = 0",
+            ),
+          )
+          yield* sql.unsafe(
+            "INSERT INTO items (path, _deleted, value) VALUES (?, 0, ?) ON CONFLICT (path) WHERE _deleted = 0 DO UPDATE SET value = excluded.value",
+            ["/a", "one"],
+          )
+          yield* sql.unsafe(
+            "INSERT INTO items (path, _deleted, value) VALUES (?, 0, ?) ON CONFLICT (path) WHERE _deleted = 0 DO UPDATE SET value = excluded.value",
+            ["/a", "two"],
+          )
+
+          return yield* sql(sqlQuery("SELECT path, _deleted, value FROM items"))
+        }).pipe(Effect.provide(TestLayer)),
+      )
+
+      expect(rows).toEqual([{ path: "/a", _deleted: 0, value: "two" }])
+    } finally {
+      await cleanupDb(dbPath)
+    }
+  })
+
+  it("preserves duplicate selected columns in values mode", async () => {
+    const dbPath = tempDbPath()
+    const ConfigLayer = Layer.setConfigProvider(
+      ConfigProvider.fromMap(new Map([["SQLITE_DATABASE_PATH", dbPath]])),
+    )
+    const TestLayer = makeTursoLive().pipe(Layer.provide(ConfigLayer))
+
+    try {
+      const rows = await Effect.runPromise(
+        Effect.gen(function* () {
+          const sql = yield* SqlClient.SqlClient
+
+          yield* sql(
+            sqlQuery(
+              "CREATE TABLE a (id INTEGER PRIMARY KEY, value TEXT NOT NULL)",
+            ),
+          )
+          yield* sql(
+            sqlQuery(
+              "CREATE TABLE b (id INTEGER PRIMARY KEY, value TEXT NOT NULL)",
+            ),
+          )
+          yield* sql.unsafe("INSERT INTO a (id, value) VALUES (?, ?)", [1, "a"])
+          yield* sql.unsafe("INSERT INTO b (id, value) VALUES (?, ?)", [1, "b"])
+
+          return yield* sql.unsafe(
+            "SELECT a.id, b.id, a.value, b.value FROM a JOIN b ON a.id = b.id",
+            [],
+          ).values
+        }).pipe(Effect.provide(TestLayer)),
+      )
+
+      expect(rows).toEqual([[1, 1, "a", "b"]])
+    } finally {
+      await cleanupDb(dbPath)
+    }
+  })
+})

--- a/packages/layer-turso-local/test/normalize-path.spec.ts
+++ b/packages/layer-turso-local/test/normalize-path.spec.ts
@@ -1,0 +1,29 @@
+import {
+  isLocalFilePath,
+  normalizeDatabasePath,
+  toTursoDatabasePath,
+} from "../src/index.js"
+import { describe, expect, it } from "bun:test"
+
+describe("Turso database path helpers", () => {
+  it("normalizes bare paths as file URLs", () => {
+    expect(normalizeDatabasePath("./data/app.db")).toBe("file://./data/app.db")
+  })
+
+  it("preserves explicit protocols", () => {
+    expect(normalizeDatabasePath("file:./data/app.db")).toBe(
+      "file:./data/app.db",
+    )
+  })
+
+  it("detects local file paths", () => {
+    expect(isLocalFilePath("./data/app.db")).toBe(true)
+    expect(isLocalFilePath("file:./data/app.db")).toBe(true)
+    expect(isLocalFilePath("libsql://example.turso.io")).toBe(false)
+  })
+
+  it("converts file URLs to Turso SDK paths", () => {
+    expect(toTursoDatabasePath("file://./data/app.db")).toBe("./data/app.db")
+    expect(toTursoDatabasePath("file:./data/app.db")).toBe("./data/app.db")
+  })
+})

--- a/packages/layer-turso-local/tsconfig.json
+++ b/packages/layer-turso-local/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ]
+}

--- a/packages/layer-turso-local/tsconfig.lib.json
+++ b/packages/layer-turso-local/tsconfig.lib.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "tsBuildInfoFile": "dist/tsconfig.lib.tsbuildinfo",
+    "emitDeclarationOnly": false,
+    "forceConsistentCasingInFileNames": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"],
+  "references": []
+}

--- a/packages/queue-service/package.json
+++ b/packages/queue-service/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@ready-for-agent/db-schema",
+  "name": "@ready-for-agent/queue-service",
   "version": "0.0.1",
   "private": true,
   "type": "module",
@@ -15,19 +15,28 @@
       "default": "./dist/index.js"
     }
   },
-  "scripts": {
-    "generate": "drizzle-kit generate",
-    "typecheck": "tsc --noEmit -p tsconfig.lib.json"
-  },
   "nx": {
-    "name": "db-schema"
+    "name": "queue-service",
+    "targets": {
+      "test": {
+        "executor": "nx:run-commands",
+        "options": {
+          "cwd": "{projectRoot}",
+          "command": "bun test"
+        },
+        "inputs": [
+          "default",
+          "^production"
+        ],
+        "cache": true
+      }
+    }
   },
   "dependencies": {
-    "drizzle-orm": "1.0.0-rc.4-5d5b77c",
-    "tslib": "^2.3.0",
-    "ulidx": "^2.4.1"
+    "effect": "^3.21.4",
+    "tslib": "^2.3.0"
   },
   "devDependencies": {
-    "drizzle-kit": "1.0.0-rc.4-5d5b77c"
+    "@types/bun": "^1.3.0"
   }
 }

--- a/packages/queue-service/src/index.ts
+++ b/packages/queue-service/src/index.ts
@@ -1,0 +1,3 @@
+export * from "./lib/errors.js"
+export * from "./lib/queue-service.js"
+export * from "./lib/types.js"

--- a/packages/queue-service/src/lib/errors.ts
+++ b/packages/queue-service/src/lib/errors.ts
@@ -1,0 +1,40 @@
+import { Data } from "effect"
+import type { ParseError } from "effect/ParseResult"
+
+export class EnqueueError extends Data.TaggedError("EnqueueError")<{
+  readonly queue: string
+  readonly message: string
+  readonly cause?: unknown
+}> {}
+
+export class ClaimError extends Data.TaggedError("ClaimError")<{
+  readonly queue: string
+  readonly message: string
+  readonly cause?: unknown
+}> {}
+
+export class AcknowledgeError extends Data.TaggedError("AcknowledgeError")<{
+  readonly jobId: string
+  readonly message: string
+  readonly cause?: unknown
+}> {}
+
+export class JobNotFoundError extends Data.TaggedError("JobNotFoundError")<{
+  readonly jobId: string
+}> {}
+
+export class InvalidQueueNameError extends Data.TaggedError(
+  "InvalidQueueNameError",
+)<{
+  readonly queueName: string
+  readonly message: string
+}> {}
+
+/**
+ * Error thrown when a job payload fails schema validation.
+ */
+export class PayloadParseError extends Data.TaggedError("PayloadParseError")<{
+  readonly queue: string
+  readonly jobId: string
+  readonly error: ParseError
+}> {}

--- a/packages/queue-service/src/lib/queue-service.ts
+++ b/packages/queue-service/src/lib/queue-service.ts
@@ -1,0 +1,211 @@
+import type { Duration } from "effect"
+import { Context, Effect, Option, Schema } from "effect"
+import type {
+  AcknowledgeError,
+  ClaimError,
+  EnqueueError,
+  JobNotFoundError,
+} from "./errors.js"
+import { InvalidQueueNameError, PayloadParseError } from "./errors.js"
+import type { Job, Payload, QueueStats, RawJob } from "./types.js"
+
+/**
+ * Maximum length for AWS SQS Standard queue names.
+ * AWS SQS supports up to 80 characters for Standard queues.
+ */
+export const MAX_QUEUE_NAME_LENGTH = 80
+
+/**
+ * Regular expression to validate queue names according to AWS SQS rules.
+ * Queue names may contain:
+ * - Uppercase letters: A–Z
+ * - Lowercase letters: a–z
+ * - Numbers: 0–9
+ * - Hyphens: -
+ * - Underscores: _
+ * - Periods: .
+ * Spaces are NOT allowed.
+ */
+const QUEUE_NAME_REGEX = /^[A-Za-z0-9._-]+$/
+
+/**
+ * Validates a queue name against AWS SQS naming rules.
+ * Returns an Effect that fails with InvalidQueueNameError if the name is invalid.
+ */
+export const validateQueueName = (
+  queueName: string,
+): Effect.Effect<string, InvalidQueueNameError> => {
+  if (queueName.length === 0) {
+    return Effect.fail(
+      new InvalidQueueNameError({
+        queueName,
+        message: "Queue name cannot be empty (minimum length is 1 character)",
+      }),
+    )
+  }
+
+  if (queueName.length > MAX_QUEUE_NAME_LENGTH) {
+    return Effect.fail(
+      new InvalidQueueNameError({
+        queueName,
+        message: `Queue name exceeds maximum length of ${MAX_QUEUE_NAME_LENGTH} characters (got ${queueName.length})`,
+      }),
+    )
+  }
+
+  if (!QUEUE_NAME_REGEX.test(queueName)) {
+    return Effect.fail(
+      new InvalidQueueNameError({
+        queueName,
+        message:
+          "Queue name contains invalid characters. Only A-Z, a-z, 0-9, hyphens (-), underscores (_), and periods (.) are allowed. Spaces are NOT allowed.",
+      }),
+    )
+  }
+
+  return Effect.succeed(queueName)
+}
+
+/**
+ * Queue service interface with generic context type parameter.
+ * Different implementations (SQLite/Turso, SQS) can specify their required context.
+ *
+ * Implementations provide rawClaim which returns unparsed payloads.
+ * Use QueueService.claim() for type-safe payload parsing with a schema.
+ *
+ * @template R - The context/dependencies required by the implementation
+ */
+export interface QueueServiceShape<R = never> {
+  /**
+   * Whether enqueue operations should be performed inside database transactions.
+   * True for database-backed queues (SQLite, Turso) to avoid lock contention.
+   * False for external queues (SQS) that don't participate in DB transactions.
+   */
+  readonly queueInTransaction: boolean
+
+  /**
+   * Add a job to the queue for immediate processing.
+   * Returns the job ID.
+   *
+   * @param options.retryLimit - Maximum retry attempts for this job:
+   *   - `0`: No retries - fail immediately on first error
+   *   - `1+`: Retry up to this many times after failure
+   *   - `undefined`: Use system default (typically 5)
+   */
+  readonly enqueue: <P extends Payload>(
+    queue: string,
+    payload: P,
+    options?: { readonly retryLimit?: number },
+  ) => Effect.Effect<string, EnqueueError | InvalidQueueNameError, R>
+
+  /**
+   * Add a job to the queue with a delay before it becomes available.
+   * Returns the job ID.
+   */
+  readonly enqueueWithDelay: <P extends Payload>(
+    queue: string,
+    payload: P,
+    delay: Duration.Duration,
+    options?: { readonly retryLimit?: number },
+  ) => Effect.Effect<string, EnqueueError | InvalidQueueNameError, R>
+
+  /**
+   * Claim the next available job from the queue (raw, unparsed payload).
+   * Returns None if no jobs are available.
+   * The job becomes invisible to other workers for the visibility timeout.
+   */
+  readonly rawClaim: (
+    queue: string,
+    visibilityTimeout?: Duration.Duration,
+  ) => Effect.Effect<
+    Option.Option<RawJob>,
+    ClaimError | InvalidQueueNameError,
+    R
+  >
+
+  /**
+   * Mark a job as successfully completed. Removes it from the queue.
+   */
+  readonly acknowledge: (
+    jobId: string,
+  ) => Effect.Effect<void, AcknowledgeError | JobNotFoundError, R>
+
+  /**
+   * Mark a job as failed. The job will be retried after becoming
+   * visible again, unless max retries is reached.
+   * Set `retryable: false` to move the job directly to a terminal/dead-letter
+   * state when the backend supports that behavior.
+   */
+  readonly fail: (
+    jobId: string,
+    options?: {
+      readonly releaseImmediately?: boolean
+      readonly retryable?: boolean
+    },
+  ) => Effect.Effect<void, AcknowledgeError | JobNotFoundError, R>
+
+  /**
+   * Set a new visibility timeout for a job that needs more processing time.
+   * The timeout is set to the specified duration from now (absolute, not relative).
+   * This matches SQS ChangeMessageVisibility semantics.
+   */
+  readonly extendVisibility: (
+    jobId: string,
+    timeout: Duration.Duration,
+  ) => Effect.Effect<void, AcknowledgeError | JobNotFoundError, R>
+
+  /**
+   * Get queue statistics (for monitoring).
+   */
+  readonly getStats: (
+    queue: string,
+  ) => Effect.Effect<QueueStats, InvalidQueueNameError, R>
+}
+
+export class QueueService extends Context.Tag(
+  "@ready-for-agent/queue-service/QueueService",
+)<
+  QueueService,
+  // biome-ignore lint/suspicious/noExplicitAny: Required for generic service tag accepting multiple DB implementations
+  QueueServiceShape<any>
+>() {
+  /**
+   * Claim the next available job from the queue with type-safe payload parsing.
+   * Returns None if no jobs are available.
+   */
+  static claim = <A, I>(
+    queue: string,
+    schema: Schema.Schema<A, I>,
+    visibilityTimeout?: Duration.Duration,
+  ): Effect.Effect<
+    Option.Option<Job<A>>,
+    ClaimError | InvalidQueueNameError | PayloadParseError,
+    QueueService
+  > =>
+    Effect.gen(function* () {
+      const service = yield* QueueService
+      const rawJobOption = yield* service.rawClaim(queue, visibilityTimeout)
+
+      if (Option.isNone(rawJobOption)) {
+        return Option.none()
+      }
+
+      const rawJob = rawJobOption.value
+      const payload = yield* Schema.decodeUnknown(schema)(rawJob.payload).pipe(
+        Effect.mapError(
+          (error) =>
+            new PayloadParseError({ queue, jobId: rawJob.jobId, error }),
+        ),
+      )
+
+      return Option.some<Job<A>>({
+        jobId: rawJob.jobId,
+        queue: rawJob.queue,
+        payload,
+        attempts: rawJob.attempts,
+        maxAttempts: rawJob.maxAttempts,
+        availableAt: rawJob.availableAt,
+        lockedUntil: rawJob.lockedUntil,
+      })
+    })
+}

--- a/packages/queue-service/src/lib/types.ts
+++ b/packages/queue-service/src/lib/types.ts
@@ -1,0 +1,42 @@
+import { type DateTime, Duration } from "effect"
+
+export type Payload = Record<string, unknown>
+
+/** Default visibility timeout for claimed jobs */
+export const DEFAULT_VISIBILITY_TIMEOUT = Duration.seconds(30)
+
+/** Default maximum retry attempts before moving to dead letter */
+export const DEFAULT_MAX_RETRIES = 5
+
+/**
+ * A raw job as returned from the database/queue before schema parsing.
+ * The payload is unknown and needs to be parsed with a schema.
+ */
+export interface RawJob {
+  readonly jobId: string
+  readonly queue: string
+  readonly payload: unknown
+  readonly attempts: number
+  readonly maxAttempts: number
+  readonly availableAt: DateTime.Utc
+  readonly lockedUntil: DateTime.Utc
+}
+
+/**
+ * A job with a typed payload after schema parsing.
+ */
+export interface Job<A> {
+  readonly jobId: string
+  readonly queue: string
+  readonly payload: A
+  readonly attempts: number
+  readonly maxAttempts: number
+  readonly availableAt: DateTime.Utc
+  readonly lockedUntil: DateTime.Utc
+}
+
+export interface QueueStats {
+  readonly pending: number
+  readonly processing: number
+  readonly deadLetter: number
+}

--- a/packages/queue-service/test/validate-queue-name.spec.ts
+++ b/packages/queue-service/test/validate-queue-name.spec.ts
@@ -1,0 +1,147 @@
+import { Effect } from "effect"
+import { InvalidQueueNameError, validateQueueName } from "../src/index.js"
+import { describe, expect, it } from "bun:test"
+
+describe("validateQueueName", () => {
+  it("should succeed for valid queue names", async () => {
+    const validNames = [
+      "test-queue",
+      "Queue.Name_123",
+      "a",
+      "A",
+      "0",
+      "test_queue",
+      "test.queue",
+      "test-queue",
+      "MixedCase123",
+      "a".repeat(80),
+    ]
+
+    for (const name of validNames) {
+      const result = await Effect.runPromise(validateQueueName(name))
+      expect(result).toBe(name)
+    }
+  })
+
+  it("should fail for empty queue name", async () => {
+    const result = await Effect.runPromise(Effect.either(validateQueueName("")))
+
+    expect(result._tag).toBe("Left")
+    if (result._tag === "Left") {
+      expect(result.left).toBeInstanceOf(InvalidQueueNameError)
+      expect(result.left.message).toContain("cannot be empty")
+      expect(result.left.message).toContain("minimum length is 1 character")
+      expect(result.left.queueName).toBe("")
+    }
+  })
+
+  it("should fail for queue name exceeding max length", async () => {
+    const longName = "a".repeat(81)
+    const result = await Effect.runPromise(
+      Effect.either(validateQueueName(longName)),
+    )
+
+    expect(result._tag).toBe("Left")
+    if (result._tag === "Left") {
+      expect(result.left).toBeInstanceOf(InvalidQueueNameError)
+      expect(result.left.message).toContain("exceeds maximum length")
+      expect(result.left.message).toContain("80 characters")
+      expect(result.left.message).toContain("81")
+      expect(result.left.queueName).toBe(longName)
+    }
+  })
+
+  it("should fail for queue names with spaces", async () => {
+    const invalidNames = [
+      "test queue",
+      " test",
+      "test ",
+      " test ",
+      "test queue name",
+    ]
+
+    for (const name of invalidNames) {
+      const result = await Effect.runPromise(
+        Effect.either(validateQueueName(name)),
+      )
+
+      expect(result._tag).toBe("Left")
+      if (result._tag === "Left") {
+        expect(result.left).toBeInstanceOf(InvalidQueueNameError)
+        expect(result.left.message).toContain("invalid characters")
+        expect(result.left.message).toContain("Spaces are NOT allowed")
+        expect(result.left.queueName).toBe(name)
+      }
+    }
+  })
+
+  it("should fail for queue names with special characters", async () => {
+    const invalidNames = [
+      "test@queue",
+      "queue!",
+      "test#queue",
+      "queue/name",
+      "test$queue",
+      "queue%name",
+      "test^queue",
+      "queue&name",
+      "test*queue",
+      "queue+name",
+      "test=queue",
+      "queue[name]",
+      "test{queue}",
+      "queue|name",
+      "test\\queue",
+      "queue:name",
+      "test;queue",
+      'queue"name',
+      "test'queue",
+      "queue<name>",
+      "test,queue",
+      "queue?name",
+    ]
+
+    for (const name of invalidNames) {
+      const result = await Effect.runPromise(
+        Effect.either(validateQueueName(name)),
+      )
+
+      expect(result._tag).toBe("Left")
+      if (result._tag === "Left") {
+        expect(result.left).toBeInstanceOf(InvalidQueueNameError)
+        expect(result.left.message).toContain("invalid characters")
+        expect(result.left.queueName).toBe(name)
+      }
+    }
+  })
+
+  it("should allow hyphens, underscores, and periods", async () => {
+    const validNames = [
+      "test-queue",
+      "test_queue",
+      "test.queue",
+      "test-_.",
+      ".-_test",
+      "my-queue_name.v2",
+    ]
+
+    for (const name of validNames) {
+      const result = await Effect.runPromise(validateQueueName(name))
+      expect(result).toBe(name)
+    }
+  })
+
+  it("should allow all alphanumeric characters", async () => {
+    const validNames = [
+      "abcdefghijklmnopqrstuvwxyz",
+      "ABCDEFGHIJKLMNOPQRSTUVWXYZ",
+      "0123456789",
+      "aA0",
+    ]
+
+    for (const name of validNames) {
+      const result = await Effect.runPromise(validateQueueName(name))
+      expect(result).toBe(name)
+    }
+  })
+})

--- a/packages/queue-service/tsconfig.json
+++ b/packages/queue-service/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ]
+}

--- a/packages/queue-service/tsconfig.lib.json
+++ b/packages/queue-service/tsconfig.lib.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "tsBuildInfoFile": "dist/tsconfig.lib.tsbuildinfo",
+    "emitDeclarationOnly": false,
+    "forceConsistentCasingInFileNames": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"],
+  "references": []
+}

--- a/packages/sqlite-queue-service/package.json
+++ b/packages/sqlite-queue-service/package.json
@@ -1,0 +1,50 @@
+{
+  "name": "@ready-for-agent/sqlite-queue-service",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    "./package.json": "./package.json",
+    ".": {
+      "@ready-for-agent/source": "./src/index.ts",
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    }
+  },
+  "nx": {
+    "name": "sqlite-queue-service",
+    "targets": {
+      "test": {
+        "executor": "nx:run-commands",
+        "options": {
+          "cwd": "{projectRoot}",
+          "command": "bun test"
+        },
+        "inputs": [
+          "default",
+          "^production"
+        ],
+        "cache": true,
+        "dependsOn": [
+          "^build"
+        ]
+      }
+    }
+  },
+  "dependencies": {
+    "@effect/sql": "^0.51.1",
+    "@ready-for-agent/db": "workspace:*",
+    "@ready-for-agent/db-schema": "workspace:*",
+    "@ready-for-agent/queue-service": "workspace:*",
+    "drizzle-orm": "1.0.0-rc.4-5d5b77c",
+    "effect": "^3.21.4",
+    "tslib": "^2.3.0"
+  },
+  "devDependencies": {
+    "@types/bun": "^1.3.0"
+  }
+}

--- a/packages/sqlite-queue-service/src/index.ts
+++ b/packages/sqlite-queue-service/src/index.ts
@@ -1,0 +1,1 @@
+export * from "./lib/sqlite-queue-service.js"

--- a/packages/sqlite-queue-service/src/lib/sqlite-queue-service.ts
+++ b/packages/sqlite-queue-service/src/lib/sqlite-queue-service.ts
@@ -1,0 +1,593 @@
+import { SqlClient } from "@effect/sql"
+import type { SqlError } from "@effect/sql/SqlError"
+import { and, eq, isNull, lt, lte, or, sql } from "drizzle-orm"
+import { DateTime, Duration, Effect, Layer, Option, Schedule } from "effect"
+import { TypedSqliteDrizzle, runDrizzle } from "@ready-for-agent/db"
+import * as schema from "@ready-for-agent/db-schema"
+import type { Payload, RawJob } from "@ready-for-agent/queue-service"
+import {
+  AcknowledgeError,
+  ClaimError,
+  DEFAULT_MAX_RETRIES,
+  DEFAULT_VISIBILITY_TIMEOUT,
+  EnqueueError,
+  JobNotFoundError,
+  QueueService,
+  validateQueueName,
+} from "@ready-for-agent/queue-service"
+
+/**
+ * Extract a meaningful error message from SqlError, including cause chain.
+ */
+const formatSqlError = (error: SqlError): string => {
+  const parts: string[] = [error.message]
+
+  let current: unknown = error.cause
+  while (current) {
+    if (current instanceof Error) {
+      parts.push(current.message)
+      current = current.cause
+    } else if (typeof current === "object" && current !== null) {
+      const obj = current as Record<string, unknown>
+      if ("message" in obj && typeof obj["message"] === "string") {
+        parts.push(obj["message"])
+      }
+      current = "cause" in obj ? obj["cause"] : undefined
+    } else if (typeof current === "string") {
+      parts.push(current)
+      break
+    } else {
+      break
+    }
+  }
+
+  return parts.join(" -> ")
+}
+
+const isSqliteBusy = (error: unknown): boolean => {
+  let current: unknown = error
+
+  while (current != null) {
+    if (current instanceof Error) {
+      if (
+        current.message.includes("SQLITE_BUSY") ||
+        current.message.includes("database is locked") ||
+        current.message.includes("SQL statements in progress")
+      ) {
+        return true
+      }
+      current = current.cause
+      continue
+    }
+
+    if (
+      typeof current === "object" &&
+      current !== null &&
+      "message" in current &&
+      typeof current.message === "string"
+    ) {
+      if (
+        current.message.includes("SQLITE_BUSY") ||
+        current.message.includes("database is locked") ||
+        current.message.includes("SQL statements in progress")
+      ) {
+        return true
+      }
+      current =
+        "cause" in current ? (current as { cause?: unknown }).cause : undefined
+      continue
+    }
+
+    if (
+      typeof current === "string" &&
+      (current.includes("SQLITE_BUSY") ||
+        current.includes("database is locked") ||
+        current.includes("SQL statements in progress"))
+    ) {
+      return true
+    }
+
+    break
+  }
+
+  return false
+}
+
+const SQLITE_BUSY_RETRY_SCHEDULE = Schedule.addDelay(Schedule.recurs(4), () =>
+  Duration.millis(50),
+)
+
+const retrySqliteBusy = <A, E, R>(effect: Effect.Effect<A, E, R>) =>
+  effect.pipe(
+    Effect.retry({
+      schedule: SQLITE_BUSY_RETRY_SCHEDULE,
+      while: isSqliteBusy,
+    }),
+  )
+
+const toUtc = (millis: number): DateTime.Utc => DateTime.unsafeMake(millis)
+
+/**
+ * SQLite/Turso implementation of the QueueService.
+ *
+ * Claim uses SqlClient.withTransaction (BEGIN IMMEDIATE via layer-turso-local)
+ * for atomic lock + attempt increment. All operations require TypedSqliteDrizzle.
+ */
+export const SqliteQueueServiceLive = Layer.succeed(
+  QueueService,
+  QueueService.of({
+    queueInTransaction: true,
+
+    enqueue: <P extends Payload>(
+      queue: string,
+      payload: P,
+      options?: { readonly retryLimit?: number },
+    ) =>
+      Effect.gen(function* () {
+        yield* validateQueueName(queue)
+        const db = yield* TypedSqliteDrizzle
+        const now = Date.now()
+
+        const result = yield* runDrizzle(
+          db
+            .insert(schema.jobQueue)
+            .values({
+              queue,
+              jobPayload: payload as Record<string, unknown>,
+              jobRetryLimit:
+                options?.retryLimit !== undefined
+                  ? options.retryLimit + 1
+                  : DEFAULT_MAX_RETRIES,
+              availableAt: now,
+              lockedUntil: null,
+              createdAt: now,
+              updatedAt: now,
+            })
+            .returning({ id: schema.jobQueue.id }),
+        ).pipe(
+          retrySqliteBusy,
+          Effect.catchTag("SqlError", (error: SqlError) => {
+            const formattedMsg = formatSqlError(error)
+            console.error(
+              `[SqliteQueueService] enqueue failed for queue=${queue}:`,
+              formattedMsg,
+              error,
+            )
+            return Effect.fail(
+              new EnqueueError({
+                queue,
+                message: `Database error: ${formattedMsg}`,
+                cause: error,
+              }),
+            )
+          }),
+        )
+
+        const row = result[0]
+        if (!row) {
+          return yield* new EnqueueError({
+            queue,
+            message: "No job ID returned from insert",
+          })
+        }
+
+        return row.id
+      }),
+
+    enqueueWithDelay: <P extends Payload>(
+      queue: string,
+      payload: P,
+      delay: Duration.Duration,
+      options?: { readonly retryLimit?: number },
+    ) =>
+      Effect.gen(function* () {
+        yield* validateQueueName(queue)
+        const db = yield* TypedSqliteDrizzle
+        const now = Date.now()
+        const availableAt = now + Duration.toMillis(delay)
+
+        const result = yield* runDrizzle(
+          db
+            .insert(schema.jobQueue)
+            .values({
+              queue,
+              jobPayload: payload as Record<string, unknown>,
+              jobRetryLimit:
+                options?.retryLimit !== undefined
+                  ? options.retryLimit + 1
+                  : DEFAULT_MAX_RETRIES,
+              availableAt,
+              lockedUntil: null,
+              createdAt: now,
+              updatedAt: now,
+            })
+            .returning({ id: schema.jobQueue.id }),
+        ).pipe(
+          retrySqliteBusy,
+          Effect.catchTag("SqlError", (error: SqlError) => {
+            const formattedMsg = formatSqlError(error)
+            console.error(
+              `[SqliteQueueService] enqueueWithDelay failed for queue=${queue}:`,
+              formattedMsg,
+              error,
+            )
+            return Effect.fail(
+              new EnqueueError({
+                queue,
+                message: `Database error: ${formattedMsg}`,
+                cause: error,
+              }),
+            )
+          }),
+        )
+
+        const row = result[0]
+        if (!row) {
+          return yield* new EnqueueError({
+            queue,
+            message: "No job ID returned from insert",
+          })
+        }
+
+        return row.id
+      }),
+
+    rawClaim: (queue: string, visibilityTimeout?: Duration.Duration) =>
+      Effect.gen(function* () {
+        yield* validateQueueName(queue)
+        const sqlClient = yield* SqlClient.SqlClient
+        const db = yield* TypedSqliteDrizzle
+        const now = Date.now()
+        const timeout = visibilityTimeout ?? DEFAULT_VISIBILITY_TIMEOUT
+        const lockedUntil = now + Duration.toMillis(timeout)
+
+        const availableJobConditions = and(
+          eq(schema.jobQueue.queue, queue),
+          lte(schema.jobQueue.availableAt, now),
+          or(
+            isNull(schema.jobQueue.lockedUntil),
+            lte(schema.jobQueue.lockedUntil, now),
+          ),
+          lt(schema.jobQueue.jobAttempts, schema.jobQueue.jobRetryLimit),
+        )
+
+        const candidate = yield* runDrizzle(
+          db
+            .select({ id: schema.jobQueue.id })
+            .from(schema.jobQueue)
+            .where(availableJobConditions)
+            .limit(1),
+        ).pipe(
+          retrySqliteBusy,
+          Effect.catchTag("SqlError", (error: SqlError) => {
+            const formattedMsg = formatSqlError(error)
+            console.error(
+              `[SqliteQueueService] rawClaim (check) failed for queue=${queue}:`,
+              formattedMsg,
+              error,
+            )
+            return Effect.fail(
+              new ClaimError({
+                queue,
+                message: `Database error: ${formattedMsg}`,
+                cause: error,
+              }),
+            )
+          }),
+        )
+
+        if (!candidate[0]) {
+          return Option.none()
+        }
+
+        // Atomic claim: BEGIN IMMEDIATE (Turso layer) then update under write lock.
+        // SQLite/Turso have no FOR UPDATE SKIP LOCKED.
+        return yield* sqlClient
+          .withTransaction(
+            Effect.gen(function* () {
+              const nextJobSubquery = db
+                .select({ id: schema.jobQueue.id })
+                .from(schema.jobQueue)
+                .where(availableJobConditions)
+                .orderBy(
+                  schema.jobQueue.jobAttempts,
+                  schema.jobQueue.availableAt,
+                  schema.jobQueue.id,
+                )
+                .limit(1)
+
+              const result = yield* runDrizzle(
+                db
+                  .update(schema.jobQueue)
+                  .set({
+                    lockedUntil,
+                    jobAttempts: sql`${schema.jobQueue.jobAttempts} + 1`,
+                    updatedAt: now,
+                  })
+                  .where(eq(schema.jobQueue.id, nextJobSubquery))
+                  .returning(),
+              )
+
+              if (!result[0]) {
+                return Option.none()
+              }
+
+              const row = result[0]
+              return Option.some<RawJob>({
+                jobId: row.id,
+                queue: row.queue,
+                payload: row.jobPayload,
+                attempts: row.jobAttempts,
+                maxAttempts: row.jobRetryLimit,
+                availableAt: toUtc(row.availableAt),
+                lockedUntil: toUtc(lockedUntil),
+              })
+            }),
+          )
+          .pipe(
+            retrySqliteBusy,
+            Effect.catchTag("SqlError", (error: SqlError) => {
+              const formattedMsg = formatSqlError(error)
+              console.error(
+                `[SqliteQueueService] rawClaim failed for queue=${queue}:`,
+                formattedMsg,
+                error,
+              )
+              return Effect.fail(
+                new ClaimError({
+                  queue,
+                  message: `Database error: ${formattedMsg}`,
+                  cause: error,
+                }),
+              )
+            }),
+          )
+      }),
+
+    acknowledge: (jobId: string) =>
+      Effect.gen(function* () {
+        const db = yield* TypedSqliteDrizzle
+
+        const result = yield* runDrizzle(
+          db
+            .delete(schema.jobQueue)
+            .where(eq(schema.jobQueue.id, jobId))
+            .returning({ id: schema.jobQueue.id }),
+        ).pipe(
+          retrySqliteBusy,
+          Effect.catchTag("SqlError", (error: SqlError) => {
+            const formattedMsg = formatSqlError(error)
+            console.error(
+              `[SqliteQueueService] acknowledge failed for jobId=${jobId}:`,
+              formattedMsg,
+              error,
+            )
+            return Effect.fail(
+              new AcknowledgeError({
+                jobId,
+                message: `Database error: ${formattedMsg}`,
+                cause: error,
+              }),
+            )
+          }),
+        )
+
+        if (!result[0]) {
+          return yield* new JobNotFoundError({ jobId })
+        }
+      }),
+
+    fail: (
+      jobId: string,
+      options?: {
+        readonly releaseImmediately?: boolean
+        readonly retryable?: boolean
+      },
+    ) =>
+      Effect.gen(function* () {
+        const db = yield* TypedSqliteDrizzle
+        const now = Date.now()
+
+        if (options?.retryable === false) {
+          const result = yield* runDrizzle(
+            db
+              .update(schema.jobQueue)
+              .set({
+                jobAttempts: sql`${schema.jobQueue.jobRetryLimit}`,
+                lockedUntil: null,
+                updatedAt: now,
+              })
+              .where(eq(schema.jobQueue.id, jobId))
+              .returning({ id: schema.jobQueue.id }),
+          ).pipe(
+            retrySqliteBusy,
+            Effect.catchTag("SqlError", (error: SqlError) => {
+              const formattedMsg = formatSqlError(error)
+              console.error(
+                `[SqliteQueueService] fail (terminal) failed for jobId=${jobId}:`,
+                formattedMsg,
+                error,
+              )
+              return Effect.fail(
+                new AcknowledgeError({
+                  jobId,
+                  message: `Failed to dead-letter job: ${formattedMsg}`,
+                  cause: error,
+                }),
+              )
+            }),
+          )
+
+          if (!result[0]) {
+            return yield* new JobNotFoundError({ jobId })
+          }
+
+          return
+        }
+
+        if (options?.releaseImmediately) {
+          const result = yield* runDrizzle(
+            db
+              .update(schema.jobQueue)
+              .set({ lockedUntil: null, updatedAt: now })
+              .where(eq(schema.jobQueue.id, jobId))
+              .returning({ id: schema.jobQueue.id }),
+          ).pipe(
+            retrySqliteBusy,
+            Effect.catchTag("SqlError", (error: SqlError) => {
+              const formattedMsg = formatSqlError(error)
+              console.error(
+                `[SqliteQueueService] fail (releaseImmediately) failed for jobId=${jobId}:`,
+                formattedMsg,
+                error,
+              )
+              return Effect.fail(
+                new AcknowledgeError({
+                  jobId,
+                  message: `Failed to mark job as failed: ${formattedMsg}`,
+                  cause: error,
+                }),
+              )
+            }),
+          )
+
+          if (!result[0]) {
+            return yield* new JobNotFoundError({ jobId })
+          }
+        } else {
+          const result = yield* runDrizzle(
+            db
+              .select({ id: schema.jobQueue.id })
+              .from(schema.jobQueue)
+              .where(eq(schema.jobQueue.id, jobId)),
+          ).pipe(
+            retrySqliteBusy,
+            Effect.catchTag("SqlError", (error: SqlError) => {
+              const formattedMsg = formatSqlError(error)
+              console.error(
+                `[SqliteQueueService] fail (verify) failed for jobId=${jobId}:`,
+                formattedMsg,
+                error,
+              )
+              return Effect.fail(
+                new AcknowledgeError({
+                  jobId,
+                  message: `Failed to verify job exists: ${formattedMsg}`,
+                  cause: error,
+                }),
+              )
+            }),
+          )
+
+          if (!result[0]) {
+            return yield* new JobNotFoundError({ jobId })
+          }
+        }
+      }),
+
+    extendVisibility: (jobId: string, timeout: Duration.Duration) =>
+      Effect.gen(function* () {
+        const db = yield* TypedSqliteDrizzle
+        const now = Date.now()
+        const newLock = now + Duration.toMillis(timeout)
+
+        const result = yield* runDrizzle(
+          db
+            .update(schema.jobQueue)
+            .set({ lockedUntil: newLock, updatedAt: now })
+            .where(
+              and(
+                eq(schema.jobQueue.id, jobId),
+                sql`${schema.jobQueue.lockedUntil} IS NOT NULL`,
+              ),
+            )
+            .returning({ id: schema.jobQueue.id }),
+        ).pipe(
+          retrySqliteBusy,
+          Effect.catchTag("SqlError", (error: SqlError) => {
+            const formattedMsg = formatSqlError(error)
+            console.error(
+              `[SqliteQueueService] extendVisibility failed for jobId=${jobId}:`,
+              formattedMsg,
+              error,
+            )
+            return Effect.fail(
+              new AcknowledgeError({
+                jobId,
+                message: `Failed to extend visibility: ${formattedMsg}`,
+                cause: error,
+              }),
+            )
+          }),
+        )
+
+        if (!result[0]) {
+          const exists = yield* runDrizzle(
+            db
+              .select({ lockedUntil: schema.jobQueue.lockedUntil })
+              .from(schema.jobQueue)
+              .where(eq(schema.jobQueue.id, jobId)),
+          ).pipe(
+            retrySqliteBusy,
+            Effect.catchTag("SqlError", (error: SqlError) => {
+              const formattedMsg = formatSqlError(error)
+              console.error(
+                `[SqliteQueueService] extendVisibility (verify) failed for jobId=${jobId}:`,
+                formattedMsg,
+                error,
+              )
+              return Effect.fail(
+                new AcknowledgeError({
+                  jobId,
+                  message: `Failed to verify job: ${formattedMsg}`,
+                  cause: error,
+                }),
+              )
+            }),
+          )
+
+          if (!exists[0]) {
+            return yield* new JobNotFoundError({ jobId })
+          }
+
+          return yield* new AcknowledgeError({
+            jobId,
+            message: "Cannot extend visibility of unlocked job",
+          })
+        }
+      }),
+
+    getStats: (queue: string) =>
+      Effect.gen(function* () {
+        yield* validateQueueName(queue)
+        const db = yield* TypedSqliteDrizzle
+        const now = Date.now()
+
+        const stats = yield* runDrizzle(
+          db
+            .select({
+              pending: sql<number>`COUNT(CASE
+              WHEN (${schema.jobQueue.lockedUntil} IS NULL OR ${schema.jobQueue.lockedUntil} <= ${now})
+                AND ${schema.jobQueue.jobAttempts} < ${schema.jobQueue.jobRetryLimit}
+              THEN 1 END)`,
+              processing: sql<number>`COUNT(CASE
+              WHEN ${schema.jobQueue.lockedUntil} > ${now}
+              THEN 1 END)`,
+              deadLetter: sql<number>`COUNT(CASE
+              WHEN ${schema.jobQueue.jobAttempts} >= ${schema.jobQueue.jobRetryLimit}
+              THEN 1 END)`,
+            })
+            .from(schema.jobQueue)
+            .where(eq(schema.jobQueue.queue, queue)),
+        ).pipe(Effect.catchAll(() => Effect.succeed([] as const)))
+
+        return (
+          stats[0] ?? {
+            pending: 0,
+            processing: 0,
+            deadLetter: 0,
+          }
+        )
+      }),
+  }),
+)

--- a/packages/sqlite-queue-service/test/sqlite-queue-service.spec.ts
+++ b/packages/sqlite-queue-service/test/sqlite-queue-service.spec.ts
@@ -1,0 +1,545 @@
+import { Duration, Effect, Layer, Option } from "effect"
+import { DatabaseTest } from "@ready-for-agent/db/test"
+import {
+  InvalidQueueNameError,
+  QueueService,
+} from "@ready-for-agent/queue-service"
+import { SqliteQueueServiceLive } from "../src/lib/sqlite-queue-service.js"
+import { describe, expect, it } from "bun:test"
+
+describe("SqliteQueueService", () => {
+  const TestLayer = Layer.mergeAll(SqliteQueueServiceLive, DatabaseTest)
+
+  type TestRequirements = Layer.Layer.Success<typeof TestLayer>
+
+  const runTest = <A, E>(
+    test: Effect.Effect<A, E, TestRequirements>,
+  ): Promise<A> => {
+    return Effect.runPromise(Effect.provide(test, TestLayer))
+  }
+
+  describe("enqueue", () => {
+    it("should enqueue a job and return job ID", () =>
+      runTest(
+        Effect.gen(function* () {
+          const queue = yield* QueueService
+
+          const jobId = yield* queue.enqueue("test-queue", { task: "test" })
+
+          expect(jobId).toBeDefined()
+          expect(typeof jobId).toBe("string")
+          expect(jobId.length).toBeGreaterThan(0)
+        }),
+      ))
+
+    it("should enqueue jobs with different payloads", () =>
+      runTest(
+        Effect.gen(function* () {
+          const queue = yield* QueueService
+
+          const jobId1 = yield* queue.enqueue("test-queue", { task: "task1" })
+          const jobId2 = yield* queue.enqueue("test-queue", { task: "task2" })
+
+          expect(jobId1).not.toBe(jobId2)
+        }),
+      ))
+
+    it("should enqueue and claim a job", () =>
+      runTest(
+        Effect.gen(function* () {
+          const queue = yield* QueueService
+
+          yield* queue.enqueue("retry-queue", { task: "test" })
+
+          const job = yield* queue.rawClaim("retry-queue")
+          expect(Option.isSome(job)).toBe(true)
+          if (Option.isSome(job)) {
+            expect(job.value.attempts).toBe(1)
+          }
+        }),
+      ))
+  })
+
+  describe("enqueueWithDelay", () => {
+    it("should enqueue a job with delay", () =>
+      runTest(
+        Effect.gen(function* () {
+          const queue = yield* QueueService
+
+          const jobId = yield* queue.enqueueWithDelay(
+            "delayed-queue",
+            { task: "delayed" },
+            Duration.seconds(60),
+          )
+
+          expect(jobId).toBeDefined()
+
+          const job = yield* queue.rawClaim("delayed-queue")
+          expect(Option.isNone(job)).toBe(true)
+        }),
+      ))
+  })
+
+  describe("claim", () => {
+    it("should claim an available job", () =>
+      runTest(
+        Effect.gen(function* () {
+          const queue = yield* QueueService
+
+          const jobId = yield* queue.enqueue("claim-queue", {
+            task: "to-claim",
+          })
+          const job = yield* queue.rawClaim("claim-queue")
+
+          expect(Option.isSome(job)).toBe(true)
+          if (Option.isSome(job)) {
+            expect(job.value.jobId).toBe(jobId)
+            expect(job.value.payload).toEqual({ task: "to-claim" })
+            expect(job.value.attempts).toBe(1)
+          }
+        }),
+      ))
+
+    it("should return None when no jobs available", () =>
+      runTest(
+        Effect.gen(function* () {
+          const queue = yield* QueueService
+
+          const job = yield* queue.rawClaim("empty-queue")
+
+          expect(Option.isNone(job)).toBe(true)
+        }),
+      ))
+
+    it("should not claim already claimed job", () =>
+      runTest(
+        Effect.gen(function* () {
+          const queue = yield* QueueService
+
+          yield* queue.enqueue("single-claim-queue", { task: "test" })
+
+          const job1 = yield* queue.rawClaim("single-claim-queue")
+          const job2 = yield* queue.rawClaim("single-claim-queue")
+
+          expect(Option.isSome(job1)).toBe(true)
+          expect(Option.isNone(job2)).toBe(true)
+        }),
+      ))
+
+    it("should increment attempts on each claim", () =>
+      runTest(
+        Effect.gen(function* () {
+          const queue = yield* QueueService
+
+          yield* queue.enqueue("attempts-queue", { task: "test" })
+
+          const job1 = yield* queue.rawClaim(
+            "attempts-queue",
+            Duration.millis(1),
+          )
+          expect(Option.isSome(job1)).toBe(true)
+          if (Option.isSome(job1)) {
+            expect(job1.value.attempts).toBe(1)
+          }
+
+          yield* Effect.sleep(Duration.millis(10))
+
+          const job2 = yield* queue.rawClaim(
+            "attempts-queue",
+            Duration.millis(1),
+          )
+          expect(Option.isSome(job2)).toBe(true)
+          if (Option.isSome(job2)) {
+            expect(job2.value.attempts).toBe(2)
+          }
+        }),
+      ))
+
+    it("should prefer fresh jobs over retried jobs", () =>
+      runTest(
+        Effect.gen(function* () {
+          const queue = yield* QueueService
+          const queueName = `retry-order-queue-${Date.now()}`
+
+          yield* queue.enqueue(queueName, { task: "retried" })
+
+          const firstClaim = yield* queue.rawClaim(
+            queueName,
+            Duration.seconds(60),
+          )
+          expect(Option.isSome(firstClaim)).toBe(true)
+          if (Option.isSome(firstClaim)) {
+            yield* queue.fail(firstClaim.value.jobId, {
+              releaseImmediately: true,
+            })
+          }
+
+          yield* queue.enqueue(queueName, { task: "fresh" })
+
+          const nextClaim = yield* queue.rawClaim(
+            queueName,
+            Duration.seconds(60),
+          )
+          expect(Option.isSome(nextClaim)).toBe(true)
+          if (Option.isSome(nextClaim)) {
+            expect(nextClaim.value.payload).toEqual({ task: "fresh" })
+            expect(nextClaim.value.attempts).toBe(1)
+          }
+        }),
+      ))
+
+    it("should not claim jobs that exceeded max retries", () =>
+      runTest(
+        Effect.gen(function* () {
+          const queue = yield* QueueService
+          const queueName = `max-retry-queue-${Date.now()}`
+
+          yield* queue.enqueue(queueName, { task: "test" })
+
+          for (let i = 0; i < 5; i++) {
+            const job = yield* queue.rawClaim(queueName, Duration.millis(1))
+            expect(Option.isSome(job)).toBe(true)
+            yield* Effect.sleep(Duration.millis(10))
+          }
+
+          const job6 = yield* queue.rawClaim(queueName)
+          expect(Option.isNone(job6)).toBe(true)
+        }),
+      ))
+  })
+
+  describe("acknowledge", () => {
+    it("should acknowledge and remove job from queue", () =>
+      runTest(
+        Effect.gen(function* () {
+          const queue = yield* QueueService
+
+          const jobId = yield* queue.enqueue("ack-queue", { task: "test" })
+          yield* queue.rawClaim("ack-queue")
+          yield* queue.acknowledge(jobId)
+
+          const job = yield* queue.rawClaim("ack-queue")
+          expect(Option.isNone(job)).toBe(true)
+        }),
+      ))
+
+    it("should fail for non-existent job", () =>
+      runTest(
+        Effect.gen(function* () {
+          const queue = yield* QueueService
+
+          const result = yield* Effect.either(
+            queue.acknowledge("non-existent-id"),
+          )
+
+          expect(result._tag).toBe("Left")
+        }),
+      ))
+  })
+
+  describe("fail", () => {
+    it("should mark job as failed but keep it for retry", () =>
+      runTest(
+        Effect.gen(function* () {
+          const queue = yield* QueueService
+
+          yield* queue.enqueue("fail-queue", { task: "test" })
+          const job = yield* queue.rawClaim("fail-queue", Duration.seconds(60))
+
+          expect(Option.isSome(job)).toBe(true)
+          if (Option.isSome(job)) {
+            yield* queue.fail(job.value.jobId)
+
+            const job2 = yield* queue.rawClaim("fail-queue")
+            expect(Option.isNone(job2)).toBe(true)
+          }
+        }),
+      ))
+
+    it("should release job immediately with releaseImmediately option", () =>
+      runTest(
+        Effect.gen(function* () {
+          const queue = yield* QueueService
+
+          yield* queue.enqueue("fail-immediate-queue", { task: "test" })
+          const job = yield* queue.rawClaim(
+            "fail-immediate-queue",
+            Duration.seconds(60),
+          )
+
+          expect(Option.isSome(job)).toBe(true)
+          if (Option.isSome(job)) {
+            yield* queue.fail(job.value.jobId, { releaseImmediately: true })
+
+            const job2 = yield* queue.rawClaim("fail-immediate-queue")
+            expect(Option.isSome(job2)).toBe(true)
+            if (Option.isSome(job2)) {
+              expect(job2.value.attempts).toBe(2)
+            }
+          }
+        }),
+      ))
+  })
+
+  describe("extendVisibility", () => {
+    it("should set new visibility timeout from now", () =>
+      runTest(
+        Effect.gen(function* () {
+          const queue = yield* QueueService
+
+          yield* queue.enqueue("extend-queue", { task: "test" })
+          const job = yield* queue.rawClaim("extend-queue", Duration.millis(50))
+
+          expect(Option.isSome(job)).toBe(true)
+          if (Option.isSome(job)) {
+            yield* queue.extendVisibility(job.value.jobId, Duration.seconds(10))
+
+            yield* Effect.sleep(Duration.millis(60))
+
+            const job2 = yield* queue.rawClaim("extend-queue")
+            expect(Option.isNone(job2)).toBe(true)
+          }
+        }),
+      ))
+
+    it("should fail for non-existent job", () =>
+      runTest(
+        Effect.gen(function* () {
+          const queue = yield* QueueService
+
+          const result = yield* Effect.either(
+            queue.extendVisibility("non-existent-id", Duration.seconds(10)),
+          )
+
+          expect(result._tag).toBe("Left")
+        }),
+      ))
+  })
+
+  describe("getStats", () => {
+    it("should return queue statistics", () =>
+      runTest(
+        Effect.gen(function* () {
+          const queue = yield* QueueService
+          const queueName = `stats-queue-${Date.now()}`
+
+          yield* queue.enqueue(queueName, { task: "pending1" })
+          yield* queue.enqueue(queueName, { task: "pending2" })
+
+          const claimed = yield* queue.rawClaim(queueName, Duration.seconds(60))
+          expect(Option.isSome(claimed)).toBe(true)
+
+          const stats = yield* queue.getStats(queueName)
+
+          expect(stats.processing).toBe(1)
+          expect(stats.pending).toBe(1)
+          expect(stats.deadLetter).toBe(0)
+        }),
+      ))
+
+    it("should count dead letter jobs", () =>
+      runTest(
+        Effect.gen(function* () {
+          const queue = yield* QueueService
+          const queueName = `dead-letter-queue-${Date.now()}`
+
+          yield* queue.enqueue(queueName, { task: "test" })
+
+          for (let i = 0; i < 5; i++) {
+            yield* queue.rawClaim(queueName, Duration.millis(1))
+            yield* Effect.sleep(Duration.millis(10))
+          }
+
+          const stats = yield* queue.getStats(queueName)
+
+          expect(stats.deadLetter).toBe(1)
+        }),
+      ))
+  })
+
+  describe("concurrency", () => {
+    it("should handle concurrent enqueue operations", () =>
+      runTest(
+        Effect.gen(function* () {
+          const queue = yield* QueueService
+          const queueName = "concurrent-enqueue-queue"
+
+          const jobIds = yield* Effect.all(
+            Array.from({ length: 10 }, (_, i) =>
+              queue.enqueue(queueName, { task: `task-${i}` }),
+            ),
+            { concurrency: 10 },
+          )
+
+          const uniqueIds = new Set(jobIds)
+          expect(uniqueIds.size).toBe(10)
+
+          const jobs: string[] = []
+          for (let i = 0; i < 10; i++) {
+            const job = yield* queue.rawClaim(queueName, Duration.millis(1))
+            if (Option.isSome(job)) {
+              jobs.push(job.value.jobId)
+            }
+            yield* Effect.sleep(Duration.millis(5))
+          }
+          expect(jobs.length).toBe(10)
+        }),
+      ))
+
+    it("should not double-claim jobs under concurrent claim attempts", () =>
+      runTest(
+        Effect.gen(function* () {
+          const queue = yield* QueueService
+          const queueName = "concurrent-claim-queue"
+
+          for (let i = 0; i < 5; i++) {
+            yield* queue.enqueue(queueName, { task: `task-${i}` })
+          }
+
+          const results = yield* Effect.all(
+            Array.from({ length: 10 }, () =>
+              queue.rawClaim(queueName, Duration.seconds(60)),
+            ),
+            { concurrency: 10 },
+          )
+
+          const successfulClaims = results.filter(Option.isSome)
+          expect(successfulClaims.length).toBe(5)
+
+          const claimedIds = successfulClaims.map((job) => job.value.jobId)
+          const uniqueClaimedIds = new Set(claimedIds)
+          expect(uniqueClaimedIds.size).toBe(5)
+        }),
+      ))
+  })
+
+  describe("queue name validation", () => {
+    it("should reject enqueue with invalid queue name (spaces)", () =>
+      runTest(
+        Effect.gen(function* () {
+          const queue = yield* QueueService
+          const result = yield* Effect.either(
+            queue.enqueue("invalid queue", { task: "test" }),
+          )
+
+          expect(result._tag).toBe("Left")
+          if (result._tag === "Left") {
+            expect(result.left).toBeInstanceOf(InvalidQueueNameError)
+            expect(result.left.message).toContain("invalid characters")
+          }
+        }),
+      ))
+
+    it("should reject enqueue with invalid queue name (special chars)", () =>
+      runTest(
+        Effect.gen(function* () {
+          const queue = yield* QueueService
+          const result = yield* Effect.either(
+            queue.enqueue("invalid@queue", { task: "test" }),
+          )
+
+          expect(result._tag).toBe("Left")
+          if (result._tag === "Left") {
+            expect(result.left).toBeInstanceOf(InvalidQueueNameError)
+          }
+        }),
+      ))
+
+    it("should reject enqueue with empty queue name", () =>
+      runTest(
+        Effect.gen(function* () {
+          const queue = yield* QueueService
+          const result = yield* Effect.either(
+            queue.enqueue("", { task: "test" }),
+          )
+
+          expect(result._tag).toBe("Left")
+          if (result._tag === "Left") {
+            expect(result.left).toBeInstanceOf(InvalidQueueNameError)
+            expect(result.left.message).toContain("cannot be empty")
+          }
+        }),
+      ))
+
+    it("should reject enqueue with queue name exceeding max length", () =>
+      runTest(
+        Effect.gen(function* () {
+          const queue = yield* QueueService
+          const longName = "a".repeat(81)
+          const result = yield* Effect.either(
+            queue.enqueue(longName, { task: "test" }),
+          )
+
+          expect(result._tag).toBe("Left")
+          if (result._tag === "Left") {
+            expect(result.left).toBeInstanceOf(InvalidQueueNameError)
+            expect(result.left.message).toContain("exceeds maximum length")
+          }
+        }),
+      ))
+
+    it("should reject enqueueWithDelay with invalid queue name", () =>
+      runTest(
+        Effect.gen(function* () {
+          const queue = yield* QueueService
+          const result = yield* Effect.either(
+            queue.enqueueWithDelay(
+              "invalid queue",
+              { task: "test" },
+              Duration.seconds(1),
+            ),
+          )
+
+          expect(result._tag).toBe("Left")
+          if (result._tag === "Left") {
+            expect(result.left).toBeInstanceOf(InvalidQueueNameError)
+          }
+        }),
+      ))
+
+    it("should reject claim with invalid queue name", () =>
+      runTest(
+        Effect.gen(function* () {
+          const queue = yield* QueueService
+          const result = yield* Effect.either(queue.rawClaim("invalid@queue"))
+
+          expect(result._tag).toBe("Left")
+          if (result._tag === "Left") {
+            expect(result.left).toBeInstanceOf(InvalidQueueNameError)
+          }
+        }),
+      ))
+
+    it("should accept valid queue names", () =>
+      runTest(
+        Effect.gen(function* () {
+          const queue = yield* QueueService
+          const validNames = [
+            "test-queue",
+            "test_queue",
+            "test.queue",
+            "TestQueue123",
+            "a",
+          ]
+
+          for (const name of validNames) {
+            const jobId = yield* queue.enqueue(name, { task: "test" })
+            expect(jobId).toBeDefined()
+          }
+        }),
+      ))
+
+    it("should reject getStats with invalid queue name", () =>
+      runTest(
+        Effect.gen(function* () {
+          const queue = yield* QueueService
+          const result = yield* Effect.either(queue.getStats("invalid queue"))
+
+          expect(result._tag).toBe("Left")
+          if (result._tag === "Left") {
+            expect(result.left).toBeInstanceOf(InvalidQueueNameError)
+          }
+        }),
+      ))
+  })
+})

--- a/packages/sqlite-queue-service/tsconfig.json
+++ b/packages/sqlite-queue-service/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ]
+}

--- a/packages/sqlite-queue-service/tsconfig.lib.json
+++ b/packages/sqlite-queue-service/tsconfig.lib.json
@@ -1,0 +1,23 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "tsBuildInfoFile": "dist/tsconfig.lib.tsbuildinfo",
+    "emitDeclarationOnly": false,
+    "forceConsistentCasingInFileNames": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"],
+  "references": [
+    {
+      "path": "../db/tsconfig.lib.json"
+    },
+    {
+      "path": "../db-schema/tsconfig.lib.json"
+    },
+    {
+      "path": "../queue-service/tsconfig.lib.json"
+    }
+  ]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,18 @@
     },
     {
       "path": "./packages/db-schema"
+    },
+    {
+      "path": "./packages/queue-service"
+    },
+    {
+      "path": "./packages/db"
+    },
+    {
+      "path": "./packages/sqlite-queue-service"
+    },
+    {
+      "path": "./packages/layer-turso-local"
     }
   ]
 }


### PR DESCRIPTION
## Why

Long-running harness work should go through a background job queue (ARCHITECTURE), on Turso rather than ad-hoc in-process work. This PR lays the queue infrastructure and Turso Effect SQL layer so a future job worker can claim and process jobs safely.

## What Changed

- **`@ready-for-agent/queue-service`** — SQS-style queue interface (`enqueue`, claim, ack, fail, visibility, stats) with proper tag id `@ready-for-agent/queue-service/QueueService`
- **`@ready-for-agent/sqlite-queue-service`** — Turso/SQLite implementation (visibility timeout, retries, concurrent claim safety)
- **`job_queue` / `completed_job` tables** + Drizzle migration in `db-schema` (prefixed ULID ids)
- **`@ready-for-agent/layer-turso-local`** — Turso local SDK Effect layer with `BEGIN IMMEDIATE` transactions
- **`@ready-for-agent/db`** — `TypedSqliteDrizzle`, `DatabaseLive` (Turso), `DatabaseTest` (in-memory for tests)
- **ADR-0002** — prefixed ULID entity IDs

Out of scope: job worker process (next), wiring `completed_job` 2PC on ack (#13 tracks a later `Context.Service` reshape).

Closes nothing; follow-up polish: #13.
