### PR TITLE
fix(harness): rename settings labels to effort (thinking)

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ ready-for-agent
 This opens the UI in the browser
 ([http://127.0.0.1:6056/](http://127.0.0.1:6056/)). This shows the
 configured state. If you open this for the first time, you will be
-prompted to set a default build model and thinking level, and configure repos.
+prompted to set a default build model and effort (thinking), and configure repos.
 
 ## Stop opening a browser window
 
@@ -153,8 +153,8 @@ KEYMAXXER_ENABLED=false npx ready-for-agent@latest
 
 Yes. Settings can select **OpenCode** or **Grok Build** as the instance-wide
 Agent Backend. The change hot-activates on Save when no Work Items are
-unfinished (including Needs Human). Model catalogs and Thinking Levels are
-backend-local, and build/review prefs are remembered per backend.
+unfinished (including Needs Human). Model catalogs and effort (thinking)
+options are backend-local, and build/review prefs are remembered per backend.
 
 2. Does the harness support any other backend than GitHub?
 

--- a/apps/harness/src/routes/__root.tsx
+++ b/apps/harness/src/routes/__root.tsx
@@ -885,17 +885,18 @@ function SettingsButton() {
 
                 {defaultModel.length > 0 && hasUnavailableBuildModel ? (
                   <p className="border border-oxblood/40 bg-oxblood-wash p-3 text-sm text-oxblood-deep">
-                    Build thinking level is unavailable — the selected model is
-                    not in the Agent Model catalog. Choose another build model.
+                    Build effort (thinking) is unavailable — the selected model
+                    is not in the Agent Model catalog. Choose another build
+                    model.
                   </p>
                 ) : defaultModel.length > 0 && buildVariants.length === 0 ? (
                   <p className="bg-paper-2 p-3 text-sm text-ink-soft">
-                    Build thinking level is unavailable — this model has no
-                    Thinking Levels.
+                    Build effort (thinking) is unavailable — this model has no
+                    effort (thinking) options.
                   </p>
                 ) : (
                   <label className="grid min-w-0 gap-1.5 text-sm font-semibold">
-                    Build thinking level
+                    Build effort (thinking)
                     <select
                       className="w-full min-w-0 border border-rule-2 bg-paper px-3 py-2 text-sm font-normal outline-none focus:border-oxblood focus:ring-2 focus:ring-oxblood/15 disabled:cursor-not-allowed disabled:opacity-60"
                       name="defaultThinkingLevel"
@@ -907,7 +908,7 @@ function SettingsButton() {
                     >
                       <option value="">
                         {buildVariants.length === 0
-                          ? "Model default (no Thinking Levels)"
+                          ? "Model default (no effort (thinking) options)"
                           : "Model default"}
                       </option>
                       {hasCustomBuildVariant && (
@@ -922,8 +923,8 @@ function SettingsButton() {
                       ))}
                     </select>
                     <span className="text-xs font-normal text-ink-faint">
-                      Optional Thinking Level for this model. Options come from
-                      the selected model.
+                      Optional effort (thinking) for this model. Options come
+                      from the selected model.
                     </span>
                   </label>
                 )}
@@ -968,19 +969,19 @@ function SettingsButton() {
                 ((reviewModel.length > 0 && hasUnavailableReviewModel) ||
                   (reviewModel.length === 0 && hasUnavailableBuildModel)) ? (
                   <p className="border border-oxblood/40 bg-oxblood-wash p-3 text-sm text-oxblood-deep">
-                    Review thinking level is unavailable — the selected model is
-                    not in the Agent Model catalog. Choose another model or use
-                    the build model.
+                    Review effort (thinking) is unavailable — the selected model
+                    is not in the Agent Model catalog. Choose another model or
+                    use the build model.
                   </p>
                 ) : reviewThinkingLevelSourceModel.length > 0 &&
                   reviewThinkingLevels.length === 0 ? (
                   <p className="bg-paper-2 p-3 text-sm text-ink-soft">
-                    Review thinking level is unavailable — this model has no
-                    Thinking Levels.
+                    Review effort (thinking) is unavailable — this model has no
+                    effort (thinking) options.
                   </p>
                 ) : (
                   <label className="grid min-w-0 gap-1.5 text-sm font-semibold">
-                    Review thinking level
+                    Review effort (thinking)
                     <select
                       className="w-full min-w-0 border border-rule-2 bg-paper px-3 py-2 text-sm font-normal outline-none focus:border-oxblood focus:ring-2 focus:ring-oxblood/15 disabled:cursor-not-allowed disabled:opacity-60"
                       name="reviewThinkingLevel"
@@ -992,7 +993,7 @@ function SettingsButton() {
                         reviewThinkingLevels.length === 0
                       }
                     >
-                      <option value="">Same as build thinking level</option>
+                      <option value="">Same as build effort (thinking)</option>
                       {hasCustomReviewVariant && (
                         <option value={reviewThinkingLevel}>
                           {formatVariantLabel(reviewThinkingLevel)}

--- a/apps/harness/src/routes/index.tsx
+++ b/apps/harness/src/routes/index.tsx
@@ -1996,20 +1996,20 @@ function RepositoryCard({
                 {buildVariantSourceModel.length > 0 &&
                 buildVariantSourceUnavailable ? (
                   <p className="border border-oxblood/40 bg-oxblood-wash p-3 text-sm text-oxblood-deep">
-                    Build thinking level override is unavailable — the selected
-                    model is not in the Agent Model catalog. Use harness default
-                    or pick another model.
+                    Build effort (thinking) override is unavailable — the
+                    selected model is not in the Agent Model catalog. Use
+                    harness default or pick another model.
                   </p>
                 ) : buildVariantSourceModel.length > 0 &&
                   buildVariants.length === 0 ? (
                   <p className="bg-paper-2 p-3 text-sm text-ink-soft">
-                    Build thinking level override is unavailable — this model
-                    has no Thinking Levels. Use harness default or pick another
-                    model.
+                    Build effort (thinking) override is unavailable — this model
+                    has no effort (thinking) options. Use harness default or
+                    pick another model.
                   </p>
                 ) : (
                   <label className="grid min-w-0 gap-1.5 text-sm font-semibold">
-                    Build thinking level
+                    Build effort (thinking)
                     <select
                       className="w-full min-w-0 border border-rule-2 bg-paper px-3 py-2 text-sm font-normal outline-none focus:border-oxblood focus:ring-2 focus:ring-oxblood/15 disabled:cursor-not-allowed disabled:opacity-60"
                       value={defaultThinkingLevel}
@@ -2081,20 +2081,20 @@ function RepositoryCard({
                 {reviewThinkingLevelSourceModel.length > 0 &&
                 reviewThinkingLevelSourceUnavailable ? (
                   <p className="border border-oxblood/40 bg-oxblood-wash p-3 text-sm text-oxblood-deep">
-                    Review thinking level override is unavailable — the selected
-                    model is not in the Agent Model catalog. Use harness default
-                    or pick another model.
+                    Review effort (thinking) override is unavailable — the
+                    selected model is not in the Agent Model catalog. Use
+                    harness default or pick another model.
                   </p>
                 ) : reviewThinkingLevelSourceModel.length > 0 &&
                   reviewThinkingLevels.length === 0 ? (
                   <p className="bg-paper-2 p-3 text-sm text-ink-soft">
-                    Review thinking level override is unavailable — this model
-                    has no Thinking Levels. Use harness default or pick another
-                    model.
+                    Review effort (thinking) override is unavailable — this
+                    model has no effort (thinking) options. Use harness default
+                    or pick another model.
                   </p>
                 ) : (
                   <label className="grid min-w-0 gap-1.5 text-sm font-semibold">
-                    Review thinking level
+                    Review effort (thinking)
                     <select
                       className="w-full min-w-0 border border-rule-2 bg-paper px-3 py-2 text-sm font-normal outline-none focus:border-oxblood focus:ring-2 focus:ring-oxblood/15 disabled:cursor-not-allowed disabled:opacity-60"
                       value={reviewThinkingLevel}


### PR DESCRIPTION
## Summary

- Rename global and repository settings labels from **Build/Review thinking level** to **Build/Review effort (thinking)**.
- Align related helper, unavailable, and option copy (including “Same as build effort (thinking)”) so user-facing wording is consistent.
- Update matching README first-run and FAQ copy. Display strings only; no config, schema, or behavior changes.

## Test plan

- [x] Confirm global settings labels and related strings use “effort (thinking)”
- [x] Confirm repository settings override labels and unavailable copy match
- [x] Pre-commit affected lint, typecheck, and test

Closes #536.