### PR TITLE
feat(queue): generate canonical job IDs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,11 @@ Default labels: needs-triage, needs-info, ready-for-agent, ready-for-human, wont
 
 Single-context layout (root CONTEXT.md + docs/adr/). See `docs/agents/domain.md`.
 
+### Compatibility
+
+Do not add support for legacy behavior, deprecations, or migration paths without
+explicit user confirmation.
+
 <!-- effect-solutions:start -->
 
 ## Effect

--- a/bun.lock
+++ b/bun.lock
@@ -208,6 +208,7 @@
       "dependencies": {
         "effect": "^4.0.0-beta.97",
         "tslib": "^2.3.0",
+        "ulidx": "^2.4.1",
       },
       "devDependencies": {
         "@types/bun": "^1.3.0",

--- a/packages/queue-service/package.json
+++ b/packages/queue-service/package.json
@@ -34,7 +34,8 @@
   },
   "dependencies": {
     "effect": "^4.0.0-beta.97",
-    "tslib": "^2.3.0"
+    "tslib": "^2.3.0",
+    "ulidx": "^2.4.1"
   },
   "devDependencies": {
     "@types/bun": "^1.3.0"

--- a/packages/queue-service/src/lib/queue-service.ts
+++ b/packages/queue-service/src/lib/queue-service.ts
@@ -7,7 +7,7 @@ import type {
   JobNotFoundError,
 } from "./errors.js"
 import { InvalidQueueNameError, PayloadParseError } from "./errors.js"
-import type { Job, Payload, QueueStats, RawJob } from "./types.js"
+import type { Job, JobId, Payload, QueueStats, RawJob } from "./types.js"
 
 /**
  * Maximum length for AWS SQS Standard queue names.
@@ -94,7 +94,7 @@ export interface QueueServiceShape {
     queue: string,
     payload: P,
     options?: { readonly retryLimit?: number },
-  ) => Effect.Effect<string, EnqueueError | InvalidQueueNameError>
+  ) => Effect.Effect<JobId, EnqueueError | InvalidQueueNameError>
 
   /**
    * Add a job to the queue with a delay before it becomes available.
@@ -105,7 +105,7 @@ export interface QueueServiceShape {
     payload: P,
     delay: Duration.Duration,
     options?: { readonly retryLimit?: number },
-  ) => Effect.Effect<string, EnqueueError | InvalidQueueNameError>
+  ) => Effect.Effect<JobId, EnqueueError | InvalidQueueNameError>
 
   /**
    * Claim the next available job from the queue (raw, unparsed payload).

--- a/packages/queue-service/src/lib/types.ts
+++ b/packages/queue-service/src/lib/types.ts
@@ -1,4 +1,13 @@
-import { type DateTime, Duration } from "effect"
+import { type DateTime, Duration, Schema } from "effect"
+import { ulid } from "ulidx"
+
+export const JobId = Schema.String.pipe(
+  Schema.check(Schema.isPattern(/^qjob-[0-9A-HJKMNP-TV-Z]{26}$/)),
+  Schema.brand("JobId"),
+)
+export type JobId = typeof JobId.Type
+
+export const makeJobId = (): JobId => JobId.make(`qjob-${ulid()}`)
 
 export type Payload = Record<string, unknown>
 
@@ -13,7 +22,7 @@ export const DEFAULT_MAX_RETRIES = 5
  * The payload is unknown and needs to be parsed with a schema.
  */
 export interface RawJob {
-  readonly jobId: string
+  readonly jobId: JobId
   readonly queue: string
   readonly payload: unknown
   readonly attempts: number
@@ -26,7 +35,7 @@ export interface RawJob {
  * A job with a typed payload after schema parsing.
  */
 export interface Job<A> {
-  readonly jobId: string
+  readonly jobId: JobId
   readonly queue: string
   readonly payload: A
   readonly attempts: number

--- a/packages/sqlite-queue-service/src/lib/sqlite-queue-service.ts
+++ b/packages/sqlite-queue-service/src/lib/sqlite-queue-service.ts
@@ -8,8 +8,10 @@ import {
   DEFAULT_MAX_RETRIES,
   DEFAULT_VISIBILITY_TIMEOUT,
   EnqueueError,
+  JobId,
   JobNotFoundError,
   QueueService,
+  makeJobId,
   validateQueueName,
 } from "@ready-for-agent/queue-service"
 
@@ -61,7 +63,7 @@ type JobRow = {
 }
 
 const rawJob = (row: JobRow): RawJob => ({
-  jobId: row.id,
+  jobId: JobId.make(row.id),
   queue: row.queue,
   payload: JSON.parse(row.job_payload),
   attempts: row.job_attempts,
@@ -85,11 +87,13 @@ export const SqliteQueueServiceLive = Layer.effect(
         Effect.gen(function* () {
           yield* validateQueueName(queue)
           const now = Date.now()
+          const jobId = makeJobId()
           const rows = yield* retrySqliteBusy(
             sql.unsafe(
               `INSERT INTO job_queue (id, queue, job_payload, job_retry_limit, available_at, locked_until, created_at, updated_at)
-               VALUES (lower(hex(randomblob(16))), ?, ?, ?, ?, NULL, ?, ?) RETURNING id`,
+               VALUES (?, ?, ?, ?, ?, NULL, ?, ?) RETURNING id`,
               [
+                jobId,
                 queue,
                 JSON.stringify(payload),
                 options?.retryLimit === undefined
@@ -116,7 +120,7 @@ export const SqliteQueueServiceLive = Layer.effect(
               queue,
               message: "No job ID returned from insert",
             })
-          return row.id
+          return JobId.make(row.id)
         }),
       enqueueWithDelay: <P extends Payload>(
         queue: string,
@@ -127,11 +131,13 @@ export const SqliteQueueServiceLive = Layer.effect(
         Effect.gen(function* () {
           yield* validateQueueName(queue)
           const now = Date.now()
+          const jobId = makeJobId()
           const rows = yield* retrySqliteBusy(
             sql.unsafe(
               `INSERT INTO job_queue (id, queue, job_payload, job_retry_limit, available_at, locked_until, created_at, updated_at)
-               VALUES (lower(hex(randomblob(16))), ?, ?, ?, ?, NULL, ?, ?) RETURNING id`,
+               VALUES (?, ?, ?, ?, ?, NULL, ?, ?) RETURNING id`,
               [
+                jobId,
                 queue,
                 JSON.stringify(payload),
                 options?.retryLimit === undefined
@@ -158,7 +164,7 @@ export const SqliteQueueServiceLive = Layer.effect(
               queue,
               message: "No job ID returned from insert",
             })
-          return row.id
+          return JobId.make(row.id)
         }),
       rawClaim: (
         queue: string,

--- a/packages/sqlite-queue-service/test/sqlite-queue-service.spec.ts
+++ b/packages/sqlite-queue-service/test/sqlite-queue-service.spec.ts
@@ -7,6 +7,8 @@ import {
 import { SqliteQueueServiceLive } from "../src/lib/sqlite-queue-service.js"
 import { describe, expect, it } from "bun:test"
 
+const JOB_ID_PATTERN = /^qjob-[0-9A-HJKMNP-TV-Z]{26}$/
+
 describe("SqliteQueueService", () => {
   const TestLayer = SqliteQueueServiceLive.pipe(
     Layer.provideMerge(DatabaseTest),
@@ -28,9 +30,7 @@ describe("SqliteQueueService", () => {
 
           const jobId = yield* queue.enqueue("test-queue", { task: "test" })
 
-          expect(jobId).toBeDefined()
-          expect(typeof jobId).toBe("string")
-          expect(jobId.length).toBeGreaterThan(0)
+          expect(jobId).toMatch(JOB_ID_PATTERN)
         }),
       ))
 
@@ -74,10 +74,30 @@ describe("SqliteQueueService", () => {
             Duration.seconds(60),
           )
 
-          expect(jobId).toBeDefined()
+          expect(jobId).toMatch(JOB_ID_PATTERN)
 
           const job = yield* queue.rawClaim("delayed-queue")
           expect(Option.isNone(job)).toBe(true)
+        }),
+      ))
+
+    it("should preserve a delayed job ID when claimed", () =>
+      runTest(
+        Effect.gen(function* () {
+          const queue = yield* QueueService
+          const jobId = yield* queue.enqueueWithDelay(
+            "delayed-round-trip-queue",
+            { task: "delayed" },
+            Duration.zero,
+          )
+
+          expect(jobId).toMatch(JOB_ID_PATTERN)
+
+          const job = yield* queue.rawClaim("delayed-round-trip-queue")
+          expect(Option.isSome(job)).toBe(true)
+          if (Option.isSome(job)) {
+            expect(job.value.jobId).toBe(jobId)
+          }
         }),
       ))
   })
@@ -91,6 +111,7 @@ describe("SqliteQueueService", () => {
           const jobId = yield* queue.enqueue("claim-queue", {
             task: "to-claim",
           })
+          expect(jobId).toMatch(JOB_ID_PATTERN)
           const job = yield* queue.rawClaim("claim-queue")
 
           expect(Option.isSome(job)).toBe(true)


### PR DESCRIPTION
## Why

Queue jobs need stable, self-describing identities before their IDs become part of the public Refresh Job GraphQL contract. The SQLite adapter currently bypasses the database schema's prefixed ULID default and stores unprefixed random hexadecimal IDs.

## What Changed

- add a validated, branded `JobId` in canonical `qjob-<ULID>` format
- generate canonical IDs for immediate and delayed SQLite enqueue operations
- expose `JobId` consistently from enqueue results and claimed jobs
- verify canonical formatting and identity round trips through the SQLite adapter
- document that legacy behavior, deprecations, and migration paths require explicit user confirmation

## Verification

SQLite queue contract tests verify that immediate and delayed jobs return canonical IDs and preserve those IDs when claimed.

Closes #56
