### PR TITLE
feat(work-item-lifecycle): create and schedule Actionable Work Items

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -230,6 +230,22 @@
         "@types/bun": "^1.3.0",
       },
     },
+    "packages/work-item-lifecycle": {
+      "name": "@ready-for-agent/work-item-lifecycle",
+      "version": "0.0.1",
+      "dependencies": {
+        "@ready-for-agent/db-service": "workspace:*",
+        "@ready-for-agent/queue-service": "workspace:*",
+        "effect": "^4.0.0-beta.97",
+        "tslib": "^2.3.0",
+        "ulidx": "^2.4.1",
+      },
+      "devDependencies": {
+        "@ready-for-agent/db": "workspace:*",
+        "@ready-for-agent/sqlite-queue-service": "workspace:*",
+        "@types/bun": "^1.3.0",
+      },
+    },
   },
   "packages": {
     "@babel/code-frame": ["@babel/code-frame@7.29.7", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.29.7", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw=="],
@@ -799,6 +815,8 @@
     "@ready-for-agent/queue-service": ["@ready-for-agent/queue-service@workspace:packages/queue-service"],
 
     "@ready-for-agent/sqlite-queue-service": ["@ready-for-agent/sqlite-queue-service@workspace:packages/sqlite-queue-service"],
+
+    "@ready-for-agent/work-item-lifecycle": ["@ready-for-agent/work-item-lifecycle@workspace:packages/work-item-lifecycle"],
 
     "@repeaterjs/repeater": ["@repeaterjs/repeater@3.1.0", "", {}, "sha512-TaoVksZRSx2KWYYpyLQtMQXXeS98VsgZImzW65xmiVgbYhXLk+aEsmzPLirqVuE4/XuUapH2iMtxUzaBNDzdSQ=="],
 

--- a/packages/db-schema/drizzle/20260714041109_luxuriant_selene/migration.sql
+++ b/packages/db-schema/drizzle/20260714041109_luxuriant_selene/migration.sql
@@ -1,0 +1,37 @@
+CREATE TABLE `step_run` (
+	`id` text PRIMARY KEY,
+	`work_item_id` text NOT NULL,
+	`step` text NOT NULL,
+	`status` text NOT NULL,
+	`queue_job_id` text,
+	`queued_at` integer NOT NULL,
+	`started_at` integer,
+	`finished_at` integer,
+	`reason_code` text,
+	`reason_message` text,
+	`created_at` integer NOT NULL,
+	`updated_at` integer NOT NULL,
+	CONSTRAINT `fk_step_run_work_item_id_work_item_id_fk` FOREIGN KEY (`work_item_id`) REFERENCES `work_item`(`id`) ON DELETE CASCADE
+);
+--> statement-breakpoint
+CREATE TABLE `work_item` (
+	`id` text PRIMARY KEY,
+	`repository_id` text NOT NULL,
+	`github_issue_number` integer NOT NULL,
+	`model` text NOT NULL,
+	`variant` text NOT NULL,
+	`state` text NOT NULL,
+	`state_ready_at` integer NOT NULL,
+	`worktree_path` text,
+	`session_id` text,
+	`failure_code` text,
+	`failure_message` text,
+	`created_at` integer NOT NULL,
+	`updated_at` integer NOT NULL,
+	CONSTRAINT `fk_work_item_repository_id_repository_id_fk` FOREIGN KEY (`repository_id`) REFERENCES `repository`(`id`) ON DELETE CASCADE
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `step_run_one_active_uidx` ON `step_run` (`work_item_id`) WHERE "step_run"."status" IN ('queued', 'running');--> statement-breakpoint
+CREATE INDEX `step_run_work_item_id_queued_at_idx` ON `step_run` (`work_item_id`,`queued_at`);--> statement-breakpoint
+CREATE UNIQUE INDEX `work_item_one_unfinished_uidx` ON `work_item` (`repository_id`,`github_issue_number`) WHERE "work_item"."state" NOT IN ('complete', 'failed', 'abandoned');--> statement-breakpoint
+CREATE INDEX `work_item_repository_issue_created_idx` ON `work_item` (`repository_id`,`github_issue_number`,`created_at`);

--- a/packages/db-schema/drizzle/20260714041109_luxuriant_selene/snapshot.json
+++ b/packages/db-schema/drizzle/20260714041109_luxuriant_selene/snapshot.json
@@ -1,0 +1,1074 @@
+{
+  "version": "7",
+  "dialect": "sqlite",
+  "id": "1ce49508-cdf8-4185-90a8-7d4931a9fcf9",
+  "prevIds": [
+    "557f6e44-154a-4c8b-b591-f71b45802d7e"
+  ],
+  "ddl": [
+    {
+      "name": "completed_job",
+      "entityType": "tables"
+    },
+    {
+      "name": "config",
+      "entityType": "tables"
+    },
+    {
+      "name": "issue",
+      "entityType": "tables"
+    },
+    {
+      "name": "issue_dependency",
+      "entityType": "tables"
+    },
+    {
+      "name": "job_queue",
+      "entityType": "tables"
+    },
+    {
+      "name": "repository",
+      "entityType": "tables"
+    },
+    {
+      "name": "step_run",
+      "entityType": "tables"
+    },
+    {
+      "name": "work_item",
+      "entityType": "tables"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "completed_job"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "queue",
+      "entityType": "columns",
+      "table": "completed_job"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "job_id",
+      "entityType": "columns",
+      "table": "completed_job"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "completed_job"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "completed_job"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "'default'",
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "config"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'opencode/deepseek-v4-flash-free'",
+      "generated": null,
+      "name": "default_model",
+      "entityType": "columns",
+      "table": "config"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'low'",
+      "generated": null,
+      "name": "default_variant",
+      "entityType": "columns",
+      "table": "config"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "config"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "config"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "issue"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "repository_id",
+      "entityType": "columns",
+      "table": "issue"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "github_issue_number",
+      "entityType": "columns",
+      "table": "issue"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "title",
+      "entityType": "columns",
+      "table": "issue"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "body",
+      "entityType": "columns",
+      "table": "issue"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "url",
+      "entityType": "columns",
+      "table": "issue"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "state",
+      "entityType": "columns",
+      "table": "issue"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "github_created_at",
+      "entityType": "columns",
+      "table": "issue"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "parent_github_issue_number",
+      "entityType": "columns",
+      "table": "issue"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "parent_github_issue_url",
+      "entityType": "columns",
+      "table": "issue"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "parent_position",
+      "entityType": "columns",
+      "table": "issue"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "false",
+      "generated": null,
+      "name": "has_children",
+      "entityType": "columns",
+      "table": "issue"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "issue"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "issue"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "issue_dependency"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "issue_id",
+      "entityType": "columns",
+      "table": "issue_dependency"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "blocking_github_issue_number",
+      "entityType": "columns",
+      "table": "issue_dependency"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "blocking_github_issue_url",
+      "entityType": "columns",
+      "table": "issue_dependency"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "issue_dependency"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "job_queue"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "queue",
+      "entityType": "columns",
+      "table": "job_queue"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "job_payload",
+      "entityType": "columns",
+      "table": "job_queue"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "0",
+      "generated": null,
+      "name": "job_attempts",
+      "entityType": "columns",
+      "table": "job_queue"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "5",
+      "generated": null,
+      "name": "job_retry_limit",
+      "entityType": "columns",
+      "table": "job_queue"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "available_at",
+      "entityType": "columns",
+      "table": "job_queue"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "locked_until",
+      "entityType": "columns",
+      "table": "job_queue"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "job_queue"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "job_queue"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "repository"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "github_owner",
+      "entityType": "columns",
+      "table": "repository"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "github_repo",
+      "entityType": "columns",
+      "table": "repository"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "local_path",
+      "entityType": "columns",
+      "table": "repository"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "is_bare",
+      "entityType": "columns",
+      "table": "repository"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "true",
+      "generated": null,
+      "name": "paused",
+      "entityType": "columns",
+      "table": "repository"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "issues_reconciled_at",
+      "entityType": "columns",
+      "table": "repository"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "repository"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "repository"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "step_run"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "work_item_id",
+      "entityType": "columns",
+      "table": "step_run"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "step",
+      "entityType": "columns",
+      "table": "step_run"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "status",
+      "entityType": "columns",
+      "table": "step_run"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "queue_job_id",
+      "entityType": "columns",
+      "table": "step_run"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "queued_at",
+      "entityType": "columns",
+      "table": "step_run"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "started_at",
+      "entityType": "columns",
+      "table": "step_run"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "finished_at",
+      "entityType": "columns",
+      "table": "step_run"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "reason_code",
+      "entityType": "columns",
+      "table": "step_run"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "reason_message",
+      "entityType": "columns",
+      "table": "step_run"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "step_run"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "step_run"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "work_item"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "repository_id",
+      "entityType": "columns",
+      "table": "work_item"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "github_issue_number",
+      "entityType": "columns",
+      "table": "work_item"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "model",
+      "entityType": "columns",
+      "table": "work_item"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "variant",
+      "entityType": "columns",
+      "table": "work_item"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "state",
+      "entityType": "columns",
+      "table": "work_item"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "state_ready_at",
+      "entityType": "columns",
+      "table": "work_item"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "worktree_path",
+      "entityType": "columns",
+      "table": "work_item"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "session_id",
+      "entityType": "columns",
+      "table": "work_item"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "failure_code",
+      "entityType": "columns",
+      "table": "work_item"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "failure_message",
+      "entityType": "columns",
+      "table": "work_item"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "work_item"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "work_item"
+    },
+    {
+      "columns": [
+        "repository_id"
+      ],
+      "tableTo": "repository",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_issue_repository_id_repository_id_fk",
+      "entityType": "fks",
+      "table": "issue"
+    },
+    {
+      "columns": [
+        "issue_id"
+      ],
+      "tableTo": "issue",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_issue_dependency_issue_id_issue_id_fk",
+      "entityType": "fks",
+      "table": "issue_dependency"
+    },
+    {
+      "columns": [
+        "work_item_id"
+      ],
+      "tableTo": "work_item",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_step_run_work_item_id_work_item_id_fk",
+      "entityType": "fks",
+      "table": "step_run"
+    },
+    {
+      "columns": [
+        "repository_id"
+      ],
+      "tableTo": "repository",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_work_item_repository_id_repository_id_fk",
+      "entityType": "fks",
+      "table": "work_item"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "completed_job_pk",
+      "table": "completed_job",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "config_pk",
+      "table": "config",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "issue_pk",
+      "table": "issue",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "issue_dependency_pk",
+      "table": "issue_dependency",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "job_queue_pk",
+      "table": "job_queue",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "repository_pk",
+      "table": "repository",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "step_run_pk",
+      "table": "step_run",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "work_item_pk",
+      "table": "work_item",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        {
+          "value": "queue",
+          "isExpression": false
+        },
+        {
+          "value": "job_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "origin": "manual",
+      "name": "completed_job_queue_job_id_uidx",
+      "entityType": "indexes",
+      "table": "completed_job"
+    },
+    {
+      "columns": [
+        {
+          "value": "repository_id",
+          "isExpression": false
+        },
+        {
+          "value": "github_issue_number",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "origin": "manual",
+      "name": "issue_repository_id_github_issue_number_uidx",
+      "entityType": "indexes",
+      "table": "issue"
+    },
+    {
+      "columns": [
+        {
+          "value": "issue_id",
+          "isExpression": false
+        },
+        {
+          "value": "blocking_github_issue_url",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "origin": "manual",
+      "name": "issue_dependency_issue_id_blocking_url_uidx",
+      "entityType": "indexes",
+      "table": "issue_dependency"
+    },
+    {
+      "columns": [
+        {
+          "value": "queue",
+          "isExpression": false
+        },
+        {
+          "value": "locked_until",
+          "isExpression": false
+        },
+        {
+          "value": "job_attempts",
+          "isExpression": false
+        },
+        {
+          "value": "available_at",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "job_queue_ready_idx",
+      "entityType": "indexes",
+      "table": "job_queue"
+    },
+    {
+      "columns": [
+        {
+          "value": "lower(\"github_owner\")",
+          "isExpression": true
+        },
+        {
+          "value": "lower(\"github_repo\")",
+          "isExpression": true
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "origin": "manual",
+      "name": "repository_github_owner_repo_lower_uidx",
+      "entityType": "indexes",
+      "table": "repository"
+    },
+    {
+      "columns": [
+        {
+          "value": "work_item_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": "\"step_run\".\"status\" IN ('queued', 'running')",
+      "origin": "manual",
+      "name": "step_run_one_active_uidx",
+      "entityType": "indexes",
+      "table": "step_run"
+    },
+    {
+      "columns": [
+        {
+          "value": "work_item_id",
+          "isExpression": false
+        },
+        {
+          "value": "queued_at",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "step_run_work_item_id_queued_at_idx",
+      "entityType": "indexes",
+      "table": "step_run"
+    },
+    {
+      "columns": [
+        {
+          "value": "repository_id",
+          "isExpression": false
+        },
+        {
+          "value": "github_issue_number",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": "\"work_item\".\"state\" NOT IN ('complete', 'failed', 'abandoned')",
+      "origin": "manual",
+      "name": "work_item_one_unfinished_uidx",
+      "entityType": "indexes",
+      "table": "work_item"
+    },
+    {
+      "columns": [
+        {
+          "value": "repository_id",
+          "isExpression": false
+        },
+        {
+          "value": "github_issue_number",
+          "isExpression": false
+        },
+        {
+          "value": "created_at",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "work_item_repository_issue_created_idx",
+      "entityType": "indexes",
+      "table": "work_item"
+    },
+    {
+      "columns": [
+        "local_path"
+      ],
+      "nameExplicit": false,
+      "name": "repository_local_path_unique",
+      "entityType": "uniques",
+      "table": "repository"
+    }
+  ],
+  "renames": []
+}

--- a/packages/db-schema/src/schema.ts
+++ b/packages/db-schema/src/schema.ts
@@ -162,3 +162,101 @@ export const completedJob = snakeCase.table(
   },
   (t) => [uniqueIndex("completed_job_queue_job_id_uidx").on(t.queue, t.jobId)],
 )
+
+/**
+ * Durable operator-requested implementation attempt for one Issue.
+ * See xplain: type work item "wi"
+ */
+export const workItem = snakeCase.table(
+  "work_item",
+  {
+    id: text()
+      .primaryKey()
+      .$defaultFn(() => `wi-${ulid()}`),
+    repositoryId: text()
+      .notNull()
+      .references(() => repository.id, { onDelete: "cascade" }),
+    githubIssueNumber: integer().notNull(),
+    model: text().notNull(),
+    variant: text().notNull(),
+    state: text({
+      enum: [
+        "create_worktree",
+        "install_dependencies",
+        "implement",
+        "review",
+        "complete",
+        "failed",
+        "abandoned",
+      ],
+    }).notNull(),
+    stateReadyAt: integer({ mode: "number" }).notNull(),
+    worktreePath: text(),
+    sessionId: text(),
+    failureCode: text(),
+    failureMessage: text(),
+    createdAt: integer({ mode: "number" })
+      .notNull()
+      .$defaultFn(() => Date.now()),
+    updatedAt: integer({ mode: "number" })
+      .notNull()
+      .$defaultFn(() => Date.now()),
+  },
+  (t) => [
+    uniqueIndex("work_item_one_unfinished_uidx")
+      .on(t.repositoryId, t.githubIssueNumber)
+      .where(sql`${t.state} NOT IN ('complete', 'failed', 'abandoned')`),
+    index("work_item_repository_issue_created_idx").on(
+      t.repositoryId,
+      t.githubIssueNumber,
+      t.createdAt,
+    ),
+  ],
+)
+
+/**
+ * One scheduled execution attempt for a Work Item Lifecycle Step.
+ * See xplain: type step run "srun"
+ */
+export const stepRun = snakeCase.table(
+  "step_run",
+  {
+    id: text()
+      .primaryKey()
+      .$defaultFn(() => `srun-${ulid()}`),
+    workItemId: text()
+      .notNull()
+      .references(() => workItem.id, { onDelete: "cascade" }),
+    step: text({
+      enum: ["create_worktree", "install_dependencies", "implement", "review"],
+    }).notNull(),
+    status: text({
+      enum: [
+        "queued",
+        "running",
+        "succeeded",
+        "failed",
+        "interrupted",
+        "cancelled",
+      ],
+    }).notNull(),
+    queueJobId: text(),
+    queuedAt: integer({ mode: "number" }).notNull(),
+    startedAt: integer({ mode: "number" }),
+    finishedAt: integer({ mode: "number" }),
+    reasonCode: text(),
+    reasonMessage: text(),
+    createdAt: integer({ mode: "number" })
+      .notNull()
+      .$defaultFn(() => Date.now()),
+    updatedAt: integer({ mode: "number" })
+      .notNull()
+      .$defaultFn(() => Date.now()),
+  },
+  (t) => [
+    uniqueIndex("step_run_one_active_uidx")
+      .on(t.workItemId)
+      .where(sql`${t.status} IN ('queued', 'running')`),
+    index("step_run_work_item_id_queued_at_idx").on(t.workItemId, t.queuedAt),
+  ],
+)

--- a/packages/work-item-lifecycle/package.json
+++ b/packages/work-item-lifecycle/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "@ready-for-agent/work-item-lifecycle",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    "./package.json": "./package.json",
+    ".": {
+      "@ready-for-agent/source": "./src/index.ts",
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    }
+  },
+  "dependencies": {
+    "@ready-for-agent/db-service": "workspace:*",
+    "@ready-for-agent/queue-service": "workspace:*",
+    "effect": "^4.0.0-beta.97",
+    "tslib": "^2.3.0",
+    "ulidx": "^2.4.1"
+  },
+  "devDependencies": {
+    "@ready-for-agent/db": "workspace:*",
+    "@ready-for-agent/sqlite-queue-service": "workspace:*",
+    "@types/bun": "^1.3.0"
+  }
+}

--- a/packages/work-item-lifecycle/project.json
+++ b/packages/work-item-lifecycle/project.json
@@ -1,0 +1,19 @@
+{
+  "name": "work-item-lifecycle",
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "packages/work-item-lifecycle/src",
+  "projectType": "library",
+  "tags": [],
+  "targets": {
+    "test": {
+      "executor": "nx:run-commands",
+      "options": {
+        "cwd": "{projectRoot}",
+        "command": "bun test"
+      },
+      "inputs": ["default", "^production"],
+      "cache": true,
+      "dependsOn": ["^build"]
+    }
+  }
+}

--- a/packages/work-item-lifecycle/src/index.ts
+++ b/packages/work-item-lifecycle/src/index.ts
@@ -1,0 +1,3 @@
+export * from "./lib/errors.js"
+export * from "./lib/types.js"
+export * from "./lib/work-item-lifecycle.js"

--- a/packages/work-item-lifecycle/src/lib/errors.ts
+++ b/packages/work-item-lifecycle/src/lib/errors.ts
@@ -1,0 +1,50 @@
+import { Data } from "effect"
+
+export class NonTransactionalQueueError extends Data.TaggedError(
+  "NonTransactionalQueueError",
+)<{
+  readonly message: string
+}> {}
+
+export class IssueNotFoundError extends Data.TaggedError("IssueNotFoundError")<{
+  readonly repositoryId: string
+  readonly githubIssueNumber: number
+}> {}
+
+export class IssueNotOpenError extends Data.TaggedError("IssueNotOpenError")<{
+  readonly repositoryId: string
+  readonly githubIssueNumber: number
+  readonly state: string
+}> {}
+
+export class ParentIssueError extends Data.TaggedError("ParentIssueError")<{
+  readonly repositoryId: string
+  readonly githubIssueNumber: number
+}> {}
+
+export class IssueBlockedError extends Data.TaggedError("IssueBlockedError")<{
+  readonly repositoryId: string
+  readonly githubIssueNumber: number
+  readonly blockerCount: number
+}> {}
+
+export class UnfinishedWorkItemExistsError extends Data.TaggedError(
+  "UnfinishedWorkItemExistsError",
+)<{
+  readonly repositoryId: string
+  readonly githubIssueNumber: number
+  readonly workItemId: string
+}> {}
+
+export class WorkItemNotFoundError extends Data.TaggedError(
+  "WorkItemNotFoundError",
+)<{
+  readonly workItemId: string
+}> {}
+
+export class WorkItemLifecycleDatabaseError extends Data.TaggedError(
+  "WorkItemLifecycleDatabaseError",
+)<{
+  readonly message: string
+  readonly cause?: unknown
+}> {}

--- a/packages/work-item-lifecycle/src/lib/types.ts
+++ b/packages/work-item-lifecycle/src/lib/types.ts
@@ -1,0 +1,81 @@
+import { Schema } from "effect"
+import { ulid } from "ulidx"
+
+export const WorkItemId = Schema.String.pipe(
+  Schema.check(Schema.isPattern(/^wi-[0-9A-HJKMNP-TV-Z]{26}$/)),
+  Schema.brand("WorkItemId"),
+)
+export type WorkItemId = typeof WorkItemId.Type
+
+export const makeWorkItemId = (): WorkItemId => WorkItemId.make(`wi-${ulid()}`)
+
+export const StepRunId = Schema.String.pipe(
+  Schema.check(Schema.isPattern(/^srun-[0-9A-HJKMNP-TV-Z]{26}$/)),
+  Schema.brand("StepRunId"),
+)
+export type StepRunId = typeof StepRunId.Type
+
+export const makeStepRunId = (): StepRunId => StepRunId.make(`srun-${ulid()}`)
+
+export type OperationalLifecycleStep =
+  | "create_worktree"
+  | "install_dependencies"
+  | "implement"
+  | "review"
+
+export type WorkItemState =
+  | OperationalLifecycleStep
+  | "complete"
+  | "failed"
+  | "abandoned"
+
+export type StepRunStatus =
+  | "queued"
+  | "running"
+  | "succeeded"
+  | "failed"
+  | "interrupted"
+  | "cancelled"
+
+export interface StepRunRecord {
+  readonly id: StepRunId
+  readonly workItemId: WorkItemId
+  readonly step: OperationalLifecycleStep
+  readonly status: StepRunStatus
+  readonly queueJobId: string | null
+  readonly queuedAt: Date
+  readonly startedAt: Date | null
+  readonly finishedAt: Date | null
+  readonly reasonCode: string | null
+  readonly reasonMessage: string | null
+}
+
+export interface WorkItemRecord {
+  readonly id: WorkItemId
+  readonly repositoryId: string
+  readonly githubIssueNumber: number
+  readonly model: string
+  readonly variant: string
+  readonly state: WorkItemState
+  readonly stateReadyAt: Date
+  readonly worktreePath: string | null
+  readonly sessionId: string | null
+  readonly failureCode: string | null
+  readonly failureMessage: string | null
+  readonly createdAt: Date
+  readonly updatedAt: Date
+  readonly stepRuns: readonly StepRunRecord[]
+}
+
+export const WORK_ITEM_LIFECYCLE_QUEUE = "jobs"
+
+export const WorkItemStepJob = Schema.TaggedStruct("work-item-step", {
+  stepRunId: StepRunId,
+})
+export type WorkItemStepJob = typeof WorkItemStepJob.Type
+
+export const TERMINAL_WORK_ITEM_STATES = [
+  "complete",
+  "failed",
+  "abandoned",
+] as const satisfies readonly WorkItemState[]

--- a/packages/work-item-lifecycle/src/lib/work-item-lifecycle.ts
+++ b/packages/work-item-lifecycle/src/lib/work-item-lifecycle.ts
@@ -1,0 +1,485 @@
+import { Context, Effect, Layer, Schema } from "effect"
+import { SqlClient } from "effect/unstable/sql"
+import type { SqlError } from "effect/unstable/sql/SqlError"
+import {
+  type DatabaseError,
+  DbService,
+  type RepositoryNotFoundError,
+} from "@ready-for-agent/db-service"
+import {
+  EnqueueError,
+  InvalidQueueNameError,
+  QueueService,
+} from "@ready-for-agent/queue-service"
+import {
+  IssueBlockedError,
+  IssueNotFoundError,
+  IssueNotOpenError,
+  NonTransactionalQueueError,
+  ParentIssueError,
+  UnfinishedWorkItemExistsError,
+  WorkItemLifecycleDatabaseError,
+  WorkItemNotFoundError,
+} from "./errors.js"
+import {
+  type OperationalLifecycleStep,
+  type StepRunId,
+  type StepRunRecord,
+  type StepRunStatus,
+  WORK_ITEM_LIFECYCLE_QUEUE,
+  type WorkItemId,
+  type WorkItemRecord,
+  type WorkItemState,
+  WorkItemStepJob,
+  makeStepRunId,
+  makeWorkItemId,
+} from "./types.js"
+
+const formatSqlError = (error: SqlError): string => {
+  const parts: string[] = [error.message]
+  let current: unknown = error.cause
+  while (current) {
+    if (current instanceof Error) {
+      parts.push(current.message)
+      current = current.cause
+    } else if (typeof current === "object" && current !== null) {
+      const obj = current as Record<string, unknown>
+      if (typeof obj["message"] === "string") {
+        parts.push(obj["message"])
+      }
+      current = "cause" in obj ? obj["cause"] : undefined
+    } else if (typeof current === "string") {
+      parts.push(current)
+      break
+    } else {
+      break
+    }
+  }
+  return parts.join(" -> ")
+}
+
+const isUnfinishedWorkItemUniqueViolation = (error: SqlError): boolean => {
+  const message = formatSqlError(error).toLowerCase()
+  return (
+    (message.includes("unique") || message.includes("sqlite_constraint")) &&
+    (message.includes("work_item_one_unfinished_uidx") ||
+      (message.includes("work_item.repository_id") &&
+        message.includes("work_item.github_issue_number")))
+  )
+}
+
+const toDatabaseError = (error: SqlError) =>
+  new WorkItemLifecycleDatabaseError({
+    message: `Database error: ${formatSqlError(error)}`,
+    cause: error,
+  })
+
+type WorkItemRow = {
+  readonly id: string
+  readonly repository_id: string
+  readonly github_issue_number: number
+  readonly model: string
+  readonly variant: string
+  readonly state: WorkItemState
+  readonly state_ready_at: number
+  readonly worktree_path: string | null
+  readonly session_id: string | null
+  readonly failure_code: string | null
+  readonly failure_message: string | null
+  readonly created_at: number
+  readonly updated_at: number
+}
+
+type StepRunRow = {
+  readonly id: string
+  readonly work_item_id: string
+  readonly step: OperationalLifecycleStep
+  readonly status: StepRunStatus
+  readonly queue_job_id: string | null
+  readonly queued_at: number
+  readonly started_at: number | null
+  readonly finished_at: number | null
+  readonly reason_code: string | null
+  readonly reason_message: string | null
+}
+
+const toStepRunRecord = (row: StepRunRow): StepRunRecord => ({
+  id: row.id as StepRunId,
+  workItemId: row.work_item_id as WorkItemId,
+  step: row.step,
+  status: row.status,
+  queueJobId: row.queue_job_id,
+  queuedAt: new Date(row.queued_at),
+  startedAt: row.started_at === null ? null : new Date(row.started_at),
+  finishedAt: row.finished_at === null ? null : new Date(row.finished_at),
+  reasonCode: row.reason_code,
+  reasonMessage: row.reason_message,
+})
+
+const toWorkItemRecord = (
+  row: WorkItemRow,
+  stepRuns: readonly StepRunRecord[],
+): WorkItemRecord => ({
+  id: row.id as WorkItemId,
+  repositoryId: row.repository_id,
+  githubIssueNumber: row.github_issue_number,
+  model: row.model,
+  variant: row.variant,
+  state: row.state,
+  stateReadyAt: new Date(row.state_ready_at),
+  worktreePath: row.worktree_path,
+  sessionId: row.session_id,
+  failureCode: row.failure_code,
+  failureMessage: row.failure_message,
+  createdAt: new Date(row.created_at),
+  updatedAt: new Date(row.updated_at),
+  stepRuns,
+})
+
+export type ImplementNowError =
+  | IssueNotFoundError
+  | IssueNotOpenError
+  | ParentIssueError
+  | IssueBlockedError
+  | UnfinishedWorkItemExistsError
+  | WorkItemLifecycleDatabaseError
+  | RepositoryNotFoundError
+  | DatabaseError
+  | EnqueueError
+  | InvalidQueueNameError
+
+export type GetWorkItemError =
+  | WorkItemNotFoundError
+  | WorkItemLifecycleDatabaseError
+
+export type ListWorkItemsError = WorkItemLifecycleDatabaseError
+
+export interface WorkItemLifecycleShape {
+  readonly implementNow: (
+    repositoryId: string,
+    githubIssueNumber: number,
+  ) => Effect.Effect<WorkItemRecord, ImplementNowError>
+  readonly getWorkItem: (
+    workItemId: string,
+  ) => Effect.Effect<WorkItemRecord, GetWorkItemError>
+  readonly listWorkItemsForIssue: (
+    repositoryId: string,
+    githubIssueNumber: number,
+  ) => Effect.Effect<readonly WorkItemRecord[], ListWorkItemsError>
+}
+
+export class WorkItemLifecycle extends Context.Service<
+  WorkItemLifecycle,
+  WorkItemLifecycleShape
+>()("@ready-for-agent/work-item-lifecycle/WorkItemLifecycle") {}
+
+export const WorkItemLifecycleLive = Layer.effect(
+  WorkItemLifecycle,
+  Effect.gen(function* () {
+    const sql = yield* SqlClient.SqlClient
+    const db = yield* DbService
+    const queue = yield* QueueService
+
+    if (!queue.queueInTransaction) {
+      return yield* new NonTransactionalQueueError({
+        message:
+          "Work Item Lifecycle requires a QueueService that participates in database transactions",
+      })
+    }
+
+    const findUnfinishedWorkItemId = (
+      repositoryId: string,
+      githubIssueNumber: number,
+    ): Effect.Effect<string | null, WorkItemLifecycleDatabaseError> =>
+      Effect.gen(function* () {
+        const rows = (yield* sql
+          .unsafe(
+            `SELECT id FROM work_item
+             WHERE repository_id = ?
+               AND github_issue_number = ?
+               AND state NOT IN ('complete', 'failed', 'abandoned')
+             ORDER BY created_at ASC, id ASC
+             LIMIT 1`,
+            [repositoryId, githubIssueNumber],
+          )
+          .pipe(Effect.mapError(toDatabaseError))) as readonly { id: string }[]
+        return rows[0]?.id ?? null
+      })
+
+    const unfinishedWorkItemExistsError = (
+      repositoryId: string,
+      githubIssueNumber: number,
+      knownWorkItemId?: string,
+    ): Effect.Effect<
+      never,
+      UnfinishedWorkItemExistsError | WorkItemLifecycleDatabaseError
+    > =>
+      Effect.gen(function* () {
+        const workItemId =
+          knownWorkItemId ??
+          (yield* findUnfinishedWorkItemId(repositoryId, githubIssueNumber))
+        return yield* new UnfinishedWorkItemExistsError({
+          repositoryId,
+          githubIssueNumber,
+          workItemId: workItemId ?? "unknown",
+        })
+      })
+
+    const loadStepRuns = (
+      workItemIds: readonly string[],
+    ): Effect.Effect<
+      Map<string, StepRunRecord[]>,
+      WorkItemLifecycleDatabaseError
+    > =>
+      Effect.gen(function* () {
+        const byWorkItem = new Map<string, StepRunRecord[]>()
+        if (workItemIds.length === 0) {
+          return byWorkItem
+        }
+
+        const placeholders = workItemIds.map(() => "?").join(", ")
+        const rows = (yield* sql
+          .unsafe(
+            `SELECT id, work_item_id, step, status, queue_job_id, queued_at,
+                    started_at, finished_at, reason_code, reason_message
+             FROM step_run
+             WHERE work_item_id IN (${placeholders})
+             ORDER BY queued_at ASC, id ASC`,
+            [...workItemIds],
+          )
+          .pipe(Effect.mapError(toDatabaseError))) as readonly StepRunRow[]
+
+        for (const row of rows) {
+          const record = toStepRunRecord(row)
+          const existing = byWorkItem.get(row.work_item_id)
+          if (existing) {
+            existing.push(record)
+          } else {
+            byWorkItem.set(row.work_item_id, [record])
+          }
+        }
+        return byWorkItem
+      })
+
+    const getWorkItem = Effect.fn("WorkItemLifecycle.getWorkItem")(function* (
+      workItemId: string,
+    ) {
+      const rows = (yield* sql
+        .unsafe(
+          `SELECT id, repository_id, github_issue_number, model, variant, state,
+                  state_ready_at, worktree_path, session_id, failure_code,
+                  failure_message, created_at, updated_at
+           FROM work_item
+           WHERE id = ?
+           LIMIT 1`,
+          [workItemId],
+        )
+        .pipe(Effect.mapError(toDatabaseError))) as readonly WorkItemRow[]
+
+      const row = rows[0]
+      if (!row) {
+        return yield* new WorkItemNotFoundError({ workItemId })
+      }
+
+      const stepRunsByWorkItem = yield* loadStepRuns([row.id])
+      return toWorkItemRecord(row, stepRunsByWorkItem.get(row.id) ?? [])
+    })
+
+    const listWorkItemsForIssue = Effect.fn(
+      "WorkItemLifecycle.listWorkItemsForIssue",
+    )(function* (repositoryId: string, githubIssueNumber: number) {
+      const rows = (yield* sql
+        .unsafe(
+          `SELECT id, repository_id, github_issue_number, model, variant, state,
+                  state_ready_at, worktree_path, session_id, failure_code,
+                  failure_message, created_at, updated_at
+           FROM work_item
+           WHERE repository_id = ? AND github_issue_number = ?
+           ORDER BY created_at ASC, id ASC`,
+          [repositoryId, githubIssueNumber],
+        )
+        .pipe(Effect.mapError(toDatabaseError))) as readonly WorkItemRow[]
+
+      const stepRunsByWorkItem = yield* loadStepRuns(rows.map((row) => row.id))
+      return rows.map((row) =>
+        toWorkItemRecord(row, stepRunsByWorkItem.get(row.id) ?? []),
+      )
+    })
+
+    const implementNow = Effect.fn("WorkItemLifecycle.implementNow")(function* (
+      repositoryId: string,
+      githubIssueNumber: number,
+    ) {
+      const issues = yield* db.listIssues(repositoryId)
+      const issue = issues.find(
+        (candidate) => candidate.githubIssueNumber === githubIssueNumber,
+      )
+
+      if (!issue) {
+        return yield* new IssueNotFoundError({
+          repositoryId,
+          githubIssueNumber,
+        })
+      }
+
+      if (issue.state !== "OPEN") {
+        return yield* new IssueNotOpenError({
+          repositoryId,
+          githubIssueNumber,
+          state: issue.state,
+        })
+      }
+
+      if (issue.hasChildren) {
+        return yield* new ParentIssueError({
+          repositoryId,
+          githubIssueNumber,
+        })
+      }
+
+      if (issue.blockedBy.length > 0) {
+        return yield* new IssueBlockedError({
+          repositoryId,
+          githubIssueNumber,
+          blockerCount: issue.blockedBy.length,
+        })
+      }
+
+      const existing = yield* listWorkItemsForIssue(
+        repositoryId,
+        githubIssueNumber,
+      )
+      const unfinished = existing.find(
+        (workItem) =>
+          workItem.state !== "complete" &&
+          workItem.state !== "failed" &&
+          workItem.state !== "abandoned",
+      )
+      if (unfinished) {
+        return yield* unfinishedWorkItemExistsError(
+          repositoryId,
+          githubIssueNumber,
+          unfinished.id,
+        )
+      }
+
+      const config = yield* db.getConfig
+      const workItemId = makeWorkItemId()
+      const stepRunId = makeStepRunId()
+      const now = Date.now()
+      const step: OperationalLifecycleStep = "create_worktree"
+
+      const createdId = yield* sql
+        .withTransaction(
+          Effect.gen(function* () {
+            yield* sql.unsafe(
+              `INSERT INTO work_item (
+                 id, repository_id, github_issue_number, model, variant, state,
+                 state_ready_at, worktree_path, session_id, failure_code,
+                 failure_message, created_at, updated_at
+               ) VALUES (?, ?, ?, ?, ?, ?, ?, NULL, NULL, NULL, NULL, ?, ?)`,
+              [
+                workItemId,
+                repositoryId,
+                githubIssueNumber,
+                config.defaultModel,
+                config.defaultVariant,
+                step,
+                now,
+                now,
+                now,
+              ],
+            )
+
+            yield* sql.unsafe(
+              `INSERT INTO step_run (
+                 id, work_item_id, step, status, queue_job_id, queued_at,
+                 started_at, finished_at, reason_code, reason_message,
+                 created_at, updated_at
+               ) VALUES (?, ?, ?, 'queued', NULL, ?, NULL, NULL, NULL, NULL, ?, ?)`,
+              [stepRunId, workItemId, step, now, now, now],
+            )
+
+            const payload = yield* Schema.decodeUnknownEffect(WorkItemStepJob)({
+              _tag: "work-item-step",
+              stepRunId,
+            }).pipe(
+              Effect.mapError(
+                (error) =>
+                  new WorkItemLifecycleDatabaseError({
+                    message: `Failed to encode work-item-step payload: ${String(error)}`,
+                    cause: error,
+                  }),
+              ),
+            )
+
+            const jobId = yield* queue.enqueue(
+              WORK_ITEM_LIFECYCLE_QUEUE,
+              payload,
+              { retryLimit: 1 },
+            )
+
+            yield* sql.unsafe(
+              `UPDATE step_run
+               SET queue_job_id = ?, updated_at = ?
+               WHERE id = ?`,
+              [jobId, now, stepRunId],
+            )
+
+            return workItemId
+          }),
+        )
+        .pipe(
+          Effect.catch((error): Effect.Effect<never, ImplementNowError> => {
+            if (error instanceof WorkItemLifecycleDatabaseError) {
+              return Effect.fail(error)
+            }
+            if (error instanceof EnqueueError) {
+              return Effect.fail(error)
+            }
+            if (error instanceof InvalidQueueNameError) {
+              return Effect.fail(error)
+            }
+            if (
+              typeof error === "object" &&
+              error !== null &&
+              "_tag" in error &&
+              (error as { _tag: string })._tag === "SqlError"
+            ) {
+              const sqlError = error as SqlError
+              if (isUnfinishedWorkItemUniqueViolation(sqlError)) {
+                return unfinishedWorkItemExistsError(
+                  repositoryId,
+                  githubIssueNumber,
+                )
+              }
+              return Effect.fail(toDatabaseError(sqlError))
+            }
+            return Effect.fail(
+              new WorkItemLifecycleDatabaseError({
+                message: `Unexpected transaction failure: ${String(error)}`,
+                cause: error,
+              }),
+            )
+          }),
+        )
+
+      return yield* getWorkItem(createdId).pipe(
+        Effect.catchTag(
+          "WorkItemNotFoundError",
+          (error) =>
+            new WorkItemLifecycleDatabaseError({
+              message: `Work Item missing after create: ${error.workItemId}`,
+              cause: error,
+            }),
+        ),
+      )
+    })
+
+    return WorkItemLifecycle.of({
+      implementNow,
+      getWorkItem,
+      listWorkItemsForIssue,
+    })
+  }),
+)

--- a/packages/work-item-lifecycle/test/work-item-lifecycle.spec.ts
+++ b/packages/work-item-lifecycle/test/work-item-lifecycle.spec.ts
@@ -1,0 +1,480 @@
+import { Cause, Effect, Layer, Option, Result } from "effect"
+import { SqlClient } from "effect/unstable/sql"
+import { DatabaseTest } from "@ready-for-agent/db/test"
+import { DbService, DbServiceLive } from "@ready-for-agent/db-service"
+import {
+  EnqueueError,
+  type JobId,
+  QueueService,
+  type QueueServiceShape,
+} from "@ready-for-agent/queue-service"
+import { SqliteQueueServiceLive } from "@ready-for-agent/sqlite-queue-service"
+import {
+  IssueBlockedError,
+  IssueNotFoundError,
+  IssueNotOpenError,
+  NonTransactionalQueueError,
+  ParentIssueError,
+  UnfinishedWorkItemExistsError,
+  WORK_ITEM_LIFECYCLE_QUEUE,
+  WorkItemLifecycle,
+  WorkItemLifecycleLive,
+  WorkItemNotFoundError,
+} from "../src/index.js"
+import { describe, expect, it } from "bun:test"
+
+describe("WorkItemLifecycle", () => {
+  const TestLayer = WorkItemLifecycleLive.pipe(
+    Layer.provideMerge(DbServiceLive),
+    Layer.provideMerge(SqliteQueueServiceLive),
+    Layer.provideMerge(DatabaseTest),
+  )
+
+  type TestRequirements = Layer.Layer.Success<typeof TestLayer>
+
+  const runTest = <A, E>(
+    test: Effect.Effect<A, E, TestRequirements>,
+  ): Promise<A> => Effect.runPromise(Effect.provide(test, TestLayer))
+
+  const sampleRepository = {
+    githubOwner: "acme",
+    githubRepo: "widgets",
+    localPath: "/repos/acme/widgets.git",
+    isBare: true,
+  }
+
+  const sampleIssueFields = {
+    title: "Implement feature",
+    body: "Issue body",
+    url: "https://github.com/acme/widgets/issues/42",
+    state: "OPEN" as const,
+    githubCreatedAt: new Date("2026-01-15T12:00:00.000Z"),
+    parent: null,
+    parentPosition: null,
+    hasChildren: false,
+    blockedBy: [],
+  }
+
+  const seedActionableIssue = Effect.gen(function* () {
+    const db = yield* DbService
+    const repository = yield* db.addRepository(sampleRepository)
+    const issue = yield* db.storeIssue({
+      repositoryId: repository.id,
+      githubIssueNumber: 42,
+      ...sampleIssueFields,
+    })
+    return { repository, issue }
+  })
+
+  describe("implementNow", () => {
+    it("creates a Work Item at Create Worktree for an actionable Issue on a paused Repository", () =>
+      runTest(
+        Effect.gen(function* () {
+          const lifecycle = yield* WorkItemLifecycle
+          const queue = yield* QueueService
+          const db = yield* DbService
+          const { repository, issue } = yield* seedActionableIssue
+
+          expect(repository.paused).toBe(true)
+
+          const workItem = yield* lifecycle.implementNow(
+            repository.id,
+            issue.githubIssueNumber,
+          )
+
+          expect(workItem.id).toMatch(/^wi-[0-9A-HJKMNP-TV-Z]{26}$/)
+          expect(workItem.repositoryId).toBe(repository.id)
+          expect(workItem.githubIssueNumber).toBe(42)
+          expect(workItem.state).toBe("create_worktree")
+          expect(workItem.model).toBe("opencode/deepseek-v4-flash-free")
+          expect(workItem.variant).toBe("low")
+          expect(workItem.worktreePath).toBeNull()
+          expect(workItem.sessionId).toBeNull()
+          expect(workItem.failureCode).toBeNull()
+          expect(workItem.failureMessage).toBeNull()
+          expect(workItem.stepRuns).toHaveLength(1)
+
+          const stepRun = workItem.stepRuns[0]!
+          expect(stepRun.id).toMatch(/^srun-[0-9A-HJKMNP-TV-Z]{26}$/)
+          expect(stepRun.workItemId).toBe(workItem.id)
+          expect(stepRun.step).toBe("create_worktree")
+          expect(stepRun.status).toBe("queued")
+          expect(stepRun.queueJobId).toMatch(/^qjob-[0-9A-HJKMNP-TV-Z]{26}$/)
+          expect(stepRun.startedAt).toBeNull()
+          expect(stepRun.finishedAt).toBeNull()
+
+          const claimed = yield* queue.rawClaim(WORK_ITEM_LIFECYCLE_QUEUE)
+          expect(Option.isSome(claimed)).toBe(true)
+          if (Option.isSome(claimed)) {
+            expect(claimed.value.jobId).toBe(stepRun.queueJobId)
+            expect(claimed.value.payload).toEqual({
+              _tag: "work-item-step",
+              stepRunId: stepRun.id,
+            })
+          }
+
+          const config = yield* db.getConfig
+          expect(workItem.model).toBe(config.defaultModel)
+          expect(workItem.variant).toBe(config.defaultVariant)
+        }),
+      ))
+
+    it("captures the current default model and variant at creation", () =>
+      runTest(
+        Effect.gen(function* () {
+          const lifecycle = yield* WorkItemLifecycle
+          const db = yield* DbService
+          const { repository, issue } = yield* seedActionableIssue
+
+          yield* db.updateConfig({
+            defaultModel: "anthropic/claude-sonnet-4-5",
+            defaultVariant: "high",
+          })
+
+          const workItem = yield* lifecycle.implementNow(
+            repository.id,
+            issue.githubIssueNumber,
+          )
+
+          expect(workItem.model).toBe("anthropic/claude-sonnet-4-5")
+          expect(workItem.variant).toBe("high")
+        }),
+      ))
+
+    it("rejects a missing Issue", () =>
+      runTest(
+        Effect.gen(function* () {
+          const lifecycle = yield* WorkItemLifecycle
+          const db = yield* DbService
+          const repository = yield* db.addRepository(sampleRepository)
+
+          const error = yield* Effect.flip(
+            lifecycle.implementNow(repository.id, 999),
+          )
+
+          expect(error).toBeInstanceOf(IssueNotFoundError)
+          if (error instanceof IssueNotFoundError) {
+            expect(error.repositoryId).toBe(repository.id)
+            expect(error.githubIssueNumber).toBe(999)
+          }
+        }),
+      ))
+
+    it("rejects a closed Issue", () =>
+      runTest(
+        Effect.gen(function* () {
+          const lifecycle = yield* WorkItemLifecycle
+          const db = yield* DbService
+          const repository = yield* db.addRepository(sampleRepository)
+          yield* db.storeIssue({
+            repositoryId: repository.id,
+            githubIssueNumber: 7,
+            ...sampleIssueFields,
+            state: "CLOSED",
+            url: "https://github.com/acme/widgets/issues/7",
+          })
+
+          const error = yield* Effect.flip(
+            lifecycle.implementNow(repository.id, 7),
+          )
+
+          expect(error).toBeInstanceOf(IssueNotOpenError)
+        }),
+      ))
+
+    it("rejects a Parent Issue", () =>
+      runTest(
+        Effect.gen(function* () {
+          const lifecycle = yield* WorkItemLifecycle
+          const db = yield* DbService
+          const repository = yield* db.addRepository(sampleRepository)
+          yield* db.storeIssue({
+            repositoryId: repository.id,
+            githubIssueNumber: 1,
+            ...sampleIssueFields,
+            title: "Parent",
+            url: "https://github.com/acme/widgets/issues/1",
+            hasChildren: true,
+          })
+
+          const error = yield* Effect.flip(
+            lifecycle.implementNow(repository.id, 1),
+          )
+
+          expect(error).toBeInstanceOf(ParentIssueError)
+        }),
+      ))
+
+    it("rejects a blocked Issue", () =>
+      runTest(
+        Effect.gen(function* () {
+          const lifecycle = yield* WorkItemLifecycle
+          const db = yield* DbService
+          const repository = yield* db.addRepository(sampleRepository)
+          yield* db.storeIssue({
+            repositoryId: repository.id,
+            githubIssueNumber: 3,
+            ...sampleIssueFields,
+            url: "https://github.com/acme/widgets/issues/3",
+            blockedBy: [
+              {
+                githubIssueNumber: 2,
+                githubIssueUrl: "https://github.com/acme/widgets/issues/2",
+              },
+            ],
+          })
+
+          const error = yield* Effect.flip(
+            lifecycle.implementNow(repository.id, 3),
+          )
+
+          expect(error).toBeInstanceOf(IssueBlockedError)
+          if (error instanceof IssueBlockedError) {
+            expect(error.blockerCount).toBe(1)
+          }
+        }),
+      ))
+
+    it("rejects a second unfinished Work Item for the same Issue", () =>
+      runTest(
+        Effect.gen(function* () {
+          const lifecycle = yield* WorkItemLifecycle
+          const { repository, issue } = yield* seedActionableIssue
+
+          const first = yield* lifecycle.implementNow(
+            repository.id,
+            issue.githubIssueNumber,
+          )
+          const error = yield* Effect.flip(
+            lifecycle.implementNow(repository.id, issue.githubIssueNumber),
+          )
+
+          expect(error).toBeInstanceOf(UnfinishedWorkItemExistsError)
+          if (error instanceof UnfinishedWorkItemExistsError) {
+            expect(error.workItemId).toBe(first.id)
+          }
+        }),
+      ))
+
+    it("permits at most one unfinished Work Item under concurrent implementNow", () =>
+      runTest(
+        Effect.gen(function* () {
+          const lifecycle = yield* WorkItemLifecycle
+          const { repository, issue } = yield* seedActionableIssue
+
+          const results = yield* Effect.all(
+            [
+              lifecycle
+                .implementNow(repository.id, issue.githubIssueNumber)
+                .pipe(Effect.result),
+              lifecycle
+                .implementNow(repository.id, issue.githubIssueNumber)
+                .pipe(Effect.result),
+            ],
+            { concurrency: "unbounded" },
+          )
+
+          const successes = results.filter((result) => Result.isSuccess(result))
+          const failures = results.filter((result) => Result.isFailure(result))
+
+          expect(successes).toHaveLength(1)
+          expect(failures).toHaveLength(1)
+          const listed = yield* lifecycle.listWorkItemsForIssue(
+            repository.id,
+            issue.githubIssueNumber,
+          )
+          expect(listed).toHaveLength(1)
+          expect(listed[0]!.stepRuns).toHaveLength(1)
+
+          if (Result.isSuccess(successes[0]!)) {
+            expect(listed[0]!.id).toBe(successes[0].success.id)
+          }
+          if (Result.isFailure(failures[0]!)) {
+            expect(failures[0].failure).toBeInstanceOf(
+              UnfinishedWorkItemExistsError,
+            )
+            if (failures[0].failure instanceof UnfinishedWorkItemExistsError) {
+              expect(failures[0].failure.workItemId).toBe(listed[0]!.id)
+            }
+          }
+        }),
+      ))
+
+    it("rolls back when enqueue fails mid-transaction", () => {
+      let enqueueCalls = 0
+      const failingEnqueueQueue: QueueServiceShape = {
+        queueInTransaction: true,
+        enqueue: () => {
+          enqueueCalls += 1
+          return Effect.fail(
+            new EnqueueError({
+              queue: WORK_ITEM_LIFECYCLE_QUEUE,
+              message: "injected enqueue failure",
+            }),
+          )
+        },
+        enqueueWithDelay: () =>
+          Effect.die("enqueueWithDelay should not be called") as Effect.Effect<
+            JobId,
+            never
+          >,
+        rawClaim: () => Effect.succeed(Option.none()),
+        acknowledge: () => Effect.void,
+        fail: () => Effect.void,
+        extendVisibility: () => Effect.void,
+        getStats: () =>
+          Effect.succeed({ pending: 0, processing: 0, deadLetter: 0 }),
+      }
+
+      const layer = WorkItemLifecycleLive.pipe(
+        Layer.provideMerge(DbServiceLive),
+        Layer.provideMerge(
+          Layer.succeed(QueueService, QueueService.of(failingEnqueueQueue)),
+        ),
+        Layer.provideMerge(DatabaseTest),
+      )
+
+      return Effect.runPromise(
+        Effect.gen(function* () {
+          const lifecycle = yield* WorkItemLifecycle
+          const db = yield* DbService
+          const repository = yield* db.addRepository(sampleRepository)
+          yield* db.storeIssue({
+            repositoryId: repository.id,
+            githubIssueNumber: 42,
+            ...sampleIssueFields,
+          })
+
+          const error = yield* Effect.flip(
+            lifecycle.implementNow(repository.id, 42),
+          )
+          expect(error).toBeInstanceOf(EnqueueError)
+          expect(enqueueCalls).toBe(1)
+
+          const listed = yield* lifecycle.listWorkItemsForIssue(
+            repository.id,
+            42,
+          )
+          expect(listed).toEqual([])
+        }).pipe(Effect.provide(layer)),
+      )
+    })
+  })
+
+  describe("getWorkItem and listWorkItemsForIssue", () => {
+    it("retrieves a Work Item with its initial Step Run", () =>
+      runTest(
+        Effect.gen(function* () {
+          const lifecycle = yield* WorkItemLifecycle
+          const { repository, issue } = yield* seedActionableIssue
+
+          const created = yield* lifecycle.implementNow(
+            repository.id,
+            issue.githubIssueNumber,
+          )
+          const retrieved = yield* lifecycle.getWorkItem(created.id)
+
+          expect(retrieved.id).toBe(created.id)
+          expect(retrieved.stepRuns).toHaveLength(1)
+          expect(retrieved.stepRuns[0]!.id).toBe(created.stepRuns[0]!.id)
+        }),
+      ))
+
+    it("lists Work Items for an Issue in creation order", () =>
+      runTest(
+        Effect.gen(function* () {
+          const lifecycle = yield* WorkItemLifecycle
+          const sql = yield* SqlClient.SqlClient
+          const { repository, issue } = yield* seedActionableIssue
+
+          const first = yield* lifecycle.implementNow(
+            repository.id,
+            issue.githubIssueNumber,
+          )
+
+          // Terminalize via SQL so a second Implement Now is allowed; abandon/retry
+          // are later tickets and are not part of this package's public surface yet.
+          yield* sql.unsafe(
+            `UPDATE work_item SET state = 'abandoned', updated_at = ? WHERE id = ?`,
+            [Date.now(), first.id],
+          )
+
+          const second = yield* lifecycle.implementNow(
+            repository.id,
+            issue.githubIssueNumber,
+          )
+
+          const listed = yield* lifecycle.listWorkItemsForIssue(
+            repository.id,
+            issue.githubIssueNumber,
+          )
+
+          expect(listed.map((item) => item.id)).toEqual([first.id, second.id])
+          expect(listed[0]!.state).toBe("abandoned")
+          expect(listed[1]!.state).toBe("create_worktree")
+          expect(listed[1]!.stepRuns).toHaveLength(1)
+        }),
+      ))
+
+    it("rejects getWorkItem for an unknown id", () =>
+      runTest(
+        Effect.gen(function* () {
+          const lifecycle = yield* WorkItemLifecycle
+          const error = yield* Effect.flip(
+            lifecycle.getWorkItem("wi-01ARZ3NDEKTSV4RRFFQ69G5FAV"),
+          )
+          expect(error).toBeInstanceOf(WorkItemNotFoundError)
+        }),
+      ))
+  })
+
+  describe("queue requirements", () => {
+    it("rejects construction when QueueService is not transactional", async () => {
+      const nonTransactionalQueue: QueueServiceShape = {
+        queueInTransaction: false,
+        enqueue: () =>
+          Effect.die("enqueue should not be called") as Effect.Effect<
+            JobId,
+            never
+          >,
+        enqueueWithDelay: () =>
+          Effect.die("enqueueWithDelay should not be called") as Effect.Effect<
+            JobId,
+            never
+          >,
+        rawClaim: () => Effect.succeed(Option.none()),
+        acknowledge: () => Effect.void,
+        fail: () => Effect.void,
+        extendVisibility: () => Effect.void,
+        getStats: () =>
+          Effect.succeed({ pending: 0, processing: 0, deadLetter: 0 }),
+      }
+
+      const NonTransactionalQueueLive = Layer.succeed(
+        QueueService,
+        QueueService.of(nonTransactionalQueue),
+      )
+
+      const layer = WorkItemLifecycleLive.pipe(
+        Layer.provideMerge(DbServiceLive),
+        Layer.provideMerge(NonTransactionalQueueLive),
+        Layer.provideMerge(DatabaseTest),
+      )
+
+      const result = await Effect.runPromiseExit(
+        Effect.gen(function* () {
+          yield* WorkItemLifecycle
+        }).pipe(Effect.provide(layer)),
+      )
+
+      expect(result._tag).toBe("Failure")
+      if (result._tag === "Failure") {
+        const failure = Cause.findErrorOption(result.cause)
+        expect(Option.isSome(failure)).toBe(true)
+        if (Option.isSome(failure)) {
+          expect(failure.value).toBeInstanceOf(NonTransactionalQueueError)
+        }
+      }
+    })
+  })
+})

--- a/packages/work-item-lifecycle/tsconfig.json
+++ b/packages/work-item-lifecycle/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ]
+}

--- a/packages/work-item-lifecycle/tsconfig.lib.json
+++ b/packages/work-item-lifecycle/tsconfig.lib.json
@@ -1,0 +1,26 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "tsBuildInfoFile": "dist/tsconfig.lib.tsbuildinfo",
+    "emitDeclarationOnly": false,
+    "forceConsistentCasingInFileNames": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"],
+  "references": [
+    {
+      "path": "../queue-service/tsconfig.lib.json"
+    },
+    {
+      "path": "../db-service/tsconfig.lib.json"
+    },
+    {
+      "path": "../sqlite-queue-service/tsconfig.lib.json"
+    },
+    {
+      "path": "../db/tsconfig.lib.json"
+    }
+  ]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -50,6 +50,9 @@
     },
     {
       "path": "./packages/issue-reconciler"
+    },
+    {
+      "path": "./packages/work-item-lifecycle"
     }
   ]
 }


### PR DESCRIPTION
## Why

Operators can identify Actionable Issues, but the harness had no durable way to start an implementation attempt. Without a Work Item and initial Step Run, Implement Now cannot survive restarts, queue redelivery, or concurrent requests, and there is no inspectable history for the attempt.

Closes the first lifecycle slice of #68 via #69.

## What Changed

- Added `work_item` and `step_run` tables (branded IDs, lifecycle states/statuses, model/variant capture, typed context and failure columns, queue-job association) with partial unique indexes for one unfinished Work Item per Issue and one Queued/Running Step Run per Work Item.
- Introduced `@ready-for-agent/work-item-lifecycle` with `implementNow`, `getWorkItem`, and `listWorkItemsForIssue`.
- `implementNow` accepts open, unblocked Leaf Issues even when the Repository is Paused; captures current OpenCode model/variant; starts at Create Worktree; atomically creates the Work Item, Queued Step Run, and transactional queue job.
- Rejects missing, closed, blocked, parent, and already-unfinished Issues with stable tagged domain errors; rejects non-transactional `QueueService` as a typed layer failure.
- Integration tests exercise the public lifecycle API against the real test database and SQLite queue (happy path, rejections, concurrency, enqueue rollback, listing).
