### PR TITLE
feat: show repository issues

### DIFF
--- a/apps/harness/src/routes/index.tsx
+++ b/apps/harness/src/routes/index.tsx
@@ -3,7 +3,7 @@ import { createFileRoute } from "@tanstack/react-router"
 import { Suspense } from "react"
 import { createClient } from "@ready-for-agent/graphql-client"
 
-const graphql = createClient({ url: "/graphql" })
+const graphql = createClient({ url: "/graphql", batch: true })
 
 const repositoriesQuery = {
   queryKey: ["repositories"],
@@ -16,11 +16,29 @@ const repositoriesQuery = {
         localPath: true,
         isBare: true,
         paused: true,
+        issuesReconciledAt: true,
       },
     })
     return result.repositories
   },
 }
+
+const issuesQuery = (repositoryId: string) => ({
+  queryKey: ["issues", repositoryId],
+  queryFn: async () => {
+    const result = await graphql.query({
+      issues: {
+        __args: { repositoryId },
+        id: true,
+        githubIssueNumber: true,
+        title: true,
+        url: true,
+        state: true,
+      },
+    })
+    return result.issues
+  },
+})
 
 export const Route = createFileRoute("/")({
   component: HomePage,
@@ -67,52 +85,126 @@ function RepositoryCards() {
       aria-label="Configured repositories"
     >
       {repositories.map((repository) => (
-        <article
-          className="min-w-0 rounded-[0.9rem] border border-[#dbe3ef] bg-white p-[1.35rem] shadow-[0_10px_30px_rgb(15_23_42_/_5%)]"
-          key={repository.id}
-        >
-          <div className="flex items-center justify-between gap-4">
-            <span className="truncate text-[0.85rem] font-[650] text-slate-500">
-              {repository.githubOwner}
-            </span>
-            <span
-              className={`shrink-0 rounded-full px-[0.55rem] py-[0.2rem] text-[0.7rem] font-[750] tracking-[0.04em] uppercase ${repository.paused ? "bg-amber-100 text-amber-800" : "bg-green-100 text-green-800"}`}
-            >
-              {repository.paused ? "Paused" : "Active"}
-            </span>
-          </div>
-          <h2 className="my-[0.2rem] mb-[1.4rem] wrap-anywhere text-2xl tracking-[-0.025em]">
-            <a
-              className="text-slate-900 hover:underline"
-              href={`https://github.com/${repository.githubOwner}/${repository.githubRepo}`}
-            >
-              {repository.githubRepo}
-            </a>
-          </h2>
-          <dl className="m-0 grid gap-[0.8rem]">
-            <div className="min-w-0">
-              <dt className="text-[0.68rem] font-[750] tracking-[0.08em] text-slate-400 uppercase">
-                Local path
-              </dt>
-              <dd
-                className="mt-[0.15rem] truncate font-mono text-[0.82rem] text-slate-700"
-                title={repository.localPath}
-              >
-                {repository.localPath}
-              </dd>
-            </div>
-            <div className="min-w-0">
-              <dt className="text-[0.68rem] font-[750] tracking-[0.08em] text-slate-400 uppercase">
-                Checkout
-              </dt>
-              <dd className="mt-[0.15rem] truncate font-mono text-[0.82rem] text-slate-700">
-                {repository.isBare ? "Bare repository" : "Working tree"}
-              </dd>
-            </div>
-          </dl>
-        </article>
+        <RepositoryCard key={repository.id} repository={repository} />
       ))}
     </section>
+  )
+}
+
+function RepositoryCard({
+  repository,
+}: {
+  repository: {
+    id: string
+    githubOwner: string
+    githubRepo: string
+    localPath: string
+    isBare: boolean
+    paused: boolean
+    issuesReconciledAt: string | null
+  }
+}) {
+  return (
+    <article className="min-w-0 rounded-[0.9rem] border border-[#dbe3ef] bg-white p-[1.35rem] shadow-[0_10px_30px_rgb(15_23_42_/_5%)]">
+      <div className="flex items-center justify-between gap-4">
+        <span className="truncate text-[0.85rem] font-[650] text-slate-500">
+          {repository.githubOwner}
+        </span>
+        <span
+          className={`shrink-0 rounded-full px-[0.55rem] py-[0.2rem] text-[0.7rem] font-[750] tracking-[0.04em] uppercase ${repository.paused ? "bg-amber-100 text-amber-800" : "bg-green-100 text-green-800"}`}
+        >
+          {repository.paused ? "Paused" : "Active"}
+        </span>
+      </div>
+      <h2 className="my-[0.2rem] mb-[1.4rem] wrap-anywhere text-2xl tracking-[-0.025em]">
+        <a
+          className="text-slate-900 hover:underline"
+          href={`https://github.com/${repository.githubOwner}/${repository.githubRepo}`}
+        >
+          {repository.githubRepo}
+        </a>
+      </h2>
+      <dl className="m-0 grid gap-[0.8rem]">
+        <div className="min-w-0">
+          <dt className="text-[0.68rem] font-[750] tracking-[0.08em] text-slate-400 uppercase">
+            Local path
+          </dt>
+          <dd
+            className="mt-[0.15rem] truncate font-mono text-[0.82rem] text-slate-700"
+            title={repository.localPath}
+          >
+            {repository.localPath}
+          </dd>
+        </div>
+        <div className="min-w-0">
+          <dt className="text-[0.68rem] font-[750] tracking-[0.08em] text-slate-400 uppercase">
+            Checkout
+          </dt>
+          <dd className="mt-[0.15rem] truncate font-mono text-[0.82rem] text-slate-700">
+            {repository.isBare ? "Bare repository" : "Working tree"}
+          </dd>
+        </div>
+      </dl>
+      <div className="mt-5 border-t border-slate-100 pt-4">
+        <h3 className="m-0 mb-2 text-[0.68rem] font-[750] tracking-[0.08em] text-slate-400 uppercase">
+          Ready-labeled issues
+        </h3>
+        {repository.issuesReconciledAt === null ? (
+          <p className="m-0 text-sm text-slate-500">Not refreshed yet.</p>
+        ) : (
+          <Suspense fallback={<RepositoryIssuesSkeleton />}>
+            <RepositoryIssues repositoryId={repository.id} />
+          </Suspense>
+        )}
+      </div>
+    </article>
+  )
+}
+
+function RepositoryIssues({ repositoryId }: { repositoryId: string }) {
+  const { data: issues } = useSuspenseQuery(issuesQuery(repositoryId))
+
+  if (issues.length === 0) {
+    return (
+      <p className="m-0 text-sm text-slate-500">No Ready-labeled issues.</p>
+    )
+  }
+
+  return (
+    <ul className="m-0 grid list-none gap-2 p-0">
+      {issues.map((issue) => (
+        <li className="flex min-w-0 items-start gap-2 text-sm" key={issue.id}>
+          <span className="shrink-0 font-mono text-xs leading-5 text-slate-400">
+            #{issue.githubIssueNumber}
+          </span>
+          <a
+            className="min-w-0 flex-1 text-slate-700 hover:text-blue-700 hover:underline"
+            href={issue.url}
+          >
+            {issue.title}
+          </a>
+          {issue.state === "CLOSED" && (
+            <span className="shrink-0 rounded-full bg-slate-100 px-1.5 py-0.5 text-[0.6rem] font-bold tracking-wide text-slate-500 uppercase">
+              Closed
+            </span>
+          )}
+        </li>
+      ))}
+    </ul>
+  )
+}
+
+function RepositoryIssuesSkeleton() {
+  return (
+    <div
+      className="grid gap-2"
+      role="status"
+      aria-label="Loading issues"
+      aria-busy="true"
+    >
+      <span className="block h-4 w-[85%] animate-pulse rounded bg-[#e8edf4] motion-reduce:animate-none" />
+      <span className="block h-4 w-[65%] animate-pulse rounded bg-[#e8edf4] motion-reduce:animate-none" />
+    </div>
   )
 }
 

--- a/packages/graphql-api/src/lib/graphql-api.ts
+++ b/packages/graphql-api/src/lib/graphql-api.ts
@@ -40,6 +40,10 @@ type UpdateConfigArgs = {
   }
 }
 
+type IssuesArgs = {
+  repositoryId: string
+}
+
 export type GraphqlRuntime = ManagedRuntime.ManagedRuntime<
   DbService | IssueReconciler,
   unknown
@@ -169,6 +173,29 @@ export const createGraphqlApi = (runtime: GraphqlRuntime) => {
             }
             return result.success
           },
+          issues: async (_parent: unknown, args: IssuesArgs) => {
+            const result = await runtime.runPromise(
+              Effect.result(
+                Effect.gen(function* () {
+                  const db = yield* DbService
+                  return yield* db.listIssues(args.repositoryId)
+                }),
+              ),
+            )
+            if (Result.isFailure(result)) {
+              throw toGraphQLError(result.failure)
+            }
+            return result.success
+          },
+        },
+        Issue: {
+          githubCreatedAt: (issue: { githubCreatedAt: Date }) =>
+            issue.githubCreatedAt.toISOString(),
+        },
+        Repository: {
+          issuesReconciledAt: (repository: {
+            issuesReconciledAt: Date | null
+          }) => repository.issuesReconciledAt?.toISOString() ?? null,
         },
         Mutation: {
           updateConfig: async (_parent: unknown, args: UpdateConfigArgs) => {
@@ -230,6 +257,7 @@ export const createGraphqlApi = (runtime: GraphqlRuntime) => {
         },
       },
     }),
+    batching: true,
     cors: false,
     fetchAPI: { Response },
     graphqlEndpoint: "/graphql",

--- a/packages/graphql-api/test/graphql-api.test.ts
+++ b/packages/graphql-api/test/graphql-api.test.ts
@@ -22,6 +22,17 @@ const config = {
   defaultVariant: "low",
 }
 
+const issue = {
+  id: "issue-test",
+  repositoryId: repository.id,
+  githubIssueNumber: 42,
+  title: "Make repository cards useful",
+  body: "Show the Ready-labeled issues.",
+  url: "https://github.com/acme/widgets/issues/42",
+  state: "OPEN" as const,
+  githubCreatedAt: new Date("2026-07-12T10:30:00.000Z"),
+}
+
 const makeRuntime = (
   dbOverrides: Partial<DbServiceShape> = {},
   reconcilerOverrides: Partial<IssueReconcilerShape> = {},
@@ -114,6 +125,7 @@ describe("GraphQL API", () => {
             localPath
             isBare
             paused
+            issuesReconciledAt
           }
         }`,
       }),
@@ -130,6 +142,7 @@ describe("GraphQL API", () => {
             localPath: repository.localPath,
             isBare: repository.isBare,
             paused: repository.paused,
+            issuesReconciledAt: null,
           },
         ],
       },
@@ -165,6 +178,73 @@ describe("GraphQL API", () => {
         },
       },
     })
+  })
+
+  test("lists issues for a repository", async () => {
+    let requestedRepositoryId: string | undefined
+    await runtime.dispose()
+    runtime = makeRuntime({
+      listIssues: (repositoryId) => {
+        requestedRepositoryId = repositoryId
+        return Effect.succeed([issue])
+      },
+    })
+
+    const response = await createGraphqlApi(runtime).fetch(
+      graphqlRequest({
+        query: `query ListIssues($repositoryId: ID!) {
+          issues(repositoryId: $repositoryId) {
+            id repositoryId githubIssueNumber title body url state githubCreatedAt
+          }
+        }`,
+        variables: { repositoryId: repository.id },
+      }),
+    )
+
+    expect(response.status).toBe(200)
+    expect(await response.json()).toEqual({
+      data: {
+        issues: [
+          {
+            ...issue,
+            githubCreatedAt: issue.githubCreatedAt.toISOString(),
+          },
+        ],
+      },
+    })
+    expect(requestedRepositoryId).toBe(repository.id)
+  })
+
+  test("accepts batched issue queries", async () => {
+    await runtime.dispose()
+    runtime = makeRuntime({ listIssues: () => Effect.succeed([issue]) })
+
+    const response = await createGraphqlApi(runtime).fetch(
+      graphqlRequest([
+        {
+          query: `query First($repositoryId: ID!) {
+            issues(repositoryId: $repositoryId) { id }
+          }`,
+          variables: { repositoryId: repository.id },
+        },
+        {
+          query: `query Second($repositoryId: ID!) {
+            issues(repositoryId: $repositoryId) { githubIssueNumber }
+          }`,
+          variables: { repositoryId: repository.id },
+        },
+      ]),
+    )
+
+    expect(response.status).toBe(200)
+    expect(await response.json()).toEqual([
+      { data: { issues: [{ id: issue.id }] } },
+      {
+        data: {
+          issues: [{ githubIssueNumber: issue.githubIssueNumber }],
+        },
+      },
+    ])
   })
 
   test("refreshes a repository through the reconciler", async () => {

--- a/packages/graphql-client/src/generated/schema.graphql
+++ b/packages/graphql-client/src/generated/schema.graphql
@@ -2,6 +2,7 @@ type Query {
   health: Boolean!
   repositories: [Repository!]!
   config: Config!
+  issues(repositoryId: ID!): [Issue!]!
 }
 
 type Config {
@@ -16,6 +17,23 @@ type Repository {
   localPath: String!
   isBare: Boolean!
   paused: Boolean!
+  issuesReconciledAt: String
+}
+
+enum IssueState {
+  OPEN
+  CLOSED
+}
+
+type Issue {
+  id: ID!
+  repositoryId: ID!
+  githubIssueNumber: Int!
+  title: String!
+  body: String!
+  url: String!
+  state: IssueState!
+  githubCreatedAt: String!
 }
 
 type RepositoryRefresh {

--- a/packages/graphql-client/src/generated/schema.ts
+++ b/packages/graphql-client/src/generated/schema.ts
@@ -5,8 +5,8 @@
 
 export type Scalars = {
     Boolean: boolean,
-    String: string,
     ID: string,
+    String: string,
     Int: number,
 }
 
@@ -14,6 +14,7 @@ export interface Query {
     health: Scalars['Boolean']
     repositories: Repository[]
     config: Config
+    issues: Issue[]
     __typename: 'Query'
 }
 
@@ -30,7 +31,22 @@ export interface Repository {
     localPath: Scalars['String']
     isBare: Scalars['Boolean']
     paused: Scalars['Boolean']
+    issuesReconciledAt: (Scalars['String'] | null)
     __typename: 'Repository'
+}
+
+export type IssueState = 'OPEN' | 'CLOSED'
+
+export interface Issue {
+    id: Scalars['ID']
+    repositoryId: Scalars['ID']
+    githubIssueNumber: Scalars['Int']
+    title: Scalars['String']
+    body: Scalars['String']
+    url: Scalars['String']
+    state: IssueState
+    githubCreatedAt: Scalars['String']
+    __typename: 'Issue'
 }
 
 export interface RepositoryRefresh {
@@ -53,6 +69,7 @@ export interface QueryGenqlSelection{
     health?: boolean | number
     repositories?: RepositoryGenqlSelection
     config?: ConfigGenqlSelection
+    issues?: (IssueGenqlSelection & { __args: {repositoryId: Scalars['ID']} })
     __typename?: boolean | number
     __scalar?: boolean | number
 }
@@ -71,6 +88,20 @@ export interface RepositoryGenqlSelection{
     localPath?: boolean | number
     isBare?: boolean | number
     paused?: boolean | number
+    issuesReconciledAt?: boolean | number
+    __typename?: boolean | number
+    __scalar?: boolean | number
+}
+
+export interface IssueGenqlSelection{
+    id?: boolean | number
+    repositoryId?: boolean | number
+    githubIssueNumber?: boolean | number
+    title?: boolean | number
+    body?: boolean | number
+    url?: boolean | number
+    state?: boolean | number
+    githubCreatedAt?: boolean | number
     __typename?: boolean | number
     __scalar?: boolean | number
 }
@@ -122,6 +153,14 @@ export interface MutationGenqlSelection{
     
 
 
+    const Issue_possibleTypes: string[] = ['Issue']
+    export const isIssue = (obj?: { __typename?: any } | null): obj is Issue => {
+      if (!obj?.__typename) throw new Error('__typename is missing in "isIssue"')
+      return Issue_possibleTypes.includes(obj.__typename)
+    }
+    
+
+
     const RepositoryRefresh_possibleTypes: string[] = ['RepositoryRefresh']
     export const isRepositoryRefresh = (obj?: { __typename?: any } | null): obj is RepositoryRefresh => {
       if (!obj?.__typename) throw new Error('__typename is missing in "isRepositoryRefresh"')
@@ -136,3 +175,8 @@ export interface MutationGenqlSelection{
       return Mutation_possibleTypes.includes(obj.__typename)
     }
     
+
+export const enumIssueState = {
+   OPEN: 'OPEN' as const,
+   CLOSED: 'CLOSED' as const
+}

--- a/packages/graphql-client/src/generated/types.ts
+++ b/packages/graphql-client/src/generated/types.ts
@@ -1,9 +1,10 @@
 export default {
     "scalars": [
         1,
-        3,
-        5,
-        7
+        2,
+        4,
+        6,
+        8
     ],
     "types": {
         "Query": {
@@ -11,40 +12,50 @@ export default {
                 1
             ],
             "repositories": [
-                4
+                5
             ],
             "config": [
-                2
+                3
+            ],
+            "issues": [
+                7,
+                {
+                    "repositoryId": [
+                        2,
+                        "ID!"
+                    ]
+                }
             ],
             "__typename": [
-                3
+                4
             ]
         },
         "Boolean": {},
+        "ID": {},
         "Config": {
             "defaultModel": [
-                3
+                4
             ],
             "defaultVariant": [
-                3
+                4
             ],
             "__typename": [
-                3
+                4
             ]
         },
         "String": {},
         "Repository": {
             "id": [
-                5
+                2
             ],
             "githubOwner": [
-                3
+                4
             ],
             "githubRepo": [
-                3
+                4
             ],
             "localPath": [
-                3
+                4
             ],
             "isBare": [
                 1
@@ -52,90 +63,122 @@ export default {
             "paused": [
                 1
             ],
+            "issuesReconciledAt": [
+                4
+            ],
             "__typename": [
-                3
+                4
             ]
         },
-        "ID": {},
-        "RepositoryRefresh": {
-            "fetched": [
-                7
+        "IssueState": {},
+        "Issue": {
+            "id": [
+                2
             ],
-            "inserted": [
-                7
+            "repositoryId": [
+                2
             ],
-            "updated": [
-                7
+            "githubIssueNumber": [
+                8
             ],
-            "deleted": [
-                7
+            "title": [
+                4
             ],
-            "unchanged": [
-                7
+            "body": [
+                4
+            ],
+            "url": [
+                4
+            ],
+            "state": [
+                6
+            ],
+            "githubCreatedAt": [
+                4
             ],
             "__typename": [
-                3
+                4
             ]
         },
         "Int": {},
+        "RepositoryRefresh": {
+            "fetched": [
+                8
+            ],
+            "inserted": [
+                8
+            ],
+            "updated": [
+                8
+            ],
+            "deleted": [
+                8
+            ],
+            "unchanged": [
+                8
+            ],
+            "__typename": [
+                4
+            ]
+        },
         "AddRepositoryInput": {
             "githubOwner": [
-                3
+                4
             ],
             "githubRepo": [
-                3
+                4
             ],
             "localPath": [
-                3
+                4
             ],
             "isBare": [
                 1
             ],
             "__typename": [
-                3
+                4
             ]
         },
         "UpdateConfigInput": {
             "defaultModel": [
-                3
+                4
             ],
             "defaultVariant": [
-                3
+                4
             ],
             "__typename": [
-                3
+                4
             ]
         },
         "Mutation": {
             "addRepository": [
-                4,
+                5,
                 {
                     "input": [
-                        8,
+                        10,
                         "AddRepositoryInput!"
                     ]
                 }
             ],
             "refreshRepository": [
-                6,
+                9,
                 {
                     "repositoryId": [
-                        5,
+                        2,
                         "ID!"
                     ]
                 }
             ],
             "updateConfig": [
-                2,
+                3,
                 {
                     "input": [
-                        9,
+                        11,
                         "UpdateConfigInput!"
                     ]
                 }
             ],
             "__typename": [
-                3
+                4
             ]
         }
     }

--- a/packages/graphql-schema/schema.graphql
+++ b/packages/graphql-schema/schema.graphql
@@ -2,6 +2,7 @@ type Query {
   health: Boolean!
   repositories: [Repository!]!
   config: Config!
+  issues(repositoryId: ID!): [Issue!]!
 }
 
 type Config {
@@ -16,6 +17,23 @@ type Repository {
   localPath: String!
   isBare: Boolean!
   paused: Boolean!
+  issuesReconciledAt: String
+}
+
+enum IssueState {
+  OPEN
+  CLOSED
+}
+
+type Issue {
+  id: ID!
+  repositoryId: ID!
+  githubIssueNumber: Int!
+  title: String!
+  body: String!
+  url: String!
+  state: IssueState!
+  githubCreatedAt: String!
 }
 
 type RepositoryRefresh {


### PR DESCRIPTION
## Why

Repository cards currently show configuration details but not the Ready-labeled Issues available for agent work. The UI also needs to distinguish repositories that have no matching issues from repositories that have never been reconciled.

## What Changed

- add a typed `issues(repositoryId: ID!)` GraphQL query backed by the local Issue store
- expose issue reconciliation status and serialize stored dates as ISO timestamps
- regenerate the shared Genql client and use it from per-repository TanStack suspense queries
- render linked Ready-labeled Issues, closed state, loading placeholders, and the unreconciled state in repository cards
- batch concurrent Genql requests through GraphQL Yoga to avoid per-card HTTP request fan-out
- cover issue retrieval and batched GraphQL requests in the API tests

## Verification

- GraphQL API tests exercise issue retrieval, timestamp serialization, and batched requests
- production client and SSR bundles build successfully with the generated Genql client
