### PR TITLE
feat(harness): show step durations and job start age

### DIFF
--- a/apps/harness/src/routes/index.tsx
+++ b/apps/harness/src/routes/index.tsx
@@ -191,6 +191,7 @@ type WorkItem = {
     phase: string
     label: string
     status: WorkItemStatus
+    durationMs: number | null
   }[]
 }
 
@@ -211,8 +212,36 @@ const workItemFields = {
     phase: true,
     label: true,
     status: true,
+    durationMs: true,
   },
 } as const
+
+/** Formats a duration for step labels, e.g. "3s" or "4m 15s". */
+function formatDuration(ms: number): string {
+  const totalSeconds = Math.max(0, Math.round(ms / 1000))
+  if (totalSeconds < 60) return `${totalSeconds}s`
+  const minutes = Math.floor(totalSeconds / 60)
+  const seconds = totalSeconds % 60
+  if (minutes < 60) {
+    return seconds === 0 ? `${minutes}m` : `${minutes}m ${seconds}s`
+  }
+  const hours = Math.floor(minutes / 60)
+  const remainingMinutes = minutes % 60
+  return remainingMinutes === 0 ? `${hours}h` : `${hours}h ${remainingMinutes}m`
+}
+
+/** Formats job start time as a relative phrase, e.g. "15 min ago". */
+function formatStartedAgo(iso: string, nowMs = Date.now()): string {
+  const elapsedMs = Math.max(0, nowMs - new Date(iso).getTime())
+  const seconds = Math.floor(elapsedMs / 1000)
+  if (seconds < 60) return "just now"
+  const minutes = Math.floor(seconds / 60)
+  if (minutes < 60) return `${minutes} min ago`
+  const hours = Math.floor(minutes / 60)
+  if (hours < 24) return hours === 1 ? "1 hour ago" : `${hours} hours ago`
+  const days = Math.floor(hours / 24)
+  return days === 1 ? "1 day ago" : `${days} days ago`
+}
 
 const workItemsQuery = (repositoryId: string) => ({
   queryKey: ["work-items", repositoryId],
@@ -1464,6 +1493,9 @@ function WorkItemLifecycleStatus({
       <div className="flex flex-wrap items-center justify-between gap-2">
         <span className="text-xs font-semibold text-slate-700">
           {workItem.stateLabel}
+          <span className="ml-1.5 font-normal text-slate-500">
+            {formatStartedAgo(workItem.createdAt)}
+          </span>
         </span>
         <span
           className={`rounded-full px-2 py-0.5 text-[0.6rem] font-bold tracking-wide uppercase ${
@@ -1492,6 +1524,11 @@ function WorkItemLifecycleStatus({
               key={lifecycleLabel.phase}
             >
               {lifecycleLabel.label}
+              {lifecycleLabel.durationMs !== null && (
+                <span className="ml-1 text-slate-400">
+                  {formatDuration(lifecycleLabel.durationMs)}
+                </span>
+              )}
             </li>
           ))}
         </ol>

--- a/packages/graphql-api/src/lib/graphql-api.ts
+++ b/packages/graphql-api/src/lib/graphql-api.ts
@@ -230,6 +230,7 @@ const lifecycleLabels = (workItem: WorkItemRecord) => {
       phase: phase.toUpperCase(),
       label: `${lifecyclePhaseLabel(phase)}: ${outcome}`,
       status: status.toUpperCase(),
+      durationMs: stepRun.executionDurationMs,
     }
   })
 }

--- a/packages/graphql-api/test/graphql-api.test.ts
+++ b/packages/graphql-api/test/graphql-api.test.ts
@@ -1074,7 +1074,7 @@ describe("GraphQL API", () => {
           workItems(repositoryId: $repositoryId, githubIssueNumber: $githubIssueNumber) {
             id state stateLabel status statusLabel statusMessage canRetry isTerminal
             stateReadyAt createdAt updatedAt
-            lifecycleLabels { phase label status }
+            lifecycleLabels { phase label status durationMs }
           }
         }`,
         variables: {
@@ -1104,6 +1104,7 @@ describe("GraphQL API", () => {
                 phase: "CREATE_WORKTREE",
                 label: "Create worktree: Running",
                 status: "RUNNING",
+                durationMs: 250,
               },
             ],
           },

--- a/packages/graphql-schema/schema.graphql
+++ b/packages/graphql-schema/schema.graphql
@@ -119,6 +119,10 @@ type LifecycleLabel {
   phase: LifecyclePhase!
   label: String!
   status: WorkItemStatus!
+  """
+  Execution duration in milliseconds; null when the step has not started.
+  """
+  durationMs: Float
 }
 
 type WorkItem {


### PR DESCRIPTION
## Why

When implementing an issue, the harness lifecycle UI showed step status but not how long each step took or when the job started. That makes it hard to tell whether a step is stuck or merely slow.

## What Changed

- Exposed `LifecycleLabel.durationMs` from GraphQL (from step-run `executionDurationMs`)
- Render each step duration as `3s` / `4m 15s` next to the step chip
- Show relative job start age as `15 min ago` next to the phase label
