### PR TITLE
fix(graphql-api): ignore package runner PATH entries

### DIFF
--- a/packages/graphql-api/src/lib/add-repository-command.ts
+++ b/packages/graphql-api/src/lib/add-repository-command.ts
@@ -1,8 +1,16 @@
 import { accessSync, constants } from "node:fs"
-import { delimiter, join } from "node:path"
+import { basename, delimiter, dirname, join, normalize } from "node:path"
 
 export const OPERATOR_BINARY = "ready-for-agent"
 export const ADD_REPOSITORY_PATH_PLACEHOLDER = "/path/to/local/repo"
+
+const isPackageRunnerBinDirectory = (directory: string): boolean => {
+  const normalized = normalize(directory)
+  return (
+    basename(normalized) === ".bin" &&
+    basename(dirname(normalized)) === "node_modules"
+  )
+}
 
 export const commandExistsOnPath = (
   command: string,
@@ -12,7 +20,7 @@ export const commandExistsOnPath = (
     return false
   }
   for (const directory of pathEnv.split(delimiter)) {
-    if (directory.length === 0) {
+    if (directory.length === 0 || isPackageRunnerBinDirectory(directory)) {
       continue
     }
     try {

--- a/packages/graphql-api/test/add-repository-command.test.ts
+++ b/packages/graphql-api/test/add-repository-command.test.ts
@@ -1,9 +1,60 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { delimiter, join } from "node:path"
 import {
   addRepositoryCommand,
+  commandExistsOnPath,
   isOperatorBinaryOnPath,
   resolveAddRepositoryCommand,
 } from "../src/lib/add-repository-command.js"
-import { describe, expect, test } from "bun:test"
+import { afterEach, describe, expect, test } from "bun:test"
+
+const temporaryDirectories: Array<string> = []
+
+const executableAt = (directory: string, command: string): void => {
+  mkdirSync(directory, { recursive: true })
+  writeFileSync(join(directory, command), "#!/bin/sh\n", { mode: 0o755 })
+}
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) {
+    rmSync(directory, { recursive: true, force: true })
+  }
+})
+
+describe("commandExistsOnPath", () => {
+  test("ignores a binary available only through an npx node_modules bin", () => {
+    const root = mkdtempSync(join(tmpdir(), "ready-for-agent-path-"))
+    temporaryDirectories.push(root)
+    const npxBin = join(
+      root,
+      ".npm",
+      "_npx",
+      "cache-key",
+      "node_modules",
+      ".bin",
+    )
+    executableAt(npxBin, "ready-for-agent")
+
+    expect(commandExistsOnPath("ready-for-agent", npxBin)).toBe(false)
+  })
+
+  test("still finds a binary on a durable PATH entry", () => {
+    const root = mkdtempSync(join(tmpdir(), "ready-for-agent-path-"))
+    temporaryDirectories.push(root)
+    const packageBin = join(root, "node_modules", ".bin")
+    const durableBin = join(root, ".local", "bin")
+    executableAt(packageBin, "ready-for-agent")
+    executableAt(durableBin, "ready-for-agent")
+
+    expect(
+      commandExistsOnPath(
+        "ready-for-agent",
+        [packageBin, durableBin].join(delimiter),
+      ),
+    ).toBe(true)
+  })
+})
 
 describe("addRepositoryCommand", () => {
   test("suggests bare binary when on PATH", () => {


### PR DESCRIPTION
## Why

When the product starts through `npx ready-for-agent`, npm injects an ephemeral `node_modules/.bin` directory into the server process PATH. The existing probe mistakes that shim for a durable user installation and suggests a bare command that fails in a fresh shell.

## What Changed

- Ignore `node_modules/.bin` entries when checking whether `ready-for-agent` is available on the user PATH.
- Preserve bare command suggestions when the binary exists in a durable PATH location.
- Add regression coverage for npx-only and mixed ephemeral/durable PATHs.

Closes #356

## Verification

- [x] `bunx nx run graphql-api:lint`
- [x] `bunx nx run graphql-api:test`
- [x] `bunx nx run graphql-api:typecheck`
- [x] `bunx nx run graphql-api:build`
- [x] Pre-commit affected lint, typecheck, and test checks