### PR TITLE
feat: show configured repository cards

### DIFF
--- a/apps/harness/package.json
+++ b/apps/harness/package.json
@@ -14,6 +14,7 @@
     "@ready-for-agent/db": "workspace:*",
     "@ready-for-agent/db-service": "workspace:*",
     "@ready-for-agent/graphql-api": "workspace:*",
+    "@ready-for-agent/graphql-client": "workspace:*",
     "@ready-for-agent/keymaxxer-service": "workspace:*",
     "@tanstack/react-query": "^5.90.0",
     "@tanstack/react-query-devtools": "^5.90.0",

--- a/apps/harness/src/routes/index.tsx
+++ b/apps/harness/src/routes/index.tsx
@@ -1,36 +1,109 @@
-import { useQuery } from "@tanstack/react-query"
+import { useSuspenseQuery } from "@tanstack/react-query"
 import { createFileRoute } from "@tanstack/react-router"
+import { Suspense } from "react"
+import { createClient } from "@ready-for-agent/graphql-client"
+
+const graphql = createClient({ url: "/graphql" })
+
+const repositoriesQuery = {
+  queryKey: ["repositories"],
+  queryFn: async () => {
+    const result = await graphql.query({
+      repositories: {
+        id: true,
+        githubOwner: true,
+        githubRepo: true,
+        localPath: true,
+        isBare: true,
+        paused: true,
+      },
+    })
+    return result.repositories
+  },
+}
 
 export const Route = createFileRoute("/")({
   component: HomePage,
 })
 
 function HomePage() {
-  const healthQuery = useQuery({
-    queryKey: ["health"],
-    queryFn: async () => {
-      await new Promise((resolve) => setTimeout(resolve, 200))
-      return {
-        status: "ok",
-        message: "Harness SPA is ready. GraphQL comes next.",
-      }
-    },
-  })
+  return (
+    <main>
+      <header className="page-header">
+        <p className="eyebrow">Workspace</p>
+        <h1>Configured repositories</h1>
+        <p className="muted">
+          Local GitHub repositories available to Ready for Agent.
+        </p>
+      </header>
+      <Suspense fallback={<RepositoryCardsSkeleton />}>
+        <RepositoryCards />
+      </Suspense>
+    </main>
+  )
+}
+
+function RepositoryCards() {
+  const { data: repositories } = useSuspenseQuery(repositoriesQuery)
+
+  if (repositories.length === 0) {
+    return (
+      <div className="empty-state">
+        <h2>No repositories configured</h2>
+        <p className="muted">Add a repository with the CLI to see it here.</p>
+      </div>
+    )
+  }
 
   return (
-    <div className="card">
-      <h1>Ready for Agent</h1>
-      <p className="muted">TanStack Router + Query SPA harness (no SSR).</p>
-      {healthQuery.isPending ? (
-        <p>Loading…</p>
-      ) : healthQuery.isError ? (
-        <p>Failed to load status.</p>
-      ) : (
-        <p>
-          <strong>{healthQuery.data.status}</strong> —{" "}
-          {healthQuery.data.message}
-        </p>
-      )}
-    </div>
+    <section className="repository-grid" aria-label="Configured repositories">
+      {repositories.map((repository) => (
+        <article className="repository-card" key={repository.id}>
+          <div className="repository-card__topline">
+            <span className="repository-owner">{repository.githubOwner}</span>
+            <span
+              className={`status ${repository.paused ? "status--paused" : "status--active"}`}
+            >
+              {repository.paused ? "Paused" : "Active"}
+            </span>
+          </div>
+          <h2>
+            <a
+              href={`https://github.com/${repository.githubOwner}/${repository.githubRepo}`}
+            >
+              {repository.githubRepo}
+            </a>
+          </h2>
+          <dl className="repository-details">
+            <div>
+              <dt>Local path</dt>
+              <dd title={repository.localPath}>{repository.localPath}</dd>
+            </div>
+            <div>
+              <dt>Checkout</dt>
+              <dd>{repository.isBare ? "Bare repository" : "Working tree"}</dd>
+            </div>
+          </dl>
+        </article>
+      ))}
+    </section>
+  )
+}
+
+function RepositoryCardsSkeleton() {
+  return (
+    <section
+      className="repository-grid"
+      aria-label="Loading repositories"
+      aria-busy="true"
+    >
+      {[0, 1, 2].map((item) => (
+        <div className="repository-card repository-card--loading" key={item}>
+          <span className="skeleton skeleton--short" />
+          <span className="skeleton skeleton--title" />
+          <span className="skeleton skeleton--line" />
+        </div>
+      ))}
+    </section>
   )
 }

--- a/apps/harness/src/styles.css
+++ b/apps/harness/src/styles.css
@@ -36,7 +36,7 @@ a:hover {
 }
 
 .shell {
-  max-width: 56rem;
+  max-width: 72rem;
   margin: 0 auto;
   padding: 1.5rem;
 }
@@ -69,4 +69,180 @@ a:hover {
 
 .muted {
   color: #64748b;
+}
+
+.page-header {
+  margin: 3.5rem 0 2rem;
+}
+
+.page-header h1 {
+  margin: 0.15rem 0 0.5rem;
+  font-size: clamp(2rem, 5vw, 3.5rem);
+  line-height: 1.05;
+  letter-spacing: -0.045em;
+}
+
+.page-header p {
+  margin: 0;
+}
+
+.eyebrow {
+  color: #2563eb;
+  font-size: 0.75rem;
+  font-weight: 800;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.repository-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(min(100%, 19rem), 1fr));
+  gap: 1rem;
+}
+
+.repository-card {
+  min-width: 0;
+  padding: 1.35rem;
+  background: #fff;
+  border: 1px solid #dbe3ef;
+  border-radius: 0.9rem;
+  box-shadow: 0 10px 30px rgb(15 23 42 / 5%);
+}
+
+.repository-card__topline {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.repository-owner {
+  overflow: hidden;
+  color: #64748b;
+  font-size: 0.85rem;
+  font-weight: 650;
+  text-overflow: ellipsis;
+}
+
+.repository-card h2 {
+  margin: 0.2rem 0 1.4rem;
+  overflow-wrap: anywhere;
+  font-size: 1.5rem;
+  letter-spacing: -0.025em;
+}
+
+.repository-card h2 a {
+  color: #0f172a;
+}
+
+.status {
+  flex: none;
+  padding: 0.2rem 0.55rem;
+  border-radius: 999px;
+  font-size: 0.7rem;
+  font-weight: 750;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.status--active {
+  color: #166534;
+  background: #dcfce7;
+}
+
+.status--paused {
+  color: #92400e;
+  background: #fef3c7;
+}
+
+.repository-details {
+  display: grid;
+  gap: 0.8rem;
+  margin: 0;
+}
+
+.repository-details div {
+  min-width: 0;
+}
+
+.repository-details dt {
+  color: #94a3b8;
+  font-size: 0.68rem;
+  font-weight: 750;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.repository-details dd {
+  margin: 0.15rem 0 0;
+  overflow: hidden;
+  color: #334155;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: 0.82rem;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.empty-state {
+  padding: 3rem 1.5rem;
+  border: 1px dashed #cbd5e1;
+  border-radius: 0.9rem;
+  text-align: center;
+}
+
+.empty-state h2,
+.empty-state p {
+  margin: 0;
+}
+
+.empty-state p {
+  margin-top: 0.35rem;
+}
+
+.repository-card--loading {
+  display: grid;
+  gap: 1rem;
+}
+
+.skeleton {
+  display: block;
+  height: 0.85rem;
+  border-radius: 0.3rem;
+  background: #e8edf4;
+  animation: pulse 1.3s ease-in-out infinite alternate;
+}
+
+.skeleton--short {
+  width: 35%;
+}
+
+.skeleton--title {
+  width: 65%;
+  height: 1.6rem;
+}
+
+.skeleton--line {
+  width: 90%;
+}
+
+@keyframes pulse {
+  to {
+    opacity: 0.45;
+  }
+}
+
+@media (max-width: 40rem) {
+  .shell {
+    padding: 1rem;
+  }
+
+  .page-header {
+    margin-top: 2.5rem;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .skeleton {
+    animation: none;
+  }
 }

--- a/apps/harness/tsconfig.app.json
+++ b/apps/harness/tsconfig.app.json
@@ -20,6 +20,9 @@
       "path": "../../packages/keymaxxer-service/tsconfig.lib.json"
     },
     {
+      "path": "../../packages/graphql-client/tsconfig.lib.json"
+    },
+    {
       "path": "../../packages/graphql-api/tsconfig.lib.json"
     },
     {

--- a/bun.lock
+++ b/bun.lock
@@ -41,6 +41,7 @@
         "@ready-for-agent/db": "workspace:*",
         "@ready-for-agent/db-service": "workspace:*",
         "@ready-for-agent/graphql-api": "workspace:*",
+        "@ready-for-agent/graphql-client": "workspace:*",
         "@ready-for-agent/keymaxxer-service": "workspace:*",
         "@tanstack/react-query": "^5.90.0",
         "@tanstack/react-query-devtools": "^5.90.0",


### PR DESCRIPTION
## Why

Configured repositories are currently only visible through the API and CLI. The harness home page should make the available workspace repositories immediately visible while preserving a responsive loading experience.

## What Changed

- query configured repositories through the generated GraphQL client
- render responsive repository cards with status, local path, checkout type, and GitHub links
- wrap the Suspense query in a loading-skeleton boundary and provide an empty state

## Verification

Loaded the app with two configured repositories and confirmed both cards render from the GraphQL response. At a 390px viewport, both cards remain visible without horizontal overflow.
