### PR TITLE
fix(harness): hide Jobs for non-relevant Issues

### DIFF
--- a/apps/harness/src/refresh-issues-live.ts
+++ b/apps/harness/src/refresh-issues-live.ts
@@ -10,6 +10,10 @@ export type RepositoryIssuesLiveQueries = {
     queryKey: readonly unknown[]
     queryFn: () => Promise<unknown>
   }
+  workItems: (repositoryId: string) => {
+    queryKey: readonly unknown[]
+    queryFn: () => Promise<unknown>
+  }
 }
 
 /**
@@ -49,6 +53,7 @@ export const followRepositoryIssuesLive = async ({
     await Promise.all([
       fetchFresh(queries.repositories),
       fetchFresh(queries.issues(repositoryId)),
+      fetchFresh(queries.workItems(repositoryId)),
     ])
   }
 
@@ -57,6 +62,9 @@ export const followRepositoryIssuesLive = async ({
       fetchFresh(queries.repositories),
       ...repositoryIds.map((repositoryId) =>
         fetchFresh(queries.issues(repositoryId)),
+      ),
+      ...repositoryIds.map((repositoryId) =>
+        fetchFresh(queries.workItems(repositoryId)),
       ),
     ])
   }

--- a/apps/harness/src/routes/index.tsx
+++ b/apps/harness/src/routes/index.tsx
@@ -340,6 +340,7 @@ function RepositoryCards() {
       queries: {
         repositories: repositoriesQuery,
         issues: issuesQuery,
+        workItems: workItemsQuery,
       },
       signal: controller.signal,
     })

--- a/apps/harness/test/refresh-issues-live.test.ts
+++ b/apps/harness/test/refresh-issues-live.test.ts
@@ -13,6 +13,8 @@ describe("Repository Issue live-query coordination", () => {
     let repositoriesFetches = 0
     let selectedIssuesFetches = 0
     let otherIssuesFetches = 0
+    let selectedWorkItemsFetches = 0
+    let otherWorkItemsFetches = 0
     let issuesReconciledAt: string | null = null
     let selectedIssues = [
       {
@@ -42,6 +44,17 @@ describe("Repository Issue live-query coordination", () => {
             return selectedIssues
           }
           otherIssuesFetches += 1
+          return []
+        },
+      }),
+      workItems: (id: string) => ({
+        queryKey: ["work-items", id] as const,
+        queryFn: async () => {
+          if (id === repositoryId) {
+            selectedWorkItemsFetches += 1
+            return []
+          }
+          otherWorkItemsFetches += 1
           return []
         },
       }),
@@ -93,6 +106,7 @@ describe("Repository Issue live-query coordination", () => {
     const fetchesBeforeInvalidation = {
       repositories: repositoriesFetches,
       selectedIssues: selectedIssuesFetches,
+      selectedWorkItems: selectedWorkItemsFetches,
     }
     releaseInvalidation?.()
 
@@ -121,15 +135,27 @@ describe("Repository Issue live-query coordination", () => {
     expect(selectedIssuesFetches).toBeGreaterThan(
       fetchesBeforeInvalidation.selectedIssues,
     )
+    expect(selectedWorkItemsFetches).toBeGreaterThan(
+      fetchesBeforeInvalidation.selectedWorkItems,
+    )
     // Initial connection refetches both displayed Repositories, but the
     // selected invalidation does not refetch the other Repository again.
     expect(otherIssuesFetches).toBe(1)
+    expect(otherWorkItemsFetches).toBe(1)
     const selectedFetchesBeforeOtherInvalidation = selectedIssuesFetches
+    const selectedWorkItemsBeforeOtherInvalidation = selectedWorkItemsFetches
     const otherFetchesBeforeOtherInvalidation = otherIssuesFetches
+    const otherWorkItemsBeforeOtherInvalidation = otherWorkItemsFetches
     await onChange?.(otherRepositoryId)
     expect(selectedIssuesFetches).toBe(selectedFetchesBeforeOtherInvalidation)
+    expect(selectedWorkItemsFetches).toBe(
+      selectedWorkItemsBeforeOtherInvalidation,
+    )
     expect(otherIssuesFetches).toBeGreaterThan(
       otherFetchesBeforeOtherInvalidation,
+    )
+    expect(otherWorkItemsFetches).toBeGreaterThan(
+      otherWorkItemsBeforeOtherInvalidation,
     )
     expect(onChange).toBeDefined()
 
@@ -176,6 +202,10 @@ describe("Repository Issue live-query coordination", () => {
           queryFn: async () => [{ id: repositoryId }],
         },
         issues: () => issuesQuery,
+        workItems: (id) => ({
+          queryKey: ["work-items", id],
+          queryFn: async () => [],
+        }),
       },
       signal: controller.signal,
       stream: async ({ onChange: handleChange, signal }) => {
@@ -250,6 +280,10 @@ describe("Repository Issue live-query coordination", () => {
             if (id === repositoryId) issuesFetches += 1
             return []
           },
+        }),
+        workItems: (id: string) => ({
+          queryKey: ["work-items", id],
+          queryFn: async () => [],
         }),
       },
       signal: controller.signal,

--- a/packages/graphql-api/src/lib/graphql-api.ts
+++ b/packages/graphql-api/src/lib/graphql-api.ts
@@ -45,6 +45,7 @@ import {
   WorkItemLifecycleDatabaseError,
   WorkItemNotFoundError,
   WorkItemTerminalError,
+  isTerminalWorkItemState,
 } from "@ready-for-agent/work-item-lifecycle"
 
 type AddRepositoryArgs = {
@@ -479,14 +480,25 @@ export const createGraphqlApi = (
               Effect.result(
                 Effect.gen(function* () {
                   const lifecycle = yield* WorkItemLifecycle
-                  return args.githubIssueNumber === undefined
-                    ? yield* lifecycle.listWorkItemsForRepository(
-                        args.repositoryId,
-                      )
-                    : yield* lifecycle.listWorkItemsForIssue(
-                        args.repositoryId,
-                        args.githubIssueNumber,
-                      )
+                  if (args.githubIssueNumber !== undefined) {
+                    return yield* lifecycle.listWorkItemsForIssue(
+                      args.repositoryId,
+                      args.githubIssueNumber,
+                    )
+                  }
+                  const db = yield* DbService
+                  const [workItems, issues] = yield* Effect.all([
+                    lifecycle.listWorkItemsForRepository(args.repositoryId),
+                    db.listIssues(args.repositoryId),
+                  ])
+                  const relevantIssueNumbers = new Set(
+                    issues.map((issue) => issue.githubIssueNumber),
+                  )
+                  return workItems.filter(
+                    (workItem) =>
+                      !isTerminalWorkItemState(workItem.state) ||
+                      relevantIssueNumbers.has(workItem.githubIssueNumber),
+                  )
                 }),
               ),
             )

--- a/packages/graphql-api/test/graphql-api.test.ts
+++ b/packages/graphql-api/test/graphql-api.test.ts
@@ -931,7 +931,9 @@ describe("GraphQL API", () => {
     let receivedRepositoryId: string | undefined
     await runtime.dispose()
     runtime = makeRuntime(
-      {},
+      {
+        listIssues: () => Effect.succeed([issue]),
+      },
       {},
       {},
       {},
@@ -966,6 +968,71 @@ describe("GraphQL API", () => {
       },
     })
     expect(receivedRepositoryId).toBe(repository.id)
+  })
+
+  test("hides terminal Work Items whose Issue is no longer Relevant", async () => {
+    const terminalOrphan = {
+      ...workItem,
+      id: makeWorkItemId(),
+      githubIssueNumber: 120,
+      state: "needs_human" as const,
+      stepRuns: [],
+    }
+    const unfinishedOrphan = {
+      ...workItem,
+      id: makeWorkItemId(),
+      githubIssueNumber: 121,
+      state: "implement" as const,
+      stepRuns: [],
+    }
+    const terminalRelevant = {
+      ...workItem,
+      id: makeWorkItemId(),
+      githubIssueNumber: issue.githubIssueNumber,
+      state: "complete" as const,
+      stepRuns: [],
+    }
+    await runtime.dispose()
+    runtime = makeRuntime(
+      {
+        listIssues: () => Effect.succeed([issue]),
+      },
+      {},
+      {},
+      {},
+      {
+        listWorkItemsForRepository: () =>
+          Effect.succeed([terminalOrphan, unfinishedOrphan, terminalRelevant]),
+      },
+    )
+
+    const response = await createGraphqlApi(runtime).fetch(
+      graphqlRequest({
+        query: `query WorkItems($repositoryId: ID!) {
+          workItems(repositoryId: $repositoryId) {
+            id githubIssueNumber state
+          }
+        }`,
+        variables: { repositoryId: repository.id },
+      }),
+    )
+
+    expect(await response.json()).toEqual({
+      data: {
+        workItems: [
+          {
+            id: unfinishedOrphan.id,
+            githubIssueNumber: 121,
+            state: "IMPLEMENT",
+          },
+          {
+            id: terminalRelevant.id,
+            githubIssueNumber: issue.githubIssueNumber,
+            state: "COMPLETE",
+          },
+        ],
+      },
+    })
   })
 
   test("starts a Work Item for Implement Now", async () => {


### PR DESCRIPTION
## Why

After a PR was merged and its GitHub Issue closed, the dashboard still showed a terminal Jobs card (e.g. `NEEDS HUMAN`) with no useful way out. Relevant Issues correctly dropped the closed root Issue, but the repository-wide Jobs list kept every Work Item forever. Operators wanted those cards to disappear once the Issue is no longer Relevant, while keeping Work Item history for later statistics.

## What Changed

- Repository-wide `workItems` now hides terminal Work Items whose Issue is absent from the Relevant Issue store; unfinished Work Items still surface.
- Issue live-refresh also refetches repository Work Items so Jobs update when reconciliation prunes Issues, not only after a full reload.
- Coverage for the GraphQL filter and live Work Item refetch paths.
