### PR TITLE
fix(work-item-lifecycle): harden pull request automation

### DIFF
--- a/apps/harness/src/routes/index.tsx
+++ b/apps/harness/src/routes/index.tsx
@@ -182,11 +182,15 @@ const terminalWorkItemStates: readonly WorkItemState[] = [
   "NEEDS_HUMAN",
 ]
 
-const formatLifecycleLabel = (value: string) =>
-  value
+const formatLifecycleLabel = (value: string) => {
+  if (value.toLowerCase() === "watch_pr_status_checks") {
+    return "GitHub status checks"
+  }
+  return value
     .toLowerCase()
     .replaceAll("_", " ")
     .replace(/^./, (first) => first.toUpperCase())
+}
 
 export const Route = createFileRoute("/")({
   component: HomePage,

--- a/packages/opencode/src/index.ts
+++ b/packages/opencode/src/index.ts
@@ -1,4 +1,5 @@
 export * from "./lib/build-args.js"
+export * from "./lib/environment.js"
 export * from "./lib/errors.js"
 export * from "./lib/opencode.js"
 export * from "./lib/parse-session-id.js"

--- a/packages/opencode/src/lib/environment.ts
+++ b/packages/opencode/src/lib/environment.ts
@@ -1,0 +1,32 @@
+const isObject = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value)
+
+export const makeOpencodeEnvironment = (
+  environment: Readonly<Record<string, string | undefined>> = process.env,
+) => {
+  const existingConfigContent = environment.OPENCODE_CONFIG_CONTENT
+  const config: Record<string, unknown> =
+    existingConfigContent === undefined
+      ? {}
+      : (() => {
+          const parsed: unknown = JSON.parse(existingConfigContent)
+          if (!isObject(parsed)) {
+            throw new TypeError(
+              "OPENCODE_CONFIG_CONTENT must contain a JSON object",
+            )
+          }
+          return parsed
+        })()
+  const mcp = isObject(config.mcp) ? config.mcp : {}
+  const keymaxxer = isObject(mcp.keymaxxer) ? mcp.keymaxxer : {}
+
+  return {
+    OPENCODE_CONFIG_CONTENT: JSON.stringify({
+      ...config,
+      mcp: {
+        ...mcp,
+        keymaxxer: { ...keymaxxer, enabled: false },
+      },
+    }),
+  } as const
+}

--- a/packages/opencode/src/lib/opencode.ts
+++ b/packages/opencode/src/lib/opencode.ts
@@ -2,6 +2,7 @@ import { Context, Duration, Effect, Layer, Stream } from "effect"
 import type { PlatformError } from "effect/PlatformError"
 import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process"
 import { buildRunArgs } from "./build-args.js"
+import { makeOpencodeEnvironment } from "./environment.js"
 import {
   OpencodeExitError,
   OpencodeTimeoutError,
@@ -47,6 +48,7 @@ export class Opencode extends Context.Service<
         const spawner = yield* ChildProcessSpawner.ChildProcessSpawner
         const binary = options.binary ?? DEFAULT_BINARY
         const defaultTimeout = options.defaultTimeout ?? DEFAULT_TIMEOUT
+        const environment = makeOpencodeEnvironment()
 
         const listModels = (
           input: ListModelsInput,
@@ -56,6 +58,8 @@ export class Opencode extends Context.Service<
             const timeoutMs = Duration.toMillis(timeout)
             const command = ChildProcess.make(binary, ["models"], {
               cwd: input.cwd,
+              env: environment,
+              extendEnv: true,
               stdin: "ignore",
               stderr: "ignore",
             })
@@ -124,6 +128,8 @@ export class Opencode extends Context.Service<
 
             const command = ChildProcess.make(binary, args, {
               cwd: input.cwd,
+              env: environment,
+              extendEnv: true,
               stdin: "ignore",
               stderr: "ignore",
             })

--- a/packages/opencode/test/environment.spec.ts
+++ b/packages/opencode/test/environment.spec.ts
@@ -1,0 +1,34 @@
+import { makeOpencodeEnvironment } from "../src/index.js"
+import { describe, expect, it } from "bun:test"
+
+describe("makeOpencodeEnvironment", () => {
+  it("disables OpenCode's Keymaxxer MCP", () => {
+    expect(
+      JSON.parse(makeOpencodeEnvironment({}).OPENCODE_CONFIG_CONTENT),
+    ).toEqual({ mcp: { keymaxxer: { enabled: false } } })
+  })
+
+  it("preserves existing configuration while disabling Keymaxxer", () => {
+    const existingConfig = JSON.stringify({
+      model: "anthropic/claude-sonnet-4-5",
+      mcp: {
+        filesystem: { enabled: true },
+        keymaxxer: { enabled: true, timeout: 10_000 },
+      },
+    })
+
+    expect(
+      JSON.parse(
+        makeOpencodeEnvironment({
+          OPENCODE_CONFIG_CONTENT: existingConfig,
+        }).OPENCODE_CONFIG_CONTENT,
+      ),
+    ).toEqual({
+      model: "anthropic/claude-sonnet-4-5",
+      mcp: {
+        filesystem: { enabled: true },
+        keymaxxer: { enabled: false, timeout: 10_000 },
+      },
+    })
+  })
+})

--- a/packages/work-item-lifecycle/src/lib/create-pr.ts
+++ b/packages/work-item-lifecycle/src/lib/create-pr.ts
@@ -1,7 +1,10 @@
 import { Duration, Effect, FileSystem } from "effect"
 import { DbService } from "@ready-for-agent/db-service"
 import { KeymaxxerService } from "@ready-for-agent/keymaxxer-service"
-import { buildRunArgs } from "@ready-for-agent/opencode"
+import {
+  buildRunArgs,
+  makeOpencodeEnvironment,
+} from "@ready-for-agent/opencode"
 import {
   CreatePrCredentialError,
   CreatePrInvalidWorktreeContextError,
@@ -63,6 +66,7 @@ const buildCreatePrPrompt = (githubIssueNumber: number) =>
   [
     "Create a pull request for the committed implementation changes in this worktree.",
     "Push the branch if needed, then open a PR against the repository default base branch.",
+    "Create the pull request as a draft.",
     `The PR must reference GitHub issue #${githubIssueNumber} (for example Closes #${githubIssueNumber}).`,
     "Follow this repository's PR title and body conventions.",
     "If a suitable open PR for this branch already exists, succeed without creating a duplicate.",
@@ -70,7 +74,6 @@ const buildCreatePrPrompt = (githubIssueNumber: number) =>
   ].join("\n")
 
 const shellQuote = (value: string) => `'${value.replaceAll("'", `'"'"'`)}'`
-
 const buildCredentialedOpenCodeCommand = (input: {
   readonly tokenName: string
   readonly prompt: string
@@ -80,12 +83,14 @@ const buildCredentialedOpenCodeCommand = (input: {
   readonly sessionId: string
 }) => {
   const args = buildRunArgs(input)
-  return [
+  const environment = makeOpencodeEnvironment()
+  return `${[
     `GH_TOKEN="$${input.tokenName}"`,
     `GITHUB_TOKEN="$${input.tokenName}"`,
+    `OPENCODE_CONFIG_CONTENT=${shellQuote(environment.OPENCODE_CONFIG_CONTENT)}`,
     shellQuote("opencode"),
     ...args.map(shellQuote),
-  ].join(" ")
+  ].join(" ")} </dev/null`
 }
 
 /**

--- a/packages/work-item-lifecycle/src/lib/pr-status-checks.ts
+++ b/packages/work-item-lifecycle/src/lib/pr-status-checks.ts
@@ -2,7 +2,10 @@ import { Data, Duration, Effect } from "effect"
 import { DbService } from "@ready-for-agent/db-service"
 import { GitHubService } from "@ready-for-agent/github-service"
 import { KeymaxxerService } from "@ready-for-agent/keymaxxer-service"
-import { buildRunArgs } from "@ready-for-agent/opencode"
+import {
+  buildRunArgs,
+  makeOpencodeEnvironment,
+} from "@ready-for-agent/opencode"
 import type { LifecycleStepContext } from "./lifecycle-steps.js"
 import { DEFAULT_LIFECYCLE_MAX_DURATIONS } from "./types.js"
 import { workItemBranchName } from "./worktree-names.js"
@@ -138,12 +141,14 @@ export const investigatePrStatusChecks = (context: LifecycleStepContext) =>
       variant: context.variant,
       sessionId,
     })
-    const command = [
+    const environment = makeOpencodeEnvironment()
+    const command = `${[
       `GH_TOKEN="$${tokenName}"`,
       `GITHUB_TOKEN="$${tokenName}"`,
+      `OPENCODE_CONFIG_CONTENT=${shellQuote(environment.OPENCODE_CONFIG_CONTENT)}`,
       shellQuote("opencode"),
       ...args.map(shellQuote),
-    ].join(" ")
+    ].join(" ")} </dev/null`
     const result = yield* keymaxxer
       .runWithSecrets({
         command,

--- a/packages/work-item-lifecycle/test/create-pr.spec.ts
+++ b/packages/work-item-lifecycle/test/create-pr.spec.ts
@@ -149,11 +149,16 @@ describe("createPr", () => {
       expect(runInput!.command).toStartWith(
         'GH_TOKEN="$GITHUB_TOKEN_ACME_WIDGETS" GITHUB_TOKEN="$GITHUB_TOKEN_ACME_WIDGETS"',
       )
+      expect(runInput!.command).toContain(
+        `OPENCODE_CONFIG_CONTENT='{"mcp":{"keymaxxer":{"enabled":false}}}'`,
+      )
       expect(runInput!.command).toContain("'opencode' 'run' '--auto'")
       expect(runInput!.command).toContain("'--session' 'ses_from_implement'")
       expect(runInput!.command).toContain("GitHub issue #2039")
       expect(runInput!.command).toContain("Closes #2039")
+      expect(runInput!.command).toContain("Create the pull request as a draft")
       expect(runInput!.command).toContain("Do not merge the pull request")
+      expect(runInput!.command).toEndWith(" </dev/null")
     }))
 
   it("rejects a missing repository credential", () =>

--- a/packages/work-item-lifecycle/test/pr-status-checks.spec.ts
+++ b/packages/work-item-lifecycle/test/pr-status-checks.spec.ts
@@ -93,6 +93,10 @@ describe("PR status check steps", () => {
       reason: "A maintainer must approve deployment",
     })
     expect(command).toContain('GH_TOKEN="$GITHUB_TOKEN_ACME_WIDGETS"')
+    expect(command).toContain(
+      `OPENCODE_CONFIG_CONTENT='{"mcp":{"keymaxxer":{"enabled":false}}}'`,
+    )
     expect(command).toContain("'--session' 'ses_implement'")
+    expect(command).toEndWith(" </dev/null")
   })
 })


### PR DESCRIPTION
## Why

Credentialed OpenCode lifecycle commands could remain alive after OpenCode completed because Keymaxxer's subprocess kept stdin open. OpenCode processes also inherited the Keymaxxer MCP, causing redundant credential handling inside a command that was already running through Keymaxxer.

Pull requests created by the lifecycle should begin as drafts, and the harness should describe the PR check phase in user-facing terms.

## What Changed

- Close stdin for Keymaxxer-wrapped Create PR and status-check investigation commands.
- Centralize the OpenCode environment policy that disables OpenCode's Keymaxxer MCP while preserving existing inline configuration.
- Ask OpenCode to create lifecycle pull requests as drafts.
- Rename the displayed lifecycle label to `GitHub status checks`.
- Add regression coverage for subprocess configuration, stdin closure, and draft creation.

## Verification

- Confirmed the Create PR workflow exits after OpenCode completes instead of leaving the subprocess running.
- The OpenCode integration suite successfully listed models and started and continued a real session with the centralized environment policy.
