### PR TITLE
docs: record live Harness e2e design

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -8,6 +8,10 @@ Opinionated agentic software engineering harness that works GitHub issues into P
 A GitHub repository the harness is configured to work on, identified by owner and name (case-insensitive identity; display casing preserved). One row per GitHub repo; the harness keeps a single local clone of it (bare or working). Displayed as `owner/name` — no separate display label.
 _Avoid_: Repo (in formal docs), target, project, checkout
 
+**End-to-End Fixture Repository**:
+A dedicated Repository whose stable GitHub state is controlled as a fixture for end-to-end validation. It contains a permanent open, Ready-labeled sentinel Issue with fixed identity and content, no hierarchy or blockers, and no Issue-closing PR; scenarios need not reject unrelated Issues.
+_Avoid_: Test repo, sandbox Repository, mutable fixture
+
 **Paused**:
 A Repository state in which the harness does not autonomously select work for the Repository while keeping its configuration. Keeping the Issue store current through scheduled polling continues while Paused. Explicit operator requests, including a manual Refresh Job or Implement Now and its resulting lifecycle, remain allowed; new Repositories start paused until deliberately unpaused. Not the same as a paused Work Item (see Pause Work Item).
 _Avoid_: Disabled, inactive, enabled=false, Pause Work Item

--- a/docs/adr/0021-live-harness-end-to-end-test.md
+++ b/docs/adr/0021-live-harness-end-to-end-test.md
@@ -1,0 +1,5 @@
+# Validate Harness end to end against a controlled GitHub Repository
+
+Harness end-to-end validation runs the production-built application, worker, Keymaxxer Sidecar, command-line client, and browser against the private End-to-End Fixture Repository `berenddeboer/test-ready-for-agent`, without GraphQL or GitHub mocks. Executable Gherkin via `playwright-bdd` adds the Repository from a fresh local checkout through the real CLI and waits for credential activation's automatic first Refresh Job to make sentinel Issue `#22`, `E2E fixture: Ready-labeled Issue refresh`, visible in the UI.
+
+Each run starts with an empty, isolated Harness database. CI copies a checked-in encrypted Keymaxxer vault containing only the read-only `GITHUB_TOKEN_BERENDDEBOER_TEST_READY_FOR_AGENT` credential into a temporary home and unlocks it with the GitHub Actions secret `E2E_KEYMAXXER_MASTER_KEY`; `KEYMAXXER_APPROVE=deny` prevents headless prompts and fails closed. Local runs instead leave `~/.keymaxxer` untouched and may prompt normally. The live scenario has no automatic retry, runs only after the existing checks on trusted pushes to `main`, and retains Playwright diagnostics on failure.


### PR DESCRIPTION
## Why

The planned live Harness end-to-end test crosses the production application, worker, Keymaxxer, GitHub, CLI, and browser boundaries. Recording its fixture vocabulary and architectural constraints prevents later implementation tickets from drifting back toward mocked GraphQL coverage or unsafe credential handling.

## What Changed

- Define the End-to-End Fixture Repository in the project glossary.
- Record the executable Gherkin topology, controlled GitHub sentinel, isolated Harness database, encrypted CI vault, local-vault behavior, and trusted-CI boundary in ADR 0021.

Related to #189.
