### PR TITLE
feat(keymaxxer): launch Sidecar from production executable internal mode

### DIFF
--- a/apps/harness/server.ts
+++ b/apps/harness/server.ts
@@ -1,3 +1,13 @@
-import { startProductionLifecycle } from "./src/server/production-lifecycle.js"
+import {
+  isInternalKeymaxxerSidecarMode,
+  runKeymaxxerSidecarProcess,
+} from "@ready-for-agent/keymaxxer-service"
 
-await startProductionLifecycle()
+if (isInternalKeymaxxerSidecarMode(process.argv)) {
+  await runKeymaxxerSidecarProcess()
+} else {
+  const { startProductionLifecycle } = await import(
+    "./src/server/production-lifecycle.js"
+  )
+  await startProductionLifecycle()
+}

--- a/apps/harness/src/server/production-lifecycle.ts
+++ b/apps/harness/src/server/production-lifecycle.ts
@@ -6,7 +6,9 @@ import { Effect } from "effect"
 import { DatabaseLive, runConfiguredMigrations } from "@ready-for-agent/db"
 import {
   KEYMAXXER_SIDECAR_URL_PREFIX,
+  type SidecarChildSpawn,
   isKeymaxxerAvailable,
+  resolveKeymaxxerSidecarChildSpawn,
 } from "@ready-for-agent/keymaxxer-service"
 import type { ApplicationRequestContext } from "../server-context.js"
 import { type Application, createApplication } from "./application.server.js"
@@ -58,8 +60,8 @@ export type ProductionLifecycleOptions = {
   readonly port?: number
   readonly clientDirectory?: string
   readonly serverEntryPath?: string
-  readonly sidecarEntryPath?: string
-  readonly workspaceRoot?: string
+  /** Override how the owned Sidecar child is spawned (tests / custom hosts). */
+  readonly sidecarSpawn?: SidecarChildSpawn
   readonly sidecarBootstrapTimeoutMs?: number
   readonly applyMigrations?: (environment: NodeJS.ProcessEnv) => Promise<void>
   readonly resolveKeymaxxerMode?: (
@@ -97,14 +99,6 @@ export type ProductionLifecycleHandle = {
   readonly dispose: () => Promise<void>
 }
 
-const defaultWorkspaceRoot = fileURLToPath(
-  new URL("../../../..", import.meta.url),
-)
-
-const defaultSidecarEntryPath = fileURLToPath(
-  new URL("../../../keymaxxer-sidecar/src/main.ts", import.meta.url),
-)
-
 const defaultClientDirectory = resolve(
   fileURLToPath(new URL("../../dist/client", import.meta.url)),
 )
@@ -115,14 +109,17 @@ const defaultServerEntryPath = fileURLToPath(
 
 export const resolveKeymaxxerMode = (
   environment: NodeJS.ProcessEnv,
+  keymaxxerAvailable: (
+    environment: NodeJS.ProcessEnv,
+  ) => boolean = isKeymaxxerAvailable,
 ): KeymaxxerMode => {
   const existingUrl = environment.KEYMAXXER_SIDECAR_URL?.trim()
-  const keymaxxerAvailable = isKeymaxxerAvailable(environment)
+  const available = keymaxxerAvailable(environment)
   const explicitlyDisabled =
     environment.KEYMAXXER_ENABLED?.trim().toLowerCase() === "false"
   const keymaxxerEnabled =
     !explicitlyDisabled &&
-    ((existingUrl !== undefined && existingUrl !== "") || keymaxxerAvailable)
+    ((existingUrl !== undefined && existingUrl !== "") || available)
 
   if (!keymaxxerEnabled) {
     return { kind: "disabled" }
@@ -150,8 +147,7 @@ const applyProductionMigrations = async (
 
 const startOwnedSidecar = (input: {
   readonly environment: NodeJS.ProcessEnv
-  readonly sidecarEntryPath: string
-  readonly workspaceRoot: string
+  readonly spawn: SidecarChildSpawn
   readonly bootstrapTimeoutMs: number
   readonly logError?: (message: string) => void
 }): Promise<{
@@ -159,15 +155,10 @@ const startOwnedSidecar = (input: {
   readonly child: OwnedChildProcess
 }> =>
   new Promise((resolvePromise, reject) => {
-    const sidecar = spawn(
-      process.execPath,
-      ["--conditions", "@ready-for-agent/source", input.sidecarEntryPath],
-      {
-        cwd: input.workspaceRoot,
-        env: input.environment,
-        stdio: ["ignore", "pipe", "inherit"],
-      },
-    )
+    const sidecar = spawn(input.spawn.command, [...input.spawn.args], {
+      env: input.environment,
+      stdio: ["ignore", "pipe", "inherit"],
+    })
 
     let settled = false
     const fail = (message: string) => {
@@ -320,8 +311,8 @@ export const startProductionLifecycle = async (
   const port = options.port ?? Number(environment.PORT ?? 4200)
   const clientDirectory = options.clientDirectory ?? defaultClientDirectory
   const serverEntryPath = options.serverEntryPath ?? defaultServerEntryPath
-  const sidecarEntryPath = options.sidecarEntryPath ?? defaultSidecarEntryPath
-  const workspaceRoot = options.workspaceRoot ?? defaultWorkspaceRoot
+  const sidecarSpawn =
+    options.sidecarSpawn ?? resolveKeymaxxerSidecarChildSpawn()
   const bootstrapTimeoutMs = options.sidecarBootstrapTimeoutMs ?? 15_000
   const onEvent = options.onEvent ?? (() => {})
   const logInfo = options.logInfo ?? ((message) => console.info(message))
@@ -340,8 +331,7 @@ export const startProductionLifecycle = async (
     ((env) =>
       startOwnedSidecar({
         environment: env,
-        sidecarEntryPath,
-        workspaceRoot,
+        spawn: sidecarSpawn,
         bootstrapTimeoutMs,
         logError,
       }))

--- a/apps/harness/test/production-lifecycle.test.ts
+++ b/apps/harness/test/production-lifecycle.test.ts
@@ -1,4 +1,13 @@
+import { spawn } from "node:child_process"
 import { EventEmitter } from "node:events"
+import { createServer } from "node:net"
+import { createInterface } from "node:readline"
+import { fileURLToPath } from "node:url"
+import {
+  INTERNAL_KEYMAXXER_SIDECAR_ARG,
+  KEYMAXXER_SIDECAR_URL_PREFIX,
+  resolveKeymaxxerSidecarChildSpawn,
+} from "@ready-for-agent/keymaxxer-service"
 import {
   type Application,
   type HttpServerHandle,
@@ -107,6 +116,16 @@ describe("production lifecycle keymaxxer mode", () => {
     ).toEqual({
       kind: "existing-url",
       url: "http://127.0.0.1:5032/cap/mcp",
+    })
+  })
+
+  test("disables when Keymaxxer is absent (no entrypoint and not on PATH)", () => {
+    expect(resolveKeymaxxerMode({}, () => false)).toEqual({ kind: "disabled" })
+  })
+
+  test("spawns a Sidecar when Keymaxxer is available", () => {
+    expect(resolveKeymaxxerMode({}, () => true)).toEqual({
+      kind: "spawn-sidecar",
     })
   })
 })
@@ -376,5 +395,187 @@ describe("production lifecycle process behavior", () => {
     )
     expect(events).toContain("sidecar-ready")
     await handle.dispose()
+  })
+
+  test("default owned Sidecar spawn uses internal mode, not workspace main.ts", () => {
+    const spawnPlan = resolveKeymaxxerSidecarChildSpawn({
+      execPath: process.execPath,
+      argv: [
+        process.execPath,
+        fileURLToPath(new URL("../server.ts", import.meta.url)),
+      ],
+    })
+    expect(spawnPlan.args).toContain(INTERNAL_KEYMAXXER_SIDECAR_ARG)
+    expect(spawnPlan.args.join(" ")).not.toContain(
+      "keymaxxer-sidecar/src/main.ts",
+    )
+  })
+
+  test("captures capability URL from an owned internal-mode Sidecar process", async () => {
+    const freePort = async () => {
+      const server = createServer()
+      await new Promise<void>((resolve, reject) => {
+        server.once("error", reject)
+        server.listen(0, "127.0.0.1", () => resolve())
+      })
+      const address = server.address()
+      if (address === null || typeof address === "string") {
+        server.close()
+        throw new Error("failed to allocate port")
+      }
+      const port = address.port
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()))
+      })
+      return port
+    }
+
+    const port = await freePort()
+    const serverEntry = fileURLToPath(new URL("../server.ts", import.meta.url))
+    const spawnPlan = resolveKeymaxxerSidecarChildSpawn({
+      execPath: process.execPath,
+      argv: [process.execPath, serverEntry],
+    })
+
+    let capturedUrl: string | undefined
+    const logs: string[] = []
+
+    const handle = await startProductionLifecycle({
+      ...baseOptions(),
+      environment: {
+        SQLITE_DATABASE_PATH: "/tmp/unused.db",
+        KEYMAXXER_SIDECAR_PORT: String(port),
+      },
+      resolveKeymaxxerMode: () => ({ kind: "spawn-sidecar" }),
+      sidecarSpawn: spawnPlan,
+      sidecarBootstrapTimeoutMs: 15_000,
+      applyMigrations: async () => {},
+      createApplication: async (environment) => {
+        capturedUrl = environment.KEYMAXXER_SIDECAR_URL
+        return fakeApplication()
+      },
+      logInfo: (message) => {
+        logs.push(message)
+      },
+      logError: (message) => {
+        errors.push(message)
+      },
+      onEvent: (event) => {
+        events.push(event)
+      },
+      argv: ["bun", "server.ts", "--no-open"],
+    })
+
+    expect(capturedUrl).toBeDefined()
+    expect(capturedUrl?.startsWith(`http://127.0.0.1:${port}/`)).toBe(true)
+    expect(capturedUrl?.endsWith("/mcp")).toBe(true)
+    expect(events).toContain("sidecar-ready")
+    expect(events.indexOf("sidecar-ready")).toBeLessThan(
+      events.indexOf("application-ready"),
+    )
+    // Full capability URL must not appear in parent logs
+    expect(logs.some((line) => line.includes(capturedUrl!))).toBe(false)
+    expect(errors.some((line) => line.includes(capturedUrl!))).toBe(false)
+
+    await handle.dispose()
+  })
+
+  test("absence of Keymaxxer selects ambient mode without spawning", async () => {
+    let startSidecarCalls = 0
+    const handle = await startProductionLifecycle({
+      ...baseOptions(),
+      environment: {
+        SQLITE_DATABASE_PATH: "/tmp/unused.db",
+      },
+      resolveKeymaxxerMode: (environment) =>
+        resolveKeymaxxerMode(environment, () => false),
+      startSidecar: async () => {
+        startSidecarCalls += 1
+        throw new Error("should not spawn when keymaxxer is absent")
+      },
+      applyMigrations: async () => {},
+      onEvent: (event) => {
+        events.push(event)
+      },
+    })
+
+    expect(startSidecarCalls).toBe(0)
+    expect(applicationEnvs[0]?.KEYMAXXER_ENABLED).toBe("false")
+    expect(applicationEnvs[0]?.KEYMAXXER_SIDECAR_URL).toBeUndefined()
+    expect(events).not.toContain("sidecar-ready")
+    await handle.dispose()
+  })
+})
+
+describe("internal Sidecar mode process entry", () => {
+  test("server.ts internal mode bootstraps without workspace sidecar main", async () => {
+    const freePort = async () => {
+      const server = createServer()
+      await new Promise<void>((resolve, reject) => {
+        server.once("error", reject)
+        server.listen(0, "127.0.0.1", () => resolve())
+      })
+      const address = server.address()
+      if (address === null || typeof address === "string") {
+        server.close()
+        throw new Error("failed to allocate port")
+      }
+      const port = address.port
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()))
+      })
+      return port
+    }
+
+    const port = await freePort()
+    const serverEntry = fileURLToPath(new URL("../server.ts", import.meta.url))
+    const child = spawn(
+      process.execPath,
+      [
+        "--conditions",
+        "@ready-for-agent/source",
+        serverEntry,
+        INTERNAL_KEYMAXXER_SIDECAR_ARG,
+      ],
+      {
+        env: {
+          ...process.env,
+          KEYMAXXER_SIDECAR_PORT: String(port),
+        },
+        stdio: ["ignore", "pipe", "pipe"],
+      },
+    )
+
+    try {
+      const url = await new Promise<string>((resolve, reject) => {
+        const timeout = setTimeout(() => {
+          reject(new Error("timed out waiting for internal mode bootstrap"))
+        }, 15_000)
+        if (child.stdout === null) {
+          clearTimeout(timeout)
+          reject(new Error("stdout missing"))
+          return
+        }
+        const lines = createInterface({ input: child.stdout })
+        lines.on("line", (line) => {
+          if (!line.startsWith(KEYMAXXER_SIDECAR_URL_PREFIX)) return
+          clearTimeout(timeout)
+          lines.close()
+          resolve(line.slice(KEYMAXXER_SIDECAR_URL_PREFIX.length).trim())
+        })
+        child.on("exit", (code) => {
+          clearTimeout(timeout)
+          reject(new Error(`exited early: ${code}`))
+        })
+      })
+
+      expect(url.startsWith(`http://127.0.0.1:${port}/`)).toBe(true)
+      child.kill("SIGTERM")
+      await new Promise<void>((resolve) => {
+        child.once("exit", () => resolve())
+      })
+    } finally {
+      child.kill("SIGTERM")
+    }
   })
 })

--- a/apps/keymaxxer-sidecar/src/main.ts
+++ b/apps/keymaxxer-sidecar/src/main.ts
@@ -1,61 +1,16 @@
 import {
-  KeymaxxerError,
-  startKeymaxxerFacade,
+  defaultKeymaxxerSidecarPort,
+  keymaxxerSidecarHost,
+  keymaxxerSidecarPortFromEnvironment,
+  runKeymaxxerSidecarProcess,
 } from "@ready-for-agent/keymaxxer-service"
 
-export const defaultKeymaxxerSidecarPort = 5032
-export const keymaxxerSidecarHost = "127.0.0.1"
-
-export const keymaxxerSidecarPortFromEnvironment = (
-  environment: Partial<Record<string, string | undefined>>,
-) => {
-  const value = environment.KEYMAXXER_SIDECAR_PORT?.trim()
-  if (value === undefined || value === "") return defaultKeymaxxerSidecarPort
-
-  const port = Number(value)
-  if (!Number.isInteger(port) || port < 1 || port > 65_535) {
-    throw new Error("KEYMAXXER_SIDECAR_PORT must be a valid TCP port")
-  }
-  return port
-}
-
-const start = async () => {
-  const port = keymaxxerSidecarPortFromEnvironment(process.env)
-  try {
-    const facade = await startKeymaxxerFacade({
-      host: keymaxxerSidecarHost,
-      port,
-      environment: process.env,
-    })
-
-    const stop = async () => {
-      await facade.stop()
-      process.exit(0)
-    }
-    process.once("SIGINT", () => {
-      void stop()
-    })
-    process.once("SIGTERM", () => {
-      void stop()
-    })
-    await new Promise(() => {})
-  } catch (error) {
-    const message =
-      error instanceof Error
-        ? error.message
-        : `Keymaxxer Sidecar failed to listen on ${keymaxxerSidecarHost}:${port}. Set KEYMAXXER_SIDECAR_PORT to an unused port.`
-    console.error(
-      message.startsWith("Keymaxxer Sidecar failed")
-        ? message
-        : `Keymaxxer Sidecar failed to listen on ${keymaxxerSidecarHost}:${port}. Set KEYMAXXER_SIDECAR_PORT to an unused port.`,
-    )
-    if (!(error instanceof KeymaxxerError)) {
-      // keep stderr single-line for topology test
-    }
-    process.exitCode = 1
-  }
+export {
+  defaultKeymaxxerSidecarPort,
+  keymaxxerSidecarHost,
+  keymaxxerSidecarPortFromEnvironment,
 }
 
 if (import.meta.main) {
-  void start()
+  void runKeymaxxerSidecarProcess()
 }

--- a/apps/ready-for-agent/package.json
+++ b/apps/ready-for-agent/package.json
@@ -31,6 +31,7 @@
   "dependencies": {
     "@effect/platform-bun": "^4.0.0-beta.97",
     "@ready-for-agent/graphql-client": "workspace:*",
+    "@ready-for-agent/keymaxxer-service": "workspace:*",
     "effect": "^4.0.0-beta.97"
   },
   "devDependencies": {

--- a/apps/ready-for-agent/src/main.ts
+++ b/apps/ready-for-agent/src/main.ts
@@ -1,20 +1,29 @@
 #!/usr/bin/env bun
-import { BunRuntime, BunServices } from "@effect/platform-bun"
-import { Effect, Layer } from "effect"
-import { Command } from "effect/unstable/cli"
-import { cli } from "./cli.ts"
-import { GraphqlApi } from "./services/graphql-api.ts"
-import { LocalGit } from "./services/local-git.ts"
-import { StartHarness } from "./services/start-harness.ts"
+import {
+  isInternalKeymaxxerSidecarMode,
+  runKeymaxxerSidecarProcess,
+} from "@ready-for-agent/keymaxxer-service"
 
-const MainLive = LocalGit.layer.pipe(
-  Layer.provideMerge(GraphqlApi.layer),
-  Layer.provideMerge(StartHarness.layer),
-  Layer.provideMerge(BunServices.layer),
-)
+if (isInternalKeymaxxerSidecarMode(process.argv)) {
+  await runKeymaxxerSidecarProcess()
+} else {
+  const { BunRuntime, BunServices } = await import("@effect/platform-bun")
+  const { Effect, Layer } = await import("effect")
+  const { Command } = await import("effect/unstable/cli")
+  const { cli } = await import("./cli.ts")
+  const { GraphqlApi } = await import("./services/graphql-api.ts")
+  const { LocalGit } = await import("./services/local-git.ts")
+  const { StartHarness } = await import("./services/start-harness.ts")
 
-const program = Command.run(cli, { version: "0.0.0" }).pipe(
-  Effect.provide(MainLive),
-)
+  const MainLive = LocalGit.layer.pipe(
+    Layer.provideMerge(GraphqlApi.layer),
+    Layer.provideMerge(StartHarness.layer),
+    Layer.provideMerge(BunServices.layer),
+  )
 
-BunRuntime.runMain(program)
+  const program = Command.run(cli, { version: "0.0.0" }).pipe(
+    Effect.provide(MainLive),
+  )
+
+  BunRuntime.runMain(program)
+}

--- a/apps/ready-for-agent/tsconfig.app.json
+++ b/apps/ready-for-agent/tsconfig.app.json
@@ -17,6 +17,9 @@
   "exclude": ["src/**/*.test.ts"],
   "references": [
     {
+      "path": "../../packages/keymaxxer-service/tsconfig.lib.json"
+    },
+    {
       "path": "../../packages/graphql-client/tsconfig.lib.json"
     }
   ]

--- a/bun.lock
+++ b/bun.lock
@@ -82,6 +82,7 @@
       "dependencies": {
         "@effect/platform-bun": "^4.0.0-beta.97",
         "@ready-for-agent/graphql-client": "workspace:*",
+        "@ready-for-agent/keymaxxer-service": "workspace:*",
         "effect": "^4.0.0-beta.97",
       },
       "devDependencies": {

--- a/docs/adr/0004-development-keymaxxer-sidecar.md
+++ b/docs/adr/0004-development-keymaxxer-sidecar.md
@@ -5,7 +5,7 @@ Ready for Agent uses a shared backend Keymaxxer Service that never exposes raw s
 ## Topology
 
 - Development and production use the same sidecar process model (not in-process Keymaxxer in the Harness).
-- Development uses `scripts/run-with-keymaxxer-sidecar.ts` so the sidecar survives Vite reloads. Production uses one lifecycle owner (`apps/harness/src/server/production-lifecycle.ts`) that starts the sidecar as a lifecycle-owned child, captures the stdout bootstrap line `KEYMAXXER_SIDECAR_URL=http://127.0.0.1:<port>/<capability>/mcp`, and keeps that URL in memory only.
+- Development uses `scripts/run-with-keymaxxer-sidecar.ts` so the sidecar survives Vite reloads. Production uses one lifecycle owner (`apps/harness/src/server/production-lifecycle.ts`) that starts the sidecar as a lifecycle-owned child by re-executing the same program in an internal non-product mode (`--ready-for-agent-internal-keymaxxer-sidecar`), captures the stdout bootstrap line `KEYMAXXER_SIDECAR_URL=http://127.0.0.1:<port>/<capability>/mcp` through a private pipe, and keeps that URL in memory only. Compiled binaries need no external Bun runtime and no workspace TypeScript Sidecar entrypoint.
 - There is no unauthenticated `/health` route. Readiness is TCP listen; auth is the unguessable path capability (#113).
 
 ## Security
@@ -23,7 +23,7 @@ The GraphQL credential query and mutation use Keymaxxer metadata only; they neve
 
 ## Keyholder
 
-The MCP launcher resolves Keymaxxer as `KEYMAXXER_ENTRYPOINT` when set to an existing path, otherwise the installed `keymaxxer` command on PATH. There is no hardcoded developer contrib path. The Keymaxxer child inherits the backend environment except repository-scoped `GITHUB_TOKEN_<OWNER>_<REPO>` values.
+The MCP launcher resolves Keymaxxer as `KEYMAXXER_ENTRYPOINT` when set to an existing path, otherwise the installed `keymaxxer` command on PATH. An existing executable entrypoint is executed directly with `serve`; a source entrypoint (for example `.ts`) is run via Bun for development only. There is no hardcoded developer contrib path. The Keymaxxer child inherits the backend environment except repository-scoped `GITHUB_TOKEN_<OWNER>_<REPO>` values.
 
 ## Startup
 

--- a/packages/keymaxxer-service/src/lib/mcp-layer.ts
+++ b/packages/keymaxxer-service/src/lib/mcp-layer.ts
@@ -1,4 +1,4 @@
-import { existsSync } from "node:fs"
+import { accessSync, constants, existsSync } from "node:fs"
 import { Client } from "@modelcontextprotocol/sdk/client/index.js"
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js"
 import { Effect, Layer } from "effect"
@@ -247,15 +247,37 @@ export const keymaxxerEnvironment = (
     ),
   ) as Record<string, string>
 
+const sourceEntrypointPattern = /\.(m?[jt]sx?|cjs|mts|cts)$/i
+
+/** True when ENTRYPOINT should be exec'd directly (not via Bun as source). */
+export const isExecutableKeymaxxerEntrypoint = (
+  path: string,
+  access: (path: string, mode: number) => void = accessSync,
+): boolean => {
+  if (sourceEntrypointPattern.test(path)) return false
+  try {
+    access(path, constants.X_OK)
+    return true
+  } catch {
+    return false
+  }
+}
+
 export const keymaxxerMcpCommand = (
   environment: Partial<Record<string, string | undefined>> = process.env,
   pathExists: (path: string) => boolean = existsSync,
+  isExecutable: (path: string) => boolean = isExecutableKeymaxxerEntrypoint,
 ) => {
   const entrypoint = environment.KEYMAXXER_ENTRYPOINT?.trim()
 
-  return entrypoint && pathExists(entrypoint)
-    ? { command: "bun", args: [entrypoint, "serve"] }
-    : { command: "keymaxxer", args: ["serve"] }
+  if (entrypoint && pathExists(entrypoint)) {
+    if (isExecutable(entrypoint)) {
+      return { command: entrypoint, args: ["serve"] }
+    }
+    return { command: "bun", args: [entrypoint, "serve"] }
+  }
+
+  return { command: "keymaxxer", args: ["serve"] }
 }
 
 export const isKeymaxxerAvailable = (
@@ -263,9 +285,12 @@ export const isKeymaxxerAvailable = (
   pathExists: (path: string) => boolean = existsSync,
   commandExists: (command: string) => boolean = (command) =>
     Bun.which(command) !== null,
+  isExecutable: (path: string) => boolean = isExecutableKeymaxxerEntrypoint,
 ) => {
-  const command = keymaxxerMcpCommand(environment, pathExists)
-  return command.command === "bun" || commandExists(command.command)
+  const entrypoint = environment.KEYMAXXER_ENTRYPOINT?.trim()
+  if (entrypoint && pathExists(entrypoint)) return true
+  const command = keymaxxerMcpCommand(environment, pathExists, isExecutable)
+  return commandExists(command.command)
 }
 
 const toolResultText = (result: ToolResult) =>

--- a/packages/keymaxxer-service/src/lib/sidecar-process.ts
+++ b/packages/keymaxxer-service/src/lib/sidecar-process.ts
@@ -1,0 +1,151 @@
+import { startKeymaxxerFacade } from "./facade.js"
+import { KeymaxxerError } from "./models.js"
+
+/** Hidden argv token: re-enter the same executable as the Keymaxxer Sidecar. */
+export const INTERNAL_KEYMAXXER_SIDECAR_ARG =
+  "--ready-for-agent-internal-keymaxxer-sidecar"
+
+export const defaultKeymaxxerSidecarPort = 5032
+export const keymaxxerSidecarHost = "127.0.0.1"
+
+export const isInternalKeymaxxerSidecarMode = (
+  argv: ReadonlyArray<string> = process.argv,
+): boolean => argv.includes(INTERNAL_KEYMAXXER_SIDECAR_ARG)
+
+export const keymaxxerSidecarPortFromEnvironment = (
+  environment: Partial<Record<string, string | undefined>>,
+) => {
+  const value = environment.KEYMAXXER_SIDECAR_PORT?.trim()
+  if (value === undefined || value === "") return defaultKeymaxxerSidecarPort
+
+  const port = Number(value)
+  if (!Number.isInteger(port) || port < 1 || port > 65_535) {
+    throw new Error("KEYMAXXER_SIDECAR_PORT must be a valid TCP port")
+  }
+  return port
+}
+
+/**
+ * True when this process is a compiled standalone product binary rather than
+ * `bun path/to/script.ts` (or similar source execution).
+ */
+export const isStandaloneExecutable = (
+  execPath: string = process.execPath,
+  argv: ReadonlyArray<string> = process.argv,
+): boolean => {
+  const base = execPath.split(/[/\\]/).pop() ?? ""
+  if (
+    base === "bun" ||
+    base === "bun.exe" ||
+    base === "node" ||
+    base === "node.exe"
+  ) {
+    return false
+  }
+  const maybeScript = argv[1]
+  if (
+    maybeScript !== undefined &&
+    /\.(m?[jt]sx?|cjs|mts|cts)$/i.test(maybeScript)
+  ) {
+    return false
+  }
+  return true
+}
+
+export type SidecarChildSpawn = {
+  readonly command: string
+  readonly args: ReadonlyArray<string>
+}
+
+/**
+ * How the production parent should re-exec this program as the Sidecar child.
+ * Compiled binaries: `execPath --ready-for-agent-internal-keymaxxer-sidecar`.
+ * Source: same Bun runtime + current entry script + the internal mode flag.
+ */
+export const resolveKeymaxxerSidecarChildSpawn = (
+  input: {
+    readonly execPath?: string
+    readonly argv?: ReadonlyArray<string>
+    readonly sourceConditions?: ReadonlyArray<string>
+  } = {},
+): SidecarChildSpawn => {
+  const execPath = input.execPath ?? process.execPath
+  const argv = input.argv ?? process.argv
+
+  if (isStandaloneExecutable(execPath, argv)) {
+    return {
+      command: execPath,
+      args: [INTERNAL_KEYMAXXER_SIDECAR_ARG],
+    }
+  }
+
+  const script = argv[1]
+  if (script === undefined || script === "") {
+    throw new Error(
+      "Cannot resolve Keymaxxer Sidecar spawn: no script entry for source runtime",
+    )
+  }
+
+  const conditions = input.sourceConditions ?? [
+    "--conditions",
+    "@ready-for-agent/source",
+  ]
+
+  return {
+    command: execPath,
+    args: [...conditions, script, INTERNAL_KEYMAXXER_SIDECAR_ARG],
+  }
+}
+
+export type RunKeymaxxerSidecarProcessOptions = {
+  readonly environment?: Partial<Record<string, string | undefined>>
+  readonly exitProcess?: (code: number) => void
+  readonly waitForever?: () => Promise<void>
+}
+
+/**
+ * Sidecar process body: listen, bootstrap URL on stdout, stop on signals.
+ * Shared by the standalone sidecar app and the production binary's internal mode.
+ */
+export const runKeymaxxerSidecarProcess = async (
+  options: RunKeymaxxerSidecarProcessOptions = {},
+): Promise<void> => {
+  const environment = options.environment ?? process.env
+  const exitProcess = options.exitProcess ?? ((code) => process.exit(code))
+  const waitForever = options.waitForever ?? (() => new Promise<void>(() => {}))
+  const port = keymaxxerSidecarPortFromEnvironment(environment)
+
+  try {
+    const facade = await startKeymaxxerFacade({
+      host: keymaxxerSidecarHost,
+      port,
+      environment,
+    })
+
+    const stop = async () => {
+      await facade.stop()
+      exitProcess(0)
+    }
+    process.once("SIGINT", () => {
+      void stop()
+    })
+    process.once("SIGTERM", () => {
+      void stop()
+    })
+    await waitForever()
+  } catch (error) {
+    const message =
+      error instanceof Error
+        ? error.message
+        : `Keymaxxer Sidecar failed to listen on ${keymaxxerSidecarHost}:${port}. Set KEYMAXXER_SIDECAR_PORT to an unused port.`
+    console.error(
+      message.startsWith("Keymaxxer Sidecar failed")
+        ? message
+        : `Keymaxxer Sidecar failed to listen on ${keymaxxerSidecarHost}:${port}. Set KEYMAXXER_SIDECAR_PORT to an unused port.`,
+    )
+    if (!(error instanceof KeymaxxerError)) {
+      // keep stderr single-line for topology test
+    }
+    exitProcess(1)
+  }
+}

--- a/packages/keymaxxer-service/src/lib/sidecar.ts
+++ b/packages/keymaxxer-service/src/lib/sidecar.ts
@@ -6,3 +6,15 @@ export {
   TOOL_NAMES,
   startKeymaxxerFacade,
 } from "./facade.js"
+export {
+  INTERNAL_KEYMAXXER_SIDECAR_ARG,
+  type RunKeymaxxerSidecarProcessOptions,
+  type SidecarChildSpawn,
+  defaultKeymaxxerSidecarPort,
+  isInternalKeymaxxerSidecarMode,
+  isStandaloneExecutable,
+  keymaxxerSidecarHost,
+  keymaxxerSidecarPortFromEnvironment,
+  resolveKeymaxxerSidecarChildSpawn,
+  runKeymaxxerSidecarProcess,
+} from "./sidecar-process.js"

--- a/packages/keymaxxer-service/test/mcp-layer.test.ts
+++ b/packages/keymaxxer-service/test/mcp-layer.test.ts
@@ -458,11 +458,12 @@ describe("MCP process configuration", () => {
     ).toEqual({ HOME: "/home/test" })
   })
 
-  test("uses an existing explicit Keymaxxer entrypoint", () => {
+  test("uses Bun for an existing source Keymaxxer entrypoint", () => {
     expect(
       keymaxxerMcpCommand(
         { KEYMAXXER_ENTRYPOINT: "/custom/keymaxxer/index.ts" },
         (path) => path === "/custom/keymaxxer/index.ts",
+        () => false,
       ),
     ).toEqual({
       command: "bun",
@@ -470,8 +471,27 @@ describe("MCP process configuration", () => {
     })
   })
 
+  test("executes a valid executable KEYMAXXER_ENTRYPOINT directly", () => {
+    expect(
+      keymaxxerMcpCommand(
+        { KEYMAXXER_ENTRYPOINT: "/usr/local/bin/keymaxxer" },
+        (path) => path === "/usr/local/bin/keymaxxer",
+        (path) => path === "/usr/local/bin/keymaxxer",
+      ),
+    ).toEqual({
+      command: "/usr/local/bin/keymaxxer",
+      args: ["serve"],
+    })
+  })
+
   test("uses keymaxxer on PATH when entrypoint is unset", () => {
-    expect(keymaxxerMcpCommand({}, () => true)).toEqual({
+    expect(
+      keymaxxerMcpCommand(
+        {},
+        () => true,
+        () => false,
+      ),
+    ).toEqual({
       command: "keymaxxer",
       args: ["serve"],
     })
@@ -480,7 +500,13 @@ describe("MCP process configuration", () => {
   test("never selects a hardcoded contrib filesystem path", () => {
     const contrib =
       "/home/berend/src/contrib/keymaxxer/packages/cli/src/index.ts"
-    expect(keymaxxerMcpCommand({}, (path) => path === contrib)).toEqual({
+    expect(
+      keymaxxerMcpCommand(
+        {},
+        (path) => path === contrib,
+        () => false,
+      ),
+    ).toEqual({
       command: "keymaxxer",
       args: ["serve"],
     })
@@ -490,6 +516,7 @@ describe("MCP process configuration", () => {
     expect(
       keymaxxerMcpCommand(
         { KEYMAXXER_ENTRYPOINT: "/missing/keymaxxer" },
+        () => false,
         () => false,
       ),
     ).toEqual({

--- a/packages/keymaxxer-service/test/sidecar-process.test.ts
+++ b/packages/keymaxxer-service/test/sidecar-process.test.ts
@@ -1,0 +1,223 @@
+import { spawn } from "node:child_process"
+import { createServer } from "node:net"
+import { createInterface } from "node:readline"
+import { fileURLToPath } from "node:url"
+import {
+  INTERNAL_KEYMAXXER_SIDECAR_ARG,
+  KEYMAXXER_SIDECAR_URL_PREFIX,
+  isInternalKeymaxxerSidecarMode,
+  isStandaloneExecutable,
+  resolveKeymaxxerSidecarChildSpawn,
+  runKeymaxxerSidecarProcess,
+} from "../src/index.js"
+import { afterEach, describe, expect, test } from "bun:test"
+
+const freePort = async () => {
+  const server = createServer()
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject)
+    server.listen(0, "127.0.0.1", () => resolve())
+  })
+  const address = server.address()
+  if (address === null || typeof address === "string") {
+    server.close()
+    throw new Error("failed to allocate port")
+  }
+  const port = address.port
+  await new Promise<void>((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()))
+  })
+  return port
+}
+
+describe("internal Keymaxxer Sidecar mode", () => {
+  test("detects the hidden internal argv token", () => {
+    expect(isInternalKeymaxxerSidecarMode(["bun", "main.ts"])).toBe(false)
+    expect(
+      isInternalKeymaxxerSidecarMode([
+        "ready-for-agent",
+        INTERNAL_KEYMAXXER_SIDECAR_ARG,
+      ]),
+    ).toBe(true)
+  })
+
+  test("classifies compiled binaries vs source runtimes", () => {
+    expect(
+      isStandaloneExecutable("/usr/bin/bun", [
+        "/usr/bin/bun",
+        "/app/server.ts",
+      ]),
+    ).toBe(false)
+    expect(
+      isStandaloneExecutable("/opt/ready-for-agent", [
+        "/opt/ready-for-agent",
+        "start",
+      ]),
+    ).toBe(true)
+    expect(
+      isStandaloneExecutable("/opt/ready-for-agent", ["/opt/ready-for-agent"]),
+    ).toBe(true)
+  })
+
+  test("spawns the same binary with the internal mode flag when standalone", () => {
+    expect(
+      resolveKeymaxxerSidecarChildSpawn({
+        execPath: "/opt/ready-for-agent",
+        argv: ["/opt/ready-for-agent", "start"],
+      }),
+    ).toEqual({
+      command: "/opt/ready-for-agent",
+      args: [INTERNAL_KEYMAXXER_SIDECAR_ARG],
+    })
+  })
+
+  test("re-invokes the current source entry with workspace conditions", () => {
+    expect(
+      resolveKeymaxxerSidecarChildSpawn({
+        execPath: "/usr/bin/bun",
+        argv: ["/usr/bin/bun", "/repo/apps/harness/server.ts"],
+      }),
+    ).toEqual({
+      command: "/usr/bin/bun",
+      args: [
+        "--conditions",
+        "@ready-for-agent/source",
+        "/repo/apps/harness/server.ts",
+        INTERNAL_KEYMAXXER_SIDECAR_ARG,
+      ],
+    })
+  })
+})
+
+describe("Keymaxxer Sidecar process bootstrap", () => {
+  const children: Array<ReturnType<typeof spawn>> = []
+
+  afterEach(() => {
+    for (const child of children) {
+      child.kill("SIGTERM")
+    }
+    children.length = 0
+  })
+
+  test("prints a private bootstrap URL and never logs the capability path", async () => {
+    const port = await freePort()
+    const serverEntry = fileURLToPath(
+      new URL("../../../apps/harness/server.ts", import.meta.url),
+    )
+    const child = spawn(
+      process.execPath,
+      [
+        "--conditions",
+        "@ready-for-agent/source",
+        serverEntry,
+        INTERNAL_KEYMAXXER_SIDECAR_ARG,
+      ],
+      {
+        env: {
+          ...process.env,
+          KEYMAXXER_SIDECAR_PORT: String(port),
+        },
+        stdio: ["ignore", "pipe", "pipe"],
+      },
+    )
+    children.push(child)
+
+    const bootstrapUrl = await new Promise<string>((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        reject(new Error("timed out waiting for bootstrap URL"))
+      }, 15_000)
+
+      let stderr = ""
+      child.stderr?.on("data", (chunk: Buffer) => {
+        stderr += chunk.toString()
+      })
+
+      if (child.stdout === null) {
+        clearTimeout(timeout)
+        reject(new Error("stdout not captured"))
+        return
+      }
+
+      const lines = createInterface({ input: child.stdout })
+      lines.on("line", (line) => {
+        if (!line.startsWith(KEYMAXXER_SIDECAR_URL_PREFIX)) return
+        clearTimeout(timeout)
+        lines.close()
+        const url = line.slice(KEYMAXXER_SIDECAR_URL_PREFIX.length).trim()
+        resolve(url)
+        // capability must not appear on stderr logs
+        expect(stderr.includes(url)).toBe(false)
+        const capability = new URL(url).pathname.split("/")[1]
+        if (capability) {
+          expect(stderr.includes(capability)).toBe(false)
+        }
+      })
+
+      child.on("exit", (code) => {
+        clearTimeout(timeout)
+        reject(
+          new Error(
+            `sidecar exited before bootstrap (code ${code ?? "?"}): ${stderr}`,
+          ),
+        )
+      })
+    })
+
+    expect(bootstrapUrl.startsWith(`http://127.0.0.1:${port}/`)).toBe(true)
+    expect(bootstrapUrl.endsWith("/mcp")).toBe(true)
+
+    const originRejected = await fetch(bootstrapUrl, {
+      method: "POST",
+      headers: {
+        origin: "http://evil.example",
+        "content-type": "application/json",
+        accept: "application/json, text/event-stream",
+      },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "initialize",
+        params: {
+          protocolVersion: "2024-11-05",
+          capabilities: {},
+          clientInfo: { name: "test", version: "0.0.0" },
+        },
+      }),
+    })
+    expect(originRejected.status).toBe(403)
+
+    child.kill("SIGTERM")
+    await new Promise<void>((resolve) => {
+      child.once("exit", () => resolve())
+    })
+  })
+
+  test("runKeymaxxerSidecarProcess exits non-zero when the port is occupied", async () => {
+    const occupying = createServer()
+    await new Promise<void>((resolve, reject) => {
+      occupying.once("error", reject)
+      occupying.listen(0, "127.0.0.1", () => resolve())
+    })
+    const address = occupying.address()
+    if (address === null || typeof address === "string") {
+      occupying.close()
+      throw new Error("failed to bind occupying server")
+    }
+
+    const exits: number[] = []
+    await runKeymaxxerSidecarProcess({
+      environment: {
+        KEYMAXXER_SIDECAR_PORT: String(address.port),
+      },
+      exitProcess: (code) => {
+        exits.push(code)
+      },
+      waitForever: async () => {},
+    })
+
+    expect(exits).toEqual([1])
+    await new Promise<void>((resolve, reject) => {
+      occupying.close((error) => (error ? reject(error) : resolve()))
+    })
+  })
+})


### PR DESCRIPTION
## Why

Production Harness startup still spawned the Keymaxxer Sidecar from workspace TypeScript under external Bun. The installed binary must start the same separate-process Sidecar from code bundled into that executable, keep the capability URL private, and treat executable `KEYMAXXER_ENTRYPOINT` overrides as real binaries.

Closes #262.

## What Changed

- Added internal non-product mode `--ready-for-agent-internal-keymaxxer-sidecar` so the same program can re-enter as the Sidecar process
- Production lifecycle re-execs that mode (compiled binary or current source entry) and captures the bootstrap capability URL over a private stdout pipe
- Executable `KEYMAXXER_ENTRYPOINT` paths run directly with `serve`; source-style entrypoints still use Bun for development
- Shared Sidecar process runner is used by the standalone sidecar app, harness production entry, and the product binary entry
- Process-level tests cover bootstrap handoff, mode selection, executable entrypoint resolution, and related lifecycle behavior
- ADR-0004 updated for the internal-mode production launch contract