### PR TITLE
docs: define job worker architecture

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -7,8 +7,15 @@
 - Database is Turso database (sqlite)
 - Backend is Effect TS
 - Services are implemented as Effect TS
-- Separate job worker who handles jobs
+- The application runtime hosts a scoped job worker service whose Effect fibers handle jobs; see `docs/adr/0007-host-job-worker-in-harness.md`
+- Every job implementation is an Effect; the job worker composes and runs those Effects for work claimed from the database queue
+- A tagged payload in the shared `jobs` queue selects the Job Effect; the worker owns claim, decoding, dispatch, acknowledgement, and failure handling
 - UI is responsive: anything that takes long is put in a queue and handled by the job worker
+- Successful Issue reconciliation publishes a Repository-specific GraphQL invalidation so subscribed clients can refetch; no client-facing job history or status snapshots are maintained
+- The first worker executes one job at a time with five-minute claim visibility; job failures are terminal, while an abandoned claim may be redelivered once after interruption
+- The scoped worker polls once per second while idle and logs and recovers from queue infrastructure errors instead of permanently terminating its fiber
+- Queue methods acquire their SQL dependency when constructing the queue layer and return self-contained Effects; complete issue #13 before implementing the worker
+- Public Job IDs use the canonical `qjob-<ULID>` format
 - Prefer Bun APIs.
 - All action/work is done by clanker, harness only does the purely deterministic steering,
   while always consulting the clanker for advice.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -9,7 +9,7 @@ A GitHub repository the harness is configured to work on, identified by owner an
 _Avoid_: Repo (in formal docs), target, project, checkout
 
 **Paused**:
-A Repository state in which the harness does not process the repo (no issue polling, worktrees, or jobs) while keeping the configuration. New Repositories start paused until deliberately unpaused.
+A Repository state in which the harness does not autonomously process the Repository while keeping its configuration. Explicit operator requests, including a manual Refresh Job, remain allowed; new Repositories start paused until deliberately unpaused.
 _Avoid_: Disabled, inactive, enabled=false
 
 **Issue**:
@@ -22,6 +22,10 @@ The harness capability that retains the Repository's current working set of Rele
 **Issue Reconciler**:
 The sole harness capability that changes the Issue store, deriving one Repository's Relevant Issues from GitHub's authoritative set of Ready-labeled Issues. Issues that are not Relevant, including Issues whose ready label was removed, are absent from the Issue store after reconciliation.
 _Avoid_: GitHub Reconciler (too broad), Issue Synchronizer (suggests bidirectional updates)
+
+**Refresh Job**:
+A durable request for the Issue Reconciler to reconcile one Repository. Acceptance of a Refresh Job does not mean reconciliation has completed.
+_Avoid_: Refresh (ambiguous between the request and its execution), sync job
 
 **Keymaxxer Service**:
 The backend boundary for vault operations. It can determine whether a named secret exists, request that a secret be added, and run a command with named secrets injected without exposing raw secret values to the Harness.

--- a/docs/adr/0007-host-job-worker-in-harness.md
+++ b/docs/adr/0007-host-job-worker-in-harness.md
@@ -1,0 +1,3 @@
+# Host the job worker in Harness
+
+The job worker runs as a long-lived scoped service in the Harness application runtime, using Effect fibers for polling and job execution rather than running as a separate OS process. This keeps the first worker operationally simple and lets it reuse Harness services, including credential-backed GitHub access; the trade-off is that application shutdowns and development reloads interrupt in-flight work, which the database queue must safely redeliver.


### PR DESCRIPTION
## Summary

- define the scoped Effect job worker architecture inside the Harness runtime
- document tagged Job dispatch, queue visibility, interruption recovery, and Repository-specific invalidation
- clarify that Paused Repositories allow explicit manual Refresh Jobs
- record the decision not to introduce a separate worker process

## Testing

- `git diff --check origin/main...HEAD`
- commit hooks: commitlint passed; Nx reported no affected tasks for the documentation-only change

Related to #55.
