### PR TITLE
feat(work-item-lifecycle): combine work turns with Agent-reported Outcomes

### DIFF
--- a/packages/work-item-lifecycle/src/lib/pr-status-checks.ts
+++ b/packages/work-item-lifecycle/src/lib/pr-status-checks.ts
@@ -370,6 +370,12 @@ export const parseInvestigationResult = (
   return null
 }
 
+/** True when any READY_FOR_AGENT_RESULT line is present (valid or not). */
+const hasInvestigationResultLine = (output: string): boolean =>
+  output
+    .split("\n")
+    .some((line) => /^READY_FOR_AGENT_RESULT:/i.test(line.trim()))
+
 const countAutomatedReviewReruns = (
   workItemId: string,
   headSha: string,
@@ -523,7 +529,7 @@ const buildInvestigationWorkPrompt = (
       "Once an automated-review check is terminal, its Automated Review Output is final: do not wait for later comments. A successful terminal review with no relevant comment means no feedback and must not be rerun.",
       "Use provider-specific progress artifacts as evidence of incompleteness only when a positively identified review comment is present but visibly incomplete. Strong evidence can include a finished banner combined with unchecked substantive review tasks, a remaining working spinner, and no final findings or synthesis. Do not treat arbitrary Markdown checkboxes in unrelated pull-request comments as an automated-review progress list.",
       "Correlate the latest relevant comment with the latest relevant run attempt. Do not rerun because of a stale incomplete comment when a newer attempt completed its review successfully.",
-      "Present, positively identified, visibly incomplete Automated Review Output requires a whole-review workflow rerun in the verdict turn (even when the run concluded success). Do not call GitHub workflow rerun APIs yourself; the harness authorizes and executes reruns. Do not use a failed-jobs-only rerun for a technically successful run.",
+      "Present, positively identified, visibly incomplete Automated Review Output requires a whole-review workflow rerun in this turn (even when the run concluded success). Do not call GitHub workflow rerun APIs yourself; the harness authorizes and executes reruns. Do not use a failed-jobs-only rerun for a technically successful run.",
       "Requesting a terminal incomplete review rerun is required recovery, not optional feedback handling. Report FAILED for a technical inability to inspect the relevant review state. Report NEEDS_HUMAN only when evidence shows that an operator must perform or decide the required action.",
       "For a genuinely completed latest review, address worthwhile feedback. A completed review with no worthwhile feedback, or a successful terminal review with no relevant comment, still needs no changes or rerun.",
       "If review feedback requires changes, verify them, commit them, and push the commit to the existing PR branch.",
@@ -533,38 +539,43 @@ const buildInvestigationWorkPrompt = (
     "If you create a commit during this handoff, after pushing it post one comment on the existing pull request that includes the commit SHA, summarizes the changes and verification, identifies the review feedback addressed, and lists any review feedback declined with a brief reason (or says none was declined).",
     "Do not post this summary comment when you did not create a commit.",
     "Do not create or merge another pull request.",
-    "When finished, stop. Do not print a READY_FOR_AGENT_RESULT line yet; a follow-up turn will ask for the verdict.",
   )
   return lines.join("\n")
 }
 
-const buildInvestigationVerdictPrompt = (): string =>
+/** Shared outcome contract for status-check work, recovery, and fallback. */
+const investigationOutcomeContractLines = (): readonly string[] => [
+  "You may include a concise work and verification summary before the result line.",
+  "End your final response with exactly one machine-readable result line:",
+  "READY_FOR_AGENT_RESULT: CHECKS_TRIGGERED",
+  "Use CHECKS_TRIGGERED when you completed an action expected to create replacement check executions (for example a commit and push, or successfully restarting failed checks).",
+  "READY_FOR_AGENT_RESULT: PROCESSED",
+  "Use PROCESSED when the handoff is handled and no replacement execution is expected: for example a green-only handoff with no relevant automated-review run or comment (including a skipped reviewer with no review output), a successful terminal review with no relevant comment (no feedback), or a genuinely completed review that had nothing to address.",
+  "Do not report PROCESSED for a present, positively identified, visibly incomplete automated review that still needs a whole-workflow rerun. Request the rerun instead.",
+  "When positive review evidence shows present, positively identified, visibly incomplete Automated Review Output that needs a whole-workflow rerun, do not call GitHub yourself. Report the workflow run id (and optional workflow name) so the harness can authorize and execute the rerun:",
+  "READY_FOR_AGENT_RESULT: RERUN_REVIEW: <workflow_run_id>",
+  "READY_FOR_AGENT_RESULT: RERUN_REVIEW: <workflow_run_id> <workflow_name>",
+  "If this handoff contained red checks and you made no commit, push, check restart, or other action capable of producing a new execution, leaving the PR red, you must not report PROCESSED or CHECKS_TRIGGERED. Report:",
+  "READY_FOR_AGENT_RESULT: FAILED: <concise reason>",
+  "Also use FAILED when a technical or observability failure prevented you from determining the relevant review state.",
+  "Use NEEDS_HUMAN only when evidence shows that an operator must perform or decide a required action:",
+  "READY_FOR_AGENT_RESULT: NEEDS_HUMAN: <concise reason>",
+]
+
+const buildInvestigationOutcomeFallbackPrompt = (): string =>
   [
     "Based only on the PR status-check work you just did in this session, report the outcome.",
     "Do not make further code changes unless required to answer accurately.",
-    "Reply with exactly one machine-readable result line (and optional brief prose before it):",
-    "READY_FOR_AGENT_RESULT: CHECKS_TRIGGERED",
-    "Use CHECKS_TRIGGERED when you completed an action expected to create replacement check executions (for example a commit and push, or successfully restarting failed checks).",
-    "READY_FOR_AGENT_RESULT: PROCESSED",
-    "Use PROCESSED when the handoff is handled and no replacement execution is expected: for example a green-only handoff with no relevant automated-review run or comment (including a skipped reviewer with no review output), a successful terminal review with no relevant comment (no feedback), or a genuinely completed review that had nothing to address.",
-    "Do not report PROCESSED for a present, positively identified, visibly incomplete automated review that still needs a whole-workflow rerun. Request the rerun instead.",
-    "When positive review evidence shows present, positively identified, visibly incomplete Automated Review Output that needs a whole-workflow rerun, do not call GitHub yourself. Report the workflow run id (and optional workflow name) so the harness can authorize and execute the rerun:",
-    "READY_FOR_AGENT_RESULT: RERUN_REVIEW: <workflow_run_id>",
-    "READY_FOR_AGENT_RESULT: RERUN_REVIEW: <workflow_run_id> <workflow_name>",
-    "If this handoff contained red checks and you made no commit, push, check restart, or other action capable of producing a new execution, leaving the PR red, you must not report PROCESSED or CHECKS_TRIGGERED. Report:",
-    "READY_FOR_AGENT_RESULT: FAILED: <concise reason>",
-    "Also use FAILED when a technical or observability failure prevented you from determining the relevant review state.",
-    "Use NEEDS_HUMAN only when evidence shows that an operator must perform or decide a required action:",
-    "READY_FOR_AGENT_RESULT: NEEDS_HUMAN: <concise reason>",
+    ...investigationOutcomeContractLines(),
   ].join("\n")
 
 const buildInvestigationRecoveryPrompt = (reason: string): string =>
   [
     "Make one focused recovery attempt to process the PR Status Check Handoff.",
-    `Your previous verdict was FAILED: ${reason}`,
+    `Your previous outcome was FAILED: ${reason}`,
     "Re-check the current pull request and retry the failed inspection or any safe action that can produce a replacement check execution, including restarting an appropriate failed workflow.",
     "Do not create an empty or no-op commit merely to restart checks.",
-    "When finished, stop. Do not print a READY_FOR_AGENT_RESULT line yet; a follow-up turn will ask for the verdict.",
+    ...investigationOutcomeContractLines(),
   ].join("\n")
 
 export const investigatePrStatusChecks = (context: LifecycleStepContext) =>
@@ -620,44 +631,27 @@ export const investigatePrStatusChecks = (context: LifecycleStepContext) =>
         )
     }
     const agentBackend = yield* AgentBackend
-    yield* agentBackend
-      .continueTurn({
-        sessionId,
-        prompt: [
-          buildInvestigationWorkPrompt(unhandled, diagnostics),
-          agentTurnGitHubCredentialGuidance(
-            auth,
-            "GitHub CLI, API, commit, or push access",
-          ),
-        ].join("\n"),
-        cwd: worktreePath,
-        model: context.model,
-        thinkingLevel: context.thinkingLevel,
-        timeout:
-          context.maxDuration ??
-          DEFAULT_LIFECYCLE_MAX_DURATIONS.investigate_pr_status_checks,
-      })
-      .pipe(
-        Effect.mapError(
-          (cause) =>
-            new PrStatusChecksOpenCodeError({
-              message:
-                "OpenCode failed while investigating PR status checks (work)",
-              cause,
-            }),
-        ),
-      )
-    const requestVerdict = (phase: string) =>
+    const timeout =
+      context.maxDuration ??
+      DEFAULT_LIFECYCLE_MAX_DURATIONS.investigate_pr_status_checks
+    const missingOutcomeMessage =
+      "OpenCode did not report CHECKS_TRIGGERED, PROCESSED, RERUN_REVIEW, FAILED, or NEEDS_HUMAN"
+
+    const continueInvestigationTurn = (
+      prompt: string,
+      phase: string,
+    ): Effect.Effect<
+      { readonly assistantText: string },
+      PrStatusChecksOpenCodeError
+    > =>
       agentBackend
         .continueTurn({
           sessionId,
-          prompt: buildInvestigationVerdictPrompt(),
+          prompt,
           cwd: worktreePath,
           model: context.model,
           thinkingLevel: context.thinkingLevel,
-          timeout:
-            context.maxDuration ??
-            DEFAULT_LIFECYCLE_MAX_DURATIONS.investigate_pr_status_checks,
+          timeout,
         })
         .pipe(
           Effect.mapError(
@@ -667,43 +661,58 @@ export const investigatePrStatusChecks = (context: LifecycleStepContext) =>
                 cause,
               }),
           ),
-          Effect.flatMap(({ assistantText }) => {
-            const result = parseInvestigationResult(assistantText)
-            return result === null
-              ? Effect.fail(
-                  new PrStatusChecksOpenCodeError({
-                    message:
-                      "OpenCode did not report CHECKS_TRIGGERED, PROCESSED, RERUN_REVIEW, FAILED, or NEEDS_HUMAN",
-                  }),
-                )
-              : Effect.succeed(result)
-          }),
         )
 
-    let investigation = yield* requestVerdict("verdict")
+    /**
+     * Parse an Agent-reported Outcome from a work turn. Missing markers get one
+     * classification-only fallback; malformed or non-final markers fail strictly.
+     */
+    const parseWithMissingOutcomeFallback = (
+      assistantText: string,
+      fallbackPhase: string,
+    ): Effect.Effect<ParsedInvestigationResult, PrStatusChecksOpenCodeError> =>
+      Effect.gen(function* () {
+        let result = parseInvestigationResult(assistantText)
+        if (result === null && !hasInvestigationResultLine(assistantText)) {
+          const fallback = yield* continueInvestigationTurn(
+            buildInvestigationOutcomeFallbackPrompt(),
+            fallbackPhase,
+          )
+          result = parseInvestigationResult(fallback.assistantText)
+        }
+        if (result === null) {
+          return yield* new PrStatusChecksOpenCodeError({
+            message: missingOutcomeMessage,
+          })
+        }
+        return result
+      })
+
+    const work = yield* continueInvestigationTurn(
+      [
+        buildInvestigationWorkPrompt(unhandled, diagnostics),
+        agentTurnGitHubCredentialGuidance(
+          auth,
+          "GitHub CLI, API, commit, or push access",
+        ),
+        // Outcome contract must remain last so the final-line rule is not diluted.
+        ...investigationOutcomeContractLines(),
+      ].join("\n"),
+      "work",
+    )
+    let investigation = yield* parseWithMissingOutcomeFallback(
+      work.assistantText,
+      "outcome fallback",
+    )
     if (typeof investigation !== "string" && investigation._tag === "failed") {
-      yield* agentBackend
-        .continueTurn({
-          sessionId,
-          prompt: buildInvestigationRecoveryPrompt(investigation.reason),
-          cwd: worktreePath,
-          model: context.model,
-          thinkingLevel: context.thinkingLevel,
-          timeout:
-            context.maxDuration ??
-            DEFAULT_LIFECYCLE_MAX_DURATIONS.investigate_pr_status_checks,
-        })
-        .pipe(
-          Effect.mapError(
-            (cause) =>
-              new PrStatusChecksOpenCodeError({
-                message:
-                  "OpenCode failed while investigating PR status checks (recovery)",
-                cause,
-              }),
-          ),
-        )
-      investigation = yield* requestVerdict("recovery verdict")
+      const recovery = yield* continueInvestigationTurn(
+        buildInvestigationRecoveryPrompt(investigation.reason),
+        "recovery",
+      )
+      investigation = yield* parseWithMissingOutcomeFallback(
+        recovery.assistantText,
+        "recovery outcome fallback",
+      )
     }
 
     const handledCheckIds = unhandled.map((check) => check.id)

--- a/packages/work-item-lifecycle/src/lib/resolve-pr-merge-conflict.ts
+++ b/packages/work-item-lifecycle/src/lib/resolve-pr-merge-conflict.ts
@@ -56,6 +56,19 @@ const parseResult = (
     : { reason: needsHuman[1].trim().slice(0, 500) }
 }
 
+const hasResultLine = (output: string): boolean =>
+  output
+    .split("\n")
+    .some((line) => /^READY_FOR_AGENT_RESULT:/i.test(line.trim()))
+
+const mergeConflictOutcomeContractLines = (): readonly string[] => [
+  "You may include a concise work and verification summary before the result line.",
+  "End your final response with exactly one machine-readable result line:",
+  "READY_FOR_AGENT_RESULT: PROCESSED",
+  "or, only when the conflict could not be resolved and pushed autonomously or requires a human decision:",
+  "READY_FOR_AGENT_RESULT: NEEDS_HUMAN: <concise reason>",
+]
+
 const workPrompt = (auth: AgentTurnGitHubAuth): string =>
   [
     "Resolve the merge conflict on the existing pull request for this worktree by rebasing its branch.",
@@ -63,23 +76,20 @@ const workPrompt = (auth: AgentTurnGitHubAuth): string =>
     "Incorporate every current remote commit from the pull-request branch into the local branch before rebasing onto the latest remote base branch. Do not drop another contributor's commits.",
     "Resolve the rebase conflicts, then run the appropriate verification for the repository.",
     "Push the rebased pull-request branch with --force-with-lease. Do not use an unconditional force push.",
-    "If the lease is rejected, refetch, incorporate the updated remote PR branch, rebase onto the current remote base again, verify, and retry the --force-with-lease push exactly once. If that second push cannot safely succeed, stop and report that human intervention is needed in the follow-up verdict turn.",
+    "If the lease is rejected, refetch, incorporate the updated remote PR branch, rebase onto the current remote base again, verify, and retry the --force-with-lease push exactly once. If that second push cannot safely succeed, stop and report human intervention is needed via the NEEDS_HUMAN outcome.",
     "Do not create or merge another pull request and do not do unrelated work.",
     agentTurnGitHubCredentialGuidance(
       auth,
       "GitHub CLI, API, fetch, or push access",
     ),
-    "When finished, stop. Do not print a READY_FOR_AGENT_RESULT line yet; a follow-up turn will ask for the verdict.",
+    ...mergeConflictOutcomeContractLines(),
   ].join("\n")
 
-const verdictPrompt = (): string =>
+const outcomeFallbackPrompt = (): string =>
   [
     "Based only on the PR merge-conflict resolution work you just did in this session, report the outcome.",
     "Do not make further code changes unless required to answer accurately.",
-    "Reply with exactly one machine-readable result line (and optional brief prose before it):",
-    "READY_FOR_AGENT_RESULT: PROCESSED",
-    "or, only when the conflict could not be resolved and pushed autonomously or requires a human decision:",
-    "READY_FOR_AGENT_RESULT: NEEDS_HUMAN: <concise reason>",
+    ...mergeConflictOutcomeContractLines(),
   ].join("\n")
 
 export const resolvePrMergeConflict = (context: LifecycleStepContext) =>
@@ -124,7 +134,7 @@ export const resolvePrMergeConflict = (context: LifecycleStepContext) =>
     const timeout =
       context.maxDuration ??
       DEFAULT_LIFECYCLE_MAX_DURATIONS.resolve_pr_merge_conflict
-    yield* agentBackend
+    const work = yield* agentBackend
       .continueTurn({
         sessionId: context.sessionId,
         prompt: workPrompt(auth),
@@ -143,26 +153,29 @@ export const resolvePrMergeConflict = (context: LifecycleStepContext) =>
             }),
         ),
       )
-    const verdict = yield* agentBackend
-      .continueTurn({
-        sessionId: context.sessionId,
-        prompt: verdictPrompt(),
-        cwd: context.worktreePath,
-        model: context.model,
-        thinkingLevel: context.thinkingLevel,
-        timeout,
-      })
-      .pipe(
-        Effect.mapError(
-          (cause) =>
-            new ResolvePrMergeConflictOpenCodeError({
-              message:
-                "OpenCode failed while resolving PR merge conflict (verdict)",
-              cause,
-            }),
-        ),
-      )
-    const result = parseResult(verdict.assistantText)
+    let result = parseResult(work.assistantText)
+    if (result === null && !hasResultLine(work.assistantText)) {
+      const fallback = yield* agentBackend
+        .continueTurn({
+          sessionId: context.sessionId,
+          prompt: outcomeFallbackPrompt(),
+          cwd: context.worktreePath,
+          model: context.model,
+          thinkingLevel: context.thinkingLevel,
+          timeout,
+        })
+        .pipe(
+          Effect.mapError(
+            (cause) =>
+              new ResolvePrMergeConflictOpenCodeError({
+                message:
+                  "OpenCode failed while resolving PR merge conflict (outcome fallback)",
+                cause,
+              }),
+          ),
+        )
+      result = parseResult(fallback.assistantText)
+    }
     if (result === null) {
       return yield* new ResolvePrMergeConflictOpenCodeError({
         message: "OpenCode did not report PROCESSED or NEEDS_HUMAN",

--- a/packages/work-item-lifecycle/test/pr-status-checks.spec.ts
+++ b/packages/work-item-lifecycle/test/pr-status-checks.spec.ts
@@ -469,7 +469,7 @@ describe("PR status check steps", () => {
     ])
   })
 
-  it("processes a red batch in a work turn followed by a verdict turn", async () => {
+  it("processes a red batch in one combined work and outcome turn", async () => {
     const prompts: string[] = []
     const result = await Effect.runPromise(
       Effect.gen(function* () {
@@ -535,7 +535,7 @@ describe("PR status check steps", () => {
             ),
             keymaxxer,
             opencodeWith(
-              ["fixed and pushed", "READY_FOR_AGENT_RESULT: CHECKS_TRIGGERED"],
+              ["fixed and pushed\nREADY_FOR_AGENT_RESULT: CHECKS_TRIGGERED"],
               (prompt, sessionId) => {
                 expect(sessionId).toBe("ses_implement")
                 prompts.push(prompt)
@@ -553,7 +553,7 @@ describe("PR status check steps", () => {
     }
     expect(result.investigation.handledCheckIds).toHaveLength(2)
     expect(result.rows.every((row) => row.handled_at === null)).toBe(true)
-    expect(prompts).toHaveLength(2)
+    expect(prompts).toHaveLength(1)
     expect(prompts[0]).toContain("Diagnose and fix these failing checks")
     expect(prompts[0]).toContain(
       "- lint (external id: actions-job:88026385443, source: Actions job)",
@@ -575,13 +575,21 @@ describe("PR status check steps", () => {
     )
     expect(prompts[0]).not.toContain("automated reviews may have completed")
     expect(prompts[0]).toContain("restart the failed checks when appropriate")
-    expect(prompts[1]).toContain("READY_FOR_AGENT_RESULT: CHECKS_TRIGGERED")
-    expect(prompts[1]).toContain("READY_FOR_AGENT_RESULT: PROCESSED")
-    expect(prompts[1]).toContain("READY_FOR_AGENT_RESULT: FAILED:")
-    expect(prompts[1]).toContain(
+    expect(prompts[0]).toContain("READY_FOR_AGENT_RESULT: CHECKS_TRIGGERED")
+    expect(prompts[0]).toContain("READY_FOR_AGENT_RESULT: PROCESSED")
+    expect(prompts[0]).toContain("READY_FOR_AGENT_RESULT: FAILED:")
+    expect(prompts[0]).toContain(
       "If this handoff contained red checks and you made no commit, push, check restart",
     )
-    expect(prompts[1]).toContain("replacement check executions")
+    expect(prompts[0]).toContain("replacement check executions")
+    const credentialIndex = prompts[0].indexOf(
+      "Use Keymaxxer secret GITHUB_TOKEN_ACME_WIDGETS via keymaxxer_run",
+    )
+    const outcomeContractIndex = prompts[0].indexOf(
+      "End your final response with exactly one machine-readable result line:",
+    )
+    expect(credentialIndex).toBeGreaterThan(-1)
+    expect(outcomeContractIndex).toBeGreaterThan(credentialIndex)
   })
 
   it("uses ambient gh guidance for investigate when the backend lacks KeymaxxerMcp", async () => {
@@ -620,7 +628,7 @@ describe("PR status check steps", () => {
             }),
             vaultOnWithoutLookup,
             opencodeWith(
-              ["fixed and pushed", "READY_FOR_AGENT_RESULT: CHECKS_TRIGGERED"],
+              ["fixed and pushed\nREADY_FOR_AGENT_RESULT: CHECKS_TRIGGERED"],
               (prompt) => prompts.push(prompt),
             ),
             DatabaseTest,
@@ -658,10 +666,8 @@ describe("PR status check steps", () => {
             keymaxxer,
             opencodeWith(
               [
-                "No code changes, commit, push, or PR comment were made.",
-                "READY_FOR_AGENT_RESULT: FAILED: ActionLint failed on GitHub 503",
-                "Reran the failed workflow; a replacement execution is queued.",
-                "READY_FOR_AGENT_RESULT: CHECKS_TRIGGERED",
+                "No code changes, commit, push, or PR comment were made.\nREADY_FOR_AGENT_RESULT: FAILED: ActionLint failed on GitHub 503",
+                "Reran the failed workflow; a replacement execution is queued.\nREADY_FOR_AGENT_RESULT: CHECKS_TRIGGERED",
               ],
               (prompt) => prompts.push(prompt),
             ),
@@ -676,13 +682,15 @@ describe("PR status check steps", () => {
       handledCheckIds: [expect.any(String)],
       checkStartAnchorRecorded: false,
     })
-    expect(prompts).toHaveLength(4)
-    expect(prompts[2]).toContain("focused recovery attempt")
-    expect(prompts[2]).toContain("ActionLint failed on GitHub 503")
-    expect(prompts[2]).toContain("process the PR Status Check Handoff")
-    expect(prompts[2]).toContain("retry the failed inspection")
-    expect(prompts[2]).toContain("Do not create an empty or no-op commit")
-    expect(prompts[3]).toContain("READY_FOR_AGENT_RESULT: FAILED:")
+    expect(prompts).toHaveLength(2)
+    expect(prompts[0]).toContain("READY_FOR_AGENT_RESULT: FAILED:")
+    expect(prompts[1]).toContain("focused recovery attempt")
+    expect(prompts[1]).toContain("ActionLint failed on GitHub 503")
+    expect(prompts[1]).toContain("process the PR Status Check Handoff")
+    expect(prompts[1]).toContain("retry the failed inspection")
+    expect(prompts[1]).toContain("Do not create an empty or no-op commit")
+    expect(prompts[1]).toContain("READY_FOR_AGENT_RESULT: CHECKS_TRIGGERED")
+    expect(prompts[1]).toContain("READY_FOR_AGENT_RESULT: FAILED:")
   })
 
   it("fails retryably after the focused recovery attempt still cannot act", async () => {
@@ -704,10 +712,8 @@ describe("PR status check steps", () => {
             }),
             keymaxxer,
             opencodeWith([
-              "No safe action was available.",
-              "READY_FOR_AGENT_RESULT: FAILED: ActionLint failed on GitHub 503",
-              "I checked the current PR and cannot safely restart or change it.",
-              "READY_FOR_AGENT_RESULT: FAILED: No autonomous recovery action remains",
+              "No safe action was available.\nREADY_FOR_AGENT_RESULT: FAILED: ActionLint failed on GitHub 503",
+              "I checked the current PR and cannot safely restart or change it.\nREADY_FOR_AGENT_RESULT: FAILED: No autonomous recovery action remains",
             ]),
             DatabaseTest,
           ),
@@ -796,7 +802,7 @@ describe("PR status check steps", () => {
             }),
             keymaxxer,
             opencodeWith(
-              ["done", "READY_FOR_AGENT_RESULT: PROCESSED"],
+              ["done\nREADY_FOR_AGENT_RESULT: PROCESSED"],
               (prompt) => {
                 prompts.push(prompt)
               },
@@ -904,8 +910,7 @@ describe("PR status check steps", () => {
             keymaxxer,
             opencodeWith(
               [
-                "No review feedback needed changes.",
-                "READY_FOR_AGENT_RESULT: PROCESSED",
+                "No review feedback needed changes.\nREADY_FOR_AGENT_RESULT: PROCESSED",
               ],
               (prompt) => prompts.push(prompt),
             ),
@@ -919,23 +924,24 @@ describe("PR status check steps", () => {
       _tag: "processed",
       handledCheckIds: [expect.any(String)],
     })
-    expect(prompts[1]).toContain("READY_FOR_AGENT_RESULT: CHECKS_TRIGGERED")
-    expect(prompts[1]).toContain("READY_FOR_AGENT_RESULT: RERUN_REVIEW:")
-    expect(prompts[1]).toContain(
+    expect(prompts).toHaveLength(1)
+    expect(prompts[0]).toContain("READY_FOR_AGENT_RESULT: CHECKS_TRIGGERED")
+    expect(prompts[0]).toContain("READY_FOR_AGENT_RESULT: RERUN_REVIEW:")
+    expect(prompts[0]).toContain(
       "Do not report PROCESSED for a present, positively identified, visibly incomplete automated review that still needs a whole-workflow rerun",
     )
-    expect(prompts[1]).toContain(
+    expect(prompts[0]).toContain(
       "including a skipped reviewer with no review output",
     )
-    expect(prompts[1]).toContain(
+    expect(prompts[0]).toContain(
       "genuinely completed review that had nothing to address",
     )
-    expect(prompts[1]).toContain("no relevant automated-review run or comment")
-    expect(prompts[1]).toContain(
+    expect(prompts[0]).toContain("no relevant automated-review run or comment")
+    expect(prompts[0]).toContain(
       "successful terminal review with no relevant comment (no feedback)",
     )
-    expect(prompts[1]).not.toContain("READY_FOR_AGENT_RESULT: WAITING")
-    expect(prompts[1]).toContain(
+    expect(prompts[0]).not.toContain("READY_FOR_AGENT_RESULT: WAITING")
+    expect(prompts[0]).toContain(
       "technical or observability failure prevented you from determining the relevant review state",
     )
   })
@@ -959,8 +965,7 @@ describe("PR status check steps", () => {
             }),
             keymaxxer,
             opencodeWith([
-              "Terminal successful review with no relevant comment; no feedback.",
-              "READY_FOR_AGENT_RESULT: PROCESSED",
+              "Terminal successful review with no relevant comment; no feedback.\nREADY_FOR_AGENT_RESULT: PROCESSED",
             ]),
             DatabaseTest,
           ),
@@ -1010,8 +1015,7 @@ describe("PR status check steps", () => {
             }),
             keymaxxer,
             opencodeWith([
-              "investigated",
-              "READY_FOR_AGENT_RESULT: NEEDS_HUMAN: A maintainer must approve deployment",
+              "investigated\nREADY_FOR_AGENT_RESULT: NEEDS_HUMAN: A maintainer must approve deployment",
             ]),
             DatabaseTest,
           ),
@@ -1026,7 +1030,7 @@ describe("PR status check steps", () => {
     })
   })
 
-  it("resolves a merge conflict in a work turn followed by a verdict turn", async () => {
+  it("resolves a merge conflict in one combined work and outcome turn", async () => {
     const prompts: string[] = []
     const result = await Effect.runPromise(
       resolvePrMergeConflict(context).pipe(
@@ -1036,8 +1040,7 @@ describe("PR status check steps", () => {
             keymaxxer,
             opencodeWith(
               [
-                "rebased, verified, and pushed",
-                "READY_FOR_AGENT_RESULT: PROCESSED",
+                "rebased, verified, and pushed\nREADY_FOR_AGENT_RESULT: PROCESSED",
               ],
               (prompt, sessionId) => {
                 expect(sessionId).toBe("ses_implement")
@@ -1050,7 +1053,7 @@ describe("PR status check steps", () => {
     )
 
     expect(result).toEqual({ _tag: "processed" })
-    expect(prompts).toHaveLength(2)
+    expect(prompts).toHaveLength(1)
     expect(prompts[0]).toContain("Fetch origin")
     expect(prompts[0]).toContain("current base branch")
     expect(prompts[0]).toContain("every current remote commit")
@@ -1059,7 +1062,8 @@ describe("PR status check steps", () => {
     expect(prompts[0]).toContain(
       "Use Keymaxxer secret GITHUB_TOKEN_ACME_WIDGETS via keymaxxer_run",
     )
-    expect(prompts[1]).toContain("READY_FOR_AGENT_RESULT: PROCESSED")
+    expect(prompts[0]).toContain("READY_FOR_AGENT_RESULT: PROCESSED")
+    expect(prompts[0]).toContain("READY_FOR_AGENT_RESULT: NEEDS_HUMAN:")
   })
 
   it("uses ambient gh guidance for merge-conflict when Keymaxxer is disabled", async () => {
@@ -1085,8 +1089,7 @@ describe("PR status check steps", () => {
             disabled,
             opencodeWith(
               [
-                "rebased, verified, and pushed",
-                "READY_FOR_AGENT_RESULT: PROCESSED",
+                "rebased, verified, and pushed\nREADY_FOR_AGENT_RESULT: PROCESSED",
               ],
               (prompt) => prompts.push(prompt),
             ),
@@ -1096,6 +1099,7 @@ describe("PR status check steps", () => {
     )
 
     expect(result).toEqual({ _tag: "processed" })
+    expect(prompts).toHaveLength(1)
     expect(prompts[0]?.toLowerCase()).not.toContain("keymaxxer")
     expect(prompts[0]).toContain(
       "Use the gh CLI with the existing ambient authentication",
@@ -1110,8 +1114,7 @@ describe("PR status check steps", () => {
             db,
             keymaxxer,
             opencodeWith([
-              "the second lease-protected push was rejected",
-              "READY_FOR_AGENT_RESULT: NEEDS_HUMAN: The PR branch changed during both push attempts",
+              "the second lease-protected push was rejected\nREADY_FOR_AGENT_RESULT: NEEDS_HUMAN: The PR branch changed during both push attempts",
             ]),
           ),
         ),
@@ -1124,20 +1127,13 @@ describe("PR status check steps", () => {
     })
   })
 
-  it("leaves checks unhandled after malformed verdict output", async () => {
+  it("uses one classification fallback when the work turn omits the outcome", async () => {
+    const prompts: string[] = []
     const result = await Effect.runPromise(
       Effect.gen(function* () {
         yield* seedWorkItem
         yield* watchPrStatusChecks(context)
-        const investigation = yield* Effect.result(
-          investigatePrStatusChecks(context),
-        )
-        const sql = yield* SqlClient.SqlClient
-        const observed = (yield* sql.unsafe(
-          `SELECT handled_at FROM pr_status_check WHERE work_item_id = ?`,
-          [context.workItemId],
-        )) as readonly { handled_at: number | null }[]
-        return { investigation, observed }
+        return yield* investigatePrStatusChecks(context)
       }).pipe(
         Effect.provide(
           Layer.mergeAll(
@@ -1150,18 +1146,181 @@ describe("PR status check steps", () => {
               ],
             }),
             keymaxxer,
-            opencodeWith(["fixed", "I forgot the marker"]),
+            opencodeWith(
+              [
+                "fixed and pushed; replacement checks should run",
+                "READY_FOR_AGENT_RESULT: CHECKS_TRIGGERED",
+              ],
+              (prompt) => prompts.push(prompt),
+            ),
             DatabaseTest,
           ),
         ),
       ),
     )
 
-    expect(result.investigation._tag).toBe("Failure")
-    expect(result.observed.every((row) => row.handled_at === null)).toBe(true)
+    expect(result).toEqual({
+      _tag: "checks_triggered",
+      handledCheckIds: [expect.any(String)],
+      checkStartAnchorRecorded: false,
+    })
+    expect(prompts).toHaveLength(2)
+    expect(prompts[1]).toContain(
+      "Based only on the PR status-check work you just did",
+    )
+    expect(prompts[1]).toContain("READY_FOR_AGENT_RESULT: CHECKS_TRIGGERED")
   })
 
-  it("rejects conflicting verdict markers and leaves checks unhandled", async () => {
+  it("uses one classification fallback when recovery omits the outcome", async () => {
+    const prompts: string[] = []
+    const result = await Effect.runPromise(
+      Effect.gen(function* () {
+        yield* seedWorkItem
+        yield* watchPrStatusChecks(context)
+        return yield* investigatePrStatusChecks(context)
+      }).pipe(
+        Effect.provide(
+          Layer.mergeAll(
+            db,
+            githubWith({
+              _tag: "failed",
+              ...mergeable,
+              terminalChecks: [
+                { externalId: "checkrun:1", name: "lint", outcome: "red" },
+              ],
+            }),
+            keymaxxer,
+            opencodeWith(
+              [
+                "READY_FOR_AGENT_RESULT: FAILED: ActionLint failed on GitHub 503",
+                "Reran the failed workflow; a replacement execution is queued.",
+                "READY_FOR_AGENT_RESULT: CHECKS_TRIGGERED",
+              ],
+              (prompt) => prompts.push(prompt),
+            ),
+            DatabaseTest,
+          ),
+        ),
+      ),
+    )
+
+    expect(result).toEqual({
+      _tag: "checks_triggered",
+      handledCheckIds: [expect.any(String)],
+      checkStartAnchorRecorded: false,
+    })
+    expect(prompts).toHaveLength(3)
+    expect(prompts[1]).toContain("focused recovery attempt")
+    expect(prompts[2]).toContain(
+      "Based only on the PR status-check work you just did",
+    )
+  })
+
+  it("uses one classification fallback when merge-conflict work omits the outcome", async () => {
+    const prompts: string[] = []
+    const result = await Effect.runPromise(
+      resolvePrMergeConflict(context).pipe(
+        Effect.provide(
+          Layer.mergeAll(
+            db,
+            keymaxxer,
+            opencodeWith(
+              [
+                "rebased, verified, and pushed with lease",
+                "READY_FOR_AGENT_RESULT: PROCESSED",
+              ],
+              (prompt) => prompts.push(prompt),
+            ),
+          ),
+        ),
+      ),
+    )
+
+    expect(result).toEqual({ _tag: "processed" })
+    expect(prompts).toHaveLength(2)
+    expect(prompts[1]).toContain(
+      "Based only on the PR merge-conflict resolution work you just did",
+    )
+  })
+
+  it("rejects malformed merge-conflict outcomes without a fallback turn", async () => {
+    const prompts: string[] = []
+    const result = await Effect.runPromise(
+      Effect.result(
+        resolvePrMergeConflict(context).pipe(
+          Effect.provide(
+            Layer.mergeAll(
+              db,
+              keymaxxer,
+              opencodeWith(
+                ["READY_FOR_AGENT_RESULT: NOT_A_REAL_OUTCOME"],
+                (prompt) => prompts.push(prompt),
+              ),
+            ),
+          ),
+        ),
+      ),
+    )
+
+    expect(result._tag).toBe("Failure")
+    expect(prompts).toHaveLength(1)
+  })
+
+  it("rejects non-final merge-conflict outcomes without a fallback turn", async () => {
+    const prompts: string[] = []
+    const result = await Effect.runPromise(
+      Effect.result(
+        resolvePrMergeConflict(context).pipe(
+          Effect.provide(
+            Layer.mergeAll(
+              db,
+              keymaxxer,
+              opencodeWith(
+                [
+                  "READY_FOR_AGENT_RESULT: PROCESSED\nmore prose after the marker",
+                ],
+                (prompt) => prompts.push(prompt),
+              ),
+            ),
+          ),
+        ),
+      ),
+    )
+
+    expect(result._tag).toBe("Failure")
+    expect(prompts).toHaveLength(1)
+  })
+
+  it("rejects conflicting merge-conflict outcomes without a fallback turn", async () => {
+    const prompts: string[] = []
+    const result = await Effect.runPromise(
+      Effect.result(
+        resolvePrMergeConflict(context).pipe(
+          Effect.provide(
+            Layer.mergeAll(
+              db,
+              keymaxxer,
+              opencodeWith(
+                [
+                  [
+                    "READY_FOR_AGENT_RESULT: PROCESSED",
+                    "READY_FOR_AGENT_RESULT: NEEDS_HUMAN: approval required",
+                  ].join("\n"),
+                ],
+                (prompt) => prompts.push(prompt),
+              ),
+            ),
+          ),
+        ),
+      ),
+    )
+
+    expect(result._tag).toBe("Failure")
+    expect(prompts).toHaveLength(1)
+  })
+
+  it("leaves checks unhandled after a missing outcome and failed fallback", async () => {
+    const prompts: string[] = []
     const result = await Effect.runPromise(
       Effect.gen(function* () {
         yield* seedWorkItem
@@ -1187,13 +1346,9 @@ describe("PR status check steps", () => {
               ],
             }),
             keymaxxer,
-            opencodeWith([
-              "fixed",
-              [
-                "READY_FOR_AGENT_RESULT: PROCESSED",
-                "READY_FOR_AGENT_RESULT: NEEDS_HUMAN: approval required",
-              ].join("\n"),
-            ]),
+            opencodeWith(["fixed", "I forgot the marker"], (prompt) =>
+              prompts.push(prompt),
+            ),
             DatabaseTest,
           ),
         ),
@@ -1202,6 +1357,140 @@ describe("PR status check steps", () => {
 
     expect(result.investigation._tag).toBe("Failure")
     expect(result.observed.every((row) => row.handled_at === null)).toBe(true)
+    expect(prompts).toHaveLength(2)
+  })
+
+  it("rejects malformed outcome markers without a fallback turn", async () => {
+    const prompts: string[] = []
+    const result = await Effect.runPromise(
+      Effect.gen(function* () {
+        yield* seedWorkItem
+        yield* watchPrStatusChecks(context)
+        const investigation = yield* Effect.result(
+          investigatePrStatusChecks(context),
+        )
+        const sql = yield* SqlClient.SqlClient
+        const observed = (yield* sql.unsafe(
+          `SELECT handled_at FROM pr_status_check WHERE work_item_id = ?`,
+          [context.workItemId],
+        )) as readonly { handled_at: number | null }[]
+        return { investigation, observed }
+      }).pipe(
+        Effect.provide(
+          Layer.mergeAll(
+            db,
+            githubWith({
+              _tag: "failed",
+              ...mergeable,
+              terminalChecks: [
+                { externalId: "checkrun:1", name: "lint", outcome: "red" },
+              ],
+            }),
+            keymaxxer,
+            opencodeWith(
+              ["READY_FOR_AGENT_RESULT: NOT_A_REAL_OUTCOME"],
+              (prompt) => prompts.push(prompt),
+            ),
+            DatabaseTest,
+          ),
+        ),
+      ),
+    )
+
+    expect(result.investigation._tag).toBe("Failure")
+    expect(result.observed.every((row) => row.handled_at === null)).toBe(true)
+    expect(prompts).toHaveLength(1)
+  })
+
+  it("rejects non-final outcome markers without a fallback turn", async () => {
+    const prompts: string[] = []
+    const result = await Effect.runPromise(
+      Effect.gen(function* () {
+        yield* seedWorkItem
+        yield* watchPrStatusChecks(context)
+        const investigation = yield* Effect.result(
+          investigatePrStatusChecks(context),
+        )
+        const sql = yield* SqlClient.SqlClient
+        const observed = (yield* sql.unsafe(
+          `SELECT handled_at FROM pr_status_check WHERE work_item_id = ?`,
+          [context.workItemId],
+        )) as readonly { handled_at: number | null }[]
+        return { investigation, observed }
+      }).pipe(
+        Effect.provide(
+          Layer.mergeAll(
+            db,
+            githubWith({
+              _tag: "failed",
+              ...mergeable,
+              terminalChecks: [
+                { externalId: "checkrun:1", name: "lint", outcome: "red" },
+              ],
+            }),
+            keymaxxer,
+            opencodeWith(
+              [
+                "READY_FOR_AGENT_RESULT: PROCESSED\nmore prose after the marker",
+              ],
+              (prompt) => prompts.push(prompt),
+            ),
+            DatabaseTest,
+          ),
+        ),
+      ),
+    )
+
+    expect(result.investigation._tag).toBe("Failure")
+    expect(result.observed.every((row) => row.handled_at === null)).toBe(true)
+    expect(prompts).toHaveLength(1)
+  })
+
+  it("rejects conflicting verdict markers without a fallback turn", async () => {
+    const prompts: string[] = []
+    const result = await Effect.runPromise(
+      Effect.gen(function* () {
+        yield* seedWorkItem
+        yield* watchPrStatusChecks(context)
+        const investigation = yield* Effect.result(
+          investigatePrStatusChecks(context),
+        )
+        const sql = yield* SqlClient.SqlClient
+        const observed = (yield* sql.unsafe(
+          `SELECT handled_at FROM pr_status_check WHERE work_item_id = ?`,
+          [context.workItemId],
+        )) as readonly { handled_at: number | null }[]
+        return { investigation, observed }
+      }).pipe(
+        Effect.provide(
+          Layer.mergeAll(
+            db,
+            githubWith({
+              _tag: "failed",
+              ...mergeable,
+              terminalChecks: [
+                { externalId: "checkrun:1", name: "lint", outcome: "red" },
+              ],
+            }),
+            keymaxxer,
+            opencodeWith(
+              [
+                [
+                  "READY_FOR_AGENT_RESULT: PROCESSED",
+                  "READY_FOR_AGENT_RESULT: NEEDS_HUMAN: approval required",
+                ].join("\n"),
+              ],
+              (prompt) => prompts.push(prompt),
+            ),
+            DatabaseTest,
+          ),
+        ),
+      ),
+    )
+
+    expect(result.investigation._tag).toBe("Failure")
+    expect(result.observed.every((row) => row.handled_at === null)).toBe(true)
+    expect(prompts).toHaveLength(1)
   })
 
   it("parses structured RERUN_REVIEW verdicts with optional workflow name", () => {
@@ -1260,8 +1549,7 @@ describe("PR status check steps", () => {
             keymaxxer,
             opencodeWith(
               [
-                "Claude review skipped; PR Review is ordinary CI; no review evidence.",
-                "READY_FOR_AGENT_RESULT: PROCESSED",
+                "Claude review skipped; PR Review is ordinary CI; no review evidence.\nREADY_FOR_AGENT_RESULT: PROCESSED",
               ],
               (prompt) => prompts.push(prompt),
             ),
@@ -1300,15 +1588,12 @@ describe("PR status check steps", () => {
         },
       ],
     }
-    // Each investigate needs its own OpenCode script (work + verdict).
+    // Each investigate needs its own OpenCode script (combined work + outcome).
     const opencodeOutputs = Array.from(
       { length: AUTOMATED_REVIEW_RERUN_LIMIT + 1 },
       () =>
-        [
-          "terminal incomplete review",
-          `READY_FOR_AGENT_RESULT: RERUN_REVIEW: ${workflowRunId} Claude Code Review`,
-        ] as const,
-    ).flat()
+        `terminal incomplete review\nREADY_FOR_AGENT_RESULT: RERUN_REVIEW: ${workflowRunId} Claude Code Review`,
+    )
 
     await Effect.runPromise(
       Effect.gen(function* () {
@@ -1470,8 +1755,7 @@ describe("PR status check steps", () => {
             ),
             keymaxxer,
             opencodeWith([
-              "need rerun",
-              "READY_FOR_AGENT_RESULT: RERUN_REVIEW: 99 Review Bot",
+              "need rerun\nREADY_FOR_AGENT_RESULT: RERUN_REVIEW: 99 Review Bot",
             ]),
             DatabaseTest,
           ),
@@ -1548,8 +1832,7 @@ describe("PR status check steps", () => {
             ),
             keymaxxer,
             opencodeWith([
-              "incomplete on new head",
-              `READY_FOR_AGENT_RESULT: RERUN_REVIEW: ${workflowRunId}`,
+              `incomplete on new head\nREADY_FOR_AGENT_RESULT: RERUN_REVIEW: ${workflowRunId}`,
             ]),
             DatabaseTest,
           ),
@@ -1604,8 +1887,7 @@ describe("PR status check steps", () => {
             }),
             keymaxxer,
             opencodeWith([
-              "Human completed the review; nothing left to address.",
-              "READY_FOR_AGENT_RESULT: PROCESSED",
+              "Human completed the review; nothing left to address.\nREADY_FOR_AGENT_RESULT: PROCESSED",
             ]),
             DatabaseTest,
           ),
@@ -1640,8 +1922,7 @@ describe("PR status check steps", () => {
             }),
             keymaxxer,
             opencodeWith([
-              "green-only no-op",
-              "READY_FOR_AGENT_RESULT: PROCESSED",
+              "green-only no-op\nREADY_FOR_AGENT_RESULT: PROCESSED",
             ]),
             DatabaseTest,
           ),
@@ -1689,8 +1970,7 @@ describe("PR status check steps", () => {
             }),
             keymaxxer,
             opencodeWith([
-              "Human finished the review; feedback addressed.",
-              "READY_FOR_AGENT_RESULT: PROCESSED",
+              "Human finished the review; feedback addressed.\nREADY_FOR_AGENT_RESULT: PROCESSED",
             ]),
             DatabaseTest,
           ),


### PR DESCRIPTION
## Why

PR Status Check investigation and merge-conflict resolution previously ran an unconditional classification-only Agent Turn after each work turn. Those verdict turns reprocessed substantial Session context for very short outcomes and added avoidable token and wall-clock cost.

ADR 0036 records the agreed protocol: lifecycle work reports its Agent-reported Outcome in the same turn unless intervening Harness activity creates required evidence, or a missing outcome needs one bounded classification fallback.

## What Changed

- Combine PR status-check investigation work and its Agent-reported Outcome into one Agent Turn (outcome contract last, after credential guidance)
- Combine the focused FAILED recovery attempt with outcome reporting in the same turn
- Combine PR merge-conflict work and PROCESSED / NEEDS_HUMAN outcome reporting into one turn
- Run one classification-only fallback only when the work (or recovery) response omits every outcome line; fail strictly on malformed, duplicate, non-final, or unknown markers
- Preserve existing outcome vocabulary, handled-check behavior, review-rerun authorization, and the single status-check recovery budget
- Extend lifecycle tests for combined turns, missing-outcome fallback, and strict-fail paths

Closes #455

## Verification

- `bunx nx test work-item-lifecycle` (including updated `pr-status-checks.spec.ts`)
- Pre-commit affected lint, typecheck, and test hooks passed on commit