### PR TITLE
feat(github-service): run Keymaxxer GitHub helpers from installed binary

### DIFF
--- a/apps/harness/server.ts
+++ b/apps/harness/server.ts
@@ -1,10 +1,16 @@
 import {
+  isInternalGitHubHelperMode,
+  runGitHubHelperProcess,
+} from "@ready-for-agent/github-service"
+import {
   isInternalKeymaxxerSidecarMode,
   runKeymaxxerSidecarProcess,
 } from "@ready-for-agent/keymaxxer-service"
 
 if (isInternalKeymaxxerSidecarMode(process.argv)) {
   await runKeymaxxerSidecarProcess()
+} else if (isInternalGitHubHelperMode(process.argv)) {
+  runGitHubHelperProcess()
 } else {
   const { startProductionLifecycle } = await import(
     "./src/server/production-lifecycle.js"

--- a/apps/harness/src/server/keymaxxer-github-layer.ts
+++ b/apps/harness/src/server/keymaxxer-github-layer.ts
@@ -1,11 +1,13 @@
 import { Effect, Layer, Schema } from "effect"
 import {
+  type GitHubHelperOperation,
   GitHubRepositoryUnavailableError,
   GitHubRequestError,
   GitHubService,
   type GitHubServiceShape,
   type ReadyLabeledIssue,
-  githubServiceBinScriptPath,
+  formatGitHubHelperShellCommand,
+  resolveGitHubHelperChildSpawn,
   sanitizeUserFacingText,
 } from "@ready-for-agent/github-service"
 import { KeymaxxerService } from "@ready-for-agent/keymaxxer-service"
@@ -230,18 +232,14 @@ export const keymaxxerGitHubLayer = (options: {
         })
       const runGitHubBin = (
         tokenName: string,
-        scriptFileName: string,
+        operation: GitHubHelperOperation,
         args: readonly string[],
       ) =>
         runGitHubCommand(
           tokenName,
-          [
-            "bun",
-            "--conditions",
-            "@ready-for-agent/source",
-            JSON.stringify(githubServiceBinScriptPath(scriptFileName)),
-            ...args,
-          ].join(" "),
+          formatGitHubHelperShellCommand(
+            resolveGitHubHelperChildSpawn({ operation, args }),
+          ),
         )
 
       const service: GitHubServiceShape = {
@@ -259,7 +257,7 @@ export const keymaxxerGitHubLayer = (options: {
             const head = encodeArgument(headRefName)
             const result = yield* runGitHubBin(
               tokenName,
-              "get-open-pr-number.ts",
+              "get-open-pr-number",
               [owner, name, head],
             )
             if (result.exitCode === 2) {
@@ -302,7 +300,7 @@ export const keymaxxerGitHubLayer = (options: {
             const head = encodeArgument(headRefName)
             const result = yield* runGitHubBin(
               tokenName,
-              "get-pr-check-status.ts",
+              "get-pr-check-status",
               [owner, name, head],
             )
             if (result.exitCode === 2) {
@@ -363,7 +361,7 @@ export const keymaxxerGitHubLayer = (options: {
                 : ""
             const result = yield* runGitHubBin(
               tokenName,
-              "get-pr-status-check-diagnostics.ts",
+              "get-pr-status-check-diagnostics",
               logDirectory === ""
                 ? [owner, name, checksArg]
                 : [owner, name, checksArg, logDirectory],
@@ -410,7 +408,7 @@ export const keymaxxerGitHubLayer = (options: {
             const head = encodeArgument(headRefName)
             const result = yield* runGitHubBin(
               tokenName,
-              "get-pr-lifecycle-status.ts",
+              "get-pr-lifecycle-status",
               [owner, name, head],
             )
             if (result.exitCode === 2) {
@@ -455,7 +453,7 @@ export const keymaxxerGitHubLayer = (options: {
             const head = encodeArgument(headRefName)
             const result = yield* runGitHubBin(
               tokenName,
-              "mark-pr-ready-for-review.ts",
+              "mark-pr-ready-for-review",
               [owner, name, head],
             )
             if (result.exitCode === 2) {
@@ -486,7 +484,7 @@ export const keymaxxerGitHubLayer = (options: {
             const head = encodeArgument(headRefName)
             const result = yield* runGitHubBin(
               tokenName,
-              "merge-pull-request.ts",
+              "merge-pull-request",
               [owner, name, head],
             )
             if (result.exitCode === 2) {
@@ -516,11 +514,10 @@ export const keymaxxerGitHubLayer = (options: {
 
             const owner = encodeArgument(repository.owner)
             const name = encodeArgument(repository.name)
-            const result = yield* runGitHubBin(
-              tokenName,
-              "list-ready-issues.ts",
-              [owner, name],
-            )
+            const result = yield* runGitHubBin(tokenName, "list-ready-issues", [
+              owner,
+              name,
+            ])
 
             if (result.exitCode === 2) {
               return yield* new GitHubRepositoryUnavailableError(repository)

--- a/apps/harness/test/keymaxxer-github-layer.test.ts
+++ b/apps/harness/test/keymaxxer-github-layer.test.ts
@@ -172,10 +172,10 @@ describe("Keymaxxer-backed GitHub layer", () => {
     )
     expect(runs[0]?.command).toContain("list-ready-issues.ts")
     expect(runs[0]?.command).toMatch(
-      /bun --conditions @ready-for-agent\/source "\/.*list-ready-issues\.ts"/,
+      /"--conditions" "@ready-for-agent\/source" "\/.*list-ready-issues\.ts"/,
     )
     expect(runs[0]?.command).not.toContain(
-      "packages/github-service/src/bin/list-ready-issues.ts",
+      "--ready-for-agent-internal-github-helper",
     )
     expect(runs[0]?.cwd).toBe("/workspace")
     expect(runs[0]?.command).not.toContain("Ready issue")
@@ -239,6 +239,7 @@ describe("Keymaxxer-backed GitHub layer", () => {
       ],
     })
     expect(runs[0]?.command).toContain("get-pr-check-status.ts")
+    expect(runs[0]?.command).toContain('"--conditions"')
     expect(runs[0]?.secrets).toEqual(["GITHUB_TOKEN_ACME_WIDGETS"])
   })
 
@@ -272,6 +273,7 @@ describe("Keymaxxer-backed GitHub layer", () => {
 
     expect(number).toBe(321)
     expect(runs[0]?.command).toContain("get-open-pr-number.ts")
+    expect(runs[0]?.command).toContain('"--conditions"')
   })
 
   test("decodes no_checks and pending terminalChecks from the bin", async () => {
@@ -386,6 +388,7 @@ describe("Keymaxxer-backed GitHub layer", () => {
     )
 
     expect(runs[0]?.command).toContain("mark-pr-ready-for-review.ts")
+    expect(runs[0]?.command).toContain('"--conditions"')
     expect(runs[0]?.secrets).toEqual(["GITHUB_TOKEN_ACME_WIDGETS"])
   })
 
@@ -463,6 +466,7 @@ describe("Keymaxxer-backed GitHub layer", () => {
     )
 
     expect(runs[0]?.command).toContain("merge-pull-request.ts")
+    expect(runs[0]?.command).toContain('"--conditions"')
     expect(runs[0]?.secrets).toEqual(["GITHUB_TOKEN_ACME_WIDGETS"])
   })
 })

--- a/apps/ready-for-agent/package.json
+++ b/apps/ready-for-agent/package.json
@@ -30,6 +30,7 @@
   },
   "dependencies": {
     "@effect/platform-bun": "^4.0.0-beta.97",
+    "@ready-for-agent/github-service": "workspace:*",
     "@ready-for-agent/graphql-client": "workspace:*",
     "@ready-for-agent/keymaxxer-service": "workspace:*",
     "effect": "^4.0.0-beta.97"

--- a/apps/ready-for-agent/src/main.ts
+++ b/apps/ready-for-agent/src/main.ts
@@ -1,5 +1,9 @@
 #!/usr/bin/env bun
 import {
+  isInternalGitHubHelperMode,
+  runGitHubHelperProcess,
+} from "@ready-for-agent/github-service"
+import {
   isInternalKeymaxxerSidecarMode,
   runKeymaxxerSidecarProcess,
 } from "@ready-for-agent/keymaxxer-service"
@@ -7,6 +11,8 @@ import { READY_FOR_AGENT_VERSION } from "./generated/version.ts"
 
 if (isInternalKeymaxxerSidecarMode(process.argv)) {
   await runKeymaxxerSidecarProcess()
+} else if (isInternalGitHubHelperMode(process.argv)) {
+  runGitHubHelperProcess()
 } else {
   const { BunRuntime, BunServices } = await import("@effect/platform-bun")
   const { Effect, Layer } = await import("effect")

--- a/apps/ready-for-agent/tsconfig.app.json
+++ b/apps/ready-for-agent/tsconfig.app.json
@@ -21,6 +21,9 @@
     },
     {
       "path": "../../packages/graphql-client/tsconfig.lib.json"
+    },
+    {
+      "path": "../../packages/github-service/tsconfig.lib.json"
     }
   ]
 }

--- a/bun.lock
+++ b/bun.lock
@@ -81,6 +81,7 @@
       },
       "dependencies": {
         "@effect/platform-bun": "^4.0.0-beta.97",
+        "@ready-for-agent/github-service": "workspace:*",
         "@ready-for-agent/graphql-client": "workspace:*",
         "@ready-for-agent/keymaxxer-service": "workspace:*",
         "effect": "^4.0.0-beta.97",

--- a/packages/github-service/src/bin/cli.ts
+++ b/packages/github-service/src/bin/cli.ts
@@ -1,11 +1,9 @@
 import * as BunRuntime from "@effect/platform-bun/BunRuntime"
 import { Effect, Schema } from "effect"
-import {
-  GitHubRepositoryUnavailableError,
-  type GitHubService,
-  GitHubServiceLive,
-  formatUserFacingError,
-} from "../index.js"
+import { GitHubRepositoryUnavailableError } from "../lib/errors.js"
+import type { GitHubService } from "../lib/github-service.js"
+import { GitHubServiceLive } from "../lib/github-service-live.js"
+import { formatUserFacingError } from "../lib/user-facing-error.js"
 
 export class CliArgumentError extends Schema.TaggedErrorClass<CliArgumentError>()(
   "CliArgumentError",

--- a/packages/github-service/src/bin/get-open-pr-number.ts
+++ b/packages/github-service/src/bin/get-open-pr-number.ts
@@ -1,17 +1,19 @@
 import { Effect } from "effect"
-import { GitHubService } from "../index.js"
+import { GitHubService } from "../lib/github-service.js"
 import { decodeArgument, runGitHubCli, writeStandardOutput } from "./cli.js"
 
-const program = Effect.gen(function* () {
-  const owner = yield* decodeArgument(process.argv[2], "owner")
-  const name = yield* decodeArgument(process.argv[3], "name")
-  const headRefName = yield* decodeArgument(process.argv[4], "head ref")
-  const github = yield* GitHubService
-  const number = yield* github.getOpenPullRequestNumber(
-    { owner, name },
-    headRefName,
-  )
-  yield* writeStandardOutput(String(number))
-})
+export const getOpenPullRequestNumberProgram = (args: ReadonlyArray<string>) =>
+  Effect.gen(function* () {
+    const owner = yield* decodeArgument(args[0], "owner")
+    const name = yield* decodeArgument(args[1], "name")
+    const headRefName = yield* decodeArgument(args[2], "head ref")
+    const github = yield* GitHubService
+    const number = yield* github.getOpenPullRequestNumber(
+      { owner, name },
+      headRefName,
+    )
+    yield* writeStandardOutput(String(number))
+  })
 
-if (import.meta.main) runGitHubCli(program)
+if (import.meta.main)
+  runGitHubCli(getOpenPullRequestNumberProgram(process.argv.slice(2)))

--- a/packages/github-service/src/bin/get-pr-check-status.ts
+++ b/packages/github-service/src/bin/get-pr-check-status.ts
@@ -1,17 +1,19 @@
 import { Effect } from "effect"
-import { GitHubService } from "../index.js"
+import { GitHubService } from "../lib/github-service.js"
 import { decodeArgument, runGitHubCli, writeStandardOutput } from "./cli.js"
 
-const program = Effect.gen(function* () {
-  const owner = yield* decodeArgument(process.argv[2], "owner")
-  const name = yield* decodeArgument(process.argv[3], "name")
-  const headRefName = yield* decodeArgument(process.argv[4], "head ref")
-  const github = yield* GitHubService
-  const status = yield* github.getPullRequestCheckStatus(
-    { owner, name },
-    headRefName,
-  )
-  yield* writeStandardOutput(JSON.stringify(status))
-})
+export const getPrCheckStatusProgram = (args: ReadonlyArray<string>) =>
+  Effect.gen(function* () {
+    const owner = yield* decodeArgument(args[0], "owner")
+    const name = yield* decodeArgument(args[1], "name")
+    const headRefName = yield* decodeArgument(args[2], "head ref")
+    const github = yield* GitHubService
+    const status = yield* github.getPullRequestCheckStatus(
+      { owner, name },
+      headRefName,
+    )
+    yield* writeStandardOutput(JSON.stringify(status))
+  })
 
-if (import.meta.main) runGitHubCli(program)
+if (import.meta.main)
+  runGitHubCli(getPrCheckStatusProgram(process.argv.slice(2)))

--- a/packages/github-service/src/bin/get-pr-lifecycle-status.ts
+++ b/packages/github-service/src/bin/get-pr-lifecycle-status.ts
@@ -1,17 +1,19 @@
 import { Effect } from "effect"
-import { GitHubService } from "../index.js"
+import { GitHubService } from "../lib/github-service.js"
 import { decodeArgument, runGitHubCli, writeStandardOutput } from "./cli.js"
 
-const program = Effect.gen(function* () {
-  const owner = yield* decodeArgument(process.argv[2], "owner")
-  const name = yield* decodeArgument(process.argv[3], "name")
-  const headRefName = yield* decodeArgument(process.argv[4], "head ref")
-  const github = yield* GitHubService
-  const status = yield* github.getPullRequestLifecycleStatus(
-    { owner, name },
-    headRefName,
-  )
-  yield* writeStandardOutput(JSON.stringify(status))
-})
+export const getPrLifecycleStatusProgram = (args: ReadonlyArray<string>) =>
+  Effect.gen(function* () {
+    const owner = yield* decodeArgument(args[0], "owner")
+    const name = yield* decodeArgument(args[1], "name")
+    const headRefName = yield* decodeArgument(args[2], "head ref")
+    const github = yield* GitHubService
+    const status = yield* github.getPullRequestLifecycleStatus(
+      { owner, name },
+      headRefName,
+    )
+    yield* writeStandardOutput(JSON.stringify(status))
+  })
 
-if (import.meta.main) runGitHubCli(program)
+if (import.meta.main)
+  runGitHubCli(getPrLifecycleStatusProgram(process.argv.slice(2)))

--- a/packages/github-service/src/bin/get-pr-status-check-diagnostics.ts
+++ b/packages/github-service/src/bin/get-pr-status-check-diagnostics.ts
@@ -1,5 +1,5 @@
 import { Effect, Schema } from "effect"
-import { GitHubService } from "../index.js"
+import { GitHubService } from "../lib/github-service.js"
 import {
   CliArgumentError,
   decodeArgument,
@@ -14,31 +14,37 @@ const ChecksArgument = Schema.Array(
   }),
 )
 
-const program = Effect.gen(function* () {
-  const owner = yield* decodeArgument(process.argv[2], "owner")
-  const name = yield* decodeArgument(process.argv[3], "name")
-  const checksJson = yield* decodeArgument(process.argv[4], "checks")
-  const logDirectoryRaw = process.argv[5]
-  const logDirectory =
-    logDirectoryRaw === undefined || logDirectoryRaw === ""
-      ? undefined
-      : yield* decodeArgument(logDirectoryRaw, "log directory")
-  const parsed = yield* Effect.try({
-    try: () => JSON.parse(checksJson) as unknown,
-    catch: () => new CliArgumentError({ message: "Invalid checks argument" }),
+export const getPrStatusCheckDiagnosticsProgram = (
+  args: ReadonlyArray<string>,
+) =>
+  Effect.gen(function* () {
+    const owner = yield* decodeArgument(args[0], "owner")
+    const name = yield* decodeArgument(args[1], "name")
+    const checksJson = yield* decodeArgument(args[2], "checks")
+    const logDirectoryRaw = args[3]
+    const logDirectory =
+      logDirectoryRaw === undefined || logDirectoryRaw === ""
+        ? undefined
+        : yield* decodeArgument(logDirectoryRaw, "log directory")
+    const parsed = yield* Effect.try({
+      try: () => JSON.parse(checksJson) as unknown,
+      catch: () => new CliArgumentError({ message: "Invalid checks argument" }),
+    })
+    const checks = yield* Schema.decodeUnknownEffect(ChecksArgument)(
+      parsed,
+    ).pipe(
+      Effect.mapError(
+        () => new CliArgumentError({ message: "Invalid checks argument" }),
+      ),
+    )
+    const github = yield* GitHubService
+    const diagnostics = yield* github.getPrStatusCheckDiagnostics(
+      { owner, name },
+      checks,
+      logDirectory === undefined ? {} : { logDirectory },
+    )
+    yield* writeStandardOutput(JSON.stringify(diagnostics))
   })
-  const checks = yield* Schema.decodeUnknownEffect(ChecksArgument)(parsed).pipe(
-    Effect.mapError(
-      () => new CliArgumentError({ message: "Invalid checks argument" }),
-    ),
-  )
-  const github = yield* GitHubService
-  const diagnostics = yield* github.getPrStatusCheckDiagnostics(
-    { owner, name },
-    checks,
-    logDirectory === undefined ? {} : { logDirectory },
-  )
-  yield* writeStandardOutput(JSON.stringify(diagnostics))
-})
 
-if (import.meta.main) runGitHubCli(program)
+if (import.meta.main)
+  runGitHubCli(getPrStatusCheckDiagnosticsProgram(process.argv.slice(2)))

--- a/packages/github-service/src/bin/list-ready-issues.ts
+++ b/packages/github-service/src/bin/list-ready-issues.ts
@@ -1,15 +1,17 @@
 import { Effect } from "effect"
-import { GitHubService } from "../index.js"
+import { GitHubService } from "../lib/github-service.js"
 import { decodeArgument, runGitHubCli, writeStandardOutput } from "./cli.js"
 
-const program = Effect.gen(function* () {
-  const repository = {
-    owner: yield* decodeArgument(process.argv[2], "owner"),
-    name: yield* decodeArgument(process.argv[3], "name"),
-  }
-  const github = yield* GitHubService
-  const issues = yield* github.listReadyIssues(repository)
-  yield* writeStandardOutput(JSON.stringify(issues))
-})
+export const listReadyIssuesProgram = (args: ReadonlyArray<string>) =>
+  Effect.gen(function* () {
+    const repository = {
+      owner: yield* decodeArgument(args[0], "owner"),
+      name: yield* decodeArgument(args[1], "name"),
+    }
+    const github = yield* GitHubService
+    const issues = yield* github.listReadyIssues(repository)
+    yield* writeStandardOutput(JSON.stringify(issues))
+  })
 
-if (import.meta.main) runGitHubCli(program)
+if (import.meta.main)
+  runGitHubCli(listReadyIssuesProgram(process.argv.slice(2)))

--- a/packages/github-service/src/bin/mark-pr-ready-for-review.ts
+++ b/packages/github-service/src/bin/mark-pr-ready-for-review.ts
@@ -1,14 +1,16 @@
 import { Effect } from "effect"
-import { GitHubService } from "../index.js"
+import { GitHubService } from "../lib/github-service.js"
 import { decodeArgument, runGitHubCli, writeStandardOutput } from "./cli.js"
 
-const program = Effect.gen(function* () {
-  const owner = yield* decodeArgument(process.argv[2], "owner")
-  const name = yield* decodeArgument(process.argv[3], "name")
-  const headRefName = yield* decodeArgument(process.argv[4], "head ref")
-  const github = yield* GitHubService
-  yield* github.markPullRequestReadyForReview({ owner, name }, headRefName)
-  yield* writeStandardOutput(JSON.stringify({ _tag: "ready" }))
-})
+export const markPrReadyForReviewProgram = (args: ReadonlyArray<string>) =>
+  Effect.gen(function* () {
+    const owner = yield* decodeArgument(args[0], "owner")
+    const name = yield* decodeArgument(args[1], "name")
+    const headRefName = yield* decodeArgument(args[2], "head ref")
+    const github = yield* GitHubService
+    yield* github.markPullRequestReadyForReview({ owner, name }, headRefName)
+    yield* writeStandardOutput(JSON.stringify({ _tag: "ready" }))
+  })
 
-if (import.meta.main) runGitHubCli(program)
+if (import.meta.main)
+  runGitHubCli(markPrReadyForReviewProgram(process.argv.slice(2)))

--- a/packages/github-service/src/bin/merge-pull-request.ts
+++ b/packages/github-service/src/bin/merge-pull-request.ts
@@ -1,14 +1,16 @@
 import { Effect } from "effect"
-import { GitHubService } from "../index.js"
+import { GitHubService } from "../lib/github-service.js"
 import { decodeArgument, runGitHubCli, writeStandardOutput } from "./cli.js"
 
-const program = Effect.gen(function* () {
-  const owner = yield* decodeArgument(process.argv[2], "owner")
-  const name = yield* decodeArgument(process.argv[3], "name")
-  const headRefName = yield* decodeArgument(process.argv[4], "head ref")
-  const github = yield* GitHubService
-  yield* github.mergePullRequest({ owner, name }, headRefName)
-  yield* writeStandardOutput(JSON.stringify({ _tag: "merged" }))
-})
+export const mergePullRequestProgram = (args: ReadonlyArray<string>) =>
+  Effect.gen(function* () {
+    const owner = yield* decodeArgument(args[0], "owner")
+    const name = yield* decodeArgument(args[1], "name")
+    const headRefName = yield* decodeArgument(args[2], "head ref")
+    const github = yield* GitHubService
+    yield* github.mergePullRequest({ owner, name }, headRefName)
+    yield* writeStandardOutput(JSON.stringify({ _tag: "merged" }))
+  })
 
-if (import.meta.main) runGitHubCli(program)
+if (import.meta.main)
+  runGitHubCli(mergePullRequestProgram(process.argv.slice(2)))

--- a/packages/github-service/src/index.ts
+++ b/packages/github-service/src/index.ts
@@ -1,5 +1,6 @@
 export { githubServiceBinScriptPath } from "./bin-script-path.js"
 export * from "./lib/errors.js"
+export * from "./lib/github-helper-process.js"
 export * from "./lib/github-service.js"
 export {
   GitHubServiceLive,

--- a/packages/github-service/src/lib/github-helper-process.ts
+++ b/packages/github-service/src/lib/github-helper-process.ts
@@ -1,0 +1,150 @@
+import type { Effect } from "effect"
+import { runGitHubCli } from "../bin/cli.js"
+import { getOpenPullRequestNumberProgram } from "../bin/get-open-pr-number.js"
+import { getPrCheckStatusProgram } from "../bin/get-pr-check-status.js"
+import { getPrLifecycleStatusProgram } from "../bin/get-pr-lifecycle-status.js"
+import { getPrStatusCheckDiagnosticsProgram } from "../bin/get-pr-status-check-diagnostics.js"
+import { listReadyIssuesProgram } from "../bin/list-ready-issues.js"
+import { markPrReadyForReviewProgram } from "../bin/mark-pr-ready-for-review.js"
+import { mergePullRequestProgram } from "../bin/merge-pull-request.js"
+import { githubServiceBinScriptPath } from "../bin-script-path.js"
+import type { GitHubService } from "./github-service.js"
+
+/** Hidden argv token: re-enter the same executable as a GitHub helper. */
+export const INTERNAL_GITHUB_HELPER_ARG =
+  "--ready-for-agent-internal-github-helper"
+
+export const GITHUB_HELPER_OPERATIONS = [
+  "list-ready-issues",
+  "get-open-pr-number",
+  "get-pr-check-status",
+  "get-pr-status-check-diagnostics",
+  "get-pr-lifecycle-status",
+  "mark-pr-ready-for-review",
+  "merge-pull-request",
+] as const
+
+export type GitHubHelperOperation = (typeof GITHUB_HELPER_OPERATIONS)[number]
+
+export const isGitHubHelperOperation = (
+  value: string,
+): value is GitHubHelperOperation =>
+  (GITHUB_HELPER_OPERATIONS as ReadonlyArray<string>).includes(value)
+
+export const isInternalGitHubHelperMode = (
+  argv: ReadonlyArray<string> = process.argv,
+): boolean => argv.includes(INTERNAL_GITHUB_HELPER_ARG)
+
+/**
+ * True when this process is a compiled standalone product binary rather than
+ * `bun path/to/script.ts` (or similar source execution).
+ */
+export const isStandaloneExecutable = (
+  execPath: string = process.execPath,
+  argv: ReadonlyArray<string> = process.argv,
+): boolean => {
+  const base = execPath.split(/[/\\]/).pop() ?? ""
+  if (
+    base === "bun" ||
+    base === "bun.exe" ||
+    base === "node" ||
+    base === "node.exe"
+  ) {
+    return false
+  }
+  const maybeScript = argv[1]
+  if (
+    maybeScript !== undefined &&
+    /\.(m?[jt]sx?|cjs|mts|cts)$/i.test(maybeScript)
+  ) {
+    return false
+  }
+  return true
+}
+
+export type GitHubHelperChildSpawn = {
+  readonly command: string
+  readonly args: ReadonlyArray<string>
+}
+
+/**
+ * How Keymaxxer should spawn a GitHub helper child.
+ * Compiled binaries: `execPath --ready-for-agent-internal-github-helper <op> …`.
+ * Source: same Bun runtime + workspace bin script + encoded args.
+ */
+export const resolveGitHubHelperChildSpawn = (input: {
+  readonly operation: GitHubHelperOperation
+  readonly args: ReadonlyArray<string>
+  readonly execPath?: string
+  readonly argv?: ReadonlyArray<string>
+  readonly sourceConditions?: ReadonlyArray<string>
+}): GitHubHelperChildSpawn => {
+  const execPath = input.execPath ?? process.execPath
+  const argv = input.argv ?? process.argv
+
+  if (isStandaloneExecutable(execPath, argv)) {
+    return {
+      command: execPath,
+      args: [INTERNAL_GITHUB_HELPER_ARG, input.operation, ...input.args],
+    }
+  }
+
+  const conditions = input.sourceConditions ?? [
+    "--conditions",
+    "@ready-for-agent/source",
+  ]
+
+  return {
+    command: execPath,
+    args: [
+      ...conditions,
+      githubServiceBinScriptPath(`${input.operation}.ts`),
+      ...input.args,
+    ],
+  }
+}
+
+/** Shell-safe command string for Keymaxxer `runWithSecrets`. */
+export const formatGitHubHelperShellCommand = (
+  spawn: GitHubHelperChildSpawn,
+): string =>
+  [spawn.command, ...spawn.args].map((part) => JSON.stringify(part)).join(" ")
+
+const programs: Record<
+  GitHubHelperOperation,
+  (args: ReadonlyArray<string>) => Effect.Effect<void, unknown, GitHubService>
+> = {
+  "list-ready-issues": listReadyIssuesProgram,
+  "get-open-pr-number": getOpenPullRequestNumberProgram,
+  "get-pr-check-status": getPrCheckStatusProgram,
+  "get-pr-status-check-diagnostics": getPrStatusCheckDiagnosticsProgram,
+  "get-pr-lifecycle-status": getPrLifecycleStatusProgram,
+  "mark-pr-ready-for-review": markPrReadyForReviewProgram,
+  "merge-pull-request": mergePullRequestProgram,
+}
+
+/**
+ * Product-binary / harness entry body for internal GitHub helper mode.
+ * Operation name is the argv token after {@link INTERNAL_GITHUB_HELPER_ARG};
+ * remaining tokens are base64url-encoded helper arguments.
+ */
+export const runGitHubHelperProcess = (
+  argv: ReadonlyArray<string> = process.argv,
+): void => {
+  const flagIndex = argv.indexOf(INTERNAL_GITHUB_HELPER_ARG)
+  if (flagIndex < 0) {
+    process.stderr.write("Missing internal GitHub helper mode flag\n")
+    process.exitCode = 1
+    return
+  }
+  const operation = argv[flagIndex + 1]
+  if (operation === undefined || !isGitHubHelperOperation(operation)) {
+    process.stderr.write(
+      `Unknown GitHub helper operation: ${operation ?? "(missing)"}\n`,
+    )
+    process.exitCode = 1
+    return
+  }
+  const args = argv.slice(flagIndex + 2)
+  runGitHubCli(programs[operation](args))
+}

--- a/packages/github-service/test/github-helper-process.spec.ts
+++ b/packages/github-service/test/github-helper-process.spec.ts
@@ -1,0 +1,203 @@
+import { spawn } from "node:child_process"
+import { fileURLToPath } from "node:url"
+import { afterEach, describe, expect, test } from "vitest"
+import {
+  INTERNAL_GITHUB_HELPER_ARG,
+  formatGitHubHelperShellCommand,
+  isInternalGitHubHelperMode,
+  isStandaloneExecutable,
+  resolveGitHubHelperChildSpawn,
+} from "../src/index.js"
+
+const harnessServerEntry = fileURLToPath(
+  new URL("../../../apps/harness/server.ts", import.meta.url),
+)
+
+/** Vitest may run under Node; GitHub helper source entry still requires Bun. */
+const bunExecutable = () =>
+  process.execPath.includes("bun") ? process.execPath : "bun"
+
+const encode = (value: string) =>
+  Buffer.from(value, "utf8").toString("base64url")
+
+describe("internal GitHub helper mode", () => {
+  test("detects the hidden internal argv token", () => {
+    expect(isInternalGitHubHelperMode(["bun", "main.ts"])).toBe(false)
+    expect(
+      isInternalGitHubHelperMode([
+        "ready-for-agent",
+        INTERNAL_GITHUB_HELPER_ARG,
+        "list-ready-issues",
+      ]),
+    ).toBe(true)
+  })
+
+  test("classifies compiled binaries vs source runtimes", () => {
+    expect(
+      isStandaloneExecutable("/usr/bin/bun", [
+        "/usr/bin/bun",
+        "/app/server.ts",
+      ]),
+    ).toBe(false)
+    expect(
+      isStandaloneExecutable("/opt/ready-for-agent", [
+        "/opt/ready-for-agent",
+        "start",
+      ]),
+    ).toBe(true)
+  })
+
+  test("spawns the same binary with the internal mode flag when standalone", () => {
+    expect(
+      resolveGitHubHelperChildSpawn({
+        operation: "list-ready-issues",
+        args: ["owner", "name"],
+        execPath: "/opt/ready-for-agent",
+        argv: ["/opt/ready-for-agent", "start"],
+      }),
+    ).toEqual({
+      command: "/opt/ready-for-agent",
+      args: [INTERNAL_GITHUB_HELPER_ARG, "list-ready-issues", "owner", "name"],
+    })
+  })
+
+  test("uses workspace bin scripts under a Bun source runtime", () => {
+    const spawnPlan = resolveGitHubHelperChildSpawn({
+      operation: "merge-pull-request",
+      args: ["o", "n", "h"],
+      execPath: "/usr/bin/bun",
+      argv: ["/usr/bin/bun", "/repo/apps/harness/server.ts"],
+    })
+    expect(spawnPlan.command).toBe("/usr/bin/bun")
+    expect(spawnPlan.args[0]).toBe("--conditions")
+    expect(spawnPlan.args[1]).toBe("@ready-for-agent/source")
+    expect(spawnPlan.args[2]).toMatch(/merge-pull-request\.ts$/)
+    expect(spawnPlan.args.slice(3)).toEqual(["o", "n", "h"])
+    expect(formatGitHubHelperShellCommand(spawnPlan)).toContain(
+      "merge-pull-request.ts",
+    )
+    expect(formatGitHubHelperShellCommand(spawnPlan)).not.toContain(
+      INTERNAL_GITHUB_HELPER_ARG,
+    )
+  })
+
+  test("shell formatting quotes every argv token", () => {
+    const command = formatGitHubHelperShellCommand({
+      command: "/opt/ready-for-agent",
+      args: [INTERNAL_GITHUB_HELPER_ARG, "list-ready-issues", "abc"],
+    })
+    expect(command).toBe(
+      '"/opt/ready-for-agent" "--ready-for-agent-internal-github-helper" "list-ready-issues" "abc"',
+    )
+  })
+})
+
+describe("GitHub helper process boundary", () => {
+  const children: Array<ReturnType<typeof spawn>> = []
+
+  afterEach(() => {
+    for (const child of children) {
+      child.kill("SIGTERM")
+    }
+    children.length = 0
+  })
+
+  test("list-ready-issues helper fails safely without a token (read path)", async () => {
+    const child = spawn(
+      bunExecutable(),
+      [
+        "--conditions",
+        "@ready-for-agent/source",
+        harnessServerEntry,
+        INTERNAL_GITHUB_HELPER_ARG,
+        "list-ready-issues",
+        encode("acme"),
+        encode("widgets"),
+      ],
+      {
+        env: {
+          ...process.env,
+          GITHUB_TOKEN: "",
+        },
+        stdio: ["ignore", "pipe", "pipe"],
+      },
+    )
+    children.push(child)
+
+    const stderrChunks: Buffer[] = []
+    child.stderr?.on("data", (chunk: Buffer) => stderrChunks.push(chunk))
+    const exitCode = await new Promise<number | null>((resolve) => {
+      child.on("close", (code) => resolve(code))
+    })
+
+    expect(exitCode).not.toBe(0)
+    expect(exitCode).not.toBe(2)
+    const stderr = Buffer.concat(stderrChunks).toString("utf8")
+    expect(stderr.length).toBeGreaterThan(0)
+    expect(stderr).not.toMatch(/ghp_[A-Za-z0-9]+/)
+  })
+
+  test("merge-pull-request helper fails safely without a token (write path)", async () => {
+    const child = spawn(
+      bunExecutable(),
+      [
+        "--conditions",
+        "@ready-for-agent/source",
+        harnessServerEntry,
+        INTERNAL_GITHUB_HELPER_ARG,
+        "merge-pull-request",
+        encode("acme"),
+        encode("widgets"),
+        encode("rfa/acme-widgets/1/wi-test"),
+      ],
+      {
+        env: {
+          ...process.env,
+          GITHUB_TOKEN: "",
+        },
+        stdio: ["ignore", "pipe", "pipe"],
+      },
+    )
+    children.push(child)
+
+    const stderrChunks: Buffer[] = []
+    child.stderr?.on("data", (chunk: Buffer) => stderrChunks.push(chunk))
+    const exitCode = await new Promise<number | null>((resolve) => {
+      child.on("close", (code) => resolve(code))
+    })
+
+    expect(exitCode).not.toBe(0)
+    expect(exitCode).not.toBe(2)
+    const stderr = Buffer.concat(stderrChunks).toString("utf8")
+    expect(stderr.length).toBeGreaterThan(0)
+  })
+
+  test("rejects unknown helper operations", async () => {
+    const child = spawn(
+      bunExecutable(),
+      [
+        "--conditions",
+        "@ready-for-agent/source",
+        harnessServerEntry,
+        INTERNAL_GITHUB_HELPER_ARG,
+        "not-a-real-operation",
+      ],
+      {
+        env: process.env,
+        stdio: ["ignore", "pipe", "pipe"],
+      },
+    )
+    children.push(child)
+
+    const stderrChunks: Buffer[] = []
+    child.stderr?.on("data", (chunk: Buffer) => stderrChunks.push(chunk))
+    const exitCode = await new Promise<number | null>((resolve) => {
+      child.on("close", (code) => resolve(code))
+    })
+
+    expect(exitCode).toBe(1)
+    expect(Buffer.concat(stderrChunks).toString("utf8")).toContain(
+      "Unknown GitHub helper operation",
+    )
+  })
+})


### PR DESCRIPTION
## Summary

- Add an internal product-binary mode (`--ready-for-agent-internal-github-helper`) so Keymaxxer-backed GitHub ops re-exec the installed executable instead of workspace TypeScript bins and external Bun.
- Wire the mode into `ready-for-agent` and harness production entrypoints; Keymaxxer GitHub layer resolves standalone vs source spawn and keeps secret values in the child environment only.
- Cover helper spawn resolution and representative read/write helper boundaries with process-level tests; keep existing GitHub/Keymaxxer layer contracts green.

Closes #264.

## Test plan

- [x] `nx test github-service` (helper process + service contract)
- [x] `nx test harness` (including keymaxxer-github-layer)
- [x] `nx test keymaxxer-service`
- [x] Pre-commit affected lint/typecheck/test
- [ ] CI green on draft PR