### PR TITLE
feat(cli): remove repository GitHub tokens

### DIFF
--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -41,7 +41,33 @@ bun run harness-cli add ~/src/pf/monorepo/
 #   paused: true
 ```
 
+Remove a repository GitHub token by local path, GitHub `owner/repository`, or
+repository id:
+
+```bash
+bun run harness-cli remove-github-token /path/to/local/repo
+bun run harness-cli remove-github-token processfocus/monorepo
+bun run harness-cli remove-github-token repo-01H...
+```
+
+Example:
+
+```bash
+bun run harness-cli remove-github-token ~/src/pf/monorepo/
+# Removed GitHub token for processfocus/monorepo
+#   secret: GITHUB_TOKEN_PROCESSFOCUS_MONOREPO
+
+bun run harness-cli remove-github-token processfocus/monorepo
+# Removed GitHub token for processfocus/monorepo
+#   secret: GITHUB_TOKEN_PROCESSFOCUS_MONOREPO
+
+bun run harness-cli remove-github-token repo-01H...
+# Removed GitHub token for processfocus/monorepo
+#   secret: GITHUB_TOKEN_PROCESSFOCUS_MONOREPO
+```
+
 ```bash
 bun run harness-cli --help
 bun run harness-cli add --help
+bun run harness-cli remove-github-token --help
 ```

--- a/apps/cli/src/cli.test.ts
+++ b/apps/cli/src/cli.test.ts
@@ -1,0 +1,32 @@
+import { Effect } from "effect"
+import { resolveRepositoryTarget } from "./cli.ts"
+import { describe, expect, test } from "bun:test"
+
+const repository = {
+  id: "repo-01J00000000000000000000000",
+  githubOwner: "berenddeboer",
+  githubRepo: "ready-for-agent",
+  localPath: "/home/berend/src/ready-for-agent",
+  isBare: false,
+  paused: true,
+}
+
+describe("resolveRepositoryTarget", () => {
+  test("resolves owner/repository without inspecting it as a path", async () => {
+    let inspected = false
+
+    const result = await Effect.runPromise(
+      resolveRepositoryTarget(
+        "berenddeboer/ready-for-agent",
+        [repository],
+        () => {
+          inspected = true
+          return Effect.die("owner/repository must not be inspected as a path")
+        },
+      ),
+    )
+
+    expect(result).toEqual(repository)
+    expect(inspected).toBe(false)
+  })
+})

--- a/apps/cli/src/cli.ts
+++ b/apps/cli/src/cli.ts
@@ -1,11 +1,55 @@
-import { Console, Effect } from "effect"
+import { Console, Effect, Schema } from "effect"
 import { Argument, Command } from "effect/unstable/cli"
-import { GraphqlApi } from "./services/graphql-api.ts"
+import type { LocalRepository } from "./domain.ts"
+import { GraphqlApi, type RepositorySummary } from "./services/graphql-api.ts"
 import { LocalGit } from "./services/local-git.ts"
 
 const pathArg = Argument.string("path").pipe(
   Argument.withDescription("Path to a local git repository"),
 )
+
+const repositoryIdPattern = /^repo-[0-9A-HJKMNP-TV-Z]{26}$/
+const githubRepositoryPattern = /^[A-Za-z0-9](?:[A-Za-z0-9-]{0,38})\/[^/]+$/
+
+export const resolveRepositoryTarget = <E>(
+  target: string,
+  repositories: readonly RepositorySummary[],
+  inspect: (path: string) => Effect.Effect<LocalRepository, E>,
+): Effect.Effect<RepositorySummary | undefined, E> => {
+  if (repositoryIdPattern.test(target)) {
+    return Effect.succeed(repositories.find(({ id }) => id === target))
+  }
+
+  if (githubRepositoryPattern.test(target)) {
+    const [owner, name] = target.split("/", 2)
+    return Effect.succeed(
+      repositories.find(
+        ({ githubOwner, githubRepo }) =>
+          githubOwner.toLowerCase() === owner?.toLowerCase() &&
+          githubRepo.toLowerCase() === name?.toLowerCase(),
+      ),
+    )
+  }
+
+  return inspect(target).pipe(
+    Effect.map((inspected) =>
+      repositories.find(
+        (repository) =>
+          repository.githubOwner === inspected.githubOwner &&
+          repository.githubRepo === inspected.githubRepo,
+      ),
+    ),
+  )
+}
+
+class RepositoryNotRegistered extends Schema.TaggedErrorClass<RepositoryNotRegistered>()(
+  "RepositoryNotRegistered",
+  { detail: Schema.String },
+) {
+  override get message() {
+    return this.detail
+  }
+}
 
 const addCommand = Command.make("add", { path: pathArg }, ({ path }) =>
   Effect.gen(function* () {
@@ -24,7 +68,50 @@ const addCommand = Command.make("add", { path: pathArg }, ({ path }) =>
   }),
 ).pipe(Command.withDescription("Add a local repository to the harness"))
 
+const targetArg = Argument.string("target").pipe(
+  Argument.withDescription(
+    "Local path, owner/repository, or repository id (repo-…)",
+  ),
+)
+
+const removeGitHubTokenCommand = Command.make(
+  "remove-github-token",
+  { target: targetArg },
+  ({ target }) =>
+    Effect.gen(function* () {
+      const graphqlApi = yield* GraphqlApi
+      const repositories = yield* graphqlApi.listRepositories
+      const localGit = yield* LocalGit
+      const repository = yield* resolveRepositoryTarget(
+        target,
+        repositories,
+        localGit.inspect,
+      )
+
+      if (repository === undefined) {
+        return yield* new RepositoryNotRegistered({
+          detail: repositoryIdPattern.test(target)
+            ? `Repository not registered: ${target}`
+            : `No registered repository matches ${target}`,
+        })
+      }
+
+      const credential = yield* graphqlApi.removeRepositoryGitHubToken(
+        repository.id,
+      )
+
+      yield* Console.log(
+        `Removed GitHub token for ${repository.githubOwner}/${repository.githubRepo}`,
+      )
+      yield* Console.log(`  secret: ${credential.githubTokenSecretName}`)
+    }),
+).pipe(
+  Command.withDescription(
+    "Remove the Keymaxxer GitHub token for a registered repository",
+  ),
+)
+
 export const cli = Command.make("harness-cli").pipe(
   Command.withDescription("CLI for the ready-for-agent harness"),
-  Command.withSubcommands([addCommand]),
+  Command.withSubcommands([addCommand, removeGitHubTokenCommand]),
 )

--- a/apps/cli/src/services/graphql-api.ts
+++ b/apps/cli/src/services/graphql-api.ts
@@ -8,20 +8,35 @@ class GraphqlRequestFailed extends Schema.TaggedErrorClass<GraphqlRequestFailed>
   { message: Schema.String },
 ) {}
 
+export type RepositorySummary = {
+  readonly id: string
+  readonly githubOwner: string
+  readonly githubRepo: string
+  readonly localPath: string
+  readonly isBare: boolean
+  readonly paused: boolean
+}
+
+export type RepositoryCredentialSummary = {
+  readonly repositoryId: string
+  readonly configured: boolean
+  readonly githubTokenSecretName: string
+  readonly githubTokenCreationUrl: string
+}
+
 export class GraphqlApi extends Context.Service<
   GraphqlApi,
   {
-    readonly addRepository: (repository: LocalRepository) => Effect.Effect<
-      {
-        readonly id: string
-        readonly githubOwner: string
-        readonly githubRepo: string
-        readonly localPath: string
-        readonly isBare: boolean
-        readonly paused: boolean
-      },
+    readonly addRepository: (
+      repository: LocalRepository,
+    ) => Effect.Effect<RepositorySummary, GraphqlRequestFailed>
+    readonly listRepositories: Effect.Effect<
+      readonly RepositorySummary[],
       GraphqlRequestFailed
     >
+    readonly removeRepositoryGitHubToken: (
+      repositoryId: string,
+    ) => Effect.Effect<RepositoryCredentialSummary, GraphqlRequestFailed>
   }
 >()("@ready-for-agent/cli/GraphqlApi") {
   static readonly layer = Layer.succeed(GraphqlApi, {
@@ -54,6 +69,56 @@ export class GraphqlApi extends Context.Service<
             throw new Error("addRepository returned null")
           }
           return added
+        },
+        catch: (cause) =>
+          new GraphqlRequestFailed({
+            message:
+              cause instanceof Error ? cause.message : "GraphQL request failed",
+          }),
+      }),
+    listRepositories: Effect.tryPromise({
+      try: async () => {
+        const client = createClient({
+          url: resolveGraphqlUrl(),
+        })
+        const result = await client.query({
+          repositories: {
+            id: true,
+            githubOwner: true,
+            githubRepo: true,
+            localPath: true,
+            isBare: true,
+            paused: true,
+          },
+        })
+        return result.repositories ?? []
+      },
+      catch: (cause) =>
+        new GraphqlRequestFailed({
+          message:
+            cause instanceof Error ? cause.message : "GraphQL request failed",
+        }),
+    }),
+    removeRepositoryGitHubToken: (repositoryId) =>
+      Effect.tryPromise({
+        try: async () => {
+          const client = createClient({
+            url: resolveGraphqlUrl(),
+          })
+          const result = await client.mutation({
+            removeRepositoryGitHubToken: {
+              __args: { repositoryId },
+              repositoryId: true,
+              configured: true,
+              githubTokenSecretName: true,
+              githubTokenCreationUrl: true,
+            },
+          })
+          const removed = result.removeRepositoryGitHubToken
+          if (!removed) {
+            throw new Error("removeRepositoryGitHubToken returned null")
+          }
+          return removed
         },
         catch: (cause) =>
           new GraphqlRequestFailed({

--- a/apps/harness/test/job-worker.test.ts
+++ b/apps/harness/test/job-worker.test.ts
@@ -415,6 +415,7 @@ describe("Job worker", () => {
       findSecrets: () => Effect.die("not used"),
       hasSecret: () => Effect.die("not used"),
       addSecret: () => Effect.die("not used"),
+      removeSecret: () => Effect.die("not used"),
       runWithSecrets: () => Effect.die("not used"),
     })
     const opencode = Layer.succeed(Opencode, {

--- a/apps/harness/test/keymaxxer-github-layer.test.ts
+++ b/apps/harness/test/keymaxxer-github-layer.test.ts
@@ -21,6 +21,7 @@ describe("Keymaxxer-backed GitHub layer", () => {
           addCalled = true
           return true
         }),
+      removeSecret: () => Effect.die("not used"),
       runWithSecrets: (input) => {
         runs.push(input)
         return Effect.succeed({ exitCode: 0, stdout: "[]", stderr: "" })
@@ -56,6 +57,7 @@ describe("Keymaxxer-backed GitHub layer", () => {
       findSecrets: () => Effect.die("not used"),
       hasSecret: () => Effect.die("not used"),
       addSecret: () => Effect.die("not used"),
+      removeSecret: () => Effect.die("not used"),
       runWithSecrets: (input) => {
         runs.push(input)
         return Effect.succeed({ exitCode: 0, stdout: "[]", stderr: "" })
@@ -90,6 +92,7 @@ describe("Keymaxxer-backed GitHub layer", () => {
       findSecrets: () => Effect.die("not used"),
       hasSecret: () => Effect.die("not used"),
       addSecret: () => Effect.die("not used"),
+      removeSecret: () => Effect.die("not used"),
       runWithSecrets: (input) => {
         runs.push(input)
         return Effect.succeed({
@@ -175,6 +178,7 @@ describe("Keymaxxer-backed GitHub layer", () => {
       findSecrets: () => Effect.die("not used"),
       hasSecret: () => Effect.die("not used"),
       addSecret: () => Effect.die("not used"),
+      removeSecret: () => Effect.die("not used"),
       runWithSecrets: (input) => {
         runs.push(input)
         return Effect.succeed({
@@ -292,6 +296,7 @@ describe("Keymaxxer-backed GitHub layer", () => {
       findSecrets: () => Effect.die("not used"),
       hasSecret: () => Effect.die("not used"),
       addSecret: () => Effect.die("not used"),
+      removeSecret: () => Effect.die("not used"),
       runWithSecrets: (input) => {
         runs.push(input)
         return Effect.succeed({

--- a/packages/graphql-api/src/lib/graphql-api.ts
+++ b/packages/graphql-api/src/lib/graphql-api.ts
@@ -642,6 +642,44 @@ export const createGraphqlApi = (
             }
             return result.success
           },
+          removeRepositoryGitHubToken: async (
+            _parent: unknown,
+            args: RepositoryCredentialArgs,
+          ) => {
+            const result = await runtime.runPromise(
+              Effect.result(
+                tokenProvisioning.withPermits(1)(
+                  Effect.gen(function* () {
+                    const db = yield* DbService
+                    const repositories = yield* db.listRepositories
+                    const repository = repositories.find(
+                      ({ id }) => id === args.repositoryId,
+                    )
+                    if (repository === undefined) {
+                      return yield* new RepositoryNotFoundError({
+                        repositoryId: args.repositoryId,
+                      })
+                    }
+
+                    const keymaxxer = yield* KeymaxxerService
+                    const account = `${repository.githubOwner}/${repository.githubRepo}`
+                    const existingToken = yield* keymaxxer.findSecret({
+                      provider: "github",
+                      account,
+                    })
+                    if (existingToken !== null) {
+                      yield* keymaxxer.removeSecret(existingToken)
+                    }
+                    return repositoryCredential(repository, null)
+                  }),
+                ),
+              ),
+            )
+            if (Result.isFailure(result)) {
+              throw toGraphQLError(result.failure)
+            }
+            return result.success
+          },
           removeRepository: async (
             _parent: unknown,
             args: RemoveRepositoryArgs,

--- a/packages/graphql-api/test/graphql-api.test.ts
+++ b/packages/graphql-api/test/graphql-api.test.ts
@@ -136,6 +136,7 @@ const makeRuntime = (
     findSecrets: (inputs) => Effect.succeed(inputs.map(() => null)),
     hasSecret: () => Effect.succeed(false),
     addSecret: () => Effect.succeed(true),
+    removeSecret: () => Effect.succeed(true),
     runWithSecrets: () => Effect.die("not used"),
     ...keymaxxerOverrides,
   }
@@ -444,6 +445,86 @@ describe("GraphQL API", () => {
         }),
       ],
     })
+  })
+
+  test("removes a repository GitHub token", async () => {
+    let removedName: string | undefined
+    await runtime.dispose()
+    runtime = makeRuntime(
+      {},
+      {},
+      {
+        findSecret: ({ account }) =>
+          Effect.succeed(
+            account === "acme/widgets" ? "GITHUB_TOKEN_ACME_WIDGETS" : null,
+          ),
+        removeSecret: (name) =>
+          Effect.sync(() => {
+            removedName = name
+            return true
+          }),
+      },
+    )
+
+    const response = await createGraphqlApi(runtime).fetch(
+      graphqlRequest({
+        query: `mutation RemoveToken($repositoryId: ID!) {
+          removeRepositoryGitHubToken(repositoryId: $repositoryId) {
+            repositoryId configured githubTokenSecretName
+          }
+        }`,
+        variables: { repositoryId: repository.id },
+      }),
+    )
+
+    expect(await response.json()).toEqual({
+      data: {
+        removeRepositoryGitHubToken: {
+          repositoryId: repository.id,
+          configured: false,
+          githubTokenSecretName: "GITHUB_TOKEN_ACME_WIDGETS",
+        },
+      },
+    })
+    expect(removedName).toBe("GITHUB_TOKEN_ACME_WIDGETS")
+  })
+
+  test("remove repository GitHub token is idempotent when missing", async () => {
+    let removeCalls = 0
+    await runtime.dispose()
+    runtime = makeRuntime(
+      {},
+      {},
+      {
+        findSecret: () => Effect.succeed(null),
+        removeSecret: () =>
+          Effect.sync(() => {
+            removeCalls += 1
+            return false
+          }),
+      },
+    )
+
+    const response = await createGraphqlApi(runtime).fetch(
+      graphqlRequest({
+        query: `mutation {
+          removeRepositoryGitHubToken(repositoryId: "${repository.id}") {
+            repositoryId configured githubTokenSecretName
+          }
+        }`,
+      }),
+    )
+
+    expect(await response.json()).toEqual({
+      data: {
+        removeRepositoryGitHubToken: {
+          repositoryId: repository.id,
+          configured: false,
+          githubTokenSecretName: "GITHUB_TOKEN_ACME_WIDGETS",
+        },
+      },
+    })
+    expect(removeCalls).toBe(0)
   })
 
   test("removes a repository", async () => {

--- a/packages/graphql-schema/schema.graphql
+++ b/packages/graphql-schema/schema.graphql
@@ -132,6 +132,7 @@ input UpdateConfigInput {
 type Mutation {
   addRepository(input: AddRepositoryInput!): Repository!
   addRepositoryGitHubToken(repositoryId: ID!): RepositoryCredential!
+  removeRepositoryGitHubToken(repositoryId: ID!): RepositoryCredential!
   removeRepository(repositoryId: ID!): ID!
   refreshRepository(repositoryId: ID!): RefreshJob!
   implementNow(repositoryId: ID!, githubIssueNumber: Int!): WorkItem!

--- a/packages/keymaxxer-service/README.md
+++ b/packages/keymaxxer-service/README.md
@@ -2,8 +2,8 @@
 
 Reusable Effect boundary for Keymaxxer vault operations. `KeymaxxerService`
 supports initializing the session, checking whether a named secret exists,
-opening Keymaxxer's add-secret flow, and running a command with named secrets
-injected.
+opening Keymaxxer's add-secret flow, removing a named secret, and running a
+command with named secrets injected.
 
 The boundary never returns raw secret values. `runWithSecrets` returns only the
 exit code and separate stdout and stderr streams. A non-zero exit is a command

--- a/packages/keymaxxer-service/src/lib/http-layer.ts
+++ b/packages/keymaxxer-service/src/lib/http-layer.ts
@@ -230,6 +230,22 @@ const makeSidecarService = (
             catch: () => safeError("addSecret", "Keymaxxer add failed"),
           })
         : Effect.fail(safeError("addSecret", "Invalid secret name")),
+    removeSecret: (name) =>
+      validateSecretName(name)
+        ? Effect.tryPromise({
+            try: async () => {
+              const result = await callTool("removeSecret", "keymaxxer_rm", {
+                name,
+              })
+              if (result.isError) {
+                throw safeError("removeSecret", "Keymaxxer remove failed")
+              }
+              await listSecrets(true)
+              return result.text.toLowerCase().includes("removed")
+            },
+            catch: () => safeError("removeSecret", "Keymaxxer remove failed"),
+          })
+        : Effect.fail(safeError("removeSecret", "Invalid secret name")),
     runWithSecrets: (input) =>
       validateRunInput(input)
         ? Effect.tryPromise({

--- a/packages/keymaxxer-service/src/lib/mcp-layer.ts
+++ b/packages/keymaxxer-service/src/lib/mcp-layer.ts
@@ -161,6 +161,22 @@ const makeMcpService = (options: McpLayerOptions) => {
             catch: () => safeError("addSecret", "Keymaxxer add failed"),
           })
         : Effect.fail(safeError("addSecret", "Invalid secret name")),
+    removeSecret: (name) =>
+      validateSecretName(name)
+        ? Effect.tryPromise({
+            try: async () => {
+              const result = await callTool("removeSecret", "keymaxxer_rm", {
+                name,
+              })
+              if (result.isError) {
+                throw safeError("removeSecret", "Keymaxxer remove failed")
+              }
+              await listSecrets(true)
+              return result.text.toLowerCase().includes("removed")
+            },
+            catch: () => safeError("removeSecret", "Keymaxxer remove failed"),
+          })
+        : Effect.fail(safeError("removeSecret", "Invalid secret name")),
     runWithSecrets: (input) =>
       validateRunInput(input)
         ? Effect.tryPromise({

--- a/packages/keymaxxer-service/src/lib/service.ts
+++ b/packages/keymaxxer-service/src/lib/service.ts
@@ -22,6 +22,9 @@ export interface KeymaxxerServiceShape {
   readonly addSecret: (
     input: AddSecretInput,
   ) => Effect.Effect<boolean, KeymaxxerError>
+  readonly removeSecret: (
+    name: SecretName,
+  ) => Effect.Effect<boolean, KeymaxxerError>
   readonly runWithSecrets: (
     input: RunWithSecretsInput,
   ) => Effect.Effect<RunWithSecretsResult, KeymaxxerError>
@@ -48,6 +51,8 @@ export const testKeymaxxerLayer = (
           secrets.add(input.name)
           return true
         }),
+      removeSecret: (name: SecretName) =>
+        Effect.sync(() => secrets.delete(name)),
       runWithSecrets: () =>
         Effect.succeed({ exitCode: 0, stdout: "", stderr: "" }),
     }

--- a/packages/keymaxxer-service/test/mcp-layer.test.ts
+++ b/packages/keymaxxer-service/test/mcp-layer.test.ts
@@ -255,6 +255,57 @@ describe("MCP Keymaxxer layer", () => {
     ])
   })
 
+  test("removes a secret by name", async () => {
+    const calls: string[] = []
+    let secrets = [
+      {
+        name: "GITHUB_TOKEN_ACME_WIDGETS",
+        provider: "github",
+        account: "acme/widgets",
+      },
+    ]
+    const client: KeymaxxerToolClient = {
+      callTool: async (input) => {
+        calls.push(input.name)
+        if (input.name === "keymaxxer_list") {
+          return textResult(JSON.stringify(secrets))
+        }
+        if (input.name === "keymaxxer_rm") {
+          secrets = secrets.filter(
+            (secret) => secret.name !== input.arguments.name,
+          )
+          return textResult(`Removed '${input.arguments.name}'.`)
+        }
+        return textResult("unexpected", true)
+      },
+      close: async () => {},
+    }
+
+    const result = await Effect.runPromise(
+      Effect.gen(function* () {
+        const keymaxxer = yield* KeymaxxerService
+        yield* keymaxxer.initialize
+        const removed = yield* keymaxxer.removeSecret(
+          "GITHUB_TOKEN_ACME_WIDGETS",
+        )
+        const remaining = yield* keymaxxer.hasSecret(
+          "GITHUB_TOKEN_ACME_WIDGETS",
+        )
+        return { removed, remaining }
+      }).pipe(
+        Effect.provide(mcpKeymaxxerLayer({ createClient: async () => client })),
+      ),
+    )
+
+    expect(result).toEqual({ removed: true, remaining: false })
+    expect(calls).toEqual([
+      "keymaxxer_list",
+      "keymaxxer_rm",
+      "keymaxxer_list",
+      "keymaxxer_list",
+    ])
+  })
+
   test("returns non-zero command results with separate output streams", async () => {
     const client: KeymaxxerToolClient = {
       callTool: async () =>

--- a/packages/keymaxxer-service/test/sidecar.test.ts
+++ b/packages/keymaxxer-service/test/sidecar.test.ts
@@ -29,6 +29,11 @@ const mockUpstream = (): KeymaxxerUpstreamClient => ({
     if (name === "keymaxxer_add") {
       return { content: [{ type: "text", text: `added ${String(args.name)}` }] }
     }
+    if (name === "keymaxxer_rm") {
+      return {
+        content: [{ type: "text", text: `Removed '${String(args.name)}'.` }],
+      }
+    }
     if (name === "keymaxxer_run") {
       return {
         content: [
@@ -79,13 +84,14 @@ describe("sidecar-backed Keymaxxer layer", () => {
             { provider: "github", account: "acme/widgets" },
           ])
           const added = yield* keymaxxer.addSecret({ name: "NEW_SECRET" })
+          const removed = yield* keymaxxer.removeSecret("PRESENT_SECRET")
           const run = yield* keymaxxer.runWithSecrets({
             command: "true",
             cwd: "/tmp",
             secrets: ["PRESENT_SECRET"],
             timeoutMs: 5_000,
           })
-          return { present, found, foundMany, added, run }
+          return { present, found, foundMany, added, removed, run }
         }).pipe(Effect.provide(sidecarKeymaxxerLayer(facade.url))),
       )
 
@@ -93,6 +99,7 @@ describe("sidecar-backed Keymaxxer layer", () => {
       expect(result.found).toBe("PRESENT_SECRET")
       expect(result.foundMany).toEqual(["PRESENT_SECRET"])
       expect(result.added).toBe(true)
+      expect(result.removed).toBe(true)
       expect(result.run).toEqual({ exitCode: 0, stdout: "ok", stderr: "" })
     } finally {
       await facade.stop()

--- a/packages/work-item-lifecycle/test/create-pr.spec.ts
+++ b/packages/work-item-lifecycle/test/create-pr.spec.ts
@@ -61,6 +61,7 @@ const stubKeymaxxer = (
     findSecret: () => Effect.succeed("GITHUB_TOKEN_ACME_WIDGETS"),
     findSecrets: () => Effect.succeed([]),
     addSecret: () => Effect.succeed(true),
+    removeSecret: () => Effect.succeed(true),
     runWithSecrets: () =>
       Effect.succeed({ exitCode: 0, stdout: "", stderr: "" }),
     ...overrides,

--- a/packages/work-item-lifecycle/test/remove-worktree.spec.ts
+++ b/packages/work-item-lifecycle/test/remove-worktree.spec.ts
@@ -33,6 +33,7 @@ const stubKeymaxxer = (
     findSecret: () => Effect.succeed("GITHUB_TOKEN_ACME_WIDGETS"),
     findSecrets: () => Effect.succeed([]),
     addSecret: () => Effect.succeed(true),
+    removeSecret: () => Effect.succeed(true),
     runWithSecrets: () =>
       Effect.succeed({ exitCode: 0, stdout: "[]", stderr: "" }),
     ...overrides,


### PR DESCRIPTION
## Summary
- add a `remove-github-token` CLI command supporting local paths, `owner/repository`, and repository IDs
- add the GraphQL mutation and Keymaxxer `removeSecret` boundary through stdio and Streamable HTTP MCP clients
- make removal idempotent when no matching token exists and document CLI usage

## Verification
- `bun nx affected -t knip --batch`
- repository pre-commit hook: affected lint, typecheck, and test targets
- CLI resolver regression test for `owner/repository`
