### PR TITLE
fix(layer-turso-local): hold semaphore for full transaction scope

### DIFF
--- a/packages/layer-turso-local/src/lib/client-live.ts
+++ b/packages/layer-turso-local/src/lib/client-live.ts
@@ -1,5 +1,5 @@
 import { connect } from "@tursodatabase/database"
-import { Context, Effect, Layer, Semaphore, Stream } from "effect"
+import { Context, Effect, Layer, Scope, Semaphore, Stream } from "effect"
 import * as Reactivity from "effect/unstable/reactivity/Reactivity"
 import * as Client from "effect/unstable/sql/SqlClient"
 import type { Connection } from "effect/unstable/sql/SqlConnection"
@@ -95,8 +95,16 @@ const makeClient = (path: string, options?: TursoClientOptions) =>
     }
     const semaphore = yield* Semaphore.make(1)
     const acquirer = semaphore.withPermits(1)(Effect.succeed(connection))
-    const transactionAcquirer = semaphore.withPermits(1)(
-      Effect.succeed(connection),
+    const transactionAcquirer = Effect.uninterruptibleMask((restore) =>
+      Effect.withFiber((fiber) => {
+        const scope = Context.getUnsafe(fiber.context, Scope.Scope)
+        return Effect.as(
+          Effect.tap(restore(semaphore.take(1)), () =>
+            Scope.addFinalizer(scope, semaphore.release(1)),
+          ),
+          connection,
+        )
+      }),
     )
 
     return yield* Client.make({

--- a/packages/layer-turso-local/test/concurrent-transaction.spec.ts
+++ b/packages/layer-turso-local/test/concurrent-transaction.spec.ts
@@ -49,6 +49,62 @@ describe("makeTursoLive", () => {
     }
   })
 
+  it("serializes concurrent top-level transactions on one client", async () => {
+    const dbPath = tempDbPath()
+    const TestLayer = makeTestLayer(dbPath)
+
+    try {
+      const result = await Effect.runPromise(
+        Effect.gen(function* () {
+          const sql = yield* SqlClient.SqlClient
+
+          yield* sql(
+            sqlQuery(
+              "CREATE TABLE concurrent_tx (id INTEGER PRIMARY KEY, value TEXT NOT NULL)",
+            ),
+          )
+
+          const tx = (value: string) =>
+            sql.withTransaction(
+              Effect.gen(function* () {
+                yield* sql(
+                  sqlQuery(
+                    `INSERT INTO concurrent_tx (value) VALUES ('${value}')`,
+                  ),
+                )
+                // Yield so a second fiber can race BEGIN while this tx is open.
+                yield* Effect.sleep("20 millis")
+                yield* sql(
+                  sqlQuery(
+                    `UPDATE concurrent_tx SET value = '${value}-done' WHERE value = '${value}'`,
+                  ),
+                )
+              }),
+            )
+
+          const exits = yield* Effect.all([tx("a"), tx("b"), tx("c")], {
+            concurrency: "unbounded",
+            mode: "result",
+          })
+
+          const rows = yield* sql(
+            sqlQuery("SELECT value FROM concurrent_tx ORDER BY id"),
+          )
+          return { exits, rows }
+        }).pipe(Effect.provide(TestLayer)),
+      )
+
+      expect(result.exits.every((exit) => exit._tag === "Success")).toBe(true)
+      expect(result.rows).toEqual([
+        { value: "a-done" },
+        { value: "b-done" },
+        { value: "c-done" },
+      ])
+    } finally {
+      await cleanupDb(dbPath)
+    }
+  })
+
   it("makes writes visible across long-lived clients", async () => {
     const dbPath = tempDbPath()
     const WriterLayer = makeTestLayer(dbPath)


### PR DESCRIPTION
## Why

Harness job workers poll lifecycle and issue-refresh queues concurrently. Both claim paths use `sql.withTransaction` on the shared Turso client. The client's `transactionAcquirer` released the single-connection semaphore as soon as the connection object was returned, not for the full transaction scope, so concurrent `BEGIN IMMEDIATE` calls raced on one connection and failed with nested-transaction errors such as:

`Lifecycle job queue poll failed … cannot start a transaction within a transaction`

## What Changed

- Hold the semaphore permit until the transaction Scope closes, matching `@effect/sql-sqlite-bun`.
- Add a regression test that runs concurrent top-level transactions on one client.