### PR TITLE
ci: install OpenCode for integration tests

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -22,6 +22,12 @@ jobs:
         with:
           bun-version: latest
 
+      # Keep this in sync with anomalyco/opencode/github's setup steps.
+      - name: Install OpenCode
+        run: curl -fsSL https://opencode.ai/install | bash
+      - name: Add OpenCode to PATH
+        run: echo "$HOME/.opencode/bin" >> "$GITHUB_PATH"
+
       # This enables task distribution via Nx Cloud
       # Run this command as early as possible, before dependencies are installed
       # Learn more at https://nx.dev/ci/reference/nx-cloud-cli#npx-nxcloud-startcirun


### PR DESCRIPTION
## Why

The `opencode:test` target contains real integration tests that run `opencode models` and start and continue a free-model Session. GitHub Actions run 29468246081 failed because the runner did not have the OpenCode executable in `PATH`.

## What Changed

Install OpenCode before dependencies and export its binary directory through `GITHUB_PATH`.

These are the same setup commands used by the official `anomalyco/opencode/github` composite action. The action itself cannot be used as an install-only action because it immediately executes `opencode github run` and requires a model and GitHub-agent authentication.

## Verification

- Installed OpenCode 1.18.2 under a fresh temporary `HOME`
- Ran `opencode:test` with only that installation in `PATH`
- All 12 tests passed, including model discovery and a real start/continue Session
- Commit hooks passed all affected lint, typecheck, and test targets
