### PR TITLE
feat(graphql-api): poll GitHub issues every minute

### DIFF
--- a/packages/graphql-api/src/lib/issue-polling.ts
+++ b/packages/graphql-api/src/lib/issue-polling.ts
@@ -14,7 +14,7 @@ export const POLLING_AUTO_HEAL_KEY = "polling-auto-heal"
 export const JOB_RECOVERY_RETRY_LIMIT = 1
 
 /** Base quiet period after a scheduled attempt completes. */
-export const ISSUE_POLLING_BASE_SECONDS = 120
+export const ISSUE_POLLING_BASE_SECONDS = 60
 
 /** Inclusive upper bound for additive jitter seconds (0–30). */
 export const ISSUE_POLLING_JITTER_SECONDS = 30
@@ -32,7 +32,7 @@ export const PollingAutoHealJobPayload = {
 }
 
 /**
- * Sample the next Issue Polling delay: 120s + uniform integer jitter in [0, 30].
+ * Sample the next Issue Polling delay: 60s + uniform integer jitter in [0, 30].
  * Injectable via Effect Random so tests can seed or replace sampling.
  */
 export const sampleIssuePollingDelay: Effect.Effect<Duration.Duration> =

--- a/packages/graphql-api/test/graphql-api.test.ts
+++ b/packages/graphql-api/test/graphql-api.test.ts
@@ -664,8 +664,8 @@ describe("GraphQL API", () => {
       _tag: "refresh-repository",
       repositoryId: repository.id,
     })
-    expect(ensured[0]?.delayMs).toBeGreaterThanOrEqual(120_000)
-    expect(ensured[0]?.delayMs).toBeLessThanOrEqual(150_000)
+    expect(ensured[0]?.delayMs).toBeGreaterThanOrEqual(60_000)
+    expect(ensured[0]?.delayMs).toBeLessThanOrEqual(90_000)
     expect(enqueued).toEqual([
       {
         queue: "issue-refresh",


### PR DESCRIPTION
## Why

Scheduled GitHub Issue polling ran every two minutes (120s base + 0–30s jitter), so external Issue changes could take over two minutes to show up in the Harness. Dropping the base quiet period to 60s halves that latency while the existing jitter still spreads requests.

## What Changed

- `packages/graphql-api/src/lib/issue-polling.ts`: `ISSUE_POLLING_BASE_SECONDS` reduced from `120` to `60`, so the scheduled poll cadence is now 60s + uniform 0–30s jitter. The doc comment on `sampleIssuePollingDelay` is updated to match.
- `packages/graphql-api/test/graphql-api.test.ts`: the add-repository activation test now asserts the new 60_000–90_000ms delay range instead of 120_000–150_000ms.
