### PR TITLE
fix(graphql-api): project lifecycle phase labels

### DIFF
--- a/apps/harness/src/routes/index.tsx
+++ b/apps/harness/src/routes/index.tsx
@@ -161,27 +161,34 @@ type WorkItemState =
   | "ABANDONED"
   | "NEEDS_HUMAN"
 
-type StepRunStatus =
+type WorkItemStatus =
   | "QUEUED"
   | "RUNNING"
   | "SUCCEEDED"
   | "FAILED"
   | "INTERRUPTED"
   | "CANCELLED"
+  | "COMPLETE"
+  | "ABANDONED"
+  | "NEEDS_HUMAN"
 
 type WorkItem = {
   id: string
   repositoryId: string
   githubIssueNumber: number
   state: WorkItemState
+  stateLabel: string
+  status: WorkItemStatus
+  statusLabel: string
+  statusMessage: string | null
+  canRetry: boolean
+  isTerminal: boolean
   sessionId: string | null
-  failureMessage: string | null
   createdAt: string
-  stepRuns: readonly {
-    id: string
-    step: WorkItemState
-    status: StepRunStatus
-    reasonMessage: string | null
+  lifecycleLabels: readonly {
+    phase: string
+    label: string
+    status: WorkItemStatus
   }[]
 }
 
@@ -190,14 +197,18 @@ const workItemFields = {
   repositoryId: true,
   githubIssueNumber: true,
   state: true,
+  stateLabel: true,
+  status: true,
+  statusLabel: true,
+  statusMessage: true,
+  canRetry: true,
+  isTerminal: true,
   sessionId: true,
-  failureMessage: true,
   createdAt: true,
-  stepRuns: {
-    id: true,
-    step: true,
+  lifecycleLabels: {
+    phase: true,
+    label: true,
     status: true,
-    reasonMessage: true,
   },
 } as const
 
@@ -213,71 +224,6 @@ const workItemsQuery = (repositoryId: string) => ({
     return result.workItems
   },
 })
-
-const terminalWorkItemStates: readonly WorkItemState[] = [
-  "COMPLETE",
-  "FAILED",
-  "ABANDONED",
-  "NEEDS_HUMAN",
-]
-
-const formatLifecycleLabel = (value: string) => {
-  if (value.toLowerCase() === "watch_pr_status_checks") {
-    return "GitHub status checks"
-  }
-  if (value.toLowerCase() === "resolve_pr_merge_conflict") {
-    return "Resolve PR merge conflict"
-  }
-  if (value.toLowerCase() === "mark_pr_ready_for_review") {
-    return "Mark PR ready for review"
-  }
-  if (value.toLowerCase() === "decide_pr_merge") {
-    return "Decide PR merge"
-  }
-  if (value.toLowerCase() === "merge_pr") {
-    return "Merge PR"
-  }
-  return value
-    .toLowerCase()
-    .replaceAll("_", " ")
-    .replace(/^./, (first) => first.toUpperCase())
-}
-
-const formatStepRunOutcome = (
-  stepRun: WorkItem["stepRuns"][number],
-  workItemState: WorkItemState,
-) => {
-  if (stepRun.step === "DECIDE_PR_MERGE" && stepRun.status === "SUCCEEDED") {
-    return workItemState === "NEEDS_HUMAN"
-      ? "Human review before merge"
-      : "Clanker may merge"
-  }
-  if (stepRun.step === "MERGE_PR" && stepRun.status === "SUCCEEDED") {
-    return "Merged"
-  }
-  return formatLifecycleLabel(stepRun.status)
-}
-
-const formatStepRunLabel = (
-  stepRun: WorkItem["stepRuns"][number],
-  workItemState: WorkItemState,
-) =>
-  `${formatLifecycleLabel(stepRun.step)}: ${formatStepRunOutcome(stepRun, workItemState)}`
-
-const collapseSuccessiveStepRuns = (
-  stepRuns: WorkItem["stepRuns"],
-  workItemState: WorkItemState,
-) => {
-  const collapsed: WorkItem["stepRuns"][number][] = []
-  let previousLabel: string | undefined
-  for (const stepRun of stepRuns) {
-    const label = formatStepRunLabel(stepRun, workItemState)
-    if (label === previousLabel) continue
-    collapsed.push(stepRun)
-    previousLabel = label
-  }
-  return collapsed
-}
 
 export const Route = createFileRoute("/")({
   component: HomePage,
@@ -1161,8 +1107,7 @@ function RepositoryIssueRow({
   )
   const latestWorkItem = issueWorkItems.at(-1)
   const hasUnfinishedWorkItem =
-    latestWorkItem !== undefined &&
-    !terminalWorkItemStates.includes(latestWorkItem.state)
+    latestWorkItem !== undefined && !latestWorkItem.isTerminal
   const canImplement =
     isActionable && !workItemsLoading && !hasUnfinishedWorkItem
   const implementNow = useMutation({
@@ -1307,10 +1252,9 @@ function RepositoryJobs({ repositoryId }: { repositoryId: string }) {
     ...workItemsQuery(repositoryId),
     refetchInterval: ({ state }) => {
       const items = state.data as readonly WorkItem[] | undefined
-      return items?.some((item) => {
-        const latestRun = item.stepRuns.at(-1)
-        return latestRun?.status === "QUEUED" || latestRun?.status === "RUNNING"
-      })
+      return items?.some(
+        (item) => item.status === "QUEUED" || item.status === "RUNNING",
+      )
         ? 1_000
         : false
     },
@@ -1332,7 +1276,7 @@ function RepositoryJobs({ repositoryId }: { repositoryId: string }) {
               Issue #{workItem.githubIssueNumber}
             </span>
             <span className="text-[0.65rem] font-bold tracking-wide text-slate-600 uppercase">
-              {formatLifecycleLabel(workItem.state)}
+              {workItem.stateLabel}
             </span>
           </div>
           {workItem.sessionId !== null && workItem.sessionId !== "" && (
@@ -1372,16 +1316,8 @@ function WorkItemLifecycleStatus({
   compact?: boolean
 }) {
   const queryClient = useQueryClient()
-  const latestRun = workItem.stepRuns.at(-1)
-  const isTerminal = terminalWorkItemStates.includes(workItem.state)
-  const status = isTerminal
-    ? workItem.state
-    : (latestRun?.status ?? workItem.state)
-  const message = workItem.failureMessage ?? latestRun?.reasonMessage
-  const canRetry =
-    compact &&
-    !isTerminal &&
-    (latestRun?.status === "FAILED" || latestRun?.status === "INTERRUPTED")
+  const status = workItem.status
+  const canRetry = compact && workItem.canRetry
   const canReset = compact
   const retry = useMutation({
     mutationFn: async () => {
@@ -1431,7 +1367,7 @@ function WorkItemLifecycleStatus({
     >
       <div className="flex flex-wrap items-center justify-between gap-2">
         <span className="text-xs font-semibold text-slate-700">
-          {formatLifecycleLabel(workItem.state)}
+          {workItem.stateLabel}
         </span>
         <span
           className={`rounded-full px-2 py-0.5 text-[0.6rem] font-bold tracking-wide uppercase ${
@@ -1446,28 +1382,28 @@ function WorkItemLifecycleStatus({
                     : "bg-blue-100 text-blue-700"
           }`}
         >
-          {formatLifecycleLabel(status)}
+          {workItem.statusLabel}
         </span>
       </div>
-      {workItem.stepRuns.length > 0 && (
+      {workItem.lifecycleLabels.length > 0 && (
         <ol
           className="mt-2 mb-0 flex list-none flex-wrap gap-1 p-0"
           aria-label="Lifecycle steps"
         >
-          {collapseSuccessiveStepRuns(workItem.stepRuns, workItem.state).map(
-            (stepRun) => (
-              <li
-                className="rounded bg-white px-1.5 py-1 text-[0.65rem] text-slate-600 ring-1 ring-slate-200"
-                key={stepRun.id}
-              >
-                {formatStepRunLabel(stepRun, workItem.state)}
-              </li>
-            ),
-          )}
+          {workItem.lifecycleLabels.map((lifecycleLabel) => (
+            <li
+              className="rounded bg-white px-1.5 py-1 text-[0.65rem] text-slate-600 ring-1 ring-slate-200"
+              key={lifecycleLabel.phase}
+            >
+              {lifecycleLabel.label}
+            </li>
+          ))}
         </ol>
       )}
-      {message !== null && message !== undefined && (
-        <p className="mt-1.5 mb-0 text-xs text-red-700">{message}</p>
+      {workItem.statusMessage !== null && (
+        <p className="mt-1.5 mb-0 text-xs text-red-700">
+          {workItem.statusMessage}
+        </p>
       )}
       {(canReset || canRetry) && (
         <div className="mt-2 flex flex-wrap gap-2">

--- a/packages/graphql-api/src/lib/graphql-api.ts
+++ b/packages/graphql-api/src/lib/graphql-api.ts
@@ -37,13 +37,16 @@ import {
   IssueBlockedError,
   IssueNotFoundError,
   IssueNotOpenError,
+  type OperationalLifecycleStep,
   ParentIssueError,
   ResetCleanupError,
   RetryNotEligibleError,
+  type StepRunRecord,
   UnfinishedWorkItemExistsError,
   WorkItemLifecycle,
   WorkItemLifecycleDatabaseError,
   WorkItemNotFoundError,
+  type WorkItemRecord,
   WorkItemTerminalError,
   isTerminalWorkItemState,
 } from "@ready-for-agent/work-item-lifecycle"
@@ -139,6 +142,96 @@ const workIssueProjection = (
       if (children.length === 0) return []
       return [issue, ...children.sort(compareChildIssues)]
     })
+}
+
+type WorkItemStatus =
+  | "queued"
+  | "running"
+  | "succeeded"
+  | "failed"
+  | "interrupted"
+  | "cancelled"
+  | "complete"
+  | "abandoned"
+  | "needs_human"
+
+type LifecyclePhase =
+  | Exclude<
+      OperationalLifecycleStep,
+      "watch_pr_status_checks" | "investigate_pr_status_checks"
+    >
+  | "github_status_checks"
+
+const lifecyclePhase = (step: OperationalLifecycleStep): LifecyclePhase => {
+  if (
+    step === "watch_pr_status_checks" ||
+    step === "investigate_pr_status_checks"
+  ) {
+    return "github_status_checks"
+  }
+  return step
+}
+
+const lifecyclePhaseLabel = (phase: LifecyclePhase): string => {
+  switch (phase) {
+    case "implement":
+      return "Build"
+    case "resolve_pr_merge_conflict":
+      return "Resolve PR merge conflict"
+    case "github_status_checks":
+      return "GitHub status checks"
+    case "mark_pr_ready_for_review":
+      return "Mark PR ready for review"
+    case "decide_pr_merge":
+      return "Decide PR merge"
+    case "merge_pr":
+      return "Merge PR"
+    default:
+      return phase
+        .replaceAll("_", " ")
+        .replace(/^./, (first) => first.toUpperCase())
+  }
+}
+
+const statusLabel = (status: WorkItemStatus): string =>
+  status.replaceAll("_", " ").replace(/^./, (first) => first.toUpperCase())
+
+const latestStepRun = (workItem: WorkItemRecord): StepRunRecord | undefined =>
+  workItem.stepRuns.at(-1)
+
+const workItemStatus = (workItem: WorkItemRecord): WorkItemStatus => {
+  if (isTerminalWorkItemState(workItem.state)) return workItem.state
+  return latestStepRun(workItem)?.status ?? "queued"
+}
+
+const lifecycleLabels = (workItem: WorkItemRecord) => {
+  const latestRuns = new Map<LifecyclePhase, StepRunRecord>()
+  for (const stepRun of workItem.stepRuns) {
+    latestRuns.set(lifecyclePhase(stepRun.step), stepRun)
+  }
+  const finalStepRun = latestStepRun(workItem)
+  const finalPhase =
+    workItem.state === "needs_human" && finalStepRun !== undefined
+      ? lifecyclePhase(finalStepRun.step)
+      : null
+
+  return [...latestRuns].map(([phase, stepRun]) => {
+    const status: WorkItemStatus =
+      phase === finalPhase ? "needs_human" : stepRun.status
+    const outcome =
+      phase === "decide_pr_merge" && status === "needs_human"
+        ? "Human review before merge"
+        : phase === "decide_pr_merge" && status === "succeeded"
+          ? "Clanker may merge"
+          : phase === "merge_pr" && status === "succeeded"
+            ? "Merged"
+            : statusLabel(status)
+    return {
+      phase: phase.toUpperCase(),
+      label: `${lifecyclePhaseLabel(phase)}: ${outcome}`,
+      status: status.toUpperCase(),
+    }
+  })
 }
 
 export type GraphqlRuntime = ManagedRuntime.ManagedRuntime<
@@ -541,22 +634,34 @@ export const createGraphqlApi = (
         },
         WorkItem: {
           state: (workItem: { state: string }) => workItem.state.toUpperCase(),
+          stateLabel: (workItem: WorkItemRecord) => {
+            if (isTerminalWorkItemState(workItem.state)) {
+              return statusLabel(workItem.state)
+            }
+            return lifecyclePhaseLabel(lifecyclePhase(workItem.state))
+          },
+          status: (workItem: WorkItemRecord) =>
+            workItemStatus(workItem).toUpperCase(),
+          statusLabel: (workItem: WorkItemRecord) =>
+            statusLabel(workItemStatus(workItem)),
+          statusMessage: (workItem: WorkItemRecord) =>
+            workItem.failureMessage ?? latestStepRun(workItem)?.reasonMessage,
+          canRetry: (workItem: WorkItemRecord) => {
+            const latestStatus = latestStepRun(workItem)?.status
+            return (
+              !isTerminalWorkItemState(workItem.state) &&
+              (latestStatus === "failed" || latestStatus === "interrupted")
+            )
+          },
+          isTerminal: (workItem: WorkItemRecord) =>
+            isTerminalWorkItemState(workItem.state),
+          lifecycleLabels,
           stateReadyAt: (workItem: { stateReadyAt: Date }) =>
             workItem.stateReadyAt.toISOString(),
           createdAt: (workItem: { createdAt: Date }) =>
             workItem.createdAt.toISOString(),
           updatedAt: (workItem: { updatedAt: Date }) =>
             workItem.updatedAt.toISOString(),
-        },
-        StepRun: {
-          step: (stepRun: { step: string }) => stepRun.step.toUpperCase(),
-          status: (stepRun: { status: string }) => stepRun.status.toUpperCase(),
-          queuedAt: (stepRun: { queuedAt: Date }) =>
-            stepRun.queuedAt.toISOString(),
-          startedAt: (stepRun: { startedAt: Date | null }) =>
-            stepRun.startedAt?.toISOString() ?? null,
-          finishedAt: (stepRun: { finishedAt: Date | null }) =>
-            stepRun.finishedAt?.toISOString() ?? null,
         },
         Subscription: {
           repositoriesChanged: {

--- a/packages/graphql-api/test/graphql-api.test.ts
+++ b/packages/graphql-api/test/graphql-api.test.ts
@@ -944,8 +944,9 @@ describe("GraphQL API", () => {
       graphqlRequest({
         query: `query WorkItems($repositoryId: ID!, $githubIssueNumber: Int!) {
           workItems(repositoryId: $repositoryId, githubIssueNumber: $githubIssueNumber) {
-            id state stateReadyAt createdAt updatedAt
-            stepRuns { id step status queuedAt startedAt finishedAt }
+            id state stateLabel status statusLabel statusMessage canRetry isTerminal
+            stateReadyAt createdAt updatedAt
+            lifecycleLabels { phase label status }
           }
         }`,
         variables: {
@@ -961,17 +962,20 @@ describe("GraphQL API", () => {
           {
             id: workItem.id,
             state: "CREATE_WORKTREE",
+            stateLabel: "Create worktree",
+            status: "RUNNING",
+            statusLabel: "Running",
+            statusMessage: null,
+            canRetry: false,
+            isTerminal: false,
             stateReadyAt: "2026-07-14T08:00:00.000Z",
             createdAt: "2026-07-14T08:00:00.000Z",
             updatedAt: "2026-07-14T08:00:01.000Z",
-            stepRuns: [
+            lifecycleLabels: [
               {
-                id: workItem.stepRuns[0]?.id,
-                step: "CREATE_WORKTREE",
+                phase: "CREATE_WORKTREE",
+                label: "Create worktree: Running",
                 status: "RUNNING",
-                queuedAt: "2026-07-14T08:00:00.000Z",
-                startedAt: "2026-07-14T08:00:01.000Z",
-                finishedAt: null,
               },
             ],
           },
@@ -979,6 +983,121 @@ describe("GraphQL API", () => {
       },
     })
     expect(receivedArgs).toEqual([repository.id, issue.githubIssueNumber])
+  })
+
+  test("projects repeated status-check runs as one lifecycle phase", async () => {
+    const baseRun = workItem.stepRuns[0]!
+    const polling = {
+      ...workItem,
+      state: "watch_pr_status_checks",
+      stepRuns: [
+        { ...baseRun, step: "implement", status: "succeeded" },
+        { ...baseRun, step: "review", status: "failed" },
+        { ...baseRun, step: "review", status: "succeeded" },
+        {
+          ...baseRun,
+          step: "resolve_pr_merge_conflict",
+          status: "succeeded",
+        },
+        { ...baseRun, step: "watch_pr_status_checks", status: "succeeded" },
+        {
+          ...baseRun,
+          step: "investigate_pr_status_checks",
+          status: "succeeded",
+        },
+        { ...baseRun, step: "watch_pr_status_checks", status: "queued" },
+      ],
+    } as WorkItemRecord
+    const needsHuman = {
+      ...polling,
+      id: makeWorkItemId(),
+      state: "needs_human",
+      failureMessage: "The pull request was closed",
+      stepRuns: [
+        {
+          ...baseRun,
+          step: "investigate_pr_status_checks",
+          status: "succeeded",
+        },
+      ],
+    } as WorkItemRecord
+    await runtime.dispose()
+    runtime = makeRuntime(
+      {},
+      {},
+      {},
+      {},
+      {
+        listWorkItemsForIssue: () => Effect.succeed([polling, needsHuman]),
+      },
+    )
+
+    const response = await createGraphqlApi(runtime).fetch(
+      graphqlRequest({
+        query: `query WorkItems($repositoryId: ID!, $githubIssueNumber: Int!) {
+          workItems(repositoryId: $repositoryId, githubIssueNumber: $githubIssueNumber) {
+            stateLabel status statusLabel statusMessage canRetry isTerminal
+            lifecycleLabels { phase label status }
+          }
+        }`,
+        variables: {
+          repositoryId: repository.id,
+          githubIssueNumber: issue.githubIssueNumber,
+        },
+      }),
+    )
+
+    expect(await response.json()).toEqual({
+      data: {
+        workItems: [
+          {
+            stateLabel: "GitHub status checks",
+            status: "QUEUED",
+            statusLabel: "Queued",
+            statusMessage: null,
+            canRetry: false,
+            isTerminal: false,
+            lifecycleLabels: [
+              {
+                phase: "IMPLEMENT",
+                label: "Build: Succeeded",
+                status: "SUCCEEDED",
+              },
+              {
+                phase: "REVIEW",
+                label: "Review: Succeeded",
+                status: "SUCCEEDED",
+              },
+              {
+                phase: "RESOLVE_PR_MERGE_CONFLICT",
+                label: "Resolve PR merge conflict: Succeeded",
+                status: "SUCCEEDED",
+              },
+              {
+                phase: "GITHUB_STATUS_CHECKS",
+                label: "GitHub status checks: Queued",
+                status: "QUEUED",
+              },
+            ],
+          },
+          {
+            stateLabel: "Needs human",
+            status: "NEEDS_HUMAN",
+            statusLabel: "Needs human",
+            statusMessage: "The pull request was closed",
+            canRetry: false,
+            isTerminal: true,
+            lifecycleLabels: [
+              {
+                phase: "GITHUB_STATUS_CHECKS",
+                label: "GitHub status checks: Needs human",
+                status: "NEEDS_HUMAN",
+              },
+            ],
+          },
+        ],
+      },
+    })
   })
 
   test("lists all Work Items for a repository", async () => {
@@ -1110,7 +1229,7 @@ describe("GraphQL API", () => {
         query: `mutation ImplementNow($repositoryId: ID!, $githubIssueNumber: Int!) {
           implementNow(repositoryId: $repositoryId, githubIssueNumber: $githubIssueNumber) {
             id state
-            stepRuns { step status }
+            lifecycleLabels { phase label status }
           }
         }`,
         variables: {
@@ -1125,7 +1244,13 @@ describe("GraphQL API", () => {
         implementNow: {
           id: workItem.id,
           state: "CREATE_WORKTREE",
-          stepRuns: [{ step: "CREATE_WORKTREE", status: "RUNNING" }],
+          lifecycleLabels: [
+            {
+              phase: "CREATE_WORKTREE",
+              label: "Create worktree: Running",
+              status: "RUNNING",
+            },
+          ],
         },
       },
     })

--- a/packages/graphql-schema/schema.graphql
+++ b/packages/graphql-schema/schema.graphql
@@ -86,26 +86,37 @@ enum WorkItemState {
   NEEDS_HUMAN
 }
 
-enum StepRunStatus {
+enum WorkItemStatus {
   QUEUED
   RUNNING
   SUCCEEDED
   FAILED
   INTERRUPTED
   CANCELLED
+  COMPLETE
+  ABANDONED
+  NEEDS_HUMAN
 }
 
-type StepRun {
-  id: ID!
-  step: WorkItemState!
-  status: StepRunStatus!
-  queuedAt: String!
-  startedAt: String
-  finishedAt: String
-  reasonCode: String
-  reasonMessage: String
-  queueWaitMs: Float!
-  executionDurationMs: Float
+enum LifecyclePhase {
+  CREATE_WORKTREE
+  INSTALL_DEPENDENCIES
+  IMPLEMENT
+  PRE_COMMIT
+  REVIEW
+  COMMIT
+  CREATE_PR
+  RESOLVE_PR_MERGE_CONFLICT
+  GITHUB_STATUS_CHECKS
+  MARK_PR_READY_FOR_REVIEW
+  DECIDE_PR_MERGE
+  MERGE_PR
+}
+
+type LifecycleLabel {
+  phase: LifecyclePhase!
+  label: String!
+  status: WorkItemStatus!
 }
 
 type WorkItem {
@@ -116,15 +127,20 @@ type WorkItem {
   model: String!
   variant: String!
   state: WorkItemState!
+  stateLabel: String!
+  status: WorkItemStatus!
+  statusLabel: String!
+  statusMessage: String
+  canRetry: Boolean!
+  isTerminal: Boolean!
   stateReadyAt: String!
   worktreePath: String
   sessionId: String
   failureCode: String
-  failureMessage: String
   createdAt: String!
   updatedAt: String!
   stateResidenceMs: Float!
-  stepRuns: [StepRun!]!
+  lifecycleLabels: [LifecycleLabel!]!
 }
 
 input AddRepositoryInput {


### PR DESCRIPTION
## Summary
- project internal Step Runs into one API-owned label per user-visible lifecycle phase
- collapse watch and investigation runs into a single GitHub status checks phase with its latest outcome
- return derived status, labels, retry eligibility, and terminal state so the harness only renders API values
- rename the public Implement label to Build

## Breaking GraphQL changes
- replace `stepRuns` with `lifecycleLabels`
- replace `StepRunStatus` with `WorkItemStatus`
- remove `failureMessage` in favor of `statusMessage`

## Validation
- `bunx nx affected -t lint typecheck test --files=packages/graphql-schema/schema.graphql,packages/graphql-api/src/lib/graphql-api.ts,packages/graphql-api/test/graphql-api.test.ts,apps/harness/src/routes/index.tsx`
- commit hooks: affected lint, typecheck, and tests