### PR TITLE
refactor(queue-service): tighten Effect error handling and claim path

### DIFF
--- a/packages/graphql-api/src/lib/to-graphql-error.ts
+++ b/packages/graphql-api/src/lib/to-graphql-error.ts
@@ -144,6 +144,8 @@ export const toGraphQLError = (error: unknown): GraphQLError => {
       return gql(error.message ?? "Database error", "DATABASE_ERROR")
     case "EnqueueError":
       return gql(error.message ?? "Enqueue error", "ENQUEUE_ERROR")
+    case "QueueReadError":
+      return gql(error.message ?? "Queue read error", "QUEUE_READ_ERROR")
     case "ResetCleanupError":
       return gql(
         error.message ?? "Reset cleanup failed",

--- a/packages/queue-service/src/lib/errors.ts
+++ b/packages/queue-service/src/lib/errors.ts
@@ -62,3 +62,15 @@ export class InvalidJobKeyError extends Schema.TaggedErrorClass<InvalidJobKeyErr
     message: Schema.String,
   },
 ) {}
+
+/**
+ * Error thrown when a queue read/inspect operation fails (list, stats).
+ */
+export class QueueReadError extends Schema.TaggedErrorClass<QueueReadError>()(
+  "QueueReadError",
+  {
+    queue: Schema.String,
+    message: Schema.String,
+    cause: Schema.optional(Schema.Defect()),
+  },
+) {}

--- a/packages/queue-service/src/lib/queue-service.ts
+++ b/packages/queue-service/src/lib/queue-service.ts
@@ -5,6 +5,7 @@ import type {
   ClaimError,
   EnqueueError,
   JobNotFoundError,
+  QueueReadError,
 } from "./errors.js"
 import {
   InvalidJobKeyError,
@@ -174,7 +175,10 @@ export interface QueueServiceShape {
    */
   readonly listKeyed: (
     queue: string,
-  ) => Effect.Effect<ReadonlyArray<KeyedQueueEntry>, InvalidQueueNameError>
+  ) => Effect.Effect<
+    ReadonlyArray<KeyedQueueEntry>,
+    InvalidQueueNameError | QueueReadError
+  >
 
   /**
    * Postpone a claimed keyed entry in place: preserve identity, release claim,
@@ -242,7 +246,7 @@ export interface QueueServiceShape {
    */
   readonly getStats: (
     queue: string,
-  ) => Effect.Effect<QueueStats, InvalidQueueNameError>
+  ) => Effect.Effect<QueueStats, InvalidQueueNameError | QueueReadError>
 
   /**
    * Move all jobs whose payload `_tag` matches from one queue to another.
@@ -264,42 +268,36 @@ export class QueueService extends Context.Service<
    * Claim the next available job from the queue with type-safe payload parsing.
    * Returns None if no jobs are available.
    */
-  static claim = <A>(
+  static claim = Effect.fn("QueueService.claim")(function* <A>(
     queue: string,
     schema: Schema.Decoder<A>,
     visibilityTimeout?: Duration.Duration,
-  ): Effect.Effect<
-    Option.Option<Job<A>>,
-    ClaimError | InvalidQueueNameError | PayloadParseError,
-    QueueService
-  > =>
-    Effect.gen(function* () {
-      const service = yield* QueueService
-      const rawJobOption = yield* service.rawClaim(queue, visibilityTimeout)
+  ) {
+    const service = yield* QueueService
+    const rawJobOption = yield* service.rawClaim(queue, visibilityTimeout)
 
-      if (Option.isNone(rawJobOption)) {
-        return Option.none()
-      }
+    if (Option.isNone(rawJobOption)) {
+      return Option.none()
+    }
 
-      const rawJob = rawJobOption.value
-      const payload = yield* Schema.decodeUnknownEffect(schema)(
-        rawJob.payload,
-      ).pipe(
-        Effect.mapError(
-          (error) =>
-            new PayloadParseError({ queue, jobId: rawJob.jobId, error }),
-        ),
-      )
+    const rawJob = rawJobOption.value
+    const payload = yield* Schema.decodeUnknownEffect(schema)(
+      rawJob.payload,
+    ).pipe(
+      Effect.mapError(
+        (error) => new PayloadParseError({ queue, jobId: rawJob.jobId, error }),
+      ),
+    )
 
-      return Option.some<Job<A>>({
-        jobId: rawJob.jobId,
-        queue: rawJob.queue,
-        key: rawJob.key,
-        payload,
-        attempts: rawJob.attempts,
-        maxAttempts: rawJob.maxAttempts,
-        availableAt: rawJob.availableAt,
-        lockedUntil: rawJob.lockedUntil,
-      })
+    return Option.some<Job<A>>({
+      jobId: rawJob.jobId,
+      queue: rawJob.queue,
+      key: rawJob.key,
+      payload,
+      attempts: rawJob.attempts,
+      maxAttempts: rawJob.maxAttempts,
+      availableAt: rawJob.availableAt,
+      lockedUntil: rawJob.lockedUntil,
     })
+  })
 }

--- a/packages/queue-service/test/claim.spec.ts
+++ b/packages/queue-service/test/claim.spec.ts
@@ -1,0 +1,103 @@
+import { DateTime, Duration, Effect, Layer, Option, Schema } from "effect"
+import {
+  JobId,
+  PayloadParseError,
+  QueueService,
+  type QueueServiceShape,
+  type RawJob,
+} from "../src/index.js"
+import { describe, expect, it } from "bun:test"
+
+const TestPayload = Schema.Struct({
+  task: Schema.String,
+})
+
+const sampleJobId = JobId.make("qjob-01ARZ3NDEKTSV4RRFFQ69G5FAV")
+
+const makeRawJob = (payload: unknown): RawJob => ({
+  jobId: sampleJobId,
+  queue: "test-queue",
+  key: null,
+  payload,
+  attempts: 1,
+  maxAttempts: 5,
+  availableAt: DateTime.makeUnsafe(0),
+  lockedUntil: DateTime.makeUnsafe(30_000),
+})
+
+const makeFakeQueue = (
+  rawClaim: QueueServiceShape["rawClaim"],
+): QueueServiceShape => ({
+  queueInTransaction: false,
+  enqueue: () => Effect.die("unused"),
+  enqueueWithDelay: () => Effect.die("unused"),
+  ensureKeyed: () => Effect.die("unused"),
+  listKeyed: () => Effect.die("unused"),
+  postponeKeyed: () => Effect.die("unused"),
+  removeKeyed: () => Effect.die("unused"),
+  rawClaim,
+  acknowledge: () => Effect.die("unused"),
+  fail: () => Effect.die("unused"),
+  extendVisibility: () => Effect.die("unused"),
+  getStats: () => Effect.die("unused"),
+  requeueByPayloadTag: () => Effect.die("unused"),
+})
+
+const runWithQueue = <A, E>(
+  queue: QueueServiceShape,
+  effect: Effect.Effect<A, E, QueueService>,
+) =>
+  Effect.runPromise(
+    Effect.provide(effect, Layer.succeed(QueueService, QueueService.of(queue))),
+  )
+
+describe("QueueService.claim", () => {
+  it("returns None when rawClaim returns None", async () => {
+    const result = await runWithQueue(
+      makeFakeQueue(() => Effect.succeed(Option.none())),
+      QueueService.claim("test-queue", TestPayload),
+    )
+    expect(Option.isNone(result)).toBe(true)
+  })
+
+  it("decodes a valid payload into a typed Job", async () => {
+    const result = await runWithQueue(
+      makeFakeQueue(() =>
+        Effect.succeed(Option.some(makeRawJob({ task: "hello" }))),
+      ),
+      QueueService.claim("test-queue", TestPayload, Duration.seconds(10)),
+    )
+    expect(Option.isSome(result)).toBe(true)
+    if (Option.isSome(result)) {
+      expect(result.value.jobId).toBe(sampleJobId)
+      expect(result.value.queue).toBe("test-queue")
+      expect(result.value.payload).toEqual({ task: "hello" })
+      expect(result.value.attempts).toBe(1)
+      expect(result.value.maxAttempts).toBe(5)
+    }
+  })
+
+  it("fails with PayloadParseError when payload does not match schema", async () => {
+    const result = await Effect.runPromise(
+      Effect.result(
+        Effect.provide(
+          QueueService.claim("test-queue", TestPayload),
+          Layer.succeed(
+            QueueService,
+            QueueService.of(
+              makeFakeQueue(() =>
+                Effect.succeed(Option.some(makeRawJob({ notTask: 1 }))),
+              ),
+            ),
+          ),
+        ),
+      ),
+    )
+    expect(result._tag).toBe("Failure")
+    if (result._tag === "Failure") {
+      expect(result.failure).toBeInstanceOf(PayloadParseError)
+      expect(result.failure.queue).toBe("test-queue")
+      expect(result.failure.jobId).toBe(sampleJobId)
+    }
+  })
+})

--- a/packages/sqlite-queue-service/src/lib/sqlite-queue-service.ts
+++ b/packages/sqlite-queue-service/src/lib/sqlite-queue-service.ts
@@ -1,4 +1,13 @@
-import { DateTime, Duration, Effect, Layer, Option, Schedule } from "effect"
+import {
+  Clock,
+  DateTime,
+  Duration,
+  Effect,
+  Layer,
+  Option,
+  Schedule,
+  Schema,
+} from "effect"
 import { SqlClient } from "effect/unstable/sql"
 import type { SqlError } from "effect/unstable/sql/SqlError"
 import type {
@@ -15,6 +24,7 @@ import {
   EnqueueError,
   JobId,
   JobNotFoundError,
+  QueueReadError,
   QueueService,
   makeJobId,
   validateJobKey,
@@ -40,11 +50,16 @@ const formatSqlError = (error: SqlError): string => {
   return parts.join(" -> ")
 }
 
-const isSqliteBusy = (error: unknown): boolean =>
-  error instanceof Error &&
-  (error.message.includes("SQLITE_BUSY") ||
-    error.message.includes("database is locked") ||
-    error.message.includes("SQL statements in progress"))
+const isSqliteBusy = (error: unknown): boolean => {
+  if (!(error instanceof Error)) return false
+  const message = error.message
+  return (
+    message.includes("SQLITE_BUSY") ||
+    message.includes("database is locked") ||
+    message.includes("SQL statements in progress") ||
+    message.includes("CONCURRENT")
+  )
+}
 
 const retrySqliteBusy = <A, E, R>(effect: Effect.Effect<A, E, R>) =>
   effect.pipe(
@@ -65,38 +80,164 @@ const retryLimitFromOptions = (options?: {
     ? DEFAULT_MAX_RETRIES
     : options.retryLimit + 1
 
-type JobRow = {
-  readonly id: string
-  readonly queue: string
-  readonly key: string | null
-  readonly job_payload: string
-  readonly job_attempts: number
-  readonly job_retry_limit: number
-  readonly available_at: number
-  readonly locked_until: number | null
-}
+const JobSqlRow = Schema.Struct({
+  id: Schema.String,
+  queue: Schema.String,
+  key: Schema.NullOr(Schema.String),
+  jobPayload: Schema.String,
+  jobAttempts: Schema.Finite,
+  jobRetryLimit: Schema.Finite,
+  availableAt: Schema.Finite,
+  lockedUntil: Schema.NullOr(Schema.Finite),
+}).pipe(
+  Schema.encodeKeys({
+    jobPayload: "job_payload",
+    jobAttempts: "job_attempts",
+    jobRetryLimit: "job_retry_limit",
+    availableAt: "available_at",
+    lockedUntil: "locked_until",
+  }),
+)
+type JobSqlRow = typeof JobSqlRow.Type
 
-const rawJob = (row: JobRow): RawJob => ({
-  jobId: JobId.make(row.id),
-  queue: row.queue,
-  key: row.key,
-  payload: JSON.parse(row.job_payload),
-  attempts: row.job_attempts,
-  maxAttempts: row.job_retry_limit,
-  availableAt: toUtc(row.available_at),
-  lockedUntil: toUtc(row.locked_until ?? row.available_at),
+const IdSqlRow = Schema.Struct({
+  id: Schema.String,
 })
 
-const keyedEntry = (row: JobRow): KeyedQueueEntry => ({
-  jobId: JobId.make(row.id),
-  queue: row.queue,
-  key: row.key as string,
-  payload: JSON.parse(row.job_payload),
-  attempts: row.job_attempts,
-  maxAttempts: row.job_retry_limit,
-  availableAt: toUtc(row.available_at),
-  lockedUntil: row.locked_until === null ? null : toUtc(row.locked_until),
+const KeyedLockSqlRow = Schema.Struct({
+  id: Schema.String,
+  key: Schema.NullOr(Schema.String),
+  lockedUntil: Schema.NullOr(Schema.Finite),
+}).pipe(
+  Schema.encodeKeys({
+    lockedUntil: "locked_until",
+  }),
+)
+
+const StatsSqlRow = Schema.Struct({
+  pending: Schema.Finite,
+  processing: Schema.Finite,
+  deadLetter: Schema.Finite,
 })
+
+const decodeJobRows = (rows: ReadonlyArray<unknown>) =>
+  Schema.decodeUnknownEffect(Schema.Array(JobSqlRow))(rows)
+
+const decodeIdRows = (rows: ReadonlyArray<unknown>) =>
+  Schema.decodeUnknownEffect(Schema.Array(IdSqlRow))(rows)
+
+const decodeKeyedLockRows = (rows: ReadonlyArray<unknown>) =>
+  Schema.decodeUnknownEffect(Schema.Array(KeyedLockSqlRow))(rows)
+
+const decodeStatsRows = (rows: ReadonlyArray<unknown>) =>
+  Schema.decodeUnknownEffect(Schema.Array(StatsSqlRow))(rows)
+
+class JsonParseError extends Schema.TaggedErrorClass<JsonParseError>()(
+  "JsonParseError",
+  {
+    message: Schema.String,
+    cause: Schema.optional(Schema.Defect()),
+  },
+) {}
+
+const parseJsonPayload = (raw: string) =>
+  Effect.try({
+    try: () => JSON.parse(raw) as unknown,
+    catch: (cause) =>
+      new JsonParseError({
+        message:
+          cause instanceof Error ? cause.message : "Failed to parse JSON",
+        cause,
+      }),
+  })
+
+const rawJobFromRow = (row: JobSqlRow): Effect.Effect<RawJob, JsonParseError> =>
+  Effect.gen(function* () {
+    const payload = yield* parseJsonPayload(row.jobPayload)
+    return {
+      jobId: JobId.make(row.id),
+      queue: row.queue,
+      key: row.key,
+      payload,
+      attempts: row.jobAttempts,
+      maxAttempts: row.jobRetryLimit,
+      availableAt: toUtc(row.availableAt),
+      lockedUntil: toUtc(row.lockedUntil ?? row.availableAt),
+    } satisfies RawJob
+  })
+
+const keyedEntryFromRow = (
+  row: JobSqlRow,
+): Effect.Effect<KeyedQueueEntry, JsonParseError> =>
+  Effect.gen(function* () {
+    const payload = yield* parseJsonPayload(row.jobPayload)
+    return {
+      jobId: JobId.make(row.id),
+      queue: row.queue,
+      key: row.key as string,
+      payload,
+      attempts: row.jobAttempts,
+      maxAttempts: row.jobRetryLimit,
+      availableAt: toUtc(row.availableAt),
+      lockedUntil: row.lockedUntil === null ? null : toUtc(row.lockedUntil),
+    } satisfies KeyedQueueEntry
+  })
+
+const toEnqueueError = (queue: string, error: SqlError) =>
+  new EnqueueError({
+    queue,
+    message: `Database error: ${formatSqlError(error)}`,
+    cause: error,
+  })
+
+const toClaimError = (queue: string, error: SqlError) =>
+  new ClaimError({
+    queue,
+    message: `Database error: ${formatSqlError(error)}`,
+    cause: error,
+  })
+
+const toAcknowledgeError = (jobId: string, error: SqlError) =>
+  new AcknowledgeError({
+    jobId,
+    message: `Database error: ${formatSqlError(error)}`,
+    cause: error,
+  })
+
+const toQueueReadSqlError = (queue: string, error: SqlError) =>
+  new QueueReadError({
+    queue,
+    message: `Database error: ${formatSqlError(error)}`,
+    cause: error,
+  })
+
+const toQueueReadSchemaError = (queue: string, error: Schema.SchemaError) =>
+  new QueueReadError({
+    queue,
+    message: `Database row shape error: ${error.message}`,
+    cause: error,
+  })
+
+const toClaimSchemaError = (queue: string, error: Schema.SchemaError) =>
+  new ClaimError({
+    queue,
+    message: `Database row shape error: ${error.message}`,
+    cause: error,
+  })
+
+const toEnqueueSchemaError = (queue: string, error: Schema.SchemaError) =>
+  new EnqueueError({
+    queue,
+    message: `Database row shape error: ${error.message}`,
+    cause: error,
+  })
+
+const toAcknowledgeSchemaError = (jobId: string, error: Schema.SchemaError) =>
+  new AcknowledgeError({
+    jobId,
+    message: `Database row shape error: ${error.message}`,
+    cause: error,
+  })
 
 export const SqliteQueueServiceLive = Layer.effect(
   QueueService,
@@ -112,7 +253,7 @@ export const SqliteQueueServiceLive = Layer.effect(
       ) =>
         Effect.gen(function* () {
           yield* validateQueueName(queue)
-          const now = Date.now()
+          const now = yield* Clock.currentTimeMillis
           const jobId = makeJobId()
           const rows = yield* retrySqliteBusy(
             sql.unsafe(
@@ -128,17 +269,11 @@ export const SqliteQueueServiceLive = Layer.effect(
                 now,
               ],
             ),
-          ).pipe(
-            Effect.mapError(
-              (error) =>
-                new EnqueueError({
-                  queue,
-                  message: `Database error: ${formatSqlError(error)}`,
-                  cause: error,
-                }),
-            ),
+          ).pipe(Effect.mapError((error) => toEnqueueError(queue, error)))
+          const decoded = yield* decodeIdRows(rows).pipe(
+            Effect.mapError((error) => toEnqueueSchemaError(queue, error)),
           )
-          const row = rows[0] as { readonly id: string } | undefined
+          const row = decoded[0]
           if (!row)
             return yield* new EnqueueError({
               queue,
@@ -154,7 +289,7 @@ export const SqliteQueueServiceLive = Layer.effect(
       ) =>
         Effect.gen(function* () {
           yield* validateQueueName(queue)
-          const now = Date.now()
+          const now = yield* Clock.currentTimeMillis
           const jobId = makeJobId()
           const rows = yield* retrySqliteBusy(
             sql.unsafe(
@@ -170,17 +305,11 @@ export const SqliteQueueServiceLive = Layer.effect(
                 now,
               ],
             ),
-          ).pipe(
-            Effect.mapError(
-              (error) =>
-                new EnqueueError({
-                  queue,
-                  message: `Database error: ${formatSqlError(error)}`,
-                  cause: error,
-                }),
-            ),
+          ).pipe(Effect.mapError((error) => toEnqueueError(queue, error)))
+          const decoded = yield* decodeIdRows(rows).pipe(
+            Effect.mapError((error) => toEnqueueSchemaError(queue, error)),
           )
-          const row = rows[0] as { readonly id: string } | undefined
+          const row = decoded[0]
           if (!row)
             return yield* new EnqueueError({
               queue,
@@ -198,7 +327,7 @@ export const SqliteQueueServiceLive = Layer.effect(
         Effect.gen(function* () {
           yield* validateQueueName(queue)
           yield* validateJobKey(key)
-          const now = Date.now()
+          const now = yield* Clock.currentTimeMillis
           const jobId = makeJobId()
           const availableAt = now + Duration.toMillis(delay)
           const result = yield* retrySqliteBusy(
@@ -220,9 +349,12 @@ export const SqliteQueueServiceLive = Layer.effect(
                     now,
                   ],
                 )
-                const insertedRow = inserted[0] as
-                  | { readonly id: string }
-                  | undefined
+                const insertedDecoded = yield* decodeIdRows(inserted).pipe(
+                  Effect.mapError((error) =>
+                    toEnqueueSchemaError(queue, error),
+                  ),
+                )
+                const insertedRow = insertedDecoded[0]
                 if (insertedRow) {
                   return {
                     jobId: JobId.make(insertedRow.id),
@@ -233,9 +365,12 @@ export const SqliteQueueServiceLive = Layer.effect(
                   `SELECT id FROM job_queue WHERE queue = ? AND key = ?`,
                   [queue, key],
                 )
-                const existingRow = existing[0] as
-                  | { readonly id: string }
-                  | undefined
+                const existingDecoded = yield* decodeIdRows(existing).pipe(
+                  Effect.mapError((error) =>
+                    toEnqueueSchemaError(queue, error),
+                  ),
+                )
+                const existingRow = existingDecoded[0]
                 if (!existingRow) {
                   return yield* new EnqueueError({
                     queue,
@@ -252,11 +387,7 @@ export const SqliteQueueServiceLive = Layer.effect(
             Effect.mapError((error) =>
               error instanceof EnqueueError
                 ? error
-                : new EnqueueError({
-                    queue,
-                    message: `Database error: ${formatSqlError(error as SqlError)}`,
-                    cause: error,
-                  }),
+                : toEnqueueError(queue, error as SqlError),
             ),
           )
           return result
@@ -272,12 +403,26 @@ export const SqliteQueueServiceLive = Layer.effect(
                ORDER BY key, id`,
               [queue],
             )
-            .pipe(Effect.orElseSucceed(() => []))
-          return (rows as ReadonlyArray<JobRow>).map(keyedEntry)
+            .pipe(Effect.mapError((error) => toQueueReadSqlError(queue, error)))
+          const decoded = yield* decodeJobRows(rows).pipe(
+            Effect.mapError((error) => toQueueReadSchemaError(queue, error)),
+          )
+          return yield* Effect.forEach(decoded, (row) =>
+            keyedEntryFromRow(row).pipe(
+              Effect.mapError(
+                (cause) =>
+                  new QueueReadError({
+                    queue,
+                    message: `Failed to parse job payload for job ${row.id}`,
+                    cause,
+                  }),
+              ),
+            ),
+          )
         }),
       postponeKeyed: (jobId: string, delay: Duration.Duration) =>
         Effect.gen(function* () {
-          const now = Date.now()
+          const now = yield* Clock.currentTimeMillis
           const availableAt = now + Duration.toMillis(delay)
           const rows = yield* retrySqliteBusy(
             sql.unsafe(
@@ -292,39 +437,21 @@ export const SqliteQueueServiceLive = Layer.effect(
                RETURNING id`,
               [availableAt, now, jobId],
             ),
-          ).pipe(
-            Effect.mapError(
-              (error) =>
-                new AcknowledgeError({
-                  jobId,
-                  message: `Database error: ${formatSqlError(error)}`,
-                  cause: error,
-                }),
-            ),
+          ).pipe(Effect.mapError((error) => toAcknowledgeError(jobId, error)))
+          const updated = yield* decodeIdRows(rows).pipe(
+            Effect.mapError((error) => toAcknowledgeSchemaError(jobId, error)),
           )
-          if (rows[0]) return
+          if (updated[0]) return
           const existing = yield* sql
             .unsafe(
               `SELECT id, key, locked_until FROM job_queue WHERE id = ?`,
               [jobId],
             )
-            .pipe(
-              Effect.mapError(
-                (error) =>
-                  new AcknowledgeError({
-                    jobId,
-                    message: `Database error: ${formatSqlError(error)}`,
-                    cause: error,
-                  }),
-              ),
-            )
-          const row = existing[0] as
-            | {
-                readonly id: string
-                readonly key: string | null
-                readonly locked_until: number | null
-              }
-            | undefined
+            .pipe(Effect.mapError((error) => toAcknowledgeError(jobId, error)))
+          const decoded = yield* decodeKeyedLockRows(existing).pipe(
+            Effect.mapError((error) => toAcknowledgeSchemaError(jobId, error)),
+          )
+          const row = decoded[0]
           if (!row) return yield* new JobNotFoundError({ jobId })
           if (row.key === null) {
             return yield* new AcknowledgeError({
@@ -346,16 +473,7 @@ export const SqliteQueueServiceLive = Layer.effect(
               queue,
               key,
             ]),
-          ).pipe(
-            Effect.mapError(
-              (error) =>
-                new EnqueueError({
-                  queue,
-                  message: `Database error: ${formatSqlError(error)}`,
-                  cause: error,
-                }),
-            ),
-          )
+          ).pipe(Effect.mapError((error) => toEnqueueError(queue, error)))
         }),
       rawClaim: (
         queue: string,
@@ -363,7 +481,7 @@ export const SqliteQueueServiceLive = Layer.effect(
       ) =>
         Effect.gen(function* () {
           yield* validateQueueName(queue)
-          const now = Date.now()
+          const now = yield* Clock.currentTimeMillis
           const lockedUntil = now + Duration.toMillis(visibilityTimeout)
           const rows = yield* retrySqliteBusy(
             sql.withTransaction(
@@ -379,18 +497,23 @@ export const SqliteQueueServiceLive = Layer.effect(
                 [lockedUntil, now, queue, now, now],
               ),
             ),
-          ).pipe(
+          ).pipe(Effect.mapError((error) => toClaimError(queue, error)))
+          const decoded = yield* decodeJobRows(rows).pipe(
+            Effect.mapError((error) => toClaimSchemaError(queue, error)),
+          )
+          const row = decoded[0]
+          if (!row) return Option.none()
+          const job = yield* rawJobFromRow(row).pipe(
             Effect.mapError(
-              (error) =>
+              (cause) =>
                 new ClaimError({
                   queue,
-                  message: `Database error: ${formatSqlError(error)}`,
-                  cause: error,
+                  message: `Failed to parse job payload for job ${row.id}`,
+                  cause,
                 }),
             ),
           )
-          const row = rows[0] as JobRow | undefined
-          return row ? Option.some(rawJob(row)) : Option.none()
+          return Option.some(job)
         }),
       acknowledge: (jobId: string) =>
         Effect.gen(function* () {
@@ -398,21 +521,15 @@ export const SqliteQueueServiceLive = Layer.effect(
             sql.unsafe("DELETE FROM job_queue WHERE id = ? RETURNING id", [
               jobId,
             ]),
-          ).pipe(
-            Effect.mapError(
-              (error) =>
-                new AcknowledgeError({
-                  jobId,
-                  message: `Database error: ${formatSqlError(error)}`,
-                  cause: error,
-                }),
-            ),
+          ).pipe(Effect.mapError((error) => toAcknowledgeError(jobId, error)))
+          const decoded = yield* decodeIdRows(rows).pipe(
+            Effect.mapError((error) => toAcknowledgeSchemaError(jobId, error)),
           )
-          if (!rows[0]) return yield* new JobNotFoundError({ jobId })
+          if (!decoded[0]) return yield* new JobNotFoundError({ jobId })
         }),
       fail: (jobId: string, options?) =>
         Effect.gen(function* () {
-          const now = Date.now()
+          const now = yield* Clock.currentTimeMillis
           const statement =
             options?.retryable === false
               ? "UPDATE job_queue SET job_attempts = job_retry_limit, locked_until = NULL, updated_at = ? WHERE id = ? RETURNING id"
@@ -425,50 +542,32 @@ export const SqliteQueueServiceLive = Layer.effect(
               : [jobId]
           const rows = yield* retrySqliteBusy(
             sql.unsafe(statement, params),
-          ).pipe(
-            Effect.mapError(
-              (error) =>
-                new AcknowledgeError({
-                  jobId,
-                  message: `Database error: ${formatSqlError(error)}`,
-                  cause: error,
-                }),
-            ),
+          ).pipe(Effect.mapError((error) => toAcknowledgeError(jobId, error)))
+          const decoded = yield* decodeIdRows(rows).pipe(
+            Effect.mapError((error) => toAcknowledgeSchemaError(jobId, error)),
           )
-          if (!rows[0]) return yield* new JobNotFoundError({ jobId })
+          if (!decoded[0]) return yield* new JobNotFoundError({ jobId })
         }),
       extendVisibility: (jobId: string, timeout: Duration.Duration) =>
         Effect.gen(function* () {
-          const now = Date.now()
+          const now = yield* Clock.currentTimeMillis
           const rows = yield* retrySqliteBusy(
             sql.unsafe(
               "UPDATE job_queue SET locked_until = ?, updated_at = ? WHERE id = ? AND locked_until IS NOT NULL RETURNING id",
               [now + Duration.toMillis(timeout), now, jobId],
             ),
-          ).pipe(
-            Effect.mapError(
-              (error) =>
-                new AcknowledgeError({
-                  jobId,
-                  message: `Database error: ${formatSqlError(error)}`,
-                  cause: error,
-                }),
-            ),
+          ).pipe(Effect.mapError((error) => toAcknowledgeError(jobId, error)))
+          const updated = yield* decodeIdRows(rows).pipe(
+            Effect.mapError((error) => toAcknowledgeSchemaError(jobId, error)),
           )
-          if (rows[0]) return
+          if (updated[0]) return
           const exists = yield* sql
             .unsafe("SELECT id FROM job_queue WHERE id = ?", [jobId])
-            .pipe(
-              Effect.mapError(
-                (error) =>
-                  new AcknowledgeError({
-                    jobId,
-                    message: `Database error: ${formatSqlError(error)}`,
-                    cause: error,
-                  }),
-              ),
-            )
-          if (!exists[0]) return yield* new JobNotFoundError({ jobId })
+            .pipe(Effect.mapError((error) => toAcknowledgeError(jobId, error)))
+          const decoded = yield* decodeIdRows(exists).pipe(
+            Effect.mapError((error) => toAcknowledgeSchemaError(jobId, error)),
+          )
+          if (!decoded[0]) return yield* new JobNotFoundError({ jobId })
           return yield* new AcknowledgeError({
             jobId,
             message: "Cannot extend visibility of unlocked job",
@@ -477,7 +576,7 @@ export const SqliteQueueServiceLive = Layer.effect(
       getStats: (queue: string) =>
         Effect.gen(function* () {
           yield* validateQueueName(queue)
-          const now = Date.now()
+          const now = yield* Clock.currentTimeMillis
           const rows = yield* sql
             .unsafe(
               `SELECT
@@ -487,12 +586,11 @@ export const SqliteQueueServiceLive = Layer.effect(
              FROM job_queue WHERE queue = ?`,
               [now, now, queue],
             )
-            .pipe(Effect.orElseSucceed(() => []))
-          return (
-            (rows[0] as
-              | { pending: number; processing: number; deadLetter: number }
-              | undefined) ?? { pending: 0, processing: 0, deadLetter: 0 }
+            .pipe(Effect.mapError((error) => toQueueReadSqlError(queue, error)))
+          const decoded = yield* decodeStatsRows(rows).pipe(
+            Effect.mapError((error) => toQueueReadSchemaError(queue, error)),
           )
+          return decoded[0] ?? { pending: 0, processing: 0, deadLetter: 0 }
         }),
       requeueByPayloadTag: (
         fromQueue: string,
@@ -503,7 +601,7 @@ export const SqliteQueueServiceLive = Layer.effect(
           yield* validateQueueName(fromQueue)
           yield* validateQueueName(toQueue)
           if (fromQueue === toQueue) return 0
-          const now = Date.now()
+          const now = yield* Clock.currentTimeMillis
           const rows = yield* retrySqliteBusy(
             sql.unsafe(
               `UPDATE job_queue
@@ -513,16 +611,7 @@ export const SqliteQueueServiceLive = Layer.effect(
                RETURNING id`,
               [toQueue, now, fromQueue, payloadTag],
             ),
-          ).pipe(
-            Effect.mapError(
-              (error) =>
-                new EnqueueError({
-                  queue: toQueue,
-                  message: `Database error: ${formatSqlError(error)}`,
-                  cause: error,
-                }),
-            ),
-          )
+          ).pipe(Effect.mapError((error) => toEnqueueError(toQueue, error)))
           return rows.length
         }),
     })

--- a/packages/sqlite-queue-service/test/sqlite-queue-service.spec.ts
+++ b/packages/sqlite-queue-service/test/sqlite-queue-service.spec.ts
@@ -1,6 +1,8 @@
 import { DateTime, Duration, Effect, Layer, Option } from "effect"
+import { SqlClient } from "effect/unstable/sql"
 import { DatabaseTest } from "@ready-for-agent/db/test"
 import {
+  ClaimError,
   InvalidQueueNameError,
   QueueService,
 } from "@ready-for-agent/queue-service"
@@ -227,6 +229,38 @@ describe("SqliteQueueService", () => {
 
           const job6 = yield* queue.rawClaim(queueName)
           expect(Option.isNone(job6)).toBe(true)
+        }),
+      ))
+
+    it("should fail with ClaimError when job payload is corrupt JSON", () =>
+      runTest(
+        Effect.gen(function* () {
+          const queue = yield* QueueService
+          const sql = yield* SqlClient.SqlClient
+          const queueName = `corrupt-payload-queue-${Date.now()}`
+          const now = Date.now()
+          yield* sql.unsafe(
+            `INSERT INTO job_queue (id, queue, job_payload, job_retry_limit, available_at, locked_until, created_at, updated_at)
+             VALUES (?, ?, ?, ?, ?, NULL, ?, ?)`,
+            [
+              "qjob-01ARZ3NDEKTSV4RRFFQ69G5FAV",
+              queueName,
+              "{not-json",
+              5,
+              now,
+              now,
+              now,
+            ],
+          )
+
+          const result = yield* Effect.result(queue.rawClaim(queueName))
+          expect(result._tag).toBe("Failure")
+          if (result._tag === "Failure") {
+            expect(result.failure).toBeInstanceOf(ClaimError)
+            expect(result.failure.message).toContain(
+              "Failed to parse job payload",
+            )
+          }
         }),
       ))
   })


### PR DESCRIPTION
## Summary

- Propagate `listKeyed`/`getStats` SQL failures as `QueueReadError` instead of empty results
- Schema-decode job SQL rows; parse JSON payloads in Effect (no untyped defects)
- Use `Clock` for timestamps; name `QueueService.claim` with `Effect.fn`; add claim unit tests

Closes #305

## Test plan

- [x] `bunx nx run queue-service:test`
- [x] `bunx nx run sqlite-queue-service:test`
- [x] `bunx nx run graphql-api:test`
- [x] Pre-commit affected lint/typecheck/test