### PR TITLE
feat(release-versioning): conventional-commit next-version seam

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -225,6 +225,25 @@
         "@types/bun": "^1.3.0",
       },
     },
+    "packages/release-versioning": {
+      "name": "@ready-for-agent/release-versioning",
+      "version": "0.0.1",
+      "bin": {
+        "compute-next-version": "./src/bin/compute-next-version.ts",
+      },
+      "dependencies": {
+        "@conventional-changelog/git-client": "^3.1.0",
+        "conventional-changelog-conventionalcommits": "^10.2.1",
+        "conventional-commits-filter": "^6.0.1",
+        "conventional-commits-parser": "^7.1.0",
+        "semver": "^7.8.5",
+        "tslib": "^2.3.0",
+      },
+      "devDependencies": {
+        "@types/semver": "^7.7.1",
+        "vitest": "^4.1.10",
+      },
+    },
     "packages/sqlite-queue-service": {
       "name": "@ready-for-agent/sqlite-queue-service",
       "version": "0.0.1",
@@ -828,6 +847,8 @@
 
     "@ready-for-agent/queue-service": ["@ready-for-agent/queue-service@workspace:packages/queue-service"],
 
+    "@ready-for-agent/release-versioning": ["@ready-for-agent/release-versioning@workspace:packages/release-versioning"],
+
     "@ready-for-agent/sqlite-queue-service": ["@ready-for-agent/sqlite-queue-service@workspace:packages/sqlite-queue-service"],
 
     "@ready-for-agent/work-item-lifecycle": ["@ready-for-agent/work-item-lifecycle@workspace:packages/work-item-lifecycle"],
@@ -1046,6 +1067,8 @@
 
     "@types/react-dom": ["@types/react-dom@19.2.3", "", { "peerDependencies": { "@types/react": "^19.2.0" } }, "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ=="],
 
+    "@types/semver": ["@types/semver@7.7.1", "", {}, "sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA=="],
+
     "@types/ws": ["@types/ws@8.18.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg=="],
 
     "@typescript/native": ["typescript@7.0.2", "", { "optionalDependencies": { "@typescript/typescript-aix-ppc64": "7.0.2", "@typescript/typescript-darwin-arm64": "7.0.2", "@typescript/typescript-darwin-x64": "7.0.2", "@typescript/typescript-freebsd-arm64": "7.0.2", "@typescript/typescript-freebsd-x64": "7.0.2", "@typescript/typescript-linux-arm": "7.0.2", "@typescript/typescript-linux-arm64": "7.0.2", "@typescript/typescript-linux-loong64": "7.0.2", "@typescript/typescript-linux-mips64el": "7.0.2", "@typescript/typescript-linux-ppc64": "7.0.2", "@typescript/typescript-linux-riscv64": "7.0.2", "@typescript/typescript-linux-s390x": "7.0.2", "@typescript/typescript-linux-x64": "7.0.2", "@typescript/typescript-netbsd-arm64": "7.0.2", "@typescript/typescript-netbsd-x64": "7.0.2", "@typescript/typescript-openbsd-arm64": "7.0.2", "@typescript/typescript-openbsd-x64": "7.0.2", "@typescript/typescript-sunos-x64": "7.0.2", "@typescript/typescript-win32-arm64": "7.0.2", "@typescript/typescript-win32-x64": "7.0.2" }, "bin": { "tsc": "bin/tsc" } }, "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA=="],
@@ -1241,6 +1264,8 @@
     "conventional-changelog-angular": ["conventional-changelog-angular@9.2.1", "", { "dependencies": { "@conventional-changelog/template": "^1.2.1" } }, "sha512-oWSL6ZhnXbYraOFTK3PgRAQJ8fADDAEv5K6AdeyQPLvjFmhG8+ejL0jZZp/R7vTmGJaBvZEE+sE7dB4bCv7sAw=="],
 
     "conventional-changelog-conventionalcommits": ["conventional-changelog-conventionalcommits@10.2.1", "", { "dependencies": { "@conventional-changelog/template": "^1.2.1" } }, "sha512-n4Kr1HFMTf3iMbES0TMxKIcYtUUv4rKqyQQp2JwfOEfFCOfGT3Tq4mCyJ8S9/YPyWhydjfKrrvnyl+gCjA+mJQ=="],
+
+    "conventional-commits-filter": ["conventional-commits-filter@6.0.1", "", {}, "sha512-cs+LadpH7Kpw0M3k8wurk+sOVVDAENA0iK4OBOrkL94j5lEVYRJ4j3zd2bhY9qgzyrPqthdcYT3axzRN7AliMg=="],
 
     "conventional-commits-parser": ["conventional-commits-parser@7.1.0", "", { "dependencies": { "@simple-libs/stream-utils": "^2.0.0", "argue-cli": "^3.1.0" }, "bin": { "conventional-commits-parser": "./dist/cli/index.js" } }, "sha512-DPp6hkUjvwIivxbkrTiLXeRswNv1A/4GFA2X6scXma0AMa9632V3TwxmrlkUIEtUktiM3Ln+RrSH2xlP3/jUTw=="],
 

--- a/packages/release-versioning/package.json
+++ b/packages/release-versioning/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "@ready-for-agent/release-versioning",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    "./package.json": "./package.json",
+    ".": {
+      "@ready-for-agent/source": "./src/index.ts",
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    }
+  },
+  "bin": {
+    "compute-next-version": "./src/bin/compute-next-version.ts"
+  },
+  "dependencies": {
+    "@conventional-changelog/git-client": "^3.1.0",
+    "conventional-changelog-conventionalcommits": "^10.2.1",
+    "conventional-commits-filter": "^6.0.1",
+    "conventional-commits-parser": "^7.1.0",
+    "semver": "^7.8.5",
+    "tslib": "^2.3.0"
+  },
+  "devDependencies": {
+    "@types/semver": "^7.7.1",
+    "vitest": "^4.1.10"
+  }
+}

--- a/packages/release-versioning/project.json
+++ b/packages/release-versioning/project.json
@@ -1,0 +1,25 @@
+{
+  "name": "release-versioning",
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "packages/release-versioning/src",
+  "projectType": "library",
+  "tags": [],
+  "targets": {
+    "test": {
+      "executor": "nx:run-commands",
+      "options": {
+        "cwd": "{projectRoot}",
+        "command": "vitest run"
+      },
+      "inputs": ["default", "^production"],
+      "cache": true
+    },
+    "compute-next-version": {
+      "executor": "nx:run-commands",
+      "options": {
+        "cwd": "{workspaceRoot}",
+        "command": "bun --conditions @ready-for-agent/source packages/release-versioning/src/bin/compute-next-version.ts"
+      }
+    }
+  }
+}

--- a/packages/release-versioning/src/bin/compute-next-version.ts
+++ b/packages/release-versioning/src/bin/compute-next-version.ts
@@ -1,0 +1,23 @@
+import {
+  InvalidVersionError,
+  NothingToReleaseError,
+  computeNextVersionFromGit,
+} from "../index.js"
+
+const cwd = process.argv[2] ?? process.cwd()
+
+try {
+  const next = await computeNextVersionFromGit(cwd)
+  process.stdout.write(`${next.version}\n`)
+} catch (error) {
+  if (error instanceof NothingToReleaseError) {
+    console.error(error.message)
+    process.exitCode = 1
+  } else if (error instanceof InvalidVersionError) {
+    console.error(error.message)
+    process.exitCode = 1
+  } else {
+    console.error(error)
+    process.exitCode = 1
+  }
+}

--- a/packages/release-versioning/src/index.ts
+++ b/packages/release-versioning/src/index.ts
@@ -1,0 +1,10 @@
+export {
+  type ComputeNextVersionInput,
+  type NextVersion,
+  type ReleaseType,
+  computeNextVersion,
+  computeNextVersionFromParsedCommits,
+  releaseVersioningParserOptions,
+} from "./lib/compute-next-version.js"
+export { InvalidVersionError, NothingToReleaseError } from "./lib/errors.js"
+export { computeNextVersionFromGit } from "./lib/from-git.js"

--- a/packages/release-versioning/src/lib/compute-next-version.ts
+++ b/packages/release-versioning/src/lib/compute-next-version.ts
@@ -1,0 +1,97 @@
+import createPreset from "conventional-changelog-conventionalcommits"
+import {
+  type Commit,
+  CommitParser,
+  type ParserOptions,
+} from "conventional-commits-parser"
+import semver from "semver"
+import { InvalidVersionError, NothingToReleaseError } from "./errors.js"
+
+const RELEASE_TYPES = ["major", "minor", "patch"] as const
+
+export type ReleaseType = (typeof RELEASE_TYPES)[number]
+
+export type ComputeNextVersionInput = {
+  lastVersion: string | null
+  commitMessages: readonly string[]
+}
+
+export type NextVersion = {
+  version: string
+  releaseType: ReleaseType
+  reason: string
+}
+
+const FIRST_PUBLIC_VERSION = "0.1.0"
+
+type WhatBumpResult = { level: 0 | 1 | 2; reason: string } | null | undefined
+
+type Preset = {
+  parser: ParserOptions
+  whatBump: (commits: Commit[]) => WhatBumpResult
+}
+
+function loadPreset(): Preset {
+  return createPreset({ preMajor: false }) as Preset
+}
+
+export function computeNextVersion(
+  input: ComputeNextVersionInput,
+): NextVersion {
+  const preset = loadPreset()
+  const parser = new CommitParser(preset.parser)
+  const commits = input.commitMessages.map((message) => parser.parse(message))
+  return nextVersionFromParsed(input.lastVersion, commits, preset.whatBump)
+}
+
+export function computeNextVersionFromParsedCommits(
+  lastVersion: string | null,
+  commits: readonly Commit[],
+): NextVersion {
+  return nextVersionFromParsed(lastVersion, commits, loadPreset().whatBump)
+}
+
+function nextVersionFromParsed(
+  lastVersion: string | null,
+  commits: readonly Commit[],
+  whatBump: (commits: Commit[]) => WhatBumpResult,
+): NextVersion {
+  const recommendation = whatBump([...commits])
+
+  if (recommendation == null || !("level" in recommendation)) {
+    throw new NothingToReleaseError()
+  }
+
+  const releaseType = RELEASE_TYPES[recommendation.level]
+  if (releaseType === undefined) {
+    throw new NothingToReleaseError()
+  }
+
+  if (lastVersion == null || lastVersion === "") {
+    return {
+      version: FIRST_PUBLIC_VERSION,
+      releaseType,
+      reason: `First public version (${recommendation.reason})`,
+    }
+  }
+
+  const cleaned = semver.clean(lastVersion)
+  if (cleaned === null) {
+    throw new InvalidVersionError(lastVersion)
+  }
+
+  const version = semver.inc(cleaned, releaseType)
+  if (version === null) {
+    throw new InvalidVersionError(lastVersion)
+  }
+
+  return {
+    version,
+    releaseType,
+    reason: recommendation.reason,
+  }
+}
+
+export function releaseVersioningParserOptions(): ParserOptions {
+  return loadPreset().parser
+}

--- a/packages/release-versioning/src/lib/errors.ts
+++ b/packages/release-versioning/src/lib/errors.ts
@@ -1,0 +1,17 @@
+export class NothingToReleaseError extends Error {
+  override readonly name = "NothingToReleaseError"
+
+  constructor(
+    message = "Nothing to release: no conventional commits since the last release tag.",
+  ) {
+    super(message)
+  }
+}
+
+export class InvalidVersionError extends Error {
+  override readonly name = "InvalidVersionError"
+
+  constructor(version: string) {
+    super(`Invalid last version: ${version}`)
+  }
+}

--- a/packages/release-versioning/src/lib/from-git.ts
+++ b/packages/release-versioning/src/lib/from-git.ts
@@ -1,0 +1,29 @@
+import { ConventionalGitClient } from "@conventional-changelog/git-client"
+import type { Commit } from "conventional-commits-parser"
+import {
+  type NextVersion,
+  computeNextVersionFromParsedCommits,
+  releaseVersioningParserOptions,
+} from "./compute-next-version.js"
+
+export async function computeNextVersionFromGit(
+  cwd: string = process.cwd(),
+): Promise<NextVersion> {
+  const git = new ConventionalGitClient(cwd)
+  const lastTag = await git.getLastSemverTag()
+  const commits: Commit[] = []
+
+  for await (const commit of git.getCommits(
+    {
+      from: lastTag ?? "",
+      merges: false,
+      format: "%B%n-hash-%n%H",
+      filterReverts: true,
+    },
+    releaseVersioningParserOptions(),
+  )) {
+    commits.push(commit)
+  }
+
+  return computeNextVersionFromParsedCommits(lastTag, commits)
+}

--- a/packages/release-versioning/test/compute-next-version.spec.ts
+++ b/packages/release-versioning/test/compute-next-version.spec.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from "vitest"
+import {
+  InvalidVersionError,
+  NothingToReleaseError,
+  computeNextVersion,
+} from "../src/index.js"
+
+describe("computeNextVersion", () => {
+  it("returns 0.1.0 as the first public version when there is no prior tag", () => {
+    const result = computeNextVersion({
+      lastVersion: null,
+      commitMessages: ["feat: initial product surface"],
+    })
+
+    expect(result).toEqual({
+      version: "0.1.0",
+      releaseType: "minor",
+      reason: expect.stringContaining("First public version"),
+    })
+  })
+
+  it("bumps minor for feat commits", () => {
+    const result = computeNextVersion({
+      lastVersion: "0.1.0",
+      commitMessages: ["feat: add install docs"],
+    })
+
+    expect(result).toMatchObject({
+      version: "0.2.0",
+      releaseType: "minor",
+    })
+  })
+
+  it("bumps patch for fix commits", () => {
+    const result = computeNextVersion({
+      lastVersion: "1.2.3",
+      commitMessages: ["fix: correct path resolution"],
+    })
+
+    expect(result).toMatchObject({
+      version: "1.2.4",
+      releaseType: "patch",
+    })
+  })
+
+  it("bumps major for breaking changes on 0.x", () => {
+    const result = computeNextVersion({
+      lastVersion: "0.5.2",
+      commitMessages: [
+        "feat!: rename public CLI flags\n\nBREAKING CHANGE: --foo is now --bar",
+      ],
+    })
+
+    expect(result).toMatchObject({
+      version: "1.0.0",
+      releaseType: "major",
+    })
+  })
+
+  it("bumps major for BREAKING CHANGE footer without bang", () => {
+    const result = computeNextVersion({
+      lastVersion: "2.0.0",
+      commitMessages: [
+        "fix: drop legacy env\n\nBREAKING CHANGE: LEGACY_PATH is no longer read",
+      ],
+    })
+
+    expect(result).toMatchObject({
+      version: "3.0.0",
+      releaseType: "major",
+    })
+  })
+
+  it("accepts a v-prefixed last version", () => {
+    const result = computeNextVersion({
+      lastVersion: "v1.0.0",
+      commitMessages: ["fix: patch something"],
+    })
+
+    expect(result).toMatchObject({
+      version: "1.0.1",
+      releaseType: "patch",
+    })
+  })
+
+  it("chooses the highest bump among mixed commits", () => {
+    const result = computeNextVersion({
+      lastVersion: "1.0.0",
+      commitMessages: ["chore: tooling", "fix: small bug", "feat: new command"],
+    })
+
+    expect(result).toMatchObject({
+      version: "1.1.0",
+      releaseType: "minor",
+    })
+  })
+
+  it("fails when there is nothing releasable", () => {
+    expect(() =>
+      computeNextVersion({
+        lastVersion: "1.0.0",
+        commitMessages: ["chore: update deps", "docs: fix typo"],
+      }),
+    ).toThrow(NothingToReleaseError)
+  })
+
+  it("fails with a clear message when empty", () => {
+    expect(() =>
+      computeNextVersion({
+        lastVersion: "1.0.0",
+        commitMessages: [],
+      }),
+    ).toThrow(/Nothing to release/)
+  })
+
+  it("fails when last version is not valid semver", () => {
+    expect(() =>
+      computeNextVersion({
+        lastVersion: "not-a-version",
+        commitMessages: ["feat: x"],
+      }),
+    ).toThrow(InvalidVersionError)
+  })
+})

--- a/packages/release-versioning/tsconfig.json
+++ b/packages/release-versioning/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ]
+}

--- a/packages/release-versioning/tsconfig.lib.json
+++ b/packages/release-versioning/tsconfig.lib.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "tsBuildInfoFile": "dist/tsconfig.lib.tsbuildinfo",
+    "emitDeclarationOnly": false,
+    "forceConsistentCasingInFileNames": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"],
+  "references": []
+}

--- a/packages/release-versioning/vitest.config.ts
+++ b/packages/release-versioning/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config"
+
+export default defineConfig({
+  test: {
+    include: ["test/**/*.spec.ts"],
+  },
+})

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -53,6 +53,9 @@
     },
     {
       "path": "./packages/work-item-lifecycle"
+    },
+    {
+      "path": "./packages/release-versioning"
     }
   ]
 }


### PR DESCRIPTION
## Summary

- Add `@ready-for-agent/release-versioning`: thin seam that computes the next semver from the last release tag and conventional commits (parser + conventionalcommits preset + `semver`).
- First public version is `0.1.0`; breaking changes bump major on 0.x; empty release set fails non-zero with a clear message (CLI for CI).
- Unit tests cover the pure versioning seam without full CI; no semantic-release auto-publish wiring.

Closes #218

## Test plan

- [x] `bunx nx run release-versioning:test`
- [x] `bunx nx run release-versioning:typecheck`
- [x] `bunx nx run release-versioning:lint`
- [x] `bunx nx run release-versioning:knip`
- [ ] CI green on this PR