### PR TITLE
test(queue-service): share queue service stubs

### DIFF
--- a/apps/harness/test/job-worker.test.ts
+++ b/apps/harness/test/job-worker.test.ts
@@ -37,10 +37,10 @@ import { Opencode } from "@ready-for-agent/opencode"
 import {
   ClaimError,
   QueueService,
-  type QueueServiceShape,
   type RawJob,
   makeJobId,
 } from "@ready-for-agent/queue-service"
+import { stubQueueService } from "@ready-for-agent/queue-service/test"
 import { SqliteQueueServiceLive } from "@ready-for-agent/sqlite-queue-service"
 import {
   WorkItemLifecycle,
@@ -173,38 +173,34 @@ const queueLayer = (
 ) =>
   Layer.mergeAll(
     defaultGithubLayer,
-    Layer.succeed(QueueService, {
-      queueInTransaction: true,
-      enqueue: unused,
-      enqueueWithDelay: unused,
-      ensureKeyed: unused,
-      listKeyed: unused,
-      reviveExhaustedKeyed: () => Effect.void,
-      postponeKeyed: (jobId, delay) =>
-        onPostponeKeyed(jobId, delay).pipe(Effect.asVoid),
-      removeKeyed: unused,
-      rawClaim: (queueName, visibilityTimeout) =>
-        Effect.gen(function* () {
-          expect(Duration.toMillis(visibilityTimeout ?? Duration.zero)).toBe(
-            Duration.toMillis(JOB_VISIBILITY_TIMEOUT),
-          )
-          if (onClaim !== undefined) return yield* onClaim(queueName)
-          const index = jobs.findIndex((job) => job.queue === queueName)
-          if (index === -1) return Option.none()
-          const [job] = jobs.splice(index, 1)
-          return Option.some(job)
-        }),
-      acknowledge: (jobId) => onAcknowledge(jobId).pipe(Effect.asVoid),
-      fail: (jobId, options) =>
-        Effect.gen(function* () {
-          expect(options?.retryable).toBe(false)
-          yield* onFail(jobId)
-        }),
-      extendVisibility: (jobId, timeout) =>
-        onExtendVisibility(jobId, timeout).pipe(Effect.asVoid),
-      getStats: unused,
-      requeueByPayloadTag: () => Effect.succeed(0),
-    } satisfies QueueServiceShape),
+    Layer.succeed(
+      QueueService,
+      stubQueueService({
+        reviveExhaustedKeyed: () => Effect.void,
+        postponeKeyed: (jobId, delay) =>
+          onPostponeKeyed(jobId, delay).pipe(Effect.asVoid),
+        rawClaim: (queueName, visibilityTimeout) =>
+          Effect.gen(function* () {
+            expect(Duration.toMillis(visibilityTimeout ?? Duration.zero)).toBe(
+              Duration.toMillis(JOB_VISIBILITY_TIMEOUT),
+            )
+            if (onClaim !== undefined) return yield* onClaim(queueName)
+            const index = jobs.findIndex((job) => job.queue === queueName)
+            if (index === -1) return Option.none()
+            const [job] = jobs.splice(index, 1)
+            return Option.some(job)
+          }),
+        acknowledge: (jobId) => onAcknowledge(jobId).pipe(Effect.asVoid),
+        fail: (jobId, options) =>
+          Effect.gen(function* () {
+            expect(options?.retryable).toBe(false)
+            yield* onFail(jobId)
+          }),
+        extendVisibility: (jobId, timeout) =>
+          onExtendVisibility(jobId, timeout).pipe(Effect.asVoid),
+        requeueByPayloadTag: () => Effect.succeed(0),
+      }),
+    ),
     Layer.succeed(WorkItemLifecycle, {
       maxDurations: {
         create_worktree: Duration.minutes(5),
@@ -260,30 +256,20 @@ describe("Job worker", () => {
           retryLimit: number | undefined
         }
       | undefined
-    const queue = Layer.succeed(QueueService, {
-      queueInTransaction: true,
-      enqueue: (queueName, payload, options) =>
-        Effect.sync(() => {
-          enqueued = {
-            queue: queueName,
-            payload,
-            retryLimit: options?.retryLimit,
-          }
-          return makeJobId()
-        }),
-      enqueueWithDelay: unused,
-      ensureKeyed: unused,
-      listKeyed: unused,
-      reviveExhaustedKeyed: () => Effect.void,
-      postponeKeyed: unused,
-      removeKeyed: unused,
-      rawClaim: unused,
-      acknowledge: unused,
-      fail: unused,
-      extendVisibility: unused,
-      getStats: unused,
-      requeueByPayloadTag: () => Effect.succeed(0),
-    } satisfies QueueServiceShape)
+    const queue = Layer.succeed(
+      QueueService,
+      stubQueueService({
+        enqueue: (queueName, payload, options) =>
+          Effect.sync(() => {
+            enqueued = {
+              queue: queueName,
+              payload,
+              retryLimit: options?.retryLimit,
+            }
+            return makeJobId()
+          }),
+      }),
+    )
 
     await Effect.runPromise(
       enqueueRefreshRepositoryJob(refreshPayload.repositoryId).pipe(

--- a/packages/graphql-api/test/graphql-api.test.ts
+++ b/packages/graphql-api/test/graphql-api.test.ts
@@ -15,6 +15,7 @@ import {
   type QueueServiceShape,
   makeJobId,
 } from "@ready-for-agent/queue-service"
+import { stubQueueService } from "@ready-for-agent/queue-service/test"
 import {
   STEP_RUN_REASON,
   WAITING_FOR_OPENCODE_SESSION_MESSAGE,
@@ -149,23 +150,11 @@ const makeRuntime = (
     runWithSecrets: () => Effect.die("not used"),
     ...keymaxxerOverrides,
   }
-  const queue: QueueServiceShape = {
-    queueInTransaction: true,
+  const queue = stubQueueService({
     enqueue: () => Effect.succeed(makeJobId()),
-    enqueueWithDelay: () => Effect.die("not used"),
-    ensureKeyed: () => Effect.die("not used"),
-    listKeyed: () => Effect.die("not used"),
-    reviveExhaustedKeyed: () => Effect.die("not used"),
-    postponeKeyed: () => Effect.die("not used"),
-    removeKeyed: () => Effect.die("not used"),
-    rawClaim: () => Effect.die("not used"),
-    acknowledge: () => Effect.die("not used"),
-    fail: () => Effect.die("not used"),
-    extendVisibility: () => Effect.die("not used"),
-    getStats: () => Effect.die("not used"),
     requeueByPayloadTag: () => Effect.succeed(0),
     ...queueOverrides,
-  }
+  })
   const lifecycle: WorkItemLifecycleShape = {
     maxDurations: {
       create_worktree: Duration.minutes(5),

--- a/packages/graphql-api/test/issue-polling.test.ts
+++ b/packages/graphql-api/test/issue-polling.test.ts
@@ -11,6 +11,7 @@ import {
   type QueueServiceShape,
   makeJobId,
 } from "@ready-for-agent/queue-service"
+import { stubQueueService } from "@ready-for-agent/queue-service/test"
 import {
   ISSUE_POLLING_BASE_SECONDS,
   ISSUE_POLLING_JITTER_SECONDS,
@@ -30,23 +31,6 @@ const repoKeep = "repo-01J00000000000000000000002"
 const repoOrphan = "repo-01J00000000000000000000003"
 const repoAdded = "repo-01J00000000000000000000004"
 
-const unusedQueue: QueueServiceShape = {
-  queueInTransaction: true,
-  enqueue: () => Effect.die("not used"),
-  enqueueWithDelay: () => Effect.die("not used"),
-  ensureKeyed: () => Effect.die("not used"),
-  listKeyed: () => Effect.die("not used"),
-  reviveExhaustedKeyed: () => Effect.die("not used"),
-  postponeKeyed: () => Effect.die("not used"),
-  removeKeyed: () => Effect.die("not used"),
-  rawClaim: () => Effect.die("not used"),
-  acknowledge: () => Effect.die("not used"),
-  fail: () => Effect.die("not used"),
-  extendVisibility: () => Effect.die("not used"),
-  getStats: () => Effect.die("not used"),
-  requeueByPayloadTag: () => Effect.succeed(0),
-}
-
 describe("issue-polling", () => {
   test("activateRepositoryPolling ensures keyed schedule and first refresh", async () => {
     const ensured: Array<{
@@ -55,19 +39,20 @@ describe("issue-polling", () => {
       delay: Duration.Duration
     }> = []
     const enqueued: Array<{ queue: string; payload: unknown }> = []
-    const runtime = makeQueueRuntime({
-      ...unusedQueue,
-      enqueue: (queueName, payload) =>
-        Effect.sync(() => {
-          enqueued.push({ queue: queueName, payload })
-          return makeJobId()
-        }),
-      ensureKeyed: (queueName, key, _payload, delay) =>
-        Effect.sync(() => {
-          ensured.push({ queue: queueName, key, delay })
-          return { jobId: makeJobId(), created: true }
-        }),
-    })
+    const runtime = makeQueueRuntime(
+      stubQueueService({
+        enqueue: (queueName, payload) =>
+          Effect.sync(() => {
+            enqueued.push({ queue: queueName, payload })
+            return makeJobId()
+          }),
+        ensureKeyed: (queueName, key, _payload, delay) =>
+          Effect.sync(() => {
+            ensured.push({ queue: queueName, key, delay })
+            return { jobId: makeJobId(), created: true }
+          }),
+      }),
+    )
 
     try {
       await runtime.runPromise(
@@ -95,13 +80,14 @@ describe("issue-polling", () => {
 
   test("suspendRepositoryPolling removes the keyed schedule", async () => {
     const removed: Array<{ queue: string; key: string }> = []
-    const runtime = makeQueueRuntime({
-      ...unusedQueue,
-      removeKeyed: (queueName, key) =>
-        Effect.sync(() => {
-          removed.push({ queue: queueName, key })
-        }),
-    })
+    const runtime = makeQueueRuntime(
+      stubQueueService({
+        removeKeyed: (queueName, key) =>
+          Effect.sync(() => {
+            removed.push({ queue: queueName, key })
+          }),
+      }),
+    )
 
     try {
       await runtime.runPromise(suspendRepositoryPolling(repo1))
@@ -116,39 +102,43 @@ describe("issue-polling", () => {
     const removed: string[] = []
     const ensured: string[] = []
     const enqueued: string[] = []
-    const runtime = makeQueueRuntime({
-      ...unusedQueue,
-      enqueue: (_queue, payload) =>
-        Effect.sync(() => {
-          const body = payload as { repositoryId: string }
-          enqueued.push(body.repositoryId)
-          return makeJobId()
-        }),
-      ensureKeyed: (_queue, key) =>
-        Effect.sync(() => {
-          ensured.push(key)
-          keyed.add(key)
-          return { jobId: makeJobId(), created: true }
-        }),
-      listKeyed: () =>
-        Effect.sync(() =>
-          [...keyed].map((key) => ({
-            jobId: makeJobId(),
-            queue: ISSUE_POLL_QUEUE,
-            key,
-            payload: { _tag: "refresh-repository" as const, repositoryId: key },
-            attempts: 0,
-            maxAttempts: 2,
-            availableAt: DateTime.makeUnsafe(0),
-            lockedUntil: null,
-          })),
-        ),
-      removeKeyed: (_queue, key) =>
-        Effect.sync(() => {
-          removed.push(key)
-          keyed.delete(key)
-        }),
-    })
+    const runtime = makeQueueRuntime(
+      stubQueueService({
+        enqueue: (_queue, payload) =>
+          Effect.sync(() => {
+            const body = payload as { repositoryId: string }
+            enqueued.push(body.repositoryId)
+            return makeJobId()
+          }),
+        ensureKeyed: (_queue, key) =>
+          Effect.sync(() => {
+            ensured.push(key)
+            keyed.add(key)
+            return { jobId: makeJobId(), created: true }
+          }),
+        listKeyed: () =>
+          Effect.sync(() =>
+            [...keyed].map((key) => ({
+              jobId: makeJobId(),
+              queue: ISSUE_POLL_QUEUE,
+              key,
+              payload: {
+                _tag: "refresh-repository" as const,
+                repositoryId: key,
+              },
+              attempts: 0,
+              maxAttempts: 2,
+              availableAt: DateTime.makeUnsafe(0),
+              lockedUntil: null,
+            })),
+          ),
+        removeKeyed: (_queue, key) =>
+          Effect.sync(() => {
+            removed.push(key)
+            keyed.delete(key)
+          }),
+      }),
+    )
 
     try {
       await runtime.runPromise(

--- a/packages/queue-service/package.json
+++ b/packages/queue-service/package.json
@@ -13,6 +13,12 @@
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
       "default": "./dist/index.js"
+    },
+    "./test": {
+      "@ready-for-agent/source": "./src/lib/test-fixtures.ts",
+      "types": "./dist/lib/test-fixtures.d.ts",
+      "import": "./dist/lib/test-fixtures.js",
+      "default": "./dist/lib/test-fixtures.js"
     }
   },
   "nx": {

--- a/packages/queue-service/src/lib/test-fixtures.ts
+++ b/packages/queue-service/src/lib/test-fixtures.ts
@@ -1,0 +1,25 @@
+import { Effect } from "effect"
+import type { QueueServiceShape } from "./queue-service.js"
+
+const unexpected = (operation: keyof QueueServiceShape) =>
+  Effect.die(`Unexpected QueueService.${operation} call`)
+
+export const stubQueueService = (
+  overrides: Partial<QueueServiceShape> = {},
+): QueueServiceShape => ({
+  queueInTransaction: true,
+  enqueue: () => unexpected("enqueue"),
+  enqueueWithDelay: () => unexpected("enqueueWithDelay"),
+  ensureKeyed: () => unexpected("ensureKeyed"),
+  listKeyed: () => unexpected("listKeyed"),
+  reviveExhaustedKeyed: () => unexpected("reviveExhaustedKeyed"),
+  postponeKeyed: () => unexpected("postponeKeyed"),
+  removeKeyed: () => unexpected("removeKeyed"),
+  rawClaim: () => unexpected("rawClaim"),
+  acknowledge: () => unexpected("acknowledge"),
+  fail: () => unexpected("fail"),
+  extendVisibility: () => unexpected("extendVisibility"),
+  getStats: () => unexpected("getStats"),
+  requeueByPayloadTag: () => unexpected("requeueByPayloadTag"),
+  ...overrides,
+})

--- a/packages/queue-service/test/claim.spec.ts
+++ b/packages/queue-service/test/claim.spec.ts
@@ -3,9 +3,10 @@ import {
   JobId,
   PayloadParseError,
   QueueService,
-  type QueueServiceShape,
   type RawJob,
 } from "../src/index.js"
+import type { QueueServiceShape } from "../src/lib/queue-service.js"
+import { stubQueueService } from "../src/lib/test-fixtures.js"
 import { describe, expect, it } from "bun:test"
 
 const TestPayload = Schema.Struct({
@@ -27,22 +28,11 @@ const makeRawJob = (payload: unknown): RawJob => ({
 
 const makeFakeQueue = (
   rawClaim: QueueServiceShape["rawClaim"],
-): QueueServiceShape => ({
-  queueInTransaction: false,
-  enqueue: () => Effect.die("unused"),
-  enqueueWithDelay: () => Effect.die("unused"),
-  ensureKeyed: () => Effect.die("unused"),
-  listKeyed: () => Effect.die("unused"),
-  reviveExhaustedKeyed: () => Effect.die("unused"),
-  postponeKeyed: () => Effect.die("unused"),
-  removeKeyed: () => Effect.die("unused"),
-  rawClaim,
-  acknowledge: () => Effect.die("unused"),
-  fail: () => Effect.die("unused"),
-  extendVisibility: () => Effect.die("unused"),
-  getStats: () => Effect.die("unused"),
-  requeueByPayloadTag: () => Effect.die("unused"),
-})
+): QueueServiceShape =>
+  stubQueueService({
+    queueInTransaction: false,
+    rawClaim,
+  })
 
 const runWithQueue = <A, E>(
   queue: QueueServiceShape,
@@ -51,6 +41,14 @@ const runWithQueue = <A, E>(
   Effect.runPromise(
     Effect.provide(effect, Layer.succeed(QueueService, QueueService.of(queue))),
   )
+
+describe("stubQueueService", () => {
+  it("identifies unexpected operation calls", async () => {
+    await expect(
+      Effect.runPromise(stubQueueService().enqueue("test-queue", {})),
+    ).rejects.toThrow("Unexpected QueueService.enqueue call")
+  })
+})
 
 describe("QueueService.claim", () => {
   it("returns None when rawClaim returns None", async () => {

--- a/packages/work-item-lifecycle/test/work-item-lifecycle.spec.ts
+++ b/packages/work-item-lifecycle/test/work-item-lifecycle.spec.ts
@@ -22,8 +22,8 @@ import {
   EnqueueError,
   type JobId,
   QueueService,
-  type QueueServiceShape,
 } from "@ready-for-agent/queue-service"
+import { stubQueueService } from "@ready-for-agent/queue-service/test"
 import { SqliteQueueServiceLive } from "@ready-for-agent/sqlite-queue-service"
 import {
   ActiveStepRunExistsError,
@@ -546,8 +546,7 @@ describe("WorkItemLifecycle", () => {
 
     it("rolls back when enqueue fails mid-transaction", () => {
       let enqueueCalls = 0
-      const failingEnqueueQueue: QueueServiceShape = {
-        queueInTransaction: true,
+      const failingEnqueueQueue = stubQueueService({
         enqueue: () => {
           enqueueCalls += 1
           return Effect.fail(
@@ -557,28 +556,7 @@ describe("WorkItemLifecycle", () => {
             }),
           )
         },
-        enqueueWithDelay: () =>
-          Effect.die("enqueueWithDelay should not be called") as Effect.Effect<
-            JobId,
-            never
-          >,
-        ensureKeyed: () =>
-          Effect.die("ensureKeyed should not be called") as Effect.Effect<
-            never,
-            never
-          >,
-        listKeyed: () => Effect.succeed([]),
-        reviveExhaustedKeyed: () => Effect.die("unused"),
-        postponeKeyed: () => Effect.void,
-        removeKeyed: () => Effect.void,
-        rawClaim: () => Effect.succeed(Option.none()),
-        acknowledge: () => Effect.void,
-        fail: () => Effect.void,
-        extendVisibility: () => Effect.void,
-        getStats: () =>
-          Effect.succeed({ pending: 0, processing: 0, deadLetter: 0 }),
-        requeueByPayloadTag: () => Effect.succeed(0),
-      }
+      })
 
       const layer = WorkItemLifecycleLive.pipe(
         Layer.provideMerge(SuccessfulStepsLive),
@@ -1034,35 +1012,9 @@ describe("WorkItemLifecycle", () => {
 
   describe("queue requirements", () => {
     it("rejects construction when QueueService is not transactional", async () => {
-      const nonTransactionalQueue: QueueServiceShape = {
+      const nonTransactionalQueue = stubQueueService({
         queueInTransaction: false,
-        enqueue: () =>
-          Effect.die("enqueue should not be called") as Effect.Effect<
-            JobId,
-            never
-          >,
-        enqueueWithDelay: () =>
-          Effect.die("enqueueWithDelay should not be called") as Effect.Effect<
-            JobId,
-            never
-          >,
-        ensureKeyed: () =>
-          Effect.die("ensureKeyed should not be called") as Effect.Effect<
-            never,
-            never
-          >,
-        listKeyed: () => Effect.succeed([]),
-        reviveExhaustedKeyed: () => Effect.die("unused"),
-        postponeKeyed: () => Effect.void,
-        removeKeyed: () => Effect.void,
-        rawClaim: () => Effect.succeed(Option.none()),
-        acknowledge: () => Effect.void,
-        fail: () => Effect.void,
-        extendVisibility: () => Effect.void,
-        getStats: () =>
-          Effect.succeed({ pending: 0, processing: 0, deadLetter: 0 }),
-        requeueByPayloadTag: () => Effect.succeed(0),
-      }
+      })
 
       const NonTransactionalQueueLive = Layer.succeed(
         QueueService,
@@ -3465,8 +3417,7 @@ describe("WorkItemLifecycle", () => {
 
     it("rolls back advancement when next-step enqueue fails", () => {
       let enqueueCalls = 0
-      const queueShape: QueueServiceShape = {
-        queueInTransaction: true,
+      const queueShape = stubQueueService({
         enqueue: (_queue, _payload) => {
           enqueueCalls += 1
           // First enqueue is implementNow; second is advancement after create worktree.
@@ -3480,28 +3431,7 @@ describe("WorkItemLifecycle", () => {
             }),
           )
         },
-        enqueueWithDelay: () =>
-          Effect.die("enqueueWithDelay should not be called") as Effect.Effect<
-            JobId,
-            never
-          >,
-        ensureKeyed: () =>
-          Effect.die("ensureKeyed should not be called") as Effect.Effect<
-            never,
-            never
-          >,
-        listKeyed: () => Effect.succeed([]),
-        reviveExhaustedKeyed: () => Effect.die("unused"),
-        postponeKeyed: () => Effect.void,
-        removeKeyed: () => Effect.void,
-        rawClaim: () => Effect.succeed(Option.none()),
-        acknowledge: () => Effect.void,
-        fail: () => Effect.void,
-        extendVisibility: () => Effect.void,
-        getStats: () =>
-          Effect.succeed({ pending: 0, processing: 0, deadLetter: 0 }),
-        requeueByPayloadTag: () => Effect.succeed(0),
-      }
+      })
 
       // Real DB + fake queue so we can fail the post-success enqueue.
       // Step run is started via runStep using the id from implementNow.


### PR DESCRIPTION
## Why

Tests across multiple packages independently constructed complete `QueueServiceShape` objects, so adding a queue operation caused broad test churn and left unused behavior inconsistent.

## What Changed

- Add a shared `stubQueueService` fixture with a complete shape and operation-specific fail-fast defaults.
- Export the fixture through `@ready-for-agent/queue-service/test`.
- Migrate GraphQL API, Harness, queue-service, and Work Item lifecycle tests to override only scenario-specific operations.
- Preserve intentional no-op and successful queue behavior explicitly.

Closes #347

## Verification

- [x] `bunx nx affected -t lint,typecheck,test`
- [x] Pre-commit affected lint, typecheck, and test checks
- [x] `git diff --check`