### PR TITLE
feat: add harness model settings

### DIFF
--- a/apps/harness/src/routes/__root.tsx
+++ b/apps/harness/src/routes/__root.tsx
@@ -1,4 +1,9 @@
-import type { QueryClient } from "@tanstack/react-query"
+import {
+  type QueryClient,
+  useMutation,
+  useQuery,
+  useQueryClient,
+} from "@tanstack/react-query"
 import { ReactQueryDevtools } from "@tanstack/react-query-devtools"
 import {
   HeadContent,
@@ -8,11 +13,33 @@ import {
   createRootRouteWithContext,
 } from "@tanstack/react-router"
 import { TanStackRouterDevtools } from "@tanstack/react-router-devtools"
-import type { ReactNode } from "react"
+import {
+  type FormEvent,
+  type ReactNode,
+  useEffect,
+  useRef,
+  useState,
+} from "react"
+import { createClient } from "@ready-for-agent/graphql-client"
 import appCss from "../styles.css?url"
 
 export interface RouterContext {
   queryClient: QueryClient
+}
+
+const graphql = createClient({ url: "/graphql" })
+
+const configQuery = {
+  queryKey: ["config"],
+  queryFn: async () => {
+    const result = await graphql.query({
+      config: {
+        defaultModel: true,
+        defaultVariant: true,
+      },
+    })
+    return result.config
+  },
 }
 
 export const Route = createRootRouteWithContext<RouterContext>()({
@@ -54,7 +81,7 @@ function RootDocument({ children }: { children: ReactNode }) {
 function RootComponent() {
   return (
     <div className="mx-auto min-h-screen max-w-6xl p-4 sm:p-6">
-      <nav className="mb-6 flex gap-4 border-b border-slate-200 pb-4">
+      <nav className="mb-6 flex items-center gap-4 border-b border-slate-200 pb-4">
         <Link
           to="/"
           className="font-medium text-slate-700 hover:underline"
@@ -63,10 +90,183 @@ function RootComponent() {
         >
           Home
         </Link>
+        <SettingsButton />
       </nav>
       <Outlet />
       <ReactQueryDevtools buttonPosition="bottom-left" />
       <TanStackRouterDevtools position="bottom-right" />
     </div>
+  )
+}
+
+function SettingsButton() {
+  const dialogRef = useRef<HTMLDialogElement>(null)
+  const queryClient = useQueryClient()
+  const config = useQuery(configQuery)
+  const [defaultModel, setDefaultModel] = useState("")
+  const [defaultVariant, setDefaultVariant] = useState("low")
+  useEffect(() => {
+    if (dialogRef.current?.open && config.data) {
+      setDefaultModel(config.data.defaultModel)
+      setDefaultVariant(config.data.defaultVariant)
+    }
+  }, [config.data])
+  const updateConfig = useMutation({
+    mutationFn: (input: { defaultModel: string; defaultVariant: string }) =>
+      graphql.mutation({
+        updateConfig: {
+          __args: { input },
+          defaultModel: true,
+          defaultVariant: true,
+        },
+      }),
+    onSuccess: ({ updateConfig: updatedConfig }) => {
+      queryClient.setQueryData(configQuery.queryKey, updatedConfig)
+      dialogRef.current?.close()
+    },
+  })
+
+  const openSettings = () => {
+    if (config.isError) {
+      void config.refetch()
+    }
+    if (config.data) {
+      setDefaultModel(config.data.defaultModel)
+      setDefaultVariant(config.data.defaultVariant)
+    }
+    updateConfig.reset()
+    dialogRef.current?.showModal()
+  }
+
+  const saveSettings = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    updateConfig.mutate({ defaultModel, defaultVariant })
+  }
+
+  const standardVariants = ["low", "medium", "high", "max"]
+  const hasCustomVariant = !standardVariants.includes(defaultVariant)
+
+  return (
+    <>
+      <button
+        type="button"
+        className="ml-auto inline-flex items-center gap-2 rounded-lg border border-slate-300 bg-white px-3 py-1.5 text-sm font-semibold text-slate-700 shadow-sm transition hover:border-slate-400 hover:bg-slate-100 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-600"
+        onClick={openSettings}
+        aria-haspopup="dialog"
+      >
+        <svg
+          aria-hidden="true"
+          className="size-4"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+        >
+          <path d="M12 15.5a3.5 3.5 0 1 0 0-7 3.5 3.5 0 0 0 0 7Z" />
+          <path d="M19.4 15a1.7 1.7 0 0 0 .34 1.88l.06.06-2.83 2.83-.06-.06a1.7 1.7 0 0 0-1.88-.34 1.7 1.7 0 0 0-1.03 1.56V21h-4v-.08A1.7 1.7 0 0 0 8.94 19.4a1.7 1.7 0 0 0-1.88.34l-.06.06-2.83-2.83.06-.06A1.7 1.7 0 0 0 4.57 15 1.7 1.7 0 0 0 3 14H3v-4h.08A1.7 1.7 0 0 0 4.6 8.94a1.7 1.7 0 0 0-.34-1.88L4.2 7l2.83-2.83.06.06A1.7 1.7 0 0 0 9 4.57 1.7 1.7 0 0 0 10 3V3h4v.08A1.7 1.7 0 0 0 15.06 4.6a1.7 1.7 0 0 0 1.88-.34L17 4.2 19.83 7l-.06.06A1.7 1.7 0 0 0 19.43 9 1.7 1.7 0 0 0 21 10h.08v4H21a1.7 1.7 0 0 0-1.6 1Z" />
+        </svg>
+        Settings
+      </button>
+
+      <dialog
+        ref={dialogRef}
+        className="m-auto w-[min(92vw,31rem)] rounded-2xl border border-slate-200 bg-white p-0 text-slate-900 shadow-2xl backdrop:bg-slate-950/45"
+        aria-labelledby="settings-title"
+        onCancel={(event) => {
+          if (updateConfig.isPending) event.preventDefault()
+        }}
+      >
+        <form onSubmit={saveSettings}>
+          <div className="border-b border-slate-200 px-6 py-5">
+            <p className="text-xs font-extrabold tracking-[0.12em] text-blue-600 uppercase">
+              Harness defaults
+            </p>
+            <h2 id="settings-title" className="mt-1 text-2xl font-bold">
+              Model settings
+            </h2>
+            <p className="mt-1 text-sm text-slate-500">
+              Applied by default when the harness starts a new agent session.
+            </p>
+          </div>
+
+          <div className="grid gap-5 px-6 py-5">
+            {config.isPending ? (
+              <p className="text-sm text-slate-500">Loading settings...</p>
+            ) : config.isError ? (
+              <p className="rounded-lg bg-red-50 p-3 text-sm text-red-700">
+                Settings could not be loaded. Close this dialog and try again.
+              </p>
+            ) : (
+              <>
+                <label className="grid gap-1.5 text-sm font-semibold">
+                  Default model
+                  <input
+                    className="rounded-lg border border-slate-300 px-3 py-2 font-mono text-sm font-normal outline-none focus:border-blue-500 focus:ring-2 focus:ring-blue-100"
+                    name="defaultModel"
+                    value={defaultModel}
+                    onChange={(event) => setDefaultModel(event.target.value)}
+                    placeholder="provider/model-name"
+                    required
+                  />
+                  <span className="text-xs font-normal text-slate-500">
+                    Use the OpenCode provider/model identifier.
+                  </span>
+                </label>
+
+                <label className="grid gap-1.5 text-sm font-semibold">
+                  Thinking level
+                  <select
+                    className="rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm font-normal outline-none focus:border-blue-500 focus:ring-2 focus:ring-blue-100"
+                    name="defaultVariant"
+                    value={defaultVariant}
+                    onChange={(event) => setDefaultVariant(event.target.value)}
+                    required
+                  >
+                    {hasCustomVariant && (
+                      <option value={defaultVariant}>{defaultVariant}</option>
+                    )}
+                    {standardVariants.map((variant) => (
+                      <option key={variant} value={variant}>
+                        {variant[0]?.toUpperCase()}
+                        {variant.slice(1)}
+                      </option>
+                    ))}
+                  </select>
+                  <span className="text-xs font-normal text-slate-500">
+                    OpenCode calls this the model variant.
+                  </span>
+                </label>
+              </>
+            )}
+
+            {updateConfig.isError && (
+              <p className="rounded-lg bg-red-50 p-3 text-sm text-red-700">
+                Settings could not be saved. Check the values and try again.
+              </p>
+            )}
+          </div>
+
+          <div className="flex justify-end gap-3 border-t border-slate-200 bg-slate-50 px-6 py-4">
+            <button
+              type="button"
+              className="rounded-lg px-4 py-2 text-sm font-semibold text-slate-600 hover:bg-slate-200"
+              onClick={() => dialogRef.current?.close()}
+              disabled={updateConfig.isPending}
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              className="rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-50"
+              disabled={
+                config.isPending || config.isError || updateConfig.isPending
+              }
+            >
+              {updateConfig.isPending ? "Saving..." : "Save settings"}
+            </button>
+          </div>
+        </form>
+      </dialog>
+    </>
   )
 }

--- a/packages/db-schema/drizzle/20260713093925_dear_mother_askani/migration.sql
+++ b/packages/db-schema/drizzle/20260713093925_dear_mother_askani/migration.sql
@@ -1,0 +1,7 @@
+CREATE TABLE `config` (
+	`id` text PRIMARY KEY DEFAULT 'default',
+	`default_model` text DEFAULT 'opencode/deepseek-v4-flash-free' NOT NULL,
+	`default_variant` text DEFAULT 'low' NOT NULL,
+	`created_at` integer NOT NULL,
+	`updated_at` integer NOT NULL
+);

--- a/packages/db-schema/drizzle/20260713093925_dear_mother_askani/snapshot.json
+++ b/packages/db-schema/drizzle/20260713093925_dear_mother_askani/snapshot.json
@@ -1,0 +1,560 @@
+{
+  "version": "7",
+  "dialect": "sqlite",
+  "id": "5faaa6e9-0526-4b02-a252-6265bd4b1fac",
+  "prevIds": [
+    "35aa0faf-4d19-4f97-8d32-3d3412f9f720"
+  ],
+  "ddl": [
+    {
+      "name": "completed_job",
+      "entityType": "tables"
+    },
+    {
+      "name": "config",
+      "entityType": "tables"
+    },
+    {
+      "name": "issue",
+      "entityType": "tables"
+    },
+    {
+      "name": "job_queue",
+      "entityType": "tables"
+    },
+    {
+      "name": "repository",
+      "entityType": "tables"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "completed_job"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "queue",
+      "entityType": "columns",
+      "table": "completed_job"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "job_id",
+      "entityType": "columns",
+      "table": "completed_job"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "completed_job"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "completed_job"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "'default'",
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "config"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'opencode/deepseek-v4-flash-free'",
+      "generated": null,
+      "name": "default_model",
+      "entityType": "columns",
+      "table": "config"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'low'",
+      "generated": null,
+      "name": "default_variant",
+      "entityType": "columns",
+      "table": "config"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "config"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "config"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "issue"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "repository_id",
+      "entityType": "columns",
+      "table": "issue"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "github_issue_number",
+      "entityType": "columns",
+      "table": "issue"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "title",
+      "entityType": "columns",
+      "table": "issue"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "body",
+      "entityType": "columns",
+      "table": "issue"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "url",
+      "entityType": "columns",
+      "table": "issue"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "state",
+      "entityType": "columns",
+      "table": "issue"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "github_created_at",
+      "entityType": "columns",
+      "table": "issue"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "issue"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "issue"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "job_queue"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "queue",
+      "entityType": "columns",
+      "table": "job_queue"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "job_payload",
+      "entityType": "columns",
+      "table": "job_queue"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "0",
+      "generated": null,
+      "name": "job_attempts",
+      "entityType": "columns",
+      "table": "job_queue"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "5",
+      "generated": null,
+      "name": "job_retry_limit",
+      "entityType": "columns",
+      "table": "job_queue"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "available_at",
+      "entityType": "columns",
+      "table": "job_queue"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "locked_until",
+      "entityType": "columns",
+      "table": "job_queue"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "job_queue"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "job_queue"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "repository"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "github_owner",
+      "entityType": "columns",
+      "table": "repository"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "github_repo",
+      "entityType": "columns",
+      "table": "repository"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "local_path",
+      "entityType": "columns",
+      "table": "repository"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "is_bare",
+      "entityType": "columns",
+      "table": "repository"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "true",
+      "generated": null,
+      "name": "paused",
+      "entityType": "columns",
+      "table": "repository"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "issues_reconciled_at",
+      "entityType": "columns",
+      "table": "repository"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "repository"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "repository"
+    },
+    {
+      "columns": [
+        "repository_id"
+      ],
+      "tableTo": "repository",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_issue_repository_id_repository_id_fk",
+      "entityType": "fks",
+      "table": "issue"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "completed_job_pk",
+      "table": "completed_job",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "config_pk",
+      "table": "config",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "issue_pk",
+      "table": "issue",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "job_queue_pk",
+      "table": "job_queue",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "repository_pk",
+      "table": "repository",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        {
+          "value": "queue",
+          "isExpression": false
+        },
+        {
+          "value": "job_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "origin": "manual",
+      "name": "completed_job_queue_job_id_uidx",
+      "entityType": "indexes",
+      "table": "completed_job"
+    },
+    {
+      "columns": [
+        {
+          "value": "repository_id",
+          "isExpression": false
+        },
+        {
+          "value": "github_issue_number",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "origin": "manual",
+      "name": "issue_repository_id_github_issue_number_uidx",
+      "entityType": "indexes",
+      "table": "issue"
+    },
+    {
+      "columns": [
+        {
+          "value": "queue",
+          "isExpression": false
+        },
+        {
+          "value": "locked_until",
+          "isExpression": false
+        },
+        {
+          "value": "job_attempts",
+          "isExpression": false
+        },
+        {
+          "value": "available_at",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "job_queue_ready_idx",
+      "entityType": "indexes",
+      "table": "job_queue"
+    },
+    {
+      "columns": [
+        {
+          "value": "lower(\"github_owner\")",
+          "isExpression": true
+        },
+        {
+          "value": "lower(\"github_repo\")",
+          "isExpression": true
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "origin": "manual",
+      "name": "repository_github_owner_repo_lower_uidx",
+      "entityType": "indexes",
+      "table": "repository"
+    },
+    {
+      "columns": [
+        "local_path"
+      ],
+      "nameExplicit": false,
+      "name": "repository_local_path_unique",
+      "entityType": "uniques",
+      "table": "repository"
+    }
+  ],
+  "renames": []
+}

--- a/packages/db-schema/src/schema.ts
+++ b/packages/db-schema/src/schema.ts
@@ -35,6 +35,18 @@ export const repository = snakeCase.table(
   ],
 )
 
+export const config = snakeCase.table("config", {
+  id: text().primaryKey().default("default"),
+  defaultModel: text().notNull().default("opencode/deepseek-v4-flash-free"),
+  defaultVariant: text().notNull().default("low"),
+  createdAt: integer({ mode: "number" })
+    .notNull()
+    .$defaultFn(() => Date.now()),
+  updatedAt: integer({ mode: "number" })
+    .notNull()
+    .$defaultFn(() => Date.now()),
+})
+
 export const issue = snakeCase.table(
   "issue",
   {

--- a/packages/db-service/src/lib/db-service.ts
+++ b/packages/db-service/src/lib/db-service.ts
@@ -4,6 +4,7 @@ import type { SqlError } from "effect/unstable/sql/SqlError"
 import { ulid } from "ulidx"
 import {
   DatabaseError,
+  InvalidConfigInputError,
   InvalidIssueInputError,
   InvalidRepositoryInputError,
   LocalPathInUseError,
@@ -12,9 +13,11 @@ import {
 } from "./errors.js"
 import type {
   AddRepositoryInput,
+  ConfigRecord,
   IssueRecord,
   RepositoryRecord,
   StoreIssueInput,
+  UpdateConfigInput,
 } from "./types.js"
 
 const formatSqlError = (error: SqlError): string => {
@@ -113,6 +116,10 @@ const toDatabaseError = (error: SqlError) =>
   })
 
 export interface DbServiceShape {
+  readonly getConfig: Effect.Effect<ConfigRecord, DatabaseError>
+  readonly updateConfig: (
+    input: UpdateConfigInput,
+  ) => Effect.Effect<ConfigRecord, InvalidConfigInputError | DatabaseError>
   readonly addRepository: (
     input: AddRepositoryInput,
   ) => Effect.Effect<
@@ -156,6 +163,86 @@ export const DbServiceLive = Layer.effect(
   DbService,
   Effect.gen(function* () {
     const sql = yield* SqlClient.SqlClient
+
+    const getConfig: Effect.Effect<ConfigRecord, DatabaseError> = Effect.gen(
+      function* () {
+        const now = Date.now()
+        yield* sql
+          .unsafe(
+            `INSERT OR IGNORE INTO config (
+               id, default_model, default_variant, created_at, updated_at
+             ) VALUES ('default', 'opencode/deepseek-v4-flash-free', 'low', ?, ?)`,
+            [now, now],
+          )
+          .pipe(Effect.mapError(toDatabaseError))
+
+        const rows = yield* sql
+          .unsafe(
+            `SELECT default_model, default_variant
+             FROM config WHERE id = 'default'`,
+          )
+          .pipe(Effect.mapError(toDatabaseError))
+        const row = rows[0] as
+          | { default_model: string; default_variant: string }
+          | undefined
+        if (!row) {
+          return yield* new DatabaseError({
+            message: "No config returned after initialization",
+          })
+        }
+        return {
+          defaultModel: row.default_model,
+          defaultVariant: row.default_variant,
+        }
+      },
+    )
+
+    const updateConfig = (
+      input: UpdateConfigInput,
+    ): Effect.Effect<ConfigRecord, InvalidConfigInputError | DatabaseError> =>
+      Effect.gen(function* () {
+        const defaultModel = input.defaultModel.trim()
+        if (defaultModel.length === 0) {
+          return yield* new InvalidConfigInputError({
+            field: "defaultModel",
+            message: "defaultModel cannot be empty",
+          })
+        }
+        const defaultVariant = input.defaultVariant.trim()
+        if (defaultVariant.length === 0) {
+          return yield* new InvalidConfigInputError({
+            field: "defaultVariant",
+            message: "defaultVariant cannot be empty",
+          })
+        }
+
+        const now = Date.now()
+        const rows = yield* sql
+          .unsafe(
+            `INSERT INTO config (
+               id, default_model, default_variant, created_at, updated_at
+             ) VALUES ('default', ?, ?, ?, ?)
+             ON CONFLICT (id) DO UPDATE SET
+               default_model = excluded.default_model,
+               default_variant = excluded.default_variant,
+               updated_at = excluded.updated_at
+             RETURNING default_model, default_variant`,
+            [defaultModel, defaultVariant, now, now],
+          )
+          .pipe(Effect.mapError(toDatabaseError))
+        const row = rows[0] as
+          | { default_model: string; default_variant: string }
+          | undefined
+        if (!row) {
+          return yield* new DatabaseError({
+            message: "No config returned from update",
+          })
+        }
+        return {
+          defaultModel: row.default_model,
+          defaultVariant: row.default_variant,
+        }
+      })
 
     const addRepository = (
       input: AddRepositoryInput,
@@ -500,6 +587,8 @@ export const DbServiceLive = Layer.effect(
       })
 
     return DbService.of({
+      getConfig,
+      updateConfig,
       addRepository,
       listRepositories,
       storeIssue,

--- a/packages/db-service/src/lib/errors.ts
+++ b/packages/db-service/src/lib/errors.ts
@@ -38,6 +38,13 @@ export class InvalidIssueInputError extends Data.TaggedError(
   readonly message: string
 }> {}
 
+export class InvalidConfigInputError extends Data.TaggedError(
+  "InvalidConfigInputError",
+)<{
+  readonly field: "defaultModel" | "defaultVariant"
+  readonly message: string
+}> {}
+
 export class DatabaseError extends Data.TaggedError("DatabaseError")<{
   readonly message: string
   readonly cause?: unknown

--- a/packages/db-service/src/lib/types.ts
+++ b/packages/db-service/src/lib/types.ts
@@ -15,6 +15,16 @@ export interface RepositoryRecord {
   readonly issuesReconciledAt: Date | null
 }
 
+export interface ConfigRecord {
+  readonly defaultModel: string
+  readonly defaultVariant: string
+}
+
+export interface UpdateConfigInput {
+  readonly defaultModel: string
+  readonly defaultVariant: string
+}
+
 export interface StoreIssueInput {
   readonly repositoryId: string
   readonly githubIssueNumber: number

--- a/packages/db-service/test/db-service.spec.ts
+++ b/packages/db-service/test/db-service.spec.ts
@@ -4,6 +4,7 @@ import { DatabaseTest } from "@ready-for-agent/db/test"
 import {
   DbService,
   DbServiceLive,
+  InvalidConfigInputError,
   InvalidIssueInputError,
   InvalidRepositoryInputError,
   LocalPathInUseError,
@@ -33,6 +34,47 @@ describe("DbService", () => {
     url: "https://github.com/acme/widgets/issues/42",
     state: "OPEN" as const,
   }
+
+  describe("config", () => {
+    it("returns defaults and persists updates", () =>
+      runTest(
+        Effect.gen(function* () {
+          const db = yield* DbService
+          expect(yield* db.getConfig).toEqual({
+            defaultModel: "opencode/deepseek-v4-flash-free",
+            defaultVariant: "low",
+          })
+
+          expect(
+            yield* db.updateConfig({
+              defaultModel: "  anthropic/claude-sonnet-4-5  ",
+              defaultVariant: "  high  ",
+            }),
+          ).toEqual({
+            defaultModel: "anthropic/claude-sonnet-4-5",
+            defaultVariant: "high",
+          })
+          expect(yield* db.getConfig).toEqual({
+            defaultModel: "anthropic/claude-sonnet-4-5",
+            defaultVariant: "high",
+          })
+        }),
+      ))
+
+    it("rejects empty values", () =>
+      runTest(
+        Effect.gen(function* () {
+          const db = yield* DbService
+          const error = yield* Effect.flip(
+            db.updateConfig({
+              defaultModel: " ",
+              defaultVariant: "high",
+            }),
+          )
+          expect(error).toBeInstanceOf(InvalidConfigInputError)
+        }),
+      ))
+  })
 
   describe("addRepository", () => {
     it("inserts a repository paused with a repo- prefixed id", () =>

--- a/packages/graphql-api/src/lib/graphql-api.ts
+++ b/packages/graphql-api/src/lib/graphql-api.ts
@@ -4,6 +4,7 @@ import { createSchema, createYoga } from "graphql-yoga"
 import {
   DatabaseError,
   DbService,
+  InvalidConfigInputError,
   InvalidRepositoryInputError,
   LocalPathInUseError,
   RepositoryAlreadyExistsError,
@@ -32,6 +33,13 @@ type RefreshRepositoryArgs = {
   repositoryId: string
 }
 
+type UpdateConfigArgs = {
+  input: {
+    defaultModel: string
+    defaultVariant: string
+  }
+}
+
 export type GraphqlRuntime = ManagedRuntime.ManagedRuntime<
   DbService | IssueReconciler,
   unknown
@@ -45,6 +53,11 @@ const toGraphQLError = (error: unknown): GraphQLError => {
         extensions: { code: "REPOSITORY_ALREADY_EXISTS" },
       },
     )
+  }
+  if (error instanceof InvalidConfigInputError) {
+    return new GraphQLError(error.message, {
+      extensions: { code: "INVALID_CONFIG_INPUT", field: error.field },
+    })
   }
   if (error instanceof LocalPathInUseError) {
     return new GraphQLError(`Local path already in use: ${error.localPath}`, {
@@ -142,8 +155,36 @@ export const createGraphqlApi = (runtime: GraphqlRuntime) => {
             }
             return result.success
           },
+          config: async () => {
+            const result = await runtime.runPromise(
+              Effect.result(
+                Effect.gen(function* () {
+                  const db = yield* DbService
+                  return yield* db.getConfig
+                }),
+              ),
+            )
+            if (Result.isFailure(result)) {
+              throw toGraphQLError(result.failure)
+            }
+            return result.success
+          },
         },
         Mutation: {
+          updateConfig: async (_parent: unknown, args: UpdateConfigArgs) => {
+            const result = await runtime.runPromise(
+              Effect.result(
+                Effect.gen(function* () {
+                  const db = yield* DbService
+                  return yield* db.updateConfig(args.input)
+                }),
+              ),
+            )
+            if (Result.isFailure(result)) {
+              throw toGraphQLError(result.failure)
+            }
+            return result.success
+          },
           addRepository: async (_parent: unknown, args: AddRepositoryArgs) => {
             const result = await runtime.runPromise(
               Effect.result(

--- a/packages/graphql-api/test/graphql-api.test.ts
+++ b/packages/graphql-api/test/graphql-api.test.ts
@@ -17,11 +17,18 @@ const repository = {
   issuesReconciledAt: null,
 }
 
+const config = {
+  defaultModel: "opencode/deepseek-v4-flash-free",
+  defaultVariant: "low",
+}
+
 const makeRuntime = (
   dbOverrides: Partial<DbServiceShape> = {},
   reconcilerOverrides: Partial<IssueReconcilerShape> = {},
 ) => {
   const db: DbServiceShape = {
+    getConfig: Effect.succeed(config),
+    updateConfig: (input) => Effect.succeed(input),
     addRepository: () => Effect.succeed(repository),
     listRepositories: Effect.succeed([repository]),
     storeIssue: () => Effect.die("not used"),
@@ -125,6 +132,37 @@ describe("GraphQL API", () => {
             paused: repository.paused,
           },
         ],
+      },
+    })
+  })
+
+  test("reads and updates config", async () => {
+    const queryResponse = await createGraphqlApi(runtime).fetch(
+      graphqlRequest({
+        query: `query { config { defaultModel defaultVariant } }`,
+      }),
+    )
+    expect(await queryResponse.json()).toEqual({ data: { config } })
+
+    const mutationResponse = await createGraphqlApi(runtime).fetch(
+      graphqlRequest({
+        query: `mutation UpdateConfig($input: UpdateConfigInput!) {
+          updateConfig(input: $input) { defaultModel defaultVariant }
+        }`,
+        variables: {
+          input: {
+            defaultModel: "anthropic/claude-sonnet-4-5",
+            defaultVariant: "high",
+          },
+        },
+      }),
+    )
+    expect(await mutationResponse.json()).toEqual({
+      data: {
+        updateConfig: {
+          defaultModel: "anthropic/claude-sonnet-4-5",
+          defaultVariant: "high",
+        },
       },
     })
   })

--- a/packages/graphql-client/src/generated/schema.graphql
+++ b/packages/graphql-client/src/generated/schema.graphql
@@ -1,6 +1,12 @@
 type Query {
   health: Boolean!
   repositories: [Repository!]!
+  config: Config!
+}
+
+type Config {
+  defaultModel: String!
+  defaultVariant: String!
 }
 
 type Repository {
@@ -27,7 +33,13 @@ input AddRepositoryInput {
   isBare: Boolean!
 }
 
+input UpdateConfigInput {
+  defaultModel: String!
+  defaultVariant: String!
+}
+
 type Mutation {
   addRepository(input: AddRepositoryInput!): Repository!
   refreshRepository(repositoryId: ID!): RepositoryRefresh!
+  updateConfig(input: UpdateConfigInput!): Config!
 }

--- a/packages/graphql-client/src/generated/schema.ts
+++ b/packages/graphql-client/src/generated/schema.ts
@@ -5,15 +5,22 @@
 
 export type Scalars = {
     Boolean: boolean,
-    ID: string,
     String: string,
+    ID: string,
     Int: number,
 }
 
 export interface Query {
     health: Scalars['Boolean']
     repositories: Repository[]
+    config: Config
     __typename: 'Query'
+}
+
+export interface Config {
+    defaultModel: Scalars['String']
+    defaultVariant: Scalars['String']
+    __typename: 'Config'
 }
 
 export interface Repository {
@@ -38,12 +45,21 @@ export interface RepositoryRefresh {
 export interface Mutation {
     addRepository: Repository
     refreshRepository: RepositoryRefresh
+    updateConfig: Config
     __typename: 'Mutation'
 }
 
 export interface QueryGenqlSelection{
     health?: boolean | number
     repositories?: RepositoryGenqlSelection
+    config?: ConfigGenqlSelection
+    __typename?: boolean | number
+    __scalar?: boolean | number
+}
+
+export interface ConfigGenqlSelection{
+    defaultModel?: boolean | number
+    defaultVariant?: boolean | number
     __typename?: boolean | number
     __scalar?: boolean | number
 }
@@ -71,9 +87,12 @@ export interface RepositoryRefreshGenqlSelection{
 
 export interface AddRepositoryInput {githubOwner: Scalars['String'],githubRepo: Scalars['String'],localPath: Scalars['String'],isBare: Scalars['Boolean']}
 
+export interface UpdateConfigInput {defaultModel: Scalars['String'],defaultVariant: Scalars['String']}
+
 export interface MutationGenqlSelection{
     addRepository?: (RepositoryGenqlSelection & { __args: {input: AddRepositoryInput} })
     refreshRepository?: (RepositoryRefreshGenqlSelection & { __args: {repositoryId: Scalars['ID']} })
+    updateConfig?: (ConfigGenqlSelection & { __args: {input: UpdateConfigInput} })
     __typename?: boolean | number
     __scalar?: boolean | number
 }
@@ -83,6 +102,14 @@ export interface MutationGenqlSelection{
     export const isQuery = (obj?: { __typename?: any } | null): obj is Query => {
       if (!obj?.__typename) throw new Error('__typename is missing in "isQuery"')
       return Query_possibleTypes.includes(obj.__typename)
+    }
+    
+
+
+    const Config_possibleTypes: string[] = ['Config']
+    export const isConfig = (obj?: { __typename?: any } | null): obj is Config => {
+      if (!obj?.__typename) throw new Error('__typename is missing in "isConfig"')
+      return Config_possibleTypes.includes(obj.__typename)
     }
     
 

--- a/packages/graphql-client/src/generated/types.ts
+++ b/packages/graphql-client/src/generated/types.ts
@@ -2,8 +2,8 @@ export default {
     "scalars": [
         1,
         3,
-        4,
-        6
+        5,
+        7
     ],
     "types": {
         "Query": {
@@ -11,25 +11,40 @@ export default {
                 1
             ],
             "repositories": [
+                4
+            ],
+            "config": [
                 2
             ],
             "__typename": [
-                4
+                3
             ]
         },
         "Boolean": {},
-        "Repository": {
-            "id": [
+        "Config": {
+            "defaultModel": [
                 3
             ],
+            "defaultVariant": [
+                3
+            ],
+            "__typename": [
+                3
+            ]
+        },
+        "String": {},
+        "Repository": {
+            "id": [
+                5
+            ],
             "githubOwner": [
-                4
+                3
             ],
             "githubRepo": [
-                4
+                3
             ],
             "localPath": [
-                4
+                3
             ],
             "isBare": [
                 1
@@ -38,70 +53,89 @@ export default {
                 1
             ],
             "__typename": [
-                4
+                3
             ]
         },
         "ID": {},
-        "String": {},
         "RepositoryRefresh": {
             "fetched": [
-                6
+                7
             ],
             "inserted": [
-                6
+                7
             ],
             "updated": [
-                6
+                7
             ],
             "deleted": [
-                6
+                7
             ],
             "unchanged": [
-                6
+                7
             ],
             "__typename": [
-                4
+                3
             ]
         },
         "Int": {},
         "AddRepositoryInput": {
             "githubOwner": [
-                4
+                3
             ],
             "githubRepo": [
-                4
+                3
             ],
             "localPath": [
-                4
+                3
             ],
             "isBare": [
                 1
             ],
             "__typename": [
-                4
+                3
+            ]
+        },
+        "UpdateConfigInput": {
+            "defaultModel": [
+                3
+            ],
+            "defaultVariant": [
+                3
+            ],
+            "__typename": [
+                3
             ]
         },
         "Mutation": {
             "addRepository": [
-                2,
+                4,
                 {
                     "input": [
-                        7,
+                        8,
                         "AddRepositoryInput!"
                     ]
                 }
             ],
             "refreshRepository": [
-                5,
+                6,
                 {
                     "repositoryId": [
-                        3,
+                        5,
                         "ID!"
                     ]
                 }
             ],
+            "updateConfig": [
+                2,
+                {
+                    "input": [
+                        9,
+                        "UpdateConfigInput!"
+                    ]
+                }
+            ],
             "__typename": [
-                4
+                3
             ]
         }
     }

--- a/packages/graphql-schema/schema.graphql
+++ b/packages/graphql-schema/schema.graphql
@@ -1,6 +1,12 @@
 type Query {
   health: Boolean!
   repositories: [Repository!]!
+  config: Config!
+}
+
+type Config {
+  defaultModel: String!
+  defaultVariant: String!
 }
 
 type Repository {
@@ -27,7 +33,13 @@ input AddRepositoryInput {
   isBare: Boolean!
 }
 
+input UpdateConfigInput {
+  defaultModel: String!
+  defaultVariant: String!
+}
+
 type Mutation {
   addRepository(input: AddRepositoryInput!): Repository!
   refreshRepository(repositoryId: ID!): RepositoryRefresh!
+  updateConfig(input: UpdateConfigInput!): Config!
 }


### PR DESCRIPTION
## Why

The harness needs persistent defaults for the model and thinking level used when starting agent sessions, with a UI that lets operators change them without editing local configuration.

## What Changed

- add a singleton `config` table and migration with model and variant defaults
- expose settings through the GraphQL `config` query and `updateConfig` mutation
- validate and persist settings through `DbService`
- regenerate the typed GraphQL client
- add a settings dialog to the harness navigation with loading, error, and pending-save handling
- cover database persistence and GraphQL behavior with tests
