### PR TITLE
feat(work-item-lifecycle): skip full reruns for accepted low-severity remediation

### DIFF
--- a/packages/graphql-api/src/lib/work-item-projection.ts
+++ b/packages/graphql-api/src/lib/work-item-projection.ts
@@ -2,6 +2,7 @@ import type { IssueRecord } from "@ready-for-agent/db-service"
 import {
   type OperationalLifecycleStep,
   REVIEW_APPLYING_FINDINGS_MESSAGE,
+  REVIEW_ASSESSING_RERUN_MESSAGE,
   REVIEW_PRE_COMMIT_MESSAGE,
   REVIEW_REVIEWING_MESSAGE,
   STEP_RUN_REASON,
@@ -127,6 +128,7 @@ const REVIEW_IN_PROGRESS_CHIP_MESSAGES = new Set<string>([
   REVIEW_REVIEWING_MESSAGE,
   REVIEW_APPLYING_FINDINGS_MESSAGE,
   REVIEW_PRE_COMMIT_MESSAGE,
+  REVIEW_ASSESSING_RERUN_MESSAGE,
 ])
 
 const isRedundantReviewInProgressMessage = (stepRun: StepRunRecord): boolean =>
@@ -176,12 +178,15 @@ export const lifecycleLabels = (workItem: WorkItemRecord) => {
           : stepRun.reasonCode === STEP_RUN_REASON.reviewPreCommit ||
               stepRun.reasonMessage === REVIEW_PRE_COMMIT_MESSAGE
             ? REVIEW_PRE_COMMIT_MESSAGE
-            : stepRun.reasonCode === STEP_RUN_REASON.reviewReviewing ||
-                stepRun.reasonMessage == null ||
-                stepRun.reasonMessage === "" ||
-                stepRun.reasonMessage === REVIEW_REVIEWING_MESSAGE
-              ? REVIEW_REVIEWING_MESSAGE
-              : stepRun.reasonMessage
+            : stepRun.reasonCode === STEP_RUN_REASON.reviewAssessingRerun ||
+                stepRun.reasonMessage === REVIEW_ASSESSING_RERUN_MESSAGE
+              ? REVIEW_ASSESSING_RERUN_MESSAGE
+              : stepRun.reasonCode === STEP_RUN_REASON.reviewReviewing ||
+                  stepRun.reasonMessage == null ||
+                  stepRun.reasonMessage === "" ||
+                  stepRun.reasonMessage === REVIEW_REVIEWING_MESSAGE
+                ? REVIEW_REVIEWING_MESSAGE
+                : stepRun.reasonMessage
         : null
     const outcome =
       reviewRunningPhase !== null

--- a/packages/graphql-api/test/graphql-api.test.ts
+++ b/packages/graphql-api/test/graphql-api.test.ts
@@ -1910,6 +1910,67 @@ describe("GraphQL API", () => {
     })
   })
 
+  test("projects running Review Step Run as Review: assessing rerun", async () => {
+    const baseRun = workItem.stepRuns[0]!
+    const assessing = {
+      ...workItem,
+      state: "review",
+      stepRuns: [
+        {
+          ...baseRun,
+          step: "review",
+          status: "running",
+          reasonCode: STEP_RUN_REASON.reviewAssessingRerun,
+          reasonMessage: "assessing rerun",
+        },
+      ],
+    } as WorkItemRecord
+    await runtime.dispose()
+    runtime = makeRuntime(
+      {},
+      {},
+      {},
+      {
+        listWorkItemsForIssue: () => Effect.succeed([assessing]),
+      },
+    )
+
+    const response = await createGraphqlApi(runtime).fetch(
+      graphqlRequest({
+        query: `query WorkItems($repositoryId: ID!, $githubIssueNumber: Int!) {
+          workItems(repositoryId: $repositoryId, githubIssueNumber: $githubIssueNumber) {
+            stateLabel status statusLabel statusMessage
+            lifecycleLabels { phase label status }
+          }
+        }`,
+        variables: {
+          repositoryId: repository.id,
+          githubIssueNumber: issue.githubIssueNumber,
+        },
+      }),
+    )
+
+    expect(await response.json()).toEqual({
+      data: {
+        workItems: [
+          {
+            stateLabel: "Review",
+            status: "RUNNING",
+            statusLabel: "Running",
+            statusMessage: null,
+            lifecycleLabels: [
+              {
+                phase: "REVIEW",
+                label: "Review: assessing rerun",
+                status: "RUNNING",
+              },
+            ],
+          },
+        ],
+      },
+    })
+  })
+
   test("keeps non-echo Review statusMessage while Review phase reasonCode is set", async () => {
     const baseRun = workItem.stepRuns[0]!
     const operational = {

--- a/packages/work-item-lifecycle/src/lib/review.ts
+++ b/packages/work-item-lifecycle/src/lib/review.ts
@@ -15,6 +15,7 @@ import {
 import {
   DEFAULT_LIFECYCLE_MAX_DURATIONS,
   REVIEW_APPLYING_FINDINGS_MESSAGE,
+  REVIEW_ASSESSING_RERUN_MESSAGE,
   REVIEW_PRE_COMMIT_MESSAGE,
   REVIEW_REVIEWING_MESSAGE,
   STEP_RUN_REASON,
@@ -52,6 +53,14 @@ export type ReviewResult =
       readonly severity: DeferredReviewSeverity
       readonly reason: string
     }
+  | {
+      readonly _tag: "accepted"
+      readonly reason: string
+      readonly deferred: {
+        readonly severity: DeferredReviewSeverity
+        readonly reason: string
+      } | null
+    }
   | { readonly _tag: "needs_human"; readonly reason: string }
 
 /** Machine-readable outcome of the reviewing (/review) pass only. */
@@ -75,6 +84,11 @@ export type ApplyReviewResult =
   | { readonly _tag: "cleared"; readonly reason: string }
   | { readonly _tag: "unresolved_high"; readonly reason: string }
 
+/** Machine-readable outcome of a Review Rerun Assessment. */
+export type RerunAssessmentResult =
+  | { readonly _tag: "accepted"; readonly reason: string }
+  | { readonly _tag: "rerun_required"; readonly reason: string }
+
 export const REVIEW_AGENT_COMMAND = "/review"
 
 const SEVERITY_RUBRIC = [
@@ -89,6 +103,18 @@ export const formatDeferredReviewSummary = (
   severity: DeferredReviewSeverity,
   reason: string,
 ): string => `${severity}: ${reason}`
+
+/** Persist Accepted Review Outcome rationale (and any deferred remainder). */
+export const formatAcceptedReviewSummary = (
+  reason: string,
+  deferred: {
+    readonly severity: DeferredReviewSeverity
+    readonly reason: string
+  } | null,
+): string =>
+  deferred === null
+    ? reason
+    : `${reason} (deferred ${deferred.severity}: ${deferred.reason})`
 
 export const buildReviewingPrompt = () =>
   [
@@ -132,6 +158,20 @@ const buildApplyFindingsPrompt = (severity: ReviewSeverity) =>
     "or",
     "READY_FOR_AGENT_RESULT: REVIEW_UNRESOLVED_HIGH: <short reason>",
     "when high-severity findings remain unresolved or disputed without a fix.",
+  ].join("\n")
+
+export const buildRerunAssessmentPrompt = () =>
+  [
+    "A prior build-model pass applied low-severity Review Findings, then nested Pre-Commit ran in this Session.",
+    "Using only this Session's account of those apply and Pre-Commit changes, decide whether another full reviewing pass is required.",
+    "Do not edit files, commit, push, open pull requests, re-review the whole worktree, capture repository snapshots, or compute diffs.",
+    "Accept without rerun only when remediation was direct, localized, and semantics-preserving relative to the low-severity findings.",
+    "Require a full reviewing pass when remediation changed behavior, contracts, schemas, dependencies, security posture, concurrency, broad generated files, expanded beyond the findings, or when you are uncertain.",
+    "End your final response with exactly one machine-readable result line:",
+    "READY_FOR_AGENT_RESULT: REVIEW_RERUN_NOT_REQUIRED: <short reason>",
+    "when the remediation may advance without another reviewing pass, or",
+    "READY_FOR_AGENT_RESULT: REVIEW_RERUN_REQUIRED: <short reason>",
+    "when a full reviewing pass is required.",
   ].join("\n")
 
 const uniqueFinalResultLine = (output: string): string | null => {
@@ -279,6 +319,41 @@ export const parseApplyReviewResult = (
   return null
 }
 
+/**
+ * Parse the unique final READY_FOR_AGENT_RESULT line from a Review Rerun Assessment.
+ * Returns null for missing, duplicate, non-final, or unrecognized markers.
+ */
+export const parseRerunAssessmentResult = (
+  output: string,
+): RerunAssessmentResult | null => {
+  const finalLine = uniqueFinalResultLine(output)
+  if (finalLine === null) {
+    return null
+  }
+
+  const notRequired = finalLine.match(
+    /^READY_FOR_AGENT_RESULT:\s*REVIEW_RERUN_NOT_REQUIRED\s*:\s*(.+)$/i,
+  )
+  if (notRequired?.[1] !== undefined && notRequired[1].trim() !== "") {
+    return {
+      _tag: "accepted",
+      reason: boundReason(notRequired[1]),
+    }
+  }
+
+  const required = finalLine.match(
+    /^READY_FOR_AGENT_RESULT:\s*REVIEW_RERUN_REQUIRED\s*:\s*(.+)$/i,
+  )
+  if (required?.[1] !== undefined && required[1].trim() !== "") {
+    return {
+      _tag: "rerun_required",
+      reason: boundReason(required[1]),
+    }
+  }
+
+  return null
+}
+
 const resolveWorktreePath = (context: LifecycleStepContext) =>
   Effect.gen(function* () {
     const worktreePath = context.worktreePath
@@ -375,14 +450,23 @@ const markReviewPreCommitPhase = markReviewPhase(
   "pre-commit",
 )
 
+const markAssessingRerunPhase = markReviewPhase(
+  STEP_RUN_REASON.reviewAssessingRerun,
+  REVIEW_ASSESSING_RERUN_MESSAGE,
+  "assessing rerun",
+)
+
 /**
  * Production Review Lifecycle Step — reviewing pass, optional apply-findings,
- * and on changed work a nested Pre-Commit then re-review. Continues the Implement
- * OpenCode Session. Reviewing uses the review model/variant; applying findings
- * and nested Pre-Commit fix turns use the build model/variant. Nested Pre-Commit
- * failures fail the Review Step Run (retryable), same spirit as standalone
- * Pre-Commit. At most {@link MAX_REVIEW_FIX_ROUNDS} changed apply rounds; further
- * findings without clean/deferred/cleared become Needs Human (not a failed Step Run).
+ * and on changed work a nested Pre-Commit then either a Review Rerun Assessment
+ * (low severity) or a mandatory full reviewing pass (medium/high). Continues the
+ * Implement OpenCode Session. Reviewing uses the review model/variant; applying
+ * findings, nested Pre-Commit fix turns, and rerun assessments use the build
+ * model/variant. Nested Pre-Commit failures fail the Review Step Run (retryable),
+ * same spirit as standalone Pre-Commit. At most {@link MAX_REVIEW_FIX_ROUNDS}
+ * changed apply rounds; assessment and reviewing turns do not independently
+ * consume rounds. Further findings without clean/deferred/cleared/accepted
+ * become Needs Human (not a failed Step Run).
  */
 export const review = (context: LifecycleStepContext) =>
   Effect.gen(function* () {
@@ -533,9 +617,54 @@ export const review = (context: LifecycleStepContext) =>
         }
       }
 
-      // fixed | fixed_and_deferred — changed work always re-reviews after Pre-Commit
+      // fixed | fixed_and_deferred — changed work: Pre-Commit then severity policy
       fixRoundsUsed += 1
+      const deferredFromApply =
+        applyParsed._tag === "fixed_and_deferred"
+          ? {
+              severity: applyParsed.severity,
+              reason: applyParsed.reason,
+            }
+          : null
+
       yield* markReviewPreCommitPhase
       yield* preCommit(context)
+
+      if (originalSeverity === "low") {
+        yield* markAssessingRerunPhase
+        const assessment = yield* opencode
+          .continue({
+            sessionId,
+            prompt: buildRerunAssessmentPrompt(),
+            cwd: worktreePath,
+            model: context.model,
+            variant: context.variant,
+            timeout,
+          })
+          .pipe(
+            Effect.mapError(
+              (cause) =>
+                new ReviewOpenCodeError({
+                  message: "OpenCode failed during Review Rerun Assessment",
+                  worktreePath,
+                  sessionId,
+                  cause,
+                }),
+            ),
+          )
+
+        const assessmentParsed = parseRerunAssessmentResult(
+          assessment.assistantText,
+        )
+        // Missing/duplicate/malformed/ambiguous → conservative full reviewing pass
+        if (assessmentParsed?._tag === "accepted") {
+          return {
+            _tag: "accepted" as const,
+            reason: assessmentParsed.reason,
+            deferred: deferredFromApply,
+          }
+        }
+      }
+      // medium/high mandatory rerun, low rerun_required, or malformed assessment
     }
   })

--- a/packages/work-item-lifecycle/src/lib/types.ts
+++ b/packages/work-item-lifecycle/src/lib/types.ts
@@ -131,6 +131,9 @@ export const REVIEW_APPLYING_FINDINGS_MESSAGE = "applying findings"
 /** Operator-visible Review phase while nested Pre-Commit runs after FIXED. */
 export const REVIEW_PRE_COMMIT_MESSAGE = "pre-commit"
 
+/** Operator-visible Review phase while Review Rerun Assessment runs. */
+export const REVIEW_ASSESSING_RERUN_MESSAGE = "assessing rerun"
+
 export const WORK_ITEM_LIFECYCLE_QUEUE = "jobs"
 
 export const WorkItemStepJob = Schema.TaggedStruct("work-item-step", {
@@ -270,10 +273,14 @@ export const STEP_RUN_REASON = {
   reviewApplyingFindings: "review_applying_findings",
   /** Mid-run: Review is re-running Pre-Commit after FIXED before re-review. */
   reviewPreCommit: "review_pre_commit",
+  /** Mid-run: Review is assessing whether low-severity remediation needs rerun. */
+  reviewAssessingRerun: "review_assessing_rerun",
   /** Successful Review that deferred findings and advanced to Commit. */
   reviewDeferred: "review_deferred",
   /** Successful Review that cleared low/medium findings without changes. */
   reviewCleared: "review_cleared",
+  /** Successful Review that accepted low-severity remediation without full rerun. */
+  reviewAccepted: "review_accepted",
   /** Successful Merge PR run that returned to Watch for fresh validation. */
   mergeRevalidation: "merge_revalidation",
 } as const

--- a/packages/work-item-lifecycle/src/lib/work-item-lifecycle.ts
+++ b/packages/work-item-lifecycle/src/lib/work-item-lifecycle.ts
@@ -61,7 +61,10 @@ import {
   PreCommitHookFailedError,
   PreCommitStageError,
 } from "./pre-commit-errors.js"
-import { formatDeferredReviewSummary } from "./review.js"
+import {
+  formatAcceptedReviewSummary,
+  formatDeferredReviewSummary,
+} from "./review.js"
 import {
   DEFAULT_LIFECYCLE_MAX_DURATIONS,
   type LifecycleMaxDurations,
@@ -1286,6 +1289,15 @@ export const makeWorkItemLifecycleLive = (
                   return {
                     stepRunReasonCode: STEP_RUN_REASON.reviewCleared,
                     stepRunNote: result.reason,
+                  }
+                }
+                if (result._tag === "accepted") {
+                  return {
+                    stepRunReasonCode: STEP_RUN_REASON.reviewAccepted,
+                    stepRunNote: formatAcceptedReviewSummary(
+                      result.reason,
+                      result.deferred,
+                    ),
                   }
                 }
                 if (result._tag === "needs_human") {

--- a/packages/work-item-lifecycle/test/review.spec.ts
+++ b/packages/work-item-lifecycle/test/review.spec.ts
@@ -19,6 +19,7 @@ import {
   PreCommitOpenCodeError,
   REVIEW_AGENT_COMMAND,
   REVIEW_APPLYING_FINDINGS_MESSAGE,
+  REVIEW_ASSESSING_RERUN_MESSAGE,
   REVIEW_FIX_LIMIT_REASON,
   REVIEW_HIGH_UNCHANGED_REASON,
   REVIEW_PRE_COMMIT_MESSAGE,
@@ -29,10 +30,13 @@ import {
   ReviewSessionContextMissingError,
   ReviewWorktreeContextMissingError,
   STEP_RUN_REASON,
+  buildRerunAssessmentPrompt,
   buildReviewingPrompt,
+  formatAcceptedReviewSummary,
   formatDeferredReviewSummary,
   makeWorkItemId,
   parseApplyReviewResult,
+  parseRerunAssessmentResult,
   parseReviewResult,
   review,
 } from "../src/index.js"
@@ -304,12 +308,88 @@ describe("formatDeferredReviewSummary", () => {
   })
 })
 
+describe("formatAcceptedReviewSummary", () => {
+  it("persists acceptance rationale and optional deferred remainder", () => {
+    expect(formatAcceptedReviewSummary("localized rename only", null)).toBe(
+      "localized rename only",
+    )
+    expect(
+      formatAcceptedReviewSummary("localized rename only", {
+        severity: "low",
+        reason: "style nits remain",
+      }),
+    ).toBe("localized rename only (deferred low: style nits remain)")
+  })
+})
+
+describe("parseRerunAssessmentResult", () => {
+  it("parses accepted-without-rerun and rerun-required lines", () => {
+    expect(
+      parseRerunAssessmentResult(
+        "Looks narrow.\nREADY_FOR_AGENT_RESULT: REVIEW_RERUN_NOT_REQUIRED: direct rename only",
+      ),
+    ).toEqual({
+      _tag: "accepted",
+      reason: "direct rename only",
+    })
+    expect(
+      parseRerunAssessmentResult(
+        "READY_FOR_AGENT_RESULT: REVIEW_RERUN_REQUIRED: expanded into parser behavior",
+      ),
+    ).toEqual({
+      _tag: "rerun_required",
+      reason: "expanded into parser behavior",
+    })
+  })
+
+  it("rejects missing, duplicate, blank, non-final, or foreign markers", () => {
+    expect(parseRerunAssessmentResult("no result line")).toBeNull()
+    expect(
+      parseRerunAssessmentResult(
+        [
+          "READY_FOR_AGENT_RESULT: REVIEW_RERUN_NOT_REQUIRED: a",
+          "READY_FOR_AGENT_RESULT: REVIEW_RERUN_REQUIRED: b",
+        ].join("\n"),
+      ),
+    ).toBeNull()
+    expect(
+      parseRerunAssessmentResult(
+        "READY_FOR_AGENT_RESULT: REVIEW_RERUN_NOT_REQUIRED: ok\ntrailing",
+      ),
+    ).toBeNull()
+    expect(
+      parseRerunAssessmentResult(
+        "READY_FOR_AGENT_RESULT: REVIEW_RERUN_NOT_REQUIRED:",
+      ),
+    ).toBeNull()
+    expect(
+      parseRerunAssessmentResult("READY_FOR_AGENT_RESULT: REVIEW_FIXED"),
+    ).toBeNull()
+    expect(
+      parseRerunAssessmentResult("READY_FOR_AGENT_RESULT: REVIEW_CLEAN"),
+    ).toBeNull()
+  })
+
+  it("bounds assessment reasons", () => {
+    const long = "x".repeat(600)
+    expect(
+      parseRerunAssessmentResult(
+        `READY_FOR_AGENT_RESULT: REVIEW_RERUN_REQUIRED: ${long}`,
+      ),
+    ).toEqual({ _tag: "rerun_required", reason: long.slice(0, 500) })
+  })
+})
+
 const isReviewingTurn = (input: {
   readonly command?: string
   readonly prompt: string
 }): boolean =>
   input.command === REVIEW_AGENT_COMMAND ||
   input.prompt === buildReviewingPrompt()
+
+const isAssessmentTurn = (input: { readonly prompt: string }): boolean =>
+  input.prompt === buildRerunAssessmentPrompt() ||
+  input.prompt.includes("REVIEW_RERUN_NOT_REQUIRED")
 
 describe("buildReviewingPrompt", () => {
   it("forbids edits, defines the severity rubric, and requires the result contract", () => {
@@ -726,7 +806,7 @@ describe("review", () => {
       })
     }))
 
-  it("runs Pre-Commit then re-reviews after FIXED and succeeds on clean", () =>
+  it("runs Pre-Commit then re-reviews after medium FIXED without assessment", () =>
     withTempGit(async (root) => {
       await writeHook(root, "#!/usr/bin/env bash\nexit 0\n")
       await writeFile(join(root, "change.txt"), "fixed\n")
@@ -791,9 +871,62 @@ describe("review", () => {
       expect(continues[2]!.variant).toBe("max")
       expect(continues[2]!.command).toBe(REVIEW_AGENT_COMMAND)
       expect(continues[2]!.prompt).toBe(buildReviewingPrompt())
+      expect(continues.some((turn) => isAssessmentTurn(turn))).toBe(false)
     }))
 
-  it("runs Pre-Commit then re-reviews after FIXED_AND_DEFERRED", () =>
+  it("runs Pre-Commit then full reviewing after high FIXED without assessment", () =>
+    withTempGit(async (root) => {
+      await writeHook(root, "#!/usr/bin/env bash\nexit 0\n")
+      await writeFile(join(root, "change.txt"), "fixed\n")
+
+      const continues: Array<{
+        model: string
+        command?: string
+        prompt: string
+      }> = []
+
+      const result = await run(
+        review(
+          baseContext(root, {
+            model: "opencode/build-model",
+            reviewModel: "opencode/review-model",
+          }),
+        ),
+        stubOpencode({
+          continue: (input) => {
+            continues.push({
+              model: input.model,
+              prompt: input.prompt,
+              command: input.command,
+            })
+            if (continues.length === 1) {
+              return Effect.succeed({
+                sessionId: "ses_implement_session",
+                assistantText:
+                  "READY_FOR_AGENT_RESULT: REVIEW_HAS_FINDINGS: high",
+              })
+            }
+            if (continues.length === 2) {
+              return Effect.succeed({
+                sessionId: "ses_implement_session",
+                assistantText: "READY_FOR_AGENT_RESULT: REVIEW_FIXED",
+              })
+            }
+            return Effect.succeed({
+              sessionId: "ses_implement_session",
+              assistantText: "READY_FOR_AGENT_RESULT: REVIEW_CLEAN",
+            })
+          },
+        }),
+      )
+
+      expect(result).toEqual({ _tag: "clean" })
+      expect(continues).toHaveLength(3)
+      expect(continues.some((turn) => isAssessmentTurn(turn))).toBe(false)
+      expect(continues[2]!.command).toBe(REVIEW_AGENT_COMMAND)
+    }))
+
+  it("runs Pre-Commit then re-reviews after high FIXED_AND_DEFERRED without assessment", () =>
     withTempGit(async (root) => {
       await writeHook(root, "#!/usr/bin/env bash\nexit 0\n")
       await writeFile(join(root, "change.txt"), "fixed\n")
@@ -846,6 +979,227 @@ describe("review", () => {
       expect(continues[1]!.model).toBe("opencode/build-model")
       expect(continues[1]!.prompt).toContain("REVIEW_FIXED_AND_DEFERRED")
       expect(continues[2]!.command).toBe(REVIEW_AGENT_COMMAND)
+      expect(continues.some((turn) => isAssessmentTurn(turn))).toBe(false)
+    }))
+
+  it("accepts low-severity FIXED without a second review-model command", () =>
+    withTempGit(async (root) => {
+      await writeHook(root, "#!/usr/bin/env bash\nexit 0\n")
+      await writeFile(join(root, "change.txt"), "fixed\n")
+
+      const continues: Array<{
+        model: string
+        variant: string
+        prompt: string
+        command?: string
+      }> = []
+
+      const result = await run(
+        review(
+          baseContext(root, {
+            model: "opencode/build-model",
+            variant: "high",
+            reviewModel: "opencode/review-model",
+            reviewVariant: "max",
+          }),
+        ),
+        stubOpencode({
+          continue: (input) => {
+            continues.push({
+              model: input.model,
+              variant: input.variant,
+              prompt: input.prompt,
+              command: input.command,
+            })
+            if (isReviewingTurn(input)) {
+              return Effect.succeed({
+                sessionId: "ses_implement_session",
+                assistantText:
+                  "READY_FOR_AGENT_RESULT: REVIEW_HAS_FINDINGS: low",
+              })
+            }
+            if (isAssessmentTurn(input)) {
+              return Effect.succeed({
+                sessionId: "ses_implement_session",
+                assistantText:
+                  "READY_FOR_AGENT_RESULT: REVIEW_RERUN_NOT_REQUIRED: direct localized rename",
+              })
+            }
+            return Effect.succeed({
+              sessionId: "ses_implement_session",
+              assistantText: "READY_FOR_AGENT_RESULT: REVIEW_FIXED",
+            })
+          },
+        }),
+      )
+
+      expect(result).toEqual({
+        _tag: "accepted",
+        reason: "direct localized rename",
+        deferred: null,
+      })
+      expect(continues).toHaveLength(3)
+      expect(continues[0]!.model).toBe("opencode/review-model")
+      expect(continues[0]!.command).toBe(REVIEW_AGENT_COMMAND)
+      expect(continues[1]!.model).toBe("opencode/build-model")
+      expect(continues[1]!.prompt).toContain("REVIEW_FIXED")
+      expect(continues[2]!.model).toBe("opencode/build-model")
+      expect(continues[2]!.variant).toBe("high")
+      expect(continues[2]!.command).toBeUndefined()
+      expect(continues[2]!.prompt).toBe(buildRerunAssessmentPrompt())
+      expect(continues[2]!.prompt).toContain(
+        "direct, localized, and semantics-preserving",
+      )
+      expect(continues.filter((turn) => isReviewingTurn(turn))).toHaveLength(1)
+    }))
+
+  it("accepts low FIXED_AND_DEFERRED and preserves deferred severity", () =>
+    withTempGit(async (root) => {
+      await writeHook(root, "#!/usr/bin/env bash\nexit 0\n")
+      await writeFile(join(root, "change.txt"), "fixed\n")
+
+      const result = await run(
+        review(
+          baseContext(root, {
+            model: "opencode/build-model",
+            reviewModel: "opencode/review-model",
+          }),
+        ),
+        stubOpencode({
+          continue: (input) => {
+            if (isReviewingTurn(input)) {
+              return Effect.succeed({
+                sessionId: "ses_implement_session",
+                assistantText:
+                  "READY_FOR_AGENT_RESULT: REVIEW_HAS_FINDINGS: low",
+              })
+            }
+            if (isAssessmentTurn(input)) {
+              return Effect.succeed({
+                sessionId: "ses_implement_session",
+                assistantText:
+                  "READY_FOR_AGENT_RESULT: REVIEW_RERUN_NOT_REQUIRED: comment-only fix",
+              })
+            }
+            return Effect.succeed({
+              sessionId: "ses_implement_session",
+              assistantText:
+                "READY_FOR_AGENT_RESULT: REVIEW_FIXED_AND_DEFERRED: low: leftover import order",
+            })
+          },
+        }),
+      )
+
+      expect(result).toEqual({
+        _tag: "accepted",
+        reason: "comment-only fix",
+        deferred: {
+          severity: "low",
+          reason: "leftover import order",
+        },
+      })
+    }))
+
+  it("re-reviews after low FIXED when assessment requires rerun", () =>
+    withTempGit(async (root) => {
+      await writeHook(root, "#!/usr/bin/env bash\nexit 0\n")
+      await writeFile(join(root, "change.txt"), "fixed\n")
+
+      const continues: Array<{
+        model: string
+        command?: string
+        prompt: string
+      }> = []
+
+      const result = await run(
+        review(
+          baseContext(root, {
+            model: "opencode/build-model",
+            reviewModel: "opencode/review-model",
+          }),
+        ),
+        stubOpencode({
+          continue: (input) => {
+            continues.push({
+              model: input.model,
+              prompt: input.prompt,
+              command: input.command,
+            })
+            if (isReviewingTurn(input)) {
+              return Effect.succeed({
+                sessionId: "ses_implement_session",
+                assistantText:
+                  continues.filter((turn) => isReviewingTurn(turn)).length === 1
+                    ? "READY_FOR_AGENT_RESULT: REVIEW_HAS_FINDINGS: low"
+                    : "READY_FOR_AGENT_RESULT: REVIEW_CLEAN",
+              })
+            }
+            if (isAssessmentTurn(input)) {
+              return Effect.succeed({
+                sessionId: "ses_implement_session",
+                assistantText:
+                  "READY_FOR_AGENT_RESULT: REVIEW_RERUN_REQUIRED: expanded scope into schema",
+              })
+            }
+            return Effect.succeed({
+              sessionId: "ses_implement_session",
+              assistantText: "READY_FOR_AGENT_RESULT: REVIEW_FIXED",
+            })
+          },
+        }),
+      )
+
+      expect(result).toEqual({ _tag: "clean" })
+      expect(continues).toHaveLength(4)
+      expect(continues[0]!.command).toBe(REVIEW_AGENT_COMMAND)
+      expect(continues[1]!.model).toBe("opencode/build-model")
+      expect(continues[2]!.model).toBe("opencode/build-model")
+      expect(isAssessmentTurn(continues[2]!)).toBe(true)
+      expect(continues[3]!.command).toBe(REVIEW_AGENT_COMMAND)
+      expect(continues[3]!.model).toBe("opencode/review-model")
+    }))
+
+  it("falls back to full reviewing when low assessment output is malformed", () =>
+    withTempGit(async (root) => {
+      await writeHook(root, "#!/usr/bin/env bash\nexit 0\n")
+      await writeFile(join(root, "change.txt"), "fixed\n")
+
+      const continues: Array<{ prompt: string; command?: string }> = []
+
+      const result = await run(
+        review(baseContext(root)),
+        stubOpencode({
+          continue: (input) => {
+            continues.push({
+              prompt: input.prompt,
+              command: input.command,
+            })
+            if (isReviewingTurn(input)) {
+              return Effect.succeed({
+                sessionId: "ses_implement_session",
+                assistantText:
+                  continues.filter((turn) => isReviewingTurn(turn)).length === 1
+                    ? "READY_FOR_AGENT_RESULT: REVIEW_HAS_FINDINGS: low"
+                    : "READY_FOR_AGENT_RESULT: REVIEW_CLEAN",
+              })
+            }
+            if (isAssessmentTurn(input)) {
+              return Effect.succeed({
+                sessionId: "ses_implement_session",
+                assistantText: "I am unsure and forgot the marker",
+              })
+            }
+            return Effect.succeed({
+              sessionId: "ses_implement_session",
+              assistantText: "READY_FOR_AGENT_RESULT: REVIEW_FIXED",
+            })
+          },
+        }),
+      )
+
+      expect(result).toEqual({ _tag: "clean" })
+      expect(continues.filter((turn) => isAssessmentTurn(turn))).toHaveLength(1)
+      expect(continues.filter((turn) => isReviewingTurn(turn))).toHaveLength(2)
     }))
 
   it("fails the Review Step Run when nested Pre-Commit fails after FIXED", () =>
@@ -932,21 +1286,32 @@ describe("review", () => {
       await writeHook(root, "#!/usr/bin/env bash\nexit 0\n")
       await writeFile(join(root, "change.txt"), "fixed\n")
 
-      let turn = 0
+      let reviewingPasses = 0
+      let applyPasses = 0
+      let assessmentPasses = 0
       const result = await run(
         review(baseContext(root)),
         stubOpencode({
           continue: (input) => {
-            turn += 1
             if (isReviewingTurn(input)) {
+              reviewingPasses += 1
               return Effect.succeed({
                 sessionId: "ses_implement_session",
                 assistantText:
-                  turn <= 3
+                  reviewingPasses <= 2
                     ? "READY_FOR_AGENT_RESULT: REVIEW_HAS_FINDINGS: low"
                     : "READY_FOR_AGENT_RESULT: REVIEW_CLEAN",
               })
             }
+            if (isAssessmentTurn(input)) {
+              assessmentPasses += 1
+              return Effect.succeed({
+                sessionId: "ses_implement_session",
+                assistantText:
+                  "READY_FOR_AGENT_RESULT: REVIEW_RERUN_REQUIRED: still uncertain",
+              })
+            }
+            applyPasses += 1
             return Effect.succeed({
               sessionId: "ses_implement_session",
               assistantText: "READY_FOR_AGENT_RESULT: REVIEW_FIXED",
@@ -955,8 +1320,10 @@ describe("review", () => {
         }),
       )
 
-      // reviewing, apply, reviewing, apply, reviewing(clean)
-      expect(turn).toBe(5)
+      // reviewing, apply, assess, reviewing, apply, assess, reviewing(clean)
+      expect(reviewingPasses).toBe(3)
+      expect(applyPasses).toBe(2)
+      expect(assessmentPasses).toBe(2)
       expect(result).toEqual({ _tag: "clean" })
     }))
 
@@ -1001,12 +1368,11 @@ describe("review", () => {
       await writeHook(root, "#!/usr/bin/env bash\nexit 0\n")
       await writeFile(join(root, "change.txt"), "fixed\n")
 
-      let turn = 0
+      let applyPasses = 0
       const result = await run(
         review(baseContext(root)),
         stubOpencode({
           continue: (input) => {
-            turn += 1
             if (isReviewingTurn(input)) {
               return Effect.succeed({
                 sessionId: "ses_implement_session",
@@ -1014,7 +1380,15 @@ describe("review", () => {
                   "READY_FOR_AGENT_RESULT: REVIEW_HAS_FINDINGS: low",
               })
             }
-            if (turn === 2) {
+            if (isAssessmentTurn(input)) {
+              return Effect.succeed({
+                sessionId: "ses_implement_session",
+                assistantText:
+                  "READY_FOR_AGENT_RESULT: REVIEW_RERUN_REQUIRED: needs another look",
+              })
+            }
+            applyPasses += 1
+            if (applyPasses === 1) {
               return Effect.succeed({
                 sessionId: "ses_implement_session",
                 assistantText: "READY_FOR_AGENT_RESULT: REVIEW_FIXED",
@@ -1033,6 +1407,53 @@ describe("review", () => {
         _tag: "deferred",
         severity: "low",
         reason: "remaining style notes",
+      })
+    }))
+
+  it("counts only changed apply rounds toward the fix limit when assessing low severity", () =>
+    withTempGit(async (root) => {
+      await writeHook(root, "#!/usr/bin/env bash\nexit 0\n")
+      await writeFile(join(root, "change.txt"), "still broken\n")
+
+      let reviewingPasses = 0
+      let applyPasses = 0
+      let assessmentPasses = 0
+      const result = await run(
+        review(baseContext(root)),
+        stubOpencode({
+          continue: (input) => {
+            if (isReviewingTurn(input)) {
+              reviewingPasses += 1
+              return Effect.succeed({
+                sessionId: "ses_implement_session",
+                assistantText:
+                  "READY_FOR_AGENT_RESULT: REVIEW_HAS_FINDINGS: low",
+              })
+            }
+            if (isAssessmentTurn(input)) {
+              assessmentPasses += 1
+              return Effect.succeed({
+                sessionId: "ses_implement_session",
+                assistantText:
+                  "READY_FOR_AGENT_RESULT: REVIEW_RERUN_REQUIRED: still risky",
+              })
+            }
+            applyPasses += 1
+            return Effect.succeed({
+              sessionId: "ses_implement_session",
+              assistantText: "READY_FOR_AGENT_RESULT: REVIEW_FIXED",
+            })
+          },
+        }),
+      )
+
+      // 6 reviewing + 5 apply + 5 assessment; no 6th apply
+      expect(applyPasses).toBe(5)
+      expect(assessmentPasses).toBe(5)
+      expect(reviewingPasses).toBe(6)
+      expect(result).toEqual({
+        _tag: "needs_human",
+        reason: REVIEW_FIX_LIMIT_REASON,
       })
     }))
 
@@ -1225,6 +1646,100 @@ describe("review", () => {
       expect(phaseDuringApply).toEqual({
         reason_code: STEP_RUN_REASON.reviewApplyingFindings,
         reason_message: REVIEW_APPLYING_FINDINGS_MESSAGE,
+      })
+    }))
+
+  it("marks Step Run phase as assessing rerun during low-severity assessment", () =>
+    withTempGit(async (root) => {
+      await writeHook(root, "#!/usr/bin/env bash\nexit 0\n")
+      await writeFile(join(root, "change.txt"), "fixed\n")
+
+      const stepRunId = "srun-01JREVIEWASSESS000000000001"
+      const workItemId = "wi-01JREVIEWASSESS0000000000001"
+      const repositoryId = "repo-review-assess-phase"
+      let phaseDuringAssess: {
+        reason_code: string | null
+        reason_message: string | null
+      } | null = null
+
+      await Effect.runPromise(
+        Effect.gen(function* () {
+          const sql = yield* SqlClient.SqlClient
+          const now = Date.now()
+          yield* sql.unsafe(
+            `INSERT INTO repository (
+               id, github_owner, github_repo, local_path, is_bare, paused,
+               issues_reconciled_at, created_at, updated_at
+             ) VALUES (?, 'o', 'r', ?, 1, 0, NULL, ?, ?)`,
+            [repositoryId, `/tmp/${repositoryId}`, now, now],
+          )
+          yield* sql.unsafe(
+            `INSERT INTO work_item (
+               id, repository_id, github_issue_number, model, variant,
+               review_model, review_variant, state, state_ready_at, worktree_path,
+               session_id, failure_code, failure_message, created_at, updated_at
+             ) VALUES (?, ?, 1, 'm', 'v', 'm', 'v', 'review', ?,
+               ?, 'ses_implement_session', NULL, NULL, ?, ?)`,
+            [workItemId, repositoryId, now, root, now, now],
+          )
+          yield* sql.unsafe(
+            `INSERT INTO step_run (
+               id, work_item_id, step, status, queue_job_id, queued_at,
+               started_at, finished_at, reason_code, reason_message,
+               created_at, updated_at
+             ) VALUES (?, ?, 'review', 'running', NULL, ?, ?, NULL, NULL, NULL, ?, ?)`,
+            [stepRunId, workItemId, now, now, now, now],
+          )
+
+          yield* review(baseContext(root, { repositoryId })).pipe(
+            Effect.provideService(CurrentStepRun, {
+              stepRunId,
+              repositoryId,
+            }),
+            Effect.provide(
+              stubOpencode({
+                continue: (input) =>
+                  Effect.gen(function* () {
+                    if (isAssessmentTurn(input)) {
+                      const rows = (yield* sql.unsafe(
+                        `SELECT reason_code, reason_message FROM step_run WHERE id = ?`,
+                        [stepRunId],
+                      )) as readonly {
+                        readonly reason_code: string | null
+                        readonly reason_message: string | null
+                      }[]
+                      phaseDuringAssess = rows[0] ?? null
+                      return {
+                        sessionId: "ses_implement_session",
+                        assistantText:
+                          "READY_FOR_AGENT_RESULT: REVIEW_RERUN_NOT_REQUIRED: localized only",
+                      }
+                    }
+                    if (isReviewingTurn(input)) {
+                      return {
+                        sessionId: "ses_implement_session",
+                        assistantText:
+                          "READY_FOR_AGENT_RESULT: REVIEW_HAS_FINDINGS: low",
+                      }
+                    }
+                    return {
+                      sessionId: "ses_implement_session",
+                      assistantText: "READY_FOR_AGENT_RESULT: REVIEW_FIXED",
+                    }
+                  }),
+              }),
+            ),
+          )
+        }).pipe(
+          Effect.provide(DbServiceLive),
+          Effect.provide(DatabaseTest),
+          Effect.provide(PlatformLayer),
+        ),
+      )
+
+      expect(phaseDuringAssess).toEqual({
+        reason_code: STEP_RUN_REASON.reviewAssessingRerun,
+        reason_message: REVIEW_ASSESSING_RERUN_MESSAGE,
       })
     }))
 

--- a/packages/work-item-lifecycle/test/work-item-lifecycle.spec.ts
+++ b/packages/work-item-lifecycle/test/work-item-lifecycle.spec.ts
@@ -4413,6 +4413,49 @@ describe("WorkItemLifecycle", () => {
       )
     })
 
+    it("advances to Commit when Review reports accepted low-severity remediation", () => {
+      const stepsAcceptedReview: LifecycleStepsShape = {
+        ...successfulSteps,
+        review: () =>
+          Effect.succeed({
+            _tag: "accepted" as const,
+            reason: "direct localized rename",
+            deferred: {
+              severity: "low" as const,
+              reason: "style nits remain",
+            },
+          }),
+      }
+
+      return runWithSteps(
+        stepsAcceptedReview,
+        Effect.gen(function* () {
+          const lifecycle = yield* WorkItemLifecycle
+          const { repository, issue } = yield* seedActionableIssue
+          yield* lifecycle.implementNow(repository.id, issue.githubIssueNumber)
+          yield* claimAndRunPending
+          yield* claimAndRunPending
+          yield* claimAndRunPending
+          yield* claimAndRunPending
+          yield* claimAndRunPending
+          const afterReview = yield* claimAndRunPending
+
+          expect(afterReview._tag).toBe("processed")
+          if (afterReview._tag === "processed") {
+            expect(afterReview.workItem.state).toBe("commit")
+            const reviewRun = afterReview.workItem.stepRuns.find(
+              (run) => run.step === "review",
+            )
+            expect(reviewRun?.status).toBe("succeeded")
+            expect(reviewRun?.reasonCode).toBe(STEP_RUN_REASON.reviewAccepted)
+            expect(reviewRun?.reasonMessage).toBe(
+              "direct localized rename (deferred low: style nits remain)",
+            )
+          }
+        }),
+      )
+    })
+
     it("enters Needs Human when Review reports unresolved high and releases the Worker Slot", () => {
       const reason = "auth bypass remains open"
       const steps: LifecycleStepsShape = {


### PR DESCRIPTION
## Summary

- After low-severity FIXED / FIXED_AND_DEFERRED remediation, run nested Pre-Commit then a build-model Review Rerun Assessment.
- Accepted assessments advance to Commit without another reviewing pass; medium/high still always re-review; malformed assessment falls back to full review.
- Project `Review: assessing rerun` and persist Accepted outcomes on the Step Run (`review_accepted`).

Closes #433

## Test plan

- [x] `work-item-lifecycle` lint, typecheck, test
- [x] `graphql-api` lint, typecheck, test
- [x] Pre-commit / affected nx lint+typecheck+test
