### PR TITLE
fix(lifecycle): terminal-fail Close Issue eligibility errors

### DIFF
--- a/packages/work-item-lifecycle/src/lib/work-item-lifecycle.ts
+++ b/packages/work-item-lifecycle/src/lib/work-item-lifecycle.ts
@@ -29,6 +29,7 @@ import {
   type JobNotFoundError,
   QueueService,
 } from "@ready-for-agent/queue-service"
+import { CloseIssueEligibilityError } from "./close-issue-errors.js"
 import {
   AbandonCleanupError,
   ActiveStepRunExistsError,
@@ -134,12 +135,40 @@ const handlerFailureMessage = (error: unknown): string => {
   return conciseMessage(error, "Lifecycle Step handler failed")
 }
 
+const closeIssueEligibilityFailure = (
+  cause: Cause.Cause<unknown>,
+): {
+  readonly failureCode: string
+  readonly failureMessage: string
+} | null => {
+  const errorOption = Cause.findErrorOption(cause)
+  if (Option.isNone(errorOption)) {
+    return null
+  }
+  const error = errorOption.value
+  if (error instanceof CloseIssueEligibilityError) {
+    return {
+      failureCode: error.failureCode,
+      failureMessage: error.message,
+    }
+  }
+  return null
+}
+
 const classifyHandlerFailure = (
   cause: Cause.Cause<unknown>,
 ): {
   readonly reasonCode: string
   readonly reasonMessage: string
 } => {
+  const eligibility = closeIssueEligibilityFailure(cause)
+  if (eligibility !== null) {
+    return {
+      reasonCode: eligibility.failureCode,
+      reasonMessage: eligibility.failureMessage,
+    }
+  }
+
   const errorOption = Cause.findErrorOption(cause)
   if (Option.isSome(errorOption)) {
     const error = errorOption.value
@@ -1683,10 +1712,20 @@ export const makeWorkItemLifecycleLive = (
         readonly reasonCode: string
         readonly reasonMessage: string
         readonly cause: Cause.Cause<unknown>
+        readonly terminalFailure?: {
+          readonly failureCode: string
+          readonly failureMessage: string
+        }
       }): Effect.Effect<WorkItemRecord, RunStepError> =>
         Effect.gen(function* () {
           const now = yield* Clock.currentTimeMillis
-          const { stepRun, workItem, reasonCode, reasonMessage } = input
+          const {
+            stepRun,
+            workItem,
+            reasonCode,
+            reasonMessage,
+            terminalFailure,
+          } = input
 
           yield* Effect.logError("Lifecycle Step handler failed", {
             workItemId: workItem.id,
@@ -1694,6 +1733,7 @@ export const makeWorkItemLifecycleLive = (
             step: stepRun.step,
             reasonCode,
             reasonMessage,
+            terminal: terminalFailure !== undefined,
           })
 
           yield* sql
@@ -1710,15 +1750,35 @@ export const makeWorkItemLifecycleLive = (
                   [now, reasonCode, reasonMessage, now, stepRun.id],
                 )
 
-                // Non-terminal failure releases the Worker Slot (no auto-wait).
-                yield* sql.unsafe(
-                  `UPDATE work_item
+                if (terminalFailure !== undefined) {
+                  yield* sql.unsafe(
+                    `UPDATE work_item
+                   SET state = 'failed',
+                       state_ready_at = ?,
+                       failure_code = ?,
+                       failure_message = ?,
+                       holds_worker_slot = 0,
+                       waiting_since = NULL,
+                       updated_at = ?
+                   WHERE id = ?`,
+                    [
+                      now,
+                      terminalFailure.failureCode,
+                      terminalFailure.failureMessage,
+                      now,
+                      workItem.id,
+                    ],
+                  )
+                } else {
+                  yield* sql.unsafe(
+                    `UPDATE work_item
                    SET holds_worker_slot = 0,
                        waiting_since = NULL,
                        updated_at = ?
                    WHERE id = ?`,
-                  [now, workItem.id],
-                )
+                    [now, workItem.id],
+                  )
+                }
 
                 if (stepRun.queue_job_id !== null) {
                   yield* queue.fail(stepRun.queue_job_id, {
@@ -2161,12 +2221,22 @@ export const makeWorkItemLifecycleLive = (
                       }
                     }
 
+                    const eligibility = closeIssueEligibilityFailure(
+                      handlerExit.cause,
+                    )
                     const failed = yield* completeFailedStep({
                       stepRun: afterStart,
                       workItem,
                       reasonCode: classification.reasonCode,
                       reasonMessage: classification.reasonMessage,
                       cause: handlerExit.cause,
+                      terminalFailure:
+                        eligibility === null
+                          ? undefined
+                          : {
+                              failureCode: eligibility.failureCode,
+                              failureMessage: eligibility.failureMessage,
+                            },
                     })
                     return { _tag: "processed" as const, workItem: failed }
                   }

--- a/packages/work-item-lifecycle/test/work-item-lifecycle.spec.ts
+++ b/packages/work-item-lifecycle/test/work-item-lifecycle.spec.ts
@@ -28,6 +28,7 @@ import { SqliteQueueServiceLive } from "@ready-for-agent/sqlite-queue-service"
 import {
   ActiveStepRunExistsError,
   BuildModelNotConfiguredError,
+  CloseIssueEligibilityError,
   CommitOpenCodeError,
   CreatePrOpenCodeError,
   IssueBlockedError,
@@ -49,6 +50,8 @@ import {
   WorkItemLifecycleLive,
   WorkItemNotFoundError,
   WorkItemTerminalError,
+  filterWorkItemsByListKind,
+  isTerminalWorkItemState,
   makeWorkItemLifecycleLive,
 } from "../src/index.js"
 import { describe, expect, it } from "bun:test"
@@ -2668,6 +2671,166 @@ describe("WorkItemLifecycle", () => {
           }
         }),
       ))
+
+    it("fails the Work Item terminally on Close Issue eligibility errors", () => {
+      const cases = [
+        {
+          name: "missing",
+          failureCode: "issue_not_found",
+          message: "Issue #42 is no longer present in the Issue store",
+        },
+        {
+          name: "parent",
+          failureCode: "issue_is_parent",
+          message: "Issue #42 has children and is no longer a Leaf Issue",
+        },
+        {
+          name: "blocked",
+          failureCode: "issue_blocked",
+          message: "Issue #42 is blocked by 1 Issue(s)",
+        },
+      ] as const
+
+      return Effect.runPromise(
+        Effect.gen(function* () {
+          for (const testCase of cases) {
+            const steps: LifecycleStepsShape = {
+              ...successfulSteps,
+              assessChanges: () =>
+                Effect.succeed({
+                  _tag: "no_changes",
+                  completionSummary: "Done without file changes",
+                }),
+              closeIssue: () =>
+                Effect.fail(
+                  new CloseIssueEligibilityError({
+                    workItemId: "unused",
+                    failureCode: testCase.failureCode,
+                    message: testCase.message,
+                  }),
+                ),
+            }
+
+            yield* Effect.gen(function* () {
+              const lifecycle = yield* WorkItemLifecycle
+              const { repository, issue } = yield* seedActionableIssue
+              const created = yield* lifecycle.implementNow(
+                repository.id,
+                issue.githubIssueNumber,
+              )
+              yield* claimAndRunPending
+              yield* claimAndRunPending
+              yield* claimAndRunPending
+              const afterAssess = yield* claimAndRunPending
+              expect(afterAssess._tag).toBe("processed")
+              if (afterAssess._tag !== "processed") {
+                return
+              }
+              expect(afterAssess.workItem.state).toBe("close_issue")
+
+              const failedClose = yield* claimAndRunPending
+              expect(failedClose._tag).toBe("processed")
+              if (failedClose._tag !== "processed") {
+                return
+              }
+              expect(failedClose.workItem.state).toBe("failed")
+              expect(failedClose.workItem.failureCode).toBe(
+                testCase.failureCode,
+              )
+              expect(failedClose.workItem.failureMessage).toBe(testCase.message)
+              expect(isTerminalWorkItemState(failedClose.workItem.state)).toBe(
+                true,
+              )
+              expect(failedClose.workItem.holdsWorkerSlot).toBe(false)
+              const closeRun = failedClose.workItem.stepRuns.at(-1)!
+              expect(closeRun.step).toBe("close_issue")
+              expect(closeRun.status).toBe("failed")
+              expect(closeRun.reasonCode).toBe(testCase.failureCode)
+              expect(closeRun.reasonMessage).toBe(testCase.message)
+
+              const listed = [afterAssess.workItem, failedClose.workItem]
+              expect(
+                filterWorkItemsByListKind(listed, "working").map(
+                  (item) => item.state,
+                ),
+              ).toEqual(["close_issue"])
+              expect(
+                filterWorkItemsByListKind(listed, "completed").map(
+                  (item) => item.state,
+                ),
+              ).toEqual(["failed"])
+
+              const retryError = yield* Effect.flip(lifecycle.retry(created.id))
+              expect(retryError).toBeInstanceOf(WorkItemTerminalError)
+            }).pipe(Effect.provide(makeTestLayer(steps)))
+          }
+        }),
+      )
+    })
+
+    it("keeps Close Issue retriable for non-eligibility handler failures", () => {
+      let closeAttempts = 0
+      const steps: LifecycleStepsShape = {
+        ...successfulSteps,
+        assessChanges: () =>
+          Effect.succeed({
+            _tag: "no_changes",
+            completionSummary: "Done without file changes",
+          }),
+        closeIssue: () =>
+          Effect.gen(function* () {
+            closeAttempts += 1
+            if (closeAttempts === 1) {
+              return yield* Effect.fail(new Error("GitHub temporary failure"))
+            }
+          }),
+      }
+
+      return runWithSteps(
+        steps,
+        Effect.gen(function* () {
+          const lifecycle = yield* WorkItemLifecycle
+          const { repository, issue } = yield* seedActionableIssue
+
+          const created = yield* lifecycle.implementNow(
+            repository.id,
+            issue.githubIssueNumber,
+          )
+          yield* claimAndRunPending
+          yield* claimAndRunPending
+          yield* claimAndRunPending
+          const afterAssess = yield* claimAndRunPending
+          expect(afterAssess._tag).toBe("processed")
+          if (afterAssess._tag !== "processed") {
+            return
+          }
+          expect(afterAssess.workItem.state).toBe("close_issue")
+
+          const failedClose = yield* claimAndRunPending
+          expect(failedClose._tag).toBe("processed")
+          if (failedClose._tag !== "processed") {
+            return
+          }
+          expect(failedClose.workItem.state).toBe("close_issue")
+          expect(failedClose.workItem.failureCode).toBeNull()
+          expect(isTerminalWorkItemState(failedClose.workItem.state)).toBe(
+            false,
+          )
+          expect(failedClose.workItem.stepRuns.at(-1)?.status).toBe("failed")
+          expect(failedClose.workItem.stepRuns.at(-1)?.reasonCode).toBe(
+            STEP_RUN_REASON.handlerFailed,
+          )
+
+          yield* lifecycle.retry(created.id)
+          const afterRetry = yield* claimAndRunPending
+          expect(afterRetry._tag).toBe("processed")
+          if (afterRetry._tag === "processed") {
+            expect(afterRetry.workItem.state).toBe("local_cleanup")
+          }
+          expect(closeAttempts).toBe(2)
+        }),
+      )
+    })
 
     it("returns noop for a Step Run that is not Queued matching the pending state", () =>
       runTest(


### PR DESCRIPTION
## Summary
- Treat `CloseIssueEligibilityError` (`issue_not_found`, `issue_is_parent`, `issue_blocked`) as a terminal Work Item failure instead of a retriable Step Run failure
- Persist eligibility `failureCode` / message on the Work Item and keep the Close Issue Step Run failed with the same outcome
- Leave non-eligibility Close Issue failures nonterminal and retriable

## Test plan
- [x] Lifecycle tests for eligibility terminal failure (missing/parent/blocked)
- [x] Lifecycle test that transient Close Issue failures remain retriable
- [x] `nx test work-item-lifecycle` / pre-commit affected lint, typecheck, test

Closes #312