### PR TITLE
fix(harness): show backend-blocking work items

### DIFF
--- a/apps/harness/src/refresh-work-items-live.ts
+++ b/apps/harness/src/refresh-work-items-live.ts
@@ -5,6 +5,8 @@ export const committedPullRequestsCountQueryKeyPrefix = [
   "committed-pull-requests-count",
 ] as const
 
+const configQueryKey = ["config"] as const
+
 export type RepositoryWorkItemsLiveQueries = {
   workItems: (repositoryId: string) => {
     queryKey: readonly unknown[]
@@ -205,7 +207,11 @@ export const followRepositoryWorkItemsLive = async ({
     // awaiting aggregates would serialize one full count refresh per event and
     // defeat coalescing under bursty lifecycle notifications.
     scheduleCommittedPullRequestsCounts()
-    await refreshWorkItems(repositoryId)
+    await Promise.all([
+      refreshWorkItems(repositoryId),
+      // Harness Settings includes the global unfinished Work Item count.
+      refreshCachedQueries(configQueryKey),
+    ])
   }
 
   const refreshAll = async () => {
@@ -214,6 +220,7 @@ export const followRepositoryWorkItemsLive = async ({
     await Promise.all([
       ...repositoryIds.map((repositoryId) => refreshWorkItems(repositoryId)),
       refreshCommittedPullRequestsCounts(),
+      refreshCachedQueries(configQueryKey),
     ])
   }
 

--- a/apps/harness/test/refresh-work-items-live.test.ts
+++ b/apps/harness/test/refresh-work-items-live.test.ts
@@ -43,6 +43,7 @@ describe("Repository Work Item live-query coordination", () => {
 
     let selectedWorkItemsFetches = 0
     let otherWorkItemsFetches = 0
+    let configFetches = 0
     let selectedWorkItems = [
       {
         id: "wi-before",
@@ -63,6 +64,15 @@ describe("Repository Work Item live-query coordination", () => {
         },
       }),
     }
+    let unfinishedWorkItemCount = 1
+    const configQuery = {
+      queryKey: ["config"] as const,
+      queryFn: async () => {
+        configFetches += 1
+        return { unfinishedWorkItemCount }
+      },
+    }
+    await queryClient.fetchQuery({ ...configQuery, staleTime: 0 })
 
     let releaseInvalidation: (() => void) | undefined
     const invalidation = new Promise<void>((resolve) => {
@@ -106,8 +116,10 @@ describe("Repository Work Item live-query coordination", () => {
         status: "RUNNING",
       },
     ]
+    unfinishedWorkItemCount = 0
     const fetchesBeforeInvalidation = {
       selectedWorkItems: selectedWorkItemsFetches,
+      config: configFetches,
     }
     releaseInvalidation?.()
 
@@ -126,6 +138,10 @@ describe("Repository Work Item live-query coordination", () => {
     expect(selectedWorkItemsFetches).toBeGreaterThan(
       fetchesBeforeInvalidation.selectedWorkItems,
     )
+    expect(queryClient.getQueryData(configQuery.queryKey)).toEqual({
+      unfinishedWorkItemCount: 0,
+    })
+    expect(configFetches).toBeGreaterThan(fetchesBeforeInvalidation.config)
     // Initial connection refetches both displayed Repositories, but the
     // selected invalidation does not refetch the other Repository again.
     expect(otherWorkItemsFetches).toBe(1)

--- a/packages/graphql-api/src/lib/graphql-api.ts
+++ b/packages/graphql-api/src/lib/graphql-api.ts
@@ -20,6 +20,7 @@ import {
   type WorkItemsListKind,
   filterWorkItemsByListKind,
   isJobsCompletedWorkItemState,
+  isJobsWorkingWorkItem,
   isRetryableFailedWorkItem,
   isRetryableNeedsHumanWorkItem,
   isTerminalWorkItemState,
@@ -395,7 +396,7 @@ export const createGraphqlApi = (
                 const visible = workItems.filter(
                   (workItem) =>
                     isJobsCompletedWorkItemState(workItem.state) ||
-                    !isTerminalWorkItemState(workItem.state) ||
+                    isJobsWorkingWorkItem(workItem) ||
                     relevantIssueNumbers.has(workItem.githubIssueNumber),
                 )
                 return filterWorkItemsByListKind(visible, listKind, limit)

--- a/packages/graphql-api/test/graphql-api.test.ts
+++ b/packages/graphql-api/test/graphql-api.test.ts
@@ -2269,7 +2269,7 @@ describe("GraphQL API", () => {
     })
   })
 
-  test("filters Working Work Items including retriable failures", async () => {
+  test("shows Working Work Items after their Issues leave the Issue store", async () => {
     const needsHuman = {
       ...workItem,
       id: makeWorkItemId(),
@@ -2340,7 +2340,7 @@ describe("GraphQL API", () => {
     await runtime.dispose()
     runtime = makeRuntime(
       {
-        listIssues: () => Effect.succeed([issue]),
+        listIssues: () => Effect.succeed([]),
       },
       {},
       {},
@@ -2593,7 +2593,7 @@ describe("GraphQL API", () => {
     })
   })
 
-  test("hides non-Completed terminal Work Items whose Issue is no longer Relevant", async () => {
+  test("keeps Working Work Items whose Issue is no longer Relevant", async () => {
     const needsHumanOrphan = {
       ...workItem,
       id: makeWorkItemId(),
@@ -2670,6 +2670,11 @@ describe("GraphQL API", () => {
     expect(await response.json()).toEqual({
       data: {
         workItems: [
+          {
+            id: needsHumanOrphan.id,
+            githubIssueNumber: 120,
+            state: "NEEDS_HUMAN",
+          },
           {
             id: unfinishedOrphan.id,
             githubIssueNumber: 121,


### PR DESCRIPTION
## Why

Harness Settings blocks an Agent Backend change while Work Items remain unfinished. `Needs Human` items whose Issues had left the Relevant Issue store were hidden from Jobs, leaving operators unable to see the records responsible for the block.

## What Changed

- Keep Jobs Working items, including `Needs Human` handoffs, visible after their Issues leave the Issue store.
- Refresh the cached Harness Settings count when Work Item lifecycle notifications arrive.
- Cover both the Working-list visibility and Settings-cache refresh behavior with regression tests.

## Verification

Reproduced against the local harness data: two `Needs Human` items made Settings report two unfinished Work Items while Jobs reported zero. After the change, the API and Jobs Working tab both show those two items.
