### PR TITLE
docs: Keymaxxer shared broker design resolutions

### DIFF
--- a/docs/research/109-keymaxxer-mcp-facade-contract.md
+++ b/docs/research/109-keymaxxer-mcp-facade-contract.md
@@ -1,0 +1,262 @@
+# Keymaxxer MCP facade contract
+
+Research for [Specify the Keymaxxer MCP facade contract](https://github.com/berenddeboer/ready-for-agent/issues/109) (map: Design a shared Keymaxxer broker for OpenCode).
+
+Verified against:
+
+| Component | Version / path |
+| --- | --- |
+| OpenCode CLI | **1.17.18** (mise `opencode`) |
+| OpenCode MCP client | Streamable HTTP first, then SSE (`packages/opencode/src/mcp/index.ts` @ `v1.17.18`) |
+| Keymaxxer | `/home/berend/src/contrib/keymaxxer` **0.2.0**, stdio only |
+| MCP SDK (keymaxxer + workspace) | `@modelcontextprotocol/sdk` **^1.29.0** |
+
+---
+
+## Decision summary
+
+1. **Transport:** MCP **Streamable HTTP** on loopback (required). Optional legacy **SSE** is nice-to-have; OpenCode falls back only if Streamable HTTP fails for non-auth reasons.
+2. **Architecture:** **Equivalent-tool facade**, not a transparent JSON-RPC proxy of the upstream stdio session.
+3. **Upstream:** Exactly **one** `keymaxxer serve` stdio process remains the sole keyholder (vault key + Allow-session set).
+4. **Tools:** Facade advertises the same four MCP tool names, schemas, and text result shapes as Keymaxxer: `keymaxxer_list`, `keymaxxer_add`, `keymaxxer_run`, `keymaxxer_rm`.
+5. **HTTP sessions ≠ vault session:** Each client gets its own Streamable HTTP MCP session; all sessions forward tool calls to the single stdio Keymaxxer client.
+
+---
+
+## Why not a transparent MCP message proxy
+
+A transparent proxy would forward every MCP message (including `initialize`, `notifications/*`, and session teardown) between HTTP clients and the stdio Keymaxxer process.
+
+That fails the multi-client goal:
+
+| Problem | Effect |
+| --- | --- |
+| Stdio transport is one session | Only the first `initialize` is valid; later clients cannot re-initialize the same process |
+| Session lifecycle | Client disconnect / `DELETE` would tear down the sole keyholder |
+| Framing mismatch | Streamable HTTP uses `mcp-session-id`, SSE event streams, and optional resumability; stdio is line-delimited JSON-RPC |
+| Capability negotiation | Each OpenCode process negotiates as client `"opencode"`; the facade must answer as server independently |
+
+**Required shape:** the sidecar is a real MCP **server** toward clients and a single MCP **client** toward Keymaxxer.
+
+```
+Harness MCP client ──┐
+OpenCode A (remote) ─┼── Streamable HTTP ──► Sidecar McpServer(s)
+OpenCode B (remote) ─┘         │
+                               │ tools/call only (shared)
+                               ▼
+                     StdioClientTransport
+                               │
+                               ▼
+                     keymaxxer serve  (sole keyholder)
+```
+
+Tool handlers on the facade:
+
+1. Validate HTTP auth (bearer capability — details in the security ticket).
+2. `callTool({ name, arguments })` on the shared upstream Client.
+3. Return the upstream `CallToolResult` unchanged (content + `isError`).
+
+Do **not** reimplement vault, approval, scrubbing, or dialogs in the facade.
+
+---
+
+## Transport contract (OpenCode 1.17.18)
+
+### Preferred: Streamable HTTP
+
+OpenCode remote connect order:
+
+1. `StreamableHTTPClientTransport` (`@modelcontextprotocol/sdk/client/streamableHttp.js`)
+2. `SSEClientTransport` (legacy fallback)
+
+Config fields (no `transport` key):
+
+| Field | Value for Keymaxxer sidecar |
+| --- | --- |
+| `type` | `"remote"` |
+| `url` | Loopback Streamable HTTP endpoint, e.g. `http://127.0.0.1:<port>/mcp` |
+| `enabled` | `true` |
+| `headers` | `{ "Authorization": "Bearer <capability>" }` |
+| `oauth` | `false` (static bearer; do not auto-start OAuth) |
+| `timeout` | High enough for unlock/approval dialogs (recommend **≥ 300_000** ms). OpenCode default connect/list timeout is 30s if unset; tool calls also use this timeout with progress reset. |
+
+Example injected via `OPENCODE_CONFIG_CONTENT` (merge, do not clobber other MCP entries):
+
+```json
+{
+  "mcp": {
+    "keymaxxer": {
+      "type": "remote",
+      "url": "http://127.0.0.1:5032/mcp",
+      "enabled": true,
+      "oauth": false,
+      "headers": {
+        "Authorization": "Bearer ${SIDECAR_CAPABILITY}"
+      },
+      "timeout": 300000
+    }
+  }
+}
+```
+
+### Server-side Streamable HTTP requirements
+
+Use `@modelcontextprotocol/sdk` `StreamableHTTPServerTransport` (or `WebStandardStreamableHTTPServerTransport` on Bun) with **stateful** sessions:
+
+- `sessionIdGenerator: () => crypto.randomUUID()` (or equivalent)
+- Map `mcp-session-id` → transport instance (SDK example: `simpleStreamableHttp.js`)
+- Accept `POST` (JSON-RPC), `GET` (SSE stream when used), `DELETE` (session end)
+- Reject non-initialize requests without a valid session id
+- On `DELETE` / transport close: drop **HTTP** session only; **never** close the upstream stdio Keymaxxer client
+
+Optional: `enableJsonResponse: true` for simple request/response clients. OpenCode’s Streamable HTTP client does not require it; prefer default streaming behavior unless a second consumer needs JSON-only.
+
+### SSE
+
+Implement SSE only if a verified consumer needs it. OpenCode will not use SSE when Streamable HTTP succeeds. Do not implement a custom REST facade and expect OpenCode `type: "remote"` to consume it — the current JSON sidecar (`POST /run-with-secrets`, etc.) is **not** MCP and is **not** sufficient for OpenCode.
+
+---
+
+## MCP session model (two layers)
+
+### Layer A — MCP-over-HTTP client sessions
+
+| Property | Contract |
+| --- | --- |
+| Scope | One session per connecting MCP client process (Harness, each OpenCode) |
+| Identity | Server-generated `mcp-session-id` |
+| Initialize | Per HTTP session; facade answers as server name e.g. `keymaxxer-sidecar` |
+| tools/list | Returns the four Keymaxxer tools (static; no list_changed required unless tools become dynamic) |
+| tools/call | Forwarded to upstream stdio client |
+| Disconnect | Ends Layer A only |
+
+### Layer B — vault / approval session (upstream Keymaxxer process)
+
+Unchanged from Keymaxxer `serve()` semantics (`packages/cli/src/mcp.ts`):
+
+| Property | Contract |
+| --- | --- |
+| Scope | Lifetime of the single stdio `keymaxxer serve` child |
+| Unlock | Lazy on first tool that needs the vault; passphrase/GUI once per process |
+| Allow session | `approved: Set<string>` in that process; shared across all Layer A clients |
+| Allow once / deny | Per `keymaxxer_run` call; once does not enter the set |
+| Idle re-lock | `KEYMAXXER_IDLE_MINUTES` if set; clears store + approved set for **all** clients |
+| Secret values | Never appear in any tool result; only in child env of `keymaxxer_run` |
+
+**Invariant:** N OpenCode processes + Harness share **one** Layer B session.
+
+---
+
+## Tool discovery and names
+
+### Upstream MCP names (protocol)
+
+Register on the facade exactly as Keymaxxer does:
+
+| Name | Input | Result |
+| --- | --- | --- |
+| `keymaxxer_list` | `{}` | Text JSON array of secret metadata (no values) |
+| `keymaxxer_run` | `command`, `secrets[]`, optional `cwd`, `timeoutMs` | Text: `exit_code`, optional redaction line, stdout/stderr; `isError` if exit ≠ 0 |
+| `keymaxxer_add` | `name` + optional attrs | Text confirmation or cancel message; value never returned |
+| `keymaxxer_rm` | `name` | Text removed / not found |
+
+Descriptions and Zod/JSON schemas should match Keymaxxer so agents and the Harness `mcpKeymaxxerLayer` keep calling the same names.
+
+### OpenCode LLM-facing IDs
+
+OpenCode prefixes every tool: `sanitize(configKey) + "_" + sanitize(mcpToolName)` (`McpCatalog.toolName`).
+
+With config key `keymaxxer` and MCP names `keymaxxer_*`, the LLM sees:
+
+- `keymaxxer_keymaxxer_list`
+- `keymaxxer_keymaxxer_run`
+- `keymaxxer_keymaxxer_add`
+- `keymaxxer_keymaxxer_rm`
+
+That matches **current** local stdio OpenCode wiring on this machine (global `mcp.keymaxxer` → same double prefix). Do **not** rename MCP tools to unprefixed `list`/`run` without a separate Harness migration: `packages/keymaxxer-service` calls `keymaxxer_list` / `keymaxxer_run` / `keymaxxer_add` by protocol name.
+
+Call path: LLM id is local to OpenCode; the remote `tools/call` uses the **original** MCP name (`keymaxxer_run`), which is what the facade must accept and forward.
+
+---
+
+## Result shape (passthrough)
+
+Upstream and facade return only MCP text content (no resources/prompts/images required):
+
+```ts
+{
+  content: [{ type: "text", text: string }],
+  isError?: true
+}
+```
+
+Facade must not parse or rewrite success payloads except for logging metadata (never log secret-bearing command output beyond what Keymaxxer already scrubbed).
+
+Error text form from Keymaxxer: `error: <message>` with `isError: true`.
+
+---
+
+## Forwarding architecture (implementation sketch)
+
+```
+Sidecar process
+├── HTTP listener (loopback only)
+│   ├── auth middleware (bearer; reject Origin — security ticket)
+│   └── /mcp → StreamableHTTPServerTransport per session
+│         └── McpServer.registerTool(keymaxxer_*) → forward
+└── Shared upstream (lazy, once)
+    └── Client + StdioClientTransport → keymaxxer serve
+        (KEYMAXXER_ENTRYPOINT / local path / keymaxxer CLI precedence unchanged)
+```
+
+Concurrency notes (detail belongs in multi-client concurrency research):
+
+- Serialize or carefully gate unlock/approval-sensitive calls so dialogs do not race.
+- Long-running `keymaxxer_run` must not block unrelated `keymaxxer_list` if the SDK allows concurrent tool calls on one Client; if not, document a single-flight queue.
+- HTTP session teardown must not abort in-flight upstream runs belonging to other sessions unless the whole sidecar shuts down.
+
+---
+
+## Compatibility matrix
+
+| Consumer | How it connects | Works with this contract? |
+| --- | --- | --- |
+| OpenCode 1.17.18 remote MCP | Streamable HTTP + bearer headers, `oauth: false` | **Yes** |
+| OpenCode local stdio Keymaxxer | Spawns its own keymaxxer | **Disable** when harness-spawned (`enabled: false` or replace with remote) |
+| Harness `mcpKeymaxxerLayer` | Stdio client today | Keep as upstream **inside** sidecar; replace Harness direct stdio with either HTTP MCP client or domain service over the same facade |
+| Current JSON sidecar (`/run-with-secrets`) | Custom REST | **Not** OpenCode-compatible; retire or keep only as internal Harness adapter, not as the OpenCode surface |
+
+---
+
+## Explicitly rejected alternatives
+
+| Alternative | Why rejected |
+| --- | --- |
+| Transparent JSON-RPC proxy onto one stdio session | Breaks multi-client initialize/session lifecycle |
+| Custom REST as OpenCode `type: "remote"` | OpenCode requires real MCP Streamable HTTP or SSE |
+| One stdio Keymaxxer per OpenCode process | Reintroduces repeated unlock/approval; violates destination |
+| Putting vault key in the Harness or OpenCode process | Violates secret boundary |
+| OAuth for loopback sidecar | Unnecessary; static bearer capability is the planned auth model |
+| Renaming tools for prettier OpenCode IDs in this ticket | Optional later; would break Harness tool names without a migration |
+
+---
+
+## OpenCode config contract for launch tickets
+
+When the Harness spawns OpenCode, it must inject remote Keymaxxer MCP and ensure no second local Keymaxxer is started:
+
+1. Set `mcp.keymaxxer` to the remote shape above (url + bearer + `oauth: false` + long timeout).
+2. Do **not** leave a local `command: […, "serve"]` entry enabled for the same logical server.
+3. Merge with existing `OPENCODE_CONFIG_CONTENT` (deep-merge `mcp`, overwrite only the `keymaxxer` entry).
+4. Do not put secret values into OpenCode env; only the bearer capability for the MCP endpoint.
+
+---
+
+## Sources
+
+- Keymaxxer MCP: `/home/berend/src/contrib/keymaxxer/packages/cli/src/mcp.ts`
+- OpenCode remote MCP: `https://github.com/anomalyco/opencode/blob/v1.17.18/packages/opencode/src/mcp/index.ts`
+- OpenCode tool naming: `…/packages/opencode/src/mcp/catalog.ts` (`toolName`, `sanitize`)
+- OpenCode docs: `https://opencode.ai/docs/mcp-servers/`
+- MCP SDK Streamable HTTP server: `@modelcontextprotocol/sdk` `server/streamableHttp.js`, example `examples/server/simpleStreamableHttp.js`
+- Current harness sidecar (non-MCP HTTP): `docs/adr/0004-development-keymaxxer-sidecar.md`, `packages/keymaxxer-service`

--- a/docs/research/110-multi-client-broker-concurrency.md
+++ b/docs/research/110-multi-client-broker-concurrency.md
@@ -1,0 +1,322 @@
+# Safe multi-client broker concurrency
+
+Research for [Determine safe multi-client broker concurrency](https://github.com/berenddeboer/ready-for-agent/issues/110) (map: Design a shared Keymaxxer broker for OpenCode).
+
+Builds on [Specify the Keymaxxer MCP facade contract](https://github.com/berenddeboer/ready-for-agent/issues/109) / [`docs/research/109-keymaxxer-mcp-facade-contract.md`](./109-keymaxxer-mcp-facade-contract.md).
+
+Verified against:
+
+| Component | Version / path |
+| --- | --- |
+| OpenCode CLI | **1.17.18** |
+| OpenCode MCP | Streamable HTTP client; parallel `callTool`; per-request abort (`packages/opencode/src/mcp/*` @ `v1.17.18`) |
+| Keymaxxer | `/home/berend/src/contrib/keymaxxer` **0.2.0** (`packages/cli/src/mcp.ts`, `client.ts`, `approver.ts`) |
+| MCP SDK | `@modelcontextprotocol/sdk` **^1.29.0** — handlers start concurrently (`Protocol._onrequest` does not await prior handlers) |
+
+---
+
+## Decision summary
+
+1. **Place concurrency control in the facade** (shared Layer A→B gate). Do not rely on current Keymaxxer alone: it has unlock/approval races under concurrent tools.
+2. **Single-flight unlock** across all HTTP clients: one passphrase dialog; all waiters share one result.
+3. **Global human-dialog lane**: serialize unlock, approval, and add-secret UI so stacked OS dialogs never appear.
+4. **Approval coalescing**: waiters for the same sensitive secret set share one dialog decision; Allow-session still lives only in upstream Keymaxxer’s `approved` set.
+5. **After dialogs are not needed**, allow concurrent `keymaxxer_list` / already-approved `keymaxxer_run` / `keymaxxer_rm` so long runs do not block list.
+6. **Disconnect = Layer A only**: cancel that session’s pending responses; never close the upstream keyholder; never cancel other sessions’ work.
+7. **Cancellation** does not tear down shared unlock or shared approvals; orphaned upstream runs may finish without delivering a result.
+8. **Timeouts**: client MCP timeout ≥ 300s for dialog paths; facade must not impose a shorter dialog timeout; optional cap + queue for concurrent secret-bearing runs (backpressure).
+
+---
+
+## As-is behavior (why rules are required)
+
+### MCP SDK
+
+`Protocol._onrequest` attaches an `AbortController` per request id and starts the handler with `Promise.resolve().then(() => handler(...))` **without** waiting for other in-flight handlers. Concurrent tool calls on one connection are first-class.
+
+Client cancel / transport close aborts those controllers and sends `notifications/cancelled` for outstanding client requests. Keymaxxer tool handlers **ignore** `extra.signal`.
+
+### OpenCode remote clients
+
+- Each OpenCode process is an independent Streamable HTTP MCP client with its own `mcp-session-id`.
+- Within one process, parallel model tool use issues concurrent `tools/call`s.
+- Per-server `timeout` (default 30s if unset) applies to connect and tool calls; progress tokens reset the timer (`resetTimeoutOnProgress: true`). Dialog-heavy tools need **≥ 300_000** ms.
+- Disconnect closes that client only; remote Keymaxxer is not OpenCode’s child process.
+
+### Keymaxxer `serve()` (sole keyholder)
+
+| State | Scope | Notes |
+| --- | --- | --- |
+| `store` | Process | Lazy unlock via GUI / env; no single-flight |
+| `approved: Set<string>` | Process | Secret **names** only; Allow-session shared for all tools in this process |
+| Dialogs | OS processes | No mutex; concurrent prompts stack |
+| Idle re-lock | Optional | `KEYMAXXER_IDLE_MINUTES` closes store and **clears all** approvals |
+
+Critical races today:
+
+| Race | Effect |
+| --- | --- |
+| Concurrent first `vault()` | Two passphrase dialogs; two DB opens; last write wins for `store` |
+| Concurrent `runGated` for same secret | Two approval dialogs; non-deterministic set updates |
+| Concurrent `keymaxxer_add` | Competing add dialogs |
+| Idle re-lock mid-flight | Store closed under active run; approvals wiped for everyone |
+| Client disconnect mid-dialog | Dialog can keep running; no cancel linkage |
+
+Multi-process Keymaxxer (N stdio servers) would give N unlocks and N approval sets — exactly what the broker forbids. The broker keeps **one** stdio `keymaxxer serve` and multiplexes HTTP clients onto it.
+
+---
+
+## Required concurrency model
+
+```
+Harness / OpenCode A / OpenCode B
+        │  concurrent tools/call (per HTTP session)
+        ▼
+┌───────────────────────────────────────────┐
+│ Facade (Streamable HTTP McpServer)        │
+│  • per-session request tracking           │
+│  • shared DialogLane (mutex + coalesce)   │
+│  • optional RunLane (concurrency limit)   │
+│  • disconnect isolates Layer A only       │
+└───────────────────┬───────────────────────┘
+                    │ tools/call forward
+                    ▼
+            one keymaxxer serve
+            (store + approved set)
+```
+
+### Layer responsibilities
+
+| Concern | Facade | Upstream Keymaxxer |
+| --- | --- | --- |
+| HTTP session lifecycle | Own | Unaware |
+| Unlock single-flight / dialog queue | **Must gate** | Should also single-flight (nice; not sufficient alone) |
+| Approval coalescing / dialog mutex | **Must gate** | Should also coalesce (nice) |
+| Allow-session / once / deny semantics | Pass through | **Sole owner** of `approved` |
+| Secret values / scrubbing | Never touch values | Sole owner |
+| Idle re-lock | Observe only; lifecycle ticket | Owner of timer |
+
+Do **not** reimplement approval policy or vault crypto in the facade (per #109). The facade only **orders and coalesces** human-interactive and multi-client-unsafe entry into the upstream client.
+
+---
+
+## Rules
+
+### 1. Serialization and dialog lane
+
+**Rule D1 — Global dialog lane.** At most one human-facing interaction runs at a time across the whole sidecar:
+
+- Vault unlock (passphrase)
+- Approval (deny / once / session)
+- Add-secret UI
+
+Implementation shape: a shared async mutex (`dialogLane`) acquired before any upstream call that may open a dialog, released when that call returns (success, deny, cancel, or error).
+
+**How the facade knows a call may dialog:**
+
+| Tool | May dialog? | Gate |
+| --- | --- | --- |
+| `keymaxxer_list` | Unlock only (if locked) | Acquire dialog lane **only while vault is locked**; after unlock, list is free |
+| `keymaxxer_run` | Unlock + approval if sensitive secrets not yet session-approved | Dialog lane for unlock/approval phase; run body may leave the lane (see R2) |
+| `keymaxxer_add` | Unlock + add UI | Always dialog lane for whole call |
+| `keymaxxer_rm` | Unlock only | Same as list |
+
+**Practical simplification (acceptable for v1):** hold the dialog lane for the entire upstream `tools/call` of `keymaxxer_run` / `keymaxxer_add` when the vault is locked **or** when `keymaxxer_run` includes any secret that is not known to be non-sensitive-and-unlocked-path. Without a facade-side sensitivity cache, **v1 may serialize all `keymaxxer_run` and `keymaxxer_add`**, and only parallelize `keymaxxer_list` / `keymaxxer_rm` after first successful unlock.
+
+**Preferred v1.1:** after first unlock, maintain a facade-side **read-only cache** of last `keymaxxer_list` metadata (names + sensitivity flags only) plus a mirror of session-approved names inferred from successful runs (or an explicit non-secret status channel later). Then:
+
+- `list` / `rm` / non-sensitive `run` / already session-approved `run` → no dialog lane
+- sensitive unapproved `run` / `add` / locked vault → dialog lane
+
+Never cache secret **values**.
+
+### 2. Unlock single-flight and deduplication
+
+**Rule U1 — One unlock.** While Layer B is locked, concurrent tools that need the vault share a single in-flight unlock promise. Exactly one passphrase dialog.
+
+**Rule U2 — Shared outcome.** All waiters resolve with the same success or the same failure (wrong passphrase / cancel). No partial “one client unlocked, another still locked.”
+
+**Rule U3 — No second dialog on success.** After unlock succeeds, further tools skip unlock until idle re-lock or process restart (Layer B lifecycle — see lifecycle ticket).
+
+Where to implement:
+
+1. **Facade (required):** if the first post-start / post-relock tool fails open, the facade still must not issue two concurrent upstream calls that both trigger `openVaultServe`. Easiest: while `!unlocked`, all vault-touching calls enter a single-flight queue that runs **one** upstream call at a time until a successful vault-using call completes.
+2. **Keymaxxer (recommended follow-up):** fix `vault()` to:
+
+   ```ts
+   let unlockPromise: Promise<SecretStore> | null = null;
+   async function vault() {
+     lastActivity = Date.now();
+     if (store) return store;
+     unlockPromise ??= openVaultServe(...).then((s) => { store = s; unlockPromise = null; return s; })
+       .catch((e) => { unlockPromise = null; throw e; });
+     return unlockPromise;
+   }
+   ```
+
+### 3. Approval deduplication
+
+**Rule A1 — One prompt per concurrent need.** If two (or more) `keymaxxer_run` calls need approval for overlapping sensitive secrets while a prompt is in flight, they must not open two dialogs.
+
+**Rule A2 — Coalesce by secret-name set.** Waiters whose `needPrompt` set is a subset of an in-flight prompt’s set may share that decision:
+
+- **session** → all waiters proceed; upstream `approved` gains those names (via the call that owns the dialog, or each waiter re-checks after dialog — second path must not re-prompt).
+- **once** → only the **owner** call (the one that opened the dialog) may run with that one-shot grant; waiters with the same secrets must either re-prompt or get a clear error asking to retry (prefer: waiters re-enter approval after owner completes — if owner chose once, waiters still need their own once/session). Document this: **Allow once is per call, not coalesced.**
+- **deny** → owner fails; waiters for the **same** secrets also fail with deny without a second dialog (shared deny). Waiters for **disjoint** secrets are unaffected.
+
+**Rule A3 — Simpler v1.** Serialize all approval-capable `keymaxxer_run` through the dialog lane (full tool call). Then A1 holds automatically; A2 reduce to sequential natural behavior:
+
+- First call: dialog → session → `approved` updated upstream  
+- Second call: upstream sees approved → no dialog  
+
+**Allow once** under serialization: first call once-runs without updating `approved`; second call prompts again — correct.
+
+**Recommendation:** ship **A3 (serialize approval-capable runs)** for the prototype (#114). Keep A2 as an optional optimization only if parallel sensitive runs become a measured bottleneck.
+
+### 4. Cancellation
+
+**Rule C1 — Per-request only.** Cancel/abort of request R affects only R’s ability to deliver a result to its HTTP session.
+
+**Rule C2 — Shared unlock.** If R is waiting on a shared unlock owned by another request, R leaving the waiter set must **not** cancel the unlock. If R is the sole owner of an in-flight unlock and all waiters are gone, the facade **may** abandon waiting for the dialog result for delivery purposes but **should not** kill the OS dialog mid-passphrase if other work might still use the eventual unlock within the same process tick — practical rule: **never kill unlock dialogs from cancel**; let them finish or time out; if unlock succeeds with zero waiters, keep the vault unlocked (Layer B benefit).
+
+**Rule C3 — Shared approval (v1 serialize).** Cancel of R while R holds the dialog lane: release the lane when the upstream call settles; do not start a second dialog for R. If the user already approved session, the approval stands (upstream state).
+
+**Rule C4 — Upstream run after secrets injected.** If R is cancelled mid-`keymaxxer_run` child process, the facade does **not** need to SIGKILL the child for v1 (Keymaxxer ignores MCP cancel). Prefer: let the child finish; drop the result if the HTTP session is gone. Optional later: plumb `AbortSignal` into Keymaxxer runner.
+
+**Rule C5 — Cross-session isolation.** Cancel/disconnect on session A never aborts session B’s in-flight upstream calls and never clears `approved`.
+
+### 5. Timeouts
+
+| Path | Rule |
+| --- | --- |
+| OpenCode / Harness MCP client | `timeout` ≥ **300_000** ms for Keymaxxer remote entry |
+| Facade → client | Do not fail a tool earlier than the client timeout while blocked on a human dialog |
+| Unlock dialog (macOS Keymaxxer) | 120s → cancel unlock |
+| Approval dialog (macOS) | 60s → deny |
+| `keymaxxer_run` `timeoutMs` | Agent-supplied; facade passes through; no default required |
+| Dialog lane wait | Waiters inherit the same human-dialog budget; no separate “queue wait” kill unless documented (optional: max queue wait = client timeout) |
+
+### 6. Backpressure
+
+**Rule B1 — Optional run concurrency limit.** Cap simultaneous upstream `keymaxxer_run` children (suggested default **4**). Excess wait in a FIFO queue.
+
+**Rule B2 — Queue overflow.** If queue depth exceeds a configured max (e.g. **32**), return `isError` text to that caller without opening dialogs: `error: keymaxxer busy — too many concurrent runs`.
+
+**Rule B3 — List priority.** `keymaxxer_list` and `keymaxxer_rm` (post-unlock) should not sit behind the run queue; only behind dialog lane when vault locked.
+
+**Rule B4 — Fairness.** FIFO global queue is enough for v1. Per-session fairness is out of scope unless starvation appears in the prototype.
+
+### 7. Disconnect and session teardown
+
+**Rule X1 — Layer A only.** HTTP `DELETE` / transport close / OpenCode process exit:
+
+- Abort pending facade handlers for that `mcp-session-id`
+- Remove that session’s waiters from unlock/run queues
+- **Do not** close stdio Keymaxxer
+- **Do not** clear `approved` or lock the vault
+
+**Rule X2 — In-flight owned by disconnected session.** If the disconnected session owned the dialog lane call, let the upstream call finish; apply U2/A semantics to any remaining waiters; discard the result that would have gone to the dead session.
+
+**Rule X3 — Sidecar process shutdown (not single-client disconnect).** Reject new sessions; stop accepting tools/call; wait for in-flight with a drain timeout; then kill upstream `keymaxxer serve` (clears key + approvals). Details belong in the lifecycle ticket; concurrency only requires that **client disconnect ≠ drain**.
+
+**Rule X4 — No cross-request corruption.** Never reuse JSON-RPC request ids across sessions; never write one session’s `CallToolResult` onto another session’s transport; one shared upstream Client is fine because the facade correlates each upstream call promise to exactly one Layer A waiter set.
+
+---
+
+## Recommended v1 gate algorithm
+
+```
+on tools/call(name, args, session):
+  register pending(session, requestId)
+
+  if name == keymaxxer_list or keymaxxer_rm:
+    if !facade.unlocked:
+      await dialogLane.run(() => forward(name, args))  // unlock side effect
+      facade.unlocked = true on success
+    else:
+      return await forward(name, args)
+
+  if name == keymaxxer_add:
+    return await dialogLane.run(() => forward(name, args))
+
+  if name == keymaxxer_run:
+    // v1: entire run under dialog lane (serializes unlock + approval + run)
+    return await dialogLane.run(() =>
+      runLane.schedule(() => forward(name, args))  // runLane limit still applies inside
+    )
+
+  on session close:
+    abort/drop pending for session; do not touch upstream process
+```
+
+v1.1 can narrow `dialogLane` to unlock/approval phases only once sensitivity/approval mirrors exist.
+
+---
+
+## What stays shared vs isolated
+
+| Artifact | Shared across clients? | Lifetime |
+| --- | --- | --- |
+| Vault unlock (derived key in Keymaxxer process) | **Yes** | Until idle re-lock or sidecar/Keymaxxer exit |
+| Allow-session set | **Yes** | Same as unlock session |
+| Allow once | **No** (per call) | Single `keymaxxer_run` |
+| Deny | Per call; coalesced waiters for same secrets may share deny | Immediate |
+| HTTP MCP session | **No** | Client connection |
+| Dialog lane / run queue | Process-global in facade | Sidecar process |
+| Secret values | Never in facade or OpenCode | Child env of run only |
+
+---
+
+## Explicit non-goals (this ticket)
+
+- Changing Keymaxxer’s Allow-session meaning (name-global for the vault session) — product semantics stay.
+- Multi-host / remote Keymaxxer — out of map scope.
+- Fixing Linux pinentry missing “Allow session” — platform gap; broker does not paper over it.
+- Full Keymaxxer cancel plumbing — optional follow-up.
+- Idle re-lock policy numbers — lifecycle ticket.
+
+---
+
+## Prototype implications (#114)
+
+A throwaway prototype must demonstrate:
+
+| Criterion | Concurrency rule that enables it |
+| --- | --- |
+| One vault unlock across concurrent OpenCode clients | U1–U3 + dialog lane |
+| Shared Allow-session per secret | Single upstream process + A3 serialization |
+| Allow once / deny preserved | A3 sequential runs; once not written to set |
+| Survive client disconnect | X1–X2 |
+| No raw secrets in results | Unchanged passthrough + Keymaxxer scrubbing |
+| No duplicate unlock/approval prompts under parallel first use | D1 + U1 + A3 |
+
+Suggested stress cases:
+
+1. Two OpenCode processes call `keymaxxer_list` together while locked → one passphrase dialog.
+2. Two processes call `keymaxxer_run` with the same prod secret while locked → one unlock, one approval; second run silent if session allowed.
+3. Allow once on first run; second process still prompts.
+4. Kill OpenCode A mid-approval → OpenCode B still completes or gets a clean error; vault session remains for B.
+5. Concurrent `list` during a long `run` (v1 may block list if run holds dialog lane — document; v1.1 should not).
+
+---
+
+## Optional Keymaxxer upstream fixes (not blocking design)
+
+1. Single-flight `vault()`  
+2. Single-flight / mutex around `requestApproval` + `approved` update  
+3. Honor `AbortSignal` to kill child on cancel  
+4. Coordinate idle re-lock with in-flight runs (refcount)
+
+Even with these, the **facade still needs** X1 disconnect isolation and multi-client session mapping; Keymaxxer fixes only harden the single keyholder under parallel tools.
+
+---
+
+## Sources
+
+- Keymaxxer MCP session: `/home/berend/src/contrib/keymaxxer/packages/cli/src/mcp.ts`
+- Gating: `/home/berend/src/contrib/keymaxxer/packages/cli/src/client.ts` (`runGated`, `openVaultServe`)
+- Approvals: `/home/berend/src/contrib/keymaxxer/packages/cli/src/approver.ts`
+- Store multi-process WAL: `/home/berend/src/contrib/keymaxxer/packages/sdk/src/store.ts`
+- MCP SDK concurrency: `@modelcontextprotocol/sdk` `shared/protocol.js` (`_onrequest`)
+- OpenCode remote MCP: `anomalyco/opencode` @ `v1.17.18` `packages/opencode/src/mcp/index.ts`, `catalog.ts`, `session/tools.ts`
+- Facade contract: [`docs/research/109-keymaxxer-mcp-facade-contract.md`](./109-keymaxxer-mcp-facade-contract.md)

--- a/docs/research/111-sidecar-vault-session-lifecycles.md
+++ b/docs/research/111-sidecar-vault-session-lifecycles.md
@@ -1,0 +1,185 @@
+# Sidecar and vault session lifecycles
+
+Resolution of [Define sidecar and vault session lifecycles](https://github.com/berenddeboer/ready-for-agent/issues/111) (part of [Design a shared Keymaxxer broker for OpenCode](https://github.com/berenddeboer/ready-for-agent/issues/106)).
+
+Depends on:
+
+- [Specify the Keymaxxer MCP facade contract](https://github.com/berenddeboer/ready-for-agent/issues/109) — Streamable HTTP facade; one stdio keyholder; Layer A HTTP sessions vs Layer B vault session
+- [Determine safe multi-client broker concurrency](https://github.com/berenddeboer/ready-for-agent/issues/110) — disconnect is Layer A only; Allow-session stays in upstream Keymaxxer
+
+---
+
+## Goal
+
+Define process ownership, startup, readiness, shutdown, crash-recovery, idle-lock, and restart semantics so:
+
+1. Vault unlock happens **once per broker (vault) session**
+2. A secret granted with **Allow session** remains approved for **all** clients exactly until that vault session locks or ends
+
+---
+
+## Two session layers (unchanged from #109)
+
+| Layer | What | Lifetime |
+| --- | --- | --- |
+| **A — HTTP MCP session** | One per Harness / OpenCode client | Client connection; disconnect ends only this layer |
+| **B — Vault / approval session** | One upstream `keymaxxer serve` process | Keyholder process life, or Keymaxxer idle re-lock |
+
+Allow-session is Layer B only (`approved` set inside Keymaxxer). It is shared across all Layer A clients attached to the same sidecar.
+
+---
+
+## Process ownership
+
+| Actor | Role |
+| --- | --- |
+| **Nx continuous target** | Starts and restarts the sidecar process (this stage only; no systemd/container contract yet) |
+| **Keymaxxer Sidecar** | Owns loopback MCP server; sole parent of one `keymaxxer serve` stdio child |
+| **Harness / OpenCode** | MCP **clients only**; never spawn Keymaxxer stdio; never own vault session |
+
+Production packaging/supervision is deferred. The process model is the same long-lived sidecar + one keyholder (not Harness in-process). When implemented, this supersedes ADR-0004’s “production in-process” topology.
+
+---
+
+## Broker / vault session boundary
+
+**One vault session = lifetime of one `keymaxxer serve` child.**
+
+Starts when the sidecar first spawns that child. Ends when any of:
+
+- Sidecar hard stop (SIGINT/SIGTERM / Nx stop)
+- Keyholder process exit (crash → later respawn is a **new** session)
+- Keymaxxer idle re-lock (`KEYMAXXER_IDLE_MINUTES` > 0: store closed, `approved` cleared)
+
+A new keyholder process is always a new vault session: re-unlock and re-approve.
+
+---
+
+## Startup sequence
+
+1. **Sidecar process starts** (Nx) → bind fixed loopback port → MCP listen.
+2. **Upstream `keymaxxer serve`** — spawn **lazily, once**, on first client need that requires the keyholder (not at listen time).
+3. **Vault unlock** — remains lazy **inside** Keymaxxer on first tool that needs the vault (one passphrase dialog for the whole vault session).
+
+No unlock prompt at sidecar boot.
+
+---
+
+## Readiness
+
+**Ready = TCP listen** on the configured loopback MCP port.
+
+Not required for readiness:
+
+- Keyholder spawned
+- Vault unlocked
+
+### Port
+
+- Default `5032`, overridable with `KEYMAXXER_SIDECAR_PORT`
+- Clients use `KEYMAXXER_SIDECAR_URL` (set by Nx for Harness)
+- Bind conflict → **fail fast** with a clear override message (no dynamic port, no discovery file)
+- Harness passes the same URL into OpenCode remote MCP config when spawning OpenCode (see launch-contract ticket)
+
+### Harness startup gate
+
+When a sidecar URL is configured:
+
+- Harness must reach TCP listen before serving
+- Short retry (~5s) for Nx process-start race
+- After the sidecar responds, protocol/init failures fail immediately
+- **No** in-process Keymaxxer fallback (would restore repeated unlock/approval prompts on reload)
+
+---
+
+## Shutdown
+
+On SIGINT/SIGTERM (Nx stop, Ctrl-C, `harness:dev` teardown):
+
+1. Stop accepting new HTTP MCP sessions
+2. Abort in-flight client requests
+3. Close/kill upstream `keymaxxer serve` (wipes key + Allow-session)
+4. Exit
+
+**Hard stop** — no multi-second graceful drain. In-flight `keymaxxer_run` children die with the keyholder.
+
+---
+
+## Crash recovery
+
+### Keyholder dies, sidecar lives
+
+1. Detect child exit
+2. Fail in-flight tools cleanly to their Layer A clients
+3. On next need, spawn a **fresh** `keymaxxer serve`
+4. New vault session → re-unlock + re-approve
+
+Never pretend Allow-session still holds across keyholder death.
+
+### Sidecar process dies
+
+1. Nx continuous target restarts the sidecar
+2. Fresh process → new vault session
+3. New bearer capability when security model is applied (security ticket)
+4. Clients must reconnect; unlock/approvals again
+5. No persistence of unlock or approvals across sidecar crashes
+
+---
+
+## Idle re-lock
+
+- Policy is **Keymaxxer’s**: `KEYMAXXER_IDLE_MINUTES` (0 / unset = off; vault stays unlocked for the keyholder’s life)
+- Sidecar **passes through** the env; does **not** invent a second idle policy
+- Idle re-lock ends the vault session for **all** clients (`store` closed, `approved` cleared)
+- Next tool call **transparently** re-prompts unlock (and approval if needed) — no facade `session_expired` protocol
+- Client MCP timeout remains ≥ 300s for dialogs (#109)
+- Known upstream gap: idle timer may clear the store during an in-flight run; v1 documents this and does not add facade refcount. Optional Keymaxxer follow-up already noted in #110.
+
+---
+
+## Allow session semantics (product)
+
+| Grant | Scope | Ends when |
+| --- | --- | --- |
+| **Allow session** | Secret name, all Layer A clients on this sidecar | Vault session ends (idle lock, keyholder death, sidecar hard stop) |
+| **Allow once** | Single `keymaxxer_run` | That call finishes |
+| **Deny** | That call (coalesced waiters may share deny per #110) | Immediate |
+
+Facade does not reimplement the `approved` set (#109/#110).
+
+---
+
+## Explicit non-goals (this ticket)
+
+- Production supervisor (systemd, k8s sidecar, etc.) — deferred
+- Dynamic port / discovery file
+- Facade-owned idle policy or refcounted idle
+- Bearer generation, rotation, logging — security ticket
+- OpenCode spawn/env merge details — launch-contract ticket
+- Changing Keymaxxer Allow-session product meaning
+
+---
+
+## Implications for prototype (#114)
+
+Must demonstrate:
+
+1. Sidecar listen without unlock; first multi-client use → one passphrase
+2. Allow session on secret S → second OpenCode client uses S without re-prompt until session ends
+3. Kill one OpenCode mid-flight → vault session remains for the other
+4. Kill keyholder (or restart sidecar) → next use re-prompts unlock and approval
+5. Hard stop of sidecar clears session (no orphan keyholder)
+
+---
+
+## ADR impact
+
+When this design is implemented, **ADR-0004 (development-only sidecar; production in-process)** is superseded for topology: one long-lived sidecar owns the vault session in the target architecture; dev is started via Nx now; prod packaging follows later under the same process model.
+
+---
+
+## Sources
+
+- Keymaxxer MCP session / idle: `/home/berend/src/contrib/keymaxxer/packages/cli/src/mcp.ts`
+- Current sidecar: `apps/keymaxxer-sidecar`, `docs/adr/0004-development-keymaxxer-sidecar.md`
+- Facade + concurrency: `docs/research/109-keymaxxer-mcp-facade-contract.md`, `docs/research/110-multi-client-broker-concurrency.md`

--- a/docs/research/113-shared-broker-security-model.md
+++ b/docs/research/113-shared-broker-security-model.md
@@ -1,0 +1,171 @@
+# Shared broker security model
+
+Resolution of [Define the shared broker security model](https://github.com/berenddeboer/ready-for-agent/issues/113) (part of [Design a shared Keymaxxer broker for OpenCode](https://github.com/berenddeboer/ready-for-agent/issues/106)).
+
+Depends on:
+
+- [Specify the Keymaxxer MCP facade contract](https://github.com/berenddeboer/ready-for-agent/issues/109) — Streamable HTTP facade; remote MCP client shape
+- [Define sidecar and vault session lifecycles](https://github.com/berenddeboer/ready-for-agent/issues/111) — fixed loopback port; TCP readiness; new capability on sidecar restart
+
+Revises #109’s sketch of `Authorization: Bearer <capability>`: v1 uses an **unguessable URL path** as the sole client secret (no Bearer header).
+
+---
+
+## Goal
+
+Define the threat model and concrete access-control contract for the loopback MCP endpoint so Harness and every spawned OpenCode process can use one shared Keymaxxer Sidecar without ambient loopback trust, without capability files, and without claiming defenses Keymaxxer cannot provide.
+
+---
+
+## Threat model
+
+### Defend against
+
+1. **Browsers** — pages that can reach `127.0.0.1` (Origin / CORS path; same spirit as ADR-0004)
+2. **Unauthenticated local clients** — processes that know the fixed port but not the capability (scanners, random tools, misconfigured agents)
+3. **Ambient loopback trust** — “anything on loopback may call vault operations once unlocked”
+
+### Explicitly do not claim
+
+- Another process as the **same OS user** that can read sidecar/keyholder memory, Harness/OpenCode env, or process listings that expose the capability URL
+- A compromised Harness or OpenCode process that already holds a valid capability URL
+- Off-host / remote attackers (loopback-only; multi-host Keymaxxer remains out of scope per #106)
+
+Same-user memory inspection is irreducible without OS-level isolation; Keymaxxer’s own threat model states this. Stronger isolation (separate OS user, sandbox) composes cleanly but is not part of this broker contract.
+
+---
+
+## Capability: unguessable path (not Bearer)
+
+| Decision | Choice |
+| --- | --- |
+| Secret form | Opaque path segment in the MCP URL |
+| Bearer header | **Not used** in v1 |
+| Capability files | **None** — do not write the secret to disk |
+| Entropy | 32 bytes CSPRNG |
+| Encoding | base64url, no padding (~43 characters) |
+| Lifetime | One generation per sidecar process listen; no mid-life rotation |
+| Independence | Not derived from vault passphrase or master key |
+
+### URL shape
+
+```text
+http://127.0.0.1:<port>/<capability>/mcp
+```
+
+- Port: fixed loopback default `5032` / `KEYMAXXER_SIDECAR_PORT` (per #111)
+- Host: `127.0.0.1` only
+- MCP Streamable HTTP lives only under `/<capability>/mcp`
+
+### Auth checks (order)
+
+1. If request has an `Origin` header → **403** (`browser requests are forbidden` or equivalent); no CORS headers ever
+2. If path capability segment missing or not equal (constant-time compare) → **404** minimal body
+3. Otherwise proceed with MCP handling
+
+Never use **401** or `WWW-Authenticate` (wrong model for path capability; noisy oracle for scanners).
+
+### What is not exposed
+
+- **No** fixed unauthenticated `/health` (or any other unauthenticated route)
+- Readiness remains **TCP listen only** (#111); Harness ~5s TCP gate does not need the capability
+- **No** unauthenticated REST operation API. When the MCP facade ships, drop the legacy JSON REST surface or place any temporary migration routes under `/<capability>/…` with the same Origin rules — prefer drop
+
+---
+
+## Generation, rotation, delivery
+
+### Generation
+
+On successful bind/listen, the sidecar:
+
+1. Generates `<capability>` in memory
+2. Serves MCP only under `/<capability>/mcp`
+3. Emits **one** bootstrap line on stdout (sole intentional full-URL emission):
+
+```text
+KEYMAXXER_SIDECAR_URL=http://127.0.0.1:<port>/<capability>/mcp
+```
+
+### Rotation
+
+- Capability changes only when the **sidecar process** restarts (Nx restart, crash, hard stop)
+- Aligns with #111: sidecar restart → new vault session + new capability
+- No idle-linked path rotation, no manual rotate API in v1
+- In-flight clients with the old URL fail until Harness re-captures stdout / reconfigures
+
+### Delivery (no files)
+
+| Consumer | How it gets the URL |
+| --- | --- |
+| **Harness** | Captures sidecar stdout bootstrap line; holds `KEYMAXXER_SIDECAR_URL` **in memory only** |
+| **OpenCode** | Harness injects into `OPENCODE_CONFIG_CONTENT` when spawning: `mcp.keymaxxer = { type: "remote", url: <full capability URL>, enabled: true, oauth: false, timeout: ≥ 300000 }` — no Bearer headers, no separate secret env var |
+
+Nx may still set port-related env for the sidecar process; the **secret path is not** pre-shared via env files or disk.
+
+---
+
+## Logging and storage constraints
+
+- After bootstrap capture, treat the full URL (and path segment) as a **secret**
+- Logs/metrics may show **host:port only** (e.g. `listening on 127.0.0.1:5032`)
+- Redact path segments that match the live capability in any access/error/crash logging
+- Never put the capability in error response bodies
+- Do not persist the capability to disk, git, or durable config
+- Facade must not log secret-bearing command output beyond what Keymaxxer already scrubbed (#109)
+
+Accepted leak class under the threat model: same-UID readers of process env / `OPENCODE_CONFIG_CONTENT` / sidecar memory.
+
+---
+
+## OpenCode remote config (security half of #112)
+
+```json
+{
+  "mcp": {
+    "keymaxxer": {
+      "type": "remote",
+      "url": "http://127.0.0.1:5032/<capability>/mcp",
+      "enabled": true,
+      "oauth": false,
+      "timeout": 300000
+    }
+  }
+}
+```
+
+No `headers.Authorization`. Local stdio `keymaxxer` command config for the same server must remain disabled so OpenCode does not spawn a second keyholder.
+
+---
+
+## Relationship to prior ADRs / tickets
+
+| Source | Effect |
+| --- | --- |
+| ADR-0004 Origin + JSON browser rejection | **Kept** Origin rejection; extended to MCP path; Content-Type-as-browser-guard is secondary once path + Origin are required |
+| ADR-0004 no remote auth | **Kept** — still loopback-only; path capability is local client auth, not remote multi-tenant auth |
+| #109 Bearer sketch | **Revised** — opaque path only |
+| #111 “new bearer on restart” | **Kept** as new path capability on sidecar restart |
+| Keymaxxer scrubbing / no raw values to agents | Unchanged; out of scope for this ticket’s HTTP surface |
+
+---
+
+## Out of scope
+
+- Unix domain sockets or SO_PEERCRED
+- Running keyholder as a separate OS user
+- OAuth / remote multi-user auth
+- Mid-session capability rotation without process restart
+- Capability files under `$XDG_RUNTIME_DIR` or similar
+
+---
+
+## Acceptance checklist (for implementers / #114)
+
+- [ ] Sidecar binds `127.0.0.1` only; MCP only at `/<cap>/mcp`
+- [ ] Capability is 32-byte CSPRNG base64url; generated once per listen
+- [ ] Stdout bootstrap line once; no capability files
+- [ ] Origin → 403; wrong path → 404; no `/health`
+- [ ] Logs never contain full capability URL after bootstrap
+- [ ] Harness memory-only URL; OpenCode remote config injects URL without Bearer
+- [ ] Sidecar restart invalidates old URL and vault session


### PR DESCRIPTION
## Why

Map #106 needs implementation-ready design decisions for a shared Keymaxxer Sidecar that serves the Harness and every spawned OpenCode process. Issues #109–#111 and #113 resolved the facade shape, multi-client concurrency, lifecycle, and loopback security model; those answers need a durable in-repo record for launch (#112) and prototype (#114) work.

## What Changed

Adds research write-ups for the closed design tickets:

- `docs/research/109-keymaxxer-mcp-facade-contract.md` — Streamable HTTP equivalent-tool facade over one stdio keyholder
- `docs/research/110-multi-client-broker-concurrency.md` — dialog lane, unlock single-flight, disconnect isolation
- `docs/research/111-sidecar-vault-session-lifecycles.md` — Nx-owned sidecar; vault session = keyholder process
- `docs/research/113-shared-broker-security-model.md` — unguessable URL path capability (no Bearer/files); Origin 403; stdout bootstrap; memory-only delivery

Closes design capture for #109, #110, #111, #113 (already closed on the tracker with resolution comments).