### PR TITLE
feat(harness): add last-week count to committed PR dashboard

### DIFF
--- a/apps/harness/e2e/steps/add-and-refresh-repository.ts
+++ b/apps/harness/e2e/steps/add-and-refresh-repository.ts
@@ -32,6 +32,7 @@ Given("the Harness has no configured Repositories", async ({ page }) => {
   ).toHaveCount(0)
   await expect(page.getByText("Today", { exact: true })).toHaveCount(0)
   await expect(page.getByText("Yesterday", { exact: true })).toHaveCount(0)
+  await expect(page.getByText("Last week", { exact: true })).toHaveCount(0)
   await expect(page.getByRole("region", { name: "Jobs" })).toHaveCount(0)
   await expect(page.getByRole("heading", { name: "Jobs" })).toHaveCount(0)
   await expect(page.getByText("Add a repository to see jobs.")).toHaveCount(0)

--- a/apps/harness/src/local-day-bounds.ts
+++ b/apps/harness/src/local-day-bounds.ts
@@ -6,10 +6,14 @@ export const localCommittedPullRequestDayBounds = (now = new Date()) => {
   startOfTomorrow.setDate(startOfTomorrow.getDate() + 1)
   const startOfYesterday = new Date(startOfToday)
   startOfYesterday.setDate(startOfYesterday.getDate() - 1)
+  const startOfLastWeek = new Date(startOfToday)
+  startOfLastWeek.setDate(startOfLastWeek.getDate() - 7)
   return {
     todayFrom: startOfToday.toISOString(),
     todayTo: startOfTomorrow.toISOString(),
     yesterdayFrom: startOfYesterday.toISOString(),
     yesterdayTo: startOfToday.toISOString(),
+    lastWeekFrom: startOfLastWeek.toISOString(),
+    lastWeekTo: startOfToday.toISOString(),
   }
 }

--- a/apps/harness/src/routes/index.tsx
+++ b/apps/harness/src/routes/index.tsx
@@ -382,8 +382,13 @@ function CommittedPullRequestsDashboard() {
   const yesterdayQuery = useQuery(
     committedPullRequestsCountQuery(bounds.yesterdayFrom, bounds.yesterdayTo),
   )
-  const loading = todayQuery.isLoading || yesterdayQuery.isLoading
-  const failed = todayQuery.isError || yesterdayQuery.isError
+  const lastWeekQuery = useQuery(
+    committedPullRequestsCountQuery(bounds.lastWeekFrom, bounds.lastWeekTo),
+  )
+  const loading =
+    todayQuery.isLoading || yesterdayQuery.isLoading || lastWeekQuery.isLoading
+  const failed =
+    todayQuery.isError || yesterdayQuery.isError || lastWeekQuery.isError
 
   if (loading) {
     return (
@@ -393,7 +398,8 @@ function CommittedPullRequestsDashboard() {
         aria-label="Loading committed pull requests"
         aria-busy="true"
       >
-        <div className="grid grid-cols-2 gap-4">
+        <div className="grid grid-cols-3 gap-4">
+          <span className="block h-12 animate-pulse rounded-lg bg-slate-100 motion-reduce:animate-none" />
           <span className="block h-12 animate-pulse rounded-lg bg-slate-100 motion-reduce:animate-none" />
           <span className="block h-12 animate-pulse rounded-lg bg-slate-100 motion-reduce:animate-none" />
         </div>
@@ -413,10 +419,11 @@ function CommittedPullRequestsDashboard() {
 
   const today = todayQuery.data ?? 0
   const yesterday = yesterdayQuery.data ?? 0
+  const lastWeek = lastWeekQuery.data ?? 0
 
   return (
     <article className="rounded-[0.9rem] border border-[#dbe3ef] bg-white p-[1.35rem] shadow-[0_10px_30px_rgb(15_23_42_/_5%)]">
-      <div className="grid grid-cols-2 gap-4">
+      <div className="grid grid-cols-3 gap-4">
         <div>
           <p className="m-0 text-xs font-bold tracking-wide text-slate-500 uppercase">
             Today
@@ -431,6 +438,14 @@ function CommittedPullRequestsDashboard() {
           </p>
           <p className="mt-1 mb-0 text-2xl font-bold tracking-[-0.03em] text-slate-900 tabular-nums">
             {yesterday}
+          </p>
+        </div>
+        <div>
+          <p className="m-0 text-xs font-bold tracking-wide text-slate-500 uppercase">
+            Last week
+          </p>
+          <p className="mt-1 mb-0 text-2xl font-bold tracking-[-0.03em] text-slate-900 tabular-nums">
+            {lastWeek}
           </p>
         </div>
       </div>

--- a/apps/harness/test/committed-pr-dashboard.test.ts
+++ b/apps/harness/test/committed-pr-dashboard.test.ts
@@ -13,10 +13,13 @@ describe("localCommittedPullRequestDayBounds", () => {
     const todayStart = new Date(2026, 6, 18, 0, 0, 0, 0)
     const tomorrowStart = new Date(2026, 6, 19, 0, 0, 0, 0)
     const yesterdayStart = new Date(2026, 6, 17, 0, 0, 0, 0)
+    const lastWeekStart = new Date(2026, 6, 11, 0, 0, 0, 0)
     expect(bounds.todayFrom).toBe(todayStart.toISOString())
     expect(bounds.todayTo).toBe(tomorrowStart.toISOString())
     expect(bounds.yesterdayFrom).toBe(yesterdayStart.toISOString())
     expect(bounds.yesterdayTo).toBe(todayStart.toISOString())
+    expect(bounds.lastWeekFrom).toBe(lastWeekStart.toISOString())
+    expect(bounds.lastWeekTo).toBe(todayStart.toISOString())
   })
 
   test("handles month and year transitions", () => {
@@ -29,11 +32,65 @@ describe("localCommittedPullRequestDayBounds", () => {
       new Date(2026, 0, 1, 0, 0, 0, 0).toISOString(),
     )
     expect(bounds.todayTo).toBe(new Date(2026, 0, 2, 0, 0, 0, 0).toISOString())
+    expect(bounds.lastWeekFrom).toBe(
+      new Date(2025, 11, 25, 0, 0, 0, 0).toISOString(),
+    )
+    expect(bounds.lastWeekTo).toBe(
+      new Date(2026, 0, 1, 0, 0, 0, 0).toISOString(),
+    )
+  })
+
+  test("last week spans seven complete local days before today", () => {
+    const now = new Date(2026, 2, 15, 12, 0, 0, 0)
+    const bounds = localCommittedPullRequestDayBounds(now)
+    const lastWeekFrom = new Date(bounds.lastWeekFrom)
+    const lastWeekTo = new Date(bounds.lastWeekTo)
+    const todayFrom = new Date(bounds.todayFrom)
+    expect(lastWeekTo.getTime()).toBe(todayFrom.getTime())
+    expect(bounds.yesterdayFrom >= bounds.lastWeekFrom).toBe(true)
+    expect(bounds.yesterdayTo <= bounds.lastWeekTo).toBe(true)
+    const msPerDay = 24 * 60 * 60 * 1000
+    expect(
+      (lastWeekTo.getTime() - lastWeekFrom.getTime()) / msPerDay,
+    ).toBeCloseTo(7, 5)
+  })
+
+  test("handles spring-forward daylight-saving local midnight", () => {
+    // US Pacific 2026: clocks spring forward 2026-03-08 02:00 → 03:00
+    const afterSpringForward = new Date(2026, 2, 9, 10, 0, 0, 0)
+    const bounds = localCommittedPullRequestDayBounds(afterSpringForward)
+    expect(bounds.lastWeekFrom).toBe(
+      new Date(2026, 2, 2, 0, 0, 0, 0).toISOString(),
+    )
+    expect(bounds.lastWeekTo).toBe(
+      new Date(2026, 2, 9, 0, 0, 0, 0).toISOString(),
+    )
+    expect(bounds.yesterdayFrom).toBe(
+      new Date(2026, 2, 8, 0, 0, 0, 0).toISOString(),
+    )
+    expect(bounds.todayFrom).toBe(
+      new Date(2026, 2, 9, 0, 0, 0, 0).toISOString(),
+    )
+  })
+
+  test("handles fall-back daylight-saving local midnight", () => {
+    // US Pacific 2026: clocks fall back 2026-11-01 02:00 → 01:00
+    const afterFallBack = new Date(2026, 10, 2, 10, 0, 0, 0)
+    const bounds = localCommittedPullRequestDayBounds(afterFallBack)
+    expect(bounds.lastWeekFrom).toBe(
+      new Date(2026, 9, 26, 0, 0, 0, 0).toISOString(),
+    )
+    expect(bounds.lastWeekTo).toBe(
+      new Date(2026, 10, 2, 0, 0, 0, 0).toISOString(),
+    )
+    expect(bounds.yesterdayFrom).toBe(
+      new Date(2026, 10, 1, 0, 0, 0, 0).toISOString(),
+    )
   })
 })
 
 describe("Committed pull requests dashboard UI", () => {
-  test("renders above the Jobs card with Today and Yesterday labels", () => {
+  test("renders above the Jobs card with Today, Yesterday, and Last week labels", () => {
     const source = homeSource()
     const dashboardIndex = source.indexOf(
       'aria-label="Committed pull requests"',
@@ -43,6 +100,7 @@ describe("Committed pull requests dashboard UI", () => {
     expect(jobsIndex).toBeGreaterThan(dashboardIndex)
     expect(source).toContain("Today")
     expect(source).toContain("Yesterday")
+    expect(source).toContain("Last week")
     expect(source).toContain("function CommittedPullRequestsDashboard()")
   })
 
@@ -55,6 +113,8 @@ describe("Committed pull requests dashboard UI", () => {
       source.indexOf("function CommittedPullRequestsDashboard()"),
       source.indexOf("function RepositoryCards()"),
     )
+    expect(dashboard).toContain("bounds.lastWeekFrom")
+    expect(dashboard).toContain("bounds.lastWeekTo")
     expect(dashboard).not.toContain("workItems")
     expect(dashboard).not.toContain("JOBS_COMPLETED_LIMIT")
   })
@@ -64,6 +124,7 @@ describe("Committed pull requests dashboard UI", () => {
     expect(source).toContain('aria-label="Loading committed pull requests"')
     expect(source).toContain('role="status"')
     expect(source).toContain('aria-busy="true"')
+    expect(source).toContain("grid-cols-3")
     expect(source).toContain(
       "Could not load committed pull requests. Please try again.",
     )
@@ -77,6 +138,18 @@ describe("Committed pull requests dashboard UI", () => {
     expect(homeBody).not.toContain("Suspense fallback={<Committed")
   })
 
+  test("waits for all three counts before leaving the loading state", () => {
+    const source = homeSource()
+    const dashboard = source.slice(
+      source.indexOf("function CommittedPullRequestsDashboard()"),
+      source.indexOf("function RepositoryCards()"),
+    )
+    expect(dashboard).toContain("lastWeekQuery.isLoading")
+    expect(dashboard).toContain("lastWeekQuery.isError")
+    expect(dashboard).toContain("todayQuery.isLoading")
+    expect(dashboard).toContain("yesterdayQuery.isLoading")
+  })
+
   test("displays zero counts rather than hiding the dashboard", () => {
     const source = homeSource()
     const dashboard = source.slice(
@@ -85,8 +158,10 @@ describe("Committed pull requests dashboard UI", () => {
     )
     expect(dashboard).toContain("todayQuery.data ?? 0")
     expect(dashboard).toContain("yesterdayQuery.data ?? 0")
+    expect(dashboard).toContain("lastWeekQuery.data ?? 0")
     expect(dashboard).toContain("{today}")
     expect(dashboard).toContain("{yesterday}")
+    expect(dashboard).toContain("{lastWeek}")
   })
 
   test("hides PR dashboard and Jobs when no repositories are configured", () => {


### PR DESCRIPTION
## Summary

- Add a **Last week** count to the committed pull-request dashboard (seven complete local calendar days before Today).
- Wire the third value through the existing `committedPullRequestsCount` aggregate with browser-local ISO bounds.
- Extend unit/e2e coverage for bounds, three-value loading/error/zero UI, and the no-repositories empty state.

Closes #316

## Test plan

- [x] `bun test test/committed-pr-dashboard.test.ts` (bounds + UI source assertions)
- [x] Pre-commit affected lint/typecheck/test
- [ ] Spot-check Harness home dashboard with repositories configured: Today, Yesterday, Last week visible
- [ ] Confirm empty Last week shows `0` and loading/error states still leave Jobs usable