### PR TITLE
feat(work-item-lifecycle): create Work Item worktrees

### DIFF
--- a/apps/harness/package.json
+++ b/apps/harness/package.json
@@ -22,6 +22,7 @@
     "@ready-for-agent/opencode": "workspace:*",
     "@ready-for-agent/queue-service": "workspace:*",
     "@ready-for-agent/sqlite-queue-service": "workspace:*",
+    "@ready-for-agent/work-item-lifecycle": "workspace:*",
     "@tanstack/react-query": "^5.90.0",
     "@tanstack/react-query-devtools": "^5.90.0",
     "@tanstack/react-router": "^1.170.17",

--- a/apps/harness/src/server/application.server.ts
+++ b/apps/harness/src/server/application.server.ts
@@ -15,6 +15,10 @@ import {
 } from "@ready-for-agent/keymaxxer-service"
 import { OpencodeLive } from "@ready-for-agent/opencode"
 import { SqliteQueueServiceLive } from "@ready-for-agent/sqlite-queue-service"
+import {
+  LifecycleStepsLive,
+  WorkItemLifecycleLive,
+} from "@ready-for-agent/work-item-lifecycle"
 import type { ApplicationRequestContext } from "../server-context.js"
 import { JobWorkerLive } from "./job-worker.js"
 import { keymaxxerGitHubLayer } from "./keymaxxer-github-layer.js"
@@ -55,14 +59,21 @@ export const createApplication = async (
   const queueLayer = SqliteQueueServiceLive.pipe(
     Layer.provideMerge(databaseLayer),
   )
-  const workerLayer = JobWorkerLive.pipe(
-    Layer.provideMerge(queueLayer),
-    Layer.provideMerge(reconcilerLayer),
-  )
   const opencodePlatformLayer = BunChildProcessSpawner.layer.pipe(
     Layer.provideMerge(Layer.merge(BunFileSystem.layer, BunPath.layer)),
   )
   const opencodeLayer = OpencodeLive.pipe(Layer.provide(opencodePlatformLayer))
+  const lifecycleLayer = WorkItemLifecycleLive.pipe(
+    Layer.provideMerge(LifecycleStepsLive),
+    Layer.provideMerge(databaseLayer),
+    Layer.provideMerge(queueLayer),
+    Layer.provide(opencodePlatformLayer),
+  )
+  const workerLayer = JobWorkerLive.pipe(
+    Layer.provideMerge(queueLayer),
+    Layer.provideMerge(reconcilerLayer),
+    Layer.provideMerge(lifecycleLayer),
+  )
   const appLayer =
     options.startWorker === false
       ? Layer.mergeAll(
@@ -70,6 +81,7 @@ export const createApplication = async (
           queueLayer,
           keymaxxerLayer,
           opencodeLayer,
+          lifecycleLayer,
         )
       : Layer.mergeAll(
           reconcilerLayer,
@@ -77,6 +89,7 @@ export const createApplication = async (
           queueLayer,
           keymaxxerLayer,
           opencodeLayer,
+          lifecycleLayer,
         )
   const runtime = ManagedRuntime.make(appLayer)
 

--- a/apps/harness/src/server/job-worker.ts
+++ b/apps/harness/src/server/job-worker.ts
@@ -7,6 +7,10 @@ import {
 } from "@ready-for-agent/db-service"
 import { IssueReconciler } from "@ready-for-agent/issue-reconciler"
 import { QueueService } from "@ready-for-agent/queue-service"
+import {
+  WorkItemLifecycle,
+  WorkItemStepJob,
+} from "@ready-for-agent/work-item-lifecycle"
 
 export const JOBS_QUEUE = "jobs"
 export const JOB_VISIBILITY_TIMEOUT = Duration.minutes(5)
@@ -17,7 +21,7 @@ const RefreshRepositoryJob = Schema.TaggedStruct("refresh-repository", {
   repositoryId: RepositoryId,
 })
 
-const JobPayload = Schema.Union([RefreshRepositoryJob])
+const JobPayload = Schema.Union([RefreshRepositoryJob, WorkItemStepJob])
 
 export const enqueueRefreshRepositoryJob = (repositoryId: RepositoryId) =>
   Effect.gen(function* () {
@@ -75,19 +79,41 @@ export const runJobWorker = (options: JobWorkerOptions = {}) =>
       if (Option.isNone(claimed)) return true
 
       const job = claimed.value
-      const result = yield* Effect.result(
-        refreshRepository(job.payload.repositoryId),
-      )
+      switch (job.payload._tag) {
+        case "refresh-repository": {
+          const result = yield* Effect.result(
+            refreshRepository(job.payload.repositoryId),
+          )
 
-      if (result._tag === "Failure") {
-        yield* Effect.logError("Refresh Job failed", {
-          jobId: job.jobId,
-          repositoryId: job.payload.repositoryId,
-          error: result.failure,
-        })
-        yield* queue.fail(job.jobId, { retryable: false })
-      } else {
-        yield* queue.acknowledge(job.jobId)
+          if (result._tag === "Failure") {
+            yield* Effect.logError("Refresh Job failed", {
+              jobId: job.jobId,
+              repositoryId: job.payload.repositoryId,
+              error: result.failure,
+            })
+            yield* queue.fail(job.jobId, { retryable: false })
+          } else {
+            yield* queue.acknowledge(job.jobId)
+          }
+          break
+        }
+        case "work-item-step": {
+          const lifecycle = yield* WorkItemLifecycle
+          const result = yield* Effect.result(
+            lifecycle.runStep(job.payload.stepRunId),
+          )
+
+          if (result._tag === "Failure") {
+            yield* Effect.logError("Work Item Lifecycle Job failed", {
+              jobId: job.jobId,
+              stepRunId: job.payload.stepRunId,
+              error: result.failure,
+            })
+          } else if (result.success._tag === "noop") {
+            yield* queue.acknowledge(job.jobId)
+          }
+          break
+        }
       }
 
       return false

--- a/apps/harness/test/job-worker.test.ts
+++ b/apps/harness/test/job-worker.test.ts
@@ -35,6 +35,11 @@ import {
   makeJobId,
 } from "@ready-for-agent/queue-service"
 import {
+  WorkItemLifecycle,
+  WorkItemStepJob,
+  makeStepRunId,
+} from "@ready-for-agent/work-item-lifecycle"
+import {
   JOBS_QUEUE,
   JOB_RECOVERY_RETRY_LIMIT,
   JOB_VISIBILITY_TIMEOUT,
@@ -98,28 +103,40 @@ const queueLayer = (
   onAcknowledge: (jobId: string) => Effect.Effect<unknown> = () => Effect.void,
   onFail: (jobId: string) => Effect.Effect<unknown> = () => Effect.void,
   onClaim?: () => Effect.Effect<Option.Option<RawJob>, ClaimError>,
+  runStep: (
+    stepRunId: string,
+  ) => Effect.Effect<{ readonly _tag: "noop" }> = () =>
+    Effect.succeed({ _tag: "noop" as const }),
 ) =>
-  Layer.succeed(QueueService, {
-    queueInTransaction: true,
-    enqueue: unused,
-    enqueueWithDelay: unused,
-    rawClaim: (_queue, visibilityTimeout) =>
-      Effect.gen(function* () {
-        expect(Duration.toMillis(visibilityTimeout ?? Duration.zero)).toBe(
-          Duration.toMillis(JOB_VISIBILITY_TIMEOUT),
-        )
-        if (onClaim !== undefined) return yield* onClaim()
-        return Option.fromNullishOr(jobs.shift())
-      }),
-    acknowledge: (jobId) => onAcknowledge(jobId).pipe(Effect.asVoid),
-    fail: (jobId, options) =>
-      Effect.gen(function* () {
-        expect(options?.retryable).toBe(false)
-        yield* onFail(jobId)
-      }),
-    extendVisibility: unused,
-    getStats: unused,
-  } satisfies QueueServiceShape)
+  Layer.merge(
+    Layer.succeed(QueueService, {
+      queueInTransaction: true,
+      enqueue: unused,
+      enqueueWithDelay: unused,
+      rawClaim: (_queue, visibilityTimeout) =>
+        Effect.gen(function* () {
+          expect(Duration.toMillis(visibilityTimeout ?? Duration.zero)).toBe(
+            Duration.toMillis(JOB_VISIBILITY_TIMEOUT),
+          )
+          if (onClaim !== undefined) return yield* onClaim()
+          return Option.fromNullishOr(jobs.shift())
+        }),
+      acknowledge: (jobId) => onAcknowledge(jobId).pipe(Effect.asVoid),
+      fail: (jobId, options) =>
+        Effect.gen(function* () {
+          expect(options?.retryable).toBe(false)
+          yield* onFail(jobId)
+        }),
+      extendVisibility: unused,
+      getStats: unused,
+    } satisfies QueueServiceShape),
+    Layer.succeed(WorkItemLifecycle, {
+      implementNow: unused,
+      runStep,
+      getWorkItem: unused,
+      listWorkItemsForIssue: unused,
+    }),
+  )
 
 const runScoped = <A, E, R>(
   effect: Effect.Effect<A, E, R>,
@@ -168,6 +185,40 @@ describe("Job worker", () => {
       payload: refreshPayload,
       retryLimit: JOB_RECOVERY_RETRY_LIMIT,
     })
+  })
+
+  test("dispatches a Work Item Lifecycle Job and acknowledges a stale no-op", async () => {
+    const stepRunId = makeStepRunId()
+    const payload = WorkItemStepJob.make({ stepRunId })
+    const job = rawJob(payload)
+    const acknowledged = await Effect.runPromise(Deferred.make<string>())
+    const dispatched = await Effect.runPromise(Deferred.make<string>())
+
+    await runScoped(
+      Effect.gen(function* () {
+        yield* runJobWorker({ idlePollInterval: Duration.zero }).pipe(
+          Effect.forkScoped({ startImmediately: true }),
+        )
+        expect(yield* Deferred.await(dispatched)).toBe(stepRunId)
+        expect(yield* Deferred.await(acknowledged)).toBe(job.jobId)
+      }),
+      Layer.merge(
+        queueLayer(
+          [job],
+          (jobId) => Deferred.succeed(acknowledged, jobId),
+          undefined,
+          undefined,
+          (receivedStepRunId) =>
+            Deferred.succeed(dispatched, receivedStepRunId).pipe(
+              Effect.as({ _tag: "noop" as const }),
+            ),
+        ),
+        Layer.merge(
+          dbLayer(),
+          Layer.succeed(IssueReconciler, { reconcile: unused }),
+        ),
+      ),
+    )
   })
 
   test("reconciles the Issue store and acknowledges after success", async () => {

--- a/apps/harness/tsconfig.app.json
+++ b/apps/harness/tsconfig.app.json
@@ -17,6 +17,15 @@
   "include": ["server.ts", "src/**/*.ts", "src/**/*.tsx"],
   "references": [
     {
+      "path": "../../packages/work-item-lifecycle/tsconfig.lib.json"
+    },
+    {
+      "path": "../../packages/sqlite-queue-service/tsconfig.lib.json"
+    },
+    {
+      "path": "../../packages/queue-service/tsconfig.lib.json"
+    },
+    {
       "path": "../../packages/opencode/tsconfig.lib.json"
     },
     {
@@ -39,12 +48,6 @@
     },
     {
       "path": "../../packages/db/tsconfig.lib.json"
-    },
-    {
-      "path": "../../packages/queue-service/tsconfig.lib.json"
-    },
-    {
-      "path": "../../packages/sqlite-queue-service/tsconfig.lib.json"
     }
   ]
 }

--- a/bun.lock
+++ b/bun.lock
@@ -48,6 +48,7 @@
         "@ready-for-agent/opencode": "workspace:*",
         "@ready-for-agent/queue-service": "workspace:*",
         "@ready-for-agent/sqlite-queue-service": "workspace:*",
+        "@ready-for-agent/work-item-lifecycle": "workspace:*",
         "@tanstack/react-query": "^5.90.0",
         "@tanstack/react-query-devtools": "^5.90.0",
         "@tanstack/react-router": "^1.170.17",
@@ -241,6 +242,7 @@
         "ulidx": "^2.4.1",
       },
       "devDependencies": {
+        "@effect/platform-bun": "^4.0.0-beta.97",
         "@ready-for-agent/db": "workspace:*",
         "@ready-for-agent/sqlite-queue-service": "workspace:*",
         "@types/bun": "^1.3.0",

--- a/packages/work-item-lifecycle/package.json
+++ b/packages/work-item-lifecycle/package.json
@@ -23,6 +23,7 @@
     "ulidx": "^2.4.1"
   },
   "devDependencies": {
+    "@effect/platform-bun": "^4.0.0-beta.97",
     "@ready-for-agent/db": "workspace:*",
     "@ready-for-agent/sqlite-queue-service": "workspace:*",
     "@types/bun": "^1.3.0"

--- a/packages/work-item-lifecycle/src/index.ts
+++ b/packages/work-item-lifecycle/src/index.ts
@@ -1,4 +1,7 @@
+export * from "./lib/create-worktree.js"
 export * from "./lib/errors.js"
 export * from "./lib/lifecycle-steps.js"
+export * from "./lib/lifecycle-steps-live.js"
 export * from "./lib/types.js"
 export * from "./lib/work-item-lifecycle.js"
+export * from "./lib/worktree-names.js"

--- a/packages/work-item-lifecycle/src/lib/create-worktree-errors.ts
+++ b/packages/work-item-lifecycle/src/lib/create-worktree-errors.ts
@@ -1,0 +1,29 @@
+import { Data } from "effect"
+
+export class CreateWorktreeRepositoryNotFoundError extends Data.TaggedError(
+  "CreateWorktreeRepositoryNotFoundError",
+)<{
+  readonly repositoryId: string
+}> {}
+
+export class WorktreeConflictError extends Data.TaggedError(
+  "WorktreeConflictError",
+)<{
+  readonly message: string
+  readonly branchName: string
+  readonly worktreePath: string
+}> {}
+
+export class GitCommandError extends Data.TaggedError("GitCommandError")<{
+  readonly message: string
+  readonly command: string
+  readonly args: readonly string[]
+  readonly cwd?: string
+  readonly exitCode: number
+  readonly stderr: string
+}> {}
+
+export type CreateWorktreeError =
+  | CreateWorktreeRepositoryNotFoundError
+  | WorktreeConflictError
+  | GitCommandError

--- a/packages/work-item-lifecycle/src/lib/create-worktree.ts
+++ b/packages/work-item-lifecycle/src/lib/create-worktree.ts
@@ -1,0 +1,247 @@
+import { Effect, FileSystem, Path } from "effect"
+import type { RepositoryRecord } from "@ready-for-agent/db-service"
+import { DbService } from "@ready-for-agent/db-service"
+import {
+  CreateWorktreeRepositoryNotFoundError,
+  GitCommandError,
+  WorktreeConflictError,
+} from "./create-worktree-errors.js"
+import { type GitRepository, gitExitCode, runGit } from "./git.js"
+import type { LifecycleStepContext } from "./lifecycle-steps.js"
+import {
+  workItemBranchName,
+  workItemWorktreePath,
+  worktreeParentPath,
+} from "./worktree-names.js"
+
+const resolveRepository = (repositoryId: string) =>
+  Effect.gen(function* () {
+    const db = yield* DbService
+    const repositories = yield* db.listRepositories
+    const repository = repositories.find(({ id }) => id === repositoryId)
+    if (repository === undefined) {
+      return yield* new CreateWorktreeRepositoryNotFoundError({ repositoryId })
+    }
+    return repository
+  })
+
+const asGitRepository = (repository: RepositoryRecord): GitRepository => ({
+  localPath: repository.localPath,
+  isBare: repository.isBare,
+})
+
+const parseDefaultBranchName = (lsRemoteOutput: string): string | null => {
+  const match = lsRemoteOutput.match(/^ref: refs\/heads\/([^\t\n]+)\tHEAD$/m)
+  const name = match?.[1]?.trim()
+  return name === undefined || name === "" ? null : name
+}
+
+const resolveStartPoint = (repository: GitRepository) =>
+  Effect.gen(function* () {
+    const remoteHead = yield* runGit(repository, [
+      "ls-remote",
+      "--symref",
+      "origin",
+      "HEAD",
+    ]).pipe(Effect.catchTag("GitCommandError", () => Effect.succeed("")))
+
+    const defaultBranchName = parseDefaultBranchName(remoteHead)
+    if (defaultBranchName !== null) {
+      const defaultBranchRef = `refs/remotes/origin/${defaultBranchName}`
+      yield* runGit(repository, [
+        "fetch",
+        "origin",
+        `+refs/heads/${defaultBranchName}:${defaultBranchRef}`,
+      ]).pipe(Effect.catchTag("GitCommandError", () => Effect.void))
+
+      const remoteRefCode = yield* gitExitCode(repository, [
+        "show-ref",
+        "--verify",
+        defaultBranchRef,
+      ])
+      if (remoteRefCode === 0) {
+        return defaultBranchRef
+      }
+    }
+
+    const headCode = yield* gitExitCode(repository, [
+      "rev-parse",
+      "--verify",
+      "HEAD",
+    ])
+    if (headCode === 0) {
+      return "HEAD"
+    }
+
+    return yield* new GitCommandError({
+      message: "Unable to resolve a start point for the worktree",
+      command: "git",
+      args: repository.isBare
+        ? ["--git-dir", repository.localPath, "rev-parse", "--verify", "HEAD"]
+        : ["-C", repository.localPath, "rev-parse", "--verify", "HEAD"],
+      exitCode: 1,
+      stderr: "No origin default branch and no local HEAD",
+    })
+  })
+
+const branchExists = (repository: GitRepository, branchName: string) =>
+  gitExitCode(repository, [
+    "show-ref",
+    "--verify",
+    `refs/heads/${branchName}`,
+  ]).pipe(Effect.map((code) => code === 0))
+
+const worktreeListContains = (
+  repository: GitRepository,
+  worktreePath: string,
+) =>
+  runGit(repository, ["worktree", "list", "--porcelain"]).pipe(
+    Effect.map((output) => {
+      const normalized = worktreePath.replace(/[/\\]+$/, "")
+      return output
+        .split("\n")
+        .some(
+          (line) =>
+            line.startsWith("worktree ") &&
+            line.slice("worktree ".length).replace(/[/\\]+$/, "") ===
+              normalized,
+        )
+    }),
+  )
+
+const branchCheckedOutAt = (
+  repository: GitRepository,
+  branchName: string,
+  worktreePath: string,
+) =>
+  runGit(repository, ["worktree", "list", "--porcelain"]).pipe(
+    Effect.map((output) => {
+      const normalized = worktreePath.replace(/[/\\]+$/, "")
+      const blocks = output.split("\n\n")
+      return blocks.some((block) => {
+        const lines = block.split("\n")
+        const pathLine = lines.find((line) => line.startsWith("worktree "))
+        const branchLine = lines.find((line) => line.startsWith("branch "))
+        if (pathLine === undefined || branchLine === undefined) {
+          return false
+        }
+        const path = pathLine.slice("worktree ".length).replace(/[/\\]+$/, "")
+        const branch = branchLine.slice("branch ".length)
+        return (
+          path === normalized &&
+          (branch === `refs/heads/${branchName}` || branch === branchName)
+        )
+      })
+    }),
+  )
+
+const ensureParentDirectory = (parentPath: string) =>
+  Effect.gen(function* () {
+    const fs = yield* FileSystem.FileSystem
+    yield* fs.makeDirectory(parentPath, { recursive: true })
+  })
+
+const pathExists = (path: string) =>
+  Effect.gen(function* () {
+    const fs = yield* FileSystem.FileSystem
+    return yield* fs.exists(path)
+  })
+
+const realPath = (path: string) =>
+  Effect.gen(function* () {
+    const fs = yield* FileSystem.FileSystem
+    return yield* fs.realPath(path)
+  })
+
+export const createWorktree = (
+  context: LifecycleStepContext,
+  options: { readonly tmpDir?: string } = {},
+) =>
+  Effect.gen(function* () {
+    const pathService = yield* Path.Path
+    const repository = yield* resolveRepository(context.repositoryId)
+    const gitRepository = asGitRepository(repository)
+
+    const branchName = workItemBranchName({
+      githubOwner: repository.githubOwner,
+      githubRepo: repository.githubRepo,
+      githubIssueNumber: context.githubIssueNumber,
+      workItemId: context.workItemId,
+    })
+
+    const plannedPath = workItemWorktreePath({
+      localPath: repository.localPath,
+      isBare: repository.isBare,
+      githubOwner: repository.githubOwner,
+      githubRepo: repository.githubRepo,
+      githubIssueNumber: context.githubIssueNumber,
+      workItemId: context.workItemId,
+      tmpDir: options.tmpDir,
+    })
+
+    const worktreePath = pathService.resolve(plannedPath)
+    const parentPath = pathService.resolve(
+      worktreeParentPath({
+        localPath: repository.localPath,
+        isBare: repository.isBare,
+        githubOwner: repository.githubOwner,
+        githubRepo: repository.githubRepo,
+        tmpDir: options.tmpDir,
+      }),
+    )
+
+    const hasBranch = yield* branchExists(gitRepository, branchName)
+    const pathPresent = yield* pathExists(worktreePath)
+
+    if (pathPresent) {
+      const absoluteExisting = yield* realPath(worktreePath)
+      const listed = yield* worktreeListContains(
+        gitRepository,
+        absoluteExisting,
+      )
+      if (!listed) {
+        return yield* new WorktreeConflictError({
+          message: `Path already exists and is not a worktree for this Repository: ${worktreePath}`,
+          branchName,
+          worktreePath,
+        })
+      }
+
+      const correctCheckout = yield* branchCheckedOutAt(
+        gitRepository,
+        branchName,
+        absoluteExisting,
+      )
+      if (!correctCheckout) {
+        return yield* new WorktreeConflictError({
+          message: `Existing worktree at ${worktreePath} is not checked out on branch ${branchName}`,
+          branchName,
+          worktreePath,
+        })
+      }
+
+      return absoluteExisting
+    }
+
+    if (hasBranch) {
+      return yield* new WorktreeConflictError({
+        message: `Branch ${branchName} already exists without worktree at ${worktreePath}`,
+        branchName,
+        worktreePath,
+      })
+    }
+
+    yield* ensureParentDirectory(parentPath)
+
+    const startPoint = yield* resolveStartPoint(gitRepository)
+    yield* runGit(gitRepository, [
+      "worktree",
+      "add",
+      "-b",
+      branchName,
+      worktreePath,
+      startPoint,
+    ])
+
+    return yield* realPath(worktreePath)
+  })

--- a/packages/work-item-lifecycle/src/lib/errors.ts
+++ b/packages/work-item-lifecycle/src/lib/errors.ts
@@ -1,5 +1,7 @@
 import { Data } from "effect"
 
+export * from "./create-worktree-errors.js"
+
 export class NonTransactionalQueueError extends Data.TaggedError(
   "NonTransactionalQueueError",
 )<{

--- a/packages/work-item-lifecycle/src/lib/git.ts
+++ b/packages/work-item-lifecycle/src/lib/git.ts
@@ -1,0 +1,74 @@
+import { Effect, Stream } from "effect"
+import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process"
+import { GitCommandError } from "./create-worktree-errors.js"
+
+export type GitRepository = {
+  readonly localPath: string
+  readonly isBare: boolean
+}
+
+const repositoryPrefix = (repository: GitRepository): readonly string[] =>
+  repository.isBare
+    ? ["--git-dir", repository.localPath]
+    : ["-C", repository.localPath]
+
+export const runGit = (
+  repository: GitRepository,
+  args: ReadonlyArray<string>,
+) =>
+  Effect.gen(function* () {
+    const spawner = yield* ChildProcessSpawner.ChildProcessSpawner
+    const fullArgs = [...repositoryPrefix(repository), ...args]
+    const command = ChildProcess.make("git", fullArgs, {
+      stdin: "ignore",
+    })
+
+    const result = yield* Effect.scoped(
+      Effect.gen(function* () {
+        const handle = yield* spawner.spawn(command)
+        const [exitCode, stdout, stderr] = yield* Effect.all(
+          [
+            handle.exitCode,
+            Stream.decodeText(handle.stdout).pipe(Stream.mkString),
+            Stream.decodeText(handle.stderr).pipe(Stream.mkString),
+          ],
+          { concurrency: 3 },
+        )
+        return {
+          exitCode: Number(exitCode),
+          stdout,
+          stderr,
+        }
+      }),
+    )
+
+    if (result.exitCode !== 0) {
+      return yield* new GitCommandError({
+        message: `git ${args.join(" ")} failed with exit ${result.exitCode}`,
+        command: "git",
+        args: fullArgs,
+        cwd: repository.isBare ? undefined : repository.localPath,
+        exitCode: result.exitCode,
+        stderr: result.stderr.trim(),
+      })
+    }
+
+    return result.stdout
+  })
+
+export const gitExitCode = (
+  repository: GitRepository,
+  args: ReadonlyArray<string>,
+) =>
+  Effect.gen(function* () {
+    const spawner = yield* ChildProcessSpawner.ChildProcessSpawner
+    const fullArgs = [...repositoryPrefix(repository), ...args]
+    const code = yield* spawner.exitCode(
+      ChildProcess.make("git", fullArgs, {
+        stdin: "ignore",
+        stdout: "ignore",
+        stderr: "ignore",
+      }),
+    )
+    return Number(code)
+  })

--- a/packages/work-item-lifecycle/src/lib/lifecycle-steps-live.ts
+++ b/packages/work-item-lifecycle/src/lib/lifecycle-steps-live.ts
@@ -1,0 +1,46 @@
+import { Effect, FileSystem, Layer, Path } from "effect"
+import { ChildProcessSpawner } from "effect/unstable/process"
+import { DbService } from "@ready-for-agent/db-service"
+import { createWorktree } from "./create-worktree.js"
+import { LifecycleSteps } from "./lifecycle-steps.js"
+
+const notImplemented = (step: string) =>
+  Effect.die(new Error(`Lifecycle Step ${step} is not implemented yet`))
+
+/**
+ * Production LifecycleSteps: real Create Worktree; other steps arrive in later tickets.
+ * Captures platform and database services so handlers remain `Effect<A>` with no requirements.
+ */
+export const LifecycleStepsLive = Layer.effect(
+  LifecycleSteps,
+  Effect.gen(function* () {
+    const db = yield* DbService
+    const fs = yield* FileSystem.FileSystem
+    const path = yield* Path.Path
+    const spawner = yield* ChildProcessSpawner.ChildProcessSpawner
+
+    const withServices = <A, E>(
+      effect: Effect.Effect<
+        A,
+        E,
+        | DbService
+        | FileSystem.FileSystem
+        | Path.Path
+        | ChildProcessSpawner.ChildProcessSpawner
+      >,
+    ) =>
+      effect.pipe(
+        Effect.provideService(DbService, db),
+        Effect.provideService(FileSystem.FileSystem, fs),
+        Effect.provideService(Path.Path, path),
+        Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, spawner),
+      )
+
+    return LifecycleSteps.of({
+      createWorktree: (context) => withServices(createWorktree(context)),
+      installDependencies: () => notImplemented("install_dependencies"),
+      implement: () => notImplemented("implement"),
+      review: () => notImplemented("review"),
+    })
+  }),
+)

--- a/packages/work-item-lifecycle/src/lib/lifecycle-steps.ts
+++ b/packages/work-item-lifecycle/src/lib/lifecycle-steps.ts
@@ -22,12 +22,16 @@ export interface LifecycleStepContext {
 export interface LifecycleStepsShape {
   readonly createWorktree: (
     context: LifecycleStepContext,
-  ) => Effect.Effect<string>
+  ) => Effect.Effect<string, unknown>
   readonly installDependencies: (
     context: LifecycleStepContext,
-  ) => Effect.Effect<void>
-  readonly implement: (context: LifecycleStepContext) => Effect.Effect<string>
-  readonly review: (context: LifecycleStepContext) => Effect.Effect<void>
+  ) => Effect.Effect<void, unknown>
+  readonly implement: (
+    context: LifecycleStepContext,
+  ) => Effect.Effect<string, unknown>
+  readonly review: (
+    context: LifecycleStepContext,
+  ) => Effect.Effect<void, unknown>
 }
 
 export class LifecycleSteps extends Context.Service<

--- a/packages/work-item-lifecycle/src/lib/work-item-lifecycle.ts
+++ b/packages/work-item-lifecycle/src/lib/work-item-lifecycle.ts
@@ -591,10 +591,13 @@ export const makeWorkItemLifecycleLive = (
       const runHandler = (
         step: OperationalLifecycleStep,
         context: LifecycleStepContext,
-      ): Effect.Effect<{
-        readonly worktreePath?: string
-        readonly sessionId?: string
-      }> => {
+      ): Effect.Effect<
+        {
+          readonly worktreePath?: string
+          readonly sessionId?: string
+        },
+        unknown
+      > => {
         switch (step) {
           case "create_worktree":
             return steps

--- a/packages/work-item-lifecycle/src/lib/worktree-names.ts
+++ b/packages/work-item-lifecycle/src/lib/worktree-names.ts
@@ -1,0 +1,106 @@
+const sanitizeSegment = (value: string): string => {
+  const cleaned = value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+  return cleaned.length > 0 ? cleaned : "repo"
+}
+
+export const repositorySlug = (
+  githubOwner: string,
+  githubRepo: string,
+): string => `${sanitizeSegment(githubOwner)}-${sanitizeSegment(githubRepo)}`
+
+/**
+ * Stable, collision-resistant branch for one Work Item.
+ * Encodes repository slug, GitHub issue number, and Work Item id.
+ */
+export const workItemBranchName = (input: {
+  readonly githubOwner: string
+  readonly githubRepo: string
+  readonly githubIssueNumber: number
+  readonly workItemId: string
+}): string => {
+  const slug = repositorySlug(input.githubOwner, input.githubRepo)
+  return `rfa/${slug}/${input.githubIssueNumber}/${input.workItemId}`
+}
+
+const basename = (path: string): string => {
+  const normalized = path.replace(/[/\\]+$/, "")
+  const parts = normalized.split(/[/\\]/)
+  return parts[parts.length - 1] ?? normalized
+}
+
+const dirname = (path: string): string => {
+  const normalized = path.replace(/[/\\]+$/, "")
+  const index = Math.max(
+    normalized.lastIndexOf("/"),
+    normalized.lastIndexOf("\\"),
+  )
+  if (index < 0) {
+    return "."
+  }
+  return index === 0 ? "/" : normalized.slice(0, index)
+}
+
+const repositoryStem = (localPath: string): string => {
+  const base = basename(localPath)
+  if (base === ".bare") {
+    return basename(dirname(localPath))
+  }
+  return base.endsWith(".git") ? base.slice(0, -4) || "repo" : base
+}
+
+/**
+ * Parent directory that will hold Issue Worktrees for a Repository.
+ *
+ * - bare + `.bare` layout: project root (sibling of `.bare`)
+ * - other bare: sibling `{stem}-worktrees` next to the bare store
+ * - non-bare: under TMPDIR so the main working tree is never polluted
+ */
+export const worktreeParentPath = (input: {
+  readonly localPath: string
+  readonly isBare: boolean
+  readonly githubOwner: string
+  readonly githubRepo: string
+  readonly tmpDir?: string
+}): string => {
+  const localPath = input.localPath.replace(/[/\\]+$/, "")
+
+  if (input.isBare) {
+    if (basename(localPath) === ".bare") {
+      return dirname(localPath)
+    }
+    return `${dirname(localPath)}/${repositoryStem(localPath)}-worktrees`
+  }
+
+  const temporaryDirectory = (input.tmpDir ?? process.env.TMPDIR ?? "/tmp")
+    .trim()
+    .replace(/[/\\]+$/, "")
+  return `${temporaryDirectory}/ready-for-agent/${sanitizeSegment(input.githubOwner)}/${sanitizeSegment(input.githubRepo)}`
+}
+
+export const workItemDirectoryName = (input: {
+  readonly githubIssueNumber: number
+  readonly workItemId: string
+}): string => `${input.githubIssueNumber}-${input.workItemId}`
+
+/**
+ * Absolute worktree path for one Work Item.
+ */
+export const workItemWorktreePath = (input: {
+  readonly localPath: string
+  readonly isBare: boolean
+  readonly githubOwner: string
+  readonly githubRepo: string
+  readonly githubIssueNumber: number
+  readonly workItemId: string
+  readonly tmpDir?: string
+}): string => {
+  const parent = worktreeParentPath(input)
+  const name = workItemDirectoryName({
+    githubIssueNumber: input.githubIssueNumber,
+    workItemId: input.workItemId,
+  })
+  return `${parent}/${name}`
+}

--- a/packages/work-item-lifecycle/test/create-worktree.spec.ts
+++ b/packages/work-item-lifecycle/test/create-worktree.spec.ts
@@ -1,0 +1,409 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { BunServices } from "@effect/platform-bun"
+import { Effect, type Layer } from "effect"
+import { DatabaseTest } from "@ready-for-agent/db/test"
+import { DbService, DbServiceLive } from "@ready-for-agent/db-service"
+import {
+  GitCommandError,
+  WorktreeConflictError,
+  createWorktree,
+  makeWorkItemId,
+  workItemBranchName,
+  workItemWorktreePath,
+} from "../src/index.js"
+import { describe, expect, it } from "bun:test"
+
+const PlatformLayer = BunServices.layer
+
+const run = <A, E>(
+  effect: Effect.Effect<
+    A,
+    E,
+    | Layer.Layer.Success<typeof PlatformLayer>
+    | Layer.Layer.Success<typeof DbServiceLive>
+  >,
+): Promise<A> =>
+  Effect.runPromise(
+    effect.pipe(
+      Effect.provide(DbServiceLive),
+      Effect.provide(DatabaseTest),
+      Effect.provide(PlatformLayer),
+    ),
+  )
+
+const git = async (cwd: string, args: ReadonlyArray<string>) => {
+  const proc = Bun.spawn(["git", ...args], {
+    cwd,
+    stdout: "pipe",
+    stderr: "pipe",
+  })
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ])
+  if (exitCode !== 0) {
+    throw new Error(
+      `git ${args.join(" ")} failed (${exitCode}): ${stderr || stdout}`,
+    )
+  }
+  return stdout.trim()
+}
+
+const initBareRepository = async (root: string) => {
+  const source = join(root, "source")
+  const bare = join(root, "widgets.git")
+  await mkdir(source, { recursive: true })
+  await git(source, ["init", "-b", "main"])
+  await git(source, ["config", "user.email", "test@example.com"])
+  await git(source, ["config", "user.name", "Test"])
+  await writeFile(join(source, "README.md"), "# widgets\n")
+  await git(source, ["add", "README.md"])
+  await git(source, ["commit", "-m", "initial"])
+  await git(root, ["clone", "--bare", source, bare])
+  return bare
+}
+
+const initDotBareRepository = async (root: string) => {
+  const project = join(root, "monorepo")
+  const source = join(root, "source")
+  const bare = join(project, ".bare")
+  await mkdir(source, { recursive: true })
+  await mkdir(project, { recursive: true })
+  await git(source, ["init", "-b", "main"])
+  await git(source, ["config", "user.email", "test@example.com"])
+  await git(source, ["config", "user.name", "Test"])
+  await writeFile(join(source, "README.md"), "# monorepo\n")
+  await git(source, ["add", "README.md"])
+  await git(source, ["commit", "-m", "initial"])
+  await git(root, ["clone", "--bare", source, bare])
+  return bare
+}
+
+const initNonBareRepository = async (root: string) => {
+  const repo = join(root, "widgets")
+  await mkdir(repo, { recursive: true })
+  await git(repo, ["init", "-b", "main"])
+  await git(repo, ["config", "user.email", "test@example.com"])
+  await git(repo, ["config", "user.name", "Test"])
+  await writeFile(join(repo, "README.md"), "# widgets\n")
+  await git(repo, ["add", "README.md"])
+  await git(repo, ["commit", "-m", "initial"])
+  return repo
+}
+
+describe("createWorktree", () => {
+  it("creates a worktree and branch for a bare Repository", async () => {
+    const root = await mkdtemp(join(tmpdir(), "rfa-wt-bare-"))
+    try {
+      const bare = await initBareRepository(root)
+      const workItemId = makeWorkItemId()
+
+      const path = await run(
+        Effect.gen(function* () {
+          const db = yield* DbService
+          const repository = yield* db.addRepository({
+            githubOwner: "acme",
+            githubRepo: "widgets",
+            localPath: bare,
+            isBare: true,
+          })
+
+          return yield* createWorktree({
+            workItemId,
+            repositoryId: repository.id,
+            githubIssueNumber: 42,
+            model: "opencode/test",
+            variant: "low",
+            worktreePath: null,
+            sessionId: null,
+          })
+        }),
+      )
+
+      const expected = workItemWorktreePath({
+        localPath: bare,
+        isBare: true,
+        githubOwner: "acme",
+        githubRepo: "widgets",
+        githubIssueNumber: 42,
+        workItemId,
+      })
+      expect(path).toBe(expected)
+
+      const branch = workItemBranchName({
+        githubOwner: "acme",
+        githubRepo: "widgets",
+        githubIssueNumber: 42,
+        workItemId,
+      })
+      const checkedOut = await git(path, ["rev-parse", "--abbrev-ref", "HEAD"])
+      expect(checkedOut).toBe(branch)
+      expect(await Bun.file(join(path, "README.md")).text()).toContain(
+        "widgets",
+      )
+    } finally {
+      await rm(root, { recursive: true, force: true })
+    }
+  })
+
+  it("places dot-bare worktrees in the project root", async () => {
+    const root = await mkdtemp(join(tmpdir(), "rfa-wt-dotbare-"))
+    try {
+      const bare = await initDotBareRepository(root)
+      const workItemId = makeWorkItemId()
+
+      const path = await run(
+        Effect.gen(function* () {
+          const db = yield* DbService
+          const repository = yield* db.addRepository({
+            githubOwner: "pf",
+            githubRepo: "monorepo",
+            localPath: bare,
+            isBare: true,
+          })
+
+          return yield* createWorktree({
+            workItemId,
+            repositoryId: repository.id,
+            githubIssueNumber: 2039,
+            model: "opencode/test",
+            variant: "low",
+            worktreePath: null,
+            sessionId: null,
+          })
+        }),
+      )
+
+      expect(path).toBe(
+        workItemWorktreePath({
+          localPath: bare,
+          isBare: true,
+          githubOwner: "pf",
+          githubRepo: "monorepo",
+          githubIssueNumber: 2039,
+          workItemId,
+        }),
+      )
+      expect(path.startsWith(join(root, "monorepo"))).toBe(true)
+      expect(path.includes("/.bare/")).toBe(false)
+    } finally {
+      await rm(root, { recursive: true, force: true })
+    }
+  })
+
+  it("creates a worktree for a non-bare Repository under tmp", async () => {
+    const root = await mkdtemp(join(tmpdir(), "rfa-wt-normal-"))
+    const tmpDir = await mkdtemp(join(tmpdir(), "rfa-wt-tmp-"))
+    try {
+      const repo = await initNonBareRepository(root)
+      const workItemId = makeWorkItemId()
+
+      const path = await run(
+        Effect.gen(function* () {
+          const db = yield* DbService
+          const repository = yield* db.addRepository({
+            githubOwner: "acme",
+            githubRepo: "widgets",
+            localPath: repo,
+            isBare: false,
+          })
+
+          return yield* createWorktree(
+            {
+              workItemId,
+              repositoryId: repository.id,
+              githubIssueNumber: 7,
+              model: "opencode/test",
+              variant: "low",
+              worktreePath: null,
+              sessionId: null,
+            },
+            { tmpDir },
+          )
+        }),
+      )
+
+      expect(path).toBe(
+        workItemWorktreePath({
+          localPath: repo,
+          isBare: false,
+          githubOwner: "acme",
+          githubRepo: "widgets",
+          githubIssueNumber: 7,
+          workItemId,
+          tmpDir,
+        }),
+      )
+      expect(path.startsWith(tmpDir)).toBe(true)
+    } finally {
+      await rm(root, { recursive: true, force: true })
+      await rm(tmpDir, { recursive: true, force: true })
+    }
+  })
+
+  it("converges on the existing correctly configured worktree on re-entry", async () => {
+    const root = await mkdtemp(join(tmpdir(), "rfa-wt-reentry-"))
+    try {
+      const bare = await initBareRepository(root)
+      const workItemId = makeWorkItemId()
+
+      const first = await run(
+        Effect.gen(function* () {
+          const db = yield* DbService
+          const repository = yield* db.addRepository({
+            githubOwner: "acme",
+            githubRepo: "widgets",
+            localPath: bare,
+            isBare: true,
+          })
+
+          const context = {
+            workItemId,
+            repositoryId: repository.id,
+            githubIssueNumber: 42,
+            model: "opencode/test",
+            variant: "low",
+            worktreePath: null,
+            sessionId: null,
+          } as const
+
+          const created = yield* createWorktree(context)
+          const again = yield* createWorktree(context)
+          return { created, again }
+        }),
+      )
+
+      expect(first.again).toBe(first.created)
+    } finally {
+      await rm(root, { recursive: true, force: true })
+    }
+  })
+
+  it("fails when the planned path exists but is not this Work Item worktree", async () => {
+    const root = await mkdtemp(join(tmpdir(), "rfa-wt-conflict-path-"))
+    try {
+      const bare = await initBareRepository(root)
+      const workItemId = makeWorkItemId()
+      const planned = workItemWorktreePath({
+        localPath: bare,
+        isBare: true,
+        githubOwner: "acme",
+        githubRepo: "widgets",
+        githubIssueNumber: 42,
+        workItemId,
+      })
+      await mkdir(planned, { recursive: true })
+      await writeFile(join(planned, "hijack.txt"), "nope")
+
+      const error = await run(
+        Effect.gen(function* () {
+          const db = yield* DbService
+          const repository = yield* db.addRepository({
+            githubOwner: "acme",
+            githubRepo: "widgets",
+            localPath: bare,
+            isBare: true,
+          })
+
+          return yield* createWorktree({
+            workItemId,
+            repositoryId: repository.id,
+            githubIssueNumber: 42,
+            model: "opencode/test",
+            variant: "low",
+            worktreePath: null,
+            sessionId: null,
+          }).pipe(Effect.flip)
+        }),
+      )
+
+      expect(error).toBeInstanceOf(WorktreeConflictError)
+    } finally {
+      await rm(root, { recursive: true, force: true })
+    }
+  })
+
+  it("fails when the branch exists without the matching worktree path", async () => {
+    const root = await mkdtemp(join(tmpdir(), "rfa-wt-conflict-branch-"))
+    try {
+      const bare = await initBareRepository(root)
+      const workItemId = makeWorkItemId()
+      const branch = workItemBranchName({
+        githubOwner: "acme",
+        githubRepo: "widgets",
+        githubIssueNumber: 42,
+        workItemId,
+      })
+      await git(bare, ["branch", branch, "HEAD"])
+
+      const error = await run(
+        Effect.gen(function* () {
+          const db = yield* DbService
+          const repository = yield* db.addRepository({
+            githubOwner: "acme",
+            githubRepo: "widgets",
+            localPath: bare,
+            isBare: true,
+          })
+
+          return yield* createWorktree({
+            workItemId,
+            repositoryId: repository.id,
+            githubIssueNumber: 42,
+            model: "opencode/test",
+            variant: "low",
+            worktreePath: null,
+            sessionId: null,
+          }).pipe(Effect.flip)
+        }),
+      )
+
+      expect(error).toBeInstanceOf(WorktreeConflictError)
+    } finally {
+      await rm(root, { recursive: true, force: true })
+    }
+  })
+
+  it("maps git command failures with command and stderr context", async () => {
+    const root = await mkdtemp(join(tmpdir(), "rfa-wt-gitfail-"))
+    try {
+      const emptyBare = join(root, "empty.git")
+      await git(root, ["init", "--bare", emptyBare])
+      const workItemId = makeWorkItemId()
+
+      const error = await run(
+        Effect.gen(function* () {
+          const db = yield* DbService
+          const repository = yield* db.addRepository({
+            githubOwner: "acme",
+            githubRepo: "widgets",
+            localPath: emptyBare,
+            isBare: true,
+          })
+
+          return yield* createWorktree({
+            workItemId,
+            repositoryId: repository.id,
+            githubIssueNumber: 1,
+            model: "opencode/test",
+            variant: "low",
+            worktreePath: null,
+            sessionId: null,
+          }).pipe(Effect.flip)
+        }),
+      )
+
+      expect(error).toBeInstanceOf(GitCommandError)
+      if (error instanceof GitCommandError) {
+        expect(error.command).toBe("git")
+        expect(error.args.length).toBeGreaterThan(0)
+        expect(error.message.length).toBeGreaterThan(0)
+      }
+    } finally {
+      await rm(root, { recursive: true, force: true })
+    }
+  })
+})

--- a/packages/work-item-lifecycle/test/worktree-names.spec.ts
+++ b/packages/work-item-lifecycle/test/worktree-names.spec.ts
@@ -1,0 +1,95 @@
+import {
+  repositorySlug,
+  workItemBranchName,
+  workItemWorktreePath,
+  worktreeParentPath,
+} from "../src/lib/worktree-names.js"
+import { describe, expect, it } from "bun:test"
+
+describe("worktree names", () => {
+  it("builds a repository slug from owner and name", () => {
+    expect(repositorySlug("Acme", "Widgets")).toBe("acme-widgets")
+    expect(repositorySlug("acme.org", "my_repo")).toBe("acme-org-my-repo")
+  })
+
+  it("builds a branch identifiable by repo, issue, and Work Item", () => {
+    expect(
+      workItemBranchName({
+        githubOwner: "acme",
+        githubRepo: "widgets",
+        githubIssueNumber: 42,
+        workItemId: "wi-01HABCDEFGHJKMNPQRSTVWXYZ",
+      }),
+    ).toBe("rfa/acme-widgets/42/wi-01HABCDEFGHJKMNPQRSTVWXYZ")
+  })
+
+  it("places dot-bare worktrees beside .bare in the project root", () => {
+    expect(
+      worktreeParentPath({
+        localPath: "/home/berend/src/pf/monorepo/.bare",
+        isBare: true,
+        githubOwner: "pf",
+        githubRepo: "monorepo",
+      }),
+    ).toBe("/home/berend/src/pf/monorepo")
+
+    expect(
+      workItemWorktreePath({
+        localPath: "/home/berend/src/pf/monorepo/.bare",
+        isBare: true,
+        githubOwner: "pf",
+        githubRepo: "monorepo",
+        githubIssueNumber: 2039,
+        workItemId: "wi-01HABCDEFGHJKMNPQRSTVWXYZ",
+      }),
+    ).toBe("/home/berend/src/pf/monorepo/2039-wi-01HABCDEFGHJKMNPQRSTVWXYZ")
+  })
+
+  it("places other bare worktrees under a sibling stem-worktrees directory", () => {
+    expect(
+      worktreeParentPath({
+        localPath: "/repos/acme/widgets.git",
+        isBare: true,
+        githubOwner: "acme",
+        githubRepo: "widgets",
+      }),
+    ).toBe("/repos/acme/widgets-worktrees")
+
+    expect(
+      workItemWorktreePath({
+        localPath: "/repos/acme/widgets.git",
+        isBare: true,
+        githubOwner: "acme",
+        githubRepo: "widgets",
+        githubIssueNumber: 42,
+        workItemId: "wi-01HABCDEFGHJKMNPQRSTVWXYZ",
+      }),
+    ).toBe("/repos/acme/widgets-worktrees/42-wi-01HABCDEFGHJKMNPQRSTVWXYZ")
+  })
+
+  it("places non-bare worktrees under the temporary ready-for-agent tree", () => {
+    expect(
+      worktreeParentPath({
+        localPath: "/home/berend/src/acme/widgets",
+        isBare: false,
+        githubOwner: "acme",
+        githubRepo: "widgets",
+        tmpDir: "/tmp",
+      }),
+    ).toBe("/tmp/ready-for-agent/acme/widgets")
+
+    expect(
+      workItemWorktreePath({
+        localPath: "/home/berend/src/acme/widgets",
+        isBare: false,
+        githubOwner: "acme",
+        githubRepo: "widgets",
+        githubIssueNumber: 7,
+        workItemId: "wi-01HZZZZZZZZZZZZZZZZZZZZZZZ",
+        tmpDir: "/var/tmp",
+      }),
+    ).toBe(
+      "/var/tmp/ready-for-agent/acme/widgets/7-wi-01HZZZZZZZZZZZZZZZZZZZZZZZ",
+    )
+  })
+})


### PR DESCRIPTION
## Why

Work Items need an isolated, durable Git branch and worktree before later Lifecycle Steps can install dependencies or run OpenCode. Create Worktree also needs to be safe after an interrupted attempt: matching external state must converge, while unrelated branches and paths must never be overwritten.

## What Changed

- Added a production Create Worktree handler using argument-based Git process execution for bare and non-bare Repositories.
- Added stable branch and directory naming derived from Repository identity, GitHub issue number, and Work Item ID.
- Preserved the established bare-clone layouts: `.bare` worktrees live beside `.bare`, other bare clones use a sibling `<repository>-worktrees` directory, and normal clones use the temporary Ready for Agent tree.
- Added re-entry validation, typed conflict and Git-command diagnostics, and persistence of the actual resolved worktree path through the lifecycle state mover.
- Wired lifecycle jobs through the Harness worker to `WorkItemLifecycle.runStep`, keeping state advancement and processed-job acknowledgement in the lifecycle driver.
- Added temporary-repository integration coverage for bare, `.bare`, and normal clones, re-entry, conflicts, Git failures, and worker dispatch.

## Verification

Integration tests create real temporary Git repositories and verify branch checkout, worktree placement, re-entry, conflict rejection, and Git failure diagnostics. The repository's affected lint, typecheck, and test hook passed for all affected projects.

Closes #78
