### PR TITLE
fix(work-item-lifecycle): wait for GitHub checks before marking PR green

### DIFF
--- a/docs/adr/0013-watch-pr-status-checks.md
+++ b/docs/adr/0013-watch-pr-status-checks.md
@@ -1,14 +1,15 @@
 # Watch PR Status Checks
 
-After Create PR succeeds, the Work Item enters Watch PR Status Checks instead of completing immediately. The step queries GitHub for the open pull request on the Work Item's deterministic branch. Successful checks advance to Mark PR Ready for Review, pending checks atomically enqueue another watch Step Run with a 30-second delay, and failed checks advance to Investigate PR Status Checks.
+After Create PR succeeds, the Work Item enters Watch PR Status Checks instead of completing immediately. The step queries GitHub for the open pull request on the Work Item's deterministic branch. A missing status-check rollup (`no_checks`) is not treated as green: it requeues with a 30-second delay until the Work Item has resided in this step for at least 60 seconds (two poll intervals), after which absence of checks is accepted as green for repos with none configured. Pending rollup states keep polling. An actual SUCCESS rollup advances to Mark PR Ready for Review. Failed checks advance to Investigate PR Status Checks.
 
-Investigate PR Status Checks continues the Implement OpenCode Session with the Repository GitHub credential. OpenCode inspects check logs, fixes, commits, and pushes when possible, then reports a structured outcome. A fix returns to a delayed Watch PR Status Checks run. A failure that cannot be fixed autonomously or requires a human decision moves the Work Item to the terminal Needs Human state with OpenCode's reason.
+Investigate PR Status Checks continues the Implement OpenCode Session with the Repository GitHub credential. OpenCode inspects check logs, fixes, commits, and pushes when possible, then reports a structured outcome. A fix returns to a delayed Watch PR Status Checks run and restarts the 60-second `no_checks` grace. A failure that cannot be fixed autonomously or requires a human decision moves the Work Item to the terminal Needs Human state with OpenCode's reason.
 
 ## Consequences
 
 - Every poll and investigation is a separate Step Run, preserving durable execution history and at-least-once queue behavior.
 - New Repository credentials request Actions read permission so OpenCode can inspect GitHub Actions check logs.
-- A newly created PR that is not yet visible through GitHub is treated as pending; a visible PR with no configured checks is green.
+- A newly created PR that is not yet visible through GitHub is treated as pending; a visible PR with a null rollup is `no_checks` (not green) until the 60-second grace elapses.
+- Same-state watch requeues preserve `state_ready_at` so residence time (and the `no_checks` grace) accumulate across polls.
 - A merged PR is treated as green and advances to Mark PR Ready for Review (a no-op if already non-draft); a closed, unmerged PR enters Needs Human instead of polling forever.
 - Needs Human is terminal and no longer blocks a later Implement Now request for the Issue.
 - Green checks no longer complete the Work Item; Mark PR Ready for Review runs next (see ADR 0014).

--- a/packages/github-service/src/lib/github-service-live.ts
+++ b/packages/github-service/src/lib/github-service-live.ts
@@ -45,8 +45,11 @@ const toPullRequestCheckStatus = (
   if (pullRequest.state !== "OPEN") {
     throw new Error(`Invalid GitHub pull request state: ${pullRequest.state}`)
   }
-  const state = pullRequest.statusCheckRollup?.state
-  if (state === undefined || state === "SUCCESS") {
+  if (pullRequest.statusCheckRollup === null) {
+    return { _tag: "no_checks" }
+  }
+  const state = pullRequest.statusCheckRollup.state
+  if (state === "SUCCESS") {
     return { _tag: "succeeded" }
   }
   if (state === "FAILURE" || state === "ERROR") {

--- a/packages/github-service/src/lib/types.ts
+++ b/packages/github-service/src/lib/types.ts
@@ -5,6 +5,7 @@ export interface GitHubRepository {
 
 export type PullRequestCheckStatus =
   | { readonly _tag: "pending" }
+  | { readonly _tag: "no_checks" }
   | { readonly _tag: "succeeded" }
   | { readonly _tag: "failed" }
   | { readonly _tag: "closed" }

--- a/packages/github-service/test/github-service.spec.ts
+++ b/packages/github-service/test/github-service.spec.ts
@@ -68,7 +68,7 @@ describe("GitHubService live implementation", () => {
     })
   }
 
-  it("treats a not-yet-visible PR as pending and a PR without checks as succeeded", async () => {
+  it("treats a not-yet-visible PR as pending and a PR without checks as no_checks", async () => {
     const responses = [
       { repository: { pullRequests: { nodes: [] } } },
       {
@@ -92,7 +92,7 @@ describe("GitHubService live implementation", () => {
       await Effect.runPromise(
         service.getPullRequestCheckStatus(repository, "branch"),
       ),
-    ).toEqual({ _tag: "succeeded" })
+    ).toEqual({ _tag: "no_checks" })
   })
 
   it("distinguishes closed and merged PRs from a not-yet-visible PR", async () => {

--- a/packages/work-item-lifecycle/src/lib/pr-status-checks.ts
+++ b/packages/work-item-lifecycle/src/lib/pr-status-checks.ts
@@ -18,7 +18,12 @@ export class PrStatusChecksOpenCodeError extends Data.TaggedError(
   "PrStatusChecksOpenCodeError",
 )<{ readonly message: string; readonly cause?: unknown }> {}
 
-export type PrStatusCheckResult = "pending" | "succeeded" | "failed" | "closed"
+export type PrStatusCheckResult =
+  | "pending"
+  | "no_checks"
+  | "succeeded"
+  | "failed"
+  | "closed"
 
 export type PrStatusCheckInvestigationResult =
   | { readonly _tag: "fixed" }

--- a/packages/work-item-lifecycle/src/lib/work-item-lifecycle.ts
+++ b/packages/work-item-lifecycle/src/lib/work-item-lifecycle.ts
@@ -275,6 +275,9 @@ const toWorkItemRecord = (
   stepRuns,
 })
 
+const PR_STATUS_CHECKS_POLL_DELAY = Duration.seconds(30)
+const PR_STATUS_CHECKS_MIN_GREEN_WAIT = Duration.seconds(60)
+
 const nextOperationalStep = (
   step: OperationalLifecycleStep,
 ): OperationalLifecycleStep | "complete" => {
@@ -693,6 +696,7 @@ export const makeWorkItemLifecycleLive = (
       const runHandler = (
         step: OperationalLifecycleStep,
         context: LifecycleStepContext,
+        workItem: WorkItemRow,
       ): Effect.Effect<
         {
           readonly worktreePath?: string
@@ -729,23 +733,55 @@ export const makeWorkItemLifecycleLive = (
             return steps.createPr(context).pipe(Effect.as({}))
           case "watch_pr_status_checks":
             return steps.watchPrStatusChecks(context).pipe(
-              Effect.map((status) => ({
-                transition:
-                  status === "succeeded"
-                    ? { nextState: "mark_pr_ready_for_review" as const }
-                    : status === "failed"
-                      ? { nextState: "investigate_pr_status_checks" as const }
-                      : status === "closed"
-                        ? {
-                            nextState: "needs_human" as const,
-                            reason:
-                              "The pull request was closed before its status checks succeeded",
-                          }
-                        : {
-                            nextState: "watch_pr_status_checks" as const,
-                            delay: Duration.seconds(30),
-                          },
-              })),
+              Effect.flatMap((status) =>
+                Effect.gen(function* () {
+                  if (status === "failed") {
+                    return {
+                      transition: {
+                        nextState: "investigate_pr_status_checks" as const,
+                      },
+                    }
+                  }
+                  if (status === "closed") {
+                    return {
+                      transition: {
+                        nextState: "needs_human" as const,
+                        reason:
+                          "The pull request was closed before its status checks succeeded",
+                      },
+                    }
+                  }
+                  if (status === "pending") {
+                    return {
+                      transition: {
+                        nextState: "watch_pr_status_checks" as const,
+                        delay: PR_STATUS_CHECKS_POLL_DELAY,
+                      },
+                    }
+                  }
+                  // succeeded, or no_checks after the grace (checks never registered)
+                  if (status === "no_checks") {
+                    const now = yield* Clock.currentTimeMillis
+                    const watchedMs = Math.max(0, now - workItem.state_ready_at)
+                    if (
+                      watchedMs <
+                      Duration.toMillis(PR_STATUS_CHECKS_MIN_GREEN_WAIT)
+                    ) {
+                      return {
+                        transition: {
+                          nextState: "watch_pr_status_checks" as const,
+                          delay: PR_STATUS_CHECKS_POLL_DELAY,
+                        },
+                      }
+                    }
+                  }
+                  return {
+                    transition: {
+                      nextState: "mark_pr_ready_for_review" as const,
+                    },
+                  }
+                }),
+              ),
             )
           case "investigate_pr_status_checks":
             return steps.investigatePrStatusChecks(context).pipe(
@@ -754,7 +790,7 @@ export const makeWorkItemLifecycleLive = (
                   result._tag === "fixed"
                     ? {
                         nextState: "watch_pr_status_checks" as const,
-                        delay: Duration.seconds(30),
+                        delay: PR_STATUS_CHECKS_POLL_DELAY,
                       }
                     : {
                         nextState: "needs_human" as const,
@@ -901,6 +937,8 @@ export const makeWorkItemLifecycleLive = (
                   )
                 } else {
                   const nextStepRunId = makeStepRunId()
+                  const stateReadyAt =
+                    nextStep === workItem.state ? workItem.state_ready_at : now
 
                   yield* sql.unsafe(
                     `UPDATE work_item
@@ -910,7 +948,14 @@ export const makeWorkItemLifecycleLive = (
                        session_id = ?,
                        updated_at = ?
                    WHERE id = ?`,
-                    [nextStep, now, worktreePath, sessionId, now, workItem.id],
+                    [
+                      nextStep,
+                      stateReadyAt,
+                      worktreePath,
+                      sessionId,
+                      now,
+                      workItem.id,
+                    ],
                   )
 
                   yield* sql.unsafe(
@@ -1199,7 +1244,7 @@ export const makeWorkItemLifecycleLive = (
                     restore(
                       Effect.raceFirst(
                         Effect.suspend(() =>
-                          runHandler(stepRun.step, context),
+                          runHandler(stepRun.step, context, workItem),
                         ).pipe(Effect.timeout(maxDuration)),
                         Deferred.await(cancel).pipe(
                           Effect.andThen(Effect.interrupt),

--- a/packages/work-item-lifecycle/test/work-item-lifecycle.spec.ts
+++ b/packages/work-item-lifecycle/test/work-item-lifecycle.spec.ts
@@ -824,6 +824,18 @@ describe("WorkItemLifecycle", () => {
       return result
     })
 
+    const allowPrChecksToAppear = (workItemId: string) =>
+      Effect.gen(function* () {
+        const sql = yield* SqlClient.SqlClient
+        yield* sql.unsafe(
+          `UPDATE work_item
+           SET state_ready_at = state_ready_at - 60000
+           WHERE id = ? AND state = 'watch_pr_status_checks'`,
+          [workItemId],
+        )
+        yield* sql.unsafe(`UPDATE job_queue SET available_at = 0`)
+      })
+
     it("drives the complete happy path to Complete with typed outputs", () =>
       runTest(
         Effect.gen(function* () {
@@ -948,6 +960,65 @@ describe("WorkItemLifecycle", () => {
           expect(final.stepRuns).toHaveLength(9)
         }),
       ))
+
+    it("keeps no_checks pending for 60 seconds before treating as green", () => {
+      const steps: LifecycleStepsShape = {
+        ...successfulSteps,
+        watchPrStatusChecks: () => Effect.succeed("no_checks"),
+      }
+
+      return runWithSteps(
+        steps,
+        Effect.gen(function* () {
+          const lifecycle = yield* WorkItemLifecycle
+          const sql = yield* SqlClient.SqlClient
+          const { repository, issue } = yield* seedActionableIssue
+          const created = yield* lifecycle.implementNow(
+            repository.id,
+            issue.githubIssueNumber,
+          )
+
+          for (let index = 0; index < 7; index += 1) {
+            yield* claimAndRunPending
+          }
+
+          const earlyEmpty = yield* claimAndRunPending
+          expect(earlyEmpty._tag).toBe("processed")
+          if (earlyEmpty._tag === "processed") {
+            expect(earlyEmpty.workItem.state).toBe("watch_pr_status_checks")
+            expect(earlyEmpty.workItem.stepRuns.at(-2)?.status).toBe(
+              "succeeded",
+            )
+            expect(earlyEmpty.workItem.stepRuns.at(-1)?.status).toBe("queued")
+          }
+
+          const delayed = (yield* sql.unsafe(
+            `SELECT available_at, created_at FROM job_queue`,
+          )) as readonly {
+            readonly available_at: number
+            readonly created_at: number
+          }[]
+          expect(delayed).toHaveLength(1)
+          expect(delayed[0]!.available_at - delayed[0]!.created_at).toBe(30_000)
+
+          const readyAt = (yield* sql.unsafe(
+            `SELECT state_ready_at FROM work_item WHERE id = ?`,
+            [created.id],
+          )) as readonly { readonly state_ready_at: number }[]
+          const watchStartedAt = readyAt[0]!.state_ready_at
+
+          yield* allowPrChecksToAppear(created.id)
+          const afterGrace = yield* claimAndRunPending
+          expect(afterGrace._tag).toBe("processed")
+          if (afterGrace._tag === "processed") {
+            expect(afterGrace.workItem.state).toBe("mark_pr_ready_for_review")
+            expect(afterGrace.workItem.stateReadyAt.getTime()).toBeGreaterThan(
+              watchStartedAt,
+            )
+          }
+        }),
+      )
+    })
 
     it("rechecks pending PR checks after 30 seconds and hands failed checks to a human when requested", () => {
       const statuses = ["pending", "failed"] as const


### PR DESCRIPTION
## Why

After Create PR, a newly opened pull request often has no status-check rollup yet. The harness treated that null rollup as green and advanced to Mark PR Ready for Review within about a second—before GitHub Actions workflows had registered. Observed on processfocus/monorepo#2054: `watch_pr_status_checks` ran once for ~1.1s and marked the draft ready while checks were still not started / in progress.

## What Changed

- Map a null open-PR `statusCheckRollup` to `no_checks` instead of `succeeded`.
- Keep polling `no_checks` every 30s until the Work Item has been in Watch PR Status Checks for at least 60s, then accept green (repos with no checks).
- Treat real rollup `SUCCESS` as green immediately; keep polling `PENDING`/`EXPECTED`.
- Preserve `state_ready_at` across same-state watch requeues so the grace accumulates.
- Update ADR 0013 and tests for the new status and grace behavior.
