### PR TITLE
feat(harness): keep add-repository guidance below configured repos

### DIFF
--- a/apps/harness/src/routes/index.tsx
+++ b/apps/harness/src/routes/index.tsx
@@ -780,17 +780,10 @@ function RepositoryCards() {
     return (
       <>
         {warning}
-        <div className="border border-dashed border-rule-2 bg-panel px-6 py-12 text-center sm:px-10">
-          <h2 className="m-0 font-serif text-2xl font-semibold text-ink">
-            No repositories configured
-          </h2>
-          <p className="mt-2 text-sm text-ink-soft">
-            Add a local Git repository with the operator binary:
-          </p>
-          <code className="mt-4 inline-block max-w-full overflow-x-auto border border-rule-2 bg-paper px-3 py-2 font-mono text-sm text-ink-2">
-            {addRepositoryCommand}
-          </code>
-        </div>
+        <AddRepositoryGuidance
+          command={addRepositoryCommand}
+          heading="No repositories configured"
+        />
       </>
     )
   }
@@ -810,7 +803,39 @@ function RepositoryCards() {
           />
         ))}
       </section>
+      <div className="mt-12 sm:mt-16">
+        <AddRepositoryGuidance command={addRepositoryCommand} />
+      </div>
     </>
+  )
+}
+
+function AddRepositoryGuidance({
+  command,
+  heading,
+}: {
+  command: string
+  heading?: string
+}) {
+  return (
+    <section
+      className="border border-dashed border-rule-2 bg-panel px-6 py-12 text-center sm:px-10"
+      aria-label="Add a repository"
+    >
+      {heading !== undefined ? (
+        <h2 className="m-0 font-serif text-2xl font-semibold text-ink">
+          {heading}
+        </h2>
+      ) : null}
+      <p
+        className={`text-sm text-ink-soft ${heading !== undefined ? "mt-2" : "m-0"}`}
+      >
+        Add a local Git repository with the operator binary:
+      </p>
+      <code className="mt-4 inline-block max-w-full overflow-x-auto border border-rule-2 bg-paper px-3 py-2 font-mono text-sm text-ink-2">
+        {command}
+      </code>
+    </section>
   )
 }
 

--- a/apps/harness/test/blank-slate-add-command.test.ts
+++ b/apps/harness/test/blank-slate-add-command.test.ts
@@ -2,17 +2,84 @@ import { readFileSync } from "node:fs"
 import { join } from "node:path"
 import { describe, expect, test } from "bun:test"
 
+const homeSource = () =>
+  readFileSync(join(import.meta.dir, "../src/routes/index.tsx"), "utf8")
+
+const sliceBetweenMarkers = (
+  source: string,
+  startMarker: string,
+  endMarker: string,
+): string => {
+  const start = source.indexOf(startMarker)
+  if (start < 0) {
+    throw new Error(`Start marker not found: ${startMarker}`)
+  }
+  const end = source.indexOf(endMarker, start)
+  if (end < 0) {
+    throw new Error(`End marker not found after ${startMarker}: ${endMarker}`)
+  }
+  return source.slice(start, end)
+}
+
+const repositoryCardsSource = () =>
+  sliceBetweenMarkers(
+    homeSource(),
+    "function RepositoryCards()",
+    "function AddRepositoryGuidance(",
+  )
+
+const addRepositoryGuidanceSource = () =>
+  sliceBetweenMarkers(
+    homeSource(),
+    "function AddRepositoryGuidance(",
+    "function RepositoryCard(",
+  )
+
 describe("blank-slate add repository command", () => {
-  test("loads suggested CLI from GraphQL and renders it in the empty state", () => {
-    const source = readFileSync(
-      join(import.meta.dir, "../src/routes/index.tsx"),
-      "utf8",
-    )
+  test("loads suggested CLI from GraphQL addRepositoryCommand query", () => {
+    const source = homeSource()
     expect(source).toContain("addRepositoryCommand")
     expect(source).toContain("addRepositoryCommandQuery")
-    expect(source).toContain("{addRepositoryCommand}")
+    expect(source).toContain("useSuspenseQuery(\n    addRepositoryCommandQuery")
     expect(source).not.toContain(
       "ready-for-agent add /path/to/local/repo\n          </code>",
     )
+  })
+
+  test("shows add-repository guidance in the empty state via shared section", () => {
+    const cards = repositoryCardsSource()
+    const emptyStart = cards.indexOf("if (repositories.length === 0)")
+    const emptyReturn = cards.indexOf("return (", emptyStart)
+    const populatedReturn = cards.indexOf("return (", emptyReturn + 1)
+    const emptyBranch = cards.slice(emptyStart, populatedReturn)
+    expect(emptyBranch).toContain("<AddRepositoryGuidance")
+    expect(emptyBranch).toContain("command={addRepositoryCommand}")
+    expect(emptyBranch).toContain('heading="No repositories configured"')
+  })
+
+  test("repeats add-repository guidance below configured repositories", () => {
+    const cards = repositoryCardsSource()
+    const emptyStart = cards.indexOf("if (repositories.length === 0)")
+    const emptyReturn = cards.indexOf("return (", emptyStart)
+    const populatedReturn = cards.indexOf("return (", emptyReturn + 1)
+    const populated = cards.slice(populatedReturn)
+    expect(populated).toContain('aria-label="Configured repositories"')
+    expect(populated).toContain("<AddRepositoryGuidance")
+    expect(populated).toContain("command={addRepositoryCommand}")
+    // Populated footer reuses the command; empty-state heading only.
+    expect(populated).not.toContain('heading="No repositories configured"')
+  })
+
+  test("shared guidance renders the dynamic command without hard-coding it", () => {
+    const guidance = addRepositoryGuidanceSource()
+    expect(guidance.length).toBeGreaterThan(0)
+    expect(guidance).toContain("command")
+    expect(guidance).toContain("{command}")
+    expect(guidance).toContain(
+      "Add a local Git repository with the operator binary:",
+    )
+    expect(guidance).toContain('aria-label="Add a repository"')
+    expect(guidance).toContain("max-w-full overflow-x-auto")
+    expect(guidance).not.toContain("ready-for-agent add /path/to/local/repo")
   })
 })


### PR DESCRIPTION
## Summary

- Extract shared `AddRepositoryGuidance` for the operator add-repository CLI section (dynamic GraphQL `addRepositoryCommand`).
- Keep the existing empty-state guidance when no repositories are configured.
- Repeat equivalent guidance below the configured repositories list so operators can still discover how to add another repository.
- Cover empty, populated, and shared-section wiring in harness source tests.

Closes #496

## Test plan

- [x] `blank-slate-add-command` tests for GraphQL wiring, empty state, populated footer, and non-hard-coded command
- [x] Pre-commit `nx affected` lint / typecheck / test
- [ ] Manual: open dashboard with no repos and with one or more repos; confirm add-repository command section is visible in both cases