### PR TITLE
feat(agent-backend): multi-backend ActiveAgentBackend registry

### DIFF
--- a/apps/harness/src/server/application.server.ts
+++ b/apps/harness/src/server/application.server.ts
@@ -204,10 +204,14 @@ export const createApplication = async (
         yield* keymaxxer.initialize
         // Startup inspection: failure must not terminate the Harness.
         const active = yield* ActiveAgentBackend
-        yield* active.recheck({
-          cwd: toolCwd,
-          timeout: "30 seconds",
-        })
+        // Startup inspect for every initial Active backend (selected-or-in-use).
+        const statuses = yield* active.listStatuses
+        for (const status of statuses) {
+          yield* active.recheck(status.backend.id, {
+            cwd: toolCwd,
+            timeout: "30 seconds",
+          })
+        }
       }),
     )
   } catch (error) {

--- a/packages/agent-backend/src/lib/active-agent-backend.ts
+++ b/packages/agent-backend/src/lib/active-agent-backend.ts
@@ -1,5 +1,5 @@
 import { Context, Effect, Layer, Ref, Result, Schema, Semaphore } from "effect"
-import type { AgentBackend } from "./agent-backend.js"
+import type { AgentBackend, AgentBackendError } from "./agent-backend.js"
 import { AgentBackend as AgentBackendService } from "./agent-backend.js"
 import { AgentBackendConfigError } from "./errors.js"
 import {
@@ -19,11 +19,31 @@ import type {
   AgentBackendDescriptor,
   AgentBackendId,
   AgentModel,
+  AgentTurnResult,
+  ContinueTurnInput,
   InspectInput,
+  InspectResult,
+  StartTurnInput,
 } from "./types.js"
 
 export type AgentBackendStatusKind = "ready" | "unavailable"
 
+/**
+ * Per-backend readiness for one Active Agent Backend: Ready or Unavailable
+ * with reason and model catalog.
+ */
+export type AgentBackendRuntimeStatus = {
+  readonly backend: AgentBackendDescriptor
+  readonly kind: AgentBackendStatusKind
+  readonly reason: string | null
+  readonly models: ReadonlyArray<AgentModel>
+}
+
+/**
+ * Singular Selected/Active status view used by GraphQL until multi-status
+ * lands (#467). `selectedBackend` and `activeBackend` are the same descriptor
+ * for a registry entry (no Selected≠Active limbo).
+ */
 export type AgentBackendStatus = {
   readonly selectedBackend: AgentBackendDescriptor
   readonly activeBackend: AgentBackendDescriptor
@@ -74,12 +94,22 @@ export type ResolveAgentBackendRuntime = (
   backendId: AgentBackendId,
 ) => Effect.Effect<ResolvedAgentBackendRuntime, unknown>
 
-type ActiveState = {
+type ActiveEntry = {
   readonly registration: AgentBackendRegistration
   readonly adapter: AgentBackendAdapter
   readonly telemetry: AgentBackendTelemetry
   readonly models: ReadonlyArray<AgentModel>
   readonly unavailableReason: string | null
+}
+
+type RegistryState = {
+  /** Active backends keyed by backend id. */
+  readonly entries: ReadonlyMap<string, ActiveEntry>
+  /**
+   * Backend id used by the process-wide AgentBackend / SessionTelemetryProvider
+   * proxies until lifecycle routes by captured Work Item backend (#466).
+   */
+  readonly proxyBackendId: AgentBackendId
 }
 
 const descriptorFor = (id: AgentBackendId): AgentBackendDescriptor => {
@@ -90,25 +120,46 @@ const descriptorFor = (id: AgentBackendId): AgentBackendDescriptor => {
   return { id, label: id }
 }
 
-const toStatus = (state: ActiveState): AgentBackendStatus => {
-  const activeBackend = state.registration.descriptor
-  if (state.unavailableReason !== null) {
+const normalizeBackendId = (backendId: string): AgentBackendId =>
+  isSelectableAgentBackendId(backendId) ? backendId : defaultAgentBackendId
+
+const toRuntimeStatus = (entry: ActiveEntry): AgentBackendRuntimeStatus => {
+  const backend = entry.registration.descriptor
+  if (entry.unavailableReason !== null) {
     return {
-      selectedBackend: activeBackend,
-      activeBackend,
+      backend,
       kind: "unavailable",
-      reason: state.unavailableReason,
+      reason: entry.unavailableReason,
       models: [],
     }
   }
   return {
-    selectedBackend: activeBackend,
-    activeBackend,
+    backend,
     kind: "ready",
     reason: null,
-    models: state.models,
+    models: entry.models,
   }
 }
+
+/** Map a runtime status to the singular GraphQL-facing shape. */
+export const toAgentBackendStatus = (
+  status: AgentBackendRuntimeStatus,
+): AgentBackendStatus => ({
+  selectedBackend: status.backend,
+  activeBackend: status.backend,
+  kind: status.kind,
+  reason: status.reason,
+  models: status.models,
+})
+
+const notActiveStatus = (
+  backendId: AgentBackendId,
+): AgentBackendRuntimeStatus => ({
+  backend: descriptorFor(backendId),
+  kind: "unavailable",
+  reason: "Agent Backend is not Active",
+  models: [],
+})
 
 const formatInspectFailure = (error: unknown): string => {
   if (
@@ -133,36 +184,103 @@ const formatInspectFailure = (error: unknown): string => {
   return "Agent Backend inspection failed"
 }
 
+const emptyEntry = (
+  runtime: ResolvedAgentBackendRuntime,
+  unavailableReason: string | null,
+): ActiveEntry => ({
+  registration: runtime.registration,
+  adapter: runtime.adapter,
+  telemetry: runtime.telemetry,
+  models: [],
+  unavailableReason,
+})
+
 export type ActiveAgentBackendShape = {
-  readonly getStatus: Effect.Effect<AgentBackendStatus>
-  readonly recheck: (input: InspectInput) => Effect.Effect<AgentBackendStatus>
-  readonly requireAgentTurnsAllowed: Effect.Effect<
-    void,
-    AgentBackendUnavailableError
-  >
+  /** Status for every Active backend (order not significant). */
+  readonly listStatuses: Effect.Effect<ReadonlyArray<AgentBackendRuntimeStatus>>
   /**
-   * Hot-activate a backend: swap Active registration + adapter, then inspect.
-   * Inspect failure leaves Active on the new backend in Unavailable.
+   * Status for one backend if it is Active; `null` when the id is not in the
+   * Active set.
+   */
+  readonly getBackendStatus: (
+    backendId: AgentBackendId,
+  ) => Effect.Effect<AgentBackendRuntimeStatus | null>
+  /**
+   * Singular status of the process-wide proxy backend (legacy GraphQL/lifecycle
+   * surface until multi-status #467 and lifecycle routing #466).
+   */
+  readonly getStatus: Effect.Effect<AgentBackendStatus>
+  /**
+   * Make `backendIds` the exact selected-or-in-use Active set: activate and
+   * inspect missing ids, drop the rest. Same-backend members that are already
+   * Active are left as-is (no re-inspect; Recheck stays explicit).
+   */
+  readonly setSelectedOrInUse: (
+    backendIds: ReadonlyArray<AgentBackendId>,
+    input: InspectInput,
+  ) => Effect.Effect<ReadonlyArray<AgentBackendRuntimeStatus>>
+  /**
+   * Hot-activate one backend on demand. Inspect failure leaves that backend
+   * Active and Unavailable. When already Active, returns current status without
+   * re-inspect (same-backend re-Save skips full re-inspect). Also moves the
+   * process-wide proxy to this backend until lifecycle routes by captured id.
    */
   readonly activate: (
     backendId: AgentBackendId,
     input: InspectInput,
-  ) => Effect.Effect<AgentBackendStatus>
+  ) => Effect.Effect<AgentBackendRuntimeStatus>
+  /** Drop a backend from the Active set when it leaves selected-or-in-use. */
+  readonly drop: (backendId: AgentBackendId) => Effect.Effect<void>
   /**
-   * Settings-only inspect of a not-yet-saved backend. Does not change Active.
+   * Recheck (inspect) one backend that is already Active. Does not add missing
+   * ids to the Active set — use `activate` or `setSelectedOrInUse` for that.
+   */
+  readonly recheck: (
+    backendId: AgentBackendId,
+    input: InspectInput,
+  ) => Effect.Effect<AgentBackendRuntimeStatus>
+  readonly requireAgentTurnsAllowed: (
+    backendId: AgentBackendId,
+  ) => Effect.Effect<void, AgentBackendUnavailableError>
+  /**
+   * Settings-only inspect of a not-yet-saved backend. Does not change the
+   * Active set.
    */
   readonly preview: (
     backendId: AgentBackendId,
     input: InspectInput,
   ) => Effect.Effect<AgentBackendPreview>
   /**
-   * Serialize Config backend commits + activate with Work Item creation so a
-   * concurrent Implement Now cannot capture the pre-activate Active backend.
+   * Serialize Config/Repository backend commits + activate with Work Item
+   * creation so a concurrent Implement Now cannot capture a pre-activate
+   * backend.
    */
   readonly withConfigCoordination: <A, E, R>(
     effect: Effect.Effect<A, E, R>,
   ) => Effect.Effect<A, E, R>
+  readonly getRegistration: (
+    backendId: AgentBackendId,
+  ) => Effect.Effect<AgentBackendRegistration>
+  /**
+   * Registration for the process-wide proxy backend (legacy until #466 routes
+   * by captured Work Item backend).
+   */
   readonly getActiveRegistration: Effect.Effect<AgentBackendRegistration>
+  /** Dispatch startTurn to the Active adapter for `backendId`. */
+  readonly startTurn: (
+    backendId: AgentBackendId,
+    input: StartTurnInput,
+  ) => Effect.Effect<AgentTurnResult, AgentBackendError>
+  /** Dispatch continueTurn to the Active adapter for `backendId`. */
+  readonly continueTurn: (
+    backendId: AgentBackendId,
+    input: ContinueTurnInput,
+  ) => Effect.Effect<AgentTurnResult, AgentBackendError>
+  /** Dispatch inspect to the Active adapter for `backendId`. */
+  readonly inspectBackend: (
+    backendId: AgentBackendId,
+    input: InspectInput,
+  ) => Effect.Effect<InspectResult, AgentBackendError>
   readonly getSessionTelemetry: (input: {
     readonly backendId: string
     readonly sessionId: string | null
@@ -175,14 +293,24 @@ export class ActiveAgentBackend extends Context.Service<
 >()("@ready-for-agent/agent-backend/ActiveAgentBackend") {}
 
 export type ActiveAgentBackendLiveOptions = {
-  readonly selectedBackendId: AgentBackendId
+  /**
+   * Initial selected-or-in-use backend ids. When empty or omitted, falls back
+   * to `selectedBackendId` or the built-in default.
+   */
+  readonly initialBackendIds?: ReadonlyArray<AgentBackendId>
+  /**
+   * Single initial backend (and process-wide proxy default). Prefer
+   * `initialBackendIds` when multiple backends should be Active at startup.
+   */
+  readonly selectedBackendId?: AgentBackendId
   readonly resolveRuntime: ResolveAgentBackendRuntime
 }
 
 /**
- * Active Agent Backend readiness, catalog, and hot-activation. Also provides
- * the process-wide AgentBackend + SessionTelemetryProvider proxies so turns
- * always use the currently Active adapter without a process restart.
+ * Multi-backend Active Agent Backend registry: readiness, catalog, activate,
+ * recheck, and turn/telemetry dispatch by backend id. Also provides process-wide
+ * AgentBackend + SessionTelemetryProvider proxies that route to the proxy
+ * default backend until lifecycle routes by captured Work Item id.
  */
 export const ActiveAgentBackendLive = (
   options: ActiveAgentBackendLiveOptions,
@@ -220,98 +348,315 @@ export const ActiveAgentBackendLive = (
           }),
         )
 
-      const initial = yield* resolveOrUnavailable(options.selectedBackendId)
-      const stateRef = yield* Ref.make<ActiveState>({
-        registration: initial.registration,
-        adapter: initial.adapter,
-        telemetry: initial.telemetry,
-        models: [],
-        unavailableReason: "Agent Backend has not been inspected yet",
+      const seedIds = (() => {
+        const fromList = options.initialBackendIds ?? []
+        if (fromList.length > 0) {
+          return [...new Set(fromList.map(normalizeBackendId))]
+        }
+        const single = options.selectedBackendId ?? defaultAgentBackendId
+        return [normalizeBackendId(single)]
+      })()
+      const proxyBackendId = seedIds[0] ?? defaultAgentBackendId
+
+      const initialEntries = new Map<string, ActiveEntry>()
+      for (const id of seedIds) {
+        const runtime = yield* resolveOrUnavailable(id)
+        initialEntries.set(
+          id,
+          emptyEntry(runtime, "Agent Backend has not been inspected yet"),
+        )
+      }
+
+      const stateRef = yield* Ref.make<RegistryState>({
+        entries: initialEntries,
+        proxyBackendId,
       })
       const configCoordination = yield* Semaphore.make(1)
       const withConfigCoordination = <A, E, R>(
         effect: Effect.Effect<A, E, R>,
       ): Effect.Effect<A, E, R> => configCoordination.withPermits(1)(effect)
 
-      const getStatus = Ref.get(stateRef).pipe(Effect.map(toStatus))
+      const listStatuses = Ref.get(stateRef).pipe(
+        Effect.map((state) =>
+          [...state.entries.values()].map((entry) => toRuntimeStatus(entry)),
+        ),
+      )
+
+      const getBackendStatus = (backendId: AgentBackendId) =>
+        Ref.get(stateRef).pipe(
+          Effect.map((state) => {
+            const entry = state.entries.get(normalizeBackendId(backendId))
+            return entry === undefined ? null : toRuntimeStatus(entry)
+          }),
+        )
+
+      const getStatus = Ref.get(stateRef).pipe(
+        Effect.map((state) => {
+          const entry = state.entries.get(state.proxyBackendId)
+          if (entry === undefined) {
+            return toAgentBackendStatus(notActiveStatus(state.proxyBackendId))
+          }
+          return toAgentBackendStatus(toRuntimeStatus(entry))
+        }),
+      )
+
+      type EnsureOutcome = {
+        readonly resolvedId: AgentBackendId
+        readonly entry: ActiveEntry
+        readonly created: boolean
+      }
+
+      /**
+       * Install a registry entry if missing. Resolve outside the ref, then
+       * install only when still absent so concurrent first-activates cannot
+       * clobber a finished inspect with a fresh empty entry.
+       */
+      const ensureEntry = Effect.fn("ActiveAgentBackend.ensureEntry")(
+        function* (backendId: AgentBackendId) {
+          const resolvedId = normalizeBackendId(backendId)
+          const current = yield* Ref.get(stateRef)
+          const existing = current.entries.get(resolvedId)
+          if (existing !== undefined) {
+            return {
+              resolvedId,
+              entry: existing,
+              created: false,
+            } satisfies EnsureOutcome
+          }
+          const runtime = yield* resolveOrUnavailable(resolvedId)
+          const candidate = emptyEntry(
+            runtime,
+            "Agent Backend has not been inspected yet",
+          )
+          return yield* Ref.modify(
+            stateRef,
+            (state): [EnsureOutcome, RegistryState] => {
+              const present = state.entries.get(resolvedId)
+              if (present !== undefined) {
+                return [
+                  {
+                    resolvedId,
+                    entry: present,
+                    created: false,
+                  },
+                  state,
+                ]
+              }
+              const entries = new Map(state.entries)
+              entries.set(resolvedId, candidate)
+              return [
+                {
+                  resolvedId,
+                  entry: candidate,
+                  created: true,
+                },
+                { ...state, entries },
+              ]
+            },
+          )
+        },
+      )
+
+      const inspectActiveEntry = (
+        inspectedBackendId: AgentBackendId,
+        entryAtStart: ActiveEntry,
+        input: InspectInput,
+      ): Effect.Effect<AgentBackendRuntimeStatus> =>
+        Effect.gen(function* () {
+          const inspected = yield* Effect.result(
+            entryAtStart.adapter.inspect(input),
+          )
+          // Discard results if this backend was dropped or replaced mid-inspect.
+          const stillSameEntry = (state: RegistryState): boolean => {
+            const previous = state.entries.get(inspectedBackendId)
+            return (
+              previous !== undefined &&
+              previous.adapter === entryAtStart.adapter
+            )
+          }
+          if (Result.isFailure(inspected)) {
+            const reason = formatInspectFailure(inspected.failure)
+            yield* Ref.update(stateRef, (state) => {
+              if (!stillSameEntry(state)) {
+                return state
+              }
+              const previous = state.entries.get(inspectedBackendId)
+              if (previous === undefined) {
+                return state
+              }
+              const entries = new Map(state.entries)
+              entries.set(inspectedBackendId, {
+                ...previous,
+                models: [],
+                unavailableReason: reason,
+              })
+              return { ...state, entries }
+            })
+            const status = yield* getBackendStatus(inspectedBackendId)
+            return status ?? notActiveStatus(inspectedBackendId)
+          }
+          yield* Ref.update(stateRef, (state) => {
+            if (!stillSameEntry(state)) {
+              return state
+            }
+            const previous = state.entries.get(inspectedBackendId)
+            if (previous === undefined) {
+              return state
+            }
+            const entries = new Map(state.entries)
+            entries.set(inspectedBackendId, {
+              ...previous,
+              models: inspected.success.models,
+              unavailableReason: null,
+            })
+            return { ...state, entries }
+          })
+          const status = yield* getBackendStatus(inspectedBackendId)
+          return status ?? notActiveStatus(inspectedBackendId)
+        })
 
       const recheck = Effect.fn("ActiveAgentBackend.recheck")(function* (
+        backendId: AgentBackendId,
         input: InspectInput,
       ) {
+        const resolvedId = normalizeBackendId(backendId)
         const current = yield* Ref.get(stateRef)
-        const inspectedBackendId = current.registration.descriptor.id
-        const inspected = yield* Effect.result(current.adapter.inspect(input))
-        // Discard results if Active was swapped (activate) during inspect.
-        const stillActive = (state: ActiveState): boolean =>
-          state.registration.descriptor.id === inspectedBackendId
-        if (Result.isFailure(inspected)) {
-          const reason = formatInspectFailure(inspected.failure)
-          yield* Ref.update(stateRef, (state) =>
-            stillActive(state)
-              ? {
-                  ...state,
-                  models: [],
-                  unavailableReason: reason,
-                }
-              : state,
-          )
-          return yield* getStatus
+        const entry = current.entries.get(resolvedId)
+        if (entry === undefined) {
+          // Recheck does not expand the Active set.
+          return notActiveStatus(resolvedId)
         }
-        yield* Ref.update(stateRef, (state) =>
-          stillActive(state)
-            ? {
-                ...state,
-                models: inspected.success.models,
-                unavailableReason: null,
-              }
-            : state,
-        )
-        return yield* getStatus
+        return yield* inspectActiveEntry(resolvedId, entry, input)
       })
-
-      const requireAgentTurnsAllowed = Effect.gen(function* () {
-        const status = yield* getStatus
-        if (status.kind === "unavailable") {
-          return yield* new AgentBackendUnavailableError({
-            message: status.reason ?? "Agent Backend is unavailable",
-            reason: status.reason ?? "Agent Backend is unavailable",
-          })
-        }
-      }).pipe(Effect.asVoid)
 
       const activate = Effect.fn("ActiveAgentBackend.activate")(function* (
         backendId: AgentBackendId,
         input: InspectInput,
       ) {
-        const resolvedId = isSelectableAgentBackendId(backendId)
-          ? backendId
-          : defaultAgentBackendId
+        const resolvedId = normalizeBackendId(backendId)
         const current = yield* Ref.get(stateRef)
-        if (current.registration.descriptor.id !== resolvedId) {
-          const runtime = yield* resolveOrUnavailable(resolvedId)
-          yield* Ref.set(stateRef, {
-            registration: runtime.registration,
-            adapter: runtime.adapter,
-            telemetry: runtime.telemetry,
-            models: [],
-            unavailableReason: "Agent Backend has not been inspected yet",
-          })
+        if (current.entries.has(resolvedId)) {
+          // Already Active: move proxy, skip full re-inspect (Recheck explicit).
+          yield* Ref.update(stateRef, (state) => ({
+            ...state,
+            proxyBackendId: resolvedId,
+          }))
+          const entry = current.entries.get(resolvedId)
+          if (entry !== undefined) {
+            return toRuntimeStatus(entry)
+          }
         }
-        return yield* recheck(input)
+        // Ensure the registry row exists before retargeting the process-wide
+        // proxy so concurrent AgentBackend calls never see a missing entry.
+        const ensured = yield* ensureEntry(resolvedId)
+        yield* Ref.update(stateRef, (state) => ({
+          ...state,
+          proxyBackendId: resolvedId,
+        }))
+        return yield* inspectActiveEntry(
+          ensured.resolvedId,
+          ensured.entry,
+          input,
+        )
       })
+
+      const drop = Effect.fn("ActiveAgentBackend.drop")(function* (
+        backendId: AgentBackendId,
+      ) {
+        const resolvedId = normalizeBackendId(backendId)
+        yield* Ref.update(stateRef, (state) => {
+          if (!state.entries.has(resolvedId)) {
+            return state
+          }
+          const entries = new Map(state.entries)
+          entries.delete(resolvedId)
+          let nextProxy = state.proxyBackendId
+          if (nextProxy === resolvedId) {
+            const remaining = entries.keys().next()
+            // Prefer another Active backend; otherwise fall back to built-in
+            // default rather than leaving proxy on a deleted id.
+            nextProxy =
+              remaining.done === true
+                ? defaultAgentBackendId
+                : (remaining.value as AgentBackendId)
+          }
+          return { entries, proxyBackendId: nextProxy }
+        })
+      })
+
+      const setSelectedOrInUse = Effect.fn(
+        "ActiveAgentBackend.setSelectedOrInUse",
+      )(function* (
+        backendIds: ReadonlyArray<AgentBackendId>,
+        input: InspectInput,
+      ) {
+        const desired = [
+          ...new Set(
+            (backendIds.length > 0 ? backendIds : [defaultAgentBackendId]).map(
+              normalizeBackendId,
+            ),
+          ),
+        ]
+        const current = yield* Ref.get(stateRef)
+        for (const id of current.entries.keys()) {
+          if (!desired.includes(id as AgentBackendId)) {
+            yield* drop(id as AgentBackendId)
+          }
+        }
+        for (const id of desired) {
+          const status = yield* getBackendStatus(id)
+          if (status === null) {
+            // Activate (ensure + inspect) rather than recheck: recheck does
+            // not expand the Active set.
+            yield* ensureEntry(id).pipe(
+              Effect.flatMap((ensured) =>
+                inspectActiveEntry(ensured.resolvedId, ensured.entry, input),
+              ),
+            )
+          }
+        }
+        // Prefer keeping the previous proxy when it remains selected-or-in-use.
+        yield* Ref.update(stateRef, (state) => {
+          if (desired.includes(state.proxyBackendId)) {
+            return state
+          }
+          return {
+            ...state,
+            proxyBackendId: desired[0] ?? defaultAgentBackendId,
+          }
+        })
+        return yield* listStatuses
+      })
+
+      const requireAgentTurnsAllowed = (backendId: AgentBackendId) =>
+        Effect.gen(function* () {
+          const resolvedId = normalizeBackendId(backendId)
+          const status = yield* getBackendStatus(resolvedId)
+          if (status === null) {
+            return yield* new AgentBackendUnavailableError({
+              message: "Agent Backend is not Active",
+              reason: "Agent Backend is not Active",
+            })
+          }
+          if (status.kind === "unavailable") {
+            return yield* new AgentBackendUnavailableError({
+              message: status.reason ?? "Agent Backend is unavailable",
+              reason: status.reason ?? "Agent Backend is unavailable",
+            })
+          }
+        }).pipe(Effect.asVoid)
 
       const preview = Effect.fn("ActiveAgentBackend.preview")(function* (
         backendId: AgentBackendId,
         input: InspectInput,
       ) {
-        const resolvedId = isSelectableAgentBackendId(backendId)
-          ? backendId
-          : defaultAgentBackendId
+        const resolvedId = normalizeBackendId(backendId)
         const backend = descriptorFor(resolvedId)
         const current = yield* Ref.get(stateRef)
+        const existing = current.entries.get(resolvedId)
         const adapter =
-          current.registration.descriptor.id === resolvedId
-            ? current.adapter
+          existing !== undefined
+            ? existing.adapter
             : (yield* resolveOrUnavailable(resolvedId)).adapter
         const inspected = yield* Effect.result(adapter.inspect(input))
         if (Result.isFailure(inspected)) {
@@ -322,6 +667,7 @@ export const ActiveAgentBackendLive = (
             models: [] as ReadonlyArray<AgentModel>,
           }
         }
+        // Preview must not mutate the Active set.
         return {
           backend,
           kind: "ready" as const,
@@ -330,9 +676,69 @@ export const ActiveAgentBackendLive = (
         }
       })
 
+      const getRegistration = (backendId: AgentBackendId) =>
+        Ref.get(stateRef).pipe(
+          Effect.map((state) => {
+            const resolvedId = normalizeBackendId(backendId)
+            const entry = state.entries.get(resolvedId)
+            if (entry !== undefined) {
+              return entry.registration
+            }
+            return resolveActiveRegistration(resolvedId)
+          }),
+        )
+
       const getActiveRegistration = Ref.get(stateRef).pipe(
-        Effect.map((state) => state.registration),
+        Effect.map((state) => {
+          const entry = state.entries.get(state.proxyBackendId)
+          if (entry !== undefined) {
+            return entry.registration
+          }
+          return resolveActiveRegistration(state.proxyBackendId)
+        }),
       )
+
+      const requireActiveEntry = (
+        backendId: AgentBackendId,
+      ): Effect.Effect<ActiveEntry, AgentBackendError> =>
+        Ref.get(stateRef).pipe(
+          Effect.flatMap((state) => {
+            const resolvedId = normalizeBackendId(backendId)
+            const entry = state.entries.get(resolvedId)
+            if (entry === undefined) {
+              return Effect.fail(
+                new AgentBackendConfigError({
+                  message: `Agent Backend is not Active: ${resolvedId}`,
+                }),
+              )
+            }
+            return Effect.succeed(entry)
+          }),
+        )
+
+      const startTurn = (
+        backendId: AgentBackendId,
+        input: StartTurnInput,
+      ): Effect.Effect<AgentTurnResult, AgentBackendError> =>
+        requireActiveEntry(backendId).pipe(
+          Effect.flatMap((entry) => entry.adapter.startTurn(input)),
+        )
+
+      const continueTurn = (
+        backendId: AgentBackendId,
+        input: ContinueTurnInput,
+      ): Effect.Effect<AgentTurnResult, AgentBackendError> =>
+        requireActiveEntry(backendId).pipe(
+          Effect.flatMap((entry) => entry.adapter.continueTurn(input)),
+        )
+
+      const inspectBackend = (
+        backendId: AgentBackendId,
+        input: InspectInput,
+      ): Effect.Effect<InspectResult, AgentBackendError> =>
+        requireActiveEntry(backendId).pipe(
+          Effect.flatMap((entry) => entry.adapter.inspect(input)),
+        )
 
       const getSessionTelemetry = Effect.fn(
         "ActiveAgentBackend.getSessionTelemetry",
@@ -342,7 +748,11 @@ export const ActiveAgentBackendLive = (
       }) {
         const registration =
           getBuiltInAgentBackend(input.backendId) ??
-          (yield* Ref.get(stateRef)).registration
+          resolveActiveRegistration(
+            isSelectableAgentBackendId(input.backendId)
+              ? input.backendId
+              : defaultAgentBackendId,
+          )
         const backend = registration.descriptor
         if (!capabilitySupported(registration, "SessionTelemetry")) {
           return unsupportedSessionTelemetry(input.sessionId ?? "", backend)
@@ -351,8 +761,9 @@ export const ActiveAgentBackendLive = (
           return missingSessionTelemetry("", backend)
         }
         const state = yield* Ref.get(stateRef)
-        if (state.registration.descriptor.id === registration.descriptor.id) {
-          return yield* state.telemetry.getSession(input.sessionId)
+        const entry = state.entries.get(registration.descriptor.id)
+        if (entry !== undefined) {
+          return yield* entry.telemetry.getSession(input.sessionId)
         }
         // Historical provenance for a non-active backend: build telemetry once.
         const runtime = yield* resolveOrUnavailable(registration.descriptor.id)
@@ -360,35 +771,84 @@ export const ActiveAgentBackendLive = (
       })
 
       const activeService = ActiveAgentBackend.of({
+        listStatuses,
+        getBackendStatus,
         getStatus,
+        setSelectedOrInUse,
+        activate,
+        drop,
         recheck,
         requireAgentTurnsAllowed,
-        activate,
         preview,
         withConfigCoordination,
+        getRegistration,
         getActiveRegistration,
+        startTurn,
+        continueTurn,
+        inspectBackend,
         getSessionTelemetry,
       })
 
       const agentBackendService = AgentBackendService.of({
         inspect: (input) =>
           Ref.get(stateRef).pipe(
-            Effect.flatMap((state) => state.adapter.inspect(input)),
+            Effect.flatMap((state) => {
+              const entry = state.entries.get(state.proxyBackendId)
+              if (entry === undefined) {
+                return Effect.fail(
+                  new AgentBackendConfigError({
+                    message: `Agent Backend is not Active: ${state.proxyBackendId}`,
+                  }),
+                )
+              }
+              return entry.adapter.inspect(input)
+            }),
           ),
         startTurn: (input) =>
           Ref.get(stateRef).pipe(
-            Effect.flatMap((state) => state.adapter.startTurn(input)),
+            Effect.flatMap((state) => {
+              const entry = state.entries.get(state.proxyBackendId)
+              if (entry === undefined) {
+                return Effect.fail(
+                  new AgentBackendConfigError({
+                    message: `Agent Backend is not Active: ${state.proxyBackendId}`,
+                  }),
+                )
+              }
+              return entry.adapter.startTurn(input)
+            }),
           ),
         continueTurn: (input) =>
           Ref.get(stateRef).pipe(
-            Effect.flatMap((state) => state.adapter.continueTurn(input)),
+            Effect.flatMap((state) => {
+              const entry = state.entries.get(state.proxyBackendId)
+              if (entry === undefined) {
+                return Effect.fail(
+                  new AgentBackendConfigError({
+                    message: `Agent Backend is not Active: ${state.proxyBackendId}`,
+                  }),
+                )
+              }
+              return entry.adapter.continueTurn(input)
+            }),
           ),
       })
 
       const telemetryService = SessionTelemetryProvider.of({
         getSession: (sessionId) =>
           Ref.get(stateRef).pipe(
-            Effect.flatMap((state) => state.telemetry.getSession(sessionId)),
+            Effect.flatMap((state) => {
+              const entry = state.entries.get(state.proxyBackendId)
+              if (entry === undefined) {
+                return Effect.succeed(
+                  unsupportedSessionTelemetry(
+                    sessionId,
+                    descriptorFor(state.proxyBackendId),
+                  ),
+                )
+              }
+              return entry.telemetry.getSession(sessionId)
+            }),
           ),
       })
 

--- a/packages/agent-backend/test/active-agent-backend.spec.ts
+++ b/packages/agent-backend/test/active-agent-backend.spec.ts
@@ -6,6 +6,7 @@ import {
   AgentBackend,
   AgentBackendConfigError,
   type AgentBackendId,
+  type AgentTurnResult,
   type ResolveAgentBackendRuntime,
   SessionTelemetryProvider,
   getBuiltInAgentBackend,
@@ -20,6 +21,11 @@ const registration = (id: AgentBackendId) => {
   }
   return found
 }
+
+const turnResult = (sessionId: string): AgentTurnResult => ({
+  sessionId,
+  assistantText: "ok",
+})
 
 const makeResolve =
   (options: {
@@ -50,20 +56,31 @@ const makeResolve =
             models: [...models],
           })
         },
-        startTurn: () => Effect.die("unused"),
-        continueTurn: () => Effect.die("unused"),
+        startTurn: () => Effect.succeed(turnResult(`${backendId}-start`)),
+        continueTurn: () => Effect.succeed(turnResult(`${backendId}-continue`)),
       },
       telemetry: {
         getSession: (sessionId: string) =>
-          Effect.succeed(
-            unsupportedSessionTelemetry(sessionId, reg.descriptor),
-          ),
+          Effect.succeed({
+            id: sessionId,
+            availability: "available" as const,
+            backend: reg.descriptor,
+            model: {
+              providerId: backendId,
+              id: `${backendId}/model-a`,
+              thinkingLevel: null,
+            },
+            tokens: null,
+            cost: null,
+            createdAt: null,
+            updatedAt: null,
+          }),
       },
     })
   }
 
-describe("ActiveAgentBackend hot-activate", () => {
-  it("activates a new backend without restart limbo and matches Selected to Active", async () => {
+describe("ActiveAgentBackend multi-backend registry", () => {
+  it("keeps two backends Active concurrently", async () => {
     const layer = ActiveAgentBackendLive({
       selectedBackendId: AGENT_BACKEND_IDS.opencode,
       resolveRuntime: makeResolve({}),
@@ -72,25 +89,188 @@ describe("ActiveAgentBackend hot-activate", () => {
     await Effect.runPromise(
       Effect.gen(function* () {
         const active = yield* ActiveAgentBackend
-        const agent = yield* AgentBackend
-        yield* active.recheck({ cwd: "/tmp" })
-        let status = yield* active.getStatus
-        expect(status.kind).toBe("ready")
-        expect(status.activeBackend.id).toBe("opencode")
-        expect(status.selectedBackend.id).toBe("opencode")
-        expect(status.models[0]?.id).toBe("opencode/model-a")
+        yield* active.recheck(AGENT_BACKEND_IDS.opencode, { cwd: "/tmp" })
+        yield* active.activate(AGENT_BACKEND_IDS.grok, { cwd: "/tmp" })
 
-        status = yield* active.activate(AGENT_BACKEND_IDS.grok, {
+        const statuses = yield* active.listStatuses
+        const ids = statuses.map((s) => s.backend.id).sort()
+        expect(ids).toEqual(["grok", "opencode"])
+        expect(statuses.every((s) => s.kind === "ready")).toBe(true)
+
+        const opencode = yield* active.getBackendStatus(
+          AGENT_BACKEND_IDS.opencode,
+        )
+        const grok = yield* active.getBackendStatus(AGENT_BACKEND_IDS.grok)
+        expect(opencode?.models[0]?.id).toBe("opencode/model-a")
+        expect(grok?.models[0]?.id).toBe("grok/model-a")
+      }).pipe(Effect.provide(layer)),
+    )
+  })
+
+  it("activates on demand and drops when unused", async () => {
+    const layer = ActiveAgentBackendLive({
+      selectedBackendId: AGENT_BACKEND_IDS.opencode,
+      resolveRuntime: makeResolve({}),
+    })
+
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        const active = yield* ActiveAgentBackend
+        yield* active.recheck(AGENT_BACKEND_IDS.opencode, { cwd: "/tmp" })
+
+        const activated = yield* active.activate(AGENT_BACKEND_IDS.grok, {
           cwd: "/tmp",
         })
-        expect(status.kind).toBe("ready")
-        expect(status.activeBackend.id).toBe("grok")
-        expect(status.selectedBackend.id).toBe("grok")
-        expect(status.models[0]?.id).toBe("grok/model-a")
+        expect(activated.kind).toBe("ready")
+        expect(activated.backend.id).toBe("grok")
+        expect(yield* active.getBackendStatus(AGENT_BACKEND_IDS.grok)).not.toBe(
+          null,
+        )
 
-        // Proxy AgentBackend uses the new adapter after activate.
-        const inspected = yield* agent.inspect({ cwd: "/tmp" })
-        expect(inspected.backend.id).toBe("grok")
+        // Same-backend activate skips re-inspect and leaves entry Ready.
+        const again = yield* active.activate(AGENT_BACKEND_IDS.grok, {
+          cwd: "/tmp",
+        })
+        expect(again.kind).toBe("ready")
+        expect(again.models[0]?.id).toBe("grok/model-a")
+
+        yield* active.drop(AGENT_BACKEND_IDS.grok)
+        expect(yield* active.getBackendStatus(AGENT_BACKEND_IDS.grok)).toBe(
+          null,
+        )
+        expect((yield* active.listStatuses).map((s) => s.backend.id)).toEqual([
+          "opencode",
+        ])
+
+        // setSelectedOrInUse drops backends outside the set and activates missing.
+        yield* active.setSelectedOrInUse([AGENT_BACKEND_IDS.grok], {
+          cwd: "/tmp",
+        })
+        const afterSync = yield* active.listStatuses
+        expect(afterSync.map((s) => s.backend.id)).toEqual(["grok"])
+        expect(afterSync[0]?.kind).toBe("ready")
+      }).pipe(Effect.provide(layer)),
+    )
+  })
+
+  it("marks per-backend Unavailable and rechecks one id", async () => {
+    const layer = ActiveAgentBackendLive({
+      initialBackendIds: [AGENT_BACKEND_IDS.opencode, AGENT_BACKEND_IDS.grok],
+      resolveRuntime: makeResolve({
+        failInspectFor: new Set([AGENT_BACKEND_IDS.grok]),
+      }),
+    })
+
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        const active = yield* ActiveAgentBackend
+        const openStatus = yield* active.recheck(AGENT_BACKEND_IDS.opencode, {
+          cwd: "/tmp",
+        })
+        expect(openStatus.kind).toBe("ready")
+
+        const grokStatus = yield* active.recheck(AGENT_BACKEND_IDS.grok, {
+          cwd: "/tmp",
+        })
+        expect(grokStatus.kind).toBe("unavailable")
+        expect(grokStatus.reason).toContain("grok binary missing")
+        expect(grokStatus.models).toEqual([])
+
+        // OpenCode stays Ready while Grok is Unavailable.
+        const openAfter = yield* active.getBackendStatus(
+          AGENT_BACKEND_IDS.opencode,
+        )
+        expect(openAfter?.kind).toBe("ready")
+
+        yield* active.requireAgentTurnsAllowed(AGENT_BACKEND_IDS.opencode)
+        const blocked = yield* Effect.result(
+          active.requireAgentTurnsAllowed(AGENT_BACKEND_IDS.grok),
+        )
+        expect(blocked._tag).toBe("Failure")
+      }).pipe(Effect.provide(layer)),
+    )
+  })
+
+  it("dispatches start/continue/telemetry by backend id", async () => {
+    const layer = ActiveAgentBackendLive({
+      initialBackendIds: [AGENT_BACKEND_IDS.opencode, AGENT_BACKEND_IDS.grok],
+      resolveRuntime: makeResolve({}),
+    })
+
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        const active = yield* ActiveAgentBackend
+        yield* active.recheck(AGENT_BACKEND_IDS.opencode, { cwd: "/tmp" })
+        yield* active.recheck(AGENT_BACKEND_IDS.grok, { cwd: "/tmp" })
+
+        const openStart = yield* active.startTurn(AGENT_BACKEND_IDS.opencode, {
+          prompt: "hi",
+          cwd: "/tmp",
+          model: "opencode/model-a",
+          thinkingLevel: null,
+        })
+        expect(openStart.sessionId).toBe("opencode-start")
+
+        const grokContinue = yield* active.continueTurn(
+          AGENT_BACKEND_IDS.grok,
+          {
+            sessionId: "ses_g",
+            prompt: "more",
+            cwd: "/tmp",
+            model: "grok/model-a",
+            thinkingLevel: null,
+          },
+        )
+        expect(grokContinue.sessionId).toBe("grok-continue")
+
+        const openTelemetry = yield* active.getSessionTelemetry({
+          backendId: AGENT_BACKEND_IDS.opencode,
+          sessionId: "ses_o",
+        })
+        expect(openTelemetry.backend.id).toBe("opencode")
+        expect(openTelemetry.availability).toBe("available")
+        expect(openTelemetry.model?.providerId).toBe("opencode")
+
+        // Grok Build does not support SessionTelemetry; dispatch still scopes
+        // the response to the requested backend id.
+        const grokTelemetry = yield* active.getSessionTelemetry({
+          backendId: AGENT_BACKEND_IDS.grok,
+          sessionId: "ses_g",
+        })
+        expect(grokTelemetry.backend.id).toBe("grok")
+        expect(grokTelemetry.availability).toBe("unsupported")
+      }).pipe(Effect.provide(layer)),
+    )
+  })
+
+  it("preview does not flip the Active set", async () => {
+    const layer = ActiveAgentBackendLive({
+      selectedBackendId: AGENT_BACKEND_IDS.opencode,
+      resolveRuntime: makeResolve({
+        modelsByBackend: {
+          opencode: [{ id: "opencode/live", thinkingLevels: [] }],
+          grok: [{ id: "grok/preview", thinkingLevels: ["high"] }],
+        },
+      }),
+    })
+
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        const active = yield* ActiveAgentBackend
+        yield* active.recheck(AGENT_BACKEND_IDS.opencode, { cwd: "/tmp" })
+        const preview = yield* active.preview(AGENT_BACKEND_IDS.grok, {
+          cwd: "/tmp",
+        })
+        expect(preview.kind).toBe("ready")
+        expect(preview.backend.id).toBe("grok")
+        expect(preview.models[0]?.id).toBe("grok/preview")
+
+        expect(yield* active.getBackendStatus(AGENT_BACKEND_IDS.grok)).toBe(
+          null,
+        )
+        const statuses = yield* active.listStatuses
+        expect(statuses.map((s) => s.backend.id)).toEqual(["opencode"])
+        expect(statuses[0]?.models[0]?.id).toBe("opencode/live")
       }).pipe(Effect.provide(layer)),
     )
   })
@@ -106,49 +286,23 @@ describe("ActiveAgentBackend hot-activate", () => {
     await Effect.runPromise(
       Effect.gen(function* () {
         const active = yield* ActiveAgentBackend
-        yield* active.recheck({ cwd: "/tmp" })
+        yield* active.recheck(AGENT_BACKEND_IDS.opencode, { cwd: "/tmp" })
         const status = yield* active.activate(AGENT_BACKEND_IDS.grok, {
           cwd: "/tmp",
         })
         expect(status.kind).toBe("unavailable")
-        expect(status.activeBackend.id).toBe("grok")
-        expect(status.selectedBackend.id).toBe("grok")
+        expect(status.backend.id).toBe("grok")
         expect(status.reason).toContain("grok binary missing")
         expect(status.models).toEqual([])
+
+        // Original backend remains Active and Ready.
+        const open = yield* active.getBackendStatus(AGENT_BACKEND_IDS.opencode)
+        expect(open?.kind).toBe("ready")
       }).pipe(Effect.provide(layer)),
     )
   })
 
-  it("previews another backend without changing Active", async () => {
-    const layer = ActiveAgentBackendLive({
-      selectedBackendId: AGENT_BACKEND_IDS.opencode,
-      resolveRuntime: makeResolve({
-        modelsByBackend: {
-          opencode: [{ id: "opencode/live", thinkingLevels: [] }],
-          grok: [{ id: "grok/preview", thinkingLevels: ["high"] }],
-        },
-      }),
-    })
-
-    await Effect.runPromise(
-      Effect.gen(function* () {
-        const active = yield* ActiveAgentBackend
-        yield* active.recheck({ cwd: "/tmp" })
-        const preview = yield* active.preview(AGENT_BACKEND_IDS.grok, {
-          cwd: "/tmp",
-        })
-        expect(preview.kind).toBe("ready")
-        expect(preview.backend.id).toBe("grok")
-        expect(preview.models[0]?.id).toBe("grok/preview")
-
-        const status = yield* active.getStatus
-        expect(status.activeBackend.id).toBe("opencode")
-        expect(status.models[0]?.id).toBe("opencode/live")
-      }).pipe(Effect.provide(layer)),
-    )
-  })
-
-  it("discards recheck results after Active is swapped mid-inspect", async () => {
+  it("discards recheck results after the backend is dropped mid-inspect", async () => {
     let releaseInspect: (() => void) | undefined
     const inspectGate = new Promise<void>((resolve) => {
       releaseInspect = resolve
@@ -194,21 +348,23 @@ describe("ActiveAgentBackend hot-activate", () => {
       Effect.gen(function* () {
         const active = yield* ActiveAgentBackend
         const recheckFiber = yield* Effect.forkChild(
-          active.recheck({ cwd: "/tmp" }),
+          active.recheck(AGENT_BACKEND_IDS.opencode, { cwd: "/tmp" }),
         )
         // Let recheck capture OpenCode adapter and block in inspect.
         yield* Effect.yieldNow
-        yield* active.activate(AGENT_BACKEND_IDS.grok, { cwd: "/tmp" })
+        yield* active.setSelectedOrInUse([AGENT_BACKEND_IDS.grok], {
+          cwd: "/tmp",
+        })
         releaseInspect?.()
         yield* Fiber.join(recheckFiber)
-        const status = yield* active.getStatus
-        expect(status.activeBackend.id).toBe("grok")
-        expect(status.models[0]?.id).toBe("grok/model-a")
+        const statuses = yield* active.listStatuses
+        expect(statuses.map((s) => s.backend.id)).toEqual(["grok"])
+        expect(statuses[0]?.models[0]?.id).toBe("grok/model-a")
       }).pipe(Effect.provide(layer)),
     )
   })
 
-  it("preview failure keeps Active unchanged", async () => {
+  it("preview failure keeps Active set unchanged", async () => {
     const layer = ActiveAgentBackendLive({
       selectedBackendId: AGENT_BACKEND_IDS.opencode,
       resolveRuntime: makeResolve({
@@ -219,13 +375,16 @@ describe("ActiveAgentBackend hot-activate", () => {
     await Effect.runPromise(
       Effect.gen(function* () {
         const active = yield* ActiveAgentBackend
-        yield* active.recheck({ cwd: "/tmp" })
+        yield* active.recheck(AGENT_BACKEND_IDS.opencode, { cwd: "/tmp" })
         const preview = yield* active.preview(AGENT_BACKEND_IDS.grok, {
           cwd: "/tmp",
         })
         expect(preview.kind).toBe("unavailable")
         expect(preview.reason).toContain("grok binary missing")
 
+        expect(yield* active.getBackendStatus(AGENT_BACKEND_IDS.grok)).toBe(
+          null,
+        )
         const status = yield* active.getStatus
         expect(status.kind).toBe("ready")
         expect(status.activeBackend.id).toBe("opencode")
@@ -233,7 +392,7 @@ describe("ActiveAgentBackend hot-activate", () => {
     )
   })
 
-  it("does not export restart_required status kinds", async () => {
+  it("process-wide AgentBackend proxy follows activate", async () => {
     const layer = ActiveAgentBackendLive({
       selectedBackendId: AGENT_BACKEND_IDS.opencode,
       resolveRuntime: makeResolve({}),
@@ -242,14 +401,79 @@ describe("ActiveAgentBackend hot-activate", () => {
     await Effect.runPromise(
       Effect.gen(function* () {
         const active = yield* ActiveAgentBackend
-        const status = yield* active.getStatus
-        expect(status.kind === "ready" || status.kind === "unavailable").toBe(
-          true,
+        const agent = yield* AgentBackend
+        yield* active.recheck(AGENT_BACKEND_IDS.opencode, { cwd: "/tmp" })
+        let inspected = yield* agent.inspect({ cwd: "/tmp" })
+        expect(inspected.backend.id).toBe("opencode")
+        expect((yield* active.getActiveRegistration).descriptor.id).toBe(
+          "opencode",
         )
-        // SessionTelemetryProvider is provided from the same layer.
+
+        // activate moves the transitional process-wide proxy (until #466).
+        yield* active.activate(AGENT_BACKEND_IDS.grok, { cwd: "/tmp" })
+        inspected = yield* agent.inspect({ cwd: "/tmp" })
+        expect(inspected.backend.id).toBe("grok")
+        expect((yield* active.getActiveRegistration).descriptor.id).toBe("grok")
+
+        const turn = yield* agent.startTurn({
+          prompt: "hi",
+          cwd: "/tmp",
+          model: "grok/model-a",
+          thinkingLevel: null,
+        })
+        expect(turn.sessionId).toBe("grok-start")
+
+        // Both backends remain Active; only the proxy target moved.
+        const ids = (yield* active.listStatuses).map((s) => s.backend.id).sort()
+        expect(ids).toEqual(["grok", "opencode"])
+
         const telemetry = yield* SessionTelemetryProvider
         const session = yield* telemetry.getSession("ses_x")
-        expect(session.availability).toBe("unsupported")
+        expect(session.backend.id).toBe("grok")
+      }).pipe(Effect.provide(layer)),
+    )
+  })
+
+  it("recheck does not expand the Active set for missing backends", async () => {
+    const layer = ActiveAgentBackendLive({
+      selectedBackendId: AGENT_BACKEND_IDS.opencode,
+      resolveRuntime: makeResolve({}),
+    })
+
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        const active = yield* ActiveAgentBackend
+        yield* active.recheck(AGENT_BACKEND_IDS.opencode, { cwd: "/tmp" })
+        const missing = yield* active.recheck(AGENT_BACKEND_IDS.grok, {
+          cwd: "/tmp",
+        })
+        expect(missing.kind).toBe("unavailable")
+        expect(missing.reason).toContain("not Active")
+        expect(yield* active.getBackendStatus(AGENT_BACKEND_IDS.grok)).toBe(
+          null,
+        )
+        expect((yield* active.listStatuses).map((s) => s.backend.id)).toEqual([
+          "opencode",
+        ])
+      }).pipe(Effect.provide(layer)),
+    )
+  })
+
+  it("getRegistration prefers the Active entry when present", async () => {
+    const layer = ActiveAgentBackendLive({
+      selectedBackendId: AGENT_BACKEND_IDS.opencode,
+      resolveRuntime: makeResolve({}),
+    })
+
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        const active = yield* ActiveAgentBackend
+        yield* active.recheck(AGENT_BACKEND_IDS.opencode, { cwd: "/tmp" })
+        const reg = yield* active.getRegistration(AGENT_BACKEND_IDS.opencode)
+        expect(reg.descriptor.id).toBe("opencode")
+        // Unknown / non-active still falls back to built-in table.
+        const builtIn = yield* active.getRegistration(AGENT_BACKEND_IDS.grok)
+        expect(builtIn.descriptor.id).toBe("grok")
       }).pipe(Effect.provide(layer)),
     )
   })

--- a/packages/graphql-api/src/lib/graphql-api.ts
+++ b/packages/graphql-api/src/lib/graphql-api.ts
@@ -3,12 +3,14 @@ import { GraphQLError } from "graphql"
 import { createSchema, createYoga } from "graphql-yoga"
 import {
   ActiveAgentBackend,
+  type AgentBackendId,
   type AgentBackendStatus,
   type SessionTelemetry,
   type SessionTelemetryAvailability,
   getBuiltInAgentBackend,
   isSelectableAgentBackendId,
   listBuiltInAgentBackends,
+  toAgentBackendStatus,
 } from "@ready-for-agent/agent-backend"
 import { DbService, RepositoryNotFoundError } from "@ready-for-agent/db-service"
 import { typeDefs } from "@ready-for-agent/graphql-schema"
@@ -262,8 +264,18 @@ export const createGraphqlApi = (
 
   const listModels = Effect.fn("graphql-api.models")(function* () {
     const active = yield* ActiveAgentBackend
-    const status = yield* active.getStatus
-    return status.models
+    const db = yield* DbService
+    const config = yield* db.getConfig
+    if (isSelectableAgentBackendId(config.selectedAgentBackend)) {
+      const status = yield* active.getBackendStatus(
+        config.selectedAgentBackend as AgentBackendId,
+      )
+      if (status !== null) {
+        return status.models
+      }
+    }
+    // Fall back to proxy status when default is not yet Active.
+    return (yield* active.getStatus).models
   })
 
   const yoga = createYoga({
@@ -324,6 +336,18 @@ export const createGraphqlApi = (
             runGraphql(
               Effect.gen(function* () {
                 const active = yield* ActiveAgentBackend
+                const db = yield* DbService
+                const config = yield* db.getConfig
+                if (isSelectableAgentBackendId(config.selectedAgentBackend)) {
+                  const runtime = yield* active.getBackendStatus(
+                    config.selectedAgentBackend as AgentBackendId,
+                  )
+                  if (runtime !== null) {
+                    return toGraphqlAgentBackendStatus(
+                      toAgentBackendStatus(runtime),
+                    )
+                  }
+                }
                 return toGraphqlAgentBackendStatus(yield* active.getStatus)
               }).pipe(Effect.withSpan("graphql-api.agentBackendStatus")),
             ),
@@ -573,11 +597,20 @@ export const createGraphqlApi = (
                     ) {
                       return next
                     }
-                    const status = yield* active.getStatus
-                    // Only hot-activate when Active differs from committed Config.
-                    // Same-backend Saves skip full inspect (Recheck remains explicit).
-                    if (status.activeBackend.id !== next.selectedAgentBackend) {
-                      yield* active.activate(next.selectedAgentBackend, {
+                    const backendId =
+                      next.selectedAgentBackend as AgentBackendId
+                    const status = yield* active.getBackendStatus(backendId)
+                    // Process-wide proxy tracks Config selected backend until
+                    // #466 routes turns by captured Work Item backend. Multi
+                    // Active means the selected id may already be Active while
+                    // the proxy still points at a prior selection (A→B→A).
+                    // activate skips re-inspect when already Active.
+                    const proxyStatus = yield* active.getStatus
+                    if (
+                      status === null ||
+                      proxyStatus.activeBackend.id !== backendId
+                    ) {
+                      yield* active.activate(backendId, {
                         cwd: agentBackendCwd,
                         timeout: "30 seconds",
                       })
@@ -603,10 +636,22 @@ export const createGraphqlApi = (
             runGraphql(
               Effect.gen(function* () {
                 const active = yield* ActiveAgentBackend
-                const status = yield* active.recheck({
-                  cwd: agentBackendCwd,
-                  timeout: "30 seconds",
-                })
+                const db = yield* DbService
+                const config = yield* db.getConfig
+                const backendId = isSelectableAgentBackendId(
+                  config.selectedAgentBackend,
+                )
+                  ? (config.selectedAgentBackend as AgentBackendId)
+                  : undefined
+                const status =
+                  backendId === undefined
+                    ? yield* active.getStatus
+                    : toAgentBackendStatus(
+                        yield* active.recheck(backendId, {
+                          cwd: agentBackendCwd,
+                          timeout: "30 seconds",
+                        }),
+                      )
                 return toGraphqlAgentBackendStatus(status)
               }).pipe(Effect.withSpan("graphql-api.recheckAgentBackend")),
             ),

--- a/packages/graphql-api/test/graphql-api.test.ts
+++ b/packages/graphql-api/test/graphql-api.test.ts
@@ -2,9 +2,12 @@ import { Duration, Effect, Layer, ManagedRuntime, Stream } from "effect"
 import {
   ActiveAgentBackend,
   type ActiveAgentBackendShape,
+  type AgentBackendId,
+  type AgentBackendRuntimeStatus,
   type AgentBackendStatus,
   type SessionTelemetry,
   missingSessionTelemetry,
+  toAgentBackendStatus,
 } from "@ready-for-agent/agent-backend"
 import { DbService, type DbServiceShape } from "@ready-for-agent/db-service"
 import {
@@ -63,15 +66,22 @@ const defaultModels = [
   },
 ] as const
 
-const readyStatus = (
-  models: AgentBackendStatus["models"] = defaultModels,
-): AgentBackendStatus => ({
-  selectedBackend: { id: "opencode", label: "OpenCode" },
-  activeBackend: { id: "opencode", label: "OpenCode" },
+const readyRuntimeStatus = (
+  models: AgentBackendRuntimeStatus["models"] = defaultModels,
+  backendId: AgentBackendId = "opencode",
+): AgentBackendRuntimeStatus => ({
+  backend: {
+    id: backendId,
+    label: backendId === "opencode" ? "OpenCode" : backendId,
+  },
   kind: "ready",
   reason: null,
   models,
 })
+
+const readyStatus = (
+  models: AgentBackendStatus["models"] = defaultModels,
+): AgentBackendStatus => toAgentBackendStatus(readyRuntimeStatus(models))
 
 const issue = {
   id: "issue-test",
@@ -220,11 +230,19 @@ const makeRuntime = (
     admitWaitingWorkItems: Effect.succeed(0),
     ...lifecycleOverrides,
   }
+  const readyRuntime = readyRuntimeStatus()
   const activeBackend: ActiveAgentBackendShape = {
+    listStatuses: Effect.succeed([readyRuntime]),
+    getBackendStatus: (backendId) =>
+      Effect.succeed(
+        backendId === readyRuntime.backend.id ? readyRuntime : null,
+      ),
     getStatus: Effect.succeed(readyStatus()),
-    recheck: () => Effect.succeed(readyStatus()),
-    requireAgentTurnsAllowed: Effect.void,
-    activate: () => Effect.succeed(readyStatus()),
+    setSelectedOrInUse: () => Effect.succeed([readyRuntime]),
+    recheck: () => Effect.succeed(readyRuntime),
+    requireAgentTurnsAllowed: () => Effect.void,
+    activate: () => Effect.succeed(readyRuntime),
+    drop: () => Effect.void,
     preview: () =>
       Effect.succeed({
         backend: { id: "opencode", label: "OpenCode" },
@@ -233,6 +251,14 @@ const makeRuntime = (
         models: readyStatus().models,
       }),
     withConfigCoordination: (effect) => effect,
+    getRegistration: () =>
+      Effect.succeed({
+        descriptor: { id: "opencode", label: "OpenCode" },
+        capabilities: [
+          { _tag: "SessionTelemetry", supported: true },
+          { _tag: "KeymaxxerMcp", supported: true },
+        ],
+      }),
     getActiveRegistration: Effect.succeed({
       descriptor: { id: "opencode", label: "OpenCode" },
       capabilities: [
@@ -240,6 +266,9 @@ const makeRuntime = (
         { _tag: "KeymaxxerMcp", supported: true },
       ],
     }),
+    startTurn: () => Effect.die("unused"),
+    continueTurn: () => Effect.die("unused"),
+    inspectBackend: () => Effect.die("unused"),
     getSessionTelemetry: (input) =>
       Effect.succeed(
         missingSessionTelemetry(input.sessionId ?? "", {
@@ -935,24 +964,33 @@ describe("GraphQL API", () => {
     })
   })
 
-  test("updateConfig activates only when Active differs from committed backend", async () => {
+  test("updateConfig activates when selected differs from proxy or is not Active", async () => {
     const activated: string[] = []
+    let proxyBackendId: AgentBackendId = "opencode"
+    const activeIds = new Set<AgentBackendId>(["opencode"])
+
     const activateRuntime = makeRuntime(
       {},
       {},
       {},
       {},
       {
-        getStatus: Effect.succeed(readyStatus()),
+        getBackendStatus: (backendId) =>
+          Effect.succeed(
+            activeIds.has(backendId)
+              ? readyRuntimeStatus(defaultModels, backendId)
+              : null,
+          ),
+        getStatus: Effect.sync(() =>
+          toAgentBackendStatus(
+            readyRuntimeStatus(defaultModels, proxyBackendId),
+          ),
+        ),
         activate: (backendId) => {
           activated.push(backendId)
-          return Effect.succeed({
-            selectedBackend: { id: backendId, label: backendId },
-            activeBackend: { id: backendId, label: backendId },
-            kind: "ready",
-            reason: null,
-            models: defaultModels,
-          })
+          activeIds.add(backendId)
+          proxyBackendId = backendId
+          return Effect.succeed(readyRuntimeStatus(defaultModels, backendId))
         },
       },
     )
@@ -980,7 +1018,32 @@ describe("GraphQL API", () => {
     })
     expect(activated).toEqual(["grok"])
 
-    // Same-backend save skips activate (no full inspect on every Save).
+    // Switch back to still-Active prior backend must activate to move proxy.
+    activated.length = 0
+    const switchBack = await createGraphqlApi(activateRuntime).fetch(
+      graphqlRequest({
+        query: `mutation UpdateConfig($input: UpdateConfigInput!) {
+          updateConfig(input: $input) { selectedAgentBackend }
+        }`,
+        variables: {
+          input: {
+            selectedAgentBackend: "opencode",
+            defaultModel: "anthropic/claude-sonnet-4-5",
+            defaultThinkingLevel: null,
+            reviewModel: null,
+            reviewThinkingLevel: null,
+            maxConcurrentAgentTurns: 2,
+            maxConcurrentWorkItems: 5,
+          },
+        },
+      }),
+    )
+    expect(await switchBack.json()).toEqual({
+      data: { updateConfig: { selectedAgentBackend: "opencode" } },
+    })
+    expect(activated).toEqual(["opencode"])
+
+    // Same-backend save with proxy already correct skips activate.
     activated.length = 0
     const sameBackend = await createGraphqlApi(activateRuntime).fetch(
       graphqlRequest({
@@ -1119,10 +1182,11 @@ describe("GraphQL API", () => {
       {},
       {},
       {
-        getStatus: Effect.sync(() => {
-          statusCount += 1
-          return readyStatus()
-        }),
+        getBackendStatus: () =>
+          Effect.sync(() => {
+            statusCount += 1
+            return readyRuntimeStatus()
+          }),
       },
     )
 

--- a/packages/work-item-lifecycle/src/lib/active-agent-backend-test.ts
+++ b/packages/work-item-lifecycle/src/lib/active-agent-backend-test.ts
@@ -3,10 +3,13 @@ import {
   AGENT_BACKEND_IDS,
   ActiveAgentBackend,
   type AgentBackendBlockedError,
+  type AgentBackendId,
   type AgentBackendRegistration,
+  type AgentBackendRuntimeStatus,
   type AgentBackendStatus,
   type SessionTelemetry,
   getBuiltInAgentBackend,
+  toAgentBackendStatus,
   unsupportedSessionTelemetry,
 } from "@ready-for-agent/agent-backend"
 
@@ -16,16 +19,23 @@ if (opencodeRegistration === undefined) {
 }
 const opencode = opencodeRegistration
 
+const runtimeStatus = (
+  registration: AgentBackendRegistration,
+  models: AgentBackendRuntimeStatus["models"] = [],
+  kind: AgentBackendRuntimeStatus["kind"] = "ready",
+  reason: string | null = null,
+): AgentBackendRuntimeStatus => ({
+  backend: registration.descriptor,
+  kind,
+  reason: kind === "unavailable" ? (reason ?? "unavailable") : null,
+  models: kind === "unavailable" ? [] : models,
+})
+
 const readyStatus = (
   registration: AgentBackendRegistration,
   models: AgentBackendStatus["models"] = [],
-): AgentBackendStatus => ({
-  selectedBackend: registration.descriptor,
-  activeBackend: registration.descriptor,
-  kind: "ready",
-  reason: null,
-  models,
-})
+): AgentBackendStatus =>
+  toAgentBackendStatus(runtimeStatus(registration, models))
 
 /**
  * Always-ready Active Agent Backend for unit tests that do not exercise
@@ -42,15 +52,23 @@ export const stubActiveAgentBackendLayer = (
   }> = {},
 ): Layer.Layer<ActiveAgentBackend> => {
   const registration = overrides.registration ?? opencode
+  const ready = runtimeStatus(registration)
+  const legacyStatus =
+    overrides.getStatus ?? Effect.succeed(readyStatus(registration))
+  const requireAllowed = overrides.requireAgentTurnsAllowed ?? Effect.void
+
   return Layer.succeed(
     ActiveAgentBackend,
     ActiveAgentBackend.of({
-      getStatus:
-        overrides.getStatus ?? Effect.succeed(readyStatus(registration)),
-      recheck: () => Effect.succeed(readyStatus(registration)),
-      requireAgentTurnsAllowed:
-        overrides.requireAgentTurnsAllowed ?? Effect.void,
-      activate: () => Effect.succeed(readyStatus(registration)),
+      listStatuses: Effect.succeed([ready]),
+      getBackendStatus: (backendId: AgentBackendId) =>
+        Effect.succeed(backendId === registration.descriptor.id ? ready : null),
+      getStatus: legacyStatus,
+      setSelectedOrInUse: () => Effect.succeed([ready]),
+      activate: () => Effect.succeed(ready),
+      drop: () => Effect.void,
+      recheck: () => Effect.succeed(ready),
+      requireAgentTurnsAllowed: (_backendId) => requireAllowed,
       preview: () =>
         Effect.succeed({
           backend: registration.descriptor,
@@ -59,7 +77,13 @@ export const stubActiveAgentBackendLayer = (
           models: [],
         }),
       withConfigCoordination: (effect) => effect,
+      getRegistration: () => Effect.succeed(registration),
       getActiveRegistration: Effect.succeed(registration),
+      startTurn: () => Effect.die("stub ActiveAgentBackend.startTurn unused"),
+      continueTurn: () =>
+        Effect.die("stub ActiveAgentBackend.continueTurn unused"),
+      inspectBackend: () =>
+        Effect.die("stub ActiveAgentBackend.inspectBackend unused"),
       getSessionTelemetry: (input) =>
         Effect.succeed(
           unsupportedSessionTelemetry(

--- a/packages/work-item-lifecycle/src/lib/work-item-lifecycle.ts
+++ b/packages/work-item-lifecycle/src/lib/work-item-lifecycle.ts
@@ -16,6 +16,7 @@ import { SqlClient } from "effect/unstable/sql"
 import type { SqlError } from "effect/unstable/sql/SqlError"
 import {
   ActiveAgentBackend,
+  type AgentBackendId,
   isAgentDependentLifecycleStep,
 } from "@ready-for-agent/agent-backend"
 import {
@@ -2581,10 +2582,15 @@ export const makeWorkItemLifecycleLive = (
               yield* notifyWorkItemsChanged(workItem.repository_id)
 
               if (isAgentDependentLifecycleStep(stepRun.step)) {
-                const readiness = yield* activeAgentBackend.getStatus
-                if (readiness.kind === "unavailable") {
+                const readiness = yield* activeAgentBackend.getBackendStatus(
+                  workItem.agent_backend as AgentBackendId,
+                )
+                if (readiness === null || readiness.kind === "unavailable") {
                   const reasonMessage =
-                    readiness.reason ?? "Agent Backend is unavailable"
+                    readiness?.reason ??
+                    (readiness === null
+                      ? "Agent Backend is not Active"
+                      : "Agent Backend is unavailable")
                   const failed = yield* completeFailedStep({
                     stepRun: afterStart,
                     workItem,
@@ -3976,20 +3982,28 @@ export const makeWorkItemLifecycleLive = (
           // runs inside the same section so it matches the backend that is stamped.
           const createdId = yield* activeAgentBackend.withConfigCoordination(
             Effect.gen(function* () {
-              yield* activeAgentBackend.requireAgentTurnsAllowed.pipe(
-                Effect.mapError(
-                  (error) =>
-                    new AgentBackendUnavailableError({
-                      message: error.message,
-                      reason: error.reason,
-                    }),
-                ),
-              )
+              // Capture harness default until lifecycle resolves effective
+              // backend (override ?? default) in #466.
+              const harnessConfig = yield* db.getConfig
+              const captureBackendId = harnessConfig.selectedAgentBackend
+              yield* activeAgentBackend
+                .requireAgentTurnsAllowed(captureBackendId as AgentBackendId)
+                .pipe(
+                  Effect.mapError(
+                    (error) =>
+                      new AgentBackendUnavailableError({
+                        message: error.message,
+                        reason: error.reason,
+                      }),
+                  ),
+                )
               // Models are not stored on the Work Item; resolve against the
               // Active backend / prefs after coordination has locked the switch.
               yield* resolveModelsForRepository(repositoryId)
               const activeRegistration =
-                yield* activeAgentBackend.getActiveRegistration
+                yield* activeAgentBackend.getRegistration(
+                  captureBackendId as AgentBackendId,
+                )
               const agentBackendId = activeRegistration.descriptor.id
               const workItemId = makeWorkItemId()
               const now = yield* Clock.currentTimeMillis

--- a/packages/work-item-lifecycle/test/agent-backend-readiness.spec.ts
+++ b/packages/work-item-lifecycle/test/agent-backend-readiness.spec.ts
@@ -1,8 +1,10 @@
 import { Effect, Layer } from "effect"
 import {
   ActiveAgentBackend,
+  type AgentBackendRuntimeStatus,
   type AgentBackendStatus,
   AgentBackendUnavailableError,
+  toAgentBackendStatus,
 } from "@ready-for-agent/agent-backend"
 import { DatabaseTest } from "@ready-for-agent/db/test"
 import { DbService, DbServiceLive } from "@ready-for-agent/db-service"
@@ -50,13 +52,15 @@ const successfulSteps: LifecycleStepsShape = {
   removeWorktree: () => Effect.void,
 }
 
-const statusUnavailable = (): AgentBackendStatus => ({
-  selectedBackend: { id: "opencode", label: "OpenCode" },
-  activeBackend: { id: "opencode", label: "OpenCode" },
+const runtimeUnavailable = (): AgentBackendRuntimeStatus => ({
+  backend: { id: "opencode", label: "OpenCode" },
   kind: "unavailable",
   reason: "opencode binary not found",
   models: [],
 })
+
+const statusUnavailable = (): AgentBackendStatus =>
+  toAgentBackendStatus(runtimeUnavailable())
 
 describe("Agent Backend readiness gates", () => {
   it("rejects Implement Now while unavailable", async () => {
@@ -125,10 +129,14 @@ describe("Agent Backend readiness gates", () => {
         Layer.succeed(
           ActiveAgentBackend,
           ActiveAgentBackend.of({
+            listStatuses: Effect.succeed([runtimeUnavailable()]),
+            getBackendStatus: () => Effect.succeed(runtimeUnavailable()),
             getStatus: Effect.succeed(statusUnavailable()),
-            recheck: () => Effect.succeed(statusUnavailable()),
-            requireAgentTurnsAllowed: Effect.void,
-            activate: () => Effect.succeed(statusUnavailable()),
+            setSelectedOrInUse: () => Effect.succeed([runtimeUnavailable()]),
+            recheck: () => Effect.succeed(runtimeUnavailable()),
+            requireAgentTurnsAllowed: () => Effect.void,
+            activate: () => Effect.succeed(runtimeUnavailable()),
+            drop: () => Effect.void,
             preview: () =>
               Effect.succeed({
                 backend: { id: "opencode", label: "OpenCode" },
@@ -137,6 +145,14 @@ describe("Agent Backend readiness gates", () => {
                 models: [],
               }),
             withConfigCoordination: (effect) => effect,
+            getRegistration: () =>
+              Effect.succeed({
+                descriptor: { id: "opencode", label: "OpenCode" },
+                capabilities: [
+                  { _tag: "SessionTelemetry", supported: true },
+                  { _tag: "KeymaxxerMcp", supported: true },
+                ],
+              }),
             getActiveRegistration: Effect.succeed({
               descriptor: { id: "opencode", label: "OpenCode" },
               capabilities: [
@@ -144,6 +160,9 @@ describe("Agent Backend readiness gates", () => {
                 { _tag: "KeymaxxerMcp", supported: true },
               ],
             }),
+            startTurn: () => Effect.die("unused"),
+            continueTurn: () => Effect.die("unused"),
+            inspectBackend: () => Effect.die("unused"),
             getSessionTelemetry: () => Effect.die("unused"),
           }),
         ),


### PR DESCRIPTION
## Summary

- Replace the singular Active Agent Backend runtime with a multi-backend registry: concurrent Active entries, `activate` / `drop` / `setSelectedOrInUse`, per-id recheck and status, and turn/telemetry dispatch by backend id.
- Keep Preview catalog-only; process-wide `AgentBackend` proxy follows activate (transitional until lifecycle routes by captured id).
- GraphQL Config save retargets the proxy when the selected backend is not Active or differs from the current proxy (covers A→B→A).
- Wire harness startup recheck across Active backends and lifecycle readiness/create gates for the new APIs.

Closes #465

## Test plan

- [x] `bunx nx test agent-backend`
- [x] `bunx nx test graphql-api`
- [x] `bunx nx test work-item-lifecycle`
- [x] Pre-commit affected lint/typecheck/test