### PR TITLE
ci: repeat Bun install before Nx

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -28,7 +28,7 @@ jobs:
       # Connect your workspace by running "nx connect" and uncomment this line to enable task distribution
       # - run: bunx nx start-ci-run --distribute-on="3 linux-medium-js" --stop-agents-after="build"
 
-      - run: bun install --no-cache --frozen-lockfile --linker=isolated || bun install --no-cache --frozen-lockfile --linker=isolated
+      - run: bun install --no-cache --frozen-lockfile --linker=isolated && bun install --no-cache --frozen-lockfile --linker=isolated
       - uses: nrwl/nx-set-shas@afb73a62d26e41464e9254689e1fd6122ee683c1 # v5.0.1
 
       # Prepend any command with "nx record --" to record its logs to Nx Cloud


### PR DESCRIPTION
## Why

A fresh Bun install can exit successfully while linking Nx's `typescript` peer to TypeScript Native 7, which does not expose the `readConfigFile` API Nx needs. Bun repairs the peer link to TypeScript 6 on the following install.

The workflow used `||` between its duplicate install commands, so the second command ran only if the first command failed. The invalid first install exits successfully, preventing the repair.

## What Changed

Change the duplicate Bun installs from fallback execution (`||`) to sequential execution (`&&`) so the second frozen install always repairs the peer link before Nx starts.

Fixes the failure in GitHub Actions run 29467958437.

## Verification

Reproduced `tsModule.readConfigFile is not a function` from a fresh partial clone at the failed run's exact SHA range. Two sequential frozen isolated-linker installs resolved Nx to TypeScript 6.0.2 and successfully calculated the affected projects.
