### PR TITLE
feat(work-item-lifecycle): pause work items

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -9,8 +9,8 @@ A GitHub repository the harness is configured to work on, identified by owner an
 _Avoid_: Repo (in formal docs), target, project, checkout
 
 **Paused**:
-A Repository state in which the harness does not autonomously select work for the Repository while keeping its configuration. Explicit operator requests, including a manual Refresh Job or Implement Now and its resulting lifecycle, remain allowed; new Repositories start paused until deliberately unpaused.
-_Avoid_: Disabled, inactive, enabled=false
+A Repository state in which the harness does not autonomously select work for the Repository while keeping its configuration. Explicit operator requests, including a manual Refresh Job or Implement Now and its resulting lifecycle, remain allowed; new Repositories start paused until deliberately unpaused. Not the same as a paused Work Item (see Pause Work Item).
+_Avoid_: Disabled, inactive, enabled=false, Pause Work Item
 
 **Repository settings**:
 Per-Repository operator preferences: Paused, optional build model and variant (null falls back to harness defaults), optional review model and variant (null falls back to harness review settings, then the build model/variant), and Auto-merge. Changing settings does not rewrite existing Work Items; build and review model/variant are captured when a Work Item is created.
@@ -120,15 +120,23 @@ A durable record of one scheduled execution attempt for a Work Item's Lifecycle 
 _Avoid_: Step duration, job attempt
 
 **Retry**:
-An explicit operator request to create a new Step Run for a Work Item whose previous run failed. Lifecycle failures are not retried automatically.
+An explicit operator request to create a new Step Run for a Work Item whose previous run failed. Lifecycle failures are not retried automatically. Retry is not allowed while a Work Item is paused; the operator must Start first.
 _Avoid_: Queue redelivery, resume
 
+**Pause Work Item**:
+An explicit operator request that marks an unfinished Work Item paused so it will not start further Lifecycle Steps until Start. A running Step Run is not interrupted; after it finishes, the next step is neither enqueued nor started while paused. Step Runs still queued (not running) are cancelled. Pause is idempotent when already paused and is rejected for missing or terminal Work Items. A paused Work Item remains unfinished and still blocks Implement Now for that Issue. Distinct from Repository Paused.
+_Avoid_: Suspend, hold, Abandon, Repository Paused
+
+**Start Work Item**:
+An explicit operator request that clears a Work Item's paused flag. If no Step Run is running and the latest run does not require Retry, a new Step Run for the current Lifecycle Step is enqueued once; if a Step Run is still running, only the flag is cleared so normal advancement resumes when it finishes. Start is idempotent when not paused and is rejected for missing or terminal Work Items.
+_Avoid_: Resume, unpause, Retry
+
 **Abandon**:
-An operator-directed transition that moves a Work Item with no running Step Run to the terminal Abandoned state while preserving its history. Repository removal may apply it automatically to non-running Work Items before deleting that Repository's lifecycle history; an Abandoned Work Item no longer prevents a later Implement Now request for the same Issue.
+An operator-directed transition that moves a Work Item with no running Step Run to the terminal Abandoned state while preserving its history. Repository removal may apply it automatically to non-running Work Items before deleting that Repository's lifecycle history; an Abandoned Work Item no longer prevents a later Implement Now request for the same Issue. Pause does not block Abandon.
 _Avoid_: Delete, cancel
 
 **Reset**:
-An operator-directed erasure of a Work Item that stops queued or running Step Runs, removes the Git worktree and branch, and deletes the Work Item and its Step Run history so the Issue returns to Not Implemented. Unlike Abandon, Reset does not preserve history.
+An operator-directed erasure of a Work Item that stops queued or running Step Runs, removes the Git worktree and branch, and deletes the Work Item and its Step Run history so the Issue returns to Not Implemented. Unlike Abandon, Reset does not preserve history. Reset is allowed while paused and removes the Work Item entirely.
 _Avoid_: Abandon, Retry, cancel
 
 **Failed Work Item**:

--- a/apps/harness/src/routes/index.tsx
+++ b/apps/harness/src/routes/index.tsx
@@ -183,6 +183,7 @@ type WorkItem = {
   status: WorkItemStatus
   statusLabel: string
   statusMessage: string | null
+  paused: boolean
   canRetry: boolean
   isTerminal: boolean
   sessionId: string | null
@@ -204,6 +205,7 @@ const workItemFields = {
   status: true,
   statusLabel: true,
   statusMessage: true,
+  paused: true,
   canRetry: true,
   isTerminal: true,
   sessionId: true,
@@ -1392,9 +1394,12 @@ function JobsCard() {
                   <p className="m-0 truncate text-xs font-semibold text-slate-700">
                     {repositoryLabel}
                   </p>
-                  <span className="font-mono text-xs font-semibold text-blue-600">
-                    Issue #{workItem.githubIssueNumber}
-                  </span>
+                  <div className="flex items-center gap-1">
+                    <span className="font-mono text-xs font-semibold text-blue-600">
+                      Issue #{workItem.githubIssueNumber}
+                    </span>
+                    <WorkItemPauseButton workItem={workItem} />
+                  </div>
                 </div>
                 <span className="shrink-0 text-[0.65rem] font-bold tracking-wide text-slate-600 uppercase">
                   {workItem.stateLabel}
@@ -1433,6 +1438,109 @@ function JobsCardSkeleton() {
   )
 }
 
+function WorkItemPauseButton({ workItem }: { workItem: WorkItem }) {
+  const queryClient = useQueryClient()
+  const updateWorkItem = (updated: WorkItem) => {
+    queryClient.setQueryData<readonly WorkItem[]>(
+      workItemsQuery(workItem.repositoryId).queryKey,
+      (current) =>
+        current?.map((candidate) =>
+          candidate.id === updated.id ? updated : candidate,
+        ),
+    )
+  }
+  const pause = useMutation({
+    mutationFn: async () => {
+      const result = await graphql.mutation({
+        pauseWorkItem: {
+          __args: { workItemId: workItem.id },
+          ...workItemFields,
+        },
+      })
+      return result.pauseWorkItem
+    },
+    onSuccess: updateWorkItem,
+  })
+  const start = useMutation({
+    mutationFn: async () => {
+      const result = await graphql.mutation({
+        startWorkItem: {
+          __args: { workItemId: workItem.id },
+          ...workItemFields,
+        },
+      })
+      return result.startWorkItem
+    },
+    onSuccess: updateWorkItem,
+  })
+
+  if (workItem.isTerminal) {
+    return null
+  }
+
+  const pending = pause.isPending || start.isPending
+  const failed = pause.isError || start.isError
+  const label = workItem.paused ? "Start job" : "Pause job"
+  const buttonClass = workItem.paused
+    ? "text-blue-700 hover:bg-blue-50 focus-visible:outline-blue-600"
+    : "text-amber-700 hover:bg-amber-50 focus-visible:outline-amber-600"
+
+  return (
+    <button
+      type="button"
+      className={`inline-flex size-8 shrink-0 items-center justify-center rounded-md transition focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-wait disabled:opacity-50 ${failed ? "text-red-600 hover:bg-red-50 focus-visible:outline-red-600" : buttonClass}`}
+      disabled={pending}
+      onClick={() => (workItem.paused ? start.mutate() : pause.mutate())}
+      aria-label={pending ? `${label} in progress` : label}
+      title={failed ? `Could not ${label.toLowerCase()}. Try again.` : label}
+    >
+      {pending ? (
+        <svg
+          aria-hidden="true"
+          className="size-4 animate-spin motion-reduce:animate-none"
+          viewBox="0 0 24 24"
+          fill="none"
+        >
+          <circle
+            className="opacity-25"
+            cx="12"
+            cy="12"
+            r="9"
+            stroke="currentColor"
+            strokeWidth="3"
+          />
+          <path
+            className="opacity-75"
+            d="M12 3a9 9 0 0 1 9 9"
+            stroke="currentColor"
+            strokeWidth="3"
+            strokeLinecap="round"
+          />
+        </svg>
+      ) : workItem.paused ? (
+        <svg
+          aria-hidden="true"
+          className="size-4"
+          viewBox="0 0 24 24"
+          fill="currentColor"
+        >
+          <path d="m8 5 11 7-11 7V5Z" />
+        </svg>
+      ) : (
+        <svg
+          aria-hidden="true"
+          className="size-4"
+          viewBox="0 0 24 24"
+          fill="currentColor"
+        >
+          <rect x="6" y="5" width="4" height="14" rx="1" />
+          <rect x="14" y="5" width="4" height="14" rx="1" />
+        </svg>
+      )}
+    </button>
+  )
+}
+
 function WorkItemLifecycleStatus({
   workItem,
   compact = false,
@@ -1444,6 +1552,15 @@ function WorkItemLifecycleStatus({
   const status = workItem.status
   const canRetry = compact && workItem.canRetry
   const canReset = compact
+  const patchWorkItem = (updated: WorkItem) => {
+    queryClient.setQueryData<readonly WorkItem[]>(
+      workItemsQuery(workItem.repositoryId).queryKey,
+      (current) =>
+        current?.map((candidate) =>
+          candidate.id === updated.id ? updated : candidate,
+        ),
+    )
+  }
   const retry = useMutation({
     mutationFn: async () => {
       const result = await graphql.mutation({
@@ -1454,15 +1571,7 @@ function WorkItemLifecycleStatus({
       })
       return result.retryWorkItem
     },
-    onSuccess: (retried) => {
-      queryClient.setQueryData<readonly WorkItem[]>(
-        workItemsQuery(workItem.repositoryId).queryKey,
-        (current) =>
-          current?.map((candidate) =>
-            candidate.id === retried.id ? retried : candidate,
-          ),
-      )
-    },
+    onSuccess: patchWorkItem,
   })
   const reset = useMutation({
     mutationFn: async () => {

--- a/apps/harness/test/job-worker.test.ts
+++ b/apps/harness/test/job-worker.test.ts
@@ -139,6 +139,8 @@ const queueLayer = (
       implementNow: unused,
       runStep,
       retry: unused,
+      pause: unused,
+      start: unused,
       abandon: unused,
       reset: unused,
       getWorkItem: unused,

--- a/packages/db-schema/drizzle/20260716055050_abandoned_luminals/migration.sql
+++ b/packages/db-schema/drizzle/20260716055050_abandoned_luminals/migration.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `work_item` ADD `paused` integer DEFAULT false NOT NULL;

--- a/packages/db-schema/drizzle/20260716055050_abandoned_luminals/snapshot.json
+++ b/packages/db-schema/drizzle/20260716055050_abandoned_luminals/snapshot.json
@@ -1,0 +1,1339 @@
+{
+  "version": "7",
+  "dialect": "sqlite",
+  "id": "ae6bbb8d-a935-47f5-9e01-085c5a7b9378",
+  "prevIds": [
+    "5d0e9fd6-f555-4d80-8825-915be66d2884",
+    "7ffaf71e-fa47-4068-8a25-fb704b6cc60b"
+  ],
+  "ddl": [
+    {
+      "name": "completed_job",
+      "entityType": "tables"
+    },
+    {
+      "name": "config",
+      "entityType": "tables"
+    },
+    {
+      "name": "issue",
+      "entityType": "tables"
+    },
+    {
+      "name": "issue_dependency",
+      "entityType": "tables"
+    },
+    {
+      "name": "job_queue",
+      "entityType": "tables"
+    },
+    {
+      "name": "pr_status_check",
+      "entityType": "tables"
+    },
+    {
+      "name": "repository",
+      "entityType": "tables"
+    },
+    {
+      "name": "step_run",
+      "entityType": "tables"
+    },
+    {
+      "name": "work_item",
+      "entityType": "tables"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "completed_job"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "queue",
+      "entityType": "columns",
+      "table": "completed_job"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "job_id",
+      "entityType": "columns",
+      "table": "completed_job"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "completed_job"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "completed_job"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "'default'",
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "config"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'opencode/deepseek-v4-flash-free'",
+      "generated": null,
+      "name": "default_model",
+      "entityType": "columns",
+      "table": "config"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'low'",
+      "generated": null,
+      "name": "default_variant",
+      "entityType": "columns",
+      "table": "config"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "review_model",
+      "entityType": "columns",
+      "table": "config"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "review_variant",
+      "entityType": "columns",
+      "table": "config"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "config"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "config"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "issue"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "repository_id",
+      "entityType": "columns",
+      "table": "issue"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "github_issue_number",
+      "entityType": "columns",
+      "table": "issue"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "title",
+      "entityType": "columns",
+      "table": "issue"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "body",
+      "entityType": "columns",
+      "table": "issue"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "url",
+      "entityType": "columns",
+      "table": "issue"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "state",
+      "entityType": "columns",
+      "table": "issue"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "github_created_at",
+      "entityType": "columns",
+      "table": "issue"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "parent_github_issue_number",
+      "entityType": "columns",
+      "table": "issue"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "parent_github_issue_url",
+      "entityType": "columns",
+      "table": "issue"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "parent_position",
+      "entityType": "columns",
+      "table": "issue"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "false",
+      "generated": null,
+      "name": "has_children",
+      "entityType": "columns",
+      "table": "issue"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "issue"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "issue"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "issue_dependency"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "issue_id",
+      "entityType": "columns",
+      "table": "issue_dependency"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "blocking_github_issue_number",
+      "entityType": "columns",
+      "table": "issue_dependency"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "blocking_github_issue_url",
+      "entityType": "columns",
+      "table": "issue_dependency"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "issue_dependency"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "job_queue"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "queue",
+      "entityType": "columns",
+      "table": "job_queue"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "job_payload",
+      "entityType": "columns",
+      "table": "job_queue"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "0",
+      "generated": null,
+      "name": "job_attempts",
+      "entityType": "columns",
+      "table": "job_queue"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "5",
+      "generated": null,
+      "name": "job_retry_limit",
+      "entityType": "columns",
+      "table": "job_queue"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "available_at",
+      "entityType": "columns",
+      "table": "job_queue"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "locked_until",
+      "entityType": "columns",
+      "table": "job_queue"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "job_queue"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "job_queue"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "pr_status_check"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "work_item_id",
+      "entityType": "columns",
+      "table": "pr_status_check"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "external_id",
+      "entityType": "columns",
+      "table": "pr_status_check"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "name",
+      "entityType": "columns",
+      "table": "pr_status_check"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "outcome",
+      "entityType": "columns",
+      "table": "pr_status_check"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "handled_at",
+      "entityType": "columns",
+      "table": "pr_status_check"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "observed_at",
+      "entityType": "columns",
+      "table": "pr_status_check"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "pr_status_check"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "pr_status_check"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "repository"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "github_owner",
+      "entityType": "columns",
+      "table": "repository"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "github_repo",
+      "entityType": "columns",
+      "table": "repository"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "local_path",
+      "entityType": "columns",
+      "table": "repository"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "is_bare",
+      "entityType": "columns",
+      "table": "repository"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "true",
+      "generated": null,
+      "name": "paused",
+      "entityType": "columns",
+      "table": "repository"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "default_model",
+      "entityType": "columns",
+      "table": "repository"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "default_variant",
+      "entityType": "columns",
+      "table": "repository"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "review_model",
+      "entityType": "columns",
+      "table": "repository"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "review_variant",
+      "entityType": "columns",
+      "table": "repository"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "false",
+      "generated": null,
+      "name": "auto_merge",
+      "entityType": "columns",
+      "table": "repository"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "issues_reconciled_at",
+      "entityType": "columns",
+      "table": "repository"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "repository"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "repository"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "step_run"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "work_item_id",
+      "entityType": "columns",
+      "table": "step_run"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "step",
+      "entityType": "columns",
+      "table": "step_run"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "status",
+      "entityType": "columns",
+      "table": "step_run"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "queue_job_id",
+      "entityType": "columns",
+      "table": "step_run"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "queued_at",
+      "entityType": "columns",
+      "table": "step_run"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "started_at",
+      "entityType": "columns",
+      "table": "step_run"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "finished_at",
+      "entityType": "columns",
+      "table": "step_run"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "reason_code",
+      "entityType": "columns",
+      "table": "step_run"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "reason_message",
+      "entityType": "columns",
+      "table": "step_run"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "step_run"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "step_run"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "work_item"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "repository_id",
+      "entityType": "columns",
+      "table": "work_item"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "github_issue_number",
+      "entityType": "columns",
+      "table": "work_item"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "github_pull_request_number",
+      "entityType": "columns",
+      "table": "work_item"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "model",
+      "entityType": "columns",
+      "table": "work_item"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "variant",
+      "entityType": "columns",
+      "table": "work_item"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "review_model",
+      "entityType": "columns",
+      "table": "work_item"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "review_variant",
+      "entityType": "columns",
+      "table": "work_item"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "state",
+      "entityType": "columns",
+      "table": "work_item"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "state_ready_at",
+      "entityType": "columns",
+      "table": "work_item"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "false",
+      "generated": null,
+      "name": "paused",
+      "entityType": "columns",
+      "table": "work_item"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "worktree_path",
+      "entityType": "columns",
+      "table": "work_item"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "session_id",
+      "entityType": "columns",
+      "table": "work_item"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "failure_code",
+      "entityType": "columns",
+      "table": "work_item"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "failure_message",
+      "entityType": "columns",
+      "table": "work_item"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "work_item"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "work_item"
+    },
+    {
+      "columns": [
+        "repository_id"
+      ],
+      "tableTo": "repository",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_issue_repository_id_repository_id_fk",
+      "entityType": "fks",
+      "table": "issue"
+    },
+    {
+      "columns": [
+        "issue_id"
+      ],
+      "tableTo": "issue",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_issue_dependency_issue_id_issue_id_fk",
+      "entityType": "fks",
+      "table": "issue_dependency"
+    },
+    {
+      "columns": [
+        "work_item_id"
+      ],
+      "tableTo": "work_item",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_pr_status_check_work_item_id_work_item_id_fk",
+      "entityType": "fks",
+      "table": "pr_status_check"
+    },
+    {
+      "columns": [
+        "work_item_id"
+      ],
+      "tableTo": "work_item",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_step_run_work_item_id_work_item_id_fk",
+      "entityType": "fks",
+      "table": "step_run"
+    },
+    {
+      "columns": [
+        "repository_id"
+      ],
+      "tableTo": "repository",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_work_item_repository_id_repository_id_fk",
+      "entityType": "fks",
+      "table": "work_item"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "completed_job_pk",
+      "table": "completed_job",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "config_pk",
+      "table": "config",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "issue_pk",
+      "table": "issue",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "issue_dependency_pk",
+      "table": "issue_dependency",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "job_queue_pk",
+      "table": "job_queue",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "pr_status_check_pk",
+      "table": "pr_status_check",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "repository_pk",
+      "table": "repository",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "step_run_pk",
+      "table": "step_run",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "work_item_pk",
+      "table": "work_item",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        {
+          "value": "queue",
+          "isExpression": false
+        },
+        {
+          "value": "job_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "origin": "manual",
+      "name": "completed_job_queue_job_id_uidx",
+      "entityType": "indexes",
+      "table": "completed_job"
+    },
+    {
+      "columns": [
+        {
+          "value": "repository_id",
+          "isExpression": false
+        },
+        {
+          "value": "github_issue_number",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "origin": "manual",
+      "name": "issue_repository_id_github_issue_number_uidx",
+      "entityType": "indexes",
+      "table": "issue"
+    },
+    {
+      "columns": [
+        {
+          "value": "issue_id",
+          "isExpression": false
+        },
+        {
+          "value": "blocking_github_issue_url",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "origin": "manual",
+      "name": "issue_dependency_issue_id_blocking_url_uidx",
+      "entityType": "indexes",
+      "table": "issue_dependency"
+    },
+    {
+      "columns": [
+        {
+          "value": "queue",
+          "isExpression": false
+        },
+        {
+          "value": "locked_until",
+          "isExpression": false
+        },
+        {
+          "value": "job_attempts",
+          "isExpression": false
+        },
+        {
+          "value": "available_at",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "job_queue_ready_idx",
+      "entityType": "indexes",
+      "table": "job_queue"
+    },
+    {
+      "columns": [
+        {
+          "value": "work_item_id",
+          "isExpression": false
+        },
+        {
+          "value": "external_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "origin": "manual",
+      "name": "pr_status_check_work_item_external_uidx",
+      "entityType": "indexes",
+      "table": "pr_status_check"
+    },
+    {
+      "columns": [
+        {
+          "value": "work_item_id",
+          "isExpression": false
+        },
+        {
+          "value": "handled_at",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "pr_status_check_work_item_handled_idx",
+      "entityType": "indexes",
+      "table": "pr_status_check"
+    },
+    {
+      "columns": [
+        {
+          "value": "lower(\"github_owner\")",
+          "isExpression": true
+        },
+        {
+          "value": "lower(\"github_repo\")",
+          "isExpression": true
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "origin": "manual",
+      "name": "repository_github_owner_repo_lower_uidx",
+      "entityType": "indexes",
+      "table": "repository"
+    },
+    {
+      "columns": [
+        {
+          "value": "work_item_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": "\"step_run\".\"status\" IN ('queued', 'running')",
+      "origin": "manual",
+      "name": "step_run_one_active_uidx",
+      "entityType": "indexes",
+      "table": "step_run"
+    },
+    {
+      "columns": [
+        {
+          "value": "work_item_id",
+          "isExpression": false
+        },
+        {
+          "value": "queued_at",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "step_run_work_item_id_queued_at_idx",
+      "entityType": "indexes",
+      "table": "step_run"
+    },
+    {
+      "columns": [
+        {
+          "value": "repository_id",
+          "isExpression": false
+        },
+        {
+          "value": "github_issue_number",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": "\"work_item\".\"state\" NOT IN ('complete', 'failed', 'abandoned', 'needs_human')",
+      "origin": "manual",
+      "name": "work_item_one_unfinished_v2_uidx",
+      "entityType": "indexes",
+      "table": "work_item"
+    },
+    {
+      "columns": [
+        {
+          "value": "repository_id",
+          "isExpression": false
+        },
+        {
+          "value": "github_issue_number",
+          "isExpression": false
+        },
+        {
+          "value": "created_at",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "work_item_repository_issue_created_idx",
+      "entityType": "indexes",
+      "table": "work_item"
+    },
+    {
+      "columns": [
+        "local_path"
+      ],
+      "nameExplicit": false,
+      "name": "repository_local_path_unique",
+      "entityType": "uniques",
+      "table": "repository"
+    }
+  ],
+  "renames": []
+}

--- a/packages/db-schema/src/schema.ts
+++ b/packages/db-schema/src/schema.ts
@@ -212,6 +212,7 @@ export const workItem = snakeCase.table(
       ],
     }).notNull(),
     stateReadyAt: integer({ mode: "number" }).notNull(),
+    paused: integer({ mode: "boolean" }).notNull().default(false),
     worktreePath: text(),
     sessionId: text(),
     failureCode: text(),

--- a/packages/graphql-api/src/lib/graphql-api.ts
+++ b/packages/graphql-api/src/lib/graphql-api.ts
@@ -672,9 +672,11 @@ export const createGraphqlApi = (
             statusLabel(workItemStatus(workItem)),
           statusMessage: (workItem: WorkItemRecord) =>
             workItem.failureMessage ?? latestStepRun(workItem)?.reasonMessage,
+          paused: (workItem: WorkItemRecord) => workItem.paused,
           canRetry: (workItem: WorkItemRecord) => {
             const latestStatus = latestStepRun(workItem)?.status
             return (
+              !workItem.paused &&
               !isTerminalWorkItemState(workItem.state) &&
               (latestStatus === "failed" || latestStatus === "interrupted")
             )
@@ -1003,6 +1005,34 @@ export const createGraphqlApi = (
                 Effect.gen(function* () {
                   const lifecycle = yield* WorkItemLifecycle
                   return yield* lifecycle.retry(args.workItemId)
+                }),
+              ),
+            )
+            if (Result.isFailure(result)) {
+              throw toGraphQLError(result.failure)
+            }
+            return result.success
+          },
+          pauseWorkItem: async (_parent: unknown, args: WorkItemArgs) => {
+            const result = await runtime.runPromise(
+              Effect.result(
+                Effect.gen(function* () {
+                  const lifecycle = yield* WorkItemLifecycle
+                  return yield* lifecycle.pause(args.workItemId)
+                }),
+              ),
+            )
+            if (Result.isFailure(result)) {
+              throw toGraphQLError(result.failure)
+            }
+            return result.success
+          },
+          startWorkItem: async (_parent: unknown, args: WorkItemArgs) => {
+            const result = await runtime.runPromise(
+              Effect.result(
+                Effect.gen(function* () {
+                  const lifecycle = yield* WorkItemLifecycle
+                  return yield* lifecycle.start(args.workItemId)
                 }),
               ),
             )

--- a/packages/graphql-api/test/graphql-api.test.ts
+++ b/packages/graphql-api/test/graphql-api.test.ts
@@ -74,6 +74,7 @@ const workItem = {
   reviewVariant: config.defaultVariant,
   state: "create_worktree",
   stateReadyAt: new Date("2026-07-14T08:00:00.000Z"),
+  paused: false,
   worktreePath: null,
   sessionId: null,
   failureCode: null,
@@ -181,6 +182,8 @@ const makeRuntime = (
     implementNow: unused,
     runStep: unused,
     retry: unused,
+    pause: unused,
+    start: unused,
     abandon: unused,
     reset: unused,
     getWorkItem: unused,
@@ -1072,7 +1075,7 @@ describe("GraphQL API", () => {
       graphqlRequest({
         query: `query WorkItems($repositoryId: ID!, $githubIssueNumber: Int!) {
           workItems(repositoryId: $repositoryId, githubIssueNumber: $githubIssueNumber) {
-            id state stateLabel status statusLabel statusMessage canRetry isTerminal
+            id state stateLabel status statusLabel statusMessage paused canRetry isTerminal
             stateReadyAt createdAt updatedAt
             lifecycleLabels { phase label status durationMs }
           }
@@ -1094,6 +1097,7 @@ describe("GraphQL API", () => {
             status: "RUNNING",
             statusLabel: "Running",
             statusMessage: null,
+            paused: false,
             canRetry: false,
             isTerminal: false,
             stateReadyAt: "2026-07-14T08:00:00.000Z",

--- a/packages/graphql-schema/schema.graphql
+++ b/packages/graphql-schema/schema.graphql
@@ -137,6 +137,7 @@ type WorkItem {
   status: WorkItemStatus!
   statusLabel: String!
   statusMessage: String
+  paused: Boolean!
   canRetry: Boolean!
   isTerminal: Boolean!
   stateReadyAt: String!
@@ -181,6 +182,8 @@ type Mutation {
   refreshRepository(repositoryId: ID!): RefreshJob!
   implementNow(repositoryId: ID!, githubIssueNumber: Int!): WorkItem!
   retryWorkItem(workItemId: ID!): WorkItem!
+  pauseWorkItem(workItemId: ID!): WorkItem!
+  startWorkItem(workItemId: ID!): WorkItem!
   resetWorkItem(workItemId: ID!): ID!
   updateConfig(input: UpdateConfigInput!): Config!
   updateRepositorySettings(input: UpdateRepositorySettingsInput!): Repository!

--- a/packages/work-item-lifecycle/src/lib/types.ts
+++ b/packages/work-item-lifecycle/src/lib/types.ts
@@ -76,6 +76,7 @@ export interface WorkItemRecord {
   readonly reviewVariant: string
   readonly state: WorkItemState
   readonly stateReadyAt: Date
+  readonly paused: boolean
   readonly worktreePath: string | null
   readonly sessionId: string | null
   readonly failureCode: string | null
@@ -113,6 +114,7 @@ export const STEP_RUN_REASON = {
   interrupted: "interrupted",
   abandoned: "abandoned",
   reset: "reset",
+  paused: "paused",
 } as const
 
 export type StepRunReasonCode =

--- a/packages/work-item-lifecycle/src/lib/work-item-lifecycle.ts
+++ b/packages/work-item-lifecycle/src/lib/work-item-lifecycle.ts
@@ -204,6 +204,7 @@ type WorkItemRow = {
   readonly review_variant: string
   readonly state: WorkItemState
   readonly state_ready_at: number
+  readonly paused: boolean | number
   readonly worktree_path: string | null
   readonly session_id: string | null
   readonly failure_code: string | null
@@ -271,6 +272,7 @@ const toWorkItemRecord = (
   reviewVariant: row.review_variant,
   state: row.state,
   stateReadyAt: new Date(row.state_ready_at),
+  paused: Boolean(row.paused),
   worktreePath: row.worktree_path,
   sessionId: row.session_id,
   failureCode: row.failure_code,
@@ -280,6 +282,11 @@ const toWorkItemRecord = (
   stateResidenceMs: Math.max(0, nowMs - row.state_ready_at),
   stepRuns,
 })
+
+const WORK_ITEM_SELECT_COLUMNS = `id, repository_id, github_issue_number, model, variant, review_model,
+                   review_variant, state, state_ready_at, paused, worktree_path, session_id,
+                   github_pull_request_number, failure_code,
+                   failure_message, created_at, updated_at`
 
 const PR_STATUS_CHECKS_POLL_DELAY = Duration.seconds(30)
 const PR_STATUS_CHECKS_MIN_GREEN_WAIT = Duration.seconds(60)
@@ -374,6 +381,22 @@ export type ResetError =
   | AcknowledgeError
   | JobNotFoundError
 
+export type PauseError =
+  | WorkItemNotFoundError
+  | WorkItemTerminalError
+  | WorkItemLifecycleDatabaseError
+  | AcknowledgeError
+  | JobNotFoundError
+
+export type StartError =
+  | WorkItemNotFoundError
+  | WorkItemTerminalError
+  | WorkItemLifecycleDatabaseError
+  | EnqueueError
+  | InvalidQueueNameError
+  | AcknowledgeError
+  | JobNotFoundError
+
 export type RunStepResult =
   | {
       readonly _tag: "processed"
@@ -395,6 +418,12 @@ export interface WorkItemLifecycleShape {
   readonly retry: (
     workItemId: string,
   ) => Effect.Effect<WorkItemRecord, RetryError>
+  readonly pause: (
+    workItemId: string,
+  ) => Effect.Effect<WorkItemRecord, PauseError>
+  readonly start: (
+    workItemId: string,
+  ) => Effect.Effect<WorkItemRecord, StartError>
   readonly abandon: (
     workItemId: string,
   ) => Effect.Effect<WorkItemRecord, AbandonError>
@@ -534,10 +563,7 @@ export const makeWorkItemLifecycleLive = (
         const nowMs = yield* Clock.currentTimeMillis
         const rows = (yield* sql
           .unsafe(
-            `SELECT id, repository_id, github_issue_number, model, variant, review_model,
-                   review_variant, state, state_ready_at, worktree_path, session_id,
-                   github_pull_request_number, failure_code,
-                   failure_message, created_at, updated_at
+            `SELECT ${WORK_ITEM_SELECT_COLUMNS}
            FROM work_item
            WHERE id = ?
            LIMIT 1`,
@@ -564,10 +590,7 @@ export const makeWorkItemLifecycleLive = (
         const nowMs = yield* Clock.currentTimeMillis
         const rows = (yield* sql
           .unsafe(
-            `SELECT id, repository_id, github_issue_number, model, variant, review_model,
-                   review_variant, state, state_ready_at, worktree_path, session_id,
-                   github_pull_request_number, failure_code,
-                   failure_message, created_at, updated_at
+            `SELECT ${WORK_ITEM_SELECT_COLUMNS}
            FROM work_item
            WHERE repository_id = ? AND github_issue_number = ?
            ORDER BY created_at ASC, rowid ASC`,
@@ -590,10 +613,7 @@ export const makeWorkItemLifecycleLive = (
         const nowMs = yield* Clock.currentTimeMillis
         const rows = (yield* sql
           .unsafe(
-            `SELECT id, repository_id, github_issue_number, model, variant, review_model,
-                   review_variant, state, state_ready_at, worktree_path, session_id,
-                   github_pull_request_number, failure_code,
-                   failure_message, created_at, updated_at
+            `SELECT ${WORK_ITEM_SELECT_COLUMNS}
            FROM work_item
            WHERE repository_id = ?
            ORDER BY created_at ASC, rowid ASC`,
@@ -633,10 +653,7 @@ export const makeWorkItemLifecycleLive = (
         Effect.gen(function* () {
           const rows = (yield* sql
             .unsafe(
-              `SELECT id, repository_id, github_issue_number, model, variant, review_model,
-                     review_variant, state, state_ready_at, worktree_path, session_id,
-                     github_pull_request_number, failure_code,
-                     failure_message, created_at, updated_at
+              `SELECT ${WORK_ITEM_SELECT_COLUMNS}
              FROM work_item
              WHERE id = ?
              LIMIT 1`,
@@ -1076,9 +1093,14 @@ export const makeWorkItemLifecycleLive = (
                     ],
                   )
                 } else {
-                  const nextStepRunId = makeStepRunId()
                   const stateReadyAt =
                     nextStep === workItem.state ? workItem.state_ready_at : now
+                  // Re-read: Pause may land while this Step Run was draining.
+                  const pausedRows = (yield* sql.unsafe(
+                    `SELECT paused FROM work_item WHERE id = ? LIMIT 1`,
+                    [workItem.id],
+                  )) as readonly { readonly paused: boolean | number }[]
+                  const isPaused = Boolean(pausedRows[0]?.paused)
 
                   yield* sql.unsafe(
                     `UPDATE work_item
@@ -1100,35 +1122,39 @@ export const makeWorkItemLifecycleLive = (
                     ],
                   )
 
-                  yield* sql.unsafe(
-                    `INSERT INTO step_run (
+                  if (!isPaused) {
+                    const nextStepRunId = makeStepRunId()
+
+                    yield* sql.unsafe(
+                      `INSERT INTO step_run (
                      id, work_item_id, step, status, queue_job_id, queued_at,
                      started_at, finished_at, reason_code, reason_message,
                      created_at, updated_at
                    ) VALUES (?, ?, ?, 'queued', NULL, ?, NULL, NULL, NULL, NULL, ?, ?)`,
-                    [nextStepRunId, workItem.id, nextStep, now, now, now],
-                  )
+                      [nextStepRunId, workItem.id, nextStep, now, now, now],
+                    )
 
-                  const payload = yield* encodeStepJob(nextStepRunId)
-                  const enqueue =
-                    transition?.delay === undefined
-                      ? queue.enqueue(WORK_ITEM_LIFECYCLE_QUEUE, payload, {
-                          retryLimit: 1,
-                        })
-                      : queue.enqueueWithDelay(
-                          WORK_ITEM_LIFECYCLE_QUEUE,
-                          payload,
-                          transition.delay,
-                          { retryLimit: 1 },
-                        )
-                  const jobId = yield* enqueue
+                    const payload = yield* encodeStepJob(nextStepRunId)
+                    const enqueue =
+                      transition?.delay === undefined
+                        ? queue.enqueue(WORK_ITEM_LIFECYCLE_QUEUE, payload, {
+                            retryLimit: 1,
+                          })
+                        : queue.enqueueWithDelay(
+                            WORK_ITEM_LIFECYCLE_QUEUE,
+                            payload,
+                            transition.delay,
+                            { retryLimit: 1 },
+                          )
+                    const jobId = yield* enqueue
 
-                  yield* sql.unsafe(
-                    `UPDATE step_run
+                    yield* sql.unsafe(
+                      `UPDATE step_run
                    SET queue_job_id = ?, updated_at = ?
                    WHERE id = ?`,
-                    [jobId, now, nextStepRunId],
-                  )
+                      [jobId, now, nextStepRunId],
+                    )
+                  }
                 }
 
                 if (stepRun.queue_job_id !== null) {
@@ -1317,6 +1343,7 @@ export const makeWorkItemLifecycleLive = (
                 SELECT 1 FROM work_item
                 WHERE work_item.id = step_run.work_item_id
                   AND work_item.state = step_run.step
+                  AND work_item.paused = 0
                   AND work_item.state NOT IN ('complete', 'failed', 'abandoned', 'needs_human')
               )
               AND NOT EXISTS (
@@ -1464,6 +1491,292 @@ export const makeWorkItemLifecycleLive = (
               }
               yield* Deferred.succeed(finished, undefined)
             }),
+        )
+      })
+
+      const pause = Effect.fn("WorkItemLifecycle.pause")(function* (
+        workItemId: string,
+      ) {
+        const workItem = yield* loadWorkItemRow(workItemId)
+        if (!workItem) {
+          return yield* new WorkItemNotFoundError({ workItemId })
+        }
+
+        if (isTerminalWorkItemState(workItem.state)) {
+          return yield* new WorkItemTerminalError({
+            workItemId,
+            state: workItem.state,
+          })
+        }
+
+        if (workItem.paused) {
+          return yield* getWorkItem(workItemId)
+        }
+
+        const now = yield* Clock.currentTimeMillis
+
+        yield* sql
+          .withTransaction(
+            Effect.gen(function* () {
+              const pausedRows = (yield* sql.unsafe(
+                `UPDATE work_item
+                  SET paused = 1,
+                      updated_at = ?
+                  WHERE id = ?
+                    AND state NOT IN ('complete', 'failed', 'abandoned', 'needs_human')
+                  RETURNING id`,
+                [now, workItemId],
+              )) as readonly { readonly id: string }[]
+
+              if (!pausedRows[0]) {
+                const current = yield* loadWorkItemRow(workItemId)
+                if (!current) {
+                  return yield* new WorkItemNotFoundError({ workItemId })
+                }
+                if (isTerminalWorkItemState(current.state)) {
+                  return yield* new WorkItemTerminalError({
+                    workItemId,
+                    state: current.state,
+                  })
+                }
+              }
+
+              const cancelledRows = (yield* sql.unsafe(
+                `UPDATE step_run
+                 SET status = 'cancelled',
+                     finished_at = ?,
+                     reason_code = ?,
+                     reason_message = ?,
+                     updated_at = ?
+                 WHERE work_item_id = ? AND status = 'queued'
+                 RETURNING queue_job_id`,
+                [
+                  now,
+                  STEP_RUN_REASON.paused,
+                  "Work Item was paused before the Step Run started",
+                  now,
+                  workItemId,
+                ],
+              )) as readonly { readonly queue_job_id: string | null }[]
+
+              for (const cancelled of cancelledRows) {
+                if (cancelled.queue_job_id !== null) {
+                  yield* queue
+                    .acknowledge(cancelled.queue_job_id)
+                    .pipe(
+                      Effect.catchTag("JobNotFoundError", () => Effect.void),
+                    )
+                }
+              }
+            }),
+          )
+          .pipe(
+            Effect.catch((error): Effect.Effect<never, PauseError> => {
+              if (
+                error instanceof WorkItemNotFoundError ||
+                error instanceof WorkItemTerminalError
+              ) {
+                return Effect.fail(error)
+              }
+              if (error instanceof WorkItemLifecycleDatabaseError) {
+                return Effect.fail(error)
+              }
+              if (
+                typeof error === "object" &&
+                error !== null &&
+                "_tag" in error &&
+                (error as { _tag: string })._tag === "SqlError"
+              ) {
+                return Effect.fail(toDatabaseError(error as SqlError))
+              }
+              if (
+                typeof error === "object" &&
+                error !== null &&
+                "_tag" in error &&
+                ((error as { _tag: string })._tag === "AcknowledgeError" ||
+                  (error as { _tag: string })._tag === "JobNotFoundError")
+              ) {
+                return Effect.fail(
+                  error as unknown as AcknowledgeError | JobNotFoundError,
+                )
+              }
+              return Effect.fail(
+                new WorkItemLifecycleDatabaseError({
+                  message: `Unexpected transaction failure: ${String(error)}`,
+                  cause: error,
+                }),
+              )
+            }),
+          )
+
+        return yield* getWorkItem(workItemId).pipe(
+          Effect.catchTag(
+            "WorkItemNotFoundError",
+            (error) =>
+              new WorkItemLifecycleDatabaseError({
+                message: `Work Item missing after pause: ${error.workItemId}`,
+                cause: error,
+              }),
+          ),
+        )
+      })
+
+      const start = Effect.fn("WorkItemLifecycle.start")(function* (
+        workItemId: string,
+      ) {
+        const workItem = yield* loadWorkItemRow(workItemId)
+        if (!workItem) {
+          return yield* new WorkItemNotFoundError({ workItemId })
+        }
+
+        if (isTerminalWorkItemState(workItem.state)) {
+          return yield* new WorkItemTerminalError({
+            workItemId,
+            state: workItem.state,
+          })
+        }
+
+        if (!workItem.paused) {
+          return yield* getWorkItem(workItemId)
+        }
+
+        const now = yield* Clock.currentTimeMillis
+        yield* sql
+          .withTransaction(
+            Effect.gen(function* () {
+              const startedRows = (yield* sql.unsafe(
+                `UPDATE work_item
+                  SET paused = 0,
+                      updated_at = ?
+                  WHERE id = ?
+                    AND paused = 1
+                    AND state NOT IN ('complete', 'failed', 'abandoned', 'needs_human')
+                  RETURNING id, state`,
+                [now, workItemId],
+              )) as readonly {
+                readonly id: string
+                readonly state: OperationalLifecycleStep
+              }[]
+
+              if (!startedRows[0]) {
+                const current = yield* loadWorkItemRow(workItemId)
+                if (!current) {
+                  return yield* new WorkItemNotFoundError({ workItemId })
+                }
+                if (isTerminalWorkItemState(current.state)) {
+                  return yield* new WorkItemTerminalError({
+                    workItemId,
+                    state: current.state,
+                  })
+                }
+                return
+              }
+
+              const pendingStep = startedRows[0].state
+
+              const activeRows = (yield* sql.unsafe(
+                `SELECT id FROM step_run
+                 WHERE work_item_id = ?
+                   AND status IN ('queued', 'running')
+                 LIMIT 1`,
+                [workItemId],
+              )) as readonly { readonly id: string }[]
+              if (activeRows[0]) {
+                return
+              }
+
+              const latestRows = (yield* sql.unsafe(
+                `SELECT status FROM step_run
+                 WHERE work_item_id = ?
+                   AND step = ?
+                 ORDER BY queued_at DESC, id DESC
+                 LIMIT 1`,
+                [workItemId, pendingStep],
+              )) as readonly { readonly status: string }[]
+              const latestStatus = latestRows[0]?.status
+              if (latestStatus === "failed" || latestStatus === "interrupted") {
+                return
+              }
+
+              const nextStepRunId = makeStepRunId()
+              yield* sql.unsafe(
+                `INSERT INTO step_run (
+                 id, work_item_id, step, status, queue_job_id, queued_at,
+                 started_at, finished_at, reason_code, reason_message,
+                 created_at, updated_at
+               ) VALUES (?, ?, ?, 'queued', NULL, ?, NULL, NULL, NULL, NULL, ?, ?)`,
+                [nextStepRunId, workItemId, pendingStep, now, now, now],
+              )
+
+              const payload = yield* encodeStepJob(nextStepRunId)
+              const jobId = yield* queue.enqueue(
+                WORK_ITEM_LIFECYCLE_QUEUE,
+                payload,
+                { retryLimit: 1 },
+              )
+
+              yield* sql.unsafe(
+                `UPDATE step_run
+               SET queue_job_id = ?, updated_at = ?
+               WHERE id = ?`,
+                [jobId, now, nextStepRunId],
+              )
+            }),
+          )
+          .pipe(
+            Effect.catch((error): Effect.Effect<never, StartError> => {
+              if (
+                error instanceof WorkItemNotFoundError ||
+                error instanceof WorkItemTerminalError
+              ) {
+                return Effect.fail(error)
+              }
+              if (error instanceof WorkItemLifecycleDatabaseError) {
+                return Effect.fail(error)
+              }
+              if (error instanceof EnqueueError) {
+                return Effect.fail(error)
+              }
+              if (error instanceof InvalidQueueNameError) {
+                return Effect.fail(error)
+              }
+              if (
+                typeof error === "object" &&
+                error !== null &&
+                "_tag" in error &&
+                (error as { _tag: string })._tag === "SqlError"
+              ) {
+                return Effect.fail(toDatabaseError(error as SqlError))
+              }
+              if (
+                typeof error === "object" &&
+                error !== null &&
+                "_tag" in error &&
+                ((error as { _tag: string })._tag === "AcknowledgeError" ||
+                  (error as { _tag: string })._tag === "JobNotFoundError")
+              ) {
+                return Effect.fail(
+                  error as unknown as AcknowledgeError | JobNotFoundError,
+                )
+              }
+              return Effect.fail(
+                new WorkItemLifecycleDatabaseError({
+                  message: `Unexpected transaction failure: ${String(error)}`,
+                  cause: error,
+                }),
+              )
+            }),
+          )
+
+        return yield* getWorkItem(workItemId).pipe(
+          Effect.catchTag(
+            "WorkItemNotFoundError",
+            (error) =>
+              new WorkItemLifecycleDatabaseError({
+                message: `Work Item missing after start: ${error.workItemId}`,
+                cause: error,
+              }),
+          ),
         )
       })
 
@@ -1793,6 +2106,13 @@ export const makeWorkItemLifecycleLive = (
           })
         }
 
+        if (workItem.paused) {
+          return yield* new RetryNotEligibleError({
+            workItemId,
+            reason: "paused",
+          })
+        }
+
         const pendingStep = workItem.state as OperationalLifecycleStep
 
         const activeRows = (yield* sql
@@ -2022,10 +2342,10 @@ export const makeWorkItemLifecycleLive = (
                 yield* sql.unsafe(
                   `INSERT INTO work_item (
                  id, repository_id, github_issue_number, model, variant,
-                 review_model, review_variant, state, state_ready_at,
+                 review_model, review_variant, state, state_ready_at, paused,
                  worktree_path, session_id, failure_code, failure_message,
                  created_at, updated_at
-               ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, NULL, NULL, NULL, NULL, ?, ?)`,
+               ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 0, NULL, NULL, NULL, NULL, ?, ?)`,
                   [
                     workItemId,
                     repositoryId,
@@ -2121,6 +2441,8 @@ export const makeWorkItemLifecycleLive = (
         implementNow,
         runStep,
         retry,
+        pause,
+        start,
         abandon,
         reset,
         getWorkItem,

--- a/packages/work-item-lifecycle/test/work-item-lifecycle.spec.ts
+++ b/packages/work-item-lifecycle/test/work-item-lifecycle.spec.ts
@@ -3471,4 +3471,194 @@ describe("WorkItemLifecycle", () => {
         }),
       ))
   })
+
+  describe("pause and start", () => {
+    const claimAndRunPending = Effect.gen(function* () {
+      const lifecycle = yield* WorkItemLifecycle
+      const queue = yield* QueueService
+      const claimed = yield* queue.rawClaim(WORK_ITEM_LIFECYCLE_QUEUE)
+      expect(Option.isSome(claimed)).toBe(true)
+      if (Option.isNone(claimed)) {
+        return yield* Effect.die("expected a queued lifecycle job")
+      }
+      const payload = claimed.value.payload as { stepRunId: string }
+      return yield* lifecycle.runStep(payload.stepRunId)
+    })
+
+    it("marks a Work Item paused and cancels queued Step Runs", () =>
+      runTest(
+        Effect.gen(function* () {
+          const lifecycle = yield* WorkItemLifecycle
+          const queue = yield* QueueService
+          const { repository, issue } = yield* seedActionableIssue
+
+          const created = yield* lifecycle.implementNow(
+            repository.id,
+            issue.githubIssueNumber,
+          )
+          expect(created.paused).toBe(false)
+          expect(created.stepRuns[0]!.status).toBe("queued")
+
+          const paused = yield* lifecycle.pause(created.id)
+          expect(paused.paused).toBe(true)
+          expect(paused.stepRuns).toHaveLength(1)
+          expect(paused.stepRuns[0]!.status).toBe("cancelled")
+          expect(paused.stepRuns[0]!.reasonCode).toBe(STEP_RUN_REASON.paused)
+
+          const remaining = yield* queue.rawClaim(WORK_ITEM_LIFECYCLE_QUEUE)
+          expect(Option.isNone(remaining)).toBe(true)
+
+          const again = yield* lifecycle.pause(created.id)
+          expect(again.paused).toBe(true)
+        }),
+      ))
+
+    it("starts a paused Work Item and enqueues the current Lifecycle Step", () =>
+      runTest(
+        Effect.gen(function* () {
+          const lifecycle = yield* WorkItemLifecycle
+          const { repository, issue } = yield* seedActionableIssue
+
+          const created = yield* lifecycle.implementNow(
+            repository.id,
+            issue.githubIssueNumber,
+          )
+          yield* lifecycle.pause(created.id)
+
+          const started = yield* lifecycle.start(created.id)
+          expect(started.paused).toBe(false)
+          expect(started.state).toBe("create_worktree")
+          expect(started.stepRuns.map((run) => run.status)).toEqual([
+            "cancelled",
+            "queued",
+          ])
+          expect(started.stepRuns[1]!.step).toBe("create_worktree")
+
+          const idle = yield* lifecycle.start(created.id)
+          expect(idle.paused).toBe(false)
+          expect(idle.stepRuns).toHaveLength(2)
+        }),
+      ))
+
+    it("advances state while paused without enqueueing the next Step Run", async () => {
+      const started = await Effect.runPromise(Deferred.make<void>())
+      const release = await Effect.runPromise(Deferred.make<void>())
+      const steps: LifecycleStepsShape = {
+        ...successfulSteps,
+        createWorktree: () =>
+          Deferred.succeed(started, undefined).pipe(
+            Effect.andThen(Deferred.await(release)),
+            Effect.as("/tmp/worktrees/paused-drain"),
+          ),
+      }
+
+      return runWithSteps(
+        steps,
+        Effect.gen(function* () {
+          const lifecycle = yield* WorkItemLifecycle
+          const queue = yield* QueueService
+          const { repository, issue } = yield* seedActionableIssue
+
+          const created = yield* lifecycle.implementNow(
+            repository.id,
+            issue.githubIssueNumber,
+          )
+          const stepRunId = created.stepRuns[0]!.id
+
+          const fiber = yield* Effect.forkChild(lifecycle.runStep(stepRunId))
+          yield* Deferred.await(started)
+
+          const paused = yield* lifecycle.pause(created.id)
+          expect(paused.paused).toBe(true)
+          expect(
+            paused.stepRuns.find((run) => run.id === stepRunId)?.status,
+          ).toBe("running")
+
+          yield* Deferred.succeed(release, undefined)
+          const result = yield* Fiber.join(fiber)
+          expect(result._tag).toBe("processed")
+          if (result._tag === "processed") {
+            expect(result.workItem.paused).toBe(true)
+            expect(result.workItem.state).toBe("install_dependencies")
+            expect(
+              result.workItem.stepRuns.map((run) => [run.step, run.status]),
+            ).toEqual([["create_worktree", "succeeded"]])
+          }
+
+          const remaining = yield* queue.rawClaim(WORK_ITEM_LIFECYCLE_QUEUE)
+          expect(Option.isNone(remaining)).toBe(true)
+
+          const afterStart = yield* lifecycle.start(created.id)
+          expect(afterStart.paused).toBe(false)
+          expect(afterStart.state).toBe("install_dependencies")
+          expect(afterStart.stepRuns.at(-1)).toMatchObject({
+            step: "install_dependencies",
+            status: "queued",
+          })
+        }),
+      )
+    })
+
+    it("rejects Retry while paused and allows it after Start", () => {
+      const steps: LifecycleStepsShape = {
+        ...successfulSteps,
+        createWorktree: () => Effect.fail(new Error("fail for retry")),
+      }
+
+      return runWithSteps(
+        steps,
+        Effect.gen(function* () {
+          const lifecycle = yield* WorkItemLifecycle
+          const { repository, issue } = yield* seedActionableIssue
+
+          const created = yield* lifecycle.implementNow(
+            repository.id,
+            issue.githubIssueNumber,
+          )
+          yield* claimAndRunPending
+          yield* lifecycle.pause(created.id)
+
+          const blocked = yield* Effect.flip(lifecycle.retry(created.id))
+          expect(blocked).toBeInstanceOf(RetryNotEligibleError)
+          if (blocked instanceof RetryNotEligibleError) {
+            expect(blocked.reason).toBe("paused")
+          }
+
+          const started = yield* lifecycle.start(created.id)
+          expect(started.paused).toBe(false)
+          // failed latest still needs explicit Retry after Start
+          expect(started.stepRuns.every((run) => run.status !== "queued")).toBe(
+            true,
+          )
+
+          const retried = yield* lifecycle.retry(created.id)
+          expect(retried.stepRuns.at(-1)?.status).toBe("queued")
+        }),
+      )
+    })
+
+    it("rejects pause and start for terminal Work Items", () =>
+      runTest(
+        Effect.gen(function* () {
+          const lifecycle = yield* WorkItemLifecycle
+          const sql = yield* SqlClient.SqlClient
+          const { repository, issue } = yield* seedActionableIssue
+
+          const created = yield* lifecycle.implementNow(
+            repository.id,
+            issue.githubIssueNumber,
+          )
+          yield* sql.unsafe(
+            `UPDATE work_item SET state = 'complete', updated_at = ? WHERE id = ?`,
+            [Date.now(), created.id],
+          )
+
+          const pauseError = yield* Effect.flip(lifecycle.pause(created.id))
+          expect(pauseError).toBeInstanceOf(WorkItemTerminalError)
+
+          const startError = yield* Effect.flip(lifecycle.start(created.id))
+          expect(startError).toBeInstanceOf(WorkItemTerminalError)
+        }),
+      ))
+  })
 })


### PR DESCRIPTION
## Summary
- add durable per-Work Item Pause and Start operations
- let running Step Runs drain while preventing subsequent lifecycle work from starting
- cancel queued Step Runs on Pause and enqueue the current step safely on Start
- expose Pause/Start through GraphQL and an icon toggle beside each job issue
- document the domain language and add the paused database migration

## Testing
- `bunx nx affected -t lint,typecheck,test --base=origin/main`
- 190 Work Item lifecycle tests
- 35 GraphQL API tests
- 41 Harness tests

Nx reports the existing Work Item lifecycle timing test as flaky; the affected check completed successfully.