### PR TITLE
fix(harness): tolerate undici stream close race

### DIFF
--- a/apps/harness/src/server.ts
+++ b/apps/harness/src/server.ts
@@ -1,6 +1,11 @@
 import handler, { createServerEntry } from "@tanstack/react-start/server-entry"
 import type { Application } from "./server/application.server.js"
+import { ignoreClosedStreamErrors } from "./server/ignore-closed-stream-errors.js"
 import type { ApplicationRequestContext } from "./server-context.js"
+
+if (import.meta.env.DEV && typeof Bun === "undefined") {
+  ignoreClosedStreamErrors()
+}
 
 let applicationPromise: Promise<Application> | undefined
 

--- a/apps/harness/src/server/ignore-closed-stream-errors.ts
+++ b/apps/harness/src/server/ignore-closed-stream-errors.ts
@@ -1,0 +1,36 @@
+export const isBenignClosedStreamError = (error: unknown): boolean => {
+  if (!(error instanceof TypeError)) return false
+  if ((error as { code?: string }).code !== "ERR_INVALID_STATE") return false
+  if (!error.message.includes("ReadableStream is already closed")) return false
+
+  const stack = error.stack ?? ""
+  return (
+    stack.includes(
+      "at ReadableByteStreamController.close (node:internal/webstreams/readablestream:",
+    ) && stack.includes("at node:internal/deps/undici/undici:")
+  )
+}
+
+/**
+ * Node/undici can race a cancelled body stream against its natural close and
+ * throw outside the request promise. Keep that teardown race from stopping the
+ * dev server while preserving Node's fatal behavior for every other error.
+ */
+export const ignoreClosedStreamErrors = (): void => {
+  const key = Symbol.for("ready-for-agent.ignoreClosedStreamErrors")
+  const state = globalThis as typeof globalThis & { [key]?: true }
+  if (state[key]) return
+  state[key] = true
+
+  process.on("uncaughtException", (error) => {
+    if (isBenignClosedStreamError(error)) return
+    console.error(error)
+    process.exit(1)
+  })
+
+  process.on("unhandledRejection", (reason) => {
+    if (isBenignClosedStreamError(reason)) return
+    console.error("Unhandled Rejection:", reason)
+    process.exit(1)
+  })
+}

--- a/apps/harness/test/ignore-closed-stream-errors.test.ts
+++ b/apps/harness/test/ignore-closed-stream-errors.test.ts
@@ -1,0 +1,28 @@
+import { isBenignClosedStreamError } from "../src/server/ignore-closed-stream-errors.js"
+import { expect, test } from "bun:test"
+
+test("recognizes the undici closed-stream teardown race", () => {
+  const error = new TypeError("Invalid state: ReadableStream is already closed")
+  ;(error as { code?: string }).code = "ERR_INVALID_STATE"
+  error.stack = `${error.name}: ${error.message}
+    at ReadableByteStreamController.close (node:internal/webstreams/readablestream:1190:13)
+    at node:internal/deps/undici/undici:1965:30`
+
+  expect(isBenignClosedStreamError(error)).toBe(true)
+})
+
+test("does not swallow unrelated invalid-state errors", () => {
+  const locked = new TypeError("Invalid state: ReadableStream is locked")
+  ;(locked as { code?: string }).code = "ERR_INVALID_STATE"
+
+  expect(isBenignClosedStreamError(locked)).toBe(false)
+  expect(isBenignClosedStreamError(new Error("boom"))).toBe(false)
+
+  const applicationError = new TypeError(
+    "Invalid state: ReadableStream is already closed",
+  )
+  ;(applicationError as { code?: string }).code = "ERR_INVALID_STATE"
+  applicationError.stack = `${applicationError.name}: ${applicationError.message}
+    at closeApplicationStream (/app/server.ts:42:11)`
+  expect(isBenignClosedStreamError(applicationError)).toBe(false)
+})

--- a/apps/harness/test/topology.test.ts
+++ b/apps/harness/test/topology.test.ts
@@ -83,6 +83,16 @@ describe("single application server topology", () => {
     expect(applicationServer).not.toContain('from "@effect/platform-bun"')
   })
 
+  test("installs the undici stream guard only in Node development", async () => {
+    const serverEntry = await readFile(
+      new URL("../src/server.ts", import.meta.url),
+      "utf8",
+    )
+
+    expect(serverEntry).toContain("import.meta.env.DEV")
+    expect(serverEntry).toContain('typeof Bun === "undefined"')
+  })
+
   test("does not start the long-lived worker during preflight", async () => {
     const preflight = await readFile(
       new URL("../src/server/preflight.ts", import.meta.url),


### PR DESCRIPTION
## Why

Disconnecting a live GraphQL SSE request during `harness:dev` can trigger a Node/undici stream teardown race. Undici then throws `ERR_INVALID_STATE: ReadableStream is already closed` outside the request promise, crashing the development server.

## What Changed

- Install a development-only Node error guard in the harness server entry.
- Ignore only the exact failure signature containing both Node's `ReadableByteStreamController.close` and embedded undici stack frames.
- Preserve fatal process behavior for unrelated exceptions and rejected promises.
- Cover the exact race signature, application-level lookalikes, and development-only installation with tests.

## Verification

- Reproduced the exact undici exception and confirmed the guarded process remains running.
- Confirmed a matching application-level error without the undici stack still exits with status 1.
- Commit hooks passed affected lint, typecheck, and tests (29 harness tests).
