### PR TITLE
docs: design individual PR status check handoffs

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -84,8 +84,16 @@ An Implementable Issue with no unfinished Work Item. Only an Actionable Issue ma
 _Avoid_: Not Implemented Issue, Ready-labeled Issue
 
 **Lifecycle Step**:
-The next action required for a Work Item: Create Worktree, Install Dependencies, Implement, Pre-Commit, Review, Commit, Create PR, Watch PR Status Checks, Investigate PR Status Checks, Mark PR Ready for Review, or a terminal Complete, Failed, Needs Human, or Abandoned state. A successful step advances the Work Item; a failed step leaves the same action pending. A pending status watch schedules another Watch PR Status Checks Step Run after 30 seconds. Green checks advance to Mark PR Ready for Review.
+The next action required for a Work Item: Create Worktree, Install Dependencies, Implement, Pre-Commit, Review, Commit, Create PR, Watch PR Status Checks, Investigate PR Status Checks, Mark PR Ready for Review, or a terminal Complete, Failed, Needs Human, or Abandoned state. A successful step advances the Work Item; a failed step leaves the same action pending. A status watch batches unhandled green and red PR Status Checks into Investigate PR Status Checks, polls again after 30 seconds while checks remain pending, and advances to Mark PR Ready for Review once the aggregate is green and every observed terminal check is handled.
 _Avoid_: Last completed step, phase
+
+**PR Status Check**:
+An individual GitHub check run or commit status context associated with a pull request. An execution is green on explicit success and red on explicit failure, error, timeout, action-required, or startup-failure; neutral, skipped, cancelled, stale, and pending results do not trigger a handoff.
+_Avoid_: Aggregate status-check rollup, workflow run
+
+**Status Check Handoff**:
+A durable batch of previously unhandled green and red PR Status Checks given to the Work Item's Implement Session by Investigate PR Status Checks. The prompt names red checks to diagnose and fix; when any check is green, it also asks OpenCode to inspect the latest pull-request review comments, disregard reviews that are visibly still in progress, and address worthwhile completed feedback.
+_Avoid_: Check classification, one prompt per check
 
 **Step Run**:
 A durable record of one scheduled execution attempt for a Work Item's Lifecycle Step, created when that attempt is queued and recording when it starts, finishes, and succeeds, fails, is interrupted, or is cancelled before starting. Retried steps produce additional Step Runs rather than replacing earlier attempts, allowing queue wait and execution duration to be measured separately.
@@ -108,11 +116,11 @@ A terminal Work Item that cannot advance because a lifecycle precondition, such 
 _Avoid_: Failed Step Run, Abandoned
 
 **Needs Human Work Item**:
-A terminal Work Item whose failed PR status checks were investigated by OpenCode, but cannot be fixed autonomously or require a human decision. The Work Item records OpenCode's concise intervention reason.
+A terminal Work Item whose Status Check Handoff cannot be processed autonomously or requires a human decision. The Work Item records OpenCode's concise intervention reason.
 _Avoid_: Failed Work Item, Failed Step Run
 
 **Complete Work Item**:
-A terminal Work Item for which Create Worktree, Install Dependencies, Implement, Pre-Commit, Review, Commit, Create PR, Watch PR Status Checks, and Mark PR Ready for Review all executed successfully, with GitHub reporting no failing or pending status checks and the PR marked ready for review. Complete does not mean GitHub closed the Issue or the PR was merged.
+A terminal Work Item for which implementation, pull-request creation, status checking, all observed Status Check Handoffs, and Mark PR Ready for Review executed successfully, with GitHub reporting no failing or pending status checks and the PR marked ready for review. Complete does not mean GitHub closed the Issue or the PR was merged.
 _Avoid_: Approved, merged, done Issue
 
 **Relevant Issue**:

--- a/docs/adr/0016-handoff-individual-pr-status-checks.md
+++ b/docs/adr/0016-handoff-individual-pr-status-checks.md
@@ -1,0 +1,17 @@
+---
+status: accepted
+---
+
+# Hand Off Individual PR Status Checks
+
+Extend Watch PR Status Checks to poll the individual GitHub Check Runs and commit status contexts behind the aggregate rollup. Persist each execution that reaches an explicit green result (`SUCCESS`) or red result (`FAILURE`, `ERROR`, `TIMED_OUT`, `ACTION_REQUIRED`, or `STARTUP_FAILURE`) and whether it has been handed to OpenCode; neutral, skipped, cancelled, stale, and pending results do not trigger a handoff.
+
+Batch every currently unhandled result into one run of the existing Investigate PR Status Checks Lifecycle Step, continuing the Work Item's Implement Session with its GitHub credential. The prompt identifies red checks to diagnose and fix; when the batch contains any green check, it also says that automated reviews may have completed and asks OpenCode to inspect the latest pull-request comments, disregard reviews visibly still in progress, and address worthwhile completed feedback. OpenCode returns `READY_FOR_AGENT_RESULT: PROCESSED` or `READY_FOR_AGENT_RESULT: NEEDS_HUMAN: <reason>`.
+
+## Consequences
+
+- A semantic result marks that batch's checks handled. A timeout, crash, malformed result, or other technical failure leaves them unhandled so Retry presents the same batch again.
+- The existing 30-second poll, 60-second no-check grace, aggregate status gate, Mark PR Ready for Review step, and terminal Complete behavior remain unchanged.
+- There is no classifier, disposable Session, subagent, persisted review-comment state, persisted pull-request identity, new quiescence window, or new Lifecycle Step.
+- Ordinary green checks may cause extra Implement Session runs. This is preferred over classification complexity.
+- A review comment that is still in progress when its check is handed off, then becomes final without another green or red check result, may be missed. This risk is accepted to keep the design status-check-only.


### PR DESCRIPTION
## Why

The pull-request status watcher currently reacts only to the aggregate rollup, so it cannot hand newly completed individual checks to the existing OpenCode implementation Session. The design needs to cover both failed checks and successful checks that may indicate automated review feedback without adding a classifier or a second review-processing workflow.

## What Changed

- Define individual PR Status Checks and batched Status Check Handoffs in the domain glossary.
- Record the accepted design for persisting unhandled green/red check executions and processing them through the existing Investigate PR Status Checks step.
- Document the deliberately simplified boundaries and accepted late-comment risk.

This PR records the design only; implementation follows separately.
