### PR TITLE
fix(harness): put pause control on right edge of Jobs card

### DIFF
--- a/apps/harness/src/routes/index.tsx
+++ b/apps/harness/src/routes/index.tsx
@@ -1561,10 +1561,10 @@ function JobsCard() {
                   )}
                 </div>
                 <div className="flex shrink-0 items-center gap-1">
-                  <WorkItemPauseButton workItem={workItem} />
                   <span className="text-[0.65rem] font-bold tracking-wide text-slate-600 uppercase">
                     {workItem.stateLabel}
                   </span>
+                  <WorkItemPauseButton workItem={workItem} />
                 </div>
               </div>
               {workItem.sessionId !== null && workItem.sessionId !== "" && (

--- a/apps/harness/test/jobs-card-no-polling.test.ts
+++ b/apps/harness/test/jobs-card-no-polling.test.ts
@@ -37,7 +37,8 @@ describe("JobsCard live updates", () => {
     )
     const stateLabelIndex = jobsCard.indexOf("{workItem.stateLabel}")
     expect(pauseIndex).toBeGreaterThan(-1)
-    expect(stateLabelIndex).toBeGreaterThan(pauseIndex)
+    expect(stateLabelIndex).toBeGreaterThan(-1)
+    expect(pauseIndex).toBeGreaterThan(stateLabelIndex)
   })
 
   test("links issue identity to the Issue store URL when available", () => {


### PR DESCRIPTION
## Summary

- Swap Jobs work-item card header so phase/state text sits left of pause/resume.
- Keep pause/resume as the rightmost control against the card edge.
- Update layout order assertion in the Jobs card source test.

Closes #234

## Test plan

- [ ] Confirm Jobs card shows phase label then pause/resume (pause flush right).
- [ ] Confirm paused jobs show resume in the same right-edge slot.
- [ ] Confirm status pill still renders correctly under the header.
- [ ] `bunx nx run harness:test -- test/jobs-card-no-polling.test.ts`