### PR TITLE
fix(graphql-api): keep completed Work Items after Issues leave projection

### DIFF
--- a/apps/harness/test/jobs-card-no-polling.test.ts
+++ b/apps/harness/test/jobs-card-no-polling.test.ts
@@ -65,6 +65,8 @@ describe("JobsCard live updates", () => {
     expect(jobsCard).toContain("issueTitle")
     expect(jobsCard).toContain("issuesQuery(repository.id)")
     expect(jobsCard).toContain("title={issueIdentity}")
+    expect(jobsCard).toContain("issueTitle === undefined")
+    expect(jobsCard).toContain("`#${workItem.githubIssueNumber}`")
     const pauseIndex = jobsCard.indexOf(
       "<WorkItemPauseButton workItem={workItem} />",
     )

--- a/packages/graphql-api/src/lib/graphql-api.ts
+++ b/packages/graphql-api/src/lib/graphql-api.ts
@@ -19,6 +19,7 @@ import {
   type WorkItemRecord,
   type WorkItemsListKind,
   filterWorkItemsByListKind,
+  isJobsCompletedWorkItemState,
   isTerminalWorkItemState,
 } from "@ready-for-agent/work-item-lifecycle"
 import {
@@ -287,6 +288,7 @@ export const createGraphqlApi = (
                 )
                 const visible = workItems.filter(
                   (workItem) =>
+                    isJobsCompletedWorkItemState(workItem.state) ||
                     !isTerminalWorkItemState(workItem.state) ||
                     relevantIssueNumbers.has(workItem.githubIssueNumber),
                 )

--- a/packages/graphql-api/test/graphql-api.test.ts
+++ b/packages/graphql-api/test/graphql-api.test.ts
@@ -2029,12 +2029,19 @@ describe("GraphQL API", () => {
     })
   })
 
-  test("hides terminal Work Items whose Issue is no longer Relevant", async () => {
-    const terminalOrphan = {
+  test("hides non-Completed terminal Work Items whose Issue is no longer Relevant", async () => {
+    const needsHumanOrphan = {
       ...workItem,
       id: makeWorkItemId(),
       githubIssueNumber: 120,
       state: "needs_human" as const,
+      stepRuns: [],
+    }
+    const failedOrphan = {
+      ...workItem,
+      id: makeWorkItemId(),
+      githubIssueNumber: 122,
+      state: "failed" as const,
       stepRuns: [],
     }
     const unfinishedOrphan = {
@@ -2042,6 +2049,20 @@ describe("GraphQL API", () => {
       id: makeWorkItemId(),
       githubIssueNumber: 121,
       state: "implement" as const,
+      stepRuns: [],
+    }
+    const completeOrphan = {
+      ...workItem,
+      id: makeWorkItemId(),
+      githubIssueNumber: 123,
+      state: "complete" as const,
+      stepRuns: [],
+    }
+    const abandonedOrphan = {
+      ...workItem,
+      id: makeWorkItemId(),
+      githubIssueNumber: 124,
+      state: "abandoned" as const,
       stepRuns: [],
     }
     const terminalRelevant = {
@@ -2060,7 +2081,14 @@ describe("GraphQL API", () => {
       {},
       {
         listWorkItemsForRepository: () =>
-          Effect.succeed([terminalOrphan, unfinishedOrphan, terminalRelevant]),
+          Effect.succeed([
+            needsHumanOrphan,
+            failedOrphan,
+            unfinishedOrphan,
+            completeOrphan,
+            abandonedOrphan,
+            terminalRelevant,
+          ]),
       },
     )
 
@@ -2084,8 +2112,85 @@ describe("GraphQL API", () => {
             state: "IMPLEMENT",
           },
           {
+            id: completeOrphan.id,
+            githubIssueNumber: 123,
+            state: "COMPLETE",
+          },
+          {
+            id: abandonedOrphan.id,
+            githubIssueNumber: 124,
+            state: "ABANDONED",
+          },
+          {
             id: terminalRelevant.id,
             githubIssueNumber: issue.githubIssueNumber,
+            state: "COMPLETE",
+          },
+        ],
+      },
+    })
+  })
+
+  test("keeps complete and abandoned Work Items in COMPLETED when Issue is absent", async () => {
+    const completeOrphan = {
+      ...workItem,
+      id: makeWorkItemId(),
+      githubIssueNumber: 201,
+      state: "complete" as const,
+      createdAt: new Date("2026-03-01T00:00:00.000Z"),
+      stepRuns: [],
+    }
+    const abandonedOrphan = {
+      ...workItem,
+      id: makeWorkItemId(),
+      githubIssueNumber: 202,
+      state: "abandoned" as const,
+      createdAt: new Date("2026-03-02T00:00:00.000Z"),
+      stepRuns: [],
+    }
+    const failedOrphan = {
+      ...workItem,
+      id: makeWorkItemId(),
+      githubIssueNumber: 203,
+      state: "failed" as const,
+      createdAt: new Date("2026-03-03T00:00:00.000Z"),
+      stepRuns: [],
+    }
+    await runtime.dispose()
+    runtime = makeRuntime(
+      {
+        listIssues: () => Effect.succeed([]),
+      },
+      {},
+      {},
+      {
+        listWorkItemsForRepository: () =>
+          Effect.succeed([completeOrphan, abandonedOrphan, failedOrphan]),
+      },
+    )
+
+    const response = await createGraphqlApi(runtime).fetch(
+      graphqlRequest({
+        query: `query WorkItems($repositoryId: ID!, $listKind: WorkItemsListKind) {
+          workItems(repositoryId: $repositoryId, listKind: $listKind) {
+            id githubIssueNumber state
+          }
+        }`,
+        variables: { repositoryId: repository.id, listKind: "COMPLETED" },
+      }),
+    )
+
+    expect(await response.json()).toEqual({
+      data: {
+        workItems: [
+          {
+            id: abandonedOrphan.id,
+            githubIssueNumber: 202,
+            state: "ABANDONED",
+          },
+          {
+            id: completeOrphan.id,
+            githubIssueNumber: 201,
             state: "COMPLETE",
           },
         ],


### PR DESCRIPTION
## Summary

- Keep `complete` and `abandoned` Work Items visible in repository-wide `workItems` (including `listKind: COMPLETED`) after their GitHub Issues leave the Relevant Issue projection.
- Preserve Working/Failed filtering for other terminal states that still require a current Issue row.
- Add regression coverage and assert Jobs card issue-identity fallback when no Issue row is present.

Closes #322

## Test plan

- [x] `bunx nx test graphql-api`
- [x] `bunx nx test harness` (jobs-card coverage)
- [x] Pre-commit affected lint/typecheck/test