### PR TITLE
refactor(db): tighten Effect boundaries for SqlClient stacks

### DIFF
--- a/apps/harness/src/server/production-lifecycle.ts
+++ b/apps/harness/src/server/production-lifecycle.ts
@@ -136,7 +136,7 @@ const applyProductionMigrations = async (
   _environment: NodeJS.ProcessEnv = process.env,
 ): Promise<void> => {
   await Effect.runPromise(
-    runConfiguredMigrations.pipe(
+    runConfiguredMigrations().pipe(
       Effect.provide(DatabaseLive),
       Effect.tap(() =>
         Effect.sync(() => {

--- a/packages/db/src/bin/migrate.ts
+++ b/packages/db/src/bin/migrate.ts
@@ -2,7 +2,7 @@ import { Effect } from "effect"
 import { DatabaseLive } from "../lib/database-live.js"
 import { runConfiguredMigrations } from "../lib/run-migrations.js"
 
-const program = runConfiguredMigrations.pipe(
+const program = runConfiguredMigrations().pipe(
   Effect.provide(DatabaseLive),
   Effect.tap(() =>
     Effect.sync(() => {

--- a/packages/db/src/lib/database-live.ts
+++ b/packages/db/src/lib/database-live.ts
@@ -1,7 +1,7 @@
 import { mkdirSync } from "node:fs"
 import { dirname } from "node:path"
 import { SqliteClient } from "@effect/sql-sqlite-bun"
-import { Effect, Layer } from "effect"
+import { Effect, Layer, Schema } from "effect"
 import { SqlClient } from "effect/unstable/sql"
 import {
   DatabasePathConfig,
@@ -9,20 +9,43 @@ import {
   toTursoDatabasePath,
 } from "@ready-for-agent/layer-turso-local/database-path"
 
-const ensureLocalDatabaseParentDir = (path: string) => {
-  if (path === ":memory:") return
-  mkdirSync(dirname(path), { recursive: true })
-}
+export class DatabaseDirectoryError extends Schema.TaggedErrorClass<DatabaseDirectoryError>()(
+  "DatabaseDirectoryError",
+  {
+    path: Schema.String,
+    cause: Schema.Defect(),
+  },
+) {}
+
+const ensureLocalDatabaseParentDir = (path: string) =>
+  path === ":memory:"
+    ? Effect.void
+    : Effect.try({
+        try: () => {
+          mkdirSync(dirname(path), { recursive: true })
+        },
+        catch: (cause) =>
+          new DatabaseDirectoryError({ path: dirname(path), cause }),
+      })
 
 /**
- * Production database layer: Bun-native SQLite (works inside compiled host binaries)
- * + SQLITE_DATABASE_PATH / product data-dir resolution from layer-turso-local.
+ * Production database layer for the harness: Bun-native SQLite
+ * (`@effect/sql-sqlite-bun`) plus path resolution from
+ * `@ready-for-agent/layer-turso-local` (`SQLITE_DATABASE_PATH` /
+ * product data-dir).
+ *
+ * Prefer this for host binaries and the default app stack
+ * (`DbServiceLive.pipe(Layer.provideMerge(DatabaseLive))`).
+ *
+ * For a Turso SDK `SqlClient` instead, compose
+ * `@ready-for-agent/layer-turso-local`'s `makeTursoLive` /
+ * `TursoLive` — same path config, different driver.
  */
 export const DatabaseLive = Layer.unwrap(
   Effect.gen(function* () {
     const configured = yield* DatabasePathConfig
     const filename = toTursoDatabasePath(normalizeDatabasePath(configured))
-    ensureLocalDatabaseParentDir(filename)
+    yield* ensureLocalDatabaseParentDir(filename)
     const client = SqliteClient.layer({
       filename,
       create: true,

--- a/packages/db/src/lib/database-test.ts
+++ b/packages/db/src/lib/database-test.ts
@@ -1,9 +1,7 @@
 import { SqliteClient } from "@effect/sql-sqlite-bun"
-import { type Config, Effect, Layer } from "effect"
+import { Effect, Layer } from "effect"
 import { SqlClient } from "effect/unstable/sql"
-import type { SqlError } from "effect/unstable/sql/SqlError"
 import {
-  type MigrationReadError,
   MigrationsFolderConfig,
   defaultMigrationsFolder,
   runMigrations,
@@ -34,15 +32,7 @@ const MigrationLayer = Layer.effectDiscard(
 )
 
 /**
- * Full test database layer: in-memory SQLite + migrations + typed Drizzle.
+ * Full test database layer: in-memory SQLite + migrations.
+ * Default consumer path for tests; production uses {@link DatabaseLive}.
  */
-export const DatabaseTest: Layer.Layer<
-  SqlClient.SqlClient | SqliteClient.SqliteClient,
-  Config.ConfigError | MigrationReadError | SqlError
-> = Layer.merge(
-  SqliteTest,
-  MigrationLayer.pipe(Layer.provide(SqliteTest)),
-) as unknown as Layer.Layer<
-  SqlClient.SqlClient | SqliteClient.SqliteClient,
-  Config.ConfigError | MigrationReadError | SqlError
->
+export const DatabaseTest = MigrationLayer.pipe(Layer.provideMerge(SqliteTest))

--- a/packages/db/src/lib/run-migrations.ts
+++ b/packages/db/src/lib/run-migrations.ts
@@ -24,9 +24,9 @@ export const MigrationsFolderConfig = Config.string("MIGRATIONS_FOLDER").pipe(
 
 const rawSql = (query: string) => Object.assign([query], { raw: [query] })
 
-type MigrationRow = {
-  readonly hash: string
-}
+const MigrationAppliedRow = Schema.Struct({
+  hash: Schema.String,
+})
 
 export type MigrationSource = {
   readonly name: string
@@ -78,79 +78,87 @@ const readMigrationSourcesFromFolder = (migrationsFolder: string) =>
     catch: (cause) => new MigrationReadError({ cause }),
   })
 
-const applyMigrationRecords = (migrations: ReadonlyArray<MigrationRecord>) =>
-  Effect.gen(function* () {
-    const sql = yield* SqlClient.SqlClient
+const applyMigrationRecords = Effect.fn("applyMigrationRecords")(function* (
+  migrations: ReadonlyArray<MigrationRecord>,
+) {
+  const sql = yield* SqlClient.SqlClient
 
-    yield* sql`
-      CREATE TABLE IF NOT EXISTS __drizzle_migrations (
-        id INTEGER PRIMARY KEY,
-        hash text NOT NULL,
-        created_at numeric,
-        name text,
-        applied_at TEXT
-      )
-    `
+  yield* sql`
+    CREATE TABLE IF NOT EXISTS __drizzle_migrations (
+      id INTEGER PRIMARY KEY,
+      hash text NOT NULL,
+      created_at numeric,
+      name text,
+      applied_at TEXT
+    )
+  `
 
-    const appliedRows = (yield* sql`
-      SELECT hash FROM __drizzle_migrations
-    `) as ReadonlyArray<MigrationRow>
-    const appliedHashes = new Set(appliedRows.map((row) => row.hash))
+  const appliedRows = yield* sql`SELECT hash FROM __drizzle_migrations`.pipe(
+    Effect.flatMap(
+      Schema.decodeUnknownEffect(Schema.Array(MigrationAppliedRow)),
+    ),
+  )
+  const appliedHashes = new Set(appliedRows.map((row) => row.hash))
 
-    for (const migration of migrations) {
-      if (appliedHashes.has(migration.hash)) {
-        continue
-      }
-
-      yield* sql.withTransaction(
-        Effect.gen(function* () {
-          for (const query of migration.statements) {
-            if (query.trim().length > 0) {
-              yield* sql(rawSql(query))
-            }
-          }
-
-          yield* sql`
-            INSERT INTO __drizzle_migrations (hash, created_at, name, applied_at)
-            VALUES (
-              ${migration.hash},
-              ${migration.folderMillis},
-              ${migration.name},
-              ${new Date().toISOString()}
-            )
-          `
-        }),
-      )
+  for (const migration of migrations) {
+    if (appliedHashes.has(migration.hash)) {
+      continue
     }
-  })
+
+    yield* sql.withTransaction(
+      Effect.gen(function* () {
+        for (const query of migration.statements) {
+          if (query.trim().length > 0) {
+            yield* sql(rawSql(query))
+          }
+        }
+
+        yield* sql`
+          INSERT INTO __drizzle_migrations (hash, created_at, name, applied_at)
+          VALUES (
+            ${migration.hash},
+            ${migration.folderMillis},
+            ${migration.name},
+            ${new Date().toISOString()}
+          )
+        `
+      }),
+    )
+  }
+})
 
 /**
  * Apply Drizzle migration SQL sources via the current SqlClient.
  * Skips migrations already recorded in __drizzle_migrations.
  */
-export const runMigrationsFromSources = (
-  sources: ReadonlyArray<MigrationSource>,
-) => applyMigrationRecords(toMigrationRecords(sources))
+export const runMigrationsFromSources = Effect.fn("runMigrationsFromSources")(
+  function* (sources: ReadonlyArray<MigrationSource>) {
+    yield* applyMigrationRecords(toMigrationRecords(sources))
+  },
+)
 
 /**
  * Apply Drizzle migration SQL files via the current SqlClient.
  * Skips migrations already recorded in __drizzle_migrations.
  */
-export const runMigrations = (migrationsFolder: string) =>
-  Effect.gen(function* () {
-    const sources = yield* readMigrationSourcesFromFolder(migrationsFolder)
-    yield* runMigrationsFromSources(sources)
-  })
+export const runMigrations = Effect.fn("runMigrations")(function* (
+  migrationsFolder: string,
+) {
+  const sources = yield* readMigrationSourcesFromFolder(migrationsFolder)
+  yield* runMigrationsFromSources(sources)
+})
 
 /**
  * Run migrations using embedded SQL when present, otherwise MIGRATIONS_FOLDER
  * (defaults to db-schema/drizzle on disk).
  */
-export const runConfiguredMigrations = Effect.gen(function* () {
-  if (embeddedMigrationSources.length > 0) {
-    yield* runMigrationsFromSources(embeddedMigrationSources)
-    return
-  }
-  const migrationsFolder = yield* MigrationsFolderConfig
-  yield* runMigrations(migrationsFolder)
-})
+export const runConfiguredMigrations = Effect.fn("runConfiguredMigrations")(
+  function* () {
+    if (embeddedMigrationSources.length > 0) {
+      yield* runMigrationsFromSources(embeddedMigrationSources)
+      return
+    }
+    const migrationsFolder = yield* MigrationsFolderConfig
+    yield* runMigrations(migrationsFolder)
+  },
+)

--- a/packages/layer-turso-local/src/lib/client-live.ts
+++ b/packages/layer-turso-local/src/lib/client-live.ts
@@ -1,7 +1,15 @@
 import { mkdirSync } from "node:fs"
 import { dirname } from "node:path"
 import { connect } from "@tursodatabase/database"
-import { Context, Effect, Layer, Scope, Semaphore, Stream } from "effect"
+import {
+  Context,
+  Effect,
+  Layer,
+  Schema,
+  Scope,
+  Semaphore,
+  Stream,
+} from "effect"
 import * as Reactivity from "effect/unstable/reactivity/Reactivity"
 import * as Client from "effect/unstable/sql/SqlClient"
 import type { Connection } from "effect/unstable/sql/SqlConnection"
@@ -44,14 +52,44 @@ const sqlError = (cause: unknown, operation: string) =>
     }),
   })
 
-const ensureLocalDatabaseParentDir = (path: string) => {
-  if (path === ":memory:") return
-  mkdirSync(dirname(path), { recursive: true })
-}
+export class DatabaseDirectoryError extends Schema.TaggedErrorClass<DatabaseDirectoryError>()(
+  "DatabaseDirectoryError",
+  {
+    path: Schema.String,
+    cause: Schema.Defect(),
+  },
+) {}
+
+const ensureLocalDatabaseParentDir = (path: string) =>
+  path === ":memory:"
+    ? Effect.void
+    : Effect.try({
+        try: () => {
+          mkdirSync(dirname(path), { recursive: true })
+        },
+        catch: (cause) =>
+          new DatabaseDirectoryError({ path: dirname(path), cause }),
+      })
+
+/** Streaming SQL is not implemented for the Turso local driver. */
+const executeStreamUnsupported = () =>
+  Stream.fail(
+    new SqlError({
+      reason: classifySqliteError(
+        new Error(
+          "executeStream is not supported by the Turso local SqlClient",
+        ),
+        {
+          message: "executeStream is not supported",
+          operation: "executeStream",
+        },
+      ),
+    }),
+  )
 
 const makeClient = (path: string, options?: TursoClientOptions) =>
   Effect.gen(function* () {
-    ensureLocalDatabaseParentDir(path)
+    yield* ensureLocalDatabaseParentDir(path)
     const databaseOptions: NonNullable<Parameters<typeof connect>[1]> = {}
     if (options?.defaultQueryTimeout !== undefined)
       databaseOptions.defaultQueryTimeout = options.defaultQueryTimeout
@@ -60,7 +98,14 @@ const makeClient = (path: string, options?: TursoClientOptions) =>
       catch: (cause) => sqlError(cause, "open database"),
     })
     yield* Effect.addFinalizer(() =>
-      Effect.promise(() => db.close()).pipe(Effect.ignore),
+      Effect.tryPromise({
+        try: () => db.close(),
+        catch: (cause) => sqlError(cause, "close database"),
+      }).pipe(
+        Effect.catch((error) =>
+          Effect.logWarning("Failed to close Turso database", { error }),
+        ),
+      ),
     )
 
     yield* Effect.tryPromise({
@@ -97,7 +142,7 @@ const makeClient = (path: string, options?: TursoClientOptions) =>
         execute(sql, params).pipe(
           Effect.map((rows) => (transformRows ? transformRows(rows) : rows)),
         ),
-      executeStream: () => Stream.die("executeStream not implemented"),
+      executeStream: executeStreamUnsupported,
     }
     const semaphore = yield* Semaphore.make(1)
     const acquirer = semaphore.withPermits(1)(Effect.succeed(connection))
@@ -122,6 +167,12 @@ const makeClient = (path: string, options?: TursoClientOptions) =>
     })
   })
 
+/**
+ * Turso SDK `SqlClient` layer (`@tursodatabase/database`).
+ * Shares `DatabasePathConfig` with `@ready-for-agent/db`'s `DatabaseLive`
+ * (Bun SQLite). Prefer `DatabaseLive` for the harness host binary; use this
+ * layer when you need the Turso driver (e.g. concurrent-tx / multiproc tests).
+ */
 export const makeTursoLive = (options?: TursoClientOptions) =>
   Layer.effectContext(
     Effect.gen(function* () {

--- a/packages/layer-turso-local/src/lib/database-path.ts
+++ b/packages/layer-turso-local/src/lib/database-path.ts
@@ -1,7 +1,6 @@
 import { homedir } from "node:os"
 import { isAbsolute, join, resolve } from "node:path"
-import { Context } from "effect"
-import * as Config from "effect/Config"
+import { Config, Context, Option } from "effect"
 
 /**
  * Human-readable database connection info for logging.
@@ -66,15 +65,39 @@ export const resolveProductDatabasePath = (
   input: ProductDataDirInput,
 ): string => join(resolveProductDataDir(input), "ready-for-agent.db")
 
-const productDatabasePathFromProcess = (): string =>
-  resolveProductDatabasePath({
-    env: {
-      HOME: process.env.HOME,
-      XDG_DATA_HOME: process.env.XDG_DATA_HOME,
-    },
-    platform: process.platform,
-    home: process.env.HOME?.trim() || homedir(),
-  })
+/**
+ * Default product database path via Config (`HOME`, `XDG_DATA_HOME`).
+ * ConfigProvider overrides cover these keys; `homedir()` is only the last
+ * resort when `HOME` is absent from the provider.
+ */
+const nonEmptyConfigString = (
+  name: string,
+): Config.Config<Option.Option<string>> =>
+  Config.option(Config.string(name)).pipe(
+    Config.map((value) =>
+      Option.flatMap(value, (raw) => {
+        const trimmed = raw.trim()
+        return trimmed === "" ? Option.none() : Option.some(trimmed)
+      }),
+    ),
+  )
+
+const productDatabasePathConfig: Config.Config<string> = Config.all({
+  HOME: nonEmptyConfigString("HOME"),
+  XDG_DATA_HOME: nonEmptyConfigString("XDG_DATA_HOME"),
+}).pipe(
+  Config.map(({ HOME, XDG_DATA_HOME }) => {
+    const home = Option.getOrElse(HOME, () => homedir())
+    return resolveProductDatabasePath({
+      env: {
+        HOME: Option.getOrUndefined(HOME),
+        XDG_DATA_HOME: Option.getOrUndefined(XDG_DATA_HOME),
+      },
+      platform: process.platform,
+      home,
+    })
+  }),
+)
 
 /**
  * Effect Config for the database path (SQLITE_DATABASE_PATH).
@@ -82,7 +105,7 @@ const productDatabasePathFromProcess = (): string =>
  */
 export const DatabasePathConfig: Config.Config<string> = Config.string(
   "SQLITE_DATABASE_PATH",
-).pipe(Config.orElse(() => Config.succeed(productDatabasePathFromProcess())))
+).pipe(Config.orElse(() => productDatabasePathConfig))
 
 export const DATABASE_PATH_NOT_CONFIGURED =
   "Database path not configured. Set SQLITE_DATABASE_PATH environment variable."

--- a/packages/layer-turso-local/test/concurrent-transaction.spec.ts
+++ b/packages/layer-turso-local/test/concurrent-transaction.spec.ts
@@ -1,7 +1,7 @@
 import { existsSync } from "node:fs"
 import { unlink } from "node:fs/promises"
 import { connect } from "@tursodatabase/database"
-import { ConfigProvider, Effect, Layer } from "effect"
+import { ConfigProvider, Effect, Exit, Layer, Stream } from "effect"
 import * as SqlClient from "effect/unstable/sql/SqlClient"
 import { makeTursoLive } from "../src/index.js"
 import { describe, expect, it } from "bun:test"
@@ -284,6 +284,30 @@ describe("makeTursoLive", () => {
         expect(rows).toEqual([{ value: "ok" }])
       } finally {
         await db.close()
+      }
+    } finally {
+      await cleanupDb(dbPath)
+    }
+  })
+
+  it("fails executeStream with a typed SqlError", async () => {
+    const dbPath = tempDbPath()
+    const TestLayer = makeTestLayer(dbPath)
+
+    try {
+      const exit = await Effect.runPromise(
+        Effect.gen(function* () {
+          const sql = yield* SqlClient.SqlClient
+          return yield* Effect.exit(
+            Stream.runCollect(sql(sqlQuery("SELECT 1")).stream),
+          )
+        }).pipe(Effect.provide(TestLayer)),
+      )
+
+      expect(Exit.isFailure(exit)).toBe(true)
+      if (Exit.isFailure(exit)) {
+        const error = exit.cause
+        expect(String(error)).toContain("executeStream")
       }
     } finally {
       await cleanupDb(dbPath)

--- a/packages/layer-turso-local/test/normalize-path.spec.ts
+++ b/packages/layer-turso-local/test/normalize-path.spec.ts
@@ -1,4 +1,6 @@
+import { ConfigProvider, Effect } from "effect"
 import {
+  DatabasePathConfig,
   isLocalFilePath,
   normalizeDatabasePath,
   resolveProductDataDir,
@@ -68,5 +70,53 @@ describe("Turso database path helpers", () => {
         home: "/home/op",
       }),
     ).toBe("/home/op/.local/share/ready-for-agent/ready-for-agent.db")
+  })
+
+  it("resolves DatabasePathConfig defaults via ConfigProvider HOME/XDG", async () => {
+    const path = await Effect.runPromise(
+      DatabasePathConfig.pipe(
+        Effect.provide(
+          ConfigProvider.layer(
+            ConfigProvider.fromUnknown({
+              HOME: "/home/cfg",
+              XDG_DATA_HOME: "/var/cfg-data",
+            }),
+          ),
+        ),
+      ),
+    )
+    expect(path).toBe("/var/cfg-data/ready-for-agent/ready-for-agent.db")
+  })
+
+  it("prefers SQLITE_DATABASE_PATH over product defaults", async () => {
+    const path = await Effect.runPromise(
+      DatabasePathConfig.pipe(
+        Effect.provide(
+          ConfigProvider.layer(
+            ConfigProvider.fromUnknown({
+              SQLITE_DATABASE_PATH: "/tmp/explicit.db",
+              HOME: "/home/cfg",
+            }),
+          ),
+        ),
+      ),
+    )
+    expect(path).toBe("/tmp/explicit.db")
+  })
+
+  it("treats whitespace-only HOME as unset for product defaults", async () => {
+    const path = await Effect.runPromise(
+      DatabasePathConfig.pipe(
+        Effect.provide(
+          ConfigProvider.layer(
+            ConfigProvider.fromUnknown({
+              HOME: "   ",
+              XDG_DATA_HOME: "/var/cfg-data",
+            }),
+          ),
+        ),
+      ),
+    )
+    expect(path).toBe("/var/cfg-data/ready-for-agent/ready-for-agent.db")
   })
 })


### PR DESCRIPTION
## Summary
- Route db/Turso mkdir and path defaults through Effect errors and Config, with typed `executeStream`/close handling on the Turso client.
- Remove `DatabaseTest` layer casts; trace migrations with `Effect.fn` and Schema-decode applied migration rows.
- Document Bun vs Turso composition paths for consumers.

Closes #303

## Test plan
- [x] `bunx nx test db`
- [x] `bunx nx test layer-turso-local`
- [x] `bunx nx typecheck db` / `layer-turso-local`
- [x] Pre-commit affected lint/typecheck/test