### PR TITLE
feat(ready-for-agent): host preflight for default ∪ repo backend overrides

### DIFF
--- a/apps/ready-for-agent/src/host-tools-preflight.test.ts
+++ b/apps/ready-for-agent/src/host-tools-preflight.test.ts
@@ -9,22 +9,63 @@ describe("host tools preflight", () => {
     expect(result.ok).toBe(true)
   })
 
-  test("requires grok instead of opencode when Grok Build is selected", () => {
+  test("requires grok instead of opencode when only Grok Build is selected", () => {
     const withGrok = checkHostTools(
       (command) => ["git", "gh", "grok"].includes(command),
-      { selectedAgentBackendId: "grok" },
+      { selectedAgentBackendIds: ["grok"] },
     )
     expect(withGrok.ok).toBe(true)
 
     const missingGrok = checkHostTools(
       (command) => ["git", "gh", "opencode"].includes(command),
-      { selectedAgentBackendId: "grok" },
+      { selectedAgentBackendIds: ["grok"] },
     )
     expect(missingGrok.ok).toBe(false)
     if (missingGrok.ok) return
     expect(missingGrok.missing.map((tool) => tool.name)).toEqual(["grok"])
     expect(missingGrok.message).toContain("grok")
     expect(missingGrok.message).not.toContain("opencode")
+  })
+
+  test("default only when no overrides: unused built-ins are not required", () => {
+    const result = checkHostTools(
+      (command) => ["git", "gh", "opencode"].includes(command),
+      { selectedAgentBackendIds: ["opencode"] },
+    )
+    expect(result.ok).toBe(true)
+  })
+
+  test("union includes override backends: both binaries required", () => {
+    const bothPresent = checkHostTools(
+      (command) => ["git", "gh", "opencode", "grok"].includes(command),
+      { selectedAgentBackendIds: ["opencode", "grok"] },
+    )
+    expect(bothPresent.ok).toBe(true)
+
+    const missingGrok = checkHostTools(
+      (command) => ["git", "gh", "opencode"].includes(command),
+      { selectedAgentBackendIds: ["opencode", "grok"] },
+    )
+    expect(missingGrok.ok).toBe(false)
+    if (missingGrok.ok) return
+    expect(missingGrok.missing.map((tool) => tool.name)).toEqual(["grok"])
+    expect(missingGrok.message).toContain("grok")
+    expect(missingGrok.message).toContain("OpenCode")
+    expect(missingGrok.message).toContain("Grok Build")
+  })
+
+  test("unused built-ins not required even when only one of two is selected", () => {
+    const onlyGrok = checkHostTools(
+      (command) => ["git", "gh", "grok"].includes(command),
+      { selectedAgentBackendIds: ["grok"] },
+    )
+    expect(onlyGrok.ok).toBe(true)
+
+    const onlyOpenCode = checkHostTools(
+      (command) => ["git", "gh", "opencode"].includes(command),
+      { selectedAgentBackendIds: ["opencode"] },
+    )
+    expect(onlyOpenCode.ok).toBe(true)
   })
 
   test("passes without keymaxxer", () => {
@@ -52,5 +93,21 @@ describe("host tools preflight", () => {
       ["git", "gh", "opencode"].includes(command),
     )
     expect(result).toEqual({ ok: true })
+  })
+
+  test("still accepts singular selectedAgentBackendId", () => {
+    const result = checkHostTools(
+      (command) => ["git", "gh", "grok"].includes(command),
+      { selectedAgentBackendId: "grok" },
+    )
+    expect(result.ok).toBe(true)
+  })
+
+  test("empty selectedAgentBackendIds still honors singular id", () => {
+    const result = checkHostTools(
+      (command) => ["git", "gh", "grok"].includes(command),
+      { selectedAgentBackendIds: [], selectedAgentBackendId: "grok" },
+    )
+    expect(result.ok).toBe(true)
   })
 })

--- a/apps/ready-for-agent/src/host-tools-preflight.ts
+++ b/apps/ready-for-agent/src/host-tools-preflight.ts
@@ -50,7 +50,19 @@ const optionalTools: ReadonlyArray<HostTool> = [
 ]
 
 export type HostToolsPreflightOptions = {
-  /** Active/selected Agent Backend id; defaults to OpenCode. */
+  /**
+   * Selected Agent Backend ids that cold-start preflight must cover
+   * (harness default ∪ Repository overrides). Unknown ids are ignored.
+   * Combined with {@link selectedAgentBackendId} when both are set; if neither
+   * yields a selectable id, OpenCode is required.
+   */
+  readonly selectedAgentBackendIds?: ReadonlyArray<string>
+  /**
+   * Single selected backend id (legacy convenience). Prefer
+   * {@link selectedAgentBackendIds} when multiple backends may be selected.
+   * Merged into the required set when present (including when the plural list
+   * is empty).
+   */
   readonly selectedAgentBackendId?: string
 }
 
@@ -62,27 +74,42 @@ export type HostToolsPreflightResult =
       readonly message: string
     }
 
-const resolveRequiredAgentBackendBinary = (
-  selectedAgentBackendId?: string,
-): { readonly name: string; readonly installHint: string } => {
-  const id =
-    selectedAgentBackendId !== undefined &&
-    isSelectableAgentBackendId(selectedAgentBackendId)
-      ? selectedAgentBackendId
-      : defaultAgentBackendId
-  return BACKEND_HOST_TOOLS[id]
+const resolveRequiredAgentBackendIds = (
+  options: HostToolsPreflightOptions,
+): ReadonlyArray<AgentBackendId> => {
+  const raw = [
+    ...(options.selectedAgentBackendIds ?? []),
+    ...(options.selectedAgentBackendId !== undefined
+      ? [options.selectedAgentBackendId]
+      : []),
+  ]
+
+  const seen = new Set<AgentBackendId>()
+  const resolved: AgentBackendId[] = []
+  for (const value of raw) {
+    if (!isSelectableAgentBackendId(value) || seen.has(value)) {
+      continue
+    }
+    seen.add(value)
+    resolved.push(value)
+  }
+
+  return resolved.length > 0 ? resolved : [defaultAgentBackendId]
 }
+
+const resolveRequiredAgentBackendBinaries = (
+  options: HostToolsPreflightOptions,
+): ReadonlyArray<{ readonly name: string; readonly installHint: string }> =>
+  resolveRequiredAgentBackendIds(options).map((id) => BACKEND_HOST_TOOLS[id])
 
 export const checkHostTools = (
   commandExists: (command: string) => boolean,
   options: HostToolsPreflightOptions = {},
 ): HostToolsPreflightResult => {
-  const backendTool = resolveRequiredAgentBackendBinary(
-    options.selectedAgentBackendId,
-  )
+  const backendTools = resolveRequiredAgentBackendBinaries(options)
   const hostTools: ReadonlyArray<HostTool> = [
     ...alwaysRequiredTools,
-    { ...backendTool, required: true },
+    ...backendTools.map((tool) => ({ ...tool, required: true as const })),
     ...optionalTools,
   ]
 
@@ -94,19 +121,21 @@ export const checkHostTools = (
     return { ok: true }
   }
 
-  const backendLabel =
-    getBuiltInAgentBackend(
-      options.selectedAgentBackendId !== undefined &&
-        isSelectableAgentBackendId(options.selectedAgentBackendId)
-        ? options.selectedAgentBackendId
-        : defaultAgentBackendId,
-    )?.descriptor.label ?? "the selected Agent Backend"
+  const backendIds = resolveRequiredAgentBackendIds(options)
+  const backendLabels = backendIds.map(
+    (id) => getBuiltInAgentBackend(id)?.descriptor.label ?? id,
+  )
+  const backendSummary =
+    backendLabels.length === 1
+      ? backendLabels[0]
+      : backendLabels.slice(0, -1).join(", ") +
+        ` and ${backendLabels[backendLabels.length - 1]}`
 
   const lines = [
     "Required host tools are missing from PATH:",
     ...missingRequired.map((tool) => `  - ${tool.name}: ${tool.installHint}`),
     "",
-    `Only the selected Agent Backend executable (${backendLabel}) is required alongside git and gh.`,
+    `Only selected Agent Backend executable(s) (${backendSummary}) are required alongside git and gh.`,
     "Install the tools above, then run ready-for-agent again.",
     "Keymaxxer is optional and does not block start.",
   ]

--- a/apps/ready-for-agent/src/peek-selected-agent-backend.test.ts
+++ b/apps/ready-for-agent/src/peek-selected-agent-backend.test.ts
@@ -1,0 +1,208 @@
+import { mkdtempSync, rmSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import {
+  peekSelectedAgentBackendId,
+  peekSelectedAgentBackendIds,
+} from "./peek-selected-agent-backend.ts"
+import { Database } from "bun:sqlite"
+import { afterEach, describe, expect, test } from "bun:test"
+
+const createTempDb = (): { readonly path: string; readonly root: string } => {
+  const root = mkdtempSync(join(tmpdir(), "rfa-peek-backend-"))
+  return { path: join(root, "ready-for-agent.db"), root }
+}
+
+const openWritable = (path: string): Database =>
+  new Database(path, { create: true })
+
+const ensureConfigTable = (db: Database): void => {
+  db.run(`
+    CREATE TABLE IF NOT EXISTS config (
+      id TEXT PRIMARY KEY DEFAULT 'default',
+      selected_agent_backend TEXT NOT NULL DEFAULT 'opencode'
+    )
+  `)
+}
+
+const ensureRepositoryTable = (db: Database): void => {
+  db.run(`
+    CREATE TABLE IF NOT EXISTS repository (
+      id TEXT PRIMARY KEY,
+      selected_agent_backend TEXT
+    )
+  `)
+}
+
+describe("peekSelectedAgentBackendIds", () => {
+  let roots: string[] = []
+
+  afterEach(() => {
+    for (const root of roots) {
+      rmSync(root, { recursive: true, force: true })
+    }
+    roots = []
+  })
+
+  test("missing DB defaults safely to OpenCode only", () => {
+    expect(
+      peekSelectedAgentBackendIds("/no/such/path/ready-for-agent.db"),
+    ).toEqual(["opencode"])
+    expect(peekSelectedAgentBackendIds(":memory:")).toEqual(["opencode"])
+    expect(peekSelectedAgentBackendIds("")).toEqual(["opencode"])
+  })
+
+  test("default only when no repository overrides", () => {
+    const { path, root } = createTempDb()
+    roots.push(root)
+    const db = openWritable(path)
+    try {
+      ensureConfigTable(db)
+      ensureRepositoryTable(db)
+      db.run(
+        `INSERT INTO config (id, selected_agent_backend) VALUES ('default', 'opencode')`,
+      )
+      db.run(
+        `INSERT INTO repository (id, selected_agent_backend) VALUES ('repo-1', NULL)`,
+      )
+      db.run(
+        `INSERT INTO repository (id, selected_agent_backend) VALUES ('repo-2', NULL)`,
+      )
+    } finally {
+      db.close()
+    }
+
+    expect(peekSelectedAgentBackendIds(path)).toEqual(["opencode"])
+    expect(peekSelectedAgentBackendId(path)).toBe("opencode")
+  })
+
+  test("union includes override backends", () => {
+    const { path, root } = createTempDb()
+    roots.push(root)
+    const db = openWritable(path)
+    try {
+      ensureConfigTable(db)
+      ensureRepositoryTable(db)
+      db.run(
+        `INSERT INTO config (id, selected_agent_backend) VALUES ('default', 'opencode')`,
+      )
+      db.run(
+        `INSERT INTO repository (id, selected_agent_backend) VALUES ('repo-1', NULL)`,
+      )
+      db.run(
+        `INSERT INTO repository (id, selected_agent_backend) VALUES ('repo-2', 'grok')`,
+      )
+      db.run(
+        `INSERT INTO repository (id, selected_agent_backend) VALUES ('repo-3', 'grok')`,
+      )
+    } finally {
+      db.close()
+    }
+
+    expect(peekSelectedAgentBackendIds(path)).toEqual(["opencode", "grok"])
+    expect(peekSelectedAgentBackendId(path)).toBe("opencode")
+  })
+
+  test("config default alone when it is not OpenCode and no overrides", () => {
+    const { path, root } = createTempDb()
+    roots.push(root)
+    const db = openWritable(path)
+    try {
+      ensureConfigTable(db)
+      ensureRepositoryTable(db)
+      db.run(
+        `INSERT INTO config (id, selected_agent_backend) VALUES ('default', 'grok')`,
+      )
+    } finally {
+      db.close()
+    }
+
+    expect(peekSelectedAgentBackendIds(path)).toEqual(["grok"])
+    expect(peekSelectedAgentBackendId(path)).toBe("grok")
+  })
+
+  test("singular peeks config only when override is OpenCode and default is Grok", () => {
+    const { path, root } = createTempDb()
+    roots.push(root)
+    const db = openWritable(path)
+    try {
+      ensureConfigTable(db)
+      ensureRepositoryTable(db)
+      db.run(
+        `INSERT INTO config (id, selected_agent_backend) VALUES ('default', 'grok')`,
+      )
+      db.run(
+        `INSERT INTO repository (id, selected_agent_backend) VALUES ('repo-1', 'opencode')`,
+      )
+    } finally {
+      db.close()
+    }
+
+    // Plural union: product default first when present, then remaining sorted.
+    expect(peekSelectedAgentBackendIds(path)).toEqual(["opencode", "grok"])
+    // Singular remains config-only, not "first of ordered union".
+    expect(peekSelectedAgentBackendId(path)).toBe("grok")
+  })
+
+  test("ignores unknown and blank repository overrides", () => {
+    const { path, root } = createTempDb()
+    roots.push(root)
+    const db = openWritable(path)
+    try {
+      ensureConfigTable(db)
+      ensureRepositoryTable(db)
+      db.run(
+        `INSERT INTO config (id, selected_agent_backend) VALUES ('default', 'opencode')`,
+      )
+      db.run(
+        `INSERT INTO repository (id, selected_agent_backend) VALUES ('repo-1', 'not-a-backend')`,
+      )
+      db.run(
+        `INSERT INTO repository (id, selected_agent_backend) VALUES ('repo-2', '  ')`,
+      )
+    } finally {
+      db.close()
+    }
+
+    expect(peekSelectedAgentBackendIds(path)).toEqual(["opencode"])
+  })
+
+  test("missing repository table still returns config default", () => {
+    const { path, root } = createTempDb()
+    roots.push(root)
+    const db = openWritable(path)
+    try {
+      ensureConfigTable(db)
+      db.run(
+        `INSERT INTO config (id, selected_agent_backend) VALUES ('default', 'grok')`,
+      )
+    } finally {
+      db.close()
+    }
+
+    expect(peekSelectedAgentBackendIds(path)).toEqual(["grok"])
+  })
+
+  test("file: URI paths work", () => {
+    const { path, root } = createTempDb()
+    roots.push(root)
+    const db = openWritable(path)
+    try {
+      ensureConfigTable(db)
+      ensureRepositoryTable(db)
+      db.run(
+        `INSERT INTO config (id, selected_agent_backend) VALUES ('default', 'opencode')`,
+      )
+      db.run(
+        `INSERT INTO repository (id, selected_agent_backend) VALUES ('repo-1', 'grok')`,
+      )
+    } finally {
+      db.close()
+    }
+
+    expect(peekSelectedAgentBackendIds(`file:${path}`)).toEqual([
+      "opencode",
+      "grok",
+    ])
+  })
+})

--- a/apps/ready-for-agent/src/peek-selected-agent-backend.ts
+++ b/apps/ready-for-agent/src/peek-selected-agent-backend.ts
@@ -1,44 +1,130 @@
-import { defaultAgentBackendId } from "@ready-for-agent/agent-backend"
+import {
+  defaultAgentBackendId,
+  isSelectableAgentBackendId,
+} from "@ready-for-agent/agent-backend"
 import { Database } from "bun:sqlite"
 
-/**
- * Read Harness Config's selected Agent Backend without starting the full app.
- * Missing DB or row defaults to OpenCode so first-run preflight stays correct.
- */
-export const peekSelectedAgentBackendId = (databasePath: string): string => {
+const resolveFilePath = (databasePath: string): string | undefined => {
   if (
     databasePath === ":memory:" ||
     databasePath.startsWith("libsql:") ||
     databasePath.trim() === ""
   ) {
-    return defaultAgentBackendId
+    return undefined
   }
 
-  const filePath = databasePath.startsWith("file://")
+  return databasePath.startsWith("file://")
     ? databasePath.slice("file://".length)
     : databasePath.startsWith("file:")
       ? databasePath.slice("file:".length)
       : databasePath
+}
+
+const normalizeBackendId = (
+  value: string | null | undefined,
+): string | undefined => {
+  const trimmed = value?.trim()
+  if (trimmed === undefined || trimmed.length === 0) {
+    return undefined
+  }
+  return isSelectableAgentBackendId(trimmed) ? trimmed : undefined
+}
+
+const readConfigBackendId = (db: Database): string => {
+  try {
+    const configRow = db
+      .query(
+        `SELECT selected_agent_backend AS selectedAgentBackend
+         FROM config
+         WHERE id = 'default'
+         LIMIT 1`,
+      )
+      .get() as { selectedAgentBackend?: string } | null
+    return (
+      normalizeBackendId(configRow?.selectedAgentBackend) ??
+      defaultAgentBackendId
+    )
+  } catch {
+    // Config table may be missing on first-run / pre-migration DBs.
+    return defaultAgentBackendId
+  }
+}
+
+/**
+ * Read Harness Config's selected Agent Backend without starting the full app.
+ * Missing DB or row defaults to OpenCode so first-run preflight stays correct.
+ * Does not include Repository overrides (use {@link peekSelectedAgentBackendIds}).
+ */
+export const peekSelectedAgentBackendId = (databasePath: string): string => {
+  const filePath = resolveFilePath(databasePath)
+  if (filePath === undefined) {
+    return defaultAgentBackendId
+  }
 
   try {
     const db = new Database(filePath, { readonly: true, create: false })
     try {
-      const row = db
-        .query(
-          `SELECT selected_agent_backend AS selectedAgentBackend
-           FROM config
-           WHERE id = 'default'
-           LIMIT 1`,
-        )
-        .get() as { selectedAgentBackend?: string } | null
-      const value = row?.selectedAgentBackend?.trim()
-      return value !== undefined && value.length > 0
-        ? value
-        : defaultAgentBackendId
+      return readConfigBackendId(db)
     } finally {
       db.close()
     }
   } catch {
     return defaultAgentBackendId
+  }
+}
+
+/**
+ * Cold-start host-tools preflight set: harness config default unioned with
+ * every distinct non-null Repository Agent Backend override.
+ *
+ * Missing DB / unreadable DB / empty config defaults safely to OpenCode only.
+ * Unknown or blank backend ids are ignored (never required as host tools).
+ */
+export const peekSelectedAgentBackendIds = (
+  databasePath: string,
+): ReadonlyArray<string> => {
+  const filePath = resolveFilePath(databasePath)
+  if (filePath === undefined) {
+    return [defaultAgentBackendId]
+  }
+
+  try {
+    const db = new Database(filePath, { readonly: true, create: false })
+    try {
+      const ids = new Set<string>()
+      ids.add(readConfigBackendId(db))
+
+      try {
+        const overrideRows = db
+          .query(
+            `SELECT DISTINCT selected_agent_backend AS selectedAgentBackend
+             FROM repository
+             WHERE selected_agent_backend IS NOT NULL
+               AND trim(selected_agent_backend) != ''`,
+          )
+          .all() as ReadonlyArray<{ selectedAgentBackend?: string | null }>
+
+        for (const row of overrideRows) {
+          const id = normalizeBackendId(row.selectedAgentBackend)
+          if (id !== undefined) {
+            ids.add(id)
+          }
+        }
+      } catch {
+        // Repository table or column may be missing; keep config-only set.
+      }
+
+      // Stable order: product default first when present, then remaining ids sorted.
+      const remaining = [...ids]
+        .filter((id) => id !== defaultAgentBackendId)
+        .sort()
+      return ids.has(defaultAgentBackendId)
+        ? [defaultAgentBackendId, ...remaining]
+        : remaining
+    } finally {
+      db.close()
+    }
+  } catch {
+    return [defaultAgentBackendId]
   }
 }

--- a/apps/ready-for-agent/src/services/start-harness.ts
+++ b/apps/ready-for-agent/src/services/start-harness.ts
@@ -7,7 +7,7 @@ import {
   shouldOpenBrowser,
 } from "../browser-open.ts"
 import { checkHostTools } from "../host-tools-preflight.ts"
-import { peekSelectedAgentBackendId } from "../peek-selected-agent-backend.ts"
+import { peekSelectedAgentBackendIds } from "../peek-selected-agent-backend.ts"
 import { bootStandaloneProduction } from "../standalone-boot.ts"
 import { ApplicationConfig } from "./application-config.ts"
 
@@ -79,12 +79,12 @@ export class StartHarness extends Context.Service<
       )
 
       const runPreflight = Effect.fn("StartHarness.runPreflight")(function* () {
-        const selectedAgentBackendId = peekSelectedAgentBackendId(
+        const selectedAgentBackendIds = peekSelectedAgentBackendIds(
           config.databasePath,
         )
         const result = checkHostTools(
           (command) => Bun.which(command) !== null,
-          { selectedAgentBackendId },
+          { selectedAgentBackendIds },
         )
         if (!result.ok) {
           return yield* new StartHarnessFailed({ detail: result.message })


### PR DESCRIPTION
## Summary

- Cold-start host tools preflight peeks harness config **and** distinct non-null Repository `selectedAgentBackend` overrides.
- `checkHostTools` requires binaries only for that union (unused built-in backends are not required).
- First-run / missing or unreadable DB still defaults safely to OpenCode.
- Singular `peekSelectedAgentBackendId` remains config-only; plural owns the union for start preflight.

Closes #468

## Test plan

- [x] `bun --conditions=@ready-for-agent/source test src/peek-selected-agent-backend.test.ts src/host-tools-preflight.test.ts` (peek union + preflight cases)
- [x] Pre-commit / `nx affected` lint, typecheck, test on commit
- [ ] Optional: start harness with a repo override to Grok and confirm both CLIs are required on cold start