### PR TITLE
fix(pre-commit): diagnose failures via sub-agent summary

### DIFF
--- a/docs/adr/0010-pre-commit-validation-before-local-review.md
+++ b/docs/adr/0010-pre-commit-validation-before-local-review.md
@@ -1,10 +1,11 @@
 # Pre-Commit Validation Before Local Review
 
-After OpenCode implements a Work Item and before Review, Ready For Agent validates the worktree by staging changes and running the repository's git pre-commit hook via `git hook run --ignore-missing pre-commit`. Missing pre-commit hooks succeed. When the hook fails, the step continues the Implement OpenCode Session with the full hook output, asks it to fix the failures (without committing or opening a PR), then re-stages and re-runs the hook, repeating until the hook passes. The Step Run's maximum duration bounds the loop. OpenCode or staging failures fail the Step Run and leave Pre-Commit pending for Retry.
+After OpenCode implements a Work Item and before Review, Ready For Agent validates the worktree by staging changes and running the repository's git pre-commit hook via `git hook run --ignore-missing pre-commit`. Missing pre-commit hooks succeed. When the hook fails, the step writes the full hook output to a temp log, continues the Implement OpenCode Session with the log path (not raw hook logs), and asks it to use a sub-agent to inspect the failure and return only a concise summary of what to fix. The main session fixes without committing or opening a PR; Ready For Agent then re-stages and re-runs the hook, repeating until the hook passes. The Step Run's maximum duration bounds the loop. OpenCode or staging failures fail the Step Run and leave Pre-Commit pending for Retry.
 
 ## Consequences
 
 - Pre-Commit is a first-class Lifecycle Step between Implement and Review, not an optional verification command.
 - The step stages with `git add -A` before each hook invocation so hooks that inspect the index see implementation changes even when OpenCode left them uncommitted.
 - Missing pre-commit hooks succeed; a failing hook triggers OpenCode fix-and-retry rather than immediately failing the Step Run.
+- Fix prompts point at a log file and require a sub-agent to summarize failures so noisy hook output does not fill the main Implement session context.
 - Pre-Commit requires the Implement OpenCode Session so fix attempts continue that conversation.

--- a/packages/work-item-lifecycle/src/lib/pre-commit.ts
+++ b/packages/work-item-lifecycle/src/lib/pre-commit.ts
@@ -11,9 +11,6 @@ import {
 } from "./pre-commit-errors.js"
 import { DEFAULT_LIFECYCLE_MAX_DURATIONS } from "./types.js"
 
-/** Max hook output chars embedded in the OpenCode CLI prompt (avoids spawn E2BIG). */
-export const HOOK_OUTPUT_PROMPT_LIMIT = 12_000
-
 const resolveWorktreePath = (context: LifecycleStepContext) =>
   Effect.gen(function* () {
     const worktreePath = context.worktreePath
@@ -92,16 +89,6 @@ const runGitInWorktree = (cwd: string, args: ReadonlyArray<string>) =>
     )
   })
 
-const truncateHookOutputForPrompt = (output: string): string => {
-  if (output.length === 0) {
-    return "(no output)"
-  }
-  if (output.length <= HOOK_OUTPUT_PROMPT_LIMIT) {
-    return output
-  }
-  return `…${output.slice(-(HOOK_OUTPUT_PROMPT_LIMIT - 1))}`
-}
-
 const writeHookOutputLog = (workItemId: string, output: string) =>
   Effect.gen(function* () {
     const fs = yield* FileSystem.FileSystem
@@ -114,16 +101,17 @@ const writeHookOutputLog = (workItemId: string, output: string) =>
     return logPath
   })
 
-const buildFixPrompt = (exitCode: number, output: string, logPath: string) =>
+const buildFixPrompt = (exitCode: number, logPath: string) =>
   [
     "The repository pre-commit hook failed after staging the worktree changes.",
     `Exit code: ${exitCode}`,
     `Full hook output is at: ${logPath}`,
-    "Read that file if you need more context than the tail below.",
-    "Hook output (tail if truncated):",
-    truncateHookOutputForPrompt(output),
-    "Diagnose and fix the failures in this worktree so pre-commit can pass.",
-    "Run the same checks the hook runs when practical, then fix the underlying issues.",
+    "Do not read that log or re-run the pre-commit hook in this main session — hook output is noisy and must stay out of the main context.",
+    "Delegate to a sub-agent that:",
+    "1. Reads the log and/or runs `git hook run --ignore-missing pre-commit` in this worktree",
+    "2. Returns only a concise summary of what failed and what to fix (no raw hook logs)",
+    "Use that summary to diagnose and fix the failures in this worktree so pre-commit can pass.",
+    "When re-checking, use a sub-agent again for the same reason; only bring back pass/fail plus a short failure summary.",
     "Do not create a git commit or open a pull request.",
   ].join("\n")
 
@@ -141,7 +129,7 @@ const askOpencodeToFix = (
       yield* opencode
         .continue({
           sessionId,
-          prompt: buildFixPrompt(exitCode, output, logPath),
+          prompt: buildFixPrompt(exitCode, logPath),
           cwd: worktreePath,
           model: context.model,
           variant: context.variant,
@@ -167,9 +155,11 @@ const askOpencodeToFix = (
  * Production Pre-Commit Lifecycle Step.
  * Stages all worktree changes then runs the repository pre-commit hook via
  * `git hook run --ignore-missing pre-commit`. Missing hooks succeed. A failing
- * hook continues the Implement OpenCode Session with the hook output, then
- * re-stages and re-runs until the hook passes (bounded by the step max
- * duration). OpenCode or stage failures fail the Step Run.
+ * hook writes full output to a temp log, continues the Implement OpenCode
+ * Session with instructions to diagnose via a sub-agent (keeping raw hook
+ * logs out of the main context), then re-stages and re-runs until the hook
+ * passes (bounded by the step max duration). OpenCode or stage failures fail
+ * the Step Run.
  */
 export const preCommit = (context: LifecycleStepContext) =>
   Effect.gen(function* () {

--- a/packages/work-item-lifecycle/test/pre-commit.spec.ts
+++ b/packages/work-item-lifecycle/test/pre-commit.spec.ts
@@ -19,7 +19,6 @@ import {
 } from "@ready-for-agent/opencode"
 import type { LifecycleStepContext } from "../src/index.js"
 import {
-  HOOK_OUTPUT_PROMPT_LIMIT,
   PreCommitInvalidWorktreeContextError,
   PreCommitOpenCodeError,
   PreCommitSessionContextMissingError,
@@ -226,17 +225,19 @@ describe("preCommit", () => {
       )
 
       expect(prompts).toHaveLength(1)
-      expect(prompts[0]).toContain(diagnostic)
+      expect(prompts[0]).not.toContain(diagnostic)
       expect(prompts[0]).toContain("pre-commit")
+      expect(prompts[0]).toMatch(/sub-agent/i)
+      expect(prompts[0]).toMatch(/summary/i)
       expect(prompts[0]).toMatch(/fix|Diagnose/i)
       expect(prompts[0]).toMatch(/Full hook output is at: /)
     }))
 
-  it("writes oversized hook output to a log and only embeds a truncated tail in the prompt", () =>
+  it("writes hook output to a log and keeps raw hook logs out of the OpenCode prompt", () =>
     withTempGit(async (root) => {
       const head = "HEAD_MARKER_SHOULD_NOT_BE_IN_PROMPT"
-      const tail = "TAIL_MARKER_MUST_BE_IN_PROMPT"
-      const filler = "x".repeat(HOOK_OUTPUT_PROMPT_LIMIT + 5_000)
+      const tail = "TAIL_MARKER_SHOULD_NOT_BE_IN_PROMPT"
+      const filler = "x".repeat(20_000)
       const diagnostic = `${head}\n${filler}\n${tail}`
       await writeFile(join(root, ".hook-diagnostic"), diagnostic)
       await writeHook(
@@ -278,9 +279,9 @@ describe("preCommit", () => {
         }),
       )
 
-      expect(prompt.length).toBeLessThan(HOOK_OUTPUT_PROMPT_LIMIT + 2_000)
       expect(prompt).not.toContain(head)
-      expect(prompt).toContain(tail)
+      expect(prompt).not.toContain(tail)
+      expect(prompt).toMatch(/sub-agent/i)
       expect(logPath.length).toBeGreaterThan(0)
       expect(logContents).toContain(head)
       expect(logContents).toContain(tail)


### PR DESCRIPTION
## Why

When Pre-Commit fails, the fix prompt used to embed a large tail of hook output into the Implement OpenCode session. Pre-commit hooks often print a lot of logging, which pollutes the main agent context and crowds out useful conversation history.

## What Changed

- Keep full hook output only in a temp log file.
- Prompt OpenCode to use a sub-agent to inspect the log / re-run pre-commit and return a concise failure summary.
- Instruct re-checks to go through a sub-agent as well so raw hook noise stays out of the main session.
- Update ADR 0010 and pre-commit tests for the new prompt shape.