### PR TITLE
feat(work-item-lifecycle): complete history and safe repository removal

### DIFF
--- a/packages/db-service/src/lib/db-service.ts
+++ b/packages/db-service/src/lib/db-service.ts
@@ -1,4 +1,4 @@
-import { Context, Effect, Layer, PubSub, Stream } from "effect"
+import { Clock, Context, Effect, Layer, PubSub, Stream } from "effect"
 import { SqlClient } from "effect/unstable/sql"
 import type { SqlError } from "effect/unstable/sql/SqlError"
 import { ulid } from "ulidx"
@@ -9,6 +9,7 @@ import {
   InvalidRepositoryInputError,
   LocalPathInUseError,
   RepositoryAlreadyExistsError,
+  RepositoryHasRunningStepError,
   RepositoryNotFoundError,
 } from "./errors.js"
 import type {
@@ -154,7 +155,10 @@ export interface DbServiceShape {
   >
   readonly removeRepository: (
     repositoryId: string,
-  ) => Effect.Effect<void, RepositoryNotFoundError | DatabaseError>
+  ) => Effect.Effect<
+    void,
+    RepositoryNotFoundError | RepositoryHasRunningStepError | DatabaseError
+  >
   readonly storeIssue: (
     input: StoreIssueInput,
   ) => Effect.Effect<
@@ -432,11 +436,86 @@ export const DbServiceLive = Layer.effect(
 
     const removeRepository = (
       repositoryId: string,
-    ): Effect.Effect<void, RepositoryNotFoundError | DatabaseError> =>
+    ): Effect.Effect<
+      void,
+      RepositoryNotFoundError | RepositoryHasRunningStepError | DatabaseError
+    > =>
       Effect.gen(function* () {
+        const now = yield* Clock.currentTimeMillis
         yield* sql
           .withTransaction(
             Effect.gen(function* () {
+              const running = (yield* sql.unsafe(
+                `SELECT step_run.id AS step_run_id, step_run.work_item_id AS work_item_id
+                 FROM step_run
+                 INNER JOIN work_item ON work_item.id = step_run.work_item_id
+                 WHERE work_item.repository_id = ?
+                   AND step_run.status = 'running'
+                 ORDER BY step_run.queued_at ASC, step_run.id ASC
+                 LIMIT 1`,
+                [repositoryId],
+              )) as readonly {
+                readonly step_run_id: string
+                readonly work_item_id: string
+              }[]
+
+              if (running[0]) {
+                return yield* new RepositoryHasRunningStepError({
+                  repositoryId,
+                  stepRunId: running[0].step_run_id,
+                  workItemId: running[0].work_item_id,
+                })
+              }
+
+              yield* sql.unsafe(
+                `UPDATE step_run
+                 SET status = 'cancelled',
+                     finished_at = ?,
+                     reason_code = 'repository_removed',
+                     reason_message = 'Repository was removed before the Step Run started',
+                     updated_at = ?
+                 WHERE status = 'queued'
+                   AND work_item_id IN (
+                     SELECT id FROM work_item WHERE repository_id = ?
+                   )`,
+                [now, now, repositoryId],
+              )
+
+              yield* sql.unsafe(
+                `DELETE FROM job_queue
+                 WHERE id IN (
+                   SELECT step_run.queue_job_id
+                   FROM step_run
+                   INNER JOIN work_item ON work_item.id = step_run.work_item_id
+                   WHERE work_item.repository_id = ?
+                     AND step_run.queue_job_id IS NOT NULL
+                 )`,
+                [repositoryId],
+              )
+
+              yield* sql.unsafe(
+                `UPDATE work_item
+                 SET state = 'abandoned',
+                     state_ready_at = ?,
+                     updated_at = ?
+                 WHERE repository_id = ?
+                   AND state NOT IN ('complete', 'failed', 'abandoned')`,
+                [now, now, repositoryId],
+              )
+
+              yield* sql.unsafe(
+                `DELETE FROM step_run
+                 WHERE work_item_id IN (
+                   SELECT id FROM work_item WHERE repository_id = ?
+                 )`,
+                [repositoryId],
+              )
+
+              yield* sql.unsafe(
+                `DELETE FROM work_item WHERE repository_id = ?`,
+                [repositoryId],
+              )
+
               yield* sql.unsafe(
                 `DELETE FROM issue_dependency
                WHERE issue_id IN (
@@ -459,7 +538,8 @@ export const DbServiceLive = Layer.effect(
           )
           .pipe(
             Effect.mapError((error) =>
-              error instanceof RepositoryNotFoundError
+              error instanceof RepositoryNotFoundError ||
+              error instanceof RepositoryHasRunningStepError
                 ? error
                 : toDatabaseError(error),
             ),

--- a/packages/db-service/src/lib/errors.ts
+++ b/packages/db-service/src/lib/errors.ts
@@ -26,6 +26,14 @@ export class RepositoryNotFoundError extends Data.TaggedError(
   readonly repositoryId: string
 }> {}
 
+export class RepositoryHasRunningStepError extends Data.TaggedError(
+  "RepositoryHasRunningStepError",
+)<{
+  readonly repositoryId: string
+  readonly stepRunId: string
+  readonly workItemId: string
+}> {}
+
 export class InvalidIssueInputError extends Data.TaggedError(
   "InvalidIssueInputError",
 )<{

--- a/packages/db-service/test/db-service.spec.ts
+++ b/packages/db-service/test/db-service.spec.ts
@@ -10,6 +10,7 @@ import {
   InvalidRepositoryInputError,
   LocalPathInUseError,
   RepositoryAlreadyExistsError,
+  RepositoryHasRunningStepError,
   RepositoryNotFoundError,
 } from "../src/index.js"
 import { describe, expect, it } from "bun:test"
@@ -282,6 +283,90 @@ describe("DbService", () => {
           const error = yield* Effect.flip(db.removeRepository("repo-missing"))
 
           expect(error).toBeInstanceOf(RepositoryNotFoundError)
+        }),
+      ))
+
+    it("rejects removal when a Step Run is Running", () =>
+      runTest(
+        Effect.gen(function* () {
+          const db = yield* DbService
+          const sql = yield* SqlClient.SqlClient
+          const repository = yield* db.addRepository(sampleInput)
+          const now = Date.now()
+
+          yield* sql.unsafe(
+            `INSERT INTO work_item (
+               id, repository_id, github_issue_number, model, variant, state,
+               state_ready_at, worktree_path, session_id, failure_code,
+               failure_message, created_at, updated_at
+             ) VALUES (?, ?, 42, 'model', 'low', 'create_worktree', ?, NULL, NULL, NULL, NULL, ?, ?)`,
+            ["wi-running-remove-test", repository.id, now, now, now],
+          )
+          yield* sql.unsafe(
+            `INSERT INTO step_run (
+               id, work_item_id, step, status, queue_job_id, queued_at,
+               started_at, finished_at, reason_code, reason_message,
+               created_at, updated_at
+             ) VALUES (?, ?, 'create_worktree', 'running', 'qjob-1', ?, ?, NULL, NULL, NULL, ?, ?)`,
+            [
+              "srun-running-remove-test",
+              "wi-running-remove-test",
+              now,
+              now,
+              now,
+              now,
+            ],
+          )
+
+          const error = yield* Effect.flip(db.removeRepository(repository.id))
+          expect(error).toBeInstanceOf(RepositoryHasRunningStepError)
+          expect(yield* db.listRepositories).toHaveLength(1)
+          expect(yield* sql.unsafe("SELECT id FROM work_item")).toHaveLength(1)
+        }),
+      ))
+
+    it("deletes lifecycle history and queued jobs when no Step Run is Running", () =>
+      runTest(
+        Effect.gen(function* () {
+          const db = yield* DbService
+          const sql = yield* SqlClient.SqlClient
+          const repository = yield* db.addRepository(sampleInput)
+          const now = Date.now()
+
+          yield* sql.unsafe(
+            `INSERT INTO work_item (
+               id, repository_id, github_issue_number, model, variant, state,
+               state_ready_at, worktree_path, session_id, failure_code,
+               failure_message, created_at, updated_at
+             ) VALUES (?, ?, 42, 'model', 'low', 'create_worktree', ?, NULL, NULL, NULL, NULL, ?, ?)`,
+            ["wi-queued-remove-test", repository.id, now, now, now],
+          )
+          yield* sql.unsafe(
+            `INSERT INTO step_run (
+               id, work_item_id, step, status, queue_job_id, queued_at,
+               started_at, finished_at, reason_code, reason_message,
+               created_at, updated_at
+             ) VALUES (?, ?, 'create_worktree', 'queued', 'qjob-queued-remove', ?, NULL, NULL, NULL, NULL, ?, ?)`,
+            ["srun-queued-remove-test", "wi-queued-remove-test", now, now, now],
+          )
+          yield* sql.unsafe(
+            `INSERT INTO job_queue (
+               id, queue, job_payload, job_attempts, job_retry_limit,
+               available_at, locked_until, created_at, updated_at
+             ) VALUES (?, 'jobs', '{}', 0, 1, ?, NULL, ?, ?)`,
+            ["qjob-queued-remove", now, now, now],
+          )
+
+          yield* db.removeRepository(repository.id)
+
+          expect(yield* db.listRepositories).toEqual([])
+          expect(yield* sql.unsafe("SELECT id FROM work_item")).toEqual([])
+          expect(yield* sql.unsafe("SELECT id FROM step_run")).toEqual([])
+          expect(
+            yield* sql.unsafe(
+              "SELECT id FROM job_queue WHERE id = 'qjob-queued-remove'",
+            ),
+          ).toEqual([])
         }),
       ))
   })

--- a/packages/work-item-lifecycle/src/lib/types.ts
+++ b/packages/work-item-lifecycle/src/lib/types.ts
@@ -48,6 +48,10 @@ export interface StepRunRecord {
   readonly finishedAt: Date | null
   readonly reasonCode: string | null
   readonly reasonMessage: string | null
+  /** Time from queued until start (or finish/now if never started). */
+  readonly queueWaitMs: number
+  /** Time from start until finish/now; null when execution never began. */
+  readonly executionDurationMs: number | null
 }
 
 export interface WorkItemRecord {
@@ -64,6 +68,8 @@ export interface WorkItemRecord {
   readonly failureMessage: string | null
   readonly createdAt: Date
   readonly updatedAt: Date
+  /** Time the Work Item has spent in its current Lifecycle Step (from stateReadyAt). */
+  readonly stateResidenceMs: number
   readonly stepRuns: readonly StepRunRecord[]
 }
 

--- a/packages/work-item-lifecycle/src/lib/work-item-lifecycle.ts
+++ b/packages/work-item-lifecycle/src/lib/work-item-lifecycle.ts
@@ -1,5 +1,6 @@
 import {
   Cause,
+  Clock,
   Context,
   Duration,
   Effect,
@@ -205,7 +206,23 @@ type StepRunRow = {
   readonly reason_message: string | null
 }
 
-const toStepRunRecord = (row: StepRunRow): StepRunRecord => ({
+const deriveQueueWaitMs = (row: StepRunRow, nowMs: number): number => {
+  const endMs = row.started_at ?? row.finished_at ?? nowMs
+  return Math.max(0, endMs - row.queued_at)
+}
+
+const deriveExecutionDurationMs = (
+  row: StepRunRow,
+  nowMs: number,
+): number | null => {
+  if (row.started_at === null) {
+    return null
+  }
+  const endMs = row.finished_at ?? nowMs
+  return Math.max(0, endMs - row.started_at)
+}
+
+const toStepRunRecord = (row: StepRunRow, nowMs: number): StepRunRecord => ({
   id: row.id as StepRunId,
   workItemId: row.work_item_id as WorkItemId,
   step: row.step,
@@ -216,11 +233,14 @@ const toStepRunRecord = (row: StepRunRow): StepRunRecord => ({
   finishedAt: row.finished_at === null ? null : new Date(row.finished_at),
   reasonCode: row.reason_code,
   reasonMessage: row.reason_message,
+  queueWaitMs: deriveQueueWaitMs(row, nowMs),
+  executionDurationMs: deriveExecutionDurationMs(row, nowMs),
 })
 
 const toWorkItemRecord = (
   row: WorkItemRow,
   stepRuns: readonly StepRunRecord[],
+  nowMs: number,
 ): WorkItemRecord => ({
   id: row.id as WorkItemId,
   repositoryId: row.repository_id,
@@ -235,6 +255,7 @@ const toWorkItemRecord = (
   failureMessage: row.failure_message,
   createdAt: new Date(row.created_at),
   updatedAt: new Date(row.updated_at),
+  stateResidenceMs: Math.max(0, nowMs - row.state_ready_at),
   stepRuns,
 })
 
@@ -405,6 +426,7 @@ export const makeWorkItemLifecycleLive = (
 
       const loadStepRuns = (
         workItemIds: readonly string[],
+        nowMs: number,
       ): Effect.Effect<
         Map<string, StepRunRecord[]>,
         WorkItemLifecycleDatabaseError
@@ -422,13 +444,13 @@ export const makeWorkItemLifecycleLive = (
                     started_at, finished_at, reason_code, reason_message
              FROM step_run
              WHERE work_item_id IN (${placeholders})
-             ORDER BY queued_at ASC, id ASC`,
+             ORDER BY queued_at ASC, rowid ASC`,
               [...workItemIds],
             )
             .pipe(Effect.mapError(toDatabaseError))) as readonly StepRunRow[]
 
           for (const row of rows) {
-            const record = toStepRunRecord(row)
+            const record = toStepRunRecord(row, nowMs)
             const existing = byWorkItem.get(row.work_item_id)
             if (existing) {
               existing.push(record)
@@ -442,6 +464,7 @@ export const makeWorkItemLifecycleLive = (
       const getWorkItem = Effect.fn("WorkItemLifecycle.getWorkItem")(function* (
         workItemId: string,
       ) {
+        const nowMs = yield* Clock.currentTimeMillis
         const rows = (yield* sql
           .unsafe(
             `SELECT id, repository_id, github_issue_number, model, variant, state,
@@ -459,13 +482,18 @@ export const makeWorkItemLifecycleLive = (
           return yield* new WorkItemNotFoundError({ workItemId })
         }
 
-        const stepRunsByWorkItem = yield* loadStepRuns([row.id])
-        return toWorkItemRecord(row, stepRunsByWorkItem.get(row.id) ?? [])
+        const stepRunsByWorkItem = yield* loadStepRuns([row.id], nowMs)
+        return toWorkItemRecord(
+          row,
+          stepRunsByWorkItem.get(row.id) ?? [],
+          nowMs,
+        )
       })
 
       const listWorkItemsForIssue = Effect.fn(
         "WorkItemLifecycle.listWorkItemsForIssue",
       )(function* (repositoryId: string, githubIssueNumber: number) {
+        const nowMs = yield* Clock.currentTimeMillis
         const rows = (yield* sql
           .unsafe(
             `SELECT id, repository_id, github_issue_number, model, variant, state,
@@ -480,9 +508,10 @@ export const makeWorkItemLifecycleLive = (
 
         const stepRunsByWorkItem = yield* loadStepRuns(
           rows.map((row) => row.id),
+          nowMs,
         )
         return rows.map((row) =>
-          toWorkItemRecord(row, stepRunsByWorkItem.get(row.id) ?? []),
+          toWorkItemRecord(row, stepRunsByWorkItem.get(row.id) ?? [], nowMs),
         )
       })
 
@@ -664,7 +693,7 @@ export const makeWorkItemLifecycleLive = (
             }
       }): Effect.Effect<WorkItemRecord, RunStepError> =>
         Effect.gen(function* () {
-          const now = Date.now()
+          const now = yield* Clock.currentTimeMillis
           const { stepRun, workItem, output, revalidation } = input
           const nextStep = nextOperationalStep(stepRun.step)
           const worktreePath = output.worktreePath ?? workItem.worktree_path
@@ -777,7 +806,7 @@ export const makeWorkItemLifecycleLive = (
         readonly cause: Cause.Cause<unknown>
       }): Effect.Effect<WorkItemRecord, RunStepError> =>
         Effect.gen(function* () {
-          const now = Date.now()
+          const now = yield* Clock.currentTimeMillis
           const { stepRun, workItem, reasonCode, reasonMessage, cause } = input
 
           yield* Effect.logError("Lifecycle Step handler failed", {
@@ -830,7 +859,7 @@ export const makeWorkItemLifecycleLive = (
         readonly cause?: Cause.Cause<unknown>
       }): Effect.Effect<void, RunStepError> =>
         Effect.gen(function* () {
-          const now = Date.now()
+          const now = yield* Clock.currentTimeMillis
           const { stepRun, reasonMessage, cause } = input
 
           if (cause) {
@@ -903,28 +932,28 @@ export const makeWorkItemLifecycleLive = (
           })
         }
 
-        const startedAt = Date.now()
+        const startedAt = yield* Clock.currentTimeMillis
         const startedRows = (yield* sql
           .unsafe(
             `UPDATE step_run
-           SET status = 'running', started_at = ?, updated_at = ?
-           WHERE id = ?
-             AND status = 'queued'
-             AND step = ?
-             AND EXISTS (
-               SELECT 1 FROM work_item
-               WHERE work_item.id = step_run.work_item_id
-                 AND work_item.state = step_run.step
-                 AND work_item.state NOT IN ('complete', 'failed', 'abandoned')
-             )
-             AND NOT EXISTS (
-               SELECT 1 FROM step_run AS other
-                WHERE other.work_item_id = step_run.work_item_id
-                  AND other.status = 'running'
-                  AND other.id != step_run.id
+            SET status = 'running', started_at = ?, updated_at = ?
+            WHERE id = ?
+              AND status = 'queued'
+              AND step = ?
+              AND EXISTS (
+                SELECT 1 FROM work_item
+                WHERE work_item.id = step_run.work_item_id
+                  AND work_item.state = step_run.step
+                  AND work_item.state NOT IN ('complete', 'failed', 'abandoned')
               )
-            RETURNING id, work_item_id, step, status, queue_job_id, queued_at,
-                      started_at, finished_at, reason_code, reason_message`,
+              AND NOT EXISTS (
+                SELECT 1 FROM step_run AS other
+                 WHERE other.work_item_id = step_run.work_item_id
+                   AND other.status = 'running'
+                   AND other.id != step_run.id
+               )
+             RETURNING id, work_item_id, step, status, queue_job_id, queued_at,
+                       started_at, finished_at, reason_code, reason_message`,
             [startedAt, startedAt, stepRunId, stepRun.step],
           )
           .pipe(Effect.mapError(toDatabaseError))) as readonly StepRunRow[]
@@ -935,7 +964,8 @@ export const makeWorkItemLifecycleLive = (
           if (current?.status === "running") {
             const maxDurationMs = Duration.toMillis(maxDurations[current.step])
             const startedMs = current.started_at ?? 0
-            const leaseExpired = Date.now() - startedMs >= maxDurationMs
+            const nowMs = yield* Clock.currentTimeMillis
+            const leaseExpired = nowMs - startedMs >= maxDurationMs
             if (leaseExpired) {
               yield* completeInterruptedStep({
                 stepRun: current,
@@ -1050,24 +1080,24 @@ export const makeWorkItemLifecycleLive = (
           })
         }
 
-        const now = Date.now()
+        const now = yield* Clock.currentTimeMillis
 
         yield* sql
           .withTransaction(
             Effect.gen(function* () {
               const abandonedRows = (yield* sql.unsafe(
                 `UPDATE work_item
-                 SET state = 'abandoned',
-                     state_ready_at = ?,
-                     updated_at = ?
-                 WHERE id = ?
-                   AND state NOT IN ('complete', 'failed', 'abandoned')
-                   AND NOT EXISTS (
-                     SELECT 1 FROM step_run
-                     WHERE step_run.work_item_id = work_item.id
-                       AND step_run.status = 'running'
-                   )
-                 RETURNING id`,
+                  SET state = 'abandoned',
+                      state_ready_at = ?,
+                      updated_at = ?
+                  WHERE id = ?
+                    AND state NOT IN ('complete', 'failed', 'abandoned')
+                    AND NOT EXISTS (
+                      SELECT 1 FROM step_run
+                      WHERE step_run.work_item_id = work_item.id
+                        AND step_run.status = 'running'
+                    )
+                  RETURNING id`,
                 [now, now, workItemId],
               )) as readonly { readonly id: string }[]
 
@@ -1242,7 +1272,7 @@ export const makeWorkItemLifecycleLive = (
           })
         }
 
-        const now = Date.now()
+        const now = yield* Clock.currentTimeMillis
         const nextStepRunId = makeStepRunId()
 
         yield* sql
@@ -1401,7 +1431,7 @@ export const makeWorkItemLifecycleLive = (
           const config = yield* db.getConfig
           const workItemId = makeWorkItemId()
           const stepRunId = makeStepRunId()
-          const now = Date.now()
+          const now = yield* Clock.currentTimeMillis
           const step: OperationalLifecycleStep = "create_worktree"
 
           const createdId = yield* sql

--- a/packages/work-item-lifecycle/test/work-item-lifecycle.spec.ts
+++ b/packages/work-item-lifecycle/test/work-item-lifecycle.spec.ts
@@ -8,9 +8,14 @@ import {
   Option,
   Result,
 } from "effect"
+import { TestClock } from "effect/testing"
 import { SqlClient } from "effect/unstable/sql"
 import { DatabaseTest } from "@ready-for-agent/db/test"
-import { DbService, DbServiceLive } from "@ready-for-agent/db-service"
+import {
+  DbService,
+  DbServiceLive,
+  RepositoryHasRunningStepError,
+} from "@ready-for-agent/db-service"
 import {
   EnqueueError,
   type JobId,
@@ -81,6 +86,18 @@ describe("WorkItemLifecycle", () => {
     steps: LifecycleStepsShape,
     test: Effect.Effect<A, E, TestRequirements>,
   ): Promise<A> => Effect.runPromise(Effect.provide(test, makeTestLayer(steps)))
+
+  const runWithTestClock = <A, E>(
+    test: Effect.Effect<A, E, TestRequirements | TestClock.TestClock>,
+  ): Promise<A> =>
+    Effect.runPromise(
+      Effect.scoped(
+        Effect.provide(
+          test,
+          TestLayer.pipe(Layer.provideMerge(TestClock.layer())),
+        ),
+      ),
+    )
 
   const sampleRepository = {
     githubOwner: "acme",
@@ -468,6 +485,267 @@ describe("WorkItemLifecycle", () => {
           expect(error).toBeInstanceOf(WorkItemNotFoundError)
         }),
       ))
+
+    it("lists Complete, Failed, and Abandoned attempts in creation order", () =>
+      runTest(
+        Effect.gen(function* () {
+          const lifecycle = yield* WorkItemLifecycle
+          const queue = yield* QueueService
+          const db = yield* DbService
+          const { repository, issue } = yield* seedActionableIssue
+
+          const claimAndRun = Effect.gen(function* () {
+            const job = yield* queue.rawClaim(WORK_ITEM_LIFECYCLE_QUEUE)
+            expect(Option.isSome(job)).toBe(true)
+            if (Option.isNone(job)) {
+              return yield* Effect.die("expected job")
+            }
+            return yield* lifecycle.runStep(
+              (job.value.payload as { stepRunId: string }).stepRunId,
+            )
+          })
+
+          const complete = yield* lifecycle.implementNow(
+            repository.id,
+            issue.githubIssueNumber,
+          )
+          for (let i = 0; i < 4; i++) {
+            yield* claimAndRun
+          }
+          expect((yield* lifecycle.getWorkItem(complete.id)).state).toBe(
+            "complete",
+          )
+
+          const failed = yield* lifecycle.implementNow(
+            repository.id,
+            issue.githubIssueNumber,
+          )
+          yield* db.deleteIssue(repository.id, issue.githubIssueNumber)
+          const failJob = yield* queue.rawClaim(WORK_ITEM_LIFECYCLE_QUEUE)
+          if (Option.isNone(failJob)) {
+            return yield* Effect.die("expected job")
+          }
+          yield* lifecycle.runStep(
+            (failJob.value.payload as { stepRunId: string }).stepRunId,
+          )
+          expect((yield* lifecycle.getWorkItem(failed.id)).state).toBe("failed")
+
+          yield* db.storeIssue({
+            repositoryId: repository.id,
+            githubIssueNumber: issue.githubIssueNumber,
+            ...sampleIssueFields,
+          })
+
+          const abandonedQueued = yield* lifecycle.implementNow(
+            repository.id,
+            issue.githubIssueNumber,
+          )
+          yield* lifecycle.abandon(abandonedQueued.id)
+
+          const listed = yield* lifecycle.listWorkItemsForIssue(
+            repository.id,
+            issue.githubIssueNumber,
+          )
+          expect(listed.map((item) => item.state)).toEqual([
+            "complete",
+            "failed",
+            "abandoned",
+          ])
+          expect(listed.map((item) => item.id)).toEqual([
+            complete.id,
+            failed.id,
+            abandonedQueued.id,
+          ])
+        }),
+      ))
+
+    it("allows Implement Now after terminal Complete and Failed attempts", () =>
+      runTest(
+        Effect.gen(function* () {
+          const lifecycle = yield* WorkItemLifecycle
+          const queue = yield* QueueService
+          const { repository, issue } = yield* seedActionableIssue
+
+          const first = yield* lifecycle.implementNow(
+            repository.id,
+            issue.githubIssueNumber,
+          )
+          for (let i = 0; i < 4; i++) {
+            const job = yield* queue.rawClaim(WORK_ITEM_LIFECYCLE_QUEUE)
+            expect(Option.isSome(job)).toBe(true)
+            if (Option.isNone(job)) {
+              return yield* Effect.die("expected job")
+            }
+            yield* lifecycle.runStep(
+              (job.value.payload as { stepRunId: string }).stepRunId,
+            )
+          }
+          expect((yield* lifecycle.getWorkItem(first.id)).state).toBe(
+            "complete",
+          )
+
+          const second = yield* lifecycle.implementNow(
+            repository.id,
+            issue.githubIssueNumber,
+          )
+          expect(second.id).not.toBe(first.id)
+          expect(second.state).toBe("create_worktree")
+
+          const unfinishedBlocks = yield* Effect.flip(
+            lifecycle.implementNow(repository.id, issue.githubIssueNumber),
+          )
+          expect(unfinishedBlocks).toBeInstanceOf(UnfinishedWorkItemExistsError)
+        }),
+      ))
+
+    it("derives queue wait, execution duration, and state residence from timestamps", () =>
+      runWithTestClock(
+        Effect.gen(function* () {
+          const lifecycle = yield* WorkItemLifecycle
+          const queue = yield* QueueService
+          const { repository, issue } = yield* seedActionableIssue
+
+          yield* TestClock.setTime(1_000)
+          const created = yield* lifecycle.implementNow(
+            repository.id,
+            issue.githubIssueNumber,
+          )
+
+          yield* TestClock.setTime(4_000)
+          const queuedOnly = yield* lifecycle.getWorkItem(created.id)
+          expect(queuedOnly.stepRuns[0]!.queueWaitMs).toBe(3_000)
+          expect(queuedOnly.stepRuns[0]!.executionDurationMs).toBeNull()
+          expect(queuedOnly.stateResidenceMs).toBe(3_000)
+
+          const job = yield* queue.rawClaim(WORK_ITEM_LIFECYCLE_QUEUE)
+          expect(Option.isSome(job)).toBe(true)
+          if (Option.isNone(job)) {
+            return yield* Effect.die("expected job")
+          }
+
+          yield* TestClock.setTime(6_000)
+          const afterSuccess = yield* lifecycle.runStep(
+            (job.value.payload as { stepRunId: string }).stepRunId,
+          )
+          expect(afterSuccess._tag).toBe("processed")
+          if (afterSuccess._tag !== "processed") {
+            return
+          }
+
+          const createRun = afterSuccess.workItem.stepRuns[0]!
+          expect(createRun.status).toBe("succeeded")
+          expect(createRun.queueWaitMs).toBe(5_000)
+          expect(createRun.executionDurationMs).toBe(0)
+
+          const installQueued = afterSuccess.workItem.stepRuns[1]!
+          expect(installQueued.status).toBe("queued")
+          expect(installQueued.queueWaitMs).toBe(0)
+          expect(afterSuccess.workItem.stateResidenceMs).toBe(0)
+
+          yield* TestClock.setTime(9_000)
+          const afterAbandon = yield* lifecycle.abandon(created.id)
+          const cancelled = afterAbandon.stepRuns.find(
+            (run) => run.status === "cancelled",
+          )!
+          expect(cancelled.queueWaitMs).toBe(3_000)
+          expect(cancelled.executionDurationMs).toBeNull()
+          expect(afterAbandon.stateResidenceMs).toBe(0)
+        }),
+      ))
+
+    it("derives timings across retries, interruption, and currently running work", async () => {
+      const failingSteps: LifecycleStepsShape = {
+        ...successfulSteps,
+        createWorktree: () => Effect.fail(new Error("first attempt")),
+      }
+
+      return Effect.runPromise(
+        Effect.scoped(
+          Effect.provide(
+            Effect.gen(function* () {
+              const lifecycle = yield* WorkItemLifecycle
+              const queue = yield* QueueService
+              const sql = yield* SqlClient.SqlClient
+              const { repository, issue } = yield* seedActionableIssue
+
+              yield* TestClock.setTime(10_000)
+              const created = yield* lifecycle.implementNow(
+                repository.id,
+                issue.githubIssueNumber,
+              )
+
+              yield* TestClock.setTime(12_000)
+              const job = yield* queue.rawClaim(WORK_ITEM_LIFECYCLE_QUEUE)
+              if (Option.isNone(job)) {
+                return yield* Effect.die("expected job")
+              }
+              yield* lifecycle.runStep(
+                (job.value.payload as { stepRunId: string }).stepRunId,
+              )
+
+              const afterFail = yield* lifecycle.getWorkItem(created.id)
+              expect(afterFail.stepRuns[0]!.status).toBe("failed")
+              expect(afterFail.stepRuns[0]!.queueWaitMs).toBe(2_000)
+              expect(afterFail.stepRuns[0]!.executionDurationMs).toBe(0)
+
+              yield* TestClock.setTime(15_000)
+              const retried = yield* lifecycle.retry(created.id)
+              expect(retried.stepRuns).toHaveLength(2)
+              expect(retried.stepRuns[1]!.status).toBe("queued")
+              expect(retried.stepRuns[1]!.queueWaitMs).toBe(0)
+
+              yield* TestClock.setTime(18_000)
+              const afterQueueWait = yield* lifecycle.getWorkItem(created.id)
+              expect(afterQueueWait.stepRuns[1]!.queueWaitMs).toBe(3_000)
+
+              yield* sql.unsafe(
+                `UPDATE step_run
+                 SET status = 'interrupted',
+                     started_at = ?,
+                     finished_at = ?,
+                     reason_code = ?,
+                     reason_message = 'worker lost',
+                     updated_at = ?
+                 WHERE id = ?`,
+                [
+                  16_000,
+                  17_000,
+                  STEP_RUN_REASON.interrupted,
+                  17_000,
+                  afterQueueWait.stepRuns[1]!.id,
+                ],
+              )
+              if (afterQueueWait.stepRuns[1]!.queueJobId) {
+                yield* queue
+                  .acknowledge(afterQueueWait.stepRuns[1]!.queueJobId)
+                  .pipe(Effect.catch(() => Effect.void))
+              }
+
+              const interrupted = yield* lifecycle.getWorkItem(created.id)
+              expect(interrupted.stepRuns[1]!.queueWaitMs).toBe(1_000)
+              expect(interrupted.stepRuns[1]!.executionDurationMs).toBe(1_000)
+
+              yield* TestClock.setTime(20_000)
+              const third = yield* lifecycle.retry(created.id)
+              yield* sql.unsafe(
+                `UPDATE step_run
+                 SET status = 'running', started_at = ?, updated_at = ?
+                 WHERE id = ?`,
+                [21_000, 21_000, third.stepRuns[2]!.id],
+              )
+              yield* TestClock.setTime(24_000)
+              const running = yield* lifecycle.getWorkItem(created.id)
+              expect(running.stepRuns[2]!.queueWaitMs).toBe(1_000)
+              expect(running.stepRuns[2]!.executionDurationMs).toBe(3_000)
+              expect(running.stateResidenceMs).toBe(14_000)
+            }),
+            makeTestLayer(failingSteps).pipe(
+              Layer.provideMerge(TestClock.layer()),
+            ),
+          ),
+        ),
+      )
+    })
   })
 
   describe("queue requirements", () => {
@@ -1884,5 +2162,149 @@ describe("WorkItemLifecycle", () => {
         }),
       )
     })
+  })
+
+  describe("Repository removal", () => {
+    it("rejects removal while a Step Run is Running and leaves data unchanged", () =>
+      runTest(
+        Effect.gen(function* () {
+          const lifecycle = yield* WorkItemLifecycle
+          const db = yield* DbService
+          const sql = yield* SqlClient.SqlClient
+          const { repository, issue } = yield* seedActionableIssue
+
+          const created = yield* lifecycle.implementNow(
+            repository.id,
+            issue.githubIssueNumber,
+          )
+          yield* sql.unsafe(
+            `UPDATE step_run
+             SET status = 'running', started_at = ?, updated_at = ?
+             WHERE id = ?`,
+            [Date.now(), Date.now(), created.stepRuns[0]!.id],
+          )
+
+          const error = yield* Effect.flip(db.removeRepository(repository.id))
+          expect(error).toBeInstanceOf(RepositoryHasRunningStepError)
+          if (error instanceof RepositoryHasRunningStepError) {
+            expect(error.repositoryId).toBe(repository.id)
+            expect(error.stepRunId).toBe(created.stepRuns[0]!.id)
+            expect(error.workItemId).toBe(created.id)
+          }
+
+          expect(yield* db.listRepositories).toHaveLength(1)
+          expect(
+            yield* lifecycle.listWorkItemsForIssue(
+              repository.id,
+              issue.githubIssueNumber,
+            ),
+          ).toHaveLength(1)
+          const jobs = yield* sql.unsafe(
+            "SELECT id FROM job_queue WHERE id = ?",
+            [created.stepRuns[0]!.queueJobId],
+          )
+          expect(jobs).toHaveLength(1)
+          expect(
+            (yield* lifecycle.getWorkItem(created.id)).stepRuns[0]!.status,
+          ).toBe("running")
+        }),
+      ))
+
+    it("removes queued and Failed history with the Repository when nothing is Running", () => {
+      const steps: LifecycleStepsShape = {
+        ...successfulSteps,
+        createWorktree: () => Effect.fail(new Error("failed before removal")),
+      }
+
+      return runWithSteps(
+        steps,
+        Effect.gen(function* () {
+          const lifecycle = yield* WorkItemLifecycle
+          const db = yield* DbService
+          const sql = yield* SqlClient.SqlClient
+          const queue = yield* QueueService
+          const { repository, issue } = yield* seedActionableIssue
+
+          const failed = yield* lifecycle.implementNow(
+            repository.id,
+            issue.githubIssueNumber,
+          )
+          const failedJob = yield* queue.rawClaim(WORK_ITEM_LIFECYCLE_QUEUE)
+          if (Option.isNone(failedJob)) {
+            return yield* Effect.die("expected job")
+          }
+          yield* lifecycle.runStep(
+            (failedJob.value.payload as { stepRunId: string }).stepRunId,
+          )
+          const afterFailure = yield* lifecycle.getWorkItem(failed.id)
+          expect(afterFailure.stepRuns[0]!.status).toBe("failed")
+
+          yield* lifecycle.abandon(failed.id)
+
+          const stillQueued = yield* lifecycle.implementNow(
+            repository.id,
+            issue.githubIssueNumber,
+          )
+          expect(stillQueued.state).toBe("create_worktree")
+          expect(
+            (yield* lifecycle.listWorkItemsForIssue(
+              repository.id,
+              issue.githubIssueNumber,
+            )).map((item) => item.state),
+          ).toEqual(["abandoned", "create_worktree"])
+
+          yield* db.removeRepository(repository.id)
+
+          expect(yield* db.listRepositories).toEqual([])
+          expect(yield* sql.unsafe("SELECT id FROM work_item")).toEqual([])
+          expect(yield* sql.unsafe("SELECT id FROM step_run")).toEqual([])
+          expect(yield* sql.unsafe("SELECT id FROM issue")).toEqual([])
+          expect(
+            yield* sql.unsafe("SELECT id FROM job_queue WHERE id IN (?, ?)", [
+              failed.stepRuns[0]!.queueJobId,
+              stillQueued.stepRuns[0]!.queueJobId,
+            ]),
+          ).toEqual([])
+        }),
+      )
+    })
+
+    it("rolls back all lifecycle and Repository changes when removal fails", () =>
+      runTest(
+        Effect.gen(function* () {
+          const lifecycle = yield* WorkItemLifecycle
+          const db = yield* DbService
+          const queue = yield* QueueService
+          const sql = yield* SqlClient.SqlClient
+          const { repository, issue } = yield* seedActionableIssue
+
+          const created = yield* lifecycle.implementNow(
+            repository.id,
+            issue.githubIssueNumber,
+          )
+          yield* sql.unsafe(
+            `CREATE TRIGGER reject_repository_removal
+             BEFORE DELETE ON repository
+             BEGIN
+               SELECT RAISE(ABORT, 'injected removal failure');
+             END`,
+          )
+
+          const error = yield* Effect.flip(db.removeRepository(repository.id))
+          expect(error._tag).toBe("DatabaseError")
+
+          expect(yield* db.listRepositories).toHaveLength(1)
+          expect(yield* db.listIssues(repository.id)).toHaveLength(1)
+          const unchanged = yield* lifecycle.getWorkItem(created.id)
+          expect(unchanged.state).toBe("create_worktree")
+          expect(unchanged.stepRuns[0]!.status).toBe("queued")
+
+          const queued = yield* queue.rawClaim(WORK_ITEM_LIFECYCLE_QUEUE)
+          expect(Option.isSome(queued)).toBe(true)
+          if (Option.isSome(queued)) {
+            expect(queued.value.jobId).toBe(created.stepRuns[0]!.queueJobId)
+          }
+        }),
+      ))
   })
 })


### PR DESCRIPTION
## Why

Operators need trustworthy lifecycle history and safe Repository teardown.

Without derived timings and ordered multi-attempt history, it is hard to inspect queue wait, execution duration, and step residence for Complete, Failed, and Abandoned Work Items. Without removal safety, deleting a Repository can detach a live Running Step Run or leave orphaned jobs and lifecycle records.

Closes #73.

## What Changed

- `getWorkItem` / `listWorkItemsForIssue` return ordered Step Runs and derive `queueWaitMs`, `executionDurationMs`, and `stateResidenceMs` from timestamps via Effect `Clock`.
- Lifecycle writes use the injected clock so timing tests can use `TestClock`.
- `DbService.removeRepository` rejects with `RepositoryHasRunningStepError` while any Step Run is Running; otherwise it cancels queued runs, removes jobs, auto-abandons unfinished Work Items, and deletes lifecycle history with the Repository in one transaction.
- Integration tests cover history ordering, derived timings, multi-attempt Implement Now, blocked removal, successful removal with queued/failed work, and transaction rollback.
