### PR TITLE
feat(work-item-lifecycle): report review fixes

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -108,7 +108,7 @@ An individual GitHub check run or commit status context associated with a pull r
 _Avoid_: Aggregate status-check rollup, workflow run
 
 **Status Check Handoff**:
-A durable batch of previously unhandled green and red PR Status Checks given to the Work Item's Implement Session by Investigate PR Status Checks. The prompt names red checks to diagnose and fix; when any check is green, it also asks OpenCode to inspect the latest pull-request review comments, disregard reviews that are visibly still in progress, and address worthwhile completed feedback.
+A durable batch of previously unhandled green and red PR Status Checks given to the Work Item's Implement Session by Investigate PR Status Checks. The prompt names red checks to diagnose and fix; when any check is green, it also asks OpenCode to inspect the latest pull-request review comments, disregard reviews that are visibly still in progress, and address worthwhile completed feedback. If processing the handoff produces a commit, OpenCode pushes it and comments on the existing pull request with the commit, verification, feedback addressed, and feedback declined with reasons.
 _Avoid_: Check classification, one prompt per check
 
 **Merge Conflict Handoff**:

--- a/packages/work-item-lifecycle/src/lib/pr-status-checks.ts
+++ b/packages/work-item-lifecycle/src/lib/pr-status-checks.ts
@@ -219,9 +219,12 @@ const buildInvestigationWorkPrompt = (
   if (hasGreen) {
     lines.push(
       "One or more automated reviews may have completed. Inspect the latest pull-request comments, disregard reviews that are visibly still in progress, and address worthwhile completed feedback.",
+      "If review feedback requires changes, verify them, commit them, and push the commit to the existing PR branch.",
     )
   }
   lines.push(
+    "If you create a commit during this handoff, after pushing it post one comment on the existing pull request that includes the commit SHA, summarizes the changes and verification, identifies the review feedback addressed, and lists any review feedback declined with a brief reason (or says none was declined).",
+    "Do not post this summary comment when you did not create a commit.",
     "Do not create or merge another pull request.",
     "When finished, stop. Do not print a READY_FOR_AGENT_RESULT line yet; a follow-up turn will ask for the verdict.",
   )

--- a/packages/work-item-lifecycle/test/pr-status-checks.spec.ts
+++ b/packages/work-item-lifecycle/test/pr-status-checks.spec.ts
@@ -396,6 +396,18 @@ describe("PR status check steps", () => {
     expect(prompts[0]).toContain(
       "disregard reviews that are visibly still in progress",
     )
+    expect(prompts[0]).toContain(
+      "If review feedback requires changes, verify them, commit them, and push the commit",
+    )
+    expect(prompts[0]).toContain(
+      "post one comment on the existing pull request that includes the commit SHA",
+    )
+    expect(prompts[0]).toContain(
+      "lists any review feedback declined with a brief reason",
+    )
+    expect(prompts[0]).toContain(
+      "Do not post this summary comment when you did not create a commit",
+    )
   })
 
   it("returns OpenCode's structured human intervention reason", async () => {


### PR DESCRIPTION
## Why

When OpenCode commits changes while processing PR status checks and automated review feedback, the pull request currently receives no durable explanation of what changed or which suggestions were rejected. Reviewers therefore cannot easily connect a follow-up commit to the feedback decision.

## What Changed

- Require review-driven changes to be verified, committed, and pushed to the existing PR branch.
- Require one follow-up PR comment after a handoff creates a commit, including the commit SHA, verification, feedback addressed, and feedback declined with reasons.
- Avoid posting the summary when the handoff creates no commit.
- Document the behavior in the Status Check Handoff domain definition and cover the prompt contract in tests.

## Verification

The review-response workflow was exercised in [test-ready-for-agent#20](https://github.com/berenddeboer/test-ready-for-agent/pull/20): an automated review identified an intentionally permissive parser, OpenCode pushed a correction, posted accepted and declined feedback, and the second automated review completed successfully.
