### PR TITLE
feat: replace active Work Item polling with GraphQL SSE invalidation

### DIFF
--- a/apps/harness/e2e/refresh-repository.e2e.ts
+++ b/apps/harness/e2e/refresh-repository.e2e.ts
@@ -111,6 +111,13 @@ test("Refresh returns after enqueueing and updates after worker invalidation", a
       })
       return
     }
+    if (operations[0]?.query.includes("repositoryWorkItemsChanged")) {
+      await route.fulfill({
+        contentType: "text/event-stream",
+        body: "event: complete\n\n",
+      })
+      return
+    }
 
     const responses = operations.map(({ query }) => jsonResponse(query))
     await fulfillJson(

--- a/apps/harness/src/refresh-work-items-live.ts
+++ b/apps/harness/src/refresh-work-items-live.ts
@@ -1,0 +1,104 @@
+import type { QueryClient } from "@tanstack/react-query"
+import { streamWorkItemsChanged } from "./work-items-live.js"
+
+export type RepositoryWorkItemsLiveQueries = {
+  workItems: (repositoryId: string) => {
+    queryKey: readonly unknown[]
+    queryFn: () => Promise<unknown>
+  }
+}
+
+/**
+ * Keeps Work Items fresh via the Work-Items-changed invalidation subscription,
+ * with reconnect and tab-visibility refetch as fallback for missed ephemeral
+ * notifications.
+ *
+ * Refetches only the affected repository's workItems query on each event.
+ * Callers supply current Repository IDs via `getRepositoryIds` so reconnect
+ * races still refresh newly added repositories.
+ */
+export const followRepositoryWorkItemsLive = async ({
+  getRepositoryIds,
+  queryClient,
+  queries,
+  signal,
+  stream = streamWorkItemsChanged,
+  documentRef = typeof document === "undefined" ? undefined : document,
+  retryDelayMs = 1_000,
+}: {
+  getRepositoryIds: () => readonly string[]
+  queryClient: QueryClient
+  queries: RepositoryWorkItemsLiveQueries
+  signal: AbortSignal
+  stream?: typeof streamWorkItemsChanged
+  documentRef?: Pick<
+    Document,
+    "visibilityState" | "addEventListener" | "removeEventListener"
+  >
+  retryDelayMs?: number
+}): Promise<void> => {
+  const fetchFresh = async (query: {
+    queryKey: readonly unknown[]
+    queryFn: () => Promise<unknown>
+  }) => {
+    await queryClient.cancelQueries({ queryKey: query.queryKey, exact: true })
+    return queryClient.fetchQuery({ ...query, staleTime: 0 })
+  }
+
+  const refresh = async (repositoryId: string) => {
+    await fetchFresh(queries.workItems(repositoryId))
+  }
+
+  const refreshAll = async () => {
+    const repositoryIds = getRepositoryIds()
+    await Promise.all(
+      repositoryIds.map((repositoryId) =>
+        fetchFresh(queries.workItems(repositoryId)),
+      ),
+    )
+  }
+
+  const refreshWhenVisible = () => {
+    if (documentRef?.visibilityState === "visible") {
+      void refreshAll().catch(() => undefined)
+    }
+  }
+
+  documentRef?.addEventListener("visibilitychange", refreshWhenVisible)
+
+  try {
+    while (!signal.aborted) {
+      const attempt = new AbortController()
+      const onAbort = () => attempt.abort()
+      signal.addEventListener("abort", onAbort, { once: true })
+      try {
+        await stream({
+          signal: attempt.signal,
+          onConnected: refreshAll,
+          onChange: refresh,
+        })
+      } catch {
+        if (signal.aborted) return
+      } finally {
+        signal.removeEventListener("abort", onAbort)
+        attempt.abort()
+      }
+
+      if (signal.aborted) return
+      await new Promise<void>((resolve) => {
+        const finish = () => {
+          signal.removeEventListener("abort", cancel)
+          resolve()
+        }
+        const timer = setTimeout(finish, retryDelayMs)
+        const cancel = () => {
+          clearTimeout(timer)
+          finish()
+        }
+        signal.addEventListener("abort", cancel, { once: true })
+      })
+    }
+  } finally {
+    documentRef?.removeEventListener("visibilitychange", refreshWhenVisible)
+  }
+}

--- a/apps/harness/src/routes/index.tsx
+++ b/apps/harness/src/routes/index.tsx
@@ -9,6 +9,7 @@ import { createFileRoute } from "@tanstack/react-router"
 import { type FormEvent, Suspense, useEffect, useRef, useState } from "react"
 import { createClient } from "@ready-for-agent/graphql-client"
 import { followRepositoryIssuesLive } from "../refresh-issues-live.js"
+import { followRepositoryWorkItemsLive } from "../refresh-work-items-live.js"
 import { streamRepositoryChanges } from "../repository-live.js"
 
 const graphql = createClient({ url: "/graphql", batch: true })
@@ -372,6 +373,19 @@ function RepositoryCards() {
       queries: {
         repositories: repositoriesQuery,
         issues: issuesQuery,
+        workItems: workItemsQuery,
+      },
+      signal: controller.signal,
+    })
+    return () => controller.abort()
+  }, [queryClient])
+
+  useEffect(() => {
+    const controller = new AbortController()
+    void followRepositoryWorkItemsLive({
+      getRepositoryIds: () => repositoryIdsRef.current,
+      queryClient,
+      queries: {
         workItems: workItemsQuery,
       },
       signal: controller.signal,
@@ -1442,17 +1456,7 @@ function RepositoryIssueRow({
 function JobsCard() {
   const { data: repositories } = useSuspenseQuery(repositoriesQuery)
   const workItemQueries = useQueries({
-    queries: repositories.map((repository) => ({
-      ...workItemsQuery(repository.id),
-      refetchInterval: ({ state }: { state: { data: unknown } }) => {
-        const items = state.data as readonly WorkItem[] | undefined
-        return items?.some(
-          (item) => item.status === "QUEUED" || item.status === "RUNNING",
-        )
-          ? 1_000
-          : false
-      },
-    })),
+    queries: repositories.map((repository) => workItemsQuery(repository.id)),
   })
 
   const repositoryById = new Map(

--- a/apps/harness/src/work-items-live.ts
+++ b/apps/harness/src/work-items-live.ts
@@ -1,0 +1,81 @@
+import { generateSubscriptionOp } from "@ready-for-agent/graphql-client"
+
+export const parseWorkItemsSubscriptionEvent = (
+  event: string,
+): string | null => {
+  let eventType = "message"
+  const data: string[] = []
+
+  for (const line of event.split(/\r?\n/)) {
+    if (line.startsWith("event:")) eventType = line.slice(6).trim()
+    if (line.startsWith("data:")) data.push(line.slice(5).trimStart())
+  }
+
+  if (eventType === "complete") return null
+  if (eventType !== "next" && eventType !== "message") return null
+  if (data.length === 0) return null
+
+  const result = JSON.parse(data.join("\n")) as {
+    data?: { repositoryWorkItemsChanged?: string }
+    errors?: unknown
+  }
+  if (result.errors !== undefined) {
+    throw new Error("Work Item change subscription failed")
+  }
+  return result.data?.repositoryWorkItemsChanged ?? null
+}
+
+export const streamWorkItemsChanged = async ({
+  signal,
+  onConnected,
+  onChange,
+  fetch: fetchRequest = fetch,
+}: {
+  signal: AbortSignal
+  onConnected: () => void | Promise<void>
+  onChange: (repositoryId: string) => void | Promise<void>
+  fetch?: typeof fetch
+}): Promise<void> => {
+  const operation = generateSubscriptionOp({
+    repositoryWorkItemsChanged: true,
+  })
+
+  const response = await fetchRequest("/graphql", {
+    method: "POST",
+    headers: {
+      accept: "text/event-stream",
+      "content-type": "application/json",
+    },
+    body: JSON.stringify(operation),
+    signal,
+  })
+
+  if (!response.ok || response.body === null) {
+    throw new Error(`Work Item change subscription returned ${response.status}`)
+  }
+
+  await onConnected()
+
+  const reader = response.body.getReader()
+  const decoder = new TextDecoder()
+  let buffer = ""
+
+  while (true) {
+    const { done, value } = await reader.read()
+    buffer += decoder.decode(value, { stream: !done })
+
+    let boundary = buffer.search(/\r?\n\r?\n/)
+    while (boundary >= 0) {
+      const separator = buffer.slice(boundary).match(/^\r?\n\r?\n/)?.[0]
+      const event = buffer.slice(0, boundary)
+      buffer = buffer.slice(boundary + (separator?.length ?? 2))
+
+      if (event.startsWith("event: complete")) return
+      const repositoryId = parseWorkItemsSubscriptionEvent(event)
+      if (repositoryId !== null) await onChange(repositoryId)
+      boundary = buffer.search(/\r?\n\r?\n/)
+    }
+
+    if (done) return
+  }
+}

--- a/apps/harness/test/jobs-card-no-polling.test.ts
+++ b/apps/harness/test/jobs-card-no-polling.test.ts
@@ -1,0 +1,20 @@
+import { readFileSync } from "node:fs"
+import { join } from "node:path"
+import { describe, expect, test } from "bun:test"
+
+describe("JobsCard live updates", () => {
+  test("does not poll workItems on a one-second interval", () => {
+    const source = readFileSync(
+      join(import.meta.dir, "../src/routes/index.tsx"),
+      "utf8",
+    )
+    const jobsCardStart = source.indexOf("function JobsCard()")
+    expect(jobsCardStart).toBeGreaterThan(-1)
+    const jobsCardEnd = source.indexOf("function JobsCardSkeleton()")
+    expect(jobsCardEnd).toBeGreaterThan(jobsCardStart)
+    const jobsCard = source.slice(jobsCardStart, jobsCardEnd)
+    expect(jobsCard).not.toContain("refetchInterval")
+    expect(jobsCard).not.toContain("1_000")
+    expect(source).toContain("followRepositoryWorkItemsLive")
+  })
+})

--- a/apps/harness/test/refresh-work-items-live.test.ts
+++ b/apps/harness/test/refresh-work-items-live.test.ts
@@ -1,0 +1,248 @@
+import { QueryClient } from "@tanstack/react-query"
+import { followRepositoryWorkItemsLive } from "../src/refresh-work-items-live.js"
+import { describe, expect, test } from "bun:test"
+
+describe("Repository Work Item live-query coordination", () => {
+  test("an invalidation refetches only the affected Repository Work Items", async () => {
+    const repositoryId = "repo-01JSELECTED000000000000000"
+    const otherRepositoryId = "repo-01JOTHER0000000000000000"
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    })
+
+    let selectedWorkItemsFetches = 0
+    let otherWorkItemsFetches = 0
+    let selectedWorkItems = [
+      {
+        id: "wi-before",
+        status: "QUEUED",
+      },
+    ]
+
+    const queries = {
+      workItems: (id: string) => ({
+        queryKey: ["work-items", id] as const,
+        queryFn: async () => {
+          if (id === repositoryId) {
+            selectedWorkItemsFetches += 1
+            return selectedWorkItems
+          }
+          otherWorkItemsFetches += 1
+          return []
+        },
+      }),
+    }
+
+    let releaseInvalidation: (() => void) | undefined
+    const invalidation = new Promise<void>((resolve) => {
+      releaseInvalidation = resolve
+    })
+    let onChange: ((repositoryId: string) => void | Promise<void>) | undefined
+    let connected: (() => void) | undefined
+    const connectedPromise = new Promise<void>((resolve) => {
+      connected = resolve
+    })
+
+    const controller = new AbortController()
+    const live = followRepositoryWorkItemsLive({
+      getRepositoryIds: () => [repositoryId, otherRepositoryId],
+      queryClient,
+      queries,
+      signal: controller.signal,
+      retryDelayMs: 10,
+      stream: async ({ onConnected, onChange: handleChange, signal }) => {
+        onChange = handleChange
+        await onConnected()
+        connected?.()
+        await invalidation
+        if (signal.aborted) return
+        await handleChange(repositoryId)
+        await new Promise<void>((resolve) => {
+          if (signal.aborted) {
+            resolve()
+            return
+          }
+          signal.addEventListener("abort", () => resolve(), { once: true })
+        })
+      },
+    })
+
+    await connectedPromise
+
+    selectedWorkItems = [
+      {
+        id: "wi-after",
+        status: "RUNNING",
+      },
+    ]
+    const fetchesBeforeInvalidation = {
+      selectedWorkItems: selectedWorkItemsFetches,
+    }
+    releaseInvalidation?.()
+
+    await Bun.sleep(20)
+
+    const workItems = queryClient.getQueryData(
+      queries.workItems(repositoryId).queryKey,
+    )
+
+    expect(workItems).toEqual([
+      {
+        id: "wi-after",
+        status: "RUNNING",
+      },
+    ])
+    expect(selectedWorkItemsFetches).toBeGreaterThan(
+      fetchesBeforeInvalidation.selectedWorkItems,
+    )
+    // Initial connection refetches both displayed Repositories, but the
+    // selected invalidation does not refetch the other Repository again.
+    expect(otherWorkItemsFetches).toBe(1)
+    const selectedWorkItemsBeforeOtherInvalidation = selectedWorkItemsFetches
+    const otherWorkItemsBeforeOtherInvalidation = otherWorkItemsFetches
+    await onChange?.(otherRepositoryId)
+    expect(selectedWorkItemsFetches).toBe(
+      selectedWorkItemsBeforeOtherInvalidation,
+    )
+    expect(otherWorkItemsFetches).toBeGreaterThan(
+      otherWorkItemsBeforeOtherInvalidation,
+    )
+    expect(onChange).toBeDefined()
+
+    controller.abort()
+    await live
+  })
+
+  test("an invalidation replaces a stale in-flight Work Item fetch", async () => {
+    const repositoryId = "repo-01JSELECTED000000000000000"
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    })
+    let resolveStale:
+      | ((items: readonly { status: string }[]) => void)
+      | undefined
+    const staleResponse = new Promise<readonly { status: string }[]>(
+      (resolve) => {
+        resolveStale = resolve
+      },
+    )
+    let workItemFetches = 0
+    const workItemsQuery = {
+      queryKey: ["work-items", repositoryId] as const,
+      queryFn: async () => {
+        workItemFetches += 1
+        if (workItemFetches === 1) return staleResponse
+        return [{ status: "RUNNING" }]
+      },
+    }
+    let onChange:
+      | ((changedRepositoryId: string) => void | Promise<void>)
+      | undefined
+    let subscribed: (() => void) | undefined
+    const subscribedPromise = new Promise<void>((resolve) => {
+      subscribed = resolve
+    })
+    const controller = new AbortController()
+    const live = followRepositoryWorkItemsLive({
+      getRepositoryIds: () => [repositoryId],
+      queryClient,
+      queries: {
+        workItems: () => workItemsQuery,
+      },
+      signal: controller.signal,
+      stream: async ({ onChange: handleChange, signal }) => {
+        onChange = handleChange
+        subscribed?.()
+        await new Promise<void>((resolve) => {
+          signal.addEventListener("abort", () => resolve(), { once: true })
+        })
+      },
+    })
+
+    await subscribedPromise
+    const staleFetch = queryClient.fetchQuery({
+      ...workItemsQuery,
+      staleTime: 0,
+    })
+    await Bun.sleep(0)
+    expect(workItemFetches).toBe(1)
+
+    await onChange?.(repositoryId)
+    expect(workItemFetches).toBe(2)
+    expect(queryClient.getQueryData(workItemsQuery.queryKey)).toEqual([
+      { status: "RUNNING" },
+    ])
+
+    resolveStale?.([{ status: "QUEUED" }])
+    await staleFetch.catch(() => undefined)
+    expect(queryClient.getQueryData(workItemsQuery.queryKey)).toEqual([
+      { status: "RUNNING" },
+    ])
+
+    controller.abort()
+    await live
+  })
+
+  test("tab visibility refetch is a fallback for missed invalidations", async () => {
+    const repositoryId = "repo-01JSELECTED000000000000000"
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    })
+    let workItemsFetches = 0
+    let visibilityState: DocumentVisibilityState = "hidden"
+    const listeners = new Map<string, Set<EventListener>>()
+
+    const documentRef = {
+      get visibilityState() {
+        return visibilityState
+      },
+      addEventListener(type: string, listener: EventListener) {
+        const set = listeners.get(type) ?? new Set()
+        set.add(listener)
+        listeners.set(type, set)
+      },
+      removeEventListener(type: string, listener: EventListener) {
+        listeners.get(type)?.delete(listener)
+      },
+    }
+
+    const controller = new AbortController()
+    const live = followRepositoryWorkItemsLive({
+      getRepositoryIds: () => [repositoryId],
+      queryClient,
+      queries: {
+        workItems: (id: string) => ({
+          queryKey: ["work-items", id],
+          queryFn: async () => {
+            if (id === repositoryId) workItemsFetches += 1
+            return []
+          },
+        }),
+      },
+      signal: controller.signal,
+      documentRef,
+      stream: async ({ onConnected, signal }) => {
+        await onConnected()
+        await new Promise<void>((resolve) => {
+          signal.addEventListener("abort", () => resolve(), { once: true })
+        })
+      },
+    })
+
+    await Bun.sleep(10)
+    const workItemsAfterConnect = workItemsFetches
+    expect(workItemsAfterConnect).toBeGreaterThan(0)
+
+    visibilityState = "visible"
+    for (const listener of listeners.get("visibilitychange") ?? []) {
+      listener(new Event("visibilitychange"))
+    }
+    await Bun.sleep(10)
+
+    expect(workItemsFetches).toBeGreaterThan(workItemsAfterConnect)
+
+    controller.abort()
+    await live
+    expect(listeners.get("visibilitychange")?.size ?? 0).toBe(0)
+  })
+})

--- a/apps/harness/test/work-items-live.test.ts
+++ b/apps/harness/test/work-items-live.test.ts
@@ -1,0 +1,53 @@
+import {
+  parseWorkItemsSubscriptionEvent,
+  streamWorkItemsChanged,
+} from "../src/work-items-live.js"
+import { describe, expect, test } from "bun:test"
+
+describe("Work Item live updates", () => {
+  test("parses GraphQL SSE events", () => {
+    expect(
+      parseWorkItemsSubscriptionEvent(
+        'event: next\ndata: {"data":{"repositoryWorkItemsChanged":"repo-1"}}',
+      ),
+    ).toBe("repo-1")
+    expect(parseWorkItemsSubscriptionEvent("event: complete")).toBeNull()
+    expect(parseWorkItemsSubscriptionEvent(": keep-alive")).toBeNull()
+  })
+
+  test("connects once and reports each changed Repository", async () => {
+    const events = [
+      'event: next\ndata: {"data":{"repositoryWorkItemsChanged":"repo-1"}}\n\n',
+      'event: next\ndata: {"data":{"repositoryWorkItemsChanged":"repo-2"}}\n\n',
+      "event: complete\n\n",
+    ]
+    const body = new ReadableStream({
+      start(controller) {
+        for (const event of events)
+          controller.enqueue(new TextEncoder().encode(event))
+        controller.close()
+      },
+    })
+    let connected = 0
+    const changes: string[] = []
+    let requestedBody: string | undefined
+
+    await streamWorkItemsChanged({
+      signal: new AbortController().signal,
+      onConnected: () => {
+        connected += 1
+      },
+      onChange: (repositoryId) => {
+        changes.push(repositoryId)
+      },
+      fetch: (_url, init) => {
+        requestedBody = String(init?.body)
+        return Promise.resolve(new Response(body, { status: 200 }))
+      },
+    })
+
+    expect(connected).toBe(1)
+    expect(changes).toEqual(["repo-1", "repo-2"])
+    expect(requestedBody).toContain("repositoryWorkItemsChanged")
+  })
+})

--- a/packages/db-service/src/lib/db-service.ts
+++ b/packages/db-service/src/lib/db-service.ts
@@ -208,7 +208,9 @@ const toDatabaseError = (error: SqlError) =>
 export interface DbServiceShape {
   readonly repositoryChanges: Stream.Stream<void>
   readonly issueChanges: Stream.Stream<string>
+  readonly workItemChanges: Stream.Stream<string>
   readonly notifyIssuesChanged: (repositoryId: string) => Effect.Effect<void>
+  readonly notifyWorkItemsChanged: (repositoryId: string) => Effect.Effect<void>
   readonly getConfig: Effect.Effect<ConfigRecord, DatabaseError>
   readonly updateConfig: (
     input: UpdateConfigInput,
@@ -285,10 +287,14 @@ const repositoryChangesKey = Symbol.for(
   "@ready-for-agent/db-service/repository-changes",
 )
 const issueChangesKey = Symbol.for("@ready-for-agent/db-service/issue-changes")
+const workItemChangesKey = Symbol.for(
+  "@ready-for-agent/db-service/work-item-changes",
+)
 
 type InvalidationGlobal = typeof globalThis & {
   [repositoryChangesKey]?: PubSub.PubSub<void>
   [issueChangesKey]?: PubSub.PubSub<string>
+  [workItemChangesKey]?: PubSub.PubSub<string>
 }
 
 const getRepositoryChanges = (): PubSub.PubSub<void> => {
@@ -303,6 +309,12 @@ const getIssueChanges = (): PubSub.PubSub<string> => {
   return globalState[issueChangesKey]
 }
 
+const getWorkItemChanges = (): PubSub.PubSub<string> => {
+  const globalState = globalThis as InvalidationGlobal
+  globalState[workItemChangesKey] ??= Effect.runSync(PubSub.unbounded<string>())
+  return globalState[workItemChangesKey]
+}
+
 const publishRepositoryChanged = (): Effect.Effect<void> =>
   PubSub.publish(getRepositoryChanges(), undefined).pipe(Effect.asVoid)
 
@@ -312,12 +324,19 @@ const publishIssuesChanged = (repositoryId: string): Effect.Effect<void> =>
     yield* PubSub.publish(getRepositoryChanges(), undefined)
   }).pipe(Effect.asVoid)
 
+const publishWorkItemsChanged = (repositoryId: string): Effect.Effect<void> =>
+  PubSub.publish(getWorkItemChanges(), repositoryId).pipe(Effect.asVoid)
+
 const repositoryChangesStream: Stream.Stream<void> = Stream.fromPubSub(
   getRepositoryChanges(),
 )
 
 const issueChangesStream: Stream.Stream<string> = Stream.fromPubSub(
   getIssueChanges(),
+)
+
+const workItemChangesStream: Stream.Stream<string> = Stream.fromPubSub(
+  getWorkItemChanges(),
 )
 
 export const DbServiceLive = Layer.effect(
@@ -770,6 +789,7 @@ export const DbServiceLive = Layer.effect(
             ),
           )
         yield* publishRepositoryChanged()
+        yield* publishWorkItemsChanged(repositoryId)
       })
 
     const storeIssue = (
@@ -1135,10 +1155,16 @@ export const DbServiceLive = Layer.effect(
     const notifyIssuesChanged = (repositoryId: string): Effect.Effect<void> =>
       publishIssuesChanged(repositoryId)
 
+    const notifyWorkItemsChanged = (
+      repositoryId: string,
+    ): Effect.Effect<void> => publishWorkItemsChanged(repositoryId)
+
     return DbService.of({
       repositoryChanges: repositoryChangesStream,
       issueChanges: issueChangesStream,
+      workItemChanges: workItemChangesStream,
       notifyIssuesChanged,
+      notifyWorkItemsChanged,
       getConfig,
       updateConfig,
       addRepository,

--- a/packages/db-service/src/lib/test-fixtures.ts
+++ b/packages/db-service/src/lib/test-fixtures.ts
@@ -27,7 +27,9 @@ export const stubDbService = (
 ): DbServiceShape => ({
   repositoryChanges: Stream.never,
   issueChanges: Stream.never,
+  workItemChanges: Stream.never,
   notifyIssuesChanged: () => Effect.void,
+  notifyWorkItemsChanged: () => Effect.void,
   getConfig: unused(),
   updateConfig: unused,
   addRepository: unused,

--- a/packages/graphql-api/src/lib/graphql-api.ts
+++ b/packages/graphql-api/src/lib/graphql-api.ts
@@ -723,6 +723,16 @@ export const createGraphqlApi = (
               ),
             resolve: (repositoryId: string) => repositoryId,
           },
+          repositoryWorkItemsChanged: {
+            subscribe: async () =>
+              runtime.runPromise(
+                Effect.gen(function* () {
+                  const db = yield* DbService
+                  return yield* Stream.toAsyncIterableEffect(db.workItemChanges)
+                }),
+              ),
+            resolve: (repositoryId: string) => repositoryId,
+          },
         },
         Mutation: {
           updateConfig: async (_parent: unknown, args: UpdateConfigArgs) => {

--- a/packages/graphql-api/test/graphql-api.test.ts
+++ b/packages/graphql-api/test/graphql-api.test.ts
@@ -1927,6 +1927,36 @@ describe("GraphQL API", () => {
     )
   })
 
+  test("streams aggregate Work Item invalidations with Repository IDs", async () => {
+    const otherRepositoryId = "repo-01J11111111111111111111111"
+    await runtime.dispose()
+    runtime = makeRuntime({
+      workItemChanges: Stream.make(repository.id, otherRepositoryId),
+    })
+
+    const response = await createGraphqlApi(runtime).fetch(
+      new Request("http://127.0.0.1:4200/graphql", {
+        method: "POST",
+        headers: {
+          accept: "text/event-stream",
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          query: "subscription { repositoryWorkItemsChanged }",
+        }),
+      }),
+    )
+
+    expect(response.status).toBe(200)
+    const body = await response.text()
+    expect(body).toContain(
+      `"data":{"repositoryWorkItemsChanged":"${repository.id}"}`,
+    )
+    expect(body).toContain(
+      `"data":{"repositoryWorkItemsChanged":"${otherRepositoryId}"}`,
+    )
+  })
+
   test("accepts same-origin browser requests", async () => {
     const response = await createGraphqlApi(runtime).fetch(
       addRepositoryRequest("http://127.0.0.1:4200"),

--- a/packages/graphql-schema/schema.graphql
+++ b/packages/graphql-schema/schema.graphql
@@ -199,4 +199,5 @@ type Subscription {
   repositoriesChanged: Boolean!
   issuesChanged(repositoryId: ID!): Boolean!
   repositoryIssuesChanged: ID!
+  repositoryWorkItemsChanged: ID!
 }

--- a/packages/work-item-lifecycle/src/lib/implement.ts
+++ b/packages/work-item-lifecycle/src/lib/implement.ts
@@ -15,17 +15,23 @@ import { DEFAULT_LIFECYCLE_MAX_DURATIONS } from "./types.js"
 const persistSessionIdMidRun = (
   workItemId: string,
   sessionId: string,
-): Effect.Effect<void, never, SqlClient.SqlClient> =>
+  repositoryId: string,
+): Effect.Effect<void, never, SqlClient.SqlClient | DbService> =>
   Effect.gen(function* () {
     const sql = yield* SqlClient.SqlClient
+    const db = yield* DbService
     const now = Date.now()
-    yield* sql.unsafe(
+    const rows = (yield* sql.unsafe(
       `UPDATE work_item
        SET session_id = ?, updated_at = ?
        WHERE id = ?
-         AND (session_id IS NULL OR session_id = '' OR session_id = ?)`,
+         AND (session_id IS NULL OR session_id = '' OR session_id = ?)
+       RETURNING id`,
       [sessionId, now, workItemId, sessionId],
-    )
+    )) as readonly { readonly id: string }[]
+    if (rows[0]) {
+      yield* db.notifyWorkItemsChanged(repositoryId)
+    }
   }).pipe(
     Effect.catch((error) =>
       Effect.logWarning("Failed to persist OpenCode session id mid-implement", {
@@ -133,6 +139,7 @@ export const implement = (context: LifecycleStepContext) =>
 
     const opencode = yield* Opencode
     const sql = yield* SqlClient.SqlClient
+    const db = yield* DbService
     // Always start a fresh Session. Ignore any prior context.sessionId from
     // setup, dependency installation, or a previous failed Step Run.
     const result = yield* opencode
@@ -144,8 +151,13 @@ export const implement = (context: LifecycleStepContext) =>
         timeout:
           context.maxDuration ?? DEFAULT_LIFECYCLE_MAX_DURATIONS.implement,
         onSessionId: (sessionId) =>
-          persistSessionIdMidRun(context.workItemId, sessionId).pipe(
+          persistSessionIdMidRun(
+            context.workItemId,
+            sessionId,
+            context.repositoryId,
+          ).pipe(
             Effect.provideService(SqlClient.SqlClient, sql),
+            Effect.provideService(DbService, db),
           ),
       })
       .pipe(

--- a/packages/work-item-lifecycle/src/lib/work-item-lifecycle.ts
+++ b/packages/work-item-lifecycle/src/lib/work-item-lifecycle.ts
@@ -488,6 +488,9 @@ export const makeWorkItemLifecycleLive = (
       const db = yield* DbService
       const queue = yield* QueueService
       const steps = yield* LifecycleSteps
+      const notifyWorkItemsChanged = (
+        repositoryId: string,
+      ): Effect.Effect<void> => db.notifyWorkItemsChanged(repositoryId)
       const maxDurations: LifecycleMaxDurations = {
         ...DEFAULT_LIFECYCLE_MAX_DURATIONS,
         ...config.maxDurations,
@@ -1225,7 +1228,7 @@ export const makeWorkItemLifecycleLive = (
             )
             .pipe(Effect.catch(catchTransactionError))
 
-          return yield* getWorkItem(workItem.id).pipe(
+          const completed = yield* getWorkItem(workItem.id).pipe(
             Effect.catchTag(
               "WorkItemNotFoundError",
               (error) =>
@@ -1235,6 +1238,8 @@ export const makeWorkItemLifecycleLive = (
                 }),
             ),
           )
+          yield* notifyWorkItemsChanged(workItem.repository_id)
+          return completed
         })
 
       const completeFailedStep = (input: {
@@ -1279,7 +1284,7 @@ export const makeWorkItemLifecycleLive = (
             )
             .pipe(Effect.catch(catchTransactionError))
 
-          return yield* getWorkItem(workItem.id).pipe(
+          const failed = yield* getWorkItem(workItem.id).pipe(
             Effect.catchTag(
               "WorkItemNotFoundError",
               (error) =>
@@ -1289,6 +1294,8 @@ export const makeWorkItemLifecycleLive = (
                 }),
             ),
           )
+          yield* notifyWorkItemsChanged(workItem.repository_id)
+          return failed
         })
 
       const completeInterruptedStep = (input: {
@@ -1337,6 +1344,11 @@ export const makeWorkItemLifecycleLive = (
               }),
             )
             .pipe(Effect.catch(catchTransactionError))
+
+          const workItem = yield* loadWorkItemRow(stepRun.work_item_id)
+          if (workItem) {
+            yield* notifyWorkItemsChanged(workItem.repository_id)
+          }
         })
 
       const acknowledgeStaleDelivery = (
@@ -1379,7 +1391,7 @@ export const makeWorkItemLifecycleLive = (
                      )
                  )
                )
-             RETURNING id`,
+             RETURNING id, work_item_id`,
             [
               now,
               STEP_RUN_REASON.interrupted,
@@ -1390,7 +1402,22 @@ export const makeWorkItemLifecycleLive = (
           )
           .pipe(Effect.mapError(toDatabaseError))) as readonly {
           readonly id: string
+          readonly work_item_id: string
         }[]
+        if (rows.length > 0) {
+          const repositoryIds = new Set<string>()
+          for (const row of rows) {
+            const workItem = yield* loadWorkItemRow(row.work_item_id)
+            if (workItem) {
+              repositoryIds.add(workItem.repository_id)
+            }
+          }
+          yield* Effect.forEach(
+            [...repositoryIds],
+            (repositoryId) => notifyWorkItemsChanged(repositoryId),
+            { discard: true },
+          )
+        }
         return rows.length
       })
 
@@ -1493,6 +1520,8 @@ export const makeWorkItemLifecycleLive = (
                 }
                 return { _tag: "noop" as const }
               }
+
+              yield* notifyWorkItemsChanged(workItem.repository_id)
 
               const maxDuration = maxDurations[stepRun.step]
               const context: LifecycleStepContext = {
@@ -1712,7 +1741,7 @@ export const makeWorkItemLifecycleLive = (
             }),
           )
 
-        return yield* getWorkItem(workItemId).pipe(
+        const paused = yield* getWorkItem(workItemId).pipe(
           Effect.catchTag(
             "WorkItemNotFoundError",
             (error) =>
@@ -1722,6 +1751,8 @@ export const makeWorkItemLifecycleLive = (
               }),
           ),
         )
+        yield* notifyWorkItemsChanged(paused.repositoryId)
+        return paused
       })
 
       const start = Effect.fn("WorkItemLifecycle.start")(function* (
@@ -1871,7 +1902,7 @@ export const makeWorkItemLifecycleLive = (
             }),
           )
 
-        return yield* getWorkItem(workItemId).pipe(
+        const started = yield* getWorkItem(workItemId).pipe(
           Effect.catchTag(
             "WorkItemNotFoundError",
             (error) =>
@@ -1881,6 +1912,8 @@ export const makeWorkItemLifecycleLive = (
               }),
           ),
         )
+        yield* notifyWorkItemsChanged(started.repositoryId)
+        return started
       })
 
       const toLifecycleStepContext = (
@@ -2097,7 +2130,7 @@ export const makeWorkItemLifecycleLive = (
             }),
           )
 
-        return yield* getWorkItem(workItemId).pipe(
+        const abandoned = yield* getWorkItem(workItemId).pipe(
           Effect.catchTag(
             "WorkItemNotFoundError",
             (error) =>
@@ -2107,6 +2140,8 @@ export const makeWorkItemLifecycleLive = (
               }),
           ),
         )
+        yield* notifyWorkItemsChanged(abandoned.repositoryId)
+        return abandoned
       })
 
       const continueAfterHumanPrOutcome = Effect.fn(
@@ -2222,7 +2257,7 @@ export const makeWorkItemLifecycleLive = (
             ),
           )
 
-        return yield* getWorkItem(workItemId).pipe(
+        const resumed = yield* getWorkItem(workItemId).pipe(
           Effect.catchTag(
             "WorkItemNotFoundError",
             (error) =>
@@ -2232,6 +2267,8 @@ export const makeWorkItemLifecycleLive = (
               }),
           ),
         )
+        yield* notifyWorkItemsChanged(resumed.repositoryId)
+        return resumed
       })
 
       const reset = Effect.fn("WorkItemLifecycle.reset")(function* (
@@ -2397,6 +2434,7 @@ export const makeWorkItemLifecycleLive = (
               }),
             )
 
+          yield* notifyWorkItemsChanged(workItem.repository_id)
           return workItem.id as WorkItemId
         }).pipe(
           Effect.ensuring(
@@ -2568,7 +2606,7 @@ export const makeWorkItemLifecycleLive = (
             }),
           )
 
-        return yield* getWorkItem(workItemId).pipe(
+        const retried = yield* getWorkItem(workItemId).pipe(
           Effect.catchTag(
             "WorkItemNotFoundError",
             (error) =>
@@ -2578,6 +2616,8 @@ export const makeWorkItemLifecycleLive = (
               }),
           ),
         )
+        yield* notifyWorkItemsChanged(retried.repositoryId)
+        return retried
       })
 
       const createWorkItem = (
@@ -2743,7 +2783,7 @@ export const makeWorkItemLifecycleLive = (
               }),
             )
 
-          return yield* getWorkItem(createdId).pipe(
+          const created = yield* getWorkItem(createdId).pipe(
             Effect.catchTag(
               "WorkItemNotFoundError",
               (error) =>
@@ -2753,6 +2793,8 @@ export const makeWorkItemLifecycleLive = (
                 }),
             ),
           )
+          yield* notifyWorkItemsChanged(created.repositoryId)
+          return created
         })
 
       const implementNow = Effect.fn("WorkItemLifecycle.implementNow")(

--- a/packages/work-item-lifecycle/test/work-item-lifecycle.spec.ts
+++ b/packages/work-item-lifecycle/test/work-item-lifecycle.spec.ts
@@ -7,6 +7,7 @@ import {
   Layer,
   Option,
   Result,
+  Stream,
 } from "effect"
 import { TestClock } from "effect/testing"
 import { SqlClient } from "effect/unstable/sql"
@@ -4056,6 +4057,88 @@ describe("WorkItemLifecycle", () => {
 
           const startError = yield* Effect.flip(lifecycle.start(created.id))
           expect(startError).toBeInstanceOf(WorkItemTerminalError)
+        }),
+      ))
+  })
+
+  describe("Work Item change invalidation", () => {
+    it("publishes after successful Work Item persistence", () =>
+      runTest(
+        Effect.gen(function* () {
+          const lifecycle = yield* WorkItemLifecycle
+          const db = yield* DbService
+          const { repository, issue } = yield* seedActionableIssue
+
+          const changes = yield* db.workItemChanges.pipe(
+            Stream.take(1),
+            Stream.runCollect,
+            Effect.forkChild,
+          )
+          yield* Effect.yieldNow
+
+          yield* lifecycle.implementNow(repository.id, issue.githubIssueNumber)
+
+          expect(yield* Fiber.join(changes)).toEqual([repository.id])
+        }),
+      ))
+
+    it("does not publish when create fails before persistence", () =>
+      runTest(
+        Effect.gen(function* () {
+          const lifecycle = yield* WorkItemLifecycle
+          const db = yield* DbService
+          const { repository } = yield* seedActionableIssue
+
+          const changes = db.workItemChanges.pipe(
+            Stream.take(1),
+            Stream.runCollect,
+          )
+
+          const error = yield* Effect.flip(
+            lifecycle.implementNow(repository.id, 999_999),
+          )
+          expect(error).toBeInstanceOf(IssueNotFoundError)
+
+          const raced = yield* Effect.race(
+            changes.pipe(Effect.as("published" as const)),
+            Effect.sleep(Duration.millis(50)).pipe(
+              Effect.as("silent" as const),
+            ),
+          )
+          expect(raced).toBe("silent")
+
+          const workItems = yield* lifecycle.listWorkItemsForRepository(
+            repository.id,
+          )
+          expect(workItems).toEqual([])
+        }),
+      ))
+
+    it("publishes after a successful step transition", () =>
+      runTest(
+        Effect.gen(function* () {
+          const lifecycle = yield* WorkItemLifecycle
+          const db = yield* DbService
+          const { repository, issue } = yield* seedActionableIssue
+
+          const workItem = yield* lifecycle.implementNow(
+            repository.id,
+            issue.githubIssueNumber,
+          )
+          const stepRunId = workItem.stepRuns[0]!.id
+
+          const changes = yield* db.workItemChanges.pipe(
+            Stream.take(2),
+            Stream.runCollect,
+            Effect.forkChild,
+          )
+          yield* Effect.yieldNow
+
+          yield* lifecycle.runStep(stepRunId)
+
+          const published = yield* Fiber.join(changes)
+          expect(published).toContain(repository.id)
+          expect(published.length).toBeGreaterThanOrEqual(1)
         }),
       ))
   })


### PR DESCRIPTION
## Summary

- Add process-global Work Item invalidation (`repositoryWorkItemsChanged`) and publish after successful Work Item persistence.
- Consume the SSE subscription in the harness, refetch only the affected repository's `workItems`, and recover on reconnect/visibility.
- Remove the JobsCard one-second poll for active Work Items.

Closes #178

## Test plan

- [x] `db-service`, `work-item-lifecycle`, `graphql-api`, and `harness` tests
- [x] Affected lint/typecheck via pre-commit
- [ ] Manual: start a job and confirm Jobs card updates without 1s polling, including terminal state
- [ ] Manual: hide/show tab and reconnect to confirm recovery after missed events