### PR TITLE
fix(harness): share Jobs lifecycle chip styles at min text-xs

### DIFF
--- a/apps/harness/src/routes/index.tsx
+++ b/apps/harness/src/routes/index.tsx
@@ -35,6 +35,10 @@ import { streamRepositoryChanges } from "../repository-live.js"
 import { sessionWorktreeParts } from "../session-worktree-line.js"
 import { workItemIssueUrl } from "../work-item-issue-url.js"
 import { WorkItemOutcomePresentation } from "../work-item-outcome-presentation.js"
+import {
+  lifecycleStepChipClassName,
+  statusBadgeClassNameForStatus,
+} from "../work-item-progress-chrome.js"
 import { workItemPullRequestUrl } from "../work-item-pull-request-url.js"
 
 const graphql = createClient({ url: "/graphql", batch: true })
@@ -1740,7 +1744,7 @@ function RepositoryIssues({
                     </span>
                   )}
                 </span>
-                <span className="flex shrink-0 items-center gap-1.5 text-[0.65rem] font-bold tracking-wide text-slate-500 uppercase">
+                <span className="flex shrink-0 items-center gap-1.5 text-xs font-bold tracking-wide text-slate-500 uppercase">
                   {closedChildren}/{children.length} closed
                   <svg
                     aria-hidden="true"
@@ -1879,12 +1883,12 @@ function RepositoryIssueRow({
         </span>
         <span className="flex shrink-0 items-center gap-1">
           {issue.state === "CLOSED" && (
-            <span className="rounded-full bg-slate-100 px-1.5 py-0.5 text-[0.6rem] font-bold tracking-wide text-slate-500 uppercase">
+            <span className="rounded-full bg-slate-100 px-1.5 py-0.5 text-xs font-bold tracking-wide text-slate-500 uppercase">
               Closed
             </span>
           )}
           {issue.blockedBy.length > 0 && (
-            <span className="rounded-full bg-amber-200/70 px-1.5 py-0.5 text-[0.6rem] font-bold tracking-wide text-amber-900 uppercase">
+            <span className="rounded-full bg-amber-200/70 px-1.5 py-0.5 text-xs font-bold tracking-wide text-amber-900 uppercase">
               Blocked
             </span>
           )}
@@ -2715,19 +2719,7 @@ function WorkItemLifecycleStatus({
   })
   const actionsPending = retry.isPending || reset.isPending
   const prNumber = workItem.githubPullRequestNumber
-  const statusBadgeClassName = `rounded-full px-2 py-0.5 text-xs font-bold tracking-wide uppercase ${
-    status === "FAILED" || status === "INTERRUPTED"
-      ? "bg-red-100 text-red-700"
-      : status === "COMPLETE" || status === "SUCCEEDED"
-        ? "bg-green-100 text-green-700"
-        : status === "ABANDONED" || status === "CANCELLED"
-          ? "bg-slate-200 text-slate-600"
-          : status === "NEEDS_HUMAN" || status === "NEEDS_HUMAN_REVIEW"
-            ? "bg-amber-100 text-amber-800"
-            : status === "WAITING_FOR_WORKER_SLOT"
-              ? "bg-violet-100 text-violet-800"
-              : "bg-blue-100 text-blue-700"
-  }`
+  const statusBadgeClassName = statusBadgeClassNameForStatus(status)
   const openPullRequestLabel =
     prNumber === null ? null : `Open pull request #${prNumber}`
   const isNoChangeComplete =
@@ -2776,8 +2768,7 @@ function WorkItemLifecycleStatus({
               openPullRequestLabel !== null &&
               lifecycleLabel.phase === "DECIDE_PR_MERGE" &&
               lifecycleLabel.status === "NEEDS_HUMAN"
-            const chipClassName =
-              "rounded bg-white px-1.5 py-1 text-xs text-slate-600 ring-1 ring-slate-200"
+            const chipClassName = lifecycleStepChipClassName
             const duration = displayDurationMs !== null && (
               <span className="ml-1 text-slate-400">
                 {formatDuration(displayDurationMs)}

--- a/apps/harness/src/work-item-outcome-presentation.tsx
+++ b/apps/harness/src/work-item-outcome-presentation.tsx
@@ -1,3 +1,5 @@
+import { prBadgeClassName } from "./work-item-progress-chrome.js"
+
 /**
  * Presentational outcome chrome for a Work Item: PR links for changed work, or
  * the distinct No-Change Outcome message, Issue link, and completion summary.
@@ -36,7 +38,7 @@ export function WorkItemOutcomePresentation({
           pullRequestUrl !== null &&
           prNumber !== null && (
             <a
-              className="rounded-full bg-slate-200 px-2 py-0.5 text-xs font-bold tracking-wide text-slate-700 uppercase hover:bg-slate-300 hover:underline"
+              className={prBadgeClassName}
               href={pullRequestUrl}
               target="_blank"
               rel="noopener noreferrer"

--- a/apps/harness/src/work-item-progress-chrome.ts
+++ b/apps/harness/src/work-item-progress-chrome.ts
@@ -1,0 +1,27 @@
+/**
+ * Shared Jobs card progress chrome: lifecycle chips, status badges, PR badges.
+ * Minimum type size is Tailwind `text-xs` (0.75rem) — no sub-xs rem utilities.
+ */
+export const jobsProgressMinTextClassName = "text-xs"
+
+export const lifecycleStepChipClassName = `rounded bg-white px-1.5 py-1 ${jobsProgressMinTextClassName} text-slate-600 ring-1 ring-slate-200`
+
+export const statusBadgeBaseClassName = `rounded-full px-2 py-0.5 ${jobsProgressMinTextClassName} font-bold tracking-wide uppercase`
+
+export const prBadgeClassName = `rounded-full bg-slate-200 px-2 py-0.5 ${jobsProgressMinTextClassName} font-bold tracking-wide text-slate-700 uppercase hover:bg-slate-300 hover:underline`
+
+export function statusBadgeClassNameForStatus(status: string): string {
+  const tone =
+    status === "FAILED" || status === "INTERRUPTED"
+      ? "bg-red-100 text-red-700"
+      : status === "COMPLETE" || status === "SUCCEEDED"
+        ? "bg-green-100 text-green-700"
+        : status === "ABANDONED" || status === "CANCELLED"
+          ? "bg-slate-200 text-slate-600"
+          : status === "NEEDS_HUMAN" || status === "NEEDS_HUMAN_REVIEW"
+            ? "bg-amber-100 text-amber-800"
+            : status === "WAITING_FOR_WORKER_SLOT"
+              ? "bg-violet-100 text-violet-800"
+              : "bg-blue-100 text-blue-700"
+  return `${statusBadgeBaseClassName} ${tone}`
+}

--- a/apps/harness/test/jobs-card-no-polling.test.ts
+++ b/apps/harness/test/jobs-card-no-polling.test.ts
@@ -117,11 +117,16 @@ describe("JobsCard live updates", () => {
 
   test("styles paused Needs human review like amber human handoff, not green Succeeded", () => {
     const { source } = jobsCardSource()
-    expect(source).toContain('"NEEDS_HUMAN_REVIEW"')
-    expect(source).toContain(
+    const chrome = readFileSync(
+      join(import.meta.dir, "../src/work-item-progress-chrome.ts"),
+      "utf8",
+    )
+    expect(source).toContain("statusBadgeClassNameForStatus")
+    expect(chrome).toContain('"NEEDS_HUMAN_REVIEW"')
+    expect(chrome).toContain(
       'status === "NEEDS_HUMAN" || status === "NEEDS_HUMAN_REVIEW"',
     )
-    expect(source).toContain("bg-amber-100 text-amber-800")
+    expect(chrome).toContain("bg-amber-100 text-amber-800")
   })
 
   test("shows copyable session id and worktree path without Session prefix", () => {

--- a/apps/harness/test/work-item-outcome-presentation.test.tsx
+++ b/apps/harness/test/work-item-outcome-presentation.test.tsx
@@ -1,9 +1,12 @@
 import { renderToStaticMarkup } from "react-dom/server"
 import { WorkItemOutcomePresentation } from "../src/work-item-outcome-presentation.js"
+import {
+  prBadgeClassName,
+  statusBadgeClassNameForStatus,
+} from "../src/work-item-progress-chrome.js"
 import { describe, expect, test } from "bun:test"
 
-const statusBadgeClassName =
-  "rounded-full px-2 py-0.5 text-xs font-bold tracking-wide uppercase bg-green-100 text-green-700"
+const statusBadgeClassName = statusBadgeClassNameForStatus("COMPLETE")
 
 describe("WorkItemOutcomePresentation", () => {
   test("renders no-change completion message, Issue link, and summary", () => {
@@ -49,6 +52,10 @@ describe("WorkItemOutcomePresentation", () => {
     expect(html).toContain('href="https://github.com/acme/widgets/pull/17"')
     expect(html).toContain("Open pull request #17")
     expect(html).toContain("Complete")
+    expect(html).toContain(prBadgeClassName)
+    expect(html).toContain("text-xs")
+    expect(html).not.toContain("0.65rem")
+    expect(html).not.toContain("0.6rem")
     expect(html).not.toContain("Issue closed without repository changes")
     expect(html).not.toContain('aria-label="Completion summary"')
   })
@@ -58,7 +65,7 @@ describe("WorkItemOutcomePresentation", () => {
       <WorkItemOutcomePresentation
         state="IMPLEMENT"
         statusLabel="Running"
-        statusBadgeClassName="bg-blue-100 text-blue-700"
+        statusBadgeClassName={statusBadgeClassNameForStatus("IMPLEMENT")}
         githubPullRequestNumber={null}
         pullRequestUrl={null}
         completionSummary={null}

--- a/apps/harness/test/work-item-progress-chrome.test.ts
+++ b/apps/harness/test/work-item-progress-chrome.test.ts
@@ -1,0 +1,37 @@
+import {
+  jobsProgressMinTextClassName,
+  lifecycleStepChipClassName,
+  prBadgeClassName,
+  statusBadgeBaseClassName,
+  statusBadgeClassNameForStatus,
+} from "../src/work-item-progress-chrome.js"
+import { describe, expect, test } from "bun:test"
+
+const forbiddenSubXsRem = ["0.6rem", "0.65rem", "0.7rem"] as const
+
+function assertMinTextXs(className: string) {
+  expect(className).toContain(jobsProgressMinTextClassName)
+  expect(className).toContain("text-xs")
+  for (const rem of forbiddenSubXsRem) {
+    expect(className).not.toContain(rem)
+  }
+}
+
+describe("work-item-progress-chrome", () => {
+  test("lifecycle step chips use shared text-xs minimum (no sub-xs rem)", () => {
+    assertMinTextXs(lifecycleStepChipClassName)
+    expect(lifecycleStepChipClassName).toContain("rounded")
+    expect(lifecycleStepChipClassName).toContain("ring-1")
+  })
+
+  test("status badge base and PR badge share text-xs minimum", () => {
+    assertMinTextXs(statusBadgeBaseClassName)
+    assertMinTextXs(prBadgeClassName)
+    expect(statusBadgeClassNameForStatus("COMPLETE")).toContain(
+      statusBadgeBaseClassName,
+    )
+    assertMinTextXs(statusBadgeClassNameForStatus("COMPLETE"))
+    assertMinTextXs(statusBadgeClassNameForStatus("FAILED"))
+    assertMinTextXs(statusBadgeClassNameForStatus("RUNNING"))
+  })
+})


### PR DESCRIPTION
## Summary
- Extract shared Jobs progress chrome tokens for lifecycle chips, status badges, and PR badges (`text-xs` minimum).
- Wire call sites through the shared module; bump remaining issue list badge sizes to `text-xs`.
- Add regression tests so sub-`text-xs` rem classes cannot return silently.

Closes #428

## Test plan
- [x] `bunx nx test harness` (progress chrome + outcome presentation + jobs card tests)
- [x] `bunx nx build harness` (dist free of `0.65rem` / `0.6rem` / `0.7rem`)
- [x] Pre-commit affected lint/typecheck/test
- [ ] Manual: Completed Jobs lifecycle chips show `text-xs` in DevTools