### PR TITLE
fix(github-service): load PR status checks via GraphQL

### DIFF
--- a/docs/adr/0013-watch-pr-status-checks.md
+++ b/docs/adr/0013-watch-pr-status-checks.md
@@ -7,7 +7,7 @@ Investigate PR Status Checks continues the Implement OpenCode Session with the R
 ## Consequences
 
 - Every poll and investigation is a separate Step Run, preserving durable execution history and at-least-once queue behavior.
-- New Repository credentials request Actions read and Commit statuses read. Individual PR Status Checks are loaded via the Actions and commit-status REST APIs (fine-grained PATs cannot call the Checks API / GraphQL CheckRun nodes). Actions read also lets OpenCode inspect workflow logs.
+- New Repository credentials request Actions read and Commit statuses read. Individual PR Status Checks are loaded from the paginated GraphQL status-check rollup. Actions read also lets OpenCode inspect workflow logs.
 - A newly created PR that is not yet visible through GitHub is treated as pending; a visible PR with a null rollup is `no_checks` (not green) until the 60-second grace elapses.
 - Same-state watch requeues preserve `state_ready_at` so residence time (and the `no_checks` grace) accumulate across polls.
 - A merged PR is treated as green and advances to Mark PR Ready for Review (a no-op if already non-draft); a closed, unmerged PR enters Needs Human instead of polling forever.

--- a/docs/adr/0016-handoff-individual-pr-status-checks.md
+++ b/docs/adr/0016-handoff-individual-pr-status-checks.md
@@ -4,7 +4,7 @@ status: accepted
 
 # Hand Off Individual PR Status Checks
 
-Extend Watch PR Status Checks to poll the individual GitHub Actions jobs and classic commit statuses behind the aggregate rollup (via REST; fine-grained PATs cannot read GraphQL CheckRun nodes). Persist each execution that reaches an explicit green result (`SUCCESS`) or red result (`FAILURE`, `ERROR`, `TIMED_OUT`, `ACTION_REQUIRED`, or `STARTUP_FAILURE`) and whether it has been handed to OpenCode; neutral, skipped, cancelled, stale, and pending results do not trigger a handoff.
+Extend Watch PR Status Checks to poll the individual CheckRun and StatusContext entries behind the aggregate GraphQL status-check rollup. Persist each observed CheckRun execution and StatusContext that reaches an explicit green result (`SUCCESS`) or red result (`FAILURE`, `ERROR`, `TIMED_OUT`, `ACTION_REQUIRED`, or `STARTUP_FAILURE`) and whether it has been handed to OpenCode; neutral, skipped, cancelled, stale, and pending results do not trigger a handoff.
 
 Batch every currently unhandled result into one run of the existing Investigate PR Status Checks Lifecycle Step, continuing the Work Item's Implement Session with its GitHub credential. Investigation is two OpenCode turns on that Session: (1) address red checks / worthwhile completed review feedback, commit and push, without a result marker; (2) a short follow-up that only asks for `READY_FOR_AGENT_RESULT: PROCESSED` or `READY_FOR_AGENT_RESULT: NEEDS_HUMAN: <reason>`. When the batch contains any green check, turn (1) also says that automated reviews may have completed and asks OpenCode to inspect the latest pull-request comments, disregard reviews visibly still in progress, and address worthwhile completed feedback.
 

--- a/packages/github-service/src/lib/github-service-live.ts
+++ b/packages/github-service/src/lib/github-service-live.ts
@@ -1,4 +1,4 @@
-import { Config, Effect, Layer, Redacted } from "effect"
+import { Config, Duration, Effect, Layer, Redacted, Schedule } from "effect"
 import {
   type FieldsSelection,
   createClient,
@@ -25,7 +25,6 @@ import type {
 } from "./types.js"
 
 const GITHUB_GRAPHQL_URL = "https://api.github.com/graphql"
-const GITHUB_REST_URL = "https://api.github.com"
 const READY_FOR_AGENT_LABEL = "ready-for-agent"
 const PAGE_SIZE = 100
 const REQUEST_TIMEOUT = "30 seconds"
@@ -39,15 +38,6 @@ export interface GitHubGraphqlClient {
     request: R & { readonly __name?: string },
     signal?: AbortSignal,
   ) => Promise<FieldsSelection<Mutation, R>>
-}
-
-/**
- * Minimal REST client used for individual PR status checks.
- * Fine-grained PATs cannot read CheckRun GraphQL nodes (Checks API gap);
- * Actions jobs + classic commit statuses remain available via REST.
- */
-export interface GitHubRestClient {
-  readonly getJson: (path: string, signal?: AbortSignal) => Promise<unknown>
 }
 
 const githubRequest = <A>(
@@ -66,13 +56,51 @@ const githubRequest = <A>(
     ),
   )
 
+const githubQuery = <A>(
+  message: string,
+  request: (signal: AbortSignal) => Promise<A>,
+): Effect.Effect<A, GitHubRequestError> =>
+  githubRequest(message, request).pipe(
+    Effect.retry({
+      schedule: Schedule.addDelay(Schedule.recurs(2), () =>
+        Effect.succeed(Duration.millis(500)),
+      ),
+    }),
+  )
+
+interface GitHubApiCheckRun {
+  readonly __typename?: "CheckRun"
+  readonly databaseId?: unknown
+  readonly name?: unknown
+  readonly status?: unknown
+  readonly conclusion?: unknown
+}
+
+interface GitHubApiStatusContext {
+  readonly __typename?: "StatusContext"
+  readonly id?: unknown
+  readonly context?: unknown
+  readonly state?: unknown
+}
+
 interface GitHubApiPullRequest {
   readonly state: unknown
   readonly merged: unknown
   readonly headRefOid?: unknown
   readonly baseRefName: unknown
   readonly mergeable: unknown
-  readonly statusCheckRollup: { readonly state: unknown } | null
+  readonly statusCheckRollup: {
+    readonly state: unknown
+    readonly contexts?: {
+      readonly nodes?:
+        | readonly (GitHubApiCheckRun | GitHubApiStatusContext | null)[]
+        | null
+      readonly pageInfo?: {
+        readonly endCursor?: unknown
+        readonly hasNextPage?: unknown
+      }
+    }
+  } | null
 }
 
 const emptyTerminalChecks: readonly TerminalPrStatusCheck[] = []
@@ -154,207 +182,118 @@ const toPullRequestCheckStatus = (
   throw new Error(`Invalid GitHub status check state: ${state}`)
 }
 
-const mapActionsJob = (job: {
-  readonly id?: unknown
-  readonly name?: unknown
-  readonly status?: unknown
-  readonly conclusion?: unknown
-}): TerminalPrStatusCheck | null => {
-  if (job.status !== "completed") {
+const mapCheckRun = (
+  check: GitHubApiCheckRun,
+): TerminalPrStatusCheck | null => {
+  if (check.status !== "COMPLETED") {
     return null
   }
-  if (typeof job.id !== "number" || !Number.isSafeInteger(job.id)) {
-    throw new Error("Invalid GitHub Actions job identity")
+  if (
+    typeof check.databaseId !== "number" ||
+    !Number.isSafeInteger(check.databaseId)
+  ) {
+    throw new Error("Invalid GitHub CheckRun identity")
   }
-  if (typeof job.name !== "string" || job.name.trim() === "") {
-    throw new Error("Invalid GitHub Actions job name")
+  if (typeof check.name !== "string" || check.name.trim() === "") {
+    throw new Error("Invalid GitHub CheckRun name")
   }
-  const conclusion = job.conclusion
-  if (conclusion === "success") {
+  const conclusion = check.conclusion
+  if (conclusion === "SUCCESS") {
     return {
-      externalId: `actions-job:${job.id}`,
-      name: job.name,
+      externalId: `actions-job:${check.databaseId}`,
+      name: check.name,
       outcome: "green",
     }
   }
   if (
-    conclusion === "failure" ||
-    conclusion === "timed_out" ||
-    conclusion === "action_required" ||
-    conclusion === "startup_failure"
+    conclusion === "FAILURE" ||
+    conclusion === "TIMED_OUT" ||
+    conclusion === "ACTION_REQUIRED" ||
+    conclusion === "STARTUP_FAILURE"
   ) {
     return {
-      externalId: `actions-job:${job.id}`,
-      name: job.name,
+      externalId: `actions-job:${check.databaseId}`,
+      name: check.name,
       outcome: "red",
     }
   }
-  // cancelled, skipped, neutral, stale, etc. do not hand off
+  // CANCELLED, SKIPPED, NEUTRAL, STALE, etc. do not hand off
   return null
 }
 
-const mapCommitStatus = (status: {
-  readonly id?: unknown
-  readonly context?: unknown
-  readonly state?: unknown
-}): TerminalPrStatusCheck | null => {
-  if (status.state === "pending") {
+const mapStatusContext = (
+  status: GitHubApiStatusContext,
+): TerminalPrStatusCheck | null => {
+  if (status.state === "PENDING" || status.state === "EXPECTED") {
     return null
   }
   if (typeof status.context !== "string" || status.context.trim() === "") {
-    throw new Error("Invalid GitHub commit status context")
+    throw new Error("Invalid GitHub StatusContext name")
   }
   const externalId =
-    typeof status.id === "number" && Number.isSafeInteger(status.id)
+    typeof status.id === "string" && status.id.trim() !== ""
       ? `status:${status.id}`
       : `status:${status.context}`
-  if (status.state === "success") {
+  if (status.state === "SUCCESS") {
     return {
       externalId,
       name: status.context,
       outcome: "green",
     }
   }
-  if (status.state === "failure" || status.state === "error") {
+  if (status.state === "FAILURE" || status.state === "ERROR") {
     return {
       externalId,
       name: status.context,
       outcome: "red",
     }
   }
-  throw new Error(`Invalid GitHub commit status state: ${status.state}`)
+  throw new Error(`Invalid GitHub StatusContext state: ${status.state}`)
 }
 
-const listTerminalChecksFromRest = (
-  rest: GitHubRestClient,
+const terminalChecksFromRollup = (
+  rollup: GitHubApiPullRequest["statusCheckRollup"],
   repository: { owner: string; name: string },
-  headSha: string,
-): Effect.Effect<readonly TerminalPrStatusCheck[], GitHubRequestError> =>
-  Effect.gen(function* () {
-    const checks: TerminalPrStatusCheck[] = []
-    let runsPage = 1
-    while (true) {
-      const runsPath =
-        `/repos/${repository.owner}/${repository.name}/actions/runs` +
-        `?head_sha=${encodeURIComponent(headSha)}&per_page=${PAGE_SIZE}&page=${runsPage}`
-      const runsBody = yield* githubRequest(
-        `Failed to list Actions runs for ${repository.owner}/${repository.name}@${headSha}`,
-        (signal) => rest.getJson(runsPath, signal),
-      )
-      const workflowRuns =
-        typeof runsBody === "object" &&
-        runsBody !== null &&
-        "workflow_runs" in runsBody &&
-        Array.isArray(runsBody.workflow_runs)
-          ? runsBody.workflow_runs
-          : []
-      for (const run of workflowRuns) {
+): Effect.Effect<readonly TerminalPrStatusCheck[], GitHubRequestError> => {
+  if (rollup === null || rollup.contexts?.nodes === undefined) {
+    return Effect.succeed(emptyTerminalChecks)
+  }
+  const checks: TerminalPrStatusCheck[] = []
+  for (const node of rollup.contexts.nodes ?? []) {
+    if (node === null || typeof node !== "object") {
+      continue
+    }
+    const mapped = (() => {
+      try {
         if (
-          typeof run !== "object" ||
-          run === null ||
-          !("id" in run) ||
-          typeof run.id !== "number"
+          node.__typename === "CheckRun" ||
+          ("databaseId" in node && "conclusion" in node)
         ) {
-          continue
+          return mapCheckRun(node as GitHubApiCheckRun)
         }
-        let jobsPage = 1
-        while (true) {
-          const jobsPath =
-            `/repos/${repository.owner}/${repository.name}/actions/runs/${run.id}/jobs` +
-            `?filter=all&per_page=${PAGE_SIZE}&page=${jobsPage}`
-          const jobsBody = yield* githubRequest(
-            `Failed to list Actions jobs for run ${run.id} on ${repository.owner}/${repository.name}`,
-            (signal) => rest.getJson(jobsPath, signal),
-          )
-          const jobs =
-            typeof jobsBody === "object" &&
-            jobsBody !== null &&
-            "jobs" in jobsBody &&
-            Array.isArray(jobsBody.jobs)
-              ? jobsBody.jobs
-              : []
-          for (const job of jobs) {
-            if (typeof job !== "object" || job === null) {
-              continue
-            }
-            const mapped = yield* Effect.try({
-              try: () => mapActionsJob(job as never),
-              catch: (cause) =>
-                new GitHubRequestError({
-                  message: `GitHub returned invalid Actions job data for ${repository.owner}/${repository.name}`,
-                  cause,
-                }),
-            })
-            if (mapped !== null) {
-              checks.push(mapped)
-            }
-          }
-          if (jobs.length < PAGE_SIZE) {
-            break
-          }
-          jobsPage += 1
+        if (
+          node.__typename === "StatusContext" ||
+          ("context" in node && "state" in node)
+        ) {
+          return mapStatusContext(node as GitHubApiStatusContext)
         }
-      }
-      if (workflowRuns.length < PAGE_SIZE) {
-        break
-      }
-      runsPage += 1
-    }
-
-    let statusesPage = 1
-    while (true) {
-      const statusesPath =
-        `/repos/${repository.owner}/${repository.name}/commits/${encodeURIComponent(headSha)}/statuses` +
-        `?per_page=${PAGE_SIZE}&page=${statusesPage}`
-      const statusesBody = yield* githubRequest(
-        `Failed to list commit statuses for ${repository.owner}/${repository.name}@${headSha}`,
-        (signal) => rest.getJson(statusesPath, signal),
-      )
-      const statuses = Array.isArray(statusesBody) ? statusesBody : []
-      for (const status of statuses) {
-        if (typeof status !== "object" || status === null) {
-          continue
-        }
-        const mapped = yield* Effect.try({
-          try: () => mapCommitStatus(status as never),
-          catch: (cause) =>
-            new GitHubRequestError({
-              message: `GitHub returned invalid commit status data for ${repository.owner}/${repository.name}`,
-              cause,
-            }),
+        return null
+      } catch (cause) {
+        return new GitHubRequestError({
+          message: `GitHub returned invalid status check data for ${repository.owner}/${repository.name}`,
+          cause,
         })
-        if (mapped !== null) {
-          checks.push(mapped)
-        }
       }
-      if (statuses.length < PAGE_SIZE) {
-        break
-      }
-      statusesPage += 1
+    })()
+    if (mapped instanceof GitHubRequestError) {
+      return Effect.fail(mapped)
     }
-
-    return uniqueTerminalChecks(checks)
-  })
-
-const makeGitHubRestClient = (token: string): GitHubRestClient => ({
-  getJson: async (path, signal) => {
-    const response = await fetch(`${GITHUB_REST_URL}${path}`, {
-      signal,
-      headers: {
-        Accept: "application/vnd.github+json",
-        Authorization: `Bearer ${token}`,
-        "X-GitHub-Api-Version": "2022-11-28",
-      },
-    })
-    if (!response.ok) {
-      const body = await response.text()
-      throw new Error(
-        `GitHub REST ${path} failed with ${response.status}: ${body.slice(0, 300)}`,
-      )
+    if (mapped !== null) {
+      checks.push(mapped)
     }
-    return response.json() as Promise<unknown>
-  },
-})
+  }
+  return Effect.succeed(uniqueTerminalChecks(checks))
+}
 
 interface GitHubApiIssue {
   readonly number: unknown
@@ -643,14 +582,36 @@ const sortDependencies = (
       left.number - right.number || left.url.localeCompare(right.url),
   )
 
+const statusCheckRollupSelection = (after?: string) =>
+  ({
+    state: true,
+    contexts: {
+      __args: { first: PAGE_SIZE, ...(after === undefined ? {} : { after }) },
+      nodes: {
+        __typename: true,
+        on_CheckRun: {
+          databaseId: true,
+          name: true,
+          status: true,
+          conclusion: true,
+        },
+        on_StatusContext: {
+          id: true,
+          context: true,
+          state: true,
+        },
+      },
+      pageInfo: { endCursor: true, hasNextPage: true },
+    },
+  }) as const
+
 export const makeGitHubService = (
   client: GitHubGraphqlClient,
-  rest?: GitHubRestClient,
 ): GitHubServiceShape => ({
   getPullRequestCheckStatus: Effect.fn(
     "GitHubService.getPullRequestCheckStatus",
   )(function* (repository, headRefName) {
-    const result = yield* githubRequest(
+    const result = yield* githubQuery(
       `Failed to get pull request checks for ${repository.owner}/${repository.name}:${headRefName}`,
       (signal) =>
         client.query(
@@ -668,11 +629,7 @@ export const makeGitHubService = (
                   headRefOid: true,
                   baseRefName: true,
                   mergeable: true,
-                  // Aggregate only: individual CheckRun GraphQL nodes require
-                  // the Checks API, which fine-grained PATs cannot use.
-                  statusCheckRollup: {
-                    state: true,
-                  },
+                  statusCheckRollup: statusCheckRollupSelection(),
                 },
               },
             },
@@ -694,22 +651,61 @@ export const makeGitHubService = (
       }
     }
 
-    let terminalChecks: readonly TerminalPrStatusCheck[] = emptyTerminalChecks
-    if (
-      rest !== undefined &&
-      pullRequest.state === "OPEN" &&
-      typeof pullRequest.headRefOid === "string" &&
-      pullRequest.headRefOid.trim() !== ""
-    ) {
-      terminalChecks = yield* listTerminalChecksFromRest(
-        rest,
+    const terminalChecks = [
+      ...(yield* terminalChecksFromRollup(
+        pullRequest.statusCheckRollup,
         repository,
-        pullRequest.headRefOid,
+      )),
+    ]
+    let pageInfo = pullRequest.statusCheckRollup?.contexts?.pageInfo
+    while (pageInfo?.hasNextPage === true) {
+      const after = pageInfo.endCursor
+      if (typeof after !== "string") {
+        return yield* new GitHubRequestError({
+          message: `GitHub returned invalid status check pagination for ${repository.owner}/${repository.name}:${headRefName}`,
+        })
+      }
+      const page = yield* githubQuery(
+        `Failed to get pull request check page for ${repository.owner}/${repository.name}:${headRefName}`,
+        (signal) =>
+          client.query(
+            {
+              repository: {
+                __args: repository,
+                pullRequests: {
+                  __args: { first: 1, headRefName },
+                  nodes: {
+                    statusCheckRollup: statusCheckRollupSelection(after),
+                  },
+                },
+              },
+            },
+            signal,
+          ),
       )
+      if (page.repository === null) {
+        return yield* new GitHubRepositoryUnavailableError(repository)
+      }
+      const rollup = (page.repository.pullRequests.nodes?.[0]
+        ?.statusCheckRollup ??
+        null) as GitHubApiPullRequest["statusCheckRollup"]
+      if (rollup === null) {
+        return yield* new GitHubRequestError({
+          message: `GitHub omitted status check page data for ${repository.owner}/${repository.name}:${headRefName}`,
+        })
+      }
+      terminalChecks.push(
+        ...(yield* terminalChecksFromRollup(rollup, repository)),
+      )
+      pageInfo = rollup?.contexts?.pageInfo
     }
 
     return yield* Effect.try({
-      try: () => toPullRequestCheckStatus(pullRequest, terminalChecks),
+      try: () =>
+        toPullRequestCheckStatus(
+          pullRequest,
+          uniqueTerminalChecks(terminalChecks),
+        ),
       catch: (cause) =>
         new GitHubRequestError({
           message: `GitHub returned invalid pull request checks for ${repository.owner}/${repository.name}:${headRefName}`,
@@ -719,7 +715,7 @@ export const makeGitHubService = (
   }),
   getOpenPullRequestNumber: Effect.fn("GitHubService.getOpenPullRequestNumber")(
     function* (repository, headRefName) {
-      const result = yield* githubRequest(
+      const result = yield* githubQuery(
         `Failed to find open pull request for ${repository.owner}/${repository.name}:${headRefName}`,
         (signal) =>
           client.query(
@@ -754,7 +750,7 @@ export const makeGitHubService = (
   markPullRequestReadyForReview: Effect.fn(
     "GitHubService.markPullRequestReadyForReview",
   )(function* (repository, headRefName) {
-    const result = yield* githubRequest(
+    const result = yield* githubQuery(
       `Failed to find pull request for ${repository.owner}/${repository.name}:${headRefName}`,
       (signal) =>
         client.query(
@@ -851,7 +847,7 @@ export const makeGitHubService = (
   }),
   mergePullRequest: Effect.fn("GitHubService.mergePullRequest")(
     function* (repository, headRefName) {
-      const result = yield* githubRequest(
+      const result = yield* githubQuery(
         `Failed to find pull request for ${repository.owner}/${repository.name}:${headRefName}`,
         (signal) =>
           client.query(
@@ -973,7 +969,7 @@ export const makeGitHubService = (
       let after: string | null = null
 
       while (true) {
-        const result = yield* githubRequest(
+        const result = yield* githubQuery(
           `Failed to list Ready-labeled Issues for ${repository.owner}/${repository.name}`,
           (signal) =>
             client.query(
@@ -1093,7 +1089,7 @@ export const makeGitHubService = (
               })
             }
 
-            const dependencyResult = yield* githubRequest(
+            const dependencyResult = yield* githubQuery(
               `Failed to list dependencies for ${repository.owner}/${repository.name}#${mappedIssue.number}`,
               (signal) =>
                 client.query(
@@ -1146,7 +1142,7 @@ export const makeGitHubService = (
               })
             }
 
-            const pullRequestResult = yield* githubRequest(
+            const pullRequestResult = yield* githubQuery(
               `Failed to list closing pull requests for ${repositoryName}#${mappedIssue.number}`,
               (signal) =>
                 client.query(
@@ -1206,7 +1202,7 @@ export const makeGitHubService = (
               })
             }
 
-            const subIssueResult = yield* githubRequest(
+            const subIssueResult = yield* githubQuery(
               `Failed to list sub-issues for ${repositoryName}#${mappedIssue.number}`,
               (signal) =>
                 client.query(
@@ -1388,12 +1384,8 @@ const makeGitHubGraphqlClient = (token: string): GitHubGraphqlClient => {
 export const GitHubServiceLive = Layer.effect(
   GitHubService,
   Config.redacted("GITHUB_TOKEN").pipe(
-    Effect.map((token) => {
-      const value = Redacted.value(token)
-      return makeGitHubService(
-        makeGitHubGraphqlClient(value),
-        makeGitHubRestClient(value),
-      )
-    }),
+    Effect.map((token) =>
+      makeGitHubService(makeGitHubGraphqlClient(Redacted.value(token))),
+    ),
   ),
 )

--- a/packages/github-service/test/github-service.spec.ts
+++ b/packages/github-service/test/github-service.spec.ts
@@ -70,7 +70,8 @@ describe("GitHubService live implementation", () => {
         .getOpenPullRequestNumber(repository, "branch")
         .pipe(Effect.result, Effect.forkChild)
       yield* Effect.yieldNow
-      yield* TestClock.adjust("30 seconds")
+      // Three attempts (initial + 2 retries), each with a 30s timeout and 500ms delay.
+      yield* TestClock.adjust("92 seconds")
       const result = yield* Fiber.join(fiber)
 
       expect(requestSignal?.aborted).toBe(true)
@@ -259,103 +260,85 @@ describe("GitHubService live implementation", () => {
     })
   })
 
-  it("loads terminal Actions jobs and commit statuses via REST", async () => {
-    const restPaths: string[] = []
-    const service = makeGitHubService(
-      {
-        query: () =>
-          Promise.resolve({
-            repository: {
-              pullRequests: {
-                nodes: [
-                  {
-                    state: "OPEN",
-                    merged: false,
-                    headRefOid: "sha-head",
-                    baseRefName: "main",
-                    mergeable: "MERGEABLE",
-                    statusCheckRollup: { state: "PENDING" },
+  it("loads terminal CheckRuns and StatusContexts via GraphQL rollup", async () => {
+    const service = makeGitHubService({
+      query: () =>
+        Promise.resolve({
+          repository: {
+            pullRequests: {
+              nodes: [
+                {
+                  state: "OPEN",
+                  merged: false,
+                  headRefOid: "sha-head",
+                  baseRefName: "main",
+                  mergeable: "MERGEABLE",
+                  statusCheckRollup: {
+                    state: "PENDING",
+                    contexts: {
+                      nodes: [
+                        {
+                          __typename: "CheckRun",
+                          databaseId: 100,
+                          name: "unit",
+                          status: "COMPLETED",
+                          conclusion: "SUCCESS",
+                        },
+                        {
+                          __typename: "CheckRun",
+                          databaseId: 101,
+                          name: "lint",
+                          status: "COMPLETED",
+                          conclusion: "FAILURE",
+                        },
+                        {
+                          __typename: "CheckRun",
+                          databaseId: 102,
+                          name: "e2e",
+                          status: "COMPLETED",
+                          conclusion: "TIMED_OUT",
+                        },
+                        {
+                          __typename: "CheckRun",
+                          databaseId: 103,
+                          name: "optional",
+                          status: "COMPLETED",
+                          conclusion: "SKIPPED",
+                        },
+                        {
+                          __typename: "CheckRun",
+                          databaseId: 104,
+                          name: "build",
+                          status: "IN_PROGRESS",
+                          conclusion: null,
+                        },
+                        {
+                          __typename: "StatusContext",
+                          id: "SC_1",
+                          context: "ci/travis",
+                          state: "SUCCESS",
+                        },
+                        {
+                          __typename: "StatusContext",
+                          id: "SC_2",
+                          context: "ci/deploy",
+                          state: "ERROR",
+                        },
+                        {
+                          __typename: "StatusContext",
+                          id: "SC_3",
+                          context: "ci/pending",
+                          state: "PENDING",
+                        },
+                      ],
+                    },
                   },
-                ],
-              },
+                },
+              ],
             },
-          }) as never,
-      },
-      {
-        getJson: async (path) => {
-          restPaths.push(path)
-          if (path.includes("/actions/runs?") && path.includes("page=1")) {
-            return {
-              workflow_runs: [{ id: 10 }, { id: 11 }],
-            }
-          }
-          if (
-            path.endsWith(
-              "/actions/runs/10/jobs?filter=all&per_page=100&page=1",
-            )
-          ) {
-            return {
-              jobs: [
-                {
-                  id: 100,
-                  name: "unit",
-                  status: "completed",
-                  conclusion: "success",
-                },
-                {
-                  id: 101,
-                  name: "lint",
-                  status: "completed",
-                  conclusion: "failure",
-                },
-                {
-                  id: 102,
-                  name: "e2e",
-                  status: "completed",
-                  conclusion: "timed_out",
-                },
-                {
-                  id: 103,
-                  name: "optional",
-                  status: "completed",
-                  conclusion: "skipped",
-                },
-                {
-                  id: 104,
-                  name: "build",
-                  status: "in_progress",
-                  conclusion: null,
-                },
-              ],
-            }
-          }
-          if (
-            path.endsWith(
-              "/actions/runs/11/jobs?filter=all&per_page=100&page=1",
-            )
-          ) {
-            return {
-              jobs: [
-                {
-                  id: 200,
-                  name: "review",
-                  status: "completed",
-                  conclusion: "success",
-                },
-              ],
-            }
-          }
-          if (path.includes("/commits/sha-head/statuses?")) {
-            return [
-              { id: 1, context: "ci/travis", state: "success" },
-              { id: 2, context: "ci/deploy", state: "error" },
-              { id: 3, context: "ci/pending", state: "pending" },
-            ]
-          }
-          throw new Error(`unexpected REST path ${path}`)
-        },
-      },
-    )
+          },
+        }) as never,
+    })
 
     const status = await Effect.runPromise(
       service.getPullRequestCheckStatus(repository, "branch"),
@@ -369,79 +352,137 @@ describe("GitHubService live implementation", () => {
         { externalId: "actions-job:100", name: "unit", outcome: "green" },
         { externalId: "actions-job:101", name: "lint", outcome: "red" },
         { externalId: "actions-job:102", name: "e2e", outcome: "red" },
-        { externalId: "actions-job:200", name: "review", outcome: "green" },
-        { externalId: "status:1", name: "ci/travis", outcome: "green" },
-        { externalId: "status:2", name: "ci/deploy", outcome: "red" },
+        { externalId: "status:SC_1", name: "ci/travis", outcome: "green" },
+        { externalId: "status:SC_2", name: "ci/deploy", outcome: "red" },
       ],
     })
-    expect(restPaths.some((path) => path.includes("head_sha=sha-head"))).toBe(
-      true,
-    )
-    expect(
-      restPaths
-        .filter((path) => path.includes("/jobs?"))
-        .every((path) => path.includes("filter=all")),
-    ).toBe(true)
-    expect(
-      restPaths.some((path) =>
-        path.includes("/commits/sha-head/statuses?per_page=100&page=1"),
-      ),
-    ).toBe(true)
   })
 
-  it("treats Actions job reruns as distinct executions", async () => {
-    let jobsPath = ""
-    const service = makeGitHubService(
-      {
-        query: () =>
-          Promise.resolve({
-            repository: {
-              pullRequests: {
-                nodes: [
-                  {
-                    state: "OPEN",
-                    merged: false,
-                    headRefOid: "sha-head",
-                    baseRefName: "main",
-                    mergeable: "MERGEABLE",
-                    statusCheckRollup: { state: "FAILURE" },
+  it("loads every GraphQL status-check rollup page", async () => {
+    let attempts = 0
+    const service = makeGitHubService({
+      query: () => {
+        attempts += 1
+        return Promise.resolve(
+          attempts === 1
+            ? {
+                repository: {
+                  pullRequests: {
+                    nodes: [
+                      {
+                        state: "OPEN",
+                        merged: false,
+                        headRefOid: "sha-head",
+                        baseRefName: "main",
+                        mergeable: "MERGEABLE",
+                        statusCheckRollup: {
+                          state: "PENDING",
+                          contexts: {
+                            nodes: [
+                              {
+                                __typename: "CheckRun",
+                                databaseId: 100,
+                                name: "unit",
+                                status: "COMPLETED",
+                                conclusion: "SUCCESS",
+                              },
+                            ],
+                            pageInfo: {
+                              endCursor: "page-2",
+                              hasNextPage: true,
+                            },
+                          },
+                        },
+                      },
+                    ],
                   },
-                ],
-              },
-            },
-          }) as never,
-      },
-      {
-        getJson: async (path) => {
-          if (path.includes("/actions/runs?")) {
-            return { workflow_runs: [{ id: 7 }] }
-          }
-          if (path.includes("/jobs")) {
-            jobsPath = path
-            return {
-              jobs: [
-                {
-                  id: 100,
-                  name: "lint",
-                  status: "completed",
-                  conclusion: "failure",
                 },
+              }
+            : {
+                repository: {
+                  pullRequests: {
+                    nodes: [
+                      {
+                        statusCheckRollup: {
+                          state: "PENDING",
+                          contexts: {
+                            nodes: [
+                              {
+                                __typename: "CheckRun",
+                                databaseId: 101,
+                                name: "lint",
+                                status: "COMPLETED",
+                                conclusion: "FAILURE",
+                              },
+                            ],
+                            pageInfo: {
+                              endCursor: null,
+                              hasNextPage: false,
+                            },
+                          },
+                        },
+                      },
+                    ],
+                  },
+                },
+              },
+        ) as never
+      },
+    })
+
+    const status = await Effect.runPromise(
+      service.getPullRequestCheckStatus(repository, "branch"),
+    )
+
+    expect(status).toMatchObject({
+      terminalChecks: [
+        { externalId: "actions-job:100", outcome: "green" },
+        { externalId: "actions-job:101", outcome: "red" },
+      ],
+    })
+    expect(attempts).toBe(2)
+  })
+
+  it("treats distinct CheckRun executions with the same name as separate", async () => {
+    const service = makeGitHubService({
+      query: () =>
+        Promise.resolve({
+          repository: {
+            pullRequests: {
+              nodes: [
                 {
-                  id: 101,
-                  name: "lint",
-                  status: "completed",
-                  conclusion: "success",
+                  state: "OPEN",
+                  merged: false,
+                  headRefOid: "sha-head",
+                  baseRefName: "main",
+                  mergeable: "MERGEABLE",
+                  statusCheckRollup: {
+                    state: "FAILURE",
+                    contexts: {
+                      nodes: [
+                        {
+                          __typename: "CheckRun",
+                          databaseId: 100,
+                          name: "lint",
+                          status: "COMPLETED",
+                          conclusion: "FAILURE",
+                        },
+                        {
+                          __typename: "CheckRun",
+                          databaseId: 101,
+                          name: "lint",
+                          status: "COMPLETED",
+                          conclusion: "SUCCESS",
+                        },
+                      ],
+                    },
+                  },
                 },
               ],
-            }
-          }
-          if (path.includes("/statuses?")) {
-            return []
-          }
-          throw new Error(`unexpected REST path ${path}`)
-        },
-      },
-    )
+            },
+          },
+        }) as never,
+    })
 
     const status = await Effect.runPromise(
       service.getPullRequestCheckStatus(repository, "branch"),
@@ -456,68 +497,44 @@ describe("GitHubService live implementation", () => {
         { externalId: "actions-job:101", name: "lint", outcome: "green" },
       ],
     })
-    expect(jobsPath).toContain("filter=all")
   })
 
-  it("fetches every commit-status execution page", async () => {
-    const restPaths: string[] = []
-    const service = makeGitHubService(
-      {
-        query: () =>
-          Promise.resolve({
-            repository: {
-              pullRequests: {
-                nodes: [
-                  {
-                    state: "OPEN",
-                    merged: false,
-                    headRefOid: "sha-head",
-                    baseRefName: "main",
-                    mergeable: "MERGEABLE",
-                    statusCheckRollup: { state: "PENDING" },
-                  },
-                ],
-              },
+  it("retries transient GraphQL failures", async () => {
+    let attempts = 0
+    const service = makeGitHubService({
+      query: () => {
+        attempts += 1
+        if (attempts < 3) {
+          return Promise.reject(new Error("temporary outage"))
+        }
+        return Promise.resolve({
+          repository: {
+            pullRequests: {
+              nodes: [
+                {
+                  state: "OPEN",
+                  merged: false,
+                  baseRefName: "main",
+                  mergeable: "MERGEABLE",
+                  statusCheckRollup: null,
+                },
+              ],
             },
-          }) as never,
+          },
+        }) as never
       },
-      {
-        getJson: async (path) => {
-          restPaths.push(path)
-          if (path.includes("/actions/runs?")) {
-            return { workflow_runs: [] }
-          }
-          if (path.endsWith("/statuses?per_page=100&page=1")) {
-            return Array.from({ length: 100 }, (_, index) => ({
-              id: index + 1,
-              context: `ci/status-${index + 1}`,
-              state: index === 0 ? "success" : "pending",
-            }))
-          }
-          if (path.endsWith("/statuses?per_page=100&page=2")) {
-            return [{ id: 101, context: "ci/deploy", state: "error" }]
-          }
-          throw new Error(`unexpected REST path ${path}`)
-        },
-      },
-    )
+    })
 
-    const status = await Effect.runPromise(
-      service.getPullRequestCheckStatus(repository, "branch"),
-    )
-
-    expect(status).toEqual({
-      _tag: "pending",
+    expect(
+      await Effect.runPromise(
+        service.getPullRequestCheckStatus(repository, "branch"),
+      ),
+    ).toEqual({
+      _tag: "no_checks",
       mergeability: "mergeable",
       baseRefName: "main",
-      terminalChecks: [
-        { externalId: "status:1", name: "ci/status-1", outcome: "green" },
-        { externalId: "status:101", name: "ci/deploy", outcome: "red" },
-      ],
     })
-    expect(restPaths).toContain(
-      "/repos/acme/widgets/commits/sha-head/statuses?per_page=100&page=2",
-    )
+    expect(attempts).toBe(3)
   })
 
   it("marks a draft PR ready for review and no-ops when already ready", async () => {
@@ -575,6 +592,37 @@ describe("GitHubService live implementation", () => {
     await Effect.runPromise(
       alreadyReady.markPullRequestReadyForReview(repository, "branch"),
     )
+  })
+
+  it("does not retry failed GraphQL mutations", async () => {
+    let mutationAttempts = 0
+    const service = makeGitHubService({
+      query: () =>
+        Promise.resolve({
+          repository: {
+            pullRequests: {
+              nodes: [
+                {
+                  id: "PR_kwDODraft",
+                  isDraft: true,
+                  state: "OPEN",
+                },
+              ],
+            },
+          },
+        }) as never,
+      mutation: () => {
+        mutationAttempts += 1
+        return Promise.reject(new Error("response lost"))
+      },
+    })
+
+    await expect(
+      Effect.runPromise(
+        service.markPullRequestReadyForReview(repository, "branch"),
+      ),
+    ).rejects.toBeInstanceOf(GitHubRequestError)
+    expect(mutationAttempts).toBe(1)
   })
 
   it("fails when the PR for the branch is missing", async () => {

--- a/packages/graphql-api/src/lib/graphql-api.ts
+++ b/packages/graphql-api/src/lib/graphql-api.ts
@@ -300,9 +300,8 @@ const githubTokenCreationUrl = (repository: Repository) => {
   url.searchParams.set("issues", "read")
   url.searchParams.set("contents", "write")
   url.searchParams.set("pull_requests", "write")
-  // Actions jobs power individual PR status-check handoffs (FG PATs cannot use Checks API).
+  // Actions + commit statuses power individual PR status-check handoffs via GraphQL rollup.
   url.searchParams.set("actions", "read")
-  // Classic commit statuses (non-Actions checks), when present.
   url.searchParams.set("statuses", "read")
   return url.toString()
 }


### PR DESCRIPTION
## Why

Watch PR Status Checks failed after Create PR with:

`Failed to list Actions runs for …`

Fine-grained PATs can use GraphQL successfully, but authenticated REST calls to `/actions/runs` were returning 503. That made the status step hard-fail before it could use the GraphQL rollup, so Work Items stalled after PR creation (including issue #159 runs).

## What Changed

- Load individual PR status checks from the GraphQL `statusCheckRollup.contexts` connection (`CheckRun` and `StatusContext`) instead of Actions/commit-status REST.
- Paginate rollup contexts and keep existing `actions-job:<id>` identities for CheckRuns.
- Retry transient GraphQL **queries** only; do not retry mutations.
- Update ADRs 0013 and 0016 to match GraphQL-only status-check loading.

## Verification

- Against PR 168 branch: `get-pr-check-status` returns `no_checks` instead of failing on REST.
- `github-service` tests cover GraphQL mapping, pagination, query retries, and no mutation retries.
