### PR TITLE
chore(harness): clarify empty issues empty-state copy

### DIFF
--- a/apps/harness/src/routes/index.tsx
+++ b/apps/harness/src/routes/index.tsx
@@ -1009,7 +1009,11 @@ function RepositoryIssues({
   const { data: issues } = useSuspenseQuery(issuesQuery(repositoryId))
 
   if (issues.length === 0) {
-    return <p className="m-0 text-sm text-slate-500">No relevant issues.</p>
+    return (
+      <p className="m-0 text-sm text-slate-500">
+        No issues found this harness can work on.
+      </p>
+    )
   }
 
   const childrenByParent = new Map<number, RepositoryIssue[]>()


### PR DESCRIPTION
## Why

The empty Issues list message was vague. "No relevant issues." does not make clear that the harness filters to work it can act on, so operators may think something is broken or that no Issues exist at all.

## What Changed

Updated the empty-state copy in the harness repository Issues list to: "No issues found this harness can work on."
