### PR TITLE
fix(harness): pass fixture clone command directly to Keymaxxer

### DIFF
--- a/apps/harness/e2e/steps/add-and-refresh-repository.ts
+++ b/apps/harness/e2e/steps/add-and-refresh-repository.ts
@@ -41,15 +41,19 @@ When("I add the Repository with the CLI", async ({ world }) => {
     throw new Error("Fixture checkout path is missing from the scenario world")
   }
 
-  const result = spawnSync("bun", ["run", "harness-cli", "add", checkoutPath], {
-    cwd: workspaceRoot,
-    env: {
-      ...process.env,
-      READY_FOR_AGENT_GRAPHQL_URL: E2E_GRAPHQL_URL,
+  const result = spawnSync(
+    "bun",
+    ["run", "ready-for-agent", "add", checkoutPath],
+    {
+      cwd: workspaceRoot,
+      env: {
+        ...process.env,
+        READY_FOR_AGENT_GRAPHQL_URL: E2E_GRAPHQL_URL,
+      },
+      encoding: "utf8",
+      timeout: 60_000,
     },
-    encoding: "utf8",
-    timeout: 60_000,
-  })
+  )
 
   if (result.status !== 0) {
     throw new Error(

--- a/apps/harness/e2e/support/clone-fixture-repo.ts
+++ b/apps/harness/e2e/support/clone-fixture-repo.ts
@@ -98,6 +98,11 @@ const assertSecretPresentViaCli = (env: NodeJS.ProcessEnv) => {
   }
 }
 
+export const keymaxxerRunArgs = (
+  secretName: string,
+  command: string,
+): string[] => ["run", "--secrets", secretName, "--", command]
+
 const cloneViaCli = (checkoutParent: string, env: NodeJS.ProcessEnv) => {
   assertSecretPresentViaCli(env)
   const dest = join(checkoutParent, "repo")
@@ -112,7 +117,7 @@ const cloneViaCli = (checkoutParent: string, env: NodeJS.ProcessEnv) => {
 
   const result = spawnSync(
     keymaxxerBin(),
-    ["run", "--secrets", FIXTURE_SECRET_NAME, "--", "bash", "-c", cloneCommand],
+    keymaxxerRunArgs(FIXTURE_SECRET_NAME, cloneCommand),
     {
       env,
       encoding: "utf8",

--- a/apps/harness/test/clone-fixture-repo-keymaxxer-args.test.ts
+++ b/apps/harness/test/clone-fixture-repo-keymaxxer-args.test.ts
@@ -1,0 +1,42 @@
+import { spawnSync } from "node:child_process"
+import { keymaxxerRunArgs } from "../e2e/support/clone-fixture-repo.ts"
+import { describe, expect, test } from "bun:test"
+
+const runAsKeymaxxerJoins = (restAfterDashDash: string[]) => {
+  const command = restAfterDashDash.join(" ")
+  return spawnSync(command, {
+    shell: true,
+    encoding: "utf8",
+  })
+}
+
+describe("keymaxxer fixture clone command args", () => {
+  test("passes the shell-quoted command as a single post-`--` argument", () => {
+    const command =
+      'git clone --depth 1 "https://example.invalid/repo.git" "/tmp/dest"'
+    const args = keymaxxerRunArgs("FIXTURE_SECRET", command)
+
+    expect(args).toEqual(["run", "--secrets", "FIXTURE_SECRET", "--", command])
+    expect(args).not.toContain("bash")
+    expect(args).not.toContain("-c")
+  })
+
+  test("nested bash -c loses multi-word script arguments after keymaxxer join", () => {
+    const script = 'printf "%s\\n" retained-arg'
+    const broken = runAsKeymaxxerJoins(["bash", "-c", script])
+
+    expect(broken.status).not.toBe(0)
+    expect(broken.stdout).not.toContain("retained-arg")
+  })
+
+  test("direct multi-word command retains all arguments after keymaxxer join", () => {
+    const command = 'printf "%s\\n" retained-arg'
+    const args = keymaxxerRunArgs("FIXTURE_SECRET", command)
+    const dashDash = args.indexOf("--")
+    const rest = args.slice(dashDash + 1)
+    const fixed = runAsKeymaxxerJoins(rest)
+
+    expect(fixed.status).toBe(0)
+    expect(fixed.stdout.trim()).toBe("retained-arg")
+  })
+})


### PR DESCRIPTION
## Summary
- Pass the shell-quoted fixture clone command directly to `keymaxxer run` (no nested `bash -c`), so Keymaxxer 0.2.1's `rest.join(" ")` no longer drops multi-word argument boundaries.
- Add a regression test covering the broken `bash -c` join path vs the fixed direct command path.
- Use `bun run ready-for-agent add` in the live e2e CLI step so the journey can complete after clone.

## Test plan
- [x] `bun test apps/harness/test/clone-fixture-repo-keymaxxer-args.test.ts`
- [x] Live Keymaxxer clone of `berenddeboer/test-ready-for-agent` via `cloneViaCli`
- [x] `bunx nx run harness:e2e`
- [x] `bunx nx run harness:test`
- [ ] Trusted `main` CI Live Harness e2e after merge

Closes #266