### PR TITLE
feat(harness): per-repo Agent Backend settings and multi-backend health

### DIFF
--- a/apps/harness/src/refresh-work-items-live.ts
+++ b/apps/harness/src/refresh-work-items-live.ts
@@ -6,6 +6,8 @@ export const committedPullRequestsCountQueryKeyPrefix = [
 ] as const
 
 const configQueryKey = ["config"] as const
+/** Per-repo unfinished gate (`blockingUnfinishedWorkItemCount`) lives here. */
+const repositoriesQueryKey = ["repositories"] as const
 
 export type RepositoryWorkItemsLiveQueries = {
   workItems: (repositoryId: string) => {
@@ -21,7 +23,8 @@ export type RepositoryWorkItemsLiveQueries = {
  *
  * Refetches only the affected repository's workItems query on each event, and
  * also refetches active committed-pull-requests dashboard counts (global across
- * repositories) so the top strip stays live without polling.
+ * repositories) so the top strip stays live without polling. Refetches config
+ * and repositories so unfinished / scoped backend-change gates stay current.
  *
  * Per-event Work Item handling does not await count refresh, so the serial SSE
  * loop can process the next notification while a coalesced trailing count
@@ -211,6 +214,8 @@ export const followRepositoryWorkItemsLive = async ({
       refreshWorkItems(repositoryId),
       // Harness Settings includes the global unfinished Work Item count.
       refreshCachedQueries(configQueryKey),
+      // Repository settings backend gate uses per-repo blocking counts.
+      refreshCachedQueries(repositoriesQueryKey),
     ])
   }
 
@@ -221,6 +226,7 @@ export const followRepositoryWorkItemsLive = async ({
       ...repositoryIds.map((repositoryId) => refreshWorkItems(repositoryId)),
       refreshCommittedPullRequestsCounts(),
       refreshCachedQueries(configQueryKey),
+      refreshCachedQueries(repositoriesQueryKey),
     ])
   }
 

--- a/apps/harness/src/routes/__root.tsx
+++ b/apps/harness/src/routes/__root.tsx
@@ -43,23 +43,30 @@ const configQuery = {
         maxConcurrentAgentTurns: true,
         maxConcurrentWorkItems: true,
         unfinishedWorkItemCount: true,
+        // Scoped gate for changing the harness default (inheriting repos only).
+        blockingUnfinishedWorkItemCount: true,
       },
     })
     return result.config
   },
 }
 
+const agentBackendStatusSelection = {
+  backend: { id: true, label: true },
+  selectedBackend: { id: true, label: true },
+  activeBackend: { id: true, label: true },
+  kind: true,
+  reason: true,
+  models: { id: true, thinkingLevels: true },
+} as const
+
 const agentBackendStatusQuery = {
   queryKey: ["agentBackendStatus"],
   queryFn: async () => {
     const result = await graphql.query({
-      agentBackendStatus: {
-        selectedBackend: { id: true, label: true },
-        activeBackend: { id: true, label: true },
-        kind: true,
-        reason: true,
-        models: { id: true, thinkingLevels: true },
-      },
+      agentBackendStatuses: agentBackendStatusSelection,
+      // Legacy singular surface for the harness default (derived server-side).
+      agentBackendStatus: agentBackendStatusSelection,
       agentBackends: { id: true, label: true },
     })
     return result
@@ -69,6 +76,15 @@ const agentBackendStatusQuery = {
 type AgentModelOption = {
   id: string
   thinkingLevels: readonly string[]
+}
+
+type AgentBackendStatusRow = {
+  backend: { id: string; label: string }
+  selectedBackend: { id: string; label: string }
+  activeBackend: { id: string; label: string }
+  kind: "READY" | "UNAVAILABLE"
+  reason: string | null
+  models: readonly AgentModelOption[]
 }
 
 const modelsQuery = {
@@ -207,15 +223,33 @@ function SettingsButton() {
   const [previewPending, setPreviewPending] = useState(false)
   const previewGenerationRef = useRef(0)
   const buildConfigured = isBuildModelConfigured(config.data)
+  const statuses: readonly AgentBackendStatusRow[] =
+    backendStatus.data?.agentBackendStatuses ?? []
   const status = backendStatus.data?.agentBackendStatus
-  const backendKind = status?.kind
+  const defaultBackendId = config.data?.selectedAgentBackend ?? "opencode"
+  const defaultStatus =
+    statuses.find((row) => row.backend.id === defaultBackendId) ?? status
+  const unavailableStatuses = statuses.filter(
+    (row) => row.kind === "UNAVAILABLE",
+  )
+  const backendKind = defaultStatus?.kind
+  const blockingUnfinishedWorkItemCount =
+    config.data?.blockingUnfinishedWorkItemCount ?? 0
   const unfinishedWorkItemCount = config.data?.unfinishedWorkItemCount ?? 0
-  const backendChangeBlocked = unfinishedWorkItemCount > 0
+  const backendChangeBlocked = blockingUnfinishedWorkItemCount > 0
+  // Hydrate editable form fields once per dialog-open session. Live WI refresh
+  // refetches config (counts) often; re-applying full config.data would wipe drafts.
+  const formHydratedForOpenRef = useRef(false)
 
   useEffect(() => {
-    if (!dialogOpen || !config.data) {
+    if (!dialogOpen) {
+      formHydratedForOpenRef.current = false
       return
     }
+    if (!config.data || formHydratedForOpenRef.current) {
+      return
+    }
+    formHydratedForOpenRef.current = true
     setSelectedAgentBackend(config.data.selectedAgentBackend)
     setDefaultModel(config.data.defaultModel ?? "")
     setDefaultVariant(config.data.defaultThinkingLevel ?? "")
@@ -229,7 +263,7 @@ function SettingsButton() {
     setPreviewModels(null)
     setPreviewError(null)
     setPreviewPending(false)
-  }, [config.data, dialogOpen])
+  }, [dialogOpen, config.data])
 
   const updateConfig = useMutation({
     mutationFn: (input: {
@@ -252,6 +286,7 @@ function SettingsButton() {
           maxConcurrentAgentTurns: true,
           maxConcurrentWorkItems: true,
           unfinishedWorkItemCount: true,
+          blockingUnfinishedWorkItemCount: true,
         },
       }),
     onSuccess: ({ updateConfig: updatedConfig }) => {
@@ -260,37 +295,112 @@ function SettingsButton() {
         queryKey: agentBackendStatusQuery.queryKey,
       })
       void queryClient.invalidateQueries({ queryKey: modelsQuery.queryKey })
+      // effectiveAgentBackend / blocking counts on Repository cards depend on
+      // the harness default; refresh so inheriting repos do not stay stale.
+      void queryClient.invalidateQueries({ queryKey: ["repositories"] })
       dialogRef.current?.close()
       setDialogOpen(false)
     },
   })
 
+  const [recheckingBackendId, setRecheckingBackendId] = useState<string | null>(
+    null,
+  )
+  const [recheckAllPending, setRecheckAllPending] = useState(false)
+  const [recheckAllFailures, setRecheckAllFailures] = useState<
+    readonly string[]
+  >([])
+
   const recheckBackend = useMutation({
-    mutationFn: () =>
-      graphql.mutation({
-        recheckAgentBackend: {
-          selectedBackend: { id: true, label: true },
-          activeBackend: { id: true, label: true },
-          kind: true,
-          reason: true,
-          models: { id: true, thinkingLevels: true },
-        },
-      }),
-    onSuccess: ({ recheckAgentBackend }) => {
-      queryClient.setQueryData(agentBackendStatusQuery.queryKey, (current) =>
-        current === undefined
-          ? {
-              agentBackendStatus: recheckAgentBackend,
+    mutationFn: async (backendId: string) => {
+      setRecheckingBackendId(backendId)
+      try {
+        const result = await graphql.mutation({
+          recheckAgentBackend: {
+            __args: { backendId },
+            ...agentBackendStatusSelection,
+          },
+        })
+        return { backendId, status: result.recheckAgentBackend }
+      } finally {
+        setRecheckingBackendId(null)
+      }
+    },
+    onSuccess: ({ backendId, status: rechecked }) => {
+      type BackendStatusQueryData = {
+        agentBackendStatuses: readonly AgentBackendStatusRow[]
+        agentBackendStatus: AgentBackendStatusRow
+        agentBackends: readonly { id: string; label: string }[]
+      }
+      queryClient.setQueryData<BackendStatusQueryData>(
+        agentBackendStatusQuery.queryKey,
+        (current) => {
+          if (current == null) {
+            return {
+              agentBackendStatuses: [rechecked],
+              agentBackendStatus: rechecked,
               agentBackends: [],
             }
-          : {
-              ...current,
-              agentBackendStatus: recheckAgentBackend,
-            },
+          }
+          const priorStatuses = current.agentBackendStatuses ?? []
+          const nextStatuses = priorStatuses.some(
+            (row) => row.backend.id === backendId,
+          )
+            ? priorStatuses.map((row) =>
+                row.backend.id === backendId ? rechecked : row,
+              )
+            : [...priorStatuses, rechecked]
+          const nextDefault =
+            backendId ===
+            (config.data?.selectedAgentBackend ?? defaultBackendId)
+              ? rechecked
+              : (current.agentBackendStatus ?? rechecked)
+          return {
+            ...current,
+            agentBackendStatuses: nextStatuses,
+            agentBackendStatus: nextDefault,
+          }
+        },
       )
-      void queryClient.invalidateQueries({ queryKey: modelsQuery.queryKey })
+      // Global models query is the harness-default catalog only.
+      if (
+        backendId === (config.data?.selectedAgentBackend ?? defaultBackendId)
+      ) {
+        void queryClient.invalidateQueries({ queryKey: modelsQuery.queryKey })
+      }
     },
   })
+
+  const backendLabelForId = (backendId: string): string =>
+    statuses.find((row) => row.backend.id === backendId)?.backend.label ??
+    (backendStatus.data?.agentBackends ?? []).find(
+      (backend) => backend.id === backendId,
+    )?.label ??
+    backendId
+
+  const recheckAllBackends = async () => {
+    const ids =
+      statuses.length > 0
+        ? statuses.map((row) => row.backend.id)
+        : [defaultBackendId]
+    setRecheckAllPending(true)
+    setRecheckAllFailures([])
+    recheckBackend.reset()
+    const failedLabels: string[] = []
+    try {
+      // Continue after individual failures so other Active backends still refresh.
+      for (const backendId of ids) {
+        try {
+          await recheckBackend.mutateAsync(backendId)
+        } catch {
+          failedLabels.push(backendLabelForId(backendId))
+        }
+      }
+    } finally {
+      setRecheckAllPending(false)
+      setRecheckAllFailures(failedLabels)
+    }
+  }
 
   const applyModelPrefs = (prefs: {
     defaultModel: string | null
@@ -381,6 +491,8 @@ function SettingsButton() {
 
   const openSettings = () => {
     setDialogOpen(true)
+    // Allow one hydrate for this open (effect or inline below).
+    formHydratedForOpenRef.current = false
     // Discard any in-flight preview from a previous dialog session.
     previewGenerationRef.current += 1
     if (config.isError) {
@@ -393,6 +505,7 @@ function SettingsButton() {
       void backendStatus.refetch()
     }
     if (config.data) {
+      formHydratedForOpenRef.current = true
       setSelectedAgentBackend(config.data.selectedAgentBackend)
       applyModelPrefs({
         defaultModel: config.data.defaultModel,
@@ -408,6 +521,7 @@ function SettingsButton() {
     setPreviewModels(null)
     setPreviewError(null)
     setPreviewPending(false)
+    setRecheckAllFailures([])
     updateConfig.reset()
     recheckBackend.reset()
     dialogRef.current?.showModal()
@@ -428,6 +542,11 @@ function SettingsButton() {
 
   const saveSettings = (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault()
+    // Live gate can flip while a draft backend change is staged; select may
+    // already be disabled — still block submit (incl. Enter).
+    if (backendChangeBlocked && selectedAgentBackend !== savedAgentBackend) {
+      return
+    }
     const parsedMaxSessions = Number(maxConcurrentAgentTurns)
     const parsedMaxWorkItems = Number(maxConcurrentWorkItems)
     updateConfig.mutate({
@@ -466,8 +585,20 @@ function SettingsButton() {
     (hasUnavailableReviewModel ||
       (reviewModel.length === 0 && hasUnavailableBuildModel) ||
       !reviewThinkingLevels.includes(reviewThinkingLevel))
+  // First-run banner is about the harness default build model only; fully
+  // configured Repository overrides are not hard-blocked by this guidance.
   const showUnconfiguredGuidance = config.isSuccess && !buildConfigured
-  const showBackendBanner = config.isSuccess && backendKind === "UNAVAILABLE"
+  const showBackendBanner =
+    config.isSuccess &&
+    (backendKind === "UNAVAILABLE" || unavailableStatuses.length > 0)
+  const bannerUnavailableReason =
+    unavailableStatuses.length === 1
+      ? `${unavailableStatuses[0]?.backend.label ?? "Agent Backend"}: ${
+          unavailableStatuses[0]?.reason ?? "unavailable"
+        }`
+      : unavailableStatuses.length > 1
+        ? `${unavailableStatuses.length} Agent Backends are unavailable`
+        : (defaultStatus?.reason ?? "Agent Backend is unavailable")
   const modelsDisabled =
     backendChanging && (previewPending || previewError !== null)
   const modelsLoading =
@@ -475,6 +606,10 @@ function SettingsButton() {
     (backendChanging
       ? previewPending
       : models.isPending || backendStatus.isPending)
+  const recheckBusy =
+    recheckBackend.isPending ||
+    recheckAllPending ||
+    recheckingBackendId !== null
 
   return (
     <>
@@ -483,7 +618,7 @@ function SettingsButton() {
           className="mr-auto flex flex-wrap items-center gap-2 border border-oxblood/40 bg-oxblood-wash px-3 py-1.5 text-xs text-oxblood-deep sm:text-sm"
           role="status"
         >
-          <span>{status?.reason ?? "Agent Backend is unavailable"}</span>
+          <span>{bannerUnavailableReason}</span>
           <button
             type="button"
             className="border border-oxblood/50 bg-paper px-2 py-0.5 text-xs font-semibold text-oxblood underline-offset-2 hover:bg-oxblood hover:text-paper"
@@ -553,14 +688,33 @@ function SettingsButton() {
             </p>
             {showUnconfiguredGuidance && (
               <p className="mt-3 border border-oxblood/40 bg-oxblood-wash p-3 text-sm text-oxblood-deep">
-                Select a default build model before the harness can create work.
+                Select a default build model before the harness can create work
+                on Repositories that inherit this default. Repositories with a
+                fully configured Agent Backend override can still create work.
               </p>
             )}
-            {!backendChanging && status?.kind === "UNAVAILABLE" && (
-              <p className="mt-3 border border-oxblood/40 bg-oxblood-wash p-3 text-sm text-oxblood-deep">
-                {status.reason ?? "Agent Backend is unavailable."}
-              </p>
-            )}
+            {!backendChanging &&
+              (unavailableStatuses.length > 0 ||
+                (unavailableStatuses.length === 0 &&
+                  defaultStatus?.kind === "UNAVAILABLE")) && (
+                <div className="mt-3 grid gap-2">
+                  {(unavailableStatuses.length > 0
+                    ? unavailableStatuses
+                    : defaultStatus !== undefined
+                      ? [defaultStatus as AgentBackendStatusRow]
+                      : []
+                  ).map((row) => (
+                    <p
+                      key={row.backend.id}
+                      className="border border-oxblood/40 bg-oxblood-wash p-3 text-sm text-oxblood-deep"
+                    >
+                      <span className="font-semibold">{row.backend.label}</span>
+                      {": "}
+                      {row.reason ?? "Agent Backend is unavailable."}
+                    </p>
+                  ))}
+                </div>
+              )}
           </div>
 
           <div className="grid gap-5 px-6 py-5">
@@ -575,7 +729,7 @@ function SettingsButton() {
             ) : (
               <>
                 <label className="grid min-w-0 gap-1.5 text-sm font-semibold">
-                  Agent Backend
+                  Default Agent Backend
                   <select
                     className="w-full min-w-0 border border-rule-2 bg-paper px-3 py-2 text-sm font-normal outline-none focus:border-oxblood focus:ring-2 focus:ring-oxblood/15 disabled:cursor-not-allowed disabled:opacity-60"
                     name="selectedAgentBackend"
@@ -595,32 +749,82 @@ function SettingsButton() {
                   </select>
                   <span className="text-xs font-normal text-ink-faint">
                     {backendChangeBlocked
-                      ? `${unfinishedWorkItemCount} unfinished Work Item${unfinishedWorkItemCount === 1 ? "" : "s"} — finish or abandon them before changing Agent Backend.`
-                      : "Activates immediately on Save when no Work Items are unfinished. Model prefs are remembered per backend."}
+                      ? `${blockingUnfinishedWorkItemCount} unfinished Work Item${
+                          blockingUnfinishedWorkItemCount === 1 ? "" : "s"
+                        } on Repositories inheriting the harness default — finish or abandon them before changing the default Agent Backend.${
+                          unfinishedWorkItemCount >
+                          blockingUnfinishedWorkItemCount
+                            ? ` (${unfinishedWorkItemCount} unfinished fleet-wide.)`
+                            : ""
+                        }`
+                      : "Activates immediately on Save when no inheriting Work Items are unfinished. Model prefs are remembered per backend. Repository overrides are independent."}
                   </span>
                 </label>
 
-                <div className="flex flex-wrap items-center gap-2">
-                  <p className="m-0 text-xs text-ink-soft">
-                    Active:{" "}
-                    <span className="font-semibold text-ink-2">
-                      {status?.activeBackend.label ?? "—"}
-                    </span>
-                    {status?.kind === "READY" ? " · Ready" : null}
-                    {backendChanging ? " · Previewing selection" : null}
-                  </p>
-                  <button
-                    type="button"
-                    className="border border-rule-2 bg-paper px-2 py-1 text-xs font-semibold text-ink-2 hover:bg-paper-2 disabled:opacity-50"
-                    disabled={recheckBackend.isPending || backendChanging}
-                    onClick={() => {
-                      recheckBackend.mutate()
-                    }}
-                  >
-                    {recheckBackend.isPending
-                      ? "Rechecking…"
-                      : "Recheck Agent Backend"}
-                  </button>
+                <div className="grid gap-2">
+                  <div className="flex flex-wrap items-center justify-between gap-2">
+                    <p className="m-0 text-xs font-semibold tracking-[0.12em] text-ink-faint uppercase">
+                      Active Agent Backends
+                    </p>
+                    <button
+                      type="button"
+                      className="border border-rule-2 bg-paper px-2 py-1 text-xs font-semibold text-ink-2 hover:bg-paper-2 disabled:opacity-50"
+                      disabled={recheckBusy || backendChanging}
+                      onClick={() => {
+                        void recheckAllBackends()
+                      }}
+                    >
+                      {recheckAllPending ? "Rechecking all…" : "Recheck all"}
+                    </button>
+                  </div>
+                  {(statuses.length > 0
+                    ? statuses
+                    : defaultStatus !== undefined
+                      ? [defaultStatus as AgentBackendStatusRow]
+                      : []
+                  ).map((row) => {
+                    const isDefault = row.backend.id === savedAgentBackend
+                    const rowRechecking = recheckingBackendId === row.backend.id
+                    return (
+                      <div
+                        key={row.backend.id}
+                        className="flex flex-wrap items-center justify-between gap-2 border border-rule bg-paper-2 px-3 py-2"
+                      >
+                        <p className="m-0 text-xs text-ink-soft">
+                          <span className="font-semibold text-ink-2">
+                            {row.backend.label}
+                          </span>
+                          {isDefault ? " · Default" : null}
+                          {row.kind === "READY" ? " · Ready" : " · Unavailable"}
+                          {backendChanging &&
+                          row.backend.id === selectedAgentBackend
+                            ? " · Previewing selection"
+                            : null}
+                          {row.kind === "UNAVAILABLE" && row.reason !== null
+                            ? ` — ${row.reason}`
+                            : null}
+                        </p>
+                        <button
+                          type="button"
+                          className="border border-rule-2 bg-paper px-2 py-1 text-xs font-semibold text-ink-2 hover:bg-paper-2 disabled:opacity-50"
+                          disabled={recheckBusy || backendChanging}
+                          onClick={() => {
+                            setRecheckAllFailures([])
+                            recheckBackend.mutate(row.backend.id)
+                          }}
+                        >
+                          {rowRechecking
+                            ? "Rechecking…"
+                            : `Recheck ${row.backend.label}`}
+                        </button>
+                      </div>
+                    )
+                  })}
+                  {statuses.length === 0 && defaultStatus === undefined && (
+                    <p className="m-0 text-xs text-ink-soft">
+                      No Active Agent Backend status yet.
+                    </p>
+                  )}
                 </div>
 
                 {backendChanging && previewError !== null && (
@@ -853,9 +1057,23 @@ function SettingsButton() {
                   : "Settings could not be saved. Check the values and try again."}
               </p>
             )}
-            {recheckBackend.isError && (
+            {recheckAllFailures.length > 0 && (
               <p className="border border-oxblood/40 bg-oxblood-wash p-3 text-sm text-oxblood-deep">
-                Recheck failed. Try again after fixing the Agent Backend.
+                Recheck failed for{" "}
+                {recheckAllFailures.length === 1
+                  ? recheckAllFailures[0]
+                  : recheckAllFailures.join(", ")}
+                . Other backends may have refreshed. Try again after fixing
+                those Agent Backends.
+              </p>
+            )}
+            {recheckAllFailures.length === 0 && recheckBackend.isError && (
+              <p className="border border-oxblood/40 bg-oxblood-wash p-3 text-sm text-oxblood-deep">
+                Recheck failed
+                {recheckBackend.variables !== undefined
+                  ? ` for ${backendLabelForId(recheckBackend.variables)}`
+                  : ""}
+                . Try again after fixing that Agent Backend.
               </p>
             )}
           </div>
@@ -880,6 +1098,7 @@ function SettingsButton() {
                 config.isError ||
                 modelsLoading ||
                 updateConfig.isPending ||
+                (backendChangeBlocked && backendChanging) ||
                 (backendChanging && previewError !== null) ||
                 // Empty build model allowed on backend change (first-run style);
                 // non-empty must still be in the preview/active catalog.

--- a/apps/harness/src/routes/index.tsx
+++ b/apps/harness/src/routes/index.tsx
@@ -56,8 +56,9 @@ const configQuery = {
         maxConcurrentAgentTurns: true,
         maxConcurrentWorkItems: true,
         // Keep selection aligned with Harness Settings so shared cache never
-        // drops unfinishedWorkItemCount (backend-change idle gate).
+        // drops unfinished / scoped gate fields.
         unfinishedWorkItemCount: true,
+        blockingUnfinishedWorkItemCount: true,
       },
     })
     return result.config
@@ -67,6 +68,11 @@ const configQuery = {
 type AgentModelOption = {
   id: string
   thinkingLevels: readonly string[]
+}
+
+type AgentBackendInfo = {
+  id: string
+  label: string
 }
 
 const modelsQuery = {
@@ -80,6 +86,21 @@ const modelsQuery = {
     return result.models
   },
 }
+
+const agentBackendsQuery = {
+  queryKey: ["agentBackends"],
+  staleTime: Number.POSITIVE_INFINITY,
+  gcTime: Number.POSITIVE_INFINITY,
+  queryFn: async () => {
+    const result = await graphql.query({
+      agentBackends: { id: true, label: true },
+    })
+    return result.agentBackends
+  },
+}
+
+/** Empty select value means inherit the harness default (null override). */
+const HARNESS_DEFAULT_BACKEND_VALUE = ""
 
 const sessionQuery = (workItemId: string) => ({
   queryKey: ["session", workItemId] as const,
@@ -164,6 +185,8 @@ const repositoriesQuery = {
         localPath: true,
         isBare: true,
         paused: true,
+        selectedAgentBackend: true,
+        effectiveAgentBackend: true,
         defaultModel: true,
         defaultThinkingLevel: true,
         reviewModel: true,
@@ -171,6 +194,7 @@ const repositoriesQuery = {
         autoMerge: true,
         includeAllIssueAuthors: true,
         issuesReconciledAt: true,
+        blockingUnfinishedWorkItemCount: true,
       },
       repositoryCredentials: {
         repositoryId: true,
@@ -236,6 +260,8 @@ type Repository = {
   localPath: string
   isBare: boolean
   paused: boolean
+  selectedAgentBackend: string | null
+  effectiveAgentBackend: string
   defaultModel: string | null
   defaultThinkingLevel: string | null
   reviewModel: string | null
@@ -243,6 +269,7 @@ type Repository = {
   autoMerge: boolean
   includeAllIssueAuthors: boolean
   issuesReconciledAt: string | null
+  blockingUnfinishedWorkItemCount: number
   credential: RepositoryCredential
 }
 
@@ -799,7 +826,15 @@ function RepositoryCard({
   const [settingsOpen, setSettingsOpen] = useState(false)
   const config = useQuery({ ...configQuery, enabled: settingsOpen })
   const models = useQuery({ ...modelsQuery, enabled: settingsOpen })
+  const agentBackends = useQuery({
+    ...agentBackendsQuery,
+    enabled: settingsOpen,
+  })
   const [paused, setPaused] = useState(repository.paused)
+  // null override = inherit harness default; select value is "" for inherit.
+  const [selectedAgentBackend, setSelectedAgentBackend] = useState<
+    string | null
+  >(repository.selectedAgentBackend)
   const [defaultModel, setDefaultModel] = useState(
     repository.defaultModel ?? "",
   )
@@ -814,6 +849,27 @@ function RepositoryCard({
   const [includeAllIssueAuthors, setIncludeAllIssueAuthors] = useState(
     repository.includeAllIssueAuthors,
   )
+  const [previewModels, setPreviewModels] = useState<
+    readonly AgentModelOption[] | null
+  >(null)
+  const [previewError, setPreviewError] = useState<string | null>(null)
+  const [previewPending, setPreviewPending] = useState(false)
+  const [harnessPrefsForDraft, setHarnessPrefsForDraft] = useState<{
+    defaultModel: string | null
+    defaultThinkingLevel: string | null
+    reviewModel: string | null
+    reviewThinkingLevel: string | null
+  } | null>(null)
+  const previewGenerationRef = useRef(0)
+  // Dialog-session stash so switching backends and back restores form fields.
+  // Server map for non-projected backends needs repositoryModelPrefs (not in API).
+  type DraftModelPrefs = {
+    defaultModel: string | null
+    defaultThinkingLevel: string | null
+    reviewModel: string | null
+    reviewThinkingLevel: string | null
+  }
+  const draftPrefsByBackendRef = useRef<Record<string, DraftModelPrefs>>({})
   const jobsQuery = workItemsQuery(repository.id)
   const { data: workItems = [], isLoading: workItemsLoading } =
     useQuery(jobsQuery)
@@ -822,6 +878,7 @@ function RepositoryCard({
     mutationFn: async (input: {
       repositoryId: string
       paused: boolean
+      selectedAgentBackend: string | null
       defaultModel: string | null
       defaultThinkingLevel: string | null
       reviewModel: string | null
@@ -838,6 +895,8 @@ function RepositoryCard({
           localPath: true,
           isBare: true,
           paused: true,
+          selectedAgentBackend: true,
+          effectiveAgentBackend: true,
           defaultModel: true,
           defaultThinkingLevel: true,
           reviewModel: true,
@@ -845,6 +904,7 @@ function RepositoryCard({
           autoMerge: true,
           includeAllIssueAuthors: true,
           issuesReconciledAt: true,
+          blockingUnfinishedWorkItemCount: true,
         },
       })
       return result.updateRepositorySettings
@@ -859,23 +919,125 @@ function RepositoryCard({
               : candidate,
           ),
       )
+      // Override changes can expand/shrink the Active Agent Backend set.
+      void queryClient.invalidateQueries({
+        queryKey: ["agentBackendStatus"],
+      })
       settingsDialogRef.current?.close()
       setSettingsOpen(false)
     },
   })
 
+  const applyRepoModelPrefs = (prefs: DraftModelPrefs) => {
+    setDefaultModel(prefs.defaultModel ?? "")
+    setDefaultVariant(prefs.defaultThinkingLevel ?? "")
+    setReviewModel(prefs.reviewModel ?? "")
+    setReviewVariant(prefs.reviewThinkingLevel ?? "")
+  }
+
+  const currentDraftModelPrefs = (): DraftModelPrefs => ({
+    defaultModel: defaultModel.trim() === "" ? null : defaultModel,
+    defaultThinkingLevel:
+      defaultThinkingLevel.trim() === "" ? null : defaultThinkingLevel,
+    reviewModel: reviewModel.trim() === "" ? null : reviewModel,
+    reviewThinkingLevel:
+      reviewThinkingLevel.trim() === "" ? null : reviewThinkingLevel,
+  })
+
+  const draftEffectiveBackend = (
+    override: string | null,
+    harnessDefault: string,
+  ): string => override ?? harnessDefault
+
+  const applyAgentBackendSelection = (nextSelectValue: string) => {
+    const nextOverride =
+      nextSelectValue === HARNESS_DEFAULT_BACKEND_VALUE ? null : nextSelectValue
+    const harnessDefault = config.data?.selectedAgentBackend ?? "opencode"
+    const previousEffective = draftEffectiveBackend(
+      selectedAgentBackend,
+      harnessDefault,
+    )
+    const nextEffective = draftEffectiveBackend(nextOverride, harnessDefault)
+    const savedEffective = repository.effectiveAgentBackend
+
+    // Stash form fields for the backend we are leaving so switching back in
+    // this dialog session restores them (harness Settings does this via prefs).
+    draftPrefsByBackendRef.current[previousEffective] = currentDraftModelPrefs()
+
+    setSelectedAgentBackend(nextOverride)
+
+    // Clear catalog/pending synchronously (before useEffect) so Save cannot
+    // validate against the previous override's catalog for a render frame.
+    // Bump generation so any in-flight preview is ignored when the effect runs.
+    previewGenerationRef.current += 1
+    if (nextEffective === harnessDefault) {
+      setPreviewPending(false)
+      setPreviewError(null)
+      setPreviewModels(null)
+      setHarnessPrefsForDraft(null)
+    } else {
+      setPreviewPending(true)
+      setPreviewError(null)
+      setPreviewModels(null)
+      setHarnessPrefsForDraft(null)
+    }
+
+    const stashed = draftPrefsByBackendRef.current[nextEffective]
+    if (stashed !== undefined) {
+      applyRepoModelPrefs(stashed)
+    } else if (nextEffective === savedEffective) {
+      applyRepoModelPrefs({
+        defaultModel: repository.defaultModel,
+        defaultThinkingLevel: repository.defaultThinkingLevel,
+        reviewModel: repository.reviewModel,
+        reviewThinkingLevel: repository.reviewThinkingLevel,
+      })
+    } else {
+      // No session stash and no projected flat columns for this effective
+      // backend — empty means inherit harness until the operator picks models.
+      applyRepoModelPrefs({
+        defaultModel: null,
+        defaultThinkingLevel: null,
+        reviewModel: null,
+        reviewThinkingLevel: null,
+      })
+    }
+  }
+
   const openSettings = () => {
     setSettingsOpen(true)
+    previewGenerationRef.current += 1
     setPaused(repository.paused)
+    setSelectedAgentBackend(repository.selectedAgentBackend)
     setDefaultModel(repository.defaultModel ?? "")
     setDefaultVariant(repository.defaultThinkingLevel ?? "")
     setReviewModel(repository.reviewModel ?? "")
     setReviewVariant(repository.reviewThinkingLevel ?? "")
     setAutoMerge(repository.autoMerge)
     setIncludeAllIssueAuthors(repository.includeAllIssueAuthors)
+    setPreviewModels(null)
+    setPreviewError(null)
+    // Override catalogs load via preview; start pending so model fields stay
+    // disabled until the effect loads the correct catalog.
+    setPreviewPending(repository.selectedAgentBackend !== null)
+    setHarnessPrefsForDraft(null)
+    // Seed session stash with the saved effective projection.
+    draftPrefsByBackendRef.current = {
+      [repository.effectiveAgentBackend]: {
+        defaultModel: repository.defaultModel,
+        defaultThinkingLevel: repository.defaultThinkingLevel,
+        reviewModel: repository.reviewModel,
+        reviewThinkingLevel: repository.reviewThinkingLevel,
+      },
+    }
     updateSettings.reset()
+    // Fresh gate counts for backend change (work-item live also refreshes this).
+    void queryClient.invalidateQueries({
+      queryKey: repositoriesQuery.queryKey,
+    })
     if (config.isError) void config.refetch()
     if (models.isError) void models.refetch()
+    if (agentBackends.isError) void agentBackends.refetch()
     settingsDialogRef.current?.showModal()
   }
 
@@ -884,6 +1046,7 @@ function RepositoryCard({
     updateSettings.mutate({
       repositoryId: repository.id,
       paused,
+      selectedAgentBackend,
       defaultModel: defaultModel.trim() === "" ? null : defaultModel,
       defaultThinkingLevel:
         defaultThinkingLevel.trim() === "" ? null : defaultThinkingLevel,
@@ -895,28 +1058,176 @@ function RepositoryCard({
     })
   }
 
-  const harnessDefaultModel = config.data?.defaultModel ?? "not configured"
-  const harnessDefaultVariant =
-    config.data?.defaultThinkingLevel ?? "not configured"
-  const resolvedBuildModel = repository.defaultModel ?? harnessDefaultModel
+  const harnessDefaultBackendId =
+    config.data?.selectedAgentBackend ?? "opencode"
+  const harnessDefaultBackendLabel =
+    (agentBackends.data ?? []).find(
+      (backend: AgentBackendInfo) => backend.id === harnessDefaultBackendId,
+    )?.label ?? harnessDefaultBackendId
+  const draftEffective = draftEffectiveBackend(
+    selectedAgentBackend,
+    harnessDefaultBackendId,
+  )
+  const savedEffective = repository.effectiveAgentBackend
+  const backendDraftChanging = draftEffective !== savedEffective
+  const backendChangeBlocked = repository.blockingUnfinishedWorkItemCount > 0
+
+  // Override / draft backends cannot use the harness-default models query.
+  // Depend only on selectedAgentBackend (not whole config.data) so live config
+  // refetches that only update unfinished counts do not thrash preview.
+  const harnessDefaultBackendFromConfig =
+    config.data?.selectedAgentBackend ?? null
+  useEffect(() => {
+    if (!settingsOpen || harnessDefaultBackendFromConfig === null) {
+      return
+    }
+    const harnessDefault = harnessDefaultBackendFromConfig
+    const effective = selectedAgentBackend ?? harnessDefault
+    if (effective === harnessDefault) {
+      setHarnessPrefsForDraft(null)
+      setPreviewModels(null)
+      setPreviewError(null)
+      setPreviewPending(false)
+      return
+    }
+    const generation = ++previewGenerationRef.current
+    setPreviewPending(true)
+    setPreviewError(null)
+    // Drop previous backend's harness prefs / catalog so inherit labels do not
+    // briefly show the wrong backend while the new preview loads.
+    setHarnessPrefsForDraft(null)
+    setPreviewModels(null)
+    void (async () => {
+      try {
+        const [prefsResult, previewResult] = await Promise.all([
+          graphql.query({
+            harnessModelPrefs: {
+              __args: { backendId: effective },
+              defaultModel: true,
+              defaultThinkingLevel: true,
+              reviewModel: true,
+              reviewThinkingLevel: true,
+            },
+          }),
+          graphql.query({
+            previewAgentBackend: {
+              __args: { backendId: effective },
+              backend: { id: true, label: true },
+              kind: true,
+              reason: true,
+              models: { id: true, thinkingLevels: true },
+            },
+          }),
+        ])
+        if (generation !== previewGenerationRef.current) {
+          return
+        }
+        setHarnessPrefsForDraft(prefsResult.harnessModelPrefs)
+        const preview = previewResult.previewAgentBackend
+        if (preview.kind === "READY") {
+          setPreviewModels(preview.models)
+          setPreviewError(null)
+        } else {
+          setPreviewModels([])
+          setPreviewError(
+            preview.reason ??
+              "Could not load model catalog for the selected Agent Backend",
+          )
+        }
+      } catch (error) {
+        if (generation !== previewGenerationRef.current) {
+          return
+        }
+        setPreviewModels([])
+        setPreviewError(
+          error instanceof Error
+            ? error.message
+            : "Could not preview the selected Agent Backend",
+        )
+      } finally {
+        if (generation === previewGenerationRef.current) {
+          setPreviewPending(false)
+        }
+      }
+    })()
+  }, [settingsOpen, harnessDefaultBackendFromConfig, selectedAgentBackend])
+
+  const inheritHarnessBuildModel = (): string => {
+    if (harnessPrefsForDraft !== null) {
+      return harnessPrefsForDraft.defaultModel ?? "not configured"
+    }
+    if (draftEffective === harnessDefaultBackendId) {
+      return config.data?.defaultModel ?? "not configured"
+    }
+    return "not configured"
+  }
+  const inheritHarnessBuildVariant = (): string => {
+    if (harnessPrefsForDraft !== null) {
+      return harnessPrefsForDraft.defaultThinkingLevel ?? "not configured"
+    }
+    if (draftEffective === harnessDefaultBackendId) {
+      return config.data?.defaultThinkingLevel ?? "not configured"
+    }
+    return "not configured"
+  }
+  const harnessDefaultModel = inheritHarnessBuildModel()
+  const harnessDefaultVariant = inheritHarnessBuildVariant()
+  const resolvedBuildModel =
+    defaultModel.length > 0 ? defaultModel : harnessDefaultModel
   const resolvedBuildVariant =
-    repository.defaultThinkingLevel ?? harnessDefaultVariant
-  const harnessReviewModel =
-    config.data?.reviewModel ?? `Build (${resolvedBuildModel})`
-  const harnessReviewVariant =
-    config.data?.reviewThinkingLevel ?? `Build (${resolvedBuildVariant})`
-  const modelIds = (models.data ?? []).map((model) => model.id)
+    defaultThinkingLevel.length > 0
+      ? defaultThinkingLevel
+      : harnessDefaultVariant
+  const inheritHarnessReviewModel = (): string => {
+    if (harnessPrefsForDraft !== null) {
+      return harnessPrefsForDraft.reviewModel ?? `Build (${resolvedBuildModel})`
+    }
+    if (draftEffective === harnessDefaultBackendId) {
+      return config.data?.reviewModel ?? `Build (${resolvedBuildModel})`
+    }
+    return `Build (${resolvedBuildModel})`
+  }
+  const inheritHarnessReviewVariant = (): string => {
+    if (harnessPrefsForDraft !== null) {
+      return (
+        harnessPrefsForDraft.reviewThinkingLevel ??
+        `Build (${resolvedBuildVariant})`
+      )
+    }
+    if (draftEffective === harnessDefaultBackendId) {
+      return (
+        config.data?.reviewThinkingLevel ?? `Build (${resolvedBuildVariant})`
+      )
+    }
+    return `Build (${resolvedBuildVariant})`
+  }
+  const harnessReviewModel = inheritHarnessReviewModel()
+  const harnessReviewVariant = inheritHarnessReviewVariant()
+
+  // Global models query catalogs only the harness default backend. Effective
+  // override catalogs (saved or draft) come from Preview.
+  const usesPreviewCatalog = draftEffective !== harnessDefaultBackendId
+  const catalogModels: readonly AgentModelOption[] | undefined =
+    usesPreviewCatalog ? (previewModels ?? undefined) : models.data
+  const modelIds = (catalogModels ?? []).map((model) => model.id)
+  const harnessBuildForSource =
+    harnessDefaultModel !== "not configured" ? harnessDefaultModel : ""
+  const harnessReviewForSource = !harnessReviewModel.startsWith("Build (")
+    ? harnessReviewModel
+    : ""
   const buildVariantSourceModel =
-    defaultModel.length > 0 ? defaultModel : (config.data?.defaultModel ?? "")
+    defaultModel.length > 0 ? defaultModel : harnessBuildForSource
   const reviewThinkingLevelSourceModel =
     reviewModel.length > 0
       ? reviewModel
       : defaultModel.length > 0
         ? defaultModel
-        : (config.data?.reviewModel ?? config.data?.defaultModel ?? "")
-  const buildVariants = variantsForModel(models.data, buildVariantSourceModel)
+        : harnessReviewForSource.length > 0
+          ? harnessReviewForSource
+          : harnessBuildForSource
+  const buildVariants = variantsForModel(catalogModels, buildVariantSourceModel)
   const reviewThinkingLevels = variantsForModel(
-    models.data,
+    catalogModels,
     reviewThinkingLevelSourceModel,
   )
   const hasUnavailableBuildModel =
@@ -937,6 +1248,23 @@ function RepositoryCard({
     reviewThinkingLevel.length > 0 &&
     (reviewThinkingLevelSourceUnavailable ||
       !reviewThinkingLevels.includes(reviewThinkingLevel))
+  const modelsDisabled =
+    usesPreviewCatalog && (previewPending || previewError !== null)
+  const modelsLoading =
+    settingsOpen &&
+    (usesPreviewCatalog
+      ? previewPending || config.isPending
+      : models.isPending || config.isPending || agentBackends.isPending)
+  // Only enforce "model not in catalog" when a catalog actually loaded.
+  // Failed/pending override preview leaves modelIds empty and must not block
+  // non-model saves for the current effective backend.
+  const catalogReadyForModelValidation = usesPreviewCatalog
+    ? !previewPending && previewError === null && previewModels !== null
+    : !models.isPending && !models.isError && models.data !== undefined
+  const blockSaveForUnavailableBuildModel =
+    catalogReadyForModelValidation &&
+    defaultModel.length > 0 &&
+    hasUnavailableBuildModel
 
   const removeRepository = useMutation({
     mutationFn: async () => {
@@ -954,6 +1282,10 @@ function RepositoryCard({
       queryClient.removeQueries({ queryKey: ["issues", repositoryId] })
       await queryClient.invalidateQueries({
         queryKey: repositoriesQuery.queryKey,
+      })
+      // Dropping a repo may shrink selected-or-in-use Active backends.
+      void queryClient.invalidateQueries({
+        queryKey: ["agentBackendStatus"],
       })
     },
   })
@@ -1253,7 +1585,8 @@ function RepositoryCard({
             </h2>
             <p className="mt-1.5 text-sm text-ink-soft">
               Overrides apply on the next Agent Turn. Empty model fields use
-              harness defaults.
+              harness defaults for this Repository&apos;s effective Agent
+              Backend.
             </p>
           </div>
           <div className="grid gap-5 px-6 py-5">
@@ -1295,9 +1628,70 @@ function RepositoryCard({
                 Relevant Issues from every author after Refresh
               </span>
             </label>
-            {models.isPending ? (
+
+            <label className="grid min-w-0 gap-1.5 text-sm font-semibold">
+              Agent Backend
+              <select
+                className="w-full min-w-0 border border-rule-2 bg-paper px-3 py-2 text-sm font-normal outline-none focus:border-oxblood focus:ring-2 focus:ring-oxblood/15 disabled:cursor-not-allowed disabled:opacity-60"
+                name="selectedAgentBackend"
+                value={selectedAgentBackend ?? HARNESS_DEFAULT_BACKEND_VALUE}
+                disabled={
+                  backendChangeBlocked ||
+                  updateSettings.isPending ||
+                  agentBackends.isPending
+                }
+                onChange={(event) => {
+                  applyAgentBackendSelection(event.target.value)
+                }}
+              >
+                <option value={HARNESS_DEFAULT_BACKEND_VALUE}>
+                  Harness default ({harnessDefaultBackendLabel})
+                </option>
+                {selectedAgentBackend !== null &&
+                  !(agentBackends.data ?? []).some(
+                    (backend) => backend.id === selectedAgentBackend,
+                  ) && (
+                    <option value={selectedAgentBackend}>
+                      {selectedAgentBackend}
+                    </option>
+                  )}
+                {(agentBackends.data ?? []).map((backend) => (
+                  <option key={backend.id} value={backend.id}>
+                    {backend.label}
+                  </option>
+                ))}
+              </select>
+              <span className="text-xs font-normal text-ink-faint">
+                {backendChangeBlocked
+                  ? `${repository.blockingUnfinishedWorkItemCount} unfinished Work Item${
+                      repository.blockingUnfinishedWorkItemCount === 1
+                        ? ""
+                        : "s"
+                    } on this Repository — finish or abandon them before changing Agent Backend.`
+                  : "Harness default inherits the global selection. Override activates on Save when the effective backend changes. Model fields in this dialog are stashed per backend while open; empty means inherit harness for that effective backend."}
+              </span>
+            </label>
+
+            {agentBackends.isError && (
+              <p className="border border-oxblood/40 bg-oxblood-wash p-3 text-sm text-oxblood-deep">
+                Agent Backends list could not be loaded. You can still inherit
+                the harness default; override options may be incomplete.
+              </p>
+            )}
+
+            {usesPreviewCatalog && previewError !== null && (
+              <p className="border border-oxblood/40 bg-oxblood-wash p-3 text-sm text-oxblood-deep">
+                Preview failed: {previewError}. Model fields stay disabled until
+                preview succeeds.
+                {backendDraftChanging
+                  ? " Changing the effective backend cannot be saved until preview succeeds."
+                  : " Non-model settings can still be saved."}
+              </p>
+            )}
+
+            {modelsLoading ? (
               <p className="text-sm text-ink-soft">Loading models...</p>
-            ) : models.isError ? (
+            ) : !usesPreviewCatalog && models.isError ? (
               <p className="border border-oxblood/40 bg-oxblood-wash p-3 text-sm text-oxblood-deep">
                 Models could not be loaded.
               </p>
@@ -1306,17 +1700,16 @@ function RepositoryCard({
                 <label className="grid min-w-0 gap-1.5 text-sm font-semibold">
                   Build model
                   <select
-                    className="w-full min-w-0 border border-rule-2 bg-paper px-3 py-2 font-mono text-sm font-normal outline-none focus:border-oxblood focus:ring-2 focus:ring-oxblood/15"
+                    className="w-full min-w-0 border border-rule-2 bg-paper px-3 py-2 font-mono text-sm font-normal outline-none focus:border-oxblood focus:ring-2 focus:ring-oxblood/15 disabled:cursor-not-allowed disabled:opacity-60"
                     value={defaultModel}
+                    disabled={modelsDisabled}
                     onChange={(event) => {
                       const nextModel = event.target.value
                       setDefaultModel(nextModel)
                       const sourceModel =
-                        nextModel.length > 0
-                          ? nextModel
-                          : (config.data?.defaultModel ?? "")
+                        nextModel.length > 0 ? nextModel : harnessBuildForSource
                       const nextVariants = variantsForModel(
-                        models.data,
+                        catalogModels,
                         sourceModel,
                       )
                       setDefaultVariant((current) =>
@@ -1326,13 +1719,13 @@ function RepositoryCard({
                         const reviewSource =
                           nextModel.length > 0
                             ? nextModel
-                            : (config.data?.reviewModel ??
-                              config.data?.defaultModel ??
-                              "")
+                            : harnessReviewForSource.length > 0
+                              ? harnessReviewForSource
+                              : harnessBuildForSource
                         setReviewVariant((current) =>
                           reconcileVariantForModel(
                             current,
-                            variantsForModel(models.data, reviewSource),
+                            variantsForModel(catalogModels, reviewSource),
                           ),
                         )
                       }
@@ -1346,7 +1739,7 @@ function RepositoryCard({
                         {defaultModel} (not in Agent Model catalog)
                       </option>
                     )}
-                    {models.data.map((model) => (
+                    {(catalogModels ?? []).map((model) => (
                       <option key={model.id} value={model.id}>
                         {model.id}
                       </option>
@@ -1371,14 +1764,15 @@ function RepositoryCard({
                   <label className="grid min-w-0 gap-1.5 text-sm font-semibold">
                     Build thinking level
                     <select
-                      className="w-full min-w-0 border border-rule-2 bg-paper px-3 py-2 text-sm font-normal outline-none focus:border-oxblood focus:ring-2 focus:ring-oxblood/15"
+                      className="w-full min-w-0 border border-rule-2 bg-paper px-3 py-2 text-sm font-normal outline-none focus:border-oxblood focus:ring-2 focus:ring-oxblood/15 disabled:cursor-not-allowed disabled:opacity-60"
                       value={defaultThinkingLevel}
                       onChange={(event) =>
                         setDefaultVariant(event.target.value)
                       }
                       disabled={
-                        buildVariantSourceModel.length > 0 &&
-                        buildVariants.length === 0
+                        modelsDisabled ||
+                        (buildVariantSourceModel.length > 0 &&
+                          buildVariants.length === 0)
                       }
                     >
                       <option value="">
@@ -1400,8 +1794,9 @@ function RepositoryCard({
                 <label className="grid min-w-0 gap-1.5 text-sm font-semibold">
                   Review model
                   <select
-                    className="w-full min-w-0 border border-rule-2 bg-paper px-3 py-2 font-mono text-sm font-normal outline-none focus:border-oxblood focus:ring-2 focus:ring-oxblood/15"
+                    className="w-full min-w-0 border border-rule-2 bg-paper px-3 py-2 font-mono text-sm font-normal outline-none focus:border-oxblood focus:ring-2 focus:ring-oxblood/15 disabled:cursor-not-allowed disabled:opacity-60"
                     value={reviewModel}
+                    disabled={modelsDisabled}
                     onChange={(event) => {
                       const nextModel = event.target.value
                       setReviewModel(nextModel)
@@ -1410,13 +1805,13 @@ function RepositoryCard({
                           ? nextModel
                           : defaultModel.length > 0
                             ? defaultModel
-                            : (config.data?.reviewModel ??
-                              config.data?.defaultModel ??
-                              "")
+                            : harnessReviewForSource.length > 0
+                              ? harnessReviewForSource
+                              : harnessBuildForSource
                       setReviewVariant((current) =>
                         reconcileVariantForModel(
                           current,
-                          variantsForModel(models.data, sourceModel),
+                          variantsForModel(catalogModels, sourceModel),
                         ),
                       )
                     }}
@@ -1429,7 +1824,7 @@ function RepositoryCard({
                         {reviewModel} (not in Agent Model catalog)
                       </option>
                     )}
-                    {models.data.map((model) => (
+                    {(catalogModels ?? []).map((model) => (
                       <option key={`review-${model.id}`} value={model.id}>
                         {model.id}
                       </option>
@@ -1454,12 +1849,13 @@ function RepositoryCard({
                   <label className="grid min-w-0 gap-1.5 text-sm font-semibold">
                     Review thinking level
                     <select
-                      className="w-full min-w-0 border border-rule-2 bg-paper px-3 py-2 text-sm font-normal outline-none focus:border-oxblood focus:ring-2 focus:ring-oxblood/15"
+                      className="w-full min-w-0 border border-rule-2 bg-paper px-3 py-2 text-sm font-normal outline-none focus:border-oxblood focus:ring-2 focus:ring-oxblood/15 disabled:cursor-not-allowed disabled:opacity-60"
                       value={reviewThinkingLevel}
                       onChange={(event) => setReviewVariant(event.target.value)}
                       disabled={
-                        reviewThinkingLevelSourceModel.length > 0 &&
-                        reviewThinkingLevels.length === 0
+                        modelsDisabled ||
+                        (reviewThinkingLevelSourceModel.length > 0 &&
+                          reviewThinkingLevels.length === 0)
                       }
                     >
                       <option value="">
@@ -1482,7 +1878,9 @@ function RepositoryCard({
             )}
             {updateSettings.isError && (
               <p className="border border-oxblood/40 bg-oxblood-wash p-3 text-sm text-oxblood-deep">
-                Settings could not be saved. Try again.
+                {updateSettings.error instanceof Error
+                  ? updateSettings.error.message
+                  : "Settings could not be saved. Try again."}
               </p>
             )}
           </div>
@@ -1501,7 +1899,19 @@ function RepositoryCard({
             <button
               type="submit"
               className="bg-oxblood px-4 py-2 text-sm font-semibold tracking-wide text-paper uppercase hover:bg-oxblood-deep disabled:cursor-wait disabled:opacity-60"
-              disabled={updateSettings.isPending}
+              disabled={
+                updateSettings.isPending ||
+                (backendChangeBlocked &&
+                  selectedAgentBackend !== repository.selectedAgentBackend) ||
+                (backendDraftChanging && modelsLoading) ||
+                (backendDraftChanging &&
+                  usesPreviewCatalog &&
+                  !catalogReadyForModelValidation) ||
+                (backendDraftChanging &&
+                  usesPreviewCatalog &&
+                  previewError !== null) ||
+                blockSaveForUnavailableBuildModel
+              }
             >
               {updateSettings.isPending ? "Saving..." : "Save"}
             </button>
@@ -1532,13 +1942,32 @@ function RepositoryCard({
             </div>
             <div className="flex min-w-0 items-baseline gap-1.5 text-xs">
               <dt className="shrink-0 font-mono font-semibold tracking-[0.12em] text-ink-faint uppercase">
+                Agent Backend:
+              </dt>
+              <dd className="m-0 min-w-0 truncate font-mono text-ink-2">
+                {repository.selectedAgentBackend === null
+                  ? `Harness default (${repository.effectiveAgentBackend})`
+                  : repository.effectiveAgentBackend}
+              </dd>
+            </div>
+            <div className="flex min-w-0 items-baseline gap-1.5 text-xs">
+              <dt className="shrink-0 font-mono font-semibold tracking-[0.12em] text-ink-faint uppercase">
                 Build model:
               </dt>
               <dd className="m-0 min-w-0 truncate font-mono text-ink-2">
-                {repository.defaultModel ?? `Default (${harnessDefaultModel})`}
+                {repository.defaultModel ??
+                  (repository.selectedAgentBackend === null
+                    ? `Default (${
+                        config.data?.defaultModel ?? "not configured"
+                      })`
+                    : "Harness default")}
                 {" · "}
                 {repository.defaultThinkingLevel ??
-                  `Default (${harnessDefaultVariant})`}
+                  (repository.selectedAgentBackend === null
+                    ? `Default (${
+                        config.data?.defaultThinkingLevel ?? "not configured"
+                      })`
+                    : "Harness default")}
               </dd>
             </div>
             <div className="flex min-w-0 items-baseline gap-1.5 text-xs">
@@ -1546,10 +1975,29 @@ function RepositoryCard({
                 Review model:
               </dt>
               <dd className="m-0 min-w-0 truncate font-mono text-ink-2">
-                {repository.reviewModel ?? `Default (${harnessReviewModel})`}
+                {repository.reviewModel ??
+                  (repository.selectedAgentBackend === null
+                    ? `Default (${
+                        config.data?.reviewModel ??
+                        `Build (${
+                          repository.defaultModel ??
+                          config.data?.defaultModel ??
+                          "not configured"
+                        })`
+                      })`
+                    : "Harness default")}
                 {" · "}
                 {repository.reviewThinkingLevel ??
-                  `Default (${harnessReviewVariant})`}
+                  (repository.selectedAgentBackend === null
+                    ? `Default (${
+                        config.data?.reviewThinkingLevel ??
+                        `Build (${
+                          repository.defaultThinkingLevel ??
+                          config.data?.defaultThinkingLevel ??
+                          "not configured"
+                        })`
+                      })`
+                    : "Harness default")}
               </dd>
             </div>
             <div className="flex min-w-0 items-baseline gap-1.5 text-xs">

--- a/apps/harness/test/harness-settings-backend-change.test.ts
+++ b/apps/harness/test/harness-settings-backend-change.test.ts
@@ -16,12 +16,27 @@ describe("Harness settings Agent Backend change", () => {
     )
     expect(source).toContain("previewAgentBackend")
     expect(source).toContain("harnessModelPrefs")
-    expect(source).toContain("unfinishedWorkItemCount")
+    expect(source).toContain("blockingUnfinishedWorkItemCount")
     expect(source).toContain("backendChangeBlocked")
     expect(source).toContain("Activates immediately on Save")
     expect(source).not.toContain("Cleared — choose after restart")
     expect(source).not.toContain("Takes effect after restart")
     expect(source).not.toContain("RESTART_REQUIRED")
     expect(source).toContain('defaultModel: defaultModel.trim() === ""')
+  })
+
+  test("global settings use multi-backend status and recheck by backend id", () => {
+    const source = rootSource()
+    expect(source).toContain("agentBackendStatuses")
+    expect(source).toContain("recheckAgentBackend")
+    expect(source).toContain("__args: { backendId }")
+    expect(source).toContain("Recheck all")
+    expect(source).toContain("Active Agent Backends")
+    expect(source).toContain("Repositories inheriting the harness default")
+    expect(source).toContain("Default Agent Backend")
+    // First-run guidance is about the default build model, not a hard fleet freeze.
+    expect(source).toContain(
+      "fully configured Agent Backend override can still create work",
+    )
   })
 })

--- a/apps/harness/test/repository-settings-agent-backend.test.ts
+++ b/apps/harness/test/repository-settings-agent-backend.test.ts
@@ -1,0 +1,46 @@
+import { readFileSync } from "node:fs"
+import { join } from "node:path"
+import { describe, expect, test } from "bun:test"
+
+const indexSource = () =>
+  readFileSync(join(import.meta.dir, "../src/routes/index.tsx"), "utf8")
+
+describe("Repository settings Agent Backend override", () => {
+  test("offers harness-default option and places backend control above models", () => {
+    const source = indexSource()
+    expect(source).toContain("HARNESS_DEFAULT_BACKEND_VALUE")
+    expect(source).toContain("Harness default ({harnessDefaultBackendLabel})")
+    expect(source).toContain('name="selectedAgentBackend"')
+    expect(source).toContain("selectedAgentBackend: true")
+    expect(source).toContain("effectiveAgentBackend: true")
+    expect(source).toContain("blockingUnfinishedWorkItemCount: true")
+    expect(source).toContain("selectedAgentBackend: string | null")
+    expect(source).toContain("applyAgentBackendSelection")
+    expect(source).toContain("previewAgentBackend")
+    expect(source).toContain("harnessModelPrefs")
+
+    // Prefer the settings-dialog control (name=), not the card summary.
+    const backendSelectIndex = source.indexOf('name="selectedAgentBackend"')
+    const buildModelIndex = source.indexOf("Build model")
+    // Backend select must appear above the first Build model field in the dialog.
+    expect(backendSelectIndex).toBeGreaterThan(-1)
+    expect(buildModelIndex).toBeGreaterThan(backendSelectIndex)
+  })
+
+  test("disables backend change with scoped unfinished reason and saves override", () => {
+    const source = indexSource()
+    expect(source).toContain("backendChangeBlocked")
+    expect(source).toContain("blockingUnfinishedWorkItemCount")
+    expect(source).toContain("on this Repository")
+    expect(source).toMatch(
+      /updateSettings\.mutate\(\{[\s\S]*selectedAgentBackend,[\s\S]*\}\)/,
+    )
+    expect(source).toContain("selectedAgentBackend: string | null")
+  })
+
+  test("work item detail continues to show captured backend provenance", () => {
+    const source = indexSource()
+    expect(source).toContain("agentBackend: { id: true, label: true }")
+    expect(source).toContain("{workItem.agentBackend.label}")
+  })
+})


### PR DESCRIPTION
## Summary

- Add Repository settings Agent Backend override control (Harness default → null, built-ins above model fields) with preview catalog and dialog-session model stash.
- Extend global Harness Settings with multi-backend health strip, recheck by backend id / recheck-all, and scoped unfinished gates for the default backend.
- Keep live gate counts fresh (config + repositories on work-item events), once-per-open form hydrate, and Work Item captured-backend provenance in the UI.
- Add thin source smoke tests for multi-status/recheck and repository backend control.

Closes #469

## Test plan

- [x] `bunx nx test harness`
- [x] `bunx nx typecheck harness`
- [x] `bunx nx lint harness`
- [x] Pre-commit `nx affected` lint/typecheck/test on commit