### PR TITLE
fix(github-service): load PR terminal checks via REST for fine-grained PATs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,10 @@ Keymaxxer is used by the Ready for Agent harness. Interactive coding agents do
 not need to use Keymaxxer themselves; use normally authenticated tools such as
 `gh` and `git` directly.
 
+Fine-grained GitHub PATs cannot call the Checks API (including GraphQL
+`statusCheckRollup.contexts`). Use a classic PAT with `repo` for harness CI
+watching.
+
 ### Triage labels
 
 Default labels: needs-triage, needs-info, ready-for-agent, ready-for-human, wontfix. See `docs/agents/triage-labels.md`.

--- a/packages/github-service/src/lib/github-service-live.ts
+++ b/packages/github-service/src/lib/github-service-live.ts
@@ -25,6 +25,7 @@ import type {
 } from "./types.js"
 
 const GITHUB_GRAPHQL_URL = "https://api.github.com/graphql"
+const GITHUB_API_URL = "https://api.github.com"
 const READY_FOR_AGENT_LABEL = "ready-for-agent"
 const PAGE_SIZE = 100
 const REQUEST_TIMEOUT = "30 seconds"
@@ -90,21 +91,6 @@ const githubQuery = <A>(
     }),
   )
 
-interface GitHubApiCheckRun {
-  readonly __typename?: "CheckRun"
-  readonly databaseId?: unknown
-  readonly name?: unknown
-  readonly status?: unknown
-  readonly conclusion?: unknown
-}
-
-interface GitHubApiStatusContext {
-  readonly __typename?: "StatusContext"
-  readonly id?: unknown
-  readonly context?: unknown
-  readonly state?: unknown
-}
-
 interface GitHubApiCommit {
   readonly oid?: unknown
   readonly pushedDate?: unknown
@@ -125,17 +111,40 @@ interface GitHubApiPullRequest {
   } | null
   readonly statusCheckRollup: {
     readonly state: unknown
-    readonly contexts?: {
-      readonly nodes?:
-        | readonly (GitHubApiCheckRun | GitHubApiStatusContext | null)[]
-        | null
-      readonly pageInfo?: {
-        readonly endCursor?: unknown
-        readonly hasNextPage?: unknown
-      }
-    }
   } | null
 }
+
+interface GitHubRestCheckRun {
+  readonly id?: unknown
+  readonly name?: unknown
+  readonly status?: unknown
+  readonly conclusion?: unknown
+}
+
+interface GitHubRestWorkflowRun {
+  readonly id?: unknown
+}
+
+interface GitHubRestJob {
+  readonly id?: unknown
+  readonly name?: unknown
+  readonly status?: unknown
+  readonly conclusion?: unknown
+}
+
+interface GitHubRestCommitStatus {
+  readonly id?: unknown
+  readonly node_id?: unknown
+  readonly context?: unknown
+  readonly state?: unknown
+}
+
+/** Load terminal check executions for a commit (REST Checks, or Actions fallback). */
+export type ListTerminalChecksForCommit = (
+  repository: { owner: string; name: string },
+  headSha: string,
+  signal?: AbortSignal,
+) => Promise<readonly TerminalPrStatusCheck[]>
 
 const emptyTerminalChecks: readonly TerminalPrStatusCheck[] = []
 
@@ -253,25 +262,32 @@ const toPullRequestCheckStatus = (
   throw new Error(`Invalid GitHub status check state: ${state}`)
 }
 
-const mapCheckRun = (
-  check: GitHubApiCheckRun,
-): TerminalPrStatusCheck | null => {
-  if (check.status !== "COMPLETED") {
+const normalizeRestToken = (value: unknown): string | null => {
+  if (typeof value !== "string" || value.trim() === "") {
     return null
   }
-  if (
-    typeof check.databaseId !== "number" ||
-    !Number.isSafeInteger(check.databaseId)
-  ) {
-    throw new Error("Invalid GitHub CheckRun identity")
+  return value.trim().toUpperCase()
+}
+
+const mapRestCheckExecution = (check: {
+  readonly id?: unknown
+  readonly name?: unknown
+  readonly status?: unknown
+  readonly conclusion?: unknown
+}): TerminalPrStatusCheck | null => {
+  if (normalizeRestToken(check.status) !== "COMPLETED") {
+    return null
+  }
+  if (typeof check.id !== "number" || !Number.isSafeInteger(check.id)) {
+    throw new Error("Invalid GitHub check execution identity")
   }
   if (typeof check.name !== "string" || check.name.trim() === "") {
-    throw new Error("Invalid GitHub CheckRun name")
+    throw new Error("Invalid GitHub check execution name")
   }
-  const conclusion = check.conclusion
+  const conclusion = normalizeRestToken(check.conclusion)
   if (conclusion === "SUCCESS") {
     return {
-      externalId: `actions-job:${check.databaseId}`,
+      externalId: `actions-job:${check.id}`,
       name: check.name,
       outcome: "green",
     }
@@ -283,87 +299,45 @@ const mapCheckRun = (
     conclusion === "STARTUP_FAILURE"
   ) {
     return {
-      externalId: `actions-job:${check.databaseId}`,
+      externalId: `actions-job:${check.id}`,
       name: check.name,
       outcome: "red",
     }
   }
-  // CANCELLED, SKIPPED, NEUTRAL, STALE, etc. do not hand off
   return null
 }
 
-const mapStatusContext = (
-  status: GitHubApiStatusContext,
+const mapRestCommitStatus = (
+  status: GitHubRestCommitStatus,
 ): TerminalPrStatusCheck | null => {
-  if (status.state === "PENDING" || status.state === "EXPECTED") {
+  if (typeof status.context !== "string" || status.context.trim() === "") {
+    throw new Error("Invalid GitHub commit status context")
+  }
+  const state = normalizeRestToken(status.state)
+  if (state === "PENDING" || state === "EXPECTED") {
     return null
   }
-  if (typeof status.context !== "string" || status.context.trim() === "") {
-    throw new Error("Invalid GitHub StatusContext name")
-  }
-  const externalId =
-    typeof status.id === "string" && status.id.trim() !== ""
-      ? `status:${status.id}`
-      : `status:${status.context}`
-  if (status.state === "SUCCESS") {
+  const identity =
+    typeof status.node_id === "string" && status.node_id.trim() !== ""
+      ? status.node_id
+      : typeof status.id === "number" && Number.isSafeInteger(status.id)
+        ? String(status.id)
+        : status.context
+  if (state === "SUCCESS") {
     return {
-      externalId,
+      externalId: `status:${identity}`,
       name: status.context,
       outcome: "green",
     }
   }
-  if (status.state === "FAILURE" || status.state === "ERROR") {
+  if (state === "FAILURE" || state === "ERROR") {
     return {
-      externalId,
+      externalId: `status:${identity}`,
       name: status.context,
       outcome: "red",
     }
   }
-  throw new Error(`Invalid GitHub StatusContext state: ${status.state}`)
-}
-
-const terminalChecksFromRollup = (
-  rollup: GitHubApiPullRequest["statusCheckRollup"],
-  repository: { owner: string; name: string },
-): Effect.Effect<readonly TerminalPrStatusCheck[], GitHubRequestError> => {
-  if (rollup === null || rollup.contexts?.nodes === undefined) {
-    return Effect.succeed(emptyTerminalChecks)
-  }
-  const checks: TerminalPrStatusCheck[] = []
-  for (const node of rollup.contexts.nodes ?? []) {
-    if (node === null || typeof node !== "object") {
-      continue
-    }
-    const mapped = (() => {
-      try {
-        if (
-          node.__typename === "CheckRun" ||
-          ("databaseId" in node && "conclusion" in node)
-        ) {
-          return mapCheckRun(node as GitHubApiCheckRun)
-        }
-        if (
-          node.__typename === "StatusContext" ||
-          ("context" in node && "state" in node)
-        ) {
-          return mapStatusContext(node as GitHubApiStatusContext)
-        }
-        return null
-      } catch (cause) {
-        return new GitHubRequestError({
-          message: `GitHub returned invalid status check data for ${repository.owner}/${repository.name}`,
-          cause,
-        })
-      }
-    })()
-    if (mapped instanceof GitHubRequestError) {
-      return Effect.fail(mapped)
-    }
-    if (mapped !== null) {
-      checks.push(mapped)
-    }
-  }
-  return Effect.succeed(uniqueTerminalChecks(checks))
+  throw new Error(`Invalid GitHub commit status state: ${status.state}`)
 }
 
 interface GitHubApiIssue {
@@ -660,31 +634,9 @@ const sortDependencies = (
       left.number - right.number || left.url.localeCompare(right.url),
   )
 
-const statusCheckRollupSelection = (after?: string) =>
-  ({
-    state: true,
-    contexts: {
-      __args: { first: PAGE_SIZE, ...(after === undefined ? {} : { after }) },
-      nodes: {
-        __typename: true,
-        on_CheckRun: {
-          databaseId: true,
-          name: true,
-          status: true,
-          conclusion: true,
-        },
-        on_StatusContext: {
-          id: true,
-          context: true,
-          state: true,
-        },
-      },
-      pageInfo: { endCursor: true, hasNextPage: true },
-    },
-  }) as const
-
 export const makeGitHubService = (
   client: GitHubGraphqlClient,
+  listTerminalChecksForCommit?: ListTerminalChecksForCommit,
 ): GitHubServiceShape => ({
   getPullRequestCheckStatus: Effect.fn(
     "GitHubService.getPullRequestCheckStatus",
@@ -716,7 +668,9 @@ export const makeGitHubService = (
                       },
                     },
                   },
-                  statusCheckRollup: statusCheckRollupSelection(),
+                  // Rollup state only — CheckRun contexts need Checks API access
+                  // that fine-grained PATs cannot grant. Terminal details load via REST.
+                  statusCheckRollup: { state: true },
                 },
               },
             },
@@ -739,61 +693,22 @@ export const makeGitHubService = (
       }
     }
 
-    const terminalChecks = [
-      ...(yield* terminalChecksFromRollup(
-        pullRequest.statusCheckRollup,
-        repository,
-      )),
-    ]
-    let pageInfo = pullRequest.statusCheckRollup?.contexts?.pageInfo
-    while (pageInfo?.hasNextPage === true) {
-      const after = pageInfo.endCursor
-      if (typeof after !== "string") {
-        return yield* new GitHubRequestError({
-          message: `GitHub returned invalid status check pagination for ${repository.owner}/${repository.name}:${headRefName}`,
-        })
-      }
-      const page = yield* githubQuery(
-        `Failed to get pull request check page for ${repository.owner}/${repository.name}:${headRefName}`,
-        (signal) =>
-          client.query(
-            {
-              repository: {
-                __args: repository,
-                pullRequests: {
-                  __args: { first: 1, headRefName },
-                  nodes: {
-                    statusCheckRollup: statusCheckRollupSelection(after),
-                  },
-                },
-              },
-            },
-            signal,
-          ),
-      )
-      if (page.repository === null) {
-        return yield* new GitHubRepositoryUnavailableError(repository)
-      }
-      const rollup = (page.repository.pullRequests.nodes?.[0]
-        ?.statusCheckRollup ??
-        null) as GitHubApiPullRequest["statusCheckRollup"]
-      if (rollup === null) {
-        return yield* new GitHubRequestError({
-          message: `GitHub omitted status check page data for ${repository.owner}/${repository.name}:${headRefName}`,
-        })
-      }
-      terminalChecks.push(
-        ...(yield* terminalChecksFromRollup(rollup, repository)),
-      )
-      pageInfo = rollup?.contexts?.pageInfo
+    let terminalChecks: readonly TerminalPrStatusCheck[] = emptyTerminalChecks
+    const headSha = pullRequest.headRefOid
+    if (
+      listTerminalChecksForCommit !== undefined &&
+      typeof headSha === "string" &&
+      headSha.trim() !== "" &&
+      pullRequest.statusCheckRollup !== null
+    ) {
+      terminalChecks = yield* githubQuery(
+        `Failed to list terminal pull request checks for ${repository.owner}/${repository.name}:${headRefName}`,
+        (signal) => listTerminalChecksForCommit(repository, headSha, signal),
+      ).pipe(Effect.map(uniqueTerminalChecks))
     }
 
     return yield* Effect.try({
-      try: () =>
-        toPullRequestCheckStatus(
-          pullRequest,
-          uniqueTerminalChecks(terminalChecks),
-        ),
+      try: () => toPullRequestCheckStatus(pullRequest, terminalChecks),
       catch: (cause) =>
         new GitHubRequestError({
           message: `GitHub returned invalid pull request checks for ${repository.owner}/${repository.name}:${headRefName}`,
@@ -1500,6 +1415,212 @@ export const makeGitHubService = (
   ),
 })
 
+const githubRestHeaders = (token: string) =>
+  ({
+    Accept: "application/vnd.github+json",
+    Authorization: `Bearer ${token}`,
+    "X-GitHub-Api-Version": "2022-11-28",
+  }) as const
+
+const readGitHubJson = async <A>(
+  response: Response,
+  message: string,
+): Promise<A> => {
+  if (!response.ok) {
+    throw new GitHubHttpError(
+      response.status,
+      `${message}: ${response.statusText}: ${await response.text()}`,
+    )
+  }
+  return (await response.json()) as A
+}
+
+const listTerminalChecksViaCheckRuns = async (
+  token: string,
+  repository: { owner: string; name: string },
+  headSha: string,
+  fetchImpl: GitHubFetch,
+  signal?: AbortSignal,
+): Promise<readonly TerminalPrStatusCheck[]> => {
+  const checks: TerminalPrStatusCheck[] = []
+  for (let page = 1; ; page += 1) {
+    const url = new URL(
+      `${GITHUB_API_URL}/repos/${repository.owner}/${repository.name}/commits/${encodeURIComponent(headSha)}/check-runs`,
+    )
+    url.searchParams.set("per_page", String(PAGE_SIZE))
+    url.searchParams.set("page", String(page))
+    url.searchParams.set("filter", "latest")
+    const response = await fetchImpl(url, {
+      headers: githubRestHeaders(token),
+      signal,
+    })
+    const body = await readGitHubJson<{
+      readonly check_runs?: readonly GitHubRestCheckRun[] | null
+    }>(
+      response,
+      `Failed to list check runs for ${repository.owner}/${repository.name}@${headSha}`,
+    )
+    const runs = body.check_runs ?? []
+    for (const run of runs) {
+      const mapped = mapRestCheckExecution(run)
+      if (mapped !== null) {
+        checks.push(mapped)
+      }
+    }
+    if (runs.length < PAGE_SIZE) {
+      break
+    }
+  }
+  return checks
+}
+
+const listTerminalChecksViaActions = async (
+  token: string,
+  repository: { owner: string; name: string },
+  headSha: string,
+  fetchImpl: GitHubFetch,
+  signal?: AbortSignal,
+): Promise<readonly TerminalPrStatusCheck[]> => {
+  const checks: TerminalPrStatusCheck[] = []
+  const runIds: number[] = []
+  for (let page = 1; ; page += 1) {
+    const url = new URL(
+      `${GITHUB_API_URL}/repos/${repository.owner}/${repository.name}/actions/runs`,
+    )
+    url.searchParams.set("head_sha", headSha)
+    url.searchParams.set("per_page", String(PAGE_SIZE))
+    url.searchParams.set("page", String(page))
+    const response = await fetchImpl(url, {
+      headers: githubRestHeaders(token),
+      signal,
+    })
+    const body = await readGitHubJson<{
+      readonly workflow_runs?: readonly GitHubRestWorkflowRun[] | null
+    }>(
+      response,
+      `Failed to list workflow runs for ${repository.owner}/${repository.name}@${headSha}`,
+    )
+    const runs = body.workflow_runs ?? []
+    for (const run of runs) {
+      if (typeof run.id === "number" && Number.isSafeInteger(run.id)) {
+        runIds.push(run.id)
+      }
+    }
+    if (runs.length < PAGE_SIZE) {
+      break
+    }
+  }
+  for (const runId of runIds) {
+    for (let page = 1; ; page += 1) {
+      const url = new URL(
+        `${GITHUB_API_URL}/repos/${repository.owner}/${repository.name}/actions/runs/${runId}/jobs`,
+      )
+      url.searchParams.set("per_page", String(PAGE_SIZE))
+      url.searchParams.set("page", String(page))
+      const response = await fetchImpl(url, {
+        headers: githubRestHeaders(token),
+        signal,
+      })
+      const body = await readGitHubJson<{
+        readonly jobs?: readonly GitHubRestJob[] | null
+      }>(
+        response,
+        `Failed to list workflow jobs for ${repository.owner}/${repository.name} run ${runId}`,
+      )
+      const jobs = body.jobs ?? []
+      for (const job of jobs) {
+        const mapped = mapRestCheckExecution(job)
+        if (mapped !== null) {
+          checks.push(mapped)
+        }
+      }
+      if (jobs.length < PAGE_SIZE) {
+        break
+      }
+    }
+  }
+  return checks
+}
+
+const listTerminalCommitStatuses = async (
+  token: string,
+  repository: { owner: string; name: string },
+  headSha: string,
+  fetchImpl: GitHubFetch,
+  signal?: AbortSignal,
+): Promise<readonly TerminalPrStatusCheck[]> => {
+  const checks: TerminalPrStatusCheck[] = []
+  const seenContexts = new Set<string>()
+  for (let page = 1; ; page += 1) {
+    const url = new URL(
+      `${GITHUB_API_URL}/repos/${repository.owner}/${repository.name}/commits/${encodeURIComponent(headSha)}/statuses`,
+    )
+    url.searchParams.set("per_page", String(PAGE_SIZE))
+    url.searchParams.set("page", String(page))
+    const response = await fetchImpl(url, {
+      headers: githubRestHeaders(token),
+      signal,
+    })
+    const statuses = await readGitHubJson<readonly GitHubRestCommitStatus[]>(
+      response,
+      `Failed to list commit statuses for ${repository.owner}/${repository.name}@${headSha}`,
+    )
+    for (const status of statuses) {
+      if (
+        typeof status.context !== "string" ||
+        seenContexts.has(status.context)
+      ) {
+        continue
+      }
+      seenContexts.add(status.context)
+      const mapped = mapRestCommitStatus(status)
+      if (mapped !== null) {
+        checks.push(mapped)
+      }
+    }
+    if (statuses.length < PAGE_SIZE) {
+      break
+    }
+  }
+  return checks
+}
+
+const makeListTerminalChecksForCommit =
+  (token: string, fetchImpl: GitHubFetch): ListTerminalChecksForCommit =>
+  async (repository, headSha, signal) => {
+    let checkRuns: readonly TerminalPrStatusCheck[]
+    try {
+      checkRuns = await listTerminalChecksViaCheckRuns(
+        token,
+        repository,
+        headSha,
+        fetchImpl,
+        signal,
+      )
+    } catch (cause) {
+      // Fine-grained PATs cannot use the Checks API; Actions jobs still work.
+      if (cause instanceof GitHubHttpError && cause.statusCode === 403) {
+        checkRuns = await listTerminalChecksViaActions(
+          token,
+          repository,
+          headSha,
+          fetchImpl,
+          signal,
+        )
+      } else {
+        throw cause
+      }
+    }
+    const statuses = await listTerminalCommitStatuses(
+      token,
+      repository,
+      headSha,
+      fetchImpl,
+      signal,
+    )
+    return uniqueTerminalChecks([...checkRuns, ...statuses])
+  }
+
 const makeGitHubGraphqlClient = (
   token: string,
   fetchImpl: GitHubFetch = fetch,
@@ -1531,9 +1652,12 @@ const makeGitHubGraphqlClient = (
 
 export const makeGitHubServiceFromToken = (
   token: string,
-  fetchImpl?: GitHubFetch,
+  fetchImpl: GitHubFetch = fetch,
 ): GitHubServiceShape =>
-  makeGitHubService(makeGitHubGraphqlClient(token, fetchImpl))
+  makeGitHubService(
+    makeGitHubGraphqlClient(token, fetchImpl),
+    makeListTerminalChecksForCommit(token, fetchImpl),
+  )
 
 export const GitHubServiceLive = Layer.effect(
   GitHubService,

--- a/packages/github-service/test/github-service.spec.ts
+++ b/packages/github-service/test/github-service.spec.ts
@@ -474,90 +474,43 @@ describe("GitHubService live implementation", () => {
     })
   })
 
-  it("loads terminal CheckRuns and StatusContexts via GraphQL rollup", async () => {
-    const service = makeGitHubService({
-      query: () =>
-        Promise.resolve({
-          repository: {
-            pullRequests: {
-              nodes: [
-                {
-                  state: "OPEN",
-                  merged: false,
-                  headRefOid: "sha-head",
-                  baseRefName: "main",
-                  mergeable: "MERGEABLE",
-                  statusCheckRollup: {
-                    state: "PENDING",
-                    contexts: {
-                      nodes: [
-                        {
-                          __typename: "CheckRun",
-                          databaseId: 100,
-                          name: "unit",
-                          status: "COMPLETED",
-                          conclusion: "SUCCESS",
-                        },
-                        {
-                          __typename: "CheckRun",
-                          databaseId: 101,
-                          name: "lint",
-                          status: "COMPLETED",
-                          conclusion: "FAILURE",
-                        },
-                        {
-                          __typename: "CheckRun",
-                          databaseId: 102,
-                          name: "e2e",
-                          status: "COMPLETED",
-                          conclusion: "TIMED_OUT",
-                        },
-                        {
-                          __typename: "CheckRun",
-                          databaseId: 103,
-                          name: "optional",
-                          status: "COMPLETED",
-                          conclusion: "SKIPPED",
-                        },
-                        {
-                          __typename: "CheckRun",
-                          databaseId: 104,
-                          name: "build",
-                          status: "IN_PROGRESS",
-                          conclusion: null,
-                        },
-                        {
-                          __typename: "StatusContext",
-                          id: "SC_1",
-                          context: "ci/travis",
-                          state: "SUCCESS",
-                        },
-                        {
-                          __typename: "StatusContext",
-                          id: "SC_2",
-                          context: "ci/deploy",
-                          state: "ERROR",
-                        },
-                        {
-                          __typename: "StatusContext",
-                          id: "SC_3",
-                          context: "ci/pending",
-                          state: "PENDING",
-                        },
-                      ],
-                    },
+  it("loads terminal checks via REST when the rollup is pending or red", async () => {
+    let listedSha: string | undefined
+    const service = makeGitHubService(
+      {
+        query: () =>
+          Promise.resolve({
+            repository: {
+              pullRequests: {
+                nodes: [
+                  {
+                    state: "OPEN",
+                    merged: false,
+                    headRefOid: "sha-head",
+                    baseRefName: "main",
+                    mergeable: "MERGEABLE",
+                    statusCheckRollup: { state: "PENDING" },
                   },
-                },
-              ],
+                ],
+              },
             },
-          },
-        }) as never,
-    })
+          }) as never,
+      },
+      async (_repository, headSha) => {
+        listedSha = headSha
+        return [
+          { externalId: "actions-job:100", name: "unit", outcome: "green" },
+          { externalId: "actions-job:101", name: "lint", outcome: "red" },
+          { externalId: "actions-job:102", name: "e2e", outcome: "red" },
+        ]
+      },
+    )
 
     const status = await Effect.runPromise(
       service.getPullRequestCheckStatus(repository, "branch"),
     )
 
+    expect(listedSha).toBe("sha-head")
     expect(status).toEqual({
       _tag: "pending",
       mergeability: "mergeable",
@@ -567,137 +520,82 @@ describe("GitHubService live implementation", () => {
         { externalId: "actions-job:100", name: "unit", outcome: "green" },
         { externalId: "actions-job:101", name: "lint", outcome: "red" },
         { externalId: "actions-job:102", name: "e2e", outcome: "red" },
-        { externalId: "status:SC_1", name: "ci/travis", outcome: "green" },
-        { externalId: "status:SC_2", name: "ci/deploy", outcome: "red" },
       ],
     })
   })
 
-  it("loads every GraphQL status-check rollup page", async () => {
-    let attempts = 0
-    const service = makeGitHubService({
-      query: () => {
-        attempts += 1
-        return Promise.resolve(
-          attempts === 1
-            ? {
-                repository: {
-                  pullRequests: {
-                    nodes: [
-                      {
-                        state: "OPEN",
-                        merged: false,
-                        headRefOid: "sha-head",
-                        baseRefName: "main",
-                        mergeable: "MERGEABLE",
-                        statusCheckRollup: {
-                          state: "PENDING",
-                          contexts: {
-                            nodes: [
-                              {
-                                __typename: "CheckRun",
-                                databaseId: 100,
-                                name: "unit",
-                                status: "COMPLETED",
-                                conclusion: "SUCCESS",
-                              },
-                            ],
-                            pageInfo: {
-                              endCursor: "page-2",
-                              hasNextPage: true,
-                            },
-                          },
-                        },
-                      },
-                    ],
+  it("loads terminal checks when the rollup is already green", async () => {
+    let listed = false
+    const service = makeGitHubService(
+      {
+        query: () =>
+          Promise.resolve({
+            repository: {
+              pullRequests: {
+                nodes: [
+                  {
+                    state: "OPEN",
+                    merged: false,
+                    headRefOid: "sha-head",
+                    baseRefName: "main",
+                    mergeable: "MERGEABLE",
+                    statusCheckRollup: { state: "SUCCESS" },
                   },
-                },
-              }
-            : {
-                repository: {
-                  pullRequests: {
-                    nodes: [
-                      {
-                        statusCheckRollup: {
-                          state: "PENDING",
-                          contexts: {
-                            nodes: [
-                              {
-                                __typename: "CheckRun",
-                                databaseId: 101,
-                                name: "lint",
-                                status: "COMPLETED",
-                                conclusion: "FAILURE",
-                              },
-                            ],
-                            pageInfo: {
-                              endCursor: null,
-                              hasNextPage: false,
-                            },
-                          },
-                        },
-                      },
-                    ],
-                  },
-                },
+                ],
               },
-        ) as never
+            },
+          }) as never,
       },
-    })
+      async () => {
+        listed = true
+        return [
+          { externalId: "actions-job:100", name: "unit", outcome: "green" },
+        ]
+      },
+    )
 
     const status = await Effect.runPromise(
       service.getPullRequestCheckStatus(repository, "branch"),
     )
 
-    expect(status).toMatchObject({
+    expect(listed).toBe(true)
+    expect(status).toEqual({
+      _tag: "succeeded",
+      mergeability: "mergeable",
+      baseRefName: "main",
+      headPushedAt: null,
       terminalChecks: [
-        { externalId: "actions-job:100", outcome: "green" },
-        { externalId: "actions-job:101", outcome: "red" },
+        { externalId: "actions-job:100", name: "unit", outcome: "green" },
       ],
     })
-    expect(attempts).toBe(2)
   })
 
-  it("treats distinct CheckRun executions with the same name as separate", async () => {
-    const service = makeGitHubService({
-      query: () =>
-        Promise.resolve({
-          repository: {
-            pullRequests: {
-              nodes: [
-                {
-                  state: "OPEN",
-                  merged: false,
-                  headRefOid: "sha-head",
-                  baseRefName: "main",
-                  mergeable: "MERGEABLE",
-                  statusCheckRollup: {
-                    state: "FAILURE",
-                    contexts: {
-                      nodes: [
-                        {
-                          __typename: "CheckRun",
-                          databaseId: 100,
-                          name: "lint",
-                          status: "COMPLETED",
-                          conclusion: "FAILURE",
-                        },
-                        {
-                          __typename: "CheckRun",
-                          databaseId: 101,
-                          name: "lint",
-                          status: "COMPLETED",
-                          conclusion: "SUCCESS",
-                        },
-                      ],
-                    },
+  it("treats distinct check executions with the same name as separate", async () => {
+    const service = makeGitHubService(
+      {
+        query: () =>
+          Promise.resolve({
+            repository: {
+              pullRequests: {
+                nodes: [
+                  {
+                    state: "OPEN",
+                    merged: false,
+                    headRefOid: "sha-head",
+                    baseRefName: "main",
+                    mergeable: "MERGEABLE",
+                    statusCheckRollup: { state: "FAILURE" },
                   },
-                },
-              ],
+                ],
+              },
             },
-          },
-        }) as never,
-    })
+          }) as never,
+      },
+      async () => [
+        { externalId: "actions-job:100", name: "lint", outcome: "red" },
+        { externalId: "actions-job:101", name: "lint", outcome: "green" },
+      ],
+    )
 
     const status = await Effect.runPromise(
       service.getPullRequestCheckStatus(repository, "branch"),
@@ -711,6 +609,161 @@ describe("GitHubService live implementation", () => {
       terminalChecks: [
         { externalId: "actions-job:100", name: "lint", outcome: "red" },
         { externalId: "actions-job:101", name: "lint", outcome: "green" },
+      ],
+    })
+  })
+
+  it("falls back to Actions jobs when Checks REST returns 403", async () => {
+    const service = makeGitHubServiceFromToken("token", async (input) => {
+      const url = String(input)
+      if (url.includes("api.github.com/graphql")) {
+        return new Response(
+          JSON.stringify({
+            data: {
+              repository: {
+                pullRequests: {
+                  nodes: [
+                    {
+                      state: "OPEN",
+                      merged: false,
+                      headRefOid: "sha-head",
+                      baseRefName: "main",
+                      mergeable: "MERGEABLE",
+                      statusCheckRollup: { state: "FAILURE" },
+                    },
+                  ],
+                },
+              },
+            },
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        )
+      }
+      if (url.includes("/check-runs")) {
+        return new Response(
+          JSON.stringify({
+            message: "Resource not accessible by personal access token",
+          }),
+          { status: 403, statusText: "Forbidden" },
+        )
+      }
+      if (url.includes("/actions/runs?") || url.includes("/actions/runs&")) {
+        return new Response(
+          JSON.stringify({
+            total_count: 1,
+            workflow_runs: [{ id: 55 }],
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        )
+      }
+      if (url.includes("/actions/runs/55/jobs")) {
+        return new Response(
+          JSON.stringify({
+            jobs: [
+              {
+                id: 200,
+                name: "lint",
+                status: "completed",
+                conclusion: "failure",
+              },
+            ],
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        )
+      }
+      if (url.includes("/statuses")) {
+        return new Response(JSON.stringify([]), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        })
+      }
+      return new Response("not found", { status: 404, statusText: "Not Found" })
+    })
+
+    const status = await Effect.runPromise(
+      service.getPullRequestCheckStatus(repository, "branch"),
+    )
+
+    expect(status).toEqual({
+      _tag: "failed",
+      mergeability: "mergeable",
+      baseRefName: "main",
+      headPushedAt: null,
+      terminalChecks: [
+        { externalId: "actions-job:200", name: "lint", outcome: "red" },
+      ],
+    })
+  })
+
+  it("loads only the latest commit status for each context", async () => {
+    const service = makeGitHubServiceFromToken("token", async (input) => {
+      const url = String(input)
+      if (url.includes("api.github.com/graphql")) {
+        return new Response(
+          JSON.stringify({
+            data: {
+              repository: {
+                pullRequests: {
+                  nodes: [
+                    {
+                      state: "OPEN",
+                      merged: false,
+                      headRefOid: "sha-head",
+                      baseRefName: "main",
+                      mergeable: "MERGEABLE",
+                      statusCheckRollup: { state: "FAILURE" },
+                    },
+                  ],
+                },
+              },
+            },
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        )
+      }
+      if (url.includes("/check-runs")) {
+        return new Response(JSON.stringify({ check_runs: [] }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        })
+      }
+      if (url.includes("/statuses")) {
+        return new Response(
+          JSON.stringify([
+            {
+              id: 3,
+              node_id: "SC_3",
+              context: "ci/build",
+              state: "failure",
+            },
+            {
+              id: 2,
+              node_id: "SC_2",
+              context: "ci/build",
+              state: "success",
+            },
+            {
+              id: 1,
+              node_id: "SC_1",
+              context: "ci/deploy",
+              state: "success",
+            },
+          ]),
+          { status: 200, headers: { "content-type": "application/json" } },
+        )
+      }
+      return new Response("not found", { status: 404, statusText: "Not Found" })
+    })
+
+    const status = await Effect.runPromise(
+      service.getPullRequestCheckStatus(repository, "branch"),
+    )
+
+    expect(status).toMatchObject({
+      _tag: "failed",
+      terminalChecks: [
+        { externalId: "status:SC_1", name: "ci/deploy", outcome: "green" },
+        { externalId: "status:SC_3", name: "ci/build", outcome: "red" },
       ],
     })
   })

--- a/packages/graphql-api/src/lib/graphql-api.ts
+++ b/packages/graphql-api/src/lib/graphql-api.ts
@@ -298,7 +298,8 @@ const githubTokenCreationUrl = (repository: Repository) => {
   url.searchParams.set("issues", "read")
   url.searchParams.set("contents", "write")
   url.searchParams.set("pull_requests", "write")
-  // Actions + commit statuses power individual PR status-check handoffs via GraphQL rollup.
+  // Actions + commit statuses help with CI visibility. Per-check CheckRun nodes
+  // need Checks API access, which fine-grained PATs cannot grant — see AGENTS.md.
   url.searchParams.set("actions", "read")
   url.searchParams.set("statuses", "read")
   return url.toString()


### PR DESCRIPTION
## Why

Harness `watch_pr_status_checks` failed on fine-grained GitHub PATs: GraphQL `statusCheckRollup.contexts` needs Checks API access that fine-grained tokens cannot grant, so GenQL failed the whole poll even when rollup state was readable.

## What Changed

- GraphQL now only reads rollup state (not CheckRun contexts).
- Terminal check details load via REST Checks, with Actions jobs fallback on 403, plus latest commit statuses.
- Document fine-grained PAT Checks limitation in `AGENTS.md`.