### PR TITLE
feat(harness): link Jobs card issue identity to GitHub

### DIFF
--- a/apps/harness/src/routes/index.tsx
+++ b/apps/harness/src/routes/index.tsx
@@ -1446,12 +1446,12 @@ function JobsCard() {
   const repositoryById = new Map(
     repositories.map((repository) => [repository.id, repository] as const),
   )
-  const issueTitleByRepoAndNumber = new Map<string, string>()
+  const issueByRepoAndNumber = new Map<string, { title: string; url: string }>()
   for (const query of issueQueries) {
     for (const issue of query.data ?? []) {
-      issueTitleByRepoAndNumber.set(
+      issueByRepoAndNumber.set(
         `${issue.repositoryId}:${issue.githubIssueNumber}`,
-        issue.title,
+        { title: issue.title, url: issue.url },
       )
     }
   }
@@ -1502,13 +1502,23 @@ function JobsCard() {
             repository === undefined
               ? workItem.repositoryId
               : `${repository.githubOwner}/${repository.githubRepo}`
-          const issueTitle = issueTitleByRepoAndNumber.get(
+          const issue = issueByRepoAndNumber.get(
             `${workItem.repositoryId}:${workItem.githubIssueNumber}`,
           )
+          const issueTitle = issue?.title
+          const issueUrl = issue?.url
           const issueIdentity =
             issueTitle === undefined
               ? `#${workItem.githubIssueNumber}`
               : `#${workItem.githubIssueNumber} · ${issueTitle}`
+          const issueIdentityContent = (
+            <>
+              <span className="font-mono">#{workItem.githubIssueNumber}</span>
+              {issueTitle !== undefined && (
+                <span className="font-sans"> · {issueTitle}</span>
+              )}
+            </>
+          )
           return (
             <li
               className="rounded-lg border border-slate-200 bg-slate-50/80 px-3 py-2"
@@ -1519,17 +1529,22 @@ function JobsCard() {
                   <p className="m-0 truncate text-xs font-semibold text-slate-700">
                     {repositoryLabel}
                   </p>
-                  <p
-                    className="m-0 truncate text-xs font-semibold text-blue-600"
-                    title={issueIdentity}
-                  >
-                    <span className="font-mono">
-                      #{workItem.githubIssueNumber}
-                    </span>
-                    {issueTitle !== undefined && (
-                      <span className="font-sans"> · {issueTitle}</span>
-                    )}
-                  </p>
+                  {issueUrl !== undefined && issueUrl !== "" ? (
+                    <a
+                      className="m-0 block truncate text-xs font-semibold text-blue-600 hover:underline"
+                      href={issueUrl}
+                      title={issueIdentity}
+                    >
+                      {issueIdentityContent}
+                    </a>
+                  ) : (
+                    <p
+                      className="m-0 truncate text-xs font-semibold text-blue-600"
+                      title={issueIdentity}
+                    >
+                      {issueIdentityContent}
+                    </p>
+                  )}
                 </div>
                 <div className="flex shrink-0 items-center gap-1">
                   <WorkItemPauseButton workItem={workItem} />

--- a/apps/harness/test/jobs-card-no-polling.test.ts
+++ b/apps/harness/test/jobs-card-no-polling.test.ts
@@ -39,4 +39,13 @@ describe("JobsCard live updates", () => {
     expect(pauseIndex).toBeGreaterThan(-1)
     expect(stateLabelIndex).toBeGreaterThan(pauseIndex)
   })
+
+  test("links issue identity to the Issue store URL when available", () => {
+    const { jobsCard } = jobsCardSource()
+    expect(jobsCard).toContain("issue.url")
+    expect(jobsCard).toContain("href={issueUrl}")
+    expect(jobsCard).toContain("text-blue-600 hover:underline")
+    expect(jobsCard).not.toContain("hover:text-blue-700")
+    expect(jobsCard).toContain('issueUrl !== undefined && issueUrl !== ""')
+  })
 })


### PR DESCRIPTION
## Why

On the harness Jobs card, each Work Item shows the Issue as plain text (`#N · title`). Operators cannot open the GitHub Issue from that line and have to find it elsewhere.

## What Changed

- Jobs card Issue identity (`#N` and optional title) is a single link when the Issue store has a URL for that Work Item's Issue
- Resting colour stays `text-blue-600`; hover underlines only (no colour change)
- When no Issue projection/URL is available, identity stays readable plain text with no broken link
- Source-level Jobs card test covers link href/styling contract

Closes #210