### PR TITLE
fix(harness): strengthen mobile kanban lane controls

### DIFF
--- a/apps/harness/src/routes/kanban.tsx
+++ b/apps/harness/src/routes/kanban.tsx
@@ -409,6 +409,7 @@ function KanbanJobsBoard() {
                   type="button"
                   className="lane-switch"
                   aria-pressed={mobileLane === lane.id}
+                  aria-controls={`lane-panel-${lane.id}`}
                   key={lane.id}
                   onClick={() => setMobileLane(lane.id)}
                 >
@@ -424,6 +425,7 @@ function KanbanJobsBoard() {
                   <section
                     className="pipeline-lane"
                     data-mobile-active={mobileLane === lane.id}
+                    id={`lane-panel-${lane.id}`}
                     key={lane.id}
                     aria-labelledby={`lane-${lane.id}`}
                   >

--- a/apps/harness/test/kanban-route.test.ts
+++ b/apps/harness/test/kanban-route.test.ts
@@ -103,14 +103,48 @@ describe("/kanban route", () => {
     expect(settledBranch).toContain("<KanbanLiveUpdates")
   })
 
-  test("ports the six-column industrial board and responsive lane selector", () => {
-    const source = stylesSource()
-    expect(source).toContain(".pipeline-board")
-    expect(source).toContain("grid-template-columns: repeat(6, minmax(0, 1fr))")
-    expect(source).toContain(".lane-header")
-    expect(source).toContain("position: sticky")
-    expect(source).toContain(".job-ticket")
-    expect(source).toContain("@media (max-width: 900px)")
-    expect(source).toContain("grid-template-columns: repeat(3, minmax(0, 1fr))")
+  test("renders an accessible mobile lane selector controlling one selected lane", () => {
+    const source = kanbanSource()
+    expect(source).toContain('useState<PipelineLaneId>("queue")')
+    expect(source).toContain('<fieldset className="lane-switcher">')
+    expect(source).toContain("aria-pressed={mobileLane === lane.id}")
+    expect(source).toMatch(/aria-controls=\{`lane-panel-\$\{lane\.id\}`\}/)
+    expect(source).toContain("onClick={() => setMobileLane(lane.id)}")
+    expect(source).toContain("data-mobile-active={mobileLane === lane.id}")
+    expect(source).toMatch(/id=\{`lane-panel-\$\{lane\.id\}`\}/)
+  })
+
+  test("keeps the six-column board and sticky lane headers on desktop", () => {
+    const desktopStyles = stylesSource().split("@media (max-width: 900px)")[0]
+    expect(desktopStyles).toContain(".pipeline-board")
+    expect(desktopStyles).toContain(
+      "grid-template-columns: repeat(6, minmax(0, 1fr))",
+    )
+    expect(desktopStyles).toContain(".lane-header")
+    expect(desktopStyles).toContain("position: sticky")
+    expect(desktopStyles).toContain(".job-ticket")
+    expect(desktopStyles).toContain(".lane-switcher")
+    expect(desktopStyles).toContain("display: none")
+  })
+
+  test("uses a touch-scrollable repository row and three-column lane selector on mobile", () => {
+    const mobileStyles = stylesSource().split("@media (max-width: 900px)")[1]
+    expect(mobileStyles).toBeDefined()
+    expect(mobileStyles).toContain(".repository-filters")
+    expect(mobileStyles).toContain("flex-wrap: nowrap")
+    expect(mobileStyles).toContain("overflow-x: auto")
+    expect(mobileStyles).toContain("touch-action: pan-x")
+    expect(mobileStyles).toContain(".lane-switcher")
+    expect(mobileStyles).toContain("display: grid")
+    expect(mobileStyles).toContain(
+      "grid-template-columns: repeat(3, minmax(0, 1fr))",
+    )
+    expect(mobileStyles).toContain(".pipeline-lane")
+    expect(mobileStyles).toContain("display: none")
+    expect(mobileStyles).toMatch(
+      /\.pipeline-lane\[data-mobile-active="true"\]\s*\{\s*display: block;\s*\}/,
+    )
+    expect(mobileStyles).toContain(".lane-header")
+    expect(mobileStyles).toContain("position: static")
   })
 })


### PR DESCRIPTION
## Why

The responsive Kanban behavior inherited from the desktop-board work lacked focused coverage for
its mobile selector, selected-lane state, touch-scrollable filters, and desktop/mobile layout
boundaries. The lane buttons also did not explicitly identify the panels they control.

## What changed

- Link each mobile lane-selector button to its corresponding lane panel with `aria-controls` and
  stable panel IDs.
- Add focused route tests for selector presence, `aria-pressed`, lane selection wiring, and
  controlled panel IDs.
- Cover the three-column mobile selector, touch-scrollable repository filters, single active lane,
  and non-sticky mobile headers.
- Preserve coverage for the six-column desktop board and sticky lane headers.
- Tighten the active-lane CSS assertion so unrelated `display: block` rules cannot produce a false
  positive.

## Verification

- `bunx nx run-many -t test,typecheck,lint -p harness --parallel=3 --outputStyle=static`
- 252 Harness tests passed.
- Harness typecheck and lint passed.
- `git diff --check` passed.

## Limitations

The responsive checks follow the repository's existing source-level structural test style; this
change does not add browser-level viewport tests.

Closes #577