### PR TITLE
feat(harness): suggest npx when ready-for-agent is not on PATH

### DIFF
--- a/apps/harness/src/routes/index.tsx
+++ b/apps/harness/src/routes/index.tsx
@@ -89,6 +89,16 @@ const repositoriesQuery = {
   },
 }
 
+const addRepositoryCommandQuery = {
+  queryKey: ["addRepositoryCommand"],
+  staleTime: Number.POSITIVE_INFINITY,
+  gcTime: Number.POSITIVE_INFINITY,
+  queryFn: async () => {
+    const result = await graphql.query({ addRepositoryCommand: true })
+    return result.addRepositoryCommand
+  },
+}
+
 const issuesQuery = (repositoryId: string) => ({
   queryKey: ["issues", repositoryId],
   queryFn: async () => {
@@ -417,6 +427,9 @@ function CommittedPullRequestsDashboard() {
 function RepositoryCards() {
   const queryClient = useQueryClient()
   const { data: repositories } = useSuspenseQuery(repositoriesQuery)
+  const { data: addRepositoryCommand } = useSuspenseQuery(
+    addRepositoryCommandQuery,
+  )
   const [liveUpdatesUnavailable, setLiveUpdatesUnavailable] = useState(false)
   const [issuesChangeCounts, setIssuesChangeCounts] = useState<
     Readonly<Record<string, number>>
@@ -537,7 +550,7 @@ function RepositoryCards() {
             Add a local Git repository with the operator binary:
           </p>
           <code className="mt-3 inline-block rounded-md bg-slate-100 px-3 py-2 font-mono text-sm text-slate-800">
-            ready-for-agent add /path/to/local/repo
+            {addRepositoryCommand}
           </code>
         </div>
       </>

--- a/apps/harness/test/blank-slate-add-command.test.ts
+++ b/apps/harness/test/blank-slate-add-command.test.ts
@@ -1,0 +1,18 @@
+import { readFileSync } from "node:fs"
+import { join } from "node:path"
+import { describe, expect, test } from "bun:test"
+
+describe("blank-slate add repository command", () => {
+  test("loads suggested CLI from GraphQL and renders it in the empty state", () => {
+    const source = readFileSync(
+      join(import.meta.dir, "../src/routes/index.tsx"),
+      "utf8",
+    )
+    expect(source).toContain("addRepositoryCommand")
+    expect(source).toContain("addRepositoryCommandQuery")
+    expect(source).toContain("{addRepositoryCommand}")
+    expect(source).not.toContain(
+      "ready-for-agent add /path/to/local/repo\n          </code>",
+    )
+  })
+})

--- a/packages/graphql-api/src/index.ts
+++ b/packages/graphql-api/src/index.ts
@@ -1,2 +1,3 @@
+export * from "./lib/add-repository-command.js"
 export * from "./lib/graphql-api.js"
 export * from "./lib/issue-polling.js"

--- a/packages/graphql-api/src/lib/add-repository-command.ts
+++ b/packages/graphql-api/src/lib/add-repository-command.ts
@@ -1,10 +1,29 @@
-import { spawnSync } from "node:child_process"
+import { accessSync, constants } from "node:fs"
+import { delimiter, join } from "node:path"
 
 export const OPERATOR_BINARY = "ready-for-agent"
 export const ADD_REPOSITORY_PATH_PLACEHOLDER = "/path/to/local/repo"
 
-export const commandExistsOnPath = (command: string): boolean =>
-  spawnSync("which", [command], { encoding: "utf8" }).status === 0
+export const commandExistsOnPath = (
+  command: string,
+  pathEnv: string | undefined = process.env.PATH,
+): boolean => {
+  if (pathEnv === undefined || pathEnv.length === 0) {
+    return false
+  }
+  for (const directory of pathEnv.split(delimiter)) {
+    if (directory.length === 0) {
+      continue
+    }
+    try {
+      accessSync(join(directory, command), constants.X_OK)
+      return true
+    } catch {
+      // keep looking
+    }
+  }
+  return false
+}
 
 export const isOperatorBinaryOnPath = (
   commandExists: (command: string) => boolean,

--- a/packages/graphql-api/src/lib/add-repository-command.ts
+++ b/packages/graphql-api/src/lib/add-repository-command.ts
@@ -1,0 +1,27 @@
+import { spawnSync } from "node:child_process"
+
+export const OPERATOR_BINARY = "ready-for-agent"
+export const ADD_REPOSITORY_PATH_PLACEHOLDER = "/path/to/local/repo"
+
+export const commandExistsOnPath = (command: string): boolean =>
+  spawnSync("which", [command], { encoding: "utf8" }).status === 0
+
+export const isOperatorBinaryOnPath = (
+  commandExists: (command: string) => boolean,
+): boolean => commandExists(OPERATOR_BINARY)
+
+export const addRepositoryCommand = (options: {
+  readonly operatorBinaryOnPath: boolean
+}): string => {
+  const invocation = options.operatorBinaryOnPath
+    ? OPERATOR_BINARY
+    : `npx ${OPERATOR_BINARY}`
+  return `${invocation} add ${ADD_REPOSITORY_PATH_PLACEHOLDER}`
+}
+
+export const resolveAddRepositoryCommand = (
+  commandExists: (command: string) => boolean = commandExistsOnPath,
+): string =>
+  addRepositoryCommand({
+    operatorBinaryOnPath: isOperatorBinaryOnPath(commandExists),
+  })

--- a/packages/graphql-api/src/lib/graphql-api.ts
+++ b/packages/graphql-api/src/lib/graphql-api.ts
@@ -56,6 +56,10 @@ import {
   isTerminalWorkItemState,
 } from "@ready-for-agent/work-item-lifecycle"
 import {
+  commandExistsOnPath,
+  resolveAddRepositoryCommand,
+} from "./add-repository-command.js"
+import {
   activateRepositoryPolling,
   enqueueRefreshRepositoryJob,
   suspendRepositoryPolling,
@@ -558,9 +562,13 @@ const toNativeResponse = (response: unknown): Response => {
 
 export const createGraphqlApi = (
   runtime: GraphqlRuntime,
-  options: { readonly opencodeCwd?: string } = {},
+  options: {
+    readonly opencodeCwd?: string
+    readonly commandExists?: (command: string) => boolean
+  } = {},
 ) => {
   const opencodeCwd = options.opencodeCwd ?? process.cwd()
+  const commandExists = options.commandExists ?? commandExistsOnPath
   const tokenProvisioning = Effect.runSync(Semaphore.make(1))
   let modelsCache: ReadonlyArray<string> | null = null
   let modelsInFlight: Promise<ReadonlyArray<string>> | null = null
@@ -570,6 +578,8 @@ export const createGraphqlApi = (
       resolvers: {
         Query: {
           health: () => true,
+          addRepositoryCommand: () =>
+            resolveAddRepositoryCommand(commandExists),
           repositories: async () => {
             const result = await runtime.runPromise(
               Effect.result(

--- a/packages/graphql-api/test/add-repository-command.test.ts
+++ b/packages/graphql-api/test/add-repository-command.test.ts
@@ -1,0 +1,43 @@
+import {
+  addRepositoryCommand,
+  isOperatorBinaryOnPath,
+  resolveAddRepositoryCommand,
+} from "../src/lib/add-repository-command.js"
+import { describe, expect, test } from "bun:test"
+
+describe("addRepositoryCommand", () => {
+  test("suggests bare binary when on PATH", () => {
+    expect(addRepositoryCommand({ operatorBinaryOnPath: true })).toBe(
+      "ready-for-agent add /path/to/local/repo",
+    )
+  })
+
+  test("prepends npx when not on PATH", () => {
+    expect(addRepositoryCommand({ operatorBinaryOnPath: false })).toBe(
+      "npx ready-for-agent add /path/to/local/repo",
+    )
+  })
+})
+
+describe("isOperatorBinaryOnPath", () => {
+  test("is true when commandExists finds ready-for-agent", () => {
+    expect(
+      isOperatorBinaryOnPath((command) => command === "ready-for-agent"),
+    ).toBe(true)
+  })
+
+  test("is false when commandExists does not find ready-for-agent", () => {
+    expect(isOperatorBinaryOnPath(() => false)).toBe(false)
+  })
+})
+
+describe("resolveAddRepositoryCommand", () => {
+  test("uses PATH check to choose suggestion", () => {
+    expect(resolveAddRepositoryCommand(() => true)).toBe(
+      "ready-for-agent add /path/to/local/repo",
+    )
+    expect(resolveAddRepositoryCommand(() => false)).toBe(
+      "npx ready-for-agent add /path/to/local/repo",
+    )
+  })
+})

--- a/packages/graphql-api/test/graphql-api.test.ts
+++ b/packages/graphql-api/test/graphql-api.test.ts
@@ -277,6 +277,38 @@ describe("GraphQL API", () => {
     })
   })
 
+  test("suggests add repository command with npx when operator binary is not on PATH", async () => {
+    const response = await createGraphqlApi(runtime, {
+      commandExists: () => false,
+    }).fetch(
+      graphqlRequest({
+        query: `query { addRepositoryCommand }`,
+      }),
+    )
+
+    expect(await response.json()).toEqual({
+      data: {
+        addRepositoryCommand: "npx ready-for-agent add /path/to/local/repo",
+      },
+    })
+  })
+
+  test("suggests add repository command without npx when operator binary is on PATH", async () => {
+    const response = await createGraphqlApi(runtime, {
+      commandExists: (command) => command === "ready-for-agent",
+    }).fetch(
+      graphqlRequest({
+        query: `query { addRepositoryCommand }`,
+      }),
+    )
+
+    expect(await response.json()).toEqual({
+      data: {
+        addRepositoryCommand: "ready-for-agent add /path/to/local/repo",
+      },
+    })
+  })
+
   test("activates Issue Polling when adding a repository that already has a GitHub token", async () => {
     const ensured: Array<{
       queue: string

--- a/packages/graphql-schema/schema.graphql
+++ b/packages/graphql-schema/schema.graphql
@@ -1,5 +1,10 @@
 type Query {
   health: Boolean!
+  """
+  Suggested CLI to add a local repository from the blank-slate empty state.
+  Uses `ready-for-agent` when that binary is on PATH; otherwise `npx ready-for-agent`.
+  """
+  addRepositoryCommand: String!
   repositories: [Repository!]!
   repositoryCredentials: [RepositoryCredential!]!
   config: Config!


### PR DESCRIPTION
## Summary

- Blank-slate empty state checks whether `ready-for-agent` is on PATH.
- Suggests `ready-for-agent add /path/to/local/repo` when on PATH, otherwise `npx ready-for-agent add /path/to/local/repo`.
- Exposes the suggestion via GraphQL `addRepositoryCommand` for the harness UI.

Closes #293

## Test plan

- [x] Unit tests for PATH-based command selection
- [x] GraphQL API tests for both PATH present/absent
- [x] Harness blank-slate wiring test
- [x] Pre-commit / affected lint, typecheck, test