### PR TITLE
feat(harness): show job counts

### DIFF
--- a/apps/harness/src/routes/index.tsx
+++ b/apps/harness/src/routes/index.tsx
@@ -1803,6 +1803,8 @@ function JobsCard() {
               }}
             >
               {tab.label}
+              {tab.id === "working" && ` (${workingItems.length})`}
+              {tab.id === "failed" && ` (${failedItems.length})`}
             </button>
           )
         })}

--- a/apps/harness/test/jobs-card-no-polling.test.ts
+++ b/apps/harness/test/jobs-card-no-polling.test.ts
@@ -58,6 +58,17 @@ describe("JobsCard live updates", () => {
     expect(completedTabIndex).toBeGreaterThan(failedTabIndex)
   })
 
+  test("shows live counts for Working and Failed, but not Completed", () => {
+    const { jobsCard } = jobsCardSource()
+    expect(jobsCard).toMatch(
+      /\{tab\.id === "working" && ` \(\$\{workingItems\.length\}\)`\}/,
+    )
+    expect(jobsCard).toMatch(
+      /\{tab\.id === "failed" && ` \(\$\{failedItems\.length\}\)`\}/,
+    )
+    expect(jobsCard).not.toContain('tab.id === "completed" &&')
+  })
+
   test("shows issue number with title and top-right pause control", () => {
     const { source, jobsCard } = jobsCardSource()
     expect(jobsCard).not.toContain("Issue #")


### PR DESCRIPTION
## Why

Operators need to see how many Working and Failed jobs are present without opening each tab.

## What Changed

- Show the current entry count on the Working and Failed tabs.
- Keep the Completed tab uncounted.
- Cover the count rendering and Completed exclusion with a regression test.

Closes #340