### PR TITLE
fix(agent-backend): kill agent CLI process trees on timeout/finalize

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 dist
 tmp
 out-tsc
+*.tsbuildinfo
 
 # platform package binaries (filled by ready-for-agent:compile / release)
 /packages/ready-for-agent-*/bin/

--- a/packages/agent-backend/src/lib/cli-runner.ts
+++ b/packages/agent-backend/src/lib/cli-runner.ts
@@ -1,6 +1,7 @@
 import { Duration, Effect, Ref, Result, Stream } from "effect"
 import type { PlatformError } from "effect/PlatformError"
 import { ChildProcess, type ChildProcessSpawner } from "effect/unstable/process"
+import type { ChildProcessHandle } from "effect/unstable/process/ChildProcessSpawner"
 import { collectChildStdout } from "./collect-child-stdout.js"
 import {
   AgentBackendExitError,
@@ -8,6 +9,7 @@ import {
   AgentBackendSessionIdMissingError,
   AgentBackendTimeoutError,
 } from "./errors.js"
+import { killProcessTree } from "./kill-process-tree.js"
 import type { OnSessionId } from "./types.js"
 
 /** Graceful terminate then force-kill bound for the Agent Turn process tree. */
@@ -54,9 +56,35 @@ const commandOptions = (input: RunCliCaptureInput) => ({
   extendEnv: false as const,
   stdin: input.stdin ?? ("ignore" as const),
   stderr: "ignore" as const,
+  // Own process group on POSIX so group signals reach every CLI worker that
+  // stayed in the session. Combined with killProcessTree for setsid stragglers.
+  detached: process.platform !== "win32",
   killSignal: "SIGTERM" as const,
   forceKillAfter: input.forceKillAfter ?? DEFAULT_FORCE_KILL_AFTER,
 })
+
+/**
+ * Terminate the harness-spawned CLI and every process it started.
+ *
+ * Snapshots the PPID tree then SIGTERM→SIGKILL escalates across the process
+ * group and known descendants. Runs as a scope finalizer (timeout / interrupt)
+ * and on the finalizeText early-exit path.
+ *
+ * `killProcessTree` always escalates to SIGKILL via `Effect.ensuring`, so an
+ * outer bound only caps the interruptible wait loop — hard kill still runs.
+ * The ensuring body is uninterruptible: it SIGKILLs the starttime-checked
+ * snapshot and, only while the original root is still ours, a short PPID
+ * re-scan for late-spawned children.
+ */
+const terminateCliTree = (
+  handle: ChildProcessHandle,
+  forceKillAfter: Duration.Input,
+): Effect.Effect<void> =>
+  killProcessTree(Number(handle.pid), { forceKillAfter }).pipe(
+    // Bounds the wait loop if it hangs; cannot cut short the ensuring escalate.
+    Effect.timeout(Duration.millis(Duration.toMillis(forceKillAfter) + 1_000)),
+    Effect.ignore,
+  )
 
 /**
  * Run a CLI once, capture full stdout, map non-zero exit and timeout to
@@ -71,6 +99,7 @@ export const runCliCapture = (
   Effect.gen(function* () {
     const spawner = input.spawner
     const timeoutMs = Duration.toMillis(input.timeout)
+    const forceKillAfter = input.forceKillAfter ?? DEFAULT_FORCE_KILL_AFTER
     const command = ChildProcess.make(
       input.binary,
       [...input.args],
@@ -80,6 +109,11 @@ export const runCliCapture = (
     const result = yield* Effect.scoped(
       Effect.gen(function* () {
         const handle = yield* spawner.spawn(command)
+        // Finalizer runs before Effect's handle cleanup (LIFO): snapshot the
+        // tree while the root is still alive, then reap group + descendants.
+        yield* Effect.addFinalizer(() =>
+          terminateCliTree(handle, forceKillAfter),
+        )
         return yield* collectChildStdout(handle)
       }),
     ).pipe(
@@ -114,6 +148,7 @@ export const runCliTurn = (
   Effect.gen(function* () {
     const spawner = input.spawner
     const timeoutMs = Duration.toMillis(input.timeout)
+    const forceKillAfter = input.forceKillAfter ?? DEFAULT_FORCE_KILL_AFTER
     const knownSessionId = input.knownSessionId
     const seenSessionId = yield* Ref.make(knownSessionId)
     const sessionIdNotified = yield* Ref.make(false)
@@ -128,6 +163,9 @@ export const runCliTurn = (
     const result = yield* Effect.scoped(
       Effect.gen(function* () {
         const handle = yield* spawner.spawn(command)
+        yield* Effect.addFinalizer(() =>
+          terminateCliTree(handle, forceKillAfter),
+        )
 
         const collectOutput = Stream.decodeText(handle.stdout).pipe(
           Stream.splitLines,
@@ -170,7 +208,17 @@ export const runCliTurn = (
                 if (event.finalizeText !== undefined) {
                   const running = yield* handle.isRunning
                   if (running) {
-                    yield* handle.kill()
+                    // Single authoritative tree kill; join exit without a
+                    // second full SIGTERM→SIGKILL budget on the direct child.
+                    yield* terminateCliTree(handle, forceKillAfter)
+                    yield* handle.exitCode.pipe(
+                      Effect.timeout(
+                        Duration.millis(
+                          Duration.toMillis(forceKillAfter) + 500,
+                        ),
+                      ),
+                      Effect.ignore,
+                    )
                   }
                   return {
                     sessionId,

--- a/packages/agent-backend/src/lib/kill-process-tree.ts
+++ b/packages/agent-backend/src/lib/kill-process-tree.ts
@@ -1,0 +1,259 @@
+import { execFileSync } from "node:child_process"
+import { readFileSync, readdirSync } from "node:fs"
+import { Clock, Duration, Effect } from "effect"
+
+/**
+ * Probe whether a pid still exists. `EPERM` means the process is present but
+ * unsignallable from this uid — treat as alive so wait/escalate still runs.
+ */
+const isAlive = (pid: number): boolean => {
+  try {
+    process.kill(pid, 0)
+    return true
+  } catch (error) {
+    const code =
+      error !== null &&
+      typeof error === "object" &&
+      "code" in error &&
+      typeof (error as { code: unknown }).code === "string"
+        ? (error as { code: string }).code
+        : undefined
+    return code === "EPERM"
+  }
+}
+
+/** Linux `/proc/<pid>/stat` starttime (field 22) for pid-reuse guards. */
+const readStarttime = (pid: number): string | undefined => {
+  if (process.platform !== "linux") return undefined
+  try {
+    const stat = readFileSync(`/proc/${pid}/stat`, "utf8")
+    const afterComm = stat.slice(stat.lastIndexOf(")") + 2).split(" ")
+    // Fields after comm: state, ppid, ... starttime is 22nd overall → index 19.
+    return afterComm[19]
+  } catch {
+    return undefined
+  }
+}
+
+type TrackedPid = {
+  readonly pid: number
+  readonly starttime: string | undefined
+}
+
+const trackPid = (pid: number): TrackedPid => ({
+  pid,
+  starttime: readStarttime(pid),
+})
+
+/**
+ * True if the pid still looks like the same process we snapshotted.
+ *
+ * - No starttime (non-Linux): fall back to liveness only.
+ * - Starttime known but re-read fails: not same (avoid kill-on-recycle after a
+ *   transient /proc glitch when we *did* capture identity).
+ * - Prefer kill only when identity was never available at track time.
+ */
+const isSameProcess = (tracked: TrackedPid): boolean => {
+  if (!isAlive(tracked.pid)) return false
+  if (tracked.starttime === undefined) return true
+  const current = readStarttime(tracked.pid)
+  if (current === undefined) return false
+  return current === tracked.starttime
+}
+
+const listDirectChildren = (pid: number): number[] => {
+  if (process.platform === "linux") {
+    const children: number[] = []
+    try {
+      for (const entry of readdirSync("/proc")) {
+        if (!/^\d+$/.test(entry)) continue
+        try {
+          const stat = readFileSync(`/proc/${entry}/stat`, "utf8")
+          // `/proc/<pid>/stat`: after comm (possibly with spaces), fields are
+          // state, ppid, pgrp, session, ...
+          const afterComm = stat.slice(stat.lastIndexOf(")") + 2).split(" ")
+          if (Number(afterComm[1]) === pid) {
+            children.push(Number(entry))
+          }
+        } catch {
+          // Process exited mid-scan.
+        }
+      }
+    } catch {
+      // /proc unavailable.
+    }
+    return children
+  }
+
+  if (process.platform === "win32") {
+    return []
+  }
+
+  // macOS and other POSIX: pgrep -P lists direct children.
+  try {
+    const out = execFileSync("pgrep", ["-P", String(pid)], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    })
+    return out
+      .trim()
+      .split("\n")
+      .filter(Boolean)
+      .map(Number)
+      .filter((n) => Number.isFinite(n) && n > 0)
+  } catch {
+    return []
+  }
+}
+
+/**
+ * Depth-first list of every process currently descended from `rootPid`.
+ *
+ * Snapshot before signalling the root so children that reparent after the
+ * leader dies remain killable.
+ */
+const listDescendantPids = (rootPid: number): number[] => {
+  const result: number[] = []
+  const stack = [rootPid]
+  const seen = new Set<number>([rootPid])
+  while (stack.length > 0) {
+    const pid = stack.pop()
+    if (pid === undefined) break
+    for (const child of listDirectChildren(pid)) {
+      if (!seen.has(child)) {
+        seen.add(child)
+        result.push(child)
+        stack.push(child)
+      }
+    }
+  }
+  return result
+}
+
+const signalPid = (pid: number, signal: NodeJS.Signals): void => {
+  try {
+    process.kill(pid, signal)
+  } catch {
+    // Already dead or not permitted.
+  }
+}
+
+/** Negative-pid group signal when the CLI was started as a process group leader. */
+const signalProcessGroup = (pgid: number, signal: NodeJS.Signals): void => {
+  if (process.platform === "win32") return
+  try {
+    process.kill(-pgid, signal)
+  } catch {
+    // Not a group leader, group already gone, or ESRCH.
+  }
+}
+
+const signalTree = (
+  root: TrackedPid,
+  descendants: ReadonlyArray<TrackedPid>,
+  signal: NodeJS.Signals,
+): void => {
+  if (process.platform === "win32") {
+    try {
+      execFileSync("taskkill", ["/pid", String(root.pid), "/T", "/F"], {
+        stdio: "ignore",
+      })
+    } catch {
+      // Process already gone.
+    }
+    return
+  }
+
+  // Group first only while the root still looks like the process we started
+  // (avoids signalling a recycled pid's process group).
+  if (isSameProcess(root)) {
+    signalProcessGroup(root.pid, signal)
+    signalPid(root.pid, signal)
+  }
+  for (const tracked of descendants) {
+    if (isSameProcess(tracked)) {
+      signalPid(tracked.pid, signal)
+    }
+  }
+}
+
+/**
+ * Whether any of the *original* snapshotted tree is still alive.
+ *
+ * Checks only the root and the initial descendant snapshot (starttime-gated).
+ * Does not re-walk PPID under the root — that would follow a recycled root
+ * pid. Late-spawned children are reaped in escalate when the root is still
+ * ours.
+ */
+const anyAlive = (
+  root: TrackedPid,
+  descendants: ReadonlyArray<TrackedPid>,
+): boolean => {
+  if (isSameProcess(root)) {
+    return true
+  }
+  if (descendants.some(isSameProcess)) {
+    return true
+  }
+  return false
+}
+
+export type KillProcessTreeOptions = {
+  readonly forceKillAfter?: Duration.Input
+}
+
+/**
+ * Kill a harness-spawned CLI and everything it started.
+ *
+ * 1. Snapshot descendants via PPID (catches `setsid` grandchildren still in the tree).
+ * 2. SIGTERM the process group and every known pid.
+ * 3. Wait up to `forceKillAfter`, then always SIGKILL (via `Effect.ensuring`) so
+ *    interruption/timeout cannot leave the tree SIGTERM-only.
+ */
+export const killProcessTree = (
+  rootPid: number,
+  options: KillProcessTreeOptions = {},
+): Effect.Effect<void> =>
+  Effect.gen(function* () {
+    if (!Number.isFinite(rootPid) || rootPid <= 0) {
+      return
+    }
+
+    if (process.platform === "win32") {
+      signalTree(trackPid(rootPid), [], "SIGKILL")
+      return
+    }
+
+    const forceKillAfter = options.forceKillAfter ?? Duration.seconds(2)
+    const root = trackPid(rootPid)
+    const descendants = listDescendantPids(rootPid).map(trackPid)
+
+    // Ensuring body must stay short (uninterruptible). Re-scan only when the
+    // original root is still ours; always SIGKILL the starttime-checked snapshot
+    // so setsid orphans reaped from the initial walk still die.
+    const escalate = Effect.sync(() => {
+      const byPid = new Map<number, TrackedPid>()
+      for (const tracked of descendants) {
+        byPid.set(tracked.pid, tracked)
+      }
+      if (isSameProcess(root)) {
+        for (const tracked of listDescendantPids(rootPid).map(trackPid)) {
+          byPid.set(tracked.pid, tracked)
+        }
+      }
+      signalTree(root, [...byPid.values()], "SIGKILL")
+    })
+
+    yield* Effect.gen(function* () {
+      signalTree(root, descendants, "SIGTERM")
+
+      const forceMs = Duration.toMillis(forceKillAfter)
+      const started = yield* Clock.currentTimeMillis
+      while ((yield* Clock.currentTimeMillis) - started < forceMs) {
+        if (!anyAlive(root, descendants)) {
+          return
+        }
+        yield* Effect.sleep(Duration.millis(25))
+      }
+    }).pipe(Effect.ensuring(escalate))
+  })

--- a/packages/agent-backend/test/cli-runner.spec.ts
+++ b/packages/agent-backend/test/cli-runner.spec.ts
@@ -257,11 +257,15 @@ describe("runCliTurn", () => {
   it("terminates the process tree on timeout", async () => {
     const markerDir = await mkdtemp(join(tmpdir(), "agent-backend-tree-"))
     const childAlive = join(markerDir, "child-alive")
+    const grandPidFile = join(markerDir, "grand.pid")
     try {
       await withExecutable(
         [
-          `printf '%s\\n' '{"sessionID":"ses_tree"}'`,
+          // Record grandchild pid before the session line so the assert is hard.
           `( while true; do touch "${childAlive}"; sleep 0.05; done ) &`,
+          `echo $! > "${grandPidFile}"`,
+          `while [ ! -s "${grandPidFile}" ]; do sleep 0.01; done`,
+          `printf '%s\\n' '{"sessionID":"ses_tree"}'`,
           "wait",
         ].join("\n"),
         async (binary) => {
@@ -285,10 +289,173 @@ describe("runCliTurn", () => {
             .then((s) => Date.now() - s.mtime.getTime() < 200)
             .catch(() => false)
           expect(stillTouched).toBe(false)
+
+          const grandPid = Number(
+            (
+              await Bun.file(grandPidFile)
+                .text()
+                .catch(() => "")
+            ).trim(),
+          )
+          expect(Number.isFinite(grandPid) && grandPid > 0).toBe(true)
+          expect(isPidAlive(grandPid)).toBe(false)
         },
       )
     } finally {
       await rm(markerDir, { recursive: true, force: true })
     }
   })
+
+  it("terminates setsid grandchildren on timeout", async () => {
+    const markerDir = await mkdtemp(join(tmpdir(), "agent-backend-setsid-"))
+    const childAlive = join(markerDir, "child-alive")
+    const grandPidFile = join(markerDir, "grand.pid")
+    try {
+      await withExecutable(
+        [
+          // Leave the process group (like some agent CLIs) so group-only kill
+          // is insufficient; tree kill via PPID must still reap the child.
+          `setsid sh -c 'echo $$ > "${grandPidFile}"; while true; do touch "${childAlive}"; sleep 0.05; done' &`,
+          `while [ ! -s "${grandPidFile}" ]; do sleep 0.01; done`,
+          `printf '%s\\n' '{"sessionID":"ses_setsid"}'`,
+          "sleep 100",
+        ].join("\n"),
+        async (binary) => {
+          await Effect.runPromise(
+            withSpawner((spawner) =>
+              runCliTurn({
+                spawner,
+                binary,
+                args: [],
+                cwd: process.cwd(),
+                env: sanitizeInheritedEnvironment(),
+                timeout: Duration.millis(400),
+                parseLine: parseSimpleLine,
+                forceKillAfter: Duration.millis(100),
+              }).pipe(Effect.flip),
+            ),
+          )
+          await Bun.sleep(300)
+          const grandPid = Number(
+            (
+              await Bun.file(grandPidFile)
+                .text()
+                .catch(() => "")
+            ).trim(),
+          )
+          expect(Number.isFinite(grandPid) && grandPid > 0).toBe(true)
+          expect(isPidAlive(grandPid)).toBe(false)
+          const stillTouched = await Bun.file(childAlive)
+            .stat()
+            .then((s) => Date.now() - s.mtime.getTime() < 200)
+            .catch(() => false)
+          expect(stillTouched).toBe(false)
+        },
+      )
+    } finally {
+      await rm(markerDir, { recursive: true, force: true })
+    }
+  })
+
+  it("terminates the process tree on finalizeText", async () => {
+    const markerDir = await mkdtemp(join(tmpdir(), "agent-backend-finalize-"))
+    const childAlive = join(markerDir, "child-alive")
+    const grandPidFile = join(markerDir, "grand.pid")
+    try {
+      await withExecutable(
+        [
+          // Spawn the setsid grandchild first so it exists before finalize kills.
+          `setsid sh -c 'echo $$ > "${grandPidFile}"; while true; do touch "${childAlive}"; sleep 0.05; done' &`,
+          `while [ ! -s "${grandPidFile}" ]; do sleep 0.01; done`,
+          `printf '%s\\n' '{"sessionID":"ses_fin","finalize":"done"}'`,
+          "sleep 100",
+        ].join("\n"),
+        async (binary) => {
+          const result = await Effect.runPromise(
+            withSpawner((spawner) =>
+              runCliTurn({
+                spawner,
+                binary,
+                args: [],
+                cwd: process.cwd(),
+                env: sanitizeInheritedEnvironment(),
+                timeout: Duration.seconds(5),
+                forceKillAfter: Duration.millis(100),
+                parseLine: (line) => {
+                  try {
+                    const parsed = JSON.parse(line) as {
+                      sessionID?: string
+                      finalize?: string
+                    }
+                    if (
+                      typeof parsed.sessionID === "string" &&
+                      typeof parsed.finalize === "string"
+                    ) {
+                      return {
+                        sessionId: parsed.sessionID,
+                        finalizeText: parsed.finalize,
+                      }
+                    }
+                    return parseSimpleLine(line)
+                  } catch {
+                    return {}
+                  }
+                },
+              }),
+            ),
+          )
+          expect(result).toEqual({
+            sessionId: "ses_fin",
+            assistantText: "done",
+          })
+          await Bun.sleep(300)
+          const grandPid = Number(
+            (
+              await Bun.file(grandPidFile)
+                .text()
+                .catch(() => "")
+            ).trim(),
+          )
+          expect(Number.isFinite(grandPid) && grandPid > 0).toBe(true)
+          expect(isPidAlive(grandPid)).toBe(false)
+        },
+      )
+    } finally {
+      await rm(markerDir, { recursive: true, force: true })
+    }
+  })
+
+  it("returns cleanly when the CLI exits on its own", async () => {
+    await withExecutable(
+      [`printf '%s\\n' '{"sessionID":"ses_clean","text":"ok"}'`].join("\n"),
+      async (binary) => {
+        const result = await Effect.runPromise(
+          withSpawner((spawner) =>
+            runCliTurn({
+              spawner,
+              binary,
+              args: [],
+              cwd: process.cwd(),
+              env: sanitizeInheritedEnvironment(),
+              timeout: Duration.seconds(2),
+              parseLine: parseSimpleLine,
+            }),
+          ),
+        )
+        expect(result).toEqual({
+          sessionId: "ses_clean",
+          assistantText: "ok",
+        })
+      },
+    )
+  })
 })
+
+const isPidAlive = (pid: number): boolean => {
+  try {
+    process.kill(pid, 0)
+    return true
+  } catch {
+    return false
+  }
+}


### PR DESCRIPTION
## Summary

- Spawn agent CLIs in their own process group (`detached` on POSIX) so group signals reach the whole turn.
- Reap the full PPID tree on timeout, finalize, and interrupt: SIGTERM then SIGKILL (via `Effect.ensuring`), with Linux starttime guards against PID reuse.
- Cover in-group grandchildren, `setsid` orphans, finalizeText, and clean exit in `cli-runner` tests.

## Test plan

- [x] `bunx nx test agent-backend`
- [x] `bunx nx run agent-backend:build`
- [x] Pre-commit affected lint/typecheck/test (via commit hooks)

Closes #516