### PR TITLE
refactor(graphql-api): improve Effect boundary and module split

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -155,9 +155,7 @@
       "version": "0.0.1",
       "dependencies": {
         "@ready-for-agent/db-service": "workspace:*",
-        "@ready-for-agent/github-service": "workspace:*",
         "@ready-for-agent/graphql-schema": "workspace:*",
-        "@ready-for-agent/issue-reconciler": "workspace:*",
         "@ready-for-agent/keymaxxer-service": "workspace:*",
         "@ready-for-agent/opencode": "workspace:*",
         "@ready-for-agent/queue-service": "workspace:*",

--- a/packages/graphql-api/package.json
+++ b/packages/graphql-api/package.json
@@ -17,9 +17,7 @@
   },
   "dependencies": {
     "@ready-for-agent/db-service": "workspace:*",
-    "@ready-for-agent/github-service": "workspace:*",
     "@ready-for-agent/graphql-schema": "workspace:*",
-    "@ready-for-agent/issue-reconciler": "workspace:*",
     "@ready-for-agent/keymaxxer-service": "workspace:*",
     "@ready-for-agent/opencode": "workspace:*",
     "@ready-for-agent/queue-service": "workspace:*",

--- a/packages/graphql-api/src/lib/graphql-api.ts
+++ b/packages/graphql-api/src/lib/graphql-api.ts
@@ -1,56 +1,22 @@
 import {
-  Data,
   Effect,
   type ManagedRuntime,
+  Ref,
   Result,
   Semaphore,
   Stream,
 } from "effect"
 import { GraphQLError } from "graphql"
 import { createSchema, createYoga } from "graphql-yoga"
-import {
-  DatabaseError,
-  DbService,
-  InvalidConfigInputError,
-  InvalidRepositoryInputError,
-  InvalidRepositorySettingsError,
-  type IssueRecord,
-  LocalPathInUseError,
-  RepositoryAlreadyExistsError,
-  RepositoryNotFoundError,
-} from "@ready-for-agent/db-service"
-import {
-  GitHubRepositoryUnavailableError,
-  GitHubRequestError,
-} from "@ready-for-agent/github-service"
+import { DbService, RepositoryNotFoundError } from "@ready-for-agent/db-service"
 import { typeDefs } from "@ready-for-agent/graphql-schema"
-import {
-  type IssueReconciler,
-  ReconciliationMutationError,
-} from "@ready-for-agent/issue-reconciler"
 import { KeymaxxerService } from "@ready-for-agent/keymaxxer-service"
 import { Opencode } from "@ready-for-agent/opencode"
-import { EnqueueError, type QueueService } from "@ready-for-agent/queue-service"
+import type { QueueService } from "@ready-for-agent/queue-service"
 import {
-  AbandonCleanupError,
-  ActiveStepRunExistsError,
-  BuildModelNotConfiguredError,
-  IssueBlockedError,
-  IssueNotFoundError,
-  IssueNotOpenError,
-  type OperationalLifecycleStep,
-  ParentIssueError,
-  ResetCleanupError,
-  RetryNotEligibleError,
-  STEP_RUN_REASON,
-  type StepRunRecord,
-  UnfinishedWorkItemExistsError,
   WAITING_FOR_WORKER_SLOT_MESSAGE,
   WorkItemLifecycle,
-  WorkItemLifecycleDatabaseError,
-  WorkItemNotFoundError,
   type WorkItemRecord,
-  WorkItemTerminalError,
   type WorkItemsListKind,
   filterWorkItemsByListKind,
   isTerminalWorkItemState,
@@ -64,6 +30,21 @@ import {
   enqueueRefreshRepositoryJob,
   suspendRepositoryPolling,
 } from "./issue-polling.js"
+import {
+  RepositoryCredentialError,
+  activatePollingIfCredentialed,
+  githubTokenSecretName,
+  repositoryCredential,
+} from "./repository-credentials.js"
+import { toGraphQLError } from "./to-graphql-error.js"
+import {
+  latestStepRun,
+  lifecycleLabels,
+  statusLabel,
+  workIssueProjection,
+  workItemStateLabel,
+  workItemStatus,
+} from "./work-item-projection.js"
 
 type AddRepositoryArgs = {
   input: {
@@ -153,397 +134,17 @@ type WorkItemArgs = {
 
 type ResetWorkItemArgs = WorkItemArgs
 
-const childIssueCategory = (issue: IssueRecord): number => {
-  if (issue.state === "CLOSED") return 2
-  return issue.blockedBy.length === 0 ? 0 : 1
-}
-
-const compareChildIssues = (left: IssueRecord, right: IssueRecord): number =>
-  childIssueCategory(left) - childIssueCategory(right) ||
-  (left.parentPosition ?? Number.MAX_SAFE_INTEGER) -
-    (right.parentPosition ?? Number.MAX_SAFE_INTEGER) ||
-  left.githubIssueNumber - right.githubIssueNumber
-
-const workIssueProjection = (
-  issues: readonly IssueRecord[],
-): readonly IssueRecord[] => {
-  const childrenByParent = new Map<number, IssueRecord[]>()
-  for (const issue of issues) {
-    if (issue.parent === null) continue
-    const children = childrenByParent.get(issue.parent.githubIssueNumber) ?? []
-    children.push(issue)
-    childrenByParent.set(issue.parent.githubIssueNumber, children)
-  }
-
-  return issues
-    .filter((issue) => issue.parent === null)
-    .sort((left, right) => right.githubIssueNumber - left.githubIssueNumber)
-    .flatMap((issue) => {
-      if (!issue.hasChildren) return [issue]
-      const children = childrenByParent.get(issue.githubIssueNumber) ?? []
-      if (children.length === 0) return []
-      return [issue, ...children.sort(compareChildIssues)]
-    })
-}
-
-type WorkItemStatus =
-  | "queued"
-  | "running"
-  | "succeeded"
-  | "failed"
-  | "interrupted"
-  | "cancelled"
-  | "complete"
-  | "abandoned"
-  | "needs_human"
-  | "needs_human_review"
-  | "waiting_for_worker_slot"
-
-type LifecyclePhase =
-  | Exclude<
-      OperationalLifecycleStep,
-      "watch_pr_status_checks" | "investigate_pr_status_checks"
-    >
-  | "github_status_checks"
-
-const lifecyclePhase = (step: OperationalLifecycleStep): LifecyclePhase => {
-  if (
-    step === "watch_pr_status_checks" ||
-    step === "investigate_pr_status_checks"
-  ) {
-    return "github_status_checks"
-  }
-  return step
-}
-
-const lifecyclePhaseLabel = (phase: LifecyclePhase): string => {
-  switch (phase) {
-    case "implement":
-      return "Build"
-    case "assess_changes":
-      return "Assess changes"
-    case "close_issue":
-      return "Close issue"
-    case "resolve_pr_merge_conflict":
-      return "Resolve PR merge conflict"
-    case "github_status_checks":
-      return "GitHub status checks"
-    case "mark_pr_ready_for_review":
-      return "Mark PR ready for review"
-    case "decide_pr_merge":
-      return "Decide PR merge"
-    case "merge_pr":
-      return "Merge PR"
-    default:
-      return phase
-        .replaceAll("_", " ")
-        .replace(/^./, (first) => first.toUpperCase())
-  }
-}
-
-const statusLabel = (status: WorkItemStatus): string =>
-  status.replaceAll("_", " ").replace(/^./, (first) => first.toUpperCase())
-
-const latestStepRun = (workItem: WorkItemRecord): StepRunRecord | undefined =>
-  workItem.stepRuns.at(-1)
-
-/** Running Step Run blocked on maxConcurrentOpencodeSessions → operator Queued. */
-const isWaitingForOpencodeSession = (stepRun: StepRunRecord): boolean =>
-  stepRun.status === "running" &&
-  stepRun.reasonCode === STEP_RUN_REASON.waitingForOpencodeSession
-
-const stepRunDisplayStatus = (stepRun: StepRunRecord): WorkItemStatus =>
-  isWaitingForOpencodeSession(stepRun) ? "queued" : stepRun.status
-
-const workItemStatus = (workItem: WorkItemRecord): WorkItemStatus => {
-  if (workItem.waitingSince != null) return "waiting_for_worker_slot"
-  if (isTerminalWorkItemState(workItem.state)) return workItem.state
-  if (workItem.paused) return "needs_human_review"
-  const latest = latestStepRun(workItem)
-  if (latest === undefined) return "queued"
-  return stepRunDisplayStatus(latest)
-}
-
-const lifecycleLabels = (workItem: WorkItemRecord) => {
-  const latestRuns = new Map<LifecyclePhase, StepRunRecord>()
-  for (const stepRun of workItem.stepRuns) {
-    latestRuns.set(lifecyclePhase(stepRun.step), stepRun)
-  }
-  const finalStepRun = latestStepRun(workItem)
-  const finalPhase =
-    workItem.state === "needs_human" && finalStepRun !== undefined
-      ? lifecyclePhase(finalStepRun.step)
-      : null
-
-  return [...latestRuns].map(([phase, stepRun]) => {
-    const status: WorkItemStatus =
-      phase === finalPhase ? "needs_human" : stepRunDisplayStatus(stepRun)
-    const outcome =
-      phase === "decide_pr_merge" && status === "needs_human"
-        ? "Human review before merge"
-        : phase === "decide_pr_merge" && status === "succeeded"
-          ? "Clanker may merge"
-          : phase === "merge_pr" && status === "succeeded"
-            ? "Merged"
-            : statusLabel(status)
-    return {
-      phase: phase.toUpperCase(),
-      label: `${lifecyclePhaseLabel(phase)}: ${outcome}`,
-      status: status.toUpperCase(),
-      durationMs: stepRun.executionDurationMs,
-    }
-  })
-}
-
-export type GraphqlRuntime = ManagedRuntime.ManagedRuntime<
+export type GraphqlServices =
   | DbService
-  | IssueReconciler
   | KeymaxxerService
   | Opencode
   | QueueService
-  | WorkItemLifecycle,
+  | WorkItemLifecycle
+
+export type GraphqlRuntime = ManagedRuntime.ManagedRuntime<
+  GraphqlServices,
   unknown
 >
-
-type Repository = {
-  id: string
-  githubOwner: string
-  githubRepo: string
-}
-
-/** Activate durable Issue Polling only when a GitHub token is already configured. */
-const activatePollingIfCredentialed = (repository: Repository) =>
-  Effect.gen(function* () {
-    const keymaxxer = yield* KeymaxxerService
-    if (keymaxxer.enabled === false) {
-      yield* activateRepositoryPolling(repository.id)
-      return
-    }
-    const credential = yield* keymaxxer.findSecret({
-      provider: "github",
-      account: `${repository.githubOwner}/${repository.githubRepo}`,
-    })
-    if (credential === null) return
-    yield* activateRepositoryPolling(repository.id)
-  })
-
-class RepositoryCredentialError extends Data.TaggedError(
-  "RepositoryCredentialError",
-)<{ readonly message: string }> {}
-
-const githubTokenSecretName = (repository: Repository) =>
-  `GITHUB_TOKEN_${repository.githubOwner}_${repository.githubRepo}`
-    .replace(/[^A-Za-z0-9_]/g, "_")
-    .toUpperCase()
-
-const githubTokenCreationUrl = (repository: Repository) => {
-  const url = new URL("https://github.com/settings/personal-access-tokens/new")
-  url.searchParams.set("name", `${repository.githubRepo} - ready-for-agent`)
-  url.searchParams.set(
-    "description",
-    `Ready For Agent token for ${repository.githubOwner}/${repository.githubRepo}`,
-  )
-  url.searchParams.set("target_name", repository.githubOwner)
-  url.searchParams.set("expires_in", "90")
-  url.searchParams.set("issues", "write")
-  url.searchParams.set("contents", "write")
-  url.searchParams.set("pull_requests", "write")
-  // Actions + commit statuses help with CI visibility. Per-check CheckRun nodes
-  // need Checks API access, which fine-grained PATs cannot grant — see AGENTS.md.
-  url.searchParams.set("actions", "read")
-  url.searchParams.set("statuses", "read")
-  return url.toString()
-}
-
-const repositoryCredential = (
-  repository: Repository,
-  existingToken: string | null,
-  configured = existingToken !== null,
-) => ({
-  repositoryId: repository.id,
-  configured,
-  githubTokenSecretName: existingToken ?? githubTokenSecretName(repository),
-  githubTokenCreationUrl: githubTokenCreationUrl(repository),
-})
-
-const toGraphQLError = (error: unknown): GraphQLError => {
-  if (error instanceof IssueNotFoundError) {
-    return new GraphQLError(
-      `Issue #${error.githubIssueNumber} was not found in repository ${error.repositoryId}`,
-      { extensions: { code: "ISSUE_NOT_FOUND" } },
-    )
-  }
-  if (error instanceof IssueNotOpenError) {
-    return new GraphQLError(
-      `Issue #${error.githubIssueNumber} is ${error.state}, not OPEN`,
-      { extensions: { code: "ISSUE_NOT_OPEN" } },
-    )
-  }
-  if (error instanceof ParentIssueError) {
-    return new GraphQLError(
-      `Issue #${error.githubIssueNumber} has child issues and cannot be implemented directly`,
-      { extensions: { code: "ISSUE_IS_PARENT" } },
-    )
-  }
-  if (error instanceof IssueBlockedError) {
-    return new GraphQLError(
-      `Issue #${error.githubIssueNumber} is blocked by ${error.blockerCount} issue(s)`,
-      { extensions: { code: "ISSUE_BLOCKED" } },
-    )
-  }
-  if (error instanceof UnfinishedWorkItemExistsError) {
-    return new GraphQLError(
-      `Issue #${error.githubIssueNumber} already has an unfinished Work Item`,
-      {
-        extensions: {
-          code: "UNFINISHED_WORK_ITEM_EXISTS",
-          workItemId: error.workItemId,
-        },
-      },
-    )
-  }
-  if (error instanceof BuildModelNotConfiguredError) {
-    return new GraphQLError(error.message, {
-      extensions: { code: "BUILD_MODEL_NOT_CONFIGURED" },
-    })
-  }
-  if (error instanceof WorkItemLifecycleDatabaseError) {
-    return new GraphQLError(error.message, {
-      extensions: { code: "WORK_ITEM_LIFECYCLE_DATABASE_ERROR" },
-    })
-  }
-  if (error instanceof WorkItemNotFoundError) {
-    return new GraphQLError(`Work Item not found: ${error.workItemId}`, {
-      extensions: { code: "WORK_ITEM_NOT_FOUND" },
-    })
-  }
-  if (error instanceof WorkItemTerminalError) {
-    return new GraphQLError(
-      `Work Item ${error.workItemId} is already ${error.state}`,
-      { extensions: { code: "WORK_ITEM_TERMINAL" } },
-    )
-  }
-  if (error instanceof ActiveStepRunExistsError) {
-    return new GraphQLError(
-      `Work Item ${error.workItemId} already has an active Step Run`,
-      { extensions: { code: "ACTIVE_STEP_RUN_EXISTS" } },
-    )
-  }
-  if (error instanceof RetryNotEligibleError) {
-    return new GraphQLError(
-      `Work Item ${error.workItemId} cannot be retried: ${error.reason}`,
-      { extensions: { code: "RETRY_NOT_ELIGIBLE" } },
-    )
-  }
-  if (error instanceof RepositoryCredentialError) {
-    return new GraphQLError(error.message, {
-      extensions: { code: "REPOSITORY_CREDENTIAL_ERROR" },
-    })
-  }
-  if (error instanceof RepositoryAlreadyExistsError) {
-    return new GraphQLError(
-      `Repository ${error.githubOwner}/${error.githubRepo} already exists`,
-      {
-        extensions: { code: "REPOSITORY_ALREADY_EXISTS" },
-      },
-    )
-  }
-  if (error instanceof InvalidConfigInputError) {
-    return new GraphQLError(error.message, {
-      extensions: { code: "INVALID_CONFIG_INPUT", field: error.field },
-    })
-  }
-  if (error instanceof InvalidRepositorySettingsError) {
-    return new GraphQLError(error.message, {
-      extensions: {
-        code: "INVALID_REPOSITORY_SETTINGS",
-        field: error.field,
-      },
-    })
-  }
-  if (error instanceof LocalPathInUseError) {
-    return new GraphQLError(`Local path already in use: ${error.localPath}`, {
-      extensions: { code: "LOCAL_PATH_IN_USE" },
-    })
-  }
-  if (error instanceof InvalidRepositoryInputError) {
-    return new GraphQLError(error.message, {
-      extensions: { code: "INVALID_REPOSITORY_INPUT", field: error.field },
-    })
-  }
-  if (error instanceof RepositoryNotFoundError) {
-    return new GraphQLError(`Repository not found: ${error.repositoryId}`, {
-      extensions: { code: "REPOSITORY_NOT_FOUND" },
-    })
-  }
-  if (error instanceof GitHubRepositoryUnavailableError) {
-    return new GraphQLError(
-      `GitHub repository is unavailable: ${error.owner}/${error.name}`,
-      { extensions: { code: "GITHUB_REPOSITORY_UNAVAILABLE" } },
-    )
-  }
-  if (error instanceof GitHubRequestError) {
-    return new GraphQLError(error.message, {
-      extensions: { code: "GITHUB_REQUEST_ERROR" },
-    })
-  }
-  if (error instanceof ReconciliationMutationError) {
-    return new GraphQLError(
-      `Failed to ${error.operation} while refreshing repository`,
-      {
-        extensions: {
-          code: "REPOSITORY_REFRESH_FAILED",
-          operation: error.operation,
-          ...(error.githubIssueNumber === undefined
-            ? {}
-            : { githubIssueNumber: error.githubIssueNumber }),
-          progress: error.progress,
-        },
-      },
-    )
-  }
-  if (error instanceof DatabaseError) {
-    return new GraphQLError(error.message, {
-      extensions: { code: "DATABASE_ERROR" },
-    })
-  }
-  if (error instanceof EnqueueError) {
-    return new GraphQLError(error.message, {
-      extensions: { code: "ENQUEUE_ERROR" },
-    })
-  }
-  if (error instanceof WorkItemNotFoundError) {
-    return new GraphQLError(`Work Item not found: ${error.workItemId}`, {
-      extensions: { code: "WORK_ITEM_NOT_FOUND" },
-    })
-  }
-  if (error instanceof WorkItemLifecycleDatabaseError) {
-    return new GraphQLError(error.message, {
-      extensions: { code: "DATABASE_ERROR" },
-    })
-  }
-  if (error instanceof ResetCleanupError) {
-    return new GraphQLError(error.message, {
-      extensions: { code: "RESET_CLEANUP_FAILED" },
-    })
-  }
-  if (error instanceof AbandonCleanupError) {
-    return new GraphQLError(error.message, {
-      extensions: { code: "ABANDON_CLEANUP_FAILED" },
-    })
-  }
-  if (error instanceof GraphQLError) {
-    return error
-  }
-  if (error instanceof Error) {
-    return new GraphQLError(error.message, {
-      extensions: { code: "INTERNAL_SERVER_ERROR" },
-    })
-  }
-  return new GraphQLError("Unexpected error", {
-    extensions: { code: "INTERNAL_SERVER_ERROR" },
-  })
-}
 
 const isSameOriginRequest = (request: Request): boolean => {
   const origin = request.headers.get("origin")
@@ -571,8 +172,43 @@ export const createGraphqlApi = (
   const opencodeCwd = options.opencodeCwd ?? process.cwd()
   const commandExists = options.commandExists ?? commandExistsOnPath
   const tokenProvisioning = Effect.runSync(Semaphore.make(1))
-  let modelsCache: ReadonlyArray<string> | null = null
-  let modelsInFlight: Promise<ReadonlyArray<string>> | null = null
+  const modelsCache = Effect.runSync(
+    Ref.make<ReadonlyArray<string> | null>(null),
+  )
+  const modelsLock = Effect.runSync(Semaphore.make(1))
+
+  const runGraphql = <A>(
+    effect: Effect.Effect<A, unknown, GraphqlServices>,
+  ): Promise<A> =>
+    runtime.runPromise(Effect.result(effect)).then((result) => {
+      if (Result.isFailure(result)) {
+        throw toGraphQLError(result.failure)
+      }
+      return result.success
+    })
+
+  const listModels = Effect.fn("graphql-api.models")(function* () {
+    const cached = yield* Ref.get(modelsCache)
+    if (cached !== null) {
+      return cached
+    }
+    return yield* modelsLock.withPermits(1)(
+      Effect.gen(function* () {
+        const again = yield* Ref.get(modelsCache)
+        if (again !== null) {
+          return again
+        }
+        const opencode = yield* Opencode
+        const models = yield* opencode.listModels({
+          cwd: opencodeCwd,
+          timeout: "30 seconds",
+        })
+        yield* Ref.set(modelsCache, models)
+        return models
+      }),
+    )
+  })
+
   const yoga = createYoga({
     schema: createSchema({
       typeDefs,
@@ -581,149 +217,82 @@ export const createGraphqlApi = (
           health: () => true,
           addRepositoryCommand: () =>
             resolveAddRepositoryCommand(commandExists),
-          repositories: async () => {
-            const result = await runtime.runPromise(
-              Effect.result(
-                Effect.gen(function* () {
-                  const db = yield* DbService
-                  return yield* db.listRepositories
-                }),
-              ),
-            )
-            if (Result.isFailure(result)) {
-              throw toGraphQLError(result.failure)
-            }
-            return result.success
-          },
-          repositoryCredentials: async () => {
-            const result = await runtime.runPromise(
-              Effect.result(
-                Effect.gen(function* () {
-                  const db = yield* DbService
-                  const repositories = yield* db.listRepositories
-                  const keymaxxer = yield* KeymaxxerService
-                  const ambientAuthentication = keymaxxer.enabled === false
-                  const tokenNames = ambientAuthentication
-                    ? repositories.map(() => null)
-                    : yield* keymaxxer.findSecrets(
-                        repositories.map((repository) => ({
-                          provider: "github",
-                          account: `${repository.githubOwner}/${repository.githubRepo}`,
-                        })),
-                      )
-                  return repositories.map((repository, index) =>
-                    repositoryCredential(
-                      repository,
-                      tokenNames[index] ?? null,
-                      ambientAuthentication || tokenNames[index] != null,
-                    ),
-                  )
-                }),
-              ),
-            )
-            if (Result.isFailure(result)) {
-              throw toGraphQLError(result.failure)
-            }
-            return result.success
-          },
-          config: async () => {
-            const result = await runtime.runPromise(
-              Effect.result(
-                Effect.gen(function* () {
-                  const db = yield* DbService
-                  return yield* db.getConfig
-                }),
-              ),
-            )
-            if (Result.isFailure(result)) {
-              throw toGraphQLError(result.failure)
-            }
-            return result.success
-          },
-          models: async () => {
-            if (modelsCache !== null) {
-              return modelsCache
-            }
-            if (modelsInFlight !== null) {
-              return modelsInFlight
-            }
-            modelsInFlight = runtime
-              .runPromise(
-                Effect.result(
-                  Effect.gen(function* () {
-                    const opencode = yield* Opencode
-                    return yield* opencode.listModels({
-                      cwd: opencodeCwd,
-                      timeout: "30 seconds",
-                    })
-                  }),
-                ),
-              )
-              .then((result) => {
-                modelsInFlight = null
-                if (Result.isFailure(result)) {
-                  throw toGraphQLError(result.failure)
-                }
-                modelsCache = result.success
-                return result.success
-              })
-              .catch((error) => {
-                modelsInFlight = null
-                throw error
-              })
-            return modelsInFlight
-          },
-          issues: async (_parent: unknown, args: IssuesArgs) => {
-            const result = await runtime.runPromise(
-              Effect.result(
-                Effect.gen(function* () {
-                  const db = yield* DbService
-                  const issues = yield* db.listIssues(args.repositoryId)
-                  return workIssueProjection(issues)
-                }),
-              ),
-            )
-            if (Result.isFailure(result)) {
-              throw toGraphQLError(result.failure)
-            }
-            return result.success
-          },
-          workItems: async (_parent: unknown, args: WorkItemsArgs) => {
-            const result = await runtime.runPromise(
-              Effect.result(
-                Effect.gen(function* () {
-                  const lifecycle = yield* WorkItemLifecycle
-                  const listKind = toWorkItemsListKind(args.listKind)
-                  const limit = args.limit
-                  if (args.githubIssueNumber !== undefined) {
-                    const workItems = yield* lifecycle.listWorkItemsForIssue(
-                      args.repositoryId,
-                      args.githubIssueNumber,
+          repositories: async () =>
+            runGraphql(
+              Effect.gen(function* () {
+                const db = yield* DbService
+                return yield* db.listRepositories
+              }).pipe(Effect.withSpan("graphql-api.repositories")),
+            ),
+          repositoryCredentials: async () =>
+            runGraphql(
+              Effect.gen(function* () {
+                const db = yield* DbService
+                const repositories = yield* db.listRepositories
+                const keymaxxer = yield* KeymaxxerService
+                const ambientAuthentication = keymaxxer.enabled === false
+                const tokenNames = ambientAuthentication
+                  ? repositories.map(() => null)
+                  : yield* keymaxxer.findSecrets(
+                      repositories.map((repository) => ({
+                        provider: "github",
+                        account: `${repository.githubOwner}/${repository.githubRepo}`,
+                      })),
                     )
-                    return filterWorkItemsByListKind(workItems, listKind, limit)
-                  }
-                  const db = yield* DbService
-                  const [workItems, issues] = yield* Effect.all([
-                    lifecycle.listWorkItemsForRepository(args.repositoryId),
-                    db.listIssues(args.repositoryId),
-                  ])
-                  const relevantIssueNumbers = new Set(
-                    issues.map((issue) => issue.githubIssueNumber),
+                return repositories.map((repository, index) =>
+                  repositoryCredential(
+                    repository,
+                    tokenNames[index] ?? null,
+                    ambientAuthentication || tokenNames[index] != null,
+                  ),
+                )
+              }).pipe(Effect.withSpan("graphql-api.repositoryCredentials")),
+            ),
+          config: async () =>
+            runGraphql(
+              Effect.gen(function* () {
+                const db = yield* DbService
+                return yield* db.getConfig
+              }).pipe(Effect.withSpan("graphql-api.config")),
+            ),
+          models: async () => runGraphql(listModels()),
+          issues: async (_parent: unknown, args: IssuesArgs) =>
+            runGraphql(
+              Effect.gen(function* () {
+                const db = yield* DbService
+                const issues = yield* db.listIssues(args.repositoryId)
+                return workIssueProjection(issues)
+              }).pipe(Effect.withSpan("graphql-api.issues")),
+            ),
+          workItems: async (_parent: unknown, args: WorkItemsArgs) =>
+            runGraphql(
+              Effect.gen(function* () {
+                const lifecycle = yield* WorkItemLifecycle
+                const listKind = toWorkItemsListKind(args.listKind)
+                const limit = args.limit
+                if (args.githubIssueNumber !== undefined) {
+                  const workItems = yield* lifecycle.listWorkItemsForIssue(
+                    args.repositoryId,
+                    args.githubIssueNumber,
                   )
-                  const visible = workItems.filter(
-                    (workItem) =>
-                      !isTerminalWorkItemState(workItem.state) ||
-                      relevantIssueNumbers.has(workItem.githubIssueNumber),
-                  )
-                  return filterWorkItemsByListKind(visible, listKind, limit)
-                }),
-              ),
-            )
-            if (Result.isFailure(result)) {
-              throw toGraphQLError(result.failure)
-            }
-            return result.success
-          },
+                  return filterWorkItemsByListKind(workItems, listKind, limit)
+                }
+                const db = yield* DbService
+                const [workItems, issues] = yield* Effect.all([
+                  lifecycle.listWorkItemsForRepository(args.repositoryId),
+                  db.listIssues(args.repositoryId),
+                ])
+                const relevantIssueNumbers = new Set(
+                  issues.map((issue) => issue.githubIssueNumber),
+                )
+                const visible = workItems.filter(
+                  (workItem) =>
+                    !isTerminalWorkItemState(workItem.state) ||
+                    relevantIssueNumbers.has(workItem.githubIssueNumber),
+                )
+                return filterWorkItemsByListKind(visible, listKind, limit)
+              }).pipe(Effect.withSpan("graphql-api.workItems")),
+            ),
           committedPullRequestsCount: async (
             _parent: unknown,
             args: CommittedPullRequestsCountArgs,
@@ -738,21 +307,14 @@ export const createGraphqlApi = (
                 },
               )
             }
-            const result = await runtime.runPromise(
-              Effect.result(
-                Effect.gen(function* () {
-                  const lifecycle = yield* WorkItemLifecycle
-                  return yield* lifecycle.countCommittedPullRequests(
-                    fromMs,
-                    toMs,
-                  )
-                }),
+            return runGraphql(
+              Effect.gen(function* () {
+                const lifecycle = yield* WorkItemLifecycle
+                return yield* lifecycle.countCommittedPullRequests(fromMs, toMs)
+              }).pipe(
+                Effect.withSpan("graphql-api.committedPullRequestsCount"),
               ),
             )
-            if (Result.isFailure(result)) {
-              throw toGraphQLError(result.failure)
-            }
-            return result.success
           },
         },
         Issue: {
@@ -766,12 +328,8 @@ export const createGraphqlApi = (
         },
         WorkItem: {
           state: (workItem: { state: string }) => workItem.state.toUpperCase(),
-          stateLabel: (workItem: WorkItemRecord) => {
-            if (isTerminalWorkItemState(workItem.state)) {
-              return statusLabel(workItem.state)
-            }
-            return lifecyclePhaseLabel(lifecyclePhase(workItem.state))
-          },
+          stateLabel: (workItem: WorkItemRecord) =>
+            workItemStateLabel(workItem),
           status: (workItem: WorkItemRecord) =>
             workItemStatus(workItem).toUpperCase(),
           statusLabel: (workItem: WorkItemRecord) =>
@@ -804,19 +362,19 @@ export const createGraphqlApi = (
         Subscription: {
           repositoriesChanged: {
             subscribe: async () =>
-              runtime.runPromise(
+              runGraphql(
                 Effect.gen(function* () {
                   const db = yield* DbService
                   return yield* Stream.toAsyncIterableEffect(
                     db.repositoryChanges,
                   )
-                }),
+                }).pipe(Effect.withSpan("graphql-api.repositoriesChanged")),
               ),
             resolve: () => true,
           },
           issuesChanged: {
             subscribe: async (_parent: unknown, args: RefreshRepositoryArgs) =>
-              runtime.runPromise(
+              runGraphql(
                 Effect.gen(function* () {
                   const db = yield* DbService
                   return yield* Stream.toAsyncIterableEffect(
@@ -826,156 +384,123 @@ export const createGraphqlApi = (
                       ),
                     ),
                   )
-                }),
+                }).pipe(Effect.withSpan("graphql-api.issuesChanged")),
               ),
             resolve: () => true,
           },
           repositoryIssuesChanged: {
             subscribe: async () =>
-              runtime.runPromise(
+              runGraphql(
                 Effect.gen(function* () {
                   const db = yield* DbService
                   return yield* Stream.toAsyncIterableEffect(db.issueChanges)
-                }),
+                }).pipe(Effect.withSpan("graphql-api.repositoryIssuesChanged")),
               ),
             resolve: (repositoryId: string) => repositoryId,
           },
           repositoryWorkItemsChanged: {
             subscribe: async () =>
-              runtime.runPromise(
+              runGraphql(
                 Effect.gen(function* () {
                   const db = yield* DbService
                   return yield* Stream.toAsyncIterableEffect(db.workItemChanges)
-                }),
+                }).pipe(
+                  Effect.withSpan("graphql-api.repositoryWorkItemsChanged"),
+                ),
               ),
             resolve: (repositoryId: string) => repositoryId,
           },
         },
         Mutation: {
-          updateConfig: async (_parent: unknown, args: UpdateConfigArgs) => {
-            const result = await runtime.runPromise(
-              Effect.result(
-                Effect.gen(function* () {
-                  const db = yield* DbService
-                  const updated = yield* db.updateConfig({
-                    defaultModel: args.input.defaultModel,
-                    defaultVariant: args.input.defaultVariant,
-                    reviewModel: args.input.reviewModel ?? null,
-                    reviewVariant: args.input.reviewVariant ?? null,
-                    maxConcurrentOpencodeSessions:
-                      args.input.maxConcurrentOpencodeSessions,
-                    maxConcurrentWorkItems: args.input.maxConcurrentWorkItems,
-                  })
-                  const lifecycle = yield* WorkItemLifecycle
-                  yield* lifecycle.admitWaitingWorkItems.pipe(
-                    Effect.catch((error) =>
-                      Effect.logError(
-                        "Failed to admit waiters after config update",
-                        { error: String(error) },
-                      ),
+          updateConfig: async (_parent: unknown, args: UpdateConfigArgs) =>
+            runGraphql(
+              Effect.gen(function* () {
+                const db = yield* DbService
+                const updated = yield* db.updateConfig({
+                  defaultModel: args.input.defaultModel,
+                  defaultVariant: args.input.defaultVariant,
+                  reviewModel: args.input.reviewModel ?? null,
+                  reviewVariant: args.input.reviewVariant ?? null,
+                  maxConcurrentOpencodeSessions:
+                    args.input.maxConcurrentOpencodeSessions,
+                  maxConcurrentWorkItems: args.input.maxConcurrentWorkItems,
+                })
+                const lifecycle = yield* WorkItemLifecycle
+                yield* lifecycle.admitWaitingWorkItems.pipe(
+                  Effect.catch((error) =>
+                    Effect.logError(
+                      "Failed to admit waiters after config update",
+                      { error: String(error) },
                     ),
-                  )
-                  return updated
-                }),
-              ),
-            )
-            if (Result.isFailure(result)) {
-              throw toGraphQLError(result.failure)
-            }
-            return result.success
-          },
+                  ),
+                )
+                return updated
+              }).pipe(Effect.withSpan("graphql-api.updateConfig")),
+            ),
           updateRepositorySettings: async (
             _parent: unknown,
             args: UpdateRepositorySettingsArgs,
-          ) => {
-            const result = await runtime.runPromise(
-              Effect.result(
-                Effect.gen(function* () {
-                  const db = yield* DbService
-                  return yield* db.updateRepositorySettings({
-                    repositoryId: args.input.repositoryId,
-                    paused: args.input.paused,
-                    defaultModel: args.input.defaultModel ?? null,
-                    defaultVariant: args.input.defaultVariant ?? null,
-                    reviewModel: args.input.reviewModel ?? null,
-                    reviewVariant: args.input.reviewVariant ?? null,
-                    autoMerge: args.input.autoMerge,
-                  })
-                }),
-              ),
-            )
-            if (Result.isFailure(result)) {
-              throw toGraphQLError(result.failure)
-            }
-            return result.success
-          },
+          ) =>
+            runGraphql(
+              Effect.gen(function* () {
+                const db = yield* DbService
+                return yield* db.updateRepositorySettings({
+                  repositoryId: args.input.repositoryId,
+                  paused: args.input.paused,
+                  defaultModel: args.input.defaultModel ?? null,
+                  defaultVariant: args.input.defaultVariant ?? null,
+                  reviewModel: args.input.reviewModel ?? null,
+                  reviewVariant: args.input.reviewVariant ?? null,
+                  autoMerge: args.input.autoMerge,
+                })
+              }).pipe(Effect.withSpan("graphql-api.updateRepositorySettings")),
+            ),
           pauseRepository: async (
             _parent: unknown,
             args: RefreshRepositoryArgs,
-          ) => {
-            const result = await runtime.runPromise(
-              Effect.result(
-                Effect.gen(function* () {
-                  const db = yield* DbService
-                  return yield* db.pauseRepository(args.repositoryId)
-                }),
-              ),
-            )
-            if (Result.isFailure(result)) {
-              throw toGraphQLError(result.failure)
-            }
-            return result.success
-          },
+          ) =>
+            runGraphql(
+              Effect.gen(function* () {
+                const db = yield* DbService
+                return yield* db.pauseRepository(args.repositoryId)
+              }).pipe(Effect.withSpan("graphql-api.pauseRepository")),
+            ),
           unpauseRepository: async (
             _parent: unknown,
             args: RefreshRepositoryArgs,
-          ) => {
-            const result = await runtime.runPromise(
-              Effect.result(
-                Effect.gen(function* () {
-                  const db = yield* DbService
-                  return yield* db.unpauseRepository(args.repositoryId)
-                }),
-              ),
-            )
-            if (Result.isFailure(result)) {
-              throw toGraphQLError(result.failure)
-            }
-            return result.success
-          },
-          addRepository: async (_parent: unknown, args: AddRepositoryArgs) => {
-            const result = await runtime.runPromise(
-              Effect.result(
-                Effect.gen(function* () {
-                  const db = yield* DbService
-                  const added = yield* db.addRepository(args.input)
-                  yield* activatePollingIfCredentialed(added).pipe(
-                    Effect.catch((error) =>
-                      Effect.logWarning(
-                        "Automatic Repository polling was not activated",
-                        {
-                          repositoryId: added.id,
-                          error,
-                        },
-                      ),
+          ) =>
+            runGraphql(
+              Effect.gen(function* () {
+                const db = yield* DbService
+                return yield* db.unpauseRepository(args.repositoryId)
+              }).pipe(Effect.withSpan("graphql-api.unpauseRepository")),
+            ),
+          addRepository: async (_parent: unknown, args: AddRepositoryArgs) =>
+            runGraphql(
+              Effect.gen(function* () {
+                const db = yield* DbService
+                const added = yield* db.addRepository(args.input)
+                yield* activatePollingIfCredentialed(added).pipe(
+                  Effect.catch((error) =>
+                    Effect.logWarning(
+                      "Automatic Repository polling was not activated",
+                      {
+                        repositoryId: added.id,
+                        error,
+                      },
                     ),
-                  )
-                  return added
-                }),
-              ),
-            )
-            if (Result.isFailure(result)) {
-              throw toGraphQLError(result.failure)
-            }
-            return result.success
-          },
+                  ),
+                )
+                return added
+              }).pipe(Effect.withSpan("graphql-api.addRepository")),
+            ),
           addRepositoryGitHubToken: async (
             _parent: unknown,
             args: RepositoryCredentialArgs,
-          ) => {
-            const result = await runtime.runPromise(
-              Effect.result(
-                tokenProvisioning.withPermits(1)(
+          ) =>
+            runGraphql(
+              tokenProvisioning
+                .withPermits(1)(
                   Effect.gen(function* () {
                     const db = yield* DbService
                     const repositories = yield* db.listRepositories
@@ -1040,182 +565,116 @@ export const createGraphqlApi = (
                     )
                     return repositoryCredential(repository, tokenName)
                   }),
-                ),
-              ),
-            )
-            if (Result.isFailure(result)) {
-              throw toGraphQLError(result.failure)
-            }
-            return result.success
-          },
+                )
+                .pipe(Effect.withSpan("graphql-api.addRepositoryGitHubToken")),
+            ),
           removeRepository: async (
             _parent: unknown,
             args: RemoveRepositoryArgs,
-          ) => {
-            const result = await runtime.runPromise(
-              Effect.result(
-                Effect.gen(function* () {
-                  const db = yield* DbService
-                  yield* db.removeRepository(args.repositoryId)
-                  yield* suspendRepositoryPolling(args.repositoryId).pipe(
-                    Effect.catch((error) =>
-                      Effect.logWarning(
-                        "Repository polling was not suspended after removal",
-                        {
-                          repositoryId: args.repositoryId,
-                          error,
-                        },
-                      ),
+          ) =>
+            runGraphql(
+              Effect.gen(function* () {
+                const db = yield* DbService
+                yield* db.removeRepository(args.repositoryId)
+                yield* suspendRepositoryPolling(args.repositoryId).pipe(
+                  Effect.catch((error) =>
+                    Effect.logWarning(
+                      "Repository polling was not suspended after removal",
+                      {
+                        repositoryId: args.repositoryId,
+                        error,
+                      },
                     ),
-                  )
-                  return args.repositoryId
-                }),
-              ),
-            )
-            if (Result.isFailure(result)) {
-              throw toGraphQLError(result.failure)
-            }
-            return result.success
-          },
-          resetWorkItem: async (_parent: unknown, args: ResetWorkItemArgs) => {
-            const result = await runtime.runPromise(
-              Effect.result(
-                Effect.gen(function* () {
-                  const lifecycle = yield* WorkItemLifecycle
-                  return yield* lifecycle.reset(args.workItemId)
-                }),
-              ),
-            )
-            if (Result.isFailure(result)) {
-              throw toGraphQLError(result.failure)
-            }
-            return result.success
-          },
+                  ),
+                )
+                return args.repositoryId
+              }).pipe(Effect.withSpan("graphql-api.removeRepository")),
+            ),
+          resetWorkItem: async (_parent: unknown, args: ResetWorkItemArgs) =>
+            runGraphql(
+              Effect.gen(function* () {
+                const lifecycle = yield* WorkItemLifecycle
+                return yield* lifecycle.reset(args.workItemId)
+              }).pipe(Effect.withSpan("graphql-api.resetWorkItem")),
+            ),
           refreshRepository: async (
             _parent: unknown,
             args: RefreshRepositoryArgs,
-          ) => {
-            const result = await runtime.runPromise(
-              Effect.result(
-                Effect.gen(function* () {
-                  const db = yield* DbService
-                  const repositories = yield* db.listRepositories
-                  const repository = repositories.find(
-                    ({ id }) => id === args.repositoryId,
-                  )
-                  if (repository === undefined) {
-                    return yield* new RepositoryNotFoundError({
-                      repositoryId: args.repositoryId,
+          ) =>
+            runGraphql(
+              Effect.gen(function* () {
+                const db = yield* DbService
+                const repositories = yield* db.listRepositories
+                const repository = repositories.find(
+                  ({ id }) => id === args.repositoryId,
+                )
+                if (repository === undefined) {
+                  return yield* new RepositoryNotFoundError({
+                    repositoryId: args.repositoryId,
+                  })
+                }
+
+                const keymaxxer = yield* KeymaxxerService
+                if (keymaxxer.enabled !== false) {
+                  const credential = yield* keymaxxer.findSecret({
+                    provider: "github",
+                    account: `${repository.githubOwner}/${repository.githubRepo}`,
+                  })
+                  if (credential === null) {
+                    return yield* new RepositoryCredentialError({
+                      message: `GitHub credential is not configured for ${repository.githubOwner}/${repository.githubRepo}`,
                     })
                   }
+                }
 
-                  const keymaxxer = yield* KeymaxxerService
-                  if (keymaxxer.enabled !== false) {
-                    const credential = yield* keymaxxer.findSecret({
-                      provider: "github",
-                      account: `${repository.githubOwner}/${repository.githubRepo}`,
-                    })
-                    if (credential === null) {
-                      return yield* new RepositoryCredentialError({
-                        message: `GitHub credential is not configured for ${repository.githubOwner}/${repository.githubRepo}`,
-                      })
-                    }
-                  }
-
-                  const jobId = yield* enqueueRefreshRepositoryJob(
-                    repository.id,
-                  )
-                  return {
-                    id: jobId,
-                    repositoryId: repository.id,
-                  }
-                }),
-              ),
-            )
-            if (Result.isFailure(result)) {
-              throw toGraphQLError(result.failure)
-            }
-            return result.success
-          },
-          implementNow: async (_parent: unknown, args: ImplementNowArgs) => {
-            const result = await runtime.runPromise(
-              Effect.result(
-                Effect.gen(function* () {
-                  const lifecycle = yield* WorkItemLifecycle
-                  return yield* lifecycle.implementNow(
-                    args.repositoryId,
-                    args.githubIssueNumber,
-                  )
-                }),
-              ),
-            )
-            if (Result.isFailure(result)) {
-              throw toGraphQLError(result.failure)
-            }
-            return result.success
-          },
-          implementLocally: async (
-            _parent: unknown,
-            args: ImplementNowArgs,
-          ) => {
-            const result = await runtime.runPromise(
-              Effect.result(
-                Effect.gen(function* () {
-                  const lifecycle = yield* WorkItemLifecycle
-                  return yield* lifecycle.implementLocally(
-                    args.repositoryId,
-                    args.githubIssueNumber,
-                  )
-                }),
-              ),
-            )
-            if (Result.isFailure(result)) {
-              throw toGraphQLError(result.failure)
-            }
-            return result.success
-          },
-          retryWorkItem: async (_parent: unknown, args: WorkItemArgs) => {
-            const result = await runtime.runPromise(
-              Effect.result(
-                Effect.gen(function* () {
-                  const lifecycle = yield* WorkItemLifecycle
-                  return yield* lifecycle.retry(args.workItemId)
-                }),
-              ),
-            )
-            if (Result.isFailure(result)) {
-              throw toGraphQLError(result.failure)
-            }
-            return result.success
-          },
-          pauseWorkItem: async (_parent: unknown, args: WorkItemArgs) => {
-            const result = await runtime.runPromise(
-              Effect.result(
-                Effect.gen(function* () {
-                  const lifecycle = yield* WorkItemLifecycle
-                  return yield* lifecycle.pause(args.workItemId)
-                }),
-              ),
-            )
-            if (Result.isFailure(result)) {
-              throw toGraphQLError(result.failure)
-            }
-            return result.success
-          },
-          startWorkItem: async (_parent: unknown, args: WorkItemArgs) => {
-            const result = await runtime.runPromise(
-              Effect.result(
-                Effect.gen(function* () {
-                  const lifecycle = yield* WorkItemLifecycle
-                  return yield* lifecycle.start(args.workItemId)
-                }),
-              ),
-            )
-            if (Result.isFailure(result)) {
-              throw toGraphQLError(result.failure)
-            }
-            return result.success
-          },
+                const jobId = yield* enqueueRefreshRepositoryJob(repository.id)
+                return {
+                  id: jobId,
+                  repositoryId: repository.id,
+                }
+              }).pipe(Effect.withSpan("graphql-api.refreshRepository")),
+            ),
+          implementNow: async (_parent: unknown, args: ImplementNowArgs) =>
+            runGraphql(
+              Effect.gen(function* () {
+                const lifecycle = yield* WorkItemLifecycle
+                return yield* lifecycle.implementNow(
+                  args.repositoryId,
+                  args.githubIssueNumber,
+                )
+              }).pipe(Effect.withSpan("graphql-api.implementNow")),
+            ),
+          implementLocally: async (_parent: unknown, args: ImplementNowArgs) =>
+            runGraphql(
+              Effect.gen(function* () {
+                const lifecycle = yield* WorkItemLifecycle
+                return yield* lifecycle.implementLocally(
+                  args.repositoryId,
+                  args.githubIssueNumber,
+                )
+              }).pipe(Effect.withSpan("graphql-api.implementLocally")),
+            ),
+          retryWorkItem: async (_parent: unknown, args: WorkItemArgs) =>
+            runGraphql(
+              Effect.gen(function* () {
+                const lifecycle = yield* WorkItemLifecycle
+                return yield* lifecycle.retry(args.workItemId)
+              }).pipe(Effect.withSpan("graphql-api.retryWorkItem")),
+            ),
+          pauseWorkItem: async (_parent: unknown, args: WorkItemArgs) =>
+            runGraphql(
+              Effect.gen(function* () {
+                const lifecycle = yield* WorkItemLifecycle
+                return yield* lifecycle.pause(args.workItemId)
+              }).pipe(Effect.withSpan("graphql-api.pauseWorkItem")),
+            ),
+          startWorkItem: async (_parent: unknown, args: WorkItemArgs) =>
+            runGraphql(
+              Effect.gen(function* () {
+                const lifecycle = yield* WorkItemLifecycle
+                return yield* lifecycle.start(args.workItemId)
+              }).pipe(Effect.withSpan("graphql-api.startWorkItem")),
+            ),
         },
       },
     }),

--- a/packages/graphql-api/src/lib/issue-polling.ts
+++ b/packages/graphql-api/src/lib/issue-polling.ts
@@ -42,15 +42,16 @@ export const sampleIssuePollingDelay: Effect.Effect<Duration.Duration> =
     ),
   )
 
-export const enqueueRefreshRepositoryJob = (repositoryId: string) =>
-  Effect.gen(function* () {
-    const queue = yield* QueueService
-    return yield* queue.enqueue(
-      ISSUE_REFRESH_QUEUE,
-      RefreshRepositoryJobPayload(repositoryId),
-      { retryLimit: JOB_RECOVERY_RETRY_LIMIT },
-    )
-  })
+export const enqueueRefreshRepositoryJob = Effect.fn(
+  "graphql-api.enqueueRefreshRepositoryJob",
+)(function* (repositoryId: string) {
+  const queue = yield* QueueService
+  return yield* queue.enqueue(
+    ISSUE_REFRESH_QUEUE,
+    RefreshRepositoryJobPayload(repositoryId),
+    { retryLimit: JOB_RECOVERY_RETRY_LIMIT },
+  )
+})
 
 /**
  * Durably ensure one high-priority Polling Auto-heal Job without awaiting repair.
@@ -65,31 +66,33 @@ export const enqueuePollingAutoHealJob = Effect.gen(function* () {
     Duration.zero,
     { retryLimit: JOB_RECOVERY_RETRY_LIMIT },
   )
-})
+}).pipe(Effect.withSpan("graphql-api.enqueuePollingAutoHealJob"))
 
 /**
  * Ensure one keyed recurring schedule and enqueue a high-priority first refresh.
  * Idempotent for the schedule; every activation enqueues a distinct first refresh.
  */
-export const activateRepositoryPolling = (repositoryId: string) =>
-  Effect.gen(function* () {
-    const queue = yield* QueueService
-    const delay = yield* sampleIssuePollingDelay
-    const payload = RefreshRepositoryJobPayload(repositoryId)
-    yield* queue.ensureKeyed(ISSUE_POLL_QUEUE, repositoryId, payload, delay, {
-      retryLimit: JOB_RECOVERY_RETRY_LIMIT,
-    })
-    return yield* queue.enqueue(ISSUE_REFRESH_QUEUE, payload, {
-      retryLimit: JOB_RECOVERY_RETRY_LIMIT,
-    })
+export const activateRepositoryPolling = Effect.fn(
+  "graphql-api.activateRepositoryPolling",
+)(function* (repositoryId: string) {
+  const queue = yield* QueueService
+  const delay = yield* sampleIssuePollingDelay
+  const payload = RefreshRepositoryJobPayload(repositoryId)
+  yield* queue.ensureKeyed(ISSUE_POLL_QUEUE, repositoryId, payload, delay, {
+    retryLimit: JOB_RECOVERY_RETRY_LIMIT,
   })
+  return yield* queue.enqueue(ISSUE_REFRESH_QUEUE, payload, {
+    retryLimit: JOB_RECOVERY_RETRY_LIMIT,
+  })
+})
 
 /** Suspend the recurring schedule without cancelling accepted manual Refresh Jobs. */
-export const suspendRepositoryPolling = (repositoryId: string) =>
-  Effect.gen(function* () {
-    const queue = yield* QueueService
-    yield* queue.removeKeyed(ISSUE_POLL_QUEUE, repositoryId)
-  })
+export const suspendRepositoryPolling = Effect.fn(
+  "graphql-api.suspendRepositoryPolling",
+)(function* (repositoryId: string) {
+  const queue = yield* QueueService
+  yield* queue.removeKeyed(ISSUE_POLL_QUEUE, repositoryId)
+})
 
 export interface RepairPollingSchedulesInput {
   readonly credentialedRepositoryIds: ReadonlyArray<string>
@@ -101,37 +104,38 @@ export interface RepairPollingSchedulesInput {
  * remove orphans, add missing entries (with a high-priority first refresh each),
  * preserve existing correct entries and due times.
  */
-export const repairPollingSchedules = (input: RepairPollingSchedulesInput) =>
-  Effect.gen(function* () {
-    const queue = yield* QueueService
-    const sampleDelay = input.sampleDelay ?? sampleIssuePollingDelay
-    const credentialed = new Set(input.credentialedRepositoryIds)
-    const existing = yield* queue.listKeyed(ISSUE_POLL_QUEUE)
+export const repairPollingSchedules = Effect.fn(
+  "graphql-api.repairPollingSchedules",
+)(function* (input: RepairPollingSchedulesInput) {
+  const queue = yield* QueueService
+  const sampleDelay = input.sampleDelay ?? sampleIssuePollingDelay
+  const credentialed = new Set(input.credentialedRepositoryIds)
+  const existing = yield* queue.listKeyed(ISSUE_POLL_QUEUE)
 
-    for (const entry of existing) {
-      if (!credentialed.has(entry.key)) {
-        yield* queue.removeKeyed(ISSUE_POLL_QUEUE, entry.key)
-      }
+  for (const entry of existing) {
+    if (!credentialed.has(entry.key)) {
+      yield* queue.removeKeyed(ISSUE_POLL_QUEUE, entry.key)
     }
+  }
 
-    const existingKeys = new Set(
-      (yield* queue.listKeyed(ISSUE_POLL_QUEUE)).map((entry) => entry.key),
-    )
-    const missing = input.credentialedRepositoryIds.filter(
-      (id) => !existingKeys.has(id),
-    )
+  const existingKeys = new Set(
+    (yield* queue.listKeyed(ISSUE_POLL_QUEUE)).map((entry) => entry.key),
+  )
+  const missing = input.credentialedRepositoryIds.filter(
+    (id) => !existingKeys.has(id),
+  )
 
-    for (const repositoryId of missing) {
-      const delay = yield* sampleDelay
-      const payload = RefreshRepositoryJobPayload(repositoryId)
-      // Enqueue first refresh before ensure so a crash between steps still
-      // leaves the Repository in the missing set on the next auto-heal attempt
-      // (duplicate first refreshes are allowed; schedules are unique).
-      yield* queue.enqueue(ISSUE_REFRESH_QUEUE, payload, {
-        retryLimit: JOB_RECOVERY_RETRY_LIMIT,
-      })
-      yield* queue.ensureKeyed(ISSUE_POLL_QUEUE, repositoryId, payload, delay, {
-        retryLimit: JOB_RECOVERY_RETRY_LIMIT,
-      })
-    }
-  })
+  for (const repositoryId of missing) {
+    const delay = yield* sampleDelay
+    const payload = RefreshRepositoryJobPayload(repositoryId)
+    // Enqueue first refresh before ensure so a crash between steps still
+    // leaves the Repository in the missing set on the next auto-heal attempt
+    // (duplicate first refreshes are allowed; schedules are unique).
+    yield* queue.enqueue(ISSUE_REFRESH_QUEUE, payload, {
+      retryLimit: JOB_RECOVERY_RETRY_LIMIT,
+    })
+    yield* queue.ensureKeyed(ISSUE_POLL_QUEUE, repositoryId, payload, delay, {
+      retryLimit: JOB_RECOVERY_RETRY_LIMIT,
+    })
+  }
+})

--- a/packages/graphql-api/src/lib/repository-credentials.ts
+++ b/packages/graphql-api/src/lib/repository-credentials.ts
@@ -1,0 +1,65 @@
+import { Data, Effect } from "effect"
+import { KeymaxxerService } from "@ready-for-agent/keymaxxer-service"
+import { activateRepositoryPolling } from "./issue-polling.js"
+
+export type Repository = {
+  id: string
+  githubOwner: string
+  githubRepo: string
+}
+
+export class RepositoryCredentialError extends Data.TaggedError(
+  "RepositoryCredentialError",
+)<{ readonly message: string }> {}
+
+export const githubTokenSecretName = (repository: Repository) =>
+  `GITHUB_TOKEN_${repository.githubOwner}_${repository.githubRepo}`
+    .replace(/[^A-Za-z0-9_]/g, "_")
+    .toUpperCase()
+
+export const githubTokenCreationUrl = (repository: Repository) => {
+  const url = new URL("https://github.com/settings/personal-access-tokens/new")
+  url.searchParams.set("name", `${repository.githubRepo} - ready-for-agent`)
+  url.searchParams.set(
+    "description",
+    `Ready For Agent token for ${repository.githubOwner}/${repository.githubRepo}`,
+  )
+  url.searchParams.set("target_name", repository.githubOwner)
+  url.searchParams.set("expires_in", "90")
+  url.searchParams.set("issues", "write")
+  url.searchParams.set("contents", "write")
+  url.searchParams.set("pull_requests", "write")
+  // Actions + commit statuses help with CI visibility. Per-check CheckRun nodes
+  // need Checks API access, which fine-grained PATs cannot grant — see AGENTS.md.
+  url.searchParams.set("actions", "read")
+  url.searchParams.set("statuses", "read")
+  return url.toString()
+}
+
+export const repositoryCredential = (
+  repository: Repository,
+  existingToken: string | null,
+  configured = existingToken !== null,
+) => ({
+  repositoryId: repository.id,
+  configured,
+  githubTokenSecretName: existingToken ?? githubTokenSecretName(repository),
+  githubTokenCreationUrl: githubTokenCreationUrl(repository),
+})
+
+/** Activate durable Issue Polling only when a GitHub token is already configured. */
+export const activatePollingIfCredentialed = Effect.fn(
+  "graphql-api.activatePollingIfCredentialed",
+)(function* (repository: Repository) {
+  const keymaxxer = yield* KeymaxxerService
+  if (keymaxxer.enabled === false) {
+    yield* activateRepositoryPolling(repository.id)
+    return
+  }
+  const credential = yield* keymaxxer.findSecret({
+    provider: "github",
+    account: `${repository.githubOwner}/${repository.githubRepo}`,
+  })
+  if (credential === null) return
+  yield* activateRepositoryPolling(repository.id)
+})

--- a/packages/graphql-api/src/lib/repository-credentials.ts
+++ b/packages/graphql-api/src/lib/repository-credentials.ts
@@ -17,7 +17,7 @@ export const githubTokenSecretName = (repository: Repository) =>
     .replace(/[^A-Za-z0-9_]/g, "_")
     .toUpperCase()
 
-export const githubTokenCreationUrl = (repository: Repository) => {
+const githubTokenCreationUrl = (repository: Repository) => {
   const url = new URL("https://github.com/settings/personal-access-tokens/new")
   url.searchParams.set("name", `${repository.githubRepo} - ready-for-agent`)
   url.searchParams.set(

--- a/packages/graphql-api/src/lib/to-graphql-error.ts
+++ b/packages/graphql-api/src/lib/to-graphql-error.ts
@@ -1,0 +1,163 @@
+import { GraphQLError } from "graphql"
+
+type TaggedError = {
+  readonly _tag: string
+  readonly message?: string
+  readonly field?: string
+  readonly repositoryId?: string
+  readonly workItemId?: string
+  readonly githubIssueNumber?: number
+  readonly state?: string
+  readonly blockerCount?: number
+  readonly reason?: string
+  readonly githubOwner?: string
+  readonly githubRepo?: string
+  readonly localPath?: string
+}
+
+const isTaggedError = (error: unknown): error is TaggedError =>
+  typeof error === "object" &&
+  error !== null &&
+  "_tag" in error &&
+  typeof (error as { _tag: unknown })._tag === "string"
+
+const gql = (message: string, code: string, extensions?: object) =>
+  new GraphQLError(message, {
+    extensions: { code, ...extensions },
+  })
+
+/**
+ * Map tagged domain failures (and GraphQLError) to GraphQL errors with
+ * `extensions.code`. Dispatch is by `_tag` only — never `instanceof`.
+ * Only tags resolvers can produce are listed; unknown tags fall back.
+ */
+export const toGraphQLError = (error: unknown): GraphQLError => {
+  if (error instanceof GraphQLError) {
+    return error
+  }
+
+  if (!isTaggedError(error)) {
+    if (error instanceof Error) {
+      return gql(error.message, "INTERNAL_SERVER_ERROR")
+    }
+    return gql("Unexpected error", "INTERNAL_SERVER_ERROR")
+  }
+
+  switch (error._tag) {
+    case "IssueNotFoundError":
+      return gql(
+        `Issue #${error.githubIssueNumber} was not found in repository ${error.repositoryId}`,
+        "ISSUE_NOT_FOUND",
+      )
+    case "IssueNotOpenError":
+      return gql(
+        `Issue #${error.githubIssueNumber} is ${error.state}, not OPEN`,
+        "ISSUE_NOT_OPEN",
+      )
+    case "ParentIssueError":
+      return gql(
+        `Issue #${error.githubIssueNumber} has child issues and cannot be implemented directly`,
+        "ISSUE_IS_PARENT",
+      )
+    case "IssueBlockedError":
+      return gql(
+        `Issue #${error.githubIssueNumber} is blocked by ${error.blockerCount} issue(s)`,
+        "ISSUE_BLOCKED",
+      )
+    case "UnfinishedWorkItemExistsError":
+      return gql(
+        `Issue #${error.githubIssueNumber} already has an unfinished Work Item`,
+        "UNFINISHED_WORK_ITEM_EXISTS",
+        { workItemId: error.workItemId },
+      )
+    case "BuildModelNotConfiguredError":
+      return gql(
+        error.message ?? "Build model not configured",
+        "BUILD_MODEL_NOT_CONFIGURED",
+      )
+    case "WorkItemLifecycleDatabaseError":
+      return gql(
+        error.message ?? "Work item lifecycle database error",
+        "WORK_ITEM_LIFECYCLE_DATABASE_ERROR",
+      )
+    case "WorkItemNotFoundError":
+      return gql(
+        `Work Item not found: ${error.workItemId}`,
+        "WORK_ITEM_NOT_FOUND",
+      )
+    case "WorkItemTerminalError":
+      return gql(
+        `Work Item ${error.workItemId} is already ${error.state}`,
+        "WORK_ITEM_TERMINAL",
+      )
+    case "ActiveStepRunExistsError":
+      return gql(
+        `Work Item ${error.workItemId} already has an active Step Run`,
+        "ACTIVE_STEP_RUN_EXISTS",
+      )
+    case "RetryNotEligibleError":
+      return gql(
+        `Work Item ${error.workItemId} cannot be retried: ${error.reason}`,
+        "RETRY_NOT_ELIGIBLE",
+      )
+    case "RepositoryCredentialError":
+      return gql(
+        error.message ?? "Repository credential error",
+        "REPOSITORY_CREDENTIAL_ERROR",
+      )
+    case "RepositoryAlreadyExistsError":
+      return gql(
+        `Repository ${error.githubOwner}/${error.githubRepo} already exists`,
+        "REPOSITORY_ALREADY_EXISTS",
+      )
+    case "InvalidConfigInputError":
+      return gql(
+        error.message ?? "Invalid config input",
+        "INVALID_CONFIG_INPUT",
+        {
+          field: error.field,
+        },
+      )
+    case "InvalidRepositorySettingsError":
+      return gql(
+        error.message ?? "Invalid repository settings",
+        "INVALID_REPOSITORY_SETTINGS",
+        { field: error.field },
+      )
+    case "LocalPathInUseError":
+      return gql(
+        `Local path already in use: ${error.localPath}`,
+        "LOCAL_PATH_IN_USE",
+      )
+    case "InvalidRepositoryInputError":
+      return gql(
+        error.message ?? "Invalid repository input",
+        "INVALID_REPOSITORY_INPUT",
+        { field: error.field },
+      )
+    case "RepositoryNotFoundError":
+      return gql(
+        `Repository not found: ${error.repositoryId}`,
+        "REPOSITORY_NOT_FOUND",
+      )
+    case "DatabaseError":
+      return gql(error.message ?? "Database error", "DATABASE_ERROR")
+    case "EnqueueError":
+      return gql(error.message ?? "Enqueue error", "ENQUEUE_ERROR")
+    case "ResetCleanupError":
+      return gql(
+        error.message ?? "Reset cleanup failed",
+        "RESET_CLEANUP_FAILED",
+      )
+    case "AbandonCleanupError":
+      return gql(
+        error.message ?? "Abandon cleanup failed",
+        "ABANDON_CLEANUP_FAILED",
+      )
+    default:
+      if (typeof error.message === "string" && error.message.length > 0) {
+        return gql(error.message, "INTERNAL_SERVER_ERROR")
+      }
+      return gql("Unexpected error", "INTERNAL_SERVER_ERROR")
+  }
+}

--- a/packages/graphql-api/src/lib/work-item-projection.ts
+++ b/packages/graphql-api/src/lib/work-item-projection.ts
@@ -1,0 +1,158 @@
+import type { IssueRecord } from "@ready-for-agent/db-service"
+import {
+  type OperationalLifecycleStep,
+  STEP_RUN_REASON,
+  type StepRunRecord,
+  type WorkItemRecord,
+  isTerminalWorkItemState,
+} from "@ready-for-agent/work-item-lifecycle"
+
+const childIssueCategory = (issue: IssueRecord): number => {
+  if (issue.state === "CLOSED") return 2
+  return issue.blockedBy.length === 0 ? 0 : 1
+}
+
+const compareChildIssues = (left: IssueRecord, right: IssueRecord): number =>
+  childIssueCategory(left) - childIssueCategory(right) ||
+  (left.parentPosition ?? Number.MAX_SAFE_INTEGER) -
+    (right.parentPosition ?? Number.MAX_SAFE_INTEGER) ||
+  left.githubIssueNumber - right.githubIssueNumber
+
+export const workIssueProjection = (
+  issues: readonly IssueRecord[],
+): readonly IssueRecord[] => {
+  const childrenByParent = new Map<number, IssueRecord[]>()
+  for (const issue of issues) {
+    if (issue.parent === null) continue
+    const children = childrenByParent.get(issue.parent.githubIssueNumber) ?? []
+    children.push(issue)
+    childrenByParent.set(issue.parent.githubIssueNumber, children)
+  }
+
+  return issues
+    .filter((issue) => issue.parent === null)
+    .sort((left, right) => right.githubIssueNumber - left.githubIssueNumber)
+    .flatMap((issue) => {
+      if (!issue.hasChildren) return [issue]
+      const children = childrenByParent.get(issue.githubIssueNumber) ?? []
+      if (children.length === 0) return []
+      return [issue, ...children.sort(compareChildIssues)]
+    })
+}
+
+export type WorkItemStatus =
+  | "queued"
+  | "running"
+  | "succeeded"
+  | "failed"
+  | "interrupted"
+  | "cancelled"
+  | "complete"
+  | "abandoned"
+  | "needs_human"
+  | "needs_human_review"
+  | "waiting_for_worker_slot"
+
+type LifecyclePhase =
+  | Exclude<
+      OperationalLifecycleStep,
+      "watch_pr_status_checks" | "investigate_pr_status_checks"
+    >
+  | "github_status_checks"
+
+const lifecyclePhase = (step: OperationalLifecycleStep): LifecyclePhase => {
+  if (
+    step === "watch_pr_status_checks" ||
+    step === "investigate_pr_status_checks"
+  ) {
+    return "github_status_checks"
+  }
+  return step
+}
+
+export const lifecyclePhaseLabel = (phase: LifecyclePhase): string => {
+  switch (phase) {
+    case "implement":
+      return "Build"
+    case "assess_changes":
+      return "Assess changes"
+    case "close_issue":
+      return "Close issue"
+    case "resolve_pr_merge_conflict":
+      return "Resolve PR merge conflict"
+    case "github_status_checks":
+      return "GitHub status checks"
+    case "mark_pr_ready_for_review":
+      return "Mark PR ready for review"
+    case "decide_pr_merge":
+      return "Decide PR merge"
+    case "merge_pr":
+      return "Merge PR"
+    default:
+      return phase
+        .replaceAll("_", " ")
+        .replace(/^./, (first) => first.toUpperCase())
+  }
+}
+
+export const statusLabel = (status: WorkItemStatus): string =>
+  status.replaceAll("_", " ").replace(/^./, (first) => first.toUpperCase())
+
+export const latestStepRun = (
+  workItem: WorkItemRecord,
+): StepRunRecord | undefined => workItem.stepRuns.at(-1)
+
+/** Running Step Run blocked on maxConcurrentOpencodeSessions → operator Queued. */
+const isWaitingForOpencodeSession = (stepRun: StepRunRecord): boolean =>
+  stepRun.status === "running" &&
+  stepRun.reasonCode === STEP_RUN_REASON.waitingForOpencodeSession
+
+const stepRunDisplayStatus = (stepRun: StepRunRecord): WorkItemStatus =>
+  isWaitingForOpencodeSession(stepRun) ? "queued" : stepRun.status
+
+export const workItemStatus = (workItem: WorkItemRecord): WorkItemStatus => {
+  if (workItem.waitingSince != null) return "waiting_for_worker_slot"
+  if (isTerminalWorkItemState(workItem.state)) return workItem.state
+  if (workItem.paused) return "needs_human_review"
+  const latest = latestStepRun(workItem)
+  if (latest === undefined) return "queued"
+  return stepRunDisplayStatus(latest)
+}
+
+export const lifecycleLabels = (workItem: WorkItemRecord) => {
+  const latestRuns = new Map<LifecyclePhase, StepRunRecord>()
+  for (const stepRun of workItem.stepRuns) {
+    latestRuns.set(lifecyclePhase(stepRun.step), stepRun)
+  }
+  const finalStepRun = latestStepRun(workItem)
+  const finalPhase =
+    workItem.state === "needs_human" && finalStepRun !== undefined
+      ? lifecyclePhase(finalStepRun.step)
+      : null
+
+  return [...latestRuns].map(([phase, stepRun]) => {
+    const status: WorkItemStatus =
+      phase === finalPhase ? "needs_human" : stepRunDisplayStatus(stepRun)
+    const outcome =
+      phase === "decide_pr_merge" && status === "needs_human"
+        ? "Human review before merge"
+        : phase === "decide_pr_merge" && status === "succeeded"
+          ? "Clanker may merge"
+          : phase === "merge_pr" && status === "succeeded"
+            ? "Merged"
+            : statusLabel(status)
+    return {
+      phase: phase.toUpperCase(),
+      label: `${lifecyclePhaseLabel(phase)}: ${outcome}`,
+      status: status.toUpperCase(),
+      durationMs: stepRun.executionDurationMs,
+    }
+  })
+}
+
+export const workItemStateLabel = (workItem: WorkItemRecord): string => {
+  if (isTerminalWorkItemState(workItem.state)) {
+    return statusLabel(workItem.state)
+  }
+  return lifecyclePhaseLabel(lifecyclePhase(workItem.state))
+}

--- a/packages/graphql-api/src/lib/work-item-projection.ts
+++ b/packages/graphql-api/src/lib/work-item-projection.ts
@@ -70,7 +70,7 @@ const lifecyclePhase = (step: OperationalLifecycleStep): LifecyclePhase => {
   return step
 }
 
-export const lifecyclePhaseLabel = (phase: LifecyclePhase): string => {
+const lifecyclePhaseLabel = (phase: LifecyclePhase): string => {
   switch (phase) {
     case "implement":
       return "Build"

--- a/packages/graphql-api/test/graphql-api.test.ts
+++ b/packages/graphql-api/test/graphql-api.test.ts
@@ -5,10 +5,6 @@ import {
   stubDbService,
 } from "@ready-for-agent/db-service/test"
 import {
-  IssueReconciler,
-  type IssueReconcilerShape,
-} from "@ready-for-agent/issue-reconciler"
-import {
   KeymaxxerService,
   type KeymaxxerServiceShape,
 } from "@ready-for-agent/keymaxxer-service"
@@ -109,7 +105,6 @@ const workItem = {
 
 const makeRuntime = (
   dbOverrides: Partial<DbServiceShape> = {},
-  reconcilerOverrides: Partial<IssueReconcilerShape> = {},
   keymaxxerOverrides: Partial<KeymaxxerServiceShape> = {},
   queueOverrides: Partial<QueueServiceShape> = {},
   lifecycleOverrides: Partial<WorkItemLifecycleShape> = {},
@@ -144,10 +139,6 @@ const makeRuntime = (
     listRepositories: Effect.succeed([repository]),
     ...dbOverrides,
   })
-  const reconciler: IssueReconcilerShape = {
-    reconcile: () => Effect.die("not used"),
-    ...reconcilerOverrides,
-  }
   const keymaxxer: KeymaxxerServiceShape = {
     initialize: Effect.void,
     findSecret: () => Effect.succeed(null),
@@ -213,7 +204,6 @@ const makeRuntime = (
   return ManagedRuntime.make(
     Layer.mergeAll(
       Layer.succeed(DbService, db),
-      Layer.succeed(IssueReconciler, reconciler),
       Layer.succeed(KeymaxxerService, keymaxxer),
       Layer.succeed(Opencode, opencode),
       Layer.succeed(QueueService, queue),
@@ -323,7 +313,6 @@ describe("GraphQL API", () => {
     await runtime.dispose()
     runtime = makeRuntime(
       {},
-      {},
       {
         findSecret: ({ account, provider }) =>
           Effect.succeed(
@@ -397,7 +386,6 @@ describe("GraphQL API", () => {
     await runtime.dispose()
     runtime = makeRuntime(
       {},
-      {},
       {
         enabled: false,
         findSecret: () => Effect.die("must not inspect the vault"),
@@ -429,7 +417,6 @@ describe("GraphQL API", () => {
     let enqueued = false
     await runtime.dispose()
     runtime = makeRuntime(
-      {},
       {},
       {
         findSecret: () => Effect.succeed(null),
@@ -467,7 +454,6 @@ describe("GraphQL API", () => {
   test("keeps the added repository when automatic Issue Polling activation fails", async () => {
     await runtime.dispose()
     runtime = makeRuntime(
-      {},
       {},
       {
         findSecret: () => Effect.succeed("GITHUB_TOKEN_ACME_WIDGETS"),
@@ -568,7 +554,6 @@ describe("GraphQL API", () => {
     await runtime.dispose()
     runtime = makeRuntime(
       {},
-      {},
       {
         findSecrets: (inputs) =>
           Effect.succeed(
@@ -622,7 +607,6 @@ describe("GraphQL API", () => {
     await runtime.dispose()
     runtime = makeRuntime(
       {},
-      {},
       {
         enabled: false,
         findSecrets: () => Effect.die("must not inspect the vault"),
@@ -655,7 +639,6 @@ describe("GraphQL API", () => {
     const enqueued: string[] = []
     await runtime.dispose()
     runtime = makeRuntime(
-      {},
       {},
       {
         findSecret: () => Effect.succeed(tokenName),
@@ -732,7 +715,6 @@ describe("GraphQL API", () => {
     await runtime.dispose()
     runtime = makeRuntime(
       {},
-      {},
       {
         findSecret: () => Effect.succeed(null),
       },
@@ -772,7 +754,6 @@ describe("GraphQL API", () => {
         },
       },
       {},
-      {},
       {
         removeKeyed: () =>
           Effect.sync(() => {
@@ -805,7 +786,6 @@ describe("GraphQL API", () => {
       {},
       {},
       {},
-      {},
       {
         reset: (id) => {
           resetWorkItemId = id
@@ -833,7 +813,6 @@ describe("GraphQL API", () => {
     const workItemId = "wi-01AAAAAAAAAAAAAAAAAAAAAAAA"
     await runtime.dispose()
     runtime = makeRuntime(
-      {},
       {},
       {},
       {},
@@ -1009,7 +988,6 @@ describe("GraphQL API", () => {
     let listCount = 0
     await runtime.dispose()
     runtime = makeRuntime(
-      {},
       {},
       {},
       {},
@@ -1218,7 +1196,6 @@ describe("GraphQL API", () => {
       {},
       {},
       {},
-      {},
       {
         listWorkItemsForIssue: (repositoryId, githubIssueNumber) => {
           receivedArgs = [repositoryId, githubIssueNumber]
@@ -1286,7 +1263,6 @@ describe("GraphQL API", () => {
     } as WorkItemRecord
     await runtime.dispose()
     runtime = makeRuntime(
-      {},
       {},
       {},
       {},
@@ -1370,7 +1346,6 @@ describe("GraphQL API", () => {
     } as WorkItemRecord
     await runtime.dispose()
     runtime = makeRuntime(
-      {},
       {},
       {},
       {},
@@ -1467,7 +1442,6 @@ describe("GraphQL API", () => {
       {},
       {},
       {},
-      {},
       {
         listWorkItemsForIssue: () => Effect.succeed([pausedAtCommit]),
       },
@@ -1549,7 +1523,6 @@ describe("GraphQL API", () => {
       {},
       {},
       {},
-      {},
       {
         listWorkItemsForIssue: () => Effect.succeed([operatorPaused]),
       },
@@ -1601,7 +1574,6 @@ describe("GraphQL API", () => {
     } as WorkItemRecord
     await runtime.dispose()
     runtime = makeRuntime(
-      {},
       {},
       {},
       {},
@@ -1660,7 +1632,6 @@ describe("GraphQL API", () => {
       {},
       {},
       {},
-      {},
       {
         listWorkItemsForIssue: () => Effect.succeed([waiting]),
       },
@@ -1711,7 +1682,6 @@ describe("GraphQL API", () => {
       },
       {},
       {},
-      {},
       {
         listWorkItemsForRepository: (repositoryId) => {
           receivedRepositoryId = repositoryId
@@ -1760,7 +1730,6 @@ describe("GraphQL API", () => {
       {
         listIssues: () => Effect.succeed([issue]),
       },
-      {},
       {},
       {},
       {
@@ -1841,7 +1810,6 @@ describe("GraphQL API", () => {
       },
       {},
       {},
-      {},
       {
         listWorkItemsForRepository: () =>
           Effect.succeed([
@@ -1911,7 +1879,6 @@ describe("GraphQL API", () => {
       {
         listIssues: () => Effect.succeed([issue]),
       },
-      {},
       {},
       {},
       {
@@ -2025,7 +1992,6 @@ describe("GraphQL API", () => {
       },
       {},
       {},
-      {},
       {
         listWorkItemsForRepository: () =>
           Effect.succeed([retriable, terminalFailed, complete, running]),
@@ -2092,7 +2058,6 @@ describe("GraphQL API", () => {
       },
       {},
       {},
-      {},
       {
         listWorkItemsForRepository: () =>
           Effect.succeed([terminalOrphan, unfinishedOrphan, terminalRelevant]),
@@ -2132,7 +2097,6 @@ describe("GraphQL API", () => {
     let receivedArgs: readonly [string, number] | undefined
     await runtime.dispose()
     runtime = makeRuntime(
-      {},
       {},
       {},
       {},
@@ -2184,7 +2148,6 @@ describe("GraphQL API", () => {
       {},
       {},
       {},
-      {},
       {
         implementLocally: (repositoryId, githubIssueNumber) => {
           receivedArgs = [repositoryId, githubIssueNumber]
@@ -2225,7 +2188,6 @@ describe("GraphQL API", () => {
       {},
       {},
       {},
-      {},
       {
         retry: (workItemId) => {
           receivedWorkItemId = workItemId
@@ -2256,7 +2218,6 @@ describe("GraphQL API", () => {
 
   test("accepts a Refresh Job for a Paused Repository without reconciling", async () => {
     const jobId = makeJobId()
-    let reconcilerCalled = false
     let enqueued:
       | {
           queue: string
@@ -2267,12 +2228,6 @@ describe("GraphQL API", () => {
     await runtime.dispose()
     runtime = makeRuntime(
       {},
-      {
-        reconcile: () => {
-          reconcilerCalled = true
-          return Effect.die("not used")
-        },
-      },
       {
         findSecret: ({ account, provider }) =>
           Effect.succeed(
@@ -2318,7 +2273,6 @@ describe("GraphQL API", () => {
       },
     })
     expect(repository.paused).toBe(true)
-    expect(reconcilerCalled).toBe(false)
     expect(enqueued).toEqual({
       queue: "issue-refresh",
       payload: {
@@ -2334,7 +2288,6 @@ describe("GraphQL API", () => {
     let enqueued = false
     await runtime.dispose()
     runtime = makeRuntime(
-      {},
       {},
       {
         enabled: false,
@@ -2372,16 +2325,9 @@ describe("GraphQL API", () => {
 
   test("rejects refresh for an unknown repository without enqueueing", async () => {
     let enqueued = false
-    let reconcilerCalled = false
     await runtime.dispose()
     runtime = makeRuntime(
       {},
-      {
-        reconcile: () => {
-          reconcilerCalled = true
-          return Effect.die("not used")
-        },
-      },
       {},
       {
         enqueue: () => {
@@ -2409,14 +2355,12 @@ describe("GraphQL API", () => {
       ],
     })
     expect(enqueued).toBe(false)
-    expect(reconcilerCalled).toBe(false)
   })
 
   test("rejects refresh when the Repository has no GitHub credential", async () => {
     let enqueued = false
     await runtime.dispose()
     runtime = makeRuntime(
-      {},
       {},
       {
         findSecret: () => Effect.succeed(null),
@@ -2456,7 +2400,6 @@ describe("GraphQL API", () => {
   test("reports enqueue failure without accepting a Refresh Job", async () => {
     await runtime.dispose()
     runtime = makeRuntime(
-      {},
       {},
       {
         findSecret: () => Effect.succeed("GITHUB_TOKEN_ACME_WIDGETS"),
@@ -2602,7 +2545,6 @@ describe("GraphQL API", () => {
     const calls: Array<{ fromMs: number; toMs: number }> = []
     await runtime.dispose()
     runtime = makeRuntime(
-      {},
       {},
       {},
       {},

--- a/packages/graphql-api/test/issue-polling.test.ts
+++ b/packages/graphql-api/test/issue-polling.test.ts
@@ -1,0 +1,168 @@
+import {
+  DateTime,
+  Duration,
+  Effect,
+  Layer,
+  ManagedRuntime,
+  Random,
+} from "effect"
+import {
+  QueueService,
+  type QueueServiceShape,
+  makeJobId,
+} from "@ready-for-agent/queue-service"
+import {
+  ISSUE_POLLING_BASE_SECONDS,
+  ISSUE_POLLING_JITTER_SECONDS,
+  ISSUE_POLL_QUEUE,
+  ISSUE_REFRESH_QUEUE,
+  activateRepositoryPolling,
+  repairPollingSchedules,
+  suspendRepositoryPolling,
+} from "../src/lib/issue-polling.js"
+import { describe, expect, test } from "bun:test"
+
+const makeQueueRuntime = (queue: QueueServiceShape) =>
+  ManagedRuntime.make(Layer.succeed(QueueService, queue))
+
+const repo1 = "repo-01J00000000000000000000001"
+const repoKeep = "repo-01J00000000000000000000002"
+const repoOrphan = "repo-01J00000000000000000000003"
+const repoAdded = "repo-01J00000000000000000000004"
+
+const unusedQueue: QueueServiceShape = {
+  queueInTransaction: true,
+  enqueue: () => Effect.die("not used"),
+  enqueueWithDelay: () => Effect.die("not used"),
+  ensureKeyed: () => Effect.die("not used"),
+  listKeyed: () => Effect.die("not used"),
+  postponeKeyed: () => Effect.die("not used"),
+  removeKeyed: () => Effect.die("not used"),
+  rawClaim: () => Effect.die("not used"),
+  acknowledge: () => Effect.die("not used"),
+  fail: () => Effect.die("not used"),
+  extendVisibility: () => Effect.die("not used"),
+  getStats: () => Effect.die("not used"),
+  requeueByPayloadTag: () => Effect.succeed(0),
+}
+
+describe("issue-polling", () => {
+  test("activateRepositoryPolling ensures keyed schedule and first refresh", async () => {
+    const ensured: Array<{
+      queue: string
+      key: string
+      delay: Duration.Duration
+    }> = []
+    const enqueued: Array<{ queue: string; payload: unknown }> = []
+    const runtime = makeQueueRuntime({
+      ...unusedQueue,
+      enqueue: (queueName, payload) =>
+        Effect.sync(() => {
+          enqueued.push({ queue: queueName, payload })
+          return makeJobId()
+        }),
+      ensureKeyed: (queueName, key, _payload, delay) =>
+        Effect.sync(() => {
+          ensured.push({ queue: queueName, key, delay })
+          return { jobId: makeJobId(), created: true }
+        }),
+    })
+
+    try {
+      await runtime.runPromise(
+        activateRepositoryPolling(repo1).pipe(Random.withSeed(1)),
+      )
+
+      expect(ensured).toHaveLength(1)
+      expect(ensured[0]?.queue).toBe(ISSUE_POLL_QUEUE)
+      expect(ensured[0]?.key).toBe(repo1)
+      const delaySeconds = Duration.toSeconds(ensured[0]!.delay)
+      expect(delaySeconds).toBeGreaterThanOrEqual(ISSUE_POLLING_BASE_SECONDS)
+      expect(delaySeconds).toBeLessThanOrEqual(
+        ISSUE_POLLING_BASE_SECONDS + ISSUE_POLLING_JITTER_SECONDS,
+      )
+      expect(enqueued).toHaveLength(1)
+      expect(enqueued[0]?.queue).toBe(ISSUE_REFRESH_QUEUE)
+      expect(enqueued[0]?.payload).toMatchObject({
+        _tag: "refresh-repository",
+        repositoryId: repo1,
+      })
+    } finally {
+      await runtime.dispose()
+    }
+  })
+
+  test("suspendRepositoryPolling removes the keyed schedule", async () => {
+    const removed: Array<{ queue: string; key: string }> = []
+    const runtime = makeQueueRuntime({
+      ...unusedQueue,
+      removeKeyed: (queueName, key) =>
+        Effect.sync(() => {
+          removed.push({ queue: queueName, key })
+        }),
+    })
+
+    try {
+      await runtime.runPromise(suspendRepositoryPolling(repo1))
+      expect(removed).toEqual([{ queue: ISSUE_POLL_QUEUE, key: repo1 }])
+    } finally {
+      await runtime.dispose()
+    }
+  })
+
+  test("repairPollingSchedules removes orphans and adds missing schedules", async () => {
+    const keyed = new Set([repoOrphan, repoKeep])
+    const removed: string[] = []
+    const ensured: string[] = []
+    const enqueued: string[] = []
+    const runtime = makeQueueRuntime({
+      ...unusedQueue,
+      enqueue: (_queue, payload) =>
+        Effect.sync(() => {
+          const body = payload as { repositoryId: string }
+          enqueued.push(body.repositoryId)
+          return makeJobId()
+        }),
+      ensureKeyed: (_queue, key) =>
+        Effect.sync(() => {
+          ensured.push(key)
+          keyed.add(key)
+          return { jobId: makeJobId(), created: true }
+        }),
+      listKeyed: () =>
+        Effect.sync(() =>
+          [...keyed].map((key) => ({
+            jobId: makeJobId(),
+            queue: ISSUE_POLL_QUEUE,
+            key,
+            payload: { _tag: "refresh-repository" as const, repositoryId: key },
+            attempts: 0,
+            maxAttempts: 2,
+            availableAt: DateTime.makeUnsafe(0),
+            lockedUntil: null,
+          })),
+        ),
+      removeKeyed: (_queue, key) =>
+        Effect.sync(() => {
+          removed.push(key)
+          keyed.delete(key)
+        }),
+    })
+
+    try {
+      await runtime.runPromise(
+        repairPollingSchedules({
+          credentialedRepositoryIds: [repoKeep, repoAdded],
+          sampleDelay: Effect.succeed(Duration.seconds(120)),
+        }),
+      )
+
+      expect(removed).toEqual([repoOrphan])
+      expect(ensured).toEqual([repoAdded])
+      expect(enqueued).toEqual([repoAdded])
+      expect([...keyed].sort()).toEqual([repoKeep, repoAdded].sort())
+    } finally {
+      await runtime.dispose()
+    }
+  })
+})

--- a/packages/graphql-api/tsconfig.lib.json
+++ b/packages/graphql-api/tsconfig.lib.json
@@ -23,13 +23,7 @@
       "path": "../keymaxxer-service/tsconfig.lib.json"
     },
     {
-      "path": "../issue-reconciler/tsconfig.lib.json"
-    },
-    {
       "path": "../graphql-schema/tsconfig.lib.json"
-    },
-    {
-      "path": "../github-service/tsconfig.lib.json"
     },
     {
       "path": "../db-service/tsconfig.lib.json"


### PR DESCRIPTION
## Summary

- Shared `runGraphql` runner for Query/Mutation/Subscription with consistent `toGraphQLError` mapping
- Split projection, credential helpers, and `_tag`-based error mapping out of the monolithic GraphQL module
- Drop unused `IssueReconciler` from GraphQL runtime; Effect-native models cache; named spans/polling ops; package-local issue-polling tests

Closes #302.

## Test plan

- [x] `bunx nx test graphql-api`
- [x] `bunx nx run graphql-api:build`
- [x] Pre-commit affected lint/typecheck/test