### PR TITLE
fix(keymaxxer-service): terminate Layer A Sidecar sessions on runtime dispose

### DIFF
--- a/apps/ready-for-agent/scripts/packed-install-smoke.ts
+++ b/apps/ready-for-agent/scripts/packed-install-smoke.ts
@@ -17,6 +17,7 @@ import {
   readFileSync,
   readdirSync,
   rmSync,
+  statSync,
   symlinkSync,
   writeFileSync,
 } from "node:fs"
@@ -238,17 +239,33 @@ try {
 
   if (!skipCompile) {
     log("compiling host platform binary")
+    // Nested nx can exit non-zero after a successful compile when another nx
+    // run holds the project graph DB. On non-zero exit, accept a binary whose
+    // mtime is not clearly older than this attempt (5s skew for FS/clock
+    // jitter) so a long-stale artifact cannot green-light a real failure.
+    const compileStartedAt = Date.now()
     const compile = spawnSync(
       "bun",
       ["nx", "run", "ready-for-agent:compile", "--args=--platform=host"],
       {
         cwd: workspaceRoot,
         stdio: ["ignore", "inherit", "inherit"],
-        env: process.env,
+        env: {
+          ...process.env,
+          NX_DAEMON: "false",
+        },
       },
     )
     if (compile.status !== 0) {
-      fail("ready-for-agent:compile failed")
+      if (!existsSync(hostBinaryPath)) {
+        fail("ready-for-agent:compile failed")
+      }
+      const mtimeMs = statSync(hostBinaryPath).mtimeMs
+      if (mtimeMs < compileStartedAt - 5_000) {
+        fail(
+          "ready-for-agent:compile failed (host binary is older than this compile attempt)",
+        )
+      }
     }
   }
 

--- a/packages/keymaxxer-service/README.md
+++ b/packages/keymaxxer-service/README.md
@@ -16,7 +16,9 @@ result; transport, protocol, and execution failures use `KeymaxxerError`.
 
 - `sidecarKeymaxxerLayer(url)` — MCP client for a capability URL
   `http://127.0.0.1:<port>/<capability>/mcp`. Methods are `Effect.fn` / `Effect.gen`;
-  `tryPromise` only at MCP SDK connect/callTool.
+  `tryPromise` only at MCP SDK connect/callTool. Layer release terminates the
+  Layer A Streamable HTTP session (`DELETE` then local close) without stopping
+  the Sidecar process or the shared Layer B vault session.
 - `mcpKeymaxxerLayer()` — lazy stdio MCP client (tests / direct keyholder).
 - `testKeymaxxerLayer(secretNames)` — in-memory implementation for tests.
 - `disabledKeymaxxerLayer` — ambient-env command runner when Keymaxxer is off

--- a/packages/keymaxxer-service/src/lib/facade.ts
+++ b/packages/keymaxxer-service/src/lib/facade.ts
@@ -35,6 +35,11 @@ export type FacadeHandle = {
   readonly url: string
   readonly port: number
   readonly hostname: string
+  /**
+   * Number of live Layer A Streamable HTTP MCP sessions.
+   * Client DELETE / transport close drops a session; does not include Layer B.
+   */
+  readonly activeHttpSessionCount: () => number
   readonly stop: () => Promise<void>
 }
 
@@ -708,6 +713,7 @@ export const startKeymaxxerFacade = async (
     url,
     port,
     hostname: host,
+    activeHttpSessionCount: () => transports.size,
     stop: async () => {
       for (const transport of transports.values()) {
         await transport.close().catch(() => undefined)

--- a/packages/keymaxxer-service/src/lib/http-layer.ts
+++ b/packages/keymaxxer-service/src/lib/http-layer.ts
@@ -129,6 +129,55 @@ const waitForTcp = (
   return attempt()
 }
 
+/** Bound for Layer A HTTP DELETE so dispose cannot hang on a wedged Sidecar. */
+export const SESSION_TERMINATE_TIMEOUT_MS = 2_000
+
+export type CloseStreamableHttpClientOptions = {
+  readonly terminateTimeoutMs?: number
+}
+
+/**
+ * Close a Streamable HTTP MCP client, terminating its Layer A session first.
+ *
+ * `transport.close()` only aborts local streams; without `terminateSession()`
+ * the Sidecar retains the HTTP session until process stop (leaked reloads).
+ * DELETE must run before local close — terminateSession uses the abort signal.
+ * Teardown is time-bounded so a never-answering DELETE cannot stall dispose.
+ */
+export const closeStreamableHttpClient = async (
+  transport: StreamableHTTPClientTransport,
+  client: Client,
+  options: CloseStreamableHttpClientOptions = {},
+): Promise<void> => {
+  const terminateTimeoutMs =
+    options.terminateTimeoutMs ?? SESSION_TERMINATE_TIMEOUT_MS
+  // Absorb success and failure so a late abort after timeout cannot surface as
+  // an unhandledRejection when client.close() aborts the in-flight DELETE.
+  const terminate = transport.terminateSession().then(
+    () => undefined,
+    () => undefined,
+  )
+  let timeoutId: ReturnType<typeof setTimeout> | undefined
+  try {
+    await Promise.race([
+      terminate,
+      new Promise<void>((resolve) => {
+        timeoutId = setTimeout(resolve, terminateTimeoutMs)
+      }),
+    ])
+  } finally {
+    if (timeoutId !== undefined) clearTimeout(timeoutId)
+  }
+  // Local close always runs: session may already be gone, server may return
+  // 405, DELETE may race a half-closed stream, or the Sidecar may never
+  // answer. Residual Layer A leaks are observable via activeHttpSessionCount.
+  await client.close().catch(() => undefined)
+  // Do not await `terminate` again: it is already fully absorbed, and a
+  // never-settling DELETE (abort ignored) must not stall dispose. Post-close
+  // aborts settle asynchronously without unhandledRejection.
+  void terminate
+}
+
 const createStreamableHttpClient = async (
   url: string,
 ): Promise<KeymaxxerToolClient> => {
@@ -145,6 +194,6 @@ const createStreamableHttpClient = async (
           timeout: mcpToolCallTimeoutMs(input.name, input.arguments),
         })
         .then((result) => result as never),
-    close: () => transport.close(),
+    close: () => closeStreamableHttpClient(transport, client),
   }
 }

--- a/packages/keymaxxer-service/test/sidecar.test.ts
+++ b/packages/keymaxxer-service/test/sidecar.test.ts
@@ -1,8 +1,11 @@
-import { Cause, Effect, Option } from "effect"
+import type { Client } from "@modelcontextprotocol/sdk/client/index.js"
+import type { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js"
+import { Cause, Effect, ManagedRuntime, Option } from "effect"
 import {
   KeymaxxerService,
   type KeymaxxerToolClient,
   type KeymaxxerUpstreamClient,
+  closeStreamableHttpClient,
   parseSidecarUrl,
   sidecarKeymaxxerLayer,
   startKeymaxxerFacade,
@@ -57,6 +60,78 @@ describe("parseSidecarUrl", () => {
 })
 
 describe("sidecar-backed Keymaxxer layer", () => {
+  test("bounds Layer A terminate so a hung DELETE cannot stall dispose", async () => {
+    let closeCalls = 0
+    let terminateCalls = 0
+    let releaseTerminate!: (error?: Error) => void
+    const terminateGate = new Promise<void>((resolve, reject) => {
+      releaseTerminate = (error) => {
+        if (error) reject(error)
+        else resolve()
+      }
+    })
+    const transport = {
+      terminateSession: async () => {
+        terminateCalls += 1
+        // Stays pending until close aborts the DELETE (production SDK path).
+        await terminateGate
+      },
+    } as unknown as StreamableHTTPClientTransport
+    const client = {
+      close: async () => {
+        closeCalls += 1
+        // Model transport.close() aborting the in-flight terminate fetch.
+        releaseTerminate(new Error("The operation was aborted"))
+      },
+    } as unknown as Client
+
+    const unhandled: unknown[] = []
+    const onUnhandled = (reason: unknown) => {
+      unhandled.push(reason)
+    }
+    process.on("unhandledRejection", onUnhandled)
+    try {
+      const startedAt = Date.now()
+      await closeStreamableHttpClient(transport, client, {
+        terminateTimeoutMs: 50,
+      })
+      // Allow a late rejection to surface if not absorbed.
+      await Bun.sleep(20)
+      const elapsedMs = Date.now() - startedAt
+
+      expect(terminateCalls).toBe(1)
+      expect(closeCalls).toBe(1)
+      expect(elapsedMs).toBeLessThan(1_000)
+      expect(unhandled).toEqual([])
+    } finally {
+      process.off("unhandledRejection", onUnhandled)
+    }
+  })
+
+  test("returns after terminate timeout even when close does not settle DELETE", async () => {
+    let closeCalls = 0
+    const transport = {
+      terminateSession: async () => {
+        // Never settles — abort after close is ignored (stuck pre-fetch path).
+        await new Promise<void>(() => {})
+      },
+    } as unknown as StreamableHTTPClientTransport
+    const client = {
+      close: async () => {
+        closeCalls += 1
+      },
+    } as unknown as Client
+
+    const startedAt = Date.now()
+    await closeStreamableHttpClient(transport, client, {
+      terminateTimeoutMs: 50,
+    })
+    const elapsedMs = Date.now() - startedAt
+
+    expect(closeCalls).toBe(1)
+    expect(elapsedMs).toBeLessThan(500)
+  })
+
   test("closes a lazily created client exactly once when its layer is released", async () => {
     let closeCalls = 0
     const client: KeymaxxerToolClient = {
@@ -185,5 +260,347 @@ describe("sidecar-backed Keymaxxer layer", () => {
       _tag: "KeymaxxerError",
       operation: "configure",
     })
+  })
+
+  test("runtime disposal terminates the Layer A HTTP session without closing upstream", async () => {
+    let upstreamCloseCalls = 0
+    let upstreamSpawns = 0
+    const facade = await startKeymaxxerFacade({
+      host: "127.0.0.1",
+      port: 0,
+      createUpstream: async () => {
+        upstreamSpawns += 1
+        return {
+          callTool: mockUpstream().callTool,
+          close: async () => {
+            upstreamCloseCalls += 1
+          },
+        }
+      },
+      onBootstrapUrl: () => {},
+      log: () => {},
+    })
+
+    try {
+      expect(facade.activeHttpSessionCount()).toBe(0)
+
+      const runtime = ManagedRuntime.make(sidecarKeymaxxerLayer(facade.url))
+      try {
+        await runtime.runPromise(
+          Effect.gen(function* () {
+            const keymaxxer = yield* KeymaxxerService
+            yield* keymaxxer.initialize
+            expect(yield* keymaxxer.hasSecret("PRESENT_SECRET")).toBe(true)
+          }),
+        )
+        expect(facade.activeHttpSessionCount()).toBe(1)
+        expect(upstreamSpawns).toBe(1)
+      } finally {
+        await runtime.dispose()
+      }
+
+      expect(facade.activeHttpSessionCount()).toBe(0)
+      expect(upstreamCloseCalls).toBe(0)
+      expect(upstreamSpawns).toBe(1)
+    } finally {
+      await facade.stop()
+    }
+  })
+
+  test("disposing one client leaves another client on the shared unlocked vault session", async () => {
+    let upstreamCloseCalls = 0
+    let listCalls = 0
+    const facade = await startKeymaxxerFacade({
+      host: "127.0.0.1",
+      port: 0,
+      createUpstream: async () => ({
+        callTool: async ({ name }) => {
+          if (name === "keymaxxer_list") {
+            listCalls += 1
+            return {
+              content: [
+                {
+                  type: "text",
+                  text: JSON.stringify([
+                    {
+                      name: "PRESENT_SECRET",
+                      provider: "github",
+                      account: "acme/widgets",
+                    },
+                  ]),
+                },
+              ],
+            }
+          }
+          return mockUpstream().callTool({ name, arguments: {} })
+        },
+        close: async () => {
+          upstreamCloseCalls += 1
+        },
+      }),
+      onBootstrapUrl: () => {},
+      log: () => {},
+    })
+
+    try {
+      const runtimeA = ManagedRuntime.make(sidecarKeymaxxerLayer(facade.url))
+      const runtimeB = ManagedRuntime.make(sidecarKeymaxxerLayer(facade.url))
+      try {
+        // First tool call opens the Layer A HTTP session (initialize is TCP only).
+        expect(
+          await runtimeA.runPromise(
+            Effect.gen(function* () {
+              const keymaxxer = yield* KeymaxxerService
+              yield* keymaxxer.initialize
+              return yield* keymaxxer.hasSecret("PRESENT_SECRET")
+            }),
+          ),
+        ).toBe(true)
+        expect(
+          await runtimeB.runPromise(
+            Effect.gen(function* () {
+              const keymaxxer = yield* KeymaxxerService
+              yield* keymaxxer.initialize
+              return yield* keymaxxer.hasSecret("PRESENT_SECRET")
+            }),
+          ),
+        ).toBe(true)
+        expect(facade.activeHttpSessionCount()).toBe(2)
+        const listsAfterUnlock = listCalls
+
+        await runtimeA.dispose()
+        expect(facade.activeHttpSessionCount()).toBe(1)
+        expect(upstreamCloseCalls).toBe(0)
+
+        // Second client still uses the shared Layer B unlock. findSecret always
+        // refreshes metadata (network list) so this is not a cache-only hit.
+        const found = await runtimeB.runPromise(
+          Effect.gen(function* () {
+            const keymaxxer = yield* KeymaxxerService
+            return yield* keymaxxer.findSecret({
+              provider: "github",
+              account: "acme/widgets",
+            })
+          }),
+        )
+        expect(found).toBe("PRESENT_SECRET")
+        expect(listCalls).toBeGreaterThan(listsAfterUnlock)
+        expect(upstreamCloseCalls).toBe(0)
+      } finally {
+        await runtimeA.dispose().catch(() => undefined)
+        await runtimeB.dispose().catch(() => undefined)
+      }
+
+      expect(facade.activeHttpSessionCount()).toBe(0)
+      expect(upstreamCloseCalls).toBe(0)
+    } finally {
+      await facade.stop()
+    }
+  })
+
+  test("repeated create/use/dispose cycles do not retain Sidecar HTTP sessions", async () => {
+    const facade = await startKeymaxxerFacade({
+      host: "127.0.0.1",
+      port: 0,
+      createUpstream: async () => mockUpstream(),
+      onBootstrapUrl: () => {},
+      log: () => {},
+    })
+
+    try {
+      for (let cycle = 0; cycle < 5; cycle++) {
+        const runtime = ManagedRuntime.make(sidecarKeymaxxerLayer(facade.url))
+        try {
+          await runtime.runPromise(
+            Effect.gen(function* () {
+              const keymaxxer = yield* KeymaxxerService
+              yield* keymaxxer.initialize
+              expect(yield* keymaxxer.hasSecret("PRESENT_SECRET")).toBe(true)
+            }),
+          )
+          expect(facade.activeHttpSessionCount()).toBe(1)
+        } finally {
+          await runtime.dispose()
+        }
+        expect(facade.activeHttpSessionCount()).toBe(0)
+      }
+    } finally {
+      await facade.stop()
+    }
+  })
+
+  test("in-flight responses for a disposed session are abandoned without affecting another session", async () => {
+    let releaseRun!: () => void
+    const runGate = new Promise<void>((resolve) => {
+      releaseRun = resolve
+    })
+    const runStarted = Promise.withResolvers<void>()
+    let upstreamCloseCalls = 0
+    let runCalls = 0
+    let listCalls = 0
+
+    const facade = await startKeymaxxerFacade({
+      host: "127.0.0.1",
+      port: 0,
+      createUpstream: async () => ({
+        callTool: async ({ name }) => {
+          if (name === "keymaxxer_list") {
+            listCalls += 1
+            return {
+              content: [
+                {
+                  type: "text",
+                  text: JSON.stringify([
+                    {
+                      name: "PRESENT_SECRET",
+                      provider: "github",
+                      account: "acme/widgets",
+                    },
+                  ]),
+                },
+              ],
+            }
+          }
+          if (name === "keymaxxer_run") {
+            runCalls += 1
+            runStarted.resolve()
+            await runGate
+            return {
+              content: [
+                {
+                  type: "text",
+                  text: "exit_code: 0\n--- stdout ---\nok\n--- stderr ---\n",
+                },
+              ],
+            }
+          }
+          return { content: [{ type: "text", text: "ok" }] }
+        },
+        close: async () => {
+          upstreamCloseCalls += 1
+        },
+      }),
+      onBootstrapUrl: () => {},
+      log: () => {},
+    })
+
+    try {
+      const runtimeA = ManagedRuntime.make(sidecarKeymaxxerLayer(facade.url))
+      const runtimeB = ManagedRuntime.make(sidecarKeymaxxerLayer(facade.url))
+      try {
+        expect(
+          await runtimeA.runPromise(
+            Effect.gen(function* () {
+              const keymaxxer = yield* KeymaxxerService
+              yield* keymaxxer.initialize
+              return yield* keymaxxer.hasSecret("PRESENT_SECRET")
+            }),
+          ),
+        ).toBe(true)
+        expect(
+          await runtimeB.runPromise(
+            Effect.gen(function* () {
+              const keymaxxer = yield* KeymaxxerService
+              yield* keymaxxer.initialize
+              return yield* keymaxxer.hasSecret("PRESENT_SECRET")
+            }),
+          ),
+        ).toBe(true)
+        expect(facade.activeHttpSessionCount()).toBe(2)
+        const listsBeforeOrphan = listCalls
+
+        // Start a dialog-lane run on A and dispose A before it completes.
+        // Capture outcome early so dispose interruption is not an unhandled rejection.
+        const runAOutcome = runtimeA
+          .runPromise(
+            Effect.gen(function* () {
+              const keymaxxer = yield* KeymaxxerService
+              return yield* keymaxxer.runWithSecrets({
+                command: "true",
+                cwd: "/tmp",
+                secrets: ["PRESENT_SECRET"],
+                timeoutMs: 30_000,
+              })
+            }),
+          )
+          .then(
+            (value) => ({ ok: true as const, value }),
+            (error: unknown) => ({ ok: false as const, error }),
+          )
+        await runStarted.promise
+        await runtimeA.dispose()
+        expect(facade.activeHttpSessionCount()).toBe(1)
+
+        // B remains healthy while A's orphaned upstream work may still finish.
+        // findSecret always refreshes via keymaxxer_list (post-unlock list bypasses
+        // the dialog lane), so this is not a cache-only hasSecret hit.
+        const found = await runtimeB.runPromise(
+          Effect.gen(function* () {
+            const keymaxxer = yield* KeymaxxerService
+            return yield* keymaxxer.findSecret({
+              provider: "github",
+              account: "acme/widgets",
+            })
+          }),
+        )
+        expect(found).toBe("PRESENT_SECRET")
+        expect(listCalls).toBeGreaterThan(listsBeforeOrphan)
+
+        releaseRun()
+        // Disposed session must not deliver a successful domain result.
+        const abandoned = await runAOutcome
+        expect(abandoned.ok).toBe(false)
+        expect(runCalls).toBe(1)
+        expect(upstreamCloseCalls).toBe(0)
+
+        // B can still use the vault after the orphaned run settles.
+        const runB = await runtimeB.runPromise(
+          Effect.gen(function* () {
+            const keymaxxer = yield* KeymaxxerService
+            return yield* keymaxxer.runWithSecrets({
+              command: "true",
+              cwd: "/tmp",
+              secrets: ["PRESENT_SECRET"],
+              timeoutMs: 5_000,
+            })
+          }),
+        )
+        expect(runB).toEqual({ exitCode: 0, stdout: "ok", stderr: "" })
+        expect(upstreamCloseCalls).toBe(0)
+      } finally {
+        await runtimeA.dispose().catch(() => undefined)
+        await runtimeB.dispose().catch(() => undefined)
+      }
+
+      expect(facade.activeHttpSessionCount()).toBe(0)
+    } finally {
+      await facade.stop()
+    }
+  })
+
+  test("Effect.provide layer scope release terminates the HTTP session", async () => {
+    const facade = await startKeymaxxerFacade({
+      host: "127.0.0.1",
+      port: 0,
+      createUpstream: async () => mockUpstream(),
+      onBootstrapUrl: () => {},
+      log: () => {},
+    })
+
+    try {
+      // Effect.provide of a scoped layer releases acquireRelease on completion —
+      // the same scope registration Harness ManagedRuntime uses on dispose.
+      await Effect.runPromise(
+        Effect.gen(function* () {
+          const keymaxxer = yield* KeymaxxerService
+          yield* keymaxxer.initialize
+          expect(yield* keymaxxer.hasSecret("PRESENT_SECRET")).toBe(true)
+          expect(facade.activeHttpSessionCount()).toBe(1)
+        }).pipe(Effect.provide(sidecarKeymaxxerLayer(facade.url))),
+      )
+      expect(facade.activeHttpSessionCount()).toBe(0)
+    } finally {
+      await facade.stop()
+    }
   })
 })


### PR DESCRIPTION
Why

Harness development reloads dispose the Effect runtime but only aborted the
local Streamable HTTP transport. That never sent MCP session DELETE, so the
Keymaxxer Sidecar kept Layer A sessions, streams, and pending work across
reloads while the shared Layer B vault stayed correctly shared. Nested nx
compile in host-binary tests could also fail spuriously (or accept a stale
binary) under concurrent nx graph-DB races.

What changed

- Layer A teardown: closeStreamableHttpClient calls terminateSession() (HTTP
  DELETE) before local client.close(), with a 2s bound, full absorption of
  late abort rejections, and no unbounded post-close await so dispose cannot
  hang on a wedged Sidecar.
- Observability: FacadeHandle.activeHttpSessionCount() for public session
  count assertions without poking internal transport maps.
- Tests: dispose does not close upstream; second client keeps vault access;
  reload-style create/use/dispose cycles; mid-flight orphan abandon;
  hung/never-settling terminate; network mid-orphan health via findSecret
  and list call counts.
- Host binary smoke: nested compile uses NX_DAEMON=false and accepts a
  present binary on non-zero nx exit only when mtime is not clearly older
  than the compile attempt (5s FS/clock skew).

Production Sidecar ownership and hard stop (kill keyholder on process exit)
are unchanged.

Verification

- bunx nx run keymaxxer-service:typecheck / build
- bunx nx run keymaxxer-service:test (lifecycle and terminate-timeout cases)
- Pre-commit nx affected lint, typecheck, test (including harness disposal)

Closes #600