### PR TITLE
fix(harness): hide PR dashboard and Jobs with no repositories

### DIFF
--- a/apps/harness/e2e/steps/add-and-refresh-repository.ts
+++ b/apps/harness/e2e/steps/add-and-refresh-repository.ts
@@ -27,6 +27,14 @@ Given("the Harness has no configured Repositories", async ({ page }) => {
   await expect(
     page.getByRole("region", { name: "Configured repositories" }),
   ).toHaveCount(0)
+  await expect(
+    page.getByRole("region", { name: "Committed pull requests" }),
+  ).toHaveCount(0)
+  await expect(page.getByText("Today", { exact: true })).toHaveCount(0)
+  await expect(page.getByText("Yesterday", { exact: true })).toHaveCount(0)
+  await expect(page.getByRole("region", { name: "Jobs" })).toHaveCount(0)
+  await expect(page.getByRole("heading", { name: "Jobs" })).toHaveCount(0)
+  await expect(page.getByText("Add a repository to see jobs.")).toHaveCount(0)
 })
 
 Given("the End-to-End Fixture Repository is checked out", async ({ world }) => {

--- a/apps/harness/src/routes/index.tsx
+++ b/apps/harness/src/routes/index.tsx
@@ -330,6 +330,22 @@ function HomePage() {
           Clanker Harness
         </h1>
       </header>
+      <Suspense fallback={<RepositoryCardsSkeleton />}>
+        <HomeBody />
+      </Suspense>
+    </main>
+  )
+}
+
+function HomeBody() {
+  const { data: repositories } = useSuspenseQuery(repositoriesQuery)
+
+  if (repositories.length === 0) {
+    return <RepositoryCards />
+  }
+
+  return (
+    <>
       <section aria-label="Committed pull requests" className="mb-8">
         <CommittedPullRequestsDashboard />
       </section>
@@ -342,11 +358,9 @@ function HomePage() {
         </Suspense>
       </section>
       <div className="mt-8">
-        <Suspense fallback={<RepositoryCardsSkeleton />}>
-          <RepositoryCards />
-        </Suspense>
+        <RepositoryCards />
       </div>
-    </main>
+    </>
   )
 }
 

--- a/apps/harness/test/committed-pr-dashboard.test.ts
+++ b/apps/harness/test/committed-pr-dashboard.test.ts
@@ -68,13 +68,13 @@ describe("Committed pull requests dashboard UI", () => {
       "Could not load committed pull requests. Please try again.",
     )
     expect(source).toContain('role="alert"')
-    const homePage = source.slice(
-      source.indexOf("function HomePage()"),
+    const homeBody = source.slice(
+      source.indexOf("function HomeBody()"),
       source.indexOf("function CommittedPullRequestsDashboard()"),
     )
-    expect(homePage).toContain("<CommittedPullRequestsDashboard />")
-    expect(homePage).toContain("<JobsCard />")
-    expect(homePage).not.toContain("Suspense fallback={<Committed")
+    expect(homeBody).toContain("<CommittedPullRequestsDashboard />")
+    expect(homeBody).toContain("<JobsCard />")
+    expect(homeBody).not.toContain("Suspense fallback={<Committed")
   })
 
   test("displays zero counts rather than hiding the dashboard", () => {
@@ -87,5 +87,23 @@ describe("Committed pull requests dashboard UI", () => {
     expect(dashboard).toContain("yesterdayQuery.data ?? 0")
     expect(dashboard).toContain("{today}")
     expect(dashboard).toContain("{yesterday}")
+  })
+
+  test("hides PR dashboard and Jobs when no repositories are configured", () => {
+    const source = homeSource()
+    const homeBody = source.slice(
+      source.indexOf("function HomeBody()"),
+      source.indexOf("function CommittedPullRequestsDashboard()"),
+    )
+    expect(homeBody).toContain("repositories.length === 0")
+    expect(homeBody).toContain("return <RepositoryCards />")
+    const emptyBranch = homeBody.slice(
+      homeBody.indexOf("repositories.length === 0"),
+      homeBody.indexOf("return ("),
+    )
+    expect(emptyBranch).not.toContain("<CommittedPullRequestsDashboard")
+    expect(emptyBranch).not.toContain("<JobsCard")
+    expect(emptyBranch).not.toContain('aria-label="Committed pull requests"')
+    expect(emptyBranch).not.toContain('aria-label="Jobs"')
   })
 })


### PR DESCRIPTION
## Summary
- When the harness has zero configured repositories, the home page shows only the header and the existing “No repositories configured” empty state.
- Omit the committed-PR dashboard (Today/Yesterday) and the Jobs section until at least one repository is configured.
- Extend unit and e2e coverage for the zero-repo empty home.

Closes #292

## Test plan
- [x] `bunx nx test harness` (includes committed-PR dashboard unit coverage)
- [x] `bunx nx run harness:typecheck`
- [x] `bunx nx run harness:lint`
- [ ] Confirm empty home UI manually or via `bunx nx run harness:e2e` when fixture credentials are available