### PR TITLE
feat: require build model selection on empty DB

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -17,8 +17,12 @@ A Repository state in which the harness does not autonomously select work for th
 _Avoid_: Disabled, inactive, enabled=false, Pause Work Item
 
 **Repository settings**:
-Per-Repository operator preferences: Paused, optional build model and variant (null falls back to harness defaults), optional review model and variant (null falls back to harness review settings, then the build model/variant), and Auto-merge. Changing settings does not rewrite existing Work Items; build and review model/variant are captured when a Work Item is created.
+Per-Repository operator preferences: Paused, optional build model and variant (null falls back to harness defaults; if those are also unset the empty option is labeled as harness default not configured), optional review model and variant (null falls back to harness review settings, then the resolved build model/variant), and Auto-merge. Changing settings does not rewrite existing Work Items; build and review model/variant are captured when a Work Item is created. A repository build override alone is enough to create Work Items even when harness defaults are still unset.
 _Avoid_: Project config, repo config file
+
+**Harness Config**:
+Harness-wide operator preferences stored as a single config row: optional default build model and build thinking level (variant), optional review model and review thinking level (null means same as build), and concurrency limits (default two OpenCode sessions and five concurrent Work Items). On a fresh empty database the build model and variant start null (unconfigured); there is no product-seeded free model. First-run UI opens Settings and shows a banner until a build model and thinking level are saved. Creating a Work Item fails with a structured error when neither a repository override nor harness defaults resolve a build model and variant.
+_Avoid_: Default model seed, product default model
 
 **Auto-merge**:
 A Repository setting that, when enabled, lets Decide PR Merge ask whether a clanker may merge a low-risk PR; when disabled, Decide PR Merge always requires a human. Enabling Auto-merge does not itself merge pull requests; only a subsequent Merge PR step merges when Decide PR Merge chooses clanker merge.
@@ -108,7 +112,7 @@ The state of an unfinished, non-paused Work Item that has not yet been Admitted 
 _Avoid_: Queued Step Run, paused, Not Implemented
 
 **Implement Now**:
-An explicit operator request that creates a Work Item for a Leaf Issue. Work Items are not created automatically by Issue reconciliation or eligibility discovery. Creation is allowed when all Worker Slots are occupied; the new Work Item is then Waiting for Worker Slot rather than rejected.
+An explicit operator request that creates a Work Item for a Leaf Issue. Work Items are not created automatically by Issue reconciliation or eligibility discovery. Creation is allowed when all Worker Slots are occupied; the new Work Item is then Waiting for Worker Slot rather than rejected. Creation is hard-blocked when no build model and variant can be resolved from repository override or harness defaults (`Select a default build model first`).
 _Avoid_: Auto-implement, enqueue Issue
 
 **Implement Locally**:

--- a/apps/harness/src/routes/__root.tsx
+++ b/apps/harness/src/routes/__root.tsx
@@ -56,6 +56,21 @@ const modelsQuery = {
   },
 }
 
+const isBuildModelConfigured = (
+  config:
+    | {
+        defaultModel: string | null
+        defaultVariant: string | null
+      }
+    | null
+    | undefined,
+): boolean =>
+  config != null &&
+  config.defaultModel != null &&
+  config.defaultModel.length > 0 &&
+  config.defaultVariant != null &&
+  config.defaultVariant.length > 0
+
 export const Route = createRootRouteWithContext<RouterContext>()({
   head: () => ({
     meta: [
@@ -117,27 +132,32 @@ function SettingsButton() {
   const dialogRef = useRef<HTMLDialogElement>(null)
   const queryClient = useQueryClient()
   const [dialogOpen, setDialogOpen] = useState(false)
-  const config = useQuery({ ...configQuery, enabled: dialogOpen })
+  const [autoOpenAttempted, setAutoOpenAttempted] = useState(false)
+  const config = useQuery(configQuery)
   const models = useQuery({ ...modelsQuery, enabled: dialogOpen })
   const [defaultModel, setDefaultModel] = useState("")
-  const [defaultVariant, setDefaultVariant] = useState("low")
+  const [defaultVariant, setDefaultVariant] = useState("")
   const [reviewModel, setReviewModel] = useState("")
   const [reviewVariant, setReviewVariant] = useState("")
   const [maxConcurrentOpencodeSessions, setMaxConcurrentOpencodeSessions] =
     useState("2")
   const [maxConcurrentWorkItems, setMaxConcurrentWorkItems] = useState("5")
+  const buildConfigured = isBuildModelConfigured(config.data)
+
   useEffect(() => {
-    if (dialogOpen && config.data) {
-      setDefaultModel(config.data.defaultModel)
-      setDefaultVariant(config.data.defaultVariant)
-      setReviewModel(config.data.reviewModel ?? "")
-      setReviewVariant(config.data.reviewVariant ?? "")
-      setMaxConcurrentOpencodeSessions(
-        String(config.data.maxConcurrentOpencodeSessions),
-      )
-      setMaxConcurrentWorkItems(String(config.data.maxConcurrentWorkItems))
+    if (!dialogOpen || !config.data) {
+      return
     }
+    setDefaultModel(config.data.defaultModel ?? "")
+    setDefaultVariant(config.data.defaultVariant ?? "")
+    setReviewModel(config.data.reviewModel ?? "")
+    setReviewVariant(config.data.reviewVariant ?? "")
+    setMaxConcurrentOpencodeSessions(
+      String(config.data.maxConcurrentOpencodeSessions),
+    )
+    setMaxConcurrentWorkItems(String(config.data.maxConcurrentWorkItems))
   }, [config.data, dialogOpen])
+
   const updateConfig = useMutation({
     mutationFn: (input: {
       defaultModel: string
@@ -174,8 +194,8 @@ function SettingsButton() {
       void models.refetch()
     }
     if (config.data) {
-      setDefaultModel(config.data.defaultModel)
-      setDefaultVariant(config.data.defaultVariant)
+      setDefaultModel(config.data.defaultModel ?? "")
+      setDefaultVariant(config.data.defaultVariant ?? "")
       setReviewModel(config.data.reviewModel ?? "")
       setReviewVariant(config.data.reviewVariant ?? "")
       setMaxConcurrentOpencodeSessions(
@@ -186,6 +206,16 @@ function SettingsButton() {
     updateConfig.reset()
     dialogRef.current?.showModal()
   }
+
+  useEffect(() => {
+    if (autoOpenAttempted || !config.isSuccess || buildConfigured) {
+      return
+    }
+    setAutoOpenAttempted(true)
+    setDialogOpen(true)
+    updateConfig.reset()
+    dialogRef.current?.showModal()
+  }, [autoOpenAttempted, buildConfigured, config.isSuccess, updateConfig.reset])
 
   const saveSettings = (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault()
@@ -206,12 +236,29 @@ function SettingsButton() {
     defaultModel.length > 0 && !models.data?.includes(defaultModel)
   const hasUnavailableReviewModel =
     reviewModel.length > 0 && !models.data?.includes(reviewModel)
-  const hasCustomBuildVariant = !standardVariants.includes(defaultVariant)
+  const hasCustomBuildVariant =
+    defaultVariant.length > 0 && !standardVariants.includes(defaultVariant)
   const hasCustomReviewVariant =
     reviewVariant.length > 0 && !standardVariants.includes(reviewVariant)
+  const showUnconfiguredGuidance = config.isSuccess && !buildConfigured
 
   return (
     <>
+      {showUnconfiguredGuidance && !dialogOpen && (
+        <div
+          className="mr-auto flex flex-wrap items-center gap-2 rounded-lg border border-amber-200 bg-amber-50 px-3 py-1.5 text-sm text-amber-950"
+          role="status"
+        >
+          <span>Select a default build model first</span>
+          <button
+            type="button"
+            className="rounded-md bg-amber-100 px-2 py-0.5 text-xs font-semibold text-amber-950 underline-offset-2 hover:bg-amber-200 hover:underline"
+            onClick={openSettings}
+          >
+            Open Settings
+          </button>
+        </div>
+      )}
       <button
         type="button"
         className="ml-auto inline-flex items-center gap-2 rounded-lg border border-slate-300 bg-white px-3 py-1.5 text-sm font-semibold text-slate-700 shadow-sm transition hover:border-slate-400 hover:bg-slate-100 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-600"
@@ -252,10 +299,16 @@ function SettingsButton() {
             <p className="mt-1 text-sm text-slate-500">
               Defaults for agent sessions and OpenCode concurrency.
             </p>
+            {showUnconfiguredGuidance && (
+              <p className="mt-3 rounded-lg bg-amber-50 p-3 text-sm text-amber-950">
+                Select a default build model and thinking level before the
+                harness can create work.
+              </p>
+            )}
           </div>
 
           <div className="grid gap-5 px-6 py-5">
-            {config.isPending || models.isPending ? (
+            {config.isPending || (dialogOpen && models.isPending) ? (
               <p className="text-sm text-slate-500">Loading settings...</p>
             ) : config.isError || models.isError ? (
               <p className="rounded-lg bg-red-50 p-3 text-sm text-red-700">
@@ -272,10 +325,15 @@ function SettingsButton() {
                     onChange={(event) => setDefaultModel(event.target.value)}
                     required
                   >
+                    {!buildConfigured && defaultModel.length === 0 && (
+                      <option value="" disabled>
+                        Select a build model
+                      </option>
+                    )}
                     {hasUnavailableBuildModel && (
                       <option value={defaultModel}>{defaultModel}</option>
                     )}
-                    {models.data.map((model) => (
+                    {(models.data ?? []).map((model) => (
                       <option key={model} value={model}>
                         {model}
                       </option>
@@ -295,6 +353,11 @@ function SettingsButton() {
                     onChange={(event) => setDefaultVariant(event.target.value)}
                     required
                   >
+                    {!buildConfigured && defaultVariant.length === 0 && (
+                      <option value="" disabled>
+                        Select a thinking level
+                      </option>
+                    )}
                     {hasCustomBuildVariant && (
                       <option value={defaultVariant}>{defaultVariant}</option>
                     )}
@@ -322,7 +385,7 @@ function SettingsButton() {
                     {hasUnavailableReviewModel && (
                       <option value={reviewModel}>{reviewModel}</option>
                     )}
-                    {models.data.map((model) => (
+                    {(models.data ?? []).map((model) => (
                       <option key={`review-${model}`} value={model}>
                         {model}
                       </option>
@@ -425,7 +488,9 @@ function SettingsButton() {
                 config.isError ||
                 models.isPending ||
                 models.isError ||
-                updateConfig.isPending
+                updateConfig.isPending ||
+                defaultModel.length === 0 ||
+                defaultVariant.length === 0
               }
             >
               {updateConfig.isPending ? "Saving..." : "Save settings"}

--- a/apps/harness/src/routes/index.tsx
+++ b/apps/harness/src/routes/index.tsx
@@ -531,8 +531,8 @@ function RepositoryCard({
   }
 
   const standardVariants = ["low", "medium", "high", "max"]
-  const harnessDefaultModel = config.data?.defaultModel ?? "harness default"
-  const harnessDefaultVariant = config.data?.defaultVariant ?? "harness default"
+  const harnessDefaultModel = config.data?.defaultModel ?? "not configured"
+  const harnessDefaultVariant = config.data?.defaultVariant ?? "not configured"
   const resolvedBuildModel = repository.defaultModel ?? harnessDefaultModel
   const resolvedBuildVariant =
     repository.defaultVariant ?? harnessDefaultVariant

--- a/packages/db-schema/drizzle/20260718120000_nullable_config_build_model/migration.sql
+++ b/packages/db-schema/drizzle/20260718120000_nullable_config_build_model/migration.sql
@@ -1,0 +1,22 @@
+CREATE TABLE `__new_config` (
+	`id` text PRIMARY KEY DEFAULT 'default',
+	`default_model` text,
+	`default_variant` text,
+	`review_model` text,
+	`review_variant` text,
+	`max_concurrent_opencode_sessions` integer DEFAULT 2 NOT NULL,
+	`max_concurrent_work_items` integer DEFAULT 5 NOT NULL,
+	`created_at` integer NOT NULL,
+	`updated_at` integer NOT NULL
+);--> statement-breakpoint
+INSERT INTO `__new_config` (
+	`id`, `default_model`, `default_variant`, `review_model`, `review_variant`,
+	`max_concurrent_opencode_sessions`, `max_concurrent_work_items`,
+	`created_at`, `updated_at`
+) SELECT
+	`id`, `default_model`, `default_variant`, `review_model`, `review_variant`,
+	`max_concurrent_opencode_sessions`, `max_concurrent_work_items`,
+	`created_at`, `updated_at`
+FROM `config`;--> statement-breakpoint
+DROP TABLE `config`;--> statement-breakpoint
+ALTER TABLE `__new_config` RENAME TO `config`;

--- a/packages/db-schema/src/schema.ts
+++ b/packages/db-schema/src/schema.ts
@@ -42,8 +42,8 @@ export const repository = snakeCase.table(
 
 export const config = snakeCase.table("config", {
   id: text().primaryKey().default("default"),
-  defaultModel: text().notNull().default("opencode/deepseek-v4-flash-free"),
-  defaultVariant: text().notNull().default("low"),
+  defaultModel: text(),
+  defaultVariant: text(),
   reviewModel: text(),
   reviewVariant: text(),
   maxConcurrentOpencodeSessions: integer({ mode: "number" })

--- a/packages/db-service/src/lib/db-service.ts
+++ b/packages/db-service/src/lib/db-service.ts
@@ -353,7 +353,7 @@ export const DbServiceLive = Layer.effect(
                id, default_model, default_variant, review_model, review_variant,
                max_concurrent_opencode_sessions, max_concurrent_work_items,
                created_at, updated_at
-             ) VALUES ('default', 'opencode/deepseek-v4-flash-free', 'low', NULL, NULL, 2, 5, ?, ?)`,
+             ) VALUES ('default', NULL, NULL, NULL, NULL, 2, 5, ?, ?)`,
             [now, now],
           )
           .pipe(Effect.mapError(toDatabaseError))
@@ -367,8 +367,8 @@ export const DbServiceLive = Layer.effect(
           .pipe(Effect.mapError(toDatabaseError))
         const row = rows[0] as
           | {
-              default_model: string
-              default_variant: string
+              default_model: string | null
+              default_variant: string | null
               review_model: string | null
               review_variant: string | null
               max_concurrent_opencode_sessions: number
@@ -469,8 +469,8 @@ export const DbServiceLive = Layer.effect(
           .pipe(Effect.mapError(toDatabaseError))
         const row = rows[0] as
           | {
-              default_model: string
-              default_variant: string
+              default_model: string | null
+              default_variant: string | null
               review_model: string | null
               review_variant: string | null
               max_concurrent_opencode_sessions: number

--- a/packages/db-service/src/lib/types.ts
+++ b/packages/db-service/src/lib/types.ts
@@ -39,8 +39,8 @@ export interface UpdateRepositorySettingsInput {
 }
 
 export interface ConfigRecord {
-  readonly defaultModel: string
-  readonly defaultVariant: string
+  readonly defaultModel: string | null
+  readonly defaultVariant: string | null
   readonly reviewModel: string | null
   readonly reviewVariant: string | null
   readonly maxConcurrentOpencodeSessions: number

--- a/packages/db-service/test/db-service.spec.ts
+++ b/packages/db-service/test/db-service.spec.ts
@@ -42,13 +42,13 @@ describe("DbService", () => {
   }
 
   describe("config", () => {
-    it("returns defaults and persists updates", () =>
+    it("returns null build model on empty DB and persists updates", () =>
       runTest(
         Effect.gen(function* () {
           const db = yield* DbService
           expect(yield* db.getConfig).toEqual({
-            defaultModel: "opencode/deepseek-v4-flash-free",
-            defaultVariant: "low",
+            defaultModel: null,
+            defaultVariant: null,
             reviewModel: null,
             reviewVariant: null,
             maxConcurrentOpencodeSessions: 2,

--- a/packages/graphql-api/src/lib/graphql-api.ts
+++ b/packages/graphql-api/src/lib/graphql-api.ts
@@ -34,6 +34,7 @@ import { EnqueueError, type QueueService } from "@ready-for-agent/queue-service"
 import {
   AbandonCleanupError,
   ActiveStepRunExistsError,
+  BuildModelNotConfiguredError,
   IssueBlockedError,
   IssueNotFoundError,
   IssueNotOpenError,
@@ -364,6 +365,11 @@ const toGraphQLError = (error: unknown): GraphQLError => {
         },
       },
     )
+  }
+  if (error instanceof BuildModelNotConfiguredError) {
+    return new GraphQLError(error.message, {
+      extensions: { code: "BUILD_MODEL_NOT_CONFIGURED" },
+    })
   }
   if (error instanceof WorkItemLifecycleDatabaseError) {
     return new GraphQLError(error.message, {

--- a/packages/graphql-schema/schema.graphql
+++ b/packages/graphql-schema/schema.graphql
@@ -9,8 +9,8 @@ type Query {
 }
 
 type Config {
-  defaultModel: String!
-  defaultVariant: String!
+  defaultModel: String
+  defaultVariant: String
   reviewModel: String
   reviewVariant: String
   maxConcurrentOpencodeSessions: Int!

--- a/packages/work-item-lifecycle/src/lib/errors.ts
+++ b/packages/work-item-lifecycle/src/lib/errors.ts
@@ -39,6 +39,12 @@ export class UnfinishedWorkItemExistsError extends Data.TaggedError(
   readonly workItemId: string
 }> {}
 
+export class BuildModelNotConfiguredError extends Data.TaggedError(
+  "BuildModelNotConfiguredError",
+)<{
+  readonly message: string
+}> {}
+
 export class WorkItemNotFoundError extends Data.TaggedError(
   "WorkItemNotFoundError",
 )<{

--- a/packages/work-item-lifecycle/src/lib/work-item-lifecycle.ts
+++ b/packages/work-item-lifecycle/src/lib/work-item-lifecycle.ts
@@ -32,6 +32,7 @@ import {
 import {
   AbandonCleanupError,
   ActiveStepRunExistsError,
+  BuildModelNotConfiguredError,
   IssueBlockedError,
   IssueNotFoundError,
   IssueNotOpenError,
@@ -359,6 +360,7 @@ export type ImplementNowError =
   | ParentIssueError
   | IssueBlockedError
   | UnfinishedWorkItemExistsError
+  | BuildModelNotConfiguredError
   | WorkItemLifecycleDatabaseError
   | RepositoryNotFoundError
   | DatabaseError
@@ -3058,6 +3060,11 @@ export const makeWorkItemLifecycleLive = (
           const repository = repositories.find(({ id }) => id === repositoryId)
           const model = repository?.defaultModel ?? config.defaultModel
           const variant = repository?.defaultVariant ?? config.defaultVariant
+          if (model === null || variant === null) {
+            return yield* new BuildModelNotConfiguredError({
+              message: "Select a default build model first",
+            })
+          }
           const reviewModel =
             repository?.reviewModel ?? config.reviewModel ?? model
           const reviewVariant =

--- a/packages/work-item-lifecycle/test/sync-needs-human-merge-handoffs.spec.ts
+++ b/packages/work-item-lifecycle/test/sync-needs-human-merge-handoffs.spec.ts
@@ -91,6 +91,14 @@ describe("syncNeedsHumanMergeHandoffs", () => {
   const driveToNeedsHuman = Effect.gen(function* () {
     const db = yield* DbService
     const lifecycle = yield* WorkItemLifecycle
+    yield* db.updateConfig({
+      defaultModel: "opencode/deepseek-v4-flash-free",
+      defaultVariant: "low",
+      reviewModel: null,
+      reviewVariant: null,
+      maxConcurrentOpencodeSessions: 2,
+      maxConcurrentWorkItems: 5,
+    })
     const repository = yield* db.addRepository({
       githubOwner: "acme",
       githubRepo: "widgets",

--- a/packages/work-item-lifecycle/test/work-item-lifecycle.spec.ts
+++ b/packages/work-item-lifecycle/test/work-item-lifecycle.spec.ts
@@ -27,6 +27,7 @@ import {
 import { SqliteQueueServiceLive } from "@ready-for-agent/sqlite-queue-service"
 import {
   ActiveStepRunExistsError,
+  BuildModelNotConfiguredError,
   CommitOpenCodeError,
   CreatePrOpenCodeError,
   IssueBlockedError,
@@ -136,8 +137,25 @@ describe("WorkItemLifecycle", () => {
     blockedBy: [],
   }
 
+  const seedHarnessBuildModel = Effect.gen(function* () {
+    const db = yield* DbService
+    const config = yield* db.getConfig
+    if (config.defaultModel !== null && config.defaultVariant !== null) {
+      return
+    }
+    yield* db.updateConfig({
+      defaultModel: config.defaultModel ?? "opencode/deepseek-v4-flash-free",
+      defaultVariant: config.defaultVariant ?? "low",
+      reviewModel: config.reviewModel,
+      reviewVariant: config.reviewVariant,
+      maxConcurrentOpencodeSessions: config.maxConcurrentOpencodeSessions,
+      maxConcurrentWorkItems: config.maxConcurrentWorkItems,
+    })
+  })
+
   const seedActionableIssue = Effect.gen(function* () {
     const db = yield* DbService
+    yield* seedHarnessBuildModel
     const repository = yield* db.addRepository(sampleRepository)
     const issue = yield* db.storeIssue({
       repositoryId: repository.id,
@@ -201,6 +219,62 @@ describe("WorkItemLifecycle", () => {
           expect(workItem.variant).toBe(config.defaultVariant)
           expect(workItem.reviewModel).toBe(config.defaultModel)
           expect(workItem.reviewVariant).toBe(config.defaultVariant)
+        }),
+      ))
+
+    it("rejects when no build model can be resolved", () =>
+      runTest(
+        Effect.gen(function* () {
+          const lifecycle = yield* WorkItemLifecycle
+          const db = yield* DbService
+          const repository = yield* db.addRepository(sampleRepository)
+          const issue = yield* db.storeIssue({
+            repositoryId: repository.id,
+            githubIssueNumber: 42,
+            ...sampleIssueFields,
+          })
+
+          const error = yield* Effect.flip(
+            lifecycle.implementNow(repository.id, issue.githubIssueNumber),
+          )
+
+          expect(error).toBeInstanceOf(BuildModelNotConfiguredError)
+          if (error instanceof BuildModelNotConfiguredError) {
+            expect(error.message).toBe("Select a default build model first")
+          }
+        }),
+      ))
+
+    it("allows repository build override when harness defaults are unset", () =>
+      runTest(
+        Effect.gen(function* () {
+          const lifecycle = yield* WorkItemLifecycle
+          const db = yield* DbService
+          const repository = yield* db.addRepository(sampleRepository)
+          const issue = yield* db.storeIssue({
+            repositoryId: repository.id,
+            githubIssueNumber: 42,
+            ...sampleIssueFields,
+          })
+          yield* db.updateRepositorySettings({
+            repositoryId: repository.id,
+            paused: repository.paused,
+            defaultModel: "anthropic/claude-sonnet-4-5",
+            defaultVariant: "max",
+            reviewModel: null,
+            reviewVariant: null,
+            autoMerge: repository.autoMerge,
+          })
+
+          const workItem = yield* lifecycle.implementNow(
+            repository.id,
+            issue.githubIssueNumber,
+          )
+
+          expect(workItem.model).toBe("anthropic/claude-sonnet-4-5")
+          expect(workItem.variant).toBe("max")
+          expect(workItem.reviewModel).toBe("anthropic/claude-sonnet-4-5")
+          expect(workItem.reviewVariant).toBe("max")
         }),
       ))
 
@@ -502,6 +576,7 @@ describe("WorkItemLifecycle", () => {
         Effect.gen(function* () {
           const lifecycle = yield* WorkItemLifecycle
           const db = yield* DbService
+          yield* seedHarnessBuildModel
           const repository = yield* db.addRepository(sampleRepository)
           yield* db.storeIssue({
             repositoryId: repository.id,
@@ -2668,6 +2743,7 @@ describe("WorkItemLifecycle", () => {
         Effect.gen(function* () {
           const lifecycle = yield* WorkItemLifecycle
           const db = yield* DbService
+          yield* seedHarnessBuildModel
           const repository = yield* db.addRepository(sampleRepository)
           yield* db.storeIssue({
             repositoryId: repository.id,
@@ -4324,6 +4400,7 @@ describe("WorkItemLifecycle", () => {
     const seedIssue = (githubIssueNumber: number) =>
       Effect.gen(function* () {
         const db = yield* DbService
+        yield* seedHarnessBuildModel
         const repository = yield* db.addRepository({
           ...sampleRepository,
           localPath: `/repos/acme/widgets-${githubIssueNumber}.git`,
@@ -4343,7 +4420,12 @@ describe("WorkItemLifecycle", () => {
         const db = yield* DbService
         const config = yield* db.getConfig
         yield* db.updateConfig({
-          ...config,
+          defaultModel:
+            config.defaultModel ?? "opencode/deepseek-v4-flash-free",
+          defaultVariant: config.defaultVariant ?? "low",
+          reviewModel: config.reviewModel,
+          reviewVariant: config.reviewVariant,
+          maxConcurrentOpencodeSessions: config.maxConcurrentOpencodeSessions,
           maxConcurrentWorkItems,
         })
       })


### PR DESCRIPTION
## Summary

- Stop seeding a free default harness build model on empty DB; build model/variant start null.
- Auto-open Settings with setup message + dismissible banner until a build model and thinking level are set.
- Hard-block Work Item creation with `BuildModelNotConfiguredError` (`Select a default build model first`); repository overrides still work.

Closes #241

## Test plan

- [x] `db-service` tests: first `getConfig` yields null model/variant; concurrency defaults remain
- [x] `work-item-lifecycle` tests: unconfigured fails; repo override alone succeeds; review fallback still works
- [x] `graphql-api` tests pass with nullable Config fields
- [ ] Manual: fresh DB opens Settings with setup message; dismiss shows banner; save enables work creation