### PR TITLE
ci: add post-merge affected checks

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    commit-message:
+      prefix: chore(ci)
+    schedule:
+      interval: weekly

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -1,0 +1,40 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  actions: read
+  contents: read
+
+jobs:
+  main:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          filter: tree:0
+          fetch-depth: 0
+
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        with:
+          bun-version: latest
+
+      # This enables task distribution via Nx Cloud
+      # Run this command as early as possible, before dependencies are installed
+      # Learn more at https://nx.dev/ci/reference/nx-cloud-cli#npx-nxcloud-startcirun
+      # Connect your workspace by running "nx connect" and uncomment this line to enable task distribution
+      # - run: bunx nx start-ci-run --distribute-on="3 linux-medium-js" --stop-agents-after="build"
+
+      - run: bun install --no-cache --frozen-lockfile || bun install --no-cache --frozen-lockfile
+      - uses: nrwl/nx-set-shas@afb73a62d26e41464e9254689e1fd6122ee683c1 # v5.0.1
+
+      # Prepend any command with "nx record --" to record its logs to Nx Cloud
+      # - run: bun nx record -- echo Hello World
+      - run: bun nx affected -t lint knip test typecheck
+
+      # Nx Cloud recommends fixes for failures to help you get CI green faster. Learn more: https://nx.dev/ci/features/self-healing-ci
+      # - run: bun nx fix-ci
+      #   if: always()

--- a/nx.json
+++ b/nx.json
@@ -2,9 +2,16 @@
   "$schema": "./node_modules/nx/schemas/nx-schema.json",
   "analytics": true,
   "namedInputs": {
-    "default": ["{projectRoot}/**/*", "sharedGlobals"],
-    "production": ["default"],
-    "sharedGlobals": []
+    "default": [
+      "{projectRoot}/**/*",
+      "sharedGlobals"
+    ],
+    "production": [
+      "default"
+    ],
+    "sharedGlobals": [
+      "{workspaceRoot}/.github/workflows/ci-cd.yml"
+    ]
   },
   "plugins": [
     {
@@ -49,7 +56,9 @@
   "targetDefaults": {
     "build": {
       "cache": true,
-      "outputs": ["{projectRoot}/dist"]
+      "outputs": [
+        "{projectRoot}/dist"
+      ]
     },
     "knip": {
       "cache": true
@@ -62,7 +71,9 @@
     },
     "typecheck": {
       "cache": true,
-      "dependsOn": ["^build"]
+      "dependsOn": [
+        "^build"
+      ]
     }
   }
 }


### PR DESCRIPTION
## Why

Post-merge changes need consistent workspace validation without running the workflow on pull request events or requiring Nx Cloud.

## What Changed

- Add a push-to-`main` GitHub Actions workflow that uses `nrwl/nx-set-shas` and runs `nx affected` for `lint`, `knip`, `test`, and `typecheck`.
- Register the workflow as an Nx shared global input.
- Add weekly Dependabot updates for pinned GitHub Actions.
