### PR TITLE
feat(harness): poll credentialed Repositories on a durable cadence

### DIFF
--- a/apps/harness/src/server/application.server.ts
+++ b/apps/harness/src/server/application.server.ts
@@ -81,6 +81,7 @@ export const createApplication = async (
     Layer.provideMerge(queueLayer),
     Layer.provideMerge(reconcilerLayer),
     Layer.provideMerge(lifecycleLayer),
+    Layer.provideMerge(keymaxxerLayer),
   )
   const loggingLayer = Logger.layer([Logger.consolePretty({ colors: false })])
   const appLayer =

--- a/apps/harness/src/server/job-worker.ts
+++ b/apps/harness/src/server/job-worker.ts
@@ -13,7 +13,14 @@ import {
   RepositoryId,
   RepositoryNotFoundError,
 } from "@ready-for-agent/db-service"
+import {
+  ISSUE_POLL_QUEUE,
+  ISSUE_REFRESH_QUEUE,
+  JOB_RECOVERY_RETRY_LIMIT,
+  sampleIssuePollingDelay,
+} from "@ready-for-agent/graphql-api"
 import { IssueReconciler } from "@ready-for-agent/issue-reconciler"
+import { KeymaxxerService } from "@ready-for-agent/keymaxxer-service"
 import { QueueService } from "@ready-for-agent/queue-service"
 import {
   WorkItemLifecycle,
@@ -22,13 +29,11 @@ import {
 
 /** Work Item lifecycle queue (unchanged). */
 export const JOBS_QUEUE = "jobs"
-/** High-priority manual Issue Refresh Job queue. */
-export const ISSUE_REFRESH_QUEUE = "issue-refresh"
+export { ISSUE_POLL_QUEUE, ISSUE_REFRESH_QUEUE, JOB_RECOVERY_RETRY_LIMIT }
 export const JOB_VISIBILITY_TIMEOUT = Duration.minutes(5)
 const LIFECYCLE_JOB_VISIBILITY_GRACE = Duration.minutes(1)
 const JOB_IDLE_POLL_INTERVAL = Duration.millis(1500)
 const ORPHAN_RECOVERY_INTERVAL = Duration.seconds(30)
-export const JOB_RECOVERY_RETRY_LIMIT = 1
 const REFRESH_REPOSITORY_TAG = "refresh-repository"
 
 /**
@@ -100,6 +105,19 @@ export const transferPersistedRefreshJobs = Effect.gen(function* () {
   )
 })
 
+const repositoryHasGitHubCredential = (
+  githubOwner: string,
+  githubRepo: string,
+) =>
+  Effect.gen(function* () {
+    const keymaxxer = yield* KeymaxxerService
+    const credential = yield* keymaxxer.findSecret({
+      provider: "github",
+      account: `${githubOwner}/${githubRepo}`,
+    })
+    return credential !== null
+  })
+
 const refreshRepository = (repositoryId: RepositoryId) =>
   Effect.gen(function* () {
     const db = yield* DbService
@@ -120,6 +138,8 @@ export interface JobWorkerOptions {
   readonly idlePollInterval?: Duration.Duration
   readonly visibilityTimeout?: Duration.Duration
   readonly orphanRecoveryInterval?: Duration.Duration
+  /** Override cadence sampling for deterministic tests. */
+  readonly samplePollingDelay?: Effect.Effect<Duration.Duration>
 }
 
 const runQueuePollLoop = <E, R>(
@@ -147,11 +167,14 @@ const runQueuePollLoop = <E, R>(
     }
   })
 
-const claimAndRunRefreshJob = (visibilityTimeout: Duration.Duration) =>
+const claimRefreshJob = (
+  queueName: string,
+  visibilityTimeout: Duration.Duration,
+) =>
   Effect.gen(function* () {
     const queue = yield* QueueService
-    const claimed = yield* QueueService.claim(
-      ISSUE_REFRESH_QUEUE,
+    return yield* QueueService.claim(
+      queueName,
       RefreshRepositoryJob,
       visibilityTimeout,
     ).pipe(
@@ -161,25 +184,149 @@ const claimAndRunRefreshJob = (visibilityTimeout: Duration.Duration) =>
           .pipe(Effect.as(Option.none())),
       ),
     )
+  })
 
-    if (Option.isNone(claimed)) return "idle" as const
+type AttemptResult =
+  | { readonly _tag: "Failure"; readonly failure: unknown }
+  | { readonly _tag: "Success"; readonly success: unknown }
 
-    const job = claimed.value
+const finalizeManualRefresh = (
+  jobId: string,
+  result: AttemptResult,
+  repositoryId: RepositoryId,
+) =>
+  Effect.gen(function* () {
+    const queue = yield* QueueService
+    if (result._tag === "Failure") {
+      yield* Effect.logError("Refresh Job failed", {
+        jobId,
+        repositoryId,
+        error: formatLogError(result.failure),
+      })
+      yield* queue.fail(jobId, { retryable: false })
+    } else {
+      yield* queue.acknowledge(jobId)
+    }
+  })
+
+const finalizeScheduledRefresh = (
+  jobId: string,
+  repositoryId: RepositoryId,
+  result: AttemptResult,
+  sampleDelay: Effect.Effect<Duration.Duration>,
+) =>
+  Effect.gen(function* () {
+    const queue = yield* QueueService
+    const db = yield* DbService
+    const repositories = yield* db.listRepositories
+    const repository = repositories.find(({ id }) => id === repositoryId)
+
+    if (repository === undefined) {
+      yield* Effect.logWarning(
+        "Scheduled Issue poll finalized without recurrence; Repository missing",
+        { jobId, repositoryId },
+      )
+      yield* queue.acknowledge(jobId)
+      return
+    }
+
+    const credentialed = yield* repositoryHasGitHubCredential(
+      repository.githubOwner,
+      repository.githubRepo,
+    )
+    if (!credentialed) {
+      yield* Effect.logWarning(
+        "Scheduled Issue poll finalized without recurrence; Repository uncredentialed",
+        { jobId, repositoryId },
+      )
+      yield* queue.acknowledge(jobId)
+      return
+    }
+
+    if (result._tag === "Failure") {
+      yield* Effect.logError("Scheduled Issue poll failed", {
+        jobId,
+        repositoryId,
+        error: formatLogError(result.failure),
+      })
+    }
+
+    const delay = yield* sampleDelay
+    yield* queue.postponeKeyed(jobId, delay)
+  })
+
+/**
+ * One dedicated polling worker: always claim high-priority manual work before
+ * scheduled recurring entries. Never interrupts a running reconciliation.
+ */
+const claimAndRunRefreshJob = (
+  visibilityTimeout: Duration.Duration,
+  sampleDelay: Effect.Effect<Duration.Duration>,
+) =>
+  Effect.gen(function* () {
+    const highPriority = yield* claimRefreshJob(
+      ISSUE_REFRESH_QUEUE,
+      visibilityTimeout,
+    )
+    if (Option.isSome(highPriority)) {
+      const job = highPriority.value
+      const result = yield* Effect.result(
+        refreshRepository(job.payload.repositoryId),
+      )
+      yield* finalizeManualRefresh(job.jobId, result, job.payload.repositoryId)
+      return "busy" as const
+    }
+
+    const scheduled = yield* claimRefreshJob(
+      ISSUE_POLL_QUEUE,
+      visibilityTimeout,
+    )
+    if (Option.isNone(scheduled)) return "idle" as const
+
+    const job = scheduled.value
+    const db = yield* DbService
+    const repositories = yield* db.listRepositories
+    const repository = repositories.find(
+      ({ id }) => id === job.payload.repositoryId,
+    )
+    if (repository === undefined) {
+      yield* finalizeScheduledRefresh(
+        job.jobId,
+        job.payload.repositoryId,
+        {
+          _tag: "Failure",
+          failure: new RepositoryNotFoundError({
+            repositoryId: job.payload.repositoryId,
+          }),
+        },
+        sampleDelay,
+      )
+      return "busy" as const
+    }
+
+    const credentialed = yield* repositoryHasGitHubCredential(
+      repository.githubOwner,
+      repository.githubRepo,
+    )
+    if (!credentialed) {
+      yield* finalizeScheduledRefresh(
+        job.jobId,
+        job.payload.repositoryId,
+        { _tag: "Failure", failure: "Repository uncredentialed" },
+        sampleDelay,
+      )
+      return "busy" as const
+    }
+
     const result = yield* Effect.result(
       refreshRepository(job.payload.repositoryId),
     )
-
-    if (result._tag === "Failure") {
-      yield* Effect.logError("Refresh Job failed", {
-        jobId: job.jobId,
-        repositoryId: job.payload.repositoryId,
-        error: formatLogError(result.failure),
-      })
-      yield* queue.fail(job.jobId, { retryable: false })
-    } else {
-      yield* queue.acknowledge(job.jobId)
-    }
-
+    yield* finalizeScheduledRefresh(
+      job.jobId,
+      job.payload.repositoryId,
+      result,
+      sampleDelay,
+    )
     return "busy" as const
   })
 
@@ -237,7 +384,7 @@ const claimAndRunLifecycleJob = (
 }
 
 /**
- * Host lifecycle and Issue Refresh workers as independent fibers that share one
+ * Host lifecycle and Issue polling workers as independent fibers that share one
  * generation token so HMR retires both together.
  */
 export const runJobWorker = (options: JobWorkerOptions = {}) =>
@@ -248,6 +395,7 @@ export const runJobWorker = (options: JobWorkerOptions = {}) =>
       options.visibilityTimeout ?? JOB_VISIBILITY_TIMEOUT
     const orphanRecoveryInterval =
       options.orphanRecoveryInterval ?? ORPHAN_RECOVERY_INTERVAL
+    const sampleDelay = options.samplePollingDelay ?? sampleIssuePollingDelay
 
     yield* Effect.all(
       [
@@ -260,8 +408,8 @@ export const runJobWorker = (options: JobWorkerOptions = {}) =>
         runQueuePollLoop(
           generation,
           idlePollInterval,
-          claimAndRunRefreshJob(visibilityTimeout),
-          "Issue refresh job queue",
+          claimAndRunRefreshJob(visibilityTimeout, sampleDelay),
+          "Issue polling job queue",
         ),
       ],
       { concurrency: "unbounded", discard: true },

--- a/apps/harness/test/job-worker.test.ts
+++ b/apps/harness/test/job-worker.test.ts
@@ -45,6 +45,7 @@ import {
   makeStepRunId,
 } from "@ready-for-agent/work-item-lifecycle"
 import {
+  ISSUE_POLL_QUEUE,
   ISSUE_REFRESH_QUEUE,
   JOBS_QUEUE,
   JOB_RECOVERY_RETRY_LIMIT,
@@ -76,12 +77,13 @@ const refreshPayload = {
 const rawJob = (
   payload: unknown,
   queue: string = ISSUE_REFRESH_QUEUE,
+  key: string | null = null,
 ): RawJob => {
   const now = DateTime.makeUnsafe(0)
   return {
     jobId: makeJobId(),
     queue,
-    key: null,
+    key,
     payload,
     attempts: 1,
     maxAttempts: 2,
@@ -102,6 +104,27 @@ const dbLayer = (
     listRepositories: Effect.succeed(repositories),
   })
 
+const keymaxxerLayer = (
+  credentialedAccounts: ReadonlySet<string> = new Set([
+    `${repository.githubOwner}/${repository.githubRepo}`,
+    `${otherRepository.githubOwner}/${otherRepository.githubRepo}`,
+  ]),
+) =>
+  Layer.succeed(KeymaxxerService, {
+    initialize: Effect.void,
+    findSecret: ({ account, provider }) =>
+      Effect.succeed(
+        provider === "github" && credentialedAccounts.has(account)
+          ? `GITHUB_TOKEN_${account.replace("/", "_").toUpperCase()}`
+          : null,
+      ),
+    findSecrets: () => Effect.die("not used"),
+    hasSecret: () => Effect.die("not used"),
+    addSecret: () => Effect.die("not used"),
+    removeSecret: () => Effect.die("not used"),
+    runWithSecrets: () => Effect.die("not used"),
+  })
+
 const queueLayer = (
   jobs: RawJob[],
   onAcknowledge: (jobId: string) => Effect.Effect<unknown> = () => Effect.void,
@@ -116,6 +139,10 @@ const queueLayer = (
     timeout: Duration.Duration,
   ) => Effect.Effect<unknown> = () => Effect.void,
   recoverOrphanedStepRuns: Effect.Effect<number> = Effect.succeed(0),
+  onPostponeKeyed: (
+    jobId: string,
+    delay: Duration.Duration,
+  ) => Effect.Effect<unknown> = () => Effect.void,
 ) =>
   Layer.merge(
     Layer.succeed(QueueService, {
@@ -124,7 +151,8 @@ const queueLayer = (
       enqueueWithDelay: unused,
       ensureKeyed: unused,
       listKeyed: unused,
-      postponeKeyed: unused,
+      postponeKeyed: (jobId, delay) =>
+        onPostponeKeyed(jobId, delay).pipe(Effect.asVoid),
       removeKeyed: unused,
       rawClaim: (queueName, visibilityTimeout) =>
         Effect.gen(function* () {
@@ -259,7 +287,7 @@ describe("Job worker", () => {
         yield* Effect.sleep("10 millis")
         expect(acknowledged).toEqual([])
       }),
-      Layer.merge(
+      Layer.mergeAll(
         queueLayer(
           [job],
           (jobId) =>
@@ -279,10 +307,9 @@ describe("Job worker", () => {
             }),
           Deferred.succeed(recovered, undefined).pipe(Effect.as(0)),
         ),
-        Layer.merge(
-          dbLayer(),
-          Layer.succeed(IssueReconciler, { reconcile: unused }),
-        ),
+        dbLayer(),
+        Layer.succeed(IssueReconciler, { reconcile: unused }),
+        keymaxxerLayer(),
       ),
     )
   })
@@ -307,7 +334,7 @@ describe("Job worker", () => {
         yield* Deferred.await(recoveredTwice).pipe(Effect.timeout("100 millis"))
         expect(recoveryCalls).toBeGreaterThanOrEqual(2)
       }),
-      Layer.merge(
+      Layer.mergeAll(
         queueLayer(
           [],
           undefined,
@@ -317,10 +344,9 @@ describe("Job worker", () => {
           undefined,
           recover,
         ),
-        Layer.merge(
-          dbLayer(),
-          Layer.succeed(IssueReconciler, { reconcile: unused }),
-        ),
+        dbLayer(),
+        Layer.succeed(IssueReconciler, { reconcile: unused }),
+        keymaxxerLayer(),
       ),
     )
   })
@@ -366,7 +392,7 @@ describe("Job worker", () => {
       Layer.provideMerge(database),
       Layer.provideMerge(github),
     )
-    const layer = Layer.mergeAll(database, reconciler, queue)
+    const layer = Layer.mergeAll(database, reconciler, queue, keymaxxerLayer())
 
     await runScoped(
       Effect.gen(function* () {
@@ -420,14 +446,13 @@ describe("Job worker", () => {
           )
           expect(yield* Deferred.await(failed)).toBe(job.jobId)
         }),
-        Layer.merge(
+        Layer.mergeAll(
           queueLayer([job], undefined, (jobId) =>
             Deferred.succeed(failed, jobId),
           ),
-          Layer.merge(
-            dbLayer(),
-            Layer.succeed(IssueReconciler, { reconcile: unused }),
-          ),
+          dbLayer(),
+          Layer.succeed(IssueReconciler, { reconcile: unused }),
+          keymaxxerLayer(),
         ),
       )
     }
@@ -481,6 +506,7 @@ describe("Job worker", () => {
           }),
         ),
         reconciler,
+        keymaxxerLayer(),
       ),
     )
   })
@@ -514,22 +540,13 @@ describe("Job worker", () => {
           }
         }),
     } satisfies IssueReconcilerShape)
-    const keymaxxer = Layer.succeed(KeymaxxerService, {
-      initialize: Effect.void,
-      findSecret: () => Effect.die("not used"),
-      findSecrets: () => Effect.die("not used"),
-      hasSecret: () => Effect.die("not used"),
-      addSecret: () => Effect.die("not used"),
-      removeSecret: () => Effect.die("not used"),
-      runWithSecrets: () => Effect.die("not used"),
-    })
     const opencode = Layer.succeed(Opencode, {
       start: () => Effect.die("not used"),
       continue: () => Effect.die("not used"),
       listModels: () => Effect.die("not used"),
     })
     const runtime = ManagedRuntime.make(
-      Layer.mergeAll(database, queue, reconciler, keymaxxer, opencode),
+      Layer.mergeAll(database, queue, reconciler, keymaxxerLayer(), opencode),
     )
     const controller = new AbortController()
 
@@ -636,6 +653,7 @@ describe("Job worker", () => {
         ),
         dbLayer(),
         reconciler,
+        keymaxxerLayer(),
       ),
     )
   })
@@ -692,6 +710,7 @@ describe("Job worker", () => {
         queueLayer(jobs),
         dbLayer([repository, otherRepository]),
         reconciler,
+        keymaxxerLayer(),
       ),
     )
   })
@@ -737,7 +756,7 @@ describe("Job worker", () => {
         )
         yield* Deferred.succeed(releaseRefresh, undefined)
       }),
-      Layer.merge(
+      Layer.mergeAll(
         queueLayer(
           jobs,
           undefined,
@@ -751,7 +770,9 @@ describe("Job worker", () => {
             }),
           (jobId) => Deferred.succeed(lifecycleLeaseExtended, jobId),
         ),
-        Layer.merge(dbLayer(), reconciler),
+        dbLayer(),
+        reconciler,
+        keymaxxerLayer(),
       ),
     )
   })
@@ -801,6 +822,7 @@ describe("Job worker", () => {
               unchanged: 0,
             }),
         }),
+        keymaxxerLayer(),
       ),
     )
   })
@@ -841,6 +863,7 @@ describe("Job worker", () => {
         ),
         dbLayer(),
         reconciler,
+        keymaxxerLayer(),
       ),
     )
   })
@@ -894,6 +917,446 @@ describe("Job worker", () => {
         const noDuplicate = yield* service.rawClaim(ISSUE_REFRESH_QUEUE)
         expect(Option.isNone(noDuplicate)).toBe(true)
       }).pipe(Effect.provide(layer), Effect.orDie),
+    )
+  })
+
+  test("checks high-priority Refresh Jobs before scheduled Issue polls", async () => {
+    const claimOrder: string[] = []
+    const repositoryOrder: string[] = []
+    const manualJob = rawJob(refreshPayload, ISSUE_REFRESH_QUEUE)
+    const scheduledJob = rawJob(
+      {
+        _tag: "refresh-repository",
+        repositoryId: RepositoryId.make(otherRepository.id),
+      },
+      ISSUE_POLL_QUEUE,
+      otherRepository.id,
+    )
+    const jobs = [scheduledJob, manualJob]
+    const done = await Effect.runPromise(Deferred.make<void>())
+
+    await runScoped(
+      Effect.gen(function* () {
+        yield* runJobWorker({
+          idlePollInterval: Duration.zero,
+          samplePollingDelay: Effect.succeed(Duration.seconds(120)),
+        }).pipe(Effect.forkScoped({ startImmediately: true }))
+        yield* Deferred.await(done)
+        expect(repositoryOrder).toEqual([repository.id, otherRepository.id])
+        const refreshClaims = claimOrder.filter(
+          (queueName) =>
+            queueName === ISSUE_REFRESH_QUEUE || queueName === ISSUE_POLL_QUEUE,
+        )
+        expect(refreshClaims[0]).toBe(ISSUE_REFRESH_QUEUE)
+        expect(refreshClaims).toContain(ISSUE_POLL_QUEUE)
+      }),
+      Layer.mergeAll(
+        queueLayer(
+          jobs,
+          undefined,
+          undefined,
+          (queueName) =>
+            Effect.sync(() => {
+              claimOrder.push(queueName)
+              const index = jobs.findIndex((job) => job.queue === queueName)
+              if (index === -1) return Option.none()
+              const [job] = jobs.splice(index, 1)
+              return Option.some(job)
+            }),
+          undefined,
+          undefined,
+          undefined,
+          () => Deferred.succeed(done, undefined),
+        ),
+        dbLayer([repository, otherRepository]),
+        Layer.succeed(IssueReconciler, {
+          reconcile: (repo) =>
+            Effect.sync(() => {
+              repositoryOrder.push(repo.id)
+              return {
+                fetched: 0,
+                inserted: 0,
+                updated: 0,
+                deleted: 0,
+                unchanged: 0,
+              }
+            }),
+        }),
+        keymaxxerLayer(),
+      ),
+    )
+  })
+
+  test("postpones a successful scheduled poll by the sampled cadence", async () => {
+    const job = rawJob(refreshPayload, ISSUE_POLL_QUEUE, repository.id)
+    const postponed = await Effect.runPromise(
+      Deferred.make<{ jobId: string; delayMs: number }>(),
+    )
+    const notifications: string[] = []
+
+    await runScoped(
+      Effect.gen(function* () {
+        yield* runJobWorker({
+          idlePollInterval: Duration.zero,
+          samplePollingDelay: Effect.succeed(Duration.seconds(137)),
+        }).pipe(Effect.forkScoped({ startImmediately: true }))
+        expect(yield* Deferred.await(postponed)).toEqual({
+          jobId: job.jobId,
+          delayMs: 137_000,
+        })
+        expect(notifications).toEqual([repository.id])
+      }),
+      Layer.mergeAll(
+        queueLayer(
+          [job],
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          (jobId, delay) =>
+            Deferred.succeed(postponed, {
+              jobId,
+              delayMs: Duration.toMillis(delay),
+            }),
+        ),
+        dbLayer([repository], (repositoryId) =>
+          Effect.sync(() => {
+            notifications.push(repositoryId)
+          }),
+        ),
+        Layer.succeed(IssueReconciler, {
+          reconcile: () =>
+            Effect.succeed({
+              fetched: 0,
+              inserted: 0,
+              updated: 0,
+              deleted: 0,
+              unchanged: 0,
+            }),
+        }),
+        keymaxxerLayer(),
+      ),
+    )
+  })
+
+  test("postpones a failed scheduled poll without publishing success", async () => {
+    const job = rawJob(refreshPayload, ISSUE_POLL_QUEUE, repository.id)
+    const postponed = await Effect.runPromise(Deferred.make<string>())
+    const notifications: string[] = []
+    let failed = false
+
+    await runScoped(
+      Effect.gen(function* () {
+        yield* runJobWorker({
+          idlePollInterval: Duration.zero,
+          samplePollingDelay: Effect.succeed(Duration.seconds(120)),
+        }).pipe(Effect.forkScoped({ startImmediately: true }))
+        expect(yield* Deferred.await(postponed)).toBe(job.jobId)
+        expect(notifications).toEqual([])
+        expect(failed).toBe(false)
+      }),
+      Layer.mergeAll(
+        queueLayer(
+          [job],
+          undefined,
+          () =>
+            Effect.sync(() => {
+              failed = true
+            }),
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          (jobId) => Deferred.succeed(postponed, jobId),
+        ),
+        dbLayer([repository], (repositoryId) =>
+          Effect.sync(() => {
+            notifications.push(repositoryId)
+          }),
+        ),
+        Layer.succeed(IssueReconciler, {
+          reconcile: () =>
+            Effect.fail(new DatabaseError({ message: "scheduled fail" })),
+        }),
+        keymaxxerLayer(),
+      ),
+    )
+  })
+
+  test("finalizes a scheduled poll without recurrence when the Repository is missing", async () => {
+    const job = rawJob(refreshPayload, ISSUE_POLL_QUEUE, repository.id)
+    const acknowledged = await Effect.runPromise(Deferred.make<string>())
+    let postponed = false
+
+    await runScoped(
+      Effect.gen(function* () {
+        yield* runJobWorker({
+          idlePollInterval: Duration.zero,
+          samplePollingDelay: Effect.succeed(Duration.seconds(120)),
+        }).pipe(Effect.forkScoped({ startImmediately: true }))
+        expect(yield* Deferred.await(acknowledged)).toBe(job.jobId)
+        expect(postponed).toBe(false)
+      }),
+      Layer.mergeAll(
+        queueLayer(
+          [job],
+          (jobId) => Deferred.succeed(acknowledged, jobId),
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          () =>
+            Effect.sync(() => {
+              postponed = true
+            }),
+        ),
+        dbLayer([]),
+        Layer.succeed(IssueReconciler, { reconcile: unused }),
+        keymaxxerLayer(),
+      ),
+    )
+  })
+
+  test("finalizes a scheduled poll without recurrence when uncredentialed", async () => {
+    const job = rawJob(refreshPayload, ISSUE_POLL_QUEUE, repository.id)
+    const acknowledged = await Effect.runPromise(Deferred.make<string>())
+    let postponed = false
+
+    await runScoped(
+      Effect.gen(function* () {
+        yield* runJobWorker({
+          idlePollInterval: Duration.zero,
+          samplePollingDelay: Effect.succeed(Duration.seconds(120)),
+        }).pipe(Effect.forkScoped({ startImmediately: true }))
+        expect(yield* Deferred.await(acknowledged)).toBe(job.jobId)
+        expect(postponed).toBe(false)
+      }),
+      Layer.mergeAll(
+        queueLayer(
+          [job],
+          (jobId) => Deferred.succeed(acknowledged, jobId),
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          () =>
+            Effect.sync(() => {
+              postponed = true
+            }),
+        ),
+        dbLayer(),
+        Layer.succeed(IssueReconciler, {
+          reconcile: () =>
+            Effect.fail(new DatabaseError({ message: "no credential" })),
+        }),
+        keymaxxerLayer(new Set()),
+      ),
+    )
+  })
+
+  test("does not alter a scheduled entry when a manual Refresh Job runs", async () => {
+    const scheduledJob = rawJob(refreshPayload, ISSUE_POLL_QUEUE, repository.id)
+    const manualJob = rawJob(refreshPayload)
+    const jobs = [manualJob]
+    const acknowledged = await Effect.runPromise(Deferred.make<string>())
+    let postponed = false
+
+    await runScoped(
+      Effect.gen(function* () {
+        yield* runJobWorker({
+          idlePollInterval: Duration.zero,
+          samplePollingDelay: Effect.succeed(Duration.seconds(120)),
+        }).pipe(Effect.forkScoped({ startImmediately: true }))
+        expect(yield* Deferred.await(acknowledged)).toBe(manualJob.jobId)
+        expect(postponed).toBe(false)
+        expect(jobs).toEqual([])
+        // Scheduled job remains unclaimed in its queue (not in the jobs list
+        // because we only enqueued the manual job).
+        expect(scheduledJob.queue).toBe(ISSUE_POLL_QUEUE)
+      }),
+      Layer.mergeAll(
+        queueLayer(
+          jobs,
+          (jobId) => Deferred.succeed(acknowledged, jobId),
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          () =>
+            Effect.sync(() => {
+              postponed = true
+            }),
+        ),
+        dbLayer(),
+        Layer.succeed(IssueReconciler, {
+          reconcile: () =>
+            Effect.succeed({
+              fetched: 0,
+              inserted: 0,
+              updated: 0,
+              deleted: 0,
+              unchanged: 0,
+            }),
+        }),
+        keymaxxerLayer(),
+      ),
+    )
+  })
+
+  test("polls a Paused Repository on the scheduled cadence", async () => {
+    const paused = makeRepositoryRecord({
+      id: repository.id,
+      paused: true,
+    })
+    const job = rawJob(refreshPayload, ISSUE_POLL_QUEUE, paused.id)
+    const postponed = await Effect.runPromise(Deferred.make<string>())
+
+    await runScoped(
+      Effect.gen(function* () {
+        yield* runJobWorker({
+          idlePollInterval: Duration.zero,
+          samplePollingDelay: Effect.succeed(Duration.seconds(125)),
+        }).pipe(Effect.forkScoped({ startImmediately: true }))
+        expect(yield* Deferred.await(postponed)).toBe(job.jobId)
+      }),
+      Layer.mergeAll(
+        queueLayer(
+          [job],
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          (jobId) => Deferred.succeed(postponed, jobId),
+        ),
+        dbLayer([paused]),
+        Layer.succeed(IssueReconciler, {
+          reconcile: (repo) =>
+            Effect.sync(() => {
+              expect(repo.paused).toBe(true)
+              return {
+                fetched: 0,
+                inserted: 0,
+                updated: 0,
+                deleted: 0,
+                unchanged: 0,
+              }
+            }),
+        }),
+        keymaxxerLayer(),
+      ),
+    )
+  })
+
+  test("persists a scheduled entry across worker restarts without replaying", async () => {
+    const database = DbServiceLive.pipe(Layer.provideMerge(DatabaseTest))
+    const queue = SqliteQueueServiceLive.pipe(Layer.provideMerge(database))
+    const reconciliations: string[] = []
+    const reconciler = Layer.succeed(IssueReconciler, {
+      reconcile: (repo) =>
+        Effect.sync(() => {
+          reconciliations.push(repo.id)
+          return {
+            fetched: 0,
+            inserted: 0,
+            updated: 0,
+            deleted: 0,
+            unchanged: 0,
+          }
+        }),
+    } satisfies IssueReconcilerShape)
+    const lifecycle = Layer.succeed(WorkItemLifecycle, {
+      maxDurations: {
+        create_worktree: Duration.minutes(5),
+        install_dependencies: Duration.minutes(15),
+        implement: Duration.hours(2),
+        pre_commit: Duration.hours(2),
+        review: Duration.hours(1),
+        commit: Duration.minutes(5),
+        create_pr: Duration.minutes(10),
+        watch_pr_status_checks: Duration.minutes(5),
+        resolve_pr_merge_conflict: Duration.hours(2),
+        investigate_pr_status_checks: Duration.hours(2),
+        mark_pr_ready_for_review: Duration.minutes(5),
+        decide_pr_merge: Duration.minutes(15),
+        merge_pr: Duration.minutes(5),
+        local_cleanup: Duration.minutes(5),
+      },
+      implementNow: unused,
+      implementLocally: unused,
+      recoverOrphanedStepRuns: Effect.succeed(0),
+      runStep: () => Effect.succeed({ _tag: "noop" as const }),
+      retry: unused,
+      pause: unused,
+      start: unused,
+      abandon: unused,
+      reset: unused,
+      getWorkItem: unused,
+      listWorkItemsForIssue: unused,
+      listWorkItemsForRepository: unused,
+    })
+
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        const db = yield* DbService
+        const service = yield* QueueService
+        const added = yield* db.addRepository({
+          githubOwner: repository.githubOwner,
+          githubRepo: repository.githubRepo,
+          localPath: repository.localPath,
+          isBare: true,
+        })
+        yield* service.ensureKeyed(
+          ISSUE_POLL_QUEUE,
+          added.id,
+          {
+            _tag: "refresh-repository",
+            repositoryId: RepositoryId.make(added.id),
+          },
+          Duration.zero,
+          { retryLimit: JOB_RECOVERY_RETRY_LIMIT },
+        )
+
+        yield* Effect.scoped(
+          Effect.gen(function* () {
+            yield* runJobWorker({
+              idlePollInterval: Duration.zero,
+              samplePollingDelay: Effect.succeed(Duration.seconds(120)),
+            }).pipe(Effect.forkScoped({ startImmediately: true }))
+            while (reconciliations.length < 1) {
+              yield* Effect.sleep("5 millis")
+            }
+          }),
+        )
+
+        expect(reconciliations).toEqual([added.id])
+
+        const keyed = yield* service.listKeyed(ISSUE_POLL_QUEUE)
+        expect(keyed).toHaveLength(1)
+        expect(keyed[0]?.key).toBe(added.id)
+        expect(keyed[0]?.attempts).toBe(0)
+
+        // Not immediately available again (postponed 120s).
+        const claimNow = yield* service.rawClaim(ISSUE_POLL_QUEUE)
+        expect(Option.isNone(claimNow)).toBe(true)
+      }).pipe(
+        Effect.provide(
+          Layer.mergeAll(
+            database,
+            queue,
+            reconciler,
+            keymaxxerLayer(),
+            lifecycle,
+          ),
+        ),
+        Effect.orDie,
+      ),
     )
   })
 })

--- a/packages/graphql-api/src/index.ts
+++ b/packages/graphql-api/src/index.ts
@@ -1,1 +1,2 @@
 export * from "./lib/graphql-api.js"
+export * from "./lib/issue-polling.js"

--- a/packages/graphql-api/src/lib/graphql-api.ts
+++ b/packages/graphql-api/src/lib/graphql-api.ts
@@ -17,7 +17,6 @@ import {
   type IssueRecord,
   LocalPathInUseError,
   RepositoryAlreadyExistsError,
-  RepositoryId,
   RepositoryNotFoundError,
 } from "@ready-for-agent/db-service"
 import {
@@ -31,7 +30,7 @@ import {
 } from "@ready-for-agent/issue-reconciler"
 import { KeymaxxerService } from "@ready-for-agent/keymaxxer-service"
 import { Opencode } from "@ready-for-agent/opencode"
-import { EnqueueError, QueueService } from "@ready-for-agent/queue-service"
+import { EnqueueError, type QueueService } from "@ready-for-agent/queue-service"
 import {
   ActiveStepRunExistsError,
   IssueBlockedError,
@@ -50,6 +49,11 @@ import {
   WorkItemTerminalError,
   isTerminalWorkItemState,
 } from "@ready-for-agent/work-item-lifecycle"
+import {
+  activateRepositoryPolling,
+  enqueueRefreshRepositoryJob,
+  suspendRepositoryPolling,
+} from "./issue-polling.js"
 
 type AddRepositoryArgs = {
   input: {
@@ -245,31 +249,14 @@ export type GraphqlRuntime = ManagedRuntime.ManagedRuntime<
   unknown
 >
 
-/** High-priority manual Issue Refresh Job queue (must match harness). */
-export const ISSUE_REFRESH_QUEUE = "issue-refresh"
-const JOB_RECOVERY_RETRY_LIMIT = 1
-
 type Repository = {
   id: string
   githubOwner: string
   githubRepo: string
 }
 
-const enqueueRefreshRepositoryJob = (repository: Repository) =>
-  Effect.gen(function* () {
-    const queue = yield* QueueService
-    return yield* queue.enqueue(
-      ISSUE_REFRESH_QUEUE,
-      {
-        _tag: "refresh-repository",
-        repositoryId: RepositoryId.make(repository.id),
-      },
-      { retryLimit: JOB_RECOVERY_RETRY_LIMIT },
-    )
-  })
-
-/** Enqueue a Refresh Job only when a GitHub token is already configured. */
-const enqueueRefreshIfCredentialed = (repository: Repository) =>
+/** Activate durable Issue Polling only when a GitHub token is already configured. */
+const activatePollingIfCredentialed = (repository: Repository) =>
   Effect.gen(function* () {
     const keymaxxer = yield* KeymaxxerService
     const credential = yield* keymaxxer.findSecret({
@@ -277,7 +264,7 @@ const enqueueRefreshIfCredentialed = (repository: Repository) =>
       account: `${repository.githubOwner}/${repository.githubRepo}`,
     })
     if (credential === null) return
-    yield* enqueueRefreshRepositoryJob(repository)
+    yield* activateRepositoryPolling(repository.id)
   })
 
 class RepositoryCredentialError extends Data.TaggedError(
@@ -816,10 +803,10 @@ export const createGraphqlApi = (
                 Effect.gen(function* () {
                   const db = yield* DbService
                   const added = yield* db.addRepository(args.input)
-                  yield* enqueueRefreshIfCredentialed(added).pipe(
+                  yield* activatePollingIfCredentialed(added).pipe(
                     Effect.catch((error) =>
                       Effect.logWarning(
-                        "Automatic Repository refresh was not queued",
+                        "Automatic Repository polling was not activated",
                         {
                           repositoryId: added.id,
                           error,
@@ -894,6 +881,17 @@ export const createGraphqlApi = (
                         })
                       }
                     }
+                    yield* activateRepositoryPolling(repository.id).pipe(
+                      Effect.catch((error) =>
+                        Effect.logWarning(
+                          "Automatic Repository polling was not activated",
+                          {
+                            repositoryId: repository.id,
+                            error,
+                          },
+                        ),
+                      ),
+                    )
                     return repositoryCredential(repository, tokenName)
                   }),
                 ),
@@ -932,6 +930,17 @@ export const createGraphqlApi = (
                     if (existingToken !== null) {
                       yield* keymaxxer.removeSecret(existingToken)
                     }
+                    yield* suspendRepositoryPolling(repository.id).pipe(
+                      Effect.catch((error) =>
+                        Effect.logWarning(
+                          "Repository polling was not suspended",
+                          {
+                            repositoryId: repository.id,
+                            error,
+                          },
+                        ),
+                      ),
+                    )
                     return repositoryCredential(repository, null)
                   }),
                 ),
@@ -951,6 +960,17 @@ export const createGraphqlApi = (
                 Effect.gen(function* () {
                   const db = yield* DbService
                   yield* db.removeRepository(args.repositoryId)
+                  yield* suspendRepositoryPolling(args.repositoryId).pipe(
+                    Effect.catch((error) =>
+                      Effect.logWarning(
+                        "Repository polling was not suspended after removal",
+                        {
+                          repositoryId: args.repositoryId,
+                          error,
+                        },
+                      ),
+                    ),
+                  )
                   return args.repositoryId
                 }),
               ),
@@ -1003,7 +1023,9 @@ export const createGraphqlApi = (
                     })
                   }
 
-                  const jobId = yield* enqueueRefreshRepositoryJob(repository)
+                  const jobId = yield* enqueueRefreshRepositoryJob(
+                    repository.id,
+                  )
                   return {
                     id: jobId,
                     repositoryId: repository.id,

--- a/packages/graphql-api/src/lib/issue-polling.ts
+++ b/packages/graphql-api/src/lib/issue-polling.ts
@@ -1,0 +1,67 @@
+import { Duration, Effect, Random } from "effect"
+import { RepositoryId } from "@ready-for-agent/db-service"
+import { QueueService } from "@ready-for-agent/queue-service"
+
+/** High-priority manual / first-refresh Issue Refresh Job queue. */
+export const ISSUE_REFRESH_QUEUE = "issue-refresh"
+
+/** Scheduled recurring Issue Polling queue (one keyed entry per Repository). */
+export const ISSUE_POLL_QUEUE = "issue-poll"
+
+export const JOB_RECOVERY_RETRY_LIMIT = 1
+
+/** Base quiet period after a scheduled attempt completes. */
+export const ISSUE_POLLING_BASE_SECONDS = 120
+
+/** Inclusive upper bound for additive jitter seconds (0–30). */
+export const ISSUE_POLLING_JITTER_SECONDS = 30
+
+const RefreshRepositoryJobPayload = (repositoryId: string) => ({
+  _tag: "refresh-repository" as const,
+  repositoryId: RepositoryId.make(repositoryId),
+})
+
+/**
+ * Sample the next Issue Polling delay: 120s + uniform integer jitter in [0, 30].
+ * Injectable via Effect Random so tests can seed or replace sampling.
+ */
+export const sampleIssuePollingDelay: Effect.Effect<Duration.Duration> =
+  Random.nextIntBetween(0, ISSUE_POLLING_JITTER_SECONDS).pipe(
+    Effect.map((jitterSeconds) =>
+      Duration.seconds(ISSUE_POLLING_BASE_SECONDS + jitterSeconds),
+    ),
+  )
+
+export const enqueueRefreshRepositoryJob = (repositoryId: string) =>
+  Effect.gen(function* () {
+    const queue = yield* QueueService
+    return yield* queue.enqueue(
+      ISSUE_REFRESH_QUEUE,
+      RefreshRepositoryJobPayload(repositoryId),
+      { retryLimit: JOB_RECOVERY_RETRY_LIMIT },
+    )
+  })
+
+/**
+ * Ensure one keyed recurring schedule and enqueue a high-priority first refresh.
+ * Idempotent for the schedule; every activation enqueues a distinct first refresh.
+ */
+export const activateRepositoryPolling = (repositoryId: string) =>
+  Effect.gen(function* () {
+    const queue = yield* QueueService
+    const delay = yield* sampleIssuePollingDelay
+    const payload = RefreshRepositoryJobPayload(repositoryId)
+    yield* queue.ensureKeyed(ISSUE_POLL_QUEUE, repositoryId, payload, delay, {
+      retryLimit: JOB_RECOVERY_RETRY_LIMIT,
+    })
+    return yield* queue.enqueue(ISSUE_REFRESH_QUEUE, payload, {
+      retryLimit: JOB_RECOVERY_RETRY_LIMIT,
+    })
+  })
+
+/** Suspend the recurring schedule without cancelling accepted manual Refresh Jobs. */
+export const suspendRepositoryPolling = (repositoryId: string) =>
+  Effect.gen(function* () {
+    const queue = yield* QueueService
+    yield* queue.removeKeyed(ISSUE_POLL_QUEUE, repositoryId)
+  })

--- a/packages/graphql-api/test/graphql-api.test.ts
+++ b/packages/graphql-api/test/graphql-api.test.ts
@@ -265,14 +265,18 @@ describe("GraphQL API", () => {
     })
   })
 
-  test("queues a Refresh Job when adding a repository that already has a GitHub token", async () => {
-    let enqueued:
-      | {
-          queue: string
-          payload: Record<string, unknown>
-          retryLimit: number | undefined
-        }
-      | undefined
+  test("activates Issue Polling when adding a repository that already has a GitHub token", async () => {
+    const ensured: Array<{
+      queue: string
+      key: string
+      payload: Record<string, unknown>
+      delayMs: number
+    }> = []
+    const enqueued: Array<{
+      queue: string
+      payload: Record<string, unknown>
+      retryLimit: number | undefined
+    }> = []
     await runtime.dispose()
     runtime = makeRuntime(
       {},
@@ -287,13 +291,23 @@ describe("GraphQL API", () => {
           ),
       },
       {
+        ensureKeyed: (queueName, key, payload, delay) =>
+          Effect.sync(() => {
+            ensured.push({
+              queue: queueName,
+              key,
+              payload,
+              delayMs: Duration.toMillis(delay),
+            })
+            return { jobId: makeJobId(), created: true }
+          }),
         enqueue: (queueName, payload, options) =>
           Effect.sync(() => {
-            enqueued = {
+            enqueued.push({
               queue: queueName,
               payload,
               retryLimit: options?.retryLimit,
-            }
+            })
             return makeJobId()
           }),
       },
@@ -313,17 +327,29 @@ describe("GraphQL API", () => {
         },
       },
     })
-    expect(enqueued).toEqual({
-      queue: "issue-refresh",
-      payload: {
-        _tag: "refresh-repository",
-        repositoryId: repository.id,
-      },
-      retryLimit: 1,
+    expect(ensured).toHaveLength(1)
+    expect(ensured[0]?.queue).toBe("issue-poll")
+    expect(ensured[0]?.key).toBe(repository.id)
+    expect(ensured[0]?.payload).toEqual({
+      _tag: "refresh-repository",
+      repositoryId: repository.id,
     })
+    expect(ensured[0]?.delayMs).toBeGreaterThanOrEqual(120_000)
+    expect(ensured[0]?.delayMs).toBeLessThanOrEqual(150_000)
+    expect(enqueued).toEqual([
+      {
+        queue: "issue-refresh",
+        payload: {
+          _tag: "refresh-repository",
+          repositoryId: repository.id,
+        },
+        retryLimit: 1,
+      },
+    ])
   })
 
-  test("does not queue a Refresh Job when adding a repository without a GitHub token", async () => {
+  test("does not activate Issue Polling when adding a repository without a GitHub token", async () => {
+    let ensured = false
     let enqueued = false
     await runtime.dispose()
     runtime = makeRuntime(
@@ -333,6 +359,10 @@ describe("GraphQL API", () => {
         findSecret: () => Effect.succeed(null),
       },
       {
+        ensureKeyed: () => {
+          ensured = true
+          return Effect.succeed({ jobId: makeJobId(), created: true })
+        },
         enqueue: () => {
           enqueued = true
           return Effect.succeed(makeJobId())
@@ -354,10 +384,11 @@ describe("GraphQL API", () => {
         },
       },
     })
+    expect(ensured).toBe(false)
     expect(enqueued).toBe(false)
   })
 
-  test("keeps the added repository when its automatic Refresh Job cannot be queued", async () => {
+  test("keeps the added repository when automatic Issue Polling activation fails", async () => {
     await runtime.dispose()
     runtime = makeRuntime(
       {},
@@ -366,10 +397,10 @@ describe("GraphQL API", () => {
         findSecret: () => Effect.succeed("GITHUB_TOKEN_ACME_WIDGETS"),
       },
       {
-        enqueue: () =>
+        ensureKeyed: () =>
           Effect.fail(
             new EnqueueError({
-              queue: "issue-refresh",
+              queue: "issue-poll",
               message: "queue unavailable",
             }),
           ),
@@ -516,6 +547,8 @@ describe("GraphQL API", () => {
     let addCalls = 0
     let addedInput: Parameters<KeymaxxerServiceShape["addSecret"]>[0] | null =
       null
+    const ensured: string[] = []
+    const enqueued: string[] = []
     await runtime.dispose()
     runtime = makeRuntime(
       {},
@@ -531,6 +564,18 @@ describe("GraphQL API", () => {
               return true
             }),
           ),
+      },
+      {
+        ensureKeyed: (_queue, key) =>
+          Effect.sync(() => {
+            ensured.push(key)
+            return { jobId: makeJobId(), created: true }
+          }),
+        enqueue: (_queue) =>
+          Effect.sync(() => {
+            enqueued.push("refresh")
+            return makeJobId()
+          }),
       },
     )
 
@@ -573,6 +618,10 @@ describe("GraphQL API", () => {
         "Fine-grained GitHub token for Ready for Agent on acme/widgets",
       tags: "ready-for-agent,harness,github",
     })
+    // Concurrent requests share token provisioning; both may activate polling.
+    expect(ensured.every((id) => id === repository.id)).toBe(true)
+    expect(ensured.length).toBeGreaterThanOrEqual(1)
+    expect(enqueued.length).toBeGreaterThanOrEqual(1)
   })
 
   test("rejects a saved token whose metadata no longer matches", async () => {
@@ -607,8 +656,9 @@ describe("GraphQL API", () => {
     })
   })
 
-  test("removes a repository GitHub token", async () => {
+  test("removes a repository GitHub token and suspends Issue Polling", async () => {
     let removedName: string | undefined
+    const removedKeys: Array<{ queue: string; key: string }> = []
     await runtime.dispose()
     runtime = makeRuntime(
       {},
@@ -622,6 +672,12 @@ describe("GraphQL API", () => {
           Effect.sync(() => {
             removedName = name
             return true
+          }),
+      },
+      {
+        removeKeyed: (queueName, key) =>
+          Effect.sync(() => {
+            removedKeys.push({ queue: queueName, key })
           }),
       },
     )
@@ -647,10 +703,12 @@ describe("GraphQL API", () => {
       },
     })
     expect(removedName).toBe("GITHUB_TOKEN_ACME_WIDGETS")
+    expect(removedKeys).toEqual([{ queue: "issue-poll", key: repository.id }])
   })
 
   test("remove repository GitHub token is idempotent when missing", async () => {
     let removeCalls = 0
+    let removeKeyedCalls = 0
     await runtime.dispose()
     runtime = makeRuntime(
       {},
@@ -661,6 +719,12 @@ describe("GraphQL API", () => {
           Effect.sync(() => {
             removeCalls += 1
             return false
+          }),
+      },
+      {
+        removeKeyed: () =>
+          Effect.sync(() => {
+            removeKeyedCalls += 1
           }),
       },
     )
@@ -685,17 +749,29 @@ describe("GraphQL API", () => {
       },
     })
     expect(removeCalls).toBe(0)
+    expect(removeKeyedCalls).toBe(1)
   })
 
-  test("removes a repository", async () => {
+  test("removes a repository and suspends Issue Polling", async () => {
     let removedRepositoryId: string | undefined
+    let removeKeyedCalls = 0
     await runtime.dispose()
-    runtime = makeRuntime({
-      removeRepository: (repositoryId) => {
-        removedRepositoryId = repositoryId
-        return Effect.void
+    runtime = makeRuntime(
+      {
+        removeRepository: (repositoryId) => {
+          removedRepositoryId = repositoryId
+          return Effect.void
+        },
       },
-    })
+      {},
+      {},
+      {
+        removeKeyed: () =>
+          Effect.sync(() => {
+            removeKeyedCalls += 1
+          }),
+      },
+    )
 
     const response = await createGraphqlApi(runtime).fetch(
       graphqlRequest({
@@ -710,6 +786,7 @@ describe("GraphQL API", () => {
       data: { removeRepository: repository.id },
     })
     expect(removedRepositoryId).toBe(repository.id)
+    expect(removeKeyedCalls).toBe(1)
   })
 
   test("resets a Work Item", async () => {


### PR DESCRIPTION
## Summary

- Activate keyed `issue-poll` schedules when a Repository is added with an existing credential or when a matching GitHub credential is configured through Harness; suspend schedules on credential or Repository removal without cancelling accepted manual Refresh Jobs.
- Dedicated polling worker claims high-priority `issue-refresh` work before scheduled `issue-poll` entries, postpones the same recurring entry by 120–150s after every scheduled attempt (success or failure), and finalizes without recurrence when a Repository is missing or uncredentialed.
- Paused Repositories continue to poll; manual Refresh Jobs stay outside the autonomous cadence. Harness and GraphQL integration tests cover activation, suspension, priority, success/failure postpone, pause, and restart persistence.

Closes #160.

## Test plan

- [x] `bunx nx test graphql-api`
- [x] harness job-worker tests (`bun test` in apps/harness)
- [x] pre-commit affected lint/typecheck/test
- [ ] Manual: add credentialed Repository → observe first high-priority refresh and recurring schedule
- [ ] Manual: remove credential → scheduled polling stops; queued manual refresh remains