### PR TITLE
feat(harness): refresh Repository Issues asynchronously

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,8 @@ node_modules
 /.sass-cache
 /connect.lock
 /coverage
+/apps/harness/playwright-report/
+/apps/harness/test-results/
 /libpeerconnection.log
 npm-debug.log
 yarn-error.log

--- a/apps/harness/e2e/keymaxxer-stub.ts
+++ b/apps/harness/e2e/keymaxxer-stub.ts
@@ -1,0 +1,16 @@
+const server = Bun.serve({
+  hostname: "127.0.0.1",
+  port: 59999,
+  fetch(request) {
+    const path = new URL(request.url).pathname
+    if (path === "/health") {
+      return Response.json({ status: "ok", protocolVersion: 3 })
+    }
+    if (path === "/initialize") {
+      return Response.json({ initialized: true })
+    }
+    return new Response("Not found", { status: 404 })
+  },
+})
+
+console.log(`Keymaxxer test stub listening on ${server.url}`)

--- a/apps/harness/e2e/refresh-repository.e2e.ts
+++ b/apps/harness/e2e/refresh-repository.e2e.ts
@@ -1,0 +1,129 @@
+import { type Route, expect, test } from "@playwright/test"
+
+const repositoryId = "repo-01JSELECTED000000000000000"
+
+const repository = (issuesReconciledAt: string | null) => ({
+  id: repositoryId,
+  githubOwner: "acme",
+  githubRepo: "widgets",
+  localPath: "/repos/acme/widgets",
+  isBare: true,
+  paused: true,
+  issuesReconciledAt,
+})
+
+const issue = {
+  id: "issue-01JAFTER00000000000000000",
+  githubIssueNumber: 59,
+  title: "Asynchronously refreshed Issue",
+  url: "https://github.com/acme/widgets/issues/59",
+  state: "OPEN",
+  parent: null,
+  hasChildren: false,
+  blockedBy: [],
+}
+
+test("Refresh returns after enqueueing and updates after worker invalidation", async ({
+  page,
+}) => {
+  let workerCompleted = false
+  let releaseInvalidation: (() => void) | undefined
+  const invalidation = new Promise<void>((resolve) => {
+    releaseInvalidation = resolve
+  })
+
+  const jsonResponse = (query: string) => {
+    if (query.includes("refreshRepository")) {
+      return {
+        data: {
+          refreshRepository: {
+            id: "qjob-01JENQUEUED00000000000000",
+            repositoryId,
+          },
+        },
+      }
+    }
+    if (query.includes("repositoryCredentials")) {
+      return {
+        data: {
+          repositories: [
+            repository(workerCompleted ? "2026-07-14T12:00:00.000Z" : null),
+          ],
+          repositoryCredentials: [
+            {
+              repositoryId,
+              configured: true,
+              githubTokenSecretName: "GITHUB_TOKEN_ACME_WIDGETS",
+              githubTokenCreationUrl: "https://github.com/settings/tokens",
+            },
+          ],
+        },
+      }
+    }
+    if (query.includes("issues(")) {
+      return { data: { issues: workerCompleted ? [issue] : [] } }
+    }
+    if (query.includes("config")) {
+      return {
+        data: { config: { defaultModel: "test/model", defaultVariant: "low" } },
+      }
+    }
+    if (query.includes("models")) {
+      return { data: { models: ["test/model"] } }
+    }
+    throw new Error(`Unexpected GraphQL operation: ${query}`)
+  }
+
+  const fulfillJson = async (route: Route, body: unknown) =>
+    route.fulfill({
+      contentType: "application/json",
+      body: JSON.stringify(body),
+    })
+
+  await page.route("**/graphql", async (route) => {
+    const request = route.request()
+    const operation = request.postDataJSON() as
+      | { query: string }
+      | readonly { query: string }[]
+    const operations = Array.isArray(operation) ? operation : [operation]
+
+    if (operations[0]?.query.includes("repositoryIssuesChanged")) {
+      await invalidation
+      await route.fulfill({
+        contentType: "text/event-stream",
+        body: `event: next\ndata: {"data":{"repositoryIssuesChanged":"${repositoryId}"}}\n\nevent: complete\n\n`,
+      })
+      return
+    }
+    if (operations[0]?.query.includes("repositoriesChanged")) {
+      await route.fulfill({
+        contentType: "text/event-stream",
+        body: "event: complete\n\n",
+      })
+      return
+    }
+
+    const responses = operations.map(({ query }) => jsonResponse(query))
+    await fulfillJson(
+      route,
+      Array.isArray(operation) ? responses : responses[0],
+    )
+  })
+
+  await page.goto("/")
+  await expect(page.getByText("Not refreshed yet.")).toBeVisible()
+
+  const refresh = page.getByRole("button", { name: "Refresh issues" })
+  await refresh.click()
+
+  // Mutation acceptance ends the pending state while the controlled worker
+  // remains incomplete and the old reconciliation metadata is still shown.
+  await expect(refresh).toBeEnabled()
+  await expect(page.getByText("Not refreshed yet.")).toBeVisible()
+
+  workerCompleted = true
+  releaseInvalidation?.()
+
+  await expect(page.getByText("Asynchronously refreshed Issue")).toBeVisible()
+  await expect(page.getByText("Not refreshed yet.")).not.toBeVisible()
+})

--- a/apps/harness/package.json
+++ b/apps/harness/package.json
@@ -33,6 +33,7 @@
     "react-dom": "^19.0.0"
   },
   "devDependencies": {
+    "@playwright/test": "^1.61.1",
     "@tailwindcss/vite": "^4.3.2",
     "@types/bun": "^1.3.0",
     "@types/react": "^19.0.8",

--- a/apps/harness/playwright.config.ts
+++ b/apps/harness/playwright.config.ts
@@ -1,0 +1,22 @@
+import { defineConfig } from "@playwright/test"
+
+export default defineConfig({
+  testDir: "./e2e",
+  testMatch: "**/*.e2e.ts",
+  use: {
+    baseURL: "http://127.0.0.1:4174",
+  },
+  webServer: [
+    {
+      command: "bun e2e/keymaxxer-stub.ts",
+      url: "http://127.0.0.1:59999/health",
+      reuseExistingServer: !process.env.CI,
+    },
+    {
+      command:
+        "SQLITE_DATABASE_PATH=/tmp/ready-for-agent-harness-e2e.db bun --conditions @ready-for-agent/source ../../packages/db/src/bin/migrate.ts && SQLITE_DATABASE_PATH=/tmp/ready-for-agent-harness-e2e.db KEYMAXXER_SIDECAR_URL=http://127.0.0.1:59999 bun run dev --host 127.0.0.1 --port 4174",
+      url: "http://127.0.0.1:4174",
+      reuseExistingServer: !process.env.CI,
+    },
+  ],
+})

--- a/apps/harness/project.json
+++ b/apps/harness/project.json
@@ -50,6 +50,19 @@
       "inputs": ["default", "^production"],
       "cache": true,
       "dependsOn": ["^build"]
+    },
+    "e2e": {
+      "executor": "nx:run-commands",
+      "options": {
+        "cwd": "{projectRoot}",
+        "command": "playwright test"
+      },
+      "dependsOn": [
+        {
+          "projects": ["graphql-client"],
+          "target": "generate"
+        }
+      ]
     }
   }
 }

--- a/apps/harness/src/issues-live.ts
+++ b/apps/harness/src/issues-live.ts
@@ -1,0 +1,79 @@
+import { generateSubscriptionOp } from "@ready-for-agent/graphql-client"
+
+export const parseIssuesSubscriptionEvent = (event: string): string | null => {
+  let eventType = "message"
+  const data: string[] = []
+
+  for (const line of event.split(/\r?\n/)) {
+    if (line.startsWith("event:")) eventType = line.slice(6).trim()
+    if (line.startsWith("data:")) data.push(line.slice(5).trimStart())
+  }
+
+  if (eventType === "complete") return null
+  if (eventType !== "next" && eventType !== "message") return null
+  if (data.length === 0) return null
+
+  const result = JSON.parse(data.join("\n")) as {
+    data?: { repositoryIssuesChanged?: string }
+    errors?: unknown
+  }
+  if (result.errors !== undefined) {
+    throw new Error("Issue change subscription failed")
+  }
+  return result.data?.repositoryIssuesChanged ?? null
+}
+
+export const streamIssuesChanged = async ({
+  signal,
+  onConnected,
+  onChange,
+  fetch: fetchRequest = fetch,
+}: {
+  signal: AbortSignal
+  onConnected: () => void | Promise<void>
+  onChange: (repositoryId: string) => void | Promise<void>
+  fetch?: typeof fetch
+}): Promise<void> => {
+  const operation = generateSubscriptionOp({
+    repositoryIssuesChanged: true,
+  })
+
+  const response = await fetchRequest("/graphql", {
+    method: "POST",
+    headers: {
+      accept: "text/event-stream",
+      "content-type": "application/json",
+    },
+    body: JSON.stringify(operation),
+    signal,
+  })
+
+  if (!response.ok || response.body === null) {
+    throw new Error(`Issue change subscription returned ${response.status}`)
+  }
+
+  await onConnected()
+
+  const reader = response.body.getReader()
+  const decoder = new TextDecoder()
+  let buffer = ""
+
+  while (true) {
+    const { done, value } = await reader.read()
+    buffer += decoder.decode(value, { stream: !done })
+
+    let boundary = buffer.search(/\r?\n\r?\n/)
+    while (boundary >= 0) {
+      const separator = buffer.slice(boundary).match(/^\r?\n\r?\n/)?.[0]
+      const event = buffer.slice(0, boundary)
+      buffer = buffer.slice(boundary + (separator?.length ?? 2))
+
+      if (event.startsWith("event: complete")) return
+      const repositoryId = parseIssuesSubscriptionEvent(event)
+      if (repositoryId !== null) await onChange(repositoryId)
+      boundary = buffer.search(/\r?\n\r?\n/)
+    }
+
+    if (done) return
+  }
+}

--- a/apps/harness/src/refresh-issues-live.ts
+++ b/apps/harness/src/refresh-issues-live.ts
@@ -1,0 +1,107 @@
+import type { QueryClient } from "@tanstack/react-query"
+import { streamIssuesChanged } from "./issues-live.js"
+
+export type RepositoryIssuesLiveQueries = {
+  repositories: {
+    queryKey: readonly unknown[]
+    queryFn: () => Promise<unknown>
+  }
+  issues: (repositoryId: string) => {
+    queryKey: readonly unknown[]
+    queryFn: () => Promise<unknown>
+  }
+}
+
+/**
+ * Keeps a Repository's Issues and reconciliation metadata fresh via the
+ * Issues-changed invalidation subscription, with reconnect and tab-visibility
+ * refetch as fallback for missed ephemeral notifications.
+ */
+export const followRepositoryIssuesLive = async ({
+  repositoryIds,
+  queryClient,
+  queries,
+  signal,
+  stream = streamIssuesChanged,
+  documentRef = typeof document === "undefined" ? undefined : document,
+  retryDelayMs = 1_000,
+}: {
+  repositoryIds: readonly string[]
+  queryClient: QueryClient
+  queries: RepositoryIssuesLiveQueries
+  signal: AbortSignal
+  stream?: typeof streamIssuesChanged
+  documentRef?: Pick<
+    Document,
+    "visibilityState" | "addEventListener" | "removeEventListener"
+  >
+  retryDelayMs?: number
+}): Promise<void> => {
+  const fetchFresh = async (query: {
+    queryKey: readonly unknown[]
+    queryFn: () => Promise<unknown>
+  }) => {
+    await queryClient.cancelQueries({ queryKey: query.queryKey, exact: true })
+    return queryClient.fetchQuery({ ...query, staleTime: 0 })
+  }
+
+  const refresh = async (repositoryId: string) => {
+    await Promise.all([
+      fetchFresh(queries.repositories),
+      fetchFresh(queries.issues(repositoryId)),
+    ])
+  }
+
+  const refreshAll = async () => {
+    await Promise.all([
+      fetchFresh(queries.repositories),
+      ...repositoryIds.map((repositoryId) =>
+        fetchFresh(queries.issues(repositoryId)),
+      ),
+    ])
+  }
+
+  const refreshWhenVisible = () => {
+    if (documentRef?.visibilityState === "visible") {
+      void refreshAll().catch(() => undefined)
+    }
+  }
+
+  documentRef?.addEventListener("visibilitychange", refreshWhenVisible)
+
+  try {
+    while (!signal.aborted) {
+      const attempt = new AbortController()
+      const onAbort = () => attempt.abort()
+      signal.addEventListener("abort", onAbort, { once: true })
+      try {
+        await stream({
+          signal: attempt.signal,
+          onConnected: refreshAll,
+          onChange: refresh,
+        })
+      } catch {
+        if (signal.aborted) return
+      } finally {
+        signal.removeEventListener("abort", onAbort)
+        attempt.abort()
+      }
+
+      if (signal.aborted) return
+      await new Promise<void>((resolve) => {
+        const finish = () => {
+          signal.removeEventListener("abort", cancel)
+          resolve()
+        }
+        const timer = setTimeout(finish, retryDelayMs)
+        const cancel = () => {
+          clearTimeout(timer)
+          finish()
+        }
+        signal.addEventListener("abort", cancel, { once: true })
+      })
+    }
+  } finally {
+    documentRef?.removeEventListener("visibilitychange", refreshWhenVisible)
+  }
+}

--- a/apps/harness/src/routes/index.tsx
+++ b/apps/harness/src/routes/index.tsx
@@ -6,6 +6,7 @@ import {
 import { createFileRoute } from "@tanstack/react-router"
 import { Suspense, useEffect, useState } from "react"
 import { createClient } from "@ready-for-agent/graphql-client"
+import { followRepositoryIssuesLive } from "../refresh-issues-live.js"
 import { streamRepositoryChanges } from "../repository-live.js"
 
 const graphql = createClient({ url: "/graphql", batch: true })
@@ -132,6 +133,7 @@ function RepositoryCards() {
   const queryClient = useQueryClient()
   const { data: repositories } = useSuspenseQuery(repositoriesQuery)
   const [liveUpdatesUnavailable, setLiveUpdatesUnavailable] = useState(false)
+  const repositoryIdsKey = repositories.map(({ id }) => id).join("\0")
 
   useEffect(() => {
     let cancelled = false
@@ -193,6 +195,22 @@ function RepositoryCards() {
     }
   }, [queryClient])
 
+  useEffect(() => {
+    const controller = new AbortController()
+    const repositoryIds =
+      repositoryIdsKey === "" ? [] : repositoryIdsKey.split("\0")
+    void followRepositoryIssuesLive({
+      repositoryIds,
+      queryClient,
+      queries: {
+        repositories: repositoriesQuery,
+        issues: issuesQuery,
+      },
+      signal: controller.signal,
+    })
+    return () => controller.abort()
+  }, [queryClient, repositoryIdsKey])
+
   const warning = liveUpdatesUnavailable ? (
     <p
       className="mb-4 rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-900"
@@ -237,6 +255,7 @@ function RepositoryCards() {
 function RepositoryCard({ repository }: { repository: Repository }) {
   const queryClient = useQueryClient()
   const [githubTokenCreated, setGithubTokenCreated] = useState(false)
+
   const removeRepository = useMutation({
     mutationFn: async () => {
       const result = await graphql.mutation({
@@ -268,14 +287,16 @@ function RepositoryCard({ repository }: { repository: Repository }) {
   }
 
   const refreshIssues = useMutation({
-    mutationFn: () =>
-      graphql.mutation({
+    mutationFn: async () => {
+      const result = await graphql.mutation({
         refreshRepository: {
           __args: { repositoryId: repository.id },
           id: true,
           repositoryId: true,
         },
-      }),
+      })
+      return result.refreshRepository
+    },
   })
 
   const addGitHubToken = useMutation({

--- a/apps/harness/test/issues-live.test.ts
+++ b/apps/harness/test/issues-live.test.ts
@@ -1,0 +1,53 @@
+import {
+  parseIssuesSubscriptionEvent,
+  streamIssuesChanged,
+} from "../src/issues-live.js"
+import { describe, expect, test } from "bun:test"
+
+describe("Issue live updates", () => {
+  test("parses GraphQL SSE events", () => {
+    expect(
+      parseIssuesSubscriptionEvent(
+        'event: next\ndata: {"data":{"repositoryIssuesChanged":"repo-1"}}',
+      ),
+    ).toBe("repo-1")
+    expect(parseIssuesSubscriptionEvent("event: complete")).toBeNull()
+    expect(parseIssuesSubscriptionEvent(": keep-alive")).toBeNull()
+  })
+
+  test("connects once and reports each changed Repository", async () => {
+    const events = [
+      'event: next\ndata: {"data":{"repositoryIssuesChanged":"repo-1"}}\n\n',
+      'event: next\ndata: {"data":{"repositoryIssuesChanged":"repo-2"}}\n\n',
+      "event: complete\n\n",
+    ]
+    const body = new ReadableStream({
+      start(controller) {
+        for (const event of events)
+          controller.enqueue(new TextEncoder().encode(event))
+        controller.close()
+      },
+    })
+    let connected = 0
+    const changes: string[] = []
+    let requestedBody: string | undefined
+
+    await streamIssuesChanged({
+      signal: new AbortController().signal,
+      onConnected: () => {
+        connected += 1
+      },
+      onChange: (repositoryId) => {
+        changes.push(repositoryId)
+      },
+      fetch: (_url, init) => {
+        requestedBody = String(init?.body)
+        return Promise.resolve(new Response(body, { status: 200 }))
+      },
+    })
+
+    expect(connected).toBe(1)
+    expect(changes).toEqual(["repo-1", "repo-2"])
+    expect(requestedBody).toContain("repositoryIssuesChanged")
+  })
+})

--- a/apps/harness/test/refresh-issues-live.test.ts
+++ b/apps/harness/test/refresh-issues-live.test.ts
@@ -1,0 +1,284 @@
+import { QueryClient } from "@tanstack/react-query"
+import { followRepositoryIssuesLive } from "../src/refresh-issues-live.js"
+import { describe, expect, test } from "bun:test"
+
+describe("Repository Issue live-query coordination", () => {
+  test("an invalidation refetches only the affected Repository Issues and metadata", async () => {
+    const repositoryId = "repo-01JSELECTED000000000000000"
+    const otherRepositoryId = "repo-01JOTHER0000000000000000"
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    })
+
+    let repositoriesFetches = 0
+    let selectedIssuesFetches = 0
+    let otherIssuesFetches = 0
+    let issuesReconciledAt: string | null = null
+    let selectedIssues = [
+      {
+        id: "issue-before",
+        title: "Before refresh",
+      },
+    ]
+
+    const queries = {
+      repositories: {
+        queryKey: ["repositories"] as const,
+        queryFn: async () => {
+          repositoriesFetches += 1
+          return [
+            {
+              id: repositoryId,
+              issuesReconciledAt,
+            },
+          ]
+        },
+      },
+      issues: (id: string) => ({
+        queryKey: ["issues", id] as const,
+        queryFn: async () => {
+          if (id === repositoryId) {
+            selectedIssuesFetches += 1
+            return selectedIssues
+          }
+          otherIssuesFetches += 1
+          return []
+        },
+      }),
+    }
+
+    let releaseInvalidation: (() => void) | undefined
+    const invalidation = new Promise<void>((resolve) => {
+      releaseInvalidation = resolve
+    })
+    let onChange: ((repositoryId: string) => void | Promise<void>) | undefined
+    let connected: (() => void) | undefined
+    const connectedPromise = new Promise<void>((resolve) => {
+      connected = resolve
+    })
+
+    const controller = new AbortController()
+    const live = followRepositoryIssuesLive({
+      repositoryIds: [repositoryId, otherRepositoryId],
+      queryClient,
+      queries,
+      signal: controller.signal,
+      retryDelayMs: 10,
+      stream: async ({ onConnected, onChange: handleChange, signal }) => {
+        onChange = handleChange
+        await onConnected()
+        connected?.()
+        await invalidation
+        if (signal.aborted) return
+        await handleChange(repositoryId)
+        await new Promise<void>((resolve) => {
+          if (signal.aborted) {
+            resolve()
+            return
+          }
+          signal.addEventListener("abort", () => resolve(), { once: true })
+        })
+      },
+    })
+
+    await connectedPromise
+
+    issuesReconciledAt = "2026-07-14T12:00:00.000Z"
+    selectedIssues = [
+      {
+        id: "issue-after",
+        title: "After refresh",
+      },
+    ]
+    const fetchesBeforeInvalidation = {
+      repositories: repositoriesFetches,
+      selectedIssues: selectedIssuesFetches,
+    }
+    releaseInvalidation?.()
+
+    await Bun.sleep(20)
+
+    const repositories = queryClient.getQueryData(queries.repositories.queryKey)
+    const issues = queryClient.getQueryData(
+      queries.issues(repositoryId).queryKey,
+    )
+
+    expect(repositories).toEqual([
+      {
+        id: repositoryId,
+        issuesReconciledAt: "2026-07-14T12:00:00.000Z",
+      },
+    ])
+    expect(issues).toEqual([
+      {
+        id: "issue-after",
+        title: "After refresh",
+      },
+    ])
+    expect(repositoriesFetches).toBeGreaterThan(
+      fetchesBeforeInvalidation.repositories,
+    )
+    expect(selectedIssuesFetches).toBeGreaterThan(
+      fetchesBeforeInvalidation.selectedIssues,
+    )
+    // Initial connection refetches both displayed Repositories, but the
+    // selected invalidation does not refetch the other Repository again.
+    expect(otherIssuesFetches).toBe(1)
+    const selectedFetchesBeforeOtherInvalidation = selectedIssuesFetches
+    const otherFetchesBeforeOtherInvalidation = otherIssuesFetches
+    await onChange?.(otherRepositoryId)
+    expect(selectedIssuesFetches).toBe(selectedFetchesBeforeOtherInvalidation)
+    expect(otherIssuesFetches).toBeGreaterThan(
+      otherFetchesBeforeOtherInvalidation,
+    )
+    expect(onChange).toBeDefined()
+
+    controller.abort()
+    await live
+  })
+
+  test("an invalidation replaces a stale in-flight Issue fetch", async () => {
+    const repositoryId = "repo-01JSELECTED000000000000000"
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    })
+    let resolveStale:
+      | ((issues: readonly { title: string }[]) => void)
+      | undefined
+    const staleResponse = new Promise<readonly { title: string }[]>(
+      (resolve) => {
+        resolveStale = resolve
+      },
+    )
+    let issueFetches = 0
+    const issuesQuery = {
+      queryKey: ["issues", repositoryId] as const,
+      queryFn: async () => {
+        issueFetches += 1
+        if (issueFetches === 1) return staleResponse
+        return [{ title: "After reconciliation" }]
+      },
+    }
+    let onChange:
+      | ((changedRepositoryId: string) => void | Promise<void>)
+      | undefined
+    let subscribed: (() => void) | undefined
+    const subscribedPromise = new Promise<void>((resolve) => {
+      subscribed = resolve
+    })
+    const controller = new AbortController()
+    const live = followRepositoryIssuesLive({
+      repositoryIds: [repositoryId],
+      queryClient,
+      queries: {
+        repositories: {
+          queryKey: ["repositories"],
+          queryFn: async () => [{ id: repositoryId }],
+        },
+        issues: () => issuesQuery,
+      },
+      signal: controller.signal,
+      stream: async ({ onChange: handleChange, signal }) => {
+        onChange = handleChange
+        subscribed?.()
+        await new Promise<void>((resolve) => {
+          signal.addEventListener("abort", () => resolve(), { once: true })
+        })
+      },
+    })
+
+    await subscribedPromise
+    const staleFetch = queryClient.fetchQuery({ ...issuesQuery, staleTime: 0 })
+    await Bun.sleep(0)
+    expect(issueFetches).toBe(1)
+
+    await onChange?.(repositoryId)
+    expect(issueFetches).toBe(2)
+    expect(queryClient.getQueryData(issuesQuery.queryKey)).toEqual([
+      { title: "After reconciliation" },
+    ])
+
+    resolveStale?.([{ title: "Before reconciliation" }])
+    await staleFetch.catch(() => undefined)
+    expect(queryClient.getQueryData(issuesQuery.queryKey)).toEqual([
+      { title: "After reconciliation" },
+    ])
+
+    controller.abort()
+    await live
+  })
+
+  test("tab visibility refetch is a fallback for missed invalidations", async () => {
+    const repositoryId = "repo-01JSELECTED000000000000000"
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    })
+    let repositoriesFetches = 0
+    let issuesFetches = 0
+    let visibilityState: DocumentVisibilityState = "hidden"
+    const listeners = new Map<string, Set<EventListener>>()
+
+    const documentRef = {
+      get visibilityState() {
+        return visibilityState
+      },
+      addEventListener(type: string, listener: EventListener) {
+        const set = listeners.get(type) ?? new Set()
+        set.add(listener)
+        listeners.set(type, set)
+      },
+      removeEventListener(type: string, listener: EventListener) {
+        listeners.get(type)?.delete(listener)
+      },
+    }
+
+    const controller = new AbortController()
+    const live = followRepositoryIssuesLive({
+      repositoryIds: [repositoryId],
+      queryClient,
+      queries: {
+        repositories: {
+          queryKey: ["repositories"],
+          queryFn: async () => {
+            repositoriesFetches += 1
+            return [{ id: repositoryId, issuesReconciledAt: "t1" }]
+          },
+        },
+        issues: (id: string) => ({
+          queryKey: ["issues", id],
+          queryFn: async () => {
+            if (id === repositoryId) issuesFetches += 1
+            return []
+          },
+        }),
+      },
+      signal: controller.signal,
+      documentRef,
+      stream: async ({ onConnected, signal }) => {
+        await onConnected()
+        await new Promise<void>((resolve) => {
+          signal.addEventListener("abort", () => resolve(), { once: true })
+        })
+      },
+    })
+
+    await Bun.sleep(10)
+    const repositoriesAfterConnect = repositoriesFetches
+    const issuesAfterConnect = issuesFetches
+    expect(repositoriesAfterConnect).toBeGreaterThan(0)
+    expect(issuesAfterConnect).toBeGreaterThan(0)
+
+    visibilityState = "visible"
+    for (const listener of listeners.get("visibilitychange") ?? []) {
+      listener(new Event("visibilitychange"))
+    }
+    await Bun.sleep(10)
+
+    expect(repositoriesFetches).toBeGreaterThan(repositoriesAfterConnect)
+    expect(issuesFetches).toBeGreaterThan(issuesAfterConnect)
+
+    controller.abort()
+    await live
+    expect(listeners.get("visibilitychange")?.size ?? 0).toBe(0)
+  })
+})

--- a/bun.lock
+++ b/bun.lock
@@ -59,6 +59,7 @@
         "react-dom": "^19.0.0",
       },
       "devDependencies": {
+        "@playwright/test": "^1.61.1",
         "@tailwindcss/vite": "^4.3.2",
         "@types/bun": "^1.3.0",
         "@types/react": "^19.0.8",
@@ -764,6 +765,8 @@
     "@oxc-resolver/binding-win32-x64-msvc": ["@oxc-resolver/binding-win32-x64-msvc@11.21.3", "", { "os": "win32", "cpu": "x64" }, "sha512-H7BCt/VnS9hnmMp42eGhZ99izSCRvlnWwy/N71K1/J8QoExwY4262Z8QiEkMDtduRJrztayDxETTckmUuAVL9Q=="],
 
     "@phenomnomnominal/tsquery": ["@phenomnomnominal/tsquery@6.2.0", "", { "dependencies": { "@types/esquery": "^1.5.4", "esquery": "^1.7.0" }, "peerDependencies": { "typescript": ">3.0.0" } }, "sha512-Vo9nkhfZxDB/sBiqIY3pjDC4mOSyure+AFlEW5hcy/tRE82MqCXjRN4InnVNMldinRt0dLYqg4HAU2XPq5e1LA=="],
+
+    "@playwright/test": ["@playwright/test@1.61.1", "", { "dependencies": { "playwright": "1.61.1" }, "bin": { "playwright": "cli.js" } }, "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig=="],
 
     "@ready-for-agent/cli": ["@ready-for-agent/cli@workspace:apps/cli"],
 
@@ -1589,6 +1592,10 @@
 
     "pkce-challenge": ["pkce-challenge@5.0.1", "", {}, "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ=="],
 
+    "playwright": ["playwright@1.61.1", "", { "dependencies": { "playwright-core": "1.61.1" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ=="],
+
+    "playwright-core": ["playwright-core@1.61.1", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg=="],
+
     "postcss": ["postcss@8.5.16", "", { "dependencies": { "nanoid": "^3.3.12", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg=="],
 
     "prettier": ["prettier@2.8.8", "", { "bin": { "prettier": "bin-prettier.js" } }, "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q=="],
@@ -1952,6 +1959,8 @@
     "p-locate/p-limit": ["p-limit@2.3.0", "", { "dependencies": { "p-try": "^2.0.0" } }, "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w=="],
 
     "parse-json/lines-and-columns": ["lines-and-columns@1.2.4", "", {}, "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="],
+
+    "playwright/fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
 
     "send/mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
 

--- a/packages/graphql-api/src/lib/graphql-api.ts
+++ b/packages/graphql-api/src/lib/graphql-api.ts
@@ -377,6 +377,16 @@ export const createGraphqlApi = (
               ),
             resolve: () => true,
           },
+          repositoryIssuesChanged: {
+            subscribe: async () =>
+              runtime.runPromise(
+                Effect.gen(function* () {
+                  const db = yield* DbService
+                  return yield* Stream.toAsyncIterableEffect(db.issueChanges)
+                }),
+              ),
+            resolve: (repositoryId: string) => repositoryId,
+          },
         },
         Mutation: {
           updateConfig: async (_parent: unknown, args: UpdateConfigArgs) => {

--- a/packages/graphql-api/test/graphql-api.test.ts
+++ b/packages/graphql-api/test/graphql-api.test.ts
@@ -832,6 +832,32 @@ describe("GraphQL API", () => {
     expect(body.match(/"data":\{"issuesChanged":true\}/g)?.length).toBe(1)
   })
 
+  test("streams aggregate issue invalidations with Repository IDs", async () => {
+    const otherRepositoryId = "repo-01J11111111111111111111111"
+    await runtime.dispose()
+    runtime = makeRuntime({
+      issueChanges: Stream.make(repository.id, otherRepositoryId),
+    })
+
+    const response = await createGraphqlApi(runtime).fetch(
+      new Request("http://127.0.0.1:4200/graphql", {
+        method: "POST",
+        headers: {
+          accept: "text/event-stream",
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          query: "subscription { repositoryIssuesChanged }",
+        }),
+      }),
+    )
+
+    expect(response.status).toBe(200)
+    expect(await response.text()).toContain(
+      `"data":{"repositoryIssuesChanged":"${otherRepositoryId}"}`,
+    )
+  })
+
   test("accepts same-origin browser requests", async () => {
     const response = await createGraphqlApi(runtime).fetch(
       addRepositoryRequest("http://127.0.0.1:4200"),

--- a/packages/graphql-schema/schema.graphql
+++ b/packages/graphql-schema/schema.graphql
@@ -81,4 +81,5 @@ type Mutation {
 type Subscription {
   repositoriesChanged: Boolean!
   issuesChanged(repositoryId: ID!): Boolean!
+  repositoryIssuesChanged: ID!
 }


### PR DESCRIPTION
## Why

Manual Repository refresh already enqueues work and returns a Job ID, but the Harness UI still treated refresh as a local mutation only. After enqueue acceptance, Issues and reconciliation metadata stayed stale until a full reconnect or page reload. That blocked the first complete background-work path: accept a Refresh Job promptly, let the worker reconcile, then update the selected Repository when notified.

## What Changed

- Subscribe once to a Repository-scoped Issues invalidation stream (`repositoryIssuesChanged`) instead of one SSE connection per card
- On invalidation, refetch that Repository's Issues and reconciliation metadata (`issuesReconciledAt`), cancelling in-flight queries first so a stale request cannot win
- Keep reconnect and tab-visibility refetch as fallbacks for missed ephemeral notifications
- Leave Refresh mutation pending state enqueue-only; no durable Job status UI
- Add unit coverage for scoped refetch / race handling, plus a Playwright browser journey for click Refresh → enqueue returns → controlled invalidation → UI update

Closes #59
