### PR TITLE
feat(work-item-lifecycle): record failures and retry Lifecycle Steps

### DIFF
--- a/packages/work-item-lifecycle/src/lib/errors.ts
+++ b/packages/work-item-lifecycle/src/lib/errors.ts
@@ -54,3 +54,25 @@ export class WorkItemLifecycleDatabaseError extends Data.TaggedError(
   readonly message: string
   readonly cause?: unknown
 }> {}
+
+export class WorkItemTerminalError extends Data.TaggedError(
+  "WorkItemTerminalError",
+)<{
+  readonly workItemId: string
+  readonly state: string
+}> {}
+
+export class ActiveStepRunExistsError extends Data.TaggedError(
+  "ActiveStepRunExistsError",
+)<{
+  readonly workItemId: string
+  readonly stepRunId: string
+  readonly status: string
+}> {}
+
+export class RetryNotEligibleError extends Data.TaggedError(
+  "RetryNotEligibleError",
+)<{
+  readonly workItemId: string
+  readonly reason: string
+}> {}

--- a/packages/work-item-lifecycle/src/lib/types.ts
+++ b/packages/work-item-lifecycle/src/lib/types.ts
@@ -1,4 +1,4 @@
-import { Schema } from "effect"
+import { Duration, Schema } from "effect"
 import { ulid } from "ulidx"
 
 export const WorkItemId = Schema.String.pipe(
@@ -79,3 +79,33 @@ export const TERMINAL_WORK_ITEM_STATES = [
   "failed",
   "abandoned",
 ] as const satisfies readonly WorkItemState[]
+
+export const isTerminalWorkItemState = (
+  state: WorkItemState,
+): state is (typeof TERMINAL_WORK_ITEM_STATES)[number] =>
+  (TERMINAL_WORK_ITEM_STATES as readonly string[]).includes(state)
+
+export const STEP_RUN_REASON = {
+  handlerFailed: "handler_failed",
+  handlerDefect: "handler_defect",
+  timeout: "timeout",
+} as const
+
+export type StepRunReasonCode =
+  (typeof STEP_RUN_REASON)[keyof typeof STEP_RUN_REASON]
+
+export type LifecycleMaxDurations = {
+  readonly [Step in OperationalLifecycleStep]: Duration.Duration
+}
+
+/** Default maximum Effect durations per Lifecycle Step (also used as visibility leases). */
+export const DEFAULT_LIFECYCLE_MAX_DURATIONS: LifecycleMaxDurations = {
+  create_worktree: Duration.minutes(5),
+  install_dependencies: Duration.minutes(15),
+  implement: Duration.hours(2),
+  review: Duration.hours(1),
+}
+
+export type WorkItemLifecycleConfig = {
+  readonly maxDurations?: LifecycleMaxDurations
+}

--- a/packages/work-item-lifecycle/src/lib/work-item-lifecycle.ts
+++ b/packages/work-item-lifecycle/src/lib/work-item-lifecycle.ts
@@ -1,4 +1,13 @@
-import { Context, Effect, Layer, Schema } from "effect"
+import {
+  Cause,
+  Context,
+  Effect,
+  Exit,
+  Layer,
+  Option,
+  Result,
+  Schema,
+} from "effect"
 import { SqlClient } from "effect/unstable/sql"
 import type { SqlError } from "effect/unstable/sql/SqlError"
 import {
@@ -14,27 +23,35 @@ import {
   QueueService,
 } from "@ready-for-agent/queue-service"
 import {
+  ActiveStepRunExistsError,
   IssueBlockedError,
   IssueNotFoundError,
   IssueNotOpenError,
   NonTransactionalQueueError,
   ParentIssueError,
+  RetryNotEligibleError,
   StepRunNotFoundError,
   UnfinishedWorkItemExistsError,
   WorkItemLifecycleDatabaseError,
   WorkItemNotFoundError,
+  WorkItemTerminalError,
 } from "./errors.js"
 import { type LifecycleStepContext, LifecycleSteps } from "./lifecycle-steps.js"
 import {
+  DEFAULT_LIFECYCLE_MAX_DURATIONS,
+  type LifecycleMaxDurations,
   type OperationalLifecycleStep,
+  STEP_RUN_REASON,
   type StepRunId,
   type StepRunRecord,
   type StepRunStatus,
   WORK_ITEM_LIFECYCLE_QUEUE,
   type WorkItemId,
+  type WorkItemLifecycleConfig,
   type WorkItemRecord,
   type WorkItemState,
   WorkItemStepJob,
+  isTerminalWorkItemState,
   makeStepRunId,
   makeWorkItemId,
 } from "./types.js"
@@ -70,6 +87,85 @@ const isUnfinishedWorkItemUniqueViolation = (error: SqlError): boolean => {
       (message.includes("work_item.repository_id") &&
         message.includes("work_item.github_issue_number")))
   )
+}
+
+const isActiveStepRunUniqueViolation = (error: SqlError): boolean => {
+  const message = formatSqlError(error).toLowerCase()
+  return (
+    (message.includes("unique") || message.includes("sqlite_constraint")) &&
+    (message.includes("step_run_one_active_uidx") ||
+      message.includes("one_active") ||
+      (message.includes("step_run") && message.includes("work_item_id")))
+  )
+}
+
+const conciseMessage = (value: unknown, fallback: string): string => {
+  if (typeof value === "string" && value.trim().length > 0) {
+    return value.trim().slice(0, 500)
+  }
+  if (value instanceof Error && value.message.trim().length > 0) {
+    return value.message.trim().slice(0, 500)
+  }
+  if (
+    typeof value === "object" &&
+    value !== null &&
+    "message" in value &&
+    typeof (value as { message: unknown }).message === "string" &&
+    (value as { message: string }).message.trim().length > 0
+  ) {
+    return (value as { message: string }).message.trim().slice(0, 500)
+  }
+  if (typeof value === "number" || typeof value === "boolean") {
+    return String(value)
+  }
+  return fallback
+}
+
+const classifyHandlerFailure = (
+  cause: Cause.Cause<unknown>,
+): {
+  readonly reasonCode: string
+  readonly reasonMessage: string
+} => {
+  const errorOption = Cause.findErrorOption(cause)
+  if (Option.isSome(errorOption)) {
+    const error = errorOption.value
+    if (
+      typeof error === "object" &&
+      error !== null &&
+      "_tag" in error &&
+      (error as { _tag: string })._tag === "TimeoutError"
+    ) {
+      return {
+        reasonCode: STEP_RUN_REASON.timeout,
+        reasonMessage:
+          "Lifecycle Step exceeded its configured maximum duration",
+      }
+    }
+    return {
+      reasonCode: STEP_RUN_REASON.handlerFailed,
+      reasonMessage: conciseMessage(error, "Lifecycle Step handler failed"),
+    }
+  }
+
+  const defect = Cause.findDefect(cause)
+  if (Result.isSuccess(defect)) {
+    return {
+      reasonCode: STEP_RUN_REASON.handlerDefect,
+      reasonMessage: conciseMessage(
+        defect.success,
+        "Lifecycle Step handler defect",
+      ),
+    }
+  }
+
+  return {
+    reasonCode: STEP_RUN_REASON.handlerFailed,
+    reasonMessage: conciseMessage(
+      Cause.squash(cause),
+      "Lifecycle Step handler failed",
+    ),
+  }
 }
 
 const toDatabaseError = (error: SqlError) =>
@@ -184,6 +280,15 @@ export type RunStepError =
   | RepositoryNotFoundError
   | DatabaseError
 
+export type RetryError =
+  | WorkItemNotFoundError
+  | WorkItemTerminalError
+  | ActiveStepRunExistsError
+  | RetryNotEligibleError
+  | WorkItemLifecycleDatabaseError
+  | EnqueueError
+  | InvalidQueueNameError
+
 export type RunStepResult =
   | {
       readonly _tag: "processed"
@@ -194,6 +299,7 @@ export type RunStepResult =
     }
 
 export interface WorkItemLifecycleShape {
+  readonly maxDurations: LifecycleMaxDurations
   readonly implementNow: (
     repositoryId: string,
     githubIssueNumber: number,
@@ -201,6 +307,9 @@ export interface WorkItemLifecycleShape {
   readonly runStep: (
     stepRunId: string,
   ) => Effect.Effect<RunStepResult, RunStepError>
+  readonly retry: (
+    workItemId: string,
+  ) => Effect.Effect<WorkItemRecord, RetryError>
   readonly getWorkItem: (
     workItemId: string,
   ) => Effect.Effect<WorkItemRecord, GetWorkItemError>
@@ -215,337 +324,352 @@ export class WorkItemLifecycle extends Context.Service<
   WorkItemLifecycleShape
 >()("@ready-for-agent/work-item-lifecycle/WorkItemLifecycle") {}
 
-export const WorkItemLifecycleLive = Layer.effect(
+export const makeWorkItemLifecycleLive = (
+  config: WorkItemLifecycleConfig = {},
+): Layer.Layer<
   WorkItemLifecycle,
-  Effect.gen(function* () {
-    const sql = yield* SqlClient.SqlClient
-    const db = yield* DbService
-    const queue = yield* QueueService
-    const steps = yield* LifecycleSteps
+  NonTransactionalQueueError,
+  SqlClient.SqlClient | DbService | QueueService | LifecycleSteps
+> =>
+  Layer.effect(
+    WorkItemLifecycle,
+    Effect.gen(function* () {
+      const sql = yield* SqlClient.SqlClient
+      const db = yield* DbService
+      const queue = yield* QueueService
+      const steps = yield* LifecycleSteps
+      const maxDurations: LifecycleMaxDurations = {
+        ...DEFAULT_LIFECYCLE_MAX_DURATIONS,
+        ...config.maxDurations,
+      }
 
-    if (!queue.queueInTransaction) {
-      return yield* new NonTransactionalQueueError({
-        message:
-          "Work Item Lifecycle requires a QueueService that participates in database transactions",
-      })
-    }
+      if (!queue.queueInTransaction) {
+        return yield* new NonTransactionalQueueError({
+          message:
+            "Work Item Lifecycle requires a QueueService that participates in database transactions",
+        })
+      }
 
-    const findUnfinishedWorkItemId = (
-      repositoryId: string,
-      githubIssueNumber: number,
-    ): Effect.Effect<string | null, WorkItemLifecycleDatabaseError> =>
-      Effect.gen(function* () {
-        const rows = (yield* sql
-          .unsafe(
-            `SELECT id FROM work_item
+      const findUnfinishedWorkItemId = (
+        repositoryId: string,
+        githubIssueNumber: number,
+      ): Effect.Effect<string | null, WorkItemLifecycleDatabaseError> =>
+        Effect.gen(function* () {
+          const rows = (yield* sql
+            .unsafe(
+              `SELECT id FROM work_item
              WHERE repository_id = ?
                AND github_issue_number = ?
                AND state NOT IN ('complete', 'failed', 'abandoned')
              ORDER BY created_at ASC, id ASC
              LIMIT 1`,
-            [repositoryId, githubIssueNumber],
-          )
-          .pipe(Effect.mapError(toDatabaseError))) as readonly { id: string }[]
-        return rows[0]?.id ?? null
-      })
-
-    const unfinishedWorkItemExistsError = (
-      repositoryId: string,
-      githubIssueNumber: number,
-      knownWorkItemId?: string,
-    ): Effect.Effect<
-      never,
-      UnfinishedWorkItemExistsError | WorkItemLifecycleDatabaseError
-    > =>
-      Effect.gen(function* () {
-        const workItemId =
-          knownWorkItemId ??
-          (yield* findUnfinishedWorkItemId(repositoryId, githubIssueNumber))
-        return yield* new UnfinishedWorkItemExistsError({
-          repositoryId,
-          githubIssueNumber,
-          workItemId: workItemId ?? "unknown",
+              [repositoryId, githubIssueNumber],
+            )
+            .pipe(Effect.mapError(toDatabaseError))) as readonly {
+            id: string
+          }[]
+          return rows[0]?.id ?? null
         })
-      })
 
-    const loadStepRuns = (
-      workItemIds: readonly string[],
-    ): Effect.Effect<
-      Map<string, StepRunRecord[]>,
-      WorkItemLifecycleDatabaseError
-    > =>
-      Effect.gen(function* () {
-        const byWorkItem = new Map<string, StepRunRecord[]>()
-        if (workItemIds.length === 0) {
-          return byWorkItem
-        }
+      const unfinishedWorkItemExistsError = (
+        repositoryId: string,
+        githubIssueNumber: number,
+        knownWorkItemId?: string,
+      ): Effect.Effect<
+        never,
+        UnfinishedWorkItemExistsError | WorkItemLifecycleDatabaseError
+      > =>
+        Effect.gen(function* () {
+          const workItemId =
+            knownWorkItemId ??
+            (yield* findUnfinishedWorkItemId(repositoryId, githubIssueNumber))
+          return yield* new UnfinishedWorkItemExistsError({
+            repositoryId,
+            githubIssueNumber,
+            workItemId: workItemId ?? "unknown",
+          })
+        })
 
-        const placeholders = workItemIds.map(() => "?").join(", ")
-        const rows = (yield* sql
-          .unsafe(
-            `SELECT id, work_item_id, step, status, queue_job_id, queued_at,
+      const loadStepRuns = (
+        workItemIds: readonly string[],
+      ): Effect.Effect<
+        Map<string, StepRunRecord[]>,
+        WorkItemLifecycleDatabaseError
+      > =>
+        Effect.gen(function* () {
+          const byWorkItem = new Map<string, StepRunRecord[]>()
+          if (workItemIds.length === 0) {
+            return byWorkItem
+          }
+
+          const placeholders = workItemIds.map(() => "?").join(", ")
+          const rows = (yield* sql
+            .unsafe(
+              `SELECT id, work_item_id, step, status, queue_job_id, queued_at,
                     started_at, finished_at, reason_code, reason_message
              FROM step_run
              WHERE work_item_id IN (${placeholders})
              ORDER BY queued_at ASC, id ASC`,
-            [...workItemIds],
-          )
-          .pipe(Effect.mapError(toDatabaseError))) as readonly StepRunRow[]
+              [...workItemIds],
+            )
+            .pipe(Effect.mapError(toDatabaseError))) as readonly StepRunRow[]
 
-        for (const row of rows) {
-          const record = toStepRunRecord(row)
-          const existing = byWorkItem.get(row.work_item_id)
-          if (existing) {
-            existing.push(record)
-          } else {
-            byWorkItem.set(row.work_item_id, [record])
+          for (const row of rows) {
+            const record = toStepRunRecord(row)
+            const existing = byWorkItem.get(row.work_item_id)
+            if (existing) {
+              existing.push(record)
+            } else {
+              byWorkItem.set(row.work_item_id, [record])
+            }
           }
-        }
-        return byWorkItem
-      })
+          return byWorkItem
+        })
 
-    const getWorkItem = Effect.fn("WorkItemLifecycle.getWorkItem")(function* (
-      workItemId: string,
-    ) {
-      const rows = (yield* sql
-        .unsafe(
-          `SELECT id, repository_id, github_issue_number, model, variant, state,
+      const getWorkItem = Effect.fn("WorkItemLifecycle.getWorkItem")(function* (
+        workItemId: string,
+      ) {
+        const rows = (yield* sql
+          .unsafe(
+            `SELECT id, repository_id, github_issue_number, model, variant, state,
                   state_ready_at, worktree_path, session_id, failure_code,
                   failure_message, created_at, updated_at
            FROM work_item
            WHERE id = ?
            LIMIT 1`,
-          [workItemId],
-        )
-        .pipe(Effect.mapError(toDatabaseError))) as readonly WorkItemRow[]
+            [workItemId],
+          )
+          .pipe(Effect.mapError(toDatabaseError))) as readonly WorkItemRow[]
 
-      const row = rows[0]
-      if (!row) {
-        return yield* new WorkItemNotFoundError({ workItemId })
-      }
+        const row = rows[0]
+        if (!row) {
+          return yield* new WorkItemNotFoundError({ workItemId })
+        }
 
-      const stepRunsByWorkItem = yield* loadStepRuns([row.id])
-      return toWorkItemRecord(row, stepRunsByWorkItem.get(row.id) ?? [])
-    })
+        const stepRunsByWorkItem = yield* loadStepRuns([row.id])
+        return toWorkItemRecord(row, stepRunsByWorkItem.get(row.id) ?? [])
+      })
 
-    const listWorkItemsForIssue = Effect.fn(
-      "WorkItemLifecycle.listWorkItemsForIssue",
-    )(function* (repositoryId: string, githubIssueNumber: number) {
-      const rows = (yield* sql
-        .unsafe(
-          `SELECT id, repository_id, github_issue_number, model, variant, state,
+      const listWorkItemsForIssue = Effect.fn(
+        "WorkItemLifecycle.listWorkItemsForIssue",
+      )(function* (repositoryId: string, githubIssueNumber: number) {
+        const rows = (yield* sql
+          .unsafe(
+            `SELECT id, repository_id, github_issue_number, model, variant, state,
                   state_ready_at, worktree_path, session_id, failure_code,
                   failure_message, created_at, updated_at
            FROM work_item
            WHERE repository_id = ? AND github_issue_number = ?
            ORDER BY created_at ASC, id ASC`,
-          [repositoryId, githubIssueNumber],
+            [repositoryId, githubIssueNumber],
+          )
+          .pipe(Effect.mapError(toDatabaseError))) as readonly WorkItemRow[]
+
+        const stepRunsByWorkItem = yield* loadStepRuns(
+          rows.map((row) => row.id),
         )
-        .pipe(Effect.mapError(toDatabaseError))) as readonly WorkItemRow[]
+        return rows.map((row) =>
+          toWorkItemRecord(row, stepRunsByWorkItem.get(row.id) ?? []),
+        )
+      })
 
-      const stepRunsByWorkItem = yield* loadStepRuns(rows.map((row) => row.id))
-      return rows.map((row) =>
-        toWorkItemRecord(row, stepRunsByWorkItem.get(row.id) ?? []),
-      )
-    })
-
-    const loadStepRunRow = (
-      stepRunId: string,
-    ): Effect.Effect<StepRunRow | null, WorkItemLifecycleDatabaseError> =>
-      Effect.gen(function* () {
-        const rows = (yield* sql
-          .unsafe(
-            `SELECT id, work_item_id, step, status, queue_job_id, queued_at,
+      const loadStepRunRow = (
+        stepRunId: string,
+      ): Effect.Effect<StepRunRow | null, WorkItemLifecycleDatabaseError> =>
+        Effect.gen(function* () {
+          const rows = (yield* sql
+            .unsafe(
+              `SELECT id, work_item_id, step, status, queue_job_id, queued_at,
                     started_at, finished_at, reason_code, reason_message
              FROM step_run
              WHERE id = ?
              LIMIT 1`,
-            [stepRunId],
-          )
-          .pipe(Effect.mapError(toDatabaseError))) as readonly StepRunRow[]
-        return rows[0] ?? null
-      })
+              [stepRunId],
+            )
+            .pipe(Effect.mapError(toDatabaseError))) as readonly StepRunRow[]
+          return rows[0] ?? null
+        })
 
-    const loadWorkItemRow = (
-      workItemId: string,
-    ): Effect.Effect<WorkItemRow | null, WorkItemLifecycleDatabaseError> =>
-      Effect.gen(function* () {
-        const rows = (yield* sql
-          .unsafe(
-            `SELECT id, repository_id, github_issue_number, model, variant, state,
+      const loadWorkItemRow = (
+        workItemId: string,
+      ): Effect.Effect<WorkItemRow | null, WorkItemLifecycleDatabaseError> =>
+        Effect.gen(function* () {
+          const rows = (yield* sql
+            .unsafe(
+              `SELECT id, repository_id, github_issue_number, model, variant, state,
                     state_ready_at, worktree_path, session_id, failure_code,
                     failure_message, created_at, updated_at
              FROM work_item
              WHERE id = ?
              LIMIT 1`,
-            [workItemId],
-          )
-          .pipe(Effect.mapError(toDatabaseError))) as readonly WorkItemRow[]
-        return rows[0] ?? null
-      })
+              [workItemId],
+            )
+            .pipe(Effect.mapError(toDatabaseError))) as readonly WorkItemRow[]
+          return rows[0] ?? null
+        })
 
-    const revalidateIssue = (
-      repositoryId: string,
-      githubIssueNumber: number,
-    ): Effect.Effect<
-      | { readonly ok: true }
-      | {
-          readonly ok: false
-          readonly failureCode: string
-          readonly failureMessage: string
-        },
-      RepositoryNotFoundError | DatabaseError
-    > =>
-      Effect.gen(function* () {
-        const issues = yield* db.listIssues(repositoryId)
-        const issue = issues.find(
-          (candidate) => candidate.githubIssueNumber === githubIssueNumber,
-        )
-
-        if (!issue) {
-          return {
-            ok: false as const,
-            failureCode: "issue_not_found",
-            failureMessage: `Issue #${githubIssueNumber} is no longer present in the Issue store`,
-          }
-        }
-
-        if (issue.state !== "OPEN") {
-          return {
-            ok: false as const,
-            failureCode: "issue_not_open",
-            failureMessage: `Issue #${githubIssueNumber} is ${issue.state}, not OPEN`,
-          }
-        }
-
-        if (issue.hasChildren) {
-          return {
-            ok: false as const,
-            failureCode: "issue_is_parent",
-            failureMessage: `Issue #${githubIssueNumber} has children and is no longer a Leaf Issue`,
-          }
-        }
-
-        if (issue.blockedBy.length > 0) {
-          return {
-            ok: false as const,
-            failureCode: "issue_blocked",
-            failureMessage: `Issue #${githubIssueNumber} is blocked by ${issue.blockedBy.length} Issue(s)`,
-          }
-        }
-
-        return { ok: true as const }
-      })
-
-    const encodeStepJob = (stepRunId: string) =>
-      Schema.decodeUnknownEffect(WorkItemStepJob)({
-        _tag: "work-item-step",
-        stepRunId,
-      }).pipe(
-        Effect.mapError(
-          (error) =>
-            new WorkItemLifecycleDatabaseError({
-              message: `Failed to encode work-item-step payload: ${String(error)}`,
-              cause: error,
-            }),
-        ),
-      )
-
-    const runHandler = (
-      step: OperationalLifecycleStep,
-      context: LifecycleStepContext,
-    ): Effect.Effect<{
-      readonly worktreePath?: string
-      readonly sessionId?: string
-    }> => {
-      switch (step) {
-        case "create_worktree":
-          return steps
-            .createWorktree(context)
-            .pipe(Effect.map((worktreePath) => ({ worktreePath })))
-        case "install_dependencies":
-          return steps.installDependencies(context).pipe(Effect.as({}))
-        case "implement":
-          return steps
-            .implement(context)
-            .pipe(Effect.map((sessionId) => ({ sessionId })))
-        case "review":
-          return steps.review(context).pipe(Effect.as({}))
-      }
-    }
-
-    const catchTransactionError = <A>(
-      error: unknown,
-    ): Effect.Effect<A, RunStepError> => {
-      if (error instanceof WorkItemLifecycleDatabaseError) {
-        return Effect.fail(error)
-      }
-      if (error instanceof EnqueueError) {
-        return Effect.fail(error)
-      }
-      if (error instanceof InvalidQueueNameError) {
-        return Effect.fail(error)
-      }
-      if (
-        typeof error === "object" &&
-        error !== null &&
-        "_tag" in error &&
-        (error as { _tag: string })._tag === "SqlError"
-      ) {
-        return Effect.fail(toDatabaseError(error as SqlError))
-      }
-      if (
-        typeof error === "object" &&
-        error !== null &&
-        "_tag" in error &&
-        ((error as { _tag: string })._tag === "AcknowledgeError" ||
-          (error as { _tag: string })._tag === "JobNotFoundError")
-      ) {
-        return Effect.fail(error as AcknowledgeError | JobNotFoundError)
-      }
-      return Effect.fail(
-        new WorkItemLifecycleDatabaseError({
-          message: `Unexpected transaction failure: ${String(error)}`,
-          cause: error,
-        }),
-      )
-    }
-
-    const completeSuccessfulStep = (input: {
-      readonly stepRun: StepRunRow
-      readonly workItem: WorkItemRow
-      readonly output: {
-        readonly worktreePath?: string
-        readonly sessionId?: string
-      }
-      readonly revalidation:
+      const revalidateIssue = (
+        repositoryId: string,
+        githubIssueNumber: number,
+      ): Effect.Effect<
         | { readonly ok: true }
         | {
             readonly ok: false
             readonly failureCode: string
             readonly failureMessage: string
-          }
-    }): Effect.Effect<WorkItemRecord, RunStepError> =>
-      Effect.gen(function* () {
-        const now = Date.now()
-        const { stepRun, workItem, output, revalidation } = input
-        const nextStep = nextOperationalStep(stepRun.step)
-        const worktreePath = output.worktreePath ?? workItem.worktree_path
-        const sessionId = output.sessionId ?? workItem.session_id
+          },
+        RepositoryNotFoundError | DatabaseError
+      > =>
+        Effect.gen(function* () {
+          const issues = yield* db.listIssues(repositoryId)
+          const issue = issues.find(
+            (candidate) => candidate.githubIssueNumber === githubIssueNumber,
+          )
 
-        yield* sql
-          .withTransaction(
-            Effect.gen(function* () {
-              yield* sql.unsafe(
-                `UPDATE step_run
+          if (!issue) {
+            return {
+              ok: false as const,
+              failureCode: "issue_not_found",
+              failureMessage: `Issue #${githubIssueNumber} is no longer present in the Issue store`,
+            }
+          }
+
+          if (issue.state !== "OPEN") {
+            return {
+              ok: false as const,
+              failureCode: "issue_not_open",
+              failureMessage: `Issue #${githubIssueNumber} is ${issue.state}, not OPEN`,
+            }
+          }
+
+          if (issue.hasChildren) {
+            return {
+              ok: false as const,
+              failureCode: "issue_is_parent",
+              failureMessage: `Issue #${githubIssueNumber} has children and is no longer a Leaf Issue`,
+            }
+          }
+
+          if (issue.blockedBy.length > 0) {
+            return {
+              ok: false as const,
+              failureCode: "issue_blocked",
+              failureMessage: `Issue #${githubIssueNumber} is blocked by ${issue.blockedBy.length} Issue(s)`,
+            }
+          }
+
+          return { ok: true as const }
+        })
+
+      const encodeStepJob = (stepRunId: string) =>
+        Schema.decodeUnknownEffect(WorkItemStepJob)({
+          _tag: "work-item-step",
+          stepRunId,
+        }).pipe(
+          Effect.mapError(
+            (error) =>
+              new WorkItemLifecycleDatabaseError({
+                message: `Failed to encode work-item-step payload: ${String(error)}`,
+                cause: error,
+              }),
+          ),
+        )
+
+      const runHandler = (
+        step: OperationalLifecycleStep,
+        context: LifecycleStepContext,
+      ): Effect.Effect<{
+        readonly worktreePath?: string
+        readonly sessionId?: string
+      }> => {
+        switch (step) {
+          case "create_worktree":
+            return steps
+              .createWorktree(context)
+              .pipe(Effect.map((worktreePath) => ({ worktreePath })))
+          case "install_dependencies":
+            return steps.installDependencies(context).pipe(Effect.as({}))
+          case "implement":
+            return steps
+              .implement(context)
+              .pipe(Effect.map((sessionId) => ({ sessionId })))
+          case "review":
+            return steps.review(context).pipe(Effect.as({}))
+        }
+      }
+
+      const catchTransactionError = <A>(
+        error: unknown,
+      ): Effect.Effect<A, RunStepError> => {
+        if (error instanceof WorkItemLifecycleDatabaseError) {
+          return Effect.fail(error)
+        }
+        if (error instanceof EnqueueError) {
+          return Effect.fail(error)
+        }
+        if (error instanceof InvalidQueueNameError) {
+          return Effect.fail(error)
+        }
+        if (
+          typeof error === "object" &&
+          error !== null &&
+          "_tag" in error &&
+          (error as { _tag: string })._tag === "SqlError"
+        ) {
+          return Effect.fail(toDatabaseError(error as SqlError))
+        }
+        if (
+          typeof error === "object" &&
+          error !== null &&
+          "_tag" in error &&
+          ((error as { _tag: string })._tag === "AcknowledgeError" ||
+            (error as { _tag: string })._tag === "JobNotFoundError")
+        ) {
+          return Effect.fail(error as AcknowledgeError | JobNotFoundError)
+        }
+        return Effect.fail(
+          new WorkItemLifecycleDatabaseError({
+            message: `Unexpected transaction failure: ${String(error)}`,
+            cause: error,
+          }),
+        )
+      }
+
+      const completeSuccessfulStep = (input: {
+        readonly stepRun: StepRunRow
+        readonly workItem: WorkItemRow
+        readonly output: {
+          readonly worktreePath?: string
+          readonly sessionId?: string
+        }
+        readonly revalidation:
+          | { readonly ok: true }
+          | {
+              readonly ok: false
+              readonly failureCode: string
+              readonly failureMessage: string
+            }
+      }): Effect.Effect<WorkItemRecord, RunStepError> =>
+        Effect.gen(function* () {
+          const now = Date.now()
+          const { stepRun, workItem, output, revalidation } = input
+          const nextStep = nextOperationalStep(stepRun.step)
+          const worktreePath = output.worktreePath ?? workItem.worktree_path
+          const sessionId = output.sessionId ?? workItem.session_id
+
+          yield* sql
+            .withTransaction(
+              Effect.gen(function* () {
+                yield* sql.unsafe(
+                  `UPDATE step_run
                  SET status = 'succeeded', finished_at = ?, updated_at = ?
                  WHERE id = ? AND status = 'running'`,
-                [now, now, stepRun.id],
-              )
+                  [now, now, stepRun.id],
+                )
 
-              if (!revalidation.ok) {
-                yield* sql.unsafe(
-                  `UPDATE work_item
+                if (!revalidation.ok) {
+                  yield* sql.unsafe(
+                    `UPDATE work_item
                    SET state = 'failed',
                        state_ready_at = ?,
                        failure_code = ?,
@@ -554,103 +678,158 @@ export const WorkItemLifecycleLive = Layer.effect(
                        session_id = ?,
                        updated_at = ?
                    WHERE id = ?`,
-                  [
-                    now,
-                    revalidation.failureCode,
-                    revalidation.failureMessage,
-                    worktreePath,
-                    sessionId,
-                    now,
-                    workItem.id,
-                  ],
-                )
-              } else if (nextStep === "complete") {
-                yield* sql.unsafe(
-                  `UPDATE work_item
+                    [
+                      now,
+                      revalidation.failureCode,
+                      revalidation.failureMessage,
+                      worktreePath,
+                      sessionId,
+                      now,
+                      workItem.id,
+                    ],
+                  )
+                } else if (nextStep === "complete") {
+                  yield* sql.unsafe(
+                    `UPDATE work_item
                    SET state = 'complete',
                        state_ready_at = ?,
                        worktree_path = ?,
                        session_id = ?,
                        updated_at = ?
                    WHERE id = ?`,
-                  [now, worktreePath, sessionId, now, workItem.id],
-                )
-              } else {
-                const nextStepRunId = makeStepRunId()
+                    [now, worktreePath, sessionId, now, workItem.id],
+                  )
+                } else {
+                  const nextStepRunId = makeStepRunId()
 
-                yield* sql.unsafe(
-                  `UPDATE work_item
+                  yield* sql.unsafe(
+                    `UPDATE work_item
                    SET state = ?,
                        state_ready_at = ?,
                        worktree_path = ?,
                        session_id = ?,
                        updated_at = ?
                    WHERE id = ?`,
-                  [nextStep, now, worktreePath, sessionId, now, workItem.id],
-                )
+                    [nextStep, now, worktreePath, sessionId, now, workItem.id],
+                  )
 
-                yield* sql.unsafe(
-                  `INSERT INTO step_run (
+                  yield* sql.unsafe(
+                    `INSERT INTO step_run (
                      id, work_item_id, step, status, queue_job_id, queued_at,
                      started_at, finished_at, reason_code, reason_message,
                      created_at, updated_at
                    ) VALUES (?, ?, ?, 'queued', NULL, ?, NULL, NULL, NULL, NULL, ?, ?)`,
-                  [nextStepRunId, workItem.id, nextStep, now, now, now],
-                )
+                    [nextStepRunId, workItem.id, nextStep, now, now, now],
+                  )
 
-                const payload = yield* encodeStepJob(nextStepRunId)
-                const jobId = yield* queue.enqueue(
-                  WORK_ITEM_LIFECYCLE_QUEUE,
-                  payload,
-                  { retryLimit: 1 },
-                )
+                  const payload = yield* encodeStepJob(nextStepRunId)
+                  const jobId = yield* queue.enqueue(
+                    WORK_ITEM_LIFECYCLE_QUEUE,
+                    payload,
+                    { retryLimit: 1 },
+                  )
 
-                yield* sql.unsafe(
-                  `UPDATE step_run
+                  yield* sql.unsafe(
+                    `UPDATE step_run
                    SET queue_job_id = ?, updated_at = ?
                    WHERE id = ?`,
-                  [jobId, now, nextStepRunId],
-                )
-              }
+                    [jobId, now, nextStepRunId],
+                  )
+                }
 
-              if (stepRun.queue_job_id !== null) {
-                yield* queue.acknowledge(stepRun.queue_job_id)
-              }
-            }),
-          )
-          .pipe(Effect.catch(catchTransactionError))
-
-        return yield* getWorkItem(workItem.id).pipe(
-          Effect.catchTag(
-            "WorkItemNotFoundError",
-            (error) =>
-              new WorkItemLifecycleDatabaseError({
-                message: `Work Item missing after step completion: ${error.workItemId}`,
-                cause: error,
+                if (stepRun.queue_job_id !== null) {
+                  yield* queue.acknowledge(stepRun.queue_job_id)
+                }
               }),
-          ),
-        )
-      })
+            )
+            .pipe(Effect.catch(catchTransactionError))
 
-    const runStep = Effect.fn("WorkItemLifecycle.runStep")(function* (
-      stepRunId: string,
-    ) {
-      const stepRun = yield* loadStepRunRow(stepRunId)
-      if (!stepRun) {
-        return yield* new StepRunNotFoundError({ stepRunId })
-      }
-
-      const workItem = yield* loadWorkItemRow(stepRun.work_item_id)
-      if (!workItem) {
-        return yield* new WorkItemNotFoundError({
-          workItemId: stepRun.work_item_id,
+          return yield* getWorkItem(workItem.id).pipe(
+            Effect.catchTag(
+              "WorkItemNotFoundError",
+              (error) =>
+                new WorkItemLifecycleDatabaseError({
+                  message: `Work Item missing after step completion: ${error.workItemId}`,
+                  cause: error,
+                }),
+            ),
+          )
         })
-      }
 
-      const startedAt = Date.now()
-      const startedRows = (yield* sql
-        .unsafe(
-          `UPDATE step_run
+      const completeFailedStep = (input: {
+        readonly stepRun: StepRunRow
+        readonly workItem: WorkItemRow
+        readonly reasonCode: string
+        readonly reasonMessage: string
+        readonly cause: Cause.Cause<unknown>
+      }): Effect.Effect<WorkItemRecord, RunStepError> =>
+        Effect.gen(function* () {
+          const now = Date.now()
+          const { stepRun, workItem, reasonCode, reasonMessage, cause } = input
+
+          yield* Effect.logError("Lifecycle Step handler failed", {
+            workItemId: workItem.id,
+            stepRunId: stepRun.id,
+            step: stepRun.step,
+            reasonCode,
+            reasonMessage,
+            cause: Cause.pretty(cause),
+          })
+
+          yield* sql
+            .withTransaction(
+              Effect.gen(function* () {
+                yield* sql.unsafe(
+                  `UPDATE step_run
+                 SET status = 'failed',
+                     finished_at = ?,
+                     reason_code = ?,
+                     reason_message = ?,
+                     updated_at = ?
+                 WHERE id = ? AND status = 'running'`,
+                  [now, reasonCode, reasonMessage, now, stepRun.id],
+                )
+
+                if (stepRun.queue_job_id !== null) {
+                  yield* queue.fail(stepRun.queue_job_id, {
+                    retryable: false,
+                  })
+                }
+              }),
+            )
+            .pipe(Effect.catch(catchTransactionError))
+
+          return yield* getWorkItem(workItem.id).pipe(
+            Effect.catchTag(
+              "WorkItemNotFoundError",
+              (error) =>
+                new WorkItemLifecycleDatabaseError({
+                  message: `Work Item missing after step failure: ${error.workItemId}`,
+                  cause: error,
+                }),
+            ),
+          )
+        })
+
+      const runStep = Effect.fn("WorkItemLifecycle.runStep")(function* (
+        stepRunId: string,
+      ) {
+        const stepRun = yield* loadStepRunRow(stepRunId)
+        if (!stepRun) {
+          return yield* new StepRunNotFoundError({ stepRunId })
+        }
+
+        const workItem = yield* loadWorkItemRow(stepRun.work_item_id)
+        if (!workItem) {
+          return yield* new WorkItemNotFoundError({
+            workItemId: stepRun.work_item_id,
+          })
+        }
+
+        const startedAt = Date.now()
+        const startedRows = (yield* sql
+          .unsafe(
+            `UPDATE step_run
            SET status = 'running', started_at = ?, updated_at = ?
            WHERE id = ?
              AND status = 'queued'
@@ -669,206 +848,394 @@ export const WorkItemLifecycleLive = Layer.effect(
               )
             RETURNING id, work_item_id, step, status, queue_job_id, queued_at,
                       started_at, finished_at, reason_code, reason_message`,
-          [startedAt, startedAt, stepRunId, stepRun.step],
+            [startedAt, startedAt, stepRunId, stepRun.step],
+          )
+          .pipe(Effect.mapError(toDatabaseError))) as readonly StepRunRow[]
+
+        const afterStart = startedRows[0]
+        if (!afterStart) {
+          return { _tag: "noop" as const }
+        }
+
+        const context: LifecycleStepContext = {
+          workItemId: workItem.id as WorkItemId,
+          repositoryId: workItem.repository_id,
+          githubIssueNumber: workItem.github_issue_number,
+          model: workItem.model,
+          variant: workItem.variant,
+          worktreePath: workItem.worktree_path,
+          sessionId: workItem.session_id,
+        }
+
+        const maxDuration = maxDurations[stepRun.step]
+        const handlerExit = yield* Effect.exit(
+          Effect.suspend(() => runHandler(stepRun.step, context)).pipe(
+            Effect.timeout(maxDuration),
+          ),
         )
-        .pipe(Effect.mapError(toDatabaseError))) as readonly StepRunRow[]
 
-      const afterStart = startedRows[0]
-      if (!afterStart) {
-        return { _tag: "noop" as const }
-      }
+        if (Exit.isFailure(handlerExit)) {
+          const classification = classifyHandlerFailure(handlerExit.cause)
+          const failed = yield* completeFailedStep({
+            stepRun: afterStart,
+            workItem,
+            reasonCode: classification.reasonCode,
+            reasonMessage: classification.reasonMessage,
+            cause: handlerExit.cause,
+          })
+          return { _tag: "processed" as const, workItem: failed }
+        }
 
-      const context: LifecycleStepContext = {
-        workItemId: workItem.id as WorkItemId,
-        repositoryId: workItem.repository_id,
-        githubIssueNumber: workItem.github_issue_number,
-        model: workItem.model,
-        variant: workItem.variant,
-        worktreePath: workItem.worktree_path,
-        sessionId: workItem.session_id,
-      }
+        const revalidation = yield* revalidateIssue(
+          workItem.repository_id,
+          workItem.github_issue_number,
+        )
 
-      const output = yield* runHandler(stepRun.step, context)
+        const completed = yield* completeSuccessfulStep({
+          stepRun: afterStart,
+          workItem,
+          output: handlerExit.value,
+          revalidation,
+        })
 
-      const revalidation = yield* revalidateIssue(
-        workItem.repository_id,
-        workItem.github_issue_number,
-      )
-
-      const completed = yield* completeSuccessfulStep({
-        stepRun: afterStart,
-        workItem,
-        output,
-        revalidation,
+        return { _tag: "processed" as const, workItem: completed }
       })
 
-      return { _tag: "processed" as const, workItem: completed }
-    })
+      const retry = Effect.fn("WorkItemLifecycle.retry")(function* (
+        workItemId: string,
+      ) {
+        const workItem = yield* loadWorkItemRow(workItemId)
+        if (!workItem) {
+          return yield* new WorkItemNotFoundError({ workItemId })
+        }
 
-    const implementNow = Effect.fn("WorkItemLifecycle.implementNow")(function* (
-      repositoryId: string,
-      githubIssueNumber: number,
-    ) {
-      const issues = yield* db.listIssues(repositoryId)
-      const issue = issues.find(
-        (candidate) => candidate.githubIssueNumber === githubIssueNumber,
-      )
+        if (isTerminalWorkItemState(workItem.state)) {
+          return yield* new WorkItemTerminalError({
+            workItemId,
+            state: workItem.state,
+          })
+        }
 
-      if (!issue) {
-        return yield* new IssueNotFoundError({
-          repositoryId,
-          githubIssueNumber,
-        })
-      }
+        const pendingStep = workItem.state as OperationalLifecycleStep
 
-      if (issue.state !== "OPEN") {
-        return yield* new IssueNotOpenError({
-          repositoryId,
-          githubIssueNumber,
-          state: issue.state,
-        })
-      }
+        const activeRows = (yield* sql
+          .unsafe(
+            `SELECT id, work_item_id, step, status, queue_job_id, queued_at,
+                  started_at, finished_at, reason_code, reason_message
+           FROM step_run
+           WHERE work_item_id = ?
+             AND status IN ('queued', 'running')
+           ORDER BY queued_at DESC, id DESC
+           LIMIT 1`,
+            [workItemId],
+          )
+          .pipe(Effect.mapError(toDatabaseError))) as readonly StepRunRow[]
 
-      if (issue.hasChildren) {
-        return yield* new ParentIssueError({
-          repositoryId,
-          githubIssueNumber,
-        })
-      }
+        const active = activeRows[0]
+        if (active) {
+          return yield* new ActiveStepRunExistsError({
+            workItemId,
+            stepRunId: active.id,
+            status: active.status,
+          })
+        }
 
-      if (issue.blockedBy.length > 0) {
-        return yield* new IssueBlockedError({
-          repositoryId,
-          githubIssueNumber,
-          blockerCount: issue.blockedBy.length,
-        })
-      }
+        const latestPendingRows = (yield* sql
+          .unsafe(
+            `SELECT id, work_item_id, step, status, queue_job_id, queued_at,
+                  started_at, finished_at, reason_code, reason_message
+           FROM step_run
+           WHERE work_item_id = ?
+             AND step = ?
+           ORDER BY queued_at DESC, id DESC
+           LIMIT 1`,
+            [workItemId, pendingStep],
+          )
+          .pipe(Effect.mapError(toDatabaseError))) as readonly StepRunRow[]
 
-      const existing = yield* listWorkItemsForIssue(
-        repositoryId,
-        githubIssueNumber,
-      )
-      const unfinished = existing.find(
-        (item) =>
-          item.state !== "complete" &&
-          item.state !== "failed" &&
-          item.state !== "abandoned",
-      )
-      if (unfinished) {
-        return yield* unfinishedWorkItemExistsError(
-          repositoryId,
-          githubIssueNumber,
-          unfinished.id,
-        )
-      }
+        const latest = latestPendingRows[0]
+        if (!latest) {
+          return yield* new RetryNotEligibleError({
+            workItemId,
+            reason: "no_prior_step_run",
+          })
+        }
 
-      const config = yield* db.getConfig
-      const workItemId = makeWorkItemId()
-      const stepRunId = makeStepRunId()
-      const now = Date.now()
-      const step: OperationalLifecycleStep = "create_worktree"
+        if (latest.status !== "failed" && latest.status !== "interrupted") {
+          return yield* new RetryNotEligibleError({
+            workItemId,
+            reason: `latest_status_${latest.status}`,
+          })
+        }
 
-      const createdId = yield* sql
-        .withTransaction(
-          Effect.gen(function* () {
-            yield* sql.unsafe(
-              `INSERT INTO work_item (
-                 id, repository_id, github_issue_number, model, variant, state,
-                 state_ready_at, worktree_path, session_id, failure_code,
-                 failure_message, created_at, updated_at
-               ) VALUES (?, ?, ?, ?, ?, ?, ?, NULL, NULL, NULL, NULL, ?, ?)`,
-              [
-                workItemId,
-                repositoryId,
-                githubIssueNumber,
-                config.defaultModel,
-                config.defaultVariant,
-                step,
-                now,
-                now,
-                now,
-              ],
-            )
+        const now = Date.now()
+        const nextStepRunId = makeStepRunId()
 
-            yield* sql.unsafe(
-              `INSERT INTO step_run (
+        yield* sql
+          .withTransaction(
+            Effect.gen(function* () {
+              yield* sql.unsafe(
+                `INSERT INTO step_run (
                  id, work_item_id, step, status, queue_job_id, queued_at,
                  started_at, finished_at, reason_code, reason_message,
                  created_at, updated_at
                ) VALUES (?, ?, ?, 'queued', NULL, ?, NULL, NULL, NULL, NULL, ?, ?)`,
-              [stepRunId, workItemId, step, now, now, now],
-            )
+                [nextStepRunId, workItemId, pendingStep, now, now, now],
+              )
 
-            const payload = yield* encodeStepJob(stepRunId)
+              const payload = yield* encodeStepJob(nextStepRunId)
+              const jobId = yield* queue.enqueue(
+                WORK_ITEM_LIFECYCLE_QUEUE,
+                payload,
+                { retryLimit: 1 },
+              )
 
-            const jobId = yield* queue.enqueue(
-              WORK_ITEM_LIFECYCLE_QUEUE,
-              payload,
-              { retryLimit: 1 },
-            )
-
-            yield* sql.unsafe(
-              `UPDATE step_run
+              yield* sql.unsafe(
+                `UPDATE step_run
                SET queue_job_id = ?, updated_at = ?
                WHERE id = ?`,
-              [jobId, now, stepRunId],
-            )
+                [jobId, now, nextStepRunId],
+              )
 
-            return workItemId
-          }),
-        )
-        .pipe(
-          Effect.catch((error): Effect.Effect<never, ImplementNowError> => {
-            if (error instanceof WorkItemLifecycleDatabaseError) {
-              return Effect.fail(error)
-            }
-            if (error instanceof EnqueueError) {
-              return Effect.fail(error)
-            }
-            if (error instanceof InvalidQueueNameError) {
-              return Effect.fail(error)
-            }
-            if (
-              typeof error === "object" &&
-              error !== null &&
-              "_tag" in error &&
-              (error as { _tag: string })._tag === "SqlError"
-            ) {
-              const sqlError = error as SqlError
-              if (isUnfinishedWorkItemUniqueViolation(sqlError)) {
-                return unfinishedWorkItemExistsError(
-                  repositoryId,
-                  githubIssueNumber,
-                )
+              yield* sql.unsafe(
+                `UPDATE work_item
+               SET updated_at = ?
+               WHERE id = ?`,
+                [now, workItemId],
+              )
+            }),
+          )
+          .pipe(
+            Effect.catch((error): Effect.Effect<never, RetryError> => {
+              if (error instanceof WorkItemLifecycleDatabaseError) {
+                return Effect.fail(error)
               }
-              return Effect.fail(toDatabaseError(sqlError))
-            }
-            return Effect.fail(
+              if (error instanceof EnqueueError) {
+                return Effect.fail(error)
+              }
+              if (error instanceof InvalidQueueNameError) {
+                return Effect.fail(error)
+              }
+              if (
+                typeof error === "object" &&
+                error !== null &&
+                "_tag" in error &&
+                (error as { _tag: string })._tag === "SqlError"
+              ) {
+                const sqlError = error as SqlError
+                if (isActiveStepRunUniqueViolation(sqlError)) {
+                  return Effect.gen(function* () {
+                    const conflict = (yield* sql
+                      .unsafe(
+                        `SELECT id, status FROM step_run
+                       WHERE work_item_id = ?
+                         AND status IN ('queued', 'running')
+                       ORDER BY queued_at DESC, id DESC
+                       LIMIT 1`,
+                        [workItemId],
+                      )
+                      .pipe(Effect.mapError(toDatabaseError))) as readonly {
+                      id: string
+                      status: string
+                    }[]
+                    const row = conflict[0]
+                    return yield* new ActiveStepRunExistsError({
+                      workItemId,
+                      stepRunId: row?.id ?? "unknown",
+                      status: row?.status ?? "queued",
+                    })
+                  })
+                }
+                return Effect.fail(toDatabaseError(sqlError))
+              }
+              return Effect.fail(
+                new WorkItemLifecycleDatabaseError({
+                  message: `Unexpected transaction failure: ${String(error)}`,
+                  cause: error,
+                }),
+              )
+            }),
+          )
+
+        return yield* getWorkItem(workItemId).pipe(
+          Effect.catchTag(
+            "WorkItemNotFoundError",
+            (error) =>
               new WorkItemLifecycleDatabaseError({
-                message: `Unexpected transaction failure: ${String(error)}`,
+                message: `Work Item missing after retry: ${error.workItemId}`,
                 cause: error,
               }),
-            )
-          }),
+          ),
         )
+      })
 
-      return yield* getWorkItem(createdId).pipe(
-        Effect.catchTag(
-          "WorkItemNotFoundError",
-          (error) =>
-            new WorkItemLifecycleDatabaseError({
-              message: `Work Item missing after create: ${error.workItemId}`,
-              cause: error,
-            }),
-        ),
+      const implementNow = Effect.fn("WorkItemLifecycle.implementNow")(
+        function* (repositoryId: string, githubIssueNumber: number) {
+          const issues = yield* db.listIssues(repositoryId)
+          const issue = issues.find(
+            (candidate) => candidate.githubIssueNumber === githubIssueNumber,
+          )
+
+          if (!issue) {
+            return yield* new IssueNotFoundError({
+              repositoryId,
+              githubIssueNumber,
+            })
+          }
+
+          if (issue.state !== "OPEN") {
+            return yield* new IssueNotOpenError({
+              repositoryId,
+              githubIssueNumber,
+              state: issue.state,
+            })
+          }
+
+          if (issue.hasChildren) {
+            return yield* new ParentIssueError({
+              repositoryId,
+              githubIssueNumber,
+            })
+          }
+
+          if (issue.blockedBy.length > 0) {
+            return yield* new IssueBlockedError({
+              repositoryId,
+              githubIssueNumber,
+              blockerCount: issue.blockedBy.length,
+            })
+          }
+
+          const existing = yield* listWorkItemsForIssue(
+            repositoryId,
+            githubIssueNumber,
+          )
+          const unfinished = existing.find(
+            (item) =>
+              item.state !== "complete" &&
+              item.state !== "failed" &&
+              item.state !== "abandoned",
+          )
+          if (unfinished) {
+            return yield* unfinishedWorkItemExistsError(
+              repositoryId,
+              githubIssueNumber,
+              unfinished.id,
+            )
+          }
+
+          const config = yield* db.getConfig
+          const workItemId = makeWorkItemId()
+          const stepRunId = makeStepRunId()
+          const now = Date.now()
+          const step: OperationalLifecycleStep = "create_worktree"
+
+          const createdId = yield* sql
+            .withTransaction(
+              Effect.gen(function* () {
+                yield* sql.unsafe(
+                  `INSERT INTO work_item (
+                 id, repository_id, github_issue_number, model, variant, state,
+                 state_ready_at, worktree_path, session_id, failure_code,
+                 failure_message, created_at, updated_at
+               ) VALUES (?, ?, ?, ?, ?, ?, ?, NULL, NULL, NULL, NULL, ?, ?)`,
+                  [
+                    workItemId,
+                    repositoryId,
+                    githubIssueNumber,
+                    config.defaultModel,
+                    config.defaultVariant,
+                    step,
+                    now,
+                    now,
+                    now,
+                  ],
+                )
+
+                yield* sql.unsafe(
+                  `INSERT INTO step_run (
+                 id, work_item_id, step, status, queue_job_id, queued_at,
+                 started_at, finished_at, reason_code, reason_message,
+                 created_at, updated_at
+               ) VALUES (?, ?, ?, 'queued', NULL, ?, NULL, NULL, NULL, NULL, ?, ?)`,
+                  [stepRunId, workItemId, step, now, now, now],
+                )
+
+                const payload = yield* encodeStepJob(stepRunId)
+
+                const jobId = yield* queue.enqueue(
+                  WORK_ITEM_LIFECYCLE_QUEUE,
+                  payload,
+                  { retryLimit: 1 },
+                )
+
+                yield* sql.unsafe(
+                  `UPDATE step_run
+               SET queue_job_id = ?, updated_at = ?
+               WHERE id = ?`,
+                  [jobId, now, stepRunId],
+                )
+
+                return workItemId
+              }),
+            )
+            .pipe(
+              Effect.catch((error): Effect.Effect<never, ImplementNowError> => {
+                if (error instanceof WorkItemLifecycleDatabaseError) {
+                  return Effect.fail(error)
+                }
+                if (error instanceof EnqueueError) {
+                  return Effect.fail(error)
+                }
+                if (error instanceof InvalidQueueNameError) {
+                  return Effect.fail(error)
+                }
+                if (
+                  typeof error === "object" &&
+                  error !== null &&
+                  "_tag" in error &&
+                  (error as { _tag: string })._tag === "SqlError"
+                ) {
+                  const sqlError = error as SqlError
+                  if (isUnfinishedWorkItemUniqueViolation(sqlError)) {
+                    return unfinishedWorkItemExistsError(
+                      repositoryId,
+                      githubIssueNumber,
+                    )
+                  }
+                  return Effect.fail(toDatabaseError(sqlError))
+                }
+                return Effect.fail(
+                  new WorkItemLifecycleDatabaseError({
+                    message: `Unexpected transaction failure: ${String(error)}`,
+                    cause: error,
+                  }),
+                )
+              }),
+            )
+
+          return yield* getWorkItem(createdId).pipe(
+            Effect.catchTag(
+              "WorkItemNotFoundError",
+              (error) =>
+                new WorkItemLifecycleDatabaseError({
+                  message: `Work Item missing after create: ${error.workItemId}`,
+                  cause: error,
+                }),
+            ),
+          )
+        },
       )
-    })
 
-    return WorkItemLifecycle.of({
-      implementNow,
-      runStep,
-      getWorkItem,
-      listWorkItemsForIssue,
-    })
-  }),
-)
+      return WorkItemLifecycle.of({
+        maxDurations,
+        implementNow,
+        runStep,
+        retry,
+        getWorkItem,
+        listWorkItemsForIssue,
+      })
+    }),
+  )
+
+export const WorkItemLifecycleLive = makeWorkItemLifecycleLive()

--- a/packages/work-item-lifecycle/test/work-item-lifecycle.spec.ts
+++ b/packages/work-item-lifecycle/test/work-item-lifecycle.spec.ts
@@ -1,4 +1,4 @@
-import { Cause, Effect, Layer, Option, Result } from "effect"
+import { Cause, Duration, Effect, Layer, Option, Result } from "effect"
 import { SqlClient } from "effect/unstable/sql"
 import { DatabaseTest } from "@ready-for-agent/db/test"
 import { DbService, DbServiceLive } from "@ready-for-agent/db-service"
@@ -10,6 +10,7 @@ import {
 } from "@ready-for-agent/queue-service"
 import { SqliteQueueServiceLive } from "@ready-for-agent/sqlite-queue-service"
 import {
+  ActiveStepRunExistsError,
   IssueBlockedError,
   IssueNotFoundError,
   IssueNotOpenError,
@@ -18,11 +19,15 @@ import {
   type LifecycleStepsShape,
   NonTransactionalQueueError,
   ParentIssueError,
+  RetryNotEligibleError,
+  STEP_RUN_REASON,
   UnfinishedWorkItemExistsError,
   WORK_ITEM_LIFECYCLE_QUEUE,
   WorkItemLifecycle,
   WorkItemLifecycleLive,
   WorkItemNotFoundError,
+  WorkItemTerminalError,
+  makeWorkItemLifecycleLive,
 } from "../src/index.js"
 import { describe, expect, it } from "bun:test"
 
@@ -424,8 +429,7 @@ describe("WorkItemLifecycle", () => {
             issue.githubIssueNumber,
           )
 
-          // Terminalize via SQL so a second Implement Now is allowed; abandon/retry
-          // are later tickets and are not part of this package's public surface yet.
+          // Terminalize via SQL so a second Implement Now is allowed; abandon is a later ticket.
           yield* sql.unsafe(
             `UPDATE work_item SET state = 'abandoned', updated_at = ? WHERE id = ?`,
             [Date.now(), first.id],
@@ -991,6 +995,492 @@ describe("WorkItemLifecycle", () => {
           expect(after.stepRuns[0]!.status).not.toBe("succeeded")
           expect(after.stepRuns[0]!.finishedAt).toBeNull()
         }).pipe(Effect.provide(layer)),
+      )
+    })
+
+    it("records typed handler failure as Failed Step Run and leaves the pending step", () => {
+      const failingSteps: LifecycleStepsShape = {
+        ...successfulSteps,
+        createWorktree: () => Effect.fail(new Error("worktree path busy")),
+      }
+
+      return runWithSteps(
+        failingSteps,
+        Effect.gen(function* () {
+          const lifecycle = yield* WorkItemLifecycle
+          const queue = yield* QueueService
+          const { repository, issue } = yield* seedActionableIssue
+
+          const created = yield* lifecycle.implementNow(
+            repository.id,
+            issue.githubIssueNumber,
+          )
+          const result = yield* claimAndRunPending
+
+          expect(result._tag).toBe("processed")
+          if (result._tag === "processed") {
+            expect(result.workItem.state).toBe("create_worktree")
+            expect(result.workItem.stepRuns).toHaveLength(1)
+            const run = result.workItem.stepRuns[0]!
+            expect(run.status).toBe("failed")
+            expect(run.reasonCode).toBe(STEP_RUN_REASON.handlerFailed)
+            expect(run.reasonMessage).toContain("worktree path busy")
+            expect(run.queuedAt).toBeInstanceOf(Date)
+            expect(run.startedAt).toBeInstanceOf(Date)
+            expect(run.finishedAt).toBeInstanceOf(Date)
+            expect(run.finishedAt!.getTime()).toBeGreaterThanOrEqual(
+              run.startedAt!.getTime(),
+            )
+          }
+
+          const remaining = yield* queue.rawClaim(WORK_ITEM_LIFECYCLE_QUEUE)
+          expect(Option.isNone(remaining)).toBe(true)
+
+          const final = yield* lifecycle.getWorkItem(created.id)
+          expect(final.state).toBe("create_worktree")
+          expect(final.stepRuns).toHaveLength(1)
+          expect(final.stepRuns[0]!.status).toBe("failed")
+        }),
+      )
+    })
+
+    it("records handler defects as Failed with a stable defect reason", () => {
+      const defectSteps: LifecycleStepsShape = {
+        ...successfulSteps,
+        createWorktree: () => Effect.die("unexpected boom"),
+      }
+
+      return runWithSteps(
+        defectSteps,
+        Effect.gen(function* () {
+          const lifecycle = yield* WorkItemLifecycle
+          const { repository, issue } = yield* seedActionableIssue
+
+          yield* lifecycle.implementNow(repository.id, issue.githubIssueNumber)
+          const result = yield* claimAndRunPending
+
+          expect(result._tag).toBe("processed")
+          if (result._tag === "processed") {
+            expect(result.workItem.state).toBe("create_worktree")
+            const run = result.workItem.stepRuns[0]!
+            expect(run.status).toBe("failed")
+            expect(run.reasonCode).toBe(STEP_RUN_REASON.handlerDefect)
+            expect(run.reasonMessage).toContain("unexpected boom")
+            expect(run.finishedAt).toBeInstanceOf(Date)
+          }
+        }),
+      )
+    })
+
+    it("records a synchronous handler throw as a Failed defect", () => {
+      const throwingSteps: LifecycleStepsShape = {
+        ...successfulSteps,
+        createWorktree: () => {
+          throw new Error("handler construction exploded")
+        },
+      }
+
+      return runWithSteps(
+        throwingSteps,
+        Effect.gen(function* () {
+          const lifecycle = yield* WorkItemLifecycle
+          const queue = yield* QueueService
+          const { repository, issue } = yield* seedActionableIssue
+
+          const created = yield* lifecycle.implementNow(
+            repository.id,
+            issue.githubIssueNumber,
+          )
+          const result = yield* claimAndRunPending
+
+          expect(result._tag).toBe("processed")
+          if (result._tag === "processed") {
+            const run = result.workItem.stepRuns[0]!
+            expect(result.workItem.state).toBe("create_worktree")
+            expect(run.status).toBe("failed")
+            expect(run.reasonCode).toBe(STEP_RUN_REASON.handlerDefect)
+            expect(run.reasonMessage).toContain("handler construction exploded")
+            expect(run.finishedAt).toBeInstanceOf(Date)
+          }
+
+          const remaining = yield* queue.rawClaim(WORK_ITEM_LIFECYCLE_QUEUE)
+          expect(Option.isNone(remaining)).toBe(true)
+          expect(
+            (yield* lifecycle.getWorkItem(created.id)).stepRuns[0]!.status,
+          ).toBe("failed")
+        }),
+      )
+    })
+
+    it("interrupts a slow handler and records Failed with a timeout reason", () => {
+      const slowSteps: LifecycleStepsShape = {
+        ...successfulSteps,
+        createWorktree: () =>
+          Effect.gen(function* () {
+            yield* Effect.sleep("200 millis")
+            return "/tmp/worktrees/too-slow"
+          }),
+      }
+
+      const layer = makeWorkItemLifecycleLive({
+        maxDurations: {
+          create_worktree: Duration.millis(20),
+          install_dependencies: Duration.minutes(15),
+          implement: Duration.hours(2),
+          review: Duration.hours(1),
+        },
+      }).pipe(
+        Layer.provideMerge(
+          Layer.succeed(LifecycleSteps, LifecycleSteps.of(slowSteps)),
+        ),
+        Layer.provideMerge(DbServiceLive),
+        Layer.provideMerge(SqliteQueueServiceLive),
+        Layer.provideMerge(DatabaseTest),
+      )
+
+      return Effect.runPromise(
+        Effect.gen(function* () {
+          const lifecycle = yield* WorkItemLifecycle
+          const queue = yield* QueueService
+          const { repository, issue } = yield* seedActionableIssue
+
+          expect(
+            Duration.toMillis(lifecycle.maxDurations.create_worktree),
+          ).toBe(20)
+
+          const created = yield* lifecycle.implementNow(
+            repository.id,
+            issue.githubIssueNumber,
+          )
+          const claimed = yield* queue.rawClaim(
+            WORK_ITEM_LIFECYCLE_QUEUE,
+            lifecycle.maxDurations.create_worktree,
+          )
+          expect(Option.isSome(claimed)).toBe(true)
+          if (Option.isNone(claimed)) {
+            return yield* Effect.die("expected lifecycle job")
+          }
+
+          const result = yield* lifecycle.runStep(
+            (claimed.value.payload as { stepRunId: string }).stepRunId,
+          )
+
+          expect(result._tag).toBe("processed")
+          if (result._tag === "processed") {
+            expect(result.workItem.state).toBe("create_worktree")
+            const run = result.workItem.stepRuns[0]!
+            expect(run.status).toBe("failed")
+            expect(run.reasonCode).toBe(STEP_RUN_REASON.timeout)
+            expect(run.reasonMessage.toLowerCase()).toContain("maximum")
+            expect(run.finishedAt).toBeInstanceOf(Date)
+          }
+
+          const remaining = yield* queue.rawClaim(WORK_ITEM_LIFECYCLE_QUEUE)
+          expect(Option.isNone(remaining)).toBe(true)
+
+          const final = yield* lifecycle.getWorkItem(created.id)
+          expect(final.state).toBe("create_worktree")
+          expect(final.stepRuns[0]!.reasonCode).toBe(STEP_RUN_REASON.timeout)
+        }).pipe(Effect.provide(layer)),
+      )
+    })
+  })
+
+  describe("retry", () => {
+    const claimAndRunPending = Effect.gen(function* () {
+      const lifecycle = yield* WorkItemLifecycle
+      const queue = yield* QueueService
+      const claimed = yield* queue.rawClaim(WORK_ITEM_LIFECYCLE_QUEUE)
+      expect(Option.isSome(claimed)).toBe(true)
+      if (Option.isNone(claimed)) {
+        return yield* Effect.die("expected a queued lifecycle job")
+      }
+      const payload = claimed.value.payload as { stepRunId: string }
+      return yield* lifecycle.runStep(payload.stepRunId)
+    })
+
+    it("creates a new Queued Step Run for a Failed pending step without changing state", () => {
+      let attempts = 0
+      const steps: LifecycleStepsShape = {
+        ...successfulSteps,
+        createWorktree: () => {
+          attempts += 1
+          if (attempts === 1) {
+            return Effect.fail(new Error("first attempt failed"))
+          }
+          return Effect.succeed("/tmp/worktrees/retry-success")
+        },
+      }
+
+      return runWithSteps(
+        steps,
+        Effect.gen(function* () {
+          const lifecycle = yield* WorkItemLifecycle
+          const queue = yield* QueueService
+          const { repository, issue } = yield* seedActionableIssue
+
+          const created = yield* lifecycle.implementNow(
+            repository.id,
+            issue.githubIssueNumber,
+          )
+          const failed = yield* claimAndRunPending
+          expect(failed._tag).toBe("processed")
+          if (failed._tag === "processed") {
+            expect(failed.workItem.stepRuns[0]!.status).toBe("failed")
+          }
+
+          const retried = yield* lifecycle.retry(created.id)
+          expect(retried.state).toBe("create_worktree")
+          expect(retried.stepRuns).toHaveLength(2)
+          expect(retried.stepRuns[0]!.status).toBe("failed")
+          expect(retried.stepRuns[0]!.reasonCode).toBe(
+            STEP_RUN_REASON.handlerFailed,
+          )
+          expect(retried.stepRuns[1]!.status).toBe("queued")
+          expect(retried.stepRuns[1]!.step).toBe("create_worktree")
+          expect(retried.stepRuns[1]!.id).not.toBe(retried.stepRuns[0]!.id)
+          expect(retried.stepRuns[1]!.queueJobId).toMatch(
+            /^qjob-[0-9A-HJKMNP-TV-Z]{26}$/,
+          )
+
+          const afterRetry = yield* claimAndRunPending
+          expect(afterRetry._tag).toBe("processed")
+          if (afterRetry._tag === "processed") {
+            expect(afterRetry.workItem.state).toBe("install_dependencies")
+            expect(afterRetry.workItem.worktreePath).toBe(
+              "/tmp/worktrees/retry-success",
+            )
+            expect(
+              afterRetry.workItem.stepRuns.map((run) => [run.step, run.status]),
+            ).toEqual([
+              ["create_worktree", "failed"],
+              ["create_worktree", "succeeded"],
+              ["install_dependencies", "queued"],
+            ])
+          }
+
+          const remaining = yield* queue.rawClaim(WORK_ITEM_LIFECYCLE_QUEUE)
+          expect(Option.isSome(remaining)).toBe(true)
+        }),
+      )
+    })
+
+    it("retains every prior Step Run across multiple retries", () => {
+      const steps: LifecycleStepsShape = {
+        ...successfulSteps,
+        createWorktree: () => Effect.fail(new Error("still failing")),
+      }
+
+      return runWithSteps(
+        steps,
+        Effect.gen(function* () {
+          const lifecycle = yield* WorkItemLifecycle
+          const { repository, issue } = yield* seedActionableIssue
+
+          const created = yield* lifecycle.implementNow(
+            repository.id,
+            issue.githubIssueNumber,
+          )
+          yield* claimAndRunPending
+          yield* lifecycle.retry(created.id)
+          yield* claimAndRunPending
+          const afterSecondFail = yield* lifecycle.retry(created.id)
+
+          expect(afterSecondFail.state).toBe("create_worktree")
+          expect(afterSecondFail.stepRuns).toHaveLength(3)
+          expect(afterSecondFail.stepRuns.map((run) => run.status)).toEqual([
+            "failed",
+            "failed",
+            "queued",
+          ])
+          expect(afterSecondFail.stepRuns[0]!.reasonMessage).toContain(
+            "still failing",
+          )
+          expect(afterSecondFail.stepRuns[1]!.reasonMessage).toContain(
+            "still failing",
+          )
+          expect(afterSecondFail.stepRuns[0]!.finishedAt).not.toBeNull()
+          expect(afterSecondFail.stepRuns[1]!.finishedAt).not.toBeNull()
+        }),
+      )
+    })
+
+    it("accepts retry after an Interrupted latest attempt for the pending step", () =>
+      runTest(
+        Effect.gen(function* () {
+          const lifecycle = yield* WorkItemLifecycle
+          const sql = yield* SqlClient.SqlClient
+          const { repository, issue } = yield* seedActionableIssue
+
+          const created = yield* lifecycle.implementNow(
+            repository.id,
+            issue.githubIssueNumber,
+          )
+          const stepRunId = created.stepRuns[0]!.id
+          const now = Date.now()
+
+          yield* sql.unsafe(
+            `UPDATE step_run
+             SET status = 'interrupted',
+                 started_at = ?,
+                 finished_at = ?,
+                 reason_code = 'interrupted',
+                 reason_message = 'worker lost',
+                 updated_at = ?
+             WHERE id = ?`,
+            [now, now, now, stepRunId],
+          )
+          yield* Effect.sleep("2 millis")
+
+          const retried = yield* lifecycle.retry(created.id)
+          expect(retried.state).toBe("create_worktree")
+          expect(retried.stepRuns).toHaveLength(2)
+          expect(retried.stepRuns[0]!.status).toBe("interrupted")
+          expect(retried.stepRuns[1]!.status).toBe("queued")
+        }),
+      ))
+
+    it("rejects retry for Queued, Running, terminal, and never-failed Work Items", () =>
+      runTest(
+        Effect.gen(function* () {
+          const lifecycle = yield* WorkItemLifecycle
+          const sql = yield* SqlClient.SqlClient
+          const { repository, issue } = yield* seedActionableIssue
+
+          const created = yield* lifecycle.implementNow(
+            repository.id,
+            issue.githubIssueNumber,
+          )
+
+          const queuedError = yield* Effect.flip(lifecycle.retry(created.id))
+          expect(queuedError).toBeInstanceOf(ActiveStepRunExistsError)
+          if (queuedError instanceof ActiveStepRunExistsError) {
+            expect(queuedError.status).toBe("queued")
+            expect(queuedError.workItemId).toBe(created.id)
+          }
+
+          const started = yield* lifecycle.runStep(created.stepRuns[0]!.id)
+          expect(started._tag).toBe("processed")
+
+          const neverFailed = yield* lifecycle.getWorkItem(created.id)
+          expect(neverFailed.state).toBe("install_dependencies")
+          const neverFailedError = yield* Effect.flip(
+            lifecycle.retry(neverFailed.id),
+          )
+          expect(neverFailedError).toBeInstanceOf(ActiveStepRunExistsError)
+
+          // Clear the next queued run and leave only a Succeeded prior run for create_worktree
+          // so retry on install_dependencies has no failed latest attempt.
+          const installQueued = neverFailed.stepRuns.find(
+            (run) =>
+              run.step === "install_dependencies" && run.status === "queued",
+          )!
+          yield* sql.unsafe(
+            `UPDATE step_run
+             SET status = 'cancelled', finished_at = ?, updated_at = ?
+             WHERE id = ?`,
+            [Date.now(), Date.now(), installQueued.id],
+          )
+
+          const notEligible = yield* Effect.flip(
+            lifecycle.retry(neverFailed.id),
+          )
+          expect(notEligible).toBeInstanceOf(RetryNotEligibleError)
+
+          // Running rejection
+          const { repository: repo2, issue: issue2 } = yield* Effect.gen(
+            function* () {
+              const db = yield* DbService
+              const repository = yield* db.addRepository({
+                ...sampleRepository,
+                githubRepo: "widgets-running",
+                localPath: "/repos/acme/widgets-running.git",
+              })
+              const issue = yield* db.storeIssue({
+                repositoryId: repository.id,
+                githubIssueNumber: 43,
+                ...sampleIssueFields,
+                url: "https://github.com/acme/widgets/issues/43",
+              })
+              return { repository, issue }
+            },
+          )
+          const runningItem = yield* lifecycle.implementNow(
+            repo2.id,
+            issue2.githubIssueNumber,
+          )
+          yield* sql.unsafe(
+            `UPDATE step_run
+             SET status = 'running', started_at = ?, updated_at = ?
+             WHERE id = ?`,
+            [Date.now(), Date.now(), runningItem.stepRuns[0]!.id],
+          )
+          const runningError = yield* Effect.flip(
+            lifecycle.retry(runningItem.id),
+          )
+          expect(runningError).toBeInstanceOf(ActiveStepRunExistsError)
+          if (runningError instanceof ActiveStepRunExistsError) {
+            expect(runningError.status).toBe("running")
+          }
+
+          // Terminal rejection
+          yield* sql.unsafe(
+            `UPDATE work_item SET state = 'complete', updated_at = ? WHERE id = ?`,
+            [Date.now(), created.id],
+          )
+          const terminalError = yield* Effect.flip(lifecycle.retry(created.id))
+          expect(terminalError).toBeInstanceOf(WorkItemTerminalError)
+          if (terminalError instanceof WorkItemTerminalError) {
+            expect(terminalError.state).toBe("complete")
+          }
+        }),
+      ))
+
+    it("cannot create more than one active Step Run under concurrent Retry", () => {
+      const steps: LifecycleStepsShape = {
+        ...successfulSteps,
+        createWorktree: () =>
+          Effect.fail(new Error("fail for concurrent retry")),
+      }
+
+      return runWithSteps(
+        steps,
+        Effect.gen(function* () {
+          const lifecycle = yield* WorkItemLifecycle
+          const { repository, issue } = yield* seedActionableIssue
+
+          const created = yield* lifecycle.implementNow(
+            repository.id,
+            issue.githubIssueNumber,
+          )
+          yield* claimAndRunPending
+
+          const results = yield* Effect.all(
+            [
+              lifecycle.retry(created.id).pipe(Effect.result),
+              lifecycle.retry(created.id).pipe(Effect.result),
+            ],
+            { concurrency: "unbounded" },
+          )
+
+          const successes = results.filter((result) => Result.isSuccess(result))
+          const failures = results.filter((result) => Result.isFailure(result))
+          expect(successes).toHaveLength(1)
+          expect(failures).toHaveLength(1)
+          if (Result.isFailure(failures[0]!)) {
+            expect(failures[0].failure).toBeInstanceOf(ActiveStepRunExistsError)
+          }
+
+          const final = yield* lifecycle.getWorkItem(created.id)
+          expect(final.state).toBe("create_worktree")
+          const active = final.stepRuns.filter(
+            (run) => run.status === "queued" || run.status === "running",
+          )
+          expect(active).toHaveLength(1)
+          expect(
+            final.stepRuns.filter((run) => run.status === "failed"),
+          ).toHaveLength(1)
+        }),
       )
     })
   })


### PR DESCRIPTION
## Why

Failed Lifecycle Steps left no durable Step Run diagnostics and no safe recovery path. Handler failures could leave work stranded, and there was no operator `retry` command that creates a distinct attempt without automatic retry loops.

Closes #71.

## What Changed

- Record typed handler failures, defects, and timeouts as `failed` Step Runs with stable reason codes and concise messages, while full Effect diagnostics go to structured logs.
- Keep the Work Item on the same pending Lifecycle Step after failure, preserve timestamps, and terminally resolve the queue job without scheduling the next step or automatic logical retry.
- Accept per-step maximum durations via `makeWorkItemLifecycleLive({ maxDurations })`, apply them with `Effect.timeout`, and expose them as `lifecycle.maxDurations` for matching claim visibility leases.
- Capture synchronous handler throws with `Effect.suspend` so construction-time defects still become durable failures.
- Add `retry(workItemId)` to atomically create one new Queued Step Run and queue job when the latest pending-step attempt is `failed` or `interrupted`.
- Reject invalid retries with `WorkItemTerminalError`, `ActiveStepRunExistsError`, and `RetryNotEligibleError`, including concurrent retry races.
- Extend public-interface integration coverage for failure, defect, timeout, valid/invalid retry, and concurrent retry.
