### PR TITLE
feat(harness): split Jobs card into Working and Completed tabs

### DIFF
--- a/apps/harness/src/refresh-issues-live.ts
+++ b/apps/harness/src/refresh-issues-live.ts
@@ -55,12 +55,37 @@ export const followRepositoryIssuesLive = async ({
     return queryClient.fetchQuery({ ...query, staleTime: 0 })
   }
 
+  const refreshWorkItems = async (repositoryId: string) => {
+    const defaultQuery = queries.workItems(repositoryId)
+    await queryClient.cancelQueries({
+      queryKey: ["work-items", repositoryId],
+    })
+    const cached = queryClient
+      .getQueryCache()
+      .findAll({ queryKey: ["work-items", repositoryId] })
+    if (cached.length === 0) {
+      await fetchFresh(defaultQuery)
+      return
+    }
+    await Promise.all(
+      cached.map(async (query) => {
+        const queryFn = query.options.queryFn
+        if (typeof queryFn !== "function") return
+        await queryClient.fetchQuery({
+          queryKey: query.queryKey,
+          queryFn: queryFn as (context: unknown) => Promise<unknown>,
+          staleTime: 0,
+        })
+      }),
+    )
+  }
+
   const refresh = async (repositoryId: string) => {
     onRepositoryChanged?.(repositoryId)
     await Promise.all([
       fetchFresh(queries.repositories),
       fetchFresh(queries.issues(repositoryId)),
-      fetchFresh(queries.workItems(repositoryId)),
+      refreshWorkItems(repositoryId),
     ])
   }
 
@@ -71,9 +96,7 @@ export const followRepositoryIssuesLive = async ({
       ...repositoryIds.map((repositoryId) =>
         fetchFresh(queries.issues(repositoryId)),
       ),
-      ...repositoryIds.map((repositoryId) =>
-        fetchFresh(queries.workItems(repositoryId)),
-      ),
+      ...repositoryIds.map((repositoryId) => refreshWorkItems(repositoryId)),
     ])
   }
 

--- a/apps/harness/src/refresh-work-items-live.ts
+++ b/apps/harness/src/refresh-work-items-live.ts
@@ -45,16 +45,39 @@ export const followRepositoryWorkItemsLive = async ({
     return queryClient.fetchQuery({ ...query, staleTime: 0 })
   }
 
+  /**
+   * Refetch every work-items cache for the repository (default list plus any
+   * Jobs Working/Completed listKind variants already in the query cache).
+   */
   const refresh = async (repositoryId: string) => {
-    await fetchFresh(queries.workItems(repositoryId))
+    const defaultQuery = queries.workItems(repositoryId)
+    await queryClient.cancelQueries({
+      queryKey: ["work-items", repositoryId],
+    })
+    const cached = queryClient
+      .getQueryCache()
+      .findAll({ queryKey: ["work-items", repositoryId] })
+    if (cached.length === 0) {
+      await fetchFresh(defaultQuery)
+      return
+    }
+    await Promise.all(
+      cached.map(async (query) => {
+        const queryFn = query.options.queryFn
+        if (typeof queryFn !== "function") return
+        await queryClient.fetchQuery({
+          queryKey: query.queryKey,
+          queryFn: queryFn as (context: unknown) => Promise<unknown>,
+          staleTime: 0,
+        })
+      }),
+    )
   }
 
   const refreshAll = async () => {
     const repositoryIds = getRepositoryIds()
     await Promise.all(
-      repositoryIds.map((repositoryId) =>
-        fetchFresh(queries.workItems(repositoryId)),
-      ),
+      repositoryIds.map((repositoryId) => refresh(repositoryId)),
     )
   }
 

--- a/apps/harness/src/routes/index.tsx
+++ b/apps/harness/src/routes/index.tsx
@@ -235,18 +235,66 @@ const workItemFields = {
   },
 } as const
 
-const workItemsQuery = (repositoryId: string) => ({
-  queryKey: ["work-items", repositoryId],
-  queryFn: async (): Promise<readonly WorkItem[]> => {
-    const result = await graphql.query({
-      workItems: {
-        __args: { repositoryId },
-        ...workItemFields,
-      },
-    })
-    return result.workItems
-  },
-})
+type WorkItemsListKindArg = "WORKING" | "COMPLETED"
+
+type WorkItemsQueryOptions = {
+  readonly listKind?: WorkItemsListKindArg
+  readonly limit?: number
+}
+
+const JOBS_COMPLETED_LIMIT = 15
+
+const workItemsQuery = (
+  repositoryId: string,
+  options: WorkItemsQueryOptions = {},
+) => {
+  const listKind = options.listKind
+  const limit = options.limit
+  return {
+    queryKey: [
+      "work-items",
+      repositoryId,
+      listKind ?? null,
+      limit ?? null,
+    ] as const,
+    queryFn: async (): Promise<readonly WorkItem[]> => {
+      const result = await graphql.query({
+        workItems: {
+          __args: {
+            repositoryId,
+            ...(listKind === undefined ? {} : { listKind }),
+            ...(limit === undefined ? {} : { limit }),
+          },
+          ...workItemFields,
+        },
+      })
+      return result.workItems
+    },
+  }
+}
+
+const jobsWorkingWorkItemsQuery = (repositoryId: string) =>
+  workItemsQuery(repositoryId, { listKind: "WORKING" })
+
+const jobsCompletedWorkItemsQuery = (repositoryId: string) =>
+  workItemsQuery(repositoryId, {
+    listKind: "COMPLETED",
+    limit: JOBS_COMPLETED_LIMIT,
+  })
+
+const patchWorkItemsCaches = (
+  queryClient: ReturnType<typeof useQueryClient>,
+  repositoryId: string,
+  update: (
+    current: readonly WorkItem[] | undefined,
+  ) => readonly WorkItem[] | undefined,
+) => {
+  for (const [queryKey] of queryClient.getQueriesData<readonly WorkItem[]>({
+    queryKey: ["work-items", repositoryId],
+  })) {
+    queryClient.setQueryData<readonly WorkItem[]>(queryKey, update)
+  }
+}
 
 export const Route = createFileRoute("/")({
   component: HomePage,
@@ -1455,10 +1503,20 @@ function RepositoryIssueRow({
   )
 }
 
+type JobsTab = "working" | "completed"
+
 function JobsCard() {
+  const [selectedTab, setSelectedTab] = useState<JobsTab>("working")
   const { data: repositories } = useSuspenseQuery(repositoriesQuery)
-  const workItemQueries = useQueries({
-    queries: repositories.map((repository) => workItemsQuery(repository.id)),
+  const workingQueries = useQueries({
+    queries: repositories.map((repository) =>
+      jobsWorkingWorkItemsQuery(repository.id),
+    ),
+  })
+  const completedQueries = useQueries({
+    queries: repositories.map((repository) =>
+      jobsCompletedWorkItemsQuery(repository.id),
+    ),
   })
   const issueQueries = useQueries({
     queries: repositories.map((repository) => issuesQuery(repository.id)),
@@ -1476,11 +1534,25 @@ function JobsCard() {
       )
     }
   }
-  const workItems = workItemQueries
-    .flatMap((query) => query.data ?? [])
-    .sort((left, right) => right.createdAt.localeCompare(left.createdAt))
-  const loading = workItemQueries.some((query) => query.isLoading)
-  const failed = workItemQueries.some((query) => query.isError)
+  const sortNewestFirst = (items: readonly WorkItem[]) =>
+    items
+      .slice()
+      .sort((left, right) => right.createdAt.localeCompare(left.createdAt))
+  const workingItems = sortNewestFirst(
+    workingQueries.flatMap((query) => query.data ?? []),
+  )
+  const completedItems = sortNewestFirst(
+    completedQueries.flatMap((query) => query.data ?? []),
+  ).slice(0, JOBS_COMPLETED_LIMIT)
+  const activeItems = selectedTab === "working" ? workingItems : completedItems
+  const activeQueries =
+    selectedTab === "working" ? workingQueries : completedQueries
+  const loading = activeQueries.some((query) => query.isLoading)
+  const failed = activeQueries.some((query) => query.isError)
+  const emptyMessage =
+    selectedTab === "working" ? "No working jobs." : "No completed jobs."
+  const listAriaLabel =
+    selectedTab === "working" ? "Working jobs" : "Completed jobs"
 
   if (repositories.length === 0) {
     return (
@@ -1492,7 +1564,7 @@ function JobsCard() {
     )
   }
 
-  if (loading && workItems.length === 0) {
+  if (loading && activeItems.length === 0) {
     return <JobsCardSkeleton />
   }
 
@@ -1506,118 +1578,166 @@ function JobsCard() {
     )
   }
 
-  if (workItems.length === 0) {
-    return (
-      <article className="rounded-[0.9rem] border border-[#dbe3ef] bg-white p-[1.35rem] shadow-[0_10px_30px_rgb(15_23_42_/_5%)]">
-        <p className="m-0 text-sm text-slate-500">No jobs yet.</p>
-      </article>
-    )
-  }
-
   return (
     <article className="rounded-[0.9rem] border border-[#dbe3ef] bg-white p-[1.35rem] shadow-[0_10px_30px_rgb(15_23_42_/_5%)]">
-      <ul className="m-0 grid list-none gap-2 p-0" aria-label="All jobs">
-        {workItems.map((workItem) => {
-          const repository = repositoryById.get(workItem.repositoryId)
-          const repositoryLabel =
-            repository === undefined
-              ? workItem.repositoryId
-              : `${repository.githubOwner}/${repository.githubRepo}`
-          const issue = issueByRepoAndNumber.get(
-            `${workItem.repositoryId}:${workItem.githubIssueNumber}`,
-          )
-          const issueTitle = issue?.title
-          const issueUrl = issue?.url
-          const issueIdentity =
-            issueTitle === undefined
-              ? `#${workItem.githubIssueNumber}`
-              : `#${workItem.githubIssueNumber} · ${issueTitle}`
-          const issueIdentityContent = (
-            <>
-              <span className="font-mono">#{workItem.githubIssueNumber}</span>
-              {issueTitle !== undefined && (
-                <span className="font-sans"> · {issueTitle}</span>
-              )}
-            </>
-          )
-          const { sessionId, worktreePath } = sessionWorktreeParts(
-            workItem.sessionId,
-            workItem.worktreePath,
-          )
+      <div
+        className="mb-3 flex gap-1 border-b border-slate-200"
+        role="tablist"
+        aria-label="Jobs"
+      >
+        {(
+          [
+            { id: "working", label: "Working" },
+            { id: "completed", label: "Completed" },
+          ] as const
+        ).map((tab) => {
+          const selected = selectedTab === tab.id
           return (
-            <li
-              className="rounded-lg border border-slate-200 bg-slate-50/80 px-3 py-2"
-              key={workItem.id}
-            >
-              <div className="flex items-start justify-between gap-3">
-                <div className="min-w-0">
-                  <p className="m-0 truncate text-xs font-semibold text-slate-700">
-                    {repositoryLabel}
-                  </p>
-                  {issueUrl !== undefined && issueUrl !== "" ? (
-                    <a
-                      className="m-0 block truncate text-xs font-semibold text-blue-600 hover:underline"
-                      href={issueUrl}
-                      title={issueIdentity}
-                    >
-                      {issueIdentityContent}
-                    </a>
-                  ) : (
-                    <p
-                      className="m-0 truncate text-xs font-semibold text-blue-600"
-                      title={issueIdentity}
-                    >
-                      {issueIdentityContent}
-                    </p>
-                  )}
-                </div>
-                <div className="flex shrink-0 items-center gap-1">
-                  <span className="text-[0.65rem] font-bold tracking-wide text-slate-600 uppercase">
-                    {workItem.stateLabel}
-                  </span>
-                  <WorkItemPauseButton workItem={workItem} />
-                </div>
-              </div>
-              {(sessionId !== null || worktreePath !== null) && (
-                <p className="mt-1 mb-0 flex min-w-0 flex-wrap items-center gap-1">
-                  {sessionId !== null && (
-                    <Copy
-                      value={sessionId}
-                      className="min-w-0 max-w-full"
-                      textClassName="font-mono text-[0.7rem] text-slate-500"
-                    />
-                  )}
-                  {sessionId !== null && worktreePath !== null && (
-                    <span className="shrink-0 font-mono text-[0.7rem] text-slate-500">
-                      -
-                    </span>
-                  )}
-                  {worktreePath !== null && (
-                    <Copy
-                      value={worktreePath}
-                      className="min-w-0 max-w-full"
-                      textClassName="font-mono text-[0.7rem] text-slate-500"
-                    />
-                  )}
-                </p>
-              )}
-              <WorkItemLifecycleStatus
-                workItem={workItem}
-                compact
-                pullRequestUrl={
-                  repository === undefined
-                    ? null
-                    : workItemPullRequestUrl(
-                        repository.githubOwner,
-                        repository.githubRepo,
-                        workItem.githubPullRequestNumber,
-                      )
+            <button
+              key={tab.id}
+              type="button"
+              role="tab"
+              id={`jobs-tab-${tab.id}`}
+              aria-selected={selected}
+              aria-controls={`jobs-panel-${tab.id}`}
+              tabIndex={selected ? 0 : -1}
+              className={`-mb-px border-b-2 px-3 py-1.5 text-sm font-semibold transition ${
+                selected
+                  ? "border-blue-600 text-blue-700"
+                  : "border-transparent text-slate-500 hover:text-slate-700"
+              }`}
+              onClick={() => setSelectedTab(tab.id)}
+              onKeyDown={(event) => {
+                if (event.key === "ArrowRight" || event.key === "ArrowLeft") {
+                  event.preventDefault()
+                  const nextTab = tab.id === "working" ? "completed" : "working"
+                  setSelectedTab(nextTab)
+                  document.getElementById(`jobs-tab-${nextTab}`)?.focus()
                 }
-              />
-            </li>
+              }}
+            >
+              {tab.label}
+            </button>
           )
         })}
-      </ul>
+      </div>
+      <div
+        role="tabpanel"
+        id={`jobs-panel-${selectedTab}`}
+        aria-labelledby={`jobs-tab-${selectedTab}`}
+      >
+        {activeItems.length === 0 ? (
+          <p className="m-0 text-sm text-slate-500">{emptyMessage}</p>
+        ) : (
+          <ul
+            className="m-0 grid list-none gap-2 p-0"
+            aria-label={listAriaLabel}
+          >
+            {activeItems.map((workItem) => {
+              const repository = repositoryById.get(workItem.repositoryId)
+              const repositoryLabel =
+                repository === undefined
+                  ? workItem.repositoryId
+                  : `${repository.githubOwner}/${repository.githubRepo}`
+              const issue = issueByRepoAndNumber.get(
+                `${workItem.repositoryId}:${workItem.githubIssueNumber}`,
+              )
+              const issueTitle = issue?.title
+              const issueUrl = issue?.url
+              const issueIdentity =
+                issueTitle === undefined
+                  ? `#${workItem.githubIssueNumber}`
+                  : `#${workItem.githubIssueNumber} · ${issueTitle}`
+              const issueIdentityContent = (
+                <>
+                  <span className="font-mono">
+                    #{workItem.githubIssueNumber}
+                  </span>
+                  {issueTitle !== undefined && (
+                    <span className="font-sans"> · {issueTitle}</span>
+                  )}
+                </>
+              )
+              const { sessionId, worktreePath } = sessionWorktreeParts(
+                workItem.sessionId,
+                workItem.worktreePath,
+              )
+              return (
+                <li
+                  className="rounded-lg border border-slate-200 bg-slate-50/80 px-3 py-2"
+                  key={workItem.id}
+                >
+                  <div className="flex items-start justify-between gap-3">
+                    <div className="min-w-0">
+                      <p className="m-0 truncate text-xs font-semibold text-slate-700">
+                        {repositoryLabel}
+                      </p>
+                      {issueUrl !== undefined && issueUrl !== "" ? (
+                        <a
+                          className="m-0 block truncate text-xs font-semibold text-blue-600 hover:underline"
+                          href={issueUrl}
+                          title={issueIdentity}
+                        >
+                          {issueIdentityContent}
+                        </a>
+                      ) : (
+                        <p
+                          className="m-0 truncate text-xs font-semibold text-blue-600"
+                          title={issueIdentity}
+                        >
+                          {issueIdentityContent}
+                        </p>
+                      )}
+                    </div>
+                    <div className="flex shrink-0 items-center gap-1">
+                      <span className="text-[0.65rem] font-bold tracking-wide text-slate-600 uppercase">
+                        {workItem.stateLabel}
+                      </span>
+                      <WorkItemPauseButton workItem={workItem} />
+                    </div>
+                  </div>
+                  {(sessionId !== null || worktreePath !== null) && (
+                    <p className="mt-1 mb-0 flex min-w-0 flex-wrap items-center gap-1">
+                      {sessionId !== null && (
+                        <Copy
+                          value={sessionId}
+                          className="min-w-0 max-w-full"
+                          textClassName="font-mono text-[0.7rem] text-slate-500"
+                        />
+                      )}
+                      {sessionId !== null && worktreePath !== null && (
+                        <span className="shrink-0 font-mono text-[0.7rem] text-slate-500">
+                          -
+                        </span>
+                      )}
+                      {worktreePath !== null && (
+                        <Copy
+                          value={worktreePath}
+                          className="min-w-0 max-w-full"
+                          textClassName="font-mono text-[0.7rem] text-slate-500"
+                        />
+                      )}
+                    </p>
+                  )}
+                  <WorkItemLifecycleStatus
+                    workItem={workItem}
+                    compact
+                    pullRequestUrl={
+                      repository === undefined
+                        ? null
+                        : workItemPullRequestUrl(
+                            repository.githubOwner,
+                            repository.githubRepo,
+                            workItem.githubPullRequestNumber,
+                          )
+                    }
+                  />
+                </li>
+              )
+            })}
+          </ul>
+        )}
+      </div>
     </article>
   )
 }
@@ -1641,12 +1761,10 @@ function JobsCardSkeleton() {
 function WorkItemPauseButton({ workItem }: { workItem: WorkItem }) {
   const queryClient = useQueryClient()
   const updateWorkItem = (updated: WorkItem) => {
-    queryClient.setQueryData<readonly WorkItem[]>(
-      workItemsQuery(workItem.repositoryId).queryKey,
-      (current) =>
-        current?.map((candidate) =>
-          candidate.id === updated.id ? updated : candidate,
-        ),
+    patchWorkItemsCaches(queryClient, workItem.repositoryId, (current) =>
+      current?.map((candidate) =>
+        candidate.id === updated.id ? updated : candidate,
+      ),
     )
   }
   const pause = useMutation({
@@ -1754,17 +1872,22 @@ function WorkItemLifecycleStatus({
   const status = workItem.status
   const canRetry = compact && workItem.canRetry
   const canReset = compact
-  const dataUpdatedAt =
-    queryClient.getQueryState(workItemsQuery(workItem.repositoryId).queryKey)
-      ?.dataUpdatedAt ?? 0
+  const dataUpdatedAt = queryClient
+    .getQueriesData({ queryKey: ["work-items", workItem.repositoryId] })
+    .reduce(
+      (latest, [queryKey]) =>
+        Math.max(
+          latest,
+          queryClient.getQueryState(queryKey)?.dataUpdatedAt ?? 0,
+        ),
+      0,
+    )
   const nowMs = useNowMs(true)
   const patchWorkItem = (updated: WorkItem) => {
-    queryClient.setQueryData<readonly WorkItem[]>(
-      workItemsQuery(workItem.repositoryId).queryKey,
-      (current) =>
-        current?.map((candidate) =>
-          candidate.id === updated.id ? updated : candidate,
-        ),
+    patchWorkItemsCaches(queryClient, workItem.repositoryId, (current) =>
+      current?.map((candidate) =>
+        candidate.id === updated.id ? updated : candidate,
+      ),
     )
   }
   const retry = useMutation({
@@ -1789,9 +1912,8 @@ function WorkItemLifecycleStatus({
       return result.resetWorkItem
     },
     onSuccess: (deletedId) => {
-      queryClient.setQueryData<readonly WorkItem[]>(
-        workItemsQuery(workItem.repositoryId).queryKey,
-        (current) => current?.filter((candidate) => candidate.id !== deletedId),
+      patchWorkItemsCaches(queryClient, workItem.repositoryId, (current) =>
+        current?.filter((candidate) => candidate.id !== deletedId),
       )
     },
   })

--- a/apps/harness/test/jobs-card-no-polling.test.ts
+++ b/apps/harness/test/jobs-card-no-polling.test.ts
@@ -25,6 +25,27 @@ describe("JobsCard live updates", () => {
     expect(source).toContain("followRepositoryWorkItemsLive")
   })
 
+  test("splits Jobs into Working and Completed tabs with listKind queries", () => {
+    const { source, jobsCard } = jobsCardSource()
+    expect(jobsCard).toContain('role="tablist"')
+    expect(jobsCard).toContain('aria-label="Jobs"')
+    expect(jobsCard).toContain('role="tab"')
+    expect(jobsCard).toContain('role="tabpanel"')
+    expect(jobsCard).toContain("Working")
+    expect(jobsCard).toContain("Completed")
+    expect(jobsCard).toContain('useState<JobsTab>("working")')
+    expect(jobsCard).toContain("jobsWorkingWorkItemsQuery")
+    expect(jobsCard).toContain("jobsCompletedWorkItemsQuery")
+    expect(jobsCard).toContain("No working jobs.")
+    expect(jobsCard).toContain("No completed jobs.")
+    expect(jobsCard).toContain("Working jobs")
+    expect(jobsCard).toContain("Completed jobs")
+    expect(jobsCard).not.toContain('aria-label="All jobs"')
+    expect(source).toContain('listKind: "WORKING"')
+    expect(source).toContain('listKind: "COMPLETED"')
+    expect(source).toContain("JOBS_COMPLETED_LIMIT = 15")
+  })
+
   test("shows issue number with title and top-right pause control", () => {
     const { jobsCard } = jobsCardSource()
     expect(jobsCard).not.toContain("Issue #")

--- a/packages/graphql-api/src/lib/graphql-api.ts
+++ b/packages/graphql-api/src/lib/graphql-api.ts
@@ -51,6 +51,8 @@ import {
   WorkItemNotFoundError,
   type WorkItemRecord,
   WorkItemTerminalError,
+  type WorkItemsListKind,
+  filterWorkItemsByListKind,
   isTerminalWorkItemState,
 } from "@ready-for-agent/work-item-lifecycle"
 import {
@@ -109,6 +111,16 @@ type IssuesArgs = {
 
 type WorkItemsArgs = IssuesArgs & {
   githubIssueNumber?: number
+  listKind?: "WORKING" | "COMPLETED"
+  limit?: number
+}
+
+const toWorkItemsListKind = (
+  listKind: WorkItemsArgs["listKind"],
+): WorkItemsListKind | undefined => {
+  if (listKind === "WORKING") return "working"
+  if (listKind === "COMPLETED") return "completed"
+  return undefined
 }
 
 type ImplementNowArgs = IssuesArgs & {
@@ -651,11 +663,14 @@ export const createGraphqlApi = (
               Effect.result(
                 Effect.gen(function* () {
                   const lifecycle = yield* WorkItemLifecycle
+                  const listKind = toWorkItemsListKind(args.listKind)
+                  const limit = args.limit
                   if (args.githubIssueNumber !== undefined) {
-                    return yield* lifecycle.listWorkItemsForIssue(
+                    const workItems = yield* lifecycle.listWorkItemsForIssue(
                       args.repositoryId,
                       args.githubIssueNumber,
                     )
+                    return filterWorkItemsByListKind(workItems, listKind, limit)
                   }
                   const db = yield* DbService
                   const [workItems, issues] = yield* Effect.all([
@@ -665,11 +680,12 @@ export const createGraphqlApi = (
                   const relevantIssueNumbers = new Set(
                     issues.map((issue) => issue.githubIssueNumber),
                   )
-                  return workItems.filter(
+                  const visible = workItems.filter(
                     (workItem) =>
                       !isTerminalWorkItemState(workItem.state) ||
                       relevantIssueNumbers.has(workItem.githubIssueNumber),
                   )
+                  return filterWorkItemsByListKind(visible, listKind, limit)
                 }),
               ),
             )

--- a/packages/graphql-api/test/graphql-api.test.ts
+++ b/packages/graphql-api/test/graphql-api.test.ts
@@ -1854,6 +1854,133 @@ describe("GraphQL API", () => {
     })
   })
 
+  test("filters Working Work Items including Needs Human", async () => {
+    const needsHuman = {
+      ...workItem,
+      id: makeWorkItemId(),
+      state: "needs_human" as const,
+      stepRuns: [],
+    }
+    const complete = {
+      ...workItem,
+      id: makeWorkItemId(),
+      state: "complete" as const,
+      stepRuns: [],
+    }
+    const implementing = {
+      ...workItem,
+      id: makeWorkItemId(),
+      state: "implement" as const,
+      stepRuns: [],
+    }
+    await runtime.dispose()
+    runtime = makeRuntime(
+      {
+        listIssues: () => Effect.succeed([issue]),
+      },
+      {},
+      {},
+      {},
+      {
+        listWorkItemsForRepository: () =>
+          Effect.succeed([needsHuman, complete, implementing]),
+      },
+    )
+
+    const response = await createGraphqlApi(runtime).fetch(
+      graphqlRequest({
+        query: `query WorkItems($repositoryId: ID!, $listKind: WorkItemsListKind) {
+          workItems(repositoryId: $repositoryId, listKind: $listKind) {
+            id state
+          }
+        }`,
+        variables: { repositoryId: repository.id, listKind: "WORKING" },
+      }),
+    )
+
+    expect(await response.json()).toEqual({
+      data: {
+        workItems: [
+          {
+            id: needsHuman.id,
+            state: "NEEDS_HUMAN",
+          },
+          {
+            id: implementing.id,
+            state: "IMPLEMENT",
+          },
+        ],
+      },
+    })
+  })
+
+  test("filters Completed Work Items newest-first with limit", async () => {
+    const baseTime = Date.parse("2026-01-01T00:00:00.000Z")
+    const completed = Array.from({ length: 18 }, (_, index) => ({
+      ...workItem,
+      id: makeWorkItemId(),
+      state: (index % 3 === 0
+        ? "complete"
+        : index % 3 === 1
+          ? "failed"
+          : "abandoned") as "complete" | "failed" | "abandoned",
+      createdAt: new Date(baseTime + index * 1000),
+      stepRuns: [],
+    }))
+    const needsHuman = {
+      ...workItem,
+      id: makeWorkItemId(),
+      state: "needs_human" as const,
+      createdAt: new Date(baseTime + 50_000),
+      stepRuns: [],
+    }
+    await runtime.dispose()
+    runtime = makeRuntime(
+      {
+        listIssues: () => Effect.succeed([issue]),
+      },
+      {},
+      {},
+      {},
+      {
+        listWorkItemsForRepository: () =>
+          Effect.succeed([...completed, needsHuman]),
+      },
+    )
+
+    const response = await createGraphqlApi(runtime).fetch(
+      graphqlRequest({
+        query: `query WorkItems($repositoryId: ID!, $listKind: WorkItemsListKind, $limit: Int) {
+          workItems(repositoryId: $repositoryId, listKind: $listKind, limit: $limit) {
+            id state
+          }
+        }`,
+        variables: {
+          repositoryId: repository.id,
+          listKind: "COMPLETED",
+          limit: 15,
+        },
+      }),
+    )
+
+    const body = (await response.json()) as {
+      data: { workItems: readonly { id: string; state: string }[] }
+    }
+    expect(body.data.workItems).toHaveLength(15)
+    expect(
+      body.data.workItems.every((item) => item.state !== "NEEDS_HUMAN"),
+    ).toBe(true)
+    expect(body.data.workItems.map((item) => item.id)).toEqual(
+      completed
+        .slice()
+        .sort(
+          (left, right) => right.createdAt.getTime() - left.createdAt.getTime(),
+        )
+        .slice(0, 15)
+        .map((item) => item.id),
+    )
+  })
+
   test("hides terminal Work Items whose Issue is no longer Relevant", async () => {
     const terminalOrphan = {
       ...workItem,

--- a/packages/graphql-schema/schema.graphql
+++ b/packages/graphql-schema/schema.graphql
@@ -5,7 +5,27 @@ type Query {
   config: Config!
   models: [String!]!
   issues(repositoryId: ID!): [Issue!]!
-  workItems(repositoryId: ID!, githubIssueNumber: Int): [WorkItem!]!
+  """
+  Work Items for a repository (or one issue when githubIssueNumber is set).
+  Omit listKind/limit for the full list (backward-compatible default).
+  listKind WORKING: unfinished + Needs Human (no 15-cap from the Jobs card).
+  listKind COMPLETED: Complete/Failed/Abandoned only, newest createdAt first;
+  pass limit (e.g. 15) to bound finished history.
+  """
+  workItems(
+    repositoryId: ID!
+    githubIssueNumber: Int
+    listKind: WorkItemsListKind
+    limit: Int
+  ): [WorkItem!]!
+}
+
+"""
+Jobs card partition: Working vs Completed membership.
+"""
+enum WorkItemsListKind {
+  WORKING
+  COMPLETED
 }
 
 type Config {

--- a/packages/work-item-lifecycle/src/lib/types.ts
+++ b/packages/work-item-lifecycle/src/lib/types.ts
@@ -123,6 +123,59 @@ export const isTerminalWorkItemState = (
 ): state is (typeof TERMINAL_WORK_ITEM_STATES)[number] =>
   (TERMINAL_WORK_ITEM_STATES as readonly string[]).includes(state)
 
+/**
+ * Jobs card Completed tab: finished outcomes only.
+ * Needs Human is domain-terminal for admission but stays on Working as active handoff.
+ */
+export const JOBS_COMPLETED_WORK_ITEM_STATES = [
+  "complete",
+  "failed",
+  "abandoned",
+] as const satisfies readonly WorkItemState[]
+
+export type JobsCompletedWorkItemState =
+  (typeof JOBS_COMPLETED_WORK_ITEM_STATES)[number]
+
+export const isJobsCompletedWorkItemState = (
+  state: WorkItemState,
+): state is JobsCompletedWorkItemState =>
+  (JOBS_COMPLETED_WORK_ITEM_STATES as readonly string[]).includes(state)
+
+/** Jobs card Working tab: unfinished lifecycle work plus Needs Human handoffs. */
+export const isJobsWorkingWorkItemState = (state: WorkItemState): boolean =>
+  !isJobsCompletedWorkItemState(state)
+
+/** GraphQL / Jobs list partition: working vs completed membership. */
+export type WorkItemsListKind = "working" | "completed"
+
+/**
+ * Filter Work Items for Jobs Working / Completed lists.
+ * Completed is ordered by createdAt newest-first (recency for the last-N window).
+ * Working preserves input order. Omitting listKind returns the input unchanged.
+ */
+export const filterWorkItemsByListKind = <
+  T extends { readonly state: WorkItemState; readonly createdAt: Date },
+>(
+  workItems: readonly T[],
+  listKind: WorkItemsListKind | undefined,
+  limit?: number,
+): readonly T[] => {
+  if (listKind === undefined) {
+    return workItems
+  }
+  if (listKind === "working") {
+    const working = workItems.filter((item) =>
+      isJobsWorkingWorkItemState(item.state),
+    )
+    return limit === undefined ? working : working.slice(0, limit)
+  }
+  const completed = workItems
+    .filter((item) => isJobsCompletedWorkItemState(item.state))
+    .slice()
+    .sort((left, right) => right.createdAt.getTime() - left.createdAt.getTime())
+  return limit === undefined ? completed : completed.slice(0, limit)
+}
+
 export const STEP_RUN_REASON = {
   handlerFailed: "handler_failed",
   handlerDefect: "handler_defect",

--- a/packages/work-item-lifecycle/test/jobs-list-filter.spec.ts
+++ b/packages/work-item-lifecycle/test/jobs-list-filter.spec.ts
@@ -1,0 +1,79 @@
+import {
+  type WorkItemState,
+  filterWorkItemsByListKind,
+  isJobsCompletedWorkItemState,
+  isJobsWorkingWorkItemState,
+} from "../src/lib/types.js"
+import { describe, expect, it } from "bun:test"
+
+const item = (state: WorkItemState, createdAtMs: number) => ({
+  state,
+  createdAt: new Date(createdAtMs),
+})
+
+describe("Jobs list membership", () => {
+  it("places Needs Human on Working, not Completed", () => {
+    expect(isJobsWorkingWorkItemState("needs_human")).toBe(true)
+    expect(isJobsCompletedWorkItemState("needs_human")).toBe(false)
+  })
+
+  it("places Complete, Failed, and Abandoned only on Completed", () => {
+    for (const state of ["complete", "failed", "abandoned"] as const) {
+      expect(isJobsCompletedWorkItemState(state)).toBe(true)
+      expect(isJobsWorkingWorkItemState(state)).toBe(false)
+    }
+  })
+
+  it("places unfinished lifecycle states on Working", () => {
+    expect(isJobsWorkingWorkItemState("implement")).toBe(true)
+    expect(isJobsWorkingWorkItemState("create_worktree")).toBe(true)
+  })
+})
+
+describe("filterWorkItemsByListKind", () => {
+  const items = [
+    item("complete", 1000),
+    item("implement", 2000),
+    item("needs_human", 3000),
+    item("failed", 4000),
+    item("abandoned", 5000),
+    item("create_worktree", 6000),
+  ]
+
+  it("returns the input unchanged when listKind is omitted", () => {
+    expect(filterWorkItemsByListKind(items, undefined)).toEqual(items)
+  })
+
+  it("filters Working to unfinished plus Needs Human, preserving order", () => {
+    expect(
+      filterWorkItemsByListKind(items, "working").map((i) => i.state),
+    ).toEqual(["implement", "needs_human", "create_worktree"])
+  })
+
+  it("filters Completed to Complete/Failed/Abandoned newest-first", () => {
+    expect(
+      filterWorkItemsByListKind(items, "completed").map((i) => i.state),
+    ).toEqual(["abandoned", "failed", "complete"])
+  })
+
+  it("limits Completed to the newest N by createdAt", () => {
+    const many = Array.from({ length: 20 }, (_, index) =>
+      item(index % 2 === 0 ? "complete" : "failed", index * 100),
+    )
+    const limited = filterWorkItemsByListKind(many, "completed", 15)
+    expect(limited).toHaveLength(15)
+    expect(limited[0]!.createdAt.getTime()).toBe(1900)
+    expect(limited[14]!.createdAt.getTime()).toBe(500)
+  })
+
+  it("does not put Needs Human under Completed even with limit", () => {
+    const mixed = [
+      item("needs_human", 9000),
+      item("complete", 8000),
+      item("failed", 7000),
+    ]
+    expect(
+      filterWorkItemsByListKind(mixed, "completed", 15).map((i) => i.state),
+    ).toEqual(["complete", "failed"])
+  })
+})


### PR DESCRIPTION
## Summary

- Split the home-page Jobs card into **Working** and **Completed** tabs (default Working), with accessible tab roles/keyboard and per-tab empty states.
- Working shows unfinished Work Items plus Needs Human; Completed shows Complete/Failed/Abandoned only, last 15 by `createdAt` newest-first (global after cross-repo merge).
- Extend GraphQL `workItems` with optional `listKind` / `limit` (backward-compatible when omitted) and domain membership helpers so Jobs queries stay focused without unbounded finished history payloads.
- Live refresh refetches all work-items cache variants per repository so tab data stays current without polling.

## Test plan

- [x] Domain unit tests for Working/Completed membership and last-N Completed ordering
- [x] GraphQL tests for WORKING filter (includes Needs Human) and COMPLETED + limit 15
- [x] Jobs card source-shape tests for tabs, listKind queries, and no-polling guarantee
- [x] harness typecheck / affected lint, typecheck, test via pre-commit

Closes #255