### PR TITLE
feat: list repositories via GraphQL

### DIFF
--- a/packages/db-service/src/lib/db-service.ts
+++ b/packages/db-service/src/lib/db-service.ts
@@ -122,6 +122,10 @@ export interface DbServiceShape {
     | LocalPathInUseError
     | DatabaseError
   >
+  readonly listRepositories: Effect.Effect<
+    readonly RepositoryRecord[],
+    DatabaseError
+  >
   readonly storeIssue: (
     input: StoreIssueInput,
   ) => Effect.Effect<
@@ -261,6 +265,42 @@ export const DbServiceLive = Layer.effect(
           issuesReconciledAt: row.issues_reconciled_at,
         })
       })
+
+    const listRepositories: Effect.Effect<
+      readonly RepositoryRecord[],
+      DatabaseError
+    > = Effect.gen(function* () {
+      const repositories = yield* sql
+        .unsafe(
+          `SELECT id, github_owner, github_repo, local_path, is_bare, paused,
+             issues_reconciled_at
+           FROM repository
+           ORDER BY lower(github_owner) ASC, lower(github_repo) ASC`,
+        )
+        .pipe(Effect.mapError(toDatabaseError))
+
+      return (
+        repositories as ReadonlyArray<{
+          id: string
+          github_owner: string
+          github_repo: string
+          local_path: string
+          is_bare: boolean | number
+          paused: boolean | number
+          issues_reconciled_at: number | null
+        }>
+      ).map((row) =>
+        toRecord({
+          id: row.id,
+          githubOwner: row.github_owner,
+          githubRepo: row.github_repo,
+          localPath: row.local_path,
+          isBare: row.is_bare,
+          paused: row.paused,
+          issuesReconciledAt: row.issues_reconciled_at,
+        }),
+      )
+    })
 
     const ensureRepositoryExists = (
       repositoryId: string,
@@ -461,6 +501,7 @@ export const DbServiceLive = Layer.effect(
 
     return DbService.of({
       addRepository,
+      listRepositories,
       storeIssue,
       listIssues,
       deleteIssue,

--- a/packages/db-service/test/db-service.spec.ts
+++ b/packages/db-service/test/db-service.spec.ts
@@ -143,6 +143,42 @@ describe("DbService", () => {
       ))
   })
 
+  describe("listRepositories", () => {
+    it("returns an empty list when none exist", () =>
+      runTest(
+        Effect.gen(function* () {
+          const db = yield* DbService
+          expect(yield* db.listRepositories).toEqual([])
+        }),
+      ))
+
+    it("returns repositories ordered by owner then name", () =>
+      runTest(
+        Effect.gen(function* () {
+          const db = yield* DbService
+          const zebra = yield* db.addRepository({
+            githubOwner: "zebra",
+            githubRepo: "tools",
+            localPath: "/repos/zebra/tools.git",
+            isBare: true,
+          })
+          const acmeWidgets = yield* db.addRepository(sampleInput)
+          const acmeApi = yield* db.addRepository({
+            githubOwner: "acme",
+            githubRepo: "api",
+            localPath: "/repos/acme/api.git",
+            isBare: false,
+          })
+
+          expect(yield* db.listRepositories).toEqual([
+            acmeApi,
+            acmeWidgets,
+            zebra,
+          ])
+        }),
+      ))
+  })
+
   describe("issues", () => {
     const addTestRepository = (db: DbService) => db.addRepository(sampleInput)
 

--- a/packages/graphql-api/src/lib/graphql-api.ts
+++ b/packages/graphql-api/src/lib/graphql-api.ts
@@ -81,6 +81,20 @@ export const createGraphqlApi = (runtime: GraphqlRuntime) => {
       resolvers: {
         Query: {
           health: () => true,
+          repositories: async () => {
+            const result = await runtime.runPromise(
+              Effect.result(
+                Effect.gen(function* () {
+                  const db = yield* DbService
+                  return yield* db.listRepositories
+                }),
+              ),
+            )
+            if (Result.isFailure(result)) {
+              throw toGraphQLError(result.failure)
+            }
+            return result.success
+          },
         },
         Mutation: {
           addRepository: async (_parent: unknown, args: AddRepositoryArgs) => {

--- a/packages/graphql-api/test/graphql-api.test.ts
+++ b/packages/graphql-api/test/graphql-api.test.ts
@@ -10,25 +10,35 @@ const repository = {
   localPath: "/repos/acme/widgets.git",
   isBare: true,
   paused: true,
+  issuesReconciledAt: null,
 }
 
-const makeRuntime = () => {
+const makeRuntime = (dbOverrides: Partial<DbServiceShape> = {}) => {
   const db: DbServiceShape = {
     addRepository: () => Effect.succeed(repository),
+    listRepositories: Effect.succeed([repository]),
     storeIssue: () => Effect.die("not used"),
     listIssues: () => Effect.die("not used"),
+    deleteIssue: () => Effect.die("not used"),
+    markIssuesReconciled: () => Effect.die("not used"),
+    ...dbOverrides,
   }
   return ManagedRuntime.make(Layer.succeed(DbService, db))
 }
 
-const graphqlRequest = (origin?: string) =>
+const graphqlRequest = (body: unknown, origin?: string) =>
   new Request("http://127.0.0.1:4200/graphql", {
     method: "POST",
     headers: {
       "content-type": "application/json",
       ...(origin === undefined ? {} : { origin }),
     },
-    body: JSON.stringify({
+    body: JSON.stringify(body),
+  })
+
+const addRepositoryRequest = (origin?: string) =>
+  graphqlRequest(
+    {
       query: `mutation AddRepository($input: AddRepositoryInput!) {
         addRepository(input: $input) { id githubOwner githubRepo }
       }`,
@@ -40,8 +50,9 @@ const graphqlRequest = (origin?: string) =>
           isBare: repository.isBare,
         },
       },
-    }),
-  })
+    },
+    origin,
+  )
 
 describe("GraphQL API", () => {
   let runtime = makeRuntime()
@@ -52,7 +63,9 @@ describe("GraphQL API", () => {
   })
 
   test("serves GraphQL through the supplied runtime", async () => {
-    const response = await createGraphqlApi(runtime).fetch(graphqlRequest())
+    const response = await createGraphqlApi(runtime).fetch(
+      addRepositoryRequest(),
+    )
 
     expect(response).toBeInstanceOf(Response)
     expect(response.status).toBe(200)
@@ -67,9 +80,42 @@ describe("GraphQL API", () => {
     })
   })
 
+  test("lists repositories", async () => {
+    const response = await createGraphqlApi(runtime).fetch(
+      graphqlRequest({
+        query: `query ListRepositories {
+          repositories {
+            id
+            githubOwner
+            githubRepo
+            localPath
+            isBare
+            paused
+          }
+        }`,
+      }),
+    )
+
+    expect(response.status).toBe(200)
+    expect(await response.json()).toEqual({
+      data: {
+        repositories: [
+          {
+            id: repository.id,
+            githubOwner: repository.githubOwner,
+            githubRepo: repository.githubRepo,
+            localPath: repository.localPath,
+            isBare: repository.isBare,
+            paused: repository.paused,
+          },
+        ],
+      },
+    })
+  })
+
   test("accepts same-origin browser requests", async () => {
     const response = await createGraphqlApi(runtime).fetch(
-      graphqlRequest("http://127.0.0.1:4200"),
+      addRepositoryRequest("http://127.0.0.1:4200"),
     )
 
     expect(response.status).toBe(200)
@@ -77,7 +123,7 @@ describe("GraphQL API", () => {
 
   test("rejects cross-origin browser requests", async () => {
     const response = await createGraphqlApi(runtime).fetch(
-      graphqlRequest("https://malicious.example"),
+      addRepositoryRequest("https://malicious.example"),
     )
 
     expect(response.status).toBe(403)

--- a/packages/graphql-client/src/generated/schema.graphql
+++ b/packages/graphql-client/src/generated/schema.graphql
@@ -1,5 +1,6 @@
 type Query {
   health: Boolean!
+  repositories: [Repository!]!
 }
 
 type Repository {

--- a/packages/graphql-client/src/generated/schema.ts
+++ b/packages/graphql-client/src/generated/schema.ts
@@ -11,6 +11,7 @@ export type Scalars = {
 
 export interface Query {
     health: Scalars['Boolean']
+    repositories: Repository[]
     __typename: 'Query'
 }
 
@@ -31,6 +32,7 @@ export interface Mutation {
 
 export interface QueryGenqlSelection{
     health?: boolean | number
+    repositories?: RepositoryGenqlSelection
     __typename?: boolean | number
     __scalar?: boolean | number
 }

--- a/packages/graphql-client/src/generated/types.ts
+++ b/packages/graphql-client/src/generated/types.ts
@@ -9,6 +9,9 @@ export default {
             "health": [
                 1
             ],
+            "repositories": [
+                2
+            ],
             "__typename": [
                 4
             ]

--- a/packages/graphql-schema/schema.graphql
+++ b/packages/graphql-schema/schema.graphql
@@ -1,5 +1,6 @@
 type Query {
   health: Boolean!
+  repositories: [Repository!]!
 }
 
 type Repository {

--- a/packages/issue-reconciler/test/issue-reconciler.spec.ts
+++ b/packages/issue-reconciler/test/issue-reconciler.spec.ts
@@ -76,6 +76,7 @@ const makeDbFixture = (options: DbFixtureOptions) => {
 
   const service: DbServiceShape = {
     addRepository: () => Effect.die("not used"),
+    listRepositories: Effect.die("not used"),
     listIssues: () => {
       actions.push("list")
       return options.listError


### PR DESCRIPTION
## Why

Callers can add a Repository through GraphQL, but there was no way to list configured Repositories. Clients and the harness need a query to read what is already persisted.

## What Changed

- Added `DbService.listRepositories`, returning all repositories ordered by owner then name
- Exposed `Query.repositories: [Repository!]!` with a resolver wired through `DbService`
- Regenerated the GraphQL client and updated fixtures/tests