### PR TITLE
feat(harness): show agent backend label inline on Jobs and kanban

### DIFF
--- a/apps/harness/src/routes/index.tsx
+++ b/apps/harness/src/routes/index.tsx
@@ -3542,56 +3542,57 @@ function JobsCard() {
                       <WorkItemPauseButton workItem={workItem} />
                     </div>
                   </div>
-                  {selectedTab === "completed" && (
-                    <p className="mt-1 mb-0 font-mono text-xs text-ink-faint">
+                  <p className="mt-1 mb-0 flex min-w-0 flex-wrap items-center gap-1">
+                    <span className="shrink-0 font-mono text-xs text-ink-faint">
                       {workItem.agentBackend.label}
-                    </p>
-                  )}
-                  {(sessionId !== null || worktreePath !== null) && (
-                    <p className="mt-1 mb-0 flex min-w-0 flex-wrap items-center gap-1">
-                      {sessionId !== null &&
-                        (selectedTab === "completed" ? (
-                          <span className="inline-flex min-w-0 max-w-full items-center gap-1">
-                            <button
-                              type="button"
-                              className="min-w-0 truncate font-mono text-xs text-ink-faint underline-offset-2 hover:text-oxblood hover:underline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-oxblood"
-                              title={sessionId}
-                              onClick={() => {
-                                setSessionDialog({
-                                  workItemId: workItem.id,
-                                  sessionId,
-                                })
-                              }}
-                            >
-                              {sessionId}
-                            </button>
-                            <Copy
-                              value={sessionId}
-                              className="shrink-0"
-                              showValue={false}
-                            />
-                          </span>
-                        ) : (
+                    </span>
+                    {(sessionId !== null || worktreePath !== null) && (
+                      <span className="shrink-0 font-mono text-xs text-ink-faint">
+                        -
+                      </span>
+                    )}
+                    {sessionId !== null &&
+                      (selectedTab === "completed" ? (
+                        <span className="inline-flex min-w-0 max-w-full items-center gap-1">
+                          <button
+                            type="button"
+                            className="min-w-0 truncate font-mono text-xs text-ink-faint underline-offset-2 hover:text-oxblood hover:underline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-oxblood"
+                            title={sessionId}
+                            onClick={() => {
+                              setSessionDialog({
+                                workItemId: workItem.id,
+                                sessionId,
+                              })
+                            }}
+                          >
+                            {sessionId}
+                          </button>
                           <Copy
                             value={sessionId}
-                            className="min-w-0 max-w-full"
-                            textClassName="font-mono text-xs text-ink-faint"
+                            className="shrink-0"
+                            showValue={false}
                           />
-                        ))}
-                      {sessionId !== null && worktreePath !== null && (
-                        <span className="shrink-0 font-mono text-xs text-ink-faint">
-                          -
                         </span>
-                      )}
-                      {worktreePath !== null && (
+                      ) : (
                         <Copy
-                          value={worktreePath}
+                          value={sessionId}
                           className="min-w-0 max-w-full"
                           textClassName="font-mono text-xs text-ink-faint"
                         />
-                      )}
-                    </p>
-                  )}
+                      ))}
+                    {sessionId !== null && worktreePath !== null && (
+                      <span className="shrink-0 font-mono text-xs text-ink-faint">
+                        -
+                      </span>
+                    )}
+                    {worktreePath !== null && (
+                      <Copy
+                        value={worktreePath}
+                        className="min-w-0 max-w-full"
+                        textClassName="font-mono text-xs text-ink-faint"
+                      />
+                    )}
+                  </p>
                   <WorkItemLifecycleStatus
                     workItem={workItem}
                     compact

--- a/apps/harness/src/routes/kanban.tsx
+++ b/apps/harness/src/routes/kanban.tsx
@@ -182,10 +182,16 @@ function PipelineTicket({
         <span className="job-ticket-state">{workItem.stateLabel}</span>
         <WorkItemPauseButton workItem={workItem} />
       </div>
-      {(sessionId !== null || worktreePath !== null) && (
-        <div className="job-ticket-runtime">
+      <div className="job-ticket-runtime">
+        <div className="flex min-w-0 items-center gap-1">
+          <span className="shrink-0 font-mono text-xs text-ink-faint">
+            {workItem.agentBackend.label}
+          </span>
           {sessionId !== null && (
-            <div className="flex min-w-0 items-center gap-1">
+            <>
+              <span className="shrink-0 font-mono text-xs text-ink-faint">
+                -
+              </span>
               <button
                 type="button"
                 className="min-w-0 truncate font-mono text-xs text-ink-faint underline-offset-2 hover:text-oxblood hover:underline"
@@ -195,17 +201,17 @@ function PipelineTicket({
                 {sessionId}
               </button>
               <Copy value={sessionId} showValue={false} className="shrink-0" />
-            </div>
-          )}
-          {worktreePath !== null && (
-            <Copy
-              value={worktreePath}
-              className="min-w-0 max-w-full"
-              textClassName="font-mono text-xs text-ink-faint"
-            />
+            </>
           )}
         </div>
-      )}
+        {worktreePath !== null && (
+          <Copy
+            value={worktreePath}
+            className="min-w-0 max-w-full"
+            textClassName="font-mono text-xs text-ink-faint"
+          />
+        )}
+      </div>
       <WorkItemLifecycleStatus
         workItem={workItem}
         compact

--- a/apps/harness/test/jobs-card-no-polling.test.ts
+++ b/apps/harness/test/jobs-card-no-polling.test.ts
@@ -145,6 +145,18 @@ describe("JobsCard live updates", () => {
     expect(jobsCard).not.toContain("Session ")
   })
 
+  test("shows agent backend label inline before session id on every tab", () => {
+    const { jobsCard } = jobsCardSource()
+    expect(jobsCard).toContain("{workItem.agentBackend.label}")
+    expect(jobsCard).not.toContain('selectedTab === "completed" && (')
+    // Label always renders; separator only when session or worktree follows.
+    expect(jobsCard).toContain("sessionId !== null || worktreePath !== null")
+    const labelIndex = jobsCard.indexOf("{workItem.agentBackend.label}")
+    const sessionValueIndex = jobsCard.indexOf("value={sessionId}")
+    expect(labelIndex).toBeGreaterThan(-1)
+    expect(sessionValueIndex).toBeGreaterThan(labelIndex)
+  })
+
   test("Completed Session id opens usage dialog; Working/Failed keep plain copy", () => {
     const { source, jobsCard } = jobsCardSource()
     expect(jobsCard).toContain('selectedTab === "completed"')

--- a/apps/harness/test/kanban-route.test.ts
+++ b/apps/harness/test/kanban-route.test.ts
@@ -74,6 +74,26 @@ describe("/kanban route", () => {
     expect(ticket).not.toContain('laneId === "complete"')
   })
 
+  test("shows agent backend label inline before session id on pipeline tickets", () => {
+    const source = kanbanSource()
+    const ticket = source.slice(
+      source.indexOf("function PipelineTicket("),
+      source.indexOf("function KanbanJobsBoard()"),
+    )
+    expect(ticket).toContain("{workItem.agentBackend.label}")
+    expect(ticket).toContain('className="job-ticket-runtime"')
+    // Runtime row is unconditional so the label shows before a session exists.
+    expect(ticket).not.toContain(
+      "(sessionId !== null || worktreePath !== null) && (",
+    )
+    const labelIndex = ticket.indexOf("{workItem.agentBackend.label}")
+    const sessionButtonIndex = ticket.indexOf(
+      "onOpenSession(workItem.id, sessionId)",
+    )
+    expect(labelIndex).toBeGreaterThan(-1)
+    expect(sessionButtonIndex).toBeGreaterThan(labelIndex)
+  })
+
   test("reuses existing queries and live invalidation without polling", () => {
     const source = kanbanSource()
     expect(source).toContain("jobsWorkingWorkItemsQuery")


### PR DESCRIPTION
## Why

Operators could not tell which agent backend (OpenCode, Grok Build,
Codex Build) was driving a work item on the Jobs Working/Failed tabs or
on kanban pipeline tickets. Only the Completed tab showed the label, and
only on its own line.

## What changed

- Jobs card: always render `workItem.agentBackend.label` inline before
  session ID / worktree path on Working, Failed, and Completed (one
  shared path; completed session dialog behavior unchanged).
- Kanban `PipelineTicket`: always show the same label in the runtime
  row, even before a session exists.
- Source-level tests lock unconditional inline placement ahead of
  session UI.

No backend, schema, or GraphQL changes; the field was already selected.

## Verification

- `bunx nx run harness:typecheck`
- Related harness UI tests (Jobs card, kanban route, agent-backend
  provenance)
- Pre-commit passed after dependency rebuild for an unrelated stale
  `db` dist cache

Closes #594