### PR TITLE
feat(repository): pause and unpause via settings-only operations

### DIFF
--- a/apps/harness/src/routes/index.tsx
+++ b/apps/harness/src/routes/index.tsx
@@ -653,6 +653,55 @@ function RepositoryCard({
     },
   })
 
+  const updateRepositoryPaused = (updated: { id: string; paused: boolean }) => {
+    queryClient.setQueryData<readonly Repository[]>(
+      repositoriesQuery.queryKey,
+      (repositories) =>
+        repositories?.map((candidate) =>
+          candidate.id === updated.id
+            ? { ...candidate, paused: updated.paused }
+            : candidate,
+        ),
+    )
+  }
+
+  const pauseRepository = useMutation({
+    mutationFn: async () => {
+      const result = await graphql.mutation({
+        pauseRepository: {
+          __args: { repositoryId: repository.id },
+          id: true,
+          paused: true,
+        },
+      })
+      return result.pauseRepository
+    },
+    onSuccess: updateRepositoryPaused,
+  })
+
+  const unpauseRepository = useMutation({
+    mutationFn: async () => {
+      const result = await graphql.mutation({
+        unpauseRepository: {
+          __args: { repositoryId: repository.id },
+          id: true,
+          paused: true,
+        },
+      })
+      return result.unpauseRepository
+    },
+    onSuccess: updateRepositoryPaused,
+  })
+
+  const pausePending = pauseRepository.isPending || unpauseRepository.isPending
+  const pauseFailed = pauseRepository.isError || unpauseRepository.isError
+  const pauseLabel = repository.paused
+    ? "Unpause repository"
+    : "Pause repository"
+  const pauseButtonClass = repository.paused
+    ? "text-blue-700 hover:bg-blue-50 focus-visible:outline-blue-600"
+    : "text-amber-700 hover:bg-amber-50 focus-visible:outline-amber-600"
+
   return (
     <article className="relative min-w-0 rounded-[0.9rem] border border-[#dbe3ef] bg-white p-[1.35rem] shadow-[0_10px_30px_rgb(15_23_42_/_5%)]">
       <div className="mb-[1.4rem] flex items-center justify-between gap-4">
@@ -665,13 +714,55 @@ function RepositoryCard({
           </a>
         </h2>
         <div className="flex shrink-0 items-center gap-1">
-          {repository.paused && (
-            <button
-              type="button"
-              className="inline-flex size-8 items-center justify-center rounded-md text-amber-700 hover:bg-amber-50 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-amber-600"
-              aria-label="Paused"
-              title="Paused"
-            >
+          <button
+            type="button"
+            className={`inline-flex size-8 items-center justify-center rounded-md transition focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-wait disabled:opacity-50 ${pauseFailed ? "text-red-600 hover:bg-red-50 focus-visible:outline-red-600" : pauseButtonClass}`}
+            disabled={pausePending}
+            onClick={() =>
+              repository.paused
+                ? unpauseRepository.mutate()
+                : pauseRepository.mutate()
+            }
+            aria-label={pausePending ? `${pauseLabel} in progress` : pauseLabel}
+            title={
+              pauseFailed
+                ? `Could not ${pauseLabel.toLowerCase()}. Try again.`
+                : pauseLabel
+            }
+          >
+            {pausePending ? (
+              <svg
+                aria-hidden="true"
+                className="size-4 animate-spin motion-reduce:animate-none"
+                viewBox="0 0 24 24"
+                fill="none"
+              >
+                <circle
+                  className="opacity-25"
+                  cx="12"
+                  cy="12"
+                  r="9"
+                  stroke="currentColor"
+                  strokeWidth="3"
+                />
+                <path
+                  className="opacity-75"
+                  d="M12 3a9 9 0 0 1 9 9"
+                  stroke="currentColor"
+                  strokeWidth="3"
+                  strokeLinecap="round"
+                />
+              </svg>
+            ) : repository.paused ? (
+              <svg
+                aria-hidden="true"
+                className="size-4"
+                viewBox="0 0 24 24"
+                fill="currentColor"
+              >
+                <path d="m8 5 11 7-11 7V5Z" />
+              </svg>
+            ) : (
               <svg
                 aria-hidden="true"
                 className="size-4"
@@ -681,8 +772,8 @@ function RepositoryCard({
                 <rect x="6" y="5" width="4" height="14" rx="1" />
                 <rect x="14" y="5" width="4" height="14" rx="1" />
               </svg>
-            </button>
-          )}
+            )}
+          </button>
           <span className="relative" data-repo-menu={repository.id}>
             <button
               type="button"

--- a/packages/db-service/src/lib/db-service.ts
+++ b/packages/db-service/src/lib/db-service.ts
@@ -228,6 +228,12 @@ export interface DbServiceShape {
     RepositoryRecord,
     InvalidRepositorySettingsError | RepositoryNotFoundError | DatabaseError
   >
+  readonly pauseRepository: (
+    repositoryId: string,
+  ) => Effect.Effect<RepositoryRecord, RepositoryNotFoundError | DatabaseError>
+  readonly unpauseRepository: (
+    repositoryId: string,
+  ) => Effect.Effect<RepositoryRecord, RepositoryNotFoundError | DatabaseError>
   readonly listRepositories: Effect.Effect<
     readonly RepositoryRecord[],
     DatabaseError
@@ -578,6 +584,50 @@ export const DbServiceLive = Layer.effect(
         yield* publishRepositoryChanged()
         return repository
       })
+
+    const setRepositoryPaused = (
+      repositoryId: string,
+      paused: boolean,
+    ): Effect.Effect<
+      RepositoryRecord,
+      RepositoryNotFoundError | DatabaseError
+    > =>
+      Effect.gen(function* () {
+        const now = Date.now()
+        const result = yield* sql
+          .unsafe(
+            `UPDATE repository
+             SET paused = ?,
+                 updated_at = ?
+             WHERE id = ?
+             RETURNING ${repositorySelectColumns}`,
+            [paused, now, repositoryId],
+          )
+          .pipe(Effect.mapError(toDatabaseError))
+
+        const row = result[0] as RepositoryRow | undefined
+        if (!row) {
+          return yield* new RepositoryNotFoundError({ repositoryId })
+        }
+
+        const repository = toRecordFromRow(row)
+        yield* publishRepositoryChanged()
+        return repository
+      })
+
+    const pauseRepository = (
+      repositoryId: string,
+    ): Effect.Effect<
+      RepositoryRecord,
+      RepositoryNotFoundError | DatabaseError
+    > => setRepositoryPaused(repositoryId, true)
+
+    const unpauseRepository = (
+      repositoryId: string,
+    ): Effect.Effect<
+      RepositoryRecord,
+      RepositoryNotFoundError | DatabaseError
+    > => setRepositoryPaused(repositoryId, false)
 
     const listRepositories: Effect.Effect<
       readonly RepositoryRecord[],
@@ -1093,6 +1143,8 @@ export const DbServiceLive = Layer.effect(
       updateConfig,
       addRepository,
       updateRepositorySettings,
+      pauseRepository,
+      unpauseRepository,
       listRepositories,
       removeRepository,
       storeIssue,

--- a/packages/db-service/src/lib/test-fixtures.ts
+++ b/packages/db-service/src/lib/test-fixtures.ts
@@ -32,6 +32,8 @@ export const stubDbService = (
   updateConfig: unused,
   addRepository: unused,
   updateRepositorySettings: unused,
+  pauseRepository: unused,
+  unpauseRepository: unused,
   listRepositories: unused(),
   removeRepository: unused,
   storeIssue: unused,

--- a/packages/db-service/test/db-service.spec.ts
+++ b/packages/db-service/test/db-service.spec.ts
@@ -306,6 +306,114 @@ describe("DbService", () => {
       ))
   })
 
+  describe("pauseRepository and unpauseRepository", () => {
+    it("unpauses a Repository without changing other settings", () =>
+      runTest(
+        Effect.gen(function* () {
+          const db = yield* DbService
+          const repo = yield* db.addRepository(sampleInput)
+          yield* db.updateRepositorySettings({
+            repositoryId: repo.id,
+            paused: true,
+            defaultModel: "anthropic/claude-sonnet-4-5",
+            defaultVariant: "high",
+            reviewModel: "anthropic/claude-opus-4-6",
+            reviewVariant: "max",
+            autoMerge: true,
+          })
+
+          const unpaused = yield* db.unpauseRepository(repo.id)
+
+          expect(unpaused).toEqual({
+            ...repo,
+            paused: false,
+            defaultModel: "anthropic/claude-sonnet-4-5",
+            defaultVariant: "high",
+            reviewModel: "anthropic/claude-opus-4-6",
+            reviewVariant: "max",
+            autoMerge: true,
+          })
+          expect(yield* db.listRepositories).toEqual([unpaused])
+        }),
+      ))
+
+    it("pauses a Repository without changing other settings", () =>
+      runTest(
+        Effect.gen(function* () {
+          const db = yield* DbService
+          const repo = yield* db.addRepository(sampleInput)
+          const configured = yield* db.updateRepositorySettings({
+            repositoryId: repo.id,
+            paused: false,
+            defaultModel: "anthropic/claude-sonnet-4-5",
+            defaultVariant: "high",
+            reviewModel: "anthropic/claude-opus-4-6",
+            reviewVariant: "max",
+            autoMerge: true,
+          })
+
+          const paused = yield* db.pauseRepository(repo.id)
+
+          expect(paused).toEqual({
+            ...configured,
+            paused: true,
+          })
+          expect(yield* db.listRepositories).toEqual([paused])
+        }),
+      ))
+
+    it("is idempotent when already paused or unpaused", () =>
+      runTest(
+        Effect.gen(function* () {
+          const db = yield* DbService
+          const repo = yield* db.addRepository(sampleInput)
+
+          const stillPaused = yield* db.pauseRepository(repo.id)
+          expect(stillPaused.paused).toBe(true)
+
+          const unpaused = yield* db.unpauseRepository(repo.id)
+          const stillUnpaused = yield* db.unpauseRepository(repo.id)
+          expect(stillUnpaused).toEqual(unpaused)
+          expect(stillUnpaused.paused).toBe(false)
+        }),
+      ))
+
+    it("rejects unknown repositories", () =>
+      runTest(
+        Effect.gen(function* () {
+          const db = yield* DbService
+          const missingId = "repo-01J00000000000000000000000"
+
+          const pauseError = yield* Effect.flip(db.pauseRepository(missingId))
+          expect(pauseError).toBeInstanceOf(RepositoryNotFoundError)
+
+          const unpauseError = yield* Effect.flip(
+            db.unpauseRepository(missingId),
+          )
+          expect(unpauseError).toBeInstanceOf(RepositoryNotFoundError)
+        }),
+      ))
+
+    it("publishes repository changes", () =>
+      runTest(
+        Effect.gen(function* () {
+          const db = yield* DbService
+          const repo = yield* db.addRepository(sampleInput)
+          const changes = yield* db.repositoryChanges.pipe(
+            Stream.take(2),
+            Stream.runCollect,
+            Effect.forkChild,
+          )
+          yield* Effect.yieldNow
+
+          yield* db.unpauseRepository(repo.id)
+          yield* db.pauseRepository(repo.id)
+
+          expect(yield* Fiber.join(changes)).toEqual([undefined, undefined])
+        }),
+      ))
+  })
+
   describe("listRepositories", () => {
     it("returns an empty list when none exist", () =>
       runTest(

--- a/packages/graphql-api/src/lib/graphql-api.ts
+++ b/packages/graphql-api/src/lib/graphql-api.ts
@@ -776,6 +776,40 @@ export const createGraphqlApi = (
             }
             return result.success
           },
+          pauseRepository: async (
+            _parent: unknown,
+            args: RefreshRepositoryArgs,
+          ) => {
+            const result = await runtime.runPromise(
+              Effect.result(
+                Effect.gen(function* () {
+                  const db = yield* DbService
+                  return yield* db.pauseRepository(args.repositoryId)
+                }),
+              ),
+            )
+            if (Result.isFailure(result)) {
+              throw toGraphQLError(result.failure)
+            }
+            return result.success
+          },
+          unpauseRepository: async (
+            _parent: unknown,
+            args: RefreshRepositoryArgs,
+          ) => {
+            const result = await runtime.runPromise(
+              Effect.result(
+                Effect.gen(function* () {
+                  const db = yield* DbService
+                  return yield* db.unpauseRepository(args.repositoryId)
+                }),
+              ),
+            )
+            if (Result.isFailure(result)) {
+              throw toGraphQLError(result.failure)
+            }
+            return result.success
+          },
           addRepository: async (_parent: unknown, args: AddRepositoryArgs) => {
             const result = await runtime.runPromise(
               Effect.result(

--- a/packages/graphql-api/test/graphql-api.test.ts
+++ b/packages/graphql-api/test/graphql-api.test.ts
@@ -849,6 +849,65 @@ describe("GraphQL API", () => {
     })
   })
 
+  test("pauses and unpauses a repository", async () => {
+    await runtime.dispose()
+    runtime = makeRuntime({
+      pauseRepository: (repositoryId) =>
+        Effect.succeed({
+          ...repository,
+          id: repositoryId,
+          paused: true,
+        }),
+      unpauseRepository: (repositoryId) =>
+        Effect.succeed({
+          ...repository,
+          id: repositoryId,
+          paused: false,
+        }),
+    })
+
+    const api = createGraphqlApi(runtime)
+    const paused = await api.fetch(
+      graphqlRequest({
+        query: `mutation PauseRepository($repositoryId: ID!) {
+          pauseRepository(repositoryId: $repositoryId) {
+            id
+            paused
+          }
+        }`,
+        variables: { repositoryId: repository.id },
+      }),
+    )
+    expect(await paused.json()).toEqual({
+      data: {
+        pauseRepository: {
+          id: repository.id,
+          paused: true,
+        },
+      },
+    })
+
+    const unpaused = await api.fetch(
+      graphqlRequest({
+        query: `mutation UnpauseRepository($repositoryId: ID!) {
+          unpauseRepository(repositoryId: $repositoryId) {
+            id
+            paused
+          }
+        }`,
+        variables: { repositoryId: repository.id },
+      }),
+    )
+    expect(await unpaused.json()).toEqual({
+      data: {
+        unpauseRepository: {
+          id: repository.id,
+          paused: false,
+        },
+      },
+    })
+  })
+
   test("lists models provided by OpenCode and caches the result", async () => {
     let listCount = 0
     await runtime.dispose()

--- a/packages/graphql-schema/schema.graphql
+++ b/packages/graphql-schema/schema.graphql
@@ -187,6 +187,8 @@ type Mutation {
   resetWorkItem(workItemId: ID!): ID!
   updateConfig(input: UpdateConfigInput!): Config!
   updateRepositorySettings(input: UpdateRepositorySettingsInput!): Repository!
+  pauseRepository(repositoryId: ID!): Repository!
+  unpauseRepository(repositoryId: ID!): Repository!
 }
 
 type Subscription {


### PR DESCRIPTION
## Why

Operators need a first-class way to pause or unpause a Repository without opening settings and resubmitting the full settings payload. Pause already exists as a stored setting, but dedicated operations make that intent explicit and match the Work Item pause/start surface. Runtime autonomous-selection filtering is intentionally out of scope for this change.

## What Changed

- Add `DbService.pauseRepository` / `unpauseRepository` that only flip `paused` and leave other Repository settings unchanged
- Expose `pauseRepository` and `unpauseRepository` GraphQL mutations
- Add a quick pause/unpause toggle on each Repository card in the harness UI
- Cover the new DbService and GraphQL seams with tests
