### PR TITLE
fix: set repository on publishable packages for npm OIDC

### DIFF
--- a/apps/ready-for-agent/package.json
+++ b/apps/ready-for-agent/package.json
@@ -4,6 +4,13 @@
   "description": "Ready for Agent: local Harness UI + backend and operator CLI",
   "license": "MIT",
   "type": "module",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/berenddeboer/ready-for-agent.git"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
   "bin": {
     "ready-for-agent": "./bin/ready-for-agent.js"
   },

--- a/packages/ready-for-agent-darwin-arm64/package.json
+++ b/packages/ready-for-agent-darwin-arm64/package.json
@@ -3,6 +3,13 @@
   "version": "0.0.0",
   "description": "The macOS arm64 binary for ready-for-agent",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/berenddeboer/ready-for-agent.git"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
   "os": [
     "darwin"
   ],

--- a/packages/ready-for-agent-darwin-x64/package.json
+++ b/packages/ready-for-agent-darwin-x64/package.json
@@ -3,6 +3,13 @@
   "version": "0.0.0",
   "description": "The macOS x64 binary for ready-for-agent",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/berenddeboer/ready-for-agent.git"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
   "os": [
     "darwin"
   ],

--- a/packages/ready-for-agent-linux-arm64/package.json
+++ b/packages/ready-for-agent-linux-arm64/package.json
@@ -3,6 +3,13 @@
   "version": "0.0.0",
   "description": "The Linux arm64 binary for ready-for-agent",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/berenddeboer/ready-for-agent.git"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
   "os": [
     "linux"
   ],

--- a/packages/ready-for-agent-linux-x64/package.json
+++ b/packages/ready-for-agent-linux-x64/package.json
@@ -3,6 +3,13 @@
   "version": "0.0.0",
   "description": "The Linux x64 binary for ready-for-agent",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/berenddeboer/ready-for-agent.git"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
   "os": [
     "linux"
   ],


### PR DESCRIPTION
## Summary

- Add `repository.url` (`git+https://github.com/berenddeboer/ready-for-agent.git`) to the launcher and all four platform packages so npm OIDC trusted publishing can match the GitHub repo.
- Add `publishConfig.access: public` on the same packages.
- Addresses the manual release failure: provenance signed, then `PUT` returned E404 for `ready-for-agent-linux-x64@0.1.0`.

## Test plan

- [ ] Merge to main
- [ ] Actions → CI → Run workflow on `main`
- [ ] Confirm platform packages publish, then launcher
- [ ] Confirm GitHub Release + `npm view ready-for-agent version` is `0.1.0` (or next computed version)