### PR TITLE
refactor(db-service): tighten Effect data and error modeling

### DIFF
--- a/packages/db-service/src/lib/db-service.ts
+++ b/packages/db-service/src/lib/db-service.ts
@@ -1,4 +1,4 @@
-import { Clock, Context, Effect, Layer, PubSub, Stream } from "effect"
+import { Clock, Context, Effect, Layer, PubSub, Schema, Stream } from "effect"
 import { SqlClient } from "effect/unstable/sql"
 import type { SqlError } from "effect/unstable/sql/SqlError"
 import { ulid } from "ulidx"
@@ -13,16 +13,23 @@ import {
   RepositoryHasRunningStepError,
   RepositoryNotFoundError,
 } from "./errors.js"
-import type {
-  AddRepositoryInput,
+import {
+  type AddRepositoryInput,
   ConfigRecord,
-  IssueDependency,
+  ConfigSqlRow,
+  type IssueDependency,
+  IssueDependencySqlRow,
   IssueRecord,
+  IssueSqlRow,
+  RepositoryId,
   RepositoryRecord,
-  StoreIssueInput,
-  UpdateConfigInput,
-  UpdateRepositorySettingsInput,
+  RepositorySqlRow,
+  RunningStepSqlRow,
+  type StoreIssueInput,
+  type UpdateConfigInput,
+  type UpdateRepositorySettingsInput,
   WorkItemPullRequest,
+  WorkItemPullRequestSqlRow,
 } from "./types.js"
 
 const formatSqlError = (error: SqlError): string => {
@@ -75,69 +82,6 @@ const trimRequired = (
   return Effect.succeed(trimmed)
 }
 
-const toRecord = (row: {
-  id: string
-  githubOwner: string
-  githubRepo: string
-  localPath: string
-  isBare: boolean | number
-  paused: boolean | number
-  defaultModel: string | null
-  defaultVariant: string | null
-  reviewModel: string | null
-  reviewVariant: string | null
-  autoMerge: boolean | number
-  issuesReconciledAt: number | null
-}): RepositoryRecord => ({
-  id: row.id,
-  githubOwner: row.githubOwner,
-  githubRepo: row.githubRepo,
-  localPath: row.localPath,
-  isBare: Boolean(row.isBare),
-  paused: Boolean(row.paused),
-  defaultModel: row.defaultModel,
-  defaultVariant: row.defaultVariant,
-  reviewModel: row.reviewModel,
-  reviewVariant: row.reviewVariant,
-  autoMerge: Boolean(row.autoMerge),
-  issuesReconciledAt:
-    row.issuesReconciledAt === null ? null : new Date(row.issuesReconciledAt),
-})
-
-type RepositoryRow = {
-  id: string
-  github_owner: string
-  github_repo: string
-  local_path: string
-  is_bare: boolean | number
-  paused: boolean | number
-  default_model: string | null
-  default_variant: string | null
-  review_model: string | null
-  review_variant: string | null
-  auto_merge: boolean | number
-  issues_reconciled_at: number | null
-}
-
-const repositorySelectColumns = `id, github_owner, github_repo, local_path, is_bare, paused,
-             default_model, default_variant, review_model, review_variant, auto_merge, issues_reconciled_at`
-
-const toRecordFromRow = (row: RepositoryRow): RepositoryRecord =>
-  toRecord({
-    id: row.id,
-    githubOwner: row.github_owner,
-    githubRepo: row.github_repo,
-    localPath: row.local_path,
-    isBare: row.is_bare,
-    paused: row.paused,
-    defaultModel: row.default_model,
-    defaultVariant: row.default_variant,
-    reviewModel: row.review_model,
-    reviewVariant: row.review_variant,
-    autoMerge: row.auto_merge,
-    issuesReconciledAt: row.issues_reconciled_at,
-  })
-
 const normalizeOptionalSetting = (
   value: string | null,
 ): Effect.Effect<string | null, InvalidRepositorySettingsError> => {
@@ -164,21 +108,54 @@ const normalizeOptionalConfigSetting = (
   return Effect.succeed(trimmed)
 }
 
-const toIssueRecord = (row: {
-  id: string
-  repositoryId: string
-  githubIssueNumber: number
-  title: string
-  body: string
-  url: string
-  state: "OPEN" | "CLOSED"
-  githubCreatedAt: number
-  parentGithubIssueNumber: number | null
-  parentGithubIssueUrl: string | null
-  parentPosition: number | null
-  hasChildren: number | boolean
-  blockedBy: readonly IssueDependency[]
-}): IssueRecord => ({
+const toDatabaseError = (error: SqlError) =>
+  new DatabaseError({
+    message: `Database error: ${formatSqlError(error)}`,
+    cause: error,
+  })
+
+const toSchemaDatabaseError = (error: Schema.SchemaError) =>
+  new DatabaseError({
+    message: `Database row shape error: ${error.message}`,
+    cause: error,
+  })
+
+const decodeRepositoryRows = (rows: ReadonlyArray<unknown>) =>
+  Schema.decodeUnknownEffect(Schema.Array(RepositorySqlRow))(rows).pipe(
+    Effect.mapError(toSchemaDatabaseError),
+  )
+const decodeConfigRows = (rows: ReadonlyArray<unknown>) =>
+  Schema.decodeUnknownEffect(Schema.Array(ConfigSqlRow))(rows).pipe(
+    Effect.mapError(toSchemaDatabaseError),
+  )
+const decodeIssueRows = (rows: ReadonlyArray<unknown>) =>
+  Schema.decodeUnknownEffect(Schema.Array(IssueSqlRow))(rows).pipe(
+    Effect.mapError(toSchemaDatabaseError),
+  )
+const decodeIssueDependencyRows = (rows: ReadonlyArray<unknown>) =>
+  Schema.decodeUnknownEffect(Schema.Array(IssueDependencySqlRow))(rows).pipe(
+    Effect.mapError(toSchemaDatabaseError),
+  )
+const decodeWorkItemPullRequestRows = (rows: ReadonlyArray<unknown>) =>
+  Schema.decodeUnknownEffect(Schema.Array(WorkItemPullRequestSqlRow))(
+    rows,
+  ).pipe(Effect.mapError(toSchemaDatabaseError))
+const decodeRunningStepRows = (rows: ReadonlyArray<unknown>) =>
+  Schema.decodeUnknownEffect(Schema.Array(RunningStepSqlRow))(rows).pipe(
+    Effect.mapError(toSchemaDatabaseError),
+  )
+
+const repositorySelectColumns = `id, github_owner, github_repo, local_path, is_bare, paused,
+             default_model, default_variant, review_model, review_variant, auto_merge, issues_reconciled_at`
+
+const issueSelectColumns = `id, repository_id, github_issue_number, title, body, url, state,
+                github_created_at, parent_github_issue_number,
+                parent_github_issue_url, parent_position, has_children`
+
+const toIssueRecord = (
+  row: IssueSqlRow,
+  blockedBy: readonly IssueDependency[],
+): IssueRecord => ({
   id: row.id,
   repositoryId: row.repositoryId,
   githubIssueNumber: row.githubIssueNumber,
@@ -188,7 +165,7 @@ const toIssueRecord = (row: {
   state: row.state,
   githubCreatedAt: new Date(row.githubCreatedAt),
   parentPosition: row.parentPosition,
-  hasChildren: Boolean(row.hasChildren),
+  hasChildren: row.hasChildren,
   parent:
     row.parentGithubIssueNumber === null || row.parentGithubIssueUrl === null
       ? null
@@ -196,19 +173,19 @@ const toIssueRecord = (row: {
           githubIssueNumber: row.parentGithubIssueNumber,
           githubIssueUrl: row.parentGithubIssueUrl,
         },
-  blockedBy: row.blockedBy,
+  blockedBy,
 })
-
-const toDatabaseError = (error: SqlError) =>
-  new DatabaseError({
-    message: `Database error: ${formatSqlError(error)}`,
-    cause: error,
-  })
 
 export interface DbServiceShape {
   readonly repositoryChanges: Stream.Stream<void>
   readonly issueChanges: Stream.Stream<string>
   readonly workItemChanges: Stream.Stream<string>
+  /**
+   * Publish that a repository's issue set changed. Issue mutations
+   * (`storeIssue`, `deleteIssue`, `markIssuesReconciled`) do **not** publish
+   * automatically so batch reconciles can notify once; callers must invoke this
+   * after a successful mutation batch when subscribers should refresh.
+   */
   readonly notifyIssuesChanged: (repositoryId: string) => Effect.Effect<void>
   readonly notifyWorkItemsChanged: (repositoryId: string) => Effect.Effect<void>
   readonly getConfig: Effect.Effect<ConfigRecord, DatabaseError>
@@ -246,6 +223,10 @@ export interface DbServiceShape {
     void,
     RepositoryNotFoundError | RepositoryHasRunningStepError | DatabaseError
   >
+  /**
+   * Upsert one issue. Does not publish `issueChanges`; call `notifyIssuesChanged`
+   * after the mutation batch when UI/subscribers should refresh.
+   */
   readonly storeIssue: (
     input: StoreIssueInput,
   ) => Effect.Effect<
@@ -264,10 +245,18 @@ export interface DbServiceShape {
     readonly WorkItemPullRequest[],
     RepositoryNotFoundError | DatabaseError
   >
+  /**
+   * Delete one issue. Does not publish `issueChanges`; call `notifyIssuesChanged`
+   * after the mutation batch when UI/subscribers should refresh.
+   */
   readonly deleteIssue: (
     repositoryId: string,
     githubIssueNumber: number,
   ) => Effect.Effect<void, RepositoryNotFoundError | DatabaseError>
+  /**
+   * Record reconciliation completion. Does not publish `issueChanges`; call
+   * `notifyIssuesChanged` after the mutation batch when UI/subscribers should refresh.
+   */
   readonly markIssuesReconciled: (
     repositoryId: string,
     reconciledAt: Date,
@@ -281,7 +270,9 @@ export class DbService extends Context.Service<DbService, DbServiceShape>()(
 /**
  * Process-global PubSubs. Survive Effect Layer rebuilds and HMR so workers and
  * GraphQL subscriptions always share the same signal channel (in-layer PubSubs
- * leave zombie workers publishing to a bus nobody listens to).
+ * leave zombie workers publishing to a bus nobody listens to). Kept intentionally
+ * outside Layer lifecycle; do not replace with Layer-scoped PubSub without a
+ * shared root layer that outlives both the job worker and GraphQL runtime.
  */
 const repositoryChangesKey = Symbol.for(
   "@ready-for-agent/db-service/repository-changes",
@@ -346,7 +337,7 @@ export const DbServiceLive = Layer.effect(
 
     const getConfig: Effect.Effect<ConfigRecord, DatabaseError> = Effect.gen(
       function* () {
-        const now = Date.now()
+        const now = yield* Clock.currentTimeMillis
         yield* sql
           .unsafe(
             `INSERT OR IGNORE INTO config (
@@ -365,82 +356,72 @@ export const DbServiceLive = Layer.effect(
              FROM config WHERE id = 'default'`,
           )
           .pipe(Effect.mapError(toDatabaseError))
-        const row = rows[0] as
-          | {
-              default_model: string | null
-              default_variant: string | null
-              review_model: string | null
-              review_variant: string | null
-              max_concurrent_opencode_sessions: number
-              max_concurrent_work_items: number
-            }
-          | undefined
+        const decoded = yield* decodeConfigRows(rows)
+        const row = decoded[0]
         if (!row) {
           return yield* new DatabaseError({
             message: "No config returned after initialization",
           })
         }
-        return {
-          defaultModel: row.default_model,
-          defaultVariant: row.default_variant,
-          reviewModel: row.review_model,
-          reviewVariant: row.review_variant,
-          maxConcurrentOpencodeSessions: row.max_concurrent_opencode_sessions,
-          maxConcurrentWorkItems: row.max_concurrent_work_items,
-        }
+        return ConfigRecord.make({
+          defaultModel: row.defaultModel,
+          defaultVariant: row.defaultVariant,
+          reviewModel: row.reviewModel,
+          reviewVariant: row.reviewVariant,
+          maxConcurrentOpencodeSessions: row.maxConcurrentOpencodeSessions,
+          maxConcurrentWorkItems: row.maxConcurrentWorkItems,
+        })
       },
-    )
+    ).pipe(Effect.withSpan("DbService.getConfig"))
 
-    const updateConfig = (
+    const updateConfig = Effect.fn("DbService.updateConfig")(function* (
       input: UpdateConfigInput,
-    ): Effect.Effect<ConfigRecord, InvalidConfigInputError | DatabaseError> =>
-      Effect.gen(function* () {
-        const defaultModel = input.defaultModel.trim()
-        if (defaultModel.length === 0) {
-          return yield* new InvalidConfigInputError({
-            field: "defaultModel",
-            message: "defaultModel cannot be empty",
-          })
-        }
-        const defaultVariant = input.defaultVariant.trim()
-        if (defaultVariant.length === 0) {
-          return yield* new InvalidConfigInputError({
-            field: "defaultVariant",
-            message: "defaultVariant cannot be empty",
-          })
-        }
-        const reviewModel = yield* normalizeOptionalConfigSetting(
-          input.reviewModel,
-        )
-        const reviewVariant = yield* normalizeOptionalConfigSetting(
-          input.reviewVariant,
-        )
-        if (
-          !Number.isSafeInteger(input.maxConcurrentOpencodeSessions) ||
-          input.maxConcurrentOpencodeSessions < 1
-        ) {
-          return yield* new InvalidConfigInputError({
-            field: "maxConcurrentOpencodeSessions",
-            message: "maxConcurrentOpencodeSessions must be a positive integer",
-          })
-        }
-        const maxConcurrentOpencodeSessions =
-          input.maxConcurrentOpencodeSessions
-        if (
-          !Number.isSafeInteger(input.maxConcurrentWorkItems) ||
-          input.maxConcurrentWorkItems < 1
-        ) {
-          return yield* new InvalidConfigInputError({
-            field: "maxConcurrentWorkItems",
-            message: "maxConcurrentWorkItems must be a positive integer",
-          })
-        }
-        const maxConcurrentWorkItems = input.maxConcurrentWorkItems
+    ) {
+      const defaultModel = input.defaultModel.trim()
+      if (defaultModel.length === 0) {
+        return yield* new InvalidConfigInputError({
+          field: "defaultModel",
+          message: "defaultModel cannot be empty",
+        })
+      }
+      const defaultVariant = input.defaultVariant.trim()
+      if (defaultVariant.length === 0) {
+        return yield* new InvalidConfigInputError({
+          field: "defaultVariant",
+          message: "defaultVariant cannot be empty",
+        })
+      }
+      const reviewModel = yield* normalizeOptionalConfigSetting(
+        input.reviewModel,
+      )
+      const reviewVariant = yield* normalizeOptionalConfigSetting(
+        input.reviewVariant,
+      )
+      if (
+        !Number.isSafeInteger(input.maxConcurrentOpencodeSessions) ||
+        input.maxConcurrentOpencodeSessions < 1
+      ) {
+        return yield* new InvalidConfigInputError({
+          field: "maxConcurrentOpencodeSessions",
+          message: "maxConcurrentOpencodeSessions must be a positive integer",
+        })
+      }
+      const maxConcurrentOpencodeSessions = input.maxConcurrentOpencodeSessions
+      if (
+        !Number.isSafeInteger(input.maxConcurrentWorkItems) ||
+        input.maxConcurrentWorkItems < 1
+      ) {
+        return yield* new InvalidConfigInputError({
+          field: "maxConcurrentWorkItems",
+          message: "maxConcurrentWorkItems must be a positive integer",
+        })
+      }
+      const maxConcurrentWorkItems = input.maxConcurrentWorkItems
 
-        const now = Date.now()
-        const rows = yield* sql
-          .unsafe(
-            `INSERT INTO config (
+      const now = yield* Clock.currentTimeMillis
+      const rows = yield* sql
+        .unsafe(
+          `INSERT INTO config (
                id, default_model, default_variant, review_model, review_variant,
                max_concurrent_opencode_sessions, max_concurrent_work_items,
                created_at, updated_at
@@ -455,158 +436,133 @@ export const DbServiceLive = Layer.effect(
                updated_at = excluded.updated_at
              RETURNING default_model, default_variant, review_model, review_variant,
                        max_concurrent_opencode_sessions, max_concurrent_work_items`,
-            [
-              defaultModel,
-              defaultVariant,
-              reviewModel,
-              reviewVariant,
-              maxConcurrentOpencodeSessions,
-              maxConcurrentWorkItems,
-              now,
-              now,
-            ],
-          )
-          .pipe(Effect.mapError(toDatabaseError))
-        const row = rows[0] as
-          | {
-              default_model: string | null
-              default_variant: string | null
-              review_model: string | null
-              review_variant: string | null
-              max_concurrent_opencode_sessions: number
-              max_concurrent_work_items: number
-            }
-          | undefined
-        if (!row) {
-          return yield* new DatabaseError({
-            message: "No config returned from update",
-          })
-        }
-        return {
-          defaultModel: row.default_model,
-          defaultVariant: row.default_variant,
-          reviewModel: row.review_model,
-          reviewVariant: row.review_variant,
-          maxConcurrentOpencodeSessions: row.max_concurrent_opencode_sessions,
-          maxConcurrentWorkItems: row.max_concurrent_work_items,
-        }
-      })
-
-    const addRepository = (
-      input: AddRepositoryInput,
-    ): Effect.Effect<
-      RepositoryRecord,
-      | InvalidRepositoryInputError
-      | RepositoryAlreadyExistsError
-      | LocalPathInUseError
-      | DatabaseError
-    > =>
-      Effect.gen(function* () {
-        const githubOwner = yield* trimRequired(
-          input.githubOwner,
-          "githubOwner",
+          [
+            defaultModel,
+            defaultVariant,
+            reviewModel,
+            reviewVariant,
+            maxConcurrentOpencodeSessions,
+            maxConcurrentWorkItems,
+            now,
+            now,
+          ],
         )
-        const githubRepo = yield* trimRequired(input.githubRepo, "githubRepo")
-        const localPath = yield* trimRequired(input.localPath, "localPath")
-        const now = Date.now()
-        const id = `repo-${ulid()}`
+        .pipe(Effect.mapError(toDatabaseError))
+      const decoded = yield* decodeConfigRows(rows)
+      const row = decoded[0]
+      if (!row) {
+        return yield* new DatabaseError({
+          message: "No config returned from update",
+        })
+      }
+      return ConfigRecord.make({
+        defaultModel: row.defaultModel,
+        defaultVariant: row.defaultVariant,
+        reviewModel: row.reviewModel,
+        reviewVariant: row.reviewVariant,
+        maxConcurrentOpencodeSessions: row.maxConcurrentOpencodeSessions,
+        maxConcurrentWorkItems: row.maxConcurrentWorkItems,
+      })
+    })
 
-        const existingByGithub = yield* sql
-          .unsafe(
-            `SELECT id FROM repository
+    const addRepository = Effect.fn("DbService.addRepository")(function* (
+      input: AddRepositoryInput,
+    ) {
+      const githubOwner = yield* trimRequired(input.githubOwner, "githubOwner")
+      const githubRepo = yield* trimRequired(input.githubRepo, "githubRepo")
+      const localPath = yield* trimRequired(input.localPath, "localPath")
+      const now = yield* Clock.currentTimeMillis
+      const id = RepositoryId.make(`repo-${ulid()}`)
+
+      const existingByGithub = yield* sql
+        .unsafe(
+          `SELECT id FROM repository
              WHERE lower(github_owner) = ? AND lower(github_repo) = ?
              LIMIT 1`,
-            [githubOwner.toLowerCase(), githubRepo.toLowerCase()],
-          )
-          .pipe(Effect.mapError(toDatabaseError))
+          [githubOwner.toLowerCase(), githubRepo.toLowerCase()],
+        )
+        .pipe(Effect.mapError(toDatabaseError))
 
-        if (existingByGithub[0]) {
-          return yield* new RepositoryAlreadyExistsError({
-            githubOwner,
-            githubRepo,
-          })
-        }
+      if (existingByGithub[0]) {
+        return yield* new RepositoryAlreadyExistsError({
+          githubOwner,
+          githubRepo,
+        })
+      }
 
-        const existingByPath = yield* sql
-          .unsafe("SELECT id FROM repository WHERE local_path = ? LIMIT 1", [
-            localPath,
-          ])
-          .pipe(Effect.mapError(toDatabaseError))
+      const existingByPath = yield* sql`
+        SELECT id FROM repository WHERE local_path = ${localPath} LIMIT 1
+      `.pipe(Effect.mapError(toDatabaseError))
 
-        if (existingByPath[0]) {
-          return yield* new LocalPathInUseError({ localPath })
-        }
+      if (existingByPath[0]) {
+        return yield* new LocalPathInUseError({ localPath })
+      }
 
-        const result = yield* sql
-          .unsafe(
-            `INSERT INTO repository (
+      const result = yield* sql
+        .unsafe(
+          `INSERT INTO repository (
                id, github_owner, github_repo, local_path, is_bare, paused,
                default_model, default_variant, review_model, review_variant,
                auto_merge, created_at, updated_at
              ) VALUES (?, ?, ?, ?, ?, ?, NULL, NULL, NULL, NULL, ?, ?, ?)
              RETURNING ${repositorySelectColumns}`,
-            [
-              id,
-              githubOwner,
-              githubRepo,
-              localPath,
-              input.isBare,
-              true,
-              false,
-              now,
-              now,
-            ],
-          )
-          .pipe(
-            Effect.mapError((error: SqlError) => {
-              if (isUniqueConstraint(error)) {
-                const message = formatSqlError(error).toLowerCase()
-                if (
-                  message.includes("local_path") ||
-                  message.includes("localpath")
-                ) {
-                  return new LocalPathInUseError({ localPath })
-                }
-                return new RepositoryAlreadyExistsError({
-                  githubOwner,
-                  githubRepo,
-                })
+          [
+            id,
+            githubOwner,
+            githubRepo,
+            localPath,
+            input.isBare,
+            true,
+            false,
+            now,
+            now,
+          ],
+        )
+        .pipe(
+          Effect.mapError((error: SqlError) => {
+            if (isUniqueConstraint(error)) {
+              const message = formatSqlError(error).toLowerCase()
+              if (
+                message.includes("local_path") ||
+                message.includes("localpath")
+              ) {
+                return new LocalPathInUseError({ localPath })
               }
-              return toDatabaseError(error)
-            }),
-          )
-
-        const row = result[0] as RepositoryRow | undefined
-        if (!row) {
-          return yield* new DatabaseError({
-            message: "No repository returned from insert",
-          })
-        }
-
-        const repository = toRecordFromRow(row)
-        yield* publishRepositoryChanged()
-        return repository
-      })
-
-    const updateRepositorySettings = (
-      input: UpdateRepositorySettingsInput,
-    ): Effect.Effect<
-      RepositoryRecord,
-      InvalidRepositorySettingsError | RepositoryNotFoundError | DatabaseError
-    > =>
-      Effect.gen(function* () {
-        const defaultModel = yield* normalizeOptionalSetting(input.defaultModel)
-        const defaultVariant = yield* normalizeOptionalSetting(
-          input.defaultVariant,
+              return new RepositoryAlreadyExistsError({
+                githubOwner,
+                githubRepo,
+              })
+            }
+            return toDatabaseError(error)
+          }),
         )
-        const reviewModel = yield* normalizeOptionalSetting(input.reviewModel)
-        const reviewVariant = yield* normalizeOptionalSetting(
-          input.reviewVariant,
-        )
-        const now = Date.now()
-        const result = yield* sql
-          .unsafe(
-            `UPDATE repository
+
+      const decoded = yield* decodeRepositoryRows(result)
+      const row = decoded[0]
+      if (!row) {
+        return yield* new DatabaseError({
+          message: "No repository returned from insert",
+        })
+      }
+
+      const repository = RepositoryRecord.make(row)
+      yield* publishRepositoryChanged()
+      return repository
+    })
+
+    const updateRepositorySettings = Effect.fn(
+      "DbService.updateRepositorySettings",
+    )(function* (input: UpdateRepositorySettingsInput) {
+      const defaultModel = yield* normalizeOptionalSetting(input.defaultModel)
+      const defaultVariant = yield* normalizeOptionalSetting(
+        input.defaultVariant,
+      )
+      const reviewModel = yield* normalizeOptionalSetting(input.reviewModel)
+      const reviewVariant = yield* normalizeOptionalSetting(input.reviewVariant)
+      const now = yield* Clock.currentTimeMillis
+      const result = yield* sql
+        .unsafe(
+          `UPDATE repository
              SET paused = ?,
                  default_model = ?,
                  default_variant = ?,
@@ -616,40 +572,35 @@ export const DbServiceLive = Layer.effect(
                  updated_at = ?
              WHERE id = ?
              RETURNING ${repositorySelectColumns}`,
-            [
-              input.paused,
-              defaultModel,
-              defaultVariant,
-              reviewModel,
-              reviewVariant,
-              input.autoMerge,
-              now,
-              input.repositoryId,
-            ],
-          )
-          .pipe(Effect.mapError(toDatabaseError))
+          [
+            input.paused,
+            defaultModel,
+            defaultVariant,
+            reviewModel,
+            reviewVariant,
+            input.autoMerge,
+            now,
+            input.repositoryId,
+          ],
+        )
+        .pipe(Effect.mapError(toDatabaseError))
 
-        const row = result[0] as RepositoryRow | undefined
-        if (!row) {
-          return yield* new RepositoryNotFoundError({
-            repositoryId: input.repositoryId,
-          })
-        }
+      const decoded = yield* decodeRepositoryRows(result)
+      const row = decoded[0]
+      if (!row) {
+        return yield* new RepositoryNotFoundError({
+          repositoryId: input.repositoryId,
+        })
+      }
 
-        const repository = toRecordFromRow(row)
-        yield* publishRepositoryChanged()
-        return repository
-      })
+      const repository = RepositoryRecord.make(row)
+      yield* publishRepositoryChanged()
+      return repository
+    })
 
-    const setRepositoryPaused = (
-      repositoryId: string,
-      paused: boolean,
-    ): Effect.Effect<
-      RepositoryRecord,
-      RepositoryNotFoundError | DatabaseError
-    > =>
-      Effect.gen(function* () {
-        const now = Date.now()
+    const setRepositoryPaused = Effect.fn("DbService.setRepositoryPaused")(
+      function* (repositoryId: string, paused: boolean) {
+        const now = yield* Clock.currentTimeMillis
         const result = yield* sql
           .unsafe(
             `UPDATE repository
@@ -661,29 +612,29 @@ export const DbServiceLive = Layer.effect(
           )
           .pipe(Effect.mapError(toDatabaseError))
 
-        const row = result[0] as RepositoryRow | undefined
+        const decoded = yield* decodeRepositoryRows(result)
+        const row = decoded[0]
         if (!row) {
           return yield* new RepositoryNotFoundError({ repositoryId })
         }
 
-        const repository = toRecordFromRow(row)
+        const repository = RepositoryRecord.make(row)
         yield* publishRepositoryChanged()
         return repository
-      })
+      },
+    )
 
-    const pauseRepository = (
+    const pauseRepository = Effect.fn("DbService.pauseRepository")(function* (
       repositoryId: string,
-    ): Effect.Effect<
-      RepositoryRecord,
-      RepositoryNotFoundError | DatabaseError
-    > => setRepositoryPaused(repositoryId, true)
+    ) {
+      return yield* setRepositoryPaused(repositoryId, true)
+    })
 
-    const unpauseRepository = (
-      repositoryId: string,
-    ): Effect.Effect<
-      RepositoryRecord,
-      RepositoryNotFoundError | DatabaseError
-    > => setRepositoryPaused(repositoryId, false)
+    const unpauseRepository = Effect.fn("DbService.unpauseRepository")(
+      function* (repositoryId: string) {
+        return yield* setRepositoryPaused(repositoryId, false)
+      },
+    )
 
     const listRepositories: Effect.Effect<
       readonly RepositoryRecord[],
@@ -697,36 +648,31 @@ export const DbServiceLive = Layer.effect(
         )
         .pipe(Effect.mapError(toDatabaseError))
 
-      return (repositories as ReadonlyArray<RepositoryRow>).map(toRecordFromRow)
+      const decoded = yield* decodeRepositoryRows(repositories)
+      return decoded.map((row) => RepositoryRecord.make(row))
+    }).pipe(Effect.withSpan("DbService.listRepositories"))
+
+    const ensureRepositoryExists = Effect.fn(
+      "DbService.ensureRepositoryExists",
+    )(function* (repositoryId: string) {
+      const repository = yield* sql`
+          SELECT id FROM repository WHERE id = ${repositoryId} LIMIT 1
+        `.pipe(Effect.mapError(toDatabaseError))
+
+      if (!repository[0]) {
+        return yield* new RepositoryNotFoundError({ repositoryId })
+      }
     })
 
-    const ensureRepositoryExists = (
+    const removeRepository = Effect.fn("DbService.removeRepository")(function* (
       repositoryId: string,
-    ): Effect.Effect<void, RepositoryNotFoundError | DatabaseError> =>
-      Effect.gen(function* () {
-        const repository = yield* sql
-          .unsafe("SELECT id FROM repository WHERE id = ? LIMIT 1", [
-            repositoryId,
-          ])
-          .pipe(Effect.mapError(toDatabaseError))
-
-        if (!repository[0]) {
-          return yield* new RepositoryNotFoundError({ repositoryId })
-        }
-      })
-
-    const removeRepository = (
-      repositoryId: string,
-    ): Effect.Effect<
-      void,
-      RepositoryNotFoundError | RepositoryHasRunningStepError | DatabaseError
-    > =>
-      Effect.gen(function* () {
-        const now = yield* Clock.currentTimeMillis
-        yield* sql
-          .withTransaction(
-            Effect.gen(function* () {
-              const running = (yield* sql.unsafe(
+    ) {
+      const now = yield* Clock.currentTimeMillis
+      yield* sql
+        .withTransaction(
+          Effect.gen(function* () {
+            const runningRows = yield* sql
+              .unsafe(
                 `SELECT step_run.id AS step_run_id, step_run.work_item_id AS work_item_id
                  FROM step_run
                  INNER JOIN work_item ON work_item.id = step_run.work_item_id
@@ -735,21 +681,20 @@ export const DbServiceLive = Layer.effect(
                  ORDER BY step_run.queued_at ASC, step_run.id ASC
                  LIMIT 1`,
                 [repositoryId],
-              )) as readonly {
-                readonly step_run_id: string
-                readonly work_item_id: string
-              }[]
+              )
+              .pipe(Effect.mapError(toDatabaseError))
+            const running = yield* decodeRunningStepRows(runningRows)
 
-              if (running[0]) {
-                return yield* new RepositoryHasRunningStepError({
-                  repositoryId,
-                  stepRunId: running[0].step_run_id,
-                  workItemId: running[0].work_item_id,
-                })
-              }
+            if (running[0]) {
+              return yield* new RepositoryHasRunningStepError({
+                repositoryId,
+                stepRunId: running[0].stepRunId,
+                workItemId: running[0].workItemId,
+              })
+            }
 
-              yield* sql.unsafe(
-                `UPDATE step_run
+            yield* sql.unsafe(
+              `UPDATE step_run
                  SET status = 'cancelled',
                      finished_at = ?,
                      reason_code = 'repository_removed',
@@ -759,11 +704,11 @@ export const DbServiceLive = Layer.effect(
                    AND work_item_id IN (
                      SELECT id FROM work_item WHERE repository_id = ?
                    )`,
-                [now, now, repositoryId],
-              )
+              [now, now, repositoryId],
+            )
 
-              yield* sql.unsafe(
-                `DELETE FROM job_queue
+            yield* sql.unsafe(
+              `DELETE FROM job_queue
                  WHERE id IN (
                    SELECT step_run.queue_job_id
                    FROM step_run
@@ -771,154 +716,145 @@ export const DbServiceLive = Layer.effect(
                    WHERE work_item.repository_id = ?
                      AND step_run.queue_job_id IS NOT NULL
                  )`,
-                [repositoryId],
-              )
+              [repositoryId],
+            )
 
-              yield* sql.unsafe(
-                `UPDATE work_item
+            yield* sql.unsafe(
+              `UPDATE work_item
                  SET state = 'abandoned',
                      state_ready_at = ?,
                      updated_at = ?
                  WHERE repository_id = ?
                    AND state NOT IN ('complete', 'failed', 'abandoned', 'needs_human')`,
-                [now, now, repositoryId],
-              )
+              [now, now, repositoryId],
+            )
 
-              yield* sql.unsafe(
-                `DELETE FROM step_run
+            yield* sql.unsafe(
+              `DELETE FROM step_run
                  WHERE work_item_id IN (
                    SELECT id FROM work_item WHERE repository_id = ?
                  )`,
-                [repositoryId],
-              )
+              [repositoryId],
+            )
 
-              yield* sql.unsafe(
-                `DELETE FROM work_item WHERE repository_id = ?`,
-                [repositoryId],
-              )
+            yield* sql`DELETE FROM work_item WHERE repository_id = ${repositoryId}`
 
-              yield* sql.unsafe(
-                `DELETE FROM issue_dependency
+            yield* sql.unsafe(
+              `DELETE FROM issue_dependency
                WHERE issue_id IN (
                  SELECT id FROM issue WHERE repository_id = ?
                )`,
-                [repositoryId],
-              )
-              yield* sql.unsafe("DELETE FROM issue WHERE repository_id = ?", [
-                repositoryId,
-              ])
-              const result = yield* sql.unsafe(
-                "DELETE FROM repository WHERE id = ? RETURNING id",
-                [repositoryId],
-              )
+              [repositoryId],
+            )
+            yield* sql`DELETE FROM issue WHERE repository_id = ${repositoryId}`
+            const result = yield* sql`
+              DELETE FROM repository WHERE id = ${repositoryId} RETURNING id
+            `
 
-              if (!result[0]) {
-                return yield* new RepositoryNotFoundError({ repositoryId })
-              }
-            }),
-          )
-          .pipe(
-            Effect.mapError((error) =>
-              error instanceof RepositoryNotFoundError ||
-              error instanceof RepositoryHasRunningStepError
-                ? error
-                : toDatabaseError(error),
-            ),
-          )
-        yield* publishRepositoryChanged()
-        yield* publishWorkItemsChanged(repositoryId)
-      })
+            if (!result[0]) {
+              return yield* new RepositoryNotFoundError({ repositoryId })
+            }
+          }),
+        )
+        .pipe(
+          Effect.mapError((error) =>
+            error instanceof RepositoryNotFoundError ||
+            error instanceof RepositoryHasRunningStepError ||
+            error instanceof DatabaseError
+              ? error
+              : toDatabaseError(error),
+          ),
+        )
+      yield* publishRepositoryChanged()
+      yield* publishWorkItemsChanged(repositoryId)
+    })
 
-    const storeIssue = (
+    const storeIssue = Effect.fn("DbService.storeIssue")(function* (
       input: StoreIssueInput,
-    ): Effect.Effect<
-      IssueRecord,
-      InvalidIssueInputError | RepositoryNotFoundError | DatabaseError
-    > =>
-      Effect.gen(function* () {
+    ) {
+      if (
+        !Number.isSafeInteger(input.githubIssueNumber) ||
+        input.githubIssueNumber <= 0
+      ) {
+        return yield* new InvalidIssueInputError({
+          field: "githubIssueNumber",
+          message: "githubIssueNumber must be a positive integer",
+        })
+      }
+      if (input.title.trim().length === 0) {
+        return yield* new InvalidIssueInputError({
+          field: "title",
+          message: "title cannot be empty",
+        })
+      }
+      if (input.url.trim().length === 0) {
+        return yield* new InvalidIssueInputError({
+          field: "url",
+          message: "url cannot be empty",
+        })
+      }
+      if (input.state !== "OPEN" && input.state !== "CLOSED") {
+        return yield* new InvalidIssueInputError({
+          field: "state",
+          message: "state must be OPEN or CLOSED",
+        })
+      }
+      if (Number.isNaN(input.githubCreatedAt.getTime())) {
+        return yield* new InvalidIssueInputError({
+          field: "githubCreatedAt",
+          message: "githubCreatedAt must be a valid date",
+        })
+      }
+
+      if (
+        input.parent !== null &&
+        (!Number.isSafeInteger(input.parent.githubIssueNumber) ||
+          input.parent.githubIssueNumber <= 0 ||
+          !URL.canParse(input.parent.githubIssueUrl))
+      ) {
+        return yield* new InvalidIssueInputError({
+          field: "parent",
+          message: "parent must have a positive issue number and valid URL",
+        })
+      }
+      if (
+        input.parentPosition !== null &&
+        (!Number.isSafeInteger(input.parentPosition) ||
+          input.parentPosition < 0)
+      ) {
+        return yield* new InvalidIssueInputError({
+          field: "parentPosition",
+          message: "parentPosition must be a non-negative integer or null",
+        })
+      }
+
+      for (const dependency of input.blockedBy) {
         if (
-          !Number.isSafeInteger(input.githubIssueNumber) ||
-          input.githubIssueNumber <= 0
+          !Number.isSafeInteger(dependency.githubIssueNumber) ||
+          dependency.githubIssueNumber <= 0
         ) {
           return yield* new InvalidIssueInputError({
-            field: "githubIssueNumber",
-            message: "githubIssueNumber must be a positive integer",
+            field: "blockedBy",
+            message: "blockedBy issue numbers must be positive integers",
           })
         }
-        if (input.title.trim().length === 0) {
+        if (!URL.canParse(dependency.githubIssueUrl)) {
           return yield* new InvalidIssueInputError({
-            field: "title",
-            message: "title cannot be empty",
+            field: "blockedBy",
+            message: "blockedBy issue URLs must be valid URLs",
           })
         }
-        if (input.url.trim().length === 0) {
-          return yield* new InvalidIssueInputError({
-            field: "url",
-            message: "url cannot be empty",
-          })
-        }
-        if (input.state !== "OPEN" && input.state !== "CLOSED") {
-          return yield* new InvalidIssueInputError({
-            field: "state",
-            message: "state must be OPEN or CLOSED",
-          })
-        }
-        if (Number.isNaN(input.githubCreatedAt.getTime())) {
-          return yield* new InvalidIssueInputError({
-            field: "githubCreatedAt",
-            message: "githubCreatedAt must be a valid date",
-          })
-        }
+      }
 
-        if (
-          input.parent !== null &&
-          (!Number.isSafeInteger(input.parent.githubIssueNumber) ||
-            input.parent.githubIssueNumber <= 0 ||
-            !URL.canParse(input.parent.githubIssueUrl))
-        ) {
-          return yield* new InvalidIssueInputError({
-            field: "parent",
-            message: "parent must have a positive issue number and valid URL",
-          })
-        }
-        if (
-          input.parentPosition !== null &&
-          (!Number.isSafeInteger(input.parentPosition) ||
-            input.parentPosition < 0)
-        ) {
-          return yield* new InvalidIssueInputError({
-            field: "parentPosition",
-            message: "parentPosition must be a non-negative integer or null",
-          })
-        }
+      yield* ensureRepositoryExists(input.repositoryId)
 
-        for (const dependency of input.blockedBy) {
-          if (
-            !Number.isSafeInteger(dependency.githubIssueNumber) ||
-            dependency.githubIssueNumber <= 0
-          ) {
-            return yield* new InvalidIssueInputError({
-              field: "blockedBy",
-              message: "blockedBy issue numbers must be positive integers",
-            })
-          }
-          if (!URL.canParse(dependency.githubIssueUrl)) {
-            return yield* new InvalidIssueInputError({
-              field: "blockedBy",
-              message: "blockedBy issue URLs must be valid URLs",
-            })
-          }
-        }
-
-        yield* ensureRepositoryExists(input.repositoryId)
-
-        const now = Date.now()
-        return yield* sql
-          .withTransaction(
-            Effect.gen(function* () {
-              const result = yield* sql
-                .unsafe(
-                  `INSERT INTO issue (
+      const now = yield* Clock.currentTimeMillis
+      return yield* sql
+        .withTransaction(
+          Effect.gen(function* () {
+            const result = yield* sql
+              .unsafe(
+                `INSERT INTO issue (
                id, repository_id, github_issue_number, title, body, url, state,
                 github_created_at, parent_github_issue_number,
                  parent_github_issue_url, parent_position, has_children,
@@ -935,266 +871,202 @@ export const DbServiceLive = Layer.effect(
                  parent_position = excluded.parent_position,
                  has_children = excluded.has_children,
                  updated_at = excluded.updated_at
-              RETURNING id, repository_id, github_issue_number, title, body, url, state,
-                github_created_at, parent_github_issue_number,
-                 parent_github_issue_url, parent_position, has_children`,
+              RETURNING ${issueSelectColumns}`,
+                [
+                  `issue-${ulid()}`,
+                  input.repositoryId,
+                  input.githubIssueNumber,
+                  input.title,
+                  input.body,
+                  input.url,
+                  input.state,
+                  input.githubCreatedAt.getTime(),
+                  input.parent?.githubIssueNumber ?? null,
+                  input.parent?.githubIssueUrl ?? null,
+                  input.parentPosition,
+                  input.hasChildren,
+                  now,
+                  now,
+                ],
+              )
+              .pipe(Effect.mapError(toDatabaseError))
+
+            const decoded = yield* decodeIssueRows(result)
+            const row = decoded[0]
+            if (!row) {
+              return yield* new DatabaseError({
+                message: "No issue returned from upsert",
+              })
+            }
+
+            yield* sql`
+              DELETE FROM issue_dependency WHERE issue_id = ${row.id}
+            `.pipe(Effect.mapError(toDatabaseError))
+            const dependencies = [
+              ...new Map(
+                input.blockedBy.map((dependency) => [
+                  dependency.githubIssueUrl,
+                  dependency,
+                ]),
+              ).values(),
+            ].sort(
+              (left, right) =>
+                left.githubIssueNumber - right.githubIssueNumber ||
+                left.githubIssueUrl.localeCompare(right.githubIssueUrl),
+            )
+            for (const dependency of dependencies) {
+              yield* sql
+                .unsafe(
+                  `INSERT INTO issue_dependency (
+                 id, issue_id, blocking_github_issue_number,
+                 blocking_github_issue_url, created_at
+               ) VALUES (?, ?, ?, ?, ?)`,
                   [
-                    `issue-${ulid()}`,
-                    input.repositoryId,
-                    input.githubIssueNumber,
-                    input.title,
-                    input.body,
-                    input.url,
-                    input.state,
-                    input.githubCreatedAt.getTime(),
-                    input.parent?.githubIssueNumber ?? null,
-                    input.parent?.githubIssueUrl ?? null,
-                    input.parentPosition,
-                    input.hasChildren,
-                    now,
+                    `issue-dependency-${ulid()}`,
+                    row.id,
+                    dependency.githubIssueNumber,
+                    dependency.githubIssueUrl,
                     now,
                   ],
                 )
                 .pipe(Effect.mapError(toDatabaseError))
+            }
 
-              const row = result[0] as
-                | {
-                    id: string
-                    repository_id: string
-                    github_issue_number: number
-                    title: string
-                    body: string
-                    url: string
-                    state: "OPEN" | "CLOSED"
-                    github_created_at: number
-                    parent_github_issue_number: number | null
-                    parent_github_issue_url: string | null
-                    parent_position: number | null
-                    has_children: number
-                  }
-                | undefined
-              if (!row) {
-                return yield* new DatabaseError({
-                  message: "No issue returned from upsert",
-                })
-              }
+            return IssueRecord.make(toIssueRecord(row, dependencies))
+          }),
+        )
+        .pipe(
+          Effect.mapError((error) =>
+            error instanceof DatabaseError ||
+            error instanceof InvalidIssueInputError ||
+            error instanceof RepositoryNotFoundError
+              ? error
+              : toDatabaseError(error),
+          ),
+        )
+    })
 
-              yield* sql
-                .unsafe("DELETE FROM issue_dependency WHERE issue_id = ?", [
-                  row.id,
-                ])
-                .pipe(Effect.mapError(toDatabaseError))
-              const dependencies = [
-                ...new Map(
-                  input.blockedBy.map((dependency) => [
-                    dependency.githubIssueUrl,
-                    dependency,
-                  ]),
-                ).values(),
-              ].sort(
-                (left, right) =>
-                  left.githubIssueNumber - right.githubIssueNumber ||
-                  left.githubIssueUrl.localeCompare(right.githubIssueUrl),
-              )
-              for (const dependency of dependencies) {
-                yield* sql
-                  .unsafe(
-                    `INSERT INTO issue_dependency (
-                 id, issue_id, blocking_github_issue_number,
-                 blocking_github_issue_url, created_at
-               ) VALUES (?, ?, ?, ?, ?)`,
-                    [
-                      `issue-dependency-${ulid()}`,
-                      row.id,
-                      dependency.githubIssueNumber,
-                      dependency.githubIssueUrl,
-                      now,
-                    ],
-                  )
-                  .pipe(Effect.mapError(toDatabaseError))
-              }
-
-              return toIssueRecord({
-                id: row.id,
-                repositoryId: row.repository_id,
-                githubIssueNumber: row.github_issue_number,
-                title: row.title,
-                body: row.body,
-                url: row.url,
-                state: row.state,
-                githubCreatedAt: row.github_created_at,
-                parentGithubIssueNumber: row.parent_github_issue_number,
-                parentGithubIssueUrl: row.parent_github_issue_url,
-                parentPosition: row.parent_position,
-                hasChildren: row.has_children,
-                blockedBy: dependencies,
-              })
-            }),
-          )
-          .pipe(
-            Effect.mapError((error) =>
-              error instanceof DatabaseError ? error : toDatabaseError(error),
-            ),
-          )
-      })
-
-    const listIssues = (
+    const listIssues = Effect.fn("DbService.listIssues")(function* (
       repositoryId: string,
-    ): Effect.Effect<
-      readonly IssueRecord[],
-      RepositoryNotFoundError | DatabaseError
-    > =>
-      Effect.gen(function* () {
-        yield* ensureRepositoryExists(repositoryId)
+    ) {
+      yield* ensureRepositoryExists(repositoryId)
 
-        const issues = yield* sql
-          .unsafe(
-            `SELECT id, repository_id, github_issue_number, title, body, url, state,
-                github_created_at, parent_github_issue_number,
-                parent_github_issue_url, parent_position, has_children
+      const issues = yield* sql
+        .unsafe(
+          `SELECT ${issueSelectColumns}
              FROM issue WHERE repository_id = ? ORDER BY github_issue_number ASC`,
-            [repositoryId],
-          )
-          .pipe(Effect.mapError(toDatabaseError))
+          [repositoryId],
+        )
+        .pipe(Effect.mapError(toDatabaseError))
 
-        const dependencies = yield* sql
-          .unsafe(
-            `SELECT d.issue_id, d.blocking_github_issue_number,
+      const dependencyRows = yield* sql
+        .unsafe(
+          `SELECT d.issue_id, d.blocking_github_issue_number,
                d.blocking_github_issue_url
              FROM issue_dependency d
              INNER JOIN issue i ON i.id = d.issue_id
              WHERE i.repository_id = ?
              ORDER BY d.blocking_github_issue_number ASC,
                d.blocking_github_issue_url ASC`,
-            [repositoryId],
-          )
-          .pipe(Effect.mapError(toDatabaseError))
-        const dependenciesByIssue = new Map<string, IssueDependency[]>()
-        for (const dependency of dependencies as ReadonlyArray<{
-          issue_id: string
-          blocking_github_issue_number: number
-          blocking_github_issue_url: string
-        }>) {
-          const records = dependenciesByIssue.get(dependency.issue_id) ?? []
-          records.push({
-            githubIssueNumber: dependency.blocking_github_issue_number,
-            githubIssueUrl: dependency.blocking_github_issue_url,
-          })
-          dependenciesByIssue.set(dependency.issue_id, records)
-        }
-
-        return (
-          issues as ReadonlyArray<{
-            id: string
-            repository_id: string
-            github_issue_number: number
-            title: string
-            body: string
-            url: string
-            state: "OPEN" | "CLOSED"
-            github_created_at: number
-            parent_github_issue_number: number | null
-            parent_github_issue_url: string | null
-            parent_position: number | null
-            has_children: number
-          }>
-        ).map((issue) =>
-          toIssueRecord({
-            id: issue.id,
-            repositoryId: issue.repository_id,
-            githubIssueNumber: issue.github_issue_number,
-            title: issue.title,
-            body: issue.body,
-            url: issue.url,
-            state: issue.state,
-            githubCreatedAt: issue.github_created_at,
-            parentGithubIssueNumber: issue.parent_github_issue_number,
-            parentGithubIssueUrl: issue.parent_github_issue_url,
-            parentPosition: issue.parent_position,
-            hasChildren: issue.has_children,
-            blockedBy: dependenciesByIssue.get(issue.id) ?? [],
-          }),
+          [repositoryId],
         )
-      })
+        .pipe(Effect.mapError(toDatabaseError))
+      const dependencies = yield* decodeIssueDependencyRows(dependencyRows)
+      const dependenciesByIssue = new Map<string, IssueDependency[]>()
+      for (const dependency of dependencies) {
+        const records = dependenciesByIssue.get(dependency.issueId) ?? []
+        records.push({
+          githubIssueNumber: dependency.githubIssueNumber,
+          githubIssueUrl: dependency.githubIssueUrl,
+        })
+        dependenciesByIssue.set(dependency.issueId, records)
+      }
 
-    const listWorkItemPullRequests = (
-      repositoryId: string,
-    ): Effect.Effect<
-      readonly WorkItemPullRequest[],
-      RepositoryNotFoundError | DatabaseError
-    > =>
-      Effect.gen(function* () {
-        yield* ensureRepositoryExists(repositoryId)
-        const rows = (yield* sql
-          .unsafe(
-            `SELECT github_issue_number, github_pull_request_number
+      const decodedIssues = yield* decodeIssueRows(issues)
+      return decodedIssues.map((issue) =>
+        IssueRecord.make(
+          toIssueRecord(issue, dependenciesByIssue.get(issue.id) ?? []),
+        ),
+      )
+    })
+
+    const listWorkItemPullRequests = Effect.fn(
+      "DbService.listWorkItemPullRequests",
+    )(function* (repositoryId: string) {
+      yield* ensureRepositoryExists(repositoryId)
+      const rows = yield* sql
+        .unsafe(
+          `SELECT github_issue_number, github_pull_request_number
              FROM work_item
              WHERE repository_id = ? AND github_pull_request_number IS NOT NULL
              ORDER BY github_issue_number ASC, github_pull_request_number ASC`,
-            [repositoryId],
-          )
-          .pipe(Effect.mapError(toDatabaseError))) as readonly {
-          readonly github_issue_number: number
-          readonly github_pull_request_number: number
-        }[]
+          [repositoryId],
+        )
+        .pipe(Effect.mapError(toDatabaseError))
 
-        return rows.map((row) => ({
-          githubIssueNumber: row.github_issue_number,
-          githubPullRequestNumber: row.github_pull_request_number,
-        }))
-      })
+      const decoded = yield* decodeWorkItemPullRequestRows(rows)
+      return decoded.map((row) =>
+        WorkItemPullRequest.make({
+          githubIssueNumber: row.githubIssueNumber,
+          githubPullRequestNumber: row.githubPullRequestNumber,
+        }),
+      )
+    })
 
-    const deleteIssue = (
+    const deleteIssue = Effect.fn("DbService.deleteIssue")(function* (
       repositoryId: string,
       githubIssueNumber: number,
-    ): Effect.Effect<void, RepositoryNotFoundError | DatabaseError> =>
-      Effect.gen(function* () {
-        yield* ensureRepositoryExists(repositoryId)
-        yield* sql
-          .unsafe(
-            `DELETE FROM issue_dependency
+    ) {
+      yield* ensureRepositoryExists(repositoryId)
+      yield* sql
+        .unsafe(
+          `DELETE FROM issue_dependency
              WHERE issue_id IN (
                SELECT id FROM issue
                WHERE repository_id = ? AND github_issue_number = ?
              )`,
-            [repositoryId, githubIssueNumber],
-          )
-          .pipe(Effect.mapError(toDatabaseError))
-        yield* sql
-          .unsafe(
-            `DELETE FROM issue
+          [repositoryId, githubIssueNumber],
+        )
+        .pipe(Effect.mapError(toDatabaseError))
+      yield* sql
+        .unsafe(
+          `DELETE FROM issue
              WHERE repository_id = ? AND github_issue_number = ?`,
-            [repositoryId, githubIssueNumber],
-          )
-          .pipe(Effect.mapError(toDatabaseError))
-      })
+          [repositoryId, githubIssueNumber],
+        )
+        .pipe(Effect.mapError(toDatabaseError))
+    })
 
-    const markIssuesReconciled = (
-      repositoryId: string,
-      reconciledAt: Date,
-    ): Effect.Effect<void, RepositoryNotFoundError | DatabaseError> =>
-      Effect.gen(function* () {
+    const markIssuesReconciled = Effect.fn("DbService.markIssuesReconciled")(
+      function* (repositoryId: string, reconciledAt: Date) {
+        const now = yield* Clock.currentTimeMillis
         const result = yield* sql
           .unsafe(
             `UPDATE repository
              SET issues_reconciled_at = ?, updated_at = ?
              WHERE id = ?
              RETURNING id`,
-            [reconciledAt.getTime(), Date.now(), repositoryId],
+            [reconciledAt.getTime(), now, repositoryId],
           )
           .pipe(Effect.mapError(toDatabaseError))
 
         if (!result[0]) {
           return yield* new RepositoryNotFoundError({ repositoryId })
         }
-      })
+      },
+    )
 
-    const notifyIssuesChanged = (repositoryId: string): Effect.Effect<void> =>
-      publishIssuesChanged(repositoryId)
+    const notifyIssuesChanged = Effect.fn("DbService.notifyIssuesChanged")(
+      function* (repositoryId: string) {
+        yield* publishIssuesChanged(repositoryId)
+      },
+    )
 
-    const notifyWorkItemsChanged = (
-      repositoryId: string,
-    ): Effect.Effect<void> => publishWorkItemsChanged(repositoryId)
+    const notifyWorkItemsChanged = Effect.fn(
+      "DbService.notifyWorkItemsChanged",
+    )(function* (repositoryId: string) {
+      yield* publishWorkItemsChanged(repositoryId)
+    })
 
     return DbService.of({
       repositoryChanges: repositoryChangesStream,

--- a/packages/db-service/src/lib/errors.ts
+++ b/packages/db-service/src/lib/errors.ts
@@ -1,79 +1,93 @@
-import { Data } from "effect"
+import { Schema } from "effect"
 
-export class InvalidRepositoryInputError extends Data.TaggedError(
+export class InvalidRepositoryInputError extends Schema.TaggedErrorClass<InvalidRepositoryInputError>()(
   "InvalidRepositoryInputError",
-)<{
-  readonly field: "githubOwner" | "githubRepo" | "localPath"
-  readonly message: string
-}> {}
+  {
+    field: Schema.Literals(["githubOwner", "githubRepo", "localPath"]),
+    message: Schema.String,
+  },
+) {}
 
-export class RepositoryAlreadyExistsError extends Data.TaggedError(
+export class RepositoryAlreadyExistsError extends Schema.TaggedErrorClass<RepositoryAlreadyExistsError>()(
   "RepositoryAlreadyExistsError",
-)<{
-  readonly githubOwner: string
-  readonly githubRepo: string
-}> {}
+  {
+    githubOwner: Schema.String,
+    githubRepo: Schema.String,
+  },
+) {}
 
-export class LocalPathInUseError extends Data.TaggedError(
+export class LocalPathInUseError extends Schema.TaggedErrorClass<LocalPathInUseError>()(
   "LocalPathInUseError",
-)<{
-  readonly localPath: string
-}> {}
+  {
+    localPath: Schema.String,
+  },
+) {}
 
-export class RepositoryNotFoundError extends Data.TaggedError(
+export class RepositoryNotFoundError extends Schema.TaggedErrorClass<RepositoryNotFoundError>()(
   "RepositoryNotFoundError",
-)<{
-  readonly repositoryId: string
-}> {}
+  {
+    repositoryId: Schema.String,
+  },
+) {}
 
-export class RepositoryHasRunningStepError extends Data.TaggedError(
+export class RepositoryHasRunningStepError extends Schema.TaggedErrorClass<RepositoryHasRunningStepError>()(
   "RepositoryHasRunningStepError",
-)<{
-  readonly repositoryId: string
-  readonly stepRunId: string
-  readonly workItemId: string
-}> {}
+  {
+    repositoryId: Schema.String,
+    stepRunId: Schema.String,
+    workItemId: Schema.String,
+  },
+) {}
 
-export class InvalidIssueInputError extends Data.TaggedError(
+export class InvalidIssueInputError extends Schema.TaggedErrorClass<InvalidIssueInputError>()(
   "InvalidIssueInputError",
-)<{
-  readonly field:
-    | "githubIssueNumber"
-    | "title"
-    | "url"
-    | "state"
-    | "githubCreatedAt"
-    | "parent"
-    | "parentPosition"
-    | "blockedBy"
-  readonly message: string
-}> {}
+  {
+    field: Schema.Literals([
+      "githubIssueNumber",
+      "title",
+      "url",
+      "state",
+      "githubCreatedAt",
+      "parent",
+      "parentPosition",
+      "blockedBy",
+    ]),
+    message: Schema.String,
+  },
+) {}
 
-export class InvalidConfigInputError extends Data.TaggedError(
+export class InvalidConfigInputError extends Schema.TaggedErrorClass<InvalidConfigInputError>()(
   "InvalidConfigInputError",
-)<{
-  readonly field:
-    | "defaultModel"
-    | "defaultVariant"
-    | "reviewModel"
-    | "reviewVariant"
-    | "maxConcurrentOpencodeSessions"
-    | "maxConcurrentWorkItems"
-  readonly message: string
-}> {}
+  {
+    field: Schema.Literals([
+      "defaultModel",
+      "defaultVariant",
+      "reviewModel",
+      "reviewVariant",
+      "maxConcurrentOpencodeSessions",
+      "maxConcurrentWorkItems",
+    ]),
+    message: Schema.String,
+  },
+) {}
 
-export class InvalidRepositorySettingsError extends Data.TaggedError(
+export class InvalidRepositorySettingsError extends Schema.TaggedErrorClass<InvalidRepositorySettingsError>()(
   "InvalidRepositorySettingsError",
-)<{
-  readonly field:
-    | "defaultModel"
-    | "defaultVariant"
-    | "reviewModel"
-    | "reviewVariant"
-  readonly message: string
-}> {}
+  {
+    field: Schema.Literals([
+      "defaultModel",
+      "defaultVariant",
+      "reviewModel",
+      "reviewVariant",
+    ]),
+    message: Schema.String,
+  },
+) {}
 
-export class DatabaseError extends Data.TaggedError("DatabaseError")<{
-  readonly message: string
-  readonly cause?: unknown
-}> {}
+export class DatabaseError extends Schema.TaggedErrorClass<DatabaseError>()(
+  "DatabaseError",
+  {
+    message: Schema.String,
+    cause: Schema.optional(Schema.Defect()),
+  },
+) {}

--- a/packages/db-service/src/lib/test-fixtures.ts
+++ b/packages/db-service/src/lib/test-fixtures.ts
@@ -1,13 +1,18 @@
 import { Effect, Layer, Stream } from "effect"
 import { DbService, type DbServiceShape } from "./db-service.js"
-import type { RepositoryRecord } from "./types.js"
+import { RepositoryId, type RepositoryRecord } from "./types.js"
 
 const unused = () => Effect.die("not used")
+
+/** Default fixture repository id (valid `RepositoryId` brand). */
+export const testRepositoryId = RepositoryId.make(
+  "repo-01ARZ3NDEKTSV4RRFFQ69G5FAV",
+)
 
 export const makeRepositoryRecord = (
   overrides: Partial<RepositoryRecord> = {},
 ): RepositoryRecord => ({
-  id: "repo-test",
+  id: testRepositoryId,
   githubOwner: "acme",
   githubRepo: "widgets",
   localPath: "/repos/acme/widgets",

--- a/packages/db-service/src/lib/types.ts
+++ b/packages/db-service/src/lib/types.ts
@@ -6,95 +6,227 @@ export const RepositoryId = Schema.String.pipe(
 )
 export type RepositoryId = typeof RepositoryId.Type
 
-export interface AddRepositoryInput {
-  readonly githubOwner: string
-  readonly githubRepo: string
-  readonly localPath: string
-  readonly isBare: boolean
-}
+/** SQLite may return 0/1 or boolean depending on driver. */
+const SqlBoolean = Schema.Union([Schema.Boolean, Schema.BooleanFromBit])
 
-export interface RepositoryRecord {
-  readonly id: string
-  readonly githubOwner: string
-  readonly githubRepo: string
-  readonly localPath: string
-  readonly isBare: boolean
-  readonly paused: boolean
-  readonly defaultModel: string | null
-  readonly defaultVariant: string | null
-  readonly reviewModel: string | null
-  readonly reviewVariant: string | null
-  readonly autoMerge: boolean
-  readonly issuesReconciledAt: Date | null
-}
+export const IssueState = Schema.Literals(["OPEN", "CLOSED"])
+export type IssueState = typeof IssueState.Type
 
-export interface UpdateRepositorySettingsInput {
-  readonly repositoryId: string
-  readonly paused: boolean
-  readonly defaultModel: string | null
-  readonly defaultVariant: string | null
-  readonly reviewModel: string | null
-  readonly reviewVariant: string | null
-  readonly autoMerge: boolean
-}
-
-export interface ConfigRecord {
-  readonly defaultModel: string | null
-  readonly defaultVariant: string | null
-  readonly reviewModel: string | null
-  readonly reviewVariant: string | null
-  readonly maxConcurrentOpencodeSessions: number
-  readonly maxConcurrentWorkItems: number
-}
-
-export interface UpdateConfigInput {
-  readonly defaultModel: string
-  readonly defaultVariant: string
-  readonly reviewModel: string | null
-  readonly reviewVariant: string | null
-  readonly maxConcurrentOpencodeSessions: number
-  readonly maxConcurrentWorkItems: number
-}
-
-export interface StoreIssueInput {
-  readonly repositoryId: string
-  readonly githubIssueNumber: number
-  readonly title: string
-  readonly body: string
-  readonly url: string
-  readonly state: IssueState
-  readonly githubCreatedAt: Date
-  readonly parent: IssueReference | null
-  readonly parentPosition: number | null
-  readonly hasChildren: boolean
-  readonly blockedBy: readonly IssueDependency[]
-}
-
-export type IssueState = "OPEN" | "CLOSED"
-
-export interface IssueRecord {
-  readonly id: string
-  readonly repositoryId: string
-  readonly githubIssueNumber: number
-  readonly title: string
-  readonly body: string
-  readonly url: string
-  readonly state: IssueState
-  readonly githubCreatedAt: Date
-  readonly parent: IssueReference | null
-  readonly parentPosition: number | null
-  readonly hasChildren: boolean
-  readonly blockedBy: readonly IssueDependency[]
-}
-
-export interface IssueReference {
-  readonly githubIssueNumber: number
-  readonly githubIssueUrl: string
-}
+export const IssueReference = Schema.Struct({
+  githubIssueNumber: Schema.Int.pipe(Schema.check(Schema.isGreaterThan(0))),
+  githubIssueUrl: Schema.String,
+})
+export type IssueReference = typeof IssueReference.Type
 
 export type IssueDependency = IssueReference
 
-export interface WorkItemPullRequest {
-  readonly githubIssueNumber: number
-  readonly githubPullRequestNumber: number
-}
+export const AddRepositoryInput = Schema.Struct({
+  githubOwner: Schema.String,
+  githubRepo: Schema.String,
+  localPath: Schema.String,
+  isBare: Schema.Boolean,
+})
+export type AddRepositoryInput = typeof AddRepositoryInput.Type
+
+export const RepositoryRecord = Schema.Struct({
+  id: RepositoryId,
+  githubOwner: Schema.String,
+  githubRepo: Schema.String,
+  localPath: Schema.String,
+  isBare: Schema.Boolean,
+  paused: Schema.Boolean,
+  defaultModel: Schema.NullOr(Schema.String),
+  defaultVariant: Schema.NullOr(Schema.String),
+  reviewModel: Schema.NullOr(Schema.String),
+  reviewVariant: Schema.NullOr(Schema.String),
+  autoMerge: Schema.Boolean,
+  issuesReconciledAt: Schema.NullOr(Schema.Date),
+})
+export type RepositoryRecord = typeof RepositoryRecord.Type
+
+export const UpdateRepositorySettingsInput = Schema.Struct({
+  repositoryId: Schema.String,
+  paused: Schema.Boolean,
+  defaultModel: Schema.NullOr(Schema.String),
+  defaultVariant: Schema.NullOr(Schema.String),
+  reviewModel: Schema.NullOr(Schema.String),
+  reviewVariant: Schema.NullOr(Schema.String),
+  autoMerge: Schema.Boolean,
+})
+export type UpdateRepositorySettingsInput =
+  typeof UpdateRepositorySettingsInput.Type
+
+export const ConfigRecord = Schema.Struct({
+  defaultModel: Schema.NullOr(Schema.String),
+  defaultVariant: Schema.NullOr(Schema.String),
+  reviewModel: Schema.NullOr(Schema.String),
+  reviewVariant: Schema.NullOr(Schema.String),
+  maxConcurrentOpencodeSessions: Schema.Int.pipe(
+    Schema.check(Schema.isGreaterThan(0)),
+  ),
+  maxConcurrentWorkItems: Schema.Int.pipe(
+    Schema.check(Schema.isGreaterThan(0)),
+  ),
+})
+export type ConfigRecord = typeof ConfigRecord.Type
+
+export const UpdateConfigInput = Schema.Struct({
+  defaultModel: Schema.String,
+  defaultVariant: Schema.String,
+  reviewModel: Schema.NullOr(Schema.String),
+  reviewVariant: Schema.NullOr(Schema.String),
+  maxConcurrentOpencodeSessions: Schema.Finite,
+  maxConcurrentWorkItems: Schema.Finite,
+})
+export type UpdateConfigInput = typeof UpdateConfigInput.Type
+
+export const StoreIssueInput = Schema.Struct({
+  repositoryId: Schema.String,
+  githubIssueNumber: Schema.Finite,
+  title: Schema.String,
+  body: Schema.String,
+  url: Schema.String,
+  state: IssueState,
+  githubCreatedAt: Schema.Date,
+  parent: Schema.NullOr(IssueReference),
+  parentPosition: Schema.NullOr(Schema.Finite),
+  hasChildren: Schema.Boolean,
+  blockedBy: Schema.Array(IssueReference),
+})
+export type StoreIssueInput = typeof StoreIssueInput.Type
+
+export const IssueRecord = Schema.Struct({
+  id: Schema.String,
+  repositoryId: RepositoryId,
+  githubIssueNumber: Schema.Int.pipe(Schema.check(Schema.isGreaterThan(0))),
+  title: Schema.String,
+  body: Schema.String,
+  url: Schema.String,
+  state: IssueState,
+  githubCreatedAt: Schema.Date,
+  parent: Schema.NullOr(IssueReference),
+  parentPosition: Schema.NullOr(
+    Schema.Int.pipe(Schema.check(Schema.isGreaterThanOrEqualTo(0))),
+  ),
+  hasChildren: Schema.Boolean,
+  blockedBy: Schema.Array(IssueReference),
+})
+export type IssueRecord = typeof IssueRecord.Type
+
+export const WorkItemPullRequest = Schema.Struct({
+  githubIssueNumber: Schema.Int.pipe(Schema.check(Schema.isGreaterThan(0))),
+  githubPullRequestNumber: Schema.Int.pipe(
+    Schema.check(Schema.isGreaterThan(0)),
+  ),
+})
+export type WorkItemPullRequest = typeof WorkItemPullRequest.Type
+
+/** Wire shape of `repository` SELECT rows (snake_case columns). */
+export const RepositorySqlRow = Schema.Struct({
+  id: RepositoryId,
+  githubOwner: Schema.String,
+  githubRepo: Schema.String,
+  localPath: Schema.String,
+  isBare: SqlBoolean,
+  paused: SqlBoolean,
+  defaultModel: Schema.NullOr(Schema.String),
+  defaultVariant: Schema.NullOr(Schema.String),
+  reviewModel: Schema.NullOr(Schema.String),
+  reviewVariant: Schema.NullOr(Schema.String),
+  autoMerge: SqlBoolean,
+  issuesReconciledAt: Schema.NullOr(Schema.DateFromMillis),
+}).pipe(
+  Schema.encodeKeys({
+    githubOwner: "github_owner",
+    githubRepo: "github_repo",
+    localPath: "local_path",
+    isBare: "is_bare",
+    defaultModel: "default_model",
+    defaultVariant: "default_variant",
+    reviewModel: "review_model",
+    reviewVariant: "review_variant",
+    autoMerge: "auto_merge",
+    issuesReconciledAt: "issues_reconciled_at",
+  }),
+)
+export type RepositorySqlRow = typeof RepositorySqlRow.Type
+
+export const ConfigSqlRow = Schema.Struct({
+  defaultModel: Schema.NullOr(Schema.String),
+  defaultVariant: Schema.NullOr(Schema.String),
+  reviewModel: Schema.NullOr(Schema.String),
+  reviewVariant: Schema.NullOr(Schema.String),
+  maxConcurrentOpencodeSessions: Schema.Int,
+  maxConcurrentWorkItems: Schema.Int,
+}).pipe(
+  Schema.encodeKeys({
+    defaultModel: "default_model",
+    defaultVariant: "default_variant",
+    reviewModel: "review_model",
+    reviewVariant: "review_variant",
+    maxConcurrentOpencodeSessions: "max_concurrent_opencode_sessions",
+    maxConcurrentWorkItems: "max_concurrent_work_items",
+  }),
+)
+export type ConfigSqlRow = typeof ConfigSqlRow.Type
+
+export const IssueSqlRow = Schema.Struct({
+  id: Schema.String,
+  repositoryId: RepositoryId,
+  githubIssueNumber: Schema.Int,
+  title: Schema.String,
+  body: Schema.String,
+  url: Schema.String,
+  state: IssueState,
+  githubCreatedAt: Schema.Finite,
+  parentGithubIssueNumber: Schema.NullOr(Schema.Int),
+  parentGithubIssueUrl: Schema.NullOr(Schema.String),
+  parentPosition: Schema.NullOr(Schema.Int),
+  hasChildren: SqlBoolean,
+}).pipe(
+  Schema.encodeKeys({
+    repositoryId: "repository_id",
+    githubIssueNumber: "github_issue_number",
+    githubCreatedAt: "github_created_at",
+    parentGithubIssueNumber: "parent_github_issue_number",
+    parentGithubIssueUrl: "parent_github_issue_url",
+    parentPosition: "parent_position",
+    hasChildren: "has_children",
+  }),
+)
+export type IssueSqlRow = typeof IssueSqlRow.Type
+
+export const IssueDependencySqlRow = Schema.Struct({
+  issueId: Schema.String,
+  githubIssueNumber: Schema.Int,
+  githubIssueUrl: Schema.String,
+}).pipe(
+  Schema.encodeKeys({
+    issueId: "issue_id",
+    githubIssueNumber: "blocking_github_issue_number",
+    githubIssueUrl: "blocking_github_issue_url",
+  }),
+)
+export type IssueDependencySqlRow = typeof IssueDependencySqlRow.Type
+
+export const WorkItemPullRequestSqlRow = Schema.Struct({
+  githubIssueNumber: Schema.Int,
+  githubPullRequestNumber: Schema.Int,
+}).pipe(
+  Schema.encodeKeys({
+    githubIssueNumber: "github_issue_number",
+    githubPullRequestNumber: "github_pull_request_number",
+  }),
+)
+export type WorkItemPullRequestSqlRow = typeof WorkItemPullRequestSqlRow.Type
+
+export const RunningStepSqlRow = Schema.Struct({
+  stepRunId: Schema.String,
+  workItemId: Schema.String,
+}).pipe(
+  Schema.encodeKeys({
+    stepRunId: "step_run_id",
+    workItemId: "work_item_id",
+  }),
+)
+export type RunningStepSqlRow = typeof RunningStepSqlRow.Type

--- a/packages/work-item-lifecycle/test/create-pr.spec.ts
+++ b/packages/work-item-lifecycle/test/create-pr.spec.ts
@@ -7,6 +7,7 @@ import type { DbService } from "@ready-for-agent/db-service"
 import {
   makeRepositoryRecord,
   stubDbServiceLayer,
+  testRepositoryId,
 } from "@ready-for-agent/db-service/test"
 import {
   GitHubService,
@@ -37,7 +38,7 @@ const baseContext = (
   overrides: Partial<LifecycleStepContext> = {},
 ): LifecycleStepContext => ({
   workItemId: makeWorkItemId(),
-  repositoryId: "repo-test",
+  repositoryId: testRepositoryId,
   githubIssueNumber: 91,
   model: "opencode/test-model",
   variant: "high",


### PR DESCRIPTION
## Summary
- Align `packages/db-service` domain errors with `Schema.TaggedErrorClass`, brand `RepositoryId` on create/read records, and Schema-decode SQL rows after queries.
- Prefer `Clock` for written timestamps, name service methods for tracing, document the issue-change notify contract, and keep process-global PubSubs with rationale.
- Update create-pr fixture usage for the branded test repository id.

Closes #304

## Test plan
- [x] `bunx nx test db-service`
- [x] `bunx nx lint db-service` / `typecheck db-service`
- [x] `bunx nx test work-item-lifecycle`
- [x] Pre-commit affected lint/typecheck/test