### PR TITLE
ci: verify GitHub Action pins with pinact

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -12,6 +12,26 @@ permissions:
   contents: read
 
 jobs:
+  # Dependency pin integrity: full SHAs + version comments match upstream releases.
+  pinact:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          filter: tree:0
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Verify GitHub Action pins
+        uses: suzuki-shunsuke/pinact-action@896d595f299e71d65b9d28349d6956abe144390a # v3.0.0
+        with:
+          fix: "false"
+          verify: "true"
+          # Built-in GITHUB_TOKEN only; pinact uses it for release/tag lookups.
+          github_token: ${{ github.token }}
+
   main:
     runs-on: ubuntu-latest
     steps:
@@ -20,7 +40,7 @@ jobs:
           filter: tree:0
           fetch-depth: 0
 
-      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version: latest
 
@@ -116,7 +136,7 @@ jobs:
           filter: tree:0
           fetch-depth: 0
 
-      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version: latest
 
@@ -162,7 +182,7 @@ jobs:
     # Manual release only, from main (never on PR/push).
     # Requires quality gates + packed-install distribution smoke before publish.
     if: github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main'
-    needs: [main, packed-install]
+    needs: [main, packed-install, pinact]
     runs-on: ubuntu-latest
     permissions:
       actions: write
@@ -175,7 +195,7 @@ jobs:
           fetch-depth: 0
           fetch-tags: true
 
-      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version: latest
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -8,6 +8,26 @@ permissions:
   contents: read
 
 jobs:
+  # Dependency pin integrity: full SHAs + version comments match upstream releases.
+  pinact:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          filter: tree:0
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Verify GitHub Action pins
+        uses: suzuki-shunsuke/pinact-action@896d595f299e71d65b9d28349d6956abe144390a # v3.0.0
+        with:
+          fix: "false"
+          verify: "true"
+          # Built-in GITHUB_TOKEN only; pinact uses it for release/tag lookups.
+          github_token: ${{ github.token }}
+
   main:
     runs-on: ubuntu-latest
     steps:
@@ -16,7 +36,7 @@ jobs:
           filter: tree:0
           fetch-depth: 0
 
-      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version: latest
 


### PR DESCRIPTION
## Why

GitHub Actions were already SHA-pinned with release-version comments, but nothing checked that those SHAs resolve to the claimed upstream release. A fabricated or stale version comment, or a SHA from an unreleased branch, could look safe in review while still executing at workflow time.

## What Changed

- Add a dedicated `pinact` job to the `PR` and `CI/CD` workflows that runs `suzuki-shunsuke/pinact-action` in verify-only mode (`fix: false`, `verify: true`).
- Pin pinact-action by full commit SHA with an accurate `# v3.0.0` comment; use only the built-in `GITHUB_TOKEN` and job-scoped `contents: read`.
- Gate the CI/CD `release` job on `pinact` so publish cannot proceed when pin verification fails.
- Set `persist-credentials: false` on pinact checkouts.
- Correct `oven-sh/setup-bun` version comments from `# v2` to `# v2.2.0` so existing pins pass verification.

## Verification

- [x] `pinact run -check -verify-comment` passes on both workflow files after the setup-bun annotation fix
- [x] Deliberately wrong version annotation fails with file/line and required correction; unpinned `uses:` fails; local `./` refs remain exempt; deliberate failures reverted
- [x] pinact-action SHA resolves to release `v3.0.0`
- [x] `actionlint` clean on both workflows
- [x] Pre-commit affected lint, typecheck, and test

Closes #511