### PR TITLE
feat(work-item-lifecycle): bound ready-PR check startup by Last PR Change

### DIFF
--- a/apps/harness/src/server/keymaxxer-github-layer.ts
+++ b/apps/harness/src/server/keymaxxer-github-layer.ts
@@ -106,10 +106,16 @@ const SerializedPullRequestCheckStatusFields = {
   baseRefName: Schema.NullOr(Schema.String),
   headPushedAt: Schema.NullOr(Schema.String),
   headSha: Schema.NullOr(Schema.String),
+  createdAt: Schema.NullOr(Schema.String),
+  isDraft: Schema.NullOr(Schema.Boolean),
 } as const
 
 const SerializedPullRequestCheckStatus = Schema.Union([
   Schema.TaggedStruct("pending", {
+    terminalChecks: Schema.Array(SerializedTerminalPrStatusCheck),
+    ...SerializedPullRequestCheckStatusFields,
+  }),
+  Schema.TaggedStruct("expected", {
     terminalChecks: Schema.Array(SerializedTerminalPrStatusCheck),
     ...SerializedPullRequestCheckStatusFields,
   }),
@@ -129,7 +135,7 @@ const SerializedPullRequestCheckStatus = Schema.Union([
   }),
 ])
 
-const decodeHeadPushedAt = (value: string | null): Date | null => {
+const decodeOptionalInstant = (value: string | null): Date | null => {
   if (value === null) {
     return null
   }
@@ -350,7 +356,8 @@ export const keymaxxerGitHubLayer = (options: {
             )(result.stdout).pipe(
               Effect.map((status) => ({
                 ...status,
-                headPushedAt: decodeHeadPushedAt(status.headPushedAt),
+                headPushedAt: decodeOptionalInstant(status.headPushedAt),
+                createdAt: decodeOptionalInstant(status.createdAt),
               })),
               Effect.mapError(() =>
                 requestError(

--- a/apps/harness/test/job-worker.test.ts
+++ b/apps/harness/test/job-worker.test.ts
@@ -140,6 +140,8 @@ const defaultGithubLayer = Layer.succeed(GitHubService, {
       baseRefName: "main",
       headPushedAt: null,
       headSha: null,
+      createdAt: null,
+      isDraft: null,
     }),
   getPrStatusCheckDiagnostics: () => Effect.succeed([]),
   getPullRequestLifecycleStatus: () =>
@@ -395,6 +397,8 @@ describe("Job worker", () => {
           baseRefName: "main",
           headPushedAt: null,
           headSha: null,
+          createdAt: null,
+          isDraft: null,
         }),
       getPrStatusCheckDiagnostics: () => Effect.succeed([]),
       getPullRequestLifecycleStatus: () =>

--- a/apps/harness/test/keymaxxer-github-layer.test.ts
+++ b/apps/harness/test/keymaxxer-github-layer.test.ts
@@ -197,6 +197,8 @@ describe("Keymaxxer-backed GitHub layer", () => {
             baseRefName: "develop",
             headPushedAt: null,
             headSha: null,
+            createdAt: null,
+            isDraft: null,
             terminalChecks: [
               {
                 externalId: "checkrun:1",
@@ -229,6 +231,8 @@ describe("Keymaxxer-backed GitHub layer", () => {
       baseRefName: "develop",
       headPushedAt: null,
       headSha: null,
+      createdAt: null,
+      isDraft: null,
       terminalChecks: [
         {
           externalId: "checkrun:1",
@@ -282,6 +286,8 @@ describe("Keymaxxer-backed GitHub layer", () => {
         baseRefName: "main",
         headPushedAt: null,
         headSha: null,
+        createdAt: null,
+        isDraft: null,
       }),
       JSON.stringify({
         _tag: "pending",
@@ -289,6 +295,8 @@ describe("Keymaxxer-backed GitHub layer", () => {
         baseRefName: "main",
         headPushedAt: null,
         headSha: null,
+        createdAt: null,
+        isDraft: null,
         terminalChecks: [
           {
             externalId: "status:SC_ci",
@@ -330,6 +338,8 @@ describe("Keymaxxer-backed GitHub layer", () => {
       baseRefName: "main",
       headPushedAt: null,
       headSha: null,
+      createdAt: null,
+      isDraft: null,
     })
 
     const pending = await Effect.runPromise(
@@ -347,6 +357,8 @@ describe("Keymaxxer-backed GitHub layer", () => {
       baseRefName: "main",
       headPushedAt: null,
       headSha: null,
+      createdAt: null,
+      isDraft: null,
       terminalChecks: [
         {
           externalId: "status:SC_ci",

--- a/packages/db-schema/drizzle/20260723051726_clever_hex/migration.sql
+++ b/packages/db-schema/drizzle/20260723051726_clever_hex/migration.sql
@@ -1,0 +1,24 @@
+ALTER TABLE `work_item` ADD `check_start_anchor_at` integer;--> statement-breakpoint
+ALTER TABLE `work_item` ADD `check_start_anchor_head_sha` text;--> statement-breakpoint
+ALTER TABLE `work_item` ADD `check_start_observed_head_sha` text;--> statement-breakpoint
+ALTER TABLE `work_item` ADD `check_start_observed_head_at` integer;--> statement-breakpoint
+-- Existing unfinished Work Items, and retryable legacy status-check failures,
+-- get a migration-time Check-Start Anchor so a later historical PR creation/push
+-- time cannot make the catch-up window already elapsed on first post-upgrade
+-- Watch (or Retry back into Watch). Millisecond epoch from integer seconds plus
+-- the three fractional-second digits (no julianday float truncation).
+UPDATE `work_item`
+SET `check_start_anchor_at` = (
+  SELECT
+    (CAST(strftime('%s', ts) AS integer) * 1000)
+    + CAST(substr(strftime('%f', ts), -3) AS integer)
+  FROM (SELECT strftime('%Y-%m-%d %H:%M:%f', 'now') AS ts)
+)
+WHERE `check_start_anchor_at` IS NULL
+  AND (
+    `state` NOT IN ('complete', 'failed', 'abandoned')
+    OR (
+      `state` = 'failed'
+      AND `failure_code` = 'pr_status_checks_unresolved'
+    )
+  );

--- a/packages/db-schema/drizzle/20260723051726_clever_hex/snapshot.json
+++ b/packages/db-schema/drizzle/20260723051726_clever_hex/snapshot.json
@@ -1,0 +1,1675 @@
+{
+  "version": "7",
+  "dialect": "sqlite",
+  "id": "8c727993-44ea-4a7f-b551-50eb4a5bee63",
+  "prevIds": [
+    "8701dbf3-c311-4e9f-ba19-1a1374589e87"
+  ],
+  "ddl": [
+    {
+      "name": "automated_review_rerun",
+      "entityType": "tables"
+    },
+    {
+      "name": "completed_job",
+      "entityType": "tables"
+    },
+    {
+      "name": "config",
+      "entityType": "tables"
+    },
+    {
+      "name": "issue",
+      "entityType": "tables"
+    },
+    {
+      "name": "issue_dependency",
+      "entityType": "tables"
+    },
+    {
+      "name": "job_queue",
+      "entityType": "tables"
+    },
+    {
+      "name": "pr_status_check",
+      "entityType": "tables"
+    },
+    {
+      "name": "repository",
+      "entityType": "tables"
+    },
+    {
+      "name": "step_run",
+      "entityType": "tables"
+    },
+    {
+      "name": "work_item",
+      "entityType": "tables"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "automated_review_rerun"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "work_item_id",
+      "entityType": "columns",
+      "table": "automated_review_rerun"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "head_sha",
+      "entityType": "columns",
+      "table": "automated_review_rerun"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "workflow_run_id",
+      "entityType": "columns",
+      "table": "automated_review_rerun"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "workflow_name",
+      "entityType": "columns",
+      "table": "automated_review_rerun"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "status",
+      "entityType": "columns",
+      "table": "automated_review_rerun"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "automated_review_rerun"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "automated_review_rerun"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "completed_job"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "queue",
+      "entityType": "columns",
+      "table": "completed_job"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "job_id",
+      "entityType": "columns",
+      "table": "completed_job"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "completed_job"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "completed_job"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "'default'",
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "config"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "default_model",
+      "entityType": "columns",
+      "table": "config"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "default_variant",
+      "entityType": "columns",
+      "table": "config"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "review_model",
+      "entityType": "columns",
+      "table": "config"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "review_variant",
+      "entityType": "columns",
+      "table": "config"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "2",
+      "generated": null,
+      "name": "max_concurrent_opencode_sessions",
+      "entityType": "columns",
+      "table": "config"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "5",
+      "generated": null,
+      "name": "max_concurrent_work_items",
+      "entityType": "columns",
+      "table": "config"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "config"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "config"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "issue"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "repository_id",
+      "entityType": "columns",
+      "table": "issue"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "github_issue_number",
+      "entityType": "columns",
+      "table": "issue"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "title",
+      "entityType": "columns",
+      "table": "issue"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "body",
+      "entityType": "columns",
+      "table": "issue"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "url",
+      "entityType": "columns",
+      "table": "issue"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "state",
+      "entityType": "columns",
+      "table": "issue"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "github_created_at",
+      "entityType": "columns",
+      "table": "issue"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "issue_author",
+      "entityType": "columns",
+      "table": "issue"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "parent_github_issue_number",
+      "entityType": "columns",
+      "table": "issue"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "parent_github_issue_url",
+      "entityType": "columns",
+      "table": "issue"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "parent_position",
+      "entityType": "columns",
+      "table": "issue"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "false",
+      "generated": null,
+      "name": "has_children",
+      "entityType": "columns",
+      "table": "issue"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "issue"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "issue"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "issue_dependency"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "issue_id",
+      "entityType": "columns",
+      "table": "issue_dependency"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "blocking_github_issue_number",
+      "entityType": "columns",
+      "table": "issue_dependency"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "blocking_github_issue_url",
+      "entityType": "columns",
+      "table": "issue_dependency"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "issue_dependency"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "job_queue"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "queue",
+      "entityType": "columns",
+      "table": "job_queue"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "key",
+      "entityType": "columns",
+      "table": "job_queue"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "job_payload",
+      "entityType": "columns",
+      "table": "job_queue"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "0",
+      "generated": null,
+      "name": "job_attempts",
+      "entityType": "columns",
+      "table": "job_queue"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "5",
+      "generated": null,
+      "name": "job_retry_limit",
+      "entityType": "columns",
+      "table": "job_queue"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "available_at",
+      "entityType": "columns",
+      "table": "job_queue"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "locked_until",
+      "entityType": "columns",
+      "table": "job_queue"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "job_queue"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "job_queue"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "pr_status_check"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "work_item_id",
+      "entityType": "columns",
+      "table": "pr_status_check"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "external_id",
+      "entityType": "columns",
+      "table": "pr_status_check"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "name",
+      "entityType": "columns",
+      "table": "pr_status_check"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "outcome",
+      "entityType": "columns",
+      "table": "pr_status_check"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "handled_at",
+      "entityType": "columns",
+      "table": "pr_status_check"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "handled_by_step_run_id",
+      "entityType": "columns",
+      "table": "pr_status_check"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "observed_at",
+      "entityType": "columns",
+      "table": "pr_status_check"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "pr_status_check"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "pr_status_check"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "repository"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "github_owner",
+      "entityType": "columns",
+      "table": "repository"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "github_repo",
+      "entityType": "columns",
+      "table": "repository"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "local_path",
+      "entityType": "columns",
+      "table": "repository"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "is_bare",
+      "entityType": "columns",
+      "table": "repository"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "true",
+      "generated": null,
+      "name": "paused",
+      "entityType": "columns",
+      "table": "repository"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "default_model",
+      "entityType": "columns",
+      "table": "repository"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "default_variant",
+      "entityType": "columns",
+      "table": "repository"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "review_model",
+      "entityType": "columns",
+      "table": "repository"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "review_variant",
+      "entityType": "columns",
+      "table": "repository"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "false",
+      "generated": null,
+      "name": "auto_merge",
+      "entityType": "columns",
+      "table": "repository"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "false",
+      "generated": null,
+      "name": "include_all_issue_authors",
+      "entityType": "columns",
+      "table": "repository"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "issues_reconciled_at",
+      "entityType": "columns",
+      "table": "repository"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "repository"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "repository"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "step_run"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "work_item_id",
+      "entityType": "columns",
+      "table": "step_run"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "step",
+      "entityType": "columns",
+      "table": "step_run"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "status",
+      "entityType": "columns",
+      "table": "step_run"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "queue_job_id",
+      "entityType": "columns",
+      "table": "step_run"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "queued_at",
+      "entityType": "columns",
+      "table": "step_run"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "started_at",
+      "entityType": "columns",
+      "table": "step_run"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "finished_at",
+      "entityType": "columns",
+      "table": "step_run"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "reason_code",
+      "entityType": "columns",
+      "table": "step_run"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "reason_message",
+      "entityType": "columns",
+      "table": "step_run"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "step_run"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "step_run"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "work_item"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "repository_id",
+      "entityType": "columns",
+      "table": "work_item"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "github_issue_number",
+      "entityType": "columns",
+      "table": "work_item"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "issue_title",
+      "entityType": "columns",
+      "table": "work_item"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "github_pull_request_number",
+      "entityType": "columns",
+      "table": "work_item"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "model",
+      "entityType": "columns",
+      "table": "work_item"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "variant",
+      "entityType": "columns",
+      "table": "work_item"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "review_model",
+      "entityType": "columns",
+      "table": "work_item"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "review_variant",
+      "entityType": "columns",
+      "table": "work_item"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "state",
+      "entityType": "columns",
+      "table": "work_item"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "state_ready_at",
+      "entityType": "columns",
+      "table": "work_item"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "false",
+      "generated": null,
+      "name": "paused",
+      "entityType": "columns",
+      "table": "work_item"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "waiting_since",
+      "entityType": "columns",
+      "table": "work_item"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "false",
+      "generated": null,
+      "name": "holds_worker_slot",
+      "entityType": "columns",
+      "table": "work_item"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "pause_before_step",
+      "entityType": "columns",
+      "table": "work_item"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "worktree_path",
+      "entityType": "columns",
+      "table": "work_item"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "starting_commit_oid",
+      "entityType": "columns",
+      "table": "work_item"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "completion_summary",
+      "entityType": "columns",
+      "table": "work_item"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "session_id",
+      "entityType": "columns",
+      "table": "work_item"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "failure_code",
+      "entityType": "columns",
+      "table": "work_item"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "failure_message",
+      "entityType": "columns",
+      "table": "work_item"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "check_start_anchor_at",
+      "entityType": "columns",
+      "table": "work_item"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "check_start_anchor_head_sha",
+      "entityType": "columns",
+      "table": "work_item"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "check_start_observed_head_sha",
+      "entityType": "columns",
+      "table": "work_item"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "check_start_observed_head_at",
+      "entityType": "columns",
+      "table": "work_item"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "work_item"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "work_item"
+    },
+    {
+      "columns": [
+        "work_item_id"
+      ],
+      "tableTo": "work_item",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_automated_review_rerun_work_item_id_work_item_id_fk",
+      "entityType": "fks",
+      "table": "automated_review_rerun"
+    },
+    {
+      "columns": [
+        "repository_id"
+      ],
+      "tableTo": "repository",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_issue_repository_id_repository_id_fk",
+      "entityType": "fks",
+      "table": "issue"
+    },
+    {
+      "columns": [
+        "issue_id"
+      ],
+      "tableTo": "issue",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_issue_dependency_issue_id_issue_id_fk",
+      "entityType": "fks",
+      "table": "issue_dependency"
+    },
+    {
+      "columns": [
+        "work_item_id"
+      ],
+      "tableTo": "work_item",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_pr_status_check_work_item_id_work_item_id_fk",
+      "entityType": "fks",
+      "table": "pr_status_check"
+    },
+    {
+      "columns": [
+        "handled_by_step_run_id"
+      ],
+      "tableTo": "step_run",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "SET NULL",
+      "nameExplicit": false,
+      "name": "fk_pr_status_check_handled_by_step_run_id_step_run_id_fk",
+      "entityType": "fks",
+      "table": "pr_status_check"
+    },
+    {
+      "columns": [
+        "work_item_id"
+      ],
+      "tableTo": "work_item",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_step_run_work_item_id_work_item_id_fk",
+      "entityType": "fks",
+      "table": "step_run"
+    },
+    {
+      "columns": [
+        "repository_id"
+      ],
+      "tableTo": "repository",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_work_item_repository_id_repository_id_fk",
+      "entityType": "fks",
+      "table": "work_item"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "automated_review_rerun_pk",
+      "table": "automated_review_rerun",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "completed_job_pk",
+      "table": "completed_job",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "config_pk",
+      "table": "config",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "issue_pk",
+      "table": "issue",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "issue_dependency_pk",
+      "table": "issue_dependency",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "job_queue_pk",
+      "table": "job_queue",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "pr_status_check_pk",
+      "table": "pr_status_check",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "repository_pk",
+      "table": "repository",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "step_run_pk",
+      "table": "step_run",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "work_item_pk",
+      "table": "work_item",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        {
+          "value": "work_item_id",
+          "isExpression": false
+        },
+        {
+          "value": "head_sha",
+          "isExpression": false
+        },
+        {
+          "value": "workflow_run_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "automated_review_rerun_budget_idx",
+      "entityType": "indexes",
+      "table": "automated_review_rerun"
+    },
+    {
+      "columns": [
+        {
+          "value": "queue",
+          "isExpression": false
+        },
+        {
+          "value": "job_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "origin": "manual",
+      "name": "completed_job_queue_job_id_uidx",
+      "entityType": "indexes",
+      "table": "completed_job"
+    },
+    {
+      "columns": [
+        {
+          "value": "repository_id",
+          "isExpression": false
+        },
+        {
+          "value": "github_issue_number",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "origin": "manual",
+      "name": "issue_repository_id_github_issue_number_uidx",
+      "entityType": "indexes",
+      "table": "issue"
+    },
+    {
+      "columns": [
+        {
+          "value": "issue_id",
+          "isExpression": false
+        },
+        {
+          "value": "blocking_github_issue_url",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "origin": "manual",
+      "name": "issue_dependency_issue_id_blocking_url_uidx",
+      "entityType": "indexes",
+      "table": "issue_dependency"
+    },
+    {
+      "columns": [
+        {
+          "value": "queue",
+          "isExpression": false
+        },
+        {
+          "value": "locked_until",
+          "isExpression": false
+        },
+        {
+          "value": "job_attempts",
+          "isExpression": false
+        },
+        {
+          "value": "available_at",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "job_queue_ready_idx",
+      "entityType": "indexes",
+      "table": "job_queue"
+    },
+    {
+      "columns": [
+        {
+          "value": "queue",
+          "isExpression": false
+        },
+        {
+          "value": "key",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": "\"job_queue\".\"key\" IS NOT NULL",
+      "origin": "manual",
+      "name": "job_queue_queue_key_uidx",
+      "entityType": "indexes",
+      "table": "job_queue"
+    },
+    {
+      "columns": [
+        {
+          "value": "work_item_id",
+          "isExpression": false
+        },
+        {
+          "value": "external_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "origin": "manual",
+      "name": "pr_status_check_work_item_external_uidx",
+      "entityType": "indexes",
+      "table": "pr_status_check"
+    },
+    {
+      "columns": [
+        {
+          "value": "work_item_id",
+          "isExpression": false
+        },
+        {
+          "value": "handled_at",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "pr_status_check_work_item_handled_idx",
+      "entityType": "indexes",
+      "table": "pr_status_check"
+    },
+    {
+      "columns": [
+        {
+          "value": "handled_by_step_run_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "pr_status_check_handled_by_step_run_idx",
+      "entityType": "indexes",
+      "table": "pr_status_check"
+    },
+    {
+      "columns": [
+        {
+          "value": "lower(\"github_owner\")",
+          "isExpression": true
+        },
+        {
+          "value": "lower(\"github_repo\")",
+          "isExpression": true
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "origin": "manual",
+      "name": "repository_github_owner_repo_lower_uidx",
+      "entityType": "indexes",
+      "table": "repository"
+    },
+    {
+      "columns": [
+        {
+          "value": "work_item_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": "\"step_run\".\"status\" IN ('queued', 'running')",
+      "origin": "manual",
+      "name": "step_run_one_active_uidx",
+      "entityType": "indexes",
+      "table": "step_run"
+    },
+    {
+      "columns": [
+        {
+          "value": "work_item_id",
+          "isExpression": false
+        },
+        {
+          "value": "queued_at",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "step_run_work_item_id_queued_at_idx",
+      "entityType": "indexes",
+      "table": "step_run"
+    },
+    {
+      "columns": [
+        {
+          "value": "repository_id",
+          "isExpression": false
+        },
+        {
+          "value": "github_issue_number",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": "\"work_item\".\"state\" NOT IN ('complete', 'failed', 'abandoned', 'needs_human')",
+      "origin": "manual",
+      "name": "work_item_one_unfinished_v2_uidx",
+      "entityType": "indexes",
+      "table": "work_item"
+    },
+    {
+      "columns": [
+        {
+          "value": "repository_id",
+          "isExpression": false
+        },
+        {
+          "value": "github_issue_number",
+          "isExpression": false
+        },
+        {
+          "value": "created_at",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "work_item_repository_issue_created_idx",
+      "entityType": "indexes",
+      "table": "work_item"
+    },
+    {
+      "columns": [
+        "local_path"
+      ],
+      "nameExplicit": false,
+      "name": "repository_local_path_unique",
+      "entityType": "uniques",
+      "table": "repository"
+    }
+  ],
+  "renames": []
+}

--- a/packages/db-schema/src/schema.ts
+++ b/packages/db-schema/src/schema.ts
@@ -277,6 +277,24 @@ export const workItem = snakeCase.table(
     sessionId: text(),
     failureCode: text(),
     failureMessage: text(),
+    /**
+     * Latest Check-Start Anchor instant (ms since epoch). Null until first
+     * Watch observation establishes Last PR Change or a conservative fallback.
+     */
+    checkStartAnchorAt: integer({ mode: "number" }),
+    /**
+     * Head SHA the Check-Start Anchor is scoped to. A replacement head must not
+     * inherit a prior head's anchor or observation fallback.
+     */
+    checkStartAnchorHeadSha: text(),
+    /**
+     * Current head SHA first observed when GitHub omitted a valid push time.
+     */
+    checkStartObservedHeadSha: text(),
+    /**
+     * First-observation instant (ms) for checkStartObservedHeadSha.
+     */
+    checkStartObservedHeadAt: integer({ mode: "number" }),
     createdAt: integer({ mode: "number" })
       .notNull()
       .$defaultFn(() => Date.now()),

--- a/packages/db/src/lib/database-test.ts
+++ b/packages/db/src/lib/database-test.ts
@@ -36,3 +36,24 @@ const MigrationLayer = Layer.effectDiscard(
  * Default consumer path for tests; production uses {@link DatabaseLive}.
  */
 export const DatabaseTest = MigrationLayer.pipe(Layer.provideMerge(SqliteTest))
+
+/**
+ * File-backed SQLite + migrations for tests that must reopen the same DB after
+ * disposing services (restart / durability acceptance).
+ */
+export const makeFileDatabaseTest = (filename: string) => {
+  const sqlite = Layer.provideMerge(
+    Layer.effectDiscard(
+      Effect.gen(function* () {
+        const sql = yield* SqlClient.SqlClient
+        yield* sql`PRAGMA foreign_keys = ON`
+      }),
+    ),
+    SqliteClient.layer({
+      filename,
+      create: true,
+      readwrite: true,
+    }),
+  )
+  return MigrationLayer.pipe(Layer.provideMerge(sqlite))
+}

--- a/packages/db/test/run-migrations.spec.ts
+++ b/packages/db/test/run-migrations.spec.ts
@@ -88,6 +88,7 @@ describe("runMigrations", () => {
           { name: "20260720220839_simple_rick_jones" },
           { name: "20260722034639_condemned_wildside" },
           { name: "20260722230410_goofy_gertrude_yorkes" },
+          { name: "20260723051726_clever_hex" },
         ])
       }).pipe(Effect.provide(SqliteTest)),
     )
@@ -229,6 +230,129 @@ describe("runMigrations", () => {
         expect(rows).toEqual([
           { id: "new-attempt", state: "abandoned" },
           { id: "old-handoff", state: "local_cleanup" },
+        ])
+      }).pipe(Effect.provide(SqliteTest)),
+    )
+  })
+
+  it("adds Check-Start Anchor columns while preserving Work Items and PR Status Checks", async () => {
+    const migrationSql = await readFile(
+      join(
+        import.meta.dir,
+        "../../db-schema/drizzle/20260723051726_clever_hex/migration.sql",
+      ),
+      "utf8",
+    )
+    const beforeMs = Date.now()
+
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        const sql = yield* SqlClient.SqlClient
+        yield* sql.unsafe(
+          `CREATE TABLE work_item (
+             id text PRIMARY KEY,
+             repository_id text NOT NULL,
+             github_issue_number integer NOT NULL,
+             state text NOT NULL,
+             failure_code text
+           )`,
+        )
+        yield* sql.unsafe(
+          `CREATE TABLE pr_status_check (
+             id text PRIMARY KEY,
+             work_item_id text NOT NULL,
+             external_id text NOT NULL,
+             name text NOT NULL,
+             outcome text NOT NULL
+           )`,
+        )
+        yield* sql.unsafe(
+          `INSERT INTO work_item VALUES
+             ('wi-existing', 'repo-1', 42, 'watch_pr_status_checks', NULL),
+             ('wi-retryable-failed', 'repo-1', 43, 'failed', 'pr_status_checks_unresolved'),
+             ('wi-other-failed', 'repo-1', 44, 'failed', 'issue_not_found'),
+             ('wi-complete', 'repo-1', 45, 'complete', NULL)`,
+        )
+        yield* sql.unsafe(
+          `INSERT INTO pr_status_check VALUES
+             ('psc-existing', 'wi-existing', 'checkrun:1', 'lint', 'green')`,
+        )
+
+        for (const statement of migrationSql.split(
+          "--> statement-breakpoint",
+        )) {
+          if (statement.trim().length > 0) {
+            yield* sql.unsafe(statement)
+          }
+        }
+
+        const afterMs = Date.now()
+        const workItems = (yield* sql.unsafe(
+          `SELECT id, state,
+                  check_start_anchor_at,
+                  check_start_anchor_head_sha,
+                  check_start_observed_head_sha,
+                  check_start_observed_head_at
+           FROM work_item
+           ORDER BY id`,
+        )) as readonly {
+          readonly id: string
+          readonly state: string
+          readonly check_start_anchor_at: number | null
+          readonly check_start_anchor_head_sha: string | null
+          readonly check_start_observed_head_sha: string | null
+          readonly check_start_observed_head_at: number | null
+        }[]
+
+        expect(workItems).toHaveLength(4)
+        const unfinished = workItems.find((row) => row.id === "wi-existing")
+        const retryableFailed = workItems.find(
+          (row) => row.id === "wi-retryable-failed",
+        )
+        const otherFailed = workItems.find(
+          (row) => row.id === "wi-other-failed",
+        )
+        const complete = workItems.find((row) => row.id === "wi-complete")
+        expect(unfinished).toMatchObject({
+          state: "watch_pr_status_checks",
+          check_start_anchor_head_sha: null,
+          check_start_observed_head_sha: null,
+          check_start_observed_head_at: null,
+        })
+        expect(unfinished?.check_start_anchor_at).not.toBeNull()
+        expect(unfinished!.check_start_anchor_at!).toBeGreaterThanOrEqual(
+          beforeMs,
+        )
+        expect(unfinished!.check_start_anchor_at!).toBeLessThanOrEqual(afterMs)
+        expect(retryableFailed?.check_start_anchor_at).not.toBeNull()
+        expect(retryableFailed!.check_start_anchor_at!).toBeGreaterThanOrEqual(
+          beforeMs,
+        )
+        expect(retryableFailed!.check_start_anchor_at!).toBeLessThanOrEqual(
+          afterMs,
+        )
+        expect(otherFailed).toEqual({
+          id: "wi-other-failed",
+          state: "failed",
+          check_start_anchor_at: null,
+          check_start_anchor_head_sha: null,
+          check_start_observed_head_sha: null,
+          check_start_observed_head_at: null,
+        })
+        expect(complete).toEqual({
+          id: "wi-complete",
+          state: "complete",
+          check_start_anchor_at: null,
+          check_start_anchor_head_sha: null,
+          check_start_observed_head_sha: null,
+          check_start_observed_head_at: null,
+        })
+
+        const checks = yield* sql.unsafe(
+          `SELECT id, external_id FROM pr_status_check`,
+        )
+        expect(checks).toEqual([
+          { id: "psc-existing", external_id: "checkrun:1" },
         ])
       }).pipe(Effect.provide(SqliteTest)),
     )

--- a/packages/github-service/github.graphql
+++ b/packages/github-service/github.graphql
@@ -111,6 +111,7 @@ type PullRequest {
   state: PullRequestState!
   merged: Boolean!
   isDraft: Boolean!
+  createdAt: DateTime!
   headRefOid: String!
   baseRefName: String!
   mergeable: MergeableState!

--- a/packages/github-service/src/lib/github-service-live.ts
+++ b/packages/github-service/src/lib/github-service-live.ts
@@ -122,6 +122,8 @@ interface GitHubApiPullRequestCommit {
 interface GitHubApiPullRequest {
   readonly state: unknown
   readonly merged: unknown
+  readonly isDraft?: unknown
+  readonly createdAt?: unknown
   readonly headRefOid?: unknown
   readonly baseRefName: unknown
   readonly mergeable: unknown
@@ -330,7 +332,7 @@ const uniqueTerminalChecks = (
 
 /**
  * Read the current PR head commit's push time. Invalid or mismatched API data
- * yields null so callers keep the conservative no-check path.
+ * yields null so callers keep the conservative observation fallback.
  */
 const parseHeadPushedAt = (pullRequest: GitHubApiPullRequest): Date | null => {
   const headRefOid = pullRequest.headRefOid
@@ -363,6 +365,28 @@ const parseHeadPushedAt = (pullRequest: GitHubApiPullRequest): Date | null => {
   return parsed
 }
 
+const parsePrCreatedAt = (pullRequest: GitHubApiPullRequest): Date | null => {
+  const createdAt = pullRequest.createdAt
+  if (typeof createdAt !== "string" || createdAt.trim() === "") {
+    return null
+  }
+  const parsed = new Date(createdAt)
+  if (Number.isNaN(parsed.getTime())) {
+    return null
+  }
+  return parsed
+}
+
+const parseIsDraft = (pullRequest: GitHubApiPullRequest): boolean | null => {
+  if (pullRequest.isDraft === true) {
+    return true
+  }
+  if (pullRequest.isDraft === false) {
+    return false
+  }
+  return null
+}
+
 const headShaFromPullRequest = (
   pullRequest: GitHubApiPullRequest | null | undefined,
 ): string | null => {
@@ -375,6 +399,15 @@ const headShaFromPullRequest = (
     : null
 }
 
+const emptyCheckSnapshotFields = {
+  mergeability: "unknown" as const,
+  baseRefName: null,
+  headPushedAt: null,
+  headSha: null,
+  createdAt: null,
+  isDraft: null,
+}
+
 const toPullRequestCheckStatus = (
   pullRequest: GitHubApiPullRequest | null | undefined,
   terminalChecks: readonly TerminalPrStatusCheck[] = emptyTerminalChecks,
@@ -383,10 +416,7 @@ const toPullRequestCheckStatus = (
     return {
       _tag: "pending",
       terminalChecks: emptyTerminalChecks,
-      mergeability: "unknown",
-      baseRefName: null,
-      headPushedAt: null,
-      headSha: null,
+      ...emptyCheckSnapshotFields,
     }
   }
   const decoded = decodeSync(GitHubPullRequestCheckFieldsSchema, pullRequest)
@@ -401,6 +431,8 @@ const toPullRequestCheckStatus = (
     baseRefName: decoded.baseRefName,
     headPushedAt: parseHeadPushedAt(pullRequest),
     headSha: headShaFromPullRequest(pullRequest),
+    createdAt: parsePrCreatedAt(pullRequest),
+    isDraft: parseIsDraft(pullRequest),
   } as const
   if (decoded.merged) {
     return { _tag: "succeeded", terminalChecks, ...snapshot }
@@ -417,6 +449,9 @@ const toPullRequestCheckStatus = (
   }
   if (state === "FAILURE" || state === "ERROR") {
     return { _tag: "failed", terminalChecks, ...snapshot }
+  }
+  if (state === "EXPECTED") {
+    return { _tag: "expected", terminalChecks, ...snapshot }
   }
   return { _tag: "pending", terminalChecks, ...snapshot }
 }
@@ -823,6 +858,8 @@ export const makeGitHubService = (
                 nodes: {
                   state: true,
                   merged: true,
+                  isDraft: true,
+                  createdAt: true,
                   headRefOid: true,
                   baseRefName: true,
                   mergeable: true,
@@ -854,10 +891,7 @@ export const makeGitHubService = (
       return {
         _tag: "pending",
         terminalChecks: emptyTerminalChecks,
-        mergeability: "unknown",
-        baseRefName: null,
-        headPushedAt: null,
-        headSha: null,
+        ...emptyCheckSnapshotFields,
       }
     }
 

--- a/packages/github-service/src/lib/github-service-test.ts
+++ b/packages/github-service/src/lib/github-service-test.ts
@@ -47,6 +47,8 @@ export const makeGitHubServiceTest = (
         baseRefName: "main",
         headPushedAt: null,
         headSha: null,
+        createdAt: null,
+        isDraft: null,
       }),
     getPrStatusCheckDiagnostics: () => Effect.succeed([]),
     getPullRequestLifecycleStatus: () => Effect.succeed({ _tag: "open" }),

--- a/packages/github-service/src/lib/types.ts
+++ b/packages/github-service/src/lib/types.ts
@@ -62,7 +62,16 @@ export type PullRequestMergeability = "mergeable" | "conflicting" | "unknown"
 
 export type PullRequestCheckStatus = (
   | {
+      /** An execution has started and has not finished. */
       readonly _tag: "pending"
+      readonly terminalChecks: readonly TerminalPrStatusCheck[]
+    }
+  | {
+      /**
+       * A required status context has not reported an execution (GitHub
+       * EXPECTED). Distinct from a started Pending execution.
+       */
+      readonly _tag: "expected"
       readonly terminalChecks: readonly TerminalPrStatusCheck[]
     }
   | { readonly _tag: "no_checks" }
@@ -80,14 +89,23 @@ export type PullRequestCheckStatus = (
   readonly baseRefName: string | null
   /**
    * When the current PR head commit was pushed, or null when GitHub omitted a
-   * valid head-commit push time. Used only as a restart freshness signal.
+   * valid head-commit push time matching the current head.
    */
   readonly headPushedAt: Date | null
   /**
    * Current PR head commit OID, or null when GitHub omitted a valid head SHA.
-   * Used to scope automated-review rerun budgets.
+   * Used to scope automated-review rerun budgets and Check-Start timing.
    */
   readonly headSha: string | null
+  /**
+   * When the pull request was created, or null when GitHub omitted a valid
+   * creation time.
+   */
+  readonly createdAt: Date | null
+  /**
+   * Whether the pull request is a draft, or null when GitHub omitted the field.
+   */
+  readonly isDraft: boolean | null
 }
 
 export type GitHubIssueState = "OPEN" | "CLOSED"

--- a/packages/github-service/test/github-service.spec.ts
+++ b/packages/github-service/test/github-service.spec.ts
@@ -141,7 +141,7 @@ describe("GitHubService live implementation", () => {
 
   for (const [state, expected] of [
     ["PENDING", "pending"],
-    ["EXPECTED", "pending"],
+    ["EXPECTED", "expected"],
     ["SUCCESS", "succeeded"],
     ["FAILURE", "failed"],
     ["ERROR", "failed"],
@@ -181,6 +181,8 @@ describe("GitHubService live implementation", () => {
         baseRefName: "main",
         headPushedAt: null,
         headSha: "abc123",
+        createdAt: null,
+        isDraft: null,
       })
     })
   }
@@ -219,6 +221,8 @@ describe("GitHubService live implementation", () => {
       baseRefName: null,
       headPushedAt: null,
       headSha: null,
+      createdAt: null,
+      isDraft: null,
     })
     expect(
       await Effect.runPromise(
@@ -230,10 +234,12 @@ describe("GitHubService live implementation", () => {
       baseRefName: "develop",
       headPushedAt: null,
       headSha: null,
+      createdAt: null,
+      isDraft: null,
     })
   })
 
-  it("reads the current head commit pushedDate as headPushedAt", async () => {
+  it("reads PR creation, draft state, and current head commit pushedDate", async () => {
     let request: unknown
     const service = makeGitHubService({
       query: (input) => {
@@ -245,6 +251,8 @@ describe("GitHubService live implementation", () => {
                 {
                   state: "OPEN",
                   merged: false,
+                  isDraft: true,
+                  createdAt: "2026-07-17T11:00:00.000Z",
                   headRefOid: "abc123",
                   baseRefName: "main",
                   mergeable: "MERGEABLE",
@@ -277,11 +285,15 @@ describe("GitHubService live implementation", () => {
       baseRefName: "main",
       headPushedAt: new Date("2026-07-17T12:00:00.000Z"),
       headSha: "abc123",
+      createdAt: new Date("2026-07-17T11:00:00.000Z"),
+      isDraft: true,
     })
     expect(request).toMatchObject({
       repository: {
         pullRequests: {
           nodes: {
+            isDraft: true,
+            createdAt: true,
             commits: {
               __args: { last: 1 },
               nodes: {
@@ -365,6 +377,8 @@ describe("GitHubService live implementation", () => {
         baseRefName: "main",
         headPushedAt: null,
         headSha: "abc123",
+        createdAt: null,
+        isDraft: null,
       })
     }
   })
@@ -471,6 +485,8 @@ describe("GitHubService live implementation", () => {
       baseRefName: "main",
       headPushedAt: null,
       headSha: null,
+      createdAt: null,
+      isDraft: null,
     })
     expect(
       await Effect.runPromise(
@@ -483,6 +499,8 @@ describe("GitHubService live implementation", () => {
       baseRefName: "main",
       headPushedAt: null,
       headSha: null,
+      createdAt: null,
+      isDraft: null,
     })
   })
 
@@ -529,6 +547,8 @@ describe("GitHubService live implementation", () => {
       baseRefName: "main",
       headPushedAt: null,
       headSha: "sha-head",
+      createdAt: null,
+      isDraft: null,
       terminalChecks: [
         { externalId: "actions-job:100", name: "unit", outcome: "green" },
         { externalId: "actions-job:101", name: "lint", outcome: "red" },
@@ -578,6 +598,8 @@ describe("GitHubService live implementation", () => {
       baseRefName: "main",
       headPushedAt: null,
       headSha: "sha-head",
+      createdAt: null,
+      isDraft: null,
       terminalChecks: [
         { externalId: "actions-job:100", name: "unit", outcome: "green" },
       ],
@@ -621,6 +643,8 @@ describe("GitHubService live implementation", () => {
       baseRefName: "main",
       headPushedAt: null,
       headSha: "sha-head",
+      createdAt: null,
+      isDraft: null,
       terminalChecks: [
         { externalId: "actions-job:100", name: "lint", outcome: "red" },
         { externalId: "actions-job:101", name: "lint", outcome: "green" },
@@ -705,6 +729,8 @@ describe("GitHubService live implementation", () => {
       baseRefName: "main",
       headPushedAt: null,
       headSha: "sha-head",
+      createdAt: null,
+      isDraft: null,
       terminalChecks: [
         { externalId: "actions-job:200", name: "CI/lint", outcome: "red" },
       ],
@@ -806,6 +832,8 @@ describe("GitHubService live implementation", () => {
       baseRefName: "main",
       headPushedAt: null,
       headSha: "sha-head",
+      createdAt: null,
+      isDraft: null,
       terminalChecks: [
         {
           externalId: "actions-job:1001",
@@ -1020,6 +1048,8 @@ describe("GitHubService live implementation", () => {
       baseRefName: "main",
       headPushedAt: null,
       headSha: null,
+      createdAt: null,
+      isDraft: null,
     })
     expect(attempts).toBe(3)
   })

--- a/packages/issue-reconciler/test/issue-reconciler.spec.ts
+++ b/packages/issue-reconciler/test/issue-reconciler.spec.ts
@@ -175,6 +175,8 @@ const makeGitHubLayer = (
         baseRefName: "main",
         headPushedAt: null,
         headSha: null,
+        createdAt: null,
+        isDraft: null,
       }),
     getPrStatusCheckDiagnostics: () => Effect.succeed([]),
     getPullRequestLifecycleStatus: () =>

--- a/packages/work-item-lifecycle/src/lib/pr-status-checks.ts
+++ b/packages/work-item-lifecycle/src/lib/pr-status-checks.ts
@@ -35,20 +35,40 @@ export class PrStatusChecksUnresolvedError extends Schema.TaggedErrorClass<PrSta
   },
 ) {}
 
+/** Timing evidence from the GitHub PR check snapshot for Check-Start Anchors. */
+export type PrStatusCheckTimingEvidence = {
+  readonly createdAt: Date | null
+  readonly headSha: string | null
+  readonly headPushedAt: Date | null
+  readonly isDraft: boolean | null
+}
+
 export type PrStatusCheckResult =
-  | "pending"
-  | {
+  | ({
+      readonly _tag: "pending"
+    } & PrStatusCheckTimingEvidence)
+  | ({
+      readonly _tag: "expected"
+    } & PrStatusCheckTimingEvidence)
+  | ({
       readonly _tag: "no_checks"
-      readonly headPushedAt: Date | null
-    }
-  | "succeeded"
-  | "failed"
-  | "closed"
-  | "handoff_needed"
-  | {
+    } & PrStatusCheckTimingEvidence)
+  | ({
+      readonly _tag: "succeeded"
+    } & PrStatusCheckTimingEvidence)
+  | ({
+      readonly _tag: "failed"
+    } & PrStatusCheckTimingEvidence)
+  | ({
+      readonly _tag: "closed"
+    } & PrStatusCheckTimingEvidence)
+  | ({
+      readonly _tag: "handoff_needed"
+    } & PrStatusCheckTimingEvidence)
+  | ({
       readonly _tag: "conflict"
       readonly retiredCheckIds: readonly string[]
-    }
+    } & PrStatusCheckTimingEvidence)
 
 export type PrStatusCheckInvestigationResult =
   | { readonly _tag: "processed"; readonly handledCheckIds: readonly string[] }
@@ -176,6 +196,18 @@ const retireUnhandledRedChecks = (workItemId: string) =>
     )
   })
 
+const timingEvidence = (status: {
+  readonly createdAt: Date | null
+  readonly headSha: string | null
+  readonly headPushedAt: Date | null
+  readonly isDraft: boolean | null
+}): PrStatusCheckTimingEvidence => ({
+  createdAt: status.createdAt,
+  headSha: status.headSha,
+  headPushedAt: status.headPushedAt,
+  isDraft: status.isDraft,
+})
+
 export const watchPrStatusChecks = (context: LifecycleStepContext) =>
   Effect.gen(function* () {
     const { repository, branch } = yield* resolveContext(context)
@@ -184,8 +216,10 @@ export const watchPrStatusChecks = (context: LifecycleStepContext) =>
       { owner: repository.githubOwner, name: repository.githubRepo },
       branch,
     )
+    const evidence = timingEvidence(status)
     const terminalChecks =
       status._tag === "pending" ||
+      status._tag === "expected" ||
       status._tag === "succeeded" ||
       status._tag === "failed"
         ? status.terminalChecks
@@ -198,27 +232,58 @@ export const watchPrStatusChecks = (context: LifecycleStepContext) =>
     }
     const unhandled = yield* listUnhandledChecks(context.workItemId)
     if (status._tag === "closed") {
-      return "closed" satisfies PrStatusCheckResult
+      return {
+        _tag: "closed",
+        ...evidence,
+      } satisfies PrStatusCheckResult
     }
     if (status.mergeability === "conflicting") {
       return {
         _tag: "conflict",
         retiredCheckIds: unhandled.map((check) => check.id),
+        ...evidence,
       } satisfies PrStatusCheckResult
     }
     if (status.mergeability === "unknown") {
-      return "pending" satisfies PrStatusCheckResult
+      return {
+        _tag: "pending",
+        ...evidence,
+      } satisfies PrStatusCheckResult
     }
     if (unhandled.length > 0) {
-      return "handoff_needed" satisfies PrStatusCheckResult
+      return {
+        _tag: "handoff_needed",
+        ...evidence,
+      } satisfies PrStatusCheckResult
     }
     if (status._tag === "no_checks") {
       return {
         _tag: "no_checks",
-        headPushedAt: status.headPushedAt,
+        ...evidence,
       } satisfies PrStatusCheckResult
     }
-    return status._tag satisfies PrStatusCheckResult
+    if (status._tag === "expected") {
+      return {
+        _tag: "expected",
+        ...evidence,
+      } satisfies PrStatusCheckResult
+    }
+    if (status._tag === "pending") {
+      return {
+        _tag: "pending",
+        ...evidence,
+      } satisfies PrStatusCheckResult
+    }
+    if (status._tag === "failed") {
+      return {
+        _tag: "failed",
+        ...evidence,
+      } satisfies PrStatusCheckResult
+    }
+    return {
+      _tag: "succeeded",
+      ...evidence,
+    } satisfies PrStatusCheckResult
   })
 
 type ParsedInvestigationResult =

--- a/packages/work-item-lifecycle/src/lib/work-item-lifecycle.ts
+++ b/packages/work-item-lifecycle/src/lib/work-item-lifecycle.ts
@@ -247,6 +247,10 @@ type WorkItemRow = {
   readonly session_id: string | null
   readonly failure_code: string | null
   readonly failure_message: string | null
+  readonly check_start_anchor_at: number | null
+  readonly check_start_anchor_head_sha: string | null
+  readonly check_start_observed_head_sha: string | null
+  readonly check_start_observed_head_at: number | null
   readonly created_at: number
   readonly updated_at: number
 }
@@ -334,35 +338,57 @@ const WORK_ITEM_SELECT_COLUMNS = `id, repository_id, github_issue_number, issue_
                    review_variant, state, state_ready_at, paused, waiting_since, holds_worker_slot,
                    pause_before_step, worktree_path, starting_commit_oid, completion_summary, session_id,
                    github_pull_request_number, failure_code,
-                   failure_message, created_at, updated_at`
+                   failure_message, check_start_anchor_at, check_start_anchor_head_sha,
+                   check_start_observed_head_sha, check_start_observed_head_at,
+                   created_at, updated_at`
 
 const PR_STATUS_CHECKS_POLL_DELAY = Duration.seconds(30)
-const PR_STATUS_CHECKS_MIN_GREEN_WAIT = Duration.seconds(60)
-/**
- * When a resumed Work Item sees `no_checks` for a PR head that has been
- * unchanged at least this long, skip the normal grace and confirmation polls.
- * Intentionally longer than the normal 60s + 30s sequence.
- */
-const PR_STATUS_CHECKS_STALE_HEAD_NO_CHECK_WAIT = Duration.minutes(2)
-/** Stored on a green watch Step Run that requeues for one confirmation poll. */
-const PR_STATUS_CHECKS_GREEN_CONFIRMING = "pr_checks_green_confirming"
-/** Stored when handled red checks leave the aggregate failed for confirmation. */
-const PR_STATUS_CHECKS_FAILED_CONFIRMING = "pr_checks_failed_confirming"
+/** Catch-up window after the latest Check-Start Anchor before startup is complete. */
+export const CHECK_START_DEADLINE_MS = 90_000
 
-const isStaleNoChecksHead = (
-  headPushedAt: Date | null,
+/** Accept finite GitHub instants, including slight clock-skew futures. */
+const validInstantMs = (value: Date | null): number | null => {
+  if (value === null) {
+    return null
+  }
+  const ms = value.getTime()
+  if (!Number.isFinite(ms)) {
+    return null
+  }
+  return ms
+}
+
+const lastPrChangeMs = (input: {
+  readonly createdAt: Date | null
+  readonly headPushedAt: Date | null
+  readonly observedHeadAt: number | null
+  readonly nowMs: number
+}): number => {
+  const createdMs = validInstantMs(input.createdAt)
+  const pushedMs = validInstantMs(input.headPushedAt)
+  const pushOrObserved = pushedMs ?? input.observedHeadAt
+  if (createdMs !== null && pushOrObserved !== null) {
+    return Math.max(createdMs, pushOrObserved)
+  }
+  if (pushOrObserved !== null) {
+    return pushOrObserved
+  }
+  if (createdMs !== null) {
+    return createdMs
+  }
+  return input.nowMs
+}
+
+const pollDelayUntilDeadline = (
   nowMs: number,
-): boolean => {
-  if (headPushedAt === null) {
-    return false
+  deadlineMs: number,
+): Duration.Duration => {
+  const remaining = deadlineMs - nowMs
+  if (remaining <= 0) {
+    return PR_STATUS_CHECKS_POLL_DELAY
   }
-  const pushedMs = headPushedAt.getTime()
-  if (!Number.isFinite(pushedMs) || pushedMs > nowMs) {
-    return false
-  }
-  return (
-    nowMs - pushedMs >=
-    Duration.toMillis(PR_STATUS_CHECKS_STALE_HEAD_NO_CHECK_WAIT)
+  return Duration.millis(
+    Math.min(Duration.toMillis(PR_STATUS_CHECKS_POLL_DELAY), remaining),
   )
 }
 
@@ -1137,26 +1163,6 @@ export const makeWorkItemLifecycleLive = (
           return { ok: true as const }
         })
 
-      const previousWatchPollNote = (
-        workItemId: string,
-      ): Effect.Effect<string | null, WorkItemLifecycleDatabaseError> =>
-        Effect.gen(function* () {
-          const rows = (yield* sql
-            .unsafe(
-              `SELECT reason_message FROM step_run
-             WHERE work_item_id = ?
-               AND step = 'watch_pr_status_checks'
-               AND status = 'succeeded'
-             ORDER BY finished_at DESC, rowid DESC
-             LIMIT 1`,
-              [workItemId],
-            )
-            .pipe(Effect.mapError(toDatabaseError))) as readonly {
-            readonly reason_message: string | null
-          }[]
-          return rows[0]?.reason_message ?? null
-        })
-
       const mergeRevalidationCount = (
         workItemId: string,
       ): Effect.Effect<number, WorkItemLifecycleDatabaseError> =>
@@ -1267,10 +1273,100 @@ export const makeWorkItemLifecycleLive = (
             return steps.watchPrStatusChecks(context).pipe(
               Effect.flatMap((status) =>
                 Effect.gen(function* () {
-                  if (
-                    typeof status === "object" &&
-                    status._tag === "conflict"
+                  const now = yield* Clock.currentTimeMillis
+                  const rawHeadSha =
+                    "headSha" in status ? (status.headSha ?? null) : null
+                  const headSha =
+                    typeof rawHeadSha === "string" && rawHeadSha.trim() !== ""
+                      ? rawHeadSha
+                      : null
+                  const createdAt =
+                    "createdAt" in status ? (status.createdAt ?? null) : null
+                  const headPushedAt =
+                    "headPushedAt" in status
+                      ? (status.headPushedAt ?? null)
+                      : null
+                  let observedHeadSha = workItem.check_start_observed_head_sha
+                  let observedHeadAt = workItem.check_start_observed_head_at
+                  const pushedMs = validInstantMs(headPushedAt)
+                  if (headSha !== null) {
+                    if (observedHeadSha !== headSha) {
+                      observedHeadSha = headSha
+                      // First-observation fallback only when GitHub omits a
+                      // valid push time for this head.
+                      observedHeadAt = pushedMs === null ? now : null
+                    } else if (pushedMs !== null) {
+                      // Authoritative push evidence supersedes any earlier
+                      // observation fallback for the same head.
+                      observedHeadAt = null
+                    }
+                  } else if (
+                    observedHeadSha !== null &&
+                    workItem.check_start_anchor_head_sha !== null &&
+                    observedHeadSha !== workItem.check_start_anchor_head_sha
                   ) {
+                    observedHeadSha = null
+                    observedHeadAt = null
+                  }
+
+                  const lastChange = lastPrChangeMs({
+                    createdAt,
+                    headPushedAt,
+                    observedHeadAt: pushedMs === null ? observedHeadAt : null,
+                    nowMs: now,
+                  })
+
+                  let anchorAt = workItem.check_start_anchor_at
+                  let anchorHeadSha = workItem.check_start_anchor_head_sha
+                  const headChanged =
+                    headSha !== null &&
+                    anchorHeadSha !== null &&
+                    headSha !== anchorHeadSha
+                  if (headChanged) {
+                    // Replacement head must not inherit the prior head's anchor.
+                    anchorAt = lastChange
+                    anchorHeadSha = headSha
+                  } else if (anchorAt === null) {
+                    anchorAt = lastChange
+                    if (headSha !== null) {
+                      anchorHeadSha = headSha
+                    }
+                  } else {
+                    // Keep a conservative persisted anchor (e.g. migration
+                    // backfill); only move it forward for newer Last PR Change.
+                    if (lastChange > anchorAt) {
+                      anchorAt = lastChange
+                    }
+                    if (headSha !== null && anchorHeadSha === null) {
+                      anchorHeadSha = headSha
+                    }
+                  }
+
+                  yield* sql
+                    .unsafe(
+                      `UPDATE work_item
+                       SET check_start_anchor_at = ?,
+                           check_start_anchor_head_sha = ?,
+                           check_start_observed_head_sha = ?,
+                           check_start_observed_head_at = ?,
+                           updated_at = ?
+                       WHERE id = ?`,
+                      [
+                        anchorAt,
+                        anchorHeadSha,
+                        observedHeadSha,
+                        observedHeadAt,
+                        now,
+                        workItem.id,
+                      ],
+                    )
+                    .pipe(Effect.mapError(toDatabaseError))
+
+                  const deadlineMs = (anchorAt ?? now) + CHECK_START_DEADLINE_MS
+                  const pastDeadline = now >= deadlineMs
+                  const requeueDelay = pollDelayUntilDeadline(now, deadlineMs)
+
+                  if (status._tag === "conflict") {
                     return {
                       handledCheckIds: status.retiredCheckIds,
                       transition: {
@@ -1278,14 +1374,14 @@ export const makeWorkItemLifecycleLive = (
                       },
                     }
                   }
-                  if (status === "handoff_needed") {
+                  if (status._tag === "handoff_needed") {
                     return {
                       transition: {
                         nextState: "investigate_pr_status_checks" as const,
                       },
                     }
                   }
-                  if (status === "closed") {
+                  if (status._tag === "closed") {
                     return {
                       transition: {
                         nextState: "needs_human" as const,
@@ -1294,22 +1390,23 @@ export const makeWorkItemLifecycleLive = (
                       },
                     }
                   }
-                  if (status === "pending") {
+                  // Actual pending executions and unknown mergeability keep polling.
+                  if (status._tag === "pending") {
                     return {
                       transition: {
                         nextState: "watch_pr_status_checks" as const,
-                        delay: PR_STATUS_CHECKS_POLL_DELAY,
+                        delay: pastDeadline
+                          ? PR_STATUS_CHECKS_POLL_DELAY
+                          : requeueDelay,
                       },
                     }
                   }
-                  if (status === "failed") {
-                    const priorNote = yield* previousWatchPollNote(workItem.id)
-                    if (priorNote !== PR_STATUS_CHECKS_FAILED_CONFIRMING) {
+                  if (status._tag === "failed") {
+                    if (!pastDeadline) {
                       return {
-                        stepRunNote: PR_STATUS_CHECKS_FAILED_CONFIRMING,
                         transition: {
                           nextState: "watch_pr_status_checks" as const,
-                          delay: PR_STATUS_CHECKS_POLL_DELAY,
+                          delay: requeueDelay,
                         },
                       }
                     }
@@ -1318,46 +1415,24 @@ export const makeWorkItemLifecycleLive = (
                         "Manual fixing may be required. GitHub status checks remained failed without a new check execution to investigate. Please fix or rerun the checks on GitHub, then click Retry checks.",
                     })
                   }
-                  const isNoChecks =
-                    typeof status === "object" && status._tag === "no_checks"
-                  // no_checks: wait the grace before treating absence as green,
-                  // unless the PR head was already pushed long enough ago that a
-                  // harness restart should not re-run the full confirmation sequence.
-                  if (isNoChecks) {
-                    const now = yield* Clock.currentTimeMillis
-                    if (isStaleNoChecksHead(status.headPushedAt, now)) {
-                      return {
-                        transition: {
-                          nextState: "mark_pr_ready_for_review" as const,
-                        },
-                      }
-                    }
-                    const watchedMs = Math.max(0, now - workItem.state_ready_at)
-                    if (
-                      watchedMs <
-                      Duration.toMillis(PR_STATUS_CHECKS_MIN_GREEN_WAIT)
-                    ) {
+                  // no_checks, expected, and all-terminal success wait for the deadline.
+                  if (
+                    status._tag === "no_checks" ||
+                    status._tag === "expected" ||
+                    status._tag === "succeeded"
+                  ) {
+                    if (!pastDeadline) {
                       return {
                         transition: {
                           nextState: "watch_pr_status_checks" as const,
-                          delay: PR_STATUS_CHECKS_POLL_DELAY,
+                          delay: requeueDelay,
                         },
                       }
                     }
-                  }
-                  // succeeded (and no_checks after grace): require two consecutive
-                  // green polls so a brief SUCCESS cannot race into merge while a
-                  // second check is still starting.
-                  if (status === "succeeded" || isNoChecks) {
-                    const priorNote = yield* previousWatchPollNote(workItem.id)
-                    if (priorNote !== PR_STATUS_CHECKS_GREEN_CONFIRMING) {
-                      return {
-                        stepRunNote: PR_STATUS_CHECKS_GREEN_CONFIRMING,
-                        transition: {
-                          nextState: "watch_pr_status_checks" as const,
-                          delay: PR_STATUS_CHECKS_POLL_DELAY,
-                        },
-                      }
+                    return {
+                      transition: {
+                        nextState: "mark_pr_ready_for_review" as const,
+                      },
                     }
                   }
                   return {
@@ -3377,15 +3452,28 @@ export const makeWorkItemLifecycleLive = (
           .withTransaction(
             Effect.gen(function* () {
               if (recoverableStatusCheckFailure || retryableNeedsHumanHandoff) {
+                // Retryable unresolved-check failures may predate Check-Start
+                // Anchor columns; give them a conservative anchor before Watch.
                 yield* sql.unsafe(
                   `UPDATE work_item
                    SET state = ?,
                        state_ready_at = ?,
                        failure_code = NULL,
                        failure_message = NULL,
+                       check_start_anchor_at = CASE
+                         WHEN ? = 1 AND check_start_anchor_at IS NULL THEN ?
+                         ELSE check_start_anchor_at
+                       END,
                        updated_at = ?
                    WHERE id = ?`,
-                  [pendingStep, now, now, workItemId],
+                  [
+                    pendingStep,
+                    now,
+                    recoverableStatusCheckFailure ? 1 : 0,
+                    now,
+                    now,
+                    workItemId,
+                  ],
                 )
               }
 

--- a/packages/work-item-lifecycle/test/assess-changes-lifecycle.spec.ts
+++ b/packages/work-item-lifecycle/test/assess-changes-lifecycle.spec.ts
@@ -79,7 +79,14 @@ describe("Assess Changes lifecycle routes", () => {
         review: () => Effect.succeed({ _tag: "clean" as const }),
         commit: () => Effect.void,
         createPr: () => Effect.succeed(1),
-        watchPrStatusChecks: () => Effect.succeed("succeeded"),
+        watchPrStatusChecks: () =>
+          Effect.succeed({
+            _tag: "succeeded" as const,
+            createdAt: new Date(0),
+            headSha: "settled-head",
+            headPushedAt: new Date(0),
+            isDraft: true,
+          }),
         resolvePrMergeConflict: () => Effect.succeed({ _tag: "processed" }),
         investigatePrStatusChecks: () =>
           Effect.succeed({ _tag: "processed", handledCheckIds: [] }),
@@ -216,7 +223,14 @@ describe("Assess Changes lifecycle routes", () => {
         review: () => Effect.succeed({ _tag: "clean" as const }),
         commit: () => Effect.void,
         createPr: () => Effect.succeed(1),
-        watchPrStatusChecks: () => Effect.succeed("succeeded"),
+        watchPrStatusChecks: () =>
+          Effect.succeed({
+            _tag: "succeeded" as const,
+            createdAt: new Date(0),
+            headSha: "settled-head",
+            headPushedAt: new Date(0),
+            isDraft: true,
+          }),
         resolvePrMergeConflict: () => Effect.succeed({ _tag: "processed" }),
         investigatePrStatusChecks: () =>
           Effect.succeed({ _tag: "processed", handledCheckIds: [] }),
@@ -323,7 +337,14 @@ describe("Assess Changes lifecycle routes", () => {
         review: () => Effect.succeed({ _tag: "clean" as const }),
         commit: () => Effect.void,
         createPr: () => Effect.succeed(1),
-        watchPrStatusChecks: () => Effect.succeed("succeeded"),
+        watchPrStatusChecks: () =>
+          Effect.succeed({
+            _tag: "succeeded" as const,
+            createdAt: new Date(0),
+            headSha: "settled-head",
+            headPushedAt: new Date(0),
+            isDraft: true,
+          }),
         resolvePrMergeConflict: () => Effect.succeed({ _tag: "processed" }),
         investigatePrStatusChecks: () =>
           Effect.succeed({ _tag: "processed", handledCheckIds: [] }),
@@ -459,7 +480,14 @@ describe("Assess Changes lifecycle routes", () => {
           createPrCalls += 1
           return Effect.succeed(1)
         },
-        watchPrStatusChecks: () => Effect.succeed("succeeded"),
+        watchPrStatusChecks: () =>
+          Effect.succeed({
+            _tag: "succeeded" as const,
+            createdAt: new Date(0),
+            headSha: "settled-head",
+            headPushedAt: new Date(0),
+            isDraft: true,
+          }),
         resolvePrMergeConflict: () => Effect.succeed({ _tag: "processed" }),
         investigatePrStatusChecks: () =>
           Effect.succeed({ _tag: "processed", handledCheckIds: [] }),
@@ -617,7 +645,14 @@ describe("Assess Changes lifecycle routes", () => {
         review: () => Effect.succeed({ _tag: "clean" as const }),
         commit: () => Effect.void,
         createPr: () => Effect.succeed(1),
-        watchPrStatusChecks: () => Effect.succeed("succeeded"),
+        watchPrStatusChecks: () =>
+          Effect.succeed({
+            _tag: "succeeded" as const,
+            createdAt: new Date(0),
+            headSha: "settled-head",
+            headPushedAt: new Date(0),
+            isDraft: true,
+          }),
         resolvePrMergeConflict: () => Effect.succeed({ _tag: "processed" }),
         investigatePrStatusChecks: () =>
           Effect.succeed({ _tag: "processed", handledCheckIds: [] }),
@@ -727,7 +762,14 @@ describe("Assess Changes lifecycle routes", () => {
         review: () => Effect.succeed({ _tag: "clean" as const }),
         commit: () => Effect.void,
         createPr: () => Effect.succeed(1),
-        watchPrStatusChecks: () => Effect.succeed("succeeded"),
+        watchPrStatusChecks: () =>
+          Effect.succeed({
+            _tag: "succeeded" as const,
+            createdAt: new Date(0),
+            headSha: "settled-head",
+            headPushedAt: new Date(0),
+            isDraft: true,
+          }),
         resolvePrMergeConflict: () => Effect.succeed({ _tag: "processed" }),
         investigatePrStatusChecks: () =>
           Effect.succeed({ _tag: "processed", handledCheckIds: [] }),
@@ -845,7 +887,14 @@ describe("Assess Changes lifecycle routes", () => {
         review: () => Effect.succeed({ _tag: "clean" as const }),
         commit: () => Effect.die("commit must not run"),
         createPr: () => Effect.succeed(1),
-        watchPrStatusChecks: () => Effect.succeed("succeeded"),
+        watchPrStatusChecks: () =>
+          Effect.succeed({
+            _tag: "succeeded" as const,
+            createdAt: new Date(0),
+            headSha: "settled-head",
+            headPushedAt: new Date(0),
+            isDraft: true,
+          }),
         resolvePrMergeConflict: () => Effect.succeed({ _tag: "processed" }),
         investigatePrStatusChecks: () =>
           Effect.succeed({ _tag: "processed", handledCheckIds: [] }),
@@ -986,7 +1035,14 @@ describe("Assess Changes lifecycle routes", () => {
         review: () => Effect.succeed({ _tag: "clean" as const }),
         commit: () => Effect.void,
         createPr: () => Effect.succeed(1),
-        watchPrStatusChecks: () => Effect.succeed("succeeded"),
+        watchPrStatusChecks: () =>
+          Effect.succeed({
+            _tag: "succeeded" as const,
+            createdAt: new Date(0),
+            headSha: "settled-head",
+            headPushedAt: new Date(0),
+            isDraft: true,
+          }),
         resolvePrMergeConflict: () => Effect.succeed({ _tag: "processed" }),
         investigatePrStatusChecks: () =>
           Effect.succeed({ _tag: "processed", handledCheckIds: [] }),

--- a/packages/work-item-lifecycle/test/close-issue.spec.ts
+++ b/packages/work-item-lifecycle/test/close-issue.spec.ts
@@ -59,6 +59,8 @@ const unusedGithub = {
       baseRefName: "main",
       headPushedAt: null,
       headSha: null,
+      createdAt: null,
+      isDraft: null,
     }),
   getPrStatusCheckDiagnostics: () => Effect.succeed([]),
   getPullRequestLifecycleStatus: () =>

--- a/packages/work-item-lifecycle/test/count-committed-pull-requests.spec.ts
+++ b/packages/work-item-lifecycle/test/count-committed-pull-requests.spec.ts
@@ -24,7 +24,14 @@ const successfulSteps: LifecycleStepsShape = {
   review: () => Effect.succeed({ _tag: "clean" as const }),
   commit: () => Effect.void,
   createPr: () => Effect.succeed(101),
-  watchPrStatusChecks: () => Effect.succeed("succeeded"),
+  watchPrStatusChecks: () =>
+    Effect.succeed({
+      _tag: "succeeded" as const,
+      createdAt: new Date(0),
+      headSha: "settled-head",
+      headPushedAt: new Date(0),
+      isDraft: true,
+    }),
   resolvePrMergeConflict: () => Effect.succeed({ _tag: "processed" }),
   investigatePrStatusChecks: () =>
     Effect.succeed({ _tag: "processed", handledCheckIds: [] }),

--- a/packages/work-item-lifecycle/test/create-pr.spec.ts
+++ b/packages/work-item-lifecycle/test/create-pr.spec.ts
@@ -86,6 +86,8 @@ const stubGitHub = (
           baseRefName: "main",
           headPushedAt: null,
           headSha: null,
+          createdAt: null,
+          isDraft: null,
         }),
       getPrStatusCheckDiagnostics: () => Effect.succeed([]),
       getPullRequestLifecycleStatus: () =>

--- a/packages/work-item-lifecycle/test/mark-pr-ready-for-review.spec.ts
+++ b/packages/work-item-lifecycle/test/mark-pr-ready-for-review.spec.ts
@@ -49,6 +49,8 @@ describe("markPrReadyForReview", () => {
           baseRefName: "main",
           headPushedAt: null,
           headSha: null,
+          createdAt: null,
+          isDraft: null,
         }),
       getPrStatusCheckDiagnostics: () => Effect.succeed([]),
       getPullRequestLifecycleStatus: () =>
@@ -84,6 +86,8 @@ describe("markPrReadyForReview", () => {
           baseRefName: "main",
           headPushedAt: null,
           headSha: null,
+          createdAt: null,
+          isDraft: null,
         }),
       getPrStatusCheckDiagnostics: () => Effect.succeed([]),
       getPullRequestLifecycleStatus: () =>

--- a/packages/work-item-lifecycle/test/merge-pr.spec.ts
+++ b/packages/work-item-lifecycle/test/merge-pr.spec.ts
@@ -49,6 +49,8 @@ describe("mergePr", () => {
           baseRefName: "main",
           headPushedAt: null,
           headSha: null,
+          createdAt: null,
+          isDraft: null,
         }),
       getPrStatusCheckDiagnostics: () => Effect.succeed([]),
       getPullRequestLifecycleStatus: () =>
@@ -81,6 +83,8 @@ describe("mergePr", () => {
           baseRefName: "main",
           headPushedAt: null,
           headSha: null,
+          createdAt: null,
+          isDraft: null,
         }),
       getPrStatusCheckDiagnostics: () => Effect.succeed([]),
       getPullRequestLifecycleStatus: () =>

--- a/packages/work-item-lifecycle/test/pr-status-checks.spec.ts
+++ b/packages/work-item-lifecycle/test/pr-status-checks.spec.ts
@@ -34,6 +34,8 @@ const mergeable = {
   baseRefName: "main",
   headPushedAt: null,
   headSha: null,
+  createdAt: null,
+  isDraft: null,
 } as const
 
 const context: LifecycleStepContext = {
@@ -154,7 +156,7 @@ describe("PR status check steps", () => {
       }).pipe(Effect.provide(Layer.mergeAll(db, github, DatabaseTest))),
     )
 
-    expect(status).toBe("pending")
+    expect(status._tag).toBe("pending")
     expect(requestedBranch).toBe(`rfa/acme-widgets/42/${context.workItemId}`)
   })
 
@@ -182,6 +184,9 @@ describe("PR status check steps", () => {
     expect(status).toEqual({
       _tag: "no_checks",
       headPushedAt,
+      headSha: null,
+      createdAt: null,
+      isDraft: null,
     })
   })
 
@@ -207,7 +212,7 @@ describe("PR status check steps", () => {
       ),
     )
 
-    expect(status).toBe("handoff_needed")
+    expect(status._tag).toBe("handoff_needed")
   })
 
   it("prioritizes a merge conflict and identifies every completed unhandled check for retirement", async () => {
@@ -231,6 +236,8 @@ describe("PR status check steps", () => {
               baseRefName: "develop",
               headPushedAt: null,
               headSha: null,
+              createdAt: null,
+              isDraft: null,
               terminalChecks: [
                 { externalId: "checkrun:1", name: "lint", outcome: "red" },
                 { externalId: "checkrun:2", name: "review", outcome: "green" },
@@ -245,6 +252,10 @@ describe("PR status check steps", () => {
     expect(result.status).toEqual({
       _tag: "conflict",
       retiredCheckIds: result.rows.map((row) => row.id),
+      headPushedAt: null,
+      headSha: null,
+      createdAt: null,
+      isDraft: null,
     })
     expect(result.rows.every((row) => row.handled_at === null)).toBe(true)
   })
@@ -257,6 +268,8 @@ describe("PR status check steps", () => {
         baseRefName: "main",
         headPushedAt: null,
         headSha: null,
+        createdAt: null,
+        isDraft: null,
         terminalChecks: [
           { externalId: "checkrun:1", name: "review", outcome: "green" },
         ],
@@ -292,14 +305,17 @@ describe("PR status check steps", () => {
       }).pipe(Effect.provide(Layer.mergeAll(db, github, DatabaseTest))),
     )
 
-    expect(result).toEqual({ unknown: "pending", known: "handoff_needed" })
+    expect(result.unknown._tag).toBe("pending")
+    expect(result.known._tag).toBe("handoff_needed")
   })
 
   it("does not re-hand off already handled checks and reports aggregate success", async () => {
     const status = await Effect.runPromise(
       Effect.gen(function* () {
         yield* seedWorkItem
-        expect(yield* watchPrStatusChecks(context)).toBe("handoff_needed")
+        expect((yield* watchPrStatusChecks(context))._tag).toBe(
+          "handoff_needed",
+        )
         const sql = yield* SqlClient.SqlClient
         yield* sql.unsafe(
           `UPDATE pr_status_check SET handled_at = ? WHERE work_item_id = ?`,
@@ -323,7 +339,7 @@ describe("PR status check steps", () => {
       ),
     )
 
-    expect(status).toBe("succeeded")
+    expect(status._tag).toBe("succeeded")
   })
 
   it("hands off a new execution of the same check name", async () => {
@@ -363,7 +379,9 @@ describe("PR status check steps", () => {
     const second = await Effect.runPromise(
       Effect.gen(function* () {
         yield* seedWorkItem
-        expect(yield* watchPrStatusChecks(context)).toBe("handoff_needed")
+        expect((yield* watchPrStatusChecks(context))._tag).toBe(
+          "handoff_needed",
+        )
         const sql = yield* SqlClient.SqlClient
         yield* sql.unsafe(
           `UPDATE pr_status_check SET handled_at = ? WHERE work_item_id = ?`,
@@ -373,7 +391,7 @@ describe("PR status check steps", () => {
       }).pipe(Effect.provide(Layer.mergeAll(db, github, DatabaseTest))),
     )
 
-    expect(second).toBe("handoff_needed")
+    expect(second._tag).toBe("handoff_needed")
   })
 
   it("retires a failed execution after a manually rerun check makes the aggregate green", async () => {
@@ -413,7 +431,9 @@ describe("PR status check steps", () => {
     const result = await Effect.runPromise(
       Effect.gen(function* () {
         yield* seedWorkItem
-        expect(yield* watchPrStatusChecks(context)).toBe("handoff_needed")
+        expect((yield* watchPrStatusChecks(context))._tag).toBe(
+          "handoff_needed",
+        )
         const status = yield* watchPrStatusChecks(context)
         const sql = yield* SqlClient.SqlClient
         const rows = (yield* sql.unsafe(
@@ -430,7 +450,7 @@ describe("PR status check steps", () => {
       }).pipe(Effect.provide(Layer.mergeAll(db, github, DatabaseTest))),
     )
 
-    expect(result.status).toBe("handoff_needed")
+    expect(result.status._tag).toBe("handoff_needed")
     expect(result.rows).toEqual([
       { external_id: "checkrun:1", handled_at: expect.any(Number) },
       { external_id: "checkrun:2", handled_at: null },

--- a/packages/work-item-lifecycle/test/sync-needs-human-merge-handoffs.spec.ts
+++ b/packages/work-item-lifecycle/test/sync-needs-human-merge-handoffs.spec.ts
@@ -33,7 +33,14 @@ describe("syncNeedsHumanMergeHandoffs", () => {
     review: () => Effect.succeed({ _tag: "clean" as const }),
     commit: () => Effect.void,
     createPr: () => Effect.succeed(101),
-    watchPrStatusChecks: () => Effect.succeed("succeeded"),
+    watchPrStatusChecks: () =>
+      Effect.succeed({
+        _tag: "succeeded" as const,
+        createdAt: new Date(0),
+        headSha: "settled-head",
+        headPushedAt: new Date(0),
+        isDraft: true,
+      }),
     resolvePrMergeConflict: () => Effect.succeed({ _tag: "processed" }),
     investigatePrStatusChecks: () =>
       Effect.succeed({ _tag: "processed", handledCheckIds: [] }),
@@ -61,6 +68,8 @@ describe("syncNeedsHumanMergeHandoffs", () => {
           baseRefName: "main",
           headPushedAt: null,
           headSha: null,
+          createdAt: null,
+          isDraft: null,
         }),
       getPrStatusCheckDiagnostics: () => Effect.succeed([]),
       getPullRequestLifecycleStatus: () => Effect.succeed(status),
@@ -133,7 +142,7 @@ describe("syncNeedsHumanMergeHandoffs", () => {
       blockedBy: [],
     })
     const created = yield* lifecycle.implementNow(repository.id, 42)
-    for (let index = 0; index < 12; index += 1) {
+    for (let index = 0; index < 11; index += 1) {
       yield* makeQueuedJobsAvailable
       yield* claimAndRunPending
     }
@@ -174,7 +183,7 @@ describe("syncNeedsHumanMergeHandoffs", () => {
       blockedBy: [],
     })
     const created = yield* lifecycle.implementNow(repository.id, 42)
-    for (let index = 0; index < 13; index += 1) {
+    for (let index = 0; index < 12; index += 1) {
       yield* makeQueuedJobsAvailable
       yield* claimAndRunPending
     }

--- a/packages/work-item-lifecycle/test/work-item-lifecycle.spec.ts
+++ b/packages/work-item-lifecycle/test/work-item-lifecycle.spec.ts
@@ -1,6 +1,8 @@
+import { mkdtemp, rm } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
 import {
   Cause,
-  Clock,
   Deferred,
   Duration,
   Effect,
@@ -12,7 +14,7 @@ import {
 } from "effect"
 import { TestClock } from "effect/testing"
 import { SqlClient } from "effect/unstable/sql"
-import { DatabaseTest } from "@ready-for-agent/db/test"
+import { DatabaseTest, makeFileDatabaseTest } from "@ready-for-agent/db/test"
 import {
   DbService,
   DbServiceLive,
@@ -28,6 +30,7 @@ import { SqliteQueueServiceLive } from "@ready-for-agent/sqlite-queue-service"
 import {
   ActiveStepRunExistsError,
   BuildModelNotConfiguredError,
+  CHECK_START_DEADLINE_MS,
   CloseIssueEligibilityError,
   CommitOpenCodeError,
   CreatePrOpenCodeError,
@@ -59,6 +62,30 @@ import {
 import { describe, expect, it } from "bun:test"
 
 describe("WorkItemLifecycle", () => {
+  const settledTiming = {
+    createdAt: new Date(0),
+    headSha: "settled-head",
+    headPushedAt: new Date(0),
+    isDraft: false,
+  } as const
+
+  const watchResult = <
+    T extends
+      | "succeeded"
+      | "pending"
+      | "expected"
+      | "no_checks"
+      | "failed"
+      | "closed"
+      | "handoff_needed",
+  >(
+    tag: T,
+  ) =>
+    ({
+      _tag: tag,
+      ...settledTiming,
+    }) as const
+
   const successfulSteps: LifecycleStepsShape = {
     createWorktree: () =>
       Effect.succeed({
@@ -72,7 +99,7 @@ describe("WorkItemLifecycle", () => {
     review: () => Effect.succeed({ _tag: "clean" as const }),
     commit: () => Effect.void,
     createPr: () => Effect.succeed(101),
-    watchPrStatusChecks: () => Effect.succeed("succeeded"),
+    watchPrStatusChecks: () => Effect.succeed(watchResult("succeeded")),
     resolvePrMergeConflict: () => Effect.succeed({ _tag: "processed" }),
     investigatePrStatusChecks: () =>
       Effect.succeed({ _tag: "processed", handledCheckIds: [] }),
@@ -110,6 +137,17 @@ describe("WorkItemLifecycle", () => {
       Layer.provideMerge(DbServiceLive),
       Layer.provideMerge(SqliteQueueServiceLive),
       Layer.provideMerge(DatabaseTest),
+    )
+
+  const makeRestartTestLayer = (steps: LifecycleStepsShape, filename: string) =>
+    WorkItemLifecycleLive.pipe(
+      Layer.provideMerge(
+        Layer.succeed(LifecycleSteps, LifecycleSteps.of(steps)),
+      ),
+      Layer.provideMerge(DbServiceLive),
+      Layer.provideMerge(SqliteQueueServiceLive),
+      Layer.provideMerge(makeFileDatabaseTest(filename)),
+      Layer.provideMerge(TestClock.layer()),
     )
 
   const runWithSteps = <A, E>(
@@ -769,7 +807,7 @@ describe("WorkItemLifecycle", () => {
             repository.id,
             issue.githubIssueNumber,
           )
-          for (let i = 0; i < 14; i++) {
+          for (let i = 0; i < 13; i++) {
             yield* claimAndRun
           }
           expect((yield* lifecycle.getWorkItem(complete.id)).state).toBe(
@@ -830,7 +868,7 @@ describe("WorkItemLifecycle", () => {
             repository.id,
             issue.githubIssueNumber,
           )
-          for (let i = 0; i < 14; i++) {
+          for (let i = 0; i < 13; i++) {
             const sql = yield* SqlClient.SqlClient
             yield* sql.unsafe(`UPDATE job_queue SET available_at = 0`)
             const job = yield* queue.rawClaim(WORK_ITEM_LIFECYCLE_QUEUE)
@@ -1062,18 +1100,6 @@ describe("WorkItemLifecycle", () => {
       return result
     })
 
-    const allowPrChecksToAppear = (workItemId: string) =>
-      Effect.gen(function* () {
-        const sql = yield* SqlClient.SqlClient
-        yield* sql.unsafe(
-          `UPDATE work_item
-           SET state_ready_at = state_ready_at - 60000
-           WHERE id = ? AND state = 'watch_pr_status_checks'`,
-          [workItemId],
-        )
-        yield* sql.unsafe(`UPDATE job_queue SET available_at = 0`)
-      })
-
     const makeQueuedJobsAvailable = Effect.gen(function* () {
       const sql = yield* SqlClient.SqlClient
       yield* sql.unsafe(`UPDATE job_queue SET available_at = 0`)
@@ -1182,13 +1208,6 @@ describe("WorkItemLifecycle", () => {
             ])
           }
 
-          const firstGreen = yield* claimAndRunPending
-          expect(firstGreen._tag).toBe("processed")
-          if (firstGreen._tag === "processed") {
-            expect(firstGreen.workItem.state).toBe("watch_pr_status_checks")
-          }
-
-          yield* makeQueuedJobsAvailable
           const afterChecks = yield* claimAndRunPending
           expect(afterChecks._tag).toBe("processed")
           if (afterChecks._tag === "processed") {
@@ -1241,7 +1260,6 @@ describe("WorkItemLifecycle", () => {
               ["commit", "succeeded"],
               ["create_pr", "succeeded"],
               ["watch_pr_status_checks", "succeeded"],
-              ["watch_pr_status_checks", "succeeded"],
               ["mark_pr_ready_for_review", "succeeded"],
               ["decide_pr_merge", "succeeded"],
               ["merge_pr", "succeeded"],
@@ -1255,7 +1273,7 @@ describe("WorkItemLifecycle", () => {
 
           const final = yield* lifecycle.getWorkItem(created.id)
           expect(final.state).toBe("complete")
-          expect(final.stepRuns).toHaveLength(14)
+          expect(final.stepRuns).toHaveLength(13)
         }),
       ))
 
@@ -1272,9 +1290,10 @@ describe("WorkItemLifecycle", () => {
             return Effect.succeed({
               _tag: "conflict",
               retiredCheckIds: [],
+              ...settledTiming,
             })
           }
-          return Effect.succeed("succeeded")
+          return Effect.succeed(watchResult("succeeded"))
         },
         resolvePrMergeConflict: () => {
           resolveCalls += 1
@@ -1320,7 +1339,7 @@ describe("WorkItemLifecycle", () => {
             ],
           )
 
-          for (let index = 0; index < 12; index += 1) {
+          for (let index = 0; index < 11; index += 1) {
             yield* makeQueuedJobsAvailable
             yield* claimAndRunPending
           }
@@ -1392,7 +1411,7 @@ describe("WorkItemLifecycle", () => {
             repository.id,
             issue.githubIssueNumber,
           )
-          for (let index = 0; index < 13; index += 1) {
+          for (let index = 0; index < 12; index += 1) {
             yield* makeQueuedJobsAvailable
             yield* claimAndRunPending
           }
@@ -1431,7 +1450,7 @@ describe("WorkItemLifecycle", () => {
             repository.id,
             issue.githubIssueNumber,
           )
-          for (let index = 0; index < 13; index += 1) {
+          for (let index = 0; index < 12; index += 1) {
             yield* makeQueuedJobsAvailable
             yield* claimAndRunPending
           }
@@ -1478,7 +1497,7 @@ describe("WorkItemLifecycle", () => {
             issue.githubIssueNumber,
           )
 
-          for (let index = 0; index < 13; index += 1) {
+          for (let index = 0; index < 12; index += 1) {
             yield* makeQueuedJobsAvailable
             yield* claimAndRunPending
           }
@@ -1514,140 +1533,17 @@ describe("WorkItemLifecycle", () => {
       )
     })
 
-    it("keeps no_checks pending for 60 seconds before treating as green", () => {
+    it("keeps no_checks pending until the 90s Check-Start Deadline and caps the final poll delay", () => {
+      const anchorInstant = 1_008_000
       const steps: LifecycleStepsShape = {
         ...successfulSteps,
         watchPrStatusChecks: () =>
-          Effect.succeed({ _tag: "no_checks", headPushedAt: null }),
-      }
-
-      return runWithSteps(
-        steps,
-        Effect.gen(function* () {
-          const lifecycle = yield* WorkItemLifecycle
-          const sql = yield* SqlClient.SqlClient
-          const { repository, issue } = yield* seedActionableIssue
-          const created = yield* lifecycle.implementNow(
-            repository.id,
-            issue.githubIssueNumber,
-          )
-
-          for (let index = 0; index < 8; index += 1) {
-            yield* claimAndRunPending
-          }
-
-          const earlyEmpty = yield* claimAndRunPending
-          expect(earlyEmpty._tag).toBe("processed")
-          if (earlyEmpty._tag === "processed") {
-            expect(earlyEmpty.workItem.state).toBe("watch_pr_status_checks")
-            expect(earlyEmpty.workItem.stepRuns.at(-2)?.status).toBe(
-              "succeeded",
-            )
-            expect(earlyEmpty.workItem.stepRuns.at(-1)?.status).toBe("queued")
-          }
-
-          const delayed = (yield* sql.unsafe(
-            `SELECT available_at, created_at FROM job_queue`,
-          )) as readonly {
-            readonly available_at: number
-            readonly created_at: number
-          }[]
-          expect(delayed).toHaveLength(1)
-          expect(delayed[0]!.available_at - delayed[0]!.created_at).toBe(30_000)
-
-          const readyAt = (yield* sql.unsafe(
-            `SELECT state_ready_at FROM work_item WHERE id = ?`,
-            [created.id],
-          )) as readonly { readonly state_ready_at: number }[]
-          const watchStartedAt = readyAt[0]!.state_ready_at
-
-          yield* allowPrChecksToAppear(created.id)
-          const firstGreenAfterGrace = yield* claimAndRunPending
-          expect(firstGreenAfterGrace._tag).toBe("processed")
-          if (firstGreenAfterGrace._tag === "processed") {
-            expect(firstGreenAfterGrace.workItem.state).toBe(
-              "watch_pr_status_checks",
-            )
-          }
-
-          yield* sql.unsafe(
-            `UPDATE step_run
-             SET finished_at = ?
-             WHERE work_item_id = ?
-               AND step = 'watch_pr_status_checks'
-               AND status = 'succeeded'`,
-            [watchStartedAt, created.id],
-          )
-          yield* sql.unsafe(`UPDATE job_queue SET available_at = 0`)
-          const afterGrace = yield* claimAndRunPending
-          expect(afterGrace._tag).toBe("processed")
-          if (afterGrace._tag === "processed") {
-            expect(afterGrace.workItem.state).toBe("mark_pr_ready_for_review")
-            expect(afterGrace.workItem.stateReadyAt.getTime()).toBeGreaterThan(
-              watchStartedAt,
-            )
-          }
-        }),
-      )
-    })
-
-    it("advances stale no_checks immediately without grace or confirmation", () => {
-      const steps: LifecycleStepsShape = {
-        ...successfulSteps,
-        watchPrStatusChecks: () =>
-          Effect.gen(function* () {
-            const now = yield* Clock.currentTimeMillis
-            return {
-              _tag: "no_checks" as const,
-              headPushedAt: new Date(now - 120_000),
-              headSha: null,
-            }
-          }),
-      }
-
-      return Effect.runPromise(
-        Effect.scoped(
-          Effect.provide(
-            Effect.gen(function* () {
-              yield* TestClock.setTime(1_000_000)
-              const lifecycle = yield* WorkItemLifecycle
-              const { repository, issue } = yield* seedActionableIssue
-              yield* lifecycle.implementNow(
-                repository.id,
-                issue.githubIssueNumber,
-              )
-
-              for (let index = 0; index < 8; index += 1) {
-                yield* TestClock.adjust(1_000)
-                yield* claimAndRunPending
-              }
-
-              yield* TestClock.adjust(1_000)
-              const afterWatch = yield* claimAndRunPending
-              expect(afterWatch._tag).toBe("processed")
-              if (afterWatch._tag === "processed") {
-                expect(afterWatch.workItem.state).toBe(
-                  "mark_pr_ready_for_review",
-                )
-              }
-            }),
-            makeTestLayer(steps).pipe(Layer.provideMerge(TestClock.layer())),
-          ),
-        ),
-      )
-    })
-
-    it("keeps the conservative no_checks path when the head is younger than two minutes", () => {
-      const steps: LifecycleStepsShape = {
-        ...successfulSteps,
-        watchPrStatusChecks: () =>
-          Effect.gen(function* () {
-            const now = yield* Clock.currentTimeMillis
-            return {
-              _tag: "no_checks" as const,
-              headPushedAt: new Date(now - 119_999),
-              headSha: null,
-            }
+          Effect.succeed({
+            _tag: "no_checks" as const,
+            createdAt: new Date(anchorInstant),
+            headSha: "fresh-head",
+            headPushedAt: new Date(anchorInstant),
+            isDraft: false,
           }),
       }
 
@@ -1669,6 +1565,339 @@ describe("WorkItemLifecycle", () => {
                 yield* claimAndRunPending
               }
 
+              // First Watch poll lands at 1_008_000 after eight 1s steps + 1s.
+              yield* TestClock.setTime(anchorInstant)
+              const earlyEmpty = yield* claimAndRunPending
+              expect(earlyEmpty._tag).toBe("processed")
+              if (earlyEmpty._tag === "processed") {
+                expect(earlyEmpty.workItem.state).toBe("watch_pr_status_checks")
+              }
+
+              const firstDelay = (yield* sql.unsafe(
+                `SELECT available_at, created_at FROM job_queue`,
+              )) as readonly {
+                readonly available_at: number
+                readonly created_at: number
+              }[]
+              expect(firstDelay).toHaveLength(1)
+              expect(
+                firstDelay[0]!.available_at - firstDelay[0]!.created_at,
+              ).toBe(30_000)
+
+              const anchors = (yield* sql.unsafe(
+                `SELECT check_start_anchor_at, check_start_anchor_head_sha
+                 FROM work_item WHERE id = ?`,
+                [created.id],
+              )) as readonly {
+                readonly check_start_anchor_at: number | null
+                readonly check_start_anchor_head_sha: string | null
+              }[]
+              expect(anchors[0]?.check_start_anchor_head_sha).toBe("fresh-head")
+              expect(anchors[0]?.check_start_anchor_at).toBe(anchorInstant)
+
+              // Advance to 89_999 ms after the anchor — still before the deadline.
+              yield* TestClock.setTime(anchorInstant + 89_999)
+              yield* sql.unsafe(`UPDATE job_queue SET available_at = 0`)
+              const atBoundary = yield* claimAndRunPending
+              expect(atBoundary._tag).toBe("processed")
+              if (atBoundary._tag === "processed") {
+                expect(atBoundary.workItem.state).toBe("watch_pr_status_checks")
+              }
+              const finalDelay = (yield* sql.unsafe(
+                `SELECT available_at, created_at FROM job_queue`,
+              )) as readonly {
+                readonly available_at: number
+                readonly created_at: number
+              }[]
+              expect(finalDelay).toHaveLength(1)
+              expect(
+                finalDelay[0]!.available_at - finalDelay[0]!.created_at,
+              ).toBe(1)
+
+              // At exactly 90_000 ms after the anchor, no_checks may advance.
+              yield* TestClock.setTime(anchorInstant + CHECK_START_DEADLINE_MS)
+              yield* sql.unsafe(`UPDATE job_queue SET available_at = 0`)
+              const afterDeadline = yield* claimAndRunPending
+              expect(afterDeadline._tag).toBe("processed")
+              if (afterDeadline._tag === "processed") {
+                expect(afterDeadline.workItem.state).toBe(
+                  "mark_pr_ready_for_review",
+                )
+              }
+            }),
+            makeTestLayer(steps).pipe(Layer.provideMerge(TestClock.layer())),
+          ),
+        ),
+      )
+    })
+
+    it("uses first observation of an undated head as the durable Check-Start Anchor fallback", async () => {
+      const steps: LifecycleStepsShape = {
+        ...successfulSteps,
+        watchPrStatusChecks: () =>
+          Effect.succeed({
+            _tag: "no_checks" as const,
+            createdAt: new Date(0),
+            headSha: "undated-head",
+            headPushedAt: null,
+            isDraft: false,
+          }),
+      }
+
+      const root = await mkdtemp(join(tmpdir(), "rfa-check-start-restart-"))
+      const dbPath = join(root, "restart.db")
+      try {
+        const established = await Effect.runPromise(
+          Effect.scoped(
+            Effect.provide(
+              Effect.gen(function* () {
+                yield* TestClock.setTime(2_000_000)
+                const lifecycle = yield* WorkItemLifecycle
+                const sql = yield* SqlClient.SqlClient
+                const { repository, issue } = yield* seedActionableIssue
+                const created = yield* lifecycle.implementNow(
+                  repository.id,
+                  issue.githubIssueNumber,
+                )
+
+                for (let index = 0; index < 8; index += 1) {
+                  yield* TestClock.adjust(1_000)
+                  yield* claimAndRunPending
+                }
+
+                yield* TestClock.adjust(1_000)
+                const first = yield* claimAndRunPending
+                expect(first._tag).toBe("processed")
+                if (first._tag === "processed") {
+                  expect(first.workItem.state).toBe("watch_pr_status_checks")
+                }
+
+                const persisted = (yield* sql.unsafe(
+                  `SELECT check_start_anchor_at, check_start_observed_head_sha,
+                          check_start_observed_head_at
+                   FROM work_item WHERE id = ?`,
+                  [created.id],
+                )) as readonly {
+                  readonly check_start_anchor_at: number | null
+                  readonly check_start_observed_head_sha: string | null
+                  readonly check_start_observed_head_at: number | null
+                }[]
+                expect(persisted[0]?.check_start_observed_head_sha).toBe(
+                  "undated-head",
+                )
+                // Last PR Change is later of creation (epoch) and first observation.
+                expect(persisted[0]?.check_start_anchor_at).toBe(
+                  persisted[0]?.check_start_observed_head_at,
+                )
+                return {
+                  workItemId: created.id,
+                  anchorAt: persisted[0]!.check_start_anchor_at!,
+                }
+              }),
+              makeRestartTestLayer(steps, dbPath),
+            ),
+          ),
+        )
+
+        // Fresh services against the same file DB — no in-memory timing retained.
+        await Effect.runPromise(
+          Effect.scoped(
+            Effect.provide(
+              Effect.gen(function* () {
+                const lifecycle = yield* WorkItemLifecycle
+                const queue = yield* QueueService
+                const sql = yield* SqlClient.SqlClient
+
+                const persisted = (yield* sql.unsafe(
+                  `SELECT check_start_anchor_at, check_start_observed_head_sha,
+                          check_start_observed_head_at
+                   FROM work_item WHERE id = ?`,
+                  [established.workItemId],
+                )) as readonly {
+                  readonly check_start_anchor_at: number | null
+                  readonly check_start_observed_head_sha: string | null
+                  readonly check_start_observed_head_at: number | null
+                }[]
+                expect(persisted[0]?.check_start_anchor_at).toBe(
+                  established.anchorAt,
+                )
+                expect(persisted[0]?.check_start_observed_head_sha).toBe(
+                  "undated-head",
+                )
+
+                yield* sql.unsafe(`UPDATE job_queue SET available_at = 0`)
+                const claimed = yield* queue.rawClaim(WORK_ITEM_LIFECYCLE_QUEUE)
+                expect(Option.isSome(claimed)).toBe(true)
+                if (Option.isNone(claimed)) {
+                  return yield* Effect.die("expected queued watch")
+                }
+                yield* TestClock.setTime(
+                  established.anchorAt + CHECK_START_DEADLINE_MS - 1,
+                )
+                const stillWaiting = yield* lifecycle.runStep(
+                  (claimed.value.payload as { stepRunId: string }).stepRunId,
+                )
+                expect(stillWaiting._tag).toBe("processed")
+                if (stillWaiting._tag === "processed") {
+                  expect(stillWaiting.workItem.state).toBe(
+                    "watch_pr_status_checks",
+                  )
+                }
+
+                yield* sql.unsafe(`UPDATE job_queue SET available_at = 0`)
+                const claimed2 = yield* queue.rawClaim(
+                  WORK_ITEM_LIFECYCLE_QUEUE,
+                )
+                expect(Option.isSome(claimed2)).toBe(true)
+                if (Option.isNone(claimed2)) {
+                  return yield* Effect.die("expected queued watch")
+                }
+                yield* TestClock.setTime(
+                  established.anchorAt + CHECK_START_DEADLINE_MS,
+                )
+                const advanced = yield* lifecycle.runStep(
+                  (claimed2.value.payload as { stepRunId: string }).stepRunId,
+                )
+                expect(advanced._tag).toBe("processed")
+                if (advanced._tag === "processed") {
+                  expect(advanced.workItem.state).toBe(
+                    "mark_pr_ready_for_review",
+                  )
+                }
+              }),
+              makeRestartTestLayer(steps, dbPath),
+            ),
+          ),
+        )
+      } finally {
+        await rm(root, { recursive: true, force: true })
+      }
+    })
+
+    it("preserves a conservative persisted anchor when Last PR Change is older", () => {
+      const conservativeAnchor = 5_000_000
+      const steps: LifecycleStepsShape = {
+        ...successfulSteps,
+        watchPrStatusChecks: () =>
+          Effect.succeed({
+            _tag: "no_checks" as const,
+            createdAt: new Date(1_000_000),
+            headSha: "old-head",
+            headPushedAt: new Date(1_000_000),
+            isDraft: false,
+          }),
+      }
+
+      return Effect.runPromise(
+        Effect.scoped(
+          Effect.provide(
+            Effect.gen(function* () {
+              yield* TestClock.setTime(conservativeAnchor)
+              const lifecycle = yield* WorkItemLifecycle
+              const sql = yield* SqlClient.SqlClient
+              const { repository, issue } = yield* seedActionableIssue
+              const created = yield* lifecycle.implementNow(
+                repository.id,
+                issue.githubIssueNumber,
+              )
+
+              for (let index = 0; index < 8; index += 1) {
+                yield* TestClock.adjust(1_000)
+                yield* claimAndRunPending
+              }
+
+              // Simulate migration backfill: unfinished Work Item already has a
+              // conservative anchor with no bound head SHA.
+              yield* sql.unsafe(
+                `UPDATE work_item
+                 SET check_start_anchor_at = ?,
+                     check_start_anchor_head_sha = NULL,
+                     check_start_observed_head_sha = NULL,
+                     check_start_observed_head_at = NULL
+                 WHERE id = ?`,
+                [conservativeAnchor, created.id],
+              )
+
+              yield* TestClock.setTime(conservativeAnchor + 1_000)
+              yield* sql.unsafe(`UPDATE job_queue SET available_at = 0`)
+              const first = yield* claimAndRunPending
+              expect(first._tag).toBe("processed")
+              if (first._tag === "processed") {
+                expect(first.workItem.state).toBe("watch_pr_status_checks")
+              }
+
+              const persisted = (yield* sql.unsafe(
+                `SELECT check_start_anchor_at, check_start_anchor_head_sha
+                 FROM work_item WHERE id = ?`,
+                [created.id],
+              )) as readonly {
+                readonly check_start_anchor_at: number | null
+                readonly check_start_anchor_head_sha: string | null
+              }[]
+              expect(persisted[0]?.check_start_anchor_at).toBe(
+                conservativeAnchor,
+              )
+              expect(persisted[0]?.check_start_anchor_head_sha).toBe("old-head")
+
+              yield* TestClock.setTime(
+                conservativeAnchor + CHECK_START_DEADLINE_MS - 1,
+              )
+              yield* sql.unsafe(`UPDATE job_queue SET available_at = 0`)
+              const stillWaiting = yield* claimAndRunPending
+              expect(stillWaiting._tag).toBe("processed")
+              if (stillWaiting._tag === "processed") {
+                expect(stillWaiting.workItem.state).toBe(
+                  "watch_pr_status_checks",
+                )
+              }
+
+              yield* TestClock.setTime(
+                conservativeAnchor + CHECK_START_DEADLINE_MS,
+              )
+              yield* sql.unsafe(`UPDATE job_queue SET available_at = 0`)
+              const advanced = yield* claimAndRunPending
+              expect(advanced._tag).toBe("processed")
+              if (advanced._tag === "processed") {
+                expect(advanced.workItem.state).toBe("mark_pr_ready_for_review")
+              }
+            }),
+            makeTestLayer(steps).pipe(Layer.provideMerge(TestClock.layer())),
+          ),
+        ),
+      )
+    })
+
+    it("takes the later of PR creation and current-head push as Last PR Change", () => {
+      const steps: LifecycleStepsShape = {
+        ...successfulSteps,
+        watchPrStatusChecks: () =>
+          Effect.succeed({
+            _tag: "succeeded" as const,
+            createdAt: new Date(1_000_000),
+            headSha: "head-a",
+            headPushedAt: new Date(1_050_000),
+            isDraft: false,
+          }),
+      }
+
+      return Effect.runPromise(
+        Effect.scoped(
+          Effect.provide(
+            Effect.gen(function* () {
+              yield* TestClock.setTime(1_050_000)
+              const lifecycle = yield* WorkItemLifecycle
+              const sql = yield* SqlClient.SqlClient
+              const { repository, issue } = yield* seedActionableIssue
+              const created = yield* lifecycle.implementNow(
+                repository.id,
+                issue.githubIssueNumber,
+              )
+
+              for (let index = 0; index < 8; index += 1) {
+                yield* TestClock.adjust(1_000)
+                yield* claimAndRunPending
+              }
+
               yield* TestClock.adjust(1_000)
               const early = yield* claimAndRunPending
               expect(early._tag).toBe("processed")
@@ -1676,27 +1905,24 @@ describe("WorkItemLifecycle", () => {
                 expect(early.workItem.state).toBe("watch_pr_status_checks")
               }
 
-              const delayed = (yield* sql.unsafe(
-                `SELECT available_at, created_at FROM job_queue`,
-              )) as readonly {
-                readonly available_at: number
-                readonly created_at: number
-              }[]
-              expect(delayed).toHaveLength(1)
-              expect(delayed[0]!.available_at - delayed[0]!.created_at).toBe(
-                30_000,
-              )
+              const anchors = (yield* sql.unsafe(
+                `SELECT check_start_anchor_at FROM work_item WHERE id = ?`,
+                [created.id],
+              )) as readonly { readonly check_start_anchor_at: number | null }[]
+              expect(anchors[0]?.check_start_anchor_at).toBe(1_050_000)
 
-              yield* allowPrChecksToAppear(created.id)
-              yield* TestClock.adjust(1_000)
-              const confirming = yield* claimAndRunPending
-              expect(confirming._tag).toBe("processed")
-              if (confirming._tag === "processed") {
-                expect(confirming.workItem.state).toBe("watch_pr_status_checks")
+              yield* TestClock.setTime(1_050_000 + 89_999)
+              yield* sql.unsafe(`UPDATE job_queue SET available_at = 0`)
+              const stillWaiting = yield* claimAndRunPending
+              expect(stillWaiting._tag).toBe("processed")
+              if (stillWaiting._tag === "processed") {
+                expect(stillWaiting.workItem.state).toBe(
+                  "watch_pr_status_checks",
+                )
               }
 
+              yield* TestClock.setTime(1_050_000 + CHECK_START_DEADLINE_MS)
               yield* sql.unsafe(`UPDATE job_queue SET available_at = 0`)
-              yield* TestClock.adjust(1_000)
               const ready = yield* claimAndRunPending
               expect(ready._tag).toBe("processed")
               if (ready._tag === "processed") {
@@ -1709,17 +1935,231 @@ describe("WorkItemLifecycle", () => {
       )
     })
 
-    it("does not use a future headPushedAt for the stale no_checks shortcut", () => {
+    it("honors a GitHub push time slightly ahead of the harness clock", () => {
+      const harnessNow = 1_000_000
+      const githubPushAt = harnessNow + 5_000
       const steps: LifecycleStepsShape = {
         ...successfulSteps,
         watchPrStatusChecks: () =>
-          Effect.gen(function* () {
-            const now = yield* Clock.currentTimeMillis
-            return {
-              _tag: "no_checks" as const,
-              headPushedAt: new Date(now + 1),
-              headSha: null,
-            }
+          Effect.succeed({
+            _tag: "no_checks" as const,
+            createdAt: new Date(harnessNow - 60_000),
+            headSha: "skew-head",
+            headPushedAt: new Date(githubPushAt),
+            isDraft: false,
+          }),
+      }
+
+      return Effect.runPromise(
+        Effect.scoped(
+          Effect.provide(
+            Effect.gen(function* () {
+              yield* TestClock.setTime(harnessNow)
+              const lifecycle = yield* WorkItemLifecycle
+              const sql = yield* SqlClient.SqlClient
+              const { repository, issue } = yield* seedActionableIssue
+              const created = yield* lifecycle.implementNow(
+                repository.id,
+                issue.githubIssueNumber,
+              )
+
+              for (let index = 0; index < 8; index += 1) {
+                yield* TestClock.adjust(1_000)
+                yield* claimAndRunPending
+              }
+
+              yield* TestClock.setTime(harnessNow + 8_000)
+              yield* sql.unsafe(`UPDATE job_queue SET available_at = 0`)
+              const first = yield* claimAndRunPending
+              expect(first._tag).toBe("processed")
+              if (first._tag === "processed") {
+                expect(first.workItem.state).toBe("watch_pr_status_checks")
+              }
+
+              const anchors = (yield* sql.unsafe(
+                `SELECT check_start_anchor_at FROM work_item WHERE id = ?`,
+                [created.id],
+              )) as readonly { readonly check_start_anchor_at: number | null }[]
+              expect(anchors[0]?.check_start_anchor_at).toBe(githubPushAt)
+
+              // Still before githubPushAt + 90s even though harness has advanced past push.
+              yield* TestClock.setTime(githubPushAt + 89_999)
+              yield* sql.unsafe(`UPDATE job_queue SET available_at = 0`)
+              const stillWaiting = yield* claimAndRunPending
+              expect(stillWaiting._tag).toBe("processed")
+              if (stillWaiting._tag === "processed") {
+                expect(stillWaiting.workItem.state).toBe(
+                  "watch_pr_status_checks",
+                )
+              }
+
+              yield* TestClock.setTime(githubPushAt + CHECK_START_DEADLINE_MS)
+              yield* sql.unsafe(`UPDATE job_queue SET available_at = 0`)
+              const ready = yield* claimAndRunPending
+              expect(ready._tag).toBe("processed")
+              if (ready._tag === "processed") {
+                expect(ready.workItem.state).toBe("mark_pr_ready_for_review")
+              }
+            }),
+            makeTestLayer(steps).pipe(Layer.provideMerge(TestClock.layer())),
+          ),
+        ),
+      )
+    })
+
+    it("does not restart the deadline when a pushed head later omits push time", () => {
+      const snapshots = [
+        {
+          _tag: "no_checks" as const,
+          createdAt: new Date(1_000_000),
+          headSha: "head-a",
+          headPushedAt: new Date(1_050_000),
+          isDraft: false,
+        },
+        {
+          _tag: "no_checks" as const,
+          createdAt: new Date(1_000_000),
+          headSha: "head-a",
+          headPushedAt: null,
+          isDraft: false,
+        },
+      ]
+      let index = 0
+      const steps: LifecycleStepsShape = {
+        ...successfulSteps,
+        watchPrStatusChecks: () =>
+          Effect.succeed(snapshots[Math.min(index++, snapshots.length - 1)]!),
+      }
+
+      return Effect.runPromise(
+        Effect.scoped(
+          Effect.provide(
+            Effect.gen(function* () {
+              yield* TestClock.setTime(1_050_000)
+              const lifecycle = yield* WorkItemLifecycle
+              const sql = yield* SqlClient.SqlClient
+              const { repository, issue } = yield* seedActionableIssue
+              const created = yield* lifecycle.implementNow(
+                repository.id,
+                issue.githubIssueNumber,
+              )
+
+              for (let index = 0; index < 8; index += 1) {
+                yield* TestClock.adjust(1_000)
+                yield* claimAndRunPending
+              }
+
+              yield* TestClock.adjust(1_000)
+              const first = yield* claimAndRunPending
+              expect(first._tag).toBe("processed")
+              if (first._tag === "processed") {
+                expect(first.workItem.state).toBe("watch_pr_status_checks")
+              }
+
+              const afterPush = (yield* sql.unsafe(
+                `SELECT check_start_anchor_at, check_start_observed_head_at
+                 FROM work_item WHERE id = ?`,
+                [created.id],
+              )) as readonly {
+                readonly check_start_anchor_at: number | null
+                readonly check_start_observed_head_at: number | null
+              }[]
+              expect(afterPush[0]?.check_start_anchor_at).toBe(1_050_000)
+              expect(afterPush[0]?.check_start_observed_head_at).toBeNull()
+
+              // Later observation still has the same head but no push time.
+              yield* TestClock.setTime(1_080_000)
+              yield* sql.unsafe(`UPDATE job_queue SET available_at = 0`)
+              const second = yield* claimAndRunPending
+              expect(second._tag).toBe("processed")
+              if (second._tag === "processed") {
+                expect(second.workItem.state).toBe("watch_pr_status_checks")
+              }
+
+              const afterOmit = (yield* sql.unsafe(
+                `SELECT check_start_anchor_at, check_start_observed_head_at
+                 FROM work_item WHERE id = ?`,
+                [created.id],
+              )) as readonly {
+                readonly check_start_anchor_at: number | null
+                readonly check_start_observed_head_at: number | null
+              }[]
+              expect(afterOmit[0]?.check_start_anchor_at).toBe(1_050_000)
+              // No new observation fallback is recorded for an already-pushed head.
+              expect(afterOmit[0]?.check_start_observed_head_at).toBeNull()
+            }),
+            makeTestLayer(steps).pipe(Layer.provideMerge(TestClock.layer())),
+          ),
+        ),
+      )
+    })
+
+    it("keeps actual pending checks polling after the Check-Start Deadline", () => {
+      const steps: LifecycleStepsShape = {
+        ...successfulSteps,
+        watchPrStatusChecks: () =>
+          Effect.succeed({
+            _tag: "pending" as const,
+            createdAt: new Date(0),
+            headSha: "pending-head",
+            headPushedAt: new Date(0),
+            isDraft: false,
+          }),
+      }
+
+      return Effect.runPromise(
+        Effect.scoped(
+          Effect.provide(
+            Effect.gen(function* () {
+              yield* TestClock.setTime(1_000_000)
+              const lifecycle = yield* WorkItemLifecycle
+              const sql = yield* SqlClient.SqlClient
+              const { repository, issue } = yield* seedActionableIssue
+              yield* lifecycle.implementNow(
+                repository.id,
+                issue.githubIssueNumber,
+              )
+
+              for (let index = 0; index < 8; index += 1) {
+                yield* TestClock.adjust(1_000)
+                yield* claimAndRunPending
+              }
+
+              yield* TestClock.adjust(1_000)
+              const afterDeadline = yield* claimAndRunPending
+              expect(afterDeadline._tag).toBe("processed")
+              if (afterDeadline._tag === "processed") {
+                expect(afterDeadline.workItem.state).toBe(
+                  "watch_pr_status_checks",
+                )
+              }
+              const delayed = (yield* sql.unsafe(
+                `SELECT available_at, created_at FROM job_queue`,
+              )) as readonly {
+                readonly available_at: number
+                readonly created_at: number
+              }[]
+              expect(delayed).toHaveLength(1)
+              expect(delayed[0]!.available_at - delayed[0]!.created_at).toBe(
+                30_000,
+              )
+            }),
+            makeTestLayer(steps).pipe(Layer.provideMerge(TestClock.layer())),
+          ),
+        ),
+      )
+    })
+
+    it("stops blocking on Expected checks at the Check-Start Deadline", () => {
+      const steps: LifecycleStepsShape = {
+        ...successfulSteps,
+        watchPrStatusChecks: () =>
+          Effect.succeed({
+            _tag: "expected" as const,
+            createdAt: new Date(0),
+            headSha: "expected-head",
+            headPushedAt: new Date(0),
+            isDraft: false,
           }),
       }
 
@@ -1741,10 +2181,12 @@ describe("WorkItemLifecycle", () => {
               }
 
               yield* TestClock.adjust(1_000)
-              const early = yield* claimAndRunPending
-              expect(early._tag).toBe("processed")
-              if (early._tag === "processed") {
-                expect(early.workItem.state).toBe("watch_pr_status_checks")
+              const afterDeadline = yield* claimAndRunPending
+              expect(afterDeadline._tag).toBe("processed")
+              if (afterDeadline._tag === "processed") {
+                expect(afterDeadline.workItem.state).toBe(
+                  "mark_pr_ready_for_review",
+                )
               }
             }),
             makeTestLayer(steps).pipe(Layer.provideMerge(TestClock.layer())),
@@ -1754,12 +2196,17 @@ describe("WorkItemLifecycle", () => {
     })
 
     it("rechecks pending PR checks after 30 seconds and hands failed checks to a human when requested", () => {
-      const statuses = ["pending", "handoff_needed"] as const
+      const statuses = [
+        watchResult("pending"),
+        watchResult("handoff_needed"),
+      ] as const
       let statusIndex = 0
       const steps: LifecycleStepsShape = {
         ...successfulSteps,
         watchPrStatusChecks: () =>
-          Effect.succeed(statuses[statusIndex++] ?? "handoff_needed"),
+          Effect.succeed(
+            statuses[statusIndex++] ?? watchResult("handoff_needed"),
+          ),
         investigatePrStatusChecks: () =>
           Effect.succeed({
             _tag: "needs_human",
@@ -1917,7 +2364,8 @@ describe("WorkItemLifecycle", () => {
         "Automated review rerun limit reached (3) for Claude Code Review; inspect or run the review manually, then Retry checks."
       const steps: LifecycleStepsShape = {
         ...successfulSteps,
-        watchPrStatusChecks: () => Effect.succeed("handoff_needed"),
+        watchPrStatusChecks: () =>
+          Effect.succeed(watchResult("handoff_needed")),
         investigatePrStatusChecks: () =>
           Effect.succeed({
             _tag: "needs_human",
@@ -1981,7 +2429,8 @@ describe("WorkItemLifecycle", () => {
       const checkId = "psc-active-review"
       const steps: LifecycleStepsShape = {
         ...successfulSteps,
-        watchPrStatusChecks: () => Effect.succeed("handoff_needed"),
+        watchPrStatusChecks: () =>
+          Effect.succeed(watchResult("handoff_needed")),
         investigatePrStatusChecks: () =>
           Effect.succeed({
             _tag: "waiting",
@@ -2052,7 +2501,11 @@ describe("WorkItemLifecycle", () => {
       const steps: LifecycleStepsShape = {
         ...successfulSteps,
         watchPrStatusChecks: () =>
-          Effect.succeed({ _tag: "conflict", retiredCheckIds: [checkId] }),
+          Effect.succeed({
+            _tag: "conflict",
+            retiredCheckIds: [checkId],
+            ...settledTiming,
+          }),
         resolvePrMergeConflict: () => Effect.succeed({ _tag: "processed" }),
       }
 
@@ -2111,7 +2564,11 @@ describe("WorkItemLifecycle", () => {
       const steps: LifecycleStepsShape = {
         ...successfulSteps,
         watchPrStatusChecks: () =>
-          Effect.succeed({ _tag: "conflict", retiredCheckIds: [] }),
+          Effect.succeed({
+            _tag: "conflict",
+            retiredCheckIds: [],
+            ...settledTiming,
+          }),
         resolvePrMergeConflict: () =>
           Effect.succeed({
             _tag: "needs_human",
@@ -2144,7 +2601,8 @@ describe("WorkItemLifecycle", () => {
       const checkId = "psc-transition-rollback"
       const steps: LifecycleStepsShape = {
         ...successfulSteps,
-        watchPrStatusChecks: () => Effect.succeed("handoff_needed"),
+        watchPrStatusChecks: () =>
+          Effect.succeed(watchResult("handoff_needed")),
         investigatePrStatusChecks: () =>
           Effect.succeed({
             _tag: "needs_human",
@@ -2208,18 +2666,19 @@ describe("WorkItemLifecycle", () => {
 
     it("batches unhandled green results while aggregate is pending and waits for handoff before Mark PR Ready", () => {
       const watchStatuses = [
-        "handoff_needed",
-        "pending",
-        "handoff_needed",
-        "succeeded",
-        "succeeded",
+        watchResult("handoff_needed"),
+        watchResult("pending"),
+        watchResult("handoff_needed"),
+        watchResult("succeeded"),
       ] as const
       let watchIndex = 0
       let investigations = 0
       const steps: LifecycleStepsShape = {
         ...successfulSteps,
         watchPrStatusChecks: () =>
-          Effect.succeed(watchStatuses[watchIndex++] ?? "succeeded"),
+          Effect.succeed(
+            watchStatuses[watchIndex++] ?? watchResult("succeeded"),
+          ),
         investigatePrStatusChecks: () => {
           investigations += 1
           return Effect.succeed({
@@ -2284,13 +2743,6 @@ describe("WorkItemLifecycle", () => {
           expect(investigations).toBe(2)
 
           yield* sql.unsafe(`UPDATE job_queue SET available_at = 0`)
-          const firstGreen = yield* claimAndRunPending
-          expect(firstGreen._tag).toBe("processed")
-          if (firstGreen._tag === "processed") {
-            expect(firstGreen.workItem.state).toBe("watch_pr_status_checks")
-          }
-
-          yield* sql.unsafe(`UPDATE job_queue SET available_at = 0`)
           const ready = yield* claimAndRunPending
           expect(ready._tag).toBe("processed")
           if (ready._tag === "processed") {
@@ -2306,7 +2758,8 @@ describe("WorkItemLifecycle", () => {
         "Manual fixing may be required. ActionLint failed twice on GitHub 503; restart did not help. Please fix or rerun the checks on GitHub, then click Retry checks."
       const steps: LifecycleStepsShape = {
         ...successfulSteps,
-        watchPrStatusChecks: () => Effect.succeed("handoff_needed"),
+        watchPrStatusChecks: () =>
+          Effect.succeed(watchResult("handoff_needed")),
         investigatePrStatusChecks: () =>
           Effect.fail(
             new PrStatusChecksUnresolvedError({ message: failureMessage }),
@@ -2380,112 +2833,113 @@ describe("WorkItemLifecycle", () => {
       )
     })
 
-    it("requires consecutive aggregate-failed polls before stopping retryably", () => {
-      const statuses = [
-        "failed",
-        "pending",
-        "failed",
-        "failed",
-        "succeeded",
-        "succeeded",
-      ] as const
+    it("fails retryably at the Check-Start Deadline when aggregate stays failed with no unhandled execution", () => {
+      const anchorInstant = 1_008_000
+      const tags = ["failed", "failed", "succeeded"] as const
       let statusIndex = 0
       const steps: LifecycleStepsShape = {
         ...successfulSteps,
-        watchPrStatusChecks: () =>
-          Effect.succeed(statuses[statusIndex++] ?? "failed"),
+        watchPrStatusChecks: () => {
+          const tag = tags[statusIndex++] ?? "failed"
+          if (tag === "succeeded") {
+            return Effect.succeed(watchResult("succeeded"))
+          }
+          return Effect.succeed({
+            _tag: tag,
+            createdAt: new Date(anchorInstant),
+            headSha: "failed-head",
+            headPushedAt: new Date(anchorInstant),
+            isDraft: false,
+          })
+        },
       }
 
-      return runWithSteps(
-        steps,
-        Effect.gen(function* () {
-          const sql = yield* SqlClient.SqlClient
-          const lifecycle = yield* WorkItemLifecycle
-          const { repository, issue } = yield* seedActionableIssue
-          const created = yield* lifecycle.implementNow(
-            repository.id,
-            issue.githubIssueNumber,
-          )
+      return Effect.runPromise(
+        Effect.scoped(
+          Effect.provide(
+            Effect.gen(function* () {
+              yield* TestClock.setTime(1_000_000)
+              const sql = yield* SqlClient.SqlClient
+              const lifecycle = yield* WorkItemLifecycle
+              const { repository, issue } = yield* seedActionableIssue
+              const created = yield* lifecycle.implementNow(
+                repository.id,
+                issue.githubIssueNumber,
+              )
 
-          for (let index = 0; index < 8; index += 1) {
-            yield* claimAndRunPending
-          }
+              for (let index = 0; index < 8; index += 1) {
+                yield* TestClock.adjust(1_000)
+                yield* claimAndRunPending
+              }
 
-          const confirming = yield* claimAndRunPending
-          expect(confirming._tag).toBe("processed")
-          if (confirming._tag === "processed") {
-            expect(confirming.workItem.state).toBe("watch_pr_status_checks")
-          }
+              // First failed poll establishes the anchor and requeues until deadline.
+              yield* TestClock.setTime(anchorInstant)
+              const beforeDeadline = yield* claimAndRunPending
+              expect(beforeDeadline._tag).toBe("processed")
+              if (beforeDeadline._tag === "processed") {
+                expect(beforeDeadline.workItem.state).toBe(
+                  "watch_pr_status_checks",
+                )
+              }
 
-          const delayed = (yield* sql.unsafe(
-            `SELECT available_at, created_at FROM job_queue`,
-          )) as readonly {
-            readonly available_at: number
-            readonly created_at: number
-          }[]
-          expect(delayed).toHaveLength(1)
-          expect(delayed[0]!.available_at - delayed[0]!.created_at).toBe(30_000)
+              const delayed = (yield* sql.unsafe(
+                `SELECT available_at, created_at FROM job_queue`,
+              )) as readonly {
+                readonly available_at: number
+                readonly created_at: number
+              }[]
+              expect(delayed).toHaveLength(1)
+              expect(delayed[0]!.available_at - delayed[0]!.created_at).toBe(
+                30_000,
+              )
 
-          yield* sql.unsafe(`UPDATE job_queue SET available_at = 0`)
-          const pending = yield* claimAndRunPending
-          expect(pending._tag).toBe("processed")
-          if (pending._tag === "processed") {
-            expect(pending.workItem.state).toBe("watch_pr_status_checks")
-          }
+              yield* TestClock.setTime(anchorInstant + CHECK_START_DEADLINE_MS)
+              yield* sql.unsafe(`UPDATE job_queue SET available_at = 0`)
+              const stopped = yield* claimAndRunPending
+              expect(stopped._tag).toBe("processed")
+              if (stopped._tag === "processed") {
+                expect(stopped.workItem.state).toBe("watch_pr_status_checks")
+                expect(stopped.workItem.failureCode).toBeNull()
+                expect(stopped.workItem.failureMessage).toBeNull()
+                expect(stopped.workItem.holdsWorkerSlot).toBe(false)
+                expect(stopped.workItem.stepRuns.at(-1)?.status).toBe("failed")
+                expect(stopped.workItem.stepRuns.at(-1)?.reasonCode).toBe(
+                  STEP_RUN_REASON.prStatusChecksUnresolved,
+                )
+                expect(
+                  stopped.workItem.stepRuns.at(-1)?.reasonMessage,
+                ).toContain(
+                  "fix or rerun the checks on GitHub, then click Retry checks",
+                )
+              }
 
-          yield* sql.unsafe(`UPDATE job_queue SET available_at = 0`)
-          const reconfirming = yield* claimAndRunPending
-          expect(reconfirming._tag).toBe("processed")
-          if (reconfirming._tag === "processed") {
-            expect(reconfirming.workItem.state).toBe("watch_pr_status_checks")
-          }
+              const jobs = (yield* sql.unsafe(
+                `SELECT id FROM job_queue WHERE job_attempts < job_retry_limit`,
+              )) as readonly { readonly id: string }[]
+              expect(jobs).toHaveLength(0)
 
-          yield* sql.unsafe(`UPDATE job_queue SET available_at = 0`)
-          const stopped = yield* claimAndRunPending
-          expect(stopped._tag).toBe("processed")
-          if (stopped._tag === "processed") {
-            expect(stopped.workItem.state).toBe("watch_pr_status_checks")
-            expect(stopped.workItem.failureCode).toBeNull()
-            expect(stopped.workItem.failureMessage).toBeNull()
-            expect(stopped.workItem.holdsWorkerSlot).toBe(false)
-            expect(stopped.workItem.stepRuns.at(-1)?.status).toBe("failed")
-            expect(stopped.workItem.stepRuns.at(-1)?.reasonCode).toBe(
-              STEP_RUN_REASON.prStatusChecksUnresolved,
-            )
-            expect(stopped.workItem.stepRuns.at(-1)?.reasonMessage).toContain(
-              "fix or rerun the checks on GitHub, then click Retry checks",
-            )
-          }
+              const retried = yield* lifecycle.retry(created.id)
+              expect(retried.state).toBe("watch_pr_status_checks")
+              expect(retried.stepRuns.at(-1)?.status).toBe("queued")
 
-          const jobs = (yield* sql.unsafe(
-            `SELECT id FROM job_queue WHERE job_attempts < job_retry_limit`,
-          )) as readonly { readonly id: string }[]
-          expect(jobs).toHaveLength(0)
-
-          const retried = yield* lifecycle.retry(created.id)
-          expect(retried.state).toBe("watch_pr_status_checks")
-          expect(retried.stepRuns.at(-1)?.status).toBe("queued")
-
-          const firstGreen = yield* claimAndRunPending
-          expect(firstGreen._tag).toBe("processed")
-          if (firstGreen._tag === "processed") {
-            expect(firstGreen.workItem.state).toBe("watch_pr_status_checks")
-          }
-
-          yield* sql.unsafe(`UPDATE job_queue SET available_at = 0`)
-          const ready = yield* claimAndRunPending
-          expect(ready._tag).toBe("processed")
-          if (ready._tag === "processed") {
-            expect(ready.workItem.state).toBe("mark_pr_ready_for_review")
-          }
-        }),
+              yield* TestClock.adjust(1_000)
+              const ready = yield* claimAndRunPending
+              expect(ready._tag).toBe("processed")
+              if (ready._tag === "processed") {
+                expect(ready.workItem.state).toBe("mark_pr_ready_for_review")
+              }
+            }),
+            makeTestLayer(steps).pipe(Layer.provideMerge(TestClock.layer())),
+          ),
+        ),
       )
     })
 
     it("returns to delayed Watch after PROCESSED investigation when OpenCode took action", () => {
       const steps: LifecycleStepsShape = {
         ...successfulSteps,
-        watchPrStatusChecks: () => Effect.succeed("handoff_needed"),
+        watchPrStatusChecks: () =>
+          Effect.succeed(watchResult("handoff_needed")),
         investigatePrStatusChecks: () =>
           Effect.succeed({
             _tag: "processed" as const,
@@ -2534,7 +2988,7 @@ describe("WorkItemLifecycle", () => {
     it("stops polling when the PR is closed without merging", () => {
       const steps: LifecycleStepsShape = {
         ...successfulSteps,
-        watchPrStatusChecks: () => Effect.succeed("closed"),
+        watchPrStatusChecks: () => Effect.succeed(watchResult("closed")),
       }
 
       return runWithSteps(
@@ -2599,7 +3053,7 @@ describe("WorkItemLifecycle", () => {
         },
         watchPrStatusChecks: (context) => {
           seen.push(context)
-          return Effect.succeed("succeeded")
+          return Effect.succeed(watchResult("succeeded"))
         },
         resolvePrMergeConflict: () => Effect.succeed({ _tag: "processed" }),
         investigatePrStatusChecks: () =>
@@ -2641,12 +3095,12 @@ describe("WorkItemLifecycle", () => {
           })
 
           yield* lifecycle.implementNow(repository.id, issue.githubIssueNumber)
-          for (let index = 0; index < 14; index += 1) {
+          for (let index = 0; index < 13; index += 1) {
             yield* makeQueuedJobsAvailable
             yield* claimAndRunPending
           }
 
-          expect(seen).toHaveLength(14)
+          expect(seen).toHaveLength(13)
           expect(seen[0]!.worktreePath).toBeNull()
           expect(seen[0]!.sessionId).toBeNull()
           expect(seen[0]!.model).toBe("anthropic/claude-sonnet-4-5")
@@ -2692,8 +3146,6 @@ describe("WorkItemLifecycle", () => {
           expect(seen[11]!.sessionId).toBe("ses_recorded")
           expect(seen[12]!.worktreePath).toBe("/tmp/worktrees/recorded")
           expect(seen[12]!.sessionId).toBe("ses_recorded")
-          expect(seen[13]!.worktreePath).toBe("/tmp/worktrees/recorded")
-          expect(seen[13]!.sessionId).toBe("ses_recorded")
         }),
       )
     })
@@ -2718,7 +3170,7 @@ describe("WorkItemLifecycle", () => {
             repository.id,
             issue.githubIssueNumber,
           )
-          for (let index = 0; index < 12; index += 1) {
+          for (let index = 0; index < 11; index += 1) {
             yield* makeQueuedJobsAvailable
             yield* claimAndRunPending
           }
@@ -2752,7 +3204,7 @@ describe("WorkItemLifecycle", () => {
             repository.id,
             issue.githubIssueNumber,
           )
-          for (let index = 0; index < 12; index += 1) {
+          for (let index = 0; index < 11; index += 1) {
             yield* makeQueuedJobsAvailable
             yield* claimAndRunPending
           }
@@ -2814,7 +3266,7 @@ describe("WorkItemLifecycle", () => {
             repository.id,
             issue.githubIssueNumber,
           )
-          for (let index = 0; index < 12; index += 1) {
+          for (let index = 0; index < 11; index += 1) {
             yield* makeQueuedJobsAvailable
             yield* claimAndRunPending
           }
@@ -2854,7 +3306,7 @@ describe("WorkItemLifecycle", () => {
             repository.id,
             issue.githubIssueNumber,
           )
-          for (let index = 0; index < 12; index += 1) {
+          for (let index = 0; index < 11; index += 1) {
             yield* makeQueuedJobsAvailable
             yield* claimAndRunPending
           }
@@ -2889,7 +3341,7 @@ describe("WorkItemLifecycle", () => {
           const lifecycle = yield* WorkItemLifecycle
           const { repository, issue } = yield* seedActionableIssue
           yield* lifecycle.implementNow(repository.id, issue.githubIssueNumber)
-          for (let index = 0; index < 12; index += 1) {
+          for (let index = 0; index < 11; index += 1) {
             yield* makeQueuedJobsAvailable
             yield* claimAndRunPending
           }
@@ -2926,7 +3378,7 @@ describe("WorkItemLifecycle", () => {
             repository.id,
             issue.githubIssueNumber,
           )
-          for (let index = 0; index < 12; index += 1) {
+          for (let index = 0; index < 11; index += 1) {
             yield* makeQueuedJobsAvailable
             yield* claimAndRunPending
           }


### PR DESCRIPTION
## Summary

- Replace overlapping Watch PR Status Checks timing heuristics with a durable Check-Start Anchor and 90-second deadline derived from Last PR Change (PR creation vs current-head push, with first-observation fallback).
- Distinguish GitHub `EXPECTED` from `PENDING`, expose PR timing/draft evidence on the check snapshot, and migrate existing Work Items (including retryable unresolved-check failures) with conservative anchors.
- Remove the old no-check grace, stale-head shortcut, and green/failed confirmation polls; cover exact deadline boundaries, capped polling, and restart reconstruction.

Closes #382

## Test plan

- [x] `work-item-lifecycle` unit/lifecycle tests (deadline boundaries, fallback, restart, conservative migration anchor)
- [x] `github-service` mapping tests for EXPECTED vs PENDING and snapshot fields
- [x] `db` migration tests for Check-Start Anchor backfill
- [x] Pre-commit / `nx affected` lint, typecheck, and test