### PR TITLE
fix(keymaxxer): harden MCP dialog timeouts and cancel-before-lane waits

### DIFF
--- a/apps/ready-for-agent/src/host-binary.test.ts
+++ b/apps/ready-for-agent/src/host-binary.test.ts
@@ -86,16 +86,29 @@ describe("compiled host binary ambient-auth smoke", () => {
       throw new Error(hostSelection.message)
     }
 
+    // Call the compile script directly. Nested `bun nx run …:compile` under
+    // `nx affected` (pre-commit) can race the Nx project-graph SQLite DB and
+    // fail with FOREIGN KEY constraint errors even after a successful compile.
+    // `ready-for-agent:test` already depends on generate-embed / graphql generate.
     const compile = Bun.spawnSync(
-      ["bun", "nx", "run", "ready-for-agent:compile", "--args=--platform=host"],
+      [
+        "bun",
+        "--conditions",
+        "@ready-for-agent/source",
+        join(appRoot, "scripts/compile-platform-binary.ts"),
+        "host",
+      ],
       {
         cwd: workspaceRoot,
         stdio: ["ignore", "inherit", "inherit"],
-        env: process.env,
+        env: {
+          ...process.env,
+          NX_DAEMON: "false",
+        },
       },
     )
     if (compile.exitCode !== 0) {
-      throw new Error("ready-for-agent:compile failed")
+      throw new Error("ready-for-agent host compile failed")
     }
 
     const binary = Bun.file(binaryPath)

--- a/packages/keymaxxer-service/README.md
+++ b/packages/keymaxxer-service/README.md
@@ -31,12 +31,17 @@ result; transport, protocol, and execution failures use `KeymaxxerError`.
   Once unlocked, metadata-only `keymaxxer_list` may proceed while a dialog
   operation waits for secret-use approval. Side-effecting failures are not
   replayed; transport failures invalidate the upstream for the next request.
-  Operator logs cover vault unlock (and wrong-passphrase retries) only; the
-  facade does **not** emit a per-call "may require operator interaction" line
-  for every `keymaxxer_run` / `keymaxxer_add`, because it cannot know whether
-  Keymaxxer will show a dialog after Allow-session is set. Dialog-capable
-  ops still share one serialized dialog lane (concurrent already-approved
-  runs are not implemented yet; many GitHub helper calls queue on that lane).
+  Harness→sidecar and sidecar→keyholder MCP tool calls use an explicit
+  human-dialog timeout of at least `KEYMAXXER_HUMAN_DIALOG_TIMEOUT_MS` (300s);
+  `keymaxxer_run` adds the declared child `timeoutMs` to that budget while the
+  child still enforces `timeoutMs` independently. Cancelled callers that have
+  not yet acquired the global dialog lane are removed and never invoke upstream;
+  an already-forwarded operation is not replayed and does not clear shared vault
+  approvals. Operator logs distinguish dialog-lane queue wait, execution failure,
+  and timeout without logging secret names, values, command output, or capability
+  URLs. Dialog-capable ops still share one serialized dialog lane (concurrent
+  already-approved runs are not implemented yet; many GitHub helper calls queue
+  on that lane).
 - `runKeymaxxerSidecarProcess()` — sidecar process body (listen, bootstrap URL,
   signals). Uses zod only for MCP SDK tool `inputSchema` registration; Effect
   client payloads use Schema.

--- a/packages/keymaxxer-service/src/lib/client-service.ts
+++ b/packages/keymaxxer-service/src/lib/client-service.ts
@@ -1,4 +1,4 @@
-import { Effect } from "effect"
+import { Effect, Result } from "effect"
 import {
   type AddSecretInput,
   type FindSecretInput,
@@ -103,7 +103,24 @@ export const makeKeymaxxerClientService = (
     const client = yield* getClient()
     const result = yield* Effect.tryPromise({
       try: () => client.callTool({ name, arguments: args }),
-      catch: () => keymaxxerError(operation, deps.failureMessage(operation)),
+      catch: (error) => {
+        const detail =
+          error instanceof Error
+            ? error.message
+            : typeof error === "object" &&
+                error !== null &&
+                "message" in error &&
+                typeof (error as { message: unknown }).message === "string"
+              ? (error as { message: string }).message
+              : ""
+        const timedOut = /timed out|timeout/i.test(detail)
+        return keymaxxerError(
+          operation,
+          timedOut
+            ? `${deps.failureMessage(operation)}: timed out`
+            : deps.failureMessage(operation),
+        )
+      },
     }).pipe(Effect.tapError(() => resetClient()))
 
     return {
@@ -238,10 +255,44 @@ export const makeKeymaxxerClientService = (
         secrets: [...decoded.secrets],
         timeoutMs: decoded.timeoutMs,
       })
-      return yield* decodeRunWithSecretsResult(
-        result.structuredContent,
-        result.text,
+      // Keymaxxer sets isError when exitCode !== 0 while still returning a normal
+      // exit_code/stdout/stderr payload. Decode that shape first so non-zero
+      // command outcomes are never misclassified as MCP/transport failures.
+      const decodedRun = yield* Effect.result(
+        decodeRunWithSecretsResult(result.structuredContent, result.text),
       )
+      if (Result.isSuccess(decodedRun)) {
+        return decodedRun.success
+      }
+
+      // Facade soft diagnostics only (tight anchors — not substrings in stderr).
+      if (result.isError) {
+        const text = result.text.trim()
+        if (
+          /^error:\s*keymaxxer\s+\S+\s+timed out waiting for the keyholder$/i.test(
+            text,
+          )
+        ) {
+          return yield* keymaxxerError(
+            "runWithSecrets",
+            `${deps.failureMessage("runWithSecrets")}: timed out`,
+          )
+        }
+        if (/^error:\s*request cancelled$/i.test(text)) {
+          return yield* keymaxxerError(
+            "runWithSecrets",
+            `${deps.failureMessage("runWithSecrets")}: cancelled`,
+          )
+        }
+        if (/^error:\s*keymaxxer\s+\S+\s+failed$/i.test(text)) {
+          return yield* keymaxxerError(
+            "runWithSecrets",
+            `${deps.failureMessage("runWithSecrets")}: execution failed`,
+          )
+        }
+      }
+
+      return yield* decodedRun.failure
     },
   )
 

--- a/packages/keymaxxer-service/src/lib/config.ts
+++ b/packages/keymaxxer-service/src/lib/config.ts
@@ -2,6 +2,35 @@ import { Config } from "effect"
 
 export const defaultKeymaxxerSidecarPort = 6057
 
+/**
+ * MCP request timeout budget for human-dialog paths (vault unlock, secret-use
+ * approval, add-secret). Matches the documented OpenCode/Harness remote MCP
+ * timeout (≥ 300s). The MCP SDK default (60s) is too short for those dialogs.
+ */
+export const KEYMAXXER_HUMAN_DIALOG_TIMEOUT_MS = 300_000
+
+/**
+ * Explicit MCP `tools/call` timeout for a Keymaxxer tool.
+ * Dialog-capable paths use at least {@link KEYMAXXER_HUMAN_DIALOG_TIMEOUT_MS}.
+ * For `keymaxxer_run`, the child command bound (`timeoutMs`) is added so MCP
+ * wait time never undercuts the declared execution timeout; the child still
+ * enforces `timeoutMs` independently inside Keymaxxer.
+ */
+export const mcpToolCallTimeoutMs = (
+  name: string,
+  args: Record<string, unknown> = {},
+): number => {
+  if (name === "keymaxxer_run") {
+    const raw = args.timeoutMs
+    const childTimeoutMs =
+      typeof raw === "number" && Number.isFinite(raw) && raw > 0
+        ? Math.trunc(raw)
+        : 0
+    return KEYMAXXER_HUMAN_DIALOG_TIMEOUT_MS + childTimeoutMs
+  }
+  return KEYMAXXER_HUMAN_DIALOG_TIMEOUT_MS
+}
+
 const isValidTcpPort = (port: number): boolean =>
   Number.isInteger(port) && port >= 1 && port <= 65_535
 

--- a/packages/keymaxxer-service/src/lib/facade.ts
+++ b/packages/keymaxxer-service/src/lib/facade.ts
@@ -5,6 +5,7 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js"
 import { WebStandardStreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js"
 import { isInitializeRequest } from "@modelcontextprotocol/sdk/types.js"
 import { z } from "zod"
+import { mcpToolCallTimeoutMs } from "./config.js"
 import { keymaxxerEnvironment, keymaxxerMcpCommand } from "./mcp-layer.js"
 
 export const KEYMAXXER_SIDECAR_URL_PREFIX = "KEYMAXXER_SIDECAR_URL="
@@ -65,6 +66,14 @@ type UpstreamToolResult = {
   structuredContent?: unknown
 }
 
+/** Thrown when a caller is removed before acquiring the global dialog lane. */
+export class DialogLaneCancelledError extends Error {
+  constructor(message = "request cancelled before dialog lane") {
+    super(message)
+    this.name = "DialogLaneCancelledError"
+  }
+}
+
 const createCapability = () => randomBytes(32).toString("base64url")
 
 const constantTimeEqual = (a: string, b: string) => {
@@ -90,20 +99,146 @@ const toolResultText = (result: { readonly content?: unknown }): string =>
         .join("\n")
     : ""
 
+const isTimeoutError = (error: unknown): boolean => {
+  if (typeof error === "object" && error !== null && "code" in error) {
+    // MCP SDK ErrorCode.RequestTimeout
+    if ((error as { code: unknown }).code === -32001) return true
+  }
+  if (error instanceof Error) {
+    return /timed out|timeout/i.test(error.message)
+  }
+  return false
+}
+
+const errorMessageSafe = (error: unknown): string => {
+  if (error instanceof Error) return error.message
+  return String(error)
+}
+
+/**
+ * Wait for a shared promise, but leave that promise running if this waiter is
+ * aborted (e.g. shared unlock must not be cancelled for remaining waiters).
+ */
+const raceAbort = async <T>(
+  promise: Promise<T>,
+  signal?: AbortSignal,
+): Promise<T> => {
+  if (signal === undefined) return promise
+  if (signal.aborted) throw new DialogLaneCancelledError()
+  return new Promise<T>((resolve, reject) => {
+    const onAbort = () => {
+      cleanup()
+      reject(new DialogLaneCancelledError())
+    }
+    const cleanup = () => {
+      signal.removeEventListener("abort", onAbort)
+    }
+    signal.addEventListener("abort", onAbort, { once: true })
+    promise.then(
+      (value) => {
+        cleanup()
+        resolve(value)
+      },
+      (error: unknown) => {
+        cleanup()
+        reject(error)
+      },
+    )
+  })
+}
+
+type DialogLaneOptions = {
+  readonly signal?: AbortSignal
+  readonly onQueueWait?: () => void
+}
+
+/**
+ * Global human-dialog mutex with cancellable waiters.
+ * A waiter aborted before it acquires the lane is removed and never runs `fn`.
+ * Once `fn` starts (forwarded upstream), abort does not stop `fn` and does not
+ * clear shared vault state — the result may simply never be delivered.
+ */
 const makeDialogLane = () => {
-  let chain: Promise<void> = Promise.resolve()
-  return async <T>(fn: () => Promise<T>): Promise<T> => {
-    let release!: () => void
-    const gate = new Promise<void>((resolve) => {
-      release = resolve
+  type Entry = {
+    readonly proceed: () => void
+    readonly fail: (error: unknown) => void
+    settled: boolean
+  }
+
+  let active: Entry | null = null
+  const queue: Entry[] = []
+
+  const removeFromQueue = (entry: Entry) => {
+    const index = queue.indexOf(entry)
+    if (index >= 0) queue.splice(index)
+  }
+
+  const startNext = () => {
+    if (active !== null) return
+    while (queue.length > 0) {
+      const entry = queue.shift()
+      if (entry === undefined) return
+      if (entry.settled) continue
+      active = entry
+      entry.settled = true
+      entry.proceed()
+      return
+    }
+  }
+
+  return async <T>(
+    fn: () => Promise<T>,
+    options: DialogLaneOptions = {},
+  ): Promise<T> => {
+    const { signal, onQueueWait } = options
+    if (signal?.aborted) {
+      throw new DialogLaneCancelledError()
+    }
+
+    const needsWait = active !== null || queue.length > 0
+    if (needsWait) {
+      onQueueWait?.()
+    }
+
+    await new Promise<void>((resolve, reject) => {
+      const entry: Entry = {
+        proceed: () => {
+          resolve()
+        },
+        fail: (error) => {
+          reject(error)
+        },
+        settled: false,
+      }
+
+      const onAbort = () => {
+        // Already acquired: leave in-flight work alone (no replay, no vault clear).
+        if (active === entry) return
+        removeFromQueue(entry)
+        if (!entry.settled) {
+          entry.settled = true
+          entry.fail(new DialogLaneCancelledError())
+        }
+      }
+
+      if (signal !== undefined) {
+        if (signal.aborted) {
+          entry.settled = true
+          entry.fail(new DialogLaneCancelledError())
+          return
+        }
+        signal.addEventListener("abort", onAbort, { once: true })
+      }
+
+      queue.push(entry)
+      startNext()
     })
-    const wait = chain
-    chain = gate
-    await wait
+
     try {
       return await fn()
     } finally {
-      release()
+      active = null
+      startNext()
     }
   }
 }
@@ -130,14 +265,18 @@ const createDefaultUpstream = async (
   await client.connect(transport)
   return {
     callTool: (input) =>
-      client.callTool(input).then(
-        (result) =>
-          result as {
-            content?: unknown
-            isError?: boolean
-            structuredContent?: unknown
-          },
-      ),
+      client
+        .callTool(input, undefined, {
+          timeout: mcpToolCallTimeoutMs(input.name, input.arguments),
+        })
+        .then(
+          (result) =>
+            result as {
+              content?: unknown
+              isError?: boolean
+              structuredContent?: unknown
+            },
+        ),
     close: () => transport.close(),
   }
 }
@@ -147,6 +286,31 @@ const exhaustedUnlockError = (): UpstreamToolResult => ({
     {
       type: "text",
       text: `error: vault unlock failed after ${MAX_UNLOCK_ATTEMPTS} attempts (wrong passphrase).`,
+    },
+  ],
+  isError: true,
+})
+
+const cancelledToolResult = (): UpstreamToolResult => ({
+  content: [{ type: "text", text: "error: request cancelled" }],
+  isError: true,
+})
+
+const timeoutToolResult = (name: string): UpstreamToolResult => ({
+  content: [
+    {
+      type: "text",
+      text: `error: keymaxxer ${name} timed out waiting for the keyholder`,
+    },
+  ],
+  isError: true,
+})
+
+const executionFailureResult = (name: string): UpstreamToolResult => ({
+  content: [
+    {
+      type: "text",
+      text: `error: keymaxxer ${name} failed`,
     },
   ],
   isError: true,
@@ -192,6 +356,14 @@ export const startKeymaxxerFacade = async (
     try {
       return await client.callTool({ name, arguments: args })
     } catch (error) {
+      if (isTimeoutError(error)) {
+        log(`[facade] upstream ${name} timed out`)
+        // Timeouts are not keyholder death; keep the upstream client.
+        return timeoutToolResult(name)
+      }
+      log(
+        `[facade] upstream ${name} execution failed: ${errorMessageSafe(error)}`,
+      )
       if (upstream === client) {
         upstream = null
         upstreamPromise = null
@@ -217,6 +389,7 @@ export const startKeymaxxerFacade = async (
    * Serialized unlock probe via metadata-only `keymaxxer_list`.
    * Wrong passphrase is retried up to MAX_UNLOCK_ATTEMPTS; other failures are not.
    * Must run inside the dialog lane (via {@link sharedUnlockProbe}).
+   * Never cancelled once started — shared vault session benefit.
    */
   const unlockProbe = async (): Promise<UpstreamToolResult> => {
     if (unlockObserved) {
@@ -256,10 +429,13 @@ export const startKeymaxxerFacade = async (
   /**
    * Single-flight unlock: concurrent waiters share one probe result.
    * A later independent request may start a new probe after this settles.
+   * The probe itself is not abortable; individual waiters may race-abort.
    */
   const sharedUnlockProbe = (): Promise<UpstreamToolResult> => {
     if (unlockInFlight !== null) return unlockInFlight
-    unlockInFlight = dialogLane(unlockProbe).then(
+    unlockInFlight = dialogLane(unlockProbe, {
+      onQueueWait: () => log("[facade] waiting for dialog lane (unlock)"),
+    }).then(
       (result) => {
         unlockInFlight = null
         return result
@@ -278,9 +454,11 @@ export const startKeymaxxerFacade = async (
    * `unlockObserved` flag after the dialog lane releases (TOCTOU with transport
    * recovery). Never return a successful list payload as a run/add outcome.
    */
-  const ensureUnlocked = async (): Promise<UpstreamToolResult | null> => {
+  const ensureUnlocked = async (
+    signal?: AbortSignal,
+  ): Promise<UpstreamToolResult | null> => {
     if (unlockObserved) return null
-    const result = await sharedUnlockProbe()
+    const result = await raceAbort(sharedUnlockProbe(), signal)
     if (result.isError === true) {
       return result
     }
@@ -290,41 +468,63 @@ export const startKeymaxxerFacade = async (
   const forwardTool = async (
     name: string,
     args: Record<string, unknown>,
+    signal?: AbortSignal,
   ): Promise<UpstreamToolResult> => {
-    if (name === "keymaxxer_list") {
-      // Once unlocked, metadata-only list bypasses a run/add waiting on approval.
-      if (unlockObserved) {
-        return noteListResult(await callUpstream(name, args))
+    try {
+      if (name === "keymaxxer_list") {
+        // Once unlocked, metadata-only list bypasses a run/add waiting on approval.
+        if (unlockObserved) {
+          if (signal?.aborted) throw new DialogLaneCancelledError()
+          return noteListResult(await callUpstream(name, args))
+        }
+        return await raceAbort(sharedUnlockProbe(), signal)
       }
-      return sharedUnlockProbe()
-    }
 
-    // Dialog-producing operations: unlock first (separate dialog-lane acquisition
-    // so metadata list can proceed while this op later waits on approval), then
-    // re-check unlock inside the op lane before calling upstream. Re-check covers
-    // transport recovery or concurrent re-lock that clears unlockObserved after
-    // ensureUnlocked returned. Call unlockProbe directly here — not
-    // sharedUnlockProbe — to avoid re-entering dialogLane while holding it.
-    if (!unlockObserved) {
-      const unlockFailure = await ensureUnlocked()
-      if (unlockFailure !== null) {
-        return unlockFailure
-      }
-    }
-
-    return dialogLane(async () => {
+      // Dialog-producing operations: unlock first (separate dialog-lane acquisition
+      // so metadata list can proceed while this op later waits on approval), then
+      // re-check unlock inside the op lane before calling upstream. Re-check covers
+      // transport recovery or concurrent re-lock that clears unlockObserved after
+      // ensureUnlocked returned. Call unlockProbe directly here — not
+      // sharedUnlockProbe — to avoid re-entering dialogLane while holding it.
       if (!unlockObserved) {
-        log(`[facade] re-probing vault unlock before ${name}`)
-        const unlockResult = await unlockProbe()
-        if (unlockResult.isError === true) {
-          return unlockResult
+        const unlockFailure = await ensureUnlocked(signal)
+        if (unlockFailure !== null) {
+          return unlockFailure
         }
       }
-      // No preemptive per-call "may require operator interaction" log: the facade
-      // cannot know if Keymaxxer will dialog, and that line spam looks stuck after
-      // Allow-session (#547). Unlock waits stay in unlockProbe only.
-      return callUpstream(name, args)
-    })
+
+      return await dialogLane(
+        async () => {
+          if (!unlockObserved) {
+            log(`[facade] re-probing vault unlock before ${name}`)
+            const unlockResult = await unlockProbe()
+            if (unlockResult.isError === true) {
+              return unlockResult
+            }
+          }
+          // No preemptive per-call "may require operator interaction" log: the facade
+          // cannot know if Keymaxxer will dialog, and that line spam looks stuck after
+          // Allow-session. Unlock waits stay in unlockProbe only.
+          try {
+            return await callUpstream(name, args)
+          } catch {
+            // callUpstream already logs and converts timeouts; remaining throws
+            // are execution/transport failures (client already invalidated).
+            return executionFailureResult(name)
+          }
+        },
+        {
+          signal,
+          onQueueWait: () => log(`[facade] waiting for dialog lane (${name})`),
+        },
+      )
+    } catch (error) {
+      if (error instanceof DialogLaneCancelledError) {
+        // Caller left before delivery; SDK already dropped the response when aborted.
+        return cancelledToolResult()
+      }
+      throw error
+    }
   }
 
   const createServer = () => {
@@ -340,8 +540,8 @@ export const startKeymaxxerFacade = async (
           "List the secrets in the vault with their attributes. Returns NO secret values.",
         inputSchema: {},
       },
-      async () => {
-        const result = await forwardTool("keymaxxer_list", {})
+      async (_args, extra) => {
+        const result = await forwardTool("keymaxxer_list", {}, extra.signal)
         return result as {
           content: { type: "text"; text: string }[]
           isError?: boolean
@@ -361,8 +561,8 @@ export const startKeymaxxerFacade = async (
           timeoutMs: z.number().optional(),
         },
       },
-      async (args) => {
-        const result = await forwardTool("keymaxxer_run", args)
+      async (args, extra) => {
+        const result = await forwardTool("keymaxxer_run", args, extra.signal)
         return result as {
           content: { type: "text"; text: string }[]
           isError?: boolean
@@ -384,8 +584,8 @@ export const startKeymaxxerFacade = async (
           tags: z.string().optional(),
         },
       },
-      async (args) => {
-        const result = await forwardTool("keymaxxer_add", args)
+      async (args, extra) => {
+        const result = await forwardTool("keymaxxer_add", args, extra.signal)
         return result as {
           content: { type: "text"; text: string }[]
           isError?: boolean

--- a/packages/keymaxxer-service/src/lib/http-layer.ts
+++ b/packages/keymaxxer-service/src/lib/http-layer.ts
@@ -5,6 +5,7 @@ import {
   type KeymaxxerToolClient,
   makeKeymaxxerClientService,
 } from "./client-service.js"
+import { mcpToolCallTimeoutMs } from "./config.js"
 import { type KeymaxxerError, keymaxxerError } from "./models.js"
 import { KeymaxxerService } from "./service.js"
 
@@ -139,7 +140,11 @@ const createStreamableHttpClient = async (
   await client.connect(transport)
   return {
     callTool: (input) =>
-      client.callTool(input).then((result) => result as never),
+      client
+        .callTool(input, undefined, {
+          timeout: mcpToolCallTimeoutMs(input.name, input.arguments),
+        })
+        .then((result) => result as never),
     close: () => transport.close(),
   }
 }

--- a/packages/keymaxxer-service/src/lib/mcp-layer.ts
+++ b/packages/keymaxxer-service/src/lib/mcp-layer.ts
@@ -6,6 +6,7 @@ import {
   type KeymaxxerToolClient,
   makeKeymaxxerClientService,
 } from "./client-service.js"
+import { mcpToolCallTimeoutMs } from "./config.js"
 import { KeymaxxerService } from "./service.js"
 
 export type { KeymaxxerToolClient, ToolResult } from "./client-service.js"
@@ -48,7 +49,11 @@ const createToolClient = async (
 
   return {
     callTool: (input) =>
-      client.callTool(input).then((result) => result as never),
+      client
+        .callTool(input, undefined, {
+          timeout: mcpToolCallTimeoutMs(input.name, input.arguments),
+        })
+        .then((result) => result as never),
     close: () => transport.close(),
   }
 }

--- a/packages/keymaxxer-service/test/facade.test.ts
+++ b/packages/keymaxxer-service/test/facade.test.ts
@@ -1,10 +1,12 @@
 import { Client } from "@modelcontextprotocol/sdk/client/index.js"
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js"
 import {
+  KEYMAXXER_HUMAN_DIALOG_TIMEOUT_MS,
   KEYMAXXER_SIDECAR_URL_PREFIX,
   type KeymaxxerUpstreamClient,
   MAX_UNLOCK_ATTEMPTS,
   isWrongPassphraseResult,
+  mcpToolCallTimeoutMs,
   startKeymaxxerFacade,
 } from "../src/index.js"
 import { describe, expect, test } from "bun:test"
@@ -706,12 +708,373 @@ describe("Keymaxxer MCP facade security surface", () => {
             /operator interaction/i.test(line),
         )
         expect(interactionLines).toEqual([])
-        // Unlock probe stays visible; successful runs must not add more facade noise.
-        expect(logs.filter((line) => line.startsWith("[facade]"))).toEqual([
-          "[facade] waiting for vault unlock",
-        ])
+        // Unlock probe stays visible; successful runs may log dialog-lane queue wait
+        // only — never secret names, capability URLs, or operator-interaction spam.
+        const facadeLines = logs.filter((line) => line.startsWith("[facade]"))
+        expect(facadeLines[0]).toBe("[facade] waiting for vault unlock")
+        for (const line of facadeLines.slice(1)) {
+          expect(line).toMatch(
+            /^\[facade\] waiting for dialog lane \(keymaxxer_run\)$/,
+          )
+          expect(line).not.toMatch(/DEMO|secret|\/mcp|capabilit/i)
+        }
       } finally {
         await connection.transport.close()
+      }
+    } finally {
+      await facade.stop()
+    }
+  })
+
+  test("mcpToolCallTimeoutMs covers the dialog budget and run child timeout", () => {
+    expect(KEYMAXXER_HUMAN_DIALOG_TIMEOUT_MS).toBeGreaterThanOrEqual(300_000)
+    expect(mcpToolCallTimeoutMs("keymaxxer_list")).toBe(
+      KEYMAXXER_HUMAN_DIALOG_TIMEOUT_MS,
+    )
+    expect(mcpToolCallTimeoutMs("keymaxxer_add")).toBe(
+      KEYMAXXER_HUMAN_DIALOG_TIMEOUT_MS,
+    )
+    expect(mcpToolCallTimeoutMs("keymaxxer_run", { timeoutMs: 5_000 })).toBe(
+      KEYMAXXER_HUMAN_DIALOG_TIMEOUT_MS + 5_000,
+    )
+    // Child timeout is independent: MCP wait is dialog + child, not child alone.
+    expect(
+      mcpToolCallTimeoutMs("keymaxxer_run", { timeoutMs: 1_000 }),
+    ).toBeGreaterThan(1_000)
+  })
+
+  test("cancelling a waiter before the dialog lane never invokes upstream later", async () => {
+    let runCalls = 0
+    let releaseFirst!: () => void
+    const firstGate = new Promise<void>((resolve) => {
+      releaseFirst = resolve
+    })
+    const firstStarted = Promise.withResolvers<void>()
+    const logs: string[] = []
+
+    const facade = await startKeymaxxerFacade({
+      host: "127.0.0.1",
+      port: 0,
+      createUpstream: async () => ({
+        callTool: async ({ name }) => {
+          if (name === "keymaxxer_list") return listResult()
+          if (name === "keymaxxer_run") {
+            runCalls += 1
+            if (runCalls === 1) {
+              firstStarted.resolve()
+              await firstGate
+            }
+            return runOkResult()
+          }
+          return { content: [{ type: "text", text: "ok" }] }
+        },
+        close: async () => {},
+      }),
+      onBootstrapUrl: () => {},
+      log: (message) => {
+        logs.push(message)
+      },
+    })
+
+    try {
+      const [holder, waiter] = await Promise.all([
+        connectClient(facade.url),
+        connectClient(facade.url),
+      ])
+      try {
+        await holder.client.callTool({ name: "keymaxxer_list", arguments: {} })
+
+        const firstRun = holder.client.callTool({
+          name: "keymaxxer_run",
+          arguments: { command: "true", secrets: ["DEMO"] },
+        })
+        await firstStarted.promise
+
+        const abort = new AbortController()
+        const secondRun = waiter.client.callTool(
+          {
+            name: "keymaxxer_run",
+            arguments: { command: "echo cancelled", secrets: ["DEMO"] },
+          },
+          undefined,
+          { signal: abort.signal },
+        )
+
+        // Wait until the second caller is known to be queued on the dialog lane.
+        for (let i = 0; i < 50; i++) {
+          if (
+            logs.some((line) =>
+              line.includes("waiting for dialog lane (keymaxxer_run)"),
+            )
+          ) {
+            break
+          }
+          await Bun.sleep(10)
+        }
+        expect(
+          logs.some((line) =>
+            line.includes("waiting for dialog lane (keymaxxer_run)"),
+          ),
+        ).toBe(true)
+        expect(runCalls).toBe(1)
+
+        abort.abort()
+        await expect(secondRun).rejects.toBeDefined()
+
+        // Give the facade a tick to drop the waiter before releasing the lane.
+        await Bun.sleep(30)
+        releaseFirst()
+        const firstResult = await firstRun
+        expect(firstResult.isError).not.toBe(true)
+
+        // Cancelled waiter must never have launched upstream after the holder finished.
+        expect(runCalls).toBe(1)
+      } finally {
+        await holder.transport.close()
+        await waiter.transport.close()
+      }
+    } finally {
+      await facade.stop()
+    }
+  })
+
+  test("cancelling one session does not cancel another session's in-flight run", async () => {
+    let runCalls = 0
+    let releaseRun!: () => void
+    const runGate = new Promise<void>((resolve) => {
+      releaseRun = resolve
+    })
+    const runStarted = Promise.withResolvers<void>()
+
+    const facade = await startKeymaxxerFacade({
+      host: "127.0.0.1",
+      port: 0,
+      createUpstream: async () => ({
+        callTool: async ({ name }) => {
+          if (name === "keymaxxer_list") return listResult()
+          if (name === "keymaxxer_run") {
+            runCalls += 1
+            runStarted.resolve()
+            await runGate
+            return runOkResult()
+          }
+          return { content: [{ type: "text", text: "ok" }] }
+        },
+        close: async () => {},
+      }),
+      onBootstrapUrl: () => {},
+      log: () => {},
+    })
+
+    try {
+      const [runner, other] = await Promise.all([
+        connectClient(facade.url),
+        connectClient(facade.url),
+      ])
+      try {
+        await other.client.callTool({ name: "keymaxxer_list", arguments: {} })
+
+        const runPromise = runner.client.callTool({
+          name: "keymaxxer_run",
+          arguments: { command: "true", secrets: ["DEMO"] },
+        })
+        await runStarted.promise
+        expect(runCalls).toBe(1)
+
+        // Closing another session must not abort the runner's upstream work.
+        await other.transport.close()
+
+        // Metadata remains available on a fresh session while run is held.
+        const observer = await connectClient(facade.url)
+        try {
+          const listWhileRun = await observer.client.callTool({
+            name: "keymaxxer_list",
+            arguments: {},
+          })
+          expect(listWhileRun.isError).not.toBe(true)
+          expect(toolText(listWhileRun)).toContain("DEMO")
+        } finally {
+          await observer.transport.close()
+        }
+
+        releaseRun()
+        const runResult = await runPromise
+        expect(runResult.isError).not.toBe(true)
+        expect(runCalls).toBe(1)
+      } finally {
+        await runner.transport.close()
+      }
+    } finally {
+      await facade.stop()
+    }
+  })
+
+  test("cancel after upstream forward does not replay the run", async () => {
+    let runCalls = 0
+    let releaseRun!: () => void
+    const runGate = new Promise<void>((resolve) => {
+      releaseRun = resolve
+    })
+    const runStarted = Promise.withResolvers<void>()
+
+    const facade = await startKeymaxxerFacade({
+      host: "127.0.0.1",
+      port: 0,
+      createUpstream: async () => ({
+        callTool: async ({ name }) => {
+          if (name === "keymaxxer_list") return listResult()
+          if (name === "keymaxxer_run") {
+            runCalls += 1
+            runStarted.resolve()
+            await runGate
+            return runOkResult()
+          }
+          return { content: [{ type: "text", text: "ok" }] }
+        },
+        close: async () => {},
+      }),
+      onBootstrapUrl: () => {},
+      log: () => {},
+    })
+
+    try {
+      const connection = await connectClient(facade.url)
+      try {
+        await connection.client.callTool({
+          name: "keymaxxer_list",
+          arguments: {},
+        })
+
+        const abort = new AbortController()
+        const runPromise = connection.client.callTool(
+          {
+            name: "keymaxxer_run",
+            arguments: { command: "true", secrets: ["DEMO"] },
+          },
+          undefined,
+          { signal: abort.signal },
+        )
+        await runStarted.promise
+        expect(runCalls).toBe(1)
+
+        // Cancel after forward: upstream may finish without delivering a result.
+        abort.abort()
+        await expect(runPromise).rejects.toBeDefined()
+
+        releaseRun()
+        // Allow the orphaned upstream call to settle without a second launch.
+        await Bun.sleep(30)
+        expect(runCalls).toBe(1)
+
+        // Shared vault session remains usable (unlock/approvals not cleared).
+        const after = await connection.client.callTool({
+          name: "keymaxxer_list",
+          arguments: {},
+        })
+        expect(after.isError).not.toBe(true)
+      } finally {
+        await connection.transport.close()
+      }
+    } finally {
+      await facade.stop()
+    }
+  })
+
+  test("queue wait, execution failure, and timeout diagnostics are distinct", async () => {
+    const logs: string[] = []
+    let runCalls = 0
+    let releaseFirst!: () => void
+    const firstGate = new Promise<void>((resolve) => {
+      releaseFirst = resolve
+    })
+    const firstStarted = Promise.withResolvers<void>()
+
+    const facade = await startKeymaxxerFacade({
+      host: "127.0.0.1",
+      port: 0,
+      createUpstream: async () => ({
+        callTool: async ({ name }) => {
+          if (name === "keymaxxer_list") return listResult()
+          if (name === "keymaxxer_run") {
+            runCalls += 1
+            if (runCalls === 1) {
+              firstStarted.resolve()
+              await firstGate
+              return runOkResult()
+            }
+            if (runCalls === 2) {
+              const timeoutError = Object.assign(
+                new Error("Request timed out"),
+                {
+                  code: -32001,
+                },
+              )
+              throw timeoutError
+            }
+            throw new Error("keyholder crashed")
+          }
+          return { content: [{ type: "text", text: "ok" }] }
+        },
+        close: async () => {},
+      }),
+      onBootstrapUrl: () => {},
+      log: (message) => {
+        logs.push(message)
+      },
+    })
+
+    try {
+      const [a, b] = await Promise.all([
+        connectClient(facade.url),
+        connectClient(facade.url),
+      ])
+      try {
+        await a.client.callTool({ name: "keymaxxer_list", arguments: {} })
+
+        const first = a.client.callTool({
+          name: "keymaxxer_run",
+          arguments: { command: "true", secrets: ["DEMO"] },
+        })
+        await firstStarted.promise
+
+        const second = b.client.callTool({
+          name: "keymaxxer_run",
+          arguments: { command: "true", secrets: ["DEMO"] },
+        })
+        for (let i = 0; i < 50; i++) {
+          if (logs.some((line) => line.includes("waiting for dialog lane"))) {
+            break
+          }
+          await Bun.sleep(10)
+        }
+        releaseFirst()
+        await first
+        const timedOut = await second
+        expect(timedOut.isError).toBe(true)
+        expect(toolText(timedOut)).toMatch(/timed out/i)
+
+        const crashed = await a.client.callTool({
+          name: "keymaxxer_run",
+          arguments: { command: "true", secrets: ["DEMO"] },
+        })
+        expect(crashed.isError).toBe(true)
+        expect(toolText(crashed)).toMatch(/failed/i)
+
+        expect(
+          logs.some((line) => line.includes("waiting for dialog lane")),
+        ).toBe(true)
+        expect(logs.some((line) => line.includes("timed out"))).toBe(true)
+        expect(logs.some((line) => line.includes("execution failed"))).toBe(
+          true,
+        )
+        for (const line of logs) {
+          expect(line).not.toMatch(
+            /DEMO|secret value|capability|Authorization|exit_code/i,
+          )
+        }
+      } finally {
+        await a.transport.close()
+        await b.transport.close()
       }
     } finally {
       await facade.stop()

--- a/packages/keymaxxer-service/test/mcp-layer.test.ts
+++ b/packages/keymaxxer-service/test/mcp-layer.test.ts
@@ -1,4 +1,4 @@
-import { Effect } from "effect"
+import { Cause, Effect, Option } from "effect"
 import {
   KeymaxxerService,
   type KeymaxxerToolClient,
@@ -284,6 +284,78 @@ describe("MCP Keymaxxer layer", () => {
       stdout: "machine output",
       stderr: "diagnostic",
     })
+  })
+
+  test("decodes isError non-zero runs even when stderr contains failed or timed out", async () => {
+    // Keymaxxer sets isError for exitCode !== 0 while still returning a run
+    // payload. Soft MCP diagnostics must not steal ordinary command failures.
+    const client: KeymaxxerToolClient = {
+      callTool: async () =>
+        textResult(
+          "exit_code: 1\n--- stdout ---\n\n--- stderr ---\ncommand failed: request timed out\n",
+          true,
+        ),
+      close: async () => {},
+    }
+
+    const result = await Effect.runPromise(
+      Effect.gen(function* () {
+        const keymaxxer = yield* KeymaxxerService
+        return yield* keymaxxer.runWithSecrets({
+          command: "false",
+          cwd: "/tmp",
+          secrets: ["A_SECRET"],
+          timeoutMs: 1_000,
+        })
+      }).pipe(
+        Effect.provide(mcpKeymaxxerLayer({ createClient: async () => client })),
+      ),
+    )
+
+    expect(result).toEqual({
+      exitCode: 1,
+      stdout: "",
+      stderr: "command failed: request timed out\n",
+    })
+  })
+
+  test("maps facade soft timeout diagnostics without decoding as a command result", async () => {
+    const client: KeymaxxerToolClient = {
+      callTool: async () =>
+        textResult(
+          "error: keymaxxer keymaxxer_run timed out waiting for the keyholder",
+          true,
+        ),
+      close: async () => {},
+    }
+
+    const exit = await Effect.runPromise(
+      Effect.gen(function* () {
+        const keymaxxer = yield* KeymaxxerService
+        return yield* Effect.exit(
+          keymaxxer.runWithSecrets({
+            command: "true",
+            cwd: "/tmp",
+            secrets: ["A_SECRET"],
+            timeoutMs: 1_000,
+          }),
+        )
+      }).pipe(
+        Effect.provide(mcpKeymaxxerLayer({ createClient: async () => client })),
+      ),
+    )
+
+    expect(exit._tag).toBe("Failure")
+    if (exit._tag === "Failure") {
+      const error = Option.getOrThrow(Cause.findErrorOption(exit.cause))
+      expect(error).toMatchObject({
+        _tag: "KeymaxxerError",
+        operation: "runWithSecrets",
+      })
+      expect(String((error as { message?: string }).message ?? error)).toMatch(
+        /timed out/i,
+      )
+    }
   })
 
   test("prefers structured command results", async () => {


### PR DESCRIPTION
## Why

Keymaxxer vault unlock and secret-use approval need a long human-dialog
window, but the MCP SDK default request timeout (60s) is too short. Under
load, abandoned callers (for example cancelled browser work) could also
remain on the global dialog lane and still launch upstream later, stacking
unnecessary secret-bearing work behind real Agent Turns and reconciliation.

## What changed

- Set an explicit human-dialog MCP budget of at least 300s on both legs:
  Harness→Sidecar (`http-layer`) and Sidecar→keyholder (`facade` /
  `mcp-layer`).
- For `keymaxxer_run`, MCP wait is dialog budget + declared child
  `timeoutMs`; the child still enforces `timeoutMs` independently.
- Reworked the facade dialog lane so a waiter cancelled **before** acquiring
  the lane is removed and never invokes upstream; cancel **after** forward
  does not replay and does not clear shared vault approvals.
- Kept cross-session isolation, post-unlock metadata list during a blocked
  run, and global serialization of unlock/approval/add-secret paths.
- Operator logs distinguish dialog-lane queue wait, execution failure, and
  timeout without secret names, values, command output, or capability URLs.
- `runWithSecrets` decodes Keymaxxer run payloads first (including non-zero
  exits that set `isError`), and only maps tight facade diagnostic lines
  (`error: keymaxxer … timed out…` / `failed` / `request cancelled`) to
  transport-style errors.
- Host binary ambient-auth smoke compiles via the platform script directly
  (with `NX_DAEMON=false`) instead of nested `nx run …:compile` under
  pre-commit.

## Verification

- `packages/keymaxxer-service` facade and MCP-layer tests: concurrent MCP
  clients cover cancel-before-lane, cancel-after-forward, cross-session
  cancel, diagnostics, timeout budgets, and decode-first non-zero run
  regression.
- Typecheck for `keymaxxer-service`.

## Limitations / follow-ups

- Cold-start unlock + dialog-producing run can need ~two dialog windows on
  the keyholder while Harness→Sidecar currently budgets one dialog window
  (+ child for run); clients that unlock via list first are unaffected.
- Soft timeout classification for list/add remains coarser than for run.

Closes #601