### PR TITLE
feat(work-item-lifecycle): run Pre-Commit and re-review after FIXED

### DIFF
--- a/packages/graphql-api/src/lib/work-item-projection.ts
+++ b/packages/graphql-api/src/lib/work-item-projection.ts
@@ -2,6 +2,7 @@ import type { IssueRecord } from "@ready-for-agent/db-service"
 import {
   type OperationalLifecycleStep,
   REVIEW_APPLYING_FINDINGS_MESSAGE,
+  REVIEW_PRE_COMMIT_MESSAGE,
   REVIEW_REVIEWING_MESSAGE,
   STEP_RUN_REASON,
   type StepRunRecord,
@@ -140,12 +141,15 @@ export const lifecycleLabels = (workItem: WorkItemRecord) => {
         ? stepRun.reasonCode === STEP_RUN_REASON.reviewApplyingFindings ||
           stepRun.reasonMessage === REVIEW_APPLYING_FINDINGS_MESSAGE
           ? REVIEW_APPLYING_FINDINGS_MESSAGE
-          : stepRun.reasonCode === STEP_RUN_REASON.reviewReviewing ||
-              stepRun.reasonMessage == null ||
-              stepRun.reasonMessage === "" ||
-              stepRun.reasonMessage === REVIEW_REVIEWING_MESSAGE
-            ? REVIEW_REVIEWING_MESSAGE
-            : stepRun.reasonMessage
+          : stepRun.reasonCode === STEP_RUN_REASON.reviewPreCommit ||
+              stepRun.reasonMessage === REVIEW_PRE_COMMIT_MESSAGE
+            ? REVIEW_PRE_COMMIT_MESSAGE
+            : stepRun.reasonCode === STEP_RUN_REASON.reviewReviewing ||
+                stepRun.reasonMessage == null ||
+                stepRun.reasonMessage === "" ||
+                stepRun.reasonMessage === REVIEW_REVIEWING_MESSAGE
+              ? REVIEW_REVIEWING_MESSAGE
+              : stepRun.reasonMessage
         : null
     const outcome =
       reviewRunningPhase !== null

--- a/packages/graphql-api/test/graphql-api.test.ts
+++ b/packages/graphql-api/test/graphql-api.test.ts
@@ -1826,6 +1826,66 @@ describe("GraphQL API", () => {
     })
   })
 
+  test("projects running Review Step Run as Review: pre-commit", async () => {
+    const baseRun = workItem.stepRuns[0]!
+    const preCommitPhase = {
+      ...workItem,
+      state: "review",
+      stepRuns: [
+        {
+          ...baseRun,
+          step: "review",
+          status: "running",
+          reasonCode: STEP_RUN_REASON.reviewPreCommit,
+          reasonMessage: "pre-commit",
+        },
+      ],
+    } as WorkItemRecord
+    await runtime.dispose()
+    runtime = makeRuntime(
+      {},
+      {},
+      {},
+      {
+        listWorkItemsForIssue: () => Effect.succeed([preCommitPhase]),
+      },
+    )
+
+    const response = await createGraphqlApi(runtime).fetch(
+      graphqlRequest({
+        query: `query WorkItems($repositoryId: ID!, $githubIssueNumber: Int!) {
+          workItems(repositoryId: $repositoryId, githubIssueNumber: $githubIssueNumber) {
+            stateLabel status statusLabel
+            lifecycleLabels { phase label status }
+          }
+        }`,
+        variables: {
+          repositoryId: repository.id,
+          githubIssueNumber: issue.githubIssueNumber,
+        },
+      }),
+    )
+
+    expect(await response.json()).toEqual({
+      data: {
+        workItems: [
+          {
+            stateLabel: "Review",
+            status: "RUNNING",
+            statusLabel: "Running",
+            lifecycleLabels: [
+              {
+                phase: "REVIEW",
+                label: "Review: pre-commit",
+                status: "RUNNING",
+              },
+            ],
+          },
+        ],
+      },
+    })
+  })
+
   test("lists all Work Items for a repository", async () => {
     let receivedRepositoryId: string | undefined
     await runtime.dispose()

--- a/packages/work-item-lifecycle/src/lib/opencode-session-limiter.ts
+++ b/packages/work-item-lifecycle/src/lib/opencode-session-limiter.ts
@@ -44,6 +44,11 @@ export const CurrentStepRun = Context.Reference<CurrentStepRunValue>(
   { defaultValue: () => null },
 )
 
+type SavedStepRunReason = {
+  readonly reasonCode: string | null
+  readonly reasonMessage: string | null
+}
+
 /**
  * Cap concurrent lifecycle OpenCode `start`/`continue` processes using the
  * current harness Config value. `listModels` is not wrapped.
@@ -54,7 +59,8 @@ export const CurrentStepRun = Context.Reference<CurrentStepRunValue>(
  *
  * While waiting for a permit, marks the ambient Step Run with
  * `waiting_for_opencode_session` so GraphQL can show **Queued** instead of
- * **Running**.
+ * **Running**. When the slot is acquired, restores any prior mid-run phase
+ * (for example Review: pre-commit) instead of clearing the reason.
  */
 export const limitOpencodeSessions = (
   opencode: OpencodeService,
@@ -71,46 +77,91 @@ export const limitOpencodeSessions = (
       Effect.orElseSucceed(() => DEFAULT_MAX_CONCURRENT_OPENCODE_SESSIONS),
     )
 
-    const reportWaitState = (waiting: boolean): Effect.Effect<void> =>
+    const markWaiting = (): Effect.Effect<SavedStepRunReason | null> =>
+      Effect.gen(function* () {
+        const current = yield* CurrentStepRun
+        if (current === null) {
+          return null
+        }
+        const rows = (yield* sql.unsafe(
+          `SELECT reason_code, reason_message FROM step_run
+           WHERE id = ? AND status = 'running'`,
+          [current.stepRunId],
+        )) as readonly {
+          readonly reason_code: string | null
+          readonly reason_message: string | null
+        }[]
+        const row = rows[0]
+        if (row === undefined) {
+          return null
+        }
+        const saved: SavedStepRunReason = {
+          reasonCode:
+            row.reason_code === STEP_RUN_REASON.waitingForOpencodeSession
+              ? null
+              : row.reason_code,
+          reasonMessage:
+            row.reason_code === STEP_RUN_REASON.waitingForOpencodeSession
+              ? null
+              : row.reason_message,
+        }
+        const now = Date.now()
+        yield* sql.unsafe(
+          `UPDATE step_run
+           SET reason_code = ?,
+               reason_message = ?,
+               updated_at = ?
+           WHERE id = ?
+             AND status = 'running'`,
+          [
+            STEP_RUN_REASON.waitingForOpencodeSession,
+            WAITING_FOR_OPENCODE_SESSION_MESSAGE,
+            now,
+            current.stepRunId,
+          ],
+        )
+        yield* db.notifyWorkItemsChanged(current.repositoryId)
+        return saved
+      }).pipe(
+        Effect.catch((error) =>
+          Effect.logWarning(
+            "Failed to update OpenCode session wait state on Step Run",
+            { waiting: true, error },
+          ).pipe(Effect.as(null)),
+        ),
+      )
+
+    const clearWaiting = (
+      saved: SavedStepRunReason | null,
+    ): Effect.Effect<void> =>
       Effect.gen(function* () {
         const current = yield* CurrentStepRun
         if (current === null) {
           return
         }
         const now = Date.now()
-        if (waiting) {
-          yield* sql.unsafe(
-            `UPDATE step_run
-             SET reason_code = ?,
-                 reason_message = ?,
-                 updated_at = ?
-             WHERE id = ?
-               AND status = 'running'`,
-            [
-              STEP_RUN_REASON.waitingForOpencodeSession,
-              WAITING_FOR_OPENCODE_SESSION_MESSAGE,
-              now,
-              current.stepRunId,
-            ],
-          )
-        } else {
-          yield* sql.unsafe(
-            `UPDATE step_run
-             SET reason_code = NULL,
-                 reason_message = NULL,
-                 updated_at = ?
-             WHERE id = ?
-               AND status = 'running'
-               AND reason_code = ?`,
-            [now, current.stepRunId, STEP_RUN_REASON.waitingForOpencodeSession],
-          )
-        }
+        yield* sql.unsafe(
+          `UPDATE step_run
+           SET reason_code = ?,
+               reason_message = ?,
+               updated_at = ?
+           WHERE id = ?
+             AND status = 'running'
+             AND reason_code = ?`,
+          [
+            saved?.reasonCode ?? null,
+            saved?.reasonMessage ?? null,
+            now,
+            current.stepRunId,
+            STEP_RUN_REASON.waitingForOpencodeSession,
+          ],
+        )
         yield* db.notifyWorkItemsChanged(current.repositoryId)
       }).pipe(
         Effect.catch((error) =>
           Effect.logWarning(
             "Failed to update OpenCode session wait state on Step Run",
-            { waiting, error },
+            { waiting: false, error },
           ),
         ),
         Effect.asVoid,
@@ -121,14 +172,16 @@ export const limitOpencodeSessions = (
     ): Effect.Effect<A, E, R> =>
       Effect.gen(function* () {
         let markedWaiting = false
+        let savedReason: SavedStepRunReason | null = null
         for (;;) {
           const max = yield* currentMax
           yield* semaphore.resize(max)
           const result = yield* semaphore.withPermitsIfAvailable(1)(
             Effect.gen(function* () {
               if (markedWaiting) {
-                yield* reportWaitState(false)
+                yield* clearWaiting(savedReason)
                 markedWaiting = false
+                savedReason = null
               }
               return yield* effect
             }),
@@ -137,7 +190,7 @@ export const limitOpencodeSessions = (
             return result.value
           }
           if (!markedWaiting) {
-            yield* reportWaitState(true)
+            savedReason = yield* markWaiting()
             markedWaiting = true
           }
           yield* Effect.sleep(CONFIG_RECHECK_INTERVAL)

--- a/packages/work-item-lifecycle/src/lib/review-errors.ts
+++ b/packages/work-item-lifecycle/src/lib/review-errors.ts
@@ -43,22 +43,9 @@ export class ReviewResultError extends Schema.TaggedErrorClass<ReviewResultError
   },
 ) {}
 
-/**
- * Apply pass reported FIXED; Pre-Commit + re-review loop is not implemented yet (#392).
- * Parse succeeded — intentional stop-short hook, not a parse failure or clean advance.
- */
-export class ReviewFixedPendingError extends Schema.TaggedErrorClass<ReviewFixedPendingError>()(
-  "ReviewFixedPendingError",
-  {
-    workItemId: Schema.String,
-    message: Schema.String,
-  },
-) {}
-
 export type ReviewError =
   | ReviewWorktreeContextMissingError
   | ReviewInvalidWorktreeContextError
   | ReviewSessionContextMissingError
   | ReviewOpenCodeError
   | ReviewResultError
-  | ReviewFixedPendingError

--- a/packages/work-item-lifecycle/src/lib/review.ts
+++ b/packages/work-item-lifecycle/src/lib/review.ts
@@ -4,6 +4,7 @@ import { DbService } from "@ready-for-agent/db-service"
 import { Opencode } from "@ready-for-agent/opencode"
 import type { LifecycleStepContext } from "./lifecycle-steps.js"
 import { CurrentStepRun } from "./opencode-session-limiter.js"
+import { preCommit } from "./pre-commit.js"
 import {
   ReviewInvalidWorktreeContextError,
   ReviewOpenCodeError,
@@ -14,15 +15,15 @@ import {
 import {
   DEFAULT_LIFECYCLE_MAX_DURATIONS,
   REVIEW_APPLYING_FINDINGS_MESSAGE,
+  REVIEW_PRE_COMMIT_MESSAGE,
   REVIEW_REVIEWING_MESSAGE,
   STEP_RUN_REASON,
 } from "./types.js"
 
-/** Final Review step outcome after reviewing (and optional apply) completes. */
+/** Final Review step outcome after reviewing, optional apply, and fix rounds. */
 export type ReviewResult =
   | { readonly _tag: "clean" }
   | { readonly _tag: "deferred"; readonly reason: string }
-  | { readonly _tag: "fixed" }
 
 /** Machine-readable outcome of the reviewing (/review) pass only. */
 export type ReviewingPassResult =
@@ -224,11 +225,19 @@ const markApplyingFindingsPhase = markReviewPhase(
   "applying findings",
 )
 
+const markReviewPreCommitPhase = markReviewPhase(
+  STEP_RUN_REASON.reviewPreCommit,
+  REVIEW_PRE_COMMIT_MESSAGE,
+  "pre-commit",
+)
+
 /**
- * Production Review Lifecycle Step — reviewing pass, then apply-findings when needed.
- * Continues the Implement OpenCode Session. Reviewing uses the review model/variant;
- * applying findings uses the build model/variant. Does not yet re-run Pre-Commit or
- * re-review after FIXED (see #392).
+ * Production Review Lifecycle Step — reviewing pass, optional apply-findings,
+ * and on FIXED a nested Pre-Commit then re-review. Continues the Implement
+ * OpenCode Session. Reviewing uses the review model/variant; applying findings
+ * and nested Pre-Commit fix turns use the build model/variant. Nested Pre-Commit
+ * failures fail the Review Step Run (retryable), same spirit as standalone
+ * Pre-Commit.
  */
 export const review = (context: LifecycleStepContext) =>
   Effect.gen(function* () {
@@ -238,73 +247,84 @@ export const review = (context: LifecycleStepContext) =>
       context.maxDuration ?? DEFAULT_LIFECYCLE_MAX_DURATIONS.review
     const opencode = yield* Opencode
 
-    yield* markReviewingPhase
+    for (;;) {
+      yield* markReviewingPhase
 
-    const reviewing = yield* opencode
-      .continue({
-        sessionId,
-        prompt: buildReviewingPrompt(),
-        cwd: worktreePath,
-        model: context.reviewModel,
-        variant: context.reviewVariant,
-        timeout,
-      })
-      .pipe(
-        Effect.mapError(
-          (cause) =>
-            new ReviewOpenCodeError({
-              message: "OpenCode failed to review the Work Item",
-              worktreePath,
-              sessionId,
-              cause,
-            }),
-        ),
-      )
+      const reviewing = yield* opencode
+        .continue({
+          sessionId,
+          prompt: buildReviewingPrompt(),
+          cwd: worktreePath,
+          model: context.reviewModel,
+          variant: context.reviewVariant,
+          timeout,
+        })
+        .pipe(
+          Effect.mapError(
+            (cause) =>
+              new ReviewOpenCodeError({
+                message: "OpenCode failed to review the Work Item",
+                worktreePath,
+                sessionId,
+                cause,
+              }),
+          ),
+        )
 
-    const reviewingParsed = parseReviewResult(reviewing.assistantText)
-    if (reviewingParsed === null) {
-      return yield* new ReviewResultError({
-        workItemId: context.workItemId,
-        message:
-          "OpenCode did not report a unique final READY_FOR_AGENT_RESULT: REVIEW_CLEAN or REVIEW_HAS_FINDINGS",
-      })
+      const reviewingParsed = parseReviewResult(reviewing.assistantText)
+      if (reviewingParsed === null) {
+        return yield* new ReviewResultError({
+          workItemId: context.workItemId,
+          message:
+            "OpenCode did not report a unique final READY_FOR_AGENT_RESULT: REVIEW_CLEAN or REVIEW_HAS_FINDINGS",
+        })
+      }
+
+      if (reviewingParsed._tag === "clean") {
+        return { _tag: "clean" as const }
+      }
+
+      yield* markApplyingFindingsPhase
+
+      const applying = yield* opencode
+        .continue({
+          sessionId,
+          prompt: buildApplyFindingsPrompt(),
+          cwd: worktreePath,
+          model: context.model,
+          variant: context.variant,
+          timeout,
+        })
+        .pipe(
+          Effect.mapError(
+            (cause) =>
+              new ReviewOpenCodeError({
+                message: "OpenCode failed while applying Review Findings",
+                worktreePath,
+                sessionId,
+                cause,
+              }),
+          ),
+        )
+
+      const applyParsed = parseApplyReviewResult(applying.assistantText)
+      if (applyParsed === null) {
+        return yield* new ReviewResultError({
+          workItemId: context.workItemId,
+          message:
+            "OpenCode did not report a unique final READY_FOR_AGENT_RESULT: REVIEW_FIXED, REVIEW_DEFERRED: <reason>, or REVIEW_CLEAN",
+        })
+      }
+
+      if (applyParsed._tag === "clean") {
+        return { _tag: "clean" as const }
+      }
+
+      if (applyParsed._tag === "deferred") {
+        return applyParsed
+      }
+
+      yield* markReviewPreCommitPhase
+      yield* preCommit(context)
     }
-
-    if (reviewingParsed._tag === "clean") {
-      return { _tag: "clean" as const }
-    }
-
-    yield* markApplyingFindingsPhase
-
-    const applying = yield* opencode
-      .continue({
-        sessionId,
-        prompt: buildApplyFindingsPrompt(),
-        cwd: worktreePath,
-        model: context.model,
-        variant: context.variant,
-        timeout,
-      })
-      .pipe(
-        Effect.mapError(
-          (cause) =>
-            new ReviewOpenCodeError({
-              message: "OpenCode failed while applying Review Findings",
-              worktreePath,
-              sessionId,
-              cause,
-            }),
-        ),
-      )
-
-    const applyParsed = parseApplyReviewResult(applying.assistantText)
-    if (applyParsed === null) {
-      return yield* new ReviewResultError({
-        workItemId: context.workItemId,
-        message:
-          "OpenCode did not report a unique final READY_FOR_AGENT_RESULT: REVIEW_FIXED, REVIEW_DEFERRED: <reason>, or REVIEW_CLEAN",
-      })
-    }
-
-    return applyParsed
   })

--- a/packages/work-item-lifecycle/src/lib/types.ts
+++ b/packages/work-item-lifecycle/src/lib/types.ts
@@ -128,6 +128,9 @@ export const REVIEW_REVIEWING_MESSAGE = "reviewing"
 /** Operator-visible Review phase while apply-findings OpenCode pass runs. */
 export const REVIEW_APPLYING_FINDINGS_MESSAGE = "applying findings"
 
+/** Operator-visible Review phase while nested Pre-Commit runs after FIXED. */
+export const REVIEW_PRE_COMMIT_MESSAGE = "pre-commit"
+
 export const WORK_ITEM_LIFECYCLE_QUEUE = "jobs"
 
 export const WorkItemStepJob = Schema.TaggedStruct("work-item-step", {
@@ -259,6 +262,8 @@ export const STEP_RUN_REASON = {
   reviewReviewing: "review_reviewing",
   /** Mid-run: Review is applying findings with the build model. */
   reviewApplyingFindings: "review_applying_findings",
+  /** Mid-run: Review is re-running Pre-Commit after FIXED before re-review. */
+  reviewPreCommit: "review_pre_commit",
   /** Successful Review that deferred findings and advanced to Commit. */
   reviewDeferred: "review_deferred",
   /** Successful Merge PR run that returned to Watch for fresh validation. */

--- a/packages/work-item-lifecycle/src/lib/work-item-lifecycle.ts
+++ b/packages/work-item-lifecycle/src/lib/work-item-lifecycle.ts
@@ -61,7 +61,6 @@ import {
   PreCommitHookFailedError,
   PreCommitStageError,
 } from "./pre-commit-errors.js"
-import { ReviewFixedPendingError } from "./review-errors.js"
 import {
   DEFAULT_LIFECYCLE_MAX_DURATIONS,
   type LifecycleMaxDurations,
@@ -1238,24 +1237,14 @@ export const makeWorkItemLifecycleLive = (
             return steps.preCommit(context).pipe(Effect.as({}))
           case "review":
             return steps.review(context).pipe(
-              Effect.flatMap((result) => {
-                if (result._tag === "clean") {
-                  return Effect.succeed({})
-                }
+              Effect.map((result) => {
                 if (result._tag === "deferred") {
-                  return Effect.succeed({
+                  return {
                     stepRunReasonCode: STEP_RUN_REASON.reviewDeferred,
                     stepRunNote: result.reason,
-                  })
+                  }
                 }
-                // Hook for #392 fix round; do not treat FIXED as success-without-loop.
-                return Effect.fail(
-                  new ReviewFixedPendingError({
-                    workItemId: context.workItemId,
-                    message:
-                      "Review applied fixes; pre-commit re-review loop is not implemented yet",
-                  }),
-                )
+                return {}
               }),
             )
           case "commit":

--- a/packages/work-item-lifecycle/test/opencode-session-limiter.spec.ts
+++ b/packages/work-item-lifecycle/test/opencode-session-limiter.spec.ts
@@ -8,6 +8,7 @@ import {
   limitOpencodeSessions,
 } from "../src/lib/opencode-session-limiter.js"
 import {
+  REVIEW_PRE_COMMIT_MESSAGE,
   STEP_RUN_REASON,
   WAITING_FOR_OPENCODE_SESSION_MESSAGE,
 } from "../src/lib/types.js"
@@ -334,6 +335,109 @@ describe("limitOpencodeSessions", () => {
           status: "running",
           reason_code: null,
           reason_message: null,
+        })
+        expect(starts).toBe(2)
+      }),
+    ))
+
+  it("restores a prior Review phase after waiting for a session slot", () =>
+    runTest(
+      Effect.gen(function* () {
+        const db = yield* DbService
+        const sql = yield* SqlClient.SqlClient
+        yield* db.updateConfig({
+          defaultModel: "opencode/deepseek-v4-flash-free",
+          defaultVariant: "low",
+          reviewModel: null,
+          reviewVariant: null,
+          maxConcurrentOpencodeSessions: 1,
+          maxConcurrentWorkItems: 5,
+        })
+
+        const repositoryId = "repo-limiter-restore-phase"
+        const workItemId = "wi-01JLIMITERREST000000000001"
+        const stepRunId = "srun-01JLIMITERREST00000000001"
+        yield* seedRunningStepRun({
+          stepRunId,
+          workItemId,
+          repositoryId,
+        })
+        yield* sql.unsafe(
+          `UPDATE step_run
+           SET reason_code = ?, reason_message = ?, updated_at = ?
+           WHERE id = ?`,
+          [
+            STEP_RUN_REASON.reviewPreCommit,
+            REVIEW_PRE_COMMIT_MESSAGE,
+            Date.now(),
+            stepRunId,
+          ],
+        )
+
+        const releaseFirst = yield* Deferred.make<void>()
+        const firstStarted = yield* Deferred.make<void>()
+        const secondStarted = yield* Deferred.make<void>()
+        let starts = 0
+
+        const inner = Opencode.of({
+          start: () =>
+            Effect.gen(function* () {
+              starts += 1
+              if (starts === 1) {
+                yield* Deferred.succeed(firstStarted, undefined)
+                yield* Deferred.await(releaseFirst)
+              } else {
+                yield* Deferred.succeed(secondStarted, undefined)
+              }
+              return { sessionId: `ses_${starts}`, assistantText: "" }
+            }),
+          continue: () =>
+            Effect.succeed({ sessionId: "ses_x", assistantText: "" }),
+          listModels: () => Effect.succeed([]),
+        })
+        const limited = yield* limitOpencodeSessions(inner, db, sql)
+
+        const first = yield* limited.start(startInput).pipe(Effect.forkChild)
+        yield* Deferred.await(firstStarted)
+
+        const second = yield* limited.start(startInput).pipe(
+          Effect.provideService(CurrentStepRun, {
+            stepRunId,
+            repositoryId,
+          }),
+          Effect.forkChild,
+        )
+
+        yield* Effect.sleep("50 millis")
+        expect(starts).toBe(1)
+
+        const waitingRows = (yield* sql.unsafe(
+          `SELECT reason_code, reason_message FROM step_run WHERE id = ?`,
+          [stepRunId],
+        )) as readonly {
+          readonly reason_code: string | null
+          readonly reason_message: string | null
+        }[]
+        expect(waitingRows[0]).toEqual({
+          reason_code: STEP_RUN_REASON.waitingForOpencodeSession,
+          reason_message: WAITING_FOR_OPENCODE_SESSION_MESSAGE,
+        })
+
+        yield* Deferred.succeed(releaseFirst, undefined)
+        yield* Deferred.await(secondStarted)
+        yield* Fiber.join(first)
+        yield* Fiber.join(second)
+
+        const afterRows = (yield* sql.unsafe(
+          `SELECT reason_code, reason_message FROM step_run WHERE id = ?`,
+          [stepRunId],
+        )) as readonly {
+          readonly reason_code: string | null
+          readonly reason_message: string | null
+        }[]
+        expect(afterRows[0]).toEqual({
+          reason_code: STEP_RUN_REASON.reviewPreCommit,
+          reason_message: REVIEW_PRE_COMMIT_MESSAGE,
         })
         expect(starts).toBe(2)
       }),

--- a/packages/work-item-lifecycle/test/review.spec.ts
+++ b/packages/work-item-lifecycle/test/review.spec.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, rm } from "node:fs/promises"
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { BunServices } from "@effect/platform-bun"
@@ -15,7 +15,9 @@ import {
 import type { LifecycleStepContext } from "../src/index.js"
 import {
   CurrentStepRun,
+  PreCommitOpenCodeError,
   REVIEW_APPLYING_FINDINGS_MESSAGE,
+  REVIEW_PRE_COMMIT_MESSAGE,
   ReviewInvalidWorktreeContextError,
   ReviewOpenCodeError,
   ReviewResultError,
@@ -112,6 +114,42 @@ const withTemp = async (assert: (root: string) => Promise<void>) => {
   } finally {
     await rm(root, { recursive: true, force: true })
   }
+}
+
+const initGitRepo = async (root: string) => {
+  const runGit = async (...args: string[]) => {
+    const proc = Bun.spawn(["git", "-c", "commit.gpgsign=false", ...args], {
+      cwd: root,
+      stdout: "ignore",
+      stderr: "pipe",
+    })
+    const exitCode = await proc.exited
+    if (exitCode !== 0) {
+      const stderr = await new Response(proc.stderr).text()
+      throw new Error(`git ${args.join(" ")} failed: ${stderr}`)
+    }
+  }
+  await runGit("init")
+  await runGit("config", "user.email", "test@example.com")
+  await runGit("config", "user.name", "Test")
+  await runGit("commit", "--no-verify", "--allow-empty", "-m", "init")
+}
+
+const withTempGit = async (assert: (root: string) => Promise<void>) => {
+  const root = await mkdtemp(join(tmpdir(), "rfa-review-git-"))
+  try {
+    await initGitRepo(root)
+    await assert(root)
+  } finally {
+    await rm(root, { recursive: true, force: true })
+  }
+}
+
+const writeHook = async (root: string, body: string) => {
+  await mkdir(join(root, ".git", "hooks"), { recursive: true })
+  await writeFile(join(root, ".git", "hooks", "pre-commit"), body, {
+    mode: 0o755,
+  })
 }
 
 describe("parseReviewResult", () => {
@@ -383,26 +421,215 @@ describe("review", () => {
       expect(result).toEqual({ _tag: "clean" })
     }))
 
-  it("returns fixed from the apply path without treating it as clean", () =>
-    withTemp(async (root) => {
-      let turn = 0
+  it("runs Pre-Commit then re-reviews after FIXED and succeeds on clean", () =>
+    withTempGit(async (root) => {
+      await writeHook(root, "#!/usr/bin/env bash\nexit 0\n")
+      await writeFile(join(root, "change.txt"), "fixed\n")
+
+      const continues: Array<{
+        model: string
+        variant: string
+        prompt: string
+      }> = []
+
       const result = await run(
-        review(baseContext(root)),
+        review(
+          baseContext(root, {
+            model: "opencode/build-model",
+            variant: "high",
+            reviewModel: "opencode/review-model",
+            reviewVariant: "max",
+          }),
+        ),
         stubOpencode({
-          continue: () => {
-            turn += 1
+          continue: (input) => {
+            continues.push({
+              model: input.model,
+              variant: input.variant,
+              prompt: input.prompt,
+            })
+            if (continues.length === 1) {
+              return Effect.succeed({
+                sessionId: "ses_implement_session",
+                assistantText:
+                  "Found a bug.\nREADY_FOR_AGENT_RESULT: REVIEW_HAS_FINDINGS",
+              })
+            }
+            if (continues.length === 2) {
+              return Effect.succeed({
+                sessionId: "ses_implement_session",
+                assistantText:
+                  "Fixed the bug.\nREADY_FOR_AGENT_RESULT: REVIEW_FIXED",
+              })
+            }
             return Effect.succeed({
               sessionId: "ses_implement_session",
               assistantText:
-                turn === 1
-                  ? "READY_FOR_AGENT_RESULT: REVIEW_HAS_FINDINGS"
-                  : "Fixed the bug.\nREADY_FOR_AGENT_RESULT: REVIEW_FIXED",
+                "Looks good now.\nREADY_FOR_AGENT_RESULT: REVIEW_CLEAN",
             })
           },
         }),
       )
-      expect(result).toEqual({ _tag: "fixed" })
-      expect(result).not.toEqual({ _tag: "clean" })
+
+      expect(result).toEqual({ _tag: "clean" })
+      expect(continues).toHaveLength(3)
+      expect(continues[0]!.model).toBe("opencode/review-model")
+      expect(continues[0]!.variant).toBe("max")
+      expect(continues[0]!.prompt).toContain("/review")
+      expect(continues[1]!.model).toBe("opencode/build-model")
+      expect(continues[1]!.variant).toBe("high")
+      expect(continues[1]!.prompt).toContain("REVIEW_FIXED")
+      expect(continues[2]!.model).toBe("opencode/review-model")
+      expect(continues[2]!.variant).toBe("max")
+      expect(continues[2]!.prompt).toContain("/review")
+    }))
+
+  it("fails the Review Step Run when nested Pre-Commit fails after FIXED", () =>
+    withTempGit(async (root) => {
+      await writeHook(
+        root,
+        [
+          "#!/usr/bin/env bash",
+          "set -euo pipefail",
+          "printf '%s\\n' 'format failed permanently' >&2",
+          "exit 1",
+          "",
+        ].join("\n"),
+      )
+      await writeFile(join(root, "change.txt"), "broken\n")
+
+      let turn = 0
+      const error = await run(
+        review(baseContext(root)).pipe(Effect.flip),
+        stubOpencode({
+          continue: () => {
+            turn += 1
+            if (turn <= 2) {
+              return Effect.succeed({
+                sessionId: "ses_implement_session",
+                assistantText:
+                  turn === 1
+                    ? "READY_FOR_AGENT_RESULT: REVIEW_HAS_FINDINGS"
+                    : "READY_FOR_AGENT_RESULT: REVIEW_FIXED",
+              })
+            }
+            return Effect.fail(
+              new OpencodeExitError({ exitCode: 2, cwd: root }),
+            )
+          },
+        }),
+      )
+
+      expect(error).toBeInstanceOf(PreCommitOpenCodeError)
+      expect(turn).toBeGreaterThanOrEqual(3)
+    }))
+
+  it("marks Step Run phase as pre-commit during nested Pre-Commit after FIXED", () =>
+    withTempGit(async (root) => {
+      await writeHook(
+        root,
+        [
+          "#!/usr/bin/env bash",
+          "set -euo pipefail",
+          'if [ -f ".pre-commit-fixed" ]; then',
+          "  exit 0",
+          "fi",
+          "printf '%s\\n' 'needs fix' >&2",
+          "exit 1",
+          "",
+        ].join("\n"),
+      )
+      await writeFile(join(root, "change.txt"), "fixed\n")
+
+      const stepRunId = "srun-01JREVIEWPRECOM000000000001"
+      const workItemId = "wi-01JREVIEWPRECOM0000000000001"
+      const repositoryId = "repo-review-pre-commit-phase"
+      let phaseDuringPreCommit: {
+        reason_code: string | null
+        reason_message: string | null
+      } | null = null
+
+      await Effect.runPromise(
+        Effect.gen(function* () {
+          const sql = yield* SqlClient.SqlClient
+          const now = Date.now()
+          yield* sql.unsafe(
+            `INSERT INTO repository (
+               id, github_owner, github_repo, local_path, is_bare, paused,
+               issues_reconciled_at, created_at, updated_at
+             ) VALUES (?, 'o', 'r', ?, 1, 0, NULL, ?, ?)`,
+            [repositoryId, `/tmp/${repositoryId}`, now, now],
+          )
+          yield* sql.unsafe(
+            `INSERT INTO work_item (
+               id, repository_id, github_issue_number, model, variant,
+               review_model, review_variant, state, state_ready_at, worktree_path,
+               session_id, failure_code, failure_message, created_at, updated_at
+             ) VALUES (?, ?, 1, 'm', 'v', 'm', 'v', 'review', ?,
+               ?, 'ses_implement_session', NULL, NULL, ?, ?)`,
+            [workItemId, repositoryId, now, root, now, now],
+          )
+          yield* sql.unsafe(
+            `INSERT INTO step_run (
+               id, work_item_id, step, status, queue_job_id, queued_at,
+               started_at, finished_at, reason_code, reason_message,
+               created_at, updated_at
+             ) VALUES (?, ?, 'review', 'running', NULL, ?, ?, NULL, NULL, NULL, ?, ?)`,
+            [stepRunId, workItemId, now, now, now, now],
+          )
+
+          let turn = 0
+          yield* review(baseContext(root, { repositoryId })).pipe(
+            Effect.provideService(CurrentStepRun, {
+              stepRunId,
+              repositoryId,
+            }),
+            Effect.provide(
+              stubOpencode({
+                continue: (input) =>
+                  Effect.gen(function* () {
+                    turn += 1
+                    if (input.prompt.includes("pre-commit")) {
+                      const rows = (yield* sql.unsafe(
+                        `SELECT reason_code, reason_message FROM step_run WHERE id = ?`,
+                        [stepRunId],
+                      )) as readonly {
+                        readonly reason_code: string | null
+                        readonly reason_message: string | null
+                      }[]
+                      phaseDuringPreCommit = rows[0] ?? null
+                      yield* Effect.promise(async () => {
+                        await writeFile(join(root, ".pre-commit-fixed"), "ok\n")
+                      })
+                      return {
+                        sessionId: "ses_implement_session",
+                        assistantText: "fixed hooks",
+                      }
+                    }
+                    return {
+                      sessionId: "ses_implement_session",
+                      assistantText:
+                        turn === 1
+                          ? "READY_FOR_AGENT_RESULT: REVIEW_HAS_FINDINGS"
+                          : turn === 2
+                            ? "READY_FOR_AGENT_RESULT: REVIEW_FIXED"
+                            : "READY_FOR_AGENT_RESULT: REVIEW_CLEAN",
+                    }
+                  }),
+              }),
+            ),
+          )
+        }).pipe(
+          Effect.provide(DbServiceLive),
+          Effect.provide(DatabaseTest),
+          Effect.provide(PlatformLayer),
+        ),
+      )
+
+      expect(phaseDuringPreCommit).toEqual({
+        reason_code: STEP_RUN_REASON.reviewPreCommit,
+        reason_message: REVIEW_PRE_COMMIT_MESSAGE,
+      })
     }))
 
   it("marks Step Run phase as applying findings during the apply turn", () =>

--- a/packages/work-item-lifecycle/test/work-item-lifecycle.spec.ts
+++ b/packages/work-item-lifecycle/test/work-item-lifecycle.spec.ts
@@ -3008,40 +3008,6 @@ describe("WorkItemLifecycle", () => {
       )
     })
 
-    it("does not advance to Commit when Review reports fixed", () => {
-      const stepsFixedReview: LifecycleStepsShape = {
-        ...successfulSteps,
-        review: () => Effect.succeed({ _tag: "fixed" as const }),
-      }
-
-      return runWithSteps(
-        stepsFixedReview,
-        Effect.gen(function* () {
-          const lifecycle = yield* WorkItemLifecycle
-          const { repository, issue } = yield* seedActionableIssue
-          yield* lifecycle.implementNow(repository.id, issue.githubIssueNumber)
-          yield* claimAndRunPending
-          yield* claimAndRunPending
-          yield* claimAndRunPending
-          yield* claimAndRunPending
-          yield* claimAndRunPending
-          const afterReview = yield* claimAndRunPending
-
-          expect(afterReview._tag).toBe("processed")
-          if (afterReview._tag === "processed") {
-            expect(afterReview.workItem.state).toBe("review")
-            const reviewRun = afterReview.workItem.stepRuns.find(
-              (run) => run.step === "review",
-            )
-            expect(reviewRun?.status).toBe("failed")
-            expect(reviewRun?.reasonMessage).toContain(
-              "pre-commit re-review loop is not implemented yet",
-            )
-          }
-        }),
-      )
-    })
-
     it("persists complete pre-commit hook output on failure", () => {
       const output = `format failed: ${"x".repeat(9_000)}`
       const steps: LifecycleStepsShape = {


### PR DESCRIPTION
## Summary

- On `REVIEW_FIXED`, run nested Pre-Commit under operator phase `Review: pre-commit`, then re-enter reviewing with the review model/variant.
- Nested Pre-Commit failure fails the Review Step Run as retryable (not deferred success); clean/deferred still advance to Commit.
- Restore mid-run Review phases after OpenCode session wait so `Review: pre-commit` is not lost.

Closes #392

## Test plan

- [x] `work-item-lifecycle` unit tests for fixed → pre-commit → clean and Pre-Commit failure
- [x] GraphQL projection test for `Review: pre-commit`
- [x] OpenCode session limiter restore-phase test
- [x] Pre-commit hook / nx affected lint, typecheck, test