### PR TITLE
refactor(opencode): improve Effect integration

### DIFF
--- a/packages/opencode/src/lib/opencode.ts
+++ b/packages/opencode/src/lib/opencode.ts
@@ -1,4 +1,4 @@
-import { Context, Duration, Effect, Layer, Stream } from "effect"
+import { Context, Duration, Effect, Layer, Ref, Stream } from "effect"
 import type { PlatformError } from "effect/PlatformError"
 import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process"
 import { buildRunArgs } from "./build-args.js"
@@ -53,59 +53,58 @@ export class Opencode extends Context.Service<
           keymaxxerMcpUrl: options.keymaxxerMcpUrl,
         })
 
-        const listModels = (
+        const listModels = Effect.fn("Opencode.listModels")(function* (
           input: ListModelsInput,
-        ): Effect.Effect<ReadonlyArray<string>, OpencodeError> =>
-          Effect.gen(function* () {
-            const timeout = input.timeout ?? defaultTimeout
-            const timeoutMs = Duration.toMillis(timeout)
-            const command = ChildProcess.make(binary, ["models"], {
-              cwd: input.cwd,
-              env: environment,
-              extendEnv: false,
-              stdin: "ignore",
-              stderr: "ignore",
-            })
-
-            const result = yield* Effect.scoped(
-              Effect.gen(function* () {
-                const handle = yield* spawner.spawn(command)
-                const collectModels = Stream.decodeText(handle.stdout).pipe(
-                  Stream.splitLines,
-                  Stream.runFold(
-                    (): ReadonlyArray<string> => [],
-                    (models, line) => {
-                      const model = line.trim()
-                      return model.length === 0 ? models : [...models, model]
-                    },
-                  ),
-                )
-
-                const [exitCode, models] = yield* Effect.all(
-                  [handle.exitCode, collectModels],
-                  { concurrency: 2 },
-                )
-
-                return { exitCode: Number(exitCode), models }
-              }),
-            ).pipe(
-              Effect.timeout(timeout),
-              Effect.catchTag("TimeoutError", () =>
-                Effect.fail(
-                  new OpencodeTimeoutError({ cwd: input.cwd, timeoutMs }),
-                ),
-              ),
-            )
-
-            if (result.exitCode !== 0) {
-              return yield* new OpencodeExitError({
-                exitCode: result.exitCode,
-                cwd: input.cwd,
-              })
-            }
-
-            return result.models
+        ) {
+          const timeout = input.timeout ?? defaultTimeout
+          const timeoutMs = Duration.toMillis(timeout)
+          const command = ChildProcess.make(binary, ["models"], {
+            cwd: input.cwd,
+            env: environment,
+            extendEnv: false,
+            stdin: "ignore",
+            stderr: "ignore",
           })
+
+          const result = yield* Effect.scoped(
+            Effect.gen(function* () {
+              const handle = yield* spawner.spawn(command)
+              const collectModels = Stream.decodeText(handle.stdout).pipe(
+                Stream.splitLines,
+                Stream.runFold(
+                  (): ReadonlyArray<string> => [],
+                  (models, line) => {
+                    const model = line.trim()
+                    return model.length === 0 ? models : [...models, model]
+                  },
+                ),
+              )
+
+              const [exitCode, models] = yield* Effect.all(
+                [handle.exitCode, collectModels],
+                { concurrency: 2 },
+              )
+
+              return { exitCode: Number(exitCode), models }
+            }),
+          ).pipe(
+            Effect.timeout(timeout),
+            Effect.catchTag("TimeoutError", () =>
+              Effect.fail(
+                new OpencodeTimeoutError({ cwd: input.cwd, timeoutMs }),
+              ),
+            ),
+          )
+
+          if (result.exitCode !== 0) {
+            return yield* new OpencodeExitError({
+              exitCode: result.exitCode,
+              cwd: input.cwd,
+            })
+          }
+
+          return result.models
+        })
 
         const run = (input: {
           readonly prompt: string
@@ -119,7 +118,7 @@ export class Opencode extends Context.Service<
             const timeout = input.timeout ?? defaultTimeout
             const timeoutMs = Duration.toMillis(timeout)
             const knownSessionId = input.sessionId
-            let seenSessionId: string | undefined = knownSessionId
+            const seenSessionId = yield* Ref.make(knownSessionId)
 
             const args = buildRunArgs({
               prompt: input.prompt,
@@ -143,24 +142,28 @@ export class Opencode extends Context.Service<
 
                 const collectOutput = Stream.decodeText(handle.stdout).pipe(
                   Stream.splitLines,
+                  Stream.map((line) => ({
+                    sessionId: parseSessionIdFromLine(line),
+                    text: parseAssistantTextFromLine(line),
+                  })),
+                  Stream.tap(({ sessionId }) =>
+                    sessionId === undefined
+                      ? Effect.void
+                      : Ref.set(seenSessionId, sessionId),
+                  ),
                   Stream.runFold(
                     (): { sessionId?: string; assistantText: string } => ({
                       assistantText: "",
                     }),
-                    (acc, line) => {
-                      const sessionId = parseSessionIdFromLine(line)
-                      if (sessionId !== undefined) {
-                        seenSessionId = sessionId
-                      }
-                      const text = parseAssistantTextFromLine(line)
+                    (acc, event) => {
                       return {
-                        sessionId: sessionId ?? acc.sessionId,
+                        sessionId: event.sessionId ?? acc.sessionId,
                         assistantText:
-                          text === undefined
+                          event.text === undefined
                             ? acc.assistantText
                             : acc.assistantText.length === 0
-                              ? text
-                              : `${acc.assistantText}\n${text}`,
+                              ? event.text
+                              : `${acc.assistantText}\n${event.text}`,
                       }
                     },
                   ),
@@ -180,14 +183,15 @@ export class Opencode extends Context.Service<
             ).pipe(
               Effect.timeout(timeout),
               Effect.catchTag("TimeoutError", () =>
-                Effect.fail(
-                  new OpencodeTimeoutError({
-                    cwd: input.cwd,
-                    timeoutMs,
-                    ...(seenSessionId !== undefined
-                      ? { sessionId: seenSessionId }
-                      : {}),
-                  }),
+                Ref.get(seenSessionId).pipe(
+                  Effect.flatMap(
+                    (sessionId) =>
+                      new OpencodeTimeoutError({
+                        cwd: input.cwd,
+                        timeoutMs,
+                        ...(sessionId !== undefined ? { sessionId } : {}),
+                      }),
+                  ),
                 ),
               ),
             )
@@ -213,8 +217,10 @@ export class Opencode extends Context.Service<
           })
 
         return {
-          start: (input) => run(input),
-          continue: (input) => run(input),
+          start: Effect.fn("Opencode.start")((input: StartInput) => run(input)),
+          continue: Effect.fn("Opencode.continue")((input: ContinueInput) =>
+            run(input),
+          ),
           listModels,
         }
       }),

--- a/packages/opencode/test/opencode.spec.ts
+++ b/packages/opencode/test/opencode.spec.ts
@@ -1,0 +1,107 @@
+import { chmod, mkdtemp, rm, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { BunServices } from "@effect/platform-bun"
+import { Effect, Layer } from "effect"
+import {
+  Opencode,
+  OpencodeExitError,
+  OpencodeTimeoutError,
+} from "../src/index.js"
+import { describe, expect, it } from "bun:test"
+
+const withExecutable = async <A>(
+  body: string,
+  use: (path: string) => Promise<A>,
+): Promise<A> => {
+  const directory = await mkdtemp(join(tmpdir(), "opencode-effect-test-"))
+  const path = join(directory, "opencode")
+  try {
+    await writeFile(path, `#!/bin/sh\n${body}\n`)
+    await chmod(path, 0o700)
+    return await use(path)
+  } finally {
+    await rm(directory, { recursive: true, force: true })
+  }
+}
+
+const start = (binary: string, timeout: string) =>
+  Effect.gen(function* () {
+    const opencode = yield* Opencode
+    return yield* opencode.start({
+      cwd: process.cwd(),
+      prompt: "test",
+      model: "test/model",
+      variant: "test",
+      timeout,
+    })
+  }).pipe(
+    Effect.provide(
+      Opencode.layer({
+        binary,
+        keymaxxerMcpUrl: "http://127.0.0.1:5032/test/mcp",
+      }).pipe(Layer.provide(BunServices.layer)),
+    ),
+  )
+
+describe("Opencode Effect service", () => {
+  it("collects structured output from a scoped child process", async () => {
+    await withExecutable(
+      [
+        `printf '%s\\n' '{"type":"step_start","sessionID":"ses_test"}'`,
+        `printf '%s\\n' '{"type":"text","part":{"type":"text","text":"first"}}'`,
+        `printf '%s\\n' '{"type":"text","part":{"type":"text","text":"second"}}'`,
+      ].join("\n"),
+      async (binary) => {
+        await expect(
+          Effect.runPromise(start(binary, "2 seconds")),
+        ).resolves.toEqual({
+          sessionId: "ses_test",
+          assistantText: "first\nsecond",
+        })
+      },
+    )
+  })
+
+  it("returns a typed exit error with the observed session", async () => {
+    await withExecutable(
+      [
+        `printf '%s\\n' '{"type":"step_start","sessionID":"ses_failed"}'`,
+        "exit 7",
+      ].join("\n"),
+      async (binary) => {
+        const error = await Effect.runPromise(
+          start(binary, "2 seconds").pipe(Effect.flip),
+        )
+        expect(error).toEqual(
+          new OpencodeExitError({
+            exitCode: 7,
+            cwd: process.cwd(),
+            sessionId: "ses_failed",
+          }),
+        )
+      },
+    )
+  })
+
+  it("retains an observed session in the typed timeout error", async () => {
+    await withExecutable(
+      [
+        `printf '%s\\n' '{"type":"step_start","sessionID":"ses_timeout"}'`,
+        "sleep 10",
+      ].join("\n"),
+      async (binary) => {
+        const error = await Effect.runPromise(
+          start(binary, "200 millis").pipe(Effect.flip),
+        )
+        expect(error).toEqual(
+          new OpencodeTimeoutError({
+            cwd: process.cwd(),
+            timeoutMs: 200,
+            sessionId: "ses_timeout",
+          }),
+        )
+      },
+    )
+  })
+})


### PR DESCRIPTION
## Why

The OpenCode service used mutable state outside Effect to retain session IDs while stdout was consumed concurrently. That state should participate in Effect's concurrency model, and the public service methods lacked named tracing spans for operational diagnostics.

## What Changed

- track observed session IDs with an Effect `Ref`, including when a run times out
- add named `Effect.fn` spans for `start`, `continue`, and `listModels`
- parse each stdout event once before folding its session and assistant output
- add subprocess-level coverage for successful output, non-zero exits, and timeout session retention

## Verification

The new subprocess tests exercise structured output collection and confirm typed exit and timeout errors retain the observed session ID. The full affected test suite passed during commit, including 15 OpenCode tests.
