### PR TITLE
fix(harness): resolve workspace sources during SSR

### DIFF
--- a/apps/harness/test/topology.test.ts
+++ b/apps/harness/test/topology.test.ts
@@ -1,4 +1,5 @@
 import { readFile } from "node:fs/promises"
+import { createServer } from "vite"
 import { describe, expect, test } from "bun:test"
 
 type Target = {
@@ -51,6 +52,26 @@ describe("single application server topology", () => {
     expect(viteConfig).toContain("enabled: true")
     expect(viteConfig).not.toContain("3001")
     expect(viteConfig).not.toContain("proxy")
+  })
+
+  test("resolves workspace source exports during SSR", async () => {
+    const server = await createServer({
+      configFile: new URL("../vite.config.ts", import.meta.url).pathname,
+      server: { middlewareMode: true },
+    })
+
+    try {
+      const resolved = await server.pluginContainer.resolveId(
+        "@ready-for-agent/issue-reconciler",
+        new URL("../src/server/application.server.ts", import.meta.url)
+          .pathname,
+        { ssr: true },
+      )
+
+      expect(resolved?.id).toEndWith("/packages/issue-reconciler/src/index.ts")
+    } finally {
+      await server.close()
+    }
   })
 
   test("does not load the Bun platform barrel during Node SSR", async () => {

--- a/apps/harness/vite.config.ts
+++ b/apps/harness/vite.config.ts
@@ -10,6 +10,9 @@ export default defineConfig({
   },
   ssr: {
     noExternal: [/^@ready-for-agent\//],
+    resolve: {
+      conditions: ["@ready-for-agent/source"],
+    },
   },
   server: {
     host: "127.0.0.1",


### PR DESCRIPTION
## Why

The harness development server resolved workspace source exports for the browser environment but not for server rendering. During SSR, Vite therefore fell through to the unbuilt `dist/index.js` export of `@ready-for-agent/issue-reconciler`, causing `/` to fail after startup.

## What Changed

- Apply the `@ready-for-agent/source` condition to Vite's SSR resolver.
- Add a regression test that resolves `@ready-for-agent/issue-reconciler` through the real Vite SSR plugin pipeline and asserts that it selects `src/index.ts`.

## Verification

Before the change, the focused SSR resolver reproduced `ERR_RESOLVE_PACKAGE_ENTRY_FAIL`. After the change, it resolves `packages/issue-reconciler/src/index.ts`, and the running development server renders `/` successfully.
