### PR TITLE
feat(harness): expose author scope in repository settings and issue list

### DIFF
--- a/apps/harness/src/routes/index.tsx
+++ b/apps/harness/src/routes/index.tsx
@@ -136,6 +136,7 @@ const issuesQuery = (repositoryId: string) => ({
         title: true,
         url: true,
         state: true,
+        issueAuthor: true,
         parent: {
           githubIssueNumber: true,
           githubIssueUrl: true,
@@ -182,6 +183,7 @@ type RepositoryIssue = {
   title: string
   url: string
   state: "OPEN" | "CLOSED"
+  issueAuthor: string | null
   parent: {
     githubIssueNumber: number
     githubIssueUrl: string
@@ -672,6 +674,9 @@ function RepositoryCard({
     repository.reviewVariant ?? "",
   )
   const [autoMerge, setAutoMerge] = useState(repository.autoMerge)
+  const [includeAllIssueAuthors, setIncludeAllIssueAuthors] = useState(
+    repository.includeAllIssueAuthors,
+  )
   const jobsQuery = workItemsQuery(repository.id)
   const { data: workItems = [], isLoading: workItemsLoading } =
     useQuery(jobsQuery)
@@ -730,6 +735,7 @@ function RepositoryCard({
     setReviewModel(repository.reviewModel ?? "")
     setReviewVariant(repository.reviewVariant ?? "")
     setAutoMerge(repository.autoMerge)
+    setIncludeAllIssueAuthors(repository.includeAllIssueAuthors)
     updateSettings.reset()
     if (config.isError) void config.refetch()
     if (models.isError) void models.refetch()
@@ -746,7 +752,7 @@ function RepositoryCard({
       reviewModel: reviewModel.trim() === "" ? null : reviewModel,
       reviewVariant: reviewVariant.trim() === "" ? null : reviewVariant,
       autoMerge,
-      includeAllIssueAuthors: repository.includeAllIssueAuthors,
+      includeAllIssueAuthors,
     })
   }
 
@@ -1114,6 +1120,14 @@ function RepositoryCard({
             {repository.autoMerge ? "Enabled" : "Disabled"}
           </dd>
         </div>
+        <div className="flex min-w-0 items-baseline gap-1.5 text-[0.82rem]">
+          <dt className="shrink-0 font-[750] tracking-[0.06em] text-slate-400 uppercase">
+            Include all Issue Authors:
+          </dt>
+          <dd className="m-0 text-slate-700">
+            {repository.includeAllIssueAuthors ? "Enabled" : "Disabled"}
+          </dd>
+        </div>
       </dl>
       <dialog
         ref={settingsDialogRef}
@@ -1163,6 +1177,20 @@ function RepositoryCard({
               Auto-merge
               <span className="font-normal text-slate-500">
                 Allow clanker merge when risk is low
+              </span>
+            </label>
+            <label className="flex items-center gap-3 text-sm font-semibold">
+              <input
+                type="checkbox"
+                className="size-4 rounded border-slate-300"
+                checked={includeAllIssueAuthors}
+                onChange={(event) =>
+                  setIncludeAllIssueAuthors(event.target.checked)
+                }
+              />
+              Include all Issue Authors
+              <span className="font-normal text-slate-500">
+                Relevant Issues from every author after Refresh
               </span>
             </label>
             {models.isPending ? (
@@ -1524,13 +1552,20 @@ function RepositoryIssues({
                 <span className="font-mono text-xs leading-5 font-semibold text-blue-600">
                   #{issue.githubIssueNumber}
                 </span>
-                <a
-                  className="min-w-0 font-semibold text-slate-800 hover:text-blue-700 hover:underline"
-                  href={issue.url}
-                  onClick={(event) => event.stopPropagation()}
-                >
-                  {issue.title}
-                </a>
+                <span className="min-w-0">
+                  <a
+                    className="font-semibold text-slate-800 hover:text-blue-700 hover:underline"
+                    href={issue.url}
+                    onClick={(event) => event.stopPropagation()}
+                  >
+                    {issue.title}
+                  </a>
+                  {issue.issueAuthor !== null && issue.issueAuthor !== "" && (
+                    <span className="mt-0.5 block text-xs font-normal text-slate-500">
+                      {issue.issueAuthor}
+                    </span>
+                  )}
+                </span>
                 <span className="flex shrink-0 items-center gap-1.5 text-[0.65rem] font-bold tracking-wide text-slate-500 uppercase">
                   {closedChildren}/{children.length} closed
                   <svg
@@ -1655,12 +1690,19 @@ function RepositoryIssueRow({
         <span className="font-mono text-xs leading-5 text-slate-400">
           #{issue.githubIssueNumber}
         </span>
-        <a
-          className="min-w-0 text-slate-700 hover:text-blue-700 hover:underline"
-          href={issue.url}
-        >
-          {issue.title}
-        </a>
+        <span className="min-w-0">
+          <a
+            className="text-slate-700 hover:text-blue-700 hover:underline"
+            href={issue.url}
+          >
+            {issue.title}
+          </a>
+          {issue.issueAuthor !== null && issue.issueAuthor !== "" && (
+            <span className="mt-0.5 block text-xs text-slate-500">
+              {issue.issueAuthor}
+            </span>
+          )}
+        </span>
         <span className="flex shrink-0 items-center gap-1">
           {issue.state === "CLOSED" && (
             <span className="rounded-full bg-slate-100 px-1.5 py-0.5 text-[0.6rem] font-bold tracking-wide text-slate-500 uppercase">

--- a/apps/harness/test/repository-settings-include-all-authors.test.ts
+++ b/apps/harness/test/repository-settings-include-all-authors.test.ts
@@ -1,0 +1,44 @@
+import { readFileSync } from "node:fs"
+import { join } from "node:path"
+import { describe, expect, test } from "bun:test"
+
+const indexSource = () =>
+  readFileSync(join(import.meta.dir, "../src/routes/index.tsx"), "utf8")
+
+describe("Repository settings Include all Issue Authors", () => {
+  test("exposes Include all Issue Authors in settings and saves local state", () => {
+    const source = indexSource()
+    expect(source).toContain("Include all Issue Authors")
+    expect(source).toContain(
+      "const [includeAllIssueAuthors, setIncludeAllIssueAuthors] = useState(",
+    )
+    expect(source).toContain(
+      "setIncludeAllIssueAuthors(repository.includeAllIssueAuthors)",
+    )
+    expect(source).toContain("checked={includeAllIssueAuthors}")
+    expect(source).toContain("setIncludeAllIssueAuthors(event.target.checked)")
+    expect(source).toMatch(
+      /updateSettings\.mutate\(\{[\s\S]*includeAllIssueAuthors,[\s\S]*\}\)/,
+    )
+    expect(source).not.toContain(
+      "includeAllIssueAuthors: repository.includeAllIssueAuthors",
+    )
+    expect(source).toContain("Relevant Issues from every author after Refresh")
+    expect(source).toContain(
+      '{repository.includeAllIssueAuthors ? "Enabled" : "Disabled"}',
+    )
+  })
+
+  test("issue list queries and shows Issue Author as secondary text", () => {
+    const source = indexSource()
+    expect(source).toContain("issueAuthor: true")
+    expect(source).toContain("issueAuthor: string | null")
+    expect(source).toContain(
+      'issue.issueAuthor !== null && issue.issueAuthor !== ""',
+    )
+    expect(source).toContain("{issue.issueAuthor}")
+    expect(source).not.toContain("Show all authors")
+    expect(source).not.toContain("mine only")
+    expect(source).not.toContain("Mine only")
+  })
+})


### PR DESCRIPTION
## Summary

- Add Include all Issue Authors to Repository settings (checkbox, summary, save via existing settings flow)
- Show Issue Author as secondary text on Relevant Issues when present
- Author scope remains reconcile-time after Refresh; no separate list-level mine/all control

Closes #363

## Test plan

- [x] `bunx nx run harness:test`
- [x] `bunx nx run harness:typecheck`
- [x] `bunx nx run harness:lint`
- [ ] Toggle Include all Issue Authors, save, Refresh issues, confirm working set matches own-only vs all
- [ ] Confirm Issue Author appears under issue titles when present