### PR TITLE
feat(work-item-lifecycle): commit via OpenCode session continue

### DIFF
--- a/docs/adr/0011-commit-after-local-review.md
+++ b/docs/adr/0011-commit-after-local-review.md
@@ -1,9 +1,9 @@
 # Commit After Local Review
 
-After Review succeeds and before a future Create PR step, Ready For Agent creates a local git commit in the Work Item worktree. The Commit step stages with `git add -A` and runs `git commit` when the index is non-empty. An empty index after staging succeeds without creating a commit so already-committed worktrees remain re-entrant. Failure records full git output on the Step Run and leaves Commit pending for Retry.
+After Review succeeds and before a future Create PR step, the Commit Lifecycle Step continues the Implement OpenCode Session and asks it to create a local git commit in the Work Item worktree. Lifecycle Steps are harness orchestration; Commit (like Implement and Review) is performed by OpenCode, not by the harness shelling out to `git commit`. The prompt requires the commit message to mention that it closes the Work Item's GitHub Issue and to follow the repository's commit conventions. Success is OpenCode exit success; the harness does not inspect git history. Failure leaves Commit pending for Retry.
 
 ## Consequences
 
-- Commit is a first-class Lifecycle Step between Review and Complete (and before Create PR when that step exists).
-- Pre-Commit remains validation-only; Commit is the step that records implementation changes as a git commit.
-- Re-running Commit on a clean index is a no-op success.
+- Commit remains a first-class Lifecycle Step between Review and Complete (and before Create PR when that step exists).
+- Pre-Commit is still harness-run git validation; Commit's work is OpenCode Session continue.
+- OpenCode owns staging, message wording (including conventional commits when the repo requires them), and whether a no-op is appropriate when nothing remains to commit.

--- a/packages/work-item-lifecycle/src/lib/commit-errors.ts
+++ b/packages/work-item-lifecycle/src/lib/commit-errors.ts
@@ -15,22 +15,24 @@ export class CommitInvalidWorktreeContextError extends Data.TaggedError(
   readonly message: string
 }> {}
 
-export class CommitStageError extends Data.TaggedError("CommitStageError")<{
+export class CommitSessionContextMissingError extends Data.TaggedError(
+  "CommitSessionContextMissingError",
+)<{
+  readonly workItemId: string
   readonly message: string
-  readonly worktreePath: string
-  readonly exitCode: number
-  readonly output: string
 }> {}
 
-export class CommitFailedError extends Data.TaggedError("CommitFailedError")<{
+export class CommitOpenCodeError extends Data.TaggedError(
+  "CommitOpenCodeError",
+)<{
   readonly message: string
   readonly worktreePath: string
-  readonly exitCode: number
-  readonly output: string
+  readonly sessionId?: string
+  readonly cause?: unknown
 }> {}
 
 export type CommitError =
   | CommitWorktreeContextMissingError
   | CommitInvalidWorktreeContextError
-  | CommitStageError
-  | CommitFailedError
+  | CommitSessionContextMissingError
+  | CommitOpenCodeError

--- a/packages/work-item-lifecycle/src/lib/commit.ts
+++ b/packages/work-item-lifecycle/src/lib/commit.ts
@@ -1,12 +1,13 @@
-import { Effect, FileSystem, Stream } from "effect"
-import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process"
+import { Effect, FileSystem } from "effect"
+import { Opencode } from "@ready-for-agent/opencode"
 import {
-  CommitFailedError,
   CommitInvalidWorktreeContextError,
-  CommitStageError,
+  CommitOpenCodeError,
+  CommitSessionContextMissingError,
   CommitWorktreeContextMissingError,
 } from "./commit-errors.js"
 import type { LifecycleStepContext } from "./lifecycle-steps.js"
+import { DEFAULT_LIFECYCLE_MAX_DURATIONS } from "./types.js"
 
 const resolveWorktreePath = (context: LifecycleStepContext) =>
   Effect.gen(function* () {
@@ -40,89 +41,62 @@ const resolveWorktreePath = (context: LifecycleStepContext) =>
     return worktreePath
   })
 
-const runGitInWorktree = (cwd: string, args: ReadonlyArray<string>) =>
-  Effect.gen(function* () {
-    const spawner = yield* ChildProcessSpawner.ChildProcessSpawner
-    const command = ChildProcess.make("git", args, {
-      cwd,
-      stdin: "ignore",
-    })
-
-    return yield* Effect.scoped(
-      Effect.gen(function* () {
-        const handle = yield* spawner.spawn(command)
-        const [exitCode, stdout, stderr] = yield* Effect.all(
-          [
-            handle.exitCode,
-            Stream.decodeText(handle.stdout).pipe(Stream.mkString),
-            Stream.decodeText(handle.stderr).pipe(Stream.mkString),
-          ],
-          { concurrency: 3 },
-        )
-        const output = [stdout, stderr]
-          .map((part) => part.trim())
-          .filter((part) => part.length > 0)
-          .join("\n")
-        return {
-          exitCode: Number(exitCode),
-          output,
-        }
+const resolveSessionId = (context: LifecycleStepContext) => {
+  const sessionId = context.sessionId
+  if (sessionId === null || sessionId.trim() === "") {
+    return Effect.fail(
+      new CommitSessionContextMissingError({
+        workItemId: context.workItemId,
+        message:
+          "Commit requires a Session ID persisted by a successful Implement Step Run",
       }),
     )
-  })
+  }
+  return Effect.succeed(sessionId)
+}
 
-const commitMessage = (context: LifecycleStepContext): string =>
-  `Implement #${context.githubIssueNumber}`
+const buildCommitPrompt = (githubIssueNumber: number) =>
+  [
+    "Create a git commit for the implementation changes in this worktree.",
+    "Follow this repository's commit message conventions (for example conventional commits if the repo uses them).",
+    `The commit message must mention that it closes GitHub issue #${githubIssueNumber}.`,
+    "Stage only the relevant implementation changes, then commit.",
+    "If there is nothing left to commit, succeed without creating an empty commit.",
+    "Do not open a pull request.",
+  ].join("\n")
 
 /**
  * Production Commit Lifecycle Step.
- * Stages all worktree changes and creates a local git commit when the index is
- * non-empty. A clean index after staging succeeds without creating a commit so
- * re-runs and already-committed worktrees remain re-entrant.
+ * Continues the Implement OpenCode Session in the Work Item worktree and asks
+ * it to create the local git commit, including that the commit closes the
+ * Work Item's GitHub Issue. Success means the command exited successfully;
+ * the step does not inspect the resulting git history.
  */
 export const commit = (context: LifecycleStepContext) =>
   Effect.gen(function* () {
     const worktreePath = yield* resolveWorktreePath(context)
+    const sessionId = yield* resolveSessionId(context)
+    const prompt = buildCommitPrompt(context.githubIssueNumber)
 
-    const stage = yield* runGitInWorktree(worktreePath, ["add", "-A"])
-    if (stage.exitCode !== 0) {
-      return yield* new CommitStageError({
-        message: `Failed to stage worktree changes before commit (exit ${stage.exitCode})`,
-        worktreePath,
-        exitCode: stage.exitCode,
-        output: stage.output || "(no output)",
+    const opencode = yield* Opencode
+    yield* opencode
+      .continue({
+        sessionId,
+        prompt,
+        cwd: worktreePath,
+        model: context.model,
+        variant: context.variant,
+        timeout: context.maxDuration ?? DEFAULT_LIFECYCLE_MAX_DURATIONS.commit,
       })
-    }
-
-    const staged = yield* runGitInWorktree(worktreePath, [
-      "diff",
-      "--cached",
-      "--quiet",
-    ])
-    // git diff --quiet: 0 = no diff, 1 = has diff, other = error
-    if (staged.exitCode === 0) {
-      return
-    }
-    if (staged.exitCode !== 1) {
-      return yield* new CommitFailedError({
-        message: `Failed to inspect staged changes before commit (exit ${staged.exitCode})`,
-        worktreePath,
-        exitCode: staged.exitCode,
-        output: staged.output || "(no output)",
-      })
-    }
-
-    const result = yield* runGitInWorktree(worktreePath, [
-      "commit",
-      "-m",
-      commitMessage(context),
-    ])
-    if (result.exitCode !== 0) {
-      return yield* new CommitFailedError({
-        message: `git commit failed (exit ${result.exitCode})`,
-        worktreePath,
-        exitCode: result.exitCode,
-        output: result.output || "(no output)",
-      })
-    }
+      .pipe(
+        Effect.mapError(
+          (cause) =>
+            new CommitOpenCodeError({
+              message: "OpenCode failed to commit the Work Item changes",
+              worktreePath,
+              sessionId,
+              cause,
+            }),
+        ),
+      )
   })

--- a/packages/work-item-lifecycle/src/lib/lifecycle-steps-live.ts
+++ b/packages/work-item-lifecycle/src/lib/lifecycle-steps-live.ts
@@ -13,7 +13,8 @@ import { review } from "./review.js"
 
 /**
  * Production LifecycleSteps: Create Worktree, Install Dependencies, Implement,
- * Pre-Commit, Review, and Commit.
+ * Pre-Commit, Review, and Commit (OpenCode continues the Implement Session for
+ * Review and Commit; Pre-Commit remains harness git validation).
  * Captures platform, database, and OpenCode services so handlers remain
  * `Effect<A>` with no requirements.
  */

--- a/packages/work-item-lifecycle/src/lib/work-item-lifecycle.ts
+++ b/packages/work-item-lifecycle/src/lib/work-item-lifecycle.ts
@@ -25,7 +25,6 @@ import {
   type JobNotFoundError,
   QueueService,
 } from "@ready-for-agent/queue-service"
-import { CommitFailedError, CommitStageError } from "./commit-errors.js"
 import {
   ActiveStepRunExistsError,
   IssueBlockedError,
@@ -134,9 +133,7 @@ const conciseMessage = (value: unknown, fallback: string): string => {
 const handlerFailureMessage = (error: unknown): string => {
   if (
     error instanceof PreCommitHookFailedError ||
-    error instanceof PreCommitStageError ||
-    error instanceof CommitFailedError ||
-    error instanceof CommitStageError
+    error instanceof PreCommitStageError
   ) {
     return `${error.message}\n${error.output}`
   }

--- a/packages/work-item-lifecycle/test/commit.spec.ts
+++ b/packages/work-item-lifecycle/test/commit.spec.ts
@@ -1,12 +1,19 @@
-import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises"
+import { mkdtemp, rm } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { BunServices } from "@effect/platform-bun"
-import { Effect, type Layer } from "effect"
+import { Duration, Effect, Layer } from "effect"
+import {
+  Opencode,
+  OpencodeExitError,
+  OpencodeTimeoutError,
+  SessionIdNotFoundError,
+} from "@ready-for-agent/opencode"
 import type { LifecycleStepContext } from "../src/index.js"
 import {
-  CommitFailedError,
   CommitInvalidWorktreeContextError,
+  CommitOpenCodeError,
+  CommitSessionContextMissingError,
   CommitWorktreeContextMissingError,
   commit,
   makeWorkItemId,
@@ -15,58 +22,61 @@ import { describe, expect, it } from "bun:test"
 
 const PlatformLayer = BunServices.layer
 
-const baseContext = (worktreePath: string | null): LifecycleStepContext => ({
+const baseContext = (
+  worktreePath: string | null,
+  overrides: Partial<LifecycleStepContext> = {},
+): LifecycleStepContext => ({
   workItemId: makeWorkItemId(),
   repositoryId: "repo-test",
   githubIssueNumber: 91,
   model: "opencode/test-model",
   variant: "high",
   worktreePath,
-  sessionId: "ses_commit",
+  sessionId: "ses_implement_session",
+  ...overrides,
 })
 
+const stubOpencode = (impl: {
+  readonly start?: (input: {
+    readonly prompt: string
+    readonly cwd: string
+    readonly model: string
+    readonly variant: string
+    readonly timeout?: Duration.Input
+  }) => Effect.Effect<{ sessionId: string }, never>
+  readonly continue?: (input: {
+    readonly sessionId: string
+    readonly prompt: string
+    readonly cwd: string
+    readonly model: string
+    readonly variant: string
+    readonly timeout?: Duration.Input
+  }) => Effect.Effect<{ sessionId: string }, never>
+}) =>
+  Layer.succeed(
+    Opencode,
+    Opencode.of({
+      start: (input) =>
+        impl.start?.(input) ??
+        Effect.succeed({ sessionId: "ses_start_should_not_run" }),
+      continue: (input) =>
+        impl.continue?.(input) ??
+        Effect.succeed({ sessionId: "ses_commit_default" }),
+      listModels: () => Effect.succeed([]),
+    }),
+  )
+
 const run = <A, E>(
-  effect: Effect.Effect<A, E, Layer.Layer.Success<typeof PlatformLayer>>,
-): Promise<A> => Effect.runPromise(effect.pipe(Effect.provide(PlatformLayer)))
+  effect: Effect.Effect<A, E, Opencode>,
+  opencodeLayer: Layer.Layer<Opencode, never, never> = stubOpencode({}),
+): Promise<A> =>
+  Effect.runPromise(
+    effect.pipe(Effect.provide(opencodeLayer), Effect.provide(PlatformLayer)),
+  )
 
-const initGitRepo = async (root: string) => {
-  const runGit = async (...args: string[]) => {
-    const proc = Bun.spawn(["git", ...args], {
-      cwd: root,
-      stdout: "ignore",
-      stderr: "pipe",
-    })
-    const exitCode = await proc.exited
-    if (exitCode !== 0) {
-      const stderr = await new Response(proc.stderr).text()
-      throw new Error(`git ${args.join(" ")} failed: ${stderr}`)
-    }
-  }
-  await runGit("init")
-  await runGit("config", "user.email", "test@example.com")
-  await runGit("config", "user.name", "Test")
-  await runGit("commit", "--allow-empty", "-m", "init")
-}
-
-const gitStdout = async (root: string, ...args: string[]) => {
-  const proc = Bun.spawn(["git", ...args], {
-    cwd: root,
-    stdout: "pipe",
-    stderr: "pipe",
-  })
-  const exitCode = await proc.exited
-  const stdout = await new Response(proc.stdout).text()
-  if (exitCode !== 0) {
-    const stderr = await new Response(proc.stderr).text()
-    throw new Error(`git ${args.join(" ")} failed: ${stderr}`)
-  }
-  return stdout.trim()
-}
-
-const withTempGit = async (assert: (root: string) => Promise<void>) => {
+const withTemp = async (assert: (root: string) => Promise<void>) => {
   const root = await mkdtemp(join(tmpdir(), "rfa-commit-"))
   try {
-    await initGitRepo(root)
     await assert(root)
   } finally {
     await rm(root, { recursive: true, force: true })
@@ -85,55 +95,124 @@ describe("commit", () => {
     expect(error).toBeInstanceOf(CommitInvalidWorktreeContextError)
   })
 
-  it("creates a commit for staged implementation changes", () =>
-    withTempGit(async (root) => {
-      await writeFile(join(root, "change.txt"), "implemented\n")
-      await run(commit(baseContext(root)))
-      const message = await gitStdout(root, "log", "-1", "--pretty=%s")
-      expect(message).toBe("Implement #91")
-      const subjectFiles = await gitStdout(
-        root,
-        "show",
-        "--name-only",
-        "--pretty=format:",
-        "HEAD",
+  it("rejects missing Session context", () =>
+    withTemp(async (root) => {
+      const error = await run(
+        commit(baseContext(root, { sessionId: null })).pipe(Effect.flip),
       )
-      expect(subjectFiles).toContain("change.txt")
+      expect(error).toBeInstanceOf(CommitSessionContextMissingError)
     }))
 
-  it("succeeds without creating a commit when the index is empty", () =>
-    withTempGit(async (root) => {
-      const before = await gitStdout(root, "rev-parse", "HEAD")
-      await run(commit(baseContext(root)))
-      const after = await gitStdout(root, "rev-parse", "HEAD")
-      expect(after).toBe(before)
+  it("rejects blank Session context", () =>
+    withTemp(async (root) => {
+      const error = await run(
+        commit(baseContext(root, { sessionId: "   " })).pipe(Effect.flip),
+      )
+      expect(error).toBeInstanceOf(CommitSessionContextMissingError)
     }))
 
-  it("is re-entrant after a successful commit", () =>
-    withTempGit(async (root) => {
-      await writeFile(join(root, "change.txt"), "implemented\n")
-      await run(commit(baseContext(root)))
-      const first = await gitStdout(root, "rev-parse", "HEAD")
-      await run(commit(baseContext(root)))
-      const second = await gitStdout(root, "rev-parse", "HEAD")
-      expect(second).toBe(first)
+  it("continues the Implement Session with a commit prompt that closes the Issue", () =>
+    withTemp(async (root) => {
+      let continued: {
+        sessionId: string
+        prompt: string
+        cwd: string
+        model: string
+        variant: string
+        timeout?: Duration.Input
+      } | null = null
+      let started = false
+
+      await run(
+        commit(
+          baseContext(root, {
+            sessionId: "ses_from_implement",
+            githubIssueNumber: 2039,
+            model: "opencode/commit-model",
+            variant: "max",
+            maxDuration: Duration.minutes(10),
+          }),
+        ),
+        stubOpencode({
+          start: () => {
+            started = true
+            return Effect.succeed({ sessionId: "ses_wrong" })
+          },
+          continue: (input) => {
+            continued = input
+            return Effect.succeed({ sessionId: "ses_from_implement" })
+          },
+        }),
+      )
+
+      expect(started).toBe(false)
+      expect(continued).not.toBeNull()
+      expect(continued!.sessionId).toBe("ses_from_implement")
+      expect(continued!.cwd).toBe(root)
+      expect(continued!.model).toBe("opencode/commit-model")
+      expect(continued!.variant).toBe("max")
+      expect(Duration.toMillis(continued!.timeout!)).toBe(
+        Duration.toMillis(Duration.minutes(10)),
+      )
+      expect(continued!.prompt).toContain("Create a git commit")
+      expect(continued!.prompt).toContain("closes GitHub issue #2039")
+      expect(continued!.prompt).toContain("Do not open a pull request")
     }))
 
-  it("fails when git commit exits non-zero", () =>
-    withTempGit(async (root) => {
-      await mkdir(join(root, ".git", "hooks"), { recursive: true })
-      await writeFile(
-        join(root, ".git", "hooks", "commit-msg"),
-        "#!/usr/bin/env bash\necho 'commit-msg rejected' >&2\nexit 1\n",
-        { mode: 0o755 },
+  it("maps OpenCode exit failure", () =>
+    withTemp(async (root) => {
+      const error = await run(
+        commit(baseContext(root)).pipe(Effect.flip),
+        Layer.succeed(
+          Opencode,
+          Opencode.of({
+            start: () => Effect.succeed({ sessionId: "unused" }),
+            continue: () =>
+              Effect.fail(new OpencodeExitError({ exitCode: 2, cwd: root })),
+            listModels: () => Effect.succeed([]),
+          }),
+        ),
       )
-      await writeFile(join(root, "change.txt"), "implemented\n")
-      const error = await run(commit(baseContext(root)).pipe(Effect.flip))
-      expect(error).toBeInstanceOf(CommitFailedError)
-      expect((error as CommitFailedError).worktreePath).toBe(root)
-      expect((error as CommitFailedError).exitCode).toBe(1)
-      expect((error as CommitFailedError).output).toContain(
-        "commit-msg rejected",
+      expect(error).toBeInstanceOf(CommitOpenCodeError)
+      expect((error as CommitOpenCodeError).worktreePath).toBe(root)
+      expect((error as CommitOpenCodeError).sessionId).toBe(
+        "ses_implement_session",
       )
+    }))
+
+  it("maps OpenCode timeout failure", () =>
+    withTemp(async (root) => {
+      const error = await run(
+        commit(baseContext(root)).pipe(Effect.flip),
+        Layer.succeed(
+          Opencode,
+          Opencode.of({
+            start: () => Effect.succeed({ sessionId: "unused" }),
+            continue: () =>
+              Effect.fail(
+                new OpencodeTimeoutError({ cwd: root, timeoutMs: 1_000 }),
+              ),
+            listModels: () => Effect.succeed([]),
+          }),
+        ),
+      )
+      expect(error).toBeInstanceOf(CommitOpenCodeError)
+    }))
+
+  it("maps missing Session ID from OpenCode", () =>
+    withTemp(async (root) => {
+      const error = await run(
+        commit(baseContext(root)).pipe(Effect.flip),
+        Layer.succeed(
+          Opencode,
+          Opencode.of({
+            start: () => Effect.succeed({ sessionId: "unused" }),
+            continue: () =>
+              Effect.fail(new SessionIdNotFoundError({ cwd: root })),
+            listModels: () => Effect.succeed([]),
+          }),
+        ),
+      )
+      expect(error).toBeInstanceOf(CommitOpenCodeError)
     }))
 })

--- a/packages/work-item-lifecycle/test/work-item-lifecycle.spec.ts
+++ b/packages/work-item-lifecycle/test/work-item-lifecycle.spec.ts
@@ -25,7 +25,7 @@ import {
 import { SqliteQueueServiceLive } from "@ready-for-agent/sqlite-queue-service"
 import {
   ActiveStepRunExistsError,
-  CommitFailedError,
+  CommitOpenCodeError,
   IssueBlockedError,
   IssueNotFoundError,
   IssueNotOpenError,
@@ -1076,17 +1076,15 @@ describe("WorkItemLifecycle", () => {
       )
     })
 
-    it("persists complete commit output on failure", () => {
-      const output = `commit rejected: ${"x".repeat(9_000)}`
+    it("persists commit OpenCode failure message", () => {
       const steps: LifecycleStepsShape = {
         ...successfulSteps,
-        commit: (context) =>
+        commit: () =>
           Effect.fail(
-            new CommitFailedError({
-              message: "git commit failed (exit 1)",
-              worktreePath: context.worktreePath!,
-              exitCode: 1,
-              output,
+            new CommitOpenCodeError({
+              message: "OpenCode failed to commit the Work Item changes",
+              worktreePath: "/tmp/worktrees/acme-widgets-42",
+              sessionId: "ses_test_implement_session",
             }),
           ),
       }
@@ -1110,7 +1108,7 @@ describe("WorkItemLifecycle", () => {
             const failedRun = result.workItem.stepRuns.at(-1)!
             expect(failedRun.status).toBe("failed")
             expect(failedRun.reasonMessage).toBe(
-              `git commit failed (exit 1)\n${output}`,
+              "OpenCode failed to commit the Work Item changes",
             )
           }
         }),


### PR DESCRIPTION
## Summary
- Commit continues the Implement OpenCode Session instead of the harness shelling out to `git commit`
- Prompt asks OpenCode to follow repo commit conventions and mention that the commit closes the Work Item's GitHub Issue
- Updates ADR 0011: Lifecycle Steps are harness orchestration; Commit work is OpenCode (like Implement/Review)

## Test plan
- [x] `work-item-lifecycle` commit unit tests (continue session, closes-issue prompt, OpenCode error mapping)
- [x] lifecycle failure path persists OpenCode commit failure message
- [x] affected lint/typecheck/test passed on commit