### PR TITLE
feat(github-service): add idempotent Issue completion with summary

### DIFF
--- a/apps/harness/src/server/ambient-github-layer.ts
+++ b/apps/harness/src/server/ambient-github-layer.ts
@@ -124,6 +124,20 @@ export const ambientGitHubLayer = (options: {
         authenticated((service) =>
           service.mergePullRequest(repository, headRefName),
         ),
+      ensureIssueCompletedWithSummary: (
+        repository,
+        issueNumber,
+        workItemId,
+        summaryMarkdown,
+      ) =>
+        authenticated((service) =>
+          service.ensureIssueCompletedWithSummary(
+            repository,
+            issueNumber,
+            workItemId,
+            summaryMarkdown,
+          ),
+        ),
       listReadyIssues: (repository) =>
         authenticated((service) => service.listReadyIssues(repository)),
     } satisfies GitHubServiceShape

--- a/apps/harness/src/server/keymaxxer-github-layer.ts
+++ b/apps/harness/src/server/keymaxxer-github-layer.ts
@@ -502,6 +502,47 @@ export const keymaxxerGitHubLayer = (options: {
               Effect.fail(requestError(repository, "merge pull request")),
             ),
           ),
+        ensureIssueCompletedWithSummary: (
+          repository,
+          issueNumber,
+          workItemId,
+          summaryMarkdown,
+        ) =>
+          Effect.gen(function* () {
+            const tokenName = yield* ensureToken(repository)
+            if (tokenName === null) {
+              return yield* requestError(
+                repository,
+                "complete Issue with summary",
+              )
+            }
+            const owner = encodeArgument(repository.owner)
+            const name = encodeArgument(repository.name)
+            const number = encodeArgument(String(issueNumber))
+            const workItem = encodeArgument(workItemId)
+            const summary = encodeArgument(summaryMarkdown)
+            const result = yield* runGitHubBin(
+              tokenName,
+              "ensure-issue-completed-with-summary",
+              [owner, name, number, workItem, summary],
+            )
+            if (result.exitCode === 2) {
+              return yield* new GitHubRepositoryUnavailableError(repository)
+            }
+            if (result.exitCode !== 0) {
+              return yield* requestError(
+                repository,
+                "complete Issue with summary",
+                result.stderr || result.stdout,
+              )
+            }
+          }).pipe(
+            Effect.catchTag("KeymaxxerError", () =>
+              Effect.fail(
+                requestError(repository, "complete Issue with summary"),
+              ),
+            ),
+          ),
         listReadyIssues: (repository) =>
           Effect.gen(function* () {
             const tokenName = yield* ensureToken(repository)

--- a/apps/harness/test/ambient-github-layer.test.ts
+++ b/apps/harness/test/ambient-github-layer.test.ts
@@ -17,6 +17,7 @@ const serviceWithList = (
   getPullRequestLifecycleStatus: () => Effect.die("not used"),
   markPullRequestReadyForReview: () => Effect.die("not used"),
   mergePullRequest: () => Effect.die("not used"),
+  ensureIssueCompletedWithSummary: () => Effect.die("not used"),
 })
 
 test("ambient GitHub authentication is resolved once", async () => {

--- a/apps/harness/test/job-worker.test.ts
+++ b/apps/harness/test/job-worker.test.ts
@@ -146,6 +146,7 @@ const defaultGithubLayer = Layer.succeed(GitHubService, {
     Effect.succeed({ _tag: "open" as const }),
   markPullRequestReadyForReview: () => Effect.void,
   mergePullRequest: () => Effect.void,
+  ensureIssueCompletedWithSummary: () => Effect.void,
   listReadyIssues: () => Effect.succeed([]),
 } satisfies GitHubServiceShape)
 
@@ -403,6 +404,7 @@ describe("Job worker", () => {
         Effect.succeed({ _tag: "open" as const }),
       markPullRequestReadyForReview: () => Effect.void,
       mergePullRequest: () => Effect.void,
+      ensureIssueCompletedWithSummary: () => Effect.void,
       listReadyIssues: () =>
         Effect.succeed([
           {

--- a/packages/github-service/github.graphql
+++ b/packages/github-service/github.graphql
@@ -17,6 +17,40 @@ type Mutation {
     input: MarkPullRequestReadyForReviewInput!
   ): MarkPullRequestReadyForReviewPayload
   mergePullRequest(input: MergePullRequestInput!): MergePullRequestPayload
+  addComment(input: AddCommentInput!): AddCommentPayload
+  closeIssue(input: CloseIssueInput!): CloseIssuePayload
+}
+
+input AddCommentInput {
+  subjectId: ID!
+  body: String!
+  clientMutationId: String
+}
+
+type AddCommentPayload {
+  clientMutationId: String
+  commentEdge: IssueCommentEdge
+}
+
+type IssueCommentEdge {
+  node: IssueComment
+}
+
+input CloseIssueInput {
+  issueId: ID!
+  stateReason: IssueClosedStateReason
+  clientMutationId: String
+}
+
+type CloseIssuePayload {
+  clientMutationId: String
+  issue: Issue
+}
+
+enum IssueClosedStateReason {
+  COMPLETED
+  NOT_PLANNED
+  DUPLICATE
 }
 
 input MarkPullRequestReadyForReviewInput {
@@ -172,6 +206,7 @@ type PageInfo {
 }
 
 type Issue {
+  id: ID!
   number: Int!
   title: String!
   body: String!
@@ -180,6 +215,7 @@ type Issue {
   state: IssueState!
   repository: Repository!
   parent: Issue
+  comments(first: Int, after: String): IssueCommentConnection!
   subIssues(first: Int, after: String): IssueConnection!
   subIssuesSummary: SubIssuesSummary!
   blockedBy(first: Int, after: String): IssueConnection!
@@ -188,6 +224,16 @@ type Issue {
     after: String
     includeClosedPrs: Boolean
   ): PullRequestConnection!
+}
+
+type IssueCommentConnection {
+  nodes: [IssueComment]
+  pageInfo: PageInfo!
+}
+
+type IssueComment {
+  id: ID!
+  body: String!
 }
 
 type SubIssuesSummary {

--- a/packages/github-service/src/bin/ensure-issue-completed-with-summary.ts
+++ b/packages/github-service/src/bin/ensure-issue-completed-with-summary.ts
@@ -1,0 +1,26 @@
+import { Effect } from "effect"
+import { GitHubService } from "../lib/github-service.js"
+import { decodeArgument, runGitHubCli, writeStandardOutput } from "./cli.js"
+
+export const ensureIssueCompletedWithSummaryProgram = (
+  args: ReadonlyArray<string>,
+) =>
+  Effect.gen(function* () {
+    const owner = yield* decodeArgument(args[0], "owner")
+    const name = yield* decodeArgument(args[1], "name")
+    const issueNumberRaw = yield* decodeArgument(args[2], "issue number")
+    const workItemId = yield* decodeArgument(args[3], "work item id")
+    const summaryMarkdown = yield* decodeArgument(args[4], "summary")
+    const issueNumber = Number(issueNumberRaw)
+    const github = yield* GitHubService
+    yield* github.ensureIssueCompletedWithSummary(
+      { owner, name },
+      issueNumber,
+      workItemId,
+      summaryMarkdown,
+    )
+    yield* writeStandardOutput(JSON.stringify({ _tag: "completed" }))
+  })
+
+if (import.meta.main)
+  runGitHubCli(ensureIssueCompletedWithSummaryProgram(process.argv.slice(2)))

--- a/packages/github-service/src/lib/github-helper-process.ts
+++ b/packages/github-service/src/lib/github-helper-process.ts
@@ -1,5 +1,6 @@
 import type { Effect } from "effect"
 import { runGitHubCli } from "../bin/cli.js"
+import { ensureIssueCompletedWithSummaryProgram } from "../bin/ensure-issue-completed-with-summary.js"
 import { getOpenPullRequestNumberProgram } from "../bin/get-open-pr-number.js"
 import { getPrCheckStatusProgram } from "../bin/get-pr-check-status.js"
 import { getPrLifecycleStatusProgram } from "../bin/get-pr-lifecycle-status.js"
@@ -22,6 +23,7 @@ export const GITHUB_HELPER_OPERATIONS = [
   "get-pr-lifecycle-status",
   "mark-pr-ready-for-review",
   "merge-pull-request",
+  "ensure-issue-completed-with-summary",
 ] as const
 
 export type GitHubHelperOperation = (typeof GITHUB_HELPER_OPERATIONS)[number]
@@ -121,6 +123,7 @@ const programs: Record<
   "get-pr-lifecycle-status": getPrLifecycleStatusProgram,
   "mark-pr-ready-for-review": markPrReadyForReviewProgram,
   "merge-pull-request": mergePullRequestProgram,
+  "ensure-issue-completed-with-summary": ensureIssueCompletedWithSummaryProgram,
 }
 
 /**

--- a/packages/github-service/src/lib/github-service-live.ts
+++ b/packages/github-service/src/lib/github-service-live.ts
@@ -680,7 +680,7 @@ const safeLogFileName = (externalId: string): string =>
   `${externalId.replace(/[^a-zA-Z0-9._-]+/g, "-")}.log`
 
 /** Hidden HTML comment marker tying a completion summary to a Work Item. */
-export const workItemCompletionMarker = (workItemId: string): string =>
+const workItemCompletionMarker = (workItemId: string): string =>
   `<!-- ready-for-agent:work-item:${workItemId} -->`
 
 export const makeGitHubService = (

--- a/packages/github-service/src/lib/github-service-live.ts
+++ b/packages/github-service/src/lib/github-service-live.ts
@@ -679,6 +679,10 @@ const boundLogExcerpt = (logText: string, maxExcerptChars: number): string => {
 const safeLogFileName = (externalId: string): string =>
   `${externalId.replace(/[^a-zA-Z0-9._-]+/g, "-")}.log`
 
+/** Hidden HTML comment marker tying a completion summary to a Work Item. */
+export const workItemCompletionMarker = (workItemId: string): string =>
+  `<!-- ready-for-agent:work-item:${workItemId} -->`
+
 export const makeGitHubService = (
   client: GitHubGraphqlClient,
   listTerminalChecksForCommit?: ListTerminalChecksForCommit,
@@ -1082,6 +1086,208 @@ export const makeGitHubService = (
       }
     },
   ),
+  ensureIssueCompletedWithSummary: Effect.fn(
+    "GitHubService.ensureIssueCompletedWithSummary",
+  )(function* (repository, issueNumber, workItemId, summaryMarkdown) {
+    if (!Number.isSafeInteger(issueNumber) || issueNumber <= 0) {
+      return yield* new GitHubRequestError({
+        message: `Invalid Issue number for ${repository.owner}/${repository.name}: ${String(issueNumber)}`,
+      })
+    }
+    if (typeof workItemId !== "string" || workItemId.trim() === "") {
+      return yield* new GitHubRequestError({
+        message: `Invalid Work Item id for ${repository.owner}/${repository.name}#${issueNumber}`,
+      })
+    }
+    if (typeof summaryMarkdown !== "string" || summaryMarkdown.trim() === "") {
+      return yield* new GitHubRequestError({
+        message: `Empty completion summary for ${repository.owner}/${repository.name}#${issueNumber}`,
+      })
+    }
+
+    const marker = workItemCompletionMarker(workItemId)
+    const issueRef = `${repository.owner}/${repository.name}#${issueNumber}`
+
+    const issueResult = yield* githubQuery(
+      `Failed to load Issue ${issueRef}`,
+      (signal) =>
+        client.query(
+          {
+            repository: {
+              __args: repository,
+              issue: {
+                __args: { number: issueNumber },
+                id: true,
+                state: true,
+              },
+            },
+          },
+          signal,
+        ),
+    )
+    if (issueResult.repository === null) {
+      return yield* new GitHubRepositoryUnavailableError(repository)
+    }
+    const issue = issueResult.repository.issue
+    if (issue === null || issue === undefined) {
+      return yield* new GitHubRequestError({
+        message: `No Issue found for ${issueRef}`,
+      })
+    }
+    if (typeof issue.id !== "string" || issue.id.trim() === "") {
+      return yield* new GitHubRequestError({
+        message: `GitHub returned an invalid Issue id for ${issueRef}`,
+      })
+    }
+    if (issue.state !== "OPEN" && issue.state !== "CLOSED") {
+      return yield* new GitHubRequestError({
+        message: `GitHub returned an invalid Issue state for ${issueRef}`,
+      })
+    }
+
+    let hasMarkedComment = false
+    let commentsAfter: string | null = null
+    while (true) {
+      const commentsResult = yield* githubQuery(
+        `Failed to list comments for Issue ${issueRef}`,
+        (signal) =>
+          client.query(
+            {
+              repository: {
+                __args: repository,
+                issue: {
+                  __args: { number: issueNumber },
+                  comments: {
+                    __args: {
+                      first: PAGE_SIZE,
+                      after: commentsAfter,
+                    },
+                    nodes: {
+                      body: true,
+                    },
+                    pageInfo: {
+                      endCursor: true,
+                      hasNextPage: true,
+                    },
+                  },
+                },
+              },
+            },
+            signal,
+          ),
+      )
+      if (commentsResult.repository === null) {
+        return yield* new GitHubRepositoryUnavailableError(repository)
+      }
+      const commentsIssue = commentsResult.repository.issue
+      if (commentsIssue === null || commentsIssue === undefined) {
+        return yield* new GitHubRequestError({
+          message: `No Issue found for ${issueRef}`,
+        })
+      }
+      for (const comment of commentsIssue.comments.nodes ?? []) {
+        if (comment !== null && typeof comment.body === "string") {
+          if (comment.body.includes(marker)) {
+            hasMarkedComment = true
+            break
+          }
+        }
+      }
+      if (hasMarkedComment) {
+        break
+      }
+      if (!commentsIssue.comments.pageInfo.hasNextPage) {
+        break
+      }
+      const endCursor = commentsIssue.comments.pageInfo.endCursor
+      if (typeof endCursor !== "string" || endCursor.trim() === "") {
+        return yield* new GitHubRequestError({
+          message: `GitHub returned an invalid comments page cursor for ${issueRef}`,
+        })
+      }
+      commentsAfter = endCursor
+    }
+
+    if (!hasMarkedComment) {
+      if (client.mutation === undefined) {
+        return yield* new GitHubRequestError({
+          message: `GitHub GraphQL client does not support mutations for ${issueRef}`,
+        })
+      }
+      const mutate = client.mutation
+      const body = `${summaryMarkdown.trimEnd()}\n\n${marker}`
+      const addResult = yield* githubRequest(
+        `Failed to post completion summary on Issue ${issueRef}`,
+        (signal) =>
+          mutate(
+            {
+              addComment: {
+                __args: {
+                  input: {
+                    subjectId: issue.id,
+                    body,
+                  },
+                },
+                commentEdge: {
+                  node: {
+                    body: true,
+                  },
+                },
+              },
+            },
+            signal,
+          ),
+      )
+      const postedBody = addResult.addComment?.commentEdge?.node?.body
+      if (typeof postedBody !== "string" || !postedBody.includes(marker)) {
+        return yield* new GitHubRequestError({
+          message: `GitHub did not return a marked completion comment for ${issueRef}`,
+        })
+      }
+    }
+
+    if (issue.state === "CLOSED") {
+      return
+    }
+
+    if (client.mutation === undefined) {
+      return yield* new GitHubRequestError({
+        message: `GitHub GraphQL client does not support mutations for ${issueRef}`,
+      })
+    }
+    const mutate = client.mutation
+    const closeResult = yield* githubRequest(
+      `Failed to close Issue ${issueRef}`,
+      (signal) =>
+        mutate(
+          {
+            closeIssue: {
+              __args: {
+                input: {
+                  issueId: issue.id,
+                  stateReason: "COMPLETED",
+                },
+              },
+              issue: {
+                state: true,
+              },
+            },
+          },
+          signal,
+        ),
+    )
+    const closedIssue = closeResult.closeIssue?.issue
+    if (closedIssue === null || closedIssue === undefined) {
+      return yield* new GitHubRequestError({
+        message: `GitHub did not return an Issue after closing ${issueRef}`,
+      })
+    }
+    if (closedIssue.state !== "CLOSED") {
+      return yield* new GitHubRequestError({
+        message: `Issue ${issueRef} is still open after close`,
+      })
+    }
+  }),
   listReadyIssues: Effect.fn("GitHubService.listReadyIssues")(
     function* (repository) {
       const issues: InternalReadyLabeledIssue[] = []

--- a/packages/github-service/src/lib/github-service-test.ts
+++ b/packages/github-service/src/lib/github-service-test.ts
@@ -50,6 +50,7 @@ export const makeGitHubServiceTest = (
     getPullRequestLifecycleStatus: () => Effect.succeed({ _tag: "open" }),
     markPullRequestReadyForReview: () => Effect.void,
     mergePullRequest: () => Effect.void,
+    ensureIssueCompletedWithSummary: () => Effect.void,
     listReadyIssues: (repository) => {
       const fixture = fixturesByRepository.get(repositoryKey(repository))
       if (fixture === undefined) {

--- a/packages/github-service/src/lib/github-service.ts
+++ b/packages/github-service/src/lib/github-service.ts
@@ -69,6 +69,20 @@ export interface GitHubServiceShape {
     void,
     GitHubRepositoryUnavailableError | GitHubRequestError
   >
+  /**
+   * Ensure a No-Change Outcome summary is posted once (hidden Work Item marker)
+   * and the Issue is closed with state reason COMPLETED. Idempotent across
+   * retries and already-closed Issues.
+   */
+  readonly ensureIssueCompletedWithSummary: (
+    repository: GitHubRepository,
+    issueNumber: number,
+    workItemId: string,
+    summaryMarkdown: string,
+  ) => Effect.Effect<
+    void,
+    GitHubRepositoryUnavailableError | GitHubRequestError
+  >
 }
 
 export class GitHubService extends Context.Service<

--- a/packages/github-service/test/github-service.spec.ts
+++ b/packages/github-service/test/github-service.spec.ts
@@ -1116,6 +1116,552 @@ describe("GitHubService live implementation", () => {
     }
   })
 
+  it("posts a marked completion summary and closes an open Issue as COMPLETED", async () => {
+    const mutations: unknown[] = []
+    const workItemId = "wi-01HXSQK2KG72RRYVWEQH4S83FK"
+    const summary = "## Findings\n\nNo repository changes were required."
+    const service = makeGitHubService({
+      query: (request) => {
+        const issueSelection = (
+          request as {
+            repository?: { issue?: { comments?: unknown } }
+          }
+        ).repository?.issue
+        if (issueSelection?.comments !== undefined) {
+          return Promise.resolve({
+            repository: {
+              issue: {
+                comments: {
+                  nodes: [{ body: "unrelated comment" }],
+                  pageInfo: { endCursor: null, hasNextPage: false },
+                },
+              },
+            },
+          }) as never
+        }
+        return Promise.resolve({
+          repository: {
+            issue: {
+              id: "I_kwDOOpen",
+              state: "OPEN",
+            },
+          },
+        }) as never
+      },
+      mutation: (request) => {
+        mutations.push(request)
+        if ((request as { addComment?: unknown }).addComment !== undefined) {
+          const body = (
+            request as {
+              addComment: { __args: { input: { body: string } } }
+            }
+          ).addComment.__args.input.body
+          return Promise.resolve({
+            addComment: {
+              commentEdge: { node: { body } },
+            },
+          }) as never
+        }
+        return Promise.resolve({
+          closeIssue: {
+            issue: { state: "CLOSED" },
+          },
+        }) as never
+      },
+    })
+
+    await Effect.runPromise(
+      service.ensureIssueCompletedWithSummary(
+        repository,
+        42,
+        workItemId,
+        summary,
+      ),
+    )
+
+    expect(mutations).toHaveLength(2)
+    expect(mutations[0]).toMatchObject({
+      addComment: {
+        __args: {
+          input: {
+            subjectId: "I_kwDOOpen",
+            body: expect.stringContaining(summary),
+          },
+        },
+      },
+    })
+    const postedBody = (
+      mutations[0] as {
+        addComment: { __args: { input: { body: string } } }
+      }
+    ).addComment.__args.input.body
+    expect(postedBody).toContain(
+      `<!-- ready-for-agent:work-item:${workItemId} -->`,
+    )
+    expect(mutations[1]).toMatchObject({
+      closeIssue: {
+        __args: {
+          input: {
+            issueId: "I_kwDOOpen",
+            stateReason: "COMPLETED",
+          },
+        },
+      },
+    })
+  })
+
+  it("reuses an existing marked comment without posting a duplicate", async () => {
+    const mutations: unknown[] = []
+    const workItemId = "wi-01HXSQK2KG72RRYVWEQH4S83FK"
+    const marker = `<!-- ready-for-agent:work-item:${workItemId} -->`
+    const service = makeGitHubService({
+      query: (request) => {
+        const issueSelection = (
+          request as {
+            repository?: { issue?: { comments?: unknown } }
+          }
+        ).repository?.issue
+        if (issueSelection?.comments !== undefined) {
+          return Promise.resolve({
+            repository: {
+              issue: {
+                comments: {
+                  nodes: [{ body: "noise" }, { body: `## Done\n\n${marker}` }],
+                  pageInfo: { endCursor: null, hasNextPage: false },
+                },
+              },
+            },
+          }) as never
+        }
+        return Promise.resolve({
+          repository: {
+            issue: {
+              id: "I_kwDOOpen",
+              state: "OPEN",
+            },
+          },
+        }) as never
+      },
+      mutation: (request) => {
+        mutations.push(request)
+        return Promise.resolve({
+          closeIssue: {
+            issue: { state: "CLOSED" },
+          },
+        }) as never
+      },
+    })
+
+    await Effect.runPromise(
+      service.ensureIssueCompletedWithSummary(
+        repository,
+        42,
+        workItemId,
+        "## Summary",
+      ),
+    )
+
+    expect(mutations).toHaveLength(1)
+    expect(mutations[0]).toMatchObject({
+      closeIssue: {
+        __args: {
+          input: {
+            issueId: "I_kwDOOpen",
+            stateReason: "COMPLETED",
+          },
+        },
+      },
+    })
+  })
+
+  it("finds a marked comment beyond the first comments page", async () => {
+    const mutations: unknown[] = []
+    const workItemId = "wi-01HXSQK2KG72RRYVWEQH4S83FK"
+    const marker = `<!-- ready-for-agent:work-item:${workItemId} -->`
+    let commentPages = 0
+    const service = makeGitHubService({
+      query: (request) => {
+        const issueSelection = (
+          request as {
+            repository?: {
+              issue?: {
+                comments?: { __args?: { after?: string } }
+              }
+            }
+          }
+        ).repository?.issue
+        if (issueSelection?.comments !== undefined) {
+          commentPages += 1
+          const after = issueSelection.comments.__args?.after
+          if (after === null || after === undefined) {
+            return Promise.resolve({
+              repository: {
+                issue: {
+                  comments: {
+                    nodes: [{ body: "page one only" }],
+                    pageInfo: { endCursor: "cursor-1", hasNextPage: true },
+                  },
+                },
+              },
+            }) as never
+          }
+          expect(after).toBe("cursor-1")
+          return Promise.resolve({
+            repository: {
+              issue: {
+                comments: {
+                  nodes: [{ body: `found on page two ${marker}` }],
+                  pageInfo: { endCursor: null, hasNextPage: false },
+                },
+              },
+            },
+          }) as never
+        }
+        return Promise.resolve({
+          repository: {
+            issue: {
+              id: "I_kwDOOpen",
+              state: "OPEN",
+            },
+          },
+        }) as never
+      },
+      mutation: (request) => {
+        mutations.push(request)
+        return Promise.resolve({
+          closeIssue: {
+            issue: { state: "CLOSED" },
+          },
+        }) as never
+      },
+    })
+
+    await Effect.runPromise(
+      service.ensureIssueCompletedWithSummary(
+        repository,
+        42,
+        workItemId,
+        "## Summary",
+      ),
+    )
+
+    expect(commentPages).toBe(2)
+    expect(mutations).toHaveLength(1)
+    expect(
+      (mutations[0] as { addComment?: unknown }).addComment,
+    ).toBeUndefined()
+  })
+
+  it("succeeds for an already-closed Issue after ensuring the summary", async () => {
+    const mutations: unknown[] = []
+    const workItemId = "wi-01HXSQK2KG72RRYVWEQH4S83FK"
+    const marker = `<!-- ready-for-agent:work-item:${workItemId} -->`
+    const service = makeGitHubService({
+      query: (request) => {
+        const issueSelection = (
+          request as {
+            repository?: { issue?: { comments?: unknown } }
+          }
+        ).repository?.issue
+        if (issueSelection?.comments !== undefined) {
+          return Promise.resolve({
+            repository: {
+              issue: {
+                comments: {
+                  nodes: [{ body: `## Already done\n\n${marker}` }],
+                  pageInfo: { endCursor: null, hasNextPage: false },
+                },
+              },
+            },
+          }) as never
+        }
+        return Promise.resolve({
+          repository: {
+            issue: {
+              id: "I_kwDOClosed",
+              state: "CLOSED",
+            },
+          },
+        }) as never
+      },
+      mutation: () => {
+        throw new Error("mutation should not run for an already-closed Issue")
+      },
+    })
+
+    await Effect.runPromise(
+      service.ensureIssueCompletedWithSummary(
+        repository,
+        42,
+        workItemId,
+        "## Summary",
+      ),
+    )
+    expect(mutations).toHaveLength(0)
+  })
+
+  it("posts a missing marked summary on an already-closed Issue without re-closing", async () => {
+    const mutations: unknown[] = []
+    const workItemId = "wi-01HXSQK2KG72RRYVWEQH4S83FK"
+    const service = makeGitHubService({
+      query: (request) => {
+        const issueSelection = (
+          request as {
+            repository?: { issue?: { comments?: unknown } }
+          }
+        ).repository?.issue
+        if (issueSelection?.comments !== undefined) {
+          return Promise.resolve({
+            repository: {
+              issue: {
+                comments: {
+                  nodes: [],
+                  pageInfo: { endCursor: null, hasNextPage: false },
+                },
+              },
+            },
+          }) as never
+        }
+        return Promise.resolve({
+          repository: {
+            issue: {
+              id: "I_kwDOClosed",
+              state: "CLOSED",
+            },
+          },
+        }) as never
+      },
+      mutation: (request) => {
+        mutations.push(request)
+        const body = (
+          request as {
+            addComment: { __args: { input: { body: string } } }
+          }
+        ).addComment.__args.input.body
+        return Promise.resolve({
+          addComment: {
+            commentEdge: { node: { body } },
+          },
+        }) as never
+      },
+    })
+
+    await Effect.runPromise(
+      service.ensureIssueCompletedWithSummary(
+        repository,
+        42,
+        workItemId,
+        "## Late summary",
+      ),
+    )
+
+    expect(mutations).toHaveLength(1)
+    expect(mutations[0]).toMatchObject({
+      addComment: {
+        __args: {
+          input: {
+            subjectId: "I_kwDOClosed",
+          },
+        },
+      },
+    })
+  })
+
+  it("retries after comment creation without posting a duplicate comment", async () => {
+    const workItemId = "wi-01HXSQK2KG72RRYVWEQH4S83FK"
+    const marker = `<!-- ready-for-agent:work-item:${workItemId} -->`
+    const summary = "## Findings"
+    let posted = false
+    const mutations: unknown[] = []
+
+    const makeClient = (
+      issueState: "OPEN" | "CLOSED",
+    ): GitHubGraphqlClient => ({
+      query: (request) => {
+        const issueSelection = (
+          request as {
+            repository?: { issue?: { comments?: unknown } }
+          }
+        ).repository?.issue
+        if (issueSelection?.comments !== undefined) {
+          return Promise.resolve({
+            repository: {
+              issue: {
+                comments: {
+                  nodes: posted
+                    ? [{ body: `${summary}\n\n${marker}` }]
+                    : [{ body: "unrelated" }],
+                  pageInfo: { endCursor: null, hasNextPage: false },
+                },
+              },
+            },
+          }) as never
+        }
+        return Promise.resolve({
+          repository: {
+            issue: {
+              id: "I_kwDOOpen",
+              state: issueState,
+            },
+          },
+        }) as never
+      },
+      mutation: (request) => {
+        mutations.push(request)
+        if ((request as { addComment?: unknown }).addComment !== undefined) {
+          posted = true
+          const body = (
+            request as {
+              addComment: { __args: { input: { body: string } } }
+            }
+          ).addComment.__args.input.body
+          return Promise.resolve({
+            addComment: {
+              commentEdge: { node: { body } },
+            },
+          }) as never
+        }
+        return Promise.reject(new Error("close failed"))
+      },
+    })
+
+    const first = makeGitHubService(makeClient("OPEN"))
+    await expect(
+      Effect.runPromise(
+        first.ensureIssueCompletedWithSummary(
+          repository,
+          42,
+          workItemId,
+          summary,
+        ),
+      ),
+    ).rejects.toBeInstanceOf(GitHubRequestError)
+
+    expect(mutations).toHaveLength(2)
+    expect((mutations[0] as { addComment?: unknown }).addComment).toBeDefined()
+    expect((mutations[1] as { closeIssue?: unknown }).closeIssue).toBeDefined()
+
+    mutations.length = 0
+    const second = makeGitHubService({
+      ...makeClient("OPEN"),
+      mutation: (request) => {
+        mutations.push(request)
+        return Promise.resolve({
+          closeIssue: {
+            issue: { state: "CLOSED" },
+          },
+        }) as never
+      },
+    })
+
+    await Effect.runPromise(
+      second.ensureIssueCompletedWithSummary(
+        repository,
+        42,
+        workItemId,
+        summary,
+      ),
+    )
+
+    expect(mutations).toHaveLength(1)
+    expect(
+      (mutations[0] as { addComment?: unknown }).addComment,
+    ).toBeUndefined()
+    expect(mutations[0]).toMatchObject({
+      closeIssue: {
+        __args: {
+          input: {
+            issueId: "I_kwDOOpen",
+            stateReason: "COMPLETED",
+          },
+        },
+      },
+    })
+  })
+
+  it("maps missing Issue and credential failures for completion", async () => {
+    const missing = makeGitHubService({
+      query: () =>
+        Promise.resolve({
+          repository: { issue: null },
+        }) as never,
+    })
+    const missingResult = await Effect.runPromise(
+      Effect.result(
+        missing.ensureIssueCompletedWithSummary(
+          repository,
+          99,
+          "wi-01HXSQK2KG72RRYVWEQH4S83FK",
+          "## Summary",
+        ),
+      ),
+    )
+    expect(Result.isFailure(missingResult)).toBe(true)
+    if (Result.isFailure(missingResult)) {
+      expect(missingResult.failure).toBeInstanceOf(GitHubRequestError)
+    }
+
+    const unavailable = makeGitHubService({
+      query: () => Promise.resolve({ repository: null }) as never,
+    })
+    const unavailableResult = await Effect.runPromise(
+      Effect.result(
+        unavailable.ensureIssueCompletedWithSummary(
+          repository,
+          99,
+          "wi-01HXSQK2KG72RRYVWEQH4S83FK",
+          "## Summary",
+        ),
+      ),
+    )
+    expect(unavailableResult).toEqual(
+      Result.fail(new GitHubRepositoryUnavailableError(repository)),
+    )
+
+    let mutationAttempts = 0
+    const failingMutation = makeGitHubService({
+      query: (request) => {
+        const issueSelection = (
+          request as {
+            repository?: { issue?: { comments?: unknown } }
+          }
+        ).repository?.issue
+        if (issueSelection?.comments !== undefined) {
+          return Promise.resolve({
+            repository: {
+              issue: {
+                comments: {
+                  nodes: [],
+                  pageInfo: { endCursor: null, hasNextPage: false },
+                },
+              },
+            },
+          }) as never
+        }
+        return Promise.resolve({
+          repository: {
+            issue: { id: "I_kwDOOpen", state: "OPEN" },
+          },
+        }) as never
+      },
+      mutation: () => {
+        mutationAttempts += 1
+        return Promise.reject(new Error("token rejected"))
+      },
+    })
+    await expect(
+      Effect.runPromise(
+        failingMutation.ensureIssueCompletedWithSummary(
+          repository,
+          42,
+          "wi-01HXSQK2KG72RRYVWEQH4S83FK",
+          "## Summary",
+        ),
+      ),
+    ).rejects.toBeInstanceOf(GitHubRequestError)
+    expect(mutationAttempts).toBe(1)
+  })
+
   it("does not merge a PR whose current head checks are not successful", async () => {
     const service = makeGitHubService({
       query: () =>

--- a/packages/graphql-api/src/lib/graphql-api.ts
+++ b/packages/graphql-api/src/lib/graphql-api.ts
@@ -336,7 +336,7 @@ const githubTokenCreationUrl = (repository: Repository) => {
   )
   url.searchParams.set("target_name", repository.githubOwner)
   url.searchParams.set("expires_in", "90")
-  url.searchParams.set("issues", "read")
+  url.searchParams.set("issues", "write")
   url.searchParams.set("contents", "write")
   url.searchParams.set("pull_requests", "write")
   // Actions + commit statuses help with CI visibility. Per-check CheckRun nodes

--- a/packages/graphql-api/test/graphql-api.test.ts
+++ b/packages/graphql-api/test/graphql-api.test.ts
@@ -574,7 +574,7 @@ describe("GraphQL API", () => {
     expect(creationUrl.searchParams.get("name")).toBe(
       `${repository.githubRepo} - ready-for-agent`,
     )
-    expect(creationUrl.searchParams.get("issues")).toBe("read")
+    expect(creationUrl.searchParams.get("issues")).toBe("write")
     expect(creationUrl.searchParams.get("contents")).toBe("write")
     expect(creationUrl.searchParams.get("pull_requests")).toBe("write")
     expect(creationUrl.searchParams.get("actions")).toBe("read")

--- a/packages/issue-reconciler/test/issue-reconciler.spec.ts
+++ b/packages/issue-reconciler/test/issue-reconciler.spec.ts
@@ -165,6 +165,7 @@ const makeGitHubLayer = (
       Effect.succeed({ _tag: "open" as const }),
     markPullRequestReadyForReview: () => Effect.void,
     mergePullRequest: () => Effect.void,
+    ensureIssueCompletedWithSummary: () => Effect.void,
     listReadyIssues: ({ owner, name }) => {
       actions.push(`github:${owner}/${name}`)
       return error ? Effect.fail(error) : Effect.succeed(issues)

--- a/packages/work-item-lifecycle/test/create-pr.spec.ts
+++ b/packages/work-item-lifecycle/test/create-pr.spec.ts
@@ -89,6 +89,7 @@ const stubGitHub = (
         Effect.succeed({ _tag: "open" as const }),
       markPullRequestReadyForReview: () => Effect.void,
       mergePullRequest: () => Effect.void,
+      ensureIssueCompletedWithSummary: () => Effect.void,
       listReadyIssues: () => Effect.succeed([]),
       ...overrides,
     }),

--- a/packages/work-item-lifecycle/test/mark-pr-ready-for-review.spec.ts
+++ b/packages/work-item-lifecycle/test/mark-pr-ready-for-review.spec.ts
@@ -54,6 +54,7 @@ describe("markPrReadyForReview", () => {
         return Effect.void
       },
       mergePullRequest: () => Effect.void,
+      ensureIssueCompletedWithSummary: () => Effect.void,
     } satisfies GitHubServiceShape)
 
     await Effect.runPromise(
@@ -82,6 +83,7 @@ describe("markPrReadyForReview", () => {
         Effect.succeed({ _tag: "open" as const }),
       markPullRequestReadyForReview: () => Effect.void,
       mergePullRequest: () => Effect.void,
+      ensureIssueCompletedWithSummary: () => Effect.void,
     } satisfies GitHubServiceShape)
 
     const exit = await Effect.runPromise(

--- a/packages/work-item-lifecycle/test/merge-pr.spec.ts
+++ b/packages/work-item-lifecycle/test/merge-pr.spec.ts
@@ -54,6 +54,7 @@ describe("mergePr", () => {
         requestedBranch = branch
         return Effect.void
       },
+      ensureIssueCompletedWithSummary: () => Effect.void,
     } satisfies GitHubServiceShape)
 
     await Effect.runPromise(
@@ -80,6 +81,7 @@ describe("mergePr", () => {
         Effect.succeed({ _tag: "open" as const }),
       markPullRequestReadyForReview: () => Effect.void,
       mergePullRequest: () => Effect.void,
+      ensureIssueCompletedWithSummary: () => Effect.void,
     } satisfies GitHubServiceShape)
 
     const exit = await Effect.runPromise(

--- a/packages/work-item-lifecycle/test/pr-status-checks.spec.ts
+++ b/packages/work-item-lifecycle/test/pr-status-checks.spec.ts
@@ -91,6 +91,7 @@ const githubWith = (
       Effect.succeed({ _tag: "open" as const }),
     markPullRequestReadyForReview: () => Effect.void,
     mergePullRequest: () => Effect.void,
+    ensureIssueCompletedWithSummary: () => Effect.void,
     ...overrides,
   } satisfies GitHubServiceShape)
 
@@ -133,6 +134,7 @@ describe("PR status check steps", () => {
         Effect.succeed({ _tag: "open" as const }),
       markPullRequestReadyForReview: () => Effect.void,
       mergePullRequest: () => Effect.void,
+      ensureIssueCompletedWithSummary: () => Effect.void,
     } satisfies GitHubServiceShape)
 
     const status = await Effect.runPromise(
@@ -264,6 +266,7 @@ describe("PR status check steps", () => {
         Effect.succeed({ _tag: "open" as const }),
       markPullRequestReadyForReview: () => Effect.void,
       mergePullRequest: () => Effect.void,
+      ensureIssueCompletedWithSummary: () => Effect.void,
     } satisfies GitHubServiceShape)
 
     const result = await Effect.runPromise(
@@ -338,6 +341,7 @@ describe("PR status check steps", () => {
         Effect.succeed({ _tag: "open" as const }),
       markPullRequestReadyForReview: () => Effect.void,
       mergePullRequest: () => Effect.void,
+      ensureIssueCompletedWithSummary: () => Effect.void,
     } satisfies GitHubServiceShape)
 
     const second = await Effect.runPromise(

--- a/packages/work-item-lifecycle/test/sync-needs-human-merge-handoffs.spec.ts
+++ b/packages/work-item-lifecycle/test/sync-needs-human-merge-handoffs.spec.ts
@@ -59,6 +59,7 @@ describe("syncNeedsHumanMergeHandoffs", () => {
       getPullRequestLifecycleStatus: () => Effect.succeed(status),
       markPullRequestReadyForReview: () => Effect.void,
       mergePullRequest: () => Effect.void,
+      ensureIssueCompletedWithSummary: () => Effect.void,
     } satisfies GitHubServiceShape)
 
   const makeLayer = (status: PullRequestLifecycleStatus) =>


### PR DESCRIPTION
## Summary

- Add `GitHubService.ensureIssueCompletedWithSummary` to post a Work Item–marked completion comment once and close the Issue with `COMPLETED`
- Wire the operation through ambient/Keymaxxer GitHub layers and the helper process
- Request Issue write access when provisioning Repository credentials
- Cover lookup, pagination, marker reuse, closure, already-closed, retry, and error mapping in GraphQL contract tests

Closes #282

## Test plan

- [x] `bunx nx test github-service`
- [x] `bunx nx test graphql-api`
- [x] Pre-commit / affected lint, typecheck, and tests