### PR TITLE
feat: add Keymaxxer service and dev sidecar

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -18,3 +18,11 @@ _Avoid_: Ticket, task (unless referring to a broader concept)
 
 **Issue store**:
 The harness capability that retains Issue representations locally. It does not fetch, refresh, or establish the authoritative state of Issues.
+
+**Keymaxxer Service**:
+The backend boundary for vault operations. It can determine whether a named secret exists, request that a secret be added, and run a command with named secrets injected without exposing raw secret values to the Harness.
+_Avoid_: Secret store, credential cache
+
+**Keymaxxer Sidecar**:
+A development-only companion process that owns the Keymaxxer MCP session so watched backend reloads do not repeat vault-unlock or secret-use approval prompts.
+_Avoid_: Credential daemon, token cache

--- a/README.md
+++ b/README.md
@@ -11,6 +11,11 @@ Opinionated agentic software engineering harness to massively increase landed PR
 2. GitHub CLI tool [gh](https://cli.github.com/)
 3. [keymaxxer](https://github.com/glommer/keymaxxer)
 
+The backend starts Keymaxxer through its MCP server. It uses
+`KEYMAXXER_ENTRYPOINT` when set, otherwise prefers the unreleased local source
+at `/home/berend/src/contrib/keymaxxer/packages/cli/src/index.ts` when present,
+and finally falls back to the installed `keymaxxer` command.
+
 ## Get started
 
 1. Checkout a repo locally.

--- a/apps/api/README.md
+++ b/apps/api/README.md
@@ -1,0 +1,25 @@
+# API
+
+The GraphQL API requires Keymaxxer to initialize before it starts listening.
+
+## Development
+
+`bunx nx run api:serve` starts a continuous Keymaxxer Sidecar on
+`http://127.0.0.1:5032` and the watched API connects to it. The sidecar owns the
+MCP session across API reloads, avoiding repeated vault unlock and secret-use
+approval prompts.
+
+Set `KEYMAXXER_SIDECAR_PORT` to use a different loopback port. The serve target
+derives `KEYMAXXER_SIDECAR_URL` from that port; an explicit URL must be an
+origin of the form `http://127.0.0.1:<port>`. A port conflict fails immediately
+and names the port override.
+
+## Production
+
+`bunx nx run api:start` does not run or select the sidecar. The API owns an
+in-process Keymaxxer MCP client and closes it during graceful shutdown.
+`NODE_ENV` does not select either topology.
+
+Set `KEYMAXXER_ENTRYPOINT` to run an explicit Keymaxxer TypeScript entrypoint.
+Without it, the MCP launcher prefers the local unreleased Keymaxxer source path
+documented in the root README and then falls back to `keymaxxer serve`.

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -12,6 +12,7 @@
     "@ready-for-agent/db": "workspace:*",
     "@ready-for-agent/db-service": "workspace:*",
     "@ready-for-agent/graphql-schema": "workspace:*",
+    "@ready-for-agent/keymaxxer-service": "workspace:*",
     "effect": "^3.21.4",
     "graphql": "^16.11.0",
     "graphql-yoga": "^5.13.0"

--- a/apps/api/project.json
+++ b/apps/api/project.json
@@ -7,9 +7,12 @@
       "executor": "nx:run-commands",
       "options": {
         "cwd": "{projectRoot}",
-        "command": "mkdir -p ../../tmp && SQLITE_DATABASE_PATH=${SQLITE_DATABASE_PATH:-../../tmp/ready-for-agent.db} bun --watch --conditions @ready-for-agent/source src/main.ts"
+        "command": "mkdir -p ../../tmp && KEYMAXXER_SIDECAR_URL=${KEYMAXXER_SIDECAR_URL:-http://127.0.0.1:${KEYMAXXER_SIDECAR_PORT:-5032}} SQLITE_DATABASE_PATH=${SQLITE_DATABASE_PATH:-../../tmp/ready-for-agent.db} bun --watch --conditions @ready-for-agent/source src/main.ts"
       },
-      "dependsOn": ["db:migrate"]
+      "dependsOn": [
+        "db:migrate",
+        { "projects": "self", "target": "keymaxxer-sidecar" }
+      ]
     },
     "start": {
       "executor": "nx:run-commands",
@@ -18,6 +21,23 @@
         "command": "mkdir -p ../../tmp && SQLITE_DATABASE_PATH=${SQLITE_DATABASE_PATH:-../../tmp/ready-for-agent.db} bun --conditions @ready-for-agent/source src/main.ts"
       },
       "dependsOn": ["db:migrate"]
+    },
+    "keymaxxer-sidecar": {
+      "continuous": true,
+      "executor": "nx:run-commands",
+      "options": {
+        "cwd": "{projectRoot}",
+        "command": "bun --conditions @ready-for-agent/source src/keymaxxer-sidecar.ts"
+      }
+    },
+    "test": {
+      "executor": "nx:run-commands",
+      "options": {
+        "cwd": "{projectRoot}",
+        "command": "bun test"
+      },
+      "inputs": ["default", "^production"],
+      "cache": true
     }
   }
 }

--- a/apps/api/src/keymaxxer-layer.ts
+++ b/apps/api/src/keymaxxer-layer.ts
@@ -1,0 +1,13 @@
+import {
+  mcpKeymaxxerLayer,
+  sidecarKeymaxxerLayer,
+} from "@ready-for-agent/keymaxxer-service"
+
+export const keymaxxerLayerFromEnvironment = (
+  environment: Partial<Record<string, string | undefined>> = process.env,
+) => {
+  const sidecarUrl = environment.KEYMAXXER_SIDECAR_URL?.trim()
+  return sidecarUrl === undefined || sidecarUrl === ""
+    ? mcpKeymaxxerLayer({ environment })
+    : sidecarKeymaxxerLayer(sidecarUrl)
+}

--- a/apps/api/src/keymaxxer-sidecar.ts
+++ b/apps/api/src/keymaxxer-sidecar.ts
@@ -1,0 +1,64 @@
+import { Effect } from "effect"
+import {
+  KeymaxxerError,
+  KeymaxxerService,
+  createKeymaxxerSidecarFetch,
+  mcpKeymaxxerLayer,
+} from "@ready-for-agent/keymaxxer-service"
+
+export const defaultKeymaxxerSidecarPort = 5032
+export const keymaxxerSidecarHost = "127.0.0.1"
+
+export const keymaxxerSidecarPortFromEnvironment = (
+  environment: Partial<Record<string, string | undefined>>,
+) => {
+  const value = environment.KEYMAXXER_SIDECAR_PORT?.trim()
+  if (value === undefined || value === "") return defaultKeymaxxerSidecarPort
+
+  const port = Number(value)
+  if (!Number.isInteger(port) || port < 1 || port > 65_535) {
+    throw new Error("KEYMAXXER_SIDECAR_PORT must be a valid TCP port")
+  }
+  return port
+}
+
+const program = Effect.scoped(
+  Effect.gen(function* () {
+    const keymaxxer = yield* KeymaxxerService
+    const port = keymaxxerSidecarPortFromEnvironment(process.env)
+    const server = yield* Effect.acquireRelease(
+      Effect.try({
+        try: () =>
+          Bun.serve({
+            fetch: createKeymaxxerSidecarFetch(keymaxxer),
+            hostname: keymaxxerSidecarHost,
+            port,
+          }),
+        catch: () =>
+          new KeymaxxerError({
+            operation: "sidecar",
+            message: `Keymaxxer Sidecar failed to listen on ${keymaxxerSidecarHost}:${port}. Set KEYMAXXER_SIDECAR_PORT to an unused port.`,
+          }),
+      }),
+      (runningServer) => Effect.promise(() => runningServer.stop(true)),
+    )
+
+    yield* Effect.log(
+      `Keymaxxer Sidecar listening on http://${server.hostname}:${server.port}`,
+    )
+    return yield* Effect.never
+  }).pipe(Effect.provide(mcpKeymaxxerLayer())),
+)
+
+if (import.meta.main) {
+  const abortController = new AbortController()
+  process.once("SIGINT", () => abortController.abort())
+  process.once("SIGTERM", () => abortController.abort())
+
+  Effect.runPromise(program, { signal: abortController.signal }).catch(() => {
+    if (!abortController.signal.aborted) {
+      console.error("Keymaxxer Sidecar startup failed")
+      process.exitCode = 1
+    }
+  })
+}

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -11,11 +11,23 @@ import {
   RepositoryAlreadyExistsError,
 } from "@ready-for-agent/db-service"
 import { typeDefs } from "@ready-for-agent/graphql-schema"
+import { KeymaxxerService } from "@ready-for-agent/keymaxxer-service"
+import { keymaxxerLayerFromEnvironment } from "./keymaxxer-layer.js"
 
 const port = Number(process.env.PORT ?? 3001)
 
-const AppLayer = DbServiceLive.pipe(Layer.provideMerge(DatabaseLive))
+const AppLayer = Layer.merge(
+  DbServiceLive.pipe(Layer.provideMerge(DatabaseLive)),
+  keymaxxerLayerFromEnvironment(),
+)
 const runtime = ManagedRuntime.make(AppLayer)
+
+await runtime.runPromise(
+  Effect.gen(function* () {
+    const keymaxxer = yield* KeymaxxerService
+    yield* keymaxxer.initialize()
+  }),
+)
 
 type AddRepositoryArgs = {
   input: {
@@ -103,3 +115,11 @@ console.info(
     `http://${server.hostname}:${server.port}`,
   )}`,
 )
+
+const shutdown = async () => {
+  await server.stop(true)
+  await runtime.dispose()
+}
+
+process.once("SIGINT", shutdown)
+process.once("SIGTERM", shutdown)

--- a/apps/api/test/keymaxxer-topology.test.ts
+++ b/apps/api/test/keymaxxer-topology.test.ts
@@ -1,0 +1,51 @@
+import { readFile } from "node:fs/promises"
+import {
+  defaultKeymaxxerSidecarPort,
+  keymaxxerSidecarPortFromEnvironment,
+} from "../src/keymaxxer-sidecar.js"
+import { describe, expect, test } from "bun:test"
+
+describe("API Keymaxxer development topology", () => {
+  test("attaches the continuous sidecar only to serve", async () => {
+    const project = JSON.parse(
+      await readFile(new URL("../project.json", import.meta.url), "utf8"),
+    ) as {
+      targets: Record<
+        string,
+        {
+          continuous?: boolean
+          dependsOn?: unknown[]
+          options: { command: string }
+        }
+      >
+    }
+
+    expect(project.targets["keymaxxer-sidecar"]?.continuous).toBe(true)
+    expect(project.targets.serve?.dependsOn).toContainEqual({
+      projects: "self",
+      target: "keymaxxer-sidecar",
+    })
+    expect(project.targets.serve?.options.command).toContain(
+      "KEYMAXXER_SIDECAR_URL",
+    )
+    expect(project.targets.start?.dependsOn).not.toContainEqual({
+      projects: "self",
+      target: "keymaxxer-sidecar",
+    })
+    expect(project.targets.start?.options.command).not.toContain(
+      "KEYMAXXER_SIDECAR_URL",
+    )
+  })
+
+  test("uses a fixed overridable port and rejects invalid values", () => {
+    expect(keymaxxerSidecarPortFromEnvironment({})).toBe(
+      defaultKeymaxxerSidecarPort,
+    )
+    expect(
+      keymaxxerSidecarPortFromEnvironment({ KEYMAXXER_SIDECAR_PORT: "6042" }),
+    ).toBe(6042)
+    expect(() =>
+      keymaxxerSidecarPortFromEnvironment({ KEYMAXXER_SIDECAR_PORT: "0" }),
+    ).toThrow("KEYMAXXER_SIDECAR_PORT")
+  })
+})

--- a/apps/api/tsconfig.app.json
+++ b/apps/api/tsconfig.app.json
@@ -16,13 +16,16 @@
   "include": ["src/**/*.ts"],
   "references": [
     {
-      "path": "../../packages/db/tsconfig.lib.json"
+      "path": "../../packages/keymaxxer-service/tsconfig.lib.json"
+    },
+    {
+      "path": "../../packages/graphql-schema/tsconfig.lib.json"
     },
     {
       "path": "../../packages/db-service/tsconfig.lib.json"
     },
     {
-      "path": "../../packages/graphql-schema/tsconfig.lib.json"
+      "path": "../../packages/db/tsconfig.lib.json"
     }
   ]
 }

--- a/bun.lock
+++ b/bun.lock
@@ -32,6 +32,7 @@
         "@ready-for-agent/db": "workspace:*",
         "@ready-for-agent/db-service": "workspace:*",
         "@ready-for-agent/graphql-schema": "workspace:*",
+        "@ready-for-agent/keymaxxer-service": "workspace:*",
         "effect": "^3.21.4",
         "graphql": "^16.11.0",
         "graphql-yoga": "^5.13.0",
@@ -124,6 +125,15 @@
     "packages/graphql-schema": {
       "name": "@ready-for-agent/graphql-schema",
       "version": "0.0.1",
+    },
+    "packages/keymaxxer-service": {
+      "name": "@ready-for-agent/keymaxxer-service",
+      "version": "0.0.1",
+      "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.29.0",
+        "effect": "^3.21.4",
+        "tslib": "^2.3.0",
+      },
     },
     "packages/layer-turso-local": {
       "name": "@ready-for-agent/layer-turso-local",
@@ -552,6 +562,8 @@
 
     "@graphql-yoga/typed-event-target": ["@graphql-yoga/typed-event-target@3.0.2", "", { "dependencies": { "@repeaterjs/repeater": "^3.0.4", "tslib": "^2.8.1" } }, "sha512-ZpJxMqB+Qfe3rp6uszCQoag4nSw42icURnBRfFYSOmTgEeOe4rD0vYlbA8spvCu2TlCesNTlEN9BLWtQqLxabA=="],
 
+    "@hono/node-server": ["@hono/node-server@1.19.14", "", { "peerDependencies": { "hono": "^4" } }, "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw=="],
+
     "@jest/diff-sequences": ["@jest/diff-sequences@30.0.1", "", {}, "sha512-n5H8QLDJ47QqbCNn5SuFjCRDrOLEZ0h8vAHCK5RL9Ls7Xa8AQLa/YxAc9UjFqoEDM48muwtBGjtMY5cr0PLDCw=="],
 
     "@jridgewell/gen-mapping": ["@jridgewell/gen-mapping@0.3.13", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.0", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA=="],
@@ -565,6 +577,8 @@
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
 
     "@js-temporal/polyfill": ["@js-temporal/polyfill@0.5.1", "", { "dependencies": { "jsbi": "^4.3.0" } }, "sha512-hloP58zRVCRSpgDxmqCWJNlizAlUgJFqG2ypq79DCvyv9tHjRYMDOcPFjzfl/A1/YxDvRCZz8wvZvmapQnKwFQ=="],
+
+    "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.29.0", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ=="],
 
     "@msgpackr-extract/msgpackr-extract-darwin-arm64": ["@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-LCkGo6JDfaBhgST7UpPWgNgLINpcpabaHfyz5OBx75nUYxBsaEPxjnyNjWpeb/xBup/682QnBfRBy2/LvPutZQ=="],
 
@@ -715,6 +729,8 @@
     "@ready-for-agent/graphql-schema": ["@ready-for-agent/graphql-schema@workspace:packages/graphql-schema"],
 
     "@ready-for-agent/harness": ["@ready-for-agent/harness@workspace:apps/harness"],
+
+    "@ready-for-agent/keymaxxer-service": ["@ready-for-agent/keymaxxer-service@workspace:packages/keymaxxer-service"],
 
     "@ready-for-agent/layer-turso-local": ["@ready-for-agent/layer-turso-local@workspace:packages/layer-turso-local"],
 
@@ -914,9 +930,13 @@
 
     "@zkochan/js-yaml": ["@zkochan/js-yaml@0.0.7", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-nrUSn7hzt7J6JWgWGz78ZYI8wj+gdIJdk0Ynjpp8l+trkn58Uqsf6RYrYkEK+3X18EX+TNdtJI0WxAtc+L84SQ=="],
 
+    "accepts": ["accepts@2.0.0", "", { "dependencies": { "mime-types": "^3.0.0", "negotiator": "^1.0.0" } }, "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng=="],
+
     "address": ["address@2.0.3", "", {}, "sha512-XNAb/a6TCqou+TufU8/u11HCu9x1gYvOoxLwtlXgIqmkrYQADVv6ljyW2zwiPhHz9R1gItAWpuDrdJMmrOBFEA=="],
 
     "ajv": ["ajv@8.20.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA=="],
+
+    "ajv-formats": ["ajv-formats@3.0.1", "", { "dependencies": { "ajv": "^8.0.0" } }, "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ=="],
 
     "ansi-colors": ["ansi-colors@4.1.3", "", {}, "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw=="],
 
@@ -964,6 +984,8 @@
 
     "bl": ["bl@4.1.0", "", { "dependencies": { "buffer": "^5.5.0", "inherits": "^2.0.4", "readable-stream": "^3.4.0" } }, "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w=="],
 
+    "body-parser": ["body-parser@2.3.0", "", { "dependencies": { "bytes": "^3.1.2", "content-type": "^2.0.0", "debug": "^4.4.3", "http-errors": "^2.0.1", "iconv-lite": "^0.7.2", "on-finished": "^2.4.1", "qs": "^6.15.2", "raw-body": "^3.0.2", "type-is": "^2.1.0" } }, "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw=="],
+
     "brace-expansion": ["brace-expansion@5.0.6", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g=="],
 
     "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
@@ -975,6 +997,8 @@
     "buffer-from": ["buffer-from@1.1.2", "", {}, "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="],
 
     "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
+
+    "bytes": ["bytes@3.1.2", "", {}, "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="],
 
     "call-bind-apply-helpers": ["call-bind-apply-helpers@1.0.2", "", { "dependencies": { "es-errors": "^1.3.0", "function-bind": "^1.1.2" } }, "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ=="],
 
@@ -1014,6 +1038,10 @@
 
     "concat-map": ["concat-map@0.0.1", "", {}, "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="],
 
+    "content-disposition": ["content-disposition@1.1.0", "", {}, "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g=="],
+
+    "content-type": ["content-type@1.0.5", "", {}, "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA=="],
+
     "conventional-changelog-angular": ["conventional-changelog-angular@9.2.1", "", { "dependencies": { "@conventional-changelog/template": "^1.2.1" } }, "sha512-oWSL6ZhnXbYraOFTK3PgRAQJ8fADDAEv5K6AdeyQPLvjFmhG8+ejL0jZZp/R7vTmGJaBvZEE+sE7dB4bCv7sAw=="],
 
     "conventional-changelog-conventionalcommits": ["conventional-changelog-conventionalcommits@10.2.1", "", { "dependencies": { "@conventional-changelog/template": "^1.2.1" } }, "sha512-n4Kr1HFMTf3iMbES0TMxKIcYtUUv4rKqyQQp2JwfOEfFCOfGT3Tq4mCyJ8S9/YPyWhydjfKrrvnyl+gCjA+mJQ=="],
@@ -1022,9 +1050,15 @@
 
     "convert-source-map": ["convert-source-map@2.0.0", "", {}, "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="],
 
+    "cookie": ["cookie@0.7.2", "", {}, "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="],
+
     "cookie-es": ["cookie-es@3.1.1", "", {}, "sha512-UaXxwISYJPTr9hwQxMFYZ7kNhSXboMXP+Z3TRX6f1/NyaGPfuNUZOWP1pUEb75B2HjfklIYLVRfWiFZJyC6Npg=="],
 
+    "cookie-signature": ["cookie-signature@1.2.2", "", {}, "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg=="],
+
     "core-js-compat": ["core-js-compat@3.49.0", "", { "dependencies": { "browserslist": "^4.28.1" } }, "sha512-VQXt1jr9cBz03b331DFDCCP90b3fanciLkgiOoy8SBHy06gNf+vQ1A3WFLqG7I8TipYIKeYK9wxd0tUrvHcOZA=="],
+
+    "cors": ["cors@2.8.6", "", { "dependencies": { "object-assign": "^4", "vary": "^1" } }, "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw=="],
 
     "corser": ["corser@2.0.1", "", {}, "sha512-utCYNzRSQIZNPIcGZdQc92UVJYAhtGAteCFg0yRaFm8f0P+CPtyGyHXJcGXnffjCybUCEx3FQ2G7U3/o9eIkVQ=="],
 
@@ -1033,6 +1067,8 @@
     "cosmiconfig-typescript-loader": ["cosmiconfig-typescript-loader@6.3.0", "", { "dependencies": { "jiti": "2.6.1" }, "peerDependencies": { "@types/node": "*", "cosmiconfig": ">=9", "typescript": ">=5" } }, "sha512-Akr82WH1Wfqatyiqpj8HDkO2o2KmJRu1FhKfSNJP3K4IdXwHfEyL7MOb62i1AGQVLtIQM+iCE9CGOtrfhR+mmA=="],
 
     "cross-inspect": ["cross-inspect@1.0.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-Pcw1JTvZLSJH83iiGWt6fRcT+BjZlCDRVwYLbUcHzv/CRpB7r0MlSrGbIyQvVSNyGnbt7G4AXuyCiDR3POvZ1A=="],
+
+    "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
 
     "csstype": ["csstype@3.2.3", "", {}, "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="],
 
@@ -1045,6 +1081,8 @@
     "define-lazy-prop": ["define-lazy-prop@2.0.0", "", {}, "sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og=="],
 
     "delayed-stream": ["delayed-stream@1.0.0", "", {}, "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="],
+
+    "depd": ["depd@2.0.0", "", {}, "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="],
 
     "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
 
@@ -1066,6 +1104,8 @@
 
     "eastasianwidth": ["eastasianwidth@0.2.0", "", {}, "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA=="],
 
+    "ee-first": ["ee-first@1.1.1", "", {}, "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="],
+
     "effect": ["effect@3.21.4", "", { "dependencies": { "@standard-schema/spec": "^1.0.0", "fast-check": "^3.23.1" } }, "sha512-B89v/xSgPbl1J2Ai2u18jxq3odpFauU1rC6/eSs4FeNHi72kwKdJp12VGigvRV2lK+kRnx+OOz41XV8guZd4gQ=="],
 
     "effect-solutions": ["effect-solutions@0.5.3", "", { "dependencies": { "@effect/platform-bun": "4.0.0-beta.59", "effect": "4.0.0-beta.59", "gray-matter": "^4.0.3", "picocolors": "^1.1.1" }, "bin": { "effect-solutions": "bin.js" } }, "sha512-JIG7XV0gJF5eVV+9un5Yp7MEFMGNfuTYxbiV/HzS80zH/9qx9ZOoXd6Mlw0FXdbC41LGcpWYZJG3MnzxYawEWg=="],
@@ -1075,6 +1115,8 @@
     "electron-to-chromium": ["electron-to-chromium@1.5.389", "", {}, "sha512-cEto7aeOqBfU1D+c5py5pE+ooscKE75JifxLBdFUZsqAxRS6y7kebtxAZvICszSl05gPjYHDTjY+lXpyGvpJbg=="],
 
     "emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
+
+    "encodeurl": ["encodeurl@2.0.0", "", {}, "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg=="],
 
     "end-of-stream": ["end-of-stream@1.4.5", "", { "dependencies": { "once": "^1.4.0" } }, "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg=="],
 
@@ -1098,6 +1140,8 @@
 
     "escalade": ["escalade@3.2.0", "", {}, "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA=="],
 
+    "escape-html": ["escape-html@1.0.3", "", {}, "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="],
+
     "escape-string-regexp": ["escape-string-regexp@1.0.5", "", {}, "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg=="],
 
     "esprima": ["esprima@4.0.1", "", { "bin": { "esparse": "./bin/esparse.js", "esvalidate": "./bin/esvalidate.js" } }, "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="],
@@ -1108,7 +1152,17 @@
 
     "esutils": ["esutils@2.0.3", "", {}, "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="],
 
+    "etag": ["etag@1.8.1", "", {}, "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg=="],
+
     "eventemitter3": ["eventemitter3@5.0.4", "", {}, "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw=="],
+
+    "eventsource": ["eventsource@3.0.7", "", { "dependencies": { "eventsource-parser": "^3.0.1" } }, "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA=="],
+
+    "eventsource-parser": ["eventsource-parser@3.1.0", "", {}, "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg=="],
+
+    "express": ["express@5.2.1", "", { "dependencies": { "accepts": "^2.0.0", "body-parser": "^2.2.1", "content-disposition": "^1.0.0", "content-type": "^1.0.5", "cookie": "^0.7.1", "cookie-signature": "^1.2.1", "debug": "^4.4.0", "depd": "^2.0.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "finalhandler": "^2.1.0", "fresh": "^2.0.0", "http-errors": "^2.0.0", "merge-descriptors": "^2.0.0", "mime-types": "^3.0.0", "on-finished": "^2.4.1", "once": "^1.4.0", "parseurl": "^1.3.3", "proxy-addr": "^2.0.7", "qs": "^6.14.0", "range-parser": "^1.2.1", "router": "^2.2.0", "send": "^1.1.0", "serve-static": "^2.2.0", "statuses": "^2.0.1", "type-is": "^2.0.1", "vary": "^1.1.2" } }, "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw=="],
+
+    "express-rate-limit": ["express-rate-limit@8.5.2", "", { "dependencies": { "ip-address": "^10.2.0" }, "peerDependencies": { "express": ">= 4.11" } }, "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A=="],
 
     "extend-shallow": ["extend-shallow@2.0.1", "", { "dependencies": { "is-extendable": "^0.1.0" } }, "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug=="],
 
@@ -1130,6 +1184,8 @@
 
     "fill-range": ["fill-range@7.1.1", "", { "dependencies": { "to-regex-range": "^5.0.1" } }, "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg=="],
 
+    "finalhandler": ["finalhandler@2.1.1", "", { "dependencies": { "debug": "^4.4.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "on-finished": "^2.4.1", "parseurl": "^1.3.3", "statuses": "^2.0.1" } }, "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA=="],
+
     "find-my-way-ts": ["find-my-way-ts@0.1.6", "", {}, "sha512-a85L9ZoXtNAey3Y6Z+eBWW658kO/MwR7zIafkIUPUMf3isZG0NCs2pjW2wtjxAKuJPxMAsHUIP4ZPGv0o5gyTA=="],
 
     "find-up": ["find-up@4.1.0", "", { "dependencies": { "locate-path": "^5.0.0", "path-exists": "^4.0.0" } }, "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw=="],
@@ -1141,6 +1197,10 @@
     "form-data": ["form-data@4.0.6", "", { "dependencies": { "asynckit": "^0.4.0", "combined-stream": "^1.0.8", "es-set-tostringtag": "^2.1.0", "hasown": "^2.0.4", "mime-types": "^2.1.35" } }, "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ=="],
 
     "formatly": ["formatly@0.3.0", "", { "dependencies": { "fd-package-json": "^2.0.0" }, "bin": { "formatly": "bin/index.mjs" } }, "sha512-9XNj/o4wrRFyhSMJOvsuyMwy8aUfBaZ1VrqHVfohyXf0Sw0e+yfKG+xZaY3arGCOMdwFsqObtzVOc1gU9KiT9w=="],
+
+    "forwarded": ["forwarded@0.2.0", "", {}, "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow=="],
+
+    "fresh": ["fresh@2.0.0", "", {}, "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A=="],
 
     "fs-constants": ["fs-constants@1.0.0", "", {}, "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="],
 
@@ -1194,13 +1254,17 @@
 
     "he": ["he@1.2.0", "", { "bin": { "he": "bin/he" } }, "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw=="],
 
+    "hono": ["hono@4.12.28", "", {}, "sha512-YwUvVpSF7m1yOblFPrU3Hbo8XhPheBoiyfGuII6z19LnOr6JpDnyyp7LFNrfV56wS8tpvtBFGRISHN02pDdLOA=="],
+
     "html-encoding-sniffer": ["html-encoding-sniffer@3.0.0", "", { "dependencies": { "whatwg-encoding": "^2.0.0" } }, "sha512-oWv4T4yJ52iKrufjnyZPkrN0CH3QnrUqdB6In1g5Fe1mia8GmF36gnfNySxoZtxD5+NmYw1EElVXiBk93UeskA=="],
+
+    "http-errors": ["http-errors@2.0.1", "", { "dependencies": { "depd": "~2.0.0", "inherits": "~2.0.4", "setprototypeof": "~1.2.0", "statuses": "~2.0.2", "toidentifier": "~1.0.1" } }, "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ=="],
 
     "http-proxy": ["http-proxy@1.18.1", "", { "dependencies": { "eventemitter3": "^4.0.0", "follow-redirects": "^1.0.0", "requires-port": "^1.0.0" } }, "sha512-7mz/721AbnJwIVbnaSv1Cz3Am0ZLT/UBwkC92VlxhXv/k/BBQfM2fXElQNC27BVGr0uwUpplYPQM9LnaBMR5NQ=="],
 
     "http-server": ["http-server@14.1.1", "", { "dependencies": { "basic-auth": "^2.0.1", "chalk": "^4.1.2", "corser": "^2.0.1", "he": "^1.2.0", "html-encoding-sniffer": "^3.0.0", "http-proxy": "^1.18.1", "mime": "^1.6.0", "minimist": "^1.2.6", "opener": "^1.5.1", "portfinder": "^1.0.28", "secure-compare": "3.0.1", "union": "~0.5.0", "url-join": "^4.0.1" }, "bin": { "http-server": "bin/http-server" } }, "sha512-+cbxadF40UXd9T01zUHgA+rlo2Bg1Srer4+B4NwIHdaGxAGGv59nYRnGGDJ9LBk7alpS0US+J+bLLdQOOkJq4A=="],
 
-    "iconv-lite": ["iconv-lite@0.6.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw=="],
+    "iconv-lite": ["iconv-lite@0.7.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ=="],
 
     "ieee754": ["ieee754@1.2.1", "", {}, "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="],
 
@@ -1213,6 +1277,10 @@
     "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
 
     "ini": ["ini@7.0.0", "", {}, "sha512-ifK0CgjALofS5bkrcTy4RaQ9Vx2Knf/eLeIO+NaswQEpH1UblrtTSCIvN71qQDMq0PeQ/SSPojvEJp9vvvfr+w=="],
+
+    "ip-address": ["ip-address@10.2.0", "", {}, "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA=="],
+
+    "ipaddr.js": ["ipaddr.js@1.9.1", "", {}, "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="],
 
     "is-arrayish": ["is-arrayish@0.2.1", "", {}, "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg=="],
 
@@ -1234,6 +1302,8 @@
 
     "is-plain-obj": ["is-plain-obj@4.1.0", "", {}, "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg=="],
 
+    "is-promise": ["is-promise@4.0.0", "", {}, "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ=="],
+
     "is-unicode-supported": ["is-unicode-supported@0.1.0", "", {}, "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw=="],
 
     "is-wsl": ["is-wsl@2.2.0", "", { "dependencies": { "is-docker": "^2.0.0" } }, "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww=="],
@@ -1243,6 +1313,8 @@
     "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
 
     "jiti": ["jiti@2.7.0", "", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ=="],
+
+    "jose": ["jose@6.2.3", "", {}, "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw=="],
 
     "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
@@ -1255,6 +1327,8 @@
     "json-parse-even-better-errors": ["json-parse-even-better-errors@2.3.1", "", {}, "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w=="],
 
     "json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
+
+    "json-schema-typed": ["json-schema-typed@8.0.2", "", {}, "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA=="],
 
     "json5": ["json5@2.2.3", "", { "bin": { "json5": "lib/cli.js" } }, "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="],
 
@@ -1292,6 +1366,10 @@
 
     "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
 
+    "media-typer": ["media-typer@1.1.0", "", {}, "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw=="],
+
+    "merge-descriptors": ["merge-descriptors@2.0.0", "", {}, "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g=="],
+
     "merge2": ["merge2@1.4.1", "", {}, "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg=="],
 
     "micromatch": ["micromatch@4.0.8", "", { "dependencies": { "braces": "^3.0.3", "picomatch": "^2.3.1" } }, "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA=="],
@@ -1322,6 +1400,8 @@
 
     "native-fetch": ["native-fetch@4.0.2", "", { "peerDependencies": { "undici": "*" } }, "sha512-4QcVlKFtv2EYVS5MBgsGX5+NWKtbDbIECdUXDBGDMAZXq3Jkv9zf+y8iS7Ub8fEdga3GpYeazp9gauNqXHJOCg=="],
 
+    "negotiator": ["negotiator@1.0.0", "", {}, "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="],
+
     "node-gyp-build-optional-packages": ["node-gyp-build-optional-packages@5.2.2", "", { "dependencies": { "detect-libc": "^2.0.1" }, "bin": { "node-gyp-build-optional-packages": "bin.js", "node-gyp-build-optional-packages-optional": "optional.js", "node-gyp-build-optional-packages-test": "build-test.js" } }, "sha512-s+w+rBWnpTMwSFbaE0UXsRlg7hU4FjekKU4eyAih5T8nJuNZT1nNsskXpxmeqSK9UzkBl6UgRlnKc8hz8IEqOw=="],
 
     "node-releases": ["node-releases@2.0.51", "", {}, "sha512-wRNIrw4DmVLKQlbgOMdkMx27Wrpzes2hh5Jtbi2bjPd+4wJstWIqP5A+lscnqbm0xxmT5Bpg8Lec5ItEBwx6BQ=="],
@@ -1332,7 +1412,11 @@
 
     "nx": ["nx@23.0.1", "", { "dependencies": { "@emnapi/core": "1.4.5", "@emnapi/runtime": "1.4.5", "@emnapi/wasi-threads": "1.0.4", "@jest/diff-sequences": "30.0.1", "@napi-rs/wasm-runtime": "0.2.4", "@tybys/wasm-util": "0.9.0", "@yarnpkg/lockfile": "1.1.0", "@zkochan/js-yaml": "0.0.7", "ansi-colors": "4.1.3", "ansi-regex": "5.0.1", "ansi-styles": "4.3.0", "argparse": "2.0.1", "asynckit": "0.4.0", "axios": "1.16.0", "balanced-match": "4.0.3", "base64-js": "1.5.1", "bl": "4.1.0", "brace-expansion": "5.0.6", "buffer": "5.7.1", "call-bind-apply-helpers": "1.0.2", "chalk": "4.1.2", "cli-cursor": "3.1.0", "cli-spinners": "2.6.1", "cliui": "8.0.1", "clone": "1.0.4", "color-convert": "2.0.1", "color-name": "1.1.4", "combined-stream": "1.0.8", "defaults": "1.0.4", "define-lazy-prop": "2.0.0", "delayed-stream": "1.0.0", "dotenv": "16.4.7", "dotenv-expand": "12.0.3", "dunder-proto": "1.0.1", "ejs": "5.0.1", "emoji-regex": "8.0.0", "end-of-stream": "1.4.5", "enquirer": "2.3.6", "es-define-property": "1.0.1", "es-errors": "1.3.0", "es-object-atoms": "1.1.1", "es-set-tostringtag": "2.1.0", "escalade": "3.2.0", "escape-string-regexp": "1.0.5", "figures": "3.2.0", "flat": "5.0.2", "follow-redirects": "1.16.0", "form-data": "4.0.6", "fs-constants": "1.0.0", "function-bind": "1.1.2", "get-caller-file": "2.0.5", "get-intrinsic": "1.3.0", "get-proto": "1.0.1", "gopd": "1.2.0", "has-flag": "4.0.0", "has-symbols": "1.1.0", "has-tostringtag": "1.0.2", "hasown": "2.0.4", "ieee754": "1.2.1", "ignore": "7.0.5", "inherits": "2.0.4", "is-docker": "2.2.1", "is-fullwidth-code-point": "3.0.0", "is-interactive": "1.0.0", "is-unicode-supported": "0.1.0", "is-wsl": "2.2.0", "isexe": "2.0.0", "json5": "2.2.3", "jsonc-parser": "3.3.1", "lines-and-columns": "2.0.3", "log-symbols": "4.1.0", "math-intrinsics": "1.1.0", "mime-db": "1.52.0", "mime-types": "2.1.35", "mimic-fn": "2.1.0", "minimatch": "10.2.5", "minimist": "1.2.8", "npm-run-path": "4.0.1", "once": "1.4.0", "onetime": "5.1.2", "open": "8.4.2", "ora": "5.4.1", "path-key": "3.1.1", "picocolors": "1.1.1", "proxy-from-env": "2.1.0", "readable-stream": "3.6.2", "require-directory": "2.1.1", "resolve.exports": "2.0.3", "restore-cursor": "3.1.0", "safe-buffer": "5.2.1", "semver": "7.7.4", "signal-exit": "3.0.7", "smol-toml": "1.6.1", "string-width": "4.2.3", "string_decoder": "1.3.0", "strip-ansi": "6.0.1", "strip-bom": "3.0.0", "supports-color": "7.2.0", "tar-stream": "2.2.0", "tmp": "0.2.7", "tsconfig-paths": "4.2.0", "tslib": "2.8.1", "util-deprecate": "1.0.2", "wcwidth": "1.0.1", "which": "3.0.1", "wrap-ansi": "7.0.0", "wrappy": "1.0.2", "y18n": "5.0.8", "yaml": "2.9.0", "yargs": "17.7.2", "yargs-parser": "21.1.1" }, "optionalDependencies": { "@nx/nx-darwin-arm64": "23.0.1", "@nx/nx-darwin-x64": "23.0.1", "@nx/nx-freebsd-x64": "23.0.1", "@nx/nx-linux-arm-gnueabihf": "23.0.1", "@nx/nx-linux-arm64-gnu": "23.0.1", "@nx/nx-linux-arm64-musl": "23.0.1", "@nx/nx-linux-x64-gnu": "23.0.1", "@nx/nx-linux-x64-musl": "23.0.1", "@nx/nx-win32-arm64-msvc": "23.0.1", "@nx/nx-win32-x64-msvc": "23.0.1" }, "peerDependencies": { "@swc-node/register": "^1.11.1", "@swc/core": "^1.15.8" }, "optionalPeers": ["@swc-node/register", "@swc/core"], "bin": { "nx": "./dist/bin/nx.js", "nx-cloud": "./dist/bin/nx-cloud.js" } }, "sha512-HnK0Ke8FcPeVQffYm1oyzkLNn7khrI8SeDeC3iyLhw/UEMCB24hjI5JSs6Amlyeb0/GaeiuQuts8NkQKd/NpGA=="],
 
+    "object-assign": ["object-assign@4.1.1", "", {}, "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="],
+
     "object-inspect": ["object-inspect@1.13.4", "", {}, "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew=="],
+
+    "on-finished": ["on-finished@2.4.1", "", { "dependencies": { "ee-first": "1.1.1" } }, "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg=="],
 
     "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
 
@@ -1358,6 +1442,8 @@
 
     "parse-json": ["parse-json@5.2.0", "", { "dependencies": { "@babel/code-frame": "^7.0.0", "error-ex": "^1.3.1", "json-parse-even-better-errors": "^2.3.0", "lines-and-columns": "^1.1.6" } }, "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg=="],
 
+    "parseurl": ["parseurl@1.3.3", "", {}, "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="],
+
     "path-exists": ["path-exists@4.0.0", "", {}, "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="],
 
     "path-is-absolute": ["path-is-absolute@1.0.1", "", {}, "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg=="],
@@ -1365,6 +1451,8 @@
     "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
 
     "path-parse": ["path-parse@1.0.7", "", {}, "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="],
+
+    "path-to-regexp": ["path-to-regexp@8.4.2", "", {}, "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA=="],
 
     "path-type": ["path-type@4.0.0", "", {}, "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw=="],
 
@@ -1374,11 +1462,15 @@
 
     "picomatch": ["picomatch@4.0.4", "", {}, "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="],
 
+    "pkce-challenge": ["pkce-challenge@5.0.1", "", {}, "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ=="],
+
     "portfinder": ["portfinder@1.0.38", "", { "dependencies": { "async": "^3.2.6", "debug": "^4.3.6" } }, "sha512-rEwq/ZHlJIKw++XtLAO8PPuOQA/zaPJOZJ37BVuN97nLpMJeuDVLVGRwbFoBgLudgdTMP2hdRJP++H+8QOA3vg=="],
 
     "postcss": ["postcss@8.5.16", "", { "dependencies": { "nanoid": "^3.3.12", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg=="],
 
     "prettier": ["prettier@2.8.8", "", { "bin": { "prettier": "bin-prettier.js" } }, "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q=="],
+
+    "proxy-addr": ["proxy-addr@2.0.7", "", { "dependencies": { "forwarded": "0.2.0", "ipaddr.js": "1.9.1" } }, "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg=="],
 
     "proxy-from-env": ["proxy-from-env@2.1.0", "", {}, "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA=="],
 
@@ -1387,6 +1479,10 @@
     "qs": ["qs@6.15.3", "", { "dependencies": { "es-define-property": "^1.0.1", "side-channel": "^1.1.1" } }, "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A=="],
 
     "queue-microtask": ["queue-microtask@1.2.3", "", {}, "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A=="],
+
+    "range-parser": ["range-parser@1.3.0", "", {}, "sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw=="],
+
+    "raw-body": ["raw-body@3.0.2", "", { "dependencies": { "bytes": "~3.1.2", "http-errors": "~2.0.1", "iconv-lite": "~0.7.0", "unpipe": "~1.0.0" } }, "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA=="],
 
     "react": ["react@19.2.7", "", {}, "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ=="],
 
@@ -1436,6 +1532,8 @@
 
     "rollup": ["rollup@4.62.2", "", { "dependencies": { "@types/estree": "1.0.9" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.62.2", "@rollup/rollup-android-arm64": "4.62.2", "@rollup/rollup-darwin-arm64": "4.62.2", "@rollup/rollup-darwin-x64": "4.62.2", "@rollup/rollup-freebsd-arm64": "4.62.2", "@rollup/rollup-freebsd-x64": "4.62.2", "@rollup/rollup-linux-arm-gnueabihf": "4.62.2", "@rollup/rollup-linux-arm-musleabihf": "4.62.2", "@rollup/rollup-linux-arm64-gnu": "4.62.2", "@rollup/rollup-linux-arm64-musl": "4.62.2", "@rollup/rollup-linux-loong64-gnu": "4.62.2", "@rollup/rollup-linux-loong64-musl": "4.62.2", "@rollup/rollup-linux-ppc64-gnu": "4.62.2", "@rollup/rollup-linux-ppc64-musl": "4.62.2", "@rollup/rollup-linux-riscv64-gnu": "4.62.2", "@rollup/rollup-linux-riscv64-musl": "4.62.2", "@rollup/rollup-linux-s390x-gnu": "4.62.2", "@rollup/rollup-linux-x64-gnu": "4.62.2", "@rollup/rollup-linux-x64-musl": "4.62.2", "@rollup/rollup-openbsd-x64": "4.62.2", "@rollup/rollup-openharmony-arm64": "4.62.2", "@rollup/rollup-win32-arm64-msvc": "4.62.2", "@rollup/rollup-win32-ia32-msvc": "4.62.2", "@rollup/rollup-win32-x64-gnu": "4.62.2", "@rollup/rollup-win32-x64-msvc": "4.62.2", "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-RFnrW4lhXA3s3eqHDZvN654g8OTjzRfqpIRJYczCGB6HzphckVAi/Qh4tbPUbRuDi7s1Llv8g/NspLkttY3gTA=="],
 
+    "router": ["router@2.2.0", "", { "dependencies": { "debug": "^4.4.0", "depd": "^2.0.0", "is-promise": "^4.0.0", "parseurl": "^1.3.3", "path-to-regexp": "^8.0.0" } }, "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ=="],
+
     "run-parallel": ["run-parallel@1.2.0", "", { "dependencies": { "queue-microtask": "^1.2.2" } }, "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA=="],
 
     "safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
@@ -1450,11 +1548,21 @@
 
     "semver": ["semver@7.8.5", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA=="],
 
+    "send": ["send@1.2.1", "", { "dependencies": { "debug": "^4.4.3", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "fresh": "^2.0.0", "http-errors": "^2.0.1", "mime-types": "^3.0.2", "ms": "^2.1.3", "on-finished": "^2.4.1", "range-parser": "^1.2.1", "statuses": "^2.0.2" } }, "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ=="],
+
     "seroval": ["seroval@1.5.5", "", {}, "sha512-bSjOuPcwPKLSJNhr9+bZxA20nQxVle5J5MNsYRVE6cIg7KpRLXGupymePavu0jrxlPiPsr4xGZSB8yUY2sH2sw=="],
 
     "seroval-plugins": ["seroval-plugins@1.5.5", "", { "peerDependencies": { "seroval": "^1.0" } }, "sha512-+BDhqYM6CEn3x09v44dpa9p6974FuUB2dxk+Ctn04k0cO1Zt6QODTXfmEZK0eBaTe/fJBvP4NMGuNJ+R8T+QMg=="],
 
+    "serve-static": ["serve-static@2.2.1", "", { "dependencies": { "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "parseurl": "^1.3.3", "send": "^1.2.0" } }, "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw=="],
+
     "set-blocking": ["set-blocking@2.0.0", "", {}, "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw=="],
+
+    "setprototypeof": ["setprototypeof@1.2.0", "", {}, "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="],
+
+    "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
+
+    "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
 
     "side-channel": ["side-channel@1.1.1", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.4", "side-channel-list": "^1.0.1", "side-channel-map": "^1.0.1", "side-channel-weakmap": "^1.0.2" } }, "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ=="],
 
@@ -1479,6 +1587,8 @@
     "source-map-support": ["source-map-support@0.5.19", "", { "dependencies": { "buffer-from": "^1.0.0", "source-map": "^0.6.0" } }, "sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw=="],
 
     "sprintf-js": ["sprintf-js@1.0.3", "", {}, "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="],
+
+    "statuses": ["statuses@2.0.2", "", {}, "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="],
 
     "string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
@@ -1506,6 +1616,8 @@
 
     "to-regex-range": ["to-regex-range@5.0.1", "", { "dependencies": { "is-number": "^7.0.0" } }, "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ=="],
 
+    "toidentifier": ["toidentifier@1.0.1", "", {}, "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="],
+
     "toml": ["toml@4.1.2", "", {}, "sha512-m0vXfHODcw3gk+KONAOlVQ5yNHc3yS3B1ybM3HS1vqDoS0RWTDDVBVVTYi8hH0k+2OM1vmo9fb1WX9EVqjqfHA=="],
 
     "tsconfig-paths": ["tsconfig-paths@4.2.0", "", { "dependencies": { "json5": "^2.2.2", "minimist": "^1.2.6", "strip-bom": "^3.0.0" } }, "sha512-NoZ4roiN7LnbKn9QqE1amc9DJfzvZXxF4xDavcOWt1BPkdx+m+0gJuPM+S0vCe7zTJMYUP0R8pO2XMr+Y8oLIg=="],
@@ -1515,6 +1627,8 @@
     "tsx": ["tsx@4.23.0", "", { "dependencies": { "esbuild": "~0.28.0" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "bin": { "tsx": "dist/cli.mjs" } }, "sha512-eUdUIaCr963q2h5u3+QwvYp0+eqPvn+egeqZUm0hwERCqqx1E3kK5ehbGCvqSE5MQAULr67ww0cA3jKc3YkM1w=="],
 
     "type-fest": ["type-fest@1.4.0", "", {}, "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA=="],
+
+    "type-is": ["type-is@2.1.0", "", { "dependencies": { "content-type": "^2.0.0", "media-typer": "^1.1.0", "mime-types": "^3.0.0" } }, "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA=="],
 
     "typescript": ["@typescript/typescript6@6.0.2", "", { "dependencies": { "@typescript/old": "npm:typescript@^6" }, "bin": { "tsc6": "bin/tsc6" } }, "sha512-mbCddXd+jm7hfx7w2YU64/Av4/NqqeG3GoRZgxPcgoTxYjhrcfJRw9ULch71SS4G+Q3bOXFhRvPqjguN0Hyp5w=="],
 
@@ -1540,6 +1654,8 @@
 
     "unixify": ["unixify@1.0.0", "", { "dependencies": { "normalize-path": "^2.1.1" } }, "sha512-6bc58dPYhCMHHuwxldQxO3RRNZ4eCogZ/st++0+fcC1nr0jiGUtAdBJ2qzmLQWSxbtz42pWt4QQMiZ9HvZf5cg=="],
 
+    "unpipe": ["unpipe@1.0.0", "", {}, "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ=="],
+
     "unplugin": ["unplugin@3.3.0", "", { "dependencies": { "@jridgewell/remapping": "^2.3.5", "picomatch": "^4.0.4", "webpack-virtual-modules": "^0.6.2" }, "peerDependencies": { "@farmfe/core": "*", "@rspack/core": "*", "bun-types-no-globals": "*", "esbuild": "*", "rolldown": "*", "rollup": "*", "unloader": "*", "vite": "*", "webpack": "*" }, "optionalPeers": ["@farmfe/core", "@rspack/core", "bun-types-no-globals", "esbuild", "rolldown", "rollup", "unloader", "vite", "webpack"] }, "sha512-qa66K+crbfyE6JK10GjvbJeRrOsuC/JpbnHctfyp/i4oBTxWOzJfRZyDiOk1PtErMFRu8JhsU/wPvOdBNWe5Rg=="],
 
     "update-browserslist-db": ["update-browserslist-db@1.2.3", "", { "dependencies": { "escalade": "^3.2.0", "picocolors": "^1.1.1" }, "peerDependencies": { "browserslist": ">= 4.21.0" }, "bin": { "update-browserslist-db": "cli.js" } }, "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w=="],
@@ -1555,6 +1671,8 @@
     "uuid": ["uuid@14.0.1", "", { "bin": { "uuid": "dist-node/bin/uuid" } }, "sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew=="],
 
     "value-or-promise": ["value-or-promise@1.0.12", "", {}, "sha512-Z6Uz+TYwEqE7ZN50gwn+1LCVo9ZVrpxRPOhOLnncYkY1ZzOYtrX8Fwf/rFktZ8R5mJms6EZf5TqNOMeZmnPq9Q=="],
+
+    "vary": ["vary@1.1.2", "", {}, "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="],
 
     "vite": ["vite@7.3.6", "", { "dependencies": { "esbuild": "^0.27.0 || ^0.28.0", "fdir": "^6.5.0", "picomatch": "^4.0.3", "postcss": "^8.5.6", "rollup": "^4.43.0", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "jiti": ">=1.21.0", "less": "^4.0.0", "lightningcss": "^1.21.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-4XP60spRGjSZFf1qYH+dJIkK2znL3zQfl9KkOV9MkkRR/3Dls0dxaBsQPTloEc5BLXWPL9vsOxopxyKoMmDueg=="],
 
@@ -1589,6 +1707,8 @@
     "yocto-queue": ["yocto-queue@0.1.0", "", {}, "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="],
 
     "zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
+
+    "zod-to-json-schema": ["zod-to-json-schema@3.25.2", "", { "peerDependencies": { "zod": "^3.25.28 || ^4" } }, "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA=="],
 
     "@babel/core/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
@@ -1650,11 +1770,15 @@
 
     "@whatwg-node/node-fetch/@fastify/busboy": ["@fastify/busboy@3.2.0", "", {}, "sha512-m9FVDXU3GT2ITSe0UaMA5rU3QkfC/UXtCU8y0gSN/GugTqtVldOBWIB5V6V3sbmenVZUIpU6f+mPEO2+m5iTaA=="],
 
+    "accepts/mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
+
     "babel-plugin-macros/cosmiconfig": ["cosmiconfig@7.1.0", "", { "dependencies": { "@types/parse-json": "^4.0.0", "import-fresh": "^3.2.1", "parse-json": "^5.0.0", "path-type": "^4.0.0", "yaml": "^1.10.0" } }, "sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA=="],
 
     "babel-plugin-polyfill-corejs2/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
     "basic-auth/safe-buffer": ["safe-buffer@5.1.2", "", {}, "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="],
+
+    "body-parser/content-type": ["content-type@2.0.0", "", {}, "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ=="],
 
     "cli-truncate/string-width": ["string-width@5.1.2", "", { "dependencies": { "eastasianwidth": "^0.2.0", "emoji-regex": "^9.2.2", "strip-ansi": "^7.0.1" } }, "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA=="],
 
@@ -1662,11 +1786,15 @@
 
     "cosmiconfig-typescript-loader/jiti": ["jiti@2.6.1", "", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ=="],
 
+    "cross-spawn/which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
+
     "drizzle-orm/effect": ["effect@4.0.0-beta.97", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "fast-check": "^4.9.0", "find-my-way-ts": "^0.1.6", "ini": "^7.0.0", "kubernetes-types": "^1.30.0", "msgpackr": "^2.0.4", "multipasta": "^0.2.8", "toml": "^4.1.2", "uuid": "^14.0.1", "yaml": "^2.9.0" } }, "sha512-pK03HpQVxGZOWdwDAy/iwvV8u3KYcUf2mOWyWqaut2zau8V2u6ejWP7b4BELjyUIiZWW1fl/s/VJpgZUcTjThg=="],
 
     "effect-solutions/@effect/platform-bun": ["@effect/platform-bun@4.0.0-beta.59", "", { "dependencies": { "@effect/platform-node-shared": "^4.0.0-beta.59" }, "peerDependencies": { "effect": "^4.0.0-beta.59" } }, "sha512-1jXCIx34X80ojiK9ACO9Q7RST9CXudRmlAbsP4kPqjUo6aqOuGSWXq9ueBO4LbaIZiioRxtTciom35U9ldfTkQ=="],
 
     "effect-solutions/effect": ["effect@4.0.0-beta.59", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "fast-check": "^4.6.0", "find-my-way-ts": "^0.1.6", "ini": "^6.0.0", "kubernetes-types": "^1.30.0", "msgpackr": "^1.11.9", "multipasta": "^0.2.7", "toml": "^4.1.1", "uuid": "^13.0.0", "yaml": "^2.8.3" } }, "sha512-xyUDLeHSe8d6lWGOvR6Fgn2HL6gYeTZ/S4Jzk9uc4ZUxMPPsNZlNXrvk0C7/utQFzeX7uAWcVnG2BjbA0SRoAA=="],
+
+    "express/mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
 
     "glob/minimatch": ["minimatch@3.1.5", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w=="],
 
@@ -1698,13 +1826,21 @@
 
     "parse-json/lines-and-columns": ["lines-and-columns@1.2.4", "", {}, "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="],
 
+    "send/mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
+
     "slice-ansi/ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
 
     "slice-ansi/is-fullwidth-code-point": ["is-fullwidth-code-point@4.0.0", "", {}, "sha512-O4L094N2/dZ7xqVdrXhh9r1KODPJpFms8B5sGdJLPy664AgvXsreZUyCQQNItZRDlYug4xStLjNp/sz3HvBowQ=="],
 
     "tsx/esbuild": ["esbuild@0.28.1", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.28.1", "@esbuild/android-arm": "0.28.1", "@esbuild/android-arm64": "0.28.1", "@esbuild/android-x64": "0.28.1", "@esbuild/darwin-arm64": "0.28.1", "@esbuild/darwin-x64": "0.28.1", "@esbuild/freebsd-arm64": "0.28.1", "@esbuild/freebsd-x64": "0.28.1", "@esbuild/linux-arm": "0.28.1", "@esbuild/linux-arm64": "0.28.1", "@esbuild/linux-ia32": "0.28.1", "@esbuild/linux-loong64": "0.28.1", "@esbuild/linux-mips64el": "0.28.1", "@esbuild/linux-ppc64": "0.28.1", "@esbuild/linux-riscv64": "0.28.1", "@esbuild/linux-s390x": "0.28.1", "@esbuild/linux-x64": "0.28.1", "@esbuild/netbsd-arm64": "0.28.1", "@esbuild/netbsd-x64": "0.28.1", "@esbuild/openbsd-arm64": "0.28.1", "@esbuild/openbsd-x64": "0.28.1", "@esbuild/openharmony-arm64": "0.28.1", "@esbuild/sunos-x64": "0.28.1", "@esbuild/win32-arm64": "0.28.1", "@esbuild/win32-ia32": "0.28.1", "@esbuild/win32-x64": "0.28.1" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw=="],
 
+    "type-is/content-type": ["content-type@2.0.0", "", {}, "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ=="],
+
+    "type-is/mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
+
     "vite/esbuild": ["esbuild@0.28.1", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.28.1", "@esbuild/android-arm": "0.28.1", "@esbuild/android-arm64": "0.28.1", "@esbuild/android-x64": "0.28.1", "@esbuild/darwin-arm64": "0.28.1", "@esbuild/darwin-x64": "0.28.1", "@esbuild/freebsd-arm64": "0.28.1", "@esbuild/freebsd-x64": "0.28.1", "@esbuild/linux-arm": "0.28.1", "@esbuild/linux-arm64": "0.28.1", "@esbuild/linux-ia32": "0.28.1", "@esbuild/linux-loong64": "0.28.1", "@esbuild/linux-mips64el": "0.28.1", "@esbuild/linux-ppc64": "0.28.1", "@esbuild/linux-riscv64": "0.28.1", "@esbuild/linux-s390x": "0.28.1", "@esbuild/linux-x64": "0.28.1", "@esbuild/netbsd-arm64": "0.28.1", "@esbuild/netbsd-x64": "0.28.1", "@esbuild/openbsd-arm64": "0.28.1", "@esbuild/openbsd-x64": "0.28.1", "@esbuild/openharmony-arm64": "0.28.1", "@esbuild/sunos-x64": "0.28.1", "@esbuild/win32-arm64": "0.28.1", "@esbuild/win32-ia32": "0.28.1", "@esbuild/win32-x64": "0.28.1" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw=="],
+
+    "whatwg-encoding/iconv-lite": ["iconv-lite@0.6.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw=="],
 
     "yargs/cliui": ["cliui@9.0.1", "", { "dependencies": { "string-width": "^7.2.0", "strip-ansi": "^7.1.0", "wrap-ansi": "^9.0.0" } }, "sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w=="],
 
@@ -1734,6 +1870,8 @@
 
     "@ready-for-agent/cli/effect/fast-check": ["fast-check@4.9.0", "", { "dependencies": { "pure-rand": "^8.0.0" } }, "sha512-7ms6T7SybUev/PQITciI0yLM2pOSFy5zpG8Ty7tQofcVaQUvrMXp6CBwqF6fThLCLOrfBtuHAtwq6Yu4XPCllg=="],
 
+    "accepts/mime-types/mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
+
     "babel-plugin-macros/cosmiconfig/yaml": ["yaml@1.10.3", "", {}, "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA=="],
 
     "cli-truncate/string-width/emoji-regex": ["emoji-regex@9.2.2", "", {}, "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="],
@@ -1750,6 +1888,8 @@
 
     "effect-solutions/effect/uuid": ["uuid@13.0.2", "", { "bin": { "uuid": "dist-node/bin/uuid" } }, "sha512-vzi9uRZ926x4XV73S/4qQaTwPXM2JBj6/6lI/byHH1jOpCzb0zDbfytgA9LcN/hzb2l7WQSQnxITOVx5un/wGw=="],
 
+    "express/mime-types/mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
+
     "glob/minimatch/brace-expansion": ["brace-expansion@1.1.16", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw=="],
 
     "listr2/wrap-ansi/ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
@@ -1765,6 +1905,8 @@
     "log-update/wrap-ansi/ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
 
     "log-update/wrap-ansi/string-width": ["string-width@5.1.2", "", { "dependencies": { "eastasianwidth": "^0.2.0", "emoji-regex": "^9.2.2", "strip-ansi": "^7.0.1" } }, "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA=="],
+
+    "send/mime-types/mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
 
     "tsx/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.28.1", "", { "os": "aix", "cpu": "ppc64" }, "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ=="],
 
@@ -1817,6 +1959,8 @@
     "tsx/esbuild/@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.28.1", "", { "os": "win32", "cpu": "ia32" }, "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg=="],
 
     "tsx/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.28.1", "", { "os": "win32", "cpu": "x64" }, "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A=="],
+
+    "type-is/mime-types/mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
 
     "vite/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.28.1", "", { "os": "aix", "cpu": "ppc64" }, "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ=="],
 

--- a/docs/adr/0004-development-keymaxxer-sidecar.md
+++ b/docs/adr/0004-development-keymaxxer-sidecar.md
@@ -1,0 +1,17 @@
+# Development Keymaxxer Sidecar
+
+Ready for Agent uses a shared backend Keymaxxer Service that never exposes raw secret values. During `api:serve`, a workspace-local sidecar owns the long-lived Keymaxxer MCP session so API reloads do not repeat vault-unlock or secret-use approval prompts; production creates the MCP client in-process and does not run a sidecar.
+
+The sidecar is a development tool attached specifically to `api:serve` and is restricted to loopback communication. Remote sidecar URLs and remote authentication are deliberately unsupported because the service can execute commands with injected secrets and there is no remote-use requirement.
+
+Because loopback alone does not prevent requests from malicious webpages, operation endpoints reject requests with an `Origin` header and require `application/json`. This causes browser JSON requests to require a CORS preflight, which the sidecar does not permit.
+
+Development uses fixed loopback port `5032`, overridable with `KEYMAXXER_SIDECAR_PORT`; `api:serve` selects it through `KEYMAXXER_SIDECAR_URL`. A port conflict fails fast and names the override instead of choosing a dynamic port that Nx cannot communicate to the API process.
+
+The MCP launcher preserves the known-good development precedence: `KEYMAXXER_ENTRYPOINT`, then `/home/berend/src/contrib/keymaxxer/packages/cli/src/index.ts` when present, then the installed `keymaxxer` command. The machine-specific fallback is deliberate while Ready for Agent depends on unreleased local Keymaxxer features.
+
+The Keymaxxer child inherits the backend environment except repository-scoped `GITHUB_TOKEN_<OWNER>_<REPO>` values. Those tokens must not cross into the credential broker process.
+
+Keymaxxer initialization gates API startup in development and production. The sidecar listens before lazily and idempotently initializing its MCP session on request; an unreachable or failed configured sidecar stops the API and never falls back to an in-process client, because fallback would silently restore repeated approval prompts.
+
+The API retries initial sidecar connection refusal for at most five seconds to tolerate Nx process-start ordering. Once the sidecar responds, initialization or protocol failures fail immediately rather than being hidden by retries.

--- a/nx.json
+++ b/nx.json
@@ -61,7 +61,8 @@
       "cache": true
     },
     "typecheck": {
-      "cache": true
+      "cache": true,
+      "dependsOn": ["^build"]
     }
   }
 }

--- a/packages/keymaxxer-service/README.md
+++ b/packages/keymaxxer-service/README.md
@@ -1,0 +1,31 @@
+# Keymaxxer Service
+
+Reusable Effect boundary for Keymaxxer vault operations. `KeymaxxerService`
+supports initializing the session, checking whether a named secret exists,
+opening Keymaxxer's add-secret flow, and running a command with named secrets
+injected.
+
+The boundary never returns raw secret values. `runWithSecrets` returns only the
+exit code and separate stdout and stderr streams. A non-zero exit is a command
+result; transport, protocol, and execution failures use `KeymaxxerError`.
+
+## Layers
+
+- `mcpKeymaxxerLayer()` owns a lazy, scoped stdio MCP client. It is used by
+  production processes and by the development sidecar.
+- `sidecarKeymaxxerLayer(url)` is the strict loopback HTTP client used by the
+  watched API. It accepts only `http://127.0.0.1:<port>`.
+- `testKeymaxxerLayer(secretNames)` is an in-memory implementation for tests.
+
+The HTTP protocol uses shared Effect schemas, rejects unknown fields and raw
+secret-shaped response fields, blocks browser-originated and non-JSON operation
+requests, and versions its non-initializing `/health` response. Sidecar
+connection refusal is retried for at most five seconds during startup; hanging
+health requests share that deadline, and HTTP and protocol failures are not
+retried.
+
+## Commands
+
+- `bunx nx run keymaxxer-service:build`
+- `bunx nx run keymaxxer-service:test`
+- `bunx nx run keymaxxer-service:typecheck`

--- a/packages/keymaxxer-service/package.json
+++ b/packages/keymaxxer-service/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@ready-for-agent/keymaxxer-service",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    "./package.json": "./package.json",
+    ".": {
+      "@ready-for-agent/source": "./src/index.ts",
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    }
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.29.0",
+    "effect": "^3.21.4",
+    "tslib": "^2.3.0"
+  }
+}

--- a/packages/keymaxxer-service/project.json
+++ b/packages/keymaxxer-service/project.json
@@ -1,0 +1,18 @@
+{
+  "name": "keymaxxer-service",
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "packages/keymaxxer-service/src",
+  "projectType": "library",
+  "tags": [],
+  "targets": {
+    "test": {
+      "executor": "nx:run-commands",
+      "options": {
+        "cwd": "{projectRoot}",
+        "command": "bun test"
+      },
+      "inputs": ["default", "^production"],
+      "cache": true
+    }
+  }
+}

--- a/packages/keymaxxer-service/src/index.ts
+++ b/packages/keymaxxer-service/src/index.ts
@@ -1,0 +1,5 @@
+export * from "./lib/http-layer.js"
+export * from "./lib/mcp-layer.js"
+export * from "./lib/models.js"
+export * from "./lib/service.js"
+export * from "./lib/sidecar.js"

--- a/packages/keymaxxer-service/src/lib/http-layer.ts
+++ b/packages/keymaxxer-service/src/lib/http-layer.ts
@@ -1,0 +1,201 @@
+import { Effect, Layer, Schema } from "effect"
+import {
+  AddSecretResponse,
+  HasSecretResponse,
+  HealthResponse,
+  InitializeResponse,
+  KeymaxxerError,
+  RunWithSecretsResult,
+  containsRawSecretValue,
+  validateRunInput,
+  validateSecretName,
+} from "./models.js"
+import { KeymaxxerService, type KeymaxxerServiceShape } from "./service.js"
+
+export type SidecarLayerOptions = {
+  readonly fetch?: typeof globalThis.fetch
+  readonly retryDelayMs?: number
+  readonly startupTimeoutMs?: number
+}
+
+export const sidecarKeymaxxerLayer = (
+  value: string,
+  options: SidecarLayerOptions = {},
+): Layer.Layer<KeymaxxerService, KeymaxxerError> =>
+  Layer.effect(
+    KeymaxxerService,
+    Effect.try({
+      try: () => makeSidecarService(parseSidecarUrl(value), options),
+      catch: () => safeError("configure", "Invalid Keymaxxer sidecar URL"),
+    }),
+  )
+
+export const parseSidecarUrl = (value: string) => {
+  const url = new URL(value)
+  if (
+    url.protocol !== "http:" ||
+    url.hostname !== "127.0.0.1" ||
+    url.username !== "" ||
+    url.password !== "" ||
+    url.pathname !== "/" ||
+    url.search !== "" ||
+    url.hash !== "" ||
+    url.port === ""
+  ) {
+    throw new Error("Sidecar URL must be an HTTP IPv4 loopback origin")
+  }
+  return url
+}
+
+const makeSidecarService = (
+  baseUrl: URL,
+  options: SidecarLayerOptions,
+): KeymaxxerServiceShape => {
+  const fetchImplementation = options.fetch ?? globalThis.fetch
+  const retryDelayMs = options.retryDelayMs ?? 100
+  const startupTimeoutMs = options.startupTimeoutMs ?? 5_000
+
+  const request = <A, I>(
+    operation: string,
+    path: string,
+    schema: Schema.Schema<A, I>,
+    responseKeys: readonly string[],
+    body?: unknown,
+  ) =>
+    Effect.tryPromise({
+      try: async () => {
+        const response = await fetchImplementation(new URL(path, baseUrl), {
+          ...(body === undefined ? {} : { body: JSON.stringify(body) }),
+          headers:
+            body === undefined
+              ? undefined
+              : { "content-type": "application/json" },
+          method: body === undefined ? "GET" : "POST",
+        })
+        if (!response.ok) {
+          throw new Error(`HTTP ${response.status}`)
+        }
+        return (await response.json()) as unknown
+      },
+      catch: () => safeError(operation, "Keymaxxer sidecar request failed"),
+    }).pipe(
+      Effect.flatMap((json) =>
+        containsRawSecretValue(json) || !hasExactKeys(json, responseKeys)
+          ? Effect.fail(
+              safeError(operation, "Keymaxxer sidecar request failed"),
+            )
+          : Schema.decodeUnknown(schema)(json).pipe(
+              Effect.mapError(() =>
+                safeError(operation, "Keymaxxer sidecar request failed"),
+              ),
+            ),
+      ),
+    )
+
+  const waitForHealth = (): Effect.Effect<void, KeymaxxerError> => {
+    const startedAt = Date.now()
+    const connect = (): Effect.Effect<Response, KeymaxxerError> =>
+      Effect.tryPromise({
+        try: () => {
+          const remainingMs = Math.max(
+            1,
+            startupTimeoutMs - (Date.now() - startedAt),
+          )
+          return fetchImplementation(new URL("/health", baseUrl), {
+            signal: AbortSignal.timeout(remainingMs),
+          })
+        },
+        catch: () =>
+          safeError("initialize", "Keymaxxer sidecar request failed"),
+      }).pipe(
+        Effect.catchAll((error) =>
+          Date.now() - startedAt >= startupTimeoutMs
+            ? Effect.fail(error)
+            : Effect.sleep(`${retryDelayMs} millis`).pipe(
+                Effect.flatMap(connect),
+              ),
+        ),
+      )
+
+    return connect().pipe(
+      Effect.flatMap((response) =>
+        Effect.tryPromise({
+          try: async () => {
+            if (!response.ok) throw new Error("Health request failed")
+            return (await response.json()) as unknown
+          },
+          catch: () =>
+            safeError("initialize", "Keymaxxer sidecar request failed"),
+        }),
+      ),
+      Effect.flatMap((json) =>
+        !hasExactKeys(json, ["status", "protocolVersion"])
+          ? Effect.fail(
+              safeError("initialize", "Keymaxxer sidecar request failed"),
+            )
+          : Schema.decodeUnknown(HealthResponse)(json).pipe(
+              Effect.mapError(() =>
+                safeError("initialize", "Keymaxxer sidecar request failed"),
+              ),
+            ),
+      ),
+      Effect.asVoid,
+    )
+  }
+
+  return {
+    initialize: () =>
+      waitForHealth().pipe(
+        Effect.flatMap(() =>
+          request(
+            "initialize",
+            "/initialize",
+            InitializeResponse,
+            ["initialized"],
+            {},
+          ),
+        ),
+        Effect.asVoid,
+      ),
+    hasSecret: (name) =>
+      validateSecretName(name)
+        ? request(
+            "hasSecret",
+            "/has-secret",
+            HasSecretResponse,
+            ["hasSecret"],
+            { name },
+          ).pipe(Effect.map((result) => result.hasSecret))
+        : Effect.fail(safeError("hasSecret", "Invalid secret name")),
+    addSecret: (input) =>
+      validateSecretName(input.name)
+        ? request(
+            "addSecret",
+            "/add-secret",
+            AddSecretResponse,
+            ["added"],
+            input,
+          ).pipe(Effect.map((result) => result.added))
+        : Effect.fail(safeError("addSecret", "Invalid secret name")),
+    runWithSecrets: (input) =>
+      validateRunInput(input)
+        ? request(
+            "runWithSecrets",
+            "/run-with-secrets",
+            RunWithSecretsResult,
+            ["exitCode", "stdout", "stderr"],
+            input,
+          )
+        : Effect.fail(safeError("runWithSecrets", "Invalid command input")),
+  }
+}
+
+const safeError = (operation: string, message: string) =>
+  new KeymaxxerError({ operation, message })
+
+const hasExactKeys = (value: unknown, keys: readonly string[]) =>
+  typeof value === "object" &&
+  value !== null &&
+  !Array.isArray(value) &&
+  Object.keys(value).length === keys.length &&
+  Object.keys(value).every((key) => keys.includes(key))

--- a/packages/keymaxxer-service/src/lib/mcp-layer.ts
+++ b/packages/keymaxxer-service/src/lib/mcp-layer.ts
@@ -1,0 +1,284 @@
+import { existsSync } from "node:fs"
+import { Client } from "@modelcontextprotocol/sdk/client/index.js"
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js"
+import { Effect, Layer } from "effect"
+import {
+  KeymaxxerError,
+  validateRunInput,
+  validateSecretName,
+} from "./models.js"
+import { KeymaxxerService, type KeymaxxerServiceShape } from "./service.js"
+
+type ToolResult = {
+  readonly content?: unknown
+  readonly isError?: boolean
+  readonly structuredContent?: unknown
+}
+
+export interface KeymaxxerToolClient {
+  readonly callTool: (input: {
+    readonly arguments: Record<string, unknown>
+    readonly name: string
+  }) => Promise<ToolResult>
+  readonly close: () => Promise<void>
+}
+
+export type McpLayerOptions = {
+  readonly createClient?: () => Promise<KeymaxxerToolClient>
+  readonly environment?: Partial<Record<string, string | undefined>>
+}
+
+export const mcpKeymaxxerLayer = (
+  options: McpLayerOptions = {},
+): Layer.Layer<KeymaxxerService> =>
+  Layer.scoped(
+    KeymaxxerService,
+    Effect.acquireRelease(
+      Effect.sync(() => makeMcpService(options)),
+      (managed) => Effect.promise(managed.close),
+    ).pipe(Effect.map((managed) => managed.service)),
+  )
+
+const makeMcpService = (options: McpLayerOptions) => {
+  let clientPromise: Promise<KeymaxxerToolClient> | null = null
+  let secretNamesPromise: Promise<Set<string>> | null = null
+
+  const getClient = () => {
+    clientPromise ??= (
+      options.createClient ?? (() => createToolClient(options))
+    )()
+    return clientPromise
+  }
+
+  const callTool = async (
+    operation: string,
+    name: string,
+    args: Record<string, unknown>,
+  ) => {
+    try {
+      const result = await (await getClient()).callTool({
+        arguments: args,
+        name,
+      })
+      return {
+        isError: result.isError === true,
+        structuredContent: result.structuredContent,
+        text: toolResultText(result),
+      }
+    } catch {
+      const failedClient = clientPromise
+      clientPromise = null
+      secretNamesPromise = null
+      await failedClient
+        ?.then((client) => client.close())
+        .catch(() => undefined)
+      throw safeError(operation, "Keymaxxer operation failed")
+    }
+  }
+
+  const listSecretNames = async (refresh = false) => {
+    if (!refresh && secretNamesPromise !== null) return secretNamesPromise
+
+    secretNamesPromise = callTool("hasSecret", "keymaxxer_list", {}).then(
+      (result) => {
+        if (result.isError)
+          throw safeError("hasSecret", "Keymaxxer list failed")
+        return parseSecretNames(result.text)
+      },
+    )
+    secretNamesPromise.catch(() => {
+      secretNamesPromise = null
+    })
+    return secretNamesPromise
+  }
+
+  const service: KeymaxxerServiceShape = {
+    initialize: () =>
+      Effect.tryPromise({
+        try: () => listSecretNames().then(() => undefined),
+        catch: () => safeError("initialize", "Keymaxxer initialization failed"),
+      }),
+    hasSecret: (name) =>
+      validateSecretName(name)
+        ? Effect.tryPromise({
+            try: async () => {
+              const names = await listSecretNames()
+              return names.has(name) || (await listSecretNames(true)).has(name)
+            },
+            catch: () => safeError("hasSecret", "Keymaxxer list failed"),
+          })
+        : Effect.fail(safeError("hasSecret", "Invalid secret name")),
+    addSecret: (input) =>
+      validateSecretName(input.name)
+        ? Effect.tryPromise({
+            try: async () => {
+              const result = await callTool("addSecret", "keymaxxer_add", input)
+              if (result.text.toLowerCase().includes("cancelled")) return false
+              if (result.isError) {
+                throw safeError("addSecret", "Keymaxxer add failed")
+              }
+              ;(await listSecretNames()).add(input.name)
+              return true
+            },
+            catch: () => safeError("addSecret", "Keymaxxer add failed"),
+          })
+        : Effect.fail(safeError("addSecret", "Invalid secret name")),
+    runWithSecrets: (input) =>
+      validateRunInput(input)
+        ? Effect.tryPromise({
+            try: async () => {
+              const result = await callTool(
+                "runWithSecrets",
+                "keymaxxer_run",
+                input,
+              )
+              const parsed =
+                parseStructuredRunResult(result.structuredContent) ??
+                parseRunResult(result.text)
+              if (parsed === null) {
+                throw safeError(
+                  "runWithSecrets",
+                  "Keymaxxer returned an invalid command result",
+                )
+              }
+              return parsed
+            },
+            catch: () =>
+              safeError("runWithSecrets", "Keymaxxer command failed"),
+          })
+        : Effect.fail(safeError("runWithSecrets", "Invalid command input")),
+  }
+
+  return {
+    service,
+    close: async () => {
+      const current = clientPromise
+      clientPromise = null
+      secretNamesPromise = null
+      await current?.then((client) => client.close()).catch(() => undefined)
+    },
+  }
+}
+
+const createToolClient = async (
+  options: McpLayerOptions,
+): Promise<KeymaxxerToolClient> => {
+  const environment = options.environment ?? process.env
+  const launch = keymaxxerMcpCommand(environment)
+  const client = new Client({ name: "ready-for-agent", version: "0.0.0" })
+  const transport = new StdioClientTransport({
+    args: launch.args,
+    command: launch.command,
+    env: keymaxxerEnvironment(environment),
+    stderr: "pipe",
+  })
+  await client.connect(transport)
+
+  return {
+    callTool: (input) =>
+      client.callTool(input).then((result) => result as unknown as ToolResult),
+    close: () => transport.close(),
+  }
+}
+
+export const keymaxxerEnvironment = (
+  environment: Partial<Record<string, string | undefined>>,
+) =>
+  Object.fromEntries(
+    Object.entries(environment).filter(
+      ([name, value]) =>
+        value !== undefined &&
+        name !== "GITHUB_TOKEN" &&
+        !name.startsWith("GITHUB_TOKEN_"),
+    ),
+  ) as Record<string, string>
+
+export const keymaxxerMcpCommand = (
+  environment: Partial<Record<string, string | undefined>> = process.env,
+) => {
+  const entrypoint =
+    environment.KEYMAXXER_ENTRYPOINT ??
+    "/home/berend/src/contrib/keymaxxer/packages/cli/src/index.ts"
+
+  return existsSync(entrypoint)
+    ? { command: "bun", args: [entrypoint, "serve"] }
+    : { command: "keymaxxer", args: ["serve"] }
+}
+
+const toolResultText = (result: ToolResult) =>
+  Array.isArray(result.content)
+    ? result.content
+        .map((item: unknown) =>
+          typeof item === "object" &&
+          item !== null &&
+          "type" in item &&
+          item.type === "text" &&
+          "text" in item &&
+          typeof item.text === "string"
+            ? item.text
+            : "",
+        )
+        .join("\n")
+    : ""
+
+const parseSecretNames = (text: string) => {
+  const parsed = JSON.parse(text) as unknown
+  if (!Array.isArray(parsed)) throw new Error("Invalid secret list")
+
+  const names = new Set<string>()
+  for (const item of parsed) {
+    if (
+      typeof item === "object" &&
+      item !== null &&
+      "name" in item &&
+      typeof item.name === "string"
+    ) {
+      names.add(item.name)
+    }
+  }
+  return names
+}
+
+const parseRunResult = (text: string) => {
+  const exitCode = text.match(/^exit_code: (-?\d+)$/m)
+  const stdoutMarker = "--- stdout ---\n"
+  const stderrMarker = "\n--- stderr ---\n"
+  const stdoutStart = text.indexOf(stdoutMarker)
+  const stderrStart = text.indexOf(
+    stderrMarker,
+    stdoutStart + stdoutMarker.length,
+  )
+  const repeatedMarker = text.indexOf(stderrMarker, stderrStart + 1)
+  if (!exitCode || stdoutStart < 0 || stderrStart < stdoutStart) return null
+  if (repeatedMarker >= 0) return null
+
+  return {
+    exitCode: Number.parseInt(exitCode[1] ?? "", 10),
+    stdout: text.slice(stdoutStart + stdoutMarker.length, stderrStart),
+    stderr: text.slice(stderrStart + stderrMarker.length),
+  }
+}
+
+const parseStructuredRunResult = (value: unknown) => {
+  if (
+    typeof value !== "object" ||
+    value === null ||
+    !("exitCode" in value) ||
+    typeof value.exitCode !== "number" ||
+    !("stdout" in value) ||
+    typeof value.stdout !== "string" ||
+    !("stderr" in value) ||
+    typeof value.stderr !== "string"
+  ) {
+    return null
+  }
+
+  return {
+    exitCode: value.exitCode,
+    stdout: value.stdout,
+    stderr: value.stderr,
+  }
+}
+
+const safeError = (operation: string, message: string) =>
+  new KeymaxxerError({ operation, message })

--- a/packages/keymaxxer-service/src/lib/models.ts
+++ b/packages/keymaxxer-service/src/lib/models.ts
@@ -1,0 +1,83 @@
+import { Schema } from "effect"
+
+export const SecretName = Schema.String
+export type SecretName = typeof SecretName.Type
+
+export const AddSecretInput = Schema.Struct({
+  name: SecretName,
+  provider: Schema.optional(Schema.String),
+  account: Schema.optional(Schema.String),
+  environment: Schema.optional(Schema.String),
+  access: Schema.optional(Schema.String),
+  description: Schema.optional(Schema.String),
+  tags: Schema.optional(Schema.String),
+})
+export type AddSecretInput = typeof AddSecretInput.Type
+
+export const HasSecretInput = Schema.Struct({ name: SecretName })
+export type HasSecretInput = typeof HasSecretInput.Type
+
+export const RunWithSecretsInput = Schema.Struct({
+  command: Schema.String,
+  cwd: Schema.String,
+  secrets: Schema.Array(SecretName),
+  timeoutMs: Schema.Number,
+})
+export type RunWithSecretsInput = typeof RunWithSecretsInput.Type
+
+export const RunWithSecretsResult = Schema.Struct({
+  exitCode: Schema.Number,
+  stdout: Schema.String,
+  stderr: Schema.String,
+})
+export type RunWithSecretsResult = typeof RunWithSecretsResult.Type
+
+export const HealthResponse = Schema.Struct({
+  status: Schema.Literal("ok"),
+  protocolVersion: Schema.Literal(1),
+})
+
+export const InitializeResponse = Schema.Struct({
+  initialized: Schema.Literal(true),
+})
+export const HasSecretResponse = Schema.Struct({ hasSecret: Schema.Boolean })
+export const AddSecretResponse = Schema.Struct({ added: Schema.Boolean })
+
+export const protocolVersion = 1 as const
+
+export class KeymaxxerError extends Schema.TaggedError<KeymaxxerError>()(
+  "KeymaxxerError",
+  {
+    operation: Schema.String,
+    message: Schema.String,
+  },
+) {}
+
+const secretNamePattern = /^[A-Za-z_][A-Za-z0-9_]*$/
+
+export const validateSecretName = (name: string) => secretNamePattern.test(name)
+
+export const validateRunInput = (input: RunWithSecretsInput) =>
+  input.command.trim() !== "" &&
+  input.cwd.startsWith("/") &&
+  input.secrets.length > 0 &&
+  input.secrets.every(validateSecretName) &&
+  new Set(input.secrets).size === input.secrets.length &&
+  Number.isInteger(input.timeoutMs) &&
+  input.timeoutMs > 0
+
+export const containsRawSecretValue = (value: unknown): boolean => {
+  if (Array.isArray(value)) {
+    return value.some(containsRawSecretValue)
+  }
+
+  if (typeof value !== "object" || value === null) {
+    return false
+  }
+
+  return Object.entries(value).some(
+    ([key, child]) =>
+      ["secret", "secretValue", "value"].includes(key) ||
+      containsRawSecretValue(child),
+  )
+}

--- a/packages/keymaxxer-service/src/lib/service.ts
+++ b/packages/keymaxxer-service/src/lib/service.ts
@@ -1,0 +1,44 @@
+import { Context, Effect, Layer } from "effect"
+import type {
+  AddSecretInput,
+  KeymaxxerError,
+  RunWithSecretsInput,
+  RunWithSecretsResult,
+  SecretName,
+} from "./models.js"
+
+export interface KeymaxxerServiceShape {
+  readonly initialize: () => Effect.Effect<void, KeymaxxerError>
+  readonly hasSecret: (
+    name: SecretName,
+  ) => Effect.Effect<boolean, KeymaxxerError>
+  readonly addSecret: (
+    input: AddSecretInput,
+  ) => Effect.Effect<boolean, KeymaxxerError>
+  readonly runWithSecrets: (
+    input: RunWithSecretsInput,
+  ) => Effect.Effect<RunWithSecretsResult, KeymaxxerError>
+}
+
+export class KeymaxxerService extends Context.Tag(
+  "@ready-for-agent/keymaxxer-service/KeymaxxerService",
+)<KeymaxxerService, KeymaxxerServiceShape>() {}
+
+export const testKeymaxxerLayer = (
+  secretNames: readonly string[] = [],
+): Layer.Layer<KeymaxxerService> =>
+  Layer.sync(KeymaxxerService, () => {
+    const secrets = new Set(secretNames)
+
+    return {
+      initialize: () => Effect.void,
+      hasSecret: (name: SecretName) => Effect.succeed(secrets.has(name)),
+      addSecret: (input: AddSecretInput) =>
+        Effect.sync(() => {
+          secrets.add(input.name)
+          return true
+        }),
+      runWithSecrets: () =>
+        Effect.succeed({ exitCode: 0, stdout: "", stderr: "" }),
+    }
+  })

--- a/packages/keymaxxer-service/src/lib/sidecar.ts
+++ b/packages/keymaxxer-service/src/lib/sidecar.ts
@@ -1,0 +1,158 @@
+import { Effect, Schema } from "effect"
+import {
+  AddSecretInput,
+  AddSecretResponse,
+  HasSecretInput,
+  HasSecretResponse,
+  InitializeResponse,
+  KeymaxxerError,
+  RunWithSecretsInput,
+  RunWithSecretsResult,
+  protocolVersion,
+  validateRunInput,
+  validateSecretName,
+} from "./models.js"
+import type { KeymaxxerServiceShape } from "./service.js"
+
+type RunEffect = <A>(effect: Effect.Effect<A, KeymaxxerError>) => Promise<A>
+
+export const createKeymaxxerSidecarFetch = (
+  keymaxxer: KeymaxxerServiceShape,
+  runEffect: RunEffect = Effect.runPromise,
+): ((request: Request) => Promise<Response>) => {
+  let initializePromise: Promise<void> | null = null
+
+  const initialize = () => {
+    initializePromise ??= runEffect(keymaxxer.initialize()).catch((error) => {
+      initializePromise = null
+      throw error
+    })
+    return initializePromise
+  }
+
+  return async (request: Request) => {
+    const url = new URL(request.url)
+    if (request.method === "GET" && url.pathname === "/health") {
+      return Response.json({ status: "ok", protocolVersion })
+    }
+    if (request.method !== "POST") return notFound()
+    if (request.headers.has("origin")) {
+      return new Response("browser requests are forbidden", { status: 403 })
+    }
+    if (!isJsonRequest(request)) {
+      return new Response("application/json required", { status: 415 })
+    }
+
+    try {
+      switch (url.pathname) {
+        case "/initialize":
+          assertExactKeys(await requestBody(request), [])
+          await initialize()
+          return schemaResponse(InitializeResponse, {
+            initialized: true,
+          } as const)
+        case "/has-secret": {
+          const input = decodeRequest(
+            HasSecretInput,
+            await requestBody(request),
+            ["name"],
+          )
+          if (!validateSecretName(input.name)) return invalidInput()
+          return schemaResponse(HasSecretResponse, {
+            hasSecret: await runEffect(keymaxxer.hasSecret(input.name)),
+          })
+        }
+        case "/add-secret": {
+          const keys = [
+            "name",
+            "provider",
+            "account",
+            "environment",
+            "access",
+            "description",
+            "tags",
+          ]
+          const input = decodeRequest(
+            AddSecretInput,
+            await requestBody(request),
+            keys,
+          )
+          if (!validateSecretName(input.name)) return invalidInput()
+          return schemaResponse(AddSecretResponse, {
+            added: await runEffect(keymaxxer.addSecret(input)),
+          })
+        }
+        case "/run-with-secrets": {
+          const input = decodeRequest(
+            RunWithSecretsInput,
+            await requestBody(request),
+            ["command", "cwd", "secrets", "timeoutMs"],
+          )
+          if (!validateRunInput(input)) return invalidInput()
+          const result = await runEffect(keymaxxer.runWithSecrets(input))
+          return schemaResponse(RunWithSecretsResult, result)
+        }
+        default:
+          return notFound()
+      }
+    } catch (error) {
+      if (error instanceof InvalidRequestError) return invalidInput()
+      const operation =
+        error instanceof KeymaxxerError ? error.operation : "sidecar"
+      return Response.json(
+        new KeymaxxerError({
+          operation,
+          message: "Keymaxxer operation failed",
+        }),
+        { status: 500 },
+      )
+    }
+  }
+}
+
+class InvalidRequestError extends Error {}
+
+const requestBody = async (request: Request): Promise<unknown> => {
+  try {
+    return (await request.json()) as unknown
+  } catch {
+    throw new InvalidRequestError()
+  }
+}
+
+const decodeRequest = <A, I>(
+  schema: Schema.Schema<A, I>,
+  value: unknown,
+  keys: readonly string[],
+) => {
+  assertExactKeys(value, keys)
+  try {
+    return Schema.decodeUnknownSync(schema)(value)
+  } catch {
+    throw new InvalidRequestError()
+  }
+}
+
+const assertExactKeys = (value: unknown, allowedKeys: readonly string[]) => {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    throw new InvalidRequestError()
+  }
+  if (Object.keys(value).some((key) => !allowedKeys.includes(key))) {
+    throw new InvalidRequestError()
+  }
+}
+
+const schemaResponse = <A, I>(schema: Schema.Schema<A, I>, value: A) =>
+  Response.json(Schema.encodeSync(schema)(value))
+
+const invalidInput = () =>
+  Response.json({ error: "invalid request" }, { status: 400 })
+
+const notFound = () => new Response("not found", { status: 404 })
+
+const isJsonRequest = (request: Request) =>
+  request.headers
+    .get("content-type")
+    ?.split(";", 1)[0]
+    ?.trim()
+    .toLowerCase() === "application/json"

--- a/packages/keymaxxer-service/test/mcp-layer.test.ts
+++ b/packages/keymaxxer-service/test/mcp-layer.test.ts
@@ -1,0 +1,244 @@
+import { Effect } from "effect"
+import {
+  KeymaxxerService,
+  type KeymaxxerToolClient,
+  keymaxxerEnvironment,
+  keymaxxerMcpCommand,
+  mcpKeymaxxerLayer,
+} from "../src/index.js"
+import { describe, expect, test } from "bun:test"
+
+const textResult = (text: string, isError = false) => ({
+  content: [{ type: "text", text }],
+  isError,
+})
+
+describe("MCP Keymaxxer layer", () => {
+  test("caches hits and refreshes misses", async () => {
+    let listCalls = 0
+    const client: KeymaxxerToolClient = {
+      callTool: async ({ name }) => {
+        expect(name).toBe("keymaxxer_list")
+        listCalls += 1
+        return textResult(
+          JSON.stringify(
+            listCalls === 1
+              ? [{ name: "EXISTING_SECRET" }]
+              : [{ name: "EXISTING_SECRET" }, { name: "LATER_SECRET" }],
+          ),
+        )
+      },
+      close: async () => {},
+    }
+
+    const result = await Effect.runPromise(
+      Effect.gen(function* () {
+        const keymaxxer = yield* KeymaxxerService
+        const existing = yield* keymaxxer.hasSecret("EXISTING_SECRET")
+        const existingAgain = yield* keymaxxer.hasSecret("EXISTING_SECRET")
+        const later = yield* keymaxxer.hasSecret("LATER_SECRET")
+        return { existing, existingAgain, later }
+      }).pipe(
+        Effect.provide(mcpKeymaxxerLayer({ createClient: async () => client })),
+      ),
+    )
+
+    expect(result).toEqual({
+      existing: true,
+      existingAgain: true,
+      later: true,
+    })
+    expect(listCalls).toBe(2)
+  })
+
+  test("updates the cache after add and treats cancellation as false", async () => {
+    const calls: string[] = []
+    const client: KeymaxxerToolClient = {
+      callTool: async ({ arguments: input, name }) => {
+        calls.push(name)
+        if (name === "keymaxxer_list") return textResult("[]")
+        if (input.name === "CANCELLED_SECRET") {
+          return textResult("Secret entry cancelled", true)
+        }
+        return textResult("Secret saved")
+      },
+      close: async () => {},
+    }
+
+    const result = await Effect.runPromise(
+      Effect.gen(function* () {
+        const keymaxxer = yield* KeymaxxerService
+        yield* keymaxxer.initialize()
+        const added = yield* keymaxxer.addSecret({ name: "NEW_SECRET" })
+        const present = yield* keymaxxer.hasSecret("NEW_SECRET")
+        const cancelled = yield* keymaxxer.addSecret({
+          name: "CANCELLED_SECRET",
+        })
+        return { added, present, cancelled }
+      }).pipe(
+        Effect.provide(mcpKeymaxxerLayer({ createClient: async () => client })),
+      ),
+    )
+
+    expect(result).toEqual({ added: true, present: true, cancelled: false })
+    expect(calls).toEqual(["keymaxxer_list", "keymaxxer_add", "keymaxxer_add"])
+  })
+
+  test("returns non-zero command results with separate output streams", async () => {
+    const client: KeymaxxerToolClient = {
+      callTool: async () =>
+        textResult(
+          "exit_code: 7\n--- stdout ---\nmachine output\n--- stderr ---\ndiagnostic",
+        ),
+      close: async () => {},
+    }
+
+    const result = await Effect.runPromise(
+      Effect.gen(function* () {
+        const keymaxxer = yield* KeymaxxerService
+        return yield* keymaxxer.runWithSecrets({
+          command: "gh issue list",
+          cwd: "/tmp",
+          secrets: ["GITHUB_TOKEN_REPOSITORY"],
+          timeoutMs: 1_000,
+        })
+      }).pipe(
+        Effect.provide(mcpKeymaxxerLayer({ createClient: async () => client })),
+      ),
+    )
+
+    expect(result).toEqual({
+      exitCode: 7,
+      stdout: "machine output",
+      stderr: "diagnostic",
+    })
+  })
+
+  test("prefers structured command results", async () => {
+    const client: KeymaxxerToolClient = {
+      callTool: async () => ({
+        content: [{ type: "text", text: "ambiguous legacy output" }],
+        structuredContent: {
+          exitCode: 3,
+          stdout: "structured stdout",
+          stderr: "structured stderr",
+        },
+      }),
+      close: async () => {},
+    }
+
+    const result = await Effect.runPromise(
+      Effect.gen(function* () {
+        const keymaxxer = yield* KeymaxxerService
+        return yield* keymaxxer.runWithSecrets({
+          command: "false",
+          cwd: "/tmp",
+          secrets: ["A_SECRET"],
+          timeoutMs: 1,
+        })
+      }).pipe(
+        Effect.provide(mcpKeymaxxerLayer({ createClient: async () => client })),
+      ),
+    )
+
+    expect(result).toEqual({
+      exitCode: 3,
+      stdout: "structured stdout",
+      stderr: "structured stderr",
+    })
+  })
+
+  test("fails safely when legacy stream delimiters are ambiguous", async () => {
+    const client: KeymaxxerToolClient = {
+      callTool: async () =>
+        textResult(
+          "exit_code: 0\n--- stdout ---\nok\n--- stderr ---\nfirst\n--- stderr ---\nsecond",
+        ),
+      close: async () => {},
+    }
+
+    const exit = await Effect.runPromise(
+      Effect.gen(function* () {
+        const keymaxxer = yield* KeymaxxerService
+        return yield* Effect.exit(
+          keymaxxer.runWithSecrets({
+            command: "printf output",
+            cwd: "/tmp",
+            secrets: ["A_SECRET"],
+            timeoutMs: 1,
+          }),
+        )
+      }).pipe(
+        Effect.provide(mcpKeymaxxerLayer({ createClient: async () => client })),
+      ),
+    )
+
+    expect(exit._tag).toBe("Failure")
+  })
+
+  test("fails invalid tool output and closes the MCP client", async () => {
+    let closed = false
+    const client: KeymaxxerToolClient = {
+      callTool: async () => textResult("not a command result"),
+      close: async () => {
+        closed = true
+      },
+    }
+
+    const exit = await Effect.runPromise(
+      Effect.gen(function* () {
+        const keymaxxer = yield* KeymaxxerService
+        return yield* Effect.exit(
+          keymaxxer.runWithSecrets({
+            command: "false",
+            cwd: "/tmp",
+            secrets: ["A_SECRET"],
+            timeoutMs: 1,
+          }),
+        )
+      }).pipe(
+        Effect.provide(mcpKeymaxxerLayer({ createClient: async () => client })),
+      ),
+    )
+
+    expect(exit._tag).toBe("Failure")
+    expect(closed).toBe(true)
+  })
+
+  test("does not turn list failures into missing secrets", async () => {
+    const client: KeymaxxerToolClient = {
+      callTool: async () => textResult("vault unavailable", true),
+      close: async () => {},
+    }
+
+    const exit = await Effect.runPromise(
+      Effect.gen(function* () {
+        const keymaxxer = yield* KeymaxxerService
+        return yield* Effect.exit(keymaxxer.hasSecret("A_SECRET"))
+      }).pipe(
+        Effect.provide(mcpKeymaxxerLayer({ createClient: async () => client })),
+      ),
+    )
+
+    expect(exit._tag).toBe("Failure")
+  })
+})
+
+describe("MCP process configuration", () => {
+  test("removes GitHub token variables from the child environment", () => {
+    expect(
+      keymaxxerEnvironment({
+        GITHUB_TOKEN: "generic",
+        GITHUB_TOKEN_OWNER_REPO: "repository",
+        HOME: "/home/test",
+      }),
+    ).toEqual({ HOME: "/home/test" })
+  })
+
+  test("uses an existing explicit Keymaxxer entrypoint", () => {
+    expect(keymaxxerMcpCommand({ KEYMAXXER_ENTRYPOINT: "/bin/true" })).toEqual({
+      command: "bun",
+      args: ["/bin/true", "serve"],
+    })
+  })
+})

--- a/packages/keymaxxer-service/test/sidecar.test.ts
+++ b/packages/keymaxxer-service/test/sidecar.test.ts
@@ -1,0 +1,352 @@
+import { Effect } from "effect"
+import {
+  KeymaxxerError,
+  KeymaxxerService,
+  type KeymaxxerServiceShape,
+  createKeymaxxerSidecarFetch,
+  sidecarKeymaxxerLayer,
+} from "../src/index.js"
+import { describe, expect, test } from "bun:test"
+
+const fakeService = (
+  overrides: Partial<KeymaxxerServiceShape> = {},
+): KeymaxxerServiceShape => ({
+  initialize: () => Effect.void,
+  hasSecret: () => Effect.succeed(false),
+  addSecret: () => Effect.succeed(true),
+  runWithSecrets: () =>
+    Effect.succeed({ exitCode: 0, stdout: "ok", stderr: "" }),
+  ...overrides,
+})
+
+const post = (url: URL, body: unknown) =>
+  fetch(url, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  })
+
+describe("Keymaxxer Sidecar protocol", () => {
+  test("health is versioned and does not initialize MCP", async () => {
+    let initializeCalls = 0
+    const server = Bun.serve({
+      hostname: "127.0.0.1",
+      port: 0,
+      fetch: createKeymaxxerSidecarFetch(
+        fakeService({
+          initialize: () =>
+            Effect.sync(() => {
+              initializeCalls += 1
+            }),
+        }),
+      ),
+    })
+
+    try {
+      const response = await fetch(new URL("/health", server.url))
+      expect(await response.json()).toEqual({
+        status: "ok",
+        protocolVersion: 1,
+      })
+      expect(initializeCalls).toBe(0)
+    } finally {
+      await server.stop(true)
+    }
+  })
+
+  test("deduplicates initialization and retries after failure", async () => {
+    let initializeCalls = 0
+    const service = fakeService({
+      initialize: () =>
+        Effect.suspend(() => {
+          initializeCalls += 1
+          return initializeCalls === 1
+            ? Effect.fail(
+                new KeymaxxerError({
+                  operation: "initialize",
+                  message: "failed",
+                }),
+              )
+            : Effect.void
+        }),
+    })
+    const fetchSidecar = createKeymaxxerSidecarFetch(service)
+    const request = () =>
+      fetchSidecar(
+        new Request("http://127.0.0.1/initialize", {
+          method: "POST",
+          body: "{}",
+          headers: { "content-type": "application/json" },
+        }),
+      )
+
+    expect((await request()).status).toBe(500)
+    expect((await request()).status).toBe(200)
+    expect((await request()).status).toBe(200)
+    expect(initializeCalls).toBe(2)
+  })
+
+  test("validates all routes and rejects unknown request fields", async () => {
+    const server = Bun.serve({
+      hostname: "127.0.0.1",
+      port: 0,
+      fetch: createKeymaxxerSidecarFetch(
+        fakeService({
+          hasSecret: (name) => Effect.succeed(name === "PRESENT_SECRET"),
+        }),
+      ),
+    })
+
+    try {
+      expect(
+        await (
+          await post(new URL("/has-secret", server.url), {
+            name: "PRESENT_SECRET",
+          })
+        ).json(),
+      ).toEqual({ hasSecret: true })
+      expect(
+        (
+          await post(new URL("/has-secret", server.url), {
+            name: "PRESENT_SECRET",
+            extra: true,
+          })
+        ).status,
+      ).toBe(400)
+      expect(
+        (
+          await post(new URL("/run-with-secrets", server.url), {
+            command: "pwd",
+            cwd: "relative",
+            secrets: ["A_SECRET"],
+            timeoutMs: 100,
+          })
+        ).status,
+      ).toBe(400)
+    } finally {
+      await server.stop(true)
+    }
+  })
+
+  test("blocks browser-originated and non-JSON operation requests", async () => {
+    let runCalls = 0
+    const fetchSidecar = createKeymaxxerSidecarFetch(
+      fakeService({
+        runWithSecrets: () =>
+          Effect.sync(() => {
+            runCalls += 1
+            return { exitCode: 0, stdout: "", stderr: "" }
+          }),
+      }),
+    )
+    const body = JSON.stringify({
+      command: "pwd",
+      cwd: "/tmp",
+      secrets: ["A_SECRET"],
+      timeoutMs: 100,
+    })
+
+    const browserResponse = await fetchSidecar(
+      new Request("http://127.0.0.1/run-with-secrets", {
+        method: "POST",
+        body,
+        headers: {
+          "content-type": "text/plain",
+          origin: "https://malicious.example",
+        },
+      }),
+    )
+    const nonJsonResponse = await fetchSidecar(
+      new Request("http://127.0.0.1/run-with-secrets", {
+        method: "POST",
+        body,
+        headers: { "content-type": "text/plain" },
+      }),
+    )
+
+    expect(browserResponse.status).toBe(403)
+    expect(nonJsonResponse.status).toBe(415)
+    expect(runCalls).toBe(0)
+  })
+})
+
+describe("sidecar-backed Keymaxxer layer", () => {
+  test("exposes all operations over loopback HTTP", async () => {
+    const server = Bun.serve({
+      hostname: "127.0.0.1",
+      port: 0,
+      fetch: createKeymaxxerSidecarFetch(
+        fakeService({
+          hasSecret: (name) => Effect.succeed(name === "PRESENT_SECRET"),
+          addSecret: (input) => Effect.succeed(input.name === "NEW_SECRET"),
+          runWithSecrets: () =>
+            Effect.succeed({ exitCode: 4, stdout: "out", stderr: "err" }),
+        }),
+      ),
+    })
+
+    try {
+      const result = await Effect.runPromise(
+        Effect.gen(function* () {
+          const keymaxxer = yield* KeymaxxerService
+          yield* keymaxxer.initialize()
+          const present = yield* keymaxxer.hasSecret("PRESENT_SECRET")
+          const added = yield* keymaxxer.addSecret({ name: "NEW_SECRET" })
+          const run = yield* keymaxxer.runWithSecrets({
+            command: "false",
+            cwd: "/tmp",
+            secrets: ["PRESENT_SECRET"],
+            timeoutMs: 100,
+          })
+          return { present, added, run }
+        }).pipe(Effect.provide(sidecarKeymaxxerLayer(server.url.toString()))),
+      )
+
+      expect(result).toEqual({
+        present: true,
+        added: true,
+        run: { exitCode: 4, stdout: "out", stderr: "err" },
+      })
+    } finally {
+      await server.stop(true)
+    }
+  })
+
+  test("rejects remote and ambiguous URLs", async () => {
+    for (const url of [
+      "https://127.0.0.1:5032",
+      "http://localhost:5032",
+      "http://127.0.0.1:5032/path",
+    ]) {
+      const exit = await Effect.runPromise(
+        Effect.exit(
+          Effect.gen(function* () {
+            yield* KeymaxxerService
+          }).pipe(Effect.provide(sidecarKeymaxxerLayer(url))),
+        ),
+      )
+      expect(exit._tag).toBe("Failure")
+    }
+  })
+
+  test("retries initial connection failures before initialization", async () => {
+    let calls = 0
+    const fetchImplementation: typeof fetch = async (input) => {
+      calls += 1
+      if (calls < 3) throw new TypeError("connection refused")
+      const path = new URL(input.toString()).pathname
+      return Response.json(
+        path === "/health"
+          ? { status: "ok", protocolVersion: 1 }
+          : { initialized: true },
+      )
+    }
+
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        const keymaxxer = yield* KeymaxxerService
+        yield* keymaxxer.initialize()
+      }).pipe(
+        Effect.provide(
+          sidecarKeymaxxerLayer("http://127.0.0.1:5032", {
+            fetch: fetchImplementation,
+            retryDelayMs: 1,
+            startupTimeoutMs: 100,
+          }),
+        ),
+      ),
+    )
+    expect(calls).toBe(4)
+  })
+
+  test("does not retry after receiving an incompatible health response", async () => {
+    let calls = 0
+    const fetchImplementation: typeof fetch = async () => {
+      calls += 1
+      return Response.json({ status: "ok", protocolVersion: 2 })
+    }
+    const exit = await Effect.runPromise(
+      Effect.exit(
+        Effect.gen(function* () {
+          const keymaxxer = yield* KeymaxxerService
+          yield* keymaxxer.initialize()
+        }).pipe(
+          Effect.provide(
+            sidecarKeymaxxerLayer("http://127.0.0.1:5032", {
+              fetch: fetchImplementation,
+              retryDelayMs: 1,
+              startupTimeoutMs: 100,
+            }),
+          ),
+        ),
+      ),
+    )
+    expect(exit._tag).toBe("Failure")
+    expect(calls).toBe(1)
+  })
+
+  test("times out a health request that never responds", async () => {
+    const fetchImplementation: typeof fetch = (_input, init) =>
+      new Promise((_resolve, reject) => {
+        init?.signal?.addEventListener("abort", () =>
+          reject(init.signal?.reason),
+        )
+      })
+    const startedAt = Date.now()
+    const exit = await Effect.runPromise(
+      Effect.exit(
+        Effect.gen(function* () {
+          const keymaxxer = yield* KeymaxxerService
+          yield* keymaxxer.initialize()
+        }).pipe(
+          Effect.provide(
+            sidecarKeymaxxerLayer("http://127.0.0.1:5032", {
+              fetch: fetchImplementation,
+              retryDelayMs: 1,
+              startupTimeoutMs: 20,
+            }),
+          ),
+        ),
+      ),
+    )
+
+    expect(exit._tag).toBe("Failure")
+    expect(Date.now() - startedAt).toBeLessThan(500)
+  })
+
+  test("rejects response fields outside the shared schema", async () => {
+    const fetchImplementation: typeof fetch = async () =>
+      Response.json({ hasSecret: true, extra: true })
+    const exit = await Effect.runPromise(
+      Effect.gen(function* () {
+        const keymaxxer = yield* KeymaxxerService
+        return yield* Effect.exit(keymaxxer.hasSecret("A_SECRET"))
+      }).pipe(
+        Effect.provide(
+          sidecarKeymaxxerLayer("http://127.0.0.1:5032", {
+            fetch: fetchImplementation,
+          }),
+        ),
+      ),
+    )
+    expect(exit._tag).toBe("Failure")
+  })
+
+  test("rejects responses containing raw secret fields", async () => {
+    const fetchImplementation: typeof fetch = async () =>
+      Response.json({ value: "raw-secret" })
+    const exit = await Effect.runPromise(
+      Effect.gen(function* () {
+        const keymaxxer = yield* KeymaxxerService
+        return yield* Effect.exit(keymaxxer.hasSecret("A_SECRET"))
+      }).pipe(
+        Effect.provide(
+          sidecarKeymaxxerLayer("http://127.0.0.1:5032", {
+            fetch: fetchImplementation,
+          }),
+        ),
+      ),
+    )
+    expect(exit._tag).toBe("Failure")
+  })
+})

--- a/packages/keymaxxer-service/tsconfig.json
+++ b/packages/keymaxxer-service/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ]
+}

--- a/packages/keymaxxer-service/tsconfig.lib.json
+++ b/packages/keymaxxer-service/tsconfig.lib.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "tsBuildInfoFile": "dist/tsconfig.lib.tsbuildinfo",
+    "emitDeclarationOnly": false,
+    "forceConsistentCasingInFileNames": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"],
+  "references": []
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -35,6 +35,9 @@
     },
     {
       "path": "./packages/layer-turso-local"
+    },
+    {
+      "path": "./packages/keymaxxer-service"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- add a reusable Effect-based Keymaxxer service with MCP, loopback sidecar, and test layers
- attach a persistent Keymaxxer sidecar to `api:serve` while keeping production in-process
- enforce strict protocol validation, browser-request protections, startup deadlines, and scoped cleanup
- document the topology and ensure typechecks build workspace dependencies

## Verification
- `bunx nx run-many -t build test typecheck lint knip --skipNxCache`
- pre-commit `nx affected -t lint,typecheck,test --batch`