### PR TITLE
fix(job-worker): preserve lifecycle queue deliveries

### DIFF
--- a/apps/harness/src/server/job-worker.ts
+++ b/apps/harness/src/server/job-worker.ts
@@ -1,5 +1,13 @@
 import "@tanstack/react-start/server-only"
-import { Duration, Effect, Layer, Option, Schedule, Schema } from "effect"
+import {
+  Clock,
+  Duration,
+  Effect,
+  Layer,
+  Option,
+  Schedule,
+  Schema,
+} from "effect"
 import {
   DbService,
   RepositoryId,
@@ -14,7 +22,9 @@ import {
 
 export const JOBS_QUEUE = "jobs"
 export const JOB_VISIBILITY_TIMEOUT = Duration.minutes(5)
+const LIFECYCLE_JOB_VISIBILITY_GRACE = Duration.minutes(1)
 const JOB_IDLE_POLL_INTERVAL = Duration.millis(1500)
+const ORPHAN_RECOVERY_INTERVAL = Duration.seconds(30)
 export const JOB_RECOVERY_RETRY_LIMIT = 1
 
 /**
@@ -97,20 +107,36 @@ const refreshRepository = (repositoryId: RepositoryId) =>
 export interface JobWorkerOptions {
   readonly idlePollInterval?: Duration.Duration
   readonly visibilityTimeout?: Duration.Duration
+  readonly orphanRecoveryInterval?: Duration.Duration
 }
 
 export const runJobWorker = (options: JobWorkerOptions = {}) =>
   Effect.gen(function* () {
     const generation = nextWorkerGeneration()
     const queue = yield* QueueService
+    const lifecycle = yield* WorkItemLifecycle
+    const lifecycleJobVisibilityTimeout = Duration.millis(
+      Math.max(
+        ...Object.values(lifecycle.maxDurations).map(Duration.toMillis),
+      ) + Duration.toMillis(LIFECYCLE_JOB_VISIBILITY_GRACE),
+    )
     const idlePollInterval = options.idlePollInterval ?? JOB_IDLE_POLL_INTERVAL
     const visibilityTimeout =
       options.visibilityTimeout ?? JOB_VISIBILITY_TIMEOUT
+    const orphanRecoveryInterval =
+      options.orphanRecoveryInterval ?? ORPHAN_RECOVERY_INTERVAL
+    let nextOrphanRecoveryAt = 0
     const sleepIdle = yield* Schedule.toStepWithSleep(
       Schedule.spaced(idlePollInterval).pipe(Schedule.jittered),
     )
 
     const claimAndRun = Effect.gen(function* () {
+      const now = yield* Clock.currentTimeMillis
+      if (now >= nextOrphanRecoveryAt) {
+        yield* lifecycle.recoverOrphanedStepRuns
+        nextOrphanRecoveryAt = now + Duration.toMillis(orphanRecoveryInterval)
+      }
+
       const claimed = yield* QueueService.claim(
         JOBS_QUEUE,
         JobPayload,
@@ -145,7 +171,10 @@ export const runJobWorker = (options: JobWorkerOptions = {}) =>
           break
         }
         case "work-item-step": {
-          const lifecycle = yield* WorkItemLifecycle
+          yield* queue.extendVisibility(
+            job.jobId,
+            lifecycleJobVisibilityTimeout,
+          )
           const result = yield* Effect.result(
             lifecycle.runStep(job.payload.stepRunId),
           )
@@ -156,8 +185,6 @@ export const runJobWorker = (options: JobWorkerOptions = {}) =>
               stepRunId: job.payload.stepRunId,
               error: formatLogError(result.failure),
             })
-          } else if (result.success._tag === "noop") {
-            yield* queue.acknowledge(job.jobId)
           }
           break
         }

--- a/apps/harness/test/job-worker.test.ts
+++ b/apps/harness/test/job-worker.test.ts
@@ -96,6 +96,11 @@ const queueLayer = (
     stepRunId: string,
   ) => Effect.Effect<{ readonly _tag: "noop" }> = () =>
     Effect.succeed({ _tag: "noop" as const }),
+  onExtendVisibility: (
+    jobId: string,
+    timeout: Duration.Duration,
+  ) => Effect.Effect<unknown> = () => Effect.void,
+  recoverOrphanedStepRuns: Effect.Effect<number> = Effect.succeed(0),
 ) =>
   Layer.merge(
     Layer.succeed(QueueService, {
@@ -116,7 +121,8 @@ const queueLayer = (
           expect(options?.retryable).toBe(false)
           yield* onFail(jobId)
         }),
-      extendVisibility: unused,
+      extendVisibility: (jobId, timeout) =>
+        onExtendVisibility(jobId, timeout).pipe(Effect.asVoid),
       getStats: unused,
     } satisfies QueueServiceShape),
     Layer.succeed(WorkItemLifecycle, {
@@ -138,6 +144,7 @@ const queueLayer = (
       },
       implementNow: unused,
       implementLocally: unused,
+      recoverOrphanedStepRuns,
       runStep,
       retry: unused,
       pause: unused,
@@ -199,31 +206,88 @@ describe("Job worker", () => {
     })
   })
 
-  test("dispatches a Work Item Lifecycle Job and acknowledges a stale no-op", async () => {
+  test("extends a Lifecycle Job lease and leaves a live no-op unacknowledged", async () => {
     const stepRunId = makeStepRunId()
     const payload = WorkItemStepJob.make({ stepRunId })
     const job = rawJob(payload)
-    const acknowledged = await Effect.runPromise(Deferred.make<string>())
     const dispatched = await Effect.runPromise(Deferred.make<string>())
+    const extended = await Effect.runPromise(
+      Deferred.make<{ readonly jobId: string; readonly timeoutMs: number }>(),
+    )
+    const recovered = await Effect.runPromise(Deferred.make<void>())
+    const acknowledged: string[] = []
 
     await runScoped(
       Effect.gen(function* () {
         yield* runJobWorker({ idlePollInterval: Duration.zero }).pipe(
           Effect.forkScoped({ startImmediately: true }),
         )
+        yield* Deferred.await(recovered)
         expect(yield* Deferred.await(dispatched)).toBe(stepRunId)
-        expect(yield* Deferred.await(acknowledged)).toBe(job.jobId)
+        expect(yield* Deferred.await(extended)).toEqual({
+          jobId: job.jobId,
+          timeoutMs: Duration.toMillis(Duration.hours(2)) + 60_000,
+        })
+        yield* Effect.sleep("10 millis")
+        expect(acknowledged).toEqual([])
       }),
       Layer.merge(
         queueLayer(
           [job],
-          (jobId) => Deferred.succeed(acknowledged, jobId),
+          (jobId) =>
+            Effect.sync(() => {
+              acknowledged.push(jobId)
+            }),
           undefined,
           undefined,
           (receivedStepRunId) =>
             Deferred.succeed(dispatched, receivedStepRunId).pipe(
               Effect.as({ _tag: "noop" as const }),
             ),
+          (jobId, timeout) =>
+            Deferred.succeed(extended, {
+              jobId,
+              timeoutMs: Duration.toMillis(timeout),
+            }),
+          Deferred.succeed(recovered, undefined).pipe(Effect.as(0)),
+        ),
+        Layer.merge(
+          dbLayer(),
+          Layer.succeed(IssueReconciler, { reconcile: unused }),
+        ),
+      ),
+    )
+  })
+
+  test("rechecks orphan recovery while the worker is running", async () => {
+    let recoveryCalls = 0
+    const recoveredTwice = await Effect.runPromise(Deferred.make<void>())
+    const recover = Effect.gen(function* () {
+      recoveryCalls += 1
+      if (recoveryCalls === 2) {
+        yield* Deferred.succeed(recoveredTwice, undefined)
+      }
+      return 0
+    })
+
+    await runScoped(
+      Effect.gen(function* () {
+        yield* runJobWorker({
+          idlePollInterval: Duration.zero,
+          orphanRecoveryInterval: Duration.zero,
+        }).pipe(Effect.forkScoped({ startImmediately: true }))
+        yield* Deferred.await(recoveredTwice).pipe(Effect.timeout("100 millis"))
+        expect(recoveryCalls).toBeGreaterThanOrEqual(2)
+      }),
+      Layer.merge(
+        queueLayer(
+          [],
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          recover,
         ),
         Layer.merge(
           dbLayer(),

--- a/packages/graphql-api/test/graphql-api.test.ts
+++ b/packages/graphql-api/test/graphql-api.test.ts
@@ -182,6 +182,7 @@ const makeRuntime = (
     },
     implementNow: unused,
     implementLocally: unused,
+    recoverOrphanedStepRuns: Effect.succeed(0),
     runStep: unused,
     retry: unused,
     pause: unused,

--- a/packages/work-item-lifecycle/src/lib/work-item-lifecycle.ts
+++ b/packages/work-item-lifecycle/src/lib/work-item-lifecycle.ts
@@ -410,6 +410,10 @@ export type RunStepResult =
 
 export interface WorkItemLifecycleShape {
   readonly maxDurations: LifecycleMaxDurations
+  readonly recoverOrphanedStepRuns: Effect.Effect<
+    number,
+    WorkItemLifecycleDatabaseError
+  >
   readonly implementNow: (
     repositoryId: string,
     githubIssueNumber: number,
@@ -1328,6 +1332,48 @@ export const makeWorkItemLifecycleLive = (
             Effect.mapError((error): RunStepError => error),
           )
         })
+
+      const recoverOrphanedStepRuns = Effect.gen(function* () {
+        const now = yield* Clock.currentTimeMillis
+        const rows = (yield* sql
+          .unsafe(
+            `UPDATE step_run
+             SET status = 'interrupted',
+                 finished_at = ?,
+                 reason_code = ?,
+                 reason_message = ?,
+                 updated_at = ?
+             WHERE status = 'running'
+               AND (
+                 queue_job_id IS NULL
+                 OR NOT EXISTS (
+                   SELECT 1 FROM job_queue
+                   WHERE job_queue.id = step_run.queue_job_id
+                 )
+                 OR EXISTS (
+                   SELECT 1 FROM job_queue
+                   WHERE job_queue.id = step_run.queue_job_id
+                     AND job_queue.job_attempts >= job_queue.job_retry_limit
+                     AND (
+                       job_queue.locked_until IS NULL
+                       OR job_queue.locked_until <= ?
+                     )
+                 )
+               )
+             RETURNING id`,
+            [
+              now,
+              STEP_RUN_REASON.interrupted,
+              "Lifecycle Step lost its queue delivery",
+              now,
+              now,
+            ],
+          )
+          .pipe(Effect.mapError(toDatabaseError))) as readonly {
+          readonly id: string
+        }[]
+        return rows.length
+      })
 
       const runStep = Effect.fn("WorkItemLifecycle.runStep")(function* (
         stepRunId: string,
@@ -2498,6 +2544,7 @@ export const makeWorkItemLifecycleLive = (
 
       return WorkItemLifecycle.of({
         maxDurations,
+        recoverOrphanedStepRuns,
         implementNow,
         implementLocally,
         runStep,

--- a/packages/work-item-lifecycle/test/work-item-lifecycle.spec.ts
+++ b/packages/work-item-lifecycle/test/work-item-lifecycle.spec.ts
@@ -2784,6 +2784,87 @@ describe("WorkItemLifecycle", () => {
   })
 
   describe("delivery safety and interruption", () => {
+    it("marks a Running Step Run Interrupted when its queue job is missing", () =>
+      runTest(
+        Effect.gen(function* () {
+          const lifecycle = yield* WorkItemLifecycle
+          const sql = yield* SqlClient.SqlClient
+          const { repository, issue } = yield* seedActionableIssue
+          const created = yield* lifecycle.implementNow(
+            repository.id,
+            issue.githubIssueNumber,
+          )
+          const stepRun = created.stepRuns[0]!
+          const now = Date.now()
+
+          yield* sql.unsafe(
+            `UPDATE step_run
+             SET status = 'running', started_at = ?, updated_at = ?
+             WHERE id = ?`,
+            [now, now, stepRun.id],
+          )
+          yield* sql.unsafe("DELETE FROM job_queue WHERE id = ?", [
+            stepRun.queueJobId,
+          ])
+
+          expect(yield* lifecycle.recoverOrphanedStepRuns).toBe(1)
+
+          const recovered = yield* lifecycle.getWorkItem(created.id)
+          expect(recovered.stepRuns[0]?.status).toBe("interrupted")
+          expect(recovered.stepRuns[0]?.reasonCode).toBe(
+            STEP_RUN_REASON.interrupted,
+          )
+          expect(recovered.stepRuns[0]?.reasonMessage).toBe(
+            "Lifecycle Step lost its queue delivery",
+          )
+        }),
+      ))
+
+    it("marks a Running Step Run Interrupted when its final queue lease expires", () =>
+      runTest(
+        Effect.gen(function* () {
+          const lifecycle = yield* WorkItemLifecycle
+          const sql = yield* SqlClient.SqlClient
+          const { repository, issue } = yield* seedActionableIssue
+          const created = yield* lifecycle.implementNow(
+            repository.id,
+            issue.githubIssueNumber,
+          )
+          const stepRun = created.stepRuns[0]!
+          const now = Date.now()
+
+          yield* sql.unsafe(
+            `UPDATE step_run
+             SET status = 'running', started_at = ?, updated_at = ?
+             WHERE id = ?`,
+            [now, now, stepRun.id],
+          )
+          yield* sql.unsafe(
+            `UPDATE job_queue
+             SET job_attempts = job_retry_limit,
+                 locked_until = ?,
+                 updated_at = ?
+             WHERE id = ?`,
+            [now + 60_000, now, stepRun.queueJobId],
+          )
+
+          expect(yield* lifecycle.recoverOrphanedStepRuns).toBe(0)
+
+          yield* sql.unsafe(
+            `UPDATE job_queue SET locked_until = ?, updated_at = ? WHERE id = ?`,
+            [now - 1, now, stepRun.queueJobId],
+          )
+
+          expect(yield* lifecycle.recoverOrphanedStepRuns).toBe(1)
+
+          const recovered = yield* lifecycle.getWorkItem(created.id)
+          expect(recovered.stepRuns[0]?.status).toBe("interrupted")
+          expect(recovered.stepRuns[0]?.reasonCode).toBe(
+            STEP_RUN_REASON.interrupted,
+          )
+        }),
+      ))
+
     it("acknowledges a stale delivery without invoking a handler", () => {
       let createCalls = 0
       const steps: LifecycleStepsShape = {


### PR DESCRIPTION
## Summary
- extend lifecycle job visibility beyond the longest configured step duration
- stop acknowledging live `noop` deliveries outside the lifecycle transaction
- periodically recover running Step Runs whose queue delivery is missing or exhausted
- preserve exhausted deliveries until their active visibility lease expires

## Root cause
A status-check investigation could outlive the worker’s five-minute visibility lease. A duplicate delivery returned `noop` and was acknowledged, deleting the queue job while the original execution was still active. Its later completion then rolled back when acknowledgement found no job, leaving a permanent `running` Step Run.

## Verification
- `bunx nx affected -t lint,typecheck,test --batch`
- 274 affected tests passed across `harness`, `graphql-api`, and `work-item-lifecycle`