### PR TITLE
feat(harness): add Home and Kanban primary nav switcher

### DIFF
--- a/apps/harness/e2e/features/kanban-route.feature
+++ b/apps/harness/e2e/features/kanban-route.feature
@@ -8,3 +8,22 @@ Feature: View the work pipeline
     And the Pipeline jobs tab is active
     And repository management is not rendered
     And the committed pull request totals are visible above the board
+
+  Scenario: Switch from Home to Kanban via top nav
+    When I open the Home dashboard
+    Then the Home top nav control is active
+    And the Kanban top nav control is not active
+    When I click the Kanban top nav control
+    Then I am on the Kanban board
+    And all six pipeline lane headers are visible
+    And the Kanban top nav control is active
+    And the Home top nav control is not active
+
+  Scenario: Switch from Kanban to Home via top nav
+    When I navigate to the Kanban board
+    Then the Kanban top nav control is active
+    And the Home top nav control is not active
+    When I click the Home top nav control
+    Then I am on the Home dashboard
+    And the Home top nav control is active
+    And the Kanban top nav control is not active

--- a/apps/harness/e2e/steps/kanban-route.ts
+++ b/apps/harness/e2e/steps/kanban-route.ts
@@ -1,4 +1,4 @@
-import { expect } from "@playwright/test"
+import { type Page, expect } from "@playwright/test"
 import { Then, When } from "./fixtures.ts"
 
 const PIPELINE_LANE_HEADERS = [
@@ -17,10 +17,10 @@ const COMMITTED_PULL_REQUEST_PERIODS = [
   "Last week",
 ] as const
 
-When("I navigate to the Kanban board", async ({ page }) => {
-  await page.goto("/kanban")
-  await expect(page).toHaveURL(/\/kanban$/)
+const primaryNav = (page: Page) =>
+  page.getByRole("navigation", { name: "Primary" })
 
+const dismissFirstRunSettings = async (page: Page) => {
   // The isolated E2E database has no default build model, so first-run
   // Settings opens automatically. Dismiss it to exercise the route beneath.
   const settingsDialog = page.getByRole("dialog", {
@@ -29,6 +29,30 @@ When("I navigate to the Kanban board", async ({ page }) => {
   await expect(settingsDialog).toBeVisible()
   await settingsDialog.getByRole("button", { name: "Cancel" }).click()
   await expect(settingsDialog).toBeHidden()
+}
+
+When("I navigate to the Kanban board", async ({ page }) => {
+  await page.goto("/kanban")
+  await expect(page).toHaveURL(/\/kanban$/)
+  await dismissFirstRunSettings(page)
+})
+
+When("I open the Home dashboard", async ({ page }) => {
+  await page.goto("/")
+  await expect(page).toHaveURL(/\/$/)
+  await dismissFirstRunSettings(page)
+})
+
+When("I click the Kanban top nav control", async ({ page }) => {
+  await primaryNav(page)
+    .getByRole("link", { name: "Kanban", exact: true })
+    .click()
+})
+
+When("I click the Home top nav control", async ({ page }) => {
+  await primaryNav(page)
+    .getByRole("link", { name: "Home", exact: true })
+    .click()
 })
 
 Then("all six pipeline lane headers are visible", async ({ page }) => {
@@ -87,3 +111,52 @@ Then(
     )
   },
 )
+
+Then("the Home top nav control is active", async ({ page }) => {
+  const home = primaryNav(page).getByRole("link", { name: "Home", exact: true })
+  await expect(home).toBeVisible()
+  await expect(home).toHaveAttribute("aria-current", "page")
+})
+
+Then("the Kanban top nav control is active", async ({ page }) => {
+  const kanban = primaryNav(page).getByRole("link", {
+    name: "Kanban",
+    exact: true,
+  })
+  await expect(kanban).toBeVisible()
+  await expect(kanban).toHaveAttribute("aria-current", "page")
+})
+
+Then("the Home top nav control is not active", async ({ page }) => {
+  const home = primaryNav(page).getByRole("link", { name: "Home", exact: true })
+  await expect(home).toBeVisible()
+  await expect(home).not.toHaveAttribute("aria-current", "page")
+})
+
+Then("the Kanban top nav control is not active", async ({ page }) => {
+  const kanban = primaryNav(page).getByRole("link", {
+    name: "Kanban",
+    exact: true,
+  })
+  await expect(kanban).toBeVisible()
+  await expect(kanban).not.toHaveAttribute("aria-current", "page")
+})
+
+Then("I am on the Kanban board", async ({ page }) => {
+  await expect(page).toHaveURL(/\/kanban$/)
+  await expect(
+    page.getByRole("region", { name: "Lifecycle pipeline" }),
+  ).toBeVisible()
+})
+
+Then("I am on the Home dashboard", async ({ page }) => {
+  await expect(page).toHaveURL(/\/$/)
+  // Home-only landmark present with zero or more Repositories (stable across
+  // the shared live-e2e database after other features add a checkout).
+  await expect(
+    page.getByRole("region", { name: "Add a repository" }),
+  ).toBeVisible()
+  await expect(
+    page.getByRole("region", { name: "Lifecycle pipeline" }),
+  ).toHaveCount(0)
+})

--- a/apps/harness/src/routes/__root.tsx
+++ b/apps/harness/src/routes/__root.tsx
@@ -169,10 +169,23 @@ function RootDocument({ children }: { children: ReactNode }) {
   )
 }
 
+// Shared layout only — Router merges className with active/inactive props, so
+// mutually exclusive visual utilities must not live on the base class string.
+const primaryNavLinkClassName =
+  "inline-flex items-center border px-3 py-1.5 text-xs font-semibold tracking-[0.14em] uppercase transition focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-oxblood"
+
+const primaryNavLinkInactiveClassName =
+  "border-rule-2 bg-panel text-ink-2 hover:border-ink-soft hover:bg-paper-2"
+
+const primaryNavLinkActiveClassName = "border-ink bg-ink text-paper"
+
 function RootComponent() {
   return (
     <div className="mx-auto min-h-screen w-full max-w-[88rem] px-5 py-6 sm:px-8 lg:px-12">
-      <nav className="mb-2 flex flex-wrap items-start gap-x-5 gap-y-3 border-b-2 border-ink pb-3">
+      <nav
+        aria-label="Primary"
+        className="mb-2 flex flex-wrap items-start gap-x-5 gap-y-3 border-b-2 border-ink pb-3"
+      >
         <div className="grid gap-1">
           <h1 className="m-0 font-serif text-[clamp(1.6rem,3.2vw,2.25rem)] leading-none font-semibold tracking-[-0.012em]">
             <Link
@@ -190,6 +203,25 @@ function RootComponent() {
           >
             {READY_FOR_AGENT_VERSION_LABEL}
           </span>
+        </div>
+        <div className="flex items-center gap-2 self-center">
+          <Link
+            to="/"
+            activeOptions={{ exact: true }}
+            className={primaryNavLinkClassName}
+            inactiveProps={{ className: primaryNavLinkInactiveClassName }}
+            activeProps={{ className: primaryNavLinkActiveClassName }}
+          >
+            Home
+          </Link>
+          <Link
+            to="/kanban"
+            className={primaryNavLinkClassName}
+            inactiveProps={{ className: primaryNavLinkInactiveClassName }}
+            activeProps={{ className: primaryNavLinkActiveClassName }}
+          >
+            Kanban
+          </Link>
         </div>
         <SettingsButton />
       </nav>

--- a/apps/harness/test/primary-nav.test.ts
+++ b/apps/harness/test/primary-nav.test.ts
@@ -1,0 +1,81 @@
+import { readFileSync } from "node:fs"
+import { join } from "node:path"
+import { describe, expect, test } from "bun:test"
+
+const rootSource = () =>
+  readFileSync(join(import.meta.dir, "../src/routes/__root.tsx"), "utf8")
+
+describe("primary Home / Kanban navigation", () => {
+  test("root chrome exposes Home and Kanban Link controls", () => {
+    const source = rootSource()
+    expect(source).toContain('aria-label="Primary"')
+    expect(source).toContain('to="/"')
+    expect(source).toContain('to="/kanban"')
+    expect(source).toMatch(/>\s*Home\s*<\/Link>/)
+    expect(source).toMatch(/>\s*Kanban\s*<\/Link>/)
+  })
+
+  test("uses TanStack Router Link with active route styling", () => {
+    const source = rootSource()
+    expect(source).toContain('from "@tanstack/react-router"')
+    expect(source).toContain("primaryNavLinkClassName")
+    expect(source).toContain("primaryNavLinkInactiveClassName")
+    expect(source).toContain("primaryNavLinkActiveClassName")
+    expect(source).toContain(
+      "inactiveProps={{ className: primaryNavLinkInactiveClassName }}",
+    )
+    expect(source).toContain(
+      "activeProps={{ className: primaryNavLinkActiveClassName }}",
+    )
+    // Home nav control (not the brand title Link) must use exact matching.
+    // Slice from the switcher container through the first destination only.
+    const homeSwitcherLink = source.slice(
+      source.indexOf('<div className="flex items-center gap-2 self-center">'),
+      source.indexOf('to="/kanban"'),
+    )
+    expect(homeSwitcherLink).toContain('to="/"')
+    expect(homeSwitcherLink).toContain("activeOptions={{ exact: true }}")
+    // Shared base must not carry exclusive active/inactive visual tokens —
+    // Router merges className with active/inactive props.
+    const sharedClassDecl = source.match(
+      /const primaryNavLinkClassName =\s*\n?\s*"([^"]+)"/,
+    )
+    expect(sharedClassDecl).not.toBeNull()
+    const sharedClasses = sharedClassDecl?.[1] ?? ""
+    for (const exclusive of [
+      "border-ink",
+      "bg-ink",
+      "text-paper",
+      "border-rule-2",
+      "bg-panel",
+      "text-ink-2",
+      "hover:border-ink-soft",
+      "hover:bg-paper-2",
+    ]) {
+      expect(sharedClasses.split(/\s+/)).not.toContain(exclusive)
+    }
+    expect(source).toContain(
+      'const primaryNavLinkInactiveClassName =\n  "border-rule-2 bg-panel text-ink-2 hover:border-ink-soft hover:bg-paper-2"',
+    )
+    expect(source).toContain(
+      'const primaryNavLinkActiveClassName = "border-ink bg-ink text-paper"',
+    )
+    // Both destinations are client Links, not raw <a href> only.
+    expect(source).not.toMatch(/<a\s+href=["']\/kanban["']/)
+    expect(source).not.toMatch(/<a\s+href=["']\/["']/)
+  })
+
+  test("shared nav lives in root layout so Home and Kanban both inherit it", () => {
+    const source = rootSource()
+    const rootComponent = source.slice(
+      source.indexOf("function RootComponent("),
+    )
+    expect(rootComponent).toContain('to="/kanban"')
+    expect(rootComponent).toMatch(/>\s*Home\s*<\/Link>/)
+    expect(rootComponent).toMatch(/>\s*Kanban\s*<\/Link>/)
+    expect(rootComponent).toContain("<Outlet />")
+    expect(rootComponent.indexOf("Home")).toBeLessThan(
+      rootComponent.indexOf("<Outlet />"),
+    )
+  })
+})


### PR DESCRIPTION
## Why

Operators had to type `/` or `/kanban` (or use the address bar) to move
between the home dashboard and the pipeline board. Switching should be
obvious from shared top chrome on both routes.

## What changed

- Primary nav in root layout (`__root.tsx`) with TanStack Router `Link`s:
  **Home** → `/`, **Kanban** → `/kanban`
- Active/inactive styles split so Router className merge cannot fight
  Tailwind (shared layout on `className`; exclusive tokens on
  `inactiveProps` / `activeProps`); Home uses `activeOptions.exact`
- Unit source tests for nav wiring, exact Home matching, and exclusive
  class tokens
- Playwright BDD: bidirectional switch, mutual `aria-current`
  exclusivity, and a Home landmark that stays valid whether the shared
  e2e DB is empty or has repositories (`Add a repository` region)

## Verification

- `bunx nx test harness -- test/primary-nav.test.ts` (and related chrome
  tests)
- `bunx nx e2e harness -- --grep "Switch from|View the empty"`

Closes #612