### PR TITLE
feat(codex): implement Agent Turns with sessions, stream parse, and /review

### DIFF
--- a/packages/codex/src/index.ts
+++ b/packages/codex/src/index.ts
@@ -1,5 +1,7 @@
+export * from "./lib/build-args.js"
 export * from "./lib/codex.js"
 export * from "./lib/environment.js"
 export * from "./lib/parse-login-status.js"
+export * from "./lib/parse-stream.js"
 export * from "./lib/session-telemetry-layer.js"
 export * from "./lib/types.js"

--- a/packages/codex/src/lib/build-args.ts
+++ b/packages/codex/src/lib/build-args.ts
@@ -1,0 +1,56 @@
+const commandPrefix = (command: string): string =>
+  command.startsWith("/") ? command : `/${command}`
+
+/**
+ * Build headless Codex argv for a new or resumed Agent Turn.
+ *
+ * Every harness launch uses machine-readable JSONL (`--json`), runs
+ * unsandboxed (`--sandbox danger-full-access`, ADR 0041), and forces
+ * unattended approval (`approval_policy=never`) so operator config cannot
+ * hang a turn on mid-tool confirmation. Model and optional reasoning effort
+ * are restated on every turn so mid-Session switches work.
+ *
+ * Resume shape: `codex exec … resume <thread_id> -- <prompt>` with the same
+ * exec-level flags so later turns stay unsandboxed, unattended, and JSONL.
+ * Prompts are always after `--` so tokens like `resume` are never parsed as
+ * subcommands.
+ */
+export const buildRunArgs = (input: {
+  readonly prompt: string
+  readonly model: string
+  /** Null omits `model_reasoning_effort` so Codex uses the model default. */
+  readonly thinkingLevel: string | null
+  /** Opaque Codex `thread_id` to resume exactly (not "most recent"). */
+  readonly resumeSessionId?: string
+  readonly command?: string
+}): ReadonlyArray<string> => {
+  const prompt =
+    input.command === undefined
+      ? input.prompt
+      : `${commandPrefix(input.command)}\n${input.prompt}`.trimEnd()
+
+  const args: string[] = [
+    "exec",
+    "--json",
+    "--sandbox",
+    "danger-full-access",
+    "--model",
+    input.model,
+    // Pin approval independently of sandbox (unlike Grok's combined --yolo).
+    // `codex exec` has no `-a`; override via config flag.
+    "-c",
+    "approval_policy=never",
+  ]
+
+  if (input.thinkingLevel !== null) {
+    args.push("-c", `model_reasoning_effort=${input.thinkingLevel}`)
+  }
+
+  if (input.resumeSessionId !== undefined) {
+    args.push("resume", input.resumeSessionId, "--", prompt)
+  } else {
+    args.push("--", prompt)
+  }
+
+  return args
+}

--- a/packages/codex/src/lib/codex.ts
+++ b/packages/codex/src/lib/codex.ts
@@ -4,14 +4,24 @@ import {
   AGENT_BACKEND_IDS,
   AgentBackend,
   AgentBackendConfigError,
+  type AgentBackendError,
+  AgentBackendExitError,
   type ContinueTurnInput,
   type InspectInput,
   type StartTurnInput,
   malformedOutput,
   runCliCapture,
+  runCliTurn,
 } from "@ready-for-agent/agent-backend"
+import { buildRunArgs } from "./build-args.js"
 import { makeCodexEnvironment } from "./environment.js"
 import { parseCodexLoginStatus } from "./parse-login-status.js"
+import {
+  codexAssistantText,
+  createCodexStreamParseState,
+  foldCodexStreamLine,
+  isSuccessfulCodexTurn,
+} from "./parse-stream.js"
 import {
   CODEX_STATIC_CATALOG,
   CODEX_UNAUTHENTICATED_MESSAGE,
@@ -41,10 +51,11 @@ const clipProbeOutput = (text: string, maxChars = 240): string => {
 /**
  * Codex Build adapter implementing the backend-neutral AgentBackend contract.
  *
- * This package ships registration, static catalog, and readiness inspection
- * (issue #556). Agent Turns (start/continue) land in #557; until then they
- * fail with a clear config error so Preview/Recheck remain demoable without
- * turns.
+ * Registration, static catalog, and readiness inspection ship with this layer.
+ * Agent Turns run `codex exec --json` unsandboxed, capture `thread_id` from
+ * `thread.started` via `onSessionId` while the first turn is still running,
+ * resume later turns with `codex exec resume`, and normalize the JSONL stream
+ * into Session ID + ordered final assistant text (issue #557 / ADR 0041).
  */
 export class Codex {
   static layer = (options: CodexLayerOptions = {}) =>
@@ -103,19 +114,148 @@ export class Codex {
           }
         })
 
-        const turnsNotImplemented = (operation: string) =>
-          new AgentBackendConfigError({
-            message: `Codex Build Agent Turns are not available yet (${operation}).`,
+        const runTurn = (input: {
+          readonly prompt: string
+          readonly cwd: string
+          readonly model: string
+          readonly thinkingLevel: string | null
+          readonly sessionId?: string
+          readonly resume: boolean
+          readonly command?: string
+          readonly timeout?: Duration.Input
+          readonly onSessionId?: StartTurnInput["onSessionId"]
+        }): Effect.Effect<
+          { readonly sessionId: string; readonly assistantText: string },
+          AgentBackendError
+        > =>
+          Effect.gen(function* () {
+            const args = buildRunArgs({
+              prompt: input.prompt,
+              model: input.model,
+              thinkingLevel: input.thinkingLevel,
+              ...(input.resume && input.sessionId !== undefined
+                ? { resumeSessionId: input.sessionId }
+                : {}),
+              ...(input.command !== undefined
+                ? { command: input.command }
+                : {}),
+            })
+
+            let stream = createCodexStreamParseState()
+            // On resume, the Session ID is already durable; seed parse state so
+            // a missing thread.started still succeeds with the known ID.
+            if (input.sessionId !== undefined) {
+              stream = { ...stream, threadId: input.sessionId }
+            }
+
+            const turn = yield* runCliTurn({
+              spawner,
+              binary,
+              args,
+              cwd: input.cwd,
+              env: environment,
+              timeout: input.timeout ?? defaultTimeout,
+              ...(input.sessionId !== undefined
+                ? { knownSessionId: input.sessionId }
+                : {}),
+              ...(input.onSessionId !== undefined
+                ? { onSessionId: input.onSessionId }
+                : {}),
+              observerLabel: "Codex Build",
+              parseLine: (line) => {
+                stream = foldCodexStreamLine(stream, line)
+
+                if (stream.malformedLine) {
+                  return {}
+                }
+                if (stream.turnFailed) {
+                  return {
+                    ...(stream.threadId !== undefined
+                      ? { sessionId: stream.threadId }
+                      : {}),
+                  }
+                }
+                if (stream.turnCompleted && isSuccessfulCodexTurn(stream)) {
+                  const finalizedSessionId = stream.threadId
+                  if (finalizedSessionId === undefined) {
+                    return {}
+                  }
+                  return {
+                    sessionId: finalizedSessionId,
+                    finalizeText: codexAssistantText(stream),
+                  }
+                }
+                if (stream.threadId !== undefined) {
+                  return { sessionId: stream.threadId }
+                }
+                return {}
+              },
+              stdin: "ignore",
+            })
+
+            if (stream.malformedLine) {
+              return yield* malformedOutput(
+                input.cwd,
+                "(malformed stream line)",
+              )
+            }
+            if (stream.turnFailed) {
+              // ExitError has no message field (shared contract); keep the
+              // stream-extracted reason in logs so harness diagnostics are not
+              // a bare exit 1.
+              yield* Effect.logWarning("Codex Build turn.failed", {
+                sessionId: stream.threadId ?? input.sessionId,
+                message: stream.turnFailedMessage ?? "Codex turn.failed",
+              })
+              return yield* new AgentBackendExitError({
+                exitCode: 1,
+                cwd: input.cwd,
+                ...(stream.threadId !== undefined
+                  ? { sessionId: stream.threadId }
+                  : input.sessionId !== undefined
+                    ? { sessionId: input.sessionId }
+                    : {}),
+              })
+            }
+            if (!stream.turnCompleted || !isSuccessfulCodexTurn(stream)) {
+              return yield* malformedOutput(
+                input.cwd,
+                "(missing or unsuccessful terminal turn.completed event)",
+              )
+            }
+
+            const sessionId = stream.threadId ?? turn.sessionId
+            if (
+              input.sessionId !== undefined &&
+              sessionId !== input.sessionId
+            ) {
+              return yield* malformedOutput(
+                input.cwd,
+                `(session id mismatch: expected ${input.sessionId}, got ${sessionId})`,
+              )
+            }
+
+            return {
+              sessionId,
+              assistantText: turn.assistantText,
+            }
           })
 
         return AgentBackend.of({
           inspect,
-          startTurn: Effect.fn("Codex.startTurn")((_input: StartTurnInput) =>
-            Effect.fail(turnsNotImplemented("startTurn")),
+          startTurn: Effect.fn("Codex.startTurn")((input: StartTurnInput) =>
+            runTurn({
+              ...input,
+              resume: false,
+            }),
           ),
           continueTurn: Effect.fn("Codex.continueTurn")(
-            (_input: ContinueTurnInput) =>
-              Effect.fail(turnsNotImplemented("continueTurn")),
+            (input: ContinueTurnInput) =>
+              runTurn({
+                ...input,
+                sessionId: input.sessionId,
+                resume: true,
+              }),
           ),
         })
       }),

--- a/packages/codex/src/lib/parse-stream.ts
+++ b/packages/codex/src/lib/parse-stream.ts
@@ -1,0 +1,127 @@
+/**
+ * Fold Codex `exec --json` JSONL events into Session ID + ordered assistant text.
+ *
+ * Session ID comes from the early `thread.started` event (`thread_id`). Final
+ * assistant text is the ordered text of `item.completed` items whose type is
+ * `agent_message`. Terminal success is `turn.completed`; failure is
+ * `turn.failed` (mapped to an exit-style failure by the adapter).
+ */
+
+export type CodexStreamParseState = {
+  threadId: string | undefined
+  agentMessages: string[]
+  turnCompleted: boolean
+  turnFailed: boolean
+  turnFailedMessage: string | undefined
+  malformedLine: boolean
+}
+
+export const createCodexStreamParseState = (): CodexStreamParseState => ({
+  threadId: undefined,
+  agentMessages: [],
+  turnCompleted: false,
+  turnFailed: false,
+  turnFailedMessage: undefined,
+  malformedLine: false,
+})
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value)
+
+const errorMessageFrom = (value: unknown): string | undefined => {
+  if (typeof value === "string" && value.length > 0) {
+    return value
+  }
+  if (isRecord(value)) {
+    if (typeof value.message === "string" && value.message.length > 0) {
+      return value.message
+    }
+    if (typeof value.error === "string" && value.error.length > 0) {
+      return value.error
+    }
+  }
+  return undefined
+}
+
+/**
+ * Fold one JSONL line. Unknown event types are ignored (non-exhaustive stream).
+ * Malformed JSON or missing `type` marks the stream malformed.
+ * Once malformed or turn.failed, further lines leave state unchanged.
+ */
+export const foldCodexStreamLine = (
+  state: CodexStreamParseState,
+  line: string,
+): CodexStreamParseState => {
+  if (state.malformedLine || state.turnFailed) {
+    return state
+  }
+
+  const trimmed = line.trim()
+  if (trimmed.length === 0) {
+    return state
+  }
+
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(trimmed)
+  } catch {
+    return { ...state, malformedLine: true }
+  }
+
+  if (!isRecord(parsed) || typeof parsed.type !== "string") {
+    return { ...state, malformedLine: true }
+  }
+
+  switch (parsed.type) {
+    case "thread.started": {
+      const threadId =
+        typeof parsed.thread_id === "string" ? parsed.thread_id : undefined
+      if (threadId === undefined || threadId.length === 0) {
+        return { ...state, malformedLine: true }
+      }
+      return { ...state, threadId }
+    }
+    case "item.completed": {
+      if (!isRecord(parsed.item)) {
+        return state
+      }
+      const item = parsed.item
+      if (item.type !== "agent_message") {
+        return state
+      }
+      if (typeof item.text !== "string") {
+        return state
+      }
+      return {
+        ...state,
+        agentMessages: [...state.agentMessages, item.text],
+      }
+    }
+    case "turn.completed":
+      return { ...state, turnCompleted: true }
+    case "turn.failed": {
+      const message =
+        errorMessageFrom(parsed.error) ??
+        errorMessageFrom(parsed.message) ??
+        "Codex turn.failed"
+      return {
+        ...state,
+        turnFailed: true,
+        turnFailedMessage: message,
+      }
+    }
+    default:
+      // Non-exhaustive event set (turn.started, item.started, tool events, …).
+      return state
+  }
+}
+
+/** Ordered final assistant text from agent_message item completions. */
+export const codexAssistantText = (state: CodexStreamParseState): string =>
+  state.agentMessages.join("")
+
+export const isSuccessfulCodexTurn = (state: CodexStreamParseState): boolean =>
+  state.turnCompleted &&
+  !state.turnFailed &&
+  state.malformedLine === false &&
+  state.threadId !== undefined

--- a/packages/codex/test/build-args.spec.ts
+++ b/packages/codex/test/build-args.spec.ts
@@ -1,0 +1,109 @@
+import { buildRunArgs } from "../src/index.js"
+import { describe, expect, it } from "bun:test"
+
+describe("buildRunArgs", () => {
+  it("builds unsandboxed unattended JSONL exec args with model and effort", () => {
+    expect(
+      buildRunArgs({
+        prompt: "implement the issue",
+        model: "gpt-5.5",
+        thinkingLevel: "medium",
+      }),
+    ).toEqual([
+      "exec",
+      "--json",
+      "--sandbox",
+      "danger-full-access",
+      "--model",
+      "gpt-5.5",
+      "-c",
+      "approval_policy=never",
+      "-c",
+      "model_reasoning_effort=medium",
+      "--",
+      "implement the issue",
+    ])
+  })
+
+  it("omits model_reasoning_effort when thinkingLevel is null but keeps approval pin", () => {
+    const args = buildRunArgs({
+      prompt: "hi",
+      model: "gpt-5.5",
+      thinkingLevel: null,
+    })
+    expect(args).toContain("approval_policy=never")
+    expect(args.some((a) => a.includes("model_reasoning_effort"))).toBe(false)
+  })
+
+  it("resumes by exact thread id and restates model/effort", () => {
+    const args = buildRunArgs({
+      prompt: "continue",
+      model: "gpt-5.6-sol",
+      thinkingLevel: "high",
+      resumeSessionId: "019fab2c-9466-7432-ad16-9de23f94f2db",
+    })
+    expect(args).toEqual([
+      "exec",
+      "--json",
+      "--sandbox",
+      "danger-full-access",
+      "--model",
+      "gpt-5.6-sol",
+      "-c",
+      "approval_policy=never",
+      "-c",
+      "model_reasoning_effort=high",
+      "resume",
+      "019fab2c-9466-7432-ad16-9de23f94f2db",
+      "--",
+      "continue",
+    ])
+    expect(args).not.toContain("--last")
+  })
+
+  it("prefixes /review command into the prompt body", () => {
+    const args = buildRunArgs({
+      prompt: "Review uncommitted worktree changes.",
+      model: "gpt-5.5",
+      thinkingLevel: null,
+      resumeSessionId: "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee",
+      command: "/review",
+    })
+    expect(args.at(-1)).toBe("/review\nReview uncommitted worktree changes.")
+  })
+
+  it("normalizes review command without a leading slash", () => {
+    const args = buildRunArgs({
+      prompt: "body",
+      model: "gpt-5.5",
+      thinkingLevel: null,
+      command: "review",
+    })
+    expect(args.at(-1)).toBe("/review\nbody")
+  })
+
+  it("does not treat a prompt of resume as the resume subcommand", () => {
+    const start = buildRunArgs({
+      prompt: "resume",
+      model: "gpt-5.5",
+      thinkingLevel: null,
+    })
+    expect(start).toEqual([
+      "exec",
+      "--json",
+      "--sandbox",
+      "danger-full-access",
+      "--model",
+      "gpt-5.5",
+      "-c",
+      "approval_policy=never",
+      "--",
+      "resume",
+    ])
+    // `--` precedes the prompt; no bare resume subcommand for a new turn.
+    expect(start.indexOf("--")).toBeLessThan(start.lastIndexOf("resume"))
+    expect(start.includes("resume") && start.indexOf("resume") === 1).toBe(
+      false,
+    )
+  })
+})

--- a/packages/codex/test/codex.spec.ts
+++ b/packages/codex/test/codex.spec.ts
@@ -2,11 +2,15 @@ import { chmod, mkdtemp, rm, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { BunServices } from "@effect/platform-bun"
-import { Effect, Layer } from "effect"
+import { Deferred, Effect, Exit, Fiber, Layer } from "effect"
 import {
   AgentBackend,
   AgentBackendConfigError,
+  AgentBackendExitError,
   AgentBackendMalformedOutputError,
+  AgentBackendSessionIdMissingError,
+  AgentBackendTimeoutError,
+  type OnSessionId,
 } from "@ready-for-agent/agent-backend"
 import {
   CODEX_STATIC_CATALOG,
@@ -39,6 +43,36 @@ const inspect = (binary: string, timeout = "2 seconds") =>
     return yield* backend.inspect({
       cwd: process.cwd(),
       timeout,
+    })
+  }).pipe(Effect.provide(provide(binary)))
+
+/** Fake stream: early thread.started, agent_message, turn.completed. */
+const successfulTurnStream = (
+  threadId = "019fab2c-9466-7432-ad16-9de23f94f2db",
+) =>
+  [
+    `printf '%s\\n' '{"type":"thread.started","thread_id":"${threadId}"}'`,
+    `printf '%s\\n' '{"type":"turn.started"}'`,
+    `printf '%s\\n' '{"type":"item.completed","item":{"id":"item_0","type":"agent_message","text":"ok"}}'`,
+    `printf '%s\\n' '{"type":"turn.completed","usage":{"input_tokens":1,"output_tokens":1}}'`,
+  ].join("\n")
+
+const startTurn = (
+  binary: string,
+  timeout: string,
+  onSessionId?: OnSessionId,
+  prompt = "test",
+  thinkingLevel: string | null = "medium",
+) =>
+  Effect.gen(function* () {
+    const backend = yield* AgentBackend
+    return yield* backend.startTurn({
+      cwd: process.cwd(),
+      prompt,
+      model: "gpt-5.5",
+      thinkingLevel,
+      timeout,
+      ...(onSessionId !== undefined ? { onSessionId } : {}),
     })
   }).pipe(Effect.provide(provide(binary)))
 
@@ -139,44 +173,321 @@ describe("Codex AgentBackend adapter (readiness inspection)", () => {
     const reason = (error as { reason?: { _tag?: string } }).reason
     expect(reason?._tag).toBe("NotFound")
   })
+})
 
-  it("startTurn and continueTurn fail until Agent Turns ship", async () => {
-    await withExecutable("exit 0", async (binary) => {
-      const outcome = await Effect.runPromise(
-        Effect.gen(function* () {
-          const backend = yield* AgentBackend
-          const start = yield* backend
-            .startTurn({
+describe("Codex AgentBackend adapter (Agent Turns)", () => {
+  it("requires exec --json, danger-full-access, and never-approval on every turn", async () => {
+    await withExecutable(
+      [
+        'case " $* " in *" exec "*) ;; *) exit 20 ;; esac',
+        'case " $* " in *" --json "*) ;; *) exit 21 ;; esac',
+        'case " $* " in *" danger-full-access "*) ;; *) exit 22 ;; esac',
+        'case " $* " in *" approval_policy=never "*) ;; *) exit 23 ;; esac',
+        successfulTurnStream(),
+      ].join("\n"),
+      async (binary) => {
+        const result = await Effect.runPromise(startTurn(binary, "2 seconds"))
+        expect(result.assistantText).toBe("ok")
+        expect(result.sessionId).toBe("019fab2c-9466-7432-ad16-9de23f94f2db")
+      },
+    )
+  })
+
+  it("collects ordered agent_message text and ignores other item types", async () => {
+    await withExecutable(
+      [
+        `printf '%s\\n' '{"type":"thread.started","thread_id":"thread-abc"}'`,
+        `printf '%s\\n' '{"type":"item.completed","item":{"id":"i0","type":"reasoning","text":"think"}}'`,
+        `printf '%s\\n' '{"type":"item.completed","item":{"id":"i1","type":"agent_message","text":"first"}}'`,
+        `printf '%s\\n' '{"type":"item.completed","item":{"id":"i2","type":"agent_message","text":" second"}}'`,
+        `printf '%s\\n' '{"type":"turn.completed"}'`,
+      ].join("\n"),
+      async (binary) => {
+        const result = await Effect.runPromise(startTurn(binary, "2 seconds"))
+        expect(result.sessionId).toBe("thread-abc")
+        expect(result.assistantText).toBe("first second")
+      },
+    )
+  })
+
+  it("notifies onSessionId from thread.started while the first turn is still running", async () => {
+    await withExecutable(
+      [
+        `printf '%s\\n' '{"type":"thread.started","thread_id":"early-thread-id"}'`,
+        "sleep 0.4",
+        `printf '%s\\n' '{"type":"item.completed","item":{"id":"i0","type":"agent_message","text":"done"}}'`,
+        `printf '%s\\n' '{"type":"turn.completed"}'`,
+      ].join("\n"),
+      async (binary) => {
+        const observed = await Effect.runPromise(
+          Effect.gen(function* () {
+            const deferred = yield* Deferred.make<string>()
+            const fiber = yield* Effect.forkChild(
+              startTurn(binary, "5 seconds", (sessionId) =>
+                Deferred.succeed(deferred, sessionId).pipe(Effect.asVoid),
+              ),
+            )
+            const earlySessionId = yield* Deferred.await(deferred)
+            const stillRunning = fiber.pollUnsafe() === undefined
+            const result = yield* Fiber.await(fiber)
+            return { earlySessionId, stillRunning, result }
+          }),
+        )
+
+        expect(observed.earlySessionId).toBe("early-thread-id")
+        expect(observed.stillRunning).toBe(true)
+        expect(Exit.isSuccess(observed.result)).toBe(true)
+        if (Exit.isSuccess(observed.result)) {
+          expect(observed.result.value.sessionId).toBe(observed.earlySessionId)
+        }
+      },
+    )
+  })
+
+  it("resumes by session id and restates model and reasoning effort", async () => {
+    await withExecutable(
+      [
+        // First turn: start
+        'case " $* " in *" resume "*)',
+        '  case " $* " in *" gpt-5.6-sol "*) ;; *) exit 30 ;; esac',
+        '  case " $* " in *" model_reasoning_effort=high "*) ;; *) exit 31 ;; esac',
+        '  case " $* " in *" thread-from-start "*) ;; *) exit 32 ;; esac',
+        successfulTurnStream("thread-from-start"),
+        "  exit 0",
+        "  ;;",
+        "esac",
+        // Start turn: no resume
+        'case " $* " in *" resume "*) exit 33 ;; esac',
+        'case " $* " in *" gpt-5.5 "*) ;; *) exit 34 ;; esac',
+        'case " $* " in *" model_reasoning_effort=low "*) ;; *) exit 35 ;; esac',
+        successfulTurnStream("thread-from-start"),
+      ].join("\n"),
+      async (binary) => {
+        const outcome = await Effect.runPromise(
+          Effect.gen(function* () {
+            const backend = yield* AgentBackend
+            const started = yield* backend.startTurn({
               cwd: process.cwd(),
-              prompt: "x",
+              prompt: "first",
+              model: "gpt-5.5",
+              thinkingLevel: "low",
+              timeout: "2 seconds",
+            })
+            const continued = yield* backend.continueTurn({
+              cwd: process.cwd(),
+              sessionId: started.sessionId,
+              prompt: "second",
+              model: "gpt-5.6-sol",
+              thinkingLevel: "high",
+              timeout: "2 seconds",
+            })
+            return { started, continued }
+          }).pipe(Effect.provide(provide(binary))),
+        )
+
+        expect(outcome.started.sessionId).toBe("thread-from-start")
+        expect(outcome.continued.sessionId).toBe(outcome.started.sessionId)
+        expect(outcome.continued.assistantText).toBe("ok")
+      },
+    )
+  })
+
+  it("omits model_reasoning_effort when thinkingLevel is null", async () => {
+    await withExecutable(
+      [
+        'case " $* " in *" model_reasoning_effort="*) exit 11 ;; esac',
+        successfulTurnStream(),
+      ].join("\n"),
+      async (binary) => {
+        await expect(
+          Effect.runPromise(
+            startTurn(binary, "2 seconds", undefined, "test", null),
+          ),
+        ).resolves.toMatchObject({ assistantText: "ok" })
+      },
+    )
+  })
+
+  it("continueTurn succeeds without a second thread.started using seeded session id", async () => {
+    await withExecutable(
+      [
+        'case " $* " in *" resume "*) ;; *) exit 50 ;; esac',
+        'case " $* " in *" seeded-thread "*) ;; *) exit 51 ;; esac',
+        // No thread.started — durable ID comes from continueTurn input.
+        `printf '%s\\n' '{"type":"item.completed","item":{"id":"i0","type":"agent_message","text":"resumed-ok"}}'`,
+        `printf '%s\\n' '{"type":"turn.completed"}'`,
+      ].join("\n"),
+      async (binary) => {
+        const result = await Effect.runPromise(
+          Effect.gen(function* () {
+            const backend = yield* AgentBackend
+            return yield* backend.continueTurn({
+              cwd: process.cwd(),
+              sessionId: "seeded-thread",
+              prompt: "continue without stream session event",
               model: "gpt-5.5",
               thinkingLevel: null,
-              timeout: "1 second",
+              timeout: "2 seconds",
             })
-            .pipe(Effect.flip)
-          const cont = yield* backend
-            .continueTurn({
+          }).pipe(Effect.provide(provide(binary))),
+        )
+        expect(result.sessionId).toBe("seeded-thread")
+        expect(result.assistantText).toBe("resumed-ok")
+      },
+    )
+  })
+
+  it("prefixes /review into the prompt on continueTurn", async () => {
+    await withExecutable(
+      [
+        'case " $* " in *"/review"*) ;; *) exit 40 ;; esac',
+        successfulTurnStream("review-thread"),
+      ].join("\n"),
+      async (binary) => {
+        const result = await Effect.runPromise(
+          Effect.gen(function* () {
+            const backend = yield* AgentBackend
+            return yield* backend.continueTurn({
               cwd: process.cwd(),
-              sessionId: "thread-1",
-              prompt: "y",
+              sessionId: "review-thread",
+              command: "/review",
+              prompt: "Review uncommitted worktree changes.",
               model: "gpt-5.5",
               thinkingLevel: null,
-              timeout: "1 second",
+              timeout: "2 seconds",
             })
-            .pipe(Effect.flip)
-          return { start, cont }
-        }).pipe(Effect.provide(provide(binary))),
-      )
+          }).pipe(Effect.provide(provide(binary))),
+        )
+        expect(result.sessionId).toBe("review-thread")
+        expect(result.assistantText).toBe("ok")
+      },
+    )
+  })
 
-      expect(outcome.start).toBeInstanceOf(AgentBackendConfigError)
-      expect(outcome.cont).toBeInstanceOf(AgentBackendConfigError)
-      if (outcome.start instanceof AgentBackendConfigError) {
-        expect(outcome.start.message).toContain("not available yet")
-        expect(outcome.start.message).toContain("startTurn")
-      }
-      if (outcome.cont instanceof AgentBackendConfigError) {
-        expect(outcome.cont.message).toContain("continueTurn")
-      }
-    })
+  it("maps turn.failed to exit failure with observed session", async () => {
+    await withExecutable(
+      [
+        `printf '%s\\n' '{"type":"thread.started","thread_id":"fail-thread"}'`,
+        `printf '%s\\n' '{"type":"turn.failed","error":{"message":"boom"}}'`,
+      ].join("\n"),
+      async (binary) => {
+        const error = await Effect.runPromise(
+          startTurn(binary, "2 seconds").pipe(Effect.flip),
+        )
+        expect(error).toBeInstanceOf(AgentBackendExitError)
+        if (error instanceof AgentBackendExitError) {
+          expect(error.exitCode).toBe(1)
+          expect(error.sessionId).toBe("fail-thread")
+        }
+      },
+    )
+  })
+
+  it("maps nonzero exit with observed session", async () => {
+    await withExecutable(
+      [
+        `printf '%s\\n' '{"type":"thread.started","thread_id":"exit-thread"}'`,
+        `printf '%s\\n' '{"type":"item.completed","item":{"id":"i0","type":"agent_message","text":"x"}}'`,
+        "exit 7",
+      ].join("\n"),
+      async (binary) => {
+        const error = await Effect.runPromise(
+          startTurn(binary, "2 seconds").pipe(Effect.flip),
+        )
+        expect(error).toBeInstanceOf(AgentBackendExitError)
+        if (error instanceof AgentBackendExitError) {
+          expect(error.exitCode).toBe(7)
+          expect(error.sessionId).toBe("exit-thread")
+        }
+      },
+    )
+  })
+
+  it("maps timeout while retaining session id from thread.started", async () => {
+    await withExecutable(
+      [
+        `printf '%s\\n' '{"type":"thread.started","thread_id":"timeout-thread"}'`,
+        "sleep 10",
+      ].join("\n"),
+      async (binary) => {
+        const error = await Effect.runPromise(
+          startTurn(binary, "200 millis").pipe(Effect.flip),
+        )
+        expect(error).toBeInstanceOf(AgentBackendTimeoutError)
+        if (error instanceof AgentBackendTimeoutError) {
+          expect(error.timeoutMs).toBe(200)
+          expect(error.sessionId).toBe("timeout-thread")
+        }
+      },
+    )
+  })
+
+  it("fails when terminal turn.completed is missing", async () => {
+    await withExecutable(
+      [
+        `printf '%s\\n' '{"type":"thread.started","thread_id":"t1"}'`,
+        `printf '%s\\n' '{"type":"item.completed","item":{"id":"i0","type":"agent_message","text":"only"}}'`,
+      ].join("\n"),
+      async (binary) => {
+        const error = await Effect.runPromise(
+          startTurn(binary, "2 seconds").pipe(Effect.flip),
+        )
+        expect(error).toBeInstanceOf(AgentBackendMalformedOutputError)
+      },
+    )
+  })
+
+  it("fails on malformed stream lines", async () => {
+    await withExecutable(
+      [
+        `printf '%s\\n' '{"type":"thread.started","thread_id":"t1"}'`,
+        "echo not-json",
+        `printf '%s\\n' '{"type":"turn.completed"}'`,
+      ].join("\n"),
+      async (binary) => {
+        const error = await Effect.runPromise(
+          startTurn(binary, "2 seconds").pipe(Effect.flip),
+        )
+        expect(error).toBeInstanceOf(AgentBackendMalformedOutputError)
+      },
+    )
+  })
+
+  it("fails startTurn when thread.started never arrives", async () => {
+    await withExecutable(
+      [
+        `printf '%s\\n' '{"type":"item.completed","item":{"id":"i0","type":"agent_message","text":"x"}}'`,
+        `printf '%s\\n' '{"type":"turn.completed"}'`,
+      ].join("\n"),
+      async (binary) => {
+        const error = await Effect.runPromise(
+          startTurn(binary, "2 seconds").pipe(Effect.flip),
+        )
+        // Missing session id: either SessionIdMissing or malformed after fold.
+        expect(
+          error instanceof AgentBackendSessionIdMissingError ||
+            error instanceof AgentBackendMalformedOutputError,
+        ).toBe(true)
+      },
+    )
+  })
+
+  it("cancels the process tree on fiber interruption", async () => {
+    await withExecutable(
+      ["trap 'exit 0' TERM", "sleep 30"].join("\n"),
+      async (binary) => {
+        const exit = await Effect.runPromise(
+          Effect.gen(function* () {
+            const fiber = yield* Effect.forkChild(
+              startTurn(binary, "30 seconds"),
+            )
+            yield* Effect.sleep("100 millis")
+            yield* Fiber.interrupt(fiber)
+            return yield* Fiber.await(fiber)
+          }),
+        )
+        expect(Exit.isSuccess(exit)).toBe(false)
+      },
+    )
   })
 })

--- a/packages/codex/test/parse-stream.spec.ts
+++ b/packages/codex/test/parse-stream.spec.ts
@@ -1,0 +1,110 @@
+import {
+  codexAssistantText,
+  createCodexStreamParseState,
+  foldCodexStreamLine,
+  isSuccessfulCodexTurn,
+} from "../src/index.js"
+import { describe, expect, it } from "bun:test"
+
+describe("parse-stream", () => {
+  it("captures thread_id and concatenates agent_message text", () => {
+    let state = createCodexStreamParseState()
+    state = foldCodexStreamLine(
+      state,
+      '{"type":"thread.started","thread_id":"thread-1"}',
+    )
+    state = foldCodexStreamLine(state, '{"type":"turn.started"}')
+    state = foldCodexStreamLine(
+      state,
+      '{"type":"item.completed","item":{"id":"item_0","type":"reasoning","text":"ignore"}}',
+    )
+    state = foldCodexStreamLine(
+      state,
+      '{"type":"item.completed","item":{"id":"item_1","type":"agent_message","text":"Hel"}}',
+    )
+    state = foldCodexStreamLine(
+      state,
+      '{"type":"item.completed","item":{"id":"item_2","type":"agent_message","text":"lo"}}',
+    )
+    state = foldCodexStreamLine(
+      state,
+      '{"type":"turn.completed","usage":{"input_tokens":1,"output_tokens":1}}',
+    )
+    expect(state.threadId).toBe("thread-1")
+    expect(codexAssistantText(state)).toBe("Hello")
+    expect(isSuccessfulCodexTurn(state)).toBe(true)
+  })
+
+  it("marks non-json lines malformed", () => {
+    let state = createCodexStreamParseState()
+    state = foldCodexStreamLine(state, "not-json")
+    expect(state.malformedLine).toBe(true)
+  })
+
+  it("marks thread.started without thread_id malformed", () => {
+    let state = createCodexStreamParseState()
+    state = foldCodexStreamLine(state, '{"type":"thread.started"}')
+    expect(state.malformedLine).toBe(true)
+  })
+
+  it("tracks turn.failed", () => {
+    let state = createCodexStreamParseState()
+    state = foldCodexStreamLine(
+      state,
+      '{"type":"thread.started","thread_id":"t1"}',
+    )
+    state = foldCodexStreamLine(
+      state,
+      '{"type":"turn.failed","error":{"message":"model overloaded"}}',
+    )
+    expect(state.turnFailed).toBe(true)
+    expect(state.turnFailedMessage).toBe("model overloaded")
+    expect(isSuccessfulCodexTurn(state)).toBe(false)
+  })
+
+  it("ignores empty lines and unknown event types", () => {
+    let state = createCodexStreamParseState()
+    state = foldCodexStreamLine(state, "")
+    state = foldCodexStreamLine(state, "   ")
+    state = foldCodexStreamLine(
+      state,
+      '{"type":"thread.started","thread_id":"t1"}',
+    )
+    state = foldCodexStreamLine(
+      state,
+      '{"type":"item.started","item":{"type":"command_execution"}}',
+    )
+    state = foldCodexStreamLine(state, '{"type":"turn.completed"}')
+    expect(state.malformedLine).toBe(false)
+    expect(isSuccessfulCodexTurn(state)).toBe(true)
+  })
+
+  it("stops folding after malformed or turn.failed", () => {
+    let state = createCodexStreamParseState()
+    state = foldCodexStreamLine(state, "not-json")
+    state = foldCodexStreamLine(
+      state,
+      '{"type":"thread.started","thread_id":"late"}',
+    )
+    expect(state.malformedLine).toBe(true)
+    expect(state.threadId).toBeUndefined()
+
+    state = createCodexStreamParseState()
+    state = foldCodexStreamLine(
+      state,
+      '{"type":"thread.started","thread_id":"t1"}',
+    )
+    state = foldCodexStreamLine(
+      state,
+      '{"type":"turn.failed","error":{"message":"boom"}}',
+    )
+    state = foldCodexStreamLine(
+      state,
+      '{"type":"item.completed","item":{"id":"i0","type":"agent_message","text":"after"}}',
+    )
+    state = foldCodexStreamLine(state, '{"type":"turn.completed"}')
+    expect(state.turnFailed).toBe(true)
+    expect(state.agentMessages).toEqual([])
+    expect(state.turnCompleted).toBe(false)
+  })
+})


### PR DESCRIPTION
Why

Codex Build was registered with a static catalog and readiness inspection,
but Agent Turns still failed closed. Work Items captured as `codex` could
not run Implement, Review, or later lifecycle turns until startTurn /
continueTurn spoke the real `codex exec` contract (ADR 0041 / issue #557).

What

- Build headless argv: `codex exec --json --sandbox danger-full-access`,
  pin `approval_policy=never`, restate model / optional reasoning effort
  every turn, and place prompts after `--` so tokens like `resume` are
  never misparsed.
- Resume by exact Codex `thread_id` via `exec resume <id> -- <prompt>`.
- Fold JSONL into the Agent Turn Result: `thread.started` to Session ID
  (early onSessionId), ordered agent_message text, turn.completed /
  turn.failed.
- Prompt-prefix `/review` like the Grok adapter.
- Map failures through shared runner errors; log turn.failed detail;
  process-tree kill on timeout / interrupt via runCliTurn.

Verification

- bunx nx test codex (fake-CLI conformance + unit tests for args and
  stream parse)
- bunx nx typecheck codex
- Local review pass: clean after remediating approval policy, prompt
  delimiter, resume-without-thread.started coverage, and related hygiene

Notes

- No Session Telemetry in v1 (capability remains unsupported).
- Auth stays ambient (codex login / OPENAI_API_KEY, ambient gh); no
  Keymaxxer or harness-held OpenAI credentials.

Closes #557