### PR TITLE
refactor(work-item-lifecycle): tighten Effect step error boundaries

### DIFF
--- a/packages/work-item-lifecycle/src/lib/assess-changes-errors.ts
+++ b/packages/work-item-lifecycle/src/lib/assess-changes-errors.ts
@@ -1,48 +1,54 @@
-import { Data } from "effect"
+import { Schema } from "effect"
 
-export class AssessChangesWorktreeContextMissingError extends Data.TaggedError(
+export class AssessChangesWorktreeContextMissingError extends Schema.TaggedErrorClass<AssessChangesWorktreeContextMissingError>()(
   "AssessChangesWorktreeContextMissingError",
-)<{
-  readonly workItemId: string
-  readonly message: string
-}> {}
+  {
+    workItemId: Schema.String,
+    message: Schema.String,
+  },
+) {}
 
-export class AssessChangesInvalidWorktreeContextError extends Data.TaggedError(
+export class AssessChangesInvalidWorktreeContextError extends Schema.TaggedErrorClass<AssessChangesInvalidWorktreeContextError>()(
   "AssessChangesInvalidWorktreeContextError",
-)<{
-  readonly workItemId: string
-  readonly worktreePath: string
-  readonly message: string
-}> {}
+  {
+    workItemId: Schema.String,
+    worktreePath: Schema.String,
+    message: Schema.String,
+  },
+) {}
 
-export class AssessChangesStartingCommitMissingError extends Data.TaggedError(
+export class AssessChangesStartingCommitMissingError extends Schema.TaggedErrorClass<AssessChangesStartingCommitMissingError>()(
   "AssessChangesStartingCommitMissingError",
-)<{
-  readonly workItemId: string
-  readonly message: string
-}> {}
+  {
+    workItemId: Schema.String,
+    message: Schema.String,
+  },
+) {}
 
-export class AssessChangesSessionMissingError extends Data.TaggedError(
+export class AssessChangesSessionMissingError extends Schema.TaggedErrorClass<AssessChangesSessionMissingError>()(
   "AssessChangesSessionMissingError",
-)<{
-  readonly workItemId: string
-  readonly message: string
-}> {}
+  {
+    workItemId: Schema.String,
+    message: Schema.String,
+  },
+) {}
 
-export class AssessChangesOpenCodeError extends Data.TaggedError(
+export class AssessChangesOpenCodeError extends Schema.TaggedErrorClass<AssessChangesOpenCodeError>()(
   "AssessChangesOpenCodeError",
-)<{
-  readonly workItemId: string
-  readonly message: string
-  readonly cause?: unknown
-}> {}
+  {
+    workItemId: Schema.String,
+    message: Schema.String,
+    cause: Schema.optional(Schema.Defect()),
+  },
+) {}
 
-export class AssessChangesResultError extends Data.TaggedError(
+export class AssessChangesResultError extends Schema.TaggedErrorClass<AssessChangesResultError>()(
   "AssessChangesResultError",
-)<{
-  readonly workItemId: string
-  readonly message: string
-}> {}
+  {
+    workItemId: Schema.String,
+    message: Schema.String,
+  },
+) {}
 
 export type AssessChangesError =
   | AssessChangesWorktreeContextMissingError

--- a/packages/work-item-lifecycle/src/lib/close-issue-errors.ts
+++ b/packages/work-item-lifecycle/src/lib/close-issue-errors.ts
@@ -1,26 +1,29 @@
-import { Data } from "effect"
+import { Schema } from "effect"
 
-export class CloseIssueSummaryMissingError extends Data.TaggedError(
+export class CloseIssueSummaryMissingError extends Schema.TaggedErrorClass<CloseIssueSummaryMissingError>()(
   "CloseIssueSummaryMissingError",
-)<{
-  readonly workItemId: string
-  readonly message: string
-}> {}
+  {
+    workItemId: Schema.String,
+    message: Schema.String,
+  },
+) {}
 
-export class CloseIssueContextError extends Data.TaggedError(
+export class CloseIssueContextError extends Schema.TaggedErrorClass<CloseIssueContextError>()(
   "CloseIssueContextError",
-)<{
-  readonly workItemId: string
-  readonly message: string
-}> {}
+  {
+    workItemId: Schema.String,
+    message: Schema.String,
+  },
+) {}
 
-export class CloseIssueEligibilityError extends Data.TaggedError(
+export class CloseIssueEligibilityError extends Schema.TaggedErrorClass<CloseIssueEligibilityError>()(
   "CloseIssueEligibilityError",
-)<{
-  readonly workItemId: string
-  readonly message: string
-  readonly failureCode: string
-}> {}
+  {
+    workItemId: Schema.String,
+    message: Schema.String,
+    failureCode: Schema.String,
+  },
+) {}
 
 export type CloseIssueError =
   | CloseIssueSummaryMissingError

--- a/packages/work-item-lifecycle/src/lib/commit-errors.ts
+++ b/packages/work-item-lifecycle/src/lib/commit-errors.ts
@@ -1,35 +1,39 @@
-import { Data } from "effect"
+import { Schema } from "effect"
 
-export class CommitWorktreeContextMissingError extends Data.TaggedError(
+export class CommitWorktreeContextMissingError extends Schema.TaggedErrorClass<CommitWorktreeContextMissingError>()(
   "CommitWorktreeContextMissingError",
-)<{
-  readonly workItemId: string
-  readonly message: string
-}> {}
+  {
+    workItemId: Schema.String,
+    message: Schema.String,
+  },
+) {}
 
-export class CommitInvalidWorktreeContextError extends Data.TaggedError(
+export class CommitInvalidWorktreeContextError extends Schema.TaggedErrorClass<CommitInvalidWorktreeContextError>()(
   "CommitInvalidWorktreeContextError",
-)<{
-  readonly workItemId: string
-  readonly worktreePath: string
-  readonly message: string
-}> {}
+  {
+    workItemId: Schema.String,
+    worktreePath: Schema.String,
+    message: Schema.String,
+  },
+) {}
 
-export class CommitSessionContextMissingError extends Data.TaggedError(
+export class CommitSessionContextMissingError extends Schema.TaggedErrorClass<CommitSessionContextMissingError>()(
   "CommitSessionContextMissingError",
-)<{
-  readonly workItemId: string
-  readonly message: string
-}> {}
+  {
+    workItemId: Schema.String,
+    message: Schema.String,
+  },
+) {}
 
-export class CommitOpenCodeError extends Data.TaggedError(
+export class CommitOpenCodeError extends Schema.TaggedErrorClass<CommitOpenCodeError>()(
   "CommitOpenCodeError",
-)<{
-  readonly message: string
-  readonly worktreePath: string
-  readonly sessionId?: string
-  readonly cause?: unknown
-}> {}
+  {
+    message: Schema.String,
+    worktreePath: Schema.String,
+    sessionId: Schema.optional(Schema.String),
+    cause: Schema.optional(Schema.Defect()),
+  },
+) {}
 
 export type CommitError =
   | CommitWorktreeContextMissingError

--- a/packages/work-item-lifecycle/src/lib/create-pr-errors.ts
+++ b/packages/work-item-lifecycle/src/lib/create-pr-errors.ts
@@ -1,51 +1,57 @@
-import { Data } from "effect"
+import { Schema } from "effect"
 
-export class CreatePrWorktreeContextMissingError extends Data.TaggedError(
+export class CreatePrWorktreeContextMissingError extends Schema.TaggedErrorClass<CreatePrWorktreeContextMissingError>()(
   "CreatePrWorktreeContextMissingError",
-)<{
-  readonly workItemId: string
-  readonly message: string
-}> {}
+  {
+    workItemId: Schema.String,
+    message: Schema.String,
+  },
+) {}
 
-export class CreatePrInvalidWorktreeContextError extends Data.TaggedError(
+export class CreatePrInvalidWorktreeContextError extends Schema.TaggedErrorClass<CreatePrInvalidWorktreeContextError>()(
   "CreatePrInvalidWorktreeContextError",
-)<{
-  readonly workItemId: string
-  readonly worktreePath: string
-  readonly message: string
-}> {}
+  {
+    workItemId: Schema.String,
+    worktreePath: Schema.String,
+    message: Schema.String,
+  },
+) {}
 
-export class CreatePrSessionContextMissingError extends Data.TaggedError(
+export class CreatePrSessionContextMissingError extends Schema.TaggedErrorClass<CreatePrSessionContextMissingError>()(
   "CreatePrSessionContextMissingError",
-)<{
-  readonly workItemId: string
-  readonly message: string
-}> {}
+  {
+    workItemId: Schema.String,
+    message: Schema.String,
+  },
+) {}
 
-export class CreatePrCredentialError extends Data.TaggedError(
+export class CreatePrCredentialError extends Schema.TaggedErrorClass<CreatePrCredentialError>()(
   "CreatePrCredentialError",
-)<{
-  readonly repositoryId: string
-  readonly message: string
-  readonly cause?: unknown
-}> {}
+  {
+    repositoryId: Schema.String,
+    message: Schema.String,
+    cause: Schema.optional(Schema.Defect()),
+  },
+) {}
 
-export class CreatePrOpenCodeError extends Data.TaggedError(
+export class CreatePrOpenCodeError extends Schema.TaggedErrorClass<CreatePrOpenCodeError>()(
   "CreatePrOpenCodeError",
-)<{
-  readonly message: string
-  readonly worktreePath: string
-  readonly sessionId?: string
-  readonly cause?: unknown
-}> {}
+  {
+    message: Schema.String,
+    worktreePath: Schema.String,
+    sessionId: Schema.optional(Schema.String),
+    cause: Schema.optional(Schema.Defect()),
+  },
+) {}
 
-export class CreatePrLookupError extends Data.TaggedError(
+export class CreatePrLookupError extends Schema.TaggedErrorClass<CreatePrLookupError>()(
   "CreatePrLookupError",
-)<{
-  readonly repositoryId: string
-  readonly message: string
-  readonly cause?: unknown
-}> {}
+  {
+    repositoryId: Schema.String,
+    message: Schema.String,
+    cause: Schema.optional(Schema.Defect()),
+  },
+) {}
 
 export type CreatePrError =
   | CreatePrWorktreeContextMissingError

--- a/packages/work-item-lifecycle/src/lib/create-worktree-errors.ts
+++ b/packages/work-item-lifecycle/src/lib/create-worktree-errors.ts
@@ -1,27 +1,32 @@
-import { Data } from "effect"
+import { Schema } from "effect"
 
-export class CreateWorktreeRepositoryNotFoundError extends Data.TaggedError(
+export class CreateWorktreeRepositoryNotFoundError extends Schema.TaggedErrorClass<CreateWorktreeRepositoryNotFoundError>()(
   "CreateWorktreeRepositoryNotFoundError",
-)<{
-  readonly repositoryId: string
-}> {}
+  {
+    repositoryId: Schema.String,
+  },
+) {}
 
-export class WorktreeConflictError extends Data.TaggedError(
+export class WorktreeConflictError extends Schema.TaggedErrorClass<WorktreeConflictError>()(
   "WorktreeConflictError",
-)<{
-  readonly message: string
-  readonly branchName: string
-  readonly worktreePath: string
-}> {}
+  {
+    message: Schema.String,
+    branchName: Schema.String,
+    worktreePath: Schema.String,
+  },
+) {}
 
-export class GitCommandError extends Data.TaggedError("GitCommandError")<{
-  readonly message: string
-  readonly command: string
-  readonly args: readonly string[]
-  readonly cwd?: string
-  readonly exitCode: number
-  readonly stderr: string
-}> {}
+export class GitCommandError extends Schema.TaggedErrorClass<GitCommandError>()(
+  "GitCommandError",
+  {
+    message: Schema.String,
+    command: Schema.String,
+    args: Schema.Array(Schema.String),
+    cwd: Schema.optional(Schema.String),
+    exitCode: Schema.Finite,
+    stderr: Schema.String,
+  },
+) {}
 
 export type CreateWorktreeError =
   | CreateWorktreeRepositoryNotFoundError

--- a/packages/work-item-lifecycle/src/lib/decide-pr-merge.ts
+++ b/packages/work-item-lifecycle/src/lib/decide-pr-merge.ts
@@ -1,17 +1,24 @@
-import { Data, Effect } from "effect"
+import { Effect, Schema } from "effect"
 import { DbService } from "@ready-for-agent/db-service"
 import { KeymaxxerService } from "@ready-for-agent/keymaxxer-service"
 import { Opencode } from "@ready-for-agent/opencode"
 import type { LifecycleStepContext } from "./lifecycle-steps.js"
 import { DEFAULT_LIFECYCLE_MAX_DURATIONS } from "./types.js"
 
-export class DecidePrMergeContextError extends Data.TaggedError(
+export class DecidePrMergeContextError extends Schema.TaggedErrorClass<DecidePrMergeContextError>()(
   "DecidePrMergeContextError",
-)<{ readonly message: string }> {}
+  {
+    message: Schema.String,
+  },
+) {}
 
-export class DecidePrMergeOpenCodeError extends Data.TaggedError(
+export class DecidePrMergeOpenCodeError extends Schema.TaggedErrorClass<DecidePrMergeOpenCodeError>()(
   "DecidePrMergeOpenCodeError",
-)<{ readonly message: string; readonly cause?: unknown }> {}
+  {
+    message: Schema.String,
+    cause: Schema.optional(Schema.Defect()),
+  },
+) {}
 
 export type DecidePrMergeResult =
   | { readonly _tag: "clanker_merge" }

--- a/packages/work-item-lifecycle/src/lib/errors.ts
+++ b/packages/work-item-lifecycle/src/lib/errors.ts
@@ -1,115 +1,151 @@
-import { Data } from "effect"
+import { Schema } from "effect"
 
 export * from "./create-worktree-errors.js"
 export * from "./install-dependencies-errors.js"
 
-export class NonTransactionalQueueError extends Data.TaggedError(
+export class NonTransactionalQueueError extends Schema.TaggedErrorClass<NonTransactionalQueueError>()(
   "NonTransactionalQueueError",
-)<{
-  readonly message: string
-}> {}
+  {
+    message: Schema.String,
+  },
+) {}
 
-export class IssueNotFoundError extends Data.TaggedError("IssueNotFoundError")<{
-  readonly repositoryId: string
-  readonly githubIssueNumber: number
-}> {}
+export class IssueNotFoundError extends Schema.TaggedErrorClass<IssueNotFoundError>()(
+  "IssueNotFoundError",
+  {
+    repositoryId: Schema.String,
+    githubIssueNumber: Schema.Finite,
+  },
+) {}
 
-export class IssueNotOpenError extends Data.TaggedError("IssueNotOpenError")<{
-  readonly repositoryId: string
-  readonly githubIssueNumber: number
-  readonly state: string
-}> {}
+export class IssueNotOpenError extends Schema.TaggedErrorClass<IssueNotOpenError>()(
+  "IssueNotOpenError",
+  {
+    repositoryId: Schema.String,
+    githubIssueNumber: Schema.Finite,
+    state: Schema.String,
+  },
+) {}
 
-export class ParentIssueError extends Data.TaggedError("ParentIssueError")<{
-  readonly repositoryId: string
-  readonly githubIssueNumber: number
-}> {}
+export class ParentIssueError extends Schema.TaggedErrorClass<ParentIssueError>()(
+  "ParentIssueError",
+  {
+    repositoryId: Schema.String,
+    githubIssueNumber: Schema.Finite,
+  },
+) {}
 
-export class IssueBlockedError extends Data.TaggedError("IssueBlockedError")<{
-  readonly repositoryId: string
-  readonly githubIssueNumber: number
-  readonly blockerCount: number
-}> {}
+export class IssueBlockedError extends Schema.TaggedErrorClass<IssueBlockedError>()(
+  "IssueBlockedError",
+  {
+    repositoryId: Schema.String,
+    githubIssueNumber: Schema.Finite,
+    blockerCount: Schema.Finite,
+  },
+) {}
 
-export class UnfinishedWorkItemExistsError extends Data.TaggedError(
+export class UnfinishedWorkItemExistsError extends Schema.TaggedErrorClass<UnfinishedWorkItemExistsError>()(
   "UnfinishedWorkItemExistsError",
-)<{
-  readonly repositoryId: string
-  readonly githubIssueNumber: number
-  readonly workItemId: string
-}> {}
+  {
+    repositoryId: Schema.String,
+    githubIssueNumber: Schema.Finite,
+    workItemId: Schema.String,
+  },
+) {}
 
-export class BuildModelNotConfiguredError extends Data.TaggedError(
+export class BuildModelNotConfiguredError extends Schema.TaggedErrorClass<BuildModelNotConfiguredError>()(
   "BuildModelNotConfiguredError",
-)<{
-  readonly message: string
-}> {}
+  {
+    message: Schema.String,
+  },
+) {}
 
-export class WorkItemNotFoundError extends Data.TaggedError(
+export class WorkItemNotFoundError extends Schema.TaggedErrorClass<WorkItemNotFoundError>()(
   "WorkItemNotFoundError",
-)<{
-  readonly workItemId: string
-}> {}
+  {
+    workItemId: Schema.String,
+  },
+) {}
 
-export class StepRunNotFoundError extends Data.TaggedError(
+export class StepRunNotFoundError extends Schema.TaggedErrorClass<StepRunNotFoundError>()(
   "StepRunNotFoundError",
-)<{
-  readonly stepRunId: string
-}> {}
+  {
+    stepRunId: Schema.String,
+  },
+) {}
 
-export class WorkItemLifecycleDatabaseError extends Data.TaggedError(
+export class WorkItemLifecycleDatabaseError extends Schema.TaggedErrorClass<WorkItemLifecycleDatabaseError>()(
   "WorkItemLifecycleDatabaseError",
-)<{
-  readonly message: string
-  readonly cause?: unknown
-}> {}
+  {
+    message: Schema.String,
+    cause: Schema.optional(Schema.Defect()),
+  },
+) {}
 
-export class WorkItemTerminalError extends Data.TaggedError(
+export class WorkItemTerminalError extends Schema.TaggedErrorClass<WorkItemTerminalError>()(
   "WorkItemTerminalError",
-)<{
-  readonly workItemId: string
-  readonly state: string
-}> {}
+  {
+    workItemId: Schema.String,
+    state: Schema.String,
+  },
+) {}
 
-export class ActiveStepRunExistsError extends Data.TaggedError(
+export class ActiveStepRunExistsError extends Schema.TaggedErrorClass<ActiveStepRunExistsError>()(
   "ActiveStepRunExistsError",
-)<{
-  readonly workItemId: string
-  readonly stepRunId: string
-  readonly status: string
-}> {}
+  {
+    workItemId: Schema.String,
+    stepRunId: Schema.String,
+    status: Schema.String,
+  },
+) {}
 
-export class RetryNotEligibleError extends Data.TaggedError(
+export class RetryNotEligibleError extends Schema.TaggedErrorClass<RetryNotEligibleError>()(
   "RetryNotEligibleError",
-)<{
-  readonly workItemId: string
-  readonly reason: string
-}> {}
+  {
+    workItemId: Schema.String,
+    reason: Schema.String,
+  },
+) {}
 
-export class WorkItemHasRunningStepError extends Data.TaggedError(
+export class WorkItemHasRunningStepError extends Schema.TaggedErrorClass<WorkItemHasRunningStepError>()(
   "WorkItemHasRunningStepError",
-)<{
-  readonly workItemId: string
-  readonly stepRunId: string
-}> {}
+  {
+    workItemId: Schema.String,
+    stepRunId: Schema.String,
+  },
+) {}
 
-export class ResetCleanupError extends Data.TaggedError("ResetCleanupError")<{
-  readonly workItemId: string
-  readonly message: string
-  readonly cause: unknown
-}> {}
+export class ResetCleanupError extends Schema.TaggedErrorClass<ResetCleanupError>()(
+  "ResetCleanupError",
+  {
+    workItemId: Schema.String,
+    message: Schema.String,
+    cause: Schema.Defect(),
+  },
+) {}
 
-export class AbandonCleanupError extends Data.TaggedError(
+export class AbandonCleanupError extends Schema.TaggedErrorClass<AbandonCleanupError>()(
   "AbandonCleanupError",
-)<{
-  readonly workItemId: string
-  readonly message: string
-  readonly cause: unknown
-}> {}
+  {
+    workItemId: Schema.String,
+    message: Schema.String,
+    cause: Schema.Defect(),
+  },
+) {}
 
-export class NeedsHumanHandoffNotEligibleError extends Data.TaggedError(
+export class NeedsHumanHandoffNotEligibleError extends Schema.TaggedErrorClass<NeedsHumanHandoffNotEligibleError>()(
   "NeedsHumanHandoffNotEligibleError",
-)<{
-  readonly workItemId: string
-  readonly reason: string
-}> {}
+  {
+    workItemId: Schema.String,
+    reason: Schema.String,
+  },
+) {}
+
+/** Ad-hoc step failure for tests and non-domain handler failures. */
+export class LifecycleStepFailedError extends Schema.TaggedErrorClass<LifecycleStepFailedError>()(
+  "LifecycleStepFailedError",
+  {
+    message: Schema.String,
+    cause: Schema.optional(Schema.Defect()),
+  },
+) {}

--- a/packages/work-item-lifecycle/src/lib/implement-errors.ts
+++ b/packages/work-item-lifecycle/src/lib/implement-errors.ts
@@ -1,41 +1,46 @@
-import { Data } from "effect"
+import { Schema } from "effect"
 
-export class ImplementWorktreeContextMissingError extends Data.TaggedError(
+export class ImplementWorktreeContextMissingError extends Schema.TaggedErrorClass<ImplementWorktreeContextMissingError>()(
   "ImplementWorktreeContextMissingError",
-)<{
-  readonly workItemId: string
-  readonly message: string
-}> {}
+  {
+    workItemId: Schema.String,
+    message: Schema.String,
+  },
+) {}
 
-export class ImplementInvalidWorktreeContextError extends Data.TaggedError(
+export class ImplementInvalidWorktreeContextError extends Schema.TaggedErrorClass<ImplementInvalidWorktreeContextError>()(
   "ImplementInvalidWorktreeContextError",
-)<{
-  readonly workItemId: string
-  readonly worktreePath: string
-  readonly message: string
-}> {}
+  {
+    workItemId: Schema.String,
+    worktreePath: Schema.String,
+    message: Schema.String,
+  },
+) {}
 
-export class ImplementRepositoryNotFoundError extends Data.TaggedError(
+export class ImplementRepositoryNotFoundError extends Schema.TaggedErrorClass<ImplementRepositoryNotFoundError>()(
   "ImplementRepositoryNotFoundError",
-)<{
-  readonly repositoryId: string
-  readonly message: string
-}> {}
+  {
+    repositoryId: Schema.String,
+    message: Schema.String,
+  },
+) {}
 
-export class ImplementIssueContextMissingError extends Data.TaggedError(
+export class ImplementIssueContextMissingError extends Schema.TaggedErrorClass<ImplementIssueContextMissingError>()(
   "ImplementIssueContextMissingError",
-)<{
-  readonly workItemId: string
-  readonly message: string
-}> {}
+  {
+    workItemId: Schema.String,
+    message: Schema.String,
+  },
+) {}
 
-export class ImplementOpenCodeError extends Data.TaggedError(
+export class ImplementOpenCodeError extends Schema.TaggedErrorClass<ImplementOpenCodeError>()(
   "ImplementOpenCodeError",
-)<{
-  readonly message: string
-  readonly worktreePath: string
-  readonly cause?: unknown
-}> {}
+  {
+    message: Schema.String,
+    worktreePath: Schema.String,
+    cause: Schema.optional(Schema.Defect()),
+  },
+) {}
 
 export type ImplementError =
   | ImplementWorktreeContextMissingError

--- a/packages/work-item-lifecycle/src/lib/install-dependencies-errors.ts
+++ b/packages/work-item-lifecycle/src/lib/install-dependencies-errors.ts
@@ -1,38 +1,42 @@
-import { Data } from "effect"
+import { Schema } from "effect"
 
-export class WorktreeContextMissingError extends Data.TaggedError(
+export class WorktreeContextMissingError extends Schema.TaggedErrorClass<WorktreeContextMissingError>()(
   "WorktreeContextMissingError",
-)<{
-  readonly workItemId: string
-  readonly message: string
-}> {}
+  {
+    workItemId: Schema.String,
+    message: Schema.String,
+  },
+) {}
 
-export class InvalidWorktreeContextError extends Data.TaggedError(
+export class InvalidWorktreeContextError extends Schema.TaggedErrorClass<InvalidWorktreeContextError>()(
   "InvalidWorktreeContextError",
-)<{
-  readonly workItemId: string
-  readonly worktreePath: string
-  readonly message: string
-}> {}
+  {
+    workItemId: Schema.String,
+    worktreePath: Schema.String,
+    message: Schema.String,
+  },
+) {}
 
-export class InstallCommandError extends Data.TaggedError(
+export class InstallCommandError extends Schema.TaggedErrorClass<InstallCommandError>()(
   "InstallCommandError",
-)<{
-  readonly message: string
-  readonly command: string
-  readonly args: readonly string[]
-  readonly cwd: string
-  readonly exitCode: number
-  readonly stderr: string
-}> {}
+  {
+    message: Schema.String,
+    command: Schema.String,
+    args: Schema.Array(Schema.String),
+    cwd: Schema.String,
+    exitCode: Schema.Finite,
+    stderr: Schema.String,
+  },
+) {}
 
-export class InstallDependenciesFallbackError extends Data.TaggedError(
+export class InstallDependenciesFallbackError extends Schema.TaggedErrorClass<InstallDependenciesFallbackError>()(
   "InstallDependenciesFallbackError",
-)<{
-  readonly message: string
-  readonly worktreePath: string
-  readonly cause?: unknown
-}> {}
+  {
+    message: Schema.String,
+    worktreePath: Schema.String,
+    cause: Schema.optional(Schema.Defect()),
+  },
+) {}
 
 export type InstallDependenciesError =
   | WorktreeContextMissingError

--- a/packages/work-item-lifecycle/src/lib/lifecycle-steps-live.ts
+++ b/packages/work-item-lifecycle/src/lib/lifecycle-steps-live.ts
@@ -26,11 +26,21 @@ import { localCleanup, removeWorktree } from "./remove-worktree.js"
 import { resolvePrMergeConflict } from "./resolve-pr-merge-conflict.js"
 import { review } from "./review.js"
 
+type StepServices =
+  | DbService
+  | KeymaxxerService
+  | FileSystem.FileSystem
+  | Path.Path
+  | ChildProcessSpawner.ChildProcessSpawner
+  | Opencode
+  | GitHubService
+  | SqlClient.SqlClient
+
 /**
  * Production LifecycleSteps: Create Worktree through local cleanup, including
  * Assess Changes (git then optional OpenCode confirm) and Close Issue for
  * No-Change Outcomes. Captures platform, database, Keymaxxer, GitHub, and
- * OpenCode services so handlers remain `Effect<A>` with no requirements.
+ * OpenCode services so handlers remain `Effect<A, E>` with no requirements.
  */
 export const LifecycleStepsLive = Layer.effect(
   LifecycleSteps,
@@ -45,30 +55,19 @@ export const LifecycleStepsLive = Layer.effect(
     const sql = yield* SqlClient.SqlClient
     const opencode = yield* limitOpencodeSessions(rawOpencode, db, sql)
 
-    const withServices = <A, E>(
-      effect: Effect.Effect<
-        A,
-        E,
-        | DbService
-        | KeymaxxerService
-        | FileSystem.FileSystem
-        | Path.Path
-        | ChildProcessSpawner.ChildProcessSpawner
-        | Opencode
-        | GitHubService
-        | SqlClient.SqlClient
-      >,
-    ) =>
-      effect.pipe(
-        Effect.provideService(DbService, db),
-        Effect.provideService(KeymaxxerService, keymaxxer),
-        Effect.provideService(FileSystem.FileSystem, fs),
-        Effect.provideService(Path.Path, path),
-        Effect.provideService(ChildProcessSpawner.ChildProcessSpawner, spawner),
-        Effect.provideService(Opencode, opencode),
-        Effect.provideService(GitHubService, github),
-        Effect.provideService(SqlClient.SqlClient, sql),
-      )
+    const services = Layer.mergeAll(
+      Layer.succeed(DbService, db),
+      Layer.succeed(KeymaxxerService, keymaxxer),
+      Layer.succeed(FileSystem.FileSystem, fs),
+      Layer.succeed(Path.Path, path),
+      Layer.succeed(ChildProcessSpawner.ChildProcessSpawner, spawner),
+      Layer.succeed(Opencode, opencode),
+      Layer.succeed(GitHubService, github),
+      Layer.succeed(SqlClient.SqlClient, sql),
+    )
+
+    const withServices = <A, E>(effect: Effect.Effect<A, E, StepServices>) =>
+      effect.pipe(Effect.provide(services))
 
     return LifecycleSteps.of({
       createWorktree: (context) => withServices(createWorktree(context)),

--- a/packages/work-item-lifecycle/src/lib/lifecycle-steps.ts
+++ b/packages/work-item-lifecycle/src/lib/lifecycle-steps.ts
@@ -1,11 +1,48 @@
 import { Context, type Duration, type Effect } from "effect"
+import type { PlatformError } from "effect/PlatformError"
+import type { SqlError } from "effect/unstable/sql/SqlError"
+import type {
+  DatabaseError,
+  RepositoryNotFoundError,
+} from "@ready-for-agent/db-service"
+import type {
+  GitHubRepositoryUnavailableError,
+  GitHubRequestError,
+} from "@ready-for-agent/github-service"
+import type { KeymaxxerError } from "@ready-for-agent/keymaxxer-service"
 import type { AssessChangesResult } from "./assess-changes.js"
-import type { DecidePrMergeResult } from "./decide-pr-merge.js"
+import type { AssessChangesError } from "./assess-changes-errors.js"
+import type { CloseIssueError } from "./close-issue-errors.js"
+import type { CommitError } from "./commit-errors.js"
+import type { CreatePrError } from "./create-pr-errors.js"
+import type { CreateWorktreeError } from "./create-worktree-errors.js"
+import type {
+  DecidePrMergeContextError,
+  DecidePrMergeOpenCodeError,
+  DecidePrMergeResult,
+} from "./decide-pr-merge.js"
+import type {
+  LifecycleStepFailedError,
+  WorkItemLifecycleDatabaseError,
+} from "./errors.js"
+import type { ImplementError } from "./implement-errors.js"
+import type { InstallDependenciesError } from "./install-dependencies-errors.js"
+import type { MarkPrReadyForReviewContextError } from "./mark-pr-ready-for-review.js"
+import type { MergePrContextError } from "./merge-pr.js"
 import type {
   PrStatusCheckInvestigationResult,
   PrStatusCheckResult,
+  PrStatusChecksContextError,
+  PrStatusChecksOpenCodeError,
 } from "./pr-status-checks.js"
-import type { ResolvePrMergeConflictResult } from "./resolve-pr-merge-conflict.js"
+import type { PreCommitError } from "./pre-commit-errors.js"
+import type { RemoveWorktreeError } from "./remove-worktree.js"
+import type {
+  ResolvePrMergeConflictContextError,
+  ResolvePrMergeConflictOpenCodeError,
+  ResolvePrMergeConflictResult,
+} from "./resolve-pr-merge-conflict.js"
+import type { ReviewError } from "./review-errors.js"
 import type { WorkItemId } from "./types.js"
 
 /**
@@ -34,61 +71,99 @@ export type CreateWorktreeResult = {
 }
 
 /**
+ * Typed failures a Lifecycle Step handler may surface to the orchestrator.
+ * Domain step errors plus platform/service errors that production handlers
+ * currently leave unmapped.
+ */
+export type LifecycleStepError =
+  | CreateWorktreeError
+  | InstallDependenciesError
+  | ImplementError
+  | AssessChangesError
+  | PreCommitError
+  | ReviewError
+  | CommitError
+  | CreatePrError
+  | CloseIssueError
+  | RemoveWorktreeError
+  | DecidePrMergeContextError
+  | DecidePrMergeOpenCodeError
+  | PrStatusChecksContextError
+  | PrStatusChecksOpenCodeError
+  | ResolvePrMergeConflictContextError
+  | ResolvePrMergeConflictOpenCodeError
+  | MarkPrReadyForReviewContextError
+  | MergePrContextError
+  | LifecycleStepFailedError
+  | DatabaseError
+  | RepositoryNotFoundError
+  | GitHubRequestError
+  | GitHubRepositoryUnavailableError
+  | KeymaxxerError
+  | PlatformError
+  | SqlError
+
+/** Errors runHandler may surface, including orchestrator DB reads mid-handler. */
+export type RunHandlerError =
+  | LifecycleStepError
+  | WorkItemLifecycleDatabaseError
+
+/**
  * Injected step handlers. Production adapters and tests both implement this
  * surface; the lifecycle module selects the handler from the pending step.
  */
 export interface LifecycleStepsShape {
   readonly createWorktree: (
     context: LifecycleStepContext,
-  ) => Effect.Effect<CreateWorktreeResult, unknown>
+  ) => Effect.Effect<CreateWorktreeResult, LifecycleStepError>
   readonly installDependencies: (
     context: LifecycleStepContext,
-  ) => Effect.Effect<void, unknown>
+  ) => Effect.Effect<void, LifecycleStepError>
   readonly implement: (
     context: LifecycleStepContext,
-  ) => Effect.Effect<string, unknown>
+  ) => Effect.Effect<string, LifecycleStepError>
   readonly assessChanges: (
     context: LifecycleStepContext,
-  ) => Effect.Effect<AssessChangesResult, unknown>
+  ) => Effect.Effect<AssessChangesResult, LifecycleStepError>
   readonly preCommit: (
     context: LifecycleStepContext,
-  ) => Effect.Effect<void, unknown>
+  ) => Effect.Effect<void, LifecycleStepError>
   readonly review: (
     context: LifecycleStepContext,
-  ) => Effect.Effect<void, unknown>
+  ) => Effect.Effect<void, LifecycleStepError>
   readonly commit: (
     context: LifecycleStepContext,
-  ) => Effect.Effect<void, unknown>
+  ) => Effect.Effect<void, LifecycleStepError>
   readonly createPr: (
     context: LifecycleStepContext,
-  ) => Effect.Effect<number, unknown>
+  ) => Effect.Effect<number, LifecycleStepError>
   readonly watchPrStatusChecks: (
     context: LifecycleStepContext,
-  ) => Effect.Effect<PrStatusCheckResult, unknown>
+  ) => Effect.Effect<PrStatusCheckResult, LifecycleStepError>
   readonly resolvePrMergeConflict: (
     context: LifecycleStepContext,
-  ) => Effect.Effect<ResolvePrMergeConflictResult, unknown>
+  ) => Effect.Effect<ResolvePrMergeConflictResult, LifecycleStepError>
   readonly investigatePrStatusChecks: (
     context: LifecycleStepContext,
-  ) => Effect.Effect<PrStatusCheckInvestigationResult, unknown>
+  ) => Effect.Effect<PrStatusCheckInvestigationResult, LifecycleStepError>
   readonly markPrReadyForReview: (
     context: LifecycleStepContext,
-  ) => Effect.Effect<void, unknown>
+  ) => Effect.Effect<void, LifecycleStepError>
   readonly decidePrMerge: (
     context: LifecycleStepContext,
-  ) => Effect.Effect<DecidePrMergeResult, unknown>
+  ) => Effect.Effect<DecidePrMergeResult, LifecycleStepError>
   readonly mergePr: (
     context: LifecycleStepContext,
-  ) => Effect.Effect<void, unknown>
+  ) => Effect.Effect<void, LifecycleStepError>
   readonly closeIssue: (
     context: LifecycleStepContext,
-  ) => Effect.Effect<void, unknown>
+  ) => Effect.Effect<void, LifecycleStepError>
   readonly localCleanup: (
     context: LifecycleStepContext,
-  ) => Effect.Effect<void, unknown>
+  ) => Effect.Effect<void, LifecycleStepError>
   readonly removeWorktree: (
     context: LifecycleStepContext,
-  ) => Effect.Effect<void, unknown>
+  ) => Effect.Effect<void, LifecycleStepError>
 }
 
 export class LifecycleSteps extends Context.Service<

--- a/packages/work-item-lifecycle/src/lib/mark-pr-ready-for-review.ts
+++ b/packages/work-item-lifecycle/src/lib/mark-pr-ready-for-review.ts
@@ -1,12 +1,15 @@
-import { Data, Effect } from "effect"
+import { Effect, Schema } from "effect"
 import { DbService } from "@ready-for-agent/db-service"
 import { GitHubService } from "@ready-for-agent/github-service"
 import type { LifecycleStepContext } from "./lifecycle-steps.js"
 import { workItemBranchName } from "./worktree-names.js"
 
-export class MarkPrReadyForReviewContextError extends Data.TaggedError(
+export class MarkPrReadyForReviewContextError extends Schema.TaggedErrorClass<MarkPrReadyForReviewContextError>()(
   "MarkPrReadyForReviewContextError",
-)<{ readonly message: string }> {}
+  {
+    message: Schema.String,
+  },
+) {}
 
 /**
  * Production Mark PR Ready for Review Lifecycle Step.

--- a/packages/work-item-lifecycle/src/lib/merge-pr.ts
+++ b/packages/work-item-lifecycle/src/lib/merge-pr.ts
@@ -1,14 +1,15 @@
-import { Data, Effect } from "effect"
+import { Effect, Schema } from "effect"
 import { DbService } from "@ready-for-agent/db-service"
 import { GitHubService } from "@ready-for-agent/github-service"
 import type { LifecycleStepContext } from "./lifecycle-steps.js"
 import { workItemBranchName } from "./worktree-names.js"
 
-export class MergePrContextError extends Data.TaggedError(
+export class MergePrContextError extends Schema.TaggedErrorClass<MergePrContextError>()(
   "MergePrContextError",
-)<{
-  readonly message: string
-}> {}
+  {
+    message: Schema.String,
+  },
+) {}
 
 /**
  * Production Merge PR Lifecycle Step.

--- a/packages/work-item-lifecycle/src/lib/pr-status-checks.ts
+++ b/packages/work-item-lifecycle/src/lib/pr-status-checks.ts
@@ -1,4 +1,4 @@
-import { Clock, Data, Effect } from "effect"
+import { Clock, Effect, Schema } from "effect"
 import { SqlClient } from "effect/unstable/sql"
 import { ulid } from "ulidx"
 import { DbService } from "@ready-for-agent/db-service"
@@ -13,13 +13,20 @@ import type { LifecycleStepContext } from "./lifecycle-steps.js"
 import { DEFAULT_LIFECYCLE_MAX_DURATIONS } from "./types.js"
 import { workItemBranchName } from "./worktree-names.js"
 
-export class PrStatusChecksContextError extends Data.TaggedError(
+export class PrStatusChecksContextError extends Schema.TaggedErrorClass<PrStatusChecksContextError>()(
   "PrStatusChecksContextError",
-)<{ readonly message: string }> {}
+  {
+    message: Schema.String,
+  },
+) {}
 
-export class PrStatusChecksOpenCodeError extends Data.TaggedError(
+export class PrStatusChecksOpenCodeError extends Schema.TaggedErrorClass<PrStatusChecksOpenCodeError>()(
   "PrStatusChecksOpenCodeError",
-)<{ readonly message: string; readonly cause?: unknown }> {}
+  {
+    message: Schema.String,
+    cause: Schema.optional(Schema.Defect()),
+  },
+) {}
 
 export type PrStatusCheckResult =
   | "pending"

--- a/packages/work-item-lifecycle/src/lib/pre-commit-errors.ts
+++ b/packages/work-item-lifecycle/src/lib/pre-commit-errors.ts
@@ -1,53 +1,59 @@
-import { Data } from "effect"
+import { Schema } from "effect"
 
-export class PreCommitWorktreeContextMissingError extends Data.TaggedError(
+export class PreCommitWorktreeContextMissingError extends Schema.TaggedErrorClass<PreCommitWorktreeContextMissingError>()(
   "PreCommitWorktreeContextMissingError",
-)<{
-  readonly workItemId: string
-  readonly message: string
-}> {}
+  {
+    workItemId: Schema.String,
+    message: Schema.String,
+  },
+) {}
 
-export class PreCommitInvalidWorktreeContextError extends Data.TaggedError(
+export class PreCommitInvalidWorktreeContextError extends Schema.TaggedErrorClass<PreCommitInvalidWorktreeContextError>()(
   "PreCommitInvalidWorktreeContextError",
-)<{
-  readonly workItemId: string
-  readonly worktreePath: string
-  readonly message: string
-}> {}
+  {
+    workItemId: Schema.String,
+    worktreePath: Schema.String,
+    message: Schema.String,
+  },
+) {}
 
-export class PreCommitStageError extends Data.TaggedError(
+export class PreCommitStageError extends Schema.TaggedErrorClass<PreCommitStageError>()(
   "PreCommitStageError",
-)<{
-  readonly message: string
-  readonly worktreePath: string
-  readonly exitCode: number
-  readonly output: string
-}> {}
+  {
+    message: Schema.String,
+    worktreePath: Schema.String,
+    exitCode: Schema.Finite,
+    output: Schema.String,
+  },
+) {}
 
-export class PreCommitHookFailedError extends Data.TaggedError(
+export class PreCommitHookFailedError extends Schema.TaggedErrorClass<PreCommitHookFailedError>()(
   "PreCommitHookFailedError",
-)<{
-  readonly message: string
-  readonly worktreePath: string
-  readonly exitCode: number
-  readonly output: string
-}> {}
+  {
+    message: Schema.String,
+    worktreePath: Schema.String,
+    exitCode: Schema.Finite,
+    output: Schema.String,
+  },
+) {}
 
-export class PreCommitSessionContextMissingError extends Data.TaggedError(
+export class PreCommitSessionContextMissingError extends Schema.TaggedErrorClass<PreCommitSessionContextMissingError>()(
   "PreCommitSessionContextMissingError",
-)<{
-  readonly workItemId: string
-  readonly message: string
-}> {}
+  {
+    workItemId: Schema.String,
+    message: Schema.String,
+  },
+) {}
 
-export class PreCommitOpenCodeError extends Data.TaggedError(
+export class PreCommitOpenCodeError extends Schema.TaggedErrorClass<PreCommitOpenCodeError>()(
   "PreCommitOpenCodeError",
-)<{
-  readonly message: string
-  readonly worktreePath: string
-  readonly sessionId: string
-  readonly cause?: unknown
-}> {}
+  {
+    message: Schema.String,
+    worktreePath: Schema.String,
+    sessionId: Schema.String,
+    cause: Schema.optional(Schema.Defect()),
+  },
+) {}
 
 export type PreCommitError =
   | PreCommitWorktreeContextMissingError

--- a/packages/work-item-lifecycle/src/lib/remove-worktree-errors.ts
+++ b/packages/work-item-lifecycle/src/lib/remove-worktree-errors.ts
@@ -1,17 +1,19 @@
-import { Data } from "effect"
+import { Schema } from "effect"
 
-export class RemoveWorktreeCredentialError extends Data.TaggedError(
+export class RemoveWorktreeCredentialError extends Schema.TaggedErrorClass<RemoveWorktreeCredentialError>()(
   "RemoveWorktreeCredentialError",
-)<{
-  readonly repositoryId: string
-  readonly message: string
-  readonly cause?: unknown
-}> {}
+  {
+    repositoryId: Schema.String,
+    message: Schema.String,
+    cause: Schema.optional(Schema.Defect()),
+  },
+) {}
 
-export class RemoveWorktreeRemoteError extends Data.TaggedError(
+export class RemoveWorktreeRemoteError extends Schema.TaggedErrorClass<RemoveWorktreeRemoteError>()(
   "RemoveWorktreeRemoteError",
-)<{
-  readonly message: string
-  readonly branchName: string
-  readonly cause?: unknown
-}> {}
+  {
+    message: Schema.String,
+    branchName: Schema.String,
+    cause: Schema.optional(Schema.Defect()),
+  },
+) {}

--- a/packages/work-item-lifecycle/src/lib/resolve-pr-merge-conflict.ts
+++ b/packages/work-item-lifecycle/src/lib/resolve-pr-merge-conflict.ts
@@ -1,17 +1,24 @@
-import { Data, Effect } from "effect"
+import { Effect, Schema } from "effect"
 import { DbService } from "@ready-for-agent/db-service"
 import { KeymaxxerService } from "@ready-for-agent/keymaxxer-service"
 import { Opencode } from "@ready-for-agent/opencode"
 import type { LifecycleStepContext } from "./lifecycle-steps.js"
 import { DEFAULT_LIFECYCLE_MAX_DURATIONS } from "./types.js"
 
-export class ResolvePrMergeConflictContextError extends Data.TaggedError(
+export class ResolvePrMergeConflictContextError extends Schema.TaggedErrorClass<ResolvePrMergeConflictContextError>()(
   "ResolvePrMergeConflictContextError",
-)<{ readonly message: string }> {}
+  {
+    message: Schema.String,
+  },
+) {}
 
-export class ResolvePrMergeConflictOpenCodeError extends Data.TaggedError(
+export class ResolvePrMergeConflictOpenCodeError extends Schema.TaggedErrorClass<ResolvePrMergeConflictOpenCodeError>()(
   "ResolvePrMergeConflictOpenCodeError",
-)<{ readonly message: string; readonly cause?: unknown }> {}
+  {
+    message: Schema.String,
+    cause: Schema.optional(Schema.Defect()),
+  },
+) {}
 
 export type ResolvePrMergeConflictResult =
   | { readonly _tag: "processed" }

--- a/packages/work-item-lifecycle/src/lib/review-errors.ts
+++ b/packages/work-item-lifecycle/src/lib/review-errors.ts
@@ -1,35 +1,39 @@
-import { Data } from "effect"
+import { Schema } from "effect"
 
-export class ReviewWorktreeContextMissingError extends Data.TaggedError(
+export class ReviewWorktreeContextMissingError extends Schema.TaggedErrorClass<ReviewWorktreeContextMissingError>()(
   "ReviewWorktreeContextMissingError",
-)<{
-  readonly workItemId: string
-  readonly message: string
-}> {}
+  {
+    workItemId: Schema.String,
+    message: Schema.String,
+  },
+) {}
 
-export class ReviewInvalidWorktreeContextError extends Data.TaggedError(
+export class ReviewInvalidWorktreeContextError extends Schema.TaggedErrorClass<ReviewInvalidWorktreeContextError>()(
   "ReviewInvalidWorktreeContextError",
-)<{
-  readonly workItemId: string
-  readonly worktreePath: string
-  readonly message: string
-}> {}
+  {
+    workItemId: Schema.String,
+    worktreePath: Schema.String,
+    message: Schema.String,
+  },
+) {}
 
-export class ReviewSessionContextMissingError extends Data.TaggedError(
+export class ReviewSessionContextMissingError extends Schema.TaggedErrorClass<ReviewSessionContextMissingError>()(
   "ReviewSessionContextMissingError",
-)<{
-  readonly workItemId: string
-  readonly message: string
-}> {}
+  {
+    workItemId: Schema.String,
+    message: Schema.String,
+  },
+) {}
 
-export class ReviewOpenCodeError extends Data.TaggedError(
+export class ReviewOpenCodeError extends Schema.TaggedErrorClass<ReviewOpenCodeError>()(
   "ReviewOpenCodeError",
-)<{
-  readonly message: string
-  readonly worktreePath: string
-  readonly sessionId?: string
-  readonly cause?: unknown
-}> {}
+  {
+    message: Schema.String,
+    worktreePath: Schema.String,
+    sessionId: Schema.optional(Schema.String),
+    cause: Schema.optional(Schema.Defect()),
+  },
+) {}
 
 export type ReviewError =
   | ReviewWorktreeContextMissingError

--- a/packages/work-item-lifecycle/src/lib/types.ts
+++ b/packages/work-item-lifecycle/src/lib/types.ts
@@ -17,38 +17,49 @@ export type StepRunId = typeof StepRunId.Type
 
 export const makeStepRunId = (): StepRunId => StepRunId.make(`srun-${ulid()}`)
 
-export type OperationalLifecycleStep =
-  | "create_worktree"
-  | "install_dependencies"
-  | "implement"
-  | "assess_changes"
-  | "pre_commit"
-  | "review"
-  | "commit"
-  | "create_pr"
-  | "watch_pr_status_checks"
-  | "resolve_pr_merge_conflict"
-  | "investigate_pr_status_checks"
-  | "mark_pr_ready_for_review"
-  | "decide_pr_merge"
-  | "merge_pr"
-  | "close_issue"
-  | "local_cleanup"
+export const OperationalLifecycleStep = Schema.Literals([
+  "create_worktree",
+  "install_dependencies",
+  "implement",
+  "assess_changes",
+  "pre_commit",
+  "review",
+  "commit",
+  "create_pr",
+  "watch_pr_status_checks",
+  "resolve_pr_merge_conflict",
+  "investigate_pr_status_checks",
+  "mark_pr_ready_for_review",
+  "decide_pr_merge",
+  "merge_pr",
+  "close_issue",
+  "local_cleanup",
+])
+export type OperationalLifecycleStep = typeof OperationalLifecycleStep.Type
 
-export type WorkItemState =
-  | OperationalLifecycleStep
-  | "complete"
-  | "failed"
-  | "abandoned"
-  | "needs_human"
+export const TerminalWorkItemState = Schema.Literals([
+  "complete",
+  "failed",
+  "abandoned",
+  "needs_human",
+])
+export type TerminalWorkItemState = typeof TerminalWorkItemState.Type
 
-export type StepRunStatus =
-  | "queued"
-  | "running"
-  | "succeeded"
-  | "failed"
-  | "interrupted"
-  | "cancelled"
+export const WorkItemState = Schema.Union([
+  OperationalLifecycleStep,
+  TerminalWorkItemState,
+])
+export type WorkItemState = typeof WorkItemState.Type
+
+export const StepRunStatus = Schema.Literals([
+  "queued",
+  "running",
+  "succeeded",
+  "failed",
+  "interrupted",
+  "cancelled",
+])
+export type StepRunStatus = typeof StepRunStatus.Type
 
 export interface StepRunRecord {
   readonly id: StepRunId
@@ -117,16 +128,11 @@ export const WorkItemStepJob = Schema.TaggedStruct("work-item-step", {
 })
 export type WorkItemStepJob = typeof WorkItemStepJob.Type
 
-export const TERMINAL_WORK_ITEM_STATES = [
-  "complete",
-  "failed",
-  "abandoned",
-  "needs_human",
-] as const satisfies readonly WorkItemState[]
+export const TERMINAL_WORK_ITEM_STATES = TerminalWorkItemState.literals
 
 export const isTerminalWorkItemState = (
   state: WorkItemState,
-): state is (typeof TERMINAL_WORK_ITEM_STATES)[number] =>
+): state is TerminalWorkItemState =>
   (TERMINAL_WORK_ITEM_STATES as readonly string[]).includes(state)
 
 /**

--- a/packages/work-item-lifecycle/src/lib/work-item-lifecycle.ts
+++ b/packages/work-item-lifecycle/src/lib/work-item-lifecycle.ts
@@ -8,6 +8,7 @@ import {
   Exit,
   Layer,
   Option,
+  Predicate,
   Result,
   Schema,
 } from "effect"
@@ -49,7 +50,11 @@ import {
   WorkItemNotFoundError,
   WorkItemTerminalError,
 } from "./errors.js"
-import { type LifecycleStepContext, LifecycleSteps } from "./lifecycle-steps.js"
+import {
+  type LifecycleStepContext,
+  LifecycleSteps,
+  type RunHandlerError,
+} from "./lifecycle-steps.js"
 import { CurrentStepRun } from "./opencode-session-limiter.js"
 import {
   PreCommitHookFailedError,
@@ -125,7 +130,7 @@ const isActiveStepRunUniqueViolation = (error: SqlError): boolean => {
 const conciseMessage = (value: unknown, fallback: string): string =>
   formatUserFacingError(value, fallback, 500)
 
-const handlerFailureMessage = (error: unknown): string => {
+const handlerFailureMessage = (error: RunHandlerError): string => {
   if (
     error instanceof PreCommitHookFailedError ||
     error instanceof PreCommitStageError
@@ -135,8 +140,10 @@ const handlerFailureMessage = (error: unknown): string => {
   return conciseMessage(error, "Lifecycle Step handler failed")
 }
 
+type HandlerExitError = RunHandlerError | Cause.TimeoutError
+
 const closeIssueEligibilityFailure = (
-  cause: Cause.Cause<unknown>,
+  cause: Cause.Cause<HandlerExitError>,
 ): {
   readonly failureCode: string
   readonly failureMessage: string
@@ -156,7 +163,7 @@ const closeIssueEligibilityFailure = (
 }
 
 const classifyHandlerFailure = (
-  cause: Cause.Cause<unknown>,
+  cause: Cause.Cause<HandlerExitError>,
 ): {
   readonly reasonCode: string
   readonly reasonMessage: string
@@ -172,12 +179,7 @@ const classifyHandlerFailure = (
   const errorOption = Cause.findErrorOption(cause)
   if (Option.isSome(errorOption)) {
     const error = errorOption.value
-    if (
-      typeof error === "object" &&
-      error !== null &&
-      "_tag" in error &&
-      (error as { _tag: string })._tag === "TimeoutError"
-    ) {
+    if (Predicate.isTagged(error, "TimeoutError")) {
       return {
         reasonCode: STEP_RUN_REASON.timeout,
         reasonMessage:
@@ -1167,7 +1169,7 @@ export const makeWorkItemLifecycleLive = (
             readonly reason?: string
           }
         },
-        unknown
+        RunHandlerError
       > => {
         switch (step) {
           case "create_worktree":

--- a/packages/work-item-lifecycle/src/lib/worktree-names.ts
+++ b/packages/work-item-lifecycle/src/lib/worktree-names.ts
@@ -74,7 +74,7 @@ export const worktreeParentPath = (input: {
     return `${dirname(localPath)}/${repositoryStem(localPath)}-worktrees`
   }
 
-  const temporaryDirectory = (input.tmpDir ?? process.env.TMPDIR ?? "/tmp")
+  const temporaryDirectory = (input.tmpDir ?? "/tmp")
     .trim()
     .replace(/[/\\]+$/, "")
   return `${temporaryDirectory}/ready-for-agent/${sanitizeSegment(input.githubOwner)}/${sanitizeSegment(input.githubRepo)}`

--- a/packages/work-item-lifecycle/test/assess-changes-lifecycle.spec.ts
+++ b/packages/work-item-lifecycle/test/assess-changes-lifecycle.spec.ts
@@ -8,6 +8,7 @@ import { DbService, DbServiceLive } from "@ready-for-agent/db-service"
 import { QueueService } from "@ready-for-agent/queue-service"
 import { SqliteQueueServiceLive } from "@ready-for-agent/sqlite-queue-service"
 import {
+  LifecycleStepFailedError,
   LifecycleSteps,
   type LifecycleStepsShape,
   WORK_ITEM_LIFECYCLE_QUEUE,
@@ -989,7 +990,11 @@ describe("Assess Changes lifecycle routes", () => {
           Effect.gen(function* () {
             closeAttempts += 1
             if (closeAttempts === 1) {
-              return yield* Effect.fail(new Error("GitHub temporary failure"))
+              return yield* Effect.fail(
+                new LifecycleStepFailedError({
+                  message: "GitHub temporary failure",
+                }),
+              )
             }
             githubCalls.push(context.completionSummary ?? "")
           }),
@@ -997,7 +1002,11 @@ describe("Assess Changes lifecycle routes", () => {
           Effect.gen(function* () {
             cleanupAttempts += 1
             if (cleanupAttempts === 1) {
-              return yield* Effect.fail(new Error("cleanup temporary failure"))
+              return yield* Effect.fail(
+                new LifecycleStepFailedError({
+                  message: "cleanup temporary failure",
+                }),
+              )
             }
           }),
         removeWorktree: () => Effect.void,

--- a/packages/work-item-lifecycle/test/work-item-lifecycle.spec.ts
+++ b/packages/work-item-lifecycle/test/work-item-lifecycle.spec.ts
@@ -35,6 +35,7 @@ import {
   IssueNotFoundError,
   IssueNotOpenError,
   type LifecycleStepContext,
+  LifecycleStepFailedError,
   LifecycleSteps,
   type LifecycleStepsShape,
   NonTransactionalQueueError,
@@ -929,7 +930,10 @@ describe("WorkItemLifecycle", () => {
     it("derives timings across retries, interruption, and currently running work", async () => {
       const failingSteps: LifecycleStepsShape = {
         ...successfulSteps,
-        createWorktree: () => Effect.fail(new Error("first attempt")),
+        createWorktree: () =>
+          Effect.fail(
+            new LifecycleStepFailedError({ message: "first attempt" }),
+          ),
       }
 
       return Effect.runPromise(
@@ -1299,7 +1303,9 @@ describe("WorkItemLifecycle", () => {
         localCleanup: () => {
           cleanupAttempts += 1
           return cleanupAttempts === 1
-            ? Effect.fail(new Error("worktree is locked"))
+            ? Effect.fail(
+                new LifecycleStepFailedError({ message: "worktree is locked" }),
+              )
             : Effect.void
         },
       }
@@ -2258,7 +2264,10 @@ describe("WorkItemLifecycle", () => {
             _tag: "needs_human",
             reason: "Auto-merge is disabled for this repository",
           }),
-        localCleanup: () => Effect.fail(new Error("worktree locked")),
+        localCleanup: () =>
+          Effect.fail(
+            new LifecycleStepFailedError({ message: "worktree locked" }),
+          ),
       }
 
       return runWithSteps(
@@ -2786,7 +2795,11 @@ describe("WorkItemLifecycle", () => {
           Effect.gen(function* () {
             closeAttempts += 1
             if (closeAttempts === 1) {
-              return yield* Effect.fail(new Error("GitHub temporary failure"))
+              return yield* Effect.fail(
+                new LifecycleStepFailedError({
+                  message: "GitHub temporary failure",
+                }),
+              )
             }
           }),
       }
@@ -2985,7 +2998,10 @@ describe("WorkItemLifecycle", () => {
     it("records typed handler failure as Failed Step Run and leaves the pending step", () => {
       const failingSteps: LifecycleStepsShape = {
         ...successfulSteps,
-        createWorktree: () => Effect.fail(new Error("worktree path busy")),
+        createWorktree: () =>
+          Effect.fail(
+            new LifecycleStepFailedError({ message: "worktree path busy" }),
+          ),
       }
 
       return runWithSteps(
@@ -3205,7 +3221,9 @@ describe("WorkItemLifecycle", () => {
         createWorktree: () => {
           attempts += 1
           if (attempts === 1) {
-            return Effect.fail(new Error("first attempt failed"))
+            return Effect.fail(
+              new LifecycleStepFailedError({ message: "first attempt failed" }),
+            )
           }
           return Effect.succeed({
             worktreePath: "/tmp/worktrees/retry-success",
@@ -3270,7 +3288,10 @@ describe("WorkItemLifecycle", () => {
     it("retains every prior Step Run across multiple retries", () => {
       const steps: LifecycleStepsShape = {
         ...successfulSteps,
-        createWorktree: () => Effect.fail(new Error("still failing")),
+        createWorktree: () =>
+          Effect.fail(
+            new LifecycleStepFailedError({ message: "still failing" }),
+          ),
       }
 
       return runWithSteps(
@@ -3442,7 +3463,11 @@ describe("WorkItemLifecycle", () => {
       const steps: LifecycleStepsShape = {
         ...successfulSteps,
         createWorktree: () =>
-          Effect.fail(new Error("fail for concurrent retry")),
+          Effect.fail(
+            new LifecycleStepFailedError({
+              message: "fail for concurrent retry",
+            }),
+          ),
       }
 
       return runWithSteps(
@@ -3909,7 +3934,10 @@ describe("WorkItemLifecycle", () => {
     it("abandons after Failed or Interrupted runs while preserving Step Run history", () => {
       const steps: LifecycleStepsShape = {
         ...successfulSteps,
-        createWorktree: () => Effect.fail(new Error("fail then abandon")),
+        createWorktree: () =>
+          Effect.fail(
+            new LifecycleStepFailedError({ message: "fail then abandon" }),
+          ),
       }
 
       return runWithSteps(
@@ -4143,7 +4171,10 @@ describe("WorkItemLifecycle", () => {
     it("removes queued and Failed history with the Repository when nothing is Running", () => {
       const steps: LifecycleStepsShape = {
         ...successfulSteps,
-        createWorktree: () => Effect.fail(new Error("failed before removal")),
+        createWorktree: () =>
+          Effect.fail(
+            new LifecycleStepFailedError({ message: "failed before removal" }),
+          ),
       }
 
       return runWithSteps(
@@ -4363,7 +4394,10 @@ describe("WorkItemLifecycle", () => {
     it("preserves the Work Item when worktree cleanup fails", () => {
       const steps: LifecycleStepsShape = {
         ...successfulSteps,
-        removeWorktree: () => Effect.fail(new Error("worktree is locked")),
+        removeWorktree: () =>
+          Effect.fail(
+            new LifecycleStepFailedError({ message: "worktree is locked" }),
+          ),
       }
 
       return runWithSteps(
@@ -4612,7 +4646,10 @@ describe("WorkItemLifecycle", () => {
     it("rejects Retry while paused and allows it after Start", () => {
       const steps: LifecycleStepsShape = {
         ...successfulSteps,
-        createWorktree: () => Effect.fail(new Error("fail for retry")),
+        createWorktree: () =>
+          Effect.fail(
+            new LifecycleStepFailedError({ message: "fail for retry" }),
+          ),
       }
 
       return runWithSteps(
@@ -4906,7 +4943,8 @@ describe("WorkItemLifecycle", () => {
       runWithSteps(
         {
           ...successfulSteps,
-          createWorktree: () => Effect.fail(new Error("boom")),
+          createWorktree: () =>
+            Effect.fail(new LifecycleStepFailedError({ message: "boom" })),
         },
         Effect.gen(function* () {
           const lifecycle = yield* WorkItemLifecycle


### PR DESCRIPTION
## Summary

- Type `LifecycleSteps` handlers with a shared `LifecycleStepError` union instead of `unknown`
- Migrate step/orchestrator errors from `Data.TaggedError` to `Schema.TaggedErrorClass`
- Schema-model lifecycle step and state unions; collapse `LifecycleStepsLive` service provision

Closes #307

## Test plan

- [x] `bunx nx test work-item-lifecycle`
- [x] Pre-commit affected lint/typecheck/test