### PR TITLE
fix(opencode): send multi-word prompts without OpenCode quotes

### DIFF
--- a/packages/opencode/src/lib/build-args.ts
+++ b/packages/opencode/src/lib/build-args.ts
@@ -7,6 +7,9 @@ const messageTokens = (prompt: string): ReadonlyArray<string> =>
     .split(/\s+/)
     .filter((token) => token.length > 0)
 
+export const shouldUsePromptStdin = (prompt: string): boolean =>
+  /\r|\n/.test(prompt)
+
 export const buildRunArgs = (input: {
   readonly prompt: string
   readonly cwd: string
@@ -41,7 +44,12 @@ export const buildRunArgs = (input: {
     return args
   }
 
-  args.push(input.prompt)
+  if (!shouldUsePromptStdin(input.prompt)) {
+    const tokens = messageTokens(input.prompt)
+    if (tokens.length > 0) {
+      args.push("--", ...tokens)
+    }
+  }
   return args
 }
 

--- a/packages/opencode/src/lib/opencode.ts
+++ b/packages/opencode/src/lib/opencode.ts
@@ -1,7 +1,7 @@
 import { Context, Duration, Effect, Layer, Ref, Stream } from "effect"
 import type { PlatformError } from "effect/PlatformError"
 import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process"
-import { buildRunArgs } from "./build-args.js"
+import { buildRunArgs, shouldUsePromptStdin } from "./build-args.js"
 import { collectChildStdout } from "./collect-child-stdout.js"
 import { makeOpencodeEnvironment } from "./environment.js"
 import {
@@ -133,12 +133,16 @@ export class Opencode extends Context.Service<
                 ? { command: input.command }
                 : {}),
             })
+            const promptOnStdin =
+              input.command === undefined && shouldUsePromptStdin(input.prompt)
 
             const command = ChildProcess.make(binary, args, {
               cwd: input.cwd,
               env: environment,
               extendEnv: false,
-              stdin: "ignore",
+              stdin: promptOnStdin
+                ? Stream.fromIterable([new TextEncoder().encode(input.prompt)])
+                : "ignore",
               stderr: "ignore",
             })
 

--- a/packages/opencode/test/build-args.spec.ts
+++ b/packages/opencode/test/build-args.spec.ts
@@ -1,28 +1,30 @@
-import { buildRunArgs, joinOpenCodeMessageArgs } from "../src/lib/build-args.js"
+import {
+  buildRunArgs,
+  joinOpenCodeMessageArgs,
+  shouldUsePromptStdin,
+} from "../src/lib/build-args.js"
 import { describe, expect, it } from "bun:test"
 
-const messageFromArgs = (args: ReadonlyArray<string>): string => {
+const messageTokensFromArgs = (
+  args: ReadonlyArray<string>,
+): ReadonlyArray<string> => {
   const separatorIndex = args.indexOf("--")
-  if (separatorIndex !== -1) {
-    return joinOpenCodeMessageArgs(args.slice(separatorIndex + 1))
-  }
-  const commandIndex = args.indexOf("--command")
-  if (commandIndex !== -1) {
-    return joinOpenCodeMessageArgs(args.slice(commandIndex + 2))
-  }
-  return joinOpenCodeMessageArgs(args.slice(-1))
+  return separatorIndex === -1 ? [] : args.slice(separatorIndex + 1)
 }
 
+const messageFromArgs = (args: ReadonlyArray<string>): string =>
+  joinOpenCodeMessageArgs(messageTokensFromArgs(args))
+
 describe("buildRunArgs", () => {
-  it("builds start args with auto, json, model, and a single prompt positional", () => {
-    expect(
-      buildRunArgs({
-        prompt: "fix the bug",
-        cwd: "/worktrees/repository",
-        model: "anthropic/claude-sonnet-4-5",
-        variant: "high",
-      }),
-    ).toEqual([
+  it("builds start args with auto, json, model, and tokenized prompt positionals", () => {
+    const args = buildRunArgs({
+      prompt: "fix the bug",
+      cwd: "/worktrees/repository",
+      model: "anthropic/claude-sonnet-4-5",
+      variant: "high",
+    })
+
+    expect(args).toEqual([
       "run",
       "--auto",
       "--format",
@@ -33,11 +35,19 @@ describe("buildRunArgs", () => {
       "anthropic/claude-sonnet-4-5",
       "--variant",
       "high",
-      "fix the bug",
+      "--",
+      "fix",
+      "the",
+      "bug",
     ])
+    expect(messageTokensFromArgs(args)).toEqual(["fix", "the", "bug"])
+    const persisted = messageFromArgs(args)
+    expect(persisted).toBe("fix the bug")
+    expect(persisted.startsWith('"')).toBe(false)
+    expect(persisted.endsWith('"')).toBe(false)
   })
 
-  it("preserves multi-line non-review prompts as one positional", () => {
+  it("uses stdin to preserve multi-line non-command prompts", () => {
     const prompt = [
       "Run git hook run --ignore-missing pre-commit",
       "",
@@ -46,14 +56,14 @@ describe("buildRunArgs", () => {
       "```",
     ].join("\n")
 
-    expect(
-      buildRunArgs({
-        prompt,
-        cwd: "/worktrees/repository",
-        model: "anthropic/claude-sonnet-4-5",
-        variant: "high",
-      }),
-    ).toEqual([
+    const args = buildRunArgs({
+      prompt,
+      cwd: "/worktrees/repository",
+      model: "anthropic/claude-sonnet-4-5",
+      variant: "high",
+    })
+
+    expect(args.slice(0, 10)).toEqual([
       "run",
       "--auto",
       "--format",
@@ -64,14 +74,34 @@ describe("buildRunArgs", () => {
       "anthropic/claude-sonnet-4-5",
       "--variant",
       "high",
-      prompt,
     ])
+    expect(shouldUsePromptStdin(prompt)).toBe(true)
+    expect(messageTokensFromArgs(args)).toEqual([])
+    expect(args).not.toContain(prompt)
   })
 
-  it("includes session for continue", () => {
+  it("uses stdin only for newline-bearing prompts", () => {
+    for (const [prompt, usesStdin, message] of [
+      ["first\nsecond", true, []],
+      ["first\tsecond", false, ["first", "second"]],
+    ] as const) {
+      const args = buildRunArgs({
+        prompt,
+        cwd: "/worktrees/repository",
+        model: "anthropic/claude-sonnet-4-5",
+        variant: "high",
+      })
+
+      expect(shouldUsePromptStdin(prompt)).toBe(usesStdin)
+      expect(messageTokensFromArgs(args)).toEqual(message)
+      expect(args).not.toContain(prompt)
+    }
+  })
+
+  it("includes session for continue and protects the prompt with --", () => {
     expect(
       buildRunArgs({
-        prompt: "continue",
+        prompt: "continue the work",
         cwd: "/worktrees/repository",
         model: "anthropic/claude-sonnet-4-5",
         variant: "max",
@@ -90,7 +120,10 @@ describe("buildRunArgs", () => {
       "max",
       "--session",
       "ses_abc",
+      "--",
       "continue",
+      "the",
+      "work",
     ])
   })
 
@@ -184,5 +217,47 @@ describe("buildRunArgs", () => {
       "--command",
       "review",
     ])
+  })
+
+  it("omits empty non-command prompt positionals", () => {
+    expect(
+      buildRunArgs({
+        prompt: "   \n\t  ",
+        cwd: "/worktrees/repository",
+        model: "anthropic/claude-sonnet-4-5",
+        variant: "high",
+      }),
+    ).toEqual([
+      "run",
+      "--auto",
+      "--format",
+      "json",
+      "--dir",
+      "/worktrees/repository",
+      "-m",
+      "anthropic/claude-sonnet-4-5",
+      "--variant",
+      "high",
+    ])
+  })
+
+  it("keeps implement-style multi-word prompts free of surrounding quotes", () => {
+    const prompt = [
+      "Implement GitHub issue berenddeboer/ready-for-agent#434.",
+      "Inspect the current GitHub Issue and this Repository's agent/project instructions.",
+      "Make the implementation in this worktree and run appropriate verification.",
+      "Do not merely propose a plan; complete the implementation work for that exact issue.",
+    ].join("\n")
+
+    const args = buildRunArgs({
+      prompt,
+      cwd: "/worktrees/issue-434",
+      model: "xai/grok-code-fast-1",
+      variant: "high",
+    })
+
+    const messageTokens = messageTokensFromArgs(args)
+    expect(shouldUsePromptStdin(prompt)).toBe(true)
+    expect(messageTokens).toEqual([])
   })
 })

--- a/packages/opencode/test/opencode.spec.ts
+++ b/packages/opencode/test/opencode.spec.ts
@@ -28,12 +28,17 @@ const withExecutable = async <A>(
   }
 }
 
-const start = (binary: string, timeout: string, onSessionId?: OnSessionId) =>
+const start = (
+  binary: string,
+  timeout: string,
+  onSessionId?: OnSessionId,
+  prompt = "test",
+) =>
   Effect.gen(function* () {
     const opencode = yield* Opencode
     return yield* opencode.start({
       cwd: process.cwd(),
-      prompt: "test",
+      prompt,
       model: "test/model",
       variant: "test",
       timeout,
@@ -62,6 +67,26 @@ describe("Opencode Effect service", () => {
         ).resolves.toEqual({
           sessionId: "ses_test",
           assistantText: "first\nsecond",
+        })
+      },
+    )
+  })
+
+  it("sends multi-line prompts through stdin without changing their structure", async () => {
+    const prompt = "first\nsecond"
+    await withExecutable(
+      [
+        "input=$(cat)",
+        "expected=$(printf 'first\\nsecond')",
+        '[ "$input" = "$expected" ] || exit 9',
+        `printf '%s\n' '{"type":"step_start","sessionID":"ses_stdin"}'`,
+      ].join("\n"),
+      async (binary) => {
+        await expect(
+          Effect.runPromise(start(binary, "2 seconds", undefined, prompt)),
+        ).resolves.toEqual({
+          sessionId: "ses_stdin",
+          assistantText: "",
         })
       },
     )


### PR DESCRIPTION
## Summary
- Stop OpenCode Session user messages from being wrapped in literal surrounding quotes for ordinary multi-word lifecycle prompts.
- Single-line non-command prompts are tokenized after `--`; newline-bearing prompts are sent via stdin so structure is preserved.
- Review’s `--command` path is unchanged; unit and spawn tests lock the argv/stdin policy.

Closes #434.

## Test plan
- [x] `bunx nx run opencode:test`
- [x] `bunx nx run opencode:lint`
- [x] `bunx nx run opencode:typecheck`
- [x] `bunx nx run opencode:build`
- [ ] Confirm Implement Session user text has no leading/trailing `"` in a live run