### PR TITLE
feat(work-item-lifecycle): apply Review findings with deferred or clean advance

### DIFF
--- a/packages/graphql-api/src/lib/work-item-projection.ts
+++ b/packages/graphql-api/src/lib/work-item-projection.ts
@@ -1,6 +1,7 @@
 import type { IssueRecord } from "@ready-for-agent/db-service"
 import {
   type OperationalLifecycleStep,
+  REVIEW_APPLYING_FINDINGS_MESSAGE,
   REVIEW_REVIEWING_MESSAGE,
   STEP_RUN_REASON,
   type StepRunRecord,
@@ -136,12 +137,15 @@ export const lifecycleLabels = (workItem: WorkItemRecord) => {
       phase === finalPhase ? "needs_human" : stepRunDisplayStatus(stepRun)
     const reviewRunningPhase =
       phase === "review" && status === "running"
-        ? stepRun.reasonCode === STEP_RUN_REASON.reviewReviewing ||
-          stepRun.reasonMessage == null ||
-          stepRun.reasonMessage === "" ||
-          stepRun.reasonMessage === REVIEW_REVIEWING_MESSAGE
-          ? REVIEW_REVIEWING_MESSAGE
-          : stepRun.reasonMessage
+        ? stepRun.reasonCode === STEP_RUN_REASON.reviewApplyingFindings ||
+          stepRun.reasonMessage === REVIEW_APPLYING_FINDINGS_MESSAGE
+          ? REVIEW_APPLYING_FINDINGS_MESSAGE
+          : stepRun.reasonCode === STEP_RUN_REASON.reviewReviewing ||
+              stepRun.reasonMessage == null ||
+              stepRun.reasonMessage === "" ||
+              stepRun.reasonMessage === REVIEW_REVIEWING_MESSAGE
+            ? REVIEW_REVIEWING_MESSAGE
+            : stepRun.reasonMessage
         : null
     const outcome =
       reviewRunningPhase !== null

--- a/packages/graphql-api/test/graphql-api.test.ts
+++ b/packages/graphql-api/test/graphql-api.test.ts
@@ -1766,6 +1766,66 @@ describe("GraphQL API", () => {
     })
   })
 
+  test("projects running Review Step Run as Review: applying findings", async () => {
+    const baseRun = workItem.stepRuns[0]!
+    const applying = {
+      ...workItem,
+      state: "review",
+      stepRuns: [
+        {
+          ...baseRun,
+          step: "review",
+          status: "running",
+          reasonCode: STEP_RUN_REASON.reviewApplyingFindings,
+          reasonMessage: "applying findings",
+        },
+      ],
+    } as WorkItemRecord
+    await runtime.dispose()
+    runtime = makeRuntime(
+      {},
+      {},
+      {},
+      {
+        listWorkItemsForIssue: () => Effect.succeed([applying]),
+      },
+    )
+
+    const response = await createGraphqlApi(runtime).fetch(
+      graphqlRequest({
+        query: `query WorkItems($repositoryId: ID!, $githubIssueNumber: Int!) {
+          workItems(repositoryId: $repositoryId, githubIssueNumber: $githubIssueNumber) {
+            stateLabel status statusLabel
+            lifecycleLabels { phase label status }
+          }
+        }`,
+        variables: {
+          repositoryId: repository.id,
+          githubIssueNumber: issue.githubIssueNumber,
+        },
+      }),
+    )
+
+    expect(await response.json()).toEqual({
+      data: {
+        workItems: [
+          {
+            stateLabel: "Review",
+            status: "RUNNING",
+            statusLabel: "Running",
+            lifecycleLabels: [
+              {
+                phase: "REVIEW",
+                label: "Review: applying findings",
+                status: "RUNNING",
+              },
+            ],
+          },
+        ],
+      },
+    })
+  })
+
   test("lists all Work Items for a repository", async () => {
     let receivedRepositoryId: string | undefined
     await runtime.dispose()

--- a/packages/work-item-lifecycle/src/lib/review-errors.ts
+++ b/packages/work-item-lifecycle/src/lib/review-errors.ts
@@ -44,11 +44,11 @@ export class ReviewResultError extends Schema.TaggedErrorClass<ReviewResultError
 ) {}
 
 /**
- * Reviewing reported findings; apply-findings is not implemented yet (#391).
- * Parse succeeded — this is the intentional stop-short hook, not a parse failure.
+ * Apply pass reported FIXED; Pre-Commit + re-review loop is not implemented yet (#392).
+ * Parse succeeded — intentional stop-short hook, not a parse failure or clean advance.
  */
-export class ReviewHasFindingsPendingError extends Schema.TaggedErrorClass<ReviewHasFindingsPendingError>()(
-  "ReviewHasFindingsPendingError",
+export class ReviewFixedPendingError extends Schema.TaggedErrorClass<ReviewFixedPendingError>()(
+  "ReviewFixedPendingError",
   {
     workItemId: Schema.String,
     message: Schema.String,
@@ -61,4 +61,4 @@ export type ReviewError =
   | ReviewSessionContextMissingError
   | ReviewOpenCodeError
   | ReviewResultError
-  | ReviewHasFindingsPendingError
+  | ReviewFixedPendingError

--- a/packages/work-item-lifecycle/src/lib/review.ts
+++ b/packages/work-item-lifecycle/src/lib/review.ts
@@ -13,13 +13,27 @@ import {
 } from "./review-errors.js"
 import {
   DEFAULT_LIFECYCLE_MAX_DURATIONS,
+  REVIEW_APPLYING_FINDINGS_MESSAGE,
   REVIEW_REVIEWING_MESSAGE,
   STEP_RUN_REASON,
 } from "./types.js"
 
+/** Final Review step outcome after reviewing (and optional apply) completes. */
 export type ReviewResult =
   | { readonly _tag: "clean" }
+  | { readonly _tag: "deferred"; readonly reason: string }
+  | { readonly _tag: "fixed" }
+
+/** Machine-readable outcome of the reviewing (/review) pass only. */
+export type ReviewingPassResult =
+  | { readonly _tag: "clean" }
   | { readonly _tag: "has_findings" }
+
+/** Machine-readable outcome of the apply-findings pass. */
+export type ApplyReviewResult =
+  | { readonly _tag: "clean" }
+  | { readonly _tag: "deferred"; readonly reason: string }
+  | { readonly _tag: "fixed" }
 
 const buildReviewingPrompt = () =>
   [
@@ -31,11 +45,22 @@ const buildReviewingPrompt = () =>
     "READY_FOR_AGENT_RESULT: REVIEW_HAS_FINDINGS",
   ].join("\n")
 
-/**
- * Parse the unique final READY_FOR_AGENT_RESULT line from a reviewing pass.
- * Returns null for missing, duplicate, non-final, or unrecognized markers.
- */
-export const parseReviewResult = (output: string): ReviewResult | null => {
+const buildApplyFindingsPrompt = () =>
+  [
+    "The previous reviewing pass reported Review Findings (REVIEW_HAS_FINDINGS).",
+    "Interpret those findings. Fix only what should be fixed now; you may defer stylistic or disputed notes.",
+    "Do not commit, push, open pull requests, or start unrelated rework.",
+    "End your final response with exactly one machine-readable result line:",
+    "READY_FOR_AGENT_RESULT: REVIEW_FIXED",
+    "when you changed the worktree to address findings,",
+    "READY_FOR_AGENT_RESULT: REVIEW_DEFERRED: <short reason>",
+    "when findings remain but should not block Commit,",
+    "or",
+    "READY_FOR_AGENT_RESULT: REVIEW_CLEAN",
+    "when on re-read there is nothing that needs fixing or deferring.",
+  ].join("\n")
+
+const uniqueFinalResultLine = (output: string): string | null => {
   const lines = output.split("\n").map((line) => line.trim())
   const nonEmptyLines = lines.filter((line) => line !== "")
   const resultLines = lines.filter((line) =>
@@ -50,6 +75,20 @@ export const parseReviewResult = (output: string): ReviewResult | null => {
   ) {
     return null
   }
+  return finalLine
+}
+
+/**
+ * Parse the unique final READY_FOR_AGENT_RESULT line from a reviewing pass.
+ * Returns null for missing, duplicate, non-final, or unrecognized markers.
+ */
+export const parseReviewResult = (
+  output: string,
+): ReviewingPassResult | null => {
+  const finalLine = uniqueFinalResultLine(output)
+  if (finalLine === null) {
+    return null
+  }
 
   if (/^READY_FOR_AGENT_RESULT:\s*REVIEW_CLEAN$/i.test(finalLine)) {
     return { _tag: "clean" }
@@ -57,6 +96,39 @@ export const parseReviewResult = (output: string): ReviewResult | null => {
 
   if (/^READY_FOR_AGENT_RESULT:\s*REVIEW_HAS_FINDINGS$/i.test(finalLine)) {
     return { _tag: "has_findings" }
+  }
+
+  return null
+}
+
+/**
+ * Parse the unique final READY_FOR_AGENT_RESULT line from an apply-findings pass.
+ * Returns null for missing, duplicate, non-final, or unrecognized markers.
+ */
+export const parseApplyReviewResult = (
+  output: string,
+): ApplyReviewResult | null => {
+  const finalLine = uniqueFinalResultLine(output)
+  if (finalLine === null) {
+    return null
+  }
+
+  if (/^READY_FOR_AGENT_RESULT:\s*REVIEW_CLEAN$/i.test(finalLine)) {
+    return { _tag: "clean" }
+  }
+
+  if (/^READY_FOR_AGENT_RESULT:\s*REVIEW_FIXED$/i.test(finalLine)) {
+    return { _tag: "fixed" }
+  }
+
+  const deferred = finalLine.match(
+    /^READY_FOR_AGENT_RESULT:\s*REVIEW_DEFERRED\s*:\s*(.+)$/i,
+  )
+  if (deferred?.[1] !== undefined && deferred[1].trim() !== "") {
+    return {
+      _tag: "deferred",
+      reason: deferred[1].trim().slice(0, 500),
+    }
   }
 
   return null
@@ -108,60 +180,74 @@ const resolveSessionId = (context: LifecycleStepContext) => {
   return Effect.succeed(sessionId)
 }
 
-const markReviewingPhase = Effect.gen(function* () {
-  const current = yield* CurrentStepRun
-  if (current === null) {
-    return
-  }
-  const sql = yield* SqlClient.SqlClient
-  const db = yield* DbService
-  const now = Date.now()
-  yield* sql.unsafe(
-    `UPDATE step_run
+const markReviewPhase = (
+  reasonCode: string,
+  reasonMessage: string,
+  logLabel: string,
+) =>
+  Effect.gen(function* () {
+    const current = yield* CurrentStepRun
+    if (current === null) {
+      return
+    }
+    const sql = yield* SqlClient.SqlClient
+    const db = yield* DbService
+    const now = Date.now()
+    yield* sql.unsafe(
+      `UPDATE step_run
      SET reason_code = ?,
          reason_message = ?,
          updated_at = ?
      WHERE id = ?
        AND status = 'running'`,
-    [
-      STEP_RUN_REASON.reviewReviewing,
-      REVIEW_REVIEWING_MESSAGE,
-      now,
-      current.stepRunId,
-    ],
+      [reasonCode, reasonMessage, now, current.stepRunId],
+    )
+    yield* db.notifyWorkItemsChanged(current.repositoryId)
+  }).pipe(
+    Effect.catch((error) =>
+      Effect.logWarning(`Failed to mark Review Step Run as ${logLabel}`, {
+        error,
+      }),
+    ),
+    Effect.asVoid,
   )
-  yield* db.notifyWorkItemsChanged(current.repositoryId)
-}).pipe(
-  Effect.catch((error) =>
-    Effect.logWarning("Failed to mark Review Step Run as reviewing", {
-      error,
-    }),
-  ),
-  Effect.asVoid,
+
+const markReviewingPhase = markReviewPhase(
+  STEP_RUN_REASON.reviewReviewing,
+  REVIEW_REVIEWING_MESSAGE,
+  "reviewing",
+)
+
+const markApplyingFindingsPhase = markReviewPhase(
+  STEP_RUN_REASON.reviewApplyingFindings,
+  REVIEW_APPLYING_FINDINGS_MESSAGE,
+  "applying findings",
 )
 
 /**
- * Production Review Lifecycle Step — reviewing pass.
- * Continues the Implement OpenCode Session with `/review` plus a harness
- * READY_FOR_AGENT_RESULT contract, using the Work Item review model/variant.
- * Returns a structured reviewing outcome; does not apply findings.
+ * Production Review Lifecycle Step — reviewing pass, then apply-findings when needed.
+ * Continues the Implement OpenCode Session. Reviewing uses the review model/variant;
+ * applying findings uses the build model/variant. Does not yet re-run Pre-Commit or
+ * re-review after FIXED (see #392).
  */
 export const review = (context: LifecycleStepContext) =>
   Effect.gen(function* () {
     const worktreePath = yield* resolveWorktreePath(context)
     const sessionId = yield* resolveSessionId(context)
+    const timeout =
+      context.maxDuration ?? DEFAULT_LIFECYCLE_MAX_DURATIONS.review
+    const opencode = yield* Opencode
 
     yield* markReviewingPhase
 
-    const opencode = yield* Opencode
-    const result = yield* opencode
+    const reviewing = yield* opencode
       .continue({
         sessionId,
         prompt: buildReviewingPrompt(),
         cwd: worktreePath,
         model: context.reviewModel,
         variant: context.reviewVariant,
-        timeout: context.maxDuration ?? DEFAULT_LIFECYCLE_MAX_DURATIONS.review,
+        timeout,
       })
       .pipe(
         Effect.mapError(
@@ -175,13 +261,50 @@ export const review = (context: LifecycleStepContext) =>
         ),
       )
 
-    const parsed = parseReviewResult(result.assistantText)
-    if (parsed === null) {
+    const reviewingParsed = parseReviewResult(reviewing.assistantText)
+    if (reviewingParsed === null) {
       return yield* new ReviewResultError({
         workItemId: context.workItemId,
         message:
           "OpenCode did not report a unique final READY_FOR_AGENT_RESULT: REVIEW_CLEAN or REVIEW_HAS_FINDINGS",
       })
     }
-    return parsed
+
+    if (reviewingParsed._tag === "clean") {
+      return { _tag: "clean" as const }
+    }
+
+    yield* markApplyingFindingsPhase
+
+    const applying = yield* opencode
+      .continue({
+        sessionId,
+        prompt: buildApplyFindingsPrompt(),
+        cwd: worktreePath,
+        model: context.model,
+        variant: context.variant,
+        timeout,
+      })
+      .pipe(
+        Effect.mapError(
+          (cause) =>
+            new ReviewOpenCodeError({
+              message: "OpenCode failed while applying Review Findings",
+              worktreePath,
+              sessionId,
+              cause,
+            }),
+        ),
+      )
+
+    const applyParsed = parseApplyReviewResult(applying.assistantText)
+    if (applyParsed === null) {
+      return yield* new ReviewResultError({
+        workItemId: context.workItemId,
+        message:
+          "OpenCode did not report a unique final READY_FOR_AGENT_RESULT: REVIEW_FIXED, REVIEW_DEFERRED: <reason>, or REVIEW_CLEAN",
+      })
+    }
+
+    return applyParsed
   })

--- a/packages/work-item-lifecycle/src/lib/types.ts
+++ b/packages/work-item-lifecycle/src/lib/types.ts
@@ -125,6 +125,9 @@ export const WAITING_FOR_OPENCODE_SESSION_MESSAGE =
 /** Operator-visible Review phase while the reviewing OpenCode pass runs. */
 export const REVIEW_REVIEWING_MESSAGE = "reviewing"
 
+/** Operator-visible Review phase while apply-findings OpenCode pass runs. */
+export const REVIEW_APPLYING_FINDINGS_MESSAGE = "applying findings"
+
 export const WORK_ITEM_LIFECYCLE_QUEUE = "jobs"
 
 export const WorkItemStepJob = Schema.TaggedStruct("work-item-step", {
@@ -254,6 +257,10 @@ export const STEP_RUN_REASON = {
   waitingForOpencodeSession: "waiting_for_opencode_session",
   /** Mid-run: Review is running the reviewing (/review) OpenCode pass. */
   reviewReviewing: "review_reviewing",
+  /** Mid-run: Review is applying findings with the build model. */
+  reviewApplyingFindings: "review_applying_findings",
+  /** Successful Review that deferred findings and advanced to Commit. */
+  reviewDeferred: "review_deferred",
   /** Successful Merge PR run that returned to Watch for fresh validation. */
   mergeRevalidation: "merge_revalidation",
 } as const

--- a/packages/work-item-lifecycle/src/lib/work-item-lifecycle.ts
+++ b/packages/work-item-lifecycle/src/lib/work-item-lifecycle.ts
@@ -61,7 +61,7 @@ import {
   PreCommitHookFailedError,
   PreCommitStageError,
 } from "./pre-commit-errors.js"
-import { ReviewHasFindingsPendingError } from "./review-errors.js"
+import { ReviewFixedPendingError } from "./review-errors.js"
 import {
   DEFAULT_LIFECYCLE_MAX_DURATIONS,
   type LifecycleMaxDurations,
@@ -1242,12 +1242,18 @@ export const makeWorkItemLifecycleLive = (
                 if (result._tag === "clean") {
                   return Effect.succeed({})
                 }
-                // Hook for #391 apply-findings; do not treat as clean or advance.
+                if (result._tag === "deferred") {
+                  return Effect.succeed({
+                    stepRunReasonCode: STEP_RUN_REASON.reviewDeferred,
+                    stepRunNote: result.reason,
+                  })
+                }
+                // Hook for #392 fix round; do not treat FIXED as success-without-loop.
                 return Effect.fail(
-                  new ReviewHasFindingsPendingError({
+                  new ReviewFixedPendingError({
                     workItemId: context.workItemId,
                     message:
-                      "Review reported findings; apply-findings path is not implemented yet",
+                      "Review applied fixes; pre-commit re-review loop is not implemented yet",
                   }),
                 )
               }),

--- a/packages/work-item-lifecycle/test/review.spec.ts
+++ b/packages/work-item-lifecycle/test/review.spec.ts
@@ -3,6 +3,7 @@ import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { BunServices } from "@effect/platform-bun"
 import { Duration, Effect, Layer } from "effect"
+import { SqlClient } from "effect/unstable/sql"
 import { DatabaseTest } from "@ready-for-agent/db/test"
 import { DbServiceLive } from "@ready-for-agent/db-service"
 import {
@@ -13,12 +14,16 @@ import {
 } from "@ready-for-agent/opencode"
 import type { LifecycleStepContext } from "../src/index.js"
 import {
+  CurrentStepRun,
+  REVIEW_APPLYING_FINDINGS_MESSAGE,
   ReviewInvalidWorktreeContextError,
   ReviewOpenCodeError,
   ReviewResultError,
   ReviewSessionContextMissingError,
   ReviewWorktreeContextMissingError,
+  STEP_RUN_REASON,
   makeWorkItemId,
+  parseApplyReviewResult,
   parseReviewResult,
   review,
 } from "../src/index.js"
@@ -140,6 +145,47 @@ describe("parseReviewResult", () => {
   })
 })
 
+describe("parseApplyReviewResult", () => {
+  it("parses fixed, deferred, and apply-clean lines", () => {
+    expect(
+      parseApplyReviewResult("READY_FOR_AGENT_RESULT: REVIEW_FIXED"),
+    ).toEqual({ _tag: "fixed" })
+    expect(
+      parseApplyReviewResult(
+        "Left style notes.\nREADY_FOR_AGENT_RESULT: REVIEW_DEFERRED: stylistic only",
+      ),
+    ).toEqual({ _tag: "deferred", reason: "stylistic only" })
+    expect(
+      parseApplyReviewResult(
+        "Nothing actionable.\nREADY_FOR_AGENT_RESULT: REVIEW_CLEAN",
+      ),
+    ).toEqual({ _tag: "clean" })
+  })
+
+  it("rejects missing, duplicate, blank deferred, or reviewing-only markers", () => {
+    expect(parseApplyReviewResult("no result line")).toBeNull()
+    expect(
+      parseApplyReviewResult(
+        [
+          "READY_FOR_AGENT_RESULT: REVIEW_FIXED",
+          "READY_FOR_AGENT_RESULT: REVIEW_CLEAN",
+        ].join("\n"),
+      ),
+    ).toBeNull()
+    expect(
+      parseApplyReviewResult(
+        "READY_FOR_AGENT_RESULT: REVIEW_FIXED\ntrailing prose",
+      ),
+    ).toBeNull()
+    expect(
+      parseApplyReviewResult("READY_FOR_AGENT_RESULT: REVIEW_DEFERRED:"),
+    ).toBeNull()
+    expect(
+      parseApplyReviewResult("READY_FOR_AGENT_RESULT: REVIEW_HAS_FINDINGS"),
+    ).toBeNull()
+  })
+})
+
 describe("review", () => {
   it("rejects missing worktree context", async () => {
     const error = await run(review(baseContext(null)).pipe(Effect.flip))
@@ -241,23 +287,209 @@ describe("review", () => {
       expect(result).toEqual({ _tag: "clean" })
     }))
 
-  it("returns has_findings for a unique final REVIEW_HAS_FINDINGS marker", () =>
+  it("applies findings with build model when reviewing reports HAS_FINDINGS", () =>
     withTemp(async (root) => {
+      const continues: Array<{
+        model: string
+        variant: string
+        prompt: string
+      }> = []
+
+      const result = await run(
+        review(
+          baseContext(root, {
+            model: "opencode/build-model",
+            variant: "high",
+            reviewModel: "opencode/review-model",
+            reviewVariant: "max",
+          }),
+        ),
+        stubOpencode({
+          continue: (input) => {
+            continues.push({
+              model: input.model,
+              variant: input.variant,
+              prompt: input.prompt,
+            })
+            if (continues.length === 1) {
+              return Effect.succeed({
+                sessionId: "ses_implement_session",
+                assistantText:
+                  "Found a bug.\nREADY_FOR_AGENT_RESULT: REVIEW_HAS_FINDINGS",
+              })
+            }
+            return Effect.succeed({
+              sessionId: "ses_implement_session",
+              assistantText:
+                "Deferred style notes.\nREADY_FOR_AGENT_RESULT: REVIEW_DEFERRED: naming nit only",
+            })
+          },
+        }),
+      )
+
+      expect(continues).toHaveLength(2)
+      expect(continues[0]!.model).toBe("opencode/review-model")
+      expect(continues[0]!.variant).toBe("max")
+      expect(continues[0]!.prompt).toContain("/review")
+      expect(continues[1]!.model).toBe("opencode/build-model")
+      expect(continues[1]!.variant).toBe("high")
+      expect(continues[1]!.prompt).toContain("REVIEW_FIXED")
+      expect(continues[1]!.prompt).toContain("REVIEW_DEFERRED:")
+      expect(result).toEqual({
+        _tag: "deferred",
+        reason: "naming nit only",
+      })
+    }))
+
+  it("returns deferred from the apply path", () =>
+    withTemp(async (root) => {
+      let turn = 0
       const result = await run(
         review(baseContext(root)),
         stubOpencode({
-          continue: () =>
-            Effect.succeed({
+          continue: () => {
+            turn += 1
+            return Effect.succeed({
               sessionId: "ses_implement_session",
               assistantText:
-                "Found a bug.\nREADY_FOR_AGENT_RESULT: REVIEW_HAS_FINDINGS",
-            }),
+                turn === 1
+                  ? "READY_FOR_AGENT_RESULT: REVIEW_HAS_FINDINGS"
+                  : "READY_FOR_AGENT_RESULT: REVIEW_DEFERRED: out of scope",
+            })
+          },
         }),
       )
-      expect(result).toEqual({ _tag: "has_findings" })
+      expect(result).toEqual({ _tag: "deferred", reason: "out of scope" })
     }))
 
-  it("fails when READY_FOR_AGENT_RESULT is missing", () =>
+  it("returns apply-clean from the apply path", () =>
+    withTemp(async (root) => {
+      let turn = 0
+      const result = await run(
+        review(baseContext(root)),
+        stubOpencode({
+          continue: () => {
+            turn += 1
+            return Effect.succeed({
+              sessionId: "ses_implement_session",
+              assistantText:
+                turn === 1
+                  ? "READY_FOR_AGENT_RESULT: REVIEW_HAS_FINDINGS"
+                  : "READY_FOR_AGENT_RESULT: REVIEW_CLEAN",
+            })
+          },
+        }),
+      )
+      expect(result).toEqual({ _tag: "clean" })
+    }))
+
+  it("returns fixed from the apply path without treating it as clean", () =>
+    withTemp(async (root) => {
+      let turn = 0
+      const result = await run(
+        review(baseContext(root)),
+        stubOpencode({
+          continue: () => {
+            turn += 1
+            return Effect.succeed({
+              sessionId: "ses_implement_session",
+              assistantText:
+                turn === 1
+                  ? "READY_FOR_AGENT_RESULT: REVIEW_HAS_FINDINGS"
+                  : "Fixed the bug.\nREADY_FOR_AGENT_RESULT: REVIEW_FIXED",
+            })
+          },
+        }),
+      )
+      expect(result).toEqual({ _tag: "fixed" })
+      expect(result).not.toEqual({ _tag: "clean" })
+    }))
+
+  it("marks Step Run phase as applying findings during the apply turn", () =>
+    withTemp(async (root) => {
+      const stepRunId = "srun-01JREVIEWAPPLY000000000001"
+      const workItemId = "wi-01JREVIEWAPPLY0000000000001"
+      const repositoryId = "repo-review-apply-phase"
+      let phaseDuringApply: {
+        reason_code: string | null
+        reason_message: string | null
+      } | null = null
+
+      await Effect.runPromise(
+        Effect.gen(function* () {
+          const sql = yield* SqlClient.SqlClient
+          const now = Date.now()
+          yield* sql.unsafe(
+            `INSERT INTO repository (
+               id, github_owner, github_repo, local_path, is_bare, paused,
+               issues_reconciled_at, created_at, updated_at
+             ) VALUES (?, 'o', 'r', ?, 1, 0, NULL, ?, ?)`,
+            [repositoryId, `/tmp/${repositoryId}`, now, now],
+          )
+          yield* sql.unsafe(
+            `INSERT INTO work_item (
+               id, repository_id, github_issue_number, model, variant,
+               review_model, review_variant, state, state_ready_at, worktree_path,
+               session_id, failure_code, failure_message, created_at, updated_at
+             ) VALUES (?, ?, 1, 'm', 'v', 'm', 'v', 'review', ?,
+               ?, 'ses_implement_session', NULL, NULL, ?, ?)`,
+            [workItemId, repositoryId, now, root, now, now],
+          )
+          yield* sql.unsafe(
+            `INSERT INTO step_run (
+               id, work_item_id, step, status, queue_job_id, queued_at,
+               started_at, finished_at, reason_code, reason_message,
+               created_at, updated_at
+             ) VALUES (?, ?, 'review', 'running', NULL, ?, ?, NULL, NULL, NULL, ?, ?)`,
+            [stepRunId, workItemId, now, now, now, now],
+          )
+
+          let turn = 0
+          yield* review(baseContext(root, { repositoryId })).pipe(
+            Effect.provideService(CurrentStepRun, {
+              stepRunId,
+              repositoryId,
+            }),
+            Effect.provide(
+              stubOpencode({
+                continue: () =>
+                  Effect.gen(function* () {
+                    turn += 1
+                    if (turn === 2) {
+                      const rows = (yield* sql.unsafe(
+                        `SELECT reason_code, reason_message FROM step_run WHERE id = ?`,
+                        [stepRunId],
+                      )) as readonly {
+                        readonly reason_code: string | null
+                        readonly reason_message: string | null
+                      }[]
+                      phaseDuringApply = rows[0] ?? null
+                    }
+                    return {
+                      sessionId: "ses_implement_session",
+                      assistantText:
+                        turn === 1
+                          ? "READY_FOR_AGENT_RESULT: REVIEW_HAS_FINDINGS"
+                          : "READY_FOR_AGENT_RESULT: REVIEW_DEFERRED: later",
+                    }
+                  }),
+              }),
+            ),
+          )
+        }).pipe(
+          Effect.provide(DbServiceLive),
+          Effect.provide(DatabaseTest),
+          Effect.provide(PlatformLayer),
+        ),
+      )
+
+      expect(phaseDuringApply).toEqual({
+        reason_code: STEP_RUN_REASON.reviewApplyingFindings,
+        reason_message: REVIEW_APPLYING_FINDINGS_MESSAGE,
+      })
+    }))
+
+  it("fails when READY_FOR_AGENT_RESULT is missing on the reviewing pass", () =>
     withTemp(async (root) => {
       const error = await run(
         review(baseContext(root)).pipe(Effect.flip),
@@ -270,6 +502,28 @@ describe("review", () => {
         }),
       )
       expect(error).toBeInstanceOf(ReviewResultError)
+    }))
+
+  it("fails when apply-path READY_FOR_AGENT_RESULT is missing or ambiguous", () =>
+    withTemp(async (root) => {
+      let turn = 0
+      const error = await run(
+        review(baseContext(root)).pipe(Effect.flip),
+        stubOpencode({
+          continue: () => {
+            turn += 1
+            return Effect.succeed({
+              sessionId: "ses_implement_session",
+              assistantText:
+                turn === 1
+                  ? "READY_FOR_AGENT_RESULT: REVIEW_HAS_FINDINGS"
+                  : "I fixed things but forgot the marker",
+            })
+          },
+        }),
+      )
+      expect(error).toBeInstanceOf(ReviewResultError)
+      expect((error as ReviewResultError).message).toContain("REVIEW_FIXED")
     }))
 
   it("fails when READY_FOR_AGENT_RESULT lines are duplicated", () =>

--- a/packages/work-item-lifecycle/test/work-item-lifecycle.spec.ts
+++ b/packages/work-item-lifecycle/test/work-item-lifecycle.spec.ts
@@ -2971,14 +2971,51 @@ describe("WorkItemLifecycle", () => {
       )
     })
 
-    it("does not advance to Commit when Review reports has_findings", () => {
-      const stepsHasFindings: LifecycleStepsShape = {
+    it("advances to Commit when Review reports deferred findings", () => {
+      const stepsDeferredReview: LifecycleStepsShape = {
         ...successfulSteps,
-        review: () => Effect.succeed({ _tag: "has_findings" as const }),
+        review: () =>
+          Effect.succeed({
+            _tag: "deferred" as const,
+            reason: "style nits only",
+          }),
       }
 
       return runWithSteps(
-        stepsHasFindings,
+        stepsDeferredReview,
+        Effect.gen(function* () {
+          const lifecycle = yield* WorkItemLifecycle
+          const { repository, issue } = yield* seedActionableIssue
+          yield* lifecycle.implementNow(repository.id, issue.githubIssueNumber)
+          yield* claimAndRunPending
+          yield* claimAndRunPending
+          yield* claimAndRunPending
+          yield* claimAndRunPending
+          yield* claimAndRunPending
+          const afterReview = yield* claimAndRunPending
+
+          expect(afterReview._tag).toBe("processed")
+          if (afterReview._tag === "processed") {
+            expect(afterReview.workItem.state).toBe("commit")
+            const reviewRun = afterReview.workItem.stepRuns.find(
+              (run) => run.step === "review",
+            )
+            expect(reviewRun?.status).toBe("succeeded")
+            expect(reviewRun?.reasonCode).toBe(STEP_RUN_REASON.reviewDeferred)
+            expect(reviewRun?.reasonMessage).toBe("style nits only")
+          }
+        }),
+      )
+    })
+
+    it("does not advance to Commit when Review reports fixed", () => {
+      const stepsFixedReview: LifecycleStepsShape = {
+        ...successfulSteps,
+        review: () => Effect.succeed({ _tag: "fixed" as const }),
+      }
+
+      return runWithSteps(
+        stepsFixedReview,
         Effect.gen(function* () {
           const lifecycle = yield* WorkItemLifecycle
           const { repository, issue } = yield* seedActionableIssue
@@ -2998,7 +3035,7 @@ describe("WorkItemLifecycle", () => {
             )
             expect(reviewRun?.status).toBe("failed")
             expect(reviewRun?.reasonMessage).toContain(
-              "apply-findings path is not implemented yet",
+              "pre-commit re-review loop is not implemented yet",
             )
           }
         }),


### PR DESCRIPTION
## Summary

- When Review reports `REVIEW_HAS_FINDINGS`, continue the Implement Session with the build model/variant to apply, defer, or re-confirm clean.
- Deferred and apply-clean succeed Review and advance to Commit; deferred reasons are retained on the Step Run; FIXED is recognized without advancing as success-without-loop.
- Operator-visible phase is `Review: applying findings` during the apply turn.

Closes #391

## Test plan

- [x] `bunx nx run work-item-lifecycle:test`
- [x] `bunx nx run graphql-api:test`
- [x] Pre-commit affected lint/typecheck/test (via commit hooks)