### PR TITLE
docs(harness): document custom GraphQL URL

### DIFF
--- a/apps/harness/README.md
+++ b/apps/harness/README.md
@@ -17,6 +17,14 @@ The SPA and GraphQL endpoint are available on the same loopback server:
 The sidecar listens separately on `127.0.0.1:5032` only to preserve the
 Keymaxxer session across application-server reloads.
 
+When the harness uses a non-standard port, point the CLI at its GraphQL
+endpoint with `READY_FOR_AGENT_GRAPHQL_URL`:
+
+```bash
+READY_FOR_AGENT_GRAPHQL_URL=http://127.0.0.1:4300/graphql \
+  bun run harness-cli add /path/to/local/repo
+```
+
 ## Production
 
 Build and start the custom Bun server with:


### PR DESCRIPTION
## Why

The Harness CLI defaults to the standard local GraphQL endpoint. Developers running the Harness on another port need to know how to direct CLI commands to that server.

## What Changed

Documented `READY_FOR_AGENT_GRAPHQL_URL` in the Harness README with an example for adding a repository through a non-standard local port.
