### PR TITLE
refactor(apps): tighten Effect boundaries

### DIFF
--- a/apps/harness/src/server/ambient-github-layer.ts
+++ b/apps/harness/src/server/ambient-github-layer.ts
@@ -1,5 +1,5 @@
-import { spawn } from "node:child_process"
-import { Effect, Layer } from "effect"
+import { Deferred, Duration, Effect, Layer, Ref } from "effect"
+import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process"
 import {
   type GitHubRepositoryUnavailableError,
   GitHubRequestError,
@@ -10,135 +10,195 @@ import {
 
 type GitHubServiceError = GitHubRepositoryUnavailableError | GitHubRequestError
 
-const resolveGhToken = (cwd: string): Promise<string> =>
-  new Promise((resolve, reject) => {
-    const child = spawn("gh", ["auth", "token"], {
-      cwd,
-      env: process.env,
-      timeout: 60_000,
-    })
-    let stdout = ""
-    let stderr = ""
-    child.stdout.setEncoding("utf8")
-    child.stderr.setEncoding("utf8")
-    child.stdout.on("data", (chunk: string) => {
-      stdout += chunk
-    })
-    child.stderr.on("data", (chunk: string) => {
-      stderr += chunk
-    })
-    child.once("error", reject)
-    child.once("close", (exitCode) => {
-      const token = stdout.trim()
-      if (exitCode === 0 && token !== "") {
-        resolve(token)
-        return
-      }
-      reject(
-        new Error(
-          stderr.trim() || "GitHub CLI did not return an authentication token",
-        ),
-      )
-    })
+const authenticationError = (cause: unknown) =>
+  new GitHubRequestError({
+    message: "Failed to resolve GitHub CLI authentication",
+    cause,
   })
 
 export const ambientGitHubLayer = (options: {
   readonly workspaceRoot: string
   readonly resolveToken?: () => Promise<string>
   readonly makeService?: (token: string) => GitHubServiceShape
-}): Layer.Layer<GitHubService> =>
-  Layer.sync(GitHubService, () => {
-    const resolveToken =
-      options.resolveToken ?? (() => resolveGhToken(options.workspaceRoot))
-    const makeService = options.makeService ?? makeGitHubServiceFromToken
-    type TokenEntry = { readonly promise: Promise<string> }
-    let cachedToken: TokenEntry | undefined
+}): Layer.Layer<
+  GitHubService,
+  never,
+  ChildProcessSpawner.ChildProcessSpawner
+> =>
+  Layer.effect(
+    GitHubService,
+    Effect.gen(function* () {
+      const spawner = yield* ChildProcessSpawner.ChildProcessSpawner
+      const makeService = options.makeService ?? makeGitHubServiceFromToken
+      const tokenCache = yield* Ref.make<
+        Deferred.Deferred<string, GitHubRequestError> | undefined
+      >(undefined)
 
-    const acquireToken = () => {
-      const source = cachedToken ?? { promise: resolveToken() }
-      cachedToken = source
-      return source.promise.then(
-        (token) => ({ source, token }),
-        (error) => {
-          if (cachedToken === source) cachedToken = undefined
-          throw error
+      const resolveGhToken = Effect.fn("AmbientGitHub.resolveGhToken")(
+        function* () {
+          const output = yield* spawner
+            .string(
+              ChildProcess.make("gh", ["auth", "token"], {
+                cwd: options.workspaceRoot,
+                stdin: "ignore",
+                stderr: "inherit",
+              }),
+            )
+            .pipe(Effect.timeout(Duration.seconds(60)))
+          const token = output.trim()
+          if (token === "") {
+            return yield* authenticationError(
+              "GitHub CLI did not return an authentication token",
+            )
+          }
+          return token
+        },
+        Effect.mapError(authenticationError),
+      )
+
+      const injectedResolveToken = options.resolveToken
+      const resolveToken =
+        injectedResolveToken === undefined
+          ? resolveGhToken
+          : Effect.fn("AmbientGitHub.resolveInjectedToken")(function* () {
+              return yield* Effect.tryPromise({
+                try: injectedResolveToken,
+                catch: authenticationError,
+              })
+            })
+
+      const acquireToken = Effect.fn("AmbientGitHub.acquireToken")(
+        function* () {
+          const candidate = yield* Deferred.make<string, GitHubRequestError>()
+          type SelectedToken = {
+            readonly source: Deferred.Deferred<string, GitHubRequestError>
+            readonly owner: boolean
+          }
+          const selected = yield* Ref.modify<
+            Deferred.Deferred<string, GitHubRequestError> | undefined,
+            SelectedToken
+          >(tokenCache, (current) =>
+            current === undefined
+              ? [{ source: candidate, owner: true }, candidate]
+              : [{ source: current, owner: false }, current],
+          )
+
+          if (selected.owner) {
+            yield* resolveToken().pipe(
+              Effect.result,
+              Effect.flatMap((result) =>
+                (result._tag === "Failure"
+                  ? Ref.update(tokenCache, (current) =>
+                      current === candidate ? undefined : current,
+                    )
+                  : Effect.void
+                ).pipe(
+                  Effect.andThen(
+                    Deferred.complete(candidate, Effect.fromResult(result)),
+                  ),
+                ),
+              ),
+              Effect.forkDetach({ startImmediately: true }),
+            )
+          }
+
+          return {
+            source: selected.source,
+            token: yield* Deferred.await(selected.source),
+          }
         },
       )
-    }
 
-    const run = <A>(
-      operation: (
-        service: GitHubServiceShape,
-      ) => Effect.Effect<A, GitHubServiceError>,
-      refreshAuthentication: boolean,
-    ): Effect.Effect<A, GitHubServiceError> =>
-      Effect.tryPromise({
-        try: acquireToken,
-        catch: (cause) =>
-          new GitHubRequestError({
-            message: "Failed to resolve GitHub CLI authentication",
-            cause,
-          }),
-      }).pipe(
-        Effect.flatMap(({ source, token }) =>
-          operation(makeService(token)).pipe(
-            Effect.catchTag("GitHubRequestError", (error) => {
-              if (!refreshAuthentication || error.statusCode !== 401) {
-                return Effect.fail(error)
-              }
-              if (cachedToken === source) cachedToken = undefined
-              return run(operation, false)
-            }),
+      const run = Effect.fn("AmbientGitHub.runAuthenticated")(function* <A>(
+        operation: (
+          service: GitHubServiceShape,
+        ) => Effect.Effect<A, GitHubServiceError>,
+      ) {
+        const { source, token } = yield* acquireToken()
+        const first = yield* Effect.result(operation(makeService(token)))
+        if (
+          first._tag !== "Failure" ||
+          first.failure._tag !== "GitHubRequestError" ||
+          first.failure.statusCode !== 401
+        ) {
+          return yield* Effect.fromResult(first)
+        }
+
+        yield* Ref.update(tokenCache, (current) =>
+          current === source ? undefined : current,
+        )
+        const refreshed = yield* acquireToken()
+        return yield* operation(makeService(refreshed.token))
+      })
+
+      const authenticated = <A>(
+        operation: (
+          service: GitHubServiceShape,
+        ) => Effect.Effect<A, GitHubServiceError>,
+      ): Effect.Effect<A, GitHubServiceError> => run(operation)
+
+      return {
+        getOpenPullRequestNumber: Effect.fn(
+          "AmbientGitHub.getOpenPullRequestNumber",
+        )((repository, headRefName) =>
+          authenticated((service) =>
+            service.getOpenPullRequestNumber(repository, headRefName),
           ),
         ),
-      )
-
-    const authenticated = <A>(
-      operation: (
-        service: GitHubServiceShape,
-      ) => Effect.Effect<A, GitHubServiceError>,
-    ): Effect.Effect<A, GitHubServiceError> => run(operation, true)
-
-    return {
-      getOpenPullRequestNumber: (repository, headRefName) =>
-        authenticated((service) =>
-          service.getOpenPullRequestNumber(repository, headRefName),
-        ),
-      getPullRequestCheckStatus: (repository, headRefName) =>
-        authenticated((service) =>
-          service.getPullRequestCheckStatus(repository, headRefName),
-        ),
-      getPrStatusCheckDiagnostics: (repository, checks, options) =>
-        authenticated((service) =>
-          service.getPrStatusCheckDiagnostics(repository, checks, options),
-        ),
-      getPullRequestLifecycleStatus: (repository, headRefName) =>
-        authenticated((service) =>
-          service.getPullRequestLifecycleStatus(repository, headRefName),
-        ),
-      markPullRequestReadyForReview: (repository, headRefName) =>
-        authenticated((service) =>
-          service.markPullRequestReadyForReview(repository, headRefName),
-        ),
-      mergePullRequest: (repository, headRefName) =>
-        authenticated((service) =>
-          service.mergePullRequest(repository, headRefName),
-        ),
-      ensureIssueCompletedWithSummary: (
-        repository,
-        issueNumber,
-        workItemId,
-        summaryMarkdown,
-      ) =>
-        authenticated((service) =>
-          service.ensureIssueCompletedWithSummary(
-            repository,
-            issueNumber,
-            workItemId,
-            summaryMarkdown,
+        getPullRequestCheckStatus: Effect.fn(
+          "AmbientGitHub.getPullRequestCheckStatus",
+        )((repository, headRefName) =>
+          authenticated((service) =>
+            service.getPullRequestCheckStatus(repository, headRefName),
           ),
         ),
-      listReadyIssues: (repository) =>
-        authenticated((service) => service.listReadyIssues(repository)),
-    } satisfies GitHubServiceShape
-  })
+        getPrStatusCheckDiagnostics: Effect.fn(
+          "AmbientGitHub.getPrStatusCheckDiagnostics",
+        )((repository, checks, requestOptions) =>
+          authenticated((service) =>
+            service.getPrStatusCheckDiagnostics(
+              repository,
+              checks,
+              requestOptions,
+            ),
+          ),
+        ),
+        getPullRequestLifecycleStatus: Effect.fn(
+          "AmbientGitHub.getPullRequestLifecycleStatus",
+        )((repository, headRefName) =>
+          authenticated((service) =>
+            service.getPullRequestLifecycleStatus(repository, headRefName),
+          ),
+        ),
+        markPullRequestReadyForReview: Effect.fn(
+          "AmbientGitHub.markPullRequestReadyForReview",
+        )((repository, headRefName) =>
+          authenticated((service) =>
+            service.markPullRequestReadyForReview(repository, headRefName),
+          ),
+        ),
+        mergePullRequest: Effect.fn("AmbientGitHub.mergePullRequest")(
+          (repository, headRefName) =>
+            authenticated((service) =>
+              service.mergePullRequest(repository, headRefName),
+            ),
+        ),
+        ensureIssueCompletedWithSummary: Effect.fn(
+          "AmbientGitHub.ensureIssueCompletedWithSummary",
+        )((repository, issueNumber, workItemId, summaryMarkdown) =>
+          authenticated((service) =>
+            service.ensureIssueCompletedWithSummary(
+              repository,
+              issueNumber,
+              workItemId,
+              summaryMarkdown,
+            ),
+          ),
+        ),
+        listReadyIssues: Effect.fn("AmbientGitHub.listReadyIssues")(
+          (repository) =>
+            authenticated((service) => service.listReadyIssues(repository)),
+        ),
+      } satisfies GitHubServiceShape
+    }),
+  )

--- a/apps/harness/src/server/application-config.ts
+++ b/apps/harness/src/server/application-config.ts
@@ -1,0 +1,86 @@
+import { homedir } from "node:os"
+import {
+  Config,
+  ConfigProvider,
+  Context,
+  Effect,
+  Layer,
+  Option,
+  Schema,
+} from "effect"
+
+const RequiredString = Schema.String.pipe(
+  Schema.check(
+    Schema.makeFilter((value: string) =>
+      value.trim() === "" ? "Expected a non-empty string" : undefined,
+    ),
+  ),
+)
+
+const Port = Schema.FiniteFromString.pipe(
+  Schema.check(Schema.isInt()),
+  Schema.check(Schema.isBetween({ minimum: 1, maximum: 65_535 })),
+)
+
+const environmentValues = (
+  environment: Partial<Record<string, string | undefined>>,
+): Record<string, string> =>
+  Object.fromEntries(
+    Object.entries(environment).filter(
+      (entry): entry is [string, string] => entry[1] !== undefined,
+    ),
+  )
+
+export const environmentConfigLayer = (
+  environment: Partial<Record<string, string | undefined>>,
+) =>
+  ConfigProvider.layer(
+    ConfigProvider.fromUnknown(environmentValues(environment)),
+  )
+
+class ApplicationConfig extends Context.Service<
+  ApplicationConfig,
+  {
+    readonly keymaxxerSidecarUrl: string | undefined
+    readonly hostToolCwd: string
+  }
+>()("ready-for-agent/harness/ApplicationConfig") {
+  static readonly layer = Layer.effect(
+    ApplicationConfig,
+    Effect.gen(function* () {
+      const enabledValue = yield* Config.option(
+        Config.string("KEYMAXXER_ENABLED"),
+      )
+      const enabled =
+        Option.getOrUndefined(enabledValue)?.trim().toLowerCase() !== "false"
+      const sidecarUrl = enabled
+        ? yield* Config.schema(RequiredString, "KEYMAXXER_SIDECAR_URL")
+        : undefined
+      const home = yield* Config.option(Config.string("HOME"))
+
+      return {
+        keymaxxerSidecarUrl: sidecarUrl?.trim(),
+        hostToolCwd: Option.getOrUndefined(home)?.trim() || homedir(),
+      }
+    }),
+  )
+}
+
+export const loadApplicationConfig = (
+  environment: Partial<Record<string, string | undefined>>,
+) =>
+  ApplicationConfig.pipe(
+    Effect.provide(
+      ApplicationConfig.layer.pipe(
+        Layer.provide(environmentConfigLayer(environment)),
+      ),
+    ),
+  )
+
+export const loadPort = (
+  environment: Partial<Record<string, string | undefined>>,
+) =>
+  Config.option(Config.schema(Port, "PORT")).pipe(
+    Effect.map(Option.getOrElse(() => 4200)),
+    Effect.provide(environmentConfigLayer(environment)),
+  )

--- a/apps/harness/src/server/application.server.ts
+++ b/apps/harness/src/server/application.server.ts
@@ -1,5 +1,4 @@
 import "@tanstack/react-start/server-only"
-import { homedir } from "node:os"
 import * as BunChildProcessSpawner from "@effect/platform-bun/BunChildProcessSpawner"
 import * as BunFileSystem from "@effect/platform-bun/BunFileSystem"
 import * as BunPath from "@effect/platform-bun/BunPath"
@@ -21,29 +20,12 @@ import {
 } from "@ready-for-agent/work-item-lifecycle"
 import type { ApplicationRequestContext } from "../application-request-context.js"
 import { ambientGitHubLayer } from "./ambient-github-layer.js"
+import {
+  environmentConfigLayer,
+  loadApplicationConfig,
+} from "./application-config.js"
 import { JobWorkerLive } from "./job-worker.js"
 import { keymaxxerGitHubLayer } from "./keymaxxer-github-layer.js"
-
-/**
- * Directory for host tools that need a cwd but are not scoped to a Repository
- * or Work Item. Never derived from compiled module locations.
- */
-const hostToolCwd = () => process.env.HOME?.trim() || homedir()
-
-const keymaxxerSidecarUrlFromEnvironment = (
-  environment: Partial<Record<string, string | undefined>>,
-) => {
-  if (environment.KEYMAXXER_ENABLED?.trim().toLowerCase() === "false") {
-    return undefined
-  }
-  const sidecarUrl = environment.KEYMAXXER_SIDECAR_URL?.trim()
-  if (sidecarUrl === undefined || sidecarUrl === "") {
-    throw new Error(
-      "KEYMAXXER_SIDECAR_URL is required (capability URL from the Keymaxxer Sidecar bootstrap line)",
-    )
-  }
-  return sidecarUrl
-}
 
 export interface Application {
   readonly context: ApplicationRequestContext
@@ -58,16 +40,23 @@ export const createApplication = async (
   environment: Partial<Record<string, string | undefined>> = process.env,
   options: CreateApplicationOptions = {},
 ): Promise<Application> => {
-  const sidecarUrl = keymaxxerSidecarUrlFromEnvironment(environment)
+  const configLayer = environmentConfigLayer(environment)
+  const config = await Effect.runPromise(loadApplicationConfig(environment))
+  const sidecarUrl = config.keymaxxerSidecarUrl
   const databaseLayer = DbServiceLive.pipe(Layer.provideMerge(DatabaseLive))
   const keymaxxerLayer =
     sidecarUrl === undefined
       ? disabledKeymaxxerLayer
       : sidecarKeymaxxerLayer(sidecarUrl)
-  const toolCwd = hostToolCwd()
+  const toolCwd = config.hostToolCwd
+  const opencodePlatformLayer = BunChildProcessSpawner.layer.pipe(
+    Layer.provideMerge(Layer.merge(BunFileSystem.layer, BunPath.layer)),
+  )
   const githubLayer =
     sidecarUrl === undefined
-      ? ambientGitHubLayer({ workspaceRoot: toolCwd })
+      ? ambientGitHubLayer({ workspaceRoot: toolCwd }).pipe(
+          Layer.provide(opencodePlatformLayer),
+        )
       : keymaxxerGitHubLayer({ workspaceRoot: toolCwd }).pipe(
           Layer.provide(keymaxxerLayer),
         )
@@ -77,9 +66,6 @@ export const createApplication = async (
   )
   const queueLayer = SqliteQueueServiceLive.pipe(
     Layer.provideMerge(databaseLayer),
-  )
-  const opencodePlatformLayer = BunChildProcessSpawner.layer.pipe(
-    Layer.provideMerge(Layer.merge(BunFileSystem.layer, BunPath.layer)),
   )
   const opencodeLayer = Opencode.layer({
     ...(sidecarUrl === undefined ? {} : { keymaxxerMcpUrl: sidecarUrl }),
@@ -100,7 +86,7 @@ export const createApplication = async (
     Layer.provideMerge(keymaxxerLayer),
   )
   const loggingLayer = Logger.layer([Logger.consolePretty({ colors: false })])
-  const appLayer =
+  const applicationServices =
     options.startWorker === false
       ? Layer.mergeAll(
           reconcilerLayer,
@@ -119,6 +105,7 @@ export const createApplication = async (
           lifecycleLayer,
           loggingLayer,
         )
+  const appLayer = applicationServices.pipe(Layer.provide(configLayer))
   const runtime = ManagedRuntime.make(appLayer)
 
   try {

--- a/apps/harness/src/server/job-worker.ts
+++ b/apps/harness/src/server/job-worker.ts
@@ -6,6 +6,7 @@ import {
   Layer,
   Option,
   Ref,
+  Result,
   Schedule,
   Schema,
 } from "effect"
@@ -83,17 +84,18 @@ const RefreshRepositoryJob = Schema.TaggedStruct("refresh-repository", {
 
 const PollingAutoHealJob = Schema.TaggedStruct("polling-auto-heal", {})
 
-export const enqueueRefreshRepositoryJob = (repositoryId: RepositoryId) =>
-  Effect.gen(function* () {
-    const queue = yield* QueueService
-    const payload = yield* Schema.decodeUnknownEffect(RefreshRepositoryJob)({
-      _tag: "refresh-repository",
-      repositoryId,
-    })
-    return yield* queue.enqueue(ISSUE_REFRESH_QUEUE, payload, {
-      retryLimit: JOB_RECOVERY_RETRY_LIMIT,
-    })
+export const enqueueRefreshRepositoryJob = Effect.fn(
+  "JobWorker.enqueueRefreshRepositoryJob",
+)(function* (repositoryId: RepositoryId) {
+  const queue = yield* QueueService
+  const payload = yield* Schema.decodeUnknownEffect(RefreshRepositoryJob)({
+    _tag: "refresh-repository",
+    repositoryId,
   })
+  return yield* queue.enqueue(ISSUE_REFRESH_QUEUE, payload, {
+    retryLimit: JOB_RECOVERY_RETRY_LIMIT,
+  })
+})
 
 /** Move pre-split Refresh Jobs off the lifecycle queue into the polling lane. */
 export const transferPersistedRefreshJobs = Effect.gen(function* () {
@@ -103,21 +105,19 @@ export const transferPersistedRefreshJobs = Effect.gen(function* () {
     ISSUE_REFRESH_QUEUE,
     REFRESH_REPOSITORY_TAG,
   )
-})
+}).pipe(Effect.withSpan("JobWorker.transferPersistedRefreshJobs"))
 
-const repositoryHasGitHubCredential = (
-  githubOwner: string,
-  githubRepo: string,
-) =>
-  Effect.gen(function* () {
-    const keymaxxer = yield* KeymaxxerService
-    if (keymaxxer.enabled === false) return true
-    const credential = yield* keymaxxer.findSecret({
-      provider: "github",
-      account: `${githubOwner}/${githubRepo}`,
-    })
-    return credential !== null
+const repositoryHasGitHubCredential = Effect.fn(
+  "JobWorker.repositoryHasGitHubCredential",
+)(function* (githubOwner: string, githubRepo: string) {
+  const keymaxxer = yield* KeymaxxerService
+  if (keymaxxer.enabled === false) return true
+  const credential = yield* keymaxxer.findSecret({
+    provider: "github",
+    account: `${githubOwner}/${githubRepo}`,
   })
+  return credential !== null
+})
 
 const listCredentialedRepositoryIds = Effect.gen(function* () {
   const db = yield* DbService
@@ -135,31 +135,33 @@ const listCredentialedRepositoryIds = Effect.gen(function* () {
   return credentialed
 })
 
-const runPollingAutoHeal = (sampleDelay: Effect.Effect<Duration.Duration>) =>
-  Effect.gen(function* () {
-    const credentialedRepositoryIds = yield* listCredentialedRepositoryIds
-    yield* repairPollingSchedules({
-      credentialedRepositoryIds,
-      sampleDelay,
-    })
+const runPollingAutoHeal = Effect.fn("JobWorker.runPollingAutoHeal")(function* (
+  sampleDelay: Effect.Effect<Duration.Duration>,
+) {
+  const credentialedRepositoryIds = yield* listCredentialedRepositoryIds
+  yield* repairPollingSchedules({
+    credentialedRepositoryIds,
+    sampleDelay,
   })
+})
 
-const refreshRepository = (repositoryId: RepositoryId) =>
-  Effect.gen(function* () {
-    const db = yield* DbService
-    const reconciler = yield* IssueReconciler
-    const repositories = yield* db.listRepositories
-    const repository = repositories.find(({ id }) => id === repositoryId)
+const refreshRepository = Effect.fn("JobWorker.refreshRepository")(function* (
+  repositoryId: RepositoryId,
+) {
+  const db = yield* DbService
+  const reconciler = yield* IssueReconciler
+  const repositories = yield* db.listRepositories
+  const repository = repositories.find(({ id }) => id === repositoryId)
 
-    if (repository === undefined) {
-      return yield* new RepositoryNotFoundError({ repositoryId })
-    }
+  if (repository === undefined) {
+    return yield* new RepositoryNotFoundError({ repositoryId })
+  }
 
-    const summary = yield* reconciler.reconcile(repository)
-    yield* syncNeedsHumanMergeHandoffs(repositoryId)
-    yield* db.notifyIssuesChanged(repositoryId)
-    return summary
-  })
+  const summary = yield* reconciler.reconcile(repository)
+  yield* syncNeedsHumanMergeHandoffs(repositoryId)
+  yield* db.notifyIssuesChanged(repositoryId)
+  return summary
+})
 
 export interface JobWorkerOptions {
   readonly idlePollInterval?: Duration.Duration
@@ -215,13 +217,9 @@ const claimRefreshJob = (
     )
   })
 
-type AttemptResult =
-  | { readonly _tag: "Failure"; readonly failure: unknown }
-  | { readonly _tag: "Success"; readonly success: unknown }
-
-const finalizeManualRefresh = (
+const finalizeManualRefresh = <A, E>(
   jobId: string,
-  result: AttemptResult,
+  result: Result.Result<A, E>,
   repositoryId: RepositoryId,
 ) =>
   Effect.gen(function* () {
@@ -238,9 +236,9 @@ const finalizeManualRefresh = (
     }
   })
 
-const finalizePollingAutoHeal = (
+const finalizePollingAutoHeal = <A, E>(
   jobId: string,
-  result: AttemptResult,
+  result: Result.Result<A, E>,
   sampleBackoff: Effect.Effect<Duration.Duration>,
 ) =>
   Effect.gen(function* () {
@@ -257,10 +255,10 @@ const finalizePollingAutoHeal = (
     yield* queue.acknowledge(jobId)
   })
 
-const finalizeScheduledRefresh = (
+const finalizeScheduledRefresh = <A, E>(
   jobId: string,
   repositoryId: RepositoryId,
-  result: AttemptResult,
+  result: Result.Result<A, E>,
   sampleDelay: Effect.Effect<Duration.Duration>,
 ) =>
   Effect.gen(function* () {
@@ -386,12 +384,7 @@ const claimAndRunRefreshJob = (
       yield* finalizeScheduledRefresh(
         job.jobId,
         job.payload.repositoryId,
-        {
-          _tag: "Failure",
-          failure: new RepositoryNotFoundError({
-            repositoryId: job.payload.repositoryId,
-          }),
-        },
+        Result.succeed(undefined),
         sampleDelay,
       )
       return "busy" as const
@@ -405,7 +398,7 @@ const claimAndRunRefreshJob = (
       yield* finalizeScheduledRefresh(
         job.jobId,
         job.payload.repositoryId,
-        { _tag: "Failure", failure: "Repository uncredentialed" },
+        Result.succeed(undefined),
         sampleDelay,
       )
       return "busy" as const
@@ -528,40 +521,40 @@ const runLifecycleClaimLoop = (
  * Host lifecycle and Issue polling workers as independent fibers that share one
  * generation token so HMR retires both together.
  */
-export const runJobWorker = (options: JobWorkerOptions = {}) =>
-  Effect.gen(function* () {
-    const generation = nextWorkerGeneration()
-    const idlePollInterval = options.idlePollInterval ?? JOB_IDLE_POLL_INTERVAL
-    const visibilityTimeout =
-      options.visibilityTimeout ?? JOB_VISIBILITY_TIMEOUT
-    const orphanRecoveryInterval =
-      options.orphanRecoveryInterval ?? ORPHAN_RECOVERY_INTERVAL
-    const sampleDelay = options.samplePollingDelay ?? sampleIssuePollingDelay
-    const sampleAutoHealBackoff =
-      options.sampleAutoHealBackoff ?? Effect.succeed(POLLING_AUTO_HEAL_BACKOFF)
+export const runJobWorker = Effect.fn("JobWorker.runJobWorker")(function* (
+  options: JobWorkerOptions = {},
+) {
+  const generation = nextWorkerGeneration()
+  const idlePollInterval = options.idlePollInterval ?? JOB_IDLE_POLL_INTERVAL
+  const visibilityTimeout = options.visibilityTimeout ?? JOB_VISIBILITY_TIMEOUT
+  const orphanRecoveryInterval =
+    options.orphanRecoveryInterval ?? ORPHAN_RECOVERY_INTERVAL
+  const sampleDelay = options.samplePollingDelay ?? sampleIssuePollingDelay
+  const sampleAutoHealBackoff =
+    options.sampleAutoHealBackoff ?? Effect.succeed(POLLING_AUTO_HEAL_BACKOFF)
 
-    yield* Effect.all(
-      [
-        runLifecycleClaimLoop(
-          generation,
-          idlePollInterval,
+  yield* Effect.all(
+    [
+      runLifecycleClaimLoop(
+        generation,
+        idlePollInterval,
+        visibilityTimeout,
+        orphanRecoveryInterval,
+      ),
+      runQueuePollLoop(
+        generation,
+        idlePollInterval,
+        claimAndRunRefreshJob(
           visibilityTimeout,
-          orphanRecoveryInterval,
+          sampleDelay,
+          sampleAutoHealBackoff,
         ),
-        runQueuePollLoop(
-          generation,
-          idlePollInterval,
-          claimAndRunRefreshJob(
-            visibilityTimeout,
-            sampleDelay,
-            sampleAutoHealBackoff,
-          ),
-          "Issue polling job queue",
-        ),
-      ],
-      { concurrency: "unbounded", discard: true },
-    )
-  })
+        "Issue polling job queue",
+      ),
+    ],
+    { concurrency: "unbounded", discard: true },
+  )
+})
 
 /**
  * Start the polling runtime and durably enqueue one high-priority Polling
@@ -570,30 +563,31 @@ export const runJobWorker = (options: JobWorkerOptions = {}) =>
  * Before accepting claims, interrupt any Step Runs still marked `running` from a
  * prior process generation so Jobs UI cannot show zombie RUNNING work.
  */
-export const startJobWorker = (options: JobWorkerOptions = {}) =>
-  Effect.gen(function* () {
-    const lifecycle = yield* WorkItemLifecycle
-    yield* lifecycle.interruptRunningStepRunsFromPriorWorker.pipe(
-      Effect.tap((count) =>
-        count > 0
-          ? Effect.logWarning(
-              "Interrupted Step Runs left running by a prior harness process",
-              { count },
-            )
-          : Effect.void,
+export const startJobWorker = Effect.fn("JobWorker.startJobWorker")(function* (
+  options: JobWorkerOptions = {},
+) {
+  const lifecycle = yield* WorkItemLifecycle
+  yield* lifecycle.interruptRunningStepRunsFromPriorWorker.pipe(
+    Effect.tap((count) =>
+      count > 0
+        ? Effect.logWarning(
+            "Interrupted Step Runs left running by a prior harness process",
+            { count },
+          )
+        : Effect.void,
+    ),
+    Effect.catch((error) =>
+      Effect.logError(
+        "Failed to interrupt prior-process running Step Runs on startup",
+        { error: formatLogError(error) },
       ),
-      Effect.catch((error) =>
-        Effect.logError(
-          "Failed to interrupt prior-process running Step Runs on startup",
-          { error: formatLogError(error) },
-        ),
-      ),
-    )
-    yield* transferPersistedRefreshJobs
-    yield* enqueuePollingAutoHealJob
-    yield* runJobWorker(options).pipe(
-      Effect.forkScoped({ startImmediately: true }),
-    )
-  })
+    ),
+  )
+  yield* transferPersistedRefreshJobs
+  yield* enqueuePollingAutoHealJob
+  yield* runJobWorker(options).pipe(
+    Effect.forkScoped({ startImmediately: true }),
+  )
+})
 
 export const JobWorkerLive = Layer.effectDiscard(startJobWorker())

--- a/apps/harness/src/server/keymaxxer-github-layer.ts
+++ b/apps/harness/src/server/keymaxxer-github-layer.ts
@@ -12,34 +12,58 @@ import {
 } from "@ready-for-agent/github-service"
 import { KeymaxxerService } from "@ready-for-agent/keymaxxer-service"
 
+const PositiveInt = Schema.Int.pipe(Schema.check(Schema.isGreaterThan(0)))
+const NonNegativeInt = Schema.Int.pipe(
+  Schema.check(Schema.isGreaterThanOrEqualTo(0)),
+)
+const RequiredString = Schema.String.pipe(
+  Schema.check(
+    Schema.makeFilter((value: string) =>
+      value.trim() === "" ? "Expected a non-empty string" : undefined,
+    ),
+  ),
+)
+const UrlString = Schema.String.pipe(
+  Schema.check(
+    Schema.makeFilter((value: string) => {
+      try {
+        new URL(value)
+        return undefined
+      } catch {
+        return "Invalid URL"
+      }
+    }),
+  ),
+)
+
 const SerializedIssue = Schema.Struct({
-  number: Schema.Finite,
-  title: Schema.String,
+  number: PositiveInt,
+  title: RequiredString,
   body: Schema.String,
-  url: Schema.String,
-  createdAt: Schema.String,
+  url: UrlString,
+  createdAt: Schema.DateFromString,
   state: Schema.Literals(["OPEN", "CLOSED"]),
   hierarchySupported: Schema.Boolean,
   hasChildren: Schema.Boolean,
-  parentPosition: Schema.NullOr(Schema.Finite),
+  parentPosition: Schema.NullOr(NonNegativeInt),
   parent: Schema.NullOr(
     Schema.Struct({
-      number: Schema.Finite,
-      url: Schema.String,
+      number: PositiveInt,
+      url: UrlString,
       state: Schema.Literals(["OPEN", "CLOSED"]),
       isReadyLabeled: Schema.Boolean,
     }),
   ),
   blockedBy: Schema.Array(
     Schema.Struct({
-      number: Schema.Finite,
-      url: Schema.String,
+      number: PositiveInt,
+      url: UrlString,
     }),
   ),
   closingPullRequests: Schema.Array(
     Schema.Struct({
-      number: Schema.Finite,
-      repository: Schema.String,
+      number: PositiveInt,
+      repository: RequiredString,
       state: Schema.Literals(["OPEN", "MERGED", "CLOSED"]),
       isDraft: Schema.Boolean,
     }),
@@ -144,70 +168,11 @@ const parseIssues = (
   stdout: string,
   repository: { owner: string; name: string },
 ): Effect.Effect<readonly ReadyLabeledIssue[], GitHubRequestError> =>
-  Effect.try({
-    try: () => JSON.parse(stdout) as unknown,
-    catch: () => requestError(repository, "list Ready-labeled Issues"),
-  }).pipe(
-    Effect.flatMap((value) =>
-      Schema.decodeUnknownEffect(SerializedIssues)(value).pipe(
-        Effect.mapError(() =>
-          requestError(repository, "list Ready-labeled Issues"),
-        ),
-      ),
-    ),
-    Effect.flatMap((issues) =>
-      Effect.try({
-        try: () =>
-          issues.map((issue) => {
-            if (!Number.isSafeInteger(issue.number) || issue.number <= 0) {
-              throw new Error("Invalid Issue number")
-            }
-            if (issue.title.trim() === "") {
-              throw new Error("Invalid Issue title")
-            }
-            const createdAt = new Date(issue.createdAt)
-            if (Number.isNaN(createdAt.getTime())) {
-              throw new Error("Invalid Issue creation time")
-            }
-            new URL(issue.url)
-            if (issue.parent !== null) {
-              if (
-                !Number.isSafeInteger(issue.parent.number) ||
-                issue.parent.number <= 0
-              ) {
-                throw new Error("Invalid parent Issue number")
-              }
-              new URL(issue.parent.url)
-            }
-            if (
-              issue.parentPosition !== null &&
-              (!Number.isSafeInteger(issue.parentPosition) ||
-                issue.parentPosition < 0)
-            ) {
-              throw new Error("Invalid parent position")
-            }
-            for (const dependency of issue.blockedBy) {
-              if (
-                !Number.isSafeInteger(dependency.number) ||
-                dependency.number <= 0
-              ) {
-                throw new Error("Invalid dependency Issue number")
-              }
-              new URL(dependency.url)
-            }
-            for (const pullRequest of issue.closingPullRequests) {
-              if (
-                !Number.isSafeInteger(pullRequest.number) ||
-                pullRequest.number <= 0 ||
-                pullRequest.repository.trim() === ""
-              ) {
-                throw new Error("Invalid closing pull request identity")
-              }
-            }
-            return { ...issue, createdAt }
-          }),
-        catch: () => requestError(repository, "list Ready-labeled Issues"),
-      }),
+  Schema.decodeUnknownEffect(Schema.fromJsonString(SerializedIssues))(
+    stdout,
+  ).pipe(
+    Effect.mapError(() =>
+      requestError(repository, "list Ready-labeled Issues"),
     ),
   )
 
@@ -218,29 +183,35 @@ export const keymaxxerGitHubLayer = (options: {
     GitHubService,
     Effect.gen(function* () {
       const keymaxxer = yield* KeymaxxerService
-      const ensureToken = (repository: { owner: string; name: string }) =>
-        keymaxxer.findSecret({
-          provider: "github",
-          account: `${repository.owner}/${repository.name}`,
-        })
-      const runGitHubCommand = (tokenName: string, command: string) =>
-        keymaxxer.runWithSecrets({
-          command: `GITHUB_TOKEN="$${tokenName}" ${command}`,
-          cwd: options.workspaceRoot,
-          secrets: [tokenName],
-          timeoutMs: 60_000,
-        })
-      const runGitHubBin = (
-        tokenName: string,
-        operation: GitHubHelperOperation,
-        args: readonly string[],
-      ) =>
-        runGitHubCommand(
-          tokenName,
-          formatGitHubHelperShellCommand(
-            resolveGitHubHelperChildSpawn({ operation, args }),
+      const ensureToken = Effect.fn("KeymaxxerGitHub.ensureToken")(
+        (repository: { owner: string; name: string }) =>
+          keymaxxer.findSecret({
+            provider: "github",
+            account: `${repository.owner}/${repository.name}`,
+          }),
+      )
+      const runGitHubCommand = Effect.fn("KeymaxxerGitHub.runCommand")(
+        (tokenName: string, command: string) =>
+          keymaxxer.runWithSecrets({
+            command: `GITHUB_TOKEN="$${tokenName}" ${command}`,
+            cwd: options.workspaceRoot,
+            secrets: [tokenName],
+            timeoutMs: 60_000,
+          }),
+      )
+      const runGitHubBin = Effect.fn("KeymaxxerGitHub.runHelper")(
+        (
+          tokenName: string,
+          operation: GitHubHelperOperation,
+          args: readonly string[],
+        ) =>
+          runGitHubCommand(
+            tokenName,
+            formatGitHubHelperShellCommand(
+              resolveGitHubHelperChildSpawn({ operation, args }),
+            ),
           ),
-        )
+      )
 
       const service: GitHubServiceShape = {
         getOpenPullRequestNumber: (repository, headRefName) =>

--- a/apps/harness/src/server/production-lifecycle.ts
+++ b/apps/harness/src/server/production-lifecycle.ts
@@ -2,7 +2,7 @@ import { spawn } from "node:child_process"
 import { resolve } from "node:path"
 import { createInterface } from "node:readline"
 import { fileURLToPath } from "node:url"
-import { Effect } from "effect"
+import { Effect, Layer } from "effect"
 import { DatabaseLive, runConfiguredMigrations } from "@ready-for-agent/db"
 import {
   KEYMAXXER_SIDECAR_URL_PREFIX,
@@ -12,6 +12,7 @@ import {
 } from "@ready-for-agent/keymaxxer-service"
 import type { ApplicationRequestContext } from "../application-request-context.js"
 import { type Application, createApplication } from "./application.server.js"
+import { environmentConfigLayer, loadPort } from "./application-config.js"
 import {
   browserOpenCommand,
   hasNoOpenFlag,
@@ -133,11 +134,13 @@ export const resolveKeymaxxerMode = (
 }
 
 const applyProductionMigrations = async (
-  _environment: NodeJS.ProcessEnv = process.env,
+  environment: NodeJS.ProcessEnv = process.env,
 ): Promise<void> => {
   await Effect.runPromise(
     runConfiguredMigrations().pipe(
-      Effect.provide(DatabaseLive),
+      Effect.provide(
+        DatabaseLive.pipe(Layer.provide(environmentConfigLayer(environment))),
+      ),
       Effect.tap(() =>
         Effect.sync(() => {
           console.info("Database migrations applied")
@@ -276,8 +279,9 @@ const defaultInstallSignalHandlers = (
 }
 
 /**
- * One production owner for database preparation, Keymaxxer Sidecar
- * coordination, application runtime, HTTP listen, browser open, and cleanup.
+ * Intentional Promise host boundary for Bun HTTP, process signals, detached
+ * browser launch, owned Sidecar bootstrap, dynamic imports, and shutdown.
+ * Effect owns the application runtime and migrations inside this outer host.
  */
 export const startProductionLifecycle = async (
   options: ProductionLifecycleOptions = {},
@@ -285,7 +289,7 @@ export const startProductionLifecycle = async (
   const environment = { ...(options.environment ?? process.env) }
   const argv = options.argv ?? process.argv
   const hostname = options.hostname ?? "127.0.0.1"
-  const port = options.port ?? Number(environment.PORT ?? 4200)
+  const port = options.port ?? (await Effect.runPromise(loadPort(environment)))
   const clientDirectory = options.clientDirectory ?? defaultClientDirectory
   const serverEntryPath = options.serverEntryPath ?? defaultServerEntryPath
   const embeddedClientAssets = options.embeddedClientAssets

--- a/apps/harness/test/ambient-github-layer.test.ts
+++ b/apps/harness/test/ambient-github-layer.test.ts
@@ -1,4 +1,7 @@
-import { Effect } from "effect"
+import * as BunChildProcessSpawner from "@effect/platform-bun/BunChildProcessSpawner"
+import * as BunFileSystem from "@effect/platform-bun/BunFileSystem"
+import * as BunPath from "@effect/platform-bun/BunPath"
+import { Effect, Layer } from "effect"
 import {
   GitHubRequestError,
   GitHubService,
@@ -6,6 +9,10 @@ import {
 } from "@ready-for-agent/github-service"
 import { ambientGitHubLayer } from "../src/server/ambient-github-layer.js"
 import { expect, test } from "bun:test"
+
+const processLayer = BunChildProcessSpawner.layer.pipe(
+  Layer.provideMerge(Layer.merge(BunFileSystem.layer, BunPath.layer)),
+)
 
 const serviceWithList = (
   listReadyIssues: GitHubServiceShape["listReadyIssues"],
@@ -40,7 +47,7 @@ test("ambient GitHub authentication is resolved once", async () => {
       const github = yield* GitHubService
       yield* github.listReadyIssues({ owner: "acme", name: "one" })
       yield* github.listReadyIssues({ owner: "acme", name: "two" })
-    }).pipe(Effect.provide(layer)),
+    }).pipe(Effect.provide(layer), Effect.provide(processLayer)),
   )
 
   expect(resolutions).toBe(1)
@@ -70,7 +77,7 @@ test("ambient GitHub authentication refreshes once after a 401", async () => {
     Effect.gen(function* () {
       const github = yield* GitHubService
       yield* github.listReadyIssues({ owner: "acme", name: "widgets" })
-    }).pipe(Effect.provide(layer)),
+    }).pipe(Effect.provide(layer), Effect.provide(processLayer)),
   )
 
   expect(resolutions).toBe(2)
@@ -115,7 +122,7 @@ test("concurrent 401 responses share one refreshed token", async () => {
         ],
         { concurrency: "unbounded" },
       )
-    }).pipe(Effect.provide(layer)),
+    }).pipe(Effect.provide(layer), Effect.provide(processLayer)),
   )
 
   expect(expiredCalls).toBe(2)
@@ -147,8 +154,34 @@ test("ambient GitHub authentication is not refreshed after a 403", async () => {
       return yield* Effect.exit(
         github.listReadyIssues({ owner: "acme", name: "widgets" }),
       )
-    }).pipe(Effect.provide(layer)),
+    }).pipe(Effect.provide(layer), Effect.provide(processLayer)),
   )
 
   expect(resolutions).toBe(1)
+})
+
+test("failed authentication acquisition is cleared for a later retry", async () => {
+  let resolutions = 0
+  const layer = ambientGitHubLayer({
+    workspaceRoot: "/workspace",
+    resolveToken: async () => {
+      resolutions += 1
+      if (resolutions === 1) throw new Error("gh unavailable")
+      return "recovered-token"
+    },
+    makeService: () => serviceWithList(() => Effect.succeed([])),
+  })
+
+  await Effect.runPromise(
+    Effect.gen(function* () {
+      const github = yield* GitHubService
+      const first = yield* Effect.exit(
+        github.listReadyIssues({ owner: "acme", name: "widgets" }),
+      )
+      expect(first._tag).toBe("Failure")
+      yield* github.listReadyIssues({ owner: "acme", name: "widgets" })
+    }).pipe(Effect.provide(layer), Effect.provide(processLayer)),
+  )
+
+  expect(resolutions).toBe(2)
 })

--- a/apps/harness/test/application-config.test.ts
+++ b/apps/harness/test/application-config.test.ts
@@ -1,0 +1,50 @@
+import { Effect } from "effect"
+import {
+  loadApplicationConfig,
+  loadPort,
+} from "../src/server/application-config.js"
+import { describe, expect, test } from "bun:test"
+
+describe("harness application config", () => {
+  test("loads the Sidecar URL and host tool cwd from the supplied environment", async () => {
+    const config = await Effect.runPromise(
+      loadApplicationConfig({
+        HOME: "/home/operator",
+        KEYMAXXER_SIDECAR_URL: " http://127.0.0.1:5032/cap/mcp ",
+      }),
+    )
+
+    expect(config).toEqual({
+      hostToolCwd: "/home/operator",
+      keymaxxerSidecarUrl: "http://127.0.0.1:5032/cap/mcp",
+    })
+  })
+
+  test("allows Keymaxxer to be explicitly disabled", async () => {
+    const config = await Effect.runPromise(
+      loadApplicationConfig({
+        HOME: "/home/operator",
+        KEYMAXXER_ENABLED: "false",
+      }),
+    )
+
+    expect(config.keymaxxerSidecarUrl).toBeUndefined()
+  })
+
+  test("rejects an enabled configuration without a Sidecar URL", async () => {
+    const exit = await Effect.runPromise(Effect.exit(loadApplicationConfig({})))
+    expect(exit._tag).toBe("Failure")
+  })
+
+  test("loads and validates the production port", async () => {
+    expect(await Effect.runPromise(loadPort({}))).toBe(4200)
+    expect(await Effect.runPromise(loadPort({ PORT: "4300" }))).toBe(4300)
+
+    for (const value of ["0", "1.5", "65536", "not-a-port"]) {
+      const exit = await Effect.runPromise(
+        Effect.exit(loadPort({ PORT: value })),
+      )
+      expect(exit._tag).toBe("Failure")
+    }
+  })
+})

--- a/apps/harness/test/keymaxxer-github-layer.test.ts
+++ b/apps/harness/test/keymaxxer-github-layer.test.ts
@@ -461,4 +461,52 @@ describe("Keymaxxer-backed GitHub layer", () => {
     expect(runs[0]?.command).toContain('"--conditions"')
     expect(runs[0]?.secrets).toEqual(["GITHUB_TOKEN_ACME_WIDGETS"])
   })
+
+  test("rejects malformed Ready Issue fields through Schema", async () => {
+    const keymaxxerLayer = Layer.succeed(KeymaxxerService, {
+      initialize: Effect.void,
+      findSecret: () => Effect.succeed("GITHUB_TOKEN_ACME_WIDGETS"),
+      findSecrets: () => Effect.die("not used"),
+      hasSecret: () => Effect.die("not used"),
+      addSecret: () => Effect.die("not used"),
+      runWithSecrets: () =>
+        Effect.succeed({
+          exitCode: 0,
+          stdout: JSON.stringify([
+            {
+              number: 0,
+              title: " ",
+              body: "Issue body",
+              url: "not-a-url",
+              createdAt: "not-a-date",
+              state: "OPEN",
+              hierarchySupported: true,
+              hasChildren: false,
+              parentPosition: -1,
+              parent: null,
+              blockedBy: [],
+              closingPullRequests: [],
+            },
+          ]),
+          stderr: "",
+        }),
+    })
+    const layer = keymaxxerGitHubLayer({ workspaceRoot: "/workspace" }).pipe(
+      Layer.provide(keymaxxerLayer),
+    )
+
+    const error = await Effect.runPromise(
+      Effect.gen(function* () {
+        const github = yield* GitHubService
+        return yield* github
+          .listReadyIssues({ owner: "acme", name: "widgets" })
+          .pipe(Effect.flip)
+      }).pipe(Effect.provide(layer)),
+    )
+
+    expect(error).toBeInstanceOf(GitHubRequestError)
+    expect(error.message).toBe(
+      "Failed to list Ready-labeled Issues for acme/widgets",
+    )
+  })
 })

--- a/apps/ready-for-agent/src/browser-open.ts
+++ b/apps/ready-for-agent/src/browser-open.ts
@@ -1,3 +1,5 @@
+import { spawn } from "node:child_process"
+
 export type BrowserOpenEnv = Partial<
   Record<"NO_BROWSER" | "PORT", string | undefined>
 >
@@ -51,4 +53,34 @@ export const browserOpenCommand = (
   }
 
   return { command: "xdg-open", args: [url] }
+}
+
+/**
+ * Detached browser launch is deliberately a host boundary: polling uses fetch
+ * and the launcher must outlive its child rather than be scoped to an Effect.
+ */
+export const openBrowserWhenReady = (platform: string, url: string): void => {
+  const { command, args } = browserOpenCommand(platform, url)
+  const deadline = Date.now() + 60_000
+
+  const tryOpen = async () => {
+    while (Date.now() < deadline) {
+      try {
+        const response = await fetch(url, { redirect: "manual" })
+        void response.body?.cancel()
+        if (response.status > 0) {
+          spawn(command, [...args], {
+            detached: true,
+            stdio: "ignore",
+          }).unref()
+          return
+        }
+      } catch {
+        // Port not ready yet.
+      }
+      await Bun.sleep(250)
+    }
+  }
+
+  void tryOpen()
 }

--- a/apps/ready-for-agent/src/cli.ts
+++ b/apps/ready-for-agent/src/cli.ts
@@ -14,16 +14,34 @@ const noOpenFlag = Flag.boolean("no-open").pipe(
   ),
 )
 
-const startHarness = (noOpen: boolean) =>
-  Effect.gen(function* () {
-    const startHarnessService = yield* StartHarness
-    yield* startHarnessService.start({ noOpen })
-  })
+const startHarnessWorkflow = Effect.fn("Cli.startHarness")(function* (
+  noOpen: boolean,
+) {
+  const startHarnessService = yield* StartHarness
+  yield* startHarnessService.start({ noOpen })
+})
+
+const addRepositoryWorkflow = Effect.fn("Cli.addRepository")(function* (
+  path: string,
+) {
+  const localGit = yield* LocalGit
+  const graphqlApi = yield* GraphqlApi
+  const repository = yield* localGit.inspect(path)
+  const added = yield* graphqlApi.addRepository(repository)
+
+  yield* Console.log(
+    `Added repository ${added.githubOwner}/${added.githubRepo}`,
+  )
+  yield* Console.log(`  id: ${added.id}`)
+  yield* Console.log(`  local path: ${added.localPath}`)
+  yield* Console.log(`  bare: ${added.isBare}`)
+  yield* Console.log(`  paused: ${added.paused}`)
+})
 
 const startCommand = Command.make(
   "start",
   { noOpen: noOpenFlag },
-  ({ noOpen }) => startHarness(noOpen),
+  ({ noOpen }) => startHarnessWorkflow(noOpen),
 ).pipe(
   Command.withDescription(
     "Start the full Harness (UI + backend); opens the browser unless --no-open / NO_BROWSER",
@@ -31,26 +49,13 @@ const startCommand = Command.make(
 )
 
 const addCommand = Command.make("add", { path: pathArg }, ({ path }) =>
-  Effect.gen(function* () {
-    const localGit = yield* LocalGit
-    const graphqlApi = yield* GraphqlApi
-    const repository = yield* localGit.inspect(path)
-    const added = yield* graphqlApi.addRepository(repository)
-
-    yield* Console.log(
-      `Added repository ${added.githubOwner}/${added.githubRepo}`,
-    )
-    yield* Console.log(`  id: ${added.id}`)
-    yield* Console.log(`  local path: ${added.localPath}`)
-    yield* Console.log(`  bare: ${added.isBare}`)
-    yield* Console.log(`  paused: ${added.paused}`)
-  }),
+  addRepositoryWorkflow(path),
 ).pipe(Command.withDescription("Add a local repository to the harness"))
 
 export const cli = Command.make(
   "ready-for-agent",
   { noOpen: noOpenFlag },
-  ({ noOpen }) => startHarness(noOpen),
+  ({ noOpen }) => startHarnessWorkflow(noOpen),
 ).pipe(
   Command.withDescription(
     "Ready for Agent operator binary (start Harness, add repositories)",

--- a/apps/ready-for-agent/src/graphql-url.ts
+++ b/apps/ready-for-agent/src/graphql-url.ts
@@ -1,4 +1,0 @@
-const defaultGraphqlUrl = "http://127.0.0.1:4200/graphql"
-
-export const resolveGraphqlUrl = (): string =>
-  process.env.READY_FOR_AGENT_GRAPHQL_URL ?? defaultGraphqlUrl

--- a/apps/ready-for-agent/src/main.ts
+++ b/apps/ready-for-agent/src/main.ts
@@ -18,13 +18,17 @@ if (isInternalKeymaxxerSidecarMode(process.argv)) {
   const { Effect, Layer } = await import("effect")
   const { Command } = await import("effect/unstable/cli")
   const { cli } = await import("./cli.ts")
+  const { ApplicationConfig } = await import("./services/application-config.ts")
   const { GraphqlApi } = await import("./services/graphql-api.ts")
   const { LocalGit } = await import("./services/local-git.ts")
   const { StartHarness } = await import("./services/start-harness.ts")
 
-  const MainLive = LocalGit.layer.pipe(
-    Layer.provideMerge(GraphqlApi.layer),
-    Layer.provideMerge(StartHarness.layer),
+  const MainLive = Layer.mergeAll(
+    LocalGit.layer,
+    GraphqlApi.layer,
+    StartHarness.layer,
+  ).pipe(
+    Layer.provideMerge(ApplicationConfig.layer),
     Layer.provideMerge(BunServices.layer),
   )
 

--- a/apps/ready-for-agent/src/services/application-config.test.ts
+++ b/apps/ready-for-agent/src/services/application-config.test.ts
@@ -1,0 +1,44 @@
+import { ConfigProvider, Effect } from "effect"
+import { ApplicationConfig } from "./application-config.ts"
+import { describe, expect, test } from "bun:test"
+
+const loadConfig = (values: Record<string, string>) =>
+  Effect.gen(function* () {
+    return yield* ApplicationConfig
+  }).pipe(
+    Effect.provide(ApplicationConfig.layer),
+    Effect.provide(ConfigProvider.layer(ConfigProvider.fromUnknown(values))),
+    Effect.runPromise,
+  )
+
+describe("ApplicationConfig", () => {
+  test("loads GraphQL, database, and browser environment through Config", async () => {
+    const config = await loadConfig({
+      READY_FOR_AGENT_GRAPHQL_URL: "https://example.test/graphql",
+      HOME: "/home/operator",
+      XDG_DATA_HOME: "/var/operator-data",
+      SQLITE_DATABASE_PATH: "/custom/product.db",
+      NO_BROWSER: "true",
+      PORT: "4300",
+    })
+
+    expect(config.graphqlUrl).toBe("https://example.test/graphql")
+    expect(config.databasePath).toBe("/custom/product.db")
+    expect(config.browserEnv).toEqual({ NO_BROWSER: "true", PORT: "4300" })
+  })
+
+  test("preserves defaults and blank database override semantics", async () => {
+    const config = await loadConfig({
+      HOME: "/home/operator",
+      SQLITE_DATABASE_PATH: "  ",
+    })
+
+    expect(config.graphqlUrl).toBe("http://127.0.0.1:4200/graphql")
+    expect(config.databasePath).toBe(
+      config.platform === "darwin"
+        ? "/home/operator/Library/Application Support/ready-for-agent/ready-for-agent.db"
+        : "/home/operator/.local/share/ready-for-agent/ready-for-agent.db",
+    )
+    expect(config.browserEnv.NO_BROWSER).toBeUndefined()
+  })
+})

--- a/apps/ready-for-agent/src/services/application-config.ts
+++ b/apps/ready-for-agent/src/services/application-config.ts
@@ -1,0 +1,52 @@
+import { homedir } from "node:os"
+import { Config, Context, Effect, Layer, Option } from "effect"
+import type { BrowserOpenEnv } from "../browser-open.ts"
+import { resolveDefaultDatabasePath } from "../product-data-dir.ts"
+
+const DEFAULT_GRAPHQL_URL = "http://127.0.0.1:4200/graphql"
+
+const optionalString = (name: string) => Config.option(Config.string(name))
+
+export class ApplicationConfig extends Context.Service<
+  ApplicationConfig,
+  {
+    readonly graphqlUrl: string
+    readonly databasePath: string
+    readonly browserEnv: BrowserOpenEnv
+    readonly platform: NodeJS.Platform
+  }
+>()("ready-for-agent/ApplicationConfig") {
+  static readonly layer = Layer.effect(
+    ApplicationConfig,
+    Effect.gen(function* () {
+      const graphqlUrl = yield* Config.string(
+        "READY_FOR_AGENT_GRAPHQL_URL",
+      ).pipe(Config.orElse(() => Config.succeed(DEFAULT_GRAPHQL_URL)))
+      const homeOption = yield* optionalString("HOME")
+      const xdgDataHome = yield* optionalString("XDG_DATA_HOME")
+      const sqliteDatabasePath = yield* optionalString("SQLITE_DATABASE_PATH")
+      const noBrowser = yield* optionalString("NO_BROWSER")
+      const port = yield* optionalString("PORT")
+      const homeValue = Option.getOrUndefined(homeOption)
+      const platform = process.platform
+
+      return {
+        graphqlUrl,
+        databasePath: resolveDefaultDatabasePath({
+          env: {
+            HOME: homeValue,
+            XDG_DATA_HOME: Option.getOrUndefined(xdgDataHome),
+            SQLITE_DATABASE_PATH: Option.getOrUndefined(sqliteDatabasePath),
+          },
+          platform,
+          home: homeValue?.trim() || homedir(),
+        }),
+        browserEnv: {
+          NO_BROWSER: Option.getOrUndefined(noBrowser),
+          PORT: Option.getOrUndefined(port),
+        },
+        platform,
+      }
+    }),
+  )
+}

--- a/apps/ready-for-agent/src/services/graphql-api.ts
+++ b/apps/ready-for-agent/src/services/graphql-api.ts
@@ -2,7 +2,7 @@ import { Context, Effect, Layer, Schema } from "effect"
 import { createClient } from "@ready-for-agent/graphql-client"
 import type { LocalRepository, RepositorySummary } from "../domain.ts"
 import { formatGraphqlRequestFailure } from "../graphql-error.ts"
-import { resolveGraphqlUrl } from "../graphql-url.ts"
+import { ApplicationConfig } from "./application-config.ts"
 
 export class GraphqlRequestFailed extends Schema.TaggedErrorClass<GraphqlRequestFailed>()(
   "GraphqlRequestFailed",
@@ -17,41 +17,49 @@ export class GraphqlApi extends Context.Service<
     ) => Effect.Effect<RepositorySummary, GraphqlRequestFailed>
   }
 >()("ready-for-agent/GraphqlApi") {
-  static readonly layer = Layer.succeed(GraphqlApi, {
-    addRepository: (repository) =>
-      Effect.tryPromise({
-        try: async () => {
-          const client = createClient({
-            url: resolveGraphqlUrl(),
-          })
-          const result = await client.mutation({
-            addRepository: {
-              __args: {
-                input: {
-                  githubOwner: repository.githubOwner,
-                  githubRepo: repository.githubRepo,
-                  localPath: repository.localPath,
-                  isBare: repository.isBare,
+  static readonly layer = Layer.effect(
+    GraphqlApi,
+    Effect.gen(function* () {
+      const config = yield* ApplicationConfig
+      const client = createClient({ url: config.graphqlUrl })
+
+      const addRepository = Effect.fn("GraphqlApi.addRepository")(function* (
+        repository: LocalRepository,
+      ) {
+        return yield* Effect.tryPromise({
+          try: async () => {
+            const result = await client.mutation({
+              addRepository: {
+                __args: {
+                  input: {
+                    githubOwner: repository.githubOwner,
+                    githubRepo: repository.githubRepo,
+                    localPath: repository.localPath,
+                    isBare: repository.isBare,
+                  },
                 },
+                id: true,
+                githubOwner: true,
+                githubRepo: true,
+                localPath: true,
+                isBare: true,
+                paused: true,
               },
-              id: true,
-              githubOwner: true,
-              githubRepo: true,
-              localPath: true,
-              isBare: true,
-              paused: true,
-            },
-          })
-          const added = result.addRepository
-          if (!added) {
-            throw new Error("addRepository returned null")
-          }
-          return added
-        },
-        catch: (cause) =>
-          new GraphqlRequestFailed({
-            message: formatGraphqlRequestFailure(cause),
-          }),
-      }),
-  })
+            })
+            const added = result.addRepository
+            if (!added) {
+              throw new Error("addRepository returned null")
+            }
+            return added
+          },
+          catch: (cause) =>
+            new GraphqlRequestFailed({
+              message: formatGraphqlRequestFailure(cause),
+            }),
+        })
+      })
+
+      return { addRepository }
+    }),
+  )
 }

--- a/apps/ready-for-agent/src/services/start-harness.ts
+++ b/apps/ready-for-agent/src/services/start-harness.ts
@@ -1,18 +1,14 @@
-import { spawn } from "node:child_process"
-import { existsSync, mkdirSync } from "node:fs"
-import { homedir } from "node:os"
-import { dirname, join, resolve } from "node:path"
-import { fileURLToPath } from "node:url"
-import { Context, Effect, Layer, Schema } from "effect"
+import { Context, Effect, FileSystem, Layer, Path, Schema } from "effect"
+import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process"
 import { isStandaloneExecutable } from "@ready-for-agent/keymaxxer-service"
 import {
-  browserOpenCommand,
+  openBrowserWhenReady,
   resolveUiUrl,
   shouldOpenBrowser,
 } from "../browser-open.ts"
 import { checkHostTools } from "../host-tools-preflight.ts"
-import { resolveDefaultDatabasePath } from "../product-data-dir.ts"
 import { bootStandaloneProduction } from "../standalone-boot.ts"
+import { ApplicationConfig } from "./application-config.ts"
 
 export class StartHarnessFailed extends Schema.TaggedErrorClass<StartHarnessFailed>()(
   "StartHarnessFailed",
@@ -27,219 +23,24 @@ export type StartHarnessOptions = {
   readonly noOpen?: boolean
 }
 
-const findMonorepoRoot = (
-  startDir: string = dirname(fileURLToPath(import.meta.url)),
-): string | undefined => {
-  let current = resolve(startDir)
-  for (let i = 0; i < 10; i++) {
-    if (
-      existsSync(join(current, "nx.json")) &&
-      existsSync(join(current, "apps", "harness", "project.json"))
-    ) {
-      return current
-    }
-    const parent = dirname(current)
-    if (parent === current) {
-      return undefined
-    }
-    current = parent
-  }
-  return undefined
-}
-
-const commandExists = (command: string) => Bun.which(command) !== null
-
-const ensureDatabaseParentDir = (databasePath: string) => {
+const databaseFilePath = (databasePath: string): string | undefined => {
   if (databasePath === ":memory:" || databasePath.startsWith("libsql:")) {
-    return
+    return undefined
   }
   const filePath = databasePath.startsWith("file://")
     ? databasePath.slice("file://".length)
     : databasePath.startsWith("file:")
       ? databasePath.slice("file:".length)
       : databasePath
-  if (filePath === ":memory:") {
-    return
-  }
-  mkdirSync(dirname(resolve(filePath)), { recursive: true })
+  return filePath === ":memory:" ? undefined : filePath
 }
 
-const openBrowserWhenReady = (url: string) => {
-  const { command, args } = browserOpenCommand(process.platform, url)
-  const deadline = Date.now() + 60_000
-
-  const tryOpen = async () => {
-    while (Date.now() < deadline) {
-      try {
-        const response = await fetch(url, { redirect: "manual" })
-        void response.body?.cancel()
-        if (response.status > 0) {
-          spawn(command, [...args], {
-            detached: true,
-            stdio: "ignore",
-          }).unref()
-          return
-        }
-      } catch {
-        // Port not ready yet.
-      }
-      await Bun.sleep(250)
-    }
-  }
-
-  void tryOpen()
-}
-
-const resolveProductDatabasePath = () => {
-  const home = process.env.HOME?.trim() || homedir()
-  return resolveDefaultDatabasePath({
-    env: {
-      HOME: process.env.HOME,
-      XDG_DATA_HOME: process.env.XDG_DATA_HOME,
-      SQLITE_DATABASE_PATH: process.env.SQLITE_DATABASE_PATH,
-    },
-    platform: process.platform,
-    home,
-  })
-}
-
-const startStandaloneProduction = (options: StartHarnessOptions) =>
-  Effect.tryPromise({
-    try: async () => {
-      const preflight = checkHostTools(commandExists)
-      if (!preflight.ok) {
-        throw new StartHarnessFailed({ detail: preflight.message })
-      }
-
-      const databasePath = resolveProductDatabasePath()
-      try {
-        ensureDatabaseParentDir(databasePath)
-      } catch (error) {
-        throw new StartHarnessFailed({
-          detail:
-            error instanceof Error
-              ? error.message
-              : `Could not create database directory for ${databasePath}`,
-        })
-      }
-
-      process.env.SQLITE_DATABASE_PATH = databasePath
-      await bootStandaloneProduction({ noOpen: options.noOpen === true })
-    },
-    catch: (cause) => {
-      if (cause instanceof StartHarnessFailed) return cause
-      return new StartHarnessFailed({
+const fail = (cause: unknown): StartHarnessFailed =>
+  cause instanceof StartHarnessFailed
+    ? cause
+    : new StartHarnessFailed({
         detail: cause instanceof Error ? cause.message : String(cause),
       })
-    },
-  })
-
-const startMonorepoDevelopment = (options: StartHarnessOptions) =>
-  Effect.callback<void, StartHarnessFailed>((resume) => {
-    const preflight = checkHostTools(commandExists)
-    if (!preflight.ok) {
-      resume(
-        Effect.fail(
-          new StartHarnessFailed({
-            detail: preflight.message,
-          }),
-        ),
-      )
-      return
-    }
-
-    const root = findMonorepoRoot()
-    if (root === undefined) {
-      resume(
-        Effect.fail(
-          new StartHarnessFailed({
-            detail:
-              "Could not find the ready-for-agent monorepo root (expected nx.json and apps/harness).",
-          }),
-        ),
-      )
-      return
-    }
-
-    const databasePath = resolveProductDatabasePath()
-    try {
-      ensureDatabaseParentDir(databasePath)
-    } catch (error) {
-      resume(
-        Effect.fail(
-          new StartHarnessFailed({
-            detail:
-              error instanceof Error
-                ? error.message
-                : `Could not create database directory for ${databasePath}`,
-          }),
-        ),
-      )
-      return
-    }
-
-    const env: NodeJS.ProcessEnv = {
-      ...process.env,
-      SQLITE_DATABASE_PATH: databasePath,
-    }
-
-    const child = spawn("bun", ["nx", "run", "harness:dev"], {
-      cwd: root,
-      env,
-      stdio: "inherit",
-    })
-
-    if (
-      shouldOpenBrowser({
-        noOpenFlag: options.noOpen === true,
-        env: {
-          NO_BROWSER: process.env.NO_BROWSER,
-          PORT: process.env.PORT,
-        },
-      })
-    ) {
-      openBrowserWhenReady(
-        resolveUiUrl({
-          NO_BROWSER: process.env.NO_BROWSER,
-          PORT: process.env.PORT,
-        }),
-      )
-    }
-
-    child.on("error", (error) => {
-      resume(
-        Effect.fail(
-          new StartHarnessFailed({
-            detail: error.message,
-          }),
-        ),
-      )
-    })
-
-    child.on("exit", (code, signal) => {
-      if (signal) {
-        resume(
-          Effect.fail(
-            new StartHarnessFailed({
-              detail: `Harness exited via signal ${signal}`,
-            }),
-          ),
-        )
-        return
-      }
-      if (code !== 0 && code !== null) {
-        resume(
-          Effect.fail(
-            new StartHarnessFailed({
-              detail: `Harness exited with code ${code}`,
-            }),
-          ),
-        )
-        return
-      }
-      resume(Effect.void)
-    })
-  })
 
 export class StartHarness extends Context.Service<
   StartHarness,
@@ -249,10 +50,117 @@ export class StartHarness extends Context.Service<
     ) => Effect.Effect<void, StartHarnessFailed>
   }
 >()("ready-for-agent/StartHarness") {
-  static readonly layer = Layer.succeed(StartHarness, {
-    start: (options = {}) =>
-      isStandaloneExecutable()
-        ? startStandaloneProduction(options)
-        : startMonorepoDevelopment(options),
-  })
+  static readonly layer = Layer.effect(
+    StartHarness,
+    Effect.gen(function* () {
+      const config = yield* ApplicationConfig
+      const fs = yield* FileSystem.FileSystem
+      const path = yield* Path.Path
+      const spawner = yield* ChildProcessSpawner.ChildProcessSpawner
+      const modulePath = yield* path.fromFileUrl(new URL(import.meta.url))
+
+      const findMonorepoRoot = Effect.fn("StartHarness.findMonorepoRoot")(
+        function* () {
+          let current = path.resolve(path.dirname(modulePath))
+          for (let i = 0; i < 10; i++) {
+            const [hasNx, hasHarness] = yield* Effect.all([
+              fs.exists(path.join(current, "nx.json")),
+              fs.exists(path.join(current, "apps", "harness", "project.json")),
+            ])
+            if (hasNx && hasHarness) return current
+
+            const parent = path.dirname(current)
+            if (parent === current) return undefined
+            current = parent
+          }
+          return undefined
+        },
+      )
+
+      const runPreflight = Effect.fn("StartHarness.runPreflight")(function* () {
+        const result = checkHostTools((command) => Bun.which(command) !== null)
+        if (!result.ok) {
+          return yield* new StartHarnessFailed({ detail: result.message })
+        }
+      })
+
+      const ensureDatabaseParentDir = Effect.fn(
+        "StartHarness.ensureDatabaseParentDir",
+      )(function* () {
+        const filePath = databaseFilePath(config.databasePath)
+        if (filePath !== undefined) {
+          yield* fs.makeDirectory(path.dirname(path.resolve(filePath)), {
+            recursive: true,
+          })
+        }
+      })
+
+      const startStandalone = Effect.fn("StartHarness.startStandalone")(
+        function* (options: StartHarnessOptions) {
+          yield* runPreflight()
+          yield* ensureDatabaseParentDir()
+
+          // The embedded harness lifecycle owns a Promise-based server host.
+          return yield* Effect.tryPromise({
+            try: () =>
+              bootStandaloneProduction({
+                noOpen: options.noOpen === true,
+                databasePath: config.databasePath,
+                browserEnv: config.browserEnv,
+              }),
+            catch: fail,
+          })
+        },
+      )
+
+      const startMonorepo = Effect.fn("StartHarness.startMonorepo")(function* (
+        options: StartHarnessOptions,
+      ) {
+        yield* runPreflight()
+        const root = yield* findMonorepoRoot()
+        if (root === undefined) {
+          return yield* new StartHarnessFailed({
+            detail:
+              "Could not find the ready-for-agent monorepo root (expected nx.json and apps/harness).",
+          })
+        }
+        yield* ensureDatabaseParentDir()
+
+        if (
+          shouldOpenBrowser({
+            noOpenFlag: options.noOpen === true,
+            env: config.browserEnv,
+          })
+        ) {
+          openBrowserWhenReady(config.platform, resolveUiUrl(config.browserEnv))
+        }
+
+        const code = yield* spawner.exitCode(
+          ChildProcess.make("bun", ["nx", "run", "harness:dev"], {
+            cwd: root,
+            env: { SQLITE_DATABASE_PATH: config.databasePath },
+            extendEnv: true,
+            stdin: "inherit",
+            stdout: "inherit",
+            stderr: "inherit",
+          }),
+        )
+        if (Number(code) !== 0) {
+          return yield* new StartHarnessFailed({
+            detail: `Harness exited with code ${code}`,
+          })
+        }
+      })
+
+      const start = Effect.fn("StartHarness.start")(function* (
+        options: StartHarnessOptions = {},
+      ) {
+        yield* isStandaloneExecutable()
+          ? startStandalone(options)
+          : startMonorepo(options)
+      }, Effect.mapError(fail))
+
+      return { start }
+    }),
+  )
 }

--- a/apps/ready-for-agent/src/standalone-boot.ts
+++ b/apps/ready-for-agent/src/standalone-boot.ts
@@ -50,14 +50,25 @@ const createEmbeddedSpaStartHandler = (input: {
 
 export const bootStandaloneProduction = async (input: {
   readonly noOpen: boolean
+  readonly databasePath: string
+  readonly browserEnv: {
+    readonly NO_BROWSER?: string | undefined
+    readonly PORT?: string | undefined
+  }
 }): Promise<void> => {
   const argv = [
     ...process.argv,
     ...(input.noOpen ? (["--no-open"] as const) : []),
   ]
 
+  // The production lifecycle is Promise-based host code. Keep its ambient
+  // environment read here and pass an immutable override instead of mutating it.
   await startProductionLifecycle({
-    environment: process.env,
+    environment: {
+      ...process.env,
+      ...input.browserEnv,
+      SQLITE_DATABASE_PATH: input.databasePath,
+    },
     argv,
     embeddedClientAssets,
     loadStartHandler: async () =>


### PR DESCRIPTION
## Summary

- Load Harness and CLI environment settings through validated Effect Config layers, including database propagation into migrations and runtime composition.
- Make ambient GitHub authentication, worker outcomes, Ready Issue decoding, and operational tracing Effect-native while documenting the intentional Promise host boundary.
- Move CLI filesystem and child-process work onto Effect platform services and reuse one GraphQL client per service layer.

Closes #309

## Test plan

- [x] `bunx nx affected -t lint,typecheck,test --batch` via pre-commit checks
- [x] `bunx nx run harness:knip`
- [x] `bunx nx run ready-for-agent:knip`