### PR TITLE
feat(work-item-lifecycle): persist OpenCode session id mid-Build

### DIFF
--- a/packages/opencode/src/lib/opencode.ts
+++ b/packages/opencode/src/lib/opencode.ts
@@ -113,12 +113,14 @@ export class Opencode extends Context.Service<
           readonly variant: string
           readonly sessionId?: string
           readonly timeout?: Duration.Input
+          readonly onSessionId?: StartInput["onSessionId"]
         }): Effect.Effect<OpencodeRunResult, OpencodeError> =>
           Effect.gen(function* () {
             const timeout = input.timeout ?? defaultTimeout
             const timeoutMs = Duration.toMillis(timeout)
             const knownSessionId = input.sessionId
             const seenSessionId = yield* Ref.make(knownSessionId)
+            const sessionIdNotified = yield* Ref.make(false)
 
             const args = buildRunArgs({
               prompt: input.prompt,
@@ -149,7 +151,28 @@ export class Opencode extends Context.Service<
                   Stream.tap(({ sessionId }) =>
                     sessionId === undefined
                       ? Effect.void
-                      : Ref.set(seenSessionId, sessionId),
+                      : Effect.gen(function* () {
+                          yield* Ref.set(seenSessionId, sessionId)
+                          const alreadyNotified = yield* Ref.getAndSet(
+                            sessionIdNotified,
+                            true,
+                          )
+                          if (
+                            alreadyNotified ||
+                            input.onSessionId === undefined
+                          ) {
+                            return
+                          }
+                          yield* input.onSessionId(sessionId).pipe(
+                            Effect.catch((error) =>
+                              Effect.logWarning(
+                                "OpenCode onSessionId observer failed",
+                                { sessionId, error },
+                              ),
+                            ),
+                            Effect.forkDetach({ startImmediately: true }),
+                          )
+                        }),
                   ),
                   Stream.runFold(
                     (): { sessionId?: string; assistantText: string } => ({

--- a/packages/opencode/src/lib/types.ts
+++ b/packages/opencode/src/lib/types.ts
@@ -1,4 +1,4 @@
-import type { Duration } from "effect"
+import type { Duration, Effect } from "effect"
 
 export interface OpencodeRunResult {
   readonly sessionId: string
@@ -10,12 +10,22 @@ export interface ListModelsInput {
   readonly timeout?: Duration.Input
 }
 
+/**
+ * Optional observer invoked with the first non-empty sessionID parsed from
+ * OpenCode stdout while the process is still running. Failures must not fail
+ * the run; the OpenCode client catches and logs them.
+ */
+export type OnSessionId = (
+  sessionId: string,
+) => Effect.Effect<void, unknown, never>
+
 export interface StartInput {
   readonly prompt: string
   readonly cwd: string
   readonly model: string
   readonly variant: string
   readonly timeout?: Duration.Input
+  readonly onSessionId?: OnSessionId
 }
 
 export interface ContinueInput {
@@ -25,6 +35,7 @@ export interface ContinueInput {
   readonly model: string
   readonly variant: string
   readonly timeout?: Duration.Input
+  readonly onSessionId?: OnSessionId
 }
 
 export interface OpencodeLayerOptions {

--- a/packages/opencode/test/opencode.spec.ts
+++ b/packages/opencode/test/opencode.spec.ts
@@ -2,8 +2,9 @@ import { chmod, mkdtemp, rm, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { BunServices } from "@effect/platform-bun"
-import { Effect, Layer } from "effect"
+import { Deferred, Effect, Exit, Fiber, Layer } from "effect"
 import {
+  type OnSessionId,
   Opencode,
   OpencodeExitError,
   OpencodeTimeoutError,
@@ -25,7 +26,7 @@ const withExecutable = async <A>(
   }
 }
 
-const start = (binary: string, timeout: string) =>
+const start = (binary: string, timeout: string, onSessionId?: OnSessionId) =>
   Effect.gen(function* () {
     const opencode = yield* Opencode
     return yield* opencode.start({
@@ -34,6 +35,7 @@ const start = (binary: string, timeout: string) =>
       model: "test/model",
       variant: "test",
       timeout,
+      ...(onSessionId !== undefined ? { onSessionId } : {}),
     })
   }).pipe(
     Effect.provide(
@@ -101,6 +103,60 @@ describe("Opencode Effect service", () => {
             sessionId: "ses_timeout",
           }),
         )
+      },
+    )
+  })
+
+  it("notifies onSessionId with the first streamed sessionID before process exit", async () => {
+    await withExecutable(
+      [
+        `printf '%s\\n' '{"type":"step_start","sessionID":"ses_early"}'`,
+        "sleep 0.4",
+        `printf '%s\\n' '{"type":"text","part":{"type":"text","text":"done"}}'`,
+      ].join("\n"),
+      async (binary) => {
+        const observed = await Effect.runPromise(
+          Effect.gen(function* () {
+            const deferred = yield* Deferred.make<string>()
+            const fiber = yield* Effect.forkChild(
+              start(binary, "5 seconds", (sessionId) =>
+                Deferred.succeed(deferred, sessionId).pipe(Effect.asVoid),
+              ),
+            )
+            const earlySessionId = yield* Deferred.await(deferred)
+            const stillRunning = fiber.pollUnsafe() === undefined
+            const result = yield* Fiber.await(fiber)
+            return { earlySessionId, stillRunning, result }
+          }),
+        )
+
+        expect(observed.earlySessionId).toBe("ses_early")
+        expect(observed.stillRunning).toBe(true)
+        expect(Exit.isSuccess(observed.result)).toBe(true)
+        if (Exit.isSuccess(observed.result)) {
+          expect(observed.result.value.sessionId).toBe("ses_early")
+        }
+      },
+    )
+  })
+
+  it("does not fail the run when onSessionId fails", async () => {
+    await withExecutable(
+      [
+        `printf '%s\\n' '{"type":"step_start","sessionID":"ses_observer_fail"}'`,
+        `printf '%s\\n' '{"type":"text","part":{"type":"text","text":"ok"}}'`,
+      ].join("\n"),
+      async (binary) => {
+        await expect(
+          Effect.runPromise(
+            start(binary, "2 seconds", () =>
+              Effect.fail(new Error("observer boom") as never),
+            ),
+          ),
+        ).resolves.toEqual({
+          sessionId: "ses_observer_fail",
+          assistantText: "ok",
+        })
       },
     )
   })

--- a/packages/work-item-lifecycle/src/lib/implement.ts
+++ b/packages/work-item-lifecycle/src/lib/implement.ts
@@ -1,4 +1,5 @@
 import { Effect, FileSystem } from "effect"
+import { SqlClient } from "effect/unstable/sql"
 import { DbService } from "@ready-for-agent/db-service"
 import { Opencode } from "@ready-for-agent/opencode"
 import {
@@ -10,6 +11,31 @@ import {
 } from "./implement-errors.js"
 import type { LifecycleStepContext } from "./lifecycle-steps.js"
 import { DEFAULT_LIFECYCLE_MAX_DURATIONS } from "./types.js"
+
+const persistSessionIdMidRun = (
+  workItemId: string,
+  sessionId: string,
+): Effect.Effect<void, never, SqlClient.SqlClient> =>
+  Effect.gen(function* () {
+    const sql = yield* SqlClient.SqlClient
+    const now = Date.now()
+    yield* sql.unsafe(
+      `UPDATE work_item
+       SET session_id = ?, updated_at = ?
+       WHERE id = ?
+         AND (session_id IS NULL OR session_id = '' OR session_id = ?)`,
+      [sessionId, now, workItemId, sessionId],
+    )
+  }).pipe(
+    Effect.catch((error) =>
+      Effect.logWarning("Failed to persist OpenCode session id mid-implement", {
+        workItemId,
+        sessionId,
+        error,
+      }),
+    ),
+    Effect.asVoid,
+  )
 
 const resolveWorktreePath = (context: LifecycleStepContext) =>
   Effect.gen(function* () {
@@ -106,6 +132,7 @@ export const implement = (context: LifecycleStepContext) =>
     )
 
     const opencode = yield* Opencode
+    const sql = yield* SqlClient.SqlClient
     // Always start a fresh Session. Ignore any prior context.sessionId from
     // setup, dependency installation, or a previous failed Step Run.
     const result = yield* opencode
@@ -116,6 +143,10 @@ export const implement = (context: LifecycleStepContext) =>
         variant: context.variant,
         timeout:
           context.maxDuration ?? DEFAULT_LIFECYCLE_MAX_DURATIONS.implement,
+        onSessionId: (sessionId) =>
+          persistSessionIdMidRun(context.workItemId, sessionId).pipe(
+            Effect.provideService(SqlClient.SqlClient, sql),
+          ),
       })
       .pipe(
         Effect.mapError(

--- a/packages/work-item-lifecycle/test/implement.spec.ts
+++ b/packages/work-item-lifecycle/test/implement.spec.ts
@@ -2,7 +2,8 @@ import { mkdtemp, rm } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { BunServices } from "@effect/platform-bun"
-import { Duration, Effect, Layer } from "effect"
+import { Duration, Effect, Fiber, Layer } from "effect"
+import { SqlClient } from "effect/unstable/sql"
 import { DatabaseTest } from "@ready-for-agent/db/test"
 import { DbService, DbServiceLive } from "@ready-for-agent/db-service"
 import {
@@ -10,6 +11,7 @@ import {
   OpencodeExitError,
   OpencodeTimeoutError,
   SessionIdNotFoundError,
+  type StartInput,
 } from "@ready-for-agent/opencode"
 import type { LifecycleStepContext } from "../src/index.js"
 import {
@@ -42,20 +44,16 @@ const baseContext = (
 })
 
 const stubOpencode = (impl: {
-  readonly start?: (input: {
-    readonly prompt: string
-    readonly cwd: string
-    readonly model: string
-    readonly variant: string
-    readonly timeout?: Duration.Input
-  }) => Effect.Effect<{ sessionId: string }, never>
+  readonly start?: (
+    input: StartInput,
+  ) => Effect.Effect<{ sessionId: string; assistantText: string }, never>
   readonly continue?: (input: {
     readonly sessionId: string
     readonly prompt: string
     readonly cwd: string
     readonly model: string
     readonly variant: string
-  }) => Effect.Effect<{ sessionId: string }, never>
+  }) => Effect.Effect<{ sessionId: string; assistantText: string }, never>
 }) =>
   Layer.succeed(
     Opencode,
@@ -82,6 +80,7 @@ const run = <A, E>(
     E,
     | Layer.Layer.Success<typeof PlatformLayer>
     | Layer.Layer.Success<typeof DbServiceLive>
+    | Layer.Layer.Success<typeof DatabaseTest>
     | Opencode
   >,
   opencodeLayer: Layer.Layer<Opencode, never, never> = stubOpencode({}),
@@ -94,6 +93,31 @@ const run = <A, E>(
       Effect.provide(PlatformLayer),
     ),
   )
+
+const seedWorkItem = (workItemId: string, repositoryId: string) =>
+  Effect.gen(function* () {
+    const sql = yield* SqlClient.SqlClient
+    const now = Date.now()
+    yield* sql.unsafe(
+      `INSERT INTO work_item (
+         id, repository_id, github_issue_number, model, variant,
+         review_model, review_variant, state, state_ready_at, worktree_path,
+         session_id, failure_code, failure_message, created_at, updated_at
+       ) VALUES (?, ?, 80, 'opencode/test-model', 'high', 'opencode/test-model', 'high',
+         'implement', ?, NULL, NULL, NULL, NULL, ?, ?)`,
+      [workItemId, repositoryId, now, now, now],
+    )
+  })
+
+const readSessionId = (workItemId: string) =>
+  Effect.gen(function* () {
+    const sql = yield* SqlClient.SqlClient
+    const rows = (yield* sql.unsafe(
+      `SELECT session_id FROM work_item WHERE id = ? LIMIT 1`,
+      [workItemId],
+    )) as readonly { readonly session_id: string | null }[]
+    return rows[0]?.session_id ?? null
+  })
 
 const withTemp = async (assert: (root: string) => Promise<void>) => {
   const root = await mkdtemp(join(tmpdir(), "rfa-implement-"))
@@ -364,5 +388,112 @@ describe("implement", () => {
       )
       expect(error).toBeInstanceOf(ImplementOpenCodeError)
       expect((error as ImplementOpenCodeError).message).toContain("Session ID")
+    }))
+
+  it("persists session_id mid-run before OpenCode completes", () =>
+    withTemp(async (root) => {
+      const workItemId = makeWorkItemId()
+      const midRunSessionId = await run(
+        Effect.gen(function* () {
+          const repository = yield* seedRepository(root)
+          yield* seedWorkItem(workItemId, repository.id)
+
+          const fiber = yield* Effect.forkChild(
+            implement(
+              baseContext(root, {
+                workItemId,
+                repositoryId: repository.id,
+              }),
+            ),
+          )
+
+          let midSessionId: string | null = null
+          for (let attempt = 0; attempt < 50; attempt += 1) {
+            const sessionId = yield* readSessionId(workItemId)
+            if (sessionId !== null && sessionId !== "") {
+              midSessionId = sessionId
+              break
+            }
+            yield* Effect.sleep("20 millis")
+          }
+
+          const finalSessionId = yield* Fiber.join(fiber)
+          return { midSessionId, finalSessionId }
+        }),
+        stubOpencode({
+          start: (input) =>
+            Effect.gen(function* () {
+              expect(input.onSessionId).toBeDefined()
+              yield* input.onSessionId!("ses_mid_build")
+              yield* Effect.sleep("150 millis")
+              return {
+                sessionId: "ses_mid_build",
+                assistantText: "",
+              }
+            }),
+        }),
+      )
+
+      expect(midRunSessionId.midSessionId).toBe("ses_mid_build")
+      expect(midRunSessionId.finalSessionId).toBe("ses_mid_build")
+    }))
+
+  it("keeps a mid-run session_id when OpenCode later fails", () =>
+    withTemp(async (root) => {
+      const workItemId = makeWorkItemId()
+      const outcome = await run(
+        Effect.gen(function* () {
+          const repository = yield* seedRepository(root)
+          yield* seedWorkItem(workItemId, repository.id)
+          const error = yield* implement(
+            baseContext(root, {
+              workItemId,
+              repositoryId: repository.id,
+            }),
+          ).pipe(Effect.flip)
+          const sessionId = yield* readSessionId(workItemId)
+          return { error, sessionId }
+        }),
+        stubOpencode({
+          start: (input) =>
+            Effect.gen(function* () {
+              yield* input.onSessionId!("ses_failed_after_emit")
+              return yield* Effect.fail(
+                new OpencodeExitError({ exitCode: 2, cwd: root }),
+              )
+            }),
+        }),
+      )
+
+      expect(outcome.error).toBeInstanceOf(ImplementOpenCodeError)
+      expect(outcome.sessionId).toBe("ses_failed_after_emit")
+    }))
+
+  it("does not fail implement when mid-run session persist has no matching row", () =>
+    withTemp(async (root) => {
+      const workItemId = makeWorkItemId()
+      const sessionId = await run(
+        Effect.gen(function* () {
+          const repository = yield* seedRepository(root)
+          return yield* implement(
+            baseContext(root, {
+              workItemId,
+              repositoryId: repository.id,
+            }),
+          )
+        }),
+        stubOpencode({
+          start: (input) =>
+            Effect.gen(function* () {
+              yield* input.onSessionId!("ses_no_row")
+              return {
+                sessionId: "ses_no_row",
+                assistantText: "",
+              }
+            }),
+        }),
+      )
+
+      expect(sessionId).toBe("ses_no_row")
     }))
 })


### PR DESCRIPTION
## Summary

- Persist the OpenCode session id on the Work Item as soon as implement/Build streams it, so Jobs UI can show `Session ses_…` while status is still RUNNING.
- Add optional `onSessionId` observer to `@ready-for-agent/opencode` (first streamed id, fire-and-forget, non-failing).
- Keep install-dependencies and other non-implement OpenCode runs from writing a Work Item session id.

Closes #169

## Test plan

- [x] `nx test opencode`
- [x] `nx test work-item-lifecycle`
- [ ] Manually confirm Jobs card shows Session while Build is RUNNING