### PR TITLE
feat: sort issues by actionability

### DIFF
--- a/apps/harness/src/server/keymaxxer-github-layer.ts
+++ b/apps/harness/src/server/keymaxxer-github-layer.ts
@@ -17,6 +17,7 @@ const SerializedIssue = Schema.Struct({
   state: Schema.Literals(["OPEN", "CLOSED"]),
   hierarchySupported: Schema.Boolean,
   hasChildren: Schema.Boolean,
+  parentPosition: Schema.NullOr(Schema.Finite),
   parent: Schema.NullOr(
     Schema.Struct({
       number: Schema.Finite,
@@ -79,6 +80,13 @@ const parseIssues = (
                 throw new Error("Invalid parent Issue number")
               }
               new URL(issue.parent.url)
+            }
+            if (
+              issue.parentPosition !== null &&
+              (!Number.isSafeInteger(issue.parentPosition) ||
+                issue.parentPosition < 0)
+            ) {
+              throw new Error("Invalid parent position")
             }
             for (const dependency of issue.blockedBy) {
               if (

--- a/apps/harness/test/keymaxxer-github-layer.test.ts
+++ b/apps/harness/test/keymaxxer-github-layer.test.ts
@@ -104,6 +104,7 @@ describe("Keymaxxer-backed GitHub layer", () => {
               state: "OPEN",
               hierarchySupported: true,
               hasChildren: false,
+              parentPosition: 0,
               parent: {
                 number: 1,
                 url: "https://github.com/acme/widgets/issues/1",

--- a/packages/db-schema/drizzle/20260714015155_military_goblin_queen/migration.sql
+++ b/packages/db-schema/drizzle/20260714015155_military_goblin_queen/migration.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `issue` ADD `parent_position` integer;

--- a/packages/db-schema/drizzle/20260714015155_military_goblin_queen/snapshot.json
+++ b/packages/db-schema/drizzle/20260714015155_military_goblin_queen/snapshot.json
@@ -1,0 +1,696 @@
+{
+  "version": "7",
+  "dialect": "sqlite",
+  "id": "557f6e44-154a-4c8b-b591-f71b45802d7e",
+  "prevIds": [
+    "be9189f9-1d1e-4f8d-a821-ed5040dc8bc2"
+  ],
+  "ddl": [
+    {
+      "name": "completed_job",
+      "entityType": "tables"
+    },
+    {
+      "name": "config",
+      "entityType": "tables"
+    },
+    {
+      "name": "issue",
+      "entityType": "tables"
+    },
+    {
+      "name": "issue_dependency",
+      "entityType": "tables"
+    },
+    {
+      "name": "job_queue",
+      "entityType": "tables"
+    },
+    {
+      "name": "repository",
+      "entityType": "tables"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "completed_job"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "queue",
+      "entityType": "columns",
+      "table": "completed_job"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "job_id",
+      "entityType": "columns",
+      "table": "completed_job"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "completed_job"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "completed_job"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "'default'",
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "config"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'opencode/deepseek-v4-flash-free'",
+      "generated": null,
+      "name": "default_model",
+      "entityType": "columns",
+      "table": "config"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'low'",
+      "generated": null,
+      "name": "default_variant",
+      "entityType": "columns",
+      "table": "config"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "config"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "config"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "issue"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "repository_id",
+      "entityType": "columns",
+      "table": "issue"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "github_issue_number",
+      "entityType": "columns",
+      "table": "issue"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "title",
+      "entityType": "columns",
+      "table": "issue"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "body",
+      "entityType": "columns",
+      "table": "issue"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "url",
+      "entityType": "columns",
+      "table": "issue"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "state",
+      "entityType": "columns",
+      "table": "issue"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "github_created_at",
+      "entityType": "columns",
+      "table": "issue"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "parent_github_issue_number",
+      "entityType": "columns",
+      "table": "issue"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "parent_github_issue_url",
+      "entityType": "columns",
+      "table": "issue"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "parent_position",
+      "entityType": "columns",
+      "table": "issue"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "false",
+      "generated": null,
+      "name": "has_children",
+      "entityType": "columns",
+      "table": "issue"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "issue"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "issue"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "issue_dependency"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "issue_id",
+      "entityType": "columns",
+      "table": "issue_dependency"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "blocking_github_issue_number",
+      "entityType": "columns",
+      "table": "issue_dependency"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "blocking_github_issue_url",
+      "entityType": "columns",
+      "table": "issue_dependency"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "issue_dependency"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "job_queue"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "queue",
+      "entityType": "columns",
+      "table": "job_queue"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "job_payload",
+      "entityType": "columns",
+      "table": "job_queue"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "0",
+      "generated": null,
+      "name": "job_attempts",
+      "entityType": "columns",
+      "table": "job_queue"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "5",
+      "generated": null,
+      "name": "job_retry_limit",
+      "entityType": "columns",
+      "table": "job_queue"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "available_at",
+      "entityType": "columns",
+      "table": "job_queue"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "locked_until",
+      "entityType": "columns",
+      "table": "job_queue"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "job_queue"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "job_queue"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "repository"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "github_owner",
+      "entityType": "columns",
+      "table": "repository"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "github_repo",
+      "entityType": "columns",
+      "table": "repository"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "local_path",
+      "entityType": "columns",
+      "table": "repository"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "is_bare",
+      "entityType": "columns",
+      "table": "repository"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "true",
+      "generated": null,
+      "name": "paused",
+      "entityType": "columns",
+      "table": "repository"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "issues_reconciled_at",
+      "entityType": "columns",
+      "table": "repository"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "repository"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "repository"
+    },
+    {
+      "columns": [
+        "repository_id"
+      ],
+      "tableTo": "repository",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_issue_repository_id_repository_id_fk",
+      "entityType": "fks",
+      "table": "issue"
+    },
+    {
+      "columns": [
+        "issue_id"
+      ],
+      "tableTo": "issue",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_issue_dependency_issue_id_issue_id_fk",
+      "entityType": "fks",
+      "table": "issue_dependency"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "completed_job_pk",
+      "table": "completed_job",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "config_pk",
+      "table": "config",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "issue_pk",
+      "table": "issue",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "issue_dependency_pk",
+      "table": "issue_dependency",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "job_queue_pk",
+      "table": "job_queue",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "repository_pk",
+      "table": "repository",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        {
+          "value": "queue",
+          "isExpression": false
+        },
+        {
+          "value": "job_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "origin": "manual",
+      "name": "completed_job_queue_job_id_uidx",
+      "entityType": "indexes",
+      "table": "completed_job"
+    },
+    {
+      "columns": [
+        {
+          "value": "repository_id",
+          "isExpression": false
+        },
+        {
+          "value": "github_issue_number",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "origin": "manual",
+      "name": "issue_repository_id_github_issue_number_uidx",
+      "entityType": "indexes",
+      "table": "issue"
+    },
+    {
+      "columns": [
+        {
+          "value": "issue_id",
+          "isExpression": false
+        },
+        {
+          "value": "blocking_github_issue_url",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "origin": "manual",
+      "name": "issue_dependency_issue_id_blocking_url_uidx",
+      "entityType": "indexes",
+      "table": "issue_dependency"
+    },
+    {
+      "columns": [
+        {
+          "value": "queue",
+          "isExpression": false
+        },
+        {
+          "value": "locked_until",
+          "isExpression": false
+        },
+        {
+          "value": "job_attempts",
+          "isExpression": false
+        },
+        {
+          "value": "available_at",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "job_queue_ready_idx",
+      "entityType": "indexes",
+      "table": "job_queue"
+    },
+    {
+      "columns": [
+        {
+          "value": "lower(\"github_owner\")",
+          "isExpression": true
+        },
+        {
+          "value": "lower(\"github_repo\")",
+          "isExpression": true
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "origin": "manual",
+      "name": "repository_github_owner_repo_lower_uidx",
+      "entityType": "indexes",
+      "table": "repository"
+    },
+    {
+      "columns": [
+        "local_path"
+      ],
+      "nameExplicit": false,
+      "name": "repository_local_path_unique",
+      "entityType": "uniques",
+      "table": "repository"
+    }
+  ],
+  "renames": []
+}

--- a/packages/db-schema/src/schema.ts
+++ b/packages/db-schema/src/schema.ts
@@ -64,6 +64,7 @@ export const issue = snakeCase.table(
     githubCreatedAt: integer({ mode: "number" }).notNull(),
     parentGithubIssueNumber: integer(),
     parentGithubIssueUrl: text(),
+    parentPosition: integer(),
     hasChildren: integer({ mode: "boolean" }).notNull().default(false),
     createdAt: integer({ mode: "number" })
       .notNull()

--- a/packages/db-service/src/lib/db-service.ts
+++ b/packages/db-service/src/lib/db-service.ts
@@ -101,6 +101,7 @@ const toIssueRecord = (row: {
   githubCreatedAt: number
   parentGithubIssueNumber: number | null
   parentGithubIssueUrl: string | null
+  parentPosition: number | null
   hasChildren: number | boolean
   blockedBy: readonly IssueDependency[]
 }): IssueRecord => ({
@@ -112,6 +113,7 @@ const toIssueRecord = (row: {
   url: row.url,
   state: row.state,
   githubCreatedAt: new Date(row.githubCreatedAt),
+  parentPosition: row.parentPosition,
   hasChildren: Boolean(row.hasChildren),
   parent:
     row.parentGithubIssueNumber === null || row.parentGithubIssueUrl === null
@@ -514,6 +516,16 @@ export const DbServiceLive = Layer.effect(
             message: "parent must have a positive issue number and valid URL",
           })
         }
+        if (
+          input.parentPosition !== null &&
+          (!Number.isSafeInteger(input.parentPosition) ||
+            input.parentPosition < 0)
+        ) {
+          return yield* new InvalidIssueInputError({
+            field: "parentPosition",
+            message: "parentPosition must be a non-negative integer or null",
+          })
+        }
 
         for (const dependency of input.blockedBy) {
           if (
@@ -544,8 +556,9 @@ export const DbServiceLive = Layer.effect(
                   `INSERT INTO issue (
                id, repository_id, github_issue_number, title, body, url, state,
                 github_created_at, parent_github_issue_number,
-                 parent_github_issue_url, has_children, created_at, updated_at
-              ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                 parent_github_issue_url, parent_position, has_children,
+                 created_at, updated_at
+              ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
              ON CONFLICT (repository_id, github_issue_number) DO UPDATE SET
                title = excluded.title,
                body = excluded.body,
@@ -554,11 +567,12 @@ export const DbServiceLive = Layer.effect(
                 github_created_at = excluded.github_created_at,
                  parent_github_issue_number = excluded.parent_github_issue_number,
                  parent_github_issue_url = excluded.parent_github_issue_url,
+                 parent_position = excluded.parent_position,
                  has_children = excluded.has_children,
                  updated_at = excluded.updated_at
               RETURNING id, repository_id, github_issue_number, title, body, url, state,
                 github_created_at, parent_github_issue_number,
-                 parent_github_issue_url, has_children`,
+                 parent_github_issue_url, parent_position, has_children`,
                   [
                     `issue-${ulid()}`,
                     input.repositoryId,
@@ -570,6 +584,7 @@ export const DbServiceLive = Layer.effect(
                     input.githubCreatedAt.getTime(),
                     input.parent?.githubIssueNumber ?? null,
                     input.parent?.githubIssueUrl ?? null,
+                    input.parentPosition,
                     input.hasChildren,
                     now,
                     now,
@@ -589,6 +604,7 @@ export const DbServiceLive = Layer.effect(
                     github_created_at: number
                     parent_github_issue_number: number | null
                     parent_github_issue_url: string | null
+                    parent_position: number | null
                     has_children: number
                   }
                 | undefined
@@ -644,6 +660,7 @@ export const DbServiceLive = Layer.effect(
                 githubCreatedAt: row.github_created_at,
                 parentGithubIssueNumber: row.parent_github_issue_number,
                 parentGithubIssueUrl: row.parent_github_issue_url,
+                parentPosition: row.parent_position,
                 hasChildren: row.has_children,
                 blockedBy: dependencies,
               })
@@ -669,7 +686,7 @@ export const DbServiceLive = Layer.effect(
           .unsafe(
             `SELECT id, repository_id, github_issue_number, title, body, url, state,
                 github_created_at, parent_github_issue_number,
-                parent_github_issue_url, has_children
+                parent_github_issue_url, parent_position, has_children
              FROM issue WHERE repository_id = ? ORDER BY github_issue_number ASC`,
             [repositoryId],
           )
@@ -713,6 +730,7 @@ export const DbServiceLive = Layer.effect(
             github_created_at: number
             parent_github_issue_number: number | null
             parent_github_issue_url: string | null
+            parent_position: number | null
             has_children: number
           }>
         ).map((issue) =>
@@ -727,6 +745,7 @@ export const DbServiceLive = Layer.effect(
             githubCreatedAt: issue.github_created_at,
             parentGithubIssueNumber: issue.parent_github_issue_number,
             parentGithubIssueUrl: issue.parent_github_issue_url,
+            parentPosition: issue.parent_position,
             hasChildren: issue.has_children,
             blockedBy: dependenciesByIssue.get(issue.id) ?? [],
           }),

--- a/packages/db-service/src/lib/errors.ts
+++ b/packages/db-service/src/lib/errors.ts
@@ -36,6 +36,7 @@ export class InvalidIssueInputError extends Data.TaggedError(
     | "state"
     | "githubCreatedAt"
     | "parent"
+    | "parentPosition"
     | "blockedBy"
   readonly message: string
 }> {}

--- a/packages/db-service/src/lib/types.ts
+++ b/packages/db-service/src/lib/types.ts
@@ -34,6 +34,7 @@ export interface StoreIssueInput {
   readonly state: IssueState
   readonly githubCreatedAt: Date
   readonly parent: IssueReference | null
+  readonly parentPosition: number | null
   readonly hasChildren: boolean
   readonly blockedBy: readonly IssueDependency[]
 }
@@ -50,6 +51,7 @@ export interface IssueRecord {
   readonly state: IssueState
   readonly githubCreatedAt: Date
   readonly parent: IssueReference | null
+  readonly parentPosition: number | null
   readonly hasChildren: boolean
   readonly blockedBy: readonly IssueDependency[]
 }

--- a/packages/db-service/test/db-service.spec.ts
+++ b/packages/db-service/test/db-service.spec.ts
@@ -35,6 +35,7 @@ describe("DbService", () => {
     url: "https://github.com/acme/widgets/issues/42",
     state: "OPEN" as const,
     parent: null,
+    parentPosition: null,
     hasChildren: false,
     blockedBy: [],
   }
@@ -410,6 +411,7 @@ describe("DbService", () => {
 
           const withParent = yield* db.storeIssue({
             ...baseInput,
+            parentPosition: 4,
             parent: {
               githubIssueNumber: 7,
               githubIssueUrl: "https://github.com/acme/widgets/issues/7",
@@ -419,8 +421,12 @@ describe("DbService", () => {
             githubIssueNumber: 7,
             githubIssueUrl: "https://github.com/acme/widgets/issues/7",
           })
+          expect(withParent.parentPosition).toBe(4)
           expect((yield* db.listIssues(repository.id))[0]?.parent).toEqual(
             withParent.parent,
+          )
+          expect((yield* db.listIssues(repository.id))[0]?.parentPosition).toBe(
+            4,
           )
 
           const withoutParent = yield* db.storeIssue({
@@ -428,6 +434,7 @@ describe("DbService", () => {
             parent: null,
           })
           expect(withoutParent.parent).toBeNull()
+          expect(withoutParent.parentPosition).toBeNull()
           expect((yield* db.listIssues(repository.id))[0]?.parent).toBeNull()
         }),
       ))

--- a/packages/github-service/src/lib/github-service-live.ts
+++ b/packages/github-service/src/lib/github-service-live.ts
@@ -83,7 +83,10 @@ interface InternalIssueParent extends GitHubIssueReference {
 }
 
 interface InternalReadyLabeledIssue
-  extends Omit<ReadyLabeledIssue, "parent" | "hierarchySupported"> {
+  extends Omit<
+    ReadyLabeledIssue,
+    "parent" | "parentPosition" | "hierarchySupported"
+  > {
   readonly parent: InternalIssueParent | null
   readonly hasUnsupportedDescendants: boolean
 }
@@ -167,6 +170,19 @@ const pageHasUnsupportedSubIssue = (
   })
 }
 
+const recordSubIssuePositions = (
+  connection: GitHubApiSubIssueConnection,
+  positions: Map<string, number>,
+  offset: number,
+): number => {
+  for (const [index, issue] of (connection.nodes ?? []).entries()) {
+    if (issue !== null) {
+      positions.set(toIssueReference(issue).url.toLowerCase(), offset + index)
+    }
+  }
+  return offset + (connection.nodes?.length ?? 0)
+}
+
 const toReadyLabeledIssue = (
   issue: GitHubApiIssue,
   repositoryName: string,
@@ -235,6 +251,7 @@ export const makeGitHubService = (
   listReadyIssues: (repository) =>
     Effect.gen(function* () {
       const issues: InternalReadyLabeledIssue[] = []
+      const subIssuePositions = new Map<string, number>()
       const repositoryName = `${repository.owner}/${repository.name}`
       let after: string | null = null
 
@@ -320,6 +337,19 @@ export const makeGitHubService = (
           let blockedByPage = issueNode.blockedBy.pageInfo
           let hasUnsupportedDescendants = mappedIssue.hasUnsupportedDescendants
           let subIssuesPage = issueNode.subIssues.pageInfo
+          let subIssueOffset = yield* Effect.try({
+            try: () =>
+              recordSubIssuePositions(
+                issueNode.subIssues,
+                subIssuePositions,
+                0,
+              ),
+            catch: (cause) =>
+              new GitHubRequestError({
+                message: `GitHub returned invalid sub-issue data for ${repositoryName}#${mappedIssue.number}`,
+                cause,
+              }),
+          })
 
           while (blockedByPage.hasNextPage) {
             if (blockedByPage.endCursor === null) {
@@ -432,6 +462,19 @@ export const makeGitHubService = (
                     cause,
                   }),
               }))
+            subIssueOffset = yield* Effect.try({
+              try: () =>
+                recordSubIssuePositions(
+                  connection,
+                  subIssuePositions,
+                  subIssueOffset,
+                ),
+              catch: (cause) =>
+                new GitHubRequestError({
+                  message: `GitHub returned invalid sub-issue data for ${repositoryName}#${mappedIssue.number}`,
+                  cause,
+                }),
+            })
             subIssuesPage = connection.pageInfo
           }
 
@@ -494,6 +537,10 @@ export const makeGitHubService = (
             createdAt: issue.createdAt,
             state: issue.state,
             hasChildren: issue.hasChildren,
+            parentPosition:
+              issue.parent === null
+                ? null
+                : (subIssuePositions.get(issueUrlKey(issue.url)) ?? null),
             parent:
               issue.parent === null
                 ? null

--- a/packages/github-service/src/lib/types.ts
+++ b/packages/github-service/src/lib/types.ts
@@ -23,6 +23,7 @@ export interface ReadyLabeledIssue {
   readonly createdAt: Date
   readonly state: GitHubIssueState
   readonly parent: GitHubIssueParent | null
+  readonly parentPosition: number | null
   readonly hasChildren: boolean
   readonly hierarchySupported: boolean
   readonly blockedBy: readonly GitHubIssueReference[]

--- a/packages/github-service/test/github-service.spec.ts
+++ b/packages/github-service/test/github-service.spec.ts
@@ -25,6 +25,7 @@ const issue = (
   createdAt: new Date(`2026-07-${String(number).padStart(2, "0")}T12:00:00Z`),
   state,
   parent: null,
+  parentPosition: null,
   hasChildren: false,
   hierarchySupported: true,
   blockedBy: [],
@@ -127,6 +128,7 @@ describe("GitHubService live implementation", () => {
       createdAt: new Date("2026-07-02T12:00:00Z"),
       state: "CLOSED",
       parent: null,
+      parentPosition: null,
       hasChildren: false,
       hierarchySupported: true,
       blockedBy: [],
@@ -326,8 +328,8 @@ describe("GitHubService live implementation", () => {
                 subIssues: {
                   nodes: [
                     {
-                      number: 3,
-                      url: "https://github.com/acme/widgets/issues/3",
+                      number: 2,
+                      url: "https://github.com/acme/widgets/issues/2",
                       repository: { nameWithOwner: "acme/widgets" },
                       subIssuesSummary: { total: 1 },
                     },
@@ -357,6 +359,7 @@ describe("GitHubService live implementation", () => {
     ])
     expect(result.map(({ hasChildren }) => hasChildren)).toEqual([true, false])
     expect(result[1]?.parent?.isReadyLabeled).toBe(true)
+    expect(result[1]?.parentPosition).toBe(0)
   })
 
   it("checks every sub-issue page for cross-Repository relationships", async () => {
@@ -508,6 +511,61 @@ describe("GitHubService live implementation", () => {
     if (Result.isFailure(result)) {
       expect(result.failure).toBeInstanceOf(GitHubRequestError)
       expect(result.failure.message).toContain("invalid Issue data")
+    }
+  })
+
+  it("wraps malformed sub-issue positions as request errors", async () => {
+    const client = {
+      query: async () => ({
+        repository: {
+          issues: {
+            nodes: [
+              {
+                number: 1,
+                title: "Root",
+                body: "Body",
+                url: "https://github.com/acme/widgets/issues/1",
+                createdAt: "2026-07-01T12:00:00Z",
+                state: "OPEN",
+                parent: null,
+                subIssuesSummary: { total: 2 },
+                subIssues: {
+                  nodes: [
+                    {
+                      number: 2,
+                      url: "https://github.com/acme/other/issues/2",
+                      repository: { nameWithOwner: "acme/other" },
+                      subIssuesSummary: { total: 0 },
+                    },
+                    {
+                      number: "invalid",
+                      url: "https://github.com/acme/widgets/issues/3",
+                      repository: { nameWithOwner: "acme/widgets" },
+                      subIssuesSummary: { total: 0 },
+                    },
+                  ],
+                  pageInfo: { endCursor: null, hasNextPage: false },
+                },
+                blockedBy: {
+                  nodes: [],
+                  pageInfo: { endCursor: null, hasNextPage: false },
+                },
+              },
+            ],
+            pageInfo: { endCursor: null, hasNextPage: false },
+          },
+        },
+      }),
+    } as GitHubGraphqlClient
+
+    const result = await Effect.runPromise(
+      makeGitHubService(client).listReadyIssues(repository).pipe(Effect.result),
+    )
+
+    expect(Result.isFailure(result)).toBe(true)
+    if (Result.isFailure(result)) {
+      expect(result.failure).toBeInstanceOf(GitHubRequestError)
+      expect(result.failure.message).toContain("invalid sub-issue data")
     }
   })
 

--- a/packages/graphql-api/src/lib/graphql-api.ts
+++ b/packages/graphql-api/src/lib/graphql-api.ts
@@ -62,6 +62,17 @@ type IssuesArgs = {
   repositoryId: string
 }
 
+const childIssueCategory = (issue: IssueRecord): number => {
+  if (issue.state === "CLOSED") return 2
+  return issue.blockedBy.length === 0 ? 0 : 1
+}
+
+const compareChildIssues = (left: IssueRecord, right: IssueRecord): number =>
+  childIssueCategory(left) - childIssueCategory(right) ||
+  (left.parentPosition ?? Number.MAX_SAFE_INTEGER) -
+    (right.parentPosition ?? Number.MAX_SAFE_INTEGER) ||
+  left.githubIssueNumber - right.githubIssueNumber
+
 const workIssueProjection = (
   issues: readonly IssueRecord[],
 ): readonly IssueRecord[] => {
@@ -80,12 +91,7 @@ const workIssueProjection = (
       if (!issue.hasChildren) return [issue]
       const children = childrenByParent.get(issue.githubIssueNumber) ?? []
       if (children.length === 0) return []
-      return [
-        issue,
-        ...children.sort(
-          (left, right) => left.githubIssueNumber - right.githubIssueNumber,
-        ),
-      ]
+      return [issue, ...children.sort(compareChildIssues)]
     })
 }
 

--- a/packages/graphql-api/test/graphql-api.test.ts
+++ b/packages/graphql-api/test/graphql-api.test.ts
@@ -37,6 +37,7 @@ const issue = {
   state: "OPEN" as const,
   githubCreatedAt: new Date("2026-07-12T10:30:00.000Z"),
   parent: null,
+  parentPosition: null,
   hasChildren: false,
   blockedBy: [
     {
@@ -465,7 +466,7 @@ describe("GraphQL API", () => {
     expect(requestedRepositoryId).toBe(repository.id)
   })
 
-  test("returns standalone and grouped child work in root order", async () => {
+  test("groups child work by actionability and preserves GitHub order", async () => {
     const makeIssue = (
       githubIssueNumber: number,
       overrides: Partial<typeof issue> = {},
@@ -488,10 +489,20 @@ describe("GraphQL API", () => {
       listIssues: () =>
         Effect.succeed([
           makeIssue(20, { hasChildren: true }),
-          makeIssue(12, { parent: parentReference, state: "CLOSED" }),
+          makeIssue(12, {
+            parent: parentReference,
+            parentPosition: 0,
+            state: "CLOSED",
+          }),
           makeIssue(3),
           parent,
-          makeIssue(11, { parent: parentReference }),
+          makeIssue(11, { parent: parentReference, parentPosition: 3 }),
+          makeIssue(13, {
+            parent: parentReference,
+            parentPosition: 1,
+            blockedBy: issue.blockedBy,
+          }),
+          makeIssue(14, { parent: parentReference, parentPosition: 2 }),
         ]),
     })
 
@@ -513,7 +524,17 @@ describe("GraphQL API", () => {
           { githubIssueNumber: 3, hasChildren: false, parent: null },
           { githubIssueNumber: 10, hasChildren: true, parent: null },
           {
+            githubIssueNumber: 14,
+            hasChildren: false,
+            parent: { githubIssueNumber: 10 },
+          },
+          {
             githubIssueNumber: 11,
+            hasChildren: false,
+            parent: { githubIssueNumber: 10 },
+          },
+          {
+            githubIssueNumber: 13,
             hasChildren: false,
             parent: { githubIssueNumber: 10 },
           },

--- a/packages/issue-reconciler/src/lib/issue-reconciler.ts
+++ b/packages/issue-reconciler/src/lib/issue-reconciler.ts
@@ -62,6 +62,7 @@ const matches = (local: IssueRecord, remote: ReadyLabeledIssue): boolean =>
   local.state === remote.state &&
   local.githubCreatedAt.getTime() === remote.createdAt.getTime() &&
   local.hasChildren === remote.hasChildren &&
+  local.parentPosition === remote.parentPosition &&
   local.parent?.githubIssueNumber === remote.parent?.number &&
   local.parent?.githubIssueUrl === remote.parent?.url &&
   local.blockedBy.length === remote.blockedBy.length &&
@@ -149,6 +150,7 @@ export const IssueReconcilerLive = Layer.effect(
             url: issue.url,
             state: issue.state,
             githubCreatedAt: issue.createdAt,
+            parentPosition: issue.parentPosition,
             hasChildren: issue.hasChildren,
             parent:
               issue.parent === null

--- a/packages/issue-reconciler/test/issue-reconciler.spec.ts
+++ b/packages/issue-reconciler/test/issue-reconciler.spec.ts
@@ -42,6 +42,7 @@ const remoteIssue = (
   ),
   state: "OPEN",
   parent: null,
+  parentPosition: null,
   hasChildren: false,
   hierarchySupported: true,
   blockedBy: [],
@@ -62,6 +63,7 @@ const localIssue = (
     url: remote.url,
     githubCreatedAt: remote.createdAt,
     state: remote.state,
+    parentPosition: remote.parentPosition,
     hasChildren: remote.hasChildren,
     parent:
       remote.parent === null
@@ -317,6 +319,7 @@ describe("IssueReconciler", () => {
     const github = makeGitHubLayer(
       [
         remoteIssue(1, {
+          parentPosition: 4,
           parent: {
             number: 9,
             url: "https://github.com/acme/widgets/issues/9",
@@ -338,6 +341,7 @@ describe("IssueReconciler", () => {
           githubIssueNumber: 9,
           githubIssueUrl: "https://github.com/acme/widgets/issues/9",
         })
+        expect(db.stored[0]?.parentPosition).toBe(4)
       }),
       db.layer,
       github,


### PR DESCRIPTION
## Why

The UI renders issues in the order returned by GraphQL, but issue-number ordering does not prioritize work that can be started. Child issues should surface actionable work first while retaining the manual order configured on GitHub within each status group.

## What Changed

- Capture each child's position from GitHub's ordered `subIssues` connection.
- Persist that position through reconciliation in a new nullable `parent_position` column.
- Return children under each parent in this order: open and unblocked, open and blocked, then closed.
- Preserve GitHub's manual child order within each category, with issue number as a deterministic fallback.
- Keep root issues in their existing issue-number order.
- Return typed `GitHubRequestError` failures when GitHub supplies malformed sub-issue position data.

## Verification

The GraphQL projection test interleaves actionable, blocked, and closed children across GitHub positions and verifies category ordering plus GitHub order within each category. GitHub service tests also verify position capture and malformed-data handling.
