### PR TITLE
fix: ship product and platform READMEs on npm packages

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -136,6 +136,11 @@ bun --conditions @ready-for-agent/source \
   packages/release-versioning/src/bin/apply-publish-versions.ts 0.1.0 --for-publish
 ```
 
+`--for-publish` also stages npm READMEs: the root product [README.md](README.md)
+into `apps/ready-for-agent/` (so the npm page is install/usage, not monorepo
+architecture notes), and a shared platform-binary stub into each
+`packages/ready-for-agent-*` package.
+
 ## Live end-to-end fixture
 
 The private End-to-End Fixture Repository

--- a/apps/ready-for-agent/README.md
+++ b/apps/ready-for-agent/README.md
@@ -1,9 +1,13 @@
-# ready-for-agent
+# ready-for-agent (monorepo)
 
 Unified operator binary for Ready for Agent: start the Harness and run operator
 commands against its GraphQL endpoint.
 
-Public install and operator docs: [README.md](../../README.md).
+**npm package README:** the published `ready-for-agent` package ships the
+repository root [README.md](../../README.md) (install and usage). Release
+staging (`apply-publish-versions --for-publish`) copies that file over this one
+for the npm tarball. Keep monorepo / package-shape notes here for contributors.
+
 Monorepo development: [CONTRIBUTING.md](../../CONTRIBUTING.md).
 
 ## Public package shape

--- a/apps/ready-for-agent/package.json
+++ b/apps/ready-for-agent/package.json
@@ -16,7 +16,8 @@
   },
   "files": [
     "bin/ready-for-agent.js",
-    "bin/select-platform.js"
+    "bin/select-platform.js",
+    "README.md"
   ],
   "scripts": {
     "typecheck": "tsc --noEmit -p tsconfig.app.json"

--- a/packages/ready-for-agent-darwin-arm64/README.md
+++ b/packages/ready-for-agent-darwin-arm64/README.md
@@ -1,0 +1,16 @@
+# ready-for-agent platform binary
+
+This package ships a **platform-specific binary** used as an optional dependency
+of [`ready-for-agent`](https://www.npmjs.com/package/ready-for-agent).
+
+It is **not meant to be installed on its own**. Install and use the main
+package instead:
+
+```bash
+npm install -g ready-for-agent
+# or
+npx ready-for-agent@latest
+```
+
+- npm: https://www.npmjs.com/package/ready-for-agent
+- GitHub: https://github.com/berenddeboer/ready-for-agent

--- a/packages/ready-for-agent-darwin-arm64/package.json
+++ b/packages/ready-for-agent-darwin-arm64/package.json
@@ -17,7 +17,8 @@
     "arm64"
   ],
   "files": [
-    "bin/ready-for-agent"
+    "bin/ready-for-agent",
+    "README.md"
   ],
   "preferUnplugged": true
 }

--- a/packages/ready-for-agent-darwin-x64/README.md
+++ b/packages/ready-for-agent-darwin-x64/README.md
@@ -1,0 +1,16 @@
+# ready-for-agent platform binary
+
+This package ships a **platform-specific binary** used as an optional dependency
+of [`ready-for-agent`](https://www.npmjs.com/package/ready-for-agent).
+
+It is **not meant to be installed on its own**. Install and use the main
+package instead:
+
+```bash
+npm install -g ready-for-agent
+# or
+npx ready-for-agent@latest
+```
+
+- npm: https://www.npmjs.com/package/ready-for-agent
+- GitHub: https://github.com/berenddeboer/ready-for-agent

--- a/packages/ready-for-agent-darwin-x64/package.json
+++ b/packages/ready-for-agent-darwin-x64/package.json
@@ -17,7 +17,8 @@
     "x64"
   ],
   "files": [
-    "bin/ready-for-agent"
+    "bin/ready-for-agent",
+    "README.md"
   ],
   "preferUnplugged": true
 }

--- a/packages/ready-for-agent-linux-arm64/README.md
+++ b/packages/ready-for-agent-linux-arm64/README.md
@@ -1,0 +1,16 @@
+# ready-for-agent platform binary
+
+This package ships a **platform-specific binary** used as an optional dependency
+of [`ready-for-agent`](https://www.npmjs.com/package/ready-for-agent).
+
+It is **not meant to be installed on its own**. Install and use the main
+package instead:
+
+```bash
+npm install -g ready-for-agent
+# or
+npx ready-for-agent@latest
+```
+
+- npm: https://www.npmjs.com/package/ready-for-agent
+- GitHub: https://github.com/berenddeboer/ready-for-agent

--- a/packages/ready-for-agent-linux-arm64/package.json
+++ b/packages/ready-for-agent-linux-arm64/package.json
@@ -17,7 +17,8 @@
     "arm64"
   ],
   "files": [
-    "bin/ready-for-agent"
+    "bin/ready-for-agent",
+    "README.md"
   ],
   "preferUnplugged": true
 }

--- a/packages/ready-for-agent-linux-x64/README.md
+++ b/packages/ready-for-agent-linux-x64/README.md
@@ -1,0 +1,16 @@
+# ready-for-agent platform binary
+
+This package ships a **platform-specific binary** used as an optional dependency
+of [`ready-for-agent`](https://www.npmjs.com/package/ready-for-agent).
+
+It is **not meant to be installed on its own**. Install and use the main
+package instead:
+
+```bash
+npm install -g ready-for-agent
+# or
+npx ready-for-agent@latest
+```
+
+- npm: https://www.npmjs.com/package/ready-for-agent
+- GitHub: https://github.com/berenddeboer/ready-for-agent

--- a/packages/ready-for-agent-linux-x64/package.json
+++ b/packages/ready-for-agent-linux-x64/package.json
@@ -17,7 +17,8 @@
     "x64"
   ],
   "files": [
-    "bin/ready-for-agent"
+    "bin/ready-for-agent",
+    "README.md"
   ],
   "preferUnplugged": true
 }

--- a/packages/release-versioning/src/bin/apply-publish-versions.ts
+++ b/packages/release-versioning/src/bin/apply-publish-versions.ts
@@ -7,6 +7,7 @@ import {
   applyVersionToPlatformPackageJson,
   assertPublishVersion,
   launcherManifestForNpmPublish,
+  preparePublishPackageReadmes,
 } from "../lib/publish-packages.js"
 
 const args = process.argv.slice(2)
@@ -23,6 +24,14 @@ if (versionArg === undefined || versionArg === "") {
 } else {
   try {
     const version = assertPublishVersion(versionArg)
+
+    if (forPublish) {
+      const staged = preparePublishPackageReadmes(cwd)
+      process.stdout.write(`staged npm README → ${staged.launcherReadmePath}\n`)
+      for (const path of staged.platformReadmePaths) {
+        process.stdout.write(`staged npm README → ${path}\n`)
+      }
+    }
 
     for (const entry of PUBLISH_PACKAGE_PATHS) {
       const path = join(cwd, entry.packageJsonRelativePath)

--- a/packages/release-versioning/src/index.ts
+++ b/packages/release-versioning/src/index.ts
@@ -10,8 +10,10 @@ export { InvalidVersionError, NothingToReleaseError } from "./lib/errors.js"
 export { computeNextVersionFromGit } from "./lib/from-git.js"
 export {
   type JsonObject,
+  LAUNCHER_PACKAGE_DIR,
   LAUNCHER_PACKAGE_NAME,
   PLATFORM_PACKAGE_NAMES,
+  PLATFORM_PACKAGE_README,
   PUBLISH_PACKAGE_PATHS,
   type PlatformPackageName,
   type PublishPackagePath,
@@ -19,4 +21,5 @@ export {
   applyVersionToPlatformPackageJson,
   assertPublishVersion,
   launcherManifestForNpmPublish,
+  preparePublishPackageReadmes,
 } from "./lib/publish-packages.js"

--- a/packages/release-versioning/src/lib/publish-packages.ts
+++ b/packages/release-versioning/src/lib/publish-packages.ts
@@ -1,3 +1,5 @@
+import { copyFileSync, mkdirSync, writeFileSync } from "node:fs"
+import { dirname, join } from "node:path"
 import semver from "semver"
 
 export const LAUNCHER_PACKAGE_NAME = "ready-for-agent"
@@ -12,6 +14,25 @@ export const PLATFORM_PACKAGE_NAMES = [
 export type PlatformPackageName = (typeof PLATFORM_PACKAGE_NAMES)[number]
 
 export type JsonObject = Record<string, unknown>
+
+/** Shared npm README for platform binary packages (not installed alone). */
+export const PLATFORM_PACKAGE_README = `# ready-for-agent platform binary
+
+This package ships a **platform-specific binary** used as an optional dependency
+of [\`ready-for-agent\`](https://www.npmjs.com/package/ready-for-agent).
+
+It is **not meant to be installed on its own**. Install and use the main
+package instead:
+
+\`\`\`bash
+npm install -g ready-for-agent
+# or
+npx ready-for-agent@latest
+\`\`\`
+
+- npm: https://www.npmjs.com/package/ready-for-agent
+- GitHub: https://github.com/berenddeboer/ready-for-agent
+`
 
 export function assertPublishVersion(version: string): string {
   const cleaned = semver.clean(version)
@@ -97,3 +118,32 @@ export const PUBLISH_PACKAGE_PATHS: readonly PublishPackagePath[] = [
     }),
   ),
 ]
+
+export const LAUNCHER_PACKAGE_DIR = "apps/ready-for-agent"
+
+/**
+ * Stages npm-facing README files for publish:
+ * - Launcher gets the repository root product README (install/usage), not the
+ *   monorepo architecture notes under apps/ready-for-agent/README.md.
+ * - Each platform package gets the shared platform-binary stub.
+ */
+export function preparePublishPackageReadmes(workspaceRoot: string): {
+  launcherReadmePath: string
+  platformReadmePaths: string[]
+} {
+  const launcherReadmePath = join(
+    workspaceRoot,
+    LAUNCHER_PACKAGE_DIR,
+    "README.md",
+  )
+  copyFileSync(join(workspaceRoot, "README.md"), launcherReadmePath)
+
+  const platformReadmePaths = PLATFORM_PACKAGE_NAMES.map((name) => {
+    const path = join(workspaceRoot, "packages", name, "README.md")
+    mkdirSync(dirname(path), { recursive: true })
+    writeFileSync(path, PLATFORM_PACKAGE_README)
+    return path
+  })
+
+  return { launcherReadmePath, platformReadmePaths }
+}

--- a/packages/release-versioning/test/publish-packages.spec.ts
+++ b/packages/release-versioning/test/publish-packages.spec.ts
@@ -1,10 +1,15 @@
+import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
 import { describe, expect, it } from "vitest"
 import {
   PLATFORM_PACKAGE_NAMES,
+  PLATFORM_PACKAGE_README,
   applyVersionToLauncherPackageJson,
   applyVersionToPlatformPackageJson,
   assertPublishVersion,
   launcherManifestForNpmPublish,
+  preparePublishPackageReadmes,
 } from "../src/lib/publish-packages.js"
 
 describe("assertPublishVersion", () => {
@@ -78,7 +83,11 @@ describe("launcherManifestForNpmPublish", () => {
         license: "MIT",
         type: "module",
         bin: { "ready-for-agent": "./bin/ready-for-agent.js" },
-        files: ["bin/ready-for-agent.js", "bin/select-platform.js"],
+        files: [
+          "bin/ready-for-agent.js",
+          "bin/select-platform.js",
+          "README.md",
+        ],
         scripts: { typecheck: "tsc" },
         dependencies: {
           "@ready-for-agent/graphql-client": "workspace:*",
@@ -100,7 +109,7 @@ describe("launcherManifestForNpmPublish", () => {
       license: "MIT",
       type: "module",
       bin: { "ready-for-agent": "./bin/ready-for-agent.js" },
-      files: ["bin/ready-for-agent.js", "bin/select-platform.js"],
+      files: ["bin/ready-for-agent.js", "bin/select-platform.js", "README.md"],
       optionalDependencies: Object.fromEntries(
         PLATFORM_PACKAGE_NAMES.map((name) => [name, "0.1.0"]),
       ),
@@ -109,5 +118,32 @@ describe("launcherManifestForNpmPublish", () => {
     expect(next).not.toHaveProperty("dependencies")
     expect(next).not.toHaveProperty("devDependencies")
     expect(next).not.toHaveProperty("scripts")
+  })
+})
+
+describe("preparePublishPackageReadmes", () => {
+  it("copies root product README to launcher and writes platform stubs", () => {
+    const root = mkdtempSync(join(tmpdir(), "rfa-publish-readme-"))
+    const productReadme = "# Ready for Agent\n\nInstall with npx.\n"
+    writeFileSync(join(root, "README.md"), productReadme)
+
+    mkdirSync(join(root, "apps", "ready-for-agent"), { recursive: true })
+    writeFileSync(
+      join(root, "apps", "ready-for-agent", "README.md"),
+      "# monorepo architecture only\n",
+    )
+    for (const name of PLATFORM_PACKAGE_NAMES) {
+      mkdirSync(join(root, "packages", name), { recursive: true })
+    }
+
+    const staged = preparePublishPackageReadmes(root)
+
+    expect(readFileSync(staged.launcherReadmePath, "utf8")).toBe(productReadme)
+    expect(staged.platformReadmePaths).toHaveLength(
+      PLATFORM_PACKAGE_NAMES.length,
+    )
+    for (const path of staged.platformReadmePaths) {
+      expect(readFileSync(path, "utf8")).toBe(PLATFORM_PACKAGE_README)
+    }
   })
 })


### PR DESCRIPTION
## Summary
- Publish the root product README for `ready-for-agent` (install/usage) instead of monorepo architecture notes.
- Add shared platform-binary stub READMEs for the four optionalDependency packages.
- Stage READMEs during `apply-publish-versions --for-publish` and include them in package `files`.

Closes #246

## Test plan
- [x] `bunx nx run release-versioning:test`
- [x] Pre-commit / affected lint, typecheck, test
- [x] `npm pack --dry-run` includes product README for launcher and stub for platform packages