### PR TITLE
fix(harness): show Started time under session id without repeated title

### DIFF
--- a/apps/harness/src/live-duration.ts
+++ b/apps/harness/src/live-duration.ts
@@ -34,17 +34,18 @@ export function formatDuration(ms: number): string {
   return remainingMinutes === 0 ? `${hours}h` : `${hours}h ${remainingMinutes}m`
 }
 
-/** Formats job start time as a relative phrase, e.g. "15 min ago". */
+/** Formats job start time as a relative phrase, e.g. "Started 15 min ago". */
 export function formatStartedAgo(iso: string, nowMs = Date.now()): string {
   const elapsedMs = Math.max(0, nowMs - new Date(iso).getTime())
   const seconds = Math.floor(elapsedMs / 1000)
-  if (seconds < 60) return "just now"
+  if (seconds < 60) return "Started just now"
   const minutes = Math.floor(seconds / 60)
-  if (minutes < 60) return `${minutes} min ago`
+  if (minutes < 60) return `Started ${minutes} min ago`
   const hours = Math.floor(minutes / 60)
-  if (hours < 24) return hours === 1 ? "1 hour ago" : `${hours} hours ago`
+  if (hours < 24)
+    return hours === 1 ? "Started 1 hour ago" : `Started ${hours} hours ago`
   const days = Math.floor(hours / 24)
-  return days === 1 ? "1 day ago" : `${days} days ago`
+  return days === 1 ? "Started 1 day ago" : `Started ${days} days ago`
 }
 
 /** Local wall-clock tick for animating live durations and relative ages. */

--- a/apps/harness/src/routes/index.tsx
+++ b/apps/harness/src/routes/index.tsx
@@ -1736,11 +1736,8 @@ function WorkItemLifecycleStatus({
       }
     >
       <div className="flex flex-wrap items-center justify-between gap-2">
-        <span className="text-xs font-semibold text-slate-700">
-          {workItem.stateLabel}
-          <span className="ml-1.5 font-normal text-slate-500">
-            {formatStartedAgo(workItem.createdAt, nowMs)}
-          </span>
+        <span className="text-xs font-normal text-slate-500">
+          {formatStartedAgo(workItem.createdAt, nowMs)}
         </span>
         <span
           className={`rounded-full px-2 py-0.5 text-[0.6rem] font-bold tracking-wide uppercase ${

--- a/apps/harness/test/live-duration.test.ts
+++ b/apps/harness/test/live-duration.test.ts
@@ -96,10 +96,14 @@ describe("liveDurationMs", () => {
 describe("formatStartedAgo", () => {
   test("advances relative age as wall clock moves without refetch", () => {
     const createdAt = new Date(1_000_000).toISOString()
-    expect(formatStartedAgo(createdAt, 1_000_000 + 30_000)).toBe("just now")
-    expect(formatStartedAgo(createdAt, 1_000_000 + 90_000)).toBe("1 min ago")
+    expect(formatStartedAgo(createdAt, 1_000_000 + 30_000)).toBe(
+      "Started just now",
+    )
+    expect(formatStartedAgo(createdAt, 1_000_000 + 90_000)).toBe(
+      "Started 1 min ago",
+    )
     expect(formatStartedAgo(createdAt, 1_000_000 + 15 * 60_000)).toBe(
-      "15 min ago",
+      "Started 15 min ago",
     )
   })
 })


### PR DESCRIPTION
## Summary

- Remove the redundant job/section title under the session id on the job detail lifecycle line.
- Show a static relative start phrase instead (`Started … ago` / `Started just now`).
- Keep the main section title, status chips, and queue/status badges unchanged.

Closes #201

## Test plan

- [x] `bunx nx run harness:test -- test/live-duration.test.ts test/jobs-card-no-polling.test.ts`
- [x] `bunx nx run harness:lint`
- [x] `bunx nx run harness:typecheck`
- [ ] Manually confirm job detail shows only `Started … ago` under the session id, with no repeated section title