### PR TITLE
fix(work-item-lifecycle): exclude OpenCode session wait from step max duration

### DIFF
--- a/packages/db-schema/README.md
+++ b/packages/db-schema/README.md
@@ -83,7 +83,8 @@ type work item = repository, github issue number, issue title,
                  check start last observed is draft.
 
 type step run = work item, step, status, queue job id,
-                queued at, started at, finished at, reason code, reason message.
+                queued at, started at, finished at, reason code, reason message,
+                session wait ms, session wait started at.
 
 type pr status check = work item, external id, name, outcome,
                        handled at, observed at.

--- a/packages/db-schema/drizzle/20260724001032_furry_wild_pack/migration.sql
+++ b/packages/db-schema/drizzle/20260724001032_furry_wild_pack/migration.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `step_run` ADD `session_wait_ms` integer DEFAULT 0 NOT NULL;--> statement-breakpoint
+ALTER TABLE `step_run` ADD `session_wait_started_at` integer;

--- a/packages/db-schema/drizzle/20260724001032_furry_wild_pack/snapshot.json
+++ b/packages/db-schema/drizzle/20260724001032_furry_wild_pack/snapshot.json
@@ -1,0 +1,1705 @@
+{
+  "version": "7",
+  "dialect": "sqlite",
+  "id": "a17c2f99-b85b-4ae5-abf5-e9e5b8b6ca6f",
+  "prevIds": [
+    "f7bf790c-5d13-40a6-879c-72bb4ea8c7e1"
+  ],
+  "ddl": [
+    {
+      "name": "automated_review_rerun",
+      "entityType": "tables"
+    },
+    {
+      "name": "completed_job",
+      "entityType": "tables"
+    },
+    {
+      "name": "config",
+      "entityType": "tables"
+    },
+    {
+      "name": "issue",
+      "entityType": "tables"
+    },
+    {
+      "name": "issue_dependency",
+      "entityType": "tables"
+    },
+    {
+      "name": "job_queue",
+      "entityType": "tables"
+    },
+    {
+      "name": "pr_status_check",
+      "entityType": "tables"
+    },
+    {
+      "name": "repository",
+      "entityType": "tables"
+    },
+    {
+      "name": "step_run",
+      "entityType": "tables"
+    },
+    {
+      "name": "work_item",
+      "entityType": "tables"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "automated_review_rerun"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "work_item_id",
+      "entityType": "columns",
+      "table": "automated_review_rerun"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "head_sha",
+      "entityType": "columns",
+      "table": "automated_review_rerun"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "workflow_run_id",
+      "entityType": "columns",
+      "table": "automated_review_rerun"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "workflow_name",
+      "entityType": "columns",
+      "table": "automated_review_rerun"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "status",
+      "entityType": "columns",
+      "table": "automated_review_rerun"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "automated_review_rerun"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "automated_review_rerun"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "completed_job"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "queue",
+      "entityType": "columns",
+      "table": "completed_job"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "job_id",
+      "entityType": "columns",
+      "table": "completed_job"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "completed_job"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "completed_job"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": "'default'",
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "config"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "default_model",
+      "entityType": "columns",
+      "table": "config"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "default_variant",
+      "entityType": "columns",
+      "table": "config"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "review_model",
+      "entityType": "columns",
+      "table": "config"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "review_variant",
+      "entityType": "columns",
+      "table": "config"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "2",
+      "generated": null,
+      "name": "max_concurrent_opencode_sessions",
+      "entityType": "columns",
+      "table": "config"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "5",
+      "generated": null,
+      "name": "max_concurrent_work_items",
+      "entityType": "columns",
+      "table": "config"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "config"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "config"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "issue"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "repository_id",
+      "entityType": "columns",
+      "table": "issue"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "github_issue_number",
+      "entityType": "columns",
+      "table": "issue"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "title",
+      "entityType": "columns",
+      "table": "issue"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "body",
+      "entityType": "columns",
+      "table": "issue"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "url",
+      "entityType": "columns",
+      "table": "issue"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "state",
+      "entityType": "columns",
+      "table": "issue"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "github_created_at",
+      "entityType": "columns",
+      "table": "issue"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "issue_author",
+      "entityType": "columns",
+      "table": "issue"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "parent_github_issue_number",
+      "entityType": "columns",
+      "table": "issue"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "parent_github_issue_url",
+      "entityType": "columns",
+      "table": "issue"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "parent_position",
+      "entityType": "columns",
+      "table": "issue"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "false",
+      "generated": null,
+      "name": "has_children",
+      "entityType": "columns",
+      "table": "issue"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "issue"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "issue"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "issue_dependency"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "issue_id",
+      "entityType": "columns",
+      "table": "issue_dependency"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "blocking_github_issue_number",
+      "entityType": "columns",
+      "table": "issue_dependency"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "blocking_github_issue_url",
+      "entityType": "columns",
+      "table": "issue_dependency"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "issue_dependency"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "job_queue"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "queue",
+      "entityType": "columns",
+      "table": "job_queue"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "key",
+      "entityType": "columns",
+      "table": "job_queue"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "job_payload",
+      "entityType": "columns",
+      "table": "job_queue"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "0",
+      "generated": null,
+      "name": "job_attempts",
+      "entityType": "columns",
+      "table": "job_queue"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "5",
+      "generated": null,
+      "name": "job_retry_limit",
+      "entityType": "columns",
+      "table": "job_queue"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "available_at",
+      "entityType": "columns",
+      "table": "job_queue"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "locked_until",
+      "entityType": "columns",
+      "table": "job_queue"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "job_queue"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "job_queue"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "pr_status_check"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "work_item_id",
+      "entityType": "columns",
+      "table": "pr_status_check"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "external_id",
+      "entityType": "columns",
+      "table": "pr_status_check"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "name",
+      "entityType": "columns",
+      "table": "pr_status_check"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "outcome",
+      "entityType": "columns",
+      "table": "pr_status_check"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "handled_at",
+      "entityType": "columns",
+      "table": "pr_status_check"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "handled_by_step_run_id",
+      "entityType": "columns",
+      "table": "pr_status_check"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "observed_at",
+      "entityType": "columns",
+      "table": "pr_status_check"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "pr_status_check"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "pr_status_check"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "repository"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "github_owner",
+      "entityType": "columns",
+      "table": "repository"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "github_repo",
+      "entityType": "columns",
+      "table": "repository"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "local_path",
+      "entityType": "columns",
+      "table": "repository"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "is_bare",
+      "entityType": "columns",
+      "table": "repository"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "true",
+      "generated": null,
+      "name": "paused",
+      "entityType": "columns",
+      "table": "repository"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "default_model",
+      "entityType": "columns",
+      "table": "repository"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "default_variant",
+      "entityType": "columns",
+      "table": "repository"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "review_model",
+      "entityType": "columns",
+      "table": "repository"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "review_variant",
+      "entityType": "columns",
+      "table": "repository"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "false",
+      "generated": null,
+      "name": "auto_merge",
+      "entityType": "columns",
+      "table": "repository"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "false",
+      "generated": null,
+      "name": "include_all_issue_authors",
+      "entityType": "columns",
+      "table": "repository"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "issues_reconciled_at",
+      "entityType": "columns",
+      "table": "repository"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "repository"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "repository"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "step_run"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "work_item_id",
+      "entityType": "columns",
+      "table": "step_run"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "step",
+      "entityType": "columns",
+      "table": "step_run"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "status",
+      "entityType": "columns",
+      "table": "step_run"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "queue_job_id",
+      "entityType": "columns",
+      "table": "step_run"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "queued_at",
+      "entityType": "columns",
+      "table": "step_run"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "started_at",
+      "entityType": "columns",
+      "table": "step_run"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "finished_at",
+      "entityType": "columns",
+      "table": "step_run"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "reason_code",
+      "entityType": "columns",
+      "table": "step_run"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "reason_message",
+      "entityType": "columns",
+      "table": "step_run"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "0",
+      "generated": null,
+      "name": "session_wait_ms",
+      "entityType": "columns",
+      "table": "step_run"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "session_wait_started_at",
+      "entityType": "columns",
+      "table": "step_run"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "step_run"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "step_run"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "id",
+      "entityType": "columns",
+      "table": "work_item"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "repository_id",
+      "entityType": "columns",
+      "table": "work_item"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "github_issue_number",
+      "entityType": "columns",
+      "table": "work_item"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "issue_title",
+      "entityType": "columns",
+      "table": "work_item"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "github_pull_request_number",
+      "entityType": "columns",
+      "table": "work_item"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "model",
+      "entityType": "columns",
+      "table": "work_item"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "variant",
+      "entityType": "columns",
+      "table": "work_item"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "review_model",
+      "entityType": "columns",
+      "table": "work_item"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "review_variant",
+      "entityType": "columns",
+      "table": "work_item"
+    },
+    {
+      "type": "text",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "state",
+      "entityType": "columns",
+      "table": "work_item"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "state_ready_at",
+      "entityType": "columns",
+      "table": "work_item"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "false",
+      "generated": null,
+      "name": "paused",
+      "entityType": "columns",
+      "table": "work_item"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "waiting_since",
+      "entityType": "columns",
+      "table": "work_item"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": "false",
+      "generated": null,
+      "name": "holds_worker_slot",
+      "entityType": "columns",
+      "table": "work_item"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "pause_before_step",
+      "entityType": "columns",
+      "table": "work_item"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "worktree_path",
+      "entityType": "columns",
+      "table": "work_item"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "starting_commit_oid",
+      "entityType": "columns",
+      "table": "work_item"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "completion_summary",
+      "entityType": "columns",
+      "table": "work_item"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "session_id",
+      "entityType": "columns",
+      "table": "work_item"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "failure_code",
+      "entityType": "columns",
+      "table": "work_item"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "failure_message",
+      "entityType": "columns",
+      "table": "work_item"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "check_start_anchor_at",
+      "entityType": "columns",
+      "table": "work_item"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "check_start_anchor_head_sha",
+      "entityType": "columns",
+      "table": "work_item"
+    },
+    {
+      "type": "text",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "check_start_observed_head_sha",
+      "entityType": "columns",
+      "table": "work_item"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "check_start_observed_head_at",
+      "entityType": "columns",
+      "table": "work_item"
+    },
+    {
+      "type": "integer",
+      "notNull": false,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "check_start_last_observed_is_draft",
+      "entityType": "columns",
+      "table": "work_item"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "created_at",
+      "entityType": "columns",
+      "table": "work_item"
+    },
+    {
+      "type": "integer",
+      "notNull": true,
+      "autoincrement": false,
+      "default": null,
+      "generated": null,
+      "name": "updated_at",
+      "entityType": "columns",
+      "table": "work_item"
+    },
+    {
+      "columns": [
+        "work_item_id"
+      ],
+      "tableTo": "work_item",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_automated_review_rerun_work_item_id_work_item_id_fk",
+      "entityType": "fks",
+      "table": "automated_review_rerun"
+    },
+    {
+      "columns": [
+        "repository_id"
+      ],
+      "tableTo": "repository",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_issue_repository_id_repository_id_fk",
+      "entityType": "fks",
+      "table": "issue"
+    },
+    {
+      "columns": [
+        "issue_id"
+      ],
+      "tableTo": "issue",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_issue_dependency_issue_id_issue_id_fk",
+      "entityType": "fks",
+      "table": "issue_dependency"
+    },
+    {
+      "columns": [
+        "work_item_id"
+      ],
+      "tableTo": "work_item",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_pr_status_check_work_item_id_work_item_id_fk",
+      "entityType": "fks",
+      "table": "pr_status_check"
+    },
+    {
+      "columns": [
+        "handled_by_step_run_id"
+      ],
+      "tableTo": "step_run",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "SET NULL",
+      "nameExplicit": false,
+      "name": "fk_pr_status_check_handled_by_step_run_id_step_run_id_fk",
+      "entityType": "fks",
+      "table": "pr_status_check"
+    },
+    {
+      "columns": [
+        "work_item_id"
+      ],
+      "tableTo": "work_item",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_step_run_work_item_id_work_item_id_fk",
+      "entityType": "fks",
+      "table": "step_run"
+    },
+    {
+      "columns": [
+        "repository_id"
+      ],
+      "tableTo": "repository",
+      "columnsTo": [
+        "id"
+      ],
+      "onUpdate": "NO ACTION",
+      "onDelete": "CASCADE",
+      "nameExplicit": false,
+      "name": "fk_work_item_repository_id_repository_id_fk",
+      "entityType": "fks",
+      "table": "work_item"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "automated_review_rerun_pk",
+      "table": "automated_review_rerun",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "completed_job_pk",
+      "table": "completed_job",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "config_pk",
+      "table": "config",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "issue_pk",
+      "table": "issue",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "issue_dependency_pk",
+      "table": "issue_dependency",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "job_queue_pk",
+      "table": "job_queue",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "pr_status_check_pk",
+      "table": "pr_status_check",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "repository_pk",
+      "table": "repository",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "step_run_pk",
+      "table": "step_run",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        "id"
+      ],
+      "nameExplicit": false,
+      "name": "work_item_pk",
+      "table": "work_item",
+      "entityType": "pks"
+    },
+    {
+      "columns": [
+        {
+          "value": "work_item_id",
+          "isExpression": false
+        },
+        {
+          "value": "head_sha",
+          "isExpression": false
+        },
+        {
+          "value": "workflow_run_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "automated_review_rerun_budget_idx",
+      "entityType": "indexes",
+      "table": "automated_review_rerun"
+    },
+    {
+      "columns": [
+        {
+          "value": "queue",
+          "isExpression": false
+        },
+        {
+          "value": "job_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "origin": "manual",
+      "name": "completed_job_queue_job_id_uidx",
+      "entityType": "indexes",
+      "table": "completed_job"
+    },
+    {
+      "columns": [
+        {
+          "value": "repository_id",
+          "isExpression": false
+        },
+        {
+          "value": "github_issue_number",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "origin": "manual",
+      "name": "issue_repository_id_github_issue_number_uidx",
+      "entityType": "indexes",
+      "table": "issue"
+    },
+    {
+      "columns": [
+        {
+          "value": "issue_id",
+          "isExpression": false
+        },
+        {
+          "value": "blocking_github_issue_url",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "origin": "manual",
+      "name": "issue_dependency_issue_id_blocking_url_uidx",
+      "entityType": "indexes",
+      "table": "issue_dependency"
+    },
+    {
+      "columns": [
+        {
+          "value": "queue",
+          "isExpression": false
+        },
+        {
+          "value": "locked_until",
+          "isExpression": false
+        },
+        {
+          "value": "job_attempts",
+          "isExpression": false
+        },
+        {
+          "value": "available_at",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "job_queue_ready_idx",
+      "entityType": "indexes",
+      "table": "job_queue"
+    },
+    {
+      "columns": [
+        {
+          "value": "queue",
+          "isExpression": false
+        },
+        {
+          "value": "key",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": "\"job_queue\".\"key\" IS NOT NULL",
+      "origin": "manual",
+      "name": "job_queue_queue_key_uidx",
+      "entityType": "indexes",
+      "table": "job_queue"
+    },
+    {
+      "columns": [
+        {
+          "value": "work_item_id",
+          "isExpression": false
+        },
+        {
+          "value": "external_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "origin": "manual",
+      "name": "pr_status_check_work_item_external_uidx",
+      "entityType": "indexes",
+      "table": "pr_status_check"
+    },
+    {
+      "columns": [
+        {
+          "value": "work_item_id",
+          "isExpression": false
+        },
+        {
+          "value": "handled_at",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "pr_status_check_work_item_handled_idx",
+      "entityType": "indexes",
+      "table": "pr_status_check"
+    },
+    {
+      "columns": [
+        {
+          "value": "handled_by_step_run_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "pr_status_check_handled_by_step_run_idx",
+      "entityType": "indexes",
+      "table": "pr_status_check"
+    },
+    {
+      "columns": [
+        {
+          "value": "lower(\"github_owner\")",
+          "isExpression": true
+        },
+        {
+          "value": "lower(\"github_repo\")",
+          "isExpression": true
+        }
+      ],
+      "isUnique": true,
+      "where": null,
+      "origin": "manual",
+      "name": "repository_github_owner_repo_lower_uidx",
+      "entityType": "indexes",
+      "table": "repository"
+    },
+    {
+      "columns": [
+        {
+          "value": "work_item_id",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": "\"step_run\".\"status\" IN ('queued', 'running')",
+      "origin": "manual",
+      "name": "step_run_one_active_uidx",
+      "entityType": "indexes",
+      "table": "step_run"
+    },
+    {
+      "columns": [
+        {
+          "value": "work_item_id",
+          "isExpression": false
+        },
+        {
+          "value": "queued_at",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "step_run_work_item_id_queued_at_idx",
+      "entityType": "indexes",
+      "table": "step_run"
+    },
+    {
+      "columns": [
+        {
+          "value": "repository_id",
+          "isExpression": false
+        },
+        {
+          "value": "github_issue_number",
+          "isExpression": false
+        }
+      ],
+      "isUnique": true,
+      "where": "\"work_item\".\"state\" NOT IN ('complete', 'failed', 'abandoned', 'needs_human')",
+      "origin": "manual",
+      "name": "work_item_one_unfinished_v2_uidx",
+      "entityType": "indexes",
+      "table": "work_item"
+    },
+    {
+      "columns": [
+        {
+          "value": "repository_id",
+          "isExpression": false
+        },
+        {
+          "value": "github_issue_number",
+          "isExpression": false
+        },
+        {
+          "value": "created_at",
+          "isExpression": false
+        }
+      ],
+      "isUnique": false,
+      "where": null,
+      "origin": "manual",
+      "name": "work_item_repository_issue_created_idx",
+      "entityType": "indexes",
+      "table": "work_item"
+    },
+    {
+      "columns": [
+        "local_path"
+      ],
+      "nameExplicit": false,
+      "name": "repository_local_path_unique",
+      "entityType": "uniques",
+      "table": "repository"
+    }
+  ],
+  "renames": []
+}

--- a/packages/db-schema/src/schema.ts
+++ b/packages/db-schema/src/schema.ts
@@ -371,6 +371,13 @@ export const stepRun = snakeCase.table(
     finishedAt: integer({ mode: "number" }),
     reasonCode: text(),
     reasonMessage: text(),
+    /**
+     * Cumulative ms spent blocked on an OpenCode session slot (completed waits).
+     * Excluded from max-duration / visibility-lease productive time.
+     */
+    sessionWaitMs: integer({ mode: "number" }).notNull().default(0),
+    /** Wall-clock start of the current OpenCode session-slot wait, if any. */
+    sessionWaitStartedAt: integer({ mode: "number" }),
     createdAt: integer({ mode: "number" })
       .notNull()
       .$defaultFn(() => Date.now()),

--- a/packages/db/test/run-migrations.spec.ts
+++ b/packages/db/test/run-migrations.spec.ts
@@ -90,6 +90,7 @@ describe("runMigrations", () => {
           { name: "20260722230410_goofy_gertrude_yorkes" },
           { name: "20260723051726_clever_hex" },
           { name: "20260723072032_free_shadow_king" },
+          { name: "20260724001032_furry_wild_pack" },
         ])
       }).pipe(Effect.provide(SqliteTest)),
     )

--- a/packages/work-item-lifecycle/src/lib/opencode-session-limiter.ts
+++ b/packages/work-item-lifecycle/src/lib/opencode-session-limiter.ts
@@ -59,8 +59,10 @@ type SavedStepRunReason = {
  *
  * While waiting for a permit, marks the ambient Step Run with
  * `waiting_for_opencode_session` so GraphQL can show **Queued** instead of
- * **Running**. When the slot is acquired, restores any prior mid-run phase
- * (for example Review: pre-commit) instead of clearing the reason.
+ * **Running**, and records `session_wait_started_at` so max-duration and
+ * visibility-lease clocks freeze for the wait. When the slot is acquired,
+ * accumulates the wait into `session_wait_ms` and restores any prior mid-run
+ * phase (for example Review: pre-commit) instead of clearing the reason.
  */
 export const limitOpencodeSessions = (
   opencode: OpencodeService,
@@ -84,12 +86,14 @@ export const limitOpencodeSessions = (
           return null
         }
         const rows = (yield* sql.unsafe(
-          `SELECT reason_code, reason_message FROM step_run
+          `SELECT reason_code, reason_message, session_wait_started_at
+           FROM step_run
            WHERE id = ? AND status = 'running'`,
           [current.stepRunId],
         )) as readonly {
           readonly reason_code: string | null
           readonly reason_message: string | null
+          readonly session_wait_started_at: number | null
         }[]
         const row = rows[0]
         if (row === undefined) {
@@ -106,16 +110,20 @@ export const limitOpencodeSessions = (
               : row.reason_message,
         }
         const now = Date.now()
+        // Keep the original wait start if already waiting (idempotent re-mark).
+        const waitStartedAt = row.session_wait_started_at ?? now
         yield* sql.unsafe(
           `UPDATE step_run
            SET reason_code = ?,
                reason_message = ?,
+               session_wait_started_at = ?,
                updated_at = ?
            WHERE id = ?
              AND status = 'running'`,
           [
             STEP_RUN_REASON.waitingForOpencodeSession,
             WAITING_FOR_OPENCODE_SESSION_MESSAGE,
+            waitStartedAt,
             now,
             current.stepRunId,
           ],
@@ -140,10 +148,32 @@ export const limitOpencodeSessions = (
           return
         }
         const now = Date.now()
+        const rows = (yield* sql.unsafe(
+          `SELECT session_wait_started_at, session_wait_ms
+           FROM step_run
+           WHERE id = ?
+             AND status = 'running'
+             AND reason_code = ?`,
+          [current.stepRunId, STEP_RUN_REASON.waitingForOpencodeSession],
+        )) as readonly {
+          readonly session_wait_started_at: number | null
+          readonly session_wait_ms: number | null
+        }[]
+        const row = rows[0]
+        if (row === undefined) {
+          return
+        }
+        const openWaitMs =
+          row.session_wait_started_at === null
+            ? 0
+            : Math.max(0, now - row.session_wait_started_at)
+        const sessionWaitMs = Math.max(0, row.session_wait_ms ?? 0) + openWaitMs
         yield* sql.unsafe(
           `UPDATE step_run
            SET reason_code = ?,
                reason_message = ?,
+               session_wait_ms = ?,
+               session_wait_started_at = NULL,
                updated_at = ?
            WHERE id = ?
              AND status = 'running'
@@ -151,6 +181,7 @@ export const limitOpencodeSessions = (
           [
             saved?.reasonCode ?? null,
             saved?.reasonMessage ?? null,
+            sessionWaitMs,
             now,
             current.stepRunId,
             STEP_RUN_REASON.waitingForOpencodeSession,

--- a/packages/work-item-lifecycle/src/lib/step-run-productive-time.ts
+++ b/packages/work-item-lifecycle/src/lib/step-run-productive-time.ts
@@ -1,0 +1,25 @@
+/**
+ * Productive Step Run time excludes OpenCode session-slot waits so max duration
+ * and visibility leases measure work, not queueing for a permit.
+ */
+
+export type StepRunProductiveTimeRow = {
+  readonly started_at: number | null
+  readonly session_wait_ms: number | null
+  readonly session_wait_started_at: number | null
+}
+
+export const computeProductiveElapsedMs = (
+  row: StepRunProductiveTimeRow,
+  nowMs: number,
+): number => {
+  if (row.started_at === null) {
+    return 0
+  }
+  const completedWaitMs = Math.max(0, row.session_wait_ms ?? 0)
+  const openWaitMs =
+    row.session_wait_started_at === null
+      ? 0
+      : Math.max(0, nowMs - row.session_wait_started_at)
+  return Math.max(0, nowMs - row.started_at - completedWaitMs - openWaitMs)
+}

--- a/packages/work-item-lifecycle/src/lib/work-item-lifecycle.ts
+++ b/packages/work-item-lifecycle/src/lib/work-item-lifecycle.ts
@@ -65,6 +65,7 @@ import {
   formatAcceptedReviewSummary,
   formatDeferredReviewSummary,
 } from "./review.js"
+import { computeProductiveElapsedMs } from "./step-run-productive-time.js"
 import {
   DEFAULT_LIFECYCLE_MAX_DURATIONS,
   type LifecycleMaxDurations,
@@ -271,7 +272,13 @@ type StepRunRow = {
   readonly finished_at: number | null
   readonly reason_code: string | null
   readonly reason_message: string | null
+  readonly session_wait_ms: number | null
+  readonly session_wait_started_at: number | null
 }
+
+const STEP_RUN_SELECT_COLUMNS = `id, work_item_id, step, status, queue_job_id, queued_at,
+                        started_at, finished_at, reason_code, reason_message,
+                        session_wait_ms, session_wait_started_at`
 
 const deriveQueueWaitMs = (row: StepRunRow, nowMs: number): number => {
   const endMs = row.started_at ?? row.finished_at ?? nowMs
@@ -725,8 +732,7 @@ export const makeWorkItemLifecycleLive = (
           const placeholders = workItemIds.map(() => "?").join(", ")
           const rows = (yield* sql
             .unsafe(
-              `SELECT id, work_item_id, step, status, queue_job_id, queued_at,
-                    started_at, finished_at, reason_code, reason_message
+              `SELECT ${STEP_RUN_SELECT_COLUMNS}
              FROM step_run
              WHERE work_item_id IN (${placeholders})
              ORDER BY queued_at ASC, rowid ASC`,
@@ -864,11 +870,10 @@ export const makeWorkItemLifecycleLive = (
         Effect.gen(function* () {
           const rows = (yield* sql
             .unsafe(
-              `SELECT id, work_item_id, step, status, queue_job_id, queued_at,
-                    started_at, finished_at, reason_code, reason_message
-             FROM step_run
-             WHERE id = ?
-             LIMIT 1`,
+              `SELECT ${STEP_RUN_SELECT_COLUMNS}
+              FROM step_run
+              WHERE id = ?
+              LIMIT 1`,
               [stepRunId],
             )
             .pipe(Effect.mapError(toDatabaseError))) as readonly StepRunRow[]
@@ -2475,8 +2480,7 @@ export const makeWorkItemLifecycleLive = (
                    AND other.status = 'running'
                    AND other.id != step_run.id
                )
-             RETURNING id, work_item_id, step, status, queue_job_id, queued_at,
-                       started_at, finished_at, reason_code, reason_message`,
+              RETURNING ${STEP_RUN_SELECT_COLUMNS}`,
                   [startedAt, startedAt, stepRunId, stepRun.step],
                 )
                 .pipe(
@@ -2487,15 +2491,41 @@ export const makeWorkItemLifecycleLive = (
               if (!afterStart) {
                 const current = yield* loadStepRunRow(stepRunId)
                 if (current?.status === "running") {
+                  const recovered =
+                    current.session_wait_started_at === null
+                      ? current
+                      : ((
+                          (yield* sql
+                            .unsafe(
+                              `UPDATE step_run
+                             SET session_wait_started_at = NULL,
+                                 reason_code = NULL,
+                                 reason_message = NULL,
+                                 updated_at = ?
+                             WHERE id = ?
+                               AND status = 'running'
+                             RETURNING ${STEP_RUN_SELECT_COLUMNS}`,
+                              [startedAt, current.id],
+                            )
+                            .pipe(
+                              Effect.mapError(toDatabaseError),
+                            )) as readonly StepRunRow[]
+                        )[0] ?? current)
+                  // A duplicate delivery in this process exits before this point
+                  // because activeStepExecutions already contains the Step Run.
+                  // An open wait here therefore belongs to a stopped process.
                   const maxDurationMs = Duration.toMillis(
-                    maxDurations[current.step],
+                    maxDurations[recovered.step],
                   )
-                  const startedMs = current.started_at ?? 0
                   const nowMs = yield* Clock.currentTimeMillis
-                  const leaseExpired = nowMs - startedMs >= maxDurationMs
+                  const productiveElapsedMs = computeProductiveElapsedMs(
+                    recovered,
+                    nowMs,
+                  )
+                  const leaseExpired = productiveElapsedMs >= maxDurationMs
                   if (leaseExpired) {
                     yield* completeInterruptedStep({
-                      stepRun: current,
+                      stepRun: recovered,
                       reasonMessage:
                         "Visibility lease expired while the Step Run was still Running",
                     })
@@ -2532,6 +2562,38 @@ export const makeWorkItemLifecycleLive = (
                 maxDuration,
               }
 
+              const productiveTimeout: Effect.Effect<
+                never,
+                Cause.TimeoutError | WorkItemLifecycleDatabaseError
+              > = Effect.gen(function* () {
+                const maxDurationMs = Duration.toMillis(maxDuration)
+                for (;;) {
+                  const nowMs = yield* Clock.currentTimeMillis
+                  const current = yield* loadStepRunRow(afterStart.id)
+                  if (current === null || current.status !== "running") {
+                    return yield* Effect.never
+                  }
+                  const productiveElapsedMs = computeProductiveElapsedMs(
+                    current,
+                    nowMs,
+                  )
+                  if (productiveElapsedMs >= maxDurationMs) {
+                    return yield* new Cause.TimeoutError()
+                  }
+                  const remainingMs = maxDurationMs - productiveElapsedMs
+                  const waitingForSession =
+                    current.session_wait_started_at !== null ||
+                    current.reason_code ===
+                      STEP_RUN_REASON.waitingForOpencodeSession
+                  // While session-slot wait freezes the clock, poll; otherwise
+                  // sleep up to the remaining productive budget (capped).
+                  const sleepMs = waitingForSession
+                    ? Math.min(500, Math.max(remainingMs, 50))
+                    : Math.min(remainingMs, 50)
+                  yield* Effect.sleep(Duration.millis(Math.max(1, sleepMs)))
+                }
+              })
+
               const result = yield* Effect.uninterruptibleMask((restore) =>
                 Effect.gen(function* () {
                   const handlerExit = yield* Effect.exit(
@@ -2544,7 +2606,7 @@ export const makeWorkItemLifecycleLive = (
                             stepRunId: afterStart.id,
                             repositoryId: workItem.repository_id,
                           }),
-                          Effect.timeout(maxDuration),
+                          Effect.raceFirst(productiveTimeout),
                         ),
                         Deferred.await(cancel).pipe(
                           Effect.andThen(Effect.interrupt),
@@ -3528,8 +3590,7 @@ export const makeWorkItemLifecycleLive = (
 
         const latestRows = (yield* sql
           .unsafe(
-            `SELECT id, work_item_id, step, status, queue_job_id, queued_at,
-                    started_at, finished_at, reason_code, reason_message
+            `SELECT ${STEP_RUN_SELECT_COLUMNS}
              FROM step_run
              WHERE work_item_id = ?
              ORDER BY queued_at DESC, rowid DESC
@@ -3578,8 +3639,7 @@ export const makeWorkItemLifecycleLive = (
 
         const activeRows = (yield* sql
           .unsafe(
-            `SELECT id, work_item_id, step, status, queue_job_id, queued_at,
-                  started_at, finished_at, reason_code, reason_message
+            `SELECT ${STEP_RUN_SELECT_COLUMNS}
            FROM step_run
            WHERE work_item_id = ?
              AND status IN ('queued', 'running')
@@ -3601,8 +3661,7 @@ export const makeWorkItemLifecycleLive = (
         if (!recoverableStatusCheckFailure && !retryableNeedsHumanHandoff) {
           const latestPendingRows = (yield* sql
             .unsafe(
-              `SELECT id, work_item_id, step, status, queue_job_id, queued_at,
-                    started_at, finished_at, reason_code, reason_message
+              `SELECT ${STEP_RUN_SELECT_COLUMNS}
              FROM step_run
              WHERE work_item_id = ?
                AND step = ?

--- a/packages/work-item-lifecycle/test/opencode-session-limiter.spec.ts
+++ b/packages/work-item-lifecycle/test/opencode-session-limiter.spec.ts
@@ -305,18 +305,24 @@ describe("limitOpencodeSessions", () => {
         expect(starts).toBe(1)
 
         const waitingRows = (yield* sql.unsafe(
-          `SELECT status, reason_code, reason_message FROM step_run WHERE id = ?`,
+          `SELECT status, reason_code, reason_message, session_wait_started_at,
+                  session_wait_ms
+           FROM step_run WHERE id = ?`,
           [stepRunId],
         )) as readonly {
           readonly status: string
           readonly reason_code: string | null
           readonly reason_message: string | null
+          readonly session_wait_started_at: number | null
+          readonly session_wait_ms: number | null
         }[]
-        expect(waitingRows[0]).toEqual({
+        expect(waitingRows[0]).toMatchObject({
           status: "running",
           reason_code: STEP_RUN_REASON.waitingForOpencodeSession,
           reason_message: WAITING_FOR_OPENCODE_SESSION_MESSAGE,
+          session_wait_ms: 0,
         })
+        expect(waitingRows[0]!.session_wait_started_at).toBeTypeOf("number")
 
         yield* Deferred.succeed(releaseFirst, undefined)
         yield* Deferred.await(secondStarted)
@@ -324,18 +330,24 @@ describe("limitOpencodeSessions", () => {
         yield* Fiber.join(second)
 
         const afterRows = (yield* sql.unsafe(
-          `SELECT status, reason_code, reason_message FROM step_run WHERE id = ?`,
+          `SELECT status, reason_code, reason_message, session_wait_started_at,
+                  session_wait_ms
+           FROM step_run WHERE id = ?`,
           [stepRunId],
         )) as readonly {
           readonly status: string
           readonly reason_code: string | null
           readonly reason_message: string | null
+          readonly session_wait_started_at: number | null
+          readonly session_wait_ms: number | null
         }[]
-        expect(afterRows[0]).toEqual({
+        expect(afterRows[0]).toMatchObject({
           status: "running",
           reason_code: null,
           reason_message: null,
+          session_wait_started_at: null,
         })
+        expect(afterRows[0]!.session_wait_ms ?? 0).toBeGreaterThanOrEqual(40)
         expect(starts).toBe(2)
       }),
     ))

--- a/packages/work-item-lifecycle/test/step-run-productive-time.spec.ts
+++ b/packages/work-item-lifecycle/test/step-run-productive-time.spec.ts
@@ -1,0 +1,56 @@
+import { computeProductiveElapsedMs } from "../src/lib/step-run-productive-time.js"
+import { describe, expect, it } from "bun:test"
+
+describe("computeProductiveElapsedMs", () => {
+  it("returns wall time when there is no session wait", () => {
+    expect(
+      computeProductiveElapsedMs(
+        {
+          started_at: 1_000,
+          session_wait_ms: 0,
+          session_wait_started_at: null,
+        },
+        1_500,
+      ),
+    ).toBe(500)
+  })
+
+  it("excludes completed session waits", () => {
+    expect(
+      computeProductiveElapsedMs(
+        {
+          started_at: 1_000,
+          session_wait_ms: 400,
+          session_wait_started_at: null,
+        },
+        1_800,
+      ),
+    ).toBe(400)
+  })
+
+  it("freezes during an open session wait", () => {
+    expect(
+      computeProductiveElapsedMs(
+        {
+          started_at: 1_000,
+          session_wait_ms: 100,
+          session_wait_started_at: 1_400,
+        },
+        2_000,
+      ),
+    ).toBe(300)
+  })
+
+  it("returns 0 before started_at", () => {
+    expect(
+      computeProductiveElapsedMs(
+        {
+          started_at: null,
+          session_wait_ms: 0,
+          session_wait_started_at: null,
+        },
+        1_000,
+      ),
+    ).toBe(0)
+  })
+})

--- a/packages/work-item-lifecycle/test/work-item-lifecycle.spec.ts
+++ b/packages/work-item-lifecycle/test/work-item-lifecycle.spec.ts
@@ -6080,6 +6080,278 @@ describe("WorkItemLifecycle", () => {
       )
     })
 
+    it("interrupts a stale OpenCode session-slot wait on lease redelivery", () => {
+      let createCalls = 0
+      const steps: LifecycleStepsShape = {
+        ...successfulSteps,
+        createWorktree: () => {
+          createCalls += 1
+          return Effect.succeed({
+            worktreePath: "/tmp/worktrees/should-not-rerun-wait",
+            startingCommitOid: "abc123",
+          })
+        },
+      }
+
+      return runWithSteps(
+        steps,
+        Effect.gen(function* () {
+          const lifecycle = yield* WorkItemLifecycle
+          const queue = yield* QueueService
+          const sql = yield* SqlClient.SqlClient
+          const { repository, issue } = yield* seedActionableIssue
+
+          const created = yield* lifecycle.implementNow(
+            repository.id,
+            issue.githubIssueNumber,
+          )
+          const stepRunId = created.stepRuns[0]!.id
+          const jobId = created.stepRuns[0]!.queueJobId!
+          const now = Date.now()
+          const maxMs = Duration.toMillis(
+            lifecycle.maxDurations.create_worktree,
+          )
+          const startedAt = now - maxMs - 5_000
+
+          yield* sql.unsafe(
+            `UPDATE step_run
+             SET status = 'running',
+                 started_at = ?,
+                 session_wait_started_at = ?,
+                 session_wait_ms = 0,
+                 reason_code = ?,
+                 reason_message = ?,
+                 updated_at = ?
+             WHERE id = ?`,
+            [
+              startedAt,
+              startedAt + 100,
+              STEP_RUN_REASON.waitingForOpencodeSession,
+              "Waiting for an OpenCode session slot",
+              now,
+              stepRunId,
+            ],
+          )
+          yield* sql.unsafe(
+            `UPDATE job_queue
+             SET locked_until = ?, updated_at = ?
+             WHERE id = ?`,
+            [now - 1, now, jobId],
+          )
+
+          const claimed = yield* queue.rawClaim(WORK_ITEM_LIFECYCLE_QUEUE)
+          expect(Option.isSome(claimed)).toBe(true)
+
+          const result = yield* lifecycle.runStep(stepRunId)
+          expect(result._tag).toBe("noop")
+          expect(createCalls).toBe(0)
+
+          const final = yield* lifecycle.getWorkItem(created.id)
+          expect(final.stepRuns[0]!.status).toBe("interrupted")
+          expect(final.stepRuns[0]!.reasonCode).toBe(
+            STEP_RUN_REASON.interrupted,
+          )
+        }),
+      )
+    })
+
+    it("does not timeout solely for OpenCode session-slot wait longer than maxDuration", () => {
+      const steps: LifecycleStepsShape = {
+        ...successfulSteps,
+        createWorktree: () =>
+          Effect.gen(function* () {
+            const sql = yield* SqlClient.SqlClient
+            const rows = (yield* sql.unsafe(
+              `SELECT id FROM step_run WHERE status = 'running' LIMIT 1`,
+            )) as readonly { readonly id: string }[]
+            const stepRunId = rows[0]!.id
+            const waitStart = Date.now()
+            yield* sql.unsafe(
+              `UPDATE step_run
+               SET session_wait_started_at = ?,
+                   reason_code = ?,
+                   reason_message = ?,
+                   updated_at = ?
+               WHERE id = ?`,
+              [
+                waitStart,
+                STEP_RUN_REASON.waitingForOpencodeSession,
+                "Waiting for an OpenCode session slot",
+                waitStart,
+                stepRunId,
+              ],
+            )
+            // Wall time well past maxDuration (20ms) while wait freezes the clock.
+            yield* Effect.sleep("80 millis")
+            const waitEnd = Date.now()
+            yield* sql.unsafe(
+              `UPDATE step_run
+               SET session_wait_ms = session_wait_ms + ?,
+                   session_wait_started_at = NULL,
+                   reason_code = NULL,
+                   reason_message = NULL,
+                   updated_at = ?
+               WHERE id = ?`,
+              [waitEnd - waitStart, waitEnd, stepRunId],
+            )
+            return {
+              worktreePath: "/tmp/worktrees/after-session-wait",
+              startingCommitOid: "abc123",
+            }
+          }),
+      }
+
+      const layer = makeWorkItemLifecycleLive({
+        maxDurations: {
+          create_worktree: Duration.millis(20),
+          install_dependencies: Duration.minutes(15),
+          implement: Duration.hours(2),
+          assess_changes: Duration.minutes(5),
+          pre_commit: Duration.hours(2),
+          review: Duration.hours(1),
+          commit: Duration.minutes(5),
+          create_pr: Duration.minutes(10),
+          watch_pr_status_checks: Duration.minutes(5),
+          resolve_pr_merge_conflict: Duration.hours(2),
+          investigate_pr_status_checks: Duration.hours(2),
+          mark_pr_ready_for_review: Duration.minutes(5),
+          decide_pr_merge: Duration.minutes(15),
+          merge_pr: Duration.minutes(5),
+          close_issue: Duration.minutes(5),
+          local_cleanup: Duration.minutes(5),
+        },
+      }).pipe(
+        Layer.provideMerge(
+          Layer.succeed(LifecycleSteps, LifecycleSteps.of(steps)),
+        ),
+        Layer.provideMerge(DbServiceLive),
+        Layer.provideMerge(SqliteQueueServiceLive),
+        Layer.provideMerge(DatabaseTest),
+      )
+
+      return Effect.runPromise(
+        Effect.gen(function* () {
+          const lifecycle = yield* WorkItemLifecycle
+          const queue = yield* QueueService
+          const { repository, issue } = yield* seedActionableIssue
+
+          yield* lifecycle.implementNow(repository.id, issue.githubIssueNumber)
+          const claimed = yield* queue.rawClaim(WORK_ITEM_LIFECYCLE_QUEUE)
+          expect(Option.isSome(claimed)).toBe(true)
+          if (Option.isNone(claimed)) {
+            return yield* Effect.die("expected lifecycle job")
+          }
+
+          const result = yield* lifecycle.runStep(
+            (claimed.value.payload as { stepRunId: string }).stepRunId,
+          )
+          expect(result._tag).toBe("processed")
+          if (result._tag === "processed") {
+            expect(result.workItem.state).toBe("install_dependencies")
+            expect(result.workItem.stepRuns[0]!.status).toBe("succeeded")
+          }
+        }).pipe(Effect.provide(layer)),
+      )
+    })
+
+    it("still times out when productive work exceeds maxDuration after a session wait", () => {
+      const steps: LifecycleStepsShape = {
+        ...successfulSteps,
+        createWorktree: () =>
+          Effect.gen(function* () {
+            const sql = yield* SqlClient.SqlClient
+            const rows = (yield* sql.unsafe(
+              `SELECT id FROM step_run WHERE status = 'running' LIMIT 1`,
+            )) as readonly { readonly id: string }[]
+            const stepRunId = rows[0]!.id
+            const waitStart = Date.now()
+            yield* sql.unsafe(
+              `UPDATE step_run
+               SET session_wait_started_at = ?,
+                   reason_code = ?,
+                   updated_at = ?
+               WHERE id = ?`,
+              [
+                waitStart,
+                STEP_RUN_REASON.waitingForOpencodeSession,
+                waitStart,
+                stepRunId,
+              ],
+            )
+            yield* Effect.sleep("40 millis")
+            const waitEnd = Date.now()
+            yield* sql.unsafe(
+              `UPDATE step_run
+               SET session_wait_ms = session_wait_ms + ?,
+                   session_wait_started_at = NULL,
+                   reason_code = NULL,
+                   updated_at = ?
+               WHERE id = ?`,
+              [waitEnd - waitStart, waitEnd, stepRunId],
+            )
+            // Productive overrun after the wait.
+            yield* Effect.sleep("80 millis")
+            return {
+              worktreePath: "/tmp/worktrees/productive-overrun",
+              startingCommitOid: "abc123",
+            }
+          }),
+      }
+
+      const layer = makeWorkItemLifecycleLive({
+        maxDurations: {
+          create_worktree: Duration.millis(30),
+          install_dependencies: Duration.minutes(15),
+          implement: Duration.hours(2),
+          assess_changes: Duration.minutes(5),
+          pre_commit: Duration.hours(2),
+          review: Duration.hours(1),
+          commit: Duration.minutes(5),
+          create_pr: Duration.minutes(10),
+          watch_pr_status_checks: Duration.minutes(5),
+          resolve_pr_merge_conflict: Duration.hours(2),
+          investigate_pr_status_checks: Duration.hours(2),
+          mark_pr_ready_for_review: Duration.minutes(5),
+          decide_pr_merge: Duration.minutes(15),
+          merge_pr: Duration.minutes(5),
+          close_issue: Duration.minutes(5),
+          local_cleanup: Duration.minutes(5),
+        },
+      }).pipe(
+        Layer.provideMerge(
+          Layer.succeed(LifecycleSteps, LifecycleSteps.of(steps)),
+        ),
+        Layer.provideMerge(DbServiceLive),
+        Layer.provideMerge(SqliteQueueServiceLive),
+        Layer.provideMerge(DatabaseTest),
+      )
+
+      return Effect.runPromise(
+        Effect.gen(function* () {
+          const lifecycle = yield* WorkItemLifecycle
+          const queue = yield* QueueService
+          const { repository, issue } = yield* seedActionableIssue
+
+          yield* lifecycle.implementNow(repository.id, issue.githubIssueNumber)
+          const claimed = yield* queue.rawClaim(WORK_ITEM_LIFECYCLE_QUEUE)
+          expect(Option.isSome(claimed)).toBe(true)
+          if (Option.isNone(claimed)) {
+            return yield* Effect.die("expected lifecycle job")
+          }
+
+          const result = yield* lifecycle.runStep(
+            (claimed.value.payload as { stepRunId: string }).stepRunId,
+          )
+          expect(result._tag).toBe("processed")
+          if (result._tag === "processed") {
+            const run = result.workItem.stepRuns[0]!
+            expect(run.status).toBe("failed")
+            expect(run.reasonCode).toBe(STEP_RUN_REASON.timeout)
+          }
+        }).pipe(Effect.provide(layer)),
+      )
+    })
+
     it("records Interrupted when the handler is fiber-interrupted before an outcome is established", () => {
       const hangForever: LifecycleStepsShape = {
         ...successfulSteps,


### PR DESCRIPTION
## Why

Waiting for an OpenCode session slot (`waiting_for_opencode_session` / UI **Queued**) counted against a Lifecycle Step's max duration and visibility lease. Short post-Implement steps such as Create PR could fail with **timeout** or lease **Interrupted** while never holding a session, because wall clocks started when the Step Run became `running`.

## What Changed

- Persist OpenCode session-slot wait accounting on `step_run` (`session_wait_ms`, `session_wait_started_at`).
- Freeze productive max-duration and visibility-lease clocks while blocked on `maxConcurrentOpencodeSessions`; resume after a permit is held.
- On lease redelivery with no local runner, clear stale open waits left by a stopped process so dead runs can still expire.
- Cover wait exclusion, productive overrun timeout, and stale-wait recovery with tests.

Closes #420.