### PR TITLE
feat(work-item-lifecycle): drive successful Work Item lifecycle

### DIFF
--- a/packages/work-item-lifecycle/src/index.ts
+++ b/packages/work-item-lifecycle/src/index.ts
@@ -1,3 +1,4 @@
 export * from "./lib/errors.js"
+export * from "./lib/lifecycle-steps.js"
 export * from "./lib/types.js"
 export * from "./lib/work-item-lifecycle.js"

--- a/packages/work-item-lifecycle/src/lib/errors.ts
+++ b/packages/work-item-lifecycle/src/lib/errors.ts
@@ -42,6 +42,12 @@ export class WorkItemNotFoundError extends Data.TaggedError(
   readonly workItemId: string
 }> {}
 
+export class StepRunNotFoundError extends Data.TaggedError(
+  "StepRunNotFoundError",
+)<{
+  readonly stepRunId: string
+}> {}
+
 export class WorkItemLifecycleDatabaseError extends Data.TaggedError(
   "WorkItemLifecycleDatabaseError",
 )<{

--- a/packages/work-item-lifecycle/src/lib/lifecycle-steps.ts
+++ b/packages/work-item-lifecycle/src/lib/lifecycle-steps.ts
@@ -1,0 +1,36 @@
+import { Context, type Effect } from "effect"
+import type { WorkItemId } from "./types.js"
+
+/**
+ * Context supplied to every Lifecycle Step handler.
+ * Later steps receive worktree/session fields persisted by earlier successes.
+ */
+export interface LifecycleStepContext {
+  readonly workItemId: WorkItemId
+  readonly repositoryId: string
+  readonly githubIssueNumber: number
+  readonly model: string
+  readonly variant: string
+  readonly worktreePath: string | null
+  readonly sessionId: string | null
+}
+
+/**
+ * Injected step handlers. Production adapters and tests both implement this
+ * surface; the lifecycle module selects the handler from the pending step.
+ */
+export interface LifecycleStepsShape {
+  readonly createWorktree: (
+    context: LifecycleStepContext,
+  ) => Effect.Effect<string>
+  readonly installDependencies: (
+    context: LifecycleStepContext,
+  ) => Effect.Effect<void>
+  readonly implement: (context: LifecycleStepContext) => Effect.Effect<string>
+  readonly review: (context: LifecycleStepContext) => Effect.Effect<void>
+}
+
+export class LifecycleSteps extends Context.Service<
+  LifecycleSteps,
+  LifecycleStepsShape
+>()("@ready-for-agent/work-item-lifecycle/LifecycleSteps") {}

--- a/packages/work-item-lifecycle/src/lib/work-item-lifecycle.ts
+++ b/packages/work-item-lifecycle/src/lib/work-item-lifecycle.ts
@@ -7,8 +7,10 @@ import {
   type RepositoryNotFoundError,
 } from "@ready-for-agent/db-service"
 import {
+  type AcknowledgeError,
   EnqueueError,
   InvalidQueueNameError,
+  type JobNotFoundError,
   QueueService,
 } from "@ready-for-agent/queue-service"
 import {
@@ -17,10 +19,12 @@ import {
   IssueNotOpenError,
   NonTransactionalQueueError,
   ParentIssueError,
+  StepRunNotFoundError,
   UnfinishedWorkItemExistsError,
   WorkItemLifecycleDatabaseError,
   WorkItemNotFoundError,
 } from "./errors.js"
+import { type LifecycleStepContext, LifecycleSteps } from "./lifecycle-steps.js"
 import {
   type OperationalLifecycleStep,
   type StepRunId,
@@ -136,6 +140,21 @@ const toWorkItemRecord = (
   stepRuns,
 })
 
+const nextOperationalStep = (
+  step: OperationalLifecycleStep,
+): OperationalLifecycleStep | "complete" => {
+  switch (step) {
+    case "create_worktree":
+      return "install_dependencies"
+    case "install_dependencies":
+      return "implement"
+    case "implement":
+      return "review"
+    case "review":
+      return "complete"
+  }
+}
+
 export type ImplementNowError =
   | IssueNotFoundError
   | IssueNotOpenError
@@ -154,11 +173,34 @@ export type GetWorkItemError =
 
 export type ListWorkItemsError = WorkItemLifecycleDatabaseError
 
+export type RunStepError =
+  | StepRunNotFoundError
+  | WorkItemNotFoundError
+  | WorkItemLifecycleDatabaseError
+  | EnqueueError
+  | InvalidQueueNameError
+  | AcknowledgeError
+  | JobNotFoundError
+  | RepositoryNotFoundError
+  | DatabaseError
+
+export type RunStepResult =
+  | {
+      readonly _tag: "processed"
+      readonly workItem: WorkItemRecord
+    }
+  | {
+      readonly _tag: "noop"
+    }
+
 export interface WorkItemLifecycleShape {
   readonly implementNow: (
     repositoryId: string,
     githubIssueNumber: number,
   ) => Effect.Effect<WorkItemRecord, ImplementNowError>
+  readonly runStep: (
+    stepRunId: string,
+  ) => Effect.Effect<RunStepResult, RunStepError>
   readonly getWorkItem: (
     workItemId: string,
   ) => Effect.Effect<WorkItemRecord, GetWorkItemError>
@@ -179,6 +221,7 @@ export const WorkItemLifecycleLive = Layer.effect(
     const sql = yield* SqlClient.SqlClient
     const db = yield* DbService
     const queue = yield* QueueService
+    const steps = yield* LifecycleSteps
 
     if (!queue.queueInTransaction) {
       return yield* new NonTransactionalQueueError({
@@ -306,6 +349,362 @@ export const WorkItemLifecycleLive = Layer.effect(
       )
     })
 
+    const loadStepRunRow = (
+      stepRunId: string,
+    ): Effect.Effect<StepRunRow | null, WorkItemLifecycleDatabaseError> =>
+      Effect.gen(function* () {
+        const rows = (yield* sql
+          .unsafe(
+            `SELECT id, work_item_id, step, status, queue_job_id, queued_at,
+                    started_at, finished_at, reason_code, reason_message
+             FROM step_run
+             WHERE id = ?
+             LIMIT 1`,
+            [stepRunId],
+          )
+          .pipe(Effect.mapError(toDatabaseError))) as readonly StepRunRow[]
+        return rows[0] ?? null
+      })
+
+    const loadWorkItemRow = (
+      workItemId: string,
+    ): Effect.Effect<WorkItemRow | null, WorkItemLifecycleDatabaseError> =>
+      Effect.gen(function* () {
+        const rows = (yield* sql
+          .unsafe(
+            `SELECT id, repository_id, github_issue_number, model, variant, state,
+                    state_ready_at, worktree_path, session_id, failure_code,
+                    failure_message, created_at, updated_at
+             FROM work_item
+             WHERE id = ?
+             LIMIT 1`,
+            [workItemId],
+          )
+          .pipe(Effect.mapError(toDatabaseError))) as readonly WorkItemRow[]
+        return rows[0] ?? null
+      })
+
+    const revalidateIssue = (
+      repositoryId: string,
+      githubIssueNumber: number,
+    ): Effect.Effect<
+      | { readonly ok: true }
+      | {
+          readonly ok: false
+          readonly failureCode: string
+          readonly failureMessage: string
+        },
+      RepositoryNotFoundError | DatabaseError
+    > =>
+      Effect.gen(function* () {
+        const issues = yield* db.listIssues(repositoryId)
+        const issue = issues.find(
+          (candidate) => candidate.githubIssueNumber === githubIssueNumber,
+        )
+
+        if (!issue) {
+          return {
+            ok: false as const,
+            failureCode: "issue_not_found",
+            failureMessage: `Issue #${githubIssueNumber} is no longer present in the Issue store`,
+          }
+        }
+
+        if (issue.state !== "OPEN") {
+          return {
+            ok: false as const,
+            failureCode: "issue_not_open",
+            failureMessage: `Issue #${githubIssueNumber} is ${issue.state}, not OPEN`,
+          }
+        }
+
+        if (issue.hasChildren) {
+          return {
+            ok: false as const,
+            failureCode: "issue_is_parent",
+            failureMessage: `Issue #${githubIssueNumber} has children and is no longer a Leaf Issue`,
+          }
+        }
+
+        if (issue.blockedBy.length > 0) {
+          return {
+            ok: false as const,
+            failureCode: "issue_blocked",
+            failureMessage: `Issue #${githubIssueNumber} is blocked by ${issue.blockedBy.length} Issue(s)`,
+          }
+        }
+
+        return { ok: true as const }
+      })
+
+    const encodeStepJob = (stepRunId: string) =>
+      Schema.decodeUnknownEffect(WorkItemStepJob)({
+        _tag: "work-item-step",
+        stepRunId,
+      }).pipe(
+        Effect.mapError(
+          (error) =>
+            new WorkItemLifecycleDatabaseError({
+              message: `Failed to encode work-item-step payload: ${String(error)}`,
+              cause: error,
+            }),
+        ),
+      )
+
+    const runHandler = (
+      step: OperationalLifecycleStep,
+      context: LifecycleStepContext,
+    ): Effect.Effect<{
+      readonly worktreePath?: string
+      readonly sessionId?: string
+    }> => {
+      switch (step) {
+        case "create_worktree":
+          return steps
+            .createWorktree(context)
+            .pipe(Effect.map((worktreePath) => ({ worktreePath })))
+        case "install_dependencies":
+          return steps.installDependencies(context).pipe(Effect.as({}))
+        case "implement":
+          return steps
+            .implement(context)
+            .pipe(Effect.map((sessionId) => ({ sessionId })))
+        case "review":
+          return steps.review(context).pipe(Effect.as({}))
+      }
+    }
+
+    const catchTransactionError = <A>(
+      error: unknown,
+    ): Effect.Effect<A, RunStepError> => {
+      if (error instanceof WorkItemLifecycleDatabaseError) {
+        return Effect.fail(error)
+      }
+      if (error instanceof EnqueueError) {
+        return Effect.fail(error)
+      }
+      if (error instanceof InvalidQueueNameError) {
+        return Effect.fail(error)
+      }
+      if (
+        typeof error === "object" &&
+        error !== null &&
+        "_tag" in error &&
+        (error as { _tag: string })._tag === "SqlError"
+      ) {
+        return Effect.fail(toDatabaseError(error as SqlError))
+      }
+      if (
+        typeof error === "object" &&
+        error !== null &&
+        "_tag" in error &&
+        ((error as { _tag: string })._tag === "AcknowledgeError" ||
+          (error as { _tag: string })._tag === "JobNotFoundError")
+      ) {
+        return Effect.fail(error as AcknowledgeError | JobNotFoundError)
+      }
+      return Effect.fail(
+        new WorkItemLifecycleDatabaseError({
+          message: `Unexpected transaction failure: ${String(error)}`,
+          cause: error,
+        }),
+      )
+    }
+
+    const completeSuccessfulStep = (input: {
+      readonly stepRun: StepRunRow
+      readonly workItem: WorkItemRow
+      readonly output: {
+        readonly worktreePath?: string
+        readonly sessionId?: string
+      }
+      readonly revalidation:
+        | { readonly ok: true }
+        | {
+            readonly ok: false
+            readonly failureCode: string
+            readonly failureMessage: string
+          }
+    }): Effect.Effect<WorkItemRecord, RunStepError> =>
+      Effect.gen(function* () {
+        const now = Date.now()
+        const { stepRun, workItem, output, revalidation } = input
+        const nextStep = nextOperationalStep(stepRun.step)
+        const worktreePath = output.worktreePath ?? workItem.worktree_path
+        const sessionId = output.sessionId ?? workItem.session_id
+
+        yield* sql
+          .withTransaction(
+            Effect.gen(function* () {
+              yield* sql.unsafe(
+                `UPDATE step_run
+                 SET status = 'succeeded', finished_at = ?, updated_at = ?
+                 WHERE id = ? AND status = 'running'`,
+                [now, now, stepRun.id],
+              )
+
+              if (!revalidation.ok) {
+                yield* sql.unsafe(
+                  `UPDATE work_item
+                   SET state = 'failed',
+                       state_ready_at = ?,
+                       failure_code = ?,
+                       failure_message = ?,
+                       worktree_path = ?,
+                       session_id = ?,
+                       updated_at = ?
+                   WHERE id = ?`,
+                  [
+                    now,
+                    revalidation.failureCode,
+                    revalidation.failureMessage,
+                    worktreePath,
+                    sessionId,
+                    now,
+                    workItem.id,
+                  ],
+                )
+              } else if (nextStep === "complete") {
+                yield* sql.unsafe(
+                  `UPDATE work_item
+                   SET state = 'complete',
+                       state_ready_at = ?,
+                       worktree_path = ?,
+                       session_id = ?,
+                       updated_at = ?
+                   WHERE id = ?`,
+                  [now, worktreePath, sessionId, now, workItem.id],
+                )
+              } else {
+                const nextStepRunId = makeStepRunId()
+
+                yield* sql.unsafe(
+                  `UPDATE work_item
+                   SET state = ?,
+                       state_ready_at = ?,
+                       worktree_path = ?,
+                       session_id = ?,
+                       updated_at = ?
+                   WHERE id = ?`,
+                  [nextStep, now, worktreePath, sessionId, now, workItem.id],
+                )
+
+                yield* sql.unsafe(
+                  `INSERT INTO step_run (
+                     id, work_item_id, step, status, queue_job_id, queued_at,
+                     started_at, finished_at, reason_code, reason_message,
+                     created_at, updated_at
+                   ) VALUES (?, ?, ?, 'queued', NULL, ?, NULL, NULL, NULL, NULL, ?, ?)`,
+                  [nextStepRunId, workItem.id, nextStep, now, now, now],
+                )
+
+                const payload = yield* encodeStepJob(nextStepRunId)
+                const jobId = yield* queue.enqueue(
+                  WORK_ITEM_LIFECYCLE_QUEUE,
+                  payload,
+                  { retryLimit: 1 },
+                )
+
+                yield* sql.unsafe(
+                  `UPDATE step_run
+                   SET queue_job_id = ?, updated_at = ?
+                   WHERE id = ?`,
+                  [jobId, now, nextStepRunId],
+                )
+              }
+
+              if (stepRun.queue_job_id !== null) {
+                yield* queue.acknowledge(stepRun.queue_job_id)
+              }
+            }),
+          )
+          .pipe(Effect.catch(catchTransactionError))
+
+        return yield* getWorkItem(workItem.id).pipe(
+          Effect.catchTag(
+            "WorkItemNotFoundError",
+            (error) =>
+              new WorkItemLifecycleDatabaseError({
+                message: `Work Item missing after step completion: ${error.workItemId}`,
+                cause: error,
+              }),
+          ),
+        )
+      })
+
+    const runStep = Effect.fn("WorkItemLifecycle.runStep")(function* (
+      stepRunId: string,
+    ) {
+      const stepRun = yield* loadStepRunRow(stepRunId)
+      if (!stepRun) {
+        return yield* new StepRunNotFoundError({ stepRunId })
+      }
+
+      const workItem = yield* loadWorkItemRow(stepRun.work_item_id)
+      if (!workItem) {
+        return yield* new WorkItemNotFoundError({
+          workItemId: stepRun.work_item_id,
+        })
+      }
+
+      const startedAt = Date.now()
+      const startedRows = (yield* sql
+        .unsafe(
+          `UPDATE step_run
+           SET status = 'running', started_at = ?, updated_at = ?
+           WHERE id = ?
+             AND status = 'queued'
+             AND step = ?
+             AND EXISTS (
+               SELECT 1 FROM work_item
+               WHERE work_item.id = step_run.work_item_id
+                 AND work_item.state = step_run.step
+                 AND work_item.state NOT IN ('complete', 'failed', 'abandoned')
+             )
+             AND NOT EXISTS (
+               SELECT 1 FROM step_run AS other
+                WHERE other.work_item_id = step_run.work_item_id
+                  AND other.status = 'running'
+                  AND other.id != step_run.id
+              )
+            RETURNING id, work_item_id, step, status, queue_job_id, queued_at,
+                      started_at, finished_at, reason_code, reason_message`,
+          [startedAt, startedAt, stepRunId, stepRun.step],
+        )
+        .pipe(Effect.mapError(toDatabaseError))) as readonly StepRunRow[]
+
+      const afterStart = startedRows[0]
+      if (!afterStart) {
+        return { _tag: "noop" as const }
+      }
+
+      const context: LifecycleStepContext = {
+        workItemId: workItem.id as WorkItemId,
+        repositoryId: workItem.repository_id,
+        githubIssueNumber: workItem.github_issue_number,
+        model: workItem.model,
+        variant: workItem.variant,
+        worktreePath: workItem.worktree_path,
+        sessionId: workItem.session_id,
+      }
+
+      const output = yield* runHandler(stepRun.step, context)
+
+      const revalidation = yield* revalidateIssue(
+        workItem.repository_id,
+        workItem.github_issue_number,
+      )
+
+      const completed = yield* completeSuccessfulStep({
+        stepRun: afterStart,
+        workItem,
+        output,
+        revalidation,
+      })
+
+      return { _tag: "processed" as const, workItem: completed }
+    })
+
     const implementNow = Effect.fn("WorkItemLifecycle.implementNow")(function* (
       repositoryId: string,
       githubIssueNumber: number,
@@ -350,10 +749,10 @@ export const WorkItemLifecycleLive = Layer.effect(
         githubIssueNumber,
       )
       const unfinished = existing.find(
-        (workItem) =>
-          workItem.state !== "complete" &&
-          workItem.state !== "failed" &&
-          workItem.state !== "abandoned",
+        (item) =>
+          item.state !== "complete" &&
+          item.state !== "failed" &&
+          item.state !== "abandoned",
       )
       if (unfinished) {
         return yield* unfinishedWorkItemExistsError(
@@ -400,18 +799,7 @@ export const WorkItemLifecycleLive = Layer.effect(
               [stepRunId, workItemId, step, now, now, now],
             )
 
-            const payload = yield* Schema.decodeUnknownEffect(WorkItemStepJob)({
-              _tag: "work-item-step",
-              stepRunId,
-            }).pipe(
-              Effect.mapError(
-                (error) =>
-                  new WorkItemLifecycleDatabaseError({
-                    message: `Failed to encode work-item-step payload: ${String(error)}`,
-                    cause: error,
-                  }),
-              ),
-            )
+            const payload = yield* encodeStepJob(stepRunId)
 
             const jobId = yield* queue.enqueue(
               WORK_ITEM_LIFECYCLE_QUEUE,
@@ -478,6 +866,7 @@ export const WorkItemLifecycleLive = Layer.effect(
 
     return WorkItemLifecycle.of({
       implementNow,
+      runStep,
       getWorkItem,
       listWorkItemsForIssue,
     })

--- a/packages/work-item-lifecycle/test/work-item-lifecycle.spec.ts
+++ b/packages/work-item-lifecycle/test/work-item-lifecycle.spec.ts
@@ -13,6 +13,9 @@ import {
   IssueBlockedError,
   IssueNotFoundError,
   IssueNotOpenError,
+  type LifecycleStepContext,
+  LifecycleSteps,
+  type LifecycleStepsShape,
   NonTransactionalQueueError,
   ParentIssueError,
   UnfinishedWorkItemExistsError,
@@ -24,7 +27,20 @@ import {
 import { describe, expect, it } from "bun:test"
 
 describe("WorkItemLifecycle", () => {
+  const successfulSteps: LifecycleStepsShape = {
+    createWorktree: () => Effect.succeed("/tmp/worktrees/acme-widgets-42"),
+    installDependencies: () => Effect.void,
+    implement: () => Effect.succeed("ses_test_implement_session"),
+    review: () => Effect.void,
+  }
+
+  const SuccessfulStepsLive = Layer.succeed(
+    LifecycleSteps,
+    LifecycleSteps.of(successfulSteps),
+  )
+
   const TestLayer = WorkItemLifecycleLive.pipe(
+    Layer.provideMerge(SuccessfulStepsLive),
     Layer.provideMerge(DbServiceLive),
     Layer.provideMerge(SqliteQueueServiceLive),
     Layer.provideMerge(DatabaseTest),
@@ -35,6 +51,21 @@ describe("WorkItemLifecycle", () => {
   const runTest = <A, E>(
     test: Effect.Effect<A, E, TestRequirements>,
   ): Promise<A> => Effect.runPromise(Effect.provide(test, TestLayer))
+
+  const makeTestLayer = (steps: LifecycleStepsShape) =>
+    WorkItemLifecycleLive.pipe(
+      Layer.provideMerge(
+        Layer.succeed(LifecycleSteps, LifecycleSteps.of(steps)),
+      ),
+      Layer.provideMerge(DbServiceLive),
+      Layer.provideMerge(SqliteQueueServiceLive),
+      Layer.provideMerge(DatabaseTest),
+    )
+
+  const runWithSteps = <A, E>(
+    steps: LifecycleStepsShape,
+    test: Effect.Effect<A, E, TestRequirements>,
+  ): Promise<A> => Effect.runPromise(Effect.provide(test, makeTestLayer(steps)))
 
   const sampleRepository = {
     githubOwner: "acme",
@@ -327,6 +358,7 @@ describe("WorkItemLifecycle", () => {
       }
 
       const layer = WorkItemLifecycleLive.pipe(
+        Layer.provideMerge(SuccessfulStepsLive),
         Layer.provideMerge(DbServiceLive),
         Layer.provideMerge(
           Layer.succeed(QueueService, QueueService.of(failingEnqueueQueue)),
@@ -398,6 +430,7 @@ describe("WorkItemLifecycle", () => {
             `UPDATE work_item SET state = 'abandoned', updated_at = ? WHERE id = ?`,
             [Date.now(), first.id],
           )
+          yield* Effect.sleep("2 millis")
 
           const second = yield* lifecycle.implementNow(
             repository.id,
@@ -456,6 +489,7 @@ describe("WorkItemLifecycle", () => {
       )
 
       const layer = WorkItemLifecycleLive.pipe(
+        Layer.provideMerge(SuccessfulStepsLive),
         Layer.provideMerge(DbServiceLive),
         Layer.provideMerge(NonTransactionalQueueLive),
         Layer.provideMerge(DatabaseTest),
@@ -475,6 +509,489 @@ describe("WorkItemLifecycle", () => {
           expect(failure.value).toBeInstanceOf(NonTransactionalQueueError)
         }
       }
+    })
+  })
+
+  describe("runStep", () => {
+    const claimAndRunPending = Effect.gen(function* () {
+      const lifecycle = yield* WorkItemLifecycle
+      const queue = yield* QueueService
+      const claimed = yield* queue.rawClaim(WORK_ITEM_LIFECYCLE_QUEUE)
+      expect(Option.isSome(claimed)).toBe(true)
+      if (Option.isNone(claimed)) {
+        return yield* Effect.die("expected a queued lifecycle job")
+      }
+      const payload = claimed.value.payload as { stepRunId: string }
+      const result = yield* lifecycle.runStep(payload.stepRunId)
+      return result
+    })
+
+    it("drives the complete happy path to Complete with typed outputs", () =>
+      runTest(
+        Effect.gen(function* () {
+          const lifecycle = yield* WorkItemLifecycle
+          const { repository, issue } = yield* seedActionableIssue
+
+          const created = yield* lifecycle.implementNow(
+            repository.id,
+            issue.githubIssueNumber,
+          )
+          expect(created.state).toBe("create_worktree")
+          expect(created.stepRuns).toHaveLength(1)
+
+          const afterCreate = yield* claimAndRunPending
+          expect(afterCreate._tag).toBe("processed")
+          if (afterCreate._tag === "processed") {
+            expect(afterCreate.workItem.state).toBe("install_dependencies")
+            expect(afterCreate.workItem.worktreePath).toBe(
+              "/tmp/worktrees/acme-widgets-42",
+            )
+            expect(afterCreate.workItem.sessionId).toBeNull()
+            expect(
+              afterCreate.workItem.stepRuns.map((run) => run.status),
+            ).toEqual(["succeeded", "queued"])
+            expect(afterCreate.workItem.stepRuns[0]!.step).toBe(
+              "create_worktree",
+            )
+            expect(afterCreate.workItem.stepRuns[1]!.step).toBe(
+              "install_dependencies",
+            )
+          }
+
+          const afterInstall = yield* claimAndRunPending
+          expect(afterInstall._tag).toBe("processed")
+          if (afterInstall._tag === "processed") {
+            expect(afterInstall.workItem.state).toBe("implement")
+            expect(afterInstall.workItem.worktreePath).toBe(
+              "/tmp/worktrees/acme-widgets-42",
+            )
+          }
+
+          const afterImplement = yield* claimAndRunPending
+          expect(afterImplement._tag).toBe("processed")
+          if (afterImplement._tag === "processed") {
+            expect(afterImplement.workItem.state).toBe("review")
+            expect(afterImplement.workItem.sessionId).toBe(
+              "ses_test_implement_session",
+            )
+          }
+
+          const afterReview = yield* claimAndRunPending
+          expect(afterReview._tag).toBe("processed")
+          if (afterReview._tag === "processed") {
+            expect(afterReview.workItem.state).toBe("complete")
+            expect(afterReview.workItem.worktreePath).toBe(
+              "/tmp/worktrees/acme-widgets-42",
+            )
+            expect(afterReview.workItem.sessionId).toBe(
+              "ses_test_implement_session",
+            )
+            expect(afterReview.workItem.failureCode).toBeNull()
+            expect(
+              afterReview.workItem.stepRuns.map((run) => [
+                run.step,
+                run.status,
+              ]),
+            ).toEqual([
+              ["create_worktree", "succeeded"],
+              ["install_dependencies", "succeeded"],
+              ["implement", "succeeded"],
+              ["review", "succeeded"],
+            ])
+          }
+
+          const queue = yield* QueueService
+          const remaining = yield* queue.rawClaim(WORK_ITEM_LIFECYCLE_QUEUE)
+          expect(Option.isNone(remaining)).toBe(true)
+
+          const final = yield* lifecycle.getWorkItem(created.id)
+          expect(final.state).toBe("complete")
+          expect(final.stepRuns).toHaveLength(4)
+        }),
+      ))
+
+    it("supplies worktree path, session, model, and variant to later handlers", () => {
+      const seen: LifecycleStepContext[] = []
+      const recordingSteps: LifecycleStepsShape = {
+        createWorktree: (context) => {
+          seen.push(context)
+          return Effect.succeed("/tmp/worktrees/recorded")
+        },
+        installDependencies: (context) => {
+          seen.push(context)
+          return Effect.void
+        },
+        implement: (context) => {
+          seen.push(context)
+          return Effect.succeed("ses_recorded")
+        },
+        review: (context) => {
+          seen.push(context)
+          return Effect.void
+        },
+      }
+
+      return runWithSteps(
+        recordingSteps,
+        Effect.gen(function* () {
+          const lifecycle = yield* WorkItemLifecycle
+          const db = yield* DbService
+          const { repository, issue } = yield* seedActionableIssue
+
+          yield* db.updateConfig({
+            defaultModel: "anthropic/claude-sonnet-4-5",
+            defaultVariant: "high",
+          })
+
+          yield* lifecycle.implementNow(repository.id, issue.githubIssueNumber)
+          yield* claimAndRunPending
+          yield* claimAndRunPending
+          yield* claimAndRunPending
+          yield* claimAndRunPending
+
+          expect(seen).toHaveLength(4)
+          expect(seen[0]!.worktreePath).toBeNull()
+          expect(seen[0]!.sessionId).toBeNull()
+          expect(seen[0]!.model).toBe("anthropic/claude-sonnet-4-5")
+          expect(seen[0]!.variant).toBe("high")
+
+          expect(seen[1]!.worktreePath).toBe("/tmp/worktrees/recorded")
+          expect(seen[1]!.sessionId).toBeNull()
+
+          expect(seen[2]!.worktreePath).toBe("/tmp/worktrees/recorded")
+          expect(seen[2]!.sessionId).toBeNull()
+          expect(seen[2]!.model).toBe("anthropic/claude-sonnet-4-5")
+          expect(seen[2]!.variant).toBe("high")
+
+          expect(seen[3]!.worktreePath).toBe("/tmp/worktrees/recorded")
+          expect(seen[3]!.sessionId).toBe("ses_recorded")
+          expect(seen[3]!.model).toBe("anthropic/claude-sonnet-4-5")
+          expect(seen[3]!.variant).toBe("high")
+        }),
+      )
+    })
+
+    it("completes Review on command success without interpreting findings", () => {
+      let reviewCalls = 0
+      const stepsWithFindings: LifecycleStepsShape = {
+        ...successfulSteps,
+        review: () => {
+          reviewCalls += 1
+          // Handler success alone advances; findings are not a lifecycle gate.
+          return Effect.void
+        },
+      }
+
+      return runWithSteps(
+        stepsWithFindings,
+        Effect.gen(function* () {
+          const lifecycle = yield* WorkItemLifecycle
+          const { repository, issue } = yield* seedActionableIssue
+          yield* lifecycle.implementNow(repository.id, issue.githubIssueNumber)
+          yield* claimAndRunPending
+          yield* claimAndRunPending
+          yield* claimAndRunPending
+          const afterReview = yield* claimAndRunPending
+
+          expect(reviewCalls).toBe(1)
+          expect(afterReview._tag).toBe("processed")
+          if (afterReview._tag === "processed") {
+            expect(afterReview.workItem.state).toBe("complete")
+          }
+        }),
+      )
+    })
+
+    it("fails the Work Item terminally when the Issue is deleted after a successful Effect", () => {
+      let createCalls = 0
+      const steps: LifecycleStepsShape = {
+        ...successfulSteps,
+        createWorktree: () => {
+          createCalls += 1
+          return Effect.succeed("/tmp/worktrees/deleted-issue")
+        },
+      }
+
+      return runWithSteps(
+        steps,
+        Effect.gen(function* () {
+          const lifecycle = yield* WorkItemLifecycle
+          const db = yield* DbService
+          const { repository, issue } = yield* seedActionableIssue
+
+          const created = yield* lifecycle.implementNow(
+            repository.id,
+            issue.githubIssueNumber,
+          )
+
+          yield* db.deleteIssue(repository.id, issue.githubIssueNumber)
+          yield* Effect.sleep("5 millis")
+
+          const result = yield* claimAndRunPending
+          expect(createCalls).toBe(1)
+          expect(result._tag).toBe("processed")
+          if (result._tag === "processed") {
+            expect(result.workItem.state).toBe("failed")
+            expect(result.workItem.failureCode).toBe("issue_not_found")
+            expect(result.workItem.stateReadyAt.getTime()).toBeGreaterThan(
+              created.stateReadyAt.getTime(),
+            )
+            expect(result.workItem.worktreePath).toBe(
+              "/tmp/worktrees/deleted-issue",
+            )
+            expect(result.workItem.stepRuns).toHaveLength(1)
+            expect(result.workItem.stepRuns[0]!.status).toBe("succeeded")
+          }
+
+          const queue = yield* QueueService
+          const remaining = yield* queue.rawClaim(WORK_ITEM_LIFECYCLE_QUEUE)
+          expect(Option.isNone(remaining)).toBe(true)
+
+          const final = yield* lifecycle.getWorkItem(created.id)
+          expect(final.state).toBe("failed")
+          expect(final.stepRuns[0]!.status).toBe("succeeded")
+        }),
+      )
+    })
+
+    it("fails terminally when the Issue becomes closed, blocked, or a Parent after success", () => {
+      const cases = [
+        {
+          name: "closed",
+          mutate: (repositoryId: string, githubIssueNumber: number) =>
+            Effect.gen(function* () {
+              const db = yield* DbService
+              yield* db.storeIssue({
+                repositoryId,
+                githubIssueNumber,
+                ...sampleIssueFields,
+                state: "CLOSED",
+                url: `https://github.com/acme/widgets/issues/${githubIssueNumber}`,
+              })
+            }),
+          code: "issue_not_open",
+        },
+        {
+          name: "parent",
+          mutate: (repositoryId: string, githubIssueNumber: number) =>
+            Effect.gen(function* () {
+              const db = yield* DbService
+              yield* db.storeIssue({
+                repositoryId,
+                githubIssueNumber,
+                ...sampleIssueFields,
+                hasChildren: true,
+                url: `https://github.com/acme/widgets/issues/${githubIssueNumber}`,
+              })
+            }),
+          code: "issue_is_parent",
+        },
+        {
+          name: "blocked",
+          mutate: (repositoryId: string, githubIssueNumber: number) =>
+            Effect.gen(function* () {
+              const db = yield* DbService
+              yield* db.storeIssue({
+                repositoryId,
+                githubIssueNumber,
+                ...sampleIssueFields,
+                blockedBy: [
+                  {
+                    githubIssueNumber: 99,
+                    githubIssueUrl: "https://github.com/acme/widgets/issues/99",
+                  },
+                ],
+                url: `https://github.com/acme/widgets/issues/${githubIssueNumber}`,
+              })
+            }),
+          code: "issue_blocked",
+        },
+      ] as const
+
+      return Effect.runPromise(
+        Effect.gen(function* () {
+          for (const testCase of cases) {
+            yield* Effect.gen(function* () {
+              const lifecycle = yield* WorkItemLifecycle
+              const { repository, issue } = yield* seedActionableIssue
+              yield* lifecycle.implementNow(
+                repository.id,
+                issue.githubIssueNumber,
+              )
+              yield* testCase.mutate(repository.id, issue.githubIssueNumber)
+              const result = yield* claimAndRunPending
+              expect(result._tag).toBe("processed")
+              if (result._tag === "processed") {
+                expect(result.workItem.state).toBe("failed")
+                expect(result.workItem.failureCode).toBe(testCase.code)
+                expect(result.workItem.stepRuns[0]!.status).toBe("succeeded")
+              }
+            }).pipe(Effect.provide(TestLayer))
+          }
+        }),
+      )
+    })
+
+    it("accepts an Issue projection deleted and restored under the same identity", () =>
+      runTest(
+        Effect.gen(function* () {
+          const lifecycle = yield* WorkItemLifecycle
+          const db = yield* DbService
+          const { repository, issue } = yield* seedActionableIssue
+
+          yield* lifecycle.implementNow(repository.id, issue.githubIssueNumber)
+
+          yield* db.deleteIssue(repository.id, issue.githubIssueNumber)
+          yield* db.storeIssue({
+            repositoryId: repository.id,
+            githubIssueNumber: issue.githubIssueNumber,
+            ...sampleIssueFields,
+            title: "Restored projection",
+            body: "New local row, same GitHub identity",
+          })
+
+          const result = yield* claimAndRunPending
+          expect(result._tag).toBe("processed")
+          if (result._tag === "processed") {
+            expect(result.workItem.state).toBe("install_dependencies")
+            expect(result.workItem.failureCode).toBeNull()
+            expect(result.workItem.worktreePath).toBe(
+              "/tmp/worktrees/acme-widgets-42",
+            )
+          }
+        }),
+      ))
+
+    it("returns noop for a Step Run that is not Queued matching the pending state", () =>
+      runTest(
+        Effect.gen(function* () {
+          const lifecycle = yield* WorkItemLifecycle
+          const { repository, issue } = yield* seedActionableIssue
+          const created = yield* lifecycle.implementNow(
+            repository.id,
+            issue.githubIssueNumber,
+          )
+          const stepRunId = created.stepRuns[0]!.id
+
+          const first = yield* lifecycle.runStep(stepRunId)
+          expect(first._tag).toBe("processed")
+
+          const second = yield* lifecycle.runStep(stepRunId)
+          expect(second).toEqual({ _tag: "noop" })
+        }),
+      ))
+
+    it("executes a concurrently delivered Step Run only once", () => {
+      let createCalls = 0
+      const slowSteps: LifecycleStepsShape = {
+        ...successfulSteps,
+        createWorktree: () =>
+          Effect.gen(function* () {
+            createCalls += 1
+            yield* Effect.sleep("20 millis")
+            return "/tmp/worktrees/concurrent"
+          }),
+      }
+
+      return runWithSteps(
+        slowSteps,
+        Effect.gen(function* () {
+          const lifecycle = yield* WorkItemLifecycle
+          const { repository, issue } = yield* seedActionableIssue
+          const created = yield* lifecycle.implementNow(
+            repository.id,
+            issue.githubIssueNumber,
+          )
+          const stepRunId = created.stepRuns[0]!.id
+
+          const results = yield* Effect.all(
+            [lifecycle.runStep(stepRunId), lifecycle.runStep(stepRunId)],
+            { concurrency: "unbounded" },
+          )
+
+          expect(createCalls).toBe(1)
+          expect(results.map((result) => result._tag).sort()).toEqual([
+            "noop",
+            "processed",
+          ])
+          const workItem = yield* lifecycle.getWorkItem(created.id)
+          expect(workItem.state).toBe("install_dependencies")
+          expect(workItem.stepRuns).toHaveLength(2)
+        }),
+      )
+    })
+
+    it("rolls back advancement when next-step enqueue fails", () => {
+      let enqueueCalls = 0
+      const queueShape: QueueServiceShape = {
+        queueInTransaction: true,
+        enqueue: (_queue, _payload) => {
+          enqueueCalls += 1
+          // First enqueue is implementNow; second is advancement after create worktree.
+          if (enqueueCalls === 1) {
+            return Effect.succeed(`qjob-01ARZ3NDEKTSV4RRFFQ69G5FAV` as JobId)
+          }
+          return Effect.fail(
+            new EnqueueError({
+              queue: WORK_ITEM_LIFECYCLE_QUEUE,
+              message: "injected advancement enqueue failure",
+            }),
+          )
+        },
+        enqueueWithDelay: () =>
+          Effect.die("enqueueWithDelay should not be called") as Effect.Effect<
+            JobId,
+            never
+          >,
+        rawClaim: () => Effect.succeed(Option.none()),
+        acknowledge: () => Effect.void,
+        fail: () => Effect.void,
+        extendVisibility: () => Effect.void,
+        getStats: () =>
+          Effect.succeed({ pending: 0, processing: 0, deadLetter: 0 }),
+      }
+
+      // Real DB + fake queue so we can fail the post-success enqueue.
+      // Step run is started via runStep using the id from implementNow.
+      const layer = WorkItemLifecycleLive.pipe(
+        Layer.provideMerge(SuccessfulStepsLive),
+        Layer.provideMerge(DbServiceLive),
+        Layer.provideMerge(
+          Layer.succeed(QueueService, QueueService.of(queueShape)),
+        ),
+        Layer.provideMerge(DatabaseTest),
+      )
+
+      return Effect.runPromise(
+        Effect.gen(function* () {
+          const lifecycle = yield* WorkItemLifecycle
+          const db = yield* DbService
+          const repository = yield* db.addRepository(sampleRepository)
+          yield* db.storeIssue({
+            repositoryId: repository.id,
+            githubIssueNumber: 42,
+            ...sampleIssueFields,
+          })
+
+          const created = yield* lifecycle.implementNow(repository.id, 42)
+          const stepRunId = created.stepRuns[0]!.id
+
+          const error = yield* Effect.flip(lifecycle.runStep(stepRunId))
+          expect(error).toBeInstanceOf(EnqueueError)
+          expect(enqueueCalls).toBe(2)
+
+          const after = yield* lifecycle.getWorkItem(created.id)
+          // Transaction rolled back: no partial advancement or succeeded run.
+          expect(after.state).toBe("create_worktree")
+          expect(after.worktreePath).toBeNull()
+          expect(after.stepRuns).toHaveLength(1)
+          // Start happened outside the completion transaction; status may be
+          // running after a failed completion commit. Advancement outputs and
+          // next step must not be visible.
+          expect(after.stepRuns[0]!.status).not.toBe("succeeded")
+          expect(after.stepRuns[0]!.finishedAt).toBeNull()
+        }).pipe(Effect.provide(layer)),
+      )
     })
   })
 })


### PR DESCRIPTION
## Why

After #69, the harness can create a durable Work Item and queue the first Create Worktree Step Run, but nothing can drive that Work Item through Install Dependencies, Implement, and Review. Without `runStep` and typed step handlers, the successful lifecycle from #68/#70 cannot complete, and later failure/retry work has no advancement path to build on.

## What Changed

Implements the successful Work Item lifecycle path for #70:

- Adds an injected `LifecycleSteps` interface with typed handlers for Create Worktree, Install Dependencies, Implement, and Review
- Adds `runStep`, which atomically compare-and-starts only a Queued Step Run matching the Work Item's pending state
- Persists Create Worktree's worktree path and Implement's Session ID for later handlers
- Revalidates the live Issue before every advancement; if revalidation fails after a successful Effect, the Step Run stays Succeeded and the Work Item becomes terminal Failed with a specific reason and no next job
- Accepts an Issue projection deleted and restored under the same Repository and GitHub issue number as the same Issue
- On ordinary success, completes the Step Run, persists typed outputs, advances state/ready time, and creates the next Step Run + queue job in one transaction (Review advances to Complete without scheduling another job)
- Completes Review based on command success only, without interpreting review findings
- Integration tests cover the four-step happy path, handler context propagation, revalidation failures, restored Issue identity, concurrent delivery, and next-step enqueue rollback using injected Effects, the real test database, and the SQLite queue

Closes #70