### PR TITLE
feat(work-item-lifecycle): capture effective Agent Backend and route turns

### DIFF
--- a/packages/work-item-lifecycle/src/lib/active-agent-backend-test.ts
+++ b/packages/work-item-lifecycle/src/lib/active-agent-backend-test.ts
@@ -7,8 +7,12 @@ import {
   type AgentBackendRegistration,
   type AgentBackendRuntimeStatus,
   type AgentBackendStatus,
+  type AgentTurnResult,
+  type ContinueTurnInput,
   type SessionTelemetry,
+  type StartTurnInput,
   getBuiltInAgentBackend,
+  isSelectableAgentBackendId,
   toAgentBackendStatus,
   unsupportedSessionTelemetry,
 } from "@ready-for-agent/agent-backend"
@@ -44,51 +48,108 @@ const readyStatus = (
 export const stubActiveAgentBackendLayer = (
   overrides: Partial<{
     readonly registration: AgentBackendRegistration
+    /** Additional Active registrations (for multi-backend routing tests). */
+    readonly registrations: ReadonlyArray<AgentBackendRegistration>
     readonly getStatus: Effect.Effect<AgentBackendStatus>
     readonly requireAgentTurnsAllowed: Effect.Effect<
       void,
       AgentBackendBlockedError
     >
+    /**
+     * Per-backend require override. When set, consulted before the singular
+     * {@link requireAgentTurnsAllowed} Effect.
+     */
+    readonly requireAgentTurnsAllowedFor: (
+      backendId: AgentBackendId,
+    ) => Effect.Effect<void, AgentBackendBlockedError>
+    readonly startTurn: (
+      backendId: AgentBackendId,
+      input: StartTurnInput,
+    ) => Effect.Effect<AgentTurnResult, never>
+    readonly continueTurn: (
+      backendId: AgentBackendId,
+      input: ContinueTurnInput,
+    ) => Effect.Effect<AgentTurnResult, never>
   }> = {},
 ): Layer.Layer<ActiveAgentBackend> => {
   const registration = overrides.registration ?? opencode
-  const ready = runtimeStatus(registration)
+  const allRegistrations = [
+    registration,
+    ...(overrides.registrations ?? []).filter(
+      (entry) => entry.descriptor.id !== registration.descriptor.id,
+    ),
+  ]
+  const byId = new Map<AgentBackendId, AgentBackendRegistration>(
+    allRegistrations.map((entry) => [entry.descriptor.id, entry] as const),
+  )
+  const readyFor = (entry: AgentBackendRegistration) => runtimeStatus(entry)
+  const allReady = allRegistrations.map(readyFor)
   const legacyStatus =
     overrides.getStatus ?? Effect.succeed(readyStatus(registration))
   const requireAllowed = overrides.requireAgentTurnsAllowed ?? Effect.void
+  const requireFor =
+    overrides.requireAgentTurnsAllowedFor ??
+    ((_backendId: AgentBackendId) => requireAllowed)
+  const registrationFor = (backendId: string): AgentBackendRegistration => {
+    const entry = byId.get(backendId as AgentBackendId)
+    if (entry !== undefined) {
+      return entry
+    }
+    // Prefer real built-ins over silently returning the primary registration,
+    // so multi-backend tests cannot green-pass with the wrong descriptor.
+    if (isSelectableAgentBackendId(backendId)) {
+      const builtIn = getBuiltInAgentBackend(backendId)
+      if (builtIn !== undefined) {
+        return builtIn
+      }
+    }
+    throw new Error(
+      `stub ActiveAgentBackend: unknown Agent Backend id: ${backendId}`,
+    )
+  }
 
   return Layer.succeed(
     ActiveAgentBackend,
     ActiveAgentBackend.of({
-      listStatuses: Effect.succeed([ready]),
-      getBackendStatus: (backendId: AgentBackendId) =>
-        Effect.succeed(backendId === registration.descriptor.id ? ready : null),
+      listStatuses: Effect.succeed(allReady),
+      getBackendStatus: (backendId: AgentBackendId) => {
+        const entry = byId.get(backendId)
+        return Effect.succeed(entry === undefined ? null : readyFor(entry))
+      },
       getStatus: legacyStatus,
-      setSelectedOrInUse: () => Effect.succeed([ready]),
-      activate: () => Effect.succeed(ready),
+      setSelectedOrInUse: () => Effect.succeed(allReady),
+      activate: (backendId) =>
+        Effect.succeed(readyFor(registrationFor(backendId))),
       drop: () => Effect.void,
-      recheck: () => Effect.succeed(ready),
-      requireAgentTurnsAllowed: (_backendId) => requireAllowed,
-      preview: () =>
+      recheck: (backendId) =>
+        Effect.succeed(readyFor(registrationFor(backendId))),
+      requireAgentTurnsAllowed: (backendId) => requireFor(backendId),
+      preview: (backendId) =>
         Effect.succeed({
-          backend: registration.descriptor,
+          backend: registrationFor(backendId).descriptor,
           kind: "ready" as const,
           reason: null,
           models: [],
         }),
       withConfigCoordination: (effect) => effect,
-      getRegistration: () => Effect.succeed(registration),
+      getRegistration: (backendId) =>
+        Effect.succeed(registrationFor(backendId)),
       getActiveRegistration: Effect.succeed(registration),
-      startTurn: () => Effect.die("stub ActiveAgentBackend.startTurn unused"),
-      continueTurn: () =>
-        Effect.die("stub ActiveAgentBackend.continueTurn unused"),
+      startTurn: (backendId, input) =>
+        overrides.startTurn !== undefined
+          ? overrides.startTurn(backendId, input)
+          : Effect.die("stub ActiveAgentBackend.startTurn unused"),
+      continueTurn: (backendId, input) =>
+        overrides.continueTurn !== undefined
+          ? overrides.continueTurn(backendId, input)
+          : Effect.die("stub ActiveAgentBackend.continueTurn unused"),
       inspectBackend: () =>
         Effect.die("stub ActiveAgentBackend.inspectBackend unused"),
       getSessionTelemetry: (input) =>
         Effect.succeed(
           unsupportedSessionTelemetry(
             input.sessionId ?? "",
-            registration.descriptor,
+            registrationFor(input.backendId).descriptor,
           ) satisfies SessionTelemetry,
         ),
     }),

--- a/packages/work-item-lifecycle/src/lib/agent-turn-github-auth.ts
+++ b/packages/work-item-lifecycle/src/lib/agent-turn-github-auth.ts
@@ -1,9 +1,16 @@
 import { Effect, Schema } from "effect"
 import {
   ActiveAgentBackend,
+  type AgentBackendId,
+  type AgentBackendRegistration,
   capabilitySupported,
+  isSelectableAgentBackendId,
 } from "@ready-for-agent/agent-backend"
 import { KeymaxxerService } from "@ready-for-agent/keymaxxer-service"
+import {
+  CurrentCapturedAgentBackendId,
+  CurrentStepRun,
+} from "./agent-turn-limiter.js"
 
 /**
  * Effective Agent Turn GitHub auth: vault-backed only when the Active Agent
@@ -20,6 +27,20 @@ export class AgentTurnGitHubCredentialMissingError extends Schema.TaggedErrorCla
   },
 ) {}
 
+/**
+ * Captured Agent Backend is missing or not selectable while a Step Run needs
+ * it. Fail closed rather than falling back to the process-wide Active
+ * registration.
+ */
+export class InvalidCapturedAgentBackendError extends Schema.TaggedErrorClass<InvalidCapturedAgentBackendError>()(
+  "InvalidCapturedAgentBackendError",
+  {
+    message: Schema.String,
+    /** Empty string when ambient capture was null on an in-flight Step Run. */
+    backendId: Schema.String,
+  },
+) {}
+
 export const isAgentTurnKeymaxxerEffective = (
   keymaxxerMcpSupported: boolean,
   keymaxxerEnabled: boolean | undefined,
@@ -31,7 +52,34 @@ export const resolveAgentTurnGitHubAuth = (input: {
 }) =>
   Effect.gen(function* () {
     const active = yield* ActiveAgentBackend
-    const registration = yield* active.getActiveRegistration
+    // Prefer the Work Item's captured backend when a Step Run is in flight.
+    // Fail closed: non-selectable capture, or null capture while a Step Run is
+    // ambient (mirrors LifecycleStepsLive routing — no silent proxy fallback).
+    const captured = yield* CurrentCapturedAgentBackendId
+    const registration: AgentBackendRegistration = yield* (() => {
+      if (captured === null) {
+        return Effect.gen(function* () {
+          const stepRun = yield* CurrentStepRun
+          if (stepRun !== null) {
+            return yield* new InvalidCapturedAgentBackendError({
+              message:
+                "Work Item captured Agent Backend is missing on an in-flight Step Run",
+              backendId: "",
+            })
+          }
+          return yield* active.getActiveRegistration
+        })
+      }
+      if (!isSelectableAgentBackendId(captured)) {
+        return Effect.fail(
+          new InvalidCapturedAgentBackendError({
+            message: `Work Item captured Agent Backend is not selectable: ${captured}`,
+            backendId: captured,
+          }),
+        )
+      }
+      return active.getRegistration(captured as AgentBackendId)
+    })()
     const keymaxxer = yield* KeymaxxerService
     const effective = isAgentTurnKeymaxxerEffective(
       capabilitySupported(registration, "KeymaxxerMcp"),

--- a/packages/work-item-lifecycle/src/lib/agent-turn-limiter.ts
+++ b/packages/work-item-lifecycle/src/lib/agent-turn-limiter.ts
@@ -41,6 +41,19 @@ export const CurrentStepRun = Context.Reference<CurrentStepRunValue>(
   { defaultValue: () => null },
 )
 
+/**
+ * Captured Agent Backend id for the Work Item whose Step Run is executing.
+ * Lifecycle sets this for the handler fiber so Agent Turns and Session ops
+ * route to the captured adapter instead of re-resolving settings each turn.
+ */
+export type CurrentCapturedAgentBackendIdValue = string | null
+
+export const CurrentCapturedAgentBackendId =
+  Context.Reference<CurrentCapturedAgentBackendIdValue>(
+    "@ready-for-agent/work-item-lifecycle/CurrentCapturedAgentBackendId",
+    { defaultValue: () => null },
+  )
+
 type SavedStepRunReason = {
   readonly reasonCode: string | null
   readonly reasonMessage: string | null

--- a/packages/work-item-lifecycle/src/lib/create-pr.ts
+++ b/packages/work-item-lifecycle/src/lib/create-pr.ts
@@ -5,6 +5,7 @@ import { GitHubService } from "@ready-for-agent/github-service"
 import {
   type AgentTurnGitHubAuth,
   AgentTurnGitHubCredentialMissingError,
+  InvalidCapturedAgentBackendError,
   agentTurnGitHubCredentialGuidance,
   resolveAgentTurnGitHubAuth,
 } from "./agent-turn-github-auth.js"
@@ -123,7 +124,10 @@ export const createPr = (context: LifecycleStepContext) =>
       githubRepo: repository.githubRepo,
     }).pipe(
       Effect.mapError((cause) => {
-        if (cause instanceof AgentTurnGitHubCredentialMissingError) {
+        if (
+          cause instanceof AgentTurnGitHubCredentialMissingError ||
+          cause instanceof InvalidCapturedAgentBackendError
+        ) {
           return new CreatePrCredentialError({
             repositoryId: context.repositoryId,
             message: cause.message,

--- a/packages/work-item-lifecycle/src/lib/decide-pr-merge.ts
+++ b/packages/work-item-lifecycle/src/lib/decide-pr-merge.ts
@@ -3,6 +3,7 @@ import { AgentBackend } from "@ready-for-agent/agent-backend"
 import { DbService } from "@ready-for-agent/db-service"
 import {
   AgentTurnGitHubCredentialMissingError,
+  InvalidCapturedAgentBackendError,
   agentTurnGitHubCredentialGuidance,
   resolveAgentTurnGitHubAuth,
 } from "./agent-turn-github-auth.js"
@@ -106,7 +107,10 @@ export const decidePrMerge = (context: LifecycleStepContext) =>
       githubRepo: repository.githubRepo,
     }).pipe(
       Effect.mapError((cause) => {
-        if (cause instanceof AgentTurnGitHubCredentialMissingError) {
+        if (
+          cause instanceof AgentTurnGitHubCredentialMissingError ||
+          cause instanceof InvalidCapturedAgentBackendError
+        ) {
           return new DecidePrMergeContextError({ message: cause.message })
         }
         return new DecidePrMergeContextError({

--- a/packages/work-item-lifecycle/src/lib/lifecycle-steps-live.ts
+++ b/packages/work-item-lifecycle/src/lib/lifecycle-steps-live.ts
@@ -4,11 +4,17 @@ import { SqlClient } from "effect/unstable/sql"
 import {
   ActiveAgentBackend,
   AgentBackend,
+  AgentBackendConfigError,
+  isSelectableAgentBackendId,
 } from "@ready-for-agent/agent-backend"
 import { DbService } from "@ready-for-agent/db-service"
 import { GitHubService } from "@ready-for-agent/github-service"
 import { KeymaxxerService } from "@ready-for-agent/keymaxxer-service"
-import { limitAgentTurns } from "./agent-turn-limiter.js"
+import {
+  CurrentCapturedAgentBackendId,
+  CurrentStepRun,
+  limitAgentTurns,
+} from "./agent-turn-limiter.js"
 import { assessChanges } from "./assess-changes.js"
 import { closeIssue } from "./close-issue.js"
 import { commit } from "./commit.js"
@@ -55,11 +61,60 @@ export const LifecycleStepsLive = Layer.effect(
     const fs = yield* FileSystem.FileSystem
     const path = yield* Path.Path
     const spawner = yield* ChildProcessSpawner.ChildProcessSpawner
-    const rawAgentBackend = yield* AgentBackend
+    const fallbackAgentBackend = yield* AgentBackend
     const activeAgentBackend = yield* ActiveAgentBackend
     const github = yield* GitHubService
     const sql = yield* SqlClient.SqlClient
-    const agentBackend = yield* limitAgentTurns(rawAgentBackend, db, sql)
+    // Dispatch Agent Turns by the Work Item's captured backend (ambient) so
+    // concurrent dual-backend fleets never share the process-wide proxy.
+    // Fail closed: non-selectable capture, or null capture while a Step Run
+    // fiber is in flight (no silent proxy fallback for lifecycle turns).
+    const resolveCapturedBackendId = Effect.gen(function* () {
+      const captured = yield* CurrentCapturedAgentBackendId
+      if (captured === null) {
+        const stepRun = yield* CurrentStepRun
+        if (stepRun !== null) {
+          return yield* new AgentBackendConfigError({
+            message:
+              "Work Item captured Agent Backend is missing on an in-flight Step Run",
+          })
+        }
+        return null
+      }
+      if (!isSelectableAgentBackendId(captured)) {
+        return yield* new AgentBackendConfigError({
+          message: `Work Item captured Agent Backend is not selectable: ${captured}`,
+        })
+      }
+      return captured
+    })
+    const routedAgentBackend = AgentBackend.of({
+      startTurn: (input) =>
+        Effect.gen(function* () {
+          const captured = yield* resolveCapturedBackendId
+          if (captured === null) {
+            return yield* fallbackAgentBackend.startTurn(input)
+          }
+          return yield* activeAgentBackend.startTurn(captured, input)
+        }),
+      continueTurn: (input) =>
+        Effect.gen(function* () {
+          const captured = yield* resolveCapturedBackendId
+          if (captured === null) {
+            return yield* fallbackAgentBackend.continueTurn(input)
+          }
+          return yield* activeAgentBackend.continueTurn(captured, input)
+        }),
+      inspect: (input) =>
+        Effect.gen(function* () {
+          const captured = yield* resolveCapturedBackendId
+          if (captured === null) {
+            return yield* fallbackAgentBackend.inspect(input)
+          }
+          return yield* activeAgentBackend.inspectBackend(captured, input)
+        }),
+    })
+    const agentBackend = yield* limitAgentTurns(routedAgentBackend, db, sql)
 
     const services = Layer.mergeAll(
       Layer.succeed(DbService, db),

--- a/packages/work-item-lifecycle/src/lib/pr-status-checks.ts
+++ b/packages/work-item-lifecycle/src/lib/pr-status-checks.ts
@@ -10,6 +10,7 @@ import {
 } from "@ready-for-agent/github-service"
 import {
   AgentTurnGitHubCredentialMissingError,
+  InvalidCapturedAgentBackendError,
   agentTurnGitHubCredentialGuidance,
   resolveAgentTurnGitHubAuth,
 } from "./agent-turn-github-auth.js"
@@ -594,7 +595,10 @@ export const investigatePrStatusChecks = (context: LifecycleStepContext) =>
       githubRepo: repository.githubRepo,
     }).pipe(
       Effect.mapError((cause) => {
-        if (cause instanceof AgentTurnGitHubCredentialMissingError) {
+        if (
+          cause instanceof AgentTurnGitHubCredentialMissingError ||
+          cause instanceof InvalidCapturedAgentBackendError
+        ) {
           return new PrStatusChecksContextError({ message: cause.message })
         }
         return new PrStatusChecksContextError({

--- a/packages/work-item-lifecycle/src/lib/resolve-agent-models.ts
+++ b/packages/work-item-lifecycle/src/lib/resolve-agent-models.ts
@@ -30,6 +30,11 @@ const nonEmpty = (value: string | null | undefined): value is string =>
  * to harness config. Review falls back to the resolved build selection when no
  * distinct review model is configured. Returns null when no build model can be
  * resolved.
+ *
+ * Callers that key prefs by Agent Backend must pass repository and harness
+ * sources already projected for that backend (Repository flat columns project
+ * the effective backend; harness fallback should use `getBackendModelPrefs`
+ * for the captured backend, not the default backend's flat columns).
  */
 export const resolveAgentModelSelection = (
   repository: AgentModelSettingsSource | null | undefined,
@@ -78,8 +83,41 @@ export const resolveAgentModelSelection = (
 }
 
 /**
+ * Load repository flat model columns and harness backend-scoped prefs for
+ * `backendId`, then resolve Agent Models for the next Agent Turn. Fails when
+ * no build model is configured for that backend.
+ */
+export const resolveAgentModelsForBackend = (
+  repositoryId: string,
+  backendId: string,
+): Effect.Effect<
+  AgentModelSelection,
+  BuildModelNotConfiguredError | DatabaseError,
+  DbService
+> =>
+  Effect.gen(function* () {
+    const db = yield* DbService
+    const repositories = yield* db.listRepositories
+    const repository: RepositoryRecord | undefined = repositories.find(
+      ({ id }) => id === repositoryId,
+    )
+    // Harness flat columns mirror the default backend; prefer the map entry
+    // for the backend this Work Item (or create path) actually uses.
+    const harnessPrefs = yield* db.getBackendModelPrefs(backendId)
+    const selection = resolveAgentModelSelection(repository, harnessPrefs)
+    if (selection === null) {
+      return yield* new BuildModelNotConfiguredError({
+        message: "Select a default build model first",
+      })
+    }
+    return selection
+  })
+
+/**
  * Load current repository and harness settings and resolve Agent Models for
- * the next Agent Turn. Fails when no build model is configured.
+ * the next Agent Turn using the harness default backend's prefs map entry.
+ * Prefer {@link resolveAgentModelsForBackend} when a captured or effective
+ * backend id is known.
  */
 export const resolveAgentModelsForRepository = (
   repositoryId: string,
@@ -91,15 +129,8 @@ export const resolveAgentModelsForRepository = (
   Effect.gen(function* () {
     const db = yield* DbService
     const config = yield* db.getConfig
-    const repositories = yield* db.listRepositories
-    const repository: RepositoryRecord | undefined = repositories.find(
-      ({ id }) => id === repositoryId,
+    return yield* resolveAgentModelsForBackend(
+      repositoryId,
+      config.selectedAgentBackend,
     )
-    const selection = resolveAgentModelSelection(repository, config)
-    if (selection === null) {
-      return yield* new BuildModelNotConfiguredError({
-        message: "Select a default build model first",
-      })
-    }
-    return selection
   })

--- a/packages/work-item-lifecycle/src/lib/resolve-pr-merge-conflict.ts
+++ b/packages/work-item-lifecycle/src/lib/resolve-pr-merge-conflict.ts
@@ -4,6 +4,7 @@ import { DbService } from "@ready-for-agent/db-service"
 import {
   type AgentTurnGitHubAuth,
   AgentTurnGitHubCredentialMissingError,
+  InvalidCapturedAgentBackendError,
   agentTurnGitHubCredentialGuidance,
   resolveAgentTurnGitHubAuth,
 } from "./agent-turn-github-auth.js"
@@ -120,7 +121,10 @@ export const resolvePrMergeConflict = (context: LifecycleStepContext) =>
       githubRepo: repository.githubRepo,
     }).pipe(
       Effect.mapError((cause) => {
-        if (cause instanceof AgentTurnGitHubCredentialMissingError) {
+        if (
+          cause instanceof AgentTurnGitHubCredentialMissingError ||
+          cause instanceof InvalidCapturedAgentBackendError
+        ) {
           return new ResolvePrMergeConflictContextError({
             message: cause.message,
           })

--- a/packages/work-item-lifecycle/src/lib/types.ts
+++ b/packages/work-item-lifecycle/src/lib/types.ts
@@ -84,7 +84,10 @@ export interface WorkItemRecord {
   readonly githubIssueNumber: number
   readonly issueTitle: string | null
   readonly githubPullRequestNumber: number | null
-  /** Active Agent Backend captured at creation (provenance). */
+  /**
+   * Effective Agent Backend captured at creation: provenance and routing
+   * authority for Agent Turns and model resolution for the Work Item lifetime.
+   */
   readonly agentBackend: string
   readonly state: WorkItemState
   readonly stateReadyAt: Date

--- a/packages/work-item-lifecycle/src/lib/work-item-lifecycle.ts
+++ b/packages/work-item-lifecycle/src/lib/work-item-lifecycle.ts
@@ -18,6 +18,7 @@ import {
   ActiveAgentBackend,
   type AgentBackendId,
   isAgentDependentLifecycleStep,
+  isSelectableAgentBackendId,
 } from "@ready-for-agent/agent-backend"
 import {
   type DatabaseError,
@@ -35,13 +36,16 @@ import {
   type JobNotFoundError,
   QueueService,
 } from "@ready-for-agent/queue-service"
-import { CurrentStepRun } from "./agent-turn-limiter.js"
+import {
+  CurrentCapturedAgentBackendId,
+  CurrentStepRun,
+} from "./agent-turn-limiter.js"
 import { CloseIssueEligibilityError } from "./close-issue-errors.js"
 import {
   AbandonCleanupError,
   ActiveStepRunExistsError,
   AgentBackendUnavailableError,
-  BuildModelNotConfiguredError,
+  type BuildModelNotConfiguredError,
   IssueBlockedError,
   IssueNotFoundError,
   IssueNotOpenError,
@@ -69,7 +73,7 @@ import {
 } from "./pre-commit-errors.js"
 import {
   type AgentModelSelection,
-  resolveAgentModelSelection,
+  resolveAgentModelsForBackend,
 } from "./resolve-agent-models.js"
 import {
   formatAcceptedReviewSummary,
@@ -648,24 +652,21 @@ export const makeWorkItemLifecycleLive = (
       const queue = yield* QueueService
       const steps = yield* LifecycleSteps
       const activeAgentBackend = yield* ActiveAgentBackend
-      const resolveModelsForRepository = (
+      /**
+       * Resolve build/review models for a backend id (create: effective;
+       * turns: captured). Uses repository flat columns (project effective)
+       * then harness `backendModelPrefs` for that backend id.
+       */
+      const resolveModelsForBackend = (
         repositoryId: string,
+        backendId: string,
       ): Effect.Effect<
         AgentModelSelection,
         BuildModelNotConfiguredError | DatabaseError
       > =>
-        Effect.gen(function* () {
-          const configRecord = yield* db.getConfig
-          const repositories = yield* db.listRepositories
-          const repository = repositories.find(({ id }) => id === repositoryId)
-          const selection = resolveAgentModelSelection(repository, configRecord)
-          if (selection === null) {
-            return yield* new BuildModelNotConfiguredError({
-              message: "Select a default build model first",
-            })
-          }
-          return selection
-        })
+        resolveAgentModelsForBackend(repositoryId, backendId).pipe(
+          Effect.provideService(DbService, db),
+        )
       const notifyWorkItemsChanged = (
         repositoryId: string,
       ): Effect.Effect<void> => db.notifyWorkItemsChanged(repositoryId)
@@ -2582,6 +2583,20 @@ export const makeWorkItemLifecycleLive = (
               yield* notifyWorkItemsChanged(workItem.repository_id)
 
               if (isAgentDependentLifecycleStep(stepRun.step)) {
+                // Fail closed on corrupt capture: getBackendStatus normalizes
+                // unknown ids to the default backend, which would silently
+                // evaluate the wrong backend's readiness.
+                if (!isSelectableAgentBackendId(workItem.agent_backend)) {
+                  const reasonMessage = `Work Item captured Agent Backend is not selectable: ${workItem.agent_backend}`
+                  const failed = yield* completeFailedStep({
+                    stepRun: afterStart,
+                    workItem,
+                    reasonCode: STEP_RUN_REASON.agentBackendUnavailable,
+                    reasonMessage,
+                    cause: Cause.fail(reasonMessage),
+                  })
+                  return { _tag: "processed" as const, workItem: failed }
+                }
                 const readiness = yield* activeAgentBackend.getBackendStatus(
                   workItem.agent_backend as AgentBackendId,
                 )
@@ -2603,8 +2618,9 @@ export const makeWorkItemLifecycleLive = (
               }
 
               const maxDuration = maxDurations[stepRun.step]
-              const modelOutcome = yield* resolveModelsForRepository(
+              const modelOutcome = yield* resolveModelsForBackend(
                 workItem.repository_id,
+                workItem.agent_backend,
               ).pipe(
                 Effect.map(
                   (
@@ -2721,6 +2737,10 @@ export const makeWorkItemLifecycleLive = (
                             stepRunId: afterStart.id,
                             repositoryId: workItem.repository_id,
                           }),
+                          Effect.provideService(
+                            CurrentCapturedAgentBackendId,
+                            workItem.agent_backend,
+                          ),
                           Effect.raceFirst(productiveTimeout),
                         ),
                         Deferred.await(cancel).pipe(
@@ -3982,12 +4002,25 @@ export const makeWorkItemLifecycleLive = (
           // runs inside the same section so it matches the backend that is stamped.
           const createdId = yield* activeAgentBackend.withConfigCoordination(
             Effect.gen(function* () {
-              // Capture harness default until lifecycle resolves effective
-              // backend (override ?? default) in #466.
+              // Effective Agent Backend: Repository override or harness default.
+              // Capture it as routing authority for the Work Item lifetime.
               const harnessConfig = yield* db.getConfig
-              const captureBackendId = harnessConfig.selectedAgentBackend
+              const repositories = yield* db.listRepositories
+              const repository = repositories.find(
+                ({ id }) => id === repositoryId,
+              )
+              const rawCaptureBackendId =
+                repository?.selectedAgentBackend ??
+                harnessConfig.selectedAgentBackend
+              if (!isSelectableAgentBackendId(rawCaptureBackendId)) {
+                return yield* new AgentBackendUnavailableError({
+                  message: `Unknown or unsupported Agent Backend: ${rawCaptureBackendId}`,
+                  reason: `Unknown or unsupported Agent Backend: ${rawCaptureBackendId}`,
+                })
+              }
+              const captureBackendId = rawCaptureBackendId
               yield* activeAgentBackend
-                .requireAgentTurnsAllowed(captureBackendId as AgentBackendId)
+                .requireAgentTurnsAllowed(captureBackendId)
                 .pipe(
                   Effect.mapError(
                     (error) =>
@@ -3998,12 +4031,10 @@ export const makeWorkItemLifecycleLive = (
                   ),
                 )
               // Models are not stored on the Work Item; resolve against the
-              // Active backend / prefs after coordination has locked the switch.
-              yield* resolveModelsForRepository(repositoryId)
+              // captured backend's prefs after coordination has locked the switch.
+              yield* resolveModelsForBackend(repositoryId, captureBackendId)
               const activeRegistration =
-                yield* activeAgentBackend.getRegistration(
-                  captureBackendId as AgentBackendId,
-                )
+                yield* activeAgentBackend.getRegistration(captureBackendId)
               const agentBackendId = activeRegistration.descriptor.id
               const workItemId = makeWorkItemId()
               const now = yield* Clock.currentTimeMillis

--- a/packages/work-item-lifecycle/test/agent-turn-github-auth.spec.ts
+++ b/packages/work-item-lifecycle/test/agent-turn-github-auth.spec.ts
@@ -4,6 +4,9 @@ import {
   type KeymaxxerServiceShape,
 } from "@ready-for-agent/keymaxxer-service"
 import {
+  CurrentCapturedAgentBackendId,
+  CurrentStepRun,
+  InvalidCapturedAgentBackendError,
   agentTurnGitHubCredentialGuidance,
   isAgentTurnKeymaxxerEffective,
   resolveAgentTurnGitHubAuth,
@@ -77,6 +80,50 @@ describe("resolveAgentTurnGitHubAuth", () => {
     )
     expect(auth).toEqual({ _tag: "ambient" })
     expect(findSecretCalled).toBe(false)
+  })
+
+  it("fails closed when ambient capture is set but not selectable", async () => {
+    const error = await Effect.runPromise(
+      Effect.flip(
+        resolveAgentTurnGitHubAuth({
+          githubOwner: "acme",
+          githubRepo: "widgets",
+        }).pipe(
+          Effect.provideService(CurrentCapturedAgentBackendId, "not-a-backend"),
+          Effect.provide(
+            Layer.mergeAll(vaultEnabled, stubActiveAgentBackendLayer()),
+          ),
+        ),
+      ),
+    )
+    expect(error).toBeInstanceOf(InvalidCapturedAgentBackendError)
+    if (error instanceof InvalidCapturedAgentBackendError) {
+      expect(error.backendId).toBe("not-a-backend")
+    }
+  })
+
+  it("fails closed when capture is missing during an in-flight Step Run", async () => {
+    const error = await Effect.runPromise(
+      Effect.flip(
+        resolveAgentTurnGitHubAuth({
+          githubOwner: "acme",
+          githubRepo: "widgets",
+        }).pipe(
+          Effect.provideService(CurrentCapturedAgentBackendId, null),
+          Effect.provideService(CurrentStepRun, {
+            stepRunId: "srun-test",
+            repositoryId: "repo-test",
+          }),
+          Effect.provide(
+            Layer.mergeAll(vaultEnabled, stubActiveAgentBackendLayer()),
+          ),
+        ),
+      ),
+    )
+    expect(error).toBeInstanceOf(InvalidCapturedAgentBackendError)
+    if (error instanceof InvalidCapturedAgentBackendError) {
+      expect(error.message).toContain("missing on an in-flight Step Run")
+    }
   })
 
   it("returns ambient auth when Keymaxxer is disabled on a capable backend", async () => {

--- a/packages/work-item-lifecycle/test/captured-agent-backend.spec.ts
+++ b/packages/work-item-lifecycle/test/captured-agent-backend.spec.ts
@@ -1,0 +1,619 @@
+import { Effect, Layer } from "effect"
+import { SqlClient } from "effect/unstable/sql"
+import {
+  AGENT_BACKEND_IDS,
+  ActiveAgentBackend,
+  AgentBackend,
+  type AgentBackendId,
+  AgentBackendUnavailableError,
+  getBuiltInAgentBackend,
+} from "@ready-for-agent/agent-backend"
+import { DatabaseTest } from "@ready-for-agent/db/test"
+import {
+  DbService,
+  DbServiceLive,
+  type DbServiceShape,
+} from "@ready-for-agent/db-service"
+import { SqliteQueueServiceLive } from "@ready-for-agent/sqlite-queue-service"
+import {
+  BuildModelNotConfiguredError,
+  CurrentCapturedAgentBackendId,
+  LifecycleSteps,
+  type LifecycleStepsShape,
+  AgentBackendUnavailableError as LifecycleUnavailableError,
+  STEP_RUN_REASON,
+  WorkItemLifecycle,
+  WorkItemLifecycleLive,
+  resolveAgentModelSelection,
+  resolveAgentModelsForBackend,
+  stubActiveAgentBackendLayer,
+} from "../src/index.js"
+import { describe, expect, it } from "bun:test"
+
+const opencodeRegistration = getBuiltInAgentBackend(AGENT_BACKEND_IDS.opencode)!
+const grokRegistration = getBuiltInAgentBackend(AGENT_BACKEND_IDS.grok)!
+
+const successfulSteps: LifecycleStepsShape = {
+  createWorktree: () =>
+    Effect.succeed({
+      worktreePath: "/tmp/worktrees/acme-widgets-42",
+      startingCommitOid: "abc123",
+    }),
+  installDependencies: () => Effect.void,
+  implement: () => Effect.succeed("ses_test"),
+  assessChanges: () => Effect.succeed({ _tag: "changes" }),
+  preCommit: () => Effect.void,
+  review: () => Effect.succeed({ _tag: "clean" as const }),
+  commit: () => Effect.void,
+  createPr: () => Effect.succeed(101),
+  watchPrStatusChecks: () =>
+    Effect.succeed({
+      _tag: "succeeded",
+      createdAt: new Date(0),
+      headSha: "head",
+      headPushedAt: new Date(0),
+      isDraft: false,
+    }),
+  resolvePrMergeConflict: () => Effect.succeed({ _tag: "processed" }),
+  investigatePrStatusChecks: () =>
+    Effect.succeed({ _tag: "processed", handledCheckIds: [] }),
+  markPrReadyForReview: () => Effect.void,
+  decidePrMerge: () => Effect.succeed({ _tag: "clanker_merge" }),
+  mergePr: () => Effect.succeed({ _tag: "merged" }),
+  closeIssue: () => Effect.void,
+  localCleanup: () => Effect.void,
+  removeWorktree: () => Effect.void,
+}
+
+const storeOpenLeafIssue = (
+  db: Pick<DbServiceShape, "storeIssue">,
+  repositoryId: string,
+  githubIssueNumber: number,
+) =>
+  db.storeIssue({
+    repositoryId,
+    githubIssueNumber,
+    title: `Issue ${githubIssueNumber}`,
+    body: "body",
+    url: `https://github.com/acme/widgets/issues/${githubIssueNumber}`,
+    state: "OPEN",
+    githubCreatedAt: new Date(),
+    issueAuthor: null,
+    parent: null,
+    parentPosition: null,
+    hasChildren: false,
+    blockedBy: [],
+  })
+
+const seedHarness = (
+  db: Pick<DbServiceShape, "updateConfig">,
+  input: {
+    readonly selectedAgentBackend: string
+    readonly defaultModel: string | null
+  },
+) =>
+  db.updateConfig({
+    selectedAgentBackend: input.selectedAgentBackend,
+    defaultModel: input.defaultModel,
+    defaultThinkingLevel: input.defaultModel === null ? null : "low",
+    reviewModel: null,
+    reviewThinkingLevel: null,
+    maxConcurrentAgentTurns: 2,
+    maxConcurrentWorkItems: 5,
+  })
+
+const lifecycleLayer = (
+  active: Layer.Layer<ActiveAgentBackend>,
+  steps: LifecycleStepsShape = successfulSteps,
+) =>
+  WorkItemLifecycleLive.pipe(
+    Layer.provideMerge(active),
+    Layer.provideMerge(Layer.succeed(LifecycleSteps, LifecycleSteps.of(steps))),
+    Layer.provideMerge(DbServiceLive),
+    Layer.provideMerge(SqliteQueueServiceLive),
+    Layer.provideMerge(DatabaseTest),
+  )
+
+describe("Captured Agent Backend (create + route + models)", () => {
+  it("captures harness default when the Repository inherits", async () => {
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        const db = yield* DbService
+        const lifecycle = yield* WorkItemLifecycle
+        const repo = yield* db.addRepository({
+          githubOwner: "acme",
+          githubRepo: "widgets",
+          localPath: "/repos/acme/widgets.git",
+          isBare: true,
+        })
+        yield* seedHarness(db, {
+          selectedAgentBackend: "opencode",
+          defaultModel: "opencode/deepseek-v4-flash-free",
+        })
+        yield* storeOpenLeafIssue(db, repo.id, 1)
+        const created = yield* lifecycle.implementNow(repo.id, 1)
+        expect(created.agentBackend).toBe("opencode")
+        expect(repo.selectedAgentBackend).toBeNull()
+      }).pipe(Effect.provide(lifecycleLayer(stubActiveAgentBackendLayer()))),
+    )
+  })
+
+  it("captures the Repository override rather than the harness default", async () => {
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        const db = yield* DbService
+        const lifecycle = yield* WorkItemLifecycle
+        const repo = yield* db.addRepository({
+          githubOwner: "acme",
+          githubRepo: "widgets",
+          localPath: "/repos/acme/widgets-override.git",
+          isBare: true,
+        })
+        yield* seedHarness(db, {
+          selectedAgentBackend: "opencode",
+          defaultModel: "opencode/deepseek-v4-flash-free",
+        })
+        yield* db.updateRepositorySettings({
+          repositoryId: repo.id,
+          paused: true,
+          selectedAgentBackend: "grok",
+          defaultModel: "grok-code-fast-1",
+          defaultThinkingLevel: "low",
+          reviewModel: null,
+          reviewThinkingLevel: null,
+          autoMerge: false,
+          includeAllIssueAuthors: false,
+        })
+        yield* storeOpenLeafIssue(db, repo.id, 2)
+        const created = yield* lifecycle.implementNow(repo.id, 2)
+        expect(created.agentBackend).toBe("grok")
+      }).pipe(
+        Effect.provide(
+          lifecycleLayer(
+            stubActiveAgentBackendLayer({
+              registration: opencodeRegistration,
+              registrations: [grokRegistration],
+            }),
+          ),
+        ),
+      ),
+    )
+  })
+
+  it("provides the captured backend id to Step Run handlers (routing ambient)", async () => {
+    let ambientDuringImplement: string | null = "unset"
+    const steps: LifecycleStepsShape = {
+      ...successfulSteps,
+      implement: () =>
+        Effect.gen(function* () {
+          ambientDuringImplement = yield* CurrentCapturedAgentBackendId
+          return "ses_routed"
+        }),
+    }
+
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        const db = yield* DbService
+        const lifecycle = yield* WorkItemLifecycle
+        const repo = yield* db.addRepository({
+          githubOwner: "acme",
+          githubRepo: "widgets",
+          localPath: "/repos/acme/widgets-route.git",
+          isBare: true,
+        })
+        yield* seedHarness(db, {
+          selectedAgentBackend: "opencode",
+          defaultModel: "opencode/deepseek-v4-flash-free",
+        })
+        yield* db.updateRepositorySettings({
+          repositoryId: repo.id,
+          paused: true,
+          selectedAgentBackend: "grok",
+          defaultModel: "grok-code-fast-1",
+          defaultThinkingLevel: null,
+          reviewModel: null,
+          reviewThinkingLevel: null,
+          autoMerge: false,
+          includeAllIssueAuthors: false,
+        })
+        yield* storeOpenLeafIssue(db, repo.id, 3)
+        const created = yield* lifecycle.implementNow(repo.id, 3)
+        expect(created.agentBackend).toBe("grok")
+
+        const createRun = created.stepRuns[0]
+        expect(createRun?.step).toBe("create_worktree")
+        const afterCreate = yield* lifecycle.runStep(createRun!.id)
+        expect(afterCreate._tag).toBe("processed")
+        if (afterCreate._tag !== "processed") {
+          return
+        }
+        const installRun = afterCreate.workItem.stepRuns.find(
+          (run) => run.step === "install_dependencies",
+        )
+        expect(installRun?.status).toBe("queued")
+        const afterInstall = yield* lifecycle.runStep(installRun!.id)
+        expect(afterInstall._tag).toBe("processed")
+        if (afterInstall._tag !== "processed") {
+          return
+        }
+        const implementRun = afterInstall.workItem.stepRuns.find(
+          (run) => run.step === "implement",
+        )
+        expect(implementRun?.status).toBe("queued")
+        const afterImplement = yield* lifecycle.runStep(implementRun!.id)
+        expect(afterImplement._tag).toBe("processed")
+        expect(ambientDuringImplement).toBe("grok")
+      }).pipe(
+        Effect.provide(
+          lifecycleLayer(
+            stubActiveAgentBackendLayer({
+              registration: opencodeRegistration,
+              registrations: [grokRegistration],
+            }),
+            steps,
+          ),
+        ),
+      ),
+    )
+  })
+
+  it("fails agent-dependent readiness when captured backend is not selectable", async () => {
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        const db = yield* DbService
+        const sql = yield* SqlClient.SqlClient
+        const lifecycle = yield* WorkItemLifecycle
+        const repo = yield* db.addRepository({
+          githubOwner: "acme",
+          githubRepo: "widgets",
+          localPath: "/repos/acme/widgets-corrupt-capture.git",
+          isBare: true,
+        })
+        yield* seedHarness(db, {
+          selectedAgentBackend: "opencode",
+          defaultModel: "opencode/deepseek-v4-flash-free",
+        })
+        yield* storeOpenLeafIssue(db, repo.id, 7)
+        const created = yield* lifecycle.implementNow(repo.id, 7)
+        // create_worktree is agent-free and should still succeed after corrupt.
+        const createRun = created.stepRuns[0]
+        expect(createRun?.step).toBe("create_worktree")
+        // Corrupt capture to a non-selectable id after create (simulates bad row).
+        yield* sql.unsafe(
+          `UPDATE work_item SET agent_backend = ? WHERE id = ?`,
+          ["not-a-backend", created.id],
+        )
+        const afterCreate = yield* lifecycle.runStep(createRun!.id)
+        expect(afterCreate._tag).toBe("processed")
+        if (afterCreate._tag !== "processed") {
+          return
+        }
+        const installRun = afterCreate.workItem.stepRuns.find(
+          (run) => run.step === "install_dependencies",
+        )
+        expect(installRun?.status).toBe("queued")
+        const afterInstall = yield* lifecycle.runStep(installRun!.id)
+        expect(afterInstall._tag).toBe("processed")
+        if (afterInstall._tag !== "processed") {
+          return
+        }
+        const failed = afterInstall.workItem.stepRuns.find(
+          (run) => run.id === installRun!.id,
+        )
+        expect(failed?.status).toBe("failed")
+        expect(failed?.reasonCode).toBe(STEP_RUN_REASON.agentBackendUnavailable)
+        expect(failed?.reasonMessage).toContain("not selectable")
+        expect(failed?.reasonMessage).toContain("not-a-backend")
+      }).pipe(
+        Effect.provide(
+          lifecycleLayer(
+            stubActiveAgentBackendLayer({
+              // Default opencode is Ready — readiness must not normalize corrupt
+              // capture to this default and allow the agent-dependent step.
+              registration: opencodeRegistration,
+            }),
+          ),
+        ),
+      ),
+    )
+  })
+
+  it("routes Agent Turns to the captured Active adapter when two backends exist", async () => {
+    const startTurnCalls: AgentBackendId[] = []
+    const fallbackCalls: string[] = []
+    const { AgentBackendConfigError, isSelectableAgentBackendId } =
+      await import("@ready-for-agent/agent-backend")
+
+    // Mirrors LifecycleStepsLive fail-closed routing (no silent fallback).
+    const routeStartTurn = Effect.gen(function* () {
+      const active = yield* ActiveAgentBackend
+      const fallback = yield* AgentBackend
+      const captured = yield* CurrentCapturedAgentBackendId
+      if (captured === null) {
+        return yield* fallback.startTurn({
+          prompt: "test",
+          cwd: "/tmp",
+          model: "x",
+          thinkingLevel: null,
+        })
+      }
+      if (!isSelectableAgentBackendId(captured)) {
+        return yield* new AgentBackendConfigError({
+          message: `Work Item captured Agent Backend is not selectable: ${captured}`,
+        })
+      }
+      return yield* active.startTurn(captured, {
+        prompt: "test",
+        cwd: "/tmp",
+        model: "grok-code-fast-1",
+        thinkingLevel: null,
+      })
+    })
+
+    const activeLayer = stubActiveAgentBackendLayer({
+      registration: opencodeRegistration,
+      registrations: [grokRegistration],
+      startTurn: (backendId) => {
+        startTurnCalls.push(backendId)
+        return Effect.succeed({
+          sessionId: `ses_${backendId}`,
+          assistantText: "",
+        })
+      },
+    })
+    const fallbackLayer = Layer.succeed(
+      AgentBackend,
+      AgentBackend.of({
+        startTurn: () => {
+          fallbackCalls.push("startTurn")
+          return Effect.succeed({
+            sessionId: "ses_fallback",
+            assistantText: "",
+          })
+        },
+        continueTurn: () =>
+          Effect.succeed({
+            sessionId: "ses_fallback",
+            assistantText: "",
+          }),
+        inspect: () => Effect.succeed({ models: [] }),
+      }),
+    )
+
+    const result = await Effect.runPromise(
+      routeStartTurn.pipe(
+        Effect.provideService(CurrentCapturedAgentBackendId, "grok"),
+        Effect.provide(Layer.mergeAll(activeLayer, fallbackLayer)),
+      ),
+    )
+    expect(result.sessionId).toBe("ses_grok")
+    expect(startTurnCalls).toEqual(["grok"])
+    expect(fallbackCalls).toEqual([])
+
+    const invalid = await Effect.runPromise(
+      Effect.flip(
+        routeStartTurn.pipe(
+          Effect.provideService(CurrentCapturedAgentBackendId, "not-a-backend"),
+          Effect.provide(Layer.mergeAll(activeLayer, fallbackLayer)),
+        ),
+      ),
+    )
+    expect(invalid).toBeInstanceOf(AgentBackendConfigError)
+    expect(fallbackCalls).toEqual([])
+    expect(startTurnCalls).toEqual(["grok"])
+  })
+
+  it("resolves models from captured backend prefs, not the default flat columns", async () => {
+    const dbLayer = DbServiceLive.pipe(Layer.provideMerge(DatabaseTest))
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        const db = yield* DbService
+        const repo = yield* db.addRepository({
+          githubOwner: "acme",
+          githubRepo: "widgets",
+          localPath: "/repos/acme/widgets-models.git",
+          isBare: true,
+        })
+        yield* seedHarness(db, {
+          selectedAgentBackend: "opencode",
+          defaultModel: "opencode/deepseek-v4-flash-free",
+        })
+        // Remember grok prefs on the harness map, then return default to opencode.
+        yield* db.updateConfig({
+          selectedAgentBackend: "grok",
+          defaultModel: "grok-code-fast-1",
+          defaultThinkingLevel: "high",
+          reviewModel: null,
+          reviewThinkingLevel: null,
+          maxConcurrentAgentTurns: 2,
+          maxConcurrentWorkItems: 5,
+        })
+        yield* db.updateConfig({
+          selectedAgentBackend: "opencode",
+          defaultModel: "opencode/deepseek-v4-flash-free",
+          defaultThinkingLevel: "low",
+          reviewModel: null,
+          reviewThinkingLevel: null,
+          maxConcurrentAgentTurns: 2,
+          maxConcurrentWorkItems: 5,
+        })
+        // Repo overrides to grok with no local model → harness map[grok].
+        yield* db.updateRepositorySettings({
+          repositoryId: repo.id,
+          paused: true,
+          selectedAgentBackend: "grok",
+          defaultModel: null,
+          defaultThinkingLevel: null,
+          reviewModel: null,
+          reviewThinkingLevel: null,
+          autoMerge: false,
+          includeAllIssueAuthors: false,
+        })
+
+        const config = yield* db.getConfig
+        expect(config.selectedAgentBackend).toBe("opencode")
+        expect(config.defaultModel).toBe("opencode/deepseek-v4-flash-free")
+
+        // Flat harness columns would wrongly pick opencode if used as fallback.
+        const wrong = resolveAgentModelSelection(
+          {
+            defaultModel: null,
+            defaultThinkingLevel: null,
+            reviewModel: null,
+            reviewThinkingLevel: null,
+          },
+          config,
+        )
+        expect(wrong?.model).toBe("opencode/deepseek-v4-flash-free")
+
+        const selection = yield* resolveAgentModelsForBackend(repo.id, "grok")
+        expect(selection.model).toBe("grok-code-fast-1")
+        expect(selection.thinkingLevel).toBe("high")
+      }).pipe(Effect.provide(dbLayer)),
+    )
+  })
+
+  it("allows create on a healthy override while the default backend is Unavailable", async () => {
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        const db = yield* DbService
+        const lifecycle = yield* WorkItemLifecycle
+        const repo = yield* db.addRepository({
+          githubOwner: "acme",
+          githubRepo: "widgets",
+          localPath: "/repos/acme/widgets-healthy-override.git",
+          isBare: true,
+        })
+        // Default backend has a model but is Unavailable; override is ready.
+        yield* seedHarness(db, {
+          selectedAgentBackend: "opencode",
+          defaultModel: "opencode/deepseek-v4-flash-free",
+        })
+        yield* db.updateRepositorySettings({
+          repositoryId: repo.id,
+          paused: true,
+          selectedAgentBackend: "grok",
+          defaultModel: "grok-code-fast-1",
+          defaultThinkingLevel: "low",
+          reviewModel: null,
+          reviewThinkingLevel: null,
+          autoMerge: false,
+          includeAllIssueAuthors: false,
+        })
+        yield* storeOpenLeafIssue(db, repo.id, 4)
+        const created = yield* lifecycle.implementNow(repo.id, 4)
+        expect(created.agentBackend).toBe("grok")
+      }).pipe(
+        Effect.provide(
+          lifecycleLayer(
+            stubActiveAgentBackendLayer({
+              registration: opencodeRegistration,
+              registrations: [grokRegistration],
+              requireAgentTurnsAllowedFor: (backendId) =>
+                backendId === "opencode"
+                  ? Effect.fail(
+                      new AgentBackendUnavailableError({
+                        message: "opencode binary not found",
+                        reason: "opencode binary not found",
+                      }),
+                    )
+                  : Effect.void,
+            }),
+          ),
+        ),
+      ),
+    )
+  })
+
+  it("rejects create when the effective backend is Unavailable", async () => {
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        const db = yield* DbService
+        const lifecycle = yield* WorkItemLifecycle
+        const repo = yield* db.addRepository({
+          githubOwner: "acme",
+          githubRepo: "widgets",
+          localPath: "/repos/acme/widgets-unavailable.git",
+          isBare: true,
+        })
+        yield* seedHarness(db, {
+          selectedAgentBackend: "opencode",
+          defaultModel: "opencode/deepseek-v4-flash-free",
+        })
+        yield* db.updateRepositorySettings({
+          repositoryId: repo.id,
+          paused: true,
+          selectedAgentBackend: "grok",
+          defaultModel: "grok-code-fast-1",
+          defaultThinkingLevel: null,
+          reviewModel: null,
+          reviewThinkingLevel: null,
+          autoMerge: false,
+          includeAllIssueAuthors: false,
+        })
+        yield* storeOpenLeafIssue(db, repo.id, 5)
+        const error = yield* Effect.flip(lifecycle.implementNow(repo.id, 5))
+        expect(error).toBeInstanceOf(LifecycleUnavailableError)
+      }).pipe(
+        Effect.provide(
+          lifecycleLayer(
+            stubActiveAgentBackendLayer({
+              registration: grokRegistration,
+              requireAgentTurnsAllowed: Effect.fail(
+                new AgentBackendUnavailableError({
+                  message: "grok binary not found",
+                  reason: "grok binary not found",
+                }),
+              ),
+            }),
+          ),
+        ),
+      ),
+    )
+  })
+
+  it("rejects create when no build model resolves for the effective backend", async () => {
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        const db = yield* DbService
+        const lifecycle = yield* WorkItemLifecycle
+        const repo = yield* db.addRepository({
+          githubOwner: "acme",
+          githubRepo: "widgets",
+          localPath: "/repos/acme/widgets-no-model.git",
+          isBare: true,
+        })
+        yield* seedHarness(db, {
+          selectedAgentBackend: "opencode",
+          defaultModel: "opencode/deepseek-v4-flash-free",
+        })
+        yield* db.updateRepositorySettings({
+          repositoryId: repo.id,
+          paused: true,
+          selectedAgentBackend: "grok",
+          defaultModel: null,
+          defaultThinkingLevel: null,
+          reviewModel: null,
+          reviewThinkingLevel: null,
+          autoMerge: false,
+          includeAllIssueAuthors: false,
+        })
+        yield* storeOpenLeafIssue(db, repo.id, 6)
+        const error = yield* Effect.flip(lifecycle.implementNow(repo.id, 6))
+        expect(error).toBeInstanceOf(BuildModelNotConfiguredError)
+        if (error instanceof BuildModelNotConfiguredError) {
+          expect(error.message).toBe("Select a default build model first")
+        }
+      }).pipe(
+        Effect.provide(
+          lifecycleLayer(
+            stubActiveAgentBackendLayer({
+              registration: opencodeRegistration,
+              registrations: [grokRegistration],
+            }),
+          ),
+        ),
+      ),
+    )
+  })
+})


### PR DESCRIPTION
## Summary

- Capture the Repository effective Agent Backend (`override ?? harness default`) on Work Item create under config coordination.
- Route Agent Turns, readiness, and model resolution by the **captured** backend for the Work Item lifetime (no re-resolve from settings each turn).
- Fail closed on non-selectable or missing capture; agent-free steps still run when a backend is Unavailable.
- Add lifecycle tests for inherit/override capture, dual-backend routing ambient, prefs keying, and create gates.

Closes #466

## Test plan

- [x] `bunx nx test work-item-lifecycle`
- [x] `bunx nx run work-item-lifecycle:typecheck`
- [x] Pre-commit `nx affected` lint/typecheck/test on commit