### PR TITLE
feat(harness): auto-heal Issue Polling schedules at startup

### DIFF
--- a/apps/harness/src/server/job-worker.ts
+++ b/apps/harness/src/server/job-worker.ts
@@ -17,6 +17,10 @@ import {
   ISSUE_POLL_QUEUE,
   ISSUE_REFRESH_QUEUE,
   JOB_RECOVERY_RETRY_LIMIT,
+  POLLING_AUTO_HEAL_BACKOFF,
+  POLLING_AUTO_HEAL_KEY,
+  enqueuePollingAutoHealJob,
+  repairPollingSchedules,
   sampleIssuePollingDelay,
 } from "@ready-for-agent/graphql-api"
 import { IssueReconciler } from "@ready-for-agent/issue-reconciler"
@@ -29,12 +33,20 @@ import {
 
 /** Work Item lifecycle queue (unchanged). */
 export const JOBS_QUEUE = "jobs"
-export { ISSUE_POLL_QUEUE, ISSUE_REFRESH_QUEUE, JOB_RECOVERY_RETRY_LIMIT }
+export {
+  ISSUE_POLL_QUEUE,
+  ISSUE_REFRESH_QUEUE,
+  JOB_RECOVERY_RETRY_LIMIT,
+  POLLING_AUTO_HEAL_BACKOFF,
+  POLLING_AUTO_HEAL_KEY,
+  enqueuePollingAutoHealJob,
+}
 export const JOB_VISIBILITY_TIMEOUT = Duration.minutes(5)
 const LIFECYCLE_JOB_VISIBILITY_GRACE = Duration.minutes(1)
 const JOB_IDLE_POLL_INTERVAL = Duration.millis(1500)
 const ORPHAN_RECOVERY_INTERVAL = Duration.seconds(30)
 const REFRESH_REPOSITORY_TAG = "refresh-repository"
+const POLLING_AUTO_HEAL_TAG = "polling-auto-heal"
 
 /**
  * Process-global generation so HMR/runtime restarts retire zombie workers that
@@ -83,6 +95,8 @@ const RefreshRepositoryJob = Schema.TaggedStruct("refresh-repository", {
   repositoryId: RepositoryId,
 })
 
+const PollingAutoHealJob = Schema.TaggedStruct("polling-auto-heal", {})
+
 export const enqueueRefreshRepositoryJob = (repositoryId: RepositoryId) =>
   Effect.gen(function* () {
     const queue = yield* QueueService
@@ -118,6 +132,31 @@ const repositoryHasGitHubCredential = (
     return credential !== null
   })
 
+const listCredentialedRepositoryIds = Effect.gen(function* () {
+  const db = yield* DbService
+  const repositories = yield* db.listRepositories
+  const credentialed: string[] = []
+  for (const repository of repositories) {
+    const hasCredential = yield* repositoryHasGitHubCredential(
+      repository.githubOwner,
+      repository.githubRepo,
+    )
+    if (hasCredential) {
+      credentialed.push(repository.id)
+    }
+  }
+  return credentialed
+})
+
+const runPollingAutoHeal = (sampleDelay: Effect.Effect<Duration.Duration>) =>
+  Effect.gen(function* () {
+    const credentialedRepositoryIds = yield* listCredentialedRepositoryIds
+    yield* repairPollingSchedules({
+      credentialedRepositoryIds,
+      sampleDelay,
+    })
+  })
+
 const refreshRepository = (repositoryId: RepositoryId) =>
   Effect.gen(function* () {
     const db = yield* DbService
@@ -140,6 +179,8 @@ export interface JobWorkerOptions {
   readonly orphanRecoveryInterval?: Duration.Duration
   /** Override cadence sampling for deterministic tests. */
   readonly samplePollingDelay?: Effect.Effect<Duration.Duration>
+  /** Override Auto-heal failure backoff for deterministic tests. */
+  readonly sampleAutoHealBackoff?: Effect.Effect<Duration.Duration>
 }
 
 const runQueuePollLoop = <E, R>(
@@ -209,6 +250,25 @@ const finalizeManualRefresh = (
     }
   })
 
+const finalizePollingAutoHeal = (
+  jobId: string,
+  result: AttemptResult,
+  sampleBackoff: Effect.Effect<Duration.Duration>,
+) =>
+  Effect.gen(function* () {
+    const queue = yield* QueueService
+    if (result._tag === "Failure") {
+      yield* Effect.logError("Polling Auto-heal Job failed", {
+        jobId,
+        error: formatLogError(result.failure),
+      })
+      const delay = yield* sampleBackoff
+      yield* queue.postponeKeyed(jobId, delay)
+      return
+    }
+    yield* queue.acknowledge(jobId)
+  })
+
 const finalizeScheduledRefresh = (
   jobId: string,
   repositoryId: RepositoryId,
@@ -255,6 +315,18 @@ const finalizeScheduledRefresh = (
     yield* queue.postponeKeyed(jobId, delay)
   })
 
+const payloadTag = (payload: unknown): string | undefined => {
+  if (
+    typeof payload === "object" &&
+    payload !== null &&
+    "_tag" in payload &&
+    typeof (payload as { _tag: unknown })._tag === "string"
+  ) {
+    return (payload as { _tag: string })._tag
+  }
+  return undefined
+}
+
 /**
  * One dedicated polling worker: always claim high-priority manual work before
  * scheduled recurring entries. Never interrupts a running reconciliation.
@@ -262,18 +334,51 @@ const finalizeScheduledRefresh = (
 const claimAndRunRefreshJob = (
   visibilityTimeout: Duration.Duration,
   sampleDelay: Effect.Effect<Duration.Duration>,
+  sampleAutoHealBackoff: Effect.Effect<Duration.Duration>,
 ) =>
   Effect.gen(function* () {
-    const highPriority = yield* claimRefreshJob(
+    const queue = yield* QueueService
+    const highPriorityRaw = yield* queue.rawClaim(
       ISSUE_REFRESH_QUEUE,
       visibilityTimeout,
     )
-    if (Option.isSome(highPriority)) {
-      const job = highPriority.value
-      const result = yield* Effect.result(
-        refreshRepository(job.payload.repositoryId),
-      )
-      yield* finalizeManualRefresh(job.jobId, result, job.payload.repositoryId)
+    if (Option.isSome(highPriorityRaw)) {
+      const job = highPriorityRaw.value
+      const tag = payloadTag(job.payload)
+
+      if (tag === POLLING_AUTO_HEAL_TAG) {
+        const decoded = yield* Schema.decodeUnknownEffect(PollingAutoHealJob)(
+          job.payload,
+        ).pipe(Effect.result)
+        if (decoded._tag === "Failure") {
+          yield* queue.fail(job.jobId, { retryable: false })
+          return "busy" as const
+        }
+        const result = yield* Effect.result(runPollingAutoHeal(sampleDelay))
+        yield* finalizePollingAutoHeal(job.jobId, result, sampleAutoHealBackoff)
+        return "busy" as const
+      }
+
+      if (tag === REFRESH_REPOSITORY_TAG) {
+        const decoded = yield* Schema.decodeUnknownEffect(RefreshRepositoryJob)(
+          job.payload,
+        ).pipe(Effect.result)
+        if (decoded._tag === "Failure") {
+          yield* queue.fail(job.jobId, { retryable: false })
+          return "busy" as const
+        }
+        const result = yield* Effect.result(
+          refreshRepository(decoded.success.repositoryId),
+        )
+        yield* finalizeManualRefresh(
+          job.jobId,
+          result,
+          decoded.success.repositoryId,
+        )
+        return "busy" as const
+      }
+
+      yield* queue.fail(job.jobId, { retryable: false })
       return "busy" as const
     }
 
@@ -396,6 +501,8 @@ export const runJobWorker = (options: JobWorkerOptions = {}) =>
     const orphanRecoveryInterval =
       options.orphanRecoveryInterval ?? ORPHAN_RECOVERY_INTERVAL
     const sampleDelay = options.samplePollingDelay ?? sampleIssuePollingDelay
+    const sampleAutoHealBackoff =
+      options.sampleAutoHealBackoff ?? Effect.succeed(POLLING_AUTO_HEAL_BACKOFF)
 
     yield* Effect.all(
       [
@@ -408,7 +515,11 @@ export const runJobWorker = (options: JobWorkerOptions = {}) =>
         runQueuePollLoop(
           generation,
           idlePollInterval,
-          claimAndRunRefreshJob(visibilityTimeout, sampleDelay),
+          claimAndRunRefreshJob(
+            visibilityTimeout,
+            sampleDelay,
+            sampleAutoHealBackoff,
+          ),
           "Issue polling job queue",
         ),
       ],
@@ -416,9 +527,17 @@ export const runJobWorker = (options: JobWorkerOptions = {}) =>
     )
   })
 
-export const JobWorkerLive = Layer.effectDiscard(
+/**
+ * Start the polling runtime and durably enqueue one high-priority Polling
+ * Auto-heal Job without awaiting repair completion.
+ */
+export const startJobWorker = (options: JobWorkerOptions = {}) =>
   Effect.gen(function* () {
     yield* transferPersistedRefreshJobs
-    yield* runJobWorker().pipe(Effect.forkScoped({ startImmediately: true }))
-  }),
-)
+    yield* enqueuePollingAutoHealJob
+    yield* runJobWorker(options).pipe(
+      Effect.forkScoped({ startImmediately: true }),
+    )
+  })
+
+export const JobWorkerLive = Layer.effectDiscard(startJobWorker())

--- a/apps/harness/test/job-worker.test.ts
+++ b/apps/harness/test/job-worker.test.ts
@@ -29,7 +29,10 @@ import {
   IssueReconcilerLive,
   type IssueReconcilerShape,
 } from "@ready-for-agent/issue-reconciler"
-import { KeymaxxerService } from "@ready-for-agent/keymaxxer-service"
+import {
+  KeymaxxerError,
+  KeymaxxerService,
+} from "@ready-for-agent/keymaxxer-service"
 import { Opencode } from "@ready-for-agent/opencode"
 import {
   ClaimError,
@@ -50,8 +53,11 @@ import {
   JOBS_QUEUE,
   JOB_RECOVERY_RETRY_LIMIT,
   JOB_VISIBILITY_TIMEOUT,
+  POLLING_AUTO_HEAL_KEY,
+  enqueuePollingAutoHealJob,
   enqueueRefreshRepositoryJob,
   runJobWorker,
+  startJobWorker,
   transferPersistedRefreshJobs,
 } from "../src/server/job-worker.js"
 import { describe, expect, test } from "bun:test"
@@ -1345,6 +1351,515 @@ describe("Job worker", () => {
         // Not immediately available again (postponed 120s).
         const claimNow = yield* service.rawClaim(ISSUE_POLL_QUEUE)
         expect(Option.isNone(claimNow)).toBe(true)
+      }).pipe(
+        Effect.provide(
+          Layer.mergeAll(
+            database,
+            queue,
+            reconciler,
+            keymaxxerLayer(),
+            lifecycle,
+          ),
+        ),
+        Effect.orDie,
+      ),
+    )
+  })
+
+  test("startup enqueues one Polling Auto-heal Job without awaiting repair", async () => {
+    const database = DbServiceLive.pipe(Layer.provideMerge(DatabaseTest))
+    const queue = SqliteQueueServiceLive.pipe(Layer.provideMerge(database))
+    const lifecycle = Layer.succeed(WorkItemLifecycle, {
+      maxDurations: {
+        create_worktree: Duration.minutes(5),
+        install_dependencies: Duration.minutes(15),
+        implement: Duration.hours(2),
+        pre_commit: Duration.hours(2),
+        review: Duration.hours(1),
+        commit: Duration.minutes(5),
+        create_pr: Duration.minutes(10),
+        watch_pr_status_checks: Duration.minutes(5),
+        resolve_pr_merge_conflict: Duration.hours(2),
+        investigate_pr_status_checks: Duration.hours(2),
+        mark_pr_ready_for_review: Duration.minutes(5),
+        decide_pr_merge: Duration.minutes(15),
+        merge_pr: Duration.minutes(5),
+        local_cleanup: Duration.minutes(5),
+      },
+      implementNow: unused,
+      implementLocally: unused,
+      recoverOrphanedStepRuns: Effect.succeed(0),
+      runStep: () => Effect.succeed({ _tag: "noop" as const }),
+      retry: unused,
+      pause: unused,
+      start: unused,
+      abandon: unused,
+      reset: unused,
+      getWorkItem: unused,
+      listWorkItemsForIssue: unused,
+      listWorkItemsForRepository: unused,
+    })
+    // Block Keymaxxer so auto-heal cannot finish during startup.
+    const blockedKeymaxxer = Layer.succeed(KeymaxxerService, {
+      initialize: Effect.void,
+      findSecret: () => Effect.never,
+      findSecrets: () => Effect.die("not used"),
+      hasSecret: () => Effect.die("not used"),
+      addSecret: () => Effect.die("not used"),
+      removeSecret: () => Effect.die("not used"),
+      runWithSecrets: () => Effect.die("not used"),
+    })
+
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        const db = yield* DbService
+        const service = yield* QueueService
+        // Ensure auto-heal must consult Keymaxxer (and therefore blocks).
+        yield* db.addRepository({
+          githubOwner: repository.githubOwner,
+          githubRepo: repository.githubRepo,
+          localPath: repository.localPath,
+          isBare: true,
+        })
+        yield* Effect.scoped(
+          Effect.gen(function* () {
+            yield* startJobWorker({
+              idlePollInterval: Duration.zero,
+              samplePollingDelay: Effect.succeed(Duration.seconds(120)),
+            })
+            // startJobWorker returns after durable enqueue + forking workers,
+            // without waiting for auto-heal to finish (blocked on Keymaxxer).
+            const autoHeal = yield* service.listKeyed(ISSUE_REFRESH_QUEUE)
+            expect(autoHeal).toHaveLength(1)
+            expect(autoHeal[0]?.key).toBe(POLLING_AUTO_HEAL_KEY)
+            expect(autoHeal[0]?.payload).toEqual({
+              _tag: "polling-auto-heal",
+            })
+            // Repair has not completed: no schedules yet.
+            expect(yield* service.listKeyed(ISSUE_POLL_QUEUE)).toEqual([])
+          }),
+        )
+      }).pipe(
+        Effect.provide(
+          Layer.mergeAll(
+            database,
+            queue,
+            Layer.succeed(IssueReconciler, {
+              reconcile: () => Effect.die("not used"),
+            }),
+            blockedKeymaxxer,
+            lifecycle,
+          ),
+        ),
+        Effect.orDie,
+      ),
+    )
+  })
+
+  test("repeated startup scheduling does not create unbounded Auto-heal Jobs", async () => {
+    const database = DbServiceLive.pipe(Layer.provideMerge(DatabaseTest))
+    const queue = SqliteQueueServiceLive.pipe(Layer.provideMerge(database))
+
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        const service = yield* QueueService
+        const first = yield* enqueuePollingAutoHealJob
+        const second = yield* enqueuePollingAutoHealJob
+        const third = yield* enqueuePollingAutoHealJob
+        expect(first.created).toBe(true)
+        expect(second.created).toBe(false)
+        expect(third.created).toBe(false)
+        expect(second.jobId).toBe(first.jobId)
+        expect(third.jobId).toBe(first.jobId)
+        const keyed = yield* service.listKeyed(ISSUE_REFRESH_QUEUE)
+        expect(keyed).toHaveLength(1)
+        expect(keyed[0]?.key).toBe(POLLING_AUTO_HEAL_KEY)
+      }).pipe(Effect.provide(Layer.mergeAll(database, queue)), Effect.orDie),
+    )
+  })
+
+  test("auto-heal repairs missing schedules, orphans, due times, and first refreshes", async () => {
+    const database = DbServiceLive.pipe(Layer.provideMerge(DatabaseTest))
+    const queue = SqliteQueueServiceLive.pipe(Layer.provideMerge(database))
+    const reconciliations: string[] = []
+    const reconciler = Layer.succeed(IssueReconciler, {
+      reconcile: (repo) =>
+        Effect.sync(() => {
+          reconciliations.push(repo.id)
+          return {
+            fetched: 0,
+            inserted: 0,
+            updated: 0,
+            deleted: 0,
+            unchanged: 0,
+          }
+        }),
+    } satisfies IssueReconcilerShape)
+    const lifecycle = Layer.succeed(WorkItemLifecycle, {
+      maxDurations: {
+        create_worktree: Duration.minutes(5),
+        install_dependencies: Duration.minutes(15),
+        implement: Duration.hours(2),
+        pre_commit: Duration.hours(2),
+        review: Duration.hours(1),
+        commit: Duration.minutes(5),
+        create_pr: Duration.minutes(10),
+        watch_pr_status_checks: Duration.minutes(5),
+        resolve_pr_merge_conflict: Duration.hours(2),
+        investigate_pr_status_checks: Duration.hours(2),
+        mark_pr_ready_for_review: Duration.minutes(5),
+        decide_pr_merge: Duration.minutes(15),
+        merge_pr: Duration.minutes(5),
+        local_cleanup: Duration.minutes(5),
+      },
+      implementNow: unused,
+      implementLocally: unused,
+      recoverOrphanedStepRuns: Effect.succeed(0),
+      runStep: () => Effect.succeed({ _tag: "noop" as const }),
+      retry: unused,
+      pause: unused,
+      start: unused,
+      abandon: unused,
+      reset: unused,
+      getWorkItem: unused,
+      listWorkItemsForIssue: unused,
+      listWorkItemsForRepository: unused,
+    })
+
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        const db = yield* DbService
+        const service = yield* QueueService
+        const credentialed = yield* db.addRepository({
+          githubOwner: repository.githubOwner,
+          githubRepo: repository.githubRepo,
+          localPath: repository.localPath,
+          isBare: true,
+        })
+        const uncredentialed = yield* db.addRepository({
+          githubOwner: "other",
+          githubRepo: "uncredentialed",
+          localPath: "/repos/other/uncredentialed.git",
+          isBare: true,
+        })
+        const preserved = yield* service.ensureKeyed(
+          ISSUE_POLL_QUEUE,
+          credentialed.id,
+          {
+            _tag: "refresh-repository",
+            repositoryId: RepositoryId.make(credentialed.id),
+          },
+          Duration.millis(90_000),
+          { retryLimit: JOB_RECOVERY_RETRY_LIMIT },
+        )
+        const preservedBefore = yield* service.listKeyed(ISSUE_POLL_QUEUE)
+        const preservedAvailableAt = DateTime.toEpochMillis(
+          preservedBefore.find((entry) => entry.key === credentialed.id)!
+            .availableAt,
+        )
+        yield* service.ensureKeyed(
+          ISSUE_POLL_QUEUE,
+          uncredentialed.id,
+          {
+            _tag: "refresh-repository",
+            repositoryId: RepositoryId.make(uncredentialed.id),
+          },
+          Duration.seconds(30),
+          { retryLimit: JOB_RECOVERY_RETRY_LIMIT },
+        )
+        yield* service.ensureKeyed(
+          ISSUE_POLL_QUEUE,
+          "repo-deleted-orphan",
+          {
+            _tag: "refresh-repository",
+            repositoryId: RepositoryId.make("repo-01J00000000000000000000099"),
+          },
+          Duration.seconds(30),
+          { retryLimit: JOB_RECOVERY_RETRY_LIMIT },
+        )
+
+        const missing = yield* db.addRepository({
+          githubOwner: otherRepository.githubOwner,
+          githubRepo: otherRepository.githubRepo,
+          localPath: otherRepository.localPath,
+          isBare: true,
+        })
+
+        yield* Effect.scoped(
+          Effect.gen(function* () {
+            yield* startJobWorker({
+              idlePollInterval: Duration.zero,
+              samplePollingDelay: Effect.succeed(Duration.seconds(142)),
+            })
+            // Wait until auto-heal finishes and the missing repo's first refresh runs.
+            while (
+              !(
+                reconciliations.includes(missing.id) &&
+                (yield* service.listKeyed(ISSUE_REFRESH_QUEUE)).every(
+                  (entry) => entry.key !== POLLING_AUTO_HEAL_KEY,
+                )
+              )
+            ) {
+              yield* Effect.sleep("5 millis")
+            }
+          }),
+        )
+
+        const schedules = yield* service.listKeyed(ISSUE_POLL_QUEUE)
+        expect(schedules.map((entry) => entry.key).sort()).toEqual(
+          [credentialed.id, missing.id].sort(),
+        )
+        const preservedEntry = schedules.find(
+          (entry) => entry.key === credentialed.id,
+        )
+        expect(preservedEntry?.jobId).toBe(preserved.jobId)
+        expect(
+          Math.abs(
+            DateTime.toEpochMillis(preservedEntry!.availableAt) -
+              preservedAvailableAt,
+          ),
+        ).toBeLessThan(2_000)
+
+        const missingEntry = schedules.find((entry) => entry.key === missing.id)
+        expect(missingEntry).toBeDefined()
+        expect(
+          DateTime.toEpochMillis(missingEntry!.availableAt) - Date.now(),
+        ).toBeGreaterThan(100_000)
+
+        // Manual first refresh for the repaired Repository was accepted and run.
+        expect(reconciliations).toContain(missing.id)
+        // Existing correct schedule was not reset into an immediate poll.
+        expect(reconciliations).not.toContain(credentialed.id)
+      }).pipe(
+        Effect.provide(
+          Layer.mergeAll(
+            database,
+            queue,
+            reconciler,
+            keymaxxerLayer(
+              new Set([
+                `${repository.githubOwner}/${repository.githubRepo}`,
+                `${otherRepository.githubOwner}/${otherRepository.githubRepo}`,
+              ]),
+            ),
+            lifecycle,
+          ),
+        ),
+        Effect.orDie,
+      ),
+    )
+  })
+
+  test("auto-heal retries with backoff until Keymaxxer succeeds", async () => {
+    const database = DbServiceLive.pipe(Layer.provideMerge(DatabaseTest))
+    const queue = SqliteQueueServiceLive.pipe(Layer.provideMerge(database))
+    let findSecretCalls = 0
+    const keymaxxer = Layer.succeed(KeymaxxerService, {
+      initialize: Effect.void,
+      findSecret: ({ account, provider }) =>
+        Effect.gen(function* () {
+          findSecretCalls += 1
+          if (findSecretCalls < 3) {
+            return yield* Effect.fail(
+              new KeymaxxerError({
+                operation: "findSecret",
+                message: "Keymaxxer unavailable",
+              }),
+            )
+          }
+          return provider === "github" &&
+            account === `${repository.githubOwner}/${repository.githubRepo}`
+            ? `GITHUB_TOKEN`
+            : null
+        }),
+      findSecrets: () => Effect.die("not used"),
+      hasSecret: () => Effect.die("not used"),
+      addSecret: () => Effect.die("not used"),
+      removeSecret: () => Effect.die("not used"),
+      runWithSecrets: () => Effect.die("not used"),
+    })
+    const lifecycle = Layer.succeed(WorkItemLifecycle, {
+      maxDurations: {
+        create_worktree: Duration.minutes(5),
+        install_dependencies: Duration.minutes(15),
+        implement: Duration.hours(2),
+        pre_commit: Duration.hours(2),
+        review: Duration.hours(1),
+        commit: Duration.minutes(5),
+        create_pr: Duration.minutes(10),
+        watch_pr_status_checks: Duration.minutes(5),
+        resolve_pr_merge_conflict: Duration.hours(2),
+        investigate_pr_status_checks: Duration.hours(2),
+        mark_pr_ready_for_review: Duration.minutes(5),
+        decide_pr_merge: Duration.minutes(15),
+        merge_pr: Duration.minutes(5),
+        local_cleanup: Duration.minutes(5),
+      },
+      implementNow: unused,
+      implementLocally: unused,
+      recoverOrphanedStepRuns: Effect.succeed(0),
+      runStep: () => Effect.succeed({ _tag: "noop" as const }),
+      retry: unused,
+      pause: unused,
+      start: unused,
+      abandon: unused,
+      reset: unused,
+      getWorkItem: unused,
+      listWorkItemsForIssue: unused,
+      listWorkItemsForRepository: unused,
+    })
+
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        const db = yield* DbService
+        const service = yield* QueueService
+        const added = yield* db.addRepository({
+          githubOwner: repository.githubOwner,
+          githubRepo: repository.githubRepo,
+          localPath: repository.localPath,
+          isBare: true,
+        })
+
+        yield* Effect.scoped(
+          Effect.gen(function* () {
+            yield* startJobWorker({
+              idlePollInterval: Duration.zero,
+              samplePollingDelay: Effect.succeed(Duration.seconds(120)),
+              sampleAutoHealBackoff: Effect.succeed(Duration.zero),
+            })
+            while ((yield* service.listKeyed(ISSUE_POLL_QUEUE)).length < 1) {
+              yield* Effect.sleep("5 millis")
+            }
+          }),
+        )
+
+        const schedules = yield* service.listKeyed(ISSUE_POLL_QUEUE)
+        expect(schedules).toHaveLength(1)
+        expect(schedules[0]?.key).toBe(added.id)
+        expect(findSecretCalls).toBeGreaterThanOrEqual(3)
+        const autoHeal = yield* service.listKeyed(ISSUE_REFRESH_QUEUE)
+        expect(
+          autoHeal.filter((entry) => entry.key === POLLING_AUTO_HEAL_KEY),
+        ).toHaveLength(0)
+      }).pipe(
+        Effect.provide(
+          Layer.mergeAll(
+            database,
+            queue,
+            Layer.succeed(IssueReconciler, {
+              reconcile: () =>
+                Effect.succeed({
+                  fetched: 0,
+                  inserted: 0,
+                  updated: 0,
+                  deleted: 0,
+                  unchanged: 0,
+                }),
+            }),
+            keymaxxer,
+            lifecycle,
+          ),
+        ),
+        Effect.orDie,
+      ),
+    )
+  })
+
+  test("successful auto-heal does not disturb queued manual Refresh Jobs", async () => {
+    const database = DbServiceLive.pipe(Layer.provideMerge(DatabaseTest))
+    const queue = SqliteQueueServiceLive.pipe(Layer.provideMerge(database))
+    const reconciliations: string[] = []
+    const reconciler = Layer.succeed(IssueReconciler, {
+      reconcile: (repo) =>
+        Effect.sync(() => {
+          reconciliations.push(repo.id)
+          return {
+            fetched: 0,
+            inserted: 0,
+            updated: 0,
+            deleted: 0,
+            unchanged: 0,
+          }
+        }),
+    } satisfies IssueReconcilerShape)
+    const lifecycle = Layer.succeed(WorkItemLifecycle, {
+      maxDurations: {
+        create_worktree: Duration.minutes(5),
+        install_dependencies: Duration.minutes(15),
+        implement: Duration.hours(2),
+        pre_commit: Duration.hours(2),
+        review: Duration.hours(1),
+        commit: Duration.minutes(5),
+        create_pr: Duration.minutes(10),
+        watch_pr_status_checks: Duration.minutes(5),
+        resolve_pr_merge_conflict: Duration.hours(2),
+        investigate_pr_status_checks: Duration.hours(2),
+        mark_pr_ready_for_review: Duration.minutes(5),
+        decide_pr_merge: Duration.minutes(15),
+        merge_pr: Duration.minutes(5),
+        local_cleanup: Duration.minutes(5),
+      },
+      implementNow: unused,
+      implementLocally: unused,
+      recoverOrphanedStepRuns: Effect.succeed(0),
+      runStep: () => Effect.succeed({ _tag: "noop" as const }),
+      retry: unused,
+      pause: unused,
+      start: unused,
+      abandon: unused,
+      reset: unused,
+      getWorkItem: unused,
+      listWorkItemsForIssue: unused,
+      listWorkItemsForRepository: unused,
+    })
+
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        const db = yield* DbService
+        const service = yield* QueueService
+        const added = yield* db.addRepository({
+          githubOwner: repository.githubOwner,
+          githubRepo: repository.githubRepo,
+          localPath: repository.localPath,
+          isBare: true,
+        })
+        const manualId = yield* service.enqueue(
+          ISSUE_REFRESH_QUEUE,
+          {
+            _tag: "refresh-repository",
+            repositoryId: RepositoryId.make(added.id),
+          },
+          { retryLimit: JOB_RECOVERY_RETRY_LIMIT },
+        )
+
+        yield* Effect.scoped(
+          Effect.gen(function* () {
+            yield* startJobWorker({
+              idlePollInterval: Duration.zero,
+              samplePollingDelay: Effect.succeed(Duration.seconds(120)),
+            })
+            while (!reconciliations.includes(added.id)) {
+              yield* Effect.sleep("5 millis")
+            }
+            // Allow the worker to drain high-priority work.
+            yield* Effect.sleep("50 millis")
+          }),
+        )
+
+        expect(
+          reconciliations.filter((id) => id === added.id).length,
+        ).toBeGreaterThanOrEqual(1)
+        // Manual job identity was accepted before auto-heal; after drain it is gone.
+        const remaining = yield* service.rawClaim(ISSUE_REFRESH_QUEUE)
+        expect(Option.isNone(remaining)).toBe(true)
+        // The schedule exists and auto-heal is finalized.
+        const schedules = yield* service.listKeyed(ISSUE_POLL_QUEUE)
+        expect(schedules.map((entry) => entry.key)).toEqual([added.id])
+        const autoHeal = yield* service.listKeyed(ISSUE_REFRESH_QUEUE)
+        expect(
+          autoHeal.filter((entry) => entry.key === POLLING_AUTO_HEAL_KEY),
+        ).toHaveLength(0)
+        void manualId
       }).pipe(
         Effect.provide(
           Layer.mergeAll(

--- a/packages/graphql-api/src/lib/issue-polling.ts
+++ b/packages/graphql-api/src/lib/issue-polling.ts
@@ -8,6 +8,9 @@ export const ISSUE_REFRESH_QUEUE = "issue-refresh"
 /** Scheduled recurring Issue Polling queue (one keyed entry per Repository). */
 export const ISSUE_POLL_QUEUE = "issue-poll"
 
+/** Stable key for the durable Polling Auto-heal Job on the high-priority queue. */
+export const POLLING_AUTO_HEAL_KEY = "polling-auto-heal"
+
 export const JOB_RECOVERY_RETRY_LIMIT = 1
 
 /** Base quiet period after a scheduled attempt completes. */
@@ -16,10 +19,17 @@ export const ISSUE_POLLING_BASE_SECONDS = 120
 /** Inclusive upper bound for additive jitter seconds (0–30). */
 export const ISSUE_POLLING_JITTER_SECONDS = 30
 
+/** Default backoff when a Polling Auto-heal Job fails (no tight loop). */
+export const POLLING_AUTO_HEAL_BACKOFF = Duration.seconds(5)
+
 const RefreshRepositoryJobPayload = (repositoryId: string) => ({
   _tag: "refresh-repository" as const,
   repositoryId: RepositoryId.make(repositoryId),
 })
+
+export const PollingAutoHealJobPayload = {
+  _tag: "polling-auto-heal" as const,
+}
 
 /**
  * Sample the next Issue Polling delay: 120s + uniform integer jitter in [0, 30].
@@ -43,6 +53,21 @@ export const enqueueRefreshRepositoryJob = (repositoryId: string) =>
   })
 
 /**
+ * Durably ensure one high-priority Polling Auto-heal Job without awaiting repair.
+ * Idempotent: repeated startup does not create an unbounded set of equivalents.
+ */
+export const enqueuePollingAutoHealJob = Effect.gen(function* () {
+  const queue = yield* QueueService
+  return yield* queue.ensureKeyed(
+    ISSUE_REFRESH_QUEUE,
+    POLLING_AUTO_HEAL_KEY,
+    PollingAutoHealJobPayload,
+    Duration.zero,
+    { retryLimit: JOB_RECOVERY_RETRY_LIMIT },
+  )
+})
+
+/**
  * Ensure one keyed recurring schedule and enqueue a high-priority first refresh.
  * Idempotent for the schedule; every activation enqueues a distinct first refresh.
  */
@@ -64,4 +89,49 @@ export const suspendRepositoryPolling = (repositoryId: string) =>
   Effect.gen(function* () {
     const queue = yield* QueueService
     yield* queue.removeKeyed(ISSUE_POLL_QUEUE, repositoryId)
+  })
+
+export interface RepairPollingSchedulesInput {
+  readonly credentialedRepositoryIds: ReadonlyArray<string>
+  readonly sampleDelay?: Effect.Effect<Duration.Duration>
+}
+
+/**
+ * Make keyed Issue Poll schedules exactly match credentialed Repositories:
+ * remove orphans, add missing entries (with a high-priority first refresh each),
+ * preserve existing correct entries and due times.
+ */
+export const repairPollingSchedules = (input: RepairPollingSchedulesInput) =>
+  Effect.gen(function* () {
+    const queue = yield* QueueService
+    const sampleDelay = input.sampleDelay ?? sampleIssuePollingDelay
+    const credentialed = new Set(input.credentialedRepositoryIds)
+    const existing = yield* queue.listKeyed(ISSUE_POLL_QUEUE)
+
+    for (const entry of existing) {
+      if (!credentialed.has(entry.key)) {
+        yield* queue.removeKeyed(ISSUE_POLL_QUEUE, entry.key)
+      }
+    }
+
+    const existingKeys = new Set(
+      (yield* queue.listKeyed(ISSUE_POLL_QUEUE)).map((entry) => entry.key),
+    )
+    const missing = input.credentialedRepositoryIds.filter(
+      (id) => !existingKeys.has(id),
+    )
+
+    for (const repositoryId of missing) {
+      const delay = yield* sampleDelay
+      const payload = RefreshRepositoryJobPayload(repositoryId)
+      // Enqueue first refresh before ensure so a crash between steps still
+      // leaves the Repository in the missing set on the next auto-heal attempt
+      // (duplicate first refreshes are allowed; schedules are unique).
+      yield* queue.enqueue(ISSUE_REFRESH_QUEUE, payload, {
+        retryLimit: JOB_RECOVERY_RETRY_LIMIT,
+      })
+      yield* queue.ensureKeyed(ISSUE_POLL_QUEUE, repositoryId, payload, delay, {
+        retryLimit: JOB_RECOVERY_RETRY_LIMIT,
+      })
+    }
   })


### PR DESCRIPTION
## Summary

- Enqueue one durable high-priority Polling Auto-heal Job on Harness startup without awaiting repair
- Repair keyed Issue Poll schedules to exactly match credentialed Repositories (add missing + first refresh, preserve due times, remove orphans)
- Retry Auto-heal with backoff on temporary database/Keymaxxer failures

Closes #161

## Test plan

- [x] `nx test harness` (auto-heal integration coverage)
- [x] `nx test graphql-api`
- [x] Pre-commit affected lint/typecheck/test