### PR TITLE
feat: limit concurrent Work Items with Worker Slots

### DIFF
--- a/apps/harness/src/routes/__root.tsx
+++ b/apps/harness/src/routes/__root.tsx
@@ -39,6 +39,7 @@ const configQuery = {
         reviewModel: true,
         reviewVariant: true,
         maxConcurrentOpencodeSessions: true,
+        maxConcurrentWorkItems: true,
       },
     })
     return result.config
@@ -124,6 +125,7 @@ function SettingsButton() {
   const [reviewVariant, setReviewVariant] = useState("")
   const [maxConcurrentOpencodeSessions, setMaxConcurrentOpencodeSessions] =
     useState("2")
+  const [maxConcurrentWorkItems, setMaxConcurrentWorkItems] = useState("5")
   useEffect(() => {
     if (dialogOpen && config.data) {
       setDefaultModel(config.data.defaultModel)
@@ -133,6 +135,7 @@ function SettingsButton() {
       setMaxConcurrentOpencodeSessions(
         String(config.data.maxConcurrentOpencodeSessions),
       )
+      setMaxConcurrentWorkItems(String(config.data.maxConcurrentWorkItems))
     }
   }, [config.data, dialogOpen])
   const updateConfig = useMutation({
@@ -142,6 +145,7 @@ function SettingsButton() {
       reviewModel: string | null
       reviewVariant: string | null
       maxConcurrentOpencodeSessions: number
+      maxConcurrentWorkItems: number
     }) =>
       graphql.mutation({
         updateConfig: {
@@ -151,6 +155,7 @@ function SettingsButton() {
           reviewModel: true,
           reviewVariant: true,
           maxConcurrentOpencodeSessions: true,
+          maxConcurrentWorkItems: true,
         },
       }),
     onSuccess: ({ updateConfig: updatedConfig }) => {
@@ -176,6 +181,7 @@ function SettingsButton() {
       setMaxConcurrentOpencodeSessions(
         String(config.data.maxConcurrentOpencodeSessions),
       )
+      setMaxConcurrentWorkItems(String(config.data.maxConcurrentWorkItems))
     }
     updateConfig.reset()
     dialogRef.current?.showModal()
@@ -183,13 +189,15 @@ function SettingsButton() {
 
   const saveSettings = (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault()
-    const parsedMax = Number(maxConcurrentOpencodeSessions)
+    const parsedMaxSessions = Number(maxConcurrentOpencodeSessions)
+    const parsedMaxWorkItems = Number(maxConcurrentWorkItems)
     updateConfig.mutate({
       defaultModel,
       defaultVariant,
       reviewModel: reviewModel.trim() === "" ? null : reviewModel,
       reviewVariant: reviewVariant.trim() === "" ? null : reviewVariant,
-      maxConcurrentOpencodeSessions: parsedMax,
+      maxConcurrentOpencodeSessions: parsedMaxSessions,
+      maxConcurrentWorkItems: parsedMaxWorkItems,
     })
   }
 
@@ -364,6 +372,27 @@ function SettingsButton() {
                     Caps how many OpenCode lifecycle processes run at once
                     (default 2). Non-OpenCode steps and model listing are not
                     counted.
+                  </span>
+                </label>
+
+                <label className="grid min-w-0 gap-1.5 text-sm font-semibold">
+                  Max concurrent Work Items
+                  <input
+                    className="w-full min-w-0 rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm font-normal outline-none focus:border-blue-500 focus:ring-2 focus:ring-blue-100"
+                    name="maxConcurrentWorkItems"
+                    type="number"
+                    min={1}
+                    step={1}
+                    required
+                    value={maxConcurrentWorkItems}
+                    onChange={(event) =>
+                      setMaxConcurrentWorkItems(event.target.value)
+                    }
+                  />
+                  <span className="text-xs font-normal text-slate-500">
+                    Caps how many Work Items may be Admitted at once (Worker
+                    Slots, default 5). Extra Implement requests wait for a free
+                    slot.
                   </span>
                 </label>
               </>

--- a/apps/harness/src/routes/index.tsx
+++ b/apps/harness/src/routes/index.tsx
@@ -181,6 +181,7 @@ type WorkItemStatus =
   | "COMPLETE"
   | "ABANDONED"
   | "NEEDS_HUMAN"
+  | "WAITING_FOR_WORKER_SLOT"
 
 type WorkItem = {
   id: string
@@ -1752,7 +1753,9 @@ function WorkItemLifecycleStatus({
                   ? "bg-slate-200 text-slate-600"
                   : status === "NEEDS_HUMAN"
                     ? "bg-amber-100 text-amber-800"
-                    : "bg-blue-100 text-blue-700"
+                    : status === "WAITING_FOR_WORKER_SLOT"
+                      ? "bg-violet-100 text-violet-800"
+                      : "bg-blue-100 text-blue-700"
           }`}
         >
           {workItem.statusLabel}
@@ -1787,7 +1790,13 @@ function WorkItemLifecycleStatus({
         </ol>
       )}
       {workItem.statusMessage !== null && (
-        <p className="mt-1.5 mb-0 text-xs text-red-700">
+        <p
+          className={`mt-1.5 mb-0 text-xs ${
+            status === "WAITING_FOR_WORKER_SLOT"
+              ? "text-violet-800"
+              : "text-red-700"
+          }`}
+        >
           {workItem.statusMessage}
         </p>
       )}

--- a/apps/harness/src/server/job-worker.ts
+++ b/apps/harness/src/server/job-worker.ts
@@ -481,14 +481,15 @@ const runLifecycleClaimLoop = (
         nextOrphanRecoveryAt = now + Duration.toMillis(orphanRecoveryInterval)
       }
 
-      const maxSessions = yield* db.getConfig.pipe(
-        Effect.map((config) =>
-          Math.max(1, config.maxConcurrentOpencodeSessions),
-        ),
-        Effect.orElseSucceed(() => 2),
+      const maxConcurrentStepRuns = yield* db.getConfig.pipe(
+        Effect.map((config) => {
+          const maxWorkItems = Math.max(1, config.maxConcurrentWorkItems)
+          const maxSessions = Math.max(1, config.maxConcurrentOpencodeSessions)
+          // Fiber budget so Worker Slot admission and non-OpenCode steps are not undercut.
+          return Math.max(maxWorkItems, maxSessions * 2)
+        }),
+        Effect.orElseSucceed(() => 5),
       )
-      // Headroom so non-OpenCode steps are not fully starved when OpenCode is saturated.
-      const maxConcurrentStepRuns = maxSessions * 2
       const active = yield* Ref.get(activeRuns)
       if (active >= maxConcurrentStepRuns) {
         yield* sleepBusy(undefined).pipe(Effect.asVoid)

--- a/apps/harness/test/job-worker.test.ts
+++ b/apps/harness/test/job-worker.test.ts
@@ -230,6 +230,7 @@ const queueLayer = (
       listWorkItemsForIssue: unused,
       listWorkItemsForRepository: () => Effect.succeed([]),
       continueAfterHumanPrOutcome: unused,
+      admitWaitingWorkItems: Effect.succeed(0),
     }),
   )
 
@@ -1415,6 +1416,7 @@ describe("Job worker", () => {
       listWorkItemsForIssue: unused,
       listWorkItemsForRepository: () => Effect.succeed([]),
       continueAfterHumanPrOutcome: unused,
+      admitWaitingWorkItems: Effect.succeed(0),
     })
 
     await Effect.runPromise(
@@ -1509,6 +1511,7 @@ describe("Job worker", () => {
       listWorkItemsForIssue: unused,
       listWorkItemsForRepository: () => Effect.succeed([]),
       continueAfterHumanPrOutcome: unused,
+      admitWaitingWorkItems: Effect.succeed(0),
     })
     // Block Keymaxxer so auto-heal cannot finish during startup.
     const blockedKeymaxxer = Layer.succeed(KeymaxxerService, {
@@ -1637,6 +1640,7 @@ describe("Job worker", () => {
       listWorkItemsForIssue: unused,
       listWorkItemsForRepository: () => Effect.succeed([]),
       continueAfterHumanPrOutcome: unused,
+      admitWaitingWorkItems: Effect.succeed(0),
     })
 
     await Effect.runPromise(
@@ -1821,6 +1825,7 @@ describe("Job worker", () => {
       listWorkItemsForIssue: unused,
       listWorkItemsForRepository: () => Effect.succeed([]),
       continueAfterHumanPrOutcome: unused,
+      admitWaitingWorkItems: Effect.succeed(0),
     })
 
     await Effect.runPromise(
@@ -1926,6 +1931,7 @@ describe("Job worker", () => {
       listWorkItemsForIssue: unused,
       listWorkItemsForRepository: () => Effect.succeed([]),
       continueAfterHumanPrOutcome: unused,
+      admitWaitingWorkItems: Effect.succeed(0),
     })
 
     await Effect.runPromise(

--- a/packages/db-schema/drizzle/20260717190000_max_concurrent_work_items/migration.sql
+++ b/packages/db-schema/drizzle/20260717190000_max_concurrent_work_items/migration.sql
@@ -1,0 +1,11 @@
+ALTER TABLE `config` ADD `max_concurrent_work_items` integer DEFAULT 5 NOT NULL;--> statement-breakpoint
+ALTER TABLE `work_item` ADD `waiting_since` integer;--> statement-breakpoint
+ALTER TABLE `work_item` ADD `holds_worker_slot` integer DEFAULT false NOT NULL;--> statement-breakpoint
+UPDATE `work_item`
+SET `holds_worker_slot` = 1
+WHERE `state` NOT IN ('complete', 'failed', 'abandoned', 'needs_human')
+  AND EXISTS (
+    SELECT 1 FROM `step_run`
+    WHERE `step_run`.`work_item_id` = `work_item`.`id`
+      AND `step_run`.`status` IN ('queued', 'running')
+  );

--- a/packages/db-schema/src/schema.ts
+++ b/packages/db-schema/src/schema.ts
@@ -49,6 +49,7 @@ export const config = snakeCase.table("config", {
   maxConcurrentOpencodeSessions: integer({ mode: "number" })
     .notNull()
     .default(2),
+  maxConcurrentWorkItems: integer({ mode: "number" }).notNull().default(5),
   createdAt: integer({ mode: "number" })
     .notNull()
     .$defaultFn(() => Date.now()),
@@ -224,6 +225,15 @@ export const workItem = snakeCase.table(
     }).notNull(),
     stateReadyAt: integer({ mode: "number" }).notNull(),
     paused: integer({ mode: "boolean" }).notNull().default(false),
+    /**
+     * When set, the Work Item is Waiting for Worker Slot (FIFO by this timestamp).
+     * Null when not waiting.
+     */
+    waitingSince: integer({ mode: "number" }),
+    /**
+     * Whether this Work Item currently occupies a Worker Slot (Admitted).
+     */
+    holdsWorkerSlot: integer({ mode: "boolean" }).notNull().default(false),
     /**
      * When set, successful advancement into this Lifecycle Step pauses the Work
      * Item (no Step Run enqueued) so the operator can inspect local work.

--- a/packages/db-service/src/lib/db-service.ts
+++ b/packages/db-service/src/lib/db-service.ts
@@ -351,8 +351,9 @@ export const DbServiceLive = Layer.effect(
           .unsafe(
             `INSERT OR IGNORE INTO config (
                id, default_model, default_variant, review_model, review_variant,
-               max_concurrent_opencode_sessions, created_at, updated_at
-             ) VALUES ('default', 'opencode/deepseek-v4-flash-free', 'low', NULL, NULL, 2, ?, ?)`,
+               max_concurrent_opencode_sessions, max_concurrent_work_items,
+               created_at, updated_at
+             ) VALUES ('default', 'opencode/deepseek-v4-flash-free', 'low', NULL, NULL, 2, 5, ?, ?)`,
             [now, now],
           )
           .pipe(Effect.mapError(toDatabaseError))
@@ -360,7 +361,7 @@ export const DbServiceLive = Layer.effect(
         const rows = yield* sql
           .unsafe(
             `SELECT default_model, default_variant, review_model, review_variant,
-                    max_concurrent_opencode_sessions
+                    max_concurrent_opencode_sessions, max_concurrent_work_items
              FROM config WHERE id = 'default'`,
           )
           .pipe(Effect.mapError(toDatabaseError))
@@ -371,6 +372,7 @@ export const DbServiceLive = Layer.effect(
               review_model: string | null
               review_variant: string | null
               max_concurrent_opencode_sessions: number
+              max_concurrent_work_items: number
             }
           | undefined
         if (!row) {
@@ -384,6 +386,7 @@ export const DbServiceLive = Layer.effect(
           reviewModel: row.review_model,
           reviewVariant: row.review_variant,
           maxConcurrentOpencodeSessions: row.max_concurrent_opencode_sessions,
+          maxConcurrentWorkItems: row.max_concurrent_work_items,
         }
       },
     )
@@ -423,29 +426,42 @@ export const DbServiceLive = Layer.effect(
         }
         const maxConcurrentOpencodeSessions =
           input.maxConcurrentOpencodeSessions
+        if (
+          !Number.isSafeInteger(input.maxConcurrentWorkItems) ||
+          input.maxConcurrentWorkItems < 1
+        ) {
+          return yield* new InvalidConfigInputError({
+            field: "maxConcurrentWorkItems",
+            message: "maxConcurrentWorkItems must be a positive integer",
+          })
+        }
+        const maxConcurrentWorkItems = input.maxConcurrentWorkItems
 
         const now = Date.now()
         const rows = yield* sql
           .unsafe(
             `INSERT INTO config (
                id, default_model, default_variant, review_model, review_variant,
-               max_concurrent_opencode_sessions, created_at, updated_at
-             ) VALUES ('default', ?, ?, ?, ?, ?, ?, ?)
+               max_concurrent_opencode_sessions, max_concurrent_work_items,
+               created_at, updated_at
+             ) VALUES ('default', ?, ?, ?, ?, ?, ?, ?, ?)
              ON CONFLICT (id) DO UPDATE SET
                default_model = excluded.default_model,
                default_variant = excluded.default_variant,
                review_model = excluded.review_model,
                review_variant = excluded.review_variant,
                max_concurrent_opencode_sessions = excluded.max_concurrent_opencode_sessions,
+               max_concurrent_work_items = excluded.max_concurrent_work_items,
                updated_at = excluded.updated_at
              RETURNING default_model, default_variant, review_model, review_variant,
-                       max_concurrent_opencode_sessions`,
+                       max_concurrent_opencode_sessions, max_concurrent_work_items`,
             [
               defaultModel,
               defaultVariant,
               reviewModel,
               reviewVariant,
               maxConcurrentOpencodeSessions,
+              maxConcurrentWorkItems,
               now,
               now,
             ],
@@ -458,6 +474,7 @@ export const DbServiceLive = Layer.effect(
               review_model: string | null
               review_variant: string | null
               max_concurrent_opencode_sessions: number
+              max_concurrent_work_items: number
             }
           | undefined
         if (!row) {
@@ -471,6 +488,7 @@ export const DbServiceLive = Layer.effect(
           reviewModel: row.review_model,
           reviewVariant: row.review_variant,
           maxConcurrentOpencodeSessions: row.max_concurrent_opencode_sessions,
+          maxConcurrentWorkItems: row.max_concurrent_work_items,
         }
       })
 

--- a/packages/db-service/src/lib/errors.ts
+++ b/packages/db-service/src/lib/errors.ts
@@ -58,6 +58,7 @@ export class InvalidConfigInputError extends Data.TaggedError(
     | "reviewModel"
     | "reviewVariant"
     | "maxConcurrentOpencodeSessions"
+    | "maxConcurrentWorkItems"
   readonly message: string
 }> {}
 

--- a/packages/db-service/src/lib/test-fixtures.ts
+++ b/packages/db-service/src/lib/test-fixtures.ts
@@ -36,6 +36,7 @@ export const stubDbService = (
     reviewModel: null,
     reviewVariant: null,
     maxConcurrentOpencodeSessions: 2,
+    maxConcurrentWorkItems: 5,
   }),
   updateConfig: unused,
   addRepository: unused,

--- a/packages/db-service/src/lib/types.ts
+++ b/packages/db-service/src/lib/types.ts
@@ -44,6 +44,7 @@ export interface ConfigRecord {
   readonly reviewModel: string | null
   readonly reviewVariant: string | null
   readonly maxConcurrentOpencodeSessions: number
+  readonly maxConcurrentWorkItems: number
 }
 
 export interface UpdateConfigInput {
@@ -52,6 +53,7 @@ export interface UpdateConfigInput {
   readonly reviewModel: string | null
   readonly reviewVariant: string | null
   readonly maxConcurrentOpencodeSessions: number
+  readonly maxConcurrentWorkItems: number
 }
 
 export interface StoreIssueInput {

--- a/packages/db-service/test/db-service.spec.ts
+++ b/packages/db-service/test/db-service.spec.ts
@@ -52,6 +52,7 @@ describe("DbService", () => {
             reviewModel: null,
             reviewVariant: null,
             maxConcurrentOpencodeSessions: 2,
+            maxConcurrentWorkItems: 5,
           })
 
           expect(
@@ -61,6 +62,7 @@ describe("DbService", () => {
               reviewModel: "  anthropic/claude-opus-4-6  ",
               reviewVariant: "  max  ",
               maxConcurrentOpencodeSessions: 4,
+              maxConcurrentWorkItems: 5,
             }),
           ).toEqual({
             defaultModel: "anthropic/claude-sonnet-4-5",
@@ -68,6 +70,7 @@ describe("DbService", () => {
             reviewModel: "anthropic/claude-opus-4-6",
             reviewVariant: "max",
             maxConcurrentOpencodeSessions: 4,
+            maxConcurrentWorkItems: 5,
           })
           expect(yield* db.getConfig).toEqual({
             defaultModel: "anthropic/claude-sonnet-4-5",
@@ -75,6 +78,7 @@ describe("DbService", () => {
             reviewModel: "anthropic/claude-opus-4-6",
             reviewVariant: "max",
             maxConcurrentOpencodeSessions: 4,
+            maxConcurrentWorkItems: 5,
           })
         }),
       ))
@@ -90,6 +94,7 @@ describe("DbService", () => {
               reviewModel: null,
               reviewVariant: null,
               maxConcurrentOpencodeSessions: 2,
+              maxConcurrentWorkItems: 5,
             }),
           )
           expect(error).toBeInstanceOf(InvalidConfigInputError)
@@ -108,11 +113,35 @@ describe("DbService", () => {
                 reviewModel: null,
                 reviewVariant: null,
                 maxConcurrentOpencodeSessions: value,
+                maxConcurrentWorkItems: 5,
               }),
             )
             expect(error).toBeInstanceOf(InvalidConfigInputError)
             expect(error).toMatchObject({
               field: "maxConcurrentOpencodeSessions",
+            })
+          }
+        }),
+      ))
+
+    it("rejects non-positive max concurrent Work Items", () =>
+      runTest(
+        Effect.gen(function* () {
+          const db = yield* DbService
+          for (const value of [0, -1, 1.5, Number.NaN]) {
+            const error = yield* Effect.flip(
+              db.updateConfig({
+                defaultModel: "anthropic/claude-sonnet-4-5",
+                defaultVariant: "high",
+                reviewModel: null,
+                reviewVariant: null,
+                maxConcurrentOpencodeSessions: 2,
+                maxConcurrentWorkItems: value,
+              }),
+            )
+            expect(error).toBeInstanceOf(InvalidConfigInputError)
+            expect(error).toMatchObject({
+              field: "maxConcurrentWorkItems",
             })
           }
         }),

--- a/packages/graphql-api/src/lib/graphql-api.ts
+++ b/packages/graphql-api/src/lib/graphql-api.ts
@@ -43,6 +43,7 @@ import {
   RetryNotEligibleError,
   type StepRunRecord,
   UnfinishedWorkItemExistsError,
+  WAITING_FOR_WORKER_SLOT_MESSAGE,
   WorkItemLifecycle,
   WorkItemLifecycleDatabaseError,
   WorkItemNotFoundError,
@@ -84,6 +85,7 @@ type UpdateConfigArgs = {
     reviewModel?: string | null
     reviewVariant?: string | null
     maxConcurrentOpencodeSessions: number
+    maxConcurrentWorkItems: number
   }
 }
 
@@ -160,6 +162,7 @@ type WorkItemStatus =
   | "complete"
   | "abandoned"
   | "needs_human"
+  | "waiting_for_worker_slot"
 
 type LifecyclePhase =
   | Exclude<
@@ -206,6 +209,7 @@ const latestStepRun = (workItem: WorkItemRecord): StepRunRecord | undefined =>
   workItem.stepRuns.at(-1)
 
 const workItemStatus = (workItem: WorkItemRecord): WorkItemStatus => {
+  if (workItem.waitingSince != null) return "waiting_for_worker_slot"
   if (isTerminalWorkItemState(workItem.state)) return workItem.state
   return latestStepRun(workItem)?.status ?? "queued"
 }
@@ -677,11 +681,15 @@ export const createGraphqlApi = (
           statusLabel: (workItem: WorkItemRecord) =>
             statusLabel(workItemStatus(workItem)),
           statusMessage: (workItem: WorkItemRecord) =>
-            workItem.failureMessage ?? latestStepRun(workItem)?.reasonMessage,
+            workItem.waitingSince != null
+              ? WAITING_FOR_WORKER_SLOT_MESSAGE
+              : (workItem.failureMessage ??
+                latestStepRun(workItem)?.reasonMessage),
           paused: (workItem: WorkItemRecord) => workItem.paused,
           canRetry: (workItem: WorkItemRecord) => {
             const latestStatus = latestStepRun(workItem)?.status
             return (
+              workItem.waitingSince == null &&
               !workItem.paused &&
               !isTerminalWorkItemState(workItem.state) &&
               (latestStatus === "failed" || latestStatus === "interrupted")
@@ -753,14 +761,25 @@ export const createGraphqlApi = (
               Effect.result(
                 Effect.gen(function* () {
                   const db = yield* DbService
-                  return yield* db.updateConfig({
+                  const updated = yield* db.updateConfig({
                     defaultModel: args.input.defaultModel,
                     defaultVariant: args.input.defaultVariant,
                     reviewModel: args.input.reviewModel ?? null,
                     reviewVariant: args.input.reviewVariant ?? null,
                     maxConcurrentOpencodeSessions:
                       args.input.maxConcurrentOpencodeSessions,
+                    maxConcurrentWorkItems: args.input.maxConcurrentWorkItems,
                   })
+                  const lifecycle = yield* WorkItemLifecycle
+                  yield* lifecycle.admitWaitingWorkItems.pipe(
+                    Effect.catch((error) =>
+                      Effect.logError(
+                        "Failed to admit waiters after config update",
+                        { error: String(error) },
+                      ),
+                    ),
+                  )
+                  return updated
                 }),
               ),
             )

--- a/packages/graphql-api/test/graphql-api.test.ts
+++ b/packages/graphql-api/test/graphql-api.test.ts
@@ -43,6 +43,7 @@ const config = {
   reviewModel: null as string | null,
   reviewVariant: null as string | null,
   maxConcurrentOpencodeSessions: 2,
+  maxConcurrentWorkItems: 5,
 }
 
 const issue = {
@@ -199,6 +200,7 @@ const makeRuntime = (
     listWorkItemsForIssue: unused,
     listWorkItemsForRepository: unused,
     continueAfterHumanPrOutcome: unused,
+    admitWaitingWorkItems: Effect.succeed(0),
     ...lifecycleOverrides,
   }
   return ManagedRuntime.make(
@@ -921,7 +923,7 @@ describe("GraphQL API", () => {
   test("reads and updates config", async () => {
     const queryResponse = await createGraphqlApi(runtime).fetch(
       graphqlRequest({
-        query: `query { config { defaultModel defaultVariant reviewModel reviewVariant maxConcurrentOpencodeSessions } }`,
+        query: `query { config { defaultModel defaultVariant reviewModel reviewVariant maxConcurrentOpencodeSessions maxConcurrentWorkItems } }`,
       }),
     )
     expect(await queryResponse.json()).toEqual({ data: { config } })
@@ -930,7 +932,7 @@ describe("GraphQL API", () => {
       graphqlRequest({
         query: `mutation UpdateConfig($input: UpdateConfigInput!) {
           updateConfig(input: $input) {
-            defaultModel defaultVariant reviewModel reviewVariant maxConcurrentOpencodeSessions
+            defaultModel defaultVariant reviewModel reviewVariant maxConcurrentOpencodeSessions maxConcurrentWorkItems
           }
         }`,
         variables: {
@@ -940,6 +942,7 @@ describe("GraphQL API", () => {
             reviewModel: "anthropic/claude-opus-4-6",
             reviewVariant: "max",
             maxConcurrentOpencodeSessions: 3,
+            maxConcurrentWorkItems: 7,
           },
         },
       }),
@@ -952,6 +955,7 @@ describe("GraphQL API", () => {
           reviewModel: "anthropic/claude-opus-4-6",
           reviewVariant: "max",
           maxConcurrentOpencodeSessions: 3,
+          maxConcurrentWorkItems: 7,
         },
       },
     })

--- a/packages/graphql-schema/schema.graphql
+++ b/packages/graphql-schema/schema.graphql
@@ -14,6 +14,7 @@ type Config {
   reviewModel: String
   reviewVariant: String
   maxConcurrentOpencodeSessions: Int!
+  maxConcurrentWorkItems: Int!
 }
 
 type Repository {
@@ -98,6 +99,7 @@ enum WorkItemStatus {
   COMPLETE
   ABANDONED
   NEEDS_HUMAN
+  WAITING_FOR_WORKER_SLOT
 }
 
 enum LifecyclePhase {
@@ -164,6 +166,7 @@ input UpdateConfigInput {
   reviewModel: String
   reviewVariant: String
   maxConcurrentOpencodeSessions: Int!
+  maxConcurrentWorkItems: Int!
 }
 
 input UpdateRepositorySettingsInput {

--- a/packages/work-item-lifecycle/src/lib/types.ts
+++ b/packages/work-item-lifecycle/src/lib/types.ts
@@ -77,6 +77,12 @@ export interface WorkItemRecord {
   readonly state: WorkItemState
   readonly stateReadyAt: Date
   readonly paused: boolean
+  /**
+   * When set, the Work Item is Waiting for Worker Slot (FIFO by this timestamp).
+   */
+  readonly waitingSince: Date | null
+  /** Whether this Work Item currently occupies a Worker Slot (Admitted). */
+  readonly holdsWorkerSlot: boolean
   /** When set, advancement into this step auto-pauses (no Step Run enqueued). */
   readonly pauseBeforeStep: OperationalLifecycleStep | null
   readonly worktreePath: string | null
@@ -89,6 +95,10 @@ export interface WorkItemRecord {
   readonly stateResidenceMs: number
   readonly stepRuns: readonly StepRunRecord[]
 }
+
+/** Operator-visible message while Waiting for Worker Slot. */
+export const WAITING_FOR_WORKER_SLOT_MESSAGE =
+  "Waiting for a worker slot to become available"
 
 export const WORK_ITEM_LIFECYCLE_QUEUE = "jobs"
 

--- a/packages/work-item-lifecycle/src/lib/work-item-lifecycle.ts
+++ b/packages/work-item-lifecycle/src/lib/work-item-lifecycle.ts
@@ -67,6 +67,8 @@ import {
   makeWorkItemId,
 } from "./types.js"
 
+export { WAITING_FOR_WORKER_SLOT_MESSAGE } from "./types.js"
+
 const formatSqlError = (error: SqlError): string => {
   const parts: string[] = [error.message]
   let current: unknown = error.cause
@@ -209,6 +211,8 @@ type WorkItemRow = {
   readonly state: WorkItemState
   readonly state_ready_at: number
   readonly paused: boolean | number
+  readonly waiting_since: number | null
+  readonly holds_worker_slot: boolean | number
   readonly pause_before_step: OperationalLifecycleStep | null
   readonly worktree_path: string | null
   readonly session_id: string | null
@@ -278,6 +282,11 @@ const toWorkItemRecord = (
   state: row.state,
   stateReadyAt: new Date(row.state_ready_at),
   paused: Boolean(row.paused),
+  waitingSince:
+    row.waiting_since === null || row.waiting_since === undefined
+      ? null
+      : new Date(row.waiting_since),
+  holdsWorkerSlot: Boolean(row.holds_worker_slot),
   pauseBeforeStep: row.pause_before_step,
   worktreePath: row.worktree_path,
   sessionId: row.session_id,
@@ -290,7 +299,8 @@ const toWorkItemRecord = (
 })
 
 const WORK_ITEM_SELECT_COLUMNS = `id, repository_id, github_issue_number, model, variant, review_model,
-                   review_variant, state, state_ready_at, paused, pause_before_step, worktree_path, session_id,
+                   review_variant, state, state_ready_at, paused, waiting_since, holds_worker_slot,
+                   pause_before_step, worktree_path, session_id,
                    github_pull_request_number, failure_code,
                    failure_message, created_at, updated_at`
 
@@ -490,6 +500,14 @@ export interface WorkItemLifecycleShape {
     workItemId: string,
     outcome: HumanPrOutcome,
   ) => Effect.Effect<WorkItemRecord, ContinueAfterHumanPrOutcomeError>
+  /** Admit FIFO waiters up to the current maxConcurrentWorkItems bound. */
+  readonly admitWaitingWorkItems: Effect.Effect<
+    number,
+    | WorkItemLifecycleDatabaseError
+    | EnqueueError
+    | InvalidQueueNameError
+    | DatabaseError
+  >
 }
 
 export class WorkItemLifecycle extends Context.Service<
@@ -718,6 +736,255 @@ export const makeWorkItemLifecycleLive = (
           return rows[0] ?? null
         })
 
+      const countOccupiedWorkerSlots = (): Effect.Effect<
+        number,
+        WorkItemLifecycleDatabaseError
+      > =>
+        Effect.gen(function* () {
+          const rows = (yield* sql
+            .unsafe(
+              `SELECT COUNT(*) AS occupied
+               FROM work_item
+               WHERE holds_worker_slot = 1`,
+            )
+            .pipe(Effect.mapError(toDatabaseError))) as readonly {
+            readonly occupied: number
+          }[]
+          return Number(rows[0]?.occupied ?? 0)
+        })
+
+      const maxWorkerSlots = (): Effect.Effect<
+        number,
+        WorkItemLifecycleDatabaseError | DatabaseError
+      > =>
+        db.getConfig.pipe(
+          Effect.map((config) => Math.max(1, config.maxConcurrentWorkItems)),
+        )
+
+      const encodeStepJob = (stepRunId: string) =>
+        Schema.decodeUnknownEffect(WorkItemStepJob)({
+          _tag: "work-item-step",
+          stepRunId,
+        }).pipe(
+          Effect.mapError(
+            (error) =>
+              new WorkItemLifecycleDatabaseError({
+                message: `Failed to encode work-item-step payload: ${String(error)}`,
+                cause: error,
+              }),
+          ),
+        )
+
+      const enqueueStepRunForWorkItem = (
+        workItemId: string,
+        step: OperationalLifecycleStep,
+        now: number,
+        delay?: Duration.Duration,
+      ): Effect.Effect<
+        void,
+        WorkItemLifecycleDatabaseError | EnqueueError | InvalidQueueNameError
+      > =>
+        Effect.gen(function* () {
+          const nextStepRunId = makeStepRunId()
+          yield* sql
+            .unsafe(
+              `INSERT INTO step_run (
+               id, work_item_id, step, status, queue_job_id, queued_at,
+               started_at, finished_at, reason_code, reason_message,
+               created_at, updated_at
+             ) VALUES (?, ?, ?, 'queued', NULL, ?, NULL, NULL, NULL, NULL, ?, ?)`,
+              [nextStepRunId, workItemId, step, now, now, now],
+            )
+            .pipe(Effect.mapError(toDatabaseError))
+          const payload = yield* encodeStepJob(nextStepRunId)
+          const enqueue =
+            delay === undefined
+              ? queue.enqueue(WORK_ITEM_LIFECYCLE_QUEUE, payload, {
+                  retryLimit: 1,
+                })
+              : queue.enqueueWithDelay(
+                  WORK_ITEM_LIFECYCLE_QUEUE,
+                  payload,
+                  delay,
+                  { retryLimit: 1 },
+                )
+          const jobId = yield* enqueue
+          yield* sql
+            .unsafe(
+              `UPDATE step_run
+             SET queue_job_id = ?, updated_at = ?
+             WHERE id = ?`,
+              [jobId, now, nextStepRunId],
+            )
+            .pipe(Effect.mapError(toDatabaseError))
+        })
+
+      /**
+       * Try to claim a free Worker Slot for this Work Item (must run in a txn).
+       * Returns true if admitted (or already holding), false if marked waiting.
+       */
+      const tryAcquireWorkerSlot = (
+        workItemId: string,
+        now: number,
+      ): Effect.Effect<
+        boolean,
+        WorkItemLifecycleDatabaseError | DatabaseError
+      > =>
+        Effect.gen(function* () {
+          const current = yield* loadWorkItemRow(workItemId)
+          if (!current) {
+            return false
+          }
+          if (current.holds_worker_slot) {
+            yield* sql
+              .unsafe(
+                `UPDATE work_item
+               SET waiting_since = NULL, updated_at = ?
+               WHERE id = ?`,
+                [now, workItemId],
+              )
+              .pipe(Effect.mapError(toDatabaseError))
+            return true
+          }
+          const limit = yield* maxWorkerSlots()
+          const occupied = yield* countOccupiedWorkerSlots()
+          if (occupied < limit) {
+            yield* sql
+              .unsafe(
+                `UPDATE work_item
+               SET holds_worker_slot = 1,
+                   waiting_since = NULL,
+                   updated_at = ?
+               WHERE id = ?`,
+                [now, workItemId],
+              )
+              .pipe(Effect.mapError(toDatabaseError))
+            return true
+          }
+          yield* sql
+            .unsafe(
+              `UPDATE work_item
+             SET holds_worker_slot = 0,
+                 waiting_since = ?,
+                 updated_at = ?
+             WHERE id = ?`,
+              [now, now, workItemId],
+            )
+            .pipe(Effect.mapError(toDatabaseError))
+          return false
+        })
+
+      const admitWaitingWorkItems = Effect.gen(function* () {
+        let admitted = 0
+        // Loop: re-read config and occupancy each admission.
+        for (;;) {
+          const limit = yield* maxWorkerSlots()
+          const occupied = yield* countOccupiedWorkerSlots()
+          if (occupied >= limit) {
+            break
+          }
+          const free = limit - occupied
+          const waiters = (yield* sql
+            .unsafe(
+              `SELECT id, state FROM work_item
+               WHERE waiting_since IS NOT NULL
+                 AND holds_worker_slot = 0
+                 AND paused = 0
+                 AND state NOT IN ('complete', 'failed', 'abandoned')
+               ORDER BY waiting_since ASC, created_at ASC, rowid ASC
+               LIMIT ?`,
+              [free],
+            )
+            .pipe(Effect.mapError(toDatabaseError))) as readonly {
+            readonly id: string
+            readonly state: WorkItemState
+          }[]
+          if (waiters.length === 0) {
+            break
+          }
+
+          const now = yield* Clock.currentTimeMillis
+          for (const waiter of waiters) {
+            const stillFree =
+              (yield* countOccupiedWorkerSlots()) < (yield* maxWorkerSlots())
+            if (!stillFree) {
+              break
+            }
+            if (
+              isTerminalWorkItemState(waiter.state) &&
+              waiter.state !== "needs_human"
+            ) {
+              continue
+            }
+
+            // Needs Human waiters re-acquire for abandon cleanup via abandon()
+            // / Refresh; only operational waiters get a Step Run here.
+            if (waiter.state === "needs_human") {
+              continue
+            }
+
+            const pendingStep = waiter.state as OperationalLifecycleStep
+            const didAdmit = yield* sql
+              .withTransaction(
+                Effect.gen(function* () {
+                  const acquired = yield* tryAcquireWorkerSlot(waiter.id, now)
+                  if (!acquired) {
+                    return false
+                  }
+                  const activeRows = (yield* sql.unsafe(
+                    `SELECT id FROM step_run
+                     WHERE work_item_id = ?
+                       AND status IN ('queued', 'running')
+                     LIMIT 1`,
+                    [waiter.id],
+                  )) as readonly { readonly id: string }[]
+                  if (activeRows[0]) {
+                    return true
+                  }
+                  yield* enqueueStepRunForWorkItem(waiter.id, pendingStep, now)
+                  return true
+                }),
+              )
+              .pipe(
+                Effect.catch((error) => {
+                  if (
+                    error instanceof WorkItemLifecycleDatabaseError ||
+                    error instanceof EnqueueError ||
+                    error instanceof InvalidQueueNameError
+                  ) {
+                    return Effect.fail(error)
+                  }
+                  if (
+                    typeof error === "object" &&
+                    error !== null &&
+                    "_tag" in error &&
+                    (error as { _tag: string })._tag === "SqlError"
+                  ) {
+                    return Effect.fail(toDatabaseError(error as SqlError))
+                  }
+                  return Effect.fail(
+                    new WorkItemLifecycleDatabaseError({
+                      message: `Failed admitting waiter: ${String(error)}`,
+                      cause: error,
+                    }),
+                  )
+                }),
+              )
+            if (didAdmit) {
+              admitted += 1
+              const row = yield* loadWorkItemRow(waiter.id)
+              if (row) {
+                yield* notifyWorkItemsChanged(row.repository_id)
+              }
+            }
+          }
+          if (waiters.length < free) {
+            break
+          }
+        }
+        return admitted
+      })
+
       const revalidateIssue = (
         repositoryId: string,
         githubIssueNumber: number,
@@ -770,20 +1037,6 @@ export const makeWorkItemLifecycleLive = (
 
           return { ok: true as const }
         })
-
-      const encodeStepJob = (stepRunId: string) =>
-        Schema.decodeUnknownEffect(WorkItemStepJob)({
-          _tag: "work-item-step",
-          stepRunId,
-        }).pipe(
-          Effect.mapError(
-            (error) =>
-              new WorkItemLifecycleDatabaseError({
-                message: `Failed to encode work-item-step payload: ${String(error)}`,
-                cause: error,
-              }),
-          ),
-        )
 
       const previousWatchPollNote = (
         workItemId: string,
@@ -1106,6 +1359,8 @@ export const makeWorkItemLifecycleLive = (
                         worktree_path = ?,
                         session_id = ?,
                         github_pull_request_number = ?,
+                        holds_worker_slot = 0,
+                        waiting_since = NULL,
                         updated_at = ?
                    WHERE id = ?`,
                     [
@@ -1127,6 +1382,8 @@ export const makeWorkItemLifecycleLive = (
                         worktree_path = ?,
                         session_id = ?,
                         github_pull_request_number = ?,
+                        holds_worker_slot = 0,
+                        waiting_since = NULL,
                         updated_at = ?
                    WHERE id = ?`,
                     [
@@ -1148,6 +1405,8 @@ export const makeWorkItemLifecycleLive = (
                         worktree_path = ?,
                         session_id = ?,
                         github_pull_request_number = ?,
+                        holds_worker_slot = 0,
+                        waiting_since = NULL,
                         updated_at = ?
                    WHERE id = ?`,
                     [
@@ -1186,6 +1445,31 @@ export const makeWorkItemLifecycleLive = (
                    SET state = ?,
                        state_ready_at = ?,
                        paused = 1,
+                       holds_worker_slot = 0,
+                       waiting_since = NULL,
+                        worktree_path = ?,
+                        session_id = ?,
+                        github_pull_request_number = ?,
+                        updated_at = ?
+                   WHERE id = ?`,
+                      [
+                        nextStep,
+                        stateReadyAt,
+                        worktreePath,
+                        sessionId,
+                        githubPullRequestNumber,
+                        now,
+                        workItem.id,
+                      ],
+                    )
+                  } else if (stayPaused) {
+                    // Operator Pause while Step Run was draining: release slot.
+                    yield* sql.unsafe(
+                      `UPDATE work_item
+                   SET state = ?,
+                       state_ready_at = ?,
+                       holds_worker_slot = 0,
+                       waiting_since = NULL,
                         worktree_path = ?,
                         session_id = ?,
                         github_pull_request_number = ?,
@@ -1224,36 +1508,11 @@ export const makeWorkItemLifecycleLive = (
                   }
 
                   if (!stayPaused) {
-                    const nextStepRunId = makeStepRunId()
-
-                    yield* sql.unsafe(
-                      `INSERT INTO step_run (
-                     id, work_item_id, step, status, queue_job_id, queued_at,
-                     started_at, finished_at, reason_code, reason_message,
-                     created_at, updated_at
-                   ) VALUES (?, ?, ?, 'queued', NULL, ?, NULL, NULL, NULL, NULL, ?, ?)`,
-                      [nextStepRunId, workItem.id, nextStep, now, now, now],
-                    )
-
-                    const payload = yield* encodeStepJob(nextStepRunId)
-                    const enqueue =
-                      transition?.delay === undefined
-                        ? queue.enqueue(WORK_ITEM_LIFECYCLE_QUEUE, payload, {
-                            retryLimit: 1,
-                          })
-                        : queue.enqueueWithDelay(
-                            WORK_ITEM_LIFECYCLE_QUEUE,
-                            payload,
-                            transition.delay,
-                            { retryLimit: 1 },
-                          )
-                    const jobId = yield* enqueue
-
-                    yield* sql.unsafe(
-                      `UPDATE step_run
-                   SET queue_job_id = ?, updated_at = ?
-                   WHERE id = ?`,
-                      [jobId, now, nextStepRunId],
+                    yield* enqueueStepRunForWorkItem(
+                      workItem.id,
+                      nextStep,
+                      now,
+                      transition?.delay,
                     )
                   }
                 }
@@ -1276,6 +1535,18 @@ export const makeWorkItemLifecycleLive = (
             ),
           )
           yield* notifyWorkItemsChanged(workItem.repository_id)
+          if (!completed.holdsWorkerSlot) {
+            yield* admitWaitingWorkItems.pipe(
+              Effect.catch((error) =>
+                Effect.logError(
+                  "Failed to admit waiters after step completion",
+                  {
+                    error: String(error),
+                  },
+                ),
+              ),
+            )
+          }
           return completed
         })
 
@@ -1312,6 +1583,16 @@ export const makeWorkItemLifecycleLive = (
                   [now, reasonCode, reasonMessage, now, stepRun.id],
                 )
 
+                // Non-terminal failure releases the Worker Slot (no auto-wait).
+                yield* sql.unsafe(
+                  `UPDATE work_item
+                   SET holds_worker_slot = 0,
+                       waiting_since = NULL,
+                       updated_at = ?
+                   WHERE id = ?`,
+                  [now, workItem.id],
+                )
+
                 if (stepRun.queue_job_id !== null) {
                   yield* queue.fail(stepRun.queue_job_id, {
                     retryable: false,
@@ -1332,6 +1613,13 @@ export const makeWorkItemLifecycleLive = (
             ),
           )
           yield* notifyWorkItemsChanged(workItem.repository_id)
+          yield* admitWaitingWorkItems.pipe(
+            Effect.catch((error) =>
+              Effect.logError("Failed to admit waiters after step failure", {
+                error: String(error),
+              }),
+            ),
+          )
           return failed
         })
 
@@ -1371,6 +1659,15 @@ export const makeWorkItemLifecycleLive = (
                   ],
                 )
 
+                yield* sql.unsafe(
+                  `UPDATE work_item
+                   SET holds_worker_slot = 0,
+                       waiting_since = NULL,
+                       updated_at = ?
+                   WHERE id = ?`,
+                  [now, stepRun.work_item_id],
+                )
+
                 if (stepRun.queue_job_id !== null) {
                   yield* queue
                     .acknowledge(stepRun.queue_job_id)
@@ -1381,6 +1678,14 @@ export const makeWorkItemLifecycleLive = (
               }),
             )
             .pipe(Effect.catch(catchTransactionError))
+
+          yield* admitWaitingWorkItems.pipe(
+            Effect.catch((error) =>
+              Effect.logError("Failed to admit waiters after interrupt", {
+                error: String(error),
+              }),
+            ),
+          )
 
           const workItem = yield* loadWorkItemRow(stepRun.work_item_id)
           if (workItem) {
@@ -1737,6 +2042,24 @@ export const makeWorkItemLifecycleLive = (
                     )
                 }
               }
+
+              // Release immediately when no Step Run is running; hold while running.
+              const runningRows = (yield* sql.unsafe(
+                `SELECT id FROM step_run
+                 WHERE work_item_id = ? AND status = 'running'
+                 LIMIT 1`,
+                [workItemId],
+              )) as readonly { readonly id: string }[]
+              if (!runningRows[0]) {
+                yield* sql.unsafe(
+                  `UPDATE work_item
+                   SET holds_worker_slot = 0,
+                       waiting_since = NULL,
+                       updated_at = ?
+                   WHERE id = ?`,
+                  [now, workItemId],
+                )
+              }
             }),
           )
           .pipe(
@@ -1789,6 +2112,15 @@ export const makeWorkItemLifecycleLive = (
           ),
         )
         yield* notifyWorkItemsChanged(paused.repositoryId)
+        if (!paused.holdsWorkerSlot) {
+          yield* admitWaitingWorkItems.pipe(
+            Effect.catch((error) =>
+              Effect.logError("Failed to admit waiters after pause", {
+                error: String(error),
+              }),
+            ),
+          )
+        }
         return paused
       })
 
@@ -1853,6 +2185,7 @@ export const makeWorkItemLifecycleLive = (
                 [workItemId],
               )) as readonly { readonly id: string }[]
               if (activeRows[0]) {
+                // Running Step Run still holds the slot from Pause-while-running.
                 return
               }
 
@@ -1869,29 +2202,12 @@ export const makeWorkItemLifecycleLive = (
                 return
               }
 
-              const nextStepRunId = makeStepRunId()
-              yield* sql.unsafe(
-                `INSERT INTO step_run (
-                 id, work_item_id, step, status, queue_job_id, queued_at,
-                 started_at, finished_at, reason_code, reason_message,
-                 created_at, updated_at
-               ) VALUES (?, ?, ?, 'queued', NULL, ?, NULL, NULL, NULL, NULL, ?, ?)`,
-                [nextStepRunId, workItemId, pendingStep, now, now, now],
-              )
+              const acquired = yield* tryAcquireWorkerSlot(workItemId, now)
+              if (!acquired) {
+                return
+              }
 
-              const payload = yield* encodeStepJob(nextStepRunId)
-              const jobId = yield* queue.enqueue(
-                WORK_ITEM_LIFECYCLE_QUEUE,
-                payload,
-                { retryLimit: 1 },
-              )
-
-              yield* sql.unsafe(
-                `UPDATE step_run
-               SET queue_job_id = ?, updated_at = ?
-               WHERE id = ?`,
-                [jobId, now, nextStepRunId],
-              )
+              yield* enqueueStepRunForWorkItem(workItemId, pendingStep, now)
             }),
           )
           .pipe(
@@ -2019,7 +2335,47 @@ export const makeWorkItemLifecycleLive = (
         }
 
         if (workItem.state === "needs_human") {
-          yield* cleanupNeedsHumanWorktree(workItem)
+          const nowAcquire = yield* Clock.currentTimeMillis
+          const acquired = yield* sql
+            .withTransaction(tryAcquireWorkerSlot(workItemId, nowAcquire))
+            .pipe(
+              Effect.mapError((error): WorkItemLifecycleDatabaseError => {
+                if (error instanceof WorkItemLifecycleDatabaseError) {
+                  return error
+                }
+                if (
+                  typeof error === "object" &&
+                  error !== null &&
+                  "_tag" in error &&
+                  (error as { _tag: string })._tag === "SqlError"
+                ) {
+                  return toDatabaseError(error as SqlError)
+                }
+                return new WorkItemLifecycleDatabaseError({
+                  message: `Failed to acquire Worker Slot for abandon: ${String(error)}`,
+                  cause: error,
+                })
+              }),
+            )
+          if (!acquired) {
+            const waiting = yield* getWorkItem(workItemId).pipe(
+              Effect.catchTag(
+                "WorkItemNotFoundError",
+                (error) =>
+                  new WorkItemLifecycleDatabaseError({
+                    message: `Work Item missing after waiting for abandon: ${error.workItemId}`,
+                    cause: error,
+                  }),
+              ),
+            )
+            yield* notifyWorkItemsChanged(waiting.repositoryId)
+            return waiting
+          }
+          const current = yield* loadWorkItemRow(workItemId)
+          if (!current) {
+            return yield* new WorkItemNotFoundError({ workItemId })
+          }
+          yield* cleanupNeedsHumanWorktree(current)
         } else if (isTerminalWorkItemState(workItem.state)) {
           return yield* new WorkItemTerminalError({
             workItemId,
@@ -2041,6 +2397,8 @@ export const makeWorkItemLifecycleLive = (
                       failure_code = NULL,
                       failure_message = NULL,
                       worktree_path = NULL,
+                      holds_worker_slot = 0,
+                      waiting_since = NULL,
                       updated_at = ?
                   WHERE id = ?
                     AND state = 'needs_human'
@@ -2053,6 +2411,8 @@ export const makeWorkItemLifecycleLive = (
                   : `UPDATE work_item
                   SET state = 'abandoned',
                       state_ready_at = ?,
+                      holds_worker_slot = 0,
+                      waiting_since = NULL,
                       updated_at = ?
                   WHERE id = ?
                     AND state NOT IN ('complete', 'failed', 'abandoned', 'needs_human')
@@ -2178,6 +2538,13 @@ export const makeWorkItemLifecycleLive = (
           ),
         )
         yield* notifyWorkItemsChanged(abandoned.repositoryId)
+        yield* admitWaitingWorkItems.pipe(
+          Effect.catch((error) =>
+            Effect.logError("Failed to admit waiters after abandon", {
+              error: String(error),
+            }),
+          ),
+        )
         return abandoned
       })
 
@@ -2217,7 +2584,6 @@ export const makeWorkItemLifecycleLive = (
         }
 
         const now = yield* Clock.currentTimeMillis
-        const nextStepRunId = makeStepRunId()
 
         yield* sql
           .withTransaction(
@@ -2242,25 +2608,12 @@ export const makeWorkItemLifecycleLive = (
                 })
               }
 
-              yield* sql.unsafe(
-                `INSERT INTO step_run (
-                   id, work_item_id, step, status, queue_job_id, queued_at,
-                   started_at, finished_at, reason_code, reason_message,
-                   created_at, updated_at
-                 ) VALUES (?, ?, 'local_cleanup', 'queued', NULL, ?, NULL, NULL, NULL, NULL, ?, ?)`,
-                [nextStepRunId, workItemId, now, now, now],
-              )
+              const acquired = yield* tryAcquireWorkerSlot(workItemId, now)
+              if (!acquired) {
+                return
+              }
 
-              const payload = yield* encodeStepJob(nextStepRunId)
-              const jobId = yield* queue.enqueue(
-                WORK_ITEM_LIFECYCLE_QUEUE,
-                payload,
-                { retryLimit: 1 },
-              )
-              yield* sql.unsafe(
-                `UPDATE step_run SET queue_job_id = ?, updated_at = ? WHERE id = ?`,
-                [jobId, now, nextStepRunId],
-              )
+              yield* enqueueStepRunForWorkItem(workItemId, "local_cleanup", now)
             }),
           )
           .pipe(
@@ -2472,6 +2825,13 @@ export const makeWorkItemLifecycleLive = (
             )
 
           yield* notifyWorkItemsChanged(workItem.repository_id)
+          yield* admitWaitingWorkItems.pipe(
+            Effect.catch((error) =>
+              Effect.logError("Failed to admit waiters after reset", {
+                error: String(error),
+              }),
+            ),
+          )
           return workItem.id as WorkItemId
         }).pipe(
           Effect.ensuring(
@@ -2555,33 +2915,16 @@ export const makeWorkItemLifecycleLive = (
         }
 
         const now = yield* Clock.currentTimeMillis
-        const nextStepRunId = makeStepRunId()
 
         yield* sql
           .withTransaction(
             Effect.gen(function* () {
-              yield* sql.unsafe(
-                `INSERT INTO step_run (
-                 id, work_item_id, step, status, queue_job_id, queued_at,
-                 started_at, finished_at, reason_code, reason_message,
-                 created_at, updated_at
-               ) VALUES (?, ?, ?, 'queued', NULL, ?, NULL, NULL, NULL, NULL, ?, ?)`,
-                [nextStepRunId, workItemId, pendingStep, now, now, now],
-              )
+              const acquired = yield* tryAcquireWorkerSlot(workItemId, now)
+              if (!acquired) {
+                return
+              }
 
-              const payload = yield* encodeStepJob(nextStepRunId)
-              const jobId = yield* queue.enqueue(
-                WORK_ITEM_LIFECYCLE_QUEUE,
-                payload,
-                { retryLimit: 1 },
-              )
-
-              yield* sql.unsafe(
-                `UPDATE step_run
-               SET queue_job_id = ?, updated_at = ?
-               WHERE id = ?`,
-                [jobId, now, nextStepRunId],
-              )
+              yield* enqueueStepRunForWorkItem(workItemId, pendingStep, now)
 
               yield* sql.unsafe(
                 `UPDATE work_item
@@ -2728,20 +3071,24 @@ export const makeWorkItemLifecycleLive = (
           const reviewVariant =
             repository?.reviewVariant ?? config.reviewVariant ?? variant
           const workItemId = makeWorkItemId()
-          const stepRunId = makeStepRunId()
           const now = yield* Clock.currentTimeMillis
           const step: OperationalLifecycleStep = "create_worktree"
 
           const createdId = yield* sql
             .withTransaction(
               Effect.gen(function* () {
+                const limit = yield* maxWorkerSlots()
+                const occupied = yield* countOccupiedWorkerSlots()
+                const admit = occupied < limit
+
                 yield* sql.unsafe(
                   `INSERT INTO work_item (
                  id, repository_id, github_issue_number, model, variant,
                  review_model, review_variant, state, state_ready_at, paused,
+                 waiting_since, holds_worker_slot,
                  pause_before_step, worktree_path, session_id, failure_code,
                  failure_message, created_at, updated_at
-               ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 0, ?, NULL, NULL, NULL, NULL, ?, ?)`,
+               ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 0, ?, ?, ?, NULL, NULL, NULL, NULL, ?, ?)`,
                   [
                     workItemId,
                     repositoryId,
@@ -2752,35 +3099,17 @@ export const makeWorkItemLifecycleLive = (
                     reviewVariant,
                     step,
                     now,
+                    admit ? null : now,
+                    admit ? 1 : 0,
                     options.pauseBeforeStep,
                     now,
                     now,
                   ],
                 )
 
-                yield* sql.unsafe(
-                  `INSERT INTO step_run (
-                 id, work_item_id, step, status, queue_job_id, queued_at,
-                 started_at, finished_at, reason_code, reason_message,
-                 created_at, updated_at
-               ) VALUES (?, ?, ?, 'queued', NULL, ?, NULL, NULL, NULL, NULL, ?, ?)`,
-                  [stepRunId, workItemId, step, now, now, now],
-                )
-
-                const payload = yield* encodeStepJob(stepRunId)
-
-                const jobId = yield* queue.enqueue(
-                  WORK_ITEM_LIFECYCLE_QUEUE,
-                  payload,
-                  { retryLimit: 1 },
-                )
-
-                yield* sql.unsafe(
-                  `UPDATE step_run
-               SET queue_job_id = ?, updated_at = ?
-               WHERE id = ?`,
-                  [jobId, now, stepRunId],
-                )
+                if (admit) {
+                  yield* enqueueStepRunForWorkItem(workItemId, step, now)
+                }
 
                 return workItemId
               }),
@@ -2865,6 +3194,7 @@ export const makeWorkItemLifecycleLive = (
         listWorkItemsForIssue,
         listWorkItemsForRepository,
         continueAfterHumanPrOutcome,
+        admitWaitingWorkItems,
       })
     }),
   )

--- a/packages/work-item-lifecycle/test/opencode-session-limiter.spec.ts
+++ b/packages/work-item-lifecycle/test/opencode-session-limiter.spec.ts
@@ -29,6 +29,7 @@ describe("limitOpencodeSessions", () => {
           reviewModel: null,
           reviewVariant: null,
           maxConcurrentOpencodeSessions: 2,
+          maxConcurrentWorkItems: 5,
         })
 
         const release = yield* Deferred.make<void>()
@@ -96,6 +97,7 @@ describe("limitOpencodeSessions", () => {
           reviewModel: null,
           reviewVariant: null,
           maxConcurrentOpencodeSessions: 1,
+          maxConcurrentWorkItems: 5,
         })
 
         const releaseStart = yield* Deferred.make<void>()
@@ -146,6 +148,7 @@ describe("limitOpencodeSessions", () => {
           reviewModel: null,
           reviewVariant: null,
           maxConcurrentOpencodeSessions: 1,
+          maxConcurrentWorkItems: 5,
         })
 
         const releaseFirst = yield* Deferred.make<void>()
@@ -184,6 +187,7 @@ describe("limitOpencodeSessions", () => {
           reviewModel: null,
           reviewVariant: null,
           maxConcurrentOpencodeSessions: 2,
+          maxConcurrentWorkItems: 5,
         })
         yield* Deferred.await(secondStarted)
         expect(starts).toBe(2)

--- a/packages/work-item-lifecycle/test/work-item-lifecycle.spec.ts
+++ b/packages/work-item-lifecycle/test/work-item-lifecycle.spec.ts
@@ -217,6 +217,7 @@ describe("WorkItemLifecycle", () => {
             reviewModel: "anthropic/claude-opus-4-6",
             reviewVariant: "max",
             maxConcurrentOpencodeSessions: 2,
+            maxConcurrentWorkItems: 5,
           })
 
           const workItem = yield* lifecycle.implementNow(
@@ -244,6 +245,7 @@ describe("WorkItemLifecycle", () => {
             reviewModel: null,
             reviewVariant: null,
             maxConcurrentOpencodeSessions: 2,
+            maxConcurrentWorkItems: 5,
           })
           yield* db.updateRepositorySettings({
             repositoryId: repository.id,
@@ -280,6 +282,7 @@ describe("WorkItemLifecycle", () => {
             reviewModel: null,
             reviewVariant: null,
             maxConcurrentOpencodeSessions: 2,
+            maxConcurrentWorkItems: 5,
           })
 
           const workItem = yield* lifecycle.implementNow(
@@ -1946,6 +1949,7 @@ describe("WorkItemLifecycle", () => {
             reviewModel: null,
             reviewVariant: null,
             maxConcurrentOpencodeSessions: 2,
+            maxConcurrentWorkItems: 5,
           })
 
           yield* lifecycle.implementNow(repository.id, issue.githubIssueNumber)
@@ -4312,6 +4316,227 @@ describe("WorkItemLifecycle", () => {
           const published = yield* Fiber.join(changes)
           expect(published).toContain(repository.id)
           expect(published.length).toBeGreaterThanOrEqual(1)
+        }),
+      ))
+  })
+
+  describe("Worker Slots", () => {
+    const seedIssue = (githubIssueNumber: number) =>
+      Effect.gen(function* () {
+        const db = yield* DbService
+        const repository = yield* db.addRepository({
+          ...sampleRepository,
+          localPath: `/repos/acme/widgets-${githubIssueNumber}.git`,
+          githubRepo: `widgets-${githubIssueNumber}`,
+        })
+        const issue = yield* db.storeIssue({
+          repositoryId: repository.id,
+          githubIssueNumber,
+          ...sampleIssueFields,
+          url: `https://github.com/acme/widgets/issues/${githubIssueNumber}`,
+        })
+        return { repository, issue }
+      })
+
+    const setMaxWorkItems = (maxConcurrentWorkItems: number) =>
+      Effect.gen(function* () {
+        const db = yield* DbService
+        const config = yield* db.getConfig
+        yield* db.updateConfig({
+          ...config,
+          maxConcurrentWorkItems,
+        })
+      })
+
+    it("admits up to the limit and queues extras as Waiting for Worker Slot", () =>
+      runTest(
+        Effect.gen(function* () {
+          const lifecycle = yield* WorkItemLifecycle
+          yield* setMaxWorkItems(2)
+
+          const a = yield* seedIssue(101)
+          const b = yield* seedIssue(102)
+          const c = yield* seedIssue(103)
+
+          const first = yield* lifecycle.implementNow(
+            a.repository.id,
+            a.issue.githubIssueNumber,
+          )
+          const second = yield* lifecycle.implementNow(
+            b.repository.id,
+            b.issue.githubIssueNumber,
+          )
+          const third = yield* lifecycle.implementNow(
+            c.repository.id,
+            c.issue.githubIssueNumber,
+          )
+
+          expect(first.holdsWorkerSlot).toBe(true)
+          expect(first.waitingSince).toBeNull()
+          expect(first.stepRuns).toHaveLength(1)
+
+          expect(second.holdsWorkerSlot).toBe(true)
+          expect(second.waitingSince).toBeNull()
+          expect(second.stepRuns).toHaveLength(1)
+
+          expect(third.holdsWorkerSlot).toBe(false)
+          expect(third.waitingSince).not.toBeNull()
+          expect(third.stepRuns).toHaveLength(0)
+          expect(third.state).toBe("create_worktree")
+        }),
+      ))
+
+    it("admits waiters FIFO when a slot is released by abandon", () =>
+      runTest(
+        Effect.gen(function* () {
+          const lifecycle = yield* WorkItemLifecycle
+          yield* setMaxWorkItems(1)
+
+          const a = yield* seedIssue(201)
+          const b = yield* seedIssue(202)
+          const c = yield* seedIssue(203)
+
+          const first = yield* lifecycle.implementNow(
+            a.repository.id,
+            a.issue.githubIssueNumber,
+          )
+          const second = yield* lifecycle.implementNow(
+            b.repository.id,
+            b.issue.githubIssueNumber,
+          )
+          const third = yield* lifecycle.implementNow(
+            c.repository.id,
+            c.issue.githubIssueNumber,
+          )
+
+          expect(first.holdsWorkerSlot).toBe(true)
+          expect(second.waitingSince).not.toBeNull()
+          expect(third.waitingSince).not.toBeNull()
+
+          yield* lifecycle.abandon(first.id)
+
+          const admittedSecond = yield* lifecycle.getWorkItem(second.id)
+          const stillWaitingThird = yield* lifecycle.getWorkItem(third.id)
+
+          expect(admittedSecond.holdsWorkerSlot).toBe(true)
+          expect(admittedSecond.waitingSince).toBeNull()
+          expect(admittedSecond.stepRuns).toHaveLength(1)
+          expect(stillWaitingThird.holdsWorkerSlot).toBe(false)
+          expect(stillWaitingThird.waitingSince).not.toBeNull()
+          expect(stillWaitingThird.stepRuns).toHaveLength(0)
+        }),
+      ))
+
+    it("releases a slot on Pause when idle and re-acquires on Start", () =>
+      runTest(
+        Effect.gen(function* () {
+          const lifecycle = yield* WorkItemLifecycle
+          yield* setMaxWorkItems(1)
+
+          const a = yield* seedIssue(301)
+          const b = yield* seedIssue(302)
+
+          const first = yield* lifecycle.implementNow(
+            a.repository.id,
+            a.issue.githubIssueNumber,
+          )
+          const waiter = yield* lifecycle.implementNow(
+            b.repository.id,
+            b.issue.githubIssueNumber,
+          )
+          expect(waiter.waitingSince).not.toBeNull()
+
+          const paused = yield* lifecycle.pause(first.id)
+          expect(paused.paused).toBe(true)
+          expect(paused.holdsWorkerSlot).toBe(false)
+
+          const admittedWaiter = yield* lifecycle.getWorkItem(waiter.id)
+          expect(admittedWaiter.holdsWorkerSlot).toBe(true)
+          expect(admittedWaiter.waitingSince).toBeNull()
+          expect(admittedWaiter.stepRuns).toHaveLength(1)
+
+          const started = yield* lifecycle.start(first.id)
+          expect(started.paused).toBe(false)
+          expect(started.holdsWorkerSlot).toBe(false)
+          expect(started.waitingSince).not.toBeNull()
+        }),
+      ))
+
+    it("releases a slot on non-terminal failure; Retry re-acquires or waits", () =>
+      runWithSteps(
+        {
+          ...successfulSteps,
+          createWorktree: () => Effect.fail(new Error("boom")),
+        },
+        Effect.gen(function* () {
+          const lifecycle = yield* WorkItemLifecycle
+          const queue = yield* QueueService
+          yield* setMaxWorkItems(1)
+
+          const a = yield* seedIssue(401)
+          const b = yield* seedIssue(402)
+
+          const first = yield* lifecycle.implementNow(
+            a.repository.id,
+            a.issue.githubIssueNumber,
+          )
+          const waiter = yield* lifecycle.implementNow(
+            b.repository.id,
+            b.issue.githubIssueNumber,
+          )
+
+          const claimed = yield* queue.rawClaim(WORK_ITEM_LIFECYCLE_QUEUE)
+          expect(Option.isSome(claimed)).toBe(true)
+          if (Option.isSome(claimed)) {
+            yield* lifecycle.runStep(
+              (claimed.value.payload as { stepRunId: string }).stepRunId,
+            )
+          }
+
+          const failed = yield* lifecycle.getWorkItem(first.id)
+          expect(failed.holdsWorkerSlot).toBe(false)
+          expect(failed.waitingSince).toBeNull()
+          expect(failed.stepRuns[0]!.status).toBe("failed")
+
+          const admittedWaiter = yield* lifecycle.getWorkItem(waiter.id)
+          expect(admittedWaiter.holdsWorkerSlot).toBe(true)
+
+          const retried = yield* lifecycle.retry(first.id)
+          expect(retried.holdsWorkerSlot).toBe(false)
+          expect(retried.waitingSince).not.toBeNull()
+          expect(
+            retried.stepRuns.filter((r) => r.status === "queued"),
+          ).toHaveLength(0)
+        }),
+      ))
+
+    it("admits waiters immediately when the config limit is raised", () =>
+      runTest(
+        Effect.gen(function* () {
+          const lifecycle = yield* WorkItemLifecycle
+          yield* setMaxWorkItems(1)
+
+          const a = yield* seedIssue(501)
+          const b = yield* seedIssue(502)
+
+          yield* lifecycle.implementNow(
+            a.repository.id,
+            a.issue.githubIssueNumber,
+          )
+          const waiter = yield* lifecycle.implementNow(
+            b.repository.id,
+            b.issue.githubIssueNumber,
+          )
+          expect(waiter.waitingSince).not.toBeNull()
+
+          yield* setMaxWorkItems(2)
+          const admitted = yield* lifecycle.admitWaitingWorkItems
+          expect(admitted).toBe(1)
+
+          const after = yield* lifecycle.getWorkItem(waiter.id)
+          expect(after.holdsWorkerSlot).toBe(true)
+          expect(after.waitingSince).toBeNull()
+          expect(after.stepRuns).toHaveLength(1)
         }),
       ))
   })


### PR DESCRIPTION
## Summary
- Cap how many Work Items may be Admitted at once via harness Config `maxConcurrentWorkItems` (default 5)
- Implement Now / Implement Locally beyond the limit create waiters (FIFO, no Step Run until admission)
- Pause, failed Step Runs, Needs Human, and terminal states release slots; Start/Retry/resume re-acquire or wait
- Fiber budget is `max(maxConcurrentWorkItems, 2 × maxConcurrentOpencodeSessions)`; settings UI exposes the new limit

Closes #203

## Test plan
- [ ] Unit/integration: create beyond limit, FIFO admit on abandon, Pause/Start re-acquire, fail+Retry wait, raise config admits waiters
- [ ] Config get/update validates positive integer default 5
- [ ] GraphQL exposes `maxConcurrentWorkItems` and `WAITING_FOR_WORKER_SLOT` status/message
- [ ] Harness settings saves max concurrent Work Items next to OpenCode sessions