### PR TITLE
fix(graphql-api): hide redundant Review in-progress statusMessage

### DIFF
--- a/packages/graphql-api/src/lib/graphql-api.ts
+++ b/packages/graphql-api/src/lib/graphql-api.ts
@@ -14,7 +14,6 @@ import { KeymaxxerService } from "@ready-for-agent/keymaxxer-service"
 import { Opencode, type OpencodeModel } from "@ready-for-agent/opencode"
 import type { QueueService } from "@ready-for-agent/queue-service"
 import {
-  WAITING_FOR_WORKER_SLOT_MESSAGE,
   WorkItemLifecycle,
   type WorkItemRecord,
   type WorkItemsListKind,
@@ -47,6 +46,7 @@ import {
   workIssueProjection,
   workItemStateLabel,
   workItemStatus,
+  workItemStatusMessage,
 } from "./work-item-projection.js"
 
 type AddRepositoryArgs = {
@@ -340,10 +340,7 @@ export const createGraphqlApi = (
           statusLabel: (workItem: WorkItemRecord) =>
             statusLabel(workItemStatus(workItem)),
           statusMessage: (workItem: WorkItemRecord) =>
-            workItem.waitingSince != null
-              ? WAITING_FOR_WORKER_SLOT_MESSAGE
-              : (workItem.failureMessage ??
-                latestStepRun(workItem)?.reasonMessage),
+            workItemStatusMessage(workItem),
           paused: (workItem: WorkItemRecord) => workItem.paused,
           canRetry: (workItem: WorkItemRecord) => {
             const latestStatus = latestStepRun(workItem)?.status

--- a/packages/graphql-api/src/lib/work-item-projection.ts
+++ b/packages/graphql-api/src/lib/work-item-projection.ts
@@ -6,6 +6,7 @@ import {
   REVIEW_REVIEWING_MESSAGE,
   STEP_RUN_REASON,
   type StepRunRecord,
+  WAITING_FOR_WORKER_SLOT_MESSAGE,
   type WorkItemRecord,
   isTerminalWorkItemState,
 } from "@ready-for-agent/work-item-lifecycle"
@@ -120,6 +121,37 @@ export const workItemStatus = (workItem: WorkItemRecord): WorkItemStatus => {
   const latest = latestStepRun(workItem)
   if (latest === undefined) return "queued"
   return stepRunDisplayStatus(latest)
+}
+
+const REVIEW_IN_PROGRESS_CHIP_MESSAGES = new Set<string>([
+  REVIEW_REVIEWING_MESSAGE,
+  REVIEW_APPLYING_FINDINGS_MESSAGE,
+  REVIEW_PRE_COMMIT_MESSAGE,
+])
+
+const isRedundantReviewInProgressMessage = (stepRun: StepRunRecord): boolean =>
+  stepRun.status === "running" &&
+  stepRun.step === "review" &&
+  stepRun.reasonMessage != null &&
+  REVIEW_IN_PROGRESS_CHIP_MESSAGES.has(stepRun.reasonMessage)
+
+export const workItemStatusMessage = (
+  workItem: WorkItemRecord,
+): string | null => {
+  if (workItem.waitingSince != null) {
+    return WAITING_FOR_WORKER_SLOT_MESSAGE
+  }
+  if (workItem.failureMessage != null) {
+    return workItem.failureMessage
+  }
+  const latest = latestStepRun(workItem)
+  if (latest === undefined || latest.reasonMessage == null) {
+    return null
+  }
+  if (isRedundantReviewInProgressMessage(latest)) {
+    return null
+  }
+  return latest.reasonMessage
 }
 
 export const lifecycleLabels = (workItem: WorkItemRecord) => {

--- a/packages/graphql-api/test/graphql-api.test.ts
+++ b/packages/graphql-api/test/graphql-api.test.ts
@@ -1735,7 +1735,7 @@ describe("GraphQL API", () => {
       graphqlRequest({
         query: `query WorkItems($repositoryId: ID!, $githubIssueNumber: Int!) {
           workItems(repositoryId: $repositoryId, githubIssueNumber: $githubIssueNumber) {
-            stateLabel status statusLabel
+            stateLabel status statusLabel statusMessage
             lifecycleLabels { phase label status }
           }
         }`,
@@ -1753,6 +1753,7 @@ describe("GraphQL API", () => {
             stateLabel: "Review",
             status: "RUNNING",
             statusLabel: "Running",
+            statusMessage: null,
             lifecycleLabels: [
               {
                 phase: "REVIEW",
@@ -1795,7 +1796,7 @@ describe("GraphQL API", () => {
       graphqlRequest({
         query: `query WorkItems($repositoryId: ID!, $githubIssueNumber: Int!) {
           workItems(repositoryId: $repositoryId, githubIssueNumber: $githubIssueNumber) {
-            stateLabel status statusLabel
+            stateLabel status statusLabel statusMessage
             lifecycleLabels { phase label status }
           }
         }`,
@@ -1813,6 +1814,7 @@ describe("GraphQL API", () => {
             stateLabel: "Review",
             status: "RUNNING",
             statusLabel: "Running",
+            statusMessage: null,
             lifecycleLabels: [
               {
                 phase: "REVIEW",
@@ -1855,7 +1857,7 @@ describe("GraphQL API", () => {
       graphqlRequest({
         query: `query WorkItems($repositoryId: ID!, $githubIssueNumber: Int!) {
           workItems(repositoryId: $repositoryId, githubIssueNumber: $githubIssueNumber) {
-            stateLabel status statusLabel
+            stateLabel status statusLabel statusMessage
             lifecycleLabels { phase label status }
           }
         }`,
@@ -1873,11 +1875,130 @@ describe("GraphQL API", () => {
             stateLabel: "Review",
             status: "RUNNING",
             statusLabel: "Running",
+            statusMessage: null,
             lifecycleLabels: [
               {
                 phase: "REVIEW",
                 label: "Review: pre-commit",
                 status: "RUNNING",
+              },
+            ],
+          },
+        ],
+      },
+    })
+  })
+
+  test("keeps non-echo Review statusMessage while Review phase reasonCode is set", async () => {
+    const baseRun = workItem.stepRuns[0]!
+    const operational = {
+      ...workItem,
+      state: "review",
+      stepRuns: [
+        {
+          ...baseRun,
+          step: "review",
+          status: "running",
+          reasonCode: STEP_RUN_REASON.reviewReviewing,
+          reasonMessage: "waiting on model response",
+        },
+      ],
+    } as WorkItemRecord
+    await runtime.dispose()
+    runtime = makeRuntime(
+      {},
+      {},
+      {},
+      {
+        listWorkItemsForIssue: () => Effect.succeed([operational]),
+      },
+    )
+
+    const response = await createGraphqlApi(runtime).fetch(
+      graphqlRequest({
+        query: `query WorkItems($repositoryId: ID!, $githubIssueNumber: Int!) {
+          workItems(repositoryId: $repositoryId, githubIssueNumber: $githubIssueNumber) {
+            status statusMessage
+            lifecycleLabels { phase label status }
+          }
+        }`,
+        variables: {
+          repositoryId: repository.id,
+          githubIssueNumber: issue.githubIssueNumber,
+        },
+      }),
+    )
+
+    expect(await response.json()).toEqual({
+      data: {
+        workItems: [
+          {
+            status: "RUNNING",
+            statusMessage: "waiting on model response",
+            lifecycleLabels: [
+              {
+                phase: "REVIEW",
+                label: "Review: reviewing",
+                status: "RUNNING",
+              },
+            ],
+          },
+        ],
+      },
+    })
+  })
+
+  test("keeps failed Review reasonMessage as statusMessage", async () => {
+    const baseRun = workItem.stepRuns[0]!
+    const failedReview = {
+      ...workItem,
+      state: "review",
+      stepRuns: [
+        {
+          ...baseRun,
+          step: "review",
+          status: "failed",
+          reasonCode: STEP_RUN_REASON.handlerFailed,
+          reasonMessage: "OpenCode failed to review the Work Item",
+        },
+      ],
+    } as WorkItemRecord
+    await runtime.dispose()
+    runtime = makeRuntime(
+      {},
+      {},
+      {},
+      {
+        listWorkItemsForIssue: () => Effect.succeed([failedReview]),
+      },
+    )
+
+    const response = await createGraphqlApi(runtime).fetch(
+      graphqlRequest({
+        query: `query WorkItems($repositoryId: ID!, $githubIssueNumber: Int!) {
+          workItems(repositoryId: $repositoryId, githubIssueNumber: $githubIssueNumber) {
+            status statusMessage
+            lifecycleLabels { phase label status }
+          }
+        }`,
+        variables: {
+          repositoryId: repository.id,
+          githubIssueNumber: issue.githubIssueNumber,
+        },
+      }),
+    )
+
+    expect(await response.json()).toEqual({
+      data: {
+        workItems: [
+          {
+            status: "FAILED",
+            statusMessage: "OpenCode failed to review the Work Item",
+            lifecycleLabels: [
+              {
+                phase: "REVIEW",
+                label: "Review: Failed",
+                status: "FAILED",
               },
             ],
           },


### PR DESCRIPTION
## Summary
- Suppress GraphQL `statusMessage` when it only echoes a running Review phase already shown on the lifecycle chip (`reviewing`, `applying findings`, `pre-commit`).
- Keep real failures and non-echo operational messages visible under the step strip.
- Cover suppression and preservation boundaries in GraphQL API tests.

Closes #404

## Test plan
- [x] `bunx nx test graphql-api`
- [x] `bunx nx run graphql-api:lint`
- [ ] Confirm Jobs UI no longer shows red `reviewing` under chips while Review runs
- [ ] Confirm failed Review still shows error text under chips