### PR TITLE
feat(harness): add today/yesterday committed PR dashboard

### DIFF
--- a/apps/harness/src/local-day-bounds.ts
+++ b/apps/harness/src/local-day-bounds.ts
@@ -1,0 +1,15 @@
+/** Local calendar-day bounds as ISO instants for the PR dashboard query. */
+export const localCommittedPullRequestDayBounds = (now = new Date()) => {
+  const startOfToday = new Date(now)
+  startOfToday.setHours(0, 0, 0, 0)
+  const startOfTomorrow = new Date(startOfToday)
+  startOfTomorrow.setDate(startOfTomorrow.getDate() + 1)
+  const startOfYesterday = new Date(startOfToday)
+  startOfYesterday.setDate(startOfYesterday.getDate() - 1)
+  return {
+    todayFrom: startOfToday.toISOString(),
+    todayTo: startOfTomorrow.toISOString(),
+    yesterdayFrom: startOfYesterday.toISOString(),
+    yesterdayTo: startOfToday.toISOString(),
+  }
+}

--- a/apps/harness/src/routes/index.tsx
+++ b/apps/harness/src/routes/index.tsx
@@ -16,6 +16,7 @@ import {
   liveDurationMs,
   useNowMs,
 } from "../live-duration.js"
+import { localCommittedPullRequestDayBounds } from "../local-day-bounds.js"
 import { followRepositoryIssuesLive } from "../refresh-issues-live.js"
 import { followRepositoryWorkItemsLive } from "../refresh-work-items-live.js"
 import { streamRepositoryChanges } from "../repository-live.js"
@@ -282,6 +283,18 @@ const jobsCompletedWorkItemsQuery = (repositoryId: string) =>
     limit: JOBS_COMPLETED_LIMIT,
   })
 
+const committedPullRequestsCountQuery = (from: string, to: string) => ({
+  queryKey: ["committed-pull-requests-count", from, to] as const,
+  queryFn: async (): Promise<number> => {
+    const result = await graphql.query({
+      committedPullRequestsCount: {
+        __args: { from, to },
+      },
+    })
+    return result.committedPullRequestsCount
+  },
+})
+
 const patchWorkItemsCaches = (
   queryClient: ReturnType<typeof useQueryClient>,
   repositoryId: string,
@@ -311,6 +324,9 @@ function HomePage() {
           Clanker Harness
         </h1>
       </header>
+      <section aria-label="Committed pull requests" className="mb-8">
+        <CommittedPullRequestsDashboard />
+      </section>
       <section aria-label="Jobs">
         <h2 className="mb-4 text-lg font-bold tracking-[-0.02em] text-slate-900">
           Jobs
@@ -325,6 +341,70 @@ function HomePage() {
         </Suspense>
       </div>
     </main>
+  )
+}
+
+function CommittedPullRequestsDashboard() {
+  const bounds = localCommittedPullRequestDayBounds()
+  const todayQuery = useQuery(
+    committedPullRequestsCountQuery(bounds.todayFrom, bounds.todayTo),
+  )
+  const yesterdayQuery = useQuery(
+    committedPullRequestsCountQuery(bounds.yesterdayFrom, bounds.yesterdayTo),
+  )
+  const loading = todayQuery.isLoading || yesterdayQuery.isLoading
+  const failed = todayQuery.isError || yesterdayQuery.isError
+
+  if (loading) {
+    return (
+      <article
+        className="rounded-[0.9rem] border border-[#dbe3ef] bg-white p-[1.35rem] shadow-[0_10px_30px_rgb(15_23_42_/_5%)]"
+        role="status"
+        aria-label="Loading committed pull requests"
+        aria-busy="true"
+      >
+        <div className="grid grid-cols-2 gap-4">
+          <span className="block h-12 animate-pulse rounded-lg bg-slate-100 motion-reduce:animate-none" />
+          <span className="block h-12 animate-pulse rounded-lg bg-slate-100 motion-reduce:animate-none" />
+        </div>
+      </article>
+    )
+  }
+
+  if (failed) {
+    return (
+      <article className="rounded-[0.9rem] border border-red-200 bg-red-50 p-[1.35rem] shadow-[0_10px_30px_rgb(15_23_42_/_5%)]">
+        <p className="m-0 text-sm text-red-700" role="alert">
+          Could not load committed pull requests. Please try again.
+        </p>
+      </article>
+    )
+  }
+
+  const today = todayQuery.data ?? 0
+  const yesterday = yesterdayQuery.data ?? 0
+
+  return (
+    <article className="rounded-[0.9rem] border border-[#dbe3ef] bg-white p-[1.35rem] shadow-[0_10px_30px_rgb(15_23_42_/_5%)]">
+      <div className="grid grid-cols-2 gap-4">
+        <div>
+          <p className="m-0 text-xs font-bold tracking-wide text-slate-500 uppercase">
+            Today
+          </p>
+          <p className="mt-1 mb-0 text-2xl font-bold tracking-[-0.03em] text-slate-900 tabular-nums">
+            {today}
+          </p>
+        </div>
+        <div>
+          <p className="m-0 text-xs font-bold tracking-wide text-slate-500 uppercase">
+            Yesterday
+          </p>
+          <p className="mt-1 mb-0 text-2xl font-bold tracking-[-0.03em] text-slate-900 tabular-nums">
+            {yesterday}
+          </p>
+        </div>
+      </div>
+    </article>
   )
 }
 

--- a/apps/harness/test/committed-pr-dashboard.test.ts
+++ b/apps/harness/test/committed-pr-dashboard.test.ts
@@ -1,0 +1,91 @@
+import { readFileSync } from "node:fs"
+import { join } from "node:path"
+import { localCommittedPullRequestDayBounds } from "../src/local-day-bounds.ts"
+import { describe, expect, test } from "bun:test"
+
+const homeSource = () =>
+  readFileSync(join(import.meta.dir, "../src/routes/index.tsx"), "utf8")
+
+describe("localCommittedPullRequestDayBounds", () => {
+  test("uses local calendar day start/end as ISO instants", () => {
+    const now = new Date(2026, 6, 18, 15, 30, 0, 0)
+    const bounds = localCommittedPullRequestDayBounds(now)
+    const todayStart = new Date(2026, 6, 18, 0, 0, 0, 0)
+    const tomorrowStart = new Date(2026, 6, 19, 0, 0, 0, 0)
+    const yesterdayStart = new Date(2026, 6, 17, 0, 0, 0, 0)
+    expect(bounds.todayFrom).toBe(todayStart.toISOString())
+    expect(bounds.todayTo).toBe(tomorrowStart.toISOString())
+    expect(bounds.yesterdayFrom).toBe(yesterdayStart.toISOString())
+    expect(bounds.yesterdayTo).toBe(todayStart.toISOString())
+  })
+
+  test("handles month and year transitions", () => {
+    const newYear = new Date(2026, 0, 1, 9, 0, 0, 0)
+    const bounds = localCommittedPullRequestDayBounds(newYear)
+    expect(bounds.yesterdayFrom).toBe(
+      new Date(2025, 11, 31, 0, 0, 0, 0).toISOString(),
+    )
+    expect(bounds.yesterdayTo).toBe(
+      new Date(2026, 0, 1, 0, 0, 0, 0).toISOString(),
+    )
+    expect(bounds.todayTo).toBe(new Date(2026, 0, 2, 0, 0, 0, 0).toISOString())
+  })
+})
+
+describe("Committed pull requests dashboard UI", () => {
+  test("renders above the Jobs card with Today and Yesterday labels", () => {
+    const source = homeSource()
+    const dashboardIndex = source.indexOf(
+      'aria-label="Committed pull requests"',
+    )
+    const jobsIndex = source.indexOf('aria-label="Jobs"')
+    expect(dashboardIndex).toBeGreaterThan(-1)
+    expect(jobsIndex).toBeGreaterThan(dashboardIndex)
+    expect(source).toContain("Today")
+    expect(source).toContain("Yesterday")
+    expect(source).toContain("function CommittedPullRequestsDashboard()")
+  })
+
+  test("loads counts via dedicated aggregate query with local day bounds", () => {
+    const source = homeSource()
+    expect(source).toContain("committedPullRequestsCount")
+    expect(source).toContain("localCommittedPullRequestDayBounds")
+    expect(source).toContain('queryKey: ["committed-pull-requests-count"')
+    const dashboard = source.slice(
+      source.indexOf("function CommittedPullRequestsDashboard()"),
+      source.indexOf("function RepositoryCards()"),
+    )
+    expect(dashboard).not.toContain("workItems")
+    expect(dashboard).not.toContain("JOBS_COMPLETED_LIMIT")
+  })
+
+  test("shows loading and error states without blocking Jobs", () => {
+    const source = homeSource()
+    expect(source).toContain('aria-label="Loading committed pull requests"')
+    expect(source).toContain('role="status"')
+    expect(source).toContain('aria-busy="true"')
+    expect(source).toContain(
+      "Could not load committed pull requests. Please try again.",
+    )
+    expect(source).toContain('role="alert"')
+    const homePage = source.slice(
+      source.indexOf("function HomePage()"),
+      source.indexOf("function CommittedPullRequestsDashboard()"),
+    )
+    expect(homePage).toContain("<CommittedPullRequestsDashboard />")
+    expect(homePage).toContain("<JobsCard />")
+    expect(homePage).not.toContain("Suspense fallback={<Committed")
+  })
+
+  test("displays zero counts rather than hiding the dashboard", () => {
+    const source = homeSource()
+    const dashboard = source.slice(
+      source.indexOf("function CommittedPullRequestsDashboard()"),
+      source.indexOf("function RepositoryCards()"),
+    )
+    expect(dashboard).toContain("todayQuery.data ?? 0")
+    expect(dashboard).toContain("yesterdayQuery.data ?? 0")
+    expect(dashboard).toContain("{today}")
+    expect(dashboard).toContain("{yesterday}")
+  })
+})

--- a/apps/harness/test/job-worker.test.ts
+++ b/apps/harness/test/job-worker.test.ts
@@ -229,6 +229,7 @@ const queueLayer = (
       getWorkItem: unused,
       listWorkItemsForIssue: unused,
       listWorkItemsForRepository: () => Effect.succeed([]),
+      countCommittedPullRequests: () => Effect.succeed(0),
       continueAfterHumanPrOutcome: unused,
       admitWaitingWorkItems: Effect.succeed(0),
     }),
@@ -1415,6 +1416,7 @@ describe("Job worker", () => {
       getWorkItem: unused,
       listWorkItemsForIssue: unused,
       listWorkItemsForRepository: () => Effect.succeed([]),
+      countCommittedPullRequests: () => Effect.succeed(0),
       continueAfterHumanPrOutcome: unused,
       admitWaitingWorkItems: Effect.succeed(0),
     })
@@ -1510,6 +1512,7 @@ describe("Job worker", () => {
       getWorkItem: unused,
       listWorkItemsForIssue: unused,
       listWorkItemsForRepository: () => Effect.succeed([]),
+      countCommittedPullRequests: () => Effect.succeed(0),
       continueAfterHumanPrOutcome: unused,
       admitWaitingWorkItems: Effect.succeed(0),
     })
@@ -1639,6 +1642,7 @@ describe("Job worker", () => {
       getWorkItem: unused,
       listWorkItemsForIssue: unused,
       listWorkItemsForRepository: () => Effect.succeed([]),
+      countCommittedPullRequests: () => Effect.succeed(0),
       continueAfterHumanPrOutcome: unused,
       admitWaitingWorkItems: Effect.succeed(0),
     })
@@ -1824,6 +1828,7 @@ describe("Job worker", () => {
       getWorkItem: unused,
       listWorkItemsForIssue: unused,
       listWorkItemsForRepository: () => Effect.succeed([]),
+      countCommittedPullRequests: () => Effect.succeed(0),
       continueAfterHumanPrOutcome: unused,
       admitWaitingWorkItems: Effect.succeed(0),
     })
@@ -1930,6 +1935,7 @@ describe("Job worker", () => {
       getWorkItem: unused,
       listWorkItemsForIssue: unused,
       listWorkItemsForRepository: () => Effect.succeed([]),
+      countCommittedPullRequests: () => Effect.succeed(0),
       continueAfterHumanPrOutcome: unused,
       admitWaitingWorkItems: Effect.succeed(0),
     })

--- a/packages/graphql-api/src/lib/graphql-api.ts
+++ b/packages/graphql-api/src/lib/graphql-api.ts
@@ -115,6 +115,21 @@ type WorkItemsArgs = IssuesArgs & {
   limit?: number
 }
 
+type CommittedPullRequestsCountArgs = {
+  from: string
+  to: string
+}
+
+const parseIsoInstantMs = (value: string, field: string): number => {
+  const ms = Date.parse(value)
+  if (Number.isNaN(ms)) {
+    throw new GraphQLError(`Invalid ISO instant for ${field}: ${value}`, {
+      extensions: { code: "BAD_USER_INPUT" },
+    })
+  }
+  return ms
+}
+
 const toWorkItemsListKind = (
   listKind: WorkItemsArgs["listKind"],
 ): WorkItemsListKind | undefined => {
@@ -686,6 +701,36 @@ export const createGraphqlApi = (
                       relevantIssueNumbers.has(workItem.githubIssueNumber),
                   )
                   return filterWorkItemsByListKind(visible, listKind, limit)
+                }),
+              ),
+            )
+            if (Result.isFailure(result)) {
+              throw toGraphQLError(result.failure)
+            }
+            return result.success
+          },
+          committedPullRequestsCount: async (
+            _parent: unknown,
+            args: CommittedPullRequestsCountArgs,
+          ) => {
+            const fromMs = parseIsoInstantMs(args.from, "from")
+            const toMs = parseIsoInstantMs(args.to, "to")
+            if (toMs < fromMs) {
+              throw new GraphQLError(
+                "`to` must be greater than or equal to `from`",
+                {
+                  extensions: { code: "BAD_USER_INPUT" },
+                },
+              )
+            }
+            const result = await runtime.runPromise(
+              Effect.result(
+                Effect.gen(function* () {
+                  const lifecycle = yield* WorkItemLifecycle
+                  return yield* lifecycle.countCommittedPullRequests(
+                    fromMs,
+                    toMs,
+                  )
                 }),
               ),
             )

--- a/packages/graphql-api/test/graphql-api.test.ts
+++ b/packages/graphql-api/test/graphql-api.test.ts
@@ -201,6 +201,7 @@ const makeRuntime = (
     getWorkItem: unused,
     listWorkItemsForIssue: unused,
     listWorkItemsForRepository: unused,
+    countCommittedPullRequests: unused,
     continueAfterHumanPrOutcome: unused,
     admitWaitingWorkItems: Effect.succeed(0),
     ...lifecycleOverrides,
@@ -2514,5 +2515,65 @@ describe("GraphQL API", () => {
     )
 
     expect(response.status).toBe(403)
+  })
+
+  test("committedPullRequestsCount aggregates via lifecycle with ISO bounds", async () => {
+    const calls: Array<{ fromMs: number; toMs: number }> = []
+    await runtime.dispose()
+    runtime = makeRuntime(
+      {},
+      {},
+      {},
+      {},
+      {
+        countCommittedPullRequests: (fromMs, toMs) => {
+          calls.push({ fromMs, toMs })
+          return Effect.succeed(3)
+        },
+      },
+    )
+
+    const response = await createGraphqlApi(runtime).fetch(
+      graphqlRequest({
+        query: `query Count($from: String!, $to: String!) {
+          committedPullRequestsCount(from: $from, to: $to)
+        }`,
+        variables: {
+          from: "2026-07-18T00:00:00.000Z",
+          to: "2026-07-19T00:00:00.000Z",
+        },
+      }),
+    )
+
+    expect(response.status).toBe(200)
+    expect(await response.json()).toEqual({
+      data: { committedPullRequestsCount: 3 },
+    })
+    expect(calls).toEqual([
+      {
+        fromMs: Date.parse("2026-07-18T00:00:00.000Z"),
+        toMs: Date.parse("2026-07-19T00:00:00.000Z"),
+      },
+    ])
+  })
+
+  test("committedPullRequestsCount rejects invalid ISO instants", async () => {
+    const response = await createGraphqlApi(runtime).fetch(
+      graphqlRequest({
+        query: `query Count($from: String!, $to: String!) {
+          committedPullRequestsCount(from: $from, to: $to)
+        }`,
+        variables: {
+          from: "not-a-date",
+          to: "2026-07-19T00:00:00.000Z",
+        },
+      }),
+    )
+
+    expect(response.status).toBe(200)
+    const body = (await response.json()) as {
+      errors?: ReadonlyArray<{ message: string }>
+    }
+    expect(body.errors?.[0]?.message).toContain("Invalid ISO instant for from")
   })
 })

--- a/packages/graphql-schema/schema.graphql
+++ b/packages/graphql-schema/schema.graphql
@@ -18,6 +18,14 @@ type Query {
     listKind: WorkItemsListKind
     limit: Int
   ): [WorkItem!]!
+  """
+  Count of unique Work Items that committed a pull request in [from, to).
+  A Work Item counts when it has a non-null GitHub PR number and at least one
+  successful commit Step Run whose finished_at falls in the half-open range.
+  `from` and `to` are ISO-8601 instants (browser local calendar-day boundaries).
+  Counts across all repositories; not limited by Jobs card filters or limits.
+  """
+  committedPullRequestsCount(from: String!, to: String!): Int!
 }
 
 """

--- a/packages/work-item-lifecycle/src/lib/work-item-lifecycle.ts
+++ b/packages/work-item-lifecycle/src/lib/work-item-lifecycle.ts
@@ -484,6 +484,14 @@ export interface WorkItemLifecycleShape {
   readonly listWorkItemsForRepository: (
     repositoryId: string,
   ) => Effect.Effect<readonly WorkItemRecord[], ListWorkItemsError>
+  /**
+   * Count unique Work Items with a non-null GitHub PR number and a successful
+   * commit Step Run whose finished_at is in the half-open range [fromMs, toMs).
+   */
+  readonly countCommittedPullRequests: (
+    fromMs: number,
+    toMs: number,
+  ) => Effect.Effect<number, ListWorkItemsError>
   readonly continueAfterHumanPrOutcome: (
     workItemId: string,
     outcome: HumanPrOutcome,
@@ -689,6 +697,28 @@ export const makeWorkItemLifecycleLive = (
         return rows.map((row) =>
           toWorkItemRecord(row, stepRunsByWorkItem.get(row.id) ?? [], nowMs),
         )
+      })
+
+      const countCommittedPullRequests = Effect.fn(
+        "WorkItemLifecycle.countCommittedPullRequests",
+      )(function* (fromMs: number, toMs: number) {
+        const rows = (yield* sql
+          .unsafe(
+            `SELECT COUNT(DISTINCT wi.id) AS count
+             FROM work_item wi
+             INNER JOIN step_run sr ON sr.work_item_id = wi.id
+             WHERE wi.github_pull_request_number IS NOT NULL
+               AND sr.step = 'commit'
+               AND sr.status = 'succeeded'
+               AND sr.finished_at IS NOT NULL
+               AND sr.finished_at >= ?
+               AND sr.finished_at < ?`,
+            [fromMs, toMs],
+          )
+          .pipe(Effect.mapError(toDatabaseError))) as readonly {
+          readonly count: number
+        }[]
+        return Number(rows[0]?.count ?? 0)
       })
 
       const loadStepRunRow = (
@@ -3192,6 +3222,7 @@ export const makeWorkItemLifecycleLive = (
         getWorkItem,
         listWorkItemsForIssue,
         listWorkItemsForRepository,
+        countCommittedPullRequests,
         continueAfterHumanPrOutcome,
         admitWaitingWorkItems,
       })

--- a/packages/work-item-lifecycle/test/count-committed-pull-requests.spec.ts
+++ b/packages/work-item-lifecycle/test/count-committed-pull-requests.spec.ts
@@ -1,0 +1,301 @@
+import { Effect, Layer } from "effect"
+import { SqlClient } from "effect/unstable/sql"
+import { DatabaseTest } from "@ready-for-agent/db/test"
+import { DbServiceLive } from "@ready-for-agent/db-service"
+import { SqliteQueueServiceLive } from "@ready-for-agent/sqlite-queue-service"
+import {
+  LifecycleSteps,
+  type LifecycleStepsShape,
+  WorkItemLifecycle,
+  WorkItemLifecycleLive,
+} from "../src/index.js"
+import { describe, expect, it } from "bun:test"
+
+const successfulSteps: LifecycleStepsShape = {
+  createWorktree: () => Effect.succeed("/tmp/worktrees/acme-widgets-42"),
+  installDependencies: () => Effect.void,
+  implement: () => Effect.succeed("ses_test"),
+  preCommit: () => Effect.void,
+  review: () => Effect.void,
+  commit: () => Effect.void,
+  createPr: () => Effect.succeed(101),
+  watchPrStatusChecks: () => Effect.succeed("succeeded"),
+  resolvePrMergeConflict: () => Effect.succeed({ _tag: "processed" }),
+  investigatePrStatusChecks: () =>
+    Effect.succeed({ _tag: "processed", handledCheckIds: [] }),
+  markPrReadyForReview: () => Effect.void,
+  decidePrMerge: () => Effect.succeed({ _tag: "clanker_merge" }),
+  mergePr: () => Effect.void,
+  localCleanup: () => Effect.void,
+  removeWorktree: () => Effect.void,
+}
+
+const TestLayer = WorkItemLifecycleLive.pipe(
+  Layer.provideMerge(
+    Layer.succeed(LifecycleSteps, LifecycleSteps.of(successfulSteps)),
+  ),
+  Layer.provideMerge(DbServiceLive),
+  Layer.provideMerge(SqliteQueueServiceLive),
+  Layer.provideMerge(DatabaseTest),
+)
+
+const runTest = <A, E>(
+  effect: Effect.Effect<A, E, Layer.Layer.Success<typeof TestLayer>>,
+) => Effect.runPromise(Effect.provide(effect, TestLayer))
+
+const seedRepository = (repositoryId: string, now: number) =>
+  Effect.gen(function* () {
+    const sql = yield* SqlClient.SqlClient
+    yield* sql.unsafe(
+      `INSERT INTO repository (
+         id, github_owner, github_repo, local_path, is_bare, paused,
+         issues_reconciled_at, created_at, updated_at
+       ) VALUES (?, 'acme', ?, ?, 1, 0, NULL, ?, ?)`,
+      [repositoryId, repositoryId, `/tmp/${repositoryId}`, now, now],
+    )
+  })
+
+const seedWorkItemWithCommit = (input: {
+  readonly workItemId: string
+  readonly repositoryId: string
+  readonly githubIssueNumber: number
+  readonly githubPullRequestNumber: number | null
+  readonly commitStatus: string
+  readonly finishedAt: number | null
+  readonly extraCommitFinishedAt?: number
+  readonly now: number
+}) =>
+  Effect.gen(function* () {
+    const sql = yield* SqlClient.SqlClient
+    yield* sql.unsafe(
+      `INSERT INTO work_item (
+         id, repository_id, github_issue_number, github_pull_request_number,
+         model, variant, review_model, review_variant, state, state_ready_at,
+         worktree_path, session_id, failure_code, failure_message,
+         created_at, updated_at
+       ) VALUES (?, ?, ?, ?, 'm', 'v', 'm', 'v', 'complete', ?,
+         NULL, NULL, NULL, NULL, ?, ?)`,
+      [
+        input.workItemId,
+        input.repositoryId,
+        input.githubIssueNumber,
+        input.githubPullRequestNumber,
+        input.now,
+        input.now,
+        input.now,
+      ],
+    )
+    yield* sql.unsafe(
+      `INSERT INTO step_run (
+         id, work_item_id, step, status, queue_job_id, queued_at,
+         started_at, finished_at, reason_code, reason_message,
+         created_at, updated_at
+       ) VALUES (?, ?, 'commit', ?, NULL, ?, ?, ?, NULL, NULL, ?, ?)`,
+      [
+        `${input.workItemId}-commit`,
+        input.workItemId,
+        input.commitStatus,
+        input.now,
+        input.finishedAt ?? input.now,
+        input.finishedAt,
+        input.now,
+        input.now,
+      ],
+    )
+    if (input.extraCommitFinishedAt !== undefined) {
+      yield* sql.unsafe(
+        `INSERT INTO step_run (
+           id, work_item_id, step, status, queue_job_id, queued_at,
+           started_at, finished_at, reason_code, reason_message,
+           created_at, updated_at
+         ) VALUES (?, ?, 'commit', 'succeeded', NULL, ?, ?, ?, NULL, NULL, ?, ?)`,
+        [
+          `${input.workItemId}-commit-retry`,
+          input.workItemId,
+          input.now,
+          input.extraCommitFinishedAt,
+          input.extraCommitFinishedAt,
+          input.now,
+          input.now,
+        ],
+      )
+    }
+  })
+
+describe("countCommittedPullRequests", () => {
+  const dayStart = Date.parse("2026-07-18T00:00:00.000Z")
+  const dayEnd = Date.parse("2026-07-19T00:00:00.000Z")
+  const yesterdayStart = Date.parse("2026-07-17T00:00:00.000Z")
+  const midDay = Date.parse("2026-07-18T12:00:00.000Z")
+  const justBeforeEnd = Date.parse("2026-07-18T23:59:59.999Z")
+  const justAtEnd = dayEnd
+  const now = midDay
+
+  it("counts successful commit Step Runs with a PR number in [from, to)", () =>
+    runTest(
+      Effect.gen(function* () {
+        const lifecycle = yield* WorkItemLifecycle
+        yield* seedRepository("repo-a", now)
+        yield* seedRepository("repo-b", now)
+        yield* seedWorkItemWithCommit({
+          workItemId: "wi-today-a",
+          repositoryId: "repo-a",
+          githubIssueNumber: 1,
+          githubPullRequestNumber: 10,
+          commitStatus: "succeeded",
+          finishedAt: midDay,
+          now,
+        })
+        yield* seedWorkItemWithCommit({
+          workItemId: "wi-today-b",
+          repositoryId: "repo-b",
+          githubIssueNumber: 2,
+          githubPullRequestNumber: 20,
+          commitStatus: "succeeded",
+          finishedAt: justBeforeEnd,
+          now,
+        })
+
+        expect(
+          yield* lifecycle.countCommittedPullRequests(dayStart, dayEnd),
+        ).toBe(2)
+      }),
+    ))
+
+  it("returns 0 when nothing matches", () =>
+    runTest(
+      Effect.gen(function* () {
+        const lifecycle = yield* WorkItemLifecycle
+        expect(
+          yield* lifecycle.countCommittedPullRequests(dayStart, dayEnd),
+        ).toBe(0)
+      }),
+    ))
+
+  it("excludes failed and unfinished commit steps", () =>
+    runTest(
+      Effect.gen(function* () {
+        const lifecycle = yield* WorkItemLifecycle
+        yield* seedRepository("repo-a", now)
+        yield* seedWorkItemWithCommit({
+          workItemId: "wi-failed",
+          repositoryId: "repo-a",
+          githubIssueNumber: 1,
+          githubPullRequestNumber: 10,
+          commitStatus: "failed",
+          finishedAt: midDay,
+          now,
+        })
+        yield* seedWorkItemWithCommit({
+          workItemId: "wi-running",
+          repositoryId: "repo-a",
+          githubIssueNumber: 2,
+          githubPullRequestNumber: 11,
+          commitStatus: "running",
+          finishedAt: null,
+          now,
+        })
+        yield* seedWorkItemWithCommit({
+          workItemId: "wi-queued",
+          repositoryId: "repo-a",
+          githubIssueNumber: 3,
+          githubPullRequestNumber: 12,
+          commitStatus: "queued",
+          finishedAt: null,
+          now,
+        })
+
+        expect(
+          yield* lifecycle.countCommittedPullRequests(dayStart, dayEnd),
+        ).toBe(0)
+      }),
+    ))
+
+  it("excludes Work Items without a PR number", () =>
+    runTest(
+      Effect.gen(function* () {
+        const lifecycle = yield* WorkItemLifecycle
+        yield* seedRepository("repo-a", now)
+        yield* seedWorkItemWithCommit({
+          workItemId: "wi-no-pr",
+          repositoryId: "repo-a",
+          githubIssueNumber: 1,
+          githubPullRequestNumber: null,
+          commitStatus: "succeeded",
+          finishedAt: midDay,
+          now,
+        })
+
+        expect(
+          yield* lifecycle.countCommittedPullRequests(dayStart, dayEnd),
+        ).toBe(0)
+      }),
+    ))
+
+  it("counts each Work Item at most once per day even with retry commits", () =>
+    runTest(
+      Effect.gen(function* () {
+        const lifecycle = yield* WorkItemLifecycle
+        yield* seedRepository("repo-a", now)
+        yield* seedWorkItemWithCommit({
+          workItemId: "wi-retry",
+          repositoryId: "repo-a",
+          githubIssueNumber: 1,
+          githubPullRequestNumber: 10,
+          commitStatus: "succeeded",
+          finishedAt: Date.parse("2026-07-18T08:00:00.000Z"),
+          extraCommitFinishedAt: Date.parse("2026-07-18T16:00:00.000Z"),
+          now,
+        })
+
+        expect(
+          yield* lifecycle.countCommittedPullRequests(dayStart, dayEnd),
+        ).toBe(1)
+      }),
+    ))
+
+  it("uses half-open [from, to) boundaries", () =>
+    runTest(
+      Effect.gen(function* () {
+        const lifecycle = yield* WorkItemLifecycle
+        yield* seedRepository("repo-a", now)
+        yield* seedWorkItemWithCommit({
+          workItemId: "wi-start",
+          repositoryId: "repo-a",
+          githubIssueNumber: 1,
+          githubPullRequestNumber: 10,
+          commitStatus: "succeeded",
+          finishedAt: dayStart,
+          now,
+        })
+        yield* seedWorkItemWithCommit({
+          workItemId: "wi-end",
+          repositoryId: "repo-a",
+          githubIssueNumber: 2,
+          githubPullRequestNumber: 11,
+          commitStatus: "succeeded",
+          finishedAt: justAtEnd,
+          now,
+        })
+        yield* seedWorkItemWithCommit({
+          workItemId: "wi-yesterday",
+          repositoryId: "repo-a",
+          githubIssueNumber: 3,
+          githubPullRequestNumber: 12,
+          commitStatus: "succeeded",
+          finishedAt: yesterdayStart,
+          now,
+        })
+
+        expect(
+          yield* lifecycle.countCommittedPullRequests(dayStart, dayEnd),
+        ).toBe(1)
+        expect(
+          yield* lifecycle.countCommittedPullRequests(yesterdayStart, dayStart),
+        ).toBe(1)
+        expect(
+          yield* lifecycle.countCommittedPullRequests(dayEnd, dayEnd + 1),
+        ).toBe(1)
+      }),
+    ))
+})


### PR DESCRIPTION
## Summary
- Add a compact Today/Yesterday committed PR dashboard above the Jobs card on the Harness home page
- Expose `committedPullRequestsCount(from, to)` GraphQL aggregate over successful commit Step Runs with a recorded PR number
- Count unique Work Items per browser-supplied local calendar-day bounds (ISO instants)

## Test plan
- [x] Lifecycle aggregation tests (boundaries, exclusions, dedupe, zeros)
- [x] GraphQL resolver tests (ISO bounds wiring, invalid input)
- [x] Harness UI source tests (placement, labels, loading/error independence)
- [x] Pre-commit / affected lint, typecheck, test

Closes #272