### PR TITLE
ci: add harness:dev GraphQL health smoke

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -64,6 +64,11 @@ jobs:
             bun nx affected -t lint knip test typecheck
           fi
 
+      # Dev-path GraphQL smoke (Bun + Vite SSR); no Keymaxxer vault required.
+      # Production live e2e below remains vault-backed and separate.
+      - name: Harness dev smoke
+        run: bunx nx run harness:smoke
+
       # Live Gherkin e2e: trusted main only (this workflow). Never on PR (pr.yml).
       - name: Require live e2e vault key
         env:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -45,3 +45,7 @@ jobs:
 
       - name: Quality gates
         run: bun nx affected -t lint knip test typecheck
+
+      # Dev-path GraphQL smoke (Bun + Vite SSR); no Keymaxxer vault required.
+      - name: Harness dev smoke
+        run: bunx nx run harness:smoke

--- a/apps/harness/project.json
+++ b/apps/harness/project.json
@@ -66,6 +66,20 @@
           "target": "generate"
         }
       ]
+    },
+    "smoke": {
+      "executor": "nx:run-commands",
+      "options": {
+        "cwd": "{projectRoot}",
+        "command": "bun --conditions @ready-for-agent/source scripts/dev-smoke.ts"
+      },
+      "dependsOn": [
+        "db:migrate",
+        {
+          "projects": ["graphql-client", "github-service", "graphql-schema"],
+          "target": "generate"
+        }
+      ]
     }
   }
 }

--- a/apps/harness/scripts/dev-smoke.ts
+++ b/apps/harness/scripts/dev-smoke.ts
@@ -1,0 +1,182 @@
+/**
+ * Boots the monorepo harness:dev path (Bun + vite.js, not the Node shebang),
+ * asserts GraphQL `{ health }`, then terminates. Used as `harness:smoke` in CI
+ * without a Keymaxxer vault.
+ */
+import { type ChildProcess, spawn } from "node:child_process"
+import { mkdtempSync, rmSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { dirname, join, resolve } from "node:path"
+import { fileURLToPath } from "node:url"
+
+const harnessRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..")
+const workspaceRoot = resolve(harnessRoot, "../..")
+const sidecarWrapper = resolve(
+  workspaceRoot,
+  "scripts/run-with-keymaxxer-sidecar.ts",
+)
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
+
+const waitForGraphqlHealth = async (
+  baseUrl: string,
+  timeoutMs: number,
+  isAlive: () => boolean,
+): Promise<void> => {
+  const deadline = Date.now() + timeoutMs
+  let lastError: unknown
+  while (Date.now() < deadline) {
+    if (!isAlive()) {
+      throw new Error(
+        `Dev server exited before GraphQL health succeeded: ${
+          lastError instanceof Error ? lastError.message : String(lastError)
+        }`,
+      )
+    }
+    try {
+      const response = await fetch(`${baseUrl}/graphql`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ query: "{ health }" }),
+      })
+      if (response.status === 200) {
+        const payload = (await response.json()) as {
+          data?: { health?: boolean }
+        }
+        if (payload.data?.health === true) {
+          return
+        }
+        lastError = new Error(
+          `Unexpected GraphQL payload: ${JSON.stringify(payload)}`,
+        )
+      } else {
+        lastError = new Error(`HTTP ${response.status}`)
+      }
+    } catch (error) {
+      lastError = error
+    }
+    await sleep(250)
+  }
+  throw new Error(
+    `Timed out waiting for GraphQL health at ${baseUrl}/graphql: ${
+      lastError instanceof Error ? lastError.message : String(lastError)
+    }`,
+  )
+}
+
+const killTree = async (child: ChildProcess) => {
+  if (child.pid === undefined) return
+  try {
+    process.kill(-child.pid, "SIGTERM")
+  } catch {
+    child.kill("SIGTERM")
+  }
+  const deadline = Date.now() + 10_000
+  while (Date.now() < deadline) {
+    if (child.exitCode !== null || child.signalCode !== null) return
+    await sleep(50)
+  }
+  try {
+    process.kill(-child.pid, "SIGKILL")
+  } catch {
+    child.kill("SIGKILL")
+  }
+}
+
+const runDir = mkdtempSync(join(tmpdir(), "ready-for-agent-harness-smoke-"))
+const dbPath = join(runDir, "harness.db")
+const port = 19_000 + Math.floor(Math.random() * 1000)
+const baseUrl = `http://127.0.0.1:${port}`
+
+const env: NodeJS.ProcessEnv = {
+  ...process.env,
+  SQLITE_DATABASE_PATH: dbPath,
+  PORT: String(port),
+  KEYMAXXER_ENABLED: "false",
+  NO_BROWSER: "1",
+}
+
+const migrate = spawn(
+  process.execPath,
+  [
+    "--conditions",
+    "@ready-for-agent/source",
+    resolve(workspaceRoot, "packages/db/src/bin/migrate.ts"),
+  ],
+  {
+    cwd: resolve(workspaceRoot, "packages/db"),
+    env,
+    stdio: "inherit",
+  },
+)
+
+const migrateCode = await new Promise<number | null>((resolvePromise) => {
+  migrate.on("exit", (code) => resolvePromise(code))
+})
+if (migrateCode !== 0) {
+  rmSync(runDir, { recursive: true, force: true })
+  console.error(`harness:smoke migrate failed with code ${migrateCode ?? "?"}`)
+  process.exit(migrateCode ?? 1)
+}
+
+// Same boot path as harness:dev — Bun runs vite.js (not the Node shebang).
+const child = spawn(
+  process.execPath,
+  [
+    "--conditions",
+    "@ready-for-agent/source",
+    sidecarWrapper,
+    "bash",
+    "-c",
+    "bun --conditions @ready-for-agent/source src/server/preflight.ts && bun --conditions @ready-for-agent/source ./node_modules/vite/bin/vite.js",
+  ],
+  {
+    cwd: harnessRoot,
+    env,
+    stdio: ["ignore", "pipe", "pipe"],
+    detached: true,
+  },
+)
+
+let output = ""
+const append = (chunk: Buffer | string) => {
+  output += typeof chunk === "string" ? chunk : chunk.toString("utf8")
+}
+child.stdout?.on("data", append)
+child.stderr?.on("data", append)
+
+let childExited = false
+let exitCode: number | null = null
+child.on("exit", (code) => {
+  childExited = true
+  exitCode = code
+})
+
+const cleanup = async () => {
+  await killTree(child)
+  rmSync(runDir, { recursive: true, force: true })
+}
+
+try {
+  await waitForGraphqlHealth(baseUrl, 120_000, () => !childExited)
+
+  const root = await fetch(`${baseUrl}/`, { redirect: "manual" })
+  if (root.status <= 0) {
+    throw new Error(`GET / failed with status ${root.status}`)
+  }
+
+  console.log(`harness:smoke ok (GraphQL health on ${baseUrl})`)
+  await cleanup()
+  process.exit(0)
+} catch (error) {
+  console.error(error instanceof Error ? error.message : String(error))
+  if (output.trim() !== "") {
+    console.error("--- dev server output ---")
+    console.error(output)
+  }
+  if (childExited) {
+    console.error(`Dev server exit code: ${exitCode ?? "?"}`)
+  }
+  await cleanup()
+  process.exit(1)
+}

--- a/apps/harness/test/topology.test.ts
+++ b/apps/harness/test/topology.test.ts
@@ -47,6 +47,34 @@ describe("single application server topology", () => {
     expect(harness.targets.start?.dependsOn).not.toContain("db:migrate")
   })
 
+  test("harness:smoke boots the Bun-vite dev path and generates GraphQL deps", async () => {
+    const harness = await readJson<{ targets: Record<string, Target> }>(
+      "../project.json",
+    )
+
+    expect(harness.targets.smoke?.dependsOn).toContain("db:migrate")
+    expect(harness.targets.smoke?.dependsOn).toContainEqual({
+      projects: ["graphql-client", "github-service", "graphql-schema"],
+      target: "generate",
+    })
+    expect(harness.targets.smoke?.options?.command).toContain("dev-smoke.ts")
+    expect(harness.targets.smoke?.options?.command).not.toContain(
+      "node_modules/vite/bin/vite.js",
+    )
+
+    const smokeScript = await readFile(
+      new URL("../scripts/dev-smoke.ts", import.meta.url),
+      "utf8",
+    )
+    expect(smokeScript).toContain("KEYMAXXER_ENABLED")
+    expect(smokeScript).toContain("run-with-keymaxxer-sidecar")
+    expect(smokeScript).toContain(
+      "bun --conditions @ready-for-agent/source ./node_modules/vite/bin/vite.js",
+    )
+    expect(smokeScript).toContain("{ health }")
+    expect(smokeScript).not.toContain("E2E_KEYMAXXER_MASTER_KEY")
+  })
+
   test("uses TanStack Start SPA mode without the old API proxy", async () => {
     const viteConfig = await readFile(
       new URL("../vite.config.ts", import.meta.url),


### PR DESCRIPTION
## Summary

- Add `harness:smoke` that boots the monorepo Bun+Vite dev path, asserts GraphQL `{ health: true }`, and tears down cleanly without a Keymaxxer vault
- Wire the smoke into `.github/workflows/pr.yml` and `.github/workflows/ci-cd.yml` after quality gates
- Cover generate deps and Bun-vite boot path in topology tests

Closes #276

## Test plan

- [x] `bunx nx run harness:smoke`
- [x] `bunx nx run harness:test` (topology assertions)
- [x] Pre-commit / affected lint, typecheck, test
- [ ] PR CI: quality gates + harness dev smoke step green