### PR TITLE
feat(db-service): per-repository Agent Backend override and scoped gates

### DIFF
--- a/packages/db-schema/drizzle/20260725180000_repository_agent_backend_override/migration.sql
+++ b/packages/db-schema/drizzle/20260725180000_repository_agent_backend_override/migration.sql
@@ -1,0 +1,2 @@
+-- Null selected_agent_backend means inherit the harness default Agent Backend.
+ALTER TABLE `repository` ADD `selected_agent_backend` text;

--- a/packages/db-schema/src/schema.ts
+++ b/packages/db-schema/src/schema.ts
@@ -19,13 +19,18 @@ export const repository = snakeCase.table(
     localPath: text().notNull().unique(),
     isBare: integer({ mode: "boolean" }).notNull(),
     paused: integer({ mode: "boolean" }).notNull().default(true),
+    /**
+     * Optional Agent Backend override. Null means inherit harness default.
+     * New and migrated rows stay null.
+     */
+    selectedAgentBackend: text(),
     defaultModel: text(),
     defaultThinkingLevel: text(),
     reviewModel: text(),
     reviewThinkingLevel: text(),
     /**
      * Per-Agent-Backend model preferences (JSON map keyed by backend id).
-     * Flat model columns mirror the Active/selected backend entry.
+     * Flat model columns mirror this row's effective backend entry.
      */
     backendModelPrefs: text().notNull().default("{}"),
     autoMerge: integer({ mode: "boolean" }).notNull().default(false),

--- a/packages/db-service/src/lib/db-service.ts
+++ b/packages/db-service/src/lib/db-service.ts
@@ -9,7 +9,7 @@ import {
   InvalidConfigInputError,
   InvalidIssueInputError,
   InvalidRepositoryInputError,
-  type InvalidRepositorySettingsError,
+  InvalidRepositorySettingsError,
   LocalPathInUseError,
   RepositoryAlreadyExistsError,
   RepositoryHasRunningStepError,
@@ -157,6 +157,43 @@ const normalizeOptionalConfigSetting = (
   return Effect.succeed(trimmed)
 }
 
+/**
+ * Unfinished Work Items block backend changes (includes Needs Human, paused,
+ * Waiting for Worker Slot). Terminal complete/failed/abandoned do not.
+ */
+const isUnfinishedStateSql = (column = "state") =>
+  `${column} NOT IN ('complete', 'failed', 'abandoned')`
+
+/**
+ * Normalize a Repository Agent Backend override. Empty/whitespace → null
+ * (inherit). Non-null must be a selectable built-in backend id.
+ */
+const normalizeRepositoryAgentBackendOverride = (
+  value: string | null,
+): Effect.Effect<string | null, InvalidRepositorySettingsError> => {
+  if (value === null) {
+    return Effect.succeed(null)
+  }
+  const trimmed = value.trim()
+  if (trimmed.length === 0) {
+    return Effect.succeed(null)
+  }
+  if (!isSelectableAgentBackendId(trimmed)) {
+    return Effect.fail(
+      new InvalidRepositorySettingsError({
+        field: "selectedAgentBackend",
+        message: `Unknown Agent Backend: ${trimmed}`,
+      }),
+    )
+  }
+  return Effect.succeed(trimmed)
+}
+
+const effectiveAgentBackend = (
+  repositoryOverride: string | null,
+  harnessDefault: string,
+): string => repositoryOverride ?? harnessDefault
+
 const toDatabaseError = (error: SqlError) =>
   new DatabaseError({
     message: `Database error: ${formatSqlError(error)}`,
@@ -195,8 +232,8 @@ const decodeRunningStepRows = (rows: ReadonlyArray<unknown>) =>
   )
 
 const repositorySelectColumns = `id, github_owner, github_repo, local_path, is_bare, paused,
-             default_model, default_thinking_level, review_model, review_thinking_level,
-             backend_model_prefs, auto_merge,
+             selected_agent_backend, default_model, default_thinking_level,
+             review_model, review_thinking_level, backend_model_prefs, auto_merge,
              include_all_issue_authors, issues_reconciled_at`
 
 const issueSelectColumns = `id, repository_id, github_issue_number, title, body, url, state,
@@ -211,6 +248,7 @@ const toRepositoryRecord = (row: RepositorySqlRow): RepositoryRecord =>
     localPath: row.localPath,
     isBare: row.isBare,
     paused: row.paused,
+    selectedAgentBackend: row.selectedAgentBackend,
     defaultModel: row.defaultModel,
     defaultThinkingLevel: row.defaultThinkingLevel,
     reviewModel: row.reviewModel,
@@ -268,8 +306,10 @@ export interface DbServiceShape {
     InvalidConfigInputError | AgentBackendChangeBlockedError | DatabaseError
   >
   /**
-   * Work Items that block Agent Backend change: anything not terminal
-   * complete/failed/abandoned (includes Needs Human and waiting/in-progress).
+   * Fleet-wide unfinished Work Item total (not terminal complete/failed/
+   * abandoned; includes Needs Human, paused, and Waiting for Worker Slot).
+   * Visibility/UI only — backend-change gates use scoped blocking counts
+   * (inheriting repos for harness default; one repository for override).
    */
   readonly countUnfinishedWorkItems: Effect.Effect<number, DatabaseError>
   readonly addRepository: (
@@ -285,7 +325,10 @@ export interface DbServiceShape {
     input: UpdateRepositorySettingsInput,
   ) => Effect.Effect<
     RepositoryRecord,
-    InvalidRepositorySettingsError | RepositoryNotFoundError | DatabaseError
+    | InvalidRepositorySettingsError
+    | AgentBackendChangeBlockedError
+    | RepositoryNotFoundError
+    | DatabaseError
   >
   readonly pauseRepository: (
     repositoryId: string,
@@ -438,19 +481,67 @@ export const DbServiceLive = Layer.effect(
         maxConcurrentWorkItems: row.maxConcurrentWorkItems,
       })
 
+    const readCount = (rows: readonly { readonly count: number }[]): number => {
+      const count = rows[0]?.count
+      return typeof count === "number" && Number.isFinite(count) ? count : 0
+    }
+
+    /** Fleet-wide unfinished total (visibility; not the global backend gate). */
     const countUnfinishedWorkItems: Effect.Effect<number, DatabaseError> =
       Effect.gen(function* () {
         const rows = (yield* sql
           .unsafe(
             `SELECT COUNT(*) AS count FROM work_item
-             WHERE state NOT IN ('complete', 'failed', 'abandoned')`,
+             WHERE ${isUnfinishedStateSql()}`,
           )
           .pipe(Effect.mapError(toDatabaseError))) as readonly {
           readonly count: number
         }[]
-        const count = rows[0]?.count
-        return typeof count === "number" && Number.isFinite(count) ? count : 0
+        return readCount(rows)
       }).pipe(Effect.withSpan("DbService.countUnfinishedWorkItems"))
+
+    /**
+     * Unfinished Work Items on Repositories that inherit the harness default
+     * (override is null). These alone block changing the global default.
+     */
+    const countBlockingUnfinishedForGlobalDefault = (): Effect.Effect<
+      number,
+      DatabaseError
+    > =>
+      Effect.gen(function* () {
+        const rows = (yield* sql
+          .unsafe(
+            `SELECT COUNT(*) AS count
+             FROM work_item wi
+             INNER JOIN repository r ON r.id = wi.repository_id
+             WHERE ${isUnfinishedStateSql("wi.state")}
+               AND r.selected_agent_backend IS NULL`,
+          )
+          .pipe(Effect.mapError(toDatabaseError))) as readonly {
+          readonly count: number
+        }[]
+        return readCount(rows)
+      })
+
+    /**
+     * Unfinished Work Items on one Repository (blocks that repo's override change).
+     */
+    const countBlockingUnfinishedForRepository = (
+      repositoryId: string,
+    ): Effect.Effect<number, DatabaseError> =>
+      Effect.gen(function* () {
+        const rows = (yield* sql
+          .unsafe(
+            `SELECT COUNT(*) AS count FROM work_item
+             WHERE repository_id = ?
+               AND ${isUnfinishedStateSql()}`,
+            [repositoryId],
+          )
+          .pipe(Effect.mapError(toDatabaseError))) as readonly {
+          readonly count: number
+        }[]
+        return readCount(rows)
+      })
 
     const readConfigRow = Effect.gen(function* () {
       const now = yield* Clock.currentTimeMillis
@@ -496,13 +587,19 @@ export const DbServiceLive = Layer.effect(
       },
     )
 
-    const projectRepositoryFlatColumns = (
+    /**
+     * Re-project flat model columns from backendModelPrefs for repositories
+     * that inherit the harness default (selected_agent_backend IS NULL). Explicit
+     * overrides keep their own effective backend projection.
+     */
+    const projectInheritingRepositoryFlatColumns = (
       now: number,
-      backendId: string,
+      harnessDefaultBackendId: string,
     ): Effect.Effect<void, SqlError> =>
       Effect.gen(function* () {
         const rows = (yield* sql.unsafe(
-          `SELECT id, backend_model_prefs AS backendModelPrefs FROM repository`,
+          `SELECT id, backend_model_prefs AS backendModelPrefs FROM repository
+           WHERE selected_agent_backend IS NULL`,
         )) as readonly {
           readonly id: string
           readonly backendModelPrefs: string
@@ -510,7 +607,7 @@ export const DbServiceLive = Layer.effect(
         for (const row of rows) {
           const prefs = prefsForBackend(
             parseBackendModelPrefsMap(row.backendModelPrefs ?? "{}"),
-            backendId,
+            harnessDefaultBackendId,
           )
           yield* sql.unsafe(
             `UPDATE repository SET
@@ -608,26 +705,17 @@ export const DbServiceLive = Layer.effect(
             const changing =
               selectedAgentBackend !== latest.selectedAgentBackend
             if (changing) {
-              const unfinishedRows = (yield* sql
-                .unsafe(
-                  `SELECT COUNT(*) AS count FROM work_item
-                   WHERE state NOT IN ('complete', 'failed', 'abandoned')`,
-                )
-                .pipe(Effect.mapError(toDatabaseError))) as readonly {
-                readonly count: number
-              }[]
-              const unfinished = unfinishedRows[0]?.count
-              const count =
-                typeof unfinished === "number" && Number.isFinite(unfinished)
-                  ? unfinished
-                  : 0
+              // Gate on inheriting repos only. Explicit-override WIP does not
+              // block the harness default change.
+              const count = yield* countBlockingUnfinishedForGlobalDefault()
               if (count > 0) {
                 return yield* new AgentBackendChangeBlockedError({
-                  message: `Cannot change Agent Backend while ${count} Work Item(s) are unfinished`,
+                  message: `Cannot change default Agent Backend while ${count} Work Item(s) are unfinished on Repositories that inherit the default`,
                   unfinishedWorkItemCount: count,
+                  scope: "global",
                 })
               }
-              yield* projectRepositoryFlatColumns(
+              yield* projectInheritingRepositoryFlatColumns(
                 now,
                 selectedAgentBackend,
               ).pipe(Effect.mapError(toDatabaseError))
@@ -761,10 +849,11 @@ export const DbServiceLive = Layer.effect(
         .unsafe(
           `INSERT INTO repository (
                id, github_owner, github_repo, local_path, is_bare, paused,
+               selected_agent_backend,
                default_model, default_thinking_level, review_model, review_thinking_level,
                backend_model_prefs,
                auto_merge, include_all_issue_authors, created_at, updated_at
-             ) VALUES (?, ?, ?, ?, ?, ?, NULL, NULL, NULL, NULL, '{}', ?, ?, ?, ?)
+             ) VALUES (?, ?, ?, ?, ?, ?, NULL, NULL, NULL, NULL, NULL, '{}', ?, ?, ?, ?)
              RETURNING ${repositorySelectColumns}`,
           [
             id,
@@ -822,19 +911,26 @@ export const DbServiceLive = Layer.effect(
       const reviewThinkingLevel = yield* normalizeOptionalSetting(
         input.reviewThinkingLevel,
       )
+      // undefined = leave override unchanged; null/string = set/clear after validate.
+      const requestedOverride =
+        input.selectedAgentBackend === undefined
+          ? undefined
+          : yield* normalizeRepositoryAgentBackendOverride(
+              input.selectedAgentBackend,
+            )
       const now = yield* Clock.currentTimeMillis
       const result = yield* sql
         .withTransaction(
           Effect.gen(function* () {
-            // Re-read Active backend selection and repo prefs inside the txn so a
-            // concurrent config backend switch cannot mis-key prefs / flat columns.
+            // Re-read harness default and repo row inside the txn so concurrent
+            // config switches cannot mis-key prefs / flat columns.
             const configRows = yield* sql
               .unsafe(
                 `SELECT selected_agent_backend AS selectedAgentBackend
                  FROM config WHERE id = 'default'`,
               )
               .pipe(Effect.mapError(toDatabaseError))
-            const selectedAgentBackend =
+            const harnessDefault =
               (
                 configRows[0] as
                   | { readonly selectedAgentBackend: string }
@@ -842,33 +938,65 @@ export const DbServiceLive = Layer.effect(
               )?.selectedAgentBackend ?? "opencode"
             const existingRows = yield* sql
               .unsafe(
-                `SELECT backend_model_prefs AS backendModelPrefs
+                `SELECT selected_agent_backend AS selectedAgentBackend,
+                        backend_model_prefs AS backendModelPrefs
                  FROM repository WHERE id = ?`,
                 [input.repositoryId],
               )
               .pipe(Effect.mapError(toDatabaseError))
             const existing = existingRows[0] as
-              | { readonly backendModelPrefs: string }
+              | {
+                  readonly selectedAgentBackend: string | null
+                  readonly backendModelPrefs: string
+                }
               | undefined
             if (!existing) {
               return yield* new RepositoryNotFoundError({
                 repositoryId: input.repositoryId,
               })
             }
+            const previousOverride = existing.selectedAgentBackend ?? null
+            const nextOverride =
+              requestedOverride === undefined
+                ? previousOverride
+                : requestedOverride
+            const overrideChanging = nextOverride !== previousOverride
+            if (overrideChanging) {
+              const count = yield* countBlockingUnfinishedForRepository(
+                input.repositoryId,
+              )
+              if (count > 0) {
+                return yield* new AgentBackendChangeBlockedError({
+                  message: `Cannot change Repository Agent Backend while ${count} Work Item(s) are unfinished on this Repository`,
+                  unfinishedWorkItemCount: count,
+                  scope: "repository",
+                  repositoryId: input.repositoryId,
+                })
+              }
+            }
+            const effectiveBackend = effectiveAgentBackend(
+              nextOverride,
+              harnessDefault,
+            )
             const prefsMap = parseBackendModelPrefsMap(
               existing.backendModelPrefs ?? "{}",
             )
-            prefsMap[selectedAgentBackend] = {
+            // Model settings write to the effective backend's map entry.
+            prefsMap[effectiveBackend] = {
               defaultModel,
               defaultThinkingLevel,
               reviewModel,
               reviewThinkingLevel,
             }
+            // When only the override changes, flat columns should still reflect
+            // the (possibly empty) prefs for the new effective backend — which
+            // we just wrote from this request's model fields.
             const backendModelPrefs = serializeBackendModelPrefsMap(prefsMap)
             return yield* sql
               .unsafe(
                 `UPDATE repository
              SET paused = ?,
+                 selected_agent_backend = ?,
                  default_model = ?,
                  default_thinking_level = ?,
                  review_model = ?,
@@ -881,6 +1009,7 @@ export const DbServiceLive = Layer.effect(
              RETURNING ${repositorySelectColumns}`,
                 [
                   input.paused,
+                  nextOverride,
                   defaultModel,
                   defaultThinkingLevel,
                   reviewModel,
@@ -905,9 +1034,15 @@ export const DbServiceLive = Layer.effect(
               const tag = (error as { _tag: string })._tag
               if (
                 tag === "RepositoryNotFoundError" ||
-                tag === "DatabaseError"
+                tag === "DatabaseError" ||
+                tag === "AgentBackendChangeBlockedError" ||
+                tag === "InvalidRepositorySettingsError"
               ) {
-                return error as RepositoryNotFoundError | DatabaseError
+                return error as
+                  | RepositoryNotFoundError
+                  | DatabaseError
+                  | AgentBackendChangeBlockedError
+                  | InvalidRepositorySettingsError
               }
             }
             return toDatabaseError(error as SqlError)

--- a/packages/db-service/src/lib/errors.ts
+++ b/packages/db-service/src/lib/errors.ts
@@ -76,7 +76,16 @@ export class AgentBackendChangeBlockedError extends Schema.TaggedErrorClass<Agen
   "AgentBackendChangeBlockedError",
   {
     message: Schema.String,
+    /**
+     * Work Items that block this change (scoped gate), not fleet total
+     * unfinished. Kept as unfinishedWorkItemCount for GraphQL extension
+     * compatibility.
+     */
     unfinishedWorkItemCount: Schema.Finite,
+    /** Where the unfinished Work Items that block this change live. */
+    scope: Schema.Literals(["global", "repository"]),
+    /** Set when scope is repository. */
+    repositoryId: Schema.optional(Schema.String),
   },
 ) {}
 
@@ -84,6 +93,7 @@ export class InvalidRepositorySettingsError extends Schema.TaggedErrorClass<Inva
   "InvalidRepositorySettingsError",
   {
     field: Schema.Literals([
+      "selectedAgentBackend",
       "defaultModel",
       "defaultThinkingLevel",
       "reviewModel",

--- a/packages/db-service/src/lib/test-fixtures.ts
+++ b/packages/db-service/src/lib/test-fixtures.ts
@@ -18,6 +18,7 @@ export const makeRepositoryRecord = (
   localPath: "/repos/acme/widgets",
   isBare: true,
   paused: false,
+  selectedAgentBackend: null,
   defaultModel: null,
   defaultThinkingLevel: null,
   reviewModel: null,

--- a/packages/db-service/src/lib/types.ts
+++ b/packages/db-service/src/lib/types.ts
@@ -35,6 +35,10 @@ export const RepositoryRecord = Schema.Struct({
   localPath: Schema.String,
   isBare: Schema.Boolean,
   paused: Schema.Boolean,
+  /**
+   * Optional Agent Backend override. Null means inherit harness default.
+   */
+  selectedAgentBackend: Schema.NullOr(Schema.String),
   defaultModel: Schema.NullOr(Schema.String),
   defaultThinkingLevel: Schema.NullOr(Schema.String),
   reviewModel: Schema.NullOr(Schema.String),
@@ -48,6 +52,12 @@ export type RepositoryRecord = typeof RepositoryRecord.Type
 export const UpdateRepositorySettingsInput = Schema.Struct({
   repositoryId: Schema.String,
   paused: Schema.Boolean,
+  /**
+   * Null clears the override (inherit harness default). Omitted leaves the
+   * stored override unchanged so callers that do not yet send the field
+   * (GraphQL until #467) do not wipe it.
+   */
+  selectedAgentBackend: Schema.optionalKey(Schema.NullOr(Schema.String)),
   defaultModel: Schema.NullOr(Schema.String),
   defaultThinkingLevel: Schema.NullOr(Schema.String),
   reviewModel: Schema.NullOr(Schema.String),
@@ -155,6 +165,7 @@ export const RepositorySqlRow = Schema.Struct({
   localPath: Schema.String,
   isBare: SqlBoolean,
   paused: SqlBoolean,
+  selectedAgentBackend: Schema.NullOr(Schema.String),
   defaultModel: Schema.NullOr(Schema.String),
   defaultThinkingLevel: Schema.NullOr(Schema.String),
   reviewModel: Schema.NullOr(Schema.String),
@@ -169,6 +180,7 @@ export const RepositorySqlRow = Schema.Struct({
     githubRepo: "github_repo",
     localPath: "local_path",
     isBare: "is_bare",
+    selectedAgentBackend: "selected_agent_backend",
     defaultModel: "default_model",
     defaultThinkingLevel: "default_thinking_level",
     reviewModel: "review_model",

--- a/packages/db-service/test/db-service.spec.ts
+++ b/packages/db-service/test/db-service.spec.ts
@@ -229,7 +229,128 @@ describe("DbService", () => {
           expect(error).toMatchObject({
             _tag: "AgentBackendChangeBlockedError",
             unfinishedWorkItemCount: 1,
+            scope: "global",
           })
+        }),
+      ))
+
+    it("allows default Agent Backend change when only explicit-override Repositories have unfinished Work Items", () =>
+      runTest(
+        Effect.gen(function* () {
+          const db = yield* DbService
+          const sql = yield* SqlClient.SqlClient
+          const inheriting = yield* db.addRepository(sampleInput)
+          const overridden = yield* db.addRepository({
+            githubOwner: "acme",
+            githubRepo: "other",
+            localPath: "/repos/acme/other.git",
+            isBare: true,
+          })
+          yield* db.updateRepositorySettings({
+            repositoryId: overridden.id,
+            paused: true,
+            selectedAgentBackend: "grok",
+            defaultModel: "grok-code",
+            defaultThinkingLevel: null,
+            reviewModel: null,
+            reviewThinkingLevel: null,
+            autoMerge: false,
+            includeAllIssueAuthors: false,
+          })
+          const now = Date.now()
+          // Unfinished only on the explicit-override repository.
+          yield* sql.unsafe(
+            `INSERT INTO work_item (
+               id, repository_id, github_issue_number, state, state_ready_at,
+               worktree_path, session_id, failure_code, failure_message,
+               created_at, updated_at
+             ) VALUES (?, ?, 1, 'implement', ?, NULL, NULL, NULL, NULL, ?, ?)`,
+            ["wi-override-only", overridden.id, now, now, now],
+          )
+          // Terminal WIP on inheriting repo must not block.
+          yield* sql.unsafe(
+            `INSERT INTO work_item (
+               id, repository_id, github_issue_number, state, state_ready_at,
+               worktree_path, session_id, failure_code, failure_message,
+               created_at, updated_at
+             ) VALUES (?, ?, 2, 'complete', ?, NULL, NULL, NULL, NULL, ?, ?)`,
+            ["wi-inheriting-done", inheriting.id, now, now, now],
+          )
+
+          const switched = yield* db.updateConfig({
+            selectedAgentBackend: "grok",
+            defaultModel: "grok-code",
+            defaultThinkingLevel: null,
+            reviewModel: null,
+            reviewThinkingLevel: null,
+            maxConcurrentAgentTurns: 2,
+            maxConcurrentWorkItems: 5,
+          })
+          expect(switched.selectedAgentBackend).toBe("grok")
+          // Fleet total still counts the unfinished override WI.
+          expect(yield* db.countUnfinishedWorkItems).toBe(1)
+        }),
+      ))
+
+    it("blocks default Agent Backend change only for unfinished Work Items on inheriting Repositories", () =>
+      runTest(
+        Effect.gen(function* () {
+          const db = yield* DbService
+          const sql = yield* SqlClient.SqlClient
+          const inheriting = yield* db.addRepository(sampleInput)
+          const overridden = yield* db.addRepository({
+            githubOwner: "acme",
+            githubRepo: "other",
+            localPath: "/repos/acme/other.git",
+            isBare: true,
+          })
+          yield* db.updateRepositorySettings({
+            repositoryId: overridden.id,
+            paused: true,
+            selectedAgentBackend: "grok",
+            defaultModel: null,
+            defaultThinkingLevel: null,
+            reviewModel: null,
+            reviewThinkingLevel: null,
+            autoMerge: false,
+            includeAllIssueAuthors: false,
+          })
+          const now = Date.now()
+          yield* sql.unsafe(
+            `INSERT INTO work_item (
+               id, repository_id, github_issue_number, state, state_ready_at,
+               worktree_path, session_id, failure_code, failure_message,
+               created_at, updated_at
+             ) VALUES (?, ?, 1, 'needs_human', ?, NULL, NULL, NULL, NULL, ?, ?)`,
+            ["wi-inheriting-block", inheriting.id, now, now, now],
+          )
+          yield* sql.unsafe(
+            `INSERT INTO work_item (
+               id, repository_id, github_issue_number, state, state_ready_at,
+               worktree_path, session_id, failure_code, failure_message,
+               created_at, updated_at
+             ) VALUES (?, ?, 2, 'implement', ?, NULL, NULL, NULL, NULL, ?, ?)`,
+            ["wi-override-wip", overridden.id, now, now, now],
+          )
+
+          const error = yield* Effect.flip(
+            db.updateConfig({
+              selectedAgentBackend: "grok",
+              defaultModel: null,
+              defaultThinkingLevel: null,
+              reviewModel: null,
+              reviewThinkingLevel: null,
+              maxConcurrentAgentTurns: 2,
+              maxConcurrentWorkItems: 5,
+            }),
+          )
+          // Blocking count is inheriting only (1), not fleet total (2).
+          expect(error).toMatchObject({
+            _tag: "AgentBackendChangeBlockedError",
+            unfinishedWorkItemCount: 1,
+            scope: "global",
+          })
+          expect(yield* db.countUnfinishedWorkItems).toBe(2)
         }),
       ))
 
@@ -352,6 +473,7 @@ describe("DbService", () => {
           expect(repo.localPath).toBe("/repos/acme/widgets.git")
           expect(repo.isBare).toBe(true)
           expect(repo.paused).toBe(true)
+          expect(repo.selectedAgentBackend).toBeNull()
           expect(repo.defaultModel).toBeNull()
           expect(repo.defaultThinkingLevel).toBeNull()
           expect(repo.reviewModel).toBeNull()
@@ -475,6 +597,7 @@ describe("DbService", () => {
           expect(updated).toEqual({
             ...repo,
             paused: false,
+            selectedAgentBackend: null,
             defaultModel: "anthropic/claude-sonnet-4-5",
             defaultThinkingLevel: "high",
             reviewModel: "anthropic/claude-opus-4-6",
@@ -483,6 +606,356 @@ describe("DbService", () => {
             includeAllIssueAuthors: true,
           })
           expect(yield* db.listRepositories).toEqual([updated])
+        }),
+      ))
+
+    it("sets and clears a Repository Agent Backend override (null inherits default)", () =>
+      runTest(
+        Effect.gen(function* () {
+          const db = yield* DbService
+          const repo = yield* db.addRepository(sampleInput)
+          expect(repo.selectedAgentBackend).toBeNull()
+
+          const withOverride = yield* db.updateRepositorySettings({
+            repositoryId: repo.id,
+            paused: true,
+            selectedAgentBackend: "  grok  ",
+            defaultModel: "grok-code",
+            defaultThinkingLevel: null,
+            reviewModel: null,
+            reviewThinkingLevel: null,
+            autoMerge: false,
+            includeAllIssueAuthors: false,
+          })
+          expect(withOverride.selectedAgentBackend).toBe("grok")
+          expect(withOverride.defaultModel).toBe("grok-code")
+
+          const cleared = yield* db.updateRepositorySettings({
+            repositoryId: repo.id,
+            paused: true,
+            selectedAgentBackend: null,
+            defaultModel: null,
+            defaultThinkingLevel: null,
+            reviewModel: null,
+            reviewThinkingLevel: null,
+            autoMerge: false,
+            includeAllIssueAuthors: false,
+          })
+          expect(cleared.selectedAgentBackend).toBeNull()
+
+          // Omitting selectedAgentBackend leaves the override unchanged.
+          yield* db.updateRepositorySettings({
+            repositoryId: repo.id,
+            paused: true,
+            selectedAgentBackend: "grok",
+            defaultModel: null,
+            defaultThinkingLevel: null,
+            reviewModel: null,
+            reviewThinkingLevel: null,
+            autoMerge: false,
+            includeAllIssueAuthors: false,
+          })
+          const preserved = yield* db.updateRepositorySettings({
+            repositoryId: repo.id,
+            paused: false,
+            defaultModel: null,
+            defaultThinkingLevel: null,
+            reviewModel: null,
+            reviewThinkingLevel: null,
+            autoMerge: false,
+            includeAllIssueAuthors: false,
+          })
+          expect(preserved.selectedAgentBackend).toBe("grok")
+          expect(preserved.paused).toBe(false)
+        }),
+      ))
+
+    it("rejects unknown Repository Agent Backend ids", () =>
+      runTest(
+        Effect.gen(function* () {
+          const db = yield* DbService
+          const repo = yield* db.addRepository(sampleInput)
+          const error = yield* Effect.flip(
+            db.updateRepositorySettings({
+              repositoryId: repo.id,
+              paused: true,
+              selectedAgentBackend: "not-a-backend",
+              defaultModel: null,
+              defaultThinkingLevel: null,
+              reviewModel: null,
+              reviewThinkingLevel: null,
+              autoMerge: false,
+              includeAllIssueAuthors: false,
+            }),
+          )
+          expect(error).toMatchObject({
+            _tag: "InvalidRepositorySettingsError",
+            field: "selectedAgentBackend",
+          })
+        }),
+      ))
+
+    it("blocks Repository Agent Backend override change while unfinished Work Items exist on that Repository only", () =>
+      runTest(
+        Effect.gen(function* () {
+          const db = yield* DbService
+          const sql = yield* SqlClient.SqlClient
+          const blocked = yield* db.addRepository(sampleInput)
+          const other = yield* db.addRepository({
+            githubOwner: "acme",
+            githubRepo: "other",
+            localPath: "/repos/acme/other.git",
+            isBare: true,
+          })
+          const now = Date.now()
+          // Unfinished only on the target repository (Needs Human counts).
+          yield* sql.unsafe(
+            `INSERT INTO work_item (
+               id, repository_id, github_issue_number, state, state_ready_at,
+               paused, waiting_since, worktree_path, session_id, failure_code,
+               failure_message, created_at, updated_at
+             ) VALUES (?, ?, 1, 'needs_human', ?, 0, NULL, NULL, NULL, NULL, NULL, ?, ?)`,
+            ["wi-blocked-repo", blocked.id, now, now, now],
+          )
+          // Terminal work on the other repository must not affect the gate.
+          yield* sql.unsafe(
+            `INSERT INTO work_item (
+               id, repository_id, github_issue_number, state, state_ready_at,
+               worktree_path, session_id, failure_code, failure_message,
+               created_at, updated_at
+             ) VALUES (?, ?, 2, 'complete', ?, NULL, NULL, NULL, NULL, ?, ?)`,
+            ["wi-other-repo-done", other.id, now, now, now],
+          )
+
+          const error = yield* Effect.flip(
+            db.updateRepositorySettings({
+              repositoryId: blocked.id,
+              paused: true,
+              selectedAgentBackend: "grok",
+              defaultModel: null,
+              defaultThinkingLevel: null,
+              reviewModel: null,
+              reviewThinkingLevel: null,
+              autoMerge: false,
+              includeAllIssueAuthors: false,
+            }),
+          )
+          expect(error).toMatchObject({
+            _tag: "AgentBackendChangeBlockedError",
+            unfinishedWorkItemCount: 1,
+            scope: "repository",
+            repositoryId: blocked.id,
+          })
+
+          // Idle other repository can still change its override.
+          const otherUpdated = yield* db.updateRepositorySettings({
+            repositoryId: other.id,
+            paused: true,
+            selectedAgentBackend: "grok",
+            defaultModel: "grok-code",
+            defaultThinkingLevel: null,
+            reviewModel: null,
+            reviewThinkingLevel: null,
+            autoMerge: false,
+            includeAllIssueAuthors: false,
+          })
+          expect(otherUpdated.selectedAgentBackend).toBe("grok")
+
+          // Same-value override write is not a change and stays allowed.
+          const sameOverride = yield* db.updateRepositorySettings({
+            repositoryId: blocked.id,
+            paused: false,
+            selectedAgentBackend: null,
+            defaultModel: null,
+            defaultThinkingLevel: null,
+            reviewModel: null,
+            reviewThinkingLevel: null,
+            autoMerge: false,
+            includeAllIssueAuthors: false,
+          })
+          expect(sameOverride.paused).toBe(false)
+          expect(sameOverride.selectedAgentBackend).toBeNull()
+        }),
+      ))
+
+    it("keys Repository model prefs by effective Agent Backend without clobbering the other backend", () =>
+      runTest(
+        Effect.gen(function* () {
+          const db = yield* DbService
+          const sql = yield* SqlClient.SqlClient
+          yield* db.updateConfig({
+            selectedAgentBackend: "opencode",
+            defaultModel: "openai/gpt-5.6-terra",
+            defaultThinkingLevel: "high",
+            reviewModel: null,
+            reviewThinkingLevel: null,
+            maxConcurrentAgentTurns: 2,
+            maxConcurrentWorkItems: 5,
+          })
+          const repo = yield* db.addRepository(sampleInput)
+
+          // Inheriting: write prefs for harness default (opencode).
+          yield* db.updateRepositorySettings({
+            repositoryId: repo.id,
+            paused: true,
+            defaultModel: "openai/opencode-model",
+            defaultThinkingLevel: "high",
+            reviewModel: "openai/opencode-review",
+            reviewThinkingLevel: "max",
+            autoMerge: false,
+            includeAllIssueAuthors: false,
+          })
+
+          // Override to grok: write prefs for effective grok.
+          const grokSettings = yield* db.updateRepositorySettings({
+            repositoryId: repo.id,
+            paused: true,
+            selectedAgentBackend: "grok",
+            defaultModel: "grok-code",
+            defaultThinkingLevel: null,
+            reviewModel: null,
+            reviewThinkingLevel: null,
+            autoMerge: false,
+            includeAllIssueAuthors: false,
+          })
+          expect(grokSettings.selectedAgentBackend).toBe("grok")
+          expect(grokSettings.defaultModel).toBe("grok-code")
+          expect(grokSettings.defaultThinkingLevel).toBeNull()
+
+          const prefsJson = (yield* sql.unsafe(
+            `SELECT backend_model_prefs AS backendModelPrefs FROM repository WHERE id = ?`,
+            [repo.id],
+          )) as readonly { readonly backendModelPrefs: string }[]
+          const prefs = JSON.parse(prefsJson[0]?.backendModelPrefs ?? "{}") as {
+            opencode?: {
+              defaultModel: string | null
+              defaultThinkingLevel: string | null
+              reviewModel: string | null
+              reviewThinkingLevel: string | null
+            }
+            grok?: {
+              defaultModel: string | null
+              defaultThinkingLevel: string | null
+              reviewModel: string | null
+              reviewThinkingLevel: string | null
+            }
+          }
+          expect(prefs.opencode).toEqual({
+            defaultModel: "openai/opencode-model",
+            defaultThinkingLevel: "high",
+            reviewModel: "openai/opencode-review",
+            reviewThinkingLevel: "max",
+          })
+          expect(prefs.grok).toEqual({
+            defaultModel: "grok-code",
+            defaultThinkingLevel: null,
+            reviewModel: null,
+            reviewThinkingLevel: null,
+          })
+
+          // Clear override (inherit opencode): flat columns write to opencode
+          // entry; grok map entry remains.
+          const inherited = yield* db.updateRepositorySettings({
+            repositoryId: repo.id,
+            paused: true,
+            selectedAgentBackend: null,
+            defaultModel: "openai/opencode-model-v2",
+            defaultThinkingLevel: "low",
+            reviewModel: null,
+            reviewThinkingLevel: null,
+            autoMerge: false,
+            includeAllIssueAuthors: false,
+          })
+          expect(inherited.selectedAgentBackend).toBeNull()
+          expect(inherited.defaultModel).toBe("openai/opencode-model-v2")
+          expect(inherited.defaultThinkingLevel).toBe("low")
+
+          const prefsAfter = JSON.parse(
+            (
+              (yield* sql.unsafe(
+                `SELECT backend_model_prefs AS backendModelPrefs FROM repository WHERE id = ?`,
+                [repo.id],
+              )) as readonly { readonly backendModelPrefs: string }[]
+            )[0]?.backendModelPrefs ?? "{}",
+          ) as typeof prefs
+          expect(prefsAfter.opencode?.defaultModel).toBe(
+            "openai/opencode-model-v2",
+          )
+          expect(prefsAfter.grok).toEqual({
+            defaultModel: "grok-code",
+            defaultThinkingLevel: null,
+            reviewModel: null,
+            reviewThinkingLevel: null,
+          })
+        }),
+      ))
+
+    it("does not re-project flat model columns for explicit-override Repositories when harness default changes", () =>
+      runTest(
+        Effect.gen(function* () {
+          const db = yield* DbService
+          yield* db.updateConfig({
+            selectedAgentBackend: "opencode",
+            defaultModel: "openai/gpt-5.6-terra",
+            defaultThinkingLevel: "high",
+            reviewModel: null,
+            reviewThinkingLevel: null,
+            maxConcurrentAgentTurns: 2,
+            maxConcurrentWorkItems: 5,
+          })
+          const inheriting = yield* db.addRepository(sampleInput)
+          const overridden = yield* db.addRepository({
+            githubOwner: "acme",
+            githubRepo: "other",
+            localPath: "/repos/acme/other.git",
+            isBare: true,
+          })
+          yield* db.updateRepositorySettings({
+            repositoryId: inheriting.id,
+            paused: true,
+            defaultModel: "openai/opencode-repo",
+            defaultThinkingLevel: "high",
+            reviewModel: null,
+            reviewThinkingLevel: null,
+            autoMerge: false,
+            includeAllIssueAuthors: false,
+          })
+          yield* db.updateRepositorySettings({
+            repositoryId: overridden.id,
+            paused: true,
+            selectedAgentBackend: "grok",
+            defaultModel: "grok-code",
+            defaultThinkingLevel: null,
+            reviewModel: null,
+            reviewThinkingLevel: null,
+            autoMerge: false,
+            includeAllIssueAuthors: false,
+          })
+
+          yield* db.updateConfig({
+            selectedAgentBackend: "grok",
+            defaultModel: "grok-code",
+            defaultThinkingLevel: null,
+            reviewModel: null,
+            reviewThinkingLevel: null,
+            maxConcurrentAgentTurns: 2,
+            maxConcurrentWorkItems: 5,
+          })
+
+          const repos = yield* db.listRepositories
+          const byId = new Map(repos.map((r) => [r.id, r]))
+          // Inheriting repo projects empty-ish grok prefs from its map (no grok entry).
+          expect(byId.get(inheriting.id)).toMatchObject({
+            selectedAgentBackend: null,
+            defaultModel: null,
+            defaultThinkingLevel: null,
+          })
+          // Override repo keeps its grok flat projection.
+          expect(byId.get(overridden.id)).toMatchObject({
+            selectedAgentBackend: "grok",
+            defaultModel: "grok-code",
+            defaultThinkingLevel: null,
+          })
         }),
       ))
 

--- a/packages/db/test/run-migrations.spec.ts
+++ b/packages/db/test/run-migrations.spec.ts
@@ -95,6 +95,7 @@ describe("runMigrations", () => {
           { name: "20260724180000_agent_backend_selection" },
           { name: "20260724190000_work_item_turn_time_models" },
           { name: "20260725120000_backend_model_prefs" },
+          { name: "20260725180000_repository_agent_backend_override" },
         ])
       }).pipe(Effect.provide(SqliteTest)),
     )
@@ -539,6 +540,52 @@ describe("runMigrations", () => {
             reviewThinkingLevel: null,
           },
         })
+      }).pipe(Effect.provide(SqliteTest)),
+    )
+  })
+
+  it("adds nullable Repository Agent Backend override defaulting to inherit (null)", async () => {
+    const migrationSql = await readFile(
+      join(
+        import.meta.dir,
+        "../../db-schema/drizzle/20260725180000_repository_agent_backend_override/migration.sql",
+      ),
+      "utf8",
+    )
+
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        const sql = yield* SqlClient.SqlClient
+        yield* sql.unsafe(
+          `CREATE TABLE repository (
+             id text PRIMARY KEY,
+             github_owner text NOT NULL,
+             github_repo text NOT NULL
+           )`,
+        )
+        yield* sql.unsafe(
+          `INSERT INTO repository (id, github_owner, github_repo) VALUES
+             ('repo-1', 'acme', 'widgets'),
+             ('repo-2', 'acme', 'api')`,
+        )
+
+        for (const statement of migrationSql.split(
+          "--> statement-breakpoint",
+        )) {
+          if (statement.trim().length > 0) {
+            yield* sql.unsafe(statement)
+          }
+        }
+
+        const rows = yield* sql.unsafe(
+          `SELECT id, selected_agent_backend
+           FROM repository
+           ORDER BY id`,
+        )
+        expect(rows).toEqual([
+          { id: "repo-1", selected_agent_backend: null },
+          { id: "repo-2", selected_agent_backend: null },
+        ])
       }).pipe(Effect.provide(SqliteTest)),
     )
   })

--- a/packages/graphql-api/src/lib/to-graphql-error.ts
+++ b/packages/graphql-api/src/lib/to-graphql-error.ts
@@ -16,6 +16,7 @@ type TaggedError = {
   readonly selectedBackendId?: string
   readonly activeBackendId?: string
   readonly unfinishedWorkItemCount?: number
+  readonly scope?: string
 }
 
 const isTaggedError = (error: unknown): error is TaggedError =>
@@ -94,6 +95,9 @@ export const toGraphQLError = (error: unknown): GraphQLError => {
             "unfinishedWorkItemCount" in error
               ? error.unfinishedWorkItemCount
               : undefined,
+          scope: "scope" in error ? error.scope : undefined,
+          repositoryId:
+            "repositoryId" in error ? error.repositoryId : undefined,
         },
       )
     case "WorkItemLifecycleDatabaseError":


### PR DESCRIPTION
## Summary

- Add nullable Repository `selectedAgentBackend` (null = inherit harness default) with migration for existing rows.
- Enforce scoped unfinished Work Item gates: repository override vs inheriting-only global default; blocking errors carry count + scope.
- Key Repository model prefs and flat columns by effective backend; leave instance-wide concurrency limits unchanged.

Closes #464

## Test plan

- [x] `bunx nx test db-service`
- [x] `bunx nx test db` (migration inherit-null)
- [x] Pre-commit / `nx affected` lint, typecheck, test on commit
- [ ] Spot-check GraphQL still maps `AgentBackendChangeBlockedError` with scope extensions