### PR TITLE
fix(e2e): generate embedded assets before CLI run

### DIFF
--- a/apps/ready-for-agent/project.json
+++ b/apps/ready-for-agent/project.json
@@ -11,7 +11,8 @@
         {
           "projects": ["graphql-client"],
           "target": "generate"
-        }
+        },
+        "generate-embed"
       ],
       "options": {
         "cwd": "{projectRoot}",

--- a/apps/ready-for-agent/src/target-topology.test.ts
+++ b/apps/ready-for-agent/src/target-topology.test.ts
@@ -1,0 +1,16 @@
+import { readFile } from "node:fs/promises"
+import { describe, expect, test } from "bun:test"
+
+describe("ready-for-agent target topology", () => {
+  test("generates embedded client assets before running the source CLI", async () => {
+    const project = JSON.parse(
+      await readFile(new URL("../project.json", import.meta.url), "utf8"),
+    ) as {
+      targets: {
+        run?: { dependsOn?: unknown[] }
+      }
+    }
+
+    expect(project.targets.run?.dependsOn).toContain("generate-embed")
+  })
+})


### PR DESCRIPTION
## Why

The live Harness e2e invokes `ready-for-agent:run` on a clean GitHub Actions runner. That target imported ignored embedded client assets without generating them first, causing the CLI to fail before the scenario could add its fixture Repository.

## What Changed

Make `ready-for-agent:run` depend on `generate-embed`, and add a topology test that preserves the prerequisite.

## Verification

`bunx nx run ready-for-agent:run --args=--help` now runs `ready-for-agent:generate-embed` before loading the CLI.
