### PR TITLE
fix(opencode): invoke review via --command without quoted /review prompt

### DIFF
--- a/packages/opencode/src/lib/build-args.ts
+++ b/packages/opencode/src/lib/build-args.ts
@@ -1,9 +1,19 @@
+const commandName = (command: string): string =>
+  command.startsWith("/") ? command.slice(1) : command
+
+const messageTokens = (prompt: string): ReadonlyArray<string> =>
+  prompt
+    .trim()
+    .split(/\s+/)
+    .filter((token) => token.length > 0)
+
 export const buildRunArgs = (input: {
   readonly prompt: string
   readonly cwd: string
   readonly model: string
   readonly variant: string
   readonly sessionId?: string
+  readonly command?: string
 }): ReadonlyArray<string> => {
   const args = [
     "run",
@@ -22,6 +32,24 @@ export const buildRunArgs = (input: {
     args.push("--session", input.sessionId)
   }
 
+  if (input.command !== undefined) {
+    args.push("--command", commandName(input.command))
+    const tokens = messageTokens(input.prompt)
+    if (tokens.length > 0) {
+      args.push("--", ...tokens)
+    }
+    return args
+  }
+
   args.push(input.prompt)
   return args
 }
+
+export const joinOpenCodeMessageArgs = (
+  messageArgs: ReadonlyArray<string>,
+): string =>
+  messageArgs
+    .map((token) =>
+      token.includes(" ") ? `"${token.replace(/"/g, '\\"')}"` : token,
+    )
+    .join(" ")

--- a/packages/opencode/src/lib/opencode.ts
+++ b/packages/opencode/src/lib/opencode.ts
@@ -112,6 +112,7 @@ export class Opencode extends Context.Service<
           readonly model: string
           readonly variant: string
           readonly sessionId?: string
+          readonly command?: string
           readonly timeout?: Duration.Input
           readonly onSessionId?: StartInput["onSessionId"]
         }): Effect.Effect<OpencodeRunResult, OpencodeError> =>
@@ -128,6 +129,9 @@ export class Opencode extends Context.Service<
               model: input.model,
               variant: input.variant,
               sessionId: input.sessionId,
+              ...(input.command !== undefined
+                ? { command: input.command }
+                : {}),
             })
 
             const command = ChildProcess.make(binary, args, {

--- a/packages/opencode/src/lib/types.ts
+++ b/packages/opencode/src/lib/types.ts
@@ -32,6 +32,7 @@ export interface StartInput {
   readonly variant: string
   readonly timeout?: Duration.Input
   readonly onSessionId?: OnSessionId
+  readonly command?: string
 }
 
 export interface ContinueInput {
@@ -42,6 +43,7 @@ export interface ContinueInput {
   readonly variant: string
   readonly timeout?: Duration.Input
   readonly onSessionId?: OnSessionId
+  readonly command?: string
 }
 
 export interface OpencodeLayerOptions {

--- a/packages/opencode/test/build-args.spec.ts
+++ b/packages/opencode/test/build-args.spec.ts
@@ -1,8 +1,20 @@
-import { buildRunArgs } from "../src/lib/build-args.js"
+import { buildRunArgs, joinOpenCodeMessageArgs } from "../src/lib/build-args.js"
 import { describe, expect, it } from "bun:test"
 
+const messageFromArgs = (args: ReadonlyArray<string>): string => {
+  const separatorIndex = args.indexOf("--")
+  if (separatorIndex !== -1) {
+    return joinOpenCodeMessageArgs(args.slice(separatorIndex + 1))
+  }
+  const commandIndex = args.indexOf("--command")
+  if (commandIndex !== -1) {
+    return joinOpenCodeMessageArgs(args.slice(commandIndex + 2))
+  }
+  return joinOpenCodeMessageArgs(args.slice(-1))
+}
+
 describe("buildRunArgs", () => {
-  it("builds start args with auto, json, model, and variant", () => {
+  it("builds start args with auto, json, model, and a single prompt positional", () => {
     expect(
       buildRunArgs({
         prompt: "fix the bug",
@@ -22,6 +34,37 @@ describe("buildRunArgs", () => {
       "--variant",
       "high",
       "fix the bug",
+    ])
+  })
+
+  it("preserves multi-line non-review prompts as one positional", () => {
+    const prompt = [
+      "Run git hook run --ignore-missing pre-commit",
+      "",
+      "```",
+      "stderr excerpt",
+      "```",
+    ].join("\n")
+
+    expect(
+      buildRunArgs({
+        prompt,
+        cwd: "/worktrees/repository",
+        model: "anthropic/claude-sonnet-4-5",
+        variant: "high",
+      }),
+    ).toEqual([
+      "run",
+      "--auto",
+      "--format",
+      "json",
+      "--dir",
+      "/worktrees/repository",
+      "-m",
+      "anthropic/claude-sonnet-4-5",
+      "--variant",
+      "high",
+      prompt,
     ])
   })
 
@@ -48,6 +91,98 @@ describe("buildRunArgs", () => {
       "--session",
       "ses_abc",
       "continue",
+    ])
+  })
+
+  it("invokes /review via --command with unquoted tokenized args after --", () => {
+    const prompt = [
+      "Review uncommitted worktree changes.",
+      "Do not edit files, commit, push, open pull requests, or apply findings in this turn.",
+      "End your final response with exactly one machine-readable result line:",
+      "READY_FOR_AGENT_RESULT: REVIEW_CLEAN",
+      "or",
+      "READY_FOR_AGENT_RESULT: REVIEW_HAS_FINDINGS",
+    ].join("\n")
+
+    const args = buildRunArgs({
+      prompt,
+      cwd: "/worktrees/repository",
+      model: "anthropic/claude-sonnet-4-5",
+      variant: "high",
+      sessionId: "ses_review",
+      command: "/review",
+    })
+
+    expect(args.slice(0, 15)).toEqual([
+      "run",
+      "--auto",
+      "--format",
+      "json",
+      "--dir",
+      "/worktrees/repository",
+      "-m",
+      "anthropic/claude-sonnet-4-5",
+      "--variant",
+      "high",
+      "--session",
+      "ses_review",
+      "--command",
+      "review",
+      "--",
+    ])
+    expect(args).not.toContain("/review")
+    expect(args.slice(15).every((token) => !token.includes(" "))).toBe(true)
+    expect(args).toContain("uncommitted")
+    expect(
+      args.indexOf("--") < args.indexOf("--ignore-missing") ||
+        !args.includes("--ignore-missing"),
+    ).toBe(true)
+
+    const withFlags = buildRunArgs({
+      prompt: "use --ignore-missing safely",
+      cwd: "/tmp",
+      model: "m",
+      variant: "v",
+      command: "/review",
+    })
+    expect(
+      withFlags.indexOf("--") < withFlags.indexOf("--ignore-missing"),
+    ).toBe(true)
+
+    const persisted = messageFromArgs(args)
+    expect(persisted.startsWith('"')).toBe(false)
+    expect(persisted.endsWith('"')).toBe(false)
+    expect(persisted.startsWith("/review")).toBe(false)
+    expect(persisted).toContain("Review uncommitted worktree changes.")
+    expect(persisted).toContain(
+      "Do not edit files, commit, push, open pull requests, or apply findings in this turn.",
+    )
+    expect(persisted).toContain("READY_FOR_AGENT_RESULT: REVIEW_CLEAN")
+    expect(persisted).toContain("READY_FOR_AGENT_RESULT: REVIEW_HAS_FINDINGS")
+  })
+
+  it("omits empty prompt when only a command is set", () => {
+    expect(
+      buildRunArgs({
+        prompt: "",
+        cwd: "/worktrees/repository",
+        model: "anthropic/claude-sonnet-4-5",
+        variant: "high",
+        command: "/review",
+      }),
+    ).toEqual([
+      "run",
+      "--auto",
+      "--format",
+      "json",
+      "--dir",
+      "/worktrees/repository",
+      "-m",
+      "anthropic/claude-sonnet-4-5",
+      "--variant",
+      "high",
+      "--command",
+      "review",
     ])
   })
 })

--- a/packages/work-item-lifecycle/src/lib/review.ts
+++ b/packages/work-item-lifecycle/src/lib/review.ts
@@ -43,10 +43,12 @@ export type ApplyReviewResult =
   | { readonly _tag: "deferred"; readonly reason: string }
   | { readonly _tag: "fixed" }
 
-const buildReviewingPrompt = () =>
+export const REVIEW_AGENT_COMMAND = "/review"
+
+export const buildReviewingPrompt = () =>
   [
-    "/review",
-    "After the review, do not edit files, commit, push, open pull requests, or apply findings in this turn.",
+    "Review uncommitted worktree changes.",
+    "Do not edit files, commit, push, open pull requests, or apply findings in this turn.",
     "End your final response with exactly one machine-readable result line:",
     "READY_FOR_AGENT_RESULT: REVIEW_CLEAN",
     "or",
@@ -262,6 +264,7 @@ export const review = (context: LifecycleStepContext) =>
       const reviewing = yield* opencode
         .continue({
           sessionId,
+          command: REVIEW_AGENT_COMMAND,
           prompt: buildReviewingPrompt(),
           cwd: worktreePath,
           model: context.reviewModel,

--- a/packages/work-item-lifecycle/test/review.spec.ts
+++ b/packages/work-item-lifecycle/test/review.spec.ts
@@ -17,6 +17,7 @@ import {
   CurrentStepRun,
   MAX_REVIEW_FIX_ROUNDS,
   PreCommitOpenCodeError,
+  REVIEW_AGENT_COMMAND,
   REVIEW_APPLYING_FINDINGS_MESSAGE,
   REVIEW_FIX_LIMIT_REASON,
   REVIEW_PRE_COMMIT_MESSAGE,
@@ -26,6 +27,7 @@ import {
   ReviewSessionContextMissingError,
   ReviewWorktreeContextMissingError,
   STEP_RUN_REASON,
+  buildReviewingPrompt,
   makeWorkItemId,
   parseApplyReviewResult,
   parseReviewResult,
@@ -68,6 +70,7 @@ const stubOpencode = (impl: {
     readonly model: string
     readonly variant: string
     readonly timeout?: Duration.Input
+    readonly command?: string
   }) => Effect.Effect<{ sessionId: string; assistantText: string }, never>
 }) =>
   Layer.succeed(
@@ -226,6 +229,33 @@ describe("parseApplyReviewResult", () => {
   })
 })
 
+const isReviewingTurn = (input: {
+  readonly command?: string
+  readonly prompt: string
+}): boolean =>
+  input.command === REVIEW_AGENT_COMMAND ||
+  input.prompt === buildReviewingPrompt()
+
+describe("buildReviewingPrompt", () => {
+  it("forbids edits and requires the result contract without a bare leading /review line", () => {
+    const prompt = buildReviewingPrompt()
+    expect(prompt).toBe(
+      [
+        "Review uncommitted worktree changes.",
+        "Do not edit files, commit, push, open pull requests, or apply findings in this turn.",
+        "End your final response with exactly one machine-readable result line:",
+        "READY_FOR_AGENT_RESULT: REVIEW_CLEAN",
+        "or",
+        "READY_FOR_AGENT_RESULT: REVIEW_HAS_FINDINGS",
+      ].join("\n"),
+    )
+    expect(prompt.startsWith('"')).toBe(false)
+    expect(prompt.endsWith('"')).toBe(false)
+    expect(prompt.startsWith("/review")).toBe(false)
+    expect(REVIEW_AGENT_COMMAND).toBe("/review")
+  })
+})
+
 describe("review", () => {
   it("rejects missing worktree context", async () => {
     const error = await run(review(baseContext(null)).pipe(Effect.flip))
@@ -263,6 +293,7 @@ describe("review", () => {
         model: string
         variant: string
         timeout?: Duration.Input
+        command?: string
       } | null = null
       let started = false
 
@@ -302,7 +333,14 @@ describe("review", () => {
       expect(Duration.toMillis(continued!.timeout!)).toBe(
         Duration.toMillis(Duration.minutes(45)),
       )
-      expect(continued!.prompt).toContain("/review")
+      expect(continued!.command).toBe(REVIEW_AGENT_COMMAND)
+      expect(continued!.prompt).toBe(buildReviewingPrompt())
+      expect(continued!.prompt.startsWith('"')).toBe(false)
+      expect(continued!.prompt.endsWith('"')).toBe(false)
+      expect(continued!.prompt.startsWith("/review")).toBe(false)
+      expect(continued!.prompt).toContain(
+        "Do not edit files, commit, push, open pull requests, or apply findings",
+      )
       expect(continued!.prompt).toContain(
         "READY_FOR_AGENT_RESULT: REVIEW_CLEAN",
       )
@@ -333,6 +371,7 @@ describe("review", () => {
         model: string
         variant: string
         prompt: string
+        command?: string
       }> = []
 
       const result = await run(
@@ -350,6 +389,7 @@ describe("review", () => {
               model: input.model,
               variant: input.variant,
               prompt: input.prompt,
+              command: input.command,
             })
             if (continues.length === 1) {
               return Effect.succeed({
@@ -370,7 +410,8 @@ describe("review", () => {
       expect(continues).toHaveLength(2)
       expect(continues[0]!.model).toBe("opencode/review-model")
       expect(continues[0]!.variant).toBe("max")
-      expect(continues[0]!.prompt).toContain("/review")
+      expect(continues[0]!.command).toBe(REVIEW_AGENT_COMMAND)
+      expect(continues[0]!.prompt).toBe(buildReviewingPrompt())
       expect(continues[1]!.model).toBe("opencode/build-model")
       expect(continues[1]!.variant).toBe("high")
       expect(continues[1]!.prompt).toContain("REVIEW_FIXED")
@@ -432,6 +473,7 @@ describe("review", () => {
         model: string
         variant: string
         prompt: string
+        command?: string
       }> = []
 
       const result = await run(
@@ -449,6 +491,7 @@ describe("review", () => {
               model: input.model,
               variant: input.variant,
               prompt: input.prompt,
+              command: input.command,
             })
             if (continues.length === 1) {
               return Effect.succeed({
@@ -477,13 +520,15 @@ describe("review", () => {
       expect(continues).toHaveLength(3)
       expect(continues[0]!.model).toBe("opencode/review-model")
       expect(continues[0]!.variant).toBe("max")
-      expect(continues[0]!.prompt).toContain("/review")
+      expect(continues[0]!.command).toBe(REVIEW_AGENT_COMMAND)
+      expect(continues[0]!.prompt).toBe(buildReviewingPrompt())
       expect(continues[1]!.model).toBe("opencode/build-model")
       expect(continues[1]!.variant).toBe("high")
       expect(continues[1]!.prompt).toContain("REVIEW_FIXED")
       expect(continues[2]!.model).toBe("opencode/review-model")
       expect(continues[2]!.variant).toBe("max")
-      expect(continues[2]!.prompt).toContain("/review")
+      expect(continues[2]!.command).toBe(REVIEW_AGENT_COMMAND)
+      expect(continues[2]!.prompt).toBe(buildReviewingPrompt())
     }))
 
   it("fails the Review Step Run when nested Pre-Commit fails after FIXED", () =>
@@ -537,7 +582,7 @@ describe("review", () => {
         stubOpencode({
           continue: (input) => {
             turn += 1
-            if (input.prompt.includes("/review")) {
+            if (isReviewingTurn(input)) {
               return Effect.succeed({
                 sessionId: "ses_implement_session",
                 assistantText: "READY_FOR_AGENT_RESULT: REVIEW_HAS_FINDINGS",
@@ -575,7 +620,7 @@ describe("review", () => {
         stubOpencode({
           continue: (input) => {
             turn += 1
-            if (input.prompt.includes("/review")) {
+            if (isReviewingTurn(input)) {
               return Effect.succeed({
                 sessionId: "ses_implement_session",
                 assistantText:
@@ -608,7 +653,7 @@ describe("review", () => {
         review(baseContext(root)),
         stubOpencode({
           continue: (input) => {
-            if (input.prompt.includes("/review")) {
+            if (isReviewingTurn(input)) {
               reviewingPasses += 1
               return Effect.succeed({
                 sessionId: "ses_implement_session",
@@ -644,7 +689,7 @@ describe("review", () => {
         stubOpencode({
           continue: (input) => {
             turn += 1
-            if (input.prompt.includes("/review")) {
+            if (isReviewingTurn(input)) {
               return Effect.succeed({
                 sessionId: "ses_implement_session",
                 assistantText: "READY_FOR_AGENT_RESULT: REVIEW_HAS_FINDINGS",


### PR DESCRIPTION
## Summary
- Invoke Review via OpenCode `--command review` instead of a bare multi-line `/review` positional prompt.
- Pass no-edit + `READY_FOR_AGENT_RESULT` instructions as tokenized command args so the Session is not wrapped in literal quotes.
- Keep ordinary non-command prompts as a single positional to preserve multi-line structure.

Closes #421

## Test plan
- [x] `bunx nx test opencode`
- [x] `bunx nx test work-item-lifecycle`
- [x] `bunx nx run opencode:lint` / `typecheck`
- [x] `bunx nx run work-item-lifecycle:lint` / `typecheck`
- [x] Pre-commit affected lint/typecheck/test