### PR TITLE
feat(harness): show active issue blockers

### DIFF
--- a/apps/harness/src/routes/index.tsx
+++ b/apps/harness/src/routes/index.tsx
@@ -52,6 +52,10 @@ const issuesQuery = (repositoryId: string) => ({
         title: true,
         url: true,
         state: true,
+        blockedBy: {
+          githubIssueNumber: true,
+          githubIssueUrl: true,
+        },
       },
     })
     return result.issues
@@ -385,20 +389,46 @@ function RepositoryIssues({ repositoryId }: { repositoryId: string }) {
   return (
     <ul className="m-0 grid list-none gap-2 p-0">
       {issues.map((issue) => (
-        <li className="flex min-w-0 items-start gap-2 text-sm" key={issue.id}>
-          <span className="shrink-0 font-mono text-xs leading-5 text-slate-400">
-            #{issue.githubIssueNumber}
-          </span>
-          <a
-            className="min-w-0 flex-1 text-slate-700 hover:text-blue-700 hover:underline"
-            href={issue.url}
-          >
-            {issue.title}
-          </a>
-          {issue.state === "CLOSED" && (
-            <span className="shrink-0 rounded-full bg-slate-100 px-1.5 py-0.5 text-[0.6rem] font-bold tracking-wide text-slate-500 uppercase">
-              Closed
+        <li
+          className={`min-w-0 rounded-md text-sm ${issue.blockedBy.length > 0 ? "-mx-2.5 bg-amber-50/70 px-2.5 py-2" : "py-0.5"}`}
+          key={issue.id}
+        >
+          <div className="flex min-w-0 items-start gap-2">
+            <span className="shrink-0 font-mono text-xs leading-5 text-slate-400">
+              #{issue.githubIssueNumber}
             </span>
+            <a
+              className="min-w-0 flex-1 text-slate-700 hover:text-blue-700 hover:underline"
+              href={issue.url}
+            >
+              {issue.title}
+            </a>
+            {issue.state === "CLOSED" && (
+              <span className="shrink-0 rounded-full bg-slate-100 px-1.5 py-0.5 text-[0.6rem] font-bold tracking-wide text-slate-500 uppercase">
+                Closed
+              </span>
+            )}
+            {issue.blockedBy.length > 0 && (
+              <span className="shrink-0 rounded-full bg-amber-200/70 px-1.5 py-0.5 text-[0.6rem] font-bold tracking-wide text-amber-900 uppercase">
+                Blocked
+              </span>
+            )}
+          </div>
+          {issue.blockedBy.length > 0 && (
+            <p className="mt-1.5 mb-0 pl-11 text-xs text-amber-900">
+              Blocked by{" "}
+              {issue.blockedBy.map((blocker, index) => (
+                <span key={blocker.githubIssueUrl}>
+                  {index > 0 && ", "}
+                  <a
+                    className="font-mono font-semibold underline decoration-amber-400 underline-offset-2 hover:text-blue-700"
+                    href={blocker.githubIssueUrl}
+                  >
+                    #{blocker.githubIssueNumber}
+                  </a>
+                </span>
+              ))}
+            </p>
           )}
         </li>
       ))}

--- a/packages/github-service/src/lib/github-service-live.ts
+++ b/packages/github-service/src/lib/github-service-live.ts
@@ -30,7 +30,7 @@ interface GitHubApiIssue {
 }
 
 interface GitHubApiIssueConnection {
-  readonly nodes: readonly (GitHubApiIssueReference | null)[] | null
+  readonly nodes: readonly (GitHubApiIssueDependency | null)[] | null
   readonly pageInfo: {
     readonly endCursor: string | null
     readonly hasNextPage: boolean
@@ -40,6 +40,10 @@ interface GitHubApiIssueConnection {
 interface GitHubApiIssueReference {
   readonly number: unknown
   readonly url: unknown
+}
+
+interface GitHubApiIssueDependency extends GitHubApiIssueReference {
+  readonly state: unknown
 }
 
 interface GitHubApiRepositoryReference {
@@ -106,6 +110,7 @@ const mapBlockedByPage = (
 ): readonly GitHubIssueReference[] =>
   (connection.nodes ?? [])
     .filter((issue) => issue !== null)
+    .filter((issue) => toIssueState(issue.state) === "OPEN")
     .map(toIssueReference)
 
 const toRepositoryName = (repository: GitHubApiRepositoryReference): string => {
@@ -267,7 +272,7 @@ export const makeGitHubService = (
                     },
                     blockedBy: {
                       __args: { first: PAGE_SIZE },
-                      nodes: { number: true, url: true },
+                      nodes: { number: true, url: true, state: true },
                       pageInfo: { endCursor: true, hasNextPage: true },
                     },
                   },
@@ -326,7 +331,7 @@ export const makeGitHubService = (
                           first: PAGE_SIZE,
                           after: blockedByPage.endCursor,
                         },
-                        nodes: { number: true, url: true },
+                        nodes: { number: true, url: true, state: true },
                         pageInfo: { endCursor: true, hasNextPage: true },
                       },
                     },

--- a/packages/github-service/test/github-service.spec.ts
+++ b/packages/github-service/test/github-service.spec.ts
@@ -60,6 +60,12 @@ describe("GitHubService live implementation", () => {
                     {
                       number: 3,
                       url: "https://github.com/acme/widgets/issues/3",
+                      state: "OPEN",
+                    },
+                    {
+                      number: 4,
+                      url: "https://github.com/acme/widgets/issues/4",
+                      state: "CLOSED",
                     },
                   ],
                   pageInfo: { endCursor: null, hasNextPage: false },
@@ -180,7 +186,7 @@ describe("GitHubService live implementation", () => {
       },
       blockedBy: {
         __args: { first: 100 },
-        nodes: { number: true, url: true },
+        nodes: { number: true, url: true, state: true },
         pageInfo: { endCursor: true, hasNextPage: true },
       },
     })
@@ -213,6 +219,7 @@ describe("GitHubService live implementation", () => {
                     {
                       number: 5,
                       url: "https://github.com/acme/widgets/issues/5",
+                      state: "OPEN",
                     },
                   ],
                   pageInfo: {
@@ -234,6 +241,7 @@ describe("GitHubService live implementation", () => {
                 {
                   number: 2,
                   url: "https://github.com/acme/widgets/issues/2",
+                  state: "OPEN",
                 },
               ],
               pageInfo: { endCursor: null, hasNextPage: false },

--- a/packages/graphql-api/test/graphql-api.test.ts
+++ b/packages/graphql-api/test/graphql-api.test.ts
@@ -37,7 +37,12 @@ const issue = {
   state: "OPEN" as const,
   githubCreatedAt: new Date("2026-07-12T10:30:00.000Z"),
   parent: null,
-  blockedBy: [],
+  blockedBy: [
+    {
+      githubIssueNumber: 17,
+      githubIssueUrl: "https://github.com/acme/widgets/issues/17",
+    },
+  ],
 }
 
 const makeRuntime = (
@@ -402,6 +407,7 @@ describe("GraphQL API", () => {
         query: `query ListIssues($repositoryId: ID!) {
           issues(repositoryId: $repositoryId) {
             id repositoryId githubIssueNumber title body url state githubCreatedAt
+            blockedBy { githubIssueNumber githubIssueUrl }
           }
         }`,
         variables: { repositoryId: repository.id },
@@ -421,6 +427,7 @@ describe("GraphQL API", () => {
             url: issue.url,
             state: issue.state,
             githubCreatedAt: issue.githubCreatedAt.toISOString(),
+            blockedBy: issue.blockedBy,
           },
         ],
       },

--- a/packages/graphql-schema/schema.graphql
+++ b/packages/graphql-schema/schema.graphql
@@ -43,6 +43,12 @@ type Issue {
   url: String!
   state: IssueState!
   githubCreatedAt: String!
+  blockedBy: [IssueReference!]!
+}
+
+type IssueReference {
+  githubIssueNumber: Int!
+  githubIssueUrl: String!
 }
 
 type RepositoryRefresh {


### PR DESCRIPTION
## Why

Relevant Issues did not expose dependency information, making blocked work appear actionable. GitHub also returns closed Issues in the `blockedBy` connection, so treating every dependency as an active blocker incorrectly marked Issues as blocked after their dependencies were completed.

## What Changed

- Expose Issue dependency references through GraphQL and request them in the Harness.
- Show active blockers as linked Issue numbers with a subtle blocked treatment that preserves the existing issue-number and title columns.
- Request dependency state from GitHub and retain only open Issues as active blockers, including across paginated results.
- Cover the GraphQL contract and open-versus-closed dependency mapping.

## Verification

The GitHub service regression test supplies both open and closed dependencies and verifies that only the open Issue is returned as a blocker.
