### PR TITLE
feat(agent-backend): hot-activate Agent Backend without restart

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,8 +153,9 @@ KEYMAXXER_ENABLED=false npx ready-for-agent@latest
 1. Is there support for agents other than OpenCode?
 
 Yes. Settings can select **OpenCode** or **Grok Build** as the instance-wide
-Agent Backend. The change activates after restart (and is rejected while any
-Work Item is unfinished). Model catalogs and Thinking Levels are backend-local.
+Agent Backend. The change hot-activates on Save when no Work Items are
+unfinished (including Needs Human). Model catalogs and Thinking Levels are
+backend-local, and build/review prefs are remembered per backend.
 
 2. Does the harness support any other backend than GitHub?
 

--- a/apps/harness/src/routes/__root.tsx
+++ b/apps/harness/src/routes/__root.tsx
@@ -42,6 +42,7 @@ const configQuery = {
         reviewThinkingLevel: true,
         maxConcurrentAgentTurns: true,
         maxConcurrentWorkItems: true,
+        unfinishedWorkItemCount: true,
       },
     })
     return result.config
@@ -199,9 +200,17 @@ function SettingsButton() {
   const [maxConcurrentAgentTurns, setMaxConcurrentOpencodeSessions] =
     useState("2")
   const [maxConcurrentWorkItems, setMaxConcurrentWorkItems] = useState("5")
+  const [previewModels, setPreviewModels] = useState<
+    readonly AgentModelOption[] | null
+  >(null)
+  const [previewError, setPreviewError] = useState<string | null>(null)
+  const [previewPending, setPreviewPending] = useState(false)
+  const previewGenerationRef = useRef(0)
   const buildConfigured = isBuildModelConfigured(config.data)
   const status = backendStatus.data?.agentBackendStatus
   const backendKind = status?.kind
+  const unfinishedWorkItemCount = config.data?.unfinishedWorkItemCount ?? 0
+  const backendChangeBlocked = unfinishedWorkItemCount > 0
 
   useEffect(() => {
     if (!dialogOpen || !config.data) {
@@ -216,6 +225,10 @@ function SettingsButton() {
       String(config.data.maxConcurrentAgentTurns),
     )
     setMaxConcurrentWorkItems(String(config.data.maxConcurrentWorkItems))
+    previewGenerationRef.current += 1
+    setPreviewModels(null)
+    setPreviewError(null)
+    setPreviewPending(false)
   }, [config.data, dialogOpen])
 
   const updateConfig = useMutation({
@@ -238,6 +251,7 @@ function SettingsButton() {
           reviewThinkingLevel: true,
           maxConcurrentAgentTurns: true,
           maxConcurrentWorkItems: true,
+          unfinishedWorkItemCount: true,
         },
       }),
     onSuccess: ({ updateConfig: updatedConfig }) => {
@@ -278,8 +292,97 @@ function SettingsButton() {
     },
   })
 
+  const applyModelPrefs = (prefs: {
+    defaultModel: string | null
+    defaultThinkingLevel: string | null
+    reviewModel: string | null
+    reviewThinkingLevel: string | null
+  }) => {
+    setDefaultModel(prefs.defaultModel ?? "")
+    setDefaultVariant(prefs.defaultThinkingLevel ?? "")
+    setReviewModel(prefs.reviewModel ?? "")
+    setReviewVariant(prefs.reviewThinkingLevel ?? "")
+  }
+
+  const applyAgentBackendSelection = async (nextBackend: string) => {
+    const generation = ++previewGenerationRef.current
+    setSelectedAgentBackend(nextBackend)
+    const savedAgentBackend = config.data?.selectedAgentBackend ?? "opencode"
+    if (nextBackend === savedAgentBackend) {
+      if (config.data) {
+        applyModelPrefs({
+          defaultModel: config.data.defaultModel,
+          defaultThinkingLevel: config.data.defaultThinkingLevel,
+          reviewModel: config.data.reviewModel,
+          reviewThinkingLevel: config.data.reviewThinkingLevel,
+        })
+      }
+      setPreviewModels(null)
+      setPreviewError(null)
+      setPreviewPending(false)
+      return
+    }
+
+    setPreviewPending(true)
+    setPreviewError(null)
+    try {
+      const [prefsResult, previewResult] = await Promise.all([
+        graphql.query({
+          harnessModelPrefs: {
+            __args: { backendId: nextBackend },
+            defaultModel: true,
+            defaultThinkingLevel: true,
+            reviewModel: true,
+            reviewThinkingLevel: true,
+          },
+        }),
+        graphql.query({
+          previewAgentBackend: {
+            __args: { backendId: nextBackend },
+            backend: { id: true, label: true },
+            kind: true,
+            reason: true,
+            models: { id: true, thinkingLevels: true },
+          },
+        }),
+      ])
+      // Ignore stale responses after a newer dropdown selection.
+      if (generation !== previewGenerationRef.current) {
+        return
+      }
+      applyModelPrefs(prefsResult.harnessModelPrefs)
+      const preview = previewResult.previewAgentBackend
+      if (preview.kind === "READY") {
+        setPreviewModels(preview.models)
+        setPreviewError(null)
+      } else {
+        setPreviewModels([])
+        setPreviewError(
+          preview.reason ??
+            "Could not load model catalog for the selected Agent Backend",
+        )
+      }
+    } catch (error) {
+      if (generation !== previewGenerationRef.current) {
+        return
+      }
+      setPreviewModels([])
+      setPreviewError(
+        error instanceof Error
+          ? error.message
+          : "Could not preview the selected Agent Backend",
+      )
+    } finally {
+      if (generation === previewGenerationRef.current) {
+        setPreviewPending(false)
+      }
+    }
+  }
+
   const openSettings = () => {
     setDialogOpen(true)
+    // Discard any in-flight preview from a previous dialog session.
+    previewGenerationRef.current += 1
     if (config.isError) {
       void config.refetch()
     }
@@ -291,15 +394,20 @@ function SettingsButton() {
     }
     if (config.data) {
       setSelectedAgentBackend(config.data.selectedAgentBackend)
-      setDefaultModel(config.data.defaultModel ?? "")
-      setDefaultVariant(config.data.defaultThinkingLevel ?? "")
-      setReviewModel(config.data.reviewModel ?? "")
-      setReviewVariant(config.data.reviewThinkingLevel ?? "")
+      applyModelPrefs({
+        defaultModel: config.data.defaultModel,
+        defaultThinkingLevel: config.data.defaultThinkingLevel,
+        reviewModel: config.data.reviewModel,
+        reviewThinkingLevel: config.data.reviewThinkingLevel,
+      })
       setMaxConcurrentOpencodeSessions(
         String(config.data.maxConcurrentAgentTurns),
       )
       setMaxConcurrentWorkItems(String(config.data.maxConcurrentWorkItems))
     }
+    setPreviewModels(null)
+    setPreviewError(null)
+    setPreviewPending(false)
     updateConfig.reset()
     recheckBackend.reset()
     dialogRef.current?.showModal()
@@ -318,58 +426,32 @@ function SettingsButton() {
   const savedAgentBackend = config.data?.selectedAgentBackend ?? "opencode"
   const backendChanging = selectedAgentBackend !== savedAgentBackend
 
-  const applyAgentBackendSelection = (nextBackend: string) => {
-    setSelectedAgentBackend(nextBackend)
-    if (nextBackend === savedAgentBackend && config.data) {
-      setDefaultModel(config.data.defaultModel ?? "")
-      setDefaultVariant(config.data.defaultThinkingLevel ?? "")
-      setReviewModel(config.data.reviewModel ?? "")
-      setReviewVariant(config.data.reviewThinkingLevel ?? "")
-      return
-    }
-    setDefaultModel("")
-    setDefaultVariant("")
-    setReviewModel("")
-    setReviewVariant("")
-  }
-
   const saveSettings = (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault()
     const parsedMaxSessions = Number(maxConcurrentAgentTurns)
     const parsedMaxWorkItems = Number(maxConcurrentWorkItems)
     updateConfig.mutate({
       selectedAgentBackend,
-      defaultModel: backendChanging
-        ? null
-        : defaultModel.trim() === ""
-          ? null
-          : defaultModel,
-      defaultThinkingLevel: backendChanging
-        ? null
-        : defaultThinkingLevel.trim() === ""
-          ? null
-          : defaultThinkingLevel,
-      reviewModel: backendChanging
-        ? null
-        : reviewModel.trim() === ""
-          ? null
-          : reviewModel,
-      reviewThinkingLevel: backendChanging
-        ? null
-        : reviewThinkingLevel.trim() === ""
-          ? null
-          : reviewThinkingLevel,
+      defaultModel: defaultModel.trim() === "" ? null : defaultModel,
+      defaultThinkingLevel:
+        defaultThinkingLevel.trim() === "" ? null : defaultThinkingLevel,
+      reviewModel: reviewModel.trim() === "" ? null : reviewModel,
+      reviewThinkingLevel:
+        reviewThinkingLevel.trim() === "" ? null : reviewThinkingLevel,
       maxConcurrentAgentTurns: parsedMaxSessions,
       maxConcurrentWorkItems: parsedMaxWorkItems,
     })
   }
 
-  const modelIds = (models.data ?? []).map((model) => model.id)
-  const buildVariants = variantsForModel(models.data, defaultModel)
+  const catalogModels: readonly AgentModelOption[] | undefined = backendChanging
+    ? (previewModels ?? undefined)
+    : models.data
+  const modelIds = (catalogModels ?? []).map((model) => model.id)
+  const buildVariants = variantsForModel(catalogModels, defaultModel)
   const reviewThinkingLevelSourceModel =
     reviewModel.length > 0 ? reviewModel : defaultModel
   const reviewThinkingLevels = variantsForModel(
-    models.data,
+    catalogModels,
     reviewThinkingLevelSourceModel,
   )
   const hasUnavailableBuildModel =
@@ -385,9 +467,14 @@ function SettingsButton() {
       (reviewModel.length === 0 && hasUnavailableBuildModel) ||
       !reviewThinkingLevels.includes(reviewThinkingLevel))
   const showUnconfiguredGuidance = config.isSuccess && !buildConfigured
-  const showBackendBanner =
-    config.isSuccess &&
-    (backendKind === "UNAVAILABLE" || backendKind === "RESTART_REQUIRED")
+  const showBackendBanner = config.isSuccess && backendKind === "UNAVAILABLE"
+  const modelsDisabled =
+    backendChanging && (previewPending || previewError !== null)
+  const modelsLoading =
+    dialogOpen &&
+    (backendChanging
+      ? previewPending
+      : models.isPending || backendStatus.isPending)
 
   return (
     <>
@@ -396,12 +483,7 @@ function SettingsButton() {
           className="mr-auto flex flex-wrap items-center gap-2 border border-oxblood/40 bg-oxblood-wash px-3 py-1.5 text-xs text-oxblood-deep sm:text-sm"
           role="status"
         >
-          <span>
-            {backendKind === "RESTART_REQUIRED"
-              ? (status?.reason ??
-                "Restart the Harness to activate the selected Agent Backend")
-              : (status?.reason ?? "Agent Backend is unavailable")}
-          </span>
+          <span>{status?.reason ?? "Agent Backend is unavailable"}</span>
           <button
             type="button"
             className="border border-oxblood/50 bg-paper px-2 py-0.5 text-xs font-semibold text-oxblood underline-offset-2 hover:bg-oxblood hover:text-paper"
@@ -474,13 +556,7 @@ function SettingsButton() {
                 Select a default build model before the harness can create work.
               </p>
             )}
-            {status?.kind === "RESTART_REQUIRED" && (
-              <p className="mt-3 border border-oxblood/40 bg-oxblood-wash p-3 text-sm text-oxblood-deep">
-                {status.reason ??
-                  "Restart the Harness to activate the selected Agent Backend."}
-              </p>
-            )}
-            {status?.kind === "UNAVAILABLE" && (
+            {!backendChanging && status?.kind === "UNAVAILABLE" && (
               <p className="mt-3 border border-oxblood/40 bg-oxblood-wash p-3 text-sm text-oxblood-deep">
                 {status.reason ?? "Agent Backend is unavailable."}
               </p>
@@ -488,10 +564,11 @@ function SettingsButton() {
           </div>
 
           <div className="grid gap-5 px-6 py-5">
-            {config.isPending ||
-            (dialogOpen && (models.isPending || backendStatus.isPending)) ? (
+            {config.isPending || modelsLoading ? (
               <p className="text-sm text-ink-soft">Loading settings...</p>
-            ) : config.isError || models.isError || backendStatus.isError ? (
+            ) : config.isError ||
+              (!backendChanging &&
+                (models.isError || backendStatus.isError)) ? (
               <p className="border border-oxblood/40 bg-oxblood-wash p-3 text-sm text-oxblood-deep">
                 Settings could not be loaded. Close this dialog and try again.
               </p>
@@ -500,12 +577,13 @@ function SettingsButton() {
                 <label className="grid min-w-0 gap-1.5 text-sm font-semibold">
                   Agent Backend
                   <select
-                    className="w-full min-w-0 border border-rule-2 bg-paper px-3 py-2 text-sm font-normal outline-none focus:border-oxblood focus:ring-2 focus:ring-oxblood/15"
+                    className="w-full min-w-0 border border-rule-2 bg-paper px-3 py-2 text-sm font-normal outline-none focus:border-oxblood focus:ring-2 focus:ring-oxblood/15 disabled:cursor-not-allowed disabled:opacity-60"
                     name="selectedAgentBackend"
                     value={selectedAgentBackend}
-                    onChange={(event) =>
-                      applyAgentBackendSelection(event.target.value)
-                    }
+                    disabled={backendChangeBlocked || updateConfig.isPending}
+                    onChange={(event) => {
+                      void applyAgentBackendSelection(event.target.value)
+                    }}
                   >
                     {(backendStatus.data?.agentBackends ?? []).map(
                       (backend) => (
@@ -516,8 +594,9 @@ function SettingsButton() {
                     )}
                   </select>
                   <span className="text-xs font-normal text-ink-faint">
-                    Takes effect after restart. Changing backend clears all
-                    model selections when no Work Items are unfinished.
+                    {backendChangeBlocked
+                      ? `${unfinishedWorkItemCount} unfinished Work Item${unfinishedWorkItemCount === 1 ? "" : "s"} — finish or abandon them before changing Agent Backend.`
+                      : "Activates immediately on Save when no Work Items are unfinished. Model prefs are remembered per backend."}
                   </span>
                 </label>
 
@@ -528,14 +607,12 @@ function SettingsButton() {
                       {status?.activeBackend.label ?? "—"}
                     </span>
                     {status?.kind === "READY" ? " · Ready" : null}
+                    {backendChanging ? " · Previewing selection" : null}
                   </p>
                   <button
                     type="button"
                     className="border border-rule-2 bg-paper px-2 py-1 text-xs font-semibold text-ink-2 hover:bg-paper-2 disabled:opacity-50"
-                    disabled={
-                      recheckBackend.isPending ||
-                      status?.kind === "RESTART_REQUIRED"
-                    }
+                    disabled={recheckBackend.isPending || backendChanging}
                     onClick={() => {
                       recheckBackend.mutate()
                     }}
@@ -546,17 +623,25 @@ function SettingsButton() {
                   </button>
                 </div>
 
+                {backendChanging && previewError !== null && (
+                  <p className="border border-oxblood/40 bg-oxblood-wash p-3 text-sm text-oxblood-deep">
+                    Preview failed: {previewError}. Model fields stay disabled
+                    until preview succeeds. Active backend is unchanged until
+                    Save.
+                  </p>
+                )}
+
                 <label className="grid min-w-0 gap-1.5 text-sm font-semibold">
                   Build model
                   <select
-                    className="w-full min-w-0 border border-rule-2 bg-paper px-3 py-2 font-mono text-sm font-normal outline-none focus:border-oxblood focus:ring-2 focus:ring-oxblood/15"
+                    className="w-full min-w-0 border border-rule-2 bg-paper px-3 py-2 font-mono text-sm font-normal outline-none focus:border-oxblood focus:ring-2 focus:ring-oxblood/15 disabled:cursor-not-allowed disabled:opacity-60"
                     name="defaultModel"
                     value={defaultModel}
                     onChange={(event) => {
                       const nextModel = event.target.value
                       setDefaultModel(nextModel)
                       const nextVariants = variantsForModel(
-                        models.data,
+                        catalogModels,
                         nextModel,
                       )
                       setDefaultVariant((current) =>
@@ -569,12 +654,12 @@ function SettingsButton() {
                       }
                     }}
                     required={!backendChanging}
-                    disabled={backendChanging}
+                    disabled={modelsDisabled}
                   >
                     {defaultModel.length === 0 && (
                       <option value="">
-                        {backendChanging
-                          ? "Cleared — choose after restart"
+                        {previewPending
+                          ? "Loading catalog…"
                           : "Select a build model"}
                       </option>
                     )}
@@ -583,7 +668,7 @@ function SettingsButton() {
                         {defaultModel} (not in Agent Model catalog)
                       </option>
                     )}
-                    {(models.data ?? []).map((model) => (
+                    {(catalogModels ?? []).map((model) => (
                       <option key={model.id} value={model.id}>
                         {model.id}
                       </option>
@@ -608,13 +693,13 @@ function SettingsButton() {
                   <label className="grid min-w-0 gap-1.5 text-sm font-semibold">
                     Build thinking level
                     <select
-                      className="w-full min-w-0 border border-rule-2 bg-paper px-3 py-2 text-sm font-normal outline-none focus:border-oxblood focus:ring-2 focus:ring-oxblood/15"
+                      className="w-full min-w-0 border border-rule-2 bg-paper px-3 py-2 text-sm font-normal outline-none focus:border-oxblood focus:ring-2 focus:ring-oxblood/15 disabled:cursor-not-allowed disabled:opacity-60"
                       name="defaultThinkingLevel"
                       value={defaultThinkingLevel}
                       onChange={(event) =>
                         setDefaultVariant(event.target.value)
                       }
-                      disabled={backendChanging || defaultModel.length === 0}
+                      disabled={modelsDisabled || defaultModel.length === 0}
                     >
                       <option value="">
                         {buildVariants.length === 0
@@ -642,15 +727,15 @@ function SettingsButton() {
                 <label className="grid min-w-0 gap-1.5 text-sm font-semibold">
                   Review model
                   <select
-                    className="w-full min-w-0 border border-rule-2 bg-paper px-3 py-2 font-mono text-sm font-normal outline-none focus:border-oxblood focus:ring-2 focus:ring-oxblood/15"
+                    className="w-full min-w-0 border border-rule-2 bg-paper px-3 py-2 font-mono text-sm font-normal outline-none focus:border-oxblood focus:ring-2 focus:ring-oxblood/15 disabled:cursor-not-allowed disabled:opacity-60"
                     name="reviewModel"
                     value={reviewModel}
-                    disabled={backendChanging}
+                    disabled={modelsDisabled}
                     onChange={(event) => {
                       const nextModel = event.target.value
                       setReviewModel(nextModel)
                       const nextVariants = variantsForModel(
-                        models.data,
+                        catalogModels,
                         nextModel.length > 0 ? nextModel : defaultModel,
                       )
                       setReviewVariant((current) =>
@@ -658,17 +743,13 @@ function SettingsButton() {
                       )
                     }}
                   >
-                    <option value="">
-                      {backendChanging
-                        ? "Cleared — choose after restart"
-                        : "Same as build model"}
-                    </option>
+                    <option value="">Same as build model</option>
                     {hasUnavailableReviewModel && (
                       <option value={reviewModel}>
                         {reviewModel} (not in Agent Model catalog)
                       </option>
                     )}
-                    {(models.data ?? []).map((model) => (
+                    {(catalogModels ?? []).map((model) => (
                       <option key={`review-${model.id}`} value={model.id}>
                         {model.id}
                       </option>
@@ -697,12 +778,12 @@ function SettingsButton() {
                   <label className="grid min-w-0 gap-1.5 text-sm font-semibold">
                     Review thinking level
                     <select
-                      className="w-full min-w-0 border border-rule-2 bg-paper px-3 py-2 text-sm font-normal outline-none focus:border-oxblood focus:ring-2 focus:ring-oxblood/15"
+                      className="w-full min-w-0 border border-rule-2 bg-paper px-3 py-2 text-sm font-normal outline-none focus:border-oxblood focus:ring-2 focus:ring-oxblood/15 disabled:cursor-not-allowed disabled:opacity-60"
                       name="reviewThinkingLevel"
                       value={reviewThinkingLevel}
                       onChange={(event) => setReviewVariant(event.target.value)}
                       disabled={
-                        backendChanging ||
+                        modelsDisabled ||
                         reviewThinkingLevelSourceModel.length === 0 ||
                         reviewThinkingLevels.length === 0
                       }
@@ -797,11 +878,13 @@ function SettingsButton() {
               disabled={
                 config.isPending ||
                 config.isError ||
-                models.isPending ||
-                models.isError ||
+                modelsLoading ||
                 updateConfig.isPending ||
-                (!backendChanging &&
-                  (defaultModel.length === 0 || hasUnavailableBuildModel))
+                (backendChanging && previewError !== null) ||
+                // Empty build model allowed on backend change (first-run style);
+                // non-empty must still be in the preview/active catalog.
+                (defaultModel.length > 0 && hasUnavailableBuildModel) ||
+                (!backendChanging && defaultModel.length === 0)
               }
             >
               {updateConfig.isPending ? "Saving..." : "Save settings"}

--- a/apps/harness/src/routes/index.tsx
+++ b/apps/harness/src/routes/index.tsx
@@ -53,6 +53,11 @@ const configQuery = {
         defaultThinkingLevel: true,
         reviewModel: true,
         reviewThinkingLevel: true,
+        maxConcurrentAgentTurns: true,
+        maxConcurrentWorkItems: true,
+        // Keep selection aligned with Harness Settings so shared cache never
+        // drops unfinishedWorkItemCount (backend-change idle gate).
+        unfinishedWorkItemCount: true,
       },
     })
     return result.config

--- a/apps/harness/src/server/application.server.ts
+++ b/apps/harness/src/server/application.server.ts
@@ -2,13 +2,22 @@ import "@tanstack/react-start/server-only"
 import * as BunChildProcessSpawner from "@effect/platform-bun/BunChildProcessSpawner"
 import * as BunFileSystem from "@effect/platform-bun/BunFileSystem"
 import * as BunPath from "@effect/platform-bun/BunPath"
-import { Effect, Layer, Logger, ManagedRuntime } from "effect"
+import {
+  Effect,
+  type FileSystem,
+  Layer,
+  Logger,
+  ManagedRuntime,
+  type Path,
+} from "effect"
+import type { ChildProcessSpawner } from "effect/unstable/process"
 import {
   AGENT_BACKEND_IDS,
   ActiveAgentBackend,
   ActiveAgentBackendLive,
+  AgentBackend,
   type AgentBackendId,
-  type AgentBackendRegistration,
+  type ResolveAgentBackendRuntime,
   SessionTelemetryProvider,
   resolveActiveRegistration,
   unsupportedSessionTelemetry,
@@ -50,35 +59,54 @@ export interface CreateApplicationOptions {
   readonly startWorker?: boolean
 }
 
-const unsupportedSessionTelemetryLive = (
-  registration: AgentBackendRegistration,
-) =>
-  Layer.succeed(SessionTelemetryProvider, {
-    getSession: (sessionId) =>
-      Effect.succeed(
-        unsupportedSessionTelemetry(sessionId, registration.descriptor),
-      ),
-  })
+type PlatformServices =
+  | ChildProcessSpawner.ChildProcessSpawner
+  | FileSystem.FileSystem
+  | Path.Path
 
-const agentBackendLayers = <R>(input: {
-  readonly activeRegistration: AgentBackendRegistration
-  readonly platformLayer: Layer.Layer<R>
-  readonly sidecarUrl: string | undefined
-}) => {
-  if (input.activeRegistration.descriptor.id === AGENT_BACKEND_IDS.grok) {
-    return {
-      adapterLayer: Grok.layer().pipe(Layer.provide(input.platformLayer)),
-      telemetryLayer: unsupportedSessionTelemetryLive(input.activeRegistration),
+const makeResolveRuntime = (
+  platformLayer: Layer.Layer<PlatformServices>,
+  sidecarUrl: string | undefined,
+): ResolveAgentBackendRuntime => {
+  return (backendId: AgentBackendId) => {
+    const registration = resolveActiveRegistration(backendId)
+
+    if (registration.descriptor.id === AGENT_BACKEND_IDS.grok) {
+      return Effect.gen(function* () {
+        const adapter = yield* AgentBackend
+        return {
+          registration,
+          adapter,
+          telemetry: {
+            getSession: (sessionId: string) =>
+              Effect.succeed(
+                unsupportedSessionTelemetry(sessionId, registration.descriptor),
+              ),
+          },
+        }
+      }).pipe(Effect.provide(Grok.layer().pipe(Layer.provide(platformLayer))))
     }
-  }
 
-  return {
-    adapterLayer: Opencode.layer({
-      ...(input.sidecarUrl === undefined
-        ? {}
-        : { keymaxxerMcpUrl: input.sidecarUrl }),
-    }).pipe(Layer.provide(input.platformLayer)),
-    telemetryLayer: OpencodeSessionTelemetryLive(),
+    return Effect.gen(function* () {
+      const adapter = yield* AgentBackend
+      const telemetry = yield* SessionTelemetryProvider
+      return {
+        registration,
+        adapter,
+        telemetry,
+      }
+    }).pipe(
+      Effect.provide(
+        Layer.mergeAll(
+          Opencode.layer({
+            ...(sidecarUrl === undefined
+              ? {}
+              : { keymaxxerMcpUrl: sidecarUrl }),
+          }).pipe(Layer.provide(platformLayer)),
+          OpencodeSessionTelemetryLive(),
+        ),
+      ),
+    )
   }
 }
 
@@ -124,25 +152,17 @@ export const createApplication = async (
     .then((id) => id as AgentBackendId)
     .catch(() => AGENT_BACKEND_IDS.opencode)
 
+  const resolveRuntime = makeResolveRuntime(platformLayer, sidecarUrl)
   const activeRegistration = resolveActiveRegistration(selectedBackendId)
-  const { adapterLayer, telemetryLayer } = agentBackendLayers({
-    activeRegistration,
-    platformLayer,
-    sidecarUrl,
-  })
   const activeLayer = ActiveAgentBackendLive({
-    selectedBackendId:
-      activeRegistration.descriptor.id === selectedBackendId
-        ? selectedBackendId
-        : activeRegistration.descriptor.id,
-    activeRegistration,
-  }).pipe(Layer.provide(adapterLayer), Layer.provide(telemetryLayer))
+    selectedBackendId: activeRegistration.descriptor.id,
+    resolveRuntime,
+  })
 
   const lifecycleLayer = WorkItemLifecycleLive.pipe(
     Layer.provideMerge(LifecycleStepsLive),
     Layer.provideMerge(databaseLayer),
     Layer.provideMerge(queueLayer),
-    Layer.provideMerge(adapterLayer),
     Layer.provideMerge(activeLayer),
     Layer.provideMerge(keymaxxerLayer),
     Layer.provideMerge(githubLayer),
@@ -161,8 +181,6 @@ export const createApplication = async (
           reconcilerLayer,
           queueLayer,
           keymaxxerLayer,
-          adapterLayer,
-          telemetryLayer,
           activeLayer,
           lifecycleLayer,
           loggingLayer,
@@ -172,8 +190,6 @@ export const createApplication = async (
           workerLayer,
           queueLayer,
           keymaxxerLayer,
-          adapterLayer,
-          telemetryLayer,
           activeLayer,
           lifecycleLayer,
           loggingLayer,

--- a/apps/harness/test/harness-settings-backend-change.test.ts
+++ b/apps/harness/test/harness-settings-backend-change.test.ts
@@ -6,35 +6,22 @@ const rootSource = () =>
   readFileSync(join(import.meta.dir, "../src/routes/__root.tsx"), "utf8")
 
 describe("Harness settings Agent Backend change", () => {
-  test("clears model and thinking selections when Agent Backend changes", () => {
+  test("previews catalog and restores per-backend prefs without restart ceremony", () => {
     const source = rootSource()
     expect(source).toContain(
-      "const applyAgentBackendSelection = (nextBackend: string) => {",
+      "const applyAgentBackendSelection = async (nextBackend: string) => {",
     )
-    expect(source).toContain("applyAgentBackendSelection(event.target.value)")
-    expect(source).toContain('setDefaultModel("")')
-    expect(source).toContain('setDefaultVariant("")')
-    expect(source).toContain('setReviewModel("")')
-    expect(source).toContain('setReviewVariant("")')
     expect(source).toContain(
-      "if (nextBackend === savedAgentBackend && config.data) {",
+      "void applyAgentBackendSelection(event.target.value)",
     )
-    expect(source).toContain('setDefaultModel(config.data.defaultModel ?? "")')
-    expect(source).toContain(
-      'setDefaultVariant(config.data.defaultThinkingLevel ?? "")',
-    )
-    expect(source).toContain('setReviewModel(config.data.reviewModel ?? "")')
-    expect(source).toContain(
-      'setReviewVariant(config.data.reviewThinkingLevel ?? "")',
-    )
-    expect(source).toContain("required={!backendChanging}")
-    expect(source).toContain("disabled={backendChanging}")
-    expect(source).toContain("defaultModel: backendChanging")
-    expect(source).toContain("defaultThinkingLevel: backendChanging")
-    expect(source).toContain("reviewModel: backendChanging")
-    expect(source).toContain("reviewThinkingLevel: backendChanging")
-    expect(source).not.toMatch(
-      /onChange=\{\(event\) =>\s*setSelectedAgentBackend\(event\.target\.value\)\s*\}/,
-    )
+    expect(source).toContain("previewAgentBackend")
+    expect(source).toContain("harnessModelPrefs")
+    expect(source).toContain("unfinishedWorkItemCount")
+    expect(source).toContain("backendChangeBlocked")
+    expect(source).toContain("Activates immediately on Save")
+    expect(source).not.toContain("Cleared — choose after restart")
+    expect(source).not.toContain("Takes effect after restart")
+    expect(source).not.toContain("RESTART_REQUIRED")
+    expect(source).toContain('defaultModel: defaultModel.trim() === ""')
   })
 })

--- a/packages/agent-backend/src/lib/active-agent-backend.ts
+++ b/packages/agent-backend/src/lib/active-agent-backend.ts
@@ -1,11 +1,13 @@
-import { Context, Effect, Layer, Ref, Result, Schema } from "effect"
+import { Context, Effect, Layer, Ref, Result, Schema, Semaphore } from "effect"
 import type { AgentBackend } from "./agent-backend.js"
 import { AgentBackend as AgentBackendService } from "./agent-backend.js"
+import { AgentBackendConfigError } from "./errors.js"
 import {
   type AgentBackendRegistration,
   capabilitySupported,
   defaultAgentBackendId,
   getBuiltInAgentBackend,
+  isSelectableAgentBackendId,
 } from "./registry.js"
 import {
   type SessionTelemetry,
@@ -20,15 +22,21 @@ import type {
   InspectInput,
 } from "./types.js"
 
-export type AgentBackendStatusKind =
-  | "ready"
-  | "unavailable"
-  | "restart_required"
+export type AgentBackendStatusKind = "ready" | "unavailable"
 
 export type AgentBackendStatus = {
   readonly selectedBackend: AgentBackendDescriptor
   readonly activeBackend: AgentBackendDescriptor
   readonly kind: AgentBackendStatusKind
+  readonly reason: string | null
+  readonly models: ReadonlyArray<AgentModel>
+}
+
+export type AgentBackendPreviewKind = "ready" | "unavailable"
+
+export type AgentBackendPreview = {
+  readonly backend: AgentBackendDescriptor
+  readonly kind: AgentBackendPreviewKind
   readonly reason: string | null
   readonly models: ReadonlyArray<AgentModel>
 }
@@ -41,22 +49,35 @@ export class AgentBackendUnavailableError extends Schema.TaggedErrorClass<AgentB
   },
 ) {}
 
-export class AgentBackendRestartRequiredError extends Schema.TaggedErrorClass<AgentBackendRestartRequiredError>()(
-  "AgentBackendRestartRequiredError",
-  {
-    message: Schema.String,
-    selectedBackendId: Schema.String,
-    activeBackendId: Schema.String,
-  },
-) {}
+/** @deprecated Restart boundary removed; kept only for type narrowing during removal. */
+export type AgentBackendBlockedError = AgentBackendUnavailableError
 
-export type AgentBackendBlockedError =
-  | AgentBackendUnavailableError
-  | AgentBackendRestartRequiredError
+export type AgentBackendAdapter = {
+  readonly inspect: AgentBackend["Service"]["inspect"]
+  readonly startTurn: AgentBackend["Service"]["startTurn"]
+  readonly continueTurn: AgentBackend["Service"]["continueTurn"]
+}
+
+export type AgentBackendTelemetry = {
+  readonly getSession: (
+    sessionId: string,
+  ) => Effect.Effect<SessionTelemetry, never>
+}
+
+export type ResolvedAgentBackendRuntime = {
+  readonly registration: AgentBackendRegistration
+  readonly adapter: AgentBackendAdapter
+  readonly telemetry: AgentBackendTelemetry
+}
+
+export type ResolveAgentBackendRuntime = (
+  backendId: AgentBackendId,
+) => Effect.Effect<ResolvedAgentBackendRuntime, unknown>
 
 type ActiveState = {
-  readonly selectedBackendId: AgentBackendId
-  readonly activeRegistration: AgentBackendRegistration
+  readonly registration: AgentBackendRegistration
+  readonly adapter: AgentBackendAdapter
+  readonly telemetry: AgentBackendTelemetry
   readonly models: ReadonlyArray<AgentModel>
   readonly unavailableReason: string | null
 }
@@ -70,20 +91,10 @@ const descriptorFor = (id: AgentBackendId): AgentBackendDescriptor => {
 }
 
 const toStatus = (state: ActiveState): AgentBackendStatus => {
-  const activeBackend = state.activeRegistration.descriptor
-  const selectedBackend = descriptorFor(state.selectedBackendId)
-  if (state.selectedBackendId !== activeBackend.id) {
-    return {
-      selectedBackend,
-      activeBackend,
-      kind: "restart_required",
-      reason: `Restart the Harness to activate ${selectedBackend.label}. ${activeBackend.label} remains active until restart.`,
-      models: state.models,
-    }
-  }
+  const activeBackend = state.registration.descriptor
   if (state.unavailableReason !== null) {
     return {
-      selectedBackend,
+      selectedBackend: activeBackend,
       activeBackend,
       kind: "unavailable",
       reason: state.unavailableReason,
@@ -91,7 +102,7 @@ const toStatus = (state: ActiveState): AgentBackendStatus => {
     }
   }
   return {
-    selectedBackend,
+    selectedBackend: activeBackend,
     activeBackend,
     kind: "ready",
     reason: null,
@@ -127,11 +138,30 @@ export type ActiveAgentBackendShape = {
   readonly recheck: (input: InspectInput) => Effect.Effect<AgentBackendStatus>
   readonly requireAgentTurnsAllowed: Effect.Effect<
     void,
-    AgentBackendBlockedError
+    AgentBackendUnavailableError
   >
-  readonly setSelectedBackend: (
-    selectedBackendId: AgentBackendId,
+  /**
+   * Hot-activate a backend: swap Active registration + adapter, then inspect.
+   * Inspect failure leaves Active on the new backend in Unavailable.
+   */
+  readonly activate: (
+    backendId: AgentBackendId,
+    input: InspectInput,
   ) => Effect.Effect<AgentBackendStatus>
+  /**
+   * Settings-only inspect of a not-yet-saved backend. Does not change Active.
+   */
+  readonly preview: (
+    backendId: AgentBackendId,
+    input: InspectInput,
+  ) => Effect.Effect<AgentBackendPreview>
+  /**
+   * Serialize Config backend commits + activate with Work Item creation so a
+   * concurrent Implement Now cannot capture the pre-activate Active backend.
+   */
+  readonly withConfigCoordination: <A, E, R>(
+    effect: Effect.Effect<A, E, R>,
+  ) => Effect.Effect<A, E, R>
   readonly getActiveRegistration: Effect.Effect<AgentBackendRegistration>
   readonly getSessionTelemetry: (input: {
     readonly backendId: string
@@ -146,32 +176,62 @@ export class ActiveAgentBackend extends Context.Service<
 
 export type ActiveAgentBackendLiveOptions = {
   readonly selectedBackendId: AgentBackendId
-  readonly activeRegistration: AgentBackendRegistration
+  readonly resolveRuntime: ResolveAgentBackendRuntime
 }
 
 /**
- * Active Agent Backend readiness and catalog. Construct after the adapter
- * AgentBackend layer. Startup/recheck inspect failures set Unavailable and
- * must not terminate the Harness process.
+ * Active Agent Backend readiness, catalog, and hot-activation. Also provides
+ * the process-wide AgentBackend + SessionTelemetryProvider proxies so turns
+ * always use the currently Active adapter without a process restart.
  */
 export const ActiveAgentBackendLive = (
   options: ActiveAgentBackendLiveOptions,
 ): Layer.Layer<
-  ActiveAgentBackend,
-  never,
-  AgentBackend | SessionTelemetryProvider
+  ActiveAgentBackend | AgentBackendService | SessionTelemetryProvider
 > =>
-  Layer.effect(
-    ActiveAgentBackend,
+  Layer.unwrap(
     Effect.gen(function* () {
-      const agentBackend = yield* AgentBackendService
-      const telemetry = yield* SessionTelemetryProvider
+      const resolveOrUnavailable = (
+        backendId: AgentBackendId,
+      ): Effect.Effect<ResolvedAgentBackendRuntime> =>
+        options.resolveRuntime(backendId).pipe(
+          Effect.catch((error) => {
+            const registration = resolveActiveRegistration(backendId)
+            const reason = formatInspectFailure(error)
+            const failConfig = () =>
+              Effect.fail(new AgentBackendConfigError({ message: reason }))
+            return Effect.succeed({
+              registration,
+              adapter: {
+                inspect: failConfig,
+                startTurn: failConfig,
+                continueTurn: failConfig,
+              },
+              telemetry: {
+                getSession: (sessionId: string) =>
+                  Effect.succeed(
+                    unsupportedSessionTelemetry(
+                      sessionId,
+                      registration.descriptor,
+                    ),
+                  ),
+              },
+            } satisfies ResolvedAgentBackendRuntime)
+          }),
+        )
+
+      const initial = yield* resolveOrUnavailable(options.selectedBackendId)
       const stateRef = yield* Ref.make<ActiveState>({
-        selectedBackendId: options.selectedBackendId,
-        activeRegistration: options.activeRegistration,
+        registration: initial.registration,
+        adapter: initial.adapter,
+        telemetry: initial.telemetry,
         models: [],
         unavailableReason: "Agent Backend has not been inspected yet",
       })
+      const configCoordination = yield* Semaphore.make(1)
+      const withConfigCoordination = <A, E, R>(
+        effect: Effect.Effect<A, E, R>,
+      ): Effect.Effect<A, E, R> => configCoordination.withPermits(1)(effect)
 
       const getStatus = Ref.get(stateRef).pipe(Effect.map(toStatus))
 
@@ -179,40 +239,38 @@ export const ActiveAgentBackendLive = (
         input: InspectInput,
       ) {
         const current = yield* Ref.get(stateRef)
-        if (
-          current.selectedBackendId !== current.activeRegistration.descriptor.id
-        ) {
-          return toStatus(current)
-        }
-        const inspected = yield* Effect.result(agentBackend.inspect(input))
+        const inspectedBackendId = current.registration.descriptor.id
+        const inspected = yield* Effect.result(current.adapter.inspect(input))
+        // Discard results if Active was swapped (activate) during inspect.
+        const stillActive = (state: ActiveState): boolean =>
+          state.registration.descriptor.id === inspectedBackendId
         if (Result.isFailure(inspected)) {
           const reason = formatInspectFailure(inspected.failure)
-          yield* Ref.update(stateRef, (state) => ({
-            ...state,
-            models: [],
-            unavailableReason: reason,
-          }))
+          yield* Ref.update(stateRef, (state) =>
+            stillActive(state)
+              ? {
+                  ...state,
+                  models: [],
+                  unavailableReason: reason,
+                }
+              : state,
+          )
           return yield* getStatus
         }
-        yield* Ref.update(stateRef, (state) => ({
-          ...state,
-          models: inspected.success.models,
-          unavailableReason: null,
-        }))
+        yield* Ref.update(stateRef, (state) =>
+          stillActive(state)
+            ? {
+                ...state,
+                models: inspected.success.models,
+                unavailableReason: null,
+              }
+            : state,
+        )
         return yield* getStatus
       })
 
       const requireAgentTurnsAllowed = Effect.gen(function* () {
         const status = yield* getStatus
-        if (status.kind === "restart_required") {
-          return yield* new AgentBackendRestartRequiredError({
-            message:
-              status.reason ??
-              "Restart the Harness to activate the selected Agent Backend",
-            selectedBackendId: status.selectedBackend.id,
-            activeBackendId: status.activeBackend.id,
-          })
-        }
         if (status.kind === "unavailable") {
           return yield* new AgentBackendUnavailableError({
             message: status.reason ?? "Agent Backend is unavailable",
@@ -221,18 +279,59 @@ export const ActiveAgentBackendLive = (
         }
       }).pipe(Effect.asVoid)
 
-      const setSelectedBackend = Effect.fn(
-        "ActiveAgentBackend.setSelectedBackend",
-      )(function* (selectedBackendId: AgentBackendId) {
-        yield* Ref.update(stateRef, (state) => ({
-          ...state,
-          selectedBackendId,
-        }))
-        return yield* getStatus
+      const activate = Effect.fn("ActiveAgentBackend.activate")(function* (
+        backendId: AgentBackendId,
+        input: InspectInput,
+      ) {
+        const resolvedId = isSelectableAgentBackendId(backendId)
+          ? backendId
+          : defaultAgentBackendId
+        const current = yield* Ref.get(stateRef)
+        if (current.registration.descriptor.id !== resolvedId) {
+          const runtime = yield* resolveOrUnavailable(resolvedId)
+          yield* Ref.set(stateRef, {
+            registration: runtime.registration,
+            adapter: runtime.adapter,
+            telemetry: runtime.telemetry,
+            models: [],
+            unavailableReason: "Agent Backend has not been inspected yet",
+          })
+        }
+        return yield* recheck(input)
+      })
+
+      const preview = Effect.fn("ActiveAgentBackend.preview")(function* (
+        backendId: AgentBackendId,
+        input: InspectInput,
+      ) {
+        const resolvedId = isSelectableAgentBackendId(backendId)
+          ? backendId
+          : defaultAgentBackendId
+        const backend = descriptorFor(resolvedId)
+        const current = yield* Ref.get(stateRef)
+        const adapter =
+          current.registration.descriptor.id === resolvedId
+            ? current.adapter
+            : (yield* resolveOrUnavailable(resolvedId)).adapter
+        const inspected = yield* Effect.result(adapter.inspect(input))
+        if (Result.isFailure(inspected)) {
+          return {
+            backend,
+            kind: "unavailable" as const,
+            reason: formatInspectFailure(inspected.failure),
+            models: [] as ReadonlyArray<AgentModel>,
+          }
+        }
+        return {
+          backend,
+          kind: "ready" as const,
+          reason: null,
+          models: inspected.success.models,
+        }
       })
 
       const getActiveRegistration = Ref.get(stateRef).pipe(
-        Effect.map((state) => state.activeRegistration),
+        Effect.map((state) => state.registration),
       )
 
       const getSessionTelemetry = Effect.fn(
@@ -243,7 +342,7 @@ export const ActiveAgentBackendLive = (
       }) {
         const registration =
           getBuiltInAgentBackend(input.backendId) ??
-          (yield* Ref.get(stateRef)).activeRegistration
+          (yield* Ref.get(stateRef)).registration
         const backend = registration.descriptor
         if (!capabilitySupported(registration, "SessionTelemetry")) {
           return unsupportedSessionTelemetry(input.sessionId ?? "", backend)
@@ -251,17 +350,53 @@ export const ActiveAgentBackendLive = (
         if (input.sessionId === null || input.sessionId.trim() === "") {
           return missingSessionTelemetry("", backend)
         }
-        return yield* telemetry.getSession(input.sessionId)
+        const state = yield* Ref.get(stateRef)
+        if (state.registration.descriptor.id === registration.descriptor.id) {
+          return yield* state.telemetry.getSession(input.sessionId)
+        }
+        // Historical provenance for a non-active backend: build telemetry once.
+        const runtime = yield* resolveOrUnavailable(registration.descriptor.id)
+        return yield* runtime.telemetry.getSession(input.sessionId)
       })
 
-      return ActiveAgentBackend.of({
+      const activeService = ActiveAgentBackend.of({
         getStatus,
         recheck,
         requireAgentTurnsAllowed,
-        setSelectedBackend,
+        activate,
+        preview,
+        withConfigCoordination,
         getActiveRegistration,
         getSessionTelemetry,
       })
+
+      const agentBackendService = AgentBackendService.of({
+        inspect: (input) =>
+          Ref.get(stateRef).pipe(
+            Effect.flatMap((state) => state.adapter.inspect(input)),
+          ),
+        startTurn: (input) =>
+          Ref.get(stateRef).pipe(
+            Effect.flatMap((state) => state.adapter.startTurn(input)),
+          ),
+        continueTurn: (input) =>
+          Ref.get(stateRef).pipe(
+            Effect.flatMap((state) => state.adapter.continueTurn(input)),
+          ),
+      })
+
+      const telemetryService = SessionTelemetryProvider.of({
+        getSession: (sessionId) =>
+          Ref.get(stateRef).pipe(
+            Effect.flatMap((state) => state.telemetry.getSession(sessionId)),
+          ),
+      })
+
+      return Layer.mergeAll(
+        Layer.succeed(ActiveAgentBackend, activeService),
+        Layer.succeed(AgentBackendService, agentBackendService),
+        Layer.succeed(SessionTelemetryProvider, telemetryService),
+      )
     }),
   )
 

--- a/packages/agent-backend/src/lib/agent-free-steps.ts
+++ b/packages/agent-backend/src/lib/agent-free-steps.ts
@@ -2,8 +2,8 @@
  * Central classification of Lifecycle Steps as Agent-free (guaranteed not to
  * invoke an Agent Turn) vs agent-dependent (always or conditionally may).
  *
- * While the Active Agent Backend is unavailable or restart-required, only
- * Agent-free steps may start.
+ * While the Active Agent Backend is unavailable, only Agent-free steps may
+ * start.
  */
 
 const AGENT_FREE_STEPS = new Set<string>([

--- a/packages/agent-backend/test/active-agent-backend.spec.ts
+++ b/packages/agent-backend/test/active-agent-backend.spec.ts
@@ -1,0 +1,256 @@
+import { Effect, Fiber } from "effect"
+import {
+  AGENT_BACKEND_IDS,
+  ActiveAgentBackend,
+  ActiveAgentBackendLive,
+  AgentBackend,
+  AgentBackendConfigError,
+  type AgentBackendId,
+  type ResolveAgentBackendRuntime,
+  SessionTelemetryProvider,
+  getBuiltInAgentBackend,
+  unsupportedSessionTelemetry,
+} from "../src/index.js"
+import { describe, expect, it } from "bun:test"
+
+const registration = (id: AgentBackendId) => {
+  const found = getBuiltInAgentBackend(id)
+  if (found === undefined) {
+    throw new Error(`missing registration ${id}`)
+  }
+  return found
+}
+
+const makeResolve =
+  (options: {
+    readonly failInspectFor?: ReadonlySet<string>
+    readonly modelsByBackend?: Record<
+      string,
+      ReadonlyArray<{ id: string; thinkingLevels: readonly string[] }>
+    >
+  }): ResolveAgentBackendRuntime =>
+  (backendId) => {
+    const reg = registration(backendId)
+    const models = options.modelsByBackend?.[backendId] ?? [
+      { id: `${backendId}/model-a`, thinkingLevels: ["low", "high"] },
+    ]
+    return Effect.succeed({
+      registration: reg,
+      adapter: {
+        inspect: () => {
+          if (options.failInspectFor?.has(backendId)) {
+            return Effect.fail(
+              new AgentBackendConfigError({
+                message: `${backendId} binary missing`,
+              }),
+            )
+          }
+          return Effect.succeed({
+            backend: reg.descriptor,
+            models: [...models],
+          })
+        },
+        startTurn: () => Effect.die("unused"),
+        continueTurn: () => Effect.die("unused"),
+      },
+      telemetry: {
+        getSession: (sessionId: string) =>
+          Effect.succeed(
+            unsupportedSessionTelemetry(sessionId, reg.descriptor),
+          ),
+      },
+    })
+  }
+
+describe("ActiveAgentBackend hot-activate", () => {
+  it("activates a new backend without restart limbo and matches Selected to Active", async () => {
+    const layer = ActiveAgentBackendLive({
+      selectedBackendId: AGENT_BACKEND_IDS.opencode,
+      resolveRuntime: makeResolve({}),
+    })
+
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        const active = yield* ActiveAgentBackend
+        const agent = yield* AgentBackend
+        yield* active.recheck({ cwd: "/tmp" })
+        let status = yield* active.getStatus
+        expect(status.kind).toBe("ready")
+        expect(status.activeBackend.id).toBe("opencode")
+        expect(status.selectedBackend.id).toBe("opencode")
+        expect(status.models[0]?.id).toBe("opencode/model-a")
+
+        status = yield* active.activate(AGENT_BACKEND_IDS.grok, {
+          cwd: "/tmp",
+        })
+        expect(status.kind).toBe("ready")
+        expect(status.activeBackend.id).toBe("grok")
+        expect(status.selectedBackend.id).toBe("grok")
+        expect(status.models[0]?.id).toBe("grok/model-a")
+
+        // Proxy AgentBackend uses the new adapter after activate.
+        const inspected = yield* agent.inspect({ cwd: "/tmp" })
+        expect(inspected.backend.id).toBe("grok")
+      }).pipe(Effect.provide(layer)),
+    )
+  })
+
+  it("leaves Unavailable on the new backend when hot-activate inspect fails", async () => {
+    const layer = ActiveAgentBackendLive({
+      selectedBackendId: AGENT_BACKEND_IDS.opencode,
+      resolveRuntime: makeResolve({
+        failInspectFor: new Set([AGENT_BACKEND_IDS.grok]),
+      }),
+    })
+
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        const active = yield* ActiveAgentBackend
+        yield* active.recheck({ cwd: "/tmp" })
+        const status = yield* active.activate(AGENT_BACKEND_IDS.grok, {
+          cwd: "/tmp",
+        })
+        expect(status.kind).toBe("unavailable")
+        expect(status.activeBackend.id).toBe("grok")
+        expect(status.selectedBackend.id).toBe("grok")
+        expect(status.reason).toContain("grok binary missing")
+        expect(status.models).toEqual([])
+      }).pipe(Effect.provide(layer)),
+    )
+  })
+
+  it("previews another backend without changing Active", async () => {
+    const layer = ActiveAgentBackendLive({
+      selectedBackendId: AGENT_BACKEND_IDS.opencode,
+      resolveRuntime: makeResolve({
+        modelsByBackend: {
+          opencode: [{ id: "opencode/live", thinkingLevels: [] }],
+          grok: [{ id: "grok/preview", thinkingLevels: ["high"] }],
+        },
+      }),
+    })
+
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        const active = yield* ActiveAgentBackend
+        yield* active.recheck({ cwd: "/tmp" })
+        const preview = yield* active.preview(AGENT_BACKEND_IDS.grok, {
+          cwd: "/tmp",
+        })
+        expect(preview.kind).toBe("ready")
+        expect(preview.backend.id).toBe("grok")
+        expect(preview.models[0]?.id).toBe("grok/preview")
+
+        const status = yield* active.getStatus
+        expect(status.activeBackend.id).toBe("opencode")
+        expect(status.models[0]?.id).toBe("opencode/live")
+      }).pipe(Effect.provide(layer)),
+    )
+  })
+
+  it("discards recheck results after Active is swapped mid-inspect", async () => {
+    let releaseInspect: (() => void) | undefined
+    const inspectGate = new Promise<void>((resolve) => {
+      releaseInspect = resolve
+    })
+    const resolveRuntime: ResolveAgentBackendRuntime = (backendId) => {
+      const reg = registration(backendId)
+      return Effect.succeed({
+        registration: reg,
+        adapter: {
+          inspect: () =>
+            Effect.gen(function* () {
+              if (backendId === AGENT_BACKEND_IDS.opencode) {
+                yield* Effect.promise(() => inspectGate)
+              }
+              return {
+                backend: reg.descriptor,
+                models: [
+                  {
+                    id: `${backendId}/model-a`,
+                    thinkingLevels: ["low"] as const,
+                  },
+                ],
+              }
+            }),
+          startTurn: () => Effect.die("unused"),
+          continueTurn: () => Effect.die("unused"),
+        },
+        telemetry: {
+          getSession: (sessionId: string) =>
+            Effect.succeed(
+              unsupportedSessionTelemetry(sessionId, reg.descriptor),
+            ),
+        },
+      })
+    }
+
+    const layer = ActiveAgentBackendLive({
+      selectedBackendId: AGENT_BACKEND_IDS.opencode,
+      resolveRuntime,
+    })
+
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        const active = yield* ActiveAgentBackend
+        const recheckFiber = yield* Effect.forkChild(
+          active.recheck({ cwd: "/tmp" }),
+        )
+        // Let recheck capture OpenCode adapter and block in inspect.
+        yield* Effect.yieldNow
+        yield* active.activate(AGENT_BACKEND_IDS.grok, { cwd: "/tmp" })
+        releaseInspect?.()
+        yield* Fiber.join(recheckFiber)
+        const status = yield* active.getStatus
+        expect(status.activeBackend.id).toBe("grok")
+        expect(status.models[0]?.id).toBe("grok/model-a")
+      }).pipe(Effect.provide(layer)),
+    )
+  })
+
+  it("preview failure keeps Active unchanged", async () => {
+    const layer = ActiveAgentBackendLive({
+      selectedBackendId: AGENT_BACKEND_IDS.opencode,
+      resolveRuntime: makeResolve({
+        failInspectFor: new Set([AGENT_BACKEND_IDS.grok]),
+      }),
+    })
+
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        const active = yield* ActiveAgentBackend
+        yield* active.recheck({ cwd: "/tmp" })
+        const preview = yield* active.preview(AGENT_BACKEND_IDS.grok, {
+          cwd: "/tmp",
+        })
+        expect(preview.kind).toBe("unavailable")
+        expect(preview.reason).toContain("grok binary missing")
+
+        const status = yield* active.getStatus
+        expect(status.kind).toBe("ready")
+        expect(status.activeBackend.id).toBe("opencode")
+      }).pipe(Effect.provide(layer)),
+    )
+  })
+
+  it("does not export restart_required status kinds", async () => {
+    const layer = ActiveAgentBackendLive({
+      selectedBackendId: AGENT_BACKEND_IDS.opencode,
+      resolveRuntime: makeResolve({}),
+    })
+
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        const active = yield* ActiveAgentBackend
+        const status = yield* active.getStatus
+        expect(status.kind === "ready" || status.kind === "unavailable").toBe(
+          true,
+        )
+        // SessionTelemetryProvider is provided from the same layer.
+        const telemetry = yield* SessionTelemetryProvider
+        const session = yield* telemetry.getSession("ses_x")
+        expect(session.availability).toBe("unsupported")
+      }).pipe(Effect.provide(layer)),
+    )
+  })
+})

--- a/packages/db-schema/drizzle/20260725120000_backend_model_prefs/migration.sql
+++ b/packages/db-schema/drizzle/20260725120000_backend_model_prefs/migration.sql
@@ -1,0 +1,40 @@
+ALTER TABLE `config` ADD `backend_model_prefs` text DEFAULT '{}' NOT NULL;--> statement-breakpoint
+UPDATE `config` SET `backend_model_prefs` = json_object(
+  CASE
+    WHEN `selected_agent_backend` IS NULL OR trim(`selected_agent_backend`) = ''
+      THEN 'opencode'
+    ELSE `selected_agent_backend`
+  END,
+  json_object(
+    'defaultModel', `default_model`,
+    'defaultThinkingLevel', `default_thinking_level`,
+    'reviewModel', `review_model`,
+    'reviewThinkingLevel', `review_thinking_level`
+  )
+);--> statement-breakpoint
+ALTER TABLE `repository` ADD `backend_model_prefs` text DEFAULT '{}' NOT NULL;--> statement-breakpoint
+UPDATE `repository`
+SET `backend_model_prefs` = json_object(
+  COALESCE(
+    (
+      SELECT CASE
+        WHEN c.`selected_agent_backend` IS NULL OR trim(c.`selected_agent_backend`) = ''
+          THEN 'opencode'
+        ELSE c.`selected_agent_backend`
+      END
+      FROM `config` c
+      WHERE c.`id` = 'default'
+    ),
+    'opencode'
+  ),
+  json_object(
+    'defaultModel', `default_model`,
+    'defaultThinkingLevel', `default_thinking_level`,
+    'reviewModel', `review_model`,
+    'reviewThinkingLevel', `review_thinking_level`
+  )
+)
+WHERE `default_model` IS NOT NULL
+   OR `default_thinking_level` IS NOT NULL
+   OR `review_model` IS NOT NULL
+   OR `review_thinking_level` IS NOT NULL;

--- a/packages/db-schema/src/schema.ts
+++ b/packages/db-schema/src/schema.ts
@@ -23,6 +23,11 @@ export const repository = snakeCase.table(
     defaultThinkingLevel: text(),
     reviewModel: text(),
     reviewThinkingLevel: text(),
+    /**
+     * Per-Agent-Backend model preferences (JSON map keyed by backend id).
+     * Flat model columns mirror the Active/selected backend entry.
+     */
+    backendModelPrefs: text().notNull().default("{}"),
     autoMerge: integer({ mode: "boolean" }).notNull().default(false),
     includeAllIssueAuthors: integer({ mode: "boolean" })
       .notNull()
@@ -45,12 +50,17 @@ export const repository = snakeCase.table(
 
 export const config = snakeCase.table("config", {
   id: text().primaryKey().default("default"),
-  /** Agent Backend selected for the next Harness startup (OpenCode by default). */
+  /** Active Agent Backend for the Harness instance (OpenCode by default). */
   selectedAgentBackend: text().notNull().default("opencode"),
   defaultModel: text(),
   defaultThinkingLevel: text(),
   reviewModel: text(),
   reviewThinkingLevel: text(),
+  /**
+   * Per-Agent-Backend model preferences (JSON map keyed by backend id).
+   * Flat model columns mirror the selected backend entry.
+   */
+  backendModelPrefs: text().notNull().default("{}"),
   maxConcurrentAgentTurns: integer({ mode: "number" }).notNull().default(2),
   maxConcurrentWorkItems: integer({ mode: "number" }).notNull().default(5),
   createdAt: integer({ mode: "number" })

--- a/packages/db-service/src/lib/db-service.ts
+++ b/packages/db-service/src/lib/db-service.ts
@@ -17,6 +17,7 @@ import {
 } from "./errors.js"
 import {
   type AddRepositoryInput,
+  type BackendModelPrefs,
   ConfigRecord,
   ConfigSqlRow,
   type IssueDependency,
@@ -32,7 +33,53 @@ import {
   type UpdateRepositorySettingsInput,
   WorkItemPullRequest,
   WorkItemPullRequestSqlRow,
+  emptyBackendModelPrefs,
 } from "./types.js"
+
+type BackendModelPrefsMap = Record<string, BackendModelPrefs>
+
+const parseBackendModelPrefsMap = (raw: string): BackendModelPrefsMap => {
+  try {
+    const parsed: unknown = JSON.parse(raw)
+    if (
+      typeof parsed !== "object" ||
+      parsed === null ||
+      Array.isArray(parsed)
+    ) {
+      return {}
+    }
+    const out: BackendModelPrefsMap = {}
+    for (const [backendId, value] of Object.entries(
+      parsed as Record<string, unknown>,
+    )) {
+      if (typeof value !== "object" || value === null || Array.isArray(value)) {
+        continue
+      }
+      const entry = value as Record<string, unknown>
+      const asOptionalString = (field: unknown): string | null =>
+        typeof field === "string" && field.trim().length > 0
+          ? field.trim()
+          : null
+      out[backendId] = {
+        defaultModel: asOptionalString(entry.defaultModel),
+        defaultThinkingLevel: asOptionalString(entry.defaultThinkingLevel),
+        reviewModel: asOptionalString(entry.reviewModel),
+        reviewThinkingLevel: asOptionalString(entry.reviewThinkingLevel),
+      }
+    }
+    return out
+  } catch {
+    return {}
+  }
+}
+
+const serializeBackendModelPrefsMap = (map: BackendModelPrefsMap): string =>
+  JSON.stringify(map)
+
+const prefsForBackend = (
+  map: BackendModelPrefsMap,
+  backendId: string,
+): BackendModelPrefs => map[backendId] ?? emptyBackendModelPrefs()
 
 const formatSqlError = (error: SqlError): string => {
   const parts: string[] = [error.message]
@@ -148,12 +195,30 @@ const decodeRunningStepRows = (rows: ReadonlyArray<unknown>) =>
   )
 
 const repositorySelectColumns = `id, github_owner, github_repo, local_path, is_bare, paused,
-             default_model, default_thinking_level, review_model, review_thinking_level, auto_merge,
+             default_model, default_thinking_level, review_model, review_thinking_level,
+             backend_model_prefs, auto_merge,
              include_all_issue_authors, issues_reconciled_at`
 
 const issueSelectColumns = `id, repository_id, github_issue_number, title, body, url, state,
                 github_created_at, issue_author, parent_github_issue_number,
                 parent_github_issue_url, parent_position, has_children`
+
+const toRepositoryRecord = (row: RepositorySqlRow): RepositoryRecord =>
+  RepositoryRecord.make({
+    id: row.id,
+    githubOwner: row.githubOwner,
+    githubRepo: row.githubRepo,
+    localPath: row.localPath,
+    isBare: row.isBare,
+    paused: row.paused,
+    defaultModel: row.defaultModel,
+    defaultThinkingLevel: row.defaultThinkingLevel,
+    reviewModel: row.reviewModel,
+    reviewThinkingLevel: row.reviewThinkingLevel,
+    autoMerge: row.autoMerge,
+    includeAllIssueAuthors: row.includeAllIssueAuthors,
+    issuesReconciledAt: row.issuesReconciledAt,
+  })
 
 const toIssueRecord = (
   row: IssueSqlRow,
@@ -193,12 +258,19 @@ export interface DbServiceShape {
   readonly notifyIssuesChanged: (repositoryId: string) => Effect.Effect<void>
   readonly notifyWorkItemsChanged: (repositoryId: string) => Effect.Effect<void>
   readonly getConfig: Effect.Effect<ConfigRecord, DatabaseError>
+  readonly getBackendModelPrefs: (
+    backendId: string,
+  ) => Effect.Effect<BackendModelPrefs, DatabaseError>
   readonly updateConfig: (
     input: UpdateConfigInput,
   ) => Effect.Effect<
     ConfigRecord,
     InvalidConfigInputError | AgentBackendChangeBlockedError | DatabaseError
   >
+  /**
+   * Work Items that block Agent Backend change: anything not terminal
+   * complete/failed/abandoned (includes Needs Human and waiting/in-progress).
+   */
   readonly countUnfinishedWorkItems: Effect.Effect<number, DatabaseError>
   readonly addRepository: (
     input: AddRepositoryInput,
@@ -344,7 +416,7 @@ export const DbServiceLive = Layer.effect(
     const sql = yield* SqlClient.SqlClient
 
     const configSelect = `selected_agent_backend, default_model, default_thinking_level,
-                    review_model, review_thinking_level,
+                    review_model, review_thinking_level, backend_model_prefs,
                     max_concurrent_agent_turns, max_concurrent_work_items`
 
     const toConfigRecord = (row: {
@@ -371,7 +443,7 @@ export const DbServiceLive = Layer.effect(
         const rows = (yield* sql
           .unsafe(
             `SELECT COUNT(*) AS count FROM work_item
-             WHERE state NOT IN ('complete', 'failed', 'abandoned', 'needs_human')`,
+             WHERE state NOT IN ('complete', 'failed', 'abandoned')`,
           )
           .pipe(Effect.mapError(toDatabaseError))) as readonly {
           readonly count: number
@@ -380,37 +452,85 @@ export const DbServiceLive = Layer.effect(
         return typeof count === "number" && Number.isFinite(count) ? count : 0
       }).pipe(Effect.withSpan("DbService.countUnfinishedWorkItems"))
 
-    const getConfig: Effect.Effect<ConfigRecord, DatabaseError> = Effect.gen(
-      function* () {
-        const now = yield* Clock.currentTimeMillis
-        yield* sql
-          .unsafe(
-            `INSERT OR IGNORE INTO config (
+    const readConfigRow = Effect.gen(function* () {
+      const now = yield* Clock.currentTimeMillis
+      yield* sql
+        .unsafe(
+          `INSERT OR IGNORE INTO config (
                id, selected_agent_backend, default_model, default_thinking_level,
-               review_model, review_thinking_level,
+               review_model, review_thinking_level, backend_model_prefs,
                max_concurrent_agent_turns, max_concurrent_work_items,
                created_at, updated_at
-             ) VALUES ('default', 'opencode', NULL, NULL, NULL, NULL, 2, 5, ?, ?)`,
-            [now, now],
-          )
-          .pipe(Effect.mapError(toDatabaseError))
+             ) VALUES ('default', 'opencode', NULL, NULL, NULL, NULL, '{}', 2, 5, ?, ?)`,
+          [now, now],
+        )
+        .pipe(Effect.mapError(toDatabaseError))
 
-        const rows = yield* sql
-          .unsafe(
-            `SELECT ${configSelect}
+      const rows = yield* sql
+        .unsafe(
+          `SELECT ${configSelect}
              FROM config WHERE id = 'default'`,
-          )
-          .pipe(Effect.mapError(toDatabaseError))
-        const decoded = yield* decodeConfigRows(rows)
-        const row = decoded[0]
-        if (!row) {
-          return yield* new DatabaseError({
-            message: "No config returned after initialization",
-          })
-        }
-        return toConfigRecord(row)
+        )
+        .pipe(Effect.mapError(toDatabaseError))
+      const decoded = yield* decodeConfigRows(rows)
+      const row = decoded[0]
+      if (!row) {
+        return yield* new DatabaseError({
+          message: "No config returned after initialization",
+        })
+      }
+      return row
+    })
+
+    const getConfig: Effect.Effect<ConfigRecord, DatabaseError> = Effect.gen(
+      function* () {
+        return toConfigRecord(yield* readConfigRow)
       },
     ).pipe(Effect.withSpan("DbService.getConfig"))
+
+    const getBackendModelPrefs = Effect.fn("DbService.getBackendModelPrefs")(
+      function* (backendId: string) {
+        const row = yield* readConfigRow
+        const map = parseBackendModelPrefsMap(row.backendModelPrefs)
+        return prefsForBackend(map, backendId.trim())
+      },
+    )
+
+    const projectRepositoryFlatColumns = (
+      now: number,
+      backendId: string,
+    ): Effect.Effect<void, SqlError> =>
+      Effect.gen(function* () {
+        const rows = (yield* sql.unsafe(
+          `SELECT id, backend_model_prefs AS backendModelPrefs FROM repository`,
+        )) as readonly {
+          readonly id: string
+          readonly backendModelPrefs: string
+        }[]
+        for (const row of rows) {
+          const prefs = prefsForBackend(
+            parseBackendModelPrefsMap(row.backendModelPrefs ?? "{}"),
+            backendId,
+          )
+          yield* sql.unsafe(
+            `UPDATE repository SET
+               default_model = ?,
+               default_thinking_level = ?,
+               review_model = ?,
+               review_thinking_level = ?,
+               updated_at = ?
+             WHERE id = ?`,
+            [
+              prefs.defaultModel,
+              prefs.defaultThinkingLevel,
+              prefs.reviewModel,
+              prefs.reviewThinkingLevel,
+              now,
+              row.id,
+            ],
+          )
+        }
+      })
 
     const updateConfig = Effect.fn("DbService.updateConfig")(function* (
       input: UpdateConfigInput,
@@ -450,101 +570,156 @@ export const DbServiceLive = Layer.effect(
       }
       const maxConcurrentWorkItems = input.maxConcurrentWorkItems
 
-      const current = yield* getConfig
-      const backendChanging =
-        selectedAgentBackend !== current.selectedAgentBackend
+      // Ensure config row exists (fresh DBs) before the write transaction.
+      yield* readConfigRow
 
-      if (backendChanging) {
-        const unfinished = yield* countUnfinishedWorkItems
-        if (unfinished > 0) {
-          return yield* new AgentBackendChangeBlockedError({
-            message: `Cannot change Agent Backend while ${unfinished} Work Item(s) are unfinished`,
-            unfinishedWorkItemCount: unfinished,
-          })
-        }
-      }
-
-      let defaultModel: string | null
-      let defaultThinkingLevel: string | null
-      let reviewModel: string | null
-      let reviewThinkingLevel: string | null
-
-      if (backendChanging) {
-        defaultModel = null
-        defaultThinkingLevel = null
-        reviewModel = null
-        reviewThinkingLevel = null
-      } else {
-        const trimmedDefaultModel = (input.defaultModel ?? "").trim()
-        if (trimmedDefaultModel.length === 0) {
-          return yield* new InvalidConfigInputError({
-            field: "defaultModel",
-            message: "defaultModel cannot be empty",
-          })
-        }
-        defaultModel = trimmedDefaultModel
-        defaultThinkingLevel = yield* normalizeOptionalConfigSetting(
-          input.defaultThinkingLevel,
-        )
-        reviewModel = yield* normalizeOptionalConfigSetting(input.reviewModel)
-        reviewThinkingLevel = yield* normalizeOptionalConfigSetting(
-          input.reviewThinkingLevel,
-        )
-      }
+      // Normalize model fields once; emptiness is enforced against the in-txn
+      // backend-change flag so concurrent switches cannot clear a build model.
+      const defaultModel = yield* normalizeOptionalConfigSetting(
+        input.defaultModel,
+      )
+      const defaultThinkingLevel = yield* normalizeOptionalConfigSetting(
+        input.defaultThinkingLevel,
+      )
+      const reviewModel = yield* normalizeOptionalConfigSetting(
+        input.reviewModel,
+      )
+      const reviewThinkingLevel = yield* normalizeOptionalConfigSetting(
+        input.reviewThinkingLevel,
+      )
 
       const now = yield* Clock.currentTimeMillis
-      const rows = yield* sql
+      const { rows, repositoryProjectionChanged } = yield* sql
         .withTransaction(
           Effect.gen(function* () {
-            if (backendChanging) {
-              yield* sql.unsafe(
-                `UPDATE repository SET
-                   default_model = NULL,
-                   default_thinking_level = NULL,
-                   review_model = NULL,
-                   review_thinking_level = NULL,
-                   updated_at = ?`,
-                [now],
-              )
+            // Re-read config + unfinished count inside the transaction so a
+            // concurrent Implement Now cannot race past the idle gate.
+            // Production SqlClient uses BEGIN IMMEDIATE (write lock at start).
+            const latestRows = yield* sql
+              .unsafe(`SELECT ${configSelect} FROM config WHERE id = 'default'`)
+              .pipe(Effect.mapError(toDatabaseError))
+            const latestDecoded = yield* decodeConfigRows(latestRows)
+            const latest = latestDecoded[0]
+            if (!latest) {
+              return yield* new DatabaseError({
+                message: "No config returned during update",
+              })
             }
-            return yield* sql.unsafe(
-              `INSERT INTO config (
+            const changing =
+              selectedAgentBackend !== latest.selectedAgentBackend
+            if (changing) {
+              const unfinishedRows = (yield* sql
+                .unsafe(
+                  `SELECT COUNT(*) AS count FROM work_item
+                   WHERE state NOT IN ('complete', 'failed', 'abandoned')`,
+                )
+                .pipe(Effect.mapError(toDatabaseError))) as readonly {
+                readonly count: number
+              }[]
+              const unfinished = unfinishedRows[0]?.count
+              const count =
+                typeof unfinished === "number" && Number.isFinite(unfinished)
+                  ? unfinished
+                  : 0
+              if (count > 0) {
+                return yield* new AgentBackendChangeBlockedError({
+                  message: `Cannot change Agent Backend while ${count} Work Item(s) are unfinished`,
+                  unfinishedWorkItemCount: count,
+                })
+              }
+              yield* projectRepositoryFlatColumns(
+                now,
+                selectedAgentBackend,
+              ).pipe(Effect.mapError(toDatabaseError))
+            } else if (defaultModel === null) {
+              // Same-backend update requires a build model (in-txn authoritative).
+              return yield* new InvalidConfigInputError({
+                field: "defaultModel",
+                message: "defaultModel cannot be empty",
+              })
+            }
+            // Merge prefs from the in-txn row so concurrent writers do not
+            // clobber each other's per-backend map entries.
+            const prefsMap = parseBackendModelPrefsMap(latest.backendModelPrefs)
+            prefsMap[selectedAgentBackend] = {
+              defaultModel,
+              defaultThinkingLevel,
+              reviewModel,
+              reviewThinkingLevel,
+            }
+            const backendModelPrefs = serializeBackendModelPrefsMap(prefsMap)
+            const written = yield* sql
+              .unsafe(
+                `INSERT INTO config (
                    id, selected_agent_backend, default_model, default_thinking_level,
-                   review_model, review_thinking_level,
+                   review_model, review_thinking_level, backend_model_prefs,
                    max_concurrent_agent_turns, max_concurrent_work_items,
                    created_at, updated_at
-                 ) VALUES ('default', ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                 ) VALUES ('default', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                  ON CONFLICT (id) DO UPDATE SET
                    selected_agent_backend = excluded.selected_agent_backend,
                    default_model = excluded.default_model,
                    default_thinking_level = excluded.default_thinking_level,
                    review_model = excluded.review_model,
                    review_thinking_level = excluded.review_thinking_level,
+                   backend_model_prefs = excluded.backend_model_prefs,
                    max_concurrent_agent_turns = excluded.max_concurrent_agent_turns,
                    max_concurrent_work_items = excluded.max_concurrent_work_items,
                    updated_at = excluded.updated_at
                  RETURNING ${configSelect}`,
-              [
-                selectedAgentBackend,
-                defaultModel,
-                defaultThinkingLevel,
-                reviewModel,
-                reviewThinkingLevel,
-                maxConcurrentAgentTurns,
-                maxConcurrentWorkItems,
-                now,
-                now,
-              ],
-            )
+                [
+                  selectedAgentBackend,
+                  defaultModel,
+                  defaultThinkingLevel,
+                  reviewModel,
+                  reviewThinkingLevel,
+                  backendModelPrefs,
+                  maxConcurrentAgentTurns,
+                  maxConcurrentWorkItems,
+                  now,
+                  now,
+                ],
+              )
+              .pipe(Effect.mapError(toDatabaseError))
+            // Publish from in-txn changing (not a pre-txn snapshot) so concurrent
+            // reverse-switches still notify clients after repo flat re-projection.
+            return {
+              rows: written,
+              repositoryProjectionChanged: changing,
+            }
           }),
         )
-        .pipe(Effect.mapError(toDatabaseError))
+        .pipe(
+          Effect.mapError((error: unknown) => {
+            if (
+              typeof error === "object" &&
+              error !== null &&
+              "_tag" in error
+            ) {
+              const tag = (error as { _tag: string })._tag
+              if (
+                tag === "AgentBackendChangeBlockedError" ||
+                tag === "DatabaseError" ||
+                tag === "InvalidConfigInputError"
+              ) {
+                return error as
+                  | AgentBackendChangeBlockedError
+                  | DatabaseError
+                  | InvalidConfigInputError
+              }
+            }
+            return toDatabaseError(error as SqlError)
+          }),
+        )
       const decoded = yield* decodeConfigRows(rows)
       const row = decoded[0]
       if (!row) {
         return yield* new DatabaseError({
           message: "No config returned from update",
         })
+      }
+      if (repositoryProjectionChanged) {
+        yield* publishRepositoryChanged()
       }
       return toConfigRecord(row)
     })
@@ -587,8 +762,9 @@ export const DbServiceLive = Layer.effect(
           `INSERT INTO repository (
                id, github_owner, github_repo, local_path, is_bare, paused,
                default_model, default_thinking_level, review_model, review_thinking_level,
+               backend_model_prefs,
                auto_merge, include_all_issue_authors, created_at, updated_at
-             ) VALUES (?, ?, ?, ?, ?, ?, NULL, NULL, NULL, NULL, ?, ?, ?, ?)
+             ) VALUES (?, ?, ?, ?, ?, ?, NULL, NULL, NULL, NULL, '{}', ?, ?, ?, ?)
              RETURNING ${repositorySelectColumns}`,
           [
             id,
@@ -630,7 +806,7 @@ export const DbServiceLive = Layer.effect(
         })
       }
 
-      const repository = RepositoryRecord.make(row)
+      const repository = toRepositoryRecord(row)
       yield* publishRepositoryChanged()
       return repository
     })
@@ -648,31 +824,95 @@ export const DbServiceLive = Layer.effect(
       )
       const now = yield* Clock.currentTimeMillis
       const result = yield* sql
-        .unsafe(
-          `UPDATE repository
+        .withTransaction(
+          Effect.gen(function* () {
+            // Re-read Active backend selection and repo prefs inside the txn so a
+            // concurrent config backend switch cannot mis-key prefs / flat columns.
+            const configRows = yield* sql
+              .unsafe(
+                `SELECT selected_agent_backend AS selectedAgentBackend
+                 FROM config WHERE id = 'default'`,
+              )
+              .pipe(Effect.mapError(toDatabaseError))
+            const selectedAgentBackend =
+              (
+                configRows[0] as
+                  | { readonly selectedAgentBackend: string }
+                  | undefined
+              )?.selectedAgentBackend ?? "opencode"
+            const existingRows = yield* sql
+              .unsafe(
+                `SELECT backend_model_prefs AS backendModelPrefs
+                 FROM repository WHERE id = ?`,
+                [input.repositoryId],
+              )
+              .pipe(Effect.mapError(toDatabaseError))
+            const existing = existingRows[0] as
+              | { readonly backendModelPrefs: string }
+              | undefined
+            if (!existing) {
+              return yield* new RepositoryNotFoundError({
+                repositoryId: input.repositoryId,
+              })
+            }
+            const prefsMap = parseBackendModelPrefsMap(
+              existing.backendModelPrefs ?? "{}",
+            )
+            prefsMap[selectedAgentBackend] = {
+              defaultModel,
+              defaultThinkingLevel,
+              reviewModel,
+              reviewThinkingLevel,
+            }
+            const backendModelPrefs = serializeBackendModelPrefsMap(prefsMap)
+            return yield* sql
+              .unsafe(
+                `UPDATE repository
              SET paused = ?,
                  default_model = ?,
                  default_thinking_level = ?,
                  review_model = ?,
                  review_thinking_level = ?,
+                 backend_model_prefs = ?,
                  auto_merge = ?,
                  include_all_issue_authors = ?,
                  updated_at = ?
              WHERE id = ?
              RETURNING ${repositorySelectColumns}`,
-          [
-            input.paused,
-            defaultModel,
-            defaultThinkingLevel,
-            reviewModel,
-            reviewThinkingLevel,
-            input.autoMerge,
-            input.includeAllIssueAuthors,
-            now,
-            input.repositoryId,
-          ],
+                [
+                  input.paused,
+                  defaultModel,
+                  defaultThinkingLevel,
+                  reviewModel,
+                  reviewThinkingLevel,
+                  backendModelPrefs,
+                  input.autoMerge,
+                  input.includeAllIssueAuthors,
+                  now,
+                  input.repositoryId,
+                ],
+              )
+              .pipe(Effect.mapError(toDatabaseError))
+          }),
         )
-        .pipe(Effect.mapError(toDatabaseError))
+        .pipe(
+          Effect.mapError((error: unknown) => {
+            if (
+              typeof error === "object" &&
+              error !== null &&
+              "_tag" in error
+            ) {
+              const tag = (error as { _tag: string })._tag
+              if (
+                tag === "RepositoryNotFoundError" ||
+                tag === "DatabaseError"
+              ) {
+                return error as RepositoryNotFoundError | DatabaseError
+              }
+            }
+            return toDatabaseError(error as SqlError)
+          }),
+        )
 
       const decoded = yield* decodeRepositoryRows(result)
       const row = decoded[0]
@@ -682,7 +922,7 @@ export const DbServiceLive = Layer.effect(
         })
       }
 
-      const repository = RepositoryRecord.make(row)
+      const repository = toRepositoryRecord(row)
       yield* publishRepositoryChanged()
       return repository
     })
@@ -707,7 +947,7 @@ export const DbServiceLive = Layer.effect(
           return yield* new RepositoryNotFoundError({ repositoryId })
         }
 
-        const repository = RepositoryRecord.make(row)
+        const repository = toRepositoryRecord(row)
         yield* publishRepositoryChanged()
         return repository
       },
@@ -738,7 +978,7 @@ export const DbServiceLive = Layer.effect(
         .pipe(Effect.mapError(toDatabaseError))
 
       const decoded = yield* decodeRepositoryRows(repositories)
-      return decoded.map((row) => RepositoryRecord.make(row))
+      return decoded.map((row) => toRepositoryRecord(row))
     }).pipe(Effect.withSpan("DbService.listRepositories"))
 
     const ensureRepositoryExists = Effect.fn(
@@ -1171,6 +1411,7 @@ export const DbServiceLive = Layer.effect(
       notifyIssuesChanged,
       notifyWorkItemsChanged,
       getConfig,
+      getBackendModelPrefs,
       updateConfig,
       countUnfinishedWorkItems,
       addRepository,

--- a/packages/db-service/src/lib/test-fixtures.ts
+++ b/packages/db-service/src/lib/test-fixtures.ts
@@ -45,6 +45,13 @@ export const stubDbService = (
     maxConcurrentAgentTurns: 2,
     maxConcurrentWorkItems: 5,
   }),
+  getBackendModelPrefs: () =>
+    Effect.succeed({
+      defaultModel: "opencode/deepseek-v4-flash-free",
+      defaultThinkingLevel: "low",
+      reviewModel: null,
+      reviewThinkingLevel: null,
+    }),
   updateConfig: unused,
   countUnfinishedWorkItems: Effect.succeed(0),
   addRepository: unused,

--- a/packages/db-service/src/lib/types.ts
+++ b/packages/db-service/src/lib/types.ts
@@ -58,6 +58,21 @@ export const UpdateRepositorySettingsInput = Schema.Struct({
 export type UpdateRepositorySettingsInput =
   typeof UpdateRepositorySettingsInput.Type
 
+export const BackendModelPrefs = Schema.Struct({
+  defaultModel: Schema.NullOr(Schema.String),
+  defaultThinkingLevel: Schema.NullOr(Schema.String),
+  reviewModel: Schema.NullOr(Schema.String),
+  reviewThinkingLevel: Schema.NullOr(Schema.String),
+})
+export type BackendModelPrefs = typeof BackendModelPrefs.Type
+
+export const emptyBackendModelPrefs = (): BackendModelPrefs => ({
+  defaultModel: null,
+  defaultThinkingLevel: null,
+  reviewModel: null,
+  reviewThinkingLevel: null,
+})
+
 export const ConfigRecord = Schema.Struct({
   selectedAgentBackend: Schema.String,
   defaultModel: Schema.NullOr(Schema.String),
@@ -75,7 +90,11 @@ export type ConfigRecord = typeof ConfigRecord.Type
 
 export const UpdateConfigInput = Schema.Struct({
   selectedAgentBackend: Schema.String,
-  /** Required when not changing backend; ignored/cleared on backend change. */
+  /**
+   * Build model for the selected backend. Required when keeping the same
+   * backend (except empty first-run rows already null). Optional on backend
+   * change so operators can hot-activate unconfigured.
+   */
   defaultModel: Schema.NullOr(Schema.String),
   defaultThinkingLevel: Schema.NullOr(Schema.String),
   reviewModel: Schema.NullOr(Schema.String),
@@ -140,6 +159,7 @@ export const RepositorySqlRow = Schema.Struct({
   defaultThinkingLevel: Schema.NullOr(Schema.String),
   reviewModel: Schema.NullOr(Schema.String),
   reviewThinkingLevel: Schema.NullOr(Schema.String),
+  backendModelPrefs: Schema.String,
   autoMerge: SqlBoolean,
   includeAllIssueAuthors: SqlBoolean,
   issuesReconciledAt: Schema.NullOr(Schema.DateFromMillis),
@@ -153,6 +173,7 @@ export const RepositorySqlRow = Schema.Struct({
     defaultThinkingLevel: "default_thinking_level",
     reviewModel: "review_model",
     reviewThinkingLevel: "review_thinking_level",
+    backendModelPrefs: "backend_model_prefs",
     autoMerge: "auto_merge",
     includeAllIssueAuthors: "include_all_issue_authors",
     issuesReconciledAt: "issues_reconciled_at",
@@ -166,6 +187,7 @@ export const ConfigSqlRow = Schema.Struct({
   defaultThinkingLevel: Schema.NullOr(Schema.String),
   reviewModel: Schema.NullOr(Schema.String),
   reviewThinkingLevel: Schema.NullOr(Schema.String),
+  backendModelPrefs: Schema.String,
   maxConcurrentAgentTurns: Schema.Int,
   maxConcurrentWorkItems: Schema.Int,
 }).pipe(
@@ -175,6 +197,7 @@ export const ConfigSqlRow = Schema.Struct({
     defaultThinkingLevel: "default_thinking_level",
     reviewModel: "review_model",
     reviewThinkingLevel: "review_thinking_level",
+    backendModelPrefs: "backend_model_prefs",
     maxConcurrentAgentTurns: "max_concurrent_agent_turns",
     maxConcurrentWorkItems: "max_concurrent_work_items",
   }),

--- a/packages/db-service/test/db-service.spec.ts
+++ b/packages/db-service/test/db-service.spec.ts
@@ -106,7 +106,7 @@ describe("DbService", () => {
         }),
       ))
 
-    it("clears harness and repository model selections when Agent Backend changes", () =>
+    it("remembers harness and repository model prefs per Agent Backend", () =>
       runTest(
         Effect.gen(function* () {
           const db = yield* DbService
@@ -131,33 +131,104 @@ describe("DbService", () => {
             includeAllIssueAuthors: false,
           })
 
-          const updated = yield* db.updateConfig({
+          const switched = yield* db.updateConfig({
             selectedAgentBackend: "grok",
-            defaultModel: "should-be-ignored",
-            defaultThinkingLevel: "should-be-ignored",
-            reviewModel: "should-be-ignored",
-            reviewThinkingLevel: "should-be-ignored",
-            maxConcurrentAgentTurns: 2,
-            maxConcurrentWorkItems: 5,
-          })
-          expect(updated).toEqual({
-            selectedAgentBackend: "grok",
-            defaultModel: null,
+            defaultModel: "grok-code",
             defaultThinkingLevel: null,
             reviewModel: null,
             reviewThinkingLevel: null,
             maxConcurrentAgentTurns: 2,
             maxConcurrentWorkItems: 5,
           })
+          expect(switched).toEqual({
+            selectedAgentBackend: "grok",
+            defaultModel: "grok-code",
+            defaultThinkingLevel: null,
+            reviewModel: null,
+            reviewThinkingLevel: null,
+            maxConcurrentAgentTurns: 2,
+            maxConcurrentWorkItems: 5,
+          })
+          expect(yield* db.getBackendModelPrefs("opencode")).toEqual({
+            defaultModel: "openai/gpt-5.6-terra",
+            defaultThinkingLevel: "high",
+            reviewModel: "openai/gpt-5.6-terra",
+            reviewThinkingLevel: "max",
+          })
+          expect(yield* db.getBackendModelPrefs("grok")).toEqual({
+            defaultModel: "grok-code",
+            defaultThinkingLevel: null,
+            reviewModel: null,
+            reviewThinkingLevel: null,
+          })
 
-          const repos = yield* db.listRepositories
-          expect(repos).toHaveLength(1)
-          expect(repos[0]).toMatchObject({
+          // Repository flat columns project the Active backend's prefs (empty for grok).
+          const reposAfterSwitch = yield* db.listRepositories
+          expect(reposAfterSwitch).toHaveLength(1)
+          expect(reposAfterSwitch[0]).toMatchObject({
             id: repository.id,
             defaultModel: null,
             defaultThinkingLevel: null,
             reviewModel: null,
             reviewThinkingLevel: null,
+          })
+
+          // Switching back restores OpenCode harness prefs and repository projection.
+          const restored = yield* db.updateConfig({
+            selectedAgentBackend: "opencode",
+            defaultModel: "openai/gpt-5.6-terra",
+            defaultThinkingLevel: "high",
+            reviewModel: "openai/gpt-5.6-terra",
+            reviewThinkingLevel: "max",
+            maxConcurrentAgentTurns: 2,
+            maxConcurrentWorkItems: 5,
+          })
+          expect(restored).toMatchObject({
+            selectedAgentBackend: "opencode",
+            defaultModel: "openai/gpt-5.6-terra",
+            defaultThinkingLevel: "high",
+          })
+          const reposRestored = yield* db.listRepositories
+          expect(reposRestored[0]).toMatchObject({
+            id: repository.id,
+            defaultModel: "openai/gpt-5.6-terra",
+            defaultThinkingLevel: "high",
+            reviewModel: "openai/gpt-5.6-terra",
+            reviewThinkingLevel: "max",
+          })
+        }),
+      ))
+
+    it("rejects Agent Backend change while a Needs Human Work Item exists", () =>
+      runTest(
+        Effect.gen(function* () {
+          const db = yield* DbService
+          const sql = yield* SqlClient.SqlClient
+          const repository = yield* db.addRepository(sampleInput)
+          const now = Date.now()
+          yield* sql.unsafe(
+            `INSERT INTO work_item (
+               id, repository_id, github_issue_number, state, state_ready_at,
+               worktree_path, session_id, failure_code, failure_message,
+               created_at, updated_at
+             ) VALUES (?, ?, 42, 'needs_human', ?, NULL, NULL, NULL, NULL, ?, ?)`,
+            ["wi-needs-human-backend", repository.id, now, now, now],
+          )
+
+          const error = yield* Effect.flip(
+            db.updateConfig({
+              selectedAgentBackend: "grok",
+              defaultModel: null,
+              defaultThinkingLevel: null,
+              reviewModel: null,
+              reviewThinkingLevel: null,
+              maxConcurrentAgentTurns: 2,
+              maxConcurrentWorkItems: 5,
+            }),
+          )
+          expect(error).toMatchObject({
+            _tag: "AgentBackendChangeBlockedError",
+            unfinishedWorkItemCount: 1,
           })
         }),
       ))

--- a/packages/db/test/run-migrations.spec.ts
+++ b/packages/db/test/run-migrations.spec.ts
@@ -94,6 +94,7 @@ describe("runMigrations", () => {
           { name: "20260724120000_agent_backend_vocabulary" },
           { name: "20260724180000_agent_backend_selection" },
           { name: "20260724190000_work_item_turn_time_models" },
+          { name: "20260725120000_backend_model_prefs" },
         ])
       }).pipe(Effect.provide(SqliteTest)),
     )
@@ -447,6 +448,97 @@ describe("runMigrations", () => {
             session_id: "ses_old",
           },
         ])
+      }).pipe(Effect.provide(SqliteTest)),
+    )
+  })
+
+  it("migrates flat model columns into per-backend prefs JSON", async () => {
+    const migrationSql = await readFile(
+      join(
+        import.meta.dir,
+        "../../db-schema/drizzle/20260725120000_backend_model_prefs/migration.sql",
+      ),
+      "utf8",
+    )
+
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        const sql = yield* SqlClient.SqlClient
+        yield* sql.unsafe(
+          `CREATE TABLE config (
+             id text PRIMARY KEY,
+             selected_agent_backend text NOT NULL DEFAULT 'opencode',
+             default_model text,
+             default_thinking_level text,
+             review_model text,
+             review_thinking_level text,
+             max_concurrent_agent_turns integer NOT NULL DEFAULT 2,
+             max_concurrent_work_items integer NOT NULL DEFAULT 5,
+             created_at integer NOT NULL,
+             updated_at integer NOT NULL
+           )`,
+        )
+        yield* sql.unsafe(
+          `INSERT INTO config (
+             id, selected_agent_backend, default_model, default_thinking_level,
+             review_model, review_thinking_level,
+             max_concurrent_agent_turns, max_concurrent_work_items,
+             created_at, updated_at
+           ) VALUES (
+             'default', 'opencode', 'openai/gpt-5.6-terra', 'high',
+             'openai/gpt-5.6-terra', 'max', 2, 5, 1, 1
+           )`,
+        )
+        yield* sql.unsafe(
+          `CREATE TABLE repository (
+             id text PRIMARY KEY,
+             default_model text,
+             default_thinking_level text,
+             review_model text,
+             review_thinking_level text
+           )`,
+        )
+        yield* sql.unsafe(
+          `INSERT INTO repository (
+             id, default_model, default_thinking_level, review_model, review_thinking_level
+           ) VALUES (
+             'repo-1', 'openai/gpt-5.6-terra', 'high', NULL, NULL
+           )`,
+        )
+
+        for (const statement of migrationSql.split(
+          "--> statement-breakpoint",
+        )) {
+          if (statement.trim().length > 0) {
+            yield* sql.unsafe(statement)
+          }
+        }
+
+        const configRows = (yield* sql.unsafe(
+          `SELECT backend_model_prefs FROM config WHERE id = 'default'`,
+        )) as readonly { backend_model_prefs: string }[]
+        const configPrefs = JSON.parse(configRows[0]!.backend_model_prefs)
+        expect(configPrefs).toEqual({
+          opencode: {
+            defaultModel: "openai/gpt-5.6-terra",
+            defaultThinkingLevel: "high",
+            reviewModel: "openai/gpt-5.6-terra",
+            reviewThinkingLevel: "max",
+          },
+        })
+
+        const repoRows = (yield* sql.unsafe(
+          `SELECT backend_model_prefs FROM repository WHERE id = 'repo-1'`,
+        )) as readonly { backend_model_prefs: string }[]
+        const repoPrefs = JSON.parse(repoRows[0]!.backend_model_prefs)
+        expect(repoPrefs).toEqual({
+          opencode: {
+            defaultModel: "openai/gpt-5.6-terra",
+            defaultThinkingLevel: "high",
+            reviewModel: null,
+            reviewThinkingLevel: null,
+          },
+        })
       }).pipe(Effect.provide(SqliteTest)),
     )
   })

--- a/packages/graphql-api/src/lib/graphql-api.ts
+++ b/packages/graphql-api/src/lib/graphql-api.ts
@@ -158,6 +158,18 @@ const toGraphqlAgentBackendStatus = (status: AgentBackendStatus) => ({
   models: status.models,
 })
 
+const toGraphqlAgentBackendPreview = (preview: {
+  readonly backend: AgentBackendStatus["selectedBackend"]
+  readonly kind: "ready" | "unavailable"
+  readonly reason: string | null
+  readonly models: AgentBackendStatus["models"]
+}) => ({
+  backend: toGraphqlBackend(preview.backend),
+  kind: preview.kind.toUpperCase(),
+  reason: preview.reason,
+  models: preview.models,
+})
+
 const resolveWorkItemBackend = (agentBackendId: string) => {
   const registration = getBuiltInAgentBackend(agentBackendId)
   if (registration !== undefined) {
@@ -296,7 +308,11 @@ export const createGraphqlApi = (
             runGraphql(
               Effect.gen(function* () {
                 const db = yield* DbService
-                return yield* db.getConfig
+                const [config, unfinishedWorkItemCount] = yield* Effect.all([
+                  db.getConfig,
+                  db.countUnfinishedWorkItems,
+                ])
+                return { ...config, unfinishedWorkItemCount }
               }).pipe(Effect.withSpan("graphql-api.config")),
             ),
           agentBackends: () =>
@@ -309,6 +325,42 @@ export const createGraphqlApi = (
                 const active = yield* ActiveAgentBackend
                 return toGraphqlAgentBackendStatus(yield* active.getStatus)
               }).pipe(Effect.withSpan("graphql-api.agentBackendStatus")),
+            ),
+          previewAgentBackend: async (
+            _parent: unknown,
+            args: { backendId: string },
+          ) =>
+            runGraphql(
+              Effect.gen(function* () {
+                const backendId = args.backendId.trim()
+                if (!isSelectableAgentBackendId(backendId)) {
+                  return {
+                    backend: {
+                      id: args.backendId,
+                      label: args.backendId,
+                    },
+                    kind: "UNAVAILABLE",
+                    reason: `Unknown Agent Backend: ${args.backendId}`,
+                    models: [],
+                  }
+                }
+                const active = yield* ActiveAgentBackend
+                const preview = yield* active.preview(backendId, {
+                  cwd: agentBackendCwd,
+                  timeout: "30 seconds",
+                })
+                return toGraphqlAgentBackendPreview(preview)
+              }).pipe(Effect.withSpan("graphql-api.previewAgentBackend")),
+            ),
+          harnessModelPrefs: async (
+            _parent: unknown,
+            args: { backendId: string },
+          ) =>
+            runGraphql(
+              Effect.gen(function* () {
+                const db = yield* DbService
+                return yield* db.getBackendModelPrefs(args.backendId)
+              }).pipe(Effect.withSpan("graphql-api.harnessModelPrefs")),
             ),
           models: async () => runGraphql(listModels()),
           issues: async (_parent: unknown, args: IssuesArgs) =>
@@ -498,24 +550,42 @@ export const createGraphqlApi = (
             runGraphql(
               Effect.gen(function* () {
                 const db = yield* DbService
-                const previous = yield* db.getConfig
-                const updated = yield* db.updateConfig({
-                  selectedAgentBackend: args.input.selectedAgentBackend,
-                  defaultModel: args.input.defaultModel ?? null,
-                  defaultThinkingLevel: args.input.defaultThinkingLevel ?? null,
-                  reviewModel: args.input.reviewModel ?? null,
-                  reviewThinkingLevel: args.input.reviewThinkingLevel ?? null,
-                  maxConcurrentAgentTurns: args.input.maxConcurrentAgentTurns,
-                  maxConcurrentWorkItems: args.input.maxConcurrentWorkItems,
-                })
-                if (
-                  updated.selectedAgentBackend !==
-                    previous.selectedAgentBackend &&
-                  isSelectableAgentBackendId(updated.selectedAgentBackend)
-                ) {
-                  const active = yield* ActiveAgentBackend
-                  yield* active.setSelectedBackend(updated.selectedAgentBackend)
-                }
+                const active = yield* ActiveAgentBackend
+                // Serialize config commit + activate with Work Item creation so
+                // Implement Now cannot capture pre-activate Active provenance.
+                const updated = yield* active.withConfigCoordination(
+                  Effect.gen(function* () {
+                    const next = yield* db.updateConfig({
+                      selectedAgentBackend: args.input.selectedAgentBackend,
+                      defaultModel: args.input.defaultModel ?? null,
+                      defaultThinkingLevel:
+                        args.input.defaultThinkingLevel ?? null,
+                      reviewModel: args.input.reviewModel ?? null,
+                      reviewThinkingLevel:
+                        args.input.reviewThinkingLevel ?? null,
+                      maxConcurrentAgentTurns:
+                        args.input.maxConcurrentAgentTurns,
+                      maxConcurrentWorkItems: args.input.maxConcurrentWorkItems,
+                    })
+                    if (
+                      !isSelectableAgentBackendId(next.selectedAgentBackend)
+                    ) {
+                      return next
+                    }
+                    const status = yield* active.getStatus
+                    // Only hot-activate when Active differs from committed Config.
+                    // Same-backend Saves skip full inspect (Recheck remains explicit).
+                    if (status.activeBackend.id !== next.selectedAgentBackend) {
+                      yield* active.activate(next.selectedAgentBackend, {
+                        cwd: agentBackendCwd,
+                        timeout: "30 seconds",
+                      })
+                    }
+                    return next
+                  }),
+                )
+                const unfinishedWorkItemCount =
+                  yield* db.countUnfinishedWorkItems
                 const lifecycle = yield* WorkItemLifecycle
                 yield* lifecycle.admitWaitingWorkItems.pipe(
                   Effect.catch((error) =>
@@ -525,7 +595,7 @@ export const createGraphqlApi = (
                     ),
                   ),
                 )
-                return updated
+                return { ...updated, unfinishedWorkItemCount }
               }).pipe(Effect.withSpan("graphql-api.updateConfig")),
             ),
           recheckAgentBackend: async () =>

--- a/packages/graphql-api/src/lib/to-graphql-error.ts
+++ b/packages/graphql-api/src/lib/to-graphql-error.ts
@@ -84,18 +84,6 @@ export const toGraphQLError = (error: unknown): GraphQLError => {
         "AGENT_BACKEND_UNAVAILABLE",
         { reason: "reason" in error ? error.reason : error.message },
       )
-    case "AgentBackendRestartRequiredError":
-      return gql(
-        error.message ??
-          "Restart the Harness to activate the selected Agent Backend",
-        "AGENT_BACKEND_RESTART_REQUIRED",
-        {
-          selectedBackendId:
-            "selectedBackendId" in error ? error.selectedBackendId : undefined,
-          activeBackendId:
-            "activeBackendId" in error ? error.activeBackendId : undefined,
-        },
-      )
     case "AgentBackendChangeBlockedError":
       return gql(
         error.message ??

--- a/packages/graphql-api/test/graphql-api.test.ts
+++ b/packages/graphql-api/test/graphql-api.test.ts
@@ -224,7 +224,15 @@ const makeRuntime = (
     getStatus: Effect.succeed(readyStatus()),
     recheck: () => Effect.succeed(readyStatus()),
     requireAgentTurnsAllowed: Effect.void,
-    setSelectedBackend: () => Effect.succeed(readyStatus()),
+    activate: () => Effect.succeed(readyStatus()),
+    preview: () =>
+      Effect.succeed({
+        backend: { id: "opencode", label: "OpenCode" },
+        kind: "ready" as const,
+        reason: null,
+        models: readyStatus().models,
+      }),
+    withConfigCoordination: (effect) => effect,
     getActiveRegistration: Effect.succeed({
       descriptor: { id: "opencode", label: "OpenCode" },
       capabilities: [
@@ -925,6 +933,77 @@ describe("GraphQL API", () => {
         },
       },
     })
+  })
+
+  test("updateConfig activates only when Active differs from committed backend", async () => {
+    const activated: string[] = []
+    const activateRuntime = makeRuntime(
+      {},
+      {},
+      {},
+      {},
+      {
+        getStatus: Effect.succeed(readyStatus()),
+        activate: (backendId) => {
+          activated.push(backendId)
+          return Effect.succeed({
+            selectedBackend: { id: backendId, label: backendId },
+            activeBackend: { id: backendId, label: backendId },
+            kind: "ready",
+            reason: null,
+            models: defaultModels,
+          })
+        },
+      },
+    )
+
+    const switchResponse = await createGraphqlApi(activateRuntime).fetch(
+      graphqlRequest({
+        query: `mutation UpdateConfig($input: UpdateConfigInput!) {
+          updateConfig(input: $input) { selectedAgentBackend }
+        }`,
+        variables: {
+          input: {
+            selectedAgentBackend: "grok",
+            defaultModel: null,
+            defaultThinkingLevel: null,
+            reviewModel: null,
+            reviewThinkingLevel: null,
+            maxConcurrentAgentTurns: 2,
+            maxConcurrentWorkItems: 5,
+          },
+        },
+      }),
+    )
+    expect(await switchResponse.json()).toEqual({
+      data: { updateConfig: { selectedAgentBackend: "grok" } },
+    })
+    expect(activated).toEqual(["grok"])
+
+    // Same-backend save skips activate (no full inspect on every Save).
+    activated.length = 0
+    const sameBackend = await createGraphqlApi(activateRuntime).fetch(
+      graphqlRequest({
+        query: `mutation UpdateConfig($input: UpdateConfigInput!) {
+          updateConfig(input: $input) { selectedAgentBackend }
+        }`,
+        variables: {
+          input: {
+            selectedAgentBackend: "opencode",
+            defaultModel: "anthropic/claude-sonnet-4-5",
+            defaultThinkingLevel: null,
+            reviewModel: null,
+            reviewThinkingLevel: null,
+            maxConcurrentAgentTurns: 2,
+            maxConcurrentWorkItems: 5,
+          },
+        },
+      }),
+    )
+    expect(await sameBackend.json()).toEqual({
+      data: { updateConfig: { selectedAgentBackend: "opencode" } },
+    })
+    expect(activated).toEqual([])
   })
 
   test("updates repository settings", async () => {

--- a/packages/graphql-schema/schema.graphql
+++ b/packages/graphql-schema/schema.graphql
@@ -13,10 +13,20 @@ type Query {
   """
   agentBackends: [AgentBackendInfo!]!
   """
-  Selected backend, Active backend, readiness/restart state, actionable reason,
-  and the instance-wide model catalog from the latest successful inspection.
+  Active Agent Backend readiness, actionable reason, and the instance-wide
+  model catalog from the latest successful inspection. Selected and Active
+  always match after Save (hot-activate).
   """
   agentBackendStatus: AgentBackendStatus!
+  """
+  Settings-only inspection of a not-yet-saved Agent Backend catalog.
+  Does not change the Active Agent Backend.
+  """
+  previewAgentBackend(backendId: String!): AgentBackendPreview!
+  """
+  Remembered build/review model prefs for a backend (Harness Config scope).
+  """
+  harnessModelPrefs(backendId: String!): BackendModelPrefs!
   """
   Agent Models available from the Active Agent Backend, each with optional
   Thinking Levels. Empty thinkingLevels means the model has no Thinking Levels.
@@ -90,12 +100,13 @@ type AgentBackendInfo {
 
 """
 Instance-wide Agent Backend readiness for Settings and lifecycle guards.
+Selected and Active always match (hot-activate on Save).
 """
 type AgentBackendStatus {
   selectedBackend: AgentBackendInfo!
   activeBackend: AgentBackendInfo!
   """
-  ready | unavailable | restart_required
+  ready | unavailable
   """
   kind: AgentBackendStatusKind!
   reason: String
@@ -105,7 +116,31 @@ type AgentBackendStatus {
 enum AgentBackendStatusKind {
   READY
   UNAVAILABLE
-  RESTART_REQUIRED
+}
+
+"""
+Settings-only preview of a not-yet-saved Agent Backend.
+"""
+type AgentBackendPreview {
+  backend: AgentBackendInfo!
+  kind: AgentBackendPreviewKind!
+  reason: String
+  models: [AgentModel!]!
+}
+
+enum AgentBackendPreviewKind {
+  READY
+  UNAVAILABLE
+}
+
+"""
+Backend-scoped build/review model preferences.
+"""
+type BackendModelPrefs {
+  defaultModel: String
+  defaultThinkingLevel: String
+  reviewModel: String
+  reviewThinkingLevel: String
 }
 
 """
@@ -133,7 +168,7 @@ enum WorkItemsListKind {
 
 type Config {
   """
-  Agent Backend selected for the next Harness startup.
+  Active Agent Backend (hot-activated on Save).
   """
   selectedAgentBackend: String!
   defaultModel: String
@@ -142,6 +177,10 @@ type Config {
   reviewThinkingLevel: String
   maxConcurrentAgentTurns: Int!
   maxConcurrentWorkItems: Int!
+  """
+  Count of Work Items that block Agent Backend change (includes Needs Human).
+  """
+  unfinishedWorkItemCount: Int!
 }
 
 type AgentModel {
@@ -315,7 +354,8 @@ input AddRepositoryInput {
 input UpdateConfigInput {
   selectedAgentBackend: String!
   """
-  Required when not changing Agent Backend. Ignored (cleared) when the backend changes.
+  Required when not changing Agent Backend. Optional on backend change
+  (empty is allowed, same as first-run).
   """
   defaultModel: String
   defaultThinkingLevel: String

--- a/packages/work-item-lifecycle/src/lib/active-agent-backend-test.ts
+++ b/packages/work-item-lifecycle/src/lib/active-agent-backend-test.ts
@@ -50,7 +50,15 @@ export const stubActiveAgentBackendLayer = (
       recheck: () => Effect.succeed(readyStatus(registration)),
       requireAgentTurnsAllowed:
         overrides.requireAgentTurnsAllowed ?? Effect.void,
-      setSelectedBackend: () => Effect.succeed(readyStatus(registration)),
+      activate: () => Effect.succeed(readyStatus(registration)),
+      preview: () =>
+        Effect.succeed({
+          backend: registration.descriptor,
+          kind: "ready" as const,
+          reason: null,
+          models: [],
+        }),
+      withConfigCoordination: (effect) => effect,
       getActiveRegistration: Effect.succeed(registration),
       getSessionTelemetry: (input) =>
         Effect.succeed(

--- a/packages/work-item-lifecycle/src/lib/errors.ts
+++ b/packages/work-item-lifecycle/src/lib/errors.ts
@@ -68,15 +68,6 @@ export class AgentBackendUnavailableError extends Schema.TaggedErrorClass<AgentB
   },
 ) {}
 
-export class AgentBackendRestartRequiredError extends Schema.TaggedErrorClass<AgentBackendRestartRequiredError>()(
-  "AgentBackendRestartRequiredError",
-  {
-    message: Schema.String,
-    selectedBackendId: Schema.String,
-    activeBackendId: Schema.String,
-  },
-) {}
-
 export class WorkItemNotFoundError extends Schema.TaggedErrorClass<WorkItemNotFoundError>()(
   "WorkItemNotFoundError",
   {

--- a/packages/work-item-lifecycle/src/lib/types.ts
+++ b/packages/work-item-lifecycle/src/lib/types.ts
@@ -266,8 +266,6 @@ export const STEP_RUN_REASON = {
   waitingForAgentTurn: "waiting_for_agent_turn",
   /** Agent-dependent step blocked because Active Agent Backend is unavailable. */
   agentBackendUnavailable: "agent_backend_unavailable",
-  /** Agent-dependent step blocked until Harness restart activates selection. */
-  agentBackendRestartRequired: "agent_backend_restart_required",
   /** Agent-dependent step blocked because no build Agent Model is configured. */
   buildModelNotConfigured: "build_model_not_configured",
   /** Mid-run: Review is running the reviewing (/review) OpenCode pass. */

--- a/packages/work-item-lifecycle/src/lib/work-item-lifecycle.ts
+++ b/packages/work-item-lifecycle/src/lib/work-item-lifecycle.ts
@@ -39,7 +39,6 @@ import { CloseIssueEligibilityError } from "./close-issue-errors.js"
 import {
   AbandonCleanupError,
   ActiveStepRunExistsError,
-  AgentBackendRestartRequiredError,
   AgentBackendUnavailableError,
   BuildModelNotConfiguredError,
   IssueBlockedError,
@@ -463,7 +462,6 @@ export type ImplementNowError =
   | UnfinishedWorkItemExistsError
   | BuildModelNotConfiguredError
   | AgentBackendUnavailableError
-  | AgentBackendRestartRequiredError
   | WorkItemLifecycleDatabaseError
   | RepositoryNotFoundError
   | DatabaseError
@@ -2596,19 +2594,6 @@ export const makeWorkItemLifecycleLive = (
                   })
                   return { _tag: "processed" as const, workItem: failed }
                 }
-                if (readiness.kind === "restart_required") {
-                  const reasonMessage =
-                    readiness.reason ??
-                    "Restart the Harness to activate the selected Agent Backend"
-                  const failed = yield* completeFailedStep({
-                    stepRun: afterStart,
-                    workItem,
-                    reasonCode: STEP_RUN_REASON.agentBackendRestartRequired,
-                    reasonMessage,
-                    cause: Cause.fail(reasonMessage),
-                  })
-                  return { _tag: "processed" as const, workItem: failed }
-                }
               }
 
               const maxDuration = maxDurations[stepRun.step]
@@ -3933,22 +3918,6 @@ export const makeWorkItemLifecycleLive = (
         },
       ): Effect.Effect<WorkItemRecord, ImplementNowError> =>
         Effect.gen(function* () {
-          yield* activeAgentBackend.requireAgentTurnsAllowed.pipe(
-            Effect.mapError((error) => {
-              if (error._tag === "AgentBackendRestartRequiredError") {
-                return new AgentBackendRestartRequiredError({
-                  message: error.message,
-                  selectedBackendId: error.selectedBackendId,
-                  activeBackendId: error.activeBackendId,
-                })
-              }
-              return new AgentBackendUnavailableError({
-                message: error.message,
-                reason: error.reason,
-              })
-            }),
-          )
-
           const issues = yield* db.listIssues(repositoryId)
           const issue = issues.find(
             (candidate) => candidate.githubIssueNumber === githubIssueNumber,
@@ -4002,88 +3971,106 @@ export const makeWorkItemLifecycleLive = (
             )
           }
 
-          // Fail fast when no build model is configured; models are not stored
-          // on the Work Item and are resolved again at each Agent Turn.
-          yield* resolveModelsForRepository(repositoryId)
-          const activeRegistration =
-            yield* activeAgentBackend.getActiveRegistration
-          const agentBackendId = activeRegistration.descriptor.id
-          const workItemId = makeWorkItemId()
-          const now = yield* Clock.currentTimeMillis
-          const step: OperationalLifecycleStep = "create_worktree"
+          // Coordinate with Config hot-activate so provenance cannot be captured
+          // while Selected is already switching Active. Fail-fast model resolve
+          // runs inside the same section so it matches the backend that is stamped.
+          const createdId = yield* activeAgentBackend.withConfigCoordination(
+            Effect.gen(function* () {
+              yield* activeAgentBackend.requireAgentTurnsAllowed.pipe(
+                Effect.mapError(
+                  (error) =>
+                    new AgentBackendUnavailableError({
+                      message: error.message,
+                      reason: error.reason,
+                    }),
+                ),
+              )
+              // Models are not stored on the Work Item; resolve against the
+              // Active backend / prefs after coordination has locked the switch.
+              yield* resolveModelsForRepository(repositoryId)
+              const activeRegistration =
+                yield* activeAgentBackend.getActiveRegistration
+              const agentBackendId = activeRegistration.descriptor.id
+              const workItemId = makeWorkItemId()
+              const now = yield* Clock.currentTimeMillis
+              const step: OperationalLifecycleStep = "create_worktree"
 
-          const createdId = yield* sql
-            .withTransaction(
-              Effect.gen(function* () {
-                const limit = yield* maxWorkerSlots()
-                const occupied = yield* countOccupiedWorkerSlots()
-                const admit = occupied < limit
+              return yield* sql
+                .withTransaction(
+                  Effect.gen(function* () {
+                    const limit = yield* maxWorkerSlots()
+                    const occupied = yield* countOccupiedWorkerSlots()
+                    const admit = occupied < limit
 
-                yield* sql.unsafe(
-                  `INSERT INTO work_item (
+                    yield* sql.unsafe(
+                      `INSERT INTO work_item (
                  id, repository_id, github_issue_number, agent_backend,
                   issue_title, state, state_ready_at, paused,
                   waiting_since, holds_worker_slot,
                   pause_before_step, worktree_path, session_id, failure_code,
                   failure_message, created_at, updated_at
                 ) VALUES (?, ?, ?, ?, ?, ?, ?, 0, ?, ?, ?, NULL, NULL, NULL, NULL, ?, ?)`,
-                  [
-                    workItemId,
-                    repositoryId,
-                    githubIssueNumber,
-                    agentBackendId,
-                    issue.title,
-                    step,
-                    now,
-                    admit ? null : now,
-                    admit ? 1 : 0,
-                    options.pauseBeforeStep,
-                    now,
-                    now,
-                  ],
-                )
-
-                if (admit) {
-                  yield* enqueueStepRunForWorkItem(workItemId, step, now)
-                }
-
-                return workItemId
-              }),
-            )
-            .pipe(
-              Effect.catch((error): Effect.Effect<never, ImplementNowError> => {
-                if (error instanceof WorkItemLifecycleDatabaseError) {
-                  return Effect.fail(error)
-                }
-                if (error instanceof EnqueueError) {
-                  return Effect.fail(error)
-                }
-                if (error instanceof InvalidQueueNameError) {
-                  return Effect.fail(error)
-                }
-                if (
-                  typeof error === "object" &&
-                  error !== null &&
-                  "_tag" in error &&
-                  (error as { _tag: string })._tag === "SqlError"
-                ) {
-                  const sqlError = error as SqlError
-                  if (isUnfinishedWorkItemUniqueViolation(sqlError)) {
-                    return unfinishedWorkItemExistsError(
-                      repositoryId,
-                      githubIssueNumber,
+                      [
+                        workItemId,
+                        repositoryId,
+                        githubIssueNumber,
+                        agentBackendId,
+                        issue.title,
+                        step,
+                        now,
+                        admit ? null : now,
+                        admit ? 1 : 0,
+                        options.pauseBeforeStep,
+                        now,
+                        now,
+                      ],
                     )
-                  }
-                  return Effect.fail(toDatabaseError(sqlError))
-                }
-                return Effect.fail(
-                  new WorkItemLifecycleDatabaseError({
-                    message: `Unexpected transaction failure: ${String(error)}`,
-                    cause: error,
+
+                    if (admit) {
+                      yield* enqueueStepRunForWorkItem(workItemId, step, now)
+                    }
+
+                    return workItemId
                   }),
                 )
-              }),
-            )
+                .pipe(
+                  Effect.catch(
+                    (error): Effect.Effect<never, ImplementNowError> => {
+                      if (error instanceof WorkItemLifecycleDatabaseError) {
+                        return Effect.fail(error)
+                      }
+                      if (error instanceof EnqueueError) {
+                        return Effect.fail(error)
+                      }
+                      if (error instanceof InvalidQueueNameError) {
+                        return Effect.fail(error)
+                      }
+                      if (
+                        typeof error === "object" &&
+                        error !== null &&
+                        "_tag" in error &&
+                        (error as { _tag: string })._tag === "SqlError"
+                      ) {
+                        const sqlError = error as SqlError
+                        if (isUnfinishedWorkItemUniqueViolation(sqlError)) {
+                          return unfinishedWorkItemExistsError(
+                            repositoryId,
+                            githubIssueNumber,
+                          )
+                        }
+                        return Effect.fail(toDatabaseError(sqlError))
+                      }
+                      return Effect.fail(
+                        new WorkItemLifecycleDatabaseError({
+                          message: `Unexpected transaction failure: ${String(error)}`,
+                          cause: error,
+                        }),
+                      )
+                    },
+                  ),
+                )
+            }),
+          )
 
           const created = yield* getWorkItem(createdId).pipe(
             Effect.catchTag(

--- a/packages/work-item-lifecycle/test/agent-backend-readiness.spec.ts
+++ b/packages/work-item-lifecycle/test/agent-backend-readiness.spec.ts
@@ -1,7 +1,6 @@
 import { Effect, Layer } from "effect"
 import {
   ActiveAgentBackend,
-  AgentBackendRestartRequiredError,
   type AgentBackendStatus,
   AgentBackendUnavailableError,
 } from "@ready-for-agent/agent-backend"
@@ -9,7 +8,6 @@ import { DatabaseTest } from "@ready-for-agent/db/test"
 import { DbService, DbServiceLive } from "@ready-for-agent/db-service"
 import { SqliteQueueServiceLive } from "@ready-for-agent/sqlite-queue-service"
 import {
-  AgentBackendRestartRequiredError as LifecycleRestartRequiredError,
   LifecycleSteps,
   type LifecycleStepsShape,
   AgentBackendUnavailableError as LifecycleUnavailableError,
@@ -57,14 +55,6 @@ const statusUnavailable = (): AgentBackendStatus => ({
   activeBackend: { id: "opencode", label: "OpenCode" },
   kind: "unavailable",
   reason: "opencode binary not found",
-  models: [],
-})
-
-const statusRestart = (): AgentBackendStatus => ({
-  selectedBackend: { id: "opencode", label: "OpenCode" },
-  activeBackend: { id: "opencode", label: "OpenCode" },
-  kind: "restart_required",
-  reason: "Restart required",
   models: [],
 })
 
@@ -129,67 +119,6 @@ describe("Agent Backend readiness gates", () => {
     )
   })
 
-  it("rejects Implement Now while restart is required", async () => {
-    const layer = WorkItemLifecycleLive.pipe(
-      Layer.provideMerge(
-        stubActiveAgentBackendLayer({
-          getStatus: Effect.succeed(statusRestart()),
-          requireAgentTurnsAllowed: Effect.fail(
-            new AgentBackendRestartRequiredError({
-              message: "Restart required",
-              selectedBackendId: "opencode",
-              activeBackendId: "opencode",
-            }),
-          ),
-        }),
-      ),
-      Layer.provideMerge(
-        Layer.succeed(LifecycleSteps, LifecycleSteps.of(successfulSteps)),
-      ),
-      Layer.provideMerge(DbServiceLive),
-      Layer.provideMerge(SqliteQueueServiceLive),
-      Layer.provideMerge(DatabaseTest),
-    )
-
-    await Effect.runPromise(
-      Effect.gen(function* () {
-        const db = yield* DbService
-        const lifecycle = yield* WorkItemLifecycle
-        const repo = yield* db.addRepository({
-          githubOwner: "acme",
-          githubRepo: "widgets",
-          localPath: "/repos/acme/widgets.git",
-          isBare: true,
-        })
-        yield* db.updateConfig({
-          selectedAgentBackend: "opencode",
-          defaultModel: "opencode/deepseek-v4-flash-free",
-          defaultThinkingLevel: "low",
-          reviewModel: null,
-          reviewThinkingLevel: null,
-          maxConcurrentAgentTurns: 2,
-          maxConcurrentWorkItems: 5,
-        })
-        yield* db.storeIssue({
-          repositoryId: repo.id,
-          githubIssueNumber: 1,
-          title: "Issue",
-          body: "body",
-          url: "https://github.com/acme/widgets/issues/1",
-          state: "OPEN",
-          githubCreatedAt: new Date(),
-          issueAuthor: null,
-          parent: null,
-          parentPosition: null,
-          hasChildren: false,
-          blockedBy: [],
-        })
-        const error = yield* Effect.flip(lifecycle.implementNow(repo.id, 1))
-        expect(error).toBeInstanceOf(LifecycleRestartRequiredError)
-      }).pipe(Effect.provide(layer)),
-    )
-  })
-
   it("allows Agent-free create_worktree while backend is unavailable", async () => {
     const layer = WorkItemLifecycleLive.pipe(
       Layer.provideMerge(
@@ -199,7 +128,15 @@ describe("Agent Backend readiness gates", () => {
             getStatus: Effect.succeed(statusUnavailable()),
             recheck: () => Effect.succeed(statusUnavailable()),
             requireAgentTurnsAllowed: Effect.void,
-            setSelectedBackend: () => Effect.succeed(statusUnavailable()),
+            activate: () => Effect.succeed(statusUnavailable()),
+            preview: () =>
+              Effect.succeed({
+                backend: { id: "opencode", label: "OpenCode" },
+                kind: "unavailable" as const,
+                reason: "opencode binary not found",
+                models: [],
+              }),
+            withConfigCoordination: (effect) => effect,
             getActiveRegistration: Effect.succeed({
               descriptor: { id: "opencode", label: "OpenCode" },
               capabilities: [


### PR DESCRIPTION
## Why

Changing **Agent Backend** in Harness settings required a process restart even when no Work Items were unfinished. Operators saw restart ceremony and could not pick models for the new backend in one Save.

## What Changed

- Hot-activate the selected Agent Backend on Save when the fleet is idle (no Harness process restart)
- Agent Backend Preview: load the pending backend’s model catalog before Save
- Remember build/review (+ thinking) model prefs per backend at Harness Config and each Repository
- Remove **Agent Backend Restart Required** (status, errors, UI copy); failure mode is Unavailable only
- Block backend change (UI + API) while any Work Item is unfinished, including Needs Human
- Coordinate config activate with Implement Now so Selected and Active stay aligned under concurrency

Closes #453