### PR TITLE
fix(pre-commit): tolerate removed diagnostic logs

### DIFF
--- a/packages/work-item-lifecycle/src/lib/pre-commit.ts
+++ b/packages/work-item-lifecycle/src/lib/pre-commit.ts
@@ -1,3 +1,4 @@
+import { dirname } from "node:path"
 import { Effect, FileSystem, Stream } from "effect"
 import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process"
 import { Opencode } from "@ready-for-agent/opencode"
@@ -92,10 +93,16 @@ const runGitInWorktree = (cwd: string, args: ReadonlyArray<string>) =>
 const writeHookOutputLog = (workItemId: string, output: string) =>
   Effect.gen(function* () {
     const fs = yield* FileSystem.FileSystem
-    const logPath = yield* fs.makeTempFileScoped({
-      prefix: `ready-for-agent-pre-commit-${workItemId}-`,
-      suffix: ".log",
-    })
+    const logPath = yield* Effect.acquireRelease(
+      fs.makeTempFile({
+        prefix: `ready-for-agent-pre-commit-${workItemId}-`,
+        suffix: ".log",
+      }),
+      (path) =>
+        fs
+          .remove(dirname(path), { recursive: true, force: true })
+          .pipe(Effect.orDie),
+    )
     yield* fs.writeFileString(logPath, output)
     yield* fs.chmod(logPath, 0o600)
     return logPath

--- a/packages/work-item-lifecycle/test/pre-commit.spec.ts
+++ b/packages/work-item-lifecycle/test/pre-commit.spec.ts
@@ -8,7 +8,7 @@ import {
   writeFile,
 } from "node:fs/promises"
 import { tmpdir } from "node:os"
-import { join } from "node:path"
+import { dirname, join } from "node:path"
 import { BunServices } from "@effect/platform-bun"
 import { type Duration, Effect, Layer } from "effect"
 import {
@@ -287,6 +287,40 @@ describe("preCommit", () => {
       expect(logContents).toContain(tail)
       expect(logMode).toBe(0o600)
       await expect(access(logPath)).rejects.toThrow()
+    }))
+
+  it("succeeds when the diagnostic consumer removes the temporary log directory", () =>
+    withTempGit(async (root) => {
+      await writeHook(
+        root,
+        [
+          "#!/usr/bin/env bash",
+          'if [ -f ".pre-commit-fixed" ]; then',
+          "  exit 0",
+          "fi",
+          "exit 1",
+          "",
+        ].join("\n"),
+      )
+      await writeFile(join(root, "change.txt"), "hello\n")
+
+      await run(
+        preCommit(baseContext(root)),
+        stubOpencode({
+          continue: (input) => {
+            const match = input.prompt.match(/Full hook output is at: (.+)$/m)
+            const logPath = match?.[1]?.trim() ?? ""
+            return Effect.promise(async () => {
+              await rm(dirname(logPath), { recursive: true })
+              await writeFile(join(root, ".pre-commit-fixed"), "ok\n")
+              return {
+                sessionId: input.sessionId,
+                assistantText: "fixed",
+              }
+            })
+          },
+        }),
+      )
     }))
 
   it("asks OpenCode again when the hook still fails after a fix attempt", () =>


### PR DESCRIPTION
## Summary

- make Pre-Commit diagnostic-log cleanup idempotent
- prevent a missing temporary directory from masking the actual OpenCode/Pre-Commit outcome
- add a regression test reproducing the recorded `FileSystem.makeTempFileScoped` defect

## Root cause

Effect `makeTempFileScoped` removes its private directory without `force` when the scope closes. If the diagnostic consumer has already removed that directory, the cleanup raises `NotFound` as a defect.

## Verification

- `bunx nx test work-item-lifecycle` (193 passed)
- `bunx nx typecheck work-item-lifecycle`
- `bunx nx lint work-item-lifecycle`
- pre-commit affected lint, typecheck, and test targets