### PR TITLE
feat: add GitLab issue reconciliation

### DIFF
--- a/apps/harness/package.json
+++ b/apps/harness/package.json
@@ -16,6 +16,7 @@
     "@ready-for-agent/db": "workspace:*",
     "@ready-for-agent/db-service": "workspace:*",
     "@ready-for-agent/github-service": "workspace:*",
+    "@ready-for-agent/gitlab-service": "workspace:*",
     "@ready-for-agent/graphql-api": "workspace:*",
     "@ready-for-agent/graphql-client": "workspace:*",
     "@ready-for-agent/issue-reconciler": "workspace:*",

--- a/apps/harness/src/routes/index.tsx
+++ b/apps/harness/src/routes/index.tsx
@@ -860,14 +860,29 @@ function AddRepositoryGuidance({
   )
   const [path, setPath] = useState("")
   const [errorMessage, setErrorMessage] = useState<string | null>(null)
+  const [inspection, setInspection] = useState<{
+    forge: "github" | "gitlab"
+    forgeHost: string
+    projectPath: string
+    localPath: string
+    isBare: boolean
+  } | null>(null)
   // Bridges pick→add so controls stay disabled across the handoff.
   const [pickToAddBridging, setPickToAddBridging] = useState(false)
 
   const addLocalRepository = useMutation({
-    mutationFn: async (localPath: string) => {
+    mutationFn: async (input: NonNullable<typeof inspection>) => {
       const result = await graphql.mutation({
-        addLocalRepository: {
-          __args: { path: localPath },
+        addRepository: {
+          __args: {
+            input: {
+              forge: input.forge,
+              forgeHost: input.forgeHost.trim(),
+              projectPath: input.projectPath.trim(),
+              localPath: input.localPath,
+              isBare: input.isBare,
+            },
+          },
           id: true,
           forge: true,
           forgeHost: true,
@@ -889,11 +904,12 @@ function AddRepositoryGuidance({
           pullRequestCount: true,
         },
       })
-      return result.addLocalRepository
+      return result.addRepository
     },
     onSuccess: async () => {
       setErrorMessage(null)
       setPath("")
+      setInspection(null)
       await queryClient.invalidateQueries({
         queryKey: repositoriesQuery.queryKey,
       })
@@ -903,6 +919,40 @@ function AddRepositoryGuidance({
         error instanceof Error
           ? error.message
           : "Could not add repository. Check the path and try again.",
+      )
+    },
+    onSettled: () => {
+      setPickToAddBridging(false)
+    },
+  })
+
+  const inspectLocalRepository = useMutation({
+    mutationFn: async (localPath: string) => {
+      const result = await graphql.mutation({
+        inspectLocalRepository: {
+          __args: { path: localPath },
+          forge: true,
+          forgeHost: true,
+          projectPath: true,
+          localPath: true,
+          isBare: true,
+        },
+      })
+      return result.inspectLocalRepository
+    },
+    onSuccess: (result) => {
+      setInspection({
+        ...result,
+        forge: result.forge === "gitlab" ? "gitlab" : "github",
+      })
+      setErrorMessage(null)
+    },
+    onError: (error) => {
+      setInspection(null)
+      setErrorMessage(
+        error instanceof Error
+          ? error.message
+          : "Could not inspect repository. Check the path and try again.",
       )
     },
     onSettled: () => {
@@ -924,8 +974,9 @@ function AddRepositoryGuidance({
       }
       setPickToAddBridging(true)
       setPath(picked)
+      setInspection(null)
       setErrorMessage(null)
-      addLocalRepository.mutate(picked)
+      inspectLocalRepository.mutate(picked)
     },
     onError: () => {
       // Transport/server failures only — cancel maps to null in onSuccess.
@@ -935,7 +986,10 @@ function AddRepositoryGuidance({
   })
 
   const busy =
-    addLocalRepository.isPending || pickDirectory.isPending || pickToAddBridging
+    addLocalRepository.isPending ||
+    inspectLocalRepository.isPending ||
+    pickDirectory.isPending ||
+    pickToAddBridging
 
   const onSubmit = (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault()
@@ -945,7 +999,12 @@ function AddRepositoryGuidance({
       return
     }
     setErrorMessage(null)
-    addLocalRepository.mutate(trimmed)
+    if (inspection === null) {
+      setInspection(null)
+      inspectLocalRepository.mutate(trimmed)
+      return
+    }
+    addLocalRepository.mutate(inspection)
   }
 
   return (
@@ -972,6 +1031,7 @@ function AddRepositoryGuidance({
             value={path}
             onChange={(event) => {
               setPath(event.target.value)
+              setInspection(null)
               if (errorMessage !== null) {
                 setErrorMessage(null)
               }
@@ -998,10 +1058,70 @@ function AddRepositoryGuidance({
               disabled={busy}
               className="bg-oxblood px-3 py-2 text-sm font-semibold tracking-wide text-paper uppercase transition hover:bg-oxblood-deep focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-oxblood disabled:cursor-wait disabled:opacity-60"
             >
-              {addLocalRepository.isPending ? "Adding…" : "Add"}
+              {addLocalRepository.isPending
+                ? "Adding…"
+                : inspectLocalRepository.isPending
+                  ? "Inspecting…"
+                  : inspection === null
+                    ? "Inspect"
+                    : "Confirm and add"}
             </button>
           </div>
         </div>
+        {inspection !== null ? (
+          <fieldset className="grid gap-3 border border-rule p-4 text-left">
+            <legend className="px-1 font-mono text-xs font-semibold tracking-[0.16em] text-ink-faint uppercase">
+              Confirm forge identity
+            </legend>
+            <label className="grid gap-1 text-sm font-semibold text-ink-2">
+              Forge
+              <select
+                className="border border-rule-2 bg-paper px-3 py-2 font-normal"
+                value={inspection.forge}
+                onChange={(event) =>
+                  setInspection({
+                    ...inspection,
+                    forge: event.target.value as "github" | "gitlab",
+                  })
+                }
+              >
+                <option value="github">GitHub</option>
+                <option value="gitlab">GitLab</option>
+              </select>
+            </label>
+            <label className="grid gap-1 text-sm font-semibold text-ink-2">
+              Forge host
+              <input
+                className="border border-rule-2 bg-paper px-3 py-2 font-mono font-normal"
+                required
+                value={inspection.forgeHost}
+                onChange={(event) =>
+                  setInspection({
+                    ...inspection,
+                    forgeHost: event.target.value,
+                  })
+                }
+              />
+            </label>
+            <label className="grid gap-1 text-sm font-semibold text-ink-2">
+              Project path
+              <input
+                className="border border-rule-2 bg-paper px-3 py-2 font-mono font-normal"
+                required
+                value={inspection.projectPath}
+                onChange={(event) =>
+                  setInspection({
+                    ...inspection,
+                    projectPath: event.target.value,
+                  })
+                }
+              />
+            </label>
+            <p className="m-0 text-xs text-ink-faint">
+              The project is verified against this forge before it is saved.
+            </p>
+          </fieldset>
+        ) : null}
         {errorMessage !== null ? (
           <p className="m-0 text-left text-sm text-oxblood-deep" role="alert">
             {errorMessage}
@@ -1044,6 +1164,11 @@ function RepositoryCard({
     ...agentBackendsQuery,
     enabled: settingsOpen,
   })
+  const [forge, setForge] = useState<"github" | "gitlab">(
+    repository.forge === "gitlab" ? "gitlab" : "github",
+  )
+  const [forgeHost, setForgeHost] = useState(repository.forgeHost)
+  const [projectPath, setProjectPath] = useState(repository.projectPath)
   const [paused, setPaused] = useState(repository.paused)
   // null override = inherit harness default; select value is "" for inherit.
   const [selectedAgentBackend, setSelectedAgentBackend] = useState<
@@ -1093,6 +1218,9 @@ function RepositoryCard({
   const updateSettings = useMutation({
     mutationFn: async (input: {
       repositoryId: string
+      forge: "github" | "gitlab"
+      forgeHost: string
+      projectPath: string
       paused: boolean
       selectedAgentBackend: string | null
       defaultModel: string | null
@@ -1142,6 +1270,9 @@ function RepositoryCard({
       // Override changes can expand/shrink the Active Agent Backend set.
       void queryClient.invalidateQueries({
         queryKey: ["agentBackendStatus"],
+      })
+      void queryClient.invalidateQueries({
+        queryKey: repositoriesQuery.queryKey,
       })
       settingsDialogRef.current?.close()
       setSettingsOpen(false)
@@ -1228,6 +1359,9 @@ function RepositoryCard({
     setSettingsOpen(true)
     previewGenerationRef.current += 1
     setPaused(repository.paused)
+    setForge(repository.forge === "gitlab" ? "gitlab" : "github")
+    setForgeHost(repository.forgeHost)
+    setProjectPath(repository.projectPath)
     setSelectedAgentBackend(repository.selectedAgentBackend)
     setDefaultModel(repository.defaultModel ?? "")
     setDefaultVariant(repository.defaultThinkingLevel ?? "")
@@ -1266,6 +1400,9 @@ function RepositoryCard({
     event.preventDefault()
     updateSettings.mutate({
       repositoryId: repository.id,
+      forge,
+      forgeHost: forgeHost.trim(),
+      projectPath: projectPath.trim(),
       paused,
       selectedAgentBackend,
       defaultModel: defaultModel.trim() === "" ? null : defaultModel,
@@ -1821,6 +1958,46 @@ function RepositoryCard({
             </p>
           </div>
           <div className="grid gap-5 px-6 py-5">
+            <fieldset className="grid gap-3 border border-rule p-4">
+              <legend className="px-1 font-mono text-xs font-semibold tracking-[0.16em] text-ink-faint uppercase">
+                Forge identity
+              </legend>
+              <label className="grid gap-1.5 text-sm font-semibold text-ink-2">
+                Forge
+                <select
+                  className="w-full border border-rule-2 bg-paper px-3 py-2 text-sm font-normal outline-none focus:border-oxblood focus:ring-2 focus:ring-oxblood/15"
+                  value={forge}
+                  onChange={(event) =>
+                    setForge(event.target.value as "github" | "gitlab")
+                  }
+                >
+                  <option value="github">GitHub</option>
+                  <option value="gitlab">GitLab</option>
+                </select>
+              </label>
+              <label className="grid gap-1.5 text-sm font-semibold text-ink-2">
+                Forge host
+                <input
+                  className="w-full border border-rule-2 bg-paper px-3 py-2 font-mono text-sm font-normal outline-none focus:border-oxblood focus:ring-2 focus:ring-oxblood/15"
+                  required
+                  value={forgeHost}
+                  onChange={(event) => setForgeHost(event.target.value)}
+                />
+              </label>
+              <label className="grid gap-1.5 text-sm font-semibold text-ink-2">
+                Project path
+                <input
+                  className="w-full border border-rule-2 bg-paper px-3 py-2 font-mono text-sm font-normal outline-none focus:border-oxblood focus:ring-2 focus:ring-oxblood/15"
+                  required
+                  value={projectPath}
+                  onChange={(event) => setProjectPath(event.target.value)}
+                />
+              </label>
+              <span className="text-xs text-ink-faint">
+                GitLab identities are verified before Save. Identity changes are
+                blocked after this Repository has any Work Item.
+              </span>
+            </fieldset>
             <label className="flex items-center gap-3 text-sm font-semibold text-ink-2">
               <input
                 type="checkbox"
@@ -2276,63 +2453,80 @@ function RepositoryCard({
               </dd>
             </div>
           </dl>
-          {!repository.credential.configured && (
-            <div className="mt-5 grid gap-2 border border-oxblood/40 bg-oxblood-wash px-4 py-3 text-sm text-oxblood-deep">
-              <strong className="font-serif text-base font-semibold">
-                GitHub token required
-              </strong>
-              {githubTokenCreated ? (
+          {!repository.credential.configured &&
+            repository.forge === "github" && (
+              <div className="mt-5 grid gap-2 border border-oxblood/40 bg-oxblood-wash px-4 py-3 text-sm text-oxblood-deep">
+                <strong className="font-serif text-base font-semibold">
+                  GitHub token required
+                </strong>
+                {githubTokenCreated ? (
+                  <p className="m-0">
+                    Store the generated token as{" "}
+                    <code className="font-bold">
+                      {repository.credential.githubTokenSecretName}
+                    </code>{" "}
+                    in Keymaxxer. Already-created tokens are not upgraded
+                    automatically — edit the token on GitHub or recreate it,
+                    then store the replacement.
+                  </p>
+                ) : (
+                  <p className="m-0">
+                    Create a fine-grained token, choose{" "}
+                    <strong>Only select repositories</strong>, select{" "}
+                    <code className="font-bold">
+                      {repository.projectPath.split("/").at(-1)}
+                    </code>
+                    , and allow <strong>Actions: Read and write</strong>{" "}
+                    (required for workflow reruns and CI logs). Already-created
+                    tokens are not upgraded automatically — edit or recreate
+                    them if Actions is still read-only.
+                  </p>
+                )}
+                {githubTokenCreated ? (
+                  <button
+                    type="button"
+                    className="w-fit bg-oxblood px-3 py-2 font-semibold tracking-wide text-paper uppercase transition hover:bg-oxblood-deep focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-oxblood disabled:cursor-wait disabled:opacity-60"
+                    disabled={addGitHubToken.isPending}
+                    onClick={() => addGitHubToken.mutate()}
+                  >
+                    {addGitHubToken.isPending
+                      ? "Waiting for Keymaxxer"
+                      : "Store in Keymaxxer"}
+                  </button>
+                ) : (
+                  <a
+                    className="w-fit bg-oxblood px-3 py-2 font-semibold tracking-wide text-paper no-underline uppercase transition hover:bg-oxblood-deep focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-oxblood"
+                    href={repository.credential.githubTokenCreationUrl}
+                    onClick={() => setGithubTokenCreated(true)}
+                    rel="noreferrer"
+                    target="_blank"
+                  >
+                    Create GitHub token
+                  </a>
+                )}
+                {addGitHubToken.isError && (
+                  <p className="m-0 text-oxblood-deep" role="alert">
+                    Keymaxxer setup was cancelled or failed.
+                  </p>
+                )}
+              </div>
+            )}
+          {!repository.credential.configured &&
+            repository.forge === "gitlab" && (
+              <div className="mt-5 grid gap-2 border border-oxblood/40 bg-oxblood-wash px-4 py-3 text-sm text-oxblood-deep">
+                <strong className="font-serif text-base font-semibold">
+                  GitLab authentication required
+                </strong>
                 <p className="m-0">
-                  Store the generated token as{" "}
+                  Set <code className="font-bold">GITLAB_TOKEN</code> before
+                  starting the Harness, or authenticate this host with{" "}
                   <code className="font-bold">
-                    {repository.credential.githubTokenSecretName}
-                  </code>{" "}
-                  in Keymaxxer. Already-created tokens are not upgraded
-                  automatically — edit the token on GitHub or recreate it, then
-                  store the replacement.
-                </p>
-              ) : (
-                <p className="m-0">
-                  Create a fine-grained token, choose{" "}
-                  <strong>Only select repositories</strong>, select{" "}
-                  <code className="font-bold">
-                    {repository.projectPath.split("/").at(-1)}
+                    glab auth login --hostname {repository.forgeHost}
                   </code>
-                  , and allow <strong>Actions: Read and write</strong> (required
-                  for workflow reruns and CI logs). Already-created tokens are
-                  not upgraded automatically — edit or recreate them if Actions
-                  is still read-only.
+                  .
                 </p>
-              )}
-              {githubTokenCreated ? (
-                <button
-                  type="button"
-                  className="w-fit bg-oxblood px-3 py-2 font-semibold tracking-wide text-paper uppercase transition hover:bg-oxblood-deep focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-oxblood disabled:cursor-wait disabled:opacity-60"
-                  disabled={addGitHubToken.isPending}
-                  onClick={() => addGitHubToken.mutate()}
-                >
-                  {addGitHubToken.isPending
-                    ? "Waiting for Keymaxxer"
-                    : "Store in Keymaxxer"}
-                </button>
-              ) : (
-                <a
-                  className="w-fit bg-oxblood px-3 py-2 font-semibold tracking-wide text-paper no-underline uppercase transition hover:bg-oxblood-deep focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-oxblood"
-                  href={repository.credential.githubTokenCreationUrl}
-                  onClick={() => setGithubTokenCreated(true)}
-                  rel="noreferrer"
-                  target="_blank"
-                >
-                  Create GitHub token
-                </a>
-              )}
-              {addGitHubToken.isError && (
-                <p className="m-0 text-oxblood-deep" role="alert">
-                  Keymaxxer setup was cancelled or failed.
-                </p>
-              )}
-            </div>
-          )}
+              </div>
+            )}
           <div className="mt-5">
             <div className="mb-2 flex items-baseline justify-between gap-3">
               <h3 className="m-0 font-mono text-xs font-semibold tracking-[0.22em] text-oxblood uppercase">
@@ -2349,7 +2543,9 @@ function RepositoryCard({
                 title={
                   repository.credential.configured
                     ? "Refresh issues"
-                    : "Add a GitHub token before refreshing issues"
+                    : repository.forge === "gitlab"
+                      ? "Authenticate GitLab before refreshing issues"
+                      : "Add a GitHub token before refreshing issues"
                 }
               >
                 <svg

--- a/apps/harness/src/server/ambient-gitlab-layer.ts
+++ b/apps/harness/src/server/ambient-gitlab-layer.ts
@@ -1,0 +1,225 @@
+import { Deferred, Duration, Effect, Layer, Ref } from "effect"
+import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process"
+import {
+  type GitLabProjectUnavailableError,
+  GitLabRequestError,
+  GitLabService,
+  type GitLabServiceShape,
+  makeGitLabService,
+  makeGitLabServiceFromToken,
+} from "@ready-for-agent/gitlab-service"
+
+type GitLabServiceError = GitLabProjectUnavailableError | GitLabRequestError
+
+const authenticationError = (forgeHost: string, cause: unknown) =>
+  new GitLabRequestError({
+    message: `Failed to resolve GitLab CLI authentication for ${forgeHost}`,
+    cause,
+  })
+
+export const ambientGitLabLayer = (options: {
+  readonly workspaceRoot: string
+  readonly environment?: Partial<Record<string, string | undefined>>
+  readonly resolveToken?: (forgeHost: string) => Promise<string>
+  readonly makeService?: (token: string) => GitLabServiceShape
+  readonly makeAnonymousService?: () => GitLabServiceShape
+}): Layer.Layer<
+  GitLabService,
+  never,
+  ChildProcessSpawner.ChildProcessSpawner
+> =>
+  Layer.effect(
+    GitLabService,
+    Effect.gen(function* () {
+      const spawner = yield* ChildProcessSpawner.ChildProcessSpawner
+      const makeService = options.makeService ?? makeGitLabServiceFromToken
+      const makeAnonymousService =
+        options.makeAnonymousService ?? (() => makeGitLabService({}))
+      const ambientToken = options.environment?.GITLAB_TOKEN?.trim()
+      const tokenCache = yield* Ref.make<
+        ReadonlyMap<string, Deferred.Deferred<string, GitLabRequestError>>
+      >(new Map())
+
+      const resolveGlabToken = Effect.fn("AmbientGitLab.resolveGlabToken")(
+        function* (forgeHost: string) {
+          const output = yield* spawner
+            .string(
+              ChildProcess.make(
+                "glab",
+                ["config", "get", "token", "--host", forgeHost],
+                {
+                  cwd: options.workspaceRoot,
+                  stdin: "ignore",
+                  stderr: "inherit",
+                },
+              ),
+            )
+            .pipe(
+              Effect.timeout(Duration.seconds(60)),
+              Effect.mapError((cause) => authenticationError(forgeHost, cause)),
+            )
+          const token = output.trim()
+          if (token === "") {
+            return yield* authenticationError(
+              forgeHost,
+              "GitLab CLI did not return an authentication token",
+            )
+          }
+          return token
+        },
+      )
+
+      const resolveToken = Effect.fn("AmbientGitLab.resolveToken")(function* (
+        forgeHost: string,
+      ) {
+        if (ambientToken !== undefined && ambientToken !== "") {
+          return ambientToken
+        }
+        const injectedResolveToken = options.resolveToken
+        if (injectedResolveToken === undefined) {
+          return yield* resolveGlabToken(forgeHost)
+        }
+        return yield* Effect.tryPromise({
+          try: () => injectedResolveToken(forgeHost),
+          catch: (cause) => authenticationError(forgeHost, cause),
+        }).pipe(
+          Effect.flatMap((token) =>
+            token.trim() === ""
+              ? Effect.fail(
+                  authenticationError(
+                    forgeHost,
+                    "GitLab token resolver returned an empty token",
+                  ),
+                )
+              : Effect.succeed(token.trim()),
+          ),
+        )
+      })
+
+      const acquireToken = Effect.fn("AmbientGitLab.acquireToken")(function* (
+        forgeHost: string,
+      ) {
+        const candidate = yield* Deferred.make<string, GitLabRequestError>()
+        type SelectedToken = {
+          readonly source: Deferred.Deferred<string, GitLabRequestError>
+          readonly owner: boolean
+        }
+        const selected = yield* Ref.modify<
+          ReadonlyMap<string, Deferred.Deferred<string, GitLabRequestError>>,
+          SelectedToken
+        >(tokenCache, (current) => {
+          const cached = current.get(forgeHost)
+          if (cached !== undefined) {
+            return [{ source: cached, owner: false }, current]
+          }
+          const next = new Map(current)
+          next.set(forgeHost, candidate)
+          return [{ source: candidate, owner: true }, next]
+        })
+
+        if (selected.owner) {
+          yield* resolveToken(forgeHost).pipe(
+            Effect.result,
+            Effect.flatMap((result) =>
+              (result._tag === "Failure"
+                ? Ref.update(tokenCache, (current) => {
+                    if (current.get(forgeHost) !== candidate) return current
+                    const next = new Map(current)
+                    next.delete(forgeHost)
+                    return next
+                  })
+                : Effect.void
+              ).pipe(
+                Effect.andThen(
+                  Deferred.complete(candidate, Effect.fromResult(result)),
+                ),
+              ),
+            ),
+            Effect.forkDetach({ startImmediately: true }),
+          )
+        }
+
+        return {
+          source: selected.source,
+          token: yield* Deferred.await(selected.source),
+        }
+      })
+
+      const invalidate = (
+        forgeHost: string,
+        source: Deferred.Deferred<string, GitLabRequestError>,
+      ) =>
+        Ref.update(tokenCache, (current) => {
+          if (current.get(forgeHost) !== source) return current
+          const next = new Map(current)
+          next.delete(forgeHost)
+          return next
+        })
+
+      const run = Effect.fn("AmbientGitLab.runAuthenticated")(function* <A>(
+        forgeHost: string,
+        operation: (
+          service: GitLabServiceShape,
+        ) => Effect.Effect<A, GitLabServiceError>,
+      ) {
+        const firstToken = yield* acquireToken(forgeHost)
+        const first = yield* Effect.result(
+          operation(makeService(firstToken.token)),
+        )
+        if (
+          first._tag !== "Failure" ||
+          first.failure._tag !== "GitLabRequestError" ||
+          first.failure.statusCode !== 401
+        ) {
+          return yield* Effect.fromResult(first)
+        }
+
+        yield* invalidate(forgeHost, firstToken.source)
+        const refreshed = yield* acquireToken(forgeHost)
+        return yield* operation(makeService(refreshed.token))
+      })
+
+      const authenticated = <A>(
+        forgeHost: string,
+        operation: (
+          service: GitLabServiceShape,
+        ) => Effect.Effect<A, GitLabServiceError>,
+      ): Effect.Effect<A, GitLabServiceError> => run(forgeHost, operation)
+
+      return {
+        verifyProject: Effect.fn("AmbientGitLab.verifyProject")((repository) =>
+          authenticated(repository.forgeHost, (service) =>
+            service.verifyProject(repository),
+          ).pipe(
+            Effect.catchTag("GitLabRequestError", (error) =>
+              error.statusCode === undefined
+                ? makeAnonymousService().verifyProject(repository)
+                : Effect.fail(error),
+            ),
+          ),
+        ),
+        getAuthenticatedUserLogin: Effect.fn(
+          "AmbientGitLab.getAuthenticatedUserLogin",
+        )((repository) =>
+          authenticated(repository.forgeHost, (service) =>
+            service.getAuthenticatedUserLogin(repository),
+          ),
+        ),
+        listReadyIssues: Effect.fn("AmbientGitLab.listReadyIssues")(
+          (repository) =>
+            authenticated(repository.forgeHost, (service) =>
+              service.listReadyIssues(repository),
+            ),
+        ),
+        hasCredentials: Effect.fn("AmbientGitLab.hasCredentials")(
+          (repository) =>
+            acquireToken(repository.forgeHost).pipe(
+              Effect.as(true),
+              Effect.catchTag("GitLabRequestError", () =>
+                Effect.succeed(false),
+              ),
+            ),
+        ),
+      }
+    }),
+  )

--- a/apps/harness/src/server/application.server.ts
+++ b/apps/harness/src/server/application.server.ts
@@ -45,6 +45,7 @@ import {
 } from "@ready-for-agent/work-item-lifecycle"
 import type { ApplicationRequestContext } from "../application-request-context.js"
 import { ambientGitHubLayer } from "./ambient-github-layer.js"
+import { ambientGitLabLayer } from "./ambient-gitlab-layer.js"
 import {
   environmentConfigLayer,
   loadApplicationConfig,
@@ -158,9 +159,14 @@ export const createApplication = async (
       : keymaxxerGitHubLayer({ workspaceRoot: toolCwd }).pipe(
           Layer.provide(keymaxxerLayer),
         )
+  const gitlabLayer = ambientGitLabLayer({
+    workspaceRoot: toolCwd,
+    environment,
+  }).pipe(Layer.provide(platformLayer))
   const reconcilerLayer = IssueReconcilerLive.pipe(
     Layer.provideMerge(databaseLayer),
     Layer.provideMerge(githubLayer),
+    Layer.provideMerge(gitlabLayer),
   )
   const queueLayer = SqliteQueueServiceLive.pipe(
     Layer.provideMerge(databaseLayer),
@@ -225,6 +231,7 @@ export const createApplication = async (
     Layer.provideMerge(reconcilerLayer),
     Layer.provideMerge(lifecycleLayer),
     Layer.provideMerge(keymaxxerLayer),
+    Layer.provideMerge(gitlabLayer),
   )
   const loggingLayer = Logger.layer([Logger.consolePretty({ colors: false })])
   const localGitLayer = LocalGit.layer.pipe(Layer.provide(platformLayer))
@@ -237,6 +244,7 @@ export const createApplication = async (
           reconcilerLayer,
           queueLayer,
           keymaxxerLayer,
+          gitlabLayer,
           activeLayer,
           lifecycleLayer,
           localGitLayer,
@@ -248,6 +256,7 @@ export const createApplication = async (
           workerLayer,
           queueLayer,
           keymaxxerLayer,
+          gitlabLayer,
           activeLayer,
           lifecycleLayer,
           localGitLayer,

--- a/apps/harness/src/server/job-worker.ts
+++ b/apps/harness/src/server/job-worker.ts
@@ -14,8 +14,10 @@ import {
   DbService,
   RepositoryId,
   RepositoryNotFoundError,
+  type RepositoryRecord,
 } from "@ready-for-agent/db-service"
 import { formatUserFacingError } from "@ready-for-agent/github-service"
+import { GitLabService } from "@ready-for-agent/gitlab-service"
 import {
   ISSUE_POLL_QUEUE,
   ISSUE_REFRESH_QUEUE,
@@ -119,14 +121,22 @@ const repositoryHasGitHubCredential = Effect.fn(
   return credential !== null
 })
 
+const repositoryHasCredential = Effect.fn("JobWorker.repositoryHasCredential")(
+  function* (repository: RepositoryRecord) {
+    if (repository.forge === "gitlab") {
+      const gitlab = yield* GitLabService
+      return yield* gitlab.hasCredentials(repository)
+    }
+    return yield* repositoryHasGitHubCredential(repository.projectPath)
+  },
+)
+
 const listCredentialedRepositoryIds = Effect.gen(function* () {
   const db = yield* DbService
   const repositories = yield* db.listRepositories
   const credentialed: string[] = []
   for (const repository of repositories) {
-    const hasCredential = yield* repositoryHasGitHubCredential(
-      repository.projectPath,
-    )
+    const hasCredential = yield* repositoryHasCredential(repository)
     if (hasCredential) {
       credentialed.push(repository.id)
     }
@@ -279,9 +289,7 @@ const finalizeScheduledRefresh = <A, E>(
       return
     }
 
-    const credentialed = yield* repositoryHasGitHubCredential(
-      repository.projectPath,
-    )
+    const credentialed = yield* repositoryHasCredential(repository)
     if (!credentialed) {
       yield* Effect.logWarning(
         "Scheduled Issue poll finalized without recurrence; Repository uncredentialed",
@@ -392,9 +400,7 @@ const claimAndRunRefreshJob = (
       return "busy" as const
     }
 
-    const credentialed = yield* repositoryHasGitHubCredential(
-      repository.projectPath,
-    )
+    const credentialed = yield* repositoryHasCredential(repository)
     if (!credentialed) {
       yield* finalizeScheduledRefresh(
         job.jobId,

--- a/apps/harness/test/ambient-gitlab-layer.test.ts
+++ b/apps/harness/test/ambient-gitlab-layer.test.ts
@@ -1,0 +1,145 @@
+import * as BunChildProcessSpawner from "@effect/platform-bun/BunChildProcessSpawner"
+import * as BunFileSystem from "@effect/platform-bun/BunFileSystem"
+import * as BunPath from "@effect/platform-bun/BunPath"
+import { Effect, Layer } from "effect"
+import {
+  GitLabRequestError,
+  GitLabService,
+  type GitLabServiceShape,
+} from "@ready-for-agent/gitlab-service"
+import { ambientGitLabLayer } from "../src/server/ambient-gitlab-layer.js"
+import { expect, test } from "bun:test"
+
+const processLayer = BunChildProcessSpawner.layer.pipe(
+  Layer.provideMerge(Layer.merge(BunFileSystem.layer, BunPath.layer)),
+)
+
+const repository = {
+  forge: "gitlab",
+  forgeHost: "git.drupalcode.org",
+  projectPath: "project/oauth_client",
+}
+
+const service = (
+  overrides: Partial<GitLabServiceShape> = {},
+): GitLabServiceShape => ({
+  verifyProject: () => Effect.void,
+  getAuthenticatedUserLogin: () => Effect.succeed("operator"),
+  listReadyIssues: () => Effect.succeed([]),
+  hasCredentials: () => Effect.succeed(true),
+  ...overrides,
+})
+
+test("GITLAB_TOKEN takes precedence over glab and is cached per host", async () => {
+  let resolutions = 0
+  const tokens: string[] = []
+  const layer = ambientGitLabLayer({
+    workspaceRoot: "/workspace",
+    environment: { GITLAB_TOKEN: " environment-token " },
+    resolveToken: async () => {
+      resolutions += 1
+      return "glab-token"
+    },
+    makeService: (token) => {
+      tokens.push(token)
+      return service()
+    },
+  })
+
+  await Effect.runPromise(
+    Effect.gen(function* () {
+      const gitlab = yield* GitLabService
+      yield* gitlab.listReadyIssues(repository)
+      yield* gitlab.getAuthenticatedUserLogin({
+        ...repository,
+        projectPath: "project/other",
+      })
+    }).pipe(Effect.provide(layer), Effect.provide(processLayer)),
+  )
+
+  expect(resolutions).toBe(0)
+  expect(tokens).toEqual(["environment-token", "environment-token"])
+})
+
+test("glab tokens are resolved independently per GitLab host", async () => {
+  const hosts: string[] = []
+  const layer = ambientGitLabLayer({
+    workspaceRoot: "/workspace",
+    resolveToken: async (host) => {
+      hosts.push(host)
+      return `token-for-${host}`
+    },
+    makeService: () => service(),
+  })
+
+  await Effect.runPromise(
+    Effect.gen(function* () {
+      const gitlab = yield* GitLabService
+      yield* gitlab.listReadyIssues(repository)
+      yield* gitlab.listReadyIssues({
+        ...repository,
+        forgeHost: "gitlab.example.com",
+      })
+    }).pipe(Effect.provide(layer), Effect.provide(processLayer)),
+  )
+
+  expect(hosts).toEqual(["git.drupalcode.org", "gitlab.example.com"])
+})
+
+test("authentication refreshes once after a GitLab 401", async () => {
+  const resolvedTokens = ["expired", "fresh"]
+  let resolutions = 0
+  const layer = ambientGitLabLayer({
+    workspaceRoot: "/workspace",
+    resolveToken: async () => resolvedTokens[resolutions++]!,
+    makeService: (token) =>
+      service({
+        listReadyIssues: () =>
+          token === "expired"
+            ? Effect.fail(
+                new GitLabRequestError({
+                  message: "Unauthorized",
+                  statusCode: 401,
+                }),
+              )
+            : Effect.succeed([]),
+      }),
+  })
+
+  await Effect.runPromise(
+    Effect.gen(function* () {
+      const gitlab = yield* GitLabService
+      yield* gitlab.listReadyIssues(repository)
+    }).pipe(Effect.provide(layer), Effect.provide(processLayer)),
+  )
+
+  expect(resolutions).toBe(2)
+})
+
+test("public project verification falls back to anonymous access", async () => {
+  let anonymousVerifications = 0
+  const layer = ambientGitLabLayer({
+    workspaceRoot: "/workspace",
+    resolveToken: async () => {
+      throw new Error("glab is not authenticated")
+    },
+    makeAnonymousService: () =>
+      service({
+        verifyProject: () => {
+          anonymousVerifications += 1
+          return Effect.void
+        },
+        hasCredentials: () => Effect.succeed(false),
+      }),
+  })
+
+  await Effect.runPromise(
+    Effect.gen(function* () {
+      const gitlab = yield* GitLabService
+      expect(yield* gitlab.hasCredentials(repository)).toBe(false)
+      yield* gitlab.verifyProject(repository)
+    }).pipe(Effect.provide(layer), Effect.provide(processLayer)),
+  )
+
+  expect(anonymousVerifications).toBe(1)
+})

--- a/apps/harness/test/job-worker.test.ts
+++ b/apps/harness/test/job-worker.test.ts
@@ -24,6 +24,10 @@ import {
   GitHubService,
   type GitHubServiceShape,
 } from "@ready-for-agent/github-service"
+import {
+  GitLabService,
+  type GitLabServiceShape,
+} from "@ready-for-agent/gitlab-service"
 import { createGraphqlApi } from "@ready-for-agent/graphql-api"
 import {
   IssueReconciler,
@@ -133,38 +137,48 @@ const keymaxxerLayer = (
     runWithSecrets: () => Effect.die("not used"),
   })
 
-const defaultGithubLayer = Layer.succeed(GitHubService, {
-  getOpenPullRequestNumber: () => Effect.succeed(1),
-  findOpenPullRequestNumber: () => Effect.succeed(1),
-  createDraftPullRequest: () => Effect.succeed(1),
-  updateOpenDraftPullRequestCopy: () => Effect.succeed(1),
-  countOpenNonDraftPullRequests: () => Effect.succeed(0),
-  getPullRequestCheckStatus: () =>
-    Effect.succeed({
-      _tag: "succeeded",
-      terminalChecks: [],
-      mergeability: "mergeable",
-      baseRefName: "main",
-      headPushedAt: null,
-      headSha: null,
-      createdAt: null,
-      isDraft: null,
-    }),
-  getPrStatusCheckDiagnostics: () => Effect.succeed([]),
-  observeAutomatedReviewEvidence: () =>
-    Effect.succeed({
-      _tag: "ambiguous" as const,
-      reason: "Automated review evidence observation is not configured",
-    }),
-  getPullRequestLifecycleStatus: () =>
-    Effect.succeed({ _tag: "open" as const }),
-  markPullRequestReadyForReview: () => Effect.void,
-  mergePullRequest: () => Effect.succeed({ _tag: "merged" }),
-  rerunWorkflowRun: () => Effect.void,
-  ensureIssueCompletedWithSummary: () => Effect.void,
+const defaultGitlabLayer = Layer.succeed(GitLabService, {
+  verifyProject: () => Effect.void,
   getAuthenticatedUserLogin: () => Effect.succeed("test-operator"),
   listReadyIssues: () => Effect.succeed([]),
-} satisfies GitHubServiceShape)
+  hasCredentials: () => Effect.succeed(true),
+} satisfies GitLabServiceShape)
+
+const defaultGithubLayer = Layer.merge(
+  Layer.succeed(GitHubService, {
+    getOpenPullRequestNumber: () => Effect.succeed(1),
+    findOpenPullRequestNumber: () => Effect.succeed(1),
+    createDraftPullRequest: () => Effect.succeed(1),
+    updateOpenDraftPullRequestCopy: () => Effect.succeed(1),
+    countOpenNonDraftPullRequests: () => Effect.succeed(0),
+    getPullRequestCheckStatus: () =>
+      Effect.succeed({
+        _tag: "succeeded",
+        terminalChecks: [],
+        mergeability: "mergeable",
+        baseRefName: "main",
+        headPushedAt: null,
+        headSha: null,
+        createdAt: null,
+        isDraft: null,
+      }),
+    getPrStatusCheckDiagnostics: () => Effect.succeed([]),
+    observeAutomatedReviewEvidence: () =>
+      Effect.succeed({
+        _tag: "ambiguous" as const,
+        reason: "Automated review evidence observation is not configured",
+      }),
+    getPullRequestLifecycleStatus: () =>
+      Effect.succeed({ _tag: "open" as const }),
+    markPullRequestReadyForReview: () => Effect.void,
+    mergePullRequest: () => Effect.succeed({ _tag: "merged" }),
+    rerunWorkflowRun: () => Effect.void,
+    ensureIssueCompletedWithSummary: () => Effect.void,
+    getAuthenticatedUserLogin: () => Effect.succeed("test-operator"),
+    listReadyIssues: () => Effect.succeed([]),
+  } satisfies GitHubServiceShape),
+  defaultGitlabLayer,
+)
 
 const queueLayer = (
   jobs: RawJob[],
@@ -455,6 +469,7 @@ describe("Job worker", () => {
     const reconciler = IssueReconcilerLive.pipe(
       Layer.provideMerge(database),
       Layer.provideMerge(github),
+      Layer.provideMerge(defaultGitlabLayer),
     )
     const layer = Layer.mergeAll(
       database,
@@ -1422,6 +1437,59 @@ describe("Job worker", () => {
             }),
         }),
         keymaxxerLayer(),
+      ),
+    )
+  })
+
+  test("polls a credentialed GitLab Repository while Paused", async () => {
+    const pausedGitlab = makeRepositoryRecord({
+      id: repository.id,
+      forge: "gitlab",
+      forgeHost: "git.drupalcode.org",
+      projectPath: "project/oauth_client",
+      paused: true,
+    })
+    const job = rawJob(refreshPayload, ISSUE_POLL_QUEUE, pausedGitlab.id)
+    const postponed = await Effect.runPromise(Deferred.make<string>())
+
+    await runScoped(
+      Effect.gen(function* () {
+        yield* runJobWorker({
+          idlePollInterval: Duration.zero,
+          samplePollingDelay: Effect.succeed(Duration.seconds(125)),
+        }).pipe(Effect.forkScoped({ startImmediately: true }))
+        expect(yield* Deferred.await(postponed)).toBe(job.jobId)
+      }),
+      Layer.mergeAll(
+        defaultGithubLayer,
+        queueLayer(
+          [job],
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          (jobId) => Deferred.succeed(postponed, jobId),
+        ),
+        dbLayer([pausedGitlab]),
+        Layer.succeed(IssueReconciler, {
+          reconcile: (repo) =>
+            Effect.sync(() => {
+              expect(repo.forge).toBe("gitlab")
+              expect(repo.paused).toBe(true)
+              return {
+                fetched: 0,
+                inserted: 0,
+                updated: 0,
+                deleted: 0,
+                unchanged: 0,
+              }
+            }),
+        }),
+        // GitHub has no credential, proving GitLab ambient auth owns this
+        // Repository's polling eligibility.
+        keymaxxerLayer(new Set()),
       ),
     )
   })

--- a/apps/harness/tsconfig.app.json
+++ b/apps/harness/tsconfig.app.json
@@ -17,9 +17,6 @@
   "include": ["server.ts", "src/**/*.ts", "src/**/*.tsx"],
   "references": [
     {
-      "path": "../../packages/agent-backend/tsconfig.lib.json"
-    },
-    {
       "path": "../../packages/work-item-lifecycle/tsconfig.lib.json"
     },
     {
@@ -38,6 +35,9 @@
       "path": "../../packages/codex/tsconfig.lib.json"
     },
     {
+      "path": "../../packages/local-git/tsconfig.lib.json"
+    },
+    {
       "path": "../../packages/issue-reconciler/tsconfig.lib.json"
     },
     {
@@ -45,6 +45,9 @@
     },
     {
       "path": "../../packages/graphql-api/tsconfig.lib.json"
+    },
+    {
+      "path": "../../packages/gitlab-service/tsconfig.lib.json"
     },
     {
       "path": "../../packages/github-service/tsconfig.lib.json"
@@ -56,10 +59,10 @@
       "path": "../../packages/db/tsconfig.lib.json"
     },
     {
-      "path": "../../packages/keymaxxer-service/tsconfig.lib.json"
+      "path": "../../packages/agent-backend/tsconfig.lib.json"
     },
     {
-      "path": "../../packages/local-git/tsconfig.lib.json"
+      "path": "../../packages/keymaxxer-service/tsconfig.lib.json"
     }
   ]
 }

--- a/apps/ready-for-agent/src/cli.test.ts
+++ b/apps/ready-for-agent/src/cli.test.ts
@@ -95,6 +95,60 @@ describe("operator binary CLI seam", () => {
     }
   })
 
+  test("add lets the operator correct a guessed GitLab identity", async () => {
+    let added:
+      | {
+          readonly forgeHost: string
+          readonly projectPath: string
+        }
+      | undefined
+    const gitlabLocalGit = Layer.succeed(LocalGit, {
+      inspect: (path) =>
+        Effect.succeed({
+          forge: "gitlab" as const,
+          forgeHost: "git.drupal.org",
+          projectPath: "project/oauth_client",
+          localPath: path,
+          isBare: false,
+          paused: true as const,
+        }),
+    })
+    const layer = mockStart.pipe(
+      Layer.provideMerge(gitlabLocalGit),
+      Layer.provideMerge(
+        Layer.succeed(GraphqlApi, {
+          addRepository: (repository) =>
+            Effect.sync(() => {
+              added = repository
+              return {
+                id: "repo-1",
+                ...repository,
+              }
+            }),
+        }),
+      ),
+    )
+
+    await Effect.runPromise(
+      runOperator(
+        [
+          "add",
+          "--forge-host",
+          "git.drupalcode.org",
+          "--project-path",
+          "project/oauth_client",
+          "/tmp/repo",
+        ],
+        layer,
+      ),
+    )
+
+    expect(added).toMatchObject({
+      forgeHost: "git.drupalcode.org",
+      projectPath: "project/oauth_client",
+    })
+  })
+
   test("binary help lists start, add, and --no-open", () => {
     const result = spawnSync(
       "bun",

--- a/apps/ready-for-agent/src/cli.ts
+++ b/apps/ready-for-agent/src/cli.ts
@@ -1,4 +1,4 @@
-import { Console, Effect } from "effect"
+import { Console, Effect, Option } from "effect"
 import { Argument, Command, Flag } from "effect/unstable/cli"
 import { GraphqlApi } from "./services/graphql-api.ts"
 import { LocalGit } from "./services/local-git.ts"
@@ -14,6 +14,20 @@ const noOpenFlag = Flag.boolean("no-open").pipe(
   ),
 )
 
+const forgeHostFlag = Flag.string("forge-host").pipe(
+  Flag.withDescription(
+    "Correct the forge host inferred from the repository remote",
+  ),
+  Flag.optional,
+)
+
+const projectPathFlag = Flag.string("project-path").pipe(
+  Flag.withDescription(
+    "Correct the forge project path inferred from the repository remote",
+  ),
+  Flag.optional,
+)
+
 const startHarnessWorkflow = Effect.fn("Cli.startHarness")(function* (
   noOpen: boolean,
 ) {
@@ -23,10 +37,23 @@ const startHarnessWorkflow = Effect.fn("Cli.startHarness")(function* (
 
 const addRepositoryWorkflow = Effect.fn("Cli.addRepository")(function* (
   path: string,
+  corrections: {
+    readonly forgeHost?: string
+    readonly projectPath?: string
+  },
 ) {
   const localGit = yield* LocalGit
   const graphqlApi = yield* GraphqlApi
-  const repository = yield* localGit.inspect(path)
+  const inspected = yield* localGit.inspect(path)
+  const repository = {
+    ...inspected,
+    ...(corrections.forgeHost === undefined
+      ? {}
+      : { forgeHost: corrections.forgeHost }),
+    ...(corrections.projectPath === undefined
+      ? {}
+      : { projectPath: corrections.projectPath }),
+  }
   const added = yield* graphqlApi.addRepository(repository)
 
   yield* Console.log(`Added repository ${added.projectPath}`)
@@ -46,9 +73,23 @@ const startCommand = Command.make(
   ),
 )
 
-const addCommand = Command.make("add", { path: pathArg }, ({ path }) =>
-  addRepositoryWorkflow(path),
-).pipe(Command.withDescription("Add a local repository to the harness"))
+const addCommand = Command.make(
+  "add",
+  {
+    path: pathArg,
+    forgeHost: forgeHostFlag,
+    projectPath: projectPathFlag,
+  },
+  ({ path, forgeHost, projectPath }) =>
+    addRepositoryWorkflow(path, {
+      forgeHost: Option.getOrUndefined(forgeHost),
+      projectPath: Option.getOrUndefined(projectPath),
+    }),
+).pipe(
+  Command.withDescription(
+    "Inspect and add a local repository; inferred GitLab identity can be corrected with flags",
+  ),
+)
 
 export const cli = Command.make(
   "ready-for-agent",

--- a/bun.lock
+++ b/bun.lock
@@ -35,6 +35,7 @@
         "@ready-for-agent/db": "workspace:*",
         "@ready-for-agent/db-service": "workspace:*",
         "@ready-for-agent/github-service": "workspace:*",
+        "@ready-for-agent/gitlab-service": "workspace:*",
         "@ready-for-agent/graphql-api": "workspace:*",
         "@ready-for-agent/graphql-client": "workspace:*",
         "@ready-for-agent/grok": "workspace:*",
@@ -184,6 +185,18 @@
         "vitest": "^4.1.10",
       },
     },
+    "packages/gitlab-service": {
+      "name": "@ready-for-agent/gitlab-service",
+      "version": "0.0.1",
+      "dependencies": {
+        "@ready-for-agent/github-service": "workspace:*",
+        "effect": "^4.0.0-beta.97",
+        "tslib": "^2.3.0",
+      },
+      "devDependencies": {
+        "@types/bun": "^1.3.0",
+      },
+    },
     "packages/graphql-api": {
       "name": "@ready-for-agent/graphql-api",
       "version": "0.0.1",
@@ -191,6 +204,7 @@
         "@ready-for-agent/agent-backend": "workspace:*",
         "@ready-for-agent/db-service": "workspace:*",
         "@ready-for-agent/github-service": "workspace:*",
+        "@ready-for-agent/gitlab-service": "workspace:*",
         "@ready-for-agent/graphql-schema": "workspace:*",
         "@ready-for-agent/keymaxxer-service": "workspace:*",
         "@ready-for-agent/local-git": "workspace:*",
@@ -232,6 +246,7 @@
       "dependencies": {
         "@ready-for-agent/db-service": "workspace:*",
         "@ready-for-agent/github-service": "workspace:*",
+        "@ready-for-agent/gitlab-service": "workspace:*",
         "effect": "^4.0.0-beta.97",
         "tslib": "^2.3.0",
       },
@@ -941,6 +956,8 @@
     "@ready-for-agent/db-service": ["@ready-for-agent/db-service@workspace:packages/db-service"],
 
     "@ready-for-agent/github-service": ["@ready-for-agent/github-service@workspace:packages/github-service"],
+
+    "@ready-for-agent/gitlab-service": ["@ready-for-agent/gitlab-service@workspace:packages/gitlab-service"],
 
     "@ready-for-agent/graphql-api": ["@ready-for-agent/graphql-api@workspace:packages/graphql-api"],
 

--- a/packages/db-service/src/lib/db-service.ts
+++ b/packages/db-service/src/lib/db-service.ts
@@ -13,6 +13,7 @@ import {
   LocalPathInUseError,
   RepositoryAlreadyExistsError,
   RepositoryHasRunningStepError,
+  RepositoryIdentityChangeBlockedError,
   RepositoryNotFoundError,
 } from "./errors.js"
 import {
@@ -142,6 +143,22 @@ const normalizeOptionalSetting = (
     return Effect.succeed(null)
   }
   return Effect.succeed(trimmed)
+}
+
+const normalizeRequiredRepositorySetting = (
+  value: string,
+  field: "forgeHost" | "projectPath",
+): Effect.Effect<string, InvalidRepositorySettingsError> => {
+  const trimmed = value.trim()
+  if (trimmed.length === 0) {
+    return Effect.fail(
+      new InvalidRepositorySettingsError({
+        field,
+        message: `${field} cannot be empty`,
+      }),
+    )
+  }
+  return Effect.succeed(field === "forgeHost" ? trimmed.toLowerCase() : trimmed)
 }
 
 const normalizeOptionalConfigSetting = (
@@ -354,6 +371,8 @@ export interface DbServiceShape {
     RepositoryRecord,
     | InvalidRepositorySettingsError
     | AgentBackendChangeBlockedError
+    | RepositoryIdentityChangeBlockedError
+    | RepositoryAlreadyExistsError
     | RepositoryNotFoundError
     | DatabaseError
   >
@@ -1011,6 +1030,20 @@ export const DbServiceLive = Layer.effect(
     const updateRepositorySettings = Effect.fn(
       "DbService.updateRepositorySettings",
     )(function* (input: UpdateRepositorySettingsInput) {
+      const requestedForgeHost =
+        input.forgeHost === undefined
+          ? undefined
+          : yield* normalizeRequiredRepositorySetting(
+              input.forgeHost,
+              "forgeHost",
+            )
+      const requestedProjectPath =
+        input.projectPath === undefined
+          ? undefined
+          : yield* normalizeRequiredRepositorySetting(
+              input.projectPath,
+              "projectPath",
+            )
       const defaultModel = yield* normalizeOptionalSetting(input.defaultModel)
       const defaultThinkingLevel = yield* normalizeOptionalSetting(
         input.defaultThinkingLevel,
@@ -1046,7 +1079,10 @@ export const DbServiceLive = Layer.effect(
               )?.selectedAgentBackend ?? "opencode"
             const existingRows = yield* sql
               .unsafe(
-                `SELECT selected_agent_backend AS selectedAgentBackend,
+                `SELECT forge,
+                        forge_host AS forgeHost,
+                        project_path AS projectPath,
+                        selected_agent_backend AS selectedAgentBackend,
                         backend_model_prefs AS backendModelPrefs
                  FROM repository WHERE id = ?`,
                 [input.repositoryId],
@@ -1056,12 +1092,67 @@ export const DbServiceLive = Layer.effect(
               | {
                   readonly selectedAgentBackend: string | null
                   readonly backendModelPrefs: string
+                  readonly forge: RepositoryRecord["forge"]
+                  readonly forgeHost: string
+                  readonly projectPath: string
                 }
               | undefined
             if (!existing) {
               return yield* new RepositoryNotFoundError({
                 repositoryId: input.repositoryId,
               })
+            }
+            const nextForge = input.forge ?? existing.forge
+            const nextForgeHost = requestedForgeHost ?? existing.forgeHost
+            const nextProjectPath = requestedProjectPath ?? existing.projectPath
+            const identityChanging =
+              nextForge !== existing.forge ||
+              nextForgeHost !== existing.forgeHost ||
+              nextProjectPath.toLowerCase() !==
+                existing.projectPath.toLowerCase()
+            if (identityChanging) {
+              const workItemRows = (yield* sql
+                .unsafe(
+                  `SELECT COUNT(*) AS count FROM work_item
+                   WHERE repository_id = ?`,
+                  [input.repositoryId],
+                )
+                .pipe(Effect.mapError(toDatabaseError))) as readonly {
+                readonly count: number
+              }[]
+              const workItemCount = readCount(workItemRows)
+              if (workItemCount > 0) {
+                return yield* new RepositoryIdentityChangeBlockedError({
+                  repositoryId: input.repositoryId,
+                  workItemCount,
+                  message: `Cannot change Repository Forge identity while ${workItemCount} Work Item(s) exist on this Repository`,
+                })
+              }
+              const duplicateRows = (yield* sql
+                .unsafe(
+                  `SELECT id FROM repository
+                   WHERE forge = ?
+                     AND forge_host = ?
+                     AND lower(project_path) = lower(?)
+                     AND id <> ?
+                   LIMIT 1`,
+                  [
+                    nextForge,
+                    nextForgeHost,
+                    nextProjectPath,
+                    input.repositoryId,
+                  ],
+                )
+                .pipe(Effect.mapError(toDatabaseError))) as readonly {
+                readonly id: string
+              }[]
+              if (duplicateRows.length > 0) {
+                return yield* new RepositoryAlreadyExistsError({
+                  forge: nextForge,
+                  forgeHost: nextForgeHost,
+                  projectPath: nextProjectPath,
+                })
+              }
             }
             const previousOverride = existing.selectedAgentBackend ?? null
             const nextOverride =
@@ -1103,7 +1194,10 @@ export const DbServiceLive = Layer.effect(
             return yield* sql
               .unsafe(
                 `UPDATE repository
-             SET paused = ?,
+             SET forge = ?,
+                 forge_host = ?,
+                 project_path = ?,
+                 paused = ?,
                  selected_agent_backend = ?,
                  default_model = ?,
                  default_thinking_level = ?,
@@ -1117,6 +1211,9 @@ export const DbServiceLive = Layer.effect(
              WHERE id = ?
              RETURNING ${repositorySelectColumns}`,
                 [
+                  nextForge,
+                  nextForgeHost,
+                  nextProjectPath,
                   input.paused,
                   nextOverride,
                   defaultModel,
@@ -1146,14 +1243,25 @@ export const DbServiceLive = Layer.effect(
                 tag === "RepositoryNotFoundError" ||
                 tag === "DatabaseError" ||
                 tag === "AgentBackendChangeBlockedError" ||
+                tag === "RepositoryIdentityChangeBlockedError" ||
+                tag === "RepositoryAlreadyExistsError" ||
                 tag === "InvalidRepositorySettingsError"
               ) {
                 return error as
                   | RepositoryNotFoundError
                   | DatabaseError
                   | AgentBackendChangeBlockedError
+                  | RepositoryIdentityChangeBlockedError
+                  | RepositoryAlreadyExistsError
                   | InvalidRepositorySettingsError
               }
+            }
+            if (isUniqueConstraint(error as SqlError)) {
+              return new RepositoryAlreadyExistsError({
+                forge: input.forge ?? "github",
+                forgeHost: requestedForgeHost ?? "",
+                projectPath: requestedProjectPath ?? "",
+              })
             }
             return toDatabaseError(error as SqlError)
           }),

--- a/packages/db-service/src/lib/errors.ts
+++ b/packages/db-service/src/lib/errors.ts
@@ -90,10 +90,22 @@ export class AgentBackendChangeBlockedError extends Schema.TaggedErrorClass<Agen
   },
 ) {}
 
+export class RepositoryIdentityChangeBlockedError extends Schema.TaggedErrorClass<RepositoryIdentityChangeBlockedError>()(
+  "RepositoryIdentityChangeBlockedError",
+  {
+    repositoryId: Schema.String,
+    workItemCount: Schema.Int,
+    message: Schema.String,
+  },
+) {}
+
 export class InvalidRepositorySettingsError extends Schema.TaggedErrorClass<InvalidRepositorySettingsError>()(
   "InvalidRepositorySettingsError",
   {
     field: Schema.Literals([
+      "forge",
+      "forgeHost",
+      "projectPath",
       "selectedAgentBackend",
       "defaultModel",
       "defaultThinkingLevel",

--- a/packages/db-service/src/lib/types.ts
+++ b/packages/db-service/src/lib/types.ts
@@ -57,6 +57,10 @@ export type RepositoryRecord = typeof RepositoryRecord.Type
 
 export const UpdateRepositorySettingsInput = Schema.Struct({
   repositoryId: Schema.String,
+  /** Omitted identity fields leave the persisted Forge identity unchanged. */
+  forge: Schema.optionalKey(Forge),
+  forgeHost: Schema.optionalKey(Schema.String),
+  projectPath: Schema.optionalKey(Schema.String),
   paused: Schema.Boolean,
   /**
    * Null clears the override (inherit harness default). Omitted leaves the

--- a/packages/db-service/test/db-service.spec.ts
+++ b/packages/db-service/test/db-service.spec.ts
@@ -11,6 +11,7 @@ import {
   LocalPathInUseError,
   RepositoryAlreadyExistsError,
   RepositoryHasRunningStepError,
+  RepositoryIdentityChangeBlockedError,
   RepositoryNotFoundError,
 } from "../src/index.js"
 import { describe, expect, it } from "bun:test"
@@ -654,6 +655,125 @@ describe("DbService", () => {
   })
 
   describe("updateRepositorySettings", () => {
+    it("corrects Forge identity when no Work Item exists", () =>
+      runTest(
+        Effect.gen(function* () {
+          const db = yield* DbService
+          const repo = yield* db.addRepository({
+            ...sampleInput,
+            forge: "gitlab",
+            forgeHost: "git.drupal.org",
+            projectPath: "project/oauth_client",
+          })
+
+          const updated = yield* db.updateRepositorySettings({
+            repositoryId: repo.id,
+            forge: "gitlab",
+            forgeHost: "  git.drupalcode.org  ",
+            projectPath: "  project/oauth_client  ",
+            paused: true,
+            defaultModel: null,
+            defaultThinkingLevel: null,
+            reviewModel: null,
+            reviewThinkingLevel: null,
+            autoMerge: false,
+            includeAllIssueAuthors: false,
+            waitForReadyForReviewChecks: true,
+          })
+
+          expect(updated).toMatchObject({
+            forge: "gitlab",
+            forgeHost: "git.drupalcode.org",
+            projectPath: "project/oauth_client",
+          })
+        }),
+      ))
+
+    it("rejects Forge identity correction when any Work Item exists", () =>
+      runTest(
+        Effect.gen(function* () {
+          const db = yield* DbService
+          const sql = yield* SqlClient.SqlClient
+          const repo = yield* db.addRepository(sampleInput)
+          const now = Date.now()
+          yield* sql.unsafe(
+            `INSERT INTO work_item (
+               id, repository_id, issue_number, state, state_ready_at,
+               worktree_path, session_id, failure_code, failure_message,
+               created_at, updated_at
+             ) VALUES (?, ?, 1, 'complete', ?, NULL, NULL, NULL, NULL, ?, ?)`,
+            ["wi-terminal-still-freezes-identity", repo.id, now, now, now],
+          )
+
+          const error = yield* Effect.flip(
+            db.updateRepositorySettings({
+              repositoryId: repo.id,
+              forge: "gitlab",
+              forgeHost: "gitlab.example",
+              projectPath: "group/widgets",
+              paused: true,
+              defaultModel: null,
+              defaultThinkingLevel: null,
+              reviewModel: null,
+              reviewThinkingLevel: null,
+              autoMerge: false,
+              includeAllIssueAuthors: false,
+              waitForReadyForReviewChecks: true,
+            }),
+          )
+
+          expect(error).toBeInstanceOf(RepositoryIdentityChangeBlockedError)
+          expect(error).toMatchObject({
+            repositoryId: repo.id,
+            workItemCount: 1,
+          })
+        }),
+      ))
+
+    it("allows Project Path display casing correction when a Work Item exists", () =>
+      runTest(
+        Effect.gen(function* () {
+          const db = yield* DbService
+          const sql = yield* SqlClient.SqlClient
+          const repo = yield* db.addRepository({
+            ...sampleInput,
+            projectPath: "Acme/Widgets",
+          })
+          const now = Date.now()
+          yield* sql.unsafe(
+            `INSERT INTO work_item (
+               id, repository_id, issue_number, state, state_ready_at,
+               worktree_path, session_id, failure_code, failure_message,
+               created_at, updated_at
+             ) VALUES (?, ?, 1, 'complete', ?, NULL, NULL, NULL, NULL, ?, ?)`,
+            [
+              "wi-display-casing-does-not-freeze-identity",
+              repo.id,
+              now,
+              now,
+              now,
+            ],
+          )
+
+          const updated = yield* db.updateRepositorySettings({
+            repositoryId: repo.id,
+            forge: repo.forge,
+            forgeHost: repo.forgeHost,
+            projectPath: "acme/widgets",
+            paused: true,
+            defaultModel: null,
+            defaultThinkingLevel: null,
+            reviewModel: null,
+            reviewThinkingLevel: null,
+            autoMerge: false,
+            includeAllIssueAuthors: false,
+            waitForReadyForReviewChecks: true,
+          })
+
+          expect(updated.projectPath).toBe("acme/widgets")
+        }),
+      ))
+
     it("updates pause, model override, auto-merge, include-all authors, and ready-check wait", () =>
       runTest(
         Effect.gen(function* () {

--- a/packages/gitlab-service/package.json
+++ b/packages/gitlab-service/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@ready-for-agent/issue-reconciler",
+  "name": "@ready-for-agent/gitlab-service",
   "version": "0.0.1",
   "private": true,
   "type": "module",
@@ -16,9 +16,7 @@
     }
   },
   "dependencies": {
-    "@ready-for-agent/db-service": "workspace:*",
     "@ready-for-agent/github-service": "workspace:*",
-    "@ready-for-agent/gitlab-service": "workspace:*",
     "effect": "^4.0.0-beta.97",
     "tslib": "^2.3.0"
   },

--- a/packages/gitlab-service/project.json
+++ b/packages/gitlab-service/project.json
@@ -1,0 +1,19 @@
+{
+  "name": "gitlab-service",
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "packages/gitlab-service/src",
+  "projectType": "library",
+  "tags": [],
+  "targets": {
+    "test": {
+      "executor": "nx:run-commands",
+      "options": {
+        "cwd": "{projectRoot}",
+        "command": "bun test"
+      },
+      "inputs": ["default", "^production"],
+      "cache": true,
+      "dependsOn": ["^build"]
+    }
+  }
+}

--- a/packages/gitlab-service/src/index.ts
+++ b/packages/gitlab-service/src/index.ts
@@ -1,0 +1,5 @@
+export * from "./lib/errors.js"
+export * from "./lib/gitlab-service.js"
+export * from "./lib/gitlab-service-live.js"
+export * from "./lib/gitlab-service-test.js"
+export * from "./lib/types.js"

--- a/packages/gitlab-service/src/lib/errors.ts
+++ b/packages/gitlab-service/src/lib/errors.ts
@@ -1,0 +1,19 @@
+import { Schema } from "effect"
+
+export class GitLabProjectUnavailableError extends Schema.TaggedErrorClass<GitLabProjectUnavailableError>()(
+  "GitLabProjectUnavailableError",
+  {
+    forge: Schema.String,
+    forgeHost: Schema.String,
+    projectPath: Schema.String,
+  },
+) {}
+
+export class GitLabRequestError extends Schema.TaggedErrorClass<GitLabRequestError>()(
+  "GitLabRequestError",
+  {
+    message: Schema.String,
+    cause: Schema.optional(Schema.Defect()),
+    statusCode: Schema.optional(Schema.Finite),
+  },
+) {}

--- a/packages/gitlab-service/src/lib/gitlab-service-live.ts
+++ b/packages/gitlab-service/src/lib/gitlab-service-live.ts
@@ -1,0 +1,331 @@
+import { Duration, Effect, Schema } from "effect"
+import { GitLabProjectUnavailableError, GitLabRequestError } from "./errors.js"
+import type { GitLabServiceShape } from "./gitlab-service.js"
+import type { GitLabReadyLabeledIssue, GitLabRepository } from "./types.js"
+
+const REQUEST_TIMEOUT = Duration.seconds(30)
+const READY_LABEL = "ready-for-agent"
+const PAGE_SIZE = 100
+
+type GitLabFetch = typeof fetch
+
+class GitLabHttpError extends Error {
+  constructor(
+    readonly statusCode: number,
+    message: string,
+  ) {
+    super(message)
+  }
+}
+
+const PositiveInt = Schema.Int.pipe(Schema.check(Schema.isGreaterThan(0)))
+const RequiredString = Schema.String.pipe(
+  Schema.check(
+    Schema.makeFilter((value: string) =>
+      value.trim() === "" ? "Expected a non-empty string" : undefined,
+    ),
+  ),
+)
+const ProjectSchema = Schema.Struct({
+  path_with_namespace: RequiredString,
+})
+const UserSchema = Schema.Struct({
+  username: RequiredString,
+})
+const IssueSchema = Schema.Struct({
+  iid: PositiveInt,
+  title: RequiredString,
+  description: Schema.NullOr(Schema.String),
+  web_url: RequiredString,
+  created_at: RequiredString,
+  state: Schema.Literal("opened"),
+  author: Schema.NullOr(
+    Schema.Struct({
+      username: RequiredString,
+    }),
+  ),
+})
+const MergeRequestSchema = Schema.Struct({
+  iid: PositiveInt,
+  state: Schema.Literals(["opened", "merged", "closed"]),
+  draft: Schema.Boolean,
+  description: Schema.NullOr(Schema.String),
+})
+
+type GitLabIssue = typeof IssueSchema.Type
+type GitLabMergeRequest = typeof MergeRequestSchema.Type
+
+const apiBase = (repository: GitLabRepository): string =>
+  `https://${repository.forgeHost}/api/v4`
+
+const projectApiPath = (repository: GitLabRepository): string =>
+  `/projects/${encodeURIComponent(repository.projectPath)}`
+
+const requestError = (message: string, cause: unknown): GitLabRequestError =>
+  new GitLabRequestError({
+    message,
+    cause,
+    ...(cause instanceof GitLabHttpError
+      ? { statusCode: cause.statusCode }
+      : {}),
+  })
+
+const decode = <S extends { readonly Type: unknown }>(
+  schema: S & Parameters<typeof Schema.decodeUnknownSync>[0],
+  value: unknown,
+): S["Type"] => Schema.decodeUnknownSync(schema)(value)
+
+const closingIssueNumbers = (description: string): ReadonlySet<number> => {
+  const numbers = new Set<number>()
+  const pattern =
+    /\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+#([1-9]\d*)\b/gi
+  for (const match of description.matchAll(pattern)) {
+    const number = Number(match[1])
+    if (Number.isSafeInteger(number)) numbers.add(number)
+  }
+  return numbers
+}
+
+const blockerNumbers = (body: string): readonly number[] => {
+  const numbers = new Set<number>()
+  for (const line of body.matchAll(/^\s*Blocked by:\s*(.+)$/gim)) {
+    for (const reference of (line[1] ?? "").matchAll(/#([1-9]\d*)\b/g)) {
+      const number = Number(reference[1])
+      if (Number.isSafeInteger(number)) numbers.add(number)
+    }
+  }
+  return [...numbers]
+}
+
+const mergeRequestState = (
+  state: GitLabMergeRequest["state"],
+): "OPEN" | "MERGED" | "CLOSED" =>
+  state === "opened" ? "OPEN" : state === "merged" ? "MERGED" : "CLOSED"
+
+const mapIssue = (
+  repository: GitLabRepository,
+  issue: GitLabIssue,
+  mergeRequests: readonly GitLabMergeRequest[],
+): GitLabReadyLabeledIssue => {
+  const body = issue.description ?? ""
+  const createdAt = new Date(issue.created_at)
+  if (Number.isNaN(createdAt.getTime())) {
+    throw new Error(`Invalid GitLab Issue creation time: ${issue.created_at}`)
+  }
+  return {
+    number: issue.iid,
+    title: issue.title,
+    body,
+    url: issue.web_url,
+    createdAt,
+    state: "OPEN",
+    author: issue.author?.username ?? null,
+    parent: null,
+    parentPosition: null,
+    hasChildren: false,
+    hierarchySupported: false,
+    blockedBy: blockerNumbers(body).map((number) => ({
+      number,
+      url: `https://${repository.forgeHost}/${repository.projectPath}/-/issues/${number}`,
+    })),
+    closingPullRequests: mergeRequests
+      .filter((mergeRequest) =>
+        closingIssueNumbers(mergeRequest.description ?? "").has(issue.iid),
+      )
+      .map((mergeRequest) => ({
+        number: mergeRequest.iid,
+        repository: repository.projectPath,
+        state: mergeRequestState(mergeRequest.state),
+        isDraft: mergeRequest.draft,
+      })),
+  }
+}
+
+export const makeGitLabService = (options: {
+  readonly token?: string
+  readonly fetch?: GitLabFetch
+}): GitLabServiceShape => {
+  const fetchImpl = options.fetch ?? fetch
+  const headers: Record<string, string> =
+    options.token === undefined || options.token.trim() === ""
+      ? { Accept: "application/json" }
+      : {
+          Accept: "application/json",
+          "PRIVATE-TOKEN": options.token,
+        }
+
+  const requestUnknown = (
+    repository: GitLabRepository,
+    path: string,
+    message: string,
+  ): Effect.Effect<unknown, GitLabRequestError> =>
+    Effect.tryPromise({
+      try: async () => {
+        const response = await fetchImpl(`${apiBase(repository)}${path}`, {
+          headers,
+        })
+        if (!response.ok) {
+          throw new GitLabHttpError(
+            response.status,
+            `${message}: GitLab returned HTTP ${response.status}`,
+          )
+        }
+        return await response.json()
+      },
+      catch: (cause) => requestError(message, cause),
+    }).pipe(
+      Effect.timeout(REQUEST_TIMEOUT),
+      Effect.catchTag("TimeoutError", (cause) =>
+        Effect.fail(requestError(`${message} timed out`, cause)),
+      ),
+    )
+
+  const requestPages = (
+    repository: GitLabRepository,
+    path: string,
+    message: string,
+  ): Effect.Effect<readonly unknown[], GitLabRequestError> =>
+    Effect.tryPromise({
+      try: async () => {
+        const values: unknown[] = []
+        let page = 1
+        while (true) {
+          const separator = path.includes("?") ? "&" : "?"
+          const response = await fetchImpl(
+            `${apiBase(repository)}${path}${separator}per_page=${PAGE_SIZE}&page=${page}`,
+            { headers },
+          )
+          if (!response.ok) {
+            throw new GitLabHttpError(
+              response.status,
+              `${message}: GitLab returned HTTP ${response.status}`,
+            )
+          }
+          const decoded: unknown = await response.json()
+          if (!Array.isArray(decoded)) {
+            throw new Error(`${message}: GitLab returned a non-array page`)
+          }
+          values.push(...decoded)
+          const nextPage = response.headers.get("x-next-page")?.trim() ?? ""
+          if (nextPage === "") break
+          const parsed = Number(nextPage)
+          if (!Number.isSafeInteger(parsed) || parsed <= page) {
+            throw new Error(`${message}: invalid GitLab x-next-page header`)
+          }
+          page = parsed
+        }
+        return values
+      },
+      catch: (cause) => requestError(message, cause),
+    }).pipe(
+      Effect.timeout(REQUEST_TIMEOUT),
+      Effect.catchTag("TimeoutError", (cause) =>
+        Effect.fail(requestError(`${message} timed out`, cause)),
+      ),
+    )
+
+  const unavailableOn404 = <A>(
+    repository: GitLabRepository,
+    effect: Effect.Effect<A, GitLabRequestError>,
+  ): Effect.Effect<A, GitLabProjectUnavailableError | GitLabRequestError> =>
+    effect.pipe(
+      Effect.catch(
+        (
+          error,
+        ): Effect.Effect<
+          never,
+          GitLabProjectUnavailableError | GitLabRequestError
+        > =>
+          error.statusCode === 404
+            ? Effect.fail(new GitLabProjectUnavailableError(repository))
+            : Effect.fail(error),
+      ),
+    )
+
+  return {
+    verifyProject: Effect.fn("GitLabService.verifyProject")((repository) =>
+      unavailableOn404(
+        repository,
+        requestUnknown(
+          repository,
+          projectApiPath(repository),
+          `Failed to verify GitLab project ${repository.projectPath} on ${repository.forgeHost}`,
+        ).pipe(
+          Effect.map((value) => decode(ProjectSchema, value)),
+          Effect.asVoid,
+          Effect.mapError((error) =>
+            error instanceof GitLabRequestError
+              ? error
+              : requestError("GitLab returned an invalid project", error),
+          ),
+        ),
+      ),
+    ),
+    getAuthenticatedUserLogin: Effect.fn(
+      "GitLabService.getAuthenticatedUserLogin",
+    )((repository) =>
+      unavailableOn404(
+        repository,
+        requestUnknown(
+          repository,
+          "/user",
+          `Failed to resolve authenticated GitLab user on ${repository.forgeHost}`,
+        ).pipe(
+          Effect.map((value) => decode(UserSchema, value).username),
+          Effect.mapError((error) =>
+            error instanceof GitLabRequestError
+              ? error
+              : requestError("GitLab returned an invalid user", error),
+          ),
+        ),
+      ),
+    ),
+    listReadyIssues: Effect.fn("GitLabService.listReadyIssues")(
+      (repository) => {
+        const project = projectApiPath(repository)
+        return unavailableOn404(
+          repository,
+          Effect.all(
+            [
+              requestPages(
+                repository,
+                `${project}/issues?state=opened&labels=${encodeURIComponent(READY_LABEL)}`,
+                `Failed to list Ready Issues for ${repository.projectPath}`,
+              ),
+              requestPages(
+                repository,
+                `${project}/merge_requests?scope=all&state=all`,
+                `Failed to list merge requests for ${repository.projectPath}`,
+              ),
+            ],
+            { concurrency: 2 },
+          ).pipe(
+            Effect.map(([issues, mergeRequests]) => {
+              const decodedIssues = decode(Schema.Array(IssueSchema), issues)
+              const decodedMergeRequests = decode(
+                Schema.Array(MergeRequestSchema),
+                mergeRequests,
+              )
+              return decodedIssues
+                .map((issue) =>
+                  mapIssue(repository, issue, decodedMergeRequests),
+                )
+                .sort((left, right) => left.number - right.number)
+            }),
+            Effect.mapError((error) =>
+              error instanceof GitLabRequestError
+                ? error
+                : requestError("GitLab returned invalid issue data", error),
+            ),
+          ),
+        )
+      },
+    ),
+    hasCredentials: () => Effect.succeed(options.token !== undefined),
+  }
+}
+
+export const makeGitLabServiceFromToken = (
+  token: string,
+  fetchImpl: GitLabFetch = fetch,
+): GitLabServiceShape => makeGitLabService({ token, fetch: fetchImpl })

--- a/packages/gitlab-service/src/lib/gitlab-service-test.ts
+++ b/packages/gitlab-service/src/lib/gitlab-service-test.ts
@@ -1,0 +1,61 @@
+import { Effect, Layer } from "effect"
+import {
+  GitLabProjectUnavailableError,
+  type GitLabRequestError,
+} from "./errors.js"
+import { GitLabService } from "./gitlab-service.js"
+import type { GitLabReadyLabeledIssue, GitLabRepository } from "./types.js"
+
+export interface GitLabServiceTestFixture {
+  readonly repository: GitLabRepository
+  readonly issues?: readonly GitLabReadyLabeledIssue[]
+  readonly operatorLogin?: string
+  readonly error?: GitLabRequestError
+}
+
+const key = (repository: GitLabRepository): string =>
+  `${repository.forgeHost.toLowerCase()}/${repository.projectPath.toLowerCase()}`
+
+export const makeGitLabServiceTest = (
+  fixtures: readonly GitLabServiceTestFixture[],
+): Layer.Layer<GitLabService> => {
+  const byRepository = new Map(
+    fixtures.map((fixture) => [key(fixture.repository), fixture]),
+  )
+  const fixtureFor = (repository: GitLabRepository) =>
+    byRepository.get(key(repository))
+
+  return Layer.succeed(GitLabService, {
+    verifyProject: (repository) => {
+      const fixture = fixtureFor(repository)
+      if (fixture === undefined) {
+        return Effect.fail(new GitLabProjectUnavailableError(repository))
+      }
+      return fixture.error === undefined
+        ? Effect.void
+        : Effect.fail(fixture.error)
+    },
+    getAuthenticatedUserLogin: (repository) => {
+      const fixture = fixtureFor(repository)
+      if (fixture === undefined) {
+        return Effect.fail(new GitLabProjectUnavailableError(repository))
+      }
+      if (fixture.error !== undefined) return Effect.fail(fixture.error)
+      return Effect.succeed(fixture.operatorLogin ?? "operator")
+    },
+    listReadyIssues: (repository) => {
+      const fixture = fixtureFor(repository)
+      if (fixture === undefined) {
+        return Effect.fail(new GitLabProjectUnavailableError(repository))
+      }
+      if (fixture.error !== undefined) return Effect.fail(fixture.error)
+      return Effect.succeed(
+        [...(fixture.issues ?? [])].sort(
+          (left, right) => left.number - right.number,
+        ),
+      )
+    },
+    hasCredentials: (repository) =>
+      Effect.succeed(fixtureFor(repository) !== undefined),
+  })
+}

--- a/packages/gitlab-service/src/lib/gitlab-service.ts
+++ b/packages/gitlab-service/src/lib/gitlab-service.ts
@@ -1,0 +1,34 @@
+import { Context, type Effect } from "effect"
+import type {
+  GitLabProjectUnavailableError,
+  GitLabRequestError,
+} from "./errors.js"
+import type { GitLabReadyLabeledIssue, GitLabRepository } from "./types.js"
+
+export type GitLabServiceError =
+  | GitLabProjectUnavailableError
+  | GitLabRequestError
+
+export interface GitLabServiceShape {
+  /** Verify Forge Host + Project Path against GitLab before persistence. */
+  readonly verifyProject: (
+    repository: GitLabRepository,
+  ) => Effect.Effect<void, GitLabServiceError>
+  /** Operator Forge User for the active ambient credential. */
+  readonly getAuthenticatedUserLogin: (
+    repository: GitLabRepository,
+  ) => Effect.Effect<string, GitLabServiceError>
+  /** Open Ready-labeled Issues mapped to the shared Forge issue domain. */
+  readonly listReadyIssues: (
+    repository: GitLabRepository,
+  ) => Effect.Effect<readonly GitLabReadyLabeledIssue[], GitLabServiceError>
+  /** Whether ambient GitLab authentication resolves for this Forge Host. */
+  readonly hasCredentials: (
+    repository: GitLabRepository,
+  ) => Effect.Effect<boolean, GitLabRequestError>
+}
+
+export class GitLabService extends Context.Service<
+  GitLabService,
+  GitLabServiceShape
+>()("@ready-for-agent/gitlab-service/GitLabService") {}

--- a/packages/gitlab-service/src/lib/types.ts
+++ b/packages/gitlab-service/src/lib/types.ts
@@ -1,0 +1,9 @@
+import type { ReadyLabeledIssue } from "@ready-for-agent/github-service"
+
+export interface GitLabRepository {
+  readonly forge: string
+  readonly forgeHost: string
+  readonly projectPath: string
+}
+
+export type GitLabReadyLabeledIssue = ReadyLabeledIssue

--- a/packages/gitlab-service/test/gitlab-service.spec.ts
+++ b/packages/gitlab-service/test/gitlab-service.spec.ts
@@ -1,0 +1,211 @@
+import { Effect, Result } from "effect"
+import {
+  GitLabProjectUnavailableError,
+  GitLabRequestError,
+  makeGitLabServiceFromToken,
+} from "../src/index.js"
+import { describe, expect, test } from "bun:test"
+
+const repository = {
+  forge: "gitlab",
+  forgeHost: "git.drupalcode.org",
+  projectPath: "project/oauth_client",
+}
+
+const json = (value: unknown, init: ResponseInit = {}): Response =>
+  new Response(JSON.stringify(value), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+    ...init,
+  })
+
+const fakeFetch = (
+  responses: Readonly<Record<string, unknown | Response>>,
+): typeof fetch =>
+  (async (input) => {
+    const url = new URL(String(input))
+    const response = responses[`${url.pathname}${url.search}`]
+    if (response === undefined) {
+      throw new Error(`Unexpected request: ${url.pathname}${url.search}`)
+    }
+    return response instanceof Response ? response : json(response)
+  }) as typeof fetch
+
+describe("GitLab issue-source adapter", () => {
+  test("maps Ready Issues, body blockers, and closing merge requests", async () => {
+    const service = makeGitLabServiceFromToken(
+      "test-token",
+      fakeFetch({
+        "/api/v4/projects/project%2Foauth_client/issues?state=opened&labels=ready-for-agent&per_page=100&page=1":
+          [
+            {
+              iid: 3601642,
+              title: "Refresh tokens",
+              description: "Context\n\nBlocked by: #3601000, #3601001",
+              web_url:
+                "https://git.drupalcode.org/project/oauth_client/-/issues/3601642",
+              created_at: "2026-07-20T01:02:03.000Z",
+              state: "opened",
+              author: { username: "alice" },
+            },
+            {
+              iid: 3601643,
+              title: "Ghost author",
+              description: null,
+              web_url:
+                "https://git.drupalcode.org/project/oauth_client/-/issues/3601643",
+              created_at: "2026-07-21T01:02:03.000Z",
+              state: "opened",
+              author: null,
+            },
+          ],
+        "/api/v4/projects/project%2Foauth_client/merge_requests?scope=all&state=all&per_page=100&page=1":
+          [
+            {
+              iid: 81,
+              state: "opened",
+              draft: true,
+              description: "Closes #3601642",
+            },
+            {
+              iid: 82,
+              state: "merged",
+              draft: false,
+              description: "Fixes #3601642",
+            },
+            {
+              iid: 83,
+              state: "closed",
+              draft: false,
+              description: "Resolves #3601642",
+            },
+            {
+              iid: 84,
+              state: "opened",
+              draft: false,
+              description: "Mentions #3601642 without closing it",
+            },
+          ],
+      }),
+    )
+
+    const issues = await Effect.runPromise(service.listReadyIssues(repository))
+
+    expect(issues).toEqual([
+      {
+        number: 3601642,
+        title: "Refresh tokens",
+        body: "Context\n\nBlocked by: #3601000, #3601001",
+        url: "https://git.drupalcode.org/project/oauth_client/-/issues/3601642",
+        createdAt: new Date("2026-07-20T01:02:03.000Z"),
+        state: "OPEN",
+        author: "alice",
+        parent: null,
+        parentPosition: null,
+        hasChildren: false,
+        hierarchySupported: false,
+        blockedBy: [
+          {
+            number: 3601000,
+            url: "https://git.drupalcode.org/project/oauth_client/-/issues/3601000",
+          },
+          {
+            number: 3601001,
+            url: "https://git.drupalcode.org/project/oauth_client/-/issues/3601001",
+          },
+        ],
+        closingPullRequests: [
+          {
+            number: 81,
+            repository: "project/oauth_client",
+            state: "OPEN",
+            isDraft: true,
+          },
+          {
+            number: 82,
+            repository: "project/oauth_client",
+            state: "MERGED",
+            isDraft: false,
+          },
+          {
+            number: 83,
+            repository: "project/oauth_client",
+            state: "CLOSED",
+            isDraft: false,
+          },
+        ],
+      },
+      {
+        number: 3601643,
+        title: "Ghost author",
+        body: "",
+        url: "https://git.drupalcode.org/project/oauth_client/-/issues/3601643",
+        createdAt: new Date("2026-07-21T01:02:03.000Z"),
+        state: "OPEN",
+        author: null,
+        parent: null,
+        parentPosition: null,
+        hasChildren: false,
+        hierarchySupported: false,
+        blockedBy: [],
+        closingPullRequests: [],
+      },
+    ])
+  })
+
+  test("resolves the Operator Forge User through the token", async () => {
+    const service = makeGitLabServiceFromToken(
+      "test-token",
+      fakeFetch({
+        "/api/v4/user": { username: "operator" },
+      }),
+    )
+
+    await expect(
+      Effect.runPromise(service.getAuthenticatedUserLogin(repository)),
+    ).resolves.toBe("operator")
+  })
+
+  test("verifies a project and rejects an unknown identity actionably", async () => {
+    const present = makeGitLabServiceFromToken(
+      "test-token",
+      fakeFetch({
+        "/api/v4/projects/project%2Foauth_client": {
+          path_with_namespace: "project/oauth_client",
+        },
+      }),
+    )
+    await expect(
+      Effect.runPromise(present.verifyProject(repository)),
+    ).resolves.toBeUndefined()
+
+    const missing = makeGitLabServiceFromToken(
+      "test-token",
+      fakeFetch({
+        "/api/v4/projects/project%2Foauth_client": new Response("not found", {
+          status: 404,
+        }),
+      }),
+    )
+    const result = await Effect.runPromise(
+      missing.verifyProject(repository).pipe(Effect.result),
+    )
+    expect(result).toEqual(
+      Result.fail(new GitLabProjectUnavailableError(repository)),
+    )
+  })
+
+  test("preserves authentication status on request failures", async () => {
+    const service = makeGitLabServiceFromToken(
+      "expired",
+      fakeFetch({
+        "/api/v4/user": new Response("unauthorized", { status: 401 }),
+      }),
+    )
+    const error = await Effect.runPromise(
+      service.getAuthenticatedUserLogin(repository).pipe(Effect.flip),
+    )
+    expect(error).toBeInstanceOf(GitLabRequestError)
+    expect(error.statusCode).toBe(401)
+  })
+})

--- a/packages/gitlab-service/tsconfig.json
+++ b/packages/gitlab-service/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ]
+}

--- a/packages/gitlab-service/tsconfig.lib.json
+++ b/packages/gitlab-service/tsconfig.lib.json
@@ -12,12 +12,6 @@
   "references": [
     {
       "path": "../github-service/tsconfig.lib.json"
-    },
-    {
-      "path": "../gitlab-service/tsconfig.lib.json"
-    },
-    {
-      "path": "../db-service/tsconfig.lib.json"
     }
   ]
 }

--- a/packages/graphql-api/package.json
+++ b/packages/graphql-api/package.json
@@ -19,6 +19,7 @@
     "@ready-for-agent/agent-backend": "workspace:*",
     "@ready-for-agent/db-service": "workspace:*",
     "@ready-for-agent/github-service": "workspace:*",
+    "@ready-for-agent/gitlab-service": "workspace:*",
     "@ready-for-agent/graphql-schema": "workspace:*",
     "@ready-for-agent/keymaxxer-service": "workspace:*",
     "@ready-for-agent/local-git": "workspace:*",

--- a/packages/graphql-api/src/lib/graphql-api.ts
+++ b/packages/graphql-api/src/lib/graphql-api.ts
@@ -20,12 +20,9 @@ import {
   listBuiltInAgentBackends,
   toAgentBackendStatus,
 } from "@ready-for-agent/agent-backend"
-import {
-  DbService,
-  InvalidRepositoryInputError,
-  RepositoryNotFoundError,
-} from "@ready-for-agent/db-service"
+import { DbService, RepositoryNotFoundError } from "@ready-for-agent/db-service"
 import { GitHubService } from "@ready-for-agent/github-service"
+import { GitLabService } from "@ready-for-agent/gitlab-service"
 import { typeDefs } from "@ready-for-agent/graphql-schema"
 import { KeymaxxerService } from "@ready-for-agent/keymaxxer-service"
 import { DirectoryPicker, LocalGit } from "@ready-for-agent/local-git"
@@ -109,6 +106,9 @@ type UpdateConfigArgs = {
 type UpdateRepositorySettingsArgs = {
   input: {
     repositoryId: string
+    forge?: "github" | "gitlab"
+    forgeHost?: string
+    projectPath?: string
     paused: boolean
     /**
      * Undefined when the client omits the field (leave override unchanged).
@@ -257,6 +257,7 @@ type ResetWorkItemArgs = WorkItemArgs
 export type GraphqlServices =
   | DbService
   | GitHubService
+  | GitLabService
   | KeymaxxerService
   | ActiveAgentBackend
   | QueueService
@@ -273,6 +274,18 @@ const isSameOriginRequest = (request: Request): boolean => {
   const origin = request.headers.get("origin")
   return origin === null || origin === new URL(request.url).origin
 }
+
+const verifyRepositoryIdentity = Effect.fn(
+  "graphql-api.verifyRepositoryIdentity",
+)(function* (identity: {
+  readonly forge: "github" | "gitlab"
+  readonly forgeHost: string
+  readonly projectPath: string
+}) {
+  if (identity.forge !== "gitlab") return
+  const gitlab = yield* GitLabService
+  yield* gitlab.verifyProject(identity)
+})
 
 const toNativeResponse = (response: unknown): Response => {
   if (response instanceof Response) return response
@@ -368,24 +381,47 @@ export const createGraphqlApi = (
                 const repositories = yield* db.listRepositories
                 const keymaxxer = yield* KeymaxxerService
                 const ambientAuthentication = keymaxxer.enabled === false
-                const tokenNames = ambientAuthentication
-                  ? repositories.map(() => null)
-                  : yield* withKeymaxxerMetadataTimeout(
-                      keymaxxer.findSecrets(
-                        repositories.map((repository) => ({
-                          provider: "github",
-                          account: repository.projectPath,
-                        })),
+                const githubRepositories = repositories.filter(
+                  ({ forge }) => forge === "github",
+                )
+                const githubTokenNames = ambientAuthentication
+                  ? githubRepositories.map(() => null)
+                  : githubRepositories.length === 0
+                    ? []
+                    : yield* withKeymaxxerMetadataTimeout(
+                        keymaxxer.findSecrets(
+                          githubRepositories.map((repository) => ({
+                            provider: "github",
+                            account: repository.projectPath,
+                          })),
+                        ),
+                        keymaxxerMetadataTimeout,
+                        "findSecrets",
+                      )
+                const gitlab = yield* GitLabService
+                let githubIndex = 0
+                return yield* Effect.forEach(
+                  repositories,
+                  (repository) => {
+                    if (repository.forge === "gitlab") {
+                      return gitlab
+                        .hasCredentials(repository)
+                        .pipe(
+                          Effect.map((configured) =>
+                            repositoryCredential(repository, null, configured),
+                          ),
+                        )
+                    }
+                    const tokenName = githubTokenNames[githubIndex++] ?? null
+                    return Effect.succeed(
+                      repositoryCredential(
+                        repository,
+                        tokenName,
+                        ambientAuthentication || tokenName !== null,
                       ),
-                      keymaxxerMetadataTimeout,
-                      "findSecrets",
                     )
-                return repositories.map((repository, index) =>
-                  repositoryCredential(
-                    repository,
-                    tokenNames[index] ?? null,
-                    ambientAuthentication || tokenNames[index] != null,
-                  ),
+                  },
+                  { concurrency: "unbounded" },
                 )
               }).pipe(Effect.withSpan("graphql-api.repositoryCredentials")),
             ),
@@ -604,6 +640,7 @@ export const createGraphqlApi = (
           }) =>
             runGraphql(
               Effect.gen(function* () {
+                if (repository.forge !== "github") return 0
                 const github = yield* GitHubService
                 // GitHub is authoritative: open non-draft PRs regardless of Work
                 // Item ownership. Credential/API failures degrade to zero so the
@@ -857,12 +894,43 @@ export const createGraphqlApi = (
               Effect.gen(function* () {
                 const db = yield* DbService
                 const active = yield* ActiveAgentBackend
+                const repositories = yield* db.listRepositories
+                const repository = repositories.find(
+                  ({ id }) => id === args.input.repositoryId,
+                )
+                if (repository === undefined) {
+                  return yield* new RepositoryNotFoundError({
+                    repositoryId: args.input.repositoryId,
+                  })
+                }
+                const nextIdentity = {
+                  forge: args.input.forge ?? repository.forge,
+                  forgeHost: args.input.forgeHost ?? repository.forgeHost,
+                  projectPath: args.input.projectPath ?? repository.projectPath,
+                }
+                const identityChanging =
+                  nextIdentity.forge !== repository.forge ||
+                  nextIdentity.forgeHost !== repository.forgeHost ||
+                  nextIdentity.projectPath.toLowerCase() !==
+                    repository.projectPath.toLowerCase()
+                if (identityChanging) {
+                  yield* verifyRepositoryIdentity(nextIdentity)
+                }
                 // Coordinate with Work Item creation when the effective backend
                 // may change so Implement Now cannot capture a pre-activate id.
-                return yield* active.withConfigCoordination(
+                const updated = yield* active.withConfigCoordination(
                   Effect.gen(function* () {
                     const updated = yield* db.updateRepositorySettings({
                       repositoryId: args.input.repositoryId,
+                      ...(args.input.forge === undefined
+                        ? {}
+                        : { forge: args.input.forge }),
+                      ...(args.input.forgeHost === undefined
+                        ? {}
+                        : { forgeHost: args.input.forgeHost }),
+                      ...(args.input.projectPath === undefined
+                        ? {}
+                        : { projectPath: args.input.projectPath }),
                       paused: args.input.paused,
                       ...(args.input.selectedAgentBackend !== undefined
                         ? {
@@ -897,6 +965,22 @@ export const createGraphqlApi = (
                     return updated
                   }),
                 )
+                if (identityChanging) {
+                  yield* suspendRepositoryPolling(updated.id).pipe(
+                    Effect.andThen(
+                      activatePollingIfCredentialed(updated, {
+                        metadataTimeout: keymaxxerMetadataTimeout,
+                      }),
+                    ),
+                    Effect.catch((error) =>
+                      Effect.logWarning(
+                        "Repository polling was not updated after Forge identity correction",
+                        { repositoryId: updated.id, error },
+                      ),
+                    ),
+                  )
+                }
+                return updated
               }).pipe(Effect.withSpan("graphql-api.updateRepositorySettings")),
             ),
           pauseRepository: async (
@@ -922,12 +1006,7 @@ export const createGraphqlApi = (
           addRepository: async (_parent: unknown, args: AddRepositoryArgs) =>
             runGraphql(
               Effect.gen(function* () {
-                if (args.input.forge !== "github") {
-                  return yield* new InvalidRepositoryInputError({
-                    field: "forge",
-                    message: `Adding ${args.input.forge} repositories is not supported`,
-                  })
-                }
+                yield* verifyRepositoryIdentity(args.input)
                 const db = yield* DbService
                 const added = yield* db.addRepository(args.input)
                 yield* activatePollingIfCredentialed(added, {
@@ -963,6 +1042,7 @@ export const createGraphqlApi = (
                 const localGit = yield* LocalGit
                 const db = yield* DbService
                 const inspected = yield* localGit.inspect(path)
+                yield* verifyRepositoryIdentity(inspected)
                 const added = yield* db.addRepository({
                   forge: inspected.forge,
                   forgeHost: inspected.forgeHost,
@@ -985,6 +1065,24 @@ export const createGraphqlApi = (
                 )
                 return added
               }).pipe(Effect.withSpan("graphql-api.addLocalRepository")),
+            ),
+          inspectLocalRepository: async (
+            _parent: unknown,
+            args: AddLocalRepositoryArgs,
+          ) =>
+            runGraphql(
+              Effect.gen(function* () {
+                const path = args.path.trim()
+                if (path.length === 0) {
+                  return yield* Effect.fail(
+                    new GraphQLError("Path is required", {
+                      extensions: { code: "BAD_USER_INPUT" },
+                    }),
+                  )
+                }
+                const localGit = yield* LocalGit
+                return yield* localGit.inspect(path)
+              }).pipe(Effect.withSpan("graphql-api.inspectLocalRepository")),
             ),
           pickLocalDirectory: async () =>
             runGraphql(

--- a/packages/graphql-api/src/lib/repository-credentials.ts
+++ b/packages/graphql-api/src/lib/repository-credentials.ts
@@ -1,4 +1,5 @@
 import { Data, type Duration, Effect } from "effect"
+import { GitLabService } from "@ready-for-agent/gitlab-service"
 import {
   KeymaxxerService,
   keymaxxerError,
@@ -79,13 +80,21 @@ export const withKeymaxxerMetadataTimeout = <A, E, R>(
     ),
   )
 
-/** Activate durable Issue Polling only when a GitHub token is already configured. */
+/** Activate durable Issue Polling only when this repository has forge credentials. */
 export const activatePollingIfCredentialed = Effect.fn(
   "graphql-api.activatePollingIfCredentialed",
 )(function* (
   repository: Repository,
   options?: { readonly metadataTimeout?: Duration.Duration },
 ) {
+  if (repository.forge === "gitlab") {
+    const gitlab = yield* GitLabService
+    if (yield* gitlab.hasCredentials(repository)) {
+      yield* activateRepositoryPolling(repository.id)
+    }
+    return
+  }
+
   const keymaxxer = yield* KeymaxxerService
   if (keymaxxer.enabled === false) {
     yield* activateRepositoryPolling(repository.id)

--- a/packages/graphql-api/src/lib/to-graphql-error.ts
+++ b/packages/graphql-api/src/lib/to-graphql-error.ts
@@ -166,6 +166,27 @@ export const toGraphQLError = (error: unknown): GraphQLError => {
         error.message ?? "Repository credential error",
         "REPOSITORY_CREDENTIAL_ERROR",
       )
+    case "GitLabProjectUnavailableError":
+      return gql(
+        `GitLab project ${error.projectPath} was not found on ${error.forgeHost}. Check the Forge Host and Project Path, then try again.`,
+        "GITLAB_PROJECT_UNAVAILABLE",
+        {
+          forgeHost: error.forgeHost,
+          projectPath: error.projectPath,
+        },
+      )
+    case "GitLabRequestError":
+      return gql(
+        error.message ?? "GitLab request failed",
+        "GITLAB_REQUEST_FAILED",
+      )
+    case "RepositoryIdentityChangeBlockedError":
+      return gql(
+        error.message ??
+          "Cannot change Repository Forge identity while Work Items exist",
+        "REPOSITORY_IDENTITY_CHANGE_BLOCKED",
+        { repositoryId: error.repositoryId },
+      )
     case "KeymaxxerError":
       return gql(
         error.message ?? "Keymaxxer operation failed",
@@ -224,10 +245,10 @@ export const toGraphQLError = (error: unknown): GraphQLError => {
         "NOT_A_GIT_REPOSITORY",
         { path: error.path },
       )
-    case "NoGitHubRemote":
+    case "NoForgeRemote":
       return gql(
-        error.message ?? `No GitHub remote found for: ${error.path ?? ""}`,
-        "NO_GITHUB_REMOTE",
+        error.message ?? `No supported Forge remote found: ${error.path ?? ""}`,
+        "NO_FORGE_REMOTE",
         { path: error.path },
       )
     case "DatabaseError":

--- a/packages/graphql-api/test/graphql-api.test.ts
+++ b/packages/graphql-api/test/graphql-api.test.ts
@@ -20,6 +20,11 @@ import {
   type GitHubServiceShape,
 } from "@ready-for-agent/github-service"
 import {
+  GitLabProjectUnavailableError,
+  GitLabService,
+  type GitLabServiceShape,
+} from "@ready-for-agent/gitlab-service"
+import {
   KeymaxxerService,
   type KeymaxxerServiceShape,
 } from "@ready-for-agent/keymaxxer-service"
@@ -191,6 +196,13 @@ const defaultGithub: GitHubServiceShape = {
   listReadyIssues: () => Effect.succeed([]),
 }
 
+const defaultGitlab: GitLabServiceShape = {
+  verifyProject: () => Effect.void,
+  getAuthenticatedUserLogin: () => Effect.succeed("test-operator"),
+  listReadyIssues: () => Effect.succeed([]),
+  hasCredentials: () => Effect.succeed(true),
+}
+
 const makeRuntime = (
   dbOverrides: Partial<DbServiceShape> = {},
   keymaxxerOverrides: Partial<KeymaxxerServiceShape> = {},
@@ -201,6 +213,7 @@ const makeRuntime = (
     readonly inspect: (path: string) => Effect.Effect<LocalRepository, unknown>
   }> = {},
   githubOverrides: Partial<GitHubServiceShape> = {},
+  gitlabOverrides: Partial<GitLabServiceShape> = {},
 ) => {
   const db = stubDbService({
     getConfig: Effect.succeed(config),
@@ -367,6 +380,10 @@ const makeRuntime = (
         ...defaultGithub,
         ...githubOverrides,
       }),
+      Layer.succeed(GitLabService, {
+        ...defaultGitlab,
+        ...gitlabOverrides,
+      }),
       localGit,
       directoryPicker,
     ),
@@ -429,15 +446,30 @@ describe("GraphQL API", () => {
     })
   })
 
-  test("rejects unsupported forges before adding a repository", async () => {
-    let addRepositoryCalled = false
+  test("verifies a GitLab project before adding the repository", async () => {
+    const actions: string[] = []
     await runtime.dispose()
-    runtime = makeRuntime({
-      addRepository: () => {
-        addRepositoryCalled = true
-        return Effect.succeed(repository)
+    runtime = makeRuntime(
+      {
+        addRepository: (input) => {
+          actions.push(`add:${input.forgeHost}/${input.projectPath}`)
+          return Effect.succeed({ ...repository, ...input })
+        },
       },
-    })
+      {},
+      {},
+      {},
+      {},
+      {},
+      {},
+      {
+        verifyProject: ({ forgeHost, projectPath }) =>
+          Effect.sync(() => {
+            actions.push(`verify:${forgeHost}/${projectPath}`)
+          }),
+        hasCredentials: () => Effect.succeed(false),
+      },
+    )
 
     const response = await createGraphqlApi(runtime).fetch(
       graphqlRequest({
@@ -456,18 +488,64 @@ describe("GraphQL API", () => {
       }),
     )
 
-    const body = (await response.json()) as {
-      errors?: ReadonlyArray<{
-        message: string
-        extensions?: { code?: string; field?: string }
-      }>
-    }
-    expect(body.errors?.[0]).toMatchObject({
-      message: "Adding gitlab repositories is not supported",
-      extensions: {
-        code: "INVALID_REPOSITORY_INPUT",
-        field: "forge",
+    expect(await response.json()).toEqual({
+      data: {
+        addRepository: {
+          id: repository.id,
+        },
       },
+    })
+    expect(actions).toEqual([
+      "verify:gitlab.com/acme/widgets",
+      "add:gitlab.com/acme/widgets",
+    ])
+  })
+
+  test("rejects an unknown GitLab project before saving", async () => {
+    let addRepositoryCalled = false
+    await runtime.dispose()
+    runtime = makeRuntime(
+      {
+        addRepository: () => {
+          addRepositoryCalled = true
+          return Effect.succeed(repository)
+        },
+      },
+      {},
+      {},
+      {},
+      {},
+      {},
+      {},
+      {
+        verifyProject: (identity) =>
+          Effect.fail(new GitLabProjectUnavailableError(identity)),
+      },
+    )
+
+    const response = await createGraphqlApi(runtime).fetch(
+      graphqlRequest({
+        query: `mutation AddRepository($input: AddRepositoryInput!) {
+          addRepository(input: $input) { id }
+        }`,
+        variables: {
+          input: {
+            forge: "gitlab",
+            forgeHost: "gitlab.example",
+            projectPath: "missing/project",
+            localPath: "/tmp/missing-project",
+            isBare: false,
+          },
+        },
+      }),
+    )
+
+    expect(await response.json()).toMatchObject({
+      errors: [
+        {
+          extensions: { code: "GITLAB_PROJECT_UNAVAILABLE" },
+        },
+      ],
     })
     expect(addRepositoryCalled).toBe(false)
   })
@@ -579,6 +657,47 @@ describe("GraphQL API", () => {
       })
     } finally {
       await addRuntime.dispose()
+    }
+  })
+
+  test("inspectLocalRepository returns the guessed identity without saving", async () => {
+    let addRepositoryCalled = false
+    const inspectRuntime = makeRuntime({
+      addRepository: () => {
+        addRepositoryCalled = true
+        return Effect.succeed(repository)
+      },
+    })
+
+    try {
+      const response = await createGraphqlApi(inspectRuntime).fetch(
+        graphqlRequest({
+          query: `mutation {
+            inspectLocalRepository(path: "/tmp/fixture-repo") {
+              forge
+              forgeHost
+              projectPath
+              localPath
+              isBare
+            }
+          }`,
+        }),
+      )
+
+      expect(await response.json()).toEqual({
+        data: {
+          inspectLocalRepository: {
+            forge: repository.forge,
+            forgeHost: repository.forgeHost,
+            projectPath: repository.projectPath,
+            localPath: "/tmp/fixture-repo",
+            isBare: repository.isBare,
+          },
+        },
+      })
+      expect(addRepositoryCalled).toBe(false)
+    } finally {
+      await inspectRuntime.dispose()
     }
   })
 
@@ -757,6 +876,66 @@ describe("GraphQL API", () => {
 
     expect(response.status).toBe(200)
     expect((await response.json()).data.addRepository.id).toBe(repository.id)
+    expect(ensured).toBe(true)
+    expect(enqueued).toBe(true)
+  })
+
+  test("activates Issue Polling when ambient GitLab authentication resolves", async () => {
+    let ensured = false
+    let enqueued = false
+    await runtime.dispose()
+    runtime = makeRuntime(
+      {
+        addRepository: (input) =>
+          Effect.succeed({ ...repository, ...input, paused: true }),
+      },
+      {
+        findSecret: () => Effect.die("must not inspect GitHub credentials"),
+      },
+      {
+        ensureKeyed: () => {
+          ensured = true
+          return Effect.succeed({ jobId: makeJobId(), created: true })
+        },
+        enqueue: () => {
+          enqueued = true
+          return Effect.succeed(makeJobId())
+        },
+      },
+      {},
+      {},
+      {},
+      {},
+      {
+        hasCredentials: () => Effect.succeed(true),
+      },
+    )
+
+    const response = await createGraphqlApi(runtime).fetch(
+      graphqlRequest({
+        query: `mutation AddRepository($input: AddRepositoryInput!) {
+          addRepository(input: $input) { id paused }
+        }`,
+        variables: {
+          input: {
+            forge: "gitlab",
+            forgeHost: "git.drupalcode.org",
+            projectPath: "project/oauth_client",
+            localPath: "/tmp/oauth_client",
+            isBare: false,
+          },
+        },
+      }),
+    )
+
+    expect(await response.json()).toEqual({
+      data: {
+        addRepository: {
+          id: repository.id,
+          paused: true,
+        },
+      },
+    })
     expect(ensured).toBe(true)
     expect(enqueued).toBe(true)
   })
@@ -1547,6 +1726,72 @@ describe("GraphQL API", () => {
     expect(settingsCalls[0]).toEqual({ selectedAgentBackend: undefined })
   })
 
+  test("updates Project Path display casing without re-verifying Forge identity", async () => {
+    const gitlabRepository = makeRepositoryRecord({
+      id: repository.id,
+      forge: "gitlab",
+      forgeHost: "gitlab.example",
+      projectPath: "Group/Widgets",
+    })
+    let verifications = 0
+    await runtime.dispose()
+    runtime = makeRuntime(
+      {
+        listRepositories: Effect.succeed([gitlabRepository]),
+        updateRepositorySettings: (input) =>
+          Effect.succeed({
+            ...gitlabRepository,
+            projectPath: input.projectPath ?? gitlabRepository.projectPath,
+          }),
+      },
+      {},
+      {},
+      {},
+      {},
+      {},
+      {},
+      {
+        verifyProject: () => {
+          verifications += 1
+          return Effect.void
+        },
+      },
+    )
+
+    const response = await createGraphqlApi(runtime).fetch(
+      graphqlRequest({
+        query: `mutation UpdateRepositorySettings($input: UpdateRepositorySettingsInput!) {
+          updateRepositorySettings(input: $input) { projectPath }
+        }`,
+        variables: {
+          input: {
+            repositoryId: gitlabRepository.id,
+            forge: "gitlab",
+            forgeHost: "gitlab.example",
+            projectPath: "group/widgets",
+            paused: true,
+            defaultModel: null,
+            defaultThinkingLevel: null,
+            reviewModel: null,
+            reviewThinkingLevel: null,
+            autoMerge: false,
+            includeAllIssueAuthors: false,
+            waitForReadyForReviewChecks: true,
+          },
+        },
+      }),
+    )
+
+    expect(await response.json()).toEqual({
+      data: {
+        updateRepositorySettings: {
+          projectPath: "group/widgets",
+        },
+      },
+    })
+    expect(verifications).toBe(0)
+  })
+
   test("exposes scoped gate counts on Config and Repository", async () => {
     await runtime.dispose()
     const counted: Array<{
@@ -1621,6 +1866,52 @@ describe("GraphQL API", () => {
         projectPath: repository.projectPath,
       },
     ])
+  })
+
+  test("reports ambient GitLab credential status without consulting Keymaxxer", async () => {
+    const gitlabRepository = {
+      ...repository,
+      forge: "gitlab" as const,
+      forgeHost: "git.drupalcode.org",
+      projectPath: "project/oauth_client",
+    }
+    await runtime.dispose()
+    runtime = makeRuntime(
+      {
+        listRepositories: Effect.succeed([gitlabRepository]),
+      },
+      {
+        findSecrets: () =>
+          Effect.die("must not inspect GitHub credentials for GitLab"),
+      },
+      {},
+      {},
+      {},
+      {},
+      {},
+      {
+        hasCredentials: () => Effect.succeed(true),
+      },
+    )
+
+    const response = await createGraphqlApi(runtime).fetch(
+      graphqlRequest({
+        query: `query {
+          repositoryCredentials { repositoryId configured }
+        }`,
+      }),
+    )
+
+    expect(await response.json()).toEqual({
+      data: {
+        repositoryCredentials: [
+          {
+            repositoryId: repository.id,
+            configured: true,
+          },
+        ],
+      },
+    })
   })
 
   test("pullRequestCount uses GitHub open non-draft PRs including external ones", async () => {

--- a/packages/graphql-api/tsconfig.lib.json
+++ b/packages/graphql-api/tsconfig.lib.json
@@ -29,6 +29,9 @@
       "path": "../github-service/tsconfig.lib.json"
     },
     {
+      "path": "../gitlab-service/tsconfig.lib.json"
+    },
+    {
       "path": "../db-service/tsconfig.lib.json"
     },
     {

--- a/packages/graphql-schema/schema.graphql
+++ b/packages/graphql-schema/schema.graphql
@@ -263,6 +263,14 @@ type Repository {
   pullRequestCount: Int!
 }
 
+type LocalRepositoryInspection {
+  forge: String!
+  forgeHost: String!
+  projectPath: String!
+  localPath: String!
+  isBare: Boolean!
+}
+
 type RepositoryCredential {
   repositoryId: ID!
   configured: Boolean!
@@ -442,6 +450,9 @@ input UpdateConfigInput {
 
 input UpdateRepositorySettingsInput {
   repositoryId: ID!
+  forge: String
+  forgeHost: String
+  projectPath: String
   paused: Boolean!
   """
   Set the Repository Agent Backend override, pass null to clear (inherit
@@ -470,6 +481,7 @@ type Mutation {
   deep server module.
   """
   addLocalRepository(path: String!): Repository!
+  inspectLocalRepository(path: String!): LocalRepositoryInspection!
   """
   Open a native OS folder dialog on the Harness host. Returns the absolute
   path, or null when the user cancels or no dialog tool is available.

--- a/packages/issue-reconciler/src/lib/issue-reconciler.ts
+++ b/packages/issue-reconciler/src/lib/issue-reconciler.ts
@@ -12,6 +12,11 @@ import {
   GitHubService,
   type ReadyLabeledIssue,
 } from "@ready-for-agent/github-service"
+import {
+  type GitLabProjectUnavailableError,
+  type GitLabRequestError,
+  GitLabService,
+} from "@ready-for-agent/gitlab-service"
 
 export const ReconciliationSummary = Schema.Struct({
   fetched: Schema.Int.pipe(Schema.check(Schema.isGreaterThanOrEqualTo(0))),
@@ -46,6 +51,8 @@ export class ReconciliationMutationError extends Schema.TaggedErrorClass<Reconci
 export type ReconciliationError =
   | GitHubRepositoryUnavailableError
   | GitHubRequestError
+  | GitLabProjectUnavailableError
+  | GitLabRequestError
   | ReconciliationMutationError
   | RepositoryNotFoundError
   | DatabaseError
@@ -83,9 +90,10 @@ const matches = (local: IssueRecord, remote: ReadyLabeledIssue): boolean =>
 
 const isActiveClosingPullRequest = (
   pullRequest: ReadyLabeledIssue["closingPullRequests"][number],
+  forge: RepositoryRecord["forge"],
 ): boolean =>
   pullRequest.state === "MERGED" ||
-  (pullRequest.state === "OPEN" && !pullRequest.isDraft)
+  (pullRequest.state === "OPEN" && (forge === "gitlab" || !pullRequest.isDraft))
 
 const matchesOperatorAuthor = (
   issueAuthor: string | null,
@@ -96,6 +104,7 @@ const matchesOperatorAuthor = (
 
 const isRelevant = (
   issue: ReadyLabeledIssue,
+  forge: RepositoryRecord["forge"],
   repositoryName: string,
   workItemPullRequestNumbers: ReadonlySet<number>,
   authorScope:
@@ -103,20 +112,25 @@ const isRelevant = (
     | { readonly includeAll: false; readonly operatorLogin: string },
 ): boolean => {
   const activeClosingPullRequests = issue.closingPullRequests.filter(
-    isActiveClosingPullRequest,
+    (pullRequest) => isActiveClosingPullRequest(pullRequest, forge),
   )
-  const hierarchyAndClosingPrs =
-    issue.hierarchySupported &&
-    (issue.parent === null
+  const supportedStructure = issue.hierarchySupported
+    ? issue.parent === null
       ? issue.state === "OPEN"
-      : issue.parent.state === "OPEN" && issue.parent.isReadyLabeled) &&
+      : issue.parent.state === "OPEN" && issue.parent.isReadyLabeled
+    : forge === "gitlab" &&
+      issue.state === "OPEN" &&
+      issue.parent === null &&
+      !issue.hasChildren
+  const structureAndClosingPrs =
+    supportedStructure &&
     (activeClosingPullRequests.length === 0 ||
       activeClosingPullRequests.some(
         (pullRequest) =>
           pullRequest.repository.toLowerCase() === repositoryName &&
           workItemPullRequestNumbers.has(pullRequest.number),
       ))
-  if (!hierarchyAndClosingPrs) {
+  if (!structureAndClosingPrs) {
     return false
   }
   if (authorScope.includeAll) {
@@ -130,11 +144,12 @@ export const IssueReconcilerLive = Layer.effect(
   Effect.gen(function* () {
     const db = yield* DbService
     const github = yield* GitHubService
+    const gitlab = yield* GitLabService
 
     const reconcile = Effect.fn("IssueReconciler.reconcile")(function* (
       repository: RepositoryRecord,
     ) {
-      const githubRepository = {
+      const forgeRepository = {
         forge: repository.forge,
         forgeHost: repository.forgeHost,
         projectPath: repository.projectPath,
@@ -143,14 +158,15 @@ export const IssueReconcilerLive = Layer.effect(
       const workItemPullRequests = yield* db.listWorkItemPullRequests(
         repository.id,
       )
+      const issueSource = repository.forge === "gitlab" ? gitlab : github
       const authorScope = repository.includeAllIssueAuthors
         ? ({ includeAll: true } as const)
         : ({
             includeAll: false,
             operatorLogin:
-              yield* github.getAuthenticatedUserLogin(githubRepository),
+              yield* issueSource.getAuthenticatedUserLogin(forgeRepository),
           } as const)
-      const remoteIssues = yield* github.listReadyIssues(githubRepository)
+      const remoteIssues = yield* issueSource.listReadyIssues(forgeRepository)
       const repositoryName = repository.projectPath.toLowerCase()
 
       const localByNumber = new Map(
@@ -172,6 +188,7 @@ export const IssueReconcilerLive = Layer.effect(
           .filter((issue) =>
             isRelevant(
               issue,
+              repository.forge,
               repositoryName,
               workItemPullRequestsByIssue.get(issue.number) ?? new Set(),
               authorScope,

--- a/packages/issue-reconciler/test/issue-reconciler.spec.ts
+++ b/packages/issue-reconciler/test/issue-reconciler.spec.ts
@@ -16,6 +16,10 @@ import {
   type ReadyLabeledIssue,
 } from "@ready-for-agent/github-service"
 import {
+  GitLabService,
+  type GitLabServiceShape,
+} from "@ready-for-agent/gitlab-service"
+import {
   IssueReconciler,
   IssueReconcilerLive,
   ReconciliationMutationError,
@@ -201,22 +205,139 @@ const makeGitHubLayer = (
     },
   } satisfies GitHubServiceShape)
 
+const defaultGitLabLayer = Layer.succeed(GitLabService, {
+  verifyProject: () => Effect.void,
+  getAuthenticatedUserLogin: () => Effect.succeed("operator"),
+  listReadyIssues: () => Effect.succeed([]),
+  hasCredentials: () => Effect.succeed(true),
+} satisfies GitLabServiceShape)
+
 const runReconciliation = <A, E>(
   effect: Effect.Effect<A, E, IssueReconciler>,
   dbLayer: Layer.Layer<DbService>,
   githubLayer: Layer.Layer<GitHubService>,
+  gitlabLayer: Layer.Layer<GitLabService> = defaultGitLabLayer,
 ): Promise<A> =>
   Effect.runPromise(
     effect.pipe(
       Effect.provide(
         IssueReconcilerLive.pipe(
-          Layer.provide(Layer.merge(dbLayer, githubLayer)),
+          Layer.provide(Layer.mergeAll(dbLayer, githubLayer, gitlabLayer)),
         ),
       ),
     ),
   )
 
 describe("IssueReconciler", () => {
+  it("reconciles GitLab standalone Issues and honors closing-PR ownership", () => {
+    const gitlabRepository = makeRepositoryRecord({
+      id: "repo-1",
+      forge: "gitlab",
+      forgeHost: "git.drupalcode.org",
+      projectPath: "project/oauth_client",
+      includeAllIssueAuthors: true,
+    })
+    const db = makeDbFixture({
+      issues: [],
+      workItemPullRequests: [{ issueNumber: 5, pullRequestNumber: 105 }],
+    })
+    const issues = [
+      remoteIssue(1, {
+        hierarchySupported: false,
+        blockedBy: [
+          {
+            number: 99,
+            url: "https://git.drupalcode.org/project/oauth_client/-/issues/99",
+          },
+        ],
+      }),
+      remoteIssue(2, {
+        hierarchySupported: false,
+        closingPullRequests: [
+          {
+            number: 102,
+            repository: "project/oauth_client",
+            state: "OPEN",
+            isDraft: true,
+          },
+        ],
+      }),
+      remoteIssue(3, {
+        hierarchySupported: false,
+        closingPullRequests: [
+          {
+            number: 103,
+            repository: "project/oauth_client",
+            state: "MERGED",
+            isDraft: false,
+          },
+        ],
+      }),
+      remoteIssue(4, {
+        hierarchySupported: false,
+        closingPullRequests: [
+          {
+            number: 104,
+            repository: "project/oauth_client",
+            state: "CLOSED",
+            isDraft: false,
+          },
+        ],
+      }),
+      remoteIssue(5, {
+        hierarchySupported: false,
+        closingPullRequests: [
+          {
+            number: 105,
+            repository: "project/oauth_client",
+            state: "OPEN",
+            isDraft: true,
+          },
+        ],
+      }),
+    ]
+    const gitlab = Layer.succeed(GitLabService, {
+      verifyProject: () => Effect.void,
+      getAuthenticatedUserLogin: () => Effect.succeed("operator"),
+      listReadyIssues: ({ projectPath }) =>
+        Effect.sync(() => {
+          db.actions.push(`gitlab:${projectPath}`)
+          return issues
+        }),
+      hasCredentials: () => Effect.succeed(true),
+    } satisfies GitLabServiceShape)
+    const github = makeGitHubLayer([], db.actions)
+
+    return runReconciliation(
+      Effect.gen(function* () {
+        const reconciler = yield* IssueReconciler
+        const summary = yield* reconciler.reconcile(gitlabRepository)
+
+        expect(summary).toEqual({
+          fetched: 5,
+          inserted: 3,
+          updated: 0,
+          deleted: 0,
+          unchanged: 0,
+        })
+        expect(db.stored.map(({ issueNumber }) => issueNumber)).toEqual([
+          1, 4, 5,
+        ])
+        expect(db.stored[0]?.blockedBy).toEqual([
+          {
+            issueNumber: 99,
+            issueUrl:
+              "https://git.drupalcode.org/project/oauth_client/-/issues/99",
+          },
+        ])
+        expect(db.actions).toContain("gitlab:project/oauth_client")
+      }),
+      db.layer,
+      github,
+      gitlab,
+    )
+  })
+
   it("classifies changes, writes by issue number, and records success", () => {
     const db = makeDbFixture({
       issues: [

--- a/packages/local-git/src/index.ts
+++ b/packages/local-git/src/index.ts
@@ -1,4 +1,5 @@
 export * from "./lib/directory-picker.js"
 export * from "./lib/local-git.js"
+export * from "./lib/parse-forge-remote.js"
 export * from "./lib/parse-github-remote.js"
 export * from "./lib/types.js"

--- a/packages/local-git/src/lib/local-git.ts
+++ b/packages/local-git/src/lib/local-git.ts
@@ -9,7 +9,7 @@ import {
 } from "effect"
 import type { PlatformError } from "effect/PlatformError"
 import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process"
-import { parseGitHubRemote } from "./parse-github-remote.js"
+import { parseForgeRemote } from "./parse-forge-remote.js"
 import type { LocalRepository } from "./types.js"
 
 export class PathNotFound extends Schema.TaggedErrorClass<PathNotFound>()(
@@ -39,12 +39,12 @@ export class NotAGitRepository extends Schema.TaggedErrorClass<NotAGitRepository
   }
 }
 
-export class NoGitHubRemote extends Schema.TaggedErrorClass<NoGitHubRemote>()(
-  "NoGitHubRemote",
+export class NoForgeRemote extends Schema.TaggedErrorClass<NoForgeRemote>()(
+  "NoForgeRemote",
   { path: Schema.String },
 ) {
   override get message() {
-    return `No GitHub remote found for: ${this.path}`
+    return `No supported Forge remote found for: ${this.path}`
   }
 }
 
@@ -52,7 +52,7 @@ export type LocalGitError =
   | PathNotFound
   | NotADirectory
   | NotAGitRepository
-  | NoGitHubRemote
+  | NoForgeRemote
   | PlatformError
 
 export class LocalGit extends Context.Service<
@@ -128,7 +128,13 @@ export class LocalGit extends Context.Service<
                   const line = output
                     .split("\n")
                     .map((entry) => entry.trim())
-                    .find((entry) => entry.includes("github.com"))
+                    .find((entry) => {
+                      const candidate = entry.split(/\s+/)[1]
+                      return (
+                        candidate !== undefined &&
+                        Option.isSome(parseForgeRemote(candidate))
+                      )
+                    })
                   if (!line) {
                     return undefined
                   }
@@ -137,18 +143,18 @@ export class LocalGit extends Context.Service<
               )
 
         if (!remoteUrl) {
-          return yield* new NoGitHubRemote({ path: localPath })
+          return yield* new NoForgeRemote({ path: localPath })
         }
 
-        const github = parseGitHubRemote(remoteUrl)
-        if (Option.isNone(github)) {
-          return yield* new NoGitHubRemote({ path: localPath })
+        const forge = parseForgeRemote(remoteUrl)
+        if (Option.isNone(forge)) {
+          return yield* new NoForgeRemote({ path: localPath })
         }
 
         return {
-          forge: "github" as const,
-          forgeHost: "github.com" as const,
-          projectPath: `${github.value.owner}/${github.value.repo}`,
+          forge: forge.value.forge,
+          forgeHost: forge.value.forgeHost,
+          projectPath: forge.value.projectPath,
           localPath,
           isBare,
           paused: true as const,

--- a/packages/local-git/src/lib/parse-forge-remote.ts
+++ b/packages/local-git/src/lib/parse-forge-remote.ts
@@ -1,0 +1,64 @@
+import { Option } from "effect"
+import { parseGitHubRemote } from "./parse-github-remote.js"
+import type { ForgeRemote } from "./types.js"
+
+const normalizeProjectPath = (value: string): string =>
+  value
+    .replace(/^\/+/, "")
+    .replace(/\/+$/, "")
+    .replace(/\.git$/, "")
+
+const parseScpRemote = (
+  value: string,
+): { readonly host: string; readonly path: string } | undefined => {
+  if (value.includes("://")) return undefined
+  const match = /^(?:[^@/\s]+@)?([^:/\s]+):(.+)$/.exec(value)
+  if (match?.[1] === undefined || match[2] === undefined) return undefined
+  return { host: match[1], path: match[2] }
+}
+
+const parseUrlRemote = (
+  value: string,
+): { readonly host: string; readonly path: string } | undefined => {
+  try {
+    const url = new URL(value)
+    if (!["http:", "https:", "ssh:", "git:"].includes(url.protocol)) {
+      return undefined
+    }
+    return { host: url.hostname, path: url.pathname }
+  } catch {
+    return undefined
+  }
+}
+
+/**
+ * Guess Forge identity from a clone remote. GitHub spellings retain the
+ * canonical github.com identity; every other network git host is a GitLab
+ * guess that must be verified (and may be corrected) before persistence.
+ */
+export const parseForgeRemote = (
+  remoteUrl: string,
+): Option.Option<ForgeRemote> => {
+  const value = remoteUrl.trim()
+  const github = parseGitHubRemote(value)
+  if (Option.isSome(github)) {
+    return Option.some({
+      forge: "github",
+      forgeHost: "github.com",
+      projectPath: `${github.value.owner}/${github.value.repo}`,
+    })
+  }
+
+  const parsed = parseScpRemote(value) ?? parseUrlRemote(value)
+  if (parsed === undefined) return Option.none()
+  const forgeHost = parsed.host.toLowerCase().replace(/^www\./, "")
+  const projectPath = normalizeProjectPath(parsed.path)
+  if (
+    forgeHost.length === 0 ||
+    !projectPath.includes("/") ||
+    projectPath.split("/").some((segment) => segment.length === 0)
+  ) {
+    return Option.none()
+  }
+  return Option.some({ forge: "gitlab", forgeHost, projectPath })
+}

--- a/packages/local-git/src/lib/types.ts
+++ b/packages/local-git/src/lib/types.ts
@@ -1,6 +1,6 @@
 export interface LocalRepository {
-  readonly forge: "github"
-  readonly forgeHost: "github.com"
+  readonly forge: "github" | "gitlab"
+  readonly forgeHost: string
   readonly projectPath: string
   readonly localPath: string
   readonly isBare: boolean
@@ -10,4 +10,10 @@ export interface LocalRepository {
 export type GitHubRemote = {
   readonly owner: string
   readonly repo: string
+}
+
+export type ForgeRemote = {
+  readonly forge: "github" | "gitlab"
+  readonly forgeHost: string
+  readonly projectPath: string
 }

--- a/packages/local-git/test/local-git.test.ts
+++ b/packages/local-git/test/local-git.test.ts
@@ -62,6 +62,50 @@ describe("LocalGit.inspect", () => {
     expect(inspected.localPath).toContain("repo")
   })
 
+  test("guesses GitLab identity from a nested-project SSH remote", async () => {
+    const repoDir = join(tempRoot, "gitlab-repo")
+    mkdirSync(repoDir)
+    const git = (args: string[]) =>
+      spawnSync("git", args, { cwd: repoDir, encoding: "utf8" })
+    expect(git(["init"]).status).toBe(0)
+    expect(
+      git([
+        "remote",
+        "add",
+        "origin",
+        "git@git.drupalcode.org:project/oauth_client.git",
+      ]).status,
+    ).toBe(0)
+
+    const inspected = await runInspect(repoDir)
+    expect(inspected).toMatchObject({
+      forge: "gitlab",
+      forgeHost: "git.drupalcode.org",
+      projectPath: "project/oauth_client",
+      isBare: false,
+      paused: true,
+    })
+  })
+
+  test("keeps an SSH alias as a correctable GitLab Forge Host guess", async () => {
+    const repoDir = join(tempRoot, "gitlab-alias")
+    mkdirSync(repoDir)
+    const git = (args: string[]) =>
+      spawnSync("git", args, { cwd: repoDir, encoding: "utf8" })
+    expect(git(["init"]).status).toBe(0)
+    expect(
+      git(["remote", "add", "origin", "git@git.drupal.org:project/mod.git"])
+        .status,
+    ).toBe(0)
+
+    const inspected = await runInspect(repoDir)
+    expect(inspected).toMatchObject({
+      forge: "gitlab",
+      forgeHost: "git.drupal.org",
+      projectPath: "project/mod",
+    })
+  })
+
   test("fails when path does not exist", async () => {
     const error = await runInspectFail(join(tempRoot, "missing"))
     expect(error._tag).toBe("PathNotFound")
@@ -74,18 +118,15 @@ describe("LocalGit.inspect", () => {
     expect(error._tag).toBe("NotAGitRepository")
   })
 
-  test("fails when git repo has no GitHub remote", async () => {
+  test("fails when git repo has no supported Forge remote", async () => {
     const repoDir = join(tempRoot, "no-gh")
     mkdirSync(repoDir)
     const git = (args: string[]) =>
       spawnSync("git", args, { cwd: repoDir, encoding: "utf8" })
     expect(git(["init"]).status).toBe(0)
-    expect(
-      git(["remote", "add", "origin", "git@gitlab.com:acme/widgets.git"])
-        .status,
-    ).toBe(0)
+    expect(git(["remote", "add", "origin", "../widgets.git"]).status).toBe(0)
 
     const error = await runInspectFail(repoDir)
-    expect(error._tag).toBe("NoGitHubRemote")
+    expect(error._tag).toBe("NoForgeRemote")
   })
 })

--- a/packages/local-git/test/parse-forge-remote.test.ts
+++ b/packages/local-git/test/parse-forge-remote.test.ts
@@ -1,0 +1,64 @@
+import { Option } from "effect"
+import { parseForgeRemote } from "../src/lib/parse-forge-remote.js"
+import { describe, expect, test } from "bun:test"
+
+const expectRemote = (
+  url: string,
+  expected: {
+    readonly forge: "github" | "gitlab"
+    readonly forgeHost: string
+    readonly projectPath: string
+  },
+): void => {
+  const result = parseForgeRemote(url)
+  expect(Option.isSome(result)).toBe(true)
+  if (Option.isSome(result)) {
+    expect(result.value).toEqual(expected)
+  }
+}
+
+describe("parseForgeRemote", () => {
+  test("recognizes GitHub spellings", () => {
+    expectRemote("git@github.com:owner/repo.git", {
+      forge: "github",
+      forgeHost: "github.com",
+      projectPath: "owner/repo",
+    })
+    expectRemote("https://github.com/owner/repo", {
+      forge: "github",
+      forgeHost: "github.com",
+      projectPath: "owner/repo",
+    })
+  })
+
+  test("recognizes GitLab nested project paths", () => {
+    expectRemote("git@gitlab.example:group/nested/project.git", {
+      forge: "gitlab",
+      forgeHost: "gitlab.example",
+      projectPath: "group/nested/project",
+    })
+    expectRemote("https://gitlab.example/group/nested/project.git", {
+      forge: "gitlab",
+      forgeHost: "gitlab.example",
+      projectPath: "group/nested/project",
+    })
+    expectRemote("ssh://git@gitlab.example/group/nested/project.git", {
+      forge: "gitlab",
+      forgeHost: "gitlab.example",
+      projectPath: "group/nested/project",
+    })
+  })
+
+  test("treats non-GitHub network hosts as correctable GitLab guesses", () => {
+    expectRemote("git@bitbucket.org:owner/repo.git", {
+      forge: "gitlab",
+      forgeHost: "bitbucket.org",
+      projectPath: "owner/repo",
+    })
+  })
+
+  test("rejects local and malformed remotes", () => {
+    expect(Option.isNone(parseForgeRemote("../owner/repo.git"))).toBe(true)
+    expect(Option.isNone(parseForgeRemote("not-a-url"))).toBe(true)
+  })
+})

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -68,6 +68,9 @@
     },
     {
       "path": "./packages/release-versioning"
+    },
+    {
+      "path": "./packages/gitlab-service"
     }
   ]
 }


### PR DESCRIPTION
## Why

Ready for Agent could represent Forge identity but could not ingest work from
GitLab projects. This adds the issue-source phase of GitLab support, including
self-managed instances whose clone hostname differs from their API hostname.

## What changed

- Detect GitLab remotes, including nested Project Paths, and let operators
  confirm or correct Forge identity through the UI, CLI, and Repository
  settings.
- Verify GitLab projects before persistence and reject unknown identities with
  actionable errors.
- Resolve ambient authentication from `GITLAB_TOKEN`, falling back to per-host
  `glab` authentication.
- Add a GitLab REST v4 adapter with pagination, schema validation, timeouts,
  and injected-fetch tests.
- Reconcile open `ready-for-agent` Issues, Issue Authors, `Blocked by: #n`
  dependencies, and closing merge requests.
- Preserve closing-PR ownership semantics: open or merged MRs hide Issues
  unless harness-owned, while closed-unmerged MRs are ignored.
- Include credentialed GitLab Repositories in scheduled polling even while
  Paused.
- Prevent Forge identity changes after any Work Item exists while allowing
  case-only Project Path display corrections without API or polling churn.

## Verification

- Full affected test run passed across 20 projects.
- DbService: 53 tests passed.
- GraphQL API: 100 tests passed.
- Affected lint, typecheck, Nx sync, formatting, and `git diff --check` passed.
- A real-PAT probe against the Drupal GitLab issue-links endpoint returned
  HTTP 200 with no native links; the implementation therefore uses the
  specified body-based blocker convention.

## Scope

This change intentionally implements GitLab issue-source support only. Later
GitLab pull-request lifecycle, pipeline, merge, and close operations remain
outside this phase.

Closes #566