### PR TITLE
feat(work-item-lifecycle): add implement locally

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -87,6 +87,10 @@ _Avoid_: Issue lifecycle, implementation job, attempt
 An explicit operator request that creates a Work Item for a Leaf Issue. Work Items are not created automatically by Issue reconciliation or eligibility discovery.
 _Avoid_: Auto-implement, enqueue Issue
 
+**Implement Locally**:
+An explicit operator request that creates a Work Item for a Leaf Issue like Implement Now, but records that the Work Item should pause before Commit. Local steps (Create Worktree through Review) run normally; after Review succeeds the Work Item advances to Commit and is paused with no Commit Step Run enqueued, so the operator can inspect the worktree. Start resumes at Commit and continues the remote lifecycle.
+_Avoid_: Local-only mode, dry run, Implement Now without PR
+
 **Not Implemented**:
 The derived status of an Issue for which no Work Item has ever been created. It is not a persisted Work Item lifecycle state.
 _Avoid_: Pending, queued
@@ -96,7 +100,7 @@ A current, open Leaf Issue with no listed blockers. A Work Item revalidates this
 _Avoid_: Ready-labeled Issue, Relevant Issue, Leaf Issue
 
 **Actionable Issue**:
-An Implementable Issue with no unfinished Work Item. Only an Actionable Issue may receive Implement Now; Repository pause does not affect actionability.
+An Implementable Issue with no unfinished Work Item. Only an Actionable Issue may receive Implement Now or Implement Locally; Repository pause does not affect actionability.
 _Avoid_: Not Implemented Issue, Ready-labeled Issue
 
 **Lifecycle Step**:

--- a/apps/harness/src/routes/index.tsx
+++ b/apps/harness/src/routes/index.tsx
@@ -1181,6 +1181,12 @@ function RepositoryIssueRow({
     latestWorkItem !== undefined && !latestWorkItem.isTerminal
   const canImplement =
     isActionable && !workItemsLoading && !hasUnfinishedWorkItem
+  const onImplementSuccess = (workItem: WorkItem) => {
+    queryClient.setQueryData<readonly WorkItem[]>(query.queryKey, (current) => [
+      ...(current ?? []),
+      workItem,
+    ])
+  }
   const implementNow = useMutation({
     mutationFn: async () => {
       const result = await graphql.mutation({
@@ -1194,13 +1200,24 @@ function RepositoryIssueRow({
       })
       return result.implementNow
     },
-    onSuccess: (workItem) => {
-      queryClient.setQueryData<readonly WorkItem[]>(
-        query.queryKey,
-        (current) => [...(current ?? []), workItem],
-      )
-    },
+    onSuccess: onImplementSuccess,
   })
+  const implementLocally = useMutation({
+    mutationFn: async () => {
+      const result = await graphql.mutation({
+        implementLocally: {
+          __args: {
+            repositoryId: issue.repositoryId,
+            githubIssueNumber: issue.githubIssueNumber,
+          },
+          ...workItemFields,
+        },
+      })
+      return result.implementLocally
+    },
+    onSuccess: onImplementSuccess,
+  })
+  const implementPending = implementNow.isPending || implementLocally.isPending
 
   useEffect(() => {
     if (!menuOpen) return
@@ -1270,19 +1287,35 @@ function RepositoryIssueRow({
               {menuOpen && (
                 <div
                   role="menu"
-                  className="absolute top-full right-0 z-10 mt-1 min-w-40 rounded-lg border border-slate-200 bg-white py-1 shadow-lg"
+                  className="absolute top-full right-0 z-10 mt-1 min-w-44 rounded-lg border border-slate-200 bg-white py-1 shadow-lg"
                 >
                   <button
                     type="button"
                     role="menuitem"
                     className="block w-full px-3 py-2 text-left text-sm font-medium text-slate-700 hover:bg-slate-50"
-                    disabled={implementNow.isPending}
+                    disabled={implementPending}
                     onClick={() => {
                       setMenuOpen(false)
+                      implementLocally.reset()
                       implementNow.mutate()
                     }}
                   >
                     {implementNow.isPending ? "Starting..." : "Implement now"}
+                  </button>
+                  <button
+                    type="button"
+                    role="menuitem"
+                    className="block w-full px-3 py-2 text-left text-sm font-medium text-slate-700 hover:bg-slate-50"
+                    disabled={implementPending}
+                    onClick={() => {
+                      setMenuOpen(false)
+                      implementNow.reset()
+                      implementLocally.mutate()
+                    }}
+                  >
+                    {implementLocally.isPending
+                      ? "Starting..."
+                      : "Implement locally"}
                   </button>
                 </div>
               )}
@@ -1293,7 +1326,7 @@ function RepositoryIssueRow({
       {latestWorkItem !== undefined && (
         <WorkItemLifecycleStatus workItem={latestWorkItem} />
       )}
-      {implementNow.isError && (
+      {(implementNow.isError || implementLocally.isError) && (
         <p className="mt-1.5 mb-0 pl-11 text-xs text-red-700" role="alert">
           Could not start implementation. Refresh the issues and try again.
         </p>

--- a/apps/harness/test/job-worker.test.ts
+++ b/apps/harness/test/job-worker.test.ts
@@ -137,6 +137,7 @@ const queueLayer = (
         local_cleanup: Duration.minutes(5),
       },
       implementNow: unused,
+      implementLocally: unused,
       runStep,
       retry: unused,
       pause: unused,

--- a/packages/db-schema/drizzle/20260716065104_uneven_wallow/migration.sql
+++ b/packages/db-schema/drizzle/20260716065104_uneven_wallow/migration.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `work_item` ADD `pause_before_step` text;

--- a/packages/db-schema/drizzle/20260716065104_uneven_wallow/snapshot.json
+++ b/packages/db-schema/drizzle/20260716065104_uneven_wallow/snapshot.json
@@ -1,0 +1,1348 @@
+{
+  "version": "7",
+  "dialect": "sqlite",
+  "id": "65961562-1071-43c8-8824-eb8bad95a598",
+  "prevIds": [
+    "ae6bbb8d-a935-47f5-9e01-085c5a7b9378"
+  ],
+  "ddl": [
+    {
+      "name": "completed_job",
+      "entityType": "tables"
+    },
+    {
+      "name": "config",
+      "entityType": "tables"
+    },
+    {
+      "name": "issue",
+      "entityType": "tables"
+    },
+    {
+      "name": "issue_dependency",
+      "entityType": "tables"
+    },
+    {
+      "name": "job_queue",
+      "entityType": "tables"
+    },
+    {
+      "name": "pr_status_check",
+      "entityType": "tables"
+    },
+    {
+      "name": "repository",
+      "entityType": "tables"
+    },
+    {
+      "name": "step_run",
+      "entityType": "tables"
+    },
+    {
+      "name": "work_item",
+      "entityType": "tables"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "completed_job"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "queue",
+      "entityType": "columns",
+      "table": "completed_job"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "job_id",
+      "entityType": "columns",
+      "table": "completed_job"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "completed_job"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "completed_job"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "'default'",
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "config"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'opencode/deepseek-v4-flash-free'",
+      "generated": null,
+      "name": "default_model",
+      "entityType": "columns",
+      "table": "config"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "'low'",
+      "generated": null,
+      "name": "default_variant",
+      "entityType": "columns",
+      "table": "config"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "review_model",
+      "entityType": "columns",
+      "table": "config"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "review_variant",
+      "entityType": "columns",
+      "table": "config"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "config"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "config"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "issue"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "repository_id",
+      "entityType": "columns",
+      "table": "issue"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "github_issue_number",
+      "entityType": "columns",
+      "table": "issue"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "title",
+      "entityType": "columns",
+      "table": "issue"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "body",
+      "entityType": "columns",
+      "table": "issue"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "url",
+      "entityType": "columns",
+      "table": "issue"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "state",
+      "entityType": "columns",
+      "table": "issue"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "github_created_at",
+      "entityType": "columns",
+      "table": "issue"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "parent_github_issue_number",
+      "entityType": "columns",
+      "table": "issue"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "parent_github_issue_url",
+      "entityType": "columns",
+      "table": "issue"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "parent_position",
+      "entityType": "columns",
+      "table": "issue"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "false",
+      "generated": null,
+      "name": "has_children",
+      "entityType": "columns",
+      "table": "issue"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "issue"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "issue"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "issue_dependency"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "issue_id",
+      "entityType": "columns",
+      "table": "issue_dependency"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "blocking_github_issue_number",
+      "entityType": "columns",
+      "table": "issue_dependency"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "blocking_github_issue_url",
+      "entityType": "columns",
+      "table": "issue_dependency"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "issue_dependency"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "job_queue"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "queue",
+      "entityType": "columns",
+      "table": "job_queue"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "job_payload",
+      "entityType": "columns",
+      "table": "job_queue"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "0",
+      "generated": null,
+      "name": "job_attempts",
+      "entityType": "columns",
+      "table": "job_queue"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "5",
+      "generated": null,
+      "name": "job_retry_limit",
+      "entityType": "columns",
+      "table": "job_queue"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "available_at",
+      "entityType": "columns",
+      "table": "job_queue"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "locked_until",
+      "entityType": "columns",
+      "table": "job_queue"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "job_queue"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "job_queue"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "pr_status_check"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "work_item_id",
+      "entityType": "columns",
+      "table": "pr_status_check"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "external_id",
+      "entityType": "columns",
+      "table": "pr_status_check"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "name",
+      "entityType": "columns",
+      "table": "pr_status_check"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "outcome",
+      "entityType": "columns",
+      "table": "pr_status_check"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "handled_at",
+      "entityType": "columns",
+      "table": "pr_status_check"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "observed_at",
+      "entityType": "columns",
+      "table": "pr_status_check"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "pr_status_check"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "pr_status_check"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "repository"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "github_owner",
+      "entityType": "columns",
+      "table": "repository"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "github_repo",
+      "entityType": "columns",
+      "table": "repository"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "local_path",
+      "entityType": "columns",
+      "table": "repository"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "is_bare",
+      "entityType": "columns",
+      "table": "repository"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "true",
+      "generated": null,
+      "name": "paused",
+      "entityType": "columns",
+      "table": "repository"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "default_model",
+      "entityType": "columns",
+      "table": "repository"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "default_variant",
+      "entityType": "columns",
+      "table": "repository"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "review_model",
+      "entityType": "columns",
+      "table": "repository"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "review_variant",
+      "entityType": "columns",
+      "table": "repository"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "false",
+      "generated": null,
+      "name": "auto_merge",
+      "entityType": "columns",
+      "table": "repository"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "issues_reconciled_at",
+      "entityType": "columns",
+      "table": "repository"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "repository"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "repository"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "step_run"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "work_item_id",
+      "entityType": "columns",
+      "table": "step_run"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "step",
+      "entityType": "columns",
+      "table": "step_run"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "status",
+      "entityType": "columns",
+      "table": "step_run"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "queue_job_id",
+      "entityType": "columns",
+      "table": "step_run"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "queued_at",
+      "entityType": "columns",
+      "table": "step_run"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "started_at",
+      "entityType": "columns",
+      "table": "step_run"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "finished_at",
+      "entityType": "columns",
+      "table": "step_run"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "reason_code",
+      "entityType": "columns",
+      "table": "step_run"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "reason_message",
+      "entityType": "columns",
+      "table": "step_run"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "step_run"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "step_run"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "work_item"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "repository_id",
+      "entityType": "columns",
+      "table": "work_item"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "github_issue_number",
+      "entityType": "columns",
+      "table": "work_item"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "github_pull_request_number",
+      "entityType": "columns",
+      "table": "work_item"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "model",
+      "entityType": "columns",
+      "table": "work_item"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "variant",
+      "entityType": "columns",
+      "table": "work_item"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "review_model",
+      "entityType": "columns",
+      "table": "work_item"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "review_variant",
+      "entityType": "columns",
+      "table": "work_item"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "state",
+      "entityType": "columns",
+      "table": "work_item"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "state_ready_at",
+      "entityType": "columns",
+      "table": "work_item"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "false",
+      "generated": null,
+      "name": "paused",
+      "entityType": "columns",
+      "table": "work_item"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "pause_before_step",
+      "entityType": "columns",
+      "table": "work_item"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "worktree_path",
+      "entityType": "columns",
+      "table": "work_item"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "session_id",
+      "entityType": "columns",
+      "table": "work_item"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "failure_code",
+      "entityType": "columns",
+      "table": "work_item"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "failure_message",
+      "entityType": "columns",
+      "table": "work_item"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "work_item"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "work_item"
+    },
+    {
+      "columns": [
+        "repository_id"
+      ],
+      "tableTo": "repository",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_issue_repository_id_repository_id_fk",
+      "entityType": "fks",
+      "table": "issue"
+    },
+    {
+      "columns": [
+        "issue_id"
+      ],
+      "tableTo": "issue",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_issue_dependency_issue_id_issue_id_fk",
+      "entityType": "fks",
+      "table": "issue_dependency"
+    },
+    {
+      "columns": [
+        "work_item_id"
+      ],
+      "tableTo": "work_item",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_pr_status_check_work_item_id_work_item_id_fk",
+      "entityType": "fks",
+      "table": "pr_status_check"
+    },
+    {
+      "columns": [
+        "work_item_id"
+      ],
+      "tableTo": "work_item",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_step_run_work_item_id_work_item_id_fk",
+      "entityType": "fks",
+      "table": "step_run"
+    },
+    {
+      "columns": [
+        "repository_id"
+      ],
+      "tableTo": "repository",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_work_item_repository_id_repository_id_fk",
+      "entityType": "fks",
+      "table": "work_item"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "completed_job_pk",
+      "table": "completed_job",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "config_pk",
+      "table": "config",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "issue_pk",
+      "table": "issue",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "issue_dependency_pk",
+      "table": "issue_dependency",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "job_queue_pk",
+      "table": "job_queue",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "pr_status_check_pk",
+      "table": "pr_status_check",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "repository_pk",
+      "table": "repository",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "step_run_pk",
+      "table": "step_run",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "work_item_pk",
+      "table": "work_item",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        {
+          "value": "queue",
+          "isExpression": false
+        },
+        {
+          "value": "job_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "origin": "manual",
+      "name": "completed_job_queue_job_id_uidx",
+      "entityType": "indexes",
+      "table": "completed_job"
+    },
+    {
+      "columns": [
+        {
+          "value": "repository_id",
+          "isExpression": false
+        },
+        {
+          "value": "github_issue_number",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "origin": "manual",
+      "name": "issue_repository_id_github_issue_number_uidx",
+      "entityType": "indexes",
+      "table": "issue"
+    },
+    {
+      "columns": [
+        {
+          "value": "issue_id",
+          "isExpression": false
+        },
+        {
+          "value": "blocking_github_issue_url",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "origin": "manual",
+      "name": "issue_dependency_issue_id_blocking_url_uidx",
+      "entityType": "indexes",
+      "table": "issue_dependency"
+    },
+    {
+      "columns": [
+        {
+          "value": "queue",
+          "isExpression": false
+        },
+        {
+          "value": "locked_until",
+          "isExpression": false
+        },
+        {
+          "value": "job_attempts",
+          "isExpression": false
+        },
+        {
+          "value": "available_at",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "job_queue_ready_idx",
+      "entityType": "indexes",
+      "table": "job_queue"
+    },
+    {
+      "columns": [
+        {
+          "value": "work_item_id",
+          "isExpression": false
+        },
+        {
+          "value": "external_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "origin": "manual",
+      "name": "pr_status_check_work_item_external_uidx",
+      "entityType": "indexes",
+      "table": "pr_status_check"
+    },
+    {
+      "columns": [
+        {
+          "value": "work_item_id",
+          "isExpression": false
+        },
+        {
+          "value": "handled_at",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "pr_status_check_work_item_handled_idx",
+      "entityType": "indexes",
+      "table": "pr_status_check"
+    },
+    {
+      "columns": [
+        {
+          "value": "lower(\"github_owner\")",
+          "isExpression": true
+        },
+        {
+          "value": "lower(\"github_repo\")",
+          "isExpression": true
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "origin": "manual",
+      "name": "repository_github_owner_repo_lower_uidx",
+      "entityType": "indexes",
+      "table": "repository"
+    },
+    {
+      "columns": [
+        {
+          "value": "work_item_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": "\"step_run\".\"status\" IN ('queued', 'running')",
+      "origin": "manual",
+      "name": "step_run_one_active_uidx",
+      "entityType": "indexes",
+      "table": "step_run"
+    },
+    {
+      "columns": [
+        {
+          "value": "work_item_id",
+          "isExpression": false
+        },
+        {
+          "value": "queued_at",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "step_run_work_item_id_queued_at_idx",
+      "entityType": "indexes",
+      "table": "step_run"
+    },
+    {
+      "columns": [
+        {
+          "value": "repository_id",
+          "isExpression": false
+        },
+        {
+          "value": "github_issue_number",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": "\"work_item\".\"state\" NOT IN ('complete', 'failed', 'abandoned', 'needs_human')",
+      "origin": "manual",
+      "name": "work_item_one_unfinished_v2_uidx",
+      "entityType": "indexes",
+      "table": "work_item"
+    },
+    {
+      "columns": [
+        {
+          "value": "repository_id",
+          "isExpression": false
+        },
+        {
+          "value": "github_issue_number",
+          "isExpression": false
+        },
+        {
+          "value": "created_at",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "work_item_repository_issue_created_idx",
+      "entityType": "indexes",
+      "table": "work_item"
+    },
+    {
+      "columns": [
+        "local_path"
+      ],
+      "nameExplicit": false,
+      "name": "repository_local_path_unique",
+      "entityType": "uniques",
+      "table": "repository"
+    }
+  ],
+  "renames": []
+}

--- a/packages/db-schema/src/schema.ts
+++ b/packages/db-schema/src/schema.ts
@@ -213,6 +213,28 @@ export const workItem = snakeCase.table(
     }).notNull(),
     stateReadyAt: integer({ mode: "number" }).notNull(),
     paused: integer({ mode: "boolean" }).notNull().default(false),
+    /**
+     * When set, successful advancement into this Lifecycle Step pauses the Work
+     * Item (no Step Run enqueued) so the operator can inspect local work.
+     */
+    pauseBeforeStep: text({
+      enum: [
+        "create_worktree",
+        "install_dependencies",
+        "implement",
+        "pre_commit",
+        "review",
+        "commit",
+        "create_pr",
+        "watch_pr_status_checks",
+        "resolve_pr_merge_conflict",
+        "investigate_pr_status_checks",
+        "mark_pr_ready_for_review",
+        "decide_pr_merge",
+        "merge_pr",
+        "local_cleanup",
+      ],
+    }),
     worktreePath: text(),
     sessionId: text(),
     failureCode: text(),

--- a/packages/graphql-api/src/lib/graphql-api.ts
+++ b/packages/graphql-api/src/lib/graphql-api.ts
@@ -999,6 +999,26 @@ export const createGraphqlApi = (
             }
             return result.success
           },
+          implementLocally: async (
+            _parent: unknown,
+            args: ImplementNowArgs,
+          ) => {
+            const result = await runtime.runPromise(
+              Effect.result(
+                Effect.gen(function* () {
+                  const lifecycle = yield* WorkItemLifecycle
+                  return yield* lifecycle.implementLocally(
+                    args.repositoryId,
+                    args.githubIssueNumber,
+                  )
+                }),
+              ),
+            )
+            if (Result.isFailure(result)) {
+              throw toGraphQLError(result.failure)
+            }
+            return result.success
+          },
           retryWorkItem: async (_parent: unknown, args: WorkItemArgs) => {
             const result = await runtime.runPromise(
               Effect.result(

--- a/packages/graphql-api/test/graphql-api.test.ts
+++ b/packages/graphql-api/test/graphql-api.test.ts
@@ -75,6 +75,7 @@ const workItem = {
   state: "create_worktree",
   stateReadyAt: new Date("2026-07-14T08:00:00.000Z"),
   paused: false,
+  pauseBeforeStep: null,
   worktreePath: null,
   sessionId: null,
   failureCode: null,
@@ -180,6 +181,7 @@ const makeRuntime = (
       local_cleanup: Duration.minutes(5),
     },
     implementNow: unused,
+    implementLocally: unused,
     runStep: unused,
     retry: unused,
     pause: unused,
@@ -1442,6 +1444,47 @@ describe("GraphQL API", () => {
               status: "RUNNING",
             },
           ],
+        },
+      },
+    })
+    expect(receivedArgs).toEqual([repository.id, issue.githubIssueNumber])
+  })
+
+  test("starts a Work Item for Implement Locally", async () => {
+    let receivedArgs: readonly [string, number] | undefined
+    await runtime.dispose()
+    runtime = makeRuntime(
+      {},
+      {},
+      {},
+      {},
+      {
+        implementLocally: (repositoryId, githubIssueNumber) => {
+          receivedArgs = [repositoryId, githubIssueNumber]
+          return Effect.succeed(workItem)
+        },
+      },
+    )
+
+    const response = await createGraphqlApi(runtime).fetch(
+      graphqlRequest({
+        query: `mutation ImplementLocally($repositoryId: ID!, $githubIssueNumber: Int!) {
+          implementLocally(repositoryId: $repositoryId, githubIssueNumber: $githubIssueNumber) {
+            id state
+          }
+        }`,
+        variables: {
+          repositoryId: repository.id,
+          githubIssueNumber: issue.githubIssueNumber,
+        },
+      }),
+    )
+
+    expect(await response.json()).toEqual({
+      data: {
+        implementLocally: {
+          id: workItem.id,
+          state: "CREATE_WORKTREE",
         },
       },
     })

--- a/packages/graphql-schema/schema.graphql
+++ b/packages/graphql-schema/schema.graphql
@@ -181,6 +181,10 @@ type Mutation {
   removeRepository(repositoryId: ID!): ID!
   refreshRepository(repositoryId: ID!): RefreshJob!
   implementNow(repositoryId: ID!, githubIssueNumber: Int!): WorkItem!
+  """
+  Create a Work Item that runs local steps through Review, then pauses before Commit.
+  """
+  implementLocally(repositoryId: ID!, githubIssueNumber: Int!): WorkItem!
   retryWorkItem(workItemId: ID!): WorkItem!
   pauseWorkItem(workItemId: ID!): WorkItem!
   startWorkItem(workItemId: ID!): WorkItem!

--- a/packages/work-item-lifecycle/src/lib/types.ts
+++ b/packages/work-item-lifecycle/src/lib/types.ts
@@ -77,6 +77,8 @@ export interface WorkItemRecord {
   readonly state: WorkItemState
   readonly stateReadyAt: Date
   readonly paused: boolean
+  /** When set, advancement into this step auto-pauses (no Step Run enqueued). */
+  readonly pauseBeforeStep: OperationalLifecycleStep | null
   readonly worktreePath: string | null
   readonly sessionId: string | null
   readonly failureCode: string | null

--- a/packages/work-item-lifecycle/src/lib/work-item-lifecycle.ts
+++ b/packages/work-item-lifecycle/src/lib/work-item-lifecycle.ts
@@ -205,6 +205,7 @@ type WorkItemRow = {
   readonly state: WorkItemState
   readonly state_ready_at: number
   readonly paused: boolean | number
+  readonly pause_before_step: OperationalLifecycleStep | null
   readonly worktree_path: string | null
   readonly session_id: string | null
   readonly failure_code: string | null
@@ -273,6 +274,7 @@ const toWorkItemRecord = (
   state: row.state,
   stateReadyAt: new Date(row.state_ready_at),
   paused: Boolean(row.paused),
+  pauseBeforeStep: row.pause_before_step,
   worktreePath: row.worktree_path,
   sessionId: row.session_id,
   failureCode: row.failure_code,
@@ -284,7 +286,7 @@ const toWorkItemRecord = (
 })
 
 const WORK_ITEM_SELECT_COLUMNS = `id, repository_id, github_issue_number, model, variant, review_model,
-                   review_variant, state, state_ready_at, paused, worktree_path, session_id,
+                   review_variant, state, state_ready_at, paused, pause_before_step, worktree_path, session_id,
                    github_pull_request_number, failure_code,
                    failure_message, created_at, updated_at`
 
@@ -409,6 +411,10 @@ export type RunStepResult =
 export interface WorkItemLifecycleShape {
   readonly maxDurations: LifecycleMaxDurations
   readonly implementNow: (
+    repositoryId: string,
+    githubIssueNumber: number,
+  ) => Effect.Effect<WorkItemRecord, ImplementNowError>
+  readonly implementLocally: (
     repositoryId: string,
     githubIssueNumber: number,
   ) => Effect.Effect<WorkItemRecord, ImplementNowError>
@@ -1097,13 +1103,44 @@ export const makeWorkItemLifecycleLive = (
                     nextStep === workItem.state ? workItem.state_ready_at : now
                   // Re-read: Pause may land while this Step Run was draining.
                   const pausedRows = (yield* sql.unsafe(
-                    `SELECT paused FROM work_item WHERE id = ? LIMIT 1`,
+                    `SELECT paused, pause_before_step FROM work_item WHERE id = ? LIMIT 1`,
                     [workItem.id],
-                  )) as readonly { readonly paused: boolean | number }[]
+                  )) as readonly {
+                    readonly paused: boolean | number
+                    readonly pause_before_step: OperationalLifecycleStep | null
+                  }[]
                   const isPaused = Boolean(pausedRows[0]?.paused)
+                  const pauseBeforeStep =
+                    pausedRows[0]?.pause_before_step ?? null
+                  const shouldPauseBeforeNext =
+                    pauseBeforeStep !== null && pauseBeforeStep === nextStep
+                  // Do not clear operator Pause; only set paused when auto-pausing.
+                  const stayPaused = isPaused || shouldPauseBeforeNext
 
-                  yield* sql.unsafe(
-                    `UPDATE work_item
+                  if (shouldPauseBeforeNext) {
+                    yield* sql.unsafe(
+                      `UPDATE work_item
+                   SET state = ?,
+                       state_ready_at = ?,
+                       paused = 1,
+                        worktree_path = ?,
+                        session_id = ?,
+                        github_pull_request_number = ?,
+                        updated_at = ?
+                   WHERE id = ?`,
+                      [
+                        nextStep,
+                        stateReadyAt,
+                        worktreePath,
+                        sessionId,
+                        githubPullRequestNumber,
+                        now,
+                        workItem.id,
+                      ],
+                    )
+                  } else {
+                    yield* sql.unsafe(
+                      `UPDATE work_item
                    SET state = ?,
                        state_ready_at = ?,
                         worktree_path = ?,
@@ -1111,18 +1148,19 @@ export const makeWorkItemLifecycleLive = (
                         github_pull_request_number = ?,
                         updated_at = ?
                    WHERE id = ?`,
-                    [
-                      nextStep,
-                      stateReadyAt,
-                      worktreePath,
-                      sessionId,
-                      githubPullRequestNumber,
-                      now,
-                      workItem.id,
-                    ],
-                  )
+                      [
+                        nextStep,
+                        stateReadyAt,
+                        worktreePath,
+                        sessionId,
+                        githubPullRequestNumber,
+                        now,
+                        workItem.id,
+                      ],
+                    )
+                  }
 
-                  if (!isPaused) {
+                  if (!stayPaused) {
                     const nextStepRunId = makeStepRunId()
 
                     yield* sql.unsafe(
@@ -2266,8 +2304,14 @@ export const makeWorkItemLifecycleLive = (
         )
       })
 
-      const implementNow = Effect.fn("WorkItemLifecycle.implementNow")(
-        function* (repositoryId: string, githubIssueNumber: number) {
+      const createWorkItem = (
+        repositoryId: string,
+        githubIssueNumber: number,
+        options: {
+          readonly pauseBeforeStep: OperationalLifecycleStep | null
+        },
+      ): Effect.Effect<WorkItemRecord, ImplementNowError> =>
+        Effect.gen(function* () {
           const issues = yield* db.listIssues(repositoryId)
           const issue = issues.find(
             (candidate) => candidate.githubIssueNumber === githubIssueNumber,
@@ -2343,9 +2387,9 @@ export const makeWorkItemLifecycleLive = (
                   `INSERT INTO work_item (
                  id, repository_id, github_issue_number, model, variant,
                  review_model, review_variant, state, state_ready_at, paused,
-                 worktree_path, session_id, failure_code, failure_message,
-                 created_at, updated_at
-               ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 0, NULL, NULL, NULL, NULL, ?, ?)`,
+                 pause_before_step, worktree_path, session_id, failure_code,
+                 failure_message, created_at, updated_at
+               ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 0, ?, NULL, NULL, NULL, NULL, ?, ?)`,
                   [
                     workItemId,
                     repositoryId,
@@ -2356,6 +2400,7 @@ export const makeWorkItemLifecycleLive = (
                     reviewVariant,
                     step,
                     now,
+                    options.pauseBeforeStep,
                     now,
                     now,
                   ],
@@ -2433,12 +2478,28 @@ export const makeWorkItemLifecycleLive = (
                 }),
             ),
           )
+        })
+
+      const implementNow = Effect.fn("WorkItemLifecycle.implementNow")(
+        function* (repositoryId: string, githubIssueNumber: number) {
+          return yield* createWorkItem(repositoryId, githubIssueNumber, {
+            pauseBeforeStep: null,
+          })
+        },
+      )
+
+      const implementLocally = Effect.fn("WorkItemLifecycle.implementLocally")(
+        function* (repositoryId: string, githubIssueNumber: number) {
+          return yield* createWorkItem(repositoryId, githubIssueNumber, {
+            pauseBeforeStep: "commit",
+          })
         },
       )
 
       return WorkItemLifecycle.of({
         maxDurations,
         implementNow,
+        implementLocally,
         runStep,
         retry,
         pause,

--- a/packages/work-item-lifecycle/test/work-item-lifecycle.spec.ts
+++ b/packages/work-item-lifecycle/test/work-item-lifecycle.spec.ts
@@ -167,6 +167,8 @@ describe("WorkItemLifecycle", () => {
           expect(workItem.state).toBe("create_worktree")
           expect(workItem.model).toBe("opencode/deepseek-v4-flash-free")
           expect(workItem.variant).toBe("low")
+          expect(workItem.paused).toBe(false)
+          expect(workItem.pauseBeforeStep).toBeNull()
           expect(workItem.worktreePath).toBeNull()
           expect(workItem.sessionId).toBeNull()
           expect(workItem.failureCode).toBeNull()
@@ -504,6 +506,90 @@ describe("WorkItemLifecycle", () => {
         }).pipe(Effect.provide(layer)),
       )
     })
+  })
+
+  describe("implementLocally", () => {
+    const claimAndRunPending = Effect.gen(function* () {
+      const lifecycle = yield* WorkItemLifecycle
+      const queue = yield* QueueService
+      const claimed = yield* queue.rawClaim(WORK_ITEM_LIFECYCLE_QUEUE)
+      expect(Option.isSome(claimed)).toBe(true)
+      if (Option.isNone(claimed)) {
+        return yield* Effect.die("expected a queued lifecycle job")
+      }
+      const payload = claimed.value.payload as { stepRunId: string }
+      return yield* lifecycle.runStep(payload.stepRunId)
+    })
+
+    it("creates a Work Item that pauses before Commit", () =>
+      runTest(
+        Effect.gen(function* () {
+          const lifecycle = yield* WorkItemLifecycle
+          const { repository, issue } = yield* seedActionableIssue
+
+          const workItem = yield* lifecycle.implementLocally(
+            repository.id,
+            issue.githubIssueNumber,
+          )
+
+          expect(workItem.state).toBe("create_worktree")
+          expect(workItem.paused).toBe(false)
+          expect(workItem.pauseBeforeStep).toBe("commit")
+          expect(workItem.stepRuns).toHaveLength(1)
+          expect(workItem.stepRuns[0]!.status).toBe("queued")
+        }),
+      ))
+
+    it("runs local steps through Review then pauses at Commit without enqueueing", () =>
+      runTest(
+        Effect.gen(function* () {
+          const lifecycle = yield* WorkItemLifecycle
+          const queue = yield* QueueService
+          const { repository, issue } = yield* seedActionableIssue
+
+          const created = yield* lifecycle.implementLocally(
+            repository.id,
+            issue.githubIssueNumber,
+          )
+
+          // create_worktree → install → implement → pre_commit → review
+          for (const expectedNext of [
+            "install_dependencies",
+            "implement",
+            "pre_commit",
+            "review",
+            "commit",
+          ] as const) {
+            const result = yield* claimAndRunPending
+            expect(result._tag).toBe("processed")
+            if (result._tag === "processed") {
+              expect(result.workItem.state).toBe(expectedNext)
+              if (expectedNext === "commit") {
+                expect(result.workItem.paused).toBe(true)
+                expect(result.workItem.pauseBeforeStep).toBe("commit")
+                expect(
+                  result.workItem.stepRuns.every(
+                    (run) => run.status !== "queued",
+                  ),
+                ).toBe(true)
+              } else {
+                expect(result.workItem.paused).toBe(false)
+              }
+            }
+          }
+
+          const remaining = yield* queue.rawClaim(WORK_ITEM_LIFECYCLE_QUEUE)
+          expect(Option.isNone(remaining)).toBe(true)
+
+          const started = yield* lifecycle.start(created.id)
+          expect(started.paused).toBe(false)
+          expect(started.state).toBe("commit")
+          expect(started.stepRuns.at(-1)).toMatchObject({
+            step: "commit",
+            status: "queued",
+          })
+        }),
+      ))
   })
 
   describe("getWorkItem and listWorkItemsForIssue", () => {


### PR DESCRIPTION
## Why

Operators sometimes want the agent to implement and review changes in a local worktree without immediately committing or opening a PR. Implement Now always continues through Commit and the remote lifecycle; there was no way to stop after Review for manual inspection.

## What Changed

- Add **Implement locally** beside Implement now on the issue kebab menu
- New GraphQL mutation `implementLocally` creates a Work Item with `pause_before_step = commit`
- Local steps run through Review; advancement into Commit auto-pauses (reuses Work Item Pause) so no Commit Step Run is enqueued
- Start resumes at Commit and continues the normal remote pipeline
- Document Implement Locally in `CONTEXT.md`
