### PR TITLE
feat(graphql-api): sort top-level issues by reverse number

### DIFF
--- a/packages/graphql-api/src/lib/graphql-api.ts
+++ b/packages/graphql-api/src/lib/graphql-api.ts
@@ -135,7 +135,7 @@ const workIssueProjection = (
 
   return issues
     .filter((issue) => issue.parent === null)
-    .sort((left, right) => left.githubIssueNumber - right.githubIssueNumber)
+    .sort((left, right) => right.githubIssueNumber - left.githubIssueNumber)
     .flatMap((issue) => {
       if (!issue.hasChildren) return [issue]
       const children = childrenByParent.get(issue.githubIssueNumber) ?? []

--- a/packages/graphql-api/test/graphql-api.test.ts
+++ b/packages/graphql-api/test/graphql-api.test.ts
@@ -993,7 +993,6 @@ describe("GraphQL API", () => {
     expect(await response.json()).toEqual({
       data: {
         issues: [
-          { githubIssueNumber: 3, hasChildren: false, parent: null },
           { githubIssueNumber: 10, hasChildren: true, parent: null },
           {
             githubIssueNumber: 14,
@@ -1015,6 +1014,7 @@ describe("GraphQL API", () => {
             hasChildren: false,
             parent: { githubIssueNumber: 10 },
           },
+          { githubIssueNumber: 3, hasChildren: false, parent: null },
         ],
       },
     })


### PR DESCRIPTION
## Why

Relevant issues at the top level should show newest work first (highest issue number). Ascending order buried recent PRDs below older issues.

## What Changed

`workIssueProjection` now sorts root issues by descending GitHub issue number. Child ordering is unchanged (actionability, then GitHub `parentPosition`).