### PR TITLE
feat(codex): add Codex Build adapter with static catalog and readiness

### DIFF
--- a/apps/harness/package.json
+++ b/apps/harness/package.json
@@ -21,6 +21,7 @@
     "@ready-for-agent/issue-reconciler": "workspace:*",
     "@ready-for-agent/keymaxxer-service": "workspace:*",
     "@ready-for-agent/local-git": "workspace:*",
+    "@ready-for-agent/codex": "workspace:*",
     "@ready-for-agent/grok": "workspace:*",
     "@ready-for-agent/opencode": "workspace:*",
     "@ready-for-agent/queue-service": "workspace:*",

--- a/apps/harness/src/server/application.server.ts
+++ b/apps/harness/src/server/application.server.ts
@@ -22,6 +22,7 @@ import {
   isSelectableAgentBackendId,
   resolveActiveRegistration,
 } from "@ready-for-agent/agent-backend"
+import { Codex, CodexSessionTelemetryLive } from "@ready-for-agent/codex"
 import { DatabaseLive } from "@ready-for-agent/db"
 import { DbService, DbServiceLive } from "@ready-for-agent/db-service"
 import { createGraphqlApi } from "@ready-for-agent/graphql-api"
@@ -86,6 +87,25 @@ const makeResolveRuntime = (
           Layer.mergeAll(
             Grok.layer().pipe(Layer.provide(platformLayer)),
             GrokSessionTelemetryLive(),
+          ),
+        ),
+      )
+    }
+
+    if (registration.descriptor.id === AGENT_BACKEND_IDS.codex) {
+      return Effect.gen(function* () {
+        const adapter = yield* AgentBackend
+        const telemetry = yield* SessionTelemetryProvider
+        return {
+          registration,
+          adapter,
+          telemetry,
+        }
+      }).pipe(
+        Effect.provide(
+          Layer.mergeAll(
+            Codex.layer().pipe(Layer.provide(platformLayer)),
+            CodexSessionTelemetryLive(),
           ),
         ),
       )

--- a/apps/harness/tsconfig.app.json
+++ b/apps/harness/tsconfig.app.json
@@ -35,6 +35,9 @@
       "path": "../../packages/grok/tsconfig.lib.json"
     },
     {
+      "path": "../../packages/codex/tsconfig.lib.json"
+    },
+    {
       "path": "../../packages/issue-reconciler/tsconfig.lib.json"
     },
     {

--- a/apps/ready-for-agent/src/host-tools-preflight.test.ts
+++ b/apps/ready-for-agent/src/host-tools-preflight.test.ts
@@ -54,7 +54,7 @@ describe("host tools preflight", () => {
     expect(missingGrok.message).toContain("Grok Build")
   })
 
-  test("unused built-ins not required even when only one of two is selected", () => {
+  test("unused built-ins not required when a single backend is selected", () => {
     const onlyGrok = checkHostTools(
       (command) => ["git", "gh", "grok"].includes(command),
       { selectedAgentBackendIds: ["grok"] },
@@ -66,6 +66,24 @@ describe("host tools preflight", () => {
       { selectedAgentBackendIds: ["opencode"] },
     )
     expect(onlyOpenCode.ok).toBe(true)
+  })
+
+  test("requires codex when only Codex Build is selected", () => {
+    const withCodex = checkHostTools(
+      (command) => ["git", "gh", "codex"].includes(command),
+      { selectedAgentBackendIds: ["codex"] },
+    )
+    expect(withCodex.ok).toBe(true)
+
+    const missingCodex = checkHostTools(
+      (command) => ["git", "gh", "opencode"].includes(command),
+      { selectedAgentBackendIds: ["codex"] },
+    )
+    expect(missingCodex.ok).toBe(false)
+    if (missingCodex.ok) return
+    expect(missingCodex.missing.map((tool) => tool.name)).toEqual(["codex"])
+    expect(missingCodex.message).toContain("codex")
+    expect(missingCodex.message).toContain("Codex Build")
   })
 
   test("passes without keymaxxer", () => {

--- a/apps/ready-for-agent/src/host-tools-preflight.ts
+++ b/apps/ready-for-agent/src/host-tools-preflight.ts
@@ -25,6 +25,11 @@ const BACKEND_HOST_TOOLS: Record<
     installHint:
       "Install Grok Build CLI: https://docs.x.ai/docs/grok-build (binary name: grok)",
   },
+  [AGENT_BACKEND_IDS.codex]: {
+    name: "codex",
+    installHint:
+      "Install Codex CLI: https://developers.openai.com/codex/cli (binary name: codex)",
+  },
 }
 
 const alwaysRequiredTools: ReadonlyArray<HostTool> = [

--- a/bun.lock
+++ b/bun.lock
@@ -31,6 +31,7 @@
       "dependencies": {
         "@effect/platform-bun": "^4.0.0-beta.97",
         "@ready-for-agent/agent-backend": "workspace:*",
+        "@ready-for-agent/codex": "workspace:*",
         "@ready-for-agent/db": "workspace:*",
         "@ready-for-agent/db-service": "workspace:*",
         "@ready-for-agent/github-service": "workspace:*",
@@ -108,6 +109,19 @@
       "name": "@ready-for-agent/agent-backend",
       "version": "0.0.1",
       "dependencies": {
+        "effect": "^4.0.0-beta.97",
+        "tslib": "^2.3.0",
+      },
+      "devDependencies": {
+        "@effect/platform-bun": "^4.0.0-beta.97",
+        "@types/bun": "^1.3.0",
+      },
+    },
+    "packages/codex": {
+      "name": "@ready-for-agent/codex",
+      "version": "0.0.1",
+      "dependencies": {
+        "@ready-for-agent/agent-backend": "workspace:*",
         "effect": "^4.0.0-beta.97",
         "tslib": "^2.3.0",
       },
@@ -917,6 +931,8 @@
     "@playwright/test": ["@playwright/test@1.61.1", "", { "dependencies": { "playwright": "1.61.1" }, "bin": { "playwright": "cli.js" } }, "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig=="],
 
     "@ready-for-agent/agent-backend": ["@ready-for-agent/agent-backend@workspace:packages/agent-backend"],
+
+    "@ready-for-agent/codex": ["@ready-for-agent/codex@workspace:packages/codex"],
 
     "@ready-for-agent/db": ["@ready-for-agent/db@workspace:packages/db"],
 

--- a/packages/agent-backend/src/lib/cli-runner.ts
+++ b/packages/agent-backend/src/lib/cli-runner.ts
@@ -2,7 +2,10 @@ import { Duration, Effect, Ref, Result, Stream } from "effect"
 import type { PlatformError } from "effect/PlatformError"
 import { ChildProcess, type ChildProcessSpawner } from "effect/unstable/process"
 import type { ChildProcessHandle } from "effect/unstable/process/ChildProcessSpawner"
-import { collectChildStdout } from "./collect-child-stdout.js"
+import {
+  collectChildStdout,
+  collectChildStdoutAndStderr,
+} from "./collect-child-stdout.js"
 import {
   AgentBackendExitError,
   AgentBackendMalformedOutputError,
@@ -41,21 +44,51 @@ export type RunCliCaptureInput = {
   readonly timeout: Duration.Input
   readonly stdin?: "ignore" | Stream.Stream<Uint8Array, PlatformError>
   readonly forceKillAfter?: Duration.Input
+  /**
+   * When true, return stdout + exitCode even if exit is non-zero instead of
+   * failing with AgentBackendExitError. Used by readiness probes that encode
+   * auth state in exit status (e.g. `codex login status`).
+   */
+  readonly allowNonZeroExit?: boolean
+  /**
+   * When true, pipe and capture stderr (returned as `stderr`). Default ignores
+   * stderr so Agent Turn noise does not fill memory. Readiness probes that
+   * print status on stderr (Codex `login status`) must opt in.
+   */
+  readonly captureStderr?: boolean
 }
 
-export type RunCliTurnInput = RunCliCaptureInput & {
+export type RunCliTurnInput = {
+  readonly spawner: ChildProcessSpawner.ChildProcessSpawner["Service"]
+  readonly binary: string
+  readonly args: ReadonlyArray<string>
+  readonly cwd: string
+  readonly env: Record<string, string>
+  readonly timeout: Duration.Input
+  readonly stdin?: "ignore" | Stream.Stream<Uint8Array, PlatformError>
+  readonly forceKillAfter?: Duration.Input
   readonly knownSessionId?: string
   readonly onSessionId?: OnSessionId
   readonly parseLine: (line: string) => CliLineEvent
   readonly observerLabel?: string
 }
 
-const commandOptions = (input: RunCliCaptureInput) => ({
+const commandOptions = (input: {
+  readonly cwd: string
+  readonly env: Record<string, string>
+  readonly stdin?: "ignore" | Stream.Stream<Uint8Array, PlatformError>
+  readonly forceKillAfter?: Duration.Input
+  readonly captureStderr?: boolean
+}) => ({
   cwd: input.cwd,
   env: input.env,
   extendEnv: false as const,
   stdin: input.stdin ?? ("ignore" as const),
-  stderr: "ignore" as const,
+  // Turns always ignore stderr so a chatty CLI cannot fill an undrained pipe.
+  // Capture probes opt in via captureStderr on runCliCapture only.
+  stderr: (input.captureStderr === true ? "pipe" : "ignore") as
+    | "pipe"
+    | "ignore",
   // Own process group on POSIX so group signals reach every CLI worker that
   // stayed in the session. Combined with killProcessTree for setsid stragglers.
   detached: process.platform !== "win32",
@@ -87,19 +120,24 @@ const terminateCliTree = (
   )
 
 /**
- * Run a CLI once, capture full stdout, map non-zero exit and timeout to
- * generic Agent Backend errors.
+ * Run a CLI once, capture full stdout (and optionally stderr), map non-zero
+ * exit and timeout to generic Agent Backend errors.
  */
 export const runCliCapture = (
   input: RunCliCaptureInput,
 ): Effect.Effect<
-  { readonly exitCode: number; readonly stdout: string },
+  {
+    readonly exitCode: number
+    readonly stdout: string
+    readonly stderr: string
+  },
   AgentBackendExitError | AgentBackendTimeoutError | PlatformError
 > =>
   Effect.gen(function* () {
     const spawner = input.spawner
     const timeoutMs = Duration.toMillis(input.timeout)
     const forceKillAfter = input.forceKillAfter ?? DEFAULT_FORCE_KILL_AFTER
+    const captureStderr = input.captureStderr === true
     const command = ChildProcess.make(
       input.binary,
       [...input.args],
@@ -114,7 +152,15 @@ export const runCliCapture = (
         yield* Effect.addFinalizer(() =>
           terminateCliTree(handle, forceKillAfter),
         )
-        return yield* collectChildStdout(handle)
+        if (captureStderr) {
+          return yield* collectChildStdoutAndStderr(handle)
+        }
+        const captured = yield* collectChildStdout(handle)
+        return {
+          exitCode: captured.exitCode,
+          stdout: captured.stdout,
+          stderr: "",
+        }
       }),
     ).pipe(
       Effect.timeout(input.timeout),
@@ -125,7 +171,7 @@ export const runCliCapture = (
       ),
     )
 
-    if (result.exitCode !== 0) {
+    if (result.exitCode !== 0 && input.allowNonZeroExit !== true) {
       return yield* new AgentBackendExitError({
         exitCode: result.exitCode,
         cwd: input.cwd,
@@ -157,7 +203,8 @@ export const runCliTurn = (
     const command = ChildProcess.make(
       input.binary,
       [...input.args],
-      commandOptions(input),
+      // Never pipe stderr for turns (undrained stderr can deadlock).
+      commandOptions({ ...input, captureStderr: false }),
     )
 
     const result = yield* Effect.scoped(

--- a/packages/agent-backend/src/lib/collect-child-stdout.ts
+++ b/packages/agent-backend/src/lib/collect-child-stdout.ts
@@ -22,3 +22,36 @@ export const collectChildStdout = (
       stdout,
     }
   })
+
+/**
+ * Drain stdout and stderr concurrently to EOF, then read exit code.
+ *
+ * Concurrent drain avoids pipe-buffer deadlock when both streams produce
+ * output. Used by readiness probes whose CLIs print status on stderr
+ * (e.g. `codex login status`).
+ */
+export const collectChildStdoutAndStderr = (
+  handle: ChildProcessHandle,
+): Effect.Effect<
+  {
+    readonly exitCode: number
+    readonly stdout: string
+    readonly stderr: string
+  },
+  PlatformError
+> =>
+  Effect.gen(function* () {
+    const [stdout, stderr] = yield* Effect.all(
+      [
+        Stream.decodeText(handle.stdout).pipe(Stream.mkString),
+        Stream.decodeText(handle.stderr).pipe(Stream.mkString),
+      ],
+      { concurrency: 2 },
+    )
+    const exitCode = yield* handle.exitCode
+    return {
+      exitCode: Number(exitCode),
+      stdout,
+      stderr,
+    }
+  })

--- a/packages/agent-backend/src/lib/registry.ts
+++ b/packages/agent-backend/src/lib/registry.ts
@@ -33,10 +33,22 @@ const GROK_REGISTRATION: AgentBackendRegistration = {
   ],
 }
 
+const CODEX_REGISTRATION: AgentBackendRegistration = {
+  descriptor: {
+    id: AGENT_BACKEND_IDS.codex,
+    label: "Codex Build",
+  },
+  capabilities: [
+    { _tag: "SessionTelemetry", supported: false },
+    { _tag: "KeymaxxerMcp", supported: false },
+  ],
+}
+
 /** Production selectable backends registered at build time. */
 const BUILT_IN_REGISTRY: ReadonlyArray<AgentBackendRegistration> = [
   OPENCODE_REGISTRATION,
   GROK_REGISTRATION,
+  CODEX_REGISTRATION,
 ]
 
 export const listBuiltInAgentBackends =

--- a/packages/agent-backend/src/lib/types.ts
+++ b/packages/agent-backend/src/lib/types.ts
@@ -4,6 +4,7 @@ import type { Duration, Effect } from "effect"
 export const AGENT_BACKEND_IDS = {
   opencode: "opencode",
   grok: "grok",
+  codex: "codex",
 } as const
 
 export type AgentBackendId =

--- a/packages/agent-backend/test/cli-runner.spec.ts
+++ b/packages/agent-backend/test/cli-runner.spec.ts
@@ -133,6 +133,54 @@ describe("runCliCapture", () => {
       )
     })
   })
+
+  it("returns stdout when allowNonZeroExit is set", async () => {
+    await withExecutable(
+      ["echo 'Not logged in'", "exit 1"].join("\n"),
+      async (binary) => {
+        const result = await Effect.runPromise(
+          withSpawner((spawner) =>
+            runCliCapture({
+              spawner,
+              binary,
+              args: [],
+              cwd: process.cwd(),
+              env: sanitizeInheritedEnvironment(),
+              timeout: Duration.seconds(2),
+              allowNonZeroExit: true,
+            }),
+          ),
+        )
+        expect(result.exitCode).toBe(1)
+        expect(result.stdout).toContain("Not logged in")
+        expect(result.stderr).toBe("")
+      },
+    )
+  })
+
+  it("captures stderr when captureStderr is set", async () => {
+    await withExecutable(
+      ["echo 'Logged in using ChatGPT' 1>&2", "exit 0"].join("\n"),
+      async (binary) => {
+        const result = await Effect.runPromise(
+          withSpawner((spawner) =>
+            runCliCapture({
+              spawner,
+              binary,
+              args: [],
+              cwd: process.cwd(),
+              env: sanitizeInheritedEnvironment(),
+              timeout: Duration.seconds(2),
+              captureStderr: true,
+            }),
+          ),
+        )
+        expect(result.exitCode).toBe(0)
+        expect(result.stdout).toBe("")
+        expect(result.stderr).toContain("Logged in using ChatGPT")
+      },
+    )
+  })
 })
 
 describe("runCliTurn", () => {

--- a/packages/agent-backend/test/registry.spec.ts
+++ b/packages/agent-backend/test/registry.spec.ts
@@ -11,26 +11,31 @@ import {
 import { describe, expect, it } from "bun:test"
 
 describe("Agent Backend registry", () => {
-  it("exposes OpenCode and Grok Build as selectable production backends", () => {
+  it("exposes OpenCode, Grok Build, and Codex Build as selectable production backends", () => {
     const backends = listBuiltInAgentBackends()
     expect(backends.map((entry) => entry.descriptor.id)).toEqual([
       AGENT_BACKEND_IDS.opencode,
       AGENT_BACKEND_IDS.grok,
+      AGENT_BACKEND_IDS.codex,
     ])
     expect(defaultAgentBackendId).toBe(AGENT_BACKEND_IDS.opencode)
     expect(getBuiltInAgentBackend("missing")).toBeUndefined()
     expect(
       getBuiltInAgentBackend(AGENT_BACKEND_IDS.grok)?.descriptor.label,
     ).toBe("Grok Build")
+    expect(
+      getBuiltInAgentBackend(AGENT_BACKEND_IDS.codex)?.descriptor.label,
+    ).toBe("Codex Build")
   })
 
   it("maps backend ids to operator-visible labels for failure copy", () => {
     expect(agentBackendLabel(AGENT_BACKEND_IDS.opencode)).toBe("OpenCode")
     expect(agentBackendLabel(AGENT_BACKEND_IDS.grok)).toBe("Grok Build")
+    expect(agentBackendLabel(AGENT_BACKEND_IDS.codex)).toBe("Codex Build")
     expect(agentBackendLabel("unknown-backend")).toBe("unknown-backend")
   })
 
-  it("declares typed capabilities for OpenCode and Grok Build", () => {
+  it("declares typed capabilities for OpenCode, Grok Build, and Codex Build", () => {
     const opencode = getBuiltInAgentBackend(AGENT_BACKEND_IDS.opencode)
     expect(opencode).toBeDefined()
     expect(capabilitySupported(opencode!, "SessionTelemetry")).toBe(true)
@@ -40,6 +45,11 @@ describe("Agent Backend registry", () => {
     expect(grok).toBeDefined()
     expect(capabilitySupported(grok!, "SessionTelemetry")).toBe(true)
     expect(capabilitySupported(grok!, "KeymaxxerMcp")).toBe(false)
+
+    const codex = getBuiltInAgentBackend(AGENT_BACKEND_IDS.codex)
+    expect(codex).toBeDefined()
+    expect(capabilitySupported(codex!, "SessionTelemetry")).toBe(false)
+    expect(capabilitySupported(codex!, "KeymaxxerMcp")).toBe(false)
   })
 })
 

--- a/packages/codex/package.json
+++ b/packages/codex/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@ready-for-agent/codex",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    "./package.json": "./package.json",
+    ".": {
+      "@ready-for-agent/source": "./src/index.ts",
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    }
+  },
+  "dependencies": {
+    "@ready-for-agent/agent-backend": "workspace:*",
+    "effect": "^4.0.0-beta.97",
+    "tslib": "^2.3.0"
+  },
+  "devDependencies": {
+    "@effect/platform-bun": "^4.0.0-beta.97",
+    "@types/bun": "^1.3.0"
+  }
+}

--- a/packages/codex/project.json
+++ b/packages/codex/project.json
@@ -1,0 +1,19 @@
+{
+  "name": "codex",
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "packages/codex/src",
+  "projectType": "library",
+  "tags": [],
+  "targets": {
+    "test": {
+      "executor": "nx:run-commands",
+      "options": {
+        "cwd": "{projectRoot}",
+        "command": "bun --conditions=@ready-for-agent/source test"
+      },
+      "inputs": ["default", "^production"],
+      "cache": true,
+      "dependsOn": ["^build"]
+    }
+  }
+}

--- a/packages/codex/src/index.ts
+++ b/packages/codex/src/index.ts
@@ -1,0 +1,5 @@
+export * from "./lib/codex.js"
+export * from "./lib/environment.js"
+export * from "./lib/parse-login-status.js"
+export * from "./lib/session-telemetry-layer.js"
+export * from "./lib/types.js"

--- a/packages/codex/src/lib/codex.ts
+++ b/packages/codex/src/lib/codex.ts
@@ -1,0 +1,125 @@
+import { Duration, Effect, Layer } from "effect"
+import { ChildProcessSpawner } from "effect/unstable/process"
+import {
+  AGENT_BACKEND_IDS,
+  AgentBackend,
+  AgentBackendConfigError,
+  type ContinueTurnInput,
+  type InspectInput,
+  type StartTurnInput,
+  malformedOutput,
+  runCliCapture,
+} from "@ready-for-agent/agent-backend"
+import { makeCodexEnvironment } from "./environment.js"
+import { parseCodexLoginStatus } from "./parse-login-status.js"
+import {
+  CODEX_STATIC_CATALOG,
+  CODEX_UNAUTHENTICATED_MESSAGE,
+  type CodexLayerOptions,
+} from "./types.js"
+
+const DEFAULT_TIMEOUT = Duration.minutes(30)
+const DEFAULT_BINARY = "codex"
+
+const CODEX_BACKEND = {
+  id: AGENT_BACKEND_IDS.codex,
+  label: "Codex Build",
+} as const
+
+/** Cap CLI probe text so Unavailable reasons stay readable in the UI. */
+const clipProbeOutput = (text: string, maxChars = 240): string => {
+  const trimmed = text.trim().replace(/\s+/g, " ")
+  if (trimmed.length === 0) {
+    return "(no output)"
+  }
+  if (trimmed.length <= maxChars) {
+    return trimmed
+  }
+  return `${trimmed.slice(0, maxChars)}…`
+}
+
+/**
+ * Codex Build adapter implementing the backend-neutral AgentBackend contract.
+ *
+ * This package ships registration, static catalog, and readiness inspection
+ * (issue #556). Agent Turns (start/continue) land in #557; until then they
+ * fail with a clear config error so Preview/Recheck remain demoable without
+ * turns.
+ */
+export class Codex {
+  static layer = (options: CodexLayerOptions = {}) =>
+    Layer.effect(
+      AgentBackend,
+      Effect.gen(function* () {
+        const spawner = yield* ChildProcessSpawner.ChildProcessSpawner
+        const binary = options.binary ?? DEFAULT_BINARY
+        const defaultTimeout = options.defaultTimeout ?? DEFAULT_TIMEOUT
+        const environment = makeCodexEnvironment()
+
+        const inspect = Effect.fn("Codex.inspect")(function* (
+          input: InspectInput,
+        ) {
+          // Real `codex login status` prints markers with eprintln! (stderr
+          // only). Capture stderr, allow non-zero exit so "Not logged in"
+          // (exit 1) keeps text for actionable ConfigError mapping.
+          const result = yield* runCliCapture({
+            spawner,
+            binary,
+            args: ["login", "status"],
+            cwd: input.cwd,
+            env: environment,
+            timeout: input.timeout ?? defaultTimeout,
+            allowNonZeroExit: true,
+            captureStderr: true,
+          })
+
+          const statusOutput = [result.stdout, result.stderr]
+            .filter((part) => part.length > 0)
+            .join("\n")
+          const status = parseCodexLoginStatus(statusOutput, result.exitCode)
+          if (status.kind === "unauthenticated") {
+            return yield* new AgentBackendConfigError({
+              message: CODEX_UNAUTHENTICATED_MESSAGE,
+            })
+          }
+          if (status.kind === "failed") {
+            // Non-zero without auth markers: not unauthenticated. Surface
+            // exit code + probe text so Recheck/Unavailable copy stays useful
+            // (ExitError has no message for formatInspectFailure).
+            return yield* new AgentBackendConfigError({
+              message: `Codex Build readiness probe failed (codex login status exit ${status.exitCode}): ${clipProbeOutput(statusOutput)}`,
+            })
+          }
+          if (status.kind === "malformed") {
+            return yield* malformedOutput(input.cwd, statusOutput)
+          }
+
+          return {
+            backend: CODEX_BACKEND,
+            models: CODEX_STATIC_CATALOG.map((model) => ({
+              id: model.id,
+              thinkingLevels: [...model.thinkingLevels],
+            })),
+          }
+        })
+
+        const turnsNotImplemented = (operation: string) =>
+          new AgentBackendConfigError({
+            message: `Codex Build Agent Turns are not available yet (${operation}).`,
+          })
+
+        return AgentBackend.of({
+          inspect,
+          startTurn: Effect.fn("Codex.startTurn")((_input: StartTurnInput) =>
+            Effect.fail(turnsNotImplemented("startTurn")),
+          ),
+          continueTurn: Effect.fn("Codex.continueTurn")(
+            (_input: ContinueTurnInput) =>
+              Effect.fail(turnsNotImplemented("continueTurn")),
+          ),
+        })
+      }),
+    )
+
+  static layerForTests = () => Codex.layer({})
+}

--- a/packages/codex/src/lib/environment.ts
+++ b/packages/codex/src/lib/environment.ts
@@ -1,0 +1,20 @@
+import { sanitizeInheritedEnvironment } from "@ready-for-agent/agent-backend"
+
+export type MakeCodexEnvironmentOptions = {
+  readonly environment?: Readonly<Record<string, string | undefined>>
+}
+
+/**
+ * Codex Build Agent Turns use ambient `gh` only: inherit process env
+ * (including ambient GitHub tokens and OPENAI_API_KEY). Codex does not support
+ * KeymaxxerMcp, so tokens are never stripped.
+ */
+export const makeCodexEnvironment = (
+  options: MakeCodexEnvironmentOptions = {},
+): Record<string, string> => {
+  const environment =
+    options.environment ?? (process.env as Record<string, string | undefined>)
+  return sanitizeInheritedEnvironment(environment, {
+    stripGitHubTokens: false,
+  })
+}

--- a/packages/codex/src/lib/parse-login-status.ts
+++ b/packages/codex/src/lib/parse-login-status.ts
@@ -1,0 +1,44 @@
+export type CodexLoginStatus =
+  | { readonly kind: "authenticated" }
+  | { readonly kind: "unauthenticated" }
+  | { readonly kind: "malformed" }
+  | { readonly kind: "failed"; readonly exitCode: number }
+
+/**
+ * Real CLI status phrases (stderr via eprintln!) and compatible test fakes.
+ * Primary form is "Logged in using …" / "Not logged in".
+ */
+// Matches real CLI: "Logged in using ChatGPT", "Logged in using an API key - …"
+const AUTHENTICATED_MARKERS = [/logged in using/i]
+
+const UNAUTHENTICATED_MARKERS = [
+  /not logged in/i,
+  /you are not authenticated/i,
+  /authentication required/i,
+  /please (?:log|sign) in/i,
+]
+
+/**
+ * Interpret `codex login status` captured text (stdout and/or stderr) plus
+ * exit code into readiness.
+ *
+ * Real CLI: authenticated exits 0 with "Logged in using …" on stderr;
+ * unauthenticated exits 1 with "Not logged in" on stderr. Classification is
+ * marker-driven so a non-zero crash or unexpected exit is not mistaken for
+ * missing auth.
+ */
+export const parseCodexLoginStatus = (
+  output: string,
+  exitCode: number,
+): CodexLoginStatus => {
+  if (UNAUTHENTICATED_MARKERS.some((marker) => marker.test(output))) {
+    return { kind: "unauthenticated" }
+  }
+  if (AUTHENTICATED_MARKERS.some((marker) => marker.test(output))) {
+    return { kind: "authenticated" }
+  }
+  if (exitCode !== 0) {
+    return { kind: "failed", exitCode }
+  }
+  return { kind: "malformed" }
+}

--- a/packages/codex/src/lib/session-telemetry-layer.ts
+++ b/packages/codex/src/lib/session-telemetry-layer.ts
@@ -1,0 +1,30 @@
+import { Effect, Layer } from "effect"
+import {
+  AGENT_BACKEND_IDS,
+  SessionTelemetryProvider,
+  unsupportedSessionTelemetry,
+} from "@ready-for-agent/agent-backend"
+
+const CODEX_BACKEND = {
+  id: AGENT_BACKEND_IDS.codex,
+  label: "Codex Build",
+} as const
+
+/**
+ * Codex Build declares Session Telemetry unsupported (ADR 0041 v1).
+ * Provides a provider that always reports `unsupported` so composition roots
+ * can wire Codex like other backends without a null telemetry branch.
+ *
+ * Accepts an unused options bag so the export is a Layer factory matching
+ * Grok/OpenCode call sites (`CodexSessionTelemetryLive()`).
+ */
+export const CodexSessionTelemetryLive = (
+  _options: Record<string, never> = {},
+): Layer.Layer<SessionTelemetryProvider> =>
+  Layer.succeed(
+    SessionTelemetryProvider,
+    SessionTelemetryProvider.of({
+      getSession: (sessionId) =>
+        Effect.succeed(unsupportedSessionTelemetry(sessionId, CODEX_BACKEND)),
+    }),
+  )

--- a/packages/codex/src/lib/types.ts
+++ b/packages/codex/src/lib/types.ts
@@ -1,0 +1,41 @@
+import type { Duration } from "effect"
+import type { AgentModel } from "@ready-for-agent/agent-backend"
+
+export interface CodexLayerOptions {
+  readonly binary?: string
+  readonly defaultTimeout?: Duration.Input
+}
+
+/**
+ * Actionable readiness-failure copy when `codex login status` reports no auth.
+ * Mirrors the Grok message shape; operators may use ChatGPT OAuth or an API key.
+ */
+export const CODEX_UNAUTHENTICATED_MESSAGE =
+  "Codex Build is not authenticated. Run `codex login` (or set `OPENAI_API_KEY`), then Recheck Agent Backend."
+
+/**
+ * Adapter-bundled static model catalog for Codex Build (ADR 0041).
+ *
+ * Only current-generation models (gpt-5.5 and up). Thinking Levels are the
+ * Codex CLI `model_reasoning_effort` values each model supports. Pinned from
+ * `codex debug models` for Codex CLI 0.145.x; update on Harness release when
+ * OpenAI ships a new generation.
+ */
+export const CODEX_STATIC_CATALOG: ReadonlyArray<AgentModel> = [
+  {
+    id: "gpt-5.6-sol",
+    thinkingLevels: ["low", "medium", "high", "xhigh", "max", "ultra"],
+  },
+  {
+    id: "gpt-5.6-terra",
+    thinkingLevels: ["low", "medium", "high", "xhigh", "max", "ultra"],
+  },
+  {
+    id: "gpt-5.6-luna",
+    thinkingLevels: ["low", "medium", "high", "xhigh", "max"],
+  },
+  {
+    id: "gpt-5.5",
+    thinkingLevels: ["low", "medium", "high", "xhigh"],
+  },
+]

--- a/packages/codex/test/catalog.spec.ts
+++ b/packages/codex/test/catalog.spec.ts
@@ -1,0 +1,33 @@
+import { CODEX_STATIC_CATALOG } from "../src/index.js"
+import { describe, expect, it } from "bun:test"
+
+/** gpt-5.5 and later: minor version after `gpt-5.` is >= 5. */
+const isGpt55OrLater = (id: string): boolean => {
+  const match = /^gpt-5\.(\d+)/.exec(id)
+  if (match === null) {
+    return false
+  }
+  return Number(match[1]) >= 5
+}
+
+describe("CODEX_STATIC_CATALOG", () => {
+  it("lists only gpt-5.5-and-up models with non-empty Thinking Levels", () => {
+    expect(CODEX_STATIC_CATALOG.length).toBeGreaterThan(0)
+
+    for (const model of CODEX_STATIC_CATALOG) {
+      expect(model.id.length).toBeGreaterThan(0)
+      expect(isGpt55OrLater(model.id)).toBe(true)
+      expect(model.thinkingLevels.length).toBeGreaterThan(0)
+      for (const level of model.thinkingLevels) {
+        expect(level.length).toBeGreaterThan(0)
+      }
+    }
+
+    const ids = CODEX_STATIC_CATALOG.map((model) => model.id)
+    expect(ids).toContain("gpt-5.5")
+    expect(ids.some((id) => id.startsWith("gpt-5.6"))).toBe(true)
+    // Legacy generation must not appear.
+    expect(ids.some((id) => id.startsWith("gpt-5.4"))).toBe(false)
+    expect(ids.some((id) => id.startsWith("gpt-5.3"))).toBe(false)
+  })
+})

--- a/packages/codex/test/codex.spec.ts
+++ b/packages/codex/test/codex.spec.ts
@@ -1,0 +1,182 @@
+import { chmod, mkdtemp, rm, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { BunServices } from "@effect/platform-bun"
+import { Effect, Layer } from "effect"
+import {
+  AgentBackend,
+  AgentBackendConfigError,
+  AgentBackendMalformedOutputError,
+} from "@ready-for-agent/agent-backend"
+import {
+  CODEX_STATIC_CATALOG,
+  CODEX_UNAUTHENTICATED_MESSAGE,
+  Codex,
+} from "../src/index.js"
+import { describe, expect, it } from "bun:test"
+
+const withExecutable = async <A>(
+  body: string,
+  use: (path: string) => Promise<A>,
+): Promise<A> => {
+  const directory = await mkdtemp(join(tmpdir(), "codex-effect-test-"))
+  const path = join(directory, "codex")
+  try {
+    await writeFile(path, `#!/bin/sh\n${body}\n`)
+    await chmod(path, 0o700)
+    return await use(path)
+  } finally {
+    await rm(directory, { recursive: true, force: true })
+  }
+}
+
+const provide = (binary: string) =>
+  Codex.layer({ binary }).pipe(Layer.provide(BunServices.layer))
+
+const inspect = (binary: string, timeout = "2 seconds") =>
+  Effect.gen(function* () {
+    const backend = yield* AgentBackend
+    return yield* backend.inspect({
+      cwd: process.cwd(),
+      timeout,
+    })
+  }).pipe(Effect.provide(provide(binary)))
+
+describe("Codex AgentBackend adapter (readiness inspection)", () => {
+  it("inspects authenticated CLI via stderr status (real CLI shape)", async () => {
+    await withExecutable(
+      [
+        'case " $* " in *" login status "*) ;; *) exit 20 ;; esac',
+        // Real codex prints status with eprintln! (stderr only, empty stdout).
+        "echo 'Logged in using ChatGPT' 1>&2",
+      ].join("\n"),
+      async (binary) => {
+        const result = await Effect.runPromise(inspect(binary))
+        expect(result.backend).toEqual({ id: "codex", label: "Codex Build" })
+        expect(result.models).toEqual(
+          CODEX_STATIC_CATALOG.map((model) => ({
+            id: model.id,
+            thinkingLevels: [...model.thinkingLevels],
+          })),
+        )
+      },
+    )
+  })
+
+  it("inspects when API key login is stored (stderr status)", async () => {
+    await withExecutable(
+      [
+        'case " $* " in *" login status "*) ;; *) exit 20 ;; esac',
+        "echo 'Logged in using an API key - sk-test' 1>&2",
+      ].join("\n"),
+      async (binary) => {
+        const result = await Effect.runPromise(inspect(binary))
+        expect(result.backend.id).toBe("codex")
+        expect(result.models.length).toBeGreaterThan(0)
+      },
+    )
+  })
+
+  it("fails inspect with actionable config error when unauthenticated (stderr)", async () => {
+    await withExecutable(
+      [
+        'case " $* " in *" login status "*) ;; *) exit 20 ;; esac',
+        "echo 'Not logged in' 1>&2",
+        "exit 1",
+      ].join("\n"),
+      async (binary) => {
+        const error = await Effect.runPromise(inspect(binary).pipe(Effect.flip))
+        expect(error).toBeInstanceOf(AgentBackendConfigError)
+        if (error instanceof AgentBackendConfigError) {
+          expect(error.message).toBe(CODEX_UNAUTHENTICATED_MESSAGE)
+          expect(error.message).toContain("codex login")
+          expect(error.message).toContain("OPENAI_API_KEY")
+        }
+      },
+    )
+  })
+
+  it("maps non-zero login status without auth markers to config error with probe text", async () => {
+    await withExecutable(
+      [
+        'case " $* " in *" login status "*) ;; *) exit 20 ;; esac',
+        "echo 'internal crash' 1>&2",
+        "exit 7",
+      ].join("\n"),
+      async (binary) => {
+        const error = await Effect.runPromise(inspect(binary).pipe(Effect.flip))
+        expect(error).toBeInstanceOf(AgentBackendConfigError)
+        if (error instanceof AgentBackendConfigError) {
+          expect(error.message).toContain("exit 7")
+          expect(error.message).toContain("internal crash")
+          expect(error.message).not.toBe(CODEX_UNAUTHENTICATED_MESSAGE)
+        }
+      },
+    )
+  })
+
+  it("fails inspect when login status output is malformed", async () => {
+    await withExecutable(
+      [
+        'case " $* " in *" login status "*) ;; *) exit 20 ;; esac',
+        "echo 'something unexpected without auth markers' 1>&2",
+        "exit 0",
+      ].join("\n"),
+      async (binary) => {
+        const error = await Effect.runPromise(inspect(binary).pipe(Effect.flip))
+        expect(error).toBeInstanceOf(AgentBackendMalformedOutputError)
+      },
+    )
+  })
+
+  it("fails inspect when the binary is missing", async () => {
+    const missing = join(tmpdir(), `codex-missing-${Date.now()}`)
+    const error = await Effect.runPromise(inspect(missing).pipe(Effect.flip))
+    // Spawn failure surfaces as PlatformError (NotFound) through the shared runner.
+    expect(error).toBeDefined()
+    expect(error).not.toBeInstanceOf(AgentBackendConfigError)
+    expect((error as { _tag?: string })._tag).toBe("PlatformError")
+    const reason = (error as { reason?: { _tag?: string } }).reason
+    expect(reason?._tag).toBe("NotFound")
+  })
+
+  it("startTurn and continueTurn fail until Agent Turns ship", async () => {
+    await withExecutable("exit 0", async (binary) => {
+      const outcome = await Effect.runPromise(
+        Effect.gen(function* () {
+          const backend = yield* AgentBackend
+          const start = yield* backend
+            .startTurn({
+              cwd: process.cwd(),
+              prompt: "x",
+              model: "gpt-5.5",
+              thinkingLevel: null,
+              timeout: "1 second",
+            })
+            .pipe(Effect.flip)
+          const cont = yield* backend
+            .continueTurn({
+              cwd: process.cwd(),
+              sessionId: "thread-1",
+              prompt: "y",
+              model: "gpt-5.5",
+              thinkingLevel: null,
+              timeout: "1 second",
+            })
+            .pipe(Effect.flip)
+          return { start, cont }
+        }).pipe(Effect.provide(provide(binary))),
+      )
+
+      expect(outcome.start).toBeInstanceOf(AgentBackendConfigError)
+      expect(outcome.cont).toBeInstanceOf(AgentBackendConfigError)
+      if (outcome.start instanceof AgentBackendConfigError) {
+        expect(outcome.start.message).toContain("not available yet")
+        expect(outcome.start.message).toContain("startTurn")
+      }
+      if (outcome.cont instanceof AgentBackendConfigError) {
+        expect(outcome.cont.message).toContain("continueTurn")
+      }
+    })
+  })
+})

--- a/packages/codex/test/environment.spec.ts
+++ b/packages/codex/test/environment.spec.ts
@@ -1,0 +1,22 @@
+import { makeCodexEnvironment } from "../src/index.js"
+import { describe, expect, it } from "bun:test"
+
+describe("makeCodexEnvironment", () => {
+  it("preserves ambient GitHub tokens and OpenAI credentials", () => {
+    const env = makeCodexEnvironment({
+      environment: {
+        PATH: "/usr/bin",
+        HOME: "/home/op",
+        GH_TOKEN: "secret",
+        GITHUB_TOKEN: "secret2",
+        OPENAI_API_KEY: "sk-test",
+        KEEP: "yes",
+      },
+    })
+    expect(env.PATH).toBe("/usr/bin")
+    expect(env.KEEP).toBe("yes")
+    expect(env.GH_TOKEN).toBe("secret")
+    expect(env.GITHUB_TOKEN).toBe("secret2")
+    expect(env.OPENAI_API_KEY).toBe("sk-test")
+  })
+})

--- a/packages/codex/test/parse-login-status.spec.ts
+++ b/packages/codex/test/parse-login-status.spec.ts
@@ -1,0 +1,41 @@
+import { parseCodexLoginStatus } from "../src/index.js"
+import { describe, expect, it } from "bun:test"
+
+describe("parseCodexLoginStatus", () => {
+  it("recognizes ChatGPT OAuth success (real CLI wording)", () => {
+    expect(parseCodexLoginStatus("Logged in using ChatGPT\n", 0)).toEqual({
+      kind: "authenticated",
+    })
+  })
+
+  it("recognizes API key login success (real CLI wording)", () => {
+    expect(
+      parseCodexLoginStatus("Logged in using an API key - sk-…\n", 0),
+    ).toEqual({
+      kind: "authenticated",
+    })
+  })
+
+  it("recognizes Not logged in", () => {
+    expect(parseCodexLoginStatus("Not logged in\n", 1)).toEqual({
+      kind: "unauthenticated",
+    })
+  })
+
+  it("treats non-zero exit without markers as failed, not unauthenticated", () => {
+    expect(parseCodexLoginStatus("", 1)).toEqual({
+      kind: "failed",
+      exitCode: 1,
+    })
+    expect(parseCodexLoginStatus("segfault dump\n", 139)).toEqual({
+      kind: "failed",
+      exitCode: 139,
+    })
+  })
+
+  it("treats exit-zero garbage as malformed", () => {
+    expect(parseCodexLoginStatus("unexpected banner only\n", 0)).toEqual({
+      kind: "malformed",
+    })
+  })
+})

--- a/packages/codex/tsconfig.json
+++ b/packages/codex/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ]
+}

--- a/packages/codex/tsconfig.lib.json
+++ b/packages/codex/tsconfig.lib.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "tsBuildInfoFile": "dist/tsconfig.lib.tsbuildinfo",
+    "emitDeclarationOnly": false,
+    "forceConsistentCasingInFileNames": true,
+    "types": ["node", "bun"]
+  },
+  "include": ["src/**/*.ts"],
+  "references": [
+    {
+      "path": "../agent-backend/tsconfig.lib.json"
+    }
+  ]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -46,6 +46,9 @@
       "path": "./packages/grok"
     },
     {
+      "path": "./packages/codex"
+    },
+    {
       "path": "./packages/github-service"
     },
     {


### PR DESCRIPTION
Why

Operators whose coding agent is OpenAI Codex could not select it as a Harness
Agent Backend. This ships the #556 slice: registration, static model catalog,
and readiness inspection so Codex Build is selectable everywhere backends are
chosen, without Agent Turns yet (#557).

What changed

- Register built-in backend id `codex` / label "Codex Build" with Session
  Telemetry and Keymaxxer unsupported
- New packages/codex adapter: static gpt-5.5+ catalog with Thinking Levels;
  inspect via `codex login status`
- Capture stderr for status probes (real CLI prints markers with eprintln!);
  marker-driven auth vs failed/malformed classification
- Wire Codex into harness resolveRuntime, host-tools preflight, and
  workspace/tsconfig
- Shared runCliCapture gains allowNonZeroExit and captureStderr; turns keep
  stderr ignored
- Agent Turns intentionally stubbed with a clear config error until #557

Verification

- nx test agent-backend, nx test codex, host-tools preflight tests
- Live inspect against authenticated codex login status returns Ready + catalog
- Pre-commit (lint/typecheck/test affected) passed after format fix

Limitations

- Agent Turns (codex exec, sessions, /review) are out of scope; selecting Codex
  for Work Items will fail turn steps until #557

Closes #556