### PR TITLE
feat(harness): show repository add command

### DIFF
--- a/apps/harness/src/routes/index.tsx
+++ b/apps/harness/src/routes/index.tsx
@@ -73,8 +73,11 @@ function RepositoryCards() {
       <div className="rounded-[0.9rem] border border-dashed border-slate-300 px-6 py-12 text-center">
         <h2 className="m-0">No repositories configured</h2>
         <p className="mt-1.5 text-slate-500">
-          Add a repository with the CLI to see it here.
+          Add a local Git repository with the CLI:
         </p>
+        <code className="mt-3 inline-block rounded-md bg-slate-100 px-3 py-2 font-mono text-sm text-slate-800">
+          bun run harness-cli add /path/to/local/repo
+        </code>
       </div>
     )
   }


### PR DESCRIPTION
## Why

The empty repository state tells users to use the CLI but does not show them how, leaving them to find the command elsewhere.

## What Changed

Show the concrete `bun run harness-cli add /path/to/local/repo` command in the harness empty state.
