### PR TITLE
test(harness): cover kanban route in live e2e

### DIFF
--- a/apps/harness/README.md
+++ b/apps/harness/README.md
@@ -69,11 +69,10 @@ without wrapping the Harness in a second coordinator process.
 
 ## Live end-to-end
 
-One Gherkin operator journey (`e2e/features/add-and-refresh-repository.feature`)
-runs the production build against a fresh isolated Harness database, clones the
-private End-to-End Fixture Repository through Keymaxxer, adds it with the real
-operator binary, and waits for credential activation's automatic first Refresh
-Job.
+The Gherkin operator journeys under `e2e/features/` run the production build
+against a fresh isolated Harness database. They verify adding and refreshing
+the private End-to-End Fixture Repository through the real operator binary, as
+well as the dedicated Kanban pipeline route.
 
 ```bash
 bunx nx run harness:e2e

--- a/apps/harness/e2e/features/kanban-route.feature
+++ b/apps/harness/e2e/features/kanban-route.feature
@@ -1,0 +1,10 @@
+Feature: View the work pipeline
+  Operators use the dedicated Kanban route to monitor delivery without
+  repository management competing with the pipeline.
+
+  Scenario: View the empty work pipeline
+    When I navigate to the Kanban board
+    Then all six pipeline lane headers are visible
+    And the Pipeline jobs tab is active
+    And repository management is not rendered
+    And the committed pull request totals are visible above the board

--- a/apps/harness/e2e/steps/kanban-route.ts
+++ b/apps/harness/e2e/steps/kanban-route.ts
@@ -1,0 +1,89 @@
+import { expect } from "@playwright/test"
+import { Then, When } from "./fixtures.ts"
+
+const PIPELINE_LANE_HEADERS = [
+  "Queue",
+  "Build",
+  "Review",
+  "Ship",
+  "Attention",
+  "Complete",
+] as const
+
+const COMMITTED_PULL_REQUEST_PERIODS = [
+  "Today",
+  "Yesterday",
+  "This week",
+  "Last week",
+] as const
+
+When("I navigate to the Kanban board", async ({ page }) => {
+  await page.goto("/kanban")
+  await expect(page).toHaveURL(/\/kanban$/)
+
+  // The isolated E2E database has no default build model, so first-run
+  // Settings opens automatically. Dismiss it to exercise the route beneath.
+  const settingsDialog = page.getByRole("dialog", {
+    name: "Harness settings",
+  })
+  await expect(settingsDialog).toBeVisible()
+  await settingsDialog.getByRole("button", { name: "Cancel" }).click()
+  await expect(settingsDialog).toBeHidden()
+})
+
+Then("all six pipeline lane headers are visible", async ({ page }) => {
+  const pipeline = page.getByRole("region", { name: "Lifecycle pipeline" })
+  await expect(pipeline).toBeVisible()
+
+  for (const lane of PIPELINE_LANE_HEADERS) {
+    await expect(
+      pipeline.getByRole("heading", { name: lane, exact: true }),
+    ).toBeVisible()
+  }
+})
+
+Then("the Pipeline jobs tab is active", async ({ page }) => {
+  await expect(
+    page.getByRole("tab", { name: "Pipeline", exact: true }),
+  ).toHaveAttribute("aria-selected", "true")
+})
+
+Then("repository management is not rendered", async ({ page }) => {
+  await expect(
+    page.getByRole("region", { name: "Configured repositories" }),
+  ).toHaveCount(0)
+  await expect(
+    page.getByRole("region", { name: "Add a repository" }),
+  ).toHaveCount(0)
+  await expect(
+    page.getByRole("heading", { name: "No repositories configured" }),
+  ).toHaveCount(0)
+})
+
+Then(
+  "the committed pull request totals are visible above the board",
+  async ({ page }) => {
+    const dashboard = page.getByRole("region", {
+      name: "Committed pull requests",
+    })
+    const pipeline = page.getByRole("region", { name: "Lifecycle pipeline" })
+    await expect(dashboard).toBeVisible()
+
+    for (const period of COMMITTED_PULL_REQUEST_PERIODS) {
+      const periodLabel = dashboard.getByText(period, { exact: true })
+      await expect(periodLabel).toBeVisible()
+      await expect(periodLabel.locator("..").getByText(/^\d+$/)).toBeVisible()
+    }
+
+    const dashboardBox = await dashboard.boundingBox()
+    const pipelineBox = await pipeline.boundingBox()
+    if (dashboardBox === null || pipelineBox === null) {
+      throw new Error(
+        "Expected the dashboard and pipeline to have layout boxes",
+      )
+    }
+    expect(dashboardBox.y + dashboardBox.height).toBeLessThanOrEqual(
+      pipelineBox.y,
+    )
+  },
+)

--- a/apps/harness/src/routes/kanban.tsx
+++ b/apps/harness/src/routes/kanban.tsx
@@ -317,12 +317,7 @@ function KanbanJobsBoard() {
   )
 
   if (loading && activeItems.length === 0) {
-    return (
-      <>
-        <KanbanLiveUpdates repositoryIds={repositoryIds} />
-        <JobsCardSkeleton />
-      </>
-    )
+    return <JobsCardSkeleton />
   }
 
   if (failed) {

--- a/apps/harness/test/kanban-route.test.ts
+++ b/apps/harness/test/kanban-route.test.ts
@@ -88,6 +88,21 @@ describe("/kanban route", () => {
     expect(source).not.toContain("refetchInterval")
   })
 
+  test("starts live invalidation after the initial board queries settle", () => {
+    const source = kanbanSource()
+    const loadingBranch = source.slice(
+      source.indexOf("if (loading && activeItems.length === 0)"),
+      source.indexOf("if (failed)"),
+    )
+    expect(loadingBranch).toContain("<JobsCardSkeleton />")
+    expect(loadingBranch).not.toContain("<KanbanLiveUpdates")
+
+    const settledBranch = source.slice(
+      source.indexOf("return (\n    <article>"),
+    )
+    expect(settledBranch).toContain("<KanbanLiveUpdates")
+  })
+
   test("ports the six-column industrial board and responsive lane selector", () => {
     const source = stylesSource()
     expect(source).toContain(".pipeline-board")


### PR DESCRIPTION
## Why

The dedicated Kanban route needed live browser coverage for its routing, pipeline layout,
default state, repository-management boundary, and committed pull-request summary.

## What changed

- Added a Playwright BDD scenario that navigates to `/kanban` and verifies all six lifecycle
  lanes, the active Pipeline tab, absence of repository-management UI, and committed
  pull-request totals above the board.
- Deferred Kanban live-query invalidation until the initial board queries settle, preventing
  the live subscription from repeatedly invalidating the first load.
- Added regression coverage for the subscription timing and updated the Harness E2E
  documentation.

## Verification

- `bunx nx run-many -t lint typecheck test -p harness` — passed (246 tests).
- The new Kanban E2E scenario passed both in isolation and in combined live-Harness runs.
- `git diff --check` — passed.

## Limitation

The complete E2E suite did not finish cleanly because the existing add-and-refresh scenario
twice timed out waiting for its external GitHub sentinel issue. The new Kanban scenario passed
during those runs.

Closes #578