### PR TITLE
fix(work-item-lifecycle): verify worktree cleanup

### DIFF
--- a/packages/work-item-lifecycle/src/lib/git.ts
+++ b/packages/work-item-lifecycle/src/lib/git.ts
@@ -43,8 +43,12 @@ export const runGit = (
     )
 
     if (result.exitCode !== 0) {
+      const diagnostic = result.stderr.trim()
       return yield* new GitCommandError({
-        message: `git ${args.join(" ")} failed with exit ${result.exitCode}`,
+        message:
+          diagnostic === ""
+            ? `git ${args.join(" ")} failed with exit ${result.exitCode}`
+            : `git ${args.join(" ")} failed with exit ${result.exitCode}: ${diagnostic}`,
         command: "git",
         args: fullArgs,
         cwd: repository.localPath,

--- a/packages/work-item-lifecycle/src/lib/remove-worktree.ts
+++ b/packages/work-item-lifecycle/src/lib/remove-worktree.ts
@@ -301,7 +301,19 @@ const removeLocalArtifacts = (
           "remove",
           "--force",
           worktreePath,
-        ])
+        ]).pipe(
+          Effect.catchTag("GitCommandError", (error) =>
+            Effect.gen(function* () {
+              // Git can remove the worktree before reporting a late cleanup error.
+              const [stillListed, stillPresent] = yield* Effect.all([
+                worktreeListContains(gitRepository, worktreePath),
+                pathExists(worktreePath),
+              ])
+              if (!stillListed && !stillPresent) return
+              return yield* error
+            }),
+          ),
+        )
       }
 
       const stillPresent = yield* pathExists(worktreePath)

--- a/packages/work-item-lifecycle/test/remove-worktree.spec.ts
+++ b/packages/work-item-lifecycle/test/remove-worktree.spec.ts
@@ -298,6 +298,53 @@ describe("removeWorktree", () => {
     }
   })
 
+  it("reports Git's diagnostic when a locked worktree cannot be removed", async () => {
+    const root = await mkdtemp(join(tmpdir(), "rfa-rm-wt-locked-"))
+    try {
+      const bare = await initBareRepository(root)
+      const workItemId = makeWorkItemId()
+
+      const error = await run(
+        Effect.gen(function* () {
+          const db = yield* DbService
+          const repository = yield* db.addRepository({
+            githubOwner: "acme",
+            githubRepo: "widgets",
+            localPath: bare,
+            isBare: true,
+          })
+          const context = {
+            workItemId,
+            repositoryId: repository.id,
+            githubIssueNumber: 42,
+            model: "opencode/test",
+            variant: "low",
+            reviewModel: "opencode/test",
+            reviewVariant: "low",
+            worktreePath: null,
+            startingCommitOid: null,
+            completionSummary: null,
+            sessionId: null,
+          } as const
+
+          const created = yield* createWorktree(context)
+          yield* Effect.promise(() =>
+            git(bare, ["worktree", "lock", created.worktreePath]),
+          )
+          return yield* localCleanup(context).pipe(Effect.flip)
+        }),
+      )
+
+      expect(error._tag).toBe("GitCommandError")
+      expect(error.message).toContain("locked working tree")
+      if (error._tag === "GitCommandError") {
+        expect(error.stderr).toContain("locked working tree")
+      }
+    } finally {
+      await rm(root, { recursive: true, force: true })
+    }
+  })
+
   it("closes an open remote PR for the Work Item branch and drops the remote branch", async () => {
     const root = await mkdtemp(join(tmpdir(), "rfa-rm-wt-remote-"))
     try {


### PR DESCRIPTION
## Why

Local cleanup can leave a Work Item stuck when `git worktree remove` returns a late non-zero exit after it has already removed both the worktree directory and Git registration. Cleanup failures also omitted Git's stderr, hiding the actionable diagnostic.

## What Changed

- Verify the worktree registration and directory after a failed removal, accepting cleanup when both are already gone.
- Include Git stderr in `GitCommandError` messages.
- Cover locked-worktree diagnostics with an integration test.

## Verification

Reproduced the reported state where the worktree directory and registration were gone while the Work Item retained a failed cleanup. The affected Nx lint, typecheck, test, and build targets pass, including 297 `work-item-lifecycle` tests.
