### PR TITLE
fix(harness): scope authentication resources to runtime

### DIFF
--- a/apps/harness/src/server/ambient-github-layer.ts
+++ b/apps/harness/src/server/ambient-github-layer.ts
@@ -29,6 +29,7 @@ export const ambientGitHubLayer = (options: {
     GitHubService,
     Effect.gen(function* () {
       const spawner = yield* ChildProcessSpawner.ChildProcessSpawner
+      const layerScope = yield* Effect.scope
       const makeService = options.makeService ?? makeGitHubServiceFromToken
       const tokenCache = yield* Ref.make<
         Deferred.Deferred<string, GitHubRequestError> | undefined
@@ -98,7 +99,7 @@ export const ambientGitHubLayer = (options: {
                   ),
                 ),
               ),
-              Effect.forkDetach({ startImmediately: true }),
+              Effect.forkIn(layerScope, { startImmediately: true }),
             )
           }
 

--- a/apps/harness/src/server/ambient-gitlab-layer.ts
+++ b/apps/harness/src/server/ambient-gitlab-layer.ts
@@ -32,6 +32,7 @@ export const ambientGitLabLayer = (options: {
     GitLabService,
     Effect.gen(function* () {
       const spawner = yield* ChildProcessSpawner.ChildProcessSpawner
+      const layerScope = yield* Effect.scope
       const makeService = options.makeService ?? makeGitLabServiceFromToken
       const makeAnonymousService =
         options.makeAnonymousService ?? (() => makeGitLabService({}))
@@ -135,7 +136,7 @@ export const ambientGitLabLayer = (options: {
                 ),
               ),
             ),
-            Effect.forkDetach({ startImmediately: true }),
+            Effect.forkIn(layerScope, { startImmediately: true }),
           )
         }
 

--- a/apps/harness/src/server/application.server.ts
+++ b/apps/harness/src/server/application.server.ts
@@ -30,6 +30,7 @@ import { Grok, GrokSessionTelemetryLive } from "@ready-for-agent/grok"
 import { IssueReconcilerLive } from "@ready-for-agent/issue-reconciler"
 import {
   KeymaxxerService,
+  type SidecarLayerOptions,
   disabledKeymaxxerLayer,
   sidecarKeymaxxerLayer,
 } from "@ready-for-agent/keymaxxer-service"
@@ -60,6 +61,7 @@ export interface Application {
 
 export interface CreateApplicationOptions {
   readonly startWorker?: boolean
+  readonly sidecarLayerOptions?: SidecarLayerOptions
 }
 
 type PlatformServices =
@@ -146,7 +148,7 @@ export const createApplication = async (
   const keymaxxerLayer =
     sidecarUrl === undefined
       ? disabledKeymaxxerLayer
-      : sidecarKeymaxxerLayer(sidecarUrl)
+      : sidecarKeymaxxerLayer(sidecarUrl, options.sidecarLayerOptions)
   const toolCwd = config.hostToolCwd
   const platformLayer = BunChildProcessSpawner.layer.pipe(
     Layer.provideMerge(Layer.merge(BunFileSystem.layer, BunPath.layer)),

--- a/apps/harness/test/ambient-github-layer.test.ts
+++ b/apps/harness/test/ambient-github-layer.test.ts
@@ -1,7 +1,8 @@
 import * as BunChildProcessSpawner from "@effect/platform-bun/BunChildProcessSpawner"
 import * as BunFileSystem from "@effect/platform-bun/BunFileSystem"
 import * as BunPath from "@effect/platform-bun/BunPath"
-import { Effect, Layer } from "effect"
+import { Effect, Layer, ManagedRuntime, Stream } from "effect"
+import { ChildProcessSpawner } from "effect/unstable/process"
 import {
   GitHubRequestError,
   GitHubService,
@@ -13,6 +14,12 @@ import { expect, test } from "bun:test"
 const processLayer = BunChildProcessSpawner.layer.pipe(
   Layer.provideMerge(Layer.merge(BunFileSystem.layer, BunPath.layer)),
 )
+
+const repository = {
+  forge: "github" as const,
+  forgeHost: "github.com",
+  projectPath: "acme/widgets",
+}
 
 const serviceWithList = (
   listReadyIssues: GitHubServiceShape["listReadyIssues"],
@@ -36,6 +43,47 @@ const serviceWithList = (
   mergePullRequest: () => Effect.die("not used"),
   rerunWorkflowRun: () => Effect.void,
   ensureIssueCompletedWithSummary: () => Effect.die("not used"),
+})
+
+const controlledTokenProcess = () => {
+  let complete: (token: string) => void = () => undefined
+  let interruptCount = 0
+  let startCount = 0
+  let started: () => void = () => undefined
+  const start = new Promise<void>((resolve) => {
+    started = resolve
+  })
+  const string = () => {
+    return Effect.callback<string>((resume) => {
+      startCount += 1
+      started()
+      complete = (token) => resume(Effect.succeed(token))
+      return Effect.sync(() => {
+        interruptCount += 1
+      })
+    })
+  }
+  const service = ChildProcessSpawner.ChildProcessSpawner.of({
+    spawn: () => Effect.never,
+    exitCode: () => Effect.never,
+    streamString: () => Stream.never,
+    streamLines: () => Stream.never,
+    lines: () => Effect.never,
+    string,
+  })
+
+  return {
+    complete: (token: string) => complete(token),
+    interrupted: () => interruptCount,
+    layer: Layer.succeed(ChildProcessSpawner.ChildProcessSpawner, service),
+    startCount: () => startCount,
+    started: start,
+  }
+}
+
+const listReadyIssues = Effect.gen(function* () {
+  const github = yield* GitHubService
+  return yield* github.listReadyIssues(repository)
 })
 
 test("ambient GitHub authentication is resolved once", async () => {
@@ -104,6 +152,56 @@ test("ambient GitHub authentication refreshes once after a 401", async () => {
   )
 
   expect(resolutions).toBe(2)
+})
+
+test("application scope interrupts in-flight ambient authentication", async () => {
+  const process = controlledTokenProcess()
+  const runtime = ManagedRuntime.make(
+    ambientGitHubLayer({
+      workspaceRoot: "/workspace",
+      makeService: () => serviceWithList(() => Effect.succeed([])),
+    }).pipe(Layer.provide(process.layer)),
+  )
+  await runtime.context()
+  const pending = runtime.runPromise(listReadyIssues).catch(() => undefined)
+
+  await process.started
+  try {
+    await runtime.dispose()
+    await pending
+    expect(process.interrupted()).toBe(1)
+  } finally {
+    process.complete("late-token")
+  }
+})
+
+test("canceling the first requester keeps shared authentication alive", async () => {
+  const process = controlledTokenProcess()
+  const runtime = ManagedRuntime.make(
+    ambientGitHubLayer({
+      workspaceRoot: "/workspace",
+      makeService: () => serviceWithList(() => Effect.succeed([])),
+    }).pipe(Layer.provide(process.layer)),
+  )
+  await runtime.context()
+  const controller = new AbortController()
+  const first = runtime
+    .runPromise(listReadyIssues, { signal: controller.signal })
+    .catch(() => undefined)
+
+  await process.started
+  controller.abort()
+  await first
+  const second = runtime.runPromise(listReadyIssues)
+  process.complete("shared-token")
+
+  try {
+    expect(await second).toEqual([])
+    expect(process.startCount()).toBe(1)
+    expect(process.interrupted()).toBe(0)
+  } finally {
+    await runtime.dispose()
+  }
 })
 
 test("concurrent 401 responses share one refreshed token", async () => {

--- a/apps/harness/test/application-runtime-disposal.test.ts
+++ b/apps/harness/test/application-runtime-disposal.test.ts
@@ -1,0 +1,106 @@
+import { mkdtemp, rm } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { Effect, Layer } from "effect"
+import { DatabaseLive, runConfiguredMigrations } from "@ready-for-agent/db"
+import { DbService, DbServiceLive } from "@ready-for-agent/db-service"
+import type { KeymaxxerToolClient } from "@ready-for-agent/keymaxxer-service"
+import { createApplication } from "../src/server/application.server.js"
+import { environmentConfigLayer } from "../src/server/application-config.js"
+import { expect, test } from "bun:test"
+
+test("application disposal closes a lazily created authentication client", async () => {
+  const directory = await mkdtemp(join(tmpdir(), "rfa-auth-runtime-"))
+  const environment = {
+    HOME: directory,
+    KEYMAXXER_SIDECAR_URL: "http://127.0.0.1:6057/application-runtime/mcp",
+    SQLITE_DATABASE_PATH: join(directory, "ready-for-agent.db"),
+  }
+  const configLayer = environmentConfigLayer(environment)
+  let application: Awaited<ReturnType<typeof createApplication>> | undefined
+  let disposed = false
+  let closeCalls = 0
+  const client: KeymaxxerToolClient = {
+    callTool: async () => ({
+      content: [
+        {
+          type: "text",
+          text: JSON.stringify([
+            {
+              name: "GITHUB_TOKEN_ACME_WIDGETS",
+              provider: "github",
+              account: "acme/widgets",
+            },
+          ]),
+        },
+      ],
+    }),
+    close: async () => {
+      closeCalls += 1
+    },
+  }
+
+  try {
+    await Effect.runPromise(
+      runConfiguredMigrations().pipe(
+        Effect.provide(DatabaseLive),
+        Effect.provide(configLayer),
+      ),
+    )
+    const databaseLayer = DbServiceLive.pipe(
+      Layer.provideMerge(DatabaseLive),
+      Layer.provide(configLayer),
+    )
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        const db = yield* DbService
+        yield* db.addRepository({
+          forge: "github",
+          forgeHost: "github.com",
+          projectPath: "acme/widgets",
+          localPath: join(directory, "widgets"),
+          isBare: true,
+        })
+      }).pipe(Effect.provide(databaseLayer)),
+    )
+
+    application = await createApplication(environment, {
+      startWorker: false,
+      sidecarLayerOptions: {
+        createClient: async () => client,
+        fetch: async () => new Response(null, { status: 404 }),
+      },
+    })
+    const response = await application.context.graphqlApi.fetch(
+      new Request("http://127.0.0.1:6056/graphql", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({
+          query: `query {
+            repositoryCredentials {
+              configured
+              repositoryId
+            }
+          }`,
+        }),
+      }),
+    )
+
+    expect(response.status).toBe(200)
+    expect(await response.json()).toMatchObject({
+      data: {
+        repositoryCredentials: [{ configured: true }],
+      },
+    })
+    expect(closeCalls).toBe(0)
+
+    await application.dispose()
+    disposed = true
+    expect(closeCalls).toBe(1)
+  } finally {
+    if (application !== undefined && !disposed) {
+      await application.dispose()
+    }
+    await rm(directory, { recursive: true, force: true })
+  }
+})

--- a/packages/keymaxxer-service/src/lib/http-layer.ts
+++ b/packages/keymaxxer-service/src/lib/http-layer.ts
@@ -73,13 +73,18 @@ export const sidecarKeymaxxerLayer = (
     KeymaxxerService,
     Effect.gen(function* () {
       const parsed = yield* parseSidecarUrlEffect(value)
-      const managed = makeKeymaxxerClientService({
-        createClient:
-          options.createClient ??
-          (() => createStreamableHttpClient(parsed.url)),
-        failureMessage: () => "Keymaxxer sidecar request failed",
-        initialize: waitForTcp(parsed, options),
-      })
+      const managed = yield* Effect.acquireRelease(
+        Effect.sync(() =>
+          makeKeymaxxerClientService({
+            createClient:
+              options.createClient ??
+              (() => createStreamableHttpClient(parsed.url)),
+            failureMessage: () => "Keymaxxer sidecar request failed",
+            initialize: waitForTcp(parsed, options),
+          }),
+        ),
+        (managed) => managed.close,
+      )
       return managed.service
     }),
   )

--- a/packages/keymaxxer-service/test/sidecar.test.ts
+++ b/packages/keymaxxer-service/test/sidecar.test.ts
@@ -1,6 +1,7 @@
-import { Effect } from "effect"
+import { Cause, Effect, Option } from "effect"
 import {
   KeymaxxerService,
+  type KeymaxxerToolClient,
   type KeymaxxerUpstreamClient,
   parseSidecarUrl,
   sidecarKeymaxxerLayer,
@@ -56,6 +57,80 @@ describe("parseSidecarUrl", () => {
 })
 
 describe("sidecar-backed Keymaxxer layer", () => {
+  test("closes a lazily created client exactly once when its layer is released", async () => {
+    let closeCalls = 0
+    const client: KeymaxxerToolClient = {
+      callTool: async () => ({
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify([{ name: "PRESENT_SECRET" }]),
+          },
+        ],
+      }),
+      close: async () => {
+        closeCalls += 1
+        throw new Error("close failed")
+      },
+    }
+
+    const present = await Effect.runPromise(
+      Effect.gen(function* () {
+        const keymaxxer = yield* KeymaxxerService
+        yield* keymaxxer.initialize
+        return yield* keymaxxer.hasSecret("PRESENT_SECRET")
+      }).pipe(
+        Effect.provide(
+          sidecarKeymaxxerLayer("http://127.0.0.1:6057/capability/mcp", {
+            createClient: async () => client,
+            fetch: async () => new Response(null, { status: 404 }),
+          }),
+        ),
+      ),
+    )
+
+    expect(present).toBe(true)
+    expect(closeCalls).toBe(1)
+  })
+
+  test("preserves a failed operation when closing its client also fails", async () => {
+    let closeCalls = 0
+    const client: KeymaxxerToolClient = {
+      callTool: async () => {
+        throw new Error("request failed")
+      },
+      close: async () => {
+        closeCalls += 1
+        throw new Error("close failed")
+      },
+    }
+
+    const exit = await Effect.runPromise(
+      Effect.gen(function* () {
+        const keymaxxer = yield* KeymaxxerService
+        return yield* Effect.exit(keymaxxer.hasSecret("PRESENT_SECRET"))
+      }).pipe(
+        Effect.provide(
+          sidecarKeymaxxerLayer("http://127.0.0.1:6057/capability/mcp", {
+            createClient: async () => client,
+            fetch: async () => new Response(null, { status: 404 }),
+          }),
+        ),
+      ),
+    )
+
+    expect(exit._tag).toBe("Failure")
+    if (exit._tag === "Failure") {
+      expect(
+        Option.getOrThrow(Cause.findErrorOption(exit.cause)),
+      ).toMatchObject({
+        _tag: "KeymaxxerError",
+        operation: "listSecrets",
+      })
+    }
+    expect(closeCalls).toBe(1)
+  })
+
   test("initializes over TCP and runs Keymaxxer tools through Streamable HTTP", async () => {
     const facade = await startKeymaxxerFacade({
       host: "127.0.0.1",


### PR DESCRIPTION
## Why

Harness authentication resources could outlive the application runtime: the
Keymaxxer sidecar layer discarded its client finalizer, while ambient Forge
token resolution used globally detached fibers.

## What changed

- Register the sidecar MCP client with the layer scope and close it exactly once
  during runtime disposal, including after failed operations without masking
  their result.
- Scope ambient GitHub and GitLab token-resolution fibers to the application
  runtime while preserving shared acquisition when an initiating request is
  cancelled.
- Add focused coverage for client finalization, resolver interruption, request
  cancellation, and disposal through the real Harness application runtime.

## Verification

- `bunx nx run keymaxxer-service:test`
- `bunx nx run harness:typecheck`
- `bunx nx run harness:test`
- `bunx nx affected -t lint`
- `git diff --check`

Closes #582