### PR TITLE
feat(harness): execute queued refresh jobs

### DIFF
--- a/apps/harness/package.json
+++ b/apps/harness/package.json
@@ -20,6 +20,8 @@
     "@ready-for-agent/issue-reconciler": "workspace:*",
     "@ready-for-agent/keymaxxer-service": "workspace:*",
     "@ready-for-agent/opencode": "workspace:*",
+    "@ready-for-agent/queue-service": "workspace:*",
+    "@ready-for-agent/sqlite-queue-service": "workspace:*",
     "@tanstack/react-query": "^5.90.0",
     "@tanstack/react-query-devtools": "^5.90.0",
     "@tanstack/react-router": "^1.170.17",

--- a/apps/harness/src/server/application.server.ts
+++ b/apps/harness/src/server/application.server.ts
@@ -14,7 +14,9 @@ import {
   sidecarKeymaxxerLayer,
 } from "@ready-for-agent/keymaxxer-service"
 import { OpencodeLive } from "@ready-for-agent/opencode"
+import { SqliteQueueServiceLive } from "@ready-for-agent/sqlite-queue-service"
 import type { ApplicationRequestContext } from "../server-context.js"
+import { JobWorkerLive } from "./job-worker.js"
 import { keymaxxerGitHubLayer } from "./keymaxxer-github-layer.js"
 
 const workspaceRoot = fileURLToPath(new URL("../../../..", import.meta.url))
@@ -33,8 +35,13 @@ export interface Application {
   readonly dispose: () => Promise<void>
 }
 
+export interface CreateApplicationOptions {
+  readonly startWorker?: boolean
+}
+
 export const createApplication = async (
   environment: Partial<Record<string, string | undefined>> = process.env,
+  options: CreateApplicationOptions = {},
 ): Promise<Application> => {
   const databaseLayer = DbServiceLive.pipe(Layer.provideMerge(DatabaseLive))
   const keymaxxerLayer = keymaxxerLayerFromEnvironment(environment)
@@ -45,15 +52,26 @@ export const createApplication = async (
     Layer.provideMerge(databaseLayer),
     Layer.provideMerge(githubLayer),
   )
+  const queueLayer = SqliteQueueServiceLive.pipe(
+    Layer.provideMerge(databaseLayer),
+  )
+  const workerLayer = JobWorkerLive.pipe(
+    Layer.provideMerge(queueLayer),
+    Layer.provideMerge(reconcilerLayer),
+  )
   const opencodePlatformLayer = BunChildProcessSpawner.layer.pipe(
     Layer.provideMerge(Layer.merge(BunFileSystem.layer, BunPath.layer)),
   )
   const opencodeLayer = OpencodeLive.pipe(Layer.provide(opencodePlatformLayer))
-  const appLayer = Layer.mergeAll(
-    reconcilerLayer,
-    keymaxxerLayer,
-    opencodeLayer,
-  )
+  const appLayer =
+    options.startWorker === false
+      ? Layer.mergeAll(reconcilerLayer, keymaxxerLayer, opencodeLayer)
+      : Layer.mergeAll(
+          reconcilerLayer,
+          workerLayer,
+          keymaxxerLayer,
+          opencodeLayer,
+        )
   const runtime = ManagedRuntime.make(appLayer)
 
   try {

--- a/apps/harness/src/server/job-worker.ts
+++ b/apps/harness/src/server/job-worker.ts
@@ -1,0 +1,110 @@
+import "@tanstack/react-start/server-only"
+import { Duration, Effect, Layer, Option, Schema } from "effect"
+import {
+  DbService,
+  RepositoryId,
+  RepositoryNotFoundError,
+} from "@ready-for-agent/db-service"
+import { IssueReconciler } from "@ready-for-agent/issue-reconciler"
+import { QueueService } from "@ready-for-agent/queue-service"
+
+export const JOBS_QUEUE = "jobs"
+export const JOB_VISIBILITY_TIMEOUT = Duration.minutes(5)
+const JOB_IDLE_POLL_INTERVAL = Duration.seconds(1)
+export const JOB_RECOVERY_RETRY_LIMIT = 1
+
+const RefreshRepositoryJob = Schema.TaggedStruct("refresh-repository", {
+  repositoryId: RepositoryId,
+})
+
+const JobPayload = Schema.Union([RefreshRepositoryJob])
+
+export const enqueueRefreshRepositoryJob = (repositoryId: RepositoryId) =>
+  Effect.gen(function* () {
+    const queue = yield* QueueService
+    const payload = yield* Schema.decodeUnknownEffect(RefreshRepositoryJob)({
+      _tag: "refresh-repository",
+      repositoryId,
+    })
+    return yield* queue.enqueue(JOBS_QUEUE, payload, {
+      retryLimit: JOB_RECOVERY_RETRY_LIMIT,
+    })
+  })
+
+const refreshRepository = (repositoryId: RepositoryId) =>
+  Effect.gen(function* () {
+    const db = yield* DbService
+    const reconciler = yield* IssueReconciler
+    const repositories = yield* db.listRepositories
+    const repository = repositories.find(({ id }) => id === repositoryId)
+
+    if (repository === undefined) {
+      return yield* new RepositoryNotFoundError({ repositoryId })
+    }
+
+    return yield* reconciler.reconcile(repository)
+  })
+
+export interface JobWorkerOptions {
+  readonly idlePollInterval?: Duration.Duration
+  readonly visibilityTimeout?: Duration.Duration
+}
+
+export const runJobWorker = (options: JobWorkerOptions = {}) =>
+  Effect.gen(function* () {
+    const queue = yield* QueueService
+    const idlePollInterval = options.idlePollInterval ?? JOB_IDLE_POLL_INTERVAL
+    const visibilityTimeout =
+      options.visibilityTimeout ?? JOB_VISIBILITY_TIMEOUT
+
+    const claimAndRun = Effect.gen(function* () {
+      const claimed = yield* QueueService.claim(
+        JOBS_QUEUE,
+        JobPayload,
+        visibilityTimeout,
+      ).pipe(
+        Effect.catchTag("PayloadParseError", (error) =>
+          queue
+            .fail(error.jobId, { retryable: false })
+            .pipe(Effect.as(Option.none())),
+        ),
+      )
+
+      if (Option.isNone(claimed)) return true
+
+      const job = claimed.value
+      const result = yield* Effect.result(
+        refreshRepository(job.payload.repositoryId),
+      )
+
+      if (result._tag === "Failure") {
+        yield* Effect.logError("Refresh Job failed", {
+          jobId: job.jobId,
+          repositoryId: job.payload.repositoryId,
+          error: result.failure,
+        })
+        yield* queue.fail(job.jobId, { retryable: false })
+      } else {
+        yield* queue.acknowledge(job.jobId)
+      }
+
+      return false
+    })
+
+    const poll = claimAndRun.pipe(
+      Effect.catch((error) =>
+        Effect.logError("Job queue poll failed", { error }).pipe(
+          Effect.as(true),
+        ),
+      ),
+      Effect.flatMap((idle) =>
+        idle ? Effect.sleep(idlePollInterval) : Effect.void,
+      ),
+    )
+
+    return yield* Effect.forever(poll)
+  })
+
+export const JobWorkerLive = Layer.effectDiscard(
+  runJobWorker().pipe(Effect.forkScoped({ startImmediately: true })),
+)

--- a/apps/harness/src/server/preflight.ts
+++ b/apps/harness/src/server/preflight.ts
@@ -1,6 +1,8 @@
 import { createApplication } from "./application.server.js"
 
 if (import.meta.main) {
-  const application = await createApplication()
+  const application = await createApplication(process.env, {
+    startWorker: false,
+  })
   await application.dispose()
 }

--- a/apps/harness/test/job-worker.test.ts
+++ b/apps/harness/test/job-worker.test.ts
@@ -1,0 +1,396 @@
+import { DateTime, Deferred, Duration, Effect, Layer, Option } from "effect"
+import { DatabaseTest } from "@ready-for-agent/db/test"
+import {
+  DatabaseError,
+  DbService,
+  DbServiceLive,
+  RepositoryId,
+  type RepositoryRecord,
+} from "@ready-for-agent/db-service"
+import {
+  GitHubService,
+  type GitHubServiceShape,
+} from "@ready-for-agent/github-service"
+import {
+  IssueReconciler,
+  IssueReconcilerLive,
+  type IssueReconcilerShape,
+} from "@ready-for-agent/issue-reconciler"
+import {
+  ClaimError,
+  QueueService,
+  type QueueServiceShape,
+  type RawJob,
+  makeJobId,
+} from "@ready-for-agent/queue-service"
+import {
+  JOBS_QUEUE,
+  JOB_RECOVERY_RETRY_LIMIT,
+  JOB_VISIBILITY_TIMEOUT,
+  enqueueRefreshRepositoryJob,
+  runJobWorker,
+} from "../src/server/job-worker.js"
+import { describe, expect, test } from "bun:test"
+
+const repository: RepositoryRecord = {
+  id: "repo-01J00000000000000000000000",
+  githubOwner: "acme",
+  githubRepo: "widgets",
+  localPath: "/repos/acme/widgets",
+  isBare: true,
+  paused: true,
+  issuesReconciledAt: null,
+}
+
+const refreshPayload = {
+  _tag: "refresh-repository" as const,
+  repositoryId: RepositoryId.make(repository.id),
+}
+
+const rawJob = (payload: unknown): RawJob => {
+  const now = DateTime.makeUnsafe(0)
+  return {
+    jobId: makeJobId(),
+    queue: JOBS_QUEUE,
+    payload,
+    attempts: 1,
+    maxAttempts: 2,
+    availableAt: now,
+    lockedUntil: now,
+  }
+}
+
+const unused = () => Effect.die("not used")
+
+const dbLayer = (repositories: readonly RepositoryRecord[] = [repository]) =>
+  Layer.succeed(DbService, {
+    repositoryChanges: Effect.die("not used") as never,
+    getConfig: unused(),
+    updateConfig: unused,
+    addRepository: unused,
+    listRepositories: Effect.succeed(repositories),
+    removeRepository: unused,
+    storeIssue: unused,
+    listIssues: unused,
+    deleteIssue: unused,
+    markIssuesReconciled: unused,
+  })
+
+const queueLayer = (
+  jobs: RawJob[],
+  onAcknowledge: (jobId: string) => Effect.Effect<unknown> = () => Effect.void,
+  onFail: (jobId: string) => Effect.Effect<unknown> = () => Effect.void,
+  onClaim?: () => Effect.Effect<Option.Option<RawJob>, ClaimError>,
+) =>
+  Layer.succeed(QueueService, {
+    queueInTransaction: true,
+    enqueue: unused,
+    enqueueWithDelay: unused,
+    rawClaim: (_queue, visibilityTimeout) =>
+      Effect.gen(function* () {
+        expect(Duration.toMillis(visibilityTimeout ?? Duration.zero)).toBe(
+          Duration.toMillis(JOB_VISIBILITY_TIMEOUT),
+        )
+        if (onClaim !== undefined) return yield* onClaim()
+        return Option.fromNullishOr(jobs.shift())
+      }),
+    acknowledge: (jobId) => onAcknowledge(jobId).pipe(Effect.asVoid),
+    fail: (jobId, options) =>
+      Effect.gen(function* () {
+        expect(options?.retryable).toBe(false)
+        yield* onFail(jobId)
+      }),
+    extendVisibility: unused,
+    getStats: unused,
+  } satisfies QueueServiceShape)
+
+const runScoped = <A, E, R>(
+  effect: Effect.Effect<A, E, R>,
+  layer: Layer.Layer<R>,
+) =>
+  Effect.runPromise(
+    Effect.scoped(effect).pipe(Effect.provide(layer), Effect.orDie),
+  )
+
+describe("Job worker", () => {
+  test("enqueues a validated Refresh Job with one recovery claim", async () => {
+    let enqueued:
+      | {
+          queue: string
+          payload: Record<string, unknown>
+          retryLimit: number | undefined
+        }
+      | undefined
+    const queue = Layer.succeed(QueueService, {
+      queueInTransaction: true,
+      enqueue: (queueName, payload, options) =>
+        Effect.sync(() => {
+          enqueued = {
+            queue: queueName,
+            payload,
+            retryLimit: options?.retryLimit,
+          }
+          return makeJobId()
+        }),
+      enqueueWithDelay: unused,
+      rawClaim: unused,
+      acknowledge: unused,
+      fail: unused,
+      extendVisibility: unused,
+      getStats: unused,
+    } satisfies QueueServiceShape)
+
+    await Effect.runPromise(
+      enqueueRefreshRepositoryJob(refreshPayload.repositoryId).pipe(
+        Effect.provide(queue),
+      ),
+    )
+
+    expect(enqueued).toEqual({
+      queue: JOBS_QUEUE,
+      payload: refreshPayload,
+      retryLimit: JOB_RECOVERY_RETRY_LIMIT,
+    })
+  })
+
+  test("reconciles the Issue store and acknowledges after success", async () => {
+    const jobs: RawJob[] = []
+    let job: RawJob | undefined
+    const acknowledged = await Effect.runPromise(Deferred.make<string>())
+    const queue = queueLayer(jobs, (jobId) =>
+      Deferred.succeed(acknowledged, jobId),
+    )
+    const database = DbServiceLive.pipe(Layer.provideMerge(DatabaseTest))
+    const github = Layer.succeed(GitHubService, {
+      listReadyIssues: () =>
+        Effect.succeed([
+          {
+            number: 57,
+            title: "Execute queued Refresh Jobs in Harness",
+            body: "Worker acceptance criteria",
+            url: "https://github.com/acme/widgets/issues/57",
+            createdAt: new Date("2026-07-14T00:00:00.000Z"),
+            state: "OPEN" as const,
+            parent: null,
+            parentPosition: null,
+            hasChildren: false,
+            hierarchySupported: true,
+            blockedBy: [],
+          },
+        ]),
+    } satisfies GitHubServiceShape)
+    const reconciler = IssueReconcilerLive.pipe(
+      Layer.provideMerge(database),
+      Layer.provideMerge(github),
+    )
+    const layer = Layer.mergeAll(database, reconciler, queue)
+
+    await runScoped(
+      Effect.gen(function* () {
+        const db = yield* DbService
+        const added = yield* db.addRepository({
+          githubOwner: repository.githubOwner,
+          githubRepo: repository.githubRepo,
+          localPath: repository.localPath,
+          isBare: true,
+        })
+        job = rawJob({
+          _tag: "refresh-repository",
+          repositoryId: RepositoryId.make(added.id),
+        })
+        jobs.push(job)
+
+        yield* runJobWorker({ idlePollInterval: Duration.zero }).pipe(
+          Effect.forkScoped({ startImmediately: true }),
+        )
+        expect(yield* Deferred.await(acknowledged)).toBe(job.jobId)
+        const issues = yield* db.listIssues(added.id)
+        expect(
+          issues.map(({ githubIssueNumber }) => githubIssueNumber),
+        ).toEqual([57])
+      }),
+      layer,
+    )
+  })
+
+  test("marks malformed and unknown payloads terminal", async () => {
+    for (const payload of [
+      { _tag: "refresh-repository", repositoryId: "invalid" },
+      { _tag: "unknown-job", repositoryId: repository.id },
+    ]) {
+      const job = rawJob(payload)
+      const failed = await Effect.runPromise(Deferred.make<string>())
+      await runScoped(
+        Effect.gen(function* () {
+          yield* runJobWorker({ idlePollInterval: Duration.zero }).pipe(
+            Effect.forkScoped({ startImmediately: true }),
+          )
+          expect(yield* Deferred.await(failed)).toBe(job.jobId)
+        }),
+        Layer.merge(
+          queueLayer([job], undefined, (jobId) =>
+            Deferred.succeed(failed, jobId),
+          ),
+          Layer.merge(
+            dbLayer(),
+            Layer.succeed(IssueReconciler, { reconcile: unused }),
+          ),
+        ),
+      )
+    }
+  })
+
+  test("marks a caught Refresh Job failure terminal", async () => {
+    const job = rawJob(refreshPayload)
+    const failed = await Effect.runPromise(Deferred.make<string>())
+    const reconciler = Layer.succeed(IssueReconciler, {
+      reconcile: () =>
+        Effect.fail(new DatabaseError({ message: "reconciliation failed" })),
+    } satisfies IssueReconcilerShape)
+
+    await runScoped(
+      Effect.gen(function* () {
+        yield* runJobWorker({ idlePollInterval: Duration.zero }).pipe(
+          Effect.forkScoped({ startImmediately: true }),
+        )
+        expect(yield* Deferred.await(failed)).toBe(job.jobId)
+      }),
+      Layer.mergeAll(
+        queueLayer([job], undefined, (jobId) =>
+          Deferred.succeed(failed, jobId),
+        ),
+        dbLayer(),
+        reconciler,
+      ),
+    )
+  })
+
+  test("executes duplicate Refresh Jobs serially", async () => {
+    const jobs = [rawJob(refreshPayload), rawJob(refreshPayload)]
+    const firstStarted = await Effect.runPromise(Deferred.make<void>())
+    const releaseFirst = await Effect.runPromise(Deferred.make<void>())
+    const secondStarted = await Effect.runPromise(Deferred.make<void>())
+    let calls = 0
+    let active = 0
+    let maximumActive = 0
+    const reconciler = Layer.succeed(IssueReconciler, {
+      reconcile: () =>
+        Effect.gen(function* () {
+          calls += 1
+          active += 1
+          maximumActive = Math.max(maximumActive, active)
+          if (calls === 1) {
+            yield* Deferred.succeed(firstStarted, undefined)
+            yield* Deferred.await(releaseFirst)
+          } else {
+            yield* Deferred.succeed(secondStarted, undefined)
+          }
+          active -= 1
+          return {
+            fetched: 0,
+            inserted: 0,
+            updated: 0,
+            deleted: 0,
+            unchanged: 0,
+          }
+        }),
+    } satisfies IssueReconcilerShape)
+
+    await runScoped(
+      Effect.gen(function* () {
+        yield* runJobWorker({ idlePollInterval: Duration.zero }).pipe(
+          Effect.forkScoped({ startImmediately: true }),
+        )
+        yield* Deferred.await(firstStarted)
+        expect(calls).toBe(1)
+        yield* Deferred.succeed(releaseFirst, undefined)
+        yield* Deferred.await(secondStarted)
+        expect(maximumActive).toBe(1)
+      }),
+      Layer.mergeAll(queueLayer(jobs), dbLayer(), reconciler),
+    )
+  })
+
+  test("recovers after a queue infrastructure error", async () => {
+    const job = rawJob(refreshPayload)
+    const acknowledged = await Effect.runPromise(Deferred.make<void>())
+    let claims = 0
+    const claim = () => {
+      claims += 1
+      return claims === 1
+        ? Effect.fail(
+            new ClaimError({ queue: JOBS_QUEUE, message: "temporarily down" }),
+          )
+        : Effect.succeed(claims === 2 ? Option.some(job) : Option.none())
+    }
+
+    await runScoped(
+      Effect.gen(function* () {
+        yield* runJobWorker({ idlePollInterval: Duration.zero }).pipe(
+          Effect.forkScoped({ startImmediately: true }),
+        )
+        yield* Deferred.await(acknowledged)
+        expect(claims).toBe(2)
+      }),
+      Layer.mergeAll(
+        queueLayer(
+          [],
+          () => Deferred.succeed(acknowledged, undefined),
+          undefined,
+          claim,
+        ),
+        dbLayer(),
+        Layer.succeed(IssueReconciler, {
+          reconcile: () =>
+            Effect.succeed({
+              fetched: 0,
+              inserted: 0,
+              updated: 0,
+              deleted: 0,
+              unchanged: 0,
+            }),
+        }),
+      ),
+    )
+  })
+
+  test("scope disposal interrupts an active Job without queue finalization", async () => {
+    const job = rawJob(refreshPayload)
+    const started = await Effect.runPromise(Deferred.make<void>())
+    const interrupted = await Effect.runPromise(Deferred.make<void>())
+    let finalized = false
+    const reconciler = Layer.succeed(IssueReconciler, {
+      reconcile: () =>
+        Deferred.succeed(started, undefined).pipe(
+          Effect.andThen(Effect.never),
+          Effect.ensuring(
+            Deferred.succeed(interrupted, undefined).pipe(Effect.asVoid),
+          ),
+        ),
+    } satisfies IssueReconcilerShape)
+
+    await runScoped(
+      Effect.gen(function* () {
+        yield* Effect.scoped(
+          Effect.gen(function* () {
+            yield* runJobWorker({ idlePollInterval: Duration.zero }).pipe(
+              Effect.forkScoped({ startImmediately: true }),
+            )
+            yield* Deferred.await(started)
+          }),
+        )
+        yield* Deferred.await(interrupted)
+        expect(finalized).toBe(false)
+      }),
+      Layer.mergeAll(
+        queueLayer(
+          [job],
+          () => Effect.sync(() => (finalized = true)),
+          () => Effect.sync(() => (finalized = true)),
+        ),
+        dbLayer(),
+        reconciler,
+      ),
+    )
+  })
+})

--- a/apps/harness/test/topology.test.ts
+++ b/apps/harness/test/topology.test.ts
@@ -82,4 +82,13 @@ describe("single application server topology", () => {
 
     expect(applicationServer).not.toContain('from "@effect/platform-bun"')
   })
+
+  test("does not start the long-lived worker during preflight", async () => {
+    const preflight = await readFile(
+      new URL("../src/server/preflight.ts", import.meta.url),
+      "utf8",
+    )
+
+    expect(preflight).toContain("startWorker: false")
+  })
 })

--- a/apps/harness/tsconfig.app.json
+++ b/apps/harness/tsconfig.app.json
@@ -39,6 +39,12 @@
     },
     {
       "path": "../../packages/db/tsconfig.lib.json"
+    },
+    {
+      "path": "../../packages/queue-service/tsconfig.lib.json"
+    },
+    {
+      "path": "../../packages/sqlite-queue-service/tsconfig.lib.json"
     }
   ]
 }

--- a/bun.lock
+++ b/bun.lock
@@ -47,6 +47,8 @@
         "@ready-for-agent/issue-reconciler": "workspace:*",
         "@ready-for-agent/keymaxxer-service": "workspace:*",
         "@ready-for-agent/opencode": "workspace:*",
+        "@ready-for-agent/queue-service": "workspace:*",
+        "@ready-for-agent/sqlite-queue-service": "workspace:*",
         "@tanstack/react-query": "^5.90.0",
         "@tanstack/react-query-devtools": "^5.90.0",
         "@tanstack/react-router": "^1.170.17",

--- a/packages/db-service/src/lib/types.ts
+++ b/packages/db-service/src/lib/types.ts
@@ -1,3 +1,11 @@
+import { Schema } from "effect"
+
+export const RepositoryId = Schema.String.pipe(
+  Schema.check(Schema.isPattern(/^repo-[0-9A-HJKMNP-TV-Z]{26}$/)),
+  Schema.brand("RepositoryId"),
+)
+export type RepositoryId = typeof RepositoryId.Type
+
 export interface AddRepositoryInput {
   readonly githubOwner: string
   readonly githubRepo: string


### PR DESCRIPTION
## Why

Harness needs a durable execution path from the shared `jobs` queue to Issue-store reconciliation. Refresh requests must survive interruption, execute serially, and terminate malformed or failed work without taking down the application runtime.

Closes #57

## What Changed

- Added a branded Repository ID and schema-validated `refresh-repository` Job payload.
- Added a scoped Harness worker that claims one Job at a time with five-minute visibility, dispatches the Refresh Job Effect, and owns acknowledgement and terminal failure handling.
- Configured Refresh Jobs for one recovery claim and made queue infrastructure failures recover on the next poll.
- Wired the SQLite queue and worker into the long-lived Harness runtime while keeping development preflight worker-free.
- Added integration coverage for Issue-store reconciliation, acknowledgement, malformed and failed Jobs, serial execution, queue recovery, and interruption cleanup.

## Verification

- A queued Refresh Job reconciles a real in-memory Issue store and is acknowledged only after reconciliation.
- Scope disposal interrupts an active Job without acknowledging or terminally failing it.
- Harness worker integration suite: 7 worker scenarios passing.
