### PR TITLE
fix(review): recover omitted command verdicts

### DIFF
--- a/packages/work-item-lifecycle/src/lib/review.ts
+++ b/packages/work-item-lifecycle/src/lib/review.ts
@@ -55,6 +55,16 @@ export const buildReviewingPrompt = () =>
     "READY_FOR_AGENT_RESULT: REVIEW_HAS_FINDINGS",
   ].join("\n")
 
+const buildReviewVerdictPrompt = () =>
+  [
+    "The /review command immediately above has completed.",
+    "Do not review again, edit files, or add explanatory prose.",
+    "If it reported any Review Findings, respond exactly:",
+    "READY_FOR_AGENT_RESULT: REVIEW_HAS_FINDINGS",
+    "Otherwise respond exactly:",
+    "READY_FOR_AGENT_RESULT: REVIEW_CLEAN",
+  ].join("\n")
+
 const buildApplyFindingsPrompt = () =>
   [
     "The previous reviewing pass reported Review Findings (REVIEW_HAS_FINDINGS).",
@@ -87,6 +97,11 @@ const uniqueFinalResultLine = (output: string): string | null => {
   }
   return finalLine
 }
+
+const hasResultLine = (output: string): boolean =>
+  output
+    .split("\n")
+    .some((line) => /^READY_FOR_AGENT_RESULT:/i.test(line.trim()))
 
 /**
  * Parse the unique final READY_FOR_AGENT_RESULT line from a reviewing pass.
@@ -283,7 +298,31 @@ export const review = (context: LifecycleStepContext) =>
           ),
         )
 
-      const reviewingParsed = parseReviewResult(reviewing.assistantText)
+      let reviewingParsed = parseReviewResult(reviewing.assistantText)
+      if (reviewingParsed === null && !hasResultLine(reviewing.assistantText)) {
+        const verdict = yield* opencode
+          .continue({
+            sessionId,
+            prompt: buildReviewVerdictPrompt(),
+            cwd: worktreePath,
+            model: context.reviewModel,
+            variant: context.reviewVariant,
+            timeout,
+          })
+          .pipe(
+            Effect.mapError(
+              (cause) =>
+                new ReviewOpenCodeError({
+                  message: "OpenCode failed to report the Review verdict",
+                  worktreePath,
+                  sessionId,
+                  cause,
+                }),
+            ),
+          )
+        reviewingParsed = parseReviewResult(verdict.assistantText)
+      }
+
       if (reviewingParsed === null) {
         return yield* new ReviewResultError({
           workItemId: context.workItemId,

--- a/packages/work-item-lifecycle/test/review.spec.ts
+++ b/packages/work-item-lifecycle/test/review.spec.ts
@@ -365,6 +365,42 @@ describe("review", () => {
       expect(result).toEqual({ _tag: "clean" })
     }))
 
+  it("requests a verdict when /review summarizes a nested clean result without its marker", () =>
+    withTemp(async (root) => {
+      const continues: Array<{ prompt: string; command?: string }> = []
+      const result = await run(
+        review(baseContext(root)),
+        stubOpencode({
+          continue: (input) => {
+            continues.push({
+              prompt: input.prompt,
+              ...(input.command !== undefined
+                ? { command: input.command }
+                : {}),
+            })
+            return Effect.succeed({
+              sessionId: "ses_implement_session",
+              assistantText:
+                continues.length === 1
+                  ? "Review clean: no findings."
+                  : "READY_FOR_AGENT_RESULT: REVIEW_CLEAN",
+            })
+          },
+        }),
+      )
+
+      expect(result).toEqual({ _tag: "clean" })
+      expect(continues).toHaveLength(2)
+      expect(continues[0]!.command).toBe(REVIEW_AGENT_COMMAND)
+      expect(continues[1]!.command).toBeUndefined()
+      expect(continues[1]!.prompt).toContain(
+        "READY_FOR_AGENT_RESULT: REVIEW_CLEAN",
+      )
+      expect(continues[1]!.prompt).toContain(
+        "READY_FOR_AGENT_RESULT: REVIEW_HAS_FINDINGS",
+      )
+    }))
+
   it("applies findings with build model when reviewing reports HAS_FINDINGS", () =>
     withTemp(async (root) => {
       const continues: Array<{
@@ -947,20 +983,29 @@ describe("review", () => {
 
   it("fails when READY_FOR_AGENT_RESULT lines are duplicated", () =>
     withTemp(async (root) => {
+      let continues = 0
       const error = await run(
         review(baseContext(root)).pipe(Effect.flip),
         stubOpencode({
-          continue: () =>
-            Effect.succeed({
-              sessionId: "ses_implement_session",
-              assistantText: [
-                "READY_FOR_AGENT_RESULT: REVIEW_CLEAN",
-                "READY_FOR_AGENT_RESULT: REVIEW_HAS_FINDINGS",
-              ].join("\n"),
-            }),
+          continue: () => {
+            continues += 1
+            return continues === 1
+              ? Effect.succeed({
+                  sessionId: "ses_implement_session",
+                  assistantText: [
+                    "READY_FOR_AGENT_RESULT: REVIEW_CLEAN",
+                    "READY_FOR_AGENT_RESULT: REVIEW_HAS_FINDINGS",
+                  ].join("\n"),
+                })
+              : Effect.succeed({
+                  sessionId: "ses_implement_session",
+                  assistantText: "READY_FOR_AGENT_RESULT: REVIEW_CLEAN",
+                })
+          },
         }),
       )
       expect(error).toBeInstanceOf(ReviewResultError)
+      expect(continues).toBe(1)
     }))
 
   it("fails when READY_FOR_AGENT_RESULT is not the final line", () =>


### PR DESCRIPTION
## Why

OpenCode's `/review` command can delegate to a subtask that emits a valid `READY_FOR_AGENT_RESULT`, then omit that marker when the parent assistant summarizes the subtask. The Review lifecycle consequently rejects an otherwise completed review because it only receives the parent assistant text.

## What Changed

- Request a verdict-only follow-up turn when `/review` returns no result marker.
- Preserve the strict result contract for duplicate, non-final, contradictory, or unknown markers rather than allowing a follow-up to repair malformed output.
- Add regression coverage for both the omitted-marker behavior and malformed-marker rejection.

## Verification

- Reproduced from OpenCode Session `ses_06f54b567ffe9WSK3VIZHepHce`, where the nested review returned `REVIEW_CLEAN` but the parent summary omitted it.
- Added a lifecycle regression that reproduces the parent-summary response and verifies the verdict follow-up.
- Added a regression proving duplicate result markers do not trigger the fallback.
