### PR TITLE
feat(opencode): run prompts through CLI

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -26,3 +26,7 @@ _Avoid_: Secret store, credential cache
 **Keymaxxer Sidecar**:
 A development-only companion process that owns the Keymaxxer MCP session so watched backend reloads do not repeat vault-unlock or secret-use approval prompts.
 _Avoid_: Credential daemon, token cache
+
+**Session**:
+An opencode conversation identified by opencode’s session id, scoped to a working directory, and continued across one or more prompt runs.
+_Avoid_: chat, thread, conversation (in formal docs)

--- a/bun.lock
+++ b/bun.lock
@@ -149,6 +149,18 @@
         "@types/bun": "^1.3.0",
       },
     },
+    "packages/opencode": {
+      "name": "@ready-for-agent/opencode",
+      "version": "0.0.1",
+      "dependencies": {
+        "effect": "^4.0.0-beta.97",
+        "tslib": "^2.3.0",
+      },
+      "devDependencies": {
+        "@effect/platform-bun": "^4.0.0-beta.97",
+        "@types/bun": "^1.3.0",
+      },
+    },
     "packages/queue-service": {
       "name": "@ready-for-agent/queue-service",
       "version": "0.0.1",
@@ -733,6 +745,8 @@
     "@ready-for-agent/keymaxxer-service": ["@ready-for-agent/keymaxxer-service@workspace:packages/keymaxxer-service"],
 
     "@ready-for-agent/layer-turso-local": ["@ready-for-agent/layer-turso-local@workspace:packages/layer-turso-local"],
+
+    "@ready-for-agent/opencode": ["@ready-for-agent/opencode@workspace:packages/opencode"],
 
     "@ready-for-agent/queue-service": ["@ready-for-agent/queue-service@workspace:packages/queue-service"],
 
@@ -1766,6 +1780,8 @@
 
     "@ready-for-agent/cli/effect": ["effect@4.0.0-beta.97", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "fast-check": "^4.9.0", "find-my-way-ts": "^0.1.6", "ini": "^7.0.0", "kubernetes-types": "^1.30.0", "msgpackr": "^2.0.4", "multipasta": "^0.2.8", "toml": "^4.1.2", "uuid": "^14.0.1", "yaml": "^2.9.0" } }, "sha512-pK03HpQVxGZOWdwDAy/iwvV8u3KYcUf2mOWyWqaut2zau8V2u6ejWP7b4BELjyUIiZWW1fl/s/VJpgZUcTjThg=="],
 
+    "@ready-for-agent/opencode/effect": ["effect@4.0.0-beta.97", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "fast-check": "^4.9.0", "find-my-way-ts": "^0.1.6", "ini": "^7.0.0", "kubernetes-types": "^1.30.0", "msgpackr": "^2.0.4", "multipasta": "^0.2.8", "toml": "^4.1.2", "uuid": "^14.0.1", "yaml": "^2.9.0" } }, "sha512-pK03HpQVxGZOWdwDAy/iwvV8u3KYcUf2mOWyWqaut2zau8V2u6ejWP7b4BELjyUIiZWW1fl/s/VJpgZUcTjThg=="],
+
     "@tanstack/router-generator/prettier": ["prettier@3.9.5", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-/FVl766LpUfB5vXgCYOYa0MeV/441Ia99AeICQIQFTY/Nw0roZwULcXpku5i1/m5kt/baz+s4Zogspd839HSMg=="],
 
     "@whatwg-node/node-fetch/@fastify/busboy": ["@fastify/busboy@3.2.0", "", {}, "sha512-m9FVDXU3GT2ITSe0UaMA5rU3QkfC/UXtCU8y0gSN/GugTqtVldOBWIB5V6V3sbmenVZUIpU6f+mPEO2+m5iTaA=="],
@@ -1869,6 +1885,8 @@
     "@oxc-resolver/binding-wasm32-wasi/@napi-rs/wasm-runtime/@tybys/wasm-util": ["@tybys/wasm-util@0.10.3", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg=="],
 
     "@ready-for-agent/cli/effect/fast-check": ["fast-check@4.9.0", "", { "dependencies": { "pure-rand": "^8.0.0" } }, "sha512-7ms6T7SybUev/PQITciI0yLM2pOSFy5zpG8Ty7tQofcVaQUvrMXp6CBwqF6fThLCLOrfBtuHAtwq6Yu4XPCllg=="],
+
+    "@ready-for-agent/opencode/effect/fast-check": ["fast-check@4.9.0", "", { "dependencies": { "pure-rand": "^8.0.0" } }, "sha512-7ms6T7SybUev/PQITciI0yLM2pOSFy5zpG8Ty7tQofcVaQUvrMXp6CBwqF6fThLCLOrfBtuHAtwq6Yu4XPCllg=="],
 
     "accepts/mime-types/mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
 
@@ -2029,6 +2047,8 @@
     "@genql/cli/yargs/cliui/wrap-ansi": ["wrap-ansi@6.2.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA=="],
 
     "@ready-for-agent/cli/effect/fast-check/pure-rand": ["pure-rand@8.4.1", "", {}, "sha512-c58R2+SPFcSIPXoU834QN/KPDDOSd8sXcSrqf6e83Me6Rrp1EYkxukkjXMVrKvKaADs1SOyNkWdfvLf6zY8qLQ=="],
+
+    "@ready-for-agent/opencode/effect/fast-check/pure-rand": ["pure-rand@8.4.1", "", {}, "sha512-c58R2+SPFcSIPXoU834QN/KPDDOSd8sXcSrqf6e83Me6Rrp1EYkxukkjXMVrKvKaADs1SOyNkWdfvLf6zY8qLQ=="],
 
     "cli-truncate/string-width/strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
 

--- a/docs/adr/0004-opencode-cli-wrapper.md
+++ b/docs/adr/0004-opencode-cli-wrapper.md
@@ -1,0 +1,3 @@
+# Opencode package wraps the CLI (Effect 4)
+
+`@ready-for-agent/opencode` shells out to the opencode CLI (`run --auto --format json`) rather than using `@opencode-ai/sdk`. We need a fire-and-forget prompt runner with Session continue, not a long-lived server client; the CLI already owns session lifecycle, permissions (`--auto`), and event streaming. Process control uses Effect 4’s `ChildProcess` / `ChildProcessSpawner` (same stack as `apps/cli`), so this package is on Effect 4 while most workspace packages remain on Effect 3 until they migrate.

--- a/packages/opencode/package.json
+++ b/packages/opencode/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@ready-for-agent/opencode",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    "./package.json": "./package.json",
+    ".": {
+      "@ready-for-agent/source": "./src/index.ts",
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    }
+  },
+  "dependencies": {
+    "effect": "^4.0.0-beta.97",
+    "tslib": "^2.3.0"
+  },
+  "devDependencies": {
+    "@effect/platform-bun": "^4.0.0-beta.97",
+    "@types/bun": "^1.3.0"
+  }
+}

--- a/packages/opencode/project.json
+++ b/packages/opencode/project.json
@@ -1,0 +1,15 @@
+{
+  "name": "opencode",
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "targets": {
+    "test": {
+      "executor": "nx:run-commands",
+      "options": {
+        "cwd": "{projectRoot}",
+        "command": "bun test"
+      },
+      "inputs": ["default", "^production"],
+      "cache": true
+    }
+  }
+}

--- a/packages/opencode/src/index.ts
+++ b/packages/opencode/src/index.ts
@@ -1,0 +1,5 @@
+export * from "./lib/build-args.js"
+export * from "./lib/errors.js"
+export * from "./lib/opencode.js"
+export * from "./lib/parse-session-id.js"
+export * from "./lib/types.js"

--- a/packages/opencode/src/lib/build-args.ts
+++ b/packages/opencode/src/lib/build-args.ts
@@ -1,0 +1,27 @@
+export const buildRunArgs = (input: {
+  readonly prompt: string
+  readonly cwd: string
+  readonly model: string
+  readonly variant: string
+  readonly sessionId?: string
+}): ReadonlyArray<string> => {
+  const args = [
+    "run",
+    "--auto",
+    "--format",
+    "json",
+    "--dir",
+    input.cwd,
+    "-m",
+    input.model,
+    "--variant",
+    input.variant,
+  ]
+
+  if (input.sessionId !== undefined) {
+    args.push("--session", input.sessionId)
+  }
+
+  args.push(input.prompt)
+  return args
+}

--- a/packages/opencode/src/lib/errors.ts
+++ b/packages/opencode/src/lib/errors.ts
@@ -1,0 +1,26 @@
+import { Schema } from "effect"
+
+export class OpencodeExitError extends Schema.TaggedErrorClass<OpencodeExitError>()(
+  "OpencodeExitError",
+  {
+    exitCode: Schema.Finite,
+    cwd: Schema.String,
+    sessionId: Schema.optionalKey(Schema.String),
+  },
+) {}
+
+export class OpencodeTimeoutError extends Schema.TaggedErrorClass<OpencodeTimeoutError>()(
+  "OpencodeTimeoutError",
+  {
+    cwd: Schema.String,
+    timeoutMs: Schema.Finite,
+    sessionId: Schema.optionalKey(Schema.String),
+  },
+) {}
+
+export class SessionIdNotFoundError extends Schema.TaggedErrorClass<SessionIdNotFoundError>()(
+  "SessionIdNotFoundError",
+  {
+    cwd: Schema.String,
+  },
+) {}

--- a/packages/opencode/src/lib/opencode.ts
+++ b/packages/opencode/src/lib/opencode.ts
@@ -1,0 +1,143 @@
+import { Context, Duration, Effect, Layer, Stream } from "effect"
+import type { PlatformError } from "effect/PlatformError"
+import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process"
+import { buildRunArgs } from "./build-args.js"
+import {
+  OpencodeExitError,
+  OpencodeTimeoutError,
+  SessionIdNotFoundError,
+} from "./errors.js"
+import { parseSessionIdFromLine } from "./parse-session-id.js"
+import type {
+  ContinueInput,
+  OpencodeLayerOptions,
+  OpencodeRunResult,
+  StartInput,
+} from "./types.js"
+
+const DEFAULT_TIMEOUT = Duration.minutes(30)
+const DEFAULT_BINARY = "opencode"
+
+export type OpencodeError =
+  | OpencodeExitError
+  | OpencodeTimeoutError
+  | SessionIdNotFoundError
+  | PlatformError
+
+export class Opencode extends Context.Service<
+  Opencode,
+  {
+    readonly start: (
+      input: StartInput,
+    ) => Effect.Effect<OpencodeRunResult, OpencodeError>
+    readonly continue: (
+      input: ContinueInput,
+    ) => Effect.Effect<OpencodeRunResult, OpencodeError>
+  }
+>()("@ready-for-agent/opencode/Opencode") {
+  static layer = (options: OpencodeLayerOptions = {}) =>
+    Layer.effect(
+      Opencode,
+      Effect.gen(function* () {
+        const spawner = yield* ChildProcessSpawner.ChildProcessSpawner
+        const binary = options.binary ?? DEFAULT_BINARY
+        const defaultTimeout = options.defaultTimeout ?? DEFAULT_TIMEOUT
+
+        const run = (input: {
+          readonly prompt: string
+          readonly cwd: string
+          readonly model: string
+          readonly variant: string
+          readonly sessionId?: string
+          readonly timeout?: Duration.Input
+        }): Effect.Effect<OpencodeRunResult, OpencodeError> =>
+          Effect.gen(function* () {
+            const timeout = input.timeout ?? defaultTimeout
+            const timeoutMs = Duration.toMillis(timeout)
+            const knownSessionId = input.sessionId
+            let seenSessionId: string | undefined = knownSessionId
+
+            const args = buildRunArgs({
+              prompt: input.prompt,
+              cwd: input.cwd,
+              model: input.model,
+              variant: input.variant,
+              sessionId: input.sessionId,
+            })
+
+            const command = ChildProcess.make(binary, args, {
+              cwd: input.cwd,
+              stdin: "ignore",
+              stderr: "ignore",
+            })
+
+            const result = yield* Effect.scoped(
+              Effect.gen(function* () {
+                const handle = yield* spawner.spawn(command)
+
+                const collectSessionId = Stream.decodeText(handle.stdout).pipe(
+                  Stream.splitLines,
+                  Stream.runFold(
+                    (): string | undefined => undefined,
+                    (acc, line) => {
+                      const parsed = parseSessionIdFromLine(line)
+                      if (parsed !== undefined) {
+                        seenSessionId = parsed
+                        return parsed
+                      }
+                      return acc
+                    },
+                  ),
+                )
+
+                const [exitCode, sessionId] = yield* Effect.all(
+                  [handle.exitCode, collectSessionId],
+                  { concurrency: 2 },
+                )
+
+                return {
+                  exitCode: Number(exitCode),
+                  sessionId,
+                }
+              }),
+            ).pipe(
+              Effect.timeout(timeout),
+              Effect.catchTag("TimeoutError", () =>
+                Effect.fail(
+                  new OpencodeTimeoutError({
+                    cwd: input.cwd,
+                    timeoutMs,
+                    ...(seenSessionId !== undefined
+                      ? { sessionId: seenSessionId }
+                      : {}),
+                  }),
+                ),
+              ),
+            )
+
+            if (result.exitCode !== 0) {
+              const sessionId = result.sessionId ?? knownSessionId
+              return yield* new OpencodeExitError({
+                exitCode: result.exitCode,
+                cwd: input.cwd,
+                ...(sessionId !== undefined ? { sessionId } : {}),
+              })
+            }
+
+            const sessionId = result.sessionId ?? knownSessionId
+            if (sessionId === undefined) {
+              return yield* new SessionIdNotFoundError({ cwd: input.cwd })
+            }
+
+            return { sessionId }
+          })
+
+        return {
+          start: (input) => run(input),
+          continue: (input) => run(input),
+        }
+      }),
+    )
+}
+
+export const OpencodeLive = Opencode.layer()

--- a/packages/opencode/src/lib/parse-session-id.ts
+++ b/packages/opencode/src/lib/parse-session-id.ts
@@ -1,0 +1,36 @@
+export const parseSessionIdFromLine = (line: string): string | undefined => {
+  const trimmed = line.trim()
+  if (trimmed.length === 0) {
+    return undefined
+  }
+
+  try {
+    const parsed: unknown = JSON.parse(trimmed)
+    if (
+      typeof parsed === "object" &&
+      parsed !== null &&
+      "sessionID" in parsed &&
+      typeof parsed.sessionID === "string" &&
+      parsed.sessionID.length > 0
+    ) {
+      return parsed.sessionID
+    }
+  } catch {
+    return undefined
+  }
+
+  return undefined
+}
+
+export const parseSessionIdFromLines = (
+  lines: Iterable<string>,
+): string | undefined => {
+  let sessionId: string | undefined
+  for (const line of lines) {
+    const parsed = parseSessionIdFromLine(line)
+    if (parsed !== undefined) {
+      sessionId = parsed
+    }
+  }
+  return sessionId
+}

--- a/packages/opencode/src/lib/types.ts
+++ b/packages/opencode/src/lib/types.ts
@@ -1,0 +1,27 @@
+import type { Duration } from "effect"
+
+export interface OpencodeRunResult {
+  readonly sessionId: string
+}
+
+export interface StartInput {
+  readonly prompt: string
+  readonly cwd: string
+  readonly model: string
+  readonly variant: string
+  readonly timeout?: Duration.Input
+}
+
+export interface ContinueInput {
+  readonly sessionId: string
+  readonly prompt: string
+  readonly cwd: string
+  readonly model: string
+  readonly variant: string
+  readonly timeout?: Duration.Input
+}
+
+export interface OpencodeLayerOptions {
+  readonly binary?: string
+  readonly defaultTimeout?: Duration.Input
+}

--- a/packages/opencode/test/build-args.spec.ts
+++ b/packages/opencode/test/build-args.spec.ts
@@ -1,0 +1,53 @@
+import { buildRunArgs } from "../src/lib/build-args.js"
+import { describe, expect, it } from "bun:test"
+
+describe("buildRunArgs", () => {
+  it("builds start args with auto, json, model, and variant", () => {
+    expect(
+      buildRunArgs({
+        prompt: "fix the bug",
+        cwd: "/worktrees/repository",
+        model: "anthropic/claude-sonnet-4-5",
+        variant: "high",
+      }),
+    ).toEqual([
+      "run",
+      "--auto",
+      "--format",
+      "json",
+      "--dir",
+      "/worktrees/repository",
+      "-m",
+      "anthropic/claude-sonnet-4-5",
+      "--variant",
+      "high",
+      "fix the bug",
+    ])
+  })
+
+  it("includes session for continue", () => {
+    expect(
+      buildRunArgs({
+        prompt: "continue",
+        cwd: "/worktrees/repository",
+        model: "anthropic/claude-sonnet-4-5",
+        variant: "max",
+        sessionId: "ses_abc",
+      }),
+    ).toEqual([
+      "run",
+      "--auto",
+      "--format",
+      "json",
+      "--dir",
+      "/worktrees/repository",
+      "-m",
+      "anthropic/claude-sonnet-4-5",
+      "--variant",
+      "max",
+      "--session",
+      "ses_abc",
+      "continue",
+    ])
+  })
+})

--- a/packages/opencode/test/opencode.integration.spec.ts
+++ b/packages/opencode/test/opencode.integration.spec.ts
@@ -1,0 +1,56 @@
+import { mkdtemp, rm } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { BunServices } from "@effect/platform-bun"
+import { Effect, Layer } from "effect"
+import { Opencode, OpencodeLive } from "../src/index.js"
+import { describe, expect, it } from "bun:test"
+
+const TestLayer = OpencodeLive.pipe(Layer.provide(BunServices.layer))
+
+describe("Opencode integration", () => {
+  it("starts and continues a real Session", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "ready-for-agent-opencode-"))
+    let sessionId: string | undefined
+
+    try {
+      const result = await Effect.runPromise(
+        Effect.gen(function* () {
+          const opencode = yield* Opencode
+          const started = yield* opencode.start({
+            cwd,
+            prompt: "Reply exactly START_OK. Do not use tools.",
+            model: "opencode/deepseek-v4-flash-free",
+            variant: "low",
+            timeout: "2 minutes",
+          })
+          yield* Effect.sync(() => {
+            sessionId = started.sessionId
+          })
+          const continued = yield* opencode.continue({
+            cwd,
+            sessionId: started.sessionId,
+            prompt: "Reply exactly CONTINUE_OK. Do not use tools.",
+            model: "opencode/deepseek-v4-flash-free",
+            variant: "low",
+            timeout: "2 minutes",
+          })
+
+          return { started, continued }
+        }).pipe(Effect.provide(TestLayer)),
+      )
+
+      expect(result.started.sessionId).toStartWith("ses_")
+      expect(result.continued.sessionId).toBe(result.started.sessionId)
+    } finally {
+      if (sessionId !== undefined) {
+        const deletion = Bun.spawn(
+          ["opencode", "session", "delete", sessionId],
+          { cwd, stdout: "ignore", stderr: "ignore" },
+        )
+        await deletion.exited
+      }
+      await rm(cwd, { recursive: true, force: true })
+    }
+  }, 180_000)
+})

--- a/packages/opencode/test/parse-session-id.spec.ts
+++ b/packages/opencode/test/parse-session-id.spec.ts
@@ -1,0 +1,37 @@
+import {
+  parseSessionIdFromLine,
+  parseSessionIdFromLines,
+} from "../src/lib/parse-session-id.js"
+import { describe, expect, it } from "bun:test"
+
+describe("parseSessionIdFromLine", () => {
+  it("extracts sessionID from a json event line", () => {
+    const line = JSON.stringify({
+      type: "text",
+      timestamp: 1,
+      sessionID: "ses_abc123",
+    })
+    expect(parseSessionIdFromLine(line)).toBe("ses_abc123")
+  })
+
+  it("returns undefined for non-json", () => {
+    expect(parseSessionIdFromLine("not json")).toBeUndefined()
+  })
+
+  it("returns undefined when sessionID is missing", () => {
+    expect(
+      parseSessionIdFromLine(JSON.stringify({ type: "text" })),
+    ).toBeUndefined()
+  })
+})
+
+describe("parseSessionIdFromLines", () => {
+  it("returns the last sessionID seen", () => {
+    const lines = [
+      JSON.stringify({ type: "step_start", sessionID: "ses_1" }),
+      "noise",
+      JSON.stringify({ type: "text", sessionID: "ses_2" }),
+    ]
+    expect(parseSessionIdFromLines(lines)).toBe("ses_2")
+  })
+})

--- a/packages/opencode/tsconfig.json
+++ b/packages/opencode/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ]
+}

--- a/packages/opencode/tsconfig.lib.json
+++ b/packages/opencode/tsconfig.lib.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "tsBuildInfoFile": "dist/tsconfig.lib.tsbuildinfo",
+    "emitDeclarationOnly": false,
+    "forceConsistentCasingInFileNames": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"],
+  "references": []
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -38,6 +38,9 @@
     },
     {
       "path": "./packages/keymaxxer-service"
+    },
+    {
+      "path": "./packages/opencode"
     }
   ]
 }


### PR DESCRIPTION
## Why

The harness needs to execute agent prompts unattended in a specific worktree and resume the resulting OpenCode Session later.

## What Changed

- Add `@ready-for-agent/opencode`, an Effect 4 service with `start` and `continue` operations.
- Invoke `opencode run` with `--auto`, JSON events, explicit model/variant, explicit working directory, and a default 30-minute timeout.
- Return OpenCode Session IDs and model process failures as typed errors.
- Add unit coverage for arguments and Session-ID parsing plus a real CLI integration test using `opencode/deepseek-v4-flash-free`.
- Record the CLI-wrapper decision and Session terminology.

## Verification

The integration test starts then continues a real OpenCode Session with `opencode/deepseek-v4-flash-free`; both calls returned the same Session ID.