### PR TITLE
docs: define issue polling architecture

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -9,7 +9,7 @@ A GitHub repository the harness is configured to work on, identified by owner an
 _Avoid_: Repo (in formal docs), target, project, checkout
 
 **Paused**:
-A Repository state in which the harness does not autonomously select work for the Repository while keeping its configuration. Explicit operator requests, including a manual Refresh Job or Implement Now and its resulting lifecycle, remain allowed; new Repositories start paused until deliberately unpaused. Not the same as a paused Work Item (see Pause Work Item).
+A Repository state in which the harness does not autonomously select work for the Repository while keeping its configuration. Keeping the Issue store current through scheduled polling continues while Paused. Explicit operator requests, including a manual Refresh Job or Implement Now and its resulting lifecycle, remain allowed; new Repositories start paused until deliberately unpaused. Not the same as a paused Work Item (see Pause Work Item).
 _Avoid_: Disabled, inactive, enabled=false, Pause Work Item
 
 **Repository settings**:
@@ -34,6 +34,14 @@ _Avoid_: GitHub Reconciler (too broad), Issue Synchronizer (suggests bidirection
 **Refresh Job**:
 A durable request for the Issue Reconciler to reconcile one Repository. Acceptance of a Refresh Job does not mean reconciliation has completed.
 _Avoid_: Refresh (ambiguous between the request and its execution), sync job
+
+**Issue Polling**:
+The autonomous recurring initiation of Issue reconciliation for every credentialed Repository, including Paused Repositories. Adding a Repository's matching GitHub credential through the Harness activates polling; removing it suspends polling. Polling is serial: only one scheduled or manual Refresh Job executes at a time. A Repository's next scheduled attempt becomes eligible 120 to 150 seconds after its previous scheduled attempt finishes, whether that attempt succeeded or failed. Manual Refresh Jobs take precedence over scheduled attempts but neither interrupt a running attempt nor alter the Repository's polling cadence.
+_Avoid_: Issue synchronization (suggests bidirectional updates), refresh interval (ambiguous about eligibility and execution)
+
+**Polling Auto-heal Job**:
+A durable high-priority startup request that makes the active Issue Polling set exactly match the Harness's credentialed Repositories, adding missing polling schedules and removing schedules for deleted or uncredentialed Repositories. It retries with backoff until reconciliation succeeds without delaying Harness startup.
+_Avoid_: Issue reconciliation (changes the Issue store), startup migration (runs on every startup and may depend on external credentials)
 
 **Keymaxxer Service**:
 The backend boundary for vault operations. It can determine whether a named secret exists, request that a secret be added, and run a command with named secrets injected without exposing raw secret values to the Harness.

--- a/docs/adr/0019-serialize-issue-polling-with-keyed-recurring-jobs.md
+++ b/docs/adr/0019-serialize-issue-polling-with-keyed-recurring-jobs.md
@@ -1,0 +1,5 @@
+# Serialize Issue polling with keyed recurring jobs
+
+Harness hosts one dedicated Issue polling worker for the supported single-process deployment, checking a high-priority manual queue before a scheduled queue so manual and scheduled Refresh Jobs never overlap while Work Item lifecycle jobs remain independent. Each credentialed Repository has one database-unique keyed recurring queue entry that is postponed for 120 seconds plus uniform 0-30 second jitter after every scheduled attempt, successful or failed; this avoids both successor-job crash gaps and a separate scheduling store, while accepting strict-priority starvation and no cross-process serialization.
+
+Repository credential activation also enqueues a high-priority first Refresh Job, credential removal suspends the recurring entry, and manual requests remain distinct one-shot jobs that neither retry nor alter cadence. Harness startup quickly enqueues a high-priority Polling Auto-heal Job rather than blocking readiness; that job retries with backoff until it has added missing entries and removed entries for deleted or uncredentialed Repositories.


### PR DESCRIPTION
## Why

Issue Polling needs a shared domain definition and a durable architectural record before implementation begins. Without these decisions, future changes could conflate manual Refresh Jobs with autonomous polling or accidentally weaken the serial GitHub polling constraint.

Related to #157.

## What Changed

- define Issue Polling and Polling Auto-heal Job in the domain glossary
- clarify that Paused Repositories continue keeping their Issue store current
- record the keyed recurring queue design, strict manual priority, 120-150 second cadence, credential lifecycle, and startup auto-healing tradeoffs in ADR 0019
