### PR TITLE
fix(work-item-lifecycle): retry pre-commit failures with OpenCode

### DIFF
--- a/apps/harness/test/job-worker.test.ts
+++ b/apps/harness/test/job-worker.test.ts
@@ -124,7 +124,7 @@ const queueLayer = (
         create_worktree: Duration.minutes(5),
         install_dependencies: Duration.minutes(15),
         implement: Duration.hours(2),
-        pre_commit: Duration.minutes(15),
+        pre_commit: Duration.hours(2),
         review: Duration.hours(1),
         commit: Duration.minutes(5),
         create_pr: Duration.minutes(10),

--- a/docs/adr/0010-pre-commit-validation-before-local-review.md
+++ b/docs/adr/0010-pre-commit-validation-before-local-review.md
@@ -1,9 +1,10 @@
 # Pre-Commit Validation Before Local Review
 
-After OpenCode implements a Work Item and before Review, Ready For Agent validates the worktree by staging changes and running the repository's git pre-commit hook via `git hook run --ignore-missing pre-commit`. Failure blocks progress and records full hook output on the Step Run. Missing pre-commit hooks do not fail the Step Run; a failing hook does.
+After OpenCode implements a Work Item and before Review, Ready For Agent validates the worktree by staging changes and running the repository's git pre-commit hook via `git hook run --ignore-missing pre-commit`. Missing pre-commit hooks succeed. When the hook fails, the step continues the Implement OpenCode Session with the full hook output, asks it to fix the failures (without committing or opening a PR), then re-stages and re-runs the hook, repeating until the hook passes. The Step Run's maximum duration bounds the loop. OpenCode or staging failures fail the Step Run and leave Pre-Commit pending for Retry.
 
 ## Consequences
 
 - Pre-Commit is a first-class Lifecycle Step between Implement and Review, not an optional verification command.
-- The step stages with `git add -A` before invoking the hook so hooks that inspect the index see implementation changes even when OpenCode left them uncommitted.
-- Missing pre-commit hooks succeed; a failing hook fails the Step Run and leaves Pre-Commit pending for Retry.
+- The step stages with `git add -A` before each hook invocation so hooks that inspect the index see implementation changes even when OpenCode left them uncommitted.
+- Missing pre-commit hooks succeed; a failing hook triggers OpenCode fix-and-retry rather than immediately failing the Step Run.
+- Pre-Commit requires the Implement OpenCode Session so fix attempts continue that conversation.

--- a/docs/adr/0011-commit-after-local-review.md
+++ b/docs/adr/0011-commit-after-local-review.md
@@ -5,5 +5,5 @@ After Review succeeds and before Create PR, the Commit Lifecycle Step continues 
 ## Consequences
 
 - Commit remains a first-class Lifecycle Step between Review and Create PR.
-- Pre-Commit is still harness-run git validation; Commit's work is OpenCode Session continue.
+- Pre-Commit remains harness-run git validation with an OpenCode fix loop on hook failure; Commit's primary work is OpenCode Session continue to create the commit.
 - OpenCode owns staging, message wording (including conventional commits when the repo requires them), and whether a no-op is appropriate when nothing remains to commit.

--- a/packages/graphql-api/test/graphql-api.test.ts
+++ b/packages/graphql-api/test/graphql-api.test.ts
@@ -156,7 +156,7 @@ const makeRuntime = (
       create_worktree: Duration.minutes(5),
       install_dependencies: Duration.minutes(15),
       implement: Duration.hours(2),
-      pre_commit: Duration.minutes(15),
+      pre_commit: Duration.hours(2),
       review: Duration.hours(1),
       commit: Duration.minutes(5),
       create_pr: Duration.minutes(10),

--- a/packages/work-item-lifecycle/src/lib/lifecycle-steps-live.ts
+++ b/packages/work-item-lifecycle/src/lib/lifecycle-steps-live.ts
@@ -24,9 +24,10 @@ import { review } from "./review.js"
 /**
  * Production LifecycleSteps: Create Worktree, Install Dependencies, Implement,
  * Pre-Commit, Review, Commit, and Create PR (OpenCode continues the Implement
- * Session for Review, Commit, and Create PR; Pre-Commit remains harness git
- * validation). Captures platform, database, Keymaxxer, and OpenCode services so
- * handlers remain `Effect<A>` with no requirements.
+ * Session for Pre-Commit fix loops, Review, Commit, and Create PR; Pre-Commit
+ * still runs harness git validation first). Captures platform, database,
+ * Keymaxxer, and OpenCode services so handlers remain `Effect<A>` with no
+ * requirements.
  */
 export const LifecycleStepsLive = Layer.effect(
   LifecycleSteps,

--- a/packages/work-item-lifecycle/src/lib/pre-commit-errors.ts
+++ b/packages/work-item-lifecycle/src/lib/pre-commit-errors.ts
@@ -33,8 +33,26 @@ export class PreCommitHookFailedError extends Data.TaggedError(
   readonly output: string
 }> {}
 
+export class PreCommitSessionContextMissingError extends Data.TaggedError(
+  "PreCommitSessionContextMissingError",
+)<{
+  readonly workItemId: string
+  readonly message: string
+}> {}
+
+export class PreCommitOpenCodeError extends Data.TaggedError(
+  "PreCommitOpenCodeError",
+)<{
+  readonly message: string
+  readonly worktreePath: string
+  readonly sessionId: string
+  readonly cause?: unknown
+}> {}
+
 export type PreCommitError =
   | PreCommitWorktreeContextMissingError
   | PreCommitInvalidWorktreeContextError
   | PreCommitStageError
   | PreCommitHookFailedError
+  | PreCommitSessionContextMissingError
+  | PreCommitOpenCodeError

--- a/packages/work-item-lifecycle/src/lib/pre-commit.ts
+++ b/packages/work-item-lifecycle/src/lib/pre-commit.ts
@@ -1,12 +1,18 @@
 import { Effect, FileSystem, Stream } from "effect"
 import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process"
+import { Opencode } from "@ready-for-agent/opencode"
 import type { LifecycleStepContext } from "./lifecycle-steps.js"
 import {
-  PreCommitHookFailedError,
   PreCommitInvalidWorktreeContextError,
+  PreCommitOpenCodeError,
+  PreCommitSessionContextMissingError,
   PreCommitStageError,
   PreCommitWorktreeContextMissingError,
 } from "./pre-commit-errors.js"
+import { DEFAULT_LIFECYCLE_MAX_DURATIONS } from "./types.js"
+
+/** Max hook output chars embedded in the OpenCode CLI prompt (avoids spawn E2BIG). */
+export const HOOK_OUTPUT_PROMPT_LIMIT = 12_000
 
 const resolveWorktreePath = (context: LifecycleStepContext) =>
   Effect.gen(function* () {
@@ -41,6 +47,20 @@ const resolveWorktreePath = (context: LifecycleStepContext) =>
     return worktreePath
   })
 
+const resolveSessionId = (context: LifecycleStepContext) => {
+  const sessionId = context.sessionId
+  if (sessionId === null || sessionId.trim() === "") {
+    return Effect.fail(
+      new PreCommitSessionContextMissingError({
+        workItemId: context.workItemId,
+        message:
+          "Pre-Commit requires a Session ID persisted by a successful Implement Step Run",
+      }),
+    )
+  }
+  return Effect.succeed(sessionId)
+}
+
 const runGitInWorktree = (cwd: string, args: ReadonlyArray<string>) =>
   Effect.gen(function* () {
     const spawner = yield* ChildProcessSpawner.ChildProcessSpawner
@@ -72,38 +92,117 @@ const runGitInWorktree = (cwd: string, args: ReadonlyArray<string>) =>
     )
   })
 
+const truncateHookOutputForPrompt = (output: string): string => {
+  if (output.length === 0) {
+    return "(no output)"
+  }
+  if (output.length <= HOOK_OUTPUT_PROMPT_LIMIT) {
+    return output
+  }
+  return `…${output.slice(-(HOOK_OUTPUT_PROMPT_LIMIT - 1))}`
+}
+
+const writeHookOutputLog = (workItemId: string, output: string) =>
+  Effect.gen(function* () {
+    const fs = yield* FileSystem.FileSystem
+    const logPath = yield* fs.makeTempFileScoped({
+      prefix: `ready-for-agent-pre-commit-${workItemId}-`,
+      suffix: ".log",
+    })
+    yield* fs.writeFileString(logPath, output)
+    yield* fs.chmod(logPath, 0o600)
+    return logPath
+  })
+
+const buildFixPrompt = (exitCode: number, output: string, logPath: string) =>
+  [
+    "The repository pre-commit hook failed after staging the worktree changes.",
+    `Exit code: ${exitCode}`,
+    `Full hook output is at: ${logPath}`,
+    "Read that file if you need more context than the tail below.",
+    "Hook output (tail if truncated):",
+    truncateHookOutputForPrompt(output),
+    "Diagnose and fix the failures in this worktree so pre-commit can pass.",
+    "Run the same checks the hook runs when practical, then fix the underlying issues.",
+    "Do not create a git commit or open a pull request.",
+  ].join("\n")
+
+const askOpencodeToFix = (
+  context: LifecycleStepContext,
+  worktreePath: string,
+  sessionId: string,
+  exitCode: number,
+  output: string,
+) =>
+  Effect.scoped(
+    Effect.gen(function* () {
+      const logPath = yield* writeHookOutputLog(context.workItemId, output)
+      const opencode = yield* Opencode
+      yield* opencode
+        .continue({
+          sessionId,
+          prompt: buildFixPrompt(exitCode, output, logPath),
+          cwd: worktreePath,
+          model: context.model,
+          variant: context.variant,
+          timeout:
+            context.maxDuration ?? DEFAULT_LIFECYCLE_MAX_DURATIONS.pre_commit,
+        })
+        .pipe(
+          Effect.mapError(
+            (cause) =>
+              new PreCommitOpenCodeError({
+                message:
+                  "OpenCode failed to fix pre-commit validation failures",
+                worktreePath,
+                sessionId,
+                cause,
+              }),
+          ),
+        )
+    }),
+  )
+
 /**
  * Production Pre-Commit Lifecycle Step.
  * Stages all worktree changes then runs the repository pre-commit hook via
- * `git hook run --ignore-missing pre-commit`. Missing hooks succeed; a
- * failing hook fails the Step Run with full hook output.
+ * `git hook run --ignore-missing pre-commit`. Missing hooks succeed. A failing
+ * hook continues the Implement OpenCode Session with the hook output, then
+ * re-stages and re-runs until the hook passes (bounded by the step max
+ * duration). OpenCode or stage failures fail the Step Run.
  */
 export const preCommit = (context: LifecycleStepContext) =>
   Effect.gen(function* () {
     const worktreePath = yield* resolveWorktreePath(context)
+    const sessionId = yield* resolveSessionId(context)
 
-    const stage = yield* runGitInWorktree(worktreePath, ["add", "-A"])
-    if (stage.exitCode !== 0) {
-      return yield* new PreCommitStageError({
-        message: `Failed to stage worktree changes before pre-commit (exit ${stage.exitCode})`,
-        worktreePath,
-        exitCode: stage.exitCode,
-        output: stage.output || "(no output)",
-      })
-    }
+    for (;;) {
+      const stage = yield* runGitInWorktree(worktreePath, ["add", "-A"])
+      if (stage.exitCode !== 0) {
+        return yield* new PreCommitStageError({
+          message: `Failed to stage worktree changes before pre-commit (exit ${stage.exitCode})`,
+          worktreePath,
+          exitCode: stage.exitCode,
+          output: stage.output || "(no output)",
+        })
+      }
 
-    const hook = yield* runGitInWorktree(worktreePath, [
-      "hook",
-      "run",
-      "--ignore-missing",
-      "pre-commit",
-    ])
-    if (hook.exitCode !== 0) {
-      return yield* new PreCommitHookFailedError({
-        message: `Pre-commit validation failed (exit ${hook.exitCode})`,
+      const hook = yield* runGitInWorktree(worktreePath, [
+        "hook",
+        "run",
+        "--ignore-missing",
+        "pre-commit",
+      ])
+      if (hook.exitCode === 0) {
+        return
+      }
+
+      yield* askOpencodeToFix(
+        context,
         worktreePath,
-        exitCode: hook.exitCode,
-        output: hook.output || "(no output)",
-      })
+        sessionId,
+        hook.exitCode,
+        hook.output || "(no output)",
+      )
     }
   })

--- a/packages/work-item-lifecycle/src/lib/types.ts
+++ b/packages/work-item-lifecycle/src/lib/types.ts
@@ -121,7 +121,7 @@ export const DEFAULT_LIFECYCLE_MAX_DURATIONS: LifecycleMaxDurations = {
   create_worktree: Duration.minutes(5),
   install_dependencies: Duration.minutes(15),
   implement: Duration.hours(2),
-  pre_commit: Duration.minutes(15),
+  pre_commit: Duration.hours(2),
   review: Duration.hours(1),
   commit: Duration.minutes(5),
   create_pr: Duration.minutes(10),

--- a/packages/work-item-lifecycle/test/pre-commit.spec.ts
+++ b/packages/work-item-lifecycle/test/pre-commit.spec.ts
@@ -1,12 +1,28 @@
-import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises"
+import {
+  access,
+  mkdir,
+  mkdtemp,
+  readFile,
+  rm,
+  stat,
+  writeFile,
+} from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { BunServices } from "@effect/platform-bun"
-import { Effect, type Layer } from "effect"
+import { type Duration, Effect, Layer } from "effect"
+import {
+  Opencode,
+  OpencodeExitError,
+  OpencodeTimeoutError,
+  SessionIdNotFoundError,
+} from "@ready-for-agent/opencode"
 import type { LifecycleStepContext } from "../src/index.js"
 import {
-  PreCommitHookFailedError,
+  HOOK_OUTPUT_PROMPT_LIMIT,
   PreCommitInvalidWorktreeContextError,
+  PreCommitOpenCodeError,
+  PreCommitSessionContextMissingError,
   PreCommitWorktreeContextMissingError,
   makeWorkItemId,
   preCommit,
@@ -15,7 +31,10 @@ import { describe, expect, it } from "bun:test"
 
 const PlatformLayer = BunServices.layer
 
-const baseContext = (worktreePath: string | null): LifecycleStepContext => ({
+const baseContext = (
+  worktreePath: string | null,
+  overrides: Partial<LifecycleStepContext> = {},
+): LifecycleStepContext => ({
   workItemId: makeWorkItemId(),
   repositoryId: "repo-test",
   githubIssueNumber: 90,
@@ -23,11 +42,52 @@ const baseContext = (worktreePath: string | null): LifecycleStepContext => ({
   variant: "high",
   worktreePath,
   sessionId: "ses_pre_commit",
+  ...overrides,
 })
 
+const stubOpencode = (impl: {
+  readonly start?: (input: {
+    readonly prompt: string
+    readonly cwd: string
+    readonly model: string
+    readonly variant: string
+    readonly timeout?: Duration.Input
+  }) => Effect.Effect<{ sessionId: string; assistantText: string }, never>
+  readonly continue?: (input: {
+    readonly sessionId: string
+    readonly prompt: string
+    readonly cwd: string
+    readonly model: string
+    readonly variant: string
+    readonly timeout?: Duration.Input
+  }) => Effect.Effect<{ sessionId: string; assistantText: string }, never>
+}) =>
+  Layer.succeed(
+    Opencode,
+    Opencode.of({
+      start: (input) =>
+        impl.start?.(input) ??
+        Effect.succeed({
+          sessionId: "ses_start_should_not_run",
+          assistantText: "",
+        }),
+      continue: (input) =>
+        impl.continue?.(input) ??
+        Effect.succeed({
+          sessionId: "ses_pre_commit_default",
+          assistantText: "",
+        }),
+      listModels: () => Effect.succeed([]),
+    }),
+  )
+
 const run = <A, E>(
-  effect: Effect.Effect<A, E, Layer.Layer.Success<typeof PlatformLayer>>,
-): Promise<A> => Effect.runPromise(effect.pipe(Effect.provide(PlatformLayer)))
+  effect: Effect.Effect<A, E, Opencode>,
+  opencodeLayer: Layer.Layer<Opencode, never, never> = stubOpencode({}),
+): Promise<A> =>
+  Effect.runPromise(
+    effect.pipe(Effect.provide(opencodeLayer), Effect.provide(PlatformLayer)),
+  )
 
 const initGitRepo = async (root: string) => {
   const runGit = async (...args: string[]) => {
@@ -58,6 +118,13 @@ const withTempGit = async (assert: (root: string) => Promise<void>) => {
   }
 }
 
+const writeHook = async (root: string, body: string) => {
+  await mkdir(join(root, ".git", "hooks"), { recursive: true })
+  await writeFile(join(root, ".git", "hooks", "pre-commit"), body, {
+    mode: 0o755,
+  })
+}
+
 describe("preCommit", () => {
   it("rejects missing worktree context", async () => {
     const error = await run(preCommit(baseContext(null)).pipe(Effect.flip))
@@ -70,46 +137,245 @@ describe("preCommit", () => {
     expect(error).toBeInstanceOf(PreCommitInvalidWorktreeContextError)
   })
 
-  it("succeeds when the pre-commit hook is missing", () =>
+  it("rejects missing Session context", () =>
     withTempGit(async (root) => {
-      await writeFile(join(root, "change.txt"), "hello\n")
-      await run(preCommit(baseContext(root)))
+      const error = await run(
+        preCommit(baseContext(root, { sessionId: null })).pipe(Effect.flip),
+      )
+      expect(error).toBeInstanceOf(PreCommitSessionContextMissingError)
     }))
 
-  it("succeeds when the pre-commit hook exits 0", () =>
+  it("succeeds when the pre-commit hook is missing without calling OpenCode", () =>
     withTempGit(async (root) => {
-      await mkdir(join(root, ".git", "hooks"), { recursive: true })
-      await writeFile(
-        join(root, ".git", "hooks", "pre-commit"),
-        "#!/usr/bin/env bash\nexit 0\n",
-        { mode: 0o755 },
-      )
+      let continues = 0
       await writeFile(join(root, "change.txt"), "hello\n")
-      await run(preCommit(baseContext(root)))
+      await run(
+        preCommit(baseContext(root)),
+        stubOpencode({
+          continue: () => {
+            continues += 1
+            return Effect.succeed({
+              sessionId: "ses_unused",
+              assistantText: "",
+            })
+          },
+        }),
+      )
+      expect(continues).toBe(0)
     }))
 
-  it("fails when the pre-commit hook exits non-zero", () =>
+  it("succeeds when the pre-commit hook exits 0 without calling OpenCode", () =>
     withTempGit(async (root) => {
-      const diagnostic = `format failed: ${"x".repeat(9_000)}`
-      await mkdir(join(root, ".git", "hooks"), { recursive: true })
-      await writeFile(
-        join(root, ".git", "hooks", "pre-commit"),
-        `#!/usr/bin/env bash\nprintf '%s\\n' '${diagnostic}' >&2\nexit 1\n`,
-        { mode: 0o755 },
+      let continues = 0
+      await writeHook(root, "#!/usr/bin/env bash\nexit 0\n")
+      await writeFile(join(root, "change.txt"), "hello\n")
+      await run(
+        preCommit(baseContext(root)),
+        stubOpencode({
+          continue: () => {
+            continues += 1
+            return Effect.succeed({
+              sessionId: "ses_unused",
+              assistantText: "",
+            })
+          },
+        }),
+      )
+      expect(continues).toBe(0)
+    }))
+
+  it("asks OpenCode to fix then re-runs until the hook succeeds", () =>
+    withTempGit(async (root) => {
+      const diagnostic = "format failed: needs fix"
+      await writeHook(
+        root,
+        [
+          "#!/usr/bin/env bash",
+          "set -euo pipefail",
+          'if [ -f ".pre-commit-fixed" ]; then',
+          "  exit 0",
+          "fi",
+          `printf '%s\\n' '${diagnostic}' >&2`,
+          "exit 1",
+          "",
+        ].join("\n"),
       )
       await writeFile(join(root, "change.txt"), "hello\n")
-      const error = await run(preCommit(baseContext(root)).pipe(Effect.flip))
-      expect(error).toBeInstanceOf(PreCommitHookFailedError)
-      expect((error as PreCommitHookFailedError).exitCode).toBe(1)
-      expect((error as PreCommitHookFailedError).output).toBe(diagnostic)
-      expect((error as PreCommitHookFailedError).worktreePath).toBe(root)
+
+      const prompts: string[] = []
+      await run(
+        preCommit(baseContext(root)),
+        stubOpencode({
+          continue: (input) => {
+            prompts.push(input.prompt)
+            expect(input.sessionId).toBe("ses_pre_commit")
+            expect(input.cwd).toBe(root)
+            expect(input.model).toBe("opencode/test-model")
+            expect(input.variant).toBe("high")
+            return Effect.promise(async () => {
+              await writeFile(join(root, ".pre-commit-fixed"), "ok\n")
+              return {
+                sessionId: input.sessionId,
+                assistantText: "fixed",
+              }
+            })
+          },
+        }),
+      )
+
+      expect(prompts).toHaveLength(1)
+      expect(prompts[0]).toContain(diagnostic)
+      expect(prompts[0]).toContain("pre-commit")
+      expect(prompts[0]).toMatch(/fix|Diagnose/i)
+      expect(prompts[0]).toMatch(/Full hook output is at: /)
+    }))
+
+  it("writes oversized hook output to a log and only embeds a truncated tail in the prompt", () =>
+    withTempGit(async (root) => {
+      const head = "HEAD_MARKER_SHOULD_NOT_BE_IN_PROMPT"
+      const tail = "TAIL_MARKER_MUST_BE_IN_PROMPT"
+      const filler = "x".repeat(HOOK_OUTPUT_PROMPT_LIMIT + 5_000)
+      const diagnostic = `${head}\n${filler}\n${tail}`
+      await writeFile(join(root, ".hook-diagnostic"), diagnostic)
+      await writeHook(
+        root,
+        [
+          "#!/usr/bin/env bash",
+          "set -euo pipefail",
+          'if [ -f ".pre-commit-fixed" ]; then',
+          "  exit 0",
+          "fi",
+          'cat ".hook-diagnostic" >&2',
+          "exit 1",
+          "",
+        ].join("\n"),
+      )
+      await writeFile(join(root, "change.txt"), "hello\n")
+
+      let prompt = ""
+      let logPath = ""
+      let logContents = ""
+      let logMode = 0
+      await run(
+        preCommit(baseContext(root)),
+        stubOpencode({
+          continue: (input) => {
+            prompt = input.prompt
+            const match = input.prompt.match(/Full hook output is at: (.+)$/m)
+            logPath = match?.[1]?.trim() ?? ""
+            return Effect.promise(async () => {
+              logContents = await readFile(logPath, "utf8")
+              logMode = (await stat(logPath)).mode & 0o777
+              await writeFile(join(root, ".pre-commit-fixed"), "ok\n")
+              return {
+                sessionId: input.sessionId,
+                assistantText: "fixed",
+              }
+            })
+          },
+        }),
+      )
+
+      expect(prompt.length).toBeLessThan(HOOK_OUTPUT_PROMPT_LIMIT + 2_000)
+      expect(prompt).not.toContain(head)
+      expect(prompt).toContain(tail)
+      expect(logPath.length).toBeGreaterThan(0)
+      expect(logContents).toContain(head)
+      expect(logContents).toContain(tail)
+      expect(logMode).toBe(0o600)
+      await expect(access(logPath)).rejects.toThrow()
+    }))
+
+  it("asks OpenCode again when the hook still fails after a fix attempt", () =>
+    withTempGit(async (root) => {
+      await writeHook(
+        root,
+        [
+          "#!/usr/bin/env bash",
+          "set -euo pipefail",
+          'attempts_file=".pre-commit-attempts"',
+          "n=0",
+          'if [ -f "$attempts_file" ]; then',
+          '  n=$(cat "$attempts_file")',
+          "fi",
+          "n=$((n + 1))",
+          'printf "%s" "$n" > "$attempts_file"',
+          'if [ "$n" -ge 3 ]; then',
+          "  exit 0",
+          "fi",
+          'printf "still failing attempt %s\\n" "$n" >&2',
+          "exit 1",
+          "",
+        ].join("\n"),
+      )
+      await writeFile(join(root, "change.txt"), "hello\n")
+
+      let continues = 0
+      await run(
+        preCommit(baseContext(root)),
+        stubOpencode({
+          continue: () => {
+            continues += 1
+            return Effect.succeed({
+              sessionId: "ses_pre_commit",
+              assistantText: "",
+            })
+          },
+        }),
+      )
+      // Hook fails on attempts 1 and 2, succeeds on 3 → two OpenCode fixes.
+      expect(continues).toBe(2)
+    }))
+
+  it("fails with OpenCode error when fix continue fails", () =>
+    withTempGit(async (root) => {
+      await writeHook(root, "#!/usr/bin/env bash\necho boom >&2\nexit 1\n")
+      await writeFile(join(root, "change.txt"), "hello\n")
+      const error = await run(
+        preCommit(baseContext(root)).pipe(Effect.flip),
+        stubOpencode({
+          continue: () =>
+            Effect.fail(
+              new OpencodeExitError({
+                exitCode: 2,
+                cwd: root,
+                sessionId: "ses_pre_commit",
+              }),
+            ),
+        }),
+      )
+      expect(error).toBeInstanceOf(PreCommitOpenCodeError)
+      expect((error as PreCommitOpenCodeError).sessionId).toBe("ses_pre_commit")
+      expect((error as PreCommitOpenCodeError).worktreePath).toBe(root)
+    }))
+
+  it("maps OpenCode timeout and missing session to PreCommitOpenCodeError", () =>
+    withTempGit(async (root) => {
+      await writeHook(root, "#!/usr/bin/env bash\nexit 1\n")
+      await writeFile(join(root, "change.txt"), "hello\n")
+
+      for (const cause of [
+        new OpencodeTimeoutError({
+          cwd: root,
+          timeoutMs: 1,
+          sessionId: "ses_pre_commit",
+        }),
+        new SessionIdNotFoundError({ cwd: root }),
+      ]) {
+        const error = await run(
+          preCommit(baseContext(root)).pipe(Effect.flip),
+          stubOpencode({
+            continue: () => Effect.fail(cause),
+          }),
+        )
+        expect(error).toBeInstanceOf(PreCommitOpenCodeError)
+      }
     }))
 
   it("stages untracked files before running the hook", () =>
     withTempGit(async (root) => {
-      await mkdir(join(root, ".git", "hooks"), { recursive: true })
-      await writeFile(
-        join(root, ".git", "hooks", "pre-commit"),
+      await writeHook(
+        root,
         [
           "#!/usr/bin/env bash",
           "set -euo pipefail",
@@ -120,7 +386,6 @@ describe("preCommit", () => {
           "exit 0",
           "",
         ].join("\n"),
-        { mode: 0o755 },
       )
       await writeFile(join(root, "change.txt"), "staged-by-pre-commit\n")
       await run(preCommit(baseContext(root)))

--- a/packages/work-item-lifecycle/test/work-item-lifecycle.spec.ts
+++ b/packages/work-item-lifecycle/test/work-item-lifecycle.spec.ts
@@ -2069,7 +2069,7 @@ describe("WorkItemLifecycle", () => {
           create_worktree: Duration.millis(20),
           install_dependencies: Duration.minutes(15),
           implement: Duration.hours(2),
-          pre_commit: Duration.minutes(15),
+          pre_commit: Duration.hours(2),
           review: Duration.hours(1),
           commit: Duration.minutes(5),
           create_pr: Duration.minutes(10),


### PR DESCRIPTION
## Why

When Pre-Commit failed (for example after Implement left lint/typecheck/test failures), the Step Run failed immediately and left the worktree for operator Retry. That meant OpenCode never got a chance to fix the same failures the repository's pre-commit hook already reported.

Large hook output also blew the OpenCode CLI argument list (`spawn E2BIG`), so even a fix prompt could not be launched.

## What Changed

- Pre-Commit stages, runs the hook, and on failure continues the Implement Session with a fix prompt, then re-stages and re-runs until the hook passes (bounded by the step max duration, now 2 hours).
- Oversized hook output is written to a private scoped temp log (`0600`); the CLI prompt only embeds a truncated tail plus the log path, then the file is deleted after OpenCode finishes.
- ADR 0010/0011 updated for the fix loop.
