### PR TITLE
fix(release-versioning): stop install mode flips on bin scripts

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -138,6 +138,11 @@ bun --conditions @ready-for-agent/source \
   packages/release-versioning/src/bin/apply-publish-versions.ts 0.1.0 --for-publish
 ```
 
+Invoke these scripts via Nx targets or `bun … path/to/script.ts` only. Do not add a
+`package.json` `"bin"` entry for the TypeScript sources: Bun workspace linking
+chmods bin targets executable and leaves a mode-only dirty tree (`100644` →
+`100755`) after `bun install`.
+
 `--for-publish` also stages npm READMEs: the root product [README.md](README.md)
 into `apps/ready-for-agent/` (so the npm page is install/usage, not monorepo
 architecture notes), and a shared platform-binary stub into each

--- a/bun.lock
+++ b/bun.lock
@@ -260,10 +260,6 @@
     "packages/release-versioning": {
       "name": "@ready-for-agent/release-versioning",
       "version": "0.0.1",
-      "bin": {
-        "compute-next-version": "./src/bin/compute-next-version.ts",
-        "apply-publish-versions": "./src/bin/apply-publish-versions.ts",
-      },
       "dependencies": {
         "@conventional-changelog/git-client": "^3.1.0",
         "conventional-changelog-conventionalcommits": "^10.2.1",

--- a/packages/release-versioning/package.json
+++ b/packages/release-versioning/package.json
@@ -15,10 +15,6 @@
       "default": "./dist/index.js"
     }
   },
-  "bin": {
-    "compute-next-version": "./src/bin/compute-next-version.ts",
-    "apply-publish-versions": "./src/bin/apply-publish-versions.ts"
-  },
   "dependencies": {
     "@conventional-changelog/git-client": "^3.1.0",
     "conventional-changelog-conventionalcommits": "^10.2.1",


### PR DESCRIPTION
## Summary

- Remove unused `package.json` `bin` entries from `@ready-for-agent/release-versioning` so Bun workspace linking no longer chmods the TypeScript sources executable after install.
- Keep invoking the helpers via Nx targets / `bun … path/to/script.ts` only.
- Document the pitfall in `CONTRIBUTING.md` so the mode-only dirty tree does not regress.

Closes #297

## Test plan

- [x] `bun install --frozen-lock-file` leaves `packages/release-versioning/src/bin/*.ts` mode-clean (`100644`)
- [x] `bunx nx run release-versioning:test`
- [x] `bunx nx run release-versioning:compute-next-version`
- [ ] CI green on this PR