### PR TITLE
feat(agent-backend): add Grok Build backend

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,9 +8,12 @@ covers monorepo development of Ready for Agent.
 ## Prerequisites
 
 1. [Bun](https://bun.sh/) (workspace package manager and runtime)
-2. Host tools from the product README: `git`, `gh`, OpenCode on PATH
+2. Host tools from the product README: `git`, `gh`, and the selected Agent
+   Backend on PATH (`opencode` by default; `grok` when developing against Grok
+   Build). Authenticate Grok with `grok login` or `XAI_API_KEY` for live runs.
 3. Optional: `keymaxxer` on PATH, or `KEYMAXXER_ENTRYPOINT` pointing at an
-  existing entrypoint (no hardcoded machine path)
+  existing entrypoint (no hardcoded machine path). Not used by Grok Build
+  Agent Turns.
 
 ## Install
 

--- a/README.md
+++ b/README.md
@@ -7,8 +7,9 @@ UI to start working on it.
 <img src="ready-for-agent.png" alt="Ready for Agent" width="90%" />
 
 It does this by creating a new worktree, installing packages, and
-asking [OpenCode](https://opencode.ai/) to implement the issue, review
-the issue, create a PR, and merge if allowed.
+asking a selectable headless Agent Backend
+([OpenCode](https://opencode.ai/) or [Grok Build](https://docs.x.ai/))
+to implement the issue, review the issue, create a PR, and merge if allowed.
 
 The goal of this clanker harness is to get you to that 50+ PRs merged
 a day nirvana. You focus on design, creating specifications, and
@@ -104,19 +105,35 @@ worktree, but withoutr creating a PR yet. This allows you to test and verify.
 
 # Requirements
 
-**Required on PATH** (start fails fast if missing):
+**Always required on PATH** (start fails fast if missing):
 
 1. [git](https://git-scm.com/)
-2. [GitHub CLI (`gh`)](https://cli.github.com/)
-3. [OpenCode](https://opencode.ai)
+2. [GitHub CLI (`gh`)](https://cli.github.com/) — used by the Harness and, for
+   Grok Build Agent Turns, as authenticated ambient `gh` (no raw token is
+   copied into the agent environment)
+
+**Agent Backend executable** (only the backend selected in Settings is
+required; default is OpenCode):
+
+3. [OpenCode](https://opencode.ai) when OpenCode is the selected Agent Backend
+4. [Grok Build](https://docs.x.ai/) (`grok` on PATH) when Grok Build is selected
+
+Authenticate Grok Build with `grok login` or `XAI_API_KEY` before Recheck /
+Agent Turns. Harness-launched Grok processes disable auto-update for that
+session (`--no-auto-update` / `GROK_DISABLE_AUTOUPDATER`). Initial Grok Build
+support does not integrate Keymaxxer for Agent Turns and does not expose
+Session Telemetry (shown as unsupported). Opt-in live adapter tests use
+`GROK_INTEGRATION=1` / `OPENCODE_INTEGRATION=1`; normal CI does not need paid
+model credentials.
 
 **Optional:**
 
-4. [keymaxxer](https://github.com/glommer/keymaxxer) — vault-backed secrets.
+5. [keymaxxer](https://github.com/glommer/keymaxxer) — vault-backed secrets for
+   Harness-owned GitHub operations and OpenCode Agent Turns.
    Resolved as `KEYMAXXER_ENTRYPOINT` when set to an existing path, otherwise
    the `keymaxxer` command on PATH. When neither is available, the harness uses
    ambient GitHub authentication. Set `KEYMAXXER_ENABLED=false` to force that
-   mode.
+   mode. Grok Build Agent Turns always use ambient `gh` in this release.
 
 # KeyMaxxer
 
@@ -135,9 +152,9 @@ KEYMAXXER_ENABLED=false npx ready-for-agent@latest
 
 1. Is there support for agents other than OpenCode?
 
-Not yet, but open for properly structured PRs. Currently everything is
-hard-coded for opencode, so the first step would be to make this more
-generalisable.
+Yes. Settings can select **OpenCode** or **Grok Build** as the instance-wide
+Agent Backend. The change activates after restart (and is rejected while any
+Work Item is unfinished). Model catalogs and Thinking Levels are backend-local.
 
 2. Does the harness support any other backend than GitHub?
 

--- a/apps/harness/package.json
+++ b/apps/harness/package.json
@@ -20,6 +20,7 @@
     "@ready-for-agent/graphql-client": "workspace:*",
     "@ready-for-agent/issue-reconciler": "workspace:*",
     "@ready-for-agent/keymaxxer-service": "workspace:*",
+    "@ready-for-agent/grok": "workspace:*",
     "@ready-for-agent/opencode": "workspace:*",
     "@ready-for-agent/queue-service": "workspace:*",
     "@ready-for-agent/sqlite-queue-service": "workspace:*",

--- a/apps/harness/src/server/application.server.ts
+++ b/apps/harness/src/server/application.server.ts
@@ -8,11 +8,15 @@ import {
   ActiveAgentBackend,
   ActiveAgentBackendLive,
   type AgentBackendId,
+  type AgentBackendRegistration,
+  SessionTelemetryProvider,
   resolveActiveRegistration,
+  unsupportedSessionTelemetry,
 } from "@ready-for-agent/agent-backend"
 import { DatabaseLive } from "@ready-for-agent/db"
 import { DbService, DbServiceLive } from "@ready-for-agent/db-service"
 import { createGraphqlApi } from "@ready-for-agent/graphql-api"
+import { Grok } from "@ready-for-agent/grok"
 import { IssueReconcilerLive } from "@ready-for-agent/issue-reconciler"
 import {
   KeymaxxerService,
@@ -44,6 +48,38 @@ export interface Application {
 
 export interface CreateApplicationOptions {
   readonly startWorker?: boolean
+}
+
+const unsupportedSessionTelemetryLive = (
+  registration: AgentBackendRegistration,
+) =>
+  Layer.succeed(SessionTelemetryProvider, {
+    getSession: (sessionId) =>
+      Effect.succeed(
+        unsupportedSessionTelemetry(sessionId, registration.descriptor),
+      ),
+  })
+
+const agentBackendLayers = <R>(input: {
+  readonly activeRegistration: AgentBackendRegistration
+  readonly platformLayer: Layer.Layer<R>
+  readonly sidecarUrl: string | undefined
+}) => {
+  if (input.activeRegistration.descriptor.id === AGENT_BACKEND_IDS.grok) {
+    return {
+      adapterLayer: Grok.layer().pipe(Layer.provide(input.platformLayer)),
+      telemetryLayer: unsupportedSessionTelemetryLive(input.activeRegistration),
+    }
+  }
+
+  return {
+    adapterLayer: Opencode.layer({
+      ...(input.sidecarUrl === undefined
+        ? {}
+        : { keymaxxerMcpUrl: input.sidecarUrl }),
+    }).pipe(Layer.provide(input.platformLayer)),
+    telemetryLayer: OpencodeSessionTelemetryLive(),
+  }
 }
 
 export const createApplication = async (
@@ -88,12 +124,12 @@ export const createApplication = async (
     .then((id) => id as AgentBackendId)
     .catch(() => AGENT_BACKEND_IDS.opencode)
 
-  // OpenCode is the only registered production backend in this PR.
   const activeRegistration = resolveActiveRegistration(selectedBackendId)
-  const adapterLayer = Opencode.layer({
-    ...(sidecarUrl === undefined ? {} : { keymaxxerMcpUrl: sidecarUrl }),
-  }).pipe(Layer.provide(platformLayer))
-  const telemetryLayer = OpencodeSessionTelemetryLive()
+  const { adapterLayer, telemetryLayer } = agentBackendLayers({
+    activeRegistration,
+    platformLayer,
+    sidecarUrl,
+  })
   const activeLayer = ActiveAgentBackendLive({
     selectedBackendId:
       activeRegistration.descriptor.id === selectedBackendId

--- a/apps/harness/tsconfig.app.json
+++ b/apps/harness/tsconfig.app.json
@@ -32,6 +32,9 @@
       "path": "../../packages/opencode/tsconfig.lib.json"
     },
     {
+      "path": "../../packages/grok/tsconfig.lib.json"
+    },
+    {
       "path": "../../packages/issue-reconciler/tsconfig.lib.json"
     },
     {

--- a/apps/ready-for-agent/README.md
+++ b/apps/ready-for-agent/README.md
@@ -58,9 +58,11 @@ This boots the full Harness (UI + backend) on the existing monorepo dev path
 (`harness:dev`), including the Keymaxxer sidecar when available.
 
 Before start, the binary checks that required host tools are on `PATH`: `git`,
-`gh`, and OpenCode. Missing tools fail immediately with install hints. Keymaxxer
-is optional (`KEYMAXXER_ENTRYPOINT` or `keymaxxer` on PATH); ambient GitHub auth
-still works without it.
+`gh`, and the selected Agent Backend executable (`opencode` by default, or
+`grok` when Grok Build is selected). Missing tools fail immediately with install
+hints. Keymaxxer is optional (`KEYMAXXER_ENTRYPOINT` or `keymaxxer` on PATH);
+ambient GitHub auth still works without it. Grok Build Agent Turns always use
+ambient `gh` and do not configure Keymaxxer MCP.
 
 On successful start the default browser opens to the local UI
 (`http://127.0.0.1:6056/` by default). Disable with:

--- a/apps/ready-for-agent/package.json
+++ b/apps/ready-for-agent/package.json
@@ -30,6 +30,7 @@
   },
   "dependencies": {
     "@effect/platform-bun": "^4.0.0-beta.97",
+    "@ready-for-agent/agent-backend": "workspace:*",
     "@ready-for-agent/github-service": "workspace:*",
     "@ready-for-agent/graphql-client": "workspace:*",
     "@ready-for-agent/keymaxxer-service": "workspace:*",

--- a/apps/ready-for-agent/src/host-tools-preflight.test.ts
+++ b/apps/ready-for-agent/src/host-tools-preflight.test.ts
@@ -2,11 +2,29 @@ import { checkHostTools } from "./host-tools-preflight.ts"
 import { describe, expect, test } from "bun:test"
 
 describe("host tools preflight", () => {
-  test("passes when git, gh, and opencode are present", () => {
+  test("passes when git, gh, and opencode are present for default backend", () => {
     const result = checkHostTools((command) =>
       ["git", "gh", "opencode"].includes(command),
     )
     expect(result.ok).toBe(true)
+  })
+
+  test("requires grok instead of opencode when Grok Build is selected", () => {
+    const withGrok = checkHostTools(
+      (command) => ["git", "gh", "grok"].includes(command),
+      { selectedAgentBackendId: "grok" },
+    )
+    expect(withGrok.ok).toBe(true)
+
+    const missingGrok = checkHostTools(
+      (command) => ["git", "gh", "opencode"].includes(command),
+      { selectedAgentBackendId: "grok" },
+    )
+    expect(missingGrok.ok).toBe(false)
+    if (missingGrok.ok) return
+    expect(missingGrok.missing.map((tool) => tool.name)).toEqual(["grok"])
+    expect(missingGrok.message).toContain("grok")
+    expect(missingGrok.message).not.toContain("opencode")
   })
 
   test("passes without keymaxxer", () => {

--- a/apps/ready-for-agent/src/host-tools-preflight.ts
+++ b/apps/ready-for-agent/src/host-tools-preflight.ts
@@ -1,10 +1,33 @@
+import {
+  AGENT_BACKEND_IDS,
+  type AgentBackendId,
+  defaultAgentBackendId,
+  getBuiltInAgentBackend,
+  isSelectableAgentBackendId,
+} from "@ready-for-agent/agent-backend"
+
 type HostTool = {
   readonly name: string
   readonly installHint: string
   readonly required: boolean
 }
 
-const HOST_TOOLS: ReadonlyArray<HostTool> = [
+const BACKEND_HOST_TOOLS: Record<
+  AgentBackendId,
+  { readonly name: string; readonly installHint: string }
+> = {
+  [AGENT_BACKEND_IDS.opencode]: {
+    name: "opencode",
+    installHint: "Install OpenCode: https://opencode.ai",
+  },
+  [AGENT_BACKEND_IDS.grok]: {
+    name: "grok",
+    installHint:
+      "Install Grok Build CLI: https://docs.x.ai/docs/grok-build (binary name: grok)",
+  },
+}
+
+const alwaysRequiredTools: ReadonlyArray<HostTool> = [
   {
     name: "git",
     installHint: "Install Git: https://git-scm.com/downloads",
@@ -15,11 +38,9 @@ const HOST_TOOLS: ReadonlyArray<HostTool> = [
     installHint: "Install GitHub CLI (gh): https://cli.github.com/",
     required: true,
   },
-  {
-    name: "opencode",
-    installHint: "Install OpenCode: https://opencode.ai",
-    required: true,
-  },
+]
+
+const optionalTools: ReadonlyArray<HostTool> = [
   {
     name: "keymaxxer",
     installHint:
@@ -27,6 +48,11 @@ const HOST_TOOLS: ReadonlyArray<HostTool> = [
     required: false,
   },
 ]
+
+export type HostToolsPreflightOptions = {
+  /** Active/selected Agent Backend id; defaults to OpenCode. */
+  readonly selectedAgentBackendId?: string
+}
 
 export type HostToolsPreflightResult =
   | { readonly ok: true }
@@ -36,10 +62,31 @@ export type HostToolsPreflightResult =
       readonly message: string
     }
 
+export const resolveRequiredAgentBackendBinary = (
+  selectedAgentBackendId?: string,
+): { readonly name: string; readonly installHint: string } => {
+  const id =
+    selectedAgentBackendId !== undefined &&
+    isSelectableAgentBackendId(selectedAgentBackendId)
+      ? selectedAgentBackendId
+      : defaultAgentBackendId
+  return BACKEND_HOST_TOOLS[id]
+}
+
 export const checkHostTools = (
   commandExists: (command: string) => boolean,
+  options: HostToolsPreflightOptions = {},
 ): HostToolsPreflightResult => {
-  const missingRequired = HOST_TOOLS.filter(
+  const backendTool = resolveRequiredAgentBackendBinary(
+    options.selectedAgentBackendId,
+  )
+  const hostTools: ReadonlyArray<HostTool> = [
+    ...alwaysRequiredTools,
+    { ...backendTool, required: true },
+    ...optionalTools,
+  ]
+
+  const missingRequired = hostTools.filter(
     (tool) => tool.required && !commandExists(tool.name),
   )
 
@@ -47,10 +94,19 @@ export const checkHostTools = (
     return { ok: true }
   }
 
+  const backendLabel =
+    getBuiltInAgentBackend(
+      options.selectedAgentBackendId !== undefined &&
+        isSelectableAgentBackendId(options.selectedAgentBackendId)
+        ? options.selectedAgentBackendId
+        : defaultAgentBackendId,
+    )?.descriptor.label ?? "the selected Agent Backend"
+
   const lines = [
     "Required host tools are missing from PATH:",
     ...missingRequired.map((tool) => `  - ${tool.name}: ${tool.installHint}`),
     "",
+    `Only the selected Agent Backend executable (${backendLabel}) is required alongside git and gh.`,
     "Install the tools above, then run ready-for-agent again.",
     "Keymaxxer is optional and does not block start.",
   ]

--- a/apps/ready-for-agent/src/host-tools-preflight.ts
+++ b/apps/ready-for-agent/src/host-tools-preflight.ts
@@ -62,7 +62,7 @@ export type HostToolsPreflightResult =
       readonly message: string
     }
 
-export const resolveRequiredAgentBackendBinary = (
+const resolveRequiredAgentBackendBinary = (
   selectedAgentBackendId?: string,
 ): { readonly name: string; readonly installHint: string } => {
   const id =

--- a/apps/ready-for-agent/src/peek-selected-agent-backend.ts
+++ b/apps/ready-for-agent/src/peek-selected-agent-backend.ts
@@ -1,0 +1,44 @@
+import { defaultAgentBackendId } from "@ready-for-agent/agent-backend"
+import { Database } from "bun:sqlite"
+
+/**
+ * Read Harness Config's selected Agent Backend without starting the full app.
+ * Missing DB or row defaults to OpenCode so first-run preflight stays correct.
+ */
+export const peekSelectedAgentBackendId = (databasePath: string): string => {
+  if (
+    databasePath === ":memory:" ||
+    databasePath.startsWith("libsql:") ||
+    databasePath.trim() === ""
+  ) {
+    return defaultAgentBackendId
+  }
+
+  const filePath = databasePath.startsWith("file://")
+    ? databasePath.slice("file://".length)
+    : databasePath.startsWith("file:")
+      ? databasePath.slice("file:".length)
+      : databasePath
+
+  try {
+    const db = new Database(filePath, { readonly: true, create: false })
+    try {
+      const row = db
+        .query(
+          `SELECT selected_agent_backend AS selectedAgentBackend
+           FROM config
+           WHERE id = 'default'
+           LIMIT 1`,
+        )
+        .get() as { selectedAgentBackend?: string } | null
+      const value = row?.selectedAgentBackend?.trim()
+      return value !== undefined && value.length > 0
+        ? value
+        : defaultAgentBackendId
+    } finally {
+      db.close()
+    }
+  } catch {
+    return defaultAgentBackendId
+  }
+}

--- a/apps/ready-for-agent/src/services/start-harness.ts
+++ b/apps/ready-for-agent/src/services/start-harness.ts
@@ -7,6 +7,7 @@ import {
   shouldOpenBrowser,
 } from "../browser-open.ts"
 import { checkHostTools } from "../host-tools-preflight.ts"
+import { peekSelectedAgentBackendId } from "../peek-selected-agent-backend.ts"
 import { bootStandaloneProduction } from "../standalone-boot.ts"
 import { ApplicationConfig } from "./application-config.ts"
 
@@ -78,7 +79,13 @@ export class StartHarness extends Context.Service<
       )
 
       const runPreflight = Effect.fn("StartHarness.runPreflight")(function* () {
-        const result = checkHostTools((command) => Bun.which(command) !== null)
+        const selectedAgentBackendId = peekSelectedAgentBackendId(
+          config.databasePath,
+        )
+        const result = checkHostTools(
+          (command) => Bun.which(command) !== null,
+          { selectedAgentBackendId },
+        )
         if (!result.ok) {
           return yield* new StartHarnessFailed({ detail: result.message })
         }

--- a/apps/ready-for-agent/tsconfig.app.json
+++ b/apps/ready-for-agent/tsconfig.app.json
@@ -17,6 +17,9 @@
   "exclude": ["src/**/*.test.ts"],
   "references": [
     {
+      "path": "../../packages/agent-backend/tsconfig.lib.json"
+    },
+    {
       "path": "../../packages/keymaxxer-service/tsconfig.lib.json"
     },
     {

--- a/bun.lock
+++ b/bun.lock
@@ -36,6 +36,7 @@
         "@ready-for-agent/github-service": "workspace:*",
         "@ready-for-agent/graphql-api": "workspace:*",
         "@ready-for-agent/graphql-client": "workspace:*",
+        "@ready-for-agent/grok": "workspace:*",
         "@ready-for-agent/issue-reconciler": "workspace:*",
         "@ready-for-agent/keymaxxer-service": "workspace:*",
         "@ready-for-agent/opencode": "workspace:*",
@@ -82,6 +83,7 @@
       },
       "dependencies": {
         "@effect/platform-bun": "^4.0.0-beta.97",
+        "@ready-for-agent/agent-backend": "workspace:*",
         "@ready-for-agent/github-service": "workspace:*",
         "@ready-for-agent/graphql-client": "workspace:*",
         "@ready-for-agent/keymaxxer-service": "workspace:*",
@@ -139,6 +141,7 @@
       "name": "@ready-for-agent/db-service",
       "version": "0.0.1",
       "dependencies": {
+        "@ready-for-agent/agent-backend": "workspace:*",
         "effect": "^4.0.0-beta.97",
         "tslib": "^2.3.0",
         "ulidx": "^2.4.1",
@@ -189,6 +192,19 @@
     "packages/graphql-schema": {
       "name": "@ready-for-agent/graphql-schema",
       "version": "0.0.1",
+    },
+    "packages/grok": {
+      "name": "@ready-for-agent/grok",
+      "version": "0.0.1",
+      "dependencies": {
+        "@ready-for-agent/agent-backend": "workspace:*",
+        "effect": "^4.0.0-beta.97",
+        "tslib": "^2.3.0",
+      },
+      "devDependencies": {
+        "@effect/platform-bun": "^4.0.0-beta.97",
+        "@types/bun": "^1.3.0",
+      },
     },
     "packages/issue-reconciler": {
       "name": "@ready-for-agent/issue-reconciler",
@@ -893,6 +909,8 @@
     "@ready-for-agent/graphql-client": ["@ready-for-agent/graphql-client@workspace:packages/graphql-client"],
 
     "@ready-for-agent/graphql-schema": ["@ready-for-agent/graphql-schema@workspace:packages/graphql-schema"],
+
+    "@ready-for-agent/grok": ["@ready-for-agent/grok@workspace:packages/grok"],
 
     "@ready-for-agent/harness": ["@ready-for-agent/harness@workspace:apps/harness"],
 

--- a/packages/agent-backend/src/lib/registry.ts
+++ b/packages/agent-backend/src/lib/registry.ts
@@ -22,9 +22,21 @@ const OPENCODE_REGISTRATION: AgentBackendRegistration = {
   ],
 }
 
-/** Production selectable backends. OpenCode is the only entry in this PR. */
+const GROK_REGISTRATION: AgentBackendRegistration = {
+  descriptor: {
+    id: AGENT_BACKEND_IDS.grok,
+    label: "Grok Build",
+  },
+  capabilities: [
+    { _tag: "SessionTelemetry", supported: false },
+    { _tag: "KeymaxxerMcp", supported: false },
+  ],
+}
+
+/** Production selectable backends registered at build time. */
 const BUILT_IN_REGISTRY: ReadonlyArray<AgentBackendRegistration> = [
   OPENCODE_REGISTRATION,
+  GROK_REGISTRATION,
 ]
 
 export const listBuiltInAgentBackends =

--- a/packages/agent-backend/test/registry.spec.ts
+++ b/packages/agent-backend/test/registry.spec.ts
@@ -10,20 +10,29 @@ import {
 import { describe, expect, it } from "bun:test"
 
 describe("Agent Backend registry", () => {
-  it("exposes only OpenCode as a selectable production backend", () => {
+  it("exposes OpenCode and Grok Build as selectable production backends", () => {
     const backends = listBuiltInAgentBackends()
     expect(backends.map((entry) => entry.descriptor.id)).toEqual([
       AGENT_BACKEND_IDS.opencode,
+      AGENT_BACKEND_IDS.grok,
     ])
     expect(defaultAgentBackendId).toBe(AGENT_BACKEND_IDS.opencode)
     expect(getBuiltInAgentBackend("missing")).toBeUndefined()
+    expect(
+      getBuiltInAgentBackend(AGENT_BACKEND_IDS.grok)?.descriptor.label,
+    ).toBe("Grok Build")
   })
 
-  it("declares typed capabilities for OpenCode", () => {
+  it("declares typed capabilities for OpenCode and Grok Build", () => {
     const opencode = getBuiltInAgentBackend(AGENT_BACKEND_IDS.opencode)
     expect(opencode).toBeDefined()
     expect(capabilitySupported(opencode!, "SessionTelemetry")).toBe(true)
     expect(capabilitySupported(opencode!, "KeymaxxerMcp")).toBe(true)
+
+    const grok = getBuiltInAgentBackend(AGENT_BACKEND_IDS.grok)
+    expect(grok).toBeDefined()
+    expect(capabilitySupported(grok!, "SessionTelemetry")).toBe(false)
+    expect(capabilitySupported(grok!, "KeymaxxerMcp")).toBe(false)
   })
 })
 

--- a/packages/db-service/src/lib/db-service.ts
+++ b/packages/db-service/src/lib/db-service.ts
@@ -2,6 +2,7 @@ import { Clock, Context, Effect, Layer, PubSub, Schema, Stream } from "effect"
 import { SqlClient } from "effect/unstable/sql"
 import type { SqlError } from "effect/unstable/sql/SqlError"
 import { ulid } from "ulidx"
+import { isSelectableAgentBackendId } from "@ready-for-agent/agent-backend"
 import {
   AgentBackendChangeBlockedError,
   DatabaseError,
@@ -421,8 +422,7 @@ export const DbServiceLive = Layer.effect(
           message: "selectedAgentBackend cannot be empty",
         })
       }
-      // Only built-in registry IDs are accepted (OpenCode in this PR).
-      if (selectedAgentBackend !== "opencode") {
+      if (!isSelectableAgentBackendId(selectedAgentBackend)) {
         return yield* new InvalidConfigInputError({
           field: "selectedAgentBackend",
           message: `Unknown Agent Backend: ${selectedAgentBackend}`,

--- a/packages/db-service/test/db-service.spec.ts
+++ b/packages/db-service/test/db-service.spec.ts
@@ -88,6 +88,44 @@ describe("DbService", () => {
         }),
       ))
 
+    it("accepts Grok Build as a selectable Agent Backend", () =>
+      runTest(
+        Effect.gen(function* () {
+          const db = yield* DbService
+          expect(
+            yield* db.updateConfig({
+              selectedAgentBackend: "grok",
+              defaultModel: null,
+              defaultThinkingLevel: null,
+              reviewModel: null,
+              reviewThinkingLevel: null,
+              maxConcurrentAgentTurns: 2,
+              maxConcurrentWorkItems: 5,
+            }),
+          ).toMatchObject({ selectedAgentBackend: "grok" })
+        }),
+      ))
+
+    it("rejects unknown Agent Backend ids", () =>
+      runTest(
+        Effect.gen(function* () {
+          const db = yield* DbService
+          const error = yield* Effect.flip(
+            db.updateConfig({
+              selectedAgentBackend: "not-a-backend",
+              defaultModel: null,
+              defaultThinkingLevel: null,
+              reviewModel: null,
+              reviewThinkingLevel: null,
+              maxConcurrentAgentTurns: 2,
+              maxConcurrentWorkItems: 5,
+            }),
+          )
+          expect(error).toBeInstanceOf(InvalidConfigInputError)
+          expect(error).toMatchObject({ field: "selectedAgentBackend" })
+        }),
+      ))
+
     it("rejects empty values", () =>
       runTest(
         Effect.gen(function* () {

--- a/packages/grok/package.json
+++ b/packages/grok/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@ready-for-agent/db-service",
+  "name": "@ready-for-agent/grok",
   "version": "0.0.1",
   "private": true,
   "type": "module",
@@ -13,22 +13,15 @@
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
       "default": "./dist/index.js"
-    },
-    "./test": {
-      "@ready-for-agent/source": "./src/lib/test-fixtures.ts",
-      "types": "./dist/lib/test-fixtures.d.ts",
-      "import": "./dist/lib/test-fixtures.js",
-      "default": "./dist/lib/test-fixtures.js"
     }
   },
   "dependencies": {
     "@ready-for-agent/agent-backend": "workspace:*",
     "effect": "^4.0.0-beta.97",
-    "tslib": "^2.3.0",
-    "ulidx": "^2.4.1"
+    "tslib": "^2.3.0"
   },
   "devDependencies": {
-    "@ready-for-agent/db": "workspace:*",
+    "@effect/platform-bun": "^4.0.0-beta.97",
     "@types/bun": "^1.3.0"
   }
 }

--- a/packages/grok/project.json
+++ b/packages/grok/project.json
@@ -1,0 +1,19 @@
+{
+  "name": "grok",
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "packages/grok/src",
+  "projectType": "library",
+  "tags": [],
+  "targets": {
+    "test": {
+      "executor": "nx:run-commands",
+      "options": {
+        "cwd": "{projectRoot}",
+        "command": "bun test"
+      },
+      "inputs": ["default", "^production"],
+      "cache": true,
+      "dependsOn": ["^build"]
+    }
+  }
+}

--- a/packages/grok/src/index.ts
+++ b/packages/grok/src/index.ts
@@ -1,0 +1,6 @@
+export * from "./lib/build-args.js"
+export * from "./lib/environment.js"
+export * from "./lib/grok.js"
+export * from "./lib/parse-models.js"
+export * from "./lib/parse-stream.js"
+export * from "./lib/types.js"

--- a/packages/grok/src/lib/build-args.ts
+++ b/packages/grok/src/lib/build-args.ts
@@ -1,0 +1,49 @@
+const commandPrefix = (command: string): string =>
+  command.startsWith("/") ? command : `/${command}`
+
+/**
+ * Build headless Grok argv. Every harness launch disables auto-update and runs
+ * fully unattended with structured streaming JSON.
+ */
+export const buildRunArgs = (input: {
+  readonly prompt: string
+  readonly cwd: string
+  readonly model: string
+  /** Null omits `--reasoning-effort` so Grok uses the model default. */
+  readonly thinkingLevel: string | null
+  /** Fresh caller-supplied UUID for a new Session. */
+  readonly sessionId?: string
+  /** Opaque Session ID to resume exactly (not "most recent"). */
+  readonly resumeSessionId?: string
+  readonly command?: string
+}): ReadonlyArray<string> => {
+  const prompt =
+    input.command === undefined
+      ? input.prompt
+      : `${commandPrefix(input.command)}\n${input.prompt}`.trimEnd()
+
+  const args = [
+    "--no-auto-update",
+    "--output-format",
+    "streaming-json",
+    "--yolo",
+    "--cwd",
+    input.cwd,
+    "-m",
+    input.model,
+    "-p",
+    prompt,
+  ]
+
+  if (input.thinkingLevel !== null) {
+    args.push("--reasoning-effort", input.thinkingLevel)
+  }
+
+  if (input.resumeSessionId !== undefined) {
+    args.push("--resume", input.resumeSessionId)
+  } else if (input.sessionId !== undefined) {
+    args.push("--session-id", input.sessionId)
+  }
+
+  return args
+}

--- a/packages/grok/src/lib/environment.ts
+++ b/packages/grok/src/lib/environment.ts
@@ -1,0 +1,20 @@
+import { sanitizeInheritedEnvironment } from "@ready-for-agent/agent-backend"
+
+export type MakeGrokEnvironmentOptions = {
+  readonly environment?: Readonly<Record<string, string | undefined>>
+}
+
+/**
+ * Grok Build Agent Turns use ambient `gh` only: sanitize inherited env, strip
+ * raw GitHub tokens, and force auto-update off for the process lifetime.
+ */
+export const makeGrokEnvironment = (
+  options: MakeGrokEnvironmentOptions = {},
+): Record<string, string> => {
+  const environment =
+    options.environment ?? (process.env as Record<string, string | undefined>)
+  return {
+    ...sanitizeInheritedEnvironment(environment),
+    GROK_DISABLE_AUTOUPDATER: "1",
+  }
+}

--- a/packages/grok/src/lib/grok.ts
+++ b/packages/grok/src/lib/grok.ts
@@ -1,0 +1,216 @@
+import { randomUUID } from "node:crypto"
+import { Duration, Effect, Layer } from "effect"
+import { ChildProcessSpawner } from "effect/unstable/process"
+import {
+  AGENT_BACKEND_IDS,
+  AgentBackend,
+  AgentBackendConfigError,
+  type AgentBackendError,
+  AgentBackendExitError,
+  type ContinueTurnInput,
+  type InspectInput,
+  type StartTurnInput,
+  malformedOutput,
+  runCliCapture,
+  runCliTurn,
+} from "@ready-for-agent/agent-backend"
+import { buildRunArgs } from "./build-args.js"
+import { makeGrokEnvironment } from "./environment.js"
+import { parseGrokModelsOutput } from "./parse-models.js"
+import {
+  createGrokStreamParseState,
+  foldGrokStreamLine,
+  grokAssistantText,
+  isSuccessfulGrokEnd,
+} from "./parse-stream.js"
+import type { GrokLayerOptions } from "./types.js"
+
+const DEFAULT_TIMEOUT = Duration.minutes(30)
+const DEFAULT_BINARY = "grok"
+
+const GROK_BACKEND = {
+  id: AGENT_BACKEND_IDS.grok,
+  label: "Grok Build",
+} as const
+
+/**
+ * Grok Build adapter implementing the backend-neutral AgentBackend contract.
+ */
+export class Grok {
+  static layer = (options: GrokLayerOptions = {}) =>
+    Layer.effect(
+      AgentBackend,
+      Effect.gen(function* () {
+        const spawner = yield* ChildProcessSpawner.ChildProcessSpawner
+        const binary = options.binary ?? DEFAULT_BINARY
+        const defaultTimeout = options.defaultTimeout ?? DEFAULT_TIMEOUT
+        const environment = makeGrokEnvironment()
+
+        const inspect = Effect.fn("Grok.inspect")(function* (
+          input: InspectInput,
+        ) {
+          const result = yield* runCliCapture({
+            spawner,
+            binary,
+            args: ["--no-auto-update", "models"],
+            cwd: input.cwd,
+            env: environment,
+            timeout: input.timeout ?? defaultTimeout,
+          })
+
+          const parsed = parseGrokModelsOutput(result.stdout)
+          if (!parsed.authenticated) {
+            return yield* new AgentBackendConfigError({
+              message:
+                "Grok Build is not authenticated. Run `grok login` (or set XAI_API_KEY), then Recheck Agent Backend.",
+            })
+          }
+          if (!parsed.complete) {
+            return yield* malformedOutput(input.cwd, result.stdout)
+          }
+
+          return {
+            backend: GROK_BACKEND,
+            models: parsed.models.map((model) => ({
+              id: model.id,
+              thinkingLevels: [...model.thinkingLevels],
+            })),
+          }
+        })
+
+        const runTurn = (input: {
+          readonly prompt: string
+          readonly cwd: string
+          readonly model: string
+          readonly thinkingLevel: string | null
+          readonly sessionId: string
+          readonly resume: boolean
+          readonly command?: string
+          readonly timeout?: Duration.Input
+          readonly onSessionId?: StartTurnInput["onSessionId"]
+        }): Effect.Effect<
+          { readonly sessionId: string; readonly assistantText: string },
+          AgentBackendError
+        > =>
+          Effect.gen(function* () {
+            if (!input.resume && input.onSessionId !== undefined) {
+              yield* input.onSessionId(input.sessionId).pipe(
+                Effect.catch((error) =>
+                  Effect.logWarning("Grok onSessionId observer failed", {
+                    sessionId: input.sessionId,
+                    error,
+                  }),
+                ),
+              )
+            }
+
+            const args = buildRunArgs({
+              prompt: input.prompt,
+              cwd: input.cwd,
+              model: input.model,
+              thinkingLevel: input.thinkingLevel,
+              ...(input.resume
+                ? { resumeSessionId: input.sessionId }
+                : { sessionId: input.sessionId }),
+              ...(input.command !== undefined
+                ? { command: input.command }
+                : {}),
+            })
+
+            let stream = createGrokStreamParseState()
+
+            const turn = yield* runCliTurn({
+              spawner,
+              binary,
+              args,
+              cwd: input.cwd,
+              env: environment,
+              timeout: input.timeout ?? defaultTimeout,
+              knownSessionId: input.sessionId,
+              observerLabel: "Grok Build",
+              parseLine: (line) => {
+                stream = foldGrokStreamLine(stream, line)
+
+                if (stream.errorMessage !== undefined) {
+                  return {}
+                }
+                if (stream.maxTurnsReached) {
+                  return {}
+                }
+                if (stream.endSeen && isSuccessfulGrokEnd(stream)) {
+                  const endSessionId = stream.endSessionId ?? input.sessionId
+                  return {
+                    sessionId: endSessionId,
+                    finalizeText: grokAssistantText(stream),
+                  }
+                }
+                return {}
+              },
+              stdin: "ignore",
+            })
+
+            if (stream.malformedLine) {
+              return yield* malformedOutput(
+                input.cwd,
+                "(malformed stream line)",
+              )
+            }
+            if (stream.errorMessage !== undefined) {
+              return yield* new AgentBackendExitError({
+                exitCode: 1,
+                cwd: input.cwd,
+                sessionId: input.sessionId,
+              })
+            }
+            if (stream.maxTurnsReached) {
+              return yield* new AgentBackendExitError({
+                exitCode: 1,
+                cwd: input.cwd,
+                sessionId: input.sessionId,
+              })
+            }
+            if (!stream.endSeen || !isSuccessfulGrokEnd(stream)) {
+              return yield* malformedOutput(
+                input.cwd,
+                "(missing or unsuccessful terminal end event)",
+              )
+            }
+            if (
+              stream.endSessionId !== undefined &&
+              stream.endSessionId !== input.sessionId
+            ) {
+              return yield* malformedOutput(
+                input.cwd,
+                `(session id mismatch: expected ${input.sessionId}, got ${stream.endSessionId})`,
+              )
+            }
+
+            return {
+              sessionId: input.sessionId,
+              assistantText: turn.assistantText,
+            }
+          })
+
+        return AgentBackend.of({
+          inspect,
+          startTurn: Effect.fn("Grok.startTurn")((input: StartTurnInput) =>
+            runTurn({
+              ...input,
+              sessionId: randomUUID(),
+              resume: false,
+            }),
+          ),
+          continueTurn: Effect.fn("Grok.continueTurn")(
+            (input: ContinueTurnInput) =>
+              runTurn({
+                ...input,
+                sessionId: input.sessionId,
+                resume: true,
+              }),
+          ),
+        })
+      }),
+    )
+
+  static layerForTests = () => Grok.layer({})
+}

--- a/packages/grok/src/lib/parse-models.ts
+++ b/packages/grok/src/lib/parse-models.ts
@@ -1,0 +1,55 @@
+import { GROK_DEFAULT_THINKING_LEVELS } from "./types.js"
+
+export type ParsedGrokModels = {
+  readonly models: ReadonlyArray<{
+    readonly id: string
+    readonly thinkingLevels: ReadonlyArray<string>
+  }>
+  readonly authenticated: boolean
+  readonly complete: boolean
+}
+
+const MODEL_LINE =
+  /^\s*\*\s+([A-Za-z0-9][A-Za-z0-9._-]*)(?:\s+\((?:default|.*?)\))?\s*$/
+
+const UNAUTHENTICATED_MARKERS = [
+  /you are not authenticated/i,
+  /not logged in/i,
+  /please (?:log|sign) in/i,
+  /authentication required/i,
+  /run\s+`?grok login/i,
+]
+
+/**
+ * Parse `grok models` plain-text catalog. Unauthenticated banners are treated
+ * as inspection failure even when the CLI exits successfully.
+ */
+export const parseGrokModelsOutput = (stdout: string): ParsedGrokModels => {
+  const authenticated = !UNAUTHENTICATED_MARKERS.some((marker) =>
+    marker.test(stdout),
+  )
+  const models: Array<{ id: string; thinkingLevels: string[] }> = []
+  const seen = new Set<string>()
+
+  for (const line of stdout.split(/\r?\n/)) {
+    const match = MODEL_LINE.exec(line)
+    if (match === null) {
+      continue
+    }
+    const id = match[1] ?? ""
+    if (id.length === 0 || seen.has(id)) {
+      continue
+    }
+    seen.add(id)
+    models.push({
+      id,
+      thinkingLevels: [...GROK_DEFAULT_THINKING_LEVELS],
+    })
+  }
+
+  return {
+    models,
+    authenticated,
+    complete: models.length > 0,
+  }
+}

--- a/packages/grok/src/lib/parse-stream.ts
+++ b/packages/grok/src/lib/parse-stream.ts
@@ -1,0 +1,108 @@
+export type GrokStreamParseState = {
+  textChunks: string[]
+  endSessionId: string | undefined
+  endStopReason: string | undefined
+  endSeen: boolean
+  errorMessage: string | undefined
+  maxTurnsReached: boolean
+  malformedLine: boolean
+}
+
+export const createGrokStreamParseState = (): GrokStreamParseState => ({
+  textChunks: [],
+  endSessionId: undefined,
+  endStopReason: undefined,
+  endSeen: false,
+  errorMessage: undefined,
+  maxTurnsReached: false,
+  malformedLine: false,
+})
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value)
+
+/** Successful terminal stop reasons for a completed Agent Turn. */
+const SUCCESS_STOP_REASONS = new Set([
+  "endturn",
+  "end_turn",
+  "stop",
+  "completed",
+  "complete",
+])
+
+/**
+ * Fold one streaming-json line. Text chunks are concatenated in arrival order;
+ * thought/reasoning chunks are ignored. Exactly one terminal `end` is required.
+ */
+export const foldGrokStreamLine = (
+  state: GrokStreamParseState,
+  line: string,
+): GrokStreamParseState => {
+  const trimmed = line.trim()
+  if (trimmed.length === 0) {
+    return state
+  }
+
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(trimmed)
+  } catch {
+    return { ...state, malformedLine: true }
+  }
+
+  if (!isRecord(parsed) || typeof parsed.type !== "string") {
+    return { ...state, malformedLine: true }
+  }
+
+  switch (parsed.type) {
+    case "text": {
+      if (typeof parsed.data === "string") {
+        return {
+          ...state,
+          textChunks: [...state.textChunks, parsed.data],
+        }
+      }
+      return state
+    }
+    case "thought":
+      return state
+    case "error": {
+      const message =
+        typeof parsed.message === "string" ? parsed.message : "Grok error event"
+      return { ...state, errorMessage: message }
+    }
+    case "max_turns_reached":
+      return { ...state, maxTurnsReached: true }
+    case "end": {
+      const sessionId =
+        typeof parsed.sessionId === "string" ? parsed.sessionId : undefined
+      const stopReason =
+        typeof parsed.stopReason === "string" ? parsed.stopReason : undefined
+      return {
+        ...state,
+        endSeen: true,
+        endSessionId: sessionId,
+        endStopReason: stopReason,
+      }
+    }
+    default:
+      // Non-exhaustive event set (auto_compact_*, tool presentation, …).
+      return state
+  }
+}
+
+export const grokAssistantText = (state: GrokStreamParseState): string =>
+  state.textChunks.join("")
+
+export const isSuccessfulGrokEnd = (state: GrokStreamParseState): boolean => {
+  if (!state.endSeen || state.errorMessage !== undefined) {
+    return false
+  }
+  if (state.maxTurnsReached) {
+    return false
+  }
+  if (state.endStopReason === undefined) {
+    return true
+  }
+  return SUCCESS_STOP_REASONS.has(state.endStopReason.toLowerCase())
+}

--- a/packages/grok/src/lib/types.ts
+++ b/packages/grok/src/lib/types.ts
@@ -1,0 +1,9 @@
+import type { Duration } from "effect"
+
+export interface GrokLayerOptions {
+  readonly binary?: string
+  readonly defaultTimeout?: Duration.Input
+}
+
+/** Installed CLI effort values advertised on every catalog model when global. */
+export const GROK_DEFAULT_THINKING_LEVELS = ["high", "medium", "low"] as const

--- a/packages/grok/test/build-args.spec.ts
+++ b/packages/grok/test/build-args.spec.ts
@@ -1,0 +1,71 @@
+import { buildRunArgs } from "../src/index.js"
+import { describe, expect, it } from "bun:test"
+
+describe("buildRunArgs", () => {
+  it("builds unattended headless args with auto-update disabled", () => {
+    expect(
+      buildRunArgs({
+        prompt: "implement the issue",
+        cwd: "/work",
+        model: "grok-4.5",
+        thinkingLevel: "medium",
+        sessionId: "11111111-1111-4111-8111-111111111111",
+      }),
+    ).toEqual([
+      "--no-auto-update",
+      "--output-format",
+      "streaming-json",
+      "--yolo",
+      "--cwd",
+      "/work",
+      "-m",
+      "grok-4.5",
+      "-p",
+      "implement the issue",
+      "--reasoning-effort",
+      "medium",
+      "--session-id",
+      "11111111-1111-4111-8111-111111111111",
+    ])
+  })
+
+  it("omits reasoning effort when thinkingLevel is null", () => {
+    const args = buildRunArgs({
+      prompt: "hi",
+      cwd: "/work",
+      model: "grok-4.5",
+      thinkingLevel: null,
+      sessionId: "11111111-1111-4111-8111-111111111111",
+    })
+    expect(args).not.toContain("--reasoning-effort")
+  })
+
+  it("resumes an exact session id rather than most-recent continue", () => {
+    const args = buildRunArgs({
+      prompt: "continue",
+      cwd: "/work",
+      model: "grok-4.5",
+      thinkingLevel: "low",
+      resumeSessionId: "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee",
+    })
+    expect(args).toContain("--resume")
+    expect(args).toContain("aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee")
+    expect(args).not.toContain("--continue")
+    expect(args).not.toContain("--session-id")
+  })
+
+  it("prefixes /review command into the single-prompt body", () => {
+    const args = buildRunArgs({
+      prompt: "Review uncommitted worktree changes.",
+      cwd: "/work",
+      model: "grok-4.5",
+      thinkingLevel: null,
+      resumeSessionId: "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee",
+      command: "/review",
+    })
+    const promptIndex = args.indexOf("-p")
+    expect(args[promptIndex + 1]).toBe(
+      "/review\nReview uncommitted worktree changes.",
+    )
+  })
+})

--- a/packages/grok/test/environment.spec.ts
+++ b/packages/grok/test/environment.spec.ts
@@ -1,0 +1,24 @@
+import { makeGrokEnvironment } from "../src/index.js"
+import { describe, expect, it } from "bun:test"
+
+describe("makeGrokEnvironment", () => {
+  it("strips GitHub token variables and disables auto-update", () => {
+    const env = makeGrokEnvironment({
+      environment: {
+        PATH: "/usr/bin",
+        HOME: "/home/op",
+        GH_TOKEN: "secret",
+        GITHUB_TOKEN: "secret2",
+        GITHUB_TOKEN_repo: "secret3",
+        KEEP: "yes",
+      },
+    })
+    expect(env.PATH).toBe("/usr/bin")
+    expect(env.KEEP).toBe("yes")
+    expect(env.GROK_DISABLE_AUTOUPDATER).toBe("1")
+    expect(env.GH_TOKEN).toBeUndefined()
+    expect(env.GITHUB_TOKEN).toBeUndefined()
+    expect(env.GITHUB_TOKEN_repo).toBeUndefined()
+    expect(env.OPENCODE_CONFIG_CONTENT).toBeUndefined()
+  })
+})

--- a/packages/grok/test/grok.integration.spec.ts
+++ b/packages/grok/test/grok.integration.spec.ts
@@ -1,0 +1,93 @@
+import { mkdtemp, rm } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { BunServices } from "@effect/platform-bun"
+import { Effect, Layer } from "effect"
+import { AgentBackend } from "@ready-for-agent/agent-backend"
+import { Grok } from "../src/index.js"
+import { describe, expect, it } from "bun:test"
+
+const TestLayer = Grok.layerForTests().pipe(Layer.provide(BunServices.layer))
+
+const runIntegration = process.env.GROK_INTEGRATION === "1"
+
+describe.skipIf(!runIntegration)("Grok AgentBackend integration", () => {
+  it("inspects models through the generic Agent Backend contract", async () => {
+    const result = await Effect.runPromise(
+      Effect.gen(function* () {
+        const backend = yield* AgentBackend
+        return yield* backend.inspect({
+          cwd: process.cwd(),
+          timeout: "30 seconds",
+        })
+      }).pipe(Effect.provide(TestLayer)),
+    )
+
+    expect(result.backend.id).toBe("grok")
+    expect(result.backend.label).toBe("Grok Build")
+    expect(result.models.length).toBeGreaterThan(0)
+    expect(
+      result.models.every((model) => Array.isArray(model.thinkingLevels)),
+    ).toBe(true)
+  }, 35_000)
+
+  it("starts and resumes a Session, switches model/effort, and invokes /review", async () => {
+    const cwd = await mkdtemp(join(tmpdir(), "ready-for-agent-grok-"))
+    try {
+      const result = await Effect.runPromise(
+        Effect.gen(function* () {
+          const backend = yield* AgentBackend
+          const models = yield* backend.inspect({
+            cwd,
+            timeout: "30 seconds",
+          })
+          const model = models.models[0]
+          if (model === undefined) {
+            return yield* Effect.die("no grok models")
+          }
+          const effort = model.thinkingLevels[0] ?? null
+          const altEffort =
+            model.thinkingLevels.find((level) => level !== effort) ?? effort
+
+          const started = yield* backend.startTurn({
+            cwd,
+            prompt: "Reply exactly START_OK. Do not use tools.",
+            model: model.id,
+            thinkingLevel: effort,
+            timeout: "3 minutes",
+          })
+          const continued = yield* backend.continueTurn({
+            cwd,
+            sessionId: started.sessionId,
+            prompt: "Reply exactly CONTINUE_OK. Do not use tools.",
+            model: model.id,
+            thinkingLevel: altEffort,
+            timeout: "3 minutes",
+          })
+          const reviewed = yield* backend.continueTurn({
+            cwd,
+            sessionId: started.sessionId,
+            command: "/review",
+            prompt:
+              "Review uncommitted worktree changes. If none, report clean with READY_FOR_AGENT_RESULT: REVIEW_CLEAN",
+            model: model.id,
+            thinkingLevel: effort,
+            timeout: "5 minutes",
+          })
+
+          return { started, continued, reviewed }
+        }).pipe(Effect.provide(TestLayer)),
+      )
+
+      expect(result.started.sessionId).toMatch(
+        /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i,
+      )
+      expect(result.continued.sessionId).toBe(result.started.sessionId)
+      expect(result.reviewed.sessionId).toBe(result.started.sessionId)
+      expect(result.started.assistantText.length).toBeGreaterThan(0)
+      expect(result.continued.assistantText.length).toBeGreaterThan(0)
+    } finally {
+      await rm(cwd, { recursive: true, force: true })
+    }
+  }, 600_000)
+})

--- a/packages/grok/test/grok.spec.ts
+++ b/packages/grok/test/grok.spec.ts
@@ -1,0 +1,332 @@
+import { chmod, mkdtemp, rm, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { BunServices } from "@effect/platform-bun"
+import { Deferred, Effect, Exit, Fiber, Layer } from "effect"
+import {
+  AgentBackend,
+  AgentBackendConfigError,
+  AgentBackendExitError,
+  AgentBackendMalformedOutputError,
+  AgentBackendTimeoutError,
+  type OnSessionId,
+} from "@ready-for-agent/agent-backend"
+import { Grok } from "../src/index.js"
+import { describe, expect, it } from "bun:test"
+
+const withExecutable = async <A>(
+  body: string,
+  use: (path: string) => Promise<A>,
+): Promise<A> => {
+  const directory = await mkdtemp(join(tmpdir(), "grok-effect-test-"))
+  const path = join(directory, "grok")
+  try {
+    await writeFile(path, `#!/bin/sh\n${body}\n`)
+    await chmod(path, 0o700)
+    return await use(path)
+  } finally {
+    await rm(directory, { recursive: true, force: true })
+  }
+}
+
+const provide = (binary: string) =>
+  Grok.layer({ binary }).pipe(Layer.provide(BunServices.layer))
+
+const captureSessionScript = [
+  'sid=""',
+  'prev=""',
+  'for arg in "$@"; do',
+  '  if [ "$prev" = "--session-id" ] || [ "$prev" = "--resume" ]; then sid="$arg"; fi',
+  '  prev="$arg"',
+  "done",
+].join("\n")
+
+const endEvent = `printf '%s\\n' "{\\"type\\":\\"end\\",\\"stopReason\\":\\"EndTurn\\",\\"sessionId\\":\\"$sid\\"}"`
+
+const startTurn = (
+  binary: string,
+  timeout: string,
+  onSessionId?: OnSessionId,
+  prompt = "test",
+  thinkingLevel: string | null = "medium",
+) =>
+  Effect.gen(function* () {
+    const backend = yield* AgentBackend
+    return yield* backend.startTurn({
+      cwd: process.cwd(),
+      prompt,
+      model: "grok-4.5",
+      thinkingLevel,
+      timeout,
+      ...(onSessionId !== undefined ? { onSessionId } : {}),
+    })
+  }).pipe(Effect.provide(provide(binary)))
+
+describe("Grok AgentBackend adapter", () => {
+  it("collects ordered text chunks and ignores thought", async () => {
+    await withExecutable(
+      [
+        'case " $* " in *" --no-auto-update "*) ;; *) exit 20 ;; esac',
+        'case " $* " in *" streaming-json "*) ;; *) exit 21 ;; esac',
+        'case " $* " in *" --yolo "*) ;; *) exit 22 ;; esac',
+        captureSessionScript,
+        `printf '%s\\n' '{"type":"thought","data":"ignore"}'`,
+        `printf '%s\\n' '{"type":"text","data":"first"}'`,
+        `printf '%s\\n' '{"type":"text","data":" second"}'`,
+        endEvent,
+      ].join("\n"),
+      async (binary) => {
+        const result = await Effect.runPromise(startTurn(binary, "2 seconds"))
+        expect(result.sessionId).toMatch(
+          /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i,
+        )
+        expect(result.assistantText).toBe("first second")
+      },
+    )
+  })
+
+  it("notifies onSessionId with the preassigned UUID before process exit", async () => {
+    await withExecutable(
+      [captureSessionScript, "sleep 0.4", endEvent].join("\n"),
+      async (binary) => {
+        const observed = await Effect.runPromise(
+          Effect.gen(function* () {
+            const deferred = yield* Deferred.make<string>()
+            const fiber = yield* Effect.forkChild(
+              startTurn(binary, "5 seconds", (sessionId) =>
+                Deferred.succeed(deferred, sessionId).pipe(Effect.asVoid),
+              ),
+            )
+            const earlySessionId = yield* Deferred.await(deferred)
+            const stillRunning = fiber.pollUnsafe() === undefined
+            const result = yield* Fiber.await(fiber)
+            return { earlySessionId, stillRunning, result }
+          }),
+        )
+
+        expect(observed.earlySessionId).toMatch(
+          /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i,
+        )
+        expect(observed.stillRunning).toBe(true)
+        expect(Exit.isSuccess(observed.result)).toBe(true)
+        if (Exit.isSuccess(observed.result)) {
+          expect(observed.result.value.sessionId).toBe(observed.earlySessionId)
+        }
+      },
+    )
+  })
+
+  it("resumes exact session and can switch model/effort", async () => {
+    await withExecutable(
+      [
+        captureSessionScript,
+        `printf '%s\\n' '{"type":"text","data":"ok"}'`,
+        endEvent,
+      ].join("\n"),
+      async (binary) => {
+        const outcome = await Effect.runPromise(
+          Effect.gen(function* () {
+            const backend = yield* AgentBackend
+            const started = yield* backend.startTurn({
+              cwd: process.cwd(),
+              prompt: "first",
+              model: "grok-4.5",
+              thinkingLevel: "low",
+              timeout: "2 seconds",
+            })
+            const continued = yield* backend.continueTurn({
+              cwd: process.cwd(),
+              sessionId: started.sessionId,
+              prompt: "second",
+              model: "grok-code-fast-1",
+              thinkingLevel: "high",
+              timeout: "2 seconds",
+            })
+            return { started, continued }
+          }).pipe(Effect.provide(provide(binary))),
+        )
+
+        expect(outcome.continued.sessionId).toBe(outcome.started.sessionId)
+        expect(outcome.continued.assistantText).toBe("ok")
+      },
+    )
+  })
+
+  it("omits --reasoning-effort when thinkingLevel is null", async () => {
+    await withExecutable(
+      [
+        'case " $* " in *" --reasoning-effort "*) exit 11 ;; esac',
+        captureSessionScript,
+        endEvent,
+      ].join("\n"),
+      async (binary) => {
+        await expect(
+          Effect.runPromise(
+            startTurn(binary, "2 seconds", undefined, "test", null),
+          ),
+        ).resolves.toMatchObject({ assistantText: "" })
+      },
+    )
+  })
+
+  it("maps nonzero exit with observed session", async () => {
+    await withExecutable(
+      [
+        captureSessionScript,
+        `printf '%s\\n' '{"type":"text","data":"x"}'`,
+        "exit 7",
+      ].join("\n"),
+      async (binary) => {
+        const error = await Effect.runPromise(
+          startTurn(binary, "2 seconds").pipe(Effect.flip),
+        )
+        expect(error).toBeInstanceOf(AgentBackendExitError)
+        if (error instanceof AgentBackendExitError) {
+          expect(error.exitCode).toBe(7)
+          expect(error.sessionId).toMatch(
+            /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i,
+          )
+        }
+      },
+    )
+  })
+
+  it("maps timeout while retaining session id", async () => {
+    await withExecutable(
+      [captureSessionScript, "sleep 10"].join("\n"),
+      async (binary) => {
+        const error = await Effect.runPromise(
+          startTurn(binary, "200 millis").pipe(Effect.flip),
+        )
+        expect(error).toBeInstanceOf(AgentBackendTimeoutError)
+        if (error instanceof AgentBackendTimeoutError) {
+          expect(error.timeoutMs).toBe(200)
+          expect(error.sessionId).toMatch(
+            /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i,
+          )
+        }
+      },
+    )
+  })
+
+  it("fails inspect when unauthenticated even if exit is zero", async () => {
+    await withExecutable(
+      [
+        "cat <<'EOF'",
+        "You are not authenticated.",
+        "",
+        "Default model: grok-4.5",
+        "",
+        "Available models:",
+        "  * grok-4.5 (default)",
+        "EOF",
+      ].join("\n"),
+      async (binary) => {
+        const error = await Effect.runPromise(
+          Effect.gen(function* () {
+            const backend = yield* AgentBackend
+            return yield* backend.inspect({
+              cwd: process.cwd(),
+              timeout: "2 seconds",
+            })
+          }).pipe(Effect.provide(provide(binary)), Effect.flip),
+        )
+        expect(error).toBeInstanceOf(AgentBackendConfigError)
+      },
+    )
+  })
+
+  it("inspects authenticated model catalog", async () => {
+    await withExecutable(
+      [
+        "cat <<'EOF'",
+        "You are logged in with grok.com.",
+        "",
+        "Default model: grok-4.5",
+        "",
+        "Available models:",
+        "  * grok-4.5 (default)",
+        "EOF",
+      ].join("\n"),
+      async (binary) => {
+        const result = await Effect.runPromise(
+          Effect.gen(function* () {
+            const backend = yield* AgentBackend
+            return yield* backend.inspect({
+              cwd: process.cwd(),
+              timeout: "2 seconds",
+            })
+          }).pipe(Effect.provide(provide(binary))),
+        )
+        expect(result.backend).toEqual({ id: "grok", label: "Grok Build" })
+        expect(result.models).toEqual([
+          {
+            id: "grok-4.5",
+            thinkingLevels: ["high", "medium", "low"],
+          },
+        ])
+      },
+    )
+  })
+
+  it("fails when terminal end event is missing", async () => {
+    await withExecutable(
+      [`printf '%s\\n' '{"type":"text","data":"only"}'`].join("\n"),
+      async (binary) => {
+        const error = await Effect.runPromise(
+          startTurn(binary, "2 seconds").pipe(Effect.flip),
+        )
+        expect(error).toBeInstanceOf(AgentBackendMalformedOutputError)
+      },
+    )
+  })
+
+  it("fails on session id mismatch in end event", async () => {
+    await withExecutable(
+      [
+        `printf '%s\\n' '{"type":"end","stopReason":"EndTurn","sessionId":"00000000-0000-4000-8000-000000000099"}'`,
+      ].join("\n"),
+      async (binary) => {
+        const error = await Effect.runPromise(
+          startTurn(binary, "2 seconds").pipe(Effect.flip),
+        )
+        expect(error).toBeInstanceOf(AgentBackendMalformedOutputError)
+      },
+    )
+  })
+
+  it("maps max-turn exhaustion to exit failure", async () => {
+    await withExecutable(
+      [
+        captureSessionScript,
+        `printf '%s\\n' '{"type":"max_turns_reached"}'`,
+        `printf '%s\\n' "{\\"type\\":\\"end\\",\\"stopReason\\":\\"MaxTurns\\",\\"sessionId\\":\\"$sid\\"}"`,
+      ].join("\n"),
+      async (binary) => {
+        const error = await Effect.runPromise(
+          startTurn(binary, "2 seconds").pipe(Effect.flip),
+        )
+        expect(error).toBeInstanceOf(AgentBackendExitError)
+      },
+    )
+  })
+
+  it("cancels the process tree on fiber interruption", async () => {
+    await withExecutable(
+      ["trap 'exit 0' TERM", "sleep 30"].join("\n"),
+      async (binary) => {
+        const exit = await Effect.runPromise(
+          Effect.gen(function* () {
+            const fiber = yield* Effect.forkChild(
+              startTurn(binary, "30 seconds"),
+            )
+            yield* Effect.sleep("100 millis")
+            yield* Fiber.interrupt(fiber)
+            return yield* Fiber.await(fiber)
+          }),
+        )
+        expect(Exit.isSuccess(exit)).toBe(false)
+      },
+    )
+  })
+})

--- a/packages/grok/test/parse-models.spec.ts
+++ b/packages/grok/test/parse-models.spec.ts
@@ -1,0 +1,51 @@
+import { parseGrokModelsOutput } from "../src/index.js"
+import { describe, expect, it } from "bun:test"
+
+describe("parseGrokModelsOutput", () => {
+  it("parses authenticated model catalog with default thinking levels", () => {
+    const parsed = parseGrokModelsOutput(
+      [
+        "You are logged in with grok.com.",
+        "",
+        "Default model: grok-4.5",
+        "",
+        "Available models:",
+        "  * grok-4.5 (default)",
+        "  * grok-code-fast-1",
+      ].join("\n"),
+    )
+    expect(parsed.authenticated).toBe(true)
+    expect(parsed.complete).toBe(true)
+    expect(parsed.models).toEqual([
+      {
+        id: "grok-4.5",
+        thinkingLevels: ["high", "medium", "low"],
+      },
+      {
+        id: "grok-code-fast-1",
+        thinkingLevels: ["high", "medium", "low"],
+      },
+    ])
+  })
+
+  it("treats explicit unauthenticated output as inspection failure input", () => {
+    const parsed = parseGrokModelsOutput(
+      [
+        "You are not authenticated.",
+        "",
+        "Default model: grok-4.5",
+        "",
+        "Available models:",
+        "  * grok-4.5 (default)",
+      ].join("\n"),
+    )
+    expect(parsed.authenticated).toBe(false)
+    expect(parsed.models.map((model) => model.id)).toEqual(["grok-4.5"])
+  })
+
+  it("marks empty catalog incomplete", () => {
+    const parsed = parseGrokModelsOutput("Available models:\n")
+    expect(parsed.complete).toBe(false)
+    expect(parsed.models).toEqual([])
+  })
+})

--- a/packages/grok/test/parse-stream.spec.ts
+++ b/packages/grok/test/parse-stream.spec.ts
@@ -1,0 +1,43 @@
+import {
+  createGrokStreamParseState,
+  foldGrokStreamLine,
+  grokAssistantText,
+  isSuccessfulGrokEnd,
+} from "../src/index.js"
+import { describe, expect, it } from "bun:test"
+
+describe("parse-stream", () => {
+  it("concatenates text chunks and ignores thought", () => {
+    let state = createGrokStreamParseState()
+    state = foldGrokStreamLine(state, '{"type":"thought","data":"hmm"}')
+    state = foldGrokStreamLine(state, '{"type":"text","data":"Hel"}')
+    state = foldGrokStreamLine(state, '{"type":"text","data":"lo"}')
+    state = foldGrokStreamLine(
+      state,
+      '{"type":"end","stopReason":"EndTurn","sessionId":"ses-1"}',
+    )
+    expect(grokAssistantText(state)).toBe("Hello")
+    expect(isSuccessfulGrokEnd(state)).toBe(true)
+    expect(state.endSessionId).toBe("ses-1")
+  })
+
+  it("marks non-json lines malformed", () => {
+    let state = createGrokStreamParseState()
+    state = foldGrokStreamLine(state, "not-json")
+    expect(state.malformedLine).toBe(true)
+  })
+
+  it("tracks max turns and error events", () => {
+    let state = createGrokStreamParseState()
+    state = foldGrokStreamLine(state, '{"type":"max_turns_reached"}')
+    expect(state.maxTurnsReached).toBe(true)
+    expect(isSuccessfulGrokEnd(state)).toBe(false)
+
+    state = createGrokStreamParseState()
+    state = foldGrokStreamLine(
+      state,
+      '{"type":"error","message":"auth failed"}',
+    )
+    expect(state.errorMessage).toBe("auth failed")
+  })
+})

--- a/packages/grok/tsconfig.json
+++ b/packages/grok/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ]
+}

--- a/packages/grok/tsconfig.lib.json
+++ b/packages/grok/tsconfig.lib.json
@@ -6,15 +6,12 @@
     "tsBuildInfoFile": "dist/tsconfig.lib.tsbuildinfo",
     "emitDeclarationOnly": false,
     "forceConsistentCasingInFileNames": true,
-    "types": ["node"]
+    "types": ["node", "bun"]
   },
   "include": ["src/**/*.ts"],
   "references": [
     {
       "path": "../agent-backend/tsconfig.lib.json"
-    },
-    {
-      "path": "../db/tsconfig.lib.json"
     }
   ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -43,6 +43,9 @@
       "path": "./packages/opencode"
     },
     {
+      "path": "./packages/grok"
+    },
+    {
       "path": "./packages/github-service"
     },
     {


### PR DESCRIPTION
## Why

Operators need to choose Grok Build without losing the durable, backend-neutral Work Item lifecycle.

## What Changed

- Add the built-in `grok` / Grok Build Agent Backend adapter with durable UUID Sessions, exact resume, structured streaming output, model inspection, and unattended auto-update-disabled turns.
- Register Grok capabilities, load the selected adapter at Harness startup, and surface unsupported Session Telemetry through the generic capability path.
- Require only the selected backend executable during host preflight and document Grok ambient `gh` authentication and Keymaxxer limitations.

Closes #418