### PR TITLE
fix(harness): use ambient GitHub auth without Keymaxxer

### DIFF
--- a/apps/harness/src/server/ambient-github-layer.ts
+++ b/apps/harness/src/server/ambient-github-layer.ts
@@ -1,0 +1,126 @@
+import { spawn } from "node:child_process"
+import { Effect, Layer } from "effect"
+import {
+  type GitHubRepositoryUnavailableError,
+  GitHubRequestError,
+  GitHubService,
+  type GitHubServiceShape,
+  makeGitHubServiceFromToken,
+} from "@ready-for-agent/github-service"
+
+type GitHubServiceError = GitHubRepositoryUnavailableError | GitHubRequestError
+
+const resolveGhToken = (cwd: string): Promise<string> =>
+  new Promise((resolve, reject) => {
+    const child = spawn("gh", ["auth", "token"], {
+      cwd,
+      env: process.env,
+      timeout: 60_000,
+    })
+    let stdout = ""
+    let stderr = ""
+    child.stdout.setEncoding("utf8")
+    child.stderr.setEncoding("utf8")
+    child.stdout.on("data", (chunk: string) => {
+      stdout += chunk
+    })
+    child.stderr.on("data", (chunk: string) => {
+      stderr += chunk
+    })
+    child.once("error", reject)
+    child.once("close", (exitCode) => {
+      const token = stdout.trim()
+      if (exitCode === 0 && token !== "") {
+        resolve(token)
+        return
+      }
+      reject(
+        new Error(
+          stderr.trim() || "GitHub CLI did not return an authentication token",
+        ),
+      )
+    })
+  })
+
+export const ambientGitHubLayer = (options: {
+  readonly workspaceRoot: string
+  readonly resolveToken?: () => Promise<string>
+  readonly makeService?: (token: string) => GitHubServiceShape
+}): Layer.Layer<GitHubService> =>
+  Layer.sync(GitHubService, () => {
+    const resolveToken =
+      options.resolveToken ?? (() => resolveGhToken(options.workspaceRoot))
+    const makeService = options.makeService ?? makeGitHubServiceFromToken
+    type TokenEntry = { readonly promise: Promise<string> }
+    let cachedToken: TokenEntry | undefined
+
+    const acquireToken = () => {
+      const source = cachedToken ?? { promise: resolveToken() }
+      cachedToken = source
+      return source.promise.then(
+        (token) => ({ source, token }),
+        (error) => {
+          if (cachedToken === source) cachedToken = undefined
+          throw error
+        },
+      )
+    }
+
+    const run = <A>(
+      operation: (
+        service: GitHubServiceShape,
+      ) => Effect.Effect<A, GitHubServiceError>,
+      refreshAuthentication: boolean,
+    ): Effect.Effect<A, GitHubServiceError> =>
+      Effect.tryPromise({
+        try: acquireToken,
+        catch: (cause) =>
+          new GitHubRequestError({
+            message: "Failed to resolve GitHub CLI authentication",
+            cause,
+          }),
+      }).pipe(
+        Effect.flatMap(({ source, token }) =>
+          operation(makeService(token)).pipe(
+            Effect.catchTag("GitHubRequestError", (error) => {
+              if (!refreshAuthentication || error.statusCode !== 401) {
+                return Effect.fail(error)
+              }
+              if (cachedToken === source) cachedToken = undefined
+              return run(operation, false)
+            }),
+          ),
+        ),
+      )
+
+    const authenticated = <A>(
+      operation: (
+        service: GitHubServiceShape,
+      ) => Effect.Effect<A, GitHubServiceError>,
+    ): Effect.Effect<A, GitHubServiceError> => run(operation, true)
+
+    return {
+      getOpenPullRequestNumber: (repository, headRefName) =>
+        authenticated((service) =>
+          service.getOpenPullRequestNumber(repository, headRefName),
+        ),
+      getPullRequestCheckStatus: (repository, headRefName) =>
+        authenticated((service) =>
+          service.getPullRequestCheckStatus(repository, headRefName),
+        ),
+      getPullRequestLifecycleStatus: (repository, headRefName) =>
+        authenticated((service) =>
+          service.getPullRequestLifecycleStatus(repository, headRefName),
+        ),
+      markPullRequestReadyForReview: (repository, headRefName) =>
+        authenticated((service) =>
+          service.markPullRequestReadyForReview(repository, headRefName),
+        ),
+      mergePullRequest: (repository, headRefName) =>
+        authenticated((service) =>
+          service.mergePullRequest(repository, headRefName),
+        ),
+      listReadyIssues: (repository) =>
+        authenticated((service) => service.listReadyIssues(repository)),
+    } satisfies GitHubServiceShape
+  })

--- a/apps/harness/src/server/application.server.ts
+++ b/apps/harness/src/server/application.server.ts
@@ -20,6 +20,7 @@ import {
   WorkItemLifecycleLive,
 } from "@ready-for-agent/work-item-lifecycle"
 import type { ApplicationRequestContext } from "../server-context.js"
+import { ambientGitHubLayer } from "./ambient-github-layer.js"
 import { JobWorkerLive } from "./job-worker.js"
 import { keymaxxerGitHubLayer } from "./keymaxxer-github-layer.js"
 
@@ -59,9 +60,12 @@ export const createApplication = async (
     sidecarUrl === undefined
       ? disabledKeymaxxerLayer
       : sidecarKeymaxxerLayer(sidecarUrl)
-  const githubLayer = keymaxxerGitHubLayer({ workspaceRoot }).pipe(
-    Layer.provide(keymaxxerLayer),
-  )
+  const githubLayer =
+    sidecarUrl === undefined
+      ? ambientGitHubLayer({ workspaceRoot })
+      : keymaxxerGitHubLayer({ workspaceRoot }).pipe(
+          Layer.provide(keymaxxerLayer),
+        )
   const reconcilerLayer = IssueReconcilerLive.pipe(
     Layer.provideMerge(databaseLayer),
     Layer.provideMerge(githubLayer),

--- a/apps/harness/src/server/keymaxxer-github-layer.ts
+++ b/apps/harness/src/server/keymaxxer-github-layer.ts
@@ -175,23 +175,15 @@ export const keymaxxerGitHubLayer = (options: {
     Effect.gen(function* () {
       const keymaxxer = yield* KeymaxxerService
       const ensureToken = (repository: { owner: string; name: string }) =>
-        keymaxxer.enabled === false
-          ? Effect.sync((): string | undefined => undefined)
-          : keymaxxer.findSecret({
-              provider: "github",
-              account: `${repository.owner}/${repository.name}`,
-            })
-      const runGitHubCommand = (
-        tokenName: string | undefined,
-        command: string,
-      ) =>
+        keymaxxer.findSecret({
+          provider: "github",
+          account: `${repository.owner}/${repository.name}`,
+        })
+      const runGitHubCommand = (tokenName: string, command: string) =>
         keymaxxer.runWithSecrets({
-          command:
-            tokenName === undefined
-              ? `GITHUB_TOKEN="\${GITHUB_TOKEN:-$(gh auth token)}" ${command}`
-              : `GITHUB_TOKEN="$${tokenName}" ${command}`,
+          command: `GITHUB_TOKEN="$${tokenName}" ${command}`,
           cwd: options.workspaceRoot,
-          secrets: tokenName === undefined ? [] : [tokenName],
+          secrets: [tokenName],
           timeoutMs: 60_000,
         })
 

--- a/apps/harness/test/ambient-github-layer.test.ts
+++ b/apps/harness/test/ambient-github-layer.test.ts
@@ -1,0 +1,152 @@
+import { Effect } from "effect"
+import {
+  GitHubRequestError,
+  GitHubService,
+  type GitHubServiceShape,
+} from "@ready-for-agent/github-service"
+import { ambientGitHubLayer } from "../src/server/ambient-github-layer.js"
+import { expect, test } from "bun:test"
+
+const serviceWithList = (
+  listReadyIssues: GitHubServiceShape["listReadyIssues"],
+): GitHubServiceShape => ({
+  listReadyIssues,
+  getOpenPullRequestNumber: () => Effect.die("not used"),
+  getPullRequestCheckStatus: () => Effect.die("not used"),
+  getPullRequestLifecycleStatus: () => Effect.die("not used"),
+  markPullRequestReadyForReview: () => Effect.die("not used"),
+  mergePullRequest: () => Effect.die("not used"),
+})
+
+test("ambient GitHub authentication is resolved once", async () => {
+  let resolutions = 0
+  const tokens: string[] = []
+  const layer = ambientGitHubLayer({
+    workspaceRoot: "/workspace",
+    resolveToken: async () => {
+      resolutions += 1
+      return "cached-token"
+    },
+    makeService: (token) => {
+      tokens.push(token)
+      return serviceWithList(() => Effect.succeed([]))
+    },
+  })
+
+  await Effect.runPromise(
+    Effect.gen(function* () {
+      const github = yield* GitHubService
+      yield* github.listReadyIssues({ owner: "acme", name: "one" })
+      yield* github.listReadyIssues({ owner: "acme", name: "two" })
+    }).pipe(Effect.provide(layer)),
+  )
+
+  expect(resolutions).toBe(1)
+  expect(tokens).toEqual(["cached-token", "cached-token"])
+})
+
+test("ambient GitHub authentication refreshes once after a 401", async () => {
+  const resolvedTokens = ["expired-token", "fresh-token"]
+  let resolutions = 0
+  const layer = ambientGitHubLayer({
+    workspaceRoot: "/workspace",
+    resolveToken: async () => resolvedTokens[resolutions++]!,
+    makeService: (token) =>
+      serviceWithList(() =>
+        token === "expired-token"
+          ? Effect.fail(
+              new GitHubRequestError({
+                message: "Unauthorized",
+                statusCode: 401,
+              }),
+            )
+          : Effect.succeed([]),
+      ),
+  })
+
+  await Effect.runPromise(
+    Effect.gen(function* () {
+      const github = yield* GitHubService
+      yield* github.listReadyIssues({ owner: "acme", name: "widgets" })
+    }).pipe(Effect.provide(layer)),
+  )
+
+  expect(resolutions).toBe(2)
+})
+
+test("concurrent 401 responses share one refreshed token", async () => {
+  const resolvedTokens = ["expired-token", "fresh-token"]
+  let resolutions = 0
+  let expiredCalls = 0
+  let releaseExpiredCalls: () => void = () => undefined
+  const bothExpiredCallsStarted = new Promise<void>((resolve) => {
+    releaseExpiredCalls = resolve
+  })
+  const layer = ambientGitHubLayer({
+    workspaceRoot: "/workspace",
+    resolveToken: async () => resolvedTokens[resolutions++]!,
+    makeService: (token) =>
+      serviceWithList(() => {
+        if (token === "fresh-token") return Effect.succeed([])
+        return Effect.tryPromise({
+          try: async () => {
+            expiredCalls += 1
+            if (expiredCalls === 2) releaseExpiredCalls()
+            await bothExpiredCallsStarted
+            throw new GitHubRequestError({
+              message: "Unauthorized",
+              statusCode: 401,
+            })
+          },
+          catch: (error) => error as GitHubRequestError,
+        })
+      }),
+  })
+
+  await Effect.runPromise(
+    Effect.gen(function* () {
+      const github = yield* GitHubService
+      yield* Effect.all(
+        [
+          github.listReadyIssues({ owner: "acme", name: "one" }),
+          github.listReadyIssues({ owner: "acme", name: "two" }),
+        ],
+        { concurrency: "unbounded" },
+      )
+    }).pipe(Effect.provide(layer)),
+  )
+
+  expect(expiredCalls).toBe(2)
+  expect(resolutions).toBe(2)
+})
+
+test("ambient GitHub authentication is not refreshed after a 403", async () => {
+  let resolutions = 0
+  const layer = ambientGitHubLayer({
+    workspaceRoot: "/workspace",
+    resolveToken: async () => {
+      resolutions += 1
+      return "insufficient-token"
+    },
+    makeService: () =>
+      serviceWithList(() =>
+        Effect.fail(
+          new GitHubRequestError({
+            message: "Forbidden",
+            statusCode: 403,
+          }),
+        ),
+      ),
+  })
+
+  await Effect.runPromise(
+    Effect.gen(function* () {
+      const github = yield* GitHubService
+      return yield* Effect.exit(
+        github.listReadyIssues({ owner: "acme", name: "widgets" }),
+      )
+    }).pipe(Effect.provide(layer)),
+  )
+
+  expect(resolutions).toBe(1)
+})

--- a/apps/harness/test/keymaxxer-github-layer.test.ts
+++ b/apps/harness/test/keymaxxer-github-layer.test.ts
@@ -8,38 +8,6 @@ import { keymaxxerGitHubLayer } from "../src/server/keymaxxer-github-layer.js"
 import { describe, expect, test } from "bun:test"
 
 describe("Keymaxxer-backed GitHub layer", () => {
-  test("uses ambient GitHub authentication when Keymaxxer is disabled", async () => {
-    const runs: RunWithSecretsInput[] = []
-    const keymaxxerLayer = Layer.succeed(KeymaxxerService, {
-      enabled: false,
-      initialize: Effect.void,
-      findSecret: () => Effect.die("must not inspect the vault"),
-      findSecrets: () => Effect.die("not used"),
-      hasSecret: () => Effect.die("not used"),
-      addSecret: () => Effect.die("not used"),
-      removeSecret: () => Effect.die("not used"),
-      runWithSecrets: (input) => {
-        runs.push(input)
-        return Effect.succeed({ exitCode: 0, stdout: "[]", stderr: "" })
-      },
-    })
-    const layer = keymaxxerGitHubLayer({ workspaceRoot: "/workspace" }).pipe(
-      Layer.provide(keymaxxerLayer),
-    )
-
-    await Effect.runPromise(
-      Effect.gen(function* () {
-        const github = yield* GitHubService
-        yield* github.listReadyIssues({ owner: "acme", name: "widgets" })
-      }).pipe(Effect.provide(layer)),
-    )
-
-    expect(runs).toHaveLength(1)
-    expect(runs[0]?.secrets).toEqual([])
-    expect(runs[0]?.command).toContain("gh auth token")
-    expect(runs[0]?.command.toLowerCase()).not.toContain("keymaxxer")
-  })
-
   test("does not prompt Keymaxxer when a repository token is missing", async () => {
     let addCalled = false
     const runs: RunWithSecretsInput[] = []

--- a/packages/github-service/src/index.ts
+++ b/packages/github-service/src/index.ts
@@ -1,5 +1,8 @@
 export * from "./lib/errors.js"
 export * from "./lib/github-service.js"
-export { GitHubServiceLive } from "./lib/github-service-live.js"
+export {
+  GitHubServiceLive,
+  makeGitHubServiceFromToken,
+} from "./lib/github-service-live.js"
 export * from "./lib/github-service-test.js"
 export * from "./lib/types.js"

--- a/packages/github-service/src/lib/errors.ts
+++ b/packages/github-service/src/lib/errors.ts
@@ -13,5 +13,6 @@ export class GitHubRequestError extends Schema.TaggedErrorClass<GitHubRequestErr
   {
     message: Schema.String,
     cause: Schema.optional(Schema.Defect()),
+    statusCode: Schema.optional(Schema.Finite),
   },
 ) {}

--- a/packages/github-service/src/lib/github-service-live.ts
+++ b/packages/github-service/src/lib/github-service-live.ts
@@ -29,6 +29,15 @@ const READY_FOR_AGENT_LABEL = "ready-for-agent"
 const PAGE_SIZE = 100
 const REQUEST_TIMEOUT = "30 seconds"
 
+class GitHubHttpError extends Error {
+  constructor(
+    readonly statusCode: number,
+    message: string,
+  ) {
+    super(message)
+  }
+}
+
 export interface GitHubGraphqlClient {
   readonly query: <R extends QueryGenqlSelection>(
     request: R & { readonly __name?: string },
@@ -40,13 +49,25 @@ export interface GitHubGraphqlClient {
   ) => Promise<FieldsSelection<Mutation, R>>
 }
 
+type GitHubFetch = (
+  input: Parameters<typeof fetch>[0],
+  init?: RequestInit,
+) => Promise<Response>
+
 const githubRequest = <A>(
   message: string,
   request: (signal: AbortSignal) => Promise<A>,
 ): Effect.Effect<A, GitHubRequestError> =>
   Effect.tryPromise({
     try: request,
-    catch: (cause) => new GitHubRequestError({ message, cause }),
+    catch: (cause) =>
+      new GitHubRequestError({
+        message,
+        cause,
+        ...(cause instanceof GitHubHttpError
+          ? { statusCode: cause.statusCode }
+          : {}),
+      }),
   }).pipe(
     Effect.timeout(REQUEST_TIMEOUT),
     Effect.catchTag("TimeoutError", (cause) =>
@@ -65,6 +86,7 @@ const githubQuery = <A>(
       schedule: Schedule.addDelay(Schedule.recurs(2), () =>
         Effect.succeed(Duration.millis(500)),
       ),
+      while: (error) => error.statusCode !== 401,
     }),
   )
 
@@ -1410,11 +1432,24 @@ export const makeGitHubService = (
   ),
 })
 
-const makeGitHubGraphqlClient = (token: string): GitHubGraphqlClient => {
+const makeGitHubGraphqlClient = (
+  token: string,
+  fetchImpl: GitHubFetch = fetch,
+): GitHubGraphqlClient => {
   const client = (signal?: AbortSignal) =>
     createClient({
       url: GITHUB_GRAPHQL_URL,
       signal,
+      fetch: async (input: Parameters<typeof fetch>[0], init?: RequestInit) => {
+        const response = await fetchImpl(input, init)
+        if (!response.ok) {
+          throw new GitHubHttpError(
+            response.status,
+            `${response.statusText}: ${await response.text()}`,
+          )
+        }
+        return response
+      },
       headers: {
         Authorization: `Bearer ${token}`,
       },
@@ -1426,11 +1461,15 @@ const makeGitHubGraphqlClient = (token: string): GitHubGraphqlClient => {
   }
 }
 
+export const makeGitHubServiceFromToken = (
+  token: string,
+  fetchImpl?: GitHubFetch,
+): GitHubServiceShape =>
+  makeGitHubService(makeGitHubGraphqlClient(token, fetchImpl))
+
 export const GitHubServiceLive = Layer.effect(
   GitHubService,
   Config.redacted("GITHUB_TOKEN").pipe(
-    Effect.map((token) =>
-      makeGitHubService(makeGitHubGraphqlClient(Redacted.value(token))),
-    ),
+    Effect.map((token) => makeGitHubServiceFromToken(Redacted.value(token))),
   ),
 )

--- a/packages/github-service/test/github-service.spec.ts
+++ b/packages/github-service/test/github-service.spec.ts
@@ -8,6 +8,7 @@ import {
   GitHubRequestError,
   GitHubService,
   type ReadyLabeledIssue,
+  makeGitHubServiceFromToken,
   makeGitHubServiceTest,
 } from "../src/index.js"
 import {
@@ -36,6 +37,25 @@ const issue = (
 })
 
 describe("GitHubService live implementation", () => {
+  it.effect("preserves an HTTP authentication status", () =>
+    Effect.gen(function* () {
+      let requests = 0
+      const service = makeGitHubServiceFromToken("expired-token", async () => {
+        requests += 1
+        return new Response("Bad credentials", {
+          status: 401,
+          statusText: "Unauthorized",
+        })
+      })
+
+      const error = yield* service.listReadyIssues(repository).pipe(Effect.flip)
+
+      expect(error).toBeInstanceOf(GitHubRequestError)
+      expect((error as GitHubRequestError).statusCode).toBe(401)
+      expect(requests).toBe(1)
+    }),
+  )
+
   it.effect("aborts an in-flight request when interrupted", () =>
     Effect.gen(function* () {
       let requestSignal: AbortSignal | undefined

--- a/packages/graphql-api/src/lib/graphql-api.ts
+++ b/packages/graphql-api/src/lib/graphql-api.ts
@@ -260,6 +260,10 @@ type Repository = {
 const activatePollingIfCredentialed = (repository: Repository) =>
   Effect.gen(function* () {
     const keymaxxer = yield* KeymaxxerService
+    if (keymaxxer.enabled === false) {
+      yield* activateRepositoryPolling(repository.id)
+      return
+    }
     const credential = yield* keymaxxer.findSecret({
       provider: "github",
       account: `${repository.githubOwner}/${repository.githubRepo}`,
@@ -298,9 +302,10 @@ const githubTokenCreationUrl = (repository: Repository) => {
 const repositoryCredential = (
   repository: Repository,
   existingToken: string | null,
+  configured = existingToken !== null,
 ) => ({
   repositoryId: repository.id,
-  configured: existingToken !== null,
+  configured,
   githubTokenSecretName: existingToken ?? githubTokenSecretName(repository),
   githubTokenCreationUrl: githubTokenCreationUrl(repository),
 })
@@ -530,14 +535,21 @@ export const createGraphqlApi = (
                   const db = yield* DbService
                   const repositories = yield* db.listRepositories
                   const keymaxxer = yield* KeymaxxerService
-                  const tokenNames = yield* keymaxxer.findSecrets(
-                    repositories.map((repository) => ({
-                      provider: "github",
-                      account: `${repository.githubOwner}/${repository.githubRepo}`,
-                    })),
-                  )
+                  const ambientAuthentication = keymaxxer.enabled === false
+                  const tokenNames = ambientAuthentication
+                    ? repositories.map(() => null)
+                    : yield* keymaxxer.findSecrets(
+                        repositories.map((repository) => ({
+                          provider: "github",
+                          account: `${repository.githubOwner}/${repository.githubRepo}`,
+                        })),
+                      )
                   return repositories.map((repository, index) =>
-                    repositoryCredential(repository, tokenNames[index] ?? null),
+                    repositoryCredential(
+                      repository,
+                      tokenNames[index] ?? null,
+                      ambientAuthentication || tokenNames[index] != null,
+                    ),
                   )
                 }),
               ),
@@ -1019,14 +1031,16 @@ export const createGraphqlApi = (
                   }
 
                   const keymaxxer = yield* KeymaxxerService
-                  const credential = yield* keymaxxer.findSecret({
-                    provider: "github",
-                    account: `${repository.githubOwner}/${repository.githubRepo}`,
-                  })
-                  if (credential === null) {
-                    return yield* new RepositoryCredentialError({
-                      message: `GitHub credential is not configured for ${repository.githubOwner}/${repository.githubRepo}`,
+                  if (keymaxxer.enabled !== false) {
+                    const credential = yield* keymaxxer.findSecret({
+                      provider: "github",
+                      account: `${repository.githubOwner}/${repository.githubRepo}`,
                     })
+                    if (credential === null) {
+                      return yield* new RepositoryCredentialError({
+                        message: `GitHub credential is not configured for ${repository.githubOwner}/${repository.githubRepo}`,
+                      })
+                    }
                   }
 
                   const jobId = yield* enqueueRefreshRepositoryJob(

--- a/packages/graphql-api/test/graphql-api.test.ts
+++ b/packages/graphql-api/test/graphql-api.test.ts
@@ -349,6 +349,39 @@ describe("GraphQL API", () => {
     ])
   })
 
+  test("activates Issue Polling with ambient GitHub authentication", async () => {
+    let ensured = false
+    let enqueued = false
+    await runtime.dispose()
+    runtime = makeRuntime(
+      {},
+      {},
+      {
+        enabled: false,
+        findSecret: () => Effect.die("must not inspect the vault"),
+      },
+      {
+        ensureKeyed: () => {
+          ensured = true
+          return Effect.succeed({ jobId: makeJobId(), created: true })
+        },
+        enqueue: () => {
+          enqueued = true
+          return Effect.succeed(makeJobId())
+        },
+      },
+    )
+
+    const response = await createGraphqlApi(runtime).fetch(
+      addRepositoryRequest(),
+    )
+
+    expect(response.status).toBe(200)
+    expect((await response.json()).data.addRepository.id).toBe(repository.id)
+    expect(ensured).toBe(true)
+    expect(enqueued).toBe(true)
+  })
+
   test("does not activate Issue Polling when adding a repository without a GitHub token", async () => {
     let ensured = false
     let enqueued = false
@@ -541,6 +574,34 @@ describe("GraphQL API", () => {
     expect(creationUrl.searchParams.get("actions")).toBe("read")
     expect(creationUrl.searchParams.get("statuses")).toBe("read")
     expect(creationUrl.searchParams.get("checks")).toBeNull()
+  })
+
+  test("reports ambient GitHub authentication as configured", async () => {
+    await runtime.dispose()
+    runtime = makeRuntime(
+      {},
+      {},
+      {
+        enabled: false,
+        findSecrets: () => Effect.die("must not inspect the vault"),
+      },
+    )
+
+    const response = await createGraphqlApi(runtime).fetch(
+      graphqlRequest({
+        query: `query {
+          repositoryCredentials { repositoryId configured }
+        }`,
+      }),
+    )
+
+    expect(await response.json()).toEqual({
+      data: {
+        repositoryCredentials: [
+          { repositoryId: repository.id, configured: true },
+        ],
+      },
+    })
   })
 
   test("opens Keymaxxer setup for a missing repository token", async () => {
@@ -1743,6 +1804,47 @@ describe("GraphQL API", () => {
       },
       retryLimit: 1,
     })
+  })
+
+  test("accepts a Refresh Job with ambient GitHub authentication", async () => {
+    const jobId = makeJobId()
+    let enqueued = false
+    await runtime.dispose()
+    runtime = makeRuntime(
+      {},
+      {},
+      {
+        enabled: false,
+        findSecret: () => Effect.die("must not inspect the vault"),
+      },
+      {
+        enqueue: () => {
+          enqueued = true
+          return Effect.succeed(jobId)
+        },
+      },
+    )
+
+    const response = await createGraphqlApi(runtime).fetch(
+      graphqlRequest({
+        query: `mutation {
+          refreshRepository(repositoryId: "${repository.id}") {
+            id
+            repositoryId
+          }
+        }`,
+      }),
+    )
+
+    expect(await response.json()).toEqual({
+      data: {
+        refreshRepository: {
+          id: jobId,
+          repositoryId: repository.id,
+        },
+      },
+    })
+    expect(enqueued).toBe(true)
   })
 
   test("rejects refresh for an unknown repository without enqueueing", async () => {

--- a/packages/keymaxxer-service/src/lib/service.ts
+++ b/packages/keymaxxer-service/src/lib/service.ts
@@ -1,3 +1,4 @@
+import { spawn } from "node:child_process"
 import { Context, Effect, Layer } from "effect"
 import type {
   AddSecretInput,
@@ -70,21 +71,28 @@ export const disabledKeymaxxerLayer: Layer.Layer<KeymaxxerService> =
     removeSecret: () => Effect.succeed(false),
     runWithSecrets: (input) =>
       Effect.tryPromise({
-        try: async () => {
-          const child = Bun.spawn(["bash", "-c", input.command], {
-            cwd: input.cwd,
-            env: process.env,
-            stdout: "pipe",
-            stderr: "pipe",
-            timeout: input.timeoutMs,
-          })
-          const [exitCode, stdout, stderr] = await Promise.all([
-            child.exited,
-            new Response(child.stdout).text(),
-            new Response(child.stderr).text(),
-          ])
-          return { exitCode, stdout, stderr }
-        },
+        try: () =>
+          new Promise<RunWithSecretsResult>((resolve, reject) => {
+            const child = spawn("bash", ["-c", input.command], {
+              cwd: input.cwd,
+              env: process.env,
+              timeout: input.timeoutMs,
+            })
+            let stdout = ""
+            let stderr = ""
+            child.stdout.setEncoding("utf8")
+            child.stderr.setEncoding("utf8")
+            child.stdout.on("data", (chunk: string) => {
+              stdout += chunk
+            })
+            child.stderr.on("data", (chunk: string) => {
+              stderr += chunk
+            })
+            child.once("error", reject)
+            child.once("close", (exitCode) => {
+              resolve({ exitCode: exitCode ?? 1, stdout, stderr })
+            })
+          }),
         catch: () =>
           new KeymaxxerError({
             operation: "run command",

--- a/packages/keymaxxer-service/test/service.test.ts
+++ b/packages/keymaxxer-service/test/service.test.ts
@@ -1,0 +1,23 @@
+import { Effect } from "effect"
+import { KeymaxxerService, disabledKeymaxxerLayer } from "../src/index.js"
+import { expect, test } from "bun:test"
+
+test("disabled Keymaxxer runs commands through the ambient environment", async () => {
+  const result = await Effect.runPromise(
+    Effect.gen(function* () {
+      const keymaxxer = yield* KeymaxxerService
+      return yield* keymaxxer.runWithSecrets({
+        command: `node -e 'process.stdout.write("ambient-auth")'`,
+        cwd: process.cwd(),
+        secrets: [],
+        timeoutMs: 5_000,
+      })
+    }).pipe(Effect.provide(disabledKeymaxxerLayer)),
+  )
+
+  expect(result).toEqual({
+    exitCode: 0,
+    stdout: "ambient-auth",
+    stderr: "",
+  })
+})


### PR DESCRIPTION
## Why

Running the Harness without Keymaxxer still treated repository-specific Keymaxxer secrets as the source of GitHub readiness. The UI requested a token, manual refresh rejected ambient authentication, and scheduled polling attempted to execute a Bun-only subprocess path from the Node-based Vite server.

Users authenticated through `gh auth login` should be able to use polling and repository refresh without creating or storing another GitHub token.

## What Changed

- Add a dedicated ambient `GitHubService` layer selected when Keymaxxer is disabled.
- Resolve `gh auth token` directly, cache it in memory, and call the shared GitHub GraphQL implementation in-process.
- Refresh the cached token once after HTTP 401 responses, including safe sharing across concurrent failures, while preserving other authorization errors.
- Keep the repository-specific Keymaxxer GitHub layer separate.
- Treat ambient GitHub authentication as configured when activating polling, reporting repository readiness, and accepting manual refresh jobs.
- Make disabled Keymaxxer command execution work in the Node Harness runtime for remaining cleanup commands.

## Verification

- Reproduced the manual refresh rejection as `REPOSITORY_CREDENTIAL_ERROR` before the fix.
- On `http://localhost:4201/`, manual refresh subsequently enqueued successfully and newly Ready-labeled issues appeared in the repository card.
- Regression coverage includes token caching, one-time 401 refresh, concurrent 401 refresh sharing, polling activation, credential status, and manual refresh with ambient authentication.
