### PR TITLE
feat(work-item): enroll every open Parent child with auto-merge

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -184,7 +184,7 @@ A durable record of one operator-requested attempt to complete a Leaf Issue's ob
 _Avoid_: Issue lifecycle, implementation job, attempt
 
 **Implement All with Auto-merge**:
-A Parent Issue operator command that enrolls open Child Issues as ordinary independent Work Items with Merge Mode Always. It creates no Parent Work Item, batch, or parent lifecycle and never updates or closes the Parent Issue. First slice: only when the Parent has exactly one open actionable Child Issue with no unfinished Work Item.
+A Parent Issue operator command that atomically enrolls every current open Child Issue without an unfinished Work Item as an ordinary independent Work Item with Merge Mode Always. Unblocked children follow Implement Now and Worker Slot admission; blocked children follow Queue and enter Waiting for blockers. Siblings may run concurrently under the global Worker Slot limit; parent order does not invent dependencies. It creates no Parent Work Item, batch, or parent lifecycle and never updates or closes the Parent Issue. Children with existing unfinished Work Items are not adopted by this command until a later product slice.
 _Avoid_: Parent batch, implement parent, bulk implement without auto-merge
 
 **Implement**:

--- a/apps/harness/src/parent-issue-actions-menu.tsx
+++ b/apps/harness/src/parent-issue-actions-menu.tsx
@@ -115,14 +115,23 @@ const isServerUnfinishedWorkItemState = (state: string): boolean => {
 }
 
 /**
- * First-slice eligibility: Parent with exactly one open actionable Child Issue
- * (leaf, unblocked) and no unfinished Work Item for that child.
+ * Eligibility: Parent with one or more open leaf Child Issues that have no
+ * unfinished Work Item (blocked or unblocked). Unsupported hierarchy shapes
+ * (any direct child with children, including closed mid-level Issues) hide the
+ * action, matching the server Supported Issue Hierarchy check.
  */
 export function isParentImplementAllWithAutoMergeEligible(input: {
   readonly openChildren: readonly {
     readonly githubIssueNumber: number
     readonly hasChildren: boolean
     readonly blockedBy: readonly unknown[]
+  }[]
+  /**
+   * All direct children of the Parent (open and closed). Hierarchy rejection
+   * uses this full set so a closed intermediate child still hides the action.
+   */
+  readonly directChildren: readonly {
+    readonly hasChildren: boolean
   }[]
   readonly workItems: readonly {
     readonly githubIssueNumber: number
@@ -131,14 +140,16 @@ export function isParentImplementAllWithAutoMergeEligible(input: {
   readonly workItemsLoading: boolean
 }): boolean {
   if (input.workItemsLoading) return false
-  if (input.openChildren.length !== 1) return false
-  const [child] = input.openChildren
-  if (child === undefined) return false
-  if (child.hasChildren || child.blockedBy.length > 0) return false
-  const unfinished = input.workItems.some(
-    (workItem) =>
-      workItem.githubIssueNumber === child.githubIssueNumber &&
-      isServerUnfinishedWorkItemState(workItem.state),
-  )
-  return !unfinished
+  if (input.openChildren.length === 0) return false
+  // Match server: any direct child with children is unsupported hierarchy.
+  if (input.directChildren.some((child) => child.hasChildren)) return false
+
+  return input.openChildren.some((child) => {
+    const unfinished = input.workItems.some(
+      (workItem) =>
+        workItem.githubIssueNumber === child.githubIssueNumber &&
+        isServerUnfinishedWorkItemState(workItem.state),
+    )
+    return !unfinished
+  })
 }

--- a/apps/harness/src/routes/index.tsx
+++ b/apps/harness/src/routes/index.tsx
@@ -2462,6 +2462,7 @@ function ParentIssueGroup({
   const openChildren = childIssues.filter((child) => child.state === "OPEN")
   const canImplementAll = isParentImplementAllWithAutoMergeEligible({
     openChildren,
+    directChildren: childIssues,
     workItems,
     workItemsLoading,
   })

--- a/apps/harness/test/parent-issue-actions-menu.test.tsx
+++ b/apps/harness/test/parent-issue-actions-menu.test.tsx
@@ -8,12 +8,20 @@ import {
 import { describe, expect, test } from "bun:test"
 
 describe("isParentImplementAllWithAutoMergeEligible", () => {
-  test("requires exactly one open actionable child without unfinished work", () => {
+  const leaf = (
+    githubIssueNumber: number,
+    blockedBy: readonly unknown[] = [],
+  ) => ({
+    githubIssueNumber,
+    hasChildren: false,
+    blockedBy,
+  })
+
+  test("allows one or more open leaf children without unfinished work, including blocked", () => {
     expect(
       isParentImplementAllWithAutoMergeEligible({
-        openChildren: [
-          { githubIssueNumber: 2, hasChildren: false, blockedBy: [] },
-        ],
+        openChildren: [leaf(2)],
+        directChildren: [leaf(2)],
         workItems: [],
         workItemsLoading: false,
       }),
@@ -21,35 +29,72 @@ describe("isParentImplementAllWithAutoMergeEligible", () => {
 
     expect(
       isParentImplementAllWithAutoMergeEligible({
-        openChildren: [
-          { githubIssueNumber: 2, hasChildren: false, blockedBy: [] },
-          { githubIssueNumber: 3, hasChildren: false, blockedBy: [] },
-        ],
+        openChildren: [leaf(2), leaf(3)],
+        directChildren: [leaf(2), leaf(3)],
         workItems: [],
         workItemsLoading: false,
       }),
-    ).toBe(false)
+    ).toBe(true)
 
     expect(
       isParentImplementAllWithAutoMergeEligible({
-        openChildren: [
-          {
-            githubIssueNumber: 2,
-            hasChildren: false,
-            blockedBy: [{ githubIssueNumber: 1 }],
-          },
-        ],
+        openChildren: [leaf(2, [{ githubIssueNumber: 1 }]), leaf(3)],
+        directChildren: [leaf(2, [{ githubIssueNumber: 1 }]), leaf(3)],
         workItems: [],
         workItemsLoading: false,
       }),
-    ).toBe(false)
+    ).toBe(true)
 
     expect(
       isParentImplementAllWithAutoMergeEligible({
-        openChildren: [
-          { githubIssueNumber: 2, hasChildren: false, blockedBy: [] },
-        ],
+        openChildren: [leaf(2, [{ githubIssueNumber: 1 }])],
+        directChildren: [leaf(2, [{ githubIssueNumber: 1 }])],
+        workItems: [],
+        workItemsLoading: false,
+      }),
+    ).toBe(true)
+
+    expect(
+      isParentImplementAllWithAutoMergeEligible({
+        openChildren: [leaf(2)],
+        directChildren: [leaf(2)],
         workItems: [{ githubIssueNumber: 2, state: "CREATE_WORKTREE" }],
+        workItemsLoading: false,
+      }),
+    ).toBe(false)
+  })
+
+  test("stays available when some open children already have unfinished work", () => {
+    expect(
+      isParentImplementAllWithAutoMergeEligible({
+        openChildren: [leaf(2), leaf(3)],
+        directChildren: [leaf(2), leaf(3)],
+        workItems: [{ githubIssueNumber: 2, state: "CREATE_WORKTREE" }],
+        workItemsLoading: false,
+      }),
+    ).toBe(true)
+  })
+
+  test("hides unsupported hierarchy for open or closed direct children with children", () => {
+    expect(
+      isParentImplementAllWithAutoMergeEligible({
+        openChildren: [
+          { githubIssueNumber: 2, hasChildren: true, blockedBy: [] },
+        ],
+        directChildren: [
+          { githubIssueNumber: 2, hasChildren: true, blockedBy: [] },
+        ],
+        workItems: [],
+        workItemsLoading: false,
+      }),
+    ).toBe(false)
+
+    // Closed mid-level child still fails server hierarchy; hide the action.
+    expect(
+      isParentImplementAllWithAutoMergeEligible({
+        openChildren: [leaf(3)],
+        directChildren: [{ hasChildren: true }, { hasChildren: false }],
+        workItems: [],
         workItemsLoading: false,
       }),
     ).toBe(false)
@@ -58,9 +103,8 @@ describe("isParentImplementAllWithAutoMergeEligible", () => {
   test("blocks Needs Human (terminal, non-retryable) to match server unfinished rules", () => {
     expect(
       isParentImplementAllWithAutoMergeEligible({
-        openChildren: [
-          { githubIssueNumber: 2, hasChildren: false, blockedBy: [] },
-        ],
+        openChildren: [leaf(2)],
+        directChildren: [leaf(2)],
         workItems: [{ githubIssueNumber: 2, state: "NEEDS_HUMAN" }],
         workItemsLoading: false,
       }),
@@ -71,9 +115,8 @@ describe("isParentImplementAllWithAutoMergeEligible", () => {
     for (const state of ["COMPLETE", "FAILED", "ABANDONED"] as const) {
       expect(
         isParentImplementAllWithAutoMergeEligible({
-          openChildren: [
-            { githubIssueNumber: 2, hasChildren: false, blockedBy: [] },
-          ],
+          openChildren: [leaf(2)],
+          directChildren: [leaf(2)],
           workItems: [{ githubIssueNumber: 2, state }],
           workItemsLoading: false,
         }),

--- a/docs/adr/0040-parent-implement-all-merge-mode-always.md
+++ b/docs/adr/0040-parent-implement-all-merge-mode-always.md
@@ -8,4 +8,4 @@ Merge Mode `always` skips only Decide PR Merge after the normal pre-merge lifecy
 
 - Child Work Items remain independent under the global Worker Slot limit; siblings may run concurrently.
 - Enrollment is atomic: failure creates no partial Work Items or Merge Mode updates.
-- First product slice supports a Parent with exactly one open actionable child; later tickets widen enrollment without replacing the Merge Mode or bulk-command model.
+- Open children without unfinished Work Items are enrolled together (Implement Now or Queue); adopting existing unfinished child Work Items remains a later product slice.

--- a/packages/graphql-api/test/graphql-api.test.ts
+++ b/packages/graphql-api/test/graphql-api.test.ts
@@ -3569,12 +3569,22 @@ describe("GraphQL API", () => {
     expect(receivedArgs).toEqual([repository.id, issue.githubIssueNumber])
   })
 
-  test("implements all with auto-merge for a Parent Issue child", async () => {
+  test("implements all with auto-merge for a Parent Issue's covered children", async () => {
     let receivedArgs: readonly [string, number] | undefined
-    const alwaysWorkItem = {
+    const actionableChild = {
       ...workItem,
+      id: makeWorkItemId(),
       mergeMode: "always" as const,
       githubIssueNumber: 43,
+    }
+    const blockedChild = {
+      ...workItem,
+      id: makeWorkItemId(),
+      mergeMode: "always" as const,
+      githubIssueNumber: 44,
+      waitingForBlockers: true,
+      holdsWorkerSlot: false,
+      stepRuns: [],
     }
     await runtime.dispose()
     runtime = makeRuntime(
@@ -3584,7 +3594,7 @@ describe("GraphQL API", () => {
       {
         implementAllWithAutoMerge: (repositoryId, githubIssueNumber) => {
           receivedArgs = [repositoryId, githubIssueNumber]
-          return Effect.succeed([alwaysWorkItem])
+          return Effect.succeed([actionableChild, blockedChild])
         },
       },
     )
@@ -3593,7 +3603,7 @@ describe("GraphQL API", () => {
       graphqlRequest({
         query: `mutation ImplementAllWithAutoMerge($repositoryId: ID!, $githubIssueNumber: Int!) {
           implementAllWithAutoMerge(repositoryId: $repositoryId, githubIssueNumber: $githubIssueNumber) {
-            id githubIssueNumber mergeMode state
+            id githubIssueNumber mergeMode state status statusLabel
           }
         }`,
         variables: {
@@ -3607,10 +3617,20 @@ describe("GraphQL API", () => {
       data: {
         implementAllWithAutoMerge: [
           {
-            id: workItem.id,
+            id: actionableChild.id,
             githubIssueNumber: 43,
             mergeMode: "ALWAYS",
             state: "CREATE_WORKTREE",
+            status: "RUNNING",
+            statusLabel: "Running",
+          },
+          {
+            id: blockedChild.id,
+            githubIssueNumber: 44,
+            mergeMode: "ALWAYS",
+            state: "CREATE_WORKTREE",
+            status: "WAITING_FOR_BLOCKERS",
+            statusLabel: "Waiting for blockers",
           },
         ],
       },
@@ -3631,7 +3651,7 @@ describe("GraphQL API", () => {
             repositoryId: repository.id,
             githubIssueNumber: 10,
             reason:
-              "Parent Issue #10 has 2 open Child Issues; this slice supports exactly one",
+              "Parent Issue #10 has no open Child Issues without an unfinished Work Item",
           } as never),
       },
     )
@@ -3657,7 +3677,9 @@ describe("GraphQL API", () => {
     expect(body.errors[0]?.extensions.code).toBe(
       "IMPLEMENT_ALL_WITH_AUTO_MERGE_NOT_ELIGIBLE",
     )
-    expect(body.errors[0]?.message).toContain("exactly one")
+    expect(body.errors[0]?.message).toContain(
+      "no open Child Issues without an unfinished Work Item",
+    )
   })
 
   test("queues a blocked Issue Work Item", async () => {

--- a/packages/graphql-schema/schema.graphql
+++ b/packages/graphql-schema/schema.graphql
@@ -482,9 +482,10 @@ type Mutation {
   """
   implementLocally(repositoryId: ID!, githubIssueNumber: Int!): WorkItem!
   """
-  Parent-level Implement all with auto-merge. First slice: Parent Issue with
-  exactly one open actionable Child Issue and no unfinished Work Item. Creates
-  that child's Work Item with Merge Mode ALWAYS. Returns covered child Work Items.
+  Parent-level Implement all with auto-merge. Snapshots open direct Child Issues
+  without an unfinished Work Item and creates ordinary Work Items with Merge Mode
+  ALWAYS atomically: unblocked children use Implement Now admission; blocked
+  children use Queue (Waiting for blockers). Returns covered child Work Items.
   Does not create a Parent Work Item.
   """
   implementAllWithAutoMerge(

--- a/packages/work-item-lifecycle/src/lib/errors.ts
+++ b/packages/work-item-lifecycle/src/lib/errors.ts
@@ -57,8 +57,9 @@ export class UnsupportedIssueHierarchyError extends Schema.TaggedErrorClass<Unsu
 ) {}
 
 /**
- * Parent Issue is outside the current Implement all with auto-merge eligibility
- * slice (open-child count, actionability, unfinished Work Item, etc.).
+ * Parent Issue is not eligible for Implement all with auto-merge (no open
+ * Child Issues without an unfinished Work Item, or concurrent enrollment
+ * conflict).
  */
 export class ImplementAllWithAutoMergeNotEligibleError extends Schema.TaggedErrorClass<ImplementAllWithAutoMergeNotEligibleError>()(
   "ImplementAllWithAutoMergeNotEligibleError",

--- a/packages/work-item-lifecycle/src/lib/work-item-lifecycle.ts
+++ b/packages/work-item-lifecycle/src/lib/work-item-lifecycle.ts
@@ -515,10 +515,6 @@ export type ImplementAllWithAutoMergeError =
   | NotAParentIssueError
   | UnsupportedIssueHierarchyError
   | ImplementAllWithAutoMergeNotEligibleError
-  | IssueNotOpenError
-  | ParentIssueError
-  | IssueBlockedError
-  | UnfinishedWorkItemExistsError
   | BuildModelNotConfiguredError
   | AgentBackendUnavailableError
   | WorkItemLifecycleDatabaseError
@@ -642,9 +638,11 @@ export interface WorkItemLifecycleShape {
     githubIssueNumber: number,
   ) => Effect.Effect<WorkItemRecord, ImplementNowError>
   /**
-   * Parent-level Implement all with auto-merge (first slice: exactly one open
-   * actionable Child Issue with no unfinished Work Item). Creates that child's
-   * ordinary Work Item with Merge Mode Always. No Parent Work Item.
+   * Parent-level Implement all with auto-merge. Snapshots open direct Child
+   * Issues without an unfinished Work Item and creates ordinary Work Items with
+   * Merge Mode Always atomically: unblocked children follow Implement Now
+   * admission; blocked children follow Queue (Waiting for blockers). No Parent
+   * Work Item.
    */
   readonly implementAllWithAutoMerge: (
     repositoryId: string,
@@ -4898,8 +4896,9 @@ export const makeWorkItemLifecycleLive = (
       )
 
       /**
-       * First-slice parent command: exactly one open actionable child, no
-       * unfinished Work Item. Creates one child Work Item with Merge Mode Always.
+       * Parent command: enroll every open direct child without an unfinished
+       * Work Item. Unblocked → Implement Now admission; blocked → Queue.
+       * All creations, Step Runs, and lifecycle jobs are one atomic unit.
        */
       const implementAllWithAutoMerge = Effect.fn(
         "WorkItemLifecycle.implementAllWithAutoMerge",
@@ -4938,61 +4937,217 @@ export const makeWorkItemLifecycleLive = (
           })
         }
 
-        const openChildren = children.filter((child) => child.state === "OPEN")
-        if (openChildren.length !== 1) {
-          return yield* new ImplementAllWithAutoMergeNotEligibleError({
-            repositoryId,
-            githubIssueNumber: parentGithubIssueNumber,
-            reason:
-              openChildren.length === 0
-                ? `Parent Issue #${parentGithubIssueNumber} has no open Child Issues`
-                : `Parent Issue #${parentGithubIssueNumber} has ${openChildren.length} open Child Issues; this slice supports exactly one`,
+        // Snapshot open direct children at acceptance; closed children and
+        // children added later are out of scope for this request.
+        const openChildren = children
+          .filter((child) => child.state === "OPEN")
+          .slice()
+          .sort((a, b) => {
+            const aPos = a.parentPosition ?? Number.MAX_SAFE_INTEGER
+            const bPos = b.parentPosition ?? Number.MAX_SAFE_INTEGER
+            if (aPos !== bPos) return aPos - bPos
+            return a.githubIssueNumber - b.githubIssueNumber
           })
-        }
 
-        const [child] = openChildren
-        if (child === undefined) {
+        if (openChildren.length === 0) {
           return yield* new ImplementAllWithAutoMergeNotEligibleError({
             repositoryId,
             githubIssueNumber: parentGithubIssueNumber,
             reason: `Parent Issue #${parentGithubIssueNumber} has no open Child Issues`,
           })
         }
-        if (child.blockedBy.length > 0) {
-          return yield* new ImplementAllWithAutoMergeNotEligibleError({
-            repositoryId,
-            githubIssueNumber: parentGithubIssueNumber,
-            reason: `Child Issue #${child.githubIssueNumber} is blocked; this slice requires an actionable child`,
-          })
-        }
 
-        const existing = yield* listWorkItemsForIssue(
-          repositoryId,
-          child.githubIssueNumber,
-        )
-        const unfinished = existing.find(
-          (item) =>
+        // Existing unfinished Work Items are not adopted here (later ticket);
+        // only children that still need a new Work Item are enrolled.
+        const repositoryWorkItems =
+          yield* listWorkItemsForRepository(repositoryId)
+        const unfinishedByIssue = new Map<number, WorkItemId>()
+        for (const item of repositoryWorkItems) {
+          if (
             item.state !== "complete" &&
             item.state !== "failed" &&
-            item.state !== "abandoned",
+            item.state !== "abandoned"
+          ) {
+            unfinishedByIssue.set(item.githubIssueNumber, item.id)
+          }
+        }
+
+        const toEnroll = openChildren.filter(
+          (child) => !unfinishedByIssue.has(child.githubIssueNumber),
         )
-        if (unfinished) {
+
+        if (toEnroll.length === 0) {
           return yield* new ImplementAllWithAutoMergeNotEligibleError({
             repositoryId,
             githubIssueNumber: parentGithubIssueNumber,
-            reason: `Child Issue #${child.githubIssueNumber} already has an unfinished Work Item`,
+            reason: `Parent Issue #${parentGithubIssueNumber} has no open Child Issues without an unfinished Work Item`,
           })
         }
 
-        const created = yield* createWorkItem(
-          repositoryId,
-          child.githubIssueNumber,
-          {
-            pauseBeforeStep: null,
-            mergeMode: "always",
-          },
+        const createdIds = yield* activeAgentBackend.withConfigCoordination(
+          Effect.gen(function* () {
+            const harnessConfig = yield* db.getConfig
+            const repositories = yield* db.listRepositories
+            const repository = repositories.find(
+              ({ id }) => id === repositoryId,
+            )
+            const rawCaptureBackendId =
+              repository?.selectedAgentBackend ??
+              harnessConfig.selectedAgentBackend
+            if (!isSelectableAgentBackendId(rawCaptureBackendId)) {
+              return yield* new AgentBackendUnavailableError({
+                message: `Unknown or unsupported Agent Backend: ${rawCaptureBackendId}`,
+                reason: `Unknown or unsupported Agent Backend: ${rawCaptureBackendId}`,
+              })
+            }
+            const captureBackendId = rawCaptureBackendId
+            yield* activeAgentBackend
+              .requireAgentTurnsAllowed(captureBackendId)
+              .pipe(
+                Effect.mapError(
+                  (error) =>
+                    new AgentBackendUnavailableError({
+                      message: error.message,
+                      reason: error.reason,
+                    }),
+                ),
+              )
+            yield* resolveModelsForBackend(repositoryId, captureBackendId)
+            const activeRegistration =
+              yield* activeAgentBackend.getRegistration(captureBackendId)
+            const agentBackendId = activeRegistration.descriptor.id
+            const now = yield* Clock.currentTimeMillis
+            const step: OperationalLifecycleStep = "create_worktree"
+
+            return yield* sql
+              .withTransaction(
+                Effect.gen(function* () {
+                  const limit = yield* maxWorkerSlots()
+                  let occupied = yield* countOccupiedWorkerSlots()
+                  const workItemIds: WorkItemId[] = []
+
+                  for (const child of toEnroll) {
+                    const workItemId = makeWorkItemId()
+                    const blocked = child.blockedBy.length > 0
+
+                    if (blocked) {
+                      yield* sql.unsafe(
+                        `INSERT INTO work_item (
+                     id, repository_id, github_issue_number, agent_backend,
+                      issue_title, state, state_ready_at, paused,
+                      waiting_since, waiting_for_blockers, merge_mode, holds_worker_slot,
+                      pause_before_step, worktree_path, session_id, failure_code,
+                      failure_message, created_at, updated_at
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, 0, NULL, 1, 'always', 0, NULL, NULL, NULL, NULL, NULL, ?, ?)`,
+                        [
+                          workItemId,
+                          repositoryId,
+                          child.githubIssueNumber,
+                          agentBackendId,
+                          child.title,
+                          step,
+                          now,
+                          now,
+                          now,
+                        ],
+                      )
+                    } else {
+                      const admit = occupied < limit
+                      yield* sql.unsafe(
+                        `INSERT INTO work_item (
+                     id, repository_id, github_issue_number, agent_backend,
+                      issue_title, state, state_ready_at, paused,
+                      waiting_since, waiting_for_blockers, merge_mode, holds_worker_slot,
+                      pause_before_step, worktree_path, session_id, failure_code,
+                      failure_message, created_at, updated_at
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, 0, ?, 0, 'always', ?, NULL, NULL, NULL, NULL, NULL, ?, ?)`,
+                        [
+                          workItemId,
+                          repositoryId,
+                          child.githubIssueNumber,
+                          agentBackendId,
+                          child.title,
+                          step,
+                          now,
+                          admit ? null : now,
+                          admit ? 1 : 0,
+                          now,
+                          now,
+                        ],
+                      )
+                      if (admit) {
+                        occupied += 1
+                        yield* enqueueStepRunForWorkItem(workItemId, step, now)
+                      }
+                    }
+
+                    workItemIds.push(workItemId)
+                  }
+
+                  return workItemIds
+                }),
+              )
+              .pipe(
+                Effect.catch(
+                  (
+                    error,
+                  ): Effect.Effect<never, ImplementAllWithAutoMergeError> => {
+                    if (error instanceof WorkItemLifecycleDatabaseError) {
+                      return Effect.fail(error)
+                    }
+                    if (error instanceof EnqueueError) {
+                      return Effect.fail(error)
+                    }
+                    if (error instanceof InvalidQueueNameError) {
+                      return Effect.fail(error)
+                    }
+                    if (
+                      typeof error === "object" &&
+                      error !== null &&
+                      "_tag" in error &&
+                      (error as { _tag: string })._tag === "SqlError"
+                    ) {
+                      const sqlError = error as SqlError
+                      if (isUnfinishedWorkItemUniqueViolation(sqlError)) {
+                        return Effect.fail(
+                          new ImplementAllWithAutoMergeNotEligibleError({
+                            repositoryId,
+                            githubIssueNumber: parentGithubIssueNumber,
+                            reason: `A concurrent request enrolled a Child Issue of Parent Issue #${parentGithubIssueNumber}`,
+                          }),
+                        )
+                      }
+                      return Effect.fail(toDatabaseError(sqlError))
+                    }
+                    return Effect.fail(
+                      new WorkItemLifecycleDatabaseError({
+                        message: `Unexpected transaction failure: ${String(error)}`,
+                        cause: error,
+                      }),
+                    )
+                  },
+                ),
+              )
+          }),
         )
-        return [created] as const
+
+        const covered = yield* Effect.forEach(
+          createdIds,
+          (workItemId) =>
+            getWorkItem(workItemId).pipe(
+              Effect.catchTag(
+                "WorkItemNotFoundError",
+                (error) =>
+                  new WorkItemLifecycleDatabaseError({
+                    message: `Work Item missing after implement-all create: ${error.workItemId}`,
+                    cause: error,
+                  }),
+              ),
+            ),
+          { concurrency: 1 },
+        )
+        yield* notifyWorkItemsChanged(repositoryId)
+        return covered
       })
 
       const queueIssue = Effect.fn("WorkItemLifecycle.queue")(function* (

--- a/packages/work-item-lifecycle/test/work-item-lifecycle.spec.ts
+++ b/packages/work-item-lifecycle/test/work-item-lifecycle.spec.ts
@@ -716,7 +716,7 @@ describe("WorkItemLifecycle", () => {
         }),
       ))
 
-    it("rejects missing, non-parent, multi-child, blocked, and unfinished cases", () =>
+    it("rejects missing, non-parent, no-open, unsupported hierarchy, and unfinished-only cases", () =>
       runTest(
         Effect.gen(function* () {
           const lifecycle = yield* WorkItemLifecycle
@@ -740,66 +740,6 @@ describe("WorkItemLifecycle", () => {
             lifecycle.implementAllWithAutoMerge(repository.id, 50),
           )
           expect(notParent).toBeInstanceOf(NotAParentIssueError)
-
-          yield* db.storeIssue({
-            repositoryId: repository.id,
-            githubIssueNumber: 102,
-            ...sampleIssueFields,
-            title: "Second child",
-            url: "https://github.com/acme/widgets/issues/102",
-            parent: {
-              githubIssueNumber: 100,
-              githubIssueUrl: "https://github.com/acme/widgets/issues/100",
-            },
-            parentPosition: 1,
-          })
-          const multi = yield* Effect.flip(
-            lifecycle.implementAllWithAutoMerge(
-              repository.id,
-              parent.githubIssueNumber,
-            ),
-          )
-          expect(multi).toBeInstanceOf(
-            ImplementAllWithAutoMergeNotEligibleError,
-          )
-
-          // Single open child but blocked.
-          const blockedRepo = yield* db.addRepository({
-            ...sampleRepository,
-            localPath: "/repos/acme/widgets-blocked-parent.git",
-            githubRepo: "widgets-blocked-parent",
-          })
-          yield* db.storeIssue({
-            repositoryId: blockedRepo.id,
-            githubIssueNumber: 200,
-            ...sampleIssueFields,
-            title: "Blocked parent",
-            url: "https://github.com/acme/widgets/issues/200",
-            hasChildren: true,
-          })
-          yield* db.storeIssue({
-            repositoryId: blockedRepo.id,
-            githubIssueNumber: 201,
-            ...sampleIssueFields,
-            title: "Blocked child",
-            url: "https://github.com/acme/widgets/issues/201",
-            parent: {
-              githubIssueNumber: 200,
-              githubIssueUrl: "https://github.com/acme/widgets/issues/200",
-            },
-            blockedBy: [
-              {
-                githubIssueNumber: 1,
-                githubIssueUrl: "https://github.com/acme/widgets/issues/1",
-              },
-            ],
-          })
-          const blocked = yield* Effect.flip(
-            lifecycle.implementAllWithAutoMerge(blockedRepo.id, 200),
-          )
-          expect(blocked).toBeInstanceOf(
-            ImplementAllWithAutoMergeNotEligibleError,
-          )
 
           // Unsupported hierarchy (grandchild).
           const grandRepo = yield* db.addRepository({
@@ -832,20 +772,40 @@ describe("WorkItemLifecycle", () => {
           )
           expect(unsupported).toBeInstanceOf(UnsupportedIssueHierarchyError)
 
-          // Close second child so parent is eligible again, then leave unfinished.
+          // Parent with only closed children.
+          const closedOnlyRepo = yield* db.addRepository({
+            ...sampleRepository,
+            localPath: "/repos/acme/widgets-closed-parent.git",
+            githubRepo: "widgets-closed-parent",
+          })
           yield* db.storeIssue({
-            repositoryId: repository.id,
-            githubIssueNumber: 102,
+            repositoryId: closedOnlyRepo.id,
+            githubIssueNumber: 400,
             ...sampleIssueFields,
-            title: "Second child",
-            url: "https://github.com/acme/widgets/issues/102",
+            title: "Closed-only parent",
+            url: "https://github.com/acme/widgets/issues/400",
+            hasChildren: true,
+          })
+          yield* db.storeIssue({
+            repositoryId: closedOnlyRepo.id,
+            githubIssueNumber: 401,
+            ...sampleIssueFields,
+            title: "Closed child",
+            url: "https://github.com/acme/widgets/issues/401",
             state: "CLOSED",
             parent: {
-              githubIssueNumber: 100,
-              githubIssueUrl: "https://github.com/acme/widgets/issues/100",
+              githubIssueNumber: 400,
+              githubIssueUrl: "https://github.com/acme/widgets/issues/400",
             },
-            parentPosition: 1,
           })
+          const noOpen = yield* Effect.flip(
+            lifecycle.implementAllWithAutoMerge(closedOnlyRepo.id, 400),
+          )
+          expect(noOpen).toBeInstanceOf(
+            ImplementAllWithAutoMergeNotEligibleError,
+          )
+
+          // All open children already have unfinished Work Items.
           yield* lifecycle.implementAllWithAutoMerge(
             repository.id,
             parent.githubIssueNumber,
@@ -860,6 +820,292 @@ describe("WorkItemLifecycle", () => {
             ImplementAllWithAutoMergeNotEligibleError,
           )
           expect(child.githubIssueNumber).toBe(101)
+        }),
+      ))
+
+    it("enrolls actionable, blocked, and skips closed children atomically", () =>
+      runTest(
+        Effect.gen(function* () {
+          const lifecycle = yield* WorkItemLifecycle
+          const db = yield* DbService
+          yield* seedHarnessBuildModel
+          const repository = yield* db.addRepository({
+            ...sampleRepository,
+            localPath: "/repos/acme/widgets-mixed-parent.git",
+            githubRepo: "widgets-mixed-parent",
+          })
+          yield* db.storeIssue({
+            repositoryId: repository.id,
+            githubIssueNumber: 500,
+            ...sampleIssueFields,
+            title: "Mixed parent",
+            url: "https://github.com/acme/widgets/issues/500",
+            hasChildren: true,
+          })
+          yield* db.storeIssue({
+            repositoryId: repository.id,
+            githubIssueNumber: 501,
+            ...sampleIssueFields,
+            title: "Actionable child",
+            url: "https://github.com/acme/widgets/issues/501",
+            parent: {
+              githubIssueNumber: 500,
+              githubIssueUrl: "https://github.com/acme/widgets/issues/500",
+            },
+            parentPosition: 0,
+          })
+          yield* db.storeIssue({
+            repositoryId: repository.id,
+            githubIssueNumber: 502,
+            ...sampleIssueFields,
+            title: "Blocked child",
+            url: "https://github.com/acme/widgets/issues/502",
+            parent: {
+              githubIssueNumber: 500,
+              githubIssueUrl: "https://github.com/acme/widgets/issues/500",
+            },
+            parentPosition: 1,
+            blockedBy: [
+              {
+                githubIssueNumber: 1,
+                githubIssueUrl: "https://github.com/acme/widgets/issues/1",
+              },
+            ],
+          })
+          yield* db.storeIssue({
+            repositoryId: repository.id,
+            githubIssueNumber: 503,
+            ...sampleIssueFields,
+            title: "Closed child",
+            url: "https://github.com/acme/widgets/issues/503",
+            state: "CLOSED",
+            parent: {
+              githubIssueNumber: 500,
+              githubIssueUrl: "https://github.com/acme/widgets/issues/500",
+            },
+            parentPosition: 2,
+          })
+
+          const covered = yield* lifecycle.implementAllWithAutoMerge(
+            repository.id,
+            500,
+          )
+
+          expect(covered).toHaveLength(2)
+          const byIssue = new Map(
+            covered.map((item) => [item.githubIssueNumber, item]),
+          )
+
+          const actionable = byIssue.get(501)!
+          expect(actionable.mergeMode).toBe("always")
+          expect(actionable.waitingForBlockers).toBe(false)
+          expect(actionable.holdsWorkerSlot).toBe(true)
+          expect(actionable.stepRuns).toHaveLength(1)
+          expect(actionable.state).toBe("create_worktree")
+
+          const blocked = byIssue.get(502)!
+          expect(blocked.mergeMode).toBe("always")
+          expect(blocked.waitingForBlockers).toBe(true)
+          expect(blocked.holdsWorkerSlot).toBe(false)
+          expect(blocked.stepRuns).toHaveLength(0)
+          expect(blocked.waitingSince).toBeNull()
+
+          const closedItems = yield* lifecycle.listWorkItemsForIssue(
+            repository.id,
+            503,
+          )
+          expect(closedItems).toHaveLength(0)
+
+          const parentItems = yield* lifecycle.listWorkItemsForIssue(
+            repository.id,
+            500,
+          )
+          expect(parentItems).toHaveLength(0)
+        }),
+      ))
+
+    it("places excess unblocked children in Waiting for Worker Slot without rejecting", () =>
+      runTest(
+        Effect.gen(function* () {
+          const lifecycle = yield* WorkItemLifecycle
+          const db = yield* DbService
+          yield* seedHarnessBuildModel
+          const config = yield* db.getConfig
+          yield* db.updateConfig({
+            selectedAgentBackend: "opencode",
+            defaultModel:
+              config.defaultModel ?? "opencode/deepseek-v4-flash-free",
+            defaultThinkingLevel: config.defaultThinkingLevel ?? "low",
+            reviewModel: config.reviewModel,
+            reviewThinkingLevel: config.reviewThinkingLevel,
+            maxConcurrentAgentTurns: config.maxConcurrentAgentTurns,
+            maxConcurrentWorkItems: 1,
+          })
+          const repository = yield* db.addRepository({
+            ...sampleRepository,
+            localPath: "/repos/acme/widgets-slot-parent.git",
+            githubRepo: "widgets-slot-parent",
+          })
+          yield* db.storeIssue({
+            repositoryId: repository.id,
+            githubIssueNumber: 600,
+            ...sampleIssueFields,
+            title: "Slot parent",
+            url: "https://github.com/acme/widgets/issues/600",
+            hasChildren: true,
+          })
+          for (const number of [601, 602] as const) {
+            yield* db.storeIssue({
+              repositoryId: repository.id,
+              githubIssueNumber: number,
+              ...sampleIssueFields,
+              title: `Child ${number}`,
+              url: `https://github.com/acme/widgets/issues/${number}`,
+              parent: {
+                githubIssueNumber: 600,
+                githubIssueUrl: "https://github.com/acme/widgets/issues/600",
+              },
+              parentPosition: number - 601,
+            })
+          }
+
+          const covered = yield* lifecycle.implementAllWithAutoMerge(
+            repository.id,
+            600,
+          )
+          expect(covered).toHaveLength(2)
+          const admitted = covered.filter((item) => item.holdsWorkerSlot)
+          const waiting = covered.filter((item) => !item.holdsWorkerSlot)
+          expect(admitted).toHaveLength(1)
+          expect(waiting).toHaveLength(1)
+          expect(admitted[0]!.stepRuns).toHaveLength(1)
+          expect(waiting[0]!.stepRuns).toHaveLength(0)
+          expect(waiting[0]!.waitingSince).not.toBeNull()
+          expect(waiting[0]!.waitingForBlockers).toBe(false)
+          expect(covered.every((item) => item.mergeMode === "always")).toBe(
+            true,
+          )
+        }),
+      ))
+
+    it("rolls back every child enrollment when a later enqueue fails", () => {
+      let enqueueCalls = 0
+      const failingEnqueueQueue = stubQueueService({
+        enqueue: () => {
+          enqueueCalls += 1
+          if (enqueueCalls >= 2) {
+            return Effect.fail(
+              new EnqueueError({
+                queue: WORK_ITEM_LIFECYCLE_QUEUE,
+                message: "injected enqueue failure on second child",
+              }),
+            )
+          }
+          return Effect.succeed("qjob-01ARZ3NDEKTSV4RRFFQ69G5FAV" as JobId)
+        },
+      })
+
+      const layer = WorkItemLifecycleLive.pipe(
+        Layer.provideMerge(stubActiveAgentBackendLayer()),
+        Layer.provideMerge(SuccessfulStepsLive),
+        Layer.provideMerge(DbServiceLive),
+        Layer.provideMerge(
+          Layer.succeed(QueueService, QueueService.of(failingEnqueueQueue)),
+        ),
+        Layer.provideMerge(DatabaseTest),
+      )
+
+      return Effect.runPromise(
+        Effect.gen(function* () {
+          const lifecycle = yield* WorkItemLifecycle
+          const db = yield* DbService
+          yield* seedHarnessBuildModel
+          const repository = yield* db.addRepository({
+            ...sampleRepository,
+            localPath: "/repos/acme/widgets-rollback-parent.git",
+            githubRepo: "widgets-rollback-parent",
+          })
+          yield* db.storeIssue({
+            repositoryId: repository.id,
+            githubIssueNumber: 700,
+            ...sampleIssueFields,
+            title: "Rollback parent",
+            url: "https://github.com/acme/widgets/issues/700",
+            hasChildren: true,
+          })
+          for (const number of [701, 702] as const) {
+            yield* db.storeIssue({
+              repositoryId: repository.id,
+              githubIssueNumber: number,
+              ...sampleIssueFields,
+              title: `Child ${number}`,
+              url: `https://github.com/acme/widgets/issues/${number}`,
+              parent: {
+                githubIssueNumber: 700,
+                githubIssueUrl: "https://github.com/acme/widgets/issues/700",
+              },
+              parentPosition: number - 701,
+            })
+          }
+
+          const error = yield* Effect.flip(
+            lifecycle.implementAllWithAutoMerge(repository.id, 700),
+          )
+          expect(error).toBeInstanceOf(EnqueueError)
+          expect(enqueueCalls).toBe(2)
+
+          const repoItems = yield* lifecycle.listWorkItemsForRepository(
+            repository.id,
+          )
+          expect(repoItems).toEqual([])
+        }).pipe(Effect.provide(layer)),
+      )
+    })
+
+    it("skips open children that already have unfinished Work Items", () =>
+      runTest(
+        Effect.gen(function* () {
+          const lifecycle = yield* WorkItemLifecycle
+          const db = yield* DbService
+          const { repository, parent, child } =
+            yield* seedParentWithOneActionableChild
+
+          const first = yield* lifecycle.implementAllWithAutoMerge(
+            repository.id,
+            parent.githubIssueNumber,
+          )
+          expect(first).toHaveLength(1)
+
+          yield* db.storeIssue({
+            repositoryId: repository.id,
+            githubIssueNumber: 102,
+            ...sampleIssueFields,
+            title: "Later sibling",
+            url: "https://github.com/acme/widgets/issues/102",
+            parent: {
+              githubIssueNumber: 100,
+              githubIssueUrl: "https://github.com/acme/widgets/issues/100",
+            },
+            parentPosition: 1,
+          })
+
+          const second = yield* lifecycle.implementAllWithAutoMerge(
+            repository.id,
+            parent.githubIssueNumber,
+          )
+          expect(second).toHaveLength(1)
+          expect(second[0]!.githubIssueNumber).toBe(102)
+          expect(second[0]!.mergeMode).toBe("always")
+
+          const original = yield* lifecycle.getWorkItem(first[0]!.id)
+          expect(original.githubIssueNumber).toBe(child.githubIssueNumber)
+          expect(original.mergeMode).toBe("always")
+          // Existing unfinished Work Item is not duplicated.
+          const originalList = yield* lifecycle.listWorkItemsForIssue(
+            repository.id,
+            child.githubIssueNumber,
+          )
+          expect(originalList).toHaveLength(1)
         }),
       ))
 


### PR DESCRIPTION
## Summary

- Widen Parent **Implement all with auto-merge** to atomically enroll every current open Child Issue without an unfinished Work Item (not only a single actionable child).
- Unblocked children follow Implement Now and Worker Slot admission (excess wait for a Worker Slot instead of rejecting the parent request); blocked children follow Queue and enter Waiting for blockers with Merge Mode Always.
- Closed children and the Parent Issue receive no Work Item; enrollment is one transaction so a later failure rolls back all new Work Items, Step Runs, and lifecycle jobs.
- Align UI eligibility with the server (including hierarchy checks over all direct children) and return covered child Work Items for a single GraphQL/UI update.

## Test plan

- [x] Lifecycle: mixed actionable/blocked/closed enrollment; Worker Slot wait without reject; atomic enqueue rollback; skip unfinished children; existing Always merge-path tests still pass
- [x] GraphQL: multi-child response (Always + Waiting for blockers); domain failure mapping
- [x] Harness: multi/blocked eligibility; closed mid-level hierarchy hides action; parent-level error alert
- [x] Pre-commit affected lint/typecheck/test

Closes #518