### PR TITLE
fix(keymaxxer-service): resolve Keymaxxer via entrypoint or PATH only

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,10 +15,8 @@ Opinionated agentic software engineering harness to massively increase landed PR
    `keymaxxer@0.2.1` in the root lockfile for live e2e vault tooling
 
 The backend starts Keymaxxer through its MCP server. It uses
-`KEYMAXXER_ENTRYPOINT` when set, otherwise prefers the unreleased local source
-at `/home/berend/src/contrib/keymaxxer/packages/cli/src/index.ts` when present,
-and finally falls back to the installed `keymaxxer` command (including the
-workspace pin).
+`KEYMAXXER_ENTRYPOINT` when set to an existing path (run with `bun`), otherwise
+the installed `keymaxxer` command on PATH (including the workspace pin).
 
 When no Keymaxxer entrypoint or executable is available, the harness starts
 without Keymaxxer and uses the user's ambient GitHub authentication. Set

--- a/docs/adr/0004-development-keymaxxer-sidecar.md
+++ b/docs/adr/0004-development-keymaxxer-sidecar.md
@@ -23,7 +23,7 @@ The GraphQL credential query and mutation use Keymaxxer metadata only; they neve
 
 ## Keyholder
 
-The MCP launcher preserves the known-good development precedence: `KEYMAXXER_ENTRYPOINT`, then `/home/berend/src/contrib/keymaxxer/packages/cli/src/index.ts` when present, then the installed `keymaxxer` command. The Keymaxxer child inherits the backend environment except repository-scoped `GITHUB_TOKEN_<OWNER>_<REPO>` values.
+The MCP launcher resolves Keymaxxer as `KEYMAXXER_ENTRYPOINT` when set to an existing path, otherwise the installed `keymaxxer` command on PATH. There is no hardcoded developer contrib path. The Keymaxxer child inherits the backend environment except repository-scoped `GITHUB_TOKEN_<OWNER>_<REPO>` values.
 
 ## Startup
 

--- a/docs/research/109-keymaxxer-mcp-facade-contract.md
+++ b/docs/research/109-keymaxxer-mcp-facade-contract.md
@@ -206,7 +206,7 @@ Sidecar process
 │         └── McpServer.registerTool(keymaxxer_*) → forward
 └── Shared upstream (lazy, once)
     └── Client + StdioClientTransport → keymaxxer serve
-        (KEYMAXXER_ENTRYPOINT / local path / keymaxxer CLI precedence unchanged)
+        (KEYMAXXER_ENTRYPOINT, then keymaxxer on PATH)
 ```
 
 Concurrency notes (detail belongs in multi-client concurrency research):

--- a/packages/keymaxxer-service/src/lib/mcp-layer.ts
+++ b/packages/keymaxxer-service/src/lib/mcp-layer.ts
@@ -251,11 +251,9 @@ export const keymaxxerMcpCommand = (
   environment: Partial<Record<string, string | undefined>> = process.env,
   pathExists: (path: string) => boolean = existsSync,
 ) => {
-  const entrypoint =
-    environment.KEYMAXXER_ENTRYPOINT ??
-    "/home/berend/src/contrib/keymaxxer/packages/cli/src/index.ts"
+  const entrypoint = environment.KEYMAXXER_ENTRYPOINT?.trim()
 
-  return pathExists(entrypoint)
+  return entrypoint && pathExists(entrypoint)
     ? { command: "bun", args: [entrypoint, "serve"] }
     : { command: "keymaxxer", args: ["serve"] }
 }

--- a/packages/keymaxxer-service/test/mcp-layer.test.ts
+++ b/packages/keymaxxer-service/test/mcp-layer.test.ts
@@ -459,9 +459,42 @@ describe("MCP process configuration", () => {
   })
 
   test("uses an existing explicit Keymaxxer entrypoint", () => {
-    expect(keymaxxerMcpCommand({ KEYMAXXER_ENTRYPOINT: "/bin/true" })).toEqual({
+    expect(
+      keymaxxerMcpCommand(
+        { KEYMAXXER_ENTRYPOINT: "/custom/keymaxxer/index.ts" },
+        (path) => path === "/custom/keymaxxer/index.ts",
+      ),
+    ).toEqual({
       command: "bun",
-      args: ["/bin/true", "serve"],
+      args: ["/custom/keymaxxer/index.ts", "serve"],
+    })
+  })
+
+  test("uses keymaxxer on PATH when entrypoint is unset", () => {
+    expect(keymaxxerMcpCommand({}, () => true)).toEqual({
+      command: "keymaxxer",
+      args: ["serve"],
+    })
+  })
+
+  test("never selects a hardcoded contrib filesystem path", () => {
+    const contrib =
+      "/home/berend/src/contrib/keymaxxer/packages/cli/src/index.ts"
+    expect(keymaxxerMcpCommand({}, (path) => path === contrib)).toEqual({
+      command: "keymaxxer",
+      args: ["serve"],
+    })
+  })
+
+  test("falls back to PATH when entrypoint is set but missing", () => {
+    expect(
+      keymaxxerMcpCommand(
+        { KEYMAXXER_ENTRYPOINT: "/missing/keymaxxer" },
+        () => false,
+      ),
+    ).toEqual({
+      command: "keymaxxer",
+      args: ["serve"],
     })
   })
 
@@ -478,7 +511,7 @@ describe("MCP process configuration", () => {
   test("reports Keymaxxer available from either source", () => {
     expect(
       isKeymaxxerAvailable(
-        {},
+        { KEYMAXXER_ENTRYPOINT: "/custom/keymaxxer/index.ts" },
         () => true,
         () => false,
       ),


### PR DESCRIPTION
## Summary

- Remove the hardcoded developer contrib Keymaxxer path from product resolution
- Resolve only `KEYMAXXER_ENTRYPOINT` (when present), then `keymaxxer` on PATH
- Update unit tests and README/ADR wording to the PATH model

Closes #214

## Test plan

- [x] `nx test keymaxxer-service` (resolution pure seam)
- [x] Pre-commit / affected lint, typecheck, test