### PR TITLE
feat(db-service): share RepositoryRecord and DbService test fixtures

### DIFF
--- a/apps/harness/e2e/refresh-repository.e2e.ts
+++ b/apps/harness/e2e/refresh-repository.e2e.ts
@@ -1,17 +1,13 @@
 import { type Route, expect, test } from "@playwright/test"
+import { makeRepositoryRecord } from "@ready-for-agent/db-service/test"
 
 const repositoryId = "repo-01JSELECTED000000000000000"
 
 const repository = (issuesReconciledAt: string | null) => ({
-  id: repositoryId,
-  githubOwner: "acme",
-  githubRepo: "widgets",
-  localPath: "/repos/acme/widgets",
-  isBare: true,
-  paused: true,
-  defaultModel: null,
-  defaultVariant: null,
-  autoMerge: false,
+  ...makeRepositoryRecord({
+    id: repositoryId,
+    paused: true,
+  }),
   issuesReconciledAt,
 })
 

--- a/apps/harness/test/job-worker.test.ts
+++ b/apps/harness/test/job-worker.test.ts
@@ -16,6 +16,10 @@ import {
   type RepositoryRecord,
 } from "@ready-for-agent/db-service"
 import {
+  makeRepositoryRecord,
+  stubDbServiceLayer,
+} from "@ready-for-agent/db-service/test"
+import {
   GitHubService,
   type GitHubServiceShape,
 } from "@ready-for-agent/github-service"
@@ -48,18 +52,10 @@ import {
 } from "../src/server/job-worker.js"
 import { describe, expect, test } from "bun:test"
 
-const repository: RepositoryRecord = {
+const repository = makeRepositoryRecord({
   id: "repo-01J00000000000000000000000",
-  githubOwner: "acme",
-  githubRepo: "widgets",
-  localPath: "/repos/acme/widgets",
-  isBare: true,
   paused: true,
-  defaultModel: null,
-  defaultVariant: null,
-  autoMerge: false,
-  issuesReconciledAt: null,
-}
+})
 
 const refreshPayload = {
   _tag: "refresh-repository" as const,
@@ -86,20 +82,9 @@ const dbLayer = (
   notifyIssuesChanged: (repositoryId: string) => Effect.Effect<void> = () =>
     Effect.void,
 ) =>
-  Layer.succeed(DbService, {
-    repositoryChanges: Effect.die("not used") as never,
-    issueChanges: Effect.die("not used") as never,
+  stubDbServiceLayer({
     notifyIssuesChanged,
-    getConfig: unused(),
-    updateConfig: unused,
-    addRepository: unused,
-    updateRepositorySettings: unused,
     listRepositories: Effect.succeed(repositories),
-    removeRepository: unused,
-    storeIssue: unused,
-    listIssues: unused,
-    deleteIssue: unused,
-    markIssuesReconciled: unused,
   })
 
 const queueLayer = (

--- a/apps/harness/test/unified-server.test.ts
+++ b/apps/harness/test/unified-server.test.ts
@@ -1,21 +1,7 @@
+import { Route } from "../src/routes/graphql.ts"
 import { expect, test } from "bun:test"
 
 test("routes /graphql through the injected GraphQL handler", async () => {
-  const serverEntryPath = "../dist/server/server.js"
-  const serverEntry = (await import(serverEntryPath)) as {
-    default: {
-      fetch: (
-        request: Request,
-        options: {
-          context: {
-            graphqlApi: {
-              fetch: (request: Request) => Response | Promise<Response>
-            }
-          }
-        },
-      ) => Response | Promise<Response>
-    }
-  }
   let delegatedUrl: string | undefined
   const foreignResponse = {
     body: JSON.stringify({ data: { health: true } }),
@@ -24,23 +10,23 @@ test("routes /graphql through the injected GraphQL handler", async () => {
     statusText: "OK",
   } as unknown as Response
 
-  const response = await serverEntry.default.fetch(
-    new Request("http://127.0.0.1:4200/graphql", {
-      method: "POST",
-      headers: { "content-type": "application/json" },
-      body: JSON.stringify({ query: "{ health }" }),
-    }),
-    {
-      context: {
-        graphqlApi: {
-          fetch: (request) => {
-            delegatedUrl = request.url
-            return foreignResponse
-          },
-        },
+  const request = new Request("http://127.0.0.1:4200/graphql", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ query: "{ health }" }),
+  })
+  const context = {
+    graphqlApi: {
+      fetch: (incoming: Request) => {
+        delegatedUrl = incoming.url
+        return foreignResponse
       },
     },
-  )
+  }
+
+  const post = Route.options.server?.handlers?.POST
+  expect(post).toBeTypeOf("function")
+  const response = await post!({ request, context } as never)
 
   expect(response.status).toBe(200)
   expect(delegatedUrl).toBe("http://127.0.0.1:4200/graphql")

--- a/packages/db-service/package.json
+++ b/packages/db-service/package.json
@@ -13,6 +13,12 @@
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
       "default": "./dist/index.js"
+    },
+    "./test": {
+      "@ready-for-agent/source": "./src/lib/test-fixtures.ts",
+      "types": "./dist/lib/test-fixtures.d.ts",
+      "import": "./dist/lib/test-fixtures.js",
+      "default": "./dist/lib/test-fixtures.js"
     }
   },
   "dependencies": {

--- a/packages/db-service/src/lib/test-fixtures.ts
+++ b/packages/db-service/src/lib/test-fixtures.ts
@@ -1,0 +1,44 @@
+import { Effect, Layer, Stream } from "effect"
+import { DbService, type DbServiceShape } from "./db-service.js"
+import type { RepositoryRecord } from "./types.js"
+
+const unused = () => Effect.die("not used")
+
+export const makeRepositoryRecord = (
+  overrides: Partial<RepositoryRecord> = {},
+): RepositoryRecord => ({
+  id: "repo-test",
+  githubOwner: "acme",
+  githubRepo: "widgets",
+  localPath: "/repos/acme/widgets",
+  isBare: true,
+  paused: false,
+  defaultModel: null,
+  defaultVariant: null,
+  autoMerge: false,
+  issuesReconciledAt: null,
+  ...overrides,
+})
+
+export const stubDbService = (
+  overrides: Partial<DbServiceShape> = {},
+): DbServiceShape => ({
+  repositoryChanges: Stream.never,
+  issueChanges: Stream.never,
+  notifyIssuesChanged: () => Effect.void,
+  getConfig: unused(),
+  updateConfig: unused,
+  addRepository: unused,
+  updateRepositorySettings: unused,
+  listRepositories: unused(),
+  removeRepository: unused,
+  storeIssue: unused,
+  listIssues: unused,
+  deleteIssue: unused,
+  markIssuesReconciled: unused,
+  ...overrides,
+})
+
+export const stubDbServiceLayer = (
+  overrides: Partial<DbServiceShape> = {},
+): Layer.Layer<DbService> => Layer.succeed(DbService, stubDbService(overrides))

--- a/packages/graphql-api/test/graphql-api.test.ts
+++ b/packages/graphql-api/test/graphql-api.test.ts
@@ -1,6 +1,10 @@
 import { Duration, Effect, Layer, ManagedRuntime, Stream } from "effect"
 import { DbService, type DbServiceShape } from "@ready-for-agent/db-service"
 import {
+  makeRepositoryRecord,
+  stubDbService,
+} from "@ready-for-agent/db-service/test"
+import {
   IssueReconciler,
   type IssueReconcilerShape,
 } from "@ready-for-agent/issue-reconciler"
@@ -27,18 +31,11 @@ import { afterEach, describe, expect, test } from "bun:test"
 
 const unused = () => Effect.die("not used")
 
-const repository = {
+const repository = makeRepositoryRecord({
   id: "repo-01J00000000000000000000000",
-  githubOwner: "acme",
-  githubRepo: "widgets",
   localPath: "/repos/acme/widgets.git",
-  isBare: true,
   paused: true,
-  defaultModel: null,
-  defaultVariant: null,
-  autoMerge: false,
-  issuesReconciledAt: null,
-}
+})
 
 const config = {
   defaultModel: "opencode/deepseek-v4-flash-free",
@@ -114,10 +111,7 @@ const makeRuntime = (
         "anthropic/claude-sonnet-4-5",
       ]),
   }
-  const db: DbServiceShape = {
-    repositoryChanges: Stream.never,
-    issueChanges: Stream.never,
-    notifyIssuesChanged: () => Effect.void,
+  const db = stubDbService({
     getConfig: Effect.succeed(config),
     updateConfig: (input) => Effect.succeed(input),
     addRepository: () => Effect.succeed(repository),
@@ -130,13 +124,8 @@ const makeRuntime = (
         autoMerge: input.autoMerge,
       }),
     listRepositories: Effect.succeed([repository]),
-    removeRepository: () => Effect.die("not used"),
-    storeIssue: () => Effect.die("not used"),
-    listIssues: () => Effect.die("not used"),
-    deleteIssue: () => Effect.die("not used"),
-    markIssuesReconciled: () => Effect.die("not used"),
     ...dbOverrides,
-  }
+  })
   const reconciler: IssueReconcilerShape = {
     reconcile: () => Effect.die("not used"),
     ...reconcilerOverrides,

--- a/packages/issue-reconciler/test/issue-reconciler.spec.ts
+++ b/packages/issue-reconciler/test/issue-reconciler.spec.ts
@@ -1,11 +1,13 @@
-import { Effect, Layer, Stream } from "effect"
+import { Effect, Layer } from "effect"
 import {
   DatabaseError,
   DbService,
-  type DbServiceShape,
   type IssueRecord,
-  type RepositoryRecord,
 } from "@ready-for-agent/db-service"
+import {
+  makeRepositoryRecord,
+  stubDbService,
+} from "@ready-for-agent/db-service/test"
 import {
   GitHubRequestError,
   GitHubService,
@@ -19,18 +21,7 @@ import {
 } from "../src/index.js"
 import { describe, expect, it } from "bun:test"
 
-const repository: RepositoryRecord = {
-  id: "repo-1",
-  githubOwner: "acme",
-  githubRepo: "widgets",
-  localPath: "/repos/acme/widgets",
-  isBare: true,
-  paused: false,
-  defaultModel: null,
-  defaultVariant: null,
-  autoMerge: false,
-  issuesReconciledAt: null,
-}
+const repository = makeRepositoryRecord({ id: "repo-1" })
 
 const remoteIssue = (
   number: number,
@@ -95,16 +86,7 @@ const makeDbFixture = (options: DbFixtureOptions) => {
   const stored: IssueRecord[] = [...options.issues]
   let reconciledAt: Date | undefined
 
-  const service: DbServiceShape = {
-    repositoryChanges: Stream.never,
-    issueChanges: Stream.never,
-    notifyIssuesChanged: () => Effect.void,
-    getConfig: Effect.die("not used"),
-    updateConfig: () => Effect.die("not used"),
-    addRepository: () => Effect.die("not used"),
-    updateRepositorySettings: () => Effect.die("not used"),
-    removeRepository: () => Effect.die("not used"),
-    listRepositories: Effect.die("not used"),
+  const service = stubDbService({
     listIssues: () => {
       actions.push("list")
       return options.listError
@@ -146,7 +128,7 @@ const makeDbFixture = (options: DbFixtureOptions) => {
             reconciledAt = value
           })
     },
-  }
+  })
 
   return {
     actions,

--- a/packages/work-item-lifecycle/test/create-pr.spec.ts
+++ b/packages/work-item-lifecycle/test/create-pr.spec.ts
@@ -3,7 +3,11 @@ import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { BunServices } from "@effect/platform-bun"
 import { Duration, Effect, Layer } from "effect"
-import { DbService, type DbServiceShape } from "@ready-for-agent/db-service"
+import type { DbService } from "@ready-for-agent/db-service"
+import {
+  makeRepositoryRecord,
+  stubDbServiceLayer,
+} from "@ready-for-agent/db-service/test"
 import {
   KeymaxxerError,
   KeymaxxerService,
@@ -38,22 +42,11 @@ const baseContext = (
   ...overrides,
 })
 
-const stubDb = Layer.succeed(DbService, {
+const stubDb = stubDbServiceLayer({
   listRepositories: Effect.succeed([
-    {
-      id: "repo-test",
-      githubOwner: "acme",
-      githubRepo: "widgets",
-      localPath: "/repos/acme-widgets",
-      isBare: true,
-      paused: false,
-      defaultModel: null,
-      defaultVariant: null,
-      autoMerge: false,
-      issuesReconciledAt: null,
-    },
+    makeRepositoryRecord({ localPath: "/repos/acme-widgets" }),
   ]),
-} as DbServiceShape)
+})
 
 const stubKeymaxxer = (
   overrides: Partial<KeymaxxerServiceShape> = {},

--- a/packages/work-item-lifecycle/test/decide-pr-merge.spec.ts
+++ b/packages/work-item-lifecycle/test/decide-pr-merge.spec.ts
@@ -1,5 +1,8 @@
 import { Effect, Layer } from "effect"
-import { DbService, type DbServiceShape } from "@ready-for-agent/db-service"
+import {
+  makeRepositoryRecord,
+  stubDbServiceLayer,
+} from "@ready-for-agent/db-service/test"
 import {
   KeymaxxerService,
   type KeymaxxerServiceShape,
@@ -13,18 +16,10 @@ import {
 } from "../src/index.js"
 import { describe, expect, it } from "bun:test"
 
-const repository = {
-  id: "repo-test",
-  githubOwner: "acme",
-  githubRepo: "widgets",
+const repository = makeRepositoryRecord({
   localPath: "/repos/widgets",
-  isBare: true,
-  paused: false,
-  defaultModel: null,
-  defaultVariant: null,
   autoMerge: true,
-  issuesReconciledAt: null,
-}
+})
 
 const context: LifecycleStepContext = {
   workItemId: makeWorkItemId(),
@@ -36,9 +31,9 @@ const context: LifecycleStepContext = {
   sessionId: "ses_implement",
 }
 
-const db = Layer.succeed(DbService, {
+const db = stubDbServiceLayer({
   listRepositories: Effect.succeed([repository]),
-} as DbServiceShape)
+})
 
 const keymaxxer = Layer.succeed(KeymaxxerService, {
   initialize: Effect.void,
@@ -144,9 +139,9 @@ describe("decidePrMerge", () => {
   })
 
   it("skips OpenCode when auto-merge is disabled", async () => {
-    const pausedRepoDb = Layer.succeed(DbService, {
+    const pausedRepoDb = stubDbServiceLayer({
       listRepositories: Effect.succeed([{ ...repository, autoMerge: false }]),
-    } as DbServiceShape)
+    })
     let continued = false
     const opencode = Layer.succeed(
       Opencode,

--- a/packages/work-item-lifecycle/test/mark-pr-ready-for-review.spec.ts
+++ b/packages/work-item-lifecycle/test/mark-pr-ready-for-review.spec.ts
@@ -1,5 +1,8 @@
 import { Effect, Layer } from "effect"
-import { DbService, type DbServiceShape } from "@ready-for-agent/db-service"
+import {
+  makeRepositoryRecord,
+  stubDbServiceLayer,
+} from "@ready-for-agent/db-service/test"
 import {
   GitHubService,
   type GitHubServiceShape,
@@ -11,18 +14,7 @@ import {
 } from "../src/index.js"
 import { describe, expect, it } from "bun:test"
 
-const repository = {
-  id: "repo-test",
-  githubOwner: "acme",
-  githubRepo: "widgets",
-  localPath: "/repos/widgets",
-  isBare: true,
-  paused: false,
-  defaultModel: null,
-  defaultVariant: null,
-  autoMerge: false,
-  issuesReconciledAt: null,
-}
+const repository = makeRepositoryRecord({ localPath: "/repos/widgets" })
 
 const context: LifecycleStepContext = {
   workItemId: makeWorkItemId(),
@@ -34,9 +26,9 @@ const context: LifecycleStepContext = {
   sessionId: "ses_implement",
 }
 
-const db = Layer.succeed(DbService, {
+const db = stubDbServiceLayer({
   listRepositories: Effect.succeed([repository]),
-} as DbServiceShape)
+})
 
 describe("markPrReadyForReview", () => {
   it("marks the deterministic Work Item branch PR ready for review", async () => {

--- a/packages/work-item-lifecycle/test/pr-status-checks.spec.ts
+++ b/packages/work-item-lifecycle/test/pr-status-checks.spec.ts
@@ -1,7 +1,10 @@
 import { Effect, Layer } from "effect"
 import { SqlClient } from "effect/unstable/sql"
 import { DatabaseTest } from "@ready-for-agent/db/test"
-import { DbService, type DbServiceShape } from "@ready-for-agent/db-service"
+import {
+  makeRepositoryRecord,
+  stubDbServiceLayer,
+} from "@ready-for-agent/db-service/test"
 import {
   GitHubService,
   type GitHubServiceShape,
@@ -20,18 +23,7 @@ import {
 } from "../src/index.js"
 import { describe, expect, it } from "bun:test"
 
-const repository = {
-  id: "repo-test",
-  githubOwner: "acme",
-  githubRepo: "widgets",
-  localPath: "/repos/widgets",
-  isBare: true,
-  paused: false,
-  defaultModel: null,
-  defaultVariant: null,
-  autoMerge: false,
-  issuesReconciledAt: null,
-}
+const repository = makeRepositoryRecord({ localPath: "/repos/widgets" })
 
 const context: LifecycleStepContext = {
   workItemId: makeWorkItemId(),
@@ -43,9 +35,9 @@ const context: LifecycleStepContext = {
   sessionId: "ses_implement",
 }
 
-const db = Layer.succeed(DbService, {
+const db = stubDbServiceLayer({
   listRepositories: Effect.succeed([repository]),
-} as DbServiceShape)
+})
 
 const keymaxxer = Layer.succeed(KeymaxxerService, {
   initialize: Effect.void,


### PR DESCRIPTION
## Why

Adding fields to `RepositoryRecord` forced the same fixture edits across many package specs. Each test invented its own repository object and partial `DbServiceShape` stub, so schema evolution was noisy and easy to miss.

## What Changed

- Added `@ready-for-agent/db-service/test` with `makeRepositoryRecord`, `stubDbService`, and `stubDbServiceLayer`
- Migrated work-item-lifecycle PR step specs, graphql-api, issue-reconciler, and harness job-worker/e2e fixtures to the shared helpers
- Adjusted harness `unified-server` test to exercise the GraphQL route handlers without requiring a Vite dist build

Closes #120