### PR TITLE
feat(graphql): request and observe Refresh Jobs asynchronously

### DIFF
--- a/apps/harness/src/routes/index.tsx
+++ b/apps/harness/src/routes/index.tsx
@@ -272,17 +272,10 @@ function RepositoryCard({ repository }: { repository: Repository }) {
       graphql.mutation({
         refreshRepository: {
           __args: { repositoryId: repository.id },
-          fetched: true,
+          id: true,
+          repositoryId: true,
         },
       }),
-    onSuccess: async () => {
-      await Promise.all([
-        queryClient.invalidateQueries({ queryKey: repositoriesQuery.queryKey }),
-        queryClient.invalidateQueries({
-          queryKey: issuesQuery(repository.id).queryKey,
-        }),
-      ])
-    },
   })
 
   const addGitHubToken = useMutation({

--- a/apps/harness/src/server/application.server.ts
+++ b/apps/harness/src/server/application.server.ts
@@ -65,10 +65,16 @@ export const createApplication = async (
   const opencodeLayer = OpencodeLive.pipe(Layer.provide(opencodePlatformLayer))
   const appLayer =
     options.startWorker === false
-      ? Layer.mergeAll(reconcilerLayer, keymaxxerLayer, opencodeLayer)
+      ? Layer.mergeAll(
+          reconcilerLayer,
+          queueLayer,
+          keymaxxerLayer,
+          opencodeLayer,
+        )
       : Layer.mergeAll(
           reconcilerLayer,
           workerLayer,
+          queueLayer,
           keymaxxerLayer,
           opencodeLayer,
         )

--- a/apps/harness/src/server/job-worker.ts
+++ b/apps/harness/src/server/job-worker.ts
@@ -42,7 +42,9 @@ const refreshRepository = (repositoryId: RepositoryId) =>
       return yield* new RepositoryNotFoundError({ repositoryId })
     }
 
-    return yield* reconciler.reconcile(repository)
+    const summary = yield* reconciler.reconcile(repository)
+    yield* db.notifyIssuesChanged(repositoryId)
+    return summary
   })
 
 export interface JobWorkerOptions {

--- a/apps/harness/test/job-worker.test.ts
+++ b/apps/harness/test/job-worker.test.ts
@@ -1,4 +1,12 @@
-import { DateTime, Deferred, Duration, Effect, Layer, Option } from "effect"
+import {
+  DateTime,
+  Deferred,
+  Duration,
+  Effect,
+  Layer,
+  ManagedRuntime,
+  Option,
+} from "effect"
 import { DatabaseTest } from "@ready-for-agent/db/test"
 import {
   DatabaseError,
@@ -11,11 +19,14 @@ import {
   GitHubService,
   type GitHubServiceShape,
 } from "@ready-for-agent/github-service"
+import { createGraphqlApi } from "@ready-for-agent/graphql-api"
 import {
   IssueReconciler,
   IssueReconcilerLive,
   type IssueReconcilerShape,
 } from "@ready-for-agent/issue-reconciler"
+import { KeymaxxerService } from "@ready-for-agent/keymaxxer-service"
+import { Opencode } from "@ready-for-agent/opencode"
 import {
   ClaimError,
   QueueService,
@@ -62,9 +73,15 @@ const rawJob = (payload: unknown): RawJob => {
 
 const unused = () => Effect.die("not used")
 
-const dbLayer = (repositories: readonly RepositoryRecord[] = [repository]) =>
+const dbLayer = (
+  repositories: readonly RepositoryRecord[] = [repository],
+  notifyIssuesChanged: (repositoryId: string) => Effect.Effect<void> = () =>
+    Effect.void,
+) =>
   Layer.succeed(DbService, {
     repositoryChanges: Effect.die("not used") as never,
+    issueChanges: Effect.die("not used") as never,
+    notifyIssuesChanged,
     getConfig: unused(),
     updateConfig: unused,
     addRepository: unused,
@@ -237,6 +254,187 @@ describe("Job worker", () => {
           ),
         ),
       )
+    }
+  })
+
+  test("publishes Issues-changed invalidation only after successful reconciliation", async () => {
+    const successJob = rawJob(refreshPayload)
+    const failureJob = rawJob(refreshPayload)
+    const acknowledged = await Effect.runPromise(Deferred.make<string>())
+    const failed = await Effect.runPromise(Deferred.make<string>())
+    const notifications: string[] = []
+    let calls = 0
+    const reconciler = Layer.succeed(IssueReconciler, {
+      reconcile: () =>
+        Effect.gen(function* () {
+          calls += 1
+          if (calls === 1) {
+            return {
+              fetched: 0,
+              inserted: 0,
+              updated: 0,
+              deleted: 0,
+              unchanged: 0,
+            }
+          }
+          return yield* Effect.fail(
+            new DatabaseError({ message: "reconciliation failed" }),
+          )
+        }),
+    } satisfies IssueReconcilerShape)
+
+    await runScoped(
+      Effect.gen(function* () {
+        yield* runJobWorker({ idlePollInterval: Duration.zero }).pipe(
+          Effect.forkScoped({ startImmediately: true }),
+        )
+        expect(yield* Deferred.await(acknowledged)).toBe(successJob.jobId)
+        expect(notifications).toEqual([repository.id])
+        expect(yield* Deferred.await(failed)).toBe(failureJob.jobId)
+        expect(notifications).toEqual([repository.id])
+      }),
+      Layer.mergeAll(
+        queueLayer(
+          [successJob, failureJob],
+          (jobId) => Deferred.succeed(acknowledged, jobId),
+          (jobId) => Deferred.succeed(failed, jobId),
+        ),
+        dbLayer([repository], (repositoryId) =>
+          Effect.sync(() => {
+            notifications.push(repositoryId)
+          }),
+        ),
+        reconciler,
+      ),
+    )
+  })
+
+  test("delivers only successful worker invalidations through GraphQL", async () => {
+    const jobs: RawJob[] = []
+    const acknowledged = await Effect.runPromise(Deferred.make<string>())
+    const failed = await Effect.runPromise(Deferred.make<string>())
+    let reconciliations = 0
+    const database = DbServiceLive.pipe(Layer.provideMerge(DatabaseTest))
+    const queue = queueLayer(
+      jobs,
+      (jobId) => Deferred.succeed(acknowledged, jobId),
+      (jobId) => Deferred.succeed(failed, jobId),
+    )
+    const reconciler = Layer.succeed(IssueReconciler, {
+      reconcile: () =>
+        Effect.gen(function* () {
+          reconciliations += 1
+          if (reconciliations === 2) {
+            return yield* Effect.fail(
+              new DatabaseError({ message: "reconciliation failed" }),
+            )
+          }
+          return {
+            fetched: 0,
+            inserted: 0,
+            updated: 0,
+            deleted: 0,
+            unchanged: 0,
+          }
+        }),
+    } satisfies IssueReconcilerShape)
+    const keymaxxer = Layer.succeed(KeymaxxerService, {
+      initialize: Effect.void,
+      findSecret: () => Effect.die("not used"),
+      findSecrets: () => Effect.die("not used"),
+      hasSecret: () => Effect.die("not used"),
+      addSecret: () => Effect.die("not used"),
+      runWithSecrets: () => Effect.die("not used"),
+    })
+    const opencode = Layer.succeed(Opencode, {
+      start: () => Effect.die("not used"),
+      continue: () => Effect.die("not used"),
+      listModels: () => Effect.die("not used"),
+    })
+    const runtime = ManagedRuntime.make(
+      Layer.mergeAll(database, queue, reconciler, keymaxxer, opencode),
+    )
+    const controller = new AbortController()
+
+    try {
+      const added = await runtime.runPromise(
+        Effect.gen(function* () {
+          const db = yield* DbService
+          return yield* db.addRepository({
+            githubOwner: repository.githubOwner,
+            githubRepo: repository.githubRepo,
+            localPath: repository.localPath,
+            isBare: true,
+          })
+        }),
+      )
+      const successJob = rawJob({
+        _tag: "refresh-repository",
+        repositoryId: RepositoryId.make(added.id),
+      })
+      const failureJob = rawJob({
+        _tag: "refresh-repository",
+        repositoryId: RepositoryId.make(added.id),
+      })
+      jobs.push(successJob, failureJob)
+
+      const response = await createGraphqlApi(runtime).fetch(
+        new Request("http://127.0.0.1:4200/graphql", {
+          method: "POST",
+          headers: {
+            accept: "text/event-stream",
+            "content-type": "application/json",
+          },
+          body: JSON.stringify({
+            query: `subscription {
+              issuesChanged(repositoryId: "${added.id}")
+            }`,
+          }),
+          signal: controller.signal,
+        }),
+      )
+      const reader = response.body?.getReader()
+      if (reader === undefined) throw new Error("Subscription has no body")
+
+      const invalidation = (async () => {
+        let event = ""
+        const decoder = new TextDecoder()
+        while (!event.includes('"data":{"issuesChanged":true}')) {
+          const next = await reader.read()
+          if (next.done) {
+            throw new Error("Subscription ended before invalidation")
+          }
+          event += decoder.decode(next.value, { stream: true })
+        }
+        return event
+      })()
+      await Bun.sleep(0)
+      runtime.runFork(runJobWorker())
+
+      expect(await runtime.runPromise(Deferred.await(acknowledged))).toBe(
+        successJob.jobId,
+      )
+      expect(await invalidation).toContain('"data":{"issuesChanged":true}')
+
+      expect(await runtime.runPromise(Deferred.await(failed))).toBe(
+        failureJob.jobId,
+      )
+      const secondEvent = reader
+        .read()
+        .then(({ value }) =>
+          value === undefined ? "" : new TextDecoder().decode(value),
+        )
+        .catch(() => "")
+      const unexpectedInvalidation = await Promise.race([
+        secondEvent.then((chunk) =>
+          chunk.includes('"data":{"issuesChanged":true}'),
+        ),
+        Bun.sleep(20).then(() => false),
+      ])
+      expect(unexpectedInvalidation).toBe(false)
+    } finally {
+      controller.abort()
+      await runtime.dispose()
     }
   })
 

--- a/bun.lock
+++ b/bun.lock
@@ -140,6 +140,7 @@
         "@ready-for-agent/issue-reconciler": "workspace:*",
         "@ready-for-agent/keymaxxer-service": "workspace:*",
         "@ready-for-agent/opencode": "workspace:*",
+        "@ready-for-agent/queue-service": "workspace:*",
         "effect": "^4.0.0-beta.97",
         "graphql": "^16.11.0",
         "graphql-yoga": "^5.13.0",

--- a/packages/db-service/src/lib/db-service.ts
+++ b/packages/db-service/src/lib/db-service.ts
@@ -133,6 +133,8 @@ const toDatabaseError = (error: SqlError) =>
 
 export interface DbServiceShape {
   readonly repositoryChanges: Stream.Stream<void>
+  readonly issueChanges: Stream.Stream<string>
+  readonly notifyIssuesChanged: (repositoryId: string) => Effect.Effect<void>
   readonly getConfig: Effect.Effect<ConfigRecord, DatabaseError>
   readonly updateConfig: (
     input: UpdateConfigInput,
@@ -184,6 +186,7 @@ export const DbServiceLive = Layer.effect(
   Effect.gen(function* () {
     const sql = yield* SqlClient.SqlClient
     const repositoryChanges = yield* PubSub.unbounded<void>()
+    const issueChanges = yield* PubSub.unbounded<string>()
 
     const getConfig: Effect.Effect<ConfigRecord, DatabaseError> = Effect.gen(
       function* () {
@@ -797,8 +800,13 @@ export const DbServiceLive = Layer.effect(
         }
       })
 
+    const notifyIssuesChanged = (repositoryId: string): Effect.Effect<void> =>
+      PubSub.publish(issueChanges, repositoryId).pipe(Effect.asVoid)
+
     return DbService.of({
       repositoryChanges: Stream.fromPubSub(repositoryChanges),
+      issueChanges: Stream.fromPubSub(issueChanges),
+      notifyIssuesChanged,
       getConfig,
       updateConfig,
       addRepository,

--- a/packages/graphql-api/package.json
+++ b/packages/graphql-api/package.json
@@ -22,6 +22,7 @@
     "@ready-for-agent/issue-reconciler": "workspace:*",
     "@ready-for-agent/keymaxxer-service": "workspace:*",
     "@ready-for-agent/opencode": "workspace:*",
+    "@ready-for-agent/queue-service": "workspace:*",
     "effect": "^4.0.0-beta.97",
     "graphql": "^16.11.0",
     "graphql-yoga": "^5.13.0",

--- a/packages/graphql-api/src/lib/graphql-api.ts
+++ b/packages/graphql-api/src/lib/graphql-api.ts
@@ -16,6 +16,7 @@ import {
   type IssueRecord,
   LocalPathInUseError,
   RepositoryAlreadyExistsError,
+  RepositoryId,
   RepositoryNotFoundError,
 } from "@ready-for-agent/db-service"
 import {
@@ -24,11 +25,12 @@ import {
 } from "@ready-for-agent/github-service"
 import { typeDefs } from "@ready-for-agent/graphql-schema"
 import {
-  IssueReconciler,
+  type IssueReconciler,
   ReconciliationMutationError,
 } from "@ready-for-agent/issue-reconciler"
 import { KeymaxxerService } from "@ready-for-agent/keymaxxer-service"
 import { Opencode } from "@ready-for-agent/opencode"
+import { EnqueueError, QueueService } from "@ready-for-agent/queue-service"
 
 type AddRepositoryArgs = {
   input: {
@@ -96,9 +98,12 @@ const workIssueProjection = (
 }
 
 export type GraphqlRuntime = ManagedRuntime.ManagedRuntime<
-  DbService | IssueReconciler | KeymaxxerService | Opencode,
+  DbService | IssueReconciler | KeymaxxerService | Opencode | QueueService,
   unknown
 >
+
+const JOBS_QUEUE = "jobs"
+const JOB_RECOVERY_RETRY_LIMIT = 1
 
 type Repository = {
   id: string
@@ -201,6 +206,11 @@ const toGraphQLError = (error: unknown): GraphQLError => {
   if (error instanceof DatabaseError) {
     return new GraphQLError(error.message, {
       extensions: { code: "DATABASE_ERROR" },
+    })
+  }
+  if (error instanceof EnqueueError) {
+    return new GraphQLError(error.message, {
+      extensions: { code: "ENQUEUE_ERROR" },
     })
   }
   if (error instanceof GraphQLError) {
@@ -351,6 +361,22 @@ export const createGraphqlApi = (
               ),
             resolve: () => true,
           },
+          issuesChanged: {
+            subscribe: async (_parent: unknown, args: RefreshRepositoryArgs) =>
+              runtime.runPromise(
+                Effect.gen(function* () {
+                  const db = yield* DbService
+                  return yield* Stream.toAsyncIterableEffect(
+                    db.issueChanges.pipe(
+                      Stream.filter(
+                        (repositoryId) => repositoryId === args.repositoryId,
+                      ),
+                    ),
+                  )
+                }),
+              ),
+            resolve: () => true,
+          },
         },
         Mutation: {
           updateConfig: async (_parent: unknown, args: UpdateConfigArgs) => {
@@ -485,8 +511,30 @@ export const createGraphqlApi = (
                     })
                   }
 
-                  const reconciler = yield* IssueReconciler
-                  return yield* reconciler.reconcile(repository)
+                  const keymaxxer = yield* KeymaxxerService
+                  const credential = yield* keymaxxer.findSecret({
+                    provider: "github",
+                    account: `${repository.githubOwner}/${repository.githubRepo}`,
+                  })
+                  if (credential === null) {
+                    return yield* new RepositoryCredentialError({
+                      message: `GitHub credential is not configured for ${repository.githubOwner}/${repository.githubRepo}`,
+                    })
+                  }
+
+                  const queue = yield* QueueService
+                  const jobId = yield* queue.enqueue(
+                    JOBS_QUEUE,
+                    {
+                      _tag: "refresh-repository",
+                      repositoryId: RepositoryId.make(repository.id),
+                    },
+                    { retryLimit: JOB_RECOVERY_RETRY_LIMIT },
+                  )
+                  return {
+                    id: jobId,
+                    repositoryId: repository.id,
+                  }
                 }),
               ),
             )

--- a/packages/graphql-api/test/graphql-api.test.ts
+++ b/packages/graphql-api/test/graphql-api.test.ts
@@ -9,11 +9,17 @@ import {
   type KeymaxxerServiceShape,
 } from "@ready-for-agent/keymaxxer-service"
 import { Opencode } from "@ready-for-agent/opencode"
+import {
+  EnqueueError,
+  QueueService,
+  type QueueServiceShape,
+  makeJobId,
+} from "@ready-for-agent/queue-service"
 import { createGraphqlApi } from "../src/index.js"
 import { afterEach, describe, expect, test } from "bun:test"
 
 const repository = {
-  id: "repo-test",
+  id: "repo-01J00000000000000000000000",
   githubOwner: "acme",
   githubRepo: "widgets",
   localPath: "/repos/acme/widgets.git",
@@ -51,6 +57,7 @@ const makeRuntime = (
   dbOverrides: Partial<DbServiceShape> = {},
   reconcilerOverrides: Partial<IssueReconcilerShape> = {},
   keymaxxerOverrides: Partial<KeymaxxerServiceShape> = {},
+  queueOverrides: Partial<QueueServiceShape> = {},
 ) => {
   const opencode = {
     start: () => Effect.die("not used"),
@@ -63,6 +70,8 @@ const makeRuntime = (
   }
   const db: DbServiceShape = {
     repositoryChanges: Stream.never,
+    issueChanges: Stream.never,
+    notifyIssuesChanged: () => Effect.void,
     getConfig: Effect.succeed(config),
     updateConfig: (input) => Effect.succeed(input),
     addRepository: () => Effect.succeed(repository),
@@ -87,12 +96,24 @@ const makeRuntime = (
     runWithSecrets: () => Effect.die("not used"),
     ...keymaxxerOverrides,
   }
+  const queue: QueueServiceShape = {
+    queueInTransaction: true,
+    enqueue: () => Effect.succeed(makeJobId()),
+    enqueueWithDelay: () => Effect.die("not used"),
+    rawClaim: () => Effect.die("not used"),
+    acknowledge: () => Effect.die("not used"),
+    fail: () => Effect.die("not used"),
+    extendVisibility: () => Effect.die("not used"),
+    getStats: () => Effect.die("not used"),
+    ...queueOverrides,
+  }
   return ManagedRuntime.make(
     Layer.mergeAll(
       Layer.succeed(DbService, db),
       Layer.succeed(IssueReconciler, reconciler),
       Layer.succeed(KeymaxxerService, keymaxxer),
       Layer.succeed(Opencode, opencode),
+      Layer.succeed(QueueService, queue),
     ),
   )
 }
@@ -580,22 +601,43 @@ describe("GraphQL API", () => {
     ])
   })
 
-  test("refreshes a repository through the reconciler", async () => {
-    let reconciledRepository: typeof repository | undefined
+  test("accepts a Refresh Job for a Paused Repository without reconciling", async () => {
+    const jobId = makeJobId()
+    let reconcilerCalled = false
+    let enqueued:
+      | {
+          queue: string
+          payload: Record<string, unknown>
+          retryLimit: number | undefined
+        }
+      | undefined
     await runtime.dispose()
     runtime = makeRuntime(
       {},
       {
-        reconcile: (selectedRepository) => {
-          reconciledRepository = selectedRepository
-          return Effect.succeed({
-            fetched: 1,
-            inserted: 1,
-            updated: 0,
-            deleted: 0,
-            unchanged: 0,
-          })
+        reconcile: () => {
+          reconcilerCalled = true
+          return Effect.die("not used")
         },
+      },
+      {
+        findSecret: ({ account, provider }) =>
+          Effect.succeed(
+            provider === "github" && account === "acme/widgets"
+              ? "GITHUB_TOKEN_ACME_WIDGETS"
+              : null,
+          ),
+      },
+      {
+        enqueue: (queueName, payload, options) =>
+          Effect.sync(() => {
+            enqueued = {
+              queue: queueName,
+              payload,
+              retryLimit: options?.retryLimit,
+            }
+            return jobId
+          }),
       },
     )
 
@@ -603,7 +645,8 @@ describe("GraphQL API", () => {
       graphqlRequest({
         query: `mutation RefreshRepository($repositoryId: ID!) {
           refreshRepository(repositoryId: $repositoryId) {
-            fetched inserted updated deleted unchanged
+            id
+            repositoryId
           }
         }`,
         variables: {
@@ -616,18 +659,25 @@ describe("GraphQL API", () => {
     expect(await response.json()).toEqual({
       data: {
         refreshRepository: {
-          fetched: 1,
-          inserted: 1,
-          updated: 0,
-          deleted: 0,
-          unchanged: 0,
+          id: jobId,
+          repositoryId: repository.id,
         },
       },
     })
-    expect(reconciledRepository).toEqual(repository)
+    expect(repository.paused).toBe(true)
+    expect(reconcilerCalled).toBe(false)
+    expect(enqueued).toEqual({
+      queue: "jobs",
+      payload: {
+        _tag: "refresh-repository",
+        repositoryId: repository.id,
+      },
+      retryLimit: 1,
+    })
   })
 
-  test("reports an unknown repository without calling the reconciler", async () => {
+  test("rejects refresh for an unknown repository without enqueueing", async () => {
+    let enqueued = false
     let reconcilerCalled = false
     await runtime.dispose()
     runtime = makeRuntime(
@@ -638,11 +688,18 @@ describe("GraphQL API", () => {
           return Effect.die("not used")
         },
       },
+      {},
+      {
+        enqueue: () => {
+          enqueued = true
+          return Effect.succeed(makeJobId())
+        },
+      },
     )
     const response = await createGraphqlApi(runtime).fetch(
       graphqlRequest({
         query: `mutation {
-          refreshRepository(repositoryId: "missing") { fetched }
+          refreshRepository(repositoryId: "missing") { id repositoryId }
         }`,
       }),
     )
@@ -657,7 +714,122 @@ describe("GraphQL API", () => {
         }),
       ],
     })
+    expect(enqueued).toBe(false)
     expect(reconcilerCalled).toBe(false)
+  })
+
+  test("rejects refresh when the Repository has no GitHub credential", async () => {
+    let enqueued = false
+    await runtime.dispose()
+    runtime = makeRuntime(
+      {},
+      {},
+      {
+        findSecret: () => Effect.succeed(null),
+      },
+      {
+        enqueue: () => {
+          enqueued = true
+          return Effect.succeed(makeJobId())
+        },
+      },
+    )
+
+    const response = await createGraphqlApi(runtime).fetch(
+      graphqlRequest({
+        query: `mutation {
+          refreshRepository(repositoryId: "${repository.id}") {
+            id
+            repositoryId
+          }
+        }`,
+      }),
+    )
+
+    expect(response.status).toBe(200)
+    expect(await response.json()).toEqual({
+      data: null,
+      errors: [
+        expect.objectContaining({
+          message: expect.stringMatching(/credential|token|configured/i),
+          extensions: { code: "REPOSITORY_CREDENTIAL_ERROR" },
+        }),
+      ],
+    })
+    expect(enqueued).toBe(false)
+  })
+
+  test("reports enqueue failure without accepting a Refresh Job", async () => {
+    await runtime.dispose()
+    runtime = makeRuntime(
+      {},
+      {},
+      {
+        findSecret: () => Effect.succeed("GITHUB_TOKEN_ACME_WIDGETS"),
+      },
+      {
+        enqueue: () =>
+          Effect.fail(
+            new EnqueueError({
+              queue: "jobs",
+              message: "queue unavailable",
+            }),
+          ),
+      },
+    )
+
+    const response = await createGraphqlApi(runtime).fetch(
+      graphqlRequest({
+        query: `mutation {
+          refreshRepository(repositoryId: "${repository.id}") {
+            id
+            repositoryId
+          }
+        }`,
+      }),
+    )
+
+    expect(response.status).toBe(200)
+    expect(await response.json()).toEqual({
+      data: null,
+      errors: [
+        expect.objectContaining({
+          message: "queue unavailable",
+          extensions: { code: "ENQUEUE_ERROR" },
+        }),
+      ],
+    })
+  })
+
+  test("streams Repository-specific issue invalidations", async () => {
+    await runtime.dispose()
+    runtime = makeRuntime({
+      issueChanges: Stream.make(
+        repository.id,
+        "repo-01J11111111111111111111111",
+      ),
+    })
+
+    const response = await createGraphqlApi(runtime).fetch(
+      new Request("http://127.0.0.1:4200/graphql", {
+        method: "POST",
+        headers: {
+          accept: "text/event-stream",
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          query: `subscription {
+            issuesChanged(repositoryId: "${repository.id}")
+          }`,
+        }),
+      }),
+    )
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get("content-type")).toContain("text/event-stream")
+    const body = await response.text()
+    expect(body).toContain('"data":{"issuesChanged":true}')
+    expect(body.match(/"data":\{"issuesChanged":true\}/g)?.length).toBe(1)
   })
 
   test("accepts same-origin browser requests", async () => {

--- a/packages/graphql-api/tsconfig.lib.json
+++ b/packages/graphql-api/tsconfig.lib.json
@@ -11,7 +11,13 @@
   "include": ["src/**/*.ts"],
   "references": [
     {
+      "path": "../queue-service/tsconfig.lib.json"
+    },
+    {
       "path": "../opencode/tsconfig.lib.json"
+    },
+    {
+      "path": "../keymaxxer-service/tsconfig.lib.json"
     },
     {
       "path": "../issue-reconciler/tsconfig.lib.json"
@@ -21,9 +27,6 @@
     },
     {
       "path": "../github-service/tsconfig.lib.json"
-    },
-    {
-      "path": "../keymaxxer-service/tsconfig.lib.json"
     },
     {
       "path": "../db-service/tsconfig.lib.json"

--- a/packages/graphql-schema/schema.graphql
+++ b/packages/graphql-schema/schema.graphql
@@ -53,12 +53,9 @@ type IssueReference {
   githubIssueUrl: String!
 }
 
-type RepositoryRefresh {
-  fetched: Int!
-  inserted: Int!
-  updated: Int!
-  deleted: Int!
-  unchanged: Int!
+type RefreshJob {
+  id: ID!
+  repositoryId: ID!
 }
 
 input AddRepositoryInput {
@@ -77,10 +74,11 @@ type Mutation {
   addRepository(input: AddRepositoryInput!): Repository!
   addRepositoryGitHubToken(repositoryId: ID!): RepositoryCredential!
   removeRepository(repositoryId: ID!): ID!
-  refreshRepository(repositoryId: ID!): RepositoryRefresh!
+  refreshRepository(repositoryId: ID!): RefreshJob!
   updateConfig(input: UpdateConfigInput!): Config!
 }
 
 type Subscription {
   repositoriesChanged: Boolean!
+  issuesChanged(repositoryId: ID!): Boolean!
 }

--- a/packages/issue-reconciler/test/issue-reconciler.spec.ts
+++ b/packages/issue-reconciler/test/issue-reconciler.spec.ts
@@ -94,6 +94,8 @@ const makeDbFixture = (options: DbFixtureOptions) => {
 
   const service: DbServiceShape = {
     repositoryChanges: Stream.never,
+    issueChanges: Stream.never,
+    notifyIssuesChanged: () => Effect.void,
     addRepository: () => Effect.die("not used"),
     listRepositories: Effect.die("not used"),
     listIssues: () => {


### PR DESCRIPTION
## Why

Manual repository refresh still ran Issue reconciliation inside the GraphQL request. That kept the request open while GitHub fetching and Issue store updates completed, and left the durable job worker path unused from the API surface.

This change makes Refresh Job acceptance a GraphQL contract: the mutation only validates and enqueues, and clients can observe successful reconciliation through a Repository-specific Issues-changed invalidation.

Closes #58.

## What Changed

- Replaced the synchronous `RepositoryRefresh` summary with `RefreshJob { id, repositoryId }`.
- `refreshRepository` now validates Repository existence and configured GitHub credential, enqueues a tagged `refresh-repository` job, and does not invoke the Issue Reconciler in the request.
- Added `issuesChanged(repositoryId)` as an ephemeral GraphQL invalidation subscription.
- Job worker publishes Issues-changed only after successful reconciliation; failed jobs publish nothing.
- Wired `QueueService` into the GraphQL application runtime so mutation enqueueing and worker execution share the same queue and invalidation path.
- Updated GraphQL and worker tests, including a composed runtime test that proves successful worker completion reaches a GraphQL subscriber and failed completion does not.

UI subscription consumption remains #59.
