### PR TITLE
feat: add GitHub issue service

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -30,3 +30,7 @@ _Avoid_: Credential daemon, token cache
 **Session**:
 An opencode conversation identified by opencode’s session id, scoped to a working directory, and continued across one or more prompt runs.
 _Avoid_: chat, thread, conversation (in formal docs)
+
+**Ready-labeled Issue**:
+An Issue carrying the `ready-for-agent` GitHub label, regardless of whether the Issue is open or closed. A fetched Ready-labeled Issue includes its number, title, body, web URL, creation time, and GitHub state so consumers can decide whether it is actionable.
+_Avoid_: Ready Issue (can imply that the Issue is open and actionable)

--- a/bun.lock
+++ b/bun.lock
@@ -115,6 +115,18 @@
         "@types/bun": "^1.3.0",
       },
     },
+    "packages/github-service": {
+      "name": "@ready-for-agent/github-service",
+      "version": "0.0.1",
+      "dependencies": {
+        "effect": "^3.21.4",
+        "tslib": "^2.3.0",
+      },
+      "devDependencies": {
+        "@genql/cli": "^6.3.3",
+        "@types/bun": "^1.3.0",
+      },
+    },
     "packages/graphql-client": {
       "name": "@ready-for-agent/graphql-client",
       "version": "0.0.1",
@@ -735,6 +747,8 @@
     "@ready-for-agent/db-schema": ["@ready-for-agent/db-schema@workspace:packages/db-schema"],
 
     "@ready-for-agent/db-service": ["@ready-for-agent/db-service@workspace:packages/db-service"],
+
+    "@ready-for-agent/github-service": ["@ready-for-agent/github-service@workspace:packages/github-service"],
 
     "@ready-for-agent/graphql-client": ["@ready-for-agent/graphql-client@workspace:packages/graphql-client"],
 

--- a/knip.json
+++ b/knip.json
@@ -20,6 +20,13 @@
         "src/generated/types.ts"
       ]
     },
+    "packages/github-service": {
+      "entry": ["test/**/*.{test,spec}.ts"],
+      "project": ["src/**/*.ts", "test/**/*.ts"],
+      "ignoreIssues": {
+        "src/internal/generated/**": ["exports", "types"]
+      }
+    },
     "packages/db": {
       "entry": ["src/bin/migrate.ts"],
       "project": ["src/**/*.{ts,tsx}"]

--- a/packages/github-service/github.graphql
+++ b/packages/github-service/github.graphql
@@ -1,0 +1,38 @@
+schema {
+  query: Query
+}
+
+scalar DateTime
+scalar URI
+
+type Query {
+  repository(owner: String!, name: String!): Repository
+}
+
+type Repository {
+  issues(first: Int, after: String, labels: [String!]): IssueConnection!
+}
+
+type IssueConnection {
+  nodes: [Issue]
+  pageInfo: PageInfo!
+}
+
+type PageInfo {
+  endCursor: String
+  hasNextPage: Boolean!
+}
+
+type Issue {
+  number: Int!
+  title: String!
+  body: String!
+  url: URI!
+  createdAt: DateTime!
+  state: IssueState!
+}
+
+enum IssueState {
+  OPEN
+  CLOSED
+}

--- a/packages/github-service/package.json
+++ b/packages/github-service/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "@ready-for-agent/github-service",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    "./package.json": "./package.json",
+    ".": {
+      "@ready-for-agent/source": "./src/index.ts",
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "generate": "genql --schema github.graphql --output ./src/internal/generated"
+  },
+  "dependencies": {
+    "effect": "^3.21.4",
+    "tslib": "^2.3.0"
+  },
+  "devDependencies": {
+    "@genql/cli": "^6.3.3",
+    "@types/bun": "^1.3.0"
+  }
+}

--- a/packages/github-service/project.json
+++ b/packages/github-service/project.json
@@ -1,0 +1,29 @@
+{
+  "name": "github-service",
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "packages/github-service/src",
+  "projectType": "library",
+  "tags": [],
+  "targets": {
+    "generate": {
+      "executor": "nx:run-commands",
+      "options": {
+        "cwd": "{projectRoot}",
+        "command": "bun run generate"
+      },
+      "cache": true,
+      "inputs": ["{projectRoot}/github.graphql", "{projectRoot}/package.json"],
+      "outputs": ["{projectRoot}/src/internal/generated"]
+    },
+    "test": {
+      "executor": "nx:run-commands",
+      "options": {
+        "cwd": "{projectRoot}",
+        "command": "bun test"
+      },
+      "inputs": ["default", "^production"],
+      "cache": true,
+      "dependsOn": ["^build"]
+    }
+  }
+}

--- a/packages/github-service/src/index.ts
+++ b/packages/github-service/src/index.ts
@@ -1,0 +1,5 @@
+export * from "./lib/errors.js"
+export * from "./lib/github-service.js"
+export { GitHubServiceLive } from "./lib/github-service-live.js"
+export * from "./lib/github-service-test.js"
+export * from "./lib/types.js"

--- a/packages/github-service/src/internal/generated/index.ts
+++ b/packages/github-service/src/internal/generated/index.ts
@@ -1,0 +1,48 @@
+// @ts-nocheck
+import type { QueryGenqlSelection, Query } from './schema'
+import {
+  linkTypeMap,
+  createClient as createClientOriginal,
+  generateGraphqlOperation,
+  type FieldsSelection,
+  type GraphqlOperation,
+  type ClientOptions,
+  GenqlError,
+} from './runtime'
+export type { FieldsSelection } from './runtime'
+export { GenqlError }
+
+import types from './types'
+export * from './schema'
+const typeMap = linkTypeMap(types as any)
+
+export interface Client {
+  query<R extends QueryGenqlSelection>(
+    request: R & { __name?: string },
+  ): Promise<FieldsSelection<Query, R>>
+}
+
+export const createClient = function (options?: ClientOptions): Client {
+  return createClientOriginal({
+    url: undefined,
+
+    ...options,
+    queryRoot: typeMap.Query!,
+    mutationRoot: typeMap.Mutation!,
+    subscriptionRoot: typeMap.Subscription!,
+  }) as any
+}
+
+export const everything = {
+  __scalar: true,
+}
+
+export type QueryResult<fields extends QueryGenqlSelection> = FieldsSelection<
+  Query,
+  fields
+>
+export const generateQueryOp: (
+  fields: QueryGenqlSelection & { __name?: string },
+) => GraphqlOperation = function (fields) {
+  return generateGraphqlOperation('query', typeMap.Query!, fields as any)
+}

--- a/packages/github-service/src/internal/generated/runtime/batcher.ts
+++ b/packages/github-service/src/internal/generated/runtime/batcher.ts
@@ -1,0 +1,275 @@
+// @ts-nocheck
+import type { GraphqlOperation } from './generateGraphqlOperation'
+import { GenqlError } from './error'
+
+type Variables = Record<string, any>
+
+type QueryError = Error & {
+    message: string
+
+    locations?: Array<{
+        line: number
+        column: number
+    }>
+    path?: any
+    rid: string
+    details?: Record<string, any>
+}
+type Result = {
+    data: Record<string, any>
+    errors: Array<QueryError>
+}
+type Fetcher = (
+    batchedQuery: GraphqlOperation | Array<GraphqlOperation>,
+) => Promise<Array<Result>>
+type Options = {
+    batchInterval?: number
+    shouldBatch?: boolean
+    maxBatchSize?: number
+}
+type Queue = Array<{
+    request: GraphqlOperation
+    resolve: (...args: Array<any>) => any
+    reject: (...args: Array<any>) => any
+}>
+
+/**
+ * takes a list of requests (queue) and batches them into a single server request.
+ * It will then resolve each individual requests promise with the appropriate data.
+ * @private
+ * @param {QueryBatcher}   client - the client to use
+ * @param {Queue} queue  - the list of requests to batch
+ */
+function dispatchQueueBatch(client: QueryBatcher, queue: Queue): void {
+    let batchedQuery: any = queue.map((item) => item.request)
+
+    if (batchedQuery.length === 1) {
+        batchedQuery = batchedQuery[0]
+    }
+    (() => {
+        try {
+            return client.fetcher(batchedQuery);
+        } catch(e) {
+            return Promise.reject(e);
+        }
+    })().then((responses: any) => {
+        if (queue.length === 1 && !Array.isArray(responses)) {
+            if (responses.errors && responses.errors.length) {
+                queue[0].reject(
+                    new GenqlError(responses.errors, responses.data),
+                )
+                return
+            }
+
+            queue[0].resolve(responses)
+            return
+        } else if (responses.length !== queue.length) {
+            throw new Error('response length did not match query length')
+        }
+
+        for (let i = 0; i < queue.length; i++) {
+            if (responses[i].errors && responses[i].errors.length) {
+                queue[i].reject(
+                    new GenqlError(responses[i].errors, responses[i].data),
+                )
+            } else {
+                queue[i].resolve(responses[i])
+            }
+        }
+    })
+    .catch((e) => {
+        for (let i = 0; i < queue.length; i++) {
+            queue[i].reject(e)
+        }
+    });
+}
+
+/**
+ * creates a list of requests to batch according to max batch size.
+ * @private
+ * @param {QueryBatcher} client - the client to create list of requests from from
+ * @param {Options} options - the options for the batch
+ */
+function dispatchQueue(client: QueryBatcher, options: Options): void {
+    const queue = client._queue
+    const maxBatchSize = options.maxBatchSize || 0
+    client._queue = []
+
+    if (maxBatchSize > 0 && maxBatchSize < queue.length) {
+        for (let i = 0; i < queue.length / maxBatchSize; i++) {
+            dispatchQueueBatch(
+                client,
+                queue.slice(i * maxBatchSize, (i + 1) * maxBatchSize),
+            )
+        }
+    } else {
+        dispatchQueueBatch(client, queue)
+    }
+}
+/**
+ * Create a batcher client.
+ * @param {Fetcher} fetcher                 - A function that can handle the network requests to graphql endpoint
+ * @param {Options} options                 - the options to be used by client
+ * @param {boolean} options.shouldBatch     - should the client batch requests. (default true)
+ * @param {integer} options.batchInterval   - duration (in MS) of each batch window. (default 6)
+ * @param {integer} options.maxBatchSize    - max number of requests in a batch. (default 0)
+ * @param {boolean} options.defaultHeaders  - default headers to include with every request
+ *
+ * @example
+ * const fetcher = batchedQuery => fetch('path/to/graphql', {
+ *    method: 'post',
+ *    headers: {
+ *      Accept: 'application/json',
+ *      'Content-Type': 'application/json',
+ *    },
+ *    body: JSON.stringify(batchedQuery),
+ *    credentials: 'include',
+ * })
+ * .then(response => response.json())
+ *
+ * const client = new QueryBatcher(fetcher, { maxBatchSize: 10 })
+ */
+
+export class QueryBatcher {
+    fetcher: Fetcher
+    _options: Options
+    _queue: Queue
+
+    constructor(
+        fetcher: Fetcher,
+        {
+            batchInterval = 6,
+            shouldBatch = true,
+            maxBatchSize = 0,
+        }: Options = {},
+    ) {
+        this.fetcher = fetcher
+        this._options = {
+            batchInterval,
+            shouldBatch,
+            maxBatchSize,
+        }
+        this._queue = []
+    }
+
+    /**
+     * Fetch will send a graphql request and return the parsed json.
+     * @param {string}      query          - the graphql query.
+     * @param {Variables}   variables      - any variables you wish to inject as key/value pairs.
+     * @param {[string]}    operationName  - the graphql operationName.
+     * @param {Options}     overrides      - the client options overrides.
+     *
+     * @return {promise} resolves to parsed json of server response
+     *
+     * @example
+     * client.fetch(`
+     *    query getHuman($id: ID!) {
+     *      human(id: $id) {
+     *        name
+     *        height
+     *      }
+     *    }
+     * `, { id: "1001" }, 'getHuman')
+     *    .then(human => {
+     *      // do something with human
+     *      console.log(human);
+     *    });
+     */
+    fetch(
+        query: string,
+        variables?: Variables,
+        operationName?: string,
+        overrides: Options = {},
+    ): Promise<Result> {
+        const request: GraphqlOperation = {
+            query,
+        }
+        const options = Object.assign({}, this._options, overrides)
+
+        if (variables) {
+            request.variables = variables
+        }
+
+        if (operationName) {
+            request.operationName = operationName
+        }
+
+        const promise = new Promise<Result>((resolve, reject) => {
+            this._queue.push({
+                request,
+                resolve,
+                reject,
+            })
+
+            if (this._queue.length === 1) {
+                if (options.shouldBatch) {
+                    setTimeout(
+                        () => dispatchQueue(this, options),
+                        options.batchInterval,
+                    )
+                } else {
+                    dispatchQueue(this, options)
+                }
+            }
+        })
+        return promise
+    }
+
+    /**
+     * Fetch will send a graphql request and return the parsed json.
+     * @param {string}      query          - the graphql query.
+     * @param {Variables}   variables      - any variables you wish to inject as key/value pairs.
+     * @param {[string]}    operationName  - the graphql operationName.
+     * @param {Options}     overrides      - the client options overrides.
+     *
+     * @return {Promise<Array<Result>>} resolves to parsed json of server response
+     *
+     * @example
+     * client.forceFetch(`
+     *    query getHuman($id: ID!) {
+     *      human(id: $id) {
+     *        name
+     *        height
+     *      }
+     *    }
+     * `, { id: "1001" }, 'getHuman')
+     *    .then(human => {
+     *      // do something with human
+     *      console.log(human);
+     *    });
+     */
+    forceFetch(
+        query: string,
+        variables?: Variables,
+        operationName?: string,
+        overrides: Options = {},
+    ): Promise<Result> {
+        const request: GraphqlOperation = {
+            query,
+        }
+        const options = Object.assign({}, this._options, overrides, {
+            shouldBatch: false,
+        })
+
+        if (variables) {
+            request.variables = variables
+        }
+
+        if (operationName) {
+            request.operationName = operationName
+        }
+
+        const promise = new Promise<Result>((resolve, reject) => {
+            const client = new QueryBatcher(this.fetcher, this._options)
+            client._queue = [
+                {
+                    request,
+                    resolve,
+                    reject,
+                },
+            ]
+            dispatchQueue(client, options)
+        })
+        return promise
+    }
+}

--- a/packages/github-service/src/internal/generated/runtime/createClient.ts
+++ b/packages/github-service/src/internal/generated/runtime/createClient.ts
@@ -1,0 +1,68 @@
+// @ts-nocheck
+
+import  { type BatchOptions, createFetcher } from './fetcher'
+import type { ExecutionResult, LinkedType } from './types'
+import {
+    generateGraphqlOperation,
+    type GraphqlOperation,
+} from './generateGraphqlOperation'
+
+export type Headers =
+    | HeadersInit
+    | (() => HeadersInit)
+    | (() => Promise<HeadersInit>)
+
+export type BaseFetcher = (
+    operation: GraphqlOperation | GraphqlOperation[],
+) => Promise<ExecutionResult | ExecutionResult[]>
+
+export type ClientOptions = Omit<RequestInit, 'body' | 'headers'> & {
+    url?: string
+    batch?: BatchOptions | boolean
+    fetcher?: BaseFetcher
+    fetch?: Function
+    headers?: Headers
+}
+
+export const createClient = ({
+    queryRoot,
+    mutationRoot,
+    subscriptionRoot,
+    ...options
+}: ClientOptions & {
+    queryRoot?: LinkedType
+    mutationRoot?: LinkedType
+    subscriptionRoot?: LinkedType
+}) => {
+    const fetcher = createFetcher(options)
+    const client: {
+        query?: Function
+        mutation?: Function
+    } = {}
+
+    if (queryRoot) {
+        client.query = (request: any) => {
+            if (!queryRoot) throw new Error('queryRoot argument is missing')
+
+            const resultPromise = fetcher(
+                generateGraphqlOperation('query', queryRoot, request),
+            )
+
+            return resultPromise
+        }
+    }
+    if (mutationRoot) {
+        client.mutation = (request: any) => {
+            if (!mutationRoot)
+                throw new Error('mutationRoot argument is missing')
+
+            const resultPromise = fetcher(
+                generateGraphqlOperation('mutation', mutationRoot, request),
+            )
+
+            return resultPromise
+        }
+    }
+
+    return client as any
+}

--- a/packages/github-service/src/internal/generated/runtime/error.ts
+++ b/packages/github-service/src/internal/generated/runtime/error.ts
@@ -1,0 +1,29 @@
+// @ts-nocheck
+export class GenqlError extends Error {
+    errors: Array<GraphqlError> = []
+    /**
+     * Partial data returned by the server
+     */
+    data?: any
+    constructor(errors: any[], data: any) {
+        let message = Array.isArray(errors)
+            ? errors.map((x) => x?.message || '').join('\n')
+            : ''
+        if (!message) {
+            message = 'GraphQL error'
+        }
+        super(message)
+        this.errors = errors
+        this.data = data
+    }
+}
+
+interface GraphqlError {
+    message: string
+    locations?: Array<{
+        line: number
+        column: number
+    }>
+    path?: string[]
+    extensions?: Record<string, any>
+}

--- a/packages/github-service/src/internal/generated/runtime/fetcher.ts
+++ b/packages/github-service/src/internal/generated/runtime/fetcher.ts
@@ -1,0 +1,97 @@
+// @ts-nocheck
+import { QueryBatcher } from './batcher'
+
+import type { ClientOptions } from './createClient'
+import type { GraphqlOperation } from './generateGraphqlOperation'
+import { GenqlError } from './error'
+
+export interface Fetcher {
+    (gql: GraphqlOperation): Promise<any>
+}
+
+export type BatchOptions = {
+    batchInterval?: number // ms
+    maxBatchSize?: number
+}
+
+const DEFAULT_BATCH_OPTIONS = {
+    maxBatchSize: 10,
+    batchInterval: 40,
+}
+
+export const createFetcher = ({
+    url,
+    headers = {},
+    fetcher,
+    fetch: _fetch,
+    batch = false,
+    ...rest
+}: ClientOptions): Fetcher => {
+    if (!url && !fetcher) {
+        throw new Error('url or fetcher is required')
+    }
+
+    fetcher = fetcher || (async (body) => {
+        let headersObject =
+            typeof headers == 'function' ? await headers() : headers
+        headersObject = headersObject || {}
+        if (typeof fetch === 'undefined' && !_fetch) {
+            throw new Error(
+                'Global `fetch` function is not available, pass a fetch polyfill to Genql `createClient`',
+            )
+        }
+        let fetchImpl = _fetch || fetch
+        const res = await fetchImpl(url!, {
+            headers: {
+                'Content-Type': 'application/json',
+                ...headersObject,
+            },
+            method: 'POST',
+            body: JSON.stringify(body),
+            ...rest,
+        })
+        if (!res.ok) {
+            throw new Error(`${res.statusText}: ${await res.text()}`)
+        }
+        const json = await res.json()
+        return json
+    })
+
+    if (!batch) {
+        return async (body) => {
+            const json = await fetcher!(body)
+            if (Array.isArray(json)) {
+                return json.map((json) => {
+                    if (json?.errors?.length) {
+                        throw new GenqlError(json.errors || [], json.data)
+                    }
+                    return json.data
+                })
+            } else {
+                if (json?.errors?.length) {
+                    throw new GenqlError(json.errors || [], json.data)
+                }
+                return json.data
+            }
+        }
+    }
+
+    const batcher = new QueryBatcher(
+        async (batchedQuery) => {
+            // console.log(batchedQuery) // [{ query: 'query{user{age}}', variables: {} }, ...]
+            const json = await fetcher!(batchedQuery)
+            return json as any
+        },
+        batch === true ? DEFAULT_BATCH_OPTIONS : batch,
+    )
+
+    return async ({ query, variables }) => {
+        const json = await batcher.fetch(query, variables)
+        if (json?.data) {
+            return json.data
+        }
+        throw new Error(
+            'Genql batch fetcher returned unexpected result ' + JSON.stringify(json),
+        )
+    }
+}

--- a/packages/github-service/src/internal/generated/runtime/generateGraphqlOperation.ts
+++ b/packages/github-service/src/internal/generated/runtime/generateGraphqlOperation.ts
@@ -1,0 +1,225 @@
+// @ts-nocheck
+import type { LinkedField, LinkedType } from './types'
+
+export interface Args {
+    [arg: string]: any | undefined
+}
+
+export interface Fields {
+    [field: string]: Request
+}
+
+export type Request = boolean | number | Fields
+
+export interface Variables {
+    [name: string]: {
+        value: any
+        typing: [LinkedType, string]
+    }
+}
+
+export interface Context {
+    root: LinkedType
+    varCounter: number
+    variables: Variables
+    fragmentCounter: number
+    fragments: string[]
+}
+
+export interface GraphqlOperation {
+    query: string
+    variables?: { [name: string]: any }
+    operationName?: string
+}
+
+const parseRequest = (
+    request: Request | undefined,
+    ctx: Context,
+    path: string[],
+): string => {
+    if (typeof request === 'object' && '__args' in request) {
+        const args: any = request.__args
+        let fields: Request | undefined = { ...request }
+        delete fields.__args
+        const argNames = Object.keys(args)
+
+        if (argNames.length === 0) {
+            return parseRequest(fields, ctx, path)
+        }
+
+        const field = getFieldFromPath(ctx.root, path)
+
+        const argStrings = argNames.map((argName) => {
+            ctx.varCounter++
+            const varName = `v${ctx.varCounter}`
+
+            const typing = field.args && field.args[argName] // typeMap used here, .args
+
+            if (!typing) {
+                throw new Error(
+                    `no typing defined for argument \`${argName}\` in path \`${path.join(
+                        '.',
+                    )}\``,
+                )
+            }
+
+            ctx.variables[varName] = {
+                value: args[argName],
+                typing,
+            }
+
+            return `${argName}:$${varName}`
+        })
+        return `(${argStrings})${parseRequest(fields, ctx, path)}`
+    } else if (typeof request === 'object' && Object.keys(request).length > 0) {
+        const fields = request
+        const fieldNames = Object.keys(fields).filter((k) => Boolean(fields[k]))
+
+        if (fieldNames.length === 0) {
+            throw new Error(
+                `field selection should not be empty: ${path.join('.')}`,
+            )
+        }
+
+        const type =
+            path.length > 0 ? getFieldFromPath(ctx.root, path).type : ctx.root
+        const scalarFields = type.scalar
+
+        let scalarFieldsFragment: string | undefined
+
+        if (fieldNames.includes('__scalar')) {
+            const falsyFieldNames = new Set(
+                Object.keys(fields).filter((k) => !Boolean(fields[k])),
+            )
+            if (scalarFields?.length) {
+                ctx.fragmentCounter++
+                scalarFieldsFragment = `f${ctx.fragmentCounter}`
+
+                ctx.fragments.push(
+                    `fragment ${scalarFieldsFragment} on ${
+                        type.name
+                    }{${scalarFields
+                        .filter((f) => !falsyFieldNames.has(f))
+                        .join(',')}}`,
+                )
+            }
+        }
+
+        const fieldsSelection = fieldNames
+            .filter((f) => !['__scalar', '__name'].includes(f))
+            .map((f) => {
+                const parsed = parseRequest(fields[f], ctx, [...path, f])
+
+                if (f.startsWith('on_')) {
+                    ctx.fragmentCounter++
+                    const implementationFragment = `f${ctx.fragmentCounter}`
+
+                    const typeMatch = f.match(/^on_(.+)/)
+
+                    if (!typeMatch || !typeMatch[1])
+                        throw new Error('match failed')
+
+                    ctx.fragments.push(
+                        `fragment ${implementationFragment} on ${typeMatch[1]}${parsed}`,
+                    )
+
+                    return `...${implementationFragment}`
+                } else {
+                    return `${f}${parsed}`
+                }
+            })
+            .concat(scalarFieldsFragment ? [`...${scalarFieldsFragment}`] : [])
+            .join(',')
+
+        return `{${fieldsSelection}}`
+    } else {
+        return ''
+    }
+}
+
+export const generateGraphqlOperation = (
+    operation: 'query' | 'mutation' | 'subscription',
+    root: LinkedType,
+    fields?: Fields,
+): GraphqlOperation => {
+    const ctx: Context = {
+        root: root,
+        varCounter: 0,
+        variables: {},
+        fragmentCounter: 0,
+        fragments: [],
+    }
+    const result = parseRequest(fields, ctx, [])
+
+    const varNames = Object.keys(ctx.variables)
+
+    const varsString =
+        varNames.length > 0
+            ? `(${varNames.map((v) => {
+                  const variableType = ctx.variables[v].typing[1]
+                  return `$${v}:${variableType}`
+              })})`
+            : ''
+
+    const operationName = fields?.__name || ''
+
+    return {
+        query: [
+            `${operation} ${operationName}${varsString}${result}`,
+            ...ctx.fragments,
+        ].join(','),
+        variables: Object.keys(ctx.variables).reduce<{ [name: string]: any }>(
+            (r, v) => {
+                r[v] = ctx.variables[v].value
+                return r
+            },
+            {},
+        ),
+        ...(operationName ? { operationName: operationName.toString() } : {}),
+    }
+}
+
+export const getFieldFromPath = (
+    root: LinkedType | undefined,
+    path: string[],
+) => {
+    let current: LinkedField | undefined
+
+    if (!root) throw new Error('root type is not provided')
+
+    if (path.length === 0) throw new Error(`path is empty`)
+
+    path.forEach((f) => {
+        const type = current ? current.type : root
+
+        if (!type.fields)
+            throw new Error(`type \`${type.name}\` does not have fields`)
+
+        const possibleTypes = Object.keys(type.fields)
+            .filter((i) => i.startsWith('on_'))
+            .reduce(
+                (types, fieldName) => {
+                    const field = type.fields && type.fields[fieldName]
+                    if (field) types.push(field.type)
+                    return types
+                },
+                [type],
+            )
+
+        let field: LinkedField | null = null
+
+        possibleTypes.forEach((type) => {
+            const found = type.fields && type.fields[f]
+            if (found) field = found
+        })
+
+        if (!field)
+            throw new Error(
+                `type \`${type.name}\` does not have a field \`${f}\``,
+            )
+
+        current = field
+    })
+
+    return current as LinkedField
+}

--- a/packages/github-service/src/internal/generated/runtime/index.ts
+++ b/packages/github-service/src/internal/generated/runtime/index.ts
@@ -1,0 +1,13 @@
+// @ts-nocheck
+export { createClient } from './createClient'
+export type { ClientOptions } from './createClient'
+export type { FieldsSelection } from './typeSelection'
+export { generateGraphqlOperation } from './generateGraphqlOperation'
+export type { GraphqlOperation } from './generateGraphqlOperation'
+export { linkTypeMap } from './linkTypeMap'
+// export { Observable } from 'zen-observable-ts'
+export { createFetcher } from './fetcher'
+export { GenqlError } from './error'
+export const everything = {
+    __scalar: true,
+}

--- a/packages/github-service/src/internal/generated/runtime/linkTypeMap.ts
+++ b/packages/github-service/src/internal/generated/runtime/linkTypeMap.ts
@@ -1,0 +1,156 @@
+// @ts-nocheck
+import type {
+    CompressedType,
+    CompressedTypeMap,
+    LinkedArgMap,
+    LinkedField,
+    LinkedType,
+    LinkedTypeMap,
+} from './types'
+
+export interface PartialLinkedFieldMap {
+    [field: string]: {
+        type: string
+        args?: LinkedArgMap
+    }
+}
+
+export const linkTypeMap = (
+    typeMap: CompressedTypeMap<number>,
+): LinkedTypeMap => {
+    const indexToName: Record<number, string> = Object.assign(
+        {},
+        ...Object.keys(typeMap.types).map((k, i) => ({ [i]: k })),
+    )
+
+    let intermediaryTypeMap = Object.assign(
+        {},
+        ...Object.keys(typeMap.types || {}).map(
+            (k): Record<string, LinkedType> => {
+                const type: CompressedType = typeMap.types[k]!
+                const fields = type || {}
+                return {
+                    [k]: {
+                        name: k,
+                        // type scalar properties
+                        scalar: Object.keys(fields).filter((f) => {
+                            const [type] = fields[f] || []
+
+                            const isScalar =
+                                type && typeMap.scalars.includes(type)
+                            if (!isScalar) {
+                                return false
+                            }
+                            const args = fields[f]?.[1]
+                            const argTypes = Object.values(args || {})
+                                .map((x) => x?.[1])
+                                .filter(Boolean)
+
+                            const hasRequiredArgs = argTypes.some(
+                                (str) => str && str.endsWith('!'),
+                            )
+                            if (hasRequiredArgs) {
+                                return false
+                            }
+                            return true
+                        }),
+                        // fields with corresponding `type` and `args`
+                        fields: Object.assign(
+                            {},
+                            ...Object.keys(fields).map(
+                                (f): PartialLinkedFieldMap => {
+                                    const [typeIndex, args] = fields[f] || []
+                                    if (typeIndex == null) {
+                                        return {}
+                                    }
+                                    return {
+                                        [f]: {
+                                            // replace index with type name
+                                            type: indexToName[typeIndex],
+                                            args: Object.assign(
+                                                {},
+                                                ...Object.keys(args || {}).map(
+                                                    (k) => {
+                                                        // if argTypeString == argTypeName, argTypeString is missing, need to readd it
+                                                        if (!args || !args[k]) {
+                                                            return
+                                                        }
+                                                        const [
+                                                            argTypeName,
+                                                            argTypeString,
+                                                        ] = args[k] as any
+                                                        return {
+                                                            [k]: [
+                                                                indexToName[
+                                                                    argTypeName
+                                                                ],
+                                                                argTypeString ||
+                                                                    indexToName[
+                                                                        argTypeName
+                                                                    ],
+                                                            ],
+                                                        }
+                                                    },
+                                                ),
+                                            ),
+                                        },
+                                    }
+                                },
+                            ),
+                        ),
+                    },
+                }
+            },
+        ),
+    )
+    const res = resolveConcreteTypes(intermediaryTypeMap)
+    return res
+}
+
+// replace typename with concrete type
+export const resolveConcreteTypes = (linkedTypeMap: LinkedTypeMap) => {
+    Object.keys(linkedTypeMap).forEach((typeNameFromKey) => {
+        const type: LinkedType = linkedTypeMap[typeNameFromKey]!
+        // type.name = typeNameFromKey
+        if (!type.fields) {
+            return
+        }
+
+        const fields = type.fields
+
+        Object.keys(fields).forEach((f) => {
+            const field: LinkedField = fields[f]!
+
+            if (field.args) {
+                const args = field.args
+                Object.keys(args).forEach((key) => {
+                    const arg = args[key]
+
+                    if (arg) {
+                        const [typeName] = arg
+
+                        if (typeof typeName === 'string') {
+                            if (!linkedTypeMap[typeName]) {
+                                linkedTypeMap[typeName] = { name: typeName }
+                            }
+
+                            arg[0] = linkedTypeMap[typeName]!
+                        }
+                    }
+                })
+            }
+
+            const typeName = field.type as LinkedType | string
+
+            if (typeof typeName === 'string') {
+                if (!linkedTypeMap[typeName]) {
+                    linkedTypeMap[typeName] = { name: typeName }
+                }
+
+                field.type = linkedTypeMap[typeName]!
+            }
+        })
+    })
+
+    return linkedTypeMap
+}

--- a/packages/github-service/src/internal/generated/runtime/typeSelection.ts
+++ b/packages/github-service/src/internal/generated/runtime/typeSelection.ts
@@ -1,0 +1,95 @@
+// @ts-nocheck
+//////////////////////////////////////////////////
+
+// SOME THINGS TO KNOW BEFORE DIVING IN
+/*
+0. DST is the request type, SRC is the response type
+
+1. FieldsSelection uses an object because currently is impossible to make recursive types
+
+2. FieldsSelection is a recursive type that makes a type based on request type and fields
+
+3. HandleObject handles object types
+
+4. Handle__scalar adds all scalar properties excluding non scalar props
+*/
+
+export type FieldsSelection<SRC extends Anify<DST> | undefined, DST> = {
+    scalar: SRC
+    union: Handle__isUnion<SRC, DST>
+    object: HandleObject<SRC, DST>
+    array: SRC extends Nil
+        ? never
+        : SRC extends Array<infer T | null>
+        ? Array<FieldsSelection<T, DST>>
+        : never
+    __scalar: Handle__scalar<SRC, DST>
+    never: never
+}[DST extends Nil
+    ? 'never'
+    : DST extends false | 0
+    ? 'never'
+    : SRC extends Scalar
+    ? 'scalar'
+    : SRC extends any[]
+    ? 'array'
+    : SRC extends { __isUnion?: any }
+    ? 'union'
+    : DST extends { __scalar?: any }
+    ? '__scalar'
+    : DST extends {}
+    ? 'object'
+    : 'never']
+
+type HandleObject<SRC extends Anify<DST>, DST> = DST extends boolean
+    ? SRC
+    : SRC extends Nil
+    ? never
+    : Pick<
+          {
+              // using keyof SRC to maintain ?: relations of SRC type
+              [Key in keyof SRC]: Key extends keyof DST
+                  ? FieldsSelection<SRC[Key], NonNullable<DST[Key]>>
+                  : SRC[Key]
+          },
+          Exclude<keyof DST, FieldsToRemove>
+          //   {
+          //       // remove falsy values
+          //       [Key in keyof DST]: DST[Key] extends false | 0 ? never : Key
+          //   }[keyof DST]
+      >
+
+type Handle__scalar<SRC extends Anify<DST>, DST> = SRC extends Nil
+    ? never
+    : Pick<
+          // continue processing fields that are in DST, directly pass SRC type if not in DST
+          {
+              [Key in keyof SRC]: Key extends keyof DST
+                  ? FieldsSelection<SRC[Key], DST[Key]>
+                  : SRC[Key]
+          },
+          // remove fields that are not scalars or are not in DST
+          {
+              [Key in keyof SRC]: SRC[Key] extends Nil
+                  ? never
+                  : Key extends FieldsToRemove
+                  ? never
+                  : SRC[Key] extends Scalar
+                  ? Key
+                  : Key extends keyof DST
+                  ? Key
+                  : never
+          }[keyof SRC]
+      >
+
+type Handle__isUnion<SRC extends Anify<DST>, DST> = SRC extends Nil
+    ? never
+    : Omit<SRC, FieldsToRemove> // just return the union type
+
+type Scalar = string | number | Date | boolean | null | undefined
+
+type Anify<T> = { [P in keyof T]?: any }
+
+type FieldsToRemove = '__isUnion' | '__scalar' | '__name' | '__args'
+
+type Nil = undefined | null

--- a/packages/github-service/src/internal/generated/runtime/types.ts
+++ b/packages/github-service/src/internal/generated/runtime/types.ts
@@ -1,0 +1,69 @@
+// @ts-nocheck
+
+export interface ExecutionResult<TData = { [key: string]: any }> {
+    errors?: Array<Error>
+    data?: TData | null
+}
+
+export interface ArgMap<keyType = number> {
+    [arg: string]: [keyType, string] | [keyType] | undefined
+}
+
+export type CompressedField<keyType = number> = [
+    type: keyType,
+    args?: ArgMap<keyType>,
+]
+
+export interface CompressedFieldMap<keyType = number> {
+    [field: string]: CompressedField<keyType> | undefined
+}
+
+export type CompressedType<keyType = number> = CompressedFieldMap<keyType>
+
+export interface CompressedTypeMap<keyType = number> {
+    scalars: Array<keyType>
+    types: {
+        [type: string]: CompressedType<keyType> | undefined
+    }
+}
+
+// normal types
+export type Field<keyType = number> = {
+    type: keyType
+    args?: ArgMap<keyType>
+}
+
+export interface FieldMap<keyType = number> {
+    [field: string]: Field<keyType> | undefined
+}
+
+export type Type<keyType = number> = FieldMap<keyType>
+
+export interface TypeMap<keyType = number> {
+    scalars: Array<keyType>
+    types: {
+        [type: string]: Type<keyType> | undefined
+    }
+}
+
+export interface LinkedArgMap {
+    [arg: string]: [LinkedType, string] | undefined
+}
+export interface LinkedField {
+    type: LinkedType
+    args?: LinkedArgMap
+}
+
+export interface LinkedFieldMap {
+    [field: string]: LinkedField | undefined
+}
+
+export interface LinkedType {
+    name: string
+    fields?: LinkedFieldMap
+    scalar?: string[]
+}
+
+export interface LinkedTypeMap {
+    [type: string]: LinkedType | undefined
+}

--- a/packages/github-service/src/internal/generated/schema.graphql
+++ b/packages/github-service/src/internal/generated/schema.graphql
@@ -1,0 +1,35 @@
+scalar DateTime
+
+scalar URI
+
+type Query {
+  repository(owner: String!, name: String!): Repository
+}
+
+type Repository {
+  issues(first: Int, after: String, labels: [String!]): IssueConnection!
+}
+
+type IssueConnection {
+  nodes: [Issue]
+  pageInfo: PageInfo!
+}
+
+type PageInfo {
+  endCursor: String
+  hasNextPage: Boolean!
+}
+
+type Issue {
+  number: Int!
+  title: String!
+  body: String!
+  url: URI!
+  createdAt: DateTime!
+  state: IssueState!
+}
+
+enum IssueState {
+  OPEN
+  CLOSED
+}

--- a/packages/github-service/src/internal/generated/schema.ts
+++ b/packages/github-service/src/internal/generated/schema.ts
@@ -1,0 +1,128 @@
+// @ts-nocheck
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+export type Scalars = {
+    DateTime: any,
+    URI: any,
+    String: string,
+    Int: number,
+    Boolean: boolean,
+}
+
+export interface Query {
+    repository: (Repository | null)
+    __typename: 'Query'
+}
+
+export interface Repository {
+    issues: IssueConnection
+    __typename: 'Repository'
+}
+
+export interface IssueConnection {
+    nodes: ((Issue | null)[] | null)
+    pageInfo: PageInfo
+    __typename: 'IssueConnection'
+}
+
+export interface PageInfo {
+    endCursor: (Scalars['String'] | null)
+    hasNextPage: Scalars['Boolean']
+    __typename: 'PageInfo'
+}
+
+export interface Issue {
+    number: Scalars['Int']
+    title: Scalars['String']
+    body: Scalars['String']
+    url: Scalars['URI']
+    createdAt: Scalars['DateTime']
+    state: IssueState
+    __typename: 'Issue'
+}
+
+export type IssueState = 'OPEN' | 'CLOSED'
+
+export interface QueryGenqlSelection{
+    repository?: (RepositoryGenqlSelection & { __args: {owner: Scalars['String'], name: Scalars['String']} })
+    __typename?: boolean | number
+    __scalar?: boolean | number
+}
+
+export interface RepositoryGenqlSelection{
+    issues?: (IssueConnectionGenqlSelection & { __args?: {first?: (Scalars['Int'] | null), after?: (Scalars['String'] | null), labels?: (Scalars['String'][] | null)} })
+    __typename?: boolean | number
+    __scalar?: boolean | number
+}
+
+export interface IssueConnectionGenqlSelection{
+    nodes?: IssueGenqlSelection
+    pageInfo?: PageInfoGenqlSelection
+    __typename?: boolean | number
+    __scalar?: boolean | number
+}
+
+export interface PageInfoGenqlSelection{
+    endCursor?: boolean | number
+    hasNextPage?: boolean | number
+    __typename?: boolean | number
+    __scalar?: boolean | number
+}
+
+export interface IssueGenqlSelection{
+    number?: boolean | number
+    title?: boolean | number
+    body?: boolean | number
+    url?: boolean | number
+    createdAt?: boolean | number
+    state?: boolean | number
+    __typename?: boolean | number
+    __scalar?: boolean | number
+}
+
+
+    const Query_possibleTypes: string[] = ['Query']
+    export const isQuery = (obj?: { __typename?: any } | null): obj is Query => {
+      if (!obj?.__typename) throw new Error('__typename is missing in "isQuery"')
+      return Query_possibleTypes.includes(obj.__typename)
+    }
+    
+
+
+    const Repository_possibleTypes: string[] = ['Repository']
+    export const isRepository = (obj?: { __typename?: any } | null): obj is Repository => {
+      if (!obj?.__typename) throw new Error('__typename is missing in "isRepository"')
+      return Repository_possibleTypes.includes(obj.__typename)
+    }
+    
+
+
+    const IssueConnection_possibleTypes: string[] = ['IssueConnection']
+    export const isIssueConnection = (obj?: { __typename?: any } | null): obj is IssueConnection => {
+      if (!obj?.__typename) throw new Error('__typename is missing in "isIssueConnection"')
+      return IssueConnection_possibleTypes.includes(obj.__typename)
+    }
+    
+
+
+    const PageInfo_possibleTypes: string[] = ['PageInfo']
+    export const isPageInfo = (obj?: { __typename?: any } | null): obj is PageInfo => {
+      if (!obj?.__typename) throw new Error('__typename is missing in "isPageInfo"')
+      return PageInfo_possibleTypes.includes(obj.__typename)
+    }
+    
+
+
+    const Issue_possibleTypes: string[] = ['Issue']
+    export const isIssue = (obj?: { __typename?: any } | null): obj is Issue => {
+      if (!obj?.__typename) throw new Error('__typename is missing in "isIssue"')
+      return Issue_possibleTypes.includes(obj.__typename)
+    }
+    
+
+export const enumIssueState = {
+   OPEN: 'OPEN' as const,
+   CLOSED: 'CLOSED' as const
+}

--- a/packages/github-service/src/internal/generated/types.ts
+++ b/packages/github-service/src/internal/generated/types.ts
@@ -1,0 +1,101 @@
+export default {
+    "scalars": [
+        0,
+        1,
+        3,
+        5,
+        8,
+        10
+    ],
+    "types": {
+        "DateTime": {},
+        "URI": {},
+        "Query": {
+            "repository": [
+                4,
+                {
+                    "owner": [
+                        3,
+                        "String!"
+                    ],
+                    "name": [
+                        3,
+                        "String!"
+                    ]
+                }
+            ],
+            "__typename": [
+                3
+            ]
+        },
+        "String": {},
+        "Repository": {
+            "issues": [
+                6,
+                {
+                    "first": [
+                        5
+                    ],
+                    "after": [
+                        3
+                    ],
+                    "labels": [
+                        3,
+                        "[String!]"
+                    ]
+                }
+            ],
+            "__typename": [
+                3
+            ]
+        },
+        "Int": {},
+        "IssueConnection": {
+            "nodes": [
+                9
+            ],
+            "pageInfo": [
+                7
+            ],
+            "__typename": [
+                3
+            ]
+        },
+        "PageInfo": {
+            "endCursor": [
+                3
+            ],
+            "hasNextPage": [
+                8
+            ],
+            "__typename": [
+                3
+            ]
+        },
+        "Boolean": {},
+        "Issue": {
+            "number": [
+                5
+            ],
+            "title": [
+                3
+            ],
+            "body": [
+                3
+            ],
+            "url": [
+                1
+            ],
+            "createdAt": [
+                0
+            ],
+            "state": [
+                10
+            ],
+            "__typename": [
+                3
+            ]
+        },
+        "IssueState": {}
+    }
+}

--- a/packages/github-service/src/lib/errors.ts
+++ b/packages/github-service/src/lib/errors.ts
@@ -1,0 +1,13 @@
+import { Data } from "effect"
+
+export class GitHubRepositoryUnavailableError extends Data.TaggedError(
+  "GitHubRepositoryUnavailableError",
+)<{
+  readonly owner: string
+  readonly name: string
+}> {}
+
+export class GitHubRequestError extends Data.TaggedError("GitHubRequestError")<{
+  readonly message: string
+  readonly cause?: unknown
+}> {}

--- a/packages/github-service/src/lib/github-service-live.ts
+++ b/packages/github-service/src/lib/github-service-live.ts
@@ -1,0 +1,133 @@
+import { Config, Effect, Layer, Redacted } from "effect"
+import { type Client, createClient } from "../internal/generated/index.js"
+import {
+  GitHubRepositoryUnavailableError,
+  GitHubRequestError,
+} from "./errors.js"
+import { GitHubService, type GitHubServiceShape } from "./github-service.js"
+import type { ReadyLabeledIssue } from "./types.js"
+
+const GITHUB_GRAPHQL_URL = "https://api.github.com/graphql"
+const READY_FOR_AGENT_LABEL = "ready-for-agent"
+const PAGE_SIZE = 100
+
+export type GitHubGraphqlClient = Pick<Client, "query">
+
+interface GitHubApiIssue {
+  readonly number: number
+  readonly title: string
+  readonly body: string
+  readonly url: unknown
+  readonly createdAt: unknown
+  readonly state: "OPEN" | "CLOSED"
+}
+
+const toReadyLabeledIssue = (issue: GitHubApiIssue): ReadyLabeledIssue => {
+  const createdAt = new Date(String(issue.createdAt))
+  if (Number.isNaN(createdAt.getTime())) {
+    throw new Error(`Invalid GitHub issue creation time: ${issue.createdAt}`)
+  }
+
+  return {
+    number: issue.number,
+    title: issue.title,
+    body: issue.body,
+    url: String(issue.url),
+    createdAt,
+    state: issue.state,
+  }
+}
+
+export const makeGitHubService = (
+  client: GitHubGraphqlClient,
+): GitHubServiceShape => ({
+  listReadyIssues: (repository) =>
+    Effect.gen(function* () {
+      const issues: ReadyLabeledIssue[] = []
+      let after: string | null = null
+
+      while (true) {
+        const result = yield* Effect.tryPromise({
+          try: () =>
+            client.query({
+              repository: {
+                __args: repository,
+                issues: {
+                  __args: {
+                    first: PAGE_SIZE,
+                    after,
+                    labels: [READY_FOR_AGENT_LABEL],
+                  },
+                  nodes: {
+                    number: true,
+                    title: true,
+                    body: true,
+                    url: true,
+                    createdAt: true,
+                    state: true,
+                  },
+                  pageInfo: {
+                    endCursor: true,
+                    hasNextPage: true,
+                  },
+                },
+              },
+            }),
+          catch: (cause) =>
+            new GitHubRequestError({
+              message: `Failed to list Ready-labeled Issues for ${repository.owner}/${repository.name}`,
+              cause,
+            }),
+        })
+
+        if (result.repository === null) {
+          return yield* new GitHubRepositoryUnavailableError(repository)
+        }
+
+        const mappedIssues = yield* Effect.try({
+          try: () =>
+            (
+              (result.repository.issues.nodes ??
+                []) as readonly (GitHubApiIssue | null)[]
+            )
+              .filter((issue) => issue !== null)
+              .map(toReadyLabeledIssue),
+          catch: (cause) =>
+            new GitHubRequestError({
+              message: `GitHub returned invalid Issue data for ${repository.owner}/${repository.name}`,
+              cause,
+            }),
+        })
+        issues.push(...mappedIssues)
+
+        const { endCursor, hasNextPage } = result.repository.issues.pageInfo
+        if (!hasNextPage) {
+          break
+        }
+        if (endCursor === null) {
+          return yield* new GitHubRequestError({
+            message: `GitHub omitted the next page cursor for ${repository.owner}/${repository.name}`,
+          })
+        }
+        after = endCursor
+      }
+
+      return issues.sort((left, right) => left.number - right.number)
+    }),
+})
+
+export const GitHubServiceLive = Layer.effect(
+  GitHubService,
+  Config.redacted("GITHUB_TOKEN").pipe(
+    Effect.map((token) =>
+      makeGitHubService(
+        createClient({
+          url: GITHUB_GRAPHQL_URL,
+          headers: {
+            Authorization: `Bearer ${Redacted.value(token)}`,
+          },
+        }),
+      ),
+    ),
+  ),
+)

--- a/packages/github-service/src/lib/github-service-test.ts
+++ b/packages/github-service/src/lib/github-service-test.ts
@@ -1,0 +1,54 @@
+import { Effect, Layer } from "effect"
+import {
+  GitHubRepositoryUnavailableError,
+  type GitHubRequestError,
+} from "./errors.js"
+import { GitHubService } from "./github-service.js"
+import type { GitHubRepository, ReadyLabeledIssue } from "./types.js"
+
+interface GitHubServiceTestFixtureBase {
+  readonly repository: GitHubRepository
+}
+
+export interface GitHubServiceTestIssuesFixture
+  extends GitHubServiceTestFixtureBase {
+  readonly issues: readonly ReadyLabeledIssue[]
+  readonly error?: never
+}
+
+export interface GitHubServiceTestErrorFixture
+  extends GitHubServiceTestFixtureBase {
+  readonly error: GitHubRequestError
+  readonly issues?: never
+}
+
+export type GitHubServiceTestFixture =
+  | GitHubServiceTestIssuesFixture
+  | GitHubServiceTestErrorFixture
+
+const repositoryKey = ({ owner, name }: GitHubRepository): string =>
+  `${owner.toLowerCase()}/${name.toLowerCase()}`
+
+export const makeGitHubServiceTest = (
+  fixtures: readonly GitHubServiceTestFixture[],
+): Layer.Layer<GitHubService> => {
+  const fixturesByRepository = new Map(
+    fixtures.map((fixture) => [repositoryKey(fixture.repository), fixture]),
+  )
+
+  return Layer.succeed(GitHubService, {
+    listReadyIssues: (repository) => {
+      const fixture = fixturesByRepository.get(repositoryKey(repository))
+      if (fixture === undefined) {
+        return Effect.fail(new GitHubRepositoryUnavailableError(repository))
+      }
+      if (fixture.error !== undefined) {
+        return Effect.fail(fixture.error)
+      }
+
+      return Effect.succeed(
+        [...fixture.issues].sort((left, right) => left.number - right.number),
+      )
+    },
+  })
+}

--- a/packages/github-service/src/lib/github-service.ts
+++ b/packages/github-service/src/lib/github-service.ts
@@ -1,0 +1,19 @@
+import { Context, type Effect } from "effect"
+import type {
+  GitHubRepositoryUnavailableError,
+  GitHubRequestError,
+} from "./errors.js"
+import type { GitHubRepository, ReadyLabeledIssue } from "./types.js"
+
+export interface GitHubServiceShape {
+  readonly listReadyIssues: (
+    repository: GitHubRepository,
+  ) => Effect.Effect<
+    readonly ReadyLabeledIssue[],
+    GitHubRepositoryUnavailableError | GitHubRequestError
+  >
+}
+
+export class GitHubService extends Context.Tag(
+  "@ready-for-agent/github-service/GitHubService",
+)<GitHubService, GitHubServiceShape>() {}

--- a/packages/github-service/src/lib/types.ts
+++ b/packages/github-service/src/lib/types.ts
@@ -1,0 +1,15 @@
+export interface GitHubRepository {
+  readonly owner: string
+  readonly name: string
+}
+
+export type GitHubIssueState = "OPEN" | "CLOSED"
+
+export interface ReadyLabeledIssue {
+  readonly number: number
+  readonly title: string
+  readonly body: string
+  readonly url: string
+  readonly createdAt: Date
+  readonly state: GitHubIssueState
+}

--- a/packages/github-service/test/github-service.spec.ts
+++ b/packages/github-service/test/github-service.spec.ts
@@ -1,0 +1,221 @@
+import { Effect, Either } from "effect"
+import {
+  GitHubRepositoryUnavailableError,
+  GitHubRequestError,
+  GitHubService,
+  type ReadyLabeledIssue,
+  makeGitHubServiceTest,
+} from "../src/index.js"
+import {
+  type GitHubGraphqlClient,
+  makeGitHubService,
+} from "../src/lib/github-service-live.js"
+import { describe, expect, it } from "bun:test"
+
+const repository = { owner: "acme", name: "widgets" }
+
+const issue = (
+  number: number,
+  state: "OPEN" | "CLOSED" = "OPEN",
+): ReadyLabeledIssue => ({
+  number,
+  title: `Issue ${number}`,
+  body: `Body ${number}`,
+  url: `https://github.com/acme/widgets/issues/${number}`,
+  createdAt: new Date(`2026-07-${String(number).padStart(2, "0")}T12:00:00Z`),
+  state,
+})
+
+describe("GitHubService live implementation", () => {
+  it("fetches every ready-for-agent page and returns mapped issues by number", async () => {
+    const requests: unknown[] = []
+    const responses = [
+      {
+        repository: {
+          issues: {
+            nodes: [
+              {
+                number: 9,
+                title: "Later issue",
+                body: "Later body",
+                url: "https://github.com/acme/widgets/issues/9",
+                createdAt: "2026-07-09T12:00:00Z",
+                state: "OPEN",
+              },
+            ],
+            pageInfo: { endCursor: "page-2", hasNextPage: true },
+          },
+        },
+      },
+      {
+        repository: {
+          issues: {
+            nodes: [
+              null,
+              {
+                number: 2,
+                title: "Earlier issue",
+                body: "Earlier body",
+                url: "https://github.com/acme/widgets/issues/2",
+                createdAt: "2026-07-02T12:00:00Z",
+                state: "CLOSED",
+              },
+            ],
+            pageInfo: { endCursor: null, hasNextPage: false },
+          },
+        },
+      },
+    ]
+    const client = {
+      query: async (request: unknown) => {
+        requests.push(request)
+        return responses.shift()
+      },
+    } as GitHubGraphqlClient
+
+    const result = await Effect.runPromise(
+      makeGitHubService(client).listReadyIssues(repository),
+    )
+
+    expect(result.map(({ number }) => number)).toEqual([2, 9])
+    expect(result[0]).toEqual({
+      number: 2,
+      title: "Earlier issue",
+      body: "Earlier body",
+      url: "https://github.com/acme/widgets/issues/2",
+      createdAt: new Date("2026-07-02T12:00:00Z"),
+      state: "CLOSED",
+    })
+    expect(requests).toHaveLength(2)
+
+    const firstRequest = requests[0] as {
+      repository: {
+        __args: { owner: string; name: string }
+        issues: {
+          __args: { first: number; after: string | null; labels: string[] }
+          nodes: Record<string, boolean>
+        }
+      }
+    }
+    expect(firstRequest.repository.__args).toEqual(repository)
+    expect(firstRequest.repository.issues.__args).toEqual({
+      first: 100,
+      after: null,
+      labels: ["ready-for-agent"],
+    })
+    expect(firstRequest.repository.issues.nodes).toEqual({
+      number: true,
+      title: true,
+      body: true,
+      url: true,
+      createdAt: true,
+      state: true,
+    })
+
+    const secondRequest = requests[1] as typeof firstRequest
+    expect(secondRequest.repository.issues.__args.after).toBe("page-2")
+  })
+
+  it("fails when the Repository is missing or inaccessible", async () => {
+    const client = {
+      query: async () => ({ repository: null }),
+    } as GitHubGraphqlClient
+
+    const result = await Effect.runPromise(
+      makeGitHubService(client).listReadyIssues(repository).pipe(Effect.either),
+    )
+
+    expect(Either.isLeft(result)).toBe(true)
+    if (Either.isLeft(result)) {
+      expect(result.left).toEqual(
+        new GitHubRepositoryUnavailableError(repository),
+      )
+    }
+  })
+
+  it("wraps GenQL failures as request errors", async () => {
+    const cause = new Error("Bad credentials")
+    const client = {
+      query: async () => Promise.reject(cause),
+    } as GitHubGraphqlClient
+
+    const result = await Effect.runPromise(
+      makeGitHubService(client).listReadyIssues(repository).pipe(Effect.either),
+    )
+
+    expect(Either.isLeft(result)).toBe(true)
+    if (Either.isLeft(result)) {
+      expect(result.left).toBeInstanceOf(GitHubRequestError)
+      expect(result.left.cause).toBe(cause)
+    }
+  })
+
+  it("fails when GitHub reports another page without a cursor", async () => {
+    const client = {
+      query: async () => ({
+        repository: {
+          issues: {
+            nodes: [],
+            pageInfo: { endCursor: null, hasNextPage: true },
+          },
+        },
+      }),
+    } as GitHubGraphqlClient
+
+    const result = await Effect.runPromise(
+      makeGitHubService(client).listReadyIssues(repository).pipe(Effect.either),
+    )
+
+    expect(Either.isLeft(result)).toBe(true)
+    if (Either.isLeft(result)) {
+      expect(result.left).toBeInstanceOf(GitHubRequestError)
+      expect(result.left.message).toContain("omitted the next page cursor")
+    }
+  })
+})
+
+describe("makeGitHubServiceTest", () => {
+  it("looks up Repository fixtures case-insensitively and sorts their issues", async () => {
+    const layer = makeGitHubServiceTest([
+      { repository, issues: [issue(9), issue(2, "CLOSED")] },
+    ])
+
+    const result = await Effect.runPromise(
+      Effect.gen(function* () {
+        const github = yield* GitHubService
+        return yield* github.listReadyIssues({ owner: "ACME", name: "Widgets" })
+      }).pipe(Effect.provide(layer)),
+    )
+
+    expect(result.map(({ number }) => number)).toEqual([2, 9])
+  })
+
+  it("returns a configured request failure", async () => {
+    const error = new GitHubRequestError({ message: "Rate limited" })
+    const layer = makeGitHubServiceTest([{ repository, error }])
+
+    const result = await Effect.runPromise(
+      Effect.gen(function* () {
+        const github = yield* GitHubService
+        return yield* github.listReadyIssues(repository)
+      }).pipe(Effect.provide(layer), Effect.either),
+    )
+
+    expect(result).toEqual(Either.left(error))
+  })
+
+  it("fails unavailable for a Repository without a fixture", async () => {
+    const layer = makeGitHubServiceTest([])
+
+    const result = await Effect.runPromise(
+      Effect.gen(function* () {
+        const github = yield* GitHubService
+        return yield* github.listReadyIssues(repository)
+      }).pipe(Effect.provide(layer), Effect.either),
+    )
+
+    expect(result).toEqual(
+      Either.left(new GitHubRepositoryUnavailableError(repository)),
+    )
+  })
+})

--- a/packages/github-service/tsconfig.json
+++ b/packages/github-service/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ]
+}

--- a/packages/github-service/tsconfig.lib.json
+++ b/packages/github-service/tsconfig.lib.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "tsBuildInfoFile": "dist/tsconfig.lib.tsbuildinfo",
+    "emitDeclarationOnly": false,
+    "forceConsistentCasingInFileNames": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"],
+  "references": []
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -41,6 +41,9 @@
     },
     {
       "path": "./packages/opencode"
+    },
+    {
+      "path": "./packages/github-service"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- add an Effect-based GitHub service with live and fixture-backed test layers
- use a package-private GenQL client to paginate `ready-for-agent` issues from GitHub GraphQL
- return typed issue data and typed repository/request failures
- document Ready-labeled Issues and wire the package into Nx and Knip

## Testing
- `bun nx run github-service:generate`
- `bun nx run github-service:test`
- `bun nx run github-service:typecheck`
- `bun nx run github-service:lint`
- `bun nx run github-service:knip`
- pre-commit affected `lint,typecheck,test` suite