### PR TITLE
fix: pin worktree-local sqlite db paths

### DIFF
--- a/apps/harness/project.json
+++ b/apps/harness/project.json
@@ -9,7 +9,7 @@
       "continuous": true,
       "executor": "nx:run-commands",
       "options": {
-        "command": "mkdir -p ../../tmp && export SQLITE_DATABASE_PATH=${SQLITE_DATABASE_PATH:-../../tmp/ready-for-agent.db} && bun --conditions @ready-for-agent/source ../../scripts/run-with-keymaxxer-sidecar.ts bash -c 'bun --conditions @ready-for-agent/source src/server/preflight.ts && vite'",
+        "command": "ROOT=\"$(cd ../.. && pwd)\" && mkdir -p \"$ROOT/tmp\" && export SQLITE_DATABASE_PATH=\"${SQLITE_DATABASE_PATH:-$ROOT/tmp/ready-for-agent.db}\" && bun --conditions @ready-for-agent/source ../../scripts/run-with-keymaxxer-sidecar.ts bash -c 'bun --conditions @ready-for-agent/source src/server/preflight.ts && vite'",
         "cwd": "apps/harness"
       },
       "dependsOn": [
@@ -32,7 +32,7 @@
       "continuous": true,
       "executor": "nx:run-commands",
       "options": {
-        "command": "mkdir -p ../../tmp && export SQLITE_DATABASE_PATH=${SQLITE_DATABASE_PATH:-../../tmp/ready-for-agent.db} && bun --conditions @ready-for-agent/source ../../scripts/run-with-keymaxxer-sidecar.ts bun --conditions @ready-for-agent/source server.ts",
+        "command": "ROOT=\"$(cd ../.. && pwd)\" && mkdir -p \"$ROOT/tmp\" && export SQLITE_DATABASE_PATH=\"${SQLITE_DATABASE_PATH:-$ROOT/tmp/ready-for-agent.db}\" && bun --conditions @ready-for-agent/source ../../scripts/run-with-keymaxxer-sidecar.ts bun --conditions @ready-for-agent/source server.ts",
         "cwd": "apps/harness"
       },
       "dependsOn": ["build", "db:migrate"]

--- a/packages/db/project.json
+++ b/packages/db/project.json
@@ -16,7 +16,7 @@
       "executor": "nx:run-commands",
       "options": {
         "cwd": "{projectRoot}",
-        "command": "mkdir -p ../../tmp && SQLITE_DATABASE_PATH=${SQLITE_DATABASE_PATH:-../../tmp/ready-for-agent.db} bun --conditions @ready-for-agent/source src/bin/migrate.ts"
+        "command": "ROOT=\"$(cd ../.. && pwd)\" && mkdir -p \"$ROOT/tmp\" && SQLITE_DATABASE_PATH=\"${SQLITE_DATABASE_PATH:-$ROOT/tmp/ready-for-agent.db}\" bun --conditions @ready-for-agent/source src/bin/migrate.ts"
       }
     }
   }

--- a/packages/layer-turso-local/src/lib/database-path.ts
+++ b/packages/layer-turso-local/src/lib/database-path.ts
@@ -1,3 +1,4 @@
+import { isAbsolute, resolve } from "node:path"
 import { Context } from "effect"
 import * as Config from "effect/Config"
 
@@ -17,16 +18,19 @@ export const isLocalFilePath = (path: string): boolean => {
   return protocol === undefined || protocol === "file"
 }
 
+const resolveLocalFilePath = (path: string): string =>
+  path === ":memory:" || isAbsolute(path) ? path : resolve(path)
+
 export const toTursoDatabasePath = (path: string): string => {
   if (path.startsWith("file://")) {
-    return path.slice("file://".length)
+    return resolveLocalFilePath(path.slice("file://".length))
   }
 
   if (path.startsWith("file:")) {
-    return path.slice("file:".length)
+    return resolveLocalFilePath(path.slice("file:".length))
   }
 
-  return path
+  return resolveLocalFilePath(path)
 }
 
 /**

--- a/packages/layer-turso-local/test/normalize-path.spec.ts
+++ b/packages/layer-turso-local/test/normalize-path.spec.ts
@@ -22,8 +22,15 @@ describe("Turso database path helpers", () => {
     expect(isLocalFilePath("libsql://example.turso.io")).toBe(false)
   })
 
-  it("converts file URLs to Turso SDK paths", () => {
-    expect(toTursoDatabasePath("file://./data/app.db")).toBe("./data/app.db")
-    expect(toTursoDatabasePath("file:./data/app.db")).toBe("./data/app.db")
+  it("converts file URLs to absolute Turso SDK paths", () => {
+    expect(toTursoDatabasePath("file://./data/app.db")).toBe(
+      `${process.cwd()}/data/app.db`,
+    )
+    expect(toTursoDatabasePath("file:./data/app.db")).toBe(
+      `${process.cwd()}/data/app.db`,
+    )
+    expect(toTursoDatabasePath("/abs/data/app.db")).toBe("/abs/data/app.db")
+    expect(toTursoDatabasePath(":memory:")).toBe(":memory:")
+    expect(toTursoDatabasePath("file::memory:")).toBe(":memory:")
   })
 })


### PR DESCRIPTION
## Why

Harness and migrate used a relative default `SQLITE_DATABASE_PATH` (`../../tmp/ready-for-agent.db`). Depending on process cwd, that could resolve outside the current worktree (for example into a shared parent `tmp/`), so concurrent worktrees could share or corrupt the same SQLite DB/WAL and fail to start with WAL short-read errors.

## What Changed

- Default `SQLITE_DATABASE_PATH` for `harness:dev`, `harness:start`, and `db:migrate` is now an absolute path under the worktree root: `$ROOT/tmp/ready-for-agent.db`.
- `toTursoDatabasePath` resolves relative filesystem paths to absolute paths at open time, while preserving `:memory:` and absolute paths.