### PR TITLE
feat(work-item-lifecycle): classify Review Findings by severity

### DIFF
--- a/packages/work-item-lifecycle/src/lib/review.ts
+++ b/packages/work-item-lifecycle/src/lib/review.ts
@@ -26,58 +26,112 @@ export const MAX_REVIEW_FIX_ROUNDS = 5
 /** Operator-visible reason when Review Fix Rounds are exhausted. */
 export const REVIEW_FIX_LIMIT_REASON = `Review fix limit reached (${MAX_REVIEW_FIX_ROUNDS}); inspect the worktree or address remaining findings, then Retry.`
 
+/** Needs Human when high-severity findings remain unresolved after apply. */
+export const REVIEW_UNRESOLVED_HIGH_REASON =
+  "Unresolved high-severity Review Findings require human attention."
+
+/**
+ * Needs Human when the builder leaves an original high-severity review
+ * unchanged or disputes it without fixing.
+ */
+export const REVIEW_HIGH_UNCHANGED_REASON =
+  "High-severity Review Findings were not fixed; human attention required."
+
+/** Aggregate impact of Review Findings in one reviewing pass. */
+export type ReviewSeverity = "low" | "medium" | "high"
+
+/** Unresolved severity eligible for deferral (never high). */
+export type DeferredReviewSeverity = "low" | "medium"
+
 /** Final Review step outcome after reviewing, optional apply, and fix rounds. */
 export type ReviewResult =
   | { readonly _tag: "clean" }
-  | { readonly _tag: "deferred"; readonly reason: string }
+  | { readonly _tag: "cleared"; readonly reason: string }
+  | {
+      readonly _tag: "deferred"
+      readonly severity: DeferredReviewSeverity
+      readonly reason: string
+    }
   | { readonly _tag: "needs_human"; readonly reason: string }
 
 /** Machine-readable outcome of the reviewing (/review) pass only. */
 export type ReviewingPassResult =
   | { readonly _tag: "clean" }
-  | { readonly _tag: "has_findings" }
+  | { readonly _tag: "has_findings"; readonly severity: ReviewSeverity }
 
 /** Machine-readable outcome of the apply-findings pass. */
 export type ApplyReviewResult =
-  | { readonly _tag: "clean" }
-  | { readonly _tag: "deferred"; readonly reason: string }
   | { readonly _tag: "fixed" }
+  | {
+      readonly _tag: "fixed_and_deferred"
+      readonly severity: DeferredReviewSeverity
+      readonly reason: string
+    }
+  | {
+      readonly _tag: "deferred"
+      readonly severity: DeferredReviewSeverity
+      readonly reason: string
+    }
+  | { readonly _tag: "cleared"; readonly reason: string }
+  | { readonly _tag: "unresolved_high"; readonly reason: string }
 
 export const REVIEW_AGENT_COMMAND = "/review"
+
+const SEVERITY_RUBRIC = [
+  "Severity measures finding impact, not expected fix effort:",
+  "low = no plausible runtime or contract impact;",
+  "medium = bounded behavior or correctness impact;",
+  "high = security, data-loss, major-contract, or broad/systemic impact.",
+].join(" ")
+
+/** Persist deferred severity + rationale on the completed Review Step Run. */
+export const formatDeferredReviewSummary = (
+  severity: DeferredReviewSeverity,
+  reason: string,
+): string => `${severity}: ${reason}`
 
 export const buildReviewingPrompt = () =>
   [
     "Review uncommitted worktree changes.",
     "Do not edit files, commit, push, open pull requests, or apply findings in this turn.",
+    SEVERITY_RUBRIC,
     "End your final response with exactly one machine-readable result line:",
     "READY_FOR_AGENT_RESULT: REVIEW_CLEAN",
-    "or",
-    "READY_FOR_AGENT_RESULT: REVIEW_HAS_FINDINGS",
+    "when there are no Review Findings, or",
+    "READY_FOR_AGENT_RESULT: REVIEW_HAS_FINDINGS: <low|medium|high>",
+    "using the highest Review Severity among the findings.",
   ].join("\n")
 
 const buildReviewVerdictPrompt = () =>
   [
     "The /review command immediately above has completed.",
     "Do not review again, edit files, or add explanatory prose.",
-    "If it reported any Review Findings, respond exactly:",
-    "READY_FOR_AGENT_RESULT: REVIEW_HAS_FINDINGS",
+    SEVERITY_RUBRIC,
+    "Classify the existing report. If it reported any Review Findings, respond exactly:",
+    "READY_FOR_AGENT_RESULT: REVIEW_HAS_FINDINGS: <low|medium|high>",
+    "using the highest Review Severity among those findings.",
     "Otherwise respond exactly:",
     "READY_FOR_AGENT_RESULT: REVIEW_CLEAN",
   ].join("\n")
 
-const buildApplyFindingsPrompt = () =>
+const buildApplyFindingsPrompt = (severity: ReviewSeverity) =>
   [
-    "The previous reviewing pass reported Review Findings (REVIEW_HAS_FINDINGS).",
-    "Interpret those findings. Fix only what should be fixed now; you may defer stylistic or disputed notes.",
+    `The previous reviewing pass reported Review Findings at severity ${severity} (REVIEW_HAS_FINDINGS: ${severity}).`,
+    "Interpret those findings. Fix only what should be fixed now.",
+    "Low- and medium-severity findings may be deferred or cleared with a reason; high-severity findings must be fixed (with optional lower-severity deferrals) or left unresolved for a human.",
     "Do not commit, push, open pull requests, or start unrelated rework.",
     "End your final response with exactly one machine-readable result line:",
     "READY_FOR_AGENT_RESULT: REVIEW_FIXED",
-    "when you changed the worktree to address findings,",
-    "READY_FOR_AGENT_RESULT: REVIEW_DEFERRED: <short reason>",
-    "when findings remain but should not block Commit,",
+    "when you changed the worktree and no findings remain deferred,",
+    "READY_FOR_AGENT_RESULT: REVIEW_FIXED_AND_DEFERRED: <low|medium>: <short reason>",
+    "when you changed the worktree and also deferred remaining low/medium findings,",
+    "READY_FOR_AGENT_RESULT: REVIEW_DEFERRED: <low|medium>: <short reason>",
+    "when you did not change the worktree and only low/medium findings remain (defer them),",
+    "READY_FOR_AGENT_RESULT: REVIEW_CLEARED: <short reason>",
+    "when you reject all low/medium findings as invalid without changing the worktree,",
     "or",
-    "READY_FOR_AGENT_RESULT: REVIEW_CLEAN",
-    "when on re-read there is nothing that needs fixing or deferring.",
+    "READY_FOR_AGENT_RESULT: REVIEW_UNRESOLVED_HIGH: <short reason>",
+    "when high-severity findings remain unresolved or disputed without a fix.",
   ].join("\n")
 
 const uniqueFinalResultLine = (output: string): string | null => {
@@ -103,6 +157,24 @@ const hasResultLine = (output: string): boolean =>
     .split("\n")
     .some((line) => /^READY_FOR_AGENT_RESULT:/i.test(line.trim()))
 
+const parseSeverity = (raw: string): ReviewSeverity | null => {
+  const value = raw.trim().toLowerCase()
+  if (value === "low" || value === "medium" || value === "high") {
+    return value
+  }
+  return null
+}
+
+const parseDeferredSeverity = (raw: string): DeferredReviewSeverity | null => {
+  const severity = parseSeverity(raw)
+  if (severity === "low" || severity === "medium") {
+    return severity
+  }
+  return null
+}
+
+const boundReason = (reason: string): string => reason.trim().slice(0, 500)
+
 /**
  * Parse the unique final READY_FOR_AGENT_RESULT line from a reviewing pass.
  * Returns null for missing, duplicate, non-final, or unrecognized markers.
@@ -119,8 +191,14 @@ export const parseReviewResult = (
     return { _tag: "clean" }
   }
 
-  if (/^READY_FOR_AGENT_RESULT:\s*REVIEW_HAS_FINDINGS$/i.test(finalLine)) {
-    return { _tag: "has_findings" }
+  const hasFindings = finalLine.match(
+    /^READY_FOR_AGENT_RESULT:\s*REVIEW_HAS_FINDINGS\s*:\s*(.+)$/i,
+  )
+  if (hasFindings?.[1] !== undefined) {
+    const severity = parseSeverity(hasFindings[1])
+    if (severity !== null) {
+      return { _tag: "has_findings", severity }
+    }
   }
 
   return null
@@ -138,21 +216,63 @@ export const parseApplyReviewResult = (
     return null
   }
 
-  if (/^READY_FOR_AGENT_RESULT:\s*REVIEW_CLEAN$/i.test(finalLine)) {
-    return { _tag: "clean" }
-  }
-
   if (/^READY_FOR_AGENT_RESULT:\s*REVIEW_FIXED$/i.test(finalLine)) {
     return { _tag: "fixed" }
   }
 
-  const deferred = finalLine.match(
-    /^READY_FOR_AGENT_RESULT:\s*REVIEW_DEFERRED\s*:\s*(.+)$/i,
+  const fixedAndDeferred = finalLine.match(
+    /^READY_FOR_AGENT_RESULT:\s*REVIEW_FIXED_AND_DEFERRED\s*:\s*(low|medium)\s*:\s*(.+)$/i,
   )
-  if (deferred?.[1] !== undefined && deferred[1].trim() !== "") {
+  if (
+    fixedAndDeferred?.[1] !== undefined &&
+    fixedAndDeferred[2] !== undefined &&
+    fixedAndDeferred[2].trim() !== ""
+  ) {
+    const severity = parseDeferredSeverity(fixedAndDeferred[1])
+    if (severity !== null) {
+      return {
+        _tag: "fixed_and_deferred",
+        severity,
+        reason: boundReason(fixedAndDeferred[2]),
+      }
+    }
+  }
+
+  const deferred = finalLine.match(
+    /^READY_FOR_AGENT_RESULT:\s*REVIEW_DEFERRED\s*:\s*(low|medium)\s*:\s*(.+)$/i,
+  )
+  if (
+    deferred?.[1] !== undefined &&
+    deferred[2] !== undefined &&
+    deferred[2].trim() !== ""
+  ) {
+    const severity = parseDeferredSeverity(deferred[1])
+    if (severity !== null) {
+      return {
+        _tag: "deferred",
+        severity,
+        reason: boundReason(deferred[2]),
+      }
+    }
+  }
+
+  const cleared = finalLine.match(
+    /^READY_FOR_AGENT_RESULT:\s*REVIEW_CLEARED\s*:\s*(.+)$/i,
+  )
+  if (cleared?.[1] !== undefined && cleared[1].trim() !== "") {
     return {
-      _tag: "deferred",
-      reason: deferred[1].trim().slice(0, 500),
+      _tag: "cleared",
+      reason: boundReason(cleared[1]),
+    }
+  }
+
+  const unresolvedHigh = finalLine.match(
+    /^READY_FOR_AGENT_RESULT:\s*REVIEW_UNRESOLVED_HIGH\s*:\s*(.+)$/i,
+  )
+  if (unresolvedHigh?.[1] !== undefined && unresolvedHigh[1].trim() !== "") {
+    return {
+      _tag: "unresolved_high",
+      reason: boundReason(unresolvedHigh[1]),
     }
   }
 
@@ -257,12 +377,12 @@ const markReviewPreCommitPhase = markReviewPhase(
 
 /**
  * Production Review Lifecycle Step — reviewing pass, optional apply-findings,
- * and on FIXED a nested Pre-Commit then re-review. Continues the Implement
+ * and on changed work a nested Pre-Commit then re-review. Continues the Implement
  * OpenCode Session. Reviewing uses the review model/variant; applying findings
  * and nested Pre-Commit fix turns use the build model/variant. Nested Pre-Commit
  * failures fail the Review Step Run (retryable), same spirit as standalone
- * Pre-Commit. At most {@link MAX_REVIEW_FIX_ROUNDS} FIXED apply rounds; further
- * findings without clean/deferred become Needs Human (not a failed Step Run).
+ * Pre-Commit. At most {@link MAX_REVIEW_FIX_ROUNDS} changed apply rounds; further
+ * findings without clean/deferred/cleared become Needs Human (not a failed Step Run).
  */
 export const review = (context: LifecycleStepContext) =>
   Effect.gen(function* () {
@@ -327,13 +447,15 @@ export const review = (context: LifecycleStepContext) =>
         return yield* new ReviewResultError({
           workItemId: context.workItemId,
           message:
-            "OpenCode did not report a unique final READY_FOR_AGENT_RESULT: REVIEW_CLEAN or REVIEW_HAS_FINDINGS",
+            "OpenCode did not report a unique final READY_FOR_AGENT_RESULT: REVIEW_CLEAN or REVIEW_HAS_FINDINGS: <low|medium|high>",
         })
       }
 
       if (reviewingParsed._tag === "clean") {
         return { _tag: "clean" as const }
       }
+
+      const originalSeverity = reviewingParsed.severity
 
       if (fixRoundsUsed >= MAX_REVIEW_FIX_ROUNDS) {
         return {
@@ -347,7 +469,7 @@ export const review = (context: LifecycleStepContext) =>
       const applying = yield* opencode
         .continue({
           sessionId,
-          prompt: buildApplyFindingsPrompt(),
+          prompt: buildApplyFindingsPrompt(originalSeverity),
           cwd: worktreePath,
           model: context.model,
           variant: context.variant,
@@ -370,18 +492,48 @@ export const review = (context: LifecycleStepContext) =>
         return yield* new ReviewResultError({
           workItemId: context.workItemId,
           message:
-            "OpenCode did not report a unique final READY_FOR_AGENT_RESULT: REVIEW_FIXED, REVIEW_DEFERRED: <reason>, or REVIEW_CLEAN",
+            "OpenCode did not report a unique final READY_FOR_AGENT_RESULT: REVIEW_FIXED, REVIEW_FIXED_AND_DEFERRED: <low|medium>: <reason>, REVIEW_DEFERRED: <low|medium>: <reason>, REVIEW_CLEARED: <reason>, or REVIEW_UNRESOLVED_HIGH: <reason>",
         })
       }
 
-      if (applyParsed._tag === "clean") {
-        return { _tag: "clean" as const }
+      if (applyParsed._tag === "unresolved_high") {
+        return {
+          _tag: "needs_human" as const,
+          reason:
+            applyParsed.reason.trim() !== ""
+              ? applyParsed.reason
+              : REVIEW_UNRESOLVED_HIGH_REASON,
+        }
       }
 
       if (applyParsed._tag === "deferred") {
-        return applyParsed
+        if (originalSeverity === "high") {
+          return {
+            _tag: "needs_human" as const,
+            reason: REVIEW_HIGH_UNCHANGED_REASON,
+          }
+        }
+        return {
+          _tag: "deferred" as const,
+          severity: applyParsed.severity,
+          reason: applyParsed.reason,
+        }
       }
 
+      if (applyParsed._tag === "cleared") {
+        if (originalSeverity === "high") {
+          return {
+            _tag: "needs_human" as const,
+            reason: REVIEW_HIGH_UNCHANGED_REASON,
+          }
+        }
+        return {
+          _tag: "cleared" as const,
+          reason: applyParsed.reason,
+        }
+      }
+
+      // fixed | fixed_and_deferred — changed work always re-reviews after Pre-Commit
       fixRoundsUsed += 1
       yield* markReviewPreCommitPhase
       yield* preCommit(context)

--- a/packages/work-item-lifecycle/src/lib/types.ts
+++ b/packages/work-item-lifecycle/src/lib/types.ts
@@ -272,6 +272,8 @@ export const STEP_RUN_REASON = {
   reviewPreCommit: "review_pre_commit",
   /** Successful Review that deferred findings and advanced to Commit. */
   reviewDeferred: "review_deferred",
+  /** Successful Review that cleared low/medium findings without changes. */
+  reviewCleared: "review_cleared",
   /** Successful Merge PR run that returned to Watch for fresh validation. */
   mergeRevalidation: "merge_revalidation",
 } as const

--- a/packages/work-item-lifecycle/src/lib/work-item-lifecycle.ts
+++ b/packages/work-item-lifecycle/src/lib/work-item-lifecycle.ts
@@ -61,6 +61,7 @@ import {
   PreCommitHookFailedError,
   PreCommitStageError,
 } from "./pre-commit-errors.js"
+import { formatDeferredReviewSummary } from "./review.js"
 import {
   DEFAULT_LIFECYCLE_MAX_DURATIONS,
   type LifecycleMaxDurations,
@@ -1275,6 +1276,15 @@ export const makeWorkItemLifecycleLive = (
                 if (result._tag === "deferred") {
                   return {
                     stepRunReasonCode: STEP_RUN_REASON.reviewDeferred,
+                    stepRunNote: formatDeferredReviewSummary(
+                      result.severity,
+                      result.reason,
+                    ),
+                  }
+                }
+                if (result._tag === "cleared") {
+                  return {
+                    stepRunReasonCode: STEP_RUN_REASON.reviewCleared,
                     stepRunNote: result.reason,
                   }
                 }

--- a/packages/work-item-lifecycle/test/review.spec.ts
+++ b/packages/work-item-lifecycle/test/review.spec.ts
@@ -20,7 +20,9 @@ import {
   REVIEW_AGENT_COMMAND,
   REVIEW_APPLYING_FINDINGS_MESSAGE,
   REVIEW_FIX_LIMIT_REASON,
+  REVIEW_HIGH_UNCHANGED_REASON,
   REVIEW_PRE_COMMIT_MESSAGE,
+  REVIEW_UNRESOLVED_HIGH_REASON,
   ReviewInvalidWorktreeContextError,
   ReviewOpenCodeError,
   ReviewResultError,
@@ -28,6 +30,7 @@ import {
   ReviewWorktreeContextMissingError,
   STEP_RUN_REASON,
   buildReviewingPrompt,
+  formatDeferredReviewSummary,
   makeWorkItemId,
   parseApplyReviewResult,
   parseReviewResult,
@@ -158,24 +161,30 @@ const writeHook = async (root: string, body: string) => {
 }
 
 describe("parseReviewResult", () => {
-  it("parses clean and has-findings lines", () => {
+  it("parses clean and severity-tagged has-findings lines", () => {
     expect(parseReviewResult("READY_FOR_AGENT_RESULT: REVIEW_CLEAN")).toEqual({
       _tag: "clean",
     })
     expect(
       parseReviewResult(
-        "Looks good overall.\nREADY_FOR_AGENT_RESULT: REVIEW_HAS_FINDINGS",
+        "Looks good overall.\nREADY_FOR_AGENT_RESULT: REVIEW_HAS_FINDINGS: low",
       ),
-    ).toEqual({ _tag: "has_findings" })
+    ).toEqual({ _tag: "has_findings", severity: "low" })
+    expect(
+      parseReviewResult("READY_FOR_AGENT_RESULT: REVIEW_HAS_FINDINGS: medium"),
+    ).toEqual({ _tag: "has_findings", severity: "medium" })
+    expect(
+      parseReviewResult("READY_FOR_AGENT_RESULT: REVIEW_HAS_FINDINGS: high"),
+    ).toEqual({ _tag: "has_findings", severity: "high" })
   })
 
-  it("rejects missing, duplicate, non-final, or unknown markers", () => {
+  it("rejects missing, duplicate, non-final, unsevered, or unknown markers", () => {
     expect(parseReviewResult("no result line")).toBeNull()
     expect(
       parseReviewResult(
         [
           "READY_FOR_AGENT_RESULT: REVIEW_CLEAN",
-          "READY_FOR_AGENT_RESULT: REVIEW_HAS_FINDINGS",
+          "READY_FOR_AGENT_RESULT: REVIEW_HAS_FINDINGS: low",
         ].join("\n"),
       ),
     ).toBeNull()
@@ -184,34 +193,63 @@ describe("parseReviewResult", () => {
         "READY_FOR_AGENT_RESULT: REVIEW_CLEAN\nAdditional output",
       ),
     ).toBeNull()
+    expect(
+      parseReviewResult("READY_FOR_AGENT_RESULT: REVIEW_HAS_FINDINGS"),
+    ).toBeNull()
+    expect(
+      parseReviewResult(
+        "READY_FOR_AGENT_RESULT: REVIEW_HAS_FINDINGS: critical",
+      ),
+    ).toBeNull()
     expect(parseReviewResult("READY_FOR_AGENT_RESULT: REVIEW_FIXED")).toBeNull()
   })
 })
 
 describe("parseApplyReviewResult", () => {
-  it("parses fixed, deferred, and apply-clean lines", () => {
+  it("parses fixed, fixed-and-deferred, deferred, cleared, and unresolved-high lines", () => {
     expect(
       parseApplyReviewResult("READY_FOR_AGENT_RESULT: REVIEW_FIXED"),
     ).toEqual({ _tag: "fixed" })
     expect(
       parseApplyReviewResult(
-        "Left style notes.\nREADY_FOR_AGENT_RESULT: REVIEW_DEFERRED: stylistic only",
+        "Fixed main bug.\nREADY_FOR_AGENT_RESULT: REVIEW_FIXED_AND_DEFERRED: low: style nits remain",
       ),
-    ).toEqual({ _tag: "deferred", reason: "stylistic only" })
+    ).toEqual({
+      _tag: "fixed_and_deferred",
+      severity: "low",
+      reason: "style nits remain",
+    })
     expect(
       parseApplyReviewResult(
-        "Nothing actionable.\nREADY_FOR_AGENT_RESULT: REVIEW_CLEAN",
+        "Left style notes.\nREADY_FOR_AGENT_RESULT: REVIEW_DEFERRED: medium: naming only",
       ),
-    ).toEqual({ _tag: "clean" })
+    ).toEqual({
+      _tag: "deferred",
+      severity: "medium",
+      reason: "naming only",
+    })
+    expect(
+      parseApplyReviewResult(
+        "Nothing actionable.\nREADY_FOR_AGENT_RESULT: REVIEW_CLEARED: false positive",
+      ),
+    ).toEqual({ _tag: "cleared", reason: "false positive" })
+    expect(
+      parseApplyReviewResult(
+        "READY_FOR_AGENT_RESULT: REVIEW_UNRESOLVED_HIGH: auth bypass still open",
+      ),
+    ).toEqual({
+      _tag: "unresolved_high",
+      reason: "auth bypass still open",
+    })
   })
 
-  it("rejects missing, duplicate, blank deferred, or reviewing-only markers", () => {
+  it("rejects missing, duplicate, blank, high-deferred, or reviewing-only markers", () => {
     expect(parseApplyReviewResult("no result line")).toBeNull()
     expect(
       parseApplyReviewResult(
         [
           "READY_FOR_AGENT_RESULT: REVIEW_FIXED",
-          "READY_FOR_AGENT_RESULT: REVIEW_CLEAN",
+          "READY_FOR_AGENT_RESULT: REVIEW_CLEARED: x",
         ].join("\n"),
       ),
     ).toBeNull()
@@ -224,8 +262,45 @@ describe("parseApplyReviewResult", () => {
       parseApplyReviewResult("READY_FOR_AGENT_RESULT: REVIEW_DEFERRED:"),
     ).toBeNull()
     expect(
-      parseApplyReviewResult("READY_FOR_AGENT_RESULT: REVIEW_HAS_FINDINGS"),
+      parseApplyReviewResult("READY_FOR_AGENT_RESULT: REVIEW_DEFERRED: low:"),
     ).toBeNull()
+    expect(
+      parseApplyReviewResult(
+        "READY_FOR_AGENT_RESULT: REVIEW_DEFERRED: high: cannot defer high",
+      ),
+    ).toBeNull()
+    expect(
+      parseApplyReviewResult("READY_FOR_AGENT_RESULT: REVIEW_CLEAN"),
+    ).toBeNull()
+    expect(
+      parseApplyReviewResult(
+        "READY_FOR_AGENT_RESULT: REVIEW_HAS_FINDINGS: low",
+      ),
+    ).toBeNull()
+  })
+
+  it("bounds deferred and cleared reasons", () => {
+    const long = "x".repeat(600)
+    expect(
+      parseApplyReviewResult(
+        `READY_FOR_AGENT_RESULT: REVIEW_DEFERRED: low: ${long}`,
+      ),
+    ).toEqual({
+      _tag: "deferred",
+      severity: "low",
+      reason: long.slice(0, 500),
+    })
+    expect(
+      parseApplyReviewResult(`READY_FOR_AGENT_RESULT: REVIEW_CLEARED: ${long}`),
+    ).toEqual({ _tag: "cleared", reason: long.slice(0, 500) })
+  })
+})
+
+describe("formatDeferredReviewSummary", () => {
+  it("joins severity and reason for Step Run persistence", () => {
+    expect(formatDeferredReviewSummary("low", "style nits")).toBe(
+      "low: style nits",
+    )
   })
 })
 
@@ -237,17 +312,20 @@ const isReviewingTurn = (input: {
   input.prompt === buildReviewingPrompt()
 
 describe("buildReviewingPrompt", () => {
-  it("forbids edits and requires the result contract without a bare leading /review line", () => {
+  it("forbids edits, defines the severity rubric, and requires the result contract", () => {
     const prompt = buildReviewingPrompt()
-    expect(prompt).toBe(
-      [
-        "Review uncommitted worktree changes.",
-        "Do not edit files, commit, push, open pull requests, or apply findings in this turn.",
-        "End your final response with exactly one machine-readable result line:",
-        "READY_FOR_AGENT_RESULT: REVIEW_CLEAN",
-        "or",
-        "READY_FOR_AGENT_RESULT: REVIEW_HAS_FINDINGS",
-      ].join("\n"),
+    expect(prompt).toContain("Review uncommitted worktree changes.")
+    expect(prompt).toContain(
+      "Do not edit files, commit, push, open pull requests, or apply findings in this turn.",
+    )
+    expect(prompt).toContain("low = no plausible runtime or contract impact")
+    expect(prompt).toContain("medium = bounded behavior or correctness impact")
+    expect(prompt).toContain(
+      "high = security, data-loss, major-contract, or broad/systemic impact",
+    )
+    expect(prompt).toContain("READY_FOR_AGENT_RESULT: REVIEW_CLEAN")
+    expect(prompt).toContain(
+      "READY_FOR_AGENT_RESULT: REVIEW_HAS_FINDINGS: <low|medium|high>",
     )
     expect(prompt.startsWith('"')).toBe(false)
     expect(prompt.endsWith('"')).toBe(false)
@@ -345,7 +423,10 @@ describe("review", () => {
         "READY_FOR_AGENT_RESULT: REVIEW_CLEAN",
       )
       expect(continued!.prompt).toContain(
-        "READY_FOR_AGENT_RESULT: REVIEW_HAS_FINDINGS",
+        "READY_FOR_AGENT_RESULT: REVIEW_HAS_FINDINGS: <low|medium|high>",
+      )
+      expect(continued!.prompt).toContain(
+        "low = no plausible runtime or contract impact",
       )
     }))
 
@@ -397,8 +478,71 @@ describe("review", () => {
         "READY_FOR_AGENT_RESULT: REVIEW_CLEAN",
       )
       expect(continues[1]!.prompt).toContain(
-        "READY_FOR_AGENT_RESULT: REVIEW_HAS_FINDINGS",
+        "READY_FOR_AGENT_RESULT: REVIEW_HAS_FINDINGS: <low|medium|high>",
       )
+      expect(continues[1]!.prompt).toContain(
+        "low = no plausible runtime or contract impact",
+      )
+    }))
+
+  it("classifies severity on the fallback verdict without another /review command", () =>
+    withTemp(async (root) => {
+      const continues: Array<{
+        prompt: string
+        command?: string
+        model: string
+      }> = []
+      const result = await run(
+        review(
+          baseContext(root, {
+            reviewModel: "opencode/review-model",
+            model: "opencode/build-model",
+          }),
+        ),
+        stubOpencode({
+          continue: (input) => {
+            continues.push({
+              prompt: input.prompt,
+              model: input.model,
+              ...(input.command !== undefined
+                ? { command: input.command }
+                : {}),
+            })
+            if (continues.length === 1) {
+              return Effect.succeed({
+                sessionId: "ses_implement_session",
+                assistantText:
+                  "Found a bounded correctness issue in the parser.",
+              })
+            }
+            if (continues.length === 2) {
+              return Effect.succeed({
+                sessionId: "ses_implement_session",
+                assistantText:
+                  "READY_FOR_AGENT_RESULT: REVIEW_HAS_FINDINGS: medium",
+              })
+            }
+            return Effect.succeed({
+              sessionId: "ses_implement_session",
+              assistantText:
+                "READY_FOR_AGENT_RESULT: REVIEW_DEFERRED: medium: follow-up ticket",
+            })
+          },
+        }),
+      )
+
+      expect(result).toEqual({
+        _tag: "deferred",
+        severity: "medium",
+        reason: "follow-up ticket",
+      })
+      expect(continues).toHaveLength(3)
+      expect(continues[0]!.command).toBe(REVIEW_AGENT_COMMAND)
+      expect(continues[0]!.model).toBe("opencode/review-model")
+      expect(continues[1]!.command).toBeUndefined()
+      expect(continues[1]!.model).toBe("opencode/review-model")
+      expect(continues[1]!.prompt).toContain("Do not review again")
+      expect(continues[2]!.model).toBe("opencode/build-model")
     }))
 
   it("applies findings with build model when reviewing reports HAS_FINDINGS", () =>
@@ -431,13 +575,13 @@ describe("review", () => {
               return Effect.succeed({
                 sessionId: "ses_implement_session",
                 assistantText:
-                  "Found a bug.\nREADY_FOR_AGENT_RESULT: REVIEW_HAS_FINDINGS",
+                  "Found a bug.\nREADY_FOR_AGENT_RESULT: REVIEW_HAS_FINDINGS: low",
               })
             }
             return Effect.succeed({
               sessionId: "ses_implement_session",
               assistantText:
-                "Deferred style notes.\nREADY_FOR_AGENT_RESULT: REVIEW_DEFERRED: naming nit only",
+                "Deferred style notes.\nREADY_FOR_AGENT_RESULT: REVIEW_DEFERRED: low: naming nit only",
             })
           },
         }),
@@ -452,13 +596,15 @@ describe("review", () => {
       expect(continues[1]!.variant).toBe("high")
       expect(continues[1]!.prompt).toContain("REVIEW_FIXED")
       expect(continues[1]!.prompt).toContain("REVIEW_DEFERRED:")
+      expect(continues[1]!.prompt).toContain("severity low")
       expect(result).toEqual({
         _tag: "deferred",
+        severity: "low",
         reason: "naming nit only",
       })
     }))
 
-  it("returns deferred from the apply path", () =>
+  it("returns deferred from the apply path with unresolved severity", () =>
     withTemp(async (root) => {
       let turn = 0
       const result = await run(
@@ -470,16 +616,20 @@ describe("review", () => {
               sessionId: "ses_implement_session",
               assistantText:
                 turn === 1
-                  ? "READY_FOR_AGENT_RESULT: REVIEW_HAS_FINDINGS"
-                  : "READY_FOR_AGENT_RESULT: REVIEW_DEFERRED: out of scope",
+                  ? "READY_FOR_AGENT_RESULT: REVIEW_HAS_FINDINGS: medium"
+                  : "READY_FOR_AGENT_RESULT: REVIEW_DEFERRED: medium: out of scope",
             })
           },
         }),
       )
-      expect(result).toEqual({ _tag: "deferred", reason: "out of scope" })
+      expect(result).toEqual({
+        _tag: "deferred",
+        severity: "medium",
+        reason: "out of scope",
+      })
     }))
 
-  it("returns apply-clean from the apply path", () =>
+  it("returns cleared from the apply path for low/medium findings", () =>
     withTemp(async (root) => {
       let turn = 0
       const result = await run(
@@ -491,13 +641,89 @@ describe("review", () => {
               sessionId: "ses_implement_session",
               assistantText:
                 turn === 1
-                  ? "READY_FOR_AGENT_RESULT: REVIEW_HAS_FINDINGS"
-                  : "READY_FOR_AGENT_RESULT: REVIEW_CLEAN",
+                  ? "READY_FOR_AGENT_RESULT: REVIEW_HAS_FINDINGS: low"
+                  : "READY_FOR_AGENT_RESULT: REVIEW_CLEARED: not a real issue",
             })
           },
         }),
       )
-      expect(result).toEqual({ _tag: "clean" })
+      expect(result).toEqual({
+        _tag: "cleared",
+        reason: "not a real issue",
+      })
+    }))
+
+  it("returns Needs Human when apply reports unresolved high", () =>
+    withTemp(async (root) => {
+      let turn = 0
+      const result = await run(
+        review(baseContext(root)),
+        stubOpencode({
+          continue: () => {
+            turn += 1
+            return Effect.succeed({
+              sessionId: "ses_implement_session",
+              assistantText:
+                turn === 1
+                  ? "READY_FOR_AGENT_RESULT: REVIEW_HAS_FINDINGS: high"
+                  : "READY_FOR_AGENT_RESULT: REVIEW_UNRESOLVED_HIGH: injection risk remains",
+            })
+          },
+        }),
+      )
+      expect(result).toEqual({
+        _tag: "needs_human",
+        reason: "injection risk remains",
+      })
+      expect(REVIEW_UNRESOLVED_HIGH_REASON).toContain("high-severity")
+    }))
+
+  it("returns Needs Human when high findings are deferred without a fix", () =>
+    withTemp(async (root) => {
+      let turn = 0
+      const result = await run(
+        review(baseContext(root)),
+        stubOpencode({
+          continue: () => {
+            turn += 1
+            return Effect.succeed({
+              sessionId: "ses_implement_session",
+              assistantText:
+                turn === 1
+                  ? "READY_FOR_AGENT_RESULT: REVIEW_HAS_FINDINGS: high"
+                  : "READY_FOR_AGENT_RESULT: REVIEW_DEFERRED: low: only nits remain",
+            })
+          },
+        }),
+      )
+      expect(result).toEqual({
+        _tag: "needs_human",
+        reason: REVIEW_HIGH_UNCHANGED_REASON,
+      })
+    }))
+
+  it("returns Needs Human when high findings are cleared without a fix", () =>
+    withTemp(async (root) => {
+      let turn = 0
+      const result = await run(
+        review(baseContext(root)),
+        stubOpencode({
+          continue: () => {
+            turn += 1
+            return Effect.succeed({
+              sessionId: "ses_implement_session",
+              assistantText:
+                turn === 1
+                  ? "READY_FOR_AGENT_RESULT: REVIEW_HAS_FINDINGS: high"
+                  : "READY_FOR_AGENT_RESULT: REVIEW_CLEARED: disagree with critic",
+            })
+          },
+        }),
+      )
+      expect(result).toEqual({
+        _tag: "needs_human",
+        reason: REVIEW_HIGH_UNCHANGED_REASON,
+      })
     }))
 
   it("runs Pre-Commit then re-reviews after FIXED and succeeds on clean", () =>
@@ -533,7 +759,7 @@ describe("review", () => {
               return Effect.succeed({
                 sessionId: "ses_implement_session",
                 assistantText:
-                  "Found a bug.\nREADY_FOR_AGENT_RESULT: REVIEW_HAS_FINDINGS",
+                  "Found a bug.\nREADY_FOR_AGENT_RESULT: REVIEW_HAS_FINDINGS: medium",
               })
             }
             if (continues.length === 2) {
@@ -567,6 +793,61 @@ describe("review", () => {
       expect(continues[2]!.prompt).toBe(buildReviewingPrompt())
     }))
 
+  it("runs Pre-Commit then re-reviews after FIXED_AND_DEFERRED", () =>
+    withTempGit(async (root) => {
+      await writeHook(root, "#!/usr/bin/env bash\nexit 0\n")
+      await writeFile(join(root, "change.txt"), "fixed\n")
+
+      const continues: Array<{
+        model: string
+        command?: string
+        prompt: string
+      }> = []
+
+      const result = await run(
+        review(
+          baseContext(root, {
+            model: "opencode/build-model",
+            reviewModel: "opencode/review-model",
+          }),
+        ),
+        stubOpencode({
+          continue: (input) => {
+            continues.push({
+              model: input.model,
+              prompt: input.prompt,
+              command: input.command,
+            })
+            if (continues.length === 1) {
+              return Effect.succeed({
+                sessionId: "ses_implement_session",
+                assistantText:
+                  "READY_FOR_AGENT_RESULT: REVIEW_HAS_FINDINGS: high",
+              })
+            }
+            if (continues.length === 2) {
+              return Effect.succeed({
+                sessionId: "ses_implement_session",
+                assistantText:
+                  "READY_FOR_AGENT_RESULT: REVIEW_FIXED_AND_DEFERRED: low: leftover style",
+              })
+            }
+            return Effect.succeed({
+              sessionId: "ses_implement_session",
+              assistantText: "READY_FOR_AGENT_RESULT: REVIEW_CLEAN",
+            })
+          },
+        }),
+      )
+
+      expect(result).toEqual({ _tag: "clean" })
+      expect(continues).toHaveLength(3)
+      expect(continues[0]!.command).toBe(REVIEW_AGENT_COMMAND)
+      expect(continues[1]!.model).toBe("opencode/build-model")
+      expect(continues[1]!.prompt).toContain("REVIEW_FIXED_AND_DEFERRED")
+      expect(continues[2]!.command).toBe(REVIEW_AGENT_COMMAND)
+    }))
+
   it("fails the Review Step Run when nested Pre-Commit fails after FIXED", () =>
     withTempGit(async (root) => {
       await writeHook(
@@ -592,7 +873,7 @@ describe("review", () => {
                 sessionId: "ses_implement_session",
                 assistantText:
                   turn === 1
-                    ? "READY_FOR_AGENT_RESULT: REVIEW_HAS_FINDINGS"
+                    ? "READY_FOR_AGENT_RESULT: REVIEW_HAS_FINDINGS: medium"
                     : "READY_FOR_AGENT_RESULT: REVIEW_FIXED",
               })
             }
@@ -621,7 +902,8 @@ describe("review", () => {
             if (isReviewingTurn(input)) {
               return Effect.succeed({
                 sessionId: "ses_implement_session",
-                assistantText: "READY_FOR_AGENT_RESULT: REVIEW_HAS_FINDINGS",
+                assistantText:
+                  "READY_FOR_AGENT_RESULT: REVIEW_HAS_FINDINGS: medium",
               })
             }
             return Effect.succeed({
@@ -661,7 +943,7 @@ describe("review", () => {
                 sessionId: "ses_implement_session",
                 assistantText:
                   turn <= 3
-                    ? "READY_FOR_AGENT_RESULT: REVIEW_HAS_FINDINGS"
+                    ? "READY_FOR_AGENT_RESULT: REVIEW_HAS_FINDINGS: low"
                     : "READY_FOR_AGENT_RESULT: REVIEW_CLEAN",
               })
             }
@@ -695,7 +977,7 @@ describe("review", () => {
                 sessionId: "ses_implement_session",
                 assistantText:
                   reviewingPasses <= MAX_REVIEW_FIX_ROUNDS
-                    ? "READY_FOR_AGENT_RESULT: REVIEW_HAS_FINDINGS"
+                    ? "READY_FOR_AGENT_RESULT: REVIEW_HAS_FINDINGS: medium"
                     : "READY_FOR_AGENT_RESULT: REVIEW_CLEAN",
               })
             }
@@ -728,7 +1010,8 @@ describe("review", () => {
             if (isReviewingTurn(input)) {
               return Effect.succeed({
                 sessionId: "ses_implement_session",
-                assistantText: "READY_FOR_AGENT_RESULT: REVIEW_HAS_FINDINGS",
+                assistantText:
+                  "READY_FOR_AGENT_RESULT: REVIEW_HAS_FINDINGS: low",
               })
             }
             if (turn === 2) {
@@ -740,7 +1023,7 @@ describe("review", () => {
             return Effect.succeed({
               sessionId: "ses_implement_session",
               assistantText:
-                "READY_FOR_AGENT_RESULT: REVIEW_DEFERRED: remaining style notes",
+                "READY_FOR_AGENT_RESULT: REVIEW_DEFERRED: low: remaining style notes",
             })
           },
         }),
@@ -748,6 +1031,7 @@ describe("review", () => {
 
       expect(result).toEqual({
         _tag: "deferred",
+        severity: "low",
         reason: "remaining style notes",
       })
     }))
@@ -838,7 +1122,7 @@ describe("review", () => {
                       sessionId: "ses_implement_session",
                       assistantText:
                         turn === 1
-                          ? "READY_FOR_AGENT_RESULT: REVIEW_HAS_FINDINGS"
+                          ? "READY_FOR_AGENT_RESULT: REVIEW_HAS_FINDINGS: medium"
                           : turn === 2
                             ? "READY_FOR_AGENT_RESULT: REVIEW_FIXED"
                             : "READY_FOR_AGENT_RESULT: REVIEW_CLEAN",
@@ -924,8 +1208,8 @@ describe("review", () => {
                       sessionId: "ses_implement_session",
                       assistantText:
                         turn === 1
-                          ? "READY_FOR_AGENT_RESULT: REVIEW_HAS_FINDINGS"
-                          : "READY_FOR_AGENT_RESULT: REVIEW_DEFERRED: later",
+                          ? "READY_FOR_AGENT_RESULT: REVIEW_HAS_FINDINGS: low"
+                          : "READY_FOR_AGENT_RESULT: REVIEW_DEFERRED: low: later",
                     }
                   }),
               }),
@@ -971,7 +1255,7 @@ describe("review", () => {
               sessionId: "ses_implement_session",
               assistantText:
                 turn === 1
-                  ? "READY_FOR_AGENT_RESULT: REVIEW_HAS_FINDINGS"
+                  ? "READY_FOR_AGENT_RESULT: REVIEW_HAS_FINDINGS: low"
                   : "I fixed things but forgot the marker",
             })
           },
@@ -994,7 +1278,7 @@ describe("review", () => {
                   sessionId: "ses_implement_session",
                   assistantText: [
                     "READY_FOR_AGENT_RESULT: REVIEW_CLEAN",
-                    "READY_FOR_AGENT_RESULT: REVIEW_HAS_FINDINGS",
+                    "READY_FOR_AGENT_RESULT: REVIEW_HAS_FINDINGS: low",
                   ].join("\n"),
                 })
               : Effect.succeed({

--- a/packages/work-item-lifecycle/test/work-item-lifecycle.spec.ts
+++ b/packages/work-item-lifecycle/test/work-item-lifecycle.spec.ts
@@ -4342,6 +4342,7 @@ describe("WorkItemLifecycle", () => {
         review: () =>
           Effect.succeed({
             _tag: "deferred" as const,
+            severity: "low" as const,
             reason: "style nits only",
           }),
       }
@@ -4367,8 +4368,89 @@ describe("WorkItemLifecycle", () => {
             )
             expect(reviewRun?.status).toBe("succeeded")
             expect(reviewRun?.reasonCode).toBe(STEP_RUN_REASON.reviewDeferred)
-            expect(reviewRun?.reasonMessage).toBe("style nits only")
+            expect(reviewRun?.reasonMessage).toBe("low: style nits only")
           }
+        }),
+      )
+    })
+
+    it("advances to Commit when Review reports cleared findings", () => {
+      const stepsClearedReview: LifecycleStepsShape = {
+        ...successfulSteps,
+        review: () =>
+          Effect.succeed({
+            _tag: "cleared" as const,
+            reason: "false positive on import order",
+          }),
+      }
+
+      return runWithSteps(
+        stepsClearedReview,
+        Effect.gen(function* () {
+          const lifecycle = yield* WorkItemLifecycle
+          const { repository, issue } = yield* seedActionableIssue
+          yield* lifecycle.implementNow(repository.id, issue.githubIssueNumber)
+          yield* claimAndRunPending
+          yield* claimAndRunPending
+          yield* claimAndRunPending
+          yield* claimAndRunPending
+          yield* claimAndRunPending
+          const afterReview = yield* claimAndRunPending
+
+          expect(afterReview._tag).toBe("processed")
+          if (afterReview._tag === "processed") {
+            expect(afterReview.workItem.state).toBe("commit")
+            const reviewRun = afterReview.workItem.stepRuns.find(
+              (run) => run.step === "review",
+            )
+            expect(reviewRun?.status).toBe("succeeded")
+            expect(reviewRun?.reasonCode).toBe(STEP_RUN_REASON.reviewCleared)
+            expect(reviewRun?.reasonMessage).toBe(
+              "false positive on import order",
+            )
+          }
+        }),
+      )
+    })
+
+    it("enters Needs Human when Review reports unresolved high and releases the Worker Slot", () => {
+      const reason = "auth bypass remains open"
+      const steps: LifecycleStepsShape = {
+        ...successfulSteps,
+        review: () =>
+          Effect.succeed({
+            _tag: "needs_human" as const,
+            reason,
+          }),
+      }
+
+      return runWithSteps(
+        steps,
+        Effect.gen(function* () {
+          const lifecycle = yield* WorkItemLifecycle
+          const { repository, issue } = yield* seedActionableIssue
+          const created = yield* lifecycle.implementNow(
+            repository.id,
+            issue.githubIssueNumber,
+          )
+          yield* claimAndRunPending
+          yield* claimAndRunPending
+          yield* claimAndRunPending
+          yield* claimAndRunPending
+          yield* claimAndRunPending
+          const afterReview = yield* claimAndRunPending
+
+          expect(afterReview._tag).toBe("processed")
+          if (afterReview._tag === "processed") {
+            expect(afterReview.workItem.state).toBe("needs_human")
+            expect(afterReview.workItem.failureCode).toBe("needs_human")
+            expect(afterReview.workItem.failureMessage).toBe(reason)
+            expect(afterReview.workItem.holdsWorkerSlot).toBe(false)
+          }
+
+          const final = yield* lifecycle.getWorkItem(created.id)
+          expect(final.state).toBe("needs_human")
+          expect(final.holdsWorkerSlot).toBe(false)
         }),
       )
     })


### PR DESCRIPTION
## Summary

- Make reviewing passes report aggregate Review Severity (`low` / `medium` / `high`) with an explicit impact rubric.
- Expand apply dispositions to fixed, fixed-and-deferred, deferred, cleared, and unresolved-high; enforce high-severity Needs Human when unchanged or disputed.
- Persist distinct Cleared and Deferred Step Run summaries; changed work still runs nested Pre-Commit then a full re-review (foundation for #433).

## Test plan

- [x] `bunx nx run work-item-lifecycle:test`
- [x] `bunx nx run work-item-lifecycle:typecheck`
- [x] `bunx nx run work-item-lifecycle:lint`
- [x] Pre-commit affected lint/typecheck/test

Closes #432