### PR TITLE
feat(work-item-lifecycle): anchor replacement-producing status check handoffs

### DIFF
--- a/packages/work-item-lifecycle/src/lib/pr-status-checks.ts
+++ b/packages/work-item-lifecycle/src/lib/pr-status-checks.ts
@@ -72,7 +72,16 @@ export type PrStatusCheckResult =
 
 export type PrStatusCheckInvestigationResult =
   | { readonly _tag: "processed"; readonly handledCheckIds: readonly string[] }
-  | { readonly _tag: "waiting"; readonly handledCheckIds: readonly string[] }
+  | {
+      readonly _tag: "checks_triggered"
+      readonly handledCheckIds: readonly string[]
+      /**
+       * True when investigate already persisted the Check-Start Anchor at the
+       * trigger event (for example a successful authorized review rerun). False
+       * when lifecycle must record the anchor at step completion.
+       */
+      readonly checkStartAnchorRecorded: boolean
+    }
   | {
       readonly _tag: "needs_human"
       readonly reason: string
@@ -288,7 +297,7 @@ export const watchPrStatusChecks = (context: LifecycleStepContext) =>
 
 type ParsedInvestigationResult =
   | "processed"
-  | "waiting"
+  | "checks_triggered"
   | { readonly _tag: "needs_human"; readonly reason: string }
   | { readonly _tag: "failed"; readonly reason: string }
   | {
@@ -316,8 +325,8 @@ export const parseInvestigationResult = (
   if (/^READY_FOR_AGENT_RESULT:\s*PROCESSED$/i.test(finalLine)) {
     return "processed"
   }
-  if (/^READY_FOR_AGENT_RESULT:\s*WAITING$/i.test(finalLine)) {
-    return "waiting"
+  if (/^READY_FOR_AGENT_RESULT:\s*CHECKS_TRIGGERED$/i.test(finalLine)) {
+    return "checks_triggered"
   }
   const rerunReview = finalLine.match(
     /^READY_FOR_AGENT_RESULT:\s*RERUN_REVIEW\s*:\s*(\d+)(?:\s+(.+))?$/i,
@@ -402,15 +411,34 @@ const reserveAutomatedReviewRerun = (
     return { _tag: "reserved" as const, id }
   })
 
-const completeAutomatedReviewRerun = (id: string) =>
+/** Mark the permit complete and record the Check-Start Anchor together. */
+const completeAuthorizedReviewRerun = (
+  permitId: string,
+  workItemId: string,
+  headSha: string,
+) =>
   Effect.gen(function* () {
     const sql = yield* SqlClient.SqlClient
     const now = yield* Clock.currentTimeMillis
-    yield* sql.unsafe(
-      `UPDATE automated_review_rerun
-       SET status = 'completed', updated_at = ?
-       WHERE id = ?`,
-      [now, id],
+    yield* sql.withTransaction(
+      Effect.gen(function* () {
+        yield* sql.unsafe(
+          `UPDATE automated_review_rerun
+           SET status = 'completed', updated_at = ?
+           WHERE id = ?`,
+          [now, permitId],
+        )
+        // Anchor must be durable as soon as the GitHub rerun succeeds so a
+        // crash before step completion cannot drop the catch-up window.
+        yield* sql.unsafe(
+          `UPDATE work_item
+           SET check_start_anchor_at = ?,
+               check_start_anchor_head_sha = ?,
+               updated_at = ?
+           WHERE id = ?`,
+          [now, headSha, now, workItemId],
+        )
+      }),
     )
   })
 
@@ -488,12 +516,12 @@ const buildInvestigationWorkPrompt = (
       'Do not assume an automated review exists merely because CI is present. Workflow or job names alone (including names containing "review" or "PR Review") are not positive review evidence. Positive evidence requires an executed reviewer job or step, or a comment from a recognized automated reviewer; ordinary CI, repository configuration, and generic bot activity are not review evidence.',
       "A skipped workflow or job with no executed reviewer steps and no recognized automated-review comment is not an incomplete review and is not review evidence. Treat it as not applicable: there is no review output to process.",
       "If no relevant automated-review run or comment exists, that is a normal no-op and does not require proof that review automation is unconfigured. Do not request a review workflow rerun solely because a skipped reviewer produced no comment.",
-      "Use provider-specific progress artifacts as evidence of incompleteness. Strong evidence can include a finished banner combined with unchecked substantive review tasks, a remaining working spinner, and no final findings or synthesis. Do not treat arbitrary Markdown checkboxes in unrelated pull-request comments as an automated-review progress list.",
+      "Once an automated-review check is terminal, its Automated Review Output is final: do not wait for later comments. A successful terminal review with no relevant comment means no feedback and must not be rerun.",
+      "Use provider-specific progress artifacts as evidence of incompleteness only when a positively identified review comment is present but visibly incomplete. Strong evidence can include a finished banner combined with unchecked substantive review tasks, a remaining working spinner, and no final findings or synthesis. Do not treat arbitrary Markdown checkboxes in unrelated pull-request comments as an automated-review progress list.",
       "Correlate the latest relevant comment with the latest relevant run attempt. Do not rerun because of a stale incomplete comment when a newer attempt completed its review successfully.",
-      "If the latest review attempt is still active, leave it alone and do not start a duplicate. Unless this handoff produced another replacement execution or left red checks unresolved, report WAITING in the verdict turn so the review can be polled again.",
-      "A terminal review attempt is incomplete only when positive review evidence shows it produced no relevant review comment or its latest relevant comment remains visibly partial. When that is true, request a whole-review workflow rerun in the verdict turn (even when the run concluded success). Do not call GitHub workflow rerun APIs yourself; the harness authorizes and executes reruns. Do not use a failed-jobs-only rerun for a technically successful run.",
+      "Present, positively identified, visibly incomplete Automated Review Output requires a whole-review workflow rerun in the verdict turn (even when the run concluded success). Do not call GitHub workflow rerun APIs yourself; the harness authorizes and executes reruns. Do not use a failed-jobs-only rerun for a technically successful run.",
       "Requesting a terminal incomplete review rerun is required recovery, not optional feedback handling. Report FAILED for a technical inability to inspect the relevant review state. Report NEEDS_HUMAN only when evidence shows that an operator must perform or decide the required action.",
-      "For a genuinely completed latest review, address worthwhile feedback. A completed review with no worthwhile feedback still needs no changes or rerun.",
+      "For a genuinely completed latest review, address worthwhile feedback. A completed review with no worthwhile feedback, or a successful terminal review with no relevant comment, still needs no changes or rerun.",
       "If review feedback requires changes, verify them, commit them, and push the commit to the existing PR branch.",
     )
   }
@@ -511,15 +539,15 @@ const buildInvestigationVerdictPrompt = (): string =>
     "Based only on the PR status-check work you just did in this session, report the outcome.",
     "Do not make further code changes unless required to answer accurately.",
     "Reply with exactly one machine-readable result line (and optional brief prose before it):",
+    "READY_FOR_AGENT_RESULT: CHECKS_TRIGGERED",
+    "Use CHECKS_TRIGGERED when you completed an action expected to create replacement check executions (for example a commit and push, or successfully restarting failed checks).",
     "READY_FOR_AGENT_RESULT: PROCESSED",
-    "Use PROCESSED only when you took an action expected to produce new check executions or a replacement execution (for example a commit and push, or restarting failed checks), or when the handoff was green-only and either no relevant automated-review run or comment existed (including a skipped reviewer with no review output) or a genuinely completed review had nothing to address.",
-    "Do not report PROCESSED for a terminal incomplete review that still needs a whole-workflow rerun. Request the rerun instead. A replacement-producing action takes precedence over WAITING in a mixed handoff.",
-    "When positive review evidence shows a terminal incomplete automated review that needs a whole-workflow rerun, do not call GitHub yourself. Report the workflow run id (and optional workflow name) so the harness can authorize and execute the rerun:",
+    "Use PROCESSED when the handoff is handled and no replacement execution is expected: for example a green-only handoff with no relevant automated-review run or comment (including a skipped reviewer with no review output), a successful terminal review with no relevant comment (no feedback), or a genuinely completed review that had nothing to address.",
+    "Do not report PROCESSED for a present, positively identified, visibly incomplete automated review that still needs a whole-workflow rerun. Request the rerun instead.",
+    "When positive review evidence shows present, positively identified, visibly incomplete Automated Review Output that needs a whole-workflow rerun, do not call GitHub yourself. Report the workflow run id (and optional workflow name) so the harness can authorize and execute the rerun:",
     "READY_FOR_AGENT_RESULT: RERUN_REVIEW: <workflow_run_id>",
     "READY_FOR_AGENT_RESULT: RERUN_REVIEW: <workflow_run_id> <workflow_name>",
-    "If positive review evidence exists, the latest review attempt is still active, you took no replacement-producing action, and no red checks remain unresolved, report:",
-    "READY_FOR_AGENT_RESULT: WAITING",
-    "If this handoff contained red checks and you made no commit, push, check restart, or other action capable of producing a new execution, leaving the PR red, you must not report PROCESSED. Report:",
+    "If this handoff contained red checks and you made no commit, push, check restart, or other action capable of producing a new execution, leaving the PR red, you must not report PROCESSED or CHECKS_TRIGGERED. Report:",
     "READY_FOR_AGENT_RESULT: FAILED: <concise reason>",
     "Also use FAILED when a technical or observability failure prevented you from determining the relevant review state.",
     "Use NEEDS_HUMAN only when evidence shows that an operator must perform or decide a required action:",
@@ -642,7 +670,7 @@ export const investigatePrStatusChecks = (context: LifecycleStepContext) =>
               ? Effect.fail(
                   new PrStatusChecksOpenCodeError({
                     message:
-                      "OpenCode did not report PROCESSED, WAITING, RERUN_REVIEW, FAILED, or NEEDS_HUMAN",
+                      "OpenCode did not report CHECKS_TRIGGERED, PROCESSED, RERUN_REVIEW, FAILED, or NEEDS_HUMAN",
                   }),
                 )
               : Effect.succeed(result)
@@ -682,10 +710,11 @@ export const investigatePrStatusChecks = (context: LifecycleStepContext) =>
         handledCheckIds,
       } satisfies PrStatusCheckInvestigationResult
     }
-    if (investigation === "waiting") {
+    if (investigation === "checks_triggered") {
       return {
-        _tag: "waiting",
-        handledCheckIds: [],
+        _tag: "checks_triggered",
+        handledCheckIds,
+        checkStartAnchorRecorded: false,
       } satisfies PrStatusCheckInvestigationResult
     }
     if (
@@ -754,10 +783,15 @@ export const investigatePrStatusChecks = (context: LifecycleStepContext) =>
           message: `Manual fixing may be required. ${detail}. Please fix or rerun the checks on GitHub, then click Retry checks.`,
         })
       }
-      yield* completeAutomatedReviewRerun(permit.id)
+      yield* completeAuthorizedReviewRerun(
+        permit.id,
+        context.workItemId,
+        headSha,
+      )
       return {
-        _tag: "processed",
+        _tag: "checks_triggered",
         handledCheckIds,
+        checkStartAnchorRecorded: true,
       } satisfies PrStatusCheckInvestigationResult
     }
     if (

--- a/packages/work-item-lifecycle/src/lib/work-item-lifecycle.ts
+++ b/packages/work-item-lifecycle/src/lib/work-item-lifecycle.ts
@@ -1195,6 +1195,7 @@ export const makeWorkItemLifecycleLive = (
           readonly sessionId?: string
           readonly githubPullRequestNumber?: number
           readonly handledCheckIds?: readonly string[]
+          readonly refreshCheckStartAnchor?: boolean
           readonly stepRunReasonCode?: StepRunReasonCode
           readonly stepRunNote?: string
           readonly transition?: {
@@ -1460,19 +1461,35 @@ export const makeWorkItemLifecycleLive = (
             )
           case "investigate_pr_status_checks":
             return steps.investigatePrStatusChecks(context).pipe(
-              Effect.map((result) => ({
-                handledCheckIds: result.handledCheckIds,
-                transition:
-                  result._tag === "processed" || result._tag === "waiting"
-                    ? {
-                        nextState: "watch_pr_status_checks" as const,
-                        delay: PR_STATUS_CHECKS_POLL_DELAY,
-                      }
-                    : {
-                        nextState: "needs_human" as const,
-                        reason: result.reason,
-                      },
-              })),
+              Effect.map((result) => {
+                if (result._tag === "checks_triggered") {
+                  return {
+                    handledCheckIds: result.handledCheckIds,
+                    // Do not overwrite an anchor already recorded at the
+                    // trigger event (authorized review rerun API success).
+                    refreshCheckStartAnchor: !result.checkStartAnchorRecorded,
+                    transition: {
+                      nextState: "watch_pr_status_checks" as const,
+                      delay: PR_STATUS_CHECKS_POLL_DELAY,
+                    },
+                  }
+                }
+                if (result._tag === "processed") {
+                  return {
+                    handledCheckIds: result.handledCheckIds,
+                    transition: {
+                      nextState: "watch_pr_status_checks" as const,
+                    },
+                  }
+                }
+                return {
+                  handledCheckIds: result.handledCheckIds,
+                  transition: {
+                    nextState: "needs_human" as const,
+                    reason: result.reason,
+                  },
+                }
+              }),
             )
           case "mark_pr_ready_for_review":
             return steps.markPrReadyForReview(context).pipe(Effect.as({}))
@@ -1582,6 +1599,7 @@ export const makeWorkItemLifecycleLive = (
           readonly sessionId?: string
           readonly githubPullRequestNumber?: number
           readonly handledCheckIds?: readonly string[]
+          readonly refreshCheckStartAnchor?: boolean
           readonly stepRunReasonCode?: StepRunReasonCode
           readonly stepRunNote?: string
           readonly transition?: {
@@ -1650,6 +1668,16 @@ export const makeWorkItemLifecycleLive = (
                        SET handled_at = ?, handled_by_step_run_id = ?, updated_at = ?
                        WHERE id = ? AND work_item_id = ? AND handled_at IS NULL`,
                     [now, stepRun.id, now, checkId, workItem.id],
+                  )
+                }
+
+                if (output.refreshCheckStartAnchor === true) {
+                  yield* sql.unsafe(
+                    `UPDATE work_item
+                     SET check_start_anchor_at = ?,
+                         updated_at = ?
+                     WHERE id = ?`,
+                    [now, now, workItem.id],
                   )
                 }
 

--- a/packages/work-item-lifecycle/test/pr-status-checks.spec.ts
+++ b/packages/work-item-lifecycle/test/pr-status-checks.spec.ts
@@ -523,7 +523,7 @@ describe("PR status check steps", () => {
             ),
             keymaxxer,
             opencodeWith(
-              ["fixed and pushed", "READY_FOR_AGENT_RESULT: PROCESSED"],
+              ["fixed and pushed", "READY_FOR_AGENT_RESULT: CHECKS_TRIGGERED"],
               (prompt, sessionId) => {
                 expect(sessionId).toBe("ses_implement")
                 prompts.push(prompt)
@@ -535,7 +535,10 @@ describe("PR status check steps", () => {
       ),
     )
 
-    expect(result.investigation._tag).toBe("processed")
+    expect(result.investigation._tag).toBe("checks_triggered")
+    if (result.investigation._tag === "checks_triggered") {
+      expect(result.investigation.checkStartAnchorRecorded).toBe(false)
+    }
     expect(result.investigation.handledCheckIds).toHaveLength(2)
     expect(result.rows.every((row) => row.handled_at === null)).toBe(true)
     expect(prompts).toHaveLength(2)
@@ -560,12 +563,13 @@ describe("PR status check steps", () => {
     )
     expect(prompts[0]).not.toContain("automated reviews may have completed")
     expect(prompts[0]).toContain("restart the failed checks when appropriate")
+    expect(prompts[1]).toContain("READY_FOR_AGENT_RESULT: CHECKS_TRIGGERED")
     expect(prompts[1]).toContain("READY_FOR_AGENT_RESULT: PROCESSED")
     expect(prompts[1]).toContain("READY_FOR_AGENT_RESULT: FAILED:")
     expect(prompts[1]).toContain(
       "If this handoff contained red checks and you made no commit, push, check restart",
     )
-    expect(prompts[1]).toContain("replacement execution")
+    expect(prompts[1]).toContain("replacement check executions")
   })
 
   it("makes a focused recovery attempt after FAILED and accepts recovered progress", async () => {
@@ -592,7 +596,7 @@ describe("PR status check steps", () => {
                 "No code changes, commit, push, or PR comment were made.",
                 "READY_FOR_AGENT_RESULT: FAILED: ActionLint failed on GitHub 503",
                 "Reran the failed workflow; a replacement execution is queued.",
-                "READY_FOR_AGENT_RESULT: PROCESSED",
+                "READY_FOR_AGENT_RESULT: CHECKS_TRIGGERED",
               ],
               (prompt) => prompts.push(prompt),
             ),
@@ -603,8 +607,9 @@ describe("PR status check steps", () => {
     )
 
     expect(result).toEqual({
-      _tag: "processed",
+      _tag: "checks_triggered",
       handledCheckIds: [expect.any(String)],
+      checkStartAnchorRecorded: false,
     })
     expect(prompts).toHaveLength(4)
     expect(prompts[2]).toContain("focused recovery attempt")
@@ -777,15 +782,14 @@ describe("PR status check steps", () => {
       "stale incomplete comment when a newer attempt completed its review successfully",
     )
     expect(prompts[0]).toContain(
-      "latest review attempt is still active, leave it alone and do not start a duplicate",
-    )
-    expect(prompts[0]).toContain("or left red checks unresolved")
-    expect(prompts[0]).toContain("report WAITING in the verdict turn")
-    expect(prompts[0]).toContain(
-      "terminal review attempt is incomplete only when positive review evidence shows it produced no relevant review comment or its latest relevant comment remains visibly partial",
+      "Once an automated-review check is terminal, its Automated Review Output is final",
     )
     expect(prompts[0]).toContain(
-      "request a whole-review workflow rerun in the verdict turn",
+      "successful terminal review with no relevant comment means no feedback and must not be rerun",
+    )
+    expect(prompts[0]).not.toContain("WAITING")
+    expect(prompts[0]).toContain(
+      "Present, positively identified, visibly incomplete Automated Review Output requires a whole-review workflow rerun",
     )
     expect(prompts[0]).toContain(
       "Do not call GitHub workflow rerun APIs yourself",
@@ -798,7 +802,7 @@ describe("PR status check steps", () => {
       "Report NEEDS_HUMAN only when evidence shows that an operator must perform or decide",
     )
     expect(prompts[0]).toContain(
-      "completed review with no worthwhile feedback still needs no changes or rerun",
+      "successful terminal review with no relevant comment, still needs no changes or rerun",
     )
     expect(prompts[0]).toContain(
       "If review feedback requires changes, verify them, commit them, and push the commit",
@@ -850,26 +854,28 @@ describe("PR status check steps", () => {
       _tag: "processed",
       handledCheckIds: [expect.any(String)],
     })
+    expect(prompts[1]).toContain("READY_FOR_AGENT_RESULT: CHECKS_TRIGGERED")
     expect(prompts[1]).toContain("READY_FOR_AGENT_RESULT: RERUN_REVIEW:")
     expect(prompts[1]).toContain(
-      "Do not report PROCESSED for a terminal incomplete review that still needs a whole-workflow rerun",
+      "Do not report PROCESSED for a present, positively identified, visibly incomplete automated review that still needs a whole-workflow rerun",
     )
     expect(prompts[1]).toContain(
       "including a skipped reviewer with no review output",
     )
     expect(prompts[1]).toContain(
-      "genuinely completed review had nothing to address",
+      "genuinely completed review that had nothing to address",
     )
+    expect(prompts[1]).toContain("no relevant automated-review run or comment")
     expect(prompts[1]).toContain(
-      "no relevant automated-review run or comment existed",
+      "successful terminal review with no relevant comment (no feedback)",
     )
-    expect(prompts[1]).toContain("READY_FOR_AGENT_RESULT: WAITING")
+    expect(prompts[1]).not.toContain("READY_FOR_AGENT_RESULT: WAITING")
     expect(prompts[1]).toContain(
       "technical or observability failure prevented you from determining the relevant review state",
     )
   })
 
-  it("leaves a green handoff unhandled while its automated review is active", async () => {
+  it("treats a successful terminal review with no relevant comment as PROCESSED no feedback", async () => {
     const result = await Effect.runPromise(
       Effect.gen(function* () {
         yield* seedWorkItem
@@ -888,8 +894,8 @@ describe("PR status check steps", () => {
             }),
             keymaxxer,
             opencodeWith([
-              "The latest automated review run is still active.",
-              "READY_FOR_AGENT_RESULT: WAITING",
+              "Terminal successful review with no relevant comment; no feedback.",
+              "READY_FOR_AGENT_RESULT: PROCESSED",
             ]),
             DatabaseTest,
           ),
@@ -898,9 +904,26 @@ describe("PR status check steps", () => {
     )
 
     expect(result).toEqual({
-      _tag: "waiting",
-      handledCheckIds: [],
+      _tag: "processed",
+      handledCheckIds: [expect.any(String)],
     })
+  })
+
+  it("rejects removed WAITING verdicts", () => {
+    expect(parseInvestigationResult("READY_FOR_AGENT_RESULT: WAITING")).toBe(
+      null,
+    )
+  })
+
+  it("parses CHECKS_TRIGGERED as a distinct valid result", () => {
+    expect(
+      parseInvestigationResult("READY_FOR_AGENT_RESULT: CHECKS_TRIGGERED"),
+    ).toBe("checks_triggered")
+    expect(
+      parseInvestigationResult(
+        "notes\nREADY_FOR_AGENT_RESULT: CHECKS_TRIGGERED",
+      ),
+    ).toBe("checks_triggered")
   })
 
   it("returns OpenCode's structured human intervention reason", async () => {
@@ -1207,9 +1230,10 @@ describe("PR status check steps", () => {
             ],
           )
           const result = yield* investigatePrStatusChecks(context)
-          expect(result._tag).toBe("processed")
-          if (result._tag === "processed") {
+          expect(result._tag).toBe("checks_triggered")
+          if (result._tag === "checks_triggered") {
             expect(result.handledCheckIds).toEqual([`psc-review-${attempt}`])
+            expect(result.checkStartAnchorRecorded).toBe(true)
             const handledAt = Date.now()
             for (const checkId of result.handledCheckIds) {
               yield* sql.unsafe(
@@ -1220,6 +1244,16 @@ describe("PR status check steps", () => {
               )
             }
           }
+          const anchors = (yield* sql.unsafe(
+            `SELECT check_start_anchor_at, check_start_anchor_head_sha
+             FROM work_item WHERE id = ?`,
+            [context.workItemId],
+          )) as readonly {
+            readonly check_start_anchor_at: number | null
+            readonly check_start_anchor_head_sha: string | null
+          }[]
+          expect(anchors[0]?.check_start_anchor_at).not.toBeNull()
+          expect(anchors[0]?.check_start_anchor_head_sha).toBe(headSha)
         }
         const now = Date.now()
         yield* sql.unsafe(
@@ -1275,15 +1309,31 @@ describe("PR status check steps", () => {
       Effect.gen(function* () {
         yield* seedWorkItem
         yield* watchPrStatusChecks(context)
+        const sql = yield* SqlClient.SqlClient
+        yield* sql.unsafe(
+          `UPDATE work_item
+           SET check_start_anchor_at = 1234,
+               check_start_anchor_head_sha = 'prior-head',
+               updated_at = 1234
+           WHERE id = ?`,
+          [context.workItemId],
+        )
         const investigation = yield* Effect.result(
           investigatePrStatusChecks(context),
         )
-        const sql = yield* SqlClient.SqlClient
         const permits = (yield* sql.unsafe(
           `SELECT status FROM automated_review_rerun WHERE work_item_id = ?`,
           [context.workItemId],
         )) as readonly { readonly status: string }[]
-        return { investigation, permits }
+        const anchors = (yield* sql.unsafe(
+          `SELECT check_start_anchor_at, check_start_anchor_head_sha
+           FROM work_item WHERE id = ?`,
+          [context.workItemId],
+        )) as readonly {
+          readonly check_start_anchor_at: number | null
+          readonly check_start_anchor_head_sha: string | null
+        }[]
+        return { investigation, permits, anchors }
       }).pipe(
         Effect.provide(
           Layer.mergeAll(
@@ -1327,6 +1377,12 @@ describe("PR status check steps", () => {
     expect(rerunCalls).toBe(1)
     expect(result.investigation._tag).toBe("Failure")
     expect(result.permits).toEqual([{ status: "reserved" }])
+    expect(result.anchors).toEqual([
+      {
+        check_start_anchor_at: 1234,
+        check_start_anchor_head_sha: "prior-head",
+      },
+    ])
   })
 
   it("gives a new PR head a fresh automated-review rerun budget", async () => {
@@ -1360,7 +1416,7 @@ describe("PR status check steps", () => {
           [context.workItemId, now, now, now],
         )
         const result = yield* investigatePrStatusChecks(context)
-        expect(result._tag).toBe("processed")
+        expect(result._tag).toBe("checks_triggered")
       }).pipe(
         Effect.provide(
           Layer.mergeAll(

--- a/packages/work-item-lifecycle/test/work-item-lifecycle.spec.ts
+++ b/packages/work-item-lifecycle/test/work-item-lifecycle.spec.ts
@@ -2425,16 +2425,17 @@ describe("WorkItemLifecycle", () => {
       )
     })
 
-    it("returns a waiting automated review to delayed Watch without handling its checks", () => {
-      const checkId = "psc-active-review"
+    it("returns PROCESSED investigation to Watch immediately without resetting the Check-Start Anchor", () => {
+      const checkId = "psc-processed-noop"
+      const priorAnchorAt = 1_000
       const steps: LifecycleStepsShape = {
         ...successfulSteps,
         watchPrStatusChecks: () =>
           Effect.succeed(watchResult("handoff_needed")),
         investigatePrStatusChecks: () =>
           Effect.succeed({
-            _tag: "waiting",
-            handledCheckIds: [],
+            _tag: "processed",
+            handledCheckIds: [checkId],
           }),
       }
 
@@ -2460,10 +2461,16 @@ describe("WorkItemLifecycle", () => {
 
           const now = Date.now()
           yield* sql.unsafe(
+            `UPDATE work_item
+             SET check_start_anchor_at = ?, updated_at = ?
+             WHERE id = ?`,
+            [priorAnchorAt, now, created.id],
+          )
+          yield* sql.unsafe(
             `INSERT INTO pr_status_check (
                id, work_item_id, external_id, name, outcome,
                handled_at, observed_at, created_at, updated_at
-             ) VALUES (?, ?, 'checkrun:active-review', 'review', 'green', NULL, ?, ?, ?)`,
+             ) VALUES (?, ?, 'checkrun:processed-noop', 'lint', 'green', NULL, ?, ?, ?)`,
             [checkId, created.id, now, now, now],
           )
 
@@ -2483,16 +2490,115 @@ describe("WorkItemLifecycle", () => {
             readonly handled_at: number | null
             readonly handled_by_step_run_id: string | null
           }[]
-          expect(checks).toEqual([
-            { handled_at: null, handled_by_step_run_id: null },
-          ])
+          expect(checks[0]?.handled_at).not.toBeNull()
 
           const delayed = (yield* sql.unsafe(
             `SELECT available_at, created_at FROM job_queue`,
           )) as readonly { available_at: number; created_at: number }[]
           expect(delayed).toHaveLength(1)
-          expect(delayed[0]!.available_at - delayed[0]!.created_at).toBe(30_000)
+          expect(delayed[0]!.available_at - delayed[0]!.created_at).toBe(0)
+
+          const anchors = (yield* sql.unsafe(
+            `SELECT check_start_anchor_at FROM work_item WHERE id = ?`,
+            [created.id],
+          )) as readonly { readonly check_start_anchor_at: number | null }[]
+          expect(anchors[0]?.check_start_anchor_at).toBe(priorAnchorAt)
         }),
+      )
+    })
+
+    it("records a fresh Check-Start Anchor and delayed Watch after CHECKS_TRIGGERED", () => {
+      const checkId = "psc-checks-triggered"
+      const priorAnchorAt = 1_000
+      const investigateAt = 50_000
+      const steps: LifecycleStepsShape = {
+        ...successfulSteps,
+        watchPrStatusChecks: () =>
+          Effect.succeed(watchResult("handoff_needed")),
+        investigatePrStatusChecks: () =>
+          Effect.succeed({
+            _tag: "checks_triggered",
+            handledCheckIds: [checkId],
+            checkStartAnchorRecorded: false,
+          }),
+      }
+
+      return Effect.runPromise(
+        Effect.scoped(
+          Effect.provide(
+            Effect.gen(function* () {
+              yield* TestClock.setTime(0)
+              const lifecycle = yield* WorkItemLifecycle
+              const sql = yield* SqlClient.SqlClient
+              const { repository, issue } = yield* seedActionableIssue
+              const created = yield* lifecycle.implementNow(
+                repository.id,
+                issue.githubIssueNumber,
+              )
+
+              for (let index = 0; index < 8; index += 1) {
+                yield* claimAndRunPending
+              }
+              const watched = yield* claimAndRunPending
+              expect(watched._tag).toBe("processed")
+              if (watched._tag === "processed") {
+                expect(watched.workItem.state).toBe(
+                  "investigate_pr_status_checks",
+                )
+              }
+
+              yield* TestClock.setTime(investigateAt)
+              yield* sql.unsafe(
+                `UPDATE work_item
+                 SET check_start_anchor_at = ?, updated_at = ?
+                 WHERE id = ?`,
+                [priorAnchorAt, investigateAt, created.id],
+              )
+              yield* sql.unsafe(
+                `INSERT INTO pr_status_check (
+                   id, work_item_id, external_id, name, outcome,
+                   handled_at, observed_at, created_at, updated_at
+                 ) VALUES (?, ?, 'checkrun:triggered', 'lint', 'red', NULL, ?, ?, ?)`,
+                [
+                  checkId,
+                  created.id,
+                  investigateAt,
+                  investigateAt,
+                  investigateAt,
+                ],
+              )
+
+              const investigated = yield* claimAndRunPending
+              expect(investigated._tag).toBe("processed")
+              if (investigated._tag === "processed") {
+                expect(investigated.workItem.state).toBe(
+                  "watch_pr_status_checks",
+                )
+              }
+
+              const checks = (yield* sql.unsafe(
+                `SELECT handled_at FROM pr_status_check WHERE id = ?`,
+                [checkId],
+              )) as readonly { readonly handled_at: number | null }[]
+              expect(checks[0]?.handled_at).not.toBeNull()
+
+              const delayed = (yield* sql.unsafe(
+                `SELECT available_at, created_at FROM job_queue`,
+              )) as readonly { available_at: number; created_at: number }[]
+              expect(delayed).toHaveLength(1)
+              expect(delayed[0]!.available_at - delayed[0]!.created_at).toBe(
+                30_000,
+              )
+
+              const anchors = (yield* sql.unsafe(
+                `SELECT check_start_anchor_at FROM work_item WHERE id = ?`,
+                [created.id],
+              )) as readonly { readonly check_start_anchor_at: number | null }[]
+              expect(anchors[0]?.check_start_anchor_at).toBe(investigateAt)
+            }),
+            makeTestLayer(steps).pipe(Layer.provideMerge(TestClock.layer())),
+          ),
+        ),
       )
     })
 
@@ -2935,53 +3041,108 @@ describe("WorkItemLifecycle", () => {
       )
     })
 
-    it("returns to delayed Watch after PROCESSED investigation when OpenCode took action", () => {
+    it("keeps a pre-recorded Check-Start Anchor after CHECKS_TRIGGERED with checkStartAnchorRecorded", () => {
+      const checkId = "psc-authorized-rerun"
+      const priorAnchorAt = 2_000
+      const triggerAt = 70_000
+      const investigateAt = 80_000
       const steps: LifecycleStepsShape = {
         ...successfulSteps,
         watchPrStatusChecks: () =>
           Effect.succeed(watchResult("handoff_needed")),
         investigatePrStatusChecks: () =>
           Effect.succeed({
-            _tag: "processed" as const,
-            handledCheckIds: [],
+            _tag: "checks_triggered" as const,
+            handledCheckIds: [checkId],
+            // Simulates authorized review rerun that already wrote the anchor.
+            checkStartAnchorRecorded: true,
           }),
       }
 
-      return runWithSteps(
-        steps,
-        Effect.gen(function* () {
-          const sql = yield* SqlClient.SqlClient
-          const lifecycle = yield* WorkItemLifecycle
-          const { repository, issue } = yield* seedActionableIssue
-          yield* lifecycle.implementNow(repository.id, issue.githubIssueNumber)
+      return Effect.runPromise(
+        Effect.scoped(
+          Effect.provide(
+            Effect.gen(function* () {
+              yield* TestClock.setTime(0)
+              const sql = yield* SqlClient.SqlClient
+              const lifecycle = yield* WorkItemLifecycle
+              const { repository, issue } = yield* seedActionableIssue
+              const created = yield* lifecycle.implementNow(
+                repository.id,
+                issue.githubIssueNumber,
+              )
 
-          for (let index = 0; index < 8; index += 1) {
-            yield* claimAndRunPending
-          }
+              for (let index = 0; index < 8; index += 1) {
+                yield* claimAndRunPending
+              }
 
-          const handoff = yield* claimAndRunPending
-          expect(handoff._tag).toBe("processed")
-          if (handoff._tag === "processed") {
-            expect(handoff.workItem.state).toBe("investigate_pr_status_checks")
-          }
+              const handoff = yield* claimAndRunPending
+              expect(handoff._tag).toBe("processed")
+              if (handoff._tag === "processed") {
+                expect(handoff.workItem.state).toBe(
+                  "investigate_pr_status_checks",
+                )
+              }
 
-          const afterInvestigate = yield* claimAndRunPending
-          expect(afterInvestigate._tag).toBe("processed")
-          if (afterInvestigate._tag === "processed") {
-            expect(afterInvestigate.workItem.state).toBe(
-              "watch_pr_status_checks",
-            )
-          }
+              yield* TestClock.setTime(investigateAt)
+              yield* sql.unsafe(
+                `UPDATE work_item
+                 SET check_start_anchor_at = ?,
+                     check_start_anchor_head_sha = 'rerun-head',
+                     updated_at = ?
+                 WHERE id = ?`,
+                [triggerAt, investigateAt, created.id],
+              )
+              yield* sql.unsafe(
+                `INSERT INTO pr_status_check (
+                   id, work_item_id, external_id, name, outcome,
+                   handled_at, observed_at, created_at, updated_at
+                 ) VALUES (?, ?, 'actions-job:review-rerun', 'review', 'green', NULL, ?, ?, ?)`,
+                [
+                  checkId,
+                  created.id,
+                  investigateAt,
+                  investigateAt,
+                  investigateAt,
+                ],
+              )
 
-          const delayed = (yield* sql.unsafe(
-            `SELECT available_at, created_at FROM job_queue`,
-          )) as readonly {
-            readonly available_at: number
-            readonly created_at: number
-          }[]
-          expect(delayed).toHaveLength(1)
-          expect(delayed[0]!.available_at - delayed[0]!.created_at).toBe(30_000)
-        }),
+              const afterInvestigate = yield* claimAndRunPending
+              expect(afterInvestigate._tag).toBe("processed")
+              if (afterInvestigate._tag === "processed") {
+                expect(afterInvestigate.workItem.state).toBe(
+                  "watch_pr_status_checks",
+                )
+              }
+
+              const delayed = (yield* sql.unsafe(
+                `SELECT available_at, created_at FROM job_queue`,
+              )) as readonly {
+                readonly available_at: number
+                readonly created_at: number
+              }[]
+              expect(delayed).toHaveLength(1)
+              expect(delayed[0]!.available_at - delayed[0]!.created_at).toBe(
+                30_000,
+              )
+
+              const anchors = (yield* sql.unsafe(
+                `SELECT check_start_anchor_at, check_start_anchor_head_sha
+                 FROM work_item WHERE id = ?`,
+                [created.id],
+              )) as readonly {
+                readonly check_start_anchor_at: number | null
+                readonly check_start_anchor_head_sha: string | null
+              }[]
+              // Must retain the trigger-time anchor, not step-completion time.
+              expect(anchors[0]?.check_start_anchor_at).toBe(triggerAt)
+              expect(anchors[0]?.check_start_anchor_head_sha).toBe("rerun-head")
+              expect(anchors[0]?.check_start_anchor_at).not.toBe(investigateAt)
+              expect(anchors[0]?.check_start_anchor_at).not.toBe(priorAnchorAt)
+            }),
+            makeTestLayer(steps).pipe(Layer.provideMerge(TestClock.layer())),
+          ),
+        ),
       )
     })
 


### PR DESCRIPTION
## Summary

- Add `CHECKS_TRIGGERED` for Status Check Handoffs that create replacement executions (push/restart), with a fresh Check-Start Anchor and delayed return to Watch
- Narrow `PROCESSED` to no-replacement outcomes that return to Watch immediately without resetting the deadline
- Remove comment-driven `WAITING`; treat terminal automated-review output as final (no comment = no feedback; present incomplete output still requests whole-workflow rerun)
- Persist authorized review-rerun anchors at API success and avoid overwriting them at step completion

Closes #383

## Test plan

- [x] `work-item-lifecycle` protocol and lifecycle tests for CHECKS_TRIGGERED / PROCESSED / removed WAITING / rerun anchor behavior
- [x] Pre-commit / affected lint, typecheck, test