### PR TITLE
fix(graphql-api): request Actions write on repository tokens

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,8 @@ not need to use Keymaxxer themselves; use normally authenticated tools such as
 Fine-grained GitHub PATs cannot call the Checks API (including GraphQL
 `statusCheckRollup.contexts`). That 403 is expected: the harness falls back to
 Actions jobs for terminal PR Status Check identity and downloads Actions job
-logs for Status Check Handoff diagnostics (`actions=read`, `statuses=read`).
+logs for Status Check Handoff diagnostics (`actions=write` for workflow
+reruns and job-log reads, `statuses=read`).
 
 ### Triage labels
 

--- a/apps/harness/src/routes/index.tsx
+++ b/apps/harness/src/routes/index.tsx
@@ -1416,13 +1416,19 @@ function RepositoryCard({
               <code className="font-bold">
                 {repository.credential.githubTokenSecretName}
               </code>{" "}
-              in Keymaxxer.
+              in Keymaxxer. Already-created tokens are not upgraded
+              automatically — edit the token on GitHub or recreate it, then
+              store the replacement.
             </p>
           ) : (
             <p className="m-0">
               Create a fine-grained token, choose{" "}
-              <strong>Only select repositories</strong>, and select{" "}
-              <code className="font-bold">{repository.githubRepo}</code>.
+              <strong>Only select repositories</strong>, select{" "}
+              <code className="font-bold">{repository.githubRepo}</code>, and
+              allow <strong>Actions: Read and write</strong> (required for
+              workflow reruns and CI logs). Already-created tokens are not
+              upgraded automatically — edit or recreate them if Actions is still
+              read-only.
             </p>
           )}
           {githubTokenCreated ? (

--- a/apps/ready-for-agent/README.md
+++ b/apps/ready-for-agent/README.md
@@ -122,6 +122,15 @@ keymaxxer rm <SECRET_NAME>
 After deletion, reload the Harness so it detects the missing credential and
 offers the existing Create GitHub token / Store in Keymaxxer flow.
 
+### Upgrade an existing GitHub token
+
+New repository token links preselect **Actions: Read and write** (workflow
+reruns and CI job logs), plus Issues, Contents, Pull requests (write), and
+Commit statuses (read). Already-created tokens are **not** upgraded
+automatically when the harness changes its requested permissions. Edit the
+fine-grained token on GitHub (or recreate it), then replace the secret in
+Keymaxxer — or remove the secret and use Create GitHub token again.
+
 ### Help
 
 ```bash

--- a/docs/adr/0013-watch-pr-status-checks.md
+++ b/docs/adr/0013-watch-pr-status-checks.md
@@ -7,7 +7,7 @@ Investigate PR Status Checks continues the Implement OpenCode Session with the R
 ## Consequences
 
 - Every poll and investigation is a separate Step Run, preserving durable execution history and at-least-once queue behavior.
-- New Repository credentials request Actions read and Commit statuses read (not Checks; fine-grained PATs cannot grant Checks). Terminal PR Status Checks load via REST Checks with Actions-jobs fallback on 403, plus commit statuses. Actions read also lets the harness download job logs for Status Check Handoff diagnostics.
+- New Repository credentials request Actions read and write and Commit statuses read (not Checks; fine-grained PATs cannot grant Checks). Terminal PR Status Checks load via REST Checks with Actions-jobs fallback on 403, plus commit statuses. Actions write lets agents rerun terminal incomplete review workflows; Actions read also lets the harness download job logs for Status Check Handoff diagnostics. Already-created repository tokens are not upgraded automatically — operators must edit the token on GitHub or recreate it and store the replacement in Keymaxxer.
 - A newly created PR that is not yet visible through GitHub is treated as pending; a visible PR with a null rollup is `no_checks` (not green) until the 60-second grace elapses.
 - Same-state watch requeues preserve `state_ready_at` so residence time (and the `no_checks` grace) accumulate across polls.
 - A merged PR is treated as green and advances to Mark PR Ready for Review (a no-op if already non-draft); a closed, unmerged PR enters Needs Human instead of polling forever.

--- a/packages/graphql-api/src/lib/repository-credentials.ts
+++ b/packages/graphql-api/src/lib/repository-credentials.ts
@@ -29,9 +29,10 @@ const githubTokenCreationUrl = (repository: Repository) => {
   url.searchParams.set("issues", "write")
   url.searchParams.set("contents", "write")
   url.searchParams.set("pull_requests", "write")
-  // Actions + commit statuses help with CI visibility. Per-check CheckRun nodes
-  // need Checks API access, which fine-grained PATs cannot grant — see AGENTS.md.
-  url.searchParams.set("actions", "read")
+  // Actions write enables workflow reruns; read covers CI visibility and job logs.
+  // Commit statuses help with CI visibility. Per-check CheckRun nodes need Checks
+  // API access, which fine-grained PATs cannot grant — see AGENTS.md.
+  url.searchParams.set("actions", "write")
   url.searchParams.set("statuses", "read")
   return url.toString()
 }

--- a/packages/graphql-api/test/graphql-api.test.ts
+++ b/packages/graphql-api/test/graphql-api.test.ts
@@ -602,7 +602,7 @@ describe("GraphQL API", () => {
     expect(creationUrl.searchParams.get("issues")).toBe("write")
     expect(creationUrl.searchParams.get("contents")).toBe("write")
     expect(creationUrl.searchParams.get("pull_requests")).toBe("write")
-    expect(creationUrl.searchParams.get("actions")).toBe("read")
+    expect(creationUrl.searchParams.get("actions")).toBe("write")
     expect(creationUrl.searchParams.get("statuses")).toBe("read")
     expect(creationUrl.searchParams.get("checks")).toBeNull()
   })


### PR DESCRIPTION
## Summary
- Preselect **Actions: Read and write** on fine-grained repository PAT creation links so agents can rerun incomplete review workflows (and still read CI job logs).
- Keep Issues, Contents, Pull requests (write) and Commit statuses (read); do not request Checks.
- Document and surface that already-created tokens are not upgraded automatically and must be edited or recreated.

Closes #370

## Test plan
- [x] `graphql-api` test asserts `actions=write` and no `checks` param
- [x] `nx` lint/typecheck/test for affected projects
- [ ] Create token via Harness link and confirm GitHub UI preselects Actions: Read and write
- [ ] Confirm existing Issues/Contents/PRs/Statuses permissions remain selected