### PR TITLE
docs: define Codex Build agent backend

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -91,6 +91,10 @@ _Avoid_: Single instance-wide backend only, Selected vs Active limbo, dual backe
 The supported xAI coding Agent Backend with the stable ID `grok`. Distinct from a Grok Agent Model.
 _Avoid_: Grok (when referring to the backend), grok-build (as the config ID)
 
+**Codex Build**:
+The supported OpenAI coding Agent Backend with the stable ID `codex`. Distinct from a Codex Agent Model.
+_Avoid_: Codex (when referring to the backend), codex-build (as the config ID)
+
 **Agent Backend Unavailable**:
 A per-backend degraded state established by failed startup inspection, failed hot-activation on Save, or Recheck Agent Backend when that Agent Backend cannot execute Agent Turns or report its Agent Models. The UI, non-agent maintenance, and Agent-free Lifecycle Steps remain available. New Agent Turns and Work Item creation that need the Unavailable backend are blocked until a Recheck (or successful re-activation) for that backend succeeds; other backends are unaffected. Runtime Agent Turn failures fail only their Step Run, and the Harness never silently falls back to another backend. Unavailable does not block changing selections while the applicable idle gate allows.
 _Avoid_: Startup failure, automatic fallback, harness-wide block when another backend is healthy, Paused Repository, restart required

--- a/docs/adr/0041-codex-build-agent-backend.md
+++ b/docs/adr/0041-codex-build-agent-backend.md
@@ -1,0 +1,13 @@
+# Codex Build Agent Backend
+
+Codex Build is the third built-in Agent Backend, with stable ID `codex`, delivered as a `packages/codex` adapter on the shared `@ready-for-agent/agent-backend` contract (ADR 0031), following the Grok adapter's shape. Turns run as `codex exec --json`; the Session ID is the Codex `thread_id`, captured from the early `thread.started` stream event and continued across turns and Harness restarts with `codex exec resume <thread_id>`. The `/review` Agent Command is prompt-prefixed, as in the Grok adapter. Authentication is ambient (ChatGPT OAuth via `codex login`, or `OPENAI_API_KEY`), with ambient `gh` for Agent GitHub Access and no Keymaxxer integration; readiness inspection is binary presence plus `codex login status`.
+
+Three deliberate deviations from the existing adapters are part of this decision:
+
+- **Static model catalog.** The Codex CLI has no one-shot models command (open feature request: openai/codex#23279), so the "instance-wide Agent Model catalog through atomic readiness inspection" requirement of ADR 0031 is met with an adapter-bundled static catalog rather than a CLI-reported one. The catalog lists only current-generation models — gpt-5.5 and up — with each model's reasoning efforts as Thinking Levels; legacy models are excluded even when an operator's account can still access them. Adding a newly released OpenAI model requires a Harness release. When openai/codex#23279 ships a supported non-interactive models command, the catalog source migrates to CLI-reported with no adapter contract change. The Codex App Server's `model/list` JSON-RPC method was rejected: it would introduce a long-lived server process into readiness inspection, breaking the atomic inspection shape.
+- **Unsandboxed turns.** Turns run with `--sandbox danger-full-access` because Codex's OS-level sandbox defaults (read-only, and network-blocked under `workspace-write`) would break shell, git, and `gh` work mid-turn in ways that surface as confusing Step Run failures. This is parity with the OpenCode and Grok adapters, which run unsandboxed; containment remains the git worktree plus operator trust in the backend.
+- **No Session Telemetry in v1.** Per the Grok precedent (ADR 0033), the adapter ships without telemetry even though `turn.completed` carries token usage; telemetry can be added later without a contract change.
+
+## Consequences
+
+New OpenAI models are unavailable to operators until a Harness release updates the static catalog, and an OpenAI-side model deprecation surfaces as an ordinary Step Run failure until the operator selects a newer model. The static catalog and sandbox stance should be revisited if OpenAI ships a one-shot models command or if the Harness later adopts a general backend-sandboxing story.


### PR DESCRIPTION
## Why

We are adding Codex Build — OpenAI's Codex CLI — as the third built-in Agent Backend (alongside OpenCode and Grok Build). Before any adapter code is written, this PR records the design decisions reached in a grilling session, so the implementation has an authoritative spec and future readers can see why three deliberate deviations from the existing adapters were made.

## What Changed

- `CONTEXT.md`: new glossary entry **Codex Build** — the supported OpenAI coding Agent Backend with stable ID `codex`, distinct from a Codex Agent Model.
- `docs/adr/0041-codex-build-agent-backend.md`: the decision record:
  - Adapter shape follows the Grok adapter on the shared `@ready-for-agent/agent-backend` contract (ADR 0031): turns run as `codex exec --json`, the Session ID is the Codex `thread_id` captured from the early `thread.started` stream event, sessions continue via `codex exec resume`, and `/review` is prompt-prefixed. Authentication is ambient (`codex login` / `OPENAI_API_KEY`, ambient `gh`, no Keymaxxer); readiness inspection is binary presence plus `codex login status`.
  - **Static model catalog**: the Codex CLI has no one-shot models command (open feature request: openai/codex#23279), so the catalog is adapter-bundled and lists only current-generation models (gpt-5.5 and up), with reasoning efforts as Thinking Levels. Migration to a CLI-reported catalog is documented with #23279 as the trigger; the App Server `model/list` JSON-RPC path was rejected for breaking the atomic readiness-inspection shape.
  - **Unsandboxed turns** via `--sandbox danger-full-access`, for parity with the OpenCode and Grok adapters; Codex's OS-sandbox defaults (read-only, network-blocked under `workspace-write`) would break shell, git, and `gh` work mid-turn.
  - **No Session Telemetry in v1**, per the Grok precedent (ADR 0033); `turn.completed` usage data can be wired in later without a contract change.
