### PR TITLE
feat: refresh repositories through GraphQL

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+**/generated/** whitespace=-trailing-space

--- a/apps/harness/package.json
+++ b/apps/harness/package.json
@@ -13,8 +13,10 @@
   "dependencies": {
     "@ready-for-agent/db": "workspace:*",
     "@ready-for-agent/db-service": "workspace:*",
+    "@ready-for-agent/github-service": "workspace:*",
     "@ready-for-agent/graphql-api": "workspace:*",
     "@ready-for-agent/graphql-client": "workspace:*",
+    "@ready-for-agent/issue-reconciler": "workspace:*",
     "@ready-for-agent/keymaxxer-service": "workspace:*",
     "@tanstack/react-query": "^5.90.0",
     "@tanstack/react-query-devtools": "^5.90.0",

--- a/apps/harness/src/server/application.server.ts
+++ b/apps/harness/src/server/application.server.ts
@@ -2,7 +2,9 @@ import "@tanstack/react-start/server-only"
 import { Effect, Layer, ManagedRuntime } from "effect"
 import { DatabaseLive } from "@ready-for-agent/db"
 import { DbServiceLive } from "@ready-for-agent/db-service"
+import { GitHubServiceLive } from "@ready-for-agent/github-service"
 import { createGraphqlApi } from "@ready-for-agent/graphql-api"
+import { IssueReconcilerLive } from "@ready-for-agent/issue-reconciler"
 import {
   KeymaxxerService,
   mcpKeymaxxerLayer,
@@ -27,8 +29,13 @@ export interface Application {
 export const createApplication = async (
   environment: Partial<Record<string, string | undefined>> = process.env,
 ): Promise<Application> => {
+  const databaseLayer = DbServiceLive.pipe(Layer.provideMerge(DatabaseLive))
+  const reconcilerLayer = IssueReconcilerLive.pipe(
+    Layer.provideMerge(databaseLayer),
+    Layer.provideMerge(GitHubServiceLive),
+  )
   const appLayer = Layer.merge(
-    DbServiceLive.pipe(Layer.provideMerge(DatabaseLive)),
+    reconcilerLayer,
     keymaxxerLayerFromEnvironment(environment),
   )
   const runtime = ManagedRuntime.make(appLayer)

--- a/apps/harness/tsconfig.app.json
+++ b/apps/harness/tsconfig.app.json
@@ -26,6 +26,12 @@
       "path": "../../packages/graphql-api/tsconfig.lib.json"
     },
     {
+      "path": "../../packages/github-service/tsconfig.lib.json"
+    },
+    {
+      "path": "../../packages/issue-reconciler/tsconfig.lib.json"
+    },
+    {
       "path": "../../packages/db-service/tsconfig.lib.json"
     },
     {

--- a/bun.lock
+++ b/bun.lock
@@ -40,8 +40,10 @@
       "dependencies": {
         "@ready-for-agent/db": "workspace:*",
         "@ready-for-agent/db-service": "workspace:*",
+        "@ready-for-agent/github-service": "workspace:*",
         "@ready-for-agent/graphql-api": "workspace:*",
         "@ready-for-agent/graphql-client": "workspace:*",
+        "@ready-for-agent/issue-reconciler": "workspace:*",
         "@ready-for-agent/keymaxxer-service": "workspace:*",
         "@tanstack/react-query": "^5.90.0",
         "@tanstack/react-query-devtools": "^5.90.0",
@@ -130,7 +132,9 @@
       "version": "0.0.1",
       "dependencies": {
         "@ready-for-agent/db-service": "workspace:*",
+        "@ready-for-agent/github-service": "workspace:*",
         "@ready-for-agent/graphql-schema": "workspace:*",
+        "@ready-for-agent/issue-reconciler": "workspace:*",
         "effect": "^4.0.0-beta.97",
         "graphql": "^16.11.0",
         "graphql-yoga": "^5.13.0",

--- a/docs/adr/0004-development-keymaxxer-sidecar.md
+++ b/docs/adr/0004-development-keymaxxer-sidecar.md
@@ -2,6 +2,8 @@
 
 Ready for Agent uses a shared backend Keymaxxer Service that never exposes raw secret values. During `harness:dev`, the separate `apps/keymaxxer-sidecar` application owns the long-lived Keymaxxer MCP session so TanStack server reloads do not repeat vault-unlock or secret-use approval prompts; production creates the MCP client in-process and does not run a sidecar.
 
+Keymaxxer is responsible for launching or provisioning application processes with named secrets injected into their environment. It is not a dependency of GitHub domain operations: `GitHubService` obtains `GITHUB_TOKEN` through Effect `Config`, and the GraphQL API invokes the Issue Reconciler without accepting a token argument. This keeps credential delivery at the application boundary instead of coupling GitHub requests or GraphQL resolvers to Keymaxxer.
+
 The sidecar is a development tool attached specifically to `harness:dev` and is restricted to loopback communication. Remote sidecar URLs and remote authentication are deliberately unsupported because the service can execute commands with injected secrets and there is no remote-use requirement.
 
 Because loopback alone does not prevent requests from malicious webpages, operation endpoints reject requests with an `Origin` header and require `application/json`. This causes browser JSON requests to require a CORS preflight, which the sidecar does not permit.

--- a/packages/graphql-api/package.json
+++ b/packages/graphql-api/package.json
@@ -17,7 +17,9 @@
   },
   "dependencies": {
     "@ready-for-agent/db-service": "workspace:*",
+    "@ready-for-agent/github-service": "workspace:*",
     "@ready-for-agent/graphql-schema": "workspace:*",
+    "@ready-for-agent/issue-reconciler": "workspace:*",
     "effect": "^4.0.0-beta.97",
     "graphql": "^16.11.0",
     "graphql-yoga": "^5.13.0",

--- a/packages/graphql-api/src/lib/graphql-api.ts
+++ b/packages/graphql-api/src/lib/graphql-api.ts
@@ -7,8 +7,17 @@ import {
   InvalidRepositoryInputError,
   LocalPathInUseError,
   RepositoryAlreadyExistsError,
+  RepositoryNotFoundError,
 } from "@ready-for-agent/db-service"
+import {
+  GitHubRepositoryUnavailableError,
+  GitHubRequestError,
+} from "@ready-for-agent/github-service"
 import { typeDefs } from "@ready-for-agent/graphql-schema"
+import {
+  IssueReconciler,
+  ReconciliationMutationError,
+} from "@ready-for-agent/issue-reconciler"
 
 type AddRepositoryArgs = {
   input: {
@@ -19,7 +28,14 @@ type AddRepositoryArgs = {
   }
 }
 
-export type GraphqlRuntime = ManagedRuntime.ManagedRuntime<DbService, unknown>
+type RefreshRepositoryArgs = {
+  repositoryId: string
+}
+
+export type GraphqlRuntime = ManagedRuntime.ManagedRuntime<
+  DbService | IssueReconciler,
+  unknown
+>
 
 const toGraphQLError = (error: unknown): GraphQLError => {
   if (error instanceof RepositoryAlreadyExistsError) {
@@ -39,6 +55,37 @@ const toGraphQLError = (error: unknown): GraphQLError => {
     return new GraphQLError(error.message, {
       extensions: { code: "INVALID_REPOSITORY_INPUT", field: error.field },
     })
+  }
+  if (error instanceof RepositoryNotFoundError) {
+    return new GraphQLError(`Repository not found: ${error.repositoryId}`, {
+      extensions: { code: "REPOSITORY_NOT_FOUND" },
+    })
+  }
+  if (error instanceof GitHubRepositoryUnavailableError) {
+    return new GraphQLError(
+      `GitHub repository is unavailable: ${error.owner}/${error.name}`,
+      { extensions: { code: "GITHUB_REPOSITORY_UNAVAILABLE" } },
+    )
+  }
+  if (error instanceof GitHubRequestError) {
+    return new GraphQLError(error.message, {
+      extensions: { code: "GITHUB_REQUEST_ERROR" },
+    })
+  }
+  if (error instanceof ReconciliationMutationError) {
+    return new GraphQLError(
+      `Failed to ${error.operation} while refreshing repository`,
+      {
+        extensions: {
+          code: "REPOSITORY_REFRESH_FAILED",
+          operation: error.operation,
+          ...(error.githubIssueNumber === undefined
+            ? {}
+            : { githubIssueNumber: error.githubIssueNumber }),
+          progress: error.progress,
+        },
+      },
+    )
   }
   if (error instanceof DatabaseError) {
     return new GraphQLError(error.message, {
@@ -103,6 +150,34 @@ export const createGraphqlApi = (runtime: GraphqlRuntime) => {
                 Effect.gen(function* () {
                   const db = yield* DbService
                   return yield* db.addRepository(args.input)
+                }),
+              ),
+            )
+            if (Result.isFailure(result)) {
+              throw toGraphQLError(result.failure)
+            }
+            return result.success
+          },
+          refreshRepository: async (
+            _parent: unknown,
+            args: RefreshRepositoryArgs,
+          ) => {
+            const result = await runtime.runPromise(
+              Effect.result(
+                Effect.gen(function* () {
+                  const db = yield* DbService
+                  const repositories = yield* db.listRepositories
+                  const repository = repositories.find(
+                    ({ id }) => id === args.repositoryId,
+                  )
+                  if (repository === undefined) {
+                    return yield* new RepositoryNotFoundError({
+                      repositoryId: args.repositoryId,
+                    })
+                  }
+
+                  const reconciler = yield* IssueReconciler
+                  return yield* reconciler.reconcile(repository)
                 }),
               ),
             )

--- a/packages/graphql-api/test/graphql-api.test.ts
+++ b/packages/graphql-api/test/graphql-api.test.ts
@@ -1,5 +1,9 @@
 import { Effect, Layer, ManagedRuntime } from "effect"
 import { DbService, type DbServiceShape } from "@ready-for-agent/db-service"
+import {
+  IssueReconciler,
+  type IssueReconcilerShape,
+} from "@ready-for-agent/issue-reconciler"
 import { createGraphqlApi } from "../src/index.js"
 import { afterEach, describe, expect, test } from "bun:test"
 
@@ -13,7 +17,10 @@ const repository = {
   issuesReconciledAt: null,
 }
 
-const makeRuntime = (dbOverrides: Partial<DbServiceShape> = {}) => {
+const makeRuntime = (
+  dbOverrides: Partial<DbServiceShape> = {},
+  reconcilerOverrides: Partial<IssueReconcilerShape> = {},
+) => {
   const db: DbServiceShape = {
     addRepository: () => Effect.succeed(repository),
     listRepositories: Effect.succeed([repository]),
@@ -23,7 +30,16 @@ const makeRuntime = (dbOverrides: Partial<DbServiceShape> = {}) => {
     markIssuesReconciled: () => Effect.die("not used"),
     ...dbOverrides,
   }
-  return ManagedRuntime.make(Layer.succeed(DbService, db))
+  const reconciler: IssueReconcilerShape = {
+    reconcile: () => Effect.die("not used"),
+    ...reconcilerOverrides,
+  }
+  return ManagedRuntime.make(
+    Layer.merge(
+      Layer.succeed(DbService, db),
+      Layer.succeed(IssueReconciler, reconciler),
+    ),
+  )
 }
 
 const graphqlRequest = (body: unknown, origin?: string) =>
@@ -111,6 +127,86 @@ describe("GraphQL API", () => {
         ],
       },
     })
+  })
+
+  test("refreshes a repository through the reconciler", async () => {
+    let reconciledRepository: typeof repository | undefined
+    await runtime.dispose()
+    runtime = makeRuntime(
+      {},
+      {
+        reconcile: (selectedRepository) => {
+          reconciledRepository = selectedRepository
+          return Effect.succeed({
+            fetched: 1,
+            inserted: 1,
+            updated: 0,
+            deleted: 0,
+            unchanged: 0,
+          })
+        },
+      },
+    )
+
+    const response = await createGraphqlApi(runtime).fetch(
+      graphqlRequest({
+        query: `mutation RefreshRepository($repositoryId: ID!) {
+          refreshRepository(repositoryId: $repositoryId) {
+            fetched inserted updated deleted unchanged
+          }
+        }`,
+        variables: {
+          repositoryId: repository.id,
+        },
+      }),
+    )
+
+    expect(response.status).toBe(200)
+    expect(await response.json()).toEqual({
+      data: {
+        refreshRepository: {
+          fetched: 1,
+          inserted: 1,
+          updated: 0,
+          deleted: 0,
+          unchanged: 0,
+        },
+      },
+    })
+    expect(reconciledRepository).toEqual(repository)
+  })
+
+  test("reports an unknown repository without calling the reconciler", async () => {
+    let reconcilerCalled = false
+    await runtime.dispose()
+    runtime = makeRuntime(
+      {},
+      {
+        reconcile: () => {
+          reconcilerCalled = true
+          return Effect.die("not used")
+        },
+      },
+    )
+    const response = await createGraphqlApi(runtime).fetch(
+      graphqlRequest({
+        query: `mutation {
+          refreshRepository(repositoryId: "missing") { fetched }
+        }`,
+      }),
+    )
+
+    expect(response.status).toBe(200)
+    expect(await response.json()).toEqual({
+      data: null,
+      errors: [
+        expect.objectContaining({
+          message: "Repository not found: missing",
+          extensions: { code: "REPOSITORY_NOT_FOUND" },
+        }),
+      ],
+    })
+    expect(reconcilerCalled).toBe(false)
   })
 
   test("accepts same-origin browser requests", async () => {

--- a/packages/graphql-api/tsconfig.lib.json
+++ b/packages/graphql-api/tsconfig.lib.json
@@ -15,6 +15,12 @@
     },
     {
       "path": "../graphql-schema/tsconfig.lib.json"
+    },
+    {
+      "path": "../github-service/tsconfig.lib.json"
+    },
+    {
+      "path": "../issue-reconciler/tsconfig.lib.json"
     }
   ]
 }

--- a/packages/graphql-client/src/generated/schema.graphql
+++ b/packages/graphql-client/src/generated/schema.graphql
@@ -12,6 +12,14 @@ type Repository {
   paused: Boolean!
 }
 
+type RepositoryRefresh {
+  fetched: Int!
+  inserted: Int!
+  updated: Int!
+  deleted: Int!
+  unchanged: Int!
+}
+
 input AddRepositoryInput {
   githubOwner: String!
   githubRepo: String!
@@ -21,4 +29,5 @@ input AddRepositoryInput {
 
 type Mutation {
   addRepository(input: AddRepositoryInput!): Repository!
+  refreshRepository(repositoryId: ID!): RepositoryRefresh!
 }

--- a/packages/graphql-client/src/generated/schema.ts
+++ b/packages/graphql-client/src/generated/schema.ts
@@ -7,6 +7,7 @@ export type Scalars = {
     Boolean: boolean,
     ID: string,
     String: string,
+    Int: number,
 }
 
 export interface Query {
@@ -25,8 +26,18 @@ export interface Repository {
     __typename: 'Repository'
 }
 
+export interface RepositoryRefresh {
+    fetched: Scalars['Int']
+    inserted: Scalars['Int']
+    updated: Scalars['Int']
+    deleted: Scalars['Int']
+    unchanged: Scalars['Int']
+    __typename: 'RepositoryRefresh'
+}
+
 export interface Mutation {
     addRepository: Repository
+    refreshRepository: RepositoryRefresh
     __typename: 'Mutation'
 }
 
@@ -48,10 +59,21 @@ export interface RepositoryGenqlSelection{
     __scalar?: boolean | number
 }
 
+export interface RepositoryRefreshGenqlSelection{
+    fetched?: boolean | number
+    inserted?: boolean | number
+    updated?: boolean | number
+    deleted?: boolean | number
+    unchanged?: boolean | number
+    __typename?: boolean | number
+    __scalar?: boolean | number
+}
+
 export interface AddRepositoryInput {githubOwner: Scalars['String'],githubRepo: Scalars['String'],localPath: Scalars['String'],isBare: Scalars['Boolean']}
 
 export interface MutationGenqlSelection{
     addRepository?: (RepositoryGenqlSelection & { __args: {input: AddRepositoryInput} })
+    refreshRepository?: (RepositoryRefreshGenqlSelection & { __args: {repositoryId: Scalars['ID']} })
     __typename?: boolean | number
     __scalar?: boolean | number
 }
@@ -69,6 +91,14 @@ export interface MutationGenqlSelection{
     export const isRepository = (obj?: { __typename?: any } | null): obj is Repository => {
       if (!obj?.__typename) throw new Error('__typename is missing in "isRepository"')
       return Repository_possibleTypes.includes(obj.__typename)
+    }
+    
+
+
+    const RepositoryRefresh_possibleTypes: string[] = ['RepositoryRefresh']
+    export const isRepositoryRefresh = (obj?: { __typename?: any } | null): obj is RepositoryRefresh => {
+      if (!obj?.__typename) throw new Error('__typename is missing in "isRepositoryRefresh"')
+      return RepositoryRefresh_possibleTypes.includes(obj.__typename)
     }
     
 

--- a/packages/graphql-client/src/generated/types.ts
+++ b/packages/graphql-client/src/generated/types.ts
@@ -2,7 +2,8 @@ export default {
     "scalars": [
         1,
         3,
-        4
+        4,
+        6
     ],
     "types": {
         "Query": {
@@ -42,6 +43,27 @@ export default {
         },
         "ID": {},
         "String": {},
+        "RepositoryRefresh": {
+            "fetched": [
+                6
+            ],
+            "inserted": [
+                6
+            ],
+            "updated": [
+                6
+            ],
+            "deleted": [
+                6
+            ],
+            "unchanged": [
+                6
+            ],
+            "__typename": [
+                4
+            ]
+        },
+        "Int": {},
         "AddRepositoryInput": {
             "githubOwner": [
                 4
@@ -64,8 +86,17 @@ export default {
                 2,
                 {
                     "input": [
-                        5,
+                        7,
                         "AddRepositoryInput!"
+                    ]
+                }
+            ],
+            "refreshRepository": [
+                5,
+                {
+                    "repositoryId": [
+                        3,
+                        "ID!"
                     ]
                 }
             ],

--- a/packages/graphql-schema/schema.graphql
+++ b/packages/graphql-schema/schema.graphql
@@ -12,6 +12,14 @@ type Repository {
   paused: Boolean!
 }
 
+type RepositoryRefresh {
+  fetched: Int!
+  inserted: Int!
+  updated: Int!
+  deleted: Int!
+  unchanged: Int!
+}
+
 input AddRepositoryInput {
   githubOwner: String!
   githubRepo: String!
@@ -21,4 +29,5 @@ input AddRepositoryInput {
 
 type Mutation {
   addRepository(input: AddRepositoryInput!): Repository!
+  refreshRepository(repositoryId: ID!): RepositoryRefresh!
 }


### PR DESCRIPTION
## Why

Configured repositories need an explicit API operation that refreshes their local Issue store from GitHub through the existing Issue Reconciler. Credential delivery must remain at the application boundary: `GitHubService` reads `GITHUB_TOKEN` through Effect `Config`, while GraphQL does not accept or expose the token and GitHub domain operations do not depend on Keymaxxer.

## What Changed

- add `refreshRepository(repositoryId: ID!): RepositoryRefresh!` and return reconciliation counts
- resolve the configured Repository, invoke `IssueReconciler`, and expose stable GraphQL error codes
- compose the Config-backed GitHub service and Issue Reconciler into the Harness runtime
- regenerate the typed GraphQL client and cover successful and unknown-Repository mutations
- document the Keymaxxer/Effect Config boundary in the development sidecar ADR
- exempt generated sources from Git trailing-whitespace checks while retaining type checking

## Verification

Invoked the mutation against the configured `processfocus/monorepo` Repository using a Keymaxxer-injected `GITHUB_TOKEN`. GitHub returned 49 Ready-labeled Issues and the second reconciliation reported 49 unchanged Issues with no inserts, updates, or deletions.
