### PR TITLE
fix(harness): calendar-week PR dashboard periods

### DIFF
--- a/apps/harness/e2e/steps/add-and-refresh-repository.ts
+++ b/apps/harness/e2e/steps/add-and-refresh-repository.ts
@@ -32,6 +32,7 @@ Given("the Harness has no configured Repositories", async ({ page }) => {
   ).toHaveCount(0)
   await expect(page.getByText("Today", { exact: true })).toHaveCount(0)
   await expect(page.getByText("Yesterday", { exact: true })).toHaveCount(0)
+  await expect(page.getByText("This week", { exact: true })).toHaveCount(0)
   await expect(page.getByText("Last week", { exact: true })).toHaveCount(0)
   await expect(page.getByRole("region", { name: "Jobs" })).toHaveCount(0)
   await expect(page.getByRole("heading", { name: "Jobs" })).toHaveCount(0)

--- a/apps/harness/src/local-day-bounds.ts
+++ b/apps/harness/src/local-day-bounds.ts
@@ -6,14 +6,21 @@ export const localCommittedPullRequestDayBounds = (now = new Date()) => {
   startOfTomorrow.setDate(startOfTomorrow.getDate() + 1)
   const startOfYesterday = new Date(startOfToday)
   startOfYesterday.setDate(startOfYesterday.getDate() - 1)
-  const startOfLastWeek = new Date(startOfToday)
+  // ISO-8601 weeks start Monday (getDay: 0=Sun … 6=Sat).
+  const day = startOfToday.getDay()
+  const daysSinceMonday = day === 0 ? 6 : day - 1
+  const startOfThisWeek = new Date(startOfToday)
+  startOfThisWeek.setDate(startOfThisWeek.getDate() - daysSinceMonday)
+  const startOfLastWeek = new Date(startOfThisWeek)
   startOfLastWeek.setDate(startOfLastWeek.getDate() - 7)
   return {
     todayFrom: startOfToday.toISOString(),
     todayTo: startOfTomorrow.toISOString(),
     yesterdayFrom: startOfYesterday.toISOString(),
     yesterdayTo: startOfToday.toISOString(),
+    thisWeekFrom: startOfThisWeek.toISOString(),
+    thisWeekTo: startOfTomorrow.toISOString(),
     lastWeekFrom: startOfLastWeek.toISOString(),
-    lastWeekTo: startOfToday.toISOString(),
+    lastWeekTo: startOfThisWeek.toISOString(),
   }
 }

--- a/apps/harness/src/routes/index.tsx
+++ b/apps/harness/src/routes/index.tsx
@@ -421,13 +421,22 @@ function CommittedPullRequestsDashboard() {
   const yesterdayQuery = useQuery(
     committedPullRequestsCountQuery(bounds.yesterdayFrom, bounds.yesterdayTo),
   )
+  const thisWeekQuery = useQuery(
+    committedPullRequestsCountQuery(bounds.thisWeekFrom, bounds.thisWeekTo),
+  )
   const lastWeekQuery = useQuery(
     committedPullRequestsCountQuery(bounds.lastWeekFrom, bounds.lastWeekTo),
   )
   const loading =
-    todayQuery.isLoading || yesterdayQuery.isLoading || lastWeekQuery.isLoading
+    todayQuery.isLoading ||
+    yesterdayQuery.isLoading ||
+    thisWeekQuery.isLoading ||
+    lastWeekQuery.isLoading
   const failed =
-    todayQuery.isError || yesterdayQuery.isError || lastWeekQuery.isError
+    todayQuery.isError ||
+    yesterdayQuery.isError ||
+    thisWeekQuery.isError ||
+    lastWeekQuery.isError
 
   if (loading) {
     return (
@@ -437,7 +446,8 @@ function CommittedPullRequestsDashboard() {
         aria-label="Loading committed pull requests"
         aria-busy="true"
       >
-        <div className="grid grid-cols-3 gap-4">
+        <div className="grid grid-cols-4 gap-4">
+          <span className="block h-12 animate-pulse rounded-lg bg-slate-100 motion-reduce:animate-none" />
           <span className="block h-12 animate-pulse rounded-lg bg-slate-100 motion-reduce:animate-none" />
           <span className="block h-12 animate-pulse rounded-lg bg-slate-100 motion-reduce:animate-none" />
           <span className="block h-12 animate-pulse rounded-lg bg-slate-100 motion-reduce:animate-none" />
@@ -458,11 +468,12 @@ function CommittedPullRequestsDashboard() {
 
   const today = todayQuery.data ?? 0
   const yesterday = yesterdayQuery.data ?? 0
+  const thisWeek = thisWeekQuery.data ?? 0
   const lastWeek = lastWeekQuery.data ?? 0
 
   return (
     <article className="rounded-[0.9rem] border border-[#dbe3ef] bg-white p-[1.35rem] shadow-[0_10px_30px_rgb(15_23_42_/_5%)]">
-      <div className="grid grid-cols-3 gap-4">
+      <div className="grid grid-cols-4 gap-4">
         <div>
           <p className="m-0 text-xs font-bold tracking-wide text-slate-500 uppercase">
             Today
@@ -477,6 +488,14 @@ function CommittedPullRequestsDashboard() {
           </p>
           <p className="mt-1 mb-0 text-2xl font-bold tracking-[-0.03em] text-slate-900 tabular-nums">
             {yesterday}
+          </p>
+        </div>
+        <div>
+          <p className="m-0 text-xs font-bold tracking-wide text-slate-500 uppercase">
+            This week
+          </p>
+          <p className="mt-1 mb-0 text-2xl font-bold tracking-[-0.03em] text-slate-900 tabular-nums">
+            {thisWeek}
           </p>
         </div>
         <div>

--- a/apps/harness/test/committed-pr-dashboard.test.ts
+++ b/apps/harness/test/committed-pr-dashboard.test.ts
@@ -7,22 +7,81 @@ const homeSource = () =>
   readFileSync(join(import.meta.dir, "../src/routes/index.tsx"), "utf8")
 
 describe("localCommittedPullRequestDayBounds", () => {
-  test("uses local calendar day start/end as ISO instants", () => {
+  test("uses local calendar day start/end as ISO instants (mid-week Saturday)", () => {
+    // 2026-07-18 is a Saturday
     const now = new Date(2026, 6, 18, 15, 30, 0, 0)
     const bounds = localCommittedPullRequestDayBounds(now)
     const todayStart = new Date(2026, 6, 18, 0, 0, 0, 0)
     const tomorrowStart = new Date(2026, 6, 19, 0, 0, 0, 0)
     const yesterdayStart = new Date(2026, 6, 17, 0, 0, 0, 0)
-    const lastWeekStart = new Date(2026, 6, 11, 0, 0, 0, 0)
+    const thisWeekStart = new Date(2026, 6, 13, 0, 0, 0, 0) // Monday
+    const lastWeekStart = new Date(2026, 6, 6, 0, 0, 0, 0) // previous Monday
     expect(bounds.todayFrom).toBe(todayStart.toISOString())
     expect(bounds.todayTo).toBe(tomorrowStart.toISOString())
     expect(bounds.yesterdayFrom).toBe(yesterdayStart.toISOString())
     expect(bounds.yesterdayTo).toBe(todayStart.toISOString())
+    expect(bounds.thisWeekFrom).toBe(thisWeekStart.toISOString())
+    expect(bounds.thisWeekTo).toBe(tomorrowStart.toISOString())
     expect(bounds.lastWeekFrom).toBe(lastWeekStart.toISOString())
-    expect(bounds.lastWeekTo).toBe(todayStart.toISOString())
+    expect(bounds.lastWeekTo).toBe(thisWeekStart.toISOString())
+  })
+
+  test("mid-week Wednesday: this week and last week do not overlap", () => {
+    // 2026-07-22 is a Wednesday (issue example)
+    const now = new Date(2026, 6, 22, 12, 0, 0, 0)
+    const bounds = localCommittedPullRequestDayBounds(now)
+    expect(bounds.thisWeekFrom).toBe(
+      new Date(2026, 6, 20, 0, 0, 0, 0).toISOString(),
+    )
+    expect(bounds.thisWeekTo).toBe(
+      new Date(2026, 6, 23, 0, 0, 0, 0).toISOString(),
+    )
+    expect(bounds.lastWeekFrom).toBe(
+      new Date(2026, 6, 13, 0, 0, 0, 0).toISOString(),
+    )
+    expect(bounds.lastWeekTo).toBe(
+      new Date(2026, 6, 20, 0, 0, 0, 0).toISOString(),
+    )
+    expect(bounds.lastWeekTo).toBe(bounds.thisWeekFrom)
+    expect(bounds.yesterdayFrom >= bounds.lastWeekTo).toBe(true)
+    expect(bounds.todayFrom >= bounds.thisWeekFrom).toBe(true)
+    expect(bounds.todayTo).toBe(bounds.thisWeekTo)
+  })
+
+  test("week starts on Monday when today is Monday", () => {
+    // 2026-07-20 is a Monday
+    const now = new Date(2026, 6, 20, 9, 0, 0, 0)
+    const bounds = localCommittedPullRequestDayBounds(now)
+    const monday = new Date(2026, 6, 20, 0, 0, 0, 0)
+    const tuesday = new Date(2026, 6, 21, 0, 0, 0, 0)
+    const prevMonday = new Date(2026, 6, 13, 0, 0, 0, 0)
+    expect(bounds.thisWeekFrom).toBe(monday.toISOString())
+    expect(bounds.thisWeekTo).toBe(tuesday.toISOString())
+    expect(bounds.lastWeekFrom).toBe(prevMonday.toISOString())
+    expect(bounds.lastWeekTo).toBe(monday.toISOString())
+    expect(bounds.todayFrom).toBe(monday.toISOString())
+  })
+
+  test("week starts on Monday when today is Sunday", () => {
+    // 2026-03-15 is a Sunday
+    const now = new Date(2026, 2, 15, 12, 0, 0, 0)
+    const bounds = localCommittedPullRequestDayBounds(now)
+    expect(bounds.thisWeekFrom).toBe(
+      new Date(2026, 2, 9, 0, 0, 0, 0).toISOString(),
+    )
+    expect(bounds.thisWeekTo).toBe(
+      new Date(2026, 2, 16, 0, 0, 0, 0).toISOString(),
+    )
+    expect(bounds.lastWeekFrom).toBe(
+      new Date(2026, 2, 2, 0, 0, 0, 0).toISOString(),
+    )
+    expect(bounds.lastWeekTo).toBe(
+      new Date(2026, 2, 9, 0, 0, 0, 0).toISOString(),
+    )
   })
 
   test("handles month and year transitions", () => {
+    // 2026-01-01 is a Thursday
     const newYear = new Date(2026, 0, 1, 9, 0, 0, 0)
     const bounds = localCommittedPullRequestDayBounds(newYear)
     expect(bounds.yesterdayFrom).toBe(
@@ -32,31 +91,40 @@ describe("localCommittedPullRequestDayBounds", () => {
       new Date(2026, 0, 1, 0, 0, 0, 0).toISOString(),
     )
     expect(bounds.todayTo).toBe(new Date(2026, 0, 2, 0, 0, 0, 0).toISOString())
+    expect(bounds.thisWeekFrom).toBe(
+      new Date(2025, 11, 29, 0, 0, 0, 0).toISOString(),
+    )
+    expect(bounds.thisWeekTo).toBe(
+      new Date(2026, 0, 2, 0, 0, 0, 0).toISOString(),
+    )
     expect(bounds.lastWeekFrom).toBe(
-      new Date(2025, 11, 25, 0, 0, 0, 0).toISOString(),
+      new Date(2025, 11, 22, 0, 0, 0, 0).toISOString(),
     )
     expect(bounds.lastWeekTo).toBe(
-      new Date(2026, 0, 1, 0, 0, 0, 0).toISOString(),
+      new Date(2025, 11, 29, 0, 0, 0, 0).toISOString(),
     )
   })
 
-  test("last week spans seven complete local days before today", () => {
+  test("last week is previous complete Mon–Sun local calendar week", () => {
     const now = new Date(2026, 2, 15, 12, 0, 0, 0)
     const bounds = localCommittedPullRequestDayBounds(now)
     const lastWeekFrom = new Date(bounds.lastWeekFrom)
     const lastWeekTo = new Date(bounds.lastWeekTo)
-    const todayFrom = new Date(bounds.todayFrom)
-    expect(lastWeekTo.getTime()).toBe(todayFrom.getTime())
-    expect(bounds.yesterdayFrom >= bounds.lastWeekFrom).toBe(true)
-    expect(bounds.yesterdayTo <= bounds.lastWeekTo).toBe(true)
+    const thisWeekFrom = new Date(bounds.thisWeekFrom)
+    expect(lastWeekTo.getTime()).toBe(thisWeekFrom.getTime())
+    expect(lastWeekFrom.getDay()).toBe(1)
+    expect(lastWeekTo.getDay()).toBe(1)
     const msPerDay = 24 * 60 * 60 * 1000
     expect(
       (lastWeekTo.getTime() - lastWeekFrom.getTime()) / msPerDay,
     ).toBeCloseTo(7, 5)
+    // When yesterday is still in the current week, it is outside last week.
+    expect(bounds.yesterdayFrom >= bounds.lastWeekTo).toBe(true)
   })
 
   test("handles spring-forward daylight-saving local midnight", () => {
     // US Pacific 2026: clocks spring forward 2026-03-08 02:00 → 03:00
+    // 2026-03-09 is a Monday
     const afterSpringForward = new Date(2026, 2, 9, 10, 0, 0, 0)
     const bounds = localCommittedPullRequestDayBounds(afterSpringForward)
     expect(bounds.lastWeekFrom).toBe(
@@ -64,6 +132,12 @@ describe("localCommittedPullRequestDayBounds", () => {
     )
     expect(bounds.lastWeekTo).toBe(
       new Date(2026, 2, 9, 0, 0, 0, 0).toISOString(),
+    )
+    expect(bounds.thisWeekFrom).toBe(
+      new Date(2026, 2, 9, 0, 0, 0, 0).toISOString(),
+    )
+    expect(bounds.thisWeekTo).toBe(
+      new Date(2026, 2, 10, 0, 0, 0, 0).toISOString(),
     )
     expect(bounds.yesterdayFrom).toBe(
       new Date(2026, 2, 8, 0, 0, 0, 0).toISOString(),
@@ -75,6 +149,7 @@ describe("localCommittedPullRequestDayBounds", () => {
 
   test("handles fall-back daylight-saving local midnight", () => {
     // US Pacific 2026: clocks fall back 2026-11-01 02:00 → 01:00
+    // 2026-11-02 is a Monday
     const afterFallBack = new Date(2026, 10, 2, 10, 0, 0, 0)
     const bounds = localCommittedPullRequestDayBounds(afterFallBack)
     expect(bounds.lastWeekFrom).toBe(
@@ -83,6 +158,12 @@ describe("localCommittedPullRequestDayBounds", () => {
     expect(bounds.lastWeekTo).toBe(
       new Date(2026, 10, 2, 0, 0, 0, 0).toISOString(),
     )
+    expect(bounds.thisWeekFrom).toBe(
+      new Date(2026, 10, 2, 0, 0, 0, 0).toISOString(),
+    )
+    expect(bounds.thisWeekTo).toBe(
+      new Date(2026, 10, 3, 0, 0, 0, 0).toISOString(),
+    )
     expect(bounds.yesterdayFrom).toBe(
       new Date(2026, 10, 1, 0, 0, 0, 0).toISOString(),
     )
@@ -90,7 +171,7 @@ describe("localCommittedPullRequestDayBounds", () => {
 })
 
 describe("Committed pull requests dashboard UI", () => {
-  test("renders above the Jobs card with Today, Yesterday, and Last week labels", () => {
+  test("renders above the Jobs card with Today, Yesterday, This week, and Last week labels", () => {
     const source = homeSource()
     const dashboardIndex = source.indexOf(
       'aria-label="Committed pull requests"',
@@ -100,6 +181,7 @@ describe("Committed pull requests dashboard UI", () => {
     expect(jobsIndex).toBeGreaterThan(dashboardIndex)
     expect(source).toContain("Today")
     expect(source).toContain("Yesterday")
+    expect(source).toContain("This week")
     expect(source).toContain("Last week")
     expect(source).toContain("function CommittedPullRequestsDashboard()")
   })
@@ -113,6 +195,8 @@ describe("Committed pull requests dashboard UI", () => {
       source.indexOf("function CommittedPullRequestsDashboard()"),
       source.indexOf("function RepositoryCards()"),
     )
+    expect(dashboard).toContain("bounds.thisWeekFrom")
+    expect(dashboard).toContain("bounds.thisWeekTo")
     expect(dashboard).toContain("bounds.lastWeekFrom")
     expect(dashboard).toContain("bounds.lastWeekTo")
     expect(dashboard).not.toContain("workItems")
@@ -124,7 +208,7 @@ describe("Committed pull requests dashboard UI", () => {
     expect(source).toContain('aria-label="Loading committed pull requests"')
     expect(source).toContain('role="status"')
     expect(source).toContain('aria-busy="true"')
-    expect(source).toContain("grid-cols-3")
+    expect(source).toContain("grid-cols-4")
     expect(source).toContain(
       "Could not load committed pull requests. Please try again.",
     )
@@ -138,12 +222,14 @@ describe("Committed pull requests dashboard UI", () => {
     expect(homeBody).not.toContain("Suspense fallback={<Committed")
   })
 
-  test("waits for all three counts before leaving the loading state", () => {
+  test("waits for all four counts before leaving the loading state", () => {
     const source = homeSource()
     const dashboard = source.slice(
       source.indexOf("function CommittedPullRequestsDashboard()"),
       source.indexOf("function RepositoryCards()"),
     )
+    expect(dashboard).toContain("thisWeekQuery.isLoading")
+    expect(dashboard).toContain("thisWeekQuery.isError")
     expect(dashboard).toContain("lastWeekQuery.isLoading")
     expect(dashboard).toContain("lastWeekQuery.isError")
     expect(dashboard).toContain("todayQuery.isLoading")
@@ -158,9 +244,11 @@ describe("Committed pull requests dashboard UI", () => {
     )
     expect(dashboard).toContain("todayQuery.data ?? 0")
     expect(dashboard).toContain("yesterdayQuery.data ?? 0")
+    expect(dashboard).toContain("thisWeekQuery.data ?? 0")
     expect(dashboard).toContain("lastWeekQuery.data ?? 0")
     expect(dashboard).toContain("{today}")
     expect(dashboard).toContain("{yesterday}")
+    expect(dashboard).toContain("{thisWeek}")
     expect(dashboard).toContain("{lastWeek}")
   })
 


### PR DESCRIPTION
## Summary
- Fix **Last week** on the console PR dashboard to the previous complete local Mon–Sun calendar week (was a trailing 7-day window that included the current week).
- Add a **This week** column for the current local calendar week so far.
- Update dashboard layout to four columns and cover calendar-week bounds in unit/e2e tests.

Closes #366

## Test plan
- [x] `bun test apps/harness/test/committed-pr-dashboard.test.ts`
- [x] Pre-commit affected lint/typecheck/test
- [ ] Spot-check console dashboard: Today | Yesterday | This week | Last week