### PR TITLE
feat(harness): typecheck unit and e2e tests in CI

### DIFF
--- a/apps/harness/e2e/support/clone-fixture-repo.ts
+++ b/apps/harness/e2e/support/clone-fixture-repo.ts
@@ -9,12 +9,16 @@ import {
 import { tmpdir } from "node:os"
 import { dirname, join, resolve } from "node:path"
 import { fileURLToPath } from "node:url"
-import { Effect } from "effect"
+import { Data, Effect } from "effect"
 import {
   KeymaxxerService,
   sidecarKeymaxxerLayer,
 } from "@ready-for-agent/keymaxxer-service"
 import { FIXTURE_REPOSITORY, FIXTURE_SECRET_NAME } from "./constants.ts"
+
+class CloneFixtureError extends Data.TaggedError("CloneFixtureError")<{
+  readonly message: string
+}> {}
 
 const supportDir = dirname(fileURLToPath(import.meta.url))
 const workspaceRoot = resolve(supportDir, "../../../..")
@@ -155,7 +159,9 @@ const cloneViaSidecar = async (checkoutParent: string, sidecarUrl: string) => {
       account: FIXTURE_REPOSITORY,
     })
     if (secretName === null) {
-      return yield* Effect.fail(new Error(missingCredentialMessage))
+      return yield* new CloneFixtureError({
+        message: missingCredentialMessage,
+      })
     }
     const cloneCommand = [
       "git",
@@ -172,16 +178,14 @@ const cloneViaSidecar = async (checkoutParent: string, sidecarUrl: string) => {
       timeoutMs: 180_000,
     })
     if (result.exitCode !== 0 || !existsSync(join(dest, ".git"))) {
-      return yield* Effect.fail(
-        new Error(
-          [
-            `Failed to clone ${FIXTURE_REPOSITORY} through Keymaxxer Sidecar.`,
-            result.stderr.trim() ||
-              result.stdout.trim() ||
-              `exit ${result.exitCode}`,
-          ].join("\n"),
-        ),
-      )
+      return yield* new CloneFixtureError({
+        message: [
+          `Failed to clone ${FIXTURE_REPOSITORY} through Keymaxxer Sidecar.`,
+          result.stderr.trim() ||
+            result.stdout.trim() ||
+            `exit ${result.exitCode}`,
+        ].join("\n"),
+      })
     }
     return dest
   })

--- a/apps/harness/src/issues-live.ts
+++ b/apps/harness/src/issues-live.ts
@@ -23,6 +23,12 @@ export const parseIssuesSubscriptionEvent = (event: string): string | null => {
   return result.data?.repositoryIssuesChanged ?? null
 }
 
+/** Minimal fetch surface used by the Issues subscription stream. */
+export type IssuesLiveFetch = (
+  input: RequestInfo | URL,
+  init?: RequestInit,
+) => Promise<Response>
+
 export const streamIssuesChanged = async ({
   signal,
   onConnected,
@@ -32,7 +38,7 @@ export const streamIssuesChanged = async ({
   signal: AbortSignal
   onConnected: () => void | Promise<void>
   onChange: (repositoryId: string) => void | Promise<void>
-  fetch?: typeof fetch
+  fetch?: IssuesLiveFetch
 }): Promise<void> => {
   const operation = generateSubscriptionOp({
     repositoryIssuesChanged: true,

--- a/apps/harness/src/repository-live.ts
+++ b/apps/harness/src/repository-live.ts
@@ -70,6 +70,12 @@ export const parseSubscriptionEvent = (
 /** How a Repository SSE stream ended when it did not throw. */
 export type RepositoryLiveStreamEnd = "complete" | "stream_ended"
 
+/** Minimal fetch surface used by the Repository subscription stream. */
+export type RepositoryLiveFetch = (
+  input: RequestInfo | URL,
+  init?: RequestInit,
+) => Promise<Response>
+
 /**
  * Open the Repository-changed GraphQL SSE subscription and consume the body
  * immediately.
@@ -100,7 +106,7 @@ export const streamRepositoryChanges = async ({
   /** Invoked on every stream activity (heartbeats and application events). */
   onActivity?: (info: { readonly kind: "chunk" | "comment" | "next" }) => void
   staleAfterMs?: number
-  fetch?: typeof fetch
+  fetch?: RepositoryLiveFetch
 }): Promise<RepositoryLiveStreamEnd> => {
   const response = await fetchRequest("/graphql", {
     method: "POST",

--- a/apps/harness/src/server/production-lifecycle.ts
+++ b/apps/harness/src/server/production-lifecycle.ts
@@ -26,6 +26,8 @@ import {
   serveStaticAssetFromEmbed,
 } from "./production-static.js"
 
+export type { Application }
+
 export type ProductionLifecycleEvent =
   | "database-ready"
   | "sidecar-ready"

--- a/apps/harness/src/work-items-live.ts
+++ b/apps/harness/src/work-items-live.ts
@@ -25,6 +25,12 @@ export const parseWorkItemsSubscriptionEvent = (
   return result.data?.repositoryWorkItemsChanged ?? null
 }
 
+/** Minimal fetch surface used by the Work Items subscription stream. */
+export type WorkItemsLiveFetch = (
+  input: RequestInfo | URL,
+  init?: RequestInit,
+) => Promise<Response>
+
 export const streamWorkItemsChanged = async ({
   signal,
   onConnected,
@@ -34,7 +40,7 @@ export const streamWorkItemsChanged = async ({
   signal: AbortSignal
   onConnected: () => void | Promise<void>
   onChange: (repositoryId: string) => void | Promise<void>
-  fetch?: typeof fetch
+  fetch?: WorkItemsLiveFetch
 }): Promise<void> => {
   const operation = generateSubscriptionOp({
     repositoryWorkItemsChanged: true,

--- a/apps/harness/test/ambient-github-layer.test.ts
+++ b/apps/harness/test/ambient-github-layer.test.ts
@@ -114,7 +114,7 @@ test("ambient GitHub authentication is resolved once", async () => {
         forgeHost: "github.com",
         projectPath: "acme/two",
       })
-    }).pipe(Effect.provide(layer), Effect.provide(processLayer)),
+    }).pipe(Effect.provide(layer.pipe(Layer.provide(processLayer)))),
   )
 
   expect(resolutions).toBe(1)
@@ -148,7 +148,7 @@ test("ambient GitHub authentication refreshes once after a 401", async () => {
         forgeHost: "github.com",
         projectPath: "acme/widgets",
       })
-    }).pipe(Effect.provide(layer), Effect.provide(processLayer)),
+    }).pipe(Effect.provide(layer.pipe(Layer.provide(processLayer)))),
   )
 
   expect(resolutions).toBe(2)
@@ -251,7 +251,7 @@ test("concurrent 401 responses share one refreshed token", async () => {
         ],
         { concurrency: "unbounded" },
       )
-    }).pipe(Effect.provide(layer), Effect.provide(processLayer)),
+    }).pipe(Effect.provide(layer.pipe(Layer.provide(processLayer)))),
   )
 
   expect(expiredCalls).toBe(2)
@@ -287,7 +287,7 @@ test("ambient GitHub authentication is not refreshed after a 403", async () => {
           projectPath: "acme/widgets",
         }),
       )
-    }).pipe(Effect.provide(layer), Effect.provide(processLayer)),
+    }).pipe(Effect.provide(layer.pipe(Layer.provide(processLayer)))),
   )
 
   expect(resolutions).toBe(1)
@@ -321,7 +321,7 @@ test("failed authentication acquisition is cleared for a later retry", async () 
         forgeHost: "github.com",
         projectPath: "acme/widgets",
       })
-    }).pipe(Effect.provide(layer), Effect.provide(processLayer)),
+    }).pipe(Effect.provide(layer.pipe(Layer.provide(processLayer)))),
   )
 
   expect(resolutions).toBe(2)

--- a/apps/harness/test/ambient-gitlab-layer.test.ts
+++ b/apps/harness/test/ambient-gitlab-layer.test.ts
@@ -54,7 +54,7 @@ test("GITLAB_TOKEN takes precedence over glab and is cached per host", async () 
         ...repository,
         projectPath: "project/other",
       })
-    }).pipe(Effect.provide(layer), Effect.provide(processLayer)),
+    }).pipe(Effect.provide(layer.pipe(Layer.provide(processLayer)))),
   )
 
   expect(resolutions).toBe(0)
@@ -80,7 +80,7 @@ test("glab tokens are resolved independently per GitLab host", async () => {
         ...repository,
         forgeHost: "gitlab.example.com",
       })
-    }).pipe(Effect.provide(layer), Effect.provide(processLayer)),
+    }).pipe(Effect.provide(layer.pipe(Layer.provide(processLayer)))),
   )
 
   expect(hosts).toEqual(["git.drupalcode.org", "gitlab.example.com"])
@@ -110,7 +110,7 @@ test("authentication refreshes once after a GitLab 401", async () => {
     Effect.gen(function* () {
       const gitlab = yield* GitLabService
       yield* gitlab.listReadyIssues(repository)
-    }).pipe(Effect.provide(layer), Effect.provide(processLayer)),
+    }).pipe(Effect.provide(layer.pipe(Layer.provide(processLayer)))),
   )
 
   expect(resolutions).toBe(2)
@@ -138,7 +138,7 @@ test("public project verification falls back to anonymous access", async () => {
       const gitlab = yield* GitLabService
       expect(yield* gitlab.hasCredentials(repository)).toBe(false)
       yield* gitlab.verifyProject(repository)
-    }).pipe(Effect.provide(layer), Effect.provide(processLayer)),
+    }).pipe(Effect.provide(layer.pipe(Layer.provide(processLayer)))),
   )
 
   expect(anonymousVerifications).toBe(1)

--- a/apps/harness/test/application-runtime-disposal.test.ts
+++ b/apps/harness/test/application-runtime-disposal.test.ts
@@ -43,8 +43,7 @@ test("application disposal closes a lazily created authentication client", async
   try {
     await Effect.runPromise(
       runConfiguredMigrations().pipe(
-        Effect.provide(DatabaseLive),
-        Effect.provide(configLayer),
+        Effect.provide(DatabaseLive.pipe(Layer.provide(configLayer))),
       ),
     )
     const databaseLayer = DbServiceLive.pipe(

--- a/apps/harness/test/job-worker.test.ts
+++ b/apps/harness/test/job-worker.test.ts
@@ -7,8 +7,17 @@ import {
   Logger,
   ManagedRuntime,
   Option,
+  type Scope,
 } from "effect"
-import { AgentBackend } from "@ready-for-agent/agent-backend"
+import {
+  ActiveAgentBackend,
+  type ActiveAgentBackendShape,
+  type AgentBackendId,
+  type AgentBackendRuntimeStatus,
+  type AgentBackendStatus,
+  missingSessionTelemetry,
+  toAgentBackendStatus,
+} from "@ready-for-agent/agent-backend"
 import { DatabaseTest } from "@ready-for-agent/db/test"
 import {
   DatabaseError,
@@ -72,12 +81,12 @@ import {
 import { describe, expect, test } from "bun:test"
 
 const repository = makeRepositoryRecord({
-  id: "repo-01J00000000000000000000000",
+  id: RepositoryId.make("repo-01J00000000000000000000000"),
   paused: true,
 })
 
 const otherRepository = makeRepositoryRecord({
-  id: "repo-01J00000000000000000000001",
+  id: RepositoryId.make("repo-01J00000000000000000000001"),
   forge: "github",
   forgeHost: "github.com",
   projectPath: "acme/gadgets",
@@ -278,13 +287,76 @@ const queueLayer = (
     }),
   )
 
-const runScoped = <A, E, R>(
-  effect: Effect.Effect<A, E, R>,
-  layer: Layer.Layer<R>,
-) =>
+const runScoped = <A, E, R, LE>(
+  effect: Effect.Effect<A, E, R | Scope.Scope>,
+  layer: Layer.Layer<R, LE, never>,
+): Promise<A> =>
   Effect.runPromise(
     Effect.scoped(effect).pipe(Effect.provide(layer), Effect.orDie),
   )
+
+const readyRuntimeStatus = (): AgentBackendRuntimeStatus => ({
+  backend: { id: "opencode", label: "OpenCode" },
+  kind: "ready",
+  reason: null,
+  models: [
+    {
+      id: "opencode/deepseek-v4-flash-free",
+      thinkingLevels: ["low", "high"],
+    },
+  ],
+})
+
+const readyStatus = (): AgentBackendStatus =>
+  toAgentBackendStatus(readyRuntimeStatus())
+
+const stubActiveAgentBackend = (): ActiveAgentBackendShape => {
+  const ready = readyRuntimeStatus()
+  return {
+    listStatuses: Effect.succeed([ready]),
+    getBackendStatus: (backendId: AgentBackendId) =>
+      Effect.succeed(backendId === ready.backend.id ? ready : null),
+    getStatus: Effect.succeed(readyStatus()),
+    setSelectedOrInUse: () => Effect.succeed([ready]),
+    recheck: () => Effect.succeed(ready),
+    requireAgentTurnsAllowed: () => Effect.void,
+    activate: () => Effect.succeed(ready),
+    drop: () => Effect.void,
+    preview: () =>
+      Effect.succeed({
+        backend: { id: "opencode", label: "OpenCode" },
+        kind: "ready" as const,
+        reason: null,
+        models: readyStatus().models,
+      }),
+    withConfigCoordination: (effect) => effect,
+    getRegistration: () =>
+      Effect.succeed({
+        descriptor: { id: "opencode", label: "OpenCode" },
+        capabilities: [
+          { _tag: "SessionTelemetry", supported: true },
+          { _tag: "KeymaxxerMcp", supported: true },
+        ],
+      }),
+    getActiveRegistration: Effect.succeed({
+      descriptor: { id: "opencode", label: "OpenCode" },
+      capabilities: [
+        { _tag: "SessionTelemetry", supported: true },
+        { _tag: "KeymaxxerMcp", supported: true },
+      ],
+    }),
+    startTurn: () => Effect.die("unused"),
+    continueTurn: () => Effect.die("unused"),
+    inspectBackend: () => Effect.die("unused"),
+    getSessionTelemetry: (input) =>
+      Effect.succeed(
+        missingSessionTelemetry(input.sessionId ?? "", {
+          id: "opencode",
+          label: "OpenCode",
+        }),
+      ),
+  }
+}
 
 describe("Job worker", () => {
   test("enqueues a validated Refresh Job on the issue-refresh queue", async () => {
@@ -693,9 +765,9 @@ describe("Job worker", () => {
               unchanged: 0,
             }
           }
-          return yield* Effect.fail(
-            new DatabaseError({ message: "reconciliation failed" }),
-          )
+          return yield* new DatabaseError({
+            message: "reconciliation failed",
+          })
         }),
     } satisfies IssueReconcilerShape)
 
@@ -743,9 +815,9 @@ describe("Job worker", () => {
         Effect.gen(function* () {
           reconciliations += 1
           if (reconciliations === 2) {
-            return yield* Effect.fail(
-              new DatabaseError({ message: "reconciliation failed" }),
-            )
+            return yield* new DatabaseError({
+              message: "reconciliation failed",
+            })
           }
           return {
             fetched: 0,
@@ -756,11 +828,6 @@ describe("Job worker", () => {
           }
         }),
     } satisfies IssueReconcilerShape)
-    const opencode = Layer.succeed(AgentBackend, {
-      startTurn: () => Effect.die("not used"),
-      continueTurn: () => Effect.die("not used"),
-      inspect: () => Effect.die("not used"),
-    })
     const sessionStore = Layer.succeed(OpencodeSessionStore, {
       getSession: (id) =>
         Effect.succeed({
@@ -787,7 +854,7 @@ describe("Job worker", () => {
         queue,
         reconciler,
         keymaxxerLayer(),
-        opencode,
+        Layer.succeed(ActiveAgentBackend, stubActiveAgentBackend()),
         sessionStore,
         defaultGithubLayer,
         localGit,
@@ -2108,6 +2175,7 @@ describe("Job worker", () => {
       }).pipe(
         Effect.provide(
           Layer.mergeAll(
+            defaultGithubLayer,
             database,
             queue,
             reconciler,
@@ -2135,12 +2203,10 @@ describe("Job worker", () => {
         Effect.gen(function* () {
           findSecretCalls += 1
           if (findSecretCalls < 3) {
-            return yield* Effect.fail(
-              new KeymaxxerError({
-                operation: "findSecret",
-                message: "Keymaxxer unavailable",
-              }),
-            )
+            return yield* new KeymaxxerError({
+              operation: "findSecret",
+              message: "Keymaxxer unavailable",
+            })
           }
           return provider === "github" &&
             account === `${repository.projectPath}`
@@ -2229,6 +2295,7 @@ describe("Job worker", () => {
       }).pipe(
         Effect.provide(
           Layer.mergeAll(
+            defaultGithubLayer,
             database,
             queue,
             Layer.succeed(IssueReconciler, {

--- a/apps/harness/test/keymaxxer-github-layer.test.ts
+++ b/apps/harness/test/keymaxxer-github-layer.test.ts
@@ -630,7 +630,7 @@ describe("Keymaxxer-backed GitHub layer", () => {
     expect(runs[0]?.command).toContain("merge-pull-request.ts")
     expect(runs[0]?.command).toContain('"--conditions"')
     expect(runs[0]?.secrets).toEqual(["GITHUB_TOKEN_ACME_WIDGETS"])
-    expect(outcomes).toEqual(serializedOutcomes)
+    expect(outcomes).toEqual([...serializedOutcomes])
   })
 
   test("rejects malformed Ready Issue fields through Schema", async () => {

--- a/apps/harness/test/parent-issue-actions-menu.test.tsx
+++ b/apps/harness/test/parent-issue-actions-menu.test.tsx
@@ -89,7 +89,7 @@ describe("isParentImplementAllWithAutoMergeEligible", () => {
     expect(
       isParentImplementAllWithAutoMergeEligible({
         openChildren: [{ issueNumber: 2, hasChildren: true, blockedBy: [] }],
-        directChildren: [{ issueNumber: 2, hasChildren: true, blockedBy: [] }],
+        directChildren: [{ hasChildren: true }],
         workItems: [],
         workItemsLoading: false,
       }),

--- a/apps/harness/test/production-sse-idle-timeout.test.ts
+++ b/apps/harness/test/production-sse-idle-timeout.test.ts
@@ -9,7 +9,7 @@ import {
   missingSessionTelemetry,
   toAgentBackendStatus,
 } from "@ready-for-agent/agent-backend"
-import { DbService } from "@ready-for-agent/db-service"
+import { DbService, RepositoryId } from "@ready-for-agent/db-service"
 import {
   makeRepositoryRecord,
   stubDbService,
@@ -48,7 +48,7 @@ import { afterEach, describe, expect, test } from "bun:test"
 const YOGA_SSE_HEARTBEAT_INTERVAL_SECONDS = 12
 
 const repository = makeRepositoryRecord({
-  id: "repo-01J00000000000000000000000",
+  id: RepositoryId.make("repo-01J00000000000000000000000"),
   localPath: "/repos/acme/widgets.git",
   paused: true,
 })

--- a/apps/harness/test/refresh-issues-live.test.ts
+++ b/apps/harness/test/refresh-issues-live.test.ts
@@ -229,15 +229,19 @@ describe("Repository Issue live-query coordination", () => {
 
     await onChange?.(repositoryId)
     expect(issueFetches).toBe(2)
-    expect(queryClient.getQueryData(issuesQuery.queryKey)).toEqual([
-      { title: "After reconciliation" },
-    ])
+    expect(
+      queryClient.getQueryData<ReadonlyArray<{ title: string }>>(
+        issuesQuery.queryKey,
+      ),
+    ).toEqual([{ title: "After reconciliation" }])
 
     resolveStale?.([{ title: "Before reconciliation" }])
     await staleFetch.catch(() => undefined)
-    expect(queryClient.getQueryData(issuesQuery.queryKey)).toEqual([
-      { title: "After reconciliation" },
-    ])
+    expect(
+      queryClient.getQueryData<ReadonlyArray<{ title: string }>>(
+        issuesQuery.queryKey,
+      ),
+    ).toEqual([{ title: "After reconciliation" }])
 
     controller.abort()
     await live

--- a/apps/harness/test/refresh-work-items-live.test.ts
+++ b/apps/harness/test/refresh-work-items-live.test.ts
@@ -139,7 +139,11 @@ describe("Repository Work Item live-query coordination", () => {
     expect(selectedWorkItemsFetches).toBeGreaterThan(
       fetchesBeforeInvalidation.selectedWorkItems,
     )
-    expect(queryClient.getQueryData(configQuery.queryKey)).toEqual({
+    expect(
+      queryClient.getQueryData<{ unfinishedWorkItemCount: number }>(
+        configQuery.queryKey,
+      ),
+    ).toEqual({
       unfinishedWorkItemCount: 0,
     })
     expect(configFetches).toBeGreaterThan(fetchesBeforeInvalidation.config)
@@ -217,15 +221,19 @@ describe("Repository Work Item live-query coordination", () => {
 
     await onChange?.(repositoryId)
     expect(workItemFetches).toBe(2)
-    expect(queryClient.getQueryData(workItemsQuery.queryKey)).toEqual([
-      { status: "RUNNING" },
-    ])
+    expect(
+      queryClient.getQueryData<ReadonlyArray<{ status: string }>>(
+        workItemsQuery.queryKey,
+      ),
+    ).toEqual([{ status: "RUNNING" }])
 
     resolveStale?.([{ status: "QUEUED" }])
     await staleFetch.catch(() => undefined)
-    expect(queryClient.getQueryData(workItemsQuery.queryKey)).toEqual([
-      { status: "RUNNING" },
-    ])
+    expect(
+      queryClient.getQueryData<ReadonlyArray<{ status: string }>>(
+        workItemsQuery.queryKey,
+      ),
+    ).toEqual([{ status: "RUNNING" }])
 
     controller.abort()
     await live
@@ -345,12 +353,12 @@ describe("Repository Work Item live-query coordination", () => {
     await connectedPromise
     const fetchesAfterConnect = countFetches
     expect(fetchesAfterConnect).toBeGreaterThan(1)
-    expect(queryClient.getQueryData(todayKey)).toBe(22)
+    expect(queryClient.getQueryData<number>(todayKey)).toBe(22)
 
     count = 23
     await onChange?.(repositoryId)
     await waitFor(() => countFetches > fetchesAfterConnect)
-    expect(queryClient.getQueryData(todayKey)).toBe(23)
+    expect(queryClient.getQueryData<number>(todayKey)).toBe(23)
 
     controller.abort()
     await live
@@ -728,7 +736,9 @@ describe("Repository Work Item live-query coordination", () => {
     await waitFor(() => pendingEvents.length === 0)
     // Two delayed retries after the first failed event-triggered pass.
     await waitFor(() => countFetches === fetchesAfterConnect + 3)
-    expect(queryClient.getQueryData(todayKey)).toBe(fetchesAfterConnect + 3)
+    expect(queryClient.getQueryData<number>(todayKey)).toBe(
+      fetchesAfterConnect + 3,
+    )
 
     controller.abort()
     await live
@@ -1081,7 +1091,9 @@ describe("Repository Work Item live-query coordination", () => {
     releaseCountFetch?.()
     // Failed pass must not drop the pending notification's trailing refresh.
     await waitFor(() => countFetches === fetchesAfterConnect + 2)
-    expect(queryClient.getQueryData(todayKey)).toBe(fetchesAfterConnect + 2)
+    expect(queryClient.getQueryData<number>(todayKey)).toBe(
+      fetchesAfterConnect + 2,
+    )
 
     controller.abort()
     await live
@@ -1146,8 +1158,10 @@ describe("Repository Work Item live-query coordination", () => {
     await Bun.sleep(20)
 
     expect(workItemFetches).toBe(fetchesAfterConnect + 1)
-    expect(queryClient.getQueryData(workItemsQuery.queryKey)).toEqual([
-      { id: `wi-${fetchesAfterConnect}` },
-    ])
+    expect(
+      queryClient.getQueryData<ReadonlyArray<{ id: string }>>(
+        workItemsQuery.queryKey,
+      ),
+    ).toEqual([{ id: `wi-${fetchesAfterConnect}` }])
   })
 })

--- a/apps/harness/test/repository-live.test.ts
+++ b/apps/harness/test/repository-live.test.ts
@@ -251,10 +251,10 @@ describe("Repository live updates", () => {
         cancelled = true
         return originalCancel(reason)
       }
-      reader.read = async () => {
+      reader.read = (async () => {
         if (cancelled) throw new Error("read rejected after cancel")
         return originalRead()
-      }
+      }) as typeof reader.read
       return reader
     }
 

--- a/apps/harness/test/unified-server.test.ts
+++ b/apps/harness/test/unified-server.test.ts
@@ -24,9 +24,20 @@ test("routes /graphql through the injected GraphQL handler", async () => {
     },
   }
 
-  const post = Route.options.server?.handlers?.POST
+  const handlers = Route.options.server?.handlers
+  expect(handlers).toBeDefined()
+  if (handlers === undefined || typeof handlers === "function") {
+    throw new Error("expected GraphQL route object handlers")
+  }
+  const post = handlers.POST
   expect(post).toBeTypeOf("function")
-  const response = await post!({ request, context } as never)
+  if (post === undefined) {
+    throw new Error("expected GraphQL POST handler")
+  }
+  const response = await post({ request, context } as never)
+  if (!(response instanceof Response)) {
+    throw new Error("expected Response from GraphQL POST handler")
+  }
 
   expect(response.status).toBe(200)
   expect(delegatedUrl).toBe("http://127.0.0.1:6056/graphql")

--- a/apps/harness/tsconfig.app.json
+++ b/apps/harness/tsconfig.app.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
+    "allowImportingTsExtensions": true,
     "composite": false,
     "declaration": false,
     "declarationMap": false,
@@ -14,7 +15,15 @@
     "tsBuildInfoFile": "./out-tsc/app/tsconfig.app.tsbuildinfo",
     "types": ["bun", "vite/client"]
   },
-  "include": ["server.ts", "src/**/*.ts", "src/**/*.tsx"],
+  "include": [
+    "server.ts",
+    "src/**/*.ts",
+    "src/**/*.tsx",
+    "test/**/*.ts",
+    "test/**/*.tsx",
+    "e2e/**/*.ts",
+    "playwright.config.ts"
+  ],
   "references": [
     {
       "path": "../../packages/work-item-lifecycle/tsconfig.lib.json"

--- a/packages/keymaxxer-service/src/lib/http-layer.ts
+++ b/packages/keymaxxer-service/src/lib/http-layer.ts
@@ -9,8 +9,14 @@ import { mcpToolCallTimeoutMs } from "./config.js"
 import { type KeymaxxerError, keymaxxerError } from "./models.js"
 import { KeymaxxerService } from "./service.js"
 
+/** Minimal fetch surface used by sidecar TCP/HTTP readiness probes. */
+export type SidecarFetch = (
+  input: string | URL,
+  init?: RequestInit,
+) => Promise<Response>
+
 export type SidecarLayerOptions = {
-  readonly fetch?: typeof globalThis.fetch
+  readonly fetch?: SidecarFetch
   readonly retryDelayMs?: number
   readonly startupTimeoutMs?: number
   readonly createClient?: () => Promise<KeymaxxerToolClient>

--- a/packages/work-item-lifecycle/src/lib/commit.ts
+++ b/packages/work-item-lifecycle/src/lib/commit.ts
@@ -530,8 +530,12 @@ const attemptNativeCommit = (worktreePath: string, message: string) =>
       }
     }
 
-    // Respect repository hooks and commit-message validation; do not bypass.
+    // Respect repository hooks and commit-message validation; do not bypass
+    // hooks. Disable GPG signing for this harness-owned non-interactive commit
+    // so a global commit.gpgsign=true cannot hang waiting for pinentry.
     const commitResult = yield* runGitInWorktree(worktreePath, [
+      "-c",
+      "commit.gpgsign=false",
       "commit",
       "-m",
       message,


### PR DESCRIPTION
Strict harness `typecheck` previously covered only app sources, so Effect
environment, branded-ID, and GraphQL runtime contract mistakes in tests could
pass CI until runtime.

Expand `apps/harness/tsconfig.app.json` to include unit tests, e2e TypeScript,
and Playwright config under the existing Nx `typecheck` path (with normal
`^build` dependency ordering). Fix harness-local diagnostics: Scope-aware
Effect test helpers, branded `RepositoryId` fixtures, `ActiveAgentBackend` for
GraphQL runtime fixtures, forge service layers in job-worker tests, minimal
fetch DI types for live streams and sidecar readiness, and Effect
language-service cleanups.

Also disable GPG signing only for harness-owned native `git commit`
(`-c commit.gpgsign=false`) so non-interactive agents and local pre-commit do
not hang on pinentry when `commit.gpgsign` is globally enabled; repository
hooks are still run.

Verified with `bunx nx run harness:typecheck`, `bunx nx run harness:test`, and
pre-commit.

Closes #585