### PR TITLE
fix(harness): clear model selections when Agent Backend changes

### DIFF
--- a/apps/harness/src/routes/__root.tsx
+++ b/apps/harness/src/routes/__root.tsx
@@ -315,12 +315,28 @@ function SettingsButton() {
     dialogRef.current?.showModal()
   }, [autoOpenAttempted, buildConfigured, config.isSuccess, updateConfig.reset])
 
+  const savedAgentBackend = config.data?.selectedAgentBackend ?? "opencode"
+  const backendChanging = selectedAgentBackend !== savedAgentBackend
+
+  const applyAgentBackendSelection = (nextBackend: string) => {
+    setSelectedAgentBackend(nextBackend)
+    if (nextBackend === savedAgentBackend && config.data) {
+      setDefaultModel(config.data.defaultModel ?? "")
+      setDefaultVariant(config.data.defaultThinkingLevel ?? "")
+      setReviewModel(config.data.reviewModel ?? "")
+      setReviewVariant(config.data.reviewThinkingLevel ?? "")
+      return
+    }
+    setDefaultModel("")
+    setDefaultVariant("")
+    setReviewModel("")
+    setReviewVariant("")
+  }
+
   const saveSettings = (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault()
     const parsedMaxSessions = Number(maxConcurrentAgentTurns)
     const parsedMaxWorkItems = Number(maxConcurrentWorkItems)
-    const backendChanging =
-      selectedAgentBackend !== (config.data?.selectedAgentBackend ?? "opencode")
     updateConfig.mutate({
       selectedAgentBackend,
       defaultModel: backendChanging
@@ -488,7 +504,7 @@ function SettingsButton() {
                     name="selectedAgentBackend"
                     value={selectedAgentBackend}
                     onChange={(event) =>
-                      setSelectedAgentBackend(event.target.value)
+                      applyAgentBackendSelection(event.target.value)
                     }
                   >
                     {(backendStatus.data?.agentBackends ?? []).map(
@@ -552,11 +568,14 @@ function SettingsButton() {
                         )
                       }
                     }}
-                    required
+                    required={!backendChanging}
+                    disabled={backendChanging}
                   >
-                    {!buildConfigured && defaultModel.length === 0 && (
-                      <option value="" disabled>
-                        Select a build model
+                    {defaultModel.length === 0 && (
+                      <option value="">
+                        {backendChanging
+                          ? "Cleared — choose after restart"
+                          : "Select a build model"}
                       </option>
                     )}
                     {hasUnavailableBuildModel && (
@@ -595,7 +614,7 @@ function SettingsButton() {
                       onChange={(event) =>
                         setDefaultVariant(event.target.value)
                       }
-                      disabled={defaultModel.length === 0}
+                      disabled={backendChanging || defaultModel.length === 0}
                     >
                       <option value="">
                         {buildVariants.length === 0
@@ -626,6 +645,7 @@ function SettingsButton() {
                     className="w-full min-w-0 border border-rule-2 bg-paper px-3 py-2 font-mono text-sm font-normal outline-none focus:border-oxblood focus:ring-2 focus:ring-oxblood/15"
                     name="reviewModel"
                     value={reviewModel}
+                    disabled={backendChanging}
                     onChange={(event) => {
                       const nextModel = event.target.value
                       setReviewModel(nextModel)
@@ -638,7 +658,11 @@ function SettingsButton() {
                       )
                     }}
                   >
-                    <option value="">Same as build model</option>
+                    <option value="">
+                      {backendChanging
+                        ? "Cleared — choose after restart"
+                        : "Same as build model"}
+                    </option>
                     {hasUnavailableReviewModel && (
                       <option value={reviewModel}>
                         {reviewModel} (not in Agent Model catalog)
@@ -678,6 +702,7 @@ function SettingsButton() {
                       value={reviewThinkingLevel}
                       onChange={(event) => setReviewVariant(event.target.value)}
                       disabled={
+                        backendChanging ||
                         reviewThinkingLevelSourceModel.length === 0 ||
                         reviewThinkingLevels.length === 0
                       }
@@ -775,8 +800,7 @@ function SettingsButton() {
                 models.isPending ||
                 models.isError ||
                 updateConfig.isPending ||
-                (selectedAgentBackend ===
-                  (config.data?.selectedAgentBackend ?? "opencode") &&
+                (!backendChanging &&
                   (defaultModel.length === 0 || hasUnavailableBuildModel))
               }
             >

--- a/apps/harness/test/harness-settings-backend-change.test.ts
+++ b/apps/harness/test/harness-settings-backend-change.test.ts
@@ -1,0 +1,40 @@
+import { readFileSync } from "node:fs"
+import { join } from "node:path"
+import { describe, expect, test } from "bun:test"
+
+const rootSource = () =>
+  readFileSync(join(import.meta.dir, "../src/routes/__root.tsx"), "utf8")
+
+describe("Harness settings Agent Backend change", () => {
+  test("clears model and thinking selections when Agent Backend changes", () => {
+    const source = rootSource()
+    expect(source).toContain(
+      "const applyAgentBackendSelection = (nextBackend: string) => {",
+    )
+    expect(source).toContain("applyAgentBackendSelection(event.target.value)")
+    expect(source).toContain('setDefaultModel("")')
+    expect(source).toContain('setDefaultVariant("")')
+    expect(source).toContain('setReviewModel("")')
+    expect(source).toContain('setReviewVariant("")')
+    expect(source).toContain(
+      "if (nextBackend === savedAgentBackend && config.data) {",
+    )
+    expect(source).toContain('setDefaultModel(config.data.defaultModel ?? "")')
+    expect(source).toContain(
+      'setDefaultVariant(config.data.defaultThinkingLevel ?? "")',
+    )
+    expect(source).toContain('setReviewModel(config.data.reviewModel ?? "")')
+    expect(source).toContain(
+      'setReviewVariant(config.data.reviewThinkingLevel ?? "")',
+    )
+    expect(source).toContain("required={!backendChanging}")
+    expect(source).toContain("disabled={backendChanging}")
+    expect(source).toContain("defaultModel: backendChanging")
+    expect(source).toContain("defaultThinkingLevel: backendChanging")
+    expect(source).toContain("reviewModel: backendChanging")
+    expect(source).toContain("reviewThinkingLevel: backendChanging")
+    expect(source).not.toMatch(
+      /onChange=\{\(event\) =>\s*setSelectedAgentBackend\(event\.target\.value\)\s*\}/,
+    )
+  })
+})

--- a/packages/db-service/test/db-service.spec.ts
+++ b/packages/db-service/test/db-service.spec.ts
@@ -106,6 +106,62 @@ describe("DbService", () => {
         }),
       ))
 
+    it("clears harness and repository model selections when Agent Backend changes", () =>
+      runTest(
+        Effect.gen(function* () {
+          const db = yield* DbService
+          yield* db.updateConfig({
+            selectedAgentBackend: "opencode",
+            defaultModel: "openai/gpt-5.6-terra",
+            defaultThinkingLevel: "high",
+            reviewModel: "openai/gpt-5.6-terra",
+            reviewThinkingLevel: "max",
+            maxConcurrentAgentTurns: 2,
+            maxConcurrentWorkItems: 5,
+          })
+          const repository = yield* db.addRepository(sampleInput)
+          yield* db.updateRepositorySettings({
+            repositoryId: repository.id,
+            paused: false,
+            defaultModel: "openai/gpt-5.6-terra",
+            defaultThinkingLevel: "high",
+            reviewModel: "openai/gpt-5.6-terra",
+            reviewThinkingLevel: "max",
+            autoMerge: false,
+            includeAllIssueAuthors: false,
+          })
+
+          const updated = yield* db.updateConfig({
+            selectedAgentBackend: "grok",
+            defaultModel: "should-be-ignored",
+            defaultThinkingLevel: "should-be-ignored",
+            reviewModel: "should-be-ignored",
+            reviewThinkingLevel: "should-be-ignored",
+            maxConcurrentAgentTurns: 2,
+            maxConcurrentWorkItems: 5,
+          })
+          expect(updated).toEqual({
+            selectedAgentBackend: "grok",
+            defaultModel: null,
+            defaultThinkingLevel: null,
+            reviewModel: null,
+            reviewThinkingLevel: null,
+            maxConcurrentAgentTurns: 2,
+            maxConcurrentWorkItems: 5,
+          })
+
+          const repos = yield* db.listRepositories
+          expect(repos).toHaveLength(1)
+          expect(repos[0]).toMatchObject({
+            id: repository.id,
+            defaultModel: null,
+            defaultThinkingLevel: null,
+            reviewModel: null,
+            reviewThinkingLevel: null,
+          })
+        }),
+      ))
+
     it("rejects unknown Agent Backend ids", () =>
       runTest(
         Effect.gen(function* () {


### PR DESCRIPTION
## Summary

- Clear Build/Review model and thinking-level fields immediately when Agent Backend changes in Harness settings
- Disable model/thinking controls while a backend change is pending so old backend values never stay visible
- Persist cleared harness and repository model selections on backend-change save (covered by db-service test)

Closes #447

## Test plan

- [x] `bun test apps/harness/test/harness-settings-backend-change.test.ts`
- [x] `bun test packages/db-service/test/db-service.spec.ts -t "clears harness and repository"`
- [x] `nx affected -t lint,typecheck,test` (pre-commit)
- [ ] Manually: open Settings with build/review models set → switch Agent Backend → confirm all four fields clear → Save → confirm cleared config; restart and choose new models