### PR TITLE
feat(harness): add dedicated kanban board

### DIFF
--- a/apps/harness/src/kanban-live.tsx
+++ b/apps/harness/src/kanban-live.tsx
@@ -1,0 +1,54 @@
+import { useQueryClient } from "@tanstack/react-query"
+import { useEffect, useRef } from "react"
+import { followRepositoryIssuesLive } from "./refresh-issues-live.js"
+import { followRepositoryWorkItemsLive } from "./refresh-work-items-live.js"
+import {
+  issuesQuery,
+  repositoriesQuery,
+  workItemsQuery,
+} from "./routes/index.js"
+
+/**
+ * Mounts the Harness's existing live invalidation subscriptions for the
+ * board-only route. Repository cards normally own these subscriptions on the
+ * dashboard, so /kanban mounts them without rendering repository management.
+ */
+export function KanbanLiveUpdates({
+  repositoryIds,
+}: {
+  readonly repositoryIds: readonly string[]
+}) {
+  const queryClient = useQueryClient()
+  const repositoryIdsRef = useRef(repositoryIds)
+  repositoryIdsRef.current = repositoryIds
+
+  useEffect(() => {
+    const controller = new AbortController()
+    void followRepositoryIssuesLive({
+      getRepositoryIds: () => repositoryIdsRef.current,
+      queryClient,
+      queries: {
+        repositories: repositoriesQuery,
+        issues: issuesQuery,
+        workItems: workItemsQuery,
+      },
+      signal: controller.signal,
+    })
+    return () => controller.abort()
+  }, [queryClient])
+
+  useEffect(() => {
+    const controller = new AbortController()
+    void followRepositoryWorkItemsLive({
+      getRepositoryIds: () => repositoryIdsRef.current,
+      queryClient,
+      queries: {
+        workItems: workItemsQuery,
+      },
+      signal: controller.signal,
+    })
+    return () => controller.abort()
+  }, [queryClient])
+
+  return null
+}

--- a/apps/harness/src/routeTree.gen.ts
+++ b/apps/harness/src/routeTree.gen.ts
@@ -11,6 +11,7 @@
 import { Route as rootRouteImport } from './routes/__root'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as GraphqlRouteImport } from './routes/graphql'
+import { Route as KanbanRouteImport } from './routes/kanban'
 
 const IndexRoute = IndexRouteImport.update({
   id: '/',
@@ -22,31 +23,40 @@ const GraphqlRoute = GraphqlRouteImport.update({
   path: '/graphql',
   getParentRoute: () => rootRouteImport,
 } as any)
+const KanbanRoute = KanbanRouteImport.update({
+  id: '/kanban',
+  path: '/kanban',
+  getParentRoute: () => rootRouteImport,
+} as any)
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
   '/graphql': typeof GraphqlRoute
+  '/kanban': typeof KanbanRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
   '/graphql': typeof GraphqlRoute
+  '/kanban': typeof KanbanRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
   '/graphql': typeof GraphqlRoute
+  '/kanban': typeof KanbanRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
-  fullPaths: '/' | '/graphql'
+  fullPaths: '/' | '/graphql' | '/kanban'
   fileRoutesByTo: FileRoutesByTo
-  to: '/' | '/graphql'
-  id: '__root__' | '/' | '/graphql'
+  to: '/' | '/graphql' | '/kanban'
+  id: '__root__' | '/' | '/graphql' | '/kanban'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
   GraphqlRoute: typeof GraphqlRoute
+  KanbanRoute: typeof KanbanRoute
 }
 
 declare module '@tanstack/react-router' {
@@ -65,12 +75,20 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof GraphqlRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/kanban': {
+      id: '/kanban'
+      path: '/kanban'
+      fullPath: '/kanban'
+      preLoaderRoute: typeof KanbanRouteImport
+      parentRoute: typeof rootRouteImport
+    }
   }
 }
 
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   GraphqlRoute: GraphqlRoute,
+  KanbanRoute: KanbanRoute,
 }
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)

--- a/apps/harness/src/routes/index.tsx
+++ b/apps/harness/src/routes/index.tsx
@@ -182,7 +182,7 @@ const reconcileVariantForModel = (
 ): string =>
   variant.length > 0 && modelVariants.includes(variant) ? variant : ""
 
-const repositoriesQuery = {
+export const repositoriesQuery = {
   queryKey: ["repositories"],
   queryFn: async () => {
     const result = await graphql.query({
@@ -246,7 +246,7 @@ const directoryPickerAvailableQuery = {
   },
 }
 
-const issuesQuery = (repositoryId: string) => ({
+export const issuesQuery = (repositoryId: string) => ({
   queryKey: ["issues", repositoryId],
   queryFn: async () => {
     const result = await graphql.query({
@@ -274,7 +274,7 @@ const issuesQuery = (repositoryId: string) => ({
   },
 })
 
-type Repository = {
+export type Repository = {
   id: string
   forge: string
   forgeHost: string
@@ -359,7 +359,7 @@ type WorkItemStatus =
   | "WAITING_FOR_WORKER_SLOT"
   | "WAITING_FOR_BLOCKERS"
 
-type WorkItem = {
+export type WorkItem = {
   id: string
   repositoryId: string
   issueNumber: number
@@ -424,11 +424,11 @@ type WorkItemsQueryOptions = {
 }
 
 /** Completed history window (successful finished outcomes). */
-const JOBS_COMPLETED_LIMIT = 15
+export const JOBS_COMPLETED_LIMIT = 15
 /** Failed history window, independent of JOBS_COMPLETED_LIMIT. */
-const JOBS_FAILED_LIMIT = 15
+export const JOBS_FAILED_LIMIT = 15
 
-const workItemsQuery = (
+export const workItemsQuery = (
   repositoryId: string,
   options: WorkItemsQueryOptions = {},
 ) => {
@@ -457,16 +457,16 @@ const workItemsQuery = (
   }
 }
 
-const jobsWorkingWorkItemsQuery = (repositoryId: string) =>
+export const jobsWorkingWorkItemsQuery = (repositoryId: string) =>
   workItemsQuery(repositoryId, { listKind: "WORKING" })
 
-const jobsFailedWorkItemsQuery = (repositoryId: string) =>
+export const jobsFailedWorkItemsQuery = (repositoryId: string) =>
   workItemsQuery(repositoryId, {
     listKind: "FAILED",
     limit: JOBS_FAILED_LIMIT,
   })
 
-const jobsCompletedWorkItemsQuery = (repositoryId: string) =>
+export const jobsCompletedWorkItemsQuery = (repositoryId: string) =>
   workItemsQuery(repositoryId, {
     listKind: "COMPLETED",
     limit: JOBS_COMPLETED_LIMIT,
@@ -554,7 +554,7 @@ function HomeBody() {
   )
 }
 
-function CommittedPullRequestsDashboard() {
+export function CommittedPullRequestsDashboard() {
   const [bounds, setBounds] = useState(() =>
     localCommittedPullRequestDayBounds(),
   )
@@ -2886,7 +2886,7 @@ const jobsTabListAriaLabel = (tab: JobsTab): string => {
   return "Completed jobs"
 }
 
-function SessionUsageDialog({
+export function SessionUsageDialog({
   workItemId,
   sessionId,
   open,
@@ -3428,7 +3428,7 @@ function JobsCard() {
   )
 }
 
-function JobsCardSkeleton() {
+export function JobsCardSkeleton() {
   return (
     <article
       className="border border-rule-2 bg-panel px-4 py-3 sm:px-5"
@@ -3444,7 +3444,7 @@ function JobsCardSkeleton() {
   )
 }
 
-function WorkItemPauseButton({ workItem }: { workItem: WorkItem }) {
+export function WorkItemPauseButton({ workItem }: { workItem: WorkItem }) {
   const queryClient = useQueryClient()
   const updateWorkItem = (updated: WorkItem) => {
     patchWorkItemsCaches(queryClient, workItem.repositoryId, (current) =>
@@ -3545,7 +3545,7 @@ function WorkItemPauseButton({ workItem }: { workItem: WorkItem }) {
   )
 }
 
-function WorkItemLifecycleStatus({
+export function WorkItemLifecycleStatus({
   workItem,
   compact = false,
   pullRequestUrl = null,

--- a/apps/harness/src/routes/kanban.tsx
+++ b/apps/harness/src/routes/kanban.tsx
@@ -1,0 +1,525 @@
+import { useQueries, useSuspenseQuery } from "@tanstack/react-query"
+import { createFileRoute } from "@tanstack/react-router"
+import { type CSSProperties, Suspense, useState } from "react"
+import { jobsCardCollapseId, useCardCollapsed } from "../card-collapse.js"
+import { CardCollapseToggle } from "../card-collapse-toggle.js"
+import { Copy } from "../copy.js"
+import { KanbanLiveUpdates } from "../kanban-live.js"
+import {
+  PIPELINE_LANES,
+  type PipelineLaneId,
+  pipelineLaneFor,
+} from "../pipeline-lanes.js"
+import { sessionWorktreeParts } from "../session-worktree-line.js"
+import { workItemIssueUrl } from "../work-item-issue-url.js"
+import { workItemPullRequestUrl } from "../work-item-pull-request-url.js"
+import {
+  CommittedPullRequestsDashboard,
+  JOBS_COMPLETED_LIMIT,
+  JOBS_FAILED_LIMIT,
+  JobsCardSkeleton,
+  type Repository,
+  SessionUsageDialog,
+  type WorkItem,
+  WorkItemLifecycleStatus,
+  WorkItemPauseButton,
+  issuesQuery,
+  jobsCompletedWorkItemsQuery,
+  jobsFailedWorkItemsQuery,
+  jobsWorkingWorkItemsQuery,
+  repositoriesQuery,
+} from "./index.js"
+
+type JobsTab = "pipeline" | "working" | "failed" | "completed"
+
+const JOBS_TABS = [
+  { id: "pipeline", label: "Pipeline" },
+  { id: "working", label: "Working" },
+  { id: "failed", label: "Failed" },
+  { id: "completed", label: "Completed" },
+] as const satisfies readonly { id: JobsTab; label: string }[]
+
+const PIPELINE_LANE_LABELS = {
+  queue: "Queue",
+  build: "Build",
+  review: "Review",
+  ship: "Ship",
+  attention: "Attention",
+  complete: "Complete",
+} as const satisfies Record<PipelineLaneId, string>
+
+const jobsTabEmptyMessage = (tab: Exclude<JobsTab, "pipeline">): string => {
+  if (tab === "working") return "No working jobs."
+  if (tab === "failed") return "No failed jobs."
+  return "No completed jobs."
+}
+
+const jobsTabListAriaLabel = (tab: Exclude<JobsTab, "pipeline">): string => {
+  if (tab === "working") return "Working jobs"
+  if (tab === "failed") return "Failed jobs"
+  return "Completed jobs"
+}
+
+const sortNewestFirst = (items: readonly WorkItem[]): readonly WorkItem[] =>
+  items
+    .slice()
+    .sort((left, right) => right.createdAt.localeCompare(left.createdAt))
+
+const repositoryIssueKey = (
+  repositoryId: string,
+  issueNumber: number,
+): string => `${repositoryId}:${issueNumber}`
+
+export const Route = createFileRoute("/kanban")({
+  component: KanbanPage,
+})
+
+function KanbanPage() {
+  const { collapsed: jobsCollapsed, toggleCollapsed: toggleJobsCollapsed } =
+    useCardCollapsed(jobsCardCollapseId())
+  const jobsBodyId = "kanban-jobs-card-body"
+
+  return (
+    <main className="industrial-shell pt-8 sm:pt-10">
+      <header className="board-masthead">
+        <p className="board-kicker">Autonomous delivery control</p>
+        <h1 className="board-title">Work pipeline</h1>
+        <p className="board-deck">Live production flow from intake to merge.</p>
+      </header>
+      <section aria-label="Committed pull requests" className="mb-5">
+        <CommittedPullRequestsDashboard />
+      </section>
+      <section aria-label="Jobs" className="pipeline-section">
+        <div className="section-rail">
+          <div>
+            <p className="section-index">01 / Live floor</p>
+            <h2 className="section-title">Pipeline</h2>
+          </div>
+          <div className="flex items-center gap-3">
+            <span className="live-marker">
+              <span aria-hidden="true" />
+              Live
+            </span>
+            <CardCollapseToggle
+              collapsed={jobsCollapsed}
+              onToggle={toggleJobsCollapsed}
+              controlsId={jobsBodyId}
+              label="Jobs"
+            />
+          </div>
+        </div>
+        {!jobsCollapsed && (
+          <div id={jobsBodyId}>
+            <Suspense fallback={<JobsCardSkeleton />}>
+              <KanbanJobsBoard />
+            </Suspense>
+          </div>
+        )}
+      </section>
+    </main>
+  )
+}
+
+function PipelineTicket({
+  workItem,
+  repository,
+  issue,
+  laneId,
+  onOpenSession,
+}: {
+  readonly workItem: WorkItem
+  readonly repository: Repository | undefined
+  readonly issue: { readonly title: string; readonly url: string } | undefined
+  readonly laneId: PipelineLaneId
+  readonly onOpenSession: (workItemId: string, sessionId: string) => void
+}) {
+  const repositoryLabel = repository?.projectPath ?? workItem.repositoryId
+  const issueTitle = issue?.title ?? workItem.issueTitle ?? undefined
+  const issueUrl =
+    issue?.url !== undefined && issue.url !== ""
+      ? issue.url
+      : repository === undefined
+        ? null
+        : workItemIssueUrl(
+            repository.forgeHost,
+            repository.projectPath,
+            workItem.issueNumber,
+          )
+  const pullRequestUrl =
+    repository === undefined
+      ? null
+      : workItemPullRequestUrl(
+          repository.forgeHost,
+          repository.projectPath,
+          workItem.pullRequestNumber,
+        )
+  const { sessionId, worktreePath } = sessionWorktreeParts(
+    workItem.sessionId,
+    workItem.worktreePath,
+  )
+  const lane = PIPELINE_LANES.find((candidate) => candidate.id === laneId)
+
+  return (
+    <li
+      className="job-ticket"
+      style={{ "--ticket-color": lane?.color ?? "#151515" } as CSSProperties}
+    >
+      <p className="job-ticket-repo" title={repositoryLabel}>
+        {repositoryLabel}
+      </p>
+      {issueUrl !== null && issueUrl !== "" ? (
+        <a className="job-ticket-title" href={issueUrl}>
+          <span className="font-mono">#{workItem.issueNumber}</span>
+          {issueTitle === undefined ? null : ` ${issueTitle}`}
+        </a>
+      ) : (
+        <span className="job-ticket-title">
+          <span className="font-mono">#{workItem.issueNumber}</span>
+          {issueTitle === undefined ? null : ` ${issueTitle}`}
+        </span>
+      )}
+      <div className="flex items-center justify-between gap-2">
+        <span className="job-ticket-state">{workItem.stateLabel}</span>
+        <WorkItemPauseButton workItem={workItem} />
+      </div>
+      {(sessionId !== null || worktreePath !== null) && (
+        <div className="job-ticket-runtime">
+          {sessionId !== null && (
+            <div className="flex min-w-0 items-center gap-1">
+              <button
+                type="button"
+                className="min-w-0 truncate font-mono text-xs text-ink-faint underline-offset-2 hover:text-oxblood hover:underline"
+                title={sessionId}
+                onClick={() => onOpenSession(workItem.id, sessionId)}
+              >
+                {sessionId}
+              </button>
+              <Copy value={sessionId} showValue={false} className="shrink-0" />
+            </div>
+          )}
+          {worktreePath !== null && (
+            <Copy
+              value={worktreePath}
+              className="min-w-0 max-w-full"
+              textClassName="font-mono text-xs text-ink-faint"
+            />
+          )}
+        </div>
+      )}
+      <WorkItemLifecycleStatus
+        workItem={workItem}
+        compact
+        issueUrl={issueUrl}
+        pullRequestUrl={pullRequestUrl}
+      />
+    </li>
+  )
+}
+
+function KanbanJobsBoard() {
+  const [selectedTab, setSelectedTab] = useState<JobsTab>("pipeline")
+  const [selectedRepositoryId, setSelectedRepositoryId] = useState<
+    string | null
+  >(null)
+  const [mobileLane, setMobileLane] = useState<PipelineLaneId>("queue")
+  const [sessionDialog, setSessionDialog] = useState<{
+    readonly workItemId: string
+    readonly sessionId: string
+  } | null>(null)
+  const { data: repositories } = useSuspenseQuery(repositoriesQuery)
+  const workingQueries = useQueries({
+    queries: repositories.map((repository) =>
+      jobsWorkingWorkItemsQuery(repository.id),
+    ),
+  })
+  const failedQueries = useQueries({
+    queries: repositories.map((repository) =>
+      jobsFailedWorkItemsQuery(repository.id),
+    ),
+  })
+  const completedQueries = useQueries({
+    queries: repositories.map((repository) =>
+      jobsCompletedWorkItemsQuery(repository.id),
+    ),
+  })
+  const issueQueries = useQueries({
+    queries: repositories.map((repository) => issuesQuery(repository.id)),
+  })
+
+  const repositoryIds = repositories.map(({ id }) => id)
+  const repositoryById = new Map(
+    repositories.map((repository) => [repository.id, repository] as const),
+  )
+  const issueByRepoAndNumber = new Map<
+    string,
+    { readonly title: string; readonly url: string }
+  >()
+  for (const query of issueQueries) {
+    for (const issue of query.data ?? []) {
+      issueByRepoAndNumber.set(
+        repositoryIssueKey(issue.repositoryId, issue.issueNumber),
+        { title: issue.title, url: issue.url },
+      )
+    }
+  }
+
+  const workingItems = sortNewestFirst(
+    workingQueries.flatMap((query) => query.data ?? []),
+  )
+  const failedItems = sortNewestFirst(
+    failedQueries.flatMap((query) => query.data ?? []),
+  ).slice(0, JOBS_FAILED_LIMIT)
+  const completedItems = sortNewestFirst(
+    completedQueries.flatMap((query) => query.data ?? []),
+  ).slice(0, JOBS_COMPLETED_LIMIT)
+  const pipelineItems = sortNewestFirst(
+    Array.from(
+      new Map(
+        [...workingItems, ...failedItems, ...completedItems].map((item) => [
+          item.id,
+          item,
+        ]),
+      ).values(),
+    ),
+  )
+  const repositoryFilteredItems = (items: readonly WorkItem[]) =>
+    selectedRepositoryId === null
+      ? items
+      : items.filter((item) => item.repositoryId === selectedRepositoryId)
+  const selectedListTab = selectedTab === "pipeline" ? null : selectedTab
+  const activeItems =
+    selectedListTab === null
+      ? pipelineItems
+      : selectedListTab === "working"
+        ? workingItems
+        : selectedListTab === "failed"
+          ? failedItems
+          : completedItems
+  const activeQueries =
+    selectedListTab === null
+      ? [...workingQueries, ...failedQueries, ...completedQueries]
+      : selectedListTab === "working"
+        ? workingQueries
+        : selectedListTab === "failed"
+          ? failedQueries
+          : completedQueries
+  const loading = activeQueries.some((query) => query.isLoading)
+  const failed = activeQueries.some((query) => query.isError)
+  const visibleItems = repositoryFilteredItems(activeItems)
+  const visiblePipelineItems = repositoryFilteredItems(pipelineItems)
+  const laneItems = new Map(
+    PIPELINE_LANES.map((lane) => [
+      lane.id,
+      visiblePipelineItems.filter(
+        (workItem) => pipelineLaneFor(workItem) === lane.id,
+      ),
+    ]),
+  )
+
+  if (loading && activeItems.length === 0) {
+    return (
+      <>
+        <KanbanLiveUpdates repositoryIds={repositoryIds} />
+        <JobsCardSkeleton />
+      </>
+    )
+  }
+
+  if (failed) {
+    return (
+      <>
+        <KanbanLiveUpdates repositoryIds={repositoryIds} />
+        <article className="border-2 border-oxblood bg-oxblood-wash px-4 py-3">
+          <p className="m-0 text-sm text-oxblood-deep" role="alert">
+            Could not load jobs. Please try again.
+          </p>
+        </article>
+      </>
+    )
+  }
+
+  return (
+    <article>
+      <KanbanLiveUpdates repositoryIds={repositoryIds} />
+      <div className="pipeline-controls">
+        <div className="pipeline-tabs" role="tablist" aria-label="Jobs">
+          {JOBS_TABS.map((tab, tabIndex) => {
+            const selected = selectedTab === tab.id
+            return (
+              <button
+                key={tab.id}
+                type="button"
+                role="tab"
+                id={`jobs-tab-${tab.id}`}
+                aria-selected={selected}
+                aria-controls={`jobs-panel-${tab.id}`}
+                tabIndex={selected ? 0 : -1}
+                className="pipeline-tab"
+                onClick={() => setSelectedTab(tab.id)}
+                onKeyDown={(event) => {
+                  if (event.key === "ArrowRight" || event.key === "ArrowLeft") {
+                    event.preventDefault()
+                    const delta = event.key === "ArrowRight" ? 1 : -1
+                    const nextIndex =
+                      (tabIndex + delta + JOBS_TABS.length) % JOBS_TABS.length
+                    const nextTab = JOBS_TABS[nextIndex]
+                    if (nextTab === undefined) return
+                    setSelectedTab(nextTab.id)
+                    document.getElementById(`jobs-tab-${nextTab.id}`)?.focus()
+                  }
+                }}
+              >
+                {tab.label}
+                {tab.id === "working" && ` (${workingItems.length})`}
+                {tab.id === "failed" && ` (${failedItems.length})`}
+                {tab.id === "completed" && ` (${completedItems.length})`}
+              </button>
+            )
+          })}
+        </div>
+        <fieldset className="repository-filters">
+          <legend className="sr-only">Filter jobs by repository</legend>
+          <button
+            type="button"
+            className="repository-filter"
+            aria-pressed={selectedRepositoryId === null}
+            onClick={() => setSelectedRepositoryId(null)}
+          >
+            All sources
+          </button>
+          {repositories.map((repository) => (
+            <button
+              type="button"
+              className="repository-filter"
+              aria-pressed={selectedRepositoryId === repository.id}
+              key={repository.id}
+              onClick={() => setSelectedRepositoryId(repository.id)}
+            >
+              {repository.projectPath}
+            </button>
+          ))}
+        </fieldset>
+      </div>
+      <div
+        role="tabpanel"
+        id={`jobs-panel-${selectedTab}`}
+        aria-labelledby={`jobs-tab-${selectedTab}`}
+      >
+        {selectedListTab === null ? (
+          <>
+            <fieldset className="lane-switcher">
+              <legend className="sr-only">Pipeline lane</legend>
+              {PIPELINE_LANES.map((lane) => (
+                <button
+                  type="button"
+                  className="lane-switch"
+                  aria-pressed={mobileLane === lane.id}
+                  key={lane.id}
+                  onClick={() => setMobileLane(lane.id)}
+                >
+                  {PIPELINE_LANE_LABELS[lane.id]}{" "}
+                  {laneItems.get(lane.id)?.length ?? 0}
+                </button>
+              ))}
+            </fieldset>
+            <section className="pipeline-board" aria-label="Lifecycle pipeline">
+              {PIPELINE_LANES.map((lane, laneIndex) => {
+                const items = laneItems.get(lane.id) ?? []
+                return (
+                  <section
+                    className="pipeline-lane"
+                    data-mobile-active={mobileLane === lane.id}
+                    key={lane.id}
+                    aria-labelledby={`lane-${lane.id}`}
+                  >
+                    <header
+                      className="lane-header"
+                      style={
+                        {
+                          "--lane-color": lane.color,
+                          "--lane-text": lane.text,
+                        } as CSSProperties
+                      }
+                    >
+                      <div>
+                        <span className="lane-number">
+                          0{laneIndex + 1} / 06
+                        </span>
+                        <h3 className="lane-title" id={`lane-${lane.id}`}>
+                          {PIPELINE_LANE_LABELS[lane.id]}
+                        </h3>
+                      </div>
+                      <span className="lane-count">
+                        {items.length}
+                        <span className="sr-only"> jobs</span>
+                      </span>
+                    </header>
+                    {items.length === 0 ? (
+                      <p className="lane-empty">Lane clear</p>
+                    ) : (
+                      <ul className="lane-stack m-0 list-none">
+                        {items.map((workItem) => (
+                          <PipelineTicket
+                            key={workItem.id}
+                            workItem={workItem}
+                            repository={repositoryById.get(
+                              workItem.repositoryId,
+                            )}
+                            issue={issueByRepoAndNumber.get(
+                              repositoryIssueKey(
+                                workItem.repositoryId,
+                                workItem.issueNumber,
+                              ),
+                            )}
+                            laneId={lane.id}
+                            onOpenSession={(workItemId, sessionId) =>
+                              setSessionDialog({ workItemId, sessionId })
+                            }
+                          />
+                        ))}
+                      </ul>
+                    )}
+                  </section>
+                )
+              })}
+            </section>
+          </>
+        ) : visibleItems.length === 0 ? (
+          <p className="pipeline-list-empty">
+            {jobsTabEmptyMessage(selectedListTab)}
+          </p>
+        ) : (
+          <ul
+            className="pipeline-list m-0 grid list-none gap-2"
+            aria-label={jobsTabListAriaLabel(selectedListTab)}
+          >
+            {visibleItems.map((workItem) => {
+              const repository = repositoryById.get(workItem.repositoryId)
+              const issue = issueByRepoAndNumber.get(
+                repositoryIssueKey(workItem.repositoryId, workItem.issueNumber),
+              )
+              return (
+                <PipelineTicket
+                  key={workItem.id}
+                  workItem={workItem}
+                  repository={repository}
+                  issue={issue}
+                  laneId={pipelineLaneFor(workItem)}
+                  onOpenSession={(workItemId, sessionId) =>
+                    setSessionDialog({ workItemId, sessionId })
+                  }
+                />
+              )
+            })}
+          </ul>
+        )}
+      </div>
+      <SessionUsageDialog
+        workItemId={sessionDialog?.workItemId ?? null}
+        sessionId={sessionDialog?.sessionId ?? null}
+        open={sessionDialog !== null}
+        onClose={() => setSessionDialog(null)}
+      />
+    </article>
+  )
+}

--- a/apps/harness/src/styles.css
+++ b/apps/harness/src/styles.css
@@ -108,4 +108,394 @@
   .entry-rule {
     border-top: 1px solid var(--color-rule-soft);
   }
+
+  .industrial-shell {
+    --industrial-ink: #151515;
+    --industrial-paper: #f4f1e8;
+    --industrial-concrete: #dedbd2;
+    max-width: 100rem;
+    margin-inline: auto;
+  }
+
+  .board-masthead {
+    display: grid;
+    grid-template-columns: 1fr auto;
+    align-items: end;
+    margin-bottom: 1rem;
+    padding: clamp(2rem, 6vw, 5rem) 0 1.1rem;
+    border-bottom: 0.5rem solid var(--industrial-ink);
+  }
+
+  .board-kicker {
+    grid-column: 1 / -1;
+    margin: 0 0 0.5rem;
+    font-family: var(--font-mono);
+    font-size: 0.68rem;
+    font-weight: 800;
+    line-height: 1;
+    letter-spacing: 0.15em;
+    text-transform: uppercase;
+  }
+
+  .board-title {
+    margin: 0;
+    font-size: clamp(3rem, 8vw, 7.5rem);
+    font-weight: 950;
+    line-height: 0.8;
+    letter-spacing: -0.07em;
+    text-transform: uppercase;
+  }
+
+  .board-deck {
+    max-width: 17rem;
+    margin: 0 0 0.25rem 2rem;
+    font-family: var(--font-mono);
+    font-size: 0.78rem;
+    font-weight: 700;
+    line-height: 1.35;
+    text-transform: uppercase;
+  }
+
+  .industrial-shell > section[aria-label="Committed pull requests"] > article {
+    border: 2px solid var(--industrial-ink);
+    background: var(--industrial-paper);
+    box-shadow: 5px 5px 0 var(--industrial-ink);
+  }
+
+  .section-rail {
+    display: flex;
+    align-items: end;
+    justify-content: space-between;
+    gap: 1rem;
+    padding: 1rem 0 0.75rem;
+  }
+
+  .section-index {
+    margin: 0 0 0.2rem;
+    color: var(--color-ink-faint);
+    font-family: var(--font-mono);
+    font-size: 0.65rem;
+    font-weight: 800;
+    line-height: 1;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+  }
+
+  .section-title {
+    margin: 0;
+    font-size: clamp(1.6rem, 3vw, 2.6rem);
+    font-weight: 950;
+    line-height: 0.95;
+    letter-spacing: -0.04em;
+    text-transform: uppercase;
+  }
+
+  .live-marker {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    font-family: var(--font-mono);
+    font-size: 0.65rem;
+    font-weight: 800;
+    line-height: 1;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+  }
+
+  .live-marker span {
+    width: 0.55rem;
+    height: 0.55rem;
+    background: #009c68;
+    animation: industrial-pulse 1.8s steps(2) infinite;
+  }
+
+  .pipeline-controls {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: space-between;
+    gap: 0.75rem;
+    padding: 0.75rem;
+    border: 2px solid var(--industrial-ink);
+    border-bottom: 0;
+    background: var(--industrial-paper);
+  }
+
+  .pipeline-tabs,
+  .repository-filters,
+  .lane-switcher {
+    display: flex;
+    min-width: 0;
+    margin: 0;
+    padding: 0;
+    border: 0;
+    flex-wrap: wrap;
+    gap: 0.35rem;
+  }
+
+  .pipeline-tab,
+  .repository-filter,
+  .lane-switch {
+    border: 1px solid var(--industrial-ink);
+    background: transparent;
+    padding: 0.45rem 0.65rem;
+    color: var(--industrial-ink);
+    font-family: var(--font-mono);
+    font-size: 0.66rem;
+    font-weight: 800;
+    line-height: 1;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+  }
+
+  .pipeline-tab:hover,
+  .repository-filter:hover,
+  .lane-switch:hover {
+    background: var(--color-paper-3);
+  }
+
+  .pipeline-tab[aria-selected="true"],
+  .repository-filter[aria-pressed="true"],
+  .lane-switch[aria-pressed="true"] {
+    background: var(--industrial-ink);
+    color: var(--industrial-paper);
+  }
+
+  .pipeline-board {
+    display: grid;
+    grid-template-columns: repeat(6, minmax(0, 1fr));
+    border: 2px solid var(--industrial-ink);
+    background: var(--industrial-ink);
+    gap: 2px;
+  }
+
+  .pipeline-lane {
+    min-width: 0;
+    min-height: 23rem;
+    background: var(--industrial-concrete);
+  }
+
+  .lane-header {
+    position: sticky;
+    top: 0;
+    z-index: 5;
+    display: flex;
+    align-items: end;
+    justify-content: space-between;
+    min-height: 5.25rem;
+    padding: 0.7rem;
+    border-bottom: 2px solid var(--industrial-ink);
+    background: var(--lane-color);
+    color: var(--lane-text, white);
+  }
+
+  .lane-number {
+    display: block;
+    margin-bottom: 0.3rem;
+    font-family: var(--font-mono);
+    font-size: 0.58rem;
+    font-weight: 800;
+    line-height: 1;
+    opacity: 0.75;
+  }
+
+  .lane-title {
+    margin: 0;
+    font-size: 1.2rem;
+    font-weight: 950;
+    line-height: 0.85;
+    letter-spacing: -0.04em;
+    text-transform: uppercase;
+  }
+
+  .lane-count {
+    font-family: var(--font-mono);
+    font-size: 2rem;
+    font-weight: 950;
+    line-height: 0.8;
+  }
+
+  .lane-stack {
+    display: grid;
+    align-content: start;
+    gap: 0.55rem;
+    padding: 0.55rem;
+  }
+
+  .lane-empty {
+    margin: 0.5rem;
+    padding-top: 1rem;
+    border-top: 1px dashed #777;
+    color: #666;
+    font-family: var(--font-mono);
+    font-size: 0.67rem;
+    font-weight: 700;
+    line-height: 1.4;
+    text-transform: uppercase;
+  }
+
+  .job-ticket {
+    position: relative;
+    min-width: 0;
+    border: 2px solid var(--industrial-ink);
+    background: var(--industrial-paper);
+    padding: 0.65rem;
+    box-shadow: 2px 2px 0 var(--industrial-ink);
+  }
+
+  .job-ticket::before {
+    content: "";
+    position: absolute;
+    inset: 0 auto 0 0;
+    width: 4px;
+    background: var(--ticket-color, var(--industrial-ink));
+  }
+
+  .job-ticket-repo {
+    margin: 0 0 0.4rem 0.35rem;
+    overflow: hidden;
+    color: var(--color-ink-faint);
+    font-family: var(--font-mono);
+    font-size: 0.68rem;
+    font-weight: 800;
+    line-height: 1;
+    text-overflow: ellipsis;
+    text-transform: uppercase;
+    white-space: nowrap;
+  }
+
+  .job-ticket-title {
+    display: block;
+    margin-left: 0.35rem;
+    overflow-wrap: anywhere;
+    color: var(--industrial-ink);
+    font-size: 0.76rem;
+    font-weight: 800;
+    line-height: 1.25;
+    text-decoration: none;
+  }
+
+  .job-ticket-title:hover {
+    color: var(--color-oxblood);
+    text-decoration: underline;
+    text-decoration-thickness: 2px;
+  }
+
+  .job-ticket-state {
+    display: inline-block;
+    margin: 0.55rem 0 0 0.35rem;
+    border: 1px solid currentColor;
+    padding: 0.2rem 0.35rem;
+    font-family: var(--font-mono);
+    font-size: 0.65rem;
+    font-weight: 800;
+    line-height: 1;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+  }
+
+  .job-ticket-runtime {
+    display: grid;
+    gap: 0.25rem;
+    margin-top: 0.5rem;
+    padding-top: 0.5rem;
+    border-top: 1px solid rgb(21 21 21 / 20%);
+  }
+
+  .pipeline-list {
+    border: 2px solid var(--industrial-ink);
+    background: var(--industrial-concrete);
+    padding: 0.75rem;
+    grid-template-columns: repeat(auto-fit, minmax(min(100%, 18rem), 1fr));
+  }
+
+  .pipeline-list-empty {
+    margin: 0;
+    border: 2px solid var(--industrial-ink);
+    background: var(--industrial-concrete);
+    padding: 1.5rem;
+    color: var(--color-ink-faint);
+    font-family: var(--font-mono);
+    font-size: 0.75rem;
+    font-weight: 700;
+    text-transform: uppercase;
+  }
+
+  .lane-switcher {
+    display: none;
+  }
+}
+
+@keyframes industrial-pulse {
+  50% {
+    opacity: 0.3;
+  }
+}
+
+@media (max-width: 900px) {
+  .board-masthead {
+    display: block;
+  }
+
+  .board-deck {
+    margin: 1rem 0 0;
+  }
+
+  .pipeline-controls {
+    display: grid;
+    min-width: 0;
+  }
+
+  .repository-filters {
+    width: 100%;
+    max-width: 100%;
+    flex-wrap: nowrap;
+    overflow-x: auto;
+    overscroll-behavior-inline: contain;
+    padding-bottom: 0.45rem;
+    scroll-snap-type: inline proximity;
+    scrollbar-color: var(--industrial-ink) var(--industrial-concrete);
+    scrollbar-width: thin;
+    touch-action: pan-x;
+  }
+
+  .repository-filter {
+    flex: 0 0 auto;
+    scroll-snap-align: start;
+  }
+
+  .lane-switcher {
+    display: grid;
+    width: 100%;
+    max-width: 100%;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    padding: 0.55rem;
+    border: 2px solid var(--industrial-ink);
+    border-bottom: 0;
+    background: var(--industrial-concrete);
+  }
+
+  .lane-switch {
+    min-width: 0;
+    min-height: 2.75rem;
+    padding-inline: 0.35rem;
+    white-space: normal;
+  }
+
+  .pipeline-board {
+    display: block;
+  }
+
+  .pipeline-lane {
+    display: none;
+    min-height: 18rem;
+  }
+
+  .pipeline-lane[data-mobile-active="true"] {
+    display: block;
+  }
+
+  .lane-header {
+    position: static;
+    min-height: 4rem;
+  }
 }

--- a/apps/harness/test/kanban-route.test.ts
+++ b/apps/harness/test/kanban-route.test.ts
@@ -1,0 +1,101 @@
+import { readFileSync } from "node:fs"
+import { join } from "node:path"
+import { describe, expect, test } from "bun:test"
+
+const kanbanSource = () =>
+  readFileSync(join(import.meta.dir, "../src/routes/kanban.tsx"), "utf8")
+
+const stylesSource = () =>
+  readFileSync(join(import.meta.dir, "../src/styles.css"), "utf8")
+
+describe("/kanban route", () => {
+  test("is a dedicated TanStack file route with Pipeline selected by default", () => {
+    const source = kanbanSource()
+    expect(source).toContain('createFileRoute("/kanban")')
+    expect(source).toContain('useState<JobsTab>("pipeline")')
+    expect(source).toContain("<CommittedPullRequestsDashboard />")
+    expect(source).toContain("<KanbanJobsBoard />")
+  })
+
+  test("renders all six lifecycle lanes as an accessible pipeline", () => {
+    const source = kanbanSource()
+    for (const label of [
+      "Queue",
+      "Build",
+      "Review",
+      "Ship",
+      "Attention",
+      "Complete",
+    ]) {
+      expect(source).toContain(`"${label}"`)
+    }
+    expect(source).toContain('aria-label="Lifecycle pipeline"')
+    expect(source).toContain("pipelineLaneFor(workItem)")
+    expect(source).toContain("Lane clear")
+  })
+
+  test("retains accessible tabs, keyboard navigation, and repository filtering", () => {
+    const source = kanbanSource()
+    expect(source).toContain('{ id: "pipeline", label: "Pipeline" }')
+    expect(source).toContain('{ id: "working", label: "Working" }')
+    expect(source).toContain('{ id: "failed", label: "Failed" }')
+    expect(source).toContain('{ id: "completed", label: "Completed" }')
+    expect(source).toContain('role="tablist"')
+    expect(source).toContain('role="tab"')
+    expect(source).toContain("aria-selected={selected}")
+    expect(source).toContain('event.key === "ArrowRight"')
+    expect(source).toContain('event.key === "ArrowLeft"')
+    expect(source).toContain("All sources")
+    expect(source).toContain("aria-pressed={selectedRepositoryId === null}")
+    expect(source).toContain(
+      "aria-pressed={selectedRepositoryId === repository.id}",
+    )
+  })
+
+  test("retains board controls and excludes repository management", () => {
+    const source = kanbanSource()
+    expect(source).toContain("<CardCollapseToggle")
+    expect(source).toContain("<SessionUsageDialog")
+    expect(source).toContain("<WorkItemPauseButton")
+    expect(source).toContain("<WorkItemLifecycleStatus")
+    expect(source).toContain("<Copy")
+    expect(source).not.toContain("RepositoryCards")
+    expect(source).not.toContain("AddRepositoryGuidance")
+  })
+
+  test("opens Session usage from tickets in every lane while retaining copy", () => {
+    const source = kanbanSource()
+    const ticket = source.slice(
+      source.indexOf("function PipelineTicket("),
+      source.indexOf("function KanbanJobsBoard()"),
+    )
+    expect(ticket).toContain("onOpenSession(workItem.id, sessionId)")
+    expect(ticket).toContain("showValue={false}")
+    expect(ticket).not.toContain('laneId === "complete"')
+  })
+
+  test("reuses existing queries and live invalidation without polling", () => {
+    const source = kanbanSource()
+    expect(source).toContain("jobsWorkingWorkItemsQuery")
+    expect(source).toContain("jobsFailedWorkItemsQuery")
+    expect(source).toContain("jobsCompletedWorkItemsQuery")
+    expect(source).toContain("issuesQuery")
+    expect(source).toContain("repositoriesQuery")
+    expect(source).toContain("<KanbanLiveUpdates")
+    expect(source).not.toContain("queryFn:")
+    expect(source).not.toContain("createClient(")
+    expect(source).not.toContain("setInterval")
+    expect(source).not.toContain("refetchInterval")
+  })
+
+  test("ports the six-column industrial board and responsive lane selector", () => {
+    const source = stylesSource()
+    expect(source).toContain(".pipeline-board")
+    expect(source).toContain("grid-template-columns: repeat(6, minmax(0, 1fr))")
+    expect(source).toContain(".lane-header")
+    expect(source).toContain("position: sticky")
+    expect(source).toContain(".job-ticket")
+    expect(source).toContain("@media (max-width: 900px)")
+    expect(source).toContain("grid-template-columns: repeat(3, minmax(0, 1fr))")
+  })
+})


### PR DESCRIPTION
## Why

Provide a focused `/kanban` view for monitoring and managing work items across repositories
without the repository-management content of the main dashboard.

## What changed

- Added a dedicated Kanban route with Pipeline, Working, Failed, and Completed views.
- Organized pipeline work into six lifecycle lanes with repository filtering and responsive
  navigation.
- Reused existing queries, live-update streams, controls, and session-usage dialog.
- Added ticket metadata, issue and pull-request links, worktree details, copy actions, and
  lifecycle controls.
- Added industrial Kanban styling, generated route registration, and source-level route
  coverage.
- Ensured session usage can be opened from tickets in every lane.

## Verification

- `bunx nx run harness:typecheck`
- `bunx nx run harness:lint`
- `bunx nx run harness:test` — 245 tests passed

Closes #576