### PR TITLE
feat(work-item-lifecycle): lift Waiting for blockers when Issue is Implementable

### DIFF
--- a/apps/harness/src/server/job-worker.ts
+++ b/apps/harness/src/server/job-worker.ts
@@ -157,8 +157,12 @@ const refreshRepository = Effect.fn("JobWorker.refreshRepository")(function* (
     return yield* new RepositoryNotFoundError({ repositoryId })
   }
 
+  const lifecycle = yield* WorkItemLifecycle
   const summary = yield* reconciler.reconcile(repository)
   yield* syncNeedsHumanMergeHandoffs(repositoryId)
+  // Issue store is current: lift or fail Waiting for blockers Work Items.
+  // Lifecycle owns Work Item mutations; reconciler only updates Issues.
+  yield* lifecycle.releaseWaitingForBlockers(repositoryId)
   yield* db.notifyIssuesChanged(repositoryId)
   return summary
 })

--- a/apps/harness/test/job-worker.test.ts
+++ b/apps/harness/test/job-worker.test.ts
@@ -244,6 +244,7 @@ const queueLayer = (
       countCommittedPullRequests: () => Effect.succeed(0),
       continueAfterHumanPrOutcome: unused,
       admitWaitingWorkItems: Effect.succeed(0),
+      releaseWaitingForBlockers: () => Effect.succeed(0),
     }),
   )
 
@@ -1448,6 +1449,7 @@ describe("Job worker", () => {
       countCommittedPullRequests: () => Effect.succeed(0),
       continueAfterHumanPrOutcome: unused,
       admitWaitingWorkItems: Effect.succeed(0),
+      releaseWaitingForBlockers: () => Effect.succeed(0),
     })
 
     await Effect.runPromise(
@@ -1553,6 +1555,7 @@ describe("Job worker", () => {
       countCommittedPullRequests: () => Effect.succeed(0),
       continueAfterHumanPrOutcome: unused,
       admitWaitingWorkItems: Effect.succeed(0),
+      releaseWaitingForBlockers: () => Effect.succeed(0),
     })
 
     await Effect.runPromise(
@@ -1622,6 +1625,7 @@ describe("Job worker", () => {
       countCommittedPullRequests: () => Effect.succeed(0),
       continueAfterHumanPrOutcome: unused,
       admitWaitingWorkItems: Effect.succeed(0),
+      releaseWaitingForBlockers: () => Effect.succeed(0),
     })
     // Block Keymaxxer so auto-heal cannot finish during startup.
     const blockedKeymaxxer = Layer.succeed(KeymaxxerService, {
@@ -1756,6 +1760,7 @@ describe("Job worker", () => {
       countCommittedPullRequests: () => Effect.succeed(0),
       continueAfterHumanPrOutcome: unused,
       admitWaitingWorkItems: Effect.succeed(0),
+      releaseWaitingForBlockers: () => Effect.succeed(0),
     })
 
     await Effect.runPromise(
@@ -1946,6 +1951,7 @@ describe("Job worker", () => {
       countCommittedPullRequests: () => Effect.succeed(0),
       continueAfterHumanPrOutcome: unused,
       admitWaitingWorkItems: Effect.succeed(0),
+      releaseWaitingForBlockers: () => Effect.succeed(0),
     })
 
     await Effect.runPromise(
@@ -2058,6 +2064,7 @@ describe("Job worker", () => {
       countCommittedPullRequests: () => Effect.succeed(0),
       continueAfterHumanPrOutcome: unused,
       admitWaitingWorkItems: Effect.succeed(0),
+      releaseWaitingForBlockers: () => Effect.succeed(0),
     })
 
     await Effect.runPromise(

--- a/packages/graphql-api/test/graphql-api.test.ts
+++ b/packages/graphql-api/test/graphql-api.test.ts
@@ -238,6 +238,7 @@ const makeRuntime = (
     countCommittedPullRequests: unused,
     continueAfterHumanPrOutcome: unused,
     admitWaitingWorkItems: Effect.succeed(0),
+    releaseWaitingForBlockers: () => Effect.succeed(0),
     ...lifecycleOverrides,
   }
   const readyRuntime = readyRuntimeStatus()

--- a/packages/work-item-lifecycle/src/lib/work-item-lifecycle.ts
+++ b/packages/work-item-lifecycle/src/lib/work-item-lifecycle.ts
@@ -673,6 +673,23 @@ export interface WorkItemLifecycleShape {
     | InvalidQueueNameError
     | DatabaseError
   >
+  /**
+   * After Issue reconciliation for a Repository: revalidate Work Items Waiting
+   * for blockers. Implementable Issues leave the hold and seek Worker Slot
+   * admission (FIFO by creation time with other waiters). Still-blocked valid
+   * open leaves stay held. Invalid candidates fail terminally. Repository
+   * Paused does not block lift; path is full remote (no pause-before-step).
+   */
+  readonly releaseWaitingForBlockers: (
+    repositoryId: string,
+  ) => Effect.Effect<
+    number,
+    | WorkItemLifecycleDatabaseError
+    | EnqueueError
+    | InvalidQueueNameError
+    | DatabaseError
+    | RepositoryNotFoundError
+  >
 }
 
 export class WorkItemLifecycle extends Context.Service<
@@ -1228,6 +1245,270 @@ export const makeWorkItemLifecycleLive = (
           }
         }
         return admitted
+      })
+
+      /**
+       * Classify a held (Waiting for blockers) Work Item's Issue after
+       * reconciliation. Still-blocked valid open leaves stay held — that is
+       * not terminal. Mid-flight revalidation uses revalidateIssue instead.
+       * Callers load the Issue store once per release pass and pass it in.
+       */
+      type HeldIssueClassification =
+        | { readonly _tag: "still_blocked" }
+        | { readonly _tag: "implementable" }
+        | {
+            readonly _tag: "invalid"
+            readonly failureCode: string
+            readonly failureMessage: string
+          }
+
+      const classifyHeldIssue = (
+        issues: readonly {
+          readonly githubIssueNumber: number
+          readonly state: string
+          readonly hasChildren: boolean
+          readonly blockedBy: readonly unknown[]
+        }[],
+        githubIssueNumber: number,
+      ): HeldIssueClassification => {
+        const issue = issues.find(
+          (candidate) => candidate.githubIssueNumber === githubIssueNumber,
+        )
+
+        if (!issue) {
+          return {
+            _tag: "invalid",
+            failureCode: "issue_not_found",
+            failureMessage: `Issue #${githubIssueNumber} is no longer present in the Issue store`,
+          }
+        }
+
+        if (issue.state !== "OPEN") {
+          return {
+            _tag: "invalid",
+            failureCode: "issue_not_open",
+            failureMessage: `Issue #${githubIssueNumber} is ${issue.state}, not OPEN`,
+          }
+        }
+
+        if (issue.hasChildren) {
+          return {
+            _tag: "invalid",
+            failureCode: "issue_is_parent",
+            failureMessage: `Issue #${githubIssueNumber} has children and is no longer a Leaf Issue`,
+          }
+        }
+
+        if (issue.blockedBy.length > 0) {
+          return { _tag: "still_blocked" }
+        }
+
+        return { _tag: "implementable" }
+      }
+
+      const releaseWaitingForBlockers = Effect.fn(
+        "WorkItemLifecycle.releaseWaitingForBlockers",
+      )(function* (repositoryId: string) {
+        // Creation order so free slots go to oldest held items first when
+        // several become Implementable together.
+        const heldRows = (yield* sql
+          .unsafe(
+            `SELECT ${WORK_ITEM_SELECT_COLUMNS}
+             FROM work_item
+             WHERE repository_id = ?
+               AND waiting_for_blockers = 1
+               AND state NOT IN ('complete', 'failed', 'abandoned')
+             ORDER BY created_at ASC, rowid ASC`,
+            [repositoryId],
+          )
+          .pipe(Effect.mapError(toDatabaseError))) as readonly WorkItemRow[]
+
+        if (heldRows.length === 0) {
+          return 0
+        }
+
+        // One Issue-store snapshot per refresh release pass (not per held row).
+        const issues = yield* db.listIssues(repositoryId)
+        let changed = 0
+
+        for (const held of heldRows) {
+          // Per-item isolation: one release failure must not abort the rest of
+          // the repository pass (or skip post-reconcile Issue notification).
+          // Matches syncNeedsHumanMergeHandoffs. Next refresh retries leftovers.
+          const didChange = yield* Effect.gen(function* () {
+            const classification = classifyHeldIssue(
+              issues,
+              held.github_issue_number,
+            )
+
+            if (classification._tag === "still_blocked") {
+              return false
+            }
+
+            const now = yield* Clock.currentTimeMillis
+
+            if (classification._tag === "invalid") {
+              const failedRows = (yield* sql
+                .unsafe(
+                  `UPDATE work_item
+                   SET state = 'failed',
+                       state_ready_at = ?,
+                       failure_code = ?,
+                       failure_message = ?,
+                       holds_worker_slot = 0,
+                       waiting_since = NULL,
+                       waiting_for_blockers = 0,
+                       updated_at = ?
+                   WHERE id = ?
+                     AND waiting_for_blockers = 1
+                     AND state NOT IN ('complete', 'failed', 'abandoned')
+                   RETURNING id`,
+                  [
+                    now,
+                    classification.failureCode,
+                    classification.failureMessage,
+                    now,
+                    held.id,
+                  ],
+                )
+                .pipe(Effect.mapError(toDatabaseError))) as readonly {
+                readonly id: string
+              }[]
+              return Boolean(failedRows[0])
+            }
+
+            // Implementable: clear hold and admit like a fresh Implement Now
+            // (full remote path — pause_before_step stays null from Queue).
+            return yield* sql
+              .withTransaction(
+                Effect.gen(function* () {
+                  const current = yield* loadWorkItemRow(held.id)
+                  if (
+                    !current?.waiting_for_blockers ||
+                    isTerminalWorkItemState(current.state)
+                  ) {
+                    return false
+                  }
+
+                  // Leave Waiting for blockers before admission so the row is
+                  // eligible for Worker Slot wait / Step Run enqueue. RETURNING
+                  // gates concurrent abandon/reset that already left the hold.
+                  const clearedRows = (yield* sql
+                    .unsafe(
+                      `UPDATE work_item
+                       SET waiting_for_blockers = 0,
+                           updated_at = ?
+                       WHERE id = ?
+                         AND waiting_for_blockers = 1
+                         AND state NOT IN ('complete', 'failed', 'abandoned')
+                       RETURNING id, state, created_at`,
+                      [now, held.id],
+                    )
+                    .pipe(Effect.mapError(toDatabaseError))) as readonly {
+                    readonly id: string
+                    readonly state: WorkItemState
+                    readonly created_at: number
+                  }[]
+                  const cleared = clearedRows[0]
+                  if (!cleared) {
+                    return false
+                  }
+
+                  const limit = yield* maxWorkerSlots()
+                  const occupied = yield* countOccupiedWorkerSlots()
+                  if (occupied < limit) {
+                    yield* sql
+                      .unsafe(
+                        `UPDATE work_item
+                         SET holds_worker_slot = 1,
+                             waiting_since = NULL,
+                             updated_at = ?
+                         WHERE id = ?
+                           AND waiting_for_blockers = 0
+                           AND state NOT IN ('complete', 'failed', 'abandoned')`,
+                        [now, held.id],
+                      )
+                      .pipe(Effect.mapError(toDatabaseError))
+                    const pendingStep =
+                      cleared.state as OperationalLifecycleStep
+                    const activeRows = (yield* sql.unsafe(
+                      `SELECT id FROM step_run
+                       WHERE work_item_id = ?
+                         AND status IN ('queued', 'running')
+                       LIMIT 1`,
+                      [held.id],
+                    )) as readonly { readonly id: string }[]
+                    if (!activeRows[0]) {
+                      yield* enqueueStepRunForWorkItem(
+                        held.id,
+                        pendingStep,
+                        now,
+                      )
+                    }
+                  } else {
+                    // FIFO with other Worker Slot waiters by creation time when
+                    // never previously admitted (CONTEXT: Waiting for Worker Slot).
+                    yield* sql
+                      .unsafe(
+                        `UPDATE work_item
+                         SET holds_worker_slot = 0,
+                             waiting_since = ?,
+                             updated_at = ?
+                         WHERE id = ?
+                           AND waiting_for_blockers = 0
+                           AND state NOT IN ('complete', 'failed', 'abandoned')`,
+                        [cleared.created_at, now, held.id],
+                      )
+                      .pipe(Effect.mapError(toDatabaseError))
+                  }
+                  return true
+                }),
+              )
+              .pipe(
+                Effect.catch((error) => {
+                  if (
+                    error instanceof WorkItemLifecycleDatabaseError ||
+                    error instanceof EnqueueError ||
+                    error instanceof InvalidQueueNameError
+                  ) {
+                    return Effect.fail(error)
+                  }
+                  if (
+                    typeof error === "object" &&
+                    error !== null &&
+                    "_tag" in error &&
+                    (error as { _tag: string })._tag === "SqlError"
+                  ) {
+                    return Effect.fail(toDatabaseError(error as SqlError))
+                  }
+                  return Effect.fail(
+                    new WorkItemLifecycleDatabaseError({
+                      message: `Failed releasing Waiting for blockers Work Item: ${String(error)}`,
+                      cause: error,
+                    }),
+                  )
+                }),
+              )
+          }).pipe(
+            Effect.catch((error) =>
+              Effect.logWarning(
+                "Failed releasing Waiting for blockers Work Item; continuing pass",
+                {
+                  workItemId: held.id,
+                  repositoryId,
+                  error: String(error),
+                },
+              ).pipe(Effect.as(false)),
+            ),
+          )
+
+          if (didChange) {
+            changed += 1
+            yield* notifyWorkItemsChanged(repositoryId)
+          }
+        }
+
+        return changed
       })
 
       const revalidateIssue = (
@@ -4738,6 +5019,7 @@ export const makeWorkItemLifecycleLive = (
         countCommittedPullRequests,
         continueAfterHumanPrOutcome,
         admitWaitingWorkItems,
+        releaseWaitingForBlockers,
       })
     }),
   )

--- a/packages/work-item-lifecycle/test/work-item-lifecycle.spec.ts
+++ b/packages/work-item-lifecycle/test/work-item-lifecycle.spec.ts
@@ -8527,5 +8527,326 @@ describe("WorkItemLifecycle", () => {
           expect(stillHeld.stepRuns).toHaveLength(0)
         }),
       ))
+
+    it("releases a held Work Item when the Issue becomes Implementable", () =>
+      runTest(
+        Effect.gen(function* () {
+          const lifecycle = yield* WorkItemLifecycle
+          const db = yield* DbService
+          const queue = yield* QueueService
+          const { repository, issue } = yield* seedBlockedIssue
+
+          const held = yield* lifecycle.queue(
+            repository.id,
+            issue.githubIssueNumber,
+          )
+          expect(held.waitingForBlockers).toBe(true)
+          expect(held.holdsWorkerSlot).toBe(false)
+          expect(held.stepRuns).toHaveLength(0)
+
+          // Simulate Issue reconciliation clearing blockers (and keep repo paused).
+          expect(repository.paused).toBe(true)
+          yield* db.storeIssue({
+            repositoryId: repository.id,
+            githubIssueNumber: issue.githubIssueNumber,
+            ...sampleIssueFields,
+            title: issue.title,
+            url: issue.url,
+            blockedBy: [],
+          })
+
+          const changed = yield* lifecycle.releaseWaitingForBlockers(
+            repository.id,
+          )
+          expect(changed).toBe(1)
+
+          const released = yield* lifecycle.getWorkItem(held.id)
+          expect(released.waitingForBlockers).toBe(false)
+          expect(released.holdsWorkerSlot).toBe(true)
+          expect(released.waitingSince).toBeNull()
+          expect(released.state).toBe("create_worktree")
+          expect(released.pauseBeforeStep).toBeNull()
+          expect(released.stepRuns).toHaveLength(1)
+          expect(released.failureCode).toBeNull()
+
+          const job = yield* queue.rawClaim(WORK_ITEM_LIFECYCLE_QUEUE)
+          expect(Option.isSome(job)).toBe(true)
+        }),
+      ))
+
+    it("keeps a still-blocked valid open leaf Waiting for blockers", () =>
+      runTest(
+        Effect.gen(function* () {
+          const lifecycle = yield* WorkItemLifecycle
+          const db = yield* DbService
+          const { repository, issue } = yield* seedBlockedIssue
+
+          const held = yield* lifecycle.queue(
+            repository.id,
+            issue.githubIssueNumber,
+          )
+
+          // Partial clearance: one blocker remains — still not Implementable.
+          yield* db.storeIssue({
+            repositoryId: repository.id,
+            githubIssueNumber: issue.githubIssueNumber,
+            ...sampleIssueFields,
+            title: issue.title,
+            url: issue.url,
+            blockedBy: [
+              {
+                githubIssueNumber: 12,
+                githubIssueUrl: "https://github.com/acme/widgets/issues/12",
+              },
+            ],
+          })
+
+          const changed = yield* lifecycle.releaseWaitingForBlockers(
+            repository.id,
+          )
+          expect(changed).toBe(0)
+
+          const stillHeld = yield* lifecycle.getWorkItem(held.id)
+          expect(stillHeld.waitingForBlockers).toBe(true)
+          expect(stillHeld.holdsWorkerSlot).toBe(false)
+          expect(stillHeld.waitingSince).toBeNull()
+          expect(stillHeld.stepRuns).toHaveLength(0)
+          expect(stillHeld.state).not.toBe("failed")
+        }),
+      ))
+
+    it("fails terminally when a held Issue is no longer a valid open leaf", () =>
+      runTest(
+        Effect.gen(function* () {
+          const lifecycle = yield* WorkItemLifecycle
+          const db = yield* DbService
+          yield* seedHarnessBuildModel
+          const repository = yield* db.addRepository({
+            ...sampleRepository,
+            localPath: "/repos/acme/widgets-held-invalid.git",
+            githubRepo: "widgets-held-invalid",
+          })
+
+          const closed = yield* db.storeIssue({
+            repositoryId: repository.id,
+            githubIssueNumber: 201,
+            ...sampleIssueFields,
+            url: "https://github.com/acme/widgets/issues/201",
+            blockedBy: [
+              {
+                githubIssueNumber: 1,
+                githubIssueUrl: "https://github.com/acme/widgets/issues/1",
+              },
+            ],
+          })
+          const closedHeld = yield* lifecycle.queue(repository.id, 201)
+          yield* db.storeIssue({
+            repositoryId: repository.id,
+            githubIssueNumber: 201,
+            ...sampleIssueFields,
+            title: closed.title,
+            url: closed.url,
+            state: "CLOSED",
+            blockedBy: [],
+          })
+
+          const missing = yield* db.storeIssue({
+            repositoryId: repository.id,
+            githubIssueNumber: 202,
+            ...sampleIssueFields,
+            title: "Missing later",
+            url: "https://github.com/acme/widgets/issues/202",
+            blockedBy: [
+              {
+                githubIssueNumber: 1,
+                githubIssueUrl: "https://github.com/acme/widgets/issues/1",
+              },
+            ],
+          })
+          const missingHeld = yield* lifecycle.queue(repository.id, 202)
+          yield* db.deleteIssue(repository.id, missing.githubIssueNumber)
+
+          const parent = yield* db.storeIssue({
+            repositoryId: repository.id,
+            githubIssueNumber: 203,
+            ...sampleIssueFields,
+            title: "Becomes parent",
+            url: "https://github.com/acme/widgets/issues/203",
+            blockedBy: [
+              {
+                githubIssueNumber: 1,
+                githubIssueUrl: "https://github.com/acme/widgets/issues/1",
+              },
+            ],
+          })
+          const parentHeld = yield* lifecycle.queue(repository.id, 203)
+          yield* db.storeIssue({
+            repositoryId: repository.id,
+            githubIssueNumber: 203,
+            ...sampleIssueFields,
+            title: parent.title,
+            url: parent.url,
+            hasChildren: true,
+            blockedBy: [],
+          })
+
+          const changed = yield* lifecycle.releaseWaitingForBlockers(
+            repository.id,
+          )
+          expect(changed).toBe(3)
+
+          const failedClosed = yield* lifecycle.getWorkItem(closedHeld.id)
+          expect(failedClosed.state).toBe("failed")
+          expect(failedClosed.waitingForBlockers).toBe(false)
+          expect(failedClosed.failureCode).toBe("issue_not_open")
+          expect(failedClosed.stepRuns).toHaveLength(0)
+
+          const failedMissing = yield* lifecycle.getWorkItem(missingHeld.id)
+          expect(failedMissing.state).toBe("failed")
+          expect(failedMissing.failureCode).toBe("issue_not_found")
+
+          const failedParent = yield* lifecycle.getWorkItem(parentHeld.id)
+          expect(failedParent.state).toBe("failed")
+          expect(failedParent.failureCode).toBe("issue_is_parent")
+        }),
+      ))
+
+    it("joins Worker Slot wait FIFO by creation time with existing waiters", () =>
+      runTest(
+        Effect.gen(function* () {
+          const lifecycle = yield* WorkItemLifecycle
+          const db = yield* DbService
+          yield* seedHarnessBuildModel
+          const config = yield* db.getConfig
+          yield* db.updateConfig({
+            selectedAgentBackend: "opencode",
+            defaultModel:
+              config.defaultModel ?? "opencode/deepseek-v4-flash-free",
+            defaultThinkingLevel: config.defaultThinkingLevel ?? "low",
+            reviewModel: config.reviewModel,
+            reviewThinkingLevel: config.reviewThinkingLevel,
+            maxConcurrentAgentTurns: config.maxConcurrentAgentTurns,
+            maxConcurrentWorkItems: 1,
+          })
+
+          // Held first (oldest creation time among the trio).
+          const heldRepo = yield* db.addRepository({
+            ...sampleRepository,
+            localPath: "/repos/acme/widgets-release-fifo-held.git",
+            githubRepo: "widgets-release-fifo-held",
+          })
+          yield* db.storeIssue({
+            repositoryId: heldRepo.id,
+            githubIssueNumber: 301,
+            ...sampleIssueFields,
+            url: "https://github.com/acme/widgets/issues/301",
+            blockedBy: [
+              {
+                githubIssueNumber: 1,
+                githubIssueUrl: "https://github.com/acme/widgets/issues/1",
+              },
+            ],
+          })
+          const held = yield* lifecycle.queue(heldRepo.id, 301)
+
+          const admittedRepo = yield* db.addRepository({
+            ...sampleRepository,
+            localPath: "/repos/acme/widgets-release-fifo-admitted.git",
+            githubRepo: "widgets-release-fifo-admitted",
+          })
+          yield* db.storeIssue({
+            repositoryId: admittedRepo.id,
+            githubIssueNumber: 302,
+            ...sampleIssueFields,
+            url: "https://github.com/acme/widgets/issues/302",
+          })
+          const occupying = yield* lifecycle.implementNow(admittedRepo.id, 302)
+          expect(occupying.holdsWorkerSlot).toBe(true)
+
+          const waiterRepo = yield* db.addRepository({
+            ...sampleRepository,
+            localPath: "/repos/acme/widgets-release-fifo-waiter.git",
+            githubRepo: "widgets-release-fifo-waiter",
+          })
+          yield* db.storeIssue({
+            repositoryId: waiterRepo.id,
+            githubIssueNumber: 303,
+            ...sampleIssueFields,
+            url: "https://github.com/acme/widgets/issues/303",
+          })
+          const slotWaiter = yield* lifecycle.implementNow(waiterRepo.id, 303)
+          expect(slotWaiter.holdsWorkerSlot).toBe(false)
+          expect(slotWaiter.waitingSince).not.toBeNull()
+
+          // Clear blockers; release should join wait line by creation time.
+          yield* db.storeIssue({
+            repositoryId: heldRepo.id,
+            githubIssueNumber: 301,
+            ...sampleIssueFields,
+            url: "https://github.com/acme/widgets/issues/301",
+            blockedBy: [],
+          })
+          const changed = yield* lifecycle.releaseWaitingForBlockers(
+            heldRepo.id,
+          )
+          expect(changed).toBe(1)
+
+          const released = yield* lifecycle.getWorkItem(held.id)
+          expect(released.waitingForBlockers).toBe(false)
+          expect(released.holdsWorkerSlot).toBe(false)
+          expect(released.waitingSince).not.toBeNull()
+          expect(released.waitingSince?.getTime()).toBe(
+            held.createdAt.getTime(),
+          )
+          expect(released.stepRuns).toHaveLength(0)
+
+          // Free the only slot: oldest creation-time waiter (released held) wins.
+          yield* lifecycle.abandon(occupying.id)
+
+          const admittedReleased = yield* lifecycle.getWorkItem(held.id)
+          expect(admittedReleased.holdsWorkerSlot).toBe(true)
+          expect(admittedReleased.waitingSince).toBeNull()
+          expect(admittedReleased.stepRuns).toHaveLength(1)
+
+          const stillWaiting = yield* lifecycle.getWorkItem(slotWaiter.id)
+          expect(stillWaiting.holdsWorkerSlot).toBe(false)
+          expect(stillWaiting.waitingSince).not.toBeNull()
+          expect(stillWaiting.stepRuns).toHaveLength(0)
+        }),
+      ))
+
+    it("second release after lift is a no-op and does not re-hold", () =>
+      runTest(
+        Effect.gen(function* () {
+          const lifecycle = yield* WorkItemLifecycle
+          const db = yield* DbService
+          const { repository, issue } = yield* seedBlockedIssue
+
+          const held = yield* lifecycle.queue(
+            repository.id,
+            issue.githubIssueNumber,
+          )
+          yield* db.storeIssue({
+            repositoryId: repository.id,
+            githubIssueNumber: issue.githubIssueNumber,
+            ...sampleIssueFields,
+            title: issue.title,
+            url: issue.url,
+            blockedBy: [],
+          })
+          yield* lifecycle.releaseWaitingForBlockers(repository.id)
+
+          const released = yield* lifecycle.getWorkItem(held.id)
+          expect(released.waitingForBlockers).toBe(false)
+          // A second release must not touch already-lifted Work Items.
+          const second = yield* lifecycle.releaseWaitingForBlockers(
+            repository.id,
+          )
+          expect(second).toBe(0)
+          const still = yield* lifecycle.getWorkItem(held.id)
+          expect(still.waitingForBlockers).toBe(false)
+          expect(still.state).toBe("create_worktree")
+        }),
+      ))
   })
 })


### PR DESCRIPTION
## Summary

- After Issue reconciliation, revalidate Work Items Waiting for blockers via lifecycle `releaseWaitingForBlockers` (job worker; reconciler does not mutate Work Items).
- Implementable Issues leave the hold and admit like Implement Now (full remote path), or join Worker Slot wait FIFO by creation time with existing waiters.
- Still-blocked valid open leaves stay held without timeout; invalid candidates (missing, closed, parent) fail terminally with clear codes.
- RETURNING-gated transitions, single Issue-store snapshot, and per-item failure isolation so one release error does not abort the repository pass or skip Issue notification.

Closes #480

## Test plan

- [x] Lifecycle live tests: release while repo paused, still-blocked no-op, invalid fail (`issue_not_open` / `issue_not_found` / `issue_is_parent`), FIFO with slot waiters by creation time, second release no-op
- [x] Job-worker / GraphQL stubs include `releaseWaitingForBlockers`
- [x] Pre-commit `nx affected` lint / typecheck / test
- [ ] Manual: Queue a blocked leaf, clear blockers via refresh, confirm Working list advances and full remote lifecycle starts