### PR TITLE
fix: report sidecar startup failures

### DIFF
--- a/apps/keymaxxer-sidecar/src/main.ts
+++ b/apps/keymaxxer-sidecar/src/main.ts
@@ -55,10 +55,12 @@ if (import.meta.main) {
   process.once("SIGINT", () => abortController.abort())
   process.once("SIGTERM", () => abortController.abort())
 
-  Effect.runPromise(program, { signal: abortController.signal }).catch(() => {
-    if (!abortController.signal.aborted) {
-      console.error("Keymaxxer Sidecar startup failed")
-      process.exitCode = 1
-    }
-  })
+  Effect.runPromise(program, { signal: abortController.signal }).catch(
+    (error) => {
+      if (!abortController.signal.aborted) {
+        console.error("Keymaxxer Sidecar startup failed", error)
+        process.exitCode = 1
+      }
+    },
+  )
 }

--- a/apps/keymaxxer-sidecar/test/topology.test.ts
+++ b/apps/keymaxxer-sidecar/test/topology.test.ts
@@ -1,5 +1,6 @@
 import {
   defaultKeymaxxerSidecarPort,
+  keymaxxerSidecarHost,
   keymaxxerSidecarPortFromEnvironment,
 } from "../src/main.js"
 import { describe, expect, test } from "bun:test"
@@ -15,5 +16,38 @@ describe("Keymaxxer development sidecar", () => {
     expect(() =>
       keymaxxerSidecarPortFromEnvironment({ KEYMAXXER_SIDECAR_PORT: "0" }),
     ).toThrow("KEYMAXXER_SIDECAR_PORT")
+  })
+
+  test("reports an actionable error when its port is occupied", async () => {
+    const occupyingServer = Bun.serve({
+      fetch: () => new Response(),
+      hostname: keymaxxerSidecarHost,
+      port: 0,
+    })
+
+    try {
+      const sidecar = Bun.spawn(
+        [
+          process.execPath,
+          "--conditions",
+          "@ready-for-agent/source",
+          new URL("../src/main.ts", import.meta.url).pathname,
+        ],
+        {
+          env: {
+            ...process.env,
+            KEYMAXXER_SIDECAR_PORT: String(occupyingServer.port),
+          },
+          stderr: "pipe",
+        },
+      )
+
+      expect(await sidecar.exited).toBe(1)
+      expect(await new Response(sidecar.stderr).text()).toContain(
+        `Keymaxxer Sidecar failed to listen on ${keymaxxerSidecarHost}:${occupyingServer.port}. Set KEYMAXXER_SIDECAR_PORT to an unused port.`,
+      )
+    } finally {
+      await occupyingServer.stop(true)
+    }
   })
 })


### PR DESCRIPTION
## Why

When the Keymaxxer Sidecar could not bind its configured port, its entrypoint discarded the Effect failure and reported only a generic startup error. This hid the actionable address-conflict message and made `harness:dev` failures difficult to diagnose.

## What Changed

- Include the underlying Effect failure in sidecar startup logging.
- Add a process-level regression test that occupies a loopback port, launches the sidecar against it, and verifies the diagnostic identifies the address and `KEYMAXXER_SIDECAR_PORT` override.

## Verification

Reproduced the failure with port `5032` occupied, then confirmed `npx nx run harness:dev` starts the sidecar on `5032` and Vite on `http://127.0.0.1:4200` after freeing the port.
