### PR TITLE
fix(keymaxxer-service): clarify operator interaction log

### DIFF
--- a/packages/keymaxxer-service/src/lib/facade.ts
+++ b/packages/keymaxxer-service/src/lib/facade.ts
@@ -320,7 +320,7 @@ export const startKeymaxxerFacade = async (
           return unlockResult
         }
       }
-      log(`[facade] waiting for secret-use approval (${name})`)
+      log(`[facade] ${name} may require operator interaction`)
       return callUpstream(name, args)
     })
   }


### PR DESCRIPTION
## Summary

- stop reporting every dialog-capable Keymaxxer operation as actively waiting for secret-use approval
- use a neutral operator-interaction diagnostic that also covers secret entry and operations that do not require approval

## Testing

- `bunx nx affected -t lint typecheck test --files=packages/keymaxxer-service/src/lib/facade.ts`
- pre-commit affected lint, typecheck, and test validation