### PR TITLE
fix(harness): keep refresh spinning until update

### DIFF
--- a/apps/harness/e2e/refresh-repository.e2e.ts
+++ b/apps/harness/e2e/refresh-repository.e2e.ts
@@ -119,12 +119,14 @@ test("Refresh returns after enqueueing and updates after worker invalidation", a
   await page.goto("/")
   await expect(page.getByText("Not refreshed yet.")).toBeVisible()
 
-  const refresh = page.getByRole("button", { name: "Refresh issues" })
+  const refresh = page.getByRole("button", { name: /Refresh issues/i })
   await refresh.click()
 
-  // Mutation acceptance ends the pending state while the controlled worker
-  // remains incomplete and the old reconciliation metadata is still shown.
-  await expect(refresh).toBeEnabled()
+  // Spinner stays active after enqueue until the Issues-changed subscription
+  // refetches this Repository (worker still incomplete, old metadata shown).
+  await expect(
+    page.getByRole("button", { name: "Refreshing issues" }),
+  ).toBeDisabled()
   await expect(page.getByText("Not refreshed yet.")).toBeVisible()
 
   workerCompleted = true
@@ -132,4 +134,7 @@ test("Refresh returns after enqueueing and updates after worker invalidation", a
 
   await expect(page.getByText("Asynchronously refreshed Issue")).toBeVisible()
   await expect(page.getByText("Not refreshed yet.")).not.toBeVisible()
+  await expect(
+    page.getByRole("button", { name: "Refresh issues" }),
+  ).toBeEnabled()
 })

--- a/apps/harness/src/refresh-issues-live.ts
+++ b/apps/harness/src/refresh-issues-live.ts
@@ -27,6 +27,7 @@ export type RepositoryIssuesLiveQueries = {
  */
 export const followRepositoryIssuesLive = async ({
   getRepositoryIds,
+  onRepositoryChanged,
   queryClient,
   queries,
   signal,
@@ -35,6 +36,7 @@ export const followRepositoryIssuesLive = async ({
   retryDelayMs = 1_000,
 }: {
   getRepositoryIds: () => readonly string[]
+  onRepositoryChanged?: (repositoryId: string) => void
   queryClient: QueryClient
   queries: RepositoryIssuesLiveQueries
   signal: AbortSignal
@@ -54,6 +56,7 @@ export const followRepositoryIssuesLive = async ({
   }
 
   const refresh = async (repositoryId: string) => {
+    onRepositoryChanged?.(repositoryId)
     await Promise.all([
       fetchFresh(queries.repositories),
       fetchFresh(queries.issues(repositoryId)),

--- a/apps/harness/src/routes/index.tsx
+++ b/apps/harness/src/routes/index.tsx
@@ -255,6 +255,9 @@ function RepositoryCards() {
   const queryClient = useQueryClient()
   const { data: repositories } = useSuspenseQuery(repositoriesQuery)
   const [liveUpdatesUnavailable, setLiveUpdatesUnavailable] = useState(false)
+  const [issuesChangeCounts, setIssuesChangeCounts] = useState<
+    Readonly<Record<string, number>>
+  >({})
   const repositoryIdsRef = useRef(repositories.map(({ id }) => id))
   repositoryIdsRef.current = repositories.map(({ id }) => id)
 
@@ -322,6 +325,12 @@ function RepositoryCards() {
     const controller = new AbortController()
     void followRepositoryIssuesLive({
       getRepositoryIds: () => repositoryIdsRef.current,
+      onRepositoryChanged: (repositoryId) => {
+        setIssuesChangeCounts((counts) => ({
+          ...counts,
+          [repositoryId]: (counts[repositoryId] ?? 0) + 1,
+        }))
+      },
       queryClient,
       queries: {
         repositories: repositoriesQuery,
@@ -367,17 +376,29 @@ function RepositoryCards() {
         aria-label="Configured repositories"
       >
         {repositories.map((repository) => (
-          <RepositoryCard key={repository.id} repository={repository} />
+          <RepositoryCard
+            issuesChangeCount={issuesChangeCounts[repository.id] ?? 0}
+            key={repository.id}
+            repository={repository}
+          />
         ))}
       </section>
     </>
   )
 }
 
-function RepositoryCard({ repository }: { repository: Repository }) {
+function RepositoryCard({
+  issuesChangeCount,
+  repository,
+}: {
+  issuesChangeCount: number
+  repository: Repository
+}) {
   const queryClient = useQueryClient()
   const [githubTokenCreated, setGithubTokenCreated] = useState(false)
   const [menuOpen, setMenuOpen] = useState(false)
+  const [awaitingRefresh, setAwaitingRefresh] = useState(false)
+  const issuesChangeCountOnRefresh = useRef(issuesChangeCount)
   const settingsDialogRef = useRef<HTMLDialogElement>(null)
   const [settingsOpen, setSettingsOpen] = useState(false)
   const config = useQuery({ ...configQuery, enabled: settingsOpen })
@@ -548,7 +569,23 @@ function RepositoryCard({ repository }: { repository: Repository }) {
       })
       return result.refreshRepository
     },
+    onMutate: () => {
+      issuesChangeCountOnRefresh.current = issuesChangeCount
+      setAwaitingRefresh(true)
+    },
+    onError: () => {
+      setAwaitingRefresh(false)
+    },
   })
+
+  useEffect(() => {
+    if (!awaitingRefresh) return
+    if (issuesChangeCount !== issuesChangeCountOnRefresh.current) {
+      setAwaitingRefresh(false)
+    }
+  }, [awaitingRefresh, issuesChangeCount])
+
+  const refreshingIssues = refreshIssues.isPending || awaitingRefresh
 
   const addGitHubToken = useMutation({
     mutationFn: async () => {
@@ -934,12 +971,10 @@ function RepositoryCard({ repository }: { repository: Repository }) {
           <button
             type="button"
             className="inline-flex size-7 items-center justify-center rounded-md border border-slate-200 bg-white text-slate-600 transition hover:border-slate-300 hover:bg-slate-50 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-600 disabled:cursor-wait disabled:opacity-60"
-            disabled={
-              refreshIssues.isPending || !repository.credential.configured
-            }
+            disabled={refreshingIssues || !repository.credential.configured}
             onClick={() => refreshIssues.mutate()}
             aria-label={
-              refreshIssues.isPending ? "Refreshing issues" : "Refresh issues"
+              refreshingIssues ? "Refreshing issues" : "Refresh issues"
             }
             title={
               repository.credential.configured
@@ -949,7 +984,7 @@ function RepositoryCard({ repository }: { repository: Repository }) {
           >
             <svg
               aria-hidden="true"
-              className={`size-4 ${refreshIssues.isPending ? "animate-spin motion-reduce:animate-none" : ""}`}
+              className={`size-4 ${refreshingIssues ? "animate-spin motion-reduce:animate-none" : ""}`}
               viewBox="0 0 24 24"
               fill="none"
               stroke="currentColor"

--- a/apps/harness/test/refresh-issues-live.test.ts
+++ b/apps/harness/test/refresh-issues-live.test.ts
@@ -15,6 +15,7 @@ describe("Repository Issue live-query coordination", () => {
     let otherIssuesFetches = 0
     let selectedWorkItemsFetches = 0
     let otherWorkItemsFetches = 0
+    const changedRepositoryIds: string[] = []
     let issuesReconciledAt: string | null = null
     let selectedIssues = [
       {
@@ -73,6 +74,9 @@ describe("Repository Issue live-query coordination", () => {
     const controller = new AbortController()
     const live = followRepositoryIssuesLive({
       getRepositoryIds: () => [repositoryId, otherRepositoryId],
+      onRepositoryChanged: (changedRepositoryId) => {
+        changedRepositoryIds.push(changedRepositoryId)
+      },
       queryClient,
       queries,
       signal: controller.signal,
@@ -138,6 +142,7 @@ describe("Repository Issue live-query coordination", () => {
     expect(selectedWorkItemsFetches).toBeGreaterThan(
       fetchesBeforeInvalidation.selectedWorkItems,
     )
+    expect(changedRepositoryIds).toEqual([repositoryId])
     // Initial connection refetches both displayed Repositories, but the
     // selected invalidation does not refetch the other Repository again.
     expect(otherIssuesFetches).toBe(1)


### PR DESCRIPTION
## Why

The repository refresh mutation returns when work is queued, so the refresh icon stopped before refreshed issue data arrived. This made an in-progress refresh appear complete.

## What Changed

- keep each repository refresh button spinning after the mutation is accepted
- stop it on the next issue-change subscription event for that repository
- expose repository-specific change notifications from the live-query coordinator
- cover the notification and button lifecycle in unit and browser tests

## Verification

The targeted repository live-query coordination tests pass (3 tests). The commit hook also ran the complete affected harness suite (41 tests).