### PR TITLE
fix(harness): keep retriable jobs working

### DIFF
--- a/apps/harness/src/routes/index.tsx
+++ b/apps/harness/src/routes/index.tsx
@@ -265,10 +265,7 @@ type WorkItemsQueryOptions = {
 
 /** Completed history window (successful finished outcomes). */
 const JOBS_COMPLETED_LIMIT = 15
-/**
- * Failed history window (terminal failed + retriable stoppages).
- * Explicit product choice, independent of JOBS_COMPLETED_LIMIT.
- */
+/** Failed history window, independent of JOBS_COMPLETED_LIMIT. */
 const JOBS_FAILED_LIMIT = 15
 
 const workItemsQuery = (

--- a/packages/graphql-api/src/lib/graphql-api.ts
+++ b/packages/graphql-api/src/lib/graphql-api.ts
@@ -20,6 +20,7 @@ import {
   type WorkItemsListKind,
   filterWorkItemsByListKind,
   isJobsCompletedWorkItemState,
+  isRetryableFailedWorkItem,
   isTerminalWorkItemState,
 } from "@ready-for-agent/work-item-lifecycle"
 import {
@@ -345,8 +346,7 @@ export const createGraphqlApi = (
           canRetry: (workItem: WorkItemRecord) => {
             const latestStatus = latestStepRun(workItem)?.status
             const recoverableStatusCheckFailure =
-              workItem.state === "failed" &&
-              workItem.failureCode === "pr_status_checks_unresolved"
+              isRetryableFailedWorkItem(workItem)
             return (
               workItem.waitingSince == null &&
               !workItem.paused &&

--- a/packages/graphql-api/test/graphql-api.test.ts
+++ b/packages/graphql-api/test/graphql-api.test.ts
@@ -1765,7 +1765,7 @@ describe("GraphQL API", () => {
     })
   })
 
-  test("filters Working Work Items including Needs Human", async () => {
+  test("filters Working Work Items including retriable failures", async () => {
     const needsHuman = {
       ...workItem,
       id: makeWorkItemId(),
@@ -1804,6 +1804,11 @@ describe("GraphQL API", () => {
       state: "failed" as const,
       stepRuns: [],
     }
+    const recoverableTerminalFailed = {
+      ...terminalFailed,
+      id: makeWorkItemId(),
+      failureCode: "pr_status_checks_unresolved",
+    }
     await runtime.dispose()
     runtime = makeRuntime(
       {
@@ -1819,6 +1824,7 @@ describe("GraphQL API", () => {
             implementing,
             retriableFailed,
             terminalFailed,
+            recoverableTerminalFailed,
           ]),
       },
     )
@@ -1827,7 +1833,7 @@ describe("GraphQL API", () => {
       graphqlRequest({
         query: `query WorkItems($repositoryId: ID!, $listKind: WorkItemsListKind) {
           workItems(repositoryId: $repositoryId, listKind: $listKind) {
-            id state
+            id state canRetry isTerminal
           }
         }`,
         variables: { repositoryId: repository.id, listKind: "WORKING" },
@@ -1840,10 +1846,26 @@ describe("GraphQL API", () => {
           {
             id: needsHuman.id,
             state: "NEEDS_HUMAN",
+            canRetry: false,
+            isTerminal: true,
           },
           {
             id: implementing.id,
             state: "IMPLEMENT",
+            canRetry: false,
+            isTerminal: false,
+          },
+          {
+            id: retriableFailed.id,
+            state: "IMPLEMENT",
+            canRetry: true,
+            isTerminal: false,
+          },
+          {
+            id: recoverableTerminalFailed.id,
+            state: "FAILED",
+            canRetry: true,
+            isTerminal: true,
           },
         ],
       },
@@ -1923,7 +1945,7 @@ describe("GraphQL API", () => {
     )
   })
 
-  test("filters Failed Work Items including retriable and terminal failures", async () => {
+  test("filters Failed Work Items to non-retryable terminal failures", async () => {
     const baseTime = Date.parse("2026-01-01T00:00:00.000Z")
     const retriableId = makeWorkItemId()
     const terminalFailedId = makeWorkItemId()
@@ -1952,8 +1974,8 @@ describe("GraphQL API", () => {
       ...workItem,
       id: terminalFailedId,
       state: "failed" as const,
-      failureCode: "pr_status_checks_unresolved",
-      failureMessage: "Manual fixing may be required",
+      failureCode: "issue_not_open",
+      failureMessage: "Issue is no longer open",
       createdAt: new Date(baseTime + 2000),
       stepRuns: [
         {
@@ -2021,14 +2043,8 @@ describe("GraphQL API", () => {
           {
             id: terminalFailed.id,
             state: "FAILED",
-            canRetry: true,
+            canRetry: false,
             isTerminal: true,
-          },
-          {
-            id: retriable.id,
-            state: "IMPLEMENT",
-            canRetry: true,
-            isTerminal: false,
           },
         ],
       },

--- a/packages/graphql-schema/schema.graphql
+++ b/packages/graphql-schema/schema.graphql
@@ -13,11 +13,10 @@ type Query {
   """
   Work Items for a repository (or one issue when githubIssueNumber is set).
   Omit listKind/limit for the full list (backward-compatible default).
-  listKind WORKING: unfinished + Needs Human, excluding Failed membership
-  (no history cap from the Jobs card).
-  listKind FAILED: terminal failed plus nonterminal Work Items whose latest
-  Step Run is failed or interrupted; newest createdAt first. Pass limit
-  (e.g. 15) to bound Failed history — independent of the Completed limit.
+  listKind WORKING: unfinished Work Items (including retryable failed or
+  interrupted Step Runs) plus Needs Human (no history cap from the Jobs card).
+  listKind FAILED: non-retryable terminal failures only, newest createdAt first.
+  Pass limit (e.g. 15) to bound Failed history — independent of the Completed limit.
   listKind COMPLETED: Complete and Abandoned only, newest createdAt first;
   pass limit (e.g. 15) to bound finished history. Terminal failed is not included.
   """

--- a/packages/work-item-lifecycle/src/lib/types.ts
+++ b/packages/work-item-lifecycle/src/lib/types.ts
@@ -138,7 +138,7 @@ export const isTerminalWorkItemState = (
 
 /**
  * Jobs card Completed tab: successful finished outcomes only.
- * Terminal `failed` belongs on Failed. Needs Human stays on Working as active handoff.
+ * Non-retryable terminal `failed` belongs on Failed. Needs Human stays on Working.
  */
 export const JOBS_COMPLETED_WORK_ITEM_STATES = [
   "complete",
@@ -153,43 +153,27 @@ export const isJobsCompletedWorkItemState = (
 ): state is JobsCompletedWorkItemState =>
   (JOBS_COMPLETED_WORK_ITEM_STATES as readonly string[]).includes(state)
 
-/** Latest Step Run statuses that place a nonterminal Work Item on Failed. */
-export const JOBS_FAILED_STEP_RUN_STATUSES = [
-  "failed",
-  "interrupted",
-] as const satisfies readonly StepRunStatus[]
-
-export type JobsFailedStepRunStatus =
-  (typeof JOBS_FAILED_STEP_RUN_STATUSES)[number]
-
-export const isJobsFailedStepRunStatus = (
-  status: StepRunStatus,
-): status is JobsFailedStepRunStatus =>
-  (JOBS_FAILED_STEP_RUN_STATUSES as readonly string[]).includes(status)
+export const RETRYABLE_FAILED_WORK_ITEM_CODE = "pr_status_checks_unresolved"
 
 type JobsListMembershipItem = {
   readonly state: WorkItemState
-  readonly stepRuns: readonly { readonly status: StepRunStatus }[]
+  readonly failureCode?: string | null
 }
 
-/**
- * Jobs card Failed tab: terminal `failed`, or nonterminal stopped on a
- * failed/interrupted latest Step Run (retriable).
- */
-export const isJobsFailedWorkItem = (item: JobsListMembershipItem): boolean => {
-  if (item.state === "failed") {
-    return true
-  }
-  if (isTerminalWorkItemState(item.state)) {
-    return false
-  }
-  const latest = item.stepRuns.at(-1)
-  return latest !== undefined && isJobsFailedStepRunStatus(latest.status)
-}
+/** Persisted terminal status-check failures are retryable for compatibility. */
+export const isRetryableFailedWorkItem = (
+  item: JobsListMembershipItem,
+): boolean =>
+  item.state === "failed" &&
+  item.failureCode === RETRYABLE_FAILED_WORK_ITEM_CODE
+
+/** Jobs card Failed tab: non-retryable terminal failures only. */
+export const isJobsFailedWorkItem = (item: JobsListMembershipItem): boolean =>
+  item.state === "failed" && !isRetryableFailedWorkItem(item)
 
 /**
- * Jobs card Working tab: unfinished lifecycle work plus Needs Human handoffs,
- * excluding Work Items currently stopped on a failed/interrupted Step Run.
+ * Jobs card Working tab: unfinished lifecycle work, retryable stoppages, and
+ * Needs Human handoffs.
  */
 export const isJobsWorkingWorkItem = (item: JobsListMembershipItem): boolean =>
   !isJobsCompletedWorkItemState(item.state) && !isJobsFailedWorkItem(item)
@@ -217,8 +201,8 @@ const applyLimit = <T>(
 export const filterWorkItemsByListKind = <
   T extends {
     readonly state: WorkItemState
+    readonly failureCode?: string | null
     readonly createdAt: Date
-    readonly stepRuns: readonly { readonly status: StepRunStatus }[]
   },
 >(
   workItems: readonly T[],

--- a/packages/work-item-lifecycle/test/jobs-list-filter.spec.ts
+++ b/packages/work-item-lifecycle/test/jobs-list-filter.spec.ts
@@ -12,8 +12,10 @@ const item = (
   state: WorkItemState,
   createdAtMs: number,
   latestStepStatus?: StepRunStatus,
+  failureCode: string | null = null,
 ) => ({
   state,
+  failureCode,
   createdAt: new Date(createdAtMs),
   stepRuns:
     latestStepStatus === undefined
@@ -44,12 +46,23 @@ describe("Jobs list membership", () => {
     expect(isJobsCompletedWorkItemState("failed")).toBe(false)
   })
 
-  it("places nonterminal failed/interrupted Step Runs only on Failed", () => {
+  it("keeps nonterminal failed/interrupted Step Runs on Working", () => {
     for (const status of ["failed", "interrupted"] as const) {
       const stopped = item("implement", 1, status)
-      expect(isJobsFailedWorkItem(stopped)).toBe(true)
-      expect(isJobsWorkingWorkItem(stopped)).toBe(false)
+      expect(isJobsFailedWorkItem(stopped)).toBe(false)
+      expect(isJobsWorkingWorkItem(stopped)).toBe(true)
     }
+  })
+
+  it("keeps the persisted retryable terminal failure on Working", () => {
+    const retryable = item(
+      "failed",
+      1,
+      "succeeded",
+      "pr_status_checks_unresolved",
+    )
+    expect(isJobsFailedWorkItem(retryable)).toBe(false)
+    expect(isJobsWorkingWorkItem(retryable)).toBe(true)
   })
 
   it("places unfinished lifecycle states on Working when not stopped on failure", () => {
@@ -78,16 +91,22 @@ describe("filterWorkItemsByListKind", () => {
     expect(filterWorkItemsByListKind(items, undefined)).toEqual(items)
   })
 
-  it("filters Working to unfinished plus Needs Human, excluding failures", () => {
+  it("filters Working to unfinished, retryable stoppages, and Needs Human", () => {
     expect(
       filterWorkItemsByListKind(items, "working").map((i) => i.state),
-    ).toEqual(["implement", "needs_human", "create_worktree"])
+    ).toEqual([
+      "implement",
+      "needs_human",
+      "create_worktree",
+      "pre_commit",
+      "review",
+    ])
   })
 
-  it("filters Failed to terminal failed plus retriable stoppages, newest-first", () => {
+  it("filters Failed to non-retryable terminal failures only", () => {
     expect(
       filterWorkItemsByListKind(items, "failed").map((i) => i.state),
-    ).toEqual(["review", "pre_commit", "failed"])
+    ).toEqual(["failed"])
   })
 
   it("filters Completed to Complete/Abandoned newest-first without terminal failed", () => {
@@ -98,7 +117,7 @@ describe("filterWorkItemsByListKind", () => {
 
   it("limits Failed to the newest N by createdAt", () => {
     const many = Array.from({ length: 20 }, (_, index) =>
-      item(index % 2 === 0 ? "failed" : "implement", index * 100, "failed"),
+      item("failed", index * 100, "failed"),
     )
     const limited = filterWorkItemsByListKind(many, "failed", 15)
     expect(limited).toHaveLength(15)
@@ -129,7 +148,7 @@ describe("filterWorkItemsByListKind", () => {
     ).toEqual(["complete", "abandoned"])
   })
 
-  it("does not put Failed under Working", () => {
+  it("puts retryable failures under Working, not terminal failures", () => {
     const mixed = [
       item("implement", 1000, "failed"),
       item("failed", 2000, "failed"),
@@ -137,9 +156,9 @@ describe("filterWorkItemsByListKind", () => {
     ]
     expect(
       filterWorkItemsByListKind(mixed, "working").map((i) => i.state),
-    ).toEqual(["implement"])
+    ).toEqual(["implement", "implement"])
     expect(
       filterWorkItemsByListKind(mixed, "working")[0]!.stepRuns[0]!.status,
-    ).toBe("running")
+    ).toBe("failed")
   })
 })


### PR DESCRIPTION
## Why

Retriable Work Items currently appear under Failed even though operators can still continue them with Retry.

## What Changed

- Keep nonterminal failed or interrupted Step Runs under Working.
- Restrict Failed membership to non-retryable terminal failures.
- Share the persisted retryable status-check failure classification with GraphQL `canRetry`.
- Add lifecycle and GraphQL regression coverage and update the schema documentation.

Closes #339

## Test plan

- [x] `bunx nx affected --targets=lint,typecheck`
- [x] `bunx nx affected --target=test`
- [x] Pre-commit affected lint, typecheck, and test checks