### PR TITLE
fix(graphql-api): name GitHub PATs as reponame - ready-for-agent

### DIFF
--- a/packages/graphql-api/src/lib/graphql-api.ts
+++ b/packages/graphql-api/src/lib/graphql-api.ts
@@ -166,7 +166,7 @@ const githubTokenSecretName = (repository: Repository) =>
 
 const githubTokenCreationUrl = (repository: Repository) => {
   const url = new URL("https://github.com/settings/personal-access-tokens/new")
-  url.searchParams.set("name", "Ready For Agent")
+  url.searchParams.set("name", `${repository.githubRepo} - ready-for-agent`)
   url.searchParams.set(
     "description",
     `Ready For Agent token for ${repository.githubOwner}/${repository.githubRepo}`,

--- a/packages/graphql-api/test/graphql-api.test.ts
+++ b/packages/graphql-api/test/graphql-api.test.ts
@@ -360,6 +360,9 @@ describe("GraphQL API", () => {
     const creationUrl = new URL(
       body.data.repositoryCredentials[0]!.githubTokenCreationUrl as string,
     )
+    expect(creationUrl.searchParams.get("name")).toBe(
+      `${repository.githubRepo} - ready-for-agent`,
+    )
     expect(creationUrl.searchParams.get("issues")).toBe("read")
     expect(creationUrl.searchParams.get("contents")).toBe("write")
     expect(creationUrl.searchParams.get("pull_requests")).toBe("write")


### PR DESCRIPTION
## Why

Generic PAT names like "Ready For Agent" make it hard to tell which repository a token belongs to when managing tokens in GitHub settings.

## What Changed

Pre-fill the fine-grained PAT creation URL with `{githubRepo} - ready-for-agent` (repo name without owner) instead of a fixed "Ready For Agent" name.