### PR TITLE
fix(opencode): drain full models stdout for settings variants

### DIFF
--- a/apps/harness/src/routes/__root.tsx
+++ b/apps/harness/src/routes/__root.tsx
@@ -385,7 +385,9 @@ function SettingsButton() {
                       </option>
                     )}
                     {hasUnavailableBuildModel && (
-                      <option value={defaultModel}>{defaultModel}</option>
+                      <option value={defaultModel}>
+                        {defaultModel} (not in OpenCode catalog)
+                      </option>
                     )}
                     {(models.data ?? []).map((model) => (
                       <option key={model.id} value={model.id}>
@@ -398,9 +400,12 @@ function SettingsButton() {
                   </span>
                 </label>
 
-                {defaultModel.length > 0 &&
-                !hasUnavailableBuildModel &&
-                buildVariants.length === 0 ? (
+                {defaultModel.length > 0 && hasUnavailableBuildModel ? (
+                  <p className="rounded-lg bg-amber-50 p-3 text-sm text-amber-950">
+                    Build thinking level is unavailable — the selected model is
+                    not in the OpenCode catalog. Choose another build model.
+                  </p>
+                ) : defaultModel.length > 0 && buildVariants.length === 0 ? (
                   <p className="rounded-lg bg-slate-50 p-3 text-sm text-slate-600">
                     Build thinking level is unavailable — this model has no
                     OpenCode variants.
@@ -417,9 +422,7 @@ function SettingsButton() {
                       }
                       required
                       disabled={
-                        defaultModel.length === 0 ||
-                        (!hasUnavailableBuildModel &&
-                          buildVariants.length === 0)
+                        defaultModel.length === 0 || buildVariants.length === 0
                       }
                     >
                       {(!buildConfigured || defaultVariant.length === 0) && (
@@ -428,7 +431,9 @@ function SettingsButton() {
                         </option>
                       )}
                       {hasCustomBuildVariant && (
-                        <option value={defaultVariant}>{defaultVariant}</option>
+                        <option value={defaultVariant}>
+                          {formatVariantLabel(defaultVariant)}
+                        </option>
                       )}
                       {buildVariants.map((variant) => (
                         <option key={variant} value={variant}>
@@ -463,7 +468,9 @@ function SettingsButton() {
                   >
                     <option value="">Same as build model</option>
                     {hasUnavailableReviewModel && (
-                      <option value={reviewModel}>{reviewModel}</option>
+                      <option value={reviewModel}>
+                        {reviewModel} (not in OpenCode catalog)
+                      </option>
                     )}
                     {(models.data ?? []).map((model) => (
                       <option key={`review-${model.id}`} value={model.id}>
@@ -477,11 +484,15 @@ function SettingsButton() {
                 </label>
 
                 {reviewVariantSourceModel.length > 0 &&
-                !(
-                  (reviewModel.length > 0 && hasUnavailableReviewModel) ||
-                  (reviewModel.length === 0 && hasUnavailableBuildModel)
-                ) &&
-                reviewVariants.length === 0 ? (
+                ((reviewModel.length > 0 && hasUnavailableReviewModel) ||
+                  (reviewModel.length === 0 && hasUnavailableBuildModel)) ? (
+                  <p className="rounded-lg bg-amber-50 p-3 text-sm text-amber-950">
+                    Review thinking level is unavailable — the selected model is
+                    not in the OpenCode catalog. Choose another model or use the
+                    build model.
+                  </p>
+                ) : reviewVariantSourceModel.length > 0 &&
+                  reviewVariants.length === 0 ? (
                   <p className="rounded-lg bg-slate-50 p-3 text-sm text-slate-600">
                     Review thinking level is unavailable — this model has no
                     OpenCode variants.
@@ -496,17 +507,14 @@ function SettingsButton() {
                       onChange={(event) => setReviewVariant(event.target.value)}
                       disabled={
                         reviewVariantSourceModel.length === 0 ||
-                        (!(
-                          (reviewModel.length > 0 &&
-                            hasUnavailableReviewModel) ||
-                          (reviewModel.length === 0 && hasUnavailableBuildModel)
-                        ) &&
-                          reviewVariants.length === 0)
+                        reviewVariants.length === 0
                       }
                     >
                       <option value="">Same as build thinking level</option>
                       {hasCustomReviewVariant && (
-                        <option value={reviewVariant}>{reviewVariant}</option>
+                        <option value={reviewVariant}>
+                          {formatVariantLabel(reviewVariant)}
+                        </option>
                       )}
                       {reviewVariants.map((variant) => (
                         <option key={`review-${variant}`} value={variant}>
@@ -590,7 +598,9 @@ function SettingsButton() {
                 models.isError ||
                 updateConfig.isPending ||
                 defaultModel.length === 0 ||
-                defaultVariant.length === 0
+                defaultVariant.length === 0 ||
+                hasUnavailableBuildModel ||
+                (defaultModel.length > 0 && buildVariants.length === 0)
               }
             >
               {updateConfig.isPending ? "Saving..." : "Save settings"}

--- a/apps/harness/src/routes/index.tsx
+++ b/apps/harness/src/routes/index.tsx
@@ -1259,7 +1259,9 @@ function RepositoryCard({
                       Harness default ({harnessDefaultModel})
                     </option>
                     {hasUnavailableBuildModel && (
-                      <option value={defaultModel}>{defaultModel}</option>
+                      <option value={defaultModel}>
+                        {defaultModel} (not in OpenCode catalog)
+                      </option>
                     )}
                     {models.data.map((model) => (
                       <option key={model.id} value={model.id}>
@@ -1269,8 +1271,14 @@ function RepositoryCard({
                   </select>
                 </label>
                 {buildVariantSourceModel.length > 0 &&
-                !buildVariantSourceUnavailable &&
-                buildVariants.length === 0 ? (
+                buildVariantSourceUnavailable ? (
+                  <p className="rounded-lg bg-amber-50 p-3 text-sm text-amber-950">
+                    Build thinking level override is unavailable — the selected
+                    model is not in the OpenCode catalog. Use harness default or
+                    pick another model.
+                  </p>
+                ) : buildVariantSourceModel.length > 0 &&
+                  buildVariants.length === 0 ? (
                   <p className="rounded-lg bg-slate-50 p-3 text-sm text-slate-600">
                     Build thinking level override is unavailable — this model
                     has no OpenCode variants. Use harness default or pick
@@ -1287,7 +1295,6 @@ function RepositoryCard({
                       }
                       disabled={
                         buildVariantSourceModel.length > 0 &&
-                        !buildVariantSourceUnavailable &&
                         buildVariants.length === 0
                       }
                     >
@@ -1295,7 +1302,9 @@ function RepositoryCard({
                         Harness default ({harnessDefaultVariant})
                       </option>
                       {hasCustomBuildVariant && (
-                        <option value={defaultVariant}>{defaultVariant}</option>
+                        <option value={defaultVariant}>
+                          {formatVariantLabel(defaultVariant)}
+                        </option>
                       )}
                       {buildVariants.map((variant) => (
                         <option key={variant} value={variant}>
@@ -1333,7 +1342,9 @@ function RepositoryCard({
                       Harness default ({harnessReviewModel})
                     </option>
                     {hasUnavailableReviewModel && (
-                      <option value={reviewModel}>{reviewModel}</option>
+                      <option value={reviewModel}>
+                        {reviewModel} (not in OpenCode catalog)
+                      </option>
                     )}
                     {models.data.map((model) => (
                       <option key={`review-${model.id}`} value={model.id}>
@@ -1343,8 +1354,14 @@ function RepositoryCard({
                   </select>
                 </label>
                 {reviewVariantSourceModel.length > 0 &&
-                !reviewVariantSourceUnavailable &&
-                reviewVariants.length === 0 ? (
+                reviewVariantSourceUnavailable ? (
+                  <p className="rounded-lg bg-amber-50 p-3 text-sm text-amber-950">
+                    Review thinking level override is unavailable — the selected
+                    model is not in the OpenCode catalog. Use harness default or
+                    pick another model.
+                  </p>
+                ) : reviewVariantSourceModel.length > 0 &&
+                  reviewVariants.length === 0 ? (
                   <p className="rounded-lg bg-slate-50 p-3 text-sm text-slate-600">
                     Review thinking level override is unavailable — this model
                     has no OpenCode variants. Use harness default or pick
@@ -1359,7 +1376,6 @@ function RepositoryCard({
                       onChange={(event) => setReviewVariant(event.target.value)}
                       disabled={
                         reviewVariantSourceModel.length > 0 &&
-                        !reviewVariantSourceUnavailable &&
                         reviewVariants.length === 0
                       }
                     >
@@ -1367,7 +1383,9 @@ function RepositoryCard({
                         Harness default ({harnessReviewVariant})
                       </option>
                       {hasCustomReviewVariant && (
-                        <option value={reviewVariant}>{reviewVariant}</option>
+                        <option value={reviewVariant}>
+                          {formatVariantLabel(reviewVariant)}
+                        </option>
                       )}
                       {reviewVariants.map((variant) => (
                         <option key={`review-${variant}`} value={variant}>

--- a/packages/opencode/src/lib/collect-child-stdout.ts
+++ b/packages/opencode/src/lib/collect-child-stdout.ts
@@ -1,0 +1,24 @@
+import { Effect, Stream } from "effect"
+import type { PlatformError } from "effect/PlatformError"
+import type { ChildProcessHandle } from "effect/unstable/process/ChildProcessSpawner"
+
+/**
+ * Drain stdout to EOF, then read exit code.
+ *
+ * Collecting stdout before relying on process exit avoids races where scope
+ * finalization or pipe teardown can clip large catalogs near OS pipe capacity.
+ */
+export const collectChildStdout = (
+  handle: ChildProcessHandle,
+): Effect.Effect<
+  { readonly exitCode: number; readonly stdout: string },
+  PlatformError
+> =>
+  Effect.gen(function* () {
+    const stdout = yield* Stream.decodeText(handle.stdout).pipe(Stream.mkString)
+    const exitCode = yield* handle.exitCode
+    return {
+      exitCode: Number(exitCode),
+      stdout,
+    }
+  })

--- a/packages/opencode/src/lib/errors.ts
+++ b/packages/opencode/src/lib/errors.ts
@@ -25,6 +25,14 @@ export class SessionIdNotFoundError extends Schema.TaggedErrorClass<SessionIdNot
   },
 ) {}
 
+export class OpencodeIncompleteOutputError extends Schema.TaggedErrorClass<OpencodeIncompleteOutputError>()(
+  "OpencodeIncompleteOutputError",
+  {
+    cwd: Schema.String,
+    byteLength: Schema.Finite,
+  },
+) {}
+
 export class OpencodeConfigError extends Schema.TaggedErrorClass<OpencodeConfigError>()(
   "OpencodeConfigError",
   {

--- a/packages/opencode/src/lib/opencode.ts
+++ b/packages/opencode/src/lib/opencode.ts
@@ -2,16 +2,18 @@ import { Context, Duration, Effect, Layer, Ref, Stream } from "effect"
 import type { PlatformError } from "effect/PlatformError"
 import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process"
 import { buildRunArgs } from "./build-args.js"
+import { collectChildStdout } from "./collect-child-stdout.js"
 import { makeOpencodeEnvironment } from "./environment.js"
 import {
   type OpencodeConfigError,
   OpencodeExitError,
+  OpencodeIncompleteOutputError,
   OpencodeTimeoutError,
   SessionIdNotFoundError,
 } from "./errors.js"
 import { parseAssistantTextFromLine } from "./parse-assistant-text.js"
 import { parseSessionIdFromLine } from "./parse-session-id.js"
-import { parseVerboseModelsOutput } from "./parse-verbose-models.js"
+import { parseVerboseModelsOutputDetailed } from "./parse-verbose-models.js"
 import type {
   ContinueInput,
   ListModelsInput,
@@ -26,6 +28,7 @@ const DEFAULT_BINARY = "opencode"
 
 export type OpencodeError =
   | OpencodeExitError
+  | OpencodeIncompleteOutputError
   | OpencodeTimeoutError
   | SessionIdNotFoundError
   | PlatformError
@@ -74,22 +77,7 @@ export class Opencode extends Context.Service<
           const result = yield* Effect.scoped(
             Effect.gen(function* () {
               const handle = yield* spawner.spawn(command)
-              const collectStdout = Stream.decodeText(handle.stdout).pipe(
-                Stream.runFold(
-                  () => "",
-                  (acc, chunk) => acc + chunk,
-                ),
-              )
-
-              const [exitCode, stdout] = yield* Effect.all(
-                [handle.exitCode, collectStdout],
-                { concurrency: 2 },
-              )
-
-              return {
-                exitCode: Number(exitCode),
-                models: parseVerboseModelsOutput(stdout),
-              }
+              return yield* collectChildStdout(handle)
             }),
           ).pipe(
             Effect.timeout(timeout),
@@ -107,7 +95,15 @@ export class Opencode extends Context.Service<
             })
           }
 
-          return result.models
+          const parsed = parseVerboseModelsOutputDetailed(result.stdout)
+          if (!parsed.complete) {
+            return yield* new OpencodeIncompleteOutputError({
+              cwd: input.cwd,
+              byteLength: Buffer.byteLength(result.stdout, "utf8"),
+            })
+          }
+
+          return parsed.models
         })
 
         const run = (input: {

--- a/packages/opencode/src/lib/parse-verbose-models.ts
+++ b/packages/opencode/src/lib/parse-verbose-models.ts
@@ -3,16 +3,23 @@ import type { OpencodeModel } from "./types.js"
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === "object" && value !== null && !Array.isArray(value)
 
+export type ParsedVerboseModels = {
+  readonly models: ReadonlyArray<OpencodeModel>
+  /** False when stdout ends mid-object or otherwise looks truncated. */
+  readonly complete: boolean
+}
+
 /**
  * Parse `opencode models --verbose` stdout: alternating model id lines and
  * multi-line JSON objects that include a `variants` map.
  */
-export const parseVerboseModelsOutput = (
+export const parseVerboseModelsOutputDetailed = (
   stdout: string,
-): ReadonlyArray<OpencodeModel> => {
+): ParsedVerboseModels => {
   const models: OpencodeModel[] = []
   const lines = stdout.split(/\r?\n/)
   let index = 0
+  let complete = true
 
   while (index < lines.length) {
     const id = lines[index]?.trim() ?? ""
@@ -25,13 +32,20 @@ export const parseVerboseModelsOutput = (
       index += 1
     }
 
-    if (index >= lines.length || (lines[index]?.trim() ?? "") !== "{") {
+    if (index >= lines.length) {
+      models.push({ id, variants: [] })
+      complete = false
+      break
+    }
+
+    if ((lines[index]?.trim() ?? "") !== "{") {
       models.push({ id, variants: [] })
       continue
     }
 
     let depth = 0
     const jsonLines: string[] = []
+    let closed = false
     for (; index < lines.length; index += 1) {
       const line = lines[index] ?? ""
       jsonLines.push(line)
@@ -41,8 +55,15 @@ export const parseVerboseModelsOutput = (
       }
       if (depth === 0) {
         index += 1
+        closed = true
         break
       }
+    }
+
+    if (!closed || depth !== 0) {
+      complete = false
+      models.push({ id, variants: [] })
+      break
     }
 
     try {
@@ -51,9 +72,15 @@ export const parseVerboseModelsOutput = (
       const variants = isRecord(variantsValue) ? Object.keys(variantsValue) : []
       models.push({ id, variants })
     } catch {
+      complete = false
       models.push({ id, variants: [] })
     }
   }
 
-  return models
+  return { models, complete }
 }
+
+export const parseVerboseModelsOutput = (
+  stdout: string,
+): ReadonlyArray<OpencodeModel> =>
+  parseVerboseModelsOutputDetailed(stdout).models

--- a/packages/opencode/test/collect-child-stdout.spec.ts
+++ b/packages/opencode/test/collect-child-stdout.spec.ts
@@ -1,0 +1,47 @@
+import { chmod, mkdtemp, rm, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { BunServices } from "@effect/platform-bun"
+import { Effect } from "effect"
+import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process"
+import { collectChildStdout } from "../src/lib/collect-child-stdout.js"
+import { describe, expect, it } from "bun:test"
+
+describe("collectChildStdout", () => {
+  it("returns full stdout equal to parsing a >64KB fixture end-to-end", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "collect-stdout-"))
+    const fixturePath = join(directory, "out.txt")
+    const binaryPath = join(directory, "writer")
+    const body = `${"y".repeat(70_000)}\nlate-marker\n`
+    try {
+      await writeFile(fixturePath, body)
+      await writeFile(
+        binaryPath,
+        ["#!/bin/sh", `cat "${fixturePath}"`, "exit 0", ""].join("\n"),
+      )
+      await chmod(binaryPath, 0o700)
+
+      const result = await Effect.runPromise(
+        Effect.gen(function* () {
+          const spawner = yield* ChildProcessSpawner.ChildProcessSpawner
+          const handle = yield* spawner.spawn(
+            ChildProcess.make(binaryPath, [], {
+              stdin: "ignore",
+              stderr: "ignore",
+            }),
+          )
+          return yield* collectChildStdout(handle)
+        }).pipe(Effect.scoped, Effect.provide(BunServices.layer)),
+      )
+
+      expect(result.exitCode).toBe(0)
+      expect(result.stdout).toBe(body)
+      expect(result.stdout.endsWith("late-marker\n")).toBe(true)
+      expect(Buffer.byteLength(result.stdout, "utf8")).toBeGreaterThan(
+        64 * 1024,
+      )
+    } finally {
+      await rm(directory, { recursive: true, force: true })
+    }
+  })
+})

--- a/packages/opencode/test/opencode.spec.ts
+++ b/packages/opencode/test/opencode.spec.ts
@@ -7,7 +7,9 @@ import {
   type OnSessionId,
   Opencode,
   OpencodeExitError,
+  OpencodeIncompleteOutputError,
   OpencodeTimeoutError,
+  parseVerboseModelsOutput,
 } from "../src/index.js"
 import { describe, expect, it } from "bun:test"
 
@@ -209,6 +211,133 @@ describe("Opencode Effect service", () => {
             variants: [],
           },
         ])
+      },
+    )
+  })
+
+  it("captures a full multi-provider verbose catalog beyond 64KB", async () => {
+    const padding = "x".repeat(1200)
+    const entries: string[] = []
+    for (let index = 0; index < 55; index += 1) {
+      entries.push(
+        [
+          `opencode/model-${index}`,
+          "{",
+          `  "id": "model-${index}",`,
+          `  "padding": "${padding}",`,
+          '  "variants": {',
+          '    "low": {},',
+          '    "medium": {},',
+          '    "high": {}',
+          "  }",
+          "}",
+        ].join("\n"),
+      )
+    }
+    entries.push(
+      [
+        "xai/grok-4.5",
+        "{",
+        '  "id": "grok-4.5",',
+        '  "variants": {',
+        '    "low": {},',
+        '    "medium": {},',
+        '    "high": {}',
+        "  }",
+        "}",
+      ].join("\n"),
+    )
+    const fullStdout = `${entries.join("\n")}\n`
+    expect(Buffer.byteLength(fullStdout, "utf8")).toBeGreaterThan(64 * 1024)
+    const expected = parseVerboseModelsOutput(fullStdout)
+    expect(expected.length).toBe(56)
+    expect(expected.at(-1)).toEqual({
+      id: "xai/grok-4.5",
+      variants: ["low", "medium", "high"],
+    })
+
+    const directory = await mkdtemp(join(tmpdir(), "opencode-effect-test-"))
+    const fixturePath = join(directory, "models-verbose.txt")
+    const binaryPath = join(directory, "opencode")
+    try {
+      await writeFile(fixturePath, fullStdout)
+      await writeFile(
+        binaryPath,
+        [
+          "#!/bin/sh",
+          'if [ "$1" = "models" ] && [ "$2" = "--verbose" ]; then',
+          `  cat "${fixturePath}"`,
+          "  exit 0",
+          "fi",
+          "exit 1",
+          "",
+        ].join("\n"),
+      )
+      await chmod(binaryPath, 0o700)
+
+      const models = await Effect.runPromise(
+        Effect.gen(function* () {
+          const opencode = yield* Opencode
+          return yield* opencode.listModels({
+            cwd: process.cwd(),
+            timeout: "5 seconds",
+          })
+        }).pipe(
+          Effect.provide(
+            Opencode.layer({
+              binary: binaryPath,
+              keymaxxerMcpUrl: "http://127.0.0.1:6057/test/mcp",
+            }).pipe(Layer.provide(BunServices.layer)),
+          ),
+        ),
+      )
+
+      expect(models).toEqual(expected)
+      expect(models.find((model) => model.id === "xai/grok-4.5")).toEqual({
+        id: "xai/grok-4.5",
+        variants: ["low", "medium", "high"],
+      })
+    } finally {
+      await rm(directory, { recursive: true, force: true })
+    }
+  })
+
+  it("fails when verbose models stdout is truncated mid-object", async () => {
+    await withExecutable(
+      [
+        'if [ "$1" = "models" ] && [ "$2" = "--verbose" ]; then',
+        `  printf '%s\\n' 'opencode/kimi-k2.5'`,
+        `  printf '%s\\n' '{'`,
+        `  printf '%s\\n' '  "variants": {'`,
+        `  printf '%s\\n' '    "low": {}'`,
+        "  exit 0",
+        "fi",
+        "exit 1",
+      ].join("\n"),
+      async (binary) => {
+        const error = await Effect.runPromise(
+          Effect.gen(function* () {
+            const opencode = yield* Opencode
+            return yield* opencode.listModels({
+              cwd: process.cwd(),
+              timeout: "2 seconds",
+            })
+          }).pipe(
+            Effect.provide(
+              Opencode.layer({
+                binary,
+                keymaxxerMcpUrl: "http://127.0.0.1:6057/test/mcp",
+              }).pipe(Layer.provide(BunServices.layer)),
+            ),
+            Effect.flip,
+          ),
+        )
+
+        expect(error).toBeInstanceOf(OpencodeIncompleteOutputError)
+        if (error instanceof OpencodeIncompleteOutputError) {
+          expect(error.cwd).toBe(process.cwd())
+          expect(error.byteLength).toBeGreaterThan(0)
+        }
       },
     )
   })

--- a/packages/opencode/test/parse-verbose-models.spec.ts
+++ b/packages/opencode/test/parse-verbose-models.spec.ts
@@ -1,4 +1,7 @@
-import { parseVerboseModelsOutput } from "../src/lib/parse-verbose-models.js"
+import {
+  parseVerboseModelsOutput,
+  parseVerboseModelsOutputDetailed,
+} from "../src/lib/parse-verbose-models.js"
 import { describe, expect, it } from "bun:test"
 
 describe("parseVerboseModelsOutput", () => {
@@ -79,5 +82,40 @@ describe("parseVerboseModelsOutput", () => {
 
   it("ignores lines that are not provider/model ids", () => {
     expect(parseVerboseModelsOutput("not-a-model\n{\n}\n")).toEqual([])
+  })
+
+  it("marks mid-object truncation as incomplete", () => {
+    const stdout = [
+      "opencode/kimi-k2.5",
+      "{",
+      '  "variants": {',
+      '    "low": {}',
+      // truncated before closing braces
+    ].join("\n")
+
+    expect(parseVerboseModelsOutputDetailed(stdout)).toEqual({
+      complete: false,
+      models: [{ id: "opencode/kimi-k2.5", variants: [] }],
+    })
+  })
+
+  it("marks a trailing model id without JSON as incomplete", () => {
+    const stdout = [
+      "opencode/complete",
+      "{",
+      '  "variants": {',
+      '    "low": {}',
+      "  }",
+      "}",
+      "xai/grok-4.5",
+    ].join("\n")
+
+    expect(parseVerboseModelsOutputDetailed(stdout)).toEqual({
+      complete: false,
+      models: [
+        { id: "opencode/complete", variants: ["low"] },
+        { id: "xai/grok-4.5", variants: [] },
+      ],
+    })
   })
 })


### PR DESCRIPTION
## Summary
- Drain complete `opencode models --verbose` stdout before parsing so late providers (e.g. `xai/grok-4.5`) appear in the models catalog with full thinking-level variants.
- Reject truncated verbose output instead of caching a partial catalog.
- Make truly unavailable models obvious in Harness and Repository settings.

Closes #375

## Test plan
- [x] `opencode` unit/integration tests for >64KB catalog capture and incomplete-output failure
- [x] `parse-verbose-models` truncation completeness tests
- [x] Pre-commit affected lint/typecheck/test
- [ ] Open Harness settings with `xai/grok-4.5` configured and confirm Low/Medium/High appear without changing model