### PR TITLE
refactor(keymaxxer-service): make client Effect-native

### DIFF
--- a/packages/keymaxxer-service/README.md
+++ b/packages/keymaxxer-service/README.md
@@ -10,14 +10,31 @@ The boundary never returns raw secret values. `runWithSecrets` returns only the
 exit code and separate stdout and stderr streams. A non-zero exit is a command
 result; transport, protocol, and execution failures use `KeymaxxerError`.
 
-## Layers
+## Layers and process boundaries
+
+**Effect-native client API** (Harness / OpenCode consumers):
+
+- `sidecarKeymaxxerLayer(url)` — MCP client for a capability URL
+  `http://127.0.0.1:<port>/<capability>/mcp`. Methods are `Effect.fn` / `Effect.gen`;
+  `tryPromise` only at MCP SDK connect/callTool.
+- `mcpKeymaxxerLayer()` — lazy stdio MCP client (tests / direct keyholder).
+- `testKeymaxxerLayer(secretNames)` — in-memory implementation for tests.
+- `disabledKeymaxxerLayer` — ambient-env command runner when Keymaxxer is off
+  (Promise `child_process` shim by design).
+
+**Promise-first process boundary** (not an Effect service):
 
 - `startKeymaxxerFacade()` — Streamable HTTP MCP facade used by
   `apps/keymaxxer-sidecar` (one stdio keyholder; path capability auth).
-- `sidecarKeymaxxerLayer(url)` — Harness MCP client for a capability URL
-  `http://127.0.0.1:<port>/<capability>/mcp`.
-- `mcpKeymaxxerLayer()` — lazy stdio MCP client (tests / direct keyholder).
-- `testKeymaxxerLayer(secretNames)` — in-memory implementation for tests.
+- `runKeymaxxerSidecarProcess()` — sidecar process body (listen, bootstrap URL,
+  signals). Uses zod only for MCP SDK tool `inputSchema` registration; Effect
+  client payloads use Schema.
+
+## Validation
+
+- Effect client: branded `SecretName` Schema and Schema decode for tool payloads.
+- Facade/MCP server registration: zod (required by the MCP SDK). One stack per
+  boundary — no dual validation of the same payload.
 
 ## Commands
 

--- a/packages/keymaxxer-service/src/index.ts
+++ b/packages/keymaxxer-service/src/index.ts
@@ -1,3 +1,5 @@
+export * from "./lib/client-service.js"
+export * from "./lib/config.js"
 export * from "./lib/facade.js"
 export * from "./lib/http-layer.js"
 export * from "./lib/mcp-layer.js"

--- a/packages/keymaxxer-service/src/lib/client-service.ts
+++ b/packages/keymaxxer-service/src/lib/client-service.ts
@@ -1,0 +1,258 @@
+import { Effect } from "effect"
+import {
+  type AddSecretInput,
+  type FindSecretInput,
+  type KeymaxxerError,
+  type RunWithSecretsInput,
+  type SecretMetadata,
+  decodeAddSecretInput,
+  decodeRunWithSecretsInput,
+  decodeRunWithSecretsResult,
+  decodeSecretMetadataList,
+  decodeSecretName,
+  keymaxxerError,
+} from "./models.js"
+import type { KeymaxxerServiceShape } from "./service.js"
+
+export type ToolResult = {
+  readonly content?: unknown
+  readonly isError?: boolean
+  readonly structuredContent?: unknown
+}
+
+export type KeymaxxerToolClient = {
+  readonly callTool: (input: {
+    readonly arguments: Record<string, unknown>
+    readonly name: string
+  }) => Promise<ToolResult>
+  readonly close: () => Promise<void>
+}
+
+export type ParsedToolResult = {
+  readonly isError: boolean
+  readonly structuredContent: unknown
+  readonly text: string
+}
+
+export const toolResultText = (result: {
+  readonly content?: unknown
+}): string =>
+  Array.isArray(result.content)
+    ? result.content
+        .map((item: unknown) =>
+          typeof item === "object" &&
+          item !== null &&
+          "type" in item &&
+          item.type === "text" &&
+          "text" in item &&
+          typeof item.text === "string"
+            ? item.text
+            : "",
+        )
+        .join("\n")
+    : ""
+
+export type ClientServiceDeps = {
+  /** Promise only at the MCP SDK connect boundary. */
+  readonly createClient: () => Promise<KeymaxxerToolClient>
+  readonly failureMessage: (operation: string) => string
+  readonly initialize?: Effect.Effect<void, KeymaxxerError>
+}
+
+/**
+ * Shared Effect-native KeymaxxerService over an MCP tool client.
+ * `tryPromise` is confined to MCP SDK connect/callTool; domain work uses Effect.gen / Effect.fn.
+ */
+export const makeKeymaxxerClientService = (
+  deps: ClientServiceDeps,
+): {
+  readonly service: KeymaxxerServiceShape
+  readonly close: Effect.Effect<void>
+} => {
+  let clientPromise: Promise<KeymaxxerToolClient> | null = null
+  let secretsCache: readonly SecretMetadata[] | null = null
+  let secretsInFlight: Effect.Effect<
+    readonly SecretMetadata[],
+    KeymaxxerError
+  > | null = null
+
+  const resetClient = (): Effect.Effect<void> =>
+    Effect.promise(async () => {
+      const failed = clientPromise
+      clientPromise = null
+      secretsCache = null
+      secretsInFlight = null
+      if (failed === null) return
+      await failed.then((client) => client.close()).catch(() => undefined)
+    })
+
+  const getClient = (): Effect.Effect<KeymaxxerToolClient, KeymaxxerError> =>
+    Effect.tryPromise({
+      try: () => {
+        clientPromise ??= deps.createClient()
+        return clientPromise
+      },
+      catch: () => keymaxxerError("connect", deps.failureMessage("connect")),
+    }).pipe(Effect.tapError(() => resetClient()))
+
+  const callTool = Effect.fn("KeymaxxerService.callTool")(function* (
+    operation: string,
+    name: string,
+    args: Record<string, unknown>,
+  ) {
+    const client = yield* getClient()
+    const result = yield* Effect.tryPromise({
+      try: () => client.callTool({ name, arguments: args }),
+      catch: () => keymaxxerError(operation, deps.failureMessage(operation)),
+    }).pipe(Effect.tapError(() => resetClient()))
+
+    return {
+      isError: result.isError === true,
+      structuredContent: result.structuredContent,
+      text: toolResultText(result),
+    } satisfies ParsedToolResult
+  })
+
+  const loadSecrets = (): Effect.Effect<
+    readonly SecretMetadata[],
+    KeymaxxerError
+  > =>
+    callTool("listSecrets", "keymaxxer_list", {}).pipe(
+      Effect.flatMap((result) =>
+        result.isError
+          ? Effect.fail(keymaxxerError("listSecrets", "Keymaxxer list failed"))
+          : decodeSecretMetadataList("listSecrets", result.text),
+      ),
+    )
+
+  const listSecrets = (
+    refresh = false,
+  ): Effect.Effect<readonly SecretMetadata[], KeymaxxerError> => {
+    if (!refresh && secretsCache !== null) {
+      return Effect.succeed(secretsCache)
+    }
+
+    if (!refresh && secretsInFlight !== null) {
+      return secretsInFlight
+    }
+
+    const inFlight = loadSecrets().pipe(
+      Effect.tap((secrets) =>
+        Effect.sync(() => {
+          secretsCache = secrets
+        }),
+      ),
+      Effect.tapError(() =>
+        Effect.sync(() => {
+          secretsCache = null
+        }),
+      ),
+      Effect.ensuring(
+        Effect.sync(() => {
+          if (secretsInFlight === inFlight) secretsInFlight = null
+        }),
+      ),
+    )
+    secretsInFlight = inFlight
+    return inFlight
+  }
+
+  const findSecretNames = Effect.fn("KeymaxxerService.findSecretNames")(
+    function* (
+      inputs: readonly {
+        readonly provider: string
+        readonly account: string
+      }[],
+    ) {
+      const secrets = yield* listSecrets(true)
+      const names: Array<string | null> = []
+      for (const input of inputs) {
+        const matches = secrets.filter(
+          (secret) =>
+            secret.provider?.toLowerCase() === input.provider.toLowerCase() &&
+            secret.account?.toLowerCase() === input.account.toLowerCase(),
+        )
+        if (matches.length > 1) {
+          return yield* keymaxxerError(
+            "findSecrets",
+            "Multiple Keymaxxer secrets match provider and account",
+          )
+        }
+        names.push(matches[0]?.name ?? null)
+      }
+      return names
+    },
+  )
+
+  const initialize =
+    deps.initialize ??
+    listSecrets().pipe(
+      Effect.asVoid,
+      Effect.withSpan("KeymaxxerService.initialize"),
+    )
+
+  const hasSecret = Effect.fn("KeymaxxerService.hasSecret")(function* (
+    name: string,
+  ) {
+    yield* decodeSecretName("hasSecret", name)
+    const hasName = (secrets: readonly SecretMetadata[]) =>
+      secrets.some((secret) => secret.name === name)
+    if (hasName(yield* listSecrets())) return true
+    return hasName(yield* listSecrets(true))
+  })
+
+  const findSecret = Effect.fn("KeymaxxerService.findSecret")(function* (
+    input: FindSecretInput,
+  ) {
+    const [found] = yield* findSecretNames([input])
+    return found ?? null
+  })
+
+  const findSecrets = Effect.fn("KeymaxxerService.findSecrets")(function* (
+    inputs: readonly FindSecretInput[],
+  ) {
+    return yield* findSecretNames(inputs)
+  })
+
+  const addSecret = Effect.fn("KeymaxxerService.addSecret")(function* (
+    input: AddSecretInput,
+  ) {
+    const decoded = yield* decodeAddSecretInput(input)
+    const result = yield* callTool("addSecret", "keymaxxer_add", {
+      ...decoded,
+    })
+    if (result.text.toLowerCase().includes("cancelled")) return false
+    if (result.isError) {
+      return yield* keymaxxerError("addSecret", "Keymaxxer add failed")
+    }
+    yield* listSecrets(true)
+    return true
+  })
+
+  const runWithSecrets = Effect.fn("KeymaxxerService.runWithSecrets")(
+    function* (input: RunWithSecretsInput) {
+      const decoded = yield* decodeRunWithSecretsInput(input)
+      const result = yield* callTool("runWithSecrets", "keymaxxer_run", {
+        command: decoded.command,
+        cwd: decoded.cwd,
+        secrets: [...decoded.secrets],
+        timeoutMs: decoded.timeoutMs,
+      })
+      return yield* decodeRunWithSecretsResult(
+        result.structuredContent,
+        result.text,
+      )
+    },
+  )
+
+  const service: KeymaxxerServiceShape = {
+    initialize,
+    hasSecret,
+    findSecret,
+    findSecrets,
+    addSecret,
+    runWithSecrets,
+  }
+
+  return { service, close: resetClient() }
+}

--- a/packages/keymaxxer-service/src/lib/config.ts
+++ b/packages/keymaxxer-service/src/lib/config.ts
@@ -1,0 +1,25 @@
+import { Config } from "effect"
+
+export const defaultKeymaxxerSidecarPort = 5032
+
+const isValidTcpPort = (port: number): boolean =>
+  Number.isInteger(port) && port >= 1 && port <= 65_535
+
+/**
+ * Effect Config for KEYMAXXER_SIDECAR_PORT (default 5032).
+ * Process entrypoints may still read env synchronously via
+ * `keymaxxerSidecarPortFromEnvironment`.
+ */
+export const KeymaxxerSidecarPortConfig = Config.int(
+  "KEYMAXXER_SIDECAR_PORT",
+).pipe(
+  Config.orElse(() => Config.succeed(defaultKeymaxxerSidecarPort)),
+  Config.map((port) => {
+    if (!isValidTcpPort(port)) {
+      throw new Error(
+        `KEYMAXXER_SIDECAR_PORT must be a valid TCP port (got ${port})`,
+      )
+    }
+    return port
+  }),
+)

--- a/packages/keymaxxer-service/src/lib/http-layer.ts
+++ b/packages/keymaxxer-service/src/lib/http-layer.ts
@@ -2,30 +2,20 @@ import { Client } from "@modelcontextprotocol/sdk/client/index.js"
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js"
 import { Effect, Layer } from "effect"
 import {
-  KeymaxxerError,
-  validateRunInput,
-  validateSecretName,
-} from "./models.js"
-import { KeymaxxerService, type KeymaxxerServiceShape } from "./service.js"
+  type KeymaxxerToolClient,
+  makeKeymaxxerClientService,
+} from "./client-service.js"
+import { type KeymaxxerError, keymaxxerError } from "./models.js"
+import { KeymaxxerService } from "./service.js"
 
 export type SidecarLayerOptions = {
   readonly fetch?: typeof globalThis.fetch
   readonly retryDelayMs?: number
   readonly startupTimeoutMs?: number
-  readonly createClient?: () => Promise<SidecarMcpClient>
+  readonly createClient?: () => Promise<KeymaxxerToolClient>
 }
 
-export type SidecarMcpClient = {
-  readonly callTool: (input: {
-    readonly name: string
-    readonly arguments: Record<string, unknown>
-  }) => Promise<{
-    content?: unknown
-    isError?: boolean
-    structuredContent?: unknown
-  }>
-  readonly close: () => Promise<void>
-}
+export type SidecarMcpClient = KeymaxxerToolClient
 
 export type ParsedSidecarUrl = {
   readonly origin: string
@@ -34,7 +24,7 @@ export type ParsedSidecarUrl = {
   readonly url: string
 }
 
-export const parseSidecarUrl = (value: string): ParsedSidecarUrl => {
+const parseSidecarUrlSync = (value: string): ParsedSidecarUrl => {
   const url = new URL(value)
   if (
     url.protocol !== "http:" ||
@@ -63,203 +53,79 @@ export const parseSidecarUrl = (value: string): ParsedSidecarUrl => {
   }
 }
 
+/** Parse and validate a sidecar capability URL (throws on invalid input). */
+export const parseSidecarUrl = (value: string): ParsedSidecarUrl =>
+  parseSidecarUrlSync(value)
+
+export const parseSidecarUrlEffect = (
+  value: string,
+): Effect.Effect<ParsedSidecarUrl, KeymaxxerError> =>
+  Effect.try({
+    try: () => parseSidecarUrlSync(value),
+    catch: () => keymaxxerError("configure", "Invalid Keymaxxer sidecar URL"),
+  })
+
 export const sidecarKeymaxxerLayer = (
   value: string,
   options: SidecarLayerOptions = {},
 ): Layer.Layer<KeymaxxerService, KeymaxxerError> =>
   Layer.effect(
     KeymaxxerService,
-    Effect.try({
-      try: () => makeSidecarService(parseSidecarUrl(value), options),
-      catch: () => safeError("configure", "Invalid Keymaxxer sidecar URL"),
+    Effect.gen(function* () {
+      const parsed = yield* parseSidecarUrlEffect(value)
+      const managed = makeKeymaxxerClientService({
+        createClient:
+          options.createClient ??
+          (() => createStreamableHttpClient(parsed.url)),
+        failureMessage: () => "Keymaxxer sidecar request failed",
+        initialize: waitForTcp(parsed, options),
+      })
+      return managed.service
     }),
   )
 
-const makeSidecarService = (
+const waitForTcp = (
   parsed: ParsedSidecarUrl,
   options: SidecarLayerOptions,
-): KeymaxxerServiceShape => {
+): Effect.Effect<void, KeymaxxerError> => {
+  const fetchImplementation = options.fetch ?? globalThis.fetch
   const retryDelayMs = options.retryDelayMs ?? 100
   const startupTimeoutMs = options.startupTimeoutMs ?? 5_000
-  let clientPromise: Promise<SidecarMcpClient> | null = null
-  let secretsPromise: Promise<readonly SecretMetadata[]> | null = null
+  const startedAt = Date.now()
 
-  const getClient = () => {
-    clientPromise ??= (
-      options.createClient ?? (() => createStreamableHttpClient(parsed.url))
-    )()
-    return clientPromise
-  }
-
-  const callTool = async (
-    operation: string,
-    name: string,
-    args: Record<string, unknown>,
-  ) => {
-    try {
-      const result = await (await getClient()).callTool({
-        name,
-        arguments: args,
-      })
-      return {
-        isError: result.isError === true,
-        structuredContent: result.structuredContent,
-        text: toolResultText(result),
-      }
-    } catch {
-      const failed = clientPromise
-      clientPromise = null
-      secretsPromise = null
-      await failed?.then((client) => client.close()).catch(() => undefined)
-      throw safeError(operation, "Keymaxxer sidecar request failed")
-    }
-  }
-
-  const listSecrets = async (refresh = false) => {
-    if (!refresh && secretsPromise !== null) return secretsPromise
-    secretsPromise = callTool("listSecrets", "keymaxxer_list", {}).then(
-      (result) => {
-        if (result.isError)
-          throw safeError("listSecrets", "Keymaxxer list failed")
-        return parseSecrets(result.text)
-      },
-    )
-    secretsPromise.catch(() => {
-      secretsPromise = null
-    })
-    return secretsPromise
-  }
-
-  const findSecretNames = async (
-    inputs: readonly { readonly provider: string; readonly account: string }[],
-  ) => {
-    const secrets = await listSecrets(true)
-    return inputs.map((input) => {
-      const matches = secrets.filter(
-        (secret) =>
-          secret.provider?.toLowerCase() === input.provider.toLowerCase() &&
-          secret.account?.toLowerCase() === input.account.toLowerCase(),
-      )
-      if (matches.length > 1) {
-        throw safeError(
-          "findSecrets",
-          "Multiple Keymaxxer secrets match provider and account",
+  const attempt = (): Effect.Effect<void, KeymaxxerError> =>
+    Effect.tryPromise({
+      try: async () => {
+        const remainingMs = Math.max(
+          1,
+          startupTimeoutMs - (Date.now() - startedAt),
         )
-      }
-      return matches[0]?.name ?? null
-    })
-  }
+        // Any HTTP response proves TCP listen; wrong path is intentionally 404.
+        await fetchImplementation(`http://${parsed.hostname}:${parsed.port}/`, {
+          signal: AbortSignal.timeout(remainingMs),
+        })
+      },
+      catch: () =>
+        keymaxxerError("initialize", "Keymaxxer sidecar request failed"),
+    }).pipe(
+      Effect.catchIf(
+        () => true,
+        (error): Effect.Effect<void, KeymaxxerError> =>
+          Date.now() - startedAt >= startupTimeoutMs
+            ? Effect.fail(error)
+            : Effect.sleep(`${retryDelayMs} millis`).pipe(
+                Effect.flatMap(attempt),
+              ),
+      ),
+      Effect.withSpan("KeymaxxerService.waitForTcp"),
+    )
 
-  const waitForTcp = (): Effect.Effect<void, KeymaxxerError> => {
-    const fetchImplementation = options.fetch ?? globalThis.fetch
-    const startedAt = Date.now()
-    const attempt = (): Effect.Effect<void, KeymaxxerError> =>
-      Effect.tryPromise({
-        try: async () => {
-          const remainingMs = Math.max(
-            1,
-            startupTimeoutMs - (Date.now() - startedAt),
-          )
-          // Any HTTP response proves TCP listen; wrong path is intentionally 404.
-          await fetchImplementation(
-            `http://${parsed.hostname}:${parsed.port}/`,
-            {
-              signal: AbortSignal.timeout(remainingMs),
-            },
-          )
-        },
-        catch: () =>
-          safeError("initialize", "Keymaxxer sidecar request failed"),
-      }).pipe(
-        Effect.catchIf(
-          () => true,
-          (error) =>
-            Date.now() - startedAt >= startupTimeoutMs
-              ? Effect.fail(error)
-              : Effect.sleep(`${retryDelayMs} millis`).pipe(
-                  Effect.flatMap(attempt),
-                ),
-        ),
-      )
-    return attempt()
-  }
-
-  return {
-    initialize: waitForTcp(),
-    hasSecret: (name) =>
-      validateSecretName(name)
-        ? Effect.tryPromise({
-            try: async () => {
-              const hasName = (secrets: readonly SecretMetadata[]) =>
-                secrets.some((secret) => secret.name === name)
-              return (
-                hasName(await listSecrets()) || hasName(await listSecrets(true))
-              )
-            },
-            catch: () => safeError("hasSecret", "Keymaxxer list failed"),
-          })
-        : Effect.fail(safeError("hasSecret", "Invalid secret name")),
-    findSecret: (input) =>
-      Effect.tryPromise({
-        try: () => findSecretNames([input]).then(([found]) => found ?? null),
-        catch: (error) =>
-          error instanceof KeymaxxerError
-            ? error
-            : safeError("findSecret", "Keymaxxer list failed"),
-      }),
-    findSecrets: (inputs) =>
-      Effect.tryPromise({
-        try: () => findSecretNames(inputs),
-        catch: (error) =>
-          error instanceof KeymaxxerError
-            ? error
-            : safeError("findSecrets", "Keymaxxer list failed"),
-      }),
-    addSecret: (input) =>
-      validateSecretName(input.name)
-        ? Effect.tryPromise({
-            try: async () => {
-              const result = await callTool("addSecret", "keymaxxer_add", input)
-              if (result.text.toLowerCase().includes("cancelled")) return false
-              if (result.isError) {
-                throw safeError("addSecret", "Keymaxxer add failed")
-              }
-              await listSecrets(true)
-              return true
-            },
-            catch: () => safeError("addSecret", "Keymaxxer add failed"),
-          })
-        : Effect.fail(safeError("addSecret", "Invalid secret name")),
-    runWithSecrets: (input) =>
-      validateRunInput(input)
-        ? Effect.tryPromise({
-            try: async () => {
-              const result = await callTool(
-                "runWithSecrets",
-                "keymaxxer_run",
-                input,
-              )
-              const parsedResult =
-                parseStructuredRunResult(result.structuredContent) ??
-                parseRunResult(result.text)
-              if (parsedResult === null) {
-                throw safeError(
-                  "runWithSecrets",
-                  "Keymaxxer returned an invalid command result",
-                )
-              }
-              return parsedResult
-            },
-            catch: () =>
-              safeError("runWithSecrets", "Keymaxxer command failed"),
-          })
-        : Effect.fail(safeError("runWithSecrets", "Invalid command input")),
-  }
+  return attempt()
 }
 
 const createStreamableHttpClient = async (
   url: string,
-): Promise<SidecarMcpClient> => {
+): Promise<KeymaxxerToolClient> => {
   const client = new Client({
     name: "ready-for-agent-harness",
     version: "0.0.0",
@@ -268,105 +134,7 @@ const createStreamableHttpClient = async (
   await client.connect(transport)
   return {
     callTool: (input) =>
-      client.callTool(input).then(
-        (result) =>
-          result as {
-            content?: unknown
-            isError?: boolean
-            structuredContent?: unknown
-          },
-      ),
+      client.callTool(input).then((result) => result as never),
     close: () => transport.close(),
   }
 }
-
-type SecretMetadata = {
-  readonly name: string
-  readonly provider: string | null
-  readonly account: string | null
-}
-
-const toolResultText = (result: { readonly content?: unknown }) =>
-  Array.isArray(result.content)
-    ? result.content
-        .map((item: unknown) =>
-          typeof item === "object" &&
-          item !== null &&
-          "type" in item &&
-          item.type === "text" &&
-          "text" in item &&
-          typeof item.text === "string"
-            ? item.text
-            : "",
-        )
-        .join("\n")
-    : ""
-
-const parseSecrets = (text: string): readonly SecretMetadata[] => {
-  const parsed = JSON.parse(text) as unknown
-  if (!Array.isArray(parsed)) throw new Error("Invalid secret list")
-
-  return parsed.map((item) => {
-    if (
-      typeof item !== "object" ||
-      item === null ||
-      !("name" in item) ||
-      typeof item.name !== "string"
-    ) {
-      throw new Error("Invalid secret list")
-    }
-    const provider = "provider" in item ? item.provider : null
-    const account = "account" in item ? item.account : null
-    if (
-      (provider !== null && typeof provider !== "string") ||
-      (account !== null && typeof account !== "string")
-    ) {
-      throw new Error("Invalid secret list")
-    }
-    return { name: item.name, provider, account }
-  })
-}
-
-const parseRunResult = (text: string) => {
-  const exitCode = text.match(/^exit_code: (-?\d+)$/m)
-  const stdoutMarker = "--- stdout ---\n"
-  const stderrMarker = "\n--- stderr ---\n"
-  const stdoutStart = text.indexOf(stdoutMarker)
-  const stderrStart = text.indexOf(
-    stderrMarker,
-    stdoutStart + stdoutMarker.length,
-  )
-  const repeatedMarker = text.indexOf(stderrMarker, stderrStart + 1)
-  if (!exitCode || stdoutStart < 0 || stderrStart < stdoutStart) return null
-  if (repeatedMarker >= 0) return null
-
-  return {
-    exitCode: Number.parseInt(exitCode[1] ?? "", 10),
-    stdout: text.slice(stdoutStart + stdoutMarker.length, stderrStart),
-    stderr: text.slice(stderrStart + stderrMarker.length),
-  }
-}
-
-const parseStructuredRunResult = (value: unknown) => {
-  if (
-    typeof value !== "object" ||
-    value === null ||
-    !("exitCode" in value) ||
-    typeof value.exitCode !== "number" ||
-    !("stdout" in value) ||
-    typeof value.stdout !== "string" ||
-    !("stderr" in value) ||
-    typeof value.stderr !== "string"
-  ) {
-    return null
-  }
-
-  return {
-    exitCode: value.exitCode,
-    stdout: value.stdout,
-    stderr: value.stderr,
-  }
-}
-
-const safeError = (operation: string, message: string) =>
-  new KeymaxxerError({ operation, message })

--- a/packages/keymaxxer-service/src/lib/mcp-layer.ts
+++ b/packages/keymaxxer-service/src/lib/mcp-layer.ts
@@ -1,27 +1,14 @@
 import { accessSync, constants, existsSync } from "node:fs"
 import { Client } from "@modelcontextprotocol/sdk/client/index.js"
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js"
-import { Effect, Layer } from "effect"
+import { Config, Effect, Layer } from "effect"
 import {
-  KeymaxxerError,
-  validateRunInput,
-  validateSecretName,
-} from "./models.js"
-import { KeymaxxerService, type KeymaxxerServiceShape } from "./service.js"
+  type KeymaxxerToolClient,
+  makeKeymaxxerClientService,
+} from "./client-service.js"
+import { KeymaxxerService } from "./service.js"
 
-type ToolResult = {
-  readonly content?: unknown
-  readonly isError?: boolean
-  readonly structuredContent?: unknown
-}
-
-export interface KeymaxxerToolClient {
-  readonly callTool: (input: {
-    readonly arguments: Record<string, unknown>
-    readonly name: string
-  }) => Promise<ToolResult>
-  readonly close: () => Promise<void>
-}
+export type { KeymaxxerToolClient, ToolResult } from "./client-service.js"
 
 export type McpLayerOptions = {
   readonly createClient?: () => Promise<KeymaxxerToolClient>
@@ -34,169 +21,16 @@ export const mcpKeymaxxerLayer = (
   Layer.effect(
     KeymaxxerService,
     Effect.acquireRelease(
-      Effect.sync(() => makeMcpService(options)),
-      (managed) => Effect.promise(managed.close),
+      Effect.sync(() =>
+        makeKeymaxxerClientService({
+          createClient:
+            options.createClient ?? (() => createToolClient(options)),
+          failureMessage: () => "Keymaxxer operation failed",
+        }),
+      ),
+      (managed) => managed.close,
     ).pipe(Effect.map((managed) => managed.service)),
   )
-
-const makeMcpService = (options: McpLayerOptions) => {
-  let clientPromise: Promise<KeymaxxerToolClient> | null = null
-  let secretsPromise: Promise<readonly SecretMetadata[]> | null = null
-
-  const getClient = () => {
-    clientPromise ??= (
-      options.createClient ?? (() => createToolClient(options))
-    )()
-    return clientPromise
-  }
-
-  const callTool = async (
-    operation: string,
-    name: string,
-    args: Record<string, unknown>,
-  ) => {
-    try {
-      const result = await (await getClient()).callTool({
-        arguments: args,
-        name,
-      })
-      return {
-        isError: result.isError === true,
-        structuredContent: result.structuredContent,
-        text: toolResultText(result),
-      }
-    } catch {
-      const failedClient = clientPromise
-      clientPromise = null
-      secretsPromise = null
-      await failedClient
-        ?.then((client) => client.close())
-        .catch(() => undefined)
-      throw safeError(operation, "Keymaxxer operation failed")
-    }
-  }
-
-  const listSecrets = async (refresh = false) => {
-    if (!refresh && secretsPromise !== null) return secretsPromise
-
-    secretsPromise = callTool("listSecrets", "keymaxxer_list", {}).then(
-      (result) => {
-        if (result.isError)
-          throw safeError("listSecrets", "Keymaxxer list failed")
-        return parseSecrets(result.text)
-      },
-    )
-    secretsPromise.catch(() => {
-      secretsPromise = null
-    })
-    return secretsPromise
-  }
-
-  const findSecretNames = async (
-    inputs: readonly { readonly provider: string; readonly account: string }[],
-  ) => {
-    const secrets = await listSecrets(true)
-    return inputs.map((input) => {
-      const matches = secrets.filter(
-        (secret) =>
-          secret.provider?.toLowerCase() === input.provider.toLowerCase() &&
-          secret.account?.toLowerCase() === input.account.toLowerCase(),
-      )
-      if (matches.length > 1) {
-        throw safeError(
-          "findSecrets",
-          "Multiple Keymaxxer secrets match provider and account",
-        )
-      }
-      return matches[0]?.name ?? null
-    })
-  }
-
-  const service: KeymaxxerServiceShape = {
-    initialize: Effect.tryPromise({
-      try: () => listSecrets().then(() => undefined),
-      catch: () => safeError("initialize", "Keymaxxer initialization failed"),
-    }),
-    hasSecret: (name) =>
-      validateSecretName(name)
-        ? Effect.tryPromise({
-            try: async () => {
-              const hasName = (secrets: readonly SecretMetadata[]) =>
-                secrets.some((secret) => secret.name === name)
-              return (
-                hasName(await listSecrets()) || hasName(await listSecrets(true))
-              )
-            },
-            catch: () => safeError("hasSecret", "Keymaxxer list failed"),
-          })
-        : Effect.fail(safeError("hasSecret", "Invalid secret name")),
-    findSecret: (input) =>
-      Effect.tryPromise({
-        try: () => findSecretNames([input]).then(([name]) => name ?? null),
-        catch: (error) =>
-          error instanceof KeymaxxerError
-            ? error
-            : safeError("findSecret", "Keymaxxer list failed"),
-      }),
-    findSecrets: (inputs) =>
-      Effect.tryPromise({
-        try: () => findSecretNames(inputs),
-        catch: (error) =>
-          error instanceof KeymaxxerError
-            ? error
-            : safeError("findSecrets", "Keymaxxer list failed"),
-      }),
-    addSecret: (input) =>
-      validateSecretName(input.name)
-        ? Effect.tryPromise({
-            try: async () => {
-              const result = await callTool("addSecret", "keymaxxer_add", input)
-              if (result.text.toLowerCase().includes("cancelled")) return false
-              if (result.isError) {
-                throw safeError("addSecret", "Keymaxxer add failed")
-              }
-              await listSecrets(true)
-              return true
-            },
-            catch: () => safeError("addSecret", "Keymaxxer add failed"),
-          })
-        : Effect.fail(safeError("addSecret", "Invalid secret name")),
-    runWithSecrets: (input) =>
-      validateRunInput(input)
-        ? Effect.tryPromise({
-            try: async () => {
-              const result = await callTool(
-                "runWithSecrets",
-                "keymaxxer_run",
-                input,
-              )
-              const parsed =
-                parseStructuredRunResult(result.structuredContent) ??
-                parseRunResult(result.text)
-              if (parsed === null) {
-                throw safeError(
-                  "runWithSecrets",
-                  "Keymaxxer returned an invalid command result",
-                )
-              }
-              return parsed
-            },
-            catch: () =>
-              safeError("runWithSecrets", "Keymaxxer command failed"),
-          })
-        : Effect.fail(safeError("runWithSecrets", "Invalid command input")),
-  }
-
-  return {
-    service,
-    close: async () => {
-      const current = clientPromise
-      clientPromise = null
-      secretsPromise = null
-      await current?.then((client) => client.close()).catch(() => undefined)
-    },
-  }
-}
 
 const createToolClient = async (
   options: McpLayerOptions,
@@ -214,7 +48,7 @@ const createToolClient = async (
 
   return {
     callTool: (input) =>
-      client.callTool(input).then((result) => result as unknown as ToolResult),
+      client.callTool(input).then((result) => result as never),
     close: () => transport.close(),
   }
 }
@@ -247,6 +81,11 @@ export const isExecutableKeymaxxerEntrypoint = (
   }
 }
 
+/** Effect Config for KEYMAXXER_ENTRYPOINT (optional). */
+export const KeymaxxerEntrypointConfig = Config.string(
+  "KEYMAXXER_ENTRYPOINT",
+).pipe(Config.option)
+
 export const keymaxxerMcpCommand = (
   environment: Partial<Record<string, string | undefined>> = process.env,
   pathExists: (path: string) => boolean = existsSync,
@@ -276,94 +115,3 @@ export const isKeymaxxerAvailable = (
   const command = keymaxxerMcpCommand(environment, pathExists, isExecutable)
   return commandExists(command.command)
 }
-
-const toolResultText = (result: ToolResult) =>
-  Array.isArray(result.content)
-    ? result.content
-        .map((item: unknown) =>
-          typeof item === "object" &&
-          item !== null &&
-          "type" in item &&
-          item.type === "text" &&
-          "text" in item &&
-          typeof item.text === "string"
-            ? item.text
-            : "",
-        )
-        .join("\n")
-    : ""
-
-type SecretMetadata = {
-  readonly name: string
-  readonly provider: string | null
-  readonly account: string | null
-}
-
-const parseSecrets = (text: string): readonly SecretMetadata[] => {
-  const parsed = JSON.parse(text) as unknown
-  if (!Array.isArray(parsed)) throw new Error("Invalid secret list")
-
-  return parsed.map((item) => {
-    if (
-      typeof item !== "object" ||
-      item === null ||
-      !("name" in item) ||
-      typeof item.name !== "string"
-    ) {
-      throw new Error("Invalid secret list")
-    }
-    const provider = "provider" in item ? item.provider : null
-    const account = "account" in item ? item.account : null
-    if (
-      (provider !== null && typeof provider !== "string") ||
-      (account !== null && typeof account !== "string")
-    ) {
-      throw new Error("Invalid secret list")
-    }
-    return { name: item.name, provider, account }
-  })
-}
-
-const parseRunResult = (text: string) => {
-  const exitCode = text.match(/^exit_code: (-?\d+)$/m)
-  const stdoutMarker = "--- stdout ---\n"
-  const stderrMarker = "\n--- stderr ---\n"
-  const stdoutStart = text.indexOf(stdoutMarker)
-  const stderrStart = text.indexOf(
-    stderrMarker,
-    stdoutStart + stdoutMarker.length,
-  )
-  const repeatedMarker = text.indexOf(stderrMarker, stderrStart + 1)
-  if (!exitCode || stdoutStart < 0 || stderrStart < stdoutStart) return null
-  if (repeatedMarker >= 0) return null
-
-  return {
-    exitCode: Number.parseInt(exitCode[1] ?? "", 10),
-    stdout: text.slice(stdoutStart + stdoutMarker.length, stderrStart),
-    stderr: text.slice(stderrStart + stderrMarker.length),
-  }
-}
-
-const parseStructuredRunResult = (value: unknown) => {
-  if (
-    typeof value !== "object" ||
-    value === null ||
-    !("exitCode" in value) ||
-    typeof value.exitCode !== "number" ||
-    !("stdout" in value) ||
-    typeof value.stdout !== "string" ||
-    !("stderr" in value) ||
-    typeof value.stderr !== "string"
-  ) {
-    return null
-  }
-
-  return {
-    exitCode: value.exitCode,
-    stdout: value.stdout,
-    stderr: value.stderr,
-  }
-}
-
-const safeError = (operation: string, message: string) =>
-  new KeymaxxerError({ operation, message })

--- a/packages/keymaxxer-service/src/lib/models.ts
+++ b/packages/keymaxxer-service/src/lib/models.ts
@@ -1,6 +1,9 @@
-import { Schema } from "effect"
+import { Effect, Schema } from "effect"
 
-export const SecretName = Schema.String
+export const SecretName = Schema.String.pipe(
+  Schema.check(Schema.isPattern(/^[A-Za-z_][A-Za-z0-9_]*$/)),
+  Schema.brand("SecretName"),
+)
 export type SecretName = typeof SecretName.Type
 
 export const AddSecretInput = Schema.Struct({
@@ -12,10 +15,18 @@ export const AddSecretInput = Schema.Struct({
   description: Schema.optional(Schema.String),
   tags: Schema.optional(Schema.String),
 })
-export type AddSecretInput = typeof AddSecretInput.Type
+export type AddSecretInput = {
+  readonly name: string
+  readonly provider?: string
+  readonly account?: string
+  readonly environment?: string
+  readonly access?: string
+  readonly description?: string
+  readonly tags?: string
+}
 
 export const HasSecretInput = Schema.Struct({ name: SecretName })
-export type HasSecretInput = typeof HasSecretInput.Type
+export type HasSecretInput = { readonly name: string }
 
 export const FindSecretInput = Schema.Struct({
   provider: Schema.String,
@@ -33,8 +44,37 @@ export const RunWithSecretsInput = Schema.Struct({
   cwd: Schema.String,
   secrets: Schema.Array(SecretName),
   timeoutMs: Schema.Finite,
-})
-export type RunWithSecretsInput = typeof RunWithSecretsInput.Type
+}).pipe(
+  Schema.check(
+    Schema.makeFilter(
+      (input: {
+        readonly command: string
+        readonly cwd: string
+        readonly secrets: readonly string[]
+        readonly timeoutMs: number
+      }) => {
+        if (input.command.trim() === "") return false
+        if (!input.cwd.startsWith("/")) return false
+        if (input.secrets.length === 0) return false
+        if (new Set(input.secrets).size !== input.secrets.length) return false
+        if (!Number.isInteger(input.timeoutMs) || input.timeoutMs <= 0)
+          return false
+        return true
+      },
+      {
+        title: "RunWithSecretsInput",
+        description:
+          "non-empty command, absolute cwd, unique secrets, positive timeout",
+      },
+    ),
+  ),
+)
+export type RunWithSecretsInput = {
+  readonly command: string
+  readonly cwd: string
+  readonly secrets: readonly string[]
+  readonly timeoutMs: number
+}
 
 export const RunWithSecretsResult = Schema.Struct({
   exitCode: Schema.Finite,
@@ -43,22 +83,18 @@ export const RunWithSecretsResult = Schema.Struct({
 })
 export type RunWithSecretsResult = typeof RunWithSecretsResult.Type
 
-export const HealthResponse = Schema.Struct({
-  status: Schema.Literal("ok"),
-  protocolVersion: Schema.Literal(3),
+export const SecretMetadata = Schema.Struct({
+  name: Schema.String,
+  provider: Schema.optionalKey(Schema.NullOr(Schema.String)),
+  account: Schema.optionalKey(Schema.NullOr(Schema.String)),
 })
+export type SecretMetadata = {
+  readonly name: string
+  readonly provider: string | null
+  readonly account: string | null
+}
 
-export const InitializeResponse = Schema.Struct({
-  initialized: Schema.Literal(true),
-})
-export const HasSecretResponse = Schema.Struct({ hasSecret: Schema.Boolean })
-export const FindSecretResponse = Schema.Struct({
-  name: Schema.NullOr(SecretName),
-})
-export const FindSecretsResponse = Schema.Struct({
-  names: Schema.Array(Schema.NullOr(SecretName)),
-})
-export const AddSecretResponse = Schema.Struct({ added: Schema.Boolean })
+export const SecretMetadataList = Schema.Array(SecretMetadata)
 
 export const protocolVersion = 3 as const
 
@@ -70,18 +106,99 @@ export class KeymaxxerError extends Schema.TaggedErrorClass<KeymaxxerError>()(
   },
 ) {}
 
-const secretNamePattern = /^[A-Za-z_][A-Za-z0-9_]*$/
+export const keymaxxerError = (operation: string, message: string) =>
+  new KeymaxxerError({ operation, message })
 
-export const validateSecretName = (name: string) => secretNamePattern.test(name)
+export const decodeSecretName = (
+  operation: string,
+  name: string,
+): Effect.Effect<SecretName, KeymaxxerError> =>
+  Schema.decodeUnknownEffect(SecretName)(name).pipe(
+    Effect.mapError(() => keymaxxerError(operation, "Invalid secret name")),
+  )
 
-export const validateRunInput = (input: RunWithSecretsInput) =>
-  input.command.trim() !== "" &&
-  input.cwd.startsWith("/") &&
-  input.secrets.length > 0 &&
-  input.secrets.every(validateSecretName) &&
-  new Set(input.secrets).size === input.secrets.length &&
-  Number.isInteger(input.timeoutMs) &&
-  input.timeoutMs > 0
+export const decodeAddSecretInput = (
+  input: AddSecretInput,
+): Effect.Effect<typeof AddSecretInput.Type, KeymaxxerError> =>
+  Schema.decodeUnknownEffect(AddSecretInput)(input).pipe(
+    Effect.mapError(() => keymaxxerError("addSecret", "Invalid secret name")),
+  )
+
+export const decodeRunWithSecretsInput = (
+  input: RunWithSecretsInput,
+): Effect.Effect<typeof RunWithSecretsInput.Type, KeymaxxerError> =>
+  Schema.decodeUnknownEffect(RunWithSecretsInput)(input).pipe(
+    Effect.mapError(() =>
+      keymaxxerError("runWithSecrets", "Invalid command input"),
+    ),
+  )
+
+export const decodeSecretMetadataList = (
+  operation: string,
+  text: string,
+): Effect.Effect<readonly SecretMetadata[], KeymaxxerError> =>
+  Effect.try({
+    try: () => JSON.parse(text) as unknown,
+    catch: () => keymaxxerError(operation, "Keymaxxer list failed"),
+  }).pipe(
+    Effect.flatMap((parsed) =>
+      Schema.decodeUnknownEffect(SecretMetadataList)(parsed).pipe(
+        Effect.mapError(() =>
+          keymaxxerError(operation, "Keymaxxer list failed"),
+        ),
+      ),
+    ),
+    Effect.map((items) =>
+      items.map((item) => ({
+        name: item.name,
+        provider: item.provider ?? null,
+        account: item.account ?? null,
+      })),
+    ),
+  )
+
+export const decodeRunWithSecretsResult = (
+  structuredContent: unknown,
+  text: string,
+): Effect.Effect<RunWithSecretsResult, KeymaxxerError> => {
+  const fromStructured =
+    Schema.decodeUnknownOption(RunWithSecretsResult)(structuredContent)
+  if (fromStructured._tag === "Some") {
+    return Effect.succeed(fromStructured.value)
+  }
+
+  const fromText = parseRunResultText(text)
+  if (fromText !== null) {
+    return Effect.succeed(fromText)
+  }
+
+  return Effect.fail(
+    keymaxxerError(
+      "runWithSecrets",
+      "Keymaxxer returned an invalid command result",
+    ),
+  )
+}
+
+const parseRunResultText = (text: string): RunWithSecretsResult | null => {
+  const exitCode = text.match(/^exit_code: (-?\d+)$/m)
+  const stdoutMarker = "--- stdout ---\n"
+  const stderrMarker = "\n--- stderr ---\n"
+  const stdoutStart = text.indexOf(stdoutMarker)
+  const stderrStart = text.indexOf(
+    stderrMarker,
+    stdoutStart + stdoutMarker.length,
+  )
+  const repeatedMarker = text.indexOf(stderrMarker, stderrStart + 1)
+  if (!exitCode || stdoutStart < 0 || stderrStart < stdoutStart) return null
+  if (repeatedMarker >= 0) return null
+
+  return {
+    exitCode: Number.parseInt(exitCode[1] ?? "", 10),
+    stdout: text.slice(stdoutStart + stdoutMarker.length, stderrStart),
+    stderr: text.slice(stderrStart + stderrMarker.length),
+  }
+}
 
 export const containsRawSecretValue = (value: unknown): boolean => {
   if (Array.isArray(value)) {

--- a/packages/keymaxxer-service/src/lib/service.ts
+++ b/packages/keymaxxer-service/src/lib/service.ts
@@ -5,22 +5,19 @@ import type {
   FindSecretInput,
   RunWithSecretsInput,
   RunWithSecretsResult,
-  SecretName,
 } from "./models.js"
-import { KeymaxxerError } from "./models.js"
+import { type KeymaxxerError, keymaxxerError } from "./models.js"
 
 export interface KeymaxxerServiceShape {
   readonly enabled?: boolean
   readonly initialize: Effect.Effect<void, KeymaxxerError>
-  readonly hasSecret: (
-    name: SecretName,
-  ) => Effect.Effect<boolean, KeymaxxerError>
+  readonly hasSecret: (name: string) => Effect.Effect<boolean, KeymaxxerError>
   readonly findSecret: (
     input: FindSecretInput,
-  ) => Effect.Effect<SecretName | null, KeymaxxerError>
+  ) => Effect.Effect<string | null, KeymaxxerError>
   readonly findSecrets: (
     inputs: readonly FindSecretInput[],
-  ) => Effect.Effect<readonly (SecretName | null)[], KeymaxxerError>
+  ) => Effect.Effect<readonly (string | null)[], KeymaxxerError>
   readonly addSecret: (
     input: AddSecretInput,
   ) => Effect.Effect<boolean, KeymaxxerError>
@@ -42,7 +39,7 @@ export const testKeymaxxerLayer = (
 
     return {
       initialize: Effect.void,
-      hasSecret: (name: SecretName) => Effect.succeed(secrets.has(name)),
+      hasSecret: (name: string) => Effect.succeed(secrets.has(name)),
       findSecret: () => Effect.succeed(null),
       findSecrets: (inputs) => Effect.succeed(inputs.map(() => null)),
       addSecret: (input: AddSecretInput) =>
@@ -55,6 +52,11 @@ export const testKeymaxxerLayer = (
     }
   })
 
+/**
+ * Fallback when Keymaxxer is unavailable: run commands through the ambient
+ * process environment without vault injection. Intentionally Promise-based
+ * `child_process` (not Effect process DI) — a process-boundary shim.
+ */
 export const disabledKeymaxxerLayer: Layer.Layer<KeymaxxerService> =
   Layer.succeed(KeymaxxerService, {
     enabled: false,
@@ -63,34 +65,37 @@ export const disabledKeymaxxerLayer: Layer.Layer<KeymaxxerService> =
     findSecret: () => Effect.succeed(null),
     findSecrets: (inputs) => Effect.succeed(inputs.map(() => null)),
     addSecret: () => Effect.succeed(false),
-    runWithSecrets: (input) =>
-      Effect.tryPromise({
-        try: () =>
-          new Promise<RunWithSecretsResult>((resolve, reject) => {
-            const child = spawn("bash", ["-c", input.command], {
-              cwd: input.cwd,
-              env: process.env,
-              timeout: input.timeoutMs,
-            })
-            let stdout = ""
-            let stderr = ""
-            child.stdout.setEncoding("utf8")
-            child.stderr.setEncoding("utf8")
-            child.stdout.on("data", (chunk: string) => {
-              stdout += chunk
-            })
-            child.stderr.on("data", (chunk: string) => {
-              stderr += chunk
-            })
-            child.once("error", reject)
-            child.once("close", (exitCode) => {
-              resolve({ exitCode: exitCode ?? 1, stdout, stderr })
-            })
-          }),
-        catch: () =>
-          new KeymaxxerError({
-            operation: "run command",
-            message: "Failed to run command without Keymaxxer",
-          }),
-      }),
+    runWithSecrets: Effect.fn("KeymaxxerService.disabled.runWithSecrets")(
+      function* (input: RunWithSecretsInput) {
+        return yield* Effect.tryPromise({
+          try: () =>
+            new Promise<RunWithSecretsResult>((resolve, reject) => {
+              const child = spawn("bash", ["-c", input.command], {
+                cwd: input.cwd,
+                env: process.env,
+                timeout: input.timeoutMs,
+              })
+              let stdout = ""
+              let stderr = ""
+              child.stdout.setEncoding("utf8")
+              child.stderr.setEncoding("utf8")
+              child.stdout.on("data", (chunk: string) => {
+                stdout += chunk
+              })
+              child.stderr.on("data", (chunk: string) => {
+                stderr += chunk
+              })
+              child.once("error", reject)
+              child.once("close", (exitCode) => {
+                resolve({ exitCode: exitCode ?? 1, stdout, stderr })
+              })
+            }),
+          catch: () =>
+            keymaxxerError(
+              "run command",
+              "Failed to run command without Keymaxxer",
+            ),
+        })
+      },
+    ),
   })

--- a/packages/keymaxxer-service/src/lib/sidecar-process.ts
+++ b/packages/keymaxxer-service/src/lib/sidecar-process.ts
@@ -1,11 +1,12 @@
+import { defaultKeymaxxerSidecarPort } from "./config.js"
 import { startKeymaxxerFacade } from "./facade.js"
-import { KeymaxxerError } from "./models.js"
+
+export { defaultKeymaxxerSidecarPort } from "./config.js"
 
 /** Hidden argv token: re-enter the same executable as the Keymaxxer Sidecar. */
 export const INTERNAL_KEYMAXXER_SIDECAR_ARG =
   "--ready-for-agent-internal-keymaxxer-sidecar"
 
-export const defaultKeymaxxerSidecarPort = 5032
 export const keymaxxerSidecarHost = "127.0.0.1"
 
 export const isInternalKeymaxxerSidecarMode = (
@@ -138,14 +139,12 @@ export const runKeymaxxerSidecarProcess = async (
       error instanceof Error
         ? error.message
         : `Keymaxxer Sidecar failed to listen on ${keymaxxerSidecarHost}:${port}. Set KEYMAXXER_SIDECAR_PORT to an unused port.`
+    // Process boundary: single-line stderr for topology tests; no Effect error channel.
     console.error(
       message.startsWith("Keymaxxer Sidecar failed")
         ? message
         : `Keymaxxer Sidecar failed to listen on ${keymaxxerSidecarHost}:${port}. Set KEYMAXXER_SIDECAR_PORT to an unused port.`,
     )
-    if (!(error instanceof KeymaxxerError)) {
-      // keep stderr single-line for topology test
-    }
     exitProcess(1)
   }
 }


### PR DESCRIPTION
## Why

`packages/keymaxxer-service` was the weakest Effect purity among domain packages: client layers were thin `tryPromise` shells over async helpers that threw, with coarse errors, dual Schema+zod validation, loose secret names, and ad-hoc `process.env` config. Parent audit #294 / findings issue #308 asked to make the Effect client path honest without changing Keymaxxer security or vault UX.

## What Changed

- Shared Effect-native MCP client (`client-service.ts`) used by HTTP and stdio layers: `Effect.fn`/`Effect.gen`, `tryPromise` only at MCP SDK connect/callTool, tagged `KeymaxxerError` without throw/`instanceof`
- Branded `SecretName` Schema and Schema decode for tool payloads
- Documented Promise-first facade/sidecar process boundary; zod stays only on the MCP facade registration edge
- Effect Config helpers for sidecar port and entrypoint; disabled layer remains an intentional ambient `child_process` shim

Closes #308.
