### PR TITLE
feat(harness): polish Waiting for blockers Working-row chrome

### DIFF
--- a/apps/harness/src/routes/index.tsx
+++ b/apps/harness/src/routes/index.tsx
@@ -38,6 +38,7 @@ import { WorkItemOutcomePresentation } from "../work-item-outcome-presentation.j
 import {
   lifecycleStepChipClassName,
   statusBadgeClassNameForStatus,
+  statusMessageClassNameForStatus,
 } from "../work-item-progress-chrome.js"
 import { workItemPullRequestUrl } from "../work-item-pull-request-url.js"
 
@@ -3237,13 +3238,16 @@ function WorkItemLifecycleStatus({
 }) {
   const queryClient = useQueryClient()
   const status = workItem.status
-  const canRetry = compact && workItem.canRetry
+  const heldForBlockers = status === "WAITING_FOR_BLOCKERS"
+  // Queue hold: Retry is never offered; API also sets canRetry false.
+  const canRetry = compact && workItem.canRetry && !heldForBlockers
   const retriesStatusChecks =
     workItem.failureCode === "pr_status_checks_unresolved" ||
     workItem.state === "WATCH_PR_STATUS_CHECKS" ||
     workItem.state === "INVESTIGATE_PR_STATUS_CHECKS" ||
     (workItem.canRetry &&
       workItem.lifecycleLabels.at(-1)?.phase === "GITHUB_STATUS_CHECKS")
+  // Reset is the cancel affordance for held Queue rows (and compact jobs generally).
   const canReset = compact
   const dataUpdatedAt = queryClient
     .getQueriesData({ queryKey: ["work-items", workItem.repositoryId] })
@@ -3293,6 +3297,7 @@ function WorkItemLifecycleStatus({
   const actionsPending = retry.isPending || reset.isPending
   const prNumber = workItem.githubPullRequestNumber
   const statusBadgeClassName = statusBadgeClassNameForStatus(status)
+  const statusMessageClassName = statusMessageClassNameForStatus(status)
   const openPullRequestLabel =
     prNumber === null ? null : `Open pull request #${prNumber}`
   const isNoChangeComplete =
@@ -3366,14 +3371,7 @@ function WorkItemLifecycleStatus({
         </ol>
       )}
       {workItem.statusMessage !== null && (
-        <p
-          className={`mt-1.5 mb-0 text-xs ${
-            status === "WAITING_FOR_WORKER_SLOT" ||
-            status === "WAITING_FOR_BLOCKERS"
-              ? "text-violet-800"
-              : "text-oxblood-deep"
-          }`}
-        >
+        <p className={`mt-1.5 mb-0 text-xs ${statusMessageClassName}`}>
           {workItem.statusMessage}
         </p>
       )}

--- a/apps/harness/src/styles.css
+++ b/apps/harness/src/styles.css
@@ -22,6 +22,9 @@
   --color-oxblood-wash: #f0ddd9;
   --color-vermilion-wash: #f4e1d8;
   --color-violet-wash: #e7dff0;
+  /* Waiting for blockers (Queue hold) — distinct from violet Worker Slot wait */
+  --color-teal: #2f5d50;
+  --color-teal-wash: #e2ebe7;
   --font-serif:
     "Iowan Old Style", "Palatino Linotype", "URW Palladio L", Palatino,
     "Book Antiqua", Georgia, "Times New Roman", serif;

--- a/apps/harness/src/work-item-progress-chrome.ts
+++ b/apps/harness/src/work-item-progress-chrome.ts
@@ -10,6 +10,11 @@ export const statusBadgeBaseClassName = `inline-flex items-center border px-2 py
 
 export const prBadgeClassName = `stamp border-rule-2 ${jobsProgressMinTextClassName} text-ink-2 no-underline hover:border-oxblood hover:text-oxblood hover:underline`
 
+/**
+ * Badge tone by operator-visible status.
+ * Waiting for blockers (Queue hold) is teal — distinct from violet Waiting for
+ * Worker Slot and from bare Step Run / Agent Turn Queued (oxblood default).
+ */
 export function statusBadgeClassNameForStatus(status: string): string {
   const tone =
     status === "FAILED" || status === "INTERRUPTED"
@@ -20,9 +25,17 @@ export function statusBadgeClassNameForStatus(status: string): string {
           ? "border-rule-2 bg-paper-2 text-ink-faint"
           : status === "NEEDS_HUMAN" || status === "NEEDS_HUMAN_REVIEW"
             ? "border-sepia/40 bg-amber-wash text-sepia"
-            : status === "WAITING_FOR_WORKER_SLOT" ||
-                status === "WAITING_FOR_BLOCKERS"
+            : status === "WAITING_FOR_WORKER_SLOT"
               ? "border-violet-300 bg-violet-wash text-violet-800"
-              : "border-oxblood/30 bg-oxblood-wash text-oxblood"
+              : status === "WAITING_FOR_BLOCKERS"
+                ? "border-teal/40 bg-teal-wash text-teal"
+                : "border-oxblood/30 bg-oxblood-wash text-oxblood"
   return `${statusBadgeBaseClassName} ${tone}`
+}
+
+/** Message line tone under the status badge (wait holds vs failure copy). */
+export function statusMessageClassNameForStatus(status: string): string {
+  if (status === "WAITING_FOR_WORKER_SLOT") return "text-violet-800"
+  if (status === "WAITING_FOR_BLOCKERS") return "text-teal"
+  return "text-oxblood-deep"
 }

--- a/apps/harness/test/waiting-for-blockers-working-row.test.ts
+++ b/apps/harness/test/waiting-for-blockers-working-row.test.ts
@@ -1,0 +1,94 @@
+import { readFileSync } from "node:fs"
+import { join } from "node:path"
+import { describe, expect, test } from "bun:test"
+
+const homeSource = () =>
+  readFileSync(join(import.meta.dir, "../src/routes/index.tsx"), "utf8")
+
+const chromeSource = () =>
+  readFileSync(
+    join(import.meta.dir, "../src/work-item-progress-chrome.ts"),
+    "utf8",
+  )
+
+const stylesSource = () =>
+  readFileSync(join(import.meta.dir, "../src/styles.css"), "utf8")
+
+describe("Waiting for blockers Working-row polish", () => {
+  test("badge chrome uses teal for blockers, violet for worker slot, oxblood for Queued", () => {
+    const chrome = chromeSource()
+    expect(chrome).toContain('status === "WAITING_FOR_WORKER_SLOT"')
+    expect(chrome).toContain('status === "WAITING_FOR_BLOCKERS"')
+    expect(chrome).toContain("bg-teal-wash text-teal")
+    expect(chrome).toContain("bg-violet-wash text-violet-800")
+    expect(chrome).toContain("bg-oxblood-wash text-oxblood")
+    // Shared violet for both wait holds must not remain.
+    expect(chrome).not.toMatch(
+      /WAITING_FOR_WORKER_SLOT\s*\|\|\s*\n?\s*status === "WAITING_FOR_BLOCKERS"/,
+    )
+    expect(stylesSource()).toContain("--color-teal:")
+    expect(stylesSource()).toContain("--color-teal-wash:")
+  })
+
+  test("status message uses distinct wait-hold tones via shared helper", () => {
+    const source = homeSource()
+    expect(source).toContain("statusMessageClassNameForStatus")
+    expect(source).toContain("statusMessageClassName")
+    expect(chromeSource()).toContain(
+      "export function statusMessageClassNameForStatus",
+    )
+    expect(chromeSource()).toContain(
+      'if (status === "WAITING_FOR_BLOCKERS") return "text-teal"',
+    )
+  })
+
+  test("Pause/Start control is omitted while Waiting for blockers", () => {
+    const source = homeSource()
+    const pauseFnStart = source.indexOf("function WorkItemPauseButton(")
+    expect(pauseFnStart).toBeGreaterThan(-1)
+    const pauseFnEnd = source.indexOf(
+      "function WorkItemLifecycleStatus(",
+      pauseFnStart,
+    )
+    const pauseFn = source.slice(pauseFnStart, pauseFnEnd)
+    expect(pauseFn).toContain(
+      'workItem.isTerminal || workItem.status === "WAITING_FOR_BLOCKERS"',
+    )
+    expect(pauseFn).toContain("return null")
+  })
+
+  test("held Working row offers Reset and withholds Retry", () => {
+    const source = homeSource()
+    const lifecycleStart = source.indexOf("function WorkItemLifecycleStatus(")
+    expect(lifecycleStart).toBeGreaterThan(-1)
+    const lifecycle = source.slice(lifecycleStart)
+    expect(lifecycle).toContain(
+      'const heldForBlockers = status === "WAITING_FOR_BLOCKERS"',
+    )
+    expect(lifecycle).toContain(
+      "const canRetry = compact && workItem.canRetry && !heldForBlockers",
+    )
+    expect(lifecycle).toContain("const canReset = compact")
+    expect(lifecycle).toContain("resetWorkItem")
+    expect(lifecycle).toContain(
+      'aria-label={reset.isPending ? "Resetting job" : "Reset job"}',
+    )
+  })
+
+  test("blocked Issue kebab offers Queue only; Actionable keeps Implement", () => {
+    const source = homeSource()
+    expect(source).toContain("const isQueueable =")
+    expect(source).toContain("const canQueue =")
+    expect(source).toContain(
+      'issue.state === "OPEN" && !issue.hasChildren && issue.blockedBy.length > 0',
+    )
+    expect(source).toContain(
+      'issue.state === "OPEN" && !issue.hasChildren && issue.blockedBy.length === 0',
+    )
+    expect(source).toContain('queueIssue.isPending ? "Queueing..." : "Queue"')
+    expect(source).toContain("{canImplement && (")
+    expect(source).toContain("{canQueue && (")
+    expect(source).toContain("Implement now")
+    expect(source).toContain("Implement locally")
+  })
+})

--- a/apps/harness/test/work-item-progress-chrome.test.ts
+++ b/apps/harness/test/work-item-progress-chrome.test.ts
@@ -4,6 +4,7 @@ import {
   prBadgeClassName,
   statusBadgeBaseClassName,
   statusBadgeClassNameForStatus,
+  statusMessageClassNameForStatus,
 } from "../src/work-item-progress-chrome.js"
 import { describe, expect, test } from "bun:test"
 
@@ -37,5 +38,37 @@ describe("work-item-progress-chrome", () => {
     assertMinTextXs(statusBadgeClassNameForStatus("COMPLETE"))
     assertMinTextXs(statusBadgeClassNameForStatus("FAILED"))
     assertMinTextXs(statusBadgeClassNameForStatus("RUNNING"))
+  })
+
+  test("Waiting for blockers badge tone is distinct from Worker Slot and Queued", () => {
+    const blockers = statusBadgeClassNameForStatus("WAITING_FOR_BLOCKERS")
+    const workerSlot = statusBadgeClassNameForStatus("WAITING_FOR_WORKER_SLOT")
+    const queued = statusBadgeClassNameForStatus("QUEUED")
+    const running = statusBadgeClassNameForStatus("RUNNING")
+
+    expect(blockers).toContain("bg-teal-wash")
+    expect(blockers).toContain("text-teal")
+    expect(workerSlot).toContain("bg-violet-wash")
+    expect(workerSlot).toContain("text-violet-800")
+    expect(queued).toContain("bg-oxblood-wash")
+    expect(queued).toContain("text-oxblood")
+
+    expect(blockers).not.toBe(workerSlot)
+    expect(blockers).not.toBe(queued)
+    expect(blockers).not.toBe(running)
+    expect(workerSlot).not.toBe(queued)
+    assertMinTextXs(blockers)
+    assertMinTextXs(workerSlot)
+  })
+
+  test("status message tone matches wait-hold badges", () => {
+    expect(statusMessageClassNameForStatus("WAITING_FOR_BLOCKERS")).toBe(
+      "text-teal",
+    )
+    expect(statusMessageClassNameForStatus("WAITING_FOR_WORKER_SLOT")).toBe(
+      "text-violet-800",
+    )
+    expect(statusMessageClassNameForStatus("QUEUED")).toBe("text-oxblood-deep")
+    expect(statusMessageClassNameForStatus("FAILED")).toBe("text-oxblood-deep")
   })
 })


### PR DESCRIPTION
## Summary

- Distinct teal badge and status-message tone for Waiting for blockers, separate from violet Waiting for Worker Slot and oxblood bare Queued.
- Held Working rows keep Reset and withhold Pause, Start, and Retry (API already sets `canRetry: false`; UI gates Retry as defense-in-depth).
- Thin unit and source checks cover chrome tones, Pause omission, Reset, and Queue kebab affordances.

Closes #481

## Test plan

- [x] `work-item-progress-chrome` unit tests for distinct badge/message tones
- [x] `waiting-for-blockers-working-row` thin source checks for held-row actions and Queue kebab
- [x] Pre-commit `nx affected` lint / typecheck / test
- [ ] Manual: Queue a blocked leaf; confirm Working row teal status, “Queued — waiting for #…”, Reset only (no Pause/Retry)