### PR TITLE
feat(harness): show issue titles in jobs list

### DIFF
--- a/apps/harness/src/routes/index.tsx
+++ b/apps/harness/src/routes/index.tsx
@@ -1438,10 +1438,22 @@ function JobsCard() {
   const workItemQueries = useQueries({
     queries: repositories.map((repository) => workItemsQuery(repository.id)),
   })
+  const issueQueries = useQueries({
+    queries: repositories.map((repository) => issuesQuery(repository.id)),
+  })
 
   const repositoryById = new Map(
     repositories.map((repository) => [repository.id, repository] as const),
   )
+  const issueTitleByRepoAndNumber = new Map<string, string>()
+  for (const query of issueQueries) {
+    for (const issue of query.data ?? []) {
+      issueTitleByRepoAndNumber.set(
+        `${issue.repositoryId}:${issue.githubIssueNumber}`,
+        issue.title,
+      )
+    }
+  }
   const workItems = workItemQueries
     .flatMap((query) => query.data ?? [])
     .sort((left, right) => right.createdAt.localeCompare(left.createdAt))
@@ -1489,26 +1501,41 @@ function JobsCard() {
             repository === undefined
               ? workItem.repositoryId
               : `${repository.githubOwner}/${repository.githubRepo}`
+          const issueTitle = issueTitleByRepoAndNumber.get(
+            `${workItem.repositoryId}:${workItem.githubIssueNumber}`,
+          )
+          const issueIdentity =
+            issueTitle === undefined
+              ? `#${workItem.githubIssueNumber}`
+              : `#${workItem.githubIssueNumber} · ${issueTitle}`
           return (
             <li
               className="rounded-lg border border-slate-200 bg-slate-50/80 px-3 py-2"
               key={workItem.id}
             >
-              <div className="flex items-center justify-between gap-3">
+              <div className="flex items-start justify-between gap-3">
                 <div className="min-w-0">
                   <p className="m-0 truncate text-xs font-semibold text-slate-700">
                     {repositoryLabel}
                   </p>
-                  <div className="flex items-center gap-1">
-                    <span className="font-mono text-xs font-semibold text-blue-600">
-                      Issue #{workItem.githubIssueNumber}
+                  <p
+                    className="m-0 truncate text-xs font-semibold text-blue-600"
+                    title={issueIdentity}
+                  >
+                    <span className="font-mono">
+                      #{workItem.githubIssueNumber}
                     </span>
-                    <WorkItemPauseButton workItem={workItem} />
-                  </div>
+                    {issueTitle !== undefined && (
+                      <span className="font-sans"> · {issueTitle}</span>
+                    )}
+                  </p>
                 </div>
-                <span className="shrink-0 text-[0.65rem] font-bold tracking-wide text-slate-600 uppercase">
-                  {workItem.stateLabel}
-                </span>
+                <div className="flex shrink-0 items-center gap-1">
+                  <WorkItemPauseButton workItem={workItem} />
+                  <span className="text-[0.65rem] font-bold tracking-wide text-slate-600 uppercase">
+                    {workItem.stateLabel}
+                  </span>
+                </div>
               </div>
               {workItem.sessionId !== null && workItem.sessionId !== "" && (
                 <p

--- a/apps/harness/test/jobs-card-no-polling.test.ts
+++ b/apps/harness/test/jobs-card-no-polling.test.ts
@@ -2,19 +2,41 @@ import { readFileSync } from "node:fs"
 import { join } from "node:path"
 import { describe, expect, test } from "bun:test"
 
+const jobsCardSource = () => {
+  const source = readFileSync(
+    join(import.meta.dir, "../src/routes/index.tsx"),
+    "utf8",
+  )
+  const jobsCardStart = source.indexOf("function JobsCard()")
+  expect(jobsCardStart).toBeGreaterThan(-1)
+  const jobsCardEnd = source.indexOf("function JobsCardSkeleton()")
+  expect(jobsCardEnd).toBeGreaterThan(jobsCardStart)
+  return {
+    source,
+    jobsCard: source.slice(jobsCardStart, jobsCardEnd),
+  }
+}
+
 describe("JobsCard live updates", () => {
   test("does not poll workItems on a one-second interval", () => {
-    const source = readFileSync(
-      join(import.meta.dir, "../src/routes/index.tsx"),
-      "utf8",
-    )
-    const jobsCardStart = source.indexOf("function JobsCard()")
-    expect(jobsCardStart).toBeGreaterThan(-1)
-    const jobsCardEnd = source.indexOf("function JobsCardSkeleton()")
-    expect(jobsCardEnd).toBeGreaterThan(jobsCardStart)
-    const jobsCard = source.slice(jobsCardStart, jobsCardEnd)
+    const { source, jobsCard } = jobsCardSource()
     expect(jobsCard).not.toContain("refetchInterval")
     expect(jobsCard).not.toContain("1_000")
     expect(source).toContain("followRepositoryWorkItemsLive")
+  })
+
+  test("shows issue number with title and top-right pause control", () => {
+    const { jobsCard } = jobsCardSource()
+    expect(jobsCard).not.toContain("Issue #")
+    expect(jobsCard).toContain("#{workItem.githubIssueNumber}")
+    expect(jobsCard).toContain("issueTitle")
+    expect(jobsCard).toContain("issuesQuery(repository.id)")
+    expect(jobsCard).toContain("title={issueIdentity}")
+    const pauseIndex = jobsCard.indexOf(
+      "<WorkItemPauseButton workItem={workItem} />",
+    )
+    const stateLabelIndex = jobsCard.indexOf("{workItem.stateLabel}")
+    expect(pauseIndex).toBeGreaterThan(-1)
+    expect(stateLabelIndex).toBeGreaterThan(pauseIndex)
   })
 })


### PR DESCRIPTION
## Summary
- Show `#N` plus the stored GitHub issue title on each JobsCard row (no `Issue` prefix)
- Move pause/start into the top-right header cluster beside the lifecycle state label
- Fall back to `#N` only when the issue title is not in local issue data

Closes #197

## Test plan
- [ ] Open the harness jobs list with active work items
- [ ] Confirm each row shows `#N · <title>` (or `#N` if title missing)
- [ ] Confirm long titles truncate and the full identity is available via tooltip
- [ ] Confirm pause/start is top-right and still works for non-terminal jobs
- [ ] Confirm terminal jobs hide the control and the lifecycle state label remains visible
- [ ] `bunx nx test harness` / lint / typecheck as applicable