### PR TITLE
ci: manual OIDC release workflow and GitHub Release

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
   pull_request:
+  workflow_dispatch:
 
 permissions:
   actions: read
@@ -40,8 +41,112 @@ jobs:
 
       # Prepend any command with "nx record --" to record its logs to Nx Cloud
       # - run: bun nx record -- echo Hello World
-      - run: bun nx affected -t lint knip test typecheck
+      # PR/main: affected quality gates only. Manual release dispatch: full suite.
+      - name: Quality gates
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            bun nx run-many -t lint knip test typecheck
+          else
+            bun nx affected -t lint knip test typecheck
+          fi
 
       # Nx Cloud recommends fixes for failures to help you get CI green faster. Learn more: https://nx.dev/ci/features/self-healing-ci
       # - run: bun nx fix-ci
       #   if: always()
+
+  release:
+    # Manual release only, from main (never on PR/push).
+    if: github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main'
+    needs: main
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          filter: tree:0
+          fetch-depth: 0
+          fetch-tags: true
+
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        with:
+          bun-version: latest
+
+      # npm OIDC trusted publishing + provenance requires a recent npm CLI.
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: "22"
+          registry-url: "https://registry.npmjs.org"
+
+      - run: bun install --no-cache --frozen-lockfile --linker=isolated && bun install --no-cache --frozen-lockfile --linker=isolated
+
+      - name: Compute next version
+        id: version
+        run: |
+          set -euo pipefail
+          VERSION="$(bun --conditions @ready-for-agent/source packages/release-versioning/src/bin/compute-next-version.ts)"
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "Next version: ${VERSION}"
+
+      - name: Apply publish versions
+        run: |
+          bun --conditions @ready-for-agent/source \
+            packages/release-versioning/src/bin/apply-publish-versions.ts \
+            "${{ steps.version.outputs.version }}" \
+            --for-publish
+
+      - name: Compile platform binaries
+        run: |
+          set -euo pipefail
+          for platform in linux-x64 linux-arm64 darwin-x64 darwin-arm64; do
+            bunx nx run ready-for-agent:compile --platform="${platform}"
+          done
+          for platform in linux-x64 linux-arm64 darwin-x64 darwin-arm64; do
+            binary="packages/ready-for-agent-${platform}/bin/ready-for-agent"
+            test -f "${binary}"
+            test -x "${binary}"
+          done
+
+      - name: Publish packages to npm (OIDC + provenance)
+        run: |
+          set -euo pipefail
+          # Platform packages first so optionalDependencies resolve on install.
+          # Publish from each package directory (no long-lived NPM_TOKEN; OIDC only).
+          for platform in linux-x64 linux-arm64 darwin-x64 darwin-arm64; do
+            (
+              cd "packages/ready-for-agent-${platform}"
+              npm publish --access public --provenance
+            )
+          done
+          (
+            cd apps/ready-for-agent
+            npm publish --access public --provenance
+          )
+
+      - name: Create git tag and GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          set -euo pipefail
+          TAG="v${VERSION}"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag "${TAG}"
+          git push origin "${TAG}"
+
+          mkdir -p dist-release
+          for platform in linux-x64 linux-arm64 darwin-x64 darwin-arm64; do
+            cp "packages/ready-for-agent-${platform}/bin/ready-for-agent" \
+              "dist-release/ready-for-agent-${platform}"
+          done
+
+          gh release create "${TAG}" \
+            --title "${TAG}" \
+            --generate-notes \
+            dist-release/ready-for-agent-linux-x64 \
+            dist-release/ready-for-agent-linux-arm64 \
+            dist-release/ready-for-agent-darwin-x64 \
+            dist-release/ready-for-agent-darwin-arm64

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -113,6 +113,29 @@ Platform packages for the published binary are described in
 Release process:
 [docs/adr/0024-manual-oidc-npm-release.md](docs/adr/0024-manual-oidc-npm-release.md).
 
+### Cutting a release
+
+Releases are **manual only** (`workflow_dispatch` on `.github/workflows/ci-cd.yml`).
+PR and `push` to `main` stay quality gates (lint, knip, test, typecheck) and never
+publish.
+
+1. One-time human setup on npm: configure Trusted Publishing (OIDC) for
+   `ready-for-agent` and each platform package, pointing at this repository and
+   workflow file.
+2. From GitHub Actions, run the **CI** workflow via **Run workflow**.
+3. The release job computes the next version from conventional commits (fails if
+   nothing to release), builds multi-platform binaries, publishes with OIDC +
+   provenance, tags `vX.Y.Z`, and creates a GitHub Release with notes and
+   binaries.
+
+Local helpers (no publish):
+
+```bash
+bunx nx run release-versioning:compute-next-version
+bun --conditions @ready-for-agent/source \
+  packages/release-versioning/src/bin/apply-publish-versions.ts 0.1.0 --for-publish
+```
+
 ## Live end-to-end fixture
 
 The private End-to-End Fixture Repository

--- a/knip.json
+++ b/knip.json
@@ -64,6 +64,10 @@
     "packages/db": {
       "project": ["src/**/*.{ts,tsx}"]
     },
+    "packages/release-versioning": {
+      "entry": ["src/bin/**/*.ts", "src/index.ts", "test/**/*.{test,spec}.ts"],
+      "project": ["src/**/*.ts", "test/**/*.ts"]
+    },
     "packages/*": {
       "entry": ["test/**/*.{test,spec}.ts"],
       "project": ["src/**/*.{ts,tsx}", "test/**/*.ts"]

--- a/packages/release-versioning/package.json
+++ b/packages/release-versioning/package.json
@@ -16,7 +16,8 @@
     }
   },
   "bin": {
-    "compute-next-version": "./src/bin/compute-next-version.ts"
+    "compute-next-version": "./src/bin/compute-next-version.ts",
+    "apply-publish-versions": "./src/bin/apply-publish-versions.ts"
   },
   "dependencies": {
     "@conventional-changelog/git-client": "^3.1.0",

--- a/packages/release-versioning/project.json
+++ b/packages/release-versioning/project.json
@@ -20,6 +20,13 @@
         "cwd": "{workspaceRoot}",
         "command": "bun --conditions @ready-for-agent/source packages/release-versioning/src/bin/compute-next-version.ts"
       }
+    },
+    "apply-publish-versions": {
+      "executor": "nx:run-commands",
+      "options": {
+        "cwd": "{workspaceRoot}",
+        "command": "bun --conditions @ready-for-agent/source packages/release-versioning/src/bin/apply-publish-versions.ts"
+      }
     }
   }
 }

--- a/packages/release-versioning/src/bin/apply-publish-versions.ts
+++ b/packages/release-versioning/src/bin/apply-publish-versions.ts
@@ -1,0 +1,44 @@
+import { readFileSync, writeFileSync } from "node:fs"
+import { join, resolve } from "node:path"
+import {
+  type JsonObject,
+  PUBLISH_PACKAGE_PATHS,
+  applyVersionToLauncherPackageJson,
+  applyVersionToPlatformPackageJson,
+  assertPublishVersion,
+  launcherManifestForNpmPublish,
+} from "../lib/publish-packages.js"
+
+const args = process.argv.slice(2)
+const forPublish = args.includes("--for-publish")
+const positional = args.filter((arg) => arg !== "--for-publish")
+const versionArg = positional[0]
+const cwd = resolve(positional[1] ?? process.cwd())
+
+if (versionArg === undefined || versionArg === "") {
+  console.error(
+    "Usage: apply-publish-versions <version> [workspaceRoot] [--for-publish]",
+  )
+  process.exitCode = 1
+} else {
+  try {
+    const version = assertPublishVersion(versionArg)
+
+    for (const entry of PUBLISH_PACKAGE_PATHS) {
+      const path = join(cwd, entry.packageJsonRelativePath)
+      const raw = JSON.parse(readFileSync(path, "utf8")) as JsonObject
+      const next =
+        entry.kind === "launcher"
+          ? forPublish
+            ? launcherManifestForNpmPublish(raw, version)
+            : applyVersionToLauncherPackageJson(raw, version)
+          : applyVersionToPlatformPackageJson(raw, version)
+
+      writeFileSync(path, `${JSON.stringify(next, null, 2)}\n`)
+      process.stdout.write(`${entry.name}@${version} → ${path}\n`)
+    }
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : error)
+    process.exitCode = 1
+  }
+}

--- a/packages/release-versioning/src/index.ts
+++ b/packages/release-versioning/src/index.ts
@@ -8,3 +8,15 @@ export {
 } from "./lib/compute-next-version.js"
 export { InvalidVersionError, NothingToReleaseError } from "./lib/errors.js"
 export { computeNextVersionFromGit } from "./lib/from-git.js"
+export {
+  type JsonObject,
+  LAUNCHER_PACKAGE_NAME,
+  PLATFORM_PACKAGE_NAMES,
+  PUBLISH_PACKAGE_PATHS,
+  type PlatformPackageName,
+  type PublishPackagePath,
+  applyVersionToLauncherPackageJson,
+  applyVersionToPlatformPackageJson,
+  assertPublishVersion,
+  launcherManifestForNpmPublish,
+} from "./lib/publish-packages.js"

--- a/packages/release-versioning/src/lib/publish-packages.ts
+++ b/packages/release-versioning/src/lib/publish-packages.ts
@@ -1,0 +1,99 @@
+import semver from "semver"
+
+export const LAUNCHER_PACKAGE_NAME = "ready-for-agent"
+
+export const PLATFORM_PACKAGE_NAMES = [
+  "ready-for-agent-linux-x64",
+  "ready-for-agent-linux-arm64",
+  "ready-for-agent-darwin-x64",
+  "ready-for-agent-darwin-arm64",
+] as const
+
+export type PlatformPackageName = (typeof PLATFORM_PACKAGE_NAMES)[number]
+
+export type JsonObject = Record<string, unknown>
+
+export function assertPublishVersion(version: string): string {
+  const cleaned = semver.clean(version)
+  if (cleaned === null || cleaned !== version) {
+    throw new Error(
+      `Invalid publish version: ${version}. Expected a clean semver string (no leading v).`,
+    )
+  }
+  return cleaned
+}
+
+/**
+ * Sets the launcher package version and pins optionalDependencies to the same
+ * version so npm installs matching platform packages.
+ */
+export function applyVersionToLauncherPackageJson(
+  pkg: JsonObject,
+  version: string,
+): JsonObject {
+  const v = assertPublishVersion(version)
+  const optionalDependencies: Record<string, string> = {
+    ...Object.fromEntries(
+      PLATFORM_PACKAGE_NAMES.map((name) => [name, v] as const),
+    ),
+  }
+
+  return {
+    ...pkg,
+    version: v,
+    optionalDependencies,
+  }
+}
+
+export function applyVersionToPlatformPackageJson(
+  pkg: JsonObject,
+  version: string,
+): JsonObject {
+  const v = assertPublishVersion(version)
+  return {
+    ...pkg,
+    version: v,
+  }
+}
+
+/**
+ * Manifest written for npm publish of the launcher: drops monorepo-only
+ * dependencies (workspace:*, Effect, etc.) so the published package is only the
+ * Node launcher + platform optionalDependencies.
+ */
+export function launcherManifestForNpmPublish(
+  pkg: JsonObject,
+  version: string,
+): JsonObject {
+  const withVersion = applyVersionToLauncherPackageJson(pkg, version)
+  const {
+    dependencies: _dependencies,
+    devDependencies: _devDependencies,
+    scripts: _scripts,
+    private: _private,
+    ...publishable
+  } = withVersion
+
+  return publishable
+}
+
+export type PublishPackagePath = {
+  name: string
+  packageJsonRelativePath: string
+  kind: "launcher" | "platform"
+}
+
+export const PUBLISH_PACKAGE_PATHS: readonly PublishPackagePath[] = [
+  {
+    name: LAUNCHER_PACKAGE_NAME,
+    packageJsonRelativePath: "apps/ready-for-agent/package.json",
+    kind: "launcher",
+  },
+  ...PLATFORM_PACKAGE_NAMES.map(
+    (name): PublishPackagePath => ({
+      name,
+      packageJsonRelativePath: `packages/${name}/package.json`,
+      kind: "platform",
+    }),
+  ),
+]

--- a/packages/release-versioning/test/publish-packages.spec.ts
+++ b/packages/release-versioning/test/publish-packages.spec.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from "vitest"
+import {
+  PLATFORM_PACKAGE_NAMES,
+  applyVersionToLauncherPackageJson,
+  applyVersionToPlatformPackageJson,
+  assertPublishVersion,
+  launcherManifestForNpmPublish,
+} from "../src/lib/publish-packages.js"
+
+describe("assertPublishVersion", () => {
+  it("accepts clean semver", () => {
+    expect(assertPublishVersion("0.1.0")).toBe("0.1.0")
+  })
+
+  it("rejects v-prefixed versions", () => {
+    expect(() => assertPublishVersion("v0.1.0")).toThrow(
+      /Invalid publish version/,
+    )
+  })
+
+  it("rejects non-semver", () => {
+    expect(() => assertPublishVersion("not-a-version")).toThrow(
+      /Invalid publish version/,
+    )
+  })
+})
+
+describe("applyVersionToLauncherPackageJson", () => {
+  it("sets version and pins all platform optionalDependencies", () => {
+    const next = applyVersionToLauncherPackageJson(
+      {
+        name: "ready-for-agent",
+        version: "0.0.0",
+        optionalDependencies: {
+          "ready-for-agent-linux-x64": "0.0.0",
+        },
+        dependencies: {
+          effect: "^4.0.0",
+        },
+      },
+      "1.2.3",
+    )
+
+    expect(next.version).toBe("1.2.3")
+    expect(next.optionalDependencies).toEqual(
+      Object.fromEntries(PLATFORM_PACKAGE_NAMES.map((name) => [name, "1.2.3"])),
+    )
+    expect(next.dependencies).toEqual({ effect: "^4.0.0" })
+  })
+})
+
+describe("applyVersionToPlatformPackageJson", () => {
+  it("sets version only", () => {
+    const next = applyVersionToPlatformPackageJson(
+      {
+        name: "ready-for-agent-linux-x64",
+        version: "0.0.0",
+        os: ["linux"],
+      },
+      "0.1.0",
+    )
+
+    expect(next).toEqual({
+      name: "ready-for-agent-linux-x64",
+      version: "0.1.0",
+      os: ["linux"],
+    })
+  })
+})
+
+describe("launcherManifestForNpmPublish", () => {
+  it("strips monorepo-only fields and keeps the public surface", () => {
+    const next = launcherManifestForNpmPublish(
+      {
+        name: "ready-for-agent",
+        version: "0.0.0",
+        description: "Ready for Agent",
+        license: "MIT",
+        type: "module",
+        bin: { "ready-for-agent": "./bin/ready-for-agent.js" },
+        files: ["bin/ready-for-agent.js", "bin/select-platform.js"],
+        scripts: { typecheck: "tsc" },
+        dependencies: {
+          "@ready-for-agent/graphql-client": "workspace:*",
+          effect: "^4.0.0",
+        },
+        devDependencies: { "@types/bun": "^1.3.0" },
+        optionalDependencies: {
+          "ready-for-agent-linux-x64": "0.0.0",
+        },
+        engines: { node: ">=20" },
+      },
+      "0.1.0",
+    )
+
+    expect(next).toEqual({
+      name: "ready-for-agent",
+      version: "0.1.0",
+      description: "Ready for Agent",
+      license: "MIT",
+      type: "module",
+      bin: { "ready-for-agent": "./bin/ready-for-agent.js" },
+      files: ["bin/ready-for-agent.js", "bin/select-platform.js"],
+      optionalDependencies: Object.fromEntries(
+        PLATFORM_PACKAGE_NAMES.map((name) => [name, "0.1.0"]),
+      ),
+      engines: { node: ">=20" },
+    })
+    expect(next).not.toHaveProperty("dependencies")
+    expect(next).not.toHaveProperty("devDependencies")
+    expect(next).not.toHaveProperty("scripts")
+  })
+})


### PR DESCRIPTION
## Summary

- Add `workflow_dispatch` release job on the existing CI workflow: conventional-commit versioning, multi-platform binary builds, npm OIDC + provenance publish, `vX.Y.Z` tag, and GitHub Release with notes and binaries
- Keep PR/`push` to `main` as quality gates only (lint/knip/test/typecheck)
- Add publish-version helpers and release docs in CONTRIBUTING

Closes #219

## Test plan

- [x] `bunx nx run release-versioning:test`
- [x] Pre-commit hooks (affected lint/typecheck/test)
- [ ] After merge: one-time npm Trusted Publisher setup for launcher + platform packages
- [ ] Manual `workflow_dispatch` on `main` smoke-tests the release job (expect fail-empty or successful first publish once trusted publishers exist)