### PR TITLE
feat(harness): show configured OpenCode models

### DIFF
--- a/apps/harness/package.json
+++ b/apps/harness/package.json
@@ -11,6 +11,7 @@
     "typecheck": "tsc --noEmit -p tsconfig.app.json"
   },
   "dependencies": {
+    "@effect/platform-bun": "^4.0.0-beta.97",
     "@ready-for-agent/db": "workspace:*",
     "@ready-for-agent/db-service": "workspace:*",
     "@ready-for-agent/github-service": "workspace:*",
@@ -18,6 +19,7 @@
     "@ready-for-agent/graphql-client": "workspace:*",
     "@ready-for-agent/issue-reconciler": "workspace:*",
     "@ready-for-agent/keymaxxer-service": "workspace:*",
+    "@ready-for-agent/opencode": "workspace:*",
     "@tanstack/react-query": "^5.90.0",
     "@tanstack/react-query-devtools": "^5.90.0",
     "@tanstack/react-router": "^1.170.17",

--- a/apps/harness/src/routes/__root.tsx
+++ b/apps/harness/src/routes/__root.tsx
@@ -42,6 +42,14 @@ const configQuery = {
   },
 }
 
+const modelsQuery = {
+  queryKey: ["models"],
+  queryFn: async () => {
+    const result = await graphql.query({ models: true })
+    return result.models
+  },
+}
+
 export const Route = createRootRouteWithContext<RouterContext>()({
   head: () => ({
     meta: [
@@ -103,6 +111,7 @@ function SettingsButton() {
   const dialogRef = useRef<HTMLDialogElement>(null)
   const queryClient = useQueryClient()
   const config = useQuery(configQuery)
+  const models = useQuery(modelsQuery)
   const [defaultModel, setDefaultModel] = useState("")
   const [defaultVariant, setDefaultVariant] = useState("low")
   useEffect(() => {
@@ -130,6 +139,9 @@ function SettingsButton() {
     if (config.isError) {
       void config.refetch()
     }
+    if (models.isError) {
+      void models.refetch()
+    }
     if (config.data) {
       setDefaultModel(config.data.defaultModel)
       setDefaultVariant(config.data.defaultVariant)
@@ -144,6 +156,8 @@ function SettingsButton() {
   }
 
   const standardVariants = ["low", "medium", "high", "max"]
+  const hasUnavailableModel =
+    defaultModel.length > 0 && !models.data?.includes(defaultModel)
   const hasCustomVariant = !standardVariants.includes(defaultVariant)
 
   return (
@@ -190,9 +204,9 @@ function SettingsButton() {
           </div>
 
           <div className="grid gap-5 px-6 py-5">
-            {config.isPending ? (
+            {config.isPending || models.isPending ? (
               <p className="text-sm text-slate-500">Loading settings...</p>
-            ) : config.isError ? (
+            ) : config.isError || models.isError ? (
               <p className="rounded-lg bg-red-50 p-3 text-sm text-red-700">
                 Settings could not be loaded. Close this dialog and try again.
               </p>
@@ -200,16 +214,24 @@ function SettingsButton() {
               <>
                 <label className="grid gap-1.5 text-sm font-semibold">
                   Default model
-                  <input
-                    className="rounded-lg border border-slate-300 px-3 py-2 font-mono text-sm font-normal outline-none focus:border-blue-500 focus:ring-2 focus:ring-blue-100"
+                  <select
+                    className="rounded-lg border border-slate-300 bg-white px-3 py-2 font-mono text-sm font-normal outline-none focus:border-blue-500 focus:ring-2 focus:ring-blue-100"
                     name="defaultModel"
                     value={defaultModel}
                     onChange={(event) => setDefaultModel(event.target.value)}
-                    placeholder="provider/model-name"
                     required
-                  />
+                  >
+                    {hasUnavailableModel && (
+                      <option value={defaultModel}>{defaultModel}</option>
+                    )}
+                    {models.data.map((model) => (
+                      <option key={model} value={model}>
+                        {model}
+                      </option>
+                    ))}
+                  </select>
                   <span className="text-xs font-normal text-slate-500">
-                    Use the OpenCode provider/model identifier.
+                    Models available from OpenCode.
                   </span>
                 </label>
 
@@ -259,7 +281,11 @@ function SettingsButton() {
               type="submit"
               className="rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-50"
               disabled={
-                config.isPending || config.isError || updateConfig.isPending
+                config.isPending ||
+                config.isError ||
+                models.isPending ||
+                models.isError ||
+                updateConfig.isPending
               }
             >
               {updateConfig.isPending ? "Saving..." : "Save settings"}

--- a/apps/harness/src/server/application.server.ts
+++ b/apps/harness/src/server/application.server.ts
@@ -1,5 +1,6 @@
 import "@tanstack/react-start/server-only"
 import { fileURLToPath } from "node:url"
+import { BunServices } from "@effect/platform-bun"
 import { Effect, Layer, ManagedRuntime } from "effect"
 import { DatabaseLive } from "@ready-for-agent/db"
 import { DbServiceLive } from "@ready-for-agent/db-service"
@@ -10,6 +11,7 @@ import {
   mcpKeymaxxerLayer,
   sidecarKeymaxxerLayer,
 } from "@ready-for-agent/keymaxxer-service"
+import { OpencodeLive } from "@ready-for-agent/opencode"
 import type { ApplicationRequestContext } from "../server-context.js"
 import { keymaxxerGitHubLayer } from "./keymaxxer-github-layer.js"
 
@@ -41,7 +43,12 @@ export const createApplication = async (
     Layer.provideMerge(databaseLayer),
     Layer.provideMerge(githubLayer),
   )
-  const appLayer = Layer.merge(reconcilerLayer, keymaxxerLayer)
+  const opencodeLayer = OpencodeLive.pipe(Layer.provide(BunServices.layer))
+  const appLayer = Layer.mergeAll(
+    reconcilerLayer,
+    keymaxxerLayer,
+    opencodeLayer,
+  )
   const runtime = ManagedRuntime.make(appLayer)
 
   try {
@@ -58,7 +65,7 @@ export const createApplication = async (
 
   return {
     context: {
-      graphqlApi: createGraphqlApi(runtime),
+      graphqlApi: createGraphqlApi(runtime, { opencodeCwd: workspaceRoot }),
     },
     dispose: runtime.dispose,
   }

--- a/apps/harness/src/server/application.server.ts
+++ b/apps/harness/src/server/application.server.ts
@@ -1,6 +1,8 @@
 import "@tanstack/react-start/server-only"
 import { fileURLToPath } from "node:url"
-import { BunServices } from "@effect/platform-bun"
+import * as BunChildProcessSpawner from "@effect/platform-bun/BunChildProcessSpawner"
+import * as BunFileSystem from "@effect/platform-bun/BunFileSystem"
+import * as BunPath from "@effect/platform-bun/BunPath"
 import { Effect, Layer, ManagedRuntime } from "effect"
 import { DatabaseLive } from "@ready-for-agent/db"
 import { DbServiceLive } from "@ready-for-agent/db-service"
@@ -43,7 +45,10 @@ export const createApplication = async (
     Layer.provideMerge(databaseLayer),
     Layer.provideMerge(githubLayer),
   )
-  const opencodeLayer = OpencodeLive.pipe(Layer.provide(BunServices.layer))
+  const opencodePlatformLayer = BunChildProcessSpawner.layer.pipe(
+    Layer.provideMerge(Layer.merge(BunFileSystem.layer, BunPath.layer)),
+  )
+  const opencodeLayer = OpencodeLive.pipe(Layer.provide(opencodePlatformLayer))
   const appLayer = Layer.mergeAll(
     reconcilerLayer,
     keymaxxerLayer,

--- a/apps/harness/test/topology.test.ts
+++ b/apps/harness/test/topology.test.ts
@@ -52,4 +52,13 @@ describe("single application server topology", () => {
     expect(viteConfig).not.toContain("3001")
     expect(viteConfig).not.toContain("proxy")
   })
+
+  test("does not load the Bun platform barrel during Node SSR", async () => {
+    const applicationServer = await readFile(
+      new URL("../src/server/application.server.ts", import.meta.url),
+      "utf8",
+    )
+
+    expect(applicationServer).not.toContain('from "@effect/platform-bun"')
+  })
 })

--- a/apps/harness/tsconfig.app.json
+++ b/apps/harness/tsconfig.app.json
@@ -17,7 +17,13 @@
   "include": ["server.ts", "src/**/*.ts", "src/**/*.tsx"],
   "references": [
     {
+      "path": "../../packages/opencode/tsconfig.lib.json"
+    },
+    {
       "path": "../../packages/keymaxxer-service/tsconfig.lib.json"
+    },
+    {
+      "path": "../../packages/issue-reconciler/tsconfig.lib.json"
     },
     {
       "path": "../../packages/graphql-client/tsconfig.lib.json"
@@ -27,9 +33,6 @@
     },
     {
       "path": "../../packages/github-service/tsconfig.lib.json"
-    },
-    {
-      "path": "../../packages/issue-reconciler/tsconfig.lib.json"
     },
     {
       "path": "../../packages/db-service/tsconfig.lib.json"

--- a/bun.lock
+++ b/bun.lock
@@ -38,6 +38,7 @@
       "name": "@ready-for-agent/harness",
       "version": "0.0.0",
       "dependencies": {
+        "@effect/platform-bun": "^4.0.0-beta.97",
         "@ready-for-agent/db": "workspace:*",
         "@ready-for-agent/db-service": "workspace:*",
         "@ready-for-agent/github-service": "workspace:*",
@@ -45,6 +46,7 @@
         "@ready-for-agent/graphql-client": "workspace:*",
         "@ready-for-agent/issue-reconciler": "workspace:*",
         "@ready-for-agent/keymaxxer-service": "workspace:*",
+        "@ready-for-agent/opencode": "workspace:*",
         "@tanstack/react-query": "^5.90.0",
         "@tanstack/react-query-devtools": "^5.90.0",
         "@tanstack/react-router": "^1.170.17",
@@ -135,6 +137,7 @@
         "@ready-for-agent/github-service": "workspace:*",
         "@ready-for-agent/graphql-schema": "workspace:*",
         "@ready-for-agent/issue-reconciler": "workspace:*",
+        "@ready-for-agent/opencode": "workspace:*",
         "effect": "^4.0.0-beta.97",
         "graphql": "^16.11.0",
         "graphql-yoga": "^5.13.0",

--- a/packages/graphql-api/package.json
+++ b/packages/graphql-api/package.json
@@ -20,6 +20,7 @@
     "@ready-for-agent/github-service": "workspace:*",
     "@ready-for-agent/graphql-schema": "workspace:*",
     "@ready-for-agent/issue-reconciler": "workspace:*",
+    "@ready-for-agent/opencode": "workspace:*",
     "effect": "^4.0.0-beta.97",
     "graphql": "^16.11.0",
     "graphql-yoga": "^5.13.0",

--- a/packages/graphql-api/src/lib/graphql-api.ts
+++ b/packages/graphql-api/src/lib/graphql-api.ts
@@ -19,6 +19,7 @@ import {
   IssueReconciler,
   ReconciliationMutationError,
 } from "@ready-for-agent/issue-reconciler"
+import { Opencode } from "@ready-for-agent/opencode"
 
 type AddRepositoryArgs = {
   input: {
@@ -45,7 +46,7 @@ type IssuesArgs = {
 }
 
 export type GraphqlRuntime = ManagedRuntime.ManagedRuntime<
-  DbService | IssueReconciler,
+  DbService | IssueReconciler | Opencode,
   unknown
 >
 
@@ -138,7 +139,11 @@ const toNativeResponse = (response: unknown): Response => {
   })
 }
 
-export const createGraphqlApi = (runtime: GraphqlRuntime) => {
+export const createGraphqlApi = (
+  runtime: GraphqlRuntime,
+  options: { readonly opencodeCwd?: string } = {},
+) => {
+  const opencodeCwd = options.opencodeCwd ?? process.cwd()
   const yoga = createYoga({
     schema: createSchema({
       typeDefs,
@@ -165,6 +170,23 @@ export const createGraphqlApi = (runtime: GraphqlRuntime) => {
                 Effect.gen(function* () {
                   const db = yield* DbService
                   return yield* db.getConfig
+                }),
+              ),
+            )
+            if (Result.isFailure(result)) {
+              throw toGraphQLError(result.failure)
+            }
+            return result.success
+          },
+          models: async () => {
+            const result = await runtime.runPromise(
+              Effect.result(
+                Effect.gen(function* () {
+                  const opencode = yield* Opencode
+                  return yield* opencode.listModels({
+                    cwd: opencodeCwd,
+                    timeout: "30 seconds",
+                  })
                 }),
               ),
             )

--- a/packages/graphql-api/test/graphql-api.test.ts
+++ b/packages/graphql-api/test/graphql-api.test.ts
@@ -4,6 +4,7 @@ import {
   IssueReconciler,
   type IssueReconcilerShape,
 } from "@ready-for-agent/issue-reconciler"
+import { Opencode } from "@ready-for-agent/opencode"
 import { createGraphqlApi } from "../src/index.js"
 import { afterEach, describe, expect, test } from "bun:test"
 
@@ -37,6 +38,15 @@ const makeRuntime = (
   dbOverrides: Partial<DbServiceShape> = {},
   reconcilerOverrides: Partial<IssueReconcilerShape> = {},
 ) => {
+  const opencode = {
+    start: () => Effect.die("not used"),
+    continue: () => Effect.die("not used"),
+    listModels: () =>
+      Effect.succeed([
+        "opencode/deepseek-v4-flash-free",
+        "anthropic/claude-sonnet-4-5",
+      ]),
+  }
   const db: DbServiceShape = {
     getConfig: Effect.succeed(config),
     updateConfig: (input) => Effect.succeed(input),
@@ -53,9 +63,10 @@ const makeRuntime = (
     ...reconcilerOverrides,
   }
   return ManagedRuntime.make(
-    Layer.merge(
+    Layer.mergeAll(
       Layer.succeed(DbService, db),
       Layer.succeed(IssueReconciler, reconciler),
+      Layer.succeed(Opencode, opencode),
     ),
   )
 }
@@ -176,6 +187,21 @@ describe("GraphQL API", () => {
           defaultModel: "anthropic/claude-sonnet-4-5",
           defaultVariant: "high",
         },
+      },
+    })
+  })
+
+  test("lists models provided by OpenCode", async () => {
+    const response = await createGraphqlApi(runtime).fetch(
+      graphqlRequest({ query: `query { models }` }),
+    )
+
+    expect(await response.json()).toEqual({
+      data: {
+        models: [
+          "opencode/deepseek-v4-flash-free",
+          "anthropic/claude-sonnet-4-5",
+        ],
       },
     })
   })

--- a/packages/graphql-api/tsconfig.lib.json
+++ b/packages/graphql-api/tsconfig.lib.json
@@ -11,7 +11,10 @@
   "include": ["src/**/*.ts"],
   "references": [
     {
-      "path": "../db-service/tsconfig.lib.json"
+      "path": "../opencode/tsconfig.lib.json"
+    },
+    {
+      "path": "../issue-reconciler/tsconfig.lib.json"
     },
     {
       "path": "../graphql-schema/tsconfig.lib.json"
@@ -20,7 +23,7 @@
       "path": "../github-service/tsconfig.lib.json"
     },
     {
-      "path": "../issue-reconciler/tsconfig.lib.json"
+      "path": "../db-service/tsconfig.lib.json"
     }
   ]
 }

--- a/packages/graphql-client/src/generated/schema.graphql
+++ b/packages/graphql-client/src/generated/schema.graphql
@@ -2,6 +2,7 @@ type Query {
   health: Boolean!
   repositories: [Repository!]!
   config: Config!
+  models: [String!]!
   issues(repositoryId: ID!): [Issue!]!
 }
 

--- a/packages/graphql-client/src/generated/schema.ts
+++ b/packages/graphql-client/src/generated/schema.ts
@@ -5,8 +5,8 @@
 
 export type Scalars = {
     Boolean: boolean,
-    ID: string,
     String: string,
+    ID: string,
     Int: number,
 }
 
@@ -14,6 +14,7 @@ export interface Query {
     health: Scalars['Boolean']
     repositories: Repository[]
     config: Config
+    models: Scalars['String'][]
     issues: Issue[]
     __typename: 'Query'
 }
@@ -69,6 +70,7 @@ export interface QueryGenqlSelection{
     health?: boolean | number
     repositories?: RepositoryGenqlSelection
     config?: ConfigGenqlSelection
+    models?: boolean | number
     issues?: (IssueGenqlSelection & { __args: {repositoryId: Scalars['ID']} })
     __typename?: boolean | number
     __scalar?: boolean | number

--- a/packages/graphql-client/src/generated/types.ts
+++ b/packages/graphql-client/src/generated/types.ts
@@ -2,7 +2,7 @@ export default {
     "scalars": [
         1,
         2,
-        4,
+        3,
         6,
         8
     ],
@@ -15,47 +15,50 @@ export default {
                 5
             ],
             "config": [
-                3
+                4
+            ],
+            "models": [
+                2
             ],
             "issues": [
                 7,
                 {
                     "repositoryId": [
-                        2,
+                        3,
                         "ID!"
                     ]
                 }
             ],
             "__typename": [
-                4
+                2
             ]
         },
         "Boolean": {},
+        "String": {},
         "ID": {},
         "Config": {
             "defaultModel": [
-                4
-            ],
-            "defaultVariant": [
-                4
-            ],
-            "__typename": [
-                4
-            ]
-        },
-        "String": {},
-        "Repository": {
-            "id": [
                 2
             ],
+            "defaultVariant": [
+                2
+            ],
+            "__typename": [
+                2
+            ]
+        },
+        "Repository": {
+            "id": [
+                3
+            ],
             "githubOwner": [
-                4
+                2
             ],
             "githubRepo": [
-                4
+                2
             ],
             "localPath": [
-                4
+                2
             ],
             "isBare": [
                 1
@@ -64,40 +67,40 @@ export default {
                 1
             ],
             "issuesReconciledAt": [
-                4
+                2
             ],
             "__typename": [
-                4
+                2
             ]
         },
         "IssueState": {},
         "Issue": {
             "id": [
-                2
+                3
             ],
             "repositoryId": [
-                2
+                3
             ],
             "githubIssueNumber": [
                 8
             ],
             "title": [
-                4
+                2
             ],
             "body": [
-                4
+                2
             ],
             "url": [
-                4
+                2
             ],
             "state": [
                 6
             ],
             "githubCreatedAt": [
-                4
+                2
             ],
             "__typename": [
-                4
+                2
             ]
         },
         "Int": {},
@@ -118,35 +121,35 @@ export default {
                 8
             ],
             "__typename": [
-                4
+                2
             ]
         },
         "AddRepositoryInput": {
             "githubOwner": [
-                4
+                2
             ],
             "githubRepo": [
-                4
+                2
             ],
             "localPath": [
-                4
+                2
             ],
             "isBare": [
                 1
             ],
             "__typename": [
-                4
+                2
             ]
         },
         "UpdateConfigInput": {
             "defaultModel": [
-                4
+                2
             ],
             "defaultVariant": [
-                4
+                2
             ],
             "__typename": [
-                4
+                2
             ]
         },
         "Mutation": {
@@ -163,13 +166,13 @@ export default {
                 9,
                 {
                     "repositoryId": [
-                        2,
+                        3,
                         "ID!"
                     ]
                 }
             ],
             "updateConfig": [
-                3,
+                4,
                 {
                     "input": [
                         11,
@@ -178,7 +181,7 @@ export default {
                 }
             ],
             "__typename": [
-                4
+                2
             ]
         }
     }

--- a/packages/graphql-schema/schema.graphql
+++ b/packages/graphql-schema/schema.graphql
@@ -2,6 +2,7 @@ type Query {
   health: Boolean!
   repositories: [Repository!]!
   config: Config!
+  models: [String!]!
   issues(repositoryId: ID!): [Issue!]!
 }
 


### PR DESCRIPTION
## Why

The harness settings dialog currently requires users to type an OpenCode provider/model identifier manually, even though the OpenCode service can report the models configured for the workspace. This makes model selection error-prone and allows values that are not currently available.

## What Changed

- Expose the OpenCode service model list through the GraphQL API with the harness workspace as its configuration context and a 30-second timeout.
- Replace the free-text default-model field with a dropdown populated from that query.
- Preserve an existing configured model when it is temporarily absent from the discovered list.
- Wire the OpenCode layer into the harness runtime and regenerate the GraphQL client.
- Import only the Bun child-process platform layers needed by OpenCode so Vite's Node SSR runner does not resolve Bun-only modules.

## Verification

- The OpenCode integration test returned the configured provider/model identifiers.
- The GraphQL model-list query test passed, and the harness production build completed successfully.
- The Node SSR import failure was reproduced before the fix; the narrow platform imports and regression test now pass.
