### PR TITLE
feat: store issue parents

### DIFF
--- a/apps/harness/src/server/keymaxxer-github-layer.ts
+++ b/apps/harness/src/server/keymaxxer-github-layer.ts
@@ -17,6 +17,12 @@ const SerializedIssue = Schema.Struct({
   url: Schema.String,
   createdAt: Schema.String,
   state: Schema.Literals(["OPEN", "CLOSED"]),
+  parent: Schema.NullOr(
+    Schema.Struct({
+      number: Schema.Finite,
+      url: Schema.String,
+    }),
+  ),
   blockedBy: Schema.Array(
     Schema.Struct({
       number: Schema.Finite,
@@ -63,6 +69,15 @@ const parseIssues = (
               throw new Error("Invalid Issue creation time")
             }
             new URL(issue.url)
+            if (issue.parent !== null) {
+              if (
+                !Number.isSafeInteger(issue.parent.number) ||
+                issue.parent.number <= 0
+              ) {
+                throw new Error("Invalid parent Issue number")
+              }
+              new URL(issue.parent.url)
+            }
             for (const dependency of issue.blockedBy) {
               if (
                 !Number.isSafeInteger(dependency.number) ||

--- a/apps/harness/test/keymaxxer-github-layer.test.ts
+++ b/apps/harness/test/keymaxxer-github-layer.test.ts
@@ -40,6 +40,10 @@ describe("Keymaxxer-backed GitHub layer", () => {
               url: "https://github.com/acme/widgets/issues/7",
               createdAt: "2026-07-07T12:00:00.000Z",
               state: "OPEN",
+              parent: {
+                number: 1,
+                url: "https://github.com/acme/widgets/issues/1",
+              },
               blockedBy: [
                 {
                   number: 3,
@@ -78,6 +82,10 @@ describe("Keymaxxer-backed GitHub layer", () => {
         url: "https://github.com/acme/widgets/issues/3",
       },
     ])
+    expect(results[0]?.[0]?.parent).toEqual({
+      number: 1,
+      url: "https://github.com/acme/widgets/issues/1",
+    })
     expect(runs).toHaveLength(2)
     expect(tokenChecks).toBe(2)
     expect(tokenAdds).toBe(1)

--- a/packages/db-schema/drizzle/20260713215850_opposite_the_enforcers/migration.sql
+++ b/packages/db-schema/drizzle/20260713215850_opposite_the_enforcers/migration.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `issue` ADD `parent_github_issue_number` integer;--> statement-breakpoint
+ALTER TABLE `issue` ADD `parent_github_issue_url` text;

--- a/packages/db-schema/drizzle/20260713215850_opposite_the_enforcers/snapshot.json
+++ b/packages/db-schema/drizzle/20260713215850_opposite_the_enforcers/snapshot.json
@@ -1,0 +1,676 @@
+{
+  "version": "7",
+  "dialect": "sqlite",
+  "id": "6db399d0-e7c8-487a-9392-82cffcbba5d4",
+  "prevIds": [
+    "9e006fd8-b2e0-4cd7-8d48-1e2a853c7b4a"
+  ],
+  "ddl": [
+    {
+      "name": "completed_job",
+      "entityType": "tables"
+    },
+    {
+      "name": "config",
+      "entityType": "tables"
+    },
+    {
+      "name": "issue",
+      "entityType": "tables"
+    },
+    {
+      "name": "issue_dependency",
+      "entityType": "tables"
+    },
+    {
+      "name": "job_queue",
+      "entityType": "tables"
+    },
+    {
+      "name": "repository",
+      "entityType": "tables"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "completed_job"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "queue",
+      "entityType": "columns",
+      "table": "completed_job"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "job_id",
+      "entityType": "columns",
+      "table": "completed_job"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "completed_job"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "completed_job"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "'default'",
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "config"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'opencode/deepseek-v4-flash-free'",
+      "generated": null,
+      "name": "default_model",
+      "entityType": "columns",
+      "table": "config"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'low'",
+      "generated": null,
+      "name": "default_variant",
+      "entityType": "columns",
+      "table": "config"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "config"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "config"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "issue"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "repository_id",
+      "entityType": "columns",
+      "table": "issue"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "github_issue_number",
+      "entityType": "columns",
+      "table": "issue"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "title",
+      "entityType": "columns",
+      "table": "issue"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "body",
+      "entityType": "columns",
+      "table": "issue"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "url",
+      "entityType": "columns",
+      "table": "issue"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "state",
+      "entityType": "columns",
+      "table": "issue"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "github_created_at",
+      "entityType": "columns",
+      "table": "issue"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "parent_github_issue_number",
+      "entityType": "columns",
+      "table": "issue"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "parent_github_issue_url",
+      "entityType": "columns",
+      "table": "issue"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "issue"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "issue"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "issue_dependency"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "issue_id",
+      "entityType": "columns",
+      "table": "issue_dependency"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "blocking_github_issue_number",
+      "entityType": "columns",
+      "table": "issue_dependency"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "blocking_github_issue_url",
+      "entityType": "columns",
+      "table": "issue_dependency"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "issue_dependency"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "job_queue"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "queue",
+      "entityType": "columns",
+      "table": "job_queue"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "job_payload",
+      "entityType": "columns",
+      "table": "job_queue"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "0",
+      "generated": null,
+      "name": "job_attempts",
+      "entityType": "columns",
+      "table": "job_queue"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "5",
+      "generated": null,
+      "name": "job_retry_limit",
+      "entityType": "columns",
+      "table": "job_queue"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "available_at",
+      "entityType": "columns",
+      "table": "job_queue"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "locked_until",
+      "entityType": "columns",
+      "table": "job_queue"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "job_queue"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "job_queue"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "repository"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "github_owner",
+      "entityType": "columns",
+      "table": "repository"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "github_repo",
+      "entityType": "columns",
+      "table": "repository"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "local_path",
+      "entityType": "columns",
+      "table": "repository"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "is_bare",
+      "entityType": "columns",
+      "table": "repository"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "true",
+      "generated": null,
+      "name": "paused",
+      "entityType": "columns",
+      "table": "repository"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "issues_reconciled_at",
+      "entityType": "columns",
+      "table": "repository"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "repository"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "repository"
+    },
+    {
+      "columns": [
+        "repository_id"
+      ],
+      "tableTo": "repository",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_issue_repository_id_repository_id_fk",
+      "entityType": "fks",
+      "table": "issue"
+    },
+    {
+      "columns": [
+        "issue_id"
+      ],
+      "tableTo": "issue",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_issue_dependency_issue_id_issue_id_fk",
+      "entityType": "fks",
+      "table": "issue_dependency"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "completed_job_pk",
+      "table": "completed_job",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "config_pk",
+      "table": "config",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "issue_pk",
+      "table": "issue",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "issue_dependency_pk",
+      "table": "issue_dependency",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "job_queue_pk",
+      "table": "job_queue",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "repository_pk",
+      "table": "repository",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        {
+          "value": "queue",
+          "isExpression": false
+        },
+        {
+          "value": "job_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "origin": "manual",
+      "name": "completed_job_queue_job_id_uidx",
+      "entityType": "indexes",
+      "table": "completed_job"
+    },
+    {
+      "columns": [
+        {
+          "value": "repository_id",
+          "isExpression": false
+        },
+        {
+          "value": "github_issue_number",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "origin": "manual",
+      "name": "issue_repository_id_github_issue_number_uidx",
+      "entityType": "indexes",
+      "table": "issue"
+    },
+    {
+      "columns": [
+        {
+          "value": "issue_id",
+          "isExpression": false
+        },
+        {
+          "value": "blocking_github_issue_url",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "origin": "manual",
+      "name": "issue_dependency_issue_id_blocking_url_uidx",
+      "entityType": "indexes",
+      "table": "issue_dependency"
+    },
+    {
+      "columns": [
+        {
+          "value": "queue",
+          "isExpression": false
+        },
+        {
+          "value": "locked_until",
+          "isExpression": false
+        },
+        {
+          "value": "job_attempts",
+          "isExpression": false
+        },
+        {
+          "value": "available_at",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "job_queue_ready_idx",
+      "entityType": "indexes",
+      "table": "job_queue"
+    },
+    {
+      "columns": [
+        {
+          "value": "lower(\"github_owner\")",
+          "isExpression": true
+        },
+        {
+          "value": "lower(\"github_repo\")",
+          "isExpression": true
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "origin": "manual",
+      "name": "repository_github_owner_repo_lower_uidx",
+      "entityType": "indexes",
+      "table": "repository"
+    },
+    {
+      "columns": [
+        "local_path"
+      ],
+      "nameExplicit": false,
+      "name": "repository_local_path_unique",
+      "entityType": "uniques",
+      "table": "repository"
+    }
+  ],
+  "renames": []
+}

--- a/packages/db-schema/src/schema.ts
+++ b/packages/db-schema/src/schema.ts
@@ -62,6 +62,8 @@ export const issue = snakeCase.table(
     url: text().notNull(),
     state: text({ enum: ["OPEN", "CLOSED"] }).notNull(),
     githubCreatedAt: integer({ mode: "number" }).notNull(),
+    parentGithubIssueNumber: integer(),
+    parentGithubIssueUrl: text(),
     createdAt: integer({ mode: "number" })
       .notNull()
       .$defaultFn(() => Date.now()),

--- a/packages/db-service/src/lib/db-service.ts
+++ b/packages/db-service/src/lib/db-service.ts
@@ -99,6 +99,8 @@ const toIssueRecord = (row: {
   url: string
   state: "OPEN" | "CLOSED"
   githubCreatedAt: number
+  parentGithubIssueNumber: number | null
+  parentGithubIssueUrl: string | null
   blockedBy: readonly IssueDependency[]
 }): IssueRecord => ({
   id: row.id,
@@ -109,6 +111,13 @@ const toIssueRecord = (row: {
   url: row.url,
   state: row.state,
   githubCreatedAt: new Date(row.githubCreatedAt),
+  parent:
+    row.parentGithubIssueNumber === null || row.parentGithubIssueUrl === null
+      ? null
+      : {
+          githubIssueNumber: row.parentGithubIssueNumber,
+          githubIssueUrl: row.parentGithubIssueUrl,
+        },
   blockedBy: row.blockedBy,
 })
 
@@ -448,6 +457,18 @@ export const DbServiceLive = Layer.effect(
           })
         }
 
+        if (
+          input.parent !== null &&
+          (!Number.isSafeInteger(input.parent.githubIssueNumber) ||
+            input.parent.githubIssueNumber <= 0 ||
+            !URL.canParse(input.parent.githubIssueUrl))
+        ) {
+          return yield* new InvalidIssueInputError({
+            field: "parent",
+            message: "parent must have a positive issue number and valid URL",
+          })
+        }
+
         for (const dependency of input.blockedBy) {
           if (
             !Number.isSafeInteger(dependency.githubIssueNumber) ||
@@ -476,17 +497,21 @@ export const DbServiceLive = Layer.effect(
                 .unsafe(
                   `INSERT INTO issue (
                id, repository_id, github_issue_number, title, body, url, state,
-               github_created_at, created_at, updated_at
-             ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                github_created_at, parent_github_issue_number,
+                parent_github_issue_url, created_at, updated_at
+              ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
              ON CONFLICT (repository_id, github_issue_number) DO UPDATE SET
                title = excluded.title,
                body = excluded.body,
                url = excluded.url,
-               state = excluded.state,
-               github_created_at = excluded.github_created_at,
-               updated_at = excluded.updated_at
-             RETURNING id, repository_id, github_issue_number, title, body, url, state,
-               github_created_at`,
+                state = excluded.state,
+                github_created_at = excluded.github_created_at,
+                parent_github_issue_number = excluded.parent_github_issue_number,
+                parent_github_issue_url = excluded.parent_github_issue_url,
+                updated_at = excluded.updated_at
+              RETURNING id, repository_id, github_issue_number, title, body, url, state,
+                github_created_at, parent_github_issue_number,
+                parent_github_issue_url`,
                   [
                     `issue-${ulid()}`,
                     input.repositoryId,
@@ -496,6 +521,8 @@ export const DbServiceLive = Layer.effect(
                     input.url,
                     input.state,
                     input.githubCreatedAt.getTime(),
+                    input.parent?.githubIssueNumber ?? null,
+                    input.parent?.githubIssueUrl ?? null,
                     now,
                     now,
                   ],
@@ -512,6 +539,8 @@ export const DbServiceLive = Layer.effect(
                     url: string
                     state: "OPEN" | "CLOSED"
                     github_created_at: number
+                    parent_github_issue_number: number | null
+                    parent_github_issue_url: string | null
                   }
                 | undefined
               if (!row) {
@@ -564,6 +593,8 @@ export const DbServiceLive = Layer.effect(
                 url: row.url,
                 state: row.state,
                 githubCreatedAt: row.github_created_at,
+                parentGithubIssueNumber: row.parent_github_issue_number,
+                parentGithubIssueUrl: row.parent_github_issue_url,
                 blockedBy: dependencies,
               })
             }),
@@ -587,7 +618,8 @@ export const DbServiceLive = Layer.effect(
         const issues = yield* sql
           .unsafe(
             `SELECT id, repository_id, github_issue_number, title, body, url, state,
-               github_created_at
+                github_created_at, parent_github_issue_number,
+                parent_github_issue_url
              FROM issue WHERE repository_id = ? ORDER BY github_issue_number ASC`,
             [repositoryId],
           )
@@ -629,6 +661,8 @@ export const DbServiceLive = Layer.effect(
             url: string
             state: "OPEN" | "CLOSED"
             github_created_at: number
+            parent_github_issue_number: number | null
+            parent_github_issue_url: string | null
           }>
         ).map((issue) =>
           toIssueRecord({
@@ -640,6 +674,8 @@ export const DbServiceLive = Layer.effect(
             url: issue.url,
             state: issue.state,
             githubCreatedAt: issue.github_created_at,
+            parentGithubIssueNumber: issue.parent_github_issue_number,
+            parentGithubIssueUrl: issue.parent_github_issue_url,
             blockedBy: dependenciesByIssue.get(issue.id) ?? [],
           }),
         )

--- a/packages/db-service/src/lib/errors.ts
+++ b/packages/db-service/src/lib/errors.ts
@@ -35,6 +35,7 @@ export class InvalidIssueInputError extends Data.TaggedError(
     | "url"
     | "state"
     | "githubCreatedAt"
+    | "parent"
     | "blockedBy"
   readonly message: string
 }> {}

--- a/packages/db-service/src/lib/types.ts
+++ b/packages/db-service/src/lib/types.ts
@@ -33,6 +33,7 @@ export interface StoreIssueInput {
   readonly url: string
   readonly state: IssueState
   readonly githubCreatedAt: Date
+  readonly parent: IssueReference | null
   readonly blockedBy: readonly IssueDependency[]
 }
 
@@ -47,10 +48,13 @@ export interface IssueRecord {
   readonly url: string
   readonly state: IssueState
   readonly githubCreatedAt: Date
+  readonly parent: IssueReference | null
   readonly blockedBy: readonly IssueDependency[]
 }
 
-export interface IssueDependency {
+export interface IssueReference {
   readonly githubIssueNumber: number
   readonly githubIssueUrl: string
 }
+
+export type IssueDependency = IssueReference

--- a/packages/db-service/test/db-service.spec.ts
+++ b/packages/db-service/test/db-service.spec.ts
@@ -34,6 +34,7 @@ describe("DbService", () => {
     body: "Issue body",
     url: "https://github.com/acme/widgets/issues/42",
     state: "OPEN" as const,
+    parent: null,
     blockedBy: [],
   }
 
@@ -248,6 +249,7 @@ describe("DbService", () => {
           expect(issue.url).toBe("https://github.com/acme/widgets/issues/42")
           expect(issue.state).toBe("OPEN")
           expect(issue.githubCreatedAt).toEqual(githubCreatedAt)
+          expect(issue.parent).toBeNull()
         }),
       ))
 
@@ -329,6 +331,43 @@ describe("DbService", () => {
           expect((yield* db.listIssues(repository.id))[0]?.blockedBy).toEqual(
             stored.blockedBy,
           )
+        }),
+      ))
+
+    it("stores, replaces, and clears an issue's parent", () =>
+      runTest(
+        Effect.gen(function* () {
+          const db = yield* DbService
+          const repository = yield* addTestRepository(db)
+          const baseInput = {
+            repositoryId: repository.id,
+            githubIssueNumber: 42,
+            title: "Child issue",
+            ...sampleIssueFields,
+            githubCreatedAt: new Date("2026-07-01T12:00:00.000Z"),
+          }
+
+          const withParent = yield* db.storeIssue({
+            ...baseInput,
+            parent: {
+              githubIssueNumber: 7,
+              githubIssueUrl: "https://github.com/acme/widgets/issues/7",
+            },
+          })
+          expect(withParent.parent).toEqual({
+            githubIssueNumber: 7,
+            githubIssueUrl: "https://github.com/acme/widgets/issues/7",
+          })
+          expect((yield* db.listIssues(repository.id))[0]?.parent).toEqual(
+            withParent.parent,
+          )
+
+          const withoutParent = yield* db.storeIssue({
+            ...baseInput,
+            parent: null,
+          })
+          expect(withoutParent.parent).toBeNull()
+          expect((yield* db.listIssues(repository.id))[0]?.parent).toBeNull()
         }),
       ))
 

--- a/packages/github-service/github.graphql
+++ b/packages/github-service/github.graphql
@@ -31,6 +31,7 @@ type Issue {
   url: URI!
   createdAt: DateTime!
   state: IssueState!
+  parent: Issue
   blockedBy(first: Int, after: String): IssueConnection!
 }
 

--- a/packages/github-service/src/lib/github-service-live.ts
+++ b/packages/github-service/src/lib/github-service-live.ts
@@ -20,6 +20,7 @@ interface GitHubApiIssue {
   readonly url: unknown
   readonly createdAt: unknown
   readonly state: unknown
+  readonly parent: GitHubApiIssueReference | null
   readonly blockedBy: GitHubApiIssueConnection
 }
 
@@ -94,6 +95,7 @@ const toReadyLabeledIssue = (issue: GitHubApiIssue): ReadyLabeledIssue => {
     url: issue.url,
     createdAt,
     state: issue.state,
+    parent: issue.parent === null ? null : toIssueReference(issue.parent),
     blockedBy: mapBlockedByPage(issue.blockedBy),
   }
 }
@@ -137,6 +139,7 @@ export const makeGitHubService = (
                     url: true,
                     createdAt: true,
                     state: true,
+                    parent: { number: true, url: true },
                     blockedBy: {
                       __args: { first: PAGE_SIZE },
                       nodes: { number: true, url: true },

--- a/packages/github-service/src/lib/types.ts
+++ b/packages/github-service/src/lib/types.ts
@@ -17,5 +17,6 @@ export interface ReadyLabeledIssue {
   readonly url: string
   readonly createdAt: Date
   readonly state: GitHubIssueState
+  readonly parent: GitHubIssueReference | null
   readonly blockedBy: readonly GitHubIssueReference[]
 }

--- a/packages/github-service/test/github-service.spec.ts
+++ b/packages/github-service/test/github-service.spec.ts
@@ -24,6 +24,7 @@ const issue = (
   url: `https://github.com/acme/widgets/issues/${number}`,
   createdAt: new Date(`2026-07-${String(number).padStart(2, "0")}T12:00:00Z`),
   state,
+  parent: null,
   blockedBy: [],
 })
 
@@ -42,6 +43,10 @@ describe("GitHubService live implementation", () => {
                 url: "https://github.com/acme/widgets/issues/9",
                 createdAt: "2026-07-09T12:00:00Z",
                 state: "OPEN",
+                parent: {
+                  number: 1,
+                  url: "https://github.com/acme/widgets/issues/1",
+                },
                 blockedBy: {
                   nodes: [
                     {
@@ -69,6 +74,7 @@ describe("GitHubService live implementation", () => {
                 url: "https://github.com/acme/widgets/issues/2",
                 createdAt: "2026-07-02T12:00:00Z",
                 state: "CLOSED",
+                parent: null,
                 blockedBy: {
                   nodes: [],
                   pageInfo: { endCursor: null, hasNextPage: false },
@@ -99,7 +105,12 @@ describe("GitHubService live implementation", () => {
       url: "https://github.com/acme/widgets/issues/2",
       createdAt: new Date("2026-07-02T12:00:00Z"),
       state: "CLOSED",
+      parent: null,
       blockedBy: [],
+    })
+    expect(result[1]?.parent).toEqual({
+      number: 1,
+      url: "https://github.com/acme/widgets/issues/1",
     })
     expect(result[1]?.blockedBy).toEqual([
       {
@@ -131,6 +142,7 @@ describe("GitHubService live implementation", () => {
       url: true,
       createdAt: true,
       state: true,
+      parent: { number: true, url: true },
       blockedBy: {
         __args: { first: 100 },
         nodes: { number: true, url: true },
@@ -156,6 +168,7 @@ describe("GitHubService live implementation", () => {
                 url: "https://github.com/acme/widgets/issues/7",
                 createdAt: "2026-07-07T12:00:00Z",
                 state: "OPEN",
+                parent: null,
                 blockedBy: {
                   nodes: [
                     {
@@ -265,6 +278,7 @@ describe("GitHubService live implementation", () => {
                 url: "not-a-url",
                 createdAt: "2026-07-01T12:00:00Z",
                 state: "OPEN",
+                parent: null,
                 blockedBy: {
                   nodes: [],
                   pageInfo: { endCursor: null, hasNextPage: false },

--- a/packages/graphql-api/test/graphql-api.test.ts
+++ b/packages/graphql-api/test/graphql-api.test.ts
@@ -32,6 +32,7 @@ const issue = {
   url: "https://github.com/acme/widgets/issues/42",
   state: "OPEN" as const,
   githubCreatedAt: new Date("2026-07-12T10:30:00.000Z"),
+  parent: null,
   blockedBy: [],
 }
 

--- a/packages/issue-reconciler/src/lib/issue-reconciler.ts
+++ b/packages/issue-reconciler/src/lib/issue-reconciler.ts
@@ -61,6 +61,8 @@ const matches = (local: IssueRecord, remote: ReadyLabeledIssue): boolean =>
   local.url === remote.url &&
   local.state === remote.state &&
   local.githubCreatedAt.getTime() === remote.createdAt.getTime() &&
+  local.parent?.githubIssueNumber === remote.parent?.number &&
+  local.parent?.githubIssueUrl === remote.parent?.url &&
   local.blockedBy.length === remote.blockedBy.length &&
   local.blockedBy.every((dependency) =>
     remote.blockedBy.some(
@@ -140,6 +142,13 @@ export const IssueReconcilerLive = Layer.effect(
             url: issue.url,
             state: issue.state,
             githubCreatedAt: issue.createdAt,
+            parent:
+              issue.parent === null
+                ? null
+                : {
+                    githubIssueNumber: issue.parent.number,
+                    githubIssueUrl: issue.parent.url,
+                  },
             blockedBy: issue.blockedBy.map((dependency) => ({
               githubIssueNumber: dependency.number,
               githubIssueUrl: dependency.url,

--- a/packages/issue-reconciler/test/issue-reconciler.spec.ts
+++ b/packages/issue-reconciler/test/issue-reconciler.spec.ts
@@ -41,6 +41,7 @@ const remoteIssue = (
     `2026-07-${String(number).padStart(2, "0")}T00:00:00.000Z`,
   ),
   state: "OPEN",
+  parent: null,
   blockedBy: [],
   ...overrides,
 })
@@ -59,6 +60,13 @@ const localIssue = (
     url: remote.url,
     githubCreatedAt: remote.createdAt,
     state: remote.state,
+    parent:
+      remote.parent === null
+        ? null
+        : {
+            githubIssueNumber: remote.parent.number,
+            githubIssueUrl: remote.parent.url,
+          },
     blockedBy: remote.blockedBy.map((dependency) => ({
       githubIssueNumber: dependency.number,
       githubIssueUrl: dependency.url,
@@ -288,6 +296,36 @@ describe("IssueReconciler", () => {
           "store:1",
           "mark",
         ])
+      }),
+      db.layer,
+      github,
+    )
+  })
+
+  it("updates an otherwise unchanged issue when its parent changes", () => {
+    const db = makeDbFixture({ issues: [localIssue(1)] })
+    const github = makeGitHubLayer(
+      [
+        remoteIssue(1, {
+          parent: {
+            number: 9,
+            url: "https://github.com/acme/widgets/issues/9",
+          },
+        }),
+      ],
+      db.actions,
+    )
+
+    return runReconciliation(
+      Effect.gen(function* () {
+        const reconciler = yield* IssueReconciler
+        const summary = yield* reconciler.reconcile(repository)
+
+        expect(summary.updated).toBe(1)
+        expect(db.stored[0]?.parent).toEqual({
+          githubIssueNumber: 9,
+          githubIssueUrl: "https://github.com/acme/widgets/issues/9",
+        })
       }),
       db.layer,
       github,


### PR DESCRIPTION
## Why

Ready-for-agent issues can belong to GitHub sub-issue hierarchies, but reconciliation currently drops that relationship. Retaining the direct parent lets downstream workflows understand an issue's immediate place in the hierarchy without requiring every ancestor to be locally reconciled.

## What Changed

- Fetch the nullable direct `Issue.parent` reference from GitHub as an issue number and URL.
- Store the parent reference in nullable issue columns through an additive database migration.
- Validate, serialize, and map parent references across the GitHub, Keymaxxer, and database service boundaries.
- Reconcile parent additions, changes, and removals alongside other issue fields.
- Add focused service tests for fetching, storing, clearing, and reconciling issue parents.

## Verification

Database tests demonstrate that a parent can be stored, replaced, listed, and cleared. Reconciler tests demonstrate that changing only the parent causes the issue to be updated.
