### PR TITLE
feat: support running without Keymaxxer

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ The backend starts Keymaxxer through its MCP server. It uses
 at `/home/berend/src/contrib/keymaxxer/packages/cli/src/index.ts` when present,
 and finally falls back to the installed `keymaxxer` command.
 
+When no Keymaxxer entrypoint or executable is available, the harness starts
+without Keymaxxer and uses the user's ambient GitHub authentication. Set
+`KEYMAXXER_ENABLED=false` to select this mode explicitly.
+
 ## Get started
 
 1. Checkout a repo locally.

--- a/apps/harness/src/server/application.server.ts
+++ b/apps/harness/src/server/application.server.ts
@@ -10,6 +10,7 @@ import { createGraphqlApi } from "@ready-for-agent/graphql-api"
 import { IssueReconcilerLive } from "@ready-for-agent/issue-reconciler"
 import {
   KeymaxxerService,
+  disabledKeymaxxerLayer,
   sidecarKeymaxxerLayer,
 } from "@ready-for-agent/keymaxxer-service"
 import { Opencode } from "@ready-for-agent/opencode"
@@ -27,6 +28,9 @@ const workspaceRoot = fileURLToPath(new URL("../../../..", import.meta.url))
 const keymaxxerSidecarUrlFromEnvironment = (
   environment: Partial<Record<string, string | undefined>>,
 ) => {
+  if (environment.KEYMAXXER_ENABLED?.trim().toLowerCase() === "false") {
+    return undefined
+  }
   const sidecarUrl = environment.KEYMAXXER_SIDECAR_URL?.trim()
   if (sidecarUrl === undefined || sidecarUrl === "") {
     throw new Error(
@@ -51,7 +55,10 @@ export const createApplication = async (
 ): Promise<Application> => {
   const sidecarUrl = keymaxxerSidecarUrlFromEnvironment(environment)
   const databaseLayer = DbServiceLive.pipe(Layer.provideMerge(DatabaseLive))
-  const keymaxxerLayer = sidecarKeymaxxerLayer(sidecarUrl)
+  const keymaxxerLayer =
+    sidecarUrl === undefined
+      ? disabledKeymaxxerLayer
+      : sidecarKeymaxxerLayer(sidecarUrl)
   const githubLayer = keymaxxerGitHubLayer({ workspaceRoot }).pipe(
     Layer.provide(keymaxxerLayer),
   )
@@ -65,9 +72,9 @@ export const createApplication = async (
   const opencodePlatformLayer = BunChildProcessSpawner.layer.pipe(
     Layer.provideMerge(Layer.merge(BunFileSystem.layer, BunPath.layer)),
   )
-  const opencodeLayer = Opencode.layer({ keymaxxerMcpUrl: sidecarUrl }).pipe(
-    Layer.provide(opencodePlatformLayer),
-  )
+  const opencodeLayer = Opencode.layer({
+    ...(sidecarUrl === undefined ? {} : { keymaxxerMcpUrl: sidecarUrl }),
+  }).pipe(Layer.provide(opencodePlatformLayer))
   const lifecycleLayer = WorkItemLifecycleLive.pipe(
     Layer.provideMerge(LifecycleStepsLive),
     Layer.provideMerge(databaseLayer),

--- a/apps/harness/src/server/job-worker.ts
+++ b/apps/harness/src/server/job-worker.ts
@@ -126,6 +126,7 @@ const repositoryHasGitHubCredential = (
 ) =>
   Effect.gen(function* () {
     const keymaxxer = yield* KeymaxxerService
+    if (keymaxxer.enabled === false) return true
     const credential = yield* keymaxxer.findSecret({
       provider: "github",
       account: `${githubOwner}/${githubRepo}`,

--- a/apps/harness/src/server/keymaxxer-github-layer.ts
+++ b/apps/harness/src/server/keymaxxer-github-layer.ts
@@ -175,9 +175,24 @@ export const keymaxxerGitHubLayer = (options: {
     Effect.gen(function* () {
       const keymaxxer = yield* KeymaxxerService
       const ensureToken = (repository: { owner: string; name: string }) =>
-        keymaxxer.findSecret({
-          provider: "github",
-          account: `${repository.owner}/${repository.name}`,
+        keymaxxer.enabled === false
+          ? Effect.sync((): string | undefined => undefined)
+          : keymaxxer.findSecret({
+              provider: "github",
+              account: `${repository.owner}/${repository.name}`,
+            })
+      const runGitHubCommand = (
+        tokenName: string | undefined,
+        command: string,
+      ) =>
+        keymaxxer.runWithSecrets({
+          command:
+            tokenName === undefined
+              ? `GITHUB_TOKEN="\${GITHUB_TOKEN:-$(gh auth token)}" ${command}`
+              : `GITHUB_TOKEN="$${tokenName}" ${command}`,
+          cwd: options.workspaceRoot,
+          secrets: tokenName === undefined ? [] : [tokenName],
+          timeoutMs: 60_000,
         })
 
       const service: GitHubServiceShape = {
@@ -193,12 +208,10 @@ export const keymaxxerGitHubLayer = (options: {
             const owner = encodeArgument(repository.owner)
             const name = encodeArgument(repository.name)
             const head = encodeArgument(headRefName)
-            const result = yield* keymaxxer.runWithSecrets({
-              command: `GITHUB_TOKEN="$${tokenName}" bun --conditions @ready-for-agent/source packages/github-service/src/bin/get-open-pr-number.ts ${owner} ${name} ${head}`,
-              cwd: options.workspaceRoot,
-              secrets: [tokenName],
-              timeoutMs: 60_000,
-            })
+            const result = yield* runGitHubCommand(
+              tokenName,
+              `bun --conditions @ready-for-agent/source packages/github-service/src/bin/get-open-pr-number.ts ${owner} ${name} ${head}`,
+            )
             if (result.exitCode === 2) {
               return yield* new GitHubRepositoryUnavailableError(repository)
             }
@@ -237,12 +250,10 @@ export const keymaxxerGitHubLayer = (options: {
             const owner = encodeArgument(repository.owner)
             const name = encodeArgument(repository.name)
             const head = encodeArgument(headRefName)
-            const result = yield* keymaxxer.runWithSecrets({
-              command: `GITHUB_TOKEN="$${tokenName}" bun --conditions @ready-for-agent/source packages/github-service/src/bin/get-pr-check-status.ts ${owner} ${name} ${head}`,
-              cwd: options.workspaceRoot,
-              secrets: [tokenName],
-              timeoutMs: 60_000,
-            })
+            const result = yield* runGitHubCommand(
+              tokenName,
+              `bun --conditions @ready-for-agent/source packages/github-service/src/bin/get-pr-check-status.ts ${owner} ${name} ${head}`,
+            )
             if (result.exitCode === 2) {
               return yield* new GitHubRepositoryUnavailableError(repository)
             }
@@ -283,12 +294,10 @@ export const keymaxxerGitHubLayer = (options: {
             const owner = encodeArgument(repository.owner)
             const name = encodeArgument(repository.name)
             const head = encodeArgument(headRefName)
-            const result = yield* keymaxxer.runWithSecrets({
-              command: `GITHUB_TOKEN="$${tokenName}" bun --conditions @ready-for-agent/source packages/github-service/src/bin/get-pr-lifecycle-status.ts ${owner} ${name} ${head}`,
-              cwd: options.workspaceRoot,
-              secrets: [tokenName],
-              timeoutMs: 60_000,
-            })
+            const result = yield* runGitHubCommand(
+              tokenName,
+              `bun --conditions @ready-for-agent/source packages/github-service/src/bin/get-pr-lifecycle-status.ts ${owner} ${name} ${head}`,
+            )
             if (result.exitCode === 2) {
               return yield* new GitHubRepositoryUnavailableError(repository)
             }
@@ -329,12 +338,10 @@ export const keymaxxerGitHubLayer = (options: {
             const owner = encodeArgument(repository.owner)
             const name = encodeArgument(repository.name)
             const head = encodeArgument(headRefName)
-            const result = yield* keymaxxer.runWithSecrets({
-              command: `GITHUB_TOKEN="$${tokenName}" bun --conditions @ready-for-agent/source packages/github-service/src/bin/mark-pr-ready-for-review.ts ${owner} ${name} ${head}`,
-              cwd: options.workspaceRoot,
-              secrets: [tokenName],
-              timeoutMs: 60_000,
-            })
+            const result = yield* runGitHubCommand(
+              tokenName,
+              `bun --conditions @ready-for-agent/source packages/github-service/src/bin/mark-pr-ready-for-review.ts ${owner} ${name} ${head}`,
+            )
             if (result.exitCode === 2) {
               return yield* new GitHubRepositoryUnavailableError(repository)
             }
@@ -361,12 +368,10 @@ export const keymaxxerGitHubLayer = (options: {
             const owner = encodeArgument(repository.owner)
             const name = encodeArgument(repository.name)
             const head = encodeArgument(headRefName)
-            const result = yield* keymaxxer.runWithSecrets({
-              command: `GITHUB_TOKEN="$${tokenName}" bun --conditions @ready-for-agent/source packages/github-service/src/bin/merge-pull-request.ts ${owner} ${name} ${head}`,
-              cwd: options.workspaceRoot,
-              secrets: [tokenName],
-              timeoutMs: 60_000,
-            })
+            const result = yield* runGitHubCommand(
+              tokenName,
+              `bun --conditions @ready-for-agent/source packages/github-service/src/bin/merge-pull-request.ts ${owner} ${name} ${head}`,
+            )
             if (result.exitCode === 2) {
               return yield* new GitHubRepositoryUnavailableError(repository)
             }
@@ -394,12 +399,10 @@ export const keymaxxerGitHubLayer = (options: {
 
             const owner = encodeArgument(repository.owner)
             const name = encodeArgument(repository.name)
-            const result = yield* keymaxxer.runWithSecrets({
-              command: `GITHUB_TOKEN="$${tokenName}" bun --conditions @ready-for-agent/source packages/github-service/src/bin/list-ready-issues.ts ${owner} ${name}`,
-              cwd: options.workspaceRoot,
-              secrets: [tokenName],
-              timeoutMs: 60_000,
-            })
+            const result = yield* runGitHubCommand(
+              tokenName,
+              `bun --conditions @ready-for-agent/source packages/github-service/src/bin/list-ready-issues.ts ${owner} ${name}`,
+            )
 
             if (result.exitCode === 2) {
               return yield* new GitHubRepositoryUnavailableError(repository)

--- a/apps/harness/test/keymaxxer-github-layer.test.ts
+++ b/apps/harness/test/keymaxxer-github-layer.test.ts
@@ -8,6 +8,38 @@ import { keymaxxerGitHubLayer } from "../src/server/keymaxxer-github-layer.js"
 import { describe, expect, test } from "bun:test"
 
 describe("Keymaxxer-backed GitHub layer", () => {
+  test("uses ambient GitHub authentication when Keymaxxer is disabled", async () => {
+    const runs: RunWithSecretsInput[] = []
+    const keymaxxerLayer = Layer.succeed(KeymaxxerService, {
+      enabled: false,
+      initialize: Effect.void,
+      findSecret: () => Effect.die("must not inspect the vault"),
+      findSecrets: () => Effect.die("not used"),
+      hasSecret: () => Effect.die("not used"),
+      addSecret: () => Effect.die("not used"),
+      removeSecret: () => Effect.die("not used"),
+      runWithSecrets: (input) => {
+        runs.push(input)
+        return Effect.succeed({ exitCode: 0, stdout: "[]", stderr: "" })
+      },
+    })
+    const layer = keymaxxerGitHubLayer({ workspaceRoot: "/workspace" }).pipe(
+      Layer.provide(keymaxxerLayer),
+    )
+
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        const github = yield* GitHubService
+        yield* github.listReadyIssues({ owner: "acme", name: "widgets" })
+      }).pipe(Effect.provide(layer)),
+    )
+
+    expect(runs).toHaveLength(1)
+    expect(runs[0]?.secrets).toEqual([])
+    expect(runs[0]?.command).toContain("gh auth token")
+    expect(runs[0]?.command.toLowerCase()).not.toContain("keymaxxer")
+  })
+
   test("does not prompt Keymaxxer when a repository token is missing", async () => {
     let addCalled = false
     const runs: RunWithSecretsInput[] = []

--- a/packages/keymaxxer-service/src/lib/mcp-layer.ts
+++ b/packages/keymaxxer-service/src/lib/mcp-layer.ts
@@ -249,14 +249,25 @@ export const keymaxxerEnvironment = (
 
 export const keymaxxerMcpCommand = (
   environment: Partial<Record<string, string | undefined>> = process.env,
+  pathExists: (path: string) => boolean = existsSync,
 ) => {
   const entrypoint =
     environment.KEYMAXXER_ENTRYPOINT ??
     "/home/berend/src/contrib/keymaxxer/packages/cli/src/index.ts"
 
-  return existsSync(entrypoint)
+  return pathExists(entrypoint)
     ? { command: "bun", args: [entrypoint, "serve"] }
     : { command: "keymaxxer", args: ["serve"] }
+}
+
+export const isKeymaxxerAvailable = (
+  environment: Partial<Record<string, string | undefined>> = process.env,
+  pathExists: (path: string) => boolean = existsSync,
+  commandExists: (command: string) => boolean = (command) =>
+    Bun.which(command) !== null,
+) => {
+  const command = keymaxxerMcpCommand(environment, pathExists)
+  return command.command === "bun" || commandExists(command.command)
 }
 
 const toolResultText = (result: ToolResult) =>

--- a/packages/keymaxxer-service/src/lib/service.ts
+++ b/packages/keymaxxer-service/src/lib/service.ts
@@ -2,13 +2,14 @@ import { Context, Effect, Layer } from "effect"
 import type {
   AddSecretInput,
   FindSecretInput,
-  KeymaxxerError,
   RunWithSecretsInput,
   RunWithSecretsResult,
   SecretName,
 } from "./models.js"
+import { KeymaxxerError } from "./models.js"
 
 export interface KeymaxxerServiceShape {
+  readonly enabled?: boolean
   readonly initialize: Effect.Effect<void, KeymaxxerError>
   readonly hasSecret: (
     name: SecretName,
@@ -56,4 +57,38 @@ export const testKeymaxxerLayer = (
       runWithSecrets: () =>
         Effect.succeed({ exitCode: 0, stdout: "", stderr: "" }),
     }
+  })
+
+export const disabledKeymaxxerLayer: Layer.Layer<KeymaxxerService> =
+  Layer.succeed(KeymaxxerService, {
+    enabled: false,
+    initialize: Effect.void,
+    hasSecret: () => Effect.succeed(false),
+    findSecret: () => Effect.succeed(null),
+    findSecrets: (inputs) => Effect.succeed(inputs.map(() => null)),
+    addSecret: () => Effect.succeed(false),
+    removeSecret: () => Effect.succeed(false),
+    runWithSecrets: (input) =>
+      Effect.tryPromise({
+        try: async () => {
+          const child = Bun.spawn(["bash", "-c", input.command], {
+            cwd: input.cwd,
+            env: process.env,
+            stdout: "pipe",
+            stderr: "pipe",
+            timeout: input.timeoutMs,
+          })
+          const [exitCode, stdout, stderr] = await Promise.all([
+            child.exited,
+            new Response(child.stdout).text(),
+            new Response(child.stderr).text(),
+          ])
+          return { exitCode, stdout, stderr }
+        },
+        catch: () =>
+          new KeymaxxerError({
+            operation: "run command",
+            message: "Failed to run command without Keymaxxer",
+          }),
+      }),
   })

--- a/packages/keymaxxer-service/test/mcp-layer.test.ts
+++ b/packages/keymaxxer-service/test/mcp-layer.test.ts
@@ -2,6 +2,7 @@ import { Effect } from "effect"
 import {
   KeymaxxerService,
   type KeymaxxerToolClient,
+  isKeymaxxerAvailable,
   keymaxxerEnvironment,
   keymaxxerMcpCommand,
   mcpKeymaxxerLayer,
@@ -462,5 +463,32 @@ describe("MCP process configuration", () => {
       command: "bun",
       args: ["/bin/true", "serve"],
     })
+  })
+
+  test("reports Keymaxxer unavailable when no entrypoint or binary exists", () => {
+    expect(
+      isKeymaxxerAvailable(
+        {},
+        () => false,
+        () => false,
+      ),
+    ).toBe(false)
+  })
+
+  test("reports Keymaxxer available from either source", () => {
+    expect(
+      isKeymaxxerAvailable(
+        {},
+        () => true,
+        () => false,
+      ),
+    ).toBe(true)
+    expect(
+      isKeymaxxerAvailable(
+        {},
+        () => false,
+        () => true,
+      ),
+    ).toBe(true)
   })
 })

--- a/packages/opencode/src/lib/environment.ts
+++ b/packages/opencode/src/lib/environment.ts
@@ -9,17 +9,14 @@ const isGitHubTokenEnvName = (name: string) =>
   name.startsWith("GITHUB_TOKEN_")
 
 export type MakeOpencodeEnvironmentOptions = {
-  readonly keymaxxerMcpUrl: string
+  readonly keymaxxerMcpUrl?: string
   readonly environment?: Readonly<Record<string, string | undefined>>
 }
 
 export const makeOpencodeEnvironment = (
   options: MakeOpencodeEnvironmentOptions,
 ): Record<string, string> => {
-  const keymaxxerMcpUrl = options.keymaxxerMcpUrl.trim()
-  if (keymaxxerMcpUrl === "") {
-    throw new TypeError("keymaxxerMcpUrl is required to spawn OpenCode")
-  }
+  const keymaxxerMcpUrl = options.keymaxxerMcpUrl?.trim()
 
   const environment = options.environment ?? process.env
   const existingConfigContent = environment.OPENCODE_CONFIG_CONTENT
@@ -36,6 +33,27 @@ export const makeOpencodeEnvironment = (
           return parsed
         })()
   const mcp = isObject(config.mcp) ? config.mcp : {}
+  const { keymaxxer: _keymaxxer, ...mcpWithoutKeymaxxer } = mcp
+
+  const opencodeConfig =
+    keymaxxerMcpUrl === undefined || keymaxxerMcpUrl === ""
+      ? {
+          ...config,
+          ...(config.mcp === undefined ? {} : { mcp: mcpWithoutKeymaxxer }),
+        }
+      : {
+          ...config,
+          mcp: {
+            ...mcp,
+            keymaxxer: {
+              type: "remote",
+              url: keymaxxerMcpUrl,
+              enabled: true,
+              oauth: false,
+              timeout: DEFAULT_MCP_TIMEOUT_MS,
+            },
+          },
+        }
 
   return {
     ...Object.fromEntries(
@@ -44,18 +62,6 @@ export const makeOpencodeEnvironment = (
           entry[1] !== undefined && !isGitHubTokenEnvName(entry[0]),
       ),
     ),
-    OPENCODE_CONFIG_CONTENT: JSON.stringify({
-      ...config,
-      mcp: {
-        ...mcp,
-        keymaxxer: {
-          type: "remote",
-          url: keymaxxerMcpUrl,
-          enabled: true,
-          oauth: false,
-          timeout: DEFAULT_MCP_TIMEOUT_MS,
-        },
-      },
-    }),
+    OPENCODE_CONFIG_CONTENT: JSON.stringify(opencodeConfig),
   }
 }

--- a/packages/opencode/src/lib/opencode.ts
+++ b/packages/opencode/src/lib/opencode.ts
@@ -249,7 +249,7 @@ export class Opencode extends Context.Service<
       }),
     )
 
-  /** Test/integration helper; production must pass keymaxxerMcpUrl explicitly. */
+  /** Test/integration helper with Keymaxxer enabled by default. */
   static layerForTests = (
     keymaxxerMcpUrl = "http://127.0.0.1:5032/test-cap/mcp",
   ) => Opencode.layer({ keymaxxerMcpUrl })

--- a/packages/opencode/src/lib/types.ts
+++ b/packages/opencode/src/lib/types.ts
@@ -41,5 +41,5 @@ export interface ContinueInput {
 export interface OpencodeLayerOptions {
   readonly binary?: string
   readonly defaultTimeout?: Duration.Input
-  readonly keymaxxerMcpUrl: string
+  readonly keymaxxerMcpUrl?: string
 }

--- a/packages/opencode/test/environment.spec.ts
+++ b/packages/opencode/test/environment.spec.ts
@@ -72,9 +72,32 @@ describe("makeOpencodeEnvironment", () => {
     expect(env.GITHUB_TOKEN_ACME_WIDGETS).toBeUndefined()
   })
 
-  it("fails closed when the capability URL is missing", () => {
-    expect(() =>
-      makeOpencodeEnvironment({ keymaxxerMcpUrl: "  ", environment: {} }),
-    ).toThrow("keymaxxerMcpUrl is required")
+  it("does not configure Keymaxxer when its capability URL is missing", () => {
+    expect(
+      JSON.parse(
+        makeOpencodeEnvironment({ environment: {} }).OPENCODE_CONFIG_CONTENT,
+      ),
+    ).toEqual({})
+  })
+
+  it("removes existing Keymaxxer configuration when disabled", () => {
+    const existingConfig = JSON.stringify({
+      model: "anthropic/claude-sonnet-4-5",
+      mcp: {
+        filesystem: { enabled: true },
+        keymaxxer: { enabled: true, type: "local" },
+      },
+    })
+
+    expect(
+      JSON.parse(
+        makeOpencodeEnvironment({
+          environment: { OPENCODE_CONFIG_CONTENT: existingConfig },
+        }).OPENCODE_CONFIG_CONTENT,
+      ),
+    ).toEqual({
+      model: "anthropic/claude-sonnet-4-5",
+      mcp: { filesystem: { enabled: true } },
+    })
   })
 })

--- a/packages/work-item-lifecycle/src/lib/create-pr.ts
+++ b/packages/work-item-lifecycle/src/lib/create-pr.ts
@@ -65,7 +65,7 @@ const resolveSessionId = (context: LifecycleStepContext) => {
 const buildCreatePrPrompt = (
   githubIssueNumber: number,
   branch: string,
-  tokenName: string,
+  tokenName: string | undefined,
 ) =>
   [
     "Create a pull request for the committed implementation changes in this worktree.",
@@ -77,7 +77,11 @@ const buildCreatePrPrompt = (
     "Follow this repository's PR title and body conventions.",
     `If a suitable open PR whose head is exactly ${branch} already exists, succeed without creating a duplicate.`,
     "Do not merge the pull request.",
-    `Use Keymaxxer secret ${tokenName} via keymaxxer_run for any GitHub CLI or API access; never put secret values in the environment.`,
+    ...(tokenName === undefined
+      ? []
+      : [
+          `Use Keymaxxer secret ${tokenName} via keymaxxer_run for any GitHub CLI or API access; never put secret values in the environment.`,
+        ]),
   ].join("\n")
 
 /**
@@ -114,21 +118,25 @@ export const createPr = (context: LifecycleStepContext) =>
     }
 
     const keymaxxer = yield* KeymaxxerService
-    const tokenName = yield* keymaxxer
-      .findSecret({
-        provider: "github",
-        account: `${repository.githubOwner}/${repository.githubRepo}`,
-      })
-      .pipe(
-        Effect.mapError(
-          (cause) =>
-            new CreatePrCredentialError({
-              repositoryId: context.repositoryId,
-              message: "Failed to resolve the repository GitHub credential",
-              cause,
-            }),
-        ),
-      )
+    const tokenName =
+      keymaxxer.enabled === false
+        ? undefined
+        : yield* keymaxxer
+            .findSecret({
+              provider: "github",
+              account: `${repository.githubOwner}/${repository.githubRepo}`,
+            })
+            .pipe(
+              Effect.mapError(
+                (cause) =>
+                  new CreatePrCredentialError({
+                    repositoryId: context.repositoryId,
+                    message:
+                      "Failed to resolve the repository GitHub credential",
+                    cause,
+                  }),
+              ),
+            )
     if (tokenName === null) {
       return yield* new CreatePrCredentialError({
         repositoryId: context.repositoryId,

--- a/packages/work-item-lifecycle/src/lib/decide-pr-merge.ts
+++ b/packages/work-item-lifecycle/src/lib/decide-pr-merge.ts
@@ -91,10 +91,13 @@ export const decidePrMerge = (context: LifecycleStepContext) =>
       }
     }
     const keymaxxer = yield* KeymaxxerService
-    const tokenName = yield* keymaxxer.findSecret({
-      provider: "github",
-      account: `${repository.githubOwner}/${repository.githubRepo}`,
-    })
+    const tokenName =
+      keymaxxer.enabled === false
+        ? undefined
+        : yield* keymaxxer.findSecret({
+            provider: "github",
+            account: `${repository.githubOwner}/${repository.githubRepo}`,
+          })
     if (tokenName === null) {
       return yield* new DecidePrMergeContextError({
         message: `No GitHub credential is configured for ${repository.githubOwner}/${repository.githubRepo}`,
@@ -104,7 +107,11 @@ export const decidePrMerge = (context: LifecycleStepContext) =>
       "Assess whether this pull request is low enough risk for an automated agent (clanker) to merge, or whether a human must merge it.",
       "Base the decision on risk: blast radius, security or auth changes, data migrations, irreversible operations, ambiguous requirements, incomplete verification, or anything that needs human judgment.",
       "Inspect the PR and its checks if needed. Do not merge the pull request.",
-      `Use Keymaxxer secret ${tokenName} via keymaxxer_run for any GitHub CLI or API access; never put secret values in the environment.`,
+      ...(tokenName === undefined
+        ? []
+        : [
+            `Use Keymaxxer secret ${tokenName} via keymaxxer_run for any GitHub CLI or API access; never put secret values in the environment.`,
+          ]),
       "End your final response with exactly one machine-readable result line:",
       "READY_FOR_AGENT_RESULT: CLANKER_MERGE",
       "or, only when a human must merge:",

--- a/packages/work-item-lifecycle/src/lib/pr-status-checks.ts
+++ b/packages/work-item-lifecycle/src/lib/pr-status-checks.ts
@@ -253,10 +253,13 @@ export const investigatePrStatusChecks = (context: LifecycleStepContext) =>
       } satisfies PrStatusCheckInvestigationResult
     }
     const keymaxxer = yield* KeymaxxerService
-    const tokenName = yield* keymaxxer.findSecret({
-      provider: "github",
-      account: `${repository.githubOwner}/${repository.githubRepo}`,
-    })
+    const tokenName =
+      keymaxxer.enabled === false
+        ? undefined
+        : yield* keymaxxer.findSecret({
+            provider: "github",
+            account: `${repository.githubOwner}/${repository.githubRepo}`,
+          })
     if (tokenName === null) {
       return yield* new PrStatusChecksContextError({
         message: `No GitHub credential is configured for ${repository.githubOwner}/${repository.githubRepo}`,
@@ -268,7 +271,11 @@ export const investigatePrStatusChecks = (context: LifecycleStepContext) =>
         sessionId,
         prompt: [
           buildInvestigationWorkPrompt(unhandled),
-          `Use Keymaxxer secret ${tokenName} via keymaxxer_run for any GitHub CLI, API, commit, or push access; never put secret values in the environment.`,
+          ...(tokenName === undefined
+            ? []
+            : [
+                `Use Keymaxxer secret ${tokenName} via keymaxxer_run for any GitHub CLI, API, commit, or push access; never put secret values in the environment.`,
+              ]),
         ].join("\n"),
         cwd: worktreePath,
         model: context.model,

--- a/packages/work-item-lifecycle/src/lib/remove-worktree.ts
+++ b/packages/work-item-lifecycle/src/lib/remove-worktree.ts
@@ -66,16 +66,21 @@ const removeDirectoryIfPresent = (path: string) =>
 
 const shellQuote = (value: string) => `'${value.replaceAll("'", `'"'"'`)}'`
 
-const credentialedCommand = (tokenName: string, parts: ReadonlyArray<string>) =>
+const credentialedCommand = (
+  tokenName: string | null,
+  parts: ReadonlyArray<string>,
+) =>
   [
-    `GH_TOKEN="$${tokenName}"`,
-    `GITHUB_TOKEN="$${tokenName}"`,
+    ...(tokenName === null
+      ? []
+      : [`GH_TOKEN="$${tokenName}"`, `GITHUB_TOKEN="$${tokenName}"`]),
     ...parts.map(shellQuote),
   ].join(" ")
 
 const resolveGithubCredential = (repository: RepositoryRecord) =>
   Effect.gen(function* () {
     const keymaxxer = yield* KeymaxxerService
+    if (keymaxxer.enabled === false) return null
     const account = `${repository.githubOwner}/${repository.githubRepo}`
     const tokenName = yield* keymaxxer
       .findSecret({
@@ -102,7 +107,7 @@ const resolveGithubCredential = (repository: RepositoryRecord) =>
   })
 
 const runRemoteCommand = (input: {
-  readonly tokenName: string
+  readonly tokenName: string | null
   readonly cwd: string
   readonly parts: ReadonlyArray<string>
   readonly branchName: string
@@ -114,7 +119,7 @@ const runRemoteCommand = (input: {
       .runWithSecrets({
         command: credentialedCommand(input.tokenName, input.parts),
         cwd: input.cwd,
-        secrets: [input.tokenName],
+        secrets: input.tokenName === null ? [] : [input.tokenName],
         timeoutMs: Duration.toMillis(REMOTE_CLEANUP_TIMEOUT),
       })
       .pipe(
@@ -139,7 +144,7 @@ const runRemoteCommand = (input: {
 const closeOpenPullRequests = (input: {
   readonly repository: RepositoryRecord
   readonly branchName: string
-  readonly tokenName: string
+  readonly tokenName: string | null
   readonly cwd: string
 }) =>
   Effect.gen(function* () {
@@ -196,7 +201,7 @@ const closeOpenPullRequests = (input: {
 const deleteRemoteBranch = (input: {
   readonly repository: RepositoryRecord
   readonly branchName: string
-  readonly tokenName: string
+  readonly tokenName: string | null
   readonly cwd: string
 }) =>
   Effect.gen(function* () {

--- a/packages/work-item-lifecycle/src/lib/resolve-pr-merge-conflict.ts
+++ b/packages/work-item-lifecycle/src/lib/resolve-pr-merge-conflict.ts
@@ -44,7 +44,7 @@ const parseResult = (
     : { reason: needsHuman[1].trim().slice(0, 500) }
 }
 
-const workPrompt = (tokenName: string): string =>
+const workPrompt = (tokenName: string | undefined): string =>
   [
     "Resolve the merge conflict on the existing pull request for this worktree by rebasing its branch.",
     "Fetch origin and inspect the pull request to determine its current base branch (normally the repository default branch).",
@@ -53,7 +53,11 @@ const workPrompt = (tokenName: string): string =>
     "Push the rebased pull-request branch with --force-with-lease. Do not use an unconditional force push.",
     "If the lease is rejected, refetch, incorporate the updated remote PR branch, rebase onto the current remote base again, verify, and retry the --force-with-lease push exactly once. If that second push cannot safely succeed, stop and report that human intervention is needed in the follow-up verdict turn.",
     "Do not create or merge another pull request and do not do unrelated work.",
-    `Use Keymaxxer secret ${tokenName} via keymaxxer_run for any GitHub CLI, API, fetch, or push access; never put secret values in the environment.`,
+    ...(tokenName === undefined
+      ? []
+      : [
+          `Use Keymaxxer secret ${tokenName} via keymaxxer_run for any GitHub CLI, API, fetch, or push access; never put secret values in the environment.`,
+        ]),
     "When finished, stop. Do not print a READY_FOR_AGENT_RESULT line yet; a follow-up turn will ask for the verdict.",
   ].join("\n")
 
@@ -91,10 +95,13 @@ export const resolvePrMergeConflict = (context: LifecycleStepContext) =>
       })
     }
     const keymaxxer = yield* KeymaxxerService
-    const tokenName = yield* keymaxxer.findSecret({
-      provider: "github",
-      account: `${repository.githubOwner}/${repository.githubRepo}`,
-    })
+    const tokenName =
+      keymaxxer.enabled === false
+        ? undefined
+        : yield* keymaxxer.findSecret({
+            provider: "github",
+            account: `${repository.githubOwner}/${repository.githubRepo}`,
+          })
     if (tokenName === null) {
       return yield* new ResolvePrMergeConflictContextError({
         message: `No GitHub credential is configured for ${repository.githubOwner}/${repository.githubRepo}`,

--- a/packages/work-item-lifecycle/test/create-pr.spec.ts
+++ b/packages/work-item-lifecycle/test/create-pr.spec.ts
@@ -267,6 +267,29 @@ describe("createPr", () => {
       )
     }))
 
+  it("uses a generic prompt when Keymaxxer is disabled", () =>
+    withTemp(async (root) => {
+      let prompt = ""
+      const pullRequestNumber = await run(createPr(baseContext(root)), {
+        keymaxxer: stubKeymaxxer({
+          enabled: false,
+          findSecret: () => Effect.die("must not inspect the vault"),
+        }),
+        opencode: stubOpencode({
+          continue: (input) => {
+            prompt = input.prompt
+            return Effect.succeed({
+              sessionId: input.sessionId,
+              assistantText: "",
+            })
+          },
+        }),
+      })
+
+      expect(pullRequestNumber).toBe(321)
+      expect(prompt.toLowerCase()).not.toContain("keymaxxer")
+    }))
+
   it("maps Keymaxxer credential lookup failure", () =>
     withTemp(async (root) => {
       const error = await run(createPr(baseContext(root)).pipe(Effect.flip), {

--- a/scripts/run-with-keymaxxer-sidecar.ts
+++ b/scripts/run-with-keymaxxer-sidecar.ts
@@ -5,6 +5,7 @@
 import { type ChildProcess, spawn } from "node:child_process"
 import { createInterface } from "node:readline"
 import { fileURLToPath } from "node:url"
+import { isKeymaxxerAvailable } from "../packages/keymaxxer-service/src/index.js"
 
 const KEYMAXXER_SIDECAR_URL_PREFIX = "KEYMAXXER_SIDECAR_URL="
 const workspaceRoot = fileURLToPath(new URL("..", import.meta.url))
@@ -19,16 +20,27 @@ if (command === undefined) {
 }
 
 const existingUrl = process.env.KEYMAXXER_SIDECAR_URL?.trim()
-if (existingUrl) {
+const keymaxxerAvailable = isKeymaxxerAvailable(process.env)
+const keymaxxerEnabled =
+  process.env.KEYMAXXER_ENABLED?.trim().toLowerCase() !== "false" &&
+  ((existingUrl !== undefined && existingUrl !== "") || keymaxxerAvailable)
+
+const spawnWrappedCommand = (environment: NodeJS.ProcessEnv) => {
   const child = spawn(command, commandArgs, {
     cwd: process.env.RUN_CWD ?? process.cwd(),
-    env: process.env,
+    env: environment,
     stdio: "inherit",
   })
   child.on("exit", (code, signal) => {
     if (signal) process.kill(process.pid, signal)
     process.exit(code ?? 1)
   })
+}
+
+if (!keymaxxerEnabled) {
+  spawnWrappedCommand({ ...process.env, KEYMAXXER_ENABLED: "false" })
+} else if (existingUrl) {
+  spawnWrappedCommand(process.env)
 } else {
   const sidecar = spawn(
     process.execPath,


### PR DESCRIPTION
## Why

The harness currently requires Keymaxxer at startup, which prevents contributors from running it in environments where Keymaxxer is not installed. Agents also receive Keymaxxer-specific instructions even when users would prefer to rely on their existing GitHub access.

## What Changed

- Detect whether a Keymaxxer entrypoint or executable is available and automatically start the harness without it when absent.
- Support explicit opt-out with `KEYMAXXER_ENABLED=false`.
- Omit Keymaxxer MCP configuration and Keymaxxer-specific lifecycle prompt text in disabled mode.
- Run harness GitHub operations through ambient `gh` authentication while preserving the existing secured Keymaxxer path.
- Remove preconfigured Keymaxxer MCP entries from OpenCode configuration when disabled.
- Add coverage for availability detection, ambient GitHub execution, generic prompts, and disabled OpenCode configuration.

## Verification

- Confirmed the launch wrapper runs its child command with `KEYMAXXER_ENABLED=false` without starting the sidecar.
- Repository commit hooks passed affected lint, typecheck, and tests.
