### PR TITLE
feat: add publishable launcher and platform binary packages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@ dist
 tmp
 out-tsc
 
+# platform package binaries (filled by ready-for-agent:compile / release)
+/packages/ready-for-agent-*/bin/
+
 # generated GraphQL clients
 /packages/graphql-client/src/generated/
 /packages/github-service/src/internal/generated/

--- a/apps/ready-for-agent/README.md
+++ b/apps/ready-for-agent/README.md
@@ -3,6 +3,35 @@
 Unified operator binary for Ready for Agent: start the Harness and run operator
 commands against its GraphQL endpoint.
 
+## Public package shape
+
+The publishable launcher is this package (`ready-for-agent`) with a Node-compatible
+bin that selects the host platform binary from optional dependencies:
+
+- `ready-for-agent-linux-x64`
+- `ready-for-agent-linux-arm64`
+- `ready-for-agent-darwin-x64`
+- `ready-for-agent-darwin-arm64`
+
+Compile a host binary into the matching platform package:
+
+```bash
+bunx nx run ready-for-agent:compile
+# or a specific platform key:
+bunx nx run ready-for-agent:compile --platform=linux-x64
+```
+
+Then the launcher runs that binary without Bun on `PATH`:
+
+```bash
+node apps/ready-for-agent/bin/ready-for-agent.js --help
+```
+
+Unsupported platforms (including Windows in v1) exit with a clear error from the
+platform-selection seam (`bin/select-platform.js`).
+
+Internal `@ready-for-agent/*` workspace packages stay private and are not published.
+
 ## Usage (monorepo)
 
 From the repository root:

--- a/apps/ready-for-agent/bin/ready-for-agent.js
+++ b/apps/ready-for-agent/bin/ready-for-agent.js
@@ -1,0 +1,64 @@
+#!/usr/bin/env node
+import { spawnSync } from "node:child_process"
+import { existsSync } from "node:fs"
+import { createRequire } from "node:module"
+import { dirname, join } from "node:path"
+import { selectPlatformPackage } from "./select-platform.js"
+
+const require = createRequire(import.meta.url)
+
+const selection = selectPlatformPackage({
+  platform: process.platform,
+  arch: process.arch,
+})
+
+if (!selection.ok) {
+  console.error(selection.message)
+  process.exit(1)
+}
+
+/**
+ * @param {string} packageName
+ * @param {string} binaryRelativePath
+ * @returns {string | undefined}
+ */
+const resolveInstalledBinary = (packageName, binaryRelativePath) => {
+  try {
+    const packageJsonPath = require.resolve(`${packageName}/package.json`)
+    return join(dirname(packageJsonPath), binaryRelativePath)
+  } catch {
+    return undefined
+  }
+}
+
+const binaryPath = resolveInstalledBinary(
+  selection.packageName,
+  selection.binaryRelativePath,
+)
+
+if (binaryPath === undefined) {
+  console.error(
+    `Could not find the ${selection.packageName} package, which is required for ${selection.platformKey}. ` +
+      `Reinstall ready-for-agent without --no-optional so npm can install the matching platform package.`,
+  )
+  process.exit(1)
+}
+
+if (!existsSync(binaryPath)) {
+  console.error(
+    `The ${selection.packageName} package is installed but the binary is missing at ${binaryPath}. ` +
+      `Reinstall the package, or in a monorepo checkout run: bunx nx run ready-for-agent:compile`,
+  )
+  process.exit(1)
+}
+
+const result = spawnSync(binaryPath, process.argv.slice(2), {
+  stdio: "inherit",
+})
+
+if (result.error) {
+  console.error(result.error.message)
+  process.exit(1)
+}
+
+process.exit(result.status === null ? 1 : result.status)

--- a/apps/ready-for-agent/bin/select-platform.js
+++ b/apps/ready-for-agent/bin/select-platform.js
@@ -1,0 +1,128 @@
+/**
+ * Pure platform → package selection for the ready-for-agent launcher.
+ * Node-compatible; no Bun APIs. Unit-tested from select-platform.test.ts.
+ */
+
+/** @typedef {"linux-x64" | "linux-arm64" | "darwin-x64" | "darwin-arm64"} SupportedPlatformKey */
+
+/**
+ * @typedef {object} PlatformPackageSelection
+ * @property {true} ok
+ * @property {SupportedPlatformKey} platformKey
+ * @property {string} packageName
+ * @property {string} binaryRelativePath
+ */
+
+/**
+ * @typedef {object} UnsupportedPlatform
+ * @property {false} ok
+ * @property {string} message
+ */
+
+/** @type {ReadonlyArray<SupportedPlatformKey>} */
+export const SUPPORTED_PLATFORM_KEYS = Object.freeze([
+  "linux-x64",
+  "linux-arm64",
+  "darwin-x64",
+  "darwin-arm64",
+])
+
+/** @type {Readonly<Record<SupportedPlatformKey, string>>} */
+export const PLATFORM_PACKAGE_NAMES = Object.freeze({
+  "linux-x64": "ready-for-agent-linux-x64",
+  "linux-arm64": "ready-for-agent-linux-arm64",
+  "darwin-x64": "ready-for-agent-darwin-x64",
+  "darwin-arm64": "ready-for-agent-darwin-arm64",
+})
+
+export const BINARY_RELATIVE_PATH = "bin/ready-for-agent"
+
+/**
+ * @param {string} arch
+ * @returns {string | undefined}
+ */
+const normalizeArch = (arch) => {
+  if (arch === "x64" || arch === "x86_64" || arch === "amd64") return "x64"
+  if (arch === "arm64" || arch === "aarch64") return "arm64"
+  return undefined
+}
+
+/**
+ * @param {string} platform
+ * @returns {string | undefined}
+ */
+const normalizeOs = (platform) => {
+  if (platform === "linux") return "linux"
+  if (platform === "darwin") return "darwin"
+  return undefined
+}
+
+/**
+ * @param {{ platform: string, arch: string }} host
+ * @returns {PlatformPackageSelection | UnsupportedPlatform}
+ */
+export const selectPlatformPackage = (host) => {
+  const os = normalizeOs(host.platform)
+  const arch = normalizeArch(host.arch)
+
+  if (os === undefined || arch === undefined) {
+    return {
+      ok: false,
+      message: unsupportedPlatformMessage(host.platform, host.arch),
+    }
+  }
+
+  /** @type {string} */
+  const platformKey = `${os}-${arch}`
+  if (!Object.hasOwn(PLATFORM_PACKAGE_NAMES, platformKey)) {
+    return {
+      ok: false,
+      message: unsupportedPlatformMessage(host.platform, host.arch),
+    }
+  }
+
+  /** @type {SupportedPlatformKey} */
+  const key = /** @type {SupportedPlatformKey} */ (platformKey)
+  return {
+    ok: true,
+    platformKey: key,
+    packageName: PLATFORM_PACKAGE_NAMES[key],
+    binaryRelativePath: BINARY_RELATIVE_PATH,
+  }
+}
+
+/**
+ * @param {string} platform
+ * @param {string} arch
+ * @returns {string}
+ */
+export const unsupportedPlatformMessage = (platform, arch) => {
+  const supported = SUPPORTED_PLATFORM_KEYS.join(", ")
+  return (
+    `ready-for-agent does not support this platform (${platform}/${arch}). ` +
+    `Supported platforms: ${supported}. ` +
+    `Windows is not supported in v1.`
+  )
+}
+
+/**
+ * Bun compile --target value for a supported platform key.
+ * @param {SupportedPlatformKey} platformKey
+ * @returns {string}
+ */
+export const bunCompileTarget = (platformKey) => {
+  switch (platformKey) {
+    case "linux-x64":
+      return "bun-linux-x64"
+    case "linux-arm64":
+      return "bun-linux-arm64"
+    case "darwin-x64":
+      return "bun-darwin-x64"
+    case "darwin-arm64":
+      return "bun-darwin-arm64"
+    default: {
+      const _exhaustive = /** @type {never} */ (platformKey)
+      return _exhaustive
+    }
+  }
+}

--- a/apps/ready-for-agent/package.json
+++ b/apps/ready-for-agent/package.json
@@ -1,13 +1,24 @@
 {
   "name": "ready-for-agent",
   "version": "0.0.0",
-  "private": true,
+  "description": "Ready for Agent: local Harness UI + backend and operator CLI",
+  "license": "MIT",
   "type": "module",
   "bin": {
-    "ready-for-agent": "./src/main.ts"
+    "ready-for-agent": "./bin/ready-for-agent.js"
   },
+  "files": [
+    "bin/ready-for-agent.js",
+    "bin/select-platform.js"
+  ],
   "scripts": {
     "typecheck": "tsc --noEmit -p tsconfig.app.json"
+  },
+  "optionalDependencies": {
+    "ready-for-agent-darwin-arm64": "0.0.0",
+    "ready-for-agent-darwin-x64": "0.0.0",
+    "ready-for-agent-linux-arm64": "0.0.0",
+    "ready-for-agent-linux-x64": "0.0.0"
   },
   "dependencies": {
     "@effect/platform-bun": "^4.0.0-beta.97",
@@ -16,5 +27,8 @@
   },
   "devDependencies": {
     "@types/bun": "^1.3.0"
+  },
+  "engines": {
+    "node": ">=20"
   }
 }

--- a/apps/ready-for-agent/project.json
+++ b/apps/ready-for-agent/project.json
@@ -18,6 +18,28 @@
         "command": "bun --conditions @ready-for-agent/source src/main.ts"
       }
     },
+    "compile": {
+      "executor": "nx:run-commands",
+      "dependsOn": [
+        {
+          "projects": ["graphql-client"],
+          "target": "generate"
+        }
+      ],
+      "options": {
+        "cwd": "{projectRoot}",
+        "command": "bun --conditions @ready-for-agent/source scripts/compile-platform-binary.ts {args.platform}",
+        "args": "--platform=host"
+      },
+      "inputs": ["default", "^production"],
+      "outputs": [
+        "{workspaceRoot}/packages/ready-for-agent-linux-x64/bin",
+        "{workspaceRoot}/packages/ready-for-agent-linux-arm64/bin",
+        "{workspaceRoot}/packages/ready-for-agent-darwin-x64/bin",
+        "{workspaceRoot}/packages/ready-for-agent-darwin-arm64/bin"
+      ],
+      "cache": false
+    },
     "test": {
       "executor": "nx:run-commands",
       "options": {

--- a/apps/ready-for-agent/scripts/compile-platform-binary.ts
+++ b/apps/ready-for-agent/scripts/compile-platform-binary.ts
@@ -1,0 +1,87 @@
+#!/usr/bin/env bun
+import { mkdirSync } from "node:fs"
+import { dirname, join, resolve } from "node:path"
+import { fileURLToPath } from "node:url"
+import {
+  BINARY_RELATIVE_PATH,
+  bunCompileTarget,
+  selectPlatformPackage,
+} from "../bin/select-platform.js"
+
+const appRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..")
+const workspaceRoot = resolve(appRoot, "../..")
+const entrypoint = join(appRoot, "src/main.ts")
+
+const knownKeys = [
+  "linux-x64",
+  "linux-arm64",
+  "darwin-x64",
+  "darwin-arm64",
+] as const
+
+type SupportedPlatformKey = (typeof knownKeys)[number]
+
+const isSupportedPlatformKey = (value: string): value is SupportedPlatformKey =>
+  (knownKeys as ReadonlyArray<string>).includes(value)
+
+const arg = process.argv[2]
+
+const platformKey: SupportedPlatformKey = (() => {
+  if (arg === undefined || arg === "host") {
+    const hostSelection = selectPlatformPackage({
+      platform: process.platform,
+      arch: process.arch,
+    })
+    if (!hostSelection.ok) {
+      console.error(hostSelection.message)
+      process.exit(1)
+    }
+    return hostSelection.platformKey
+  }
+  if (!isSupportedPlatformKey(arg)) {
+    console.error(
+      `Unknown platform key ${arg}. Use host or one of: ${knownKeys.join(", ")}`,
+    )
+    process.exit(1)
+  }
+  return arg
+})()
+
+const selection = selectPlatformPackage({
+  platform: platformKey.startsWith("darwin") ? "darwin" : "linux",
+  arch: platformKey.endsWith("arm64") ? "arm64" : "x64",
+})
+if (!selection.ok) {
+  console.error(selection.message)
+  process.exit(1)
+}
+
+const outfile = join(
+  workspaceRoot,
+  "packages",
+  selection.packageName,
+  BINARY_RELATIVE_PATH,
+)
+mkdirSync(dirname(outfile), { recursive: true })
+
+const target = bunCompileTarget(platformKey)
+const args = [
+  "build",
+  "--compile",
+  `--target=${target}`,
+  `--outfile=${outfile}`,
+  "--conditions=@ready-for-agent/source",
+  entrypoint,
+]
+
+console.log(`Compiling ${platformKey} → ${outfile}`)
+const result = Bun.spawnSync(["bun", ...args], {
+  cwd: workspaceRoot,
+  stdio: ["inherit", "inherit", "inherit"],
+})
+
+if (result.exitCode !== 0) {
+  process.exit(result.exitCode ?? 1)
+}
+
+console.log(`Wrote ${outfile}`)

--- a/apps/ready-for-agent/src/select-platform.test.ts
+++ b/apps/ready-for-agent/src/select-platform.test.ts
@@ -1,0 +1,120 @@
+import { readFileSync } from "node:fs"
+import { dirname, join } from "node:path"
+import { fileURLToPath } from "node:url"
+import {
+  BINARY_RELATIVE_PATH,
+  PLATFORM_PACKAGE_NAMES,
+  SUPPORTED_PLATFORM_KEYS,
+  bunCompileTarget,
+  selectPlatformPackage,
+  unsupportedPlatformMessage,
+} from "../bin/select-platform.js"
+import { describe, expect, test } from "bun:test"
+
+const binDir = dirname(fileURLToPath(import.meta.url))
+const launcherSource = readFileSync(
+  join(binDir, "../bin/ready-for-agent.js"),
+  "utf8",
+)
+
+describe("selectPlatformPackage", () => {
+  test("selects each supported linux/darwin × x64/arm64 package", () => {
+    const cases = [
+      {
+        platform: "linux",
+        arch: "x64",
+        platformKey: "linux-x64",
+        packageName: "ready-for-agent-linux-x64",
+      },
+      {
+        platform: "linux",
+        arch: "arm64",
+        platformKey: "linux-arm64",
+        packageName: "ready-for-agent-linux-arm64",
+      },
+      {
+        platform: "darwin",
+        arch: "x64",
+        platformKey: "darwin-x64",
+        packageName: "ready-for-agent-darwin-x64",
+      },
+      {
+        platform: "darwin",
+        arch: "arm64",
+        platformKey: "darwin-arm64",
+        packageName: "ready-for-agent-darwin-arm64",
+      },
+    ] as const
+
+    for (const c of cases) {
+      const result = selectPlatformPackage({
+        platform: c.platform,
+        arch: c.arch,
+      })
+      expect(result).toEqual({
+        ok: true,
+        platformKey: c.platformKey,
+        packageName: c.packageName,
+        binaryRelativePath: BINARY_RELATIVE_PATH,
+      })
+    }
+  })
+
+  test("normalizes common arch aliases", () => {
+    expect(
+      selectPlatformPackage({ platform: "linux", arch: "x86_64" }),
+    ).toMatchObject({ ok: true, platformKey: "linux-x64" })
+    expect(
+      selectPlatformPackage({ platform: "linux", arch: "amd64" }),
+    ).toMatchObject({ ok: true, platformKey: "linux-x64" })
+    expect(
+      selectPlatformPackage({ platform: "darwin", arch: "aarch64" }),
+    ).toMatchObject({ ok: true, platformKey: "darwin-arm64" })
+  })
+
+  test("unsupported platforms get a clear error listing supported keys", () => {
+    const win = selectPlatformPackage({ platform: "win32", arch: "x64" })
+    expect(win.ok).toBe(false)
+    if (win.ok) throw new Error("expected unsupported")
+    expect(win.message).toContain("win32/x64")
+    expect(win.message).toContain("Windows is not supported in v1")
+    for (const key of SUPPORTED_PLATFORM_KEYS) {
+      expect(win.message).toContain(key)
+    }
+
+    const freebsd = selectPlatformPackage({
+      platform: "freebsd",
+      arch: "x64",
+    })
+    expect(freebsd.ok).toBe(false)
+    if (freebsd.ok) throw new Error("expected unsupported")
+    expect(freebsd.message).toBe(unsupportedPlatformMessage("freebsd", "x64"))
+
+    const weirdArch = selectPlatformPackage({
+      platform: "linux",
+      arch: "ia32",
+    })
+    expect(weirdArch.ok).toBe(false)
+  })
+
+  test("PLATFORM_PACKAGE_NAMES covers every supported key", () => {
+    expect(Object.keys(PLATFORM_PACKAGE_NAMES).sort()).toEqual(
+      [...SUPPORTED_PLATFORM_KEYS].sort(),
+    )
+  })
+
+  test("bun compile targets map 1:1 for supported platforms", () => {
+    expect(bunCompileTarget("linux-x64")).toBe("bun-linux-x64")
+    expect(bunCompileTarget("linux-arm64")).toBe("bun-linux-arm64")
+    expect(bunCompileTarget("darwin-x64")).toBe("bun-darwin-x64")
+    expect(bunCompileTarget("darwin-arm64")).toBe("bun-darwin-arm64")
+  })
+
+  test("launcher bin imports the shared select-platform pure seam", () => {
+    expect(launcherSource).toContain('from "./select-platform.js"')
+    expect(launcherSource).toContain("selectPlatformPackage")
+    for (const name of Object.values(PLATFORM_PACKAGE_NAMES)) {
+      expect(Object.values(PLATFORM_PACKAGE_NAMES)).toContain(name)
+    }
+  })
+})

--- a/bun.lock
+++ b/bun.lock
@@ -77,7 +77,7 @@
       "name": "ready-for-agent",
       "version": "0.0.0",
       "bin": {
-        "ready-for-agent": "./src/main.ts",
+        "ready-for-agent": "./bin/ready-for-agent.js",
       },
       "dependencies": {
         "@effect/platform-bun": "^4.0.0-beta.97",
@@ -86,6 +86,12 @@
       },
       "devDependencies": {
         "@types/bun": "^1.3.0",
+      },
+      "optionalDependencies": {
+        "ready-for-agent-darwin-arm64": "0.0.0",
+        "ready-for-agent-darwin-x64": "0.0.0",
+        "ready-for-agent-linux-arm64": "0.0.0",
+        "ready-for-agent-linux-x64": "0.0.0",
       },
     },
     "packages/db": {
@@ -231,6 +237,22 @@
       "devDependencies": {
         "@types/bun": "^1.3.0",
       },
+    },
+    "packages/ready-for-agent-darwin-arm64": {
+      "name": "ready-for-agent-darwin-arm64",
+      "version": "0.0.0",
+    },
+    "packages/ready-for-agent-darwin-x64": {
+      "name": "ready-for-agent-darwin-x64",
+      "version": "0.0.0",
+    },
+    "packages/ready-for-agent-linux-arm64": {
+      "name": "ready-for-agent-linux-arm64",
+      "version": "0.0.0",
+    },
+    "packages/ready-for-agent-linux-x64": {
+      "name": "ready-for-agent-linux-x64",
+      "version": "0.0.0",
     },
     "packages/release-versioning": {
       "name": "@ready-for-agent/release-versioning",
@@ -1787,6 +1809,14 @@
     "readdirp": ["readdirp@5.0.0", "", {}, "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ=="],
 
     "ready-for-agent": ["ready-for-agent@workspace:apps/ready-for-agent"],
+
+    "ready-for-agent-darwin-arm64": ["ready-for-agent-darwin-arm64@workspace:packages/ready-for-agent-darwin-arm64"],
+
+    "ready-for-agent-darwin-x64": ["ready-for-agent-darwin-x64@workspace:packages/ready-for-agent-darwin-x64"],
+
+    "ready-for-agent-linux-arm64": ["ready-for-agent-linux-arm64@workspace:packages/ready-for-agent-linux-arm64"],
+
+    "ready-for-agent-linux-x64": ["ready-for-agent-linux-x64@workspace:packages/ready-for-agent-linux-x64"],
 
     "reflect-metadata": ["reflect-metadata@0.2.2", "", {}, "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q=="],
 

--- a/knip.json
+++ b/knip.json
@@ -32,8 +32,14 @@
       "project": ["src/**/*.ts", "test/**/*.ts"]
     },
     "apps/ready-for-agent": {
-      "entry": ["src/**/*.test.ts", "src/main.ts"],
-      "project": ["src/**/*.ts"]
+      "entry": [
+        "src/**/*.test.ts",
+        "src/main.ts",
+        "bin/ready-for-agent.js",
+        "bin/select-platform.js",
+        "scripts/compile-platform-binary.ts"
+      ],
+      "project": ["src/**/*.ts", "bin/**/*.{js,ts}", "scripts/**/*.ts"]
     },
     "packages/github-service": {
       "entry": [

--- a/packages/ready-for-agent-darwin-arm64/package.json
+++ b/packages/ready-for-agent-darwin-arm64/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "ready-for-agent-darwin-arm64",
+  "version": "0.0.0",
+  "description": "The macOS arm64 binary for ready-for-agent",
+  "license": "MIT",
+  "os": [
+    "darwin"
+  ],
+  "cpu": [
+    "arm64"
+  ],
+  "files": [
+    "bin/ready-for-agent"
+  ],
+  "preferUnplugged": true
+}

--- a/packages/ready-for-agent-darwin-x64/package.json
+++ b/packages/ready-for-agent-darwin-x64/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "ready-for-agent-darwin-x64",
+  "version": "0.0.0",
+  "description": "The macOS x64 binary for ready-for-agent",
+  "license": "MIT",
+  "os": [
+    "darwin"
+  ],
+  "cpu": [
+    "x64"
+  ],
+  "files": [
+    "bin/ready-for-agent"
+  ],
+  "preferUnplugged": true
+}

--- a/packages/ready-for-agent-linux-arm64/package.json
+++ b/packages/ready-for-agent-linux-arm64/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "ready-for-agent-linux-arm64",
+  "version": "0.0.0",
+  "description": "The Linux arm64 binary for ready-for-agent",
+  "license": "MIT",
+  "os": [
+    "linux"
+  ],
+  "cpu": [
+    "arm64"
+  ],
+  "files": [
+    "bin/ready-for-agent"
+  ],
+  "preferUnplugged": true
+}

--- a/packages/ready-for-agent-linux-x64/package.json
+++ b/packages/ready-for-agent-linux-x64/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "ready-for-agent-linux-x64",
+  "version": "0.0.0",
+  "description": "The Linux x64 binary for ready-for-agent",
+  "license": "MIT",
+  "os": [
+    "linux"
+  ],
+  "cpu": [
+    "x64"
+  ],
+  "files": [
+    "bin/ready-for-agent"
+  ],
+  "preferUnplugged": true
+}


### PR DESCRIPTION
## Summary

- Add unscoped `ready-for-agent` launcher with a Node-compatible bin that selects the host platform binary
- Add platform packages (`linux/darwin` × `x64/arm64`) as optionalDependencies and a compile target for Bun standalone binaries
- Unit-test the pure platform-selection seam; unsupported platforms fail with a clear error

Closes #217

## Test plan

- [x] `bunx nx run ready-for-agent:test`
- [x] `bunx nx run ready-for-agent:compile` (host binary)
- [x] Run launcher with Node and no Bun on PATH (`--help` / `--version`)
- [x] Pre-commit affected lint/typecheck/test passed