### PR TITLE
refactor(queue): adopt service layers

### DIFF
--- a/packages/queue-service/src/lib/queue-service.ts
+++ b/packages/queue-service/src/lib/queue-service.ts
@@ -67,15 +67,13 @@ export const validateQueueName = (
 }
 
 /**
- * Queue service interface with generic context type parameter.
- * Different implementations (SQLite/Turso, SQS) can specify their required context.
- *
+ * Queue service interface.
  * Implementations provide rawClaim which returns unparsed payloads.
  * Use QueueService.claim() for type-safe payload parsing with a schema.
  *
- * @template R - The context/dependencies required by the implementation
+ * Method Effects have R = never; backends acquire deps once in their Layer.
  */
-export interface QueueServiceShape<R = never> {
+export interface QueueServiceShape {
   /**
    * Whether enqueue operations should be performed inside database transactions.
    * True for database-backed queues (SQLite, Turso) to avoid lock contention.
@@ -96,7 +94,7 @@ export interface QueueServiceShape<R = never> {
     queue: string,
     payload: P,
     options?: { readonly retryLimit?: number },
-  ) => Effect.Effect<string, EnqueueError | InvalidQueueNameError, R>
+  ) => Effect.Effect<string, EnqueueError | InvalidQueueNameError>
 
   /**
    * Add a job to the queue with a delay before it becomes available.
@@ -107,7 +105,7 @@ export interface QueueServiceShape<R = never> {
     payload: P,
     delay: Duration.Duration,
     options?: { readonly retryLimit?: number },
-  ) => Effect.Effect<string, EnqueueError | InvalidQueueNameError, R>
+  ) => Effect.Effect<string, EnqueueError | InvalidQueueNameError>
 
   /**
    * Claim the next available job from the queue (raw, unparsed payload).
@@ -117,18 +115,14 @@ export interface QueueServiceShape<R = never> {
   readonly rawClaim: (
     queue: string,
     visibilityTimeout?: Duration.Duration,
-  ) => Effect.Effect<
-    Option.Option<RawJob>,
-    ClaimError | InvalidQueueNameError,
-    R
-  >
+  ) => Effect.Effect<Option.Option<RawJob>, ClaimError | InvalidQueueNameError>
 
   /**
    * Mark a job as successfully completed. Removes it from the queue.
    */
   readonly acknowledge: (
     jobId: string,
-  ) => Effect.Effect<void, AcknowledgeError | JobNotFoundError, R>
+  ) => Effect.Effect<void, AcknowledgeError | JobNotFoundError>
 
   /**
    * Mark a job as failed. The job will be retried after becoming
@@ -142,7 +136,7 @@ export interface QueueServiceShape<R = never> {
       readonly releaseImmediately?: boolean
       readonly retryable?: boolean
     },
-  ) => Effect.Effect<void, AcknowledgeError | JobNotFoundError, R>
+  ) => Effect.Effect<void, AcknowledgeError | JobNotFoundError>
 
   /**
    * Set a new visibility timeout for a job that needs more processing time.
@@ -152,21 +146,19 @@ export interface QueueServiceShape<R = never> {
   readonly extendVisibility: (
     jobId: string,
     timeout: Duration.Duration,
-  ) => Effect.Effect<void, AcknowledgeError | JobNotFoundError, R>
+  ) => Effect.Effect<void, AcknowledgeError | JobNotFoundError>
 
   /**
    * Get queue statistics (for monitoring).
    */
   readonly getStats: (
     queue: string,
-  ) => Effect.Effect<QueueStats, InvalidQueueNameError, R>
+  ) => Effect.Effect<QueueStats, InvalidQueueNameError>
 }
 
-/** @effect-expect-leaking any */
 export class QueueService extends Context.Service<
   QueueService,
-  // biome-ignore lint/suspicious/noExplicitAny: Required for generic service tag accepting multiple DB implementations
-  QueueServiceShape<any>
+  QueueServiceShape
 >()("@ready-for-agent/queue-service/QueueService") {
   /**
    * Claim the next available job from the queue with type-safe payload parsing.
@@ -174,7 +166,7 @@ export class QueueService extends Context.Service<
    */
   static claim = <A>(
     queue: string,
-    schema: Schema.Schema<A>,
+    schema: Schema.Decoder<A>,
     visibilityTimeout?: Duration.Duration,
   ): Effect.Effect<
     Option.Option<Job<A>>,

--- a/packages/sqlite-queue-service/src/lib/sqlite-queue-service.ts
+++ b/packages/sqlite-queue-service/src/lib/sqlite-queue-service.ts
@@ -70,196 +70,138 @@ const rawJob = (row: JobRow): RawJob => ({
   lockedUntil: toUtc(row.locked_until ?? row.available_at),
 })
 
-export const SqliteQueueServiceLive = Layer.succeed(
+export const SqliteQueueServiceLive = Layer.effect(
   QueueService,
-  QueueService.of({
-    queueInTransaction: true,
-    enqueue: <P extends Payload>(
-      queue: string,
-      payload: P,
-      options?: { readonly retryLimit?: number },
-    ) =>
-      Effect.gen(function* () {
-        yield* validateQueueName(queue)
-        const sql = yield* SqlClient.SqlClient
-        const now = Date.now()
-        const rows = yield* retrySqliteBusy(
-          sql.unsafe(
-            `INSERT INTO job_queue (id, queue, job_payload, job_retry_limit, available_at, locked_until, created_at, updated_at)
-             VALUES (lower(hex(randomblob(16))), ?, ?, ?, ?, NULL, ?, ?) RETURNING id`,
-            [
-              queue,
-              JSON.stringify(payload),
-              options?.retryLimit === undefined
-                ? DEFAULT_MAX_RETRIES
-                : options.retryLimit + 1,
-              now,
-              now,
-              now,
-            ],
-          ),
-        ).pipe(
-          Effect.mapError(
-            (error) =>
-              new EnqueueError({
-                queue,
-                message: `Database error: ${formatSqlError(error)}`,
-                cause: error,
-              }),
-          ),
-        )
-        const row = rows[0] as { readonly id: string } | undefined
-        if (!row)
-          return yield* new EnqueueError({
-            queue,
-            message: "No job ID returned from insert",
-          })
-        return row.id
-      }),
-    enqueueWithDelay: <P extends Payload>(
-      queue: string,
-      payload: P,
-      delay: Duration.Duration,
-      options?: { readonly retryLimit?: number },
-    ) =>
-      Effect.gen(function* () {
-        yield* validateQueueName(queue)
-        const sql = yield* SqlClient.SqlClient
-        const now = Date.now()
-        const rows = yield* retrySqliteBusy(
-          sql.unsafe(
-            `INSERT INTO job_queue (id, queue, job_payload, job_retry_limit, available_at, locked_until, created_at, updated_at)
-             VALUES (lower(hex(randomblob(16))), ?, ?, ?, ?, NULL, ?, ?) RETURNING id`,
-            [
-              queue,
-              JSON.stringify(payload),
-              options?.retryLimit === undefined
-                ? DEFAULT_MAX_RETRIES
-                : options.retryLimit + 1,
-              now + Duration.toMillis(delay),
-              now,
-              now,
-            ],
-          ),
-        ).pipe(
-          Effect.mapError(
-            (error) =>
-              new EnqueueError({
-                queue,
-                message: `Database error: ${formatSqlError(error)}`,
-                cause: error,
-              }),
-          ),
-        )
-        const row = rows[0] as { readonly id: string } | undefined
-        if (!row)
-          return yield* new EnqueueError({
-            queue,
-            message: "No job ID returned from insert",
-          })
-        return row.id
-      }),
-    rawClaim: (queue: string, visibilityTimeout = DEFAULT_VISIBILITY_TIMEOUT) =>
-      Effect.gen(function* () {
-        yield* validateQueueName(queue)
-        const sql = yield* SqlClient.SqlClient
-        const now = Date.now()
-        const lockedUntil = now + Duration.toMillis(visibilityTimeout)
-        const rows = yield* retrySqliteBusy(
-          sql.withTransaction(
+  Effect.gen(function* () {
+    const sql = yield* SqlClient.SqlClient
+
+    return QueueService.of({
+      queueInTransaction: true,
+      enqueue: <P extends Payload>(
+        queue: string,
+        payload: P,
+        options?: { readonly retryLimit?: number },
+      ) =>
+        Effect.gen(function* () {
+          yield* validateQueueName(queue)
+          const now = Date.now()
+          const rows = yield* retrySqliteBusy(
             sql.unsafe(
-              `UPDATE job_queue SET locked_until = ?, job_attempts = job_attempts + 1, updated_at = ?
-               WHERE id = (
-                 SELECT id FROM job_queue
-                 WHERE queue = ? AND available_at <= ? AND (locked_until IS NULL OR locked_until <= ?)
-                   AND job_attempts < job_retry_limit
-                 ORDER BY job_attempts, available_at, id LIMIT 1
-               )
-               RETURNING id, queue, job_payload, job_attempts, job_retry_limit, available_at, locked_until`,
-              [lockedUntil, now, queue, now, now],
-            ),
-          ),
-        ).pipe(
-          Effect.mapError(
-            (error) =>
-              new ClaimError({
+              `INSERT INTO job_queue (id, queue, job_payload, job_retry_limit, available_at, locked_until, created_at, updated_at)
+               VALUES (lower(hex(randomblob(16))), ?, ?, ?, ?, NULL, ?, ?) RETURNING id`,
+              [
                 queue,
-                message: `Database error: ${formatSqlError(error)}`,
-                cause: error,
-              }),
-          ),
-        )
-        const row = rows[0] as JobRow | undefined
-        return row ? Option.some(rawJob(row)) : Option.none()
-      }),
-    acknowledge: (jobId: string) =>
-      Effect.gen(function* () {
-        const sql = yield* SqlClient.SqlClient
-        const rows = yield* retrySqliteBusy(
-          sql.unsafe("DELETE FROM job_queue WHERE id = ? RETURNING id", [
-            jobId,
-          ]),
-        ).pipe(
-          Effect.mapError(
-            (error) =>
-              new AcknowledgeError({
-                jobId,
-                message: `Database error: ${formatSqlError(error)}`,
-                cause: error,
-              }),
-          ),
-        )
-        if (!rows[0]) return yield* new JobNotFoundError({ jobId })
-      }),
-    fail: (jobId: string, options?) =>
-      Effect.gen(function* () {
-        const sql = yield* SqlClient.SqlClient
-        const now = Date.now()
-        const statement =
-          options?.retryable === false
-            ? "UPDATE job_queue SET job_attempts = job_retry_limit, locked_until = NULL, updated_at = ? WHERE id = ? RETURNING id"
-            : options?.releaseImmediately
-              ? "UPDATE job_queue SET locked_until = NULL, updated_at = ? WHERE id = ? RETURNING id"
-              : "SELECT id FROM job_queue WHERE id = ?"
-        const params =
-          options?.retryable === false || options?.releaseImmediately
-            ? [now, jobId]
-            : [jobId]
-        const rows = yield* retrySqliteBusy(sql.unsafe(statement, params)).pipe(
-          Effect.mapError(
-            (error) =>
-              new AcknowledgeError({
-                jobId,
-                message: `Database error: ${formatSqlError(error)}`,
-                cause: error,
-              }),
-          ),
-        )
-        if (!rows[0]) return yield* new JobNotFoundError({ jobId })
-      }),
-    extendVisibility: (jobId: string, timeout: Duration.Duration) =>
-      Effect.gen(function* () {
-        const sql = yield* SqlClient.SqlClient
-        const now = Date.now()
-        const rows = yield* retrySqliteBusy(
-          sql.unsafe(
-            "UPDATE job_queue SET locked_until = ?, updated_at = ? WHERE id = ? AND locked_until IS NOT NULL RETURNING id",
-            [now + Duration.toMillis(timeout), now, jobId],
-          ),
-        ).pipe(
-          Effect.mapError(
-            (error) =>
-              new AcknowledgeError({
-                jobId,
-                message: `Database error: ${formatSqlError(error)}`,
-                cause: error,
-              }),
-          ),
-        )
-        if (rows[0]) return
-        const exists = yield* sql
-          .unsafe("SELECT id FROM job_queue WHERE id = ?", [jobId])
-          .pipe(
+                JSON.stringify(payload),
+                options?.retryLimit === undefined
+                  ? DEFAULT_MAX_RETRIES
+                  : options.retryLimit + 1,
+                now,
+                now,
+                now,
+              ],
+            ),
+          ).pipe(
+            Effect.mapError(
+              (error) =>
+                new EnqueueError({
+                  queue,
+                  message: `Database error: ${formatSqlError(error)}`,
+                  cause: error,
+                }),
+            ),
+          )
+          const row = rows[0] as { readonly id: string } | undefined
+          if (!row)
+            return yield* new EnqueueError({
+              queue,
+              message: "No job ID returned from insert",
+            })
+          return row.id
+        }),
+      enqueueWithDelay: <P extends Payload>(
+        queue: string,
+        payload: P,
+        delay: Duration.Duration,
+        options?: { readonly retryLimit?: number },
+      ) =>
+        Effect.gen(function* () {
+          yield* validateQueueName(queue)
+          const now = Date.now()
+          const rows = yield* retrySqliteBusy(
+            sql.unsafe(
+              `INSERT INTO job_queue (id, queue, job_payload, job_retry_limit, available_at, locked_until, created_at, updated_at)
+               VALUES (lower(hex(randomblob(16))), ?, ?, ?, ?, NULL, ?, ?) RETURNING id`,
+              [
+                queue,
+                JSON.stringify(payload),
+                options?.retryLimit === undefined
+                  ? DEFAULT_MAX_RETRIES
+                  : options.retryLimit + 1,
+                now + Duration.toMillis(delay),
+                now,
+                now,
+              ],
+            ),
+          ).pipe(
+            Effect.mapError(
+              (error) =>
+                new EnqueueError({
+                  queue,
+                  message: `Database error: ${formatSqlError(error)}`,
+                  cause: error,
+                }),
+            ),
+          )
+          const row = rows[0] as { readonly id: string } | undefined
+          if (!row)
+            return yield* new EnqueueError({
+              queue,
+              message: "No job ID returned from insert",
+            })
+          return row.id
+        }),
+      rawClaim: (
+        queue: string,
+        visibilityTimeout = DEFAULT_VISIBILITY_TIMEOUT,
+      ) =>
+        Effect.gen(function* () {
+          yield* validateQueueName(queue)
+          const now = Date.now()
+          const lockedUntil = now + Duration.toMillis(visibilityTimeout)
+          const rows = yield* retrySqliteBusy(
+            sql.withTransaction(
+              sql.unsafe(
+                `UPDATE job_queue SET locked_until = ?, job_attempts = job_attempts + 1, updated_at = ?
+                 WHERE id = (
+                   SELECT id FROM job_queue
+                   WHERE queue = ? AND available_at <= ? AND (locked_until IS NULL OR locked_until <= ?)
+                     AND job_attempts < job_retry_limit
+                   ORDER BY job_attempts, available_at, id LIMIT 1
+                 )
+                 RETURNING id, queue, job_payload, job_attempts, job_retry_limit, available_at, locked_until`,
+                [lockedUntil, now, queue, now, now],
+              ),
+            ),
+          ).pipe(
+            Effect.mapError(
+              (error) =>
+                new ClaimError({
+                  queue,
+                  message: `Database error: ${formatSqlError(error)}`,
+                  cause: error,
+                }),
+            ),
+          )
+          const row = rows[0] as JobRow | undefined
+          return row ? Option.some(rawJob(row)) : Option.none()
+        }),
+      acknowledge: (jobId: string) =>
+        Effect.gen(function* () {
+          const rows = yield* retrySqliteBusy(
+            sql.unsafe("DELETE FROM job_queue WHERE id = ? RETURNING id", [
+              jobId,
+            ]),
+          ).pipe(
             Effect.mapError(
               (error) =>
                 new AcknowledgeError({
@@ -269,32 +211,92 @@ export const SqliteQueueServiceLive = Layer.succeed(
                 }),
             ),
           )
-        if (!exists[0]) return yield* new JobNotFoundError({ jobId })
-        return yield* new AcknowledgeError({
-          jobId,
-          message: "Cannot extend visibility of unlocked job",
-        })
-      }),
-    getStats: (queue: string) =>
-      Effect.gen(function* () {
-        yield* validateQueueName(queue)
-        const sql = yield* SqlClient.SqlClient
-        const now = Date.now()
-        const rows = yield* sql
-          .unsafe(
-            `SELECT
-             COUNT(CASE WHEN (locked_until IS NULL OR locked_until <= ?) AND job_attempts < job_retry_limit THEN 1 END) AS pending,
-             COUNT(CASE WHEN locked_until > ? THEN 1 END) AS processing,
-             COUNT(CASE WHEN job_attempts >= job_retry_limit THEN 1 END) AS deadLetter
-           FROM job_queue WHERE queue = ?`,
-            [now, now, queue],
+          if (!rows[0]) return yield* new JobNotFoundError({ jobId })
+        }),
+      fail: (jobId: string, options?) =>
+        Effect.gen(function* () {
+          const now = Date.now()
+          const statement =
+            options?.retryable === false
+              ? "UPDATE job_queue SET job_attempts = job_retry_limit, locked_until = NULL, updated_at = ? WHERE id = ? RETURNING id"
+              : options?.releaseImmediately
+                ? "UPDATE job_queue SET locked_until = NULL, updated_at = ? WHERE id = ? RETURNING id"
+                : "SELECT id FROM job_queue WHERE id = ?"
+          const params =
+            options?.retryable === false || options?.releaseImmediately
+              ? [now, jobId]
+              : [jobId]
+          const rows = yield* retrySqliteBusy(
+            sql.unsafe(statement, params),
+          ).pipe(
+            Effect.mapError(
+              (error) =>
+                new AcknowledgeError({
+                  jobId,
+                  message: `Database error: ${formatSqlError(error)}`,
+                  cause: error,
+                }),
+            ),
           )
-          .pipe(Effect.orElseSucceed(() => []))
-        return (
-          (rows[0] as
-            | { pending: number; processing: number; deadLetter: number }
-            | undefined) ?? { pending: 0, processing: 0, deadLetter: 0 }
-        )
-      }),
+          if (!rows[0]) return yield* new JobNotFoundError({ jobId })
+        }),
+      extendVisibility: (jobId: string, timeout: Duration.Duration) =>
+        Effect.gen(function* () {
+          const now = Date.now()
+          const rows = yield* retrySqliteBusy(
+            sql.unsafe(
+              "UPDATE job_queue SET locked_until = ?, updated_at = ? WHERE id = ? AND locked_until IS NOT NULL RETURNING id",
+              [now + Duration.toMillis(timeout), now, jobId],
+            ),
+          ).pipe(
+            Effect.mapError(
+              (error) =>
+                new AcknowledgeError({
+                  jobId,
+                  message: `Database error: ${formatSqlError(error)}`,
+                  cause: error,
+                }),
+            ),
+          )
+          if (rows[0]) return
+          const exists = yield* sql
+            .unsafe("SELECT id FROM job_queue WHERE id = ?", [jobId])
+            .pipe(
+              Effect.mapError(
+                (error) =>
+                  new AcknowledgeError({
+                    jobId,
+                    message: `Database error: ${formatSqlError(error)}`,
+                    cause: error,
+                  }),
+              ),
+            )
+          if (!exists[0]) return yield* new JobNotFoundError({ jobId })
+          return yield* new AcknowledgeError({
+            jobId,
+            message: "Cannot extend visibility of unlocked job",
+          })
+        }),
+      getStats: (queue: string) =>
+        Effect.gen(function* () {
+          yield* validateQueueName(queue)
+          const now = Date.now()
+          const rows = yield* sql
+            .unsafe(
+              `SELECT
+               COUNT(CASE WHEN (locked_until IS NULL OR locked_until <= ?) AND job_attempts < job_retry_limit THEN 1 END) AS pending,
+               COUNT(CASE WHEN locked_until > ? THEN 1 END) AS processing,
+               COUNT(CASE WHEN job_attempts >= job_retry_limit THEN 1 END) AS deadLetter
+             FROM job_queue WHERE queue = ?`,
+              [now, now, queue],
+            )
+            .pipe(Effect.orElseSucceed(() => []))
+          return (
+            (rows[0] as
+              | { pending: number; processing: number; deadLetter: number }
+              | undefined) ?? { pending: 0, processing: 0, deadLetter: 0 }
+          )
+        }),
+    })
   }),
 )

--- a/packages/sqlite-queue-service/test/sqlite-queue-service.spec.ts
+++ b/packages/sqlite-queue-service/test/sqlite-queue-service.spec.ts
@@ -8,7 +8,9 @@ import { SqliteQueueServiceLive } from "../src/lib/sqlite-queue-service.js"
 import { describe, expect, it } from "bun:test"
 
 describe("SqliteQueueService", () => {
-  const TestLayer = Layer.mergeAll(SqliteQueueServiceLive, DatabaseTest)
+  const TestLayer = SqliteQueueServiceLive.pipe(
+    Layer.provideMerge(DatabaseTest),
+  )
 
   type TestRequirements = Layer.Layer.Success<typeof TestLayer>
 


### PR DESCRIPTION
## Why

Queue backend dependencies currently leak into `QueueService` method Effect requirements and are looked up on every operation. Acquiring backend dependencies when constructing the Layer keeps the public service contract backend-independent and makes dependency composition explicit.

## What Changed

- remove the generic context parameter from `QueueServiceShape`, leaving service methods with `R = never`
- retain `QueueService` as a uniquely tagged `Context.Service` without an `any` escape hatch
- construct `SqliteQueueServiceLive` with `Layer.effect` and acquire `SqlClient` once for all methods
- compose the SQLite queue test Layer with its database dependency
- accept decode-only schemas in `QueueService.claim`, including transformed schemas with different encoded and decoded types

Closes #13
