### PR TITLE
chore(hooks): refuse pushes from worktreeN slot branches

### DIFF
--- a/hk.pkl
+++ b/hk.pkl
@@ -57,4 +57,26 @@ bunx nx affected -t lint,typecheck,test --batch
       }
     }
   }
+  ["pre-push"] {
+    steps {
+      ["no-slot-branch-push"] {
+        // Slot branches (worktreeN) are local-only mirrors of main. Pushing them
+        // creates origin/worktreeN and Magit Unmerged/Rebase noise.
+        // hk does not forward pre-push stdin ref lines to steps, so gate on the
+        // current branch name (same pattern as pre-commit descriptive-branch).
+        check = #"""
+branch_name=$(git branch --show-current)
+
+case "$branch_name" in
+  worktree*[!0-9]* | worktree | "") ;;
+  worktree*)
+    echo "Refusing to push from slot branch '$branch_name'."
+    echo "Push a descriptive feature branch instead; leave worktreeN local-only."
+    exit 1
+    ;;
+esac
+"""#
+      }
+    }
+  }
 }


### PR DESCRIPTION
## Why

Permanent bare-repo slot branches (`worktree1`, `worktree2`, …) are local-only mirrors of `main`. Accidentally pushing them creates `origin/worktreeN` and sets upstream tracking, so Magit shows Unmerged/Unpulled/Rebase noise on the slot worktree.

Pre-commit already refused *commits* on those slots; it did not stop `git push -u origin worktreeN` (or Magit push-with-upstream) after the slot was reset to `main`.

## What Changed

- Added an `hk` `pre-push` step `no-slot-branch-push` that refuses pushes when the current branch is a `worktreeN` slot (same matching pattern as the existing pre-commit guard).
- Notes that hk does not forward pre-push stdin ref lines, so the guard keys off the current branch name.
