### PR TITLE
docs: define Agent-reported Outcome protocol

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -119,6 +119,10 @@ _Avoid_: Agent run, prompt run, OpenCode process
 The normalized successful output of an Agent Turn: its Session ID and ordered final assistant text, recovered from the Agent Backend's machine-readable output. Backend-specific events and terminal presentation are not part of the result.
 _Avoid_: CLI stdout, transcript, tool-event stream
 
+**Agent-reported Outcome**:
+A lifecycle-specific, machine-readable conclusion included in an Agent Turn's final assistant text so the Harness can choose the next lifecycle transition. It is semantic lifecycle data carried inside, but distinct from, the transport-level Agent Turn Result.
+_Avoid_: Ruling, verdict, Agent Turn Result
+
 **Agent-free Lifecycle Step**:
 A Lifecycle Step guaranteed not to invoke an Agent Turn. A step that may need an Agent Turn conditionally is not Agent-free and does not start while the Agent Backend is Unavailable.
 _Avoid_: Step that usually avoids the agent, non-OpenCode step

--- a/docs/adr/0036-report-agent-outcomes-in-work-turns.md
+++ b/docs/adr/0036-report-agent-outcomes-in-work-turns.md
@@ -1,0 +1,9 @@
+# Report Agent-reported Outcomes in work turns
+
+Status: accepted
+
+An Agent Turn that performs lifecycle work also reports the Agent-reported Outcome needed to choose the next lifecycle transition in its final response. A separate outcome-classification Agent Turn is justified only when intervening Harness-controlled work or observation creates evidence required for the decision, or as one bounded recovery when an otherwise valid work turn omits its outcome; malformed, duplicate, or contradictory outcomes fail strictly. This protocol applies to every Agent Backend.
+
+PR Status Check investigation, its focused recovery attempt, and PR merge-conflict resolution therefore combine work and outcome reporting instead of unconditionally continuing the Session for a verdict. The response may contain a concise work and verification summary followed by exactly one final outcome line. Existing lifecycle semantics and the single status-check recovery budget remain unchanged. Review's missing-outcome fallback remains a bounded recovery, while Review Rerun Assessment remains separate because nested Pre-Commit can create new decision evidence.
+
+In the 24 measurable OpenCode Work Item Sessions among the 25 latest Work Item PRs inspected on 2026-07-24, the 33 unconditional status-check and merge-conflict verdict turns consumed 6,938,788 tokens: 15.9% on top of their associated work turns and 2.3% of main-Session usage. Nearly all measured ruling-only usage was input or cache context rather than generated output, so combining turns removes repeated context processing without requiring lifecycle-token telemetry or schema changes.


### PR DESCRIPTION
## Why

PR Status Check investigation and merge-conflict resolution currently use unconditional classification-only Agent Turns after their work turns. Analysis of the latest Work Item PRs found that these turns repeatedly process substantial Session context to generate very short outcomes.

Capture the agreed boundary before implementation: lifecycle work reports its Agent-reported Outcome in the same turn unless intervening Harness activity creates evidence needed for the decision or a missing outcome requires bounded recovery.

## What Changed

- define `Agent-reported Outcome` separately from the transport-level Agent Turn Result
- record the cross-backend work-and-outcome protocol and its exceptions in ADR 0036
- preserve the measured token evidence that motivated the decision

Implementation is tracked in #455.
