### PR TITLE
ci: run workflow on pull requests

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+  pull_request:
 
 permissions:
   actions: read


### PR DESCRIPTION
## Summary

- Add a `pull_request` trigger to the existing CI workflow so PRs get the same lint/knip/test/typecheck checks as pushes to `main`.
- Leave job steps, permissions, and Nx affected setup unchanged.

Closes #183

## Test plan

- [ ] Confirm the CI check appears on this draft PR and runs `lint`, `knip`, `test`, and `typecheck` via `nx affected`
- [ ] Confirm `push` to `main` still triggers the same workflow after merge
- [ ] Confirm `nrwl/nx-set-shas` sets base/head correctly on the PR