### PR TITLE
fix(harness): count only open pull requests in repository header

### DIFF
--- a/apps/harness/src/refresh-work-items-live.ts
+++ b/apps/harness/src/refresh-work-items-live.ts
@@ -7,7 +7,7 @@ export const committedPullRequestsCountQueryKeyPrefix = [
 
 const configQueryKey = ["config"] as const
 /**
- * Per-repo unfinished gate (`blockingUnfinishedWorkItemCount`) and total Work
+ * Per-repo unfinished gate (`blockingUnfinishedWorkItemCount`) and open Work
  * Item PR count (`pullRequestCount`) live here.
  */
 const repositoriesQueryKey = ["repositories"] as const

--- a/apps/harness/src/routes/index.tsx
+++ b/apps/harness/src/routes/index.tsx
@@ -1624,8 +1624,8 @@ function RepositoryCard({
   const repositoryLabel = `${repository.githubOwner}/${repository.githubRepo}`
   const pullRequestCountLabel =
     repository.pullRequestCount === 1
-      ? "1 pull request"
-      : `${repository.pullRequestCount} pull requests`
+      ? "1 open pull request"
+      : `${repository.pullRequestCount} open pull requests`
   const {
     collapsed: repositoryCollapsed,
     toggleCollapsed: toggleRepositoryCollapsed,

--- a/apps/harness/test/repository-header-pr-count.test.ts
+++ b/apps/harness/test/repository-header-pr-count.test.ts
@@ -12,7 +12,7 @@ const refreshSource = () =>
   )
 
 describe("repository header pull request count", () => {
-  test("repositories query requests total pullRequestCount", () => {
+  test("repositories query requests open pullRequestCount", () => {
     const source = homeSource()
     expect(source).toContain("pullRequestCount: true")
     expect(source).toContain("pullRequestCount: number")
@@ -39,16 +39,17 @@ describe("repository header pull request count", () => {
     expect(header).toContain("tabular-nums")
   })
 
-  test("zero PRs use plural accessible label without special-casing away the digit", () => {
+  test("labels describe open PRs; zero uses plural without dropping the digit", () => {
     const source = homeSource()
-    expect(source).toContain('? "1 pull request"')
-    expect(source).toContain("pull requests`")
+    expect(source).toContain('? "1 open pull request"')
+    expect(source).toContain("open pull requests`")
     expect(source).toContain("repository.pullRequestCount === 1")
   })
 
-  test("work-item live refresh keeps repository PR counts current", () => {
+  test("work-item live refresh keeps open repository PR counts current", () => {
     const source = refreshSource()
     expect(source).toContain("pullRequestCount")
+    expect(source).toContain("open Work")
     expect(source).toContain('const repositoriesQueryKey = ["repositories"]')
   })
 })

--- a/packages/db-service/src/lib/db-service.ts
+++ b/packages/db-service/src/lib/db-service.ts
@@ -330,9 +330,11 @@ export interface DbServiceShape {
     repositoryId: string,
   ) => Effect.Effect<number, DatabaseError>
   /**
-   * Distinct Work Item PRs for one Repository (any Work Item state). Does not
-   * apply Issue relevance filters (label, author, hierarchy) or Jobs-card
-   * listKind partitions — total recorded pull requests only.
+   * Distinct open Work Item PRs for one Repository: unfinished Work Items with a
+   * recorded PR number. Terminal complete/failed/abandoned are excluded so
+   * merged and closed PRs do not accumulate in the header count. Does not apply
+   * Issue relevance filters (label, author, hierarchy) or Jobs-card listKind
+   * partitions.
    */
   readonly countPullRequestsForRepository: (
     repositoryId: string,
@@ -579,7 +581,7 @@ export const DbServiceLive = Layer.effect(
       }).pipe(Effect.withSpan("DbService.countBlockingUnfinishedForRepository"))
 
     /**
-     * Distinct Work Item PR numbers for one Repository (all Work Item states).
+     * Distinct open Work Item PR numbers for one Repository (unfinished only).
      */
     const countPullRequestsForRepository = (
       repositoryId: string,
@@ -590,7 +592,8 @@ export const DbServiceLive = Layer.effect(
             `SELECT COUNT(DISTINCT github_pull_request_number) AS count
              FROM work_item
              WHERE repository_id = ?
-               AND github_pull_request_number IS NOT NULL`,
+               AND github_pull_request_number IS NOT NULL
+               AND ${isUnfinishedStateSql()}`,
             [repositoryId],
           )
           .pipe(Effect.mapError(toDatabaseError))) as readonly {

--- a/packages/db-service/test/db-service.spec.ts
+++ b/packages/db-service/test/db-service.spec.ts
@@ -1790,7 +1790,7 @@ describe("DbService", () => {
   })
 
   describe("countPullRequestsForRepository", () => {
-    it("returns zero when the Repository has no Work Item PRs", () =>
+    it("returns zero when the Repository has no open Work Item PRs", () =>
       runTest(
         Effect.gen(function* () {
           const db = yield* DbService
@@ -1801,7 +1801,7 @@ describe("DbService", () => {
         }),
       ))
 
-    it("counts distinct Work Item PRs across all states without Issue filters", () =>
+    it("counts only open (unfinished) Work Item PRs and excludes closed or merged", () =>
       runTest(
         Effect.gen(function* () {
           const db = yield* DbService
@@ -1814,19 +1814,30 @@ describe("DbService", () => {
             isBare: true,
           })
           const now = Date.now()
-          // Terminal + unfinished + abandoned with PRs all count.
+          // Terminal complete/failed/abandoned (merged or closed) do not count.
+          // Unfinished Work Items with a PR number do.
           yield* sql.unsafe(
             `INSERT INTO work_item (
                id, repository_id, github_issue_number, github_pull_request_number,
                state, state_ready_at, agent_backend, worktree_path, session_id,
                failure_code, failure_message, created_at, updated_at
              ) VALUES
-               ('wi-pr-1', ?, 1, 10, 'complete', ?, 'opencode', NULL, NULL, NULL, NULL, ?, ?),
-               ('wi-pr-2', ?, 2, 20, 'watch_pr_status_checks', ?, 'opencode', NULL, NULL, NULL, NULL, ?, ?),
-               ('wi-pr-3', ?, 3, 30, 'abandoned', ?, 'opencode', NULL, NULL, NULL, NULL, ?, ?),
-               ('wi-no-pr', ?, 4, NULL, 'complete', ?, 'opencode', NULL, NULL, NULL, NULL, ?, ?),
-               ('wi-other', ?, 5, 99, 'complete', ?, 'opencode', NULL, NULL, NULL, NULL, ?, ?)`,
+               ('wi-pr-merged', ?, 1, 10, 'complete', ?, 'opencode', NULL, NULL, NULL, NULL, ?, ?),
+               ('wi-pr-open', ?, 2, 20, 'watch_pr_status_checks', ?, 'opencode', NULL, NULL, NULL, NULL, ?, ?),
+               ('wi-pr-closed', ?, 3, 30, 'abandoned', ?, 'opencode', NULL, NULL, NULL, NULL, ?, ?),
+               ('wi-pr-failed', ?, 4, 40, 'failed', ?, 'opencode', NULL, NULL, NULL, NULL, ?, ?),
+               ('wi-pr-needs-human', ?, 5, 50, 'needs_human', ?, 'opencode', NULL, NULL, NULL, NULL, ?, ?),
+               ('wi-no-pr', ?, 6, NULL, 'implement', ?, 'opencode', NULL, NULL, NULL, NULL, ?, ?),
+               ('wi-other-open', ?, 7, 99, 'decide_pr_merge', ?, 'opencode', NULL, NULL, NULL, NULL, ?, ?)`,
             [
+              repository.id,
+              now,
+              now,
+              now,
+              repository.id,
+              now,
+              now,
+              now,
               repository.id,
               now,
               now,
@@ -1849,21 +1860,68 @@ describe("DbService", () => {
               now,
             ],
           )
-          // Duplicate PR number on the same repository still counts once.
+          // Duplicate open PR number on the same repository still counts once.
           yield* sql.unsafe(
             `INSERT INTO work_item (
                id, repository_id, github_issue_number, github_pull_request_number,
                state, state_ready_at, agent_backend, worktree_path, session_id,
                failure_code, failure_message, created_at, updated_at
              ) VALUES
-               ('wi-pr-dup', ?, 6, 10, 'failed', ?, 'opencode', NULL, NULL, NULL, NULL, ?, ?)`,
+               ('wi-pr-dup', ?, 8, 20, 'merge_pr', ?, 'opencode', NULL, NULL, NULL, NULL, ?, ?)`,
             [repository.id, now, now, now],
           )
 
+          // Open: 20 (watch + merge_pr dup), 50 (needs_human). Merged/closed/failed excluded.
           expect(yield* db.countPullRequestsForRepository(repository.id)).toBe(
-            3,
+            2,
           )
           expect(yield* db.countPullRequestsForRepository(other.id)).toBe(1)
+        }),
+      ))
+
+    it("drops a PR from the count when its Work Item becomes terminal", () =>
+      runTest(
+        Effect.gen(function* () {
+          const db = yield* DbService
+          const sql = yield* SqlClient.SqlClient
+          const repository = yield* db.addRepository(sampleInput)
+          const now = Date.now()
+          yield* sql.unsafe(
+            `INSERT INTO work_item (
+               id, repository_id, github_issue_number, github_pull_request_number,
+               state, state_ready_at, agent_backend, worktree_path, session_id,
+               failure_code, failure_message, created_at, updated_at
+             ) VALUES
+               ('wi-open-then-merge', ?, 1, 42, 'watch_pr_status_checks', ?, 'opencode', NULL, NULL, NULL, NULL, ?, ?)`,
+            [repository.id, now, now, now],
+          )
+          expect(yield* db.countPullRequestsForRepository(repository.id)).toBe(
+            1,
+          )
+
+          yield* sql.unsafe(
+            `UPDATE work_item SET state = 'complete', updated_at = ? WHERE id = 'wi-open-then-merge'`,
+            [now],
+          )
+          expect(yield* db.countPullRequestsForRepository(repository.id)).toBe(
+            0,
+          )
+
+          yield* sql.unsafe(
+            `UPDATE work_item SET state = 'needs_human', updated_at = ? WHERE id = 'wi-open-then-merge'`,
+            [now],
+          )
+          expect(yield* db.countPullRequestsForRepository(repository.id)).toBe(
+            1,
+          )
+
+          yield* sql.unsafe(
+            `UPDATE work_item SET state = 'abandoned', updated_at = ? WHERE id = 'wi-open-then-merge'`,
+            [now],
+          )
+          expect(yield* db.countPullRequestsForRepository(repository.id)).toBe(
+            0,
+          )
         }),
       ))
   })

--- a/packages/graphql-schema/schema.graphql
+++ b/packages/graphql-schema/schema.graphql
@@ -255,9 +255,9 @@ type Repository {
   """
   blockingUnfinishedWorkItemCount: Int!
   """
-  Distinct Work Item PRs recorded for this Repository (any Work Item state).
-  Total only — does not apply Issue relevance filters (label, author, hierarchy)
-  or Jobs-card status partitions.
+  Distinct open Work Item PRs for this Repository (unfinished Work Items only).
+  Terminal complete/failed/abandoned PRs are excluded. Does not apply Issue
+  relevance filters (label, author, hierarchy) or Jobs-card status partitions.
   """
   pullRequestCount: Int!
 }


### PR DESCRIPTION
## Summary

- Count only open Work Item PRs in the repository header: unfinished Work Items with a recorded PR number.
- Exclude terminal complete/failed/abandoned PRs so merged and closed counts no longer accumulate.
- Align GraphQL field docs, accessible UI labels ("open pull request(s)"), and tests with open-only semantics; keep live refresh via existing Work Item invalidation of repositories.

## Test plan

- [x] `db-service` unit tests for zero, open-only exclusion of terminal states, distinct counts, and open→terminal transitions
- [x] harness UI source tests for open PR labels and live refresh wiring
- [x] GraphQL schema description update; existing `pullRequestCount` field wiring
- [x] pre-commit affected lint, typecheck, and test

Closes #506.