### PR TITLE
feat(harness): show job deletion progress

### DIFF
--- a/apps/harness/src/routes/index.tsx
+++ b/apps/harness/src/routes/index.tsx
@@ -1021,22 +1021,47 @@ function WorkItemLifecycleStatus({
               aria-label={reset.isPending ? "Resetting job" : "Reset job"}
               title={reset.isPending ? "Resetting..." : "Reset"}
             >
-              <svg
-                aria-hidden="true"
-                className="size-4"
-                viewBox="0 0 24 24"
-                fill="none"
-                stroke="currentColor"
-                strokeWidth="2"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-              >
-                <path d="M3 6h18" />
-                <path d="M8 6V4h8v2" />
-                <path d="m19 6-1 14H6L5 6" />
-                <path d="M10 11v5" />
-                <path d="M14 11v5" />
-              </svg>
+              {reset.isPending ? (
+                <svg
+                  aria-hidden="true"
+                  className="size-4 animate-spin motion-reduce:animate-none"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                >
+                  <circle
+                    className="opacity-25"
+                    cx="12"
+                    cy="12"
+                    r="9"
+                    stroke="currentColor"
+                    strokeWidth="3"
+                  />
+                  <path
+                    className="opacity-75"
+                    d="M12 3a9 9 0 0 1 9 9"
+                    stroke="currentColor"
+                    strokeWidth="3"
+                    strokeLinecap="round"
+                  />
+                </svg>
+              ) : (
+                <svg
+                  aria-hidden="true"
+                  className="size-4"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                >
+                  <path d="M3 6h18" />
+                  <path d="M8 6V4h8v2" />
+                  <path d="m19 6-1 14H6L5 6" />
+                  <path d="M10 11v5" />
+                  <path d="M14 11v5" />
+                </svg>
+              )}
             </button>
           )}
           {canRetry && (


### PR DESCRIPTION
## Why

Deleting a job had no visible progress feedback after pressing the trash button, making the action appear unresponsive while the mutation was in flight.

## What Changed

Replace the trash icon with an in-place spinner while job deletion is pending. The action remains disabled, updates its accessible label, preserves its dimensions, and respects reduced-motion preferences.