### PR TITLE
ci: isolate Bun dependency links

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -28,7 +28,7 @@ jobs:
       # Connect your workspace by running "nx connect" and uncomment this line to enable task distribution
       # - run: bunx nx start-ci-run --distribute-on="3 linux-medium-js" --stop-agents-after="build"
 
-      - run: bun install --no-cache --frozen-lockfile || bun install --no-cache --frozen-lockfile
+      - run: bun install --no-cache --frozen-lockfile --linker=isolated || bun install --no-cache --frozen-lockfile --linker=isolated
       - uses: nrwl/nx-set-shas@afb73a62d26e41464e9254689e1fd6122ee683c1 # v5.0.1
 
       # Prepend any command with "nx record --" to record its logs to Nx Cloud


### PR DESCRIPTION
## Why

The post-merge workflow fails while Nx builds its project graph after a clean Bun install. Bun's hoisted linker satisfies Nx's `typescript` peer with the aliased TypeScript native package, whose default API does not provide `readConfigFile`.

## What Changed

Install dependencies with Bun's isolated linker in CI. This keeps Nx linked to the TypeScript 6 compiler API while preserving the native TypeScript dependency used by the workspace.

Fixes the failure in GitHub Actions run 29467489292.

## Verification

Reproduced the failure from a fresh partial clone with Bun 1.3.14 and the frozen lockfile. With `--linker=isolated`, the same clean install resolves Nx to TypeScript 6.0.2 and successfully calculates all 17 affected projects.
