### PR TITLE
feat(harness): repo card kebab menu for settings and remove

### DIFF
--- a/apps/harness/src/routes/index.tsx
+++ b/apps/harness/src/routes/index.tsx
@@ -390,6 +390,7 @@ function RepositoryCards() {
 function RepositoryCard({ repository }: { repository: Repository }) {
   const queryClient = useQueryClient()
   const [githubTokenCreated, setGithubTokenCreated] = useState(false)
+  const [menuOpen, setMenuOpen] = useState(false)
   const settingsDialogRef = useRef<HTMLDialogElement>(null)
   const config = useQuery(configQuery)
   const models = useQuery(modelsQuery)
@@ -504,6 +505,25 @@ function RepositoryCard({ repository }: { repository: Repository }) {
     }
   }
 
+  useEffect(() => {
+    if (!menuOpen) return
+    const onPointerDown = (event: PointerEvent) => {
+      const target = event.target
+      if (!(target instanceof Element)) return
+      if (target.closest(`[data-repo-menu="${repository.id}"]`)) return
+      setMenuOpen(false)
+    }
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") setMenuOpen(false)
+    }
+    document.addEventListener("pointerdown", onPointerDown)
+    document.addEventListener("keydown", onKeyDown)
+    return () => {
+      document.removeEventListener("pointerdown", onPointerDown)
+      document.removeEventListener("keydown", onKeyDown)
+    }
+  }, [menuOpen, repository.id])
+
   const refreshIssues = useMutation({
     mutationFn: async () => {
       const result = await graphql.mutation({
@@ -545,32 +565,7 @@ function RepositoryCard({ repository }: { repository: Repository }) {
 
   return (
     <article className="relative min-w-0 rounded-[0.9rem] border border-[#dbe3ef] bg-white p-[1.35rem] shadow-[0_10px_30px_rgb(15_23_42_/_5%)]">
-      <button
-        type="button"
-        className="absolute top-4 right-4 inline-flex size-8 items-center justify-center rounded-md text-slate-400 transition hover:bg-red-50 hover:text-red-700 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-red-600 disabled:cursor-wait disabled:opacity-50"
-        onClick={confirmRemoval}
-        disabled={removeRepository.isPending}
-        aria-label={`Remove ${repository.githubOwner}/${repository.githubRepo}`}
-        title={`Remove ${repository.githubOwner}/${repository.githubRepo}`}
-      >
-        <svg
-          aria-hidden="true"
-          className="size-4"
-          viewBox="0 0 24 24"
-          fill="none"
-          stroke="currentColor"
-          strokeWidth="2"
-          strokeLinecap="round"
-          strokeLinejoin="round"
-        >
-          <path d="M3 6h18" />
-          <path d="M8 6V4h8v2" />
-          <path d="m19 6-1 14H6L5 6" />
-          <path d="M10 11v5" />
-          <path d="M14 11v5" />
-        </svg>
-      </button>
-      <div className="mb-[1.4rem] flex items-center justify-between gap-4 pr-10">
+      <div className="mb-[1.4rem] flex items-center justify-between gap-4">
         <h2 className="m-0 min-w-0 truncate text-2xl tracking-[-0.025em]">
           <a
             className="text-slate-900 hover:underline"
@@ -579,19 +574,77 @@ function RepositoryCard({ repository }: { repository: Repository }) {
             {repository.githubOwner}/{repository.githubRepo}
           </a>
         </h2>
-        <div className="flex shrink-0 items-center gap-2">
-          <span
-            className={`rounded-full px-[0.55rem] py-[0.2rem] text-[0.7rem] font-[750] tracking-[0.04em] uppercase ${repository.paused ? "bg-amber-100 text-amber-800" : "bg-green-100 text-green-800"}`}
-          >
-            {repository.paused ? "Paused" : "Active"}
+        <div className="flex shrink-0 items-center gap-1">
+          {repository.paused && (
+            <button
+              type="button"
+              className="inline-flex size-8 items-center justify-center rounded-md text-amber-700 hover:bg-amber-50 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-amber-600"
+              aria-label="Paused"
+              title="Paused"
+            >
+              <svg
+                aria-hidden="true"
+                className="size-4"
+                viewBox="0 0 24 24"
+                fill="currentColor"
+              >
+                <rect x="6" y="5" width="4" height="14" rx="1" />
+                <rect x="14" y="5" width="4" height="14" rx="1" />
+              </svg>
+            </button>
+          )}
+          <span className="relative" data-repo-menu={repository.id}>
+            <button
+              type="button"
+              className="inline-flex size-8 items-center justify-center rounded-md text-slate-500 hover:bg-slate-100 hover:text-slate-800 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-600"
+              aria-label={`Actions for ${repository.githubOwner}/${repository.githubRepo}`}
+              aria-haspopup="menu"
+              aria-expanded={menuOpen}
+              onClick={() => setMenuOpen((open) => !open)}
+            >
+              <svg
+                aria-hidden="true"
+                className="size-4"
+                viewBox="0 0 24 24"
+                fill="currentColor"
+              >
+                <circle cx="12" cy="5" r="1.75" />
+                <circle cx="12" cy="12" r="1.75" />
+                <circle cx="12" cy="19" r="1.75" />
+              </svg>
+            </button>
+            {menuOpen && (
+              <div
+                role="menu"
+                className="absolute top-full right-0 z-10 mt-1 min-w-40 rounded-lg border border-slate-200 bg-white py-1 shadow-lg"
+              >
+                <button
+                  type="button"
+                  role="menuitem"
+                  className="block w-full px-3 py-2 text-left text-sm font-medium text-slate-700 hover:bg-slate-50"
+                  onClick={() => {
+                    setMenuOpen(false)
+                    openSettings()
+                  }}
+                >
+                  Settings
+                </button>
+                <hr className="my-1 border-t border-slate-200" />
+                <button
+                  type="button"
+                  role="menuitem"
+                  className="block w-full px-3 py-2 text-left text-sm font-medium text-red-700 hover:bg-red-50 disabled:cursor-wait disabled:opacity-50"
+                  disabled={removeRepository.isPending}
+                  onClick={() => {
+                    setMenuOpen(false)
+                    confirmRemoval()
+                  }}
+                >
+                  {removeRepository.isPending ? "Removing..." : "Remove"}
+                </button>
+              </div>
+            )}
           </span>
-          <button
-            type="button"
-            className="rounded-md border border-slate-300 bg-white px-2.5 py-1 text-xs font-semibold text-slate-700 transition hover:border-slate-400 hover:bg-slate-50 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-600"
-            onClick={openSettings}
-          >
-            Settings
-          </button>
         </div>
       </div>
       <dl className="m-0 grid gap-[0.8rem]">


### PR DESCRIPTION
## Why

The repository card header was getting crowded: a status badge, a Settings button, and a trash icon all competed for space. Folding secondary actions into a kebab keeps the header clean while leaving room for a clearer paused affordance.

## What Changed

- Replaced the Settings button and trash icon with a kebab menu: **Settings**, a divider, then **Remove** (same confirm + mutation as before)
- Replaced the Paused/Active text badge with a pause icon button when the repo is paused (action not wired yet)
- Pause control sits to the left of the kebab
