### PR TITLE
fix: make PR check confirmation deterministic

### DIFF
--- a/packages/work-item-lifecycle/src/lib/work-item-lifecycle.ts
+++ b/packages/work-item-lifecycle/src/lib/work-item-lifecycle.ts
@@ -795,7 +795,7 @@ export const makeWorkItemLifecycleLive = (
              WHERE work_item_id = ?
                AND step = 'watch_pr_status_checks'
                AND status = 'succeeded'
-             ORDER BY finished_at DESC
+             ORDER BY finished_at DESC, rowid DESC
              LIMIT 1`,
               [workItemId],
             )

--- a/packages/work-item-lifecycle/test/work-item-lifecycle.spec.ts
+++ b/packages/work-item-lifecycle/test/work-item-lifecycle.spec.ts
@@ -1306,6 +1306,14 @@ describe("WorkItemLifecycle", () => {
             )
           }
 
+          yield* sql.unsafe(
+            `UPDATE step_run
+             SET finished_at = ?
+             WHERE work_item_id = ?
+               AND step = 'watch_pr_status_checks'
+               AND status = 'succeeded'`,
+            [watchStartedAt, created.id],
+          )
           yield* sql.unsafe(`UPDATE job_queue SET available_at = 0`)
           const afterGrace = yield* claimAndRunPending
           expect(afterGrace._tag).toBe("processed")


### PR DESCRIPTION
## Why

PR status-check confirmation could become flaky when multiple successful watch Step Runs finished in the same millisecond. The previous-poll lookup ordered only by `finished_at`, so SQLite could return an older poll without the confirmation marker and unnecessarily restart the confirmation sequence.

## What Changed

- Use `rowid DESC` to deterministically select the newest Step Run when `finished_at` timestamps tie.
- Force tied completion timestamps in the regression test so this ordering requirement remains covered.

## Verification

The focused `no_checks` grace-period regression passed 100 consecutive runs after reproducing 41 failures in 100 runs before the fix.
