### PR TITLE
fix(keymaxxer-service): prevent Keymaxxer dialogs from blocking GraphQL (#484)

### DIFF
--- a/packages/graphql-api/src/lib/graphql-api.ts
+++ b/packages/graphql-api/src/lib/graphql-api.ts
@@ -1,4 +1,11 @@
-import { Effect, type ManagedRuntime, Result, Semaphore, Stream } from "effect"
+import {
+  Duration,
+  Effect,
+  type ManagedRuntime,
+  Result,
+  Semaphore,
+  Stream,
+} from "effect"
 import { GraphQLError } from "graphql"
 import { createSchema, createYoga } from "graphql-yoga"
 import {
@@ -42,6 +49,7 @@ import {
   activatePollingIfCredentialed,
   githubTokenSecretName,
   repositoryCredential,
+  withKeymaxxerMetadataTimeout,
 } from "./repository-credentials.js"
 import { toGraphQLError } from "./to-graphql-error.js"
 import {
@@ -262,6 +270,13 @@ const toNativeResponse = (response: unknown): Response => {
   })
 }
 
+/**
+ * Bound for GraphQL-facing Keymaxxer metadata (list / find secret).
+ * Long enough for an operator unlock dialog; short enough that an abandoned
+ * wait does not freeze the Harness UI forever.
+ */
+export const DEFAULT_KEYMAXXER_METADATA_TIMEOUT = Duration.seconds(60)
+
 export const createGraphqlApi = (
   runtime: GraphqlRuntime,
   options: {
@@ -269,11 +284,18 @@ export const createGraphqlApi = (
     /** @deprecated Use agentBackendCwd */
     readonly opencodeCwd?: string
     readonly commandExists?: (command: string) => boolean
+    /**
+     * Bound for GraphQL Keymaxxer metadata waits (repositoryCredentials, etc.).
+     * Defaults to {@link DEFAULT_KEYMAXXER_METADATA_TIMEOUT}.
+     */
+    readonly keymaxxerMetadataTimeout?: Duration.Duration
   } = {},
 ) => {
   const agentBackendCwd =
     options.agentBackendCwd ?? options.opencodeCwd ?? process.cwd()
   const commandExists = options.commandExists ?? commandExistsOnPath
+  const keymaxxerMetadataTimeout =
+    options.keymaxxerMetadataTimeout ?? DEFAULT_KEYMAXXER_METADATA_TIMEOUT
   const tokenProvisioning = Effect.runSync(Semaphore.make(1))
 
   const runGraphql = <A>(
@@ -326,11 +348,15 @@ export const createGraphqlApi = (
                 const ambientAuthentication = keymaxxer.enabled === false
                 const tokenNames = ambientAuthentication
                   ? repositories.map(() => null)
-                  : yield* keymaxxer.findSecrets(
-                      repositories.map((repository) => ({
-                        provider: "github",
-                        account: `${repository.githubOwner}/${repository.githubRepo}`,
-                      })),
+                  : yield* withKeymaxxerMetadataTimeout(
+                      keymaxxer.findSecrets(
+                        repositories.map((repository) => ({
+                          provider: "github",
+                          account: `${repository.githubOwner}/${repository.githubRepo}`,
+                        })),
+                      ),
+                      keymaxxerMetadataTimeout,
+                      "findSecrets",
                     )
                 return repositories.map((repository, index) =>
                   repositoryCredential(
@@ -824,7 +850,9 @@ export const createGraphqlApi = (
               Effect.gen(function* () {
                 const db = yield* DbService
                 const added = yield* db.addRepository(args.input)
-                yield* activatePollingIfCredentialed(added).pipe(
+                yield* activatePollingIfCredentialed(added, {
+                  metadataTimeout: keymaxxerMetadataTimeout,
+                }).pipe(
                   Effect.catch((error) =>
                     Effect.logWarning(
                       "Automatic Repository polling was not activated",
@@ -859,18 +887,31 @@ export const createGraphqlApi = (
 
                     const keymaxxer = yield* KeymaxxerService
                     const account = `${repository.githubOwner}/${repository.githubRepo}`
-                    const existingToken = yield* keymaxxer.findSecret({
-                      provider: "github",
-                      account,
-                    })
+                    const existingToken = yield* withKeymaxxerMetadataTimeout(
+                      keymaxxer.findSecret({
+                        provider: "github",
+                        account,
+                      }),
+                      keymaxxerMetadataTimeout,
+                      "findSecret",
+                    )
                     let tokenName = existingToken
                     if (tokenName === null) {
                       tokenName = githubTokenSecretName(repository)
-                      if (yield* keymaxxer.hasSecret(tokenName)) {
+                      if (
+                        yield* withKeymaxxerMetadataTimeout(
+                          keymaxxer.hasSecret(tokenName),
+                          keymaxxerMetadataTimeout,
+                          "hasSecret",
+                        )
+                      ) {
                         return yield* new RepositoryCredentialError({
                           message: `Keymaxxer secret ${tokenName} already exists for another account`,
                         })
                       }
+                      // Interactive secret entry/approval: intentionally not
+                      // wrapped in the short metadata timeout. Holds
+                      // tokenProvisioning until the operator finishes or cancels.
                       const added = yield* keymaxxer.addSecret({
                         name: tokenName,
                         provider: "github",
@@ -885,10 +926,14 @@ export const createGraphqlApi = (
                           message: "Keymaxxer GitHub token setup was cancelled",
                         })
                       }
-                      tokenName = yield* keymaxxer.findSecret({
-                        provider: "github",
-                        account,
-                      })
+                      tokenName = yield* withKeymaxxerMetadataTimeout(
+                        keymaxxer.findSecret({
+                          provider: "github",
+                          account,
+                        }),
+                        keymaxxerMetadataTimeout,
+                        "findSecret",
+                      )
                       if (tokenName === null) {
                         return yield* new RepositoryCredentialError({
                           message:
@@ -958,19 +1003,13 @@ export const createGraphqlApi = (
                   })
                 }
 
-                const keymaxxer = yield* KeymaxxerService
-                if (keymaxxer.enabled !== false) {
-                  const credential = yield* keymaxxer.findSecret({
-                    provider: "github",
-                    account: `${repository.githubOwner}/${repository.githubRepo}`,
-                  })
-                  if (credential === null) {
-                    return yield* new RepositoryCredentialError({
-                      message: `GitHub credential is not configured for ${repository.githubOwner}/${repository.githubRepo}`,
-                    })
-                  }
-                }
-
+                // Accept promptly after Repository validation. Credential
+                // availability and reconciliation outcomes belong to job
+                // execution — do not block GraphQL on Keymaxxer dialogs.
+                // Acceptance is intentionally non-blocking; the Refresh Job
+                // worker may still wait on vault unlock or secret-use approval
+                // while reconciling (failure/progress is job status, not this
+                // mutation).
                 const jobId = yield* enqueueRefreshRepositoryJob(repository.id)
                 return {
                   id: jobId,

--- a/packages/graphql-api/src/lib/repository-credentials.ts
+++ b/packages/graphql-api/src/lib/repository-credentials.ts
@@ -1,5 +1,8 @@
-import { Data, Effect } from "effect"
-import { KeymaxxerService } from "@ready-for-agent/keymaxxer-service"
+import { Data, type Duration, Effect } from "effect"
+import {
+  KeymaxxerService,
+  keymaxxerError,
+} from "@ready-for-agent/keymaxxer-service"
 import { activateRepositoryPolling } from "./issue-polling.js"
 
 export type Repository = {
@@ -48,19 +51,56 @@ export const repositoryCredential = (
   githubTokenCreationUrl: githubTokenCreationUrl(repository),
 })
 
+/**
+ * Bound a GraphQL-facing Keymaxxer metadata effect.
+ *
+ * This is a **client-side** wait bound: the GraphQL fiber fails with an
+ * actionable error so the Harness UI unblocks. The underlying MCP/`tryPromise`
+ * Keymaxxer call is not aborted, so the Sidecar dialog lane may still be
+ * occupied until the operator dismisses the dialog or Keymaxxer returns.
+ * Plumbing AbortSignal through the HTTP MCP client is a separate change.
+ */
+export const withKeymaxxerMetadataTimeout = <A, E, R>(
+  effect: Effect.Effect<A, E, R>,
+  timeout: Duration.Duration,
+  operation = "metadata",
+): Effect.Effect<A, E | ReturnType<typeof keymaxxerError>, R> =>
+  effect.pipe(
+    Effect.timeout(timeout),
+    Effect.catchTag("TimeoutError", () =>
+      Effect.fail(
+        keymaxxerError(
+          operation,
+          "Keymaxxer did not respond in time (waiting for vault unlock or secret-use approval)",
+        ),
+      ),
+    ),
+  )
+
 /** Activate durable Issue Polling only when a GitHub token is already configured. */
 export const activatePollingIfCredentialed = Effect.fn(
   "graphql-api.activatePollingIfCredentialed",
-)(function* (repository: Repository) {
+)(function* (
+  repository: Repository,
+  options?: { readonly metadataTimeout?: Duration.Duration },
+) {
   const keymaxxer = yield* KeymaxxerService
   if (keymaxxer.enabled === false) {
     yield* activateRepositoryPolling(repository.id)
     return
   }
-  const credential = yield* keymaxxer.findSecret({
+  const lookup = keymaxxer.findSecret({
     provider: "github",
     account: `${repository.githubOwner}/${repository.githubRepo}`,
   })
+  const credential =
+    options?.metadataTimeout === undefined
+      ? yield* lookup
+      : yield* withKeymaxxerMetadataTimeout(
+          lookup,
+          options.metadataTimeout,
+          "findSecret",
+        )
   if (credential === null) return
   yield* activateRepositoryPolling(repository.id)
 })

--- a/packages/graphql-api/src/lib/to-graphql-error.ts
+++ b/packages/graphql-api/src/lib/to-graphql-error.ts
@@ -130,6 +130,11 @@ export const toGraphQLError = (error: unknown): GraphQLError => {
         error.message ?? "Repository credential error",
         "REPOSITORY_CREDENTIAL_ERROR",
       )
+    case "KeymaxxerError":
+      return gql(
+        error.message ?? "Keymaxxer operation failed",
+        "KEYMAXXER_ERROR",
+      )
     case "RepositoryAlreadyExistsError":
       return gql(
         `Repository ${error.githubOwner}/${error.githubRepo} already exists`,

--- a/packages/graphql-api/test/graphql-api.test.ts
+++ b/packages/graphql-api/test/graphql-api.test.ts
@@ -3434,12 +3434,7 @@ describe("GraphQL API", () => {
     runtime = makeRuntime(
       {},
       {
-        findSecret: ({ account, provider }) =>
-          Effect.succeed(
-            provider === "github" && account === "acme/widgets"
-              ? "GITHUB_TOKEN_ACME_WIDGETS"
-              : null,
-          ),
+        findSecret: () => Effect.die("must not inspect the vault on accept"),
       },
       {
         enqueue: (queueName, payload, options) =>
@@ -3528,6 +3523,45 @@ describe("GraphQL API", () => {
     expect(enqueued).toBe(true)
   })
 
+  test("bounds repositoryCredentials wait when Keymaxxer never resolves", async () => {
+    await runtime.dispose()
+    runtime = makeRuntime(
+      {},
+      {
+        findSecrets: () => Effect.never,
+      },
+    )
+
+    const started = Date.now()
+    const response = await createGraphqlApi(runtime, {
+      keymaxxerMetadataTimeout: Duration.millis(50),
+    }).fetch(
+      graphqlRequest({
+        query: `query {
+          repositoryCredentials {
+            repositoryId
+            configured
+          }
+        }`,
+      }),
+    )
+    const elapsedMs = Date.now() - started
+
+    expect(response.status).toBe(200)
+    expect(await response.json()).toEqual({
+      data: null,
+      errors: [
+        expect.objectContaining({
+          message: expect.stringMatching(
+            /Keymaxxer did not respond in time|vault unlock|secret-use approval/i,
+          ),
+          extensions: { code: "KEYMAXXER_ERROR" },
+        }),
+      ],
+    })
+    expect(elapsedMs).toBeLessThan(2_000)
+  })
+
   test("rejects refresh for an unknown repository without enqueueing", async () => {
     let enqueued = false
     await runtime.dispose()
@@ -3562,18 +3596,29 @@ describe("GraphQL API", () => {
     expect(enqueued).toBe(false)
   })
 
-  test("rejects refresh when the Repository has no GitHub credential", async () => {
+  test("accepts a Refresh Job without inspecting Keymaxxer credentials", async () => {
+    const jobId = makeJobId()
     let enqueued = false
+    let vaultInspected = false
     await runtime.dispose()
     runtime = makeRuntime(
       {},
       {
-        findSecret: () => Effect.succeed(null),
+        findSecret: () =>
+          Effect.sync(() => {
+            vaultInspected = true
+            return null
+          }),
+        findSecrets: () =>
+          Effect.sync(() => {
+            vaultInspected = true
+            return []
+          }),
       },
       {
         enqueue: () => {
           enqueued = true
-          return Effect.succeed(makeJobId())
+          return Effect.succeed(jobId)
         },
       },
     )
@@ -3591,24 +3636,22 @@ describe("GraphQL API", () => {
 
     expect(response.status).toBe(200)
     expect(await response.json()).toEqual({
-      data: null,
-      errors: [
-        expect.objectContaining({
-          message: expect.stringMatching(/credential|token|configured/i),
-          extensions: { code: "REPOSITORY_CREDENTIAL_ERROR" },
-        }),
-      ],
+      data: {
+        refreshRepository: {
+          id: jobId,
+          repositoryId: repository.id,
+        },
+      },
     })
-    expect(enqueued).toBe(false)
+    expect(enqueued).toBe(true)
+    expect(vaultInspected).toBe(false)
   })
 
   test("reports enqueue failure without accepting a Refresh Job", async () => {
     await runtime.dispose()
     runtime = makeRuntime(
       {},
-      {
-        findSecret: () => Effect.succeed("GITHUB_TOKEN_ACME_WIDGETS"),
-      },
+      {},
       {
         enqueue: () =>
           Effect.fail(

--- a/packages/keymaxxer-service/README.md
+++ b/packages/keymaxxer-service/README.md
@@ -26,6 +26,11 @@ result; transport, protocol, and execution failures use `KeymaxxerError`.
 
 - `startKeymaxxerFacade()` — Streamable HTTP MCP facade used by
   `apps/keymaxxer-sidecar` (one stdio keyholder; path capability auth).
+  Before the first `keymaxxer_run` / `keymaxxer_add`, it runs a serialized
+  `keymaxxer_list` unlock probe (wrong passphrase retried up to three times).
+  Once unlocked, metadata-only `keymaxxer_list` may proceed while a dialog
+  operation waits for secret-use approval. Side-effecting failures are not
+  replayed; transport failures invalidate the upstream for the next request.
 - `runKeymaxxerSidecarProcess()` — sidecar process body (listen, bootstrap URL,
   signals). Uses zod only for MCP SDK tool `inputSchema` registration; Effect
   client payloads use Schema.

--- a/packages/keymaxxer-service/src/lib/facade.ts
+++ b/packages/keymaxxer-service/src/lib/facade.ts
@@ -9,6 +9,21 @@ import { keymaxxerEnvironment, keymaxxerMcpCommand } from "./mcp-layer.js"
 
 export const KEYMAXXER_SIDECAR_URL_PREFIX = "KEYMAXXER_SIDECAR_URL="
 
+/** Max unlock probe attempts for wrong-passphrase failures (inclusive). */
+export const MAX_UNLOCK_ATTEMPTS = 3
+
+/**
+ * Keymaxxer 0.2.x returns `error: wrong passphrase.` as tool text (no structured
+ * code). Treat this as a safe pre-operation unlock failure that may be retried.
+ */
+export const isWrongPassphraseResult = (result: {
+  readonly isError?: boolean
+  readonly content?: unknown
+}): boolean => {
+  if (result.isError !== true) return false
+  return /error:\s*wrong passphrase\.?/i.test(toolResultText(result))
+}
+
 export const TOOL_NAMES = [
   "keymaxxer_list",
   "keymaxxer_run",
@@ -44,6 +59,12 @@ export type KeymaxxerUpstreamClient = {
   readonly close: () => Promise<void>
 }
 
+type UpstreamToolResult = {
+  content?: unknown
+  isError?: boolean
+  structuredContent?: unknown
+}
+
 const createCapability = () => randomBytes(32).toString("base64url")
 
 const constantTimeEqual = (a: string, b: string) => {
@@ -52,6 +73,22 @@ const constantTimeEqual = (a: string, b: string) => {
   if (ab.length !== bb.length) return false
   return timingSafeEqual(ab, bb)
 }
+
+const toolResultText = (result: { readonly content?: unknown }): string =>
+  Array.isArray(result.content)
+    ? result.content
+        .map((item: unknown) =>
+          typeof item === "object" &&
+          item !== null &&
+          "type" in item &&
+          item.type === "text" &&
+          "text" in item &&
+          typeof item.text === "string"
+            ? item.text
+            : "",
+        )
+        .join("\n")
+    : ""
 
 const makeDialogLane = () => {
   let chain: Promise<void> = Promise.resolve()
@@ -105,6 +142,16 @@ const createDefaultUpstream = async (
   }
 }
 
+const exhaustedUnlockError = (): UpstreamToolResult => ({
+  content: [
+    {
+      type: "text",
+      text: `error: vault unlock failed after ${MAX_UNLOCK_ATTEMPTS} attempts (wrong passphrase).`,
+    },
+  ],
+  isError: true,
+})
+
 export const startKeymaxxerFacade = async (
   options: StartFacadeOptions = {},
 ): Promise<FacadeHandle> => {
@@ -117,6 +164,8 @@ export const startKeymaxxerFacade = async (
   let upstream: KeymaxxerUpstreamClient | null = null
   let upstreamPromise: Promise<KeymaxxerUpstreamClient> | null = null
   let unlockObserved = false
+  /** Shared in-flight unlock so concurrent waiters share one probe outcome. */
+  let unlockInFlight: Promise<UpstreamToolResult> | null = null
 
   const ensureUpstream = () => {
     if (upstream) return Promise.resolve(upstream)
@@ -135,29 +184,145 @@ export const startKeymaxxerFacade = async (
     return upstreamPromise
   }
 
-  const forwardTool = async (name: string, args: Record<string, unknown>) => {
+  const callUpstream = async (
+    name: string,
+    args: Record<string, unknown>,
+  ): Promise<UpstreamToolResult> => {
     const client = await ensureUpstream()
-    const needsDialogLane =
-      name === "keymaxxer_run" || name === "keymaxxer_add" || !unlockObserved
+    try {
+      return await client.callTool({ name, arguments: args })
+    } catch (error) {
+      if (upstream === client) {
+        upstream = null
+        upstreamPromise = null
+        unlockObserved = false
+      }
+      await client.close().catch(() => undefined)
+      throw error
+    }
+  }
 
-    const call = async () => {
-      try {
-        const result = await client.callTool({ name, arguments: args })
-        if (!result.isError) unlockObserved = true
+  /**
+   * Note a locked-vault list failure so later traffic re-enters the unlock path.
+   * Wrong passphrase is the only Keymaxxer 0.2.x signal we treat as re-lock.
+   */
+  const noteListResult = (result: UpstreamToolResult): UpstreamToolResult => {
+    if (isWrongPassphraseResult(result)) {
+      unlockObserved = false
+    }
+    return result
+  }
+
+  /**
+   * Serialized unlock probe via metadata-only `keymaxxer_list`.
+   * Wrong passphrase is retried up to MAX_UNLOCK_ATTEMPTS; other failures are not.
+   * Must run inside the dialog lane (via {@link sharedUnlockProbe}).
+   */
+  const unlockProbe = async (): Promise<UpstreamToolResult> => {
+    if (unlockObserved) {
+      return noteListResult(await callUpstream("keymaxxer_list", {}))
+    }
+
+    log("[facade] waiting for vault unlock")
+
+    for (let attempt = 1; attempt <= MAX_UNLOCK_ATTEMPTS; attempt++) {
+      const result = await callUpstream("keymaxxer_list", {})
+      if (result.isError !== true) {
+        unlockObserved = true
         return result
-      } catch (error) {
-        if (upstream === client) {
-          upstream = null
-          upstreamPromise = null
-          unlockObserved = false
+      }
+
+      if (isWrongPassphraseResult(result)) {
+        if (attempt < MAX_UNLOCK_ATTEMPTS) {
+          log(
+            `[facade] vault unlock attempt ${attempt}/${MAX_UNLOCK_ATTEMPTS} failed (wrong passphrase); retrying`,
+          )
+          continue
         }
-        await client.close().catch(() => undefined)
+        log(
+          `[facade] vault unlock exhausted after ${MAX_UNLOCK_ATTEMPTS} wrong-passphrase attempts`,
+        )
+        return exhaustedUnlockError()
+      }
+
+      // Non-retryable unlock failure (e.g. no vault) — surface immediately.
+      return result
+    }
+
+    // Loop always returns on the final attempt; keep a defensive exhausted path.
+    return exhaustedUnlockError()
+  }
+
+  /**
+   * Single-flight unlock: concurrent waiters share one probe result.
+   * A later independent request may start a new probe after this settles.
+   */
+  const sharedUnlockProbe = (): Promise<UpstreamToolResult> => {
+    if (unlockInFlight !== null) return unlockInFlight
+    unlockInFlight = dialogLane(unlockProbe).then(
+      (result) => {
+        unlockInFlight = null
+        return result
+      },
+      (error) => {
+        unlockInFlight = null
         throw error
+      },
+    )
+    return unlockInFlight
+  }
+
+  /**
+   * Ensure the vault is unlocked before a dialog-producing operation.
+   * Success is decided from the probe result only — do not re-read the shared
+   * `unlockObserved` flag after the dialog lane releases (TOCTOU with transport
+   * recovery). Never return a successful list payload as a run/add outcome.
+   */
+  const ensureUnlocked = async (): Promise<UpstreamToolResult | null> => {
+    if (unlockObserved) return null
+    const result = await sharedUnlockProbe()
+    if (result.isError === true) {
+      return result
+    }
+    return null
+  }
+
+  const forwardTool = async (
+    name: string,
+    args: Record<string, unknown>,
+  ): Promise<UpstreamToolResult> => {
+    if (name === "keymaxxer_list") {
+      // Once unlocked, metadata-only list bypasses a run/add waiting on approval.
+      if (unlockObserved) {
+        return noteListResult(await callUpstream(name, args))
+      }
+      return sharedUnlockProbe()
+    }
+
+    // Dialog-producing operations: unlock first (separate dialog-lane acquisition
+    // so metadata list can proceed while this op later waits on approval), then
+    // re-check unlock inside the op lane before calling upstream. Re-check covers
+    // transport recovery or concurrent re-lock that clears unlockObserved after
+    // ensureUnlocked returned. Call unlockProbe directly here — not
+    // sharedUnlockProbe — to avoid re-entering dialogLane while holding it.
+    if (!unlockObserved) {
+      const unlockFailure = await ensureUnlocked()
+      if (unlockFailure !== null) {
+        return unlockFailure
       }
     }
 
-    if (needsDialogLane) return dialogLane(call)
-    return call()
+    return dialogLane(async () => {
+      if (!unlockObserved) {
+        log(`[facade] re-probing vault unlock before ${name}`)
+        const unlockResult = await unlockProbe()
+        if (unlockResult.isError === true) {
+          return unlockResult
+        }
+      }
+      log(`[facade] waiting for secret-use approval (${name})`)
+      return callUpstream(name, args)
+    })
   }
 
   const createServer = () => {

--- a/packages/keymaxxer-service/test/facade.test.ts
+++ b/packages/keymaxxer-service/test/facade.test.ts
@@ -3,9 +3,33 @@ import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/
 import {
   KEYMAXXER_SIDECAR_URL_PREFIX,
   type KeymaxxerUpstreamClient,
+  MAX_UNLOCK_ATTEMPTS,
+  isWrongPassphraseResult,
   startKeymaxxerFacade,
 } from "../src/index.js"
 import { describe, expect, test } from "bun:test"
+
+const listResult = (
+  secrets: Array<{ name: string; provider?: string; account?: string }> = [
+    { name: "DEMO", provider: "github", account: "acme/widgets" },
+  ],
+) => ({
+  content: [{ type: "text", text: JSON.stringify(secrets) }],
+})
+
+const wrongPassphraseResult = () => ({
+  content: [{ type: "text", text: "error: wrong passphrase." }],
+  isError: true as const,
+})
+
+const runOkResult = () => ({
+  content: [
+    {
+      type: "text",
+      text: "exit_code: 0\n--- stdout ---\nok\n--- stderr ---\n",
+    },
+  ],
+})
 
 const mockUpstream = (
   secrets: Array<{ name: string; provider?: string; account?: string }> = [
@@ -14,19 +38,10 @@ const mockUpstream = (
 ): KeymaxxerUpstreamClient => ({
   callTool: async ({ name }) => {
     if (name === "keymaxxer_list") {
-      return {
-        content: [{ type: "text", text: JSON.stringify(secrets) }],
-      }
+      return listResult(secrets)
     }
     if (name === "keymaxxer_run") {
-      return {
-        content: [
-          {
-            type: "text",
-            text: "exit_code: 0\n--- stdout ---\nok\n--- stderr ---\n",
-          },
-        ],
-      }
+      return runOkResult()
     }
     return { content: [{ type: "text", text: "ok" }] }
   },
@@ -39,6 +54,20 @@ const connectClient = async (url: string) => {
   await client.connect(transport)
   return { client, transport }
 }
+
+const toolText = (result: { content?: unknown }): string =>
+  Array.isArray(result.content)
+    ? result.content
+        .map((item: unknown) =>
+          typeof item === "object" &&
+          item !== null &&
+          "text" in item &&
+          typeof item.text === "string"
+            ? item.text
+            : "",
+        )
+        .join("\n")
+    : ""
 
 describe("Keymaxxer MCP facade security surface", () => {
   test("rejects Origin, wrong path, and has no health route", async () => {
@@ -193,5 +222,516 @@ describe("Keymaxxer MCP facade security surface", () => {
     } finally {
       process.stdout.write = originalWrite
     }
+  })
+
+  test("retries unlock probe after wrong passphrase then continues the original operation", async () => {
+    const calls: string[] = []
+    let listAttempts = 0
+    const facade = await startKeymaxxerFacade({
+      host: "127.0.0.1",
+      port: 0,
+      createUpstream: async () => ({
+        callTool: async ({ name }) => {
+          calls.push(name)
+          if (name === "keymaxxer_list") {
+            listAttempts += 1
+            if (listAttempts === 1) return wrongPassphraseResult()
+            return listResult()
+          }
+          if (name === "keymaxxer_run") return runOkResult()
+          return { content: [{ type: "text", text: "ok" }] }
+        },
+        close: async () => {},
+      }),
+      onBootstrapUrl: () => {},
+      log: () => {},
+    })
+
+    try {
+      const connection = await connectClient(facade.url)
+      try {
+        const result = await connection.client.callTool({
+          name: "keymaxxer_run",
+          arguments: {
+            command: "true",
+            secrets: ["DEMO"],
+          },
+        })
+        expect(result.isError).not.toBe(true)
+        expect(toolText(result)).toContain("exit_code: 0")
+        // Unlock probe (fail + success) then the original run — no generic re-run.
+        expect(calls).toEqual([
+          "keymaxxer_list",
+          "keymaxxer_list",
+          "keymaxxer_run",
+        ])
+        expect(listAttempts).toBe(2)
+      } finally {
+        await connection.transport.close()
+      }
+    } finally {
+      await facade.stop()
+    }
+  })
+
+  test("returns an actionable error after exhausted unlock retries", async () => {
+    let listAttempts = 0
+    const facade = await startKeymaxxerFacade({
+      host: "127.0.0.1",
+      port: 0,
+      createUpstream: async () => ({
+        callTool: async ({ name }) => {
+          if (name === "keymaxxer_list") {
+            listAttempts += 1
+            return wrongPassphraseResult()
+          }
+          throw new Error(`unexpected tool ${name}`)
+        },
+        close: async () => {},
+      }),
+      onBootstrapUrl: () => {},
+      log: () => {},
+    })
+
+    try {
+      const connection = await connectClient(facade.url)
+      try {
+        const result = await connection.client.callTool({
+          name: "keymaxxer_run",
+          arguments: {
+            command: "true",
+            secrets: ["DEMO"],
+          },
+        })
+        expect(result.isError).toBe(true)
+        expect(toolText(result)).toMatch(
+          /vault unlock failed after 3 attempts/i,
+        )
+        expect(toolText(result).toLowerCase()).toContain("wrong passphrase")
+        expect(listAttempts).toBe(MAX_UNLOCK_ATTEMPTS)
+      } finally {
+        await connection.transport.close()
+      }
+    } finally {
+      await facade.stop()
+    }
+  })
+
+  test("allows concurrent keymaxxer_list while keymaxxer_run waits on approval", async () => {
+    let releaseApproval!: () => void
+    const approvalGate = new Promise<void>((resolve) => {
+      releaseApproval = resolve
+    })
+    let runStarted = false
+    let listDuringApproval = 0
+    const runStartedSignal = Promise.withResolvers<void>()
+
+    const facade = await startKeymaxxerFacade({
+      host: "127.0.0.1",
+      port: 0,
+      createUpstream: async () => ({
+        callTool: async ({ name }) => {
+          if (name === "keymaxxer_list") {
+            if (runStarted) listDuringApproval += 1
+            return listResult()
+          }
+          if (name === "keymaxxer_run") {
+            runStarted = true
+            runStartedSignal.resolve()
+            await approvalGate
+            return runOkResult()
+          }
+          return { content: [{ type: "text", text: "ok" }] }
+        },
+        close: async () => {},
+      }),
+      onBootstrapUrl: () => {},
+      log: () => {},
+    })
+
+    try {
+      const [runner, lister] = await Promise.all([
+        connectClient(facade.url),
+        connectClient(facade.url),
+      ])
+      try {
+        // Establish unlocked state first so list can bypass the dialog lane.
+        const unlock = await lister.client.callTool({
+          name: "keymaxxer_list",
+          arguments: {},
+        })
+        expect(unlock.isError).not.toBe(true)
+
+        const runPromise = runner.client.callTool({
+          name: "keymaxxer_run",
+          arguments: {
+            command: "true",
+            secrets: ["DEMO"],
+          },
+        })
+
+        await runStartedSignal.promise
+
+        const listStarted = Date.now()
+        const listResultCall = await lister.client.callTool({
+          name: "keymaxxer_list",
+          arguments: {},
+        })
+        const listElapsedMs = Date.now() - listStarted
+
+        expect(listResultCall.isError).not.toBe(true)
+        expect(listDuringApproval).toBe(1)
+        // List must complete while run is still blocked on approval.
+        expect(listElapsedMs).toBeLessThan(500)
+
+        releaseApproval()
+        const runResult = await runPromise
+        expect(runResult.isError).not.toBe(true)
+      } finally {
+        await runner.transport.close()
+        await lister.transport.close()
+      }
+    } finally {
+      await facade.stop()
+    }
+  })
+
+  test("shares one unlock probe across concurrent first operations", async () => {
+    let listAttempts = 0
+    let unlockHold!: () => void
+    const unlockGate = new Promise<void>((resolve) => {
+      unlockHold = resolve
+    })
+    const firstListStarted = Promise.withResolvers<void>()
+
+    const facade = await startKeymaxxerFacade({
+      host: "127.0.0.1",
+      port: 0,
+      createUpstream: async () => ({
+        callTool: async ({ name }) => {
+          if (name === "keymaxxer_list") {
+            listAttempts += 1
+            if (listAttempts === 1) firstListStarted.resolve()
+            await unlockGate
+            return listResult()
+          }
+          if (name === "keymaxxer_run") return runOkResult()
+          return { content: [{ type: "text", text: "ok" }] }
+        },
+        close: async () => {},
+      }),
+      onBootstrapUrl: () => {},
+      log: () => {},
+    })
+
+    try {
+      const [a, b] = await Promise.all([
+        connectClient(facade.url),
+        connectClient(facade.url),
+      ])
+      try {
+        const runA = a.client.callTool({
+          name: "keymaxxer_run",
+          arguments: { command: "true", secrets: ["DEMO"] },
+        })
+        const runB = b.client.callTool({
+          name: "keymaxxer_run",
+          arguments: { command: "true", secrets: ["DEMO"] },
+        })
+        await firstListStarted.promise
+        // Still gated on unlock — concurrent waiters must not start a second probe.
+        expect(listAttempts).toBe(1)
+        unlockHold()
+        const [resultA, resultB] = await Promise.all([runA, runB])
+        expect(resultA.isError).not.toBe(true)
+        expect(resultB.isError).not.toBe(true)
+        // One shared unlock list, then two runs (serialized on dialog lane).
+        expect(listAttempts).toBe(1)
+      } finally {
+        await a.transport.close()
+        await b.transport.close()
+      }
+    } finally {
+      await facade.stop()
+    }
+  })
+
+  test("re-probes unlock before run when unlockObserved was cleared after ensureUnlocked", async () => {
+    const calls: string[] = []
+    let runCalls = 0
+    let releaseFirstRun!: () => void
+    const firstRunGate = new Promise<void>((resolve) => {
+      releaseFirstRun = resolve
+    })
+    const firstRunStarted = Promise.withResolvers<void>()
+
+    const facade = await startKeymaxxerFacade({
+      host: "127.0.0.1",
+      port: 0,
+      createUpstream: async () => ({
+        callTool: async ({ name }) => {
+          calls.push(name)
+          if (name === "keymaxxer_list") return listResult()
+          if (name === "keymaxxer_run") {
+            runCalls += 1
+            if (runCalls === 1) {
+              firstRunStarted.resolve()
+              await firstRunGate
+              throw new Error("keyholder exited mid-run")
+            }
+            return runOkResult()
+          }
+          return { content: [{ type: "text", text: "ok" }] }
+        },
+        close: async () => {},
+      }),
+      onBootstrapUrl: () => {},
+      log: () => {},
+    })
+
+    try {
+      const [a, b] = await Promise.all([
+        connectClient(facade.url),
+        connectClient(facade.url),
+      ])
+      try {
+        // Establish unlocked state so both runs skip the outer ensureUnlocked.
+        await a.client.callTool({ name: "keymaxxer_list", arguments: {} })
+        const listAfterUnlock = calls.filter(
+          (c) => c === "keymaxxer_list",
+        ).length
+
+        const runA = a.client.callTool({
+          name: "keymaxxer_run",
+          arguments: { command: "true", secrets: ["DEMO"] },
+        })
+        await firstRunStarted.promise
+
+        // Second run is past ensureUnlocked (still unlocked) and queues on the
+        // dialog lane behind the first run. When the first throws, unlock is
+        // cleared; the second must re-probe with list before keymaxxer_run.
+        const runB = b.client.callTool({
+          name: "keymaxxer_run",
+          arguments: { command: "true", secrets: ["DEMO"] },
+        })
+
+        // Let B enqueue on the dialog lane before A fails and clears unlock.
+        await Bun.sleep(50)
+        releaseFirstRun()
+
+        const [resultA, resultB] = await Promise.all([runA, runB])
+        expect(resultA.isError).toBe(true)
+        expect(resultB.isError).not.toBe(true)
+        expect(toolText(resultB)).toContain("exit_code: 0")
+
+        const listAfter = calls.filter((c) => c === "keymaxxer_list").length
+        expect(listAfter).toBeGreaterThan(listAfterUnlock)
+        // Final successful path is list re-probe then run (not bare run).
+        const lastList = calls.lastIndexOf("keymaxxer_list")
+        const lastRun = calls.lastIndexOf("keymaxxer_run")
+        expect(lastList).toBeGreaterThan(-1)
+        expect(lastRun).toBeGreaterThan(lastList)
+      } finally {
+        await a.transport.close()
+        await b.transport.close()
+      }
+    } finally {
+      await facade.stop()
+    }
+  })
+
+  test("does not return unlock list payload as keymaxxer_run result after unlock", async () => {
+    const facade = await startKeymaxxerFacade({
+      host: "127.0.0.1",
+      port: 0,
+      createUpstream: async () => ({
+        callTool: async ({ name }) => {
+          if (name === "keymaxxer_list") return listResult()
+          if (name === "keymaxxer_run") return runOkResult()
+          return { content: [{ type: "text", text: "ok" }] }
+        },
+        close: async () => {},
+      }),
+      onBootstrapUrl: () => {},
+      log: () => {},
+    })
+
+    try {
+      const connection = await connectClient(facade.url)
+      try {
+        const result = await connection.client.callTool({
+          name: "keymaxxer_run",
+          arguments: { command: "true", secrets: ["DEMO"] },
+        })
+        expect(result.isError).not.toBe(true)
+        // Run result shape, not the unlock probe's secret metadata list JSON.
+        expect(toolText(result)).toContain("exit_code: 0")
+        expect(toolText(result)).not.toContain('"name":"DEMO"')
+      } finally {
+        await connection.transport.close()
+      }
+    } finally {
+      await facade.stop()
+    }
+  })
+
+  test("re-enters unlock path after wrong-passphrase list once unlocked", async () => {
+    let listCalls = 0
+    const facade = await startKeymaxxerFacade({
+      host: "127.0.0.1",
+      port: 0,
+      createUpstream: async () => ({
+        callTool: async ({ name }) => {
+          if (name === "keymaxxer_list") {
+            listCalls += 1
+            // First list unlocks; second simulates idle re-lock wrong passphrase.
+            if (listCalls === 1) return listResult()
+            if (listCalls === 2) return wrongPassphraseResult()
+            return listResult()
+          }
+          return { content: [{ type: "text", text: "ok" }] }
+        },
+        close: async () => {},
+      }),
+      onBootstrapUrl: () => {},
+      log: () => {},
+    })
+
+    try {
+      const connection = await connectClient(facade.url)
+      try {
+        const unlocked = await connection.client.callTool({
+          name: "keymaxxer_list",
+          arguments: {},
+        })
+        expect(unlocked.isError).not.toBe(true)
+
+        const locked = await connection.client.callTool({
+          name: "keymaxxer_list",
+          arguments: {},
+        })
+        expect(locked.isError).toBe(true)
+
+        // After wrong passphrase, a subsequent list should re-probe unlock.
+        const again = await connection.client.callTool({
+          name: "keymaxxer_list",
+          arguments: {},
+        })
+        expect(again.isError).not.toBe(true)
+        expect(listCalls).toBe(3)
+      } finally {
+        await connection.transport.close()
+      }
+    } finally {
+      await facade.stop()
+    }
+  })
+
+  test("probes unlock with keymaxxer_list before the first keymaxxer_run", async () => {
+    const calls: string[] = []
+    const facade = await startKeymaxxerFacade({
+      host: "127.0.0.1",
+      port: 0,
+      createUpstream: async () => ({
+        callTool: async ({ name }) => {
+          calls.push(name)
+          if (name === "keymaxxer_list") return listResult()
+          if (name === "keymaxxer_run") return runOkResult()
+          return { content: [{ type: "text", text: "ok" }] }
+        },
+        close: async () => {},
+      }),
+      onBootstrapUrl: () => {},
+      log: () => {},
+    })
+
+    try {
+      const connection = await connectClient(facade.url)
+      try {
+        await connection.client.callTool({
+          name: "keymaxxer_run",
+          arguments: { command: "true", secrets: ["DEMO"] },
+        })
+        expect(calls).toEqual(["keymaxxer_list", "keymaxxer_run"])
+      } finally {
+        await connection.transport.close()
+      }
+    } finally {
+      await facade.stop()
+    }
+  })
+
+  test("does not replay a side-effecting request after transport failure", async () => {
+    let upstreamSpawns = 0
+    let runCalls = 0
+    const facade = await startKeymaxxerFacade({
+      host: "127.0.0.1",
+      port: 0,
+      createUpstream: async () => {
+        upstreamSpawns += 1
+        if (upstreamSpawns === 1) {
+          return {
+            callTool: async ({ name }) => {
+              if (name === "keymaxxer_list") return listResult()
+              runCalls += 1
+              throw new Error("keyholder exited mid-run")
+            },
+            close: async () => {},
+          }
+        }
+        return {
+          callTool: async ({ name }) => {
+            if (name === "keymaxxer_list") return listResult()
+            runCalls += 1
+            return runOkResult()
+          },
+          close: async () => {},
+        }
+      },
+      onBootstrapUrl: () => {},
+      log: () => {},
+    })
+
+    try {
+      const connection = await connectClient(facade.url)
+      try {
+        const failed = await connection.client.callTool({
+          name: "keymaxxer_run",
+          arguments: { command: "echo once", secrets: ["DEMO"] },
+        })
+        expect(failed.isError).toBe(true)
+        // Unlock probe + one failed run on the first keyholder.
+        expect(runCalls).toBe(1)
+        expect(upstreamSpawns).toBe(1)
+
+        const recovered = await connection.client.callTool({
+          name: "keymaxxer_list",
+          arguments: {},
+        })
+        expect(recovered.isError).not.toBe(true)
+        expect(upstreamSpawns).toBe(2)
+        // Recovery list does not re-run the failed side-effecting command.
+        expect(runCalls).toBe(1)
+      } finally {
+        await connection.transport.close()
+      }
+    } finally {
+      await facade.stop()
+    }
+  })
+
+  test("isWrongPassphraseResult detects Keymaxxer unlock text", () => {
+    expect(isWrongPassphraseResult(wrongPassphraseResult())).toBe(true)
+    expect(
+      isWrongPassphraseResult({
+        content: [{ type: "text", text: "error: no vault found." }],
+        isError: true,
+      }),
+    ).toBe(false)
+    expect(
+      isWrongPassphraseResult({
+        content: [{ type: "text", text: "error: wrong passphrase." }],
+      }),
+    ).toBe(false)
   })
 })


### PR DESCRIPTION
## Summary

- Separate vault unlock from secret-use approval in the Keymaxxer Sidecar facade (serialized `keymaxxer_list` unlock probe with bounded wrong-passphrase retries; post-unlock metadata list can proceed while `run`/`add` wait on approval).
- Accept `refreshRepository` after Repository validation without inspecting Keymaxxer; credential and reconciliation outcomes stay on Refresh Job execution.
- Bound GraphQL-facing Keymaxxer metadata waits and map timeouts to an actionable `KEYMAXXER_ERROR`.

Closes #484

## Test plan

- [x] `bunx nx run keymaxxer-service:test`
- [x] `bunx nx run graphql-api:test`
- [x] Pre-commit `nx affected` lint/typecheck/test on commit
- [ ] Manual: with vault locked / approval pending, confirm repository credential queries remain responsive and Refresh Job acceptance returns promptly