### PR TITLE
feat(harness): show jobs across repositories

### DIFF
--- a/apps/harness/e2e/refresh-repository.e2e.ts
+++ b/apps/harness/e2e/refresh-repository.e2e.ts
@@ -62,6 +62,9 @@ test("Refresh returns after enqueueing and updates after worker invalidation", a
     if (query.includes("issues(")) {
       return { data: { issues: workerCompleted ? [issue] : [] } }
     }
+    if (query.includes("workItems")) {
+      return { data: { workItems: [] } }
+    }
     if (query.includes("config")) {
       return {
         data: {

--- a/apps/harness/src/routes/index.tsx
+++ b/apps/harness/src/routes/index.tsx
@@ -1,5 +1,6 @@
 import {
   useMutation,
+  useQueries,
   useQuery,
   useQueryClient,
   useSuspenseQuery,
@@ -247,6 +248,14 @@ function HomePage() {
       <Suspense fallback={<RepositoryCardsSkeleton />}>
         <RepositoryCards />
       </Suspense>
+      <section className="mt-8" aria-label="Jobs">
+        <h2 className="mb-4 text-lg font-bold tracking-[-0.02em] text-slate-900">
+          Jobs
+        </h2>
+        <Suspense fallback={<JobsCardSkeleton />}>
+          <JobsCard />
+        </Suspense>
+      </section>
     </main>
   )
 }
@@ -979,14 +988,6 @@ function RepositoryCard({ repository }: { repository: Repository }) {
           </Suspense>
         )}
       </div>
-      <div className="mt-5 border-t border-slate-100 pt-4">
-        <h3 className="mb-2 text-[0.68rem] font-[750] tracking-[0.08em] text-slate-400 uppercase">
-          Jobs
-        </h3>
-        <Suspense fallback={<RepositoryJobsSkeleton />}>
-          <RepositoryJobs repositoryId={repository.id} />
-        </Suspense>
-      </div>
       {removeRepository.isError && (
         <p className="mt-3 mb-0 text-sm text-red-700" role="alert">
           Could not remove repository. Please try again.
@@ -1251,64 +1252,120 @@ function RepositoryIssueRow({
   )
 }
 
-function RepositoryJobs({ repositoryId }: { repositoryId: string }) {
-  const { data: workItems } = useSuspenseQuery({
-    ...workItemsQuery(repositoryId),
-    refetchInterval: ({ state }) => {
-      const items = state.data as readonly WorkItem[] | undefined
-      return items?.some(
-        (item) => item.status === "QUEUED" || item.status === "RUNNING",
-      )
-        ? 1_000
-        : false
-    },
+function JobsCard() {
+  const { data: repositories } = useSuspenseQuery(repositoriesQuery)
+  const workItemQueries = useQueries({
+    queries: repositories.map((repository) => ({
+      ...workItemsQuery(repository.id),
+      refetchInterval: ({ state }: { state: { data: unknown } }) => {
+        const items = state.data as readonly WorkItem[] | undefined
+        return items?.some(
+          (item) => item.status === "QUEUED" || item.status === "RUNNING",
+        )
+          ? 1_000
+          : false
+      },
+    })),
   })
 
+  const repositoryById = new Map(
+    repositories.map((repository) => [repository.id, repository] as const),
+  )
+  const workItems = workItemQueries
+    .flatMap((query) => query.data ?? [])
+    .sort((left, right) => right.createdAt.localeCompare(left.createdAt))
+  const loading = workItemQueries.some((query) => query.isLoading)
+  const failed = workItemQueries.some((query) => query.isError)
+
+  if (repositories.length === 0) {
+    return (
+      <article className="rounded-[0.9rem] border border-[#dbe3ef] bg-white p-[1.35rem] shadow-[0_10px_30px_rgb(15_23_42_/_5%)]">
+        <p className="m-0 text-sm text-slate-500">
+          Add a repository to see jobs.
+        </p>
+      </article>
+    )
+  }
+
+  if (loading && workItems.length === 0) {
+    return <JobsCardSkeleton />
+  }
+
+  if (failed) {
+    return (
+      <article className="rounded-[0.9rem] border border-red-200 bg-red-50 p-[1.35rem] shadow-[0_10px_30px_rgb(15_23_42_/_5%)]">
+        <p className="m-0 text-sm text-red-700" role="alert">
+          Could not load jobs. Please try again.
+        </p>
+      </article>
+    )
+  }
+
   if (workItems.length === 0) {
-    return <p className="m-0 text-sm text-slate-500">No jobs yet.</p>
+    return (
+      <article className="rounded-[0.9rem] border border-[#dbe3ef] bg-white p-[1.35rem] shadow-[0_10px_30px_rgb(15_23_42_/_5%)]">
+        <p className="m-0 text-sm text-slate-500">No jobs yet.</p>
+      </article>
+    )
   }
 
   return (
-    <ul className="m-0 grid list-none gap-2 p-0" aria-label="Repository jobs">
-      {[...workItems].reverse().map((workItem) => (
-        <li
-          className="rounded-lg border border-slate-200 bg-slate-50/80 px-3 py-2"
-          key={workItem.id}
-        >
-          <div className="flex items-center justify-between gap-3">
-            <span className="font-mono text-xs font-semibold text-blue-600">
-              Issue #{workItem.githubIssueNumber}
-            </span>
-            <span className="text-[0.65rem] font-bold tracking-wide text-slate-600 uppercase">
-              {workItem.stateLabel}
-            </span>
-          </div>
-          {workItem.sessionId !== null && workItem.sessionId !== "" && (
-            <p
-              className="mt-1 mb-0 truncate font-mono text-[0.7rem] text-slate-500"
-              title={workItem.sessionId}
+    <article className="rounded-[0.9rem] border border-[#dbe3ef] bg-white p-[1.35rem] shadow-[0_10px_30px_rgb(15_23_42_/_5%)]">
+      <ul className="m-0 grid list-none gap-2 p-0" aria-label="All jobs">
+        {workItems.map((workItem) => {
+          const repository = repositoryById.get(workItem.repositoryId)
+          const repositoryLabel =
+            repository === undefined
+              ? workItem.repositoryId
+              : `${repository.githubOwner}/${repository.githubRepo}`
+          return (
+            <li
+              className="rounded-lg border border-slate-200 bg-slate-50/80 px-3 py-2"
+              key={workItem.id}
             >
-              Session {workItem.sessionId}
-            </p>
-          )}
-          <WorkItemLifecycleStatus workItem={workItem} compact />
-        </li>
-      ))}
-    </ul>
+              <div className="flex items-center justify-between gap-3">
+                <div className="min-w-0">
+                  <p className="m-0 truncate text-xs font-semibold text-slate-700">
+                    {repositoryLabel}
+                  </p>
+                  <span className="font-mono text-xs font-semibold text-blue-600">
+                    Issue #{workItem.githubIssueNumber}
+                  </span>
+                </div>
+                <span className="shrink-0 text-[0.65rem] font-bold tracking-wide text-slate-600 uppercase">
+                  {workItem.stateLabel}
+                </span>
+              </div>
+              {workItem.sessionId !== null && workItem.sessionId !== "" && (
+                <p
+                  className="mt-1 mb-0 truncate font-mono text-[0.7rem] text-slate-500"
+                  title={workItem.sessionId}
+                >
+                  Session {workItem.sessionId}
+                </p>
+              )}
+              <WorkItemLifecycleStatus workItem={workItem} compact />
+            </li>
+          )
+        })}
+      </ul>
+    </article>
   )
 }
 
-function RepositoryJobsSkeleton() {
+function JobsCardSkeleton() {
   return (
-    <div
-      className="grid gap-2"
+    <article
+      className="rounded-[0.9rem] border border-[#dbe3ef] bg-white p-[1.35rem] shadow-[0_10px_30px_rgb(15_23_42_/_5%)]"
       role="status"
       aria-label="Loading jobs"
       aria-busy="true"
     >
-      <span className="block h-12 animate-pulse rounded-lg bg-slate-100 motion-reduce:animate-none" />
-      <span className="block h-12 animate-pulse rounded-lg bg-slate-100 motion-reduce:animate-none" />
-    </div>
+      <div className="grid gap-2">
+        <span className="block h-12 animate-pulse rounded-lg bg-slate-100 motion-reduce:animate-none" />
+        <span className="block h-12 animate-pulse rounded-lg bg-slate-100 motion-reduce:animate-none" />
+      </div>
+    </article>
   )
 }
 

--- a/packages/graphql-api/test/graphql-api.test.ts
+++ b/packages/graphql-api/test/graphql-api.test.ts
@@ -1113,6 +1113,64 @@ describe("GraphQL API", () => {
     expect(receivedArgs).toEqual([repository.id, issue.githubIssueNumber])
   })
 
+  test("serializes local_cleanup as a lifecycle phase", async () => {
+    const baseRun = workItem.stepRuns[0]!
+    const cleanedUp = {
+      ...workItem,
+      state: "complete",
+      stepRuns: [
+        { ...baseRun, step: "merge_pr", status: "succeeded" },
+        { ...baseRun, step: "local_cleanup", status: "succeeded" },
+      ],
+    } as WorkItemRecord
+    await runtime.dispose()
+    runtime = makeRuntime(
+      {},
+      {},
+      {},
+      {},
+      {
+        listWorkItemsForIssue: () => Effect.succeed([cleanedUp]),
+      },
+    )
+
+    const response = await createGraphqlApi(runtime).fetch(
+      graphqlRequest({
+        query: `query WorkItems($repositoryId: ID!, $githubIssueNumber: Int!) {
+          workItems(repositoryId: $repositoryId, githubIssueNumber: $githubIssueNumber) {
+            state lifecycleLabels { phase label status }
+          }
+        }`,
+        variables: {
+          repositoryId: repository.id,
+          githubIssueNumber: issue.githubIssueNumber,
+        },
+      }),
+    )
+
+    expect(await response.json()).toEqual({
+      data: {
+        workItems: [
+          {
+            state: "COMPLETE",
+            lifecycleLabels: [
+              {
+                phase: "MERGE_PR",
+                label: "Merge PR: Merged",
+                status: "SUCCEEDED",
+              },
+              {
+                phase: "LOCAL_CLEANUP",
+                label: "Local cleanup: Succeeded",
+                status: "SUCCEEDED",
+              },
+            ],
+          },
+        ],
+      },
+    })
+  })
+
   test("projects repeated status-check runs as one lifecycle phase", async () => {
     const baseRun = workItem.stepRuns[0]!
     const polling = {

--- a/packages/graphql-schema/schema.graphql
+++ b/packages/graphql-schema/schema.graphql
@@ -112,6 +112,7 @@ enum LifecyclePhase {
   MARK_PR_READY_FOR_REVIEW
   DECIDE_PR_MERGE
   MERGE_PR
+  LOCAL_CLEANUP
 }
 
 type LifecycleLabel {


### PR DESCRIPTION
## Why

Jobs were tied to individual Repository cards, making it difficult to monitor work across the configured workspace. The new global view initially exposed a missing GraphQL lifecycle enum value, which caused completed Work Item queries to fail and made the Jobs card jump between states.

## What Changed

- move Jobs out of Repository cards into one workspace-level card
- combine and sort Work Items from all configured Repositories, with Repository identity shown on each Job
- retain lifecycle progress alongside Relevant Issues in Repository cards
- render explicit loading, empty, and query-error states for the global Jobs card
- add `LOCAL_CLEANUP` to the GraphQL lifecycle phase enum and cover its serialization

## Verification

- Confirmed in the running Harness that a completed Job including `LOCAL_CLEANUP` renders successfully.
- Observed the Jobs region at a stable height across repeated polling measurements.
