### PR TITLE
fix(agent-backend): gate Agent Turn Keymaxxer on effective backend support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,9 +6,8 @@ Issues live in GitHub Issues for berenddeboer/ready-for-agent (via `gh`). See `d
 
 ### Credentials
 
-Keymaxxer is used by the Ready for Agent harness. Interactive coding agents do
-not need to use Keymaxxer themselves; use normally authenticated tools such as
-`gh` and `git` directly.
+Use `gh` and `git` with the logged-in user's existing credentials (normal `gh`
+configuration or ambient GitHub token environment variables).
 
 Fine-grained GitHub PATs cannot call the Checks API (including GraphQL
 `statusCheckRollup.contexts`). That 403 is expected: the harness falls back to

--- a/packages/agent-backend/src/lib/environment.ts
+++ b/packages/agent-backend/src/lib/environment.ts
@@ -3,16 +3,29 @@ const isGitHubTokenEnvName = (name: string) =>
   name === "GITHUB_TOKEN" ||
   name.startsWith("GITHUB_TOKEN_")
 
+export type SanitizeInheritedEnvironmentOptions = {
+  /**
+   * When true (default), strip GH_TOKEN / GITHUB_TOKEN / GITHUB_TOKEN_*.
+   * Set false when the backend is not receiving vault-backed Keymaxxer MCP so
+   * ambient GitHub authentication remains available to Agent Turns.
+   */
+  readonly stripGitHubTokens?: boolean
+}
+
 /**
- * Inherit process environment with GitHub token variables stripped.
- * Adapters may merge additional backend-specific entries afterward.
+ * Inherit process environment, dropping undefined entries. Optionally strip
+ * GitHub token variables when the backend receives vault-backed credentials.
  */
 export const sanitizeInheritedEnvironment = (
   environment: Readonly<Record<string, string | undefined>> = process.env,
-): Record<string, string> =>
-  Object.fromEntries(
+  options: SanitizeInheritedEnvironmentOptions = {},
+): Record<string, string> => {
+  const stripGitHubTokens = options.stripGitHubTokens !== false
+  return Object.fromEntries(
     Object.entries(environment).filter(
       (entry): entry is [string, string] =>
-        entry[1] !== undefined && !isGitHubTokenEnvName(entry[0]),
+        entry[1] !== undefined &&
+        !(stripGitHubTokens && isGitHubTokenEnvName(entry[0])),
     ),
   )
+}

--- a/packages/agent-backend/test/environment.spec.ts
+++ b/packages/agent-backend/test/environment.spec.ts
@@ -2,7 +2,7 @@ import { sanitizeInheritedEnvironment } from "../src/index.js"
 import { describe, expect, it } from "bun:test"
 
 describe("sanitizeInheritedEnvironment", () => {
-  it("drops only GitHub token names", () => {
+  it("drops only GitHub token names by default", () => {
     const result = sanitizeInheritedEnvironment({
       HOME: "/home/user",
       GH_TOKEN: "a",
@@ -12,6 +12,26 @@ describe("sanitizeInheritedEnvironment", () => {
     })
     expect(result).toEqual({
       HOME: "/home/user",
+      NOT_GITHUB_TOKEN: "keep",
+    })
+  })
+
+  it("preserves GitHub token names when stripGitHubTokens is false", () => {
+    const result = sanitizeInheritedEnvironment(
+      {
+        HOME: "/home/user",
+        GH_TOKEN: "a",
+        GITHUB_TOKEN: "b",
+        GITHUB_TOKEN_REPO: "c",
+        NOT_GITHUB_TOKEN: "keep",
+      },
+      { stripGitHubTokens: false },
+    )
+    expect(result).toEqual({
+      HOME: "/home/user",
+      GH_TOKEN: "a",
+      GITHUB_TOKEN: "b",
+      GITHUB_TOKEN_REPO: "c",
       NOT_GITHUB_TOKEN: "keep",
     })
   })

--- a/packages/grok/src/lib/environment.ts
+++ b/packages/grok/src/lib/environment.ts
@@ -5,8 +5,9 @@ export type MakeGrokEnvironmentOptions = {
 }
 
 /**
- * Grok Build Agent Turns use ambient `gh` only: sanitize inherited env, strip
- * raw GitHub tokens, and force auto-update off for the process lifetime.
+ * Grok Build Agent Turns use ambient `gh` only: inherit process env (including
+ * ambient GitHub tokens), and force auto-update off for the process lifetime.
+ * Grok does not support KeymaxxerMcp, so tokens are never stripped.
  */
 export const makeGrokEnvironment = (
   options: MakeGrokEnvironmentOptions = {},
@@ -14,7 +15,9 @@ export const makeGrokEnvironment = (
   const environment =
     options.environment ?? (process.env as Record<string, string | undefined>)
   return {
-    ...sanitizeInheritedEnvironment(environment),
+    ...sanitizeInheritedEnvironment(environment, {
+      stripGitHubTokens: false,
+    }),
     GROK_DISABLE_AUTOUPDATER: "1",
   }
 }

--- a/packages/grok/test/environment.spec.ts
+++ b/packages/grok/test/environment.spec.ts
@@ -2,7 +2,7 @@ import { makeGrokEnvironment } from "../src/index.js"
 import { describe, expect, it } from "bun:test"
 
 describe("makeGrokEnvironment", () => {
-  it("strips GitHub token variables and disables auto-update", () => {
+  it("preserves ambient GitHub tokens and disables auto-update", () => {
     const env = makeGrokEnvironment({
       environment: {
         PATH: "/usr/bin",
@@ -16,9 +16,9 @@ describe("makeGrokEnvironment", () => {
     expect(env.PATH).toBe("/usr/bin")
     expect(env.KEEP).toBe("yes")
     expect(env.GROK_DISABLE_AUTOUPDATER).toBe("1")
-    expect(env.GH_TOKEN).toBeUndefined()
-    expect(env.GITHUB_TOKEN).toBeUndefined()
-    expect(env.GITHUB_TOKEN_repo).toBeUndefined()
+    expect(env.GH_TOKEN).toBe("secret")
+    expect(env.GITHUB_TOKEN).toBe("secret2")
+    expect(env.GITHUB_TOKEN_repo).toBe("secret3")
     expect(env.OPENCODE_CONFIG_CONTENT).toBeUndefined()
   })
 })

--- a/packages/opencode/src/lib/environment.ts
+++ b/packages/opencode/src/lib/environment.ts
@@ -42,28 +42,31 @@ export const makeOpencodeEnvironment = Effect.fn("makeOpencodeEnvironment")(
     const mcp = isObject(config.mcp) ? config.mcp : {}
     const { keymaxxer: _keymaxxer, ...mcpWithoutKeymaxxer } = mcp
 
-    const opencodeConfig =
-      keymaxxerMcpUrl === undefined || keymaxxerMcpUrl === ""
-        ? {
-            ...config,
-            ...(config.mcp === undefined ? {} : { mcp: mcpWithoutKeymaxxer }),
-          }
-        : {
-            ...config,
-            mcp: {
-              ...mcp,
-              keymaxxer: {
-                type: "remote",
-                url: keymaxxerMcpUrl,
-                enabled: true,
-                oauth: false,
-                timeout: DEFAULT_MCP_TIMEOUT_MS,
-              },
+    const vaultMcpConfigured =
+      keymaxxerMcpUrl !== undefined && keymaxxerMcpUrl !== ""
+    const opencodeConfig = vaultMcpConfigured
+      ? {
+          ...config,
+          mcp: {
+            ...mcp,
+            keymaxxer: {
+              type: "remote",
+              url: keymaxxerMcpUrl,
+              enabled: true,
+              oauth: false,
+              timeout: DEFAULT_MCP_TIMEOUT_MS,
             },
-          }
+          },
+        }
+      : {
+          ...config,
+          ...(config.mcp === undefined ? {} : { mcp: mcpWithoutKeymaxxer }),
+        }
 
     return {
-      ...sanitizeInheritedEnvironment(environment),
+      ...sanitizeInheritedEnvironment(environment, {
+        stripGitHubTokens: vaultMcpConfigured,
+      }),
       OPENCODE_CONFIG_CONTENT: JSON.stringify(opencodeConfig),
     }
   },

--- a/packages/opencode/test/environment.spec.ts
+++ b/packages/opencode/test/environment.spec.ts
@@ -59,7 +59,7 @@ describe("makeOpencodeEnvironment", () => {
     })
   })
 
-  it("strips GitHub token environment variables", () => {
+  it("strips GitHub token environment variables when vault MCP is configured", () => {
     const env = makeEnv({
       keymaxxerMcpUrl: "http://127.0.0.1:6057/cap/mcp",
       environment: {
@@ -75,6 +75,23 @@ describe("makeOpencodeEnvironment", () => {
     expect(env.GH_TOKEN).toBeUndefined()
     expect(env.GITHUB_TOKEN).toBeUndefined()
     expect(env.GITHUB_TOKEN_ACME_WIDGETS).toBeUndefined()
+  })
+
+  it("preserves ambient GitHub tokens when vault MCP is not configured", () => {
+    const env = makeEnv({
+      environment: {
+        PATH: "/usr/bin",
+        GH_TOKEN: "secret",
+        GITHUB_TOKEN: "secret",
+        GITHUB_TOKEN_ACME_WIDGETS: "secret",
+        KEEP: "yes",
+      },
+    })
+    expect(env.PATH).toBe("/usr/bin")
+    expect(env.KEEP).toBe("yes")
+    expect(env.GH_TOKEN).toBe("secret")
+    expect(env.GITHUB_TOKEN).toBe("secret")
+    expect(env.GITHUB_TOKEN_ACME_WIDGETS).toBe("secret")
   })
 
   it("does not configure Keymaxxer when its capability URL is missing", () => {

--- a/packages/work-item-lifecycle/src/index.ts
+++ b/packages/work-item-lifecycle/src/index.ts
@@ -1,4 +1,5 @@
 export * from "./lib/active-agent-backend-test.js"
+export * from "./lib/agent-turn-github-auth.js"
 export * from "./lib/agent-turn-limiter.js"
 export * from "./lib/assess-changes.js"
 export * from "./lib/assess-changes-errors.js"

--- a/packages/work-item-lifecycle/src/lib/active-agent-backend-test.ts
+++ b/packages/work-item-lifecycle/src/lib/active-agent-backend-test.ts
@@ -3,6 +3,7 @@ import {
   AGENT_BACKEND_IDS,
   ActiveAgentBackend,
   type AgentBackendBlockedError,
+  type AgentBackendRegistration,
   type AgentBackendStatus,
   type SessionTelemetry,
   getBuiltInAgentBackend,
@@ -16,10 +17,11 @@ if (opencodeRegistration === undefined) {
 const opencode = opencodeRegistration
 
 const readyStatus = (
+  registration: AgentBackendRegistration,
   models: AgentBackendStatus["models"] = [],
 ): AgentBackendStatus => ({
-  selectedBackend: opencode.descriptor,
-  activeBackend: opencode.descriptor,
+  selectedBackend: registration.descriptor,
+  activeBackend: registration.descriptor,
   kind: "ready",
   reason: null,
   models,
@@ -31,28 +33,40 @@ const readyStatus = (
  */
 export const stubActiveAgentBackendLayer = (
   overrides: Partial<{
+    readonly registration: AgentBackendRegistration
     readonly getStatus: Effect.Effect<AgentBackendStatus>
     readonly requireAgentTurnsAllowed: Effect.Effect<
       void,
       AgentBackendBlockedError
     >
   }> = {},
-): Layer.Layer<ActiveAgentBackend> =>
-  Layer.succeed(
+): Layer.Layer<ActiveAgentBackend> => {
+  const registration = overrides.registration ?? opencode
+  return Layer.succeed(
     ActiveAgentBackend,
     ActiveAgentBackend.of({
-      getStatus: overrides.getStatus ?? Effect.succeed(readyStatus()),
-      recheck: () => Effect.succeed(readyStatus()),
+      getStatus:
+        overrides.getStatus ?? Effect.succeed(readyStatus(registration)),
+      recheck: () => Effect.succeed(readyStatus(registration)),
       requireAgentTurnsAllowed:
         overrides.requireAgentTurnsAllowed ?? Effect.void,
-      setSelectedBackend: () => Effect.succeed(readyStatus()),
-      getActiveRegistration: Effect.succeed(opencode),
+      setSelectedBackend: () => Effect.succeed(readyStatus(registration)),
+      getActiveRegistration: Effect.succeed(registration),
       getSessionTelemetry: (input) =>
         Effect.succeed(
           unsupportedSessionTelemetry(
             input.sessionId ?? "",
-            opencode.descriptor,
+            registration.descriptor,
           ) satisfies SessionTelemetry,
         ),
     }),
   )
+}
+
+const grokRegistration = getBuiltInAgentBackend(AGENT_BACKEND_IDS.grok)
+if (grokRegistration === undefined) {
+  throw new Error("Grok Agent Backend registration is missing")
+}
+
+export const stubGrokActiveAgentBackendLayer: Layer.Layer<ActiveAgentBackend> =
+  stubActiveAgentBackendLayer({ registration: grokRegistration })

--- a/packages/work-item-lifecycle/src/lib/agent-turn-github-auth.ts
+++ b/packages/work-item-lifecycle/src/lib/agent-turn-github-auth.ts
@@ -1,0 +1,72 @@
+import { Effect, Schema } from "effect"
+import {
+  ActiveAgentBackend,
+  capabilitySupported,
+} from "@ready-for-agent/agent-backend"
+import { KeymaxxerService } from "@ready-for-agent/keymaxxer-service"
+
+/**
+ * Effective Agent Turn GitHub auth: vault-backed only when the Active Agent
+ * Backend supports KeymaxxerMcp and Keymaxxer is enabled for that instance.
+ */
+export type AgentTurnGitHubAuth =
+  | { readonly _tag: "keymaxxer"; readonly tokenName: string }
+  | { readonly _tag: "ambient" }
+
+export class AgentTurnGitHubCredentialMissingError extends Schema.TaggedErrorClass<AgentTurnGitHubCredentialMissingError>()(
+  "AgentTurnGitHubCredentialMissingError",
+  {
+    message: Schema.String,
+  },
+) {}
+
+export const isAgentTurnKeymaxxerEffective = (
+  keymaxxerMcpSupported: boolean,
+  keymaxxerEnabled: boolean | undefined,
+): boolean => keymaxxerMcpSupported && keymaxxerEnabled !== false
+
+export const resolveAgentTurnGitHubAuth = (input: {
+  readonly githubOwner: string
+  readonly githubRepo: string
+}) =>
+  Effect.gen(function* () {
+    const active = yield* ActiveAgentBackend
+    const registration = yield* active.getActiveRegistration
+    const keymaxxer = yield* KeymaxxerService
+    const effective = isAgentTurnKeymaxxerEffective(
+      capabilitySupported(registration, "KeymaxxerMcp"),
+      keymaxxer.enabled,
+    )
+    if (!effective) {
+      return { _tag: "ambient" } satisfies AgentTurnGitHubAuth
+    }
+    const tokenName = yield* keymaxxer.findSecret({
+      provider: "github",
+      account: `${input.githubOwner}/${input.githubRepo}`,
+    })
+    if (tokenName === null) {
+      return yield* new AgentTurnGitHubCredentialMissingError({
+        message: `No GitHub credential is configured for ${input.githubOwner}/${input.githubRepo}`,
+      })
+    }
+    return {
+      _tag: "keymaxxer",
+      tokenName,
+    } satisfies AgentTurnGitHubAuth
+  })
+
+/**
+ * Credential guidance line for Agent Turn prompts. Always included so ambient
+ * backends get explicit `gh` instructions without Keymaxxer wording.
+ */
+export const agentTurnGitHubCredentialGuidance = (
+  auth: AgentTurnGitHubAuth,
+  accessScope: string,
+): string => {
+  switch (auth._tag) {
+    case "keymaxxer":
+      return `Use Keymaxxer secret ${auth.tokenName} via keymaxxer_run for any ${accessScope}; never put secret values in the environment.`
+    case "ambient":
+      return `Use the gh CLI with the existing ambient authentication for any ${accessScope}.`
+  }
+}

--- a/packages/work-item-lifecycle/src/lib/create-pr.ts
+++ b/packages/work-item-lifecycle/src/lib/create-pr.ts
@@ -2,7 +2,12 @@ import { Effect, FileSystem } from "effect"
 import { AgentBackend } from "@ready-for-agent/agent-backend"
 import { DbService } from "@ready-for-agent/db-service"
 import { GitHubService } from "@ready-for-agent/github-service"
-import { KeymaxxerService } from "@ready-for-agent/keymaxxer-service"
+import {
+  type AgentTurnGitHubAuth,
+  AgentTurnGitHubCredentialMissingError,
+  agentTurnGitHubCredentialGuidance,
+  resolveAgentTurnGitHubAuth,
+} from "./agent-turn-github-auth.js"
 import {
   CreatePrCredentialError,
   CreatePrInvalidWorktreeContextError,
@@ -65,7 +70,7 @@ const resolveSessionId = (context: LifecycleStepContext) => {
 const buildCreatePrPrompt = (
   githubIssueNumber: number,
   branch: string,
-  tokenName: string | undefined,
+  auth: AgentTurnGitHubAuth,
 ) =>
   [
     "Create a pull request for the committed implementation changes in this worktree.",
@@ -77,11 +82,7 @@ const buildCreatePrPrompt = (
     "Follow this repository's PR title and body conventions.",
     `If a suitable open PR whose head is exactly ${branch} already exists, succeed without creating a duplicate.`,
     "Do not merge the pull request.",
-    ...(tokenName === undefined
-      ? []
-      : [
-          `Use Keymaxxer secret ${tokenName} via keymaxxer_run for any GitHub CLI or API access; never put secret values in the environment.`,
-        ]),
+    agentTurnGitHubCredentialGuidance(auth, "GitHub CLI or API access"),
   ].join("\n")
 
 /**
@@ -117,32 +118,24 @@ export const createPr = (context: LifecycleStepContext) =>
       })
     }
 
-    const keymaxxer = yield* KeymaxxerService
-    const tokenName =
-      keymaxxer.enabled === false
-        ? undefined
-        : yield* keymaxxer
-            .findSecret({
-              provider: "github",
-              account: `${repository.githubOwner}/${repository.githubRepo}`,
-            })
-            .pipe(
-              Effect.mapError(
-                (cause) =>
-                  new CreatePrCredentialError({
-                    repositoryId: context.repositoryId,
-                    message:
-                      "Failed to resolve the repository GitHub credential",
-                    cause,
-                  }),
-              ),
-            )
-    if (tokenName === null) {
-      return yield* new CreatePrCredentialError({
-        repositoryId: context.repositoryId,
-        message: `No GitHub credential is configured for ${repository.githubOwner}/${repository.githubRepo}`,
-      })
-    }
+    const auth = yield* resolveAgentTurnGitHubAuth({
+      githubOwner: repository.githubOwner,
+      githubRepo: repository.githubRepo,
+    }).pipe(
+      Effect.mapError((cause) => {
+        if (cause instanceof AgentTurnGitHubCredentialMissingError) {
+          return new CreatePrCredentialError({
+            repositoryId: context.repositoryId,
+            message: cause.message,
+          })
+        }
+        return new CreatePrCredentialError({
+          repositoryId: context.repositoryId,
+          message: "Failed to resolve the repository GitHub credential",
+          cause,
+        })
+      }),
+    )
 
     const branch = workItemBranchName({
       githubOwner: repository.githubOwner,
@@ -157,11 +150,7 @@ export const createPr = (context: LifecycleStepContext) =>
     yield* agentBackend
       .continueTurn({
         sessionId,
-        prompt: buildCreatePrPrompt(
-          context.githubIssueNumber,
-          branch,
-          tokenName,
-        ),
+        prompt: buildCreatePrPrompt(context.githubIssueNumber, branch, auth),
         cwd: worktreePath,
         model: context.model,
         thinkingLevel: context.thinkingLevel,

--- a/packages/work-item-lifecycle/src/lib/decide-pr-merge.ts
+++ b/packages/work-item-lifecycle/src/lib/decide-pr-merge.ts
@@ -1,7 +1,11 @@
 import { Effect, Schema } from "effect"
 import { AgentBackend } from "@ready-for-agent/agent-backend"
 import { DbService } from "@ready-for-agent/db-service"
-import { KeymaxxerService } from "@ready-for-agent/keymaxxer-service"
+import {
+  AgentTurnGitHubCredentialMissingError,
+  agentTurnGitHubCredentialGuidance,
+  resolveAgentTurnGitHubAuth,
+} from "./agent-turn-github-auth.js"
 import type { LifecycleStepContext } from "./lifecycle-steps.js"
 import { DEFAULT_LIFECYCLE_MAX_DURATIONS } from "./types.js"
 
@@ -97,28 +101,24 @@ export const decidePrMerge = (context: LifecycleStepContext) =>
         reason: "Auto-merge is disabled for this repository",
       }
     }
-    const keymaxxer = yield* KeymaxxerService
-    const tokenName =
-      keymaxxer.enabled === false
-        ? undefined
-        : yield* keymaxxer.findSecret({
-            provider: "github",
-            account: `${repository.githubOwner}/${repository.githubRepo}`,
-          })
-    if (tokenName === null) {
-      return yield* new DecidePrMergeContextError({
-        message: `No GitHub credential is configured for ${repository.githubOwner}/${repository.githubRepo}`,
-      })
-    }
+    const auth = yield* resolveAgentTurnGitHubAuth({
+      githubOwner: repository.githubOwner,
+      githubRepo: repository.githubRepo,
+    }).pipe(
+      Effect.mapError((cause) => {
+        if (cause instanceof AgentTurnGitHubCredentialMissingError) {
+          return new DecidePrMergeContextError({ message: cause.message })
+        }
+        return new DecidePrMergeContextError({
+          message: "Failed to resolve the repository GitHub credential",
+        })
+      }),
+    )
     const prompt = [
       "Assess whether this pull request is low enough risk for an automated agent (clanker) to merge, or whether a human must merge it.",
       "Base the decision on risk: blast radius, security or auth changes, data migrations, irreversible operations, ambiguous requirements, incomplete verification, or anything that needs human judgment.",
       "Inspect the PR and its checks if needed. Do not merge the pull request.",
-      ...(tokenName === undefined
-        ? []
-        : [
-            `Use Keymaxxer secret ${tokenName} via keymaxxer_run for any GitHub CLI or API access; never put secret values in the environment.`,
-          ]),
+      agentTurnGitHubCredentialGuidance(auth, "GitHub CLI or API access"),
       "End your final response with exactly one machine-readable result line:",
       "READY_FOR_AGENT_RESULT: CLANKER_MERGE",
       "or, only when a human must merge:",

--- a/packages/work-item-lifecycle/src/lib/lifecycle-steps-live.ts
+++ b/packages/work-item-lifecycle/src/lib/lifecycle-steps-live.ts
@@ -1,7 +1,10 @@
 import { Effect, FileSystem, Layer, Path } from "effect"
 import { ChildProcessSpawner } from "effect/unstable/process"
 import { SqlClient } from "effect/unstable/sql"
-import { AgentBackend } from "@ready-for-agent/agent-backend"
+import {
+  ActiveAgentBackend,
+  AgentBackend,
+} from "@ready-for-agent/agent-backend"
 import { DbService } from "@ready-for-agent/db-service"
 import { GitHubService } from "@ready-for-agent/github-service"
 import { KeymaxxerService } from "@ready-for-agent/keymaxxer-service"
@@ -33,14 +36,16 @@ type StepServices =
   | Path.Path
   | ChildProcessSpawner.ChildProcessSpawner
   | AgentBackend
+  | ActiveAgentBackend
   | GitHubService
   | SqlClient.SqlClient
 
 /**
  * Production LifecycleSteps: Create Worktree through local cleanup, including
  * Assess Changes (git then optional OpenCode confirm) and Close Issue for
- * No-Change Outcomes. Captures platform, database, Keymaxxer, GitHub, and
- * OpenCode services so handlers remain `Effect<A, E>` with no requirements.
+ * No-Change Outcomes. Captures platform, database, Keymaxxer, GitHub, Active
+ * Agent Backend, and Agent Backend services so handlers remain `Effect<A, E>`
+ * with no requirements.
  */
 export const LifecycleStepsLive = Layer.effect(
   LifecycleSteps,
@@ -51,6 +56,7 @@ export const LifecycleStepsLive = Layer.effect(
     const path = yield* Path.Path
     const spawner = yield* ChildProcessSpawner.ChildProcessSpawner
     const rawAgentBackend = yield* AgentBackend
+    const activeAgentBackend = yield* ActiveAgentBackend
     const github = yield* GitHubService
     const sql = yield* SqlClient.SqlClient
     const agentBackend = yield* limitAgentTurns(rawAgentBackend, db, sql)
@@ -62,6 +68,7 @@ export const LifecycleStepsLive = Layer.effect(
       Layer.succeed(Path.Path, path),
       Layer.succeed(ChildProcessSpawner.ChildProcessSpawner, spawner),
       Layer.succeed(AgentBackend, agentBackend),
+      Layer.succeed(ActiveAgentBackend, activeAgentBackend),
       Layer.succeed(GitHubService, github),
       Layer.succeed(SqlClient.SqlClient, sql),
     )

--- a/packages/work-item-lifecycle/src/lib/pr-status-checks.ts
+++ b/packages/work-item-lifecycle/src/lib/pr-status-checks.ts
@@ -8,7 +8,11 @@ import {
   type PrStatusCheckDiagnostic,
   type TerminalPrStatusCheck,
 } from "@ready-for-agent/github-service"
-import { KeymaxxerService } from "@ready-for-agent/keymaxxer-service"
+import {
+  AgentTurnGitHubCredentialMissingError,
+  agentTurnGitHubCredentialGuidance,
+  resolveAgentTurnGitHubAuth,
+} from "./agent-turn-github-auth.js"
 import type { LifecycleStepContext } from "./lifecycle-steps.js"
 import { DEFAULT_LIFECYCLE_MAX_DURATIONS } from "./types.js"
 import { workItemBranchName } from "./worktree-names.js"
@@ -574,19 +578,19 @@ export const investigatePrStatusChecks = (context: LifecycleStepContext) =>
         handledCheckIds: [],
       } satisfies PrStatusCheckInvestigationResult
     }
-    const keymaxxer = yield* KeymaxxerService
-    const tokenName =
-      keymaxxer.enabled === false
-        ? undefined
-        : yield* keymaxxer.findSecret({
-            provider: "github",
-            account: `${repository.githubOwner}/${repository.githubRepo}`,
-          })
-    if (tokenName === null) {
-      return yield* new PrStatusChecksContextError({
-        message: `No GitHub credential is configured for ${repository.githubOwner}/${repository.githubRepo}`,
-      })
-    }
+    const auth = yield* resolveAgentTurnGitHubAuth({
+      githubOwner: repository.githubOwner,
+      githubRepo: repository.githubRepo,
+    }).pipe(
+      Effect.mapError((cause) => {
+        if (cause instanceof AgentTurnGitHubCredentialMissingError) {
+          return new PrStatusChecksContextError({ message: cause.message })
+        }
+        return new PrStatusChecksContextError({
+          message: "Failed to resolve the repository GitHub credential",
+        })
+      }),
+    )
     const redChecks = unhandled.filter((check) => check.outcome === "red")
     let diagnostics: readonly PrStatusCheckDiagnostic[] = []
     if (redChecks.length > 0) {
@@ -621,11 +625,10 @@ export const investigatePrStatusChecks = (context: LifecycleStepContext) =>
         sessionId,
         prompt: [
           buildInvestigationWorkPrompt(unhandled, diagnostics),
-          ...(tokenName === undefined
-            ? []
-            : [
-                `Use Keymaxxer secret ${tokenName} via keymaxxer_run for any GitHub CLI, API, commit, or push access; never put secret values in the environment.`,
-              ]),
+          agentTurnGitHubCredentialGuidance(
+            auth,
+            "GitHub CLI, API, commit, or push access",
+          ),
         ].join("\n"),
         cwd: worktreePath,
         model: context.model,

--- a/packages/work-item-lifecycle/src/lib/resolve-pr-merge-conflict.ts
+++ b/packages/work-item-lifecycle/src/lib/resolve-pr-merge-conflict.ts
@@ -1,7 +1,12 @@
 import { Effect, Schema } from "effect"
 import { AgentBackend } from "@ready-for-agent/agent-backend"
 import { DbService } from "@ready-for-agent/db-service"
-import { KeymaxxerService } from "@ready-for-agent/keymaxxer-service"
+import {
+  type AgentTurnGitHubAuth,
+  AgentTurnGitHubCredentialMissingError,
+  agentTurnGitHubCredentialGuidance,
+  resolveAgentTurnGitHubAuth,
+} from "./agent-turn-github-auth.js"
 import type { LifecycleStepContext } from "./lifecycle-steps.js"
 import { DEFAULT_LIFECYCLE_MAX_DURATIONS } from "./types.js"
 
@@ -51,7 +56,7 @@ const parseResult = (
     : { reason: needsHuman[1].trim().slice(0, 500) }
 }
 
-const workPrompt = (tokenName: string | undefined): string =>
+const workPrompt = (auth: AgentTurnGitHubAuth): string =>
   [
     "Resolve the merge conflict on the existing pull request for this worktree by rebasing its branch.",
     "Fetch origin and inspect the pull request to determine its current base branch (normally the repository default branch).",
@@ -60,11 +65,10 @@ const workPrompt = (tokenName: string | undefined): string =>
     "Push the rebased pull-request branch with --force-with-lease. Do not use an unconditional force push.",
     "If the lease is rejected, refetch, incorporate the updated remote PR branch, rebase onto the current remote base again, verify, and retry the --force-with-lease push exactly once. If that second push cannot safely succeed, stop and report that human intervention is needed in the follow-up verdict turn.",
     "Do not create or merge another pull request and do not do unrelated work.",
-    ...(tokenName === undefined
-      ? []
-      : [
-          `Use Keymaxxer secret ${tokenName} via keymaxxer_run for any GitHub CLI, API, fetch, or push access; never put secret values in the environment.`,
-        ]),
+    agentTurnGitHubCredentialGuidance(
+      auth,
+      "GitHub CLI, API, fetch, or push access",
+    ),
     "When finished, stop. Do not print a READY_FOR_AGENT_RESULT line yet; a follow-up turn will ask for the verdict.",
   ].join("\n")
 
@@ -101,19 +105,21 @@ export const resolvePrMergeConflict = (context: LifecycleStepContext) =>
         message: `Repository ${context.repositoryId} was not found`,
       })
     }
-    const keymaxxer = yield* KeymaxxerService
-    const tokenName =
-      keymaxxer.enabled === false
-        ? undefined
-        : yield* keymaxxer.findSecret({
-            provider: "github",
-            account: `${repository.githubOwner}/${repository.githubRepo}`,
+    const auth = yield* resolveAgentTurnGitHubAuth({
+      githubOwner: repository.githubOwner,
+      githubRepo: repository.githubRepo,
+    }).pipe(
+      Effect.mapError((cause) => {
+        if (cause instanceof AgentTurnGitHubCredentialMissingError) {
+          return new ResolvePrMergeConflictContextError({
+            message: cause.message,
           })
-    if (tokenName === null) {
-      return yield* new ResolvePrMergeConflictContextError({
-        message: `No GitHub credential is configured for ${repository.githubOwner}/${repository.githubRepo}`,
-      })
-    }
+        }
+        return new ResolvePrMergeConflictContextError({
+          message: "Failed to resolve the repository GitHub credential",
+        })
+      }),
+    )
     const agentBackend = yield* AgentBackend
     const timeout =
       context.maxDuration ??
@@ -121,7 +127,7 @@ export const resolvePrMergeConflict = (context: LifecycleStepContext) =>
     yield* agentBackend
       .continueTurn({
         sessionId: context.sessionId,
-        prompt: workPrompt(tokenName),
+        prompt: workPrompt(auth),
         cwd: context.worktreePath,
         model: context.model,
         thinkingLevel: context.thinkingLevel,

--- a/packages/work-item-lifecycle/test/agent-turn-github-auth.spec.ts
+++ b/packages/work-item-lifecycle/test/agent-turn-github-auth.spec.ts
@@ -1,0 +1,124 @@
+import { Effect, Layer } from "effect"
+import {
+  KeymaxxerService,
+  type KeymaxxerServiceShape,
+} from "@ready-for-agent/keymaxxer-service"
+import {
+  agentTurnGitHubCredentialGuidance,
+  isAgentTurnKeymaxxerEffective,
+  resolveAgentTurnGitHubAuth,
+  stubActiveAgentBackendLayer,
+  stubGrokActiveAgentBackendLayer,
+} from "../src/index.js"
+import { describe, expect, it } from "bun:test"
+
+const vaultEnabled = Layer.succeed(KeymaxxerService, {
+  initialize: Effect.void,
+  hasSecret: () => Effect.succeed(true),
+  findSecret: () => Effect.succeed("GITHUB_TOKEN_ACME_WIDGETS"),
+  findSecrets: () => Effect.succeed([]),
+  addSecret: () => Effect.succeed(true),
+  runWithSecrets: () => Effect.succeed({ exitCode: 0, stdout: "", stderr: "" }),
+} satisfies KeymaxxerServiceShape)
+
+describe("isAgentTurnKeymaxxerEffective", () => {
+  it("requires both capability and enablement", () => {
+    expect(isAgentTurnKeymaxxerEffective(true, true)).toBe(true)
+    expect(isAgentTurnKeymaxxerEffective(true, undefined)).toBe(true)
+    expect(isAgentTurnKeymaxxerEffective(true, false)).toBe(false)
+    expect(isAgentTurnKeymaxxerEffective(false, true)).toBe(false)
+    expect(isAgentTurnKeymaxxerEffective(false, false)).toBe(false)
+  })
+})
+
+describe("resolveAgentTurnGitHubAuth", () => {
+  it("returns keymaxxer auth for a capable backend when the vault is enabled", async () => {
+    const auth = await Effect.runPromise(
+      resolveAgentTurnGitHubAuth({
+        githubOwner: "acme",
+        githubRepo: "widgets",
+      }).pipe(
+        Effect.provide(
+          Layer.mergeAll(vaultEnabled, stubActiveAgentBackendLayer()),
+        ),
+      ),
+    )
+    expect(auth).toEqual({
+      _tag: "keymaxxer",
+      tokenName: "GITHUB_TOKEN_ACME_WIDGETS",
+    })
+  })
+
+  it("returns ambient auth when the backend lacks KeymaxxerMcp", async () => {
+    let findSecretCalled = false
+    const auth = await Effect.runPromise(
+      resolveAgentTurnGitHubAuth({
+        githubOwner: "acme",
+        githubRepo: "widgets",
+      }).pipe(
+        Effect.provide(
+          Layer.mergeAll(
+            Layer.succeed(KeymaxxerService, {
+              initialize: Effect.void,
+              hasSecret: () => Effect.succeed(true),
+              findSecret: () => {
+                findSecretCalled = true
+                return Effect.succeed("GITHUB_TOKEN_ACME_WIDGETS")
+              },
+              findSecrets: () => Effect.succeed([]),
+              addSecret: () => Effect.succeed(true),
+              runWithSecrets: () =>
+                Effect.succeed({ exitCode: 0, stdout: "", stderr: "" }),
+            } satisfies KeymaxxerServiceShape),
+            stubGrokActiveAgentBackendLayer,
+          ),
+        ),
+      ),
+    )
+    expect(auth).toEqual({ _tag: "ambient" })
+    expect(findSecretCalled).toBe(false)
+  })
+
+  it("returns ambient auth when Keymaxxer is disabled on a capable backend", async () => {
+    const auth = await Effect.runPromise(
+      resolveAgentTurnGitHubAuth({
+        githubOwner: "acme",
+        githubRepo: "widgets",
+      }).pipe(
+        Effect.provide(
+          Layer.mergeAll(
+            Layer.succeed(KeymaxxerService, {
+              enabled: false,
+              initialize: Effect.void,
+              hasSecret: () => Effect.succeed(false),
+              findSecret: () => Effect.die("must not inspect the vault"),
+              findSecrets: () => Effect.succeed([]),
+              addSecret: () => Effect.succeed(false),
+              runWithSecrets: () =>
+                Effect.succeed({ exitCode: 0, stdout: "", stderr: "" }),
+            } satisfies KeymaxxerServiceShape),
+            stubActiveAgentBackendLayer(),
+          ),
+        ),
+      ),
+    )
+    expect(auth).toEqual({ _tag: "ambient" })
+  })
+})
+
+describe("agentTurnGitHubCredentialGuidance", () => {
+  it("mentions Keymaxxer only for vault-backed auth", () => {
+    expect(
+      agentTurnGitHubCredentialGuidance(
+        { _tag: "keymaxxer", tokenName: "GITHUB_TOKEN_ACME_WIDGETS" },
+        "GitHub CLI or API access",
+      ),
+    ).toContain("keymaxxer_run")
+    const ambient = agentTurnGitHubCredentialGuidance(
+      { _tag: "ambient" },
+      "GitHub CLI or API access",
+    )
+    expect(ambient.toLowerCase()).not.toContain("keymaxxer")
+    expect(ambient).toContain("ambient authentication")
+  })
+})

--- a/packages/work-item-lifecycle/test/create-pr.spec.ts
+++ b/packages/work-item-lifecycle/test/create-pr.spec.ts
@@ -3,7 +3,10 @@ import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { BunServices } from "@effect/platform-bun"
 import { Duration, Effect, Layer } from "effect"
-import { AgentBackend } from "@ready-for-agent/agent-backend"
+import {
+  type ActiveAgentBackend,
+  AgentBackend,
+} from "@ready-for-agent/agent-backend"
 import type { DbService } from "@ready-for-agent/db-service"
 import {
   makeRepositoryRecord,
@@ -28,6 +31,8 @@ import {
   CreatePrWorktreeContextMissingError,
   createPr,
   makeWorkItemId,
+  stubActiveAgentBackendLayer,
+  stubGrokActiveAgentBackendLayer,
 } from "../src/index.js"
 import { describe, expect, it } from "bun:test"
 
@@ -138,12 +143,17 @@ const run = <A, E>(
   effect: Effect.Effect<
     A,
     E,
-    DbService | GitHubService | KeymaxxerService | AgentBackend
+    | DbService
+    | GitHubService
+    | KeymaxxerService
+    | AgentBackend
+    | ActiveAgentBackend
   >,
   layers: {
     keymaxxer?: Layer.Layer<KeymaxxerService>
     opencode?: Layer.Layer<AgentBackend>
     github?: Layer.Layer<GitHubService>
+    activeBackend?: Layer.Layer<ActiveAgentBackend>
   } = {},
 ): Promise<A> =>
   Effect.runPromise(
@@ -154,6 +164,7 @@ const run = <A, E>(
           layers.github ?? stubGitHub(),
           layers.keymaxxer ?? stubKeymaxxer(),
           layers.opencode ?? stubOpencode(),
+          layers.activeBackend ?? stubActiveAgentBackendLayer(),
         ),
       ),
       Effect.provide(PlatformLayer),
@@ -281,7 +292,7 @@ describe("createPr", () => {
       )
     }))
 
-  it("uses a generic prompt when Keymaxxer is disabled", () =>
+  it("uses ambient gh guidance when Keymaxxer is disabled on a capable backend", () =>
     withTemp(async (root) => {
       let prompt = ""
       const pullRequestNumber = await run(createPr(baseContext(root)), {
@@ -289,6 +300,66 @@ describe("createPr", () => {
           enabled: false,
           findSecret: () => Effect.die("must not inspect the vault"),
         }),
+        opencode: stubOpencode({
+          continueTurn: (input) => {
+            prompt = input.prompt
+            return Effect.succeed({
+              sessionId: input.sessionId,
+              assistantText: "",
+            })
+          },
+        }),
+      })
+
+      expect(pullRequestNumber).toBe(321)
+      expect(prompt.toLowerCase()).not.toContain("keymaxxer")
+      expect(prompt).not.toContain("keymaxxer_run")
+      expect(prompt).toContain(
+        "Use the gh CLI with the existing ambient authentication",
+      )
+    }))
+
+  it("uses ambient gh guidance when the backend lacks KeymaxxerMcp even if the vault is enabled", () =>
+    withTemp(async (root) => {
+      let prompt = ""
+      let findSecretCalled = false
+      const pullRequestNumber = await run(createPr(baseContext(root)), {
+        keymaxxer: stubKeymaxxer({
+          findSecret: () => {
+            findSecretCalled = true
+            return Effect.succeed("GITHUB_TOKEN_ACME_WIDGETS")
+          },
+        }),
+        activeBackend: stubGrokActiveAgentBackendLayer,
+        opencode: stubOpencode({
+          continueTurn: (input) => {
+            prompt = input.prompt
+            return Effect.succeed({
+              sessionId: input.sessionId,
+              assistantText: "",
+            })
+          },
+        }),
+      })
+
+      expect(pullRequestNumber).toBe(321)
+      expect(findSecretCalled).toBe(false)
+      expect(prompt.toLowerCase()).not.toContain("keymaxxer")
+      expect(prompt).not.toContain("keymaxxer_run")
+      expect(prompt).not.toContain("GITHUB_TOKEN_ACME_WIDGETS")
+      expect(prompt).toContain(
+        "Use the gh CLI with the existing ambient authentication",
+      )
+    }))
+
+  it("does not fail Agent Turns for a missing vault credential when KeymaxxerMcp is unavailable", () =>
+    withTemp(async (root) => {
+      let prompt = ""
+      const pullRequestNumber = await run(createPr(baseContext(root)), {
+        keymaxxer: stubKeymaxxer({
+          findSecret: () => Effect.succeed(null),
+        }),
+        activeBackend: stubGrokActiveAgentBackendLayer,
         opencode: stubOpencode({
           continueTurn: (input) => {
             prompt = input.prompt

--- a/packages/work-item-lifecycle/test/decide-pr-merge.spec.ts
+++ b/packages/work-item-lifecycle/test/decide-pr-merge.spec.ts
@@ -13,6 +13,8 @@ import {
   decidePrMerge,
   makeWorkItemId,
   parseDecidePrMergeResult,
+  stubActiveAgentBackendLayer,
+  stubGrokActiveAgentBackendLayer,
 } from "../src/index.js"
 import { describe, expect, it } from "bun:test"
 
@@ -108,7 +110,14 @@ describe("decidePrMerge", () => {
 
     const result = await Effect.runPromise(
       decidePrMerge(context).pipe(
-        Effect.provide(Layer.mergeAll(db, keymaxxer, agentBackend)),
+        Effect.provide(
+          Layer.mergeAll(
+            db,
+            keymaxxer,
+            agentBackend,
+            stubActiveAgentBackendLayer(),
+          ),
+        ),
       ),
     )
 
@@ -117,6 +126,112 @@ describe("decidePrMerge", () => {
     expect(prompt).toContain("CLANKER_MERGE")
     expect(prompt).toContain(
       "Use Keymaxxer secret GITHUB_TOKEN_ACME_WIDGETS via keymaxxer_run",
+    )
+  })
+
+  it("uses ambient gh guidance when the backend lacks KeymaxxerMcp", async () => {
+    let prompt = ""
+    let findSecretCalled = false
+    const agentBackend = Layer.succeed(
+      AgentBackend,
+      AgentBackend.of({
+        startTurn: () => Effect.die("unused"),
+        continueTurn: (input) => {
+          prompt = input.prompt
+          return Effect.succeed({
+            sessionId: input.sessionId,
+            assistantText: "READY_FOR_AGENT_RESULT: CLANKER_MERGE",
+          })
+        },
+        inspect: () =>
+          Effect.succeed({
+            backend: { id: "grok" as const, label: "Grok Build" },
+            models: [],
+          }),
+      }),
+    )
+    const vaultOn = Layer.succeed(KeymaxxerService, {
+      initialize: Effect.void,
+      hasSecret: () => Effect.succeed(true),
+      findSecret: () => {
+        findSecretCalled = true
+        return Effect.succeed("GITHUB_TOKEN_ACME_WIDGETS")
+      },
+      findSecrets: () => Effect.succeed([]),
+      addSecret: () => Effect.succeed(true),
+      runWithSecrets: () =>
+        Effect.succeed({ exitCode: 0, stdout: "", stderr: "" }),
+    } satisfies KeymaxxerServiceShape)
+
+    const result = await Effect.runPromise(
+      decidePrMerge(context).pipe(
+        Effect.provide(
+          Layer.mergeAll(
+            db,
+            vaultOn,
+            agentBackend,
+            stubGrokActiveAgentBackendLayer,
+          ),
+        ),
+      ),
+    )
+
+    expect(result).toEqual({ _tag: "clanker_merge" })
+    expect(findSecretCalled).toBe(false)
+    expect(prompt.toLowerCase()).not.toContain("keymaxxer")
+    expect(prompt).toContain(
+      "Use the gh CLI with the existing ambient authentication",
+    )
+  })
+
+  it("uses ambient gh guidance when Keymaxxer is disabled on a capable backend", async () => {
+    let prompt = ""
+    const agentBackend = Layer.succeed(
+      AgentBackend,
+      AgentBackend.of({
+        startTurn: () => Effect.die("unused"),
+        continueTurn: (input) => {
+          prompt = input.prompt
+          return Effect.succeed({
+            sessionId: input.sessionId,
+            assistantText: "READY_FOR_AGENT_RESULT: CLANKER_MERGE",
+          })
+        },
+        inspect: () =>
+          Effect.succeed({
+            backend: { id: "opencode" as const, label: "OpenCode" },
+            models: [],
+          }),
+      }),
+    )
+    const disabled = Layer.succeed(KeymaxxerService, {
+      enabled: false,
+      initialize: Effect.void,
+      hasSecret: () => Effect.succeed(false),
+      findSecret: () => Effect.die("must not inspect the vault"),
+      findSecrets: () => Effect.succeed([]),
+      addSecret: () => Effect.succeed(false),
+      runWithSecrets: () =>
+        Effect.succeed({ exitCode: 0, stdout: "", stderr: "" }),
+    } satisfies KeymaxxerServiceShape)
+
+    const result = await Effect.runPromise(
+      decidePrMerge(context).pipe(
+        Effect.provide(
+          Layer.mergeAll(
+            db,
+            disabled,
+            agentBackend,
+            stubActiveAgentBackendLayer(),
+          ),
+        ),
+      ),
+    )
+
+    expect(result).toEqual({ _tag: "clanker_merge" })
+    expect(prompt.toLowerCase()).not.toContain("keymaxxer")
+    expect(prompt).toContain(
+      "Use the gh CLI with the existing ambient authentication",
     )
   })
 
@@ -141,7 +256,14 @@ describe("decidePrMerge", () => {
 
     const result = await Effect.runPromise(
       decidePrMerge(context).pipe(
-        Effect.provide(Layer.mergeAll(db, keymaxxer, agentBackend)),
+        Effect.provide(
+          Layer.mergeAll(
+            db,
+            keymaxxer,
+            agentBackend,
+            stubActiveAgentBackendLayer(),
+          ),
+        ),
       ),
     )
 
@@ -174,7 +296,14 @@ describe("decidePrMerge", () => {
 
     const result = await Effect.runPromise(
       decidePrMerge(context).pipe(
-        Effect.provide(Layer.mergeAll(pausedRepoDb, keymaxxer, agentBackend)),
+        Effect.provide(
+          Layer.mergeAll(
+            pausedRepoDb,
+            keymaxxer,
+            agentBackend,
+            stubActiveAgentBackendLayer(),
+          ),
+        ),
       ),
     )
 

--- a/packages/work-item-lifecycle/test/pr-status-checks.spec.ts
+++ b/packages/work-item-lifecycle/test/pr-status-checks.spec.ts
@@ -24,6 +24,8 @@ import {
   makeWorkItemId,
   parseInvestigationResult,
   resolvePrMergeConflict,
+  stubActiveAgentBackendLayer,
+  stubGrokActiveAgentBackendLayer,
   watchPrStatusChecks,
 } from "../src/index.js"
 import { describe, expect, it } from "bun:test"
@@ -56,7 +58,7 @@ const db = stubDbServiceLayer({
   listRepositories: Effect.succeed([repository]),
 })
 
-const keymaxxer = Layer.succeed(KeymaxxerService, {
+const keymaxxerService = Layer.succeed(KeymaxxerService, {
   initialize: Effect.void,
   hasSecret: () => Effect.succeed(true),
   findSecret: () => Effect.succeed("GITHUB_TOKEN_ACME_WIDGETS"),
@@ -64,6 +66,12 @@ const keymaxxer = Layer.succeed(KeymaxxerService, {
   addSecret: () => Effect.succeed(true),
   runWithSecrets: () => Effect.succeed({ exitCode: 0, stdout: "", stderr: "" }),
 } satisfies KeymaxxerServiceShape)
+
+/** Vault-enabled Keymaxxer plus capable (OpenCode) Active Agent Backend. */
+const keymaxxer = Layer.mergeAll(
+  keymaxxerService,
+  stubActiveAgentBackendLayer(),
+)
 
 const seedWorkItem = Effect.gen(function* () {
   const sql = yield* SqlClient.SqlClient
@@ -576,6 +584,59 @@ describe("PR status check steps", () => {
     expect(prompts[1]).toContain("replacement check executions")
   })
 
+  it("uses ambient gh guidance for investigate when the backend lacks KeymaxxerMcp", async () => {
+    const prompts: string[] = []
+    let findSecretCalled = false
+    const vaultOnWithoutLookup = Layer.mergeAll(
+      Layer.succeed(KeymaxxerService, {
+        initialize: Effect.void,
+        hasSecret: () => Effect.succeed(true),
+        findSecret: () => {
+          findSecretCalled = true
+          return Effect.succeed("GITHUB_TOKEN_ACME_WIDGETS")
+        },
+        findSecrets: () => Effect.succeed([]),
+        addSecret: () => Effect.succeed(true),
+        runWithSecrets: () =>
+          Effect.succeed({ exitCode: 0, stdout: "", stderr: "" }),
+      } satisfies KeymaxxerServiceShape),
+      stubGrokActiveAgentBackendLayer,
+    )
+    const result = await Effect.runPromise(
+      Effect.gen(function* () {
+        yield* seedWorkItem
+        yield* watchPrStatusChecks(context)
+        return yield* investigatePrStatusChecks(context)
+      }).pipe(
+        Effect.provide(
+          Layer.mergeAll(
+            db,
+            githubWith({
+              _tag: "failed",
+              ...mergeable,
+              terminalChecks: [
+                { externalId: "checkrun:1", name: "lint", outcome: "red" },
+              ],
+            }),
+            vaultOnWithoutLookup,
+            opencodeWith(
+              ["fixed and pushed", "READY_FOR_AGENT_RESULT: CHECKS_TRIGGERED"],
+              (prompt) => prompts.push(prompt),
+            ),
+            DatabaseTest,
+          ),
+        ),
+      ),
+    )
+
+    expect(result._tag).toBe("checks_triggered")
+    expect(findSecretCalled).toBe(false)
+    expect(prompts[0]?.toLowerCase()).not.toContain("keymaxxer")
+    expect(prompts[0]).toContain(
+      "Use the gh CLI with the existing ambient authentication",
+    )
+  })
+
   it("makes a focused recovery attempt after FAILED and accepts recovered progress", async () => {
     const prompts: string[] = []
     const result = await Effect.runPromise(
@@ -999,6 +1060,46 @@ describe("PR status check steps", () => {
       "Use Keymaxxer secret GITHUB_TOKEN_ACME_WIDGETS via keymaxxer_run",
     )
     expect(prompts[1]).toContain("READY_FOR_AGENT_RESULT: PROCESSED")
+  })
+
+  it("uses ambient gh guidance for merge-conflict when Keymaxxer is disabled", async () => {
+    const prompts: string[] = []
+    const disabled = Layer.mergeAll(
+      Layer.succeed(KeymaxxerService, {
+        enabled: false,
+        initialize: Effect.void,
+        hasSecret: () => Effect.succeed(false),
+        findSecret: () => Effect.die("must not inspect the vault"),
+        findSecrets: () => Effect.succeed([]),
+        addSecret: () => Effect.succeed(false),
+        runWithSecrets: () =>
+          Effect.succeed({ exitCode: 0, stdout: "", stderr: "" }),
+      } satisfies KeymaxxerServiceShape),
+      stubActiveAgentBackendLayer(),
+    )
+    const result = await Effect.runPromise(
+      resolvePrMergeConflict(context).pipe(
+        Effect.provide(
+          Layer.mergeAll(
+            db,
+            disabled,
+            opencodeWith(
+              [
+                "rebased, verified, and pushed",
+                "READY_FOR_AGENT_RESULT: PROCESSED",
+              ],
+              (prompt) => prompts.push(prompt),
+            ),
+          ),
+        ),
+      ),
+    )
+
+    expect(result).toEqual({ _tag: "processed" })
+    expect(prompts[0]?.toLowerCase()).not.toContain("keymaxxer")
+    expect(prompts[0]).toContain(
+      "Use the gh CLI with the existing ambient authentication",
+    )
   })
 
   it("returns the merge-conflict resolver's human intervention reason", async () => {


### PR DESCRIPTION
## Summary

- Drive Agent Turn credential lookup, prompt wording, and GH token stripping from effective Keymaxxer availability (`KeymaxxerMcp` capability **and** runtime enablement).
- When unavailable, use ambient `gh` guidance, skip vault credential requirements, and preserve ambient GitHub token env vars (Grok never strips; OpenCode strips only with vault MCP configured).
- Remove Keymaxxer from root `AGENTS.md`. Closes #451.

## Test plan

- [x] `work-item-lifecycle`, `agent-backend`, `opencode`, `grok` unit tests
- [x] Pre-commit / affected lint, typecheck, test
- [ ] Confirm Grok + sidecar-enabled harness does not inject Keymaxxer into lifecycle prompts
- [ ] Confirm OpenCode + Keymaxxer disabled uses ambient `gh` guidance and inherits tokens