### PR TITLE
feat(harness): collapse jobs and repository cards

### DIFF
--- a/apps/harness/src/card-collapse-toggle.tsx
+++ b/apps/harness/src/card-collapse-toggle.tsx
@@ -1,0 +1,38 @@
+type CardCollapseToggleProps = {
+  collapsed: boolean
+  onToggle: () => void
+  controlsId: string
+  label: string
+}
+
+/** Keyboard-accessible expand/collapse control for dashboard cards. */
+export function CardCollapseToggle({
+  collapsed,
+  onToggle,
+  controlsId,
+  label,
+}: CardCollapseToggleProps) {
+  return (
+    <button
+      type="button"
+      className="inline-flex size-8 shrink-0 items-center justify-center rounded-md text-slate-500 transition hover:bg-slate-100 hover:text-slate-800 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-600"
+      aria-expanded={!collapsed}
+      aria-controls={controlsId}
+      aria-label={collapsed ? `Expand ${label}` : `Collapse ${label}`}
+      onClick={onToggle}
+    >
+      <svg
+        aria-hidden="true"
+        className={`size-4 transition-transform ${collapsed ? "" : "rotate-180"}`}
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      >
+        <path d="m6 9 6 6 6-6" />
+      </svg>
+    </button>
+  )
+}

--- a/apps/harness/src/card-collapse.ts
+++ b/apps/harness/src/card-collapse.ts
@@ -1,0 +1,94 @@
+import { useCallback, useEffect, useState } from "react"
+
+export const CARD_COLLAPSE_STORAGE_KEY = "ready-for-agent.card-collapsed"
+
+const browserStorage = (): Storage | null => {
+  try {
+    const storage = globalThis.localStorage
+    return storage ?? null
+  } catch {
+    return null
+  }
+}
+
+const readStore = (): Record<string, boolean> => {
+  const storage = browserStorage()
+  if (storage === null) return {}
+  try {
+    const raw = storage.getItem(CARD_COLLAPSE_STORAGE_KEY)
+    if (raw === null || raw === "") return {}
+    const parsed: unknown = JSON.parse(raw)
+    if (
+      parsed === null ||
+      typeof parsed !== "object" ||
+      Array.isArray(parsed)
+    ) {
+      return {}
+    }
+    const store: Record<string, boolean> = {}
+    for (const [key, value] of Object.entries(parsed)) {
+      if (typeof value === "boolean") store[key] = value
+    }
+    return store
+  } catch {
+    return {}
+  }
+}
+
+/** Whether a card is collapsed; missing keys default to expanded. */
+export function readCardCollapsed(cardId: string): boolean {
+  return readStore()[cardId] === true
+}
+
+/** Persist collapsed/expanded for one card id. */
+export function writeCardCollapsed(cardId: string, collapsed: boolean): void {
+  const storage = browserStorage()
+  if (storage === null) return
+  try {
+    const store = readStore()
+    if (collapsed) store[cardId] = true
+    else delete store[cardId]
+    storage.setItem(CARD_COLLAPSE_STORAGE_KEY, JSON.stringify(store))
+  } catch {
+    // Quota or private mode — preference is best-effort only.
+  }
+}
+
+export function jobsCardCollapseId(): string {
+  return "jobs"
+}
+
+export function repositoryCardCollapseId(repositoryId: string): string {
+  return `repository:${repositoryId}`
+}
+
+/** Collapsed preference for a dashboard card, restored from localStorage. */
+export function useCardCollapsed(cardId: string): {
+  collapsed: boolean
+  setCollapsed: (collapsed: boolean) => void
+  toggleCollapsed: () => void
+} {
+  const [collapsed, setCollapsedState] = useState(false)
+
+  useEffect(() => {
+    setCollapsedState(readCardCollapsed(cardId))
+  }, [cardId])
+
+  const setCollapsed = useCallback(
+    (next: boolean) => {
+      setCollapsedState(next)
+      writeCardCollapsed(cardId, next)
+    },
+    [cardId],
+  )
+
+  const toggleCollapsed = useCallback(() => {
+    setCollapsedState((current) => {
+      const next = !current
+      writeCardCollapsed(cardId, next)
+      return next
+    })
+  }, [cardId])
+
+  return { collapsed, setCollapsed, toggleCollapsed }
+}

--- a/apps/harness/src/routes/index.tsx
+++ b/apps/harness/src/routes/index.tsx
@@ -8,6 +8,12 @@ import {
 import { createFileRoute } from "@tanstack/react-router"
 import { type FormEvent, Suspense, useEffect, useRef, useState } from "react"
 import { createClient } from "@ready-for-agent/graphql-client"
+import {
+  jobsCardCollapseId,
+  repositoryCardCollapseId,
+  useCardCollapsed,
+} from "../card-collapse.js"
+import { CardCollapseToggle } from "../card-collapse-toggle.js"
 import { Copy } from "../copy.js"
 import {
   formatDuration,
@@ -390,6 +396,9 @@ function HomePage() {
 
 function HomeBody() {
   const { data: repositories } = useSuspenseQuery(repositoriesQuery)
+  const { collapsed: jobsCollapsed, toggleCollapsed: toggleJobsCollapsed } =
+    useCardCollapsed(jobsCardCollapseId())
+  const jobsBodyId = "jobs-card-body"
 
   if (repositories.length === 0) {
     return <RepositoryCards />
@@ -401,12 +410,24 @@ function HomeBody() {
         <CommittedPullRequestsDashboard />
       </section>
       <section aria-label="Jobs">
-        <h2 className="mb-4 text-lg font-bold tracking-[-0.02em] text-slate-900">
-          Jobs
-        </h2>
-        <Suspense fallback={<JobsCardSkeleton />}>
-          <JobsCard />
-        </Suspense>
+        <div className="mb-4 flex items-center justify-between gap-3">
+          <h2 className="m-0 text-lg font-bold tracking-[-0.02em] text-slate-900">
+            Jobs
+          </h2>
+          <CardCollapseToggle
+            collapsed={jobsCollapsed}
+            onToggle={toggleJobsCollapsed}
+            controlsId={jobsBodyId}
+            label="Jobs"
+          />
+        </div>
+        {!jobsCollapsed && (
+          <div id={jobsBodyId}>
+            <Suspense fallback={<JobsCardSkeleton />}>
+              <JobsCard />
+            </Suspense>
+          </div>
+        )}
       </section>
       <div className="mt-8">
         <RepositoryCards />
@@ -964,19 +985,33 @@ function RepositoryCard({
   const pauseButtonClass = repository.paused
     ? "border-blue-300 text-blue-700 hover:bg-blue-50 focus-visible:outline-blue-600"
     : "border-amber-300 text-amber-700 hover:bg-amber-50 focus-visible:outline-amber-600"
+  const repositoryLabel = `${repository.githubOwner}/${repository.githubRepo}`
+  const {
+    collapsed: repositoryCollapsed,
+    toggleCollapsed: toggleRepositoryCollapsed,
+  } = useCardCollapsed(repositoryCardCollapseId(repository.id))
+  const repositoryBodyId = `repository-card-body-${repository.id}`
 
   return (
     <article className="relative min-w-0 rounded-[0.9rem] border border-[#dbe3ef] bg-white p-[1.35rem] shadow-[0_10px_30px_rgb(15_23_42_/_5%)]">
-      <div className="mb-[1.4rem] flex items-center justify-between gap-4">
+      <div
+        className={`flex items-center justify-between gap-4 ${repositoryCollapsed ? "" : "mb-[1.4rem]"}`}
+      >
         <h2 className="m-0 min-w-0 truncate text-2xl tracking-[-0.025em]">
           <a
             className="text-slate-900 hover:underline"
             href={`https://github.com/${repository.githubOwner}/${repository.githubRepo}`}
           >
-            {repository.githubOwner}/{repository.githubRepo}
+            {repositoryLabel}
           </a>
         </h2>
         <div className="flex shrink-0 items-center gap-1">
+          <CardCollapseToggle
+            collapsed={repositoryCollapsed}
+            onToggle={toggleRepositoryCollapsed}
+            controlsId={repositoryBodyId}
+            label={repositoryLabel}
+          />
           <button
             type="button"
             className={`inline-flex size-8 items-center justify-center rounded-full border transition focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-wait disabled:opacity-50 ${pauseFailed ? "border-red-300 text-red-600 hover:bg-red-50 focus-visible:outline-red-600" : pauseButtonClass}`}
@@ -1091,63 +1126,6 @@ function RepositoryCard({
           </span>
         </div>
       </div>
-      <dl className="m-0 grid gap-1">
-        <div className="flex min-w-0 items-baseline gap-1.5 text-[0.82rem]">
-          <dt className="shrink-0 font-[750] tracking-[0.06em] text-slate-400 uppercase">
-            Path:
-          </dt>
-          <dd
-            className="m-0 min-w-0 truncate font-mono text-slate-700"
-            title={repository.localPath}
-          >
-            {repository.localPath}
-          </dd>
-        </div>
-        <div className="flex min-w-0 items-baseline gap-1.5 text-[0.82rem]">
-          <dt className="shrink-0 font-[750] tracking-[0.06em] text-slate-400 uppercase">
-            Checkout:
-          </dt>
-          <dd className="m-0 min-w-0 truncate font-mono text-slate-700">
-            {repository.isBare ? "Bare repository" : "Working tree"}
-          </dd>
-        </div>
-        <div className="flex min-w-0 items-baseline gap-1.5 text-[0.82rem]">
-          <dt className="shrink-0 font-[750] tracking-[0.06em] text-slate-400 uppercase">
-            Build model:
-          </dt>
-          <dd className="m-0 min-w-0 truncate font-mono text-slate-700">
-            {repository.defaultModel ?? `Default (${harnessDefaultModel})`}
-            {" · "}
-            {repository.defaultVariant ?? `Default (${harnessDefaultVariant})`}
-          </dd>
-        </div>
-        <div className="flex min-w-0 items-baseline gap-1.5 text-[0.82rem]">
-          <dt className="shrink-0 font-[750] tracking-[0.06em] text-slate-400 uppercase">
-            Review model:
-          </dt>
-          <dd className="m-0 min-w-0 truncate font-mono text-slate-700">
-            {repository.reviewModel ?? `Default (${harnessReviewModel})`}
-            {" · "}
-            {repository.reviewVariant ?? `Default (${harnessReviewVariant})`}
-          </dd>
-        </div>
-        <div className="flex min-w-0 items-baseline gap-1.5 text-[0.82rem]">
-          <dt className="shrink-0 font-[750] tracking-[0.06em] text-slate-400 uppercase">
-            Auto-merge:
-          </dt>
-          <dd className="m-0 text-slate-700">
-            {repository.autoMerge ? "Enabled" : "Disabled"}
-          </dd>
-        </div>
-        <div className="flex min-w-0 items-baseline gap-1.5 text-[0.82rem]">
-          <dt className="shrink-0 font-[750] tracking-[0.06em] text-slate-400 uppercase">
-            Include all Issue Authors:
-          </dt>
-          <dd className="m-0 text-slate-700">
-            {repository.includeAllIssueAuthors ? "Enabled" : "Disabled"}
-          </dd>
-        </div>
-      </dl>
       <dialog
         ref={settingsDialogRef}
         className="m-auto w-[min(92vw,31rem)] rounded-2xl border border-slate-200 bg-white p-0 text-slate-900 shadow-2xl backdrop:bg-slate-950/45"
@@ -1407,114 +1385,177 @@ function RepositoryCard({
           </div>
         </form>
       </dialog>
-      {!repository.credential.configured && (
-        <div className="mt-5 grid gap-2 rounded-lg border border-amber-200 bg-amber-50 px-3.5 py-3 text-sm text-amber-950">
-          <strong>GitHub token required</strong>
-          {githubTokenCreated ? (
-            <p className="m-0">
-              Store the generated token as{" "}
-              <code className="font-bold">
-                {repository.credential.githubTokenSecretName}
-              </code>{" "}
-              in Keymaxxer. Already-created tokens are not upgraded
-              automatically — edit the token on GitHub or recreate it, then
-              store the replacement.
-            </p>
-          ) : (
-            <p className="m-0">
-              Create a fine-grained token, choose{" "}
-              <strong>Only select repositories</strong>, select{" "}
-              <code className="font-bold">{repository.githubRepo}</code>, and
-              allow <strong>Actions: Read and write</strong> (required for
-              workflow reruns and CI logs). Already-created tokens are not
-              upgraded automatically — edit or recreate them if Actions is still
-              read-only.
-            </p>
+      {!repositoryCollapsed && (
+        <div id={repositoryBodyId}>
+          <dl className="m-0 grid gap-1">
+            <div className="flex min-w-0 items-baseline gap-1.5 text-[0.82rem]">
+              <dt className="shrink-0 font-[750] tracking-[0.06em] text-slate-400 uppercase">
+                Path:
+              </dt>
+              <dd
+                className="m-0 min-w-0 truncate font-mono text-slate-700"
+                title={repository.localPath}
+              >
+                {repository.localPath}
+              </dd>
+            </div>
+            <div className="flex min-w-0 items-baseline gap-1.5 text-[0.82rem]">
+              <dt className="shrink-0 font-[750] tracking-[0.06em] text-slate-400 uppercase">
+                Checkout:
+              </dt>
+              <dd className="m-0 min-w-0 truncate font-mono text-slate-700">
+                {repository.isBare ? "Bare repository" : "Working tree"}
+              </dd>
+            </div>
+            <div className="flex min-w-0 items-baseline gap-1.5 text-[0.82rem]">
+              <dt className="shrink-0 font-[750] tracking-[0.06em] text-slate-400 uppercase">
+                Build model:
+              </dt>
+              <dd className="m-0 min-w-0 truncate font-mono text-slate-700">
+                {repository.defaultModel ?? `Default (${harnessDefaultModel})`}
+                {" · "}
+                {repository.defaultVariant ??
+                  `Default (${harnessDefaultVariant})`}
+              </dd>
+            </div>
+            <div className="flex min-w-0 items-baseline gap-1.5 text-[0.82rem]">
+              <dt className="shrink-0 font-[750] tracking-[0.06em] text-slate-400 uppercase">
+                Review model:
+              </dt>
+              <dd className="m-0 min-w-0 truncate font-mono text-slate-700">
+                {repository.reviewModel ?? `Default (${harnessReviewModel})`}
+                {" · "}
+                {repository.reviewVariant ??
+                  `Default (${harnessReviewVariant})`}
+              </dd>
+            </div>
+            <div className="flex min-w-0 items-baseline gap-1.5 text-[0.82rem]">
+              <dt className="shrink-0 font-[750] tracking-[0.06em] text-slate-400 uppercase">
+                Auto-merge:
+              </dt>
+              <dd className="m-0 text-slate-700">
+                {repository.autoMerge ? "Enabled" : "Disabled"}
+              </dd>
+            </div>
+            <div className="flex min-w-0 items-baseline gap-1.5 text-[0.82rem]">
+              <dt className="shrink-0 font-[750] tracking-[0.06em] text-slate-400 uppercase">
+                Include all Issue Authors:
+              </dt>
+              <dd className="m-0 text-slate-700">
+                {repository.includeAllIssueAuthors ? "Enabled" : "Disabled"}
+              </dd>
+            </div>
+          </dl>
+          {!repository.credential.configured && (
+            <div className="mt-5 grid gap-2 rounded-lg border border-amber-200 bg-amber-50 px-3.5 py-3 text-sm text-amber-950">
+              <strong>GitHub token required</strong>
+              {githubTokenCreated ? (
+                <p className="m-0">
+                  Store the generated token as{" "}
+                  <code className="font-bold">
+                    {repository.credential.githubTokenSecretName}
+                  </code>{" "}
+                  in Keymaxxer. Already-created tokens are not upgraded
+                  automatically — edit the token on GitHub or recreate it, then
+                  store the replacement.
+                </p>
+              ) : (
+                <p className="m-0">
+                  Create a fine-grained token, choose{" "}
+                  <strong>Only select repositories</strong>, select{" "}
+                  <code className="font-bold">{repository.githubRepo}</code>,
+                  and allow <strong>Actions: Read and write</strong> (required
+                  for workflow reruns and CI logs). Already-created tokens are
+                  not upgraded automatically — edit or recreate them if Actions
+                  is still read-only.
+                </p>
+              )}
+              {githubTokenCreated ? (
+                <button
+                  type="button"
+                  className="w-fit rounded-md bg-amber-900 px-3 py-2 font-semibold text-white transition hover:bg-amber-800 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-amber-900 disabled:cursor-wait disabled:opacity-60"
+                  disabled={addGitHubToken.isPending}
+                  onClick={() => addGitHubToken.mutate()}
+                >
+                  {addGitHubToken.isPending
+                    ? "Waiting for Keymaxxer"
+                    : "Store in Keymaxxer"}
+                </button>
+              ) : (
+                <a
+                  className="w-fit rounded-md bg-amber-900 px-3 py-2 font-semibold text-white no-underline transition hover:bg-amber-800 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-amber-900"
+                  href={repository.credential.githubTokenCreationUrl}
+                  onClick={() => setGithubTokenCreated(true)}
+                  rel="noreferrer"
+                  target="_blank"
+                >
+                  Create GitHub token
+                </a>
+              )}
+              {addGitHubToken.isError && (
+                <p className="m-0 text-red-700" role="alert">
+                  Keymaxxer setup was cancelled or failed.
+                </p>
+              )}
+            </div>
           )}
-          {githubTokenCreated ? (
-            <button
-              type="button"
-              className="w-fit rounded-md bg-amber-900 px-3 py-2 font-semibold text-white transition hover:bg-amber-800 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-amber-900 disabled:cursor-wait disabled:opacity-60"
-              disabled={addGitHubToken.isPending}
-              onClick={() => addGitHubToken.mutate()}
-            >
-              {addGitHubToken.isPending
-                ? "Waiting for Keymaxxer"
-                : "Store in Keymaxxer"}
-            </button>
-          ) : (
-            <a
-              className="w-fit rounded-md bg-amber-900 px-3 py-2 font-semibold text-white no-underline transition hover:bg-amber-800 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-amber-900"
-              href={repository.credential.githubTokenCreationUrl}
-              onClick={() => setGithubTokenCreated(true)}
-              rel="noreferrer"
-              target="_blank"
-            >
-              Create GitHub token
-            </a>
-          )}
-          {addGitHubToken.isError && (
-            <p className="m-0 text-red-700" role="alert">
-              Keymaxxer setup was cancelled or failed.
+          <div className="mt-5 border-t border-slate-100 pt-4">
+            <div className="mb-2 flex items-center justify-between gap-3">
+              <h3 className="m-0 text-[0.68rem] font-[750] tracking-[0.08em] text-slate-400 uppercase">
+                Relevant issues
+              </h3>
+              <button
+                type="button"
+                className="inline-flex size-7 items-center justify-center rounded-md border border-slate-200 bg-white text-slate-600 transition hover:border-slate-300 hover:bg-slate-50 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-600 disabled:cursor-wait disabled:opacity-60"
+                disabled={refreshingIssues || !repository.credential.configured}
+                onClick={() => refreshIssues.mutate()}
+                aria-label={
+                  refreshingIssues ? "Refreshing issues" : "Refresh issues"
+                }
+                title={
+                  repository.credential.configured
+                    ? "Refresh issues"
+                    : "Add a GitHub token before refreshing issues"
+                }
+              >
+                <svg
+                  aria-hidden="true"
+                  className={`size-4 ${refreshingIssues ? "animate-spin motion-reduce:animate-none" : ""}`}
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                >
+                  <path d="M20 11a8.1 8.1 0 0 0-15.5-2M4 4v5h5" />
+                  <path d="M4 13a8.1 8.1 0 0 0 15.5 2M20 20v-5h-5" />
+                </svg>
+              </button>
+            </div>
+            {refreshIssues.isError && (
+              <p className="mb-2 text-sm text-red-700" role="alert">
+                Failed to refresh issues.
+              </p>
+            )}
+            {repository.issuesReconciledAt === null ? (
+              <p className="m-0 text-sm text-slate-500">Not refreshed yet.</p>
+            ) : (
+              <Suspense fallback={<RepositoryIssuesSkeleton />}>
+                <RepositoryIssues
+                  repository={repository}
+                  workItems={workItems}
+                  workItemsLoading={workItemsLoading}
+                />
+              </Suspense>
+            )}
+          </div>
+          {removeRepository.isError && (
+            <p className="mt-3 mb-0 text-sm text-red-700" role="alert">
+              Could not remove repository. Please try again.
             </p>
           )}
         </div>
-      )}
-      <div className="mt-5 border-t border-slate-100 pt-4">
-        <div className="mb-2 flex items-center justify-between gap-3">
-          <h3 className="m-0 text-[0.68rem] font-[750] tracking-[0.08em] text-slate-400 uppercase">
-            Relevant issues
-          </h3>
-          <button
-            type="button"
-            className="inline-flex size-7 items-center justify-center rounded-md border border-slate-200 bg-white text-slate-600 transition hover:border-slate-300 hover:bg-slate-50 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-600 disabled:cursor-wait disabled:opacity-60"
-            disabled={refreshingIssues || !repository.credential.configured}
-            onClick={() => refreshIssues.mutate()}
-            aria-label={
-              refreshingIssues ? "Refreshing issues" : "Refresh issues"
-            }
-            title={
-              repository.credential.configured
-                ? "Refresh issues"
-                : "Add a GitHub token before refreshing issues"
-            }
-          >
-            <svg
-              aria-hidden="true"
-              className={`size-4 ${refreshingIssues ? "animate-spin motion-reduce:animate-none" : ""}`}
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="2"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-            >
-              <path d="M20 11a8.1 8.1 0 0 0-15.5-2M4 4v5h5" />
-              <path d="M4 13a8.1 8.1 0 0 0 15.5 2M20 20v-5h-5" />
-            </svg>
-          </button>
-        </div>
-        {refreshIssues.isError && (
-          <p className="mb-2 text-sm text-red-700" role="alert">
-            Failed to refresh issues.
-          </p>
-        )}
-        {repository.issuesReconciledAt === null ? (
-          <p className="m-0 text-sm text-slate-500">Not refreshed yet.</p>
-        ) : (
-          <Suspense fallback={<RepositoryIssuesSkeleton />}>
-            <RepositoryIssues
-              repository={repository}
-              workItems={workItems}
-              workItemsLoading={workItemsLoading}
-            />
-          </Suspense>
-        )}
-      </div>
-      {removeRepository.isError && (
-        <p className="mt-3 mb-0 text-sm text-red-700" role="alert">
-          Could not remove repository. Please try again.
-        </p>
       )}
     </article>
   )

--- a/apps/harness/test/card-collapse-ui.test.ts
+++ b/apps/harness/test/card-collapse-ui.test.ts
@@ -1,0 +1,50 @@
+import { readFileSync } from "node:fs"
+import { join } from "node:path"
+import { describe, expect, test } from "bun:test"
+
+const homeSource = () =>
+  readFileSync(join(import.meta.dir, "../src/routes/index.tsx"), "utf8")
+
+const toggleSource = () =>
+  readFileSync(join(import.meta.dir, "../src/card-collapse-toggle.tsx"), "utf8")
+
+describe("collapsible jobs and repository cards", () => {
+  test("jobs section has expand/collapse control and hides body when collapsed", () => {
+    const source = homeSource()
+    expect(source).toContain('from "../card-collapse.js"')
+    expect(source).toContain('from "../card-collapse-toggle.js"')
+    expect(source).toContain("jobsCardCollapseId()")
+    expect(source).toContain("useCardCollapsed(jobsCardCollapseId())")
+    expect(source).toContain('label="Jobs"')
+    expect(source).toContain("jobs-card-body")
+    expect(source).toContain("!jobsCollapsed &&")
+    expect(source).toContain("toggleJobsCollapsed")
+  })
+
+  test("repository cards collapse body while keeping header controls", () => {
+    const source = homeSource()
+    expect(source).toContain("repositoryCardCollapseId(repository.id)")
+    expect(source).toContain("repository-card-body-")
+    expect(source).toContain("!repositoryCollapsed &&")
+    expect(source).toContain("toggleRepositoryCollapsed")
+    expect(source).toContain("label={repositoryLabel}")
+    const collapseToggleIndex = source.indexOf(
+      "collapsed={repositoryCollapsed}",
+    )
+    const actionsMenuIndex = source.indexOf("data-repo-menu={repository.id}")
+    const bodyStart = source.indexOf("!repositoryCollapsed &&")
+    expect(collapseToggleIndex).toBeGreaterThan(-1)
+    expect(actionsMenuIndex).toBeGreaterThan(collapseToggleIndex)
+    expect(bodyStart).toBeGreaterThan(actionsMenuIndex)
+  })
+
+  test("collapse toggle is a keyboard-focusable button with aria-expanded", () => {
+    const source = toggleSource()
+    expect(source).toContain('type="button"')
+    expect(source).toContain("aria-expanded={!collapsed}")
+    expect(source).toContain("aria-controls={controlsId}")
+    expect(source).toContain("Expand ")
+    expect(source).toContain("Collapse ")
+    expect(source).toContain("focus-visible:outline-2")
+  })
+})

--- a/apps/harness/test/card-collapse.test.ts
+++ b/apps/harness/test/card-collapse.test.ts
@@ -1,0 +1,89 @@
+import {
+  CARD_COLLAPSE_STORAGE_KEY,
+  jobsCardCollapseId,
+  readCardCollapsed,
+  repositoryCardCollapseId,
+  writeCardCollapsed,
+} from "../src/card-collapse.js"
+import { afterEach, beforeAll, describe, expect, test } from "bun:test"
+
+const memoryStorage = (): Storage => {
+  const values = new Map<string, string>()
+  return {
+    get length() {
+      return values.size
+    },
+    clear() {
+      values.clear()
+    },
+    getItem(key: string) {
+      return values.has(key) ? (values.get(key) ?? null) : null
+    },
+    key(index: number) {
+      return [...values.keys()][index] ?? null
+    },
+    removeItem(key: string) {
+      values.delete(key)
+    },
+    setItem(key: string, value: string) {
+      values.set(key, String(value))
+    },
+  }
+}
+
+beforeAll(() => {
+  Object.defineProperty(globalThis, "localStorage", {
+    configurable: true,
+    value: memoryStorage(),
+  })
+})
+
+afterEach(() => {
+  localStorage.removeItem(CARD_COLLAPSE_STORAGE_KEY)
+})
+
+describe("card collapse preference", () => {
+  test("defaults to expanded when unset", () => {
+    expect(readCardCollapsed(jobsCardCollapseId())).toBe(false)
+    expect(readCardCollapsed(repositoryCardCollapseId("repo-1"))).toBe(false)
+  })
+
+  test("persists collapsed state per card id", () => {
+    writeCardCollapsed(jobsCardCollapseId(), true)
+    writeCardCollapsed(repositoryCardCollapseId("repo-1"), true)
+    writeCardCollapsed(repositoryCardCollapseId("repo-2"), false)
+
+    expect(readCardCollapsed(jobsCardCollapseId())).toBe(true)
+    expect(readCardCollapsed(repositoryCardCollapseId("repo-1"))).toBe(true)
+    expect(readCardCollapsed(repositoryCardCollapseId("repo-2"))).toBe(false)
+
+    const raw = localStorage.getItem(CARD_COLLAPSE_STORAGE_KEY)
+    expect(raw).not.toBeNull()
+    expect(JSON.parse(raw!)).toEqual({
+      jobs: true,
+      "repository:repo-1": true,
+    })
+  })
+
+  test("clearing collapse removes the key so default expanded returns", () => {
+    writeCardCollapsed(jobsCardCollapseId(), true)
+    expect(readCardCollapsed(jobsCardCollapseId())).toBe(true)
+    writeCardCollapsed(jobsCardCollapseId(), false)
+    expect(readCardCollapsed(jobsCardCollapseId())).toBe(false)
+    expect(localStorage.getItem(CARD_COLLAPSE_STORAGE_KEY)).toBe("{}")
+  })
+
+  test("ignores corrupt storage", () => {
+    localStorage.setItem(CARD_COLLAPSE_STORAGE_KEY, "not-json")
+    expect(readCardCollapsed(jobsCardCollapseId())).toBe(false)
+    localStorage.setItem(CARD_COLLAPSE_STORAGE_KEY, '["jobs"]')
+    expect(readCardCollapsed(jobsCardCollapseId())).toBe(false)
+    localStorage.setItem(CARD_COLLAPSE_STORAGE_KEY, '{"jobs":"yes"}')
+    expect(readCardCollapsed(jobsCardCollapseId())).toBe(false)
+  })
+
+  test("uses stable ids for jobs and repositories", () => {
+    expect(jobsCardCollapseId()).toBe("jobs")
+    expect(repositoryCardCollapseId("abc")).toBe("repository:abc")
+  })
+})


### PR DESCRIPTION
## Summary

- Add expand/collapse controls for the Jobs section and each repository card on the home dashboard.
- Keep headers and controls visible when collapsed so cards can be expanded again.
- Persist collapsed/expanded preferences in localStorage across reloads.

Closes #359

## Test plan

- [x] Unit tests for localStorage collapse preference store
- [x] Source-level UI wiring tests for jobs/repo collapse controls and accessibility attributes
- [x] Pre-commit affected lint/typecheck/test
- [ ] Manually collapse/expand Jobs and a repository card; reload and confirm state persists
- [ ] Confirm expand/collapse control is keyboard reachable (Tab/Enter/Space)