### PR TITLE
docs: ADR-0030 session usage via live OpenCode SQLite

### DIFF
--- a/docs/adr/0030-session-usage-live-opencode-sqlite.md
+++ b/docs/adr/0030-session-usage-live-opencode-sqlite.md
@@ -1,0 +1,11 @@
+# Session usage via live OpenCode SQLite
+
+The Jobs Completed dialog needs OpenCode session model, token totals (input, output, reasoning, cache read/write), cost, and timestamps. We expose that with a root GraphQL `session(id: String!)` query that live-reads OpenCode’s SQLite (`opencode db path` / XDG data dir), not a harness-side snapshot and not `opencode export`.
+
+**Why live-read, not snapshot:** usage is already authoritative in OpenCode; duplicating it on every start/continue couples the lifecycle to NDJSON parsing and still goes stale if OpenCode is the source of truth mid-session. Completed history accepts “missing if OpenCode pruned the row.”
+
+**Why SQLite, not export:** export returns the full transcript and is too heavy for a totals dialog; the `session` table already has the aggregates.
+
+**API shape:** `session` returns null when no Work Item owns that `sessionId` (do not leak unrelated local chats). When owned, return a `Session` with `availability` `AVAILABLE` | `MISSING` | `UNAVAILABLE` so the dialog can open with Suspense/error UI when the row is gone or the DB is locked. OpenCode metric fields are null unless `AVAILABLE`. No agent field; no Work Item chrome on the payload (the Completed row already shows it).
+
+**Access:** read-only SQLite with a short timeout; lock/read failures map to `UNAVAILABLE`. Path resolution follows OpenCode’s data directory rules only—no harness override.


### PR DESCRIPTION
## Summary

- Adds **ADR-0030**: Session usage dialog backed by GraphQL `session(id:)` live-reading OpenCode’s SQLite (ownership gate, availability states, no harness snapshot).
- Spec for implementation: #406.

## Test plan

- [ ] ADR numbering/title looks correct next to existing `docs/adr/*`
- [ ] #406 still matches the ADR (no drift)