### PR TITLE
feat(harness): present No-Change Outcomes in Jobs

### DIFF
--- a/apps/harness/src/routes/index.tsx
+++ b/apps/harness/src/routes/index.tsx
@@ -21,6 +21,8 @@ import { followRepositoryIssuesLive } from "../refresh-issues-live.js"
 import { followRepositoryWorkItemsLive } from "../refresh-work-items-live.js"
 import { streamRepositoryChanges } from "../repository-live.js"
 import { sessionWorktreeParts } from "../session-worktree-line.js"
+import { workItemIssueUrl } from "../work-item-issue-url.js"
+import { WorkItemOutcomePresentation } from "../work-item-outcome-presentation.js"
 import { workItemPullRequestUrl } from "../work-item-pull-request-url.js"
 
 const graphql = createClient({ url: "/graphql", batch: true })
@@ -1555,6 +1557,15 @@ function RepositoryIssueRow({
       {latestWorkItem !== undefined && (
         <WorkItemLifecycleStatus
           workItem={latestWorkItem}
+          issueUrl={
+            issue.url !== ""
+              ? issue.url
+              : workItemIssueUrl(
+                  repository.githubOwner,
+                  repository.githubRepo,
+                  latestWorkItem.githubIssueNumber,
+                )
+          }
           pullRequestUrl={workItemPullRequestUrl(
             repository.githubOwner,
             repository.githubRepo,
@@ -1727,7 +1738,16 @@ function JobsCard() {
                 `${workItem.repositoryId}:${workItem.githubIssueNumber}`,
               )
               const issueTitle = issue?.title
-              const issueUrl = issue?.url
+              const issueUrl =
+                issue?.url !== undefined && issue.url !== ""
+                  ? issue.url
+                  : repository === undefined
+                    ? null
+                    : workItemIssueUrl(
+                        repository.githubOwner,
+                        repository.githubRepo,
+                        workItem.githubIssueNumber,
+                      )
               const issueIdentity =
                 issueTitle === undefined
                   ? `#${workItem.githubIssueNumber}`
@@ -1756,7 +1776,7 @@ function JobsCard() {
                       <p className="m-0 truncate text-xs font-semibold text-slate-700">
                         {repositoryLabel}
                       </p>
-                      {issueUrl !== undefined && issueUrl !== "" ? (
+                      {issueUrl !== null && issueUrl !== "" ? (
                         <a
                           className="m-0 block truncate text-xs font-semibold text-blue-600 hover:underline"
                           href={issueUrl}
@@ -1806,6 +1826,7 @@ function JobsCard() {
                   <WorkItemLifecycleStatus
                     workItem={workItem}
                     compact
+                    issueUrl={issueUrl}
                     pullRequestUrl={
                       repository === undefined
                         ? null
@@ -1947,10 +1968,12 @@ function WorkItemLifecycleStatus({
   workItem,
   compact = false,
   pullRequestUrl = null,
+  issueUrl = null,
 }: {
   workItem: WorkItem
   compact?: boolean
   pullRequestUrl?: string | null
+  issueUrl?: string | null
 }) {
   const queryClient = useQueryClient()
   const status = workItem.status
@@ -2018,6 +2041,11 @@ function WorkItemLifecycleStatus({
   }`
   const openPullRequestLabel =
     prNumber === null ? null : `Open pull request #${prNumber}`
+  const isNoChangeComplete =
+    workItem.state === "COMPLETE" &&
+    prNumber === null &&
+    workItem.completionSummary !== null &&
+    workItem.completionSummary.trim() !== ""
 
   return (
     <div
@@ -2031,32 +2059,15 @@ function WorkItemLifecycleStatus({
         <span className="text-xs font-normal text-slate-500">
           {formatStartedAgo(workItem.createdAt, nowMs)}
         </span>
-        <span className="flex flex-wrap items-center justify-end gap-1">
-          {pullRequestUrl !== null && prNumber !== null && (
-            <a
-              className="rounded-full bg-slate-200 px-2 py-0.5 text-[0.6rem] font-bold tracking-wide text-slate-700 uppercase hover:bg-slate-300 hover:underline"
-              href={pullRequestUrl}
-              target="_blank"
-              rel="noopener noreferrer"
-              aria-label={openPullRequestLabel ?? undefined}
-            >
-              PR #{prNumber}
-            </a>
-          )}
-          {pullRequestUrl !== null && openPullRequestLabel !== null ? (
-            <a
-              className={`${statusBadgeClassName} hover:underline`}
-              href={pullRequestUrl}
-              target="_blank"
-              rel="noopener noreferrer"
-              aria-label={`${openPullRequestLabel}: ${workItem.statusLabel}`}
-            >
-              {workItem.statusLabel}
-            </a>
-          ) : (
-            <span className={statusBadgeClassName}>{workItem.statusLabel}</span>
-          )}
-        </span>
+        <WorkItemOutcomePresentation
+          state={workItem.state}
+          statusLabel={workItem.statusLabel}
+          statusBadgeClassName={statusBadgeClassName}
+          githubPullRequestNumber={workItem.githubPullRequestNumber}
+          pullRequestUrl={pullRequestUrl}
+          completionSummary={workItem.completionSummary}
+          issueUrl={issueUrl}
+        />
       </div>
       {workItem.lifecycleLabels.length > 0 && (
         <ol
@@ -2071,6 +2082,7 @@ function WorkItemLifecycleStatus({
               nowMs,
             )
             const linkToPullRequest =
+              !isNoChangeComplete &&
               pullRequestUrl !== null &&
               openPullRequestLabel !== null &&
               lifecycleLabel.phase === "DECIDE_PR_MERGE" &&

--- a/apps/harness/src/work-item-issue-url.ts
+++ b/apps/harness/src/work-item-issue-url.ts
@@ -1,0 +1,6 @@
+export const workItemIssueUrl = (
+  githubOwner: string,
+  githubRepo: string,
+  githubIssueNumber: number,
+): string =>
+  `https://github.com/${githubOwner}/${githubRepo}/issues/${githubIssueNumber}`

--- a/apps/harness/src/work-item-outcome-presentation.tsx
+++ b/apps/harness/src/work-item-outcome-presentation.tsx
@@ -1,0 +1,94 @@
+/**
+ * Presentational outcome chrome for a Work Item: PR links for changed work, or
+ * the distinct No-Change Outcome message, Issue link, and completion summary.
+ */
+export function WorkItemOutcomePresentation({
+  state,
+  statusLabel,
+  statusBadgeClassName,
+  githubPullRequestNumber,
+  pullRequestUrl,
+  completionSummary,
+  issueUrl,
+}: {
+  state: string
+  statusLabel: string
+  statusBadgeClassName: string
+  githubPullRequestNumber: number | null
+  pullRequestUrl: string | null
+  completionSummary: string | null
+  issueUrl: string | null
+}) {
+  const isNoChangeComplete =
+    state === "COMPLETE" &&
+    githubPullRequestNumber === null &&
+    completionSummary !== null &&
+    completionSummary.trim() !== ""
+  const prNumber = githubPullRequestNumber
+  const openPullRequestLabel =
+    prNumber === null ? null : `Open pull request #${prNumber}`
+  const summary = completionSummary?.trim() ?? ""
+
+  return (
+    <>
+      <span className="flex flex-wrap items-center justify-end gap-1">
+        {!isNoChangeComplete &&
+          pullRequestUrl !== null &&
+          prNumber !== null && (
+            <a
+              className="rounded-full bg-slate-200 px-2 py-0.5 text-[0.6rem] font-bold tracking-wide text-slate-700 uppercase hover:bg-slate-300 hover:underline"
+              href={pullRequestUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              aria-label={openPullRequestLabel ?? undefined}
+            >
+              PR #{prNumber}
+            </a>
+          )}
+        {!isNoChangeComplete &&
+        pullRequestUrl !== null &&
+        openPullRequestLabel !== null ? (
+          <a
+            className={`${statusBadgeClassName} hover:underline`}
+            href={pullRequestUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            aria-label={`${openPullRequestLabel}: ${statusLabel}`}
+          >
+            {statusLabel}
+          </a>
+        ) : (
+          <span className={statusBadgeClassName}>{statusLabel}</span>
+        )}
+      </span>
+      {isNoChangeComplete && (
+        <div className="mt-1.5 w-full basis-full">
+          {issueUrl !== null && issueUrl !== "" ? (
+            <a
+              className="m-0 text-xs font-semibold text-slate-700 underline decoration-slate-300 underline-offset-2 hover:text-blue-700"
+              href={issueUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Issue closed without repository changes
+            </a>
+          ) : (
+            <p className="m-0 text-xs font-semibold text-slate-700">
+              Issue closed without repository changes
+            </p>
+          )}
+          {summary !== "" && (
+            <section
+              className="mt-1.5 rounded-md border border-slate-200 bg-white px-2 py-1.5"
+              aria-label="Completion summary"
+            >
+              <p className="m-0 whitespace-pre-wrap text-xs text-slate-600">
+                {summary}
+              </p>
+            </section>
+          )}
+        </div>
+      )}
+    </>
+  )
+}

--- a/apps/harness/test/jobs-card-no-polling.test.ts
+++ b/apps/harness/test/jobs-card-no-polling.test.ts
@@ -68,21 +68,22 @@ describe("JobsCard live updates", () => {
     expect(jobsCard).toContain("href={issueUrl}")
     expect(jobsCard).toContain("text-blue-600 hover:underline")
     expect(jobsCard).not.toContain("hover:text-blue-700")
-    expect(jobsCard).toContain('issueUrl !== undefined && issueUrl !== ""')
+    expect(jobsCard).toContain("workItemIssueUrl(")
+    expect(jobsCard).toContain("issueUrl={issueUrl}")
   })
 
   test("links status badge and Decide PR merge handoff to Work Item PR", () => {
     const { source, jobsCard } = jobsCardSource()
     expect(source).toContain("githubPullRequestNumber: true")
     expect(source).toContain("workItemPullRequestUrl")
+    expect(source).toContain("WorkItemOutcomePresentation")
+    expect(source).toContain("completionSummary: true")
     expect(jobsCard).toContain("workItemPullRequestUrl(")
     expect(jobsCard).toContain("workItem.githubPullRequestNumber")
     expect(source).toContain('target="_blank"')
     expect(source).toContain('rel="noopener noreferrer"')
-    expect(source).toContain("Open pull request #")
     expect(source).toContain('lifecycleLabel.phase === "DECIDE_PR_MERGE"')
     expect(source).toContain('lifecycleLabel.status === "NEEDS_HUMAN"')
-    expect(source).toContain("PR #{prNumber}")
   })
 
   test("styles paused Needs human review like amber human handoff, not green Succeeded", () => {

--- a/apps/harness/test/work-item-issue-url.test.ts
+++ b/apps/harness/test/work-item-issue-url.test.ts
@@ -1,0 +1,10 @@
+import { workItemIssueUrl } from "../src/work-item-issue-url.js"
+import { describe, expect, test } from "bun:test"
+
+describe("workItemIssueUrl", () => {
+  test("builds GitHub Issue URL from repository identity and issue number", () => {
+    expect(workItemIssueUrl("acme", "widgets", 42)).toBe(
+      "https://github.com/acme/widgets/issues/42",
+    )
+  })
+})

--- a/apps/harness/test/work-item-outcome-presentation.test.tsx
+++ b/apps/harness/test/work-item-outcome-presentation.test.tsx
@@ -1,0 +1,73 @@
+import { renderToStaticMarkup } from "react-dom/server"
+import { WorkItemOutcomePresentation } from "../src/work-item-outcome-presentation.js"
+import { describe, expect, test } from "bun:test"
+
+const statusBadgeClassName =
+  "rounded-full px-2 py-0.5 text-[0.6rem] font-bold tracking-wide uppercase bg-green-100 text-green-700"
+
+describe("WorkItemOutcomePresentation", () => {
+  test("renders no-change completion message, Issue link, and summary", () => {
+    const html = renderToStaticMarkup(
+      <WorkItemOutcomePresentation
+        state="COMPLETE"
+        statusLabel="Complete"
+        statusBadgeClassName={statusBadgeClassName}
+        githubPullRequestNumber={null}
+        pullRequestUrl={null}
+        completionSummary={
+          "Investigated the question.\n\nFollow-up: https://github.com/acme/widgets/issues/9"
+        }
+        issueUrl="https://github.com/acme/widgets/issues/42"
+      />,
+    )
+
+    expect(html).toContain("Issue closed without repository changes")
+    expect(html).toContain('href="https://github.com/acme/widgets/issues/42"')
+    expect(html).toContain('aria-label="Completion summary"')
+    expect(html).toContain("Investigated the question.")
+    expect(html).toContain("https://github.com/acme/widgets/issues/9")
+    expect(html).toContain("Complete")
+    expect(html).not.toContain("PR #")
+    expect(html).not.toContain("Open pull request")
+    expect(html).not.toContain("missing")
+  })
+
+  test("keeps pull-request number, link, and status presentation for changed work", () => {
+    const html = renderToStaticMarkup(
+      <WorkItemOutcomePresentation
+        state="COMPLETE"
+        statusLabel="Complete"
+        statusBadgeClassName={statusBadgeClassName}
+        githubPullRequestNumber={17}
+        pullRequestUrl="https://github.com/acme/widgets/pull/17"
+        completionSummary={null}
+        issueUrl="https://github.com/acme/widgets/issues/3"
+      />,
+    )
+
+    expect(html).toContain("PR #17")
+    expect(html).toContain('href="https://github.com/acme/widgets/pull/17"')
+    expect(html).toContain("Open pull request #17")
+    expect(html).toContain("Complete")
+    expect(html).not.toContain("Issue closed without repository changes")
+    expect(html).not.toContain('aria-label="Completion summary"')
+  })
+
+  test("does not treat incomplete work without a PR as a No-Change Outcome", () => {
+    const html = renderToStaticMarkup(
+      <WorkItemOutcomePresentation
+        state="IMPLEMENT"
+        statusLabel="Running"
+        statusBadgeClassName="bg-blue-100 text-blue-700"
+        githubPullRequestNumber={null}
+        pullRequestUrl={null}
+        completionSummary={null}
+        issueUrl="https://github.com/acme/widgets/issues/3"
+      />,
+    )
+
+    expect(html).not.toContain("Issue closed without repository changes")
+    expect(html).not.toContain('aria-label="Completion summary"')
+    expect(html).toContain("Running")
+  })
+})

--- a/packages/work-item-lifecycle/test/count-committed-pull-requests.spec.ts
+++ b/packages/work-item-lifecycle/test/count-committed-pull-requests.spec.ts
@@ -238,6 +238,44 @@ describe("countCommittedPullRequests", () => {
       }),
     ))
 
+  it("does not count Complete No-Change Outcomes as committed pull requests", () =>
+    runTest(
+      Effect.gen(function* () {
+        const lifecycle = yield* WorkItemLifecycle
+        const sql = yield* SqlClient.SqlClient
+        yield* seedRepository("repo-a", now)
+        yield* sql.unsafe(
+          `INSERT INTO work_item (
+             id, repository_id, github_issue_number, github_pull_request_number,
+             model, variant, review_model, review_variant, state, state_ready_at,
+             worktree_path, session_id, failure_code, failure_message,
+             completion_summary, created_at, updated_at
+           ) VALUES (
+             'wi-no-change', 'repo-a', 7, NULL,
+             'm', 'v', 'm', 'v', 'complete', ?,
+             NULL, NULL, NULL, NULL,
+             'Findings posted on the Issue.', ?, ?
+           )`,
+          [now, now, now],
+        )
+        yield* sql.unsafe(
+          `INSERT INTO step_run (
+             id, work_item_id, step, status, queue_job_id, queued_at,
+             started_at, finished_at, reason_code, reason_message,
+             created_at, updated_at
+           ) VALUES (
+             'wi-no-change-close', 'wi-no-change', 'close_issue', 'succeeded',
+             NULL, ?, ?, ?, NULL, NULL, ?, ?
+           )`,
+          [now, midDay, midDay, now, now],
+        )
+
+        expect(
+          yield* lifecycle.countCommittedPullRequests(dayStart, dayEnd),
+        ).toBe(0)
+      }),
+    ))
+
   it("counts each Work Item at most once per day even with retry commits", () =>
     runTest(
       Effect.gen(function* () {


### PR DESCRIPTION
## Summary

- Present completed No-Change Outcomes in Jobs as `Issue closed without repository changes`, with a GitHub Issue link and the persisted completion summary in Work Item details.
- Keep changed-work PR number/link presentation and Working/Completed tab membership unchanged.
- Ensure committed-pull-request metrics still exclude No-Change Outcomes (no PR path).

## Test plan

- [x] Rendered UI tests for no-change completion, changed-work completion, Issue link, and summary
- [x] Jobs card wiring assertions for issue URL fallback and outcome presentation
- [x] `countCommittedPullRequests` excludes complete No-Change Outcomes
- [x] Pre-commit hooks (`lint` / `typecheck` / `test` affected projects)
- [ ] Manual smoke: complete No-Change Work Item appears under Completed with message, Issue link, and summary; changed Complete still shows PR

Closes #285