### PR TITLE
feat(harness): move manual Refresh Jobs to issue-refresh queue

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -7,13 +7,14 @@
 - Database is Turso database (sqlite)
 - Backend is Effect TS
 - Services are implemented as Effect TS
-- The application runtime hosts a scoped job worker service whose Effect fibers handle jobs; see `docs/adr/0007-host-job-worker-in-harness.md`
-- Every job implementation is an Effect; the job worker composes and runs those Effects for work claimed from the database queue
-- A tagged payload in the shared `jobs` queue selects the Job Effect; the worker owns claim, decoding, dispatch, acknowledgement, and failure handling
-- UI is responsive: anything that takes long is put in a queue and handled by the job worker
+- The application runtime hosts scoped job worker fibers; see `docs/adr/0007-host-job-worker-in-harness.md` and `docs/adr/0019-serialize-issue-polling-with-keyed-recurring-jobs.md`
+- Every job implementation is an Effect; workers compose and run those Effects for work claimed from the database queue
+- Work Item lifecycle jobs use the `jobs` queue; manual Refresh Jobs use the high-priority `issue-refresh` queue. Independent workers claim each queue; Issue Refresh Jobs execute serially on the polling lane while lifecycle work may run in parallel
+- UI is responsive: anything that takes long is put in a queue and handled by the job workers
 - Successful Issue reconciliation publishes a Repository-specific issues invalidation and a repositories invalidation so subscribed clients refetch Issues and `issuesReconciledAt`; no client-facing job history or status snapshots are maintained
-- The first worker executes one job at a time with five-minute claim visibility; job failures are terminal, while an abandoned claim may be redelivered once after interruption
-- The scoped worker polls about every 1.5s while idle (Effect `Schedule.spaced` + `Schedule.jittered`, ~0.8–1.2×) and logs and recovers from queue infrastructure errors instead of permanently terminating its fiber
+- Each worker executes one job at a time with five-minute claim visibility; Refresh Job reconciliation failures are terminal, while an abandoned claim may be redelivered once after interruption
+- Workers poll about every 1.5s while idle (Effect `Schedule.spaced` + `Schedule.jittered`, ~0.8–1.2×) and log and recover from queue infrastructure errors instead of permanently terminating their fibers
+- On startup, any persisted `refresh-repository` rows still on `jobs` are moved once into `issue-refresh` so they are not dropped, duplicated, or claimed by both workers
 - Queue methods acquire their SQL dependency when constructing the queue layer and return self-contained Effects; complete issue #13 before implementing the worker
 - Public Job IDs use the canonical `qjob-<ULID>` format
 - Prefer Bun APIs.

--- a/apps/harness/src/server/job-worker.ts
+++ b/apps/harness/src/server/job-worker.ts
@@ -20,12 +20,16 @@ import {
   WorkItemStepJob,
 } from "@ready-for-agent/work-item-lifecycle"
 
+/** Work Item lifecycle queue (unchanged). */
 export const JOBS_QUEUE = "jobs"
+/** High-priority manual Issue Refresh Job queue. */
+export const ISSUE_REFRESH_QUEUE = "issue-refresh"
 export const JOB_VISIBILITY_TIMEOUT = Duration.minutes(5)
 const LIFECYCLE_JOB_VISIBILITY_GRACE = Duration.minutes(1)
 const JOB_IDLE_POLL_INTERVAL = Duration.millis(1500)
 const ORPHAN_RECOVERY_INTERVAL = Duration.seconds(30)
 export const JOB_RECOVERY_RETRY_LIMIT = 1
+const REFRESH_REPOSITORY_TAG = "refresh-repository"
 
 /**
  * Process-global generation so HMR/runtime restarts retire zombie workers that
@@ -74,8 +78,6 @@ const RefreshRepositoryJob = Schema.TaggedStruct("refresh-repository", {
   repositoryId: RepositoryId,
 })
 
-const JobPayload = Schema.Union([RefreshRepositoryJob, WorkItemStepJob])
-
 export const enqueueRefreshRepositoryJob = (repositoryId: RepositoryId) =>
   Effect.gen(function* () {
     const queue = yield* QueueService
@@ -83,10 +85,20 @@ export const enqueueRefreshRepositoryJob = (repositoryId: RepositoryId) =>
       _tag: "refresh-repository",
       repositoryId,
     })
-    return yield* queue.enqueue(JOBS_QUEUE, payload, {
+    return yield* queue.enqueue(ISSUE_REFRESH_QUEUE, payload, {
       retryLimit: JOB_RECOVERY_RETRY_LIMIT,
     })
   })
+
+/** Move pre-split Refresh Jobs off the lifecycle queue into the polling lane. */
+export const transferPersistedRefreshJobs = Effect.gen(function* () {
+  const queue = yield* QueueService
+  return yield* queue.requeueByPayloadTag(
+    JOBS_QUEUE,
+    ISSUE_REFRESH_QUEUE,
+    REFRESH_REPOSITORY_TAG,
+  )
+})
 
 const refreshRepository = (repositoryId: RepositoryId) =>
   Effect.gen(function* () {
@@ -110,93 +122,21 @@ export interface JobWorkerOptions {
   readonly orphanRecoveryInterval?: Duration.Duration
 }
 
-export const runJobWorker = (options: JobWorkerOptions = {}) =>
+const runQueuePollLoop = <E, R>(
+  generation: number,
+  idlePollInterval: Duration.Duration,
+  claimAndRun: Effect.Effect<"idle" | "busy", E, R>,
+  logLabel: string,
+) =>
   Effect.gen(function* () {
-    const generation = nextWorkerGeneration()
-    const queue = yield* QueueService
-    const lifecycle = yield* WorkItemLifecycle
-    const lifecycleJobVisibilityTimeout = Duration.millis(
-      Math.max(
-        ...Object.values(lifecycle.maxDurations).map(Duration.toMillis),
-      ) + Duration.toMillis(LIFECYCLE_JOB_VISIBILITY_GRACE),
-    )
-    const idlePollInterval = options.idlePollInterval ?? JOB_IDLE_POLL_INTERVAL
-    const visibilityTimeout =
-      options.visibilityTimeout ?? JOB_VISIBILITY_TIMEOUT
-    const orphanRecoveryInterval =
-      options.orphanRecoveryInterval ?? ORPHAN_RECOVERY_INTERVAL
-    let nextOrphanRecoveryAt = 0
     const sleepIdle = yield* Schedule.toStepWithSleep(
       Schedule.spaced(idlePollInterval).pipe(Schedule.jittered),
     )
 
-    const claimAndRun = Effect.gen(function* () {
-      const now = yield* Clock.currentTimeMillis
-      if (now >= nextOrphanRecoveryAt) {
-        yield* lifecycle.recoverOrphanedStepRuns
-        nextOrphanRecoveryAt = now + Duration.toMillis(orphanRecoveryInterval)
-      }
-
-      const claimed = yield* QueueService.claim(
-        JOBS_QUEUE,
-        JobPayload,
-        visibilityTimeout,
-      ).pipe(
-        Effect.catchTag("PayloadParseError", (error) =>
-          queue
-            .fail(error.jobId, { retryable: false })
-            .pipe(Effect.as(Option.none())),
-        ),
-      )
-
-      if (Option.isNone(claimed)) return "idle" as const
-
-      const job = claimed.value
-      switch (job.payload._tag) {
-        case "refresh-repository": {
-          const result = yield* Effect.result(
-            refreshRepository(job.payload.repositoryId),
-          )
-
-          if (result._tag === "Failure") {
-            yield* Effect.logError("Refresh Job failed", {
-              jobId: job.jobId,
-              repositoryId: job.payload.repositoryId,
-              error: formatLogError(result.failure),
-            })
-            yield* queue.fail(job.jobId, { retryable: false })
-          } else {
-            yield* queue.acknowledge(job.jobId)
-          }
-          break
-        }
-        case "work-item-step": {
-          yield* queue.extendVisibility(
-            job.jobId,
-            lifecycleJobVisibilityTimeout,
-          )
-          const result = yield* Effect.result(
-            lifecycle.runStep(job.payload.stepRunId),
-          )
-
-          if (result._tag === "Failure") {
-            yield* Effect.logError("Work Item Lifecycle Job failed", {
-              jobId: job.jobId,
-              stepRunId: job.payload.stepRunId,
-              error: formatLogError(result.failure),
-            })
-          }
-          break
-        }
-      }
-
-      return "busy" as const
-    })
-
     while (generation === currentWorkerGeneration()) {
       const state = yield* claimAndRun.pipe(
         Effect.catch((error) =>
-          Effect.logError("Job queue poll failed", {
+          Effect.logError(`${logLabel} poll failed`, {
             error: formatLogError(error),
           }).pipe(Effect.as("idle" as const)),
         ),
@@ -207,6 +147,130 @@ export const runJobWorker = (options: JobWorkerOptions = {}) =>
     }
   })
 
+const claimAndRunRefreshJob = (visibilityTimeout: Duration.Duration) =>
+  Effect.gen(function* () {
+    const queue = yield* QueueService
+    const claimed = yield* QueueService.claim(
+      ISSUE_REFRESH_QUEUE,
+      RefreshRepositoryJob,
+      visibilityTimeout,
+    ).pipe(
+      Effect.catchTag("PayloadParseError", (error) =>
+        queue
+          .fail(error.jobId, { retryable: false })
+          .pipe(Effect.as(Option.none())),
+      ),
+    )
+
+    if (Option.isNone(claimed)) return "idle" as const
+
+    const job = claimed.value
+    const result = yield* Effect.result(
+      refreshRepository(job.payload.repositoryId),
+    )
+
+    if (result._tag === "Failure") {
+      yield* Effect.logError("Refresh Job failed", {
+        jobId: job.jobId,
+        repositoryId: job.payload.repositoryId,
+        error: formatLogError(result.failure),
+      })
+      yield* queue.fail(job.jobId, { retryable: false })
+    } else {
+      yield* queue.acknowledge(job.jobId)
+    }
+
+    return "busy" as const
+  })
+
+const claimAndRunLifecycleJob = (
+  visibilityTimeout: Duration.Duration,
+  orphanRecoveryInterval: Duration.Duration,
+) => {
+  let nextOrphanRecoveryAt = 0
+
+  return Effect.gen(function* () {
+    const queue = yield* QueueService
+    const lifecycle = yield* WorkItemLifecycle
+    const lifecycleJobVisibilityTimeout = Duration.millis(
+      Math.max(
+        ...Object.values(lifecycle.maxDurations).map(Duration.toMillis),
+      ) + Duration.toMillis(LIFECYCLE_JOB_VISIBILITY_GRACE),
+    )
+
+    const now = yield* Clock.currentTimeMillis
+    if (now >= nextOrphanRecoveryAt) {
+      yield* lifecycle.recoverOrphanedStepRuns
+      nextOrphanRecoveryAt = now + Duration.toMillis(orphanRecoveryInterval)
+    }
+
+    const claimed = yield* QueueService.claim(
+      JOBS_QUEUE,
+      WorkItemStepJob,
+      visibilityTimeout,
+    ).pipe(
+      Effect.catchTag("PayloadParseError", (error) =>
+        queue
+          .fail(error.jobId, { retryable: false })
+          .pipe(Effect.as(Option.none())),
+      ),
+    )
+
+    if (Option.isNone(claimed)) return "idle" as const
+
+    const job = claimed.value
+    yield* queue.extendVisibility(job.jobId, lifecycleJobVisibilityTimeout)
+    const result = yield* Effect.result(
+      lifecycle.runStep(job.payload.stepRunId),
+    )
+
+    if (result._tag === "Failure") {
+      yield* Effect.logError("Work Item Lifecycle Job failed", {
+        jobId: job.jobId,
+        stepRunId: job.payload.stepRunId,
+        error: formatLogError(result.failure),
+      })
+    }
+
+    return "busy" as const
+  })
+}
+
+/**
+ * Host lifecycle and Issue Refresh workers as independent fibers that share one
+ * generation token so HMR retires both together.
+ */
+export const runJobWorker = (options: JobWorkerOptions = {}) =>
+  Effect.gen(function* () {
+    const generation = nextWorkerGeneration()
+    const idlePollInterval = options.idlePollInterval ?? JOB_IDLE_POLL_INTERVAL
+    const visibilityTimeout =
+      options.visibilityTimeout ?? JOB_VISIBILITY_TIMEOUT
+    const orphanRecoveryInterval =
+      options.orphanRecoveryInterval ?? ORPHAN_RECOVERY_INTERVAL
+
+    yield* Effect.all(
+      [
+        runQueuePollLoop(
+          generation,
+          idlePollInterval,
+          claimAndRunLifecycleJob(visibilityTimeout, orphanRecoveryInterval),
+          "Lifecycle job queue",
+        ),
+        runQueuePollLoop(
+          generation,
+          idlePollInterval,
+          claimAndRunRefreshJob(visibilityTimeout),
+          "Issue refresh job queue",
+        ),
+      ],
+      { concurrency: "unbounded", discard: true },
+    )
+  })
+
 export const JobWorkerLive = Layer.effectDiscard(
-  runJobWorker().pipe(Effect.forkScoped({ startImmediately: true })),
+  Effect.gen(function* () {
+    yield* transferPersistedRefreshJobs
+    yield* runJobWorker().pipe(Effect.forkScoped({ startImmediately: true }))
+  }),
 )

--- a/apps/harness/test/job-worker.test.ts
+++ b/apps/harness/test/job-worker.test.ts
@@ -38,17 +38,20 @@ import {
   type RawJob,
   makeJobId,
 } from "@ready-for-agent/queue-service"
+import { SqliteQueueServiceLive } from "@ready-for-agent/sqlite-queue-service"
 import {
   WorkItemLifecycle,
   WorkItemStepJob,
   makeStepRunId,
 } from "@ready-for-agent/work-item-lifecycle"
 import {
+  ISSUE_REFRESH_QUEUE,
   JOBS_QUEUE,
   JOB_RECOVERY_RETRY_LIMIT,
   JOB_VISIBILITY_TIMEOUT,
   enqueueRefreshRepositoryJob,
   runJobWorker,
+  transferPersistedRefreshJobs,
 } from "../src/server/job-worker.js"
 import { describe, expect, test } from "bun:test"
 
@@ -57,16 +60,27 @@ const repository = makeRepositoryRecord({
   paused: true,
 })
 
+const otherRepository = makeRepositoryRecord({
+  id: "repo-01J00000000000000000000001",
+  githubOwner: "acme",
+  githubRepo: "gadgets",
+  localPath: "/repos/acme/gadgets.git",
+  paused: true,
+})
+
 const refreshPayload = {
   _tag: "refresh-repository" as const,
   repositoryId: RepositoryId.make(repository.id),
 }
 
-const rawJob = (payload: unknown): RawJob => {
+const rawJob = (
+  payload: unknown,
+  queue: string = ISSUE_REFRESH_QUEUE,
+): RawJob => {
   const now = DateTime.makeUnsafe(0)
   return {
     jobId: makeJobId(),
-    queue: JOBS_QUEUE,
+    queue,
     key: null,
     payload,
     attempts: 1,
@@ -92,7 +106,7 @@ const queueLayer = (
   jobs: RawJob[],
   onAcknowledge: (jobId: string) => Effect.Effect<unknown> = () => Effect.void,
   onFail: (jobId: string) => Effect.Effect<unknown> = () => Effect.void,
-  onClaim?: () => Effect.Effect<Option.Option<RawJob>, ClaimError>,
+  onClaim?: (queue: string) => Effect.Effect<Option.Option<RawJob>, ClaimError>,
   runStep: (
     stepRunId: string,
   ) => Effect.Effect<{ readonly _tag: "noop" }> = () =>
@@ -112,13 +126,16 @@ const queueLayer = (
       listKeyed: unused,
       postponeKeyed: unused,
       removeKeyed: unused,
-      rawClaim: (_queue, visibilityTimeout) =>
+      rawClaim: (queueName, visibilityTimeout) =>
         Effect.gen(function* () {
           expect(Duration.toMillis(visibilityTimeout ?? Duration.zero)).toBe(
             Duration.toMillis(JOB_VISIBILITY_TIMEOUT),
           )
-          if (onClaim !== undefined) return yield* onClaim()
-          return Option.fromNullishOr(jobs.shift())
+          if (onClaim !== undefined) return yield* onClaim(queueName)
+          const index = jobs.findIndex((job) => job.queue === queueName)
+          if (index === -1) return Option.none()
+          const [job] = jobs.splice(index, 1)
+          return Option.some(job)
         }),
       acknowledge: (jobId) => onAcknowledge(jobId).pipe(Effect.asVoid),
       fail: (jobId, options) =>
@@ -129,6 +146,7 @@ const queueLayer = (
       extendVisibility: (jobId, timeout) =>
         onExtendVisibility(jobId, timeout).pipe(Effect.asVoid),
       getStats: unused,
+      requeueByPayloadTag: () => Effect.succeed(0),
     } satisfies QueueServiceShape),
     Layer.succeed(WorkItemLifecycle, {
       maxDurations: {
@@ -171,7 +189,7 @@ const runScoped = <A, E, R>(
   )
 
 describe("Job worker", () => {
-  test("enqueues a validated Refresh Job with one recovery claim", async () => {
+  test("enqueues a validated Refresh Job on the issue-refresh queue", async () => {
     let enqueued:
       | {
           queue: string
@@ -200,6 +218,7 @@ describe("Job worker", () => {
       fail: unused,
       extendVisibility: unused,
       getStats: unused,
+      requeueByPayloadTag: () => Effect.succeed(0),
     } satisfies QueueServiceShape)
 
     await Effect.runPromise(
@@ -209,7 +228,7 @@ describe("Job worker", () => {
     )
 
     expect(enqueued).toEqual({
-      queue: JOBS_QUEUE,
+      queue: ISSUE_REFRESH_QUEUE,
       payload: refreshPayload,
       retryLimit: JOB_RECOVERY_RETRY_LIMIT,
     })
@@ -218,7 +237,7 @@ describe("Job worker", () => {
   test("extends a Lifecycle Job lease and leaves a live no-op unacknowledged", async () => {
     const stepRunId = makeStepRunId()
     const payload = WorkItemStepJob.make({ stepRunId })
-    const job = rawJob(payload)
+    const job = rawJob(payload, JOBS_QUEUE)
     const dispatched = await Effect.runPromise(Deferred.make<string>())
     const extended = await Effect.runPromise(
       Deferred.make<{ readonly jobId: string; readonly timeoutMs: number }>(),
@@ -378,11 +397,21 @@ describe("Job worker", () => {
   })
 
   test("marks malformed and unknown payloads terminal", async () => {
-    for (const payload of [
-      { _tag: "refresh-repository", repositoryId: "invalid" },
-      { _tag: "unknown-job", repositoryId: repository.id },
+    for (const { payload, queue } of [
+      {
+        payload: { _tag: "refresh-repository", repositoryId: "invalid" },
+        queue: ISSUE_REFRESH_QUEUE,
+      },
+      {
+        payload: { _tag: "unknown-job", repositoryId: repository.id },
+        queue: ISSUE_REFRESH_QUEUE,
+      },
+      {
+        payload: { _tag: "unknown-job", stepRunId: "srun-bad" },
+        queue: JOBS_QUEUE,
+      },
     ]) {
-      const job = rawJob(payload)
+      const job = rawJob(payload, queue)
       const failed = await Effect.runPromise(Deferred.make<string>())
       await runScoped(
         Effect.gen(function* () {
@@ -611,8 +640,14 @@ describe("Job worker", () => {
     )
   })
 
-  test("executes duplicate Refresh Jobs serially", async () => {
-    const jobs = [rawJob(refreshPayload), rawJob(refreshPayload)]
+  test("executes duplicate Refresh Jobs serially across repositories", async () => {
+    const jobs = [
+      rawJob(refreshPayload),
+      rawJob({
+        _tag: "refresh-repository",
+        repositoryId: RepositoryId.make(otherRepository.id),
+      }),
+    ]
     const firstStarted = await Effect.runPromise(Deferred.make<void>())
     const releaseFirst = await Effect.runPromise(Deferred.make<void>())
     const secondStarted = await Effect.runPromise(Deferred.make<void>())
@@ -653,21 +688,91 @@ describe("Job worker", () => {
         yield* Deferred.await(secondStarted)
         expect(maximumActive).toBe(1)
       }),
-      Layer.mergeAll(queueLayer(jobs), dbLayer(), reconciler),
+      Layer.mergeAll(
+        queueLayer(jobs),
+        dbLayer([repository, otherRepository]),
+        reconciler,
+      ),
+    )
+  })
+
+  test("runs Work Item lifecycle jobs while Issue refresh is active", async () => {
+    const refreshJob = rawJob(refreshPayload)
+    const stepRunId = makeStepRunId()
+    const lifecycleJob = rawJob(WorkItemStepJob.make({ stepRunId }), JOBS_QUEUE)
+    const jobs = [refreshJob, lifecycleJob]
+    const refreshStarted = await Effect.runPromise(Deferred.make<void>())
+    const releaseRefresh = await Effect.runPromise(Deferred.make<void>())
+    const lifecycleDispatched = await Effect.runPromise(Deferred.make<string>())
+    const lifecycleLeaseExtended = await Effect.runPromise(
+      Deferred.make<string>(),
+    )
+    let refreshActiveDuringLifecycle = false
+
+    const reconciler = Layer.succeed(IssueReconciler, {
+      reconcile: () =>
+        Effect.gen(function* () {
+          yield* Deferred.succeed(refreshStarted, undefined)
+          yield* Deferred.await(releaseRefresh)
+          return {
+            fetched: 0,
+            inserted: 0,
+            updated: 0,
+            deleted: 0,
+            unchanged: 0,
+          }
+        }),
+    } satisfies IssueReconcilerShape)
+
+    await runScoped(
+      Effect.gen(function* () {
+        yield* runJobWorker({ idlePollInterval: Duration.zero }).pipe(
+          Effect.forkScoped({ startImmediately: true }),
+        )
+        yield* Deferred.await(refreshStarted)
+        expect(yield* Deferred.await(lifecycleDispatched)).toBe(stepRunId)
+        expect(refreshActiveDuringLifecycle).toBe(true)
+        expect(yield* Deferred.await(lifecycleLeaseExtended)).toBe(
+          lifecycleJob.jobId,
+        )
+        yield* Deferred.succeed(releaseRefresh, undefined)
+      }),
+      Layer.merge(
+        queueLayer(
+          jobs,
+          undefined,
+          undefined,
+          undefined,
+          (receivedStepRunId) =>
+            Effect.gen(function* () {
+              refreshActiveDuringLifecycle = true
+              yield* Deferred.succeed(lifecycleDispatched, receivedStepRunId)
+              return { _tag: "noop" as const }
+            }),
+          (jobId) => Deferred.succeed(lifecycleLeaseExtended, jobId),
+        ),
+        Layer.merge(dbLayer(), reconciler),
+      ),
     )
   })
 
   test("recovers after a queue infrastructure error", async () => {
     const job = rawJob(refreshPayload)
     const acknowledged = await Effect.runPromise(Deferred.make<void>())
-    let claims = 0
-    const claim = () => {
-      claims += 1
-      return claims === 1
+    let refreshClaims = 0
+    const claim = (queueName: string) => {
+      if (queueName !== ISSUE_REFRESH_QUEUE) {
+        return Effect.succeed(Option.none())
+      }
+      refreshClaims += 1
+      return refreshClaims === 1
         ? Effect.fail(
-            new ClaimError({ queue: JOBS_QUEUE, message: "temporarily down" }),
+            new ClaimError({
+              queue: ISSUE_REFRESH_QUEUE,
+              message: "temporarily down",
+            }),
           )
-        : Effect.succeed(claims === 2 ? Option.some(job) : Option.none())
+        : Effect.succeed(refreshClaims === 2 ? Option.some(job) : Option.none())
     }
 
     await runScoped(
@@ -676,7 +781,7 @@ describe("Job worker", () => {
           Effect.forkScoped({ startImmediately: true }),
         )
         yield* Deferred.await(acknowledged)
-        expect(claims).toBe(2)
+        expect(refreshClaims).toBe(2)
       }),
       Layer.mergeAll(
         queueLayer(
@@ -737,6 +842,58 @@ describe("Job worker", () => {
         dbLayer(),
         reconciler,
       ),
+    )
+  })
+
+  test("transfers persisted Refresh Jobs into the issue-refresh queue once", async () => {
+    const database = DbServiceLive.pipe(Layer.provideMerge(DatabaseTest))
+    const queue = SqliteQueueServiceLive.pipe(Layer.provideMerge(database))
+    const layer = Layer.mergeAll(database, queue)
+
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        const service = yield* QueueService
+        const retainedId = yield* service.enqueue(
+          JOBS_QUEUE,
+          {
+            _tag: "refresh-repository",
+            repositoryId: RepositoryId.make(repository.id),
+          },
+          { retryLimit: JOB_RECOVERY_RETRY_LIMIT },
+        )
+        const lifecycleId = yield* service.enqueue(
+          JOBS_QUEUE,
+          WorkItemStepJob.make({ stepRunId: makeStepRunId() }),
+          { retryLimit: JOB_RECOVERY_RETRY_LIMIT },
+        )
+
+        const moved = yield* transferPersistedRefreshJobs
+        expect(moved).toBe(1)
+        const movedAgain = yield* transferPersistedRefreshJobs
+        expect(movedAgain).toBe(0)
+
+        const fromLifecycle = yield* service.rawClaim(JOBS_QUEUE)
+        expect(Option.isSome(fromLifecycle)).toBe(true)
+        if (Option.isSome(fromLifecycle)) {
+          expect(fromLifecycle.value.jobId).toBe(lifecycleId)
+          expect(fromLifecycle.value.payload).toMatchObject({
+            _tag: "work-item-step",
+          })
+        }
+
+        const fromRefresh = yield* service.rawClaim(ISSUE_REFRESH_QUEUE)
+        expect(Option.isSome(fromRefresh)).toBe(true)
+        if (Option.isSome(fromRefresh)) {
+          expect(fromRefresh.value.jobId).toBe(retainedId)
+          expect(fromRefresh.value.payload).toEqual({
+            _tag: "refresh-repository",
+            repositoryId: repository.id,
+          })
+        }
+
+        const noDuplicate = yield* service.rawClaim(ISSUE_REFRESH_QUEUE)
+        expect(Option.isNone(noDuplicate)).toBe(true)
+      }).pipe(Effect.provide(layer), Effect.orDie),
     )
   })
 })

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "harness-cli": "bun nx run cli:run --",
     "knip": "knip --no-config-hints",
     "lint": "biome check .",
-    "prepare": "bash scripts/install-git-hooks.sh && effect-tsgo patch"
+    "prepare": "bash scripts/install-git-hooks.sh && effect-tsgo patch && node scripts/fix-bun-typescript-for-nx.mjs"
   },
   "private": true,
   "dependencies": {},

--- a/packages/graphql-api/src/lib/graphql-api.ts
+++ b/packages/graphql-api/src/lib/graphql-api.ts
@@ -245,7 +245,8 @@ export type GraphqlRuntime = ManagedRuntime.ManagedRuntime<
   unknown
 >
 
-const JOBS_QUEUE = "jobs"
+/** High-priority manual Issue Refresh Job queue (must match harness). */
+export const ISSUE_REFRESH_QUEUE = "issue-refresh"
 const JOB_RECOVERY_RETRY_LIMIT = 1
 
 type Repository = {
@@ -258,7 +259,7 @@ const enqueueRefreshRepositoryJob = (repository: Repository) =>
   Effect.gen(function* () {
     const queue = yield* QueueService
     return yield* queue.enqueue(
-      JOBS_QUEUE,
+      ISSUE_REFRESH_QUEUE,
       {
         _tag: "refresh-repository",
         repositoryId: RepositoryId.make(repository.id),

--- a/packages/graphql-api/test/graphql-api.test.ts
+++ b/packages/graphql-api/test/graphql-api.test.ts
@@ -165,6 +165,7 @@ const makeRuntime = (
     fail: () => Effect.die("not used"),
     extendVisibility: () => Effect.die("not used"),
     getStats: () => Effect.die("not used"),
+    requeueByPayloadTag: () => Effect.succeed(0),
     ...queueOverrides,
   }
   const lifecycle: WorkItemLifecycleShape = {
@@ -313,7 +314,7 @@ describe("GraphQL API", () => {
       },
     })
     expect(enqueued).toEqual({
-      queue: "jobs",
+      queue: "issue-refresh",
       payload: {
         _tag: "refresh-repository",
         repositoryId: repository.id,
@@ -368,7 +369,7 @@ describe("GraphQL API", () => {
         enqueue: () =>
           Effect.fail(
             new EnqueueError({
-              queue: "jobs",
+              queue: "issue-refresh",
               message: "queue unavailable",
             }),
           ),
@@ -1657,7 +1658,7 @@ describe("GraphQL API", () => {
     expect(repository.paused).toBe(true)
     expect(reconcilerCalled).toBe(false)
     expect(enqueued).toEqual({
-      queue: "jobs",
+      queue: "issue-refresh",
       payload: {
         _tag: "refresh-repository",
         repositoryId: repository.id,
@@ -1761,7 +1762,7 @@ describe("GraphQL API", () => {
         enqueue: () =>
           Effect.fail(
             new EnqueueError({
-              queue: "jobs",
+              queue: "issue-refresh",
               message: "queue unavailable",
             }),
           ),

--- a/packages/queue-service/src/lib/queue-service.ts
+++ b/packages/queue-service/src/lib/queue-service.ts
@@ -243,6 +243,17 @@ export interface QueueServiceShape {
   readonly getStats: (
     queue: string,
   ) => Effect.Effect<QueueStats, InvalidQueueNameError>
+
+  /**
+   * Move all jobs whose payload `_tag` matches from one queue to another.
+   * Preserves job identity and remaining columns. Idempotent when none match.
+   * Returns the number of jobs moved.
+   */
+  readonly requeueByPayloadTag: (
+    fromQueue: string,
+    toQueue: string,
+    payloadTag: string,
+  ) => Effect.Effect<number, EnqueueError | InvalidQueueNameError>
 }
 
 export class QueueService extends Context.Service<

--- a/packages/sqlite-queue-service/src/lib/sqlite-queue-service.ts
+++ b/packages/sqlite-queue-service/src/lib/sqlite-queue-service.ts
@@ -494,6 +494,37 @@ export const SqliteQueueServiceLive = Layer.effect(
               | undefined) ?? { pending: 0, processing: 0, deadLetter: 0 }
           )
         }),
+      requeueByPayloadTag: (
+        fromQueue: string,
+        toQueue: string,
+        payloadTag: string,
+      ) =>
+        Effect.gen(function* () {
+          yield* validateQueueName(fromQueue)
+          yield* validateQueueName(toQueue)
+          if (fromQueue === toQueue) return 0
+          const now = Date.now()
+          const rows = yield* retrySqliteBusy(
+            sql.unsafe(
+              `UPDATE job_queue
+               SET queue = ?, updated_at = ?
+               WHERE queue = ?
+                 AND json_extract(job_payload, '$._tag') = ?
+               RETURNING id`,
+              [toQueue, now, fromQueue, payloadTag],
+            ),
+          ).pipe(
+            Effect.mapError(
+              (error) =>
+                new EnqueueError({
+                  queue: toQueue,
+                  message: `Database error: ${formatSqlError(error)}`,
+                  cause: error,
+                }),
+            ),
+          )
+          return rows.length
+        }),
     })
   }),
 )

--- a/packages/sqlite-queue-service/test/sqlite-queue-service.spec.ts
+++ b/packages/sqlite-queue-service/test/sqlite-queue-service.spec.ts
@@ -702,6 +702,51 @@ describe("SqliteQueueService", () => {
           expect(jobId).not.toBe(zeroDelayId)
         }),
       ))
+
+    it("moves jobs by payload tag between queues without duplication", () =>
+      runTest(
+        Effect.gen(function* () {
+          const queue = yield* QueueService
+          const refreshId = yield* queue.enqueue("from-queue", {
+            _tag: "refresh-repository",
+            repositoryId: "repo-1",
+          })
+          const otherId = yield* queue.enqueue("from-queue", {
+            _tag: "work-item-step",
+            stepRunId: "srun-1",
+          })
+
+          const moved = yield* queue.requeueByPayloadTag(
+            "from-queue",
+            "to-queue",
+            "refresh-repository",
+          )
+          expect(moved).toBe(1)
+          expect(
+            yield* queue.requeueByPayloadTag(
+              "from-queue",
+              "to-queue",
+              "refresh-repository",
+            ),
+          ).toBe(0)
+
+          const remaining = yield* queue.rawClaim("from-queue")
+          expect(Option.isSome(remaining)).toBe(true)
+          if (Option.isSome(remaining)) {
+            expect(remaining.value.jobId).toBe(otherId)
+          }
+
+          const transferred = yield* queue.rawClaim("to-queue")
+          expect(Option.isSome(transferred)).toBe(true)
+          if (Option.isSome(transferred)) {
+            expect(transferred.value.jobId).toBe(refreshId)
+            expect(transferred.value.payload).toEqual({
+              _tag: "refresh-repository",
+              repositoryId: "repo-1",
+            })
+          }
+        }),
+      ))
   })
 
   describe("queue name validation", () => {

--- a/packages/work-item-lifecycle/test/work-item-lifecycle.spec.ts
+++ b/packages/work-item-lifecycle/test/work-item-lifecycle.spec.ts
@@ -478,6 +478,7 @@ describe("WorkItemLifecycle", () => {
         extendVisibility: () => Effect.void,
         getStats: () =>
           Effect.succeed({ pending: 0, processing: 0, deadLetter: 0 }),
+        requeueByPayloadTag: () => Effect.succeed(0),
       }
 
       const layer = WorkItemLifecycleLive.pipe(
@@ -955,6 +956,7 @@ describe("WorkItemLifecycle", () => {
         extendVisibility: () => Effect.void,
         getStats: () =>
           Effect.succeed({ pending: 0, processing: 0, deadLetter: 0 }),
+        requeueByPayloadTag: () => Effect.succeed(0),
       }
 
       const NonTransactionalQueueLive = Layer.succeed(
@@ -2266,6 +2268,7 @@ describe("WorkItemLifecycle", () => {
         extendVisibility: () => Effect.void,
         getStats: () =>
           Effect.succeed({ pending: 0, processing: 0, deadLetter: 0 }),
+        requeueByPayloadTag: () => Effect.succeed(0),
       }
 
       // Real DB + fake queue so we can fail the post-success enqueue.

--- a/scripts/fix-bun-typescript-for-nx.mjs
+++ b/scripts/fix-bun-typescript-for-nx.mjs
@@ -1,0 +1,47 @@
+/**
+ * Bun installs `@typescript/native` (npm:typescript@7) under the package name
+ * `typescript`, which can occupy `node_modules/.bun/node_modules/typescript`.
+ * Nested requires (e.g. Nx 23) then load TS 7's stub entry without
+ * `readConfigFile` and fail project-graph construction.
+ *
+ * Classic TS is already linked at the workspace root as `typescript`
+ * (`@typescript/typescript6`). Removing the nested shadow makes Node continue
+ * to that root install. `@typescript/native` keeps its own scoped path.
+ */
+import { existsSync, lstatSync, readFileSync, rmSync } from "node:fs"
+import { createRequire } from "node:module"
+import { dirname, join } from "node:path"
+import { fileURLToPath } from "node:url"
+
+const root = join(dirname(fileURLToPath(import.meta.url)), "..")
+const nestedTypescript = join(
+  root,
+  "node_modules",
+  ".bun",
+  "node_modules",
+  "typescript",
+)
+
+if (!existsSync(nestedTypescript)) process.exit(0)
+
+const packageJsonPath = join(nestedTypescript, "package.json")
+if (!existsSync(packageJsonPath)) process.exit(0)
+
+const { version, name } = JSON.parse(readFileSync(packageJsonPath, "utf8"))
+const requireFromNested = createRequire(join(nestedTypescript, "package.json"))
+
+let hasReadConfigFile = false
+try {
+  const ts = requireFromNested(".")
+  hasReadConfigFile = typeof ts.readConfigFile === "function"
+} catch {
+  hasReadConfigFile = false
+}
+
+if (name === "typescript" && !hasReadConfigFile) {
+  const stat = lstatSync(nestedTypescript)
+  rmSync(nestedTypescript, { recursive: !stat.isSymbolicLink(), force: true })
+  console.log(
+    `fix-bun-typescript-for-nx: removed nested typescript@${version} shadow so Nx can use classic TypeScript`,
+  )
+}


### PR DESCRIPTION
## Summary

- Route manual Refresh Jobs to a dedicated high-priority `issue-refresh` queue and run them on a serial polling worker independent of Work Item lifecycle jobs on `jobs`.
- Transfer any persisted pre-split `refresh-repository` rows from `jobs` into `issue-refresh` once at startup so they are not dropped, duplicated, or dual-claimed.
- Preserve existing GraphQL refresh acceptance, terminal failure after one reconciliation attempt, and success-only Issue-change notifications.

## Test plan

- [x] Harness job-worker tests: queue routing, serial multi-repo refresh, terminal failure, notifications, lifecycle independence, persisted-job transfer
- [x] GraphQL API tests for enqueue target queue
- [x] SQLite queue service tests for `requeueByPayloadTag`
- [x] Pre-commit nx-affected lint/typecheck/test

Closes #159