### PR TITLE
fix(harness): restart backend runtime on source changes

### DIFF
--- a/apps/harness/src/server.ts
+++ b/apps/harness/src/server.ts
@@ -1,5 +1,9 @@
 import handler, { createServerEntry } from "@tanstack/react-start/server-entry"
 import type { Application } from "./server/application.server.js"
+import {
+  registerDevelopmentApplicationDisposer,
+  unregisterDevelopmentApplicationDisposer,
+} from "./server/development-application.js"
 import { ignoreClosedStreamErrors } from "./server/ignore-closed-stream-errors.js"
 import type { ApplicationRequestContext } from "./server-context.js"
 
@@ -8,6 +12,18 @@ if (import.meta.env.DEV && typeof Bun === "undefined") {
 }
 
 let applicationPromise: Promise<Application> | undefined
+
+const disposeApplication = async () => {
+  const currentApplication = applicationPromise
+  applicationPromise = undefined
+  if (currentApplication !== undefined) {
+    await (await currentApplication).dispose()
+  }
+}
+
+if (import.meta.env.DEV) {
+  registerDevelopmentApplicationDisposer(disposeApplication)
+}
 
 const getApplication = () => {
   applicationPromise ??= import("./server/application.server.js").then(
@@ -42,10 +58,7 @@ export default createServerEntry({
 
 if (import.meta.hot) {
   import.meta.hot.dispose(async () => {
-    const currentApplication = applicationPromise
-    applicationPromise = undefined
-    if (currentApplication !== undefined) {
-      await (await currentApplication).dispose()
-    }
+    unregisterDevelopmentApplicationDisposer(disposeApplication)
+    await disposeApplication()
   })
 }

--- a/apps/harness/src/server/backend-runtime-restart.ts
+++ b/apps/harness/src/server/backend-runtime-restart.ts
@@ -1,0 +1,72 @@
+import { relative, sep } from "node:path"
+import type { Plugin, ViteDevServer } from "vite"
+import { disposeDevelopmentApplication } from "./development-application.js"
+
+const restartDelayMs = 50
+
+export const isBackendRuntimeSource = (file: string, workspaceRoot: string) => {
+  const relativeFile = relative(workspaceRoot, file).split(sep).join("/")
+  if (relativeFile.startsWith("../")) return false
+
+  if (relativeFile === "apps/harness/src/server.ts") return true
+  if (relativeFile.startsWith("apps/harness/src/server/")) return true
+  if (!relativeFile.startsWith("packages/")) return false
+
+  const [, packageName, sourceDirectory] = relativeFile.split("/")
+  return sourceDirectory === "src" && packageName !== "graphql-client"
+}
+
+export const backendRuntimeRestart = (
+  workspaceRoot: string,
+  delay = restartDelayMs,
+): Plugin => {
+  let server: ViteDevServer | undefined
+  let restartTimeout: ReturnType<typeof setTimeout> | undefined
+  let restarting = false
+
+  const scheduleRestart = () => {
+    if (server === undefined) return
+    if (restartTimeout !== undefined) clearTimeout(restartTimeout)
+
+    restartTimeout = setTimeout(() => {
+      restartTimeout = undefined
+      restarting = true
+      void disposeDevelopmentApplication()
+        .then(() => server?.restart())
+        .catch((error: unknown) => {
+          server?.config.logger.error(
+            `Backend runtime restart failed: ${String(error)}`,
+          )
+        })
+        .finally(() => {
+          restarting = false
+        })
+    }, delay)
+  }
+
+  return {
+    name: "ready-for-agent-backend-runtime-restart",
+    apply: "serve",
+    configureServer(viteServer) {
+      server = viteServer
+      viteServer.middlewares.use((_request, response, next) => {
+        if (!restarting) {
+          next()
+          return
+        }
+
+        response.statusCode = 503
+        response.setHeader("Retry-After", "1")
+        response.end("Server runtime is restarting")
+      })
+    },
+    hotUpdate({ file }) {
+      if (isBackendRuntimeSource(file, workspaceRoot)) scheduleRestart()
+    },
+    async closeBundle() {
+      if (restartTimeout !== undefined) clearTimeout(restartTimeout)
+      restartTimeout = undefined
+      await disposeDevelopmentApplication()
+    },
+  }
+}

--- a/apps/harness/src/server/development-application.ts
+++ b/apps/harness/src/server/development-application.ts
@@ -1,0 +1,33 @@
+type ApplicationDisposer = () => Promise<void>
+
+const disposerKey = Symbol.for(
+  "@ready-for-agent/harness/development-application-disposer",
+)
+
+type DevelopmentGlobal = typeof globalThis & {
+  [disposerKey]?: ApplicationDisposer
+}
+
+const developmentGlobal = globalThis as DevelopmentGlobal
+
+export const registerDevelopmentApplicationDisposer = (
+  disposer: ApplicationDisposer,
+) => {
+  developmentGlobal[disposerKey] = disposer
+}
+
+export const unregisterDevelopmentApplicationDisposer = (
+  disposer: ApplicationDisposer,
+) => {
+  if (developmentGlobal[disposerKey] === disposer) {
+    delete developmentGlobal[disposerKey]
+  }
+}
+
+export const disposeDevelopmentApplication = async () => {
+  const disposer = developmentGlobal[disposerKey]
+  if (disposer === undefined) return
+
+  delete developmentGlobal[disposerKey]
+  await disposer()
+}

--- a/apps/harness/test/backend-runtime-restart.test.ts
+++ b/apps/harness/test/backend-runtime-restart.test.ts
@@ -1,0 +1,123 @@
+import { resolve } from "node:path"
+import type { ViteDevServer } from "vite"
+import {
+  backendRuntimeRestart,
+  isBackendRuntimeSource,
+} from "../src/server/backend-runtime-restart.js"
+import {
+  disposeDevelopmentApplication,
+  registerDevelopmentApplicationDisposer,
+} from "../src/server/development-application.js"
+import { afterEach, describe, expect, test } from "bun:test"
+
+const workspaceRoot = resolve(import.meta.dirname, "../../..")
+
+type TestPlugin = {
+  readonly configureServer: (server: ViteDevServer) => void
+  readonly hotUpdate: (context: { readonly file: string }) => void
+  readonly closeBundle: () => Promise<void>
+}
+
+const testPlugin = (delay = 1) =>
+  backendRuntimeRestart(workspaceRoot, delay) as unknown as TestPlugin
+
+afterEach(async () => {
+  await disposeDevelopmentApplication()
+})
+
+describe("backend runtime restart", () => {
+  test("classifies only runtime-owning Harness and backend package sources", () => {
+    expect(
+      isBackendRuntimeSource(
+        resolve(workspaceRoot, "apps/harness/src/server.ts"),
+        workspaceRoot,
+      ),
+    ).toBe(true)
+    expect(
+      isBackendRuntimeSource(
+        resolve(workspaceRoot, "apps/harness/src/server/job-worker.ts"),
+        workspaceRoot,
+      ),
+    ).toBe(true)
+    expect(
+      isBackendRuntimeSource(
+        resolve(workspaceRoot, "packages/work-item-lifecycle/src/index.ts"),
+        workspaceRoot,
+      ),
+    ).toBe(true)
+
+    expect(
+      isBackendRuntimeSource(
+        resolve(workspaceRoot, "apps/harness/src/routes/index.tsx"),
+        workspaceRoot,
+      ),
+    ).toBe(false)
+    expect(
+      isBackendRuntimeSource(
+        resolve(workspaceRoot, "packages/graphql-client/src/index.ts"),
+        workspaceRoot,
+      ),
+    ).toBe(false)
+  })
+
+  test("coalesces backend edits without restarting for client edits", async () => {
+    let restarts = 0
+    const plugin = testPlugin()
+    plugin.configureServer({
+      restart: async () => {
+        restarts += 1
+      },
+      config: { logger: { error: () => undefined } },
+      middlewares: { use: () => undefined },
+    } as unknown as ViteDevServer)
+
+    plugin.hotUpdate({
+      file: resolve(workspaceRoot, "apps/harness/src/routes/index.tsx"),
+    })
+    plugin.hotUpdate({
+      file: resolve(workspaceRoot, "packages/db-service/src/index.ts"),
+    })
+    plugin.hotUpdate({
+      file: resolve(workspaceRoot, "packages/db-service/src/lib/types.ts"),
+    })
+
+    await Bun.sleep(10)
+    expect(restarts).toBe(1)
+  })
+
+  test("disposes the active runtime before restarting Vite", async () => {
+    const events: string[] = []
+    registerDevelopmentApplicationDisposer(async () => {
+      await Bun.sleep(2)
+      events.push("disposed")
+    })
+    const plugin = testPlugin()
+    plugin.configureServer({
+      restart: async () => {
+        events.push("restarted")
+      },
+      config: { logger: { error: () => undefined } },
+      middlewares: { use: () => undefined },
+    } as unknown as ViteDevServer)
+
+    plugin.hotUpdate({
+      file: resolve(workspaceRoot, "packages/db-service/src/index.ts"),
+    })
+
+    await Bun.sleep(10)
+    expect(events).toEqual(["disposed", "restarted"])
+  })
+
+  test("disposes the application when Vite closes the old server", async () => {
+    let disposals = 0
+    registerDevelopmentApplicationDisposer(async () => {
+      disposals += 1
+    })
+
+    const plugin = testPlugin()
+    await plugin.closeBundle()
+    await plugin.closeBundle()
+
+    expect(disposals).toBe(1)
+  })
+})

--- a/apps/harness/test/topology.test.ts
+++ b/apps/harness/test/topology.test.ts
@@ -30,6 +30,7 @@ describe("single application server topology", () => {
     expect(harness.targets.dev?.options?.command).toContain(
       "run-with-keymaxxer-sidecar",
     )
+    expect(harness.targets.dev?.options?.command).toContain("vite")
     expect(harness.targets.dev?.options?.command).toContain(
       "export SQLITE_DATABASE_PATH",
     )

--- a/apps/harness/vite.config.ts
+++ b/apps/harness/vite.config.ts
@@ -1,10 +1,19 @@
+import { fileURLToPath } from "node:url"
 import tailwindcss from "@tailwindcss/vite"
 import { tanstackStart } from "@tanstack/react-start/plugin/vite"
 import react from "@vitejs/plugin-react"
 import { defineConfig } from "vite"
+import { backendRuntimeRestart } from "./src/server/backend-runtime-restart.js"
+
+const workspaceRoot = fileURLToPath(new URL("../..", import.meta.url))
 
 export default defineConfig({
-  plugins: [tanstackStart({ spa: { enabled: true } }), react(), tailwindcss()],
+  plugins: [
+    backendRuntimeRestart(workspaceRoot),
+    tanstackStart({ spa: { enabled: true } }),
+    react(),
+    tailwindcss(),
+  ],
   resolve: {
     conditions: ["@ready-for-agent/source"],
   },


### PR DESCRIPTION
## Why

Backend workspace changes could leave the long-lived Harness Effect runtime attached to Vite's stale SSR module namespace. Developers then had to restart `harness:dev` manually, which also risked interrupting the separate Keymaxxer Sidecar session.

## What Changed

- restart Vite's SSR server when Harness server files or backend package sources change
- dispose the active application runtime before restarting so only one Job Worker remains active
- preserve normal client HMR for routes, styles, and `graphql-client`
- coalesce rapid backend edits and return `503` while runtime replacement is underway
- cover source classification, restart coalescing, disposal ordering, and Sidecar process topology

Closes #135
