### PR TITLE
fix(harness): fix parent issue row control order and menu font

### DIFF
--- a/apps/harness/src/parent-issue-actions-menu.tsx
+++ b/apps/harness/src/parent-issue-actions-menu.tsx
@@ -70,7 +70,7 @@ export function ParentIssueActionsMenu({
       {menuOpen && (
         <div
           role="menu"
-          className="absolute top-full right-0 z-10 mt-1 min-w-56 border border-rule-2 bg-panel py-1 shadow-[0_12px_30px_rgb(28_22_14_/_18%)]"
+          className="absolute top-full right-0 z-10 mt-1 min-w-56 border border-rule-2 bg-panel py-1 font-sans normal-case tracking-normal shadow-[0_12px_30px_rgb(28_22_14_/_18%)]"
         >
           <button
             type="button"
@@ -89,7 +89,7 @@ export function ParentIssueActionsMenu({
       )}
       {errorMessage !== null && (
         <p
-          className="absolute top-full right-0 z-10 mt-1 w-56 border border-rule-2 bg-panel px-2 py-1.5 text-xs text-oxblood-deep normal-case tracking-normal"
+          className="absolute top-full right-0 z-10 mt-1 w-56 border border-rule-2 bg-panel px-2 py-1.5 font-sans text-xs font-normal text-oxblood-deep normal-case tracking-normal"
           role="alert"
         >
           {errorMessage}

--- a/apps/harness/src/routes/index.tsx
+++ b/apps/harness/src/routes/index.tsx
@@ -2552,8 +2552,22 @@ function ParentIssueGroup({
               </span>
             )}
           </span>
-          <span className="flex shrink-0 items-center gap-1.5 font-mono text-xs font-semibold tracking-[0.1em] text-ink-faint uppercase">
-            {closedChildren}/{childIssues.length} closed
+          <span className="flex shrink-0 items-center gap-1.5">
+            <span className="font-mono text-xs font-semibold tracking-[0.1em] text-ink-faint uppercase">
+              {closedChildren}/{childIssues.length} closed
+            </span>
+            <svg
+              aria-hidden="true"
+              className="size-3.5 text-ink-faint transition-transform group-open:rotate-180"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            >
+              <path d="m6 9 6 6 6-6" />
+            </svg>
             {canImplementAll && (
               <ParentIssueActionsMenu
                 parentGithubIssueNumber={parent.githubIssueNumber}
@@ -2567,18 +2581,6 @@ function ParentIssueGroup({
                 onImplementAllWithAutoMerge={() => implementAll.mutate()}
               />
             )}
-            <svg
-              aria-hidden="true"
-              className="size-3.5 transition-transform group-open:rotate-180"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="2"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-            >
-              <path d="m6 9 6 6 6-6" />
-            </svg>
           </span>
         </summary>
         <ul className="relative m-0 grid list-none gap-1 py-1 pl-0 before:absolute before:top-0 before:bottom-1 before:-left-2 before:w-px before:bg-rule-2">

--- a/apps/harness/test/parent-issue-actions-menu.test.tsx
+++ b/apps/harness/test/parent-issue-actions-menu.test.tsx
@@ -205,4 +205,52 @@ describe("ParentIssueActionsMenu", () => {
     expect(source).not.toContain('"Queue"')
     expect(source.match(/role="menuitem"/g)?.length).toBe(1)
   })
+
+  test("menu shell resets inherited mono/uppercase styles to match other app menus", () => {
+    const source = readFileSync(
+      join(import.meta.dir, "../src/parent-issue-actions-menu.tsx"),
+      "utf8",
+    )
+    // Other menus (leaf issue, repository card) use plain sans menuitems.
+    // Explicit resets keep the kebab menu correct if a parent stamp/label wraps it.
+    expect(source).toMatch(
+      /role="menu"[\s\S]*?font-sans[\s\S]*?normal-case[\s\S]*?tracking-normal/,
+    )
+    expect(source).toContain(
+      'className="block w-full px-3 py-2 text-left text-sm font-medium text-ink-2 hover:bg-paper-2"',
+    )
+  })
+})
+
+describe("ParentIssueGroup control order", () => {
+  test("chevron sits left of kebab; kebab is rightmost control", () => {
+    // Parent row lives in the dashboard route; lock DOM order without a browser.
+    const source = readFileSync(
+      join(import.meta.dir, "../src/routes/index.tsx"),
+      "utf8",
+    )
+    const groupStart = source.indexOf("function ParentIssueGroup")
+    expect(groupStart).toBeGreaterThanOrEqual(0)
+    const groupEnd = source.indexOf("function RepositoryIssueRow", groupStart)
+    expect(groupEnd).toBeGreaterThan(groupStart)
+    const group = source.slice(groupStart, groupEnd)
+
+    // Anchor on the UI closed-count label, not the closedChildren prop name.
+    const closedLabel = group.indexOf("childIssues.length} closed")
+    const chevron = group.indexOf("group-open:rotate-180")
+    const kebab = group.indexOf("<ParentIssueActionsMenu")
+    expect(closedLabel).toBeGreaterThanOrEqual(0)
+    expect(chevron).toBeGreaterThan(closedLabel)
+    expect(kebab).toBeGreaterThan(chevron)
+
+    // Stamp mono/uppercase applies only to the closed count, not the controls.
+    // Chevron keeps text-ink-faint for currentColor without re-wrapping the menu.
+    expect(group).toMatch(
+      /font-mono text-xs font-semibold tracking-\[0\.1em\] text-ink-faint uppercase[\s\S]*?closed/,
+    )
+    expect(group).toContain(
+      "size-3.5 text-ink-faint transition-transform group-open:rotate-180",
+    )
+    expect(group).not.toMatch(/flex shrink-0 items-center gap-1\.5 font-mono/)
+  })
 })


### PR DESCRIPTION
## Summary

- On Relevant Issues parent rows, put the expand/collapse chevron left of the kebab so the kebab is rightmost.
- Scope mono/uppercase stamp styles to the closed-count label and reset parent menu font inheritance so kebab items match other app menus.
- Keep the chevron in the faint stamp color without wrapping the menu; lock control order and menu styles with unit tests.

## Test plan

- [x] `parent-issue-actions-menu` unit tests (eligibility, menu contract, control order, font reset)
- [x] Pre-commit affected lint, typecheck, and test

Closes #534