### PR TITLE
fix(work-item-lifecycle): continue OpenCode session on Build retry

### DIFF
--- a/docs/research/112-direct-opencode-launch-contract.md
+++ b/docs/research/112-direct-opencode-launch-contract.md
@@ -50,7 +50,7 @@ opencode run --auto --format json --dir <cwd> -m <model> --variant <variant> [--
 | Step | Session policy |
 | --- | --- |
 | Install fallback | `start`; session id discarded |
-| Implement | Always `start` (fresh session; ignore any prior) |
+| Implement | `continue` when Work Item `sessionId` is set (Retry after interrupt/fail); otherwise `start` |
 | Review, Commit, Create PR, Investigate PR checks, Decide PR merge | `continue` with Work Item `sessionId` |
 
 - stdin: ignore  

--- a/packages/work-item-lifecycle/src/lib/implement.ts
+++ b/packages/work-item-lifecycle/src/lib/implement.ts
@@ -120,10 +120,32 @@ const buildImplementPrompt = (
     "Do not merely propose a plan; complete the implementation work for that exact issue.",
   ].join("\n")
 
+const buildContinueImplementPrompt = (
+  githubOwner: string,
+  githubRepo: string,
+  githubIssueNumber: number,
+) =>
+  [
+    `Continue implementing GitHub issue ${githubOwner}/${githubRepo}#${githubIssueNumber}.`,
+    "A previous Implement attempt was interrupted or failed; resume from the existing session and worktree state.",
+    "Inspect the current GitHub Issue, this Repository's agent/project instructions, and any partial work already present.",
+    "Finish the implementation in this worktree and run appropriate verification.",
+    "Do not merely propose a plan; complete the implementation work for that exact issue.",
+  ].join("\n")
+
+const priorSessionId = (context: LifecycleStepContext): string | null => {
+  const sessionId = context.sessionId
+  if (sessionId === null || sessionId.trim() === "") {
+    return null
+  }
+  return sessionId
+}
+
 /**
  * Production Implement Lifecycle Step.
- * Starts a fresh OpenCode Session in the Work Item worktree and asks it to
- * implement the referenced GitHub Issue. Always uses start — never continue.
+ * Starts a fresh OpenCode Session in the Work Item worktree when none exists,
+ * or continues the prior Session when `session_id` is already set (Retry after
+ * interrupt or failed Build). Fresh start after delete/reset has no session id.
  */
 export const implement = (context: LifecycleStepContext) =>
   Effect.gen(function* () {
@@ -131,45 +153,65 @@ export const implement = (context: LifecycleStepContext) =>
     const repository = yield* resolveRepository(context)
     const githubIssueNumber = yield* resolveIssueNumber(context)
 
-    const prompt = buildImplementPrompt(
-      repository.githubOwner,
-      repository.githubRepo,
-      githubIssueNumber,
-    )
+    const existingSessionId = priorSessionId(context)
+    const prompt =
+      existingSessionId === null
+        ? buildImplementPrompt(
+            repository.githubOwner,
+            repository.githubRepo,
+            githubIssueNumber,
+          )
+        : buildContinueImplementPrompt(
+            repository.githubOwner,
+            repository.githubRepo,
+            githubIssueNumber,
+          )
 
     const opencode = yield* Opencode
     const sql = yield* SqlClient.SqlClient
     const db = yield* DbService
-    // Always start a fresh Session. Ignore any prior context.sessionId from
-    // setup, dependency installation, or a previous failed Step Run.
-    const result = yield* opencode
-      .start({
-        prompt,
-        cwd: worktreePath,
-        model: context.model,
-        variant: context.variant,
-        timeout:
-          context.maxDuration ?? DEFAULT_LIFECYCLE_MAX_DURATIONS.implement,
-        onSessionId: (sessionId) =>
-          persistSessionIdMidRun(
-            context.workItemId,
-            sessionId,
-            context.repositoryId,
-          ).pipe(
-            Effect.provideService(SqlClient.SqlClient, sql),
-            Effect.provideService(DbService, db),
-          ),
-      })
-      .pipe(
-        Effect.mapError(
-          (cause) =>
-            new ImplementOpenCodeError({
-              message: "OpenCode failed to implement the Work Item issue",
-              worktreePath,
-              cause,
-            }),
-        ),
+    const onSessionId = (sessionId: string) =>
+      persistSessionIdMidRun(
+        context.workItemId,
+        sessionId,
+        context.repositoryId,
+      ).pipe(
+        Effect.provideService(SqlClient.SqlClient, sql),
+        Effect.provideService(DbService, db),
       )
+
+    const run =
+      existingSessionId === null
+        ? opencode.start({
+            prompt,
+            cwd: worktreePath,
+            model: context.model,
+            variant: context.variant,
+            timeout:
+              context.maxDuration ?? DEFAULT_LIFECYCLE_MAX_DURATIONS.implement,
+            onSessionId,
+          })
+        : opencode.continue({
+            sessionId: existingSessionId,
+            prompt,
+            cwd: worktreePath,
+            model: context.model,
+            variant: context.variant,
+            timeout:
+              context.maxDuration ?? DEFAULT_LIFECYCLE_MAX_DURATIONS.implement,
+            onSessionId,
+          })
+
+    const result = yield* run.pipe(
+      Effect.mapError(
+        (cause) =>
+          new ImplementOpenCodeError({
+            message: "OpenCode failed to implement the Work Item issue",
+            worktreePath,
+            cause,
+          }),
+      ),
+    )
 
     if (result.sessionId.trim() === "") {
       return yield* new ImplementOpenCodeError({

--- a/packages/work-item-lifecycle/test/implement.spec.ts
+++ b/packages/work-item-lifecycle/test/implement.spec.ts
@@ -175,7 +175,7 @@ describe("implement", () => {
       expect(error).toBeInstanceOf(ImplementIssueContextMissingError)
     }))
 
-  it("starts OpenCode with exact issue identity, worktree, model, and variant", () =>
+  it("starts OpenCode with exact issue identity, worktree, model, and variant when no prior session", () =>
     withTemp(async (root) => {
       let started: {
         prompt: string
@@ -197,7 +197,7 @@ describe("implement", () => {
               variant: "max",
               reviewModel: "opencode/implement-model",
               reviewVariant: "max",
-              sessionId: "ses_install_fallback_must_ignore",
+              sessionId: null,
               maxDuration: Duration.minutes(90),
             }),
           )
@@ -232,76 +232,138 @@ describe("implement", () => {
       expect(continued).toBe(false)
     }))
 
-  it("always starts a fresh Session despite an earlier installation Session", () =>
+  it("starts a fresh Session when session_id is blank", () =>
+    withTemp(async (root) => {
+      let started = false
+      let continued = false
+
+      const sessionId = await run(
+        Effect.gen(function* () {
+          const repository = yield* seedRepository(root)
+          return yield* implement(
+            baseContext(root, {
+              repositoryId: repository.id,
+              sessionId: "   ",
+            }),
+          )
+        }),
+        stubOpencode({
+          start: () => {
+            started = true
+            return Effect.succeed({
+              sessionId: "ses_blank_prior_start",
+              assistantText: "",
+            })
+          },
+          continue: () => {
+            continued = true
+            return Effect.succeed({
+              sessionId: "ses_should_not",
+              assistantText: "",
+            })
+          },
+        }),
+      )
+
+      expect(sessionId).toBe("ses_blank_prior_start")
+      expect(started).toBe(true)
+      expect(continued).toBe(false)
+    }))
+
+  it("continues the prior OpenCode Session when session_id is set (retry after interrupt)", () =>
+    withTemp(async (root) => {
+      let continued: {
+        sessionId: string
+        prompt: string
+        cwd: string
+        model: string
+        variant: string
+        timeout?: Duration.Input
+      } | null = null
+      let started = false
+
+      const sessionId = await run(
+        Effect.gen(function* () {
+          const repository = yield* seedRepository(root)
+          return yield* implement(
+            baseContext(root, {
+              repositoryId: repository.id,
+              githubIssueNumber: 80,
+              model: "opencode/implement-model",
+              variant: "max",
+              sessionId: "ses_interrupted_build",
+              maxDuration: Duration.minutes(90),
+            }),
+          )
+        }),
+        stubOpencode({
+          start: () => {
+            started = true
+            return Effect.succeed({
+              sessionId: "ses_should_not_start",
+              assistantText: "",
+            })
+          },
+          continue: (input) => {
+            continued = input
+            return Effect.succeed({
+              sessionId: input.sessionId,
+              assistantText: "",
+            })
+          },
+        }),
+      )
+
+      expect(sessionId).toBe("ses_interrupted_build")
+      expect(started).toBe(false)
+      expect(continued).not.toBeNull()
+      expect(continued!.sessionId).toBe("ses_interrupted_build")
+      expect(continued!.cwd).toBe(root)
+      expect(continued!.model).toBe("opencode/implement-model")
+      expect(continued!.variant).toBe("max")
+      expect(Duration.toMillis(continued!.timeout!)).toBe(
+        Duration.toMillis(Duration.minutes(90)),
+      )
+      expect(continued!.prompt).toContain("Continue implementing")
+      expect(continued!.prompt).toContain("acme/widgets#80")
+      expect(continued!.prompt).toContain("interrupted or failed")
+      expect(continued!.prompt).toContain("partial work")
+    }))
+
+  it("continues after a failed Build when session_id exists", () =>
     withTemp(async (root) => {
       const calls: string[] = []
-      let continueCalls = 0
 
-      const first = await run(
+      const sessionId = await run(
         Effect.gen(function* () {
           const repository = yield* seedRepository(root)
           return yield* implement(
             baseContext(root, {
               repositoryId: repository.id,
-              sessionId: "ses_from_install_fallback",
+              sessionId: "ses_after_failed_build",
             }),
           )
         }),
         stubOpencode({
           start: () => {
-            calls.push("start-1")
+            calls.push("start")
             return Effect.succeed({
-              sessionId: "ses_first_implement",
+              sessionId: "ses_wrong",
               assistantText: "",
             })
           },
-          continue: () => {
-            continueCalls += 1
+          continue: (input) => {
+            calls.push(`continue:${input.sessionId}`)
             return Effect.succeed({
-              sessionId: "ses_should_not",
+              sessionId: input.sessionId,
               assistantText: "",
             })
           },
         }),
       )
 
-      expect(first).toBe("ses_first_implement")
-      expect(calls).toEqual(["start-1"])
-      expect(continueCalls).toBe(0)
-
-      // Retry is re-entrant: another Implement run starts a new Session even
-      // when context still carries the previous Session id.
-      const second = await run(
-        Effect.gen(function* () {
-          const repository = yield* seedRepository(root)
-          return yield* implement(
-            baseContext(root, {
-              repositoryId: repository.id,
-              sessionId: first,
-            }),
-          )
-        }),
-        stubOpencode({
-          start: () => {
-            calls.push("start-2")
-            return Effect.succeed({
-              sessionId: "ses_retry_implement",
-              assistantText: "",
-            })
-          },
-          continue: () => {
-            continueCalls += 1
-            return Effect.succeed({
-              sessionId: "ses_should_not",
-              assistantText: "",
-            })
-          },
-        }),
-      )
-
-      expect(second).toBe("ses_retry_implement")
-      expect(calls).toEqual(["start-1", "start-2"])
-      expect(continueCalls).toBe(0)
+      expect(sessionId).toBe("ses_after_failed_build")
+      expect(calls).toEqual(["continue:ses_after_failed_build"])
     }))
 
   it("maps OpenCode exit failure", () =>


### PR DESCRIPTION
## Summary

- On Build/Implement Retry, continue the prior OpenCode session when `work_item.session_id` is set instead of always calling `start`.
- Keep `start` when there is no prior session (fresh Work Item or after delete/reset).
- Update implement tests and the OpenCode launch research note to match.

Closes #379

## Test plan

- [x] Unit tests: no `session_id` → `start`; existing `session_id` → `continue`; blank session still starts
- [x] Pre-commit affected lint/typecheck/test
- [ ] Manually interrupt a Build Step Run, Retry, and confirm the same OpenCode session resumes
- [ ] Confirm delete job then new Implement starts a fresh session