### PR TITLE
fix(layer-turso-local): drop multiprocess WAL for single-process harness

### DIFF
--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -15,6 +15,12 @@ plus the development-only Keymaxxer sidecar. By default, application data is
 stored in `tmp/ready-for-agent.db`. Set `SQLITE_DATABASE_PATH` to use another
 SQLite/Turso database.
 
+Stop the harness completely before opening that database with external write
+tooling (CLI, GUI, or a second process). The harness uses single-process default
+WAL; concurrent writers are not supported. Stale `*.db-tshm` files from older
+multiprocess-WAL runs may remain; Turso rebuilds or ignores them after a clean
+mode switch, and no data migration is required.
+
 Then add a local repository:
 
 ```bash

--- a/apps/harness/README.md
+++ b/apps/harness/README.md
@@ -25,6 +25,15 @@ READY_FOR_AGENT_GRAPHQL_URL=http://127.0.0.1:4300/graphql \
   bun run harness-cli add /path/to/local/repo
 ```
 
+## Database
+
+By default the harness stores application data in `tmp/ready-for-agent.db`
+(override with `SQLITE_DATABASE_PATH`). Fully stop the harness before opening
+that file with external write tooling. The harness uses single-process default
+WAL; concurrent writers are not supported. Stale `*.db-tshm` files from older
+multiprocess-WAL runs may remain; Turso rebuilds or ignores them after a clean
+mode switch, and no data migration is required.
+
 ## Production
 
 Build and start the custom Bun server with:

--- a/packages/layer-turso-local/src/lib/client-live.ts
+++ b/packages/layer-turso-local/src/lib/client-live.ts
@@ -44,9 +44,7 @@ const sqlError = (cause: unknown, operation: string) =>
 
 const makeClient = (path: string, options?: TursoClientOptions) =>
   Effect.gen(function* () {
-    const databaseOptions: NonNullable<Parameters<typeof connect>[1]> = {
-      experimental: ["multiprocess_wal"],
-    }
+    const databaseOptions: NonNullable<Parameters<typeof connect>[1]> = {}
     if (options?.defaultQueryTimeout !== undefined)
       databaseOptions.defaultQueryTimeout = options.defaultQueryTimeout
     const db = yield* Effect.tryPromise({

--- a/packages/layer-turso-local/test/concurrent-transaction.spec.ts
+++ b/packages/layer-turso-local/test/concurrent-transaction.spec.ts
@@ -1,5 +1,7 @@
+import { existsSync } from "node:fs"
 import { unlink } from "node:fs/promises"
-import { Effect } from "effect"
+import { connect } from "@tursodatabase/database"
+import { ConfigProvider, Effect, Layer } from "effect"
 import * as SqlClient from "effect/unstable/sql/SqlClient"
 import { makeTursoLive } from "../src/index.js"
 import { describe, expect, it } from "bun:test"
@@ -9,15 +11,20 @@ const tempDbPath = () =>
 
 const sqlQuery = (sql: string) => Object.assign([sql], { raw: [sql] })
 
-const makeTestLayer = (dbPath: string) => {
-  process.env.SQLITE_DATABASE_PATH = dbPath
-  return makeTursoLive()
-}
+const makeTestLayer = (dbPath: string) =>
+  makeTursoLive().pipe(
+    Layer.provide(
+      ConfigProvider.layer(
+        ConfigProvider.fromUnknown({ SQLITE_DATABASE_PATH: dbPath }),
+      ),
+    ),
+  )
 
 const cleanupDb = async (dbPath: string) => {
   await unlink(dbPath).catch(() => {})
   await unlink(`${dbPath}-wal`).catch(() => {})
   await unlink(`${dbPath}-shm`).catch(() => {})
+  await unlink(`${dbPath}-tshm`).catch(() => {})
 }
 
 describe("makeTursoLive", () => {
@@ -252,6 +259,56 @@ describe("makeTursoLive", () => {
       )
 
       expect(rows).toEqual([[1, 1, "a", "b"]])
+    } finally {
+      await cleanupDb(dbPath)
+    }
+  })
+
+  it("can be reopened by a default Turso connection after close", async () => {
+    const dbPath = tempDbPath()
+    const TestLayer = makeTestLayer(dbPath)
+
+    try {
+      await Effect.runPromise(
+        Effect.gen(function* () {
+          const sql = yield* SqlClient.SqlClient
+
+          yield* sql(sqlQuery("CREATE TABLE reopen (value TEXT NOT NULL)"))
+          yield* sql(sqlQuery("INSERT INTO reopen (value) VALUES ('ok')"))
+        }).pipe(Effect.provide(TestLayer)),
+      )
+
+      const db = await connect(dbPath)
+      try {
+        const rows = await db.all("SELECT value FROM reopen")
+        expect(rows).toEqual([{ value: "ok" }])
+      } finally {
+        await db.close()
+      }
+    } finally {
+      await cleanupDb(dbPath)
+    }
+  })
+
+  it("does not create a .db-tshm multiprocess coordination file", async () => {
+    const dbPath = tempDbPath()
+    const TestLayer = makeTestLayer(dbPath)
+
+    try {
+      await Effect.runPromise(
+        Effect.gen(function* () {
+          const sql = yield* SqlClient.SqlClient
+
+          yield* sql(sqlQuery("CREATE TABLE no_tshm (value TEXT NOT NULL)"))
+          yield* sql.withTransaction(
+            Effect.gen(function* () {
+              yield* sql(sqlQuery("INSERT INTO no_tshm (value) VALUES ('ok')"))
+            }),
+          )
+        }).pipe(Effect.provide(TestLayer)),
+      )
+
+      expect(existsSync(`${dbPath}-tshm`)).toBe(false)
     } finally {
       await cleanupDb(dbPath)
     }


### PR DESCRIPTION
## Summary

- Remove experimental `multiprocess_wal` from `makeTursoLive` so the harness uses single-process default WAL.
- Keep `PRAGMA journal_mode = wal`, `BEGIN IMMEDIATE`, busy timeout, and the in-process semaphore unchanged.
- Add regression tests for reopening with a default Turso connection and for no `.db-tshm` coordination file.
- Document that the harness must be fully stopped before external write tooling; stale `*.db-tshm` files need no migration.

Closes #196

## Test plan

- [x] `bunx nx run layer-turso-local:test`
- [x] `bunx nx run layer-turso-local:lint`
- [x] `bunx nx run layer-turso-local:typecheck`
- [x] Pre-commit affected lint/typecheck/test
- [ ] Optional: stop harness, open `tmp/ready-for-agent.db` with default tooling without experimental flags