### PR TITLE
fix(harness): live-refresh dashboard committed PR counts

### DIFF
--- a/apps/harness/src/local-day-bounds.ts
+++ b/apps/harness/src/local-day-bounds.ts
@@ -24,3 +24,11 @@ export const localCommittedPullRequestDayBounds = (now = new Date()) => {
     lastWeekTo: startOfThisWeek.toISOString(),
   }
 }
+
+/** Milliseconds until the next local midnight (at least 1ms). */
+export const msUntilNextLocalMidnight = (now = new Date()) => {
+  const startOfTomorrow = new Date(now)
+  startOfTomorrow.setHours(0, 0, 0, 0)
+  startOfTomorrow.setDate(startOfTomorrow.getDate() + 1)
+  return Math.max(1, startOfTomorrow.getTime() - now.getTime())
+}

--- a/apps/harness/src/refresh-work-items-live.ts
+++ b/apps/harness/src/refresh-work-items-live.ts
@@ -1,6 +1,10 @@
 import type { QueryClient } from "@tanstack/react-query"
 import { streamWorkItemsChanged } from "./work-items-live.js"
 
+export const committedPullRequestsCountQueryKeyPrefix = [
+  "committed-pull-requests-count",
+] as const
+
 export type RepositoryWorkItemsLiveQueries = {
   workItems: (repositoryId: string) => {
     queryKey: readonly unknown[]
@@ -13,7 +17,13 @@ export type RepositoryWorkItemsLiveQueries = {
  * with reconnect and tab-visibility refetch as fallback for missed ephemeral
  * notifications.
  *
- * Refetches only the affected repository's workItems query on each event.
+ * Refetches only the affected repository's workItems query on each event, and
+ * also refetches active committed-pull-requests dashboard counts (global across
+ * repositories) so the top strip stays live without polling.
+ *
+ * Per-event Work Item handling does not await count refresh, so the serial SSE
+ * loop can process the next notification while a coalesced trailing count
+ * refresh is still in flight. Connect and visibility still await counts.
  * Callers supply current Repository IDs via `getRepositoryIds` so reconnect
  * races still refresh newly added repositories.
  */
@@ -41,28 +51,26 @@ export const followRepositoryWorkItemsLive = async ({
     queryKey: readonly unknown[]
     queryFn: () => Promise<unknown>
   }) => {
+    if (signal.aborted) return
     await queryClient.cancelQueries({ queryKey: query.queryKey, exact: true })
+    if (signal.aborted) return
     return queryClient.fetchQuery({ ...query, staleTime: 0 })
   }
 
-  /**
-   * Refetch every work-items cache for the repository (default list plus any
-   * Jobs Working/Failed/Completed listKind variants already in the query cache).
-   */
-  const refresh = async (repositoryId: string) => {
-    const defaultQuery = queries.workItems(repositoryId)
-    await queryClient.cancelQueries({
-      queryKey: ["work-items", repositoryId],
-    })
-    const cached = queryClient
-      .getQueryCache()
-      .findAll({ queryKey: ["work-items", repositoryId] })
-    if (cached.length === 0) {
-      await fetchFresh(defaultQuery)
-      return
-    }
+  const refreshCachedQueries = async (
+    queryKey: readonly unknown[],
+    { activeOnly = false }: { activeOnly?: boolean } = {},
+  ) => {
+    if (signal.aborted) return
+    await queryClient.cancelQueries({ queryKey })
+    if (signal.aborted) return
+    const cached = queryClient.getQueryCache().findAll({ queryKey })
+    const targets = activeOnly
+      ? cached.filter((query) => query.isActive())
+      : cached
     await Promise.all(
-      cached.map(async (query) => {
+      targets.map(async (query) => {
+        if (signal.aborted) return
         const queryFn = query.options.queryFn
         if (typeof queryFn !== "function") return
         await queryClient.fetchQuery({
@@ -74,20 +82,183 @@ export const followRepositoryWorkItemsLive = async ({
     )
   }
 
+  let committedCountsRefresh: Promise<void> | undefined
+  let committedCountsRefreshPending = false
+  let committedCountsRetryLoop: Promise<void> | undefined
+  let fullRefreshRetryLoop: Promise<void> | undefined
+  let fullRefreshPending = false
+
+  const waitForRetryDelay = () =>
+    new Promise<void>((resolve) => {
+      if (signal.aborted) {
+        resolve()
+        return
+      }
+      const timer = setTimeout(() => {
+        signal.removeEventListener("abort", onAbort)
+        resolve()
+      }, retryDelayMs)
+      const onAbort = () => {
+        clearTimeout(timer)
+        resolve()
+      }
+      signal.addEventListener("abort", onAbort, { once: true })
+    })
+
+  /**
+   * Refetch active committed-pull-requests-count windows (Today / Yesterday /
+   * This week / Last week) observed by the mounted dashboard. Coalesces so a
+   * burst of Work Item notifications shares one trailing aggregate refresh.
+   *
+   * Intermediate pass failures are swallowed so pending notifications still
+   * drain. A failure on the final pass rejects so callers can retry or
+   * reconnect. Abort stops further trailing passes.
+   */
+  const refreshCommittedPullRequestsCounts = (): Promise<void> => {
+    if (signal.aborted) return Promise.resolve()
+    committedCountsRefreshPending = true
+    if (committedCountsRefresh !== undefined) return committedCountsRefresh
+
+    committedCountsRefresh = (async () => {
+      let lastError: unknown
+      try {
+        while (committedCountsRefreshPending && !signal.aborted) {
+          committedCountsRefreshPending = false
+          try {
+            await refreshCachedQueries(
+              committedPullRequestsCountQueryKeyPrefix,
+              { activeOnly: true },
+            )
+            lastError = undefined
+          } catch (error) {
+            lastError = error
+          }
+        }
+      } finally {
+        committedCountsRefresh = undefined
+      }
+      if (signal.aborted) {
+        committedCountsRefreshPending = false
+        return
+      }
+      if (committedCountsRefreshPending) {
+        await refreshCommittedPullRequestsCounts()
+        return
+      }
+      if (lastError !== undefined) throw lastError
+    })()
+
+    return committedCountsRefresh
+  }
+
+  /**
+   * Keep retrying count refresh until it succeeds or the follower aborts.
+   * Used for detached event-path refreshes that cannot tear down the SSE
+   * stream on failure.
+   */
+  const scheduleCommittedPullRequestsCounts = () => {
+    if (signal.aborted) return
+    if (committedCountsRetryLoop !== undefined) {
+      // Ensure the running loop performs at least one more pass after the
+      // current attempt (including while waiting out a backoff delay).
+      committedCountsRefreshPending = true
+      return
+    }
+
+    committedCountsRetryLoop = (async () => {
+      try {
+        while (!signal.aborted) {
+          try {
+            await refreshCommittedPullRequestsCounts()
+            return
+          } catch {
+            await waitForRetryDelay()
+          }
+        }
+      } finally {
+        committedCountsRetryLoop = undefined
+        if (committedCountsRefreshPending && !signal.aborted) {
+          scheduleCommittedPullRequestsCounts()
+        }
+      }
+    })()
+  }
+
+  /**
+   * Refetch every work-items cache for the repository (default list plus any
+   * Jobs Working/Failed/Completed listKind variants already in the query cache).
+   */
+  const refreshWorkItems = async (repositoryId: string) => {
+    if (signal.aborted) return
+    const defaultQuery = queries.workItems(repositoryId)
+    const queryKey = ["work-items", repositoryId] as const
+    const cached = queryClient.getQueryCache().findAll({ queryKey })
+    if (cached.length === 0) {
+      await fetchFresh(defaultQuery)
+      return
+    }
+    await refreshCachedQueries(queryKey)
+  }
+
+  const refresh = async (repositoryId: string) => {
+    // Do not await counts here: the SSE subscriber awaits each onChange, so
+    // awaiting aggregates would serialize one full count refresh per event and
+    // defeat coalescing under bursty lifecycle notifications.
+    scheduleCommittedPullRequestsCounts()
+    await refreshWorkItems(repositoryId)
+  }
+
   const refreshAll = async () => {
+    if (signal.aborted) return
     const repositoryIds = getRepositoryIds()
-    await Promise.all(
-      repositoryIds.map((repositoryId) => refresh(repositoryId)),
-    )
+    await Promise.all([
+      ...repositoryIds.map((repositoryId) => refreshWorkItems(repositoryId)),
+      refreshCommittedPullRequestsCounts(),
+    ])
+  }
+
+  const scheduleRefreshAll = () => {
+    if (signal.aborted) return
+    fullRefreshPending = true
+    if (fullRefreshRetryLoop !== undefined) return
+
+    fullRefreshRetryLoop = (async () => {
+      try {
+        while (!signal.aborted) {
+          fullRefreshPending = false
+          try {
+            await refreshAll()
+            if (!fullRefreshPending || signal.aborted) return
+          } catch {
+            await waitForRetryDelay()
+          }
+        }
+      } finally {
+        fullRefreshRetryLoop = undefined
+        if (fullRefreshPending && !signal.aborted) {
+          scheduleRefreshAll()
+        }
+      }
+    })()
   }
 
   const refreshWhenVisible = () => {
     if (documentRef?.visibilityState === "visible") {
-      void refreshAll().catch(() => undefined)
+      scheduleRefreshAll()
     }
   }
 
   documentRef?.addEventListener("visibilitychange", refreshWhenVisible)
+
+  const cancelOwnedQueries = () => {
+    committedCountsRefreshPending = false
+    fullRefreshPending = false
+    void queryClient.cancelQueries({
+      queryKey: committedPullRequestsCountQueryKeyPrefix,
+    })
+    void queryClient.cancelQueries({ queryKey: ["work-items"] })
+  }
+  signal.addEventListener("abort", cancelOwnedQueries, { once: true })
 
   try {
     while (!signal.aborted) {
@@ -123,5 +294,6 @@ export const followRepositoryWorkItemsLive = async ({
     }
   } finally {
     documentRef?.removeEventListener("visibilitychange", refreshWhenVisible)
+    signal.removeEventListener("abort", cancelOwnedQueries)
   }
 }

--- a/apps/harness/src/routes/index.tsx
+++ b/apps/harness/src/routes/index.tsx
@@ -22,9 +22,15 @@ import {
   liveDurationMs,
   useNowMs,
 } from "../live-duration.js"
-import { localCommittedPullRequestDayBounds } from "../local-day-bounds.js"
+import {
+  localCommittedPullRequestDayBounds,
+  msUntilNextLocalMidnight,
+} from "../local-day-bounds.js"
 import { followRepositoryIssuesLive } from "../refresh-issues-live.js"
-import { followRepositoryWorkItemsLive } from "../refresh-work-items-live.js"
+import {
+  committedPullRequestsCountQueryKeyPrefix,
+  followRepositoryWorkItemsLive,
+} from "../refresh-work-items-live.js"
 import { streamRepositoryChanges } from "../repository-live.js"
 import { sessionWorktreeParts } from "../session-worktree-line.js"
 import { workItemIssueUrl } from "../work-item-issue-url.js"
@@ -401,7 +407,7 @@ const jobsCompletedWorkItemsQuery = (repositoryId: string) =>
   })
 
 const committedPullRequestsCountQuery = (from: string, to: string) => ({
-  queryKey: ["committed-pull-requests-count", from, to] as const,
+  queryKey: [...committedPullRequestsCountQueryKeyPrefix, from, to] as const,
   queryFn: async (): Promise<number> => {
     const result = await graphql.query({
       committedPullRequestsCount: {
@@ -491,7 +497,37 @@ function HomeBody() {
 }
 
 function CommittedPullRequestsDashboard() {
-  const bounds = localCommittedPullRequestDayBounds()
+  const [bounds, setBounds] = useState(() =>
+    localCommittedPullRequestDayBounds(),
+  )
+
+  useEffect(() => {
+    let timer: ReturnType<typeof setTimeout> | undefined
+    const syncBounds = () => {
+      const next = localCommittedPullRequestDayBounds()
+      setBounds((current) =>
+        current.todayFrom === next.todayFrom && current.todayTo === next.todayTo
+          ? current
+          : next,
+      )
+    }
+    const scheduleMidnightRollover = () => {
+      timer = setTimeout(() => {
+        syncBounds()
+        scheduleMidnightRollover()
+      }, msUntilNextLocalMidnight())
+    }
+    const onVisibility = () => {
+      if (document.visibilityState === "visible") syncBounds()
+    }
+    scheduleMidnightRollover()
+    document.addEventListener("visibilitychange", onVisibility)
+    return () => {
+      if (timer !== undefined) clearTimeout(timer)
+      document.removeEventListener("visibilitychange", onVisibility)
+    }
+  }, [])
+
   const todayQuery = useQuery(
     committedPullRequestsCountQuery(bounds.todayFrom, bounds.todayTo),
   )

--- a/apps/harness/test/committed-pr-dashboard.test.ts
+++ b/apps/harness/test/committed-pr-dashboard.test.ts
@@ -1,6 +1,9 @@
 import { readFileSync } from "node:fs"
 import { join } from "node:path"
-import { localCommittedPullRequestDayBounds } from "../src/local-day-bounds.ts"
+import {
+  localCommittedPullRequestDayBounds,
+  msUntilNextLocalMidnight,
+} from "../src/local-day-bounds.ts"
 import { describe, expect, test } from "bun:test"
 
 const homeSource = () =>
@@ -147,6 +150,16 @@ describe("localCommittedPullRequestDayBounds", () => {
     )
   })
 
+  test("msUntilNextLocalMidnight is positive and lands on local midnight", () => {
+    const now = new Date(2026, 6, 22, 15, 30, 0, 0)
+    const ms = msUntilNextLocalMidnight(now)
+    expect(ms).toBeGreaterThan(0)
+    const rolled = new Date(now.getTime() + ms)
+    expect(rolled.getHours()).toBe(0)
+    expect(rolled.getMinutes()).toBe(0)
+    expect(rolled.getDate()).toBe(23)
+  })
+
   test("handles fall-back daylight-saving local midnight", () => {
     // US Pacific 2026: clocks fall back 2026-11-01 02:00 → 01:00
     // 2026-11-02 is a Monday
@@ -190,7 +203,10 @@ describe("Committed pull requests dashboard UI", () => {
     const source = homeSource()
     expect(source).toContain("committedPullRequestsCount")
     expect(source).toContain("localCommittedPullRequestDayBounds")
-    expect(source).toContain('queryKey: ["committed-pull-requests-count"')
+    expect(source).toContain("committedPullRequestsCountQueryKeyPrefix")
+    expect(source).toContain(
+      "queryKey: [...committedPullRequestsCountQueryKeyPrefix, from, to]",
+    )
     const dashboard = source.slice(
       source.indexOf("function CommittedPullRequestsDashboard()"),
       source.indexOf("function RepositoryCards()"),
@@ -201,6 +217,36 @@ describe("Committed pull requests dashboard UI", () => {
     expect(dashboard).toContain("bounds.lastWeekTo")
     expect(dashboard).not.toContain("workItems")
     expect(dashboard).not.toContain("JOBS_COMPLETED_LIMIT")
+  })
+
+  test("stays live via work-items subscription without polling", () => {
+    const source = homeSource()
+    expect(source).toContain("followRepositoryWorkItemsLive")
+    expect(source).toContain("committedPullRequestsCountQueryKeyPrefix")
+    const dashboard = source.slice(
+      source.indexOf("function CommittedPullRequestsDashboard()"),
+      source.indexOf("function RepositoryCards()"),
+    )
+    expect(dashboard).not.toContain("refetchInterval")
+    const refreshSource = readFileSync(
+      join(import.meta.dir, "../src/refresh-work-items-live.ts"),
+      "utf8",
+    )
+    expect(refreshSource).toContain("refreshCommittedPullRequestsCounts")
+    expect(refreshSource).toContain("committedPullRequestsCountQueryKeyPrefix")
+    expect(refreshSource).toContain('"committed-pull-requests-count"')
+  })
+
+  test("rolls day bounds at local midnight and on tab visibility", () => {
+    const source = homeSource()
+    const dashboard = source.slice(
+      source.indexOf("function CommittedPullRequestsDashboard()"),
+      source.indexOf("function RepositoryCards()"),
+    )
+    expect(dashboard).toContain("msUntilNextLocalMidnight")
+    expect(dashboard).toContain("scheduleMidnightRollover")
+    expect(dashboard).toContain("visibilitychange")
+    expect(dashboard).toContain("setBounds")
   })
 
   test("shows loading and error states without blocking Jobs", () => {

--- a/apps/harness/test/refresh-work-items-live.test.ts
+++ b/apps/harness/test/refresh-work-items-live.test.ts
@@ -1,6 +1,37 @@
-import { QueryClient } from "@tanstack/react-query"
-import { followRepositoryWorkItemsLive } from "../src/refresh-work-items-live.js"
+import { QueryClient, QueryObserver } from "@tanstack/react-query"
+import {
+  committedPullRequestsCountQueryKeyPrefix,
+  followRepositoryWorkItemsLive,
+} from "../src/refresh-work-items-live.js"
 import { describe, expect, test } from "bun:test"
+
+const observeQuery = (
+  queryClient: QueryClient,
+  query: {
+    queryKey: readonly unknown[]
+    queryFn: () => Promise<unknown>
+  },
+) => {
+  const observer = new QueryObserver(queryClient, {
+    queryKey: query.queryKey,
+    queryFn: query.queryFn,
+    staleTime: 0,
+  })
+  return observer.subscribe(() => undefined)
+}
+
+const waitFor = async (
+  predicate: () => boolean,
+  { timeoutMs = 1_000 }: { timeoutMs?: number } = {},
+) => {
+  const started = Date.now()
+  while (!predicate()) {
+    if (Date.now() - started > timeoutMs) {
+      throw new Error("waitFor timed out")
+    }
+    await Bun.sleep(5)
+  }
+}
 
 describe("Repository Work Item live-query coordination", () => {
   test("an invalidation refetches only the affected Repository Work Items", async () => {
@@ -244,5 +275,790 @@ describe("Repository Work Item live-query coordination", () => {
     controller.abort()
     await live
     expect(listeners.get("visibilitychange")?.size ?? 0).toBe(0)
+  })
+
+  test("an invalidation refetches active committed pull request counts", async () => {
+    const repositoryId = "repo-01JSELECTED000000000000000"
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    })
+    let countFetches = 0
+    let count = 22
+    const todayKey = [
+      ...committedPullRequestsCountQueryKeyPrefix,
+      "2026-07-22T00:00:00.000Z",
+      "2026-07-23T00:00:00.000Z",
+    ] as const
+    const countQuery = {
+      queryKey: todayKey,
+      queryFn: async () => {
+        countFetches += 1
+        return count
+      },
+    }
+    const stopObserving = observeQuery(queryClient, countQuery)
+    await queryClient.fetchQuery(countQuery)
+
+    let onChange: ((repositoryId: string) => void | Promise<void>) | undefined
+    let connected: (() => void) | undefined
+    const connectedPromise = new Promise<void>((resolve) => {
+      connected = resolve
+    })
+    const controller = new AbortController()
+    const live = followRepositoryWorkItemsLive({
+      getRepositoryIds: () => [repositoryId],
+      queryClient,
+      queries: {
+        workItems: (id: string) => ({
+          queryKey: ["work-items", id] as const,
+          queryFn: async () => [],
+        }),
+      },
+      signal: controller.signal,
+      stream: async ({ onConnected, onChange: handleChange, signal }) => {
+        onChange = handleChange
+        await onConnected()
+        connected?.()
+        await new Promise<void>((resolve) => {
+          signal.addEventListener("abort", () => resolve(), { once: true })
+        })
+      },
+    })
+
+    await connectedPromise
+    const fetchesAfterConnect = countFetches
+    expect(fetchesAfterConnect).toBeGreaterThan(1)
+    expect(queryClient.getQueryData(todayKey)).toBe(22)
+
+    count = 23
+    await onChange?.(repositoryId)
+    await waitFor(() => countFetches > fetchesAfterConnect)
+    expect(queryClient.getQueryData(todayKey)).toBe(23)
+
+    controller.abort()
+    await live
+    stopObserving()
+  })
+
+  test("an invalidation skips inactive committed pull request counts", async () => {
+    const repositoryId = "repo-01JSELECTED000000000000000"
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    })
+    let countFetches = 0
+    const todayKey = [
+      ...committedPullRequestsCountQueryKeyPrefix,
+      "from",
+      "to",
+    ] as const
+    await queryClient.fetchQuery({
+      queryKey: todayKey,
+      queryFn: async () => {
+        countFetches += 1
+        return countFetches
+      },
+    })
+    expect(countFetches).toBe(1)
+
+    let onChange: ((repositoryId: string) => void | Promise<void>) | undefined
+    let connected: (() => void) | undefined
+    const connectedPromise = new Promise<void>((resolve) => {
+      connected = resolve
+    })
+    const controller = new AbortController()
+    const live = followRepositoryWorkItemsLive({
+      getRepositoryIds: () => [repositoryId],
+      queryClient,
+      queries: {
+        workItems: (id: string) => ({
+          queryKey: ["work-items", id] as const,
+          queryFn: async () => [],
+        }),
+      },
+      signal: controller.signal,
+      stream: async ({ onConnected, onChange: handleChange, signal }) => {
+        onChange = handleChange
+        await onConnected()
+        connected?.()
+        await new Promise<void>((resolve) => {
+          signal.addEventListener("abort", () => resolve(), { once: true })
+        })
+      },
+    })
+
+    await connectedPromise
+    expect(countFetches).toBe(1)
+    await onChange?.(repositoryId)
+    await Bun.sleep(20)
+    expect(countFetches).toBe(1)
+
+    controller.abort()
+    await live
+  })
+
+  test("tab visibility also refetches active committed pull request counts", async () => {
+    const repositoryId = "repo-01JSELECTED000000000000000"
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    })
+    let countFetches = 0
+    const todayKey = [
+      ...committedPullRequestsCountQueryKeyPrefix,
+      "from",
+      "to",
+    ] as const
+    const countQuery = {
+      queryKey: todayKey,
+      queryFn: async () => {
+        countFetches += 1
+        return countFetches
+      },
+    }
+    const stopObserving = observeQuery(queryClient, countQuery)
+    await queryClient.fetchQuery(countQuery)
+
+    let visibilityState: DocumentVisibilityState = "hidden"
+    const listeners = new Map<string, Set<EventListener>>()
+    const documentRef = {
+      get visibilityState() {
+        return visibilityState
+      },
+      addEventListener(type: string, listener: EventListener) {
+        const set = listeners.get(type) ?? new Set()
+        set.add(listener)
+        listeners.set(type, set)
+      },
+      removeEventListener(type: string, listener: EventListener) {
+        listeners.get(type)?.delete(listener)
+      },
+    }
+
+    const controller = new AbortController()
+    const live = followRepositoryWorkItemsLive({
+      getRepositoryIds: () => [repositoryId],
+      queryClient,
+      queries: {
+        workItems: (id: string) => ({
+          queryKey: ["work-items", id],
+          queryFn: async () => [],
+        }),
+      },
+      signal: controller.signal,
+      documentRef,
+      stream: async ({ onConnected, signal }) => {
+        await onConnected()
+        await new Promise<void>((resolve) => {
+          signal.addEventListener("abort", () => resolve(), { once: true })
+        })
+      },
+    })
+
+    await Bun.sleep(10)
+    const afterConnect = countFetches
+    expect(afterConnect).toBeGreaterThan(1)
+
+    visibilityState = "visible"
+    for (const listener of listeners.get("visibilitychange") ?? []) {
+      listener(new Event("visibilitychange"))
+    }
+    await Bun.sleep(10)
+
+    expect(countFetches).toBeGreaterThan(afterConnect)
+
+    controller.abort()
+    await live
+    stopObserving()
+  })
+
+  test("serial Work Item notifications coalesce count refreshes", async () => {
+    const repositoryId = "repo-01JSELECTED000000000000000"
+    const otherRepositoryId = "repo-01JOTHER0000000000000000"
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    })
+    let countFetches = 0
+    let blockCountFetches = false
+    let releaseCountFetch: (() => void) | undefined
+    const todayKey = [
+      ...committedPullRequestsCountQueryKeyPrefix,
+      "from",
+      "to",
+    ] as const
+    const countQuery = {
+      queryKey: todayKey,
+      queryFn: async () => {
+        countFetches += 1
+        if (blockCountFetches) {
+          await new Promise<void>((resolve) => {
+            releaseCountFetch = resolve
+          })
+        }
+        return countFetches
+      },
+    }
+    const stopObserving = observeQuery(queryClient, countQuery)
+    await queryClient.fetchQuery(countQuery)
+
+    const pendingEvents: string[] = []
+    let wakeEvents: (() => void) | undefined
+    let connected: (() => void) | undefined
+    const connectedPromise = new Promise<void>((resolve) => {
+      connected = resolve
+    })
+    const controller = new AbortController()
+    const live = followRepositoryWorkItemsLive({
+      getRepositoryIds: () => [repositoryId, otherRepositoryId],
+      queryClient,
+      queries: {
+        workItems: (id: string) => ({
+          queryKey: ["work-items", id] as const,
+          queryFn: async () => [],
+        }),
+      },
+      signal: controller.signal,
+      // Mirror production: await each onChange before reading the next event.
+      stream: async ({ onConnected, onChange, signal }) => {
+        await onConnected()
+        connected?.()
+        while (!signal.aborted) {
+          if (pendingEvents.length === 0) {
+            await new Promise<void>((resolve) => {
+              if (signal.aborted) {
+                resolve()
+                return
+              }
+              wakeEvents = resolve
+              signal.addEventListener("abort", () => resolve(), { once: true })
+            })
+            wakeEvents = undefined
+            continue
+          }
+          const nextRepositoryId = pendingEvents.shift()
+          if (nextRepositoryId === undefined) continue
+          await onChange(nextRepositoryId)
+        }
+      },
+    })
+
+    await connectedPromise
+    const fetchesAfterConnect = countFetches
+    expect(fetchesAfterConnect).toBeGreaterThan(1)
+
+    blockCountFetches = true
+    pendingEvents.push(repositoryId, otherRepositoryId)
+    wakeEvents?.()
+
+    await waitFor(() => countFetches === fetchesAfterConnect + 1)
+    // Both serial events were handled (work-items path finished) while one
+    // count refresh remains gated — second event only marked a trailing pass.
+    await waitFor(() => pendingEvents.length === 0)
+    expect(countFetches).toBe(fetchesAfterConnect + 1)
+
+    blockCountFetches = false
+    releaseCountFetch?.()
+    await waitFor(() => countFetches === fetchesAfterConnect + 2)
+
+    controller.abort()
+    await live
+    stopObserving()
+  })
+
+  test("failed count refreshes keep retrying until success", async () => {
+    const repositoryId = "repo-01JSELECTED000000000000000"
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    })
+    let countFetches = 0
+    let remainingFailures = 0
+    const todayKey = [
+      ...committedPullRequestsCountQueryKeyPrefix,
+      "from",
+      "to",
+    ] as const
+    const countQuery = {
+      queryKey: todayKey,
+      queryFn: async () => {
+        countFetches += 1
+        if (remainingFailures > 0) {
+          remainingFailures -= 1
+          throw new Error("count refresh failed")
+        }
+        return countFetches
+      },
+    }
+    const stopObserving = observeQuery(queryClient, countQuery)
+    await queryClient.fetchQuery(countQuery)
+
+    const pendingEvents: string[] = []
+    let wakeEvents: (() => void) | undefined
+    let connected: (() => void) | undefined
+    const connectedPromise = new Promise<void>((resolve) => {
+      connected = resolve
+    })
+    const controller = new AbortController()
+    const live = followRepositoryWorkItemsLive({
+      getRepositoryIds: () => [repositoryId],
+      queryClient,
+      queries: {
+        workItems: (id: string) => ({
+          queryKey: ["work-items", id] as const,
+          queryFn: async () => [],
+        }),
+      },
+      signal: controller.signal,
+      retryDelayMs: 15,
+      stream: async ({ onConnected, onChange, signal }) => {
+        await onConnected()
+        connected?.()
+        while (!signal.aborted) {
+          if (pendingEvents.length === 0) {
+            await new Promise<void>((resolve) => {
+              if (signal.aborted) {
+                resolve()
+                return
+              }
+              wakeEvents = resolve
+              signal.addEventListener("abort", () => resolve(), { once: true })
+            })
+            wakeEvents = undefined
+            continue
+          }
+          const nextRepositoryId = pendingEvents.shift()
+          if (nextRepositoryId === undefined) continue
+          await onChange(nextRepositoryId)
+        }
+      },
+    })
+
+    await connectedPromise
+    const fetchesAfterConnect = countFetches
+
+    remainingFailures = 2
+    pendingEvents.push(repositoryId)
+    wakeEvents?.()
+    await waitFor(() => pendingEvents.length === 0)
+    // Two delayed retries after the first failed event-triggered pass.
+    await waitFor(() => countFetches === fetchesAfterConnect + 3)
+    expect(queryClient.getQueryData(todayKey)).toBe(fetchesAfterConnect + 3)
+
+    controller.abort()
+    await live
+    stopObserving()
+  })
+
+  test("a second visibility refresh runs a trailing pass", async () => {
+    const repositoryId = "repo-01JSELECTED000000000000000"
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    })
+    let countFetches = 0
+    let blockCountFetches = false
+    let releaseCountFetch: (() => void) | undefined
+    const todayKey = [
+      ...committedPullRequestsCountQueryKeyPrefix,
+      "from",
+      "to",
+    ] as const
+    const countQuery = {
+      queryKey: todayKey,
+      queryFn: async () => {
+        countFetches += 1
+        if (blockCountFetches) {
+          await new Promise<void>((resolve) => {
+            releaseCountFetch = resolve
+          })
+        }
+        return countFetches
+      },
+    }
+    const stopObserving = observeQuery(queryClient, countQuery)
+    await queryClient.fetchQuery(countQuery)
+
+    let visibilityState: DocumentVisibilityState = "hidden"
+    const listeners = new Map<string, Set<EventListener>>()
+    const documentRef = {
+      get visibilityState() {
+        return visibilityState
+      },
+      addEventListener(type: string, listener: EventListener) {
+        const set = listeners.get(type) ?? new Set()
+        set.add(listener)
+        listeners.set(type, set)
+      },
+      removeEventListener(type: string, listener: EventListener) {
+        listeners.get(type)?.delete(listener)
+      },
+    }
+
+    const controller = new AbortController()
+    const live = followRepositoryWorkItemsLive({
+      getRepositoryIds: () => [repositoryId],
+      queryClient,
+      queries: {
+        workItems: (id: string) => ({
+          queryKey: ["work-items", id],
+          queryFn: async () => [],
+        }),
+      },
+      signal: controller.signal,
+      documentRef,
+      stream: async ({ onConnected, signal }) => {
+        await onConnected()
+        await new Promise<void>((resolve) => {
+          signal.addEventListener("abort", () => resolve(), { once: true })
+        })
+      },
+    })
+
+    await Bun.sleep(10)
+    const afterConnect = countFetches
+    blockCountFetches = true
+    visibilityState = "visible"
+    for (const listener of listeners.get("visibilitychange") ?? []) {
+      listener(new Event("visibilitychange"))
+    }
+    await waitFor(() => countFetches === afterConnect + 1)
+
+    // Second visibility pulse while the first full refresh is still gated.
+    for (const listener of listeners.get("visibilitychange") ?? []) {
+      listener(new Event("visibilitychange"))
+    }
+    await Bun.sleep(10)
+    expect(countFetches).toBe(afterConnect + 1)
+
+    blockCountFetches = false
+    releaseCountFetch?.()
+    await waitFor(() => countFetches === afterConnect + 2)
+
+    controller.abort()
+    await live
+    stopObserving()
+  })
+
+  test("abort stops trailing committed count refreshes", async () => {
+    const repositoryId = "repo-01JSELECTED000000000000000"
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    })
+    let countFetches = 0
+    let blockCountFetches = false
+    let releaseCountFetch: (() => void) | undefined
+    const todayKey = [
+      ...committedPullRequestsCountQueryKeyPrefix,
+      "from",
+      "to",
+    ] as const
+    const countQuery = {
+      queryKey: todayKey,
+      queryFn: async () => {
+        countFetches += 1
+        if (blockCountFetches) {
+          await new Promise<void>((resolve) => {
+            releaseCountFetch = resolve
+          })
+        }
+        return countFetches
+      },
+    }
+    const stopObserving = observeQuery(queryClient, countQuery)
+    await queryClient.fetchQuery(countQuery)
+
+    const pendingEvents: string[] = []
+    let wakeEvents: (() => void) | undefined
+    let connected: (() => void) | undefined
+    const connectedPromise = new Promise<void>((resolve) => {
+      connected = resolve
+    })
+    const controller = new AbortController()
+    const live = followRepositoryWorkItemsLive({
+      getRepositoryIds: () => [repositoryId],
+      queryClient,
+      queries: {
+        workItems: (id: string) => ({
+          queryKey: ["work-items", id] as const,
+          queryFn: async () => [],
+        }),
+      },
+      signal: controller.signal,
+      stream: async ({ onConnected, onChange, signal }) => {
+        await onConnected()
+        connected?.()
+        while (!signal.aborted) {
+          if (pendingEvents.length === 0) {
+            await new Promise<void>((resolve) => {
+              if (signal.aborted) {
+                resolve()
+                return
+              }
+              wakeEvents = resolve
+              signal.addEventListener("abort", () => resolve(), { once: true })
+            })
+            wakeEvents = undefined
+            continue
+          }
+          const nextRepositoryId = pendingEvents.shift()
+          if (nextRepositoryId === undefined) continue
+          await onChange(nextRepositoryId)
+        }
+      },
+    })
+
+    await connectedPromise
+    const fetchesAfterConnect = countFetches
+    blockCountFetches = true
+    pendingEvents.push(repositoryId, repositoryId)
+    wakeEvents?.()
+    await waitFor(() => countFetches === fetchesAfterConnect + 1)
+    await waitFor(() => pendingEvents.length === 0)
+
+    controller.abort()
+    blockCountFetches = false
+    releaseCountFetch?.()
+    await live
+    await Bun.sleep(20)
+    expect(countFetches).toBe(fetchesAfterConnect + 1)
+    stopObserving()
+  })
+
+  test("visibility refresh keeps retrying after failure", async () => {
+    const repositoryId = "repo-01JSELECTED000000000000000"
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    })
+    let countFetches = 0
+    let remainingFailures = 0
+    const todayKey = [
+      ...committedPullRequestsCountQueryKeyPrefix,
+      "from",
+      "to",
+    ] as const
+    const countQuery = {
+      queryKey: todayKey,
+      queryFn: async () => {
+        countFetches += 1
+        if (remainingFailures > 0) {
+          remainingFailures -= 1
+          throw new Error("count refresh failed")
+        }
+        return countFetches
+      },
+    }
+    const stopObserving = observeQuery(queryClient, countQuery)
+    await queryClient.fetchQuery(countQuery)
+
+    let visibilityState: DocumentVisibilityState = "hidden"
+    const listeners = new Map<string, Set<EventListener>>()
+    const documentRef = {
+      get visibilityState() {
+        return visibilityState
+      },
+      addEventListener(type: string, listener: EventListener) {
+        const set = listeners.get(type) ?? new Set()
+        set.add(listener)
+        listeners.set(type, set)
+      },
+      removeEventListener(type: string, listener: EventListener) {
+        listeners.get(type)?.delete(listener)
+      },
+    }
+
+    const controller = new AbortController()
+    const live = followRepositoryWorkItemsLive({
+      getRepositoryIds: () => [repositoryId],
+      queryClient,
+      queries: {
+        workItems: (id: string) => ({
+          queryKey: ["work-items", id],
+          queryFn: async () => [],
+        }),
+      },
+      signal: controller.signal,
+      documentRef,
+      retryDelayMs: 15,
+      stream: async ({ onConnected, signal }) => {
+        await onConnected()
+        await new Promise<void>((resolve) => {
+          signal.addEventListener("abort", () => resolve(), { once: true })
+        })
+      },
+    })
+
+    await Bun.sleep(10)
+    const afterConnect = countFetches
+    remainingFailures = 2
+    visibilityState = "visible"
+    for (const listener of listeners.get("visibilitychange") ?? []) {
+      listener(new Event("visibilitychange"))
+    }
+    await waitFor(() => countFetches >= afterConnect + 3)
+    expect(queryClient.getQueryData(todayKey)).toBeGreaterThanOrEqual(
+      afterConnect + 3,
+    )
+
+    controller.abort()
+    await live
+    stopObserving()
+  })
+
+  test("a failed count refresh still drains a pending notification", async () => {
+    const repositoryId = "repo-01JSELECTED000000000000000"
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    })
+    let countFetches = 0
+    let failNextCountFetch = false
+    let blockCountFetches = false
+    let releaseCountFetch: (() => void) | undefined
+    const todayKey = [
+      ...committedPullRequestsCountQueryKeyPrefix,
+      "from",
+      "to",
+    ] as const
+    const countQuery = {
+      queryKey: todayKey,
+      queryFn: async () => {
+        countFetches += 1
+        if (blockCountFetches) {
+          await new Promise<void>((resolve) => {
+            releaseCountFetch = resolve
+          })
+        }
+        if (failNextCountFetch) {
+          failNextCountFetch = false
+          throw new Error("count refresh failed")
+        }
+        return countFetches
+      },
+    }
+    const stopObserving = observeQuery(queryClient, countQuery)
+    await queryClient.fetchQuery(countQuery)
+
+    const pendingEvents: string[] = []
+    let wakeEvents: (() => void) | undefined
+    let connected: (() => void) | undefined
+    const connectedPromise = new Promise<void>((resolve) => {
+      connected = resolve
+    })
+    const controller = new AbortController()
+    const live = followRepositoryWorkItemsLive({
+      getRepositoryIds: () => [repositoryId],
+      queryClient,
+      queries: {
+        workItems: (id: string) => ({
+          queryKey: ["work-items", id] as const,
+          queryFn: async () => [],
+        }),
+      },
+      signal: controller.signal,
+      stream: async ({ onConnected, onChange, signal }) => {
+        await onConnected()
+        connected?.()
+        while (!signal.aborted) {
+          if (pendingEvents.length === 0) {
+            await new Promise<void>((resolve) => {
+              if (signal.aborted) {
+                resolve()
+                return
+              }
+              wakeEvents = resolve
+              signal.addEventListener("abort", () => resolve(), { once: true })
+            })
+            wakeEvents = undefined
+            continue
+          }
+          const nextRepositoryId = pendingEvents.shift()
+          if (nextRepositoryId === undefined) continue
+          await onChange(nextRepositoryId)
+        }
+      },
+    })
+
+    await connectedPromise
+    const fetchesAfterConnect = countFetches
+
+    failNextCountFetch = true
+    blockCountFetches = true
+    pendingEvents.push(repositoryId)
+    wakeEvents?.()
+    await waitFor(() => countFetches === fetchesAfterConnect + 1)
+    await waitFor(() => pendingEvents.length === 0)
+
+    // Second event arrives while the failing pass is still in flight.
+    pendingEvents.push(repositoryId)
+    wakeEvents?.()
+    await waitFor(() => pendingEvents.length === 0)
+
+    blockCountFetches = false
+    releaseCountFetch?.()
+    // Failed pass must not drop the pending notification's trailing refresh.
+    await waitFor(() => countFetches === fetchesAfterConnect + 2)
+    expect(queryClient.getQueryData(todayKey)).toBe(fetchesAfterConnect + 2)
+
+    controller.abort()
+    await live
+    stopObserving()
+  })
+
+  test("abort cancels in-flight Work Item refreshes", async () => {
+    const repositoryId = "repo-01JSELECTED000000000000000"
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    })
+    let workItemFetches = 0
+    let releaseWorkItemFetch: (() => void) | undefined
+    const workItemsQuery = {
+      queryKey: ["work-items", repositoryId] as const,
+      queryFn: async () => {
+        workItemFetches += 1
+        if (workItemFetches >= 2) {
+          await new Promise<void>((resolve) => {
+            releaseWorkItemFetch = resolve
+          })
+        }
+        return [{ id: `wi-${workItemFetches}` }]
+      },
+    }
+
+    let onChange: ((repositoryId: string) => void | Promise<void>) | undefined
+    let connected: (() => void) | undefined
+    const connectedPromise = new Promise<void>((resolve) => {
+      connected = resolve
+    })
+    const controller = new AbortController()
+    const live = followRepositoryWorkItemsLive({
+      getRepositoryIds: () => [repositoryId],
+      queryClient,
+      queries: {
+        workItems: () => workItemsQuery,
+      },
+      signal: controller.signal,
+      stream: async ({ onConnected, onChange: handleChange, signal }) => {
+        onChange = handleChange
+        await onConnected()
+        connected?.()
+        await new Promise<void>((resolve) => {
+          signal.addEventListener("abort", () => resolve(), { once: true })
+        })
+      },
+    })
+
+    await connectedPromise
+    const fetchesAfterConnect = workItemFetches
+    expect(fetchesAfterConnect).toBeGreaterThan(0)
+
+    const inFlight = onChange?.(repositoryId)
+    await waitFor(() => workItemFetches === fetchesAfterConnect + 1)
+    expect(releaseWorkItemFetch).toBeDefined()
+
+    controller.abort()
+    await live
+    releaseWorkItemFetch?.()
+    await inFlight?.catch(() => undefined)
+    await Bun.sleep(20)
+
+    expect(workItemFetches).toBe(fetchesAfterConnect + 1)
+    expect(queryClient.getQueryData(workItemsQuery.queryKey)).toEqual([
+      { id: `wi-${fetchesAfterConnect}` },
+    ])
   })
 })


### PR DESCRIPTION
## Summary

- Refresh the console Today / Yesterday / This week / Last week committed-PR counts live via the existing work-items SSE path (no polling).
- Coalesce active-query refetches with retries, visibility fallback, abort-safe cleanup, and local-midnight day-bound rollover.

Closes #415

## Test plan

- [x] `bunx nx test harness -- test/refresh-work-items-live.test.ts test/committed-pr-dashboard.test.ts`
- [x] `bunx nx lint harness` / `bunx nx typecheck harness`
- [ ] Manually: complete a commit while the console is open and confirm dashboard counts update without reload
- [ ] Manually: leave tab open across local midnight and confirm period bounds roll over