### PR TITLE
feat: wire GraphQL addRepository through Yoga and genql

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "@ready-for-agent/api",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "bun --watch --conditions @ready-for-agent/source src/main.ts",
+    "start": "bun --conditions @ready-for-agent/source src/main.ts",
+    "typecheck": "tsc --noEmit -p tsconfig.app.json"
+  },
+  "nx": {
+    "name": "api",
+    "targets": {
+      "serve": {
+        "command": "bun --watch --conditions @ready-for-agent/source src/main.ts",
+        "options": {
+          "cwd": "{projectRoot}"
+        }
+      }
+    }
+  },
+  "dependencies": {
+    "@ready-for-agent/graphql-schema": "workspace:*",
+    "graphql": "^16.11.0",
+    "graphql-yoga": "^5.13.0"
+  },
+  "devDependencies": {
+    "@types/bun": "^1.3.0"
+  }
+}

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -1,0 +1,49 @@
+import { createSchema, createYoga } from "graphql-yoga"
+import { typeDefs } from "@ready-for-agent/graphql-schema"
+
+const port = Number(process.env.PORT ?? 3001)
+
+const yoga = createYoga({
+  schema: createSchema({
+    typeDefs,
+    resolvers: {
+      Query: {
+        health: () => true,
+      },
+      Mutation: {
+        addRepository: (
+          _parent,
+          args: {
+            input: {
+              githubOwner: string
+              githubRepo: string
+              localPath: string
+              isBare: boolean
+            }
+          },
+        ) => ({
+          id: "stub-repository-id",
+          githubOwner: args.input.githubOwner,
+          githubRepo: args.input.githubRepo,
+          localPath: args.input.localPath,
+          isBare: args.input.isBare,
+          paused: true,
+        }),
+      },
+    },
+  }),
+  graphqlEndpoint: "/graphql",
+  graphiql: true,
+})
+
+const server = Bun.serve({
+  port,
+  fetch: yoga,
+})
+
+console.info(
+  `GraphQL API listening on ${new URL(
+    yoga.graphqlEndpoint,
+    `http://${server.hostname}:${server.port}`,
+  )}`,
+)

--- a/apps/api/tsconfig.app.json
+++ b/apps/api/tsconfig.app.json
@@ -11,13 +11,12 @@
     "noEmit": true,
     "rootDir": "src",
     "tsBuildInfoFile": "./out-tsc/app/tsconfig.app.tsbuildinfo",
-    "types": ["node"]
+    "types": ["bun"]
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["src/**/*.test.ts"],
   "references": [
     {
-      "path": "../../packages/graphql-client/tsconfig.lib.json"
+      "path": "../../packages/graphql-schema/tsconfig.lib.json"
     }
   ]
 }

--- a/apps/api/tsconfig.json
+++ b/apps/api/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.app.json"
+    }
+  ]
+}

--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -4,19 +4,35 @@ CLI for the ready-for-agent harness.
 
 ## Usage
 
-From the repo root:
+Start the GraphQL API and harness from the repo root:
+
+```bash
+bun run --cwd apps/api dev
+# In another terminal:
+bun run --cwd apps/harness dev
+```
+
+Then add a local repository:
 
 ```bash
 bun run harness-cli add /path/to/local/repo
 ```
 
-Inspects a local git repository and prints the harness Repository fields (owner/repo, path, bare, paused). Persistence is not wired yet. The path must be a git repo with a GitHub remote; new repositories are reported as paused.
+The CLI inspects the local git repository, calls the harness GraphQL endpoint at `http://127.0.0.1:4200/graphql`, and prints the returned Repository fields. The API currently returns a stub response; persistence is not wired yet. The path must be a git repository with a GitHub remote, and new Repositories are reported as paused.
+
+Override the endpoint when the harness is available elsewhere:
+
+```bash
+READY_FOR_AGENT_GRAPHQL_URL=http://127.0.0.1:3001/graphql \
+  bun run harness-cli add /path/to/local/repo
+```
 
 Example:
 
 ```bash
 bun run harness-cli add ~/src/pf/monorepo/
 # Added repository processfocus/monorepo
+#   id: stub-repository-id
 #   local path: /home/berend/src/pf/monorepo
 #   bare: true
 #   paused: true

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -20,6 +20,7 @@
   },
   "dependencies": {
     "@effect/platform-bun": "^4.0.0-beta.97",
+    "@ready-for-agent/graphql-client": "workspace:*",
     "effect": "^4.0.0-beta.97"
   }
 }

--- a/apps/cli/src/cli.ts
+++ b/apps/cli/src/cli.ts
@@ -1,5 +1,6 @@
 import { Console, Effect } from "effect"
 import { Argument, Command } from "effect/unstable/cli"
+import { GraphqlApi } from "./services/graphql-api.ts"
 import { LocalGit } from "./services/local-git.ts"
 
 const pathArg = Argument.string("path").pipe(
@@ -9,14 +10,17 @@ const pathArg = Argument.string("path").pipe(
 const addCommand = Command.make("add", { path: pathArg }, ({ path }) =>
   Effect.gen(function* () {
     const localGit = yield* LocalGit
+    const graphqlApi = yield* GraphqlApi
     const repository = yield* localGit.inspect(path)
+    const added = yield* graphqlApi.addRepository(repository)
 
     yield* Console.log(
-      `Added repository ${repository.githubOwner}/${repository.githubRepo}`,
+      `Added repository ${added.githubOwner}/${added.githubRepo}`,
     )
-    yield* Console.log(`  local path: ${repository.localPath}`)
-    yield* Console.log(`  bare: ${repository.isBare}`)
-    yield* Console.log(`  paused: ${repository.paused}`)
+    yield* Console.log(`  id: ${added.id}`)
+    yield* Console.log(`  local path: ${added.localPath}`)
+    yield* Console.log(`  bare: ${added.isBare}`)
+    yield* Console.log(`  paused: ${added.paused}`)
   }),
 ).pipe(Command.withDescription("Add a local repository to the harness"))
 

--- a/apps/cli/src/graphql-url.ts
+++ b/apps/cli/src/graphql-url.ts
@@ -1,0 +1,4 @@
+const defaultGraphqlUrl = "http://127.0.0.1:4200/graphql"
+
+export const resolveGraphqlUrl = (): string =>
+  process.env.READY_FOR_AGENT_GRAPHQL_URL ?? defaultGraphqlUrl

--- a/apps/cli/src/main.ts
+++ b/apps/cli/src/main.ts
@@ -2,9 +2,13 @@ import { BunRuntime, BunServices } from "@effect/platform-bun"
 import { Effect, Layer } from "effect"
 import { Command } from "effect/unstable/cli"
 import { cli } from "./cli.ts"
+import { GraphqlApi } from "./services/graphql-api.ts"
 import { LocalGit } from "./services/local-git.ts"
 
-const MainLive = LocalGit.layer.pipe(Layer.provideMerge(BunServices.layer))
+const MainLive = LocalGit.layer.pipe(
+  Layer.provideMerge(GraphqlApi.layer),
+  Layer.provideMerge(BunServices.layer),
+)
 
 const program = Command.run(cli, { version: "0.0.0" }).pipe(
   Effect.provide(MainLive),

--- a/apps/cli/src/services/graphql-api.ts
+++ b/apps/cli/src/services/graphql-api.ts
@@ -1,0 +1,65 @@
+import { Context, Effect, Layer, Schema } from "effect"
+import { createClient } from "@ready-for-agent/graphql-client"
+import type { LocalRepository } from "../domain.ts"
+import { resolveGraphqlUrl } from "../graphql-url.ts"
+
+class GraphqlRequestFailed extends Schema.TaggedErrorClass<GraphqlRequestFailed>()(
+  "GraphqlRequestFailed",
+  { message: Schema.String },
+) {}
+
+export class GraphqlApi extends Context.Service<
+  GraphqlApi,
+  {
+    readonly addRepository: (repository: LocalRepository) => Effect.Effect<
+      {
+        readonly id: string
+        readonly githubOwner: string
+        readonly githubRepo: string
+        readonly localPath: string
+        readonly isBare: boolean
+        readonly paused: boolean
+      },
+      GraphqlRequestFailed
+    >
+  }
+>()("@ready-for-agent/cli/GraphqlApi") {
+  static readonly layer = Layer.succeed(GraphqlApi, {
+    addRepository: (repository) =>
+      Effect.tryPromise({
+        try: async () => {
+          const client = createClient({
+            url: resolveGraphqlUrl(),
+          })
+          const result = await client.mutation({
+            addRepository: {
+              __args: {
+                input: {
+                  githubOwner: repository.githubOwner,
+                  githubRepo: repository.githubRepo,
+                  localPath: repository.localPath,
+                  isBare: repository.isBare,
+                },
+              },
+              id: true,
+              githubOwner: true,
+              githubRepo: true,
+              localPath: true,
+              isBare: true,
+              paused: true,
+            },
+          })
+          const added = result.addRepository
+          if (!added) {
+            throw new Error("addRepository returned null")
+          }
+          return added
+        },
+        catch: (cause) =>
+          new GraphqlRequestFailed({
+            message:
+              cause instanceof Error ? cause.message : "GraphQL request failed",
+          }),
+      }),
+  })
+}

--- a/apps/harness/vite.config.ts
+++ b/apps/harness/vite.config.ts
@@ -2,6 +2,13 @@ import { tanstackRouter } from "@tanstack/router-plugin/vite"
 import react from "@vitejs/plugin-react"
 import { defineConfig } from "vite"
 
+const graphqlProxy = {
+  "/graphql": {
+    target: "http://127.0.0.1:3001",
+    changeOrigin: true,
+  },
+}
+
 export default defineConfig({
   plugins: [
     tanstackRouter({
@@ -12,5 +19,10 @@ export default defineConfig({
   ],
   server: {
     port: 4200,
+    proxy: graphqlProxy,
+  },
+  preview: {
+    port: 4200,
+    proxy: graphqlProxy,
   },
 })

--- a/bun.lock
+++ b/bun.lock
@@ -25,11 +25,24 @@
         "typescript": "npm:@typescript/typescript6@^6.0.2",
       },
     },
+    "apps/api": {
+      "name": "@ready-for-agent/api",
+      "version": "0.0.0",
+      "dependencies": {
+        "@ready-for-agent/graphql-schema": "workspace:*",
+        "graphql": "^16.11.0",
+        "graphql-yoga": "^5.13.0",
+      },
+      "devDependencies": {
+        "@types/bun": "^1.3.0",
+      },
+    },
     "apps/cli": {
       "name": "@ready-for-agent/cli",
       "version": "0.0.0",
       "dependencies": {
         "@effect/platform-bun": "^4.0.0-beta.97",
+        "@ready-for-agent/graphql-client": "workspace:*",
         "effect": "^4.0.0-beta.97",
       },
     },
@@ -74,12 +87,24 @@
       "version": "0.0.1",
       "dependencies": {
         "drizzle-orm": "1.0.0-rc.4-5d5b77c",
+        "effect": "^3.21.4",
         "tslib": "^2.3.0",
         "ulidx": "^2.4.1",
       },
       "devDependencies": {
         "drizzle-kit": "1.0.0-rc.4-5d5b77c",
       },
+    },
+    "packages/graphql-client": {
+      "name": "@ready-for-agent/graphql-client",
+      "version": "0.0.1",
+      "devDependencies": {
+        "@genql/cli": "^6.3.3",
+      },
+    },
+    "packages/graphql-schema": {
+      "name": "@ready-for-agent/graphql-schema",
+      "version": "0.0.1",
     },
     "packages/layer-turso-local": {
       "name": "@ready-for-agent/layer-turso-local",
@@ -424,6 +449,12 @@
 
     "@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.0.4", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-PJR+bOmMOPH8AtcTGAyYNiuJ3/Fcoj2XN/gBEWzDIKh254XO+mM9XoXHk5GNEhodxeMznbg7BlRojVbKN+gC6g=="],
 
+    "@envelop/core": ["@envelop/core@5.5.1", "", { "dependencies": { "@envelop/instrumentation": "^1.0.0", "@envelop/types": "^5.2.1", "@whatwg-node/promise-helpers": "^1.2.4", "tslib": "^2.5.0" } }, "sha512-3DQg8sFskDo386TkL5j12jyRAdip/8yzK3x7YGbZBgobZ4aKXrvDU0GppU0SnmrpQnNaiTUsxBs9LKkwQ/eyvw=="],
+
+    "@envelop/instrumentation": ["@envelop/instrumentation@1.0.0", "", { "dependencies": { "@whatwg-node/promise-helpers": "^1.2.1", "tslib": "^2.5.0" } }, "sha512-cxgkB66RQB95H3X27jlnxCRNTmPuSTgmBAq6/4n2Dtv4hsk4yz8FadA1ggmd0uZzvKqWD6CR+WFgTjhDqg7eyw=="],
+
+    "@envelop/types": ["@envelop/types@5.2.1", "", { "dependencies": { "@whatwg-node/promise-helpers": "^1.0.0", "tslib": "^2.5.0" } }, "sha512-CsFmA3u3c2QoLDTfEpGr4t25fjMU31nyvse7IzWTvb0ZycuPjMjb0fjlheh+PbhBYb9YLugnT2uY6Mwcg1o+Zg=="],
+
     "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.25.12", "", { "os": "aix", "cpu": "ppc64" }, "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA=="],
 
     "@esbuild/android-arm": ["@esbuild/android-arm@0.25.12", "", { "os": "android", "cpu": "arm" }, "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg=="],
@@ -476,6 +507,32 @@
 
     "@esbuild/win32-x64": ["@esbuild/win32-x64@0.25.12", "", { "os": "win32", "cpu": "x64" }, "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA=="],
 
+    "@fastify/busboy": ["@fastify/busboy@2.1.1", "", {}, "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA=="],
+
+    "@genql/cli": ["@genql/cli@6.3.4", "", { "dependencies": { "@graphql-tools/graphql-file-loader": "^7.5.17", "@graphql-tools/load": "^7.8.14", "fs-extra": "^10.1.0", "graphql": "^16.6.0", "kleur": "^4.1.5", "listr2": "^6.3.1", "lodash": "^4.17.21", "mkdirp": "^0.5.1", "native-fetch": "^4.0.2", "prettier": "^2.8.0", "qs": "^6.11.0", "rimraf": "^2.6.3", "undici": "^5.22.0", "yargs": "^15.3.1" }, "bin": { "genql": "dist/cli.js" } }, "sha512-VloARc3XFSNhrAiNfNoro3X3bgxGPHQw2WiwfwEF3XUQ4azff01PtoQBGBt8Ng7aPQscGVzfTfjmdv/uG9AAKQ=="],
+
+    "@graphql-tools/executor": ["@graphql-tools/executor@1.5.5", "", { "dependencies": { "@graphql-tools/utils": "^11.2.0", "@graphql-typed-document-node/core": "^3.2.0", "@repeaterjs/repeater": "^3.0.4", "@whatwg-node/disposablestack": "^0.0.6", "@whatwg-node/promise-helpers": "^1.0.0", "tslib": "^2.4.0" }, "peerDependencies": { "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0" } }, "sha512-JAdn4G+ehthnGdJABS+wO6LxAIcoGPiSRHIz1ECYLtaQGkpFIdqH6BLUbZcToX/W/nmOG0kTFLoepCGkugbsBA=="],
+
+    "@graphql-tools/graphql-file-loader": ["@graphql-tools/graphql-file-loader@7.5.17", "", { "dependencies": { "@graphql-tools/import": "6.7.18", "@graphql-tools/utils": "^9.2.1", "globby": "^11.0.3", "tslib": "^2.4.0", "unixify": "^1.0.0" }, "peerDependencies": { "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0" } }, "sha512-hVwwxPf41zOYgm4gdaZILCYnKB9Zap7Ys9OhY1hbwuAuC4MMNY9GpUjoTU3CQc3zUiPoYStyRtUGkHSJZ3HxBw=="],
+
+    "@graphql-tools/import": ["@graphql-tools/import@6.7.18", "", { "dependencies": { "@graphql-tools/utils": "^9.2.1", "resolve-from": "5.0.0", "tslib": "^2.4.0" }, "peerDependencies": { "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0" } }, "sha512-XQDdyZTp+FYmT7as3xRWH/x8dx0QZA2WZqfMF5EWb36a0PiH7WwlRQYIdyYXj8YCLpiWkeBXgBRHmMnwEYR8iQ=="],
+
+    "@graphql-tools/load": ["@graphql-tools/load@7.8.14", "", { "dependencies": { "@graphql-tools/schema": "^9.0.18", "@graphql-tools/utils": "^9.2.1", "p-limit": "3.1.0", "tslib": "^2.4.0" }, "peerDependencies": { "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0" } }, "sha512-ASQvP+snHMYm+FhIaLxxFgVdRaM0vrN9wW2BKInQpktwWTXVyk+yP5nQUCEGmn0RTdlPKrffBaigxepkEAJPrg=="],
+
+    "@graphql-tools/merge": ["@graphql-tools/merge@9.2.0", "", { "dependencies": { "@graphql-tools/utils": "^11.2.0", "tslib": "^2.4.0" }, "peerDependencies": { "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0" } }, "sha512-kChDH/sOxm3TCICup5NgTiz/aJBk+5GAuC0lfJS8FcRfsqZvlCkNwpsYTGAATBCJMrgZ9+csRugCjS97jPcNMw=="],
+
+    "@graphql-tools/schema": ["@graphql-tools/schema@10.0.36", "", { "dependencies": { "@graphql-tools/merge": "^9.2.0", "@graphql-tools/utils": "^11.2.0", "tslib": "^2.4.0" }, "peerDependencies": { "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0" } }, "sha512-g8S5aLirZInoi3NojzmBxwsZfVawOE0UBlVWYe8kDAR0FxS0riBDiyW7JnlAKayooHMRAMwGaze4RQU3VTTyig=="],
+
+    "@graphql-tools/utils": ["@graphql-tools/utils@10.11.0", "", { "dependencies": { "@graphql-typed-document-node/core": "^3.1.1", "@whatwg-node/promise-helpers": "^1.0.0", "cross-inspect": "1.0.1", "tslib": "^2.4.0" }, "peerDependencies": { "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0" } }, "sha512-iBFR9GXIs0gCD+yc3hoNswViL1O5josI33dUqiNStFI/MHLCEPduasceAcazRH77YONKNiviHBV8f7OgcT4o2Q=="],
+
+    "@graphql-typed-document-node/core": ["@graphql-typed-document-node/core@3.2.0", "", { "peerDependencies": { "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0" } }, "sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ=="],
+
+    "@graphql-yoga/logger": ["@graphql-yoga/logger@2.0.1", "", { "dependencies": { "tslib": "^2.8.1" } }, "sha512-Nv0BoDGLMg9QBKy9cIswQ3/6aKaKjlTh87x3GiBg2Z4RrjyrM48DvOOK0pJh1C1At+b0mUIM67cwZcFTDLN4sA=="],
+
+    "@graphql-yoga/subscription": ["@graphql-yoga/subscription@5.0.5", "", { "dependencies": { "@graphql-yoga/typed-event-target": "^3.0.2", "@repeaterjs/repeater": "^3.0.4", "@whatwg-node/events": "^0.1.0", "tslib": "^2.8.1" } }, "sha512-oCMWOqFs6QV96/NZRt/ZhTQvzjkGB4YohBOpKM4jH/lDT4qb7Lex/aGCxpi/JD9njw3zBBtMqxbaC22+tFHVvw=="],
+
+    "@graphql-yoga/typed-event-target": ["@graphql-yoga/typed-event-target@3.0.2", "", { "dependencies": { "@repeaterjs/repeater": "^3.0.4", "tslib": "^2.8.1" } }, "sha512-ZpJxMqB+Qfe3rp6uszCQoag4nSw42icURnBRfFYSOmTgEeOe4rD0vYlbA8spvCu2TlCesNTlEN9BLWtQqLxabA=="],
+
     "@jest/diff-sequences": ["@jest/diff-sequences@30.0.1", "", {}, "sha512-n5H8QLDJ47QqbCNn5SuFjCRDrOLEZ0h8vAHCK5RL9Ls7Xa8AQLa/YxAc9UjFqoEDM48muwtBGjtMY5cr0PLDCw=="],
 
     "@jridgewell/gen-mapping": ["@jridgewell/gen-mapping@0.3.13", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.0", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA=="],
@@ -503,6 +560,12 @@
     "@msgpackr-extract/msgpackr-extract-win32-x64": ["@msgpackr-extract/msgpackr-extract-win32-x64@3.0.4", "", { "os": "win32", "cpu": "x64" }, "sha512-CmCXPQrkbwExx3j946/PtHWHbYJiCRBRDl4BlkRQcJB/YOwQxJRTpoo7aTsortjgoJ1x7opzTSxn7C+ASSLVjQ=="],
 
     "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@0.2.4", "", { "dependencies": { "@emnapi/core": "^1.1.0", "@emnapi/runtime": "^1.1.0", "@tybys/wasm-util": "^0.9.0" } }, "sha512-9zESzOO5aDByvhIAsOy9TbpZ0Ur2AJbUI7UT73kcUTS2mxAMHOBaa1st/jAymNoCtvrit99kkzT1FZuXVcgfIQ=="],
+
+    "@nodelib/fs.scandir": ["@nodelib/fs.scandir@2.1.5", "", { "dependencies": { "@nodelib/fs.stat": "2.0.5", "run-parallel": "^1.1.9" } }, "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g=="],
+
+    "@nodelib/fs.stat": ["@nodelib/fs.stat@2.0.5", "", {}, "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A=="],
+
+    "@nodelib/fs.walk": ["@nodelib/fs.walk@1.2.8", "", { "dependencies": { "@nodelib/fs.scandir": "2.1.5", "fastq": "^1.6.0" } }, "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg=="],
 
     "@nx/devkit": ["@nx/devkit@23.0.1", "", { "dependencies": { "@zkochan/js-yaml": "0.0.7", "ejs": "5.0.1", "enquirer": "~2.3.6", "minimatch": "10.2.5", "semver": "^7.6.3", "tslib": "^2.3.0", "yargs-parser": "21.1.1" }, "peerDependencies": { "nx": ">= 22 <= 24 || ^23.0.0-0" } }, "sha512-A/chuNS1RZwdbRe/Nf+w0qtPEFHLcZNPzo8Abw5mBxyXmy9yvHZpuZuqDbt/lASFU+TEb74xExL1AnKWwqpOIg=="],
 
@@ -618,11 +681,17 @@
 
     "@phenomnomnominal/tsquery": ["@phenomnomnominal/tsquery@6.2.0", "", { "dependencies": { "@types/esquery": "^1.5.4", "esquery": "^1.7.0" }, "peerDependencies": { "typescript": ">3.0.0" } }, "sha512-Vo9nkhfZxDB/sBiqIY3pjDC4mOSyure+AFlEW5hcy/tRE82MqCXjRN4InnVNMldinRt0dLYqg4HAU2XPq5e1LA=="],
 
+    "@ready-for-agent/api": ["@ready-for-agent/api@workspace:apps/api"],
+
     "@ready-for-agent/cli": ["@ready-for-agent/cli@workspace:apps/cli"],
 
     "@ready-for-agent/db": ["@ready-for-agent/db@workspace:packages/db"],
 
     "@ready-for-agent/db-schema": ["@ready-for-agent/db-schema@workspace:packages/db-schema"],
+
+    "@ready-for-agent/graphql-client": ["@ready-for-agent/graphql-client@workspace:packages/graphql-client"],
+
+    "@ready-for-agent/graphql-schema": ["@ready-for-agent/graphql-schema@workspace:packages/graphql-schema"],
 
     "@ready-for-agent/harness": ["@ready-for-agent/harness@workspace:apps/harness"],
 
@@ -631,6 +700,8 @@
     "@ready-for-agent/queue-service": ["@ready-for-agent/queue-service@workspace:packages/queue-service"],
 
     "@ready-for-agent/sqlite-queue-service": ["@ready-for-agent/sqlite-queue-service@workspace:packages/sqlite-queue-service"],
+
+    "@repeaterjs/repeater": ["@repeaterjs/repeater@3.1.0", "", {}, "sha512-TaoVksZRSx2KWYYpyLQtMQXXeS98VsgZImzW65xmiVgbYhXLk+aEsmzPLirqVuE4/XuUapH2iMtxUzaBNDzdSQ=="],
 
     "@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-rc.3", "", {}, "sha512-eybk3TjzzzV97Dlj5c+XrBFW57eTNhzod66y9HrBlzJ6NsCrWCp/2kaPS3K9wJmurBC0Tdw4yPjXKZqlznim3Q=="],
 
@@ -806,6 +877,18 @@
 
     "@vitejs/plugin-react": ["@vitejs/plugin-react@5.2.0", "", { "dependencies": { "@babel/core": "^7.29.0", "@babel/plugin-transform-react-jsx-self": "^7.27.1", "@babel/plugin-transform-react-jsx-source": "^7.27.1", "@rolldown/pluginutils": "1.0.0-rc.3", "@types/babel__core": "^7.20.5", "react-refresh": "^0.18.0" }, "peerDependencies": { "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0" } }, "sha512-YmKkfhOAi3wsB1PhJq5Scj3GXMn3WvtQ/JC0xoopuHoXSdmtdStOpFrYaT1kie2YgFBcIe64ROzMYRjCrYOdYw=="],
 
+    "@whatwg-node/disposablestack": ["@whatwg-node/disposablestack@0.0.6", "", { "dependencies": { "@whatwg-node/promise-helpers": "^1.0.0", "tslib": "^2.6.3" } }, "sha512-LOtTn+JgJvX8WfBVJtF08TGrdjuFzGJc4mkP8EdDI8ADbvO7kiexYep1o8dwnt0okb0jYclCDXF13xU7Ge4zSw=="],
+
+    "@whatwg-node/events": ["@whatwg-node/events@0.1.2", "", { "dependencies": { "tslib": "^2.6.3" } }, "sha512-ApcWxkrs1WmEMS2CaLLFUEem/49erT3sxIVjpzU5f6zmVcnijtDSrhoK2zVobOIikZJdH63jdAXOrvjf6eOUNQ=="],
+
+    "@whatwg-node/fetch": ["@whatwg-node/fetch@0.10.13", "", { "dependencies": { "@whatwg-node/node-fetch": "^0.8.3", "urlpattern-polyfill": "^10.0.0" } }, "sha512-b4PhJ+zYj4357zwk4TTuF2nEe0vVtOrwdsrNo5hL+u1ojXNhh1FgJ6pg1jzDlwlT4oBdzfSwaBwMCtFCsIWg8Q=="],
+
+    "@whatwg-node/node-fetch": ["@whatwg-node/node-fetch@0.8.6", "", { "dependencies": { "@fastify/busboy": "^3.1.1", "@whatwg-node/disposablestack": "^0.0.6", "@whatwg-node/promise-helpers": "^1.3.2", "tslib": "^2.6.3" } }, "sha512-BDMdYFcerLQkwA2RTldxOqRCs6ZQD1S7UgP3pUdGUkcbgTrP/V5ko77ZkCww9DHmC4lpoYuwigGfQYj285gMvA=="],
+
+    "@whatwg-node/promise-helpers": ["@whatwg-node/promise-helpers@1.3.2", "", { "dependencies": { "tslib": "^2.6.3" } }, "sha512-Nst5JdK47VIl9UcGwtv2Rcgyn5lWtZ0/mhRQ4G8NN2isxpq2TO30iqHzmwoJycjWuyUfg3GFXqP/gFHXeV57IA=="],
+
+    "@whatwg-node/server": ["@whatwg-node/server@0.11.0", "", { "dependencies": { "@envelop/instrumentation": "^1.0.0", "@whatwg-node/disposablestack": "^0.0.6", "@whatwg-node/fetch": "^0.10.13", "@whatwg-node/promise-helpers": "^1.3.2", "tslib": "^2.6.3" } }, "sha512-VSdkwnJRr8Yv9UgB2aXB3VUPWwd6Oqnn0hycFwhg9pZgWxJXb7JmhsiXe9tmpMwjHFxli12PGcz9aI63YYloGQ=="],
+
     "@yarnpkg/lockfile": ["@yarnpkg/lockfile@1.1.0", "", {}, "sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ=="],
 
     "@zkochan/js-yaml": ["@zkochan/js-yaml@0.0.7", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-nrUSn7hzt7J6JWgWGz78ZYI8wj+gdIJdk0Ynjpp8l+trkn58Uqsf6RYrYkEK+3X18EX+TNdtJI0WxAtc+L84SQ=="],
@@ -816,6 +899,8 @@
 
     "ansi-colors": ["ansi-colors@4.1.3", "", {}, "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw=="],
 
+    "ansi-escapes": ["ansi-escapes@5.0.0", "", { "dependencies": { "type-fest": "^1.0.2" } }, "sha512-5GFMVX8HqE/TB+FuBJGuO5XG0WrsA6ptUqoODaT/n9mmUaZFkqnBueB4leqGBCmrUHnCnC4PCZTCd0E7QQ83bA=="],
+
     "ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
     "ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
@@ -825,6 +910,8 @@
     "argparse": ["argparse@2.0.1", "", {}, "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="],
 
     "argue-cli": ["argue-cli@3.1.0", "", {}, "sha512-DhBpBfXL4SS2uC0N922MMajKR3CdrTG0u2or1PNYgXMsrSzViJrbtvT0nCLlLGUI0plam/ZZCs7aAauHtW9thw=="],
+
+    "array-union": ["array-union@2.1.0", "", {}, "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw=="],
 
     "async": ["async@3.2.6", "", {}, "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA=="],
 
@@ -858,6 +945,8 @@
 
     "brace-expansion": ["brace-expansion@5.0.6", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g=="],
 
+    "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
+
     "browserslist": ["browserslist@4.28.5", "", { "dependencies": { "baseline-browser-mapping": "^2.10.42", "caniuse-lite": "^1.0.30001800", "electron-to-chromium": "^1.5.387", "node-releases": "^2.0.50", "update-browserslist-db": "^1.2.3" }, "bin": { "browserslist": "cli.js" } }, "sha512-Cu2E6QejHWzuDMTkuwgpABFgDfZrXLQq5V13YOACZx4mFAG4IwGTbTfHPMr4WtxlHoXSM8FIuRwYYCz5XiabaQ=="],
 
     "buffer": ["buffer@5.7.1", "", { "dependencies": { "base64-js": "^1.3.1", "ieee754": "^1.1.13" } }, "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ=="],
@@ -872,6 +961,8 @@
 
     "callsites": ["callsites@3.1.0", "", {}, "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="],
 
+    "camelcase": ["camelcase@5.3.1", "", {}, "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="],
+
     "caniuse-lite": ["caniuse-lite@1.0.30001803", "", {}, "sha512-g/uHREV2ZpK9qMalCsWaxmA6ol+DX8GYhuf3T40RKoP+oL7vhRJh8LNt73PCjpnR6l14FzfPrB5Yux4PKm2meg=="],
 
     "chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
@@ -881,6 +972,8 @@
     "cli-cursor": ["cli-cursor@3.1.0", "", { "dependencies": { "restore-cursor": "^3.1.0" } }, "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw=="],
 
     "cli-spinners": ["cli-spinners@2.6.1", "", {}, "sha512-x/5fWmGMnbKQAaNwN+UZlV79qBLM9JFnJuJ03gIi5whrob0xV0ofNVHy9DhwGdsMJQc2OKv0oGmLzvaqvAVv+g=="],
+
+    "cli-truncate": ["cli-truncate@3.1.0", "", { "dependencies": { "slice-ansi": "^5.0.0", "string-width": "^5.0.0" } }, "sha512-wfOBkjXteqSnI59oPcJkcPl/ZmwvMMOj340qUIY1SKZCv0B9Cf4D4fAucRkIKQmsIuYK3x1rrgU7MeGRruiuiA=="],
 
     "cliui": ["cliui@8.0.1", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.1", "wrap-ansi": "^7.0.0" } }, "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ=="],
 
@@ -892,9 +985,13 @@
 
     "color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
 
+    "colorette": ["colorette@2.0.20", "", {}, "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w=="],
+
     "columnify": ["columnify@1.6.0", "", { "dependencies": { "strip-ansi": "^6.0.1", "wcwidth": "^1.0.0" } }, "sha512-lomjuFZKfM6MSAnV9aCZC9sc0qGbmZdfygNv+nCpqVkSKdCxCklLtd16O0EILGkImHw9ZpHkAnHaB+8Zxq5W6Q=="],
 
     "combined-stream": ["combined-stream@1.0.8", "", { "dependencies": { "delayed-stream": "~1.0.0" } }, "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg=="],
+
+    "concat-map": ["concat-map@0.0.1", "", {}, "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="],
 
     "conventional-changelog-angular": ["conventional-changelog-angular@9.2.1", "", { "dependencies": { "@conventional-changelog/template": "^1.2.1" } }, "sha512-oWSL6ZhnXbYraOFTK3PgRAQJ8fADDAEv5K6AdeyQPLvjFmhG8+ejL0jZZp/R7vTmGJaBvZEE+sE7dB4bCv7sAw=="],
 
@@ -914,9 +1011,13 @@
 
     "cosmiconfig-typescript-loader": ["cosmiconfig-typescript-loader@6.3.0", "", { "dependencies": { "jiti": "2.6.1" }, "peerDependencies": { "@types/node": "*", "cosmiconfig": ">=9", "typescript": ">=5" } }, "sha512-Akr82WH1Wfqatyiqpj8HDkO2o2KmJRu1FhKfSNJP3K4IdXwHfEyL7MOb62i1AGQVLtIQM+iCE9CGOtrfhR+mmA=="],
 
+    "cross-inspect": ["cross-inspect@1.0.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-Pcw1JTvZLSJH83iiGWt6fRcT+BjZlCDRVwYLbUcHzv/CRpB7r0MlSrGbIyQvVSNyGnbt7G4AXuyCiDR3POvZ1A=="],
+
     "csstype": ["csstype@3.2.3", "", {}, "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="],
 
     "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
+    "decamelize": ["decamelize@1.2.0", "", {}, "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA=="],
 
     "defaults": ["defaults@1.0.4", "", { "dependencies": { "clone": "^1.0.2" } }, "sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A=="],
 
@@ -930,6 +1031,8 @@
 
     "diff": ["diff@8.0.4", "", {}, "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw=="],
 
+    "dir-glob": ["dir-glob@3.0.1", "", { "dependencies": { "path-type": "^4.0.0" } }, "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA=="],
+
     "dotenv": ["dotenv@16.4.7", "", {}, "sha512-47qPchRCykZC03FhkYAhrvwU4xDBFIj1QPqaarj6mdM/hgUzfPHcpkHJOn3mJAufFeeAxAzeGsr5X0M4k6fLZQ=="],
 
     "dotenv-expand": ["dotenv-expand@12.0.3", "", { "dependencies": { "dotenv": "^16.4.5" } }, "sha512-uc47g4b+4k/M/SeaW1y4OApx+mtLWl92l5LMPP0GNXctZqELk+YGgOPIIC5elYmUH4OuoK3JLhuRUYegeySiFA=="],
@@ -939,6 +1042,8 @@
     "drizzle-orm": ["drizzle-orm@1.0.0-rc.4-5d5b77c", "", { "peerDependencies": { "@aws-sdk/client-rds-data": ">=3", "@cloudflare/workers-types": ">=4", "@effect/sql-pg": ">=4.0.0-beta.58 || >=4.0.0", "@electric-sql/pglite": ">=0.2.0", "@libsql/client": ">=0.10.0", "@libsql/client-wasm": ">=0.10.0", "@neondatabase/serverless": ">=0.10.0", "@op-engineering/op-sqlite": ">=2", "@opentelemetry/api": "^1.4.1", "@planetscale/database": ">=1.13", "@sinclair/typebox": ">=0.34.8", "@sqlitecloud/drivers": ">=1.0.653", "@tidbcloud/serverless": "*", "@tursodatabase/database": ">=0.2.1", "@tursodatabase/database-common": ">=0.2.1", "@tursodatabase/database-wasm": ">=0.2.1", "@types/better-sqlite3": "*", "@types/mssql": "^9.1.4", "@types/pg": "*", "@types/sql.js": "*", "@upstash/redis": ">=1.34.7", "@vercel/postgres": ">=0.8.0", "@xata.io/client": "*", "arktype": ">=2.0.0", "better-sqlite3": ">=9.3.0", "bun-types": "*", "effect": ">=4.0.0-beta.58 || >=4.0.0", "expo-sqlite": ">=14.0.0", "mssql": "^11.0.1", "mysql2": ">=2", "pg": ">=8", "postgres": ">=3", "sql.js": ">=1", "sqlite3": ">=5", "typebox": ">=1.0.0", "valibot": ">=1.0.0-beta.7", "zod": "^3.25.0 || ^4.0.0" }, "optionalPeers": ["@aws-sdk/client-rds-data", "@cloudflare/workers-types", "@effect/sql-pg", "@electric-sql/pglite", "@libsql/client", "@libsql/client-wasm", "@neondatabase/serverless", "@op-engineering/op-sqlite", "@opentelemetry/api", "@planetscale/database", "@sinclair/typebox", "@sqlitecloud/drivers", "@tidbcloud/serverless", "@tursodatabase/database", "@tursodatabase/database-common", "@tursodatabase/database-wasm", "@types/better-sqlite3", "@types/mssql", "@types/pg", "@types/sql.js", "@upstash/redis", "@vercel/postgres", "@xata.io/client", "arktype", "better-sqlite3", "bun-types", "effect", "expo-sqlite", "mssql", "mysql2", "pg", "postgres", "sql.js", "sqlite3", "typebox", "valibot", "zod"] }, "sha512-Oq9W4B11PracWY9cuCLTFT+JA5kXqR6rBmWcM8oh0xwLgCviVl9wh6ZuWX7Zpv1Jir/8W+M37syvjSYtj1f5iA=="],
 
     "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
+
+    "eastasianwidth": ["eastasianwidth@0.2.0", "", {}, "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA=="],
 
     "effect": ["effect@4.0.0-beta.97", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "fast-check": "^4.9.0", "find-my-way-ts": "^0.1.6", "ini": "^7.0.0", "kubernetes-types": "^1.30.0", "msgpackr": "^2.0.4", "multipasta": "^0.2.8", "toml": "^4.1.2", "uuid": "^14.0.1", "yaml": "^2.9.0" } }, "sha512-pK03HpQVxGZOWdwDAy/iwvV8u3KYcUf2mOWyWqaut2zau8V2u6ejWP7b4BELjyUIiZWW1fl/s/VJpgZUcTjThg=="],
 
@@ -982,7 +1087,7 @@
 
     "esutils": ["esutils@2.0.3", "", {}, "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="],
 
-    "eventemitter3": ["eventemitter3@4.0.7", "", {}, "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="],
+    "eventemitter3": ["eventemitter3@5.0.4", "", {}, "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw=="],
 
     "extend-shallow": ["extend-shallow@2.0.1", "", { "dependencies": { "is-extendable": "^0.1.0" } }, "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug=="],
 
@@ -990,7 +1095,11 @@
 
     "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
 
+    "fast-glob": ["fast-glob@3.3.3", "", { "dependencies": { "@nodelib/fs.stat": "^2.0.2", "@nodelib/fs.walk": "^1.2.3", "glob-parent": "^5.1.2", "merge2": "^1.3.0", "micromatch": "^4.0.8" } }, "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg=="],
+
     "fast-uri": ["fast-uri@3.1.3", "", {}, "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg=="],
+
+    "fastq": ["fastq@1.20.1", "", { "dependencies": { "reusify": "^1.0.4" } }, "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw=="],
 
     "fd-package-json": ["fd-package-json@2.0.0", "", { "dependencies": { "walk-up-path": "^4.0.0" } }, "sha512-jKmm9YtsNXN789RS/0mSzOC1NUq9mkVd65vbSSVsKdjGvYXBuE4oWe2QOEoFeRmJg+lPuZxpmrfFclNhoRMneQ=="],
 
@@ -998,7 +1107,11 @@
 
     "figures": ["figures@3.2.0", "", { "dependencies": { "escape-string-regexp": "^1.0.5" } }, "sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg=="],
 
+    "fill-range": ["fill-range@7.1.1", "", { "dependencies": { "to-regex-range": "^5.0.1" } }, "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg=="],
+
     "find-my-way-ts": ["find-my-way-ts@0.1.6", "", {}, "sha512-a85L9ZoXtNAey3Y6Z+eBWW658kO/MwR7zIafkIUPUMf3isZG0NCs2pjW2wtjxAKuJPxMAsHUIP4ZPGv0o5gyTA=="],
+
+    "find-up": ["find-up@4.1.0", "", { "dependencies": { "locate-path": "^5.0.0", "path-exists": "^4.0.0" } }, "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw=="],
 
     "flat": ["flat@5.0.2", "", { "bin": { "flat": "cli.js" } }, "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ=="],
 
@@ -1009,6 +1122,10 @@
     "formatly": ["formatly@0.3.0", "", { "dependencies": { "fd-package-json": "^2.0.0" }, "bin": { "formatly": "bin/index.mjs" } }, "sha512-9XNj/o4wrRFyhSMJOvsuyMwy8aUfBaZ1VrqHVfohyXf0Sw0e+yfKG+xZaY3arGCOMdwFsqObtzVOc1gU9KiT9w=="],
 
     "fs-constants": ["fs-constants@1.0.0", "", {}, "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="],
+
+    "fs-extra": ["fs-extra@10.1.0", "", { "dependencies": { "graceful-fs": "^4.2.0", "jsonfile": "^6.0.1", "universalify": "^2.0.0" } }, "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ=="],
+
+    "fs.realpath": ["fs.realpath@1.0.0", "", {}, "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="],
 
     "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
@@ -1026,11 +1143,23 @@
 
     "get-tsconfig": ["get-tsconfig@4.14.0", "", { "dependencies": { "resolve-pkg-maps": "^1.0.0" } }, "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA=="],
 
+    "glob": ["glob@7.2.3", "", { "dependencies": { "fs.realpath": "^1.0.0", "inflight": "^1.0.4", "inherits": "2", "minimatch": "^3.1.1", "once": "^1.3.0", "path-is-absolute": "^1.0.0" } }, "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q=="],
+
+    "glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
+
     "global-directory": ["global-directory@5.0.0", "", { "dependencies": { "ini": "6.0.0" } }, "sha512-1pgFdhK3J2LeM+dVf2Pd424yHx2ou338lC0ErNP2hPx4j8eW1Sp0XqSjNxtk6Tc4Kr5wlWtSvz8cn2yb7/SG/w=="],
+
+    "globby": ["globby@11.1.0", "", { "dependencies": { "array-union": "^2.1.0", "dir-glob": "^3.0.1", "fast-glob": "^3.2.9", "ignore": "^5.2.0", "merge2": "^1.4.1", "slash": "^3.0.0" } }, "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g=="],
 
     "goober": ["goober@2.1.19", "", { "peerDependencies": { "csstype": "^3.0.10" } }, "sha512-U7veizMqxyKlM58+Z5j2ngJBH/r9siDmxpvNxSw0PylF6WQvrASJEZrxh1hidRBJc2jqoBVSyOban5u8m+6Rxg=="],
 
     "gopd": ["gopd@1.2.0", "", {}, "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="],
+
+    "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
+
+    "graphql": ["graphql@16.14.2", "", {}, "sha512-Chq1s4CY7jmh8gO2qvLIJyfCDIN+EHLFW/9iShnp1z8FjBQMoodWP1kDC36VAMXXIvAjj4ARa7ntfAV2BrjsbA=="],
+
+    "graphql-yoga": ["graphql-yoga@5.21.2", "", { "dependencies": { "@envelop/core": "^5.5.1", "@envelop/instrumentation": "^1.0.0", "@graphql-tools/executor": "^1.5.0", "@graphql-tools/schema": "^10.0.11", "@graphql-tools/utils": "^10.11.0", "@graphql-yoga/logger": "^2.0.1", "@graphql-yoga/subscription": "^5.0.5", "@whatwg-node/fetch": "^0.10.6", "@whatwg-node/promise-helpers": "^1.3.2", "@whatwg-node/server": "^0.11.0", "lru-cache": "^10.0.0", "tslib": "^2.8.1" }, "peerDependencies": { "graphql": "^15.2.0 || ^16.0.0" } }, "sha512-IIRF/3xtjj2D6caAWL9177hQ8tV3mWB3hve1GRnz7njPhQ3iY1jFtSp98fNGv0yV9kaPh9kKQ8JWdJZnedVmDw=="],
 
     "gray-matter": ["gray-matter@4.0.3", "", { "dependencies": { "js-yaml": "^3.13.1", "kind-of": "^6.0.2", "section-matter": "^1.0.0", "strip-bom-string": "^1.0.0" } }, "sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q=="],
 
@@ -1058,6 +1187,8 @@
 
     "import-fresh": ["import-fresh@3.3.1", "", { "dependencies": { "parent-module": "^1.0.0", "resolve-from": "^4.0.0" } }, "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ=="],
 
+    "inflight": ["inflight@1.0.6", "", { "dependencies": { "once": "^1.3.0", "wrappy": "1" } }, "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA=="],
+
     "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
 
     "ini": ["ini@7.0.0", "", {}, "sha512-ifK0CgjALofS5bkrcTy4RaQ9Vx2Knf/eLeIO+NaswQEpH1UblrtTSCIvN71qQDMq0PeQ/SSPojvEJp9vvvfr+w=="],
@@ -1070,9 +1201,15 @@
 
     "is-extendable": ["is-extendable@0.1.1", "", {}, "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw=="],
 
+    "is-extglob": ["is-extglob@2.1.1", "", {}, "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ=="],
+
     "is-fullwidth-code-point": ["is-fullwidth-code-point@3.0.0", "", {}, "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="],
 
+    "is-glob": ["is-glob@4.0.3", "", { "dependencies": { "is-extglob": "^2.1.1" } }, "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg=="],
+
     "is-interactive": ["is-interactive@1.0.0", "", {}, "sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w=="],
+
+    "is-number": ["is-number@7.0.0", "", {}, "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="],
 
     "is-plain-obj": ["is-plain-obj@4.1.0", "", {}, "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg=="],
 
@@ -1102,7 +1239,11 @@
 
     "jsonc-parser": ["jsonc-parser@3.3.1", "", {}, "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ=="],
 
+    "jsonfile": ["jsonfile@6.2.1", "", { "dependencies": { "universalify": "^2.0.0" }, "optionalDependencies": { "graceful-fs": "^4.1.6" } }, "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q=="],
+
     "kind-of": ["kind-of@6.0.3", "", {}, "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw=="],
+
+    "kleur": ["kleur@4.1.5", "", {}, "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ=="],
 
     "knip": ["knip@6.25.0", "", { "dependencies": { "fdir": "^6.5.0", "formatly": "^0.3.0", "get-tsconfig": "4.14.0", "jiti": "^2.7.0", "oxc-parser": "^0.137.0", "oxc-resolver": "11.21.3", "picomatch": "^4.0.4", "smol-toml": "^1.6.1", "strip-json-comments": "5.0.3", "tinyglobby": "^0.2.17", "unbash": "^4.0.1", "yaml": "^2.9.0", "zod": "^4.1.11" }, "bin": { "knip": "bin/knip.js", "knip-bun": "bin/knip-bun.js" } }, "sha512-Q3n41VjOOB/aqsbxb8kallAcFKrUz3b2S5fD5pTODljVpP01t+rvAgy2x3j0Cq8yEpRRHNdar1vHuqFfGuIakQ=="],
 
@@ -1112,15 +1253,27 @@
 
     "lines-and-columns": ["lines-and-columns@2.0.3", "", {}, "sha512-cNOjgCnLB+FnvWWtyRTzmB3POJ+cXxTA81LoW7u8JdmhfXzriropYwpjShnz1QLLWsQwY7nIxoDmcPTwphDK9w=="],
 
+    "listr2": ["listr2@6.6.1", "", { "dependencies": { "cli-truncate": "^3.1.0", "colorette": "^2.0.20", "eventemitter3": "^5.0.1", "log-update": "^5.0.1", "rfdc": "^1.3.0", "wrap-ansi": "^8.1.0" }, "peerDependencies": { "enquirer": ">= 2.3.0 < 3" }, "optionalPeers": ["enquirer"] }, "sha512-+rAXGHh0fkEWdXBmX+L6mmfmXmXvDGEKzkjxO+8mP3+nI/r/CWznVBvsibXdxda9Zz0OW2e2ikphN3OwCT/jSg=="],
+
+    "locate-path": ["locate-path@5.0.0", "", { "dependencies": { "p-locate": "^4.1.0" } }, "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g=="],
+
+    "lodash": ["lodash@4.18.1", "", {}, "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q=="],
+
     "lodash.debounce": ["lodash.debounce@4.0.8", "", {}, "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow=="],
 
     "log-symbols": ["log-symbols@4.1.0", "", { "dependencies": { "chalk": "^4.1.0", "is-unicode-supported": "^0.1.0" } }, "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg=="],
 
-    "lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
+    "log-update": ["log-update@5.0.1", "", { "dependencies": { "ansi-escapes": "^5.0.0", "cli-cursor": "^4.0.0", "slice-ansi": "^5.0.0", "strip-ansi": "^7.0.1", "wrap-ansi": "^8.0.1" } }, "sha512-5UtUDQ/6edw4ofyljDNcOVJQ4c7OjDro4h3y8e1GQL5iYElYclVHJ3zeWchylvMaKnDbDilC8irOVyexnA/Slw=="],
+
+    "lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
 
     "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
 
     "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
+
+    "merge2": ["merge2@1.4.1", "", {}, "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg=="],
+
+    "micromatch": ["micromatch@4.0.8", "", { "dependencies": { "braces": "^3.0.3", "picomatch": "^2.3.1" } }, "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA=="],
 
     "mime": ["mime@1.6.0", "", { "bin": { "mime": "cli.js" } }, "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg=="],
 
@@ -1134,6 +1287,8 @@
 
     "minimist": ["minimist@1.2.8", "", {}, "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="],
 
+    "mkdirp": ["mkdirp@0.5.6", "", { "dependencies": { "minimist": "^1.2.6" }, "bin": { "mkdirp": "bin/cmd.js" } }, "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw=="],
+
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
     "msgpackr": ["msgpackr@2.0.4", "", { "optionalDependencies": { "msgpackr-extract": "^3.0.4" } }, "sha512-o1C5KRmuRt+apqMr1HuGSqWStZoRBUpEsCsl15uM9VdAF1qHLtvMOU2En747EnTyEl6c4pzPewRMFF31s1CNbA=="],
@@ -1144,9 +1299,13 @@
 
     "nanoid": ["nanoid@3.3.15", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA=="],
 
+    "native-fetch": ["native-fetch@4.0.2", "", { "peerDependencies": { "undici": "*" } }, "sha512-4QcVlKFtv2EYVS5MBgsGX5+NWKtbDbIECdUXDBGDMAZXq3Jkv9zf+y8iS7Ub8fEdga3GpYeazp9gauNqXHJOCg=="],
+
     "node-gyp-build-optional-packages": ["node-gyp-build-optional-packages@5.2.2", "", { "dependencies": { "detect-libc": "^2.0.1" }, "bin": { "node-gyp-build-optional-packages": "bin.js", "node-gyp-build-optional-packages-optional": "optional.js", "node-gyp-build-optional-packages-test": "build-test.js" } }, "sha512-s+w+rBWnpTMwSFbaE0UXsRlg7hU4FjekKU4eyAih5T8nJuNZT1nNsskXpxmeqSK9UzkBl6UgRlnKc8hz8IEqOw=="],
 
     "node-releases": ["node-releases@2.0.51", "", {}, "sha512-wRNIrw4DmVLKQlbgOMdkMx27Wrpzes2hh5Jtbi2bjPd+4wJstWIqP5A+lscnqbm0xxmT5Bpg8Lec5ItEBwx6BQ=="],
+
+    "normalize-path": ["normalize-path@2.1.1", "", { "dependencies": { "remove-trailing-separator": "^1.0.1" } }, "sha512-3pKJwH184Xo/lnH6oyP1q2pMd7HcypqqmRs91/6/i2CGtWwIKGCkOOMTm/zXbgTEWHw1uNpNi/igc3ePOYHb6w=="],
 
     "npm-run-path": ["npm-run-path@4.0.1", "", { "dependencies": { "path-key": "^3.0.0" } }, "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw=="],
 
@@ -1168,9 +1327,19 @@
 
     "oxc-resolver": ["oxc-resolver@11.21.3", "", { "optionalDependencies": { "@oxc-resolver/binding-android-arm-eabi": "11.21.3", "@oxc-resolver/binding-android-arm64": "11.21.3", "@oxc-resolver/binding-darwin-arm64": "11.21.3", "@oxc-resolver/binding-darwin-x64": "11.21.3", "@oxc-resolver/binding-freebsd-x64": "11.21.3", "@oxc-resolver/binding-linux-arm-gnueabihf": "11.21.3", "@oxc-resolver/binding-linux-arm-musleabihf": "11.21.3", "@oxc-resolver/binding-linux-arm64-gnu": "11.21.3", "@oxc-resolver/binding-linux-arm64-musl": "11.21.3", "@oxc-resolver/binding-linux-ppc64-gnu": "11.21.3", "@oxc-resolver/binding-linux-riscv64-gnu": "11.21.3", "@oxc-resolver/binding-linux-riscv64-musl": "11.21.3", "@oxc-resolver/binding-linux-s390x-gnu": "11.21.3", "@oxc-resolver/binding-linux-x64-gnu": "11.21.3", "@oxc-resolver/binding-linux-x64-musl": "11.21.3", "@oxc-resolver/binding-openharmony-arm64": "11.21.3", "@oxc-resolver/binding-wasm32-wasi": "11.21.3", "@oxc-resolver/binding-win32-arm64-msvc": "11.21.3", "@oxc-resolver/binding-win32-x64-msvc": "11.21.3" } }, "sha512-2Mx3fKQz7+xgrBONjsxOgCGtMHOn38/HxMzW1I5efwXB5a4lRN0Vp40gYUJFBWJslcrvwoofTrqoTnLbwTd3pA=="],
 
+    "p-limit": ["p-limit@3.1.0", "", { "dependencies": { "yocto-queue": "^0.1.0" } }, "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ=="],
+
+    "p-locate": ["p-locate@4.1.0", "", { "dependencies": { "p-limit": "^2.2.0" } }, "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A=="],
+
+    "p-try": ["p-try@2.2.0", "", {}, "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="],
+
     "parent-module": ["parent-module@1.0.1", "", { "dependencies": { "callsites": "^3.0.0" } }, "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g=="],
 
     "parse-json": ["parse-json@5.2.0", "", { "dependencies": { "@babel/code-frame": "^7.0.0", "error-ex": "^1.3.1", "json-parse-even-better-errors": "^2.3.0", "lines-and-columns": "^1.1.6" } }, "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg=="],
+
+    "path-exists": ["path-exists@4.0.0", "", {}, "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="],
+
+    "path-is-absolute": ["path-is-absolute@1.0.1", "", {}, "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg=="],
 
     "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
 
@@ -1188,13 +1357,15 @@
 
     "postcss": ["postcss@8.5.16", "", { "dependencies": { "nanoid": "^3.3.12", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg=="],
 
-    "prettier": ["prettier@3.9.5", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-/FVl766LpUfB5vXgCYOYa0MeV/441Ia99AeICQIQFTY/Nw0roZwULcXpku5i1/m5kt/baz+s4Zogspd839HSMg=="],
+    "prettier": ["prettier@2.8.8", "", { "bin": { "prettier": "bin-prettier.js" } }, "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q=="],
 
     "proxy-from-env": ["proxy-from-env@2.1.0", "", {}, "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA=="],
 
     "pure-rand": ["pure-rand@8.4.1", "", {}, "sha512-c58R2+SPFcSIPXoU834QN/KPDDOSd8sXcSrqf6e83Me6Rrp1EYkxukkjXMVrKvKaADs1SOyNkWdfvLf6zY8qLQ=="],
 
     "qs": ["qs@6.15.3", "", { "dependencies": { "es-define-property": "^1.0.1", "side-channel": "^1.1.1" } }, "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A=="],
+
+    "queue-microtask": ["queue-microtask@1.2.3", "", {}, "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A=="],
 
     "react": ["react@19.2.7", "", {}, "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ=="],
 
@@ -1216,9 +1387,13 @@
 
     "regjsparser": ["regjsparser@0.13.2", "", { "dependencies": { "jsesc": "~3.1.0" }, "bin": { "regjsparser": "bin/parser" } }, "sha512-NgRBy2Nx/bE+9F27nVHnqcN5HjyLmecqsqx2PJHu3/IEtADD4WuxuXIVExD5PoSDFVrl78dOonfcOe5O+5nbzQ=="],
 
+    "remove-trailing-separator": ["remove-trailing-separator@1.1.0", "", {}, "sha512-/hS+Y0u3aOfIETiaiirUFwDBDzmXPvO+jAfKTitUngIPzdKc6Z0LoFjM/CK5PL4C+eKwHohlHAb6H0VFfmmUsw=="],
+
     "require-directory": ["require-directory@2.1.1", "", {}, "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q=="],
 
     "require-from-string": ["require-from-string@2.0.2", "", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
+
+    "require-main-filename": ["require-main-filename@2.0.0", "", {}, "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg=="],
 
     "requires-port": ["requires-port@1.0.0", "", {}, "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ=="],
 
@@ -1232,7 +1407,15 @@
 
     "restore-cursor": ["restore-cursor@3.1.0", "", { "dependencies": { "onetime": "^5.1.0", "signal-exit": "^3.0.2" } }, "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA=="],
 
+    "reusify": ["reusify@1.1.0", "", {}, "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw=="],
+
+    "rfdc": ["rfdc@1.4.1", "", {}, "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA=="],
+
+    "rimraf": ["rimraf@2.7.1", "", { "dependencies": { "glob": "^7.1.3" }, "bin": { "rimraf": "./bin.js" } }, "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w=="],
+
     "rollup": ["rollup@4.62.2", "", { "dependencies": { "@types/estree": "1.0.9" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.62.2", "@rollup/rollup-android-arm64": "4.62.2", "@rollup/rollup-darwin-arm64": "4.62.2", "@rollup/rollup-darwin-x64": "4.62.2", "@rollup/rollup-freebsd-arm64": "4.62.2", "@rollup/rollup-freebsd-x64": "4.62.2", "@rollup/rollup-linux-arm-gnueabihf": "4.62.2", "@rollup/rollup-linux-arm-musleabihf": "4.62.2", "@rollup/rollup-linux-arm64-gnu": "4.62.2", "@rollup/rollup-linux-arm64-musl": "4.62.2", "@rollup/rollup-linux-loong64-gnu": "4.62.2", "@rollup/rollup-linux-loong64-musl": "4.62.2", "@rollup/rollup-linux-ppc64-gnu": "4.62.2", "@rollup/rollup-linux-ppc64-musl": "4.62.2", "@rollup/rollup-linux-riscv64-gnu": "4.62.2", "@rollup/rollup-linux-riscv64-musl": "4.62.2", "@rollup/rollup-linux-s390x-gnu": "4.62.2", "@rollup/rollup-linux-x64-gnu": "4.62.2", "@rollup/rollup-linux-x64-musl": "4.62.2", "@rollup/rollup-openbsd-x64": "4.62.2", "@rollup/rollup-openharmony-arm64": "4.62.2", "@rollup/rollup-win32-arm64-msvc": "4.62.2", "@rollup/rollup-win32-ia32-msvc": "4.62.2", "@rollup/rollup-win32-x64-gnu": "4.62.2", "@rollup/rollup-win32-x64-msvc": "4.62.2", "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-RFnrW4lhXA3s3eqHDZvN654g8OTjzRfqpIRJYczCGB6HzphckVAi/Qh4tbPUbRuDi7s1Llv8g/NspLkttY3gTA=="],
+
+    "run-parallel": ["run-parallel@1.2.0", "", { "dependencies": { "queue-microtask": "^1.2.2" } }, "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA=="],
 
     "safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
 
@@ -1250,6 +1433,8 @@
 
     "seroval-plugins": ["seroval-plugins@1.5.5", "", { "peerDependencies": { "seroval": "^1.0" } }, "sha512-+BDhqYM6CEn3x09v44dpa9p6974FuUB2dxk+Ctn04k0cO1Zt6QODTXfmEZK0eBaTe/fJBvP4NMGuNJ+R8T+QMg=="],
 
+    "set-blocking": ["set-blocking@2.0.0", "", {}, "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw=="],
+
     "side-channel": ["side-channel@1.1.1", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.4", "side-channel-list": "^1.0.1", "side-channel-map": "^1.0.1", "side-channel-weakmap": "^1.0.2" } }, "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ=="],
 
     "side-channel-list": ["side-channel-list@1.0.1", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.4" } }, "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w=="],
@@ -1259,6 +1444,10 @@
     "side-channel-weakmap": ["side-channel-weakmap@1.0.2", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3", "side-channel-map": "^1.0.1" } }, "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A=="],
 
     "signal-exit": ["signal-exit@3.0.7", "", {}, "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="],
+
+    "slash": ["slash@3.0.0", "", {}, "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q=="],
+
+    "slice-ansi": ["slice-ansi@5.0.0", "", { "dependencies": { "ansi-styles": "^6.0.0", "is-fullwidth-code-point": "^4.0.0" } }, "sha512-FC+lgizVPfie0kkhqUScwRu1O/lF6NOgJmlCgK+/LYxDCTk8sGelYaHDhFcDN+Sn3Cv+3VSa4Byeo+IMCzpMgQ=="],
 
     "smol-toml": ["smol-toml@1.6.1", "", {}, "sha512-dWUG8F5sIIARXih1DTaQAX4SsiTXhInKf1buxdY9DIg4ZYPZK5nGM1VRIYmEbDbsHt7USo99xSLFu5Q1IqTmsg=="],
 
@@ -1294,6 +1483,8 @@
 
     "tmp": ["tmp@0.2.7", "", {}, "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw=="],
 
+    "to-regex-range": ["to-regex-range@5.0.1", "", { "dependencies": { "is-number": "^7.0.0" } }, "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ=="],
+
     "toml": ["toml@4.1.2", "", {}, "sha512-m0vXfHODcw3gk+KONAOlVQ5yNHc3yS3B1ybM3HS1vqDoS0RWTDDVBVVTYi8hH0k+2OM1vmo9fb1WX9EVqjqfHA=="],
 
     "tsconfig-paths": ["tsconfig-paths@4.2.0", "", { "dependencies": { "json5": "^2.2.2", "minimist": "^1.2.6", "strip-bom": "^3.0.0" } }, "sha512-NoZ4roiN7LnbKn9QqE1amc9DJfzvZXxF4xDavcOWt1BPkdx+m+0gJuPM+S0vCe7zTJMYUP0R8pO2XMr+Y8oLIg=="],
@@ -1302,11 +1493,15 @@
 
     "tsx": ["tsx@4.23.0", "", { "dependencies": { "esbuild": "~0.28.0" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "bin": { "tsx": "dist/cli.mjs" } }, "sha512-eUdUIaCr963q2h5u3+QwvYp0+eqPvn+egeqZUm0hwERCqqx1E3kK5ehbGCvqSE5MQAULr67ww0cA3jKc3YkM1w=="],
 
+    "type-fest": ["type-fest@1.4.0", "", {}, "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA=="],
+
     "typescript": ["@typescript/typescript6@6.0.2", "", { "dependencies": { "@typescript/old": "npm:typescript@^6" }, "bin": { "tsc6": "bin/tsc6" } }, "sha512-mbCddXd+jm7hfx7w2YU64/Av4/NqqeG3GoRZgxPcgoTxYjhrcfJRw9ULch71SS4G+Q3bOXFhRvPqjguN0Hyp5w=="],
 
     "ulidx": ["ulidx@2.4.1", "", { "dependencies": { "layerr": "^3.0.0" } }, "sha512-xY7c8LPyzvhvew0Fn+Ek3wBC9STZAuDI/Y5andCKi9AX6/jvfaX45PhsDX8oxgPL0YFp0Jhr8qWMbS/p9375Xg=="],
 
     "unbash": ["unbash@4.0.2", "", {}, "sha512-8gwNZ29+0/3zmXw7ToIHZtg6wK37xnniRUdBt7B27xZxaxfgR5tGMaGHT0t0dLtBV9fXE7zurh0s6Z1DHVjfWg=="],
+
+    "undici": ["undici@5.29.0", "", { "dependencies": { "@fastify/busboy": "^2.0.0" } }, "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg=="],
 
     "undici-types": ["undici-types@8.3.0", "", {}, "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ=="],
 
@@ -1320,17 +1515,25 @@
 
     "union": ["union@0.5.0", "", { "dependencies": { "qs": "^6.4.0" } }, "sha512-N6uOhuW6zO95P3Mel2I2zMsbsanvvtgn6jVqJv4vbVcz/JN0OkL9suomjQGmWtxJQXOCqUJvquc1sMeNz/IwlA=="],
 
+    "universalify": ["universalify@2.0.1", "", {}, "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw=="],
+
+    "unixify": ["unixify@1.0.0", "", { "dependencies": { "normalize-path": "^2.1.1" } }, "sha512-6bc58dPYhCMHHuwxldQxO3RRNZ4eCogZ/st++0+fcC1nr0jiGUtAdBJ2qzmLQWSxbtz42pWt4QQMiZ9HvZf5cg=="],
+
     "unplugin": ["unplugin@3.3.0", "", { "dependencies": { "@jridgewell/remapping": "^2.3.5", "picomatch": "^4.0.4", "webpack-virtual-modules": "^0.6.2" }, "peerDependencies": { "@farmfe/core": "*", "@rspack/core": "*", "bun-types-no-globals": "*", "esbuild": "*", "rolldown": "*", "rollup": "*", "unloader": "*", "vite": "*", "webpack": "*" }, "optionalPeers": ["@farmfe/core", "@rspack/core", "bun-types-no-globals", "esbuild", "rolldown", "rollup", "unloader", "vite", "webpack"] }, "sha512-qa66K+crbfyE6JK10GjvbJeRrOsuC/JpbnHctfyp/i4oBTxWOzJfRZyDiOk1PtErMFRu8JhsU/wPvOdBNWe5Rg=="],
 
     "update-browserslist-db": ["update-browserslist-db@1.2.3", "", { "dependencies": { "escalade": "^3.2.0", "picocolors": "^1.1.1" }, "peerDependencies": { "browserslist": ">= 4.21.0" }, "bin": { "update-browserslist-db": "cli.js" } }, "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w=="],
 
     "url-join": ["url-join@4.0.1", "", {}, "sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA=="],
 
+    "urlpattern-polyfill": ["urlpattern-polyfill@10.1.0", "", {}, "sha512-IGjKp/o0NL3Bso1PymYURCJxMPNAf/ILOpendP9f5B6e1rTJgdgiOvgfoT8VxCAdY+Wisb9uhGaJJf3yZ2V9nw=="],
+
     "use-sync-external-store": ["use-sync-external-store@1.6.0", "", { "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w=="],
 
     "util-deprecate": ["util-deprecate@1.0.2", "", {}, "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="],
 
     "uuid": ["uuid@14.0.1", "", { "bin": { "uuid": "dist-node/bin/uuid" } }, "sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew=="],
+
+    "value-or-promise": ["value-or-promise@1.0.12", "", {}, "sha512-Z6Uz+TYwEqE7ZN50gwn+1LCVo9ZVrpxRPOhOLnncYkY1ZzOYtrX8Fwf/rFktZ8R5mJms6EZf5TqNOMeZmnPq9Q=="],
 
     "vite": ["vite@7.3.6", "", { "dependencies": { "esbuild": "^0.27.0 || ^0.28.0", "fdir": "^6.5.0", "picomatch": "^4.0.3", "postcss": "^8.5.6", "rollup": "^4.43.0", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "jiti": ">=1.21.0", "less": "^4.0.0", "lightningcss": "^1.21.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-4XP60spRGjSZFf1qYH+dJIkK2znL3zQfl9KkOV9MkkRR/3Dls0dxaBsQPTloEc5BLXWPL9vsOxopxyKoMmDueg=="],
 
@@ -1343,6 +1546,8 @@
     "whatwg-encoding": ["whatwg-encoding@2.0.0", "", { "dependencies": { "iconv-lite": "0.6.3" } }, "sha512-p41ogyeMUrw3jWclHWTQg1k05DSVXPLcVxRTYsXUk+ZooOCZLcoYgPZ/HL/D/N+uQPOtcp1me1WhBEaX02mhWg=="],
 
     "which": ["which@3.0.1", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "bin/which.js" } }, "sha512-XA1b62dzQzLfaEOSQFTCOd5KFf/1VSzZo7/7TUjnya6u0vGGKzU96UQBZTAThCb2j4/xjBAyii1OhRLJEivHvg=="],
+
+    "which-module": ["which-module@2.0.1", "", {}, "sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ=="],
 
     "wrap-ansi": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
 
@@ -1360,9 +1565,13 @@
 
     "yargs-parser": ["yargs-parser@21.1.1", "", {}, "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw=="],
 
+    "yocto-queue": ["yocto-queue@0.1.0", "", {}, "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="],
+
     "zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
 
     "@babel/core/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
+
+    "@babel/helper-compilation-targets/lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
 
     "@babel/helper-compilation-targets/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
@@ -1392,6 +1601,22 @@
 
     "@effect/sql-sqlite-bun/effect": ["effect@3.21.4", "", { "dependencies": { "@standard-schema/spec": "^1.0.0", "fast-check": "^3.23.1" } }, "sha512-B89v/xSgPbl1J2Ai2u18jxq3odpFauU1rC6/eSs4FeNHi72kwKdJp12VGigvRV2lK+kRnx+OOz41XV8guZd4gQ=="],
 
+    "@genql/cli/yargs": ["yargs@15.4.1", "", { "dependencies": { "cliui": "^6.0.0", "decamelize": "^1.2.0", "find-up": "^4.1.0", "get-caller-file": "^2.0.1", "require-directory": "^2.1.1", "require-main-filename": "^2.0.0", "set-blocking": "^2.0.0", "string-width": "^4.2.0", "which-module": "^2.0.0", "y18n": "^4.0.0", "yargs-parser": "^18.1.2" } }, "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A=="],
+
+    "@graphql-tools/executor/@graphql-tools/utils": ["@graphql-tools/utils@11.2.0", "", { "dependencies": { "@graphql-typed-document-node/core": "^3.1.1", "@whatwg-node/promise-helpers": "^1.0.0", "cross-inspect": "1.0.1", "tslib": "^2.4.0" }, "peerDependencies": { "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0" } }, "sha512-eu9h1R3j/wWc4rvmYJF5AKtlwniDzstrZ/c6KSz+HdI+n7I7iog9xyKmBfpUwSbG1TqPNZBzWjFMkzdYOKq6Bg=="],
+
+    "@graphql-tools/graphql-file-loader/@graphql-tools/utils": ["@graphql-tools/utils@9.2.1", "", { "dependencies": { "@graphql-typed-document-node/core": "^3.1.1", "tslib": "^2.4.0" }, "peerDependencies": { "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0" } }, "sha512-WUw506Ql6xzmOORlriNrD6Ugx+HjVgYxt9KCXD9mHAak+eaXSwuGGPyE60hy9xaDEoXKBsG7SkG69ybitaVl6A=="],
+
+    "@graphql-tools/import/@graphql-tools/utils": ["@graphql-tools/utils@9.2.1", "", { "dependencies": { "@graphql-typed-document-node/core": "^3.1.1", "tslib": "^2.4.0" }, "peerDependencies": { "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0" } }, "sha512-WUw506Ql6xzmOORlriNrD6Ugx+HjVgYxt9KCXD9mHAak+eaXSwuGGPyE60hy9xaDEoXKBsG7SkG69ybitaVl6A=="],
+
+    "@graphql-tools/load/@graphql-tools/schema": ["@graphql-tools/schema@9.0.19", "", { "dependencies": { "@graphql-tools/merge": "^8.4.1", "@graphql-tools/utils": "^9.2.1", "tslib": "^2.4.0", "value-or-promise": "^1.0.12" }, "peerDependencies": { "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0" } }, "sha512-oBRPoNBtCkk0zbUsyP4GaIzCt8C0aCI4ycIRUL67KK5pOHljKLBBtGT+Jr6hkzA74C8Gco8bpZPe7aWFjiaK2w=="],
+
+    "@graphql-tools/load/@graphql-tools/utils": ["@graphql-tools/utils@9.2.1", "", { "dependencies": { "@graphql-typed-document-node/core": "^3.1.1", "tslib": "^2.4.0" }, "peerDependencies": { "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0" } }, "sha512-WUw506Ql6xzmOORlriNrD6Ugx+HjVgYxt9KCXD9mHAak+eaXSwuGGPyE60hy9xaDEoXKBsG7SkG69ybitaVl6A=="],
+
+    "@graphql-tools/merge/@graphql-tools/utils": ["@graphql-tools/utils@11.2.0", "", { "dependencies": { "@graphql-typed-document-node/core": "^3.1.1", "@whatwg-node/promise-helpers": "^1.0.0", "cross-inspect": "1.0.1", "tslib": "^2.4.0" }, "peerDependencies": { "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0" } }, "sha512-eu9h1R3j/wWc4rvmYJF5AKtlwniDzstrZ/c6KSz+HdI+n7I7iog9xyKmBfpUwSbG1TqPNZBzWjFMkzdYOKq6Bg=="],
+
+    "@graphql-tools/schema/@graphql-tools/utils": ["@graphql-tools/utils@11.2.0", "", { "dependencies": { "@graphql-typed-document-node/core": "^3.1.1", "@whatwg-node/promise-helpers": "^1.0.0", "cross-inspect": "1.0.1", "tslib": "^2.4.0" }, "peerDependencies": { "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0" } }, "sha512-eu9h1R3j/wWc4rvmYJF5AKtlwniDzstrZ/c6KSz+HdI+n7I7iog9xyKmBfpUwSbG1TqPNZBzWjFMkzdYOKq6Bg=="],
+
     "@oxc-parser/binding-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.11.1", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.2", "tslib": "^2.4.0" } }, "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ=="],
 
     "@oxc-parser/binding-wasm32-wasi/@emnapi/runtime": ["@emnapi/runtime@1.11.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw=="],
@@ -1406,17 +1631,25 @@
 
     "@ready-for-agent/db/effect": ["effect@3.21.4", "", { "dependencies": { "@standard-schema/spec": "^1.0.0", "fast-check": "^3.23.1" } }, "sha512-B89v/xSgPbl1J2Ai2u18jxq3odpFauU1rC6/eSs4FeNHi72kwKdJp12VGigvRV2lK+kRnx+OOz41XV8guZd4gQ=="],
 
+    "@ready-for-agent/db-schema/effect": ["effect@3.21.4", "", { "dependencies": { "@standard-schema/spec": "^1.0.0", "fast-check": "^3.23.1" } }, "sha512-B89v/xSgPbl1J2Ai2u18jxq3odpFauU1rC6/eSs4FeNHi72kwKdJp12VGigvRV2lK+kRnx+OOz41XV8guZd4gQ=="],
+
     "@ready-for-agent/layer-turso-local/effect": ["effect@3.21.4", "", { "dependencies": { "@standard-schema/spec": "^1.0.0", "fast-check": "^3.23.1" } }, "sha512-B89v/xSgPbl1J2Ai2u18jxq3odpFauU1rC6/eSs4FeNHi72kwKdJp12VGigvRV2lK+kRnx+OOz41XV8guZd4gQ=="],
 
     "@ready-for-agent/queue-service/effect": ["effect@3.21.4", "", { "dependencies": { "@standard-schema/spec": "^1.0.0", "fast-check": "^3.23.1" } }, "sha512-B89v/xSgPbl1J2Ai2u18jxq3odpFauU1rC6/eSs4FeNHi72kwKdJp12VGigvRV2lK+kRnx+OOz41XV8guZd4gQ=="],
 
     "@ready-for-agent/sqlite-queue-service/effect": ["effect@3.21.4", "", { "dependencies": { "@standard-schema/spec": "^1.0.0", "fast-check": "^3.23.1" } }, "sha512-B89v/xSgPbl1J2Ai2u18jxq3odpFauU1rC6/eSs4FeNHi72kwKdJp12VGigvRV2lK+kRnx+OOz41XV8guZd4gQ=="],
 
+    "@tanstack/router-generator/prettier": ["prettier@3.9.5", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-/FVl766LpUfB5vXgCYOYa0MeV/441Ia99AeICQIQFTY/Nw0roZwULcXpku5i1/m5kt/baz+s4Zogspd839HSMg=="],
+
+    "@whatwg-node/node-fetch/@fastify/busboy": ["@fastify/busboy@3.2.0", "", {}, "sha512-m9FVDXU3GT2ITSe0UaMA5rU3QkfC/UXtCU8y0gSN/GugTqtVldOBWIB5V6V3sbmenVZUIpU6f+mPEO2+m5iTaA=="],
+
     "babel-plugin-macros/cosmiconfig": ["cosmiconfig@7.1.0", "", { "dependencies": { "@types/parse-json": "^4.0.0", "import-fresh": "^3.2.1", "parse-json": "^5.0.0", "path-type": "^4.0.0", "yaml": "^1.10.0" } }, "sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA=="],
 
     "babel-plugin-polyfill-corejs2/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
     "basic-auth/safe-buffer": ["safe-buffer@5.1.2", "", {}, "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="],
+
+    "cli-truncate/string-width": ["string-width@5.1.2", "", { "dependencies": { "eastasianwidth": "^0.2.0", "emoji-regex": "^9.2.2", "strip-ansi": "^7.0.1" } }, "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA=="],
 
     "cosmiconfig/js-yaml": ["js-yaml@4.3.0", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q=="],
 
@@ -1426,17 +1659,39 @@
 
     "effect-solutions/effect": ["effect@4.0.0-beta.59", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "fast-check": "^4.6.0", "find-my-way-ts": "^0.1.6", "ini": "^6.0.0", "kubernetes-types": "^1.30.0", "msgpackr": "^1.11.9", "multipasta": "^0.2.7", "toml": "^4.1.1", "uuid": "^13.0.0", "yaml": "^2.8.3" } }, "sha512-xyUDLeHSe8d6lWGOvR6Fgn2HL6gYeTZ/S4Jzk9uc4ZUxMPPsNZlNXrvk0C7/utQFzeX7uAWcVnG2BjbA0SRoAA=="],
 
+    "glob/minimatch": ["minimatch@3.1.5", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w=="],
+
     "global-directory/ini": ["ini@6.0.0", "", {}, "sha512-IBTdIkzZNOpqm7q3dRqJvMaldXjDHWkEDfrwGEQTs5eaQMWV+djAhR+wahyNNMAa+qpbDUhBMVt4ZKNwpPm7xQ=="],
+
+    "globby/ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
+
+    "http-proxy/eventemitter3": ["eventemitter3@4.0.7", "", {}, "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="],
 
     "import-fresh/resolve-from": ["resolve-from@4.0.0", "", {}, "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="],
 
     "js-yaml/argparse": ["argparse@1.0.10", "", { "dependencies": { "sprintf-js": "~1.0.2" } }, "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg=="],
 
+    "listr2/wrap-ansi": ["wrap-ansi@8.1.0", "", { "dependencies": { "ansi-styles": "^6.1.0", "string-width": "^5.0.1", "strip-ansi": "^7.0.1" } }, "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ=="],
+
+    "log-update/cli-cursor": ["cli-cursor@4.0.0", "", { "dependencies": { "restore-cursor": "^4.0.0" } }, "sha512-VGtlMu3x/4DOtIUwEkRezxUZ2lBacNJCHash0N0WeZDBS+7Ux1dm3XWAgWYxLJFMMdOeXMHXorshEFhbMSGelg=="],
+
+    "log-update/strip-ansi": ["strip-ansi@7.2.0", "", { "dependencies": { "ansi-regex": "^6.2.2" } }, "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w=="],
+
+    "log-update/wrap-ansi": ["wrap-ansi@8.1.0", "", { "dependencies": { "ansi-styles": "^6.1.0", "string-width": "^5.0.1", "strip-ansi": "^7.0.1" } }, "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ=="],
+
+    "micromatch/picomatch": ["picomatch@2.3.2", "", {}, "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="],
+
     "nx/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
 
     "nx/yargs": ["yargs@17.7.2", "", { "dependencies": { "cliui": "^8.0.1", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "require-directory": "^2.1.1", "string-width": "^4.2.3", "y18n": "^5.0.5", "yargs-parser": "^21.1.1" } }, "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w=="],
 
+    "p-locate/p-limit": ["p-limit@2.3.0", "", { "dependencies": { "p-try": "^2.0.0" } }, "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w=="],
+
     "parse-json/lines-and-columns": ["lines-and-columns@1.2.4", "", {}, "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="],
+
+    "slice-ansi/ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
+
+    "slice-ansi/is-fullwidth-code-point": ["is-fullwidth-code-point@4.0.0", "", {}, "sha512-O4L094N2/dZ7xqVdrXhh9r1KODPJpFms8B5sGdJLPy664AgvXsreZUyCQQNItZRDlYug4xStLjNp/sz3HvBowQ=="],
 
     "tsx/esbuild": ["esbuild@0.28.1", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.28.1", "@esbuild/android-arm": "0.28.1", "@esbuild/android-arm64": "0.28.1", "@esbuild/android-x64": "0.28.1", "@esbuild/darwin-arm64": "0.28.1", "@esbuild/darwin-x64": "0.28.1", "@esbuild/freebsd-arm64": "0.28.1", "@esbuild/freebsd-x64": "0.28.1", "@esbuild/linux-arm": "0.28.1", "@esbuild/linux-arm64": "0.28.1", "@esbuild/linux-ia32": "0.28.1", "@esbuild/linux-loong64": "0.28.1", "@esbuild/linux-mips64el": "0.28.1", "@esbuild/linux-ppc64": "0.28.1", "@esbuild/linux-riscv64": "0.28.1", "@esbuild/linux-s390x": "0.28.1", "@esbuild/linux-x64": "0.28.1", "@esbuild/netbsd-arm64": "0.28.1", "@esbuild/netbsd-x64": "0.28.1", "@esbuild/openbsd-arm64": "0.28.1", "@esbuild/openbsd-x64": "0.28.1", "@esbuild/openharmony-arm64": "0.28.1", "@esbuild/sunos-x64": "0.28.1", "@esbuild/win32-arm64": "0.28.1", "@esbuild/win32-ia32": "0.28.1", "@esbuild/win32-x64": "0.28.1" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw=="],
 
@@ -1458,6 +1713,14 @@
 
     "@effect/sql/effect/fast-check": ["fast-check@3.23.2", "", { "dependencies": { "pure-rand": "^6.1.0" } }, "sha512-h5+1OzzfCC3Ef7VbtKdcv7zsstUQwUDlYpUTvjeUsJAssPgLn7QzbboPtL5ro04Mq0rPOsMzl7q5hIbRs2wD1A=="],
 
+    "@genql/cli/yargs/cliui": ["cliui@6.0.0", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.0", "wrap-ansi": "^6.2.0" } }, "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ=="],
+
+    "@genql/cli/yargs/y18n": ["y18n@4.0.3", "", {}, "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ=="],
+
+    "@genql/cli/yargs/yargs-parser": ["yargs-parser@18.1.3", "", { "dependencies": { "camelcase": "^5.0.0", "decamelize": "^1.2.0" } }, "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ=="],
+
+    "@graphql-tools/load/@graphql-tools/schema/@graphql-tools/merge": ["@graphql-tools/merge@8.4.2", "", { "dependencies": { "@graphql-tools/utils": "^9.2.1", "tslib": "^2.4.0" }, "peerDependencies": { "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0" } }, "sha512-XbrHAaj8yDuINph+sAfuq3QCZ/tKblrTLOpirK0+CAgNlZUCHs0Fa+xtMUURgwCVThLle1AF7svJCxFizygLsw=="],
+
     "@oxc-parser/binding-wasm32-wasi/@emnapi/core/@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.2.2", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA=="],
 
     "@oxc-parser/binding-wasm32-wasi/@napi-rs/wasm-runtime/@tybys/wasm-util": ["@tybys/wasm-util@0.10.3", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg=="],
@@ -1465,6 +1728,8 @@
     "@oxc-resolver/binding-wasm32-wasi/@emnapi/core/@emnapi/wasi-threads": ["@emnapi/wasi-threads@1.2.2", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA=="],
 
     "@oxc-resolver/binding-wasm32-wasi/@napi-rs/wasm-runtime/@tybys/wasm-util": ["@tybys/wasm-util@0.10.3", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg=="],
+
+    "@ready-for-agent/db-schema/effect/fast-check": ["fast-check@3.23.2", "", { "dependencies": { "pure-rand": "^6.1.0" } }, "sha512-h5+1OzzfCC3Ef7VbtKdcv7zsstUQwUDlYpUTvjeUsJAssPgLn7QzbboPtL5ro04Mq0rPOsMzl7q5hIbRs2wD1A=="],
 
     "@ready-for-agent/db/effect/fast-check": ["fast-check@3.23.2", "", { "dependencies": { "pure-rand": "^6.1.0" } }, "sha512-h5+1OzzfCC3Ef7VbtKdcv7zsstUQwUDlYpUTvjeUsJAssPgLn7QzbboPtL5ro04Mq0rPOsMzl7q5hIbRs2wD1A=="],
 
@@ -1476,11 +1741,31 @@
 
     "babel-plugin-macros/cosmiconfig/yaml": ["yaml@1.10.3", "", {}, "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA=="],
 
+    "cli-truncate/string-width/emoji-regex": ["emoji-regex@9.2.2", "", {}, "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="],
+
+    "cli-truncate/string-width/strip-ansi": ["strip-ansi@7.2.0", "", { "dependencies": { "ansi-regex": "^6.2.2" } }, "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w=="],
+
     "effect-solutions/effect/ini": ["ini@6.0.0", "", {}, "sha512-IBTdIkzZNOpqm7q3dRqJvMaldXjDHWkEDfrwGEQTs5eaQMWV+djAhR+wahyNNMAa+qpbDUhBMVt4ZKNwpPm7xQ=="],
 
     "effect-solutions/effect/msgpackr": ["msgpackr@1.12.1", "", { "optionalDependencies": { "msgpackr-extract": "^3.0.2" } }, "sha512-4EUH9tQHnMmEgzW/MdAP0KIfa1T9AF+htl0ffe2n5vb2EKn9y2co8ccpgWko6S52Jy1PQZKwRnx5/KkYjtd9MQ=="],
 
     "effect-solutions/effect/uuid": ["uuid@13.0.2", "", { "bin": { "uuid": "dist-node/bin/uuid" } }, "sha512-vzi9uRZ926x4XV73S/4qQaTwPXM2JBj6/6lI/byHH1jOpCzb0zDbfytgA9LcN/hzb2l7WQSQnxITOVx5un/wGw=="],
+
+    "glob/minimatch/brace-expansion": ["brace-expansion@1.1.16", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw=="],
+
+    "listr2/wrap-ansi/ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
+
+    "listr2/wrap-ansi/string-width": ["string-width@5.1.2", "", { "dependencies": { "eastasianwidth": "^0.2.0", "emoji-regex": "^9.2.2", "strip-ansi": "^7.0.1" } }, "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA=="],
+
+    "listr2/wrap-ansi/strip-ansi": ["strip-ansi@7.2.0", "", { "dependencies": { "ansi-regex": "^6.2.2" } }, "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w=="],
+
+    "log-update/cli-cursor/restore-cursor": ["restore-cursor@4.0.0", "", { "dependencies": { "onetime": "^5.1.0", "signal-exit": "^3.0.2" } }, "sha512-I9fPXU9geO9bHOt9pHHOhOkYerIMsmVaWB0rA2AI9ERh/+x/i7MV5HKBNrg+ljO5eoPVgCcnFuRjJ9uH6I/3eg=="],
+
+    "log-update/strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
+
+    "log-update/wrap-ansi/ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
+
+    "log-update/wrap-ansi/string-width": ["string-width@5.1.2", "", { "dependencies": { "eastasianwidth": "^0.2.0", "emoji-regex": "^9.2.2", "strip-ansi": "^7.0.1" } }, "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA=="],
 
     "tsx/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.28.1", "", { "os": "aix", "cpu": "ppc64" }, "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ=="],
 
@@ -1604,6 +1889,10 @@
 
     "@effect/sql/effect/fast-check/pure-rand": ["pure-rand@6.1.0", "", {}, "sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA=="],
 
+    "@genql/cli/yargs/cliui/wrap-ansi": ["wrap-ansi@6.2.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA=="],
+
+    "@ready-for-agent/db-schema/effect/fast-check/pure-rand": ["pure-rand@6.1.0", "", {}, "sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA=="],
+
     "@ready-for-agent/db/effect/fast-check/pure-rand": ["pure-rand@6.1.0", "", {}, "sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA=="],
 
     "@ready-for-agent/layer-turso-local/effect/fast-check/pure-rand": ["pure-rand@6.1.0", "", {}, "sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA=="],
@@ -1611,6 +1900,16 @@
     "@ready-for-agent/queue-service/effect/fast-check/pure-rand": ["pure-rand@6.1.0", "", {}, "sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA=="],
 
     "@ready-for-agent/sqlite-queue-service/effect/fast-check/pure-rand": ["pure-rand@6.1.0", "", {}, "sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA=="],
+
+    "cli-truncate/string-width/strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
+
+    "glob/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
+
+    "listr2/wrap-ansi/string-width/emoji-regex": ["emoji-regex@9.2.2", "", {}, "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="],
+
+    "listr2/wrap-ansi/strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
+
+    "log-update/wrap-ansi/string-width/emoji-regex": ["emoji-regex@9.2.2", "", {}, "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="],
 
     "yargs/cliui/strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
 

--- a/docs/adr/0003-graphql-schema-client-api-split.md
+++ b/docs/adr/0003-graphql-schema-client-api-split.md
@@ -1,0 +1,3 @@
+# GraphQL SDL, genql client, and Yoga API as separate packages
+
+The GraphQL contract is SDL in `@ready-for-agent/graphql-schema` (schema only). Typed callers use a committed genql client in `@ready-for-agent/graphql-client`. The HTTP server is `apps/api` (Bun + GraphQL Yoga) with stub resolvers until real services exist. The SPA (`apps/harness` on port 4200) proxies `/graphql` to the API; the CLI defaults to `http://127.0.0.1:4200/graphql`. Rejected: schema+client in one package (muddies server vs consumer deps), genql per consumer (drift), Yoga inside Vite middleware (dev-only), CLI talking to the API port directly (two public ports).

--- a/knip.json
+++ b/knip.json
@@ -3,9 +3,22 @@
   "ignoreDependencies": ["@swc/helpers", "nx"],
   "ignoreBinaries": ["skills"],
   "workspaces": {
+    "apps/api": {
+      "entry": ["src/main.ts"],
+      "project": ["src/**/*.ts"]
+    },
     "apps/cli": {
       "entry": ["src/main.ts", "src/**/*.test.ts"],
       "project": ["src/**/*.ts"]
+    },
+    "packages/graphql-client": {
+      "entry": ["src/index.ts"],
+      "project": [
+        "src/index.ts",
+        "src/generated/index.ts",
+        "src/generated/schema.ts",
+        "src/generated/types.ts"
+      ]
     },
     "packages/*": {
       "entry": ["src/index.ts", "test/**/*.{test,spec}.ts"],

--- a/nx.json
+++ b/nx.json
@@ -2,13 +2,8 @@
   "$schema": "./node_modules/nx/schemas/nx-schema.json",
   "analytics": true,
   "namedInputs": {
-    "default": [
-      "{projectRoot}/**/*",
-      "sharedGlobals"
-    ],
-    "production": [
-      "default"
-    ],
+    "default": ["{projectRoot}/**/*", "sharedGlobals"],
+    "production": ["default"],
     "sharedGlobals": []
   },
   "plugins": [
@@ -54,9 +49,7 @@
   "targetDefaults": {
     "build": {
       "cache": true,
-      "outputs": [
-        "{projectRoot}/dist"
-      ]
+      "outputs": ["{projectRoot}/dist"]
     },
     "knip": {
       "cache": true

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "license": "MIT",
   "scripts": {
     "commitlint": "commitlint",
-    "harness-cli": "bun apps/cli/src/main.ts",
+    "harness-cli": "bun --conditions @ready-for-agent/source apps/cli/src/main.ts",
     "knip": "knip --no-config-hints",
     "lint": "biome check .",
     "prepare": "bash scripts/install-git-hooks.sh && effect-tsgo patch"

--- a/packages/graphql-client/package.json
+++ b/packages/graphql-client/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@ready-for-agent/db-schema",
+  "name": "@ready-for-agent/graphql-client",
   "version": "0.0.1",
   "private": true,
   "type": "module",
@@ -16,19 +16,13 @@
     }
   },
   "scripts": {
-    "generate": "drizzle-kit generate",
+    "generate": "genql --schema ../graphql-schema/schema.graphql --output ./src/generated",
     "typecheck": "tsc --noEmit -p tsconfig.lib.json"
   },
   "nx": {
-    "name": "db-schema"
-  },
-  "dependencies": {
-    "drizzle-orm": "1.0.0-rc.4-5d5b77c",
-    "effect": "^3.21.4",
-    "tslib": "^2.3.0",
-    "ulidx": "^2.4.1"
+    "name": "graphql-client"
   },
   "devDependencies": {
-    "drizzle-kit": "1.0.0-rc.4-5d5b77c"
+    "@genql/cli": "^6.3.3"
   }
 }

--- a/packages/graphql-client/src/generated/index.ts
+++ b/packages/graphql-client/src/generated/index.ts
@@ -1,0 +1,65 @@
+// @ts-nocheck
+import type {
+  QueryGenqlSelection,
+  Query,
+  MutationGenqlSelection,
+  Mutation,
+} from './schema'
+import {
+  linkTypeMap,
+  createClient as createClientOriginal,
+  generateGraphqlOperation,
+  type FieldsSelection,
+  type GraphqlOperation,
+  type ClientOptions,
+  GenqlError,
+} from './runtime'
+export type { FieldsSelection } from './runtime'
+export { GenqlError }
+
+import types from './types'
+export * from './schema'
+const typeMap = linkTypeMap(types as any)
+
+export interface Client {
+  query<R extends QueryGenqlSelection>(
+    request: R & { __name?: string },
+  ): Promise<FieldsSelection<Query, R>>
+
+  mutation<R extends MutationGenqlSelection>(
+    request: R & { __name?: string },
+  ): Promise<FieldsSelection<Mutation, R>>
+}
+
+export const createClient = function (options?: ClientOptions): Client {
+  return createClientOriginal({
+    url: undefined,
+
+    ...options,
+    queryRoot: typeMap.Query!,
+    mutationRoot: typeMap.Mutation!,
+    subscriptionRoot: typeMap.Subscription!,
+  }) as any
+}
+
+export const everything = {
+  __scalar: true,
+}
+
+export type QueryResult<fields extends QueryGenqlSelection> = FieldsSelection<
+  Query,
+  fields
+>
+export const generateQueryOp: (
+  fields: QueryGenqlSelection & { __name?: string },
+) => GraphqlOperation = function (fields) {
+  return generateGraphqlOperation('query', typeMap.Query!, fields as any)
+}
+
+export type MutationResult<fields extends MutationGenqlSelection> =
+  FieldsSelection<Mutation, fields>
+export const generateMutationOp: (
+  fields: MutationGenqlSelection & { __name?: string },
+) => GraphqlOperation = function (fields) {
+  return generateGraphqlOperation('mutation', typeMap.Mutation!, fields as any)
+}

--- a/packages/graphql-client/src/generated/runtime/batcher.ts
+++ b/packages/graphql-client/src/generated/runtime/batcher.ts
@@ -1,0 +1,275 @@
+// @ts-nocheck
+import type { GraphqlOperation } from './generateGraphqlOperation'
+import { GenqlError } from './error'
+
+type Variables = Record<string, any>
+
+type QueryError = Error & {
+    message: string
+
+    locations?: Array<{
+        line: number
+        column: number
+    }>
+    path?: any
+    rid: string
+    details?: Record<string, any>
+}
+type Result = {
+    data: Record<string, any>
+    errors: Array<QueryError>
+}
+type Fetcher = (
+    batchedQuery: GraphqlOperation | Array<GraphqlOperation>,
+) => Promise<Array<Result>>
+type Options = {
+    batchInterval?: number
+    shouldBatch?: boolean
+    maxBatchSize?: number
+}
+type Queue = Array<{
+    request: GraphqlOperation
+    resolve: (...args: Array<any>) => any
+    reject: (...args: Array<any>) => any
+}>
+
+/**
+ * takes a list of requests (queue) and batches them into a single server request.
+ * It will then resolve each individual requests promise with the appropriate data.
+ * @private
+ * @param {QueryBatcher}   client - the client to use
+ * @param {Queue} queue  - the list of requests to batch
+ */
+function dispatchQueueBatch(client: QueryBatcher, queue: Queue): void {
+    let batchedQuery: any = queue.map((item) => item.request)
+
+    if (batchedQuery.length === 1) {
+        batchedQuery = batchedQuery[0]
+    }
+    (() => {
+        try {
+            return client.fetcher(batchedQuery);
+        } catch(e) {
+            return Promise.reject(e);
+        }
+    })().then((responses: any) => {
+        if (queue.length === 1 && !Array.isArray(responses)) {
+            if (responses.errors && responses.errors.length) {
+                queue[0].reject(
+                    new GenqlError(responses.errors, responses.data),
+                )
+                return
+            }
+
+            queue[0].resolve(responses)
+            return
+        } else if (responses.length !== queue.length) {
+            throw new Error('response length did not match query length')
+        }
+
+        for (let i = 0; i < queue.length; i++) {
+            if (responses[i].errors && responses[i].errors.length) {
+                queue[i].reject(
+                    new GenqlError(responses[i].errors, responses[i].data),
+                )
+            } else {
+                queue[i].resolve(responses[i])
+            }
+        }
+    })
+    .catch((e) => {
+        for (let i = 0; i < queue.length; i++) {
+            queue[i].reject(e)
+        }
+    });
+}
+
+/**
+ * creates a list of requests to batch according to max batch size.
+ * @private
+ * @param {QueryBatcher} client - the client to create list of requests from from
+ * @param {Options} options - the options for the batch
+ */
+function dispatchQueue(client: QueryBatcher, options: Options): void {
+    const queue = client._queue
+    const maxBatchSize = options.maxBatchSize || 0
+    client._queue = []
+
+    if (maxBatchSize > 0 && maxBatchSize < queue.length) {
+        for (let i = 0; i < queue.length / maxBatchSize; i++) {
+            dispatchQueueBatch(
+                client,
+                queue.slice(i * maxBatchSize, (i + 1) * maxBatchSize),
+            )
+        }
+    } else {
+        dispatchQueueBatch(client, queue)
+    }
+}
+/**
+ * Create a batcher client.
+ * @param {Fetcher} fetcher                 - A function that can handle the network requests to graphql endpoint
+ * @param {Options} options                 - the options to be used by client
+ * @param {boolean} options.shouldBatch     - should the client batch requests. (default true)
+ * @param {integer} options.batchInterval   - duration (in MS) of each batch window. (default 6)
+ * @param {integer} options.maxBatchSize    - max number of requests in a batch. (default 0)
+ * @param {boolean} options.defaultHeaders  - default headers to include with every request
+ *
+ * @example
+ * const fetcher = batchedQuery => fetch('path/to/graphql', {
+ *    method: 'post',
+ *    headers: {
+ *      Accept: 'application/json',
+ *      'Content-Type': 'application/json',
+ *    },
+ *    body: JSON.stringify(batchedQuery),
+ *    credentials: 'include',
+ * })
+ * .then(response => response.json())
+ *
+ * const client = new QueryBatcher(fetcher, { maxBatchSize: 10 })
+ */
+
+export class QueryBatcher {
+    fetcher: Fetcher
+    _options: Options
+    _queue: Queue
+
+    constructor(
+        fetcher: Fetcher,
+        {
+            batchInterval = 6,
+            shouldBatch = true,
+            maxBatchSize = 0,
+        }: Options = {},
+    ) {
+        this.fetcher = fetcher
+        this._options = {
+            batchInterval,
+            shouldBatch,
+            maxBatchSize,
+        }
+        this._queue = []
+    }
+
+    /**
+     * Fetch will send a graphql request and return the parsed json.
+     * @param {string}      query          - the graphql query.
+     * @param {Variables}   variables      - any variables you wish to inject as key/value pairs.
+     * @param {[string]}    operationName  - the graphql operationName.
+     * @param {Options}     overrides      - the client options overrides.
+     *
+     * @return {promise} resolves to parsed json of server response
+     *
+     * @example
+     * client.fetch(`
+     *    query getHuman($id: ID!) {
+     *      human(id: $id) {
+     *        name
+     *        height
+     *      }
+     *    }
+     * `, { id: "1001" }, 'getHuman')
+     *    .then(human => {
+     *      // do something with human
+     *      console.log(human);
+     *    });
+     */
+    fetch(
+        query: string,
+        variables?: Variables,
+        operationName?: string,
+        overrides: Options = {},
+    ): Promise<Result> {
+        const request: GraphqlOperation = {
+            query,
+        }
+        const options = Object.assign({}, this._options, overrides)
+
+        if (variables) {
+            request.variables = variables
+        }
+
+        if (operationName) {
+            request.operationName = operationName
+        }
+
+        const promise = new Promise<Result>((resolve, reject) => {
+            this._queue.push({
+                request,
+                resolve,
+                reject,
+            })
+
+            if (this._queue.length === 1) {
+                if (options.shouldBatch) {
+                    setTimeout(
+                        () => dispatchQueue(this, options),
+                        options.batchInterval,
+                    )
+                } else {
+                    dispatchQueue(this, options)
+                }
+            }
+        })
+        return promise
+    }
+
+    /**
+     * Fetch will send a graphql request and return the parsed json.
+     * @param {string}      query          - the graphql query.
+     * @param {Variables}   variables      - any variables you wish to inject as key/value pairs.
+     * @param {[string]}    operationName  - the graphql operationName.
+     * @param {Options}     overrides      - the client options overrides.
+     *
+     * @return {Promise<Array<Result>>} resolves to parsed json of server response
+     *
+     * @example
+     * client.forceFetch(`
+     *    query getHuman($id: ID!) {
+     *      human(id: $id) {
+     *        name
+     *        height
+     *      }
+     *    }
+     * `, { id: "1001" }, 'getHuman')
+     *    .then(human => {
+     *      // do something with human
+     *      console.log(human);
+     *    });
+     */
+    forceFetch(
+        query: string,
+        variables?: Variables,
+        operationName?: string,
+        overrides: Options = {},
+    ): Promise<Result> {
+        const request: GraphqlOperation = {
+            query,
+        }
+        const options = Object.assign({}, this._options, overrides, {
+            shouldBatch: false,
+        })
+
+        if (variables) {
+            request.variables = variables
+        }
+
+        if (operationName) {
+            request.operationName = operationName
+        }
+
+        const promise = new Promise<Result>((resolve, reject) => {
+            const client = new QueryBatcher(this.fetcher, this._options)
+            client._queue = [
+                {
+                    request,
+                    resolve,
+                    reject,
+                },
+            ]
+            dispatchQueue(client, options)
+        })
+        return promise
+    }
+}

--- a/packages/graphql-client/src/generated/runtime/createClient.ts
+++ b/packages/graphql-client/src/generated/runtime/createClient.ts
@@ -1,0 +1,68 @@
+// @ts-nocheck
+
+import  { type BatchOptions, createFetcher } from './fetcher'
+import type { ExecutionResult, LinkedType } from './types'
+import {
+    generateGraphqlOperation,
+    type GraphqlOperation,
+} from './generateGraphqlOperation'
+
+export type Headers =
+    | HeadersInit
+    | (() => HeadersInit)
+    | (() => Promise<HeadersInit>)
+
+export type BaseFetcher = (
+    operation: GraphqlOperation | GraphqlOperation[],
+) => Promise<ExecutionResult | ExecutionResult[]>
+
+export type ClientOptions = Omit<RequestInit, 'body' | 'headers'> & {
+    url?: string
+    batch?: BatchOptions | boolean
+    fetcher?: BaseFetcher
+    fetch?: Function
+    headers?: Headers
+}
+
+export const createClient = ({
+    queryRoot,
+    mutationRoot,
+    subscriptionRoot,
+    ...options
+}: ClientOptions & {
+    queryRoot?: LinkedType
+    mutationRoot?: LinkedType
+    subscriptionRoot?: LinkedType
+}) => {
+    const fetcher = createFetcher(options)
+    const client: {
+        query?: Function
+        mutation?: Function
+    } = {}
+
+    if (queryRoot) {
+        client.query = (request: any) => {
+            if (!queryRoot) throw new Error('queryRoot argument is missing')
+
+            const resultPromise = fetcher(
+                generateGraphqlOperation('query', queryRoot, request),
+            )
+
+            return resultPromise
+        }
+    }
+    if (mutationRoot) {
+        client.mutation = (request: any) => {
+            if (!mutationRoot)
+                throw new Error('mutationRoot argument is missing')
+
+            const resultPromise = fetcher(
+                generateGraphqlOperation('mutation', mutationRoot, request),
+            )
+
+            return resultPromise
+        }
+    }
+
+    return client as any
+}

--- a/packages/graphql-client/src/generated/runtime/error.ts
+++ b/packages/graphql-client/src/generated/runtime/error.ts
@@ -1,0 +1,29 @@
+// @ts-nocheck
+export class GenqlError extends Error {
+    errors: Array<GraphqlError> = []
+    /**
+     * Partial data returned by the server
+     */
+    data?: any
+    constructor(errors: any[], data: any) {
+        let message = Array.isArray(errors)
+            ? errors.map((x) => x?.message || '').join('\n')
+            : ''
+        if (!message) {
+            message = 'GraphQL error'
+        }
+        super(message)
+        this.errors = errors
+        this.data = data
+    }
+}
+
+interface GraphqlError {
+    message: string
+    locations?: Array<{
+        line: number
+        column: number
+    }>
+    path?: string[]
+    extensions?: Record<string, any>
+}

--- a/packages/graphql-client/src/generated/runtime/fetcher.ts
+++ b/packages/graphql-client/src/generated/runtime/fetcher.ts
@@ -1,0 +1,97 @@
+// @ts-nocheck
+import { QueryBatcher } from './batcher'
+
+import type { ClientOptions } from './createClient'
+import type { GraphqlOperation } from './generateGraphqlOperation'
+import { GenqlError } from './error'
+
+export interface Fetcher {
+    (gql: GraphqlOperation): Promise<any>
+}
+
+export type BatchOptions = {
+    batchInterval?: number // ms
+    maxBatchSize?: number
+}
+
+const DEFAULT_BATCH_OPTIONS = {
+    maxBatchSize: 10,
+    batchInterval: 40,
+}
+
+export const createFetcher = ({
+    url,
+    headers = {},
+    fetcher,
+    fetch: _fetch,
+    batch = false,
+    ...rest
+}: ClientOptions): Fetcher => {
+    if (!url && !fetcher) {
+        throw new Error('url or fetcher is required')
+    }
+
+    fetcher = fetcher || (async (body) => {
+        let headersObject =
+            typeof headers == 'function' ? await headers() : headers
+        headersObject = headersObject || {}
+        if (typeof fetch === 'undefined' && !_fetch) {
+            throw new Error(
+                'Global `fetch` function is not available, pass a fetch polyfill to Genql `createClient`',
+            )
+        }
+        let fetchImpl = _fetch || fetch
+        const res = await fetchImpl(url!, {
+            headers: {
+                'Content-Type': 'application/json',
+                ...headersObject,
+            },
+            method: 'POST',
+            body: JSON.stringify(body),
+            ...rest,
+        })
+        if (!res.ok) {
+            throw new Error(`${res.statusText}: ${await res.text()}`)
+        }
+        const json = await res.json()
+        return json
+    })
+
+    if (!batch) {
+        return async (body) => {
+            const json = await fetcher!(body)
+            if (Array.isArray(json)) {
+                return json.map((json) => {
+                    if (json?.errors?.length) {
+                        throw new GenqlError(json.errors || [], json.data)
+                    }
+                    return json.data
+                })
+            } else {
+                if (json?.errors?.length) {
+                    throw new GenqlError(json.errors || [], json.data)
+                }
+                return json.data
+            }
+        }
+    }
+
+    const batcher = new QueryBatcher(
+        async (batchedQuery) => {
+            // console.log(batchedQuery) // [{ query: 'query{user{age}}', variables: {} }, ...]
+            const json = await fetcher!(batchedQuery)
+            return json as any
+        },
+        batch === true ? DEFAULT_BATCH_OPTIONS : batch,
+    )
+
+    return async ({ query, variables }) => {
+        const json = await batcher.fetch(query, variables)
+        if (json?.data) {
+            return json.data
+        }
+        throw new Error(
+            'Genql batch fetcher returned unexpected result ' + JSON.stringify(json),
+        )
+    }
+}

--- a/packages/graphql-client/src/generated/runtime/generateGraphqlOperation.ts
+++ b/packages/graphql-client/src/generated/runtime/generateGraphqlOperation.ts
@@ -1,0 +1,225 @@
+// @ts-nocheck
+import type { LinkedField, LinkedType } from './types'
+
+export interface Args {
+    [arg: string]: any | undefined
+}
+
+export interface Fields {
+    [field: string]: Request
+}
+
+export type Request = boolean | number | Fields
+
+export interface Variables {
+    [name: string]: {
+        value: any
+        typing: [LinkedType, string]
+    }
+}
+
+export interface Context {
+    root: LinkedType
+    varCounter: number
+    variables: Variables
+    fragmentCounter: number
+    fragments: string[]
+}
+
+export interface GraphqlOperation {
+    query: string
+    variables?: { [name: string]: any }
+    operationName?: string
+}
+
+const parseRequest = (
+    request: Request | undefined,
+    ctx: Context,
+    path: string[],
+): string => {
+    if (typeof request === 'object' && '__args' in request) {
+        const args: any = request.__args
+        let fields: Request | undefined = { ...request }
+        delete fields.__args
+        const argNames = Object.keys(args)
+
+        if (argNames.length === 0) {
+            return parseRequest(fields, ctx, path)
+        }
+
+        const field = getFieldFromPath(ctx.root, path)
+
+        const argStrings = argNames.map((argName) => {
+            ctx.varCounter++
+            const varName = `v${ctx.varCounter}`
+
+            const typing = field.args && field.args[argName] // typeMap used here, .args
+
+            if (!typing) {
+                throw new Error(
+                    `no typing defined for argument \`${argName}\` in path \`${path.join(
+                        '.',
+                    )}\``,
+                )
+            }
+
+            ctx.variables[varName] = {
+                value: args[argName],
+                typing,
+            }
+
+            return `${argName}:$${varName}`
+        })
+        return `(${argStrings})${parseRequest(fields, ctx, path)}`
+    } else if (typeof request === 'object' && Object.keys(request).length > 0) {
+        const fields = request
+        const fieldNames = Object.keys(fields).filter((k) => Boolean(fields[k]))
+
+        if (fieldNames.length === 0) {
+            throw new Error(
+                `field selection should not be empty: ${path.join('.')}`,
+            )
+        }
+
+        const type =
+            path.length > 0 ? getFieldFromPath(ctx.root, path).type : ctx.root
+        const scalarFields = type.scalar
+
+        let scalarFieldsFragment: string | undefined
+
+        if (fieldNames.includes('__scalar')) {
+            const falsyFieldNames = new Set(
+                Object.keys(fields).filter((k) => !Boolean(fields[k])),
+            )
+            if (scalarFields?.length) {
+                ctx.fragmentCounter++
+                scalarFieldsFragment = `f${ctx.fragmentCounter}`
+
+                ctx.fragments.push(
+                    `fragment ${scalarFieldsFragment} on ${
+                        type.name
+                    }{${scalarFields
+                        .filter((f) => !falsyFieldNames.has(f))
+                        .join(',')}}`,
+                )
+            }
+        }
+
+        const fieldsSelection = fieldNames
+            .filter((f) => !['__scalar', '__name'].includes(f))
+            .map((f) => {
+                const parsed = parseRequest(fields[f], ctx, [...path, f])
+
+                if (f.startsWith('on_')) {
+                    ctx.fragmentCounter++
+                    const implementationFragment = `f${ctx.fragmentCounter}`
+
+                    const typeMatch = f.match(/^on_(.+)/)
+
+                    if (!typeMatch || !typeMatch[1])
+                        throw new Error('match failed')
+
+                    ctx.fragments.push(
+                        `fragment ${implementationFragment} on ${typeMatch[1]}${parsed}`,
+                    )
+
+                    return `...${implementationFragment}`
+                } else {
+                    return `${f}${parsed}`
+                }
+            })
+            .concat(scalarFieldsFragment ? [`...${scalarFieldsFragment}`] : [])
+            .join(',')
+
+        return `{${fieldsSelection}}`
+    } else {
+        return ''
+    }
+}
+
+export const generateGraphqlOperation = (
+    operation: 'query' | 'mutation' | 'subscription',
+    root: LinkedType,
+    fields?: Fields,
+): GraphqlOperation => {
+    const ctx: Context = {
+        root: root,
+        varCounter: 0,
+        variables: {},
+        fragmentCounter: 0,
+        fragments: [],
+    }
+    const result = parseRequest(fields, ctx, [])
+
+    const varNames = Object.keys(ctx.variables)
+
+    const varsString =
+        varNames.length > 0
+            ? `(${varNames.map((v) => {
+                  const variableType = ctx.variables[v].typing[1]
+                  return `$${v}:${variableType}`
+              })})`
+            : ''
+
+    const operationName = fields?.__name || ''
+
+    return {
+        query: [
+            `${operation} ${operationName}${varsString}${result}`,
+            ...ctx.fragments,
+        ].join(','),
+        variables: Object.keys(ctx.variables).reduce<{ [name: string]: any }>(
+            (r, v) => {
+                r[v] = ctx.variables[v].value
+                return r
+            },
+            {},
+        ),
+        ...(operationName ? { operationName: operationName.toString() } : {}),
+    }
+}
+
+export const getFieldFromPath = (
+    root: LinkedType | undefined,
+    path: string[],
+) => {
+    let current: LinkedField | undefined
+
+    if (!root) throw new Error('root type is not provided')
+
+    if (path.length === 0) throw new Error(`path is empty`)
+
+    path.forEach((f) => {
+        const type = current ? current.type : root
+
+        if (!type.fields)
+            throw new Error(`type \`${type.name}\` does not have fields`)
+
+        const possibleTypes = Object.keys(type.fields)
+            .filter((i) => i.startsWith('on_'))
+            .reduce(
+                (types, fieldName) => {
+                    const field = type.fields && type.fields[fieldName]
+                    if (field) types.push(field.type)
+                    return types
+                },
+                [type],
+            )
+
+        let field: LinkedField | null = null
+
+        possibleTypes.forEach((type) => {
+            const found = type.fields && type.fields[f]
+            if (found) field = found
+        })
+
+        if (!field)
+            throw new Error(
+                `type \`${type.name}\` does not have a field \`${f}\``,
+            )
+
+        current = field
+    })
+
+    return current as LinkedField
+}

--- a/packages/graphql-client/src/generated/runtime/index.ts
+++ b/packages/graphql-client/src/generated/runtime/index.ts
@@ -1,0 +1,13 @@
+// @ts-nocheck
+export { createClient } from './createClient'
+export type { ClientOptions } from './createClient'
+export type { FieldsSelection } from './typeSelection'
+export { generateGraphqlOperation } from './generateGraphqlOperation'
+export type { GraphqlOperation } from './generateGraphqlOperation'
+export { linkTypeMap } from './linkTypeMap'
+// export { Observable } from 'zen-observable-ts'
+export { createFetcher } from './fetcher'
+export { GenqlError } from './error'
+export const everything = {
+    __scalar: true,
+}

--- a/packages/graphql-client/src/generated/runtime/linkTypeMap.ts
+++ b/packages/graphql-client/src/generated/runtime/linkTypeMap.ts
@@ -1,0 +1,156 @@
+// @ts-nocheck
+import type {
+    CompressedType,
+    CompressedTypeMap,
+    LinkedArgMap,
+    LinkedField,
+    LinkedType,
+    LinkedTypeMap,
+} from './types'
+
+export interface PartialLinkedFieldMap {
+    [field: string]: {
+        type: string
+        args?: LinkedArgMap
+    }
+}
+
+export const linkTypeMap = (
+    typeMap: CompressedTypeMap<number>,
+): LinkedTypeMap => {
+    const indexToName: Record<number, string> = Object.assign(
+        {},
+        ...Object.keys(typeMap.types).map((k, i) => ({ [i]: k })),
+    )
+
+    let intermediaryTypeMap = Object.assign(
+        {},
+        ...Object.keys(typeMap.types || {}).map(
+            (k): Record<string, LinkedType> => {
+                const type: CompressedType = typeMap.types[k]!
+                const fields = type || {}
+                return {
+                    [k]: {
+                        name: k,
+                        // type scalar properties
+                        scalar: Object.keys(fields).filter((f) => {
+                            const [type] = fields[f] || []
+
+                            const isScalar =
+                                type && typeMap.scalars.includes(type)
+                            if (!isScalar) {
+                                return false
+                            }
+                            const args = fields[f]?.[1]
+                            const argTypes = Object.values(args || {})
+                                .map((x) => x?.[1])
+                                .filter(Boolean)
+
+                            const hasRequiredArgs = argTypes.some(
+                                (str) => str && str.endsWith('!'),
+                            )
+                            if (hasRequiredArgs) {
+                                return false
+                            }
+                            return true
+                        }),
+                        // fields with corresponding `type` and `args`
+                        fields: Object.assign(
+                            {},
+                            ...Object.keys(fields).map(
+                                (f): PartialLinkedFieldMap => {
+                                    const [typeIndex, args] = fields[f] || []
+                                    if (typeIndex == null) {
+                                        return {}
+                                    }
+                                    return {
+                                        [f]: {
+                                            // replace index with type name
+                                            type: indexToName[typeIndex],
+                                            args: Object.assign(
+                                                {},
+                                                ...Object.keys(args || {}).map(
+                                                    (k) => {
+                                                        // if argTypeString == argTypeName, argTypeString is missing, need to readd it
+                                                        if (!args || !args[k]) {
+                                                            return
+                                                        }
+                                                        const [
+                                                            argTypeName,
+                                                            argTypeString,
+                                                        ] = args[k] as any
+                                                        return {
+                                                            [k]: [
+                                                                indexToName[
+                                                                    argTypeName
+                                                                ],
+                                                                argTypeString ||
+                                                                    indexToName[
+                                                                        argTypeName
+                                                                    ],
+                                                            ],
+                                                        }
+                                                    },
+                                                ),
+                                            ),
+                                        },
+                                    }
+                                },
+                            ),
+                        ),
+                    },
+                }
+            },
+        ),
+    )
+    const res = resolveConcreteTypes(intermediaryTypeMap)
+    return res
+}
+
+// replace typename with concrete type
+export const resolveConcreteTypes = (linkedTypeMap: LinkedTypeMap) => {
+    Object.keys(linkedTypeMap).forEach((typeNameFromKey) => {
+        const type: LinkedType = linkedTypeMap[typeNameFromKey]!
+        // type.name = typeNameFromKey
+        if (!type.fields) {
+            return
+        }
+
+        const fields = type.fields
+
+        Object.keys(fields).forEach((f) => {
+            const field: LinkedField = fields[f]!
+
+            if (field.args) {
+                const args = field.args
+                Object.keys(args).forEach((key) => {
+                    const arg = args[key]
+
+                    if (arg) {
+                        const [typeName] = arg
+
+                        if (typeof typeName === 'string') {
+                            if (!linkedTypeMap[typeName]) {
+                                linkedTypeMap[typeName] = { name: typeName }
+                            }
+
+                            arg[0] = linkedTypeMap[typeName]!
+                        }
+                    }
+                })
+            }
+
+            const typeName = field.type as LinkedType | string
+
+            if (typeof typeName === 'string') {
+                if (!linkedTypeMap[typeName]) {
+                    linkedTypeMap[typeName] = { name: typeName }
+                }
+
+                field.type = linkedTypeMap[typeName]!
+            }
+        })
+    })
+
+    return linkedTypeMap
+}

--- a/packages/graphql-client/src/generated/runtime/typeSelection.ts
+++ b/packages/graphql-client/src/generated/runtime/typeSelection.ts
@@ -1,0 +1,95 @@
+// @ts-nocheck
+//////////////////////////////////////////////////
+
+// SOME THINGS TO KNOW BEFORE DIVING IN
+/*
+0. DST is the request type, SRC is the response type
+
+1. FieldsSelection uses an object because currently is impossible to make recursive types
+
+2. FieldsSelection is a recursive type that makes a type based on request type and fields
+
+3. HandleObject handles object types
+
+4. Handle__scalar adds all scalar properties excluding non scalar props
+*/
+
+export type FieldsSelection<SRC extends Anify<DST> | undefined, DST> = {
+    scalar: SRC
+    union: Handle__isUnion<SRC, DST>
+    object: HandleObject<SRC, DST>
+    array: SRC extends Nil
+        ? never
+        : SRC extends Array<infer T | null>
+        ? Array<FieldsSelection<T, DST>>
+        : never
+    __scalar: Handle__scalar<SRC, DST>
+    never: never
+}[DST extends Nil
+    ? 'never'
+    : DST extends false | 0
+    ? 'never'
+    : SRC extends Scalar
+    ? 'scalar'
+    : SRC extends any[]
+    ? 'array'
+    : SRC extends { __isUnion?: any }
+    ? 'union'
+    : DST extends { __scalar?: any }
+    ? '__scalar'
+    : DST extends {}
+    ? 'object'
+    : 'never']
+
+type HandleObject<SRC extends Anify<DST>, DST> = DST extends boolean
+    ? SRC
+    : SRC extends Nil
+    ? never
+    : Pick<
+          {
+              // using keyof SRC to maintain ?: relations of SRC type
+              [Key in keyof SRC]: Key extends keyof DST
+                  ? FieldsSelection<SRC[Key], NonNullable<DST[Key]>>
+                  : SRC[Key]
+          },
+          Exclude<keyof DST, FieldsToRemove>
+          //   {
+          //       // remove falsy values
+          //       [Key in keyof DST]: DST[Key] extends false | 0 ? never : Key
+          //   }[keyof DST]
+      >
+
+type Handle__scalar<SRC extends Anify<DST>, DST> = SRC extends Nil
+    ? never
+    : Pick<
+          // continue processing fields that are in DST, directly pass SRC type if not in DST
+          {
+              [Key in keyof SRC]: Key extends keyof DST
+                  ? FieldsSelection<SRC[Key], DST[Key]>
+                  : SRC[Key]
+          },
+          // remove fields that are not scalars or are not in DST
+          {
+              [Key in keyof SRC]: SRC[Key] extends Nil
+                  ? never
+                  : Key extends FieldsToRemove
+                  ? never
+                  : SRC[Key] extends Scalar
+                  ? Key
+                  : Key extends keyof DST
+                  ? Key
+                  : never
+          }[keyof SRC]
+      >
+
+type Handle__isUnion<SRC extends Anify<DST>, DST> = SRC extends Nil
+    ? never
+    : Omit<SRC, FieldsToRemove> // just return the union type
+
+type Scalar = string | number | Date | boolean | null | undefined
+
+type Anify<T> = { [P in keyof T]?: any }
+
+type FieldsToRemove = '__isUnion' | '__scalar' | '__name' | '__args'
+
+type Nil = undefined | null

--- a/packages/graphql-client/src/generated/runtime/types.ts
+++ b/packages/graphql-client/src/generated/runtime/types.ts
@@ -1,0 +1,69 @@
+// @ts-nocheck
+
+export interface ExecutionResult<TData = { [key: string]: any }> {
+    errors?: Array<Error>
+    data?: TData | null
+}
+
+export interface ArgMap<keyType = number> {
+    [arg: string]: [keyType, string] | [keyType] | undefined
+}
+
+export type CompressedField<keyType = number> = [
+    type: keyType,
+    args?: ArgMap<keyType>,
+]
+
+export interface CompressedFieldMap<keyType = number> {
+    [field: string]: CompressedField<keyType> | undefined
+}
+
+export type CompressedType<keyType = number> = CompressedFieldMap<keyType>
+
+export interface CompressedTypeMap<keyType = number> {
+    scalars: Array<keyType>
+    types: {
+        [type: string]: CompressedType<keyType> | undefined
+    }
+}
+
+// normal types
+export type Field<keyType = number> = {
+    type: keyType
+    args?: ArgMap<keyType>
+}
+
+export interface FieldMap<keyType = number> {
+    [field: string]: Field<keyType> | undefined
+}
+
+export type Type<keyType = number> = FieldMap<keyType>
+
+export interface TypeMap<keyType = number> {
+    scalars: Array<keyType>
+    types: {
+        [type: string]: Type<keyType> | undefined
+    }
+}
+
+export interface LinkedArgMap {
+    [arg: string]: [LinkedType, string] | undefined
+}
+export interface LinkedField {
+    type: LinkedType
+    args?: LinkedArgMap
+}
+
+export interface LinkedFieldMap {
+    [field: string]: LinkedField | undefined
+}
+
+export interface LinkedType {
+    name: string
+    fields?: LinkedFieldMap
+    scalar?: string[]
+}
+
+export interface LinkedTypeMap {
+    [type: string]: LinkedType | undefined
+}

--- a/packages/graphql-client/src/generated/schema.graphql
+++ b/packages/graphql-client/src/generated/schema.graphql
@@ -1,0 +1,23 @@
+type Query {
+  health: Boolean!
+}
+
+type Repository {
+  id: ID!
+  githubOwner: String!
+  githubRepo: String!
+  localPath: String!
+  isBare: Boolean!
+  paused: Boolean!
+}
+
+input AddRepositoryInput {
+  githubOwner: String!
+  githubRepo: String!
+  localPath: String!
+  isBare: Boolean!
+}
+
+type Mutation {
+  addRepository(input: AddRepositoryInput!): Repository!
+}

--- a/packages/graphql-client/src/generated/schema.ts
+++ b/packages/graphql-client/src/generated/schema.ts
@@ -1,0 +1,79 @@
+// @ts-nocheck
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+export type Scalars = {
+    Boolean: boolean,
+    ID: string,
+    String: string,
+}
+
+export interface Query {
+    health: Scalars['Boolean']
+    __typename: 'Query'
+}
+
+export interface Repository {
+    id: Scalars['ID']
+    githubOwner: Scalars['String']
+    githubRepo: Scalars['String']
+    localPath: Scalars['String']
+    isBare: Scalars['Boolean']
+    paused: Scalars['Boolean']
+    __typename: 'Repository'
+}
+
+export interface Mutation {
+    addRepository: Repository
+    __typename: 'Mutation'
+}
+
+export interface QueryGenqlSelection{
+    health?: boolean | number
+    __typename?: boolean | number
+    __scalar?: boolean | number
+}
+
+export interface RepositoryGenqlSelection{
+    id?: boolean | number
+    githubOwner?: boolean | number
+    githubRepo?: boolean | number
+    localPath?: boolean | number
+    isBare?: boolean | number
+    paused?: boolean | number
+    __typename?: boolean | number
+    __scalar?: boolean | number
+}
+
+export interface AddRepositoryInput {githubOwner: Scalars['String'],githubRepo: Scalars['String'],localPath: Scalars['String'],isBare: Scalars['Boolean']}
+
+export interface MutationGenqlSelection{
+    addRepository?: (RepositoryGenqlSelection & { __args: {input: AddRepositoryInput} })
+    __typename?: boolean | number
+    __scalar?: boolean | number
+}
+
+
+    const Query_possibleTypes: string[] = ['Query']
+    export const isQuery = (obj?: { __typename?: any } | null): obj is Query => {
+      if (!obj?.__typename) throw new Error('__typename is missing in "isQuery"')
+      return Query_possibleTypes.includes(obj.__typename)
+    }
+    
+
+
+    const Repository_possibleTypes: string[] = ['Repository']
+    export const isRepository = (obj?: { __typename?: any } | null): obj is Repository => {
+      if (!obj?.__typename) throw new Error('__typename is missing in "isRepository"')
+      return Repository_possibleTypes.includes(obj.__typename)
+    }
+    
+
+
+    const Mutation_possibleTypes: string[] = ['Mutation']
+    export const isMutation = (obj?: { __typename?: any } | null): obj is Mutation => {
+      if (!obj?.__typename) throw new Error('__typename is missing in "isMutation"')
+      return Mutation_possibleTypes.includes(obj.__typename)
+    }
+    

--- a/packages/graphql-client/src/generated/types.ts
+++ b/packages/graphql-client/src/generated/types.ts
@@ -1,0 +1,74 @@
+export default {
+    "scalars": [
+        1,
+        3,
+        4
+    ],
+    "types": {
+        "Query": {
+            "health": [
+                1
+            ],
+            "__typename": [
+                4
+            ]
+        },
+        "Boolean": {},
+        "Repository": {
+            "id": [
+                3
+            ],
+            "githubOwner": [
+                4
+            ],
+            "githubRepo": [
+                4
+            ],
+            "localPath": [
+                4
+            ],
+            "isBare": [
+                1
+            ],
+            "paused": [
+                1
+            ],
+            "__typename": [
+                4
+            ]
+        },
+        "ID": {},
+        "String": {},
+        "AddRepositoryInput": {
+            "githubOwner": [
+                4
+            ],
+            "githubRepo": [
+                4
+            ],
+            "localPath": [
+                4
+            ],
+            "isBare": [
+                1
+            ],
+            "__typename": [
+                4
+            ]
+        },
+        "Mutation": {
+            "addRepository": [
+                2,
+                {
+                    "input": [
+                        5,
+                        "AddRepositoryInput!"
+                    ]
+                }
+            ],
+            "__typename": [
+                4
+            ]
+        }
+    }
+}

--- a/packages/graphql-client/src/index.ts
+++ b/packages/graphql-client/src/index.ts
@@ -1,0 +1,1 @@
+export * from "./generated/index.js"

--- a/packages/graphql-client/tsconfig.json
+++ b/packages/graphql-client/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ]
+}

--- a/packages/graphql-client/tsconfig.lib.json
+++ b/packages/graphql-client/tsconfig.lib.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "tsBuildInfoFile": "dist/tsconfig.lib.tsbuildinfo",
+    "emitDeclarationOnly": false,
+    "forceConsistentCasingInFileNames": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/packages/graphql-schema/package.json
+++ b/packages/graphql-schema/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@ready-for-agent/db-schema",
+  "name": "@ready-for-agent/graphql-schema",
   "version": "0.0.1",
   "private": true,
   "type": "module",
@@ -13,22 +13,13 @@
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
       "default": "./dist/index.js"
-    }
+    },
+    "./schema.graphql": "./schema.graphql"
   },
   "scripts": {
-    "generate": "drizzle-kit generate",
     "typecheck": "tsc --noEmit -p tsconfig.lib.json"
   },
   "nx": {
-    "name": "db-schema"
-  },
-  "dependencies": {
-    "drizzle-orm": "1.0.0-rc.4-5d5b77c",
-    "effect": "^3.21.4",
-    "tslib": "^2.3.0",
-    "ulidx": "^2.4.1"
-  },
-  "devDependencies": {
-    "drizzle-kit": "1.0.0-rc.4-5d5b77c"
+    "name": "graphql-schema"
   }
 }

--- a/packages/graphql-schema/schema.graphql
+++ b/packages/graphql-schema/schema.graphql
@@ -1,0 +1,23 @@
+type Query {
+  health: Boolean!
+}
+
+type Repository {
+  id: ID!
+  githubOwner: String!
+  githubRepo: String!
+  localPath: String!
+  isBare: Boolean!
+  paused: Boolean!
+}
+
+input AddRepositoryInput {
+  githubOwner: String!
+  githubRepo: String!
+  localPath: String!
+  isBare: Boolean!
+}
+
+type Mutation {
+  addRepository(input: AddRepositoryInput!): Repository!
+}

--- a/packages/graphql-schema/src/index.ts
+++ b/packages/graphql-schema/src/index.ts
@@ -1,0 +1,10 @@
+import { readFileSync } from "node:fs"
+import { dirname, join } from "node:path"
+import { fileURLToPath } from "node:url"
+
+const packageRoot = join(dirname(fileURLToPath(import.meta.url)), "..")
+
+export const typeDefs = readFileSync(
+  join(packageRoot, "schema.graphql"),
+  "utf8",
+)

--- a/packages/graphql-schema/tsconfig.json
+++ b/packages/graphql-schema/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ]
+}

--- a/packages/graphql-schema/tsconfig.lib.json
+++ b/packages/graphql-schema/tsconfig.lib.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "tsBuildInfoFile": "dist/tsconfig.lib.tsbuildinfo",
+    "emitDeclarationOnly": false,
+    "forceConsistentCasingInFileNames": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/packages/queue-service/src/lib/queue-service.ts
+++ b/packages/queue-service/src/lib/queue-service.ts
@@ -162,6 +162,7 @@ export interface QueueServiceShape<R = never> {
   ) => Effect.Effect<QueueStats, InvalidQueueNameError, R>
 }
 
+/** @effect-expect-leaking any */
 export class QueueService extends Context.Tag(
   "@ready-for-agent/queue-service/QueueService",
 )<

--- a/packages/sqlite-queue-service/src/lib/sqlite-queue-service.ts
+++ b/packages/sqlite-queue-service/src/lib/sqlite-queue-service.ts
@@ -579,7 +579,7 @@ export const SqliteQueueServiceLive = Layer.succeed(
             })
             .from(schema.jobQueue)
             .where(eq(schema.jobQueue.queue, queue)),
-        ).pipe(Effect.catchAll(() => Effect.succeed([] as const)))
+        ).pipe(Effect.orElseSucceed(() => [] as const))
 
         return (
           stats[0] ?? {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,9 @@
   "files": [],
   "references": [
     {
+      "path": "./apps/api"
+    },
+    {
       "path": "./apps/cli"
     },
     {
@@ -11,6 +14,12 @@
     },
     {
       "path": "./packages/db-schema"
+    },
+    {
+      "path": "./packages/graphql-client"
+    },
+    {
+      "path": "./packages/graphql-schema"
     },
     {
       "path": "./packages/queue-service"


### PR DESCRIPTION
## Why

The harness needs a typed GraphQL path so the CLI (and later the SPA) can register Repositories without ad-hoc HTTP. This PR proves the end-to-end contract: schema → Yoga → genql client → CLI, with a stub resolver and no persistence yet.

## What Changed

- Added `packages/graphql-schema` (SDL + `typeDefs` export) with `addRepository` mutation and a minimal `health` query
- Added `packages/graphql-client` with a committed genql-generated client
- Added `apps/api` (Bun + GraphQL Yoga) with stub resolvers and GraphiQL
- Proxied `/graphql` from the harness Vite dev/preview server (port 4200) to the API (port 3001)
- Wired `harness-cli add` to inspect the local git repo, call `addRepository` via genql, and print the stub result
- Documented the GraphQL package split in `docs/adr/0003-graphql-schema-client-api-split.md`
- Fixed pre-existing Effect/drizzle monorepo friction so pre-commit hooks pass:
  - aligned `db-schema` onto the same drizzle peer graph as other DB packages
  - suppressed intentional `QueueService` requirement leakage for effect-tsgo
  - replaced `catchAll` + `succeed` with `orElseSucceed` in the queue stats path

## Verification

```bash
bun run --cwd apps/api start
READY_FOR_AGENT_GRAPHQL_URL=http://127.0.0.1:3001/graphql bun run harness-cli add .
# Added repository berenddeboer/ready-for-agent
#   id: stub-repository-id
#   local path: ...
#   bare: false
#   paused: true
```
