### PR TITLE
fix(db): enable foreign keys pragma on startup

### DIFF
--- a/packages/db/src/lib/database-test.ts
+++ b/packages/db/src/lib/database-test.ts
@@ -1,6 +1,6 @@
 import { SqliteClient } from "@effect/sql-sqlite-bun"
 import { type Config, Effect, Layer } from "effect"
-import type { SqlClient } from "effect/unstable/sql"
+import { SqlClient } from "effect/unstable/sql"
 import type { SqlError } from "effect/unstable/sql/SqlError"
 import {
   type MigrationReadError,
@@ -12,11 +12,19 @@ import {
 export { MigrationsFolderConfig, defaultMigrationsFolder }
 
 /**
- * In-memory SQLite client for tests.
+ * In-memory SQLite client for tests, with foreign keys enabled on startup.
  */
-export const SqliteTest = SqliteClient.layer({
-  filename: ":memory:",
-})
+export const SqliteTest = Layer.provideMerge(
+  Layer.effectDiscard(
+    Effect.gen(function* () {
+      const sql = yield* SqlClient.SqlClient
+      yield* sql`PRAGMA foreign_keys = ON`
+    }),
+  ),
+  SqliteClient.layer({
+    filename: ":memory:",
+  }),
+)
 
 const MigrationLayer = Layer.effectDiscard(
   Effect.gen(function* () {

--- a/packages/db/test/foreign-keys.spec.ts
+++ b/packages/db/test/foreign-keys.spec.ts
@@ -1,0 +1,24 @@
+import { Effect } from "effect"
+import { SqlClient } from "effect/unstable/sql"
+import { SqliteTest } from "../src/lib/database-test.js"
+import { describe, expect, it } from "bun:test"
+
+describe("SqliteTest foreign keys", () => {
+  it("enables foreign keys on startup", async () => {
+    const result = await Effect.runPromise(
+      Effect.gen(function* () {
+        const sql = yield* SqlClient.SqlClient
+        const pragma = yield* sql`PRAGMA foreign_keys`
+        yield* sql`CREATE TABLE parent (id INTEGER PRIMARY KEY, name TEXT NOT NULL)`
+        yield* sql`CREATE TABLE child (id INTEGER PRIMARY KEY, parent_id INTEGER NOT NULL REFERENCES parent(id))`
+        const insertOrphan = yield* Effect.exit(
+          sql`INSERT INTO child (id, parent_id) VALUES (1, 999)`,
+        )
+        return { pragma, insertOrphan }
+      }).pipe(Effect.provide(SqliteTest)),
+    )
+
+    expect(result.pragma).toEqual([{ foreign_keys: 1 }])
+    expect(result.insertOrphan._tag).toBe("Failure")
+  })
+})

--- a/packages/layer-turso-local/src/lib/client-live.ts
+++ b/packages/layer-turso-local/src/lib/client-live.ts
@@ -57,19 +57,19 @@ const makeClient = (path: string, options?: TursoClientOptions) =>
       Effect.promise(() => db.close()).pipe(Effect.ignore),
     )
 
-    let pragmasExecuted = false
+    yield* Effect.tryPromise({
+      try: async () => {
+        await db.all("PRAGMA foreign_keys = ON")
+        await db.all("PRAGMA journal_mode = wal")
+        const timeout = options?.busy_timeout ?? 1500
+        if (timeout > 0) await db.all(`PRAGMA busy_timeout = ${timeout}`)
+      },
+      catch: (cause) => sqlError(cause, "configure database"),
+    })
+
     const execute = (sql: string, params: ReadonlyArray<unknown> = []) =>
       Effect.tryPromise({
-        try: async () => {
-          if (!pragmasExecuted) {
-            await db.all("PRAGMA foreign_keys = ON")
-            await db.all("PRAGMA journal_mode = wal")
-            const timeout = options?.busy_timeout ?? 1500
-            if (timeout > 0) await db.all(`PRAGMA busy_timeout = ${timeout}`)
-            pragmasExecuted = true
-          }
-          return (await db.all(sql, [...params])) as TursoRow[]
-        },
+        try: async () => (await db.all(sql, [...params])) as TursoRow[],
         catch: (cause) => sqlError(cause, "execute statement"),
       })
 

--- a/packages/layer-turso-local/test/concurrent-transaction.spec.ts
+++ b/packages/layer-turso-local/test/concurrent-transaction.spec.ts
@@ -130,6 +130,42 @@ describe("makeTursoLive", () => {
     }
   })
 
+  it("enables foreign keys on startup", async () => {
+    const dbPath = tempDbPath()
+    const TestLayer = makeTestLayer(dbPath)
+
+    try {
+      const result = await Effect.runPromise(
+        Effect.gen(function* () {
+          const sql = yield* SqlClient.SqlClient
+          const pragma = yield* sql(sqlQuery("PRAGMA foreign_keys"))
+          yield* sql(
+            sqlQuery(
+              "CREATE TABLE parent (id INTEGER PRIMARY KEY, name TEXT NOT NULL)",
+            ),
+          )
+          yield* sql(
+            sqlQuery(
+              "CREATE TABLE child (id INTEGER PRIMARY KEY, parent_id INTEGER NOT NULL REFERENCES parent(id))",
+            ),
+          )
+          const insertOrphan = yield* Effect.exit(
+            sql.unsafe(
+              "INSERT INTO child (id, parent_id) VALUES (?, ?)",
+              [1, 999],
+            ),
+          )
+          return { pragma, insertOrphan }
+        }).pipe(Effect.provide(TestLayer)),
+      )
+
+      expect(result.pragma).toEqual([{ foreign_keys: 1 }])
+      expect(result.insertOrphan._tag).toBe("Failure")
+    } finally {
+      await cleanupDb(dbPath)
+    }
+  })
+
   it("preserves duplicate selected columns in values mode", async () => {
     const dbPath = tempDbPath()
     const TestLayer = makeTestLayer(dbPath)


### PR DESCRIPTION
## Summary
- set `PRAGMA foreign_keys = ON` at Turso connection open (not lazy first query)
- enable foreign keys on `SqliteTest` layer init
- add tests that assert the pragma and that orphan FK inserts fail

## Testing
- `bunx nx run layer-turso-local:test`
- `bunx nx run db:test`
- pre-commit affected lint/typecheck/test

Closes #19