### PR TITLE
feat(harness): show pull request count after repository name

### DIFF
--- a/apps/harness/src/refresh-work-items-live.ts
+++ b/apps/harness/src/refresh-work-items-live.ts
@@ -6,7 +6,10 @@ export const committedPullRequestsCountQueryKeyPrefix = [
 ] as const
 
 const configQueryKey = ["config"] as const
-/** Per-repo unfinished gate (`blockingUnfinishedWorkItemCount`) lives here. */
+/**
+ * Per-repo unfinished gate (`blockingUnfinishedWorkItemCount`) and total Work
+ * Item PR count (`pullRequestCount`) live here.
+ */
 const repositoriesQueryKey = ["repositories"] as const
 
 export type RepositoryWorkItemsLiveQueries = {

--- a/apps/harness/src/routes/index.tsx
+++ b/apps/harness/src/routes/index.tsx
@@ -199,6 +199,7 @@ const repositoriesQuery = {
         waitForReadyForReviewChecks: true,
         issuesReconciledAt: true,
         blockingUnfinishedWorkItemCount: true,
+        pullRequestCount: true,
       },
       repositoryCredentials: {
         repositoryId: true,
@@ -285,6 +286,7 @@ type Repository = {
   waitForReadyForReviewChecks: boolean
   issuesReconciledAt: string | null
   blockingUnfinishedWorkItemCount: number
+  pullRequestCount: number
   credential: RepositoryCredential
 }
 
@@ -862,6 +864,7 @@ function AddRepositoryGuidance({
           waitForReadyForReviewChecks: true,
           issuesReconciledAt: true,
           blockingUnfinishedWorkItemCount: true,
+          pullRequestCount: true,
         },
       })
       return result.addLocalRepository
@@ -1098,6 +1101,7 @@ function RepositoryCard({
           waitForReadyForReviewChecks: true,
           issuesReconciledAt: true,
           blockingUnfinishedWorkItemCount: true,
+          pullRequestCount: true,
         },
       })
       return result.updateRepositorySettings
@@ -1618,6 +1622,10 @@ function RepositoryCard({
     ? "border-oxblood/50 text-oxblood hover:bg-oxblood-wash focus-visible:outline-oxblood"
     : "border-sepia/50 text-sepia hover:bg-amber-wash focus-visible:outline-sepia"
   const repositoryLabel = `${repository.githubOwner}/${repository.githubRepo}`
+  const pullRequestCountLabel =
+    repository.pullRequestCount === 1
+      ? "1 pull request"
+      : `${repository.pullRequestCount} pull requests`
   const {
     collapsed: repositoryCollapsed,
     toggleCollapsed: toggleRepositoryCollapsed,
@@ -1629,13 +1637,20 @@ function RepositoryCard({
       <div
         className={`flex flex-wrap items-start justify-between gap-x-4 gap-y-2 ${repositoryCollapsed ? "" : "mb-5"}`}
       >
-        <h2 className="m-0 min-w-0 truncate font-serif text-2xl font-semibold tracking-[-0.012em]">
+        <h2 className="m-0 flex min-w-0 max-w-full items-baseline gap-x-2 font-serif text-2xl font-semibold tracking-[-0.012em]">
           <a
-            className="text-ink hover:text-oxblood hover:underline"
+            className="min-w-0 truncate text-ink hover:text-oxblood hover:underline"
             href={`https://github.com/${repository.githubOwner}/${repository.githubRepo}`}
           >
             {repositoryLabel}
           </a>
+          <span
+            className="shrink-0 font-mono text-sm font-semibold tracking-normal text-ink-faint tabular-nums"
+            title={pullRequestCountLabel}
+          >
+            <span className="sr-only">{pullRequestCountLabel}</span>
+            <span aria-hidden="true">{repository.pullRequestCount}</span>
+          </span>
         </h2>
         <div className="flex shrink-0 items-center gap-1">
           <CardCollapseToggle

--- a/apps/harness/test/repository-header-pr-count.test.ts
+++ b/apps/harness/test/repository-header-pr-count.test.ts
@@ -1,0 +1,54 @@
+import { readFileSync } from "node:fs"
+import { join } from "node:path"
+import { describe, expect, test } from "bun:test"
+
+const homeSource = () =>
+  readFileSync(join(import.meta.dir, "../src/routes/index.tsx"), "utf8")
+
+const refreshSource = () =>
+  readFileSync(
+    join(import.meta.dir, "../src/refresh-work-items-live.ts"),
+    "utf8",
+  )
+
+describe("repository header pull request count", () => {
+  test("repositories query requests total pullRequestCount", () => {
+    const source = homeSource()
+    expect(source).toContain("pullRequestCount: true")
+    expect(source).toContain("pullRequestCount: number")
+  })
+
+  test("header renders the count immediately after the repository name", () => {
+    const source = homeSource()
+    const titleIndex = source.indexOf("title={pullRequestCountLabel}")
+    expect(titleIndex).toBeGreaterThan(-1)
+    // Count sits in the same h2 as the repository name link.
+    const headerStart = source.lastIndexOf("<h2", titleIndex)
+    const headerEnd = source.indexOf("</h2>", titleIndex)
+    expect(headerStart).toBeGreaterThan(-1)
+    expect(headerEnd).toBeGreaterThan(titleIndex)
+    const header = source.slice(headerStart, headerEnd)
+    const nameInHeader = header.indexOf("{repositoryLabel}")
+    const countInHeader = header.indexOf("{repository.pullRequestCount}")
+    expect(nameInHeader).toBeGreaterThan(-1)
+    expect(countInHeader).toBeGreaterThan(nameInHeader)
+    expect(header).toContain('className="sr-only"')
+    expect(header).toContain("{pullRequestCountLabel}")
+    expect(header).toContain('aria-hidden="true"')
+    expect(header).toContain("shrink-0")
+    expect(header).toContain("tabular-nums")
+  })
+
+  test("zero PRs use plural accessible label without special-casing away the digit", () => {
+    const source = homeSource()
+    expect(source).toContain('? "1 pull request"')
+    expect(source).toContain("pull requests`")
+    expect(source).toContain("repository.pullRequestCount === 1")
+  })
+
+  test("work-item live refresh keeps repository PR counts current", () => {
+    const source = refreshSource()
+    expect(source).toContain("pullRequestCount")
+    expect(source).toContain('const repositoriesQueryKey = ["repositories"]')
+  })
+})

--- a/packages/db-service/src/lib/db-service.ts
+++ b/packages/db-service/src/lib/db-service.ts
@@ -330,6 +330,14 @@ export interface DbServiceShape {
     repositoryId: string,
   ) => Effect.Effect<number, DatabaseError>
   /**
+   * Distinct Work Item PRs for one Repository (any Work Item state). Does not
+   * apply Issue relevance filters (label, author, hierarchy) or Jobs-card
+   * listKind partitions — total recorded pull requests only.
+   */
+  readonly countPullRequestsForRepository: (
+    repositoryId: string,
+  ) => Effect.Effect<number, DatabaseError>
+  /**
    * Selected-or-in-use Agent Backend ids: harness default ∪ distinct
    * Repository overrides ∪ unfinished Work Items' captured backends.
    * Used to hot-activate / drop Active backends after settings Save.
@@ -569,6 +577,27 @@ export const DbServiceLive = Layer.effect(
         }[]
         return readCount(rows)
       }).pipe(Effect.withSpan("DbService.countBlockingUnfinishedForRepository"))
+
+    /**
+     * Distinct Work Item PR numbers for one Repository (all Work Item states).
+     */
+    const countPullRequestsForRepository = (
+      repositoryId: string,
+    ): Effect.Effect<number, DatabaseError> =>
+      Effect.gen(function* () {
+        const rows = (yield* sql
+          .unsafe(
+            `SELECT COUNT(DISTINCT github_pull_request_number) AS count
+             FROM work_item
+             WHERE repository_id = ?
+               AND github_pull_request_number IS NOT NULL`,
+            [repositoryId],
+          )
+          .pipe(Effect.mapError(toDatabaseError))) as readonly {
+          readonly count: number
+        }[]
+        return readCount(rows)
+      }).pipe(Effect.withSpan("DbService.countPullRequestsForRepository"))
 
     const readConfigRow = Effect.gen(function* () {
       const now = yield* Clock.currentTimeMillis
@@ -1654,6 +1683,7 @@ export const DbServiceLive = Layer.effect(
       countUnfinishedWorkItems,
       countBlockingUnfinishedForGlobalDefault,
       countBlockingUnfinishedForRepository,
+      countPullRequestsForRepository,
       listSelectedOrInUseBackendIds,
       addRepository,
       updateRepositorySettings,

--- a/packages/db-service/src/lib/test-fixtures.ts
+++ b/packages/db-service/src/lib/test-fixtures.ts
@@ -58,6 +58,7 @@ export const stubDbService = (
   countUnfinishedWorkItems: Effect.succeed(0),
   countBlockingUnfinishedForGlobalDefault: Effect.succeed(0),
   countBlockingUnfinishedForRepository: () => Effect.succeed(0),
+  countPullRequestsForRepository: () => Effect.succeed(0),
   listSelectedOrInUseBackendIds: Effect.succeed(["opencode"]),
   addRepository: unused,
   updateRepositorySettings: unused,

--- a/packages/db-service/test/db-service.spec.ts
+++ b/packages/db-service/test/db-service.spec.ts
@@ -1788,4 +1788,83 @@ describe("DbService", () => {
         }),
       ))
   })
+
+  describe("countPullRequestsForRepository", () => {
+    it("returns zero when the Repository has no Work Item PRs", () =>
+      runTest(
+        Effect.gen(function* () {
+          const db = yield* DbService
+          const repository = yield* db.addRepository(sampleInput)
+          expect(yield* db.countPullRequestsForRepository(repository.id)).toBe(
+            0,
+          )
+        }),
+      ))
+
+    it("counts distinct Work Item PRs across all states without Issue filters", () =>
+      runTest(
+        Effect.gen(function* () {
+          const db = yield* DbService
+          const sql = yield* SqlClient.SqlClient
+          const repository = yield* db.addRepository(sampleInput)
+          const other = yield* db.addRepository({
+            githubOwner: "acme",
+            githubRepo: "other",
+            localPath: "/repos/acme/other.git",
+            isBare: true,
+          })
+          const now = Date.now()
+          // Terminal + unfinished + abandoned with PRs all count.
+          yield* sql.unsafe(
+            `INSERT INTO work_item (
+               id, repository_id, github_issue_number, github_pull_request_number,
+               state, state_ready_at, agent_backend, worktree_path, session_id,
+               failure_code, failure_message, created_at, updated_at
+             ) VALUES
+               ('wi-pr-1', ?, 1, 10, 'complete', ?, 'opencode', NULL, NULL, NULL, NULL, ?, ?),
+               ('wi-pr-2', ?, 2, 20, 'watch_pr_status_checks', ?, 'opencode', NULL, NULL, NULL, NULL, ?, ?),
+               ('wi-pr-3', ?, 3, 30, 'abandoned', ?, 'opencode', NULL, NULL, NULL, NULL, ?, ?),
+               ('wi-no-pr', ?, 4, NULL, 'complete', ?, 'opencode', NULL, NULL, NULL, NULL, ?, ?),
+               ('wi-other', ?, 5, 99, 'complete', ?, 'opencode', NULL, NULL, NULL, NULL, ?, ?)`,
+            [
+              repository.id,
+              now,
+              now,
+              now,
+              repository.id,
+              now,
+              now,
+              now,
+              repository.id,
+              now,
+              now,
+              now,
+              repository.id,
+              now,
+              now,
+              now,
+              other.id,
+              now,
+              now,
+              now,
+            ],
+          )
+          // Duplicate PR number on the same repository still counts once.
+          yield* sql.unsafe(
+            `INSERT INTO work_item (
+               id, repository_id, github_issue_number, github_pull_request_number,
+               state, state_ready_at, agent_backend, worktree_path, session_id,
+               failure_code, failure_message, created_at, updated_at
+             ) VALUES
+               ('wi-pr-dup', ?, 6, 10, 'failed', ?, 'opencode', NULL, NULL, NULL, NULL, ?, ?)`,
+            [repository.id, now, now, now],
+          )
+
+          expect(yield* db.countPullRequestsForRepository(repository.id)).toBe(
+            3,
+          )
+          expect(yield* db.countPullRequestsForRepository(other.id)).toBe(1)
+        }),
+      ))
+  })
 })

--- a/packages/graphql-api/src/lib/graphql-api.ts
+++ b/packages/graphql-api/src/lib/graphql-api.ts
@@ -590,6 +590,15 @@ export const createGraphqlApi = (
                 ),
               ),
             ),
+          pullRequestCount: async (repository: { id: string }) =>
+            runGraphql(
+              Effect.gen(function* () {
+                const db = yield* DbService
+                return yield* db.countPullRequestsForRepository(repository.id)
+              }).pipe(
+                Effect.withSpan("graphql-api.Repository.pullRequestCount"),
+              ),
+            ),
         },
         WorkItem: {
           agentBackend: (workItem: WorkItemRecord) =>

--- a/packages/graphql-api/test/graphql-api.test.ts
+++ b/packages/graphql-api/test/graphql-api.test.ts
@@ -1453,6 +1453,8 @@ describe("GraphQL API", () => {
       countBlockingUnfinishedForGlobalDefault: Effect.succeed(1),
       countBlockingUnfinishedForRepository: (repositoryId) =>
         Effect.succeed(repositoryId === repository.id ? 2 : 0),
+      countPullRequestsForRepository: (repositoryId) =>
+        Effect.succeed(repositoryId === repository.id ? 7 : 0),
       listRepositories: Effect.succeed([
         makeRepositoryRecord({
           id: repository.id,
@@ -1473,6 +1475,7 @@ describe("GraphQL API", () => {
             selectedAgentBackend
             effectiveAgentBackend
             blockingUnfinishedWorkItemCount
+            pullRequestCount
           }
         }`,
       }),
@@ -1489,6 +1492,7 @@ describe("GraphQL API", () => {
             selectedAgentBackend: "grok",
             effectiveAgentBackend: "grok",
             blockingUnfinishedWorkItemCount: 2,
+            pullRequestCount: 7,
           },
         ],
       },

--- a/packages/graphql-schema/schema.graphql
+++ b/packages/graphql-schema/schema.graphql
@@ -254,6 +254,12 @@ type Repository {
   rejected while this is greater than zero.
   """
   blockingUnfinishedWorkItemCount: Int!
+  """
+  Distinct Work Item PRs recorded for this Repository (any Work Item state).
+  Total only — does not apply Issue relevance filters (label, author, hierarchy)
+  or Jobs-card status partitions.
+  """
+  pullRequestCount: Int!
 }
 
 type RepositoryCredential {


### PR DESCRIPTION
## Summary

- Add `Repository.pullRequestCount`: distinct Work Item PR numbers for a repository, with no issue relevance or Jobs listKind filters.
- Surface the count in GraphQL and render it immediately after `owner/name` in the repository header (including zero).
- Keep the header usable on small screens (name truncates; count stays visible) and refresh via existing work-item live invalidation of repositories.

## Test plan

- [x] `db-service` unit tests for zero / distinct / cross-repo counts
- [x] `graphql-api` field wiring for `pullRequestCount`
- [x] harness UI source tests for header placement and labels
- [x] pre-commit affected lint, typecheck, and test

Closes #504.