### PR TITLE
feat(harness): cap dashboard at two repo cards and widen shell

### DIFF
--- a/apps/harness/src/routes/__root.tsx
+++ b/apps/harness/src/routes/__root.tsx
@@ -88,7 +88,7 @@ function RootDocument({ children }: { children: ReactNode }) {
 
 function RootComponent() {
   return (
-    <div className="mx-auto min-h-screen max-w-6xl p-4 sm:p-6">
+    <div className="mx-auto min-h-screen max-w-7xl p-4 sm:p-6">
       <nav className="mb-6 flex items-center gap-4 border-b border-slate-200 pb-4">
         <Link
           to="/"

--- a/apps/harness/src/routes/index.tsx
+++ b/apps/harness/src/routes/index.tsx
@@ -376,7 +376,7 @@ function RepositoryCards() {
     <>
       {warning}
       <section
-        className="grid grid-cols-[repeat(auto-fit,minmax(min(100%,19rem),1fr))] gap-4"
+        className="grid grid-cols-1 gap-4 md:grid-cols-2"
         aria-label="Configured repositories"
       >
         {repositories.map((repository) => (
@@ -1443,11 +1443,11 @@ function RepositoryIssuesSkeleton() {
 function RepositoryCardsSkeleton() {
   return (
     <section
-      className="grid grid-cols-[repeat(auto-fit,minmax(min(100%,19rem),1fr))] gap-4"
+      className="grid grid-cols-1 gap-4 md:grid-cols-2"
       aria-label="Loading repositories"
       aria-busy="true"
     >
-      {[0, 1, 2].map((item) => (
+      {[0, 1].map((item) => (
         <div
           className="grid min-w-0 gap-4 rounded-[0.9rem] border border-[#dbe3ef] bg-white p-[1.35rem] shadow-[0_10px_30px_rgb(15_23_42_/_5%)]"
           key={item}


### PR DESCRIPTION
## Why

On wide screens the repository grid could fit three cards side by side, which made each card feel cramped. The shell was also capped at `max-w-6xl` (~1152px), leaving unused horizontal space on desktop.

## What Changed

- Cap the repository card grid at two columns (`grid-cols-1 md:grid-cols-2`) and match the loading skeleton.
- Widen the app shell from `max-w-6xl` to `max-w-7xl` (~1280px).