### PR TITLE
feat(work-item-lifecycle): make delivery and abandonment safe

### DIFF
--- a/packages/work-item-lifecycle/src/lib/errors.ts
+++ b/packages/work-item-lifecycle/src/lib/errors.ts
@@ -76,3 +76,10 @@ export class RetryNotEligibleError extends Data.TaggedError(
   readonly workItemId: string
   readonly reason: string
 }> {}
+
+export class WorkItemHasRunningStepError extends Data.TaggedError(
+  "WorkItemHasRunningStepError",
+)<{
+  readonly workItemId: string
+  readonly stepRunId: string
+}> {}

--- a/packages/work-item-lifecycle/src/lib/types.ts
+++ b/packages/work-item-lifecycle/src/lib/types.ts
@@ -89,6 +89,8 @@ export const STEP_RUN_REASON = {
   handlerFailed: "handler_failed",
   handlerDefect: "handler_defect",
   timeout: "timeout",
+  interrupted: "interrupted",
+  abandoned: "abandoned",
 } as const
 
 export type StepRunReasonCode =

--- a/packages/work-item-lifecycle/src/lib/work-item-lifecycle.ts
+++ b/packages/work-item-lifecycle/src/lib/work-item-lifecycle.ts
@@ -1,6 +1,7 @@
 import {
   Cause,
   Context,
+  Duration,
   Effect,
   Exit,
   Layer,
@@ -32,6 +33,7 @@ import {
   RetryNotEligibleError,
   StepRunNotFoundError,
   UnfinishedWorkItemExistsError,
+  WorkItemHasRunningStepError,
   WorkItemLifecycleDatabaseError,
   WorkItemNotFoundError,
   WorkItemTerminalError,
@@ -289,6 +291,14 @@ export type RetryError =
   | EnqueueError
   | InvalidQueueNameError
 
+export type AbandonError =
+  | WorkItemNotFoundError
+  | WorkItemTerminalError
+  | WorkItemHasRunningStepError
+  | WorkItemLifecycleDatabaseError
+  | AcknowledgeError
+  | JobNotFoundError
+
 export type RunStepResult =
   | {
       readonly _tag: "processed"
@@ -310,6 +320,9 @@ export interface WorkItemLifecycleShape {
   readonly retry: (
     workItemId: string,
   ) => Effect.Effect<WorkItemRecord, RetryError>
+  readonly abandon: (
+    workItemId: string,
+  ) => Effect.Effect<WorkItemRecord, AbandonError>
   readonly getWorkItem: (
     workItemId: string,
   ) => Effect.Effect<WorkItemRecord, GetWorkItemError>
@@ -811,6 +824,70 @@ export const makeWorkItemLifecycleLive = (
           )
         })
 
+      const completeInterruptedStep = (input: {
+        readonly stepRun: StepRunRow
+        readonly reasonMessage: string
+        readonly cause?: Cause.Cause<unknown>
+      }): Effect.Effect<void, RunStepError> =>
+        Effect.gen(function* () {
+          const now = Date.now()
+          const { stepRun, reasonMessage, cause } = input
+
+          if (cause) {
+            yield* Effect.logWarning("Lifecycle Step interrupted", {
+              workItemId: stepRun.work_item_id,
+              stepRunId: stepRun.id,
+              step: stepRun.step,
+              reasonMessage,
+              cause: Cause.pretty(cause),
+            })
+          }
+
+          yield* sql
+            .withTransaction(
+              Effect.gen(function* () {
+                yield* sql.unsafe(
+                  `UPDATE step_run
+                 SET status = 'interrupted',
+                     finished_at = ?,
+                     reason_code = ?,
+                     reason_message = ?,
+                     updated_at = ?
+                 WHERE id = ? AND status = 'running'`,
+                  [
+                    now,
+                    STEP_RUN_REASON.interrupted,
+                    reasonMessage,
+                    now,
+                    stepRun.id,
+                  ],
+                )
+
+                if (stepRun.queue_job_id !== null) {
+                  yield* queue
+                    .acknowledge(stepRun.queue_job_id)
+                    .pipe(
+                      Effect.catchTag("JobNotFoundError", () => Effect.void),
+                    )
+                }
+              }),
+            )
+            .pipe(Effect.catch(catchTransactionError))
+        })
+
+      const acknowledgeStaleDelivery = (
+        stepRun: StepRunRow,
+      ): Effect.Effect<void, RunStepError> =>
+        Effect.gen(function* () {
+          if (stepRun.queue_job_id === null) {
+            return
+          }
+          yield* queue.acknowledge(stepRun.queue_job_id).pipe(
+            Effect.catchTag("JobNotFoundError", () => Effect.void),
+            Effect.mapError((error): RunStepError => error),
+          )
+        })
+
       const runStep = Effect.fn("WorkItemLifecycle.runStep")(function* (
         stepRunId: string,
       ) {
@@ -854,6 +931,29 @@ export const makeWorkItemLifecycleLive = (
 
         const afterStart = startedRows[0]
         if (!afterStart) {
+          const current = yield* loadStepRunRow(stepRunId)
+          if (current?.status === "running") {
+            const maxDurationMs = Duration.toMillis(maxDurations[current.step])
+            const startedMs = current.started_at ?? 0
+            const leaseExpired = Date.now() - startedMs >= maxDurationMs
+            if (leaseExpired) {
+              yield* completeInterruptedStep({
+                stepRun: current,
+                reasonMessage:
+                  "Visibility lease expired while the Step Run was still Running",
+              })
+            }
+            return { _tag: "noop" as const }
+          }
+          if (
+            current &&
+            (current.status === "succeeded" ||
+              current.status === "failed" ||
+              current.status === "interrupted" ||
+              current.status === "cancelled")
+          ) {
+            yield* acknowledgeStaleDelivery(current)
+          }
           return { _tag: "noop" as const }
         }
 
@@ -868,37 +968,211 @@ export const makeWorkItemLifecycleLive = (
         }
 
         const maxDuration = maxDurations[stepRun.step]
-        const handlerExit = yield* Effect.exit(
-          Effect.suspend(() => runHandler(stepRun.step, context)).pipe(
-            Effect.timeout(maxDuration),
-          ),
+
+        const result = yield* Effect.uninterruptibleMask((restore) =>
+          Effect.gen(function* () {
+            const handlerExit = yield* Effect.exit(
+              restore(
+                Effect.suspend(() => runHandler(stepRun.step, context)).pipe(
+                  Effect.timeout(maxDuration),
+                ),
+              ),
+            )
+
+            if (Exit.isFailure(handlerExit)) {
+              const classification = classifyHandlerFailure(handlerExit.cause)
+              const isTimeout =
+                classification.reasonCode === STEP_RUN_REASON.timeout
+              if (!isTimeout && Cause.hasInterruptsOnly(handlerExit.cause)) {
+                yield* completeInterruptedStep({
+                  stepRun: afterStart,
+                  reasonMessage:
+                    "Lifecycle Step was interrupted before an outcome could be established",
+                  cause: handlerExit.cause,
+                })
+                const interrupted = yield* getWorkItem(workItem.id).pipe(
+                  Effect.catchTag(
+                    "WorkItemNotFoundError",
+                    (error) =>
+                      new WorkItemLifecycleDatabaseError({
+                        message: `Work Item missing after interruption: ${error.workItemId}`,
+                        cause: error,
+                      }),
+                  ),
+                )
+                return {
+                  _tag: "processed" as const,
+                  workItem: interrupted,
+                }
+              }
+
+              const failed = yield* completeFailedStep({
+                stepRun: afterStart,
+                workItem,
+                reasonCode: classification.reasonCode,
+                reasonMessage: classification.reasonMessage,
+                cause: handlerExit.cause,
+              })
+              return { _tag: "processed" as const, workItem: failed }
+            }
+
+            const revalidation = yield* revalidateIssue(
+              workItem.repository_id,
+              workItem.github_issue_number,
+            )
+
+            const completed = yield* completeSuccessfulStep({
+              stepRun: afterStart,
+              workItem,
+              output: handlerExit.value,
+              revalidation,
+            })
+
+            return { _tag: "processed" as const, workItem: completed }
+          }),
         )
 
-        if (Exit.isFailure(handlerExit)) {
-          const classification = classifyHandlerFailure(handlerExit.cause)
-          const failed = yield* completeFailedStep({
-            stepRun: afterStart,
-            workItem,
-            reasonCode: classification.reasonCode,
-            reasonMessage: classification.reasonMessage,
-            cause: handlerExit.cause,
-          })
-          return { _tag: "processed" as const, workItem: failed }
+        return result
+      })
+
+      const abandon = Effect.fn("WorkItemLifecycle.abandon")(function* (
+        workItemId: string,
+      ) {
+        const workItem = yield* loadWorkItemRow(workItemId)
+        if (!workItem) {
+          return yield* new WorkItemNotFoundError({ workItemId })
         }
 
-        const revalidation = yield* revalidateIssue(
-          workItem.repository_id,
-          workItem.github_issue_number,
+        if (isTerminalWorkItemState(workItem.state)) {
+          return yield* new WorkItemTerminalError({
+            workItemId,
+            state: workItem.state,
+          })
+        }
+
+        const now = Date.now()
+
+        yield* sql
+          .withTransaction(
+            Effect.gen(function* () {
+              const abandonedRows = (yield* sql.unsafe(
+                `UPDATE work_item
+                 SET state = 'abandoned',
+                     state_ready_at = ?,
+                     updated_at = ?
+                 WHERE id = ?
+                   AND state NOT IN ('complete', 'failed', 'abandoned')
+                   AND NOT EXISTS (
+                     SELECT 1 FROM step_run
+                     WHERE step_run.work_item_id = work_item.id
+                       AND step_run.status = 'running'
+                   )
+                 RETURNING id`,
+                [now, now, workItemId],
+              )) as readonly { readonly id: string }[]
+
+              if (!abandonedRows[0]) {
+                const current = yield* loadWorkItemRow(workItemId)
+                if (!current) {
+                  return yield* new WorkItemNotFoundError({ workItemId })
+                }
+                if (isTerminalWorkItemState(current.state)) {
+                  return yield* new WorkItemTerminalError({
+                    workItemId,
+                    state: current.state,
+                  })
+                }
+
+                const runningRows = (yield* sql.unsafe(
+                  `SELECT id FROM step_run
+                   WHERE work_item_id = ? AND status = 'running'
+                   ORDER BY queued_at DESC, id DESC
+                   LIMIT 1`,
+                  [workItemId],
+                )) as readonly { readonly id: string }[]
+                return yield* new WorkItemHasRunningStepError({
+                  workItemId,
+                  stepRunId: runningRows[0]?.id ?? "unknown",
+                })
+              }
+
+              const cancelledRows = (yield* sql.unsafe(
+                `UPDATE step_run
+                 SET status = 'cancelled',
+                     finished_at = ?,
+                     reason_code = ?,
+                     reason_message = ?,
+                     updated_at = ?
+                 WHERE work_item_id = ? AND status = 'queued'
+                 RETURNING queue_job_id`,
+                [
+                  now,
+                  STEP_RUN_REASON.abandoned,
+                  "Work Item was abandoned before the Step Run started",
+                  now,
+                  workItemId,
+                ],
+              )) as readonly { readonly queue_job_id: string | null }[]
+
+              for (const cancelled of cancelledRows) {
+                if (cancelled.queue_job_id !== null) {
+                  yield* queue
+                    .acknowledge(cancelled.queue_job_id)
+                    .pipe(
+                      Effect.catchTag("JobNotFoundError", () => Effect.void),
+                    )
+                }
+              }
+            }),
+          )
+          .pipe(
+            Effect.catch((error): Effect.Effect<never, AbandonError> => {
+              if (
+                error instanceof WorkItemNotFoundError ||
+                error instanceof WorkItemTerminalError ||
+                error instanceof WorkItemHasRunningStepError
+              ) {
+                return Effect.fail(error)
+              }
+              if (error instanceof WorkItemLifecycleDatabaseError) {
+                return Effect.fail(error)
+              }
+              if (
+                typeof error === "object" &&
+                error !== null &&
+                "_tag" in error &&
+                ((error as { _tag: string })._tag === "AcknowledgeError" ||
+                  (error as { _tag: string })._tag === "JobNotFoundError")
+              ) {
+                return Effect.fail(error as AcknowledgeError | JobNotFoundError)
+              }
+              if (
+                typeof error === "object" &&
+                error !== null &&
+                "_tag" in error &&
+                (error as { _tag: string })._tag === "SqlError"
+              ) {
+                return Effect.fail(toDatabaseError(error as SqlError))
+              }
+              return Effect.fail(
+                new WorkItemLifecycleDatabaseError({
+                  message: `Unexpected transaction failure: ${String(error)}`,
+                  cause: error,
+                }),
+              )
+            }),
+          )
+
+        return yield* getWorkItem(workItemId).pipe(
+          Effect.catchTag(
+            "WorkItemNotFoundError",
+            (error) =>
+              new WorkItemLifecycleDatabaseError({
+                message: `Work Item missing after abandon: ${error.workItemId}`,
+                cause: error,
+              }),
+          ),
         )
-
-        const completed = yield* completeSuccessfulStep({
-          stepRun: afterStart,
-          workItem,
-          output: handlerExit.value,
-          revalidation,
-        })
-
-        return { _tag: "processed" as const, workItem: completed }
       })
 
       const retry = Effect.fn("WorkItemLifecycle.retry")(function* (
@@ -1232,6 +1506,7 @@ export const makeWorkItemLifecycleLive = (
         implementNow,
         runStep,
         retry,
+        abandon,
         getWorkItem,
         listWorkItemsForIssue,
       })

--- a/packages/work-item-lifecycle/test/work-item-lifecycle.spec.ts
+++ b/packages/work-item-lifecycle/test/work-item-lifecycle.spec.ts
@@ -1,4 +1,13 @@
-import { Cause, Duration, Effect, Layer, Option, Result } from "effect"
+import {
+  Cause,
+  Deferred,
+  Duration,
+  Effect,
+  Fiber,
+  Layer,
+  Option,
+  Result,
+} from "effect"
 import { SqlClient } from "effect/unstable/sql"
 import { DatabaseTest } from "@ready-for-agent/db/test"
 import { DbService, DbServiceLive } from "@ready-for-agent/db-service"
@@ -23,6 +32,7 @@ import {
   STEP_RUN_REASON,
   UnfinishedWorkItemExistsError,
   WORK_ITEM_LIFECYCLE_QUEUE,
+  WorkItemHasRunningStepError,
   WorkItemLifecycle,
   WorkItemLifecycleLive,
   WorkItemNotFoundError,
@@ -421,7 +431,6 @@ describe("WorkItemLifecycle", () => {
       runTest(
         Effect.gen(function* () {
           const lifecycle = yield* WorkItemLifecycle
-          const sql = yield* SqlClient.SqlClient
           const { repository, issue } = yield* seedActionableIssue
 
           const first = yield* lifecycle.implementNow(
@@ -429,11 +438,7 @@ describe("WorkItemLifecycle", () => {
             issue.githubIssueNumber,
           )
 
-          // Terminalize via SQL so a second Implement Now is allowed; abandon is a later ticket.
-          yield* sql.unsafe(
-            `UPDATE work_item SET state = 'abandoned', updated_at = ? WHERE id = ?`,
-            [Date.now(), first.id],
-          )
+          yield* lifecycle.abandon(first.id)
           yield* Effect.sleep("2 millis")
 
           const second = yield* lifecycle.implementNow(
@@ -1480,6 +1485,402 @@ describe("WorkItemLifecycle", () => {
           expect(
             final.stepRuns.filter((run) => run.status === "failed"),
           ).toHaveLength(1)
+        }),
+      )
+    })
+  })
+
+  describe("delivery safety and interruption", () => {
+    it("acknowledges a stale delivery without invoking a handler", () => {
+      let createCalls = 0
+      const steps: LifecycleStepsShape = {
+        ...successfulSteps,
+        createWorktree: () => {
+          createCalls += 1
+          return Effect.succeed("/tmp/worktrees/stale-delivery")
+        },
+      }
+
+      return runWithSteps(
+        steps,
+        Effect.gen(function* () {
+          const lifecycle = yield* WorkItemLifecycle
+          const queue = yield* QueueService
+          const { repository, issue } = yield* seedActionableIssue
+
+          const created = yield* lifecycle.implementNow(
+            repository.id,
+            issue.githubIssueNumber,
+          )
+          const stepRunId = created.stepRuns[0]!.id
+          const jobId = created.stepRuns[0]!.queueJobId!
+
+          const first = yield* lifecycle.runStep(stepRunId)
+          expect(first._tag).toBe("processed")
+          expect(createCalls).toBe(1)
+
+          const second = yield* lifecycle.runStep(stepRunId)
+          expect(second).toEqual({ _tag: "noop" })
+          expect(createCalls).toBe(1)
+
+          const remaining = yield* queue.rawClaim(WORK_ITEM_LIFECYCLE_QUEUE)
+          expect(Option.isSome(remaining)).toBe(true)
+          if (Option.isSome(remaining)) {
+            expect(remaining.value.jobId).not.toBe(jobId)
+          }
+
+          const final = yield* lifecycle.getWorkItem(created.id)
+          expect(final.state).toBe("install_dependencies")
+          expect(
+            final.stepRuns.filter((run) => run.step === "create_worktree"),
+          ).toHaveLength(1)
+        }),
+      )
+    })
+
+    it("marks a Running Step Run Interrupted on lease-expiry redelivery without rerunning the handler", () => {
+      let createCalls = 0
+      const steps: LifecycleStepsShape = {
+        ...successfulSteps,
+        createWorktree: () => {
+          createCalls += 1
+          return Effect.succeed("/tmp/worktrees/should-not-rerun")
+        },
+      }
+
+      return runWithSteps(
+        steps,
+        Effect.gen(function* () {
+          const lifecycle = yield* WorkItemLifecycle
+          const queue = yield* QueueService
+          const sql = yield* SqlClient.SqlClient
+          const { repository, issue } = yield* seedActionableIssue
+
+          const created = yield* lifecycle.implementNow(
+            repository.id,
+            issue.githubIssueNumber,
+          )
+          const stepRunId = created.stepRuns[0]!.id
+          const jobId = created.stepRuns[0]!.queueJobId!
+          const now = Date.now()
+          const startedAt =
+            now -
+            Duration.toMillis(lifecycle.maxDurations.create_worktree) -
+            1_000
+
+          yield* sql.unsafe(
+            `UPDATE step_run
+             SET status = 'running', started_at = ?, updated_at = ?
+             WHERE id = ?`,
+            [startedAt, now, stepRunId],
+          )
+          yield* sql.unsafe(
+            `UPDATE job_queue
+             SET locked_until = ?, updated_at = ?
+             WHERE id = ?`,
+            [now - 1, now, jobId],
+          )
+
+          const claimed = yield* queue.rawClaim(WORK_ITEM_LIFECYCLE_QUEUE)
+          expect(Option.isSome(claimed)).toBe(true)
+          if (Option.isNone(claimed)) {
+            return yield* Effect.die("expected redelivered lifecycle job")
+          }
+          expect(claimed.value.jobId).toBe(jobId)
+
+          const result = yield* lifecycle.runStep(stepRunId)
+          expect(result._tag).toBe("noop")
+          expect(createCalls).toBe(0)
+
+          const final = yield* lifecycle.getWorkItem(created.id)
+          expect(final.state).toBe("create_worktree")
+          const run = final.stepRuns[0]!
+          expect(run.status).toBe("interrupted")
+          expect(run.reasonCode).toBe(STEP_RUN_REASON.interrupted)
+          expect(run.reasonMessage).toBeTruthy()
+          expect(run.startedAt).toBeInstanceOf(Date)
+          expect(run.finishedAt).toBeInstanceOf(Date)
+
+          const remaining = yield* queue.rawClaim(WORK_ITEM_LIFECYCLE_QUEUE)
+          expect(Option.isNone(remaining)).toBe(true)
+
+          const retried = yield* lifecycle.retry(created.id)
+          expect(retried.stepRuns).toHaveLength(2)
+          expect(retried.stepRuns[0]!.status).toBe("interrupted")
+          expect(retried.stepRuns[1]!.status).toBe("queued")
+        }),
+      )
+    })
+
+    it("records Interrupted when the handler is fiber-interrupted before an outcome is established", () => {
+      const hangForever: LifecycleStepsShape = {
+        ...successfulSteps,
+        createWorktree: () =>
+          Effect.gen(function* () {
+            yield* Effect.sleep("10 seconds")
+            return "/tmp/worktrees/never"
+          }),
+      }
+
+      return runWithSteps(
+        hangForever,
+        Effect.gen(function* () {
+          const lifecycle = yield* WorkItemLifecycle
+          const queue = yield* QueueService
+          const { repository, issue } = yield* seedActionableIssue
+
+          const created = yield* lifecycle.implementNow(
+            repository.id,
+            issue.githubIssueNumber,
+          )
+          const stepRunId = created.stepRuns[0]!.id
+
+          const fiber = yield* Effect.forkChild(lifecycle.runStep(stepRunId))
+          yield* Effect.sleep("30 millis")
+          yield* Fiber.interrupt(fiber)
+
+          const final = yield* lifecycle.getWorkItem(created.id)
+          expect(final.state).toBe("create_worktree")
+          const run = final.stepRuns[0]!
+          expect(run.status).toBe("interrupted")
+          expect(run.reasonCode).toBe(STEP_RUN_REASON.interrupted)
+          expect(run.finishedAt).toBeInstanceOf(Date)
+
+          const remaining = yield* queue.rawClaim(WORK_ITEM_LIFECYCLE_QUEUE)
+          expect(Option.isNone(remaining)).toBe(true)
+
+          const retried = yield* lifecycle.retry(created.id)
+          expect(retried.stepRuns[1]!.status).toBe("queued")
+        }),
+      )
+    })
+  })
+
+  describe("abandon", () => {
+    it("abandons a Queued Work Item, cancels the Step Run, and removes its queue job", () =>
+      runTest(
+        Effect.gen(function* () {
+          const lifecycle = yield* WorkItemLifecycle
+          const queue = yield* QueueService
+          const { repository, issue } = yield* seedActionableIssue
+
+          const created = yield* lifecycle.implementNow(
+            repository.id,
+            issue.githubIssueNumber,
+          )
+
+          const abandoned = yield* lifecycle.abandon(created.id)
+          expect(abandoned.state).toBe("abandoned")
+          expect(abandoned.stepRuns).toHaveLength(1)
+          const run = abandoned.stepRuns[0]!
+          expect(run.status).toBe("cancelled")
+          expect(run.startedAt).toBeNull()
+          expect(run.finishedAt).toBeInstanceOf(Date)
+          expect(run.reasonCode).toBe(STEP_RUN_REASON.abandoned)
+          expect(run.reasonMessage).toBeTruthy()
+
+          const remaining = yield* queue.rawClaim(WORK_ITEM_LIFECYCLE_QUEUE)
+          expect(Option.isNone(remaining)).toBe(true)
+
+          const late = yield* lifecycle.runStep(run.id)
+          expect(late).toEqual({ _tag: "noop" })
+
+          const next = yield* lifecycle.implementNow(
+            repository.id,
+            issue.githubIssueNumber,
+          )
+          expect(next.id).not.toBe(created.id)
+          expect(next.state).toBe("create_worktree")
+
+          const listed = yield* lifecycle.listWorkItemsForIssue(
+            repository.id,
+            issue.githubIssueNumber,
+          )
+          expect(listed.map((item) => item.id)).toEqual([created.id, next.id])
+          expect(listed[0]!.state).toBe("abandoned")
+        }),
+      ))
+
+    it("abandons after Failed or Interrupted runs while preserving Step Run history", () => {
+      const steps: LifecycleStepsShape = {
+        ...successfulSteps,
+        createWorktree: () => Effect.fail(new Error("fail then abandon")),
+      }
+
+      return runWithSteps(
+        steps,
+        Effect.gen(function* () {
+          const lifecycle = yield* WorkItemLifecycle
+          const queue = yield* QueueService
+          const sql = yield* SqlClient.SqlClient
+          const { repository, issue } = yield* seedActionableIssue
+
+          const created = yield* lifecycle.implementNow(
+            repository.id,
+            issue.githubIssueNumber,
+          )
+          const job = yield* queue.rawClaim(WORK_ITEM_LIFECYCLE_QUEUE)
+          expect(Option.isSome(job)).toBe(true)
+          if (Option.isNone(job)) {
+            return yield* Effect.die("expected job")
+          }
+          yield* lifecycle.runStep(
+            (job.value.payload as { stepRunId: string }).stepRunId,
+          )
+
+          const afterFail = yield* lifecycle.getWorkItem(created.id)
+          expect(afterFail.stepRuns[0]!.status).toBe("failed")
+
+          const abandoned = yield* lifecycle.abandon(created.id)
+          expect(abandoned.state).toBe("abandoned")
+          expect(abandoned.stepRuns).toHaveLength(1)
+          expect(abandoned.stepRuns[0]!.status).toBe("failed")
+          expect(abandoned.stepRuns[0]!.reasonMessage).toContain(
+            "fail then abandon",
+          )
+
+          const second = yield* lifecycle.implementNow(
+            repository.id,
+            issue.githubIssueNumber,
+          )
+          const now = Date.now()
+          yield* sql.unsafe(
+            `UPDATE step_run
+             SET status = 'interrupted',
+                 started_at = ?,
+                 finished_at = ?,
+                 reason_code = ?,
+                 reason_message = 'worker lost',
+                 updated_at = ?
+             WHERE id = ?`,
+            [
+              now,
+              now,
+              STEP_RUN_REASON.interrupted,
+              now,
+              second.stepRuns[0]!.id,
+            ],
+          )
+          if (second.stepRuns[0]!.queueJobId) {
+            yield* queue
+              .acknowledge(second.stepRuns[0]!.queueJobId)
+              .pipe(Effect.catch(() => Effect.void))
+          }
+
+          const abandonedInterrupted = yield* lifecycle.abandon(second.id)
+          expect(abandonedInterrupted.state).toBe("abandoned")
+          expect(abandonedInterrupted.stepRuns[0]!.status).toBe("interrupted")
+
+          const third = yield* lifecycle.implementNow(
+            repository.id,
+            issue.githubIssueNumber,
+          )
+          expect(third.id).not.toBe(created.id)
+          expect(third.id).not.toBe(second.id)
+
+          const listed = yield* lifecycle.listWorkItemsForIssue(
+            repository.id,
+            issue.githubIssueNumber,
+          )
+          expect(listed).toHaveLength(3)
+          expect(listed.map((item) => item.state)).toEqual([
+            "abandoned",
+            "abandoned",
+            "create_worktree",
+          ])
+        }),
+      )
+    })
+
+    it("rejects abandon for terminal Work Items and while a Step Run is Running", () =>
+      runTest(
+        Effect.gen(function* () {
+          const lifecycle = yield* WorkItemLifecycle
+          const sql = yield* SqlClient.SqlClient
+          const { repository, issue } = yield* seedActionableIssue
+
+          const created = yield* lifecycle.implementNow(
+            repository.id,
+            issue.githubIssueNumber,
+          )
+
+          yield* sql.unsafe(
+            `UPDATE step_run
+             SET status = 'running', started_at = ?, updated_at = ?
+             WHERE id = ?`,
+            [Date.now(), Date.now(), created.stepRuns[0]!.id],
+          )
+
+          const runningError = yield* Effect.flip(lifecycle.abandon(created.id))
+          expect(runningError).toBeInstanceOf(WorkItemHasRunningStepError)
+          if (runningError instanceof WorkItemHasRunningStepError) {
+            expect(runningError.workItemId).toBe(created.id)
+            expect(runningError.stepRunId).toBe(created.stepRuns[0]!.id)
+          }
+
+          yield* sql.unsafe(
+            `UPDATE step_run
+             SET status = 'failed', finished_at = ?, updated_at = ?
+             WHERE id = ?`,
+            [Date.now(), Date.now(), created.stepRuns[0]!.id],
+          )
+          const abandoned = yield* lifecycle.abandon(created.id)
+          expect(abandoned.state).toBe("abandoned")
+
+          const terminalError = yield* Effect.flip(
+            lifecycle.abandon(created.id),
+          )
+          expect(terminalError).toBeInstanceOf(WorkItemTerminalError)
+          if (terminalError instanceof WorkItemTerminalError) {
+            expect(terminalError.state).toBe("abandoned")
+          }
+
+          yield* sql.unsafe(
+            `UPDATE work_item SET state = 'complete', updated_at = ? WHERE id = ?`,
+            [Date.now(), created.id],
+          )
+          const completeError = yield* Effect.flip(
+            lifecycle.abandon(created.id),
+          )
+          expect(completeError).toBeInstanceOf(WorkItemTerminalError)
+        }),
+      ))
+
+    it("cannot abandon while a concurrently started handler is Running", async () => {
+      const started = await Effect.runPromise(Deferred.make<void>())
+      const release = await Effect.runPromise(Deferred.make<void>())
+      const steps: LifecycleStepsShape = {
+        ...successfulSteps,
+        createWorktree: () =>
+          Deferred.succeed(started, undefined).pipe(
+            Effect.andThen(Deferred.await(release)),
+            Effect.as("/tmp/worktrees/concurrent-abandon"),
+          ),
+      }
+
+      return runWithSteps(
+        steps,
+        Effect.gen(function* () {
+          const lifecycle = yield* WorkItemLifecycle
+          const { repository, issue } = yield* seedActionableIssue
+          const created = yield* lifecycle.implementNow(
+            repository.id,
+            issue.githubIssueNumber,
+          )
+
+          const running = yield* Effect.forkChild(
+            lifecycle.runStep(created.stepRuns[0]!.id),
+          )
+          yield* Deferred.await(started)
+
+          const error = yield* Effect.flip(lifecycle.abandon(created.id))
+          expect(error).toBeInstanceOf(WorkItemHasRunningStepError)
+          expect((yield* lifecycle.getWorkItem(created.id)).state).toBe(
+            "create_worktree",
+          )
+
+          yield* Deferred.succeed(release, undefined)
+          yield* Fiber.join(running)
         }),
       )
     })


### PR DESCRIPTION
## Why

Work Item execution needs to stay correct under at-least-once queue delivery and explicit operator abandonment. Duplicate or expired deliveries must not re-run Effects, uncertain worker loss must become an Interrupted attempt that requires Retry, and operators must be able to abandon non-running work without leaving executable queue jobs behind.

## What Changed

- Extend `WorkItemLifecycle.runStep` so stale/duplicate deliveries are acknowledged as no-ops, concurrent in-lease starts cannot re-run handlers, and lease-expiry redelivery of a still-Running Step Run marks it Interrupted without re-executing the handler.
- Record fiber interruption as Interrupted while keeping configured timeouts as Failed with a timeout reason.
- Add `abandon` for non-terminal Work Items with no Running Step Run: cancel any Queued Step Run, remove its queue job, move the Work Item to Abandoned, preserve history after Failed/Interrupted, and release the one-unfinished constraint so a later Implement Now can proceed.
- Reject abandon of terminal Work Items and concurrent Running execution with stable tagged domain errors, including an atomic transaction path that closes the abandon/start race.
- Cover stale delivery, lease-expiry recovery, graceful interruption, queued cancellation, abandonment after failure, and concurrent Running rejection with integration tests.

Closes #72.