### PR TITLE
fix(keymaxxer-service): stop per-call operator-interaction log spam

### DIFF
--- a/packages/keymaxxer-service/README.md
+++ b/packages/keymaxxer-service/README.md
@@ -31,6 +31,12 @@ result; transport, protocol, and execution failures use `KeymaxxerError`.
   Once unlocked, metadata-only `keymaxxer_list` may proceed while a dialog
   operation waits for secret-use approval. Side-effecting failures are not
   replayed; transport failures invalidate the upstream for the next request.
+  Operator logs cover vault unlock (and wrong-passphrase retries) only; the
+  facade does **not** emit a per-call "may require operator interaction" line
+  for every `keymaxxer_run` / `keymaxxer_add`, because it cannot know whether
+  Keymaxxer will show a dialog after Allow-session is set. Dialog-capable
+  ops still share one serialized dialog lane (concurrent already-approved
+  runs are not implemented yet; many GitHub helper calls queue on that lane).
 - `runKeymaxxerSidecarProcess()` — sidecar process body (listen, bootstrap URL,
   signals). Uses zod only for MCP SDK tool `inputSchema` registration; Effect
   client payloads use Schema.

--- a/packages/keymaxxer-service/src/lib/facade.ts
+++ b/packages/keymaxxer-service/src/lib/facade.ts
@@ -320,7 +320,9 @@ export const startKeymaxxerFacade = async (
           return unlockResult
         }
       }
-      log(`[facade] ${name} may require operator interaction`)
+      // No preemptive per-call "may require operator interaction" log: the facade
+      // cannot know if Keymaxxer will dialog, and that line spam looks stuck after
+      // Allow-session (#547). Unlock waits stay in unlockProbe only.
       return callUpstream(name, args)
     })
   }

--- a/packages/keymaxxer-service/test/facade.test.ts
+++ b/packages/keymaxxer-service/test/facade.test.ts
@@ -661,6 +661,63 @@ describe("Keymaxxer MCP facade security surface", () => {
     }
   })
 
+  test("does not spam operator-interaction lines for successful post-unlock runs", async () => {
+    const logs: string[] = []
+    const burst = 8
+    const facade = await startKeymaxxerFacade({
+      host: "127.0.0.1",
+      port: 0,
+      createUpstream: async () => mockUpstream(),
+      onBootstrapUrl: () => {},
+      log: (message) => {
+        logs.push(message)
+      },
+    })
+
+    try {
+      const connection = await connectClient(facade.url)
+      try {
+        const unlock = await connection.client.callTool({
+          name: "keymaxxer_list",
+          arguments: {},
+        })
+        expect(unlock.isError).not.toBe(true)
+        expect(
+          logs.filter((line) => line.includes("waiting for vault unlock")),
+        ).toHaveLength(1)
+
+        const results = await Promise.all(
+          Array.from({ length: burst }, () =>
+            connection.client.callTool({
+              name: "keymaxxer_run",
+              arguments: { command: "true", secrets: ["DEMO"] },
+            }),
+          ),
+        )
+        for (const result of results) {
+          expect(result.isError).not.toBe(true)
+          expect(toolText(result)).toContain("exit_code: 0")
+        }
+
+        const interactionLines = logs.filter(
+          (line) =>
+            /may require operator interaction/i.test(line) ||
+            /waiting for secret-use approval/i.test(line) ||
+            /operator interaction/i.test(line),
+        )
+        expect(interactionLines).toEqual([])
+        // Unlock probe stays visible; successful runs must not add more facade noise.
+        expect(logs.filter((line) => line.startsWith("[facade]"))).toEqual([
+          "[facade] waiting for vault unlock",
+        ])
+      } finally {
+        await connection.transport.close()
+      }
+    } finally {
+      await facade.stop()
+    }
+  })
+
   test("does not replay a side-effecting request after transport failure", async () => {
     let upstreamSpawns = 0
     let runCalls = 0


### PR DESCRIPTION
## Why

After vault unlock and Allow-session approval, the Keymaxxer Sidecar facade logged
`[facade] keymaxxer_run may require operator interaction` on every dialog-lane
entry. That looked like a stuck approval dialog even when each `keymaxxer_run`
succeeded, and normal Harness GitHub helper traffic made the noise worse (#547).

The facade cannot know whether Keymaxxer will show a dialog, so a preemptive
per-call line is misleading. #493 softened the wording but still spammed once per call.

## What

- Remove the unconditional operator-interaction log at dialog-lane entry for
  `keymaxxer_run` / `keymaxxer_add` in the MCP facade.
- Keep unlock-probe diagnostics (`waiting for vault unlock`, wrong-passphrase
  retries, re-probe before op).
- Leave dialog-lane serialization unchanged (post-approval concurrent runs remain
  out of scope; research #110).
- Document quieter diagnostics and the serialized dialog lane in the package README.
- Add a facade regression test: after unlock, a burst of successful mock
  `keymaxxer_run` calls must not emit operator-interaction lines.

## Verification

- `bunx nx run keymaxxer-service:test` — facade suite green, including the new
  regression (one pre-existing sidecar process bootstrap failure on main is
  unrelated to this change).
- `bunx nx run keymaxxer-service:typecheck` — pass
- `bunx nx run keymaxxer-service:lint` — pass
- Pre-commit hook — pass after Biome formatting of the new assertion

## Limitations

- Real Zenity/pinentry approval waits are not logged via a timed "still waiting"
  diagnostic; this change only stops the false preemptive spam.
- Already-approved `keymaxxer_run` traffic remains serialized on the dialog lane.

Closes #547