### PR TITLE
feat: persist repositories through GraphQL

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,3 +48,8 @@ Single-context layout (root CONTEXT.md + docs/adr/). See `docs/agents/domain.md`
 
 
 <!-- nx configuration end-->
+
+## Nx project config
+
+Put Nx-specific config (`name`, custom targets like `test`/`migrate`/`serve`) in
+each package's `project.json`, not under an `"nx"` key in `package.json`.

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -8,19 +8,11 @@
     "start": "bun --conditions @ready-for-agent/source src/main.ts",
     "typecheck": "tsc --noEmit -p tsconfig.app.json"
   },
-  "nx": {
-    "name": "api",
-    "targets": {
-      "serve": {
-        "command": "bun --watch --conditions @ready-for-agent/source src/main.ts",
-        "options": {
-          "cwd": "{projectRoot}"
-        }
-      }
-    }
-  },
   "dependencies": {
+    "@ready-for-agent/db": "workspace:*",
+    "@ready-for-agent/db-service": "workspace:*",
     "@ready-for-agent/graphql-schema": "workspace:*",
+    "effect": "^3.21.4",
     "graphql": "^16.11.0",
     "graphql-yoga": "^5.13.0"
   },

--- a/apps/api/project.json
+++ b/apps/api/project.json
@@ -3,10 +3,11 @@
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "targets": {
     "serve": {
+      "continuous": true,
       "executor": "nx:run-commands",
       "options": {
         "cwd": "{projectRoot}",
-        "command": "bun --watch --conditions @ready-for-agent/source src/main.ts"
+        "command": "mkdir -p ../../tmp && SQLITE_DATABASE_PATH=${SQLITE_DATABASE_PATH:-../../tmp/ready-for-agent.db} bun --watch --conditions @ready-for-agent/source src/main.ts"
       },
       "dependsOn": ["db:migrate"]
     },
@@ -14,7 +15,7 @@
       "executor": "nx:run-commands",
       "options": {
         "cwd": "{projectRoot}",
-        "command": "bun --conditions @ready-for-agent/source src/main.ts"
+        "command": "mkdir -p ../../tmp && SQLITE_DATABASE_PATH=${SQLITE_DATABASE_PATH:-../../tmp/ready-for-agent.db} bun --conditions @ready-for-agent/source src/main.ts"
       },
       "dependsOn": ["db:migrate"]
     }

--- a/apps/api/project.json
+++ b/apps/api/project.json
@@ -1,0 +1,22 @@
+{
+  "name": "api",
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "targets": {
+    "serve": {
+      "executor": "nx:run-commands",
+      "options": {
+        "cwd": "{projectRoot}",
+        "command": "bun --watch --conditions @ready-for-agent/source src/main.ts"
+      },
+      "dependsOn": ["db:migrate"]
+    },
+    "start": {
+      "executor": "nx:run-commands",
+      "options": {
+        "cwd": "{projectRoot}",
+        "command": "bun --conditions @ready-for-agent/source src/main.ts"
+      },
+      "dependsOn": ["db:migrate"]
+    }
+  }
+}

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -1,7 +1,67 @@
+import { Effect, Either, Layer, ManagedRuntime } from "effect"
+import { GraphQLError } from "graphql"
 import { createSchema, createYoga } from "graphql-yoga"
+import { DatabaseLive } from "@ready-for-agent/db"
+import {
+  DatabaseError,
+  DbService,
+  DbServiceLive,
+  InvalidRepositoryInputError,
+  LocalPathInUseError,
+  RepositoryAlreadyExistsError,
+} from "@ready-for-agent/db-service"
 import { typeDefs } from "@ready-for-agent/graphql-schema"
 
 const port = Number(process.env.PORT ?? 3001)
+
+const AppLayer = DbServiceLive.pipe(Layer.provideMerge(DatabaseLive))
+const runtime = ManagedRuntime.make(AppLayer)
+
+type AddRepositoryArgs = {
+  input: {
+    githubOwner: string
+    githubRepo: string
+    localPath: string
+    isBare: boolean
+  }
+}
+
+const toGraphQLError = (error: unknown): GraphQLError => {
+  if (error instanceof RepositoryAlreadyExistsError) {
+    return new GraphQLError(
+      `Repository ${error.githubOwner}/${error.githubRepo} already exists`,
+      {
+        extensions: { code: "REPOSITORY_ALREADY_EXISTS" },
+      },
+    )
+  }
+  if (error instanceof LocalPathInUseError) {
+    return new GraphQLError(`Local path already in use: ${error.localPath}`, {
+      extensions: { code: "LOCAL_PATH_IN_USE" },
+    })
+  }
+  if (error instanceof InvalidRepositoryInputError) {
+    return new GraphQLError(error.message, {
+      extensions: { code: "INVALID_REPOSITORY_INPUT", field: error.field },
+    })
+  }
+  if (error instanceof DatabaseError) {
+    return new GraphQLError(error.message, {
+      extensions: { code: "DATABASE_ERROR" },
+    })
+  }
+  if (error instanceof GraphQLError) {
+    return error
+  }
+  if (error instanceof Error) {
+    return new GraphQLError(error.message, {
+      extensions: { code: "INTERNAL_SERVER_ERROR" },
+    })
+  }
+  return new GraphQLError("Unexpected error", {
+    extensions: { code: "INTERNAL_SERVER_ERROR" },
+  })
+}
 
 const yoga = createYoga({
   schema: createSchema({
@@ -11,24 +71,20 @@ const yoga = createYoga({
         health: () => true,
       },
       Mutation: {
-        addRepository: (
-          _parent,
-          args: {
-            input: {
-              githubOwner: string
-              githubRepo: string
-              localPath: string
-              isBare: boolean
-            }
-          },
-        ) => ({
-          id: "stub-repository-id",
-          githubOwner: args.input.githubOwner,
-          githubRepo: args.input.githubRepo,
-          localPath: args.input.localPath,
-          isBare: args.input.isBare,
-          paused: true,
-        }),
+        addRepository: async (_parent: unknown, args: AddRepositoryArgs) => {
+          const result = await runtime.runPromise(
+            Effect.either(
+              Effect.gen(function* () {
+                const db = yield* DbService
+                return yield* db.addRepository(args.input)
+              }),
+            ),
+          )
+          if (Either.isLeft(result)) {
+            throw toGraphQLError(result.left)
+          }
+          return result.right
+        },
       },
     },
   }),

--- a/apps/api/tsconfig.app.json
+++ b/apps/api/tsconfig.app.json
@@ -16,6 +16,12 @@
   "include": ["src/**/*.ts"],
   "references": [
     {
+      "path": "../../packages/db/tsconfig.lib.json"
+    },
+    {
+      "path": "../../packages/db-service/tsconfig.lib.json"
+    },
+    {
       "path": "../../packages/graphql-schema/tsconfig.lib.json"
     }
   ]

--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -4,13 +4,15 @@ CLI for the ready-for-agent harness.
 
 ## Usage
 
-Start the GraphQL API and harness from the repo root:
+Start the harness from the repo root:
 
 ```bash
-bun run --cwd apps/api dev
-# In another terminal:
-bun run --cwd apps/harness dev
+bun nx run harness:dev
 ```
+
+This starts both Vite and the GraphQL API. By default, API development data is
+stored in `tmp/ready-for-agent.db`. Set `SQLITE_DATABASE_PATH` to use another
+SQLite/Turso database.
 
 Then add a local repository:
 
@@ -18,7 +20,7 @@ Then add a local repository:
 bun run harness-cli add /path/to/local/repo
 ```
 
-The CLI inspects the local git repository, calls the harness GraphQL endpoint at `http://127.0.0.1:4200/graphql`, and prints the returned Repository fields. The API currently returns a stub response; persistence is not wired yet. The path must be a git repository with a GitHub remote, and new Repositories are reported as paused.
+The CLI inspects the local git repository, calls the harness GraphQL endpoint at `http://127.0.0.1:4200/graphql`, and prints the persisted Repository fields. The path must be a git repository with a GitHub remote, and new Repositories are reported as paused.
 
 Override the endpoint when the harness is available elsewhere:
 
@@ -32,7 +34,7 @@ Example:
 ```bash
 bun run harness-cli add ~/src/pf/monorepo/
 # Added repository processfocus/monorepo
-#   id: stub-repository-id
+#   id: repo-01...
 #   local path: /home/berend/src/pf/monorepo
 #   bare: true
 #   paused: true

--- a/apps/harness/project.json
+++ b/apps/harness/project.json
@@ -8,7 +8,13 @@
       "options": {
         "command": "vite",
         "cwd": "apps/harness"
-      }
+      },
+      "dependsOn": [
+        {
+          "projects": ["api"],
+          "target": "serve"
+        }
+      ]
     }
   }
 }

--- a/apps/harness/vite.config.ts
+++ b/apps/harness/vite.config.ts
@@ -18,6 +18,7 @@ export default defineConfig({
     react(),
   ],
   server: {
+    host: "127.0.0.1",
     port: 4200,
     proxy: graphqlProxy,
   },

--- a/bun.lock
+++ b/bun.lock
@@ -29,7 +29,10 @@
       "name": "@ready-for-agent/api",
       "version": "0.0.0",
       "dependencies": {
+        "@ready-for-agent/db": "workspace:*",
+        "@ready-for-agent/db-service": "workspace:*",
         "@ready-for-agent/graphql-schema": "workspace:*",
+        "effect": "^3.21.4",
         "graphql": "^16.11.0",
         "graphql-yoga": "^5.13.0",
       },
@@ -93,6 +96,22 @@
       },
       "devDependencies": {
         "drizzle-kit": "1.0.0-rc.4-5d5b77c",
+      },
+    },
+    "packages/db-service": {
+      "name": "@ready-for-agent/db-service",
+      "version": "0.0.1",
+      "dependencies": {
+        "@effect/sql": "^0.51.1",
+        "@ready-for-agent/db": "workspace:*",
+        "@ready-for-agent/db-schema": "workspace:*",
+        "drizzle-orm": "1.0.0-rc.4-5d5b77c",
+        "effect": "^3.21.4",
+        "tslib": "^2.3.0",
+        "ulidx": "^2.4.1",
+      },
+      "devDependencies": {
+        "@types/bun": "^1.3.0",
       },
     },
     "packages/graphql-client": {
@@ -689,6 +708,8 @@
 
     "@ready-for-agent/db-schema": ["@ready-for-agent/db-schema@workspace:packages/db-schema"],
 
+    "@ready-for-agent/db-service": ["@ready-for-agent/db-service@workspace:packages/db-service"],
+
     "@ready-for-agent/graphql-client": ["@ready-for-agent/graphql-client@workspace:packages/graphql-client"],
 
     "@ready-for-agent/graphql-schema": ["@ready-for-agent/graphql-schema@workspace:packages/graphql-schema"],
@@ -1045,7 +1066,7 @@
 
     "eastasianwidth": ["eastasianwidth@0.2.0", "", {}, "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA=="],
 
-    "effect": ["effect@4.0.0-beta.97", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "fast-check": "^4.9.0", "find-my-way-ts": "^0.1.6", "ini": "^7.0.0", "kubernetes-types": "^1.30.0", "msgpackr": "^2.0.4", "multipasta": "^0.2.8", "toml": "^4.1.2", "uuid": "^14.0.1", "yaml": "^2.9.0" } }, "sha512-pK03HpQVxGZOWdwDAy/iwvV8u3KYcUf2mOWyWqaut2zau8V2u6ejWP7b4BELjyUIiZWW1fl/s/VJpgZUcTjThg=="],
+    "effect": ["effect@3.21.4", "", { "dependencies": { "@standard-schema/spec": "^1.0.0", "fast-check": "^3.23.1" } }, "sha512-B89v/xSgPbl1J2Ai2u18jxq3odpFauU1rC6/eSs4FeNHi72kwKdJp12VGigvRV2lK+kRnx+OOz41XV8guZd4gQ=="],
 
     "effect-solutions": ["effect-solutions@0.5.3", "", { "dependencies": { "@effect/platform-bun": "4.0.0-beta.59", "effect": "4.0.0-beta.59", "gray-matter": "^4.0.3", "picocolors": "^1.1.1" }, "bin": { "effect-solutions": "bin.js" } }, "sha512-JIG7XV0gJF5eVV+9un5Yp7MEFMGNfuTYxbiV/HzS80zH/9qx9ZOoXd6Mlw0FXdbC41LGcpWYZJG3MnzxYawEWg=="],
 
@@ -1091,7 +1112,7 @@
 
     "extend-shallow": ["extend-shallow@2.0.1", "", { "dependencies": { "is-extendable": "^0.1.0" } }, "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug=="],
 
-    "fast-check": ["fast-check@4.9.0", "", { "dependencies": { "pure-rand": "^8.0.0" } }, "sha512-7ms6T7SybUev/PQITciI0yLM2pOSFy5zpG8Ty7tQofcVaQUvrMXp6CBwqF6fThLCLOrfBtuHAtwq6Yu4XPCllg=="],
+    "fast-check": ["fast-check@3.23.2", "", { "dependencies": { "pure-rand": "^6.1.0" } }, "sha512-h5+1OzzfCC3Ef7VbtKdcv7zsstUQwUDlYpUTvjeUsJAssPgLn7QzbboPtL5ro04Mq0rPOsMzl7q5hIbRs2wD1A=="],
 
     "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
 
@@ -1361,7 +1382,7 @@
 
     "proxy-from-env": ["proxy-from-env@2.1.0", "", {}, "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA=="],
 
-    "pure-rand": ["pure-rand@8.4.1", "", {}, "sha512-c58R2+SPFcSIPXoU834QN/KPDDOSd8sXcSrqf6e83Me6Rrp1EYkxukkjXMVrKvKaADs1SOyNkWdfvLf6zY8qLQ=="],
+    "pure-rand": ["pure-rand@6.1.0", "", {}, "sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA=="],
 
     "qs": ["qs@6.15.3", "", { "dependencies": { "es-define-property": "^1.0.1", "side-channel": "^1.1.1" } }, "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A=="],
 
@@ -1585,21 +1606,15 @@
 
     "@babel/preset-env/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
-    "@effect/experimental/effect": ["effect@3.21.4", "", { "dependencies": { "@standard-schema/spec": "^1.0.0", "fast-check": "^3.23.1" } }, "sha512-B89v/xSgPbl1J2Ai2u18jxq3odpFauU1rC6/eSs4FeNHi72kwKdJp12VGigvRV2lK+kRnx+OOz41XV8guZd4gQ=="],
-
     "@effect/experimental/uuid": ["uuid@11.1.1", "", { "bin": { "uuid": "dist/esm/bin/uuid" } }, "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ=="],
-
-    "@effect/platform/effect": ["effect@3.21.4", "", { "dependencies": { "@standard-schema/spec": "^1.0.0", "fast-check": "^3.23.1" } }, "sha512-B89v/xSgPbl1J2Ai2u18jxq3odpFauU1rC6/eSs4FeNHi72kwKdJp12VGigvRV2lK+kRnx+OOz41XV8guZd4gQ=="],
 
     "@effect/platform/msgpackr": ["msgpackr@1.12.1", "", { "optionalDependencies": { "msgpackr-extract": "^3.0.2" } }, "sha512-4EUH9tQHnMmEgzW/MdAP0KIfa1T9AF+htl0ffe2n5vb2EKn9y2co8ccpgWko6S52Jy1PQZKwRnx5/KkYjtd9MQ=="],
 
-    "@effect/sql/effect": ["effect@3.21.4", "", { "dependencies": { "@standard-schema/spec": "^1.0.0", "fast-check": "^3.23.1" } }, "sha512-B89v/xSgPbl1J2Ai2u18jxq3odpFauU1rC6/eSs4FeNHi72kwKdJp12VGigvRV2lK+kRnx+OOz41XV8guZd4gQ=="],
+    "@effect/platform-bun/effect": ["effect@4.0.0-beta.97", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "fast-check": "^4.9.0", "find-my-way-ts": "^0.1.6", "ini": "^7.0.0", "kubernetes-types": "^1.30.0", "msgpackr": "^2.0.4", "multipasta": "^0.2.8", "toml": "^4.1.2", "uuid": "^14.0.1", "yaml": "^2.9.0" } }, "sha512-pK03HpQVxGZOWdwDAy/iwvV8u3KYcUf2mOWyWqaut2zau8V2u6ejWP7b4BELjyUIiZWW1fl/s/VJpgZUcTjThg=="],
+
+    "@effect/platform-node-shared/effect": ["effect@4.0.0-beta.97", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "fast-check": "^4.9.0", "find-my-way-ts": "^0.1.6", "ini": "^7.0.0", "kubernetes-types": "^1.30.0", "msgpackr": "^2.0.4", "multipasta": "^0.2.8", "toml": "^4.1.2", "uuid": "^14.0.1", "yaml": "^2.9.0" } }, "sha512-pK03HpQVxGZOWdwDAy/iwvV8u3KYcUf2mOWyWqaut2zau8V2u6ejWP7b4BELjyUIiZWW1fl/s/VJpgZUcTjThg=="],
 
     "@effect/sql/uuid": ["uuid@11.1.1", "", { "bin": { "uuid": "dist/esm/bin/uuid" } }, "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ=="],
-
-    "@effect/sql-drizzle/effect": ["effect@3.21.4", "", { "dependencies": { "@standard-schema/spec": "^1.0.0", "fast-check": "^3.23.1" } }, "sha512-B89v/xSgPbl1J2Ai2u18jxq3odpFauU1rC6/eSs4FeNHi72kwKdJp12VGigvRV2lK+kRnx+OOz41XV8guZd4gQ=="],
-
-    "@effect/sql-sqlite-bun/effect": ["effect@3.21.4", "", { "dependencies": { "@standard-schema/spec": "^1.0.0", "fast-check": "^3.23.1" } }, "sha512-B89v/xSgPbl1J2Ai2u18jxq3odpFauU1rC6/eSs4FeNHi72kwKdJp12VGigvRV2lK+kRnx+OOz41XV8guZd4gQ=="],
 
     "@genql/cli/yargs": ["yargs@15.4.1", "", { "dependencies": { "cliui": "^6.0.0", "decamelize": "^1.2.0", "find-up": "^4.1.0", "get-caller-file": "^2.0.1", "require-directory": "^2.1.1", "require-main-filename": "^2.0.0", "set-blocking": "^2.0.0", "string-width": "^4.2.0", "which-module": "^2.0.0", "y18n": "^4.0.0", "yargs-parser": "^18.1.2" } }, "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A=="],
 
@@ -1629,15 +1644,7 @@
 
     "@oxc-resolver/binding-wasm32-wasi/@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@1.1.6", "", { "dependencies": { "@tybys/wasm-util": "^0.10.3" }, "peerDependencies": { "@emnapi/core": "^1.7.1", "@emnapi/runtime": "^1.7.1" } }, "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg=="],
 
-    "@ready-for-agent/db/effect": ["effect@3.21.4", "", { "dependencies": { "@standard-schema/spec": "^1.0.0", "fast-check": "^3.23.1" } }, "sha512-B89v/xSgPbl1J2Ai2u18jxq3odpFauU1rC6/eSs4FeNHi72kwKdJp12VGigvRV2lK+kRnx+OOz41XV8guZd4gQ=="],
-
-    "@ready-for-agent/db-schema/effect": ["effect@3.21.4", "", { "dependencies": { "@standard-schema/spec": "^1.0.0", "fast-check": "^3.23.1" } }, "sha512-B89v/xSgPbl1J2Ai2u18jxq3odpFauU1rC6/eSs4FeNHi72kwKdJp12VGigvRV2lK+kRnx+OOz41XV8guZd4gQ=="],
-
-    "@ready-for-agent/layer-turso-local/effect": ["effect@3.21.4", "", { "dependencies": { "@standard-schema/spec": "^1.0.0", "fast-check": "^3.23.1" } }, "sha512-B89v/xSgPbl1J2Ai2u18jxq3odpFauU1rC6/eSs4FeNHi72kwKdJp12VGigvRV2lK+kRnx+OOz41XV8guZd4gQ=="],
-
-    "@ready-for-agent/queue-service/effect": ["effect@3.21.4", "", { "dependencies": { "@standard-schema/spec": "^1.0.0", "fast-check": "^3.23.1" } }, "sha512-B89v/xSgPbl1J2Ai2u18jxq3odpFauU1rC6/eSs4FeNHi72kwKdJp12VGigvRV2lK+kRnx+OOz41XV8guZd4gQ=="],
-
-    "@ready-for-agent/sqlite-queue-service/effect": ["effect@3.21.4", "", { "dependencies": { "@standard-schema/spec": "^1.0.0", "fast-check": "^3.23.1" } }, "sha512-B89v/xSgPbl1J2Ai2u18jxq3odpFauU1rC6/eSs4FeNHi72kwKdJp12VGigvRV2lK+kRnx+OOz41XV8guZd4gQ=="],
+    "@ready-for-agent/cli/effect": ["effect@4.0.0-beta.97", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "fast-check": "^4.9.0", "find-my-way-ts": "^0.1.6", "ini": "^7.0.0", "kubernetes-types": "^1.30.0", "msgpackr": "^2.0.4", "multipasta": "^0.2.8", "toml": "^4.1.2", "uuid": "^14.0.1", "yaml": "^2.9.0" } }, "sha512-pK03HpQVxGZOWdwDAy/iwvV8u3KYcUf2mOWyWqaut2zau8V2u6ejWP7b4BELjyUIiZWW1fl/s/VJpgZUcTjThg=="],
 
     "@tanstack/router-generator/prettier": ["prettier@3.9.5", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-/FVl766LpUfB5vXgCYOYa0MeV/441Ia99AeICQIQFTY/Nw0roZwULcXpku5i1/m5kt/baz+s4Zogspd839HSMg=="],
 
@@ -1654,6 +1661,8 @@
     "cosmiconfig/js-yaml": ["js-yaml@4.3.0", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q=="],
 
     "cosmiconfig-typescript-loader/jiti": ["jiti@2.6.1", "", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ=="],
+
+    "drizzle-orm/effect": ["effect@4.0.0-beta.97", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "fast-check": "^4.9.0", "find-my-way-ts": "^0.1.6", "ini": "^7.0.0", "kubernetes-types": "^1.30.0", "msgpackr": "^2.0.4", "multipasta": "^0.2.8", "toml": "^4.1.2", "uuid": "^14.0.1", "yaml": "^2.9.0" } }, "sha512-pK03HpQVxGZOWdwDAy/iwvV8u3KYcUf2mOWyWqaut2zau8V2u6ejWP7b4BELjyUIiZWW1fl/s/VJpgZUcTjThg=="],
 
     "effect-solutions/@effect/platform-bun": ["@effect/platform-bun@4.0.0-beta.59", "", { "dependencies": { "@effect/platform-node-shared": "^4.0.0-beta.59" }, "peerDependencies": { "effect": "^4.0.0-beta.59" } }, "sha512-1jXCIx34X80ojiK9ACO9Q7RST9CXudRmlAbsP4kPqjUo6aqOuGSWXq9ueBO4LbaIZiioRxtTciom35U9ldfTkQ=="],
 
@@ -1703,15 +1712,9 @@
 
     "yargs/yargs-parser": ["yargs-parser@22.0.0", "", {}, "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw=="],
 
-    "@effect/experimental/effect/fast-check": ["fast-check@3.23.2", "", { "dependencies": { "pure-rand": "^6.1.0" } }, "sha512-h5+1OzzfCC3Ef7VbtKdcv7zsstUQwUDlYpUTvjeUsJAssPgLn7QzbboPtL5ro04Mq0rPOsMzl7q5hIbRs2wD1A=="],
+    "@effect/platform-bun/effect/fast-check": ["fast-check@4.9.0", "", { "dependencies": { "pure-rand": "^8.0.0" } }, "sha512-7ms6T7SybUev/PQITciI0yLM2pOSFy5zpG8Ty7tQofcVaQUvrMXp6CBwqF6fThLCLOrfBtuHAtwq6Yu4XPCllg=="],
 
-    "@effect/platform/effect/fast-check": ["fast-check@3.23.2", "", { "dependencies": { "pure-rand": "^6.1.0" } }, "sha512-h5+1OzzfCC3Ef7VbtKdcv7zsstUQwUDlYpUTvjeUsJAssPgLn7QzbboPtL5ro04Mq0rPOsMzl7q5hIbRs2wD1A=="],
-
-    "@effect/sql-drizzle/effect/fast-check": ["fast-check@3.23.2", "", { "dependencies": { "pure-rand": "^6.1.0" } }, "sha512-h5+1OzzfCC3Ef7VbtKdcv7zsstUQwUDlYpUTvjeUsJAssPgLn7QzbboPtL5ro04Mq0rPOsMzl7q5hIbRs2wD1A=="],
-
-    "@effect/sql-sqlite-bun/effect/fast-check": ["fast-check@3.23.2", "", { "dependencies": { "pure-rand": "^6.1.0" } }, "sha512-h5+1OzzfCC3Ef7VbtKdcv7zsstUQwUDlYpUTvjeUsJAssPgLn7QzbboPtL5ro04Mq0rPOsMzl7q5hIbRs2wD1A=="],
-
-    "@effect/sql/effect/fast-check": ["fast-check@3.23.2", "", { "dependencies": { "pure-rand": "^6.1.0" } }, "sha512-h5+1OzzfCC3Ef7VbtKdcv7zsstUQwUDlYpUTvjeUsJAssPgLn7QzbboPtL5ro04Mq0rPOsMzl7q5hIbRs2wD1A=="],
+    "@effect/platform-node-shared/effect/fast-check": ["fast-check@4.9.0", "", { "dependencies": { "pure-rand": "^8.0.0" } }, "sha512-7ms6T7SybUev/PQITciI0yLM2pOSFy5zpG8Ty7tQofcVaQUvrMXp6CBwqF6fThLCLOrfBtuHAtwq6Yu4XPCllg=="],
 
     "@genql/cli/yargs/cliui": ["cliui@6.0.0", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.0", "wrap-ansi": "^6.2.0" } }, "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ=="],
 
@@ -1729,21 +1732,17 @@
 
     "@oxc-resolver/binding-wasm32-wasi/@napi-rs/wasm-runtime/@tybys/wasm-util": ["@tybys/wasm-util@0.10.3", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg=="],
 
-    "@ready-for-agent/db-schema/effect/fast-check": ["fast-check@3.23.2", "", { "dependencies": { "pure-rand": "^6.1.0" } }, "sha512-h5+1OzzfCC3Ef7VbtKdcv7zsstUQwUDlYpUTvjeUsJAssPgLn7QzbboPtL5ro04Mq0rPOsMzl7q5hIbRs2wD1A=="],
-
-    "@ready-for-agent/db/effect/fast-check": ["fast-check@3.23.2", "", { "dependencies": { "pure-rand": "^6.1.0" } }, "sha512-h5+1OzzfCC3Ef7VbtKdcv7zsstUQwUDlYpUTvjeUsJAssPgLn7QzbboPtL5ro04Mq0rPOsMzl7q5hIbRs2wD1A=="],
-
-    "@ready-for-agent/layer-turso-local/effect/fast-check": ["fast-check@3.23.2", "", { "dependencies": { "pure-rand": "^6.1.0" } }, "sha512-h5+1OzzfCC3Ef7VbtKdcv7zsstUQwUDlYpUTvjeUsJAssPgLn7QzbboPtL5ro04Mq0rPOsMzl7q5hIbRs2wD1A=="],
-
-    "@ready-for-agent/queue-service/effect/fast-check": ["fast-check@3.23.2", "", { "dependencies": { "pure-rand": "^6.1.0" } }, "sha512-h5+1OzzfCC3Ef7VbtKdcv7zsstUQwUDlYpUTvjeUsJAssPgLn7QzbboPtL5ro04Mq0rPOsMzl7q5hIbRs2wD1A=="],
-
-    "@ready-for-agent/sqlite-queue-service/effect/fast-check": ["fast-check@3.23.2", "", { "dependencies": { "pure-rand": "^6.1.0" } }, "sha512-h5+1OzzfCC3Ef7VbtKdcv7zsstUQwUDlYpUTvjeUsJAssPgLn7QzbboPtL5ro04Mq0rPOsMzl7q5hIbRs2wD1A=="],
+    "@ready-for-agent/cli/effect/fast-check": ["fast-check@4.9.0", "", { "dependencies": { "pure-rand": "^8.0.0" } }, "sha512-7ms6T7SybUev/PQITciI0yLM2pOSFy5zpG8Ty7tQofcVaQUvrMXp6CBwqF6fThLCLOrfBtuHAtwq6Yu4XPCllg=="],
 
     "babel-plugin-macros/cosmiconfig/yaml": ["yaml@1.10.3", "", {}, "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA=="],
 
     "cli-truncate/string-width/emoji-regex": ["emoji-regex@9.2.2", "", {}, "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="],
 
     "cli-truncate/string-width/strip-ansi": ["strip-ansi@7.2.0", "", { "dependencies": { "ansi-regex": "^6.2.2" } }, "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w=="],
+
+    "drizzle-orm/effect/fast-check": ["fast-check@4.9.0", "", { "dependencies": { "pure-rand": "^8.0.0" } }, "sha512-7ms6T7SybUev/PQITciI0yLM2pOSFy5zpG8Ty7tQofcVaQUvrMXp6CBwqF6fThLCLOrfBtuHAtwq6Yu4XPCllg=="],
+
+    "effect-solutions/effect/fast-check": ["fast-check@4.9.0", "", { "dependencies": { "pure-rand": "^8.0.0" } }, "sha512-7ms6T7SybUev/PQITciI0yLM2pOSFy5zpG8Ty7tQofcVaQUvrMXp6CBwqF6fThLCLOrfBtuHAtwq6Yu4XPCllg=="],
 
     "effect-solutions/effect/ini": ["ini@6.0.0", "", {}, "sha512-IBTdIkzZNOpqm7q3dRqJvMaldXjDHWkEDfrwGEQTs5eaQMWV+djAhR+wahyNNMAa+qpbDUhBMVt4ZKNwpPm7xQ=="],
 
@@ -1879,29 +1878,19 @@
 
     "yargs/string-width/strip-ansi": ["strip-ansi@7.2.0", "", { "dependencies": { "ansi-regex": "^6.2.2" } }, "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w=="],
 
-    "@effect/experimental/effect/fast-check/pure-rand": ["pure-rand@6.1.0", "", {}, "sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA=="],
+    "@effect/platform-bun/effect/fast-check/pure-rand": ["pure-rand@8.4.1", "", {}, "sha512-c58R2+SPFcSIPXoU834QN/KPDDOSd8sXcSrqf6e83Me6Rrp1EYkxukkjXMVrKvKaADs1SOyNkWdfvLf6zY8qLQ=="],
 
-    "@effect/platform/effect/fast-check/pure-rand": ["pure-rand@6.1.0", "", {}, "sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA=="],
-
-    "@effect/sql-drizzle/effect/fast-check/pure-rand": ["pure-rand@6.1.0", "", {}, "sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA=="],
-
-    "@effect/sql-sqlite-bun/effect/fast-check/pure-rand": ["pure-rand@6.1.0", "", {}, "sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA=="],
-
-    "@effect/sql/effect/fast-check/pure-rand": ["pure-rand@6.1.0", "", {}, "sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA=="],
+    "@effect/platform-node-shared/effect/fast-check/pure-rand": ["pure-rand@8.4.1", "", {}, "sha512-c58R2+SPFcSIPXoU834QN/KPDDOSd8sXcSrqf6e83Me6Rrp1EYkxukkjXMVrKvKaADs1SOyNkWdfvLf6zY8qLQ=="],
 
     "@genql/cli/yargs/cliui/wrap-ansi": ["wrap-ansi@6.2.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA=="],
 
-    "@ready-for-agent/db-schema/effect/fast-check/pure-rand": ["pure-rand@6.1.0", "", {}, "sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA=="],
-
-    "@ready-for-agent/db/effect/fast-check/pure-rand": ["pure-rand@6.1.0", "", {}, "sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA=="],
-
-    "@ready-for-agent/layer-turso-local/effect/fast-check/pure-rand": ["pure-rand@6.1.0", "", {}, "sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA=="],
-
-    "@ready-for-agent/queue-service/effect/fast-check/pure-rand": ["pure-rand@6.1.0", "", {}, "sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA=="],
-
-    "@ready-for-agent/sqlite-queue-service/effect/fast-check/pure-rand": ["pure-rand@6.1.0", "", {}, "sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA=="],
+    "@ready-for-agent/cli/effect/fast-check/pure-rand": ["pure-rand@8.4.1", "", {}, "sha512-c58R2+SPFcSIPXoU834QN/KPDDOSd8sXcSrqf6e83Me6Rrp1EYkxukkjXMVrKvKaADs1SOyNkWdfvLf6zY8qLQ=="],
 
     "cli-truncate/string-width/strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
+
+    "drizzle-orm/effect/fast-check/pure-rand": ["pure-rand@8.4.1", "", {}, "sha512-c58R2+SPFcSIPXoU834QN/KPDDOSd8sXcSrqf6e83Me6Rrp1EYkxukkjXMVrKvKaADs1SOyNkWdfvLf6zY8qLQ=="],
+
+    "effect-solutions/effect/fast-check/pure-rand": ["pure-rand@8.4.1", "", {}, "sha512-c58R2+SPFcSIPXoU834QN/KPDDOSd8sXcSrqf6e83Me6Rrp1EYkxukkjXMVrKvKaADs1SOyNkWdfvLf6zY8qLQ=="],
 
     "glob/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
 

--- a/knip.json
+++ b/knip.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://unpkg.com/knip@5/schema.json",
-  "ignoreDependencies": ["@swc/helpers", "nx"],
+  "ignoreDependencies": ["@swc/helpers", "nx", "tslib"],
   "ignoreBinaries": ["skills"],
   "workspaces": {
     "apps/api": {
@@ -19,6 +19,10 @@
         "src/generated/schema.ts",
         "src/generated/types.ts"
       ]
+    },
+    "packages/db": {
+      "entry": ["src/bin/migrate.ts"],
+      "project": ["src/**/*.{ts,tsx}"]
     },
     "packages/*": {
       "entry": ["src/index.ts", "test/**/*.{test,spec}.ts"],

--- a/packages/db-schema/src/schema.ts
+++ b/packages/db-schema/src/schema.ts
@@ -13,7 +13,7 @@ export const repository = snakeCase.table(
   {
     id: text()
       .primaryKey()
-      .$defaultFn(() => ulid()),
+      .$defaultFn(() => `repo-${ulid()}`),
     githubOwner: text().notNull(),
     githubRepo: text().notNull(),
     localPath: text().notNull().unique(),

--- a/packages/db-service/package.json
+++ b/packages/db-service/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@ready-for-agent/db",
+  "name": "@ready-for-agent/db-service",
   "version": "0.0.1",
   "private": true,
   "type": "module",
@@ -13,25 +13,18 @@
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
       "default": "./dist/index.js"
-    },
-    "./test": {
-      "@ready-for-agent/source": "./src/lib/database-test.ts",
-      "types": "./dist/lib/database-test.d.ts",
-      "import": "./dist/lib/database-test.js",
-      "default": "./dist/lib/database-test.js"
     }
   },
   "dependencies": {
     "@effect/sql": "^0.51.1",
-    "@effect/sql-drizzle": "^0.50.0",
+    "@ready-for-agent/db": "workspace:*",
     "@ready-for-agent/db-schema": "workspace:*",
-    "@ready-for-agent/layer-turso-local": "workspace:*",
     "drizzle-orm": "1.0.0-rc.4-5d5b77c",
     "effect": "^3.21.4",
-    "tslib": "^2.3.0"
+    "tslib": "^2.3.0",
+    "ulidx": "^2.4.1"
   },
   "devDependencies": {
-    "@effect/sql-sqlite-bun": "^0.52.0",
     "@types/bun": "^1.3.0"
   }
 }

--- a/packages/db-service/project.json
+++ b/packages/db-service/project.json
@@ -1,0 +1,16 @@
+{
+  "name": "db-service",
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "targets": {
+    "test": {
+      "executor": "nx:run-commands",
+      "options": {
+        "cwd": "{projectRoot}",
+        "command": "bun test"
+      },
+      "inputs": ["default", "^production"],
+      "cache": true,
+      "dependsOn": ["^build"]
+    }
+  }
+}

--- a/packages/db-service/src/index.ts
+++ b/packages/db-service/src/index.ts
@@ -1,0 +1,3 @@
+export * from "./lib/db-service.js"
+export * from "./lib/errors.js"
+export * from "./lib/types.js"

--- a/packages/db-service/src/lib/db-service.ts
+++ b/packages/db-service/src/lib/db-service.ts
@@ -1,0 +1,211 @@
+import type { SqlError } from "@effect/sql/SqlError"
+import { and, eq, sql } from "drizzle-orm"
+import { Context, Effect, Layer } from "effect"
+import { ulid } from "ulidx"
+import { TypedSqliteDrizzle, runDrizzle } from "@ready-for-agent/db"
+import * as schema from "@ready-for-agent/db-schema"
+import {
+  DatabaseError,
+  InvalidRepositoryInputError,
+  LocalPathInUseError,
+  RepositoryAlreadyExistsError,
+} from "./errors.js"
+import type { AddRepositoryInput, RepositoryRecord } from "./types.js"
+
+const formatSqlError = (error: SqlError): string => {
+  const parts: string[] = [error.message]
+
+  let current: unknown = error.cause
+  while (current) {
+    if (current instanceof Error) {
+      parts.push(current.message)
+      current = current.cause
+    } else if (typeof current === "object" && current !== null) {
+      const obj = current as Record<string, unknown>
+      if ("message" in obj && typeof obj["message"] === "string") {
+        parts.push(obj["message"])
+      }
+      current = "cause" in obj ? obj["cause"] : undefined
+    } else if (typeof current === "string") {
+      parts.push(current)
+      break
+    } else {
+      break
+    }
+  }
+
+  return parts.join(" -> ")
+}
+
+const isUniqueConstraint = (error: SqlError): boolean => {
+  const message = formatSqlError(error).toLowerCase()
+  return (
+    message.includes("unique") ||
+    message.includes("constraint") ||
+    message.includes("sqlite_constraint")
+  )
+}
+
+const trimRequired = (
+  value: string,
+  field: "githubOwner" | "githubRepo" | "localPath",
+): Effect.Effect<string, InvalidRepositoryInputError> => {
+  const trimmed = value.trim()
+  if (trimmed.length === 0) {
+    return Effect.fail(
+      new InvalidRepositoryInputError({
+        field,
+        message: `${field} cannot be empty`,
+      }),
+    )
+  }
+  return Effect.succeed(trimmed)
+}
+
+const toRecord = (row: {
+  id: string
+  githubOwner: string
+  githubRepo: string
+  localPath: string
+  isBare: boolean
+  paused: boolean
+}): RepositoryRecord => ({
+  id: row.id,
+  githubOwner: row.githubOwner,
+  githubRepo: row.githubRepo,
+  localPath: row.localPath,
+  isBare: row.isBare,
+  paused: row.paused,
+})
+
+const toDatabaseError = (error: SqlError) =>
+  new DatabaseError({
+    message: `Database error: ${formatSqlError(error)}`,
+    cause: error,
+  })
+
+export interface DbServiceShape {
+  readonly addRepository: (
+    input: AddRepositoryInput,
+  ) => Effect.Effect<
+    RepositoryRecord,
+    | InvalidRepositoryInputError
+    | RepositoryAlreadyExistsError
+    | LocalPathInUseError
+    | DatabaseError
+  >
+}
+
+export class DbService extends Context.Tag(
+  "@ready-for-agent/db-service/DbService",
+)<DbService, DbServiceShape>() {}
+
+export const DbServiceLive = Layer.effect(
+  DbService,
+  Effect.gen(function* () {
+    const db = yield* TypedSqliteDrizzle
+
+    const addRepository = (
+      input: AddRepositoryInput,
+    ): Effect.Effect<
+      RepositoryRecord,
+      | InvalidRepositoryInputError
+      | RepositoryAlreadyExistsError
+      | LocalPathInUseError
+      | DatabaseError
+    > =>
+      Effect.gen(function* () {
+        const githubOwner = yield* trimRequired(
+          input.githubOwner,
+          "githubOwner",
+        )
+        const githubRepo = yield* trimRequired(input.githubRepo, "githubRepo")
+        const localPath = yield* trimRequired(input.localPath, "localPath")
+        const now = Date.now()
+        const id = `repo-${ulid()}`
+
+        const existingByGithub = yield* runDrizzle(
+          db
+            .select({ id: schema.repository.id })
+            .from(schema.repository)
+            .where(
+              and(
+                sql`lower(${schema.repository.githubOwner}) = ${githubOwner.toLowerCase()}`,
+                sql`lower(${schema.repository.githubRepo}) = ${githubRepo.toLowerCase()}`,
+              ),
+            )
+            .limit(1),
+        ).pipe(Effect.mapError(toDatabaseError))
+
+        if (existingByGithub[0]) {
+          return yield* new RepositoryAlreadyExistsError({
+            githubOwner,
+            githubRepo,
+          })
+        }
+
+        const existingByPath = yield* runDrizzle(
+          db
+            .select({ id: schema.repository.id })
+            .from(schema.repository)
+            .where(eq(schema.repository.localPath, localPath))
+            .limit(1),
+        ).pipe(Effect.mapError(toDatabaseError))
+
+        if (existingByPath[0]) {
+          return yield* new LocalPathInUseError({ localPath })
+        }
+
+        const result = yield* runDrizzle(
+          db
+            .insert(schema.repository)
+            .values({
+              id,
+              githubOwner,
+              githubRepo,
+              localPath,
+              isBare: input.isBare,
+              paused: true,
+              createdAt: now,
+              updatedAt: now,
+            })
+            .returning({
+              id: schema.repository.id,
+              githubOwner: schema.repository.githubOwner,
+              githubRepo: schema.repository.githubRepo,
+              localPath: schema.repository.localPath,
+              isBare: schema.repository.isBare,
+              paused: schema.repository.paused,
+            }),
+        ).pipe(
+          Effect.mapError((error: SqlError) => {
+            if (isUniqueConstraint(error)) {
+              const message = formatSqlError(error).toLowerCase()
+              if (
+                message.includes("local_path") ||
+                message.includes("localpath")
+              ) {
+                return new LocalPathInUseError({ localPath })
+              }
+              return new RepositoryAlreadyExistsError({
+                githubOwner,
+                githubRepo,
+              })
+            }
+            return toDatabaseError(error)
+          }),
+        )
+
+        const row = result[0]
+        if (!row) {
+          return yield* new DatabaseError({
+            message: "No repository returned from insert",
+          })
+        }
+
+        return toRecord(row)
+      })
+
+    return DbService.of({ addRepository })
+  }),
+)

--- a/packages/db-service/src/lib/errors.ts
+++ b/packages/db-service/src/lib/errors.ts
@@ -1,0 +1,26 @@
+import { Data } from "effect"
+
+export class InvalidRepositoryInputError extends Data.TaggedError(
+  "InvalidRepositoryInputError",
+)<{
+  readonly field: "githubOwner" | "githubRepo" | "localPath"
+  readonly message: string
+}> {}
+
+export class RepositoryAlreadyExistsError extends Data.TaggedError(
+  "RepositoryAlreadyExistsError",
+)<{
+  readonly githubOwner: string
+  readonly githubRepo: string
+}> {}
+
+export class LocalPathInUseError extends Data.TaggedError(
+  "LocalPathInUseError",
+)<{
+  readonly localPath: string
+}> {}
+
+export class DatabaseError extends Data.TaggedError("DatabaseError")<{
+  readonly message: string
+  readonly cause?: unknown
+}> {}

--- a/packages/db-service/src/lib/types.ts
+++ b/packages/db-service/src/lib/types.ts
@@ -1,0 +1,15 @@
+export interface AddRepositoryInput {
+  readonly githubOwner: string
+  readonly githubRepo: string
+  readonly localPath: string
+  readonly isBare: boolean
+}
+
+export interface RepositoryRecord {
+  readonly id: string
+  readonly githubOwner: string
+  readonly githubRepo: string
+  readonly localPath: string
+  readonly isBare: boolean
+  readonly paused: boolean
+}

--- a/packages/db-service/test/db-service.spec.ts
+++ b/packages/db-service/test/db-service.spec.ts
@@ -1,0 +1,144 @@
+import { Effect, Either, Layer } from "effect"
+import { DatabaseTest } from "@ready-for-agent/db/test"
+import {
+  DbService,
+  DbServiceLive,
+  InvalidRepositoryInputError,
+  LocalPathInUseError,
+  RepositoryAlreadyExistsError,
+} from "../src/index.js"
+import { describe, expect, it } from "bun:test"
+
+describe("DbService", () => {
+  const TestLayer = DbServiceLive.pipe(Layer.provideMerge(DatabaseTest))
+
+  type TestRequirements = Layer.Layer.Success<typeof TestLayer>
+
+  const runTest = <A, E>(
+    test: Effect.Effect<A, E, TestRequirements>,
+  ): Promise<A> => Effect.runPromise(Effect.provide(test, TestLayer))
+
+  const sampleInput = {
+    githubOwner: "acme",
+    githubRepo: "widgets",
+    localPath: "/repos/acme/widgets.git",
+    isBare: true,
+  }
+
+  describe("addRepository", () => {
+    it("inserts a repository paused with a repo- prefixed id", () =>
+      runTest(
+        Effect.gen(function* () {
+          const db = yield* DbService
+          const repo = yield* db.addRepository(sampleInput)
+
+          expect(repo.id.startsWith("repo-")).toBe(true)
+          expect(repo.githubOwner).toBe("acme")
+          expect(repo.githubRepo).toBe("widgets")
+          expect(repo.localPath).toBe("/repos/acme/widgets.git")
+          expect(repo.isBare).toBe(true)
+          expect(repo.paused).toBe(true)
+        }),
+      ))
+
+    it("trims input fields", () =>
+      runTest(
+        Effect.gen(function* () {
+          const db = yield* DbService
+          const repo = yield* db.addRepository({
+            githubOwner: "  acme  ",
+            githubRepo: "  widgets  ",
+            localPath: "  /repos/acme/widgets.git  ",
+            isBare: false,
+          })
+
+          expect(repo.githubOwner).toBe("acme")
+          expect(repo.githubRepo).toBe("widgets")
+          expect(repo.localPath).toBe("/repos/acme/widgets.git")
+          expect(repo.isBare).toBe(false)
+          expect(repo.paused).toBe(true)
+        }),
+      ))
+
+    it("rejects empty fields", () =>
+      runTest(
+        Effect.gen(function* () {
+          const db = yield* DbService
+          const result = yield* Effect.either(
+            db.addRepository({
+              ...sampleInput,
+              githubOwner: "   ",
+            }),
+          )
+
+          expect(Either.isLeft(result)).toBe(true)
+          if (Either.isLeft(result)) {
+            expect(result.left).toBeInstanceOf(InvalidRepositoryInputError)
+            if (result.left instanceof InvalidRepositoryInputError) {
+              expect(result.left.field).toBe("githubOwner")
+            }
+          }
+        }),
+      ))
+
+    it("fails when github identity already exists (case-insensitive)", () =>
+      runTest(
+        Effect.gen(function* () {
+          const db = yield* DbService
+          yield* db.addRepository(sampleInput)
+
+          const result = yield* Effect.either(
+            db.addRepository({
+              ...sampleInput,
+              githubOwner: "Acme",
+              githubRepo: "Widgets",
+              localPath: "/other/path",
+            }),
+          )
+
+          expect(Either.isLeft(result)).toBe(true)
+          if (Either.isLeft(result)) {
+            expect(result.left).toBeInstanceOf(RepositoryAlreadyExistsError)
+          }
+        }),
+      ))
+
+    it("fails when local path is already in use", () =>
+      runTest(
+        Effect.gen(function* () {
+          const db = yield* DbService
+          yield* db.addRepository(sampleInput)
+
+          const result = yield* Effect.either(
+            db.addRepository({
+              githubOwner: "other",
+              githubRepo: "repo",
+              localPath: sampleInput.localPath,
+              isBare: true,
+            }),
+          )
+
+          expect(Either.isLeft(result)).toBe(true)
+          if (Either.isLeft(result)) {
+            expect(result.left).toBeInstanceOf(LocalPathInUseError)
+          }
+        }),
+      ))
+
+    it("preserves display casing of owner and repo", () =>
+      runTest(
+        Effect.gen(function* () {
+          const db = yield* DbService
+          const repo = yield* db.addRepository({
+            githubOwner: "AcmeCorp",
+            githubRepo: "MyWidgets",
+            localPath: "/repos/AcmeCorp/MyWidgets",
+            isBare: false,
+          })
+
+          expect(repo.githubOwner).toBe("AcmeCorp")
+          expect(repo.githubRepo).toBe("MyWidgets")
+        }),
+      ))
+  })
+})

--- a/packages/db-service/tsconfig.json
+++ b/packages/db-service/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ]
+}

--- a/packages/db-service/tsconfig.lib.json
+++ b/packages/db-service/tsconfig.lib.json
@@ -1,0 +1,20 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "tsBuildInfoFile": "dist/tsconfig.lib.tsbuildinfo",
+    "emitDeclarationOnly": false,
+    "forceConsistentCasingInFileNames": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"],
+  "references": [
+    {
+      "path": "../db/tsconfig.lib.json"
+    },
+    {
+      "path": "../db-schema/tsconfig.lib.json"
+    }
+  ]
+}

--- a/packages/db/project.json
+++ b/packages/db/project.json
@@ -6,7 +6,7 @@
       "executor": "nx:run-commands",
       "options": {
         "cwd": "{projectRoot}",
-        "command": "bun --conditions @ready-for-agent/source src/bin/migrate.ts"
+        "command": "mkdir -p ../../tmp && SQLITE_DATABASE_PATH=${SQLITE_DATABASE_PATH:-../../tmp/ready-for-agent.db} bun --conditions @ready-for-agent/source src/bin/migrate.ts"
       }
     }
   }

--- a/packages/db/project.json
+++ b/packages/db/project.json
@@ -1,0 +1,13 @@
+{
+  "name": "db",
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "targets": {
+    "migrate": {
+      "executor": "nx:run-commands",
+      "options": {
+        "cwd": "{projectRoot}",
+        "command": "bun --conditions @ready-for-agent/source src/bin/migrate.ts"
+      }
+    }
+  }
+}

--- a/packages/db/src/bin/migrate.ts
+++ b/packages/db/src/bin/migrate.ts
@@ -1,0 +1,14 @@
+import { Effect } from "effect"
+import { TursoLive } from "@ready-for-agent/layer-turso-local"
+import { runConfiguredMigrations } from "../lib/run-migrations.js"
+
+const program = runConfiguredMigrations.pipe(
+  Effect.provide(TursoLive),
+  Effect.tap(() =>
+    Effect.sync(() => {
+      console.info("Database migrations applied")
+    }),
+  ),
+)
+
+await Effect.runPromise(program)

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -3,4 +3,5 @@ import "@effect/sql-drizzle/Sqlite"
 
 export * from "./lib/database-live.js"
 export * from "./lib/run-drizzle.js"
+export * from "./lib/run-migrations.js"
 export * from "./lib/typed-drizzle.js"

--- a/packages/db/src/lib/database-test.ts
+++ b/packages/db/src/lib/database-test.ts
@@ -1,22 +1,14 @@
-import { dirname, join } from "node:path"
-import { fileURLToPath } from "node:url"
 import { SqlClient } from "@effect/sql"
 import { SqliteClient } from "@effect/sql-sqlite-bun"
-import { Config, Context, Effect, Layer } from "effect"
+import { Context, Effect, Layer } from "effect"
+import {
+  MigrationsFolderConfig,
+  defaultMigrationsFolder,
+} from "./run-migrations.js"
 import { runSqliteTestMigrations } from "./test-migrations.js"
 import { TypedSqliteDrizzleLayer } from "./typed-drizzle.js"
 
-const __filename = fileURLToPath(import.meta.url)
-const __dirname = dirname(__filename)
-const defaultMigrationsFolder = join(__dirname, "../../../db-schema/drizzle")
-
-/**
- * Config for the migrations folder path.
- * Override with ConfigProvider.fromMap({ MIGRATIONS_FOLDER: "/custom/path" })
- */
-export const MigrationsFolderConfig = Config.string("MIGRATIONS_FOLDER").pipe(
-  Config.withDefault(defaultMigrationsFolder),
-)
+export { MigrationsFolderConfig, defaultMigrationsFolder }
 
 const runPragmas = (ctx: Context.Context<SqlClient.SqlClient>) =>
   Effect.gen(function* () {

--- a/packages/db/src/lib/run-migrations.ts
+++ b/packages/db/src/lib/run-migrations.ts
@@ -1,0 +1,82 @@
+import { dirname, join } from "node:path"
+import { fileURLToPath } from "node:url"
+import { SqlClient } from "@effect/sql"
+import { readMigrationFiles } from "drizzle-orm/migrator"
+import { Config, Effect } from "effect"
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = dirname(__filename)
+
+export const defaultMigrationsFolder = join(
+  __dirname,
+  "../../../db-schema/drizzle",
+)
+
+/**
+ * Config for the migrations folder path.
+ * Override with ConfigProvider.fromMap({ MIGRATIONS_FOLDER: "/custom/path" })
+ */
+export const MigrationsFolderConfig = Config.string("MIGRATIONS_FOLDER").pipe(
+  Config.withDefault(defaultMigrationsFolder),
+)
+
+const rawSql = (query: string) => Object.assign([query], { raw: [query] })
+
+type MigrationRow = {
+  readonly hash: string
+}
+
+/**
+ * Apply Drizzle migration SQL files via the current SqlClient.
+ * Skips migrations already recorded in __drizzle_migrations.
+ */
+export const runMigrations = (migrationsFolder: string) =>
+  Effect.gen(function* () {
+    const sql = yield* SqlClient.SqlClient
+    const migrations = readMigrationFiles({ migrationsFolder })
+
+    yield* sql`
+      CREATE TABLE IF NOT EXISTS __drizzle_migrations (
+        id INTEGER PRIMARY KEY,
+        hash text NOT NULL,
+        created_at numeric,
+        name text,
+        applied_at TEXT
+      )
+    `
+
+    const appliedRows = (yield* sql`
+      SELECT hash FROM __drizzle_migrations
+    `) as ReadonlyArray<MigrationRow>
+    const appliedHashes = new Set(appliedRows.map((row) => row.hash))
+
+    for (const migration of migrations) {
+      if (appliedHashes.has(migration.hash)) {
+        continue
+      }
+
+      for (const query of migration.sql) {
+        if (query.trim().length > 0) {
+          yield* sql(rawSql(query))
+        }
+      }
+
+      yield* sql`
+        INSERT INTO __drizzle_migrations (hash, created_at, name, applied_at)
+        VALUES (
+          ${migration.hash},
+          ${migration.folderMillis},
+          ${migration.name},
+          ${new Date().toISOString()}
+        )
+      `
+    }
+  })
+
+/**
+ * Run migrations using MIGRATIONS_FOLDER config (defaults to db-schema/drizzle).
+ */
+export const runConfiguredMigrations = Effect.gen(function* () {
+  const migrationsFolder = yield* MigrationsFolderConfig
+  yield* runMigrations(migrationsFolder)
+})

--- a/packages/db/src/lib/test-migrations.ts
+++ b/packages/db/src/lib/test-migrations.ts
@@ -1,39 +1,8 @@
-import { SqliteClient } from "@effect/sql-sqlite-bun"
-import { readMigrationFiles } from "drizzle-orm/migrator"
-import { Effect } from "effect"
+import { runMigrations } from "./run-migrations.js"
 
-const rawSql = (query: string) => Object.assign([query], { raw: [query] })
-
+/**
+ * Apply migrations for tests (in-memory or temp SQLite).
+ * Delegates to the shared migrator used by production.
+ */
 export const runSqliteTestMigrations = (migrationsFolder: string) =>
-  Effect.gen(function* () {
-    const sql = yield* SqliteClient.SqliteClient
-    const migrations = readMigrationFiles({ migrationsFolder })
-
-    yield* sql`
-      CREATE TABLE IF NOT EXISTS __drizzle_migrations (
-        id INTEGER PRIMARY KEY,
-        hash text NOT NULL,
-        created_at numeric,
-        name text,
-        applied_at TEXT
-      )
-    `
-
-    for (const migration of migrations) {
-      for (const query of migration.sql) {
-        if (query.trim().length > 0) {
-          yield* sql(rawSql(query))
-        }
-      }
-
-      yield* sql`
-        INSERT INTO __drizzle_migrations (hash, created_at, name, applied_at)
-        VALUES (
-          ${migration.hash},
-          ${migration.folderMillis},
-          ${migration.name},
-          ${new Date().toISOString()}
-        )
-      `
-    }
-  })
+  runMigrations(migrationsFolder)

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -28,6 +28,9 @@
       "path": "./packages/db"
     },
     {
+      "path": "./packages/db-service"
+    },
+    {
       "path": "./packages/sqlite-queue-service"
     },
     {


### PR DESCRIPTION
## Why

The GraphQL `addRepository` mutation returned a stub, so repositories added by the CLI were not persisted and could not report real duplicate conflicts.

## What Changed

- Add the Effect-backed `@ready-for-agent/db-service` package with `DbService.addRepository` and typed validation and uniqueness errors.
- Wire the GraphQL mutation to the service, returning conflict codes for duplicate repository identities and local paths.
- Add an Effect/Turso migration target and run it before the API starts.
- Generate `repo-`-prefixed repository IDs and add database-backed service tests.
- Make `harness:dev` start the API and use an ignored local database by default.
- Move custom Nx configuration into package `project.json` files and document that convention.

## Verification

Manually exercised the full local flow: `bun nx run harness:dev` followed by `bun run harness-cli add .` adds a persisted, paused Repository. Duplicate GitHub identity returns `REPOSITORY_ALREADY_EXISTS`; duplicate local path returns `LOCAL_PATH_IN_USE`.
