### PR TITLE
fix(harness): coalesce Keymaxxer open PR counts with a lightweight helper

### DIFF
--- a/apps/harness/src/server/keymaxxer-github-layer.ts
+++ b/apps/harness/src/server/keymaxxer-github-layer.ts
@@ -1,4 +1,4 @@
-import { Effect, Layer, Schema } from "effect"
+import { Deferred, Effect, Exit, Layer, Ref, Schema } from "effect"
 import {
   type GitHubHelperOperation,
   type GitHubRepository,
@@ -13,6 +13,34 @@ import {
   sanitizeUserFacingText,
 } from "@ready-for-agent/github-service"
 import { KeymaxxerService } from "@ready-for-agent/keymaxxer-service"
+
+/**
+ * Successful Keymaxxer-backed open non-draft PR counts may be reused for this
+ * long so concurrent tabs, reconnects, and closely spaced invalidations share
+ * one helper invocation. Kept well below the UI poll interval (30s) so the
+ * automatic visible-tab refresh still observes GitHub changes after expiry.
+ */
+export const OPEN_PULL_REQUEST_COUNT_FRESHNESS_MS = 5_000
+
+type GitHubCountError = GitHubRepositoryUnavailableError | GitHubRequestError
+
+type OpenPullRequestCountCacheEntry =
+  | {
+      readonly kind: "inflight"
+      readonly deferred: Deferred.Deferred<number, GitHubCountError>
+    }
+  | {
+      readonly kind: "success"
+      readonly count: number
+      readonly fetchedAtMs: number
+    }
+
+const openPullRequestCountCacheKey = (repository: GitHubRepository): string =>
+  [
+    repository.forge.toLowerCase(),
+    repository.forgeHost.toLowerCase(),
+    repository.projectPath.toLowerCase(),
+  ].join("\0")
 
 const PositiveInt = Schema.Int.pipe(Schema.check(Schema.isGreaterThan(0)))
 const NonNegativeInt = Schema.Int.pipe(
@@ -232,11 +260,26 @@ const parseIssues = (
 
 export const keymaxxerGitHubLayer = (options: {
   readonly workspaceRoot: string
+  /**
+   * Override the successful-count freshness window (tests and experiments).
+   * Defaults to {@link OPEN_PULL_REQUEST_COUNT_FRESHNESS_MS}.
+   */
+  readonly openPullRequestCountFreshnessMs?: number
+  /** Injectable clock for freshness tests. Defaults to `Date.now`. */
+  readonly nowMs?: () => number
 }): Layer.Layer<GitHubService, never, KeymaxxerService> =>
   Layer.effect(
     GitHubService,
     Effect.gen(function* () {
       const keymaxxer = yield* KeymaxxerService
+      const layerScope = yield* Effect.scope
+      const countFreshnessMs =
+        options.openPullRequestCountFreshnessMs ??
+        OPEN_PULL_REQUEST_COUNT_FRESHNESS_MS
+      const nowMs = options.nowMs ?? Date.now
+      const openPullRequestCountCache = yield* Ref.make(
+        new Map<string, OpenPullRequestCountCacheEntry>(),
+      )
       const ensureToken = Effect.fn("KeymaxxerGitHub.ensureToken")(
         (repository: GitHubRepository) =>
           keymaxxer.findSecret({
@@ -266,6 +309,148 @@ export const keymaxxerGitHubLayer = (options: {
             ),
           ),
       )
+
+      const fetchOpenNonDraftPullRequestCount = (
+        repository: GitHubRepository,
+      ): Effect.Effect<number, GitHubCountError> =>
+        Effect.gen(function* () {
+          const tokenName = yield* ensureToken(repository)
+          if (tokenName === null) {
+            return yield* requestError(
+              repository,
+              "count open non-draft pull requests",
+            )
+          }
+          const [forge, forgeHost, projectPath] =
+            encodedRepositoryArguments(repository)
+          const result = yield* runGitHubBin(
+            tokenName,
+            "count-open-non-draft-pull-requests",
+            [forge, forgeHost, projectPath],
+          )
+          if (result.exitCode === 2) {
+            return yield* repositoryUnavailable(repository)
+          }
+          if (result.exitCode !== 0) {
+            return yield* requestError(
+              repository,
+              "count open non-draft pull requests",
+              result.stderr || result.stdout,
+            )
+          }
+          // Empty body on exit 0 must not become Number("") === 0 and then be
+          // success-cached as a genuine open-PR count of zero.
+          const trimmed = result.stdout.trim()
+          if (trimmed === "") {
+            return yield* requestError(
+              repository,
+              "decode open non-draft pull request count",
+              "empty stdout",
+            )
+          }
+          const count = Number(trimmed)
+          if (!Number.isSafeInteger(count) || count < 0) {
+            return yield* requestError(
+              repository,
+              "decode open non-draft pull request count",
+              result.stdout,
+            )
+          }
+          return count
+        }).pipe(
+          Effect.catchTag("KeymaxxerError", () =>
+            Effect.fail(
+              requestError(repository, "count open non-draft pull requests"),
+            ),
+          ),
+        )
+
+      /**
+       * Process-wide single-flight + short success cache per Repository.
+       * Concurrent callers share one Keymaxxer helper; failures are never
+       * stored as a successful zero.
+       */
+      const countOpenNonDraftPullRequestsCoalesced = Effect.fn(
+        "KeymaxxerGitHub.countOpenNonDraftPullRequests",
+      )(function* (repository: GitHubRepository) {
+        const key = openPullRequestCountCacheKey(repository)
+        const candidate = yield* Deferred.make<number, GitHubCountError>()
+
+        type Claim =
+          | { readonly role: "owner" }
+          | {
+              readonly role: "join"
+              readonly deferred: Deferred.Deferred<number, GitHubCountError>
+            }
+          | { readonly role: "cached"; readonly count: number }
+
+        const claim = yield* Ref.modify(
+          openPullRequestCountCache,
+          (cache): [Claim, Map<string, OpenPullRequestCountCacheEntry>] => {
+            const current = cache.get(key)
+            const observedAt = nowMs()
+            if (
+              current?.kind === "success" &&
+              observedAt - current.fetchedAtMs < countFreshnessMs
+            ) {
+              return [{ role: "cached", count: current.count }, cache]
+            }
+            if (current?.kind === "inflight") {
+              return [{ role: "join", deferred: current.deferred }, cache]
+            }
+            const next = new Map(cache)
+            next.set(key, { kind: "inflight", deferred: candidate })
+            return [{ role: "owner" }, next]
+          },
+        )
+
+        if (claim.role === "cached") {
+          return claim.count
+        }
+        if (claim.role === "join") {
+          return yield* Deferred.await(claim.deferred)
+        }
+
+        // Use Exit (not Effect.result) so interrupt/defect also settles the
+        // shared Deferred and clears inflight; otherwise joiners could hang.
+        // Settle is uninterruptible so layer teardown cannot leave joiners
+        // waiting after the fetch Exit is already known.
+        yield* fetchOpenNonDraftPullRequestCount(repository).pipe(
+          Effect.exit,
+          Effect.flatMap((exit) =>
+            Effect.uninterruptible(
+              Effect.gen(function* () {
+                yield* Ref.update(openPullRequestCountCache, (cache) => {
+                  const next = new Map(cache)
+                  const current = next.get(key)
+                  if (
+                    current?.kind !== "inflight" ||
+                    current.deferred !== candidate
+                  ) {
+                    return cache
+                  }
+                  if (Exit.isSuccess(exit)) {
+                    next.set(key, {
+                      kind: "success",
+                      count: exit.value,
+                      fetchedAtMs: nowMs(),
+                    })
+                  } else {
+                    // Failures / interrupt must not leave a permanent inflight
+                    // entry or be stored as a successful zero.
+                    next.delete(key)
+                  }
+                  return next
+                })
+                yield* Deferred.done(candidate, exit)
+              }),
+            ),
+          ),
+          Effect.forkIn(layerScope, { startImmediately: true }),
+        )
+
+        return yield* Deferred.await(candidate)
+      })
 
       const service: GitHubServiceShape = {
         getAuthenticatedUserLogin: (repository) =>
@@ -505,48 +690,7 @@ export const keymaxxerGitHubLayer = (options: {
               ),
             ),
           ),
-        countOpenNonDraftPullRequests: (repository) =>
-          Effect.gen(function* () {
-            const tokenName = yield* ensureToken(repository)
-            if (tokenName === null) {
-              return yield* requestError(
-                repository,
-                "count open non-draft pull requests",
-              )
-            }
-            const [forge, forgeHost, projectPath] =
-              encodedRepositoryArguments(repository)
-            const result = yield* runGitHubBin(
-              tokenName,
-              "count-open-non-draft-pull-requests",
-              [forge, forgeHost, projectPath],
-            )
-            if (result.exitCode === 2) {
-              return yield* repositoryUnavailable(repository)
-            }
-            if (result.exitCode !== 0) {
-              return yield* requestError(
-                repository,
-                "count open non-draft pull requests",
-                result.stderr || result.stdout,
-              )
-            }
-            const count = Number(result.stdout.trim())
-            if (!Number.isSafeInteger(count) || count < 0) {
-              return yield* requestError(
-                repository,
-                "decode open non-draft pull request count",
-                result.stdout,
-              )
-            }
-            return count
-          }).pipe(
-            Effect.catchTag("KeymaxxerError", () =>
-              Effect.fail(
-                requestError(repository, "count open non-draft pull requests"),
-              ),
-            ),
-          ),
+        countOpenNonDraftPullRequests: countOpenNonDraftPullRequestsCoalesced,
         getPullRequestCheckStatus: (repository, headRefName) =>
           Effect.gen(function* () {
             const tokenName = yield* ensureToken(repository)

--- a/apps/harness/test/keymaxxer-github-layer.test.ts
+++ b/apps/harness/test/keymaxxer-github-layer.test.ts
@@ -1,4 +1,4 @@
-import { Effect, Layer } from "effect"
+import { Effect, Exit, Layer } from "effect"
 import {
   GitHubRequestError,
   GitHubService,
@@ -7,8 +7,23 @@ import {
   KeymaxxerService,
   type RunWithSecretsInput,
 } from "@ready-for-agent/keymaxxer-service"
-import { keymaxxerGitHubLayer } from "../src/server/keymaxxer-github-layer.js"
+import {
+  OPEN_PULL_REQUEST_COUNT_FRESHNESS_MS,
+  keymaxxerGitHubLayer,
+} from "../src/server/keymaxxer-github-layer.js"
 import { describe, expect, test } from "bun:test"
+
+const acmeWidgets = {
+  forge: "github",
+  forgeHost: "github.com",
+  projectPath: "acme/widgets",
+} as const
+
+const acmeGadgets = {
+  forge: "github",
+  forgeHost: "github.com",
+  projectPath: "acme/gadgets",
+} as const
 
 describe("Keymaxxer-backed GitHub layer", () => {
   test("does not prompt Keymaxxer when a repository token is missing", async () => {
@@ -339,6 +354,46 @@ describe("Keymaxxer-backed GitHub layer", () => {
     expect(runs[0]?.secrets).toEqual(["GITHUB_TOKEN_ACME_WIDGETS"])
   })
 
+  test("empty stdout on exit 0 is a decode error and is not success-cached as zero", async () => {
+    const runs: RunWithSecretsInput[] = []
+    let clock = 50_000
+    const keymaxxerLayer = Layer.succeed(KeymaxxerService, {
+      initialize: Effect.void,
+      findSecret: () => Effect.succeed("GITHUB_TOKEN_ACME_WIDGETS"),
+      findSecrets: () => Effect.die("not used"),
+      hasSecret: () => Effect.die("not used"),
+      addSecret: () => Effect.die("not used"),
+      runWithSecrets: (input) => {
+        runs.push(input)
+        if (runs.length === 1) {
+          return Effect.succeed({ exitCode: 0, stdout: "   ", stderr: "" })
+        }
+        return Effect.succeed({ exitCode: 0, stdout: "3", stderr: "" })
+      },
+    })
+    const layer = keymaxxerGitHubLayer({
+      workspaceRoot: "/workspace",
+      openPullRequestCountFreshnessMs: 60_000,
+      nowMs: () => clock,
+    }).pipe(Layer.provide(keymaxxerLayer))
+
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        const github = yield* GitHubService
+        const first = yield* Effect.exit(
+          github.countOpenNonDraftPullRequests(acmeWidgets),
+        )
+        expect(Exit.isFailure(first)).toBe(true)
+
+        clock += 10
+        const second = yield* github.countOpenNonDraftPullRequests(acmeWidgets)
+        expect(second).toBe(3)
+      }).pipe(Effect.provide(layer)),
+    )
+
+    expect(runs).toHaveLength(2)
+  })
+
   test("decodes no_checks and pending terminalChecks from the bin", async () => {
     const responses = [
       JSON.stringify({
@@ -628,5 +683,282 @@ describe("Keymaxxer-backed GitHub layer", () => {
     expect(error.message).toBe(
       "Failed to list Ready-labeled Issues for acme/widgets",
     )
+  })
+
+  test("freshness window is shorter than the UI open-PR count poll interval", () => {
+    // UI poll is 30_000ms; reuse must expire so automatic refresh can observe changes.
+    expect(OPEN_PULL_REQUEST_COUNT_FRESHNESS_MS).toBeGreaterThan(0)
+    expect(OPEN_PULL_REQUEST_COUNT_FRESHNESS_MS).toBeLessThan(30_000)
+  })
+
+  test("concurrent count requests for one Repository share one Keymaxxer helper", async () => {
+    const runs: RunWithSecretsInput[] = []
+    let releaseHelper: (() => void) | undefined
+    const helperHeld = new Promise<void>((resolve) => {
+      releaseHelper = resolve
+    })
+    let helperStarts = 0
+    const keymaxxerLayer = Layer.succeed(KeymaxxerService, {
+      initialize: Effect.void,
+      findSecret: () => Effect.succeed("GITHUB_TOKEN_ACME_WIDGETS"),
+      findSecrets: () => Effect.die("not used"),
+      hasSecret: () => Effect.die("not used"),
+      addSecret: () => Effect.die("not used"),
+      runWithSecrets: (input) =>
+        Effect.gen(function* () {
+          runs.push(input)
+          helperStarts += 1
+          yield* Effect.promise(() => helperHeld)
+          return { exitCode: 0, stdout: "7", stderr: "" }
+        }),
+    })
+    const layer = keymaxxerGitHubLayer({ workspaceRoot: "/workspace" }).pipe(
+      Layer.provide(keymaxxerLayer),
+    )
+
+    const countsPromise = Effect.runPromise(
+      Effect.gen(function* () {
+        const github = yield* GitHubService
+        return yield* Effect.all(
+          [
+            github.countOpenNonDraftPullRequests(acmeWidgets),
+            github.countOpenNonDraftPullRequests(acmeWidgets),
+          ],
+          { concurrency: 2 },
+        )
+      }).pipe(Effect.provide(layer)),
+    )
+
+    for (let i = 0; i < 100 && helperStarts < 1; i += 1) {
+      await Bun.sleep(5)
+    }
+    expect(helperStarts).toBe(1)
+    releaseHelper?.()
+    const counts = await countsPromise
+
+    expect(counts).toEqual([7, 7])
+    expect(runs).toHaveLength(1)
+    expect(runs[0]?.command).toContain("count-open-non-draft-pull-requests.ts")
+    expect(runs[0]?.secrets).toEqual(["GITHUB_TOKEN_ACME_WIDGETS"])
+  })
+
+  test("count requests for different Repositories never share credentials or results", async () => {
+    const runs: RunWithSecretsInput[] = []
+    const tokens = new Map([
+      ["acme/widgets", "TOKEN_WIDGETS"],
+      ["acme/gadgets", "TOKEN_GADGETS"],
+    ])
+    const keymaxxerLayer = Layer.succeed(KeymaxxerService, {
+      initialize: Effect.void,
+      findSecret: ({ account }) => Effect.succeed(tokens.get(account) ?? null),
+      findSecrets: () => Effect.die("not used"),
+      hasSecret: () => Effect.die("not used"),
+      addSecret: () => Effect.die("not used"),
+      runWithSecrets: (input) => {
+        runs.push(input)
+        const stdout = input.secrets[0] === "TOKEN_WIDGETS" ? "2" : "9"
+        return Effect.succeed({ exitCode: 0, stdout, stderr: "" })
+      },
+    })
+    const layer = keymaxxerGitHubLayer({ workspaceRoot: "/workspace" }).pipe(
+      Layer.provide(keymaxxerLayer),
+    )
+
+    const counts = await Effect.runPromise(
+      Effect.gen(function* () {
+        const github = yield* GitHubService
+        return yield* Effect.all(
+          [
+            github.countOpenNonDraftPullRequests(acmeWidgets),
+            github.countOpenNonDraftPullRequests(acmeGadgets),
+          ],
+          { concurrency: 2 },
+        )
+      }).pipe(Effect.provide(layer)),
+    )
+
+    expect(counts).toEqual([2, 9])
+    expect(runs).toHaveLength(2)
+    expect(runs.map(({ secrets }) => secrets).sort()).toEqual([
+      ["TOKEN_GADGETS"],
+      ["TOKEN_WIDGETS"],
+    ])
+  })
+
+  test("closely spaced successful counts reuse the freshness window without a second helper", async () => {
+    const runs: RunWithSecretsInput[] = []
+    let clock = 1_000
+    const keymaxxerLayer = Layer.succeed(KeymaxxerService, {
+      initialize: Effect.void,
+      findSecret: () => Effect.succeed("GITHUB_TOKEN_ACME_WIDGETS"),
+      findSecrets: () => Effect.die("not used"),
+      hasSecret: () => Effect.die("not used"),
+      addSecret: () => Effect.die("not used"),
+      runWithSecrets: (input) => {
+        runs.push(input)
+        return Effect.succeed({
+          exitCode: 0,
+          stdout: String(runs.length),
+          stderr: "",
+        })
+      },
+    })
+    const layer = keymaxxerGitHubLayer({
+      workspaceRoot: "/workspace",
+      openPullRequestCountFreshnessMs: 5_000,
+      nowMs: () => clock,
+    }).pipe(Layer.provide(keymaxxerLayer))
+
+    const counts = await Effect.runPromise(
+      Effect.gen(function* () {
+        const github = yield* GitHubService
+        const first = yield* github.countOpenNonDraftPullRequests(acmeWidgets)
+        clock += 1_000
+        const second = yield* github.countOpenNonDraftPullRequests(acmeWidgets)
+        return [first, second] as const
+      }).pipe(Effect.provide(layer)),
+    )
+
+    expect(counts).toEqual([1, 1])
+    expect(runs).toHaveLength(1)
+  })
+
+  test("expiry permits a later request to observe a changed GitHub count", async () => {
+    const runs: RunWithSecretsInput[] = []
+    let clock = 10_000
+    const keymaxxerLayer = Layer.succeed(KeymaxxerService, {
+      initialize: Effect.void,
+      findSecret: () => Effect.succeed("GITHUB_TOKEN_ACME_WIDGETS"),
+      findSecrets: () => Effect.die("not used"),
+      hasSecret: () => Effect.die("not used"),
+      addSecret: () => Effect.die("not used"),
+      runWithSecrets: (input) => {
+        runs.push(input)
+        return Effect.succeed({
+          exitCode: 0,
+          stdout: String(runs.length * 3),
+          stderr: "",
+        })
+      },
+    })
+    const layer = keymaxxerGitHubLayer({
+      workspaceRoot: "/workspace",
+      openPullRequestCountFreshnessMs: 5_000,
+      nowMs: () => clock,
+    }).pipe(Layer.provide(keymaxxerLayer))
+
+    const counts = await Effect.runPromise(
+      Effect.gen(function* () {
+        const github = yield* GitHubService
+        const first = yield* github.countOpenNonDraftPullRequests(acmeWidgets)
+        clock += 5_000
+        const second = yield* github.countOpenNonDraftPullRequests(acmeWidgets)
+        return [first, second] as const
+      }).pipe(Effect.provide(layer)),
+    )
+
+    expect(counts).toEqual([3, 6])
+    expect(runs).toHaveLength(2)
+  })
+
+  test("GitHub and Keymaxxer failures are not stored as successful zero counts", async () => {
+    const runs: RunWithSecretsInput[] = []
+    let clock = 100
+    const keymaxxerLayer = Layer.succeed(KeymaxxerService, {
+      initialize: Effect.void,
+      findSecret: () => Effect.succeed("GITHUB_TOKEN_ACME_WIDGETS"),
+      findSecrets: () => Effect.die("not used"),
+      hasSecret: () => Effect.die("not used"),
+      addSecret: () => Effect.die("not used"),
+      runWithSecrets: (input) => {
+        runs.push(input)
+        if (runs.length === 1) {
+          return Effect.succeed({
+            exitCode: 1,
+            stdout: "",
+            stderr: "upstream boom",
+          })
+        }
+        if (runs.length === 2) {
+          return Effect.succeed({ exitCode: 2, stdout: "", stderr: "" })
+        }
+        return Effect.succeed({ exitCode: 0, stdout: "0", stderr: "" })
+      },
+    })
+    const layer = keymaxxerGitHubLayer({
+      workspaceRoot: "/workspace",
+      openPullRequestCountFreshnessMs: 60_000,
+      nowMs: () => clock,
+    }).pipe(Layer.provide(keymaxxerLayer))
+
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        const github = yield* GitHubService
+
+        const requestFailure = yield* Effect.exit(
+          github.countOpenNonDraftPullRequests(acmeWidgets),
+        )
+        expect(Exit.isFailure(requestFailure)).toBe(true)
+
+        clock += 10
+        const unavailable = yield* Effect.exit(
+          github.countOpenNonDraftPullRequests(acmeWidgets),
+        )
+        expect(Exit.isFailure(unavailable)).toBe(true)
+        if (Exit.isFailure(unavailable)) {
+          const error = unavailable.cause
+          // Ensure we did not swallow unavailable into a cached zero.
+          expect(String(error)).toContain("GitHubRepositoryUnavailableError")
+        }
+
+        clock += 10
+        const zero = yield* github.countOpenNonDraftPullRequests(acmeWidgets)
+        expect(zero).toBe(0)
+
+        clock += 10
+        // Genuine zero is success-cached; failures above must not have been.
+        const cachedZero =
+          yield* github.countOpenNonDraftPullRequests(acmeWidgets)
+        expect(cachedZero).toBe(0)
+      }).pipe(Effect.provide(layer)),
+    )
+
+    expect(runs).toHaveLength(3)
+  })
+
+  test("raw Forge credentials stay in the Keymaxxer child and never enter the count result path", async () => {
+    const secretName = "GITHUB_TOKEN_ACME_WIDGETS"
+    const rawToken = "ghp_this_must_never_appear_in_harness_memory_path"
+    const runs: RunWithSecretsInput[] = []
+    const keymaxxerLayer = Layer.succeed(KeymaxxerService, {
+      initialize: Effect.void,
+      findSecret: () => Effect.succeed(secretName),
+      findSecrets: () => Effect.die("not used"),
+      hasSecret: () => Effect.die("not used"),
+      addSecret: () => Effect.die("not used"),
+      runWithSecrets: (input) => {
+        runs.push(input)
+        // Keymaxxer injects the secret by name into the child env; the Harness
+        // only sees the secret name and the child's decoded stdout count.
+        expect(input.secrets).toEqual([secretName])
+        expect(input.command).toContain(`GITHUB_TOKEN="$${secretName}"`)
+        expect(JSON.stringify(input)).not.toContain(rawToken)
+        return Effect.succeed({ exitCode: 0, stdout: "5", stderr: "" })
+      },
+    })
+    const layer = keymaxxerGitHubLayer({ workspaceRoot: "/workspace" }).pipe(
+      Layer.provide(keymaxxerLayer),
+    )
+
+    const count = await Effect.runPromise(
+      Effect.gen(function* () {
+        const github = yield* GitHubService
+        return yield* github.countOpenNonDraftPullRequests(acmeWidgets)
+      }).pipe(Effect.provide(layer)),
+    )
+
+    expect(count).toBe(5)
+    expect(runs).toHaveLength(1)
+    expect(JSON.stringify(runs)).not.toContain(rawToken)
   })
 })

--- a/packages/github-service/src/bin/count-open-non-draft-pull-requests.ts
+++ b/packages/github-service/src/bin/count-open-non-draft-pull-requests.ts
@@ -1,25 +1,35 @@
-import { Effect } from "effect"
-import { GitHubService } from "../lib/github-service.js"
-import {
-  decodeArgument,
-  githubRepository,
-  runGitHubCli,
-  writeStandardOutput,
-} from "./cli.js"
+/**
+ * Source-mode Keymaxxer child entrypoint for open non-draft PR counts.
+ *
+ * Kept deliberately free of the full Effect/GitHubService/genql helper graph so
+ * development Keymaxxer children start without loading every GitHub operation.
+ * Product binaries re-enter via {@link runGitHubHelperProcess} and also run this
+ * lightweight count body (but the product re-entry module may still load other
+ * helper imports for non-count operations — cold-start savings are mainly here).
+ */
+import { writeSync } from "node:fs"
+import { runOpenNonDraftPullRequestCountCli } from "../lib/open-non-draft-pull-request-count.js"
 
-export const countOpenNonDraftPullRequestsProgram = (
+/**
+ * Run the count CLI and terminate the process.
+ * Uses synchronous stdio + `process.exit` so (1) HTTP keep-alive from `fetch`
+ * cannot leave a Keymaxxer child hung until the run timeout, and (2) a tiny
+ * success payload is fully flushed before exit (async write + exit can drop
+ * buffered digits, which the harness would decode as a false zero).
+ */
+export const runCountOpenNonDraftPullRequestsProgram = (
   args: ReadonlyArray<string>,
-) =>
-  Effect.gen(function* () {
-    const forge = yield* decodeArgument(args[0], "forge")
-    const forgeHost = yield* decodeArgument(args[1], "forge host")
-    const projectPath = yield* decodeArgument(args[2], "project path")
-    const github = yield* GitHubService
-    const count = yield* github.countOpenNonDraftPullRequests(
-      githubRepository(forge, forgeHost, projectPath),
-    )
-    yield* writeStandardOutput(String(count))
+): Promise<never> =>
+  runOpenNonDraftPullRequestCountCli(args).then((result) => {
+    if (result.stdout !== "") {
+      writeSync(1, result.stdout)
+    }
+    if (result.stderr !== "") {
+      writeSync(2, result.stderr)
+    }
+    process.exit(result.exitCode)
   })
 
-if (import.meta.main)
-  runGitHubCli(countOpenNonDraftPullRequestsProgram(process.argv.slice(2)))
+if (import.meta.main) {
+  void runCountOpenNonDraftPullRequestsProgram(process.argv.slice(2))
+}

--- a/packages/github-service/src/index.ts
+++ b/packages/github-service/src/index.ts
@@ -8,5 +8,6 @@ export {
   makeGitHubServiceFromToken,
 } from "./lib/github-service-live.js"
 export * from "./lib/github-service-test.js"
+export * from "./lib/open-non-draft-pull-request-count.js"
 export * from "./lib/types.js"
 export * from "./lib/user-facing-error.js"

--- a/packages/github-service/src/lib/github-helper-process.ts
+++ b/packages/github-service/src/lib/github-helper-process.ts
@@ -1,6 +1,6 @@
 import type { Effect } from "effect"
 import { runGitHubCli } from "../bin/cli.js"
-import { countOpenNonDraftPullRequestsProgram } from "../bin/count-open-non-draft-pull-requests.js"
+import { runCountOpenNonDraftPullRequestsProgram } from "../bin/count-open-non-draft-pull-requests.js"
 import { createDraftPullRequestProgram } from "../bin/create-draft-pull-request.js"
 import { ensureIssueCompletedWithSummaryProgram } from "../bin/ensure-issue-completed-with-summary.js"
 import { findOpenPullRequestNumberProgram } from "../bin/find-open-pr-number.js"
@@ -126,15 +126,19 @@ export const formatGitHubHelperShellCommand = (
 ): string =>
   [spawn.command, ...spawn.args].map((part) => JSON.stringify(part)).join(" ")
 
-const programs: Record<
+type FullHelperOperation = Exclude<
   GitHubHelperOperation,
+  "count-open-non-draft-pull-requests"
+>
+
+const programs: Record<
+  FullHelperOperation,
   (args: ReadonlyArray<string>) => Effect.Effect<void, unknown, GitHubService>
 > = {
   "list-ready-issues": listReadyIssuesProgram,
   "get-authenticated-user-login": getAuthenticatedUserLoginProgram,
   "get-open-pr-number": getOpenPullRequestNumberProgram,
   "find-open-pr-number": findOpenPullRequestNumberProgram,
-  "count-open-non-draft-pull-requests": countOpenNonDraftPullRequestsProgram,
   "create-draft-pull-request": createDraftPullRequestProgram,
   "update-open-draft-pull-request-copy": updateOpenDraftPullRequestCopyProgram,
   "get-pr-check-status": getPrCheckStatusProgram,
@@ -170,5 +174,13 @@ export const runGitHubHelperProcess = (
     return
   }
   const args = argv.slice(flagIndex + 2)
+  // Count uses the lightweight CLI body (same GraphQL contract as source mode).
+  // Note: this module still top-level-imports other helper programs for non-count
+  // operations, so product-binary re-entry does not get the full cold-start win
+  // that source-mode `count-open-non-draft-pull-requests.ts` does.
+  if (operation === "count-open-non-draft-pull-requests") {
+    void runCountOpenNonDraftPullRequestsProgram(args)
+    return
+  }
   runGitHubCli(programs[operation](args))
 }

--- a/packages/github-service/src/lib/open-non-draft-pull-request-count.ts
+++ b/packages/github-service/src/lib/open-non-draft-pull-request-count.ts
@@ -1,0 +1,361 @@
+/**
+ * Lightweight open non-draft Pull Request count for the high-frequency header
+ * path. Intentionally avoids the full GitHubService / genql / Effect helper
+ * graph so source-mode Keymaxxer children start quickly.
+ *
+ * Contracts match {@link GitHubService.countOpenNonDraftPullRequests}:
+ * paginated OPEN PRs, draft exclusion, 30s request timeout, two retries with
+ * 500ms delay (no retry on HTTP 401), repository-unavailable when GitHub
+ * returns a null repository.
+ */
+
+const GITHUB_GRAPHQL_URL = "https://api.github.com/graphql"
+const PAGE_SIZE = 100
+const REQUEST_TIMEOUT_MS = 30_000
+const RETRY_DELAY_MS = 500
+const MAX_RETRIES = 2
+
+const COUNT_QUERY = `query CountOpenNonDraftPullRequests($owner: String!, $name: String!, $after: String) {
+  repository(owner: $owner, name: $name) {
+    pullRequests(first: ${PAGE_SIZE}, states: [OPEN], after: $after) {
+      nodes {
+        isDraft
+      }
+      pageInfo {
+        endCursor
+        hasNextPage
+      }
+    }
+  }
+}`
+
+export type OpenNonDraftPullRequestCountFetch = (
+  input: Parameters<typeof fetch>[0],
+  init?: RequestInit,
+) => Promise<Response>
+
+export type OpenNonDraftPullRequestCountOk = {
+  readonly _tag: "ok"
+  readonly count: number
+}
+
+export type OpenNonDraftPullRequestCountUnavailable = {
+  readonly _tag: "unavailable"
+}
+
+export type OpenNonDraftPullRequestCountFailed = {
+  readonly _tag: "error"
+  readonly message: string
+  readonly statusCode?: number
+}
+
+export type OpenNonDraftPullRequestCountResult =
+  | OpenNonDraftPullRequestCountOk
+  | OpenNonDraftPullRequestCountUnavailable
+  | OpenNonDraftPullRequestCountFailed
+
+export type OpenNonDraftPullRequestCountInput = {
+  readonly token: string
+  readonly owner: string
+  readonly name: string
+  readonly fetchImpl?: OpenNonDraftPullRequestCountFetch
+  readonly sleepMs?: (ms: number) => Promise<void>
+}
+
+type GraphQlPage = {
+  readonly data?: {
+    readonly repository?: {
+      readonly pullRequests?: {
+        readonly nodes?:
+          | readonly ({ readonly isDraft?: boolean } | null)[]
+          | null
+        readonly pageInfo?: {
+          readonly endCursor?: string | null
+          readonly hasNextPage?: boolean
+        }
+      } | null
+    } | null
+  } | null
+  readonly errors?: readonly { readonly message?: string }[]
+}
+
+class CountHttpError extends Error {
+  constructor(
+    readonly statusCode: number,
+    message: string,
+  ) {
+    super(message)
+  }
+}
+
+const defaultSleep = (ms: number): Promise<void> =>
+  new Promise((resolve) => {
+    setTimeout(resolve, ms)
+  })
+
+const projectLabel = (owner: string, name: string): string =>
+  name === "" ? owner : `${owner}/${name}`
+
+const toApiRepository = (
+  projectPath: string,
+): { readonly owner: string; readonly name: string } => {
+  const separator = projectPath.indexOf("/")
+  if (separator <= 0 || separator === projectPath.length - 1) {
+    return { owner: projectPath, name: "" }
+  }
+  return {
+    owner: projectPath.slice(0, separator),
+    name: projectPath.slice(separator + 1),
+  }
+}
+
+const decodeBase64Url = (value: string | undefined, name: string): string => {
+  if (value === undefined || value === "") {
+    throw new Error(`Missing ${name} argument`)
+  }
+  return Buffer.from(value, "base64url").toString("utf8")
+}
+
+const fetchGraphQlPage = async (
+  input: {
+    readonly token: string
+    readonly owner: string
+    readonly name: string
+    readonly after: string | null
+    readonly fetchImpl: OpenNonDraftPullRequestCountFetch
+  },
+  signal: AbortSignal,
+): Promise<GraphQlPage> => {
+  const response = await input.fetchImpl(GITHUB_GRAPHQL_URL, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${input.token}`,
+      "Content-Type": "application/json",
+      Accept: "application/json",
+    },
+    body: JSON.stringify({
+      query: COUNT_QUERY,
+      variables: {
+        owner: input.owner,
+        name: input.name,
+        after: input.after,
+      },
+    }),
+    signal,
+  })
+
+  if (!response.ok) {
+    const body = await response.text()
+    throw new CountHttpError(
+      response.status,
+      `${response.statusText}: ${body.slice(0, 300)}`,
+    )
+  }
+
+  const page = (await response.json()) as GraphQlPage
+  // Match genql: any GraphQL `errors` array is a failure (retryable), even when
+  // partial `data` is present. Clean `{ repository: null }` without errors is
+  // handled by the caller as repository-unavailable.
+  if (page.errors !== undefined && page.errors.length > 0) {
+    const message = page.errors
+      .map((error) =>
+        typeof error.message === "string" && error.message.trim() !== ""
+          ? error.message
+          : "GraphQL error",
+      )
+      .join("\n")
+    throw new Error(message)
+  }
+  return page
+}
+
+const withTimeoutAndRetry = async <A>(
+  message: string,
+  request: (signal: AbortSignal) => Promise<A>,
+  sleepMs: (ms: number) => Promise<void>,
+): Promise<A> => {
+  let attempt = 0
+  // Explicit loop result type avoids circular inference when A is inferred from
+  // a request that closes over mutable pagination state.
+  let lastError: (Error & { statusCode?: number }) | undefined
+  while (attempt <= MAX_RETRIES) {
+    const controller = new AbortController()
+    const timer = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS)
+    try {
+      const value: A = await request(controller.signal)
+      return value
+    } catch (cause) {
+      const statusCode =
+        cause instanceof CountHttpError ? cause.statusCode : undefined
+      const timedOut =
+        cause instanceof Error &&
+        (cause.name === "AbortError" || /aborted/i.test(cause.message))
+      const failMessage = timedOut ? `${message} timed out` : message
+      const detail =
+        cause instanceof Error && cause.message.trim() !== ""
+          ? cause.message
+          : undefined
+      const error = new Error(
+        detail === undefined ? failMessage : `${failMessage}: ${detail}`,
+      ) as Error & { statusCode?: number }
+      if (statusCode !== undefined) {
+        error.statusCode = statusCode
+      }
+      lastError = error
+      if (statusCode === 401 || attempt >= MAX_RETRIES) {
+        throw error
+      }
+      attempt += 1
+      await sleepMs(RETRY_DELAY_MS)
+    } finally {
+      clearTimeout(timer)
+    }
+  }
+  throw lastError ?? new Error(message)
+}
+
+/**
+ * Count currently open, non-draft pull requests via GitHub GraphQL.
+ * Does not log or return the token.
+ */
+export const countOpenNonDraftPullRequestsLite = async (
+  input: OpenNonDraftPullRequestCountInput,
+): Promise<OpenNonDraftPullRequestCountResult> => {
+  const fetchImpl = input.fetchImpl ?? fetch
+  const sleepMs = input.sleepMs ?? defaultSleep
+  const label = projectLabel(input.owner, input.name)
+  let count = 0
+  let cursor: string | null = null
+
+  try {
+    for (;;) {
+      const afterCursor: string | null = cursor
+      const page: GraphQlPage = await withTimeoutAndRetry<GraphQlPage>(
+        `Failed to count open pull requests for ${label}`,
+        (signal: AbortSignal): Promise<GraphQlPage> =>
+          fetchGraphQlPage(
+            {
+              token: input.token,
+              owner: input.owner,
+              name: input.name,
+              after: afterCursor,
+              fetchImpl,
+            },
+            signal,
+          ),
+        sleepMs,
+      )
+
+      if (page.data?.repository == null) {
+        return { _tag: "unavailable" }
+      }
+
+      const nodes = page.data.repository.pullRequests?.nodes ?? []
+      for (const node of nodes) {
+        if (node !== null && node !== undefined && node.isDraft === false) {
+          count += 1
+        }
+      }
+
+      const pageInfo:
+        | {
+            readonly endCursor?: string | null
+            readonly hasNextPage?: boolean
+          }
+        | undefined = page.data.repository.pullRequests?.pageInfo
+      if (
+        pageInfo?.hasNextPage !== true ||
+        pageInfo.endCursor === null ||
+        pageInfo.endCursor === undefined ||
+        pageInfo.endCursor === ""
+      ) {
+        break
+      }
+      cursor = pageInfo.endCursor
+    }
+    return { _tag: "ok", count }
+  } catch (cause) {
+    const statusCode =
+      typeof cause === "object" &&
+      cause !== null &&
+      "statusCode" in cause &&
+      typeof (cause as { statusCode: unknown }).statusCode === "number"
+        ? (cause as { statusCode: number }).statusCode
+        : undefined
+    const message =
+      cause instanceof Error && cause.message.trim() !== ""
+        ? cause.message
+        : `Failed to count open pull requests for ${label}`
+    return statusCode === undefined
+      ? { _tag: "error", message }
+      : { _tag: "error", message, statusCode }
+  }
+}
+
+export type OpenNonDraftPullRequestCountCliResult = {
+  readonly exitCode: number
+  readonly stdout: string
+  readonly stderr: string
+}
+
+/**
+ * CLI body for the dedicated count helper process.
+ * Args are base64url-encoded forge, forgeHost, projectPath (same as other helpers).
+ * Token is read only from `GITHUB_TOKEN` in the process environment.
+ */
+export const runOpenNonDraftPullRequestCountCli = async (
+  args: ReadonlyArray<string>,
+  options?: {
+    readonly env?: NodeJS.ProcessEnv
+    readonly fetchImpl?: OpenNonDraftPullRequestCountFetch
+    readonly sleepMs?: (ms: number) => Promise<void>
+  },
+): Promise<OpenNonDraftPullRequestCountCliResult> => {
+  try {
+    const env = options?.env ?? process.env
+    const token = env.GITHUB_TOKEN
+    if (token === undefined || token.trim() === "") {
+      return {
+        exitCode: 1,
+        stdout: "",
+        stderr: "Failed to count open pull requests: missing GITHUB_TOKEN\n",
+      }
+    }
+
+    // forge and forgeHost are accepted for argv compatibility with other helpers.
+    decodeBase64Url(args[0], "forge")
+    decodeBase64Url(args[1], "forge host")
+    const projectPath = decodeBase64Url(args[2], "project path")
+    const { owner, name } = toApiRepository(projectPath)
+
+    const result = await countOpenNonDraftPullRequestsLite({
+      token,
+      owner,
+      name,
+      fetchImpl: options?.fetchImpl,
+      sleepMs: options?.sleepMs,
+    })
+
+    if (result._tag === "ok") {
+      return { exitCode: 0, stdout: String(result.count), stderr: "" }
+    }
+    if (result._tag === "unavailable") {
+      return { exitCode: 2, stdout: "", stderr: "" }
+    }
+    return {
+      exitCode: 1,
+      stdout: "",
+      stderr: `${result.message}\n`,
+    }
+  } catch (cause) {
+    const message =
+      cause instanceof Error && cause.message.trim() !== ""
+        ? cause.message
+        : "Command failed"
+    return {
+      exitCode: 1,
+      stdout: "",
+      stderr: `${message}\n`,
+    }
+  }
+}

--- a/packages/github-service/test/open-non-draft-pull-request-count.spec.ts
+++ b/packages/github-service/test/open-non-draft-pull-request-count.spec.ts
@@ -1,0 +1,335 @@
+import { spawn } from "node:child_process"
+import { fileURLToPath } from "node:url"
+import { afterEach, describe, expect, test } from "vitest"
+import {
+  countOpenNonDraftPullRequestsLite,
+  runOpenNonDraftPullRequestCountCli,
+} from "../src/lib/open-non-draft-pull-request-count.js"
+
+const encode = (value: string) =>
+  Buffer.from(value, "utf8").toString("base64url")
+
+const binScript = fileURLToPath(
+  new URL("../src/bin/count-open-non-draft-pull-requests.ts", import.meta.url),
+)
+
+const bunExecutable = () =>
+  process.execPath.includes("bun") ? process.execPath : "bun"
+
+const jsonResponse = (body: unknown, status = 200): Response =>
+  new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  })
+
+describe("countOpenNonDraftPullRequestsLite", () => {
+  test("counts open non-draft PRs across pages and excludes drafts", async () => {
+    const requests: unknown[] = []
+    const pages = [
+      {
+        data: {
+          repository: {
+            pullRequests: {
+              nodes: [
+                { isDraft: false },
+                { isDraft: true },
+                { isDraft: false },
+              ],
+              pageInfo: { endCursor: "c1", hasNextPage: true },
+            },
+          },
+        },
+      },
+      {
+        data: {
+          repository: {
+            pullRequests: {
+              nodes: [{ isDraft: false }, null],
+              pageInfo: { endCursor: null, hasNextPage: false },
+            },
+          },
+        },
+      },
+    ]
+
+    const result = await countOpenNonDraftPullRequestsLite({
+      token: "test-token",
+      owner: "acme",
+      name: "widgets",
+      fetchImpl: async (_input, init) => {
+        requests.push(JSON.parse(String(init?.body)))
+        return jsonResponse(pages.shift()!)
+      },
+    })
+
+    expect(result).toEqual({ _tag: "ok", count: 3 })
+    expect(requests).toEqual([
+      {
+        query: expect.stringContaining("pullRequests"),
+        variables: { owner: "acme", name: "widgets", after: null },
+      },
+      {
+        query: expect.stringContaining("states: [OPEN]"),
+        variables: { owner: "acme", name: "widgets", after: "c1" },
+      },
+    ])
+  })
+
+  test("returns zero when GitHub has no open non-draft PRs", async () => {
+    const result = await countOpenNonDraftPullRequestsLite({
+      token: "test-token",
+      owner: "acme",
+      name: "widgets",
+      fetchImpl: async () =>
+        jsonResponse({
+          data: {
+            repository: {
+              pullRequests: {
+                nodes: [{ isDraft: true }],
+                pageInfo: { endCursor: null, hasNextPage: false },
+              },
+            },
+          },
+        }),
+    })
+    expect(result).toEqual({ _tag: "ok", count: 0 })
+  })
+
+  test("reports repository unavailable when GitHub returns a null repository", async () => {
+    const result = await countOpenNonDraftPullRequestsLite({
+      token: "test-token",
+      owner: "acme",
+      name: "missing",
+      fetchImpl: async () => jsonResponse({ data: { repository: null } }),
+    })
+    expect(result).toEqual({ _tag: "unavailable" })
+  })
+
+  test("retries GraphQL errors then fails without treating them as unavailable", async () => {
+    let calls = 0
+    const sleeps: number[] = []
+    const result = await countOpenNonDraftPullRequestsLite({
+      token: "test-token",
+      owner: "acme",
+      name: "widgets",
+      sleepMs: async (ms) => {
+        sleeps.push(ms)
+      },
+      fetchImpl: async () => {
+        calls += 1
+        return jsonResponse({
+          data: { repository: null },
+          errors: [
+            { message: "Something went wrong while executing your query." },
+          ],
+        })
+      },
+    })
+    expect(result._tag).toBe("error")
+    expect(calls).toBe(3)
+    expect(sleeps).toEqual([500, 500])
+    if (result._tag === "error") {
+      expect(result.message).toContain("Something went wrong")
+    }
+  })
+
+  test("does not retry HTTP 401 and preserves status on the error path", async () => {
+    let calls = 0
+    const result = await countOpenNonDraftPullRequestsLite({
+      token: "bad-token",
+      owner: "acme",
+      name: "widgets",
+      fetchImpl: async () => {
+        calls += 1
+        return new Response("Bad credentials", {
+          status: 401,
+          statusText: "Unauthorized",
+        })
+      },
+    })
+    expect(calls).toBe(1)
+    expect(result._tag).toBe("error")
+    if (result._tag === "error") {
+      expect(result.statusCode).toBe(401)
+      expect(result.message).not.toContain("bad-token")
+    }
+  })
+
+  test("retries transient failures then succeeds", async () => {
+    let calls = 0
+    const sleeps: number[] = []
+    const result = await countOpenNonDraftPullRequestsLite({
+      token: "test-token",
+      owner: "acme",
+      name: "widgets",
+      sleepMs: async (ms) => {
+        sleeps.push(ms)
+      },
+      fetchImpl: async () => {
+        calls += 1
+        if (calls < 3) {
+          return new Response("temporary", {
+            status: 502,
+            statusText: "Bad Gateway",
+          })
+        }
+        return jsonResponse({
+          data: {
+            repository: {
+              pullRequests: {
+                nodes: [{ isDraft: false }],
+                pageInfo: { endCursor: null, hasNextPage: false },
+              },
+            },
+          },
+        })
+      },
+    })
+    expect(result).toEqual({ _tag: "ok", count: 1 })
+    expect(calls).toBe(3)
+    expect(sleeps).toEqual([500, 500])
+  })
+
+  test("never includes the token in error messages", async () => {
+    const secret = "ghp_super_secret_token_value"
+    const result = await countOpenNonDraftPullRequestsLite({
+      token: secret,
+      owner: "acme",
+      name: "widgets",
+      sleepMs: async () => undefined,
+      fetchImpl: async () => {
+        throw new Error("network down")
+      },
+    })
+    expect(result._tag).toBe("error")
+    if (result._tag === "error") {
+      expect(result.message).not.toContain(secret)
+    }
+  })
+})
+
+describe("runOpenNonDraftPullRequestCountCli", () => {
+  test("writes the count on stdout with exit 0", async () => {
+    const result = await runOpenNonDraftPullRequestCountCli(
+      [encode("github"), encode("github.com"), encode("acme/widgets")],
+      {
+        env: { GITHUB_TOKEN: "test-token" },
+        fetchImpl: async () =>
+          jsonResponse({
+            data: {
+              repository: {
+                pullRequests: {
+                  nodes: [{ isDraft: false }, { isDraft: false }],
+                  pageInfo: { endCursor: null, hasNextPage: false },
+                },
+              },
+            },
+          }),
+      },
+    )
+    expect(result).toEqual({ exitCode: 0, stdout: "2", stderr: "" })
+  })
+
+  test("exits 2 when the repository is unavailable", async () => {
+    const result = await runOpenNonDraftPullRequestCountCli(
+      [encode("github"), encode("github.com"), encode("acme/missing")],
+      {
+        env: { GITHUB_TOKEN: "test-token" },
+        fetchImpl: async () => jsonResponse({ data: { repository: null } }),
+      },
+    )
+    expect(result.exitCode).toBe(2)
+    expect(result.stdout).toBe("")
+  })
+
+  test("exits 1 without a token and does not call GitHub", async () => {
+    let called = false
+    const result = await runOpenNonDraftPullRequestCountCli(
+      [encode("github"), encode("github.com"), encode("acme/widgets")],
+      {
+        env: { GITHUB_TOKEN: "" },
+        fetchImpl: async () => {
+          called = true
+          return jsonResponse({ data: { repository: null } })
+        },
+      },
+    )
+    expect(called).toBe(false)
+    expect(result.exitCode).toBe(1)
+    expect(result.stderr).toContain("GITHUB_TOKEN")
+  })
+
+  test("exits 1 for a missing project path argument", async () => {
+    const result = await runOpenNonDraftPullRequestCountCli(
+      [encode("github"), encode("github.com")],
+      { env: { GITHUB_TOKEN: "test-token" } },
+    )
+    expect(result.exitCode).toBe(1)
+    expect(result.stderr).toContain("Missing project path argument")
+  })
+})
+
+describe("count-open-non-draft-pull-requests child process", () => {
+  const children: Array<ReturnType<typeof spawn>> = []
+
+  afterEach(() => {
+    for (const child of children) {
+      child.kill("SIGTERM")
+    }
+    children.length = 0
+  })
+
+  test("source entrypoint flushes stdio synchronously then forces process exit", async () => {
+    // Hang-on-keep-alive: only setting exitCode left fetch sockets open.
+    // False-zero cache: async write + process.exit can drop digits; writeSync
+    // drains before exit.
+    const { readFileSync } = await import("node:fs")
+    const source = readFileSync(binScript, "utf8")
+    expect(source).toContain("writeSync(1, result.stdout)")
+    expect(source).toContain("writeSync(2, result.stderr)")
+    expect(source).toContain("process.exit(result.exitCode)")
+    expect(source).not.toMatch(/process\.exitCode\s*=\s*result\.exitCode/)
+  })
+
+  test("fails safely without a token and never echoes a secret", async () => {
+    const secret = "ghp_should_not_appear_in_stderr"
+    const child = spawn(
+      bunExecutable(),
+      [
+        "--conditions",
+        "@ready-for-agent/source",
+        binScript,
+        encode("github"),
+        encode("github.com"),
+        encode("acme/widgets"),
+      ],
+      {
+        env: {
+          ...process.env,
+          GITHUB_TOKEN: "",
+          // Ensure an accidental ambient secret is not required for this test.
+          READY_FOR_AGENT_TEST_SECRET: secret,
+        },
+        stdio: ["ignore", "pipe", "pipe"],
+      },
+    )
+    children.push(child)
+
+    const stderrChunks: Buffer[] = []
+    const stdoutChunks: Buffer[] = []
+    child.stderr?.on("data", (chunk: Buffer) => stderrChunks.push(chunk))
+    child.stdout?.on("data", (chunk: Buffer) => stdoutChunks.push(chunk))
+    const exitCode = await new Promise<number | null>((resolve) => {
+      child.on("close", (code) => resolve(code))
+    })
+
+    expect(exitCode).toBe(1)
+    expect(exitCode).not.toBe(2)
+    const stderr = Buffer.concat(stderrChunks).toString("utf8")
+    const stdout = Buffer.concat(stdoutChunks).toString("utf8")
+    expect(stderr.length).toBeGreaterThan(0)
+    expect(stderr).not.toContain(secret)
+    expect(stderr).not.toMatch(/ghp_[A-Za-z0-9]+/)
+    expect(stdout).toBe("")
+  })
+})


### PR DESCRIPTION
## Why

Keymaxxer-backed open non-draft PR counting was a high-frequency hot path:
concurrent tabs, reconnects, and closely spaced invalidations each spawned full
source-mode GitHub helper children on the serialized Keymaxxer lane. That
amplified vault/GitHub work and slowed the harness even after counts were
decoupled from the main repositories projection (#596 / #605).

## What changed

- **Single-flight + short success cache** in the Keymaxxer GitHub layer:
  concurrent `countOpenNonDraftPullRequests` for one Repository share one
  helper; different Repositories stay isolated; successful counts may reuse a
  5s freshness window (under the 30s UI poll); failures and interrupts are
  never stored as successful zeros.
- **Lightweight count child**: dedicated GraphQL pagination path (OPEN filter,
  draft exclusion, 30s timeout, bounded retries, exit 2 when unavailable)
  without loading the full Effect/genql helper graph in source mode;
  `writeSync` + `process.exit` so keep-alive cannot hang the child and empty
  exit-0 stdout cannot be decoded as a cached zero.
- **Settle hardening**: owner path uses `Effect.exit` + uninterruptible
  cache/`Deferred.done` so joiners are not left hanging on interrupt/teardown.

## Verification

- `nx run github-service:test`
- harness `keymaxxer-github-layer` tests (coalesce, isolation, freshness,
  expiry, failure non-caching, empty stdout, credentials)
- `nx run github-service:typecheck` / `nx run harness:typecheck`
- Review re-pass: clean after remediation

## Notes

- Dialog serialization and Allow-session semantics are unchanged; this reduces
  duplicate count traffic only.
- Product-binary re-entry still top-level-imports other helpers; cold-start
  savings are mainly the source-mode count script.

Closes #597