### PR TITLE
fix(harness): clarify ready-for-review check wait help text

### DIFF
--- a/apps/harness/src/routes/index.tsx
+++ b/apps/harness/src/routes/index.tsx
@@ -1836,10 +1836,9 @@ function RepositoryCard({
                 Wait for checks to start after ready for review
               </span>
               <span className="font-normal text-ink-faint">
-                When enabled, waits up to 90 seconds after ready for review for
-                new checks to start. Disable only when becoming ready cannot
-                start relevant workflows; then settled draft-phase checks may
-                advance without that startup wait.
+                Wait up to 90 seconds for workflows that start after a PR is
+                marked ready for review. If this repository has no such
+                workflows, turn off this setting to skip the wait.
               </span>
             </label>
 

--- a/apps/harness/test/repository-settings-wait-for-ready-checks.test.ts
+++ b/apps/harness/test/repository-settings-wait-for-ready-checks.test.ts
@@ -25,8 +25,12 @@ describe("Repository settings Wait for checks to start after ready for review", 
     expect(source).not.toContain(
       "waitForReadyForReviewChecks: repository.waitForReadyForReviewChecks",
     )
-    expect(source).toContain("Disable only when becoming ready cannot")
-    expect(source).toContain("start relevant workflows")
+    expect(source).toContain(
+      "Wait up to 90 seconds for workflows that start after a PR is",
+    )
+    expect(source).toContain(
+      "workflows, turn off this setting to skip the wait.",
+    )
     expect(source).toContain("repository.waitForReadyForReviewChecks")
     expect(source).toContain('? "Enabled"')
     expect(source).toContain("Wait for ready checks:")


### PR DESCRIPTION
## Summary

- Replace the technical help text on **Wait for checks to start after ready for review** with operator-focused copy.
- Keep the checkbox label, polarity, default, persistence, and lifecycle behavior unchanged.
- Update the harness source-scan test to assert the revised help text.

Closes #502

## Test plan

- [x] `bunx nx test harness`
- [x] `bunx nx lint harness`
- [ ] Manual: open repository settings and confirm the help text under **Wait for checks to start after ready for review** matches the approved two-sentence copy