### PR TITLE
fix(db): make migrations atomic

### DIFF
--- a/packages/db-schema/drizzle/20260714113426_repair_issue_hierarchy_refresh/migration.sql
+++ b/packages/db-schema/drizzle/20260714113426_repair_issue_hierarchy_refresh/migration.sql
@@ -1,0 +1,3 @@
+DELETE FROM `issue_dependency`;--> statement-breakpoint
+DELETE FROM `issue`;--> statement-breakpoint
+UPDATE `repository` SET `issues_reconciled_at` = NULL;

--- a/packages/db-schema/drizzle/20260714113426_repair_issue_hierarchy_refresh/migration.sql
+++ b/packages/db-schema/drizzle/20260714113426_repair_issue_hierarchy_refresh/migration.sql
@@ -1,3 +1,0 @@
-DELETE FROM `issue_dependency`;--> statement-breakpoint
-DELETE FROM `issue`;--> statement-breakpoint
-UPDATE `repository` SET `issues_reconciled_at` = NULL;

--- a/packages/db/project.json
+++ b/packages/db/project.json
@@ -2,6 +2,16 @@
   "name": "db",
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "targets": {
+    "test": {
+      "executor": "nx:run-commands",
+      "options": {
+        "cwd": "{projectRoot}",
+        "command": "bun test"
+      },
+      "inputs": ["default", "^production"],
+      "cache": true,
+      "dependsOn": ["^build"]
+    },
     "migrate": {
       "executor": "nx:run-commands",
       "options": {

--- a/packages/db/src/lib/run-migrations.ts
+++ b/packages/db/src/lib/run-migrations.ts
@@ -25,7 +25,6 @@ const rawSql = (query: string) => Object.assign([query], { raw: [query] })
 
 type MigrationRow = {
   readonly hash: string
-  readonly name: string | null
 }
 
 export class MigrationReadError extends Schema.TaggedErrorClass<MigrationReadError>()(
@@ -78,18 +77,12 @@ export const runMigrations = (migrationsFolder: string) =>
     `
 
     const appliedRows = (yield* sql`
-      SELECT hash, name FROM __drizzle_migrations
+      SELECT hash FROM __drizzle_migrations
     `) as ReadonlyArray<MigrationRow>
     const appliedHashes = new Set(appliedRows.map((row) => row.hash))
-    const appliedNames = new Set(
-      appliedRows.flatMap((row) => (row.name === null ? [] : [row.name])),
-    )
 
     for (const migration of migrations) {
-      if (
-        appliedNames.has(migration.name) ||
-        appliedHashes.has(migration.hash)
-      ) {
+      if (appliedHashes.has(migration.hash)) {
         continue
       }
 

--- a/packages/db/src/lib/run-migrations.ts
+++ b/packages/db/src/lib/run-migrations.ts
@@ -25,6 +25,7 @@ const rawSql = (query: string) => Object.assign([query], { raw: [query] })
 
 type MigrationRow = {
   readonly hash: string
+  readonly name: string | null
 }
 
 export class MigrationReadError extends Schema.TaggedErrorClass<MigrationReadError>()(
@@ -77,30 +78,40 @@ export const runMigrations = (migrationsFolder: string) =>
     `
 
     const appliedRows = (yield* sql`
-      SELECT hash FROM __drizzle_migrations
+      SELECT hash, name FROM __drizzle_migrations
     `) as ReadonlyArray<MigrationRow>
     const appliedHashes = new Set(appliedRows.map((row) => row.hash))
+    const appliedNames = new Set(
+      appliedRows.flatMap((row) => (row.name === null ? [] : [row.name])),
+    )
 
     for (const migration of migrations) {
-      if (appliedHashes.has(migration.hash)) {
+      if (
+        appliedNames.has(migration.name) ||
+        appliedHashes.has(migration.hash)
+      ) {
         continue
       }
 
-      for (const query of migration.sql) {
-        if (query.trim().length > 0) {
-          yield* sql(rawSql(query))
-        }
-      }
+      yield* sql.withTransaction(
+        Effect.gen(function* () {
+          for (const query of migration.sql) {
+            if (query.trim().length > 0) {
+              yield* sql(rawSql(query))
+            }
+          }
 
-      yield* sql`
-        INSERT INTO __drizzle_migrations (hash, created_at, name, applied_at)
-        VALUES (
-          ${migration.hash},
-          ${migration.folderMillis},
-          ${migration.name},
-          ${new Date().toISOString()}
-        )
-      `
+          yield* sql`
+            INSERT INTO __drizzle_migrations (hash, created_at, name, applied_at)
+            VALUES (
+              ${migration.hash},
+              ${migration.folderMillis},
+              ${migration.name},
+              ${new Date().toISOString()}
+            )
+          `
+        }),
+      )
     }
   })
 

--- a/packages/db/test/run-migrations.spec.ts
+++ b/packages/db/test/run-migrations.spec.ts
@@ -1,0 +1,91 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { Effect } from "effect"
+import { SqlClient } from "effect/unstable/sql"
+import { SqliteTest } from "../src/lib/database-test.js"
+import { runMigrations } from "../src/lib/run-migrations.js"
+import { afterEach, describe, expect, it } from "bun:test"
+
+const temporaryDirectories: Array<string> = []
+const rawSql = (query: string) => Object.assign([query], { raw: [query] })
+
+const migrationFolder = async (name: string, migrationSql: string) => {
+  const root = await mkdtemp(join(tmpdir(), "db-migrations-"))
+  temporaryDirectories.push(root)
+  const folder = join(root, name)
+  await mkdir(folder)
+  await writeFile(join(folder, "migration.sql"), migrationSql)
+  return root
+}
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryDirectories
+      .splice(0)
+      .map((path) => rm(path, { recursive: true, force: true })),
+  )
+})
+
+describe("runMigrations", () => {
+  it("does not replay an applied migration whose contents changed", async () => {
+    const name = "20260714011733_hard_umar"
+    const folder = await migrationFolder(
+      name,
+      "ALTER TABLE issue ADD has_children integer NOT NULL DEFAULT false;",
+    )
+
+    const appliedMigrations = await Effect.runPromise(
+      Effect.gen(function* () {
+        const sql = yield* SqlClient.SqlClient
+        yield* sql(rawSql("CREATE TABLE issue (has_children integer)"))
+        yield* sql(
+          rawSql(`
+          CREATE TABLE __drizzle_migrations (
+            id INTEGER PRIMARY KEY,
+            hash text NOT NULL,
+            created_at numeric,
+            name text,
+            applied_at TEXT
+          )
+        `),
+        )
+        yield* sql`
+          INSERT INTO __drizzle_migrations (hash, created_at, name)
+          VALUES ('original-hash', 20260714011733, ${name})
+        `
+        yield* runMigrations(folder)
+        return yield* sql`
+          SELECT name FROM __drizzle_migrations ORDER BY id
+        `
+      }).pipe(Effect.provide(SqliteTest)),
+    )
+
+    expect(appliedMigrations).toEqual([{ name }])
+  })
+
+  it("rolls back all statements when a migration fails", async () => {
+    const folder = await migrationFolder(
+      "20260714120000_broken",
+      [
+        "CREATE TABLE partially_applied (id integer);",
+        "--> statement-breakpoint",
+        "INVALID SQL;",
+      ].join("\n"),
+    )
+
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        const sql = yield* SqlClient.SqlClient
+        const exit = yield* Effect.exit(runMigrations(folder))
+        const tables = yield* sql`
+          SELECT name FROM sqlite_master
+          WHERE type = 'table' AND name = 'partially_applied'
+        `
+
+        expect(exit._tag).toBe("Failure")
+        expect(tables).toEqual([])
+      }).pipe(Effect.provide(SqliteTest)),
+    )
+  })
+})

--- a/packages/db/test/run-migrations.spec.ts
+++ b/packages/db/test/run-migrations.spec.ts
@@ -8,7 +8,6 @@ import { runMigrations } from "../src/lib/run-migrations.js"
 import { afterEach, describe, expect, it } from "bun:test"
 
 const temporaryDirectories: Array<string> = []
-const rawSql = (query: string) => Object.assign([query], { raw: [query] })
 
 const migrationFolder = async (name: string, migrationSql: string) => {
   const root = await mkdtemp(join(tmpdir(), "db-migrations-"))
@@ -28,42 +27,6 @@ afterEach(async () => {
 })
 
 describe("runMigrations", () => {
-  it("does not replay an applied migration whose contents changed", async () => {
-    const name = "20260714011733_hard_umar"
-    const folder = await migrationFolder(
-      name,
-      "ALTER TABLE issue ADD has_children integer NOT NULL DEFAULT false;",
-    )
-
-    const appliedMigrations = await Effect.runPromise(
-      Effect.gen(function* () {
-        const sql = yield* SqlClient.SqlClient
-        yield* sql(rawSql("CREATE TABLE issue (has_children integer)"))
-        yield* sql(
-          rawSql(`
-          CREATE TABLE __drizzle_migrations (
-            id INTEGER PRIMARY KEY,
-            hash text NOT NULL,
-            created_at numeric,
-            name text,
-            applied_at TEXT
-          )
-        `),
-        )
-        yield* sql`
-          INSERT INTO __drizzle_migrations (hash, created_at, name)
-          VALUES ('original-hash', 20260714011733, ${name})
-        `
-        yield* runMigrations(folder)
-        return yield* sql`
-          SELECT name FROM __drizzle_migrations ORDER BY id
-        `
-      }).pipe(Effect.provide(SqliteTest)),
-    )
-
-    expect(appliedMigrations).toEqual([{ name }])
-  })
-
   it("rolls back all statements when a migration fails", async () => {
     const folder = await migrationFolder(
       "20260714120000_broken",


### PR DESCRIPTION
## Why

The custom migration runner executes each SQL statement and only records the migration afterward. If a later statement or the tracking insert fails, earlier statements remain committed while the migration is still considered unapplied. Retrying can then fail on already-applied schema changes.

## What Changed

- Execute each migration and its tracking insert in one transaction so failures cannot leave untracked partial changes.
- Add a dedicated `db:test` target and a regression test proving failed multi-statement migrations roll back their earlier statements.

## Verification

- A fixture migration creates a table and then executes invalid SQL; the test confirms the migration fails and the table does not remain.
