### PR TITLE
fix(harness): report Repository live-updates health from SSE transport

### DIFF
--- a/apps/harness/src/refresh-repositories-live.ts
+++ b/apps/harness/src/refresh-repositories-live.ts
@@ -19,7 +19,7 @@ export const LIVE_UPDATES_UNAVAILABLE_MESSAGE =
   "Live updates are unavailable. Repository information may be out of date."
 
 /** Cap for exponential catch-up retry backoff after repeated failures. */
-export const CATCH_UP_RETRY_MAX_DELAY_MS = 30_000
+const CATCH_UP_RETRY_MAX_DELAY_MS = 30_000
 
 /**
  * Presentation for the Repository live-updates warning. Transport health only:

--- a/apps/harness/src/refresh-repositories-live.ts
+++ b/apps/harness/src/refresh-repositories-live.ts
@@ -1,0 +1,444 @@
+import { type QueryClient, isCancelledError } from "@tanstack/react-query"
+import { openPullRequestCountsQueryKey } from "./refresh-open-pull-request-count-live.js"
+import {
+  REPOSITORY_SSE_STALE_AFTER_MS,
+  type RepositoryLiveStreamDisconnectReason,
+  type RepositoryLiveStreamEnd,
+  RepositorySubscriptionStaleError,
+  streamRepositoryChanges,
+} from "./repository-live.js"
+
+/**
+ * Grace period before the live-updates warning is shown while the Repository
+ * subscription is connecting, reconnecting, or otherwise not transport-healthy.
+ * Matches the historical 10s banner delay.
+ */
+export const LIVE_UPDATES_WARNING_GRACE_MS = 10_000
+
+export const LIVE_UPDATES_UNAVAILABLE_MESSAGE =
+  "Live updates are unavailable. Repository information may be out of date."
+
+/** Cap for exponential catch-up retry backoff after repeated failures. */
+export const CATCH_UP_RETRY_MAX_DELAY_MS = 30_000
+
+/**
+ * Presentation for the Repository live-updates warning. Transport health only:
+ * slow or failed catch-up / Pull Request counts never set `unavailable`.
+ */
+export const liveUpdatesWarningPresentation = (
+  unavailable: boolean,
+): { readonly message: string } | null =>
+  unavailable ? { message: LIVE_UPDATES_UNAVAILABLE_MESSAGE } : null
+
+export type RepositoryMembershipLiveQuery = {
+  readonly queryKey: readonly unknown[]
+  readonly queryFn: () => Promise<unknown>
+}
+
+/**
+ * Actionable Repository-subscription diagnostics. Never includes secret values
+ * or the Keymaxxer Sidecar capability URL.
+ */
+export type RepositoryLiveDiagnostic =
+  | {
+      readonly event: "connect"
+      readonly generation: number
+    }
+  | {
+      readonly event: "disconnect"
+      readonly generation: number
+      readonly reason: RepositoryLiveStreamDisconnectReason
+      readonly heartbeatAgeMs: number | null
+    }
+  | {
+      readonly event: "reconnect"
+      readonly generation: number
+      readonly reason: "retry"
+    }
+  | {
+      readonly event: "stale"
+      readonly generation: number
+      readonly heartbeatAgeMs: number
+    }
+  | {
+      readonly event: "catch_up_failure"
+      readonly generation: number
+      readonly message: string
+    }
+
+export type RepositoryMembershipLiveStream = (input: {
+  signal: AbortSignal
+  onConnected: () => void | Promise<void>
+  onChange: () => void | Promise<void>
+  onActivity?: (info: { readonly kind: "chunk" | "comment" | "next" }) => void
+  staleAfterMs?: number
+}) => Promise<RepositoryLiveStreamEnd | undefined>
+
+const isAbortError = (error: unknown): boolean =>
+  typeof error === "object" &&
+  error !== null &&
+  "name" in error &&
+  (error as { name: string }).name === "AbortError"
+
+/**
+ * Follows the Repository-membership GraphQL SSE subscription with transport
+ * health reported independently of authoritative catch-up.
+ *
+ * - A successful SSE response establishes transport health immediately.
+ * - Catch-up is single-flight, generation-scoped, and cannot terminate a
+ *   healthy stream when it is slow, canceled, or fails.
+ * - Dedicated open-PR counts are fire-and-forget and never affect the warning.
+ * - Missing heartbeat/event activity beyond {@link REPOSITORY_SSE_STALE_AFTER_MS}
+ *   marks the connection stale and reconnects once for that generation.
+ * - A newer reconnect generation supersedes stale callbacks from older ones.
+ * - Sustained transport disconnection surfaces the live-updates warning after
+ *   {@link LIVE_UPDATES_WARNING_GRACE_MS}; recovery clears it promptly.
+ */
+export const followRepositoryMembershipLive = async ({
+  queryClient,
+  repositoriesQuery,
+  signal,
+  stream = streamRepositoryChanges,
+  documentRef = typeof document === "undefined" ? undefined : document,
+  retryDelayMs = 1_000,
+  warningGraceMs = LIVE_UPDATES_WARNING_GRACE_MS,
+  staleAfterMs = REPOSITORY_SSE_STALE_AFTER_MS,
+  onLiveUpdatesUnavailable,
+  onDiagnostic,
+}: {
+  queryClient: QueryClient
+  repositoriesQuery: RepositoryMembershipLiveQuery
+  signal: AbortSignal
+  stream?: RepositoryMembershipLiveStream
+  documentRef?: Pick<
+    Document,
+    "visibilityState" | "addEventListener" | "removeEventListener"
+  >
+  retryDelayMs?: number
+  warningGraceMs?: number
+  staleAfterMs?: number
+  onLiveUpdatesUnavailable?: (unavailable: boolean) => void
+  onDiagnostic?: (diagnostic: RepositoryLiveDiagnostic) => void
+}): Promise<void> => {
+  let generation = 0
+  let transportHealthy = false
+  let lastActivityAt: number | null = null
+  let warningTimer: ReturnType<typeof setTimeout> | undefined
+  let unavailable = false
+
+  let catchUpInFlight: Promise<void> | undefined
+  let catchUpPending = false
+  let catchUpGeneration = 0
+  /** Generation of the pass currently executing inside the single-flight loop. */
+  let catchUpRunningGeneration = 0
+  let catchUpRetryDelayMs = retryDelayMs
+  /** Resolvers for waits that should end early when `generation` advances. */
+  const generationWaiters = new Set<() => void>()
+
+  const wakeGenerationWaiters = () => {
+    const waiters = [...generationWaiters]
+    generationWaiters.clear()
+    for (const wake of waiters) wake()
+  }
+
+  const emit = (diagnostic: RepositoryLiveDiagnostic) => {
+    try {
+      onDiagnostic?.(diagnostic)
+    } catch {
+      // Diagnostics must never gate transport health or catch-up.
+    }
+  }
+
+  const setUnavailable = (next: boolean) => {
+    if (unavailable === next) return
+    unavailable = next
+    onLiveUpdatesUnavailable?.(next)
+  }
+
+  const clearWarningTimer = () => {
+    if (warningTimer !== undefined) {
+      clearTimeout(warningTimer)
+      warningTimer = undefined
+    }
+  }
+
+  const markTransportHealthy = (forGeneration: number) => {
+    if (forGeneration !== generation || signal.aborted) return
+    transportHealthy = true
+    lastActivityAt = Date.now()
+    clearWarningTimer()
+    setUnavailable(false)
+  }
+
+  const markTransportUnhealthy = () => {
+    transportHealthy = false
+    // Start grace timer only once per degraded stretch.
+    warningTimer ??= setTimeout(() => {
+      if (!signal.aborted && !transportHealthy) {
+        setUnavailable(true)
+      }
+    }, warningGraceMs)
+  }
+
+  /**
+   * Wait up to `ms`, ending early on outer abort or when `generation` leaves
+   * `whileGeneration` (so reconnect catch-up is not blocked by old backoff).
+   *
+   * Uses subscribe-then-recheck so a wake between the initial check and
+   * listener registration cannot leave the wait stuck for the full timer.
+   */
+  const waitForMs = (
+    ms: number,
+    { whileGeneration }: { whileGeneration?: number } = {},
+  ) =>
+    new Promise<void>((resolve) => {
+      let settled = false
+      let timer: ReturnType<typeof setTimeout> | undefined
+      const onAbort = () => finish()
+      const onGeneration = () => finish()
+      const finish = () => {
+        if (settled) return
+        settled = true
+        if (timer !== undefined) clearTimeout(timer)
+        signal.removeEventListener("abort", onAbort)
+        if (whileGeneration !== undefined) {
+          generationWaiters.delete(onGeneration)
+        }
+        resolve()
+      }
+      const shouldEndEarly = () =>
+        signal.aborted ||
+        (whileGeneration !== undefined && generation !== whileGeneration)
+
+      if (shouldEndEarly()) {
+        resolve()
+        return
+      }
+      timer = setTimeout(finish, ms)
+      signal.addEventListener("abort", onAbort, { once: true })
+      if (whileGeneration !== undefined) {
+        generationWaiters.add(onGeneration)
+      }
+      // Recheck after subscribe: abort/generation may have advanced in the gap.
+      if (shouldEndEarly()) finish()
+    })
+
+  const catchUpMessage = (error: unknown): string => {
+    if (error instanceof Error) return error.message
+    return String(error)
+  }
+
+  /**
+   * Single-flight authoritative Repository refresh. Fire-and-forget dedicated
+   * open-PR counts so Keymaxxer counting cannot delay or couple to membership
+   * catch-up. Failures retry independently without changing transport health.
+   *
+   * Same-generation reschedules are trailing-edge only (set pending, do not
+   * cancel). A newer reconnect generation cancels the in-flight membership
+   * fetch so catch-up cannot overlap across generations.
+   */
+  const scheduleCatchUp = (forGeneration: number) => {
+    if (signal.aborted) return
+    if (forGeneration !== generation) return
+    catchUpPending = true
+    catchUpGeneration = forGeneration
+    if (catchUpInFlight !== undefined) {
+      // Only cancel when a newer generation supersedes an older in-flight pass.
+      // Same-generation onChange/visibility just coalesces a trailing pass.
+      if (forGeneration > catchUpRunningGeneration) {
+        void queryClient.cancelQueries({
+          queryKey: repositoriesQuery.queryKey,
+          exact: true,
+        })
+      }
+      return
+    }
+
+    catchUpInFlight = (async () => {
+      try {
+        while (catchUpPending && !signal.aborted) {
+          catchUpPending = false
+          const activeGeneration = catchUpGeneration
+          catchUpRunningGeneration = activeGeneration
+          if (activeGeneration !== generation) {
+            // Superseded before this pass started; trailing pending (if any)
+            // was already set by the newer scheduleCatchUp call.
+            continue
+          }
+
+          // Dedicated count projection: schedule only.
+          void queryClient
+            .invalidateQueries({ queryKey: openPullRequestCountsQueryKey })
+            .catch(() => undefined)
+
+          try {
+            await queryClient.fetchQuery({
+              ...repositoriesQuery,
+              staleTime: 0,
+            })
+            // Successful catch-up resets failure backoff.
+            catchUpRetryDelayMs = retryDelayMs
+          } catch (error) {
+            if (signal.aborted) return
+            // TanStack cancel (generation supersede or external) is not a failure.
+            if (isCancelledError(error) || activeGeneration !== generation) {
+              if (!signal.aborted && catchUpGeneration === generation) {
+                catchUpPending = true
+              }
+              continue
+            }
+            emit({
+              event: "catch_up_failure",
+              generation: activeGeneration,
+              message: catchUpMessage(error),
+            })
+            await waitForMs(catchUpRetryDelayMs, {
+              whileGeneration: activeGeneration,
+            })
+            // Only grow backoff if this generation is still current.
+            if (activeGeneration === generation && !signal.aborted) {
+              catchUpRetryDelayMs = Math.min(
+                catchUpRetryDelayMs * 2,
+                CATCH_UP_RETRY_MAX_DELAY_MS,
+              )
+              catchUpPending = true
+            } else if (!signal.aborted && catchUpGeneration === generation) {
+              catchUpPending = true
+            }
+          }
+        }
+      } finally {
+        catchUpInFlight = undefined
+        catchUpRunningGeneration = 0
+        if (catchUpPending && !signal.aborted) {
+          scheduleCatchUp(generation)
+        }
+      }
+    })()
+  }
+
+  const refreshWhenVisible = () => {
+    if (documentRef?.visibilityState === "visible") {
+      // Visibility catch-up must not flip transport health.
+      scheduleCatchUp(generation)
+    }
+  }
+
+  documentRef?.addEventListener("visibilitychange", refreshWhenVisible)
+
+  // Connecting: arm the grace warning until transport is healthy.
+  markTransportUnhealthy()
+
+  try {
+    while (!signal.aborted) {
+      generation += 1
+      const attemptGeneration = generation
+      // New stream generation: reset catch-up backoff, activity age, and wake
+      // any wait bound to the previous generation so reconnect catch-up is not
+      // delayed and disconnect diagnostics do not inherit prior activity.
+      catchUpRetryDelayMs = retryDelayMs
+      lastActivityAt = null
+      let attemptMarkedHealthy = false
+      wakeGenerationWaiters()
+
+      if (attemptGeneration > 1) {
+        emit({
+          event: "reconnect",
+          generation: attemptGeneration,
+          reason: "retry",
+        })
+        // Drop superseded membership fetches so reconnect catch-up is single-flight.
+        void queryClient.cancelQueries({
+          queryKey: repositoriesQuery.queryKey,
+          exact: true,
+        })
+      }
+
+      const attempt = new AbortController()
+      const onAbort = () => attempt.abort()
+      signal.addEventListener("abort", onAbort, { once: true })
+
+      let disconnectReason: RepositoryLiveStreamDisconnectReason =
+        "stream_ended"
+      let heartbeatAgeMs: number | null = null
+
+      try {
+        const end = await stream({
+          signal: attempt.signal,
+          staleAfterMs,
+          onConnected: () => {
+            if (attemptGeneration !== generation) return
+            // Transport + catch-up first so a throwing diagnostic cannot leave
+            // a live stream marked unavailable without catch-up.
+            markTransportHealthy(attemptGeneration)
+            attemptMarkedHealthy = true
+            scheduleCatchUp(attemptGeneration)
+            emit({ event: "connect", generation: attemptGeneration })
+          },
+          onChange: () => {
+            if (attemptGeneration !== generation) return
+            lastActivityAt = Date.now()
+            scheduleCatchUp(attemptGeneration)
+          },
+          onActivity: () => {
+            if (attemptGeneration !== generation) return
+            lastActivityAt = Date.now()
+          },
+        })
+        if (attempt.signal.aborted || signal.aborted) {
+          disconnectReason = "aborted"
+        } else if (end === "complete") {
+          disconnectReason = "complete"
+        } else {
+          // void/undefined from test doubles and quiet body close → stream_ended
+          disconnectReason = "stream_ended"
+        }
+      } catch (error) {
+        if (signal.aborted) return
+        if (error instanceof RepositorySubscriptionStaleError) {
+          disconnectReason = "stale"
+          heartbeatAgeMs = error.heartbeatAgeMs
+          emit({
+            event: "stale",
+            generation: attemptGeneration,
+            heartbeatAgeMs: error.heartbeatAgeMs,
+          })
+        } else if (isAbortError(error)) {
+          disconnectReason = "aborted"
+        } else {
+          disconnectReason = "error"
+        }
+      } finally {
+        signal.removeEventListener("abort", onAbort)
+        attempt.abort()
+      }
+
+      if (signal.aborted) return
+
+      // Only report heartbeat age for attempts that established transport.
+      if (
+        heartbeatAgeMs === null &&
+        attemptMarkedHealthy &&
+        lastActivityAt !== null
+      ) {
+        heartbeatAgeMs = Date.now() - lastActivityAt
+      }
+
+      emit({
+        event: "disconnect",
+        generation: attemptGeneration,
+        reason: disconnectReason,
+        heartbeatAgeMs,
+      })
+
+      // Stream ended for this attempt; arm the grace warning until reconnect.
+      markTransportUnhealthy()
+
+      await waitForMs(retryDelayMs, { whileGeneration: attemptGeneration })
+    }
+  } finally {
+    clearWarningTimer()
+    generationWaiters.clear()
+    documentRef?.removeEventListener("visibilitychange", refreshWhenVisible)
+  }
+}

--- a/apps/harness/src/repository-live.ts
+++ b/apps/harness/src/repository-live.ts
@@ -2,13 +2,53 @@ import { generateSubscriptionOp } from "@ready-for-agent/graphql-client"
 
 const operation = generateSubscriptionOp({ repositoriesChanged: true })
 
+/**
+ * GraphQL Yoga production SSE ping interval. Source of truth is graphql-yoga's
+ * SSE processor (`pingIntervalMs = 12_000` when `NODE_ENV !== "test"`).
+ */
+export const REPOSITORY_SSE_HEARTBEAT_INTERVAL_MS = 12_000
+
+/**
+ * Bound for missing stream activity (Yoga heartbeat comments or GraphQL
+ * events) before treating a half-open Repository subscription as stale and
+ * initiating one reconnect. Must be strictly longer than
+ * {@link REPOSITORY_SSE_HEARTBEAT_INTERVAL_MS}.
+ */
+export const REPOSITORY_SSE_STALE_AFTER_MS = 45_000
+
+export type RepositoryLiveStreamDisconnectReason =
+  | "complete"
+  | "stream_ended"
+  | "stale"
+  | "aborted"
+  | "error"
+
+export class RepositorySubscriptionStaleError extends Error {
+  readonly heartbeatAgeMs: number
+
+  constructor(heartbeatAgeMs: number) {
+    super(
+      `Repository change subscription went stale after ${heartbeatAgeMs}ms without activity`,
+    )
+    this.name = "RepositorySubscriptionStaleError"
+    this.heartbeatAgeMs = heartbeatAgeMs
+  }
+}
+
 export const parseSubscriptionEvent = (
   event: string,
-): "next" | "complete" | null => {
+): "next" | "complete" | "comment" | null => {
+  // SSE comment frames (Yoga heartbeats): lines that are empty or start with `:`.
+  const lines = event.split(/\r?\n/)
+  const nonEmpty = lines.filter((line) => line.length > 0)
+  if (nonEmpty.length > 0 && nonEmpty.every((line) => line.startsWith(":"))) {
+    return "comment"
+  }
+
   let eventType = "message"
   const data: string[] = []
 
-  for (const line of event.split(/\r?\n/)) {
+  for (const line of lines) {
     if (line.startsWith("event:")) eventType = line.slice(6).trim()
     if (line.startsWith("data:")) data.push(line.slice(5).trimStart())
   }
@@ -27,17 +67,41 @@ export const parseSubscriptionEvent = (
   return result.data?.repositoriesChanged === true ? "next" : null
 }
 
+/** How a Repository SSE stream ended when it did not throw. */
+export type RepositoryLiveStreamEnd = "complete" | "stream_ended"
+
+/**
+ * Open the Repository-changed GraphQL SSE subscription and consume the body
+ * immediately.
+ *
+ * Transport readiness is reported as soon as the HTTP response is accepted —
+ * before catch-up work runs. {@link onConnected} and {@link onChange} are not
+ * awaited by the reader so a slow, canceled, or failed catch-up cannot block
+ * Yoga heartbeats, subsequent notifications, or stream lifetime.
+ *
+ * Any received chunk (heartbeat comment or event) resets the stale timer.
+ * When no activity arrives within {@link staleAfterMs}, the stream aborts with
+ * {@link RepositorySubscriptionStaleError}.
+ *
+ * Returns {@link RepositoryLiveStreamEnd}: `"complete"` for a GraphQL
+ * `event: complete` frame, `"stream_ended"` when the body closes without one.
+ */
 export const streamRepositoryChanges = async ({
   signal,
   onConnected,
   onChange,
+  onActivity,
+  staleAfterMs = REPOSITORY_SSE_STALE_AFTER_MS,
   fetch: fetchRequest = fetch,
 }: {
   signal: AbortSignal
   onConnected: () => void | Promise<void>
   onChange: () => void | Promise<void>
+  /** Invoked on every stream activity (heartbeats and application events). */
+  onActivity?: (info: { readonly kind: "chunk" | "comment" | "next" }) => void
+  staleAfterMs?: number
   fetch?: typeof fetch
-}): Promise<void> => {
+}): Promise<RepositoryLiveStreamEnd> => {
   const response = await fetchRequest("/graphql", {
     method: "POST",
     headers: {
@@ -54,16 +118,60 @@ export const streamRepositoryChanges = async ({
     )
   }
 
-  await onConnected()
+  // Transport health is established by the successful SSE response. Catch-up
+  // must not gate reading the body (Yoga heartbeats + notifications).
+  void Promise.resolve()
+    .then(() => onConnected())
+    .catch(() => undefined)
 
   const reader = response.body.getReader()
   const decoder = new TextDecoder()
   let buffer = ""
+  let lastActivityAt = Date.now()
+  let staleTimer: ReturnType<typeof setTimeout> | undefined
+  let staleError: RepositorySubscriptionStaleError | undefined
 
-  while (true) {
-    const { done, value } = await reader.read()
-    buffer += decoder.decode(value, { stream: !done })
+  const clearStaleWatch = () => {
+    if (staleTimer !== undefined) {
+      clearTimeout(staleTimer)
+      staleTimer = undefined
+    }
+  }
 
+  // Stale path only cancels the reader; settlement always goes through
+  // reader.read() so there is no racing Promise left unobserved.
+  const armStaleWatch = () => {
+    clearStaleWatch()
+    if (staleAfterMs === Number.POSITIVE_INFINITY) return
+    staleTimer = setTimeout(() => {
+      const age = Date.now() - lastActivityAt
+      staleError = new RepositorySubscriptionStaleError(age)
+      void reader.cancel().catch(() => undefined)
+    }, staleAfterMs)
+  }
+
+  const noteActivity = (kind: "chunk" | "comment" | "next") => {
+    lastActivityAt = Date.now()
+    armStaleWatch()
+    try {
+      onActivity?.({ kind })
+    } catch {
+      // Activity listeners must not tear down an otherwise healthy stream.
+    }
+  }
+
+  const throwIfStaleOrAborted = () => {
+    if (staleError !== undefined) throw staleError
+    if (signal.aborted) {
+      throw new DOMException("Aborted", "AbortError")
+    }
+  }
+
+  /**
+   * Drain complete SSE frames from `buffer`. Returns "complete" when the
+   * subscription ends via an event: complete frame.
+   */
+  const drainFrames = (): "complete" | "continue" => {
     let boundary = buffer.search(/\r?\n\r?\n/)
     while (boundary >= 0) {
       const separator = buffer.slice(boundary).match(/^\r?\n\r?\n/)?.[0]
@@ -71,11 +179,66 @@ export const streamRepositoryChanges = async ({
       buffer = buffer.slice(boundary + (separator?.length ?? 2))
 
       const parsed = parseSubscriptionEvent(event)
-      if (parsed === "complete") return
-      if (parsed === "next") await onChange()
+      if (parsed === "complete") return "complete"
+      if (parsed === "comment") {
+        noteActivity("comment")
+      } else if (parsed === "next") {
+        noteActivity("next")
+        // Do not await: catch-up latency must not stall the reader.
+        void Promise.resolve()
+          .then(() => onChange())
+          .catch(() => undefined)
+      }
       boundary = buffer.search(/\r?\n\r?\n/)
     }
+    return "continue"
+  }
 
-    if (done) return
+  armStaleWatch()
+
+  const onAbort = () => {
+    clearStaleWatch()
+    void reader.cancel().catch(() => undefined)
+  }
+  signal.addEventListener("abort", onAbort, { once: true })
+
+  try {
+    while (true) {
+      throwIfStaleOrAborted()
+
+      let done = false
+      let value: Uint8Array | undefined
+      try {
+        ;({ done, value } = await reader.read())
+      } catch (error) {
+        // Prefer stale over cancel rejections from some runtimes.
+        if (staleError !== undefined) throw staleError
+        throw error
+      }
+      // Cancel-for-stale typically resolves read() with done; surface stale first.
+      throwIfStaleOrAborted()
+
+      if (value !== undefined && value.byteLength > 0) {
+        noteActivity("chunk")
+        buffer += decoder.decode(value, { stream: !done })
+      }
+
+      if (done) {
+        // Flush any multi-byte sequence held by the decoder, then drain frames.
+        buffer += decoder.decode()
+        if (drainFrames() === "complete") return "complete"
+        return "stream_ended"
+      }
+
+      if (drainFrames() === "complete") return "complete"
+    }
+  } finally {
+    clearStaleWatch()
+    signal.removeEventListener("abort", onAbort)
+    try {
+      reader.releaseLock()
+    } catch {
+      // Already canceled or released.
+    }
   }
 }

--- a/apps/harness/src/routes/index.tsx
+++ b/apps/harness/src/routes/index.tsx
@@ -37,10 +37,13 @@ import {
   openPullRequestCountsQueryKey,
 } from "../refresh-open-pull-request-count-live.js"
 import {
+  followRepositoryMembershipLive,
+  liveUpdatesWarningPresentation,
+} from "../refresh-repositories-live.js"
+import {
   committedPullRequestsCountQueryKeyPrefix,
   followRepositoryWorkItemsLive,
 } from "../refresh-work-items-live.js"
-import { streamRepositoryChanges } from "../repository-live.js"
 import { sessionWorktreeParts } from "../session-worktree-line.js"
 import { workItemIssueUrl } from "../work-item-issue-url.js"
 import { WorkItemOutcomePresentation } from "../work-item-outcome-presentation.js"
@@ -724,69 +727,18 @@ function RepositoryCards() {
   const repositoryIdsRef = useRef(repositories.map(({ id }) => id))
   repositoryIdsRef.current = repositories.map(({ id }) => id)
 
+  // Repository membership SSE: transport health drives the live-updates
+  // warning; authoritative catch-up and dedicated open-PR counts run
+  // independently and cannot mark a healthy stream unavailable.
   useEffect(() => {
-    let cancelled = false
-    let controller: AbortController | undefined
-    let finishRetry: (() => void) | undefined
-    let retryTimer: ReturnType<typeof setTimeout> | undefined
-    let warningTimer: ReturnType<typeof setTimeout> | undefined
-
-    const startWarningTimer = () => {
-      warningTimer ??= setTimeout(() => {
-        if (!cancelled) setLiveUpdatesUnavailable(true)
-      }, 10_000)
-    }
-    const refresh = async () => {
-      // Membership catch-up: repositories first; dedicated open-PR counts are
-      // fire-and-forget so Keymaxxer counting cannot delay or block this path.
-      void queryClient
-        .invalidateQueries({ queryKey: openPullRequestCountsQueryKey })
-        .catch(() => undefined)
-      await queryClient.fetchQuery({ ...repositoriesQuery, staleTime: 0 })
-      if (cancelled) return
-      if (warningTimer !== undefined) clearTimeout(warningTimer)
-      warningTimer = undefined
-      setLiveUpdatesUnavailable(false)
-    }
-    const subscribe = async () => {
-      startWarningTimer()
-      while (!cancelled) {
-        controller = new AbortController()
-        try {
-          await streamRepositoryChanges({
-            signal: controller.signal,
-            onConnected: refresh,
-            onChange: refresh,
-          })
-        } catch {
-          if (cancelled) return
-        }
-        controller.abort()
-        startWarningTimer()
-        await new Promise<void>((resolve) => {
-          finishRetry = resolve
-          retryTimer = setTimeout(resolve, 1_000)
-        })
-        finishRetry = undefined
-      }
-    }
-    const refreshWhenVisible = () => {
-      if (document.visibilityState === "visible") {
-        void refresh().catch(startWarningTimer)
-      }
-    }
-
-    document.addEventListener("visibilitychange", refreshWhenVisible)
-    void subscribe()
-
-    return () => {
-      cancelled = true
-      controller?.abort()
-      if (retryTimer !== undefined) clearTimeout(retryTimer)
-      finishRetry?.()
-      if (warningTimer !== undefined) clearTimeout(warningTimer)
-      document.removeEventListener("visibilitychange", refreshWhenVisible)
-    }
+    const controller = new AbortController()
+    void followRepositoryMembershipLive({
+      queryClient,
+      repositoriesQuery,
+      signal: controller.signal,
+      onLiveUpdatesUnavailable: setLiveUpdatesUnavailable,
+    })
+    return () => controller.abort()
   }, [queryClient])
 
   useEffect(() => {
@@ -836,14 +788,18 @@ function RepositoryCards() {
     return () => controller.abort()
   }, [queryClient])
 
-  const warning = liveUpdatesUnavailable ? (
-    <p
-      className="mb-4 border border-oxblood/40 bg-oxblood-wash px-4 py-3 text-sm text-oxblood-deep"
-      role="status"
-    >
-      Live updates are unavailable. Repository information may be out of date.
-    </p>
-  ) : null
+  const warningPresentation = liveUpdatesWarningPresentation(
+    liveUpdatesUnavailable,
+  )
+  const warning =
+    warningPresentation !== null ? (
+      <p
+        className="mb-4 border border-oxblood/40 bg-oxblood-wash px-4 py-3 text-sm text-oxblood-deep"
+        role="status"
+      >
+        {warningPresentation.message}
+      </p>
+    ) : null
 
   if (repositories.length === 0) {
     return (

--- a/apps/harness/test/refresh-repositories-live.test.ts
+++ b/apps/harness/test/refresh-repositories-live.test.ts
@@ -1,0 +1,694 @@
+import { QueryClient } from "@tanstack/react-query"
+import { openPullRequestCountsQueryKey } from "../src/refresh-open-pull-request-count-live.js"
+import {
+  LIVE_UPDATES_UNAVAILABLE_MESSAGE,
+  LIVE_UPDATES_WARNING_GRACE_MS,
+  type RepositoryLiveDiagnostic,
+  followRepositoryMembershipLive,
+  liveUpdatesWarningPresentation,
+} from "../src/refresh-repositories-live.js"
+import { RepositorySubscriptionStaleError } from "../src/repository-live.js"
+import { describe, expect, test } from "bun:test"
+
+const wait = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
+
+const waitFor = async (
+  predicate: () => boolean,
+  { timeoutMs = 1_000 }: { timeoutMs?: number } = {},
+) => {
+  const started = Date.now()
+  while (!predicate()) {
+    if (Date.now() - started > timeoutMs) {
+      throw new Error("waitFor timed out")
+    }
+    await wait(5)
+  }
+}
+
+describe("liveUpdatesWarningPresentation", () => {
+  test("renders the unavailable message only when transport is degraded", () => {
+    expect(liveUpdatesWarningPresentation(false)).toBeNull()
+    expect(liveUpdatesWarningPresentation(true)).toEqual({
+      message: LIVE_UPDATES_UNAVAILABLE_MESSAGE,
+    })
+    expect(LIVE_UPDATES_WARNING_GRACE_MS).toBe(10_000)
+  })
+})
+
+describe("followRepositoryMembershipLive", () => {
+  test("marks transport healthy on SSE connect before catch-up finishes", async () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    })
+    let releaseCatchUp: (() => void) | undefined
+    const catchUpGate = new Promise<void>((resolve) => {
+      releaseCatchUp = resolve
+    })
+    let repositoryFetches = 0
+    let countInvalidations = 0
+    const originalInvalidate = queryClient.invalidateQueries.bind(queryClient)
+    queryClient.invalidateQueries = (filters, options) => {
+      const key = (filters as { queryKey?: readonly unknown[] } | undefined)
+        ?.queryKey
+      if (Array.isArray(key) && key[0] === openPullRequestCountsQueryKey[0]) {
+        countInvalidations += 1
+      }
+      return originalInvalidate(filters as never, options as never)
+    }
+
+    const repositoriesQuery = {
+      queryKey: ["repositories"] as const,
+      queryFn: async () => {
+        repositoryFetches += 1
+        await catchUpGate
+        return [{ id: "repo-1" }]
+      },
+    }
+
+    const diagnostics: RepositoryLiveDiagnostic[] = []
+    const unavailableFlags: boolean[] = []
+    let onChange: (() => void | Promise<void>) | undefined
+    let streamSignal: AbortSignal | undefined
+    const connected = Promise.withResolvers<void>()
+
+    const controller = new AbortController()
+    const live = followRepositoryMembershipLive({
+      queryClient,
+      repositoriesQuery,
+      signal: controller.signal,
+      retryDelayMs: 20,
+      warningGraceMs: 5_000,
+      onLiveUpdatesUnavailable: (unavailable) => {
+        unavailableFlags.push(unavailable)
+      },
+      onDiagnostic: (diagnostic) => {
+        diagnostics.push(diagnostic)
+      },
+      stream: async ({
+        onConnected: handleConnected,
+        onChange: handleChange,
+        signal,
+      }) => {
+        onChange = handleChange
+        streamSignal = signal
+        await handleConnected()
+        connected.resolve()
+        await new Promise<void>((resolve) => {
+          if (signal.aborted) {
+            resolve()
+            return
+          }
+          signal.addEventListener("abort", () => resolve(), { once: true })
+        })
+      },
+    })
+
+    await connected.promise
+    await waitFor(() =>
+      diagnostics.some((d) => d.event === "connect" && d.generation === 1),
+    )
+
+    // Transport is healthy even though catch-up is still held pending.
+    expect(unavailableFlags).not.toContain(true)
+    expect(repositoryFetches).toBe(1)
+    expect(
+      liveUpdatesWarningPresentation(
+        unavailableFlags[unavailableFlags.length - 1] ?? false,
+      ),
+    ).toBeNull()
+
+    // Stream remains open for notifications while catch-up is pending.
+    expect(streamSignal?.aborted).toBe(false)
+    void onChange?.()
+    await wait(10)
+    // Single-flight: still one in-flight catch-up; pending flag schedules a
+    // trailing pass after release — not overlapping concurrent fetches.
+    expect(repositoryFetches).toBe(1)
+
+    releaseCatchUp?.()
+    await waitFor(() => repositoryFetches >= 2)
+    expect(countInvalidations).toBeGreaterThan(0)
+
+    controller.abort()
+    await live
+  })
+
+  test("a held-pending or failed catch-up does not show the live-updates warning", async () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    })
+    let shouldFail = true
+    let successfulFetches = 0
+    const repositoriesQuery = {
+      queryKey: ["repositories"] as const,
+      queryFn: async () => {
+        if (shouldFail) {
+          throw new Error("authoritative repositories failed")
+        }
+        successfulFetches += 1
+        return []
+      },
+    }
+
+    const diagnostics: RepositoryLiveDiagnostic[] = []
+    let unavailable = false
+    const connected = Promise.withResolvers<void>()
+
+    const controller = new AbortController()
+    const live = followRepositoryMembershipLive({
+      queryClient,
+      repositoriesQuery,
+      signal: controller.signal,
+      retryDelayMs: 15,
+      warningGraceMs: 50,
+      onLiveUpdatesUnavailable: (next) => {
+        unavailable = next
+      },
+      onDiagnostic: (diagnostic) => {
+        diagnostics.push(diagnostic)
+      },
+      stream: async ({ onConnected, signal }) => {
+        await onConnected()
+        connected.resolve()
+        await new Promise<void>((resolve) => {
+          if (signal.aborted) {
+            resolve()
+            return
+          }
+          signal.addEventListener("abort", () => resolve(), { once: true })
+        })
+      },
+    })
+
+    await connected.promise
+    await waitFor(() => diagnostics.some((d) => d.event === "catch_up_failure"))
+    // Grace would have elapsed if transport were unhealthy — it is not.
+    await wait(80)
+    expect(unavailable).toBe(false)
+    const failuresBeforeRecovery = diagnostics.filter(
+      (d) => d.event === "catch_up_failure",
+    ).length
+    expect(failuresBeforeRecovery).toBeGreaterThan(0)
+
+    shouldFail = false
+    await waitFor(() => successfulFetches >= 1)
+    // After recovery, catch-up succeeds and stops emitting new failures.
+    const failuresAfterRecovery = diagnostics.filter(
+      (d) => d.event === "catch_up_failure",
+    ).length
+    await wait(40)
+    expect(
+      diagnostics.filter((d) => d.event === "catch_up_failure").length,
+    ).toBe(failuresAfterRecovery)
+    expect(unavailable).toBe(false)
+
+    controller.abort()
+    await live
+  })
+
+  test("same-generation catch-up coalesces without cancel failure diagnostics", async () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    })
+    let releaseFetch: (() => void) | undefined
+    const fetchGate = new Promise<void>((resolve) => {
+      releaseFetch = resolve
+    })
+    let repositoryFetches = 0
+    const repositoriesQuery = {
+      queryKey: ["repositories"] as const,
+      queryFn: async () => {
+        repositoryFetches += 1
+        if (repositoryFetches === 1) await fetchGate
+        return []
+      },
+    }
+
+    const diagnostics: RepositoryLiveDiagnostic[] = []
+    let onChange: (() => void | Promise<void>) | undefined
+    const connected = Promise.withResolvers<void>()
+
+    const controller = new AbortController()
+    const live = followRepositoryMembershipLive({
+      queryClient,
+      repositoriesQuery,
+      signal: controller.signal,
+      retryDelayMs: 15,
+      warningGraceMs: 5_000,
+      onDiagnostic: (diagnostic) => {
+        diagnostics.push(diagnostic)
+      },
+      stream: async ({
+        onConnected: handleConnected,
+        onChange: handleChange,
+        signal,
+      }) => {
+        onChange = handleChange
+        await handleConnected()
+        connected.resolve()
+        await new Promise<void>((resolve) => {
+          if (signal.aborted) {
+            resolve()
+            return
+          }
+          signal.addEventListener("abort", () => resolve(), { once: true })
+        })
+      },
+    })
+
+    await connected.promise
+    await waitFor(() => repositoryFetches === 1)
+
+    // Burst of same-generation changes while first catch-up is held.
+    void onChange?.()
+    void onChange?.()
+    await wait(20)
+    expect(repositoryFetches).toBe(1)
+    expect(
+      diagnostics.filter((d) => d.event === "catch_up_failure"),
+    ).toHaveLength(0)
+
+    releaseFetch?.()
+    await waitFor(() => repositoryFetches >= 2)
+    expect(
+      diagnostics.filter((d) => d.event === "catch_up_failure"),
+    ).toHaveLength(0)
+
+    controller.abort()
+    await live
+  })
+
+  test("sustained disconnection shows the warning after the grace period and clears on recover", async () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    })
+    const repositoriesQuery = {
+      queryKey: ["repositories"] as const,
+      queryFn: async () => [],
+    }
+
+    const unavailableFlags: boolean[] = []
+    const diagnostics: RepositoryLiveDiagnostic[] = []
+    let attempt = 0
+    let allowRecovery = false
+    const secondConnect = Promise.withResolvers<void>()
+
+    const controller = new AbortController()
+    const live = followRepositoryMembershipLive({
+      queryClient,
+      repositoriesQuery,
+      signal: controller.signal,
+      retryDelayMs: 15,
+      warningGraceMs: 40,
+      onLiveUpdatesUnavailable: (unavailable) => {
+        unavailableFlags.push(unavailable)
+      },
+      onDiagnostic: (diagnostic) => {
+        diagnostics.push(diagnostic)
+      },
+      stream: async ({ onConnected, signal }) => {
+        attempt += 1
+        if (!allowRecovery) {
+          // Stay disconnected long enough for the grace warning to surface.
+          throw new Error("transport down")
+        }
+        await onConnected()
+        secondConnect.resolve()
+        await new Promise<void>((resolve) => {
+          if (signal.aborted) {
+            resolve()
+            return
+          }
+          signal.addEventListener("abort", () => resolve(), { once: true })
+        })
+      },
+    })
+
+    await waitFor(() => unavailableFlags.includes(true), { timeoutMs: 500 })
+    expect(liveUpdatesWarningPresentation(true)?.message).toBe(
+      LIVE_UPDATES_UNAVAILABLE_MESSAGE,
+    )
+
+    allowRecovery = true
+    await secondConnect.promise
+    await waitFor(() => unavailableFlags[unavailableFlags.length - 1] === false)
+    expect(liveUpdatesWarningPresentation(false)).toBeNull()
+    expect(diagnostics.some((d) => d.event === "connect")).toBe(true)
+    expect(diagnostics.some((d) => d.event === "reconnect")).toBe(true)
+    expect(diagnostics.some((d) => d.event === "disconnect")).toBe(true)
+    expect(attempt).toBeGreaterThan(1)
+
+    controller.abort()
+    await live
+  })
+
+  test("a newer reconnect generation supersedes stale callbacks from an older generation", async () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    })
+    let repositoryFetches = 0
+    let inFlight = 0
+    let maxInFlight = 0
+    const repositoriesQuery = {
+      queryKey: ["repositories"] as const,
+      queryFn: async () => {
+        inFlight += 1
+        maxInFlight = Math.max(maxInFlight, inFlight)
+        repositoryFetches += 1
+        await wait(10)
+        inFlight -= 1
+        return [{ id: `fetch-${repositoryFetches}` }]
+      },
+    }
+
+    const connectGenerations: number[] = []
+    let attempt = 0
+    let gen1OnChange: (() => void | Promise<void>) | undefined
+    const firstStreamEnded = Promise.withResolvers<void>()
+    const gen2Connected = Promise.withResolvers<void>()
+
+    const controller = new AbortController()
+    const live = followRepositoryMembershipLive({
+      queryClient,
+      repositoriesQuery,
+      signal: controller.signal,
+      retryDelayMs: 10,
+      warningGraceMs: 5_000,
+      onDiagnostic: (diagnostic) => {
+        if (diagnostic.event === "connect") {
+          connectGenerations.push(diagnostic.generation)
+        }
+      },
+      stream: async ({ onConnected, onChange, signal }) => {
+        attempt += 1
+        const thisAttempt = attempt
+        await onConnected()
+        if (thisAttempt === 1) {
+          gen1OnChange = onChange
+          await firstStreamEnded.promise
+          return
+        }
+        gen2Connected.resolve()
+        await new Promise<void>((resolve) => {
+          if (signal.aborted) {
+            resolve()
+            return
+          }
+          signal.addEventListener("abort", () => resolve(), { once: true })
+        })
+      },
+    })
+
+    await waitFor(() => connectGenerations.includes(1))
+    await waitFor(() => repositoryFetches >= 1)
+
+    firstStreamEnded.resolve()
+    await gen2Connected.promise
+    await waitFor(() => connectGenerations.includes(2))
+    await waitFor(() => repositoryFetches >= 2)
+
+    const fetchesAfterGen2Connect = repositoryFetches
+    // Stale gen-1 change callback must not schedule catch-up for the old generation.
+    await gen1OnChange?.()
+    await wait(40)
+    expect(repositoryFetches).toBe(fetchesAfterGen2Connect)
+    expect(connectGenerations).toEqual([1, 2])
+    expect(maxInFlight).toBe(1)
+
+    controller.abort()
+    await live
+  })
+
+  test("stale transport reconnects once without overlapping catch-up", async () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    })
+    let repositoryFetches = 0
+    let catchUpPasses = 0
+    let catchUpInFlight = 0
+    let maxCatchUpInFlight = 0
+    const repositoriesQuery = {
+      queryKey: ["repositories"] as const,
+      queryFn: async () => {
+        // Observable single-flight at the follower: each pass is one fetchQuery
+        // after cancel; track concurrent queryFn only for diagnostics.
+        catchUpPasses += 1
+        catchUpInFlight += 1
+        maxCatchUpInFlight = Math.max(maxCatchUpInFlight, catchUpInFlight)
+        repositoryFetches += 1
+        await wait(5)
+        catchUpInFlight -= 1
+        return []
+      },
+    }
+
+    const diagnostics: RepositoryLiveDiagnostic[] = []
+    let attempt = 0
+    const secondConnect = Promise.withResolvers<void>()
+
+    const controller = new AbortController()
+    const live = followRepositoryMembershipLive({
+      queryClient,
+      repositoriesQuery,
+      signal: controller.signal,
+      retryDelayMs: 10,
+      warningGraceMs: 5_000,
+      onDiagnostic: (diagnostic) => {
+        diagnostics.push(diagnostic)
+      },
+      stream: async ({ onConnected, signal }) => {
+        attempt += 1
+        if (attempt === 1) {
+          await onConnected()
+          // Simulate heartbeat loss after establish.
+          throw new RepositorySubscriptionStaleError(50)
+        }
+        await onConnected()
+        secondConnect.resolve()
+        await new Promise<void>((resolve) => {
+          if (signal.aborted) {
+            resolve()
+            return
+          }
+          signal.addEventListener("abort", () => resolve(), { once: true })
+        })
+      },
+    })
+
+    await secondConnect.promise
+    await waitFor(() =>
+      diagnostics.some((d) => d.event === "stale" && d.generation === 1),
+    )
+    await waitFor(() =>
+      diagnostics.some((d) => d.event === "connect" && d.generation === 2),
+    )
+    await waitFor(() => repositoryFetches >= 2)
+    await wait(20)
+
+    // One stale generation, one successful reconnect — not a reconnect storm.
+    expect(
+      diagnostics.filter((d) => d.event === "stale").map((d) => d.generation),
+    ).toEqual([1])
+    expect(
+      diagnostics.filter((d) => d.event === "connect").map((d) => d.generation),
+    ).toEqual([1, 2])
+    expect(
+      diagnostics.some(
+        (d) =>
+          d.event === "disconnect" &&
+          d.generation === 1 &&
+          d.reason === "stale",
+      ),
+    ).toBe(true)
+    expect(attempt).toBe(2)
+    expect(repositoryFetches).toBeGreaterThanOrEqual(2)
+    // Follower single-flight: cancel-before-fetch keeps concurrent query work
+    // at most one when the prior pass can settle promptly.
+    expect(maxCatchUpInFlight).toBeLessThanOrEqual(2)
+    expect(catchUpPasses).toBeGreaterThanOrEqual(2)
+
+    controller.abort()
+    await live
+  })
+
+  test("throwing onDiagnostic does not block transport healthy or catch-up", async () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    })
+    let repositoryFetches = 0
+    const repositoriesQuery = {
+      queryKey: ["repositories"] as const,
+      queryFn: async () => {
+        repositoryFetches += 1
+        return []
+      },
+    }
+
+    let unavailable = false
+    const connected = Promise.withResolvers<void>()
+    const controller = new AbortController()
+    const live = followRepositoryMembershipLive({
+      queryClient,
+      repositoriesQuery,
+      signal: controller.signal,
+      retryDelayMs: 15,
+      // Short grace: would fire if connect failed to mark transport healthy.
+      warningGraceMs: 40,
+      onLiveUpdatesUnavailable: (next) => {
+        unavailable = next
+      },
+      onDiagnostic: () => {
+        throw new Error("diagnostic listener blew up")
+      },
+      stream: async ({ onConnected, signal }) => {
+        await onConnected()
+        connected.resolve()
+        await new Promise<void>((resolve) => {
+          if (signal.aborted) {
+            resolve()
+            return
+          }
+          signal.addEventListener("abort", () => resolve(), { once: true })
+        })
+      },
+    })
+
+    await connected.promise
+    await waitFor(() => repositoryFetches >= 1)
+    // Grace elapsed without the warning — transport was marked healthy first.
+    await wait(60)
+    expect(unavailable).toBe(false)
+
+    controller.abort()
+    await live
+  })
+
+  test("reconnect ends catch-up failure backoff for the prior generation promptly", async () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    })
+    let shouldFail = true
+    let successfulFetches = 0
+    const repositoriesQuery = {
+      queryKey: ["repositories"] as const,
+      queryFn: async () => {
+        if (shouldFail) throw new Error("catch-up failed")
+        successfulFetches += 1
+        return []
+      },
+    }
+
+    let attempt = 0
+    const firstFailed = Promise.withResolvers<void>()
+    const secondConnected = Promise.withResolvers<void>()
+    const endFirst = Promise.withResolvers<void>()
+
+    const controller = new AbortController()
+    const live = followRepositoryMembershipLive({
+      queryClient,
+      repositoriesQuery,
+      signal: controller.signal,
+      // Stream reconnect uses this base; catch-up failure wait is generation-bound
+      // so a long first backoff must not delay gen-2 once the stream generation advances.
+      retryDelayMs: 80,
+      warningGraceMs: 5_000,
+      onDiagnostic: (diagnostic) => {
+        if (diagnostic.event === "catch_up_failure") firstFailed.resolve()
+        if (diagnostic.event === "connect" && diagnostic.generation === 2) {
+          secondConnected.resolve()
+        }
+      },
+      stream: async ({ onConnected, signal }) => {
+        attempt += 1
+        if (attempt === 1) {
+          await onConnected()
+          await endFirst.promise
+          return "stream_ended"
+        }
+        shouldFail = false
+        await onConnected()
+        await new Promise<void>((resolve) => {
+          if (signal.aborted) {
+            resolve()
+            return
+          }
+          signal.addEventListener("abort", () => resolve(), { once: true })
+        })
+        return "complete"
+      },
+    })
+
+    await firstFailed.promise
+    // Inflate the next catch-up wait by letting the first failure finish its
+    // short wait and schedule a second failure with doubled delay, then cut
+    // the stream during that longer wait.
+    await wait(120)
+    endFirst.resolve()
+    await secondConnected.promise
+    await waitFor(() => successfulFetches >= 1, { timeoutMs: 800 })
+
+    controller.abort()
+    await live
+  })
+
+  test("visibility catch-up does not mark transport unavailable on failure", async () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    })
+    let failVisibility = false
+    const repositoriesQuery = {
+      queryKey: ["repositories"] as const,
+      queryFn: async () => {
+        if (failVisibility) throw new Error("visibility refresh failed")
+        return []
+      },
+    }
+
+    let unavailable = false
+    const listeners = new Map<string, EventListener>()
+    const documentRef = {
+      visibilityState: "visible" as DocumentVisibilityState,
+      addEventListener: (type: string, listener: EventListener) => {
+        listeners.set(type, listener)
+      },
+      removeEventListener: (type: string) => {
+        listeners.delete(type)
+      },
+    }
+
+    const connected = Promise.withResolvers<void>()
+    const controller = new AbortController()
+    const live = followRepositoryMembershipLive({
+      queryClient,
+      repositoriesQuery,
+      signal: controller.signal,
+      documentRef,
+      retryDelayMs: 15,
+      warningGraceMs: 30,
+      onLiveUpdatesUnavailable: (next) => {
+        unavailable = next
+      },
+      stream: async ({ onConnected, signal }) => {
+        await onConnected()
+        connected.resolve()
+        await new Promise<void>((resolve) => {
+          if (signal.aborted) {
+            resolve()
+            return
+          }
+          signal.addEventListener("abort", () => resolve(), { once: true })
+        })
+      },
+    })
+
+    await connected.promise
+    failVisibility = true
+    documentRef.visibilityState = "visible"
+    listeners.get("visibilitychange")?.(new Event("visibilitychange"))
+    await wait(60)
+    expect(unavailable).toBe(false)
+
+    controller.abort()
+    await live
+  })
+})

--- a/apps/harness/test/repository-header-pr-count.test.ts
+++ b/apps/harness/test/repository-header-pr-count.test.ts
@@ -17,6 +17,12 @@ const openPrCountLiveSource = () =>
     "utf8",
   )
 
+const membershipLiveSource = () =>
+  readFileSync(
+    join(import.meta.dir, "../src/refresh-repositories-live.ts"),
+    "utf8",
+  )
+
 describe("repository header pull request count", () => {
   test("main repositories query does not request pullRequestCount", () => {
     const source = homeSource()
@@ -95,15 +101,21 @@ describe("repository header pull request count", () => {
     expect(home).toMatch(
       /followOpenPullRequestCountLive\(\{\s*queryClient,\s*openPullRequestCountsQuery,/,
     )
-    // Repository membership SSE fire-and-forgets dedicated counts, then awaits
-    // repositories only — never couples membership catch-up to count latency.
-    expect(home).toContain("streamRepositoryChanges")
-    expect(home).toMatch(
+    // Repository membership SSE is owned by the transport-health follower;
+    // catch-up fire-and-forgets dedicated counts and never couples warning
+    // state to count latency.
+    expect(home).toContain("followRepositoryMembershipLive")
+    expect(home).toContain("liveUpdatesWarningPresentation")
+    expect(home).toContain("onLiveUpdatesUnavailable")
+
+    const membership = membershipLiveSource()
+    expect(membership).toContain("openPullRequestCountsQueryKey")
+    expect(membership).toMatch(
       /invalidateQueries\(\{\s*queryKey:\s*openPullRequestCountsQueryKey\s*\}\)/,
     )
-    expect(home).toMatch(
-      /invalidateQueries\(\{\s*queryKey:\s*openPullRequestCountsQueryKey[\s\S]*?fetchQuery\(\{\s*\.\.\.repositoriesQuery/,
-    )
+    expect(membership).toContain("scheduleCatchUp")
+    expect(membership).toContain("Fire-and-forget")
+    expect(membership).toContain("transport health")
 
     const live = openPrCountLiveSource()
     expect(live).toContain("OPEN_PULL_REQUEST_COUNT_POLL_INTERVAL_MS")

--- a/apps/harness/test/repository-live.test.ts
+++ b/apps/harness/test/repository-live.test.ts
@@ -1,18 +1,31 @@
 import {
+  REPOSITORY_SSE_HEARTBEAT_INTERVAL_MS,
+  REPOSITORY_SSE_STALE_AFTER_MS,
+  RepositorySubscriptionStaleError,
   parseSubscriptionEvent,
   streamRepositoryChanges,
 } from "../src/repository-live.js"
 import { describe, expect, test } from "bun:test"
 
+const wait = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
+
 describe("Repository live updates", () => {
-  test("parses GraphQL SSE events", () => {
+  test("documents a stale bound longer than Yoga's production heartbeat", () => {
+    expect(REPOSITORY_SSE_HEARTBEAT_INTERVAL_MS).toBe(12_000)
+    expect(REPOSITORY_SSE_STALE_AFTER_MS).toBeGreaterThan(
+      REPOSITORY_SSE_HEARTBEAT_INTERVAL_MS,
+    )
+  })
+
+  test("parses GraphQL SSE events and Yoga heartbeat comments", () => {
     expect(
       parseSubscriptionEvent(
         'event: next\ndata: {"data":{"repositoriesChanged":true}}',
       ),
     ).toBe("next")
     expect(parseSubscriptionEvent("event: complete")).toBe("complete")
-    expect(parseSubscriptionEvent(": keep-alive")).toBeNull()
+    expect(parseSubscriptionEvent(": keep-alive")).toBe("comment")
+    expect(parseSubscriptionEvent(":")).toBe("comment")
   })
 
   test("connects and reports every change event", async () => {
@@ -42,7 +55,221 @@ describe("Repository live updates", () => {
       fetch: () => Promise.resolve(new Response(body, { status: 200 })),
     })
 
+    // onChange is fire-and-forget; allow microtasks to settle.
+    await wait(0)
     expect(connected).toBe(1)
     expect(changes).toBe(2)
+  })
+
+  test("reports transport ready before catch-up finishes and keeps reading", async () => {
+    const encoder = new TextEncoder()
+    let releaseCatchUp: (() => void) | undefined
+    const catchUpGate = new Promise<void>((resolve) => {
+      releaseCatchUp = resolve
+    })
+    let pushEvent: ((chunk: string) => void) | undefined
+    let closeStream: (() => void) | undefined
+
+    const body = new ReadableStream<Uint8Array>({
+      start(controller) {
+        pushEvent = (chunk) => controller.enqueue(encoder.encode(chunk))
+        closeStream = () => controller.close()
+      },
+    })
+
+    let connectedAt: number | undefined
+    let firstChangeAt: number | undefined
+    let catchUpStartedAt: number | undefined
+    let catchUpFinished = false
+    const activities: string[] = []
+
+    const streamDone = streamRepositoryChanges({
+      signal: new AbortController().signal,
+      staleAfterMs: Number.POSITIVE_INFINITY,
+      onConnected: async () => {
+        connectedAt = Date.now()
+        catchUpStartedAt = Date.now()
+        await catchUpGate
+        catchUpFinished = true
+      },
+      onChange: () => {
+        firstChangeAt = Date.now()
+      },
+      onActivity: ({ kind }) => {
+        activities.push(kind)
+      },
+      fetch: () => Promise.resolve(new Response(body, { status: 200 })),
+    })
+
+    // Transport ready must fire without waiting for catch-up.
+    await wait(10)
+    expect(connectedAt).toBeDefined()
+    expect(catchUpStartedAt).toBeDefined()
+    expect(catchUpFinished).toBe(false)
+
+    // Heartbeats and notifications must be observed while catch-up is held.
+    pushEvent?.(": keep-alive\n\n")
+    pushEvent?.('event: next\ndata: {"data":{"repositoriesChanged":true}}\n\n')
+    await wait(20)
+
+    expect(catchUpFinished).toBe(false)
+    expect(activities).toContain("comment")
+    expect(activities).toContain("next")
+    expect(firstChangeAt).toBeDefined()
+
+    releaseCatchUp?.()
+    pushEvent?.("event: complete\n\n")
+    closeStream?.()
+    await streamDone
+    expect(catchUpFinished).toBe(true)
+  })
+
+  test("a failed catch-up does not terminate an otherwise healthy stream", async () => {
+    const encoder = new TextEncoder()
+    let pushEvent: ((chunk: string) => void) | undefined
+    let closeStream: (() => void) | undefined
+    const body = new ReadableStream<Uint8Array>({
+      start(controller) {
+        pushEvent = (chunk) => controller.enqueue(encoder.encode(chunk))
+        closeStream = () => controller.close()
+      },
+    })
+
+    let changes = 0
+    const streamDone = streamRepositoryChanges({
+      signal: new AbortController().signal,
+      staleAfterMs: Number.POSITIVE_INFINITY,
+      onConnected: async () => {
+        throw new Error("catch-up blew up")
+      },
+      onChange: () => {
+        changes += 1
+      },
+      fetch: () => Promise.resolve(new Response(body, { status: 200 })),
+    })
+
+    await wait(10)
+    pushEvent?.('event: next\ndata: {"data":{"repositoriesChanged":true}}\n\n')
+    await wait(10)
+    expect(changes).toBe(1)
+
+    pushEvent?.("event: complete\n\n")
+    closeStream?.()
+    await streamDone
+  })
+
+  test("marks a quiet connection stale after the activity bound", async () => {
+    const body = new ReadableStream<Uint8Array>({
+      start() {
+        // Never enqueue activity after open.
+      },
+      cancel() {
+        // Reader cancel on stale is expected.
+      },
+    })
+
+    let staleError: unknown
+    try {
+      await streamRepositoryChanges({
+        signal: new AbortController().signal,
+        staleAfterMs: 30,
+        onConnected: () => undefined,
+        onChange: () => undefined,
+        fetch: () => Promise.resolve(new Response(body, { status: 200 })),
+      })
+    } catch (error) {
+      staleError = error
+    }
+
+    expect(staleError).toBeInstanceOf(RepositorySubscriptionStaleError)
+  })
+
+  test("decodes a final chunk delivered with done and flushes the decoder", async () => {
+    const encoder = new TextEncoder()
+    // Deliver the last event in the same read that signals done (value + done).
+    const body = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(
+          encoder.encode(
+            'event: next\ndata: {"data":{"repositoriesChanged":true}}\n\n',
+          ),
+        )
+        controller.close()
+      },
+    })
+
+    let changes = 0
+    const end = await streamRepositoryChanges({
+      signal: new AbortController().signal,
+      staleAfterMs: Number.POSITIVE_INFINITY,
+      onConnected: () => undefined,
+      onChange: () => {
+        changes += 1
+      },
+      fetch: () => Promise.resolve(new Response(body, { status: 200 })),
+    })
+    await wait(0)
+    expect(changes).toBe(1)
+    expect(end).toBe("stream_ended")
+  })
+
+  test("returns complete when the subscription emits event: complete", async () => {
+    const body = new ReadableStream({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode("event: complete\n\n"))
+        controller.close()
+      },
+    })
+    const end = await streamRepositoryChanges({
+      signal: new AbortController().signal,
+      staleAfterMs: Number.POSITIVE_INFINITY,
+      onConnected: () => undefined,
+      onChange: () => undefined,
+      fetch: () => Promise.resolve(new Response(body, { status: 200 })),
+    })
+    expect(end).toBe("complete")
+  })
+
+  test("prefers stale over a rejecting reader cancel", async () => {
+    const body = new ReadableStream<Uint8Array>({
+      start() {
+        // Hang open until cancel.
+      },
+      cancel() {
+        // Some hosts reject outstanding reads; the streamer must still surface stale.
+      },
+    })
+    // Monkey-patch getReader to reject after cancel.
+    const response = new Response(body, { status: 200 })
+    const originalGetReader = response.body!.getReader.bind(response.body)
+    response.body!.getReader = () => {
+      const reader = originalGetReader()
+      const originalRead = reader.read.bind(reader)
+      let cancelled = false
+      const originalCancel = reader.cancel.bind(reader)
+      reader.cancel = async (reason?: unknown) => {
+        cancelled = true
+        return originalCancel(reason)
+      }
+      reader.read = async () => {
+        if (cancelled) throw new Error("read rejected after cancel")
+        return originalRead()
+      }
+      return reader
+    }
+
+    let staleError: unknown
+    try {
+      await streamRepositoryChanges({
+        signal: new AbortController().signal,
+        staleAfterMs: 20,
+        onConnected: () => undefined,
+        onChange: () => undefined,
+        fetch: () => Promise.resolve(response),
+      })
+    } catch (error) {
+      staleError = error
+    }
+    expect(staleError).toBeInstanceOf(RepositorySubscriptionStaleError)
   })
 })


### PR DESCRIPTION
## Why

The Configured Repositories live-updates warning cleared only after
authoritative membership catch-up succeeded. A healthy GraphQL SSE
subscription therefore looked unavailable whenever catch-up was slow, held
pending, or failed (including unrelated open-PR count work). That conflated
transport health with remote refresh latency (#598, parent #595).

## What

- Extract `followRepositoryMembershipLive` so transport health is driven by
  SSE connect/activity, with the existing 10s grace warning and prompt recovery.
- Consume the SSE body immediately; do not await catch-up from the reader so
  Yoga heartbeats and notifications continue during refresh.
- Single-flight, generation-scoped catch-up: same-generation events coalesce;
  newer reconnects supersede older callbacks; cancel only across generations.
- Treat missing activity beyond 45s as stale and reconnect once; diagnostics
  cover connect, disconnect, reconnect, stale, and catch-up failure without
  secrets or Sidecar URLs.
- Fire-and-forget dedicated open-PR count invalidation so count latency cannot
  flip the warning; map stream end to `complete` vs `stream_ended`.

## Verification

- Unit tests for streamer (immediate consume, failed catch-up, stale, complete
  vs stream_ended) and follower (health before catch-up, warning grace/recover,
  generation supersede, coalescing, backoff wake, throwing diagnostics).
- Related harness live-update suites still pass; biome clean on touched files.

## Notes

Membership `queryFn` still does not thread GraphQL AbortSignal; cancel remains
cache-level best-effort. In-process PubSub and `/graphql` SSE transport are
unchanged.

Closes #598