### PR TITLE
ci: use Node 26 so release has npm 11 for OIDC publish

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -74,8 +74,6 @@ jobs:
         with:
           bun-version: latest
 
-      # npm OIDC trusted publishing needs npm >= 11.5.1 (Node 22 ships npm 10.x).
-      # Node 26 includes npm 11.17+; bun is used for install/build, npm only for publish.
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: "26"
@@ -113,11 +111,7 @@ jobs:
       - name: Publish packages to npm (OIDC + provenance)
         run: |
           set -euo pipefail
-          # setup-node injects a placeholder NODE_AUTH_TOKEN when no secret is set;
-          # clear it so npm uses OIDC trusted publishing instead of a dummy token.
-          unset NODE_AUTH_TOKEN || true
           # Platform packages first so optionalDependencies resolve on install.
-          # Publish from each package directory (no long-lived NPM_TOKEN; OIDC only).
           for platform in linux-x64 linux-arm64 darwin-x64 darwin-arm64; do
             (
               cd "packages/ready-for-agent-${platform}"

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -74,10 +74,11 @@ jobs:
         with:
           bun-version: latest
 
-      # npm OIDC trusted publishing + provenance requires a recent npm CLI.
+      # npm OIDC trusted publishing needs npm >= 11.5.1 (Node 22 ships npm 10.x).
+      # Node 26 includes npm 11.17+; bun is used for install/build, npm only for publish.
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          node-version: "22"
+          node-version: "26"
           registry-url: "https://registry.npmjs.org"
 
       - run: bun install --no-cache --frozen-lockfile --linker=isolated && bun install --no-cache --frozen-lockfile --linker=isolated
@@ -112,6 +113,9 @@ jobs:
       - name: Publish packages to npm (OIDC + provenance)
         run: |
           set -euo pipefail
+          # setup-node injects a placeholder NODE_AUTH_TOKEN when no secret is set;
+          # clear it so npm uses OIDC trusted publishing instead of a dummy token.
+          unset NODE_AUTH_TOKEN || true
           # Platform packages first so optionalDependencies resolve on install.
           # Publish from each package directory (no long-lived NPM_TOKEN; OIDC only).
           for platform in linux-x64 linux-arm64 darwin-x64 darwin-arm64; do


### PR DESCRIPTION
## Summary

- Bump release job Node from 22 → **26** (ships **npm 11.17+**; OIDC trusted publishing needs **npm ≥ 11.5.1**).
- Previous failure: provenance signed, then `PUT` E404 — npm 10.9.8 cannot use OIDC and falls back to setup-node’s dummy `NODE_AUTH_TOKEN`.
- `unset NODE_AUTH_TOKEN` before `npm publish` so a placeholder token cannot win over OIDC.
- Bun still handles install/build/compile; npm is only for publish.

## Test plan

- [ ] Merge to main
- [ ] Actions → CI → Run workflow on `main`
- [ ] Release log shows Node 26 / npm 11.x
- [ ] All five packages publish; GitHub Release created
- [ ] `npm view ready-for-agent version` is the new release (e.g. `0.1.0`)