### PR TITLE
fix(harness): update first-run settings guidance for backend and models

### DIFF
--- a/apps/harness/src/routes/__root.tsx
+++ b/apps/harness/src/routes/__root.tsx
@@ -688,9 +688,9 @@ function SettingsButton() {
             </p>
             {showUnconfiguredGuidance && (
               <p className="mt-3 border border-oxblood/40 bg-oxblood-wash p-3 text-sm text-oxblood-deep">
-                Select a default build model before the harness can create work
-                on Repositories that inherit this default. Repositories with a
-                fully configured Agent Backend override can still create work.
+                Select a default agent backend, and default build model.
+                Optionally select a different review model (recommended). You
+                can override this per configured repo.
               </p>
             )}
             {!backendChanging &&

--- a/apps/harness/test/harness-settings-backend-change.test.ts
+++ b/apps/harness/test/harness-settings-backend-change.test.ts
@@ -34,9 +34,13 @@ describe("Harness settings Agent Backend change", () => {
     expect(source).toContain("Active Agent Backends")
     expect(source).toContain("Repositories inheriting the harness default")
     expect(source).toContain("Default Agent Backend")
-    // First-run guidance is about the default build model, not a hard fleet freeze.
+    // First-run guidance covers default backend/model setup and per-repo overrides.
     expect(source).toContain(
-      "fully configured Agent Backend override can still create work",
+      "Select a default agent backend, and default build model",
     )
+    expect(source).toContain(
+      "Optionally select a different review model (recommended)",
+    )
+    expect(source).toContain("override this per configured repo")
   })
 })


### PR DESCRIPTION
## Why

First-run Settings guidance only told operators to pick a default build
model. Operators also need a default agent backend and are encouraged to
set a review model; per-repo overrides should be obvious.

## What changed

- Settings dialog unconfigured guidance now covers default agent backend,
  build model, optional review model, and per-repo overrides.
- Updated the harness source-string test that asserted the old copy.
- Left the compact header banner and structured "Select a default build
  model first" error messages unchanged (short CTA / API contract).

## Verification

- `bunx nx test harness` — 209 pass, 0 fail
- Local code review: clean (no findings)

Closes #548