### PR TITLE
feat(harness): show copyable session id and worktree path on Jobs card

### DIFF
--- a/apps/harness/src/copy.tsx
+++ b/apps/harness/src/copy.tsx
@@ -1,0 +1,86 @@
+import { useCallback, useEffect, useRef, useState } from "react"
+
+export function Copy({
+  value,
+  className,
+  textClassName,
+}: {
+  value: string
+  className?: string
+  textClassName?: string
+}) {
+  const [copied, setCopied] = useState(false)
+  const resetTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  useEffect(() => {
+    return () => {
+      if (resetTimer.current !== null) {
+        clearTimeout(resetTimer.current)
+      }
+    }
+  }, [])
+
+  const handleCopy = useCallback(async () => {
+    try {
+      await navigator.clipboard.writeText(value)
+      setCopied(true)
+      if (resetTimer.current !== null) {
+        clearTimeout(resetTimer.current)
+      }
+      resetTimer.current = setTimeout(() => {
+        setCopied(false)
+        resetTimer.current = null
+      }, 1_500)
+    } catch {
+      setCopied(false)
+    }
+  }, [value])
+
+  return (
+    <span
+      className={`inline-flex min-w-0 max-w-full items-center gap-1 ${className ?? ""}`}
+    >
+      <span className={`min-w-0 truncate ${textClassName ?? ""}`} title={value}>
+        {value}
+      </span>
+      <button
+        type="button"
+        className="inline-flex size-5 shrink-0 items-center justify-center rounded text-slate-400 transition hover:bg-slate-100 hover:text-slate-700 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-600"
+        onClick={() => {
+          void handleCopy()
+        }}
+        aria-label={copied ? "Copied" : "Copy"}
+        title={copied ? "Copied" : "Copy"}
+      >
+        {copied ? (
+          <svg
+            aria-hidden="true"
+            className="size-3.5 text-emerald-600"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2.5"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          >
+            <path d="M5 13l4 4L19 7" />
+          </svg>
+        ) : (
+          <svg
+            aria-hidden="true"
+            className="size-3.5"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          >
+            <rect x="9" y="9" width="11" height="11" rx="2" />
+            <path d="M5 15V5a2 2 0 0 1 2-2h10" />
+          </svg>
+        )}
+      </button>
+    </span>
+  )
+}

--- a/apps/harness/src/routes/index.tsx
+++ b/apps/harness/src/routes/index.tsx
@@ -8,6 +8,7 @@ import {
 import { createFileRoute } from "@tanstack/react-router"
 import { type FormEvent, Suspense, useEffect, useRef, useState } from "react"
 import { createClient } from "@ready-for-agent/graphql-client"
+import { Copy } from "../copy.js"
 import {
   formatDuration,
   formatStartedAgo,
@@ -18,6 +19,7 @@ import {
 import { followRepositoryIssuesLive } from "../refresh-issues-live.js"
 import { followRepositoryWorkItemsLive } from "../refresh-work-items-live.js"
 import { streamRepositoryChanges } from "../repository-live.js"
+import { sessionWorktreeLine } from "../session-worktree-line.js"
 import { workItemPullRequestUrl } from "../work-item-pull-request-url.js"
 
 const graphql = createClient({ url: "/graphql", batch: true })
@@ -198,6 +200,7 @@ type WorkItem = {
   canRetry: boolean
   isTerminal: boolean
   sessionId: string | null
+  worktreePath: string | null
   createdAt: string
   lifecycleLabels: readonly {
     phase: string
@@ -221,6 +224,7 @@ const workItemFields = {
   canRetry: true,
   isTerminal: true,
   sessionId: true,
+  worktreePath: true,
   createdAt: true,
   lifecycleLabels: {
     phase: true,
@@ -1533,6 +1537,10 @@ function JobsCard() {
               )}
             </>
           )
+          const sessionWorktree = sessionWorktreeLine(
+            workItem.sessionId,
+            workItem.worktreePath,
+          )
           return (
             <li
               className="rounded-lg border border-slate-200 bg-slate-50/80 px-3 py-2"
@@ -1567,12 +1575,13 @@ function JobsCard() {
                   </span>
                 </div>
               </div>
-              {workItem.sessionId !== null && workItem.sessionId !== "" && (
-                <p
-                  className="mt-1 mb-0 truncate font-mono text-[0.7rem] text-slate-500"
-                  title={workItem.sessionId}
-                >
-                  Session {workItem.sessionId}
+              {sessionWorktree !== null && (
+                <p className="mt-1 mb-0 min-w-0">
+                  <Copy
+                    value={sessionWorktree}
+                    className="w-full"
+                    textClassName="font-mono text-[0.7rem] text-slate-500"
+                  />
                 </p>
               )}
               <WorkItemLifecycleStatus

--- a/apps/harness/src/session-worktree-line.ts
+++ b/apps/harness/src/session-worktree-line.ts
@@ -1,0 +1,20 @@
+const present = (value: string | null | undefined): value is string =>
+  value !== null && value !== undefined && value !== ""
+
+export const sessionWorktreeLine = (
+  sessionId: string | null | undefined,
+  worktreePath: string | null | undefined,
+): string | null => {
+  const hasSession = present(sessionId)
+  const hasPath = present(worktreePath)
+  if (hasSession && hasPath) {
+    return `${sessionId} / ${worktreePath}`
+  }
+  if (hasSession) {
+    return sessionId
+  }
+  if (hasPath) {
+    return worktreePath
+  }
+  return null
+}

--- a/apps/harness/test/copy-component.test.ts
+++ b/apps/harness/test/copy-component.test.ts
@@ -1,0 +1,21 @@
+import { readFileSync } from "node:fs"
+import { join } from "node:path"
+import { describe, expect, test } from "bun:test"
+
+describe("Copy component", () => {
+  test("renders text with a right-side copy control that writes full value", () => {
+    const source = readFileSync(
+      join(import.meta.dir, "../src/copy.tsx"),
+      "utf8",
+    )
+    expect(source).toContain("export function Copy")
+    expect(source).toContain("navigator.clipboard.writeText(value)")
+    expect(source).toContain("title={value}")
+    expect(source).toContain("truncate")
+    expect(source).toContain('aria-label={copied ? "Copied" : "Copy"}')
+    const textIndex = source.indexOf("title={value}")
+    const buttonIndex = source.indexOf('type="button"')
+    expect(textIndex).toBeGreaterThan(-1)
+    expect(buttonIndex).toBeGreaterThan(textIndex)
+  })
+})

--- a/apps/harness/test/jobs-card-no-polling.test.ts
+++ b/apps/harness/test/jobs-card-no-polling.test.ts
@@ -62,4 +62,16 @@ describe("JobsCard live updates", () => {
     expect(source).toContain('lifecycleLabel.status === "NEEDS_HUMAN"')
     expect(source).toContain("PR #{prNumber}")
   })
+
+  test("shows copyable session id and worktree path without Session prefix", () => {
+    const { source, jobsCard } = jobsCardSource()
+    expect(source).toContain("worktreePath: true")
+    expect(source).toContain("sessionWorktreeLine")
+    expect(source).toContain('from "../copy.js"')
+    expect(jobsCard).toContain("sessionWorktree")
+    expect(jobsCard).toContain("<Copy")
+    expect(jobsCard).toContain("value={sessionWorktree}")
+    expect(jobsCard).not.toContain("Session {workItem.sessionId}")
+    expect(jobsCard).not.toContain("Session ")
+  })
 })

--- a/apps/harness/test/session-worktree-line.test.ts
+++ b/apps/harness/test/session-worktree-line.test.ts
@@ -1,0 +1,31 @@
+import { sessionWorktreeLine } from "../src/session-worktree-line.ts"
+import { describe, expect, test } from "bun:test"
+
+describe("sessionWorktreeLine", () => {
+  test("formats both session and worktree with spaces around slash", () => {
+    expect(
+      sessionWorktreeLine(
+        "ses_090b4a729ffev80sNihn1xDyHB",
+        "/home/berend/src/ready-for-agent/worktree1",
+      ),
+    ).toBe(
+      "ses_090b4a729ffev80sNihn1xDyHB / /home/berend/src/ready-for-agent/worktree1",
+    )
+  })
+
+  test("shows only session when path is missing", () => {
+    expect(sessionWorktreeLine("ses_abc", null)).toBe("ses_abc")
+    expect(sessionWorktreeLine("ses_abc", "")).toBe("ses_abc")
+  })
+
+  test("shows only worktree when session is missing", () => {
+    expect(sessionWorktreeLine(null, "/tmp/wt")).toBe("/tmp/wt")
+    expect(sessionWorktreeLine("", "/tmp/wt")).toBe("/tmp/wt")
+  })
+
+  test("returns null when both are empty", () => {
+    expect(sessionWorktreeLine(null, null)).toBeNull()
+    expect(sessionWorktreeLine("", "")).toBeNull()
+    expect(sessionWorktreeLine(undefined, undefined)).toBeNull()
+  })
+})


### PR DESCRIPTION
## Summary

- Replace the Jobs card `Session …` line with a copyable `sessionId / worktreePath` line (omit empty parts).
- Add a reusable `Copy` component (truncated display, full value on clipboard).
- Request `worktreePath` in the harness work-items GraphQL selection set.

Closes #233

## Test plan

- [x] `bunx nx run harness:test`
- [x] Pre-commit affected lint/typecheck/test
- [ ] Confirm Jobs card shows `sessionId / worktreePath` with copy control on the right
- [ ] Confirm copy writes the full untruncated string
- [ ] Confirm long paths truncate with hover title