### PR TITLE
fix: strip ANSI and Effect dumps from operator failure messages

### DIFF
--- a/apps/harness/src/server/job-worker.ts
+++ b/apps/harness/src/server/job-worker.ts
@@ -14,6 +14,7 @@ import {
   RepositoryId,
   RepositoryNotFoundError,
 } from "@ready-for-agent/db-service"
+import { formatUserFacingError } from "@ready-for-agent/github-service"
 import {
   ISSUE_POLL_QUEUE,
   ISSUE_REFRESH_QUEUE,
@@ -73,24 +74,8 @@ const currentWorkerGeneration = (): number => {
   return globalState[workerGenerationKey] ?? 0
 }
 
-const formatLogError = (error: unknown): string => {
-  if (typeof error === "string" && error.trim().length > 0) {
-    return error.trim()
-  }
-  if (error instanceof Error && error.message.trim().length > 0) {
-    return error.message.trim()
-  }
-  if (
-    typeof error === "object" &&
-    error !== null &&
-    "message" in error &&
-    typeof (error as { message: unknown }).message === "string" &&
-    (error as { message: string }).message.trim().length > 0
-  ) {
-    return (error as { message: string }).message.trim()
-  }
-  return String(error)
-}
+const formatLogError = (error: unknown): string =>
+  formatUserFacingError(error, "Unknown error")
 
 const RefreshRepositoryJob = Schema.TaggedStruct("refresh-repository", {
   repositoryId: RepositoryId,

--- a/apps/harness/src/server/keymaxxer-github-layer.ts
+++ b/apps/harness/src/server/keymaxxer-github-layer.ts
@@ -5,6 +5,7 @@ import {
   GitHubService,
   type GitHubServiceShape,
   type ReadyLabeledIssue,
+  sanitizeUserFacingText,
 } from "@ready-for-agent/github-service"
 import { KeymaxxerService } from "@ready-for-agent/keymaxxer-service"
 
@@ -98,13 +99,18 @@ const requestError = (
   repository: { owner: string; name: string },
   operation: string,
   detail?: string,
-) =>
-  new GitHubRequestError({
+) => {
+  const cleaned =
+    detail === undefined || detail.trim() === ""
+      ? ""
+      : sanitizeUserFacingText(detail, 300)
+  return new GitHubRequestError({
     message:
-      detail === undefined || detail.trim() === ""
+      cleaned === ""
         ? `Failed to ${operation} for ${repository.owner}/${repository.name}`
-        : `Failed to ${operation} for ${repository.owner}/${repository.name}: ${detail.trim().slice(0, 300)}`,
+        : `Failed to ${operation} for ${repository.owner}/${repository.name}: ${cleaned}`,
   })
+}
 
 const encodeArgument = (value: string) =>
   Buffer.from(value, "utf8").toString("base64url")

--- a/apps/harness/test/keymaxxer-github-layer.test.ts
+++ b/apps/harness/test/keymaxxer-github-layer.test.ts
@@ -1,5 +1,8 @@
 import { Effect, Layer } from "effect"
-import { GitHubService } from "@ready-for-agent/github-service"
+import {
+  GitHubRequestError,
+  GitHubService,
+} from "@ready-for-agent/github-service"
 import {
   KeymaxxerService,
   type RunWithSecretsInput,
@@ -377,6 +380,47 @@ describe("Keymaxxer-backed GitHub layer", () => {
 
     expect(runs[0]?.command).toContain("mark-pr-ready-for-review.ts")
     expect(runs[0]?.secrets).toEqual(["GITHUB_TOKEN_ACME_WIDGETS"])
+  })
+
+  test("sanitizes ANSI Effect dumps from CLI stderr into plain GitHubRequestError messages", async () => {
+    const esc = String.fromCharCode(0x1b)
+    const ansiDump = `{\n  ${esc}[0m_tag${esc}[2m:${esc}[0m ${esc}[32m"GitHubRequestError"${esc}[0m,\n  ${esc}[0mmessage${esc}[2m:${esc}[0m ${esc}[32m"HTTP 401: Bad credentials"${esc}[0m,\n}`
+    const keymaxxerLayer = Layer.succeed(KeymaxxerService, {
+      initialize: Effect.void,
+      findSecret: () => Effect.succeed("GITHUB_TOKEN_ACME_WIDGETS"),
+      findSecrets: () => Effect.die("not used"),
+      hasSecret: () => Effect.die("not used"),
+      addSecret: () => Effect.die("not used"),
+      removeSecret: () => Effect.die("not used"),
+      runWithSecrets: () =>
+        Effect.succeed({
+          exitCode: 1,
+          stdout: "",
+          stderr: ansiDump,
+        }),
+    })
+    const layer = keymaxxerGitHubLayer({ workspaceRoot: "/workspace" }).pipe(
+      Layer.provide(keymaxxerLayer),
+    )
+
+    const error = await Effect.runPromise(
+      Effect.gen(function* () {
+        const github = yield* GitHubService
+        return yield* github
+          .getPullRequestCheckStatus(
+            { owner: "processfocus", name: "monorepo" },
+            "branch",
+          )
+          .pipe(Effect.flip)
+      }).pipe(Effect.provide(layer)),
+    )
+
+    expect(error).toBeInstanceOf(GitHubRequestError)
+    expect(error.message).toBe(
+      "Failed to get pull request check status for processfocus/monorepo: HTTP 401: Bad credentials",
+    )
+    expect(error.message.includes(`${esc}[`)).toBe(false)
+    expect(error.message).not.toContain("_tag")
   })
 
   test("merges a PR through the configured repository token", async () => {

--- a/packages/github-service/src/bin/cli.ts
+++ b/packages/github-service/src/bin/cli.ts
@@ -4,6 +4,7 @@ import {
   GitHubRepositoryUnavailableError,
   type GitHubService,
   GitHubServiceLive,
+  formatUserFacingError,
 } from "../index.js"
 
 class CliArgumentError extends Schema.TaggedErrorClass<CliArgumentError>()(
@@ -33,7 +34,9 @@ export const runGitHubCli = <A, E>(
           process.exitCode = 2
           return
         }
-        console.error(error)
+        process.stderr.write(
+          `${formatUserFacingError(error, "Command failed")}\n`,
+        )
         process.exitCode = 1
       }),
     ),

--- a/packages/github-service/src/index.ts
+++ b/packages/github-service/src/index.ts
@@ -6,3 +6,4 @@ export {
 } from "./lib/github-service-live.js"
 export * from "./lib/github-service-test.js"
 export * from "./lib/types.js"
+export * from "./lib/user-facing-error.js"

--- a/packages/github-service/src/lib/user-facing-error.ts
+++ b/packages/github-service/src/lib/user-facing-error.ts
@@ -1,0 +1,79 @@
+const ESC = String.fromCharCode(0x1b)
+const CSI = String.fromCharCode(0x9b)
+const ANSI_ESCAPE_RE = new RegExp(
+  `[${ESC}${CSI}][[()#;?]*(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[0-9A-ORZcf-nqry=><]`,
+  "g",
+)
+
+export const stripAnsi = (text: string): string =>
+  text.replace(ANSI_ESCAPE_RE, "")
+
+const extractMessageFromInspectDump = (text: string): string | undefined => {
+  if (!/_tag\s*:/.test(text)) {
+    return undefined
+  }
+  const messageMatch = text.match(/message\s*:\s*"((?:\\.|[^"\\])*)"/)
+  if (messageMatch?.[1] !== undefined && messageMatch[1].trim().length > 0) {
+    return messageMatch[1]
+      .replace(/\\n/g, "\n")
+      .replace(/\\"/g, '"')
+      .replace(/\\\\/g, "\\")
+  }
+  const tagMatch = text.match(/_tag\s*:\s*"([^"]+)"/)
+  if (tagMatch?.[1] !== undefined && tagMatch[1].trim().length > 0) {
+    return tagMatch[1]
+  }
+  return undefined
+}
+
+export const sanitizeUserFacingText = (
+  text: string,
+  maxLength?: number,
+): string => {
+  let cleaned = stripAnsi(text).trim()
+  const extracted = extractMessageFromInspectDump(cleaned)
+  if (extracted !== undefined) {
+    cleaned = extracted.trim()
+  }
+  if (maxLength !== undefined) {
+    cleaned = cleaned.slice(0, maxLength)
+  }
+  return cleaned
+}
+
+export const formatUserFacingError = (
+  error: unknown,
+  fallback = "Unknown error",
+  maxLength?: number,
+): string => {
+  const finish = (value: string): string => {
+    const cleaned = sanitizeUserFacingText(value, maxLength)
+    return cleaned.length > 0 ? cleaned : fallback
+  }
+
+  if (typeof error === "string") {
+    return finish(error)
+  }
+  if (
+    typeof error === "object" &&
+    error !== null &&
+    "message" in error &&
+    typeof (error as { message: unknown }).message === "string" &&
+    (error as { message: string }).message.trim().length > 0
+  ) {
+    return finish((error as { message: string }).message)
+  }
+  if (
+    typeof error === "object" &&
+    error !== null &&
+    "_tag" in error &&
+    typeof (error as { _tag: unknown })._tag === "string" &&
+    (error as { _tag: string })._tag.trim().length > 0
+  ) {
+    return finish((error as { _tag: string })._tag)
+  }
+  if (typeof error === "number" || typeof error === "boolean") {
+    return finish(String(error))
+  }
+  return fallback
+}

--- a/packages/github-service/test/github-service.spec.ts
+++ b/packages/github-service/test/github-service.spec.ts
@@ -8,8 +8,11 @@ import {
   GitHubRequestError,
   GitHubService,
   type ReadyLabeledIssue,
+  formatUserFacingError,
   makeGitHubServiceFromToken,
   makeGitHubServiceTest,
+  sanitizeUserFacingText,
+  stripAnsi,
 } from "../src/index.js"
 import {
   type GitHubGraphqlClient,
@@ -1774,6 +1777,27 @@ describe("GitHubService live implementation", () => {
   })
 })
 
+describe("user-facing error formatting", () => {
+  const esc = String.fromCharCode(0x1b)
+  const csiOpen = `${esc}[`
+
+  it("strips ANSI CSI sequences from Effect-style dumps", () => {
+    const colored = `{\n  ${esc}[0m_tag${esc}[2m:${esc}[0m ${esc}[32m"GitHubRequestError"${esc}[0m,\n  ${esc}[0mmessage${esc}[2m:${esc}[0m ${esc}[32m"boom happened"${esc}[0m,\n}`
+    expect(stripAnsi(colored).includes(csiOpen)).toBe(false)
+    expect(sanitizeUserFacingText(colored)).toBe("boom happened")
+    expect(formatUserFacingError(colored, "fallback")).toBe("boom happened")
+  })
+
+  it("prefers Error.message over inspect dumps", () => {
+    const error = new GitHubRequestError({
+      message: "Failed to get pull request check status for acme/widgets",
+    })
+    expect(formatUserFacingError(error, "fallback")).toBe(
+      "Failed to get pull request check status for acme/widgets",
+    )
+  })
+})
+
 describe("CLI arguments", () => {
   it.effect("reports a missing argument as a typed failure", () =>
     Effect.gen(function* () {
@@ -1800,6 +1824,8 @@ describe("CLI arguments", () => {
 
     expect(result.status).toBe(1)
     expect(result.stderr).toContain("Missing owner argument")
+    expect(result.stderr.includes(`${String.fromCharCode(0x1b)}[`)).toBe(false)
+    expect(result.stderr).not.toMatch(/_tag/)
   })
 })
 

--- a/packages/work-item-lifecycle/src/lib/work-item-lifecycle.ts
+++ b/packages/work-item-lifecycle/src/lib/work-item-lifecycle.ts
@@ -19,6 +19,10 @@ import {
   type RepositoryNotFoundError,
 } from "@ready-for-agent/db-service"
 import {
+  formatUserFacingError,
+  sanitizeUserFacingText,
+} from "@ready-for-agent/github-service"
+import {
   type AcknowledgeError,
   EnqueueError,
   InvalidQueueNameError,
@@ -115,34 +119,15 @@ const isActiveStepRunUniqueViolation = (error: SqlError): boolean => {
   )
 }
 
-const conciseMessage = (value: unknown, fallback: string): string => {
-  if (typeof value === "string" && value.trim().length > 0) {
-    return value.trim().slice(0, 500)
-  }
-  if (value instanceof Error && value.message.trim().length > 0) {
-    return value.message.trim().slice(0, 500)
-  }
-  if (
-    typeof value === "object" &&
-    value !== null &&
-    "message" in value &&
-    typeof (value as { message: unknown }).message === "string" &&
-    (value as { message: string }).message.trim().length > 0
-  ) {
-    return (value as { message: string }).message.trim().slice(0, 500)
-  }
-  if (typeof value === "number" || typeof value === "boolean") {
-    return String(value)
-  }
-  return fallback
-}
+const conciseMessage = (value: unknown, fallback: string): string =>
+  formatUserFacingError(value, fallback, 500)
 
 const handlerFailureMessage = (error: unknown): string => {
   if (
     error instanceof PreCommitHookFailedError ||
     error instanceof PreCommitStageError
   ) {
-    return `${error.message}\n${error.output}`
+    return sanitizeUserFacingText(`${error.message}\n${error.output}`)
   }
   return conciseMessage(error, "Lifecycle Step handler failed")
 }


### PR DESCRIPTION
## Summary
- Print plain GitHub CLI failure messages to stderr instead of Effect object dumps with ANSI
- Sanitize subprocess stderr when building `GitHubRequestError` messages for Step Run `reasonMessage`
- Reuse shared user-facing error helpers for lifecycle messages and job-worker logs

## Test plan
- [x] `github-service` unit tests for stripAnsi / formatUserFacingError
- [x] CLI spawn test asserts no CSI / `_tag` on stderr
- [x] Keymaxxer GitHub layer test with ANSI Effect dump → plain message
- [x] Affected lint, typecheck, and tests green

Closes #213