### PR TITLE
feat(opencode): list configured models

### DIFF
--- a/packages/opencode/src/lib/opencode.ts
+++ b/packages/opencode/src/lib/opencode.ts
@@ -10,6 +10,7 @@ import {
 import { parseSessionIdFromLine } from "./parse-session-id.js"
 import type {
   ContinueInput,
+  ListModelsInput,
   OpencodeLayerOptions,
   OpencodeRunResult,
   StartInput,
@@ -33,6 +34,10 @@ export class Opencode extends Context.Service<
     readonly continue: (
       input: ContinueInput,
     ) => Effect.Effect<OpencodeRunResult, OpencodeError>
+    /** Lists models from OpenCode's active providers for the working directory. */
+    readonly listModels: (
+      input: ListModelsInput,
+    ) => Effect.Effect<ReadonlyArray<string>, OpencodeError>
   }
 >()("@ready-for-agent/opencode/Opencode") {
   static layer = (options: OpencodeLayerOptions = {}) =>
@@ -42,6 +47,58 @@ export class Opencode extends Context.Service<
         const spawner = yield* ChildProcessSpawner.ChildProcessSpawner
         const binary = options.binary ?? DEFAULT_BINARY
         const defaultTimeout = options.defaultTimeout ?? DEFAULT_TIMEOUT
+
+        const listModels = (
+          input: ListModelsInput,
+        ): Effect.Effect<ReadonlyArray<string>, OpencodeError> =>
+          Effect.gen(function* () {
+            const timeout = input.timeout ?? defaultTimeout
+            const timeoutMs = Duration.toMillis(timeout)
+            const command = ChildProcess.make(binary, ["models"], {
+              cwd: input.cwd,
+              stdin: "ignore",
+              stderr: "ignore",
+            })
+
+            const result = yield* Effect.scoped(
+              Effect.gen(function* () {
+                const handle = yield* spawner.spawn(command)
+                const collectModels = Stream.decodeText(handle.stdout).pipe(
+                  Stream.splitLines,
+                  Stream.runFold(
+                    (): ReadonlyArray<string> => [],
+                    (models, line) => {
+                      const model = line.trim()
+                      return model.length === 0 ? models : [...models, model]
+                    },
+                  ),
+                )
+
+                const [exitCode, models] = yield* Effect.all(
+                  [handle.exitCode, collectModels],
+                  { concurrency: 2 },
+                )
+
+                return { exitCode: Number(exitCode), models }
+              }),
+            ).pipe(
+              Effect.timeout(timeout),
+              Effect.catchTag("TimeoutError", () =>
+                Effect.fail(
+                  new OpencodeTimeoutError({ cwd: input.cwd, timeoutMs }),
+                ),
+              ),
+            )
+
+            if (result.exitCode !== 0) {
+              return yield* new OpencodeExitError({
+                exitCode: result.exitCode,
+                cwd: input.cwd,
+              })
+            }
+
+            return result.models
+          })
 
         const run = (input: {
           readonly prompt: string
@@ -135,6 +192,7 @@ export class Opencode extends Context.Service<
         return {
           start: (input) => run(input),
           continue: (input) => run(input),
+          listModels,
         }
       }),
     )

--- a/packages/opencode/src/lib/types.ts
+++ b/packages/opencode/src/lib/types.ts
@@ -4,6 +4,11 @@ export interface OpencodeRunResult {
   readonly sessionId: string
 }
 
+export interface ListModelsInput {
+  readonly cwd: string
+  readonly timeout?: Duration.Input
+}
+
 export interface StartInput {
   readonly prompt: string
   readonly cwd: string

--- a/packages/opencode/test/opencode.integration.spec.ts
+++ b/packages/opencode/test/opencode.integration.spec.ts
@@ -9,6 +9,22 @@ import { describe, expect, it } from "bun:test"
 const TestLayer = OpencodeLive.pipe(Layer.provide(BunServices.layer))
 
 describe("Opencode integration", () => {
+  it("lists models from OpenCode's active providers", async () => {
+    const models = await Effect.runPromise(
+      Effect.gen(function* () {
+        const opencode = yield* Opencode
+        return yield* opencode.listModels({
+          cwd: process.cwd(),
+          timeout: "30 seconds",
+        })
+      }).pipe(Effect.provide(TestLayer)),
+    )
+
+    expect(models.length).toBeGreaterThan(0)
+    expect(models).toContain("opencode/deepseek-v4-flash-free")
+    expect(models.every((model) => model.includes("/"))).toBe(true)
+  }, 35_000)
+
   it("starts and continues a real Session", async () => {
     const cwd = await mkdtemp(join(tmpdir(), "ready-for-agent-opencode-"))
     let sessionId: string | undefined


### PR DESCRIPTION
## Why

Consumers need to choose models that OpenCode can actually use in the current working directory. A broad model catalog includes providers and models that are unavailable because of credentials, configuration, plugins, or OpenCode compatibility rules.

## What Changed

- Add `Opencode.listModels({ cwd, timeout? })` to expose OpenCode's active-provider model list.
- Delegate selection to `opencode models` so OpenCode remains responsible for provider and compatibility filtering.
- Preserve the service's typed process exit and timeout failures.
- Add integration coverage that verifies configured model IDs are returned.

## Verification

The integration test called the installed OpenCode CLI and returned active-provider models, including `opencode/deepseek-v4-flash-free`. The complete `opencode` test suite passed with 8 tests.
