### PR TITLE
feat: show lifecycle step as Queued while waiting for OpenCode slot

### DIFF
--- a/docs/adr/0021-limit-concurrent-opencode-sessions.md
+++ b/docs/adr/0021-limit-concurrent-opencode-sessions.md
@@ -2,4 +2,6 @@
 
 The harness Config setting `maxConcurrentOpencodeSessions` (default 2) caps how many concurrent OpenCode CLI processes lifecycle work may spawn. Enforcement is a shared Effect semaphore around lifecycle `Opencode.start` / `Opencode.continue` (not `listModels` or Issue Polling). Config is re-read on each acquire; lowering the limit does not interrupt in-flight processes.
 
+While a Step Run is blocked on that semaphore (no permit yet), the Step Run stays `running` in the database but is marked with reason `waiting_for_opencode_session`. GraphQL projects that mid-run wait as **Queued** on both the lifecycle chip and the overall Work Item status so operators do not count the waiter as an active OpenCode session.
+
 Lifecycle jobs use claim-and-fork on the `jobs` queue with a fiber budget of at least `max(maxConcurrentWorkItems, 2 × maxConcurrentOpencodeSessions)` so non-OpenCode Lifecycle Steps can still progress while OpenCode slots are saturated and Worker Slot admission is not undercut (ADR 0022). Issue Polling remains a separate serial lane (ADR 0019). This extends ADR 0007/0008: lifecycle work may run in parallel across Work Items, still at most one running Step Run per Work Item.

--- a/packages/graphql-api/src/lib/graphql-api.ts
+++ b/packages/graphql-api/src/lib/graphql-api.ts
@@ -41,6 +41,7 @@ import {
   ParentIssueError,
   ResetCleanupError,
   RetryNotEligibleError,
+  STEP_RUN_REASON,
   type StepRunRecord,
   UnfinishedWorkItemExistsError,
   WAITING_FOR_WORKER_SLOT_MESSAGE,
@@ -208,10 +209,20 @@ const statusLabel = (status: WorkItemStatus): string =>
 const latestStepRun = (workItem: WorkItemRecord): StepRunRecord | undefined =>
   workItem.stepRuns.at(-1)
 
+/** Running Step Run blocked on maxConcurrentOpencodeSessions → operator Queued. */
+const isWaitingForOpencodeSession = (stepRun: StepRunRecord): boolean =>
+  stepRun.status === "running" &&
+  stepRun.reasonCode === STEP_RUN_REASON.waitingForOpencodeSession
+
+const stepRunDisplayStatus = (stepRun: StepRunRecord): WorkItemStatus =>
+  isWaitingForOpencodeSession(stepRun) ? "queued" : stepRun.status
+
 const workItemStatus = (workItem: WorkItemRecord): WorkItemStatus => {
   if (workItem.waitingSince != null) return "waiting_for_worker_slot"
   if (isTerminalWorkItemState(workItem.state)) return workItem.state
-  return latestStepRun(workItem)?.status ?? "queued"
+  const latest = latestStepRun(workItem)
+  if (latest === undefined) return "queued"
+  return stepRunDisplayStatus(latest)
 }
 
 const lifecycleLabels = (workItem: WorkItemRecord) => {
@@ -227,7 +238,7 @@ const lifecycleLabels = (workItem: WorkItemRecord) => {
 
   return [...latestRuns].map(([phase, stepRun]) => {
     const status: WorkItemStatus =
-      phase === finalPhase ? "needs_human" : stepRun.status
+      phase === finalPhase ? "needs_human" : stepRunDisplayStatus(stepRun)
     const outcome =
       phase === "decide_pr_merge" && status === "needs_human"
         ? "Human review before merge"

--- a/packages/graphql-api/test/graphql-api.test.ts
+++ b/packages/graphql-api/test/graphql-api.test.ts
@@ -20,6 +20,8 @@ import {
   makeJobId,
 } from "@ready-for-agent/queue-service"
 import {
+  STEP_RUN_REASON,
+  WAITING_FOR_OPENCODE_SESSION_MESSAGE,
   WorkItemLifecycle,
   type WorkItemLifecycleShape,
   WorkItemNotFoundError,
@@ -1496,6 +1498,68 @@ describe("GraphQL API", () => {
                 phase: "GITHUB_STATUS_CHECKS",
                 label: "GitHub status checks: Needs human",
                 status: "NEEDS_HUMAN",
+              },
+            ],
+          },
+        ],
+      },
+    })
+  })
+
+  test("projects running Step Run waiting for OpenCode session as Queued", async () => {
+    const baseRun = workItem.stepRuns[0]!
+    const waiting = {
+      ...workItem,
+      state: "implement",
+      stepRuns: [
+        {
+          ...baseRun,
+          step: "implement",
+          status: "running",
+          reasonCode: STEP_RUN_REASON.waitingForOpencodeSession,
+          reasonMessage: WAITING_FOR_OPENCODE_SESSION_MESSAGE,
+        },
+      ],
+    } as WorkItemRecord
+    await runtime.dispose()
+    runtime = makeRuntime(
+      {},
+      {},
+      {},
+      {},
+      {
+        listWorkItemsForIssue: () => Effect.succeed([waiting]),
+      },
+    )
+
+    const response = await createGraphqlApi(runtime).fetch(
+      graphqlRequest({
+        query: `query WorkItems($repositoryId: ID!, $githubIssueNumber: Int!) {
+          workItems(repositoryId: $repositoryId, githubIssueNumber: $githubIssueNumber) {
+            stateLabel status statusLabel statusMessage
+            lifecycleLabels { phase label status }
+          }
+        }`,
+        variables: {
+          repositoryId: repository.id,
+          githubIssueNumber: issue.githubIssueNumber,
+        },
+      }),
+    )
+
+    expect(await response.json()).toEqual({
+      data: {
+        workItems: [
+          {
+            stateLabel: "Build",
+            status: "QUEUED",
+            statusLabel: "Queued",
+            statusMessage: WAITING_FOR_OPENCODE_SESSION_MESSAGE,
+            lifecycleLabels: [
+              {
+                phase: "IMPLEMENT",
+                label: "Build: Queued",
+                status: "QUEUED",
               },
             ],
           },

--- a/packages/work-item-lifecycle/src/lib/lifecycle-steps-live.ts
+++ b/packages/work-item-lifecycle/src/lib/lifecycle-steps-live.ts
@@ -41,9 +41,9 @@ export const LifecycleStepsLive = Layer.effect(
     const path = yield* Path.Path
     const spawner = yield* ChildProcessSpawner.ChildProcessSpawner
     const rawOpencode = yield* Opencode
-    const opencode = yield* limitOpencodeSessions(rawOpencode, db)
     const github = yield* GitHubService
     const sql = yield* SqlClient.SqlClient
+    const opencode = yield* limitOpencodeSessions(rawOpencode, db, sql)
 
     const withServices = <A, E>(
       effect: Effect.Effect<

--- a/packages/work-item-lifecycle/src/lib/opencode-session-limiter.ts
+++ b/packages/work-item-lifecycle/src/lib/opencode-session-limiter.ts
@@ -1,4 +1,5 @@
-import { Duration, Effect, Option, Semaphore } from "effect"
+import { Context, Duration, Effect, Option, Semaphore } from "effect"
+import type { SqlClient } from "effect/unstable/sql/SqlClient"
 import type { DbServiceShape } from "@ready-for-agent/db-service"
 import type {
   ContinueInput,
@@ -8,6 +9,10 @@ import type {
   StartInput,
 } from "@ready-for-agent/opencode"
 import { Opencode } from "@ready-for-agent/opencode"
+import {
+  STEP_RUN_REASON,
+  WAITING_FOR_OPENCODE_SESSION_MESSAGE,
+} from "./types.js"
 
 const DEFAULT_MAX_CONCURRENT_OPENCODE_SESSIONS = 2
 const CONFIG_RECHECK_INTERVAL = Duration.millis(200)
@@ -25,16 +30,35 @@ export interface OpencodeService {
 }
 
 /**
+ * Ambient Step Run identity for the fiber executing a Lifecycle Step handler.
+ * Used by the OpenCode session limiter to project mid-run wait state.
+ */
+export type CurrentStepRunValue = {
+  readonly stepRunId: string
+  readonly repositoryId: string
+} | null
+
+export const CurrentStepRun = Context.Reference<CurrentStepRunValue>(
+  "@ready-for-agent/work-item-lifecycle/CurrentStepRun",
+  { defaultValue: () => null },
+)
+
+/**
  * Cap concurrent lifecycle OpenCode `start`/`continue` processes using the
  * current harness Config value. `listModels` is not wrapped.
  *
  * Re-reads Config on each acquire attempt and resizes the semaphore so raising
  * the limit frees capacity promptly and lowering it does not interrupt
  * in-flight processes (they finish; new acquires wait until taken drops).
+ *
+ * While waiting for a permit, marks the ambient Step Run with
+ * `waiting_for_opencode_session` so GraphQL can show **Queued** instead of
+ * **Running**.
  */
 export const limitOpencodeSessions = (
   opencode: OpencodeService,
-  db: Pick<DbServiceShape, "getConfig">,
+  db: Pick<DbServiceShape, "getConfig" | "notifyWorkItemsChanged">,
+  sql: Pick<SqlClient, "unsafe">,
 ): Effect.Effect<OpencodeService> =>
   Effect.gen(function* () {
     const semaphore = yield* Semaphore.make(
@@ -46,16 +70,74 @@ export const limitOpencodeSessions = (
       Effect.orElseSucceed(() => DEFAULT_MAX_CONCURRENT_OPENCODE_SESSIONS),
     )
 
+    const reportWaitState = (waiting: boolean): Effect.Effect<void> =>
+      Effect.gen(function* () {
+        const current = yield* CurrentStepRun
+        if (current === null) {
+          return
+        }
+        const now = Date.now()
+        if (waiting) {
+          yield* sql.unsafe(
+            `UPDATE step_run
+             SET reason_code = ?,
+                 reason_message = ?,
+                 updated_at = ?
+             WHERE id = ?
+               AND status = 'running'`,
+            [
+              STEP_RUN_REASON.waitingForOpencodeSession,
+              WAITING_FOR_OPENCODE_SESSION_MESSAGE,
+              now,
+              current.stepRunId,
+            ],
+          )
+        } else {
+          yield* sql.unsafe(
+            `UPDATE step_run
+             SET reason_code = NULL,
+                 reason_message = NULL,
+                 updated_at = ?
+             WHERE id = ?
+               AND status = 'running'
+               AND reason_code = ?`,
+            [now, current.stepRunId, STEP_RUN_REASON.waitingForOpencodeSession],
+          )
+        }
+        yield* db.notifyWorkItemsChanged(current.repositoryId)
+      }).pipe(
+        Effect.catch((error) =>
+          Effect.logWarning(
+            "Failed to update OpenCode session wait state on Step Run",
+            { waiting, error },
+          ),
+        ),
+        Effect.asVoid,
+      )
+
     const withSessionSlot = <A, E, R>(
       effect: Effect.Effect<A, E, R>,
     ): Effect.Effect<A, E, R> =>
       Effect.gen(function* () {
+        let markedWaiting = false
         for (;;) {
           const max = yield* currentMax
           yield* semaphore.resize(max)
-          const result = yield* semaphore.withPermitsIfAvailable(1)(effect)
+          const result = yield* semaphore.withPermitsIfAvailable(1)(
+            Effect.gen(function* () {
+              if (markedWaiting) {
+                yield* reportWaitState(false)
+                markedWaiting = false
+              }
+              return yield* effect
+            }),
+          )
           if (Option.isSome(result)) {
             return result.value
+          }
+          if (!markedWaiting) {
+            yield* reportWaitState(true)
+            markedWaiting = true
           }
           yield* Effect.sleep(CONFIG_RECHECK_INTERVAL)
         }

--- a/packages/work-item-lifecycle/src/lib/types.ts
+++ b/packages/work-item-lifecycle/src/lib/types.ts
@@ -100,6 +100,10 @@ export interface WorkItemRecord {
 export const WAITING_FOR_WORKER_SLOT_MESSAGE =
   "Waiting for a worker slot to become available"
 
+/** Operator-visible message while a running Step Run waits for an OpenCode session slot. */
+export const WAITING_FOR_OPENCODE_SESSION_MESSAGE =
+  "Waiting for an OpenCode session slot"
+
 export const WORK_ITEM_LIFECYCLE_QUEUE = "jobs"
 
 export const WorkItemStepJob = Schema.TaggedStruct("work-item-step", {
@@ -127,6 +131,8 @@ export const STEP_RUN_REASON = {
   abandoned: "abandoned",
   reset: "reset",
   paused: "paused",
+  /** Mid-run: Step Run is Running but blocked on maxConcurrentOpencodeSessions. */
+  waitingForOpencodeSession: "waiting_for_opencode_session",
 } as const
 
 export type StepRunReasonCode =

--- a/packages/work-item-lifecycle/src/lib/work-item-lifecycle.ts
+++ b/packages/work-item-lifecycle/src/lib/work-item-lifecycle.ts
@@ -44,6 +44,7 @@ import {
   WorkItemTerminalError,
 } from "./errors.js"
 import { type LifecycleStepContext, LifecycleSteps } from "./lifecycle-steps.js"
+import { CurrentStepRun } from "./opencode-session-limiter.js"
 import {
   PreCommitHookFailedError,
   PreCommitStageError,
@@ -1886,7 +1887,13 @@ export const makeWorkItemLifecycleLive = (
                       Effect.raceFirst(
                         Effect.suspend(() =>
                           runHandler(stepRun.step, context, workItem),
-                        ).pipe(Effect.timeout(maxDuration)),
+                        ).pipe(
+                          Effect.provideService(CurrentStepRun, {
+                            stepRunId: afterStart.id,
+                            repositoryId: workItem.repository_id,
+                          }),
+                          Effect.timeout(maxDuration),
+                        ),
                         Deferred.await(cancel).pipe(
                           Effect.andThen(Effect.interrupt),
                         ),

--- a/packages/work-item-lifecycle/test/opencode-session-limiter.spec.ts
+++ b/packages/work-item-lifecycle/test/opencode-session-limiter.spec.ts
@@ -1,8 +1,16 @@
 import { Deferred, Effect, Fiber, Layer, Ref } from "effect"
+import { SqlClient } from "effect/unstable/sql"
 import { DatabaseTest } from "@ready-for-agent/db/test"
 import { DbService, DbServiceLive } from "@ready-for-agent/db-service"
 import { Opencode } from "@ready-for-agent/opencode"
-import { limitOpencodeSessions } from "../src/lib/opencode-session-limiter.js"
+import {
+  CurrentStepRun,
+  limitOpencodeSessions,
+} from "../src/lib/opencode-session-limiter.js"
+import {
+  STEP_RUN_REASON,
+  WAITING_FOR_OPENCODE_SESSION_MESSAGE,
+} from "../src/lib/types.js"
 import { describe, expect, it } from "bun:test"
 
 const TestLayer = DbServiceLive.pipe(Layer.provideMerge(DatabaseTest))
@@ -18,11 +26,46 @@ const startInput = {
   variant: "low",
 }
 
+const seedRunningStepRun = (input: {
+  readonly stepRunId: string
+  readonly workItemId: string
+  readonly repositoryId: string
+}) =>
+  Effect.gen(function* () {
+    const sql = yield* SqlClient.SqlClient
+    const now = Date.now()
+    yield* sql.unsafe(
+      `INSERT INTO repository (
+         id, github_owner, github_repo, local_path, is_bare, paused,
+         issues_reconciled_at, created_at, updated_at
+       ) VALUES (?, 'o', 'r', ?, 1, 0, NULL, ?, ?)`,
+      [input.repositoryId, `/tmp/${input.repositoryId}`, now, now],
+    )
+    yield* sql.unsafe(
+      `INSERT INTO work_item (
+         id, repository_id, github_issue_number, model, variant,
+         review_model, review_variant, state, state_ready_at, worktree_path,
+         session_id, failure_code, failure_message, created_at, updated_at
+       ) VALUES (?, ?, 1, 'm', 'v', 'm', 'v', 'implement', ?,
+         '/tmp/worktree', NULL, NULL, NULL, ?, ?)`,
+      [input.workItemId, input.repositoryId, now, now, now],
+    )
+    yield* sql.unsafe(
+      `INSERT INTO step_run (
+         id, work_item_id, step, status, queue_job_id, queued_at,
+         started_at, finished_at, reason_code, reason_message,
+         created_at, updated_at
+       ) VALUES (?, ?, 'implement', 'running', NULL, ?, ?, NULL, NULL, NULL, ?, ?)`,
+      [input.stepRunId, input.workItemId, now, now, now, now],
+    )
+  })
+
 describe("limitOpencodeSessions", () => {
   it("caps concurrent start/continue to Config max and queues the rest", () =>
     runTest(
       Effect.gen(function* () {
         const db = yield* DbService
+        const sql = yield* SqlClient.SqlClient
         yield* db.updateConfig({
           defaultModel: "opencode/deepseek-v4-flash-free",
           defaultVariant: "low",
@@ -57,7 +100,7 @@ describe("limitOpencodeSessions", () => {
           continue: () => gatedRun(),
           listModels: () => Effect.succeed([]),
         })
-        const limited = yield* limitOpencodeSessions(inner, db)
+        const limited = yield* limitOpencodeSessions(inner, db, sql)
 
         const first = yield* limited.start(startInput).pipe(Effect.forkChild)
         const second = yield* limited.start(startInput).pipe(Effect.forkChild)
@@ -91,6 +134,7 @@ describe("limitOpencodeSessions", () => {
     runTest(
       Effect.gen(function* () {
         const db = yield* DbService
+        const sql = yield* SqlClient.SqlClient
         yield* db.updateConfig({
           defaultModel: "opencode/deepseek-v4-flash-free",
           defaultVariant: "low",
@@ -122,7 +166,7 @@ describe("limitOpencodeSessions", () => {
               return ["model-a"]
             }),
         })
-        const limited = yield* limitOpencodeSessions(inner, db)
+        const limited = yield* limitOpencodeSessions(inner, db, sql)
 
         const startFiber = yield* limited
           .start(startInput)
@@ -142,6 +186,7 @@ describe("limitOpencodeSessions", () => {
     runTest(
       Effect.gen(function* () {
         const db = yield* DbService
+        const sql = yield* SqlClient.SqlClient
         yield* db.updateConfig({
           defaultModel: "opencode/deepseek-v4-flash-free",
           defaultVariant: "low",
@@ -172,7 +217,7 @@ describe("limitOpencodeSessions", () => {
             Effect.succeed({ sessionId: "ses_x", assistantText: "" }),
           listModels: () => Effect.succeed([]),
         })
-        const limited = yield* limitOpencodeSessions(inner, db)
+        const limited = yield* limitOpencodeSessions(inner, db, sql)
 
         const first = yield* limited.start(startInput).pipe(Effect.forkChild)
         yield* Deferred.await(firstStarted)
@@ -195,6 +240,102 @@ describe("limitOpencodeSessions", () => {
         yield* Deferred.succeed(releaseFirst, undefined)
         yield* Fiber.join(first)
         yield* Fiber.join(second)
+      }),
+    ))
+
+  it("marks the ambient Step Run waiting while blocked on a session slot", () =>
+    runTest(
+      Effect.gen(function* () {
+        const db = yield* DbService
+        const sql = yield* SqlClient.SqlClient
+        yield* db.updateConfig({
+          defaultModel: "opencode/deepseek-v4-flash-free",
+          defaultVariant: "low",
+          reviewModel: null,
+          reviewVariant: null,
+          maxConcurrentOpencodeSessions: 1,
+          maxConcurrentWorkItems: 5,
+        })
+
+        const repositoryId = "repo-limiter-wait"
+        const workItemId = "wi-01JLIMITERWAIT000000000001"
+        const stepRunId = "srun-01JLIMITERWAIT00000000001"
+        yield* seedRunningStepRun({
+          stepRunId,
+          workItemId,
+          repositoryId,
+        })
+
+        const releaseFirst = yield* Deferred.make<void>()
+        const firstStarted = yield* Deferred.make<void>()
+        const secondStarted = yield* Deferred.make<void>()
+        let starts = 0
+
+        const inner = Opencode.of({
+          start: () =>
+            Effect.gen(function* () {
+              starts += 1
+              if (starts === 1) {
+                yield* Deferred.succeed(firstStarted, undefined)
+                yield* Deferred.await(releaseFirst)
+              } else {
+                yield* Deferred.succeed(secondStarted, undefined)
+              }
+              return { sessionId: `ses_${starts}`, assistantText: "" }
+            }),
+          continue: () =>
+            Effect.succeed({ sessionId: "ses_x", assistantText: "" }),
+          listModels: () => Effect.succeed([]),
+        })
+        const limited = yield* limitOpencodeSessions(inner, db, sql)
+
+        const first = yield* limited.start(startInput).pipe(Effect.forkChild)
+        yield* Deferred.await(firstStarted)
+
+        const second = yield* limited.start(startInput).pipe(
+          Effect.provideService(CurrentStepRun, {
+            stepRunId,
+            repositoryId,
+          }),
+          Effect.forkChild,
+        )
+
+        yield* Effect.sleep("50 millis")
+        expect(starts).toBe(1)
+
+        const waitingRows = (yield* sql.unsafe(
+          `SELECT status, reason_code, reason_message FROM step_run WHERE id = ?`,
+          [stepRunId],
+        )) as readonly {
+          readonly status: string
+          readonly reason_code: string | null
+          readonly reason_message: string | null
+        }[]
+        expect(waitingRows[0]).toEqual({
+          status: "running",
+          reason_code: STEP_RUN_REASON.waitingForOpencodeSession,
+          reason_message: WAITING_FOR_OPENCODE_SESSION_MESSAGE,
+        })
+
+        yield* Deferred.succeed(releaseFirst, undefined)
+        yield* Deferred.await(secondStarted)
+        yield* Fiber.join(first)
+        yield* Fiber.join(second)
+
+        const afterRows = (yield* sql.unsafe(
+          `SELECT status, reason_code, reason_message FROM step_run WHERE id = ?`,
+          [stepRunId],
+        )) as readonly {
+          readonly status: string
+          readonly reason_code: string | null
+          readonly reason_message: string | null
+        }[]
+        expect(afterRows[0]).toEqual({
+          status: "running",
+          reason_code: null,
+          reason_message: null,
+        })
+        expect(starts).toBe(2)
       }),
     ))
 })


### PR DESCRIPTION
## Summary

- While a Step Run is blocked on `maxConcurrentOpencodeSessions`, mark it with `waiting_for_opencode_session` and project **Queued** in GraphQL lifecycle chips and overall Work Item status
- Clear that wait signal when an OpenCode session slot is acquired so the chip returns to **Running**
- Document the overall-badge choice (match chip → Queued) in ADR 0021

Closes #207

## Test plan

- [x] `nx test work-item-lifecycle` (limiter wait-state + existing concurrency tests)
- [x] `nx test graphql-api` (Queued projection for waiting OpenCode session)
- [x] Pre-commit / affected lint, typecheck, test