### PR TITLE
fix(harness): refresh repositories after add

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -11,9 +11,9 @@
 - Every job implementation is an Effect; the job worker composes and runs those Effects for work claimed from the database queue
 - A tagged payload in the shared `jobs` queue selects the Job Effect; the worker owns claim, decoding, dispatch, acknowledgement, and failure handling
 - UI is responsive: anything that takes long is put in a queue and handled by the job worker
-- Successful Issue reconciliation publishes a Repository-specific GraphQL invalidation so subscribed clients can refetch; no client-facing job history or status snapshots are maintained
+- Successful Issue reconciliation publishes a Repository-specific issues invalidation and a repositories invalidation so subscribed clients refetch Issues and `issuesReconciledAt`; no client-facing job history or status snapshots are maintained
 - The first worker executes one job at a time with five-minute claim visibility; job failures are terminal, while an abandoned claim may be redelivered once after interruption
-- The scoped worker polls once per second while idle and logs and recovers from queue infrastructure errors instead of permanently terminating its fiber
+- The scoped worker polls about every 1.5s while idle (Effect `Schedule.spaced` + `Schedule.jittered`, ~0.8–1.2×) and logs and recovers from queue infrastructure errors instead of permanently terminating its fiber
 - Queue methods acquire their SQL dependency when constructing the queue layer and return self-contained Effects; complete issue #13 before implementing the worker
 - Public Job IDs use the canonical `qjob-<ULID>` format
 - Prefer Bun APIs.

--- a/apps/harness/src/refresh-issues-live.ts
+++ b/apps/harness/src/refresh-issues-live.ts
@@ -17,12 +17,16 @@ export type RepositoryIssuesLiveQueries = {
 }
 
 /**
- * Keeps a Repository's Issues and reconciliation metadata fresh via the
+ * Keeps Repository Issues and reconciliation metadata fresh via the
  * Issues-changed invalidation subscription, with reconnect and tab-visibility
  * refetch as fallback for missed ephemeral notifications.
+ *
+ * The subscription stays open across membership changes; callers supply the
+ * current Repository IDs via `getRepositoryIds` so reconnect races cannot drop
+ * a just-finished Refresh Job invalidation.
  */
 export const followRepositoryIssuesLive = async ({
-  repositoryIds,
+  getRepositoryIds,
   queryClient,
   queries,
   signal,
@@ -30,7 +34,7 @@ export const followRepositoryIssuesLive = async ({
   documentRef = typeof document === "undefined" ? undefined : document,
   retryDelayMs = 1_000,
 }: {
-  repositoryIds: readonly string[]
+  getRepositoryIds: () => readonly string[]
   queryClient: QueryClient
   queries: RepositoryIssuesLiveQueries
   signal: AbortSignal
@@ -58,6 +62,7 @@ export const followRepositoryIssuesLive = async ({
   }
 
   const refreshAll = async () => {
+    const repositoryIds = getRepositoryIds()
     await Promise.all([
       fetchFresh(queries.repositories),
       ...repositoryIds.map((repositoryId) =>

--- a/apps/harness/src/routes/index.tsx
+++ b/apps/harness/src/routes/index.tsx
@@ -255,7 +255,8 @@ function RepositoryCards() {
   const queryClient = useQueryClient()
   const { data: repositories } = useSuspenseQuery(repositoriesQuery)
   const [liveUpdatesUnavailable, setLiveUpdatesUnavailable] = useState(false)
-  const repositoryIdsKey = repositories.map(({ id }) => id).join("\0")
+  const repositoryIdsRef = useRef(repositories.map(({ id }) => id))
+  repositoryIdsRef.current = repositories.map(({ id }) => id)
 
   useEffect(() => {
     let cancelled = false
@@ -319,10 +320,8 @@ function RepositoryCards() {
 
   useEffect(() => {
     const controller = new AbortController()
-    const repositoryIds =
-      repositoryIdsKey === "" ? [] : repositoryIdsKey.split("\0")
     void followRepositoryIssuesLive({
-      repositoryIds,
+      getRepositoryIds: () => repositoryIdsRef.current,
       queryClient,
       queries: {
         repositories: repositoriesQuery,
@@ -332,7 +331,7 @@ function RepositoryCards() {
       signal: controller.signal,
     })
     return () => controller.abort()
-  }, [queryClient, repositoryIdsKey])
+  }, [queryClient])
 
   const warning = liveUpdatesUnavailable ? (
     <p

--- a/apps/harness/src/server/job-worker.ts
+++ b/apps/harness/src/server/job-worker.ts
@@ -1,5 +1,5 @@
 import "@tanstack/react-start/server-only"
-import { Duration, Effect, Layer, Option, Schema } from "effect"
+import { Duration, Effect, Layer, Option, Schedule, Schema } from "effect"
 import {
   DbService,
   RepositoryId,
@@ -14,8 +14,32 @@ import {
 
 export const JOBS_QUEUE = "jobs"
 export const JOB_VISIBILITY_TIMEOUT = Duration.minutes(5)
-const JOB_IDLE_POLL_INTERVAL = Duration.seconds(1)
+const JOB_IDLE_POLL_INTERVAL = Duration.millis(1500)
 export const JOB_RECOVERY_RETRY_LIMIT = 1
+
+/**
+ * Process-global generation so HMR/runtime restarts retire zombie workers that
+ * would otherwise keep claiming jobs while GraphQL listens on a new runtime.
+ */
+const workerGenerationKey = Symbol.for(
+  "@ready-for-agent/harness/job-worker-generation",
+)
+
+const nextWorkerGeneration = (): number => {
+  const globalState = globalThis as typeof globalThis & {
+    [workerGenerationKey]?: number
+  }
+  const next = (globalState[workerGenerationKey] ?? 0) + 1
+  globalState[workerGenerationKey] = next
+  return next
+}
+
+const currentWorkerGeneration = (): number => {
+  const globalState = globalThis as typeof globalThis & {
+    [workerGenerationKey]?: number
+  }
+  return globalState[workerGenerationKey] ?? 0
+}
 
 const formatLogError = (error: unknown): string => {
   if (typeof error === "string" && error.trim().length > 0) {
@@ -77,10 +101,14 @@ export interface JobWorkerOptions {
 
 export const runJobWorker = (options: JobWorkerOptions = {}) =>
   Effect.gen(function* () {
+    const generation = nextWorkerGeneration()
     const queue = yield* QueueService
     const idlePollInterval = options.idlePollInterval ?? JOB_IDLE_POLL_INTERVAL
     const visibilityTimeout =
       options.visibilityTimeout ?? JOB_VISIBILITY_TIMEOUT
+    const sleepIdle = yield* Schedule.toStepWithSleep(
+      Schedule.spaced(idlePollInterval).pipe(Schedule.jittered),
+    )
 
     const claimAndRun = Effect.gen(function* () {
       const claimed = yield* QueueService.claim(
@@ -95,7 +123,7 @@ export const runJobWorker = (options: JobWorkerOptions = {}) =>
         ),
       )
 
-      if (Option.isNone(claimed)) return true
+      if (Option.isNone(claimed)) return "idle" as const
 
       const job = claimed.value
       switch (job.payload._tag) {
@@ -135,21 +163,21 @@ export const runJobWorker = (options: JobWorkerOptions = {}) =>
         }
       }
 
-      return false
+      return "busy" as const
     })
 
-    const poll = claimAndRun.pipe(
-      Effect.catch((error) =>
-        Effect.logError("Job queue poll failed", {
-          error: formatLogError(error),
-        }).pipe(Effect.as(true)),
-      ),
-      Effect.flatMap((idle) =>
-        idle ? Effect.sleep(idlePollInterval) : Effect.void,
-      ),
-    )
-
-    return yield* Effect.forever(poll)
+    while (generation === currentWorkerGeneration()) {
+      const state = yield* claimAndRun.pipe(
+        Effect.catch((error) =>
+          Effect.logError("Job queue poll failed", {
+            error: formatLogError(error),
+          }).pipe(Effect.as("idle" as const)),
+        ),
+      )
+      if (state === "idle") {
+        yield* sleepIdle(undefined).pipe(Effect.asVoid)
+      }
+    }
   })
 
 export const JobWorkerLive = Layer.effectDiscard(

--- a/apps/harness/test/refresh-issues-live.test.ts
+++ b/apps/harness/test/refresh-issues-live.test.ts
@@ -72,7 +72,7 @@ describe("Repository Issue live-query coordination", () => {
 
     const controller = new AbortController()
     const live = followRepositoryIssuesLive({
-      repositoryIds: [repositoryId, otherRepositoryId],
+      getRepositoryIds: () => [repositoryId, otherRepositoryId],
       queryClient,
       queries,
       signal: controller.signal,
@@ -194,7 +194,7 @@ describe("Repository Issue live-query coordination", () => {
     })
     const controller = new AbortController()
     const live = followRepositoryIssuesLive({
-      repositoryIds: [repositoryId],
+      getRepositoryIds: () => [repositoryId],
       queryClient,
       queries: {
         repositories: {
@@ -264,7 +264,7 @@ describe("Repository Issue live-query coordination", () => {
 
     const controller = new AbortController()
     const live = followRepositoryIssuesLive({
-      repositoryIds: [repositoryId],
+      getRepositoryIds: () => [repositoryId],
       queryClient,
       queries: {
         repositories: {

--- a/packages/db-service/src/lib/db-service.ts
+++ b/packages/db-service/src/lib/db-service.ts
@@ -270,12 +270,54 @@ export class DbService extends Context.Service<DbService, DbServiceShape>()(
   "@ready-for-agent/db-service/DbService",
 ) {}
 
+/**
+ * Process-global PubSubs. Survive Effect Layer rebuilds and HMR so workers and
+ * GraphQL subscriptions always share the same signal channel (in-layer PubSubs
+ * leave zombie workers publishing to a bus nobody listens to).
+ */
+const repositoryChangesKey = Symbol.for(
+  "@ready-for-agent/db-service/repository-changes",
+)
+const issueChangesKey = Symbol.for("@ready-for-agent/db-service/issue-changes")
+
+type InvalidationGlobal = typeof globalThis & {
+  [repositoryChangesKey]?: PubSub.PubSub<void>
+  [issueChangesKey]?: PubSub.PubSub<string>
+}
+
+const getRepositoryChanges = (): PubSub.PubSub<void> => {
+  const globalState = globalThis as InvalidationGlobal
+  globalState[repositoryChangesKey] ??= Effect.runSync(PubSub.unbounded<void>())
+  return globalState[repositoryChangesKey]
+}
+
+const getIssueChanges = (): PubSub.PubSub<string> => {
+  const globalState = globalThis as InvalidationGlobal
+  globalState[issueChangesKey] ??= Effect.runSync(PubSub.unbounded<string>())
+  return globalState[issueChangesKey]
+}
+
+const publishRepositoryChanged = (): Effect.Effect<void> =>
+  PubSub.publish(getRepositoryChanges(), undefined).pipe(Effect.asVoid)
+
+const publishIssuesChanged = (repositoryId: string): Effect.Effect<void> =>
+  Effect.gen(function* () {
+    yield* PubSub.publish(getIssueChanges(), repositoryId)
+    yield* PubSub.publish(getRepositoryChanges(), undefined)
+  }).pipe(Effect.asVoid)
+
+const repositoryChangesStream: Stream.Stream<void> = Stream.fromPubSub(
+  getRepositoryChanges(),
+)
+
+const issueChangesStream: Stream.Stream<string> = Stream.fromPubSub(
+  getIssueChanges(),
+)
+
 export const DbServiceLive = Layer.effect(
   DbService,
   Effect.gen(function* () {
     const sql = yield* SqlClient.SqlClient
-    const repositoryChanges = yield* PubSub.unbounded<void>()
-    const issueChanges = yield* PubSub.unbounded<string>()
 
     const getConfig: Effect.Effect<ConfigRecord, DatabaseError> = Effect.gen(
       function* () {
@@ -480,7 +522,7 @@ export const DbServiceLive = Layer.effect(
         }
 
         const repository = toRecordFromRow(row)
-        yield* PubSub.publish(repositoryChanges, undefined)
+        yield* publishRepositoryChanged()
         return repository
       })
 
@@ -533,7 +575,7 @@ export const DbServiceLive = Layer.effect(
         }
 
         const repository = toRecordFromRow(row)
-        yield* PubSub.publish(repositoryChanges, undefined)
+        yield* publishRepositoryChanged()
         return repository
       })
 
@@ -677,7 +719,7 @@ export const DbServiceLive = Layer.effect(
                 : toDatabaseError(error),
             ),
           )
-        yield* PubSub.publish(repositoryChanges, undefined)
+        yield* publishRepositoryChanged()
       })
 
     const storeIssue = (
@@ -1041,11 +1083,11 @@ export const DbServiceLive = Layer.effect(
       })
 
     const notifyIssuesChanged = (repositoryId: string): Effect.Effect<void> =>
-      PubSub.publish(issueChanges, repositoryId).pipe(Effect.asVoid)
+      publishIssuesChanged(repositoryId)
 
     return DbService.of({
-      repositoryChanges: Stream.fromPubSub(repositoryChanges),
-      issueChanges: Stream.fromPubSub(issueChanges),
+      repositoryChanges: repositoryChangesStream,
+      issueChanges: issueChangesStream,
       notifyIssuesChanged,
       getConfig,
       updateConfig,

--- a/packages/graphql-api/src/lib/graphql-api.ts
+++ b/packages/graphql-api/src/lib/graphql-api.ts
@@ -253,6 +253,31 @@ type Repository = {
   githubRepo: string
 }
 
+const enqueueRefreshRepositoryJob = (repository: Repository) =>
+  Effect.gen(function* () {
+    const queue = yield* QueueService
+    return yield* queue.enqueue(
+      JOBS_QUEUE,
+      {
+        _tag: "refresh-repository",
+        repositoryId: RepositoryId.make(repository.id),
+      },
+      { retryLimit: JOB_RECOVERY_RETRY_LIMIT },
+    )
+  })
+
+/** Enqueue a Refresh Job only when a GitHub token is already configured. */
+const enqueueRefreshIfCredentialed = (repository: Repository) =>
+  Effect.gen(function* () {
+    const keymaxxer = yield* KeymaxxerService
+    const credential = yield* keymaxxer.findSecret({
+      provider: "github",
+      account: `${repository.githubOwner}/${repository.githubRepo}`,
+    })
+    if (credential === null) return
+    yield* enqueueRefreshRepositoryJob(repository)
+  })
+
 class RepositoryCredentialError extends Data.TaggedError(
   "RepositoryCredentialError",
 )<{ readonly message: string }> {}
@@ -753,7 +778,19 @@ export const createGraphqlApi = (
               Effect.result(
                 Effect.gen(function* () {
                   const db = yield* DbService
-                  return yield* db.addRepository(args.input)
+                  const added = yield* db.addRepository(args.input)
+                  yield* enqueueRefreshIfCredentialed(added).pipe(
+                    Effect.catch((error) =>
+                      Effect.logWarning(
+                        "Automatic Repository refresh was not queued",
+                        {
+                          repositoryId: added.id,
+                          error,
+                        },
+                      ),
+                    ),
+                  )
+                  return added
                 }),
               ),
             )
@@ -929,15 +966,7 @@ export const createGraphqlApi = (
                     })
                   }
 
-                  const queue = yield* QueueService
-                  const jobId = yield* queue.enqueue(
-                    JOBS_QUEUE,
-                    {
-                      _tag: "refresh-repository",
-                      repositoryId: RepositoryId.make(repository.id),
-                    },
-                    { retryLimit: JOB_RECOVERY_RETRY_LIMIT },
-                  )
+                  const jobId = yield* enqueueRefreshRepositoryJob(repository)
                   return {
                     id: jobId,
                     repositoryId: repository.id,

--- a/packages/graphql-api/test/graphql-api.test.ts
+++ b/packages/graphql-api/test/graphql-api.test.ts
@@ -254,6 +254,133 @@ describe("GraphQL API", () => {
     })
   })
 
+  test("queues a Refresh Job when adding a repository that already has a GitHub token", async () => {
+    let enqueued:
+      | {
+          queue: string
+          payload: Record<string, unknown>
+          retryLimit: number | undefined
+        }
+      | undefined
+    await runtime.dispose()
+    runtime = makeRuntime(
+      {},
+      {},
+      {
+        findSecret: ({ account, provider }) =>
+          Effect.succeed(
+            provider === "github" &&
+              account === `${repository.githubOwner}/${repository.githubRepo}`
+              ? "GITHUB_TOKEN_ACME_WIDGETS"
+              : null,
+          ),
+      },
+      {
+        enqueue: (queueName, payload, options) =>
+          Effect.sync(() => {
+            enqueued = {
+              queue: queueName,
+              payload,
+              retryLimit: options?.retryLimit,
+            }
+            return makeJobId()
+          }),
+      },
+    )
+
+    const response = await createGraphqlApi(runtime).fetch(
+      addRepositoryRequest(),
+    )
+
+    expect(response.status).toBe(200)
+    expect(await response.json()).toEqual({
+      data: {
+        addRepository: {
+          id: repository.id,
+          githubOwner: repository.githubOwner,
+          githubRepo: repository.githubRepo,
+        },
+      },
+    })
+    expect(enqueued).toEqual({
+      queue: "jobs",
+      payload: {
+        _tag: "refresh-repository",
+        repositoryId: repository.id,
+      },
+      retryLimit: 1,
+    })
+  })
+
+  test("does not queue a Refresh Job when adding a repository without a GitHub token", async () => {
+    let enqueued = false
+    await runtime.dispose()
+    runtime = makeRuntime(
+      {},
+      {},
+      {
+        findSecret: () => Effect.succeed(null),
+      },
+      {
+        enqueue: () => {
+          enqueued = true
+          return Effect.succeed(makeJobId())
+        },
+      },
+    )
+
+    const response = await createGraphqlApi(runtime).fetch(
+      addRepositoryRequest(),
+    )
+
+    expect(response.status).toBe(200)
+    expect(await response.json()).toEqual({
+      data: {
+        addRepository: {
+          id: repository.id,
+          githubOwner: repository.githubOwner,
+          githubRepo: repository.githubRepo,
+        },
+      },
+    })
+    expect(enqueued).toBe(false)
+  })
+
+  test("keeps the added repository when its automatic Refresh Job cannot be queued", async () => {
+    await runtime.dispose()
+    runtime = makeRuntime(
+      {},
+      {},
+      {
+        findSecret: () => Effect.succeed("GITHUB_TOKEN_ACME_WIDGETS"),
+      },
+      {
+        enqueue: () =>
+          Effect.fail(
+            new EnqueueError({
+              queue: "jobs",
+              message: "queue unavailable",
+            }),
+          ),
+      },
+    )
+
+    const response = await createGraphqlApi(runtime).fetch(
+      addRepositoryRequest(),
+    )
+
+    expect(response.status).toBe(200)
+    expect(await response.json()).toEqual({
+      data: {
+        addRepository: {
+          id: repository.id,
+          githubOwner: repository.githubOwner,
+          githubRepo: repository.githubRepo,
+        },
+      },
+    })
+  })
+
   test("streams repository membership changes", async () => {
     await runtime.dispose()
     runtime = makeRuntime({ repositoryChanges: Stream.make(undefined) })


### PR DESCRIPTION
## Why

Adding a credentialed repository through `harness-cli add` persisted the repository but did not reliably show its reconciled issues until the browser was reloaded. During backend HMR, stale workers could continue consuming jobs while publishing invalidations to a PubSub owned by an obsolete Effect layer, and reconnecting the client subscription created another window for dropping the signal.

## What Changed

- enqueue a best-effort Refresh Job immediately after adding a repository when its GitHub token already exists
- keep the client issue subscription stable as repository membership changes
- share repository and issue invalidations through process-global Effect PubSubs across layer rebuilds
- retire stale HMR worker generations before they claim more jobs
- poll an idle queue around every 1.5 seconds with Effect schedule jitter
- cover credentialed add, missing credential, enqueue failure, and live refresh behavior

## Verification

- Manually added `processfocus/monorepo` with the browser already open and observed its issues appear without reloading the page.
- The pre-commit affected lint, typecheck, and test suite passed.
