### PR TITLE
feat(harness): animate running step duration without polling

### DIFF
--- a/apps/harness/src/live-duration.ts
+++ b/apps/harness/src/live-duration.ts
@@ -1,0 +1,62 @@
+import { useEffect, useState } from "react"
+
+/** Statuses that show a wall-clock-advancing duration in the UI. */
+export function isLiveDurationStatus(status: string): boolean {
+  return status === "RUNNING"
+}
+
+/**
+ * Duration to display for a lifecycle label.
+ * While running, advances from the last authoritative snapshot using local wall clock.
+ */
+export function liveDurationMs(
+  durationMs: number | null,
+  isRunning: boolean,
+  snapshotAtMs: number,
+  nowMs: number,
+): number | null {
+  if (durationMs === null) return null
+  if (!isRunning || snapshotAtMs <= 0) return durationMs
+  return durationMs + Math.max(0, nowMs - snapshotAtMs)
+}
+
+/** Formats a duration for step labels, e.g. "3s" or "4m 15s". */
+export function formatDuration(ms: number): string {
+  const totalSeconds = Math.max(0, Math.round(ms / 1000))
+  if (totalSeconds < 60) return `${totalSeconds}s`
+  const minutes = Math.floor(totalSeconds / 60)
+  const seconds = totalSeconds % 60
+  if (minutes < 60) {
+    return seconds === 0 ? `${minutes}m` : `${minutes}m ${seconds}s`
+  }
+  const hours = Math.floor(minutes / 60)
+  const remainingMinutes = minutes % 60
+  return remainingMinutes === 0 ? `${hours}h` : `${hours}h ${remainingMinutes}m`
+}
+
+/** Formats job start time as a relative phrase, e.g. "15 min ago". */
+export function formatStartedAgo(iso: string, nowMs = Date.now()): string {
+  const elapsedMs = Math.max(0, nowMs - new Date(iso).getTime())
+  const seconds = Math.floor(elapsedMs / 1000)
+  if (seconds < 60) return "just now"
+  const minutes = Math.floor(seconds / 60)
+  if (minutes < 60) return `${minutes} min ago`
+  const hours = Math.floor(minutes / 60)
+  if (hours < 24) return hours === 1 ? "1 hour ago" : `${hours} hours ago`
+  const days = Math.floor(hours / 24)
+  return days === 1 ? "1 day ago" : `${days} days ago`
+}
+
+/** Local wall-clock tick for animating live durations and relative ages. */
+export function useNowMs(enabled: boolean, intervalMs = 1000): number {
+  const [nowMs, setNowMs] = useState(() => Date.now())
+  useEffect(() => {
+    if (!enabled) return
+    setNowMs(Date.now())
+    const id = setInterval(() => {
+      setNowMs(Date.now())
+    }, intervalMs)
+    return () => clearInterval(id)
+  }, [enabled, intervalMs])
+  return nowMs
+}

--- a/apps/harness/src/routes/index.tsx
+++ b/apps/harness/src/routes/index.tsx
@@ -8,6 +8,13 @@ import {
 import { createFileRoute } from "@tanstack/react-router"
 import { type FormEvent, Suspense, useEffect, useRef, useState } from "react"
 import { createClient } from "@ready-for-agent/graphql-client"
+import {
+  formatDuration,
+  formatStartedAgo,
+  isLiveDurationStatus,
+  liveDurationMs,
+  useNowMs,
+} from "../live-duration.js"
 import { followRepositoryIssuesLive } from "../refresh-issues-live.js"
 import { followRepositoryWorkItemsLive } from "../refresh-work-items-live.js"
 import { streamRepositoryChanges } from "../repository-live.js"
@@ -218,33 +225,6 @@ const workItemFields = {
     durationMs: true,
   },
 } as const
-
-/** Formats a duration for step labels, e.g. "3s" or "4m 15s". */
-function formatDuration(ms: number): string {
-  const totalSeconds = Math.max(0, Math.round(ms / 1000))
-  if (totalSeconds < 60) return `${totalSeconds}s`
-  const minutes = Math.floor(totalSeconds / 60)
-  const seconds = totalSeconds % 60
-  if (minutes < 60) {
-    return seconds === 0 ? `${minutes}m` : `${minutes}m ${seconds}s`
-  }
-  const hours = Math.floor(minutes / 60)
-  const remainingMinutes = minutes % 60
-  return remainingMinutes === 0 ? `${hours}h` : `${hours}h ${remainingMinutes}m`
-}
-
-/** Formats job start time as a relative phrase, e.g. "15 min ago". */
-function formatStartedAgo(iso: string, nowMs = Date.now()): string {
-  const elapsedMs = Math.max(0, nowMs - new Date(iso).getTime())
-  const seconds = Math.floor(elapsedMs / 1000)
-  if (seconds < 60) return "just now"
-  const minutes = Math.floor(seconds / 60)
-  if (minutes < 60) return `${minutes} min ago`
-  const hours = Math.floor(minutes / 60)
-  if (hours < 24) return hours === 1 ? "1 hour ago" : `${hours} hours ago`
-  const days = Math.floor(hours / 24)
-  return days === 1 ? "1 day ago" : `${days} days ago`
-}
 
 const workItemsQuery = (repositoryId: string) => ({
   queryKey: ["work-items", repositoryId],
@@ -1677,6 +1657,10 @@ function WorkItemLifecycleStatus({
   const status = workItem.status
   const canRetry = compact && workItem.canRetry
   const canReset = compact
+  const dataUpdatedAt =
+    queryClient.getQueryState(workItemsQuery(workItem.repositoryId).queryKey)
+      ?.dataUpdatedAt ?? 0
+  const nowMs = useNowMs(true)
   const patchWorkItem = (updated: WorkItem) => {
     queryClient.setQueryData<readonly WorkItem[]>(
       workItemsQuery(workItem.repositoryId).queryKey,
@@ -1728,7 +1712,7 @@ function WorkItemLifecycleStatus({
         <span className="text-xs font-semibold text-slate-700">
           {workItem.stateLabel}
           <span className="ml-1.5 font-normal text-slate-500">
-            {formatStartedAgo(workItem.createdAt)}
+            {formatStartedAgo(workItem.createdAt, nowMs)}
           </span>
         </span>
         <span
@@ -1752,19 +1736,27 @@ function WorkItemLifecycleStatus({
           className="mt-2 mb-0 flex list-none flex-wrap gap-1 p-0"
           aria-label="Lifecycle steps"
         >
-          {workItem.lifecycleLabels.map((lifecycleLabel) => (
-            <li
-              className="rounded bg-white px-1.5 py-1 text-[0.65rem] text-slate-600 ring-1 ring-slate-200"
-              key={lifecycleLabel.phase}
-            >
-              {lifecycleLabel.label}
-              {lifecycleLabel.durationMs !== null && (
-                <span className="ml-1 text-slate-400">
-                  {formatDuration(lifecycleLabel.durationMs)}
-                </span>
-              )}
-            </li>
-          ))}
+          {workItem.lifecycleLabels.map((lifecycleLabel) => {
+            const displayDurationMs = liveDurationMs(
+              lifecycleLabel.durationMs,
+              isLiveDurationStatus(lifecycleLabel.status),
+              dataUpdatedAt,
+              nowMs,
+            )
+            return (
+              <li
+                className="rounded bg-white px-1.5 py-1 text-[0.65rem] text-slate-600 ring-1 ring-slate-200"
+                key={lifecycleLabel.phase}
+              >
+                {lifecycleLabel.label}
+                {displayDurationMs !== null && (
+                  <span className="ml-1 text-slate-400">
+                    {formatDuration(displayDurationMs)}
+                  </span>
+                )}
+              </li>
+            )
+          })}
         </ol>
       )}
       {workItem.statusMessage !== null && (

--- a/apps/harness/test/backend-runtime-restart.test.ts
+++ b/apps/harness/test/backend-runtime-restart.test.ts
@@ -21,6 +21,19 @@ type TestPlugin = {
 const testPlugin = (delay = 1) =>
   backendRuntimeRestart(workspaceRoot, delay) as unknown as TestPlugin
 
+const waitFor = async (
+  predicate: () => boolean,
+  timeoutMs = 1_000,
+): Promise<void> => {
+  const startedAt = Date.now()
+  while (!predicate()) {
+    if (Date.now() - startedAt > timeoutMs) {
+      throw new Error(`Timed out after ${timeoutMs}ms waiting for condition`)
+    }
+    await Bun.sleep(5)
+  }
+}
+
 afterEach(async () => {
   await disposeDevelopmentApplication()
 })
@@ -81,7 +94,7 @@ describe("backend runtime restart", () => {
       file: resolve(workspaceRoot, "packages/db-service/src/lib/types.ts"),
     })
 
-    await Bun.sleep(10)
+    await waitFor(() => restarts === 1)
     expect(restarts).toBe(1)
   })
 
@@ -104,7 +117,7 @@ describe("backend runtime restart", () => {
       file: resolve(workspaceRoot, "packages/db-service/src/index.ts"),
     })
 
-    await Bun.sleep(10)
+    await waitFor(() => events.length === 2)
     expect(events).toEqual(["disposed", "restarted"])
   })
 

--- a/apps/harness/test/live-duration.test.ts
+++ b/apps/harness/test/live-duration.test.ts
@@ -1,0 +1,113 @@
+import {
+  formatDuration,
+  formatStartedAgo,
+  isLiveDurationStatus,
+  liveDurationMs,
+} from "../src/live-duration.js"
+import { describe, expect, test } from "bun:test"
+
+describe("liveDurationMs", () => {
+  test("advances a running snapshot without needing a query refetch", () => {
+    const snapshotAtMs = 1_000_000
+    const snapshotDurationMs = 78_000
+    expect(
+      liveDurationMs(snapshotDurationMs, true, snapshotAtMs, snapshotAtMs),
+    ).toBe(78_000)
+    expect(
+      liveDurationMs(
+        snapshotDurationMs,
+        true,
+        snapshotAtMs,
+        snapshotAtMs + 1_000,
+      ),
+    ).toBe(79_000)
+    expect(
+      formatDuration(
+        liveDurationMs(
+          snapshotDurationMs,
+          true,
+          snapshotAtMs,
+          snapshotAtMs + 1_000,
+        )!,
+      ),
+    ).toBe("1m 19s")
+  })
+
+  test("keeps terminal durations fixed", () => {
+    const snapshotAtMs = 1_000_000
+    const finishedMs = 120_000
+    for (const status of [
+      "SUCCEEDED",
+      "FAILED",
+      "INTERRUPTED",
+      "CANCELLED",
+      "ABANDONED",
+      "NEEDS_HUMAN",
+      "QUEUED",
+      "COMPLETE",
+    ] as const) {
+      expect(isLiveDurationStatus(status)).toBe(false)
+      expect(
+        liveDurationMs(
+          finishedMs,
+          isLiveDurationStatus(status),
+          snapshotAtMs,
+          snapshotAtMs + 30_000,
+        ),
+      ).toBe(finishedMs)
+    }
+  })
+
+  test("resets baseline when query data updates with a new duration", () => {
+    const firstSnapshotAt = 1_000_000
+    const firstDuration = 78_000
+    const advanced = liveDurationMs(
+      firstDuration,
+      true,
+      firstSnapshotAt,
+      firstSnapshotAt + 5_000,
+    )
+    expect(advanced).toBe(83_000)
+
+    const secondSnapshotAt = firstSnapshotAt + 5_000
+    const secondDuration = 80_000
+    expect(
+      liveDurationMs(secondDuration, true, secondSnapshotAt, secondSnapshotAt),
+    ).toBe(80_000)
+    expect(
+      liveDurationMs(
+        secondDuration,
+        true,
+        secondSnapshotAt,
+        secondSnapshotAt + 2_000,
+      ),
+    ).toBe(82_000)
+  })
+
+  test("returns null when server duration is null", () => {
+    expect(liveDurationMs(null, true, 1_000, 2_000)).toBeNull()
+  })
+
+  test("does not invent progress when snapshot time is unknown", () => {
+    expect(liveDurationMs(78_000, true, 0, 50_000)).toBe(78_000)
+  })
+})
+
+describe("formatStartedAgo", () => {
+  test("advances relative age as wall clock moves without refetch", () => {
+    const createdAt = new Date(1_000_000).toISOString()
+    expect(formatStartedAgo(createdAt, 1_000_000 + 30_000)).toBe("just now")
+    expect(formatStartedAgo(createdAt, 1_000_000 + 90_000)).toBe("1 min ago")
+    expect(formatStartedAgo(createdAt, 1_000_000 + 15 * 60_000)).toBe(
+      "15 min ago",
+    )
+  })
+})
+
+describe("formatDuration", () => {
+  test("formats step durations used by lifecycle labels", () => {
+    expect(formatDuration(3_000)).toBe("3s")
+    expect(formatDuration(78_000)).toBe("1m 18s")
+    expect(formatDuration(120_000)).toBe("2m")
+  })
+})


### PR DESCRIPTION
## Summary

- Advance running lifecycle step durations in the harness UI from a local wall-clock baseline (`durationMs` + elapsed since query `dataUpdatedAt`).
- Keep relative start phrases (`formatStartedAgo`) updating on the same client tick without restoring `workItems` polling.
- Freeze terminal/non-running durations and snap back to server truth after SSE/refetch cache updates.

Closes #186

## Test plan

- [x] `apps/harness/test/live-duration.test.ts` (live advance, non-running freeze, baseline reset, relative age)
- [x] `jobs-card-no-polling` still asserts no `refetchInterval` on JobsCard
- [x] Affected harness lint/typecheck/test via pre-commit
- [ ] Manual: start a job and confirm running step duration counts up without 1s GraphQL polling
- [ ] Manual: after SSE/refetch completes a step, duration freezes at the final value