### PR TITLE
fix(harness): boot dev under Bun and resolve GitHub bin paths

### DIFF
--- a/apps/harness/package.json
+++ b/apps/harness/package.json
@@ -4,9 +4,9 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "vite",
-    "build": "vite build",
-    "preview": "vite preview",
+    "dev": "bun --conditions @ready-for-agent/source ./node_modules/vite/bin/vite.js",
+    "build": "bun --conditions @ready-for-agent/source ./node_modules/vite/bin/vite.js build",
+    "preview": "bun --conditions @ready-for-agent/source ./node_modules/vite/bin/vite.js preview",
     "start": "bun --conditions @ready-for-agent/source server.ts",
     "typecheck": "tsc --noEmit -p tsconfig.app.json"
   },

--- a/apps/harness/project.json
+++ b/apps/harness/project.json
@@ -15,13 +15,13 @@
       "continuous": true,
       "executor": "nx:run-commands",
       "options": {
-        "command": "ROOT=\"$(cd ../.. && pwd)\" && mkdir -p \"$ROOT/tmp\" && export SQLITE_DATABASE_PATH=\"${SQLITE_DATABASE_PATH:-$ROOT/tmp/ready-for-agent.db}\" && bun --conditions @ready-for-agent/source ../../scripts/run-with-keymaxxer-sidecar.ts bash -c 'bun --conditions @ready-for-agent/source src/server/preflight.ts && vite'",
+        "command": "ROOT=\"$(cd ../.. && pwd)\" && mkdir -p \"$ROOT/tmp\" && export SQLITE_DATABASE_PATH=\"${SQLITE_DATABASE_PATH:-$ROOT/tmp/ready-for-agent.db}\" && bun --conditions @ready-for-agent/source ../../scripts/run-with-keymaxxer-sidecar.ts bash -c 'bun --conditions @ready-for-agent/source src/server/preflight.ts && bun --conditions @ready-for-agent/source ./node_modules/vite/bin/vite.js'",
         "cwd": "apps/harness"
       },
       "dependsOn": [
         "db:migrate",
         {
-          "projects": ["graphql-client", "github-service"],
+          "projects": ["graphql-client", "github-service", "graphql-schema"],
           "target": "generate"
         }
       ]
@@ -29,7 +29,7 @@
     "serve": {
       "dependsOn": [
         {
-          "projects": ["graphql-client", "github-service"],
+          "projects": ["graphql-client", "github-service", "graphql-schema"],
           "target": "generate"
         }
       ]

--- a/apps/harness/src/server/keymaxxer-github-layer.ts
+++ b/apps/harness/src/server/keymaxxer-github-layer.ts
@@ -5,6 +5,7 @@ import {
   GitHubService,
   type GitHubServiceShape,
   type ReadyLabeledIssue,
+  githubServiceBinScriptPath,
   sanitizeUserFacingText,
 } from "@ready-for-agent/github-service"
 import { KeymaxxerService } from "@ready-for-agent/keymaxxer-service"
@@ -227,6 +228,21 @@ export const keymaxxerGitHubLayer = (options: {
           secrets: [tokenName],
           timeoutMs: 60_000,
         })
+      const runGitHubBin = (
+        tokenName: string,
+        scriptFileName: string,
+        args: readonly string[],
+      ) =>
+        runGitHubCommand(
+          tokenName,
+          [
+            "bun",
+            "--conditions",
+            "@ready-for-agent/source",
+            JSON.stringify(githubServiceBinScriptPath(scriptFileName)),
+            ...args,
+          ].join(" "),
+        )
 
       const service: GitHubServiceShape = {
         getOpenPullRequestNumber: (repository, headRefName) =>
@@ -241,9 +257,10 @@ export const keymaxxerGitHubLayer = (options: {
             const owner = encodeArgument(repository.owner)
             const name = encodeArgument(repository.name)
             const head = encodeArgument(headRefName)
-            const result = yield* runGitHubCommand(
+            const result = yield* runGitHubBin(
               tokenName,
-              `bun --conditions @ready-for-agent/source packages/github-service/src/bin/get-open-pr-number.ts ${owner} ${name} ${head}`,
+              "get-open-pr-number.ts",
+              [owner, name, head],
             )
             if (result.exitCode === 2) {
               return yield* new GitHubRepositoryUnavailableError(repository)
@@ -283,9 +300,10 @@ export const keymaxxerGitHubLayer = (options: {
             const owner = encodeArgument(repository.owner)
             const name = encodeArgument(repository.name)
             const head = encodeArgument(headRefName)
-            const result = yield* runGitHubCommand(
+            const result = yield* runGitHubBin(
               tokenName,
-              `bun --conditions @ready-for-agent/source packages/github-service/src/bin/get-pr-check-status.ts ${owner} ${name} ${head}`,
+              "get-pr-check-status.ts",
+              [owner, name, head],
             )
             if (result.exitCode === 2) {
               return yield* new GitHubRepositoryUnavailableError(repository)
@@ -343,9 +361,12 @@ export const keymaxxerGitHubLayer = (options: {
               options.logDirectory.trim() !== ""
                 ? encodeArgument(options.logDirectory)
                 : ""
-            const result = yield* runGitHubCommand(
+            const result = yield* runGitHubBin(
               tokenName,
-              `bun --conditions @ready-for-agent/source packages/github-service/src/bin/get-pr-status-check-diagnostics.ts ${owner} ${name} ${checksArg}${logDirectory === "" ? "" : ` ${logDirectory}`}`,
+              "get-pr-status-check-diagnostics.ts",
+              logDirectory === ""
+                ? [owner, name, checksArg]
+                : [owner, name, checksArg, logDirectory],
             )
             if (result.exitCode === 2) {
               return yield* new GitHubRepositoryUnavailableError(repository)
@@ -387,9 +408,10 @@ export const keymaxxerGitHubLayer = (options: {
             const owner = encodeArgument(repository.owner)
             const name = encodeArgument(repository.name)
             const head = encodeArgument(headRefName)
-            const result = yield* runGitHubCommand(
+            const result = yield* runGitHubBin(
               tokenName,
-              `bun --conditions @ready-for-agent/source packages/github-service/src/bin/get-pr-lifecycle-status.ts ${owner} ${name} ${head}`,
+              "get-pr-lifecycle-status.ts",
+              [owner, name, head],
             )
             if (result.exitCode === 2) {
               return yield* new GitHubRepositoryUnavailableError(repository)
@@ -431,9 +453,10 @@ export const keymaxxerGitHubLayer = (options: {
             const owner = encodeArgument(repository.owner)
             const name = encodeArgument(repository.name)
             const head = encodeArgument(headRefName)
-            const result = yield* runGitHubCommand(
+            const result = yield* runGitHubBin(
               tokenName,
-              `bun --conditions @ready-for-agent/source packages/github-service/src/bin/mark-pr-ready-for-review.ts ${owner} ${name} ${head}`,
+              "mark-pr-ready-for-review.ts",
+              [owner, name, head],
             )
             if (result.exitCode === 2) {
               return yield* new GitHubRepositoryUnavailableError(repository)
@@ -461,9 +484,10 @@ export const keymaxxerGitHubLayer = (options: {
             const owner = encodeArgument(repository.owner)
             const name = encodeArgument(repository.name)
             const head = encodeArgument(headRefName)
-            const result = yield* runGitHubCommand(
+            const result = yield* runGitHubBin(
               tokenName,
-              `bun --conditions @ready-for-agent/source packages/github-service/src/bin/merge-pull-request.ts ${owner} ${name} ${head}`,
+              "merge-pull-request.ts",
+              [owner, name, head],
             )
             if (result.exitCode === 2) {
               return yield* new GitHubRepositoryUnavailableError(repository)
@@ -492,9 +516,10 @@ export const keymaxxerGitHubLayer = (options: {
 
             const owner = encodeArgument(repository.owner)
             const name = encodeArgument(repository.name)
-            const result = yield* runGitHubCommand(
+            const result = yield* runGitHubBin(
               tokenName,
-              `bun --conditions @ready-for-agent/source packages/github-service/src/bin/list-ready-issues.ts ${owner} ${name}`,
+              "list-ready-issues.ts",
+              [owner, name],
             )
 
             if (result.exitCode === 2) {

--- a/apps/harness/test/keymaxxer-github-layer.test.ts
+++ b/apps/harness/test/keymaxxer-github-layer.test.ts
@@ -171,6 +171,13 @@ describe("Keymaxxer-backed GitHub layer", () => {
       'GITHUB_TOKEN="$GITHUB_TOKEN_ACME_WIDGETS" ',
     )
     expect(runs[0]?.command).toContain("list-ready-issues.ts")
+    expect(runs[0]?.command).toMatch(
+      /bun --conditions @ready-for-agent\/source "\/.*list-ready-issues\.ts"/,
+    )
+    expect(runs[0]?.command).not.toContain(
+      "packages/github-service/src/bin/list-ready-issues.ts",
+    )
+    expect(runs[0]?.cwd).toBe("/workspace")
     expect(runs[0]?.command).not.toContain("Ready issue")
   })
 

--- a/apps/harness/test/topology.test.ts
+++ b/apps/harness/test/topology.test.ts
@@ -30,7 +30,12 @@ describe("single application server topology", () => {
     expect(harness.targets.dev?.options?.command).toContain(
       "run-with-keymaxxer-sidecar",
     )
-    expect(harness.targets.dev?.options?.command).toContain("vite")
+    expect(harness.targets.dev?.options?.command).toContain(
+      "node_modules/vite/bin/vite.js",
+    )
+    expect(harness.targets.dev?.options?.command).toContain(
+      "bun --conditions @ready-for-agent/source ./node_modules/vite/bin/vite.js",
+    )
     expect(harness.targets.dev?.options?.command).toContain(
       "export SQLITE_DATABASE_PATH",
     )

--- a/packages/github-service/src/bin-script-path.ts
+++ b/packages/github-service/src/bin-script-path.ts
@@ -1,0 +1,8 @@
+import { fileURLToPath } from "node:url"
+
+/**
+ * Absolute path to a github-service CLI script under `src/bin`.
+ * Callers may run these with any cwd (e.g. $HOME for host tools).
+ */
+export const githubServiceBinScriptPath = (scriptFileName: string): string =>
+  fileURLToPath(new URL(`./bin/${scriptFileName}`, import.meta.url))

--- a/packages/github-service/src/index.ts
+++ b/packages/github-service/src/index.ts
@@ -1,3 +1,4 @@
+export { githubServiceBinScriptPath } from "./bin-script-path.js"
 export * from "./lib/errors.js"
 export * from "./lib/github-service.js"
 export {

--- a/packages/graphql-schema/project.json
+++ b/packages/graphql-schema/project.json
@@ -19,10 +19,31 @@
       "cache": true
     },
     "build": {
-      "dependsOn": ["generate", "^build"]
+      "dependsOn": ["generate", "^build"],
+      "options": {
+        "command": "tsc --build tsconfig.lib.json --force"
+      },
+      "inputs": [
+        "default",
+        "^production",
+        "{projectRoot}/schema.graphql",
+        {
+          "dependentTasksOutputFiles": "**/*",
+          "transitive": false
+        }
+      ]
     },
     "typecheck": {
-      "dependsOn": ["generate", "^build"]
+      "dependsOn": ["generate", "^build"],
+      "inputs": [
+        "default",
+        "^production",
+        "{projectRoot}/schema.graphql",
+        {
+          "dependentTasksOutputFiles": "**/*",
+          "transitive": false
+        }
+      ]
     }
   }
 }


### PR DESCRIPTION
## Summary

- Run Vite under Bun for `harness:dev` so SSR can load Bun modules (fixes `ERR_UNSUPPORTED_ESM_URL_SCHEME` / `bun:`).
- Depend on `graphql-schema:generate` for `harness:dev` / `serve`.
- Force `graphql-schema` rebuild so generated type-defs are written to dist.
- Invoke Keymaxxer GitHub CLI scripts via absolute paths so they work with host-tool `cwd` (`$HOME`).

## Follow-up

CI smoke for `harness:dev` + GraphQL `{ health }` is tracked in #276 (labeled ready-for-agent).

## Test plan

- [x] `bun test` for harness topology + keymaxxer-github-layer
- [x] Pre-commit affected lint/typecheck/test
- [x] Local: `harness:dev` serves `/` and GraphQL health; issue poll no longer reports missing `list-ready-issues.ts`