### PR TITLE
fix(worktree): avoid shared config lock race

### DIFF
--- a/packages/work-item-lifecycle/src/lib/create-worktree.ts
+++ b/packages/work-item-lifecycle/src/lib/create-worktree.ts
@@ -268,6 +268,7 @@ export const createWorktree = (
     yield* runGit(gitRepository, [
       "worktree",
       "add",
+      "--no-track",
       "-b",
       branchName,
       worktreePath,

--- a/packages/work-item-lifecycle/test/create-worktree.spec.ts
+++ b/packages/work-item-lifecycle/test/create-worktree.spec.ts
@@ -462,6 +462,63 @@ describe("createWorktree", () => {
     }
   })
 
+  it("creates a worktree while another process holds the shared config lock", async () => {
+    const root = await mkdtemp(join(tmpdir(), "rfa-wt-config-lock-"))
+    try {
+      const bare = await initBareRepository(root)
+      await git(bare, [
+        "config",
+        "remote.origin.fetch",
+        "+refs/heads/*:refs/remotes/origin/*",
+      ])
+      await writeFile(join(bare, "config.lock"), "held by another process")
+      const workItemId = makeWorkItemId()
+
+      const path = await run(
+        Effect.gen(function* () {
+          const db = yield* DbService
+          const repository = yield* db.addRepository({
+            forge: "github",
+            forgeHost: "github.com",
+            projectPath: "acme/widgets",
+            localPath: bare,
+            isBare: true,
+          })
+
+          return (yield* createWorktree({
+            workItemId,
+            repositoryId: repository.id,
+            issueNumber: 42,
+            issueTitle: null,
+            agentBackend: "opencode",
+            model: "opencode/test",
+            thinkingLevel: "low",
+            reviewModel: "opencode/test",
+            reviewThinkingLevel: "low",
+            worktreePath: null,
+            startingCommitOid: null,
+            completionSummary: null,
+            publicationTitle: null,
+            publicationBody: null,
+            sessionId: null,
+          })).worktreePath
+        }),
+      )
+
+      expect(await git(path, ["rev-parse", "--abbrev-ref", "HEAD"])).toBe(
+        workItemBranchName({
+          forge: "github",
+          forgeHost: "github.com",
+          projectPath: "acme/widgets",
+          issueNumber: 42,
+          workItemId,
+        }),
+      )
+    } finally {
+      await rm(root, { recursive: true, force: true })
+    }
+  })
+
   it("fails when the planned path exists but is not this Work Item worktree", async () => {
     const root = await mkdtemp(join(tmpdir(), "rfa-wt-conflict-path-"))
     try {


### PR DESCRIPTION
## Why

Concurrent Work Items for one Repository can run `git worktree add` at the same time. When the start point is a remote-tracking branch, Git automatically writes upstream configuration to the shared repository config and fails immediately if another process owns `config.lock`. Git may create the branch before returning exit 255, so blindly retrying the full command is not safe.

## What Changed

- Create Work Item worktrees with `--no-track`, avoiding shared config writes during concurrent worktree creation. The existing `git push -u` establishes tracking when the branch is published.
- Add a regression test that holds the bare Repository's shared config lock while creating a worktree.

## Verification

The regression test reproduced `could not lock config file config` and `unable to write upstream branch configuration` before the fix. With `--no-track`, the worktree and expected branch are created while `config.lock` remains held.

The affected Nx lint, typecheck, and test targets pass, including 518 Work Item lifecycle tests.
