### PR TITLE
refactor(github-service): improve Effect integration

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -123,12 +123,15 @@
       "name": "@ready-for-agent/github-service",
       "version": "0.0.1",
       "dependencies": {
+        "@effect/platform-bun": "^4.0.0-beta.97",
         "effect": "^4.0.0-beta.97",
         "tslib": "^2.3.0",
       },
       "devDependencies": {
+        "@effect/vitest": "^4.0.0-beta.97",
         "@genql/cli": "^6.3.3",
         "@types/bun": "^1.3.0",
+        "vitest": "^4.1.10",
       },
     },
     "packages/graphql-api": {
@@ -542,6 +545,8 @@
     "@effect/tsgo-win32-arm64": ["@effect/tsgo-win32-arm64@0.18.1", "", { "os": "win32", "cpu": "arm64" }, "sha512-hTPY071Vqk9fY34uTyI/FBW/b1eeXxFdMDLE6j+4IkcmNaUuu58ZZE3vmHg1Mabz+cFVs6hWpFAVqekdAgfrxQ=="],
 
     "@effect/tsgo-win32-x64": ["@effect/tsgo-win32-x64@0.18.1", "", { "os": "win32", "cpu": "x64" }, "sha512-5mfPlupGP/cyTkcWR5J2ZdyaxdU6zMHX4oyHy18EjXLdFoJOdjr9C/VNY6iZLbLHkTsQ3xYMFzVt0ruFdI8kNQ=="],
+
+    "@effect/vitest": ["@effect/vitest@4.0.0-beta.97", "", { "peerDependencies": { "effect": "^4.0.0-beta.97", "vitest": "^3.0.0 || ^4.0.0" } }, "sha512-1dH6LBWSZyqnTV7ZO+yIpPGPf/xd7RtFfvQ4ZpTy9elzFN+wr1YBFpHSCr8+BfXOml6b8g9Mtj5eDy1qjbizUA=="],
 
     "@emnapi/core": ["@emnapi/core@1.4.5", "", { "dependencies": { "@emnapi/wasi-threads": "1.0.4", "tslib": "^2.4.0" } }, "sha512-XsLw1dEOpkSX/WucdqUhPWP7hDxSvZiY+fsUC14h+FtQ2Ifni4znbBt8punRX+Uj2JG/uDb8nEHVKvrVlvdZ5Q=="],
 
@@ -995,6 +1000,10 @@
 
     "@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
 
+    "@types/chai": ["@types/chai@5.2.3", "", { "dependencies": { "@types/deep-eql": "*", "assertion-error": "^2.0.1" } }, "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA=="],
+
+    "@types/deep-eql": ["@types/deep-eql@4.0.2", "", {}, "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw=="],
+
     "@types/esquery": ["@types/esquery@1.5.4", "", { "dependencies": { "@types/estree": "*" } }, "sha512-yYO4Q8H+KJHKW1rEeSzHxcZi90durqYgWVfnh5K6ZADVBjBv2e1NEveYX5yT2bffgN7RqzH3k9930m+i2yBoMA=="],
 
     "@types/estree": ["@types/estree@1.0.9", "", {}, "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg=="],
@@ -1055,6 +1064,20 @@
 
     "@vitejs/plugin-react": ["@vitejs/plugin-react@5.2.0", "", { "dependencies": { "@babel/core": "^7.29.0", "@babel/plugin-transform-react-jsx-self": "^7.27.1", "@babel/plugin-transform-react-jsx-source": "^7.27.1", "@rolldown/pluginutils": "1.0.0-rc.3", "@types/babel__core": "^7.20.5", "react-refresh": "^0.18.0" }, "peerDependencies": { "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0" } }, "sha512-YmKkfhOAi3wsB1PhJq5Scj3GXMn3WvtQ/JC0xoopuHoXSdmtdStOpFrYaT1kie2YgFBcIe64ROzMYRjCrYOdYw=="],
 
+    "@vitest/expect": ["@vitest/expect@4.1.10", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "@types/chai": "^5.2.2", "@vitest/spy": "4.1.10", "@vitest/utils": "4.1.10", "chai": "^6.2.2", "tinyrainbow": "^3.1.0" } }, "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA=="],
+
+    "@vitest/mocker": ["@vitest/mocker@4.1.10", "", { "dependencies": { "@vitest/spy": "4.1.10", "estree-walker": "^3.0.3", "magic-string": "^0.30.21" }, "peerDependencies": { "msw": "^2.4.9", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0" }, "optionalPeers": ["msw", "vite"] }, "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow=="],
+
+    "@vitest/pretty-format": ["@vitest/pretty-format@4.1.10", "", { "dependencies": { "tinyrainbow": "^3.1.0" } }, "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q=="],
+
+    "@vitest/runner": ["@vitest/runner@4.1.10", "", { "dependencies": { "@vitest/utils": "4.1.10", "pathe": "^2.0.3" } }, "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg=="],
+
+    "@vitest/snapshot": ["@vitest/snapshot@4.1.10", "", { "dependencies": { "@vitest/pretty-format": "4.1.10", "@vitest/utils": "4.1.10", "magic-string": "^0.30.21", "pathe": "^2.0.3" } }, "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw=="],
+
+    "@vitest/spy": ["@vitest/spy@4.1.10", "", {}, "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw=="],
+
+    "@vitest/utils": ["@vitest/utils@4.1.10", "", { "dependencies": { "@vitest/pretty-format": "4.1.10", "convert-source-map": "^2.0.0", "tinyrainbow": "^3.1.0" } }, "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA=="],
+
     "@whatwg-node/disposablestack": ["@whatwg-node/disposablestack@0.0.6", "", { "dependencies": { "@whatwg-node/promise-helpers": "^1.0.0", "tslib": "^2.6.3" } }, "sha512-LOtTn+JgJvX8WfBVJtF08TGrdjuFzGJc4mkP8EdDI8ADbvO7kiexYep1o8dwnt0okb0jYclCDXF13xU7Ge4zSw=="],
 
     "@whatwg-node/events": ["@whatwg-node/events@0.1.2", "", { "dependencies": { "tslib": "^2.6.3" } }, "sha512-ApcWxkrs1WmEMS2CaLLFUEem/49erT3sxIVjpzU5f6zmVcnijtDSrhoK2zVobOIikZJdH63jdAXOrvjf6eOUNQ=="],
@@ -1094,6 +1117,8 @@
     "argue-cli": ["argue-cli@3.1.0", "", {}, "sha512-DhBpBfXL4SS2uC0N922MMajKR3CdrTG0u2or1PNYgXMsrSzViJrbtvT0nCLlLGUI0plam/ZZCs7aAauHtW9thw=="],
 
     "array-union": ["array-union@2.1.0", "", {}, "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw=="],
+
+    "assertion-error": ["assertion-error@2.0.1", "", {}, "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA=="],
 
     "asynckit": ["asynckit@0.4.0", "", {}, "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="],
 
@@ -1146,6 +1171,8 @@
     "camelcase": ["camelcase@5.3.1", "", {}, "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="],
 
     "caniuse-lite": ["caniuse-lite@1.0.30001803", "", {}, "sha512-g/uHREV2ZpK9qMalCsWaxmA6ol+DX8GYhuf3T40RKoP+oL7vhRJh8LNt73PCjpnR6l14FzfPrB5Yux4PKm2meg=="],
+
+    "chai": ["chai@6.2.2", "", {}, "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg=="],
 
     "chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
@@ -1267,6 +1294,8 @@
 
     "es-errors": ["es-errors@1.3.0", "", {}, "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="],
 
+    "es-module-lexer": ["es-module-lexer@2.3.1", "", {}, "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA=="],
+
     "es-object-atoms": ["es-object-atoms@1.1.1", "", { "dependencies": { "es-errors": "^1.3.0" } }, "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA=="],
 
     "es-set-tostringtag": ["es-set-tostringtag@2.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "get-intrinsic": "^1.2.6", "has-tostringtag": "^1.0.2", "hasown": "^2.0.2" } }, "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA=="],
@@ -1287,6 +1316,8 @@
 
     "estraverse": ["estraverse@5.3.0", "", {}, "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA=="],
 
+    "estree-walker": ["estree-walker@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.0" } }, "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g=="],
+
     "esutils": ["esutils@2.0.3", "", {}, "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="],
 
     "etag": ["etag@1.8.1", "", {}, "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg=="],
@@ -1296,6 +1327,8 @@
     "eventsource": ["eventsource@3.0.7", "", { "dependencies": { "eventsource-parser": "^3.0.1" } }, "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA=="],
 
     "eventsource-parser": ["eventsource-parser@3.1.0", "", {}, "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg=="],
+
+    "expect-type": ["expect-type@1.4.0", "", {}, "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA=="],
 
     "express": ["express@5.2.1", "", { "dependencies": { "accepts": "^2.0.0", "body-parser": "^2.2.1", "content-disposition": "^1.0.0", "content-type": "^1.0.5", "cookie": "^0.7.1", "cookie-signature": "^1.2.1", "debug": "^4.4.0", "depd": "^2.0.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "finalhandler": "^2.1.0", "fresh": "^2.0.0", "http-errors": "^2.0.0", "merge-descriptors": "^2.0.0", "mime-types": "^3.0.0", "on-finished": "^2.4.1", "once": "^1.4.0", "parseurl": "^1.3.3", "proxy-addr": "^2.0.7", "qs": "^6.14.0", "range-parser": "^1.2.1", "router": "^2.2.0", "send": "^1.1.0", "serve-static": "^2.2.0", "statuses": "^2.0.1", "type-is": "^2.0.1", "vary": "^1.1.2" } }, "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw=="],
 
@@ -1573,6 +1606,8 @@
 
     "object-inspect": ["object-inspect@1.13.4", "", {}, "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew=="],
 
+    "obug": ["obug@2.1.3", "", {}, "sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg=="],
+
     "on-finished": ["on-finished@2.4.1", "", { "dependencies": { "ee-first": "1.1.1" } }, "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg=="],
 
     "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
@@ -1727,6 +1762,8 @@
 
     "side-channel-weakmap": ["side-channel-weakmap@1.0.2", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3", "side-channel-map": "^1.0.1" } }, "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A=="],
 
+    "siginfo": ["siginfo@2.0.0", "", {}, "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g=="],
+
     "signal-exit": ["signal-exit@3.0.7", "", {}, "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="],
 
     "slash": ["slash@3.0.0", "", {}, "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q=="],
@@ -1745,7 +1782,11 @@
 
     "srvx": ["srvx@0.11.21", "", { "bin": { "srvx": "bin/srvx.mjs" } }, "sha512-GWTHjKMeekX8CwJf4VU9Oo6mJpSGaflGMddbCvR+Cmmh9sslRMiGbAoqqZacE0r1ncARh6buCEETr2W52F8b1w=="],
 
+    "stackback": ["stackback@0.0.2", "", {}, "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw=="],
+
     "statuses": ["statuses@2.0.2", "", {}, "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="],
+
+    "std-env": ["std-env@4.2.0", "", {}, "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw=="],
 
     "string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
@@ -1769,9 +1810,13 @@
 
     "tar-stream": ["tar-stream@2.2.0", "", { "dependencies": { "bl": "^4.0.3", "end-of-stream": "^1.4.1", "fs-constants": "^1.0.0", "inherits": "^2.0.3", "readable-stream": "^3.1.1" } }, "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ=="],
 
+    "tinybench": ["tinybench@2.9.0", "", {}, "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg=="],
+
     "tinyexec": ["tinyexec@1.2.4", "", {}, "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg=="],
 
     "tinyglobby": ["tinyglobby@0.2.17", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.4" } }, "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g=="],
+
+    "tinyrainbow": ["tinyrainbow@3.1.0", "", {}, "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw=="],
 
     "tmp": ["tmp@0.2.7", "", {}, "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw=="],
 
@@ -1837,6 +1882,8 @@
 
     "vitefu": ["vitefu@1.1.3", "", { "peerDependencies": { "vite": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0" }, "optionalPeers": ["vite"] }, "sha512-ub4okH7Z5KLjb6hDyjqrGXqWtWvoYdU3IGm/NorpgHncKoLTCfRIbvlhBm7r0YstIaQRYlp4yEbFqDcKSzXSSg=="],
 
+    "vitest": ["vitest@4.1.10", "", { "dependencies": { "@vitest/expect": "4.1.10", "@vitest/mocker": "4.1.10", "@vitest/pretty-format": "4.1.10", "@vitest/runner": "4.1.10", "@vitest/snapshot": "4.1.10", "@vitest/spy": "4.1.10", "@vitest/utils": "4.1.10", "es-module-lexer": "^2.0.0", "expect-type": "^1.3.0", "magic-string": "^0.30.21", "obug": "^2.1.1", "pathe": "^2.0.3", "picomatch": "^4.0.3", "std-env": "^4.0.0-rc.1", "tinybench": "^2.9.0", "tinyexec": "^1.0.2", "tinyglobby": "^0.2.15", "tinyrainbow": "^3.1.0", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@opentelemetry/api": "^1.9.0", "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0", "@vitest/browser-playwright": "4.1.10", "@vitest/browser-preview": "4.1.10", "@vitest/browser-webdriverio": "4.1.10", "@vitest/coverage-istanbul": "4.1.10", "@vitest/coverage-v8": "4.1.10", "@vitest/ui": "4.1.10", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@opentelemetry/api", "@types/node", "@vitest/browser-playwright", "@vitest/browser-preview", "@vitest/browser-webdriverio", "@vitest/coverage-istanbul", "@vitest/coverage-v8", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "./vitest.mjs" } }, "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw=="],
+
     "walk-up-path": ["walk-up-path@4.0.0", "", {}, "sha512-3hu+tD8YzSLGuFYtPRb48vdhKMi0KQV5sn+uWr8+7dMEq/2G/dtLrdDinkLjqq5TIbIBjYJ4Ax/n3YiaW7QM8A=="],
 
     "wcwidth": ["wcwidth@1.0.1", "", { "dependencies": { "defaults": "^1.0.3" } }, "sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg=="],
@@ -1846,6 +1893,8 @@
     "which": ["which@3.0.1", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "bin/which.js" } }, "sha512-XA1b62dzQzLfaEOSQFTCOd5KFf/1VSzZo7/7TUjnya6u0vGGKzU96UQBZTAThCb2j4/xjBAyii1OhRLJEivHvg=="],
 
     "which-module": ["which-module@2.0.1", "", {}, "sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ=="],
+
+    "why-is-node-running": ["why-is-node-running@2.3.0", "", { "dependencies": { "siginfo": "^2.0.0", "stackback": "0.0.2" }, "bin": { "why-is-node-running": "cli.js" } }, "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w=="],
 
     "wrap-ansi": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
 

--- a/packages/github-service/package.json
+++ b/packages/github-service/package.json
@@ -19,11 +19,14 @@
     "generate": "genql --schema github.graphql --output ./src/internal/generated"
   },
   "dependencies": {
+    "@effect/platform-bun": "^4.0.0-beta.97",
     "effect": "^4.0.0-beta.97",
     "tslib": "^2.3.0"
   },
   "devDependencies": {
+    "@effect/vitest": "^4.0.0-beta.97",
     "@genql/cli": "^6.3.3",
-    "@types/bun": "^1.3.0"
+    "@types/bun": "^1.3.0",
+    "vitest": "^4.1.10"
   }
 }

--- a/packages/github-service/project.json
+++ b/packages/github-service/project.json
@@ -41,7 +41,7 @@
       "executor": "nx:run-commands",
       "options": {
         "cwd": "{projectRoot}",
-        "command": "bun test"
+        "command": "vitest run"
       },
       "inputs": ["default", "^production"],
       "cache": true,

--- a/packages/github-service/src/bin/cli.ts
+++ b/packages/github-service/src/bin/cli.ts
@@ -1,0 +1,41 @@
+import * as BunRuntime from "@effect/platform-bun/BunRuntime"
+import { Effect, Schema } from "effect"
+import {
+  GitHubRepositoryUnavailableError,
+  type GitHubService,
+  GitHubServiceLive,
+} from "../index.js"
+
+class CliArgumentError extends Schema.TaggedErrorClass<CliArgumentError>()(
+  "CliArgumentError",
+  { message: Schema.String },
+) {}
+
+export const decodeArgument = (
+  value: string | undefined,
+  name: string,
+): Effect.Effect<string, CliArgumentError> =>
+  value === undefined
+    ? Effect.fail(new CliArgumentError({ message: `Missing ${name} argument` }))
+    : Effect.succeed(Buffer.from(value, "base64url").toString("utf8"))
+
+export const writeStandardOutput = (value: string): Effect.Effect<void> =>
+  Effect.sync(() => process.stdout.write(value))
+
+export const runGitHubCli = <A, E>(
+  program: Effect.Effect<A, E, GitHubService>,
+): void =>
+  program.pipe(
+    Effect.provide(GitHubServiceLive),
+    Effect.catch((error) =>
+      Effect.sync(() => {
+        if (error instanceof GitHubRepositoryUnavailableError) {
+          process.exitCode = 2
+          return
+        }
+        console.error(error)
+        process.exitCode = 1
+      }),
+    ),
+    BunRuntime.runMain,
+  )

--- a/packages/github-service/src/bin/get-open-pr-number.ts
+++ b/packages/github-service/src/bin/get-open-pr-number.ts
@@ -1,32 +1,17 @@
 import { Effect } from "effect"
-import { GitHubService, GitHubServiceLive } from "../index.js"
-
-const decodeArgument = (value: string | undefined): string => {
-  if (value === undefined) throw new Error("Missing encoded argument")
-  return Buffer.from(value, "base64url").toString("utf8")
-}
+import { GitHubService } from "../index.js"
+import { decodeArgument, runGitHubCli, writeStandardOutput } from "./cli.js"
 
 const program = Effect.gen(function* () {
-  const owner = decodeArgument(process.argv[2])
-  const name = decodeArgument(process.argv[3])
-  const headRefName = decodeArgument(process.argv[4])
+  const owner = yield* decodeArgument(process.argv[2], "owner")
+  const name = yield* decodeArgument(process.argv[3], "name")
+  const headRefName = yield* decodeArgument(process.argv[4], "head ref")
   const github = yield* GitHubService
   const number = yield* github.getOpenPullRequestNumber(
     { owner, name },
     headRefName,
   )
-  process.stdout.write(String(number))
-}).pipe(
-  Effect.provide(GitHubServiceLive),
-  Effect.catchTag("GitHubRepositoryUnavailableError", () =>
-    Effect.sync(() => process.exit(2)),
-  ),
-  Effect.catch((error) =>
-    Effect.sync(() => {
-      console.error(error)
-      process.exit(1)
-    }),
-  ),
-)
+  yield* writeStandardOutput(String(number))
+})
 
-Effect.runPromise(program)
+if (import.meta.main) runGitHubCli(program)

--- a/packages/github-service/src/bin/get-pr-check-status.ts
+++ b/packages/github-service/src/bin/get-pr-check-status.ts
@@ -1,32 +1,17 @@
 import { Effect } from "effect"
-import { GitHubService, GitHubServiceLive } from "../index.js"
-
-const decodeArgument = (value: string | undefined): string => {
-  if (value === undefined) throw new Error("Missing encoded argument")
-  return Buffer.from(value, "base64url").toString("utf8")
-}
+import { GitHubService } from "../index.js"
+import { decodeArgument, runGitHubCli, writeStandardOutput } from "./cli.js"
 
 const program = Effect.gen(function* () {
-  const owner = decodeArgument(process.argv[2])
-  const name = decodeArgument(process.argv[3])
-  const headRefName = decodeArgument(process.argv[4])
+  const owner = yield* decodeArgument(process.argv[2], "owner")
+  const name = yield* decodeArgument(process.argv[3], "name")
+  const headRefName = yield* decodeArgument(process.argv[4], "head ref")
   const github = yield* GitHubService
   const status = yield* github.getPullRequestCheckStatus(
     { owner, name },
     headRefName,
   )
-  process.stdout.write(JSON.stringify(status))
-}).pipe(
-  Effect.provide(GitHubServiceLive),
-  Effect.catchTag("GitHubRepositoryUnavailableError", () =>
-    Effect.sync(() => process.exit(2)),
-  ),
-  Effect.catch((error) =>
-    Effect.sync(() => {
-      console.error(error)
-      process.exit(1)
-    }),
-  ),
-)
+  yield* writeStandardOutput(JSON.stringify(status))
+})
 
-Effect.runPromise(program)
+if (import.meta.main) runGitHubCli(program)

--- a/packages/github-service/src/bin/list-ready-issues.ts
+++ b/packages/github-service/src/bin/list-ready-issues.ts
@@ -1,33 +1,15 @@
-import { Effect, Result } from "effect"
-import {
-  GitHubRepositoryUnavailableError,
-  GitHubService,
-  GitHubServiceLive,
-} from "../index.js"
+import { Effect } from "effect"
+import { GitHubService } from "../index.js"
+import { decodeArgument, runGitHubCli, writeStandardOutput } from "./cli.js"
 
-const decodeArgument = (value: string | undefined): string => {
-  if (value === undefined) throw new Error("Missing Repository argument")
-  return Buffer.from(value, "base64url").toString("utf8")
-}
-
-if (import.meta.main) {
+const program = Effect.gen(function* () {
   const repository = {
-    owner: decodeArgument(process.argv[2]),
-    name: decodeArgument(process.argv[3]),
+    owner: yield* decodeArgument(process.argv[2], "owner"),
+    name: yield* decodeArgument(process.argv[3], "name"),
   }
-  const result = await Effect.runPromise(
-    Effect.gen(function* () {
-      const github = yield* GitHubService
-      return yield* github.listReadyIssues(repository)
-    }).pipe(Effect.provide(GitHubServiceLive), Effect.result),
-  )
+  const github = yield* GitHubService
+  const issues = yield* github.listReadyIssues(repository)
+  yield* writeStandardOutput(JSON.stringify(issues))
+})
 
-  if (Result.isSuccess(result)) {
-    process.stdout.write(JSON.stringify(result.success))
-  } else if (result.failure instanceof GitHubRepositoryUnavailableError) {
-    process.exitCode = 2
-  } else {
-    process.stderr.write("GitHub query failed\n")
-    process.exitCode = 1
-  }
-}
+if (import.meta.main) runGitHubCli(program)

--- a/packages/github-service/src/bin/mark-pr-ready-for-review.ts
+++ b/packages/github-service/src/bin/mark-pr-ready-for-review.ts
@@ -1,29 +1,14 @@
 import { Effect } from "effect"
-import { GitHubService, GitHubServiceLive } from "../index.js"
-
-const decodeArgument = (value: string | undefined): string => {
-  if (value === undefined) throw new Error("Missing encoded argument")
-  return Buffer.from(value, "base64url").toString("utf8")
-}
+import { GitHubService } from "../index.js"
+import { decodeArgument, runGitHubCli, writeStandardOutput } from "./cli.js"
 
 const program = Effect.gen(function* () {
-  const owner = decodeArgument(process.argv[2])
-  const name = decodeArgument(process.argv[3])
-  const headRefName = decodeArgument(process.argv[4])
+  const owner = yield* decodeArgument(process.argv[2], "owner")
+  const name = yield* decodeArgument(process.argv[3], "name")
+  const headRefName = yield* decodeArgument(process.argv[4], "head ref")
   const github = yield* GitHubService
   yield* github.markPullRequestReadyForReview({ owner, name }, headRefName)
-  process.stdout.write(JSON.stringify({ _tag: "ready" }))
-}).pipe(
-  Effect.provide(GitHubServiceLive),
-  Effect.catchTag("GitHubRepositoryUnavailableError", () =>
-    Effect.sync(() => process.exit(2)),
-  ),
-  Effect.catch((error) =>
-    Effect.sync(() => {
-      console.error(error)
-      process.exit(1)
-    }),
-  ),
-)
+  yield* writeStandardOutput(JSON.stringify({ _tag: "ready" }))
+})
 
-Effect.runPromise(program)
+if (import.meta.main) runGitHubCli(program)

--- a/packages/github-service/src/bin/merge-pull-request.ts
+++ b/packages/github-service/src/bin/merge-pull-request.ts
@@ -1,29 +1,14 @@
 import { Effect } from "effect"
-import { GitHubService, GitHubServiceLive } from "../index.js"
-
-const decodeArgument = (value: string | undefined): string => {
-  if (value === undefined) throw new Error("Missing encoded argument")
-  return Buffer.from(value, "base64url").toString("utf8")
-}
+import { GitHubService } from "../index.js"
+import { decodeArgument, runGitHubCli, writeStandardOutput } from "./cli.js"
 
 const program = Effect.gen(function* () {
-  const owner = decodeArgument(process.argv[2])
-  const name = decodeArgument(process.argv[3])
-  const headRefName = decodeArgument(process.argv[4])
+  const owner = yield* decodeArgument(process.argv[2], "owner")
+  const name = yield* decodeArgument(process.argv[3], "name")
+  const headRefName = yield* decodeArgument(process.argv[4], "head ref")
   const github = yield* GitHubService
   yield* github.mergePullRequest({ owner, name }, headRefName)
-  process.stdout.write(JSON.stringify({ _tag: "merged" }))
-}).pipe(
-  Effect.provide(GitHubServiceLive),
-  Effect.catchTag("GitHubRepositoryUnavailableError", () =>
-    Effect.sync(() => process.exit(2)),
-  ),
-  Effect.catch((error) =>
-    Effect.sync(() => {
-      console.error(error)
-      process.exit(1)
-    }),
-  ),
-)
+  yield* writeStandardOutput(JSON.stringify({ _tag: "merged" }))
+})
 
-Effect.runPromise(program)
+if (import.meta.main) runGitHubCli(program)

--- a/packages/github-service/src/lib/errors.ts
+++ b/packages/github-service/src/lib/errors.ts
@@ -1,13 +1,17 @@
-import { Data } from "effect"
+import { Schema } from "effect"
 
-export class GitHubRepositoryUnavailableError extends Data.TaggedError(
+export class GitHubRepositoryUnavailableError extends Schema.TaggedErrorClass<GitHubRepositoryUnavailableError>()(
   "GitHubRepositoryUnavailableError",
-)<{
-  readonly owner: string
-  readonly name: string
-}> {}
+  {
+    owner: Schema.String,
+    name: Schema.String,
+  },
+) {}
 
-export class GitHubRequestError extends Data.TaggedError("GitHubRequestError")<{
-  readonly message: string
-  readonly cause?: unknown
-}> {}
+export class GitHubRequestError extends Schema.TaggedErrorClass<GitHubRequestError>()(
+  "GitHubRequestError",
+  {
+    message: Schema.String,
+    cause: Schema.optional(Schema.Defect()),
+  },
+) {}

--- a/packages/github-service/src/lib/github-service-live.ts
+++ b/packages/github-service/src/lib/github-service-live.ts
@@ -1,5 +1,14 @@
 import { Config, Effect, Layer, Redacted } from "effect"
-import { type Client, createClient } from "../internal/generated/index.js"
+import {
+  type FieldsSelection,
+  createClient,
+} from "../internal/generated/index.js"
+import type {
+  Mutation,
+  MutationGenqlSelection,
+  Query,
+  QueryGenqlSelection,
+} from "../internal/generated/schema.js"
 import {
   GitHubRepositoryUnavailableError,
   GitHubRequestError,
@@ -19,9 +28,18 @@ const GITHUB_GRAPHQL_URL = "https://api.github.com/graphql"
 const GITHUB_REST_URL = "https://api.github.com"
 const READY_FOR_AGENT_LABEL = "ready-for-agent"
 const PAGE_SIZE = 100
+const REQUEST_TIMEOUT = "30 seconds"
 
-export type GitHubGraphqlClient = Pick<Client, "query"> &
-  Partial<Pick<Client, "mutation">>
+export interface GitHubGraphqlClient {
+  readonly query: <R extends QueryGenqlSelection>(
+    request: R & { readonly __name?: string },
+    signal?: AbortSignal,
+  ) => Promise<FieldsSelection<Query, R>>
+  readonly mutation?: <R extends MutationGenqlSelection>(
+    request: R & { readonly __name?: string },
+    signal?: AbortSignal,
+  ) => Promise<FieldsSelection<Mutation, R>>
+}
 
 /**
  * Minimal REST client used for individual PR status checks.
@@ -29,8 +47,24 @@ export type GitHubGraphqlClient = Pick<Client, "query"> &
  * Actions jobs + classic commit statuses remain available via REST.
  */
 export interface GitHubRestClient {
-  readonly getJson: (path: string) => Promise<unknown>
+  readonly getJson: (path: string, signal?: AbortSignal) => Promise<unknown>
 }
+
+const githubRequest = <A>(
+  message: string,
+  request: (signal: AbortSignal) => Promise<A>,
+): Effect.Effect<A, GitHubRequestError> =>
+  Effect.tryPromise({
+    try: request,
+    catch: (cause) => new GitHubRequestError({ message, cause }),
+  }).pipe(
+    Effect.timeout(REQUEST_TIMEOUT),
+    Effect.catchTag("TimeoutError", (cause) =>
+      Effect.fail(
+        new GitHubRequestError({ message: `${message} timed out`, cause }),
+      ),
+    ),
+  )
 
 interface GitHubApiPullRequest {
   readonly state: unknown
@@ -203,14 +237,10 @@ const listTerminalChecksFromRest = (
       const runsPath =
         `/repos/${repository.owner}/${repository.name}/actions/runs` +
         `?head_sha=${encodeURIComponent(headSha)}&per_page=${PAGE_SIZE}&page=${runsPage}`
-      const runsBody = yield* Effect.tryPromise({
-        try: () => rest.getJson(runsPath),
-        catch: (cause) =>
-          new GitHubRequestError({
-            message: `Failed to list Actions runs for ${repository.owner}/${repository.name}@${headSha}`,
-            cause,
-          }),
-      })
+      const runsBody = yield* githubRequest(
+        `Failed to list Actions runs for ${repository.owner}/${repository.name}@${headSha}`,
+        (signal) => rest.getJson(runsPath, signal),
+      )
       const workflowRuns =
         typeof runsBody === "object" &&
         runsBody !== null &&
@@ -232,14 +262,10 @@ const listTerminalChecksFromRest = (
           const jobsPath =
             `/repos/${repository.owner}/${repository.name}/actions/runs/${run.id}/jobs` +
             `?filter=all&per_page=${PAGE_SIZE}&page=${jobsPage}`
-          const jobsBody = yield* Effect.tryPromise({
-            try: () => rest.getJson(jobsPath),
-            catch: (cause) =>
-              new GitHubRequestError({
-                message: `Failed to list Actions jobs for run ${run.id} on ${repository.owner}/${repository.name}`,
-                cause,
-              }),
-          })
+          const jobsBody = yield* githubRequest(
+            `Failed to list Actions jobs for run ${run.id} on ${repository.owner}/${repository.name}`,
+            (signal) => rest.getJson(jobsPath, signal),
+          )
           const jobs =
             typeof jobsBody === "object" &&
             jobsBody !== null &&
@@ -280,14 +306,10 @@ const listTerminalChecksFromRest = (
       const statusesPath =
         `/repos/${repository.owner}/${repository.name}/commits/${encodeURIComponent(headSha)}/statuses` +
         `?per_page=${PAGE_SIZE}&page=${statusesPage}`
-      const statusesBody = yield* Effect.tryPromise({
-        try: () => rest.getJson(statusesPath),
-        catch: (cause) =>
-          new GitHubRequestError({
-            message: `Failed to list commit statuses for ${repository.owner}/${repository.name}@${headSha}`,
-            cause,
-          }),
-      })
+      const statusesBody = yield* githubRequest(
+        `Failed to list commit statuses for ${repository.owner}/${repository.name}@${headSha}`,
+        (signal) => rest.getJson(statusesPath, signal),
+      )
       const statuses = Array.isArray(statusesBody) ? statusesBody : []
       for (const status of statuses) {
         if (typeof status !== "object" || status === null) {
@@ -315,8 +337,9 @@ const listTerminalChecksFromRest = (
   })
 
 const makeGitHubRestClient = (token: string): GitHubRestClient => ({
-  getJson: async (path) => {
+  getJson: async (path, signal) => {
     const response = await fetch(`${GITHUB_REST_URL}${path}`, {
+      signal,
       headers: {
         Accept: "application/vnd.github+json",
         Authorization: `Bearer ${token}`,
@@ -624,11 +647,14 @@ export const makeGitHubService = (
   client: GitHubGraphqlClient,
   rest?: GitHubRestClient,
 ): GitHubServiceShape => ({
-  getPullRequestCheckStatus: (repository, headRefName) =>
-    Effect.gen(function* () {
-      const result = yield* Effect.tryPromise({
-        try: () =>
-          client.query({
+  getPullRequestCheckStatus: Effect.fn(
+    "GitHubService.getPullRequestCheckStatus",
+  )(function* (repository, headRefName) {
+    const result = yield* githubRequest(
+      `Failed to get pull request checks for ${repository.owner}/${repository.name}:${headRefName}`,
+      (signal) =>
+        client.query(
+          {
             repository: {
               __args: repository,
               pullRequests: {
@@ -650,73 +676,69 @@ export const makeGitHubService = (
                 },
               },
             },
-          }),
-        catch: (cause) =>
-          new GitHubRequestError({
-            message: `Failed to get pull request checks for ${repository.owner}/${repository.name}:${headRefName}`,
-            cause,
-          }),
-      })
-      if (result.repository === null) {
-        return yield* new GitHubRepositoryUnavailableError(repository)
+          },
+          signal,
+        ),
+    )
+    if (result.repository === null) {
+      return yield* new GitHubRepositoryUnavailableError(repository)
+    }
+    const pullRequest = (result.repository.pullRequests.nodes?.[0] ??
+      null) as GitHubApiPullRequest | null
+    if (pullRequest === null) {
+      return {
+        _tag: "pending",
+        terminalChecks: emptyTerminalChecks,
+        mergeability: "unknown",
+        baseRefName: null,
       }
-      const pullRequest = (result.repository.pullRequests.nodes?.[0] ??
-        null) as GitHubApiPullRequest | null
-      if (pullRequest === null) {
-        return {
-          _tag: "pending",
-          terminalChecks: emptyTerminalChecks,
-          mergeability: "unknown",
-          baseRefName: null,
-        }
-      }
+    }
 
-      let terminalChecks: readonly TerminalPrStatusCheck[] = emptyTerminalChecks
-      if (
-        rest !== undefined &&
-        pullRequest.state === "OPEN" &&
-        typeof pullRequest.headRefOid === "string" &&
-        pullRequest.headRefOid.trim() !== ""
-      ) {
-        terminalChecks = yield* listTerminalChecksFromRest(
-          rest,
-          repository,
-          pullRequest.headRefOid,
-        )
-      }
+    let terminalChecks: readonly TerminalPrStatusCheck[] = emptyTerminalChecks
+    if (
+      rest !== undefined &&
+      pullRequest.state === "OPEN" &&
+      typeof pullRequest.headRefOid === "string" &&
+      pullRequest.headRefOid.trim() !== ""
+    ) {
+      terminalChecks = yield* listTerminalChecksFromRest(
+        rest,
+        repository,
+        pullRequest.headRefOid,
+      )
+    }
 
-      return yield* Effect.try({
-        try: () => toPullRequestCheckStatus(pullRequest, terminalChecks),
-        catch: (cause) =>
-          new GitHubRequestError({
-            message: `GitHub returned invalid pull request checks for ${repository.owner}/${repository.name}:${headRefName}`,
-            cause,
-          }),
-      })
-    }),
-  getOpenPullRequestNumber: (repository, headRefName) =>
-    Effect.gen(function* () {
-      const result = yield* Effect.tryPromise({
-        try: () =>
-          client.query({
-            repository: {
-              __args: repository,
-              pullRequests: {
-                __args: {
-                  first: 1,
-                  states: ["OPEN"],
-                  headRefName,
+    return yield* Effect.try({
+      try: () => toPullRequestCheckStatus(pullRequest, terminalChecks),
+      catch: (cause) =>
+        new GitHubRequestError({
+          message: `GitHub returned invalid pull request checks for ${repository.owner}/${repository.name}:${headRefName}`,
+          cause,
+        }),
+    })
+  }),
+  getOpenPullRequestNumber: Effect.fn("GitHubService.getOpenPullRequestNumber")(
+    function* (repository, headRefName) {
+      const result = yield* githubRequest(
+        `Failed to find open pull request for ${repository.owner}/${repository.name}:${headRefName}`,
+        (signal) =>
+          client.query(
+            {
+              repository: {
+                __args: repository,
+                pullRequests: {
+                  __args: {
+                    first: 1,
+                    states: ["OPEN"],
+                    headRefName,
+                  },
+                  nodes: { number: true },
                 },
-                nodes: { number: true },
               },
             },
-          }),
-        catch: (cause) =>
-          new GitHubRequestError({
-            message: `Failed to find open pull request for ${repository.owner}/${repository.name}:${headRefName}`,
-            cause,
-          }),
-      })
+            signal,
+          ),
+      )
       if (result.repository === null) {
         return yield* new GitHubRepositoryUnavailableError(repository)
       }
@@ -727,12 +749,16 @@ export const makeGitHubService = (
         })
       }
       return Number(number)
-    }),
-  markPullRequestReadyForReview: (repository, headRefName) =>
-    Effect.gen(function* () {
-      const result = yield* Effect.tryPromise({
-        try: () =>
-          client.query({
+    },
+  ),
+  markPullRequestReadyForReview: Effect.fn(
+    "GitHubService.markPullRequestReadyForReview",
+  )(function* (repository, headRefName) {
+    const result = yield* githubRequest(
+      `Failed to find pull request for ${repository.owner}/${repository.name}:${headRefName}`,
+      (signal) =>
+        client.query(
+          {
             repository: {
               __args: repository,
               pullRequests: {
@@ -747,59 +773,58 @@ export const makeGitHubService = (
                 },
               },
             },
-          }),
-        catch: (cause) =>
-          new GitHubRequestError({
-            message: `Failed to find pull request for ${repository.owner}/${repository.name}:${headRefName}`,
-            cause,
-          }),
+          },
+          signal,
+        ),
+    )
+    if (result.repository === null) {
+      return yield* new GitHubRepositoryUnavailableError(repository)
+    }
+    const pullRequest = result.repository.pullRequests.nodes?.[0]
+    if (pullRequest === null || pullRequest === undefined) {
+      return yield* new GitHubRequestError({
+        message: `No pull request found for ${repository.owner}/${repository.name}:${headRefName}`,
       })
-      if (result.repository === null) {
-        return yield* new GitHubRepositoryUnavailableError(repository)
-      }
-      const pullRequest = result.repository.pullRequests.nodes?.[0]
-      if (pullRequest === null || pullRequest === undefined) {
-        return yield* new GitHubRequestError({
-          message: `No pull request found for ${repository.owner}/${repository.name}:${headRefName}`,
-        })
-      }
-      if (typeof pullRequest.id !== "string" || pullRequest.id.trim() === "") {
-        return yield* new GitHubRequestError({
-          message: `GitHub returned an invalid pull request id for ${repository.owner}/${repository.name}:${headRefName}`,
-        })
-      }
-      if (pullRequest.isDraft !== true && pullRequest.isDraft !== false) {
-        return yield* new GitHubRequestError({
-          message: `GitHub returned an invalid draft flag for ${repository.owner}/${repository.name}:${headRefName}`,
-        })
-      }
-      if (pullRequest.state === "CLOSED") {
-        return yield* new GitHubRequestError({
-          message: `Pull request for ${repository.owner}/${repository.name}:${headRefName} is closed`,
-        })
-      }
-      if (pullRequest.state !== "OPEN" && pullRequest.state !== "MERGED") {
-        return yield* new GitHubRequestError({
-          message: `GitHub returned an invalid pull request state for ${repository.owner}/${repository.name}:${headRefName}`,
-        })
-      }
-      if (pullRequest.isDraft === false) {
-        return
-      }
-      if (pullRequest.state === "MERGED") {
-        return yield* new GitHubRequestError({
-          message: `GitHub returned a merged draft pull request for ${repository.owner}/${repository.name}:${headRefName}`,
-        })
-      }
-      if (client.mutation === undefined) {
-        return yield* new GitHubRequestError({
-          message: `GitHub GraphQL client does not support mutations for ${repository.owner}/${repository.name}:${headRefName}`,
-        })
-      }
-      const mutate = client.mutation
-      const mutation = yield* Effect.tryPromise({
-        try: () =>
-          mutate({
+    }
+    if (typeof pullRequest.id !== "string" || pullRequest.id.trim() === "") {
+      return yield* new GitHubRequestError({
+        message: `GitHub returned an invalid pull request id for ${repository.owner}/${repository.name}:${headRefName}`,
+      })
+    }
+    if (pullRequest.isDraft !== true && pullRequest.isDraft !== false) {
+      return yield* new GitHubRequestError({
+        message: `GitHub returned an invalid draft flag for ${repository.owner}/${repository.name}:${headRefName}`,
+      })
+    }
+    if (pullRequest.state === "CLOSED") {
+      return yield* new GitHubRequestError({
+        message: `Pull request for ${repository.owner}/${repository.name}:${headRefName} is closed`,
+      })
+    }
+    if (pullRequest.state !== "OPEN" && pullRequest.state !== "MERGED") {
+      return yield* new GitHubRequestError({
+        message: `GitHub returned an invalid pull request state for ${repository.owner}/${repository.name}:${headRefName}`,
+      })
+    }
+    if (pullRequest.isDraft === false) {
+      return
+    }
+    if (pullRequest.state === "MERGED") {
+      return yield* new GitHubRequestError({
+        message: `GitHub returned a merged draft pull request for ${repository.owner}/${repository.name}:${headRefName}`,
+      })
+    }
+    if (client.mutation === undefined) {
+      return yield* new GitHubRequestError({
+        message: `GitHub GraphQL client does not support mutations for ${repository.owner}/${repository.name}:${headRefName}`,
+      })
+    }
+    const mutate = client.mutation
+    const mutation = yield* githubRequest(
+      `Failed to mark pull request ready for review for ${repository.owner}/${repository.name}:${headRefName}`,
+      (signal) =>
+        mutate(
+          {
             markPullRequestReadyForReview: {
               __args: {
                 input: { pullRequestId: pullRequest.id },
@@ -808,56 +833,51 @@ export const makeGitHubService = (
                 isDraft: true,
               },
             },
-          }),
-        catch: (cause) =>
-          new GitHubRequestError({
-            message: `Failed to mark pull request ready for review for ${repository.owner}/${repository.name}:${headRefName}`,
-            cause,
-          }),
+          },
+          signal,
+        ),
+    )
+    const readyPullRequest = mutation.markPullRequestReadyForReview?.pullRequest
+    if (readyPullRequest === null || readyPullRequest === undefined) {
+      return yield* new GitHubRequestError({
+        message: `GitHub did not return a pull request after marking ready for review for ${repository.owner}/${repository.name}:${headRefName}`,
       })
-      const readyPullRequest =
-        mutation.markPullRequestReadyForReview?.pullRequest
-      if (readyPullRequest === null || readyPullRequest === undefined) {
-        return yield* new GitHubRequestError({
-          message: `GitHub did not return a pull request after marking ready for review for ${repository.owner}/${repository.name}:${headRefName}`,
-        })
-      }
-      if (readyPullRequest.isDraft !== false) {
-        return yield* new GitHubRequestError({
-          message: `Pull request for ${repository.owner}/${repository.name}:${headRefName} is still a draft`,
-        })
-      }
-    }),
-  mergePullRequest: (repository, headRefName) =>
-    Effect.gen(function* () {
-      const result = yield* Effect.tryPromise({
-        try: () =>
-          client.query({
-            repository: {
-              __args: repository,
-              pullRequests: {
-                __args: {
-                  first: 1,
-                  headRefName,
-                },
-                nodes: {
-                  id: true,
-                  state: true,
-                  merged: true,
-                  headRefOid: true,
-                  statusCheckRollup: {
+    }
+    if (readyPullRequest.isDraft !== false) {
+      return yield* new GitHubRequestError({
+        message: `Pull request for ${repository.owner}/${repository.name}:${headRefName} is still a draft`,
+      })
+    }
+  }),
+  mergePullRequest: Effect.fn("GitHubService.mergePullRequest")(
+    function* (repository, headRefName) {
+      const result = yield* githubRequest(
+        `Failed to find pull request for ${repository.owner}/${repository.name}:${headRefName}`,
+        (signal) =>
+          client.query(
+            {
+              repository: {
+                __args: repository,
+                pullRequests: {
+                  __args: {
+                    first: 1,
+                    headRefName,
+                  },
+                  nodes: {
+                    id: true,
                     state: true,
+                    merged: true,
+                    headRefOid: true,
+                    statusCheckRollup: {
+                      state: true,
+                    },
                   },
                 },
               },
             },
-          }),
-        catch: (cause) =>
-          new GitHubRequestError({
-            message: `Failed to find pull request for ${repository.owner}/${repository.name}:${headRefName}`,
-            cause,
-          }),
-      })
+            signal,
+          ),
+      )
       if (result.repository === null) {
         return yield* new GitHubRepositoryUnavailableError(repository)
       }
@@ -907,29 +927,28 @@ export const makeGitHubService = (
         })
       }
       const mutate = client.mutation
-      const mutation = yield* Effect.tryPromise({
-        try: () =>
-          mutate({
-            mergePullRequest: {
-              __args: {
-                input: {
-                  pullRequestId: pullRequest.id,
-                  expectedHeadOid: pullRequest.headRefOid,
-                  mergeMethod: "SQUASH",
+      const mutation = yield* githubRequest(
+        `Failed to merge pull request for ${repository.owner}/${repository.name}:${headRefName}`,
+        (signal) =>
+          mutate(
+            {
+              mergePullRequest: {
+                __args: {
+                  input: {
+                    pullRequestId: pullRequest.id,
+                    expectedHeadOid: pullRequest.headRefOid,
+                    mergeMethod: "SQUASH",
+                  },
+                },
+                pullRequest: {
+                  merged: true,
+                  state: true,
                 },
               },
-              pullRequest: {
-                merged: true,
-                state: true,
-              },
             },
-          }),
-        catch: (cause) =>
-          new GitHubRequestError({
-            message: `Failed to merge pull request for ${repository.owner}/${repository.name}:${headRefName}`,
-            cause,
-          }),
-      })
+            signal,
+          ),
+      )
       const mergedPullRequest = mutation.mergePullRequest?.pullRequest
       if (mergedPullRequest === null || mergedPullRequest === undefined) {
         return yield* new GitHubRequestError({
@@ -944,87 +963,87 @@ export const makeGitHubService = (
           message: `Pull request for ${repository.owner}/${repository.name}:${headRefName} was not merged`,
         })
       }
-    }),
-  listReadyIssues: (repository) =>
-    Effect.gen(function* () {
+    },
+  ),
+  listReadyIssues: Effect.fn("GitHubService.listReadyIssues")(
+    function* (repository) {
       const issues: InternalReadyLabeledIssue[] = []
       const subIssuePositions = new Map<string, number>()
       const repositoryName = `${repository.owner}/${repository.name}`
       let after: string | null = null
 
       while (true) {
-        const result = yield* Effect.tryPromise({
-          try: () =>
-            client.query({
-              repository: {
-                __args: repository,
-                issues: {
-                  __args: {
-                    first: PAGE_SIZE,
-                    after,
-                    labels: [READY_FOR_AGENT_LABEL],
-                  },
-                  nodes: {
-                    number: true,
-                    title: true,
-                    body: true,
-                    url: true,
-                    createdAt: true,
-                    state: true,
-                    parent: {
+        const result = yield* githubRequest(
+          `Failed to list Ready-labeled Issues for ${repository.owner}/${repository.name}`,
+          (signal) =>
+            client.query(
+              {
+                repository: {
+                  __args: repository,
+                  issues: {
+                    __args: {
+                      first: PAGE_SIZE,
+                      after,
+                      labels: [READY_FOR_AGENT_LABEL],
+                    },
+                    nodes: {
                       number: true,
+                      title: true,
+                      body: true,
                       url: true,
+                      createdAt: true,
                       state: true,
-                      repository: { nameWithOwner: true },
                       parent: {
                         number: true,
                         url: true,
-                        repository: { nameWithOwner: true },
-                      },
-                    },
-                    subIssuesSummary: { total: true },
-                    subIssues: {
-                      __args: { first: PAGE_SIZE },
-                      nodes: {
-                        number: true,
-                        url: true,
-                        repository: { nameWithOwner: true },
-                        subIssuesSummary: { total: true },
-                      },
-                      pageInfo: { endCursor: true, hasNextPage: true },
-                    },
-                    blockedBy: {
-                      __args: { first: PAGE_SIZE },
-                      nodes: { number: true, url: true, state: true },
-                      pageInfo: { endCursor: true, hasNextPage: true },
-                    },
-                    closedByPullRequestsReferences: {
-                      __args: {
-                        first: PAGE_SIZE,
-                        includeClosedPrs: true,
-                      },
-                      nodes: {
-                        number: true,
                         state: true,
-                        merged: true,
                         repository: { nameWithOwner: true },
+                        parent: {
+                          number: true,
+                          url: true,
+                          repository: { nameWithOwner: true },
+                        },
                       },
-                      pageInfo: { endCursor: true, hasNextPage: true },
+                      subIssuesSummary: { total: true },
+                      subIssues: {
+                        __args: { first: PAGE_SIZE },
+                        nodes: {
+                          number: true,
+                          url: true,
+                          repository: { nameWithOwner: true },
+                          subIssuesSummary: { total: true },
+                        },
+                        pageInfo: { endCursor: true, hasNextPage: true },
+                      },
+                      blockedBy: {
+                        __args: { first: PAGE_SIZE },
+                        nodes: { number: true, url: true, state: true },
+                        pageInfo: { endCursor: true, hasNextPage: true },
+                      },
+                      closedByPullRequestsReferences: {
+                        __args: {
+                          first: PAGE_SIZE,
+                          includeClosedPrs: true,
+                        },
+                        nodes: {
+                          number: true,
+                          state: true,
+                          merged: true,
+                          repository: { nameWithOwner: true },
+                        },
+                        pageInfo: { endCursor: true, hasNextPage: true },
+                      },
                     },
-                  },
-                  pageInfo: {
-                    endCursor: true,
-                    hasNextPage: true,
+                    pageInfo: {
+                      endCursor: true,
+                      hasNextPage: true,
+                    },
                   },
                 },
               },
-            }),
-          catch: (cause) =>
-            new GitHubRequestError({
-              message: `Failed to list Ready-labeled Issues for ${repository.owner}/${repository.name}`,
-              cause,
-            }),
-        })
+              signal,
+            ),
+        )
 
         if (result.repository === null) {
           return yield* new GitHubRepositoryUnavailableError(repository)
@@ -1074,30 +1093,29 @@ export const makeGitHubService = (
               })
             }
 
-            const dependencyResult = yield* Effect.tryPromise({
-              try: () =>
-                client.query({
-                  repository: {
-                    __args: repository,
-                    issue: {
-                      __args: { number: mappedIssue.number },
-                      blockedBy: {
-                        __args: {
-                          first: PAGE_SIZE,
-                          after: blockedByPage.endCursor,
+            const dependencyResult = yield* githubRequest(
+              `Failed to list dependencies for ${repository.owner}/${repository.name}#${mappedIssue.number}`,
+              (signal) =>
+                client.query(
+                  {
+                    repository: {
+                      __args: repository,
+                      issue: {
+                        __args: { number: mappedIssue.number },
+                        blockedBy: {
+                          __args: {
+                            first: PAGE_SIZE,
+                            after: blockedByPage.endCursor,
+                          },
+                          nodes: { number: true, url: true, state: true },
+                          pageInfo: { endCursor: true, hasNextPage: true },
                         },
-                        nodes: { number: true, url: true, state: true },
-                        pageInfo: { endCursor: true, hasNextPage: true },
                       },
                     },
                   },
-                }),
-              catch: (cause) =>
-                new GitHubRequestError({
-                  message: `Failed to list dependencies for ${repository.owner}/${repository.name}#${mappedIssue.number}`,
-                  cause,
-                }),
-            })
+                  signal,
+                ),
+            )
             if (dependencyResult.repository === null) {
               return yield* new GitHubRepositoryUnavailableError(repository)
             }
@@ -1128,36 +1146,35 @@ export const makeGitHubService = (
               })
             }
 
-            const pullRequestResult = yield* Effect.tryPromise({
-              try: () =>
-                client.query({
-                  repository: {
-                    __args: repository,
-                    issue: {
-                      __args: { number: mappedIssue.number },
-                      closedByPullRequestsReferences: {
-                        __args: {
-                          first: PAGE_SIZE,
-                          after: closingPullRequestsPage.endCursor,
-                          includeClosedPrs: true,
+            const pullRequestResult = yield* githubRequest(
+              `Failed to list closing pull requests for ${repositoryName}#${mappedIssue.number}`,
+              (signal) =>
+                client.query(
+                  {
+                    repository: {
+                      __args: repository,
+                      issue: {
+                        __args: { number: mappedIssue.number },
+                        closedByPullRequestsReferences: {
+                          __args: {
+                            first: PAGE_SIZE,
+                            after: closingPullRequestsPage.endCursor,
+                            includeClosedPrs: true,
+                          },
+                          nodes: {
+                            number: true,
+                            state: true,
+                            merged: true,
+                            repository: { nameWithOwner: true },
+                          },
+                          pageInfo: { endCursor: true, hasNextPage: true },
                         },
-                        nodes: {
-                          number: true,
-                          state: true,
-                          merged: true,
-                          repository: { nameWithOwner: true },
-                        },
-                        pageInfo: { endCursor: true, hasNextPage: true },
                       },
                     },
                   },
-                }),
-              catch: (cause) =>
-                new GitHubRequestError({
-                  message: `Failed to list closing pull requests for ${repositoryName}#${mappedIssue.number}`,
-                  cause,
-                }),
-            })
+                  signal,
+                ),
+            )
             if (pullRequestResult.repository === null) {
               return yield* new GitHubRepositoryUnavailableError(repository)
             }
@@ -1189,35 +1206,34 @@ export const makeGitHubService = (
               })
             }
 
-            const subIssueResult = yield* Effect.tryPromise({
-              try: () =>
-                client.query({
-                  repository: {
-                    __args: repository,
-                    issue: {
-                      __args: { number: mappedIssue.number },
-                      subIssues: {
-                        __args: {
-                          first: PAGE_SIZE,
-                          after: subIssuesPage.endCursor,
+            const subIssueResult = yield* githubRequest(
+              `Failed to list sub-issues for ${repositoryName}#${mappedIssue.number}`,
+              (signal) =>
+                client.query(
+                  {
+                    repository: {
+                      __args: repository,
+                      issue: {
+                        __args: { number: mappedIssue.number },
+                        subIssues: {
+                          __args: {
+                            first: PAGE_SIZE,
+                            after: subIssuesPage.endCursor,
+                          },
+                          nodes: {
+                            number: true,
+                            url: true,
+                            repository: { nameWithOwner: true },
+                            subIssuesSummary: { total: true },
+                          },
+                          pageInfo: { endCursor: true, hasNextPage: true },
                         },
-                        nodes: {
-                          number: true,
-                          url: true,
-                          repository: { nameWithOwner: true },
-                          subIssuesSummary: { total: true },
-                        },
-                        pageInfo: { endCursor: true, hasNextPage: true },
                       },
                     },
                   },
-                }),
-              catch: (cause) =>
-                new GitHubRequestError({
-                  message: `Failed to list sub-issues for ${repositoryName}#${mappedIssue.number}`,
-                  cause,
-                }),
-            })
+                  signal,
+                ),
+            )
             if (subIssueResult.repository === null) {
               return yield* new GitHubRepositoryUnavailableError(repository)
             }
@@ -1349,8 +1365,25 @@ export const makeGitHubService = (
           }
         })
         .sort((left, right) => left.number - right.number)
-    }),
+    },
+  ),
 })
+
+const makeGitHubGraphqlClient = (token: string): GitHubGraphqlClient => {
+  const client = (signal?: AbortSignal) =>
+    createClient({
+      url: GITHUB_GRAPHQL_URL,
+      signal,
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+    })
+
+  return {
+    query: (request, signal) => client(signal).query(request),
+    mutation: (request, signal) => client(signal).mutation(request),
+  }
+}
 
 export const GitHubServiceLive = Layer.effect(
   GitHubService,
@@ -1358,12 +1391,7 @@ export const GitHubServiceLive = Layer.effect(
     Effect.map((token) => {
       const value = Redacted.value(token)
       return makeGitHubService(
-        createClient({
-          url: GITHUB_GRAPHQL_URL,
-          headers: {
-            Authorization: `Bearer ${value}`,
-          },
-        }),
+        makeGitHubGraphqlClient(value),
         makeGitHubRestClient(value),
       )
     }),

--- a/packages/github-service/test/github-service.spec.ts
+++ b/packages/github-service/test/github-service.spec.ts
@@ -1,4 +1,8 @@
-import { Effect, Result } from "effect"
+import { spawnSync } from "node:child_process"
+import { describe, expect, it } from "@effect/vitest"
+import { Effect, Fiber, Result } from "effect"
+import { TestClock } from "effect/testing"
+import { decodeArgument } from "../src/bin/cli.js"
 import {
   GitHubRepositoryUnavailableError,
   GitHubRequestError,
@@ -10,7 +14,6 @@ import {
   type GitHubGraphqlClient,
   makeGitHubService,
 } from "../src/lib/github-service-live.js"
-import { describe, expect, it } from "bun:test"
 
 const repository = { owner: "acme", name: "widgets" }
 
@@ -33,6 +36,52 @@ const issue = (
 })
 
 describe("GitHubService live implementation", () => {
+  it.effect("aborts an in-flight request when interrupted", () =>
+    Effect.gen(function* () {
+      let requestSignal: AbortSignal | undefined
+      const service = makeGitHubService({
+        query: (_request, signal) => {
+          requestSignal = signal
+          return new Promise(() => undefined)
+        },
+      })
+
+      const fiber = yield* service
+        .getOpenPullRequestNumber(repository, "branch")
+        .pipe(Effect.forkChild)
+      yield* Effect.yieldNow
+      yield* Fiber.interrupt(fiber)
+
+      expect(requestSignal?.aborted).toBe(true)
+    }),
+  )
+
+  it.effect("aborts and maps a request timeout to GitHubRequestError", () =>
+    Effect.gen(function* () {
+      let requestSignal: AbortSignal | undefined
+      const service = makeGitHubService({
+        query: (_request, signal) => {
+          requestSignal = signal
+          return new Promise(() => undefined)
+        },
+      })
+
+      const fiber = yield* service
+        .getOpenPullRequestNumber(repository, "branch")
+        .pipe(Effect.result, Effect.forkChild)
+      yield* Effect.yieldNow
+      yield* TestClock.adjust("30 seconds")
+      const result = yield* Fiber.join(fiber)
+
+      expect(requestSignal?.aborted).toBe(true)
+      expect(Result.isFailure(result)).toBe(true)
+      if (Result.isFailure(result)) {
+        expect(result.failure).toBeInstanceOf(GitHubRequestError)
+        expect(result.failure.message).toContain("timed out")
+      }
+    }),
+  )
+
   it("resolves the open pull request number for a branch", async () => {
     let request: unknown
     const service = makeGitHubService({
@@ -1385,6 +1434,35 @@ describe("GitHubService live implementation", () => {
       expect(result.failure).toBeInstanceOf(GitHubRequestError)
       expect(result.failure.message).toContain("omitted the next page cursor")
     }
+  })
+})
+
+describe("CLI arguments", () => {
+  it.effect("reports a missing argument as a typed failure", () =>
+    Effect.gen(function* () {
+      const error = yield* decodeArgument(undefined, "owner").pipe(Effect.flip)
+      expect(error._tag).toBe("CliArgumentError")
+      expect(error.message).toBe("Missing owner argument")
+    }),
+  )
+
+  it("exits with status 1 for a missing argument", () => {
+    const result = spawnSync(
+      "bun",
+      [
+        "--conditions",
+        "@ready-for-agent/source",
+        "src/bin/get-open-pr-number.ts",
+      ],
+      {
+        cwd: new URL("../", import.meta.url),
+        encoding: "utf8",
+        env: { ...process.env, GITHUB_TOKEN: "test-token" },
+      },
+    )
+
+    expect(result.status).toBe(1)
+    expect(result.stderr).toContain("Missing owner argument")
   })
 })
 

--- a/packages/github-service/vitest.config.ts
+++ b/packages/github-service/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config"
+
+export default defineConfig({
+  test: {
+    include: ["test/**/*.spec.ts"],
+  },
+})


### PR DESCRIPTION
## Summary
- make GitHub requests interruptible and bounded with typed timeout failures
- run CLI entry points through the Bun Effect runtime with typed argument handling
- add named service spans, schema-backed errors, and Effect-native tests

## Testing
- `bunx nx affected -t lint,typecheck,test --base=origin/main --head=HEAD --batch`
- `bunx nx run work-item-lifecycle:test` (rerun after Nx identified one timing-sensitive test as flaky)