### PR TITLE
fix(harness): decouple open PR counts from repositories live projection

### DIFF
--- a/apps/harness/project.json
+++ b/apps/harness/project.json
@@ -51,7 +51,7 @@
       "executor": "nx:run-commands",
       "options": {
         "cwd": "{projectRoot}",
-        "command": "bun test"
+        "command": "bun --conditions=@ready-for-agent/source test"
       },
       "inputs": ["default", "^production"],
       "cache": true,

--- a/apps/harness/src/refresh-open-pull-request-count-live.ts
+++ b/apps/harness/src/refresh-open-pull-request-count-live.ts
@@ -7,28 +7,85 @@ import type { QueryClient } from "@tanstack/react-query"
  */
 export const OPEN_PULL_REQUEST_COUNT_POLL_INTERVAL_MS = 30_000
 
+/**
+ * Dedicated TanStack Query cache identity for GitHub-authoritative open
+ * non-draft Pull Request counts. Independent of the Configured Repositories
+ * projection so count latency cannot cancel, block, or invalidate Repository
+ * cards, credentials, Issues, Work Items, or controls.
+ */
+export const openPullRequestCountsQueryKey = [
+  "open-pull-request-counts",
+] as const
+
 export type OpenPullRequestCountLiveQuery = {
   readonly queryKey: readonly unknown[]
   readonly queryFn: () => Promise<unknown>
 }
 
 /**
- * Keeps `Repository.pullRequestCount` current via GitHub-backed repositories
- * query refetch: periodic polling while the tab is visible, plus an immediate
- * refetch when a backgrounded tab becomes visible again.
+ * Header presentation for one Repository's open non-draft PR count.
+ *
+ * A missing per-repo value is loading whenever the dedicated projection is
+ * pending or fetching (e.g. after add-repository while a stale map still
+ * lacks the new id). "Unavailable" only applies when the query is settled
+ * without a count for that Repository.
+ */
+export const openPullRequestCountPresentation = ({
+  count,
+  isPending,
+  isFetching,
+}: {
+  readonly count: number | undefined
+  readonly isPending: boolean
+  readonly isFetching: boolean
+}): {
+  readonly label: string
+  readonly display: string
+  readonly loading: boolean
+} => {
+  if (count !== undefined) {
+    return {
+      label:
+        count === 1 ? "1 open pull request" : `${count} open pull requests`,
+      display: String(count),
+      loading: false,
+    }
+  }
+  const loading = isPending || isFetching
+  if (loading) {
+    return {
+      label: "Loading open pull requests",
+      display: "…",
+      loading: true,
+    }
+  }
+  return {
+    label: "Open pull requests unavailable",
+    display: "—",
+    loading: false,
+  }
+}
+
+/**
+ * Keeps the dedicated open Pull Request count projection current via
+ * GitHub-backed refetch: periodic polling while the tab is visible, plus an
+ * immediate refetch when a backgrounded tab becomes visible again.
+ *
+ * Refreshes only the dedicated count query identity. Never cancels,
+ * invalidates, fetches, or awaits the main Configured Repositories query.
  *
  * Transient fetch failures are swallowed so a single GraphQL/network blip does
  * not tear down the poller; the next poll tick or visibility event retries.
  */
 export const followOpenPullRequestCountLive = async ({
   queryClient,
-  repositoriesQuery,
+  openPullRequestCountsQuery,
   signal,
   documentRef = typeof document === "undefined" ? undefined : document,
   pollIntervalMs = OPEN_PULL_REQUEST_COUNT_POLL_INTERVAL_MS,
 }: {
   queryClient: QueryClient
-  repositoriesQuery: OpenPullRequestCountLiveQuery
+  openPullRequestCountsQuery: OpenPullRequestCountLiveQuery
   signal: AbortSignal
   documentRef?: Pick<
     Document,
@@ -40,12 +97,12 @@ export const followOpenPullRequestCountLive = async ({
     if (signal.aborted) return
     try {
       await queryClient.cancelQueries({
-        queryKey: repositoriesQuery.queryKey,
+        queryKey: openPullRequestCountsQuery.queryKey,
         exact: true,
       })
       if (signal.aborted) return
       await queryClient.fetchQuery({
-        ...repositoriesQuery,
+        ...openPullRequestCountsQuery,
         staleTime: 0,
       })
     } catch {
@@ -94,7 +151,7 @@ export const followOpenPullRequestCountLive = async ({
   } finally {
     documentRef?.removeEventListener("visibilitychange", refreshWhenVisible)
     void queryClient.cancelQueries({
-      queryKey: repositoriesQuery.queryKey,
+      queryKey: openPullRequestCountsQuery.queryKey,
       exact: true,
     })
   }

--- a/apps/harness/src/refresh-work-items-live.ts
+++ b/apps/harness/src/refresh-work-items-live.ts
@@ -1,4 +1,5 @@
 import type { QueryClient } from "@tanstack/react-query"
+import { openPullRequestCountsQueryKey } from "./refresh-open-pull-request-count-live.js"
 import { streamWorkItemsChanged } from "./work-items-live.js"
 
 export const committedPullRequestsCountQueryKeyPrefix = [
@@ -8,9 +9,11 @@ export const committedPullRequestsCountQueryKeyPrefix = [
 const configQueryKey = ["config"] as const
 /**
  * Per-repo unfinished gate (`blockingUnfinishedWorkItemCount`) lives here.
- * GitHub-authoritative open non-draft PR count (`pullRequestCount`) is kept
- * live by {@link followOpenPullRequestCountLive}; Work Item events still
- * refetch repositories as a secondary path when harness-owned PRs change.
+ * GitHub-authoritative open non-draft PR count is a dedicated projection
+ * (`openPullRequestCountsQuery` / {@link followOpenPullRequestCountLive}).
+ * Work Item events may invalidate that projection fire-and-forget for faster
+ * harness-owned PR freshness, but never cancel, await, or couple their
+ * completion or subscription lifetime to count refresh.
  */
 const repositoriesQueryKey = ["repositories"] as const
 
@@ -95,6 +98,8 @@ export const followRepositoryWorkItemsLive = async ({
   let committedCountsRefresh: Promise<void> | undefined
   let committedCountsRefreshPending = false
   let committedCountsRetryLoop: Promise<void> | undefined
+  let openPrCountsRefresh: Promise<void> | undefined
+  let openPrCountsRefreshPending = false
   let fullRefreshRetryLoop: Promise<void> | undefined
   let fullRefreshPending = false
 
@@ -210,11 +215,46 @@ export const followRepositoryWorkItemsLive = async ({
     await refreshCachedQueries(queryKey)
   }
 
+  /**
+   * Secondary freshness for header open-PR counts when harness-owned Work Item
+   * PRs change. Fire-and-forget and coalesced: a burst of Work Item events
+   * shares one trailing invalidate of the dedicated projection. Never awaited
+   * by the SSE path and never cancels repositories. Poll/visibility on the
+   * dedicated follower remain authoritative for external GitHub PRs that do
+   * not emit Work Item SSE.
+   */
+  const scheduleOpenPullRequestCounts = () => {
+    if (signal.aborted) return
+    openPrCountsRefreshPending = true
+    if (openPrCountsRefresh !== undefined) return
+
+    openPrCountsRefresh = (async () => {
+      try {
+        while (openPrCountsRefreshPending && !signal.aborted) {
+          openPrCountsRefreshPending = false
+          try {
+            await queryClient.invalidateQueries({
+              queryKey: openPullRequestCountsQueryKey,
+            })
+          } catch {
+            // Secondary path: keep the follower alive on transient failures.
+          }
+        }
+      } finally {
+        openPrCountsRefresh = undefined
+        if (openPrCountsRefreshPending && !signal.aborted) {
+          scheduleOpenPullRequestCounts()
+        }
+      }
+    })()
+  }
+
   const refresh = async (repositoryId: string) => {
     // Do not await counts here: the SSE subscriber awaits each onChange, so
     // awaiting aggregates would serialize one full count refresh per event and
     // defeat coalescing under bursty lifecycle notifications.
     scheduleCommittedPullRequestsCounts()
+    scheduleOpenPullRequestCounts()
     await Promise.all([
       refreshWorkItems(repositoryId),
       // Harness Settings includes the global unfinished Work Item count.
@@ -227,6 +267,9 @@ export const followRepositoryWorkItemsLive = async ({
   const refreshAll = async () => {
     if (signal.aborted) return
     const repositoryIds = getRepositoryIds()
+    // Open PR counts: schedule only — do not await so SSE reconnect catch-up
+    // cannot couple to Keymaxxer-backed GitHub counting.
+    scheduleOpenPullRequestCounts()
     await Promise.all([
       ...repositoryIds.map((repositoryId) => refreshWorkItems(repositoryId)),
       refreshCommittedPullRequestsCounts(),
@@ -270,11 +313,14 @@ export const followRepositoryWorkItemsLive = async ({
 
   const cancelOwnedQueries = () => {
     committedCountsRefreshPending = false
+    openPrCountsRefreshPending = false
     fullRefreshPending = false
     void queryClient.cancelQueries({
       queryKey: committedPullRequestsCountQueryKeyPrefix,
     })
     void queryClient.cancelQueries({ queryKey: ["work-items"] })
+    // Do not cancel openPullRequestCountsQueryKey: that projection is owned by
+    // followOpenPullRequestCountLive; this follower only schedules invalidation.
   }
   signal.addEventListener("abort", cancelOwnedQueries, { once: true })
 

--- a/apps/harness/src/routes/index.tsx
+++ b/apps/harness/src/routes/index.tsx
@@ -238,7 +238,7 @@ export const repositoriesQuery = {
  * Independent of {@link repositoriesQuery}: a slow or failed count must not
  * cancel or block the Configured Repositories projection.
  */
-export const openPullRequestCountsQuery = {
+const openPullRequestCountsQuery = {
   queryKey: openPullRequestCountsQueryKey,
   queryFn: async (): Promise<Readonly<Record<string, number>>> => {
     const result = await graphql.query({

--- a/apps/harness/src/routes/index.tsx
+++ b/apps/harness/src/routes/index.tsx
@@ -31,7 +31,11 @@ import {
   isParentImplementAllWithAutoMergeEligible,
 } from "../parent-issue-actions-menu.js"
 import { followRepositoryIssuesLive } from "../refresh-issues-live.js"
-import { followOpenPullRequestCountLive } from "../refresh-open-pull-request-count-live.js"
+import {
+  followOpenPullRequestCountLive,
+  openPullRequestCountPresentation,
+  openPullRequestCountsQueryKey,
+} from "../refresh-open-pull-request-count-live.js"
 import {
   committedPullRequestsCountQueryKeyPrefix,
   followRepositoryWorkItemsLive,
@@ -185,6 +189,10 @@ const reconcileVariantForModel = (
 export const repositoriesQuery = {
   queryKey: ["repositories"],
   queryFn: async () => {
+    // Intentionally omits pullRequestCount: GitHub-authoritative open non-draft
+    // PR counting is a dedicated projection (openPullRequestCountsQuery) so
+    // Keymaxxer-backed count latency cannot delay Configured Repositories,
+    // credentials, Issues, Work Items, or controls.
     const result = await graphql.query({
       repositories: {
         id: true,
@@ -205,7 +213,6 @@ export const repositoriesQuery = {
         waitForReadyForReviewChecks: true,
         issuesReconciledAt: true,
         blockingUnfinishedWorkItemCount: true,
-        pullRequestCount: true,
       },
       repositoryCredentials: {
         repositoryId: true,
@@ -223,6 +230,29 @@ export const repositoriesQuery = {
       }
       return { ...repository, credential }
     })
+  },
+}
+
+/**
+ * Dedicated cache identity for GitHub open non-draft Pull Request counts.
+ * Independent of {@link repositoriesQuery}: a slow or failed count must not
+ * cancel or block the Configured Repositories projection.
+ */
+export const openPullRequestCountsQuery = {
+  queryKey: openPullRequestCountsQueryKey,
+  queryFn: async (): Promise<Readonly<Record<string, number>>> => {
+    const result = await graphql.query({
+      repositories: {
+        id: true,
+        pullRequestCount: true,
+      },
+    })
+    return Object.fromEntries(
+      result.repositories.map(({ id, pullRequestCount }) => [
+        id,
+        pullRequestCount,
+      ]),
+    )
   },
 }
 
@@ -293,7 +323,6 @@ export type Repository = {
   waitForReadyForReviewChecks: boolean
   issuesReconciledAt: string | null
   blockingUnfinishedWorkItemCount: number
-  pullRequestCount: number
   credential: RepositoryCredential
 }
 
@@ -708,6 +737,11 @@ function RepositoryCards() {
       }, 10_000)
     }
     const refresh = async () => {
+      // Membership catch-up: repositories first; dedicated open-PR counts are
+      // fire-and-forget so Keymaxxer counting cannot delay or block this path.
+      void queryClient
+        .invalidateQueries({ queryKey: openPullRequestCountsQueryKey })
+        .catch(() => undefined)
       await queryClient.fetchQuery({ ...repositoriesQuery, staleTime: 0 })
       if (cancelled) return
       if (warningTimer !== undefined) clearTimeout(warningTimer)
@@ -789,14 +823,14 @@ function RepositoryCards() {
     return () => controller.abort()
   }, [queryClient])
 
-  // GitHub-authoritative open non-draft PR header counts: poll while visible
-  // and refetch immediately when a backgrounded tab returns (external PRs do
-  // not emit Work Item SSE events).
+  // GitHub-authoritative open non-draft PR header counts: dedicated projection
+  // only — poll while visible and refetch when a backgrounded tab returns
+  // (external PRs do not emit Work Item SSE events). Never touches repositoriesQuery.
   useEffect(() => {
     const controller = new AbortController()
     void followOpenPullRequestCountLive({
       queryClient,
-      repositoriesQuery,
+      openPullRequestCountsQuery,
       signal: controller.signal,
     })
     return () => controller.abort()
@@ -901,7 +935,6 @@ function AddRepositoryGuidance({
           waitForReadyForReviewChecks: true,
           issuesReconciledAt: true,
           blockingUnfinishedWorkItemCount: true,
-          pullRequestCount: true,
         },
       })
       return result.addRepository
@@ -912,6 +945,9 @@ function AddRepositoryGuidance({
       setInspection(null)
       await queryClient.invalidateQueries({
         queryKey: repositoriesQuery.queryKey,
+      })
+      void queryClient.invalidateQueries({
+        queryKey: openPullRequestCountsQuery.queryKey,
       })
     },
     onError: (error) => {
@@ -1252,7 +1288,6 @@ function RepositoryCard({
           waitForReadyForReviewChecks: true,
           issuesReconciledAt: true,
           blockingUnfinishedWorkItemCount: true,
-          pullRequestCount: true,
         },
       })
       return result.updateRepositorySettings
@@ -1642,6 +1677,9 @@ function RepositoryCard({
       await queryClient.invalidateQueries({
         queryKey: repositoriesQuery.queryKey,
       })
+      void queryClient.invalidateQueries({
+        queryKey: openPullRequestCountsQuery.queryKey,
+      })
       // Dropping a repo may shrink selected-or-in-use Active backends.
       void queryClient.invalidateQueries({
         queryKey: ["agentBackendStatus"],
@@ -1780,10 +1818,21 @@ function RepositoryCard({
     ? "border-oxblood/50 text-oxblood hover:bg-oxblood-wash focus-visible:outline-oxblood"
     : "border-sepia/50 text-sepia hover:bg-amber-wash focus-visible:outline-sepia"
   const repositoryLabel = `${repository.projectPath}`
-  const pullRequestCountLabel =
-    repository.pullRequestCount === 1
-      ? "1 open pull request"
-      : `${repository.pullRequestCount} open pull requests`
+  // Dedicated count projection: loading/last-known must not block the card.
+  const {
+    data: openPullRequestCounts,
+    isPending: openPullRequestCountsPending,
+    isFetching: openPullRequestCountsFetching,
+  } = useQuery(openPullRequestCountsQuery)
+  const {
+    label: pullRequestCountLabel,
+    display: pullRequestCountDisplay,
+    loading: pullRequestCountLoading,
+  } = openPullRequestCountPresentation({
+    count: openPullRequestCounts?.[repository.id],
+    isPending: openPullRequestCountsPending,
+    isFetching: openPullRequestCountsFetching,
+  })
   const {
     collapsed: repositoryCollapsed,
     toggleCollapsed: toggleRepositoryCollapsed,
@@ -1805,9 +1854,10 @@ function RepositoryCard({
           <span
             className="shrink-0 font-mono text-sm font-semibold tracking-normal text-ink-faint tabular-nums"
             title={pullRequestCountLabel}
+            aria-busy={pullRequestCountLoading ? true : undefined}
           >
             <span className="sr-only">{pullRequestCountLabel}</span>
-            <span aria-hidden="true">{repository.pullRequestCount}</span>
+            <span aria-hidden="true">{pullRequestCountDisplay}</span>
           </span>
         </h2>
         <div className="flex shrink-0 items-center gap-1">

--- a/apps/harness/test/refresh-open-pull-request-count-live.test.ts
+++ b/apps/harness/test/refresh-open-pull-request-count-live.test.ts
@@ -2,26 +2,107 @@ import { QueryClient } from "@tanstack/react-query"
 import {
   OPEN_PULL_REQUEST_COUNT_POLL_INTERVAL_MS,
   followOpenPullRequestCountLive,
+  openPullRequestCountPresentation,
+  openPullRequestCountsQueryKey,
 } from "../src/refresh-open-pull-request-count-live.js"
 import { describe, expect, test } from "bun:test"
 
 const wait = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
+
+describe("openPullRequestCountPresentation", () => {
+  test("shows a known count with singular or plural label", () => {
+    expect(
+      openPullRequestCountPresentation({
+        count: 1,
+        isPending: false,
+        isFetching: false,
+      }),
+    ).toEqual({
+      label: "1 open pull request",
+      display: "1",
+      loading: false,
+    })
+    expect(
+      openPullRequestCountPresentation({
+        count: 0,
+        isPending: false,
+        isFetching: true,
+      }),
+    ).toEqual({
+      label: "0 open pull requests",
+      display: "0",
+      loading: false,
+    })
+  })
+
+  test("treats a missing count as loading while pending or fetching", () => {
+    expect(
+      openPullRequestCountPresentation({
+        count: undefined,
+        isPending: true,
+        isFetching: false,
+      }),
+    ).toMatchObject({ display: "…", loading: true })
+    // Stale shared map after add-repo: isPending false, isFetching true.
+    expect(
+      openPullRequestCountPresentation({
+        count: undefined,
+        isPending: false,
+        isFetching: true,
+      }),
+    ).toEqual({
+      label: "Loading open pull requests",
+      display: "…",
+      loading: true,
+    })
+  })
+
+  test("marks a missing count unavailable only when settled", () => {
+    expect(
+      openPullRequestCountPresentation({
+        count: undefined,
+        isPending: false,
+        isFetching: false,
+      }),
+    ).toEqual({
+      label: "Open pull requests unavailable",
+      display: "—",
+      loading: false,
+    })
+  })
+})
 
 describe("followOpenPullRequestCountLive", () => {
   test("exports a positive poll interval for GitHub-backed counts", () => {
     expect(OPEN_PULL_REQUEST_COUNT_POLL_INTERVAL_MS).toBeGreaterThan(0)
   })
 
-  test("refetches repositories immediately when the tab becomes visible", async () => {
+  test("uses a dedicated query key distinct from repositories", () => {
+    expect(openPullRequestCountsQueryKey).toEqual(["open-pull-request-counts"])
+    expect(openPullRequestCountsQueryKey).not.toEqual(["repositories"])
+  })
+
+  test("refetches only the dedicated count projection when the tab becomes visible", async () => {
     const queryClient = new QueryClient()
-    let fetches = 0
+    let countFetches = 0
+    let repositoryFetches = 0
+    const openPullRequestCountsQuery = {
+      queryKey: openPullRequestCountsQueryKey,
+      queryFn: async () => {
+        countFetches += 1
+        return {}
+      },
+    }
     const repositoriesQuery = {
       queryKey: ["repositories"] as const,
       queryFn: async () => {
-        fetches += 1
+        repositoryFetches += 1
         return []
       },
     }
+    // Seed repositories so any accidental cancel/refetch would be observable.
+    await queryClient.fetchQuery(repositoriesQuery)
+    repositoryFetches = 0
 
     let visibilityState: DocumentVisibilityState = "hidden"
     const listeners = new Map<string, EventListener>()
@@ -40,34 +121,49 @@ describe("followOpenPullRequestCountLive", () => {
     const controller = new AbortController()
     const follower = followOpenPullRequestCountLive({
       queryClient,
-      repositoriesQuery,
+      openPullRequestCountsQuery,
       signal: controller.signal,
       documentRef,
       pollIntervalMs: 60_000,
     })
 
     await wait(20)
-    expect(fetches).toBe(0)
+    expect(countFetches).toBe(0)
+    expect(repositoryFetches).toBe(0)
 
     visibilityState = "visible"
     listeners.get("visibilitychange")?.(new Event("visibilitychange"))
     await wait(20)
-    expect(fetches).toBe(1)
+    expect(countFetches).toBe(1)
+    expect(repositoryFetches).toBe(0)
+    expect(
+      queryClient.getQueryState(repositoriesQuery.queryKey)?.dataUpdatedAt,
+    ).toBeGreaterThan(0)
 
     controller.abort()
     await follower
   })
 
-  test("polls while visible so external PR changes update without browser refresh", async () => {
+  test("polls only the dedicated count projection while visible", async () => {
     const queryClient = new QueryClient()
-    let fetches = 0
+    let countFetches = 0
+    let repositoryFetches = 0
+    const openPullRequestCountsQuery = {
+      queryKey: openPullRequestCountsQueryKey,
+      queryFn: async () => {
+        countFetches += 1
+        return {}
+      },
+    }
     const repositoriesQuery = {
       queryKey: ["repositories"] as const,
       queryFn: async () => {
-        fetches += 1
+        repositoryFetches += 1
         return []
       },
     }
+    await queryClient.fetchQuery(repositoriesQuery)
+    repositoryFetches = 0
 
     const documentRef = {
       visibilityState: "visible" as DocumentVisibilityState,
@@ -78,14 +174,15 @@ describe("followOpenPullRequestCountLive", () => {
     const controller = new AbortController()
     const follower = followOpenPullRequestCountLive({
       queryClient,
-      repositoriesQuery,
+      openPullRequestCountsQuery,
       signal: controller.signal,
       documentRef,
       pollIntervalMs: 30,
     })
 
     await wait(100)
-    expect(fetches).toBeGreaterThanOrEqual(2)
+    expect(countFetches).toBeGreaterThanOrEqual(2)
+    expect(repositoryFetches).toBe(0)
 
     controller.abort()
     await follower
@@ -94,11 +191,11 @@ describe("followOpenPullRequestCountLive", () => {
   test("skips periodic poll ticks while the tab is hidden", async () => {
     const queryClient = new QueryClient()
     let fetches = 0
-    const repositoriesQuery = {
-      queryKey: ["repositories"] as const,
+    const openPullRequestCountsQuery = {
+      queryKey: openPullRequestCountsQueryKey,
       queryFn: async () => {
         fetches += 1
-        return []
+        return {}
       },
     }
 
@@ -111,7 +208,7 @@ describe("followOpenPullRequestCountLive", () => {
     const controller = new AbortController()
     const follower = followOpenPullRequestCountLive({
       queryClient,
-      repositoriesQuery,
+      openPullRequestCountsQuery,
       signal: controller.signal,
       documentRef,
       pollIntervalMs: 20,
@@ -124,7 +221,7 @@ describe("followOpenPullRequestCountLive", () => {
     await follower
   })
 
-  test("keeps polling after a failed repositories fetch", async () => {
+  test("keeps polling after a failed count fetch without touching repositories", async () => {
     const queryClient = new QueryClient({
       defaultOptions: {
         queries: {
@@ -132,15 +229,83 @@ describe("followOpenPullRequestCountLive", () => {
         },
       },
     })
-    let fetches = 0
+    let countFetches = 0
+    let repositoryFetches = 0
+    const openPullRequestCountsQuery = {
+      queryKey: openPullRequestCountsQueryKey,
+      queryFn: async () => {
+        countFetches += 1
+        if (countFetches === 1) {
+          throw new Error("transient GraphQL failure")
+        }
+        return {}
+      },
+    }
     const repositoriesQuery = {
       queryKey: ["repositories"] as const,
       queryFn: async () => {
-        fetches += 1
-        if (fetches === 1) {
-          throw new Error("transient GraphQL failure")
-        }
+        repositoryFetches += 1
         return []
+      },
+    }
+    await queryClient.fetchQuery(repositoriesQuery)
+    repositoryFetches = 0
+
+    const documentRef = {
+      visibilityState: "visible" as DocumentVisibilityState,
+      addEventListener: () => {},
+      removeEventListener: () => {},
+    }
+
+    const controller = new AbortController()
+    const follower = followOpenPullRequestCountLive({
+      queryClient,
+      openPullRequestCountsQuery,
+      signal: controller.signal,
+      documentRef,
+      pollIntervalMs: 30,
+    })
+
+    await wait(100)
+    expect(countFetches).toBeGreaterThanOrEqual(2)
+    expect(repositoryFetches).toBe(0)
+
+    controller.abort()
+    await follower
+  })
+
+  test("abort does not cancel an in-flight repositories query", async () => {
+    const queryClient = new QueryClient()
+    let repositoriesCompleted = false
+    let repositoriesCanceled = false
+
+    const repositoriesQuery = {
+      queryKey: ["repositories"] as const,
+      queryFn: async () => {
+        await wait(80)
+        repositoriesCompleted = true
+        return [{ id: "repo-1" }]
+      },
+    }
+
+    // Seed cache then start a long-running repositories refetch that must
+    // complete even when the count follower aborts and cancels its own key.
+    await queryClient.fetchQuery(repositoriesQuery)
+    repositoriesCompleted = false
+    const repositoriesRefetch = queryClient
+      .fetchQuery({ ...repositoriesQuery, staleTime: 0 })
+      .then(() => {
+        repositoriesCompleted = true
+      })
+      .catch(() => {
+        repositoriesCanceled = true
+      })
+
+    const openPullRequestCountsQuery = {
+      queryKey: openPullRequestCountsQueryKey,
+      queryFn: async () => {
+        await wait(200)
+        return {}
       },
     }
 
@@ -153,16 +318,18 @@ describe("followOpenPullRequestCountLive", () => {
     const controller = new AbortController()
     const follower = followOpenPullRequestCountLive({
       queryClient,
-      repositoriesQuery,
+      openPullRequestCountsQuery,
       signal: controller.signal,
       documentRef,
-      pollIntervalMs: 30,
+      pollIntervalMs: 60_000,
     })
 
-    await wait(100)
-    expect(fetches).toBeGreaterThanOrEqual(2)
-
+    await wait(10)
     controller.abort()
     await follower
+    await repositoriesRefetch
+
+    expect(repositoriesCanceled).toBe(false)
+    expect(repositoriesCompleted).toBe(true)
   })
 })

--- a/apps/harness/test/refresh-work-items-live.test.ts
+++ b/apps/harness/test/refresh-work-items-live.test.ts
@@ -1,4 +1,5 @@
 import { QueryClient, QueryObserver } from "@tanstack/react-query"
+import { openPullRequestCountsQueryKey } from "../src/refresh-open-pull-request-count-live.js"
 import {
   committedPullRequestsCountQueryKeyPrefix,
   followRepositoryWorkItemsLive,
@@ -350,6 +351,78 @@ describe("Repository Work Item live-query coordination", () => {
     await onChange?.(repositoryId)
     await waitFor(() => countFetches > fetchesAfterConnect)
     expect(queryClient.getQueryData(todayKey)).toBe(23)
+
+    controller.abort()
+    await live
+    stopObserving()
+  })
+
+  test("an invalidation fire-and-forgets open PR counts without awaiting them", async () => {
+    const repositoryId = "repo-01JSELECTED000000000000000"
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    })
+    let openPrCountFetches = 0
+    let workItemsFetches = 0
+    let releaseOpenPrCount: (() => void) | undefined
+    const openPrCountHeld = new Promise<void>((resolve) => {
+      releaseOpenPrCount = resolve
+    })
+    const openPrCountQuery = {
+      queryKey: openPullRequestCountsQueryKey,
+      queryFn: async () => {
+        openPrCountFetches += 1
+        if (openPrCountFetches > 1) {
+          await openPrCountHeld
+        }
+        return { [repositoryId]: openPrCountFetches }
+      },
+    }
+    const stopObserving = observeQuery(queryClient, openPrCountQuery)
+    await queryClient.fetchQuery(openPrCountQuery)
+    expect(openPrCountFetches).toBe(1)
+
+    let onChange: ((repositoryId: string) => void | Promise<void>) | undefined
+    let connected: (() => void) | undefined
+    const connectedPromise = new Promise<void>((resolve) => {
+      connected = resolve
+    })
+    const controller = new AbortController()
+    const live = followRepositoryWorkItemsLive({
+      getRepositoryIds: () => [repositoryId],
+      queryClient,
+      queries: {
+        workItems: (id: string) => ({
+          queryKey: ["work-items", id] as const,
+          queryFn: async () => {
+            workItemsFetches += 1
+            return []
+          },
+        }),
+      },
+      signal: controller.signal,
+      stream: async ({ onConnected, onChange: handleChange, signal }) => {
+        onChange = handleChange
+        await onConnected()
+        connected?.()
+        await new Promise<void>((resolve) => {
+          signal.addEventListener("abort", () => resolve(), { once: true })
+        })
+      },
+    })
+
+    await connectedPromise
+    await waitFor(() => openPrCountFetches >= 2)
+    const workItemsAfterConnect = workItemsFetches
+    expect(workItemsAfterConnect).toBeGreaterThan(0)
+
+    // Event path must finish even while open-PR count refresh is held pending.
+    const changeDone = onChange?.(repositoryId)
+    await changeDone
+    expect(workItemsFetches).toBeGreaterThan(workItemsAfterConnect)
+
+    releaseOpenPrCount?.()
+    await waitFor(() => openPrCountFetches >= 3)
 
     controller.abort()
     await live

--- a/apps/harness/test/repository-header-pr-count.test.ts
+++ b/apps/harness/test/repository-header-pr-count.test.ts
@@ -27,7 +27,7 @@ describe("repository header pull request count", () => {
       "export const repositoriesQuery = {",
     )
     const openCountsStart = source.indexOf(
-      "export const openPullRequestCountsQuery = {",
+      "const openPullRequestCountsQuery = {",
     )
     expect(repositoriesQueryStart).toBeGreaterThan(-1)
     expect(openCountsStart).toBeGreaterThan(repositoriesQueryStart)
@@ -40,10 +40,12 @@ describe("repository header pull request count", () => {
 
   test("dedicated openPullRequestCountsQuery requests pullRequestCount", () => {
     const source = homeSource()
-    expect(source).toContain("export const openPullRequestCountsQuery")
+    // Module-local (not exported): knip treats an unused export as a failure.
+    expect(source).toContain("const openPullRequestCountsQuery = {")
+    expect(source).not.toContain("export const openPullRequestCountsQuery")
     expect(source).toContain("openPullRequestCountsQueryKey")
     const openCountsStart = source.indexOf(
-      "export const openPullRequestCountsQuery = {",
+      "const openPullRequestCountsQuery = {",
     )
     const openCountsEnd = source.indexOf(
       "export type Repository",

--- a/apps/harness/test/repository-header-pr-count.test.ts
+++ b/apps/harness/test/repository-header-pr-count.test.ts
@@ -18,10 +18,40 @@ const openPrCountLiveSource = () =>
   )
 
 describe("repository header pull request count", () => {
-  test("repositories query requests open pullRequestCount", () => {
+  test("main repositories query does not request pullRequestCount", () => {
     const source = homeSource()
-    expect(source).toContain("pullRequestCount: true")
-    expect(source).toContain("pullRequestCount: number")
+    // Dedicated projection owns the count field; the Configured Repositories
+    // selection must not include it.
+    expect(source).toContain("Intentionally omits pullRequestCount")
+    const repositoriesQueryStart = source.indexOf(
+      "export const repositoriesQuery = {",
+    )
+    const openCountsStart = source.indexOf(
+      "export const openPullRequestCountsQuery = {",
+    )
+    expect(repositoriesQueryStart).toBeGreaterThan(-1)
+    expect(openCountsStart).toBeGreaterThan(repositoriesQueryStart)
+    const repositoriesQueryBody = source.slice(
+      repositoriesQueryStart,
+      openCountsStart,
+    )
+    expect(repositoriesQueryBody).not.toContain("pullRequestCount: true")
+  })
+
+  test("dedicated openPullRequestCountsQuery requests pullRequestCount", () => {
+    const source = homeSource()
+    expect(source).toContain("export const openPullRequestCountsQuery")
+    expect(source).toContain("openPullRequestCountsQueryKey")
+    const openCountsStart = source.indexOf(
+      "export const openPullRequestCountsQuery = {",
+    )
+    const openCountsEnd = source.indexOf(
+      "export type Repository",
+      openCountsStart,
+    )
+    const body = source.slice(openCountsStart, openCountsEnd)
+    expect(body).toContain("pullRequestCount: true")
+    expect(body).toContain("id: true")
   })
 
   test("header renders the count immediately after the repository name", () => {
@@ -35,7 +65,7 @@ describe("repository header pull request count", () => {
     expect(headerEnd).toBeGreaterThan(titleIndex)
     const header = source.slice(headerStart, headerEnd)
     const nameInHeader = header.indexOf("{repositoryLabel}")
-    const countInHeader = header.indexOf("{repository.pullRequestCount}")
+    const countInHeader = header.indexOf("{pullRequestCountDisplay}")
     expect(nameInHeader).toBeGreaterThan(-1)
     expect(countInHeader).toBeGreaterThan(nameInHeader)
     expect(header).toContain('className="sr-only"')
@@ -45,29 +75,55 @@ describe("repository header pull request count", () => {
     expect(header).toContain("tabular-nums")
   })
 
-  test("labels describe open PRs; zero uses plural without dropping the digit", () => {
+  test("header uses presentation helper with isPending and isFetching", () => {
     const source = homeSource()
-    expect(source).toContain('? "1 open pull request"')
-    expect(source).toContain("open pull requests`")
-    expect(source).toContain("repository.pullRequestCount === 1")
+    expect(source).toContain("openPullRequestCountPresentation")
+    expect(source).toContain("isFetching: openPullRequestCountsFetching")
+    expect(source).toContain("isPending: openPullRequestCountsPending")
+    expect(source).toContain(
+      "aria-busy={pullRequestCountLoading ? true : undefined}",
+    )
   })
 
-  test("uses GitHub-backed live refresh independent of Work Item SSE", () => {
+  test("uses dedicated GitHub-backed live refresh independent of repositoriesQuery", () => {
     const home = homeSource()
     expect(home).toContain("followOpenPullRequestCountLive")
-    expect(home).toContain("repositoriesQuery")
+    expect(home).toContain("openPullRequestCountsQuery")
+    // Follower must receive the dedicated query, not repositoriesQuery.
+    expect(home).toMatch(
+      /followOpenPullRequestCountLive\(\{\s*queryClient,\s*openPullRequestCountsQuery,/,
+    )
+    // Repository membership SSE fire-and-forgets dedicated counts, then awaits
+    // repositories only — never couples membership catch-up to count latency.
+    expect(home).toContain("streamRepositoryChanges")
+    expect(home).toMatch(
+      /invalidateQueries\(\{\s*queryKey:\s*openPullRequestCountsQueryKey\s*\}\)/,
+    )
+    expect(home).toMatch(
+      /invalidateQueries\(\{\s*queryKey:\s*openPullRequestCountsQueryKey[\s\S]*?fetchQuery\(\{\s*\.\.\.repositoriesQuery/,
+    )
 
     const live = openPrCountLiveSource()
     expect(live).toContain("OPEN_PULL_REQUEST_COUNT_POLL_INTERVAL_MS")
+    expect(live).toContain("openPullRequestCountsQueryKey")
+    expect(live).toContain("openPullRequestCountPresentation")
     expect(live).toContain("visibilitychange")
     expect(live).toContain("GitHub-authoritative")
     expect(live).toContain("External PR changes do not emit Work Item SSE")
+    expect(live).toContain("Never cancels")
+    expect(live).toContain("Configured Repositories")
   })
 
-  test("work-item live refresh still invalidates repositories as a secondary path", () => {
+  test("work-item live refresh fire-and-forgets dedicated count without awaiting", () => {
     const source = refreshSource()
-    expect(source).toContain("pullRequestCount")
-    expect(source).toContain("followOpenPullRequestCountLive")
+    expect(source).toContain("openPullRequestCountsQueryKey")
+    expect(source).toContain("scheduleOpenPullRequestCounts")
+    expect(source).toContain("Fire-and-forget")
+    expect(source).toContain("openPrCountsRefreshPending")
     expect(source).toContain('const repositoriesQueryKey = ["repositories"]')
+    // Must not await the dedicated count projection on the SSE path.
+    expect(source).toMatch(
+      /scheduleOpenPullRequestCounts\(\)\s*\n\s*await Promise\.all/,
+    )
   })
 })

--- a/packages/graphql-api/test/graphql-api.test.ts
+++ b/packages/graphql-api/test/graphql-api.test.ts
@@ -1956,6 +1956,127 @@ describe("GraphQL API", () => {
     })
   })
 
+  test("repositories without pullRequestCount does not invoke GitHub counting", async () => {
+    await runtime.dispose()
+    let countCalls = 0
+    runtime = makeRuntime(
+      {
+        listRepositories: Effect.succeed([repository]),
+      },
+      {},
+      {},
+      {},
+      {},
+      {},
+      {
+        countOpenNonDraftPullRequests: () => {
+          countCalls += 1
+          return Effect.succeed(9)
+        },
+      },
+    )
+
+    const response = await createGraphqlApi(runtime).fetch(
+      graphqlRequest({
+        query: `query {
+          repositories {
+            id
+            projectPath
+            paused
+            blockingUnfinishedWorkItemCount
+          }
+        }`,
+      }),
+    )
+    expect(await response.json()).toEqual({
+      data: {
+        repositories: [
+          {
+            id: repository.id,
+            projectPath: repository.projectPath,
+            paused: repository.paused,
+            blockingUnfinishedWorkItemCount: 0,
+          },
+        ],
+      },
+    })
+    expect(countCalls).toBe(0)
+  })
+
+  test("base repositories query completes while pullRequestCount is held pending", async () => {
+    await runtime.dispose()
+    let releaseCount: (() => void) | undefined
+    const countHeld = new Promise<void>((resolve) => {
+      releaseCount = resolve
+    })
+    let countStarted = false
+    runtime = makeRuntime(
+      {
+        listRepositories: Effect.succeed([repository]),
+      },
+      {},
+      {},
+      {},
+      {},
+      {},
+      {
+        countOpenNonDraftPullRequests: () =>
+          Effect.gen(function* () {
+            countStarted = true
+            yield* Effect.promise(() => countHeld)
+            return 4
+          }),
+      },
+    )
+
+    const api = createGraphqlApi(runtime)
+
+    const baseResponsePromise = api.fetch(
+      graphqlRequest({
+        query: `query {
+          repositories {
+            id
+            projectPath
+            blockingUnfinishedWorkItemCount
+          }
+        }`,
+      }),
+    )
+
+    const countResponsePromise = api.fetch(
+      graphqlRequest({
+        query: `query {
+          repositories { id pullRequestCount }
+        }`,
+      }),
+    )
+
+    // Base Configured Repositories selection must finish without awaiting count.
+    const baseResponse = await baseResponsePromise
+    expect(await baseResponse.json()).toEqual({
+      data: {
+        repositories: [
+          {
+            id: repository.id,
+            projectPath: repository.projectPath,
+            blockingUnfinishedWorkItemCount: 0,
+          },
+        ],
+      },
+    })
+
+    // Allow the held count request a brief moment to start, then release it.
+    await Bun.sleep(20)
+    expect(countStarted).toBe(true)
+    releaseCount?.()
+    const countResponse = await countResponsePromise
+    expect(await countResponse.json()).toEqual({
+      data: {
+        repositories: [{ id: repository.id, pullRequestCount: 4 }],
+      },
+    })
+  })
+
   test("pullRequestCount degrades to zero when GitHub is unavailable", async () => {
     await runtime.dispose()
     runtime = makeRuntime(


### PR DESCRIPTION
## Why

Configured Repositories (and live catch-up paths that refetch them) included
GitHub-authoritative open non-draft PR counts. With Keymaxxer, those counts
queue serialized credential work and delayed Repository cards, credentials,
Issues, Work Items, and controls even when local GraphQL data was healthy.

## What

- Stop selecting `pullRequestCount` on the main Configured Repositories query
  and related mutations; keep `Repository.pullRequestCount` for a dedicated
  client projection (`openPullRequestCountsQuery` / query key).
- Drive header counts from that projection with loading vs unavailable
  presentation (`isPending` / `isFetching` so missing ids during refetch do
  not look permanently unavailable).
- Poll and visibility catch-up refresh only the dedicated count identity;
  never cancel or await the repositories query for counts.
- Fire-and-forget (coalesced) invalidation of open-PR counts from Work Item
  SSE and repository membership refresh so harness-owned membership/PR
  changes stay fresh without coupling SSE completion to GitHub counting.
- GraphQL and harness tests for field laziness, pending independence,
  presentation state, and follower isolation; harness tests run with the
  source condition so migrations match source.

#523 semantics (GitHub open non-draft counts, draft exclusion, degrade on
GitHub failure at the resolver) are unchanged.

## Verification

- harness: open-PR presentation, live follower isolation, Work Item
  fire-and-forget counts, repository-header structure
- graphql-api: repositories without `pullRequestCount` does not count; base
  list completes while count is held pending
- pre-commit (lint/typecheck/affected tests) passed after format fix

Part of #595.

Closes #596