### PR TITLE
feat(work-item): adopt existing Parent child Work Items safely

### DIFF
--- a/apps/harness/src/parent-issue-actions-menu.tsx
+++ b/apps/harness/src/parent-issue-actions-menu.tsx
@@ -100,25 +100,12 @@ export function ParentIssueActionsMenu({
 }
 
 /**
- * Matches server unfinished uniqueness for Work Item creation: only
- * complete / failed / abandoned free the Issue for a new attempt.
- * Needs Human remains unfinished (blocks Implement all), even though GraphQL
- * marks it terminal with canRetry false.
- */
-const isServerUnfinishedWorkItemState = (state: string): boolean => {
-  const normalized = state.toLowerCase()
-  return (
-    normalized !== "complete" &&
-    normalized !== "failed" &&
-    normalized !== "abandoned"
-  )
-}
-
-/**
- * Eligibility: Parent with one or more open leaf Child Issues that have no
- * unfinished Work Item (blocked or unblocked). Unsupported hierarchy shapes
- * (any direct child with children, including closed mid-level Issues) hide the
- * action, matching the server Supported Issue Hierarchy check.
+ * Eligibility: Parent with one or more open leaf Child Issues under a Supported
+ * Issue Hierarchy. Available even when open children already have unfinished
+ * Work Items (the command adopts them and sets Merge Mode Always). Unsupported
+ * hierarchy shapes (any direct child with children, including closed mid-level
+ * Issues) hide the action, matching the server check. Work Item rows are not
+ * required for eligibility once loading finishes — repeated invocation is safe.
  */
 export function isParentImplementAllWithAutoMergeEligible(input: {
   readonly openChildren: readonly {
@@ -143,13 +130,5 @@ export function isParentImplementAllWithAutoMergeEligible(input: {
   if (input.openChildren.length === 0) return false
   // Match server: any direct child with children is unsupported hierarchy.
   if (input.directChildren.some((child) => child.hasChildren)) return false
-
-  return input.openChildren.some((child) => {
-    const unfinished = input.workItems.some(
-      (workItem) =>
-        workItem.githubIssueNumber === child.githubIssueNumber &&
-        isServerUnfinishedWorkItemState(workItem.state),
-    )
-    return !unfinished
-  })
+  return true
 }

--- a/apps/harness/src/routes/index.tsx
+++ b/apps/harness/src/routes/index.tsx
@@ -2458,7 +2458,6 @@ function ParentIssueGroup({
   workItemsLoading: boolean
 }) {
   const queryClient = useQueryClient()
-  const query = workItemsQuery(parent.repositoryId)
   const openChildren = childIssues.filter((child) => child.state === "OPEN")
   const canImplementAll = isParentImplementAllWithAutoMergeEligible({
     openChildren,
@@ -2479,11 +2478,39 @@ function ParentIssueGroup({
       })
       return result.implementAllWithAutoMerge
     },
-    onSuccess: (created) => {
-      queryClient.setQueryData<readonly WorkItem[]>(
-        query.queryKey,
-        (current) => [...(current ?? []), ...created],
-      )
+    // Covered rows may be newly created or adopted (same id, updated mergeMode).
+    // Update matching ids in every work-items cache; only append missing ids
+    // into the default Issues list and Jobs WORKING (never Failed/Completed).
+    onSuccess: (covered) => {
+      const byId = new Map(covered.map((item) => [item.id, item]))
+      for (const [queryKey] of queryClient.getQueriesData<readonly WorkItem[]>({
+        queryKey: ["work-items", parent.repositoryId],
+      })) {
+        // queryKey: ["work-items", repositoryId, listKind | null, limit | null]
+        const listKind = queryKey[2]
+        const allowAppend = listKind === null || listKind === "WORKING"
+        queryClient.setQueryData<readonly WorkItem[]>(queryKey, (current) => {
+          const next: WorkItem[] = []
+          const seen = new Set<string>()
+          for (const item of current ?? []) {
+            const updated = byId.get(item.id)
+            if (updated !== undefined) {
+              next.push(updated)
+              seen.add(item.id)
+            } else {
+              next.push(item)
+            }
+          }
+          if (allowAppend) {
+            for (const item of covered) {
+              if (!seen.has(item.id)) {
+                next.push(item)
+              }
+            }
+          }
+          return next
+        })
+      }
     },
   })
 

--- a/apps/harness/test/parent-issue-actions-menu.test.tsx
+++ b/apps/harness/test/parent-issue-actions-menu.test.tsx
@@ -17,7 +17,7 @@ describe("isParentImplementAllWithAutoMergeEligible", () => {
     blockedBy,
   })
 
-  test("allows one or more open leaf children without unfinished work, including blocked", () => {
+  test("allows one or more open leaf children, including blocked and unfinished", () => {
     expect(
       isParentImplementAllWithAutoMergeEligible({
         openChildren: [leaf(2)],
@@ -54,6 +54,7 @@ describe("isParentImplementAllWithAutoMergeEligible", () => {
       }),
     ).toBe(true)
 
+    // Existing unfinished Work Items are adopted; action stays available.
     expect(
       isParentImplementAllWithAutoMergeEligible({
         openChildren: [leaf(2)],
@@ -61,15 +62,27 @@ describe("isParentImplementAllWithAutoMergeEligible", () => {
         workItems: [{ githubIssueNumber: 2, state: "CREATE_WORKTREE" }],
         workItemsLoading: false,
       }),
-    ).toBe(false)
+    ).toBe(true)
   })
 
-  test("stays available when some open children already have unfinished work", () => {
+  test("stays available when some or all open children already have unfinished work", () => {
     expect(
       isParentImplementAllWithAutoMergeEligible({
         openChildren: [leaf(2), leaf(3)],
         directChildren: [leaf(2), leaf(3)],
         workItems: [{ githubIssueNumber: 2, state: "CREATE_WORKTREE" }],
+        workItemsLoading: false,
+      }),
+    ).toBe(true)
+
+    expect(
+      isParentImplementAllWithAutoMergeEligible({
+        openChildren: [leaf(2), leaf(3)],
+        directChildren: [leaf(2), leaf(3)],
+        workItems: [
+          { githubIssueNumber: 2, state: "CREATE_WORKTREE" },
+          { githubIssueNumber: 3, state: "IMPLEMENT" },
+        ],
         workItemsLoading: false,
       }),
     ).toBe(true)
@@ -100,7 +113,7 @@ describe("isParentImplementAllWithAutoMergeEligible", () => {
     ).toBe(false)
   })
 
-  test("blocks Needs Human (terminal, non-retryable) to match server unfinished rules", () => {
+  test("stays available for Needs Human unfinished children (adopt Merge Mode Only)", () => {
     expect(
       isParentImplementAllWithAutoMergeEligible({
         openChildren: [leaf(2)],
@@ -108,7 +121,7 @@ describe("isParentImplementAllWithAutoMergeEligible", () => {
         workItems: [{ githubIssueNumber: 2, state: "NEEDS_HUMAN" }],
         workItemsLoading: false,
       }),
-    ).toBe(false)
+    ).toBe(true)
   })
 
   test("allows complete, failed, and abandoned child history", () => {
@@ -122,6 +135,26 @@ describe("isParentImplementAllWithAutoMergeEligible", () => {
         }),
       ).toBe(true)
     }
+  })
+
+  test("hides while work items are loading and when there are no open children", () => {
+    expect(
+      isParentImplementAllWithAutoMergeEligible({
+        openChildren: [leaf(2)],
+        directChildren: [leaf(2)],
+        workItems: [],
+        workItemsLoading: true,
+      }),
+    ).toBe(false)
+
+    expect(
+      isParentImplementAllWithAutoMergeEligible({
+        openChildren: [],
+        directChildren: [{ hasChildren: false }],
+        workItems: [],
+        workItemsLoading: false,
+      }),
+    ).toBe(false)
   })
 })
 

--- a/docs/adr/0040-parent-implement-all-merge-mode-always.md
+++ b/docs/adr/0040-parent-implement-all-merge-mode-always.md
@@ -8,4 +8,5 @@ Merge Mode `always` skips only Decide PR Merge after the normal pre-merge lifecy
 
 - Child Work Items remain independent under the global Worker Slot limit; siblings may run concurrently.
 - Enrollment is atomic: failure creates no partial Work Items or Merge Mode updates.
-- Open children without unfinished Work Items are enrolled together (Implement Now or Queue); adopting existing unfinished child Work Items remains a later product slice.
+- Open children without unfinished Work Items are enrolled together (Implement Now or Queue); existing unfinished child Work Items are adopted in the same atomic request by setting Merge Mode Always without reset or duplication.
+- A merge-related Needs Human handoff on an adopted Work Item remains stopped; setting Merge Mode Always does not clear the handoff or enqueue Merge PR.

--- a/packages/graphql-api/test/graphql-api.test.ts
+++ b/packages/graphql-api/test/graphql-api.test.ts
@@ -3650,8 +3650,7 @@ describe("GraphQL API", () => {
             _tag: "ImplementAllWithAutoMergeNotEligibleError",
             repositoryId: repository.id,
             githubIssueNumber: 10,
-            reason:
-              "Parent Issue #10 has no open Child Issues without an unfinished Work Item",
+            reason: "Parent Issue #10 has no open Child Issues",
           } as never),
       },
     )
@@ -3677,9 +3676,7 @@ describe("GraphQL API", () => {
     expect(body.errors[0]?.extensions.code).toBe(
       "IMPLEMENT_ALL_WITH_AUTO_MERGE_NOT_ELIGIBLE",
     )
-    expect(body.errors[0]?.message).toContain(
-      "no open Child Issues without an unfinished Work Item",
-    )
+    expect(body.errors[0]?.message).toContain("no open Child Issues")
   })
 
   test("queues a blocked Issue Work Item", async () => {

--- a/packages/graphql-schema/schema.graphql
+++ b/packages/graphql-schema/schema.graphql
@@ -483,10 +483,13 @@ type Mutation {
   implementLocally(repositoryId: ID!, githubIssueNumber: Int!): WorkItem!
   """
   Parent-level Implement all with auto-merge. Snapshots open direct Child Issues
-  without an unfinished Work Item and creates ordinary Work Items with Merge Mode
-  ALWAYS atomically: unblocked children use Implement Now admission; blocked
-  children use Queue (Waiting for blockers). Returns covered child Work Items.
-  Does not create a Parent Work Item.
+  and atomically enrolls them: creates ordinary Work Items with Merge Mode ALWAYS
+  for children without an unfinished Work Item (unblocked → Implement Now
+  admission; blocked → Queue / Waiting for blockers); sets Merge Mode ALWAYS on
+  each existing unfinished child Work Item without resetting lifecycle state,
+  history, admission, Session, worktree, or PR. A merge-related Needs Human
+  handoff stays stopped. Returns covered child Work Items. Does not create a
+  Parent Work Item.
   """
   implementAllWithAutoMerge(
     repositoryId: ID!

--- a/packages/work-item-lifecycle/src/lib/errors.ts
+++ b/packages/work-item-lifecycle/src/lib/errors.ts
@@ -58,8 +58,7 @@ export class UnsupportedIssueHierarchyError extends Schema.TaggedErrorClass<Unsu
 
 /**
  * Parent Issue is not eligible for Implement all with auto-merge (no open
- * Child Issues without an unfinished Work Item, or concurrent enrollment
- * conflict).
+ * Child Issues, or concurrent enrollment conflict).
  */
 export class ImplementAllWithAutoMergeNotEligibleError extends Schema.TaggedErrorClass<ImplementAllWithAutoMergeNotEligibleError>()(
   "ImplementAllWithAutoMergeNotEligibleError",

--- a/packages/work-item-lifecycle/src/lib/work-item-lifecycle.ts
+++ b/packages/work-item-lifecycle/src/lib/work-item-lifecycle.ts
@@ -46,7 +46,7 @@ import {
   AbandonCleanupError,
   ActiveStepRunExistsError,
   AgentBackendUnavailableError,
-  type BuildModelNotConfiguredError,
+  BuildModelNotConfiguredError,
   ImplementAllWithAutoMergeNotEligibleError,
   IssueBlockedError,
   IssueNotBlockedError,
@@ -639,10 +639,12 @@ export interface WorkItemLifecycleShape {
   ) => Effect.Effect<WorkItemRecord, ImplementNowError>
   /**
    * Parent-level Implement all with auto-merge. Snapshots open direct Child
-   * Issues without an unfinished Work Item and creates ordinary Work Items with
-   * Merge Mode Always atomically: unblocked children follow Implement Now
-   * admission; blocked children follow Queue (Waiting for blockers). No Parent
-   * Work Item.
+   * Issues and, atomically: creates ordinary Work Items with Merge Mode Always
+   * for children without an unfinished Work Item (unblocked → Implement Now
+   * admission; blocked → Queue / Waiting for blockers); sets Merge Mode Always
+   * on each existing unfinished child Work Item without resetting lifecycle
+   * state, history, admission, Session, worktree, or PR. A merge-related Needs
+   * Human handoff stays stopped. No Parent Work Item.
    */
   readonly implementAllWithAutoMerge: (
     repositoryId: string,
@@ -4896,9 +4898,11 @@ export const makeWorkItemLifecycleLive = (
       )
 
       /**
-       * Parent command: enroll every open direct child without an unfinished
-       * Work Item. Unblocked → Implement Now admission; blocked → Queue.
-       * All creations, Step Runs, and lifecycle jobs are one atomic unit.
+       * Parent command: for every open direct child, either adopt the existing
+       * unfinished Work Item (set Merge Mode Always only) or create a new one
+       * with Always. Unblocked creates → Implement Now admission; blocked →
+       * Queue. Create + adopt in one atomic transaction; failure rolls back
+       * both. Does not clear Needs Human or enqueue Merge PR.
        */
       const implementAllWithAutoMerge = Effect.fn(
         "WorkItemLifecycle.implementAllWithAutoMerge",
@@ -4957,8 +4961,9 @@ export const makeWorkItemLifecycleLive = (
           })
         }
 
-        // Existing unfinished Work Items are not adopted here (later ticket);
-        // only children that still need a new Work Item are enrolled.
+        // Pre-scan only decides whether any create may need Agent Backend
+        // resolution. The transaction re-reads unfinished rows so concurrent
+        // create/abandon races stay all-or-nothing.
         const repositoryWorkItems =
           yield* listWorkItemsForRepository(repositoryId)
         const unfinishedByIssue = new Map<number, WorkItemId>()
@@ -4972,50 +4977,66 @@ export const makeWorkItemLifecycleLive = (
           }
         }
 
-        const toEnroll = openChildren.filter(
+        const mayNeedCreate = openChildren.some(
           (child) => !unfinishedByIssue.has(child.githubIssueNumber),
         )
 
-        if (toEnroll.length === 0) {
-          return yield* new ImplementAllWithAutoMergeNotEligibleError({
-            repositoryId,
-            githubIssueNumber: parentGithubIssueNumber,
-            reason: `Parent Issue #${parentGithubIssueNumber} has no open Child Issues without an unfinished Work Item`,
-          })
+        const mapTransactionError = (
+          error: unknown,
+        ): Effect.Effect<never, ImplementAllWithAutoMergeError> => {
+          if (error instanceof WorkItemLifecycleDatabaseError) {
+            return Effect.fail(error)
+          }
+          if (error instanceof EnqueueError) {
+            return Effect.fail(error)
+          }
+          if (error instanceof InvalidQueueNameError) {
+            return Effect.fail(error)
+          }
+          if (error instanceof AgentBackendUnavailableError) {
+            return Effect.fail(error)
+          }
+          if (error instanceof BuildModelNotConfiguredError) {
+            return Effect.fail(error)
+          }
+          // Domain eligibility failures raised inside the transaction (e.g.
+          // pure-adopt concurrent abandon) must keep their tag for GraphQL.
+          if (error instanceof ImplementAllWithAutoMergeNotEligibleError) {
+            return Effect.fail(error)
+          }
+          if (
+            typeof error === "object" &&
+            error !== null &&
+            "_tag" in error &&
+            (error as { _tag: string })._tag === "SqlError"
+          ) {
+            const sqlError = error as SqlError
+            if (isUnfinishedWorkItemUniqueViolation(sqlError)) {
+              return Effect.fail(
+                new ImplementAllWithAutoMergeNotEligibleError({
+                  repositoryId,
+                  githubIssueNumber: parentGithubIssueNumber,
+                  reason: `A concurrent request enrolled a Child Issue of Parent Issue #${parentGithubIssueNumber}`,
+                }),
+              )
+            }
+            return Effect.fail(toDatabaseError(sqlError))
+          }
+          return Effect.fail(
+            new WorkItemLifecycleDatabaseError({
+              message: `Unexpected transaction failure: ${String(error)}`,
+              cause: error,
+            }),
+          )
         }
 
-        const createdIds = yield* activeAgentBackend.withConfigCoordination(
+        const enrollOpenChildren = (
+          agentBackendId: string | null,
+        ): Effect.Effect<
+          readonly WorkItemId[],
+          ImplementAllWithAutoMergeError
+        > =>
           Effect.gen(function* () {
-            const harnessConfig = yield* db.getConfig
-            const repositories = yield* db.listRepositories
-            const repository = repositories.find(
-              ({ id }) => id === repositoryId,
-            )
-            const rawCaptureBackendId =
-              repository?.selectedAgentBackend ??
-              harnessConfig.selectedAgentBackend
-            if (!isSelectableAgentBackendId(rawCaptureBackendId)) {
-              return yield* new AgentBackendUnavailableError({
-                message: `Unknown or unsupported Agent Backend: ${rawCaptureBackendId}`,
-                reason: `Unknown or unsupported Agent Backend: ${rawCaptureBackendId}`,
-              })
-            }
-            const captureBackendId = rawCaptureBackendId
-            yield* activeAgentBackend
-              .requireAgentTurnsAllowed(captureBackendId)
-              .pipe(
-                Effect.mapError(
-                  (error) =>
-                    new AgentBackendUnavailableError({
-                      message: error.message,
-                      reason: error.reason,
-                    }),
-                ),
-              )
-            yield* resolveModelsForBackend(repositoryId, captureBackendId)
-            const activeRegistration =
-              yield* activeAgentBackend.getRegistration(captureBackendId)
-            const agentBackendId = activeRegistration.descriptor.id
             const now = yield* Clock.currentTimeMillis
             const step: OperationalLifecycleStep = "create_worktree"
 
@@ -5026,7 +5047,63 @@ export const makeWorkItemLifecycleLive = (
                   let occupied = yield* countOccupiedWorkerSlots()
                   const workItemIds: WorkItemId[] = []
 
-                  for (const child of toEnroll) {
+                  for (const child of openChildren) {
+                    const unfinishedRows = (yield* sql
+                      .unsafe(
+                        `SELECT id FROM work_item
+                         WHERE repository_id = ?
+                           AND github_issue_number = ?
+                           AND state NOT IN ('complete', 'failed', 'abandoned')
+                         LIMIT 1`,
+                        [repositoryId, child.githubIssueNumber],
+                      )
+                      .pipe(Effect.mapError(toDatabaseError))) as readonly {
+                      readonly id: string
+                    }[]
+
+                    const existingId = unfinishedRows[0]?.id
+                    if (existingId !== undefined) {
+                      // Adopt only: durable Merge Mode Always. Do not touch
+                      // state, admission, Step Runs, Session, worktree, PR, or
+                      // Needs Human handoff. RETURNING rejects a concurrent
+                      // terminal transition so we never report a false adopt.
+                      const adoptedRows = (yield* sql
+                        .unsafe(
+                          `UPDATE work_item
+                           SET merge_mode = 'always', updated_at = ?
+                           WHERE id = ?
+                             AND state NOT IN ('complete', 'failed', 'abandoned')
+                           RETURNING id`,
+                          [now, existingId],
+                        )
+                        .pipe(Effect.mapError(toDatabaseError))) as readonly {
+                        readonly id: string
+                      }[]
+                      if (adoptedRows[0]?.id === undefined) {
+                        return yield* new ImplementAllWithAutoMergeNotEligibleError(
+                          {
+                            repositoryId,
+                            githubIssueNumber: parentGithubIssueNumber,
+                            reason: `A concurrent request changed a Child Issue of Parent Issue #${parentGithubIssueNumber}`,
+                          },
+                        )
+                      }
+                      workItemIds.push(existingId as WorkItemId)
+                      continue
+                    }
+
+                    if (agentBackendId === null) {
+                      // Race: pre-scan expected pure adopt, but a concurrent
+                      // abandon left this child without an unfinished WI.
+                      return yield* new ImplementAllWithAutoMergeNotEligibleError(
+                        {
+                          repositoryId,
+                          githubIssueNumber: parentGithubIssueNumber,
+                          reason: `A concurrent request changed a Child Issue of Parent Issue #${parentGithubIssueNumber}`,
+                        },
+                      )
+                    }
+
                     const workItemId = makeWorkItemId()
                     const blocked = child.blockedBy.length > 0
 
@@ -5087,59 +5164,56 @@ export const makeWorkItemLifecycleLive = (
                   return workItemIds
                 }),
               )
-              .pipe(
-                Effect.catch(
-                  (
-                    error,
-                  ): Effect.Effect<never, ImplementAllWithAutoMergeError> => {
-                    if (error instanceof WorkItemLifecycleDatabaseError) {
-                      return Effect.fail(error)
-                    }
-                    if (error instanceof EnqueueError) {
-                      return Effect.fail(error)
-                    }
-                    if (error instanceof InvalidQueueNameError) {
-                      return Effect.fail(error)
-                    }
-                    if (
-                      typeof error === "object" &&
-                      error !== null &&
-                      "_tag" in error &&
-                      (error as { _tag: string })._tag === "SqlError"
-                    ) {
-                      const sqlError = error as SqlError
-                      if (isUnfinishedWorkItemUniqueViolation(sqlError)) {
-                        return Effect.fail(
-                          new ImplementAllWithAutoMergeNotEligibleError({
-                            repositoryId,
-                            githubIssueNumber: parentGithubIssueNumber,
-                            reason: `A concurrent request enrolled a Child Issue of Parent Issue #${parentGithubIssueNumber}`,
-                          }),
-                        )
-                      }
-                      return Effect.fail(toDatabaseError(sqlError))
-                    }
-                    return Effect.fail(
-                      new WorkItemLifecycleDatabaseError({
-                        message: `Unexpected transaction failure: ${String(error)}`,
-                        cause: error,
-                      }),
-                    )
-                  },
-                ),
-              )
-          }),
-        )
+              .pipe(Effect.catch(mapTransactionError))
+          })
+
+        const coveredIds = mayNeedCreate
+          ? yield* activeAgentBackend.withConfigCoordination(
+              Effect.gen(function* () {
+                const harnessConfig = yield* db.getConfig
+                const repositories = yield* db.listRepositories
+                const repository = repositories.find(
+                  ({ id }) => id === repositoryId,
+                )
+                const rawCaptureBackendId =
+                  repository?.selectedAgentBackend ??
+                  harnessConfig.selectedAgentBackend
+                if (!isSelectableAgentBackendId(rawCaptureBackendId)) {
+                  return yield* new AgentBackendUnavailableError({
+                    message: `Unknown or unsupported Agent Backend: ${rawCaptureBackendId}`,
+                    reason: `Unknown or unsupported Agent Backend: ${rawCaptureBackendId}`,
+                  })
+                }
+                const captureBackendId = rawCaptureBackendId
+                yield* activeAgentBackend
+                  .requireAgentTurnsAllowed(captureBackendId)
+                  .pipe(
+                    Effect.mapError(
+                      (error) =>
+                        new AgentBackendUnavailableError({
+                          message: error.message,
+                          reason: error.reason,
+                        }),
+                    ),
+                  )
+                yield* resolveModelsForBackend(repositoryId, captureBackendId)
+                const activeRegistration =
+                  yield* activeAgentBackend.getRegistration(captureBackendId)
+                const agentBackendId = activeRegistration.descriptor.id
+                return yield* enrollOpenChildren(agentBackendId)
+              }),
+            )
+          : yield* enrollOpenChildren(null)
 
         const covered = yield* Effect.forEach(
-          createdIds,
+          coveredIds,
           (workItemId) =>
             getWorkItem(workItemId).pipe(
               Effect.catchTag(
                 "WorkItemNotFoundError",
                 (error) =>
                   new WorkItemLifecycleDatabaseError({
-                    message: `Work Item missing after implement-all create: ${error.workItemId}`,
+                    message: `Work Item missing after implement-all adopt/create: ${error.workItemId}`,
                     cause: error,
                   }),
               ),

--- a/packages/work-item-lifecycle/test/work-item-lifecycle.spec.ts
+++ b/packages/work-item-lifecycle/test/work-item-lifecycle.spec.ts
@@ -716,13 +716,12 @@ describe("WorkItemLifecycle", () => {
         }),
       ))
 
-    it("rejects missing, non-parent, no-open, unsupported hierarchy, and unfinished-only cases", () =>
+    it("rejects missing, non-parent, no-open, and unsupported hierarchy cases", () =>
       runTest(
         Effect.gen(function* () {
           const lifecycle = yield* WorkItemLifecycle
           const db = yield* DbService
-          const { repository, parent, child } =
-            yield* seedParentWithOneActionableChild
+          const { repository } = yield* seedParentWithOneActionableChild
 
           const missing = yield* Effect.flip(
             lifecycle.implementAllWithAutoMerge(repository.id, 999),
@@ -804,22 +803,6 @@ describe("WorkItemLifecycle", () => {
           expect(noOpen).toBeInstanceOf(
             ImplementAllWithAutoMergeNotEligibleError,
           )
-
-          // All open children already have unfinished Work Items.
-          yield* lifecycle.implementAllWithAutoMerge(
-            repository.id,
-            parent.githubIssueNumber,
-          )
-          const unfinished = yield* Effect.flip(
-            lifecycle.implementAllWithAutoMerge(
-              repository.id,
-              parent.githubIssueNumber,
-            ),
-          )
-          expect(unfinished).toBeInstanceOf(
-            ImplementAllWithAutoMergeNotEligibleError,
-          )
-          expect(child.githubIssueNumber).toBe(101)
         }),
       ))
 
@@ -1062,7 +1045,7 @@ describe("WorkItemLifecycle", () => {
       )
     })
 
-    it("skips open children that already have unfinished Work Items", () =>
+    it("adopts unfinished children and enrolls later-added open children without duplication", () =>
       runTest(
         Effect.gen(function* () {
           const lifecycle = yield* WorkItemLifecycle
@@ -1070,12 +1053,28 @@ describe("WorkItemLifecycle", () => {
           const { repository, parent, child } =
             yield* seedParentWithOneActionableChild
 
+          // Ordinary unfinished Work Item created outside the parent command.
+          const ordinary = yield* lifecycle.implementNow(
+            repository.id,
+            child.githubIssueNumber,
+          )
+          expect(ordinary.mergeMode).toBe("ordinary")
+          const stepRunCount = ordinary.stepRuns.length
+          const ordinaryState = ordinary.state
+          const holdsSlot = ordinary.holdsWorkerSlot
+
           const first = yield* lifecycle.implementAllWithAutoMerge(
             repository.id,
             parent.githubIssueNumber,
           )
           expect(first).toHaveLength(1)
+          expect(first[0]!.id).toBe(ordinary.id)
+          expect(first[0]!.mergeMode).toBe("always")
+          expect(first[0]!.state).toBe(ordinaryState)
+          expect(first[0]!.holdsWorkerSlot).toBe(holdsSlot)
+          expect(first[0]!.stepRuns).toHaveLength(stepRunCount)
 
+          // Child added after the first accepted snapshot is not yet enrolled.
           yield* db.storeIssue({
             repositoryId: repository.id,
             githubIssueNumber: 102,
@@ -1093,19 +1092,364 @@ describe("WorkItemLifecycle", () => {
             repository.id,
             parent.githubIssueNumber,
           )
-          expect(second).toHaveLength(1)
-          expect(second[0]!.githubIssueNumber).toBe(102)
-          expect(second[0]!.mergeMode).toBe("always")
+          expect(second).toHaveLength(2)
+          const byIssue = new Map(
+            second.map((item) => [item.githubIssueNumber, item]),
+          )
+          const adopted = byIssue.get(child.githubIssueNumber)!
+          expect(adopted.id).toBe(ordinary.id)
+          expect(adopted.mergeMode).toBe("always")
+          expect(adopted.state).toBe(ordinaryState)
+          expect(adopted.stepRuns).toHaveLength(stepRunCount)
 
-          const original = yield* lifecycle.getWorkItem(first[0]!.id)
-          expect(original.githubIssueNumber).toBe(child.githubIssueNumber)
-          expect(original.mergeMode).toBe("always")
-          // Existing unfinished Work Item is not duplicated.
+          const later = byIssue.get(102)!
+          expect(later.mergeMode).toBe("always")
+          expect(later.id).not.toBe(ordinary.id)
+
+          // No duplicate unfinished Work Item for the original child.
           const originalList = yield* lifecycle.listWorkItemsForIssue(
             repository.id,
             child.githubIssueNumber,
           )
           expect(originalList).toHaveLength(1)
+        }),
+      ))
+
+    it("preserves identity, progress, Session, worktree, and PR when adopting", () =>
+      runTest(
+        Effect.gen(function* () {
+          const lifecycle = yield* WorkItemLifecycle
+          const sql = yield* SqlClient.SqlClient
+          const { repository, parent, child } =
+            yield* seedParentWithOneActionableChild
+
+          const ordinary = yield* lifecycle.implementNow(
+            repository.id,
+            child.githubIssueNumber,
+          )
+          yield* sql.unsafe(
+            `UPDATE work_item
+             SET state = 'implement',
+                 session_id = 'ses_adopt_preserve',
+                 worktree_path = '/tmp/worktrees/adopt-preserve',
+                 github_pull_request_number = 77,
+                 starting_commit_oid = 'deadbeef'
+             WHERE id = ?`,
+            [ordinary.id],
+          )
+
+          const before = yield* lifecycle.getWorkItem(ordinary.id)
+          const covered = yield* lifecycle.implementAllWithAutoMerge(
+            repository.id,
+            parent.githubIssueNumber,
+          )
+
+          expect(covered).toHaveLength(1)
+          const adopted = covered[0]!
+          expect(adopted.id).toBe(before.id)
+          expect(adopted.mergeMode).toBe("always")
+          expect(adopted.state).toBe("implement")
+          expect(adopted.sessionId).toBe("ses_adopt_preserve")
+          expect(adopted.worktreePath).toBe("/tmp/worktrees/adopt-preserve")
+          expect(adopted.githubPullRequestNumber).toBe(77)
+          expect(adopted.startingCommitOid).toBe("deadbeef")
+          expect(adopted.holdsWorkerSlot).toBe(before.holdsWorkerSlot)
+          expect(adopted.stepRuns.map((run) => run.id)).toEqual(
+            before.stepRuns.map((run) => run.id),
+          )
+        }),
+      ))
+
+    it("leaves merge-related Needs Human stopped when setting Merge Mode Always", () =>
+      runTest(
+        Effect.gen(function* () {
+          const lifecycle = yield* WorkItemLifecycle
+          const sql = yield* SqlClient.SqlClient
+          const { repository, parent, child } =
+            yield* seedParentWithOneActionableChild
+
+          const ordinary = yield* lifecycle.implementNow(
+            repository.id,
+            child.githubIssueNumber,
+          )
+          // Simulate a merge-related Needs Human handoff with ordinary mode.
+          yield* sql.unsafe(
+            `UPDATE work_item
+             SET state = 'needs_human',
+                 merge_mode = 'ordinary',
+                 github_pull_request_number = 88,
+                 failure_code = 'needs_human',
+                 failure_message = 'Human merge required',
+                 holds_worker_slot = 0,
+                 waiting_since = NULL
+             WHERE id = ?`,
+            [ordinary.id],
+          )
+          yield* sql.unsafe(
+            `UPDATE step_run
+             SET status = 'succeeded',
+                 step = 'decide_pr_merge',
+                 finished_at = ?
+             WHERE work_item_id = ?`,
+            [Date.now(), ordinary.id],
+          )
+
+          const before = yield* lifecycle.getWorkItem(ordinary.id)
+          expect(before.state).toBe("needs_human")
+          expect(before.mergeMode).toBe("ordinary")
+
+          const covered = yield* lifecycle.implementAllWithAutoMerge(
+            repository.id,
+            parent.githubIssueNumber,
+          )
+
+          expect(covered).toHaveLength(1)
+          const adopted = covered[0]!
+          expect(adopted.id).toBe(ordinary.id)
+          expect(adopted.mergeMode).toBe("always")
+          expect(adopted.state).toBe("needs_human")
+          expect(adopted.failureCode).toBe("needs_human")
+          expect(adopted.failureMessage).toBe("Human merge required")
+          expect(adopted.githubPullRequestNumber).toBe(88)
+          expect(adopted.holdsWorkerSlot).toBe(false)
+          // No Merge PR (or other) Step Run enqueued by the adopt path.
+          expect(adopted.stepRuns.every((run) => run.status !== "queued")).toBe(
+            true,
+          )
+          expect(adopted.stepRuns.some((run) => run.step === "merge_pr")).toBe(
+            false,
+          )
+        }),
+      ))
+
+    it("rolls back Merge Mode changes when a later create enqueue fails", () => {
+      let enqueueCalls = 0
+      const failingEnqueueQueue = stubQueueService({
+        enqueue: () => {
+          enqueueCalls += 1
+          return Effect.fail(
+            new EnqueueError({
+              queue: WORK_ITEM_LIFECYCLE_QUEUE,
+              message: "injected enqueue failure on new child",
+            }),
+          )
+        },
+      })
+
+      const layer = WorkItemLifecycleLive.pipe(
+        Layer.provideMerge(stubActiveAgentBackendLayer()),
+        Layer.provideMerge(SuccessfulStepsLive),
+        Layer.provideMerge(DbServiceLive),
+        Layer.provideMerge(
+          Layer.succeed(QueueService, QueueService.of(failingEnqueueQueue)),
+        ),
+        Layer.provideMerge(DatabaseTest),
+      )
+
+      return Effect.runPromise(
+        Effect.gen(function* () {
+          const lifecycle = yield* WorkItemLifecycle
+          const db = yield* DbService
+          yield* seedHarnessBuildModel
+          const repository = yield* db.addRepository({
+            ...sampleRepository,
+            localPath: "/repos/acme/widgets-mixed-rollback.git",
+            githubRepo: "widgets-mixed-rollback",
+          })
+          yield* db.storeIssue({
+            repositoryId: repository.id,
+            githubIssueNumber: 800,
+            ...sampleIssueFields,
+            title: "Mixed rollback parent",
+            url: "https://github.com/acme/widgets/issues/800",
+            hasChildren: true,
+          })
+          yield* db.storeIssue({
+            repositoryId: repository.id,
+            githubIssueNumber: 801,
+            ...sampleIssueFields,
+            title: "Existing child",
+            url: "https://github.com/acme/widgets/issues/801",
+            parent: {
+              githubIssueNumber: 800,
+              githubIssueUrl: "https://github.com/acme/widgets/issues/800",
+            },
+            parentPosition: 0,
+          })
+          yield* db.storeIssue({
+            repositoryId: repository.id,
+            githubIssueNumber: 802,
+            ...sampleIssueFields,
+            title: "New child",
+            url: "https://github.com/acme/widgets/issues/802",
+            parent: {
+              githubIssueNumber: 800,
+              githubIssueUrl: "https://github.com/acme/widgets/issues/800",
+            },
+            parentPosition: 1,
+          })
+
+          // Existing ordinary unfinished Work Item (adopt target).
+          // implementNow enqueues; use direct insert to avoid the failing queue.
+          const sql = yield* SqlClient.SqlClient
+          const existingId = "wi-01ARZ3NDEKTSV4RRFFQ69G5FAV"
+          const now = Date.now()
+          yield* sql.unsafe(
+            `INSERT INTO work_item (
+               id, repository_id, github_issue_number, agent_backend,
+               issue_title, state, state_ready_at, paused,
+               waiting_since, waiting_for_blockers, merge_mode, holds_worker_slot,
+               pause_before_step, worktree_path, session_id, failure_code,
+               failure_message, created_at, updated_at
+             ) VALUES (?, ?, ?, 'opencode', ?, 'create_worktree', ?, 0, NULL, 0, 'ordinary', 0, NULL, NULL, NULL, NULL, NULL, ?, ?)`,
+            [existingId, repository.id, 801, "Existing child", now, now, now],
+          )
+
+          const error = yield* Effect.flip(
+            lifecycle.implementAllWithAutoMerge(repository.id, 800),
+          )
+          expect(error).toBeInstanceOf(EnqueueError)
+          expect(enqueueCalls).toBe(1)
+
+          const existing = yield* lifecycle.getWorkItem(existingId)
+          expect(existing.mergeMode).toBe("ordinary")
+          expect(existing.state).toBe("create_worktree")
+
+          const newChildItems = yield* lifecycle.listWorkItemsForIssue(
+            repository.id,
+            802,
+          )
+          expect(newChildItems).toEqual([])
+        }).pipe(Effect.provide(layer)),
+      )
+    })
+
+    it("maps concurrent parent and child Implement Now to all-or-nothing without duplicates", () =>
+      runTest(
+        Effect.gen(function* () {
+          const lifecycle = yield* WorkItemLifecycle
+          const db = yield* DbService
+          yield* seedHarnessBuildModel
+          const repository = yield* db.addRepository({
+            ...sampleRepository,
+            localPath: "/repos/acme/widgets-concurrent-parent.git",
+            githubRepo: "widgets-concurrent-parent",
+          })
+          yield* db.storeIssue({
+            repositoryId: repository.id,
+            githubIssueNumber: 900,
+            ...sampleIssueFields,
+            title: "Concurrent parent",
+            url: "https://github.com/acme/widgets/issues/900",
+            hasChildren: true,
+          })
+          yield* db.storeIssue({
+            repositoryId: repository.id,
+            githubIssueNumber: 901,
+            ...sampleIssueFields,
+            title: "Child A",
+            url: "https://github.com/acme/widgets/issues/901",
+            parent: {
+              githubIssueNumber: 900,
+              githubIssueUrl: "https://github.com/acme/widgets/issues/900",
+            },
+            parentPosition: 0,
+          })
+          yield* db.storeIssue({
+            repositoryId: repository.id,
+            githubIssueNumber: 902,
+            ...sampleIssueFields,
+            title: "Child B",
+            url: "https://github.com/acme/widgets/issues/902",
+            parent: {
+              githubIssueNumber: 900,
+              githubIssueUrl: "https://github.com/acme/widgets/issues/900",
+            },
+            parentPosition: 1,
+          })
+
+          // Child-level Implement Now wins first for A.
+          const childA = yield* lifecycle.implementNow(repository.id, 901)
+          expect(childA.mergeMode).toBe("ordinary")
+
+          // Parent command adopts A and creates B.
+          const covered = yield* lifecycle.implementAllWithAutoMerge(
+            repository.id,
+            900,
+          )
+          expect(covered).toHaveLength(2)
+          const byIssue = new Map(
+            covered.map((item) => [item.githubIssueNumber, item]),
+          )
+          expect(byIssue.get(901)!.id).toBe(childA.id)
+          expect(byIssue.get(901)!.mergeMode).toBe("always")
+          expect(byIssue.get(902)!.mergeMode).toBe("always")
+
+          // Second Implement Now on A is rejected (one unfinished invariant).
+          const conflict = yield* Effect.flip(
+            lifecycle.implementNow(repository.id, 901),
+          )
+          expect(conflict).toBeInstanceOf(UnfinishedWorkItemExistsError)
+
+          const listA = yield* lifecycle.listWorkItemsForIssue(
+            repository.id,
+            901,
+          )
+          expect(listA).toHaveLength(1)
+          const listB = yield* lifecycle.listWorkItemsForIssue(
+            repository.id,
+            902,
+          )
+          expect(listB).toHaveLength(1)
+
+          // Idempotent re-run: no new Work Items or Step Runs.
+          const stepRunsBBefore = listB[0]!.stepRuns.length
+          const again = yield* lifecycle.implementAllWithAutoMerge(
+            repository.id,
+            900,
+          )
+          expect(again).toHaveLength(2)
+          expect(new Set(again.map((item) => item.id))).toEqual(
+            new Set(covered.map((item) => item.id)),
+          )
+          const listBAfter = yield* lifecycle.listWorkItemsForIssue(
+            repository.id,
+            902,
+          )
+          expect(listBAfter[0]!.stepRuns).toHaveLength(stepRunsBBefore)
+        }),
+      ))
+
+    it("creates a new Work Item after terminal history without erasing it", () =>
+      runTest(
+        Effect.gen(function* () {
+          const lifecycle = yield* WorkItemLifecycle
+          const { repository, parent, child } =
+            yield* seedParentWithOneActionableChild
+
+          const first = yield* lifecycle.implementNow(
+            repository.id,
+            child.githubIssueNumber,
+          )
+          yield* lifecycle.abandon(first.id)
+          expect(first.mergeMode).toBe("ordinary")
+
+          const covered = yield* lifecycle.implementAllWithAutoMerge(
+            repository.id,
+            parent.githubIssueNumber,
+          )
+          expect(covered).toHaveLength(1)
+          expect(covered[0]!.id).not.toBe(first.id)
+          expect(covered[0]!.mergeMode).toBe("always")
+
+          const history = yield* lifecycle.listWorkItemsForIssue(
+            repository.id,
+            child.githubIssueNumber,
+          )
+          expect(history).toHaveLength(2)
+          expect(history[0]!.id).toBe(first.id)
+          expect(history[0]!.state).toBe("abandoned")
+          expect(history[1]!.id).toBe(covered[0]!.id)
         }),
       ))
 


### PR DESCRIPTION
## Summary

- Complete Parent **Implement all with auto-merge** for open children that already have unfinished Work Items: adopt each existing Work Item without reset or duplication and set durable Merge Mode Always.
- Enroll new open children and adopt existing ones in the same atomic request; failure rolls back both new Work Items and Merge Mode changes.
- Preserve lifecycle step/status, history, admission, Session, worktree, and Work Item PR; leave merge-related Needs Human handoffs stopped (no Merge PR enqueue).
- Keep the parent action available when unfinished children exist; safe repeated invocation and later enrollment of children added after an earlier snapshot.
- Client cache upserts covered rows by id and appends only into the default Issues list and Jobs WORKING (not Failed/Completed).

## Test plan

- [x] Lifecycle: adopt ordinary unfinished (preserve identity/progress/Session/worktree/PR); Needs Human stays stopped; mixed create+adopt enqueue rollback restores Merge Mode; concurrent Implement Now + parent; later-added child; terminal history re-create; idempotent re-run
- [x] GraphQL: domain failure mapping for not-eligible
- [x] Harness: eligibility with unfinished / Needs Human / all unfinished; listKind-aware cache upsert on implement-all success
- [x] Pre-commit affected lint/typecheck/test

Closes #519