### PR TITLE
feat: reconcile GitHub issue dependencies

### DIFF
--- a/apps/harness/src/server/keymaxxer-github-layer.ts
+++ b/apps/harness/src/server/keymaxxer-github-layer.ts
@@ -17,6 +17,12 @@ const SerializedIssue = Schema.Struct({
   url: Schema.String,
   createdAt: Schema.String,
   state: Schema.Literals(["OPEN", "CLOSED"]),
+  blockedBy: Schema.Array(
+    Schema.Struct({
+      number: Schema.Finite,
+      url: Schema.String,
+    }),
+  ),
 })
 
 const SerializedIssues = Schema.Array(SerializedIssue)
@@ -57,6 +63,15 @@ const parseIssues = (
               throw new Error("Invalid Issue creation time")
             }
             new URL(issue.url)
+            for (const dependency of issue.blockedBy) {
+              if (
+                !Number.isSafeInteger(dependency.number) ||
+                dependency.number <= 0
+              ) {
+                throw new Error("Invalid dependency Issue number")
+              }
+              new URL(dependency.url)
+            }
             return { ...issue, createdAt }
           }),
         catch: () => requestError(repository),

--- a/apps/harness/test/keymaxxer-github-layer.test.ts
+++ b/apps/harness/test/keymaxxer-github-layer.test.ts
@@ -40,6 +40,12 @@ describe("Keymaxxer-backed GitHub layer", () => {
               url: "https://github.com/acme/widgets/issues/7",
               createdAt: "2026-07-07T12:00:00.000Z",
               state: "OPEN",
+              blockedBy: [
+                {
+                  number: 3,
+                  url: "https://github.com/acme/widgets/issues/3",
+                },
+              ],
             },
           ]),
           stderr: "",
@@ -66,6 +72,12 @@ describe("Keymaxxer-backed GitHub layer", () => {
     expect(results[0]?.[0]?.createdAt).toEqual(
       new Date("2026-07-07T12:00:00.000Z"),
     )
+    expect(results[0]?.[0]?.blockedBy).toEqual([
+      {
+        number: 3,
+        url: "https://github.com/acme/widgets/issues/3",
+      },
+    ])
     expect(runs).toHaveLength(2)
     expect(tokenChecks).toBe(2)
     expect(tokenAdds).toBe(1)

--- a/packages/db-schema/drizzle/20260713095502_bitter_slayback/migration.sql
+++ b/packages/db-schema/drizzle/20260713095502_bitter_slayback/migration.sql
@@ -1,0 +1,10 @@
+CREATE TABLE `issue_dependency` (
+	`id` text PRIMARY KEY,
+	`issue_id` text NOT NULL,
+	`blocking_github_issue_number` integer NOT NULL,
+	`blocking_github_issue_url` text NOT NULL,
+	`created_at` integer NOT NULL,
+	CONSTRAINT `fk_issue_dependency_issue_id_issue_id_fk` FOREIGN KEY (`issue_id`) REFERENCES `issue`(`id`) ON DELETE CASCADE
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `issue_dependency_issue_id_blocking_url_uidx` ON `issue_dependency` (`issue_id`,`blocking_github_issue_url`);

--- a/packages/db-schema/drizzle/20260713095502_bitter_slayback/snapshot.json
+++ b/packages/db-schema/drizzle/20260713095502_bitter_slayback/snapshot.json
@@ -1,0 +1,656 @@
+{
+  "version": "7",
+  "dialect": "sqlite",
+  "id": "9e006fd8-b2e0-4cd7-8d48-1e2a853c7b4a",
+  "prevIds": [
+    "5faaa6e9-0526-4b02-a252-6265bd4b1fac"
+  ],
+  "ddl": [
+    {
+      "name": "completed_job",
+      "entityType": "tables"
+    },
+    {
+      "name": "config",
+      "entityType": "tables"
+    },
+    {
+      "name": "issue",
+      "entityType": "tables"
+    },
+    {
+      "name": "issue_dependency",
+      "entityType": "tables"
+    },
+    {
+      "name": "job_queue",
+      "entityType": "tables"
+    },
+    {
+      "name": "repository",
+      "entityType": "tables"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "completed_job"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "queue",
+      "entityType": "columns",
+      "table": "completed_job"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "job_id",
+      "entityType": "columns",
+      "table": "completed_job"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "completed_job"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "completed_job"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "'default'",
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "config"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'opencode/deepseek-v4-flash-free'",
+      "generated": null,
+      "name": "default_model",
+      "entityType": "columns",
+      "table": "config"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'low'",
+      "generated": null,
+      "name": "default_variant",
+      "entityType": "columns",
+      "table": "config"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "config"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "config"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "issue"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "repository_id",
+      "entityType": "columns",
+      "table": "issue"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "github_issue_number",
+      "entityType": "columns",
+      "table": "issue"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "title",
+      "entityType": "columns",
+      "table": "issue"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "body",
+      "entityType": "columns",
+      "table": "issue"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "url",
+      "entityType": "columns",
+      "table": "issue"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "state",
+      "entityType": "columns",
+      "table": "issue"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "github_created_at",
+      "entityType": "columns",
+      "table": "issue"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "issue"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "issue"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "issue_dependency"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "issue_id",
+      "entityType": "columns",
+      "table": "issue_dependency"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "blocking_github_issue_number",
+      "entityType": "columns",
+      "table": "issue_dependency"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "blocking_github_issue_url",
+      "entityType": "columns",
+      "table": "issue_dependency"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "issue_dependency"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "job_queue"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "queue",
+      "entityType": "columns",
+      "table": "job_queue"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "job_payload",
+      "entityType": "columns",
+      "table": "job_queue"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "0",
+      "generated": null,
+      "name": "job_attempts",
+      "entityType": "columns",
+      "table": "job_queue"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "5",
+      "generated": null,
+      "name": "job_retry_limit",
+      "entityType": "columns",
+      "table": "job_queue"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "available_at",
+      "entityType": "columns",
+      "table": "job_queue"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "locked_until",
+      "entityType": "columns",
+      "table": "job_queue"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "job_queue"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "job_queue"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "repository"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "github_owner",
+      "entityType": "columns",
+      "table": "repository"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "github_repo",
+      "entityType": "columns",
+      "table": "repository"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "local_path",
+      "entityType": "columns",
+      "table": "repository"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "is_bare",
+      "entityType": "columns",
+      "table": "repository"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "true",
+      "generated": null,
+      "name": "paused",
+      "entityType": "columns",
+      "table": "repository"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "issues_reconciled_at",
+      "entityType": "columns",
+      "table": "repository"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "repository"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "repository"
+    },
+    {
+      "columns": [
+        "repository_id"
+      ],
+      "tableTo": "repository",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_issue_repository_id_repository_id_fk",
+      "entityType": "fks",
+      "table": "issue"
+    },
+    {
+      "columns": [
+        "issue_id"
+      ],
+      "tableTo": "issue",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_issue_dependency_issue_id_issue_id_fk",
+      "entityType": "fks",
+      "table": "issue_dependency"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "completed_job_pk",
+      "table": "completed_job",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "config_pk",
+      "table": "config",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "issue_pk",
+      "table": "issue",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "issue_dependency_pk",
+      "table": "issue_dependency",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "job_queue_pk",
+      "table": "job_queue",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "repository_pk",
+      "table": "repository",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        {
+          "value": "queue",
+          "isExpression": false
+        },
+        {
+          "value": "job_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "origin": "manual",
+      "name": "completed_job_queue_job_id_uidx",
+      "entityType": "indexes",
+      "table": "completed_job"
+    },
+    {
+      "columns": [
+        {
+          "value": "repository_id",
+          "isExpression": false
+        },
+        {
+          "value": "github_issue_number",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "origin": "manual",
+      "name": "issue_repository_id_github_issue_number_uidx",
+      "entityType": "indexes",
+      "table": "issue"
+    },
+    {
+      "columns": [
+        {
+          "value": "issue_id",
+          "isExpression": false
+        },
+        {
+          "value": "blocking_github_issue_url",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "origin": "manual",
+      "name": "issue_dependency_issue_id_blocking_url_uidx",
+      "entityType": "indexes",
+      "table": "issue_dependency"
+    },
+    {
+      "columns": [
+        {
+          "value": "queue",
+          "isExpression": false
+        },
+        {
+          "value": "locked_until",
+          "isExpression": false
+        },
+        {
+          "value": "job_attempts",
+          "isExpression": false
+        },
+        {
+          "value": "available_at",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "job_queue_ready_idx",
+      "entityType": "indexes",
+      "table": "job_queue"
+    },
+    {
+      "columns": [
+        {
+          "value": "lower(\"github_owner\")",
+          "isExpression": true
+        },
+        {
+          "value": "lower(\"github_repo\")",
+          "isExpression": true
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "origin": "manual",
+      "name": "repository_github_owner_repo_lower_uidx",
+      "entityType": "indexes",
+      "table": "repository"
+    },
+    {
+      "columns": [
+        "local_path"
+      ],
+      "nameExplicit": false,
+      "name": "repository_local_path_unique",
+      "entityType": "uniques",
+      "table": "repository"
+    }
+  ],
+  "renames": []
+}

--- a/packages/db-schema/src/schema.ts
+++ b/packages/db-schema/src/schema.ts
@@ -77,6 +77,29 @@ export const issue = snakeCase.table(
   ],
 )
 
+export const issueDependency = snakeCase.table(
+  "issue_dependency",
+  {
+    id: text()
+      .primaryKey()
+      .$defaultFn(() => `issue-dependency-${ulid()}`),
+    issueId: text()
+      .notNull()
+      .references(() => issue.id, { onDelete: "cascade" }),
+    blockingGithubIssueNumber: integer().notNull(),
+    blockingGithubIssueUrl: text().notNull(),
+    createdAt: integer({ mode: "number" })
+      .notNull()
+      .$defaultFn(() => Date.now()),
+  },
+  (t) => [
+    uniqueIndex("issue_dependency_issue_id_blocking_url_uidx").on(
+      t.issueId,
+      t.blockingGithubIssueUrl,
+    ),
+  ],
+)
+
 /**
  * Background job queue (SQS-style visibility timeout semantics).
  * See xplain: type job queue "qjob"

--- a/packages/db-service/src/lib/db-service.ts
+++ b/packages/db-service/src/lib/db-service.ts
@@ -14,6 +14,7 @@ import {
 import type {
   AddRepositoryInput,
   ConfigRecord,
+  IssueDependency,
   IssueRecord,
   RepositoryRecord,
   StoreIssueInput,
@@ -98,6 +99,7 @@ const toIssueRecord = (row: {
   url: string
   state: "OPEN" | "CLOSED"
   githubCreatedAt: number
+  blockedBy: readonly IssueDependency[]
 }): IssueRecord => ({
   id: row.id,
   repositoryId: row.repositoryId,
@@ -107,6 +109,7 @@ const toIssueRecord = (row: {
   url: row.url,
   state: row.state,
   githubCreatedAt: new Date(row.githubCreatedAt),
+  blockedBy: row.blockedBy,
 })
 
 const toDatabaseError = (error: SqlError) =>
@@ -445,12 +448,33 @@ export const DbServiceLive = Layer.effect(
           })
         }
 
+        for (const dependency of input.blockedBy) {
+          if (
+            !Number.isSafeInteger(dependency.githubIssueNumber) ||
+            dependency.githubIssueNumber <= 0
+          ) {
+            return yield* new InvalidIssueInputError({
+              field: "blockedBy",
+              message: "blockedBy issue numbers must be positive integers",
+            })
+          }
+          if (!URL.canParse(dependency.githubIssueUrl)) {
+            return yield* new InvalidIssueInputError({
+              field: "blockedBy",
+              message: "blockedBy issue URLs must be valid URLs",
+            })
+          }
+        }
+
         yield* ensureRepositoryExists(input.repositoryId)
 
         const now = Date.now()
-        const result = yield* sql
-          .unsafe(
-            `INSERT INTO issue (
+        return yield* sql
+          .withTransaction(
+            Effect.gen(function* () {
+              const result = yield* sql
+                .unsafe(
+                  `INSERT INTO issue (
                id, repository_id, github_issue_number, title, body, url, state,
                github_created_at, created_at, updated_at
              ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
@@ -463,49 +487,92 @@ export const DbServiceLive = Layer.effect(
                updated_at = excluded.updated_at
              RETURNING id, repository_id, github_issue_number, title, body, url, state,
                github_created_at`,
-            [
-              `issue-${ulid()}`,
-              input.repositoryId,
-              input.githubIssueNumber,
-              input.title,
-              input.body,
-              input.url,
-              input.state,
-              input.githubCreatedAt.getTime(),
-              now,
-              now,
-            ],
+                  [
+                    `issue-${ulid()}`,
+                    input.repositoryId,
+                    input.githubIssueNumber,
+                    input.title,
+                    input.body,
+                    input.url,
+                    input.state,
+                    input.githubCreatedAt.getTime(),
+                    now,
+                    now,
+                  ],
+                )
+                .pipe(Effect.mapError(toDatabaseError))
+
+              const row = result[0] as
+                | {
+                    id: string
+                    repository_id: string
+                    github_issue_number: number
+                    title: string
+                    body: string
+                    url: string
+                    state: "OPEN" | "CLOSED"
+                    github_created_at: number
+                  }
+                | undefined
+              if (!row) {
+                return yield* new DatabaseError({
+                  message: "No issue returned from upsert",
+                })
+              }
+
+              yield* sql
+                .unsafe("DELETE FROM issue_dependency WHERE issue_id = ?", [
+                  row.id,
+                ])
+                .pipe(Effect.mapError(toDatabaseError))
+              const dependencies = [
+                ...new Map(
+                  input.blockedBy.map((dependency) => [
+                    dependency.githubIssueUrl,
+                    dependency,
+                  ]),
+                ).values(),
+              ].sort(
+                (left, right) =>
+                  left.githubIssueNumber - right.githubIssueNumber ||
+                  left.githubIssueUrl.localeCompare(right.githubIssueUrl),
+              )
+              for (const dependency of dependencies) {
+                yield* sql
+                  .unsafe(
+                    `INSERT INTO issue_dependency (
+                 id, issue_id, blocking_github_issue_number,
+                 blocking_github_issue_url, created_at
+               ) VALUES (?, ?, ?, ?, ?)`,
+                    [
+                      `issue-dependency-${ulid()}`,
+                      row.id,
+                      dependency.githubIssueNumber,
+                      dependency.githubIssueUrl,
+                      now,
+                    ],
+                  )
+                  .pipe(Effect.mapError(toDatabaseError))
+              }
+
+              return toIssueRecord({
+                id: row.id,
+                repositoryId: row.repository_id,
+                githubIssueNumber: row.github_issue_number,
+                title: row.title,
+                body: row.body,
+                url: row.url,
+                state: row.state,
+                githubCreatedAt: row.github_created_at,
+                blockedBy: dependencies,
+              })
+            }),
           )
-          .pipe(Effect.mapError(toDatabaseError))
-
-        const row = result[0] as
-          | {
-              id: string
-              repository_id: string
-              github_issue_number: number
-              title: string
-              body: string
-              url: string
-              state: "OPEN" | "CLOSED"
-              github_created_at: number
-            }
-          | undefined
-        if (!row) {
-          return yield* new DatabaseError({
-            message: "No issue returned from upsert",
-          })
-        }
-
-        return toIssueRecord({
-          id: row.id,
-          repositoryId: row.repository_id,
-          githubIssueNumber: row.github_issue_number,
-          title: row.title,
-          body: row.body,
-          url: row.url,
-          state: row.state,
-          githubCreatedAt: row.github_created_at,
-        })
+          .pipe(
+            Effect.mapError((error) =>
+              error instanceof DatabaseError ? error : toDatabaseError(error),
+            ),
+          )
       })
 
     const listIssues = (
@@ -525,6 +592,32 @@ export const DbServiceLive = Layer.effect(
             [repositoryId],
           )
           .pipe(Effect.mapError(toDatabaseError))
+
+        const dependencies = yield* sql
+          .unsafe(
+            `SELECT d.issue_id, d.blocking_github_issue_number,
+               d.blocking_github_issue_url
+             FROM issue_dependency d
+             INNER JOIN issue i ON i.id = d.issue_id
+             WHERE i.repository_id = ?
+             ORDER BY d.blocking_github_issue_number ASC,
+               d.blocking_github_issue_url ASC`,
+            [repositoryId],
+          )
+          .pipe(Effect.mapError(toDatabaseError))
+        const dependenciesByIssue = new Map<string, IssueDependency[]>()
+        for (const dependency of dependencies as ReadonlyArray<{
+          issue_id: string
+          blocking_github_issue_number: number
+          blocking_github_issue_url: string
+        }>) {
+          const records = dependenciesByIssue.get(dependency.issue_id) ?? []
+          records.push({
+            githubIssueNumber: dependency.blocking_github_issue_number,
+            githubIssueUrl: dependency.blocking_github_issue_url,
+          })
+          dependenciesByIssue.set(dependency.issue_id, records)
+        }
 
         return (
           issues as ReadonlyArray<{
@@ -547,6 +640,7 @@ export const DbServiceLive = Layer.effect(
             url: issue.url,
             state: issue.state,
             githubCreatedAt: issue.github_created_at,
+            blockedBy: dependenciesByIssue.get(issue.id) ?? [],
           }),
         )
       })
@@ -557,6 +651,16 @@ export const DbServiceLive = Layer.effect(
     ): Effect.Effect<void, RepositoryNotFoundError | DatabaseError> =>
       Effect.gen(function* () {
         yield* ensureRepositoryExists(repositoryId)
+        yield* sql
+          .unsafe(
+            `DELETE FROM issue_dependency
+             WHERE issue_id IN (
+               SELECT id FROM issue
+               WHERE repository_id = ? AND github_issue_number = ?
+             )`,
+            [repositoryId, githubIssueNumber],
+          )
+          .pipe(Effect.mapError(toDatabaseError))
         yield* sql
           .unsafe(
             `DELETE FROM issue

--- a/packages/db-service/src/lib/errors.ts
+++ b/packages/db-service/src/lib/errors.ts
@@ -35,6 +35,7 @@ export class InvalidIssueInputError extends Data.TaggedError(
     | "url"
     | "state"
     | "githubCreatedAt"
+    | "blockedBy"
   readonly message: string
 }> {}
 

--- a/packages/db-service/src/lib/types.ts
+++ b/packages/db-service/src/lib/types.ts
@@ -33,6 +33,7 @@ export interface StoreIssueInput {
   readonly url: string
   readonly state: IssueState
   readonly githubCreatedAt: Date
+  readonly blockedBy: readonly IssueDependency[]
 }
 
 export type IssueState = "OPEN" | "CLOSED"
@@ -46,4 +47,10 @@ export interface IssueRecord {
   readonly url: string
   readonly state: IssueState
   readonly githubCreatedAt: Date
+  readonly blockedBy: readonly IssueDependency[]
+}
+
+export interface IssueDependency {
+  readonly githubIssueNumber: number
+  readonly githubIssueUrl: string
 }

--- a/packages/db-service/test/db-service.spec.ts
+++ b/packages/db-service/test/db-service.spec.ts
@@ -2,6 +2,7 @@ import { Effect, Layer } from "effect"
 import { SqlClient } from "effect/unstable/sql"
 import { DatabaseTest } from "@ready-for-agent/db/test"
 import {
+  DatabaseError,
   DbService,
   DbServiceLive,
   InvalidConfigInputError,
@@ -33,6 +34,7 @@ describe("DbService", () => {
     body: "Issue body",
     url: "https://github.com/acme/widgets/issues/42",
     state: "OPEN" as const,
+    blockedBy: [],
   }
 
   describe("config", () => {
@@ -279,6 +281,101 @@ describe("DbService", () => {
             new Date("2026-07-02T12:00:00.000Z"),
           )
           expect(yield* db.listIssues(repository.id)).toHaveLength(1)
+        }),
+      ))
+
+    it("replaces and lists an issue's blocking dependencies", () =>
+      runTest(
+        Effect.gen(function* () {
+          const db = yield* DbService
+          const repository = yield* addTestRepository(db)
+          const baseInput = {
+            repositoryId: repository.id,
+            githubIssueNumber: 42,
+            title: "Blocked issue",
+            ...sampleIssueFields,
+            githubCreatedAt: new Date("2026-07-01T12:00:00.000Z"),
+          }
+          yield* db.storeIssue({
+            ...baseInput,
+            blockedBy: [
+              {
+                githubIssueNumber: 9,
+                githubIssueUrl: "https://github.com/other/project/issues/9",
+              },
+              {
+                githubIssueNumber: 3,
+                githubIssueUrl: "https://github.com/acme/widgets/issues/3",
+              },
+            ],
+          })
+
+          const stored = yield* db.storeIssue({
+            ...baseInput,
+            blockedBy: [
+              {
+                githubIssueNumber: 5,
+                githubIssueUrl: "https://github.com/acme/widgets/issues/5",
+              },
+            ],
+          })
+
+          expect(stored.blockedBy).toEqual([
+            {
+              githubIssueNumber: 5,
+              githubIssueUrl: "https://github.com/acme/widgets/issues/5",
+            },
+          ])
+          expect((yield* db.listIssues(repository.id))[0]?.blockedBy).toEqual(
+            stored.blockedBy,
+          )
+        }),
+      ))
+
+    it("rolls back the issue and dependencies when replacement fails", () =>
+      runTest(
+        Effect.gen(function* () {
+          const db = yield* DbService
+          const sql = yield* SqlClient.SqlClient
+          const repository = yield* addTestRepository(db)
+          const original = yield* db.storeIssue({
+            repositoryId: repository.id,
+            githubIssueNumber: 42,
+            title: "Original title",
+            ...sampleIssueFields,
+            githubCreatedAt: new Date("2026-07-01T12:00:00.000Z"),
+            blockedBy: [
+              {
+                githubIssueNumber: 3,
+                githubIssueUrl: "https://github.com/acme/widgets/issues/3",
+              },
+            ],
+          })
+          yield* sql.unsafe(`CREATE TRIGGER fail_dependency_insert
+            BEFORE INSERT ON issue_dependency
+            WHEN NEW.blocking_github_issue_number = 5
+            BEGIN
+              SELECT RAISE(ABORT, 'forced dependency insert failure');
+            END`)
+
+          const error = yield* Effect.flip(
+            db.storeIssue({
+              repositoryId: repository.id,
+              githubIssueNumber: 42,
+              title: "Updated title",
+              ...sampleIssueFields,
+              githubCreatedAt: new Date("2026-07-02T12:00:00.000Z"),
+              blockedBy: [
+                {
+                  githubIssueNumber: 5,
+                  githubIssueUrl: "https://github.com/acme/widgets/issues/5",
+                },
+              ],
+            }),
+          )
+
+          expect(error).toBeInstanceOf(DatabaseError)
+          expect(yield* db.listIssues(repository.id)).toEqual([original])
         }),
       ))
 

--- a/packages/github-service/github.graphql
+++ b/packages/github-service/github.graphql
@@ -11,6 +11,7 @@ type Query {
 
 type Repository {
   issues(first: Int, after: String, labels: [String!]): IssueConnection!
+  issue(number: Int!): Issue
 }
 
 type IssueConnection {
@@ -30,6 +31,7 @@ type Issue {
   url: URI!
   createdAt: DateTime!
   state: IssueState!
+  blockedBy(first: Int, after: String): IssueConnection!
 }
 
 enum IssueState {

--- a/packages/github-service/src/internal/generated/schema.graphql
+++ b/packages/github-service/src/internal/generated/schema.graphql
@@ -8,6 +8,7 @@ type Query {
 
 type Repository {
   issues(first: Int, after: String, labels: [String!]): IssueConnection!
+  issue(number: Int!): Issue
 }
 
 type IssueConnection {
@@ -27,6 +28,7 @@ type Issue {
   url: URI!
   createdAt: DateTime!
   state: IssueState!
+  blockedBy(first: Int, after: String): IssueConnection!
 }
 
 enum IssueState {

--- a/packages/github-service/src/internal/generated/schema.ts
+++ b/packages/github-service/src/internal/generated/schema.ts
@@ -18,6 +18,7 @@ export interface Query {
 
 export interface Repository {
     issues: IssueConnection
+    issue: (Issue | null)
     __typename: 'Repository'
 }
 
@@ -40,6 +41,7 @@ export interface Issue {
     url: Scalars['URI']
     createdAt: Scalars['DateTime']
     state: IssueState
+    blockedBy: IssueConnection
     __typename: 'Issue'
 }
 
@@ -53,6 +55,7 @@ export interface QueryGenqlSelection{
 
 export interface RepositoryGenqlSelection{
     issues?: (IssueConnectionGenqlSelection & { __args?: {first?: (Scalars['Int'] | null), after?: (Scalars['String'] | null), labels?: (Scalars['String'][] | null)} })
+    issue?: (IssueGenqlSelection & { __args: {number: Scalars['Int']} })
     __typename?: boolean | number
     __scalar?: boolean | number
 }
@@ -78,6 +81,7 @@ export interface IssueGenqlSelection{
     url?: boolean | number
     createdAt?: boolean | number
     state?: boolean | number
+    blockedBy?: (IssueConnectionGenqlSelection & { __args?: {first?: (Scalars['Int'] | null), after?: (Scalars['String'] | null)} })
     __typename?: boolean | number
     __scalar?: boolean | number
 }

--- a/packages/github-service/src/internal/generated/types.ts
+++ b/packages/github-service/src/internal/generated/types.ts
@@ -45,6 +45,15 @@ export default {
                     ]
                 }
             ],
+            "issue": [
+                9,
+                {
+                    "number": [
+                        5,
+                        "Int!"
+                    ]
+                }
+            ],
             "__typename": [
                 3
             ]
@@ -91,6 +100,17 @@ export default {
             ],
             "state": [
                 10
+            ],
+            "blockedBy": [
+                6,
+                {
+                    "first": [
+                        5
+                    ],
+                    "after": [
+                        3
+                    ]
+                }
             ],
             "__typename": [
                 3

--- a/packages/github-service/src/lib/github-service-live.ts
+++ b/packages/github-service/src/lib/github-service-live.ts
@@ -5,7 +5,7 @@ import {
   GitHubRequestError,
 } from "./errors.js"
 import { GitHubService, type GitHubServiceShape } from "./github-service.js"
-import type { ReadyLabeledIssue } from "./types.js"
+import type { GitHubIssueReference, ReadyLabeledIssue } from "./types.js"
 
 const GITHUB_GRAPHQL_URL = "https://api.github.com/graphql"
 const READY_FOR_AGENT_LABEL = "ready-for-agent"
@@ -20,7 +20,46 @@ interface GitHubApiIssue {
   readonly url: unknown
   readonly createdAt: unknown
   readonly state: unknown
+  readonly blockedBy: GitHubApiIssueConnection
 }
+
+interface GitHubApiIssueConnection {
+  readonly nodes: readonly (GitHubApiIssueReference | null)[] | null
+  readonly pageInfo: {
+    readonly endCursor: string | null
+    readonly hasNextPage: boolean
+  }
+}
+
+interface GitHubApiIssueReference {
+  readonly number: unknown
+  readonly url: unknown
+}
+
+const toIssueReference = (
+  issue: GitHubApiIssueReference,
+): GitHubIssueReference => {
+  if (!Number.isSafeInteger(issue.number) || Number(issue.number) <= 0) {
+    throw new Error(`Invalid GitHub dependency issue number: ${issue.number}`)
+  }
+  if (typeof issue.url !== "string") {
+    throw new Error(`Invalid GitHub dependency issue URL: ${issue.url}`)
+  }
+  try {
+    new URL(issue.url)
+  } catch {
+    throw new Error(`Invalid GitHub dependency issue URL: ${issue.url}`)
+  }
+
+  return { number: Number(issue.number), url: issue.url }
+}
+
+const mapBlockedByPage = (
+  connection: GitHubApiIssueConnection,
+): readonly GitHubIssueReference[] =>
+  (connection.nodes ?? [])
+    .filter((issue) => issue !== null)
+    .map(toIssueReference)
 
 const toReadyLabeledIssue = (issue: GitHubApiIssue): ReadyLabeledIssue => {
   if (!Number.isSafeInteger(issue.number) || Number(issue.number) <= 0) {
@@ -55,8 +94,21 @@ const toReadyLabeledIssue = (issue: GitHubApiIssue): ReadyLabeledIssue => {
     url: issue.url,
     createdAt,
     state: issue.state,
+    blockedBy: mapBlockedByPage(issue.blockedBy),
   }
 }
+
+const sortDependencies = (
+  dependencies: readonly GitHubIssueReference[],
+): readonly GitHubIssueReference[] =>
+  [
+    ...new Map(
+      dependencies.map((dependency) => [dependency.url, dependency]),
+    ).values(),
+  ].sort(
+    (left, right) =>
+      left.number - right.number || left.url.localeCompare(right.url),
+  )
 
 export const makeGitHubService = (
   client: GitHubGraphqlClient,
@@ -85,6 +137,11 @@ export const makeGitHubService = (
                     url: true,
                     createdAt: true,
                     state: true,
+                    blockedBy: {
+                      __args: { first: PAGE_SIZE },
+                      nodes: { number: true, url: true },
+                      pageInfo: { endCursor: true, hasNextPage: true },
+                    },
                   },
                   pageInfo: {
                     endCursor: true,
@@ -104,21 +161,81 @@ export const makeGitHubService = (
           return yield* new GitHubRepositoryUnavailableError(repository)
         }
 
-        const mappedIssues = yield* Effect.try({
-          try: () =>
-            (
-              (result.repository.issues.nodes ??
-                []) as readonly (GitHubApiIssue | null)[]
-            )
-              .filter((issue) => issue !== null)
-              .map(toReadyLabeledIssue),
-          catch: (cause) =>
-            new GitHubRequestError({
-              message: `GitHub returned invalid Issue data for ${repository.owner}/${repository.name}`,
-              cause,
-            }),
-        })
-        issues.push(...mappedIssues)
+        const issueNodes = (result.repository.issues.nodes ??
+          []) as readonly (GitHubApiIssue | null)[]
+        for (const issueNode of issueNodes) {
+          if (issueNode === null) continue
+
+          const mappedIssue = yield* Effect.try({
+            try: () => toReadyLabeledIssue(issueNode),
+            catch: (cause) =>
+              new GitHubRequestError({
+                message: `GitHub returned invalid Issue data for ${repository.owner}/${repository.name}`,
+                cause,
+              }),
+          })
+          const blockedBy = [...mappedIssue.blockedBy]
+          let blockedByPage = issueNode.blockedBy.pageInfo
+
+          while (blockedByPage.hasNextPage) {
+            if (blockedByPage.endCursor === null) {
+              return yield* new GitHubRequestError({
+                message: `GitHub omitted the dependency page cursor for ${repository.owner}/${repository.name}#${mappedIssue.number}`,
+              })
+            }
+
+            const dependencyResult = yield* Effect.tryPromise({
+              try: () =>
+                client.query({
+                  repository: {
+                    __args: repository,
+                    issue: {
+                      __args: { number: mappedIssue.number },
+                      blockedBy: {
+                        __args: {
+                          first: PAGE_SIZE,
+                          after: blockedByPage.endCursor,
+                        },
+                        nodes: { number: true, url: true },
+                        pageInfo: { endCursor: true, hasNextPage: true },
+                      },
+                    },
+                  },
+                }),
+              catch: (cause) =>
+                new GitHubRequestError({
+                  message: `Failed to list dependencies for ${repository.owner}/${repository.name}#${mappedIssue.number}`,
+                  cause,
+                }),
+            })
+            if (dependencyResult.repository === null) {
+              return yield* new GitHubRepositoryUnavailableError(repository)
+            }
+            if (dependencyResult.repository.issue === null) {
+              return yield* new GitHubRequestError({
+                message: `GitHub could not find Issue ${repository.owner}/${repository.name}#${mappedIssue.number} while listing dependencies`,
+              })
+            }
+
+            const connection = dependencyResult.repository.issue
+              .blockedBy as GitHubApiIssueConnection
+            const pageDependencies = yield* Effect.try({
+              try: () => mapBlockedByPage(connection),
+              catch: (cause) =>
+                new GitHubRequestError({
+                  message: `GitHub returned invalid dependency data for ${repository.owner}/${repository.name}#${mappedIssue.number}`,
+                  cause,
+                }),
+            })
+            blockedBy.push(...pageDependencies)
+            blockedByPage = connection.pageInfo
+          }
+
+          issues.push({
+            ...mappedIssue,
+            blockedBy: sortDependencies(blockedBy),
+          })
+        }
 
         const { endCursor, hasNextPage } = result.repository.issues.pageInfo
         if (!hasNextPage) {

--- a/packages/github-service/src/lib/types.ts
+++ b/packages/github-service/src/lib/types.ts
@@ -5,6 +5,11 @@ export interface GitHubRepository {
 
 export type GitHubIssueState = "OPEN" | "CLOSED"
 
+export interface GitHubIssueReference {
+  readonly number: number
+  readonly url: string
+}
+
 export interface ReadyLabeledIssue {
   readonly number: number
   readonly title: string
@@ -12,4 +17,5 @@ export interface ReadyLabeledIssue {
   readonly url: string
   readonly createdAt: Date
   readonly state: GitHubIssueState
+  readonly blockedBy: readonly GitHubIssueReference[]
 }

--- a/packages/github-service/test/github-service.spec.ts
+++ b/packages/github-service/test/github-service.spec.ts
@@ -24,6 +24,7 @@ const issue = (
   url: `https://github.com/acme/widgets/issues/${number}`,
   createdAt: new Date(`2026-07-${String(number).padStart(2, "0")}T12:00:00Z`),
   state,
+  blockedBy: [],
 })
 
 describe("GitHubService live implementation", () => {
@@ -41,6 +42,15 @@ describe("GitHubService live implementation", () => {
                 url: "https://github.com/acme/widgets/issues/9",
                 createdAt: "2026-07-09T12:00:00Z",
                 state: "OPEN",
+                blockedBy: {
+                  nodes: [
+                    {
+                      number: 3,
+                      url: "https://github.com/acme/widgets/issues/3",
+                    },
+                  ],
+                  pageInfo: { endCursor: null, hasNextPage: false },
+                },
               },
             ],
             pageInfo: { endCursor: "page-2", hasNextPage: true },
@@ -59,6 +69,10 @@ describe("GitHubService live implementation", () => {
                 url: "https://github.com/acme/widgets/issues/2",
                 createdAt: "2026-07-02T12:00:00Z",
                 state: "CLOSED",
+                blockedBy: {
+                  nodes: [],
+                  pageInfo: { endCursor: null, hasNextPage: false },
+                },
               },
             ],
             pageInfo: { endCursor: null, hasNextPage: false },
@@ -85,7 +99,14 @@ describe("GitHubService live implementation", () => {
       url: "https://github.com/acme/widgets/issues/2",
       createdAt: new Date("2026-07-02T12:00:00Z"),
       state: "CLOSED",
+      blockedBy: [],
     })
+    expect(result[1]?.blockedBy).toEqual([
+      {
+        number: 3,
+        url: "https://github.com/acme/widgets/issues/3",
+      },
+    ])
     expect(requests).toHaveLength(2)
 
     const firstRequest = requests[0] as {
@@ -110,10 +131,91 @@ describe("GitHubService live implementation", () => {
       url: true,
       createdAt: true,
       state: true,
+      blockedBy: {
+        __args: { first: 100 },
+        nodes: { number: true, url: true },
+        pageInfo: { endCursor: true, hasNextPage: true },
+      },
     })
 
     const secondRequest = requests[1] as typeof firstRequest
     expect(secondRequest.repository.issues.__args.after).toBe("page-2")
+  })
+
+  it("fetches additional dependency pages only when needed", async () => {
+    const requests: unknown[] = []
+    const responses = [
+      {
+        repository: {
+          issues: {
+            nodes: [
+              {
+                number: 7,
+                title: "Blocked issue",
+                body: "Body",
+                url: "https://github.com/acme/widgets/issues/7",
+                createdAt: "2026-07-07T12:00:00Z",
+                state: "OPEN",
+                blockedBy: {
+                  nodes: [
+                    {
+                      number: 5,
+                      url: "https://github.com/acme/widgets/issues/5",
+                    },
+                  ],
+                  pageInfo: {
+                    endCursor: "dependency-page-2",
+                    hasNextPage: true,
+                  },
+                },
+              },
+            ],
+            pageInfo: { endCursor: null, hasNextPage: false },
+          },
+        },
+      },
+      {
+        repository: {
+          issue: {
+            blockedBy: {
+              nodes: [
+                {
+                  number: 2,
+                  url: "https://github.com/acme/widgets/issues/2",
+                },
+              ],
+              pageInfo: { endCursor: null, hasNextPage: false },
+            },
+          },
+        },
+      },
+    ]
+    const client = {
+      query: async (request: unknown) => {
+        requests.push(request)
+        return responses.shift()
+      },
+    } as GitHubGraphqlClient
+
+    const result = await Effect.runPromise(
+      makeGitHubService(client).listReadyIssues(repository),
+    )
+
+    expect(result[0]?.blockedBy.map(({ number }) => number)).toEqual([2, 5])
+    expect(requests).toHaveLength(2)
+    const dependencyRequest = requests[1] as {
+      repository: {
+        issue: {
+          __args: { number: number }
+          blockedBy: { __args: { first: number; after: string } }
+        }
+      }
+    }
+    expect(dependencyRequest.repository.issue.__args).toEqual({ number: 7 })
+    expect(dependencyRequest.repository.issue.blockedBy.__args).toEqual({
+      first: 100,
+      after: "dependency-page-2",
+    })
   })
 
   it("fails when the Repository is missing or inaccessible", async () => {
@@ -163,6 +265,10 @@ describe("GitHubService live implementation", () => {
                 url: "not-a-url",
                 createdAt: "2026-07-01T12:00:00Z",
                 state: "OPEN",
+                blockedBy: {
+                  nodes: [],
+                  pageInfo: { endCursor: null, hasNextPage: false },
+                },
               },
             ],
             pageInfo: { endCursor: null, hasNextPage: false },

--- a/packages/graphql-api/test/graphql-api.test.ts
+++ b/packages/graphql-api/test/graphql-api.test.ts
@@ -31,6 +31,7 @@ const issue = {
   url: "https://github.com/acme/widgets/issues/42",
   state: "OPEN" as const,
   githubCreatedAt: new Date("2026-07-12T10:30:00.000Z"),
+  blockedBy: [],
 }
 
 const makeRuntime = (
@@ -206,7 +207,13 @@ describe("GraphQL API", () => {
       data: {
         issues: [
           {
-            ...issue,
+            id: issue.id,
+            repositoryId: issue.repositoryId,
+            githubIssueNumber: issue.githubIssueNumber,
+            title: issue.title,
+            body: issue.body,
+            url: issue.url,
+            state: issue.state,
             githubCreatedAt: issue.githubCreatedAt.toISOString(),
           },
         ],

--- a/packages/issue-reconciler/src/lib/issue-reconciler.ts
+++ b/packages/issue-reconciler/src/lib/issue-reconciler.ts
@@ -60,7 +60,15 @@ const matches = (local: IssueRecord, remote: ReadyLabeledIssue): boolean =>
   local.body === remote.body &&
   local.url === remote.url &&
   local.state === remote.state &&
-  local.githubCreatedAt.getTime() === remote.createdAt.getTime()
+  local.githubCreatedAt.getTime() === remote.createdAt.getTime() &&
+  local.blockedBy.length === remote.blockedBy.length &&
+  local.blockedBy.every((dependency) =>
+    remote.blockedBy.some(
+      (remoteDependency) =>
+        dependency.githubIssueNumber === remoteDependency.number &&
+        dependency.githubIssueUrl === remoteDependency.url,
+    ),
+  )
 
 export const IssueReconcilerLive = Layer.effect(
   IssueReconciler,
@@ -132,6 +140,10 @@ export const IssueReconcilerLive = Layer.effect(
             url: issue.url,
             state: issue.state,
             githubCreatedAt: issue.createdAt,
+            blockedBy: issue.blockedBy.map((dependency) => ({
+              githubIssueNumber: dependency.number,
+              githubIssueUrl: dependency.url,
+            })),
           })
           .pipe(
             Effect.mapError((cause) =>

--- a/packages/issue-reconciler/test/issue-reconciler.spec.ts
+++ b/packages/issue-reconciler/test/issue-reconciler.spec.ts
@@ -41,6 +41,7 @@ const remoteIssue = (
     `2026-07-${String(number).padStart(2, "0")}T00:00:00.000Z`,
   ),
   state: "OPEN",
+  blockedBy: [],
   ...overrides,
 })
 
@@ -58,6 +59,10 @@ const localIssue = (
     url: remote.url,
     githubCreatedAt: remote.createdAt,
     state: remote.state,
+    blockedBy: remote.blockedBy.map((dependency) => ({
+      githubIssueNumber: dependency.number,
+      githubIssueUrl: dependency.url,
+    })),
     ...overrides,
   }
 }
@@ -167,7 +172,19 @@ describe("IssueReconciler", () => {
       ],
     })
     const github = makeGitHubLayer(
-      [remoteIssue(3), remoteIssue(2, { state: "CLOSED" }), remoteIssue(1)],
+      [
+        remoteIssue(3),
+        remoteIssue(2, {
+          state: "CLOSED",
+          blockedBy: [
+            {
+              number: 1,
+              url: "https://github.com/acme/widgets/issues/1",
+            },
+          ],
+        }),
+        remoteIssue(1),
+      ],
       db.actions,
     )
 
@@ -206,6 +223,14 @@ describe("IssueReconciler", () => {
           { githubIssueNumber: 3, state: "OPEN" },
         ])
         expect(db.reconciledAt).toBeInstanceOf(Date)
+        expect(
+          db.stored.find((issue) => issue.githubIssueNumber === 2)?.blockedBy,
+        ).toEqual([
+          {
+            githubIssueNumber: 1,
+            githubIssueUrl: "https://github.com/acme/widgets/issues/1",
+          },
+        ])
       }),
       db.layer,
       github,
@@ -232,6 +257,40 @@ describe("IssueReconciler", () => {
       }),
       db.layer,
       makeGitHubLayer([], db.actions),
+    )
+  })
+
+  it("updates an otherwise unchanged issue when its dependencies change", () => {
+    const db = makeDbFixture({ issues: [localIssue(1)] })
+    const github = makeGitHubLayer(
+      [
+        remoteIssue(1, {
+          blockedBy: [
+            {
+              number: 2,
+              url: "https://github.com/acme/widgets/issues/2",
+            },
+          ],
+        }),
+      ],
+      db.actions,
+    )
+
+    return runReconciliation(
+      Effect.gen(function* () {
+        const reconciler = yield* IssueReconciler
+        const summary = yield* reconciler.reconcile(repository)
+
+        expect(summary.updated).toBe(1)
+        expect(db.actions).toEqual([
+          "list",
+          "github:acme/widgets",
+          "store:1",
+          "mark",
+        ])
+      }),
+      db.layer,
+      github,
     )
   })
 


### PR DESCRIPTION
## Why

The local Ready-labeled issue projection did not include GitHub's native issue dependencies. That meant reconciliation could not preserve which issues are blocked, and downstream agent selection could treat blocked work as available.

## What Changed

- Fetch each Ready issue's `blockedBy` connection in the existing GitHub GraphQL traversal, with follow-up pagination only when an issue has more than 100 dependencies.
- Store dependency references in a normalized `issue_dependency` table using the blocking issue number and URL so cross-repository blockers remain unambiguous.
- Reconcile dependency-only changes and atomically replace issue fields and dependency edges in one database transaction.
- Carry dependency data through the Keymaxxer-backed GitHub adapter and generated client.
- Add coverage for GraphQL dependency pagination, persistence and replacement, dependency-only reconciliation, and transaction rollback on replacement failure.

## Verification

- A live read-only query against `berenddeboer/ready-for-agent` confirmed GitHub accepts the generated `blockedBy` selection.
- A forced SQLite dependency-insert failure confirms the previous issue fields and dependency edges are rolled back together.
