### PR TITLE
fix: request GitHub credentials on demand

### DIFF
--- a/apps/harness/src/server/application.server.ts
+++ b/apps/harness/src/server/application.server.ts
@@ -1,8 +1,8 @@
 import "@tanstack/react-start/server-only"
+import { fileURLToPath } from "node:url"
 import { Effect, Layer, ManagedRuntime } from "effect"
 import { DatabaseLive } from "@ready-for-agent/db"
 import { DbServiceLive } from "@ready-for-agent/db-service"
-import { GitHubServiceLive } from "@ready-for-agent/github-service"
 import { createGraphqlApi } from "@ready-for-agent/graphql-api"
 import { IssueReconcilerLive } from "@ready-for-agent/issue-reconciler"
 import {
@@ -11,6 +11,9 @@ import {
   sidecarKeymaxxerLayer,
 } from "@ready-for-agent/keymaxxer-service"
 import type { ApplicationRequestContext } from "../server-context.js"
+import { keymaxxerGitHubLayer } from "./keymaxxer-github-layer.js"
+
+const workspaceRoot = fileURLToPath(new URL("../../../..", import.meta.url))
 
 const keymaxxerLayerFromEnvironment = (
   environment: Partial<Record<string, string | undefined>>,
@@ -30,14 +33,15 @@ export const createApplication = async (
   environment: Partial<Record<string, string | undefined>> = process.env,
 ): Promise<Application> => {
   const databaseLayer = DbServiceLive.pipe(Layer.provideMerge(DatabaseLive))
+  const keymaxxerLayer = keymaxxerLayerFromEnvironment(environment)
+  const githubLayer = keymaxxerGitHubLayer({ workspaceRoot }).pipe(
+    Layer.provide(keymaxxerLayer),
+  )
   const reconcilerLayer = IssueReconcilerLive.pipe(
     Layer.provideMerge(databaseLayer),
-    Layer.provideMerge(GitHubServiceLive),
+    Layer.provideMerge(githubLayer),
   )
-  const appLayer = Layer.merge(
-    reconcilerLayer,
-    keymaxxerLayerFromEnvironment(environment),
-  )
+  const appLayer = Layer.merge(reconcilerLayer, keymaxxerLayer)
   const runtime = ManagedRuntime.make(appLayer)
 
   try {

--- a/apps/harness/src/server/keymaxxer-github-layer.ts
+++ b/apps/harness/src/server/keymaxxer-github-layer.ts
@@ -1,0 +1,115 @@
+import { Effect, Layer, Schema } from "effect"
+import {
+  GitHubRepositoryUnavailableError,
+  GitHubRequestError,
+  GitHubService,
+  type GitHubServiceShape,
+  type ReadyLabeledIssue,
+} from "@ready-for-agent/github-service"
+import { KeymaxxerService } from "@ready-for-agent/keymaxxer-service"
+
+const githubTokenName = "GITHUB_TOKEN"
+
+const SerializedIssue = Schema.Struct({
+  number: Schema.Finite,
+  title: Schema.String,
+  body: Schema.String,
+  url: Schema.String,
+  createdAt: Schema.String,
+  state: Schema.Literals(["OPEN", "CLOSED"]),
+})
+
+const SerializedIssues = Schema.Array(SerializedIssue)
+
+const requestError = (repository: { owner: string; name: string }) =>
+  new GitHubRequestError({
+    message: `Failed to list Ready-labeled Issues for ${repository.owner}/${repository.name}`,
+  })
+
+const encodeArgument = (value: string) =>
+  Buffer.from(value, "utf8").toString("base64url")
+
+const parseIssues = (
+  stdout: string,
+  repository: { owner: string; name: string },
+): Effect.Effect<readonly ReadyLabeledIssue[], GitHubRequestError> =>
+  Effect.try({
+    try: () => JSON.parse(stdout) as unknown,
+    catch: () => requestError(repository),
+  }).pipe(
+    Effect.flatMap((value) =>
+      Schema.decodeUnknownEffect(SerializedIssues)(value).pipe(
+        Effect.mapError(() => requestError(repository)),
+      ),
+    ),
+    Effect.flatMap((issues) =>
+      Effect.try({
+        try: () =>
+          issues.map((issue) => {
+            if (!Number.isSafeInteger(issue.number) || issue.number <= 0) {
+              throw new Error("Invalid Issue number")
+            }
+            if (issue.title.trim() === "") {
+              throw new Error("Invalid Issue title")
+            }
+            const createdAt = new Date(issue.createdAt)
+            if (Number.isNaN(createdAt.getTime())) {
+              throw new Error("Invalid Issue creation time")
+            }
+            new URL(issue.url)
+            return { ...issue, createdAt }
+          }),
+        catch: () => requestError(repository),
+      }),
+    ),
+  )
+
+export const keymaxxerGitHubLayer = (options: {
+  readonly workspaceRoot: string
+}): Layer.Layer<GitHubService, never, KeymaxxerService> =>
+  Layer.effect(
+    GitHubService,
+    Effect.gen(function* () {
+      const keymaxxer = yield* KeymaxxerService
+
+      const service: GitHubServiceShape = {
+        listReadyIssues: (repository) =>
+          Effect.gen(function* () {
+            const hasToken = yield* keymaxxer.hasSecret(githubTokenName)
+            if (!hasToken) {
+              const added = yield* keymaxxer.addSecret({
+                name: githubTokenName,
+                provider: "github",
+                description:
+                  "GitHub token used to refresh configured Repositories",
+                tags: "ready-for-agent,harness,github",
+              })
+              if (!added) return yield* requestError(repository)
+            }
+
+            const owner = encodeArgument(repository.owner)
+            const name = encodeArgument(repository.name)
+            const result = yield* keymaxxer.runWithSecrets({
+              command: `bun --conditions @ready-for-agent/source packages/github-service/src/bin/list-ready-issues.ts ${owner} ${name}`,
+              cwd: options.workspaceRoot,
+              secrets: [githubTokenName],
+              timeoutMs: 60_000,
+            })
+
+            if (result.exitCode === 2) {
+              return yield* new GitHubRepositoryUnavailableError(repository)
+            }
+            if (result.exitCode !== 0) {
+              return yield* requestError(repository)
+            }
+            return yield* parseIssues(result.stdout, repository)
+          }).pipe(
+            Effect.catchTag("KeymaxxerError", () =>
+              Effect.fail(requestError(repository)),
+            ),
+          ),
+      }
+
+      return service
+    }),
+  )

--- a/apps/harness/src/server/keymaxxer-github-layer.ts
+++ b/apps/harness/src/server/keymaxxer-github-layer.ts
@@ -1,4 +1,4 @@
-import { Effect, Layer, Schema } from "effect"
+import { Effect, Layer, Schema, Semaphore } from "effect"
 import {
   GitHubRepositoryUnavailableError,
   GitHubRequestError,
@@ -71,21 +71,24 @@ export const keymaxxerGitHubLayer = (options: {
     GitHubService,
     Effect.gen(function* () {
       const keymaxxer = yield* KeymaxxerService
+      const tokenProvisioning = yield* Semaphore.make(1)
+      const ensureToken = tokenProvisioning.withPermits(1)(
+        Effect.gen(function* () {
+          if (yield* keymaxxer.hasSecret(githubTokenName)) return true
+
+          return yield* keymaxxer.addSecret({
+            name: githubTokenName,
+            provider: "github",
+            description: "GitHub token used to refresh configured Repositories",
+            tags: "ready-for-agent,harness,github",
+          })
+        }),
+      )
 
       const service: GitHubServiceShape = {
         listReadyIssues: (repository) =>
           Effect.gen(function* () {
-            const hasToken = yield* keymaxxer.hasSecret(githubTokenName)
-            if (!hasToken) {
-              const added = yield* keymaxxer.addSecret({
-                name: githubTokenName,
-                provider: "github",
-                description:
-                  "GitHub token used to refresh configured Repositories",
-                tags: "ready-for-agent,harness,github",
-              })
-              if (!added) return yield* requestError(repository)
-            }
+            if (!(yield* ensureToken)) return yield* requestError(repository)
 
             const owner = encodeArgument(repository.owner)
             const name = encodeArgument(repository.name)

--- a/apps/harness/test/keymaxxer-github-layer.test.ts
+++ b/apps/harness/test/keymaxxer-github-layer.test.ts
@@ -1,0 +1,74 @@
+import { Effect, Layer } from "effect"
+import { GitHubService } from "@ready-for-agent/github-service"
+import {
+  KeymaxxerService,
+  type RunWithSecretsInput,
+} from "@ready-for-agent/keymaxxer-service"
+import { keymaxxerGitHubLayer } from "../src/server/keymaxxer-github-layer.js"
+import { describe, expect, test } from "bun:test"
+
+describe("Keymaxxer-backed GitHub layer", () => {
+  test("obtains GITHUB_TOKEN through Keymaxxer for every GitHub query", async () => {
+    const runs: RunWithSecretsInput[] = []
+    let tokenChecks = 0
+    let tokenPresent = false
+    let tokenAdds = 0
+    const keymaxxerLayer = Layer.succeed(KeymaxxerService, {
+      initialize: Effect.void,
+      hasSecret: () =>
+        Effect.sync(() => {
+          tokenChecks += 1
+          return tokenPresent
+        }),
+      addSecret: () =>
+        Effect.sync(() => {
+          tokenAdds += 1
+          tokenPresent = true
+          return true
+        }),
+      runWithSecrets: (input) => {
+        runs.push(input)
+        return Effect.succeed({
+          exitCode: 0,
+          stdout: JSON.stringify([
+            {
+              number: 7,
+              title: "Ready issue",
+              body: "Issue body",
+              url: "https://github.com/acme/widgets/issues/7",
+              createdAt: "2026-07-07T12:00:00.000Z",
+              state: "OPEN",
+            },
+          ]),
+          stderr: "",
+        })
+      },
+    })
+    const layer = keymaxxerGitHubLayer({
+      workspaceRoot: "/workspace",
+    }).pipe(Layer.provide(keymaxxerLayer))
+
+    const results = await Effect.runPromise(
+      Effect.gen(function* () {
+        const github = yield* GitHubService
+        return [
+          yield* github.listReadyIssues({ owner: "acme", name: "widgets" }),
+          yield* github.listReadyIssues({ owner: "acme", name: "widgets" }),
+        ]
+      }).pipe(Effect.provide(layer)),
+    )
+
+    expect(results[0]?.[0]?.createdAt).toEqual(
+      new Date("2026-07-07T12:00:00.000Z"),
+    )
+    expect(runs).toHaveLength(2)
+    expect(tokenChecks).toBe(2)
+    expect(tokenAdds).toBe(1)
+    expect(runs.map(({ secrets }) => secrets)).toEqual([
+      ["GITHUB_TOKEN"],
+      ["GITHUB_TOKEN"],
+    ])
+    expect(runs[0]?.command).toContain("list-ready-issues.ts")
+    expect(runs[0]?.command).not.toContain("Ready issue")
+  })
+})

--- a/apps/harness/test/keymaxxer-github-layer.test.ts
+++ b/apps/harness/test/keymaxxer-github-layer.test.ts
@@ -21,11 +21,13 @@ describe("Keymaxxer-backed GitHub layer", () => {
           return tokenPresent
         }),
       addSecret: () =>
-        Effect.sync(() => {
-          tokenAdds += 1
-          tokenPresent = true
-          return true
-        }),
+        Effect.sleep("10 millis").pipe(
+          Effect.map(() => {
+            tokenAdds += 1
+            tokenPresent = true
+            return true
+          }),
+        ),
       runWithSecrets: (input) => {
         runs.push(input)
         return Effect.succeed({
@@ -51,10 +53,13 @@ describe("Keymaxxer-backed GitHub layer", () => {
     const results = await Effect.runPromise(
       Effect.gen(function* () {
         const github = yield* GitHubService
-        return [
-          yield* github.listReadyIssues({ owner: "acme", name: "widgets" }),
-          yield* github.listReadyIssues({ owner: "acme", name: "widgets" }),
-        ]
+        return yield* Effect.all(
+          [
+            github.listReadyIssues({ owner: "acme", name: "widgets" }),
+            github.listReadyIssues({ owner: "acme", name: "widgets" }),
+          ],
+          { concurrency: "unbounded" },
+        )
       }).pipe(Effect.provide(layer)),
     )
 

--- a/docs/adr/0004-development-keymaxxer-sidecar.md
+++ b/docs/adr/0004-development-keymaxxer-sidecar.md
@@ -2,7 +2,7 @@
 
 Ready for Agent uses a shared backend Keymaxxer Service that never exposes raw secret values. During `harness:dev`, the separate `apps/keymaxxer-sidecar` application owns the long-lived Keymaxxer MCP session so TanStack server reloads do not repeat vault-unlock or secret-use approval prompts; production creates the MCP client in-process and does not run a sidecar.
 
-Keymaxxer is responsible for launching or provisioning application processes with named secrets injected into their environment. It is not a dependency of GitHub domain operations: `GitHubService` obtains `GITHUB_TOKEN` through Effect `Config`, and the GraphQL API invokes the Issue Reconciler without accepting a token argument. This keeps credential delivery at the application boundary instead of coupling GitHub requests or GraphQL resolvers to Keymaxxer.
+Keymaxxer is responsible for launching GitHub query processes with named secrets injected into their environment. It is not a dependency of GitHub domain operations: the Harness adapter asks Keymaxxer to run each query, while `GitHubService` obtains the injected `GITHUB_TOKEN` through Effect `Config`. The GraphQL API invokes the Issue Reconciler without accepting a token argument. This keeps credential delivery at the application boundary instead of coupling GitHub requests or GraphQL resolvers to Keymaxxer, allows the Harness to start without GitHub credentials, and leaves secret caching to Keymaxxer.
 
 The sidecar is a development tool attached specifically to `harness:dev` and is restricted to loopback communication. Remote sidecar URLs and remote authentication are deliberately unsupported because the service can execute commands with injected secrets and there is no remote-use requirement.
 

--- a/packages/github-service/src/bin/list-ready-issues.ts
+++ b/packages/github-service/src/bin/list-ready-issues.ts
@@ -1,0 +1,33 @@
+import { Effect, Result } from "effect"
+import {
+  GitHubRepositoryUnavailableError,
+  GitHubService,
+  GitHubServiceLive,
+} from "../index.js"
+
+const decodeArgument = (value: string | undefined): string => {
+  if (value === undefined) throw new Error("Missing Repository argument")
+  return Buffer.from(value, "base64url").toString("utf8")
+}
+
+if (import.meta.main) {
+  const repository = {
+    owner: decodeArgument(process.argv[2]),
+    name: decodeArgument(process.argv[3]),
+  }
+  const result = await Effect.runPromise(
+    Effect.gen(function* () {
+      const github = yield* GitHubService
+      return yield* github.listReadyIssues(repository)
+    }).pipe(Effect.provide(GitHubServiceLive), Effect.result),
+  )
+
+  if (Result.isSuccess(result)) {
+    process.stdout.write(JSON.stringify(result.success))
+  } else if (result.failure instanceof GitHubRepositoryUnavailableError) {
+    process.exitCode = 2
+  } else {
+    process.stderr.write("GitHub query failed\n")
+    process.exitCode = 1
+  }
+}


### PR DESCRIPTION
## Why

Composing the Config-backed GitHub layer into the Harness runtime made `GITHUB_TOKEN` mandatory during startup. That prevented `harness:dev` from starting without a pre-injected credential, even though GitHub access is only needed when a Repository is refreshed.

GitHub credentials must remain isolated behind Keymaxxer: the Harness must not receive or store raw secret values, and the GitHub domain service must not depend on Keymaxxer.

## What Changed

- Add a Harness adapter that asks Keymaxxer to run each GitHub query with `GITHUB_TOKEN` injected into an isolated child process.
- Keep `GitHubServiceLive` independent of Keymaxxer and read the injected token through Effect Config inside the query process.
- Start the Harness without requiring `GITHUB_TOKEN`; request or add it only when a refresh reaches GitHub.
- Serialize first-use token provisioning so concurrent refreshes cannot open duplicate credential dialogs.
- Validate the child-process Issue payload before returning it through `GitHubService`.
- Document the on-demand Keymaxxer credential boundary.

## Verification

- Started `harness:dev` with `GITHUB_TOKEN` explicitly absent and received a successful GraphQL health response.
- Exercised two concurrent GitHub queries and confirmed both use Keymaxxer while first-use credential provisioning occurs once.
