### PR TITLE
feat: remove configured repositories

### DIFF
--- a/apps/harness/src/routes/index.tsx
+++ b/apps/harness/src/routes/index.tsx
@@ -1,4 +1,8 @@
-import { useSuspenseQuery } from "@tanstack/react-query"
+import {
+  useMutation,
+  useQueryClient,
+  useSuspenseQuery,
+} from "@tanstack/react-query"
 import { createFileRoute } from "@tanstack/react-router"
 import { Suspense } from "react"
 import { createClient } from "@ready-for-agent/graphql-client"
@@ -39,6 +43,16 @@ const issuesQuery = (repositoryId: string) => ({
     return result.issues
   },
 })
+
+type Repository = {
+  id: string
+  githubOwner: string
+  githubRepo: string
+  localPath: string
+  isBare: boolean
+  paused: boolean
+  issuesReconciledAt: string | null
+}
 
 export const Route = createFileRoute("/")({
   component: HomePage,
@@ -94,22 +108,66 @@ function RepositoryCards() {
   )
 }
 
-function RepositoryCard({
-  repository,
-}: {
-  repository: {
-    id: string
-    githubOwner: string
-    githubRepo: string
-    localPath: string
-    isBare: boolean
-    paused: boolean
-    issuesReconciledAt: string | null
+function RepositoryCard({ repository }: { repository: Repository }) {
+  const queryClient = useQueryClient()
+  const removeRepository = useMutation({
+    mutationFn: async () => {
+      const result = await graphql.mutation({
+        removeRepository: { __args: { repositoryId: repository.id } },
+      })
+      return result.removeRepository
+    },
+    onSuccess: async (repositoryId) => {
+      await queryClient.cancelQueries({ queryKey: repositoriesQuery.queryKey })
+      queryClient.setQueryData<readonly Repository[]>(
+        repositoriesQuery.queryKey,
+        (repositories) => repositories?.filter(({ id }) => id !== repositoryId),
+      )
+      queryClient.removeQueries({ queryKey: ["issues", repositoryId] })
+      await queryClient.invalidateQueries({
+        queryKey: repositoriesQuery.queryKey,
+      })
+    },
+  })
+
+  const confirmRemoval = () => {
+    if (
+      window.confirm(
+        `Remove ${repository.githubOwner}/${repository.githubRepo} and its stored issues?`,
+      )
+    ) {
+      removeRepository.mutate()
+    }
   }
-}) {
+
   return (
-    <article className="min-w-0 rounded-[0.9rem] border border-[#dbe3ef] bg-white p-[1.35rem] shadow-[0_10px_30px_rgb(15_23_42_/_5%)]">
-      <div className="flex items-center justify-between gap-4">
+    <article className="relative min-w-0 rounded-[0.9rem] border border-[#dbe3ef] bg-white p-[1.35rem] shadow-[0_10px_30px_rgb(15_23_42_/_5%)]">
+      <button
+        type="button"
+        className="absolute top-4 right-4 inline-flex size-8 items-center justify-center rounded-md text-slate-400 transition hover:bg-red-50 hover:text-red-700 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-red-600 disabled:cursor-wait disabled:opacity-50"
+        onClick={confirmRemoval}
+        disabled={removeRepository.isPending}
+        aria-label={`Remove ${repository.githubOwner}/${repository.githubRepo}`}
+        title={`Remove ${repository.githubOwner}/${repository.githubRepo}`}
+      >
+        <svg
+          aria-hidden="true"
+          className="size-4"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        >
+          <path d="M3 6h18" />
+          <path d="M8 6V4h8v2" />
+          <path d="m19 6-1 14H6L5 6" />
+          <path d="M10 11v5" />
+          <path d="M14 11v5" />
+        </svg>
+      </button>
+      <div className="flex items-center justify-between gap-4 pr-10">
         <span className="truncate text-[0.85rem] font-[650] text-slate-500">
           {repository.githubOwner}
         </span>
@@ -160,6 +218,11 @@ function RepositoryCard({
           </Suspense>
         )}
       </div>
+      {removeRepository.isError && (
+        <p className="mt-3 mb-0 text-sm text-red-700" role="alert">
+          Could not remove repository. Please try again.
+        </p>
+      )}
     </article>
   )
 }

--- a/packages/db-service/src/lib/db-service.ts
+++ b/packages/db-service/src/lib/db-service.ts
@@ -145,6 +145,9 @@ export interface DbServiceShape {
     readonly RepositoryRecord[],
     DatabaseError
   >
+  readonly removeRepository: (
+    repositoryId: string,
+  ) => Effect.Effect<void, RepositoryNotFoundError | DatabaseError>
   readonly storeIssue: (
     input: StoreIssueInput,
   ) => Effect.Effect<
@@ -415,6 +418,40 @@ export const DbServiceLive = Layer.effect(
           return yield* new RepositoryNotFoundError({ repositoryId })
         }
       })
+
+    const removeRepository = (
+      repositoryId: string,
+    ): Effect.Effect<void, RepositoryNotFoundError | DatabaseError> =>
+      sql
+        .withTransaction(
+          Effect.gen(function* () {
+            yield* sql.unsafe(
+              `DELETE FROM issue_dependency
+               WHERE issue_id IN (
+                 SELECT id FROM issue WHERE repository_id = ?
+               )`,
+              [repositoryId],
+            )
+            yield* sql.unsafe("DELETE FROM issue WHERE repository_id = ?", [
+              repositoryId,
+            ])
+            const result = yield* sql.unsafe(
+              "DELETE FROM repository WHERE id = ? RETURNING id",
+              [repositoryId],
+            )
+
+            if (!result[0]) {
+              return yield* new RepositoryNotFoundError({ repositoryId })
+            }
+          }),
+        )
+        .pipe(
+          Effect.mapError((error) =>
+            error instanceof RepositoryNotFoundError
+              ? error
+              : toDatabaseError(error),
+          ),
+        )
 
     const storeIssue = (
       input: StoreIssueInput,
@@ -731,6 +768,7 @@ export const DbServiceLive = Layer.effect(
       updateConfig,
       addRepository,
       listRepositories,
+      removeRepository,
       storeIssue,
       listIssues,
       deleteIssue,

--- a/packages/db-service/test/db-service.spec.ts
+++ b/packages/db-service/test/db-service.spec.ts
@@ -224,6 +224,48 @@ describe("DbService", () => {
       ))
   })
 
+  describe("removeRepository", () => {
+    it("removes the repository, its issues, and issue dependencies", () =>
+      runTest(
+        Effect.gen(function* () {
+          const db = yield* DbService
+          const sql = yield* SqlClient.SqlClient
+          const repository = yield* db.addRepository(sampleInput)
+          yield* db.storeIssue({
+            repositoryId: repository.id,
+            githubIssueNumber: 42,
+            title: "Remove with repository",
+            ...sampleIssueFields,
+            githubCreatedAt: new Date("2026-07-01T12:00:00.000Z"),
+            blockedBy: [
+              {
+                githubIssueNumber: 7,
+                githubIssueUrl: "https://github.com/acme/widgets/issues/7",
+              },
+            ],
+          })
+
+          yield* db.removeRepository(repository.id)
+
+          expect(yield* db.listRepositories).toEqual([])
+          expect(yield* sql.unsafe("SELECT id FROM issue")).toEqual([])
+          expect(yield* sql.unsafe("SELECT id FROM issue_dependency")).toEqual(
+            [],
+          )
+        }),
+      ))
+
+    it("fails when the repository does not exist", () =>
+      runTest(
+        Effect.gen(function* () {
+          const db = yield* DbService
+          const error = yield* Effect.flip(db.removeRepository("repo-missing"))
+
+          expect(error).toBeInstanceOf(RepositoryNotFoundError)
+        }),
+      ))
+  })
+
   describe("issues", () => {
     const addTestRepository = (db: DbService) => db.addRepository(sampleInput)
 

--- a/packages/graphql-api/src/lib/graphql-api.ts
+++ b/packages/graphql-api/src/lib/graphql-api.ts
@@ -34,6 +34,10 @@ type RefreshRepositoryArgs = {
   repositoryId: string
 }
 
+type RemoveRepositoryArgs = {
+  repositoryId: string
+}
+
 type UpdateConfigArgs = {
   input: {
     defaultModel: string
@@ -240,6 +244,24 @@ export const createGraphqlApi = (
                 Effect.gen(function* () {
                   const db = yield* DbService
                   return yield* db.addRepository(args.input)
+                }),
+              ),
+            )
+            if (Result.isFailure(result)) {
+              throw toGraphQLError(result.failure)
+            }
+            return result.success
+          },
+          removeRepository: async (
+            _parent: unknown,
+            args: RemoveRepositoryArgs,
+          ) => {
+            const result = await runtime.runPromise(
+              Effect.result(
+                Effect.gen(function* () {
+                  const db = yield* DbService
+                  yield* db.removeRepository(args.repositoryId)
+                  return args.repositoryId
                 }),
               ),
             )

--- a/packages/graphql-api/test/graphql-api.test.ts
+++ b/packages/graphql-api/test/graphql-api.test.ts
@@ -54,6 +54,7 @@ const makeRuntime = (
     updateConfig: (input) => Effect.succeed(input),
     addRepository: () => Effect.succeed(repository),
     listRepositories: Effect.succeed([repository]),
+    removeRepository: () => Effect.die("not used"),
     storeIssue: () => Effect.die("not used"),
     listIssues: () => Effect.die("not used"),
     deleteIssue: () => Effect.die("not used"),
@@ -160,6 +161,31 @@ describe("GraphQL API", () => {
         ],
       },
     })
+  })
+
+  test("removes a repository", async () => {
+    let removedRepositoryId: string | undefined
+    await runtime.dispose()
+    runtime = makeRuntime({
+      removeRepository: (repositoryId) => {
+        removedRepositoryId = repositoryId
+        return Effect.void
+      },
+    })
+
+    const response = await createGraphqlApi(runtime).fetch(
+      graphqlRequest({
+        query: `mutation RemoveRepository($repositoryId: ID!) {
+          removeRepository(repositoryId: $repositoryId)
+        }`,
+        variables: { repositoryId: repository.id },
+      }),
+    )
+
+    expect(await response.json()).toEqual({
+      data: { removeRepository: repository.id },
+    })
+    expect(removedRepositoryId).toBe(repository.id)
   })
 
   test("reads and updates config", async () => {

--- a/packages/graphql-schema/schema.graphql
+++ b/packages/graphql-schema/schema.graphql
@@ -59,6 +59,7 @@ input UpdateConfigInput {
 
 type Mutation {
   addRepository(input: AddRepositoryInput!): Repository!
+  removeRepository(repositoryId: ID!): ID!
   refreshRepository(repositoryId: ID!): RepositoryRefresh!
   updateConfig(input: UpdateConfigInput!): Config!
 }


### PR DESCRIPTION
## Why

Configured repositories could be added and refreshed, but not removed. Users need a safe way to remove a repository and its projected GitHub issues from the local database.

## What Changed

- add the `removeRepository` GraphQL mutation
- delete a repository, its issues, and issue dependencies in one database transaction
- add an accessible trash action with confirmation and error feedback to repository cards
- keep React Query caches synchronized while avoiding stale in-flight refetches
- cover successful deletion, related-record cleanup, missing repositories, and GraphQL delegation

## Verification

- database test confirms repository, issue, and issue-dependency records are removed
- GraphQL API test confirms the mutation delegates the requested repository ID
