### PR TITLE
feat(work-item-lifecycle): rewatch checks after marking a draft PR ready

### DIFF
--- a/packages/db-schema/README.md
+++ b/packages/db-schema/README.md
@@ -77,7 +77,10 @@ type work item = repository, github issue number, issue title,
                  review model, review variant, state, state ready at,
                  paused, waiting since, holds worker slot, pause before step,
                  worktree path, starting commit oid, completion summary,
-                 session id, failure code, failure message.
+                 session id, failure code, failure message,
+                 check start anchor at, check start anchor head sha,
+                 check start observed head sha, check start observed head at,
+                 check start last observed is draft.
 
 type step run = work item, step, status, queue job id,
                 queued at, started at, finished at, reason code, reason message.

--- a/packages/db-schema/drizzle/20260723072032_free_shadow_king/migration.sql
+++ b/packages/db-schema/drizzle/20260723072032_free_shadow_king/migration.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `work_item` ADD `check_start_last_observed_is_draft` integer;

--- a/packages/db-schema/drizzle/20260723072032_free_shadow_king/snapshot.json
+++ b/packages/db-schema/drizzle/20260723072032_free_shadow_king/snapshot.json
@@ -1,0 +1,1685 @@
+{
+  "version": "7",
+  "dialect": "sqlite",
+  "id": "f7bf790c-5d13-40a6-879c-72bb4ea8c7e1",
+  "prevIds": [
+    "8c727993-44ea-4a7f-b551-50eb4a5bee63"
+  ],
+  "ddl": [
+    {
+      "name": "automated_review_rerun",
+      "entityType": "tables"
+    },
+    {
+      "name": "completed_job",
+      "entityType": "tables"
+    },
+    {
+      "name": "config",
+      "entityType": "tables"
+    },
+    {
+      "name": "issue",
+      "entityType": "tables"
+    },
+    {
+      "name": "issue_dependency",
+      "entityType": "tables"
+    },
+    {
+      "name": "job_queue",
+      "entityType": "tables"
+    },
+    {
+      "name": "pr_status_check",
+      "entityType": "tables"
+    },
+    {
+      "name": "repository",
+      "entityType": "tables"
+    },
+    {
+      "name": "step_run",
+      "entityType": "tables"
+    },
+    {
+      "name": "work_item",
+      "entityType": "tables"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "automated_review_rerun"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "work_item_id",
+      "entityType": "columns",
+      "table": "automated_review_rerun"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "head_sha",
+      "entityType": "columns",
+      "table": "automated_review_rerun"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "workflow_run_id",
+      "entityType": "columns",
+      "table": "automated_review_rerun"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "workflow_name",
+      "entityType": "columns",
+      "table": "automated_review_rerun"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "status",
+      "entityType": "columns",
+      "table": "automated_review_rerun"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "automated_review_rerun"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "automated_review_rerun"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "completed_job"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "queue",
+      "entityType": "columns",
+      "table": "completed_job"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "job_id",
+      "entityType": "columns",
+      "table": "completed_job"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "completed_job"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "completed_job"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "'default'",
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "config"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "default_model",
+      "entityType": "columns",
+      "table": "config"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "default_variant",
+      "entityType": "columns",
+      "table": "config"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "review_model",
+      "entityType": "columns",
+      "table": "config"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "review_variant",
+      "entityType": "columns",
+      "table": "config"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "2",
+      "generated": null,
+      "name": "max_concurrent_opencode_sessions",
+      "entityType": "columns",
+      "table": "config"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "5",
+      "generated": null,
+      "name": "max_concurrent_work_items",
+      "entityType": "columns",
+      "table": "config"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "config"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "config"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "issue"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "repository_id",
+      "entityType": "columns",
+      "table": "issue"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "github_issue_number",
+      "entityType": "columns",
+      "table": "issue"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "title",
+      "entityType": "columns",
+      "table": "issue"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "body",
+      "entityType": "columns",
+      "table": "issue"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "url",
+      "entityType": "columns",
+      "table": "issue"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "state",
+      "entityType": "columns",
+      "table": "issue"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "github_created_at",
+      "entityType": "columns",
+      "table": "issue"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "issue_author",
+      "entityType": "columns",
+      "table": "issue"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "parent_github_issue_number",
+      "entityType": "columns",
+      "table": "issue"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "parent_github_issue_url",
+      "entityType": "columns",
+      "table": "issue"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "parent_position",
+      "entityType": "columns",
+      "table": "issue"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "false",
+      "generated": null,
+      "name": "has_children",
+      "entityType": "columns",
+      "table": "issue"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "issue"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "issue"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "issue_dependency"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "issue_id",
+      "entityType": "columns",
+      "table": "issue_dependency"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "blocking_github_issue_number",
+      "entityType": "columns",
+      "table": "issue_dependency"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "blocking_github_issue_url",
+      "entityType": "columns",
+      "table": "issue_dependency"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "issue_dependency"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "job_queue"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "queue",
+      "entityType": "columns",
+      "table": "job_queue"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "key",
+      "entityType": "columns",
+      "table": "job_queue"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "job_payload",
+      "entityType": "columns",
+      "table": "job_queue"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "0",
+      "generated": null,
+      "name": "job_attempts",
+      "entityType": "columns",
+      "table": "job_queue"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "5",
+      "generated": null,
+      "name": "job_retry_limit",
+      "entityType": "columns",
+      "table": "job_queue"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "available_at",
+      "entityType": "columns",
+      "table": "job_queue"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "locked_until",
+      "entityType": "columns",
+      "table": "job_queue"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "job_queue"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "job_queue"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "pr_status_check"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "work_item_id",
+      "entityType": "columns",
+      "table": "pr_status_check"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "external_id",
+      "entityType": "columns",
+      "table": "pr_status_check"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "name",
+      "entityType": "columns",
+      "table": "pr_status_check"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "outcome",
+      "entityType": "columns",
+      "table": "pr_status_check"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "handled_at",
+      "entityType": "columns",
+      "table": "pr_status_check"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "handled_by_step_run_id",
+      "entityType": "columns",
+      "table": "pr_status_check"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "observed_at",
+      "entityType": "columns",
+      "table": "pr_status_check"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "pr_status_check"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "pr_status_check"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "repository"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "github_owner",
+      "entityType": "columns",
+      "table": "repository"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "github_repo",
+      "entityType": "columns",
+      "table": "repository"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "local_path",
+      "entityType": "columns",
+      "table": "repository"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "is_bare",
+      "entityType": "columns",
+      "table": "repository"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "true",
+      "generated": null,
+      "name": "paused",
+      "entityType": "columns",
+      "table": "repository"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "default_model",
+      "entityType": "columns",
+      "table": "repository"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "default_variant",
+      "entityType": "columns",
+      "table": "repository"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "review_model",
+      "entityType": "columns",
+      "table": "repository"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "review_variant",
+      "entityType": "columns",
+      "table": "repository"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "false",
+      "generated": null,
+      "name": "auto_merge",
+      "entityType": "columns",
+      "table": "repository"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "false",
+      "generated": null,
+      "name": "include_all_issue_authors",
+      "entityType": "columns",
+      "table": "repository"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "issues_reconciled_at",
+      "entityType": "columns",
+      "table": "repository"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "repository"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "repository"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "step_run"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "work_item_id",
+      "entityType": "columns",
+      "table": "step_run"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "step",
+      "entityType": "columns",
+      "table": "step_run"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "status",
+      "entityType": "columns",
+      "table": "step_run"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "queue_job_id",
+      "entityType": "columns",
+      "table": "step_run"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "queued_at",
+      "entityType": "columns",
+      "table": "step_run"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "started_at",
+      "entityType": "columns",
+      "table": "step_run"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "finished_at",
+      "entityType": "columns",
+      "table": "step_run"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "reason_code",
+      "entityType": "columns",
+      "table": "step_run"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "reason_message",
+      "entityType": "columns",
+      "table": "step_run"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "step_run"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "step_run"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "work_item"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "repository_id",
+      "entityType": "columns",
+      "table": "work_item"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "github_issue_number",
+      "entityType": "columns",
+      "table": "work_item"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "issue_title",
+      "entityType": "columns",
+      "table": "work_item"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "github_pull_request_number",
+      "entityType": "columns",
+      "table": "work_item"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "model",
+      "entityType": "columns",
+      "table": "work_item"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "variant",
+      "entityType": "columns",
+      "table": "work_item"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "review_model",
+      "entityType": "columns",
+      "table": "work_item"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "review_variant",
+      "entityType": "columns",
+      "table": "work_item"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "state",
+      "entityType": "columns",
+      "table": "work_item"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "state_ready_at",
+      "entityType": "columns",
+      "table": "work_item"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "false",
+      "generated": null,
+      "name": "paused",
+      "entityType": "columns",
+      "table": "work_item"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "waiting_since",
+      "entityType": "columns",
+      "table": "work_item"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "false",
+      "generated": null,
+      "name": "holds_worker_slot",
+      "entityType": "columns",
+      "table": "work_item"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "pause_before_step",
+      "entityType": "columns",
+      "table": "work_item"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "worktree_path",
+      "entityType": "columns",
+      "table": "work_item"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "starting_commit_oid",
+      "entityType": "columns",
+      "table": "work_item"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "completion_summary",
+      "entityType": "columns",
+      "table": "work_item"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "session_id",
+      "entityType": "columns",
+      "table": "work_item"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "failure_code",
+      "entityType": "columns",
+      "table": "work_item"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "failure_message",
+      "entityType": "columns",
+      "table": "work_item"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "check_start_anchor_at",
+      "entityType": "columns",
+      "table": "work_item"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "check_start_anchor_head_sha",
+      "entityType": "columns",
+      "table": "work_item"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "check_start_observed_head_sha",
+      "entityType": "columns",
+      "table": "work_item"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "check_start_observed_head_at",
+      "entityType": "columns",
+      "table": "work_item"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "check_start_last_observed_is_draft",
+      "entityType": "columns",
+      "table": "work_item"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "work_item"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "work_item"
+    },
+    {
+      "columns": [
+        "work_item_id"
+      ],
+      "tableTo": "work_item",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_automated_review_rerun_work_item_id_work_item_id_fk",
+      "entityType": "fks",
+      "table": "automated_review_rerun"
+    },
+    {
+      "columns": [
+        "repository_id"
+      ],
+      "tableTo": "repository",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_issue_repository_id_repository_id_fk",
+      "entityType": "fks",
+      "table": "issue"
+    },
+    {
+      "columns": [
+        "issue_id"
+      ],
+      "tableTo": "issue",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_issue_dependency_issue_id_issue_id_fk",
+      "entityType": "fks",
+      "table": "issue_dependency"
+    },
+    {
+      "columns": [
+        "work_item_id"
+      ],
+      "tableTo": "work_item",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_pr_status_check_work_item_id_work_item_id_fk",
+      "entityType": "fks",
+      "table": "pr_status_check"
+    },
+    {
+      "columns": [
+        "handled_by_step_run_id"
+      ],
+      "tableTo": "step_run",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "SET NULL",
+      "nameExplicit": false,
+      "name": "fk_pr_status_check_handled_by_step_run_id_step_run_id_fk",
+      "entityType": "fks",
+      "table": "pr_status_check"
+    },
+    {
+      "columns": [
+        "work_item_id"
+      ],
+      "tableTo": "work_item",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_step_run_work_item_id_work_item_id_fk",
+      "entityType": "fks",
+      "table": "step_run"
+    },
+    {
+      "columns": [
+        "repository_id"
+      ],
+      "tableTo": "repository",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_work_item_repository_id_repository_id_fk",
+      "entityType": "fks",
+      "table": "work_item"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "automated_review_rerun_pk",
+      "table": "automated_review_rerun",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "completed_job_pk",
+      "table": "completed_job",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "config_pk",
+      "table": "config",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "issue_pk",
+      "table": "issue",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "issue_dependency_pk",
+      "table": "issue_dependency",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "job_queue_pk",
+      "table": "job_queue",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "pr_status_check_pk",
+      "table": "pr_status_check",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "repository_pk",
+      "table": "repository",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "step_run_pk",
+      "table": "step_run",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "work_item_pk",
+      "table": "work_item",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        {
+          "value": "work_item_id",
+          "isExpression": false
+        },
+        {
+          "value": "head_sha",
+          "isExpression": false
+        },
+        {
+          "value": "workflow_run_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "automated_review_rerun_budget_idx",
+      "entityType": "indexes",
+      "table": "automated_review_rerun"
+    },
+    {
+      "columns": [
+        {
+          "value": "queue",
+          "isExpression": false
+        },
+        {
+          "value": "job_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "origin": "manual",
+      "name": "completed_job_queue_job_id_uidx",
+      "entityType": "indexes",
+      "table": "completed_job"
+    },
+    {
+      "columns": [
+        {
+          "value": "repository_id",
+          "isExpression": false
+        },
+        {
+          "value": "github_issue_number",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "origin": "manual",
+      "name": "issue_repository_id_github_issue_number_uidx",
+      "entityType": "indexes",
+      "table": "issue"
+    },
+    {
+      "columns": [
+        {
+          "value": "issue_id",
+          "isExpression": false
+        },
+        {
+          "value": "blocking_github_issue_url",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "origin": "manual",
+      "name": "issue_dependency_issue_id_blocking_url_uidx",
+      "entityType": "indexes",
+      "table": "issue_dependency"
+    },
+    {
+      "columns": [
+        {
+          "value": "queue",
+          "isExpression": false
+        },
+        {
+          "value": "locked_until",
+          "isExpression": false
+        },
+        {
+          "value": "job_attempts",
+          "isExpression": false
+        },
+        {
+          "value": "available_at",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "job_queue_ready_idx",
+      "entityType": "indexes",
+      "table": "job_queue"
+    },
+    {
+      "columns": [
+        {
+          "value": "queue",
+          "isExpression": false
+        },
+        {
+          "value": "key",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": "\"job_queue\".\"key\" IS NOT NULL",
+      "origin": "manual",
+      "name": "job_queue_queue_key_uidx",
+      "entityType": "indexes",
+      "table": "job_queue"
+    },
+    {
+      "columns": [
+        {
+          "value": "work_item_id",
+          "isExpression": false
+        },
+        {
+          "value": "external_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "origin": "manual",
+      "name": "pr_status_check_work_item_external_uidx",
+      "entityType": "indexes",
+      "table": "pr_status_check"
+    },
+    {
+      "columns": [
+        {
+          "value": "work_item_id",
+          "isExpression": false
+        },
+        {
+          "value": "handled_at",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "pr_status_check_work_item_handled_idx",
+      "entityType": "indexes",
+      "table": "pr_status_check"
+    },
+    {
+      "columns": [
+        {
+          "value": "handled_by_step_run_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "pr_status_check_handled_by_step_run_idx",
+      "entityType": "indexes",
+      "table": "pr_status_check"
+    },
+    {
+      "columns": [
+        {
+          "value": "lower(\"github_owner\")",
+          "isExpression": true
+        },
+        {
+          "value": "lower(\"github_repo\")",
+          "isExpression": true
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "origin": "manual",
+      "name": "repository_github_owner_repo_lower_uidx",
+      "entityType": "indexes",
+      "table": "repository"
+    },
+    {
+      "columns": [
+        {
+          "value": "work_item_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": "\"step_run\".\"status\" IN ('queued', 'running')",
+      "origin": "manual",
+      "name": "step_run_one_active_uidx",
+      "entityType": "indexes",
+      "table": "step_run"
+    },
+    {
+      "columns": [
+        {
+          "value": "work_item_id",
+          "isExpression": false
+        },
+        {
+          "value": "queued_at",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "step_run_work_item_id_queued_at_idx",
+      "entityType": "indexes",
+      "table": "step_run"
+    },
+    {
+      "columns": [
+        {
+          "value": "repository_id",
+          "isExpression": false
+        },
+        {
+          "value": "github_issue_number",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": "\"work_item\".\"state\" NOT IN ('complete', 'failed', 'abandoned', 'needs_human')",
+      "origin": "manual",
+      "name": "work_item_one_unfinished_v2_uidx",
+      "entityType": "indexes",
+      "table": "work_item"
+    },
+    {
+      "columns": [
+        {
+          "value": "repository_id",
+          "isExpression": false
+        },
+        {
+          "value": "github_issue_number",
+          "isExpression": false
+        },
+        {
+          "value": "created_at",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "work_item_repository_issue_created_idx",
+      "entityType": "indexes",
+      "table": "work_item"
+    },
+    {
+      "columns": [
+        "local_path"
+      ],
+      "nameExplicit": false,
+      "name": "repository_local_path_unique",
+      "entityType": "uniques",
+      "table": "repository"
+    }
+  ],
+  "renames": []
+}

--- a/packages/db-schema/src/schema.ts
+++ b/packages/db-schema/src/schema.ts
@@ -295,6 +295,12 @@ export const workItem = snakeCase.table(
      * First-observation instant (ms) for checkStartObservedHeadSha.
      */
     checkStartObservedHeadAt: integer({ mode: "number" }),
+    /**
+     * Last observed Work Item PR draft flag from Watch (1/0). Null until the
+     * first boolean draft observation. Used to detect an external draft-to-ready
+     * transition that must create a ready-phase Check-Start Anchor.
+     */
+    checkStartLastObservedIsDraft: integer({ mode: "number" }),
     createdAt: integer({ mode: "number" })
       .notNull()
       .$defaultFn(() => Date.now()),

--- a/packages/db/test/run-migrations.spec.ts
+++ b/packages/db/test/run-migrations.spec.ts
@@ -89,6 +89,7 @@ describe("runMigrations", () => {
           { name: "20260722034639_condemned_wildside" },
           { name: "20260722230410_goofy_gertrude_yorkes" },
           { name: "20260723051726_clever_hex" },
+          { name: "20260723072032_free_shadow_king" },
         ])
       }).pipe(Effect.provide(SqliteTest)),
     )

--- a/packages/work-item-lifecycle/src/lib/work-item-lifecycle.ts
+++ b/packages/work-item-lifecycle/src/lib/work-item-lifecycle.ts
@@ -251,6 +251,7 @@ type WorkItemRow = {
   readonly check_start_anchor_head_sha: string | null
   readonly check_start_observed_head_sha: string | null
   readonly check_start_observed_head_at: number | null
+  readonly check_start_last_observed_is_draft: number | null
   readonly created_at: number
   readonly updated_at: number
 }
@@ -338,9 +339,10 @@ const WORK_ITEM_SELECT_COLUMNS = `id, repository_id, github_issue_number, issue_
                    review_variant, state, state_ready_at, paused, waiting_since, holds_worker_slot,
                    pause_before_step, worktree_path, starting_commit_oid, completion_summary, session_id,
                    github_pull_request_number, failure_code,
-                   failure_message, check_start_anchor_at, check_start_anchor_head_sha,
-                   check_start_observed_head_sha, check_start_observed_head_at,
-                   created_at, updated_at`
+                    failure_message, check_start_anchor_at, check_start_anchor_head_sha,
+                    check_start_observed_head_sha, check_start_observed_head_at,
+                    check_start_last_observed_is_draft,
+                    created_at, updated_at`
 
 const PR_STATUS_CHECKS_POLL_DELAY = Duration.seconds(30)
 /** Catch-up window after the latest Check-Start Anchor before startup is complete. */
@@ -419,7 +421,7 @@ const nextOperationalStep = (
     case "investigate_pr_status_checks":
       return "watch_pr_status_checks"
     case "mark_pr_ready_for_review":
-      return "decide_pr_merge"
+      return "watch_pr_status_checks"
     case "decide_pr_merge":
       return "merge_pr"
     case "merge_pr":
@@ -1220,6 +1222,7 @@ export const makeWorkItemLifecycleLive = (
           readonly githubPullRequestNumber?: number
           readonly handledCheckIds?: readonly string[]
           readonly refreshCheckStartAnchor?: boolean
+          readonly checkStartLastObservedIsDraft?: number | null
           readonly stepRunReasonCode?: StepRunReasonCode
           readonly stepRunNote?: string
           readonly transition?: {
@@ -1292,6 +1295,9 @@ export const makeWorkItemLifecycleLive = (
             return steps.createPr(context).pipe(
               Effect.map((githubPullRequestNumber) => ({
                 githubPullRequestNumber,
+                // Create PR opens a draft; persist so an external ready before
+                // the first Watch poll still gets a ready-phase anchor.
+                checkStartLastObservedIsDraft: 1,
               })),
             )
           case "watch_pr_status_checks":
@@ -1311,6 +1317,12 @@ export const makeWorkItemLifecycleLive = (
                     "headPushedAt" in status
                       ? (status.headPushedAt ?? null)
                       : null
+                  const observedIsDraft =
+                    "isDraft" in status ? (status.isDraft ?? null) : null
+                  // Unknown draft status is neither draft nor ready; do not
+                  // Mark Ready or Decide until GitHub reports a boolean.
+                  const isDraft = observedIsDraft === true
+                  const isReady = observedIsDraft === false
                   let observedHeadSha = workItem.check_start_observed_head_sha
                   let observedHeadAt = workItem.check_start_observed_head_at
                   const pushedMs = validInstantMs(headPushedAt)
@@ -1367,6 +1379,26 @@ export const makeWorkItemLifecycleLive = (
                     }
                   }
 
+                  // External draft→ready is a Check-Start Anchor (ready-phase window).
+                  const previouslyDraft =
+                    workItem.check_start_last_observed_is_draft === 1
+                  if (
+                    previouslyDraft &&
+                    !isDraft &&
+                    observedIsDraft === false
+                  ) {
+                    if (anchorAt === null || now > anchorAt) {
+                      anchorAt = now
+                    }
+                  }
+
+                  const lastObservedIsDraft =
+                    observedIsDraft === null
+                      ? workItem.check_start_last_observed_is_draft
+                      : observedIsDraft
+                        ? 1
+                        : 0
+
                   yield* sql
                     .unsafe(
                       `UPDATE work_item
@@ -1374,6 +1406,7 @@ export const makeWorkItemLifecycleLive = (
                            check_start_anchor_head_sha = ?,
                            check_start_observed_head_sha = ?,
                            check_start_observed_head_at = ?,
+                           check_start_last_observed_is_draft = ?,
                            updated_at = ?
                        WHERE id = ?`,
                       [
@@ -1381,6 +1414,7 @@ export const makeWorkItemLifecycleLive = (
                         anchorHeadSha,
                         observedHeadSha,
                         observedHeadAt,
+                        lastObservedIsDraft,
                         now,
                         workItem.id,
                       ],
@@ -1427,11 +1461,23 @@ export const makeWorkItemLifecycleLive = (
                     }
                   }
                   if (status._tag === "failed") {
-                    if (!pastDeadline) {
+                    // Draft with no unhandled terminals and known mergeability
+                    // still advances to Mark Ready; the ready-phase window can
+                    // restart checks. Ready PRs fail retryably at the deadline.
+                    if (isDraft) {
+                      return {
+                        transition: {
+                          nextState: "mark_pr_ready_for_review" as const,
+                        },
+                      }
+                    }
+                    if (!isReady || !pastDeadline) {
                       return {
                         transition: {
                           nextState: "watch_pr_status_checks" as const,
-                          delay: requeueDelay,
+                          delay: pastDeadline
+                            ? PR_STATUS_CHECKS_POLL_DELAY
+                            : requeueDelay,
                         },
                       }
                     }
@@ -1440,12 +1486,32 @@ export const makeWorkItemLifecycleLive = (
                         "Manual fixing may be required. GitHub status checks remained failed without a new check execution to investigate. Please fix or rerun the checks on GitHub, then click Retry checks.",
                     })
                   }
-                  // no_checks, expected, and all-terminal success wait for the deadline.
+                  // Settled: no_checks, expected, and all-terminal success.
                   if (
                     status._tag === "no_checks" ||
                     status._tag === "expected" ||
                     status._tag === "succeeded"
                   ) {
+                    // Draft skips the catch-up window and advances to Mark Ready.
+                    if (isDraft) {
+                      return {
+                        transition: {
+                          nextState: "mark_pr_ready_for_review" as const,
+                        },
+                      }
+                    }
+                    // Unknown draft status: keep polling until GitHub reports it.
+                    if (!isReady) {
+                      return {
+                        transition: {
+                          nextState: "watch_pr_status_checks" as const,
+                          delay: pastDeadline
+                            ? PR_STATUS_CHECKS_POLL_DELAY
+                            : requeueDelay,
+                        },
+                      }
+                    }
+                    // Ready phase waits for the Check-Start Deadline, then Decide.
                     if (!pastDeadline) {
                       return {
                         transition: {
@@ -1456,13 +1522,17 @@ export const makeWorkItemLifecycleLive = (
                     }
                     return {
                       transition: {
-                        nextState: "mark_pr_ready_for_review" as const,
+                        nextState: "decide_pr_merge" as const,
                       },
                     }
                   }
                   return {
                     transition: {
-                      nextState: "mark_pr_ready_for_review" as const,
+                      nextState: isDraft
+                        ? ("mark_pr_ready_for_review" as const)
+                        : isReady
+                          ? ("decide_pr_merge" as const)
+                          : ("watch_pr_status_checks" as const),
                     },
                   }
                 }),
@@ -1516,7 +1586,17 @@ export const makeWorkItemLifecycleLive = (
               }),
             )
           case "mark_pr_ready_for_review":
-            return steps.markPrReadyForReview(context).pipe(Effect.as({}))
+            return steps.markPrReadyForReview(context).pipe(
+              Effect.as({
+                // Fresh ready-phase Check-Start Anchor; return to Watch so
+                // ready_for_review workflows get the full catch-up window.
+                refreshCheckStartAnchor: true,
+                checkStartLastObservedIsDraft: 0,
+                transition: {
+                  nextState: "watch_pr_status_checks" as const,
+                },
+              }),
+            )
           case "decide_pr_merge":
             return steps.decidePrMerge(context).pipe(
               Effect.map((result) =>
@@ -1624,6 +1704,7 @@ export const makeWorkItemLifecycleLive = (
           readonly githubPullRequestNumber?: number
           readonly handledCheckIds?: readonly string[]
           readonly refreshCheckStartAnchor?: boolean
+          readonly checkStartLastObservedIsDraft?: number | null
           readonly stepRunReasonCode?: StepRunReasonCode
           readonly stepRunNote?: string
           readonly transition?: {
@@ -1695,13 +1776,40 @@ export const makeWorkItemLifecycleLive = (
                   )
                 }
 
-                if (output.refreshCheckStartAnchor === true) {
+                if (
+                  output.refreshCheckStartAnchor === true ||
+                  output.checkStartLastObservedIsDraft !== undefined
+                ) {
+                  // Clearing the head binding with a fresh anchor prevents a
+                  // later head change from replacing the ready-phase instant
+                  // with an older Last PR Change timestamp.
                   yield* sql.unsafe(
                     `UPDATE work_item
-                     SET check_start_anchor_at = ?,
+                     SET check_start_anchor_at = CASE
+                           WHEN ? = 1 THEN ?
+                           ELSE check_start_anchor_at
+                         END,
+                         check_start_anchor_head_sha = CASE
+                           WHEN ? = 1 THEN NULL
+                           ELSE check_start_anchor_head_sha
+                         END,
+                         check_start_last_observed_is_draft = CASE
+                           WHEN ? = 1 THEN ?
+                           ELSE check_start_last_observed_is_draft
+                         END,
                          updated_at = ?
                      WHERE id = ?`,
-                    [now, now, workItem.id],
+                    [
+                      output.refreshCheckStartAnchor === true ? 1 : 0,
+                      now,
+                      output.refreshCheckStartAnchor === true ? 1 : 0,
+                      output.checkStartLastObservedIsDraft !== undefined
+                        ? 1
+                        : 0,
+                      output.checkStartLastObservedIsDraft ?? null,
+                      now,
+                      workItem.id,
+                    ],
                   )
                 }
 

--- a/packages/work-item-lifecycle/test/sync-needs-human-merge-handoffs.spec.ts
+++ b/packages/work-item-lifecycle/test/sync-needs-human-merge-handoffs.spec.ts
@@ -39,7 +39,8 @@ describe("syncNeedsHumanMergeHandoffs", () => {
         createdAt: new Date(0),
         headSha: "settled-head",
         headPushedAt: new Date(0),
-        isDraft: true,
+        // Already-ready snapshot: Watch advances past deadline to Decide.
+        isDraft: false,
       }),
     resolvePrMergeConflict: () => Effect.succeed({ _tag: "processed" }),
     investigatePrStatusChecks: () =>
@@ -142,7 +143,16 @@ describe("syncNeedsHumanMergeHandoffs", () => {
       blockedBy: [],
     })
     const created = yield* lifecycle.implementNow(repository.id, 42)
-    for (let index = 0; index < 11; index += 1) {
+    for (let index = 0; index < 8; index += 1) {
+      yield* makeQueuedJobsAvailable
+      yield* claimAndRunPending
+    }
+    const sql = yield* SqlClient.SqlClient
+    yield* sql.unsafe(
+      `UPDATE work_item SET check_start_last_observed_is_draft = NULL WHERE id = ?`,
+      [created.id],
+    )
+    for (let index = 0; index < 2; index += 1) {
       yield* makeQueuedJobsAvailable
       yield* claimAndRunPending
     }
@@ -183,7 +193,16 @@ describe("syncNeedsHumanMergeHandoffs", () => {
       blockedBy: [],
     })
     const created = yield* lifecycle.implementNow(repository.id, 42)
-    for (let index = 0; index < 12; index += 1) {
+    for (let index = 0; index < 8; index += 1) {
+      yield* makeQueuedJobsAvailable
+      yield* claimAndRunPending
+    }
+    const sql = yield* SqlClient.SqlClient
+    yield* sql.unsafe(
+      `UPDATE work_item SET check_start_last_observed_is_draft = NULL WHERE id = ?`,
+      [created.id],
+    )
+    for (let index = 0; index < 3; index += 1) {
       yield* makeQueuedJobsAvailable
       yield* claimAndRunPending
     }

--- a/packages/work-item-lifecycle/test/work-item-lifecycle.spec.ts
+++ b/packages/work-item-lifecycle/test/work-item-lifecycle.spec.ts
@@ -216,6 +216,18 @@ describe("WorkItemLifecycle", () => {
     return { repository, issue }
   })
 
+  /** Drop Create PR draft provenance so already-ready stubs use Last PR Change. */
+  const forgetCreatePrDraftProvenance = (workItemId: string) =>
+    Effect.gen(function* () {
+      const sql = yield* SqlClient.SqlClient
+      yield* sql.unsafe(
+        `UPDATE work_item
+         SET check_start_last_observed_is_draft = NULL
+         WHERE id = ?`,
+        [workItemId],
+      )
+    })
+
   describe("implementNow", () => {
     it("creates a Work Item at Create Worktree for an actionable Issue on a paused Repository", () =>
       runTest(
@@ -808,7 +820,11 @@ describe("WorkItemLifecycle", () => {
             repository.id,
             issue.githubIssueNumber,
           )
-          for (let i = 0; i < 13; i++) {
+          for (let i = 0; i < 8; i++) {
+            yield* claimAndRun
+          }
+          yield* forgetCreatePrDraftProvenance(complete.id)
+          for (let i = 0; i < 4; i++) {
             yield* claimAndRun
           }
           expect((yield* lifecycle.getWorkItem(complete.id)).state).toBe(
@@ -869,7 +885,20 @@ describe("WorkItemLifecycle", () => {
             repository.id,
             issue.githubIssueNumber,
           )
-          for (let i = 0; i < 13; i++) {
+          for (let i = 0; i < 8; i++) {
+            const sql = yield* SqlClient.SqlClient
+            yield* sql.unsafe(`UPDATE job_queue SET available_at = 0`)
+            const job = yield* queue.rawClaim(WORK_ITEM_LIFECYCLE_QUEUE)
+            expect(Option.isSome(job)).toBe(true)
+            if (Option.isNone(job)) {
+              return yield* Effect.die("expected job")
+            }
+            yield* lifecycle.runStep(
+              (job.value.payload as { stepRunId: string }).stepRunId,
+            )
+          }
+          yield* forgetCreatePrDraftProvenance(first.id)
+          for (let i = 0; i < 4; i++) {
             const sql = yield* SqlClient.SqlClient
             yield* sql.unsafe(`UPDATE job_queue SET available_at = 0`)
             const job = yield* queue.rawClaim(WORK_ITEM_LIFECYCLE_QUEUE)
@@ -1106,6 +1135,16 @@ describe("WorkItemLifecycle", () => {
       yield* sql.unsafe(`UPDATE job_queue SET available_at = 0`)
     })
 
+    /** Run steps through Create PR, then clear draft provenance for already-ready snapshots. */
+    const driveThroughCreatePrAlreadyReady = (workItemId: string) =>
+      Effect.gen(function* () {
+        for (let index = 0; index < 8; index += 1) {
+          yield* makeQueuedJobsAvailable
+          yield* claimAndRunPending
+        }
+        yield* forgetCreatePrDraftProvenance(workItemId)
+      })
+
     it("drives the complete happy path to Complete with typed outputs", () =>
       runTest(
         Effect.gen(function* () {
@@ -1208,17 +1247,13 @@ describe("WorkItemLifecycle", () => {
               },
             ])
           }
+          yield* forgetCreatePrDraftProvenance(created.id)
 
+          // Already-ready settled PR past its Check-Start Deadline advances to Decide.
           const afterChecks = yield* claimAndRunPending
           expect(afterChecks._tag).toBe("processed")
           if (afterChecks._tag === "processed") {
-            expect(afterChecks.workItem.state).toBe("mark_pr_ready_for_review")
-          }
-
-          const afterReady = yield* claimAndRunPending
-          expect(afterReady._tag).toBe("processed")
-          if (afterReady._tag === "processed") {
-            expect(afterReady.workItem.state).toBe("decide_pr_merge")
+            expect(afterChecks.workItem.state).toBe("decide_pr_merge")
           }
 
           const afterDecide = yield* claimAndRunPending
@@ -1261,7 +1296,6 @@ describe("WorkItemLifecycle", () => {
               ["commit", "succeeded"],
               ["create_pr", "succeeded"],
               ["watch_pr_status_checks", "succeeded"],
-              ["mark_pr_ready_for_review", "succeeded"],
               ["decide_pr_merge", "succeeded"],
               ["merge_pr", "succeeded"],
               ["local_cleanup", "succeeded"],
@@ -1274,7 +1308,7 @@ describe("WorkItemLifecycle", () => {
 
           const final = yield* lifecycle.getWorkItem(created.id)
           expect(final.state).toBe("complete")
-          expect(final.stepRuns).toHaveLength(13)
+          expect(final.stepRuns).toHaveLength(12)
         }),
       ))
 
@@ -1340,7 +1374,9 @@ describe("WorkItemLifecycle", () => {
             ],
           )
 
-          for (let index = 0; index < 11; index += 1) {
+          // create…create_pr (8) + watch→decide + decide→merge = 10 runs to merge_pr.
+          yield* driveThroughCreatePrAlreadyReady(created.id)
+          for (let index = 0; index < 2; index += 1) {
             yield* makeQueuedJobsAvailable
             yield* claimAndRunPending
           }
@@ -1412,7 +1448,8 @@ describe("WorkItemLifecycle", () => {
             repository.id,
             issue.githubIssueNumber,
           )
-          for (let index = 0; index < 12; index += 1) {
+          yield* driveThroughCreatePrAlreadyReady(created.id)
+          for (let index = 0; index < 3; index += 1) {
             yield* makeQueuedJobsAvailable
             yield* claimAndRunPending
           }
@@ -1451,7 +1488,8 @@ describe("WorkItemLifecycle", () => {
             repository.id,
             issue.githubIssueNumber,
           )
-          for (let index = 0; index < 12; index += 1) {
+          yield* driveThroughCreatePrAlreadyReady(created.id)
+          for (let index = 0; index < 3; index += 1) {
             yield* makeQueuedJobsAvailable
             yield* claimAndRunPending
           }
@@ -1498,7 +1536,8 @@ describe("WorkItemLifecycle", () => {
             issue.githubIssueNumber,
           )
 
-          for (let index = 0; index < 12; index += 1) {
+          yield* driveThroughCreatePrAlreadyReady(created.id)
+          for (let index = 0; index < 3; index += 1) {
             yield* makeQueuedJobsAvailable
             yield* claimAndRunPending
           }
@@ -1565,6 +1604,7 @@ describe("WorkItemLifecycle", () => {
                 yield* TestClock.adjust(1_000)
                 yield* claimAndRunPending
               }
+              yield* forgetCreatePrDraftProvenance(created.id)
 
               // First Watch poll lands at 1_008_000 after eight 1s steps + 1s.
               yield* TestClock.setTime(anchorInstant)
@@ -1615,15 +1655,13 @@ describe("WorkItemLifecycle", () => {
                 finalDelay[0]!.available_at - finalDelay[0]!.created_at,
               ).toBe(1)
 
-              // At exactly 90_000 ms after the anchor, no_checks may advance.
+              // At exactly 90_000 ms after the anchor, settled ready may Decide.
               yield* TestClock.setTime(anchorInstant + CHECK_START_DEADLINE_MS)
               yield* sql.unsafe(`UPDATE job_queue SET available_at = 0`)
               const afterDeadline = yield* claimAndRunPending
               expect(afterDeadline._tag).toBe("processed")
               if (afterDeadline._tag === "processed") {
-                expect(afterDeadline.workItem.state).toBe(
-                  "mark_pr_ready_for_review",
-                )
+                expect(afterDeadline.workItem.state).toBe("decide_pr_merge")
               }
             }),
             makeTestLayer(steps).pipe(Layer.provideMerge(TestClock.layer())),
@@ -1665,6 +1703,7 @@ describe("WorkItemLifecycle", () => {
                   yield* TestClock.adjust(1_000)
                   yield* claimAndRunPending
                 }
+                yield* forgetCreatePrDraftProvenance(created.id)
 
                 yield* TestClock.adjust(1_000)
                 const first = yield* claimAndRunPending
@@ -1761,9 +1800,7 @@ describe("WorkItemLifecycle", () => {
                 )
                 expect(advanced._tag).toBe("processed")
                 if (advanced._tag === "processed") {
-                  expect(advanced.workItem.state).toBe(
-                    "mark_pr_ready_for_review",
-                  )
+                  expect(advanced.workItem.state).toBe("decide_pr_merge")
                 }
               }),
               makeRestartTestLayer(steps, dbPath),
@@ -1806,6 +1843,7 @@ describe("WorkItemLifecycle", () => {
                 yield* TestClock.adjust(1_000)
                 yield* claimAndRunPending
               }
+              yield* forgetCreatePrDraftProvenance(created.id)
 
               // Simulate migration backfill: unfinished Work Item already has a
               // conservative anchor with no bound head SHA.
@@ -1859,7 +1897,7 @@ describe("WorkItemLifecycle", () => {
               const advanced = yield* claimAndRunPending
               expect(advanced._tag).toBe("processed")
               if (advanced._tag === "processed") {
-                expect(advanced.workItem.state).toBe("mark_pr_ready_for_review")
+                expect(advanced.workItem.state).toBe("decide_pr_merge")
               }
             }),
             makeTestLayer(steps).pipe(Layer.provideMerge(TestClock.layer())),
@@ -1898,6 +1936,7 @@ describe("WorkItemLifecycle", () => {
                 yield* TestClock.adjust(1_000)
                 yield* claimAndRunPending
               }
+              yield* forgetCreatePrDraftProvenance(created.id)
 
               yield* TestClock.adjust(1_000)
               const early = yield* claimAndRunPending
@@ -1927,7 +1966,7 @@ describe("WorkItemLifecycle", () => {
               const ready = yield* claimAndRunPending
               expect(ready._tag).toBe("processed")
               if (ready._tag === "processed") {
-                expect(ready.workItem.state).toBe("mark_pr_ready_for_review")
+                expect(ready.workItem.state).toBe("decide_pr_merge")
               }
             }),
             makeTestLayer(steps).pipe(Layer.provideMerge(TestClock.layer())),
@@ -1968,6 +2007,7 @@ describe("WorkItemLifecycle", () => {
                 yield* TestClock.adjust(1_000)
                 yield* claimAndRunPending
               }
+              yield* forgetCreatePrDraftProvenance(created.id)
 
               yield* TestClock.setTime(harnessNow + 8_000)
               yield* sql.unsafe(`UPDATE job_queue SET available_at = 0`)
@@ -1999,7 +2039,7 @@ describe("WorkItemLifecycle", () => {
               const ready = yield* claimAndRunPending
               expect(ready._tag).toBe("processed")
               if (ready._tag === "processed") {
-                expect(ready.workItem.state).toBe("mark_pr_ready_for_review")
+                expect(ready.workItem.state).toBe("decide_pr_merge")
               }
             }),
             makeTestLayer(steps).pipe(Layer.provideMerge(TestClock.layer())),
@@ -2049,6 +2089,7 @@ describe("WorkItemLifecycle", () => {
                 yield* TestClock.adjust(1_000)
                 yield* claimAndRunPending
               }
+              yield* forgetCreatePrDraftProvenance(created.id)
 
               yield* TestClock.adjust(1_000)
               const first = yield* claimAndRunPending
@@ -2171,6 +2212,51 @@ describe("WorkItemLifecycle", () => {
               yield* TestClock.setTime(1_000_000)
               const lifecycle = yield* WorkItemLifecycle
               const { repository, issue } = yield* seedActionableIssue
+              const created = yield* lifecycle.implementNow(
+                repository.id,
+                issue.githubIssueNumber,
+              )
+
+              for (let index = 0; index < 8; index += 1) {
+                yield* TestClock.adjust(1_000)
+                yield* claimAndRunPending
+              }
+              yield* forgetCreatePrDraftProvenance(created.id)
+
+              yield* TestClock.adjust(1_000)
+              const afterDeadline = yield* claimAndRunPending
+              expect(afterDeadline._tag).toBe("processed")
+              if (afterDeadline._tag === "processed") {
+                expect(afterDeadline.workItem.state).toBe("decide_pr_merge")
+              }
+            }),
+            makeTestLayer(steps).pipe(Layer.provideMerge(TestClock.layer())),
+          ),
+        ),
+      )
+    })
+
+    it("advances a settled draft to Mark PR Ready without waiting for the Check-Start Deadline", () => {
+      const anchorInstant = 1_008_000
+      const steps: LifecycleStepsShape = {
+        ...successfulSteps,
+        watchPrStatusChecks: () =>
+          Effect.succeed({
+            _tag: "succeeded" as const,
+            createdAt: new Date(anchorInstant),
+            headSha: "draft-head",
+            headPushedAt: new Date(anchorInstant),
+            isDraft: true,
+          }),
+      }
+
+      return Effect.runPromise(
+        Effect.scoped(
+          Effect.provide(
+            Effect.gen(function* () {
+              yield* TestClock.setTime(1_000_000)
+              const lifecycle = yield* WorkItemLifecycle
+              const { repository, issue } = yield* seedActionableIssue
               yield* lifecycle.implementNow(
                 repository.id,
                 issue.githubIssueNumber,
@@ -2181,13 +2267,651 @@ describe("WorkItemLifecycle", () => {
                 yield* claimAndRunPending
               }
 
+              // Still well before the 90s deadline for this head.
+              yield* TestClock.setTime(anchorInstant + 1_000)
+              const afterWatch = yield* claimAndRunPending
+              expect(afterWatch._tag).toBe("processed")
+              if (afterWatch._tag === "processed") {
+                expect(afterWatch.workItem.state).toBe(
+                  "mark_pr_ready_for_review",
+                )
+              }
+            }),
+            makeTestLayer(steps).pipe(Layer.provideMerge(TestClock.layer())),
+          ),
+        ),
+      )
+    })
+
+    it("returns Mark PR Ready to Watch with a fresh ready-phase anchor and only then Decides after 90s", () => {
+      let prIsDraft = true
+      let markReadyCalls = 0
+      const steps: LifecycleStepsShape = {
+        ...successfulSteps,
+        watchPrStatusChecks: () =>
+          Effect.succeed({
+            _tag: "succeeded" as const,
+            createdAt: new Date(0),
+            headSha: "ready-phase-head",
+            headPushedAt: new Date(0),
+            isDraft: prIsDraft,
+          }),
+        markPrReadyForReview: () => {
+          markReadyCalls += 1
+          prIsDraft = false
+          return Effect.void
+        },
+      }
+
+      return Effect.runPromise(
+        Effect.scoped(
+          Effect.provide(
+            Effect.gen(function* () {
+              yield* TestClock.setTime(1_000_000)
+              const lifecycle = yield* WorkItemLifecycle
+              const sql = yield* SqlClient.SqlClient
+              const { repository, issue } = yield* seedActionableIssue
+              const created = yield* lifecycle.implementNow(
+                repository.id,
+                issue.githubIssueNumber,
+              )
+
+              for (let index = 0; index < 8; index += 1) {
+                yield* TestClock.adjust(1_000)
+                yield* claimAndRunPending
+              }
               yield* TestClock.adjust(1_000)
+              const afterDraftWatch = yield* claimAndRunPending
+              expect(afterDraftWatch._tag).toBe("processed")
+              if (afterDraftWatch._tag === "processed") {
+                expect(afterDraftWatch.workItem.state).toBe(
+                  "mark_pr_ready_for_review",
+                )
+              }
+
+              const markReadyAt = 2_000_000
+              yield* TestClock.setTime(markReadyAt)
+              const afterMarkReady = yield* claimAndRunPending
+              expect(afterMarkReady._tag).toBe("processed")
+              if (afterMarkReady._tag === "processed") {
+                expect(afterMarkReady.workItem.state).toBe(
+                  "watch_pr_status_checks",
+                )
+              }
+              expect(markReadyCalls).toBe(1)
+
+              const anchors = (yield* sql.unsafe(
+                `SELECT check_start_anchor_at, check_start_last_observed_is_draft
+                 FROM work_item WHERE id = ?`,
+                [created.id],
+              )) as readonly {
+                readonly check_start_anchor_at: number | null
+                readonly check_start_last_observed_is_draft: number | null
+              }[]
+              expect(anchors[0]?.check_start_anchor_at).toBe(markReadyAt)
+              expect(anchors[0]?.check_start_last_observed_is_draft).toBe(0)
+
+              // Ready phase cannot Decide before the fresh 90s window.
+              yield* TestClock.setTime(markReadyAt + 89_999)
+              yield* sql.unsafe(`UPDATE job_queue SET available_at = 0`)
+              const stillWatching = yield* claimAndRunPending
+              expect(stillWatching._tag).toBe("processed")
+              if (stillWatching._tag === "processed") {
+                expect(stillWatching.workItem.state).toBe(
+                  "watch_pr_status_checks",
+                )
+              }
+
+              yield* TestClock.setTime(markReadyAt + CHECK_START_DEADLINE_MS)
+              yield* sql.unsafe(`UPDATE job_queue SET available_at = 0`)
+              const afterReadyWindow = yield* claimAndRunPending
+              expect(afterReadyWindow._tag).toBe("processed")
+              if (afterReadyWindow._tag === "processed") {
+                expect(afterReadyWindow.workItem.state).toBe("decide_pr_merge")
+              }
+              expect(markReadyCalls).toBe(1)
+            }),
+            makeTestLayer(steps).pipe(Layer.provideMerge(TestClock.layer())),
+          ),
+        ),
+      )
+    })
+
+    it("creates a durable ready-phase anchor on first external draft-to-ready observation", async () => {
+      const root = await mkdtemp(join(tmpdir(), "rfa-draft-ready-restart-"))
+      const dbPath = join(root, "restart.db")
+      try {
+        const established = await Effect.runPromise(
+          Effect.scoped(
+            Effect.provide(
+              Effect.gen(function* () {
+                yield* TestClock.setTime(1_000_000)
+                const lifecycle = yield* WorkItemLifecycle
+                const sql = yield* SqlClient.SqlClient
+                const { repository, issue } = yield* seedActionableIssue
+                const created = yield* lifecycle.implementNow(
+                  repository.id,
+                  issue.githubIssueNumber,
+                )
+
+                for (let index = 0; index < 8; index += 1) {
+                  yield* TestClock.adjust(1_000)
+                  yield* claimAndRunPending
+                }
+
+                // Pending draft records draft observation without Mark Ready.
+                yield* TestClock.setTime(1_008_000)
+                const draftPoll = yield* claimAndRunPending
+                expect(draftPoll._tag).toBe("processed")
+                if (draftPoll._tag === "processed") {
+                  expect(draftPoll.workItem.state).toBe(
+                    "watch_pr_status_checks",
+                  )
+                }
+
+                const persisted = (yield* sql.unsafe(
+                  `SELECT check_start_last_observed_is_draft
+                   FROM work_item WHERE id = ?`,
+                  [created.id],
+                )) as readonly {
+                  readonly check_start_last_observed_is_draft: number | null
+                }[]
+                expect(persisted[0]?.check_start_last_observed_is_draft).toBe(1)
+                return { workItemId: created.id }
+              }),
+              makeRestartTestLayer(
+                {
+                  ...successfulSteps,
+                  watchPrStatusChecks: () =>
+                    Effect.succeed({
+                      _tag: "pending" as const,
+                      createdAt: new Date(1_000_000),
+                      headSha: "external-ready-head",
+                      headPushedAt: new Date(1_000_000),
+                      isDraft: true,
+                    }),
+                },
+                dbPath,
+              ),
+            ),
+          ),
+        )
+
+        const readyObservedAt = 1_050_000
+        await Effect.runPromise(
+          Effect.scoped(
+            Effect.provide(
+              Effect.gen(function* () {
+                const lifecycle = yield* WorkItemLifecycle
+                const sql = yield* SqlClient.SqlClient
+                const queue = yield* QueueService
+
+                const before = (yield* sql.unsafe(
+                  `SELECT check_start_last_observed_is_draft
+                   FROM work_item WHERE id = ?`,
+                  [established.workItemId],
+                )) as readonly {
+                  readonly check_start_last_observed_is_draft: number | null
+                }[]
+                expect(before[0]?.check_start_last_observed_is_draft).toBe(1)
+
+                yield* sql.unsafe(`UPDATE job_queue SET available_at = 0`)
+                const claimed = yield* queue.rawClaim(WORK_ITEM_LIFECYCLE_QUEUE)
+                expect(Option.isSome(claimed)).toBe(true)
+                if (Option.isNone(claimed)) {
+                  return yield* Effect.die("expected queued watch")
+                }
+                yield* TestClock.setTime(readyObservedAt)
+                const afterReady = yield* lifecycle.runStep(
+                  (claimed.value.payload as { stepRunId: string }).stepRunId,
+                )
+                expect(afterReady._tag).toBe("processed")
+                if (afterReady._tag === "processed") {
+                  expect(afterReady.workItem.state).toBe(
+                    "watch_pr_status_checks",
+                  )
+                }
+
+                const after = (yield* sql.unsafe(
+                  `SELECT check_start_last_observed_is_draft, check_start_anchor_at
+                   FROM work_item WHERE id = ?`,
+                  [established.workItemId],
+                )) as readonly {
+                  readonly check_start_last_observed_is_draft: number | null
+                  readonly check_start_anchor_at: number | null
+                }[]
+                expect(after[0]?.check_start_last_observed_is_draft).toBe(0)
+                expect(after[0]?.check_start_anchor_at).toBe(readyObservedAt)
+
+                yield* sql.unsafe(`UPDATE job_queue SET available_at = 0`)
+                const claimed2 = yield* queue.rawClaim(
+                  WORK_ITEM_LIFECYCLE_QUEUE,
+                )
+                expect(Option.isSome(claimed2)).toBe(true)
+                if (Option.isNone(claimed2)) {
+                  return yield* Effect.die("expected queued watch")
+                }
+                yield* TestClock.setTime(
+                  readyObservedAt + CHECK_START_DEADLINE_MS - 1,
+                )
+                const stillWaiting = yield* lifecycle.runStep(
+                  (claimed2.value.payload as { stepRunId: string }).stepRunId,
+                )
+                expect(stillWaiting._tag).toBe("processed")
+                if (stillWaiting._tag === "processed") {
+                  expect(stillWaiting.workItem.state).toBe(
+                    "watch_pr_status_checks",
+                  )
+                }
+
+                yield* sql.unsafe(`UPDATE job_queue SET available_at = 0`)
+                const claimed3 = yield* queue.rawClaim(
+                  WORK_ITEM_LIFECYCLE_QUEUE,
+                )
+                expect(Option.isSome(claimed3)).toBe(true)
+                if (Option.isNone(claimed3)) {
+                  return yield* Effect.die("expected queued watch")
+                }
+                yield* TestClock.setTime(
+                  readyObservedAt + CHECK_START_DEADLINE_MS,
+                )
+                const decided = yield* lifecycle.runStep(
+                  (claimed3.value.payload as { stepRunId: string }).stepRunId,
+                )
+                expect(decided._tag).toBe("processed")
+                if (decided._tag === "processed") {
+                  expect(decided.workItem.state).toBe("decide_pr_merge")
+                }
+              }),
+              makeRestartTestLayer(
+                {
+                  ...successfulSteps,
+                  watchPrStatusChecks: () =>
+                    Effect.succeed({
+                      _tag: "succeeded" as const,
+                      createdAt: new Date(1_000_000),
+                      headSha: "external-ready-head",
+                      headPushedAt: new Date(1_000_000),
+                      isDraft: false,
+                    }),
+                  markPrReadyForReview: () =>
+                    Effect.die("Mark PR Ready must not run for external ready"),
+                },
+                dbPath,
+              ),
+            ),
+          ),
+        )
+      } finally {
+        await rm(root, { recursive: true, force: true })
+      }
+    })
+
+    it("keeps draft pending, conflict, and handoff priority ahead of Mark PR Ready", () => {
+      const runDraftPriority = (
+        status: {
+          readonly _tag: "pending" | "conflict" | "handoff_needed"
+          readonly retiredCheckIds?: readonly string[]
+          readonly createdAt: Date
+          readonly headSha: string
+          readonly headPushedAt: Date
+          readonly isDraft: true
+        },
+        expectedNext:
+          | "watch_pr_status_checks"
+          | "resolve_pr_merge_conflict"
+          | "investigate_pr_status_checks",
+      ) => {
+        const steps: LifecycleStepsShape = {
+          ...successfulSteps,
+          watchPrStatusChecks: () =>
+            Effect.succeed(
+              status._tag === "conflict"
+                ? {
+                    _tag: "conflict" as const,
+                    retiredCheckIds: status.retiredCheckIds ?? [],
+                    createdAt: status.createdAt,
+                    headSha: status.headSha,
+                    headPushedAt: status.headPushedAt,
+                    isDraft: true,
+                  }
+                : status,
+            ),
+        }
+        return Effect.runPromise(
+          Effect.scoped(
+            Effect.provide(
+              Effect.gen(function* () {
+                yield* TestClock.setTime(1_000_000)
+                const lifecycle = yield* WorkItemLifecycle
+                const { repository, issue } = yield* seedActionableIssue
+                yield* lifecycle.implementNow(
+                  repository.id,
+                  issue.githubIssueNumber,
+                )
+
+                for (let index = 0; index < 8; index += 1) {
+                  yield* TestClock.adjust(1_000)
+                  yield* claimAndRunPending
+                }
+
+                yield* TestClock.adjust(1_000)
+                const afterWatch = yield* claimAndRunPending
+                expect(afterWatch._tag).toBe("processed")
+                if (afterWatch._tag === "processed") {
+                  expect(afterWatch.workItem.state).toBe(expectedNext)
+                }
+              }),
+              makeTestLayer(steps).pipe(Layer.provideMerge(TestClock.layer())),
+            ),
+          ),
+        )
+      }
+
+      return runDraftPriority(
+        {
+          _tag: "pending",
+          createdAt: new Date(0),
+          headSha: "draft-pending",
+          headPushedAt: new Date(0),
+          isDraft: true,
+        },
+        "watch_pr_status_checks",
+      )
+        .then(() =>
+          runDraftPriority(
+            {
+              _tag: "conflict",
+              retiredCheckIds: [],
+              createdAt: new Date(0),
+              headSha: "draft-conflict",
+              headPushedAt: new Date(0),
+              isDraft: true,
+            },
+            "resolve_pr_merge_conflict",
+          ),
+        )
+        .then(() =>
+          runDraftPriority(
+            {
+              _tag: "handoff_needed",
+              createdAt: new Date(0),
+              headSha: "draft-handoff",
+              headPushedAt: new Date(0),
+              isDraft: true,
+            },
+            "investigate_pr_status_checks",
+          ),
+        )
+    })
+
+    it("advances a draft failed aggregate with no unhandled terminals to Mark PR Ready", () => {
+      const steps: LifecycleStepsShape = {
+        ...successfulSteps,
+        watchPrStatusChecks: () =>
+          Effect.succeed({
+            _tag: "failed" as const,
+            createdAt: new Date(1_008_000),
+            headSha: "draft-failed-head",
+            headPushedAt: new Date(1_008_000),
+            isDraft: true,
+          }),
+      }
+
+      return Effect.runPromise(
+        Effect.scoped(
+          Effect.provide(
+            Effect.gen(function* () {
+              yield* TestClock.setTime(1_000_000)
+              const lifecycle = yield* WorkItemLifecycle
+              const { repository, issue } = yield* seedActionableIssue
+              yield* lifecycle.implementNow(
+                repository.id,
+                issue.githubIssueNumber,
+              )
+
+              for (let index = 0; index < 8; index += 1) {
+                yield* TestClock.adjust(1_000)
+                yield* claimAndRunPending
+              }
+
+              yield* TestClock.setTime(1_009_000)
+              const afterWatch = yield* claimAndRunPending
+              expect(afterWatch._tag).toBe("processed")
+              if (afterWatch._tag === "processed") {
+                expect(afterWatch.workItem.state).toBe(
+                  "mark_pr_ready_for_review",
+                )
+              }
+            }),
+            makeTestLayer(steps).pipe(Layer.provideMerge(TestClock.layer())),
+          ),
+        ),
+      )
+    })
+
+    it("anchors first Watch of an externally-ready PR after Create PR draft provenance", () => {
+      const readyObservedAt = 1_050_000
+      const steps: LifecycleStepsShape = {
+        ...successfulSteps,
+        watchPrStatusChecks: () =>
+          Effect.succeed({
+            _tag: "succeeded" as const,
+            // Old Last PR Change would already be past the deadline.
+            createdAt: new Date(0),
+            headSha: "external-before-watch",
+            headPushedAt: new Date(0),
+            isDraft: false,
+          }),
+        markPrReadyForReview: () =>
+          Effect.die("Mark PR Ready must not run when already ready"),
+      }
+
+      return Effect.runPromise(
+        Effect.scoped(
+          Effect.provide(
+            Effect.gen(function* () {
+              yield* TestClock.setTime(1_000_000)
+              const lifecycle = yield* WorkItemLifecycle
+              const sql = yield* SqlClient.SqlClient
+              const { repository, issue } = yield* seedActionableIssue
+              const created = yield* lifecycle.implementNow(
+                repository.id,
+                issue.githubIssueNumber,
+              )
+
+              for (let index = 0; index < 8; index += 1) {
+                yield* TestClock.adjust(1_000)
+                yield* claimAndRunPending
+              }
+
+              const afterCreatePr = (yield* sql.unsafe(
+                `SELECT check_start_last_observed_is_draft
+                 FROM work_item WHERE id = ?`,
+                [created.id],
+              )) as readonly {
+                readonly check_start_last_observed_is_draft: number | null
+              }[]
+              expect(afterCreatePr[0]?.check_start_last_observed_is_draft).toBe(
+                1,
+              )
+
+              yield* TestClock.setTime(readyObservedAt)
+              const firstWatch = yield* claimAndRunPending
+              expect(firstWatch._tag).toBe("processed")
+              if (firstWatch._tag === "processed") {
+                // Fresh ready-phase anchor blocks Decide despite old Last PR Change.
+                expect(firstWatch.workItem.state).toBe("watch_pr_status_checks")
+              }
+
+              const anchors = (yield* sql.unsafe(
+                `SELECT check_start_anchor_at, check_start_last_observed_is_draft
+                 FROM work_item WHERE id = ?`,
+                [created.id],
+              )) as readonly {
+                readonly check_start_anchor_at: number | null
+                readonly check_start_last_observed_is_draft: number | null
+              }[]
+              expect(anchors[0]?.check_start_anchor_at).toBe(readyObservedAt)
+              expect(anchors[0]?.check_start_last_observed_is_draft).toBe(0)
+
+              yield* TestClock.setTime(
+                readyObservedAt + CHECK_START_DEADLINE_MS,
+              )
+              yield* sql.unsafe(`UPDATE job_queue SET available_at = 0`)
               const afterDeadline = yield* claimAndRunPending
               expect(afterDeadline._tag).toBe("processed")
               if (afterDeadline._tag === "processed") {
-                expect(afterDeadline.workItem.state).toBe(
+                expect(afterDeadline.workItem.state).toBe("decide_pr_merge")
+              }
+            }),
+            makeTestLayer(steps).pipe(Layer.provideMerge(TestClock.layer())),
+          ),
+        ),
+      )
+    })
+
+    it("keeps a ready-phase anchor when Mark PR Ready is already-ready idempotent", () => {
+      let markReadyCalls = 0
+      let prIsDraft: boolean | null = true
+      const steps: LifecycleStepsShape = {
+        ...successfulSteps,
+        watchPrStatusChecks: () =>
+          Effect.succeed({
+            _tag: "succeeded" as const,
+            createdAt: new Date(0),
+            headSha: "already-ready-head",
+            headPushedAt: new Date(0),
+            isDraft: prIsDraft,
+          }),
+        // GitHub no-op path: step succeeds; subsequent snapshots report ready.
+        markPrReadyForReview: () => {
+          markReadyCalls += 1
+          prIsDraft = false
+          return Effect.void
+        },
+      }
+
+      return Effect.runPromise(
+        Effect.scoped(
+          Effect.provide(
+            Effect.gen(function* () {
+              yield* TestClock.setTime(1_000_000)
+              const lifecycle = yield* WorkItemLifecycle
+              const sql = yield* SqlClient.SqlClient
+              const { repository, issue } = yield* seedActionableIssue
+              const created = yield* lifecycle.implementNow(
+                repository.id,
+                issue.githubIssueNumber,
+              )
+
+              for (let index = 0; index < 8; index += 1) {
+                yield* TestClock.adjust(1_000)
+                yield* claimAndRunPending
+              }
+              yield* TestClock.adjust(1_000)
+              const afterDraftWatch = yield* claimAndRunPending
+              expect(afterDraftWatch._tag).toBe("processed")
+              if (afterDraftWatch._tag === "processed") {
+                expect(afterDraftWatch.workItem.state).toBe(
                   "mark_pr_ready_for_review",
                 )
+              }
+
+              const markReadyAt = 2_500_000
+              yield* TestClock.setTime(markReadyAt)
+              const afterMark = yield* claimAndRunPending
+              expect(afterMark._tag).toBe("processed")
+              if (afterMark._tag === "processed") {
+                expect(afterMark.workItem.state).toBe("watch_pr_status_checks")
+              }
+              expect(markReadyCalls).toBe(1)
+
+              const anchors = (yield* sql.unsafe(
+                `SELECT check_start_anchor_at, check_start_anchor_head_sha,
+                        check_start_last_observed_is_draft
+                 FROM work_item WHERE id = ?`,
+                [created.id],
+              )) as readonly {
+                readonly check_start_anchor_at: number | null
+                readonly check_start_anchor_head_sha: string | null
+                readonly check_start_last_observed_is_draft: number | null
+              }[]
+              expect(anchors[0]?.check_start_anchor_at).toBe(markReadyAt)
+              expect(anchors[0]?.check_start_anchor_head_sha).toBeNull()
+              expect(anchors[0]?.check_start_last_observed_is_draft).toBe(0)
+
+              // Next ready snapshot must not re-enter Mark or rewind the anchor.
+              yield* TestClock.setTime(markReadyAt + 1_000)
+              yield* sql.unsafe(`UPDATE job_queue SET available_at = 0`)
+              const afterReadyWatch = yield* claimAndRunPending
+              expect(afterReadyWatch._tag).toBe("processed")
+              if (afterReadyWatch._tag === "processed") {
+                expect(afterReadyWatch.workItem.state).toBe(
+                  "watch_pr_status_checks",
+                )
+              }
+              expect(markReadyCalls).toBe(1)
+
+              const afterReadyAnchors = (yield* sql.unsafe(
+                `SELECT check_start_anchor_at FROM work_item WHERE id = ?`,
+                [created.id],
+              )) as readonly { readonly check_start_anchor_at: number | null }[]
+              expect(afterReadyAnchors[0]?.check_start_anchor_at).toBe(
+                markReadyAt,
+              )
+
+              yield* TestClock.setTime(markReadyAt + CHECK_START_DEADLINE_MS)
+              yield* sql.unsafe(`UPDATE job_queue SET available_at = 0`)
+              const afterDeadline = yield* claimAndRunPending
+              expect(afterDeadline._tag).toBe("processed")
+              if (afterDeadline._tag === "processed") {
+                expect(afterDeadline.workItem.state).toBe("decide_pr_merge")
+              }
+              expect(markReadyCalls).toBe(1)
+            }),
+            makeTestLayer(steps).pipe(Layer.provideMerge(TestClock.layer())),
+          ),
+        ),
+      )
+    })
+
+    it("keeps polling when draft status is unknown rather than Decide or Mark Ready", () => {
+      const steps: LifecycleStepsShape = {
+        ...successfulSteps,
+        watchPrStatusChecks: () =>
+          Effect.succeed({
+            _tag: "succeeded" as const,
+            createdAt: new Date(0),
+            headSha: "unknown-draft-head",
+            headPushedAt: new Date(0),
+            isDraft: null,
+          }),
+      }
+
+      return Effect.runPromise(
+        Effect.scoped(
+          Effect.provide(
+            Effect.gen(function* () {
+              yield* TestClock.setTime(1_000_000)
+              const lifecycle = yield* WorkItemLifecycle
+              const { repository, issue } = yield* seedActionableIssue
+              const created = yield* lifecycle.implementNow(
+                repository.id,
+                issue.githubIssueNumber,
+              )
+
+              for (let index = 0; index < 8; index += 1) {
+                yield* TestClock.adjust(1_000)
+                yield* claimAndRunPending
+              }
+              yield* forgetCreatePrDraftProvenance(created.id)
+
+              yield* TestClock.adjust(1_000)
+              const afterWatch = yield* claimAndRunPending
+              expect(afterWatch._tag).toBe("processed")
+              if (afterWatch._tag === "processed") {
+                expect(afterWatch.workItem.state).toBe("watch_pr_status_checks")
               }
             }),
             makeTestLayer(steps).pipe(Layer.provideMerge(TestClock.layer())),
@@ -2230,6 +2954,8 @@ describe("WorkItemLifecycle", () => {
           for (let index = 0; index < 8; index += 1) {
             yield* claimAndRunPending
           }
+          yield* forgetCreatePrDraftProvenance(created.id)
+
           const pending = yield* claimAndRunPending
           expect(pending._tag).toBe("processed")
           if (pending._tag === "processed") {
@@ -2389,6 +3115,8 @@ describe("WorkItemLifecycle", () => {
           for (let index = 0; index < 8; index += 1) {
             yield* claimAndRunPending
           }
+          yield* forgetCreatePrDraftProvenance(created.id)
+
           const watched = yield* claimAndRunPending
           expect(watched._tag).toBe("processed")
           if (watched._tag === "processed") {
@@ -2454,6 +3182,8 @@ describe("WorkItemLifecycle", () => {
           for (let index = 0; index < 8; index += 1) {
             yield* claimAndRunPending
           }
+          yield* forgetCreatePrDraftProvenance(created.id)
+
           const watched = yield* claimAndRunPending
           expect(watched._tag).toBe("processed")
           if (watched._tag === "processed") {
@@ -2540,6 +3270,8 @@ describe("WorkItemLifecycle", () => {
               for (let index = 0; index < 8; index += 1) {
                 yield* claimAndRunPending
               }
+              yield* forgetCreatePrDraftProvenance(created.id)
+
               const watched = yield* claimAndRunPending
               expect(watched._tag).toBe("processed")
               if (watched._tag === "processed") {
@@ -2629,6 +3361,8 @@ describe("WorkItemLifecycle", () => {
           for (let index = 0; index < 8; index += 1) {
             yield* claimAndRunPending
           }
+          yield* forgetCreatePrDraftProvenance(created.id)
+
           const now = Date.now()
           yield* sql.unsafe(
             `INSERT INTO pr_status_check (
@@ -2801,11 +3535,15 @@ describe("WorkItemLifecycle", () => {
           const lifecycle = yield* WorkItemLifecycle
           const sql = yield* SqlClient.SqlClient
           const { repository, issue } = yield* seedActionableIssue
-          yield* lifecycle.implementNow(repository.id, issue.githubIssueNumber)
+          const created = yield* lifecycle.implementNow(
+            repository.id,
+            issue.githubIssueNumber,
+          )
 
           for (let index = 0; index < 8; index += 1) {
             yield* claimAndRunPending
           }
+          yield* forgetCreatePrDraftProvenance(created.id)
 
           const firstHandoff = yield* claimAndRunPending
           expect(firstHandoff._tag).toBe("processed")
@@ -2853,7 +3591,7 @@ describe("WorkItemLifecycle", () => {
           const ready = yield* claimAndRunPending
           expect(ready._tag).toBe("processed")
           if (ready._tag === "processed") {
-            expect(ready.workItem.state).toBe("mark_pr_ready_for_review")
+            expect(ready.workItem.state).toBe("decide_pr_merge")
           }
         }),
       )
@@ -2887,6 +3625,7 @@ describe("WorkItemLifecycle", () => {
           for (let index = 0; index < 8; index += 1) {
             yield* claimAndRunPending
           }
+          yield* forgetCreatePrDraftProvenance(created.id)
 
           const now = Date.now()
           yield* sql.unsafe(
@@ -2978,6 +3717,7 @@ describe("WorkItemLifecycle", () => {
                 yield* TestClock.adjust(1_000)
                 yield* claimAndRunPending
               }
+              yield* forgetCreatePrDraftProvenance(created.id)
 
               // First failed poll establishes the anchor and requeues until deadline.
               yield* TestClock.setTime(anchorInstant)
@@ -3033,7 +3773,7 @@ describe("WorkItemLifecycle", () => {
               const ready = yield* claimAndRunPending
               expect(ready._tag).toBe("processed")
               if (ready._tag === "processed") {
-                expect(ready.workItem.state).toBe("mark_pr_ready_for_review")
+                expect(ready.workItem.state).toBe("decide_pr_merge")
               }
             }),
             makeTestLayer(steps).pipe(Layer.provideMerge(TestClock.layer())),
@@ -3076,6 +3816,7 @@ describe("WorkItemLifecycle", () => {
               for (let index = 0; index < 8; index += 1) {
                 yield* claimAndRunPending
               }
+              yield* forgetCreatePrDraftProvenance(created.id)
 
               const handoff = yield* claimAndRunPending
               expect(handoff._tag).toBe("processed")
@@ -3257,12 +3998,19 @@ describe("WorkItemLifecycle", () => {
           })
 
           yield* lifecycle.implementNow(repository.id, issue.githubIssueNumber)
-          for (let index = 0; index < 13; index += 1) {
+          const wi = yield* lifecycle.listWorkItemsForIssue(
+            repository.id,
+            issue.githubIssueNumber,
+          )
+          const workItemId = wi[0]!.id
+          yield* driveThroughCreatePrAlreadyReady(workItemId)
+          for (let index = 0; index < 4; index += 1) {
             yield* makeQueuedJobsAvailable
             yield* claimAndRunPending
           }
 
-          expect(seen).toHaveLength(13)
+          // Mark Ready is skipped when the PR snapshot is already ready.
+          expect(seen).toHaveLength(12)
           expect(seen[0]!.worktreePath).toBeNull()
           expect(seen[0]!.sessionId).toBeNull()
           expect(seen[0]!.model).toBe("anthropic/claude-sonnet-4-5")
@@ -3306,8 +4054,6 @@ describe("WorkItemLifecycle", () => {
           expect(seen[10]!.sessionId).toBe("ses_recorded")
           expect(seen[11]!.worktreePath).toBe("/tmp/worktrees/recorded")
           expect(seen[11]!.sessionId).toBe("ses_recorded")
-          expect(seen[12]!.worktreePath).toBe("/tmp/worktrees/recorded")
-          expect(seen[12]!.sessionId).toBe("ses_recorded")
         }),
       )
     })
@@ -3332,7 +4078,8 @@ describe("WorkItemLifecycle", () => {
             repository.id,
             issue.githubIssueNumber,
           )
-          for (let index = 0; index < 11; index += 1) {
+          yield* driveThroughCreatePrAlreadyReady(created.id)
+          for (let index = 0; index < 2; index += 1) {
             yield* makeQueuedJobsAvailable
             yield* claimAndRunPending
           }
@@ -3366,7 +4113,8 @@ describe("WorkItemLifecycle", () => {
             repository.id,
             issue.githubIssueNumber,
           )
-          for (let index = 0; index < 11; index += 1) {
+          yield* driveThroughCreatePrAlreadyReady(created.id)
+          for (let index = 0; index < 2; index += 1) {
             yield* makeQueuedJobsAvailable
             yield* claimAndRunPending
           }
@@ -3428,7 +4176,8 @@ describe("WorkItemLifecycle", () => {
             repository.id,
             issue.githubIssueNumber,
           )
-          for (let index = 0; index < 11; index += 1) {
+          yield* driveThroughCreatePrAlreadyReady(created.id)
+          for (let index = 0; index < 2; index += 1) {
             yield* makeQueuedJobsAvailable
             yield* claimAndRunPending
           }
@@ -3468,7 +4217,8 @@ describe("WorkItemLifecycle", () => {
             repository.id,
             issue.githubIssueNumber,
           )
-          for (let index = 0; index < 11; index += 1) {
+          yield* driveThroughCreatePrAlreadyReady(created.id)
+          for (let index = 0; index < 2; index += 1) {
             yield* makeQueuedJobsAvailable
             yield* claimAndRunPending
           }
@@ -3503,7 +4253,7 @@ describe("WorkItemLifecycle", () => {
           const lifecycle = yield* WorkItemLifecycle
           const { repository, issue } = yield* seedActionableIssue
           yield* lifecycle.implementNow(repository.id, issue.githubIssueNumber)
-          for (let index = 0; index < 11; index += 1) {
+          for (let index = 0; index < 10; index += 1) {
             yield* makeQueuedJobsAvailable
             yield* claimAndRunPending
           }
@@ -3540,7 +4290,8 @@ describe("WorkItemLifecycle", () => {
             repository.id,
             issue.githubIssueNumber,
           )
-          for (let index = 0; index < 11; index += 1) {
+          yield* driveThroughCreatePrAlreadyReady(created.id)
+          for (let index = 0; index < 2; index += 1) {
             yield* makeQueuedJobsAvailable
             yield* claimAndRunPending
           }


### PR DESCRIPTION
## Summary

- Make Watch PR Status Checks draft-aware: settled drafts advance to Mark PR Ready without waiting for the Check-Start Deadline; pending, handoff, conflict, and unknown mergeability still take precedence.
- Mark PR Ready returns to Watch with a fresh ready-phase Check-Start Anchor (head binding cleared) so `ready_for_review` workflows get the full 90s window before Decide PR Merge.
- Persist draft observation (including Create PR draft provenance) so external draft-to-ready transitions survive restarts; unknown `isDraft` keeps polling instead of Decide/Mark Ready.

Closes #384

## Test plan

- [x] `bunx nx test work-item-lifecycle`
- [x] Lifecycle tests for draft skip-deadline, Mark Ready → Watch → Decide after 90s, external draft→ready across restart, already-ready idempotence, unknown draft polling
- [x] Pre-commit / affected lint, typecheck, test