### PR TITLE
feat(harness): group child issues by parent

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -43,6 +43,22 @@ _Avoid_: Ready Issue (can imply that the Issue is open and actionable)
 A GitHub issue hierarchy wholly contained within one Repository and limited to a root Issue with optional direct children. A hierarchy containing a cross-Repository relationship or a grandchild is unsupported in its entirety.
 _Avoid_: Issue tree (implies arbitrary depth), nested Issues
 
+**Parent Issue**:
+A root Issue with one or more direct children. It organizes related work but is not itself a unit the harness works directly.
+_Avoid_: PRD (the relationship does not establish document type), epic
+
+**Child Issue**:
+A direct child of a Parent Issue. In a Supported Issue Hierarchy, a Child Issue has no children of its own.
+_Avoid_: Subtask, nested Issue
+
+**Standalone Issue**:
+A root Issue with no children. It is structurally eligible to be worked directly.
+_Avoid_: Unparented Issue, top-level Issue
+
+**Leaf Issue**:
+An Issue with no children: either a Standalone Issue or a Child Issue. Only Leaf Issues are structurally eligible to be worked directly, subject to other workflow constraints.
+_Avoid_: Actionable Issue (actionability also depends on workflow constraints)
+
 **Relevant Issue**:
 A Ready-labeled Issue in a Supported Issue Hierarchy that remains pertinent to the harness: either an open root Issue, or a direct child whose parent is open and Ready-labeled. A closed root Issue, or a child with a closed or non-Ready-labeled parent, is not relevant.
 _Avoid_: Active Issue (a Relevant Issue may be closed), Actionable Issue (actionability also depends on workflow constraints), Visible Issue (presentation-specific)

--- a/apps/harness/src/routes/index.tsx
+++ b/apps/harness/src/routes/index.tsx
@@ -52,6 +52,11 @@ const issuesQuery = (repositoryId: string) => ({
         title: true,
         url: true,
         state: true,
+        parent: {
+          githubIssueNumber: true,
+          githubIssueUrl: true,
+        },
+        hasChildren: true,
         blockedBy: {
           githubIssueNumber: true,
           githubIssueUrl: true,
@@ -78,6 +83,23 @@ type RepositoryCredential = {
   configured: boolean
   githubTokenSecretName: string
   githubTokenCreationUrl: string
+}
+
+type RepositoryIssue = {
+  id: string
+  githubIssueNumber: number
+  title: string
+  url: string
+  state: "OPEN" | "CLOSED"
+  parent: {
+    githubIssueNumber: number
+    githubIssueUrl: string
+  } | null
+  hasChildren: boolean
+  blockedBy: readonly {
+    githubIssueNumber: number
+    githubIssueUrl: string
+  }[]
 }
 
 export const Route = createFileRoute("/")({
@@ -386,53 +408,117 @@ function RepositoryIssues({ repositoryId }: { repositoryId: string }) {
     return <p className="m-0 text-sm text-slate-500">No relevant issues.</p>
   }
 
+  const childrenByParent = new Map<number, RepositoryIssue[]>()
+  for (const issue of issues) {
+    if (issue.parent === null) continue
+    const children = childrenByParent.get(issue.parent.githubIssueNumber) ?? []
+    children.push(issue)
+    childrenByParent.set(issue.parent.githubIssueNumber, children)
+  }
+
   return (
     <ul className="m-0 grid list-none gap-2 p-0">
-      {issues.map((issue) => (
-        <li
-          className={`min-w-0 rounded-md text-sm ${issue.blockedBy.length > 0 ? "-mx-2.5 bg-amber-50/70 px-2.5 py-2" : "py-0.5"}`}
-          key={issue.id}
-        >
-          <div className="flex min-w-0 items-start gap-2">
-            <span className="shrink-0 font-mono text-xs leading-5 text-slate-400">
-              #{issue.githubIssueNumber}
-            </span>
-            <a
-              className="min-w-0 flex-1 text-slate-700 hover:text-blue-700 hover:underline"
-              href={issue.url}
+      {issues.map((issue) => {
+        if (issue.parent !== null) return null
+        if (!issue.hasChildren) {
+          return <RepositoryIssueRow issue={issue} key={issue.id} />
+        }
+
+        const children = childrenByParent.get(issue.githubIssueNumber) ?? []
+        const closedChildren = children.filter(
+          (child) => child.state === "CLOSED",
+        ).length
+        return (
+          <li className="min-w-0" key={issue.id}>
+            <details
+              className="group -mx-2.5 rounded-lg bg-slate-50/90 px-2.5 py-1"
+              open
             >
-              {issue.title}
-            </a>
-            {issue.state === "CLOSED" && (
-              <span className="shrink-0 rounded-full bg-slate-100 px-1.5 py-0.5 text-[0.6rem] font-bold tracking-wide text-slate-500 uppercase">
-                Closed
-              </span>
-            )}
-            {issue.blockedBy.length > 0 && (
-              <span className="shrink-0 rounded-full bg-amber-200/70 px-1.5 py-0.5 text-[0.6rem] font-bold tracking-wide text-amber-900 uppercase">
-                Blocked
-              </span>
-            )}
-          </div>
-          {issue.blockedBy.length > 0 && (
-            <p className="mt-1.5 mb-0 pl-11 text-xs text-amber-900">
-              Blocked by{" "}
-              {issue.blockedBy.map((blocker, index) => (
-                <span key={blocker.githubIssueUrl}>
-                  {index > 0 && ", "}
-                  <a
-                    className="font-mono font-semibold underline decoration-amber-400 underline-offset-2 hover:text-blue-700"
-                    href={blocker.githubIssueUrl}
-                  >
-                    #{blocker.githubIssueNumber}
-                  </a>
+              <summary className="grid cursor-pointer list-none grid-cols-[2.25rem_minmax(0,1fr)_auto] items-start gap-2 py-1.5 marker:content-none">
+                <span className="font-mono text-xs leading-5 font-semibold text-blue-600">
+                  #{issue.githubIssueNumber}
                 </span>
-              ))}
-            </p>
-          )}
-        </li>
-      ))}
+                <a
+                  className="min-w-0 font-semibold text-slate-800 hover:text-blue-700 hover:underline"
+                  href={issue.url}
+                  onClick={(event) => event.stopPropagation()}
+                >
+                  {issue.title}
+                </a>
+                <span className="flex shrink-0 items-center gap-1.5 text-[0.65rem] font-bold tracking-wide text-slate-500 uppercase">
+                  {closedChildren}/{children.length} closed
+                  <svg
+                    aria-hidden="true"
+                    className="size-3.5 transition-transform group-open:rotate-180"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth="2"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  >
+                    <path d="m6 9 6 6 6-6" />
+                  </svg>
+                </span>
+              </summary>
+              <ul className="relative m-0 grid list-none gap-1.5 py-1 pl-0 before:absolute before:top-0 before:bottom-1 before:-left-2.5 before:w-0.5 before:rounded-full before:bg-blue-200">
+                {children.map((child) => (
+                  <RepositoryIssueRow issue={child} key={child.id} />
+                ))}
+              </ul>
+            </details>
+          </li>
+        )
+      })}
     </ul>
+  )
+}
+
+function RepositoryIssueRow({ issue }: { issue: RepositoryIssue }) {
+  return (
+    <li
+      className={`min-w-0 rounded-md text-sm ${issue.blockedBy.length > 0 ? "bg-amber-50/70 py-2" : "py-0.5"}`}
+    >
+      <div className="grid min-w-0 grid-cols-[2.25rem_minmax(0,1fr)_auto] items-start gap-2">
+        <span className="font-mono text-xs leading-5 text-slate-400">
+          #{issue.githubIssueNumber}
+        </span>
+        <a
+          className="min-w-0 text-slate-700 hover:text-blue-700 hover:underline"
+          href={issue.url}
+        >
+          {issue.title}
+        </a>
+        <span className="flex shrink-0 items-center gap-1">
+          {issue.state === "CLOSED" && (
+            <span className="rounded-full bg-slate-100 px-1.5 py-0.5 text-[0.6rem] font-bold tracking-wide text-slate-500 uppercase">
+              Closed
+            </span>
+          )}
+          {issue.blockedBy.length > 0 && (
+            <span className="rounded-full bg-amber-200/70 px-1.5 py-0.5 text-[0.6rem] font-bold tracking-wide text-amber-900 uppercase">
+              Blocked
+            </span>
+          )}
+        </span>
+      </div>
+      {issue.blockedBy.length > 0 && (
+        <p className="mt-1.5 mb-0 pl-11 text-xs text-amber-900">
+          Blocked by{" "}
+          {issue.blockedBy.map((blocker, index) => (
+            <span key={blocker.githubIssueUrl}>
+              {index > 0 && ", "}
+              <a
+                className="font-mono font-semibold underline decoration-amber-400 underline-offset-2 hover:text-blue-700"
+                href={blocker.githubIssueUrl}
+              >
+                #{blocker.githubIssueNumber}
+              </a>
+            </span>
+          ))}
+        </p>
+      )}
+    </li>
   )
 }
 

--- a/apps/harness/src/server/keymaxxer-github-layer.ts
+++ b/apps/harness/src/server/keymaxxer-github-layer.ts
@@ -16,6 +16,7 @@ const SerializedIssue = Schema.Struct({
   createdAt: Schema.String,
   state: Schema.Literals(["OPEN", "CLOSED"]),
   hierarchySupported: Schema.Boolean,
+  hasChildren: Schema.Boolean,
   parent: Schema.NullOr(
     Schema.Struct({
       number: Schema.Finite,

--- a/apps/harness/test/keymaxxer-github-layer.test.ts
+++ b/apps/harness/test/keymaxxer-github-layer.test.ts
@@ -103,6 +103,7 @@ describe("Keymaxxer-backed GitHub layer", () => {
               createdAt: "2026-07-07T12:00:00.000Z",
               state: "OPEN",
               hierarchySupported: true,
+              hasChildren: false,
               parent: {
                 number: 1,
                 url: "https://github.com/acme/widgets/issues/1",

--- a/docs/adr/0006-only-leaf-issues-are-work-units.md
+++ b/docs/adr/0006-only-leaf-issues-are-work-units.md
@@ -1,0 +1,3 @@
+# Only Leaf Issues are units of work
+
+The harness works only Leaf Issues directly: Standalone Issues and Child Issues may become work units, while Parent Issues are organizational context even when they are open and Ready-labeled. Treating a Parent Issue as independent work would allow an agent to implement the container and its children separately, duplicating or conflicting with the decomposition expressed by the GitHub hierarchy; consumers may therefore retain or display Parent Issues as context without offering them as work.

--- a/packages/db-schema/drizzle/20260714011733_hard_umar/migration.sql
+++ b/packages/db-schema/drizzle/20260714011733_hard_umar/migration.sql
@@ -1,0 +1,4 @@
+ALTER TABLE `issue` ADD `has_children` integer DEFAULT false NOT NULL;--> statement-breakpoint
+DELETE FROM `issue_dependency`;--> statement-breakpoint
+DELETE FROM `issue`;--> statement-breakpoint
+UPDATE `repository` SET `issues_reconciled_at` = NULL;

--- a/packages/db-schema/drizzle/20260714011733_hard_umar/snapshot.json
+++ b/packages/db-schema/drizzle/20260714011733_hard_umar/snapshot.json
@@ -1,0 +1,686 @@
+{
+  "version": "7",
+  "dialect": "sqlite",
+  "id": "be9189f9-1d1e-4f8d-a821-ed5040dc8bc2",
+  "prevIds": [
+    "6db399d0-e7c8-487a-9392-82cffcbba5d4"
+  ],
+  "ddl": [
+    {
+      "name": "completed_job",
+      "entityType": "tables"
+    },
+    {
+      "name": "config",
+      "entityType": "tables"
+    },
+    {
+      "name": "issue",
+      "entityType": "tables"
+    },
+    {
+      "name": "issue_dependency",
+      "entityType": "tables"
+    },
+    {
+      "name": "job_queue",
+      "entityType": "tables"
+    },
+    {
+      "name": "repository",
+      "entityType": "tables"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "completed_job"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "queue",
+      "entityType": "columns",
+      "table": "completed_job"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "job_id",
+      "entityType": "columns",
+      "table": "completed_job"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "completed_job"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "completed_job"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "'default'",
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "config"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'opencode/deepseek-v4-flash-free'",
+      "generated": null,
+      "name": "default_model",
+      "entityType": "columns",
+      "table": "config"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'low'",
+      "generated": null,
+      "name": "default_variant",
+      "entityType": "columns",
+      "table": "config"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "config"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "config"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "issue"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "repository_id",
+      "entityType": "columns",
+      "table": "issue"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "github_issue_number",
+      "entityType": "columns",
+      "table": "issue"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "title",
+      "entityType": "columns",
+      "table": "issue"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "body",
+      "entityType": "columns",
+      "table": "issue"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "url",
+      "entityType": "columns",
+      "table": "issue"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "state",
+      "entityType": "columns",
+      "table": "issue"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "github_created_at",
+      "entityType": "columns",
+      "table": "issue"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "parent_github_issue_number",
+      "entityType": "columns",
+      "table": "issue"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "parent_github_issue_url",
+      "entityType": "columns",
+      "table": "issue"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "false",
+      "generated": null,
+      "name": "has_children",
+      "entityType": "columns",
+      "table": "issue"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "issue"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "issue"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "issue_dependency"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "issue_id",
+      "entityType": "columns",
+      "table": "issue_dependency"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "blocking_github_issue_number",
+      "entityType": "columns",
+      "table": "issue_dependency"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "blocking_github_issue_url",
+      "entityType": "columns",
+      "table": "issue_dependency"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "issue_dependency"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "job_queue"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "queue",
+      "entityType": "columns",
+      "table": "job_queue"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "job_payload",
+      "entityType": "columns",
+      "table": "job_queue"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "0",
+      "generated": null,
+      "name": "job_attempts",
+      "entityType": "columns",
+      "table": "job_queue"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "5",
+      "generated": null,
+      "name": "job_retry_limit",
+      "entityType": "columns",
+      "table": "job_queue"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "available_at",
+      "entityType": "columns",
+      "table": "job_queue"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "locked_until",
+      "entityType": "columns",
+      "table": "job_queue"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "job_queue"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "job_queue"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "repository"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "github_owner",
+      "entityType": "columns",
+      "table": "repository"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "github_repo",
+      "entityType": "columns",
+      "table": "repository"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "local_path",
+      "entityType": "columns",
+      "table": "repository"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "is_bare",
+      "entityType": "columns",
+      "table": "repository"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "true",
+      "generated": null,
+      "name": "paused",
+      "entityType": "columns",
+      "table": "repository"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "issues_reconciled_at",
+      "entityType": "columns",
+      "table": "repository"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "repository"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "repository"
+    },
+    {
+      "columns": [
+        "repository_id"
+      ],
+      "tableTo": "repository",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_issue_repository_id_repository_id_fk",
+      "entityType": "fks",
+      "table": "issue"
+    },
+    {
+      "columns": [
+        "issue_id"
+      ],
+      "tableTo": "issue",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_issue_dependency_issue_id_issue_id_fk",
+      "entityType": "fks",
+      "table": "issue_dependency"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "completed_job_pk",
+      "table": "completed_job",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "config_pk",
+      "table": "config",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "issue_pk",
+      "table": "issue",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "issue_dependency_pk",
+      "table": "issue_dependency",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "job_queue_pk",
+      "table": "job_queue",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "repository_pk",
+      "table": "repository",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        {
+          "value": "queue",
+          "isExpression": false
+        },
+        {
+          "value": "job_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "origin": "manual",
+      "name": "completed_job_queue_job_id_uidx",
+      "entityType": "indexes",
+      "table": "completed_job"
+    },
+    {
+      "columns": [
+        {
+          "value": "repository_id",
+          "isExpression": false
+        },
+        {
+          "value": "github_issue_number",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "origin": "manual",
+      "name": "issue_repository_id_github_issue_number_uidx",
+      "entityType": "indexes",
+      "table": "issue"
+    },
+    {
+      "columns": [
+        {
+          "value": "issue_id",
+          "isExpression": false
+        },
+        {
+          "value": "blocking_github_issue_url",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "origin": "manual",
+      "name": "issue_dependency_issue_id_blocking_url_uidx",
+      "entityType": "indexes",
+      "table": "issue_dependency"
+    },
+    {
+      "columns": [
+        {
+          "value": "queue",
+          "isExpression": false
+        },
+        {
+          "value": "locked_until",
+          "isExpression": false
+        },
+        {
+          "value": "job_attempts",
+          "isExpression": false
+        },
+        {
+          "value": "available_at",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "job_queue_ready_idx",
+      "entityType": "indexes",
+      "table": "job_queue"
+    },
+    {
+      "columns": [
+        {
+          "value": "lower(\"github_owner\")",
+          "isExpression": true
+        },
+        {
+          "value": "lower(\"github_repo\")",
+          "isExpression": true
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "origin": "manual",
+      "name": "repository_github_owner_repo_lower_uidx",
+      "entityType": "indexes",
+      "table": "repository"
+    },
+    {
+      "columns": [
+        "local_path"
+      ],
+      "nameExplicit": false,
+      "name": "repository_local_path_unique",
+      "entityType": "uniques",
+      "table": "repository"
+    }
+  ],
+  "renames": []
+}

--- a/packages/db-schema/src/schema.ts
+++ b/packages/db-schema/src/schema.ts
@@ -64,6 +64,7 @@ export const issue = snakeCase.table(
     githubCreatedAt: integer({ mode: "number" }).notNull(),
     parentGithubIssueNumber: integer(),
     parentGithubIssueUrl: text(),
+    hasChildren: integer({ mode: "boolean" }).notNull().default(false),
     createdAt: integer({ mode: "number" })
       .notNull()
       .$defaultFn(() => Date.now()),

--- a/packages/db-service/src/lib/db-service.ts
+++ b/packages/db-service/src/lib/db-service.ts
@@ -101,6 +101,7 @@ const toIssueRecord = (row: {
   githubCreatedAt: number
   parentGithubIssueNumber: number | null
   parentGithubIssueUrl: string | null
+  hasChildren: number | boolean
   blockedBy: readonly IssueDependency[]
 }): IssueRecord => ({
   id: row.id,
@@ -111,6 +112,7 @@ const toIssueRecord = (row: {
   url: row.url,
   state: row.state,
   githubCreatedAt: new Date(row.githubCreatedAt),
+  hasChildren: Boolean(row.hasChildren),
   parent:
     row.parentGithubIssueNumber === null || row.parentGithubIssueUrl === null
       ? null
@@ -535,20 +537,21 @@ export const DbServiceLive = Layer.effect(
                   `INSERT INTO issue (
                id, repository_id, github_issue_number, title, body, url, state,
                 github_created_at, parent_github_issue_number,
-                parent_github_issue_url, created_at, updated_at
-              ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                 parent_github_issue_url, has_children, created_at, updated_at
+              ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
              ON CONFLICT (repository_id, github_issue_number) DO UPDATE SET
                title = excluded.title,
                body = excluded.body,
                url = excluded.url,
                 state = excluded.state,
                 github_created_at = excluded.github_created_at,
-                parent_github_issue_number = excluded.parent_github_issue_number,
-                parent_github_issue_url = excluded.parent_github_issue_url,
-                updated_at = excluded.updated_at
+                 parent_github_issue_number = excluded.parent_github_issue_number,
+                 parent_github_issue_url = excluded.parent_github_issue_url,
+                 has_children = excluded.has_children,
+                 updated_at = excluded.updated_at
               RETURNING id, repository_id, github_issue_number, title, body, url, state,
                 github_created_at, parent_github_issue_number,
-                parent_github_issue_url`,
+                 parent_github_issue_url, has_children`,
                   [
                     `issue-${ulid()}`,
                     input.repositoryId,
@@ -560,6 +563,7 @@ export const DbServiceLive = Layer.effect(
                     input.githubCreatedAt.getTime(),
                     input.parent?.githubIssueNumber ?? null,
                     input.parent?.githubIssueUrl ?? null,
+                    input.hasChildren,
                     now,
                     now,
                   ],
@@ -578,6 +582,7 @@ export const DbServiceLive = Layer.effect(
                     github_created_at: number
                     parent_github_issue_number: number | null
                     parent_github_issue_url: string | null
+                    has_children: number
                   }
                 | undefined
               if (!row) {
@@ -632,6 +637,7 @@ export const DbServiceLive = Layer.effect(
                 githubCreatedAt: row.github_created_at,
                 parentGithubIssueNumber: row.parent_github_issue_number,
                 parentGithubIssueUrl: row.parent_github_issue_url,
+                hasChildren: row.has_children,
                 blockedBy: dependencies,
               })
             }),
@@ -656,7 +662,7 @@ export const DbServiceLive = Layer.effect(
           .unsafe(
             `SELECT id, repository_id, github_issue_number, title, body, url, state,
                 github_created_at, parent_github_issue_number,
-                parent_github_issue_url
+                parent_github_issue_url, has_children
              FROM issue WHERE repository_id = ? ORDER BY github_issue_number ASC`,
             [repositoryId],
           )
@@ -700,6 +706,7 @@ export const DbServiceLive = Layer.effect(
             github_created_at: number
             parent_github_issue_number: number | null
             parent_github_issue_url: string | null
+            has_children: number
           }>
         ).map((issue) =>
           toIssueRecord({
@@ -713,6 +720,7 @@ export const DbServiceLive = Layer.effect(
             githubCreatedAt: issue.github_created_at,
             parentGithubIssueNumber: issue.parent_github_issue_number,
             parentGithubIssueUrl: issue.parent_github_issue_url,
+            hasChildren: issue.has_children,
             blockedBy: dependenciesByIssue.get(issue.id) ?? [],
           }),
         )

--- a/packages/db-service/src/lib/types.ts
+++ b/packages/db-service/src/lib/types.ts
@@ -34,6 +34,7 @@ export interface StoreIssueInput {
   readonly state: IssueState
   readonly githubCreatedAt: Date
   readonly parent: IssueReference | null
+  readonly hasChildren: boolean
   readonly blockedBy: readonly IssueDependency[]
 }
 
@@ -49,6 +50,7 @@ export interface IssueRecord {
   readonly state: IssueState
   readonly githubCreatedAt: Date
   readonly parent: IssueReference | null
+  readonly hasChildren: boolean
   readonly blockedBy: readonly IssueDependency[]
 }
 

--- a/packages/db-service/test/db-service.spec.ts
+++ b/packages/db-service/test/db-service.spec.ts
@@ -35,6 +35,7 @@ describe("DbService", () => {
     url: "https://github.com/acme/widgets/issues/42",
     state: "OPEN" as const,
     parent: null,
+    hasChildren: false,
     blockedBy: [],
   }
 
@@ -410,6 +411,34 @@ describe("DbService", () => {
           })
           expect(withoutParent.parent).toBeNull()
           expect((yield* db.listIssues(repository.id))[0]?.parent).toBeNull()
+        }),
+      ))
+
+    it("stores and replaces whether an issue has children", () =>
+      runTest(
+        Effect.gen(function* () {
+          const db = yield* DbService
+          const repository = yield* addTestRepository(db)
+          const baseInput = {
+            repositoryId: repository.id,
+            githubIssueNumber: 42,
+            title: "Parent issue",
+            ...sampleIssueFields,
+            githubCreatedAt: new Date("2026-07-01T12:00:00.000Z"),
+          }
+
+          expect(
+            (yield* db.storeIssue({ ...baseInput, hasChildren: true }))
+              .hasChildren,
+          ).toBe(true)
+          expect((yield* db.listIssues(repository.id))[0]?.hasChildren).toBe(
+            true,
+          )
+
+          expect(
+            (yield* db.storeIssue({ ...baseInput, hasChildren: false }))
+              .hasChildren,
+          ).toBe(false)
         }),
       ))
 

--- a/packages/github-service/src/lib/github-service-live.ts
+++ b/packages/github-service/src/lib/github-service-live.ts
@@ -25,6 +25,7 @@ interface GitHubApiIssue {
   readonly createdAt: unknown
   readonly state: unknown
   readonly parent: GitHubApiIssueParent | null
+  readonly subIssuesSummary: { readonly total: unknown }
   readonly subIssues: GitHubApiSubIssueConnection
   readonly blockedBy: GitHubApiIssueConnection
 }
@@ -188,6 +189,12 @@ const toReadyLabeledIssue = (
     throw new Error(`Invalid GitHub issue URL: ${issue.url}`)
   }
   const state = toIssueState(issue.state)
+  if (
+    !Number.isSafeInteger(issue.subIssuesSummary.total) ||
+    Number(issue.subIssuesSummary.total) < 0
+  ) {
+    throw new Error("Invalid GitHub sub-issue count")
+  }
   const createdAt = new Date(String(issue.createdAt))
   if (Number.isNaN(createdAt.getTime())) {
     throw new Error(`Invalid GitHub issue creation time: ${issue.createdAt}`)
@@ -201,6 +208,7 @@ const toReadyLabeledIssue = (
     createdAt,
     state,
     parent: issue.parent === null ? null : toIssueParent(issue.parent),
+    hasChildren: Number(issue.subIssuesSummary.total) > 0,
     hasUnsupportedDescendants: pageHasUnsupportedSubIssue(
       issue.subIssues,
       repositoryName,
@@ -260,6 +268,7 @@ export const makeGitHubService = (
                         repository: { nameWithOwner: true },
                       },
                     },
+                    subIssuesSummary: { total: true },
                     subIssues: {
                       __args: { first: PAGE_SIZE },
                       nodes: {
@@ -484,6 +493,7 @@ export const makeGitHubService = (
             url: issue.url,
             createdAt: issue.createdAt,
             state: issue.state,
+            hasChildren: issue.hasChildren,
             parent:
               issue.parent === null
                 ? null

--- a/packages/github-service/src/lib/types.ts
+++ b/packages/github-service/src/lib/types.ts
@@ -23,6 +23,7 @@ export interface ReadyLabeledIssue {
   readonly createdAt: Date
   readonly state: GitHubIssueState
   readonly parent: GitHubIssueParent | null
+  readonly hasChildren: boolean
   readonly hierarchySupported: boolean
   readonly blockedBy: readonly GitHubIssueReference[]
 }

--- a/packages/github-service/test/github-service.spec.ts
+++ b/packages/github-service/test/github-service.spec.ts
@@ -25,6 +25,7 @@ const issue = (
   createdAt: new Date(`2026-07-${String(number).padStart(2, "0")}T12:00:00Z`),
   state,
   parent: null,
+  hasChildren: false,
   hierarchySupported: true,
   blockedBy: [],
 })
@@ -51,6 +52,7 @@ describe("GitHubService live implementation", () => {
                   repository: { nameWithOwner: "acme/widgets" },
                   parent: null,
                 },
+                subIssuesSummary: { total: 0 },
                 subIssues: {
                   nodes: [],
                   pageInfo: { endCursor: null, hasNextPage: false },
@@ -89,6 +91,7 @@ describe("GitHubService live implementation", () => {
                 createdAt: "2026-07-02T12:00:00Z",
                 state: "CLOSED",
                 parent: null,
+                subIssuesSummary: { total: 0 },
                 subIssues: {
                   nodes: [],
                   pageInfo: { endCursor: null, hasNextPage: false },
@@ -124,6 +127,7 @@ describe("GitHubService live implementation", () => {
       createdAt: new Date("2026-07-02T12:00:00Z"),
       state: "CLOSED",
       parent: null,
+      hasChildren: false,
       hierarchySupported: true,
       blockedBy: [],
     })
@@ -174,6 +178,7 @@ describe("GitHubService live implementation", () => {
           repository: { nameWithOwner: true },
         },
       },
+      subIssuesSummary: { total: true },
       subIssues: {
         __args: { first: 100 },
         nodes: {
@@ -210,6 +215,7 @@ describe("GitHubService live implementation", () => {
                 createdAt: "2026-07-07T12:00:00Z",
                 state: "OPEN",
                 parent: null,
+                subIssuesSummary: { total: 0 },
                 subIssues: {
                   nodes: [],
                   pageInfo: { endCursor: null, hasNextPage: false },
@@ -293,6 +299,7 @@ describe("GitHubService live implementation", () => {
         repository: { nameWithOwner: "acme/widgets" },
         parent: null,
       },
+      subIssuesSummary: { total: 0 },
       subIssues: {
         nodes: [],
         pageInfo: { endCursor: null, hasNextPage: false },
@@ -315,6 +322,7 @@ describe("GitHubService live implementation", () => {
                 createdAt: "2026-07-01T12:00:00Z",
                 state: "OPEN",
                 parent: null,
+                subIssuesSummary: { total: 1 },
                 subIssues: {
                   nodes: [
                     {
@@ -347,6 +355,7 @@ describe("GitHubService live implementation", () => {
       false,
       false,
     ])
+    expect(result.map(({ hasChildren }) => hasChildren)).toEqual([true, false])
     expect(result[1]?.parent?.isReadyLabeled).toBe(true)
   })
 
@@ -365,6 +374,7 @@ describe("GitHubService live implementation", () => {
                 createdAt: "2026-07-01T12:00:00Z",
                 state: "OPEN",
                 parent: null,
+                subIssuesSummary: { total: 1 },
                 subIssues: {
                   nodes: [],
                   pageInfo: {
@@ -473,6 +483,7 @@ describe("GitHubService live implementation", () => {
                 createdAt: "2026-07-01T12:00:00Z",
                 state: "OPEN",
                 parent: null,
+                subIssuesSummary: { total: 0 },
                 subIssues: {
                   nodes: [],
                   pageInfo: { endCursor: null, hasNextPage: false },

--- a/packages/graphql-api/src/lib/graphql-api.ts
+++ b/packages/graphql-api/src/lib/graphql-api.ts
@@ -6,6 +6,7 @@ import {
   DbService,
   InvalidConfigInputError,
   InvalidRepositoryInputError,
+  type IssueRecord,
   LocalPathInUseError,
   RepositoryAlreadyExistsError,
   RepositoryNotFoundError,
@@ -52,6 +53,33 @@ type UpdateConfigArgs = {
 
 type IssuesArgs = {
   repositoryId: string
+}
+
+const workIssueProjection = (
+  issues: readonly IssueRecord[],
+): readonly IssueRecord[] => {
+  const childrenByParent = new Map<number, IssueRecord[]>()
+  for (const issue of issues) {
+    if (issue.parent === null) continue
+    const children = childrenByParent.get(issue.parent.githubIssueNumber) ?? []
+    children.push(issue)
+    childrenByParent.set(issue.parent.githubIssueNumber, children)
+  }
+
+  return issues
+    .filter((issue) => issue.parent === null)
+    .sort((left, right) => left.githubIssueNumber - right.githubIssueNumber)
+    .flatMap((issue) => {
+      if (!issue.hasChildren) return [issue]
+      const children = childrenByParent.get(issue.githubIssueNumber) ?? []
+      if (children.length === 0) return []
+      return [
+        issue,
+        ...children.sort(
+          (left, right) => left.githubIssueNumber - right.githubIssueNumber,
+        ),
+      ]
+    })
 }
 
 export type GraphqlRuntime = ManagedRuntime.ManagedRuntime<
@@ -277,7 +305,8 @@ export const createGraphqlApi = (
               Effect.result(
                 Effect.gen(function* () {
                   const db = yield* DbService
-                  return yield* db.listIssues(args.repositoryId)
+                  const issues = yield* db.listIssues(args.repositoryId)
+                  return workIssueProjection(issues)
                 }),
               ),
             )

--- a/packages/graphql-api/test/graphql-api.test.ts
+++ b/packages/graphql-api/test/graphql-api.test.ts
@@ -37,6 +37,7 @@ const issue = {
   state: "OPEN" as const,
   githubCreatedAt: new Date("2026-07-12T10:30:00.000Z"),
   parent: null,
+  hasChildren: false,
   blockedBy: [
     {
       githubIssueNumber: 17,
@@ -407,6 +408,8 @@ describe("GraphQL API", () => {
         query: `query ListIssues($repositoryId: ID!) {
           issues(repositoryId: $repositoryId) {
             id repositoryId githubIssueNumber title body url state githubCreatedAt
+            parent { githubIssueNumber githubIssueUrl }
+            hasChildren
             blockedBy { githubIssueNumber githubIssueUrl }
           }
         }`,
@@ -427,12 +430,76 @@ describe("GraphQL API", () => {
             url: issue.url,
             state: issue.state,
             githubCreatedAt: issue.githubCreatedAt.toISOString(),
+            parent: issue.parent,
+            hasChildren: issue.hasChildren,
             blockedBy: issue.blockedBy,
           },
         ],
       },
     })
     expect(requestedRepositoryId).toBe(repository.id)
+  })
+
+  test("returns standalone and grouped child work in root order", async () => {
+    const makeIssue = (
+      githubIssueNumber: number,
+      overrides: Partial<typeof issue> = {},
+    ) => ({
+      ...issue,
+      id: `issue-${githubIssueNumber}`,
+      githubIssueNumber,
+      title: `Issue ${githubIssueNumber}`,
+      url: `https://github.com/acme/widgets/issues/${githubIssueNumber}`,
+      blockedBy: [],
+      ...overrides,
+    })
+    const parent = makeIssue(10, { hasChildren: true })
+    const parentReference = {
+      githubIssueNumber: 10,
+      githubIssueUrl: parent.url,
+    }
+    await runtime.dispose()
+    runtime = makeRuntime({
+      listIssues: () =>
+        Effect.succeed([
+          makeIssue(20, { hasChildren: true }),
+          makeIssue(12, { parent: parentReference, state: "CLOSED" }),
+          makeIssue(3),
+          parent,
+          makeIssue(11, { parent: parentReference }),
+        ]),
+    })
+
+    const response = await createGraphqlApi(runtime).fetch(
+      graphqlRequest({
+        query: `query ListIssues($repositoryId: ID!) {
+          issues(repositoryId: $repositoryId) {
+            githubIssueNumber hasChildren
+            parent { githubIssueNumber }
+          }
+        }`,
+        variables: { repositoryId: repository.id },
+      }),
+    )
+
+    expect(await response.json()).toEqual({
+      data: {
+        issues: [
+          { githubIssueNumber: 3, hasChildren: false, parent: null },
+          { githubIssueNumber: 10, hasChildren: true, parent: null },
+          {
+            githubIssueNumber: 11,
+            hasChildren: false,
+            parent: { githubIssueNumber: 10 },
+          },
+          {
+            githubIssueNumber: 12,
+            hasChildren: false,
+            parent: { githubIssueNumber: 10 },
+          },
+        ],
+      },
+    })
   })
 
   test("accepts batched issue queries", async () => {

--- a/packages/graphql-schema/schema.graphql
+++ b/packages/graphql-schema/schema.graphql
@@ -43,6 +43,8 @@ type Issue {
   url: String!
   state: IssueState!
   githubCreatedAt: String!
+  parent: IssueReference
+  hasChildren: Boolean!
   blockedBy: [IssueReference!]!
 }
 

--- a/packages/issue-reconciler/src/lib/issue-reconciler.ts
+++ b/packages/issue-reconciler/src/lib/issue-reconciler.ts
@@ -61,6 +61,7 @@ const matches = (local: IssueRecord, remote: ReadyLabeledIssue): boolean =>
   local.url === remote.url &&
   local.state === remote.state &&
   local.githubCreatedAt.getTime() === remote.createdAt.getTime() &&
+  local.hasChildren === remote.hasChildren &&
   local.parent?.githubIssueNumber === remote.parent?.number &&
   local.parent?.githubIssueUrl === remote.parent?.url &&
   local.blockedBy.length === remote.blockedBy.length &&
@@ -148,6 +149,7 @@ export const IssueReconcilerLive = Layer.effect(
             url: issue.url,
             state: issue.state,
             githubCreatedAt: issue.createdAt,
+            hasChildren: issue.hasChildren,
             parent:
               issue.parent === null
                 ? null

--- a/packages/issue-reconciler/test/issue-reconciler.spec.ts
+++ b/packages/issue-reconciler/test/issue-reconciler.spec.ts
@@ -42,6 +42,7 @@ const remoteIssue = (
   ),
   state: "OPEN",
   parent: null,
+  hasChildren: false,
   hierarchySupported: true,
   blockedBy: [],
   ...overrides,
@@ -61,6 +62,7 @@ const localIssue = (
     url: remote.url,
     githubCreatedAt: remote.createdAt,
     state: remote.state,
+    hasChildren: remote.hasChildren,
     parent:
       remote.parent === null
         ? null
@@ -335,6 +337,26 @@ describe("IssueReconciler", () => {
           githubIssueNumber: 9,
           githubIssueUrl: "https://github.com/acme/widgets/issues/9",
         })
+      }),
+      db.layer,
+      github,
+    )
+  })
+
+  it("updates an otherwise unchanged issue when it gains children", () => {
+    const db = makeDbFixture({ issues: [localIssue(1)] })
+    const github = makeGitHubLayer(
+      [remoteIssue(1, { hasChildren: true })],
+      db.actions,
+    )
+
+    return runReconciliation(
+      Effect.gen(function* () {
+        const reconciler = yield* IssueReconciler
+        const summary = yield* reconciler.reconcile(repository)
+
+        expect(summary.updated).toBe(1)
+        expect(db.stored[0]?.hasChildren).toBe(true)
       }),
       db.layer,
       github,


### PR DESCRIPTION
## Why

Parent Issues organize decomposed work and must not be treated as independent work units alongside their children. The issue list previously flattened that hierarchy, making children appear standalone and making related work harder to scan.

## What Changed

- document Parent, Child, Standalone, and Leaf Issue terminology and record that only Leaf Issues are work units
- retain GitHub's `hasChildren` hierarchy fact through reconciliation and the local Issue projection
- expose `parent` and `hasChildren` in GraphQL, omit parent containers without relevant children, and guarantee root-group ordering
- invalidate the rebuildable Issue projection during migration so existing rows cannot be misclassified before an authoritative refresh
- render parent issues as collapsible context bands with completion counts while keeping child and standalone issue columns aligned

## Verification

The GraphQL API coverage verifies that standalone issues and parent groups are returned in root order, children are ordered within their parent, and empty parents are omitted. Database, GitHub ingestion, and reconciliation coverage verifies that `hasChildren` is persisted and updated.
