### PR TITLE
feat: product XDG state, browser open, and host-tool preflight

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,10 +11,13 @@ Opinionated agentic software engineering harness to massively increase landed PR
 ## Requirements
 1. git
 2. GitHub CLI tool [gh](https://cli.github.com/)
-3. [keymaxxer](https://github.com/glommer/keymaxxer) — workspace pins exact
-   `keymaxxer@0.2.1` in the root lockfile for live e2e vault tooling
+3. [OpenCode](https://opencode.ai) on `PATH`
+4. [keymaxxer](https://github.com/glommer/keymaxxer) — optional; workspace pins
+   exact `keymaxxer@0.2.1` in the root lockfile for live e2e vault tooling
 
-The backend starts Keymaxxer through its MCP server. It uses
+The operator binary fails fast at start if `git`, `gh`, or OpenCode is missing.
+
+The backend starts Keymaxxer through its MCP server when available. It uses
 `KEYMAXXER_ENTRYPOINT` when set to an existing path (run with `bun`), otherwise
 the installed `keymaxxer` command on PATH (including the workspace pin).
 

--- a/apps/harness/README.md
+++ b/apps/harness/README.md
@@ -35,12 +35,24 @@ READY_FOR_AGENT_GRAPHQL_URL=http://127.0.0.1:4300/graphql \
 
 ## Database
 
-By default the harness stores application data in `tmp/ready-for-agent.db`
-(override with `SQLITE_DATABASE_PATH`). Fully stop the harness before opening
-that file with external write tooling. The harness uses single-process default
-WAL; concurrent writers are not supported. Stale `*.db-tshm` files from older
-multiprocess-WAL runs may remain; Turso rebuilds or ignores them after a clean
-mode switch, and no data migration is required.
+- **Operator binary / product default:** platform data dir
+  (`~/.local/share/ready-for-agent/` on Linux, Application Support on macOS),
+  database file `ready-for-agent.db`.
+- **Monorepo `nx run harness:dev` / `harness:start`:** `tmp/ready-for-agent.db`
+  when `SQLITE_DATABASE_PATH` is unset.
+- **Override:** `SQLITE_DATABASE_PATH` always wins.
+
+Fully stop the harness before opening that file with external write tooling.
+The harness uses single-process default WAL; concurrent writers are not
+supported. Stale `*.db-tshm` files from older multiprocess-WAL runs may remain;
+Turso rebuilds or ignores them after a clean mode switch, and no data migration
+is required.
+
+## Browser open
+
+Production `harness:start` opens the default browser to the local UI after
+listen unless `NO_BROWSER` is set. The operator binary also supports
+`--no-open`.
 
 ## Production
 

--- a/apps/harness/server.ts
+++ b/apps/harness/server.ts
@@ -1,3 +1,4 @@
+import { spawn } from "node:child_process"
 import { resolve, sep } from "node:path"
 import { createApplication } from "./src/server/application.server.js"
 import type { ApplicationRequestContext } from "./src/server-context.js"
@@ -9,6 +10,32 @@ const serverEntryPath = "./dist/server/server.js"
 
 if (!Number.isInteger(port) || port < 1 || port > 65_535) {
   throw new Error("PORT must be a valid TCP port")
+}
+
+const shouldOpenBrowser = () => {
+  const raw = process.env.NO_BROWSER?.trim().toLowerCase()
+  if (raw === undefined || raw === "") return true
+  if (raw === "0" || raw === "false" || raw === "no" || raw === "off") {
+    return true
+  }
+  return false
+}
+
+const openDefaultBrowser = (url: string) => {
+  const launch =
+    process.platform === "darwin"
+      ? { command: "open", args: [url] }
+      : process.platform === "win32"
+        ? { command: "cmd", args: ["/c", "start", "", url] }
+        : { command: "xdg-open", args: [url] }
+  try {
+    spawn(launch.command, launch.args, {
+      detached: true,
+      stdio: "ignore",
+    }).unref()
+  } catch {
+    // Browser open is best-effort; start still succeeds.
+  }
 }
 
 type StartHandler = {
@@ -72,7 +99,11 @@ const server = Bun.serve({
   },
 })
 
-console.info(`Ready for Agent listening on http://${hostname}:${server.port}`)
+const listenUrl = `http://${hostname}:${server.port}/`
+console.info(`Ready for Agent listening on ${listenUrl.slice(0, -1)}`)
+if (shouldOpenBrowser()) {
+  openDefaultBrowser(listenUrl)
+}
 
 let shuttingDown = false
 const shutdown = async () => {

--- a/apps/ready-for-agent/README.md
+++ b/apps/ready-for-agent/README.md
@@ -14,9 +14,33 @@ bun run ready-for-agent start
 ```
 
 This boots the full Harness (UI + backend) on the existing monorepo dev path
-(`harness:dev`), including the Keymaxxer sidecar. By default, application data
-is stored in `tmp/ready-for-agent.db`. Set `SQLITE_DATABASE_PATH` to use another
-SQLite/Turso database.
+(`harness:dev`), including the Keymaxxer sidecar when available.
+
+Before start, the binary checks that required host tools are on `PATH`: `git`,
+`gh`, and OpenCode. Missing tools fail immediately with install hints. Keymaxxer
+is optional; ambient GitHub auth still works without it.
+
+On successful start the default browser opens to the local UI
+(`http://127.0.0.1:4200/` by default). Disable with:
+
+```bash
+bun run ready-for-agent --no-open
+# or
+NO_BROWSER=1 bun run ready-for-agent
+```
+
+### Application data
+
+By default, product state is stored under the platform data directory:
+
+- Linux: `$XDG_DATA_HOME/ready-for-agent/` or `~/.local/share/ready-for-agent/`
+- macOS: `~/Library/Application Support/ready-for-agent/`
+
+The SQLite database file is `ready-for-agent.db` in that directory. Set
+`SQLITE_DATABASE_PATH` to use another SQLite/Turso database (this still overrides
+the product default). Monorepo `nx run harness:dev` may still default to
+`tmp/ready-for-agent.db` when started without the operator binary and without
+`SQLITE_DATABASE_PATH`.
 
 Stop the harness completely before opening that database with external write
 tooling (CLI, GUI, or a second process). The harness uses single-process default
@@ -57,6 +81,7 @@ bun run ready-for-agent remove-github-token repo-01H...
 
 ```bash
 bun run ready-for-agent --help
+bun run ready-for-agent start --help
 bun run ready-for-agent add --help
 bun run ready-for-agent remove-github-token --help
 ```

--- a/apps/ready-for-agent/src/browser-open.test.ts
+++ b/apps/ready-for-agent/src/browser-open.test.ts
@@ -1,0 +1,50 @@
+import {
+  browserOpenCommand,
+  resolveUiUrl,
+  shouldOpenBrowser,
+} from "./browser-open.ts"
+import { describe, expect, test } from "bun:test"
+
+describe("browser open policy", () => {
+  test("opens by default", () => {
+    expect(shouldOpenBrowser({ noOpenFlag: false, env: {} })).toBe(true)
+  })
+
+  test("--no-open disables browser open", () => {
+    expect(shouldOpenBrowser({ noOpenFlag: true, env: {} })).toBe(false)
+  })
+
+  test("NO_BROWSER disables browser open", () => {
+    expect(
+      shouldOpenBrowser({ noOpenFlag: false, env: { NO_BROWSER: "1" } }),
+    ).toBe(false)
+    expect(
+      shouldOpenBrowser({ noOpenFlag: false, env: { NO_BROWSER: "true" } }),
+    ).toBe(false)
+  })
+
+  test("explicit false-like NO_BROWSER keeps open enabled", () => {
+    expect(
+      shouldOpenBrowser({ noOpenFlag: false, env: { NO_BROWSER: "0" } }),
+    ).toBe(true)
+    expect(
+      shouldOpenBrowser({ noOpenFlag: false, env: { NO_BROWSER: "false" } }),
+    ).toBe(true)
+  })
+
+  test("UI URL uses PORT or default 4200", () => {
+    expect(resolveUiUrl({})).toBe("http://127.0.0.1:4200/")
+    expect(resolveUiUrl({ PORT: "4300" })).toBe("http://127.0.0.1:4300/")
+  })
+
+  test("browser open command is platform-appropriate", () => {
+    expect(browserOpenCommand("linux", "http://127.0.0.1:4200/")).toEqual({
+      command: "xdg-open",
+      args: ["http://127.0.0.1:4200/"],
+    })
+    expect(browserOpenCommand("darwin", "http://127.0.0.1:4200/")).toEqual({
+      command: "open",
+      args: ["http://127.0.0.1:4200/"],
+    })
+  })
+})

--- a/apps/ready-for-agent/src/browser-open.ts
+++ b/apps/ready-for-agent/src/browser-open.ts
@@ -2,8 +2,8 @@ export type BrowserOpenEnv = Partial<
   Record<"NO_BROWSER" | "PORT", string | undefined>
 >
 
-export const DEFAULT_UI_PORT = 4200
-export const DEFAULT_UI_HOST = "127.0.0.1"
+const DEFAULT_UI_PORT = 4200
+const DEFAULT_UI_HOST = "127.0.0.1"
 
 /** Whether start should open the default browser to the local UI. */
 export const shouldOpenBrowser = (input: {

--- a/apps/ready-for-agent/src/browser-open.ts
+++ b/apps/ready-for-agent/src/browser-open.ts
@@ -1,0 +1,54 @@
+export type BrowserOpenEnv = Partial<
+  Record<"NO_BROWSER" | "PORT", string | undefined>
+>
+
+export const DEFAULT_UI_PORT = 4200
+export const DEFAULT_UI_HOST = "127.0.0.1"
+
+/** Whether start should open the default browser to the local UI. */
+export const shouldOpenBrowser = (input: {
+  readonly noOpenFlag: boolean
+  readonly env: BrowserOpenEnv
+}): boolean => {
+  if (input.noOpenFlag) {
+    return false
+  }
+
+  const raw = input.env.NO_BROWSER?.trim().toLowerCase()
+  if (raw === undefined || raw === "") {
+    return true
+  }
+
+  if (raw === "0" || raw === "false" || raw === "no" || raw === "off") {
+    return true
+  }
+
+  return false
+}
+
+export const resolveUiUrl = (
+  env: BrowserOpenEnv = {},
+  host: string = DEFAULT_UI_HOST,
+): string => {
+  const port = Number(env.PORT ?? DEFAULT_UI_PORT)
+  const safePort =
+    Number.isInteger(port) && port >= 1 && port <= 65_535
+      ? port
+      : DEFAULT_UI_PORT
+  return `http://${host}:${safePort}/`
+}
+
+export const browserOpenCommand = (
+  platform: string,
+  url: string,
+): { readonly command: string; readonly args: ReadonlyArray<string> } => {
+  if (platform === "darwin") {
+    return { command: "open", args: [url] }
+  }
+
+  if (platform === "win32") {
+    return { command: "cmd", args: ["/c", "start", "", url] }
+  }
+
+  return { command: "xdg-open", args: [url] }
+}

--- a/apps/ready-for-agent/src/cli.test.ts
+++ b/apps/ready-for-agent/src/cli.test.ts
@@ -35,9 +35,10 @@ describe("operator binary CLI seam", () => {
   })
 
   const mockStart = Layer.succeed(StartHarness, {
-    start: Effect.sync(() => {
-      started += 1
-    }),
+    start: () =>
+      Effect.sync(() => {
+        started += 1
+      }),
   })
 
   const mockLocalGit = Layer.succeed(LocalGit, {
@@ -98,7 +99,7 @@ describe("operator binary CLI seam", () => {
     }
   })
 
-  test("binary help lists start, add, and remove-github-token", () => {
+  test("binary help lists start, add, remove-github-token, and --no-open", () => {
     const result = spawnSync(
       "bun",
       ["--conditions", "@ready-for-agent/source", "src/main.ts", "--help"],
@@ -113,6 +114,27 @@ describe("operator binary CLI seam", () => {
     expect(output).toContain("start")
     expect(output).toContain("add")
     expect(output).toContain("remove-github-token")
+    expect(output).toContain("no-open")
+  })
+
+  test("default and start accept --no-open without starting GraphQL commands", async () => {
+    const layer = mockStart.pipe(
+      Layer.provideMerge(mockLocalGit),
+      Layer.provideMerge(
+        Layer.succeed(GraphqlApi, {
+          addRepository: () => Effect.die("graphql should not run for start"),
+          listRepositories: Effect.die("graphql should not run for start"),
+          removeRepositoryGitHubToken: () =>
+            Effect.die("graphql should not run for start"),
+        }),
+      ),
+    )
+
+    await Effect.runPromise(runOperator(["--no-open"], layer))
+    expect(started).toBe(1)
+
+    await Effect.runPromise(runOperator(["start", "--no-open"], layer))
+    expect(started).toBe(2)
   })
 
   test("binary add against unreachable GraphQL prints start hint", () => {

--- a/apps/ready-for-agent/src/cli.ts
+++ b/apps/ready-for-agent/src/cli.ts
@@ -1,5 +1,5 @@
 import { Console, Effect, Schema } from "effect"
-import { Argument, Command } from "effect/unstable/cli"
+import { Argument, Command, Flag } from "effect/unstable/cli"
 import {
   isRepositoryId,
   resolveRepositoryTarget,
@@ -12,6 +12,12 @@ const pathArg = Argument.string("path").pipe(
   Argument.withDescription("Path to a local git repository"),
 )
 
+const noOpenFlag = Flag.boolean("no-open").pipe(
+  Flag.withDescription(
+    "Do not open the default browser after a successful start (also: NO_BROWSER)",
+  ),
+)
+
 class RepositoryNotRegistered extends Schema.TaggedErrorClass<RepositoryNotRegistered>()(
   "RepositoryNotRegistered",
   { detail: Schema.String },
@@ -21,14 +27,19 @@ class RepositoryNotRegistered extends Schema.TaggedErrorClass<RepositoryNotRegis
   }
 }
 
-const startHarness = Effect.gen(function* () {
-  const startHarnessService = yield* StartHarness
-  yield* startHarnessService.start
-})
+const startHarness = (noOpen: boolean) =>
+  Effect.gen(function* () {
+    const startHarnessService = yield* StartHarness
+    yield* startHarnessService.start({ noOpen })
+  })
 
-const startCommand = Command.make("start", {}, () => startHarness).pipe(
+const startCommand = Command.make(
+  "start",
+  { noOpen: noOpenFlag },
+  ({ noOpen }) => startHarness(noOpen),
+).pipe(
   Command.withDescription(
-    "Start the full Harness (UI + backend) on the monorepo dev path",
+    "Start the full Harness (UI + backend); opens the browser unless --no-open / NO_BROWSER",
   ),
 )
 
@@ -92,7 +103,11 @@ const removeGitHubTokenCommand = Command.make(
   ),
 )
 
-export const cli = Command.make("ready-for-agent", {}, () => startHarness).pipe(
+export const cli = Command.make(
+  "ready-for-agent",
+  { noOpen: noOpenFlag },
+  ({ noOpen }) => startHarness(noOpen),
+).pipe(
   Command.withDescription(
     "Ready for Agent operator binary (start Harness, add repositories, manage tokens)",
   ),

--- a/apps/ready-for-agent/src/host-tools-preflight.test.ts
+++ b/apps/ready-for-agent/src/host-tools-preflight.test.ts
@@ -1,0 +1,38 @@
+import { checkHostTools } from "./host-tools-preflight.ts"
+import { describe, expect, test } from "bun:test"
+
+describe("host tools preflight", () => {
+  test("passes when git, gh, and opencode are present", () => {
+    const result = checkHostTools((command) =>
+      ["git", "gh", "opencode"].includes(command),
+    )
+    expect(result.ok).toBe(true)
+  })
+
+  test("passes without keymaxxer", () => {
+    const result = checkHostTools((command) =>
+      ["git", "gh", "opencode"].includes(command),
+    )
+    expect(result.ok).toBe(true)
+  })
+
+  test("fails with install hints when required tools are missing", () => {
+    const result = checkHostTools((command) => command === "git")
+    expect(result.ok).toBe(false)
+    if (result.ok) return
+
+    expect(result.missing.map((tool) => tool.name)).toEqual(["gh", "opencode"])
+    expect(result.message).toContain("gh")
+    expect(result.message).toContain("https://cli.github.com/")
+    expect(result.message).toContain("opencode")
+    expect(result.message).toContain("https://opencode.ai")
+    expect(result.message).toContain("Keymaxxer is optional")
+  })
+
+  test("does not fail solely because keymaxxer is missing", () => {
+    const result = checkHostTools((command) =>
+      ["git", "gh", "opencode"].includes(command),
+    )
+    expect(result).toEqual({ ok: true })
+  })
+})

--- a/apps/ready-for-agent/src/host-tools-preflight.ts
+++ b/apps/ready-for-agent/src/host-tools-preflight.ts
@@ -1,10 +1,10 @@
-export type HostTool = {
+type HostTool = {
   readonly name: string
   readonly installHint: string
   readonly required: boolean
 }
 
-export const HOST_TOOLS: ReadonlyArray<HostTool> = [
+const HOST_TOOLS: ReadonlyArray<HostTool> = [
   {
     name: "git",
     installHint: "Install Git: https://git-scm.com/downloads",

--- a/apps/ready-for-agent/src/host-tools-preflight.ts
+++ b/apps/ready-for-agent/src/host-tools-preflight.ts
@@ -1,0 +1,63 @@
+export type HostTool = {
+  readonly name: string
+  readonly installHint: string
+  readonly required: boolean
+}
+
+export const HOST_TOOLS: ReadonlyArray<HostTool> = [
+  {
+    name: "git",
+    installHint: "Install Git: https://git-scm.com/downloads",
+    required: true,
+  },
+  {
+    name: "gh",
+    installHint: "Install GitHub CLI (gh): https://cli.github.com/",
+    required: true,
+  },
+  {
+    name: "opencode",
+    installHint: "Install OpenCode: https://opencode.ai",
+    required: true,
+  },
+  {
+    name: "keymaxxer",
+    installHint:
+      "Keymaxxer is optional. Install when you want vault-backed secrets; ambient GitHub auth still works without it.",
+    required: false,
+  },
+]
+
+export type HostToolsPreflightResult =
+  | { readonly ok: true }
+  | {
+      readonly ok: false
+      readonly missing: ReadonlyArray<HostTool>
+      readonly message: string
+    }
+
+export const checkHostTools = (
+  commandExists: (command: string) => boolean,
+): HostToolsPreflightResult => {
+  const missingRequired = HOST_TOOLS.filter(
+    (tool) => tool.required && !commandExists(tool.name),
+  )
+
+  if (missingRequired.length === 0) {
+    return { ok: true }
+  }
+
+  const lines = [
+    "Required host tools are missing from PATH:",
+    ...missingRequired.map((tool) => `  - ${tool.name}: ${tool.installHint}`),
+    "",
+    "Install the tools above, then run ready-for-agent again.",
+    "Keymaxxer is optional and does not block start.",
+  ]
+
+  return {
+    ok: false,
+    missing: missingRequired,
+    message: lines.join("\n"),
+  }
+}

--- a/apps/ready-for-agent/src/product-data-dir.test.ts
+++ b/apps/ready-for-agent/src/product-data-dir.test.ts
@@ -1,0 +1,67 @@
+import {
+  resolveDefaultDatabasePath,
+  resolveProductDataDir,
+} from "./product-data-dir.ts"
+import { describe, expect, test } from "bun:test"
+
+describe("product data dir", () => {
+  test("Linux defaults to ~/.local/share/ready-for-agent", () => {
+    expect(
+      resolveProductDataDir({
+        env: {},
+        platform: "linux",
+        home: "/home/op",
+      }),
+    ).toBe("/home/op/.local/share/ready-for-agent")
+  })
+
+  test("Linux honors XDG_DATA_HOME", () => {
+    expect(
+      resolveProductDataDir({
+        env: { XDG_DATA_HOME: "/var/data" },
+        platform: "linux",
+        home: "/home/op",
+      }),
+    ).toBe("/var/data/ready-for-agent")
+  })
+
+  test("macOS uses Application Support", () => {
+    expect(
+      resolveProductDataDir({
+        env: { XDG_DATA_HOME: "/ignored" },
+        platform: "darwin",
+        home: "/Users/op",
+      }),
+    ).toBe("/Users/op/Library/Application Support/ready-for-agent")
+  })
+
+  test("default database path is under the product data dir", () => {
+    expect(
+      resolveDefaultDatabasePath({
+        env: {},
+        platform: "linux",
+        home: "/home/op",
+      }),
+    ).toBe("/home/op/.local/share/ready-for-agent/ready-for-agent.db")
+  })
+
+  test("SQLITE_DATABASE_PATH overrides the product default", () => {
+    expect(
+      resolveDefaultDatabasePath({
+        env: { SQLITE_DATABASE_PATH: "/custom/app.db" },
+        platform: "linux",
+        home: "/home/op",
+      }),
+    ).toBe("/custom/app.db")
+  })
+
+  test("blank SQLITE_DATABASE_PATH falls back to product default", () => {
+    expect(
+      resolveDefaultDatabasePath({
+        env: { SQLITE_DATABASE_PATH: "  " },
+        platform: "linux",
+        home: "/home/op",
+      }),
+    ).toBe("/home/op/.local/share/ready-for-agent/ready-for-agent.db")
+  })
+})

--- a/apps/ready-for-agent/src/product-data-dir.ts
+++ b/apps/ready-for-agent/src/product-data-dir.ts
@@ -1,6 +1,6 @@
 import { join } from "node:path"
 
-export type ProductPathEnv = Partial<
+type ProductPathEnv = Partial<
   Record<"HOME" | "XDG_DATA_HOME" | "SQLITE_DATABASE_PATH", string | undefined>
 >
 

--- a/apps/ready-for-agent/src/product-data-dir.ts
+++ b/apps/ready-for-agent/src/product-data-dir.ts
@@ -1,0 +1,42 @@
+import { join } from "node:path"
+
+export type ProductPathEnv = Partial<
+  Record<"HOME" | "XDG_DATA_HOME" | "SQLITE_DATABASE_PATH", string | undefined>
+>
+
+export type ProductPathInput = {
+  readonly env: ProductPathEnv
+  readonly platform: string
+  readonly home: string
+}
+
+/** Product application data directory (XDG on Linux, Application Support on macOS). */
+export const resolveProductDataDir = ({
+  env,
+  platform,
+  home,
+}: ProductPathInput): string => {
+  if (platform === "darwin") {
+    return join(home, "Library", "Application Support", "ready-for-agent")
+  }
+
+  const xdgDataHome = env.XDG_DATA_HOME?.trim()
+  if (xdgDataHome !== undefined && xdgDataHome !== "") {
+    return join(xdgDataHome, "ready-for-agent")
+  }
+
+  return join(home, ".local", "share", "ready-for-agent")
+}
+
+/**
+ * Database file path for product mode.
+ * `SQLITE_DATABASE_PATH` wins when set; otherwise the product data dir.
+ */
+export const resolveDefaultDatabasePath = (input: ProductPathInput): string => {
+  const override = input.env.SQLITE_DATABASE_PATH?.trim()
+  if (override !== undefined && override !== "") {
+    return override
+  }
+
+  return join(resolveProductDataDir(input), "ready-for-agent.db")
+}

--- a/apps/ready-for-agent/src/services/start-harness.ts
+++ b/apps/ready-for-agent/src/services/start-harness.ts
@@ -1,8 +1,16 @@
 import { spawn } from "node:child_process"
-import { existsSync } from "node:fs"
+import { existsSync, mkdirSync } from "node:fs"
+import { homedir } from "node:os"
 import { dirname, join, resolve } from "node:path"
 import { fileURLToPath } from "node:url"
 import { Context, Effect, Layer, Schema } from "effect"
+import {
+  browserOpenCommand,
+  resolveUiUrl,
+  shouldOpenBrowser,
+} from "../browser-open.ts"
+import { checkHostTools } from "../host-tools-preflight.ts"
+import { resolveDefaultDatabasePath } from "../product-data-dir.ts"
 
 export class StartHarnessFailed extends Schema.TaggedErrorClass<StartHarnessFailed>()(
   "StartHarnessFailed",
@@ -11,6 +19,10 @@ export class StartHarnessFailed extends Schema.TaggedErrorClass<StartHarnessFail
   override get message() {
     return this.detail
   }
+}
+
+export type StartHarnessOptions = {
+  readonly noOpen?: boolean
 }
 
 const findMonorepoRoot = (
@@ -33,66 +45,172 @@ const findMonorepoRoot = (
   return undefined
 }
 
+const commandExists = (command: string) => Bun.which(command) !== null
+
+const ensureDatabaseParentDir = (databasePath: string) => {
+  if (databasePath === ":memory:" || databasePath.startsWith("libsql:")) {
+    return
+  }
+  const filePath = databasePath.startsWith("file://")
+    ? databasePath.slice("file://".length)
+    : databasePath.startsWith("file:")
+      ? databasePath.slice("file:".length)
+      : databasePath
+  if (filePath === ":memory:") {
+    return
+  }
+  mkdirSync(dirname(resolve(filePath)), { recursive: true })
+}
+
+const openBrowserWhenReady = (url: string) => {
+  const { command, args } = browserOpenCommand(process.platform, url)
+  const deadline = Date.now() + 60_000
+
+  const tryOpen = async () => {
+    while (Date.now() < deadline) {
+      try {
+        const response = await fetch(url, { redirect: "manual" })
+        void response.body?.cancel()
+        if (response.status > 0) {
+          spawn(command, [...args], {
+            detached: true,
+            stdio: "ignore",
+          }).unref()
+          return
+        }
+      } catch {
+        // Port not ready yet.
+      }
+      await Bun.sleep(250)
+    }
+  }
+
+  void tryOpen()
+}
+
 export class StartHarness extends Context.Service<
   StartHarness,
   {
-    readonly start: Effect.Effect<void, StartHarnessFailed>
+    readonly start: (
+      options?: StartHarnessOptions,
+    ) => Effect.Effect<void, StartHarnessFailed>
   }
 >()("ready-for-agent/StartHarness") {
   static readonly layer = Layer.succeed(StartHarness, {
-    start: Effect.callback<void, StartHarnessFailed>((resume) => {
-      const root = findMonorepoRoot()
-      if (root === undefined) {
-        resume(
-          Effect.fail(
-            new StartHarnessFailed({
-              detail:
-                "Could not find the ready-for-agent monorepo root (expected nx.json and apps/harness).",
-            }),
-          ),
-        )
-        return
-      }
-
-      const child = spawn("bun", ["nx", "run", "harness:dev"], {
-        cwd: root,
-        env: process.env,
-        stdio: "inherit",
-      })
-
-      child.on("error", (error) => {
-        resume(
-          Effect.fail(
-            new StartHarnessFailed({
-              detail: error.message,
-            }),
-          ),
-        )
-      })
-
-      child.on("exit", (code, signal) => {
-        if (signal) {
+    start: (options = {}) =>
+      Effect.callback<void, StartHarnessFailed>((resume) => {
+        const preflight = checkHostTools(commandExists)
+        if (!preflight.ok) {
           resume(
             Effect.fail(
               new StartHarnessFailed({
-                detail: `Harness exited via signal ${signal}`,
+                detail: preflight.message,
               }),
             ),
           )
           return
         }
-        if (code !== 0 && code !== null) {
+
+        const root = findMonorepoRoot()
+        if (root === undefined) {
           resume(
             Effect.fail(
               new StartHarnessFailed({
-                detail: `Harness exited with code ${code}`,
+                detail:
+                  "Could not find the ready-for-agent monorepo root (expected nx.json and apps/harness).",
               }),
             ),
           )
           return
         }
-        resume(Effect.void)
-      })
-    }),
+
+        const home = process.env.HOME?.trim() || homedir()
+        const databasePath = resolveDefaultDatabasePath({
+          env: {
+            HOME: process.env.HOME,
+            XDG_DATA_HOME: process.env.XDG_DATA_HOME,
+            SQLITE_DATABASE_PATH: process.env.SQLITE_DATABASE_PATH,
+          },
+          platform: process.platform,
+          home,
+        })
+        try {
+          ensureDatabaseParentDir(databasePath)
+        } catch (error) {
+          resume(
+            Effect.fail(
+              new StartHarnessFailed({
+                detail:
+                  error instanceof Error
+                    ? error.message
+                    : `Could not create database directory for ${databasePath}`,
+              }),
+            ),
+          )
+          return
+        }
+
+        const env: NodeJS.ProcessEnv = {
+          ...process.env,
+          SQLITE_DATABASE_PATH: databasePath,
+        }
+
+        const child = spawn("bun", ["nx", "run", "harness:dev"], {
+          cwd: root,
+          env,
+          stdio: "inherit",
+        })
+
+        if (
+          shouldOpenBrowser({
+            noOpenFlag: options.noOpen === true,
+            env: {
+              NO_BROWSER: process.env.NO_BROWSER,
+              PORT: process.env.PORT,
+            },
+          })
+        ) {
+          openBrowserWhenReady(
+            resolveUiUrl({
+              NO_BROWSER: process.env.NO_BROWSER,
+              PORT: process.env.PORT,
+            }),
+          )
+        }
+
+        child.on("error", (error) => {
+          resume(
+            Effect.fail(
+              new StartHarnessFailed({
+                detail: error.message,
+              }),
+            ),
+          )
+        })
+
+        child.on("exit", (code, signal) => {
+          if (signal) {
+            resume(
+              Effect.fail(
+                new StartHarnessFailed({
+                  detail: `Harness exited via signal ${signal}`,
+                }),
+              ),
+            )
+            return
+          }
+          if (code !== 0 && code !== null) {
+            resume(
+              Effect.fail(
+                new StartHarnessFailed({
+                  detail: `Harness exited with code ${code}`,
+                }),
+              ),
+            )
+            return
+          }
+          resume(Effect.void)
+        })
+      }),
   })
 }

--- a/hk.pkl
+++ b/hk.pkl
@@ -32,11 +32,21 @@ esac
         depends = "bun-lockfile"
         glob = List("*.ts", "*.tsx", "*.js", "*.jsx", "*.json", "**/*.ts", "**/*.tsx", "**/*.js", "**/*.jsx", "**/*.json")
         exclude = "**/generated/**"
-        fix = "unset $(git rev-parse --local-env-vars); bunx nx affected -t lint --fix --batch --excludeTaskDependencies"
+        // Strip git local-env-vars and NX_* so hooks under `nx run harness:dev`
+        // are not treated as nested Nx invocations (false recursive-task errors).
+        fix = #"""
+unset $(git rev-parse --local-env-vars)
+for v in $(printenv | cut -d= -f1 | grep '^NX_'); do unset "$v"; done
+bunx nx affected -t lint --fix --batch --excludeTaskDependencies
+"""#
       }
       ["nx-affected"] {
         depends = List("biome-json", "nx-lint-fix")
-        check = "unset $(git rev-parse --local-env-vars); bunx nx affected -t lint,typecheck,test --batch"
+        check = #"""
+unset $(git rev-parse --local-env-vars)
+for v in $(printenv | cut -d= -f1 | grep '^NX_'); do unset "$v"; done
+bunx nx affected -t lint,typecheck,test --batch
+"""#
       }
     }
   }

--- a/packages/layer-turso-local/src/lib/client-live.ts
+++ b/packages/layer-turso-local/src/lib/client-live.ts
@@ -1,3 +1,5 @@
+import { mkdirSync } from "node:fs"
+import { dirname } from "node:path"
 import { connect } from "@tursodatabase/database"
 import { Context, Effect, Layer, Scope, Semaphore, Stream } from "effect"
 import * as Reactivity from "effect/unstable/reactivity/Reactivity"
@@ -42,8 +44,14 @@ const sqlError = (cause: unknown, operation: string) =>
     }),
   })
 
+const ensureLocalDatabaseParentDir = (path: string) => {
+  if (path === ":memory:") return
+  mkdirSync(dirname(path), { recursive: true })
+}
+
 const makeClient = (path: string, options?: TursoClientOptions) =>
   Effect.gen(function* () {
+    ensureLocalDatabaseParentDir(path)
     const databaseOptions: NonNullable<Parameters<typeof connect>[1]> = {}
     if (options?.defaultQueryTimeout !== undefined)
       databaseOptions.defaultQueryTimeout = options.defaultQueryTimeout

--- a/packages/layer-turso-local/src/lib/database-path.ts
+++ b/packages/layer-turso-local/src/lib/database-path.ts
@@ -1,4 +1,5 @@
-import { isAbsolute, resolve } from "node:path"
+import { homedir } from "node:os"
+import { isAbsolute, join, resolve } from "node:path"
 import { Context } from "effect"
 import * as Config from "effect/Config"
 
@@ -33,12 +34,52 @@ export const toTursoDatabasePath = (path: string): string => {
   return resolveLocalFilePath(path)
 }
 
+export type ProductDataDirInput = {
+  readonly env: {
+    readonly HOME?: string
+    readonly XDG_DATA_HOME?: string
+  }
+  readonly platform: string
+  readonly home: string
+}
+
+/** Product application data directory (XDG on Linux, Application Support on macOS). */
+export const resolveProductDataDir = ({
+  env,
+  platform,
+  home,
+}: ProductDataDirInput): string => {
+  if (platform === "darwin") {
+    return join(home, "Library", "Application Support", "ready-for-agent")
+  }
+
+  const xdgDataHome = env.XDG_DATA_HOME?.trim()
+  if (xdgDataHome !== undefined && xdgDataHome !== "") {
+    return join(xdgDataHome, "ready-for-agent")
+  }
+
+  return join(home, ".local", "share", "ready-for-agent")
+}
+
+/** Product default SQLite path when SQLITE_DATABASE_PATH is unset. */
+export const resolveProductDatabasePath = (
+  input: ProductDataDirInput,
+): string => join(resolveProductDataDir(input), "ready-for-agent.db")
+
+const productDatabasePathFromProcess = (): string =>
+  resolveProductDatabasePath({
+    env: process.env,
+    platform: process.platform,
+    home: process.env.HOME?.trim() || homedir(),
+  })
+
 /**
  * Effect Config for the database path (SQLITE_DATABASE_PATH).
+ * Defaults to the product XDG / platform data directory when unset.
  */
 export const DatabasePathConfig: Config.Config<string> = Config.string(
   "SQLITE_DATABASE_PATH",
-)
+).pipe(Config.orElse(() => Config.succeed(productDatabasePathFromProcess())))
 
 export const DATABASE_PATH_NOT_CONFIGURED =
   "Database path not configured. Set SQLITE_DATABASE_PATH environment variable."

--- a/packages/layer-turso-local/test/normalize-path.spec.ts
+++ b/packages/layer-turso-local/test/normalize-path.spec.ts
@@ -1,6 +1,8 @@
 import {
   isLocalFilePath,
   normalizeDatabasePath,
+  resolveProductDataDir,
+  resolveProductDatabasePath,
   toTursoDatabasePath,
 } from "../src/index.js"
 import { describe, expect, it } from "bun:test"
@@ -32,5 +34,39 @@ describe("Turso database path helpers", () => {
     expect(toTursoDatabasePath("/abs/data/app.db")).toBe("/abs/data/app.db")
     expect(toTursoDatabasePath(":memory:")).toBe(":memory:")
     expect(toTursoDatabasePath("file::memory:")).toBe(":memory:")
+  })
+
+  it("resolves product data dir for Linux and macOS", () => {
+    expect(
+      resolveProductDataDir({
+        env: {},
+        platform: "linux",
+        home: "/home/op",
+      }),
+    ).toBe("/home/op/.local/share/ready-for-agent")
+    expect(
+      resolveProductDataDir({
+        env: { XDG_DATA_HOME: "/var/data" },
+        platform: "linux",
+        home: "/home/op",
+      }),
+    ).toBe("/var/data/ready-for-agent")
+    expect(
+      resolveProductDataDir({
+        env: {},
+        platform: "darwin",
+        home: "/Users/op",
+      }),
+    ).toBe("/Users/op/Library/Application Support/ready-for-agent")
+  })
+
+  it("resolves product database path under the data dir", () => {
+    expect(
+      resolveProductDatabasePath({
+        env: {},
+        platform: "linux",
+        home: "/home/op",
+      }),
+    ).toBe("/home/op/.local/share/ready-for-agent/ready-for-agent.db")
   })
 })


### PR DESCRIPTION
## Summary
- Default product state under XDG / macOS Application Support (`ready-for-agent.db`), with `SQLITE_DATABASE_PATH` still overriding
- Open the local UI in the browser on successful start; opt out via `--no-open` or `NO_BROWSER`
- Fail fast when required host tools (`git`, `gh`, OpenCode) are missing; Keymaxxer remains optional

Closes #216

## Test plan
- [x] `ready-for-agent` unit tests (path, browser policy, host-tool preflight, CLI)
- [x] `layer-turso-local` path/default tests
- [x] Pre-commit / affected lint, typecheck, test
- [ ] Manual: `ready-for-agent --no-open` starts harness without browser
- [ ] Manual: missing `opencode`/`gh` on PATH yields install hints and does not start