### PR TITLE
feat(gitlab): create draft MRs and close issues over the Forge API

### DIFF
--- a/apps/harness/src/routes/index.tsx
+++ b/apps/harness/src/routes/index.tsx
@@ -3110,12 +3110,14 @@ function RepositoryIssueRow({
             issue.url !== ""
               ? issue.url
               : workItemIssueUrl(
+                  repository.forge,
                   repository.forgeHost,
                   repository.projectPath,
                   latestWorkItem.issueNumber,
                 )
           }
           pullRequestUrl={workItemPullRequestUrl(
+            repository.forge,
             repository.forgeHost,
             repository.projectPath,
             latestWorkItem.pullRequestNumber,
@@ -3580,6 +3582,7 @@ function JobsCard() {
                   : repository === undefined
                     ? null
                     : workItemIssueUrl(
+                        repository.forge,
                         repository.forgeHost,
                         repository.projectPath,
                         workItem.issueNumber,
@@ -3690,6 +3693,7 @@ function JobsCard() {
                       repository === undefined
                         ? null
                         : workItemPullRequestUrl(
+                            repository.forge,
                             repository.forgeHost,
                             repository.projectPath,
                             workItem.pullRequestNumber,

--- a/apps/harness/src/routes/kanban.tsx
+++ b/apps/harness/src/routes/kanban.tsx
@@ -141,6 +141,7 @@ function PipelineTicket({
       : repository === undefined
         ? null
         : workItemIssueUrl(
+            repository.forge,
             repository.forgeHost,
             repository.projectPath,
             workItem.issueNumber,
@@ -149,6 +150,7 @@ function PipelineTicket({
     repository === undefined
       ? null
       : workItemPullRequestUrl(
+          repository.forge,
           repository.forgeHost,
           repository.projectPath,
           workItem.pullRequestNumber,

--- a/apps/harness/src/server/ambient-gitlab-layer.ts
+++ b/apps/harness/src/server/ambient-gitlab-layer.ts
@@ -230,6 +230,70 @@ export const ambientGitLabLayer = (options: {
               ),
             ),
         ),
+        getOpenPullRequestNumber: Effect.fn(
+          "AmbientGitLab.getOpenPullRequestNumber",
+        )((repository, headRefName) =>
+          authenticated(repository.forgeHost, (service) =>
+            service.getOpenPullRequestNumber(repository, headRefName),
+          ),
+        ),
+        findOpenPullRequestNumber: Effect.fn(
+          "AmbientGitLab.findOpenPullRequestNumber",
+        )((repository, headRefName) =>
+          authenticated(repository.forgeHost, (service) =>
+            service.findOpenPullRequestNumber(repository, headRefName),
+          ),
+        ),
+        createDraftPullRequest: Effect.fn(
+          "AmbientGitLab.createDraftPullRequest",
+        )((repository, input) =>
+          authenticated(repository.forgeHost, (service) =>
+            service.createDraftPullRequest(repository, input),
+          ),
+        ),
+        updateOpenDraftPullRequestCopy: Effect.fn(
+          "AmbientGitLab.updateOpenDraftPullRequestCopy",
+        )((repository, headRefName, input) =>
+          authenticated(repository.forgeHost, (service) =>
+            service.updateOpenDraftPullRequestCopy(
+              repository,
+              headRefName,
+              input,
+            ),
+          ),
+        ),
+        countOpenNonDraftPullRequests: Effect.fn(
+          "AmbientGitLab.countOpenNonDraftPullRequests",
+        )((repository) =>
+          authenticated(repository.forgeHost, (service) =>
+            service.countOpenNonDraftPullRequests(repository),
+          ),
+        ),
+        ensureIssueCompletedWithSummary: Effect.fn(
+          "AmbientGitLab.ensureIssueCompletedWithSummary",
+        )((repository, issueNumber, workItemId, summaryMarkdown) =>
+          authenticated(repository.forgeHost, (service) =>
+            service.ensureIssueCompletedWithSummary(
+              repository,
+              issueNumber,
+              workItemId,
+              summaryMarkdown,
+            ),
+          ),
+        ),
+        closeOpenPullRequestsForBranch: Effect.fn(
+          "AmbientGitLab.closeOpenPullRequestsForBranch",
+        )((repository, headRefName) =>
+          authenticated(repository.forgeHost, (service) =>
+            service.closeOpenPullRequestsForBranch(repository, headRefName),
+          ),
+        ),
+        deleteBranch: Effect.fn("AmbientGitLab.deleteBranch")(
+          (repository, branchName) =>
+            authenticated(repository.forgeHost, (service) =>
+              service.deleteBranch(repository, branchName),
+            ),
+        ),
       }
     }),
   )

--- a/apps/harness/src/server/application.server.ts
+++ b/apps/harness/src/server/application.server.ts
@@ -233,6 +233,7 @@ export const createApplication = async (
     Layer.provideMerge(activeLayer),
     Layer.provideMerge(keymaxxerLayer),
     Layer.provideMerge(githubLayer),
+    Layer.provideMerge(gitlabLayer),
     Layer.provide(platformLayer),
   )
   const workerLayer = JobWorkerLive.pipe(

--- a/apps/harness/src/server/keymaxxer-gitlab-layer.ts
+++ b/apps/harness/src/server/keymaxxer-gitlab-layer.ts
@@ -243,6 +243,7 @@ export const keymaxxerGitLabLayer = (options: {
         operation: GitLabHelperOperation,
         decode: (stdout: string) => Effect.Effect<A, GitLabServiceError>,
         operationLabel: string,
+        extraArgs: readonly string[] = [],
       ): Effect.Effect<A, GitLabServiceError> =>
         Effect.gen(function* () {
           const [forge, forgeHost, projectPath] =
@@ -251,6 +252,7 @@ export const keymaxxerGitLabLayer = (options: {
             forge,
             forgeHost,
             projectPath,
+            ...extraArgs,
           ])
           if (result.exitCode === 2) {
             return yield* repositoryUnavailable(repository)
@@ -371,6 +373,244 @@ export const keymaxxerGitLabLayer = (options: {
         hasAmbientCredentials: Effect.fn(
           "KeymaxxerGitLab.hasAmbientCredentials",
         )((repository) => ambient.hasAmbientCredentials(repository)),
+        getOpenPullRequestNumber: Effect.fn(
+          "KeymaxxerGitLab.getOpenPullRequestNumber",
+        )((repository, headRefName) =>
+          withVaultOrAmbient(
+            repository,
+            (tokenName) =>
+              runVaultHelper(
+                repository,
+                tokenName,
+                "get-open-pull-request-number",
+                (stdout) => {
+                  const number = Number(stdout.trim())
+                  if (!Number.isSafeInteger(number) || number <= 0) {
+                    return Effect.fail(
+                      requestError(
+                        repository,
+                        "decode open pull request number",
+                        stdout,
+                      ),
+                    )
+                  }
+                  return Effect.succeed(number)
+                },
+                "get open pull request number",
+                [encodeArgument(headRefName)],
+              ),
+            (ambientService) =>
+              ambientService.getOpenPullRequestNumber(repository, headRefName),
+          ),
+        ),
+        findOpenPullRequestNumber: Effect.fn(
+          "KeymaxxerGitLab.findOpenPullRequestNumber",
+        )((repository, headRefName) =>
+          withVaultOrAmbient(
+            repository,
+            (tokenName) =>
+              runVaultHelper(
+                repository,
+                tokenName,
+                "find-open-pull-request-number",
+                (stdout) => {
+                  const trimmed = stdout.trim()
+                  if (trimmed === "") return Effect.succeed(null)
+                  const number = Number(trimmed)
+                  if (!Number.isSafeInteger(number) || number <= 0) {
+                    return Effect.fail(
+                      requestError(
+                        repository,
+                        "decode open pull request number",
+                        stdout,
+                      ),
+                    )
+                  }
+                  return Effect.succeed(number)
+                },
+                "find open pull request number",
+                [encodeArgument(headRefName)],
+              ),
+            (ambientService) =>
+              ambientService.findOpenPullRequestNumber(repository, headRefName),
+          ),
+        ),
+        createDraftPullRequest: Effect.fn(
+          "KeymaxxerGitLab.createDraftPullRequest",
+        )((repository, input) =>
+          withVaultOrAmbient(
+            repository,
+            (tokenName) =>
+              runVaultHelper(
+                repository,
+                tokenName,
+                "create-draft-pull-request",
+                (stdout) => {
+                  const number = Number(stdout.trim())
+                  if (!Number.isSafeInteger(number) || number <= 0) {
+                    return Effect.fail(
+                      requestError(
+                        repository,
+                        "decode created draft pull request number",
+                        stdout,
+                      ),
+                    )
+                  }
+                  return Effect.succeed(number)
+                },
+                "create draft pull request",
+                [
+                  encodeArgument(
+                    JSON.stringify({
+                      headRefName: input.headRefName,
+                      title: input.title,
+                      body: input.body,
+                      ...(input.baseRefName === undefined
+                        ? {}
+                        : { baseRefName: input.baseRefName }),
+                    }),
+                  ),
+                ],
+              ),
+            (ambientService) =>
+              ambientService.createDraftPullRequest(repository, input),
+          ),
+        ),
+        updateOpenDraftPullRequestCopy: Effect.fn(
+          "KeymaxxerGitLab.updateOpenDraftPullRequestCopy",
+        )((repository, headRefName, input) =>
+          withVaultOrAmbient(
+            repository,
+            (tokenName) =>
+              runVaultHelper(
+                repository,
+                tokenName,
+                "update-open-draft-pull-request-copy",
+                (stdout) => {
+                  const trimmed = stdout.trim()
+                  if (trimmed === "") return Effect.succeed(null)
+                  const number = Number(trimmed)
+                  if (!Number.isSafeInteger(number) || number <= 0) {
+                    return Effect.fail(
+                      requestError(
+                        repository,
+                        "decode updated draft pull request number",
+                        stdout,
+                      ),
+                    )
+                  }
+                  return Effect.succeed(number)
+                },
+                "update open draft pull request copy",
+                [
+                  encodeArgument(headRefName),
+                  encodeArgument(
+                    JSON.stringify({ title: input.title, body: input.body }),
+                  ),
+                ],
+              ),
+            (ambientService) =>
+              ambientService.updateOpenDraftPullRequestCopy(
+                repository,
+                headRefName,
+                input,
+              ),
+          ),
+        ),
+        countOpenNonDraftPullRequests: Effect.fn(
+          "KeymaxxerGitLab.countOpenNonDraftPullRequests",
+        )((repository) =>
+          withVaultOrAmbient(
+            repository,
+            (tokenName) =>
+              runVaultHelper(
+                repository,
+                tokenName,
+                "count-open-non-draft-pull-requests",
+                (stdout) => {
+                  const count = Number(stdout.trim())
+                  if (!Number.isSafeInteger(count) || count < 0) {
+                    return Effect.fail(
+                      requestError(
+                        repository,
+                        "decode open non-draft pull request count",
+                        stdout,
+                      ),
+                    )
+                  }
+                  return Effect.succeed(count)
+                },
+                "count open non-draft pull requests",
+              ),
+            (ambientService) =>
+              ambientService.countOpenNonDraftPullRequests(repository),
+          ),
+        ),
+        ensureIssueCompletedWithSummary: Effect.fn(
+          "KeymaxxerGitLab.ensureIssueCompletedWithSummary",
+        )((repository, issueNumber, workItemId, summaryMarkdown) =>
+          withVaultOrAmbient(
+            repository,
+            (tokenName) =>
+              runVaultHelper(
+                repository,
+                tokenName,
+                "ensure-issue-completed-with-summary",
+                () => Effect.void,
+                "ensure issue completed with summary",
+                [
+                  encodeArgument(String(issueNumber)),
+                  encodeArgument(workItemId),
+                  encodeArgument(summaryMarkdown),
+                ],
+              ),
+            (ambientService) =>
+              ambientService.ensureIssueCompletedWithSummary(
+                repository,
+                issueNumber,
+                workItemId,
+                summaryMarkdown,
+              ),
+          ),
+        ),
+        closeOpenPullRequestsForBranch: Effect.fn(
+          "KeymaxxerGitLab.closeOpenPullRequestsForBranch",
+        )((repository, headRefName) =>
+          withVaultOrAmbient(
+            repository,
+            (tokenName) =>
+              runVaultHelper(
+                repository,
+                tokenName,
+                "close-open-pull-requests-for-branch",
+                () => Effect.void,
+                "close open pull requests for branch",
+                [encodeArgument(headRefName)],
+              ),
+            (ambientService) =>
+              ambientService.closeOpenPullRequestsForBranch(
+                repository,
+                headRefName,
+              ),
+          ),
+        ),
+        deleteBranch: Effect.fn("KeymaxxerGitLab.deleteBranch")(
+          (repository, branchName) =>
+            withVaultOrAmbient(
+              repository,
+              (tokenName) =>
+                runVaultHelper(
+                  repository,
+                  tokenName,
+                  "delete-branch",
+                  () => Effect.void,
+                  "delete branch",
+                  [encodeArgument(branchName)],
+                ),
+              (ambientService) =>
+                ambientService.deleteBranch(repository, branchName),
+            ),
+        ),
       }
       return service
     }),

--- a/apps/harness/src/work-item-issue-url.ts
+++ b/apps/harness/src/work-item-issue-url.ts
@@ -1,5 +1,9 @@
 export const workItemIssueUrl = (
+  forge: string,
   forgeHost: string,
   projectPath: string,
   issueNumber: number,
-): string => `https://${forgeHost}/${projectPath}/issues/${issueNumber}`
+): string =>
+  forge === "gitlab"
+    ? `https://${forgeHost}/${projectPath}/-/issues/${issueNumber}`
+    : `https://${forgeHost}/${projectPath}/issues/${issueNumber}`

--- a/apps/harness/src/work-item-pull-request-url.ts
+++ b/apps/harness/src/work-item-pull-request-url.ts
@@ -1,8 +1,11 @@
 export const workItemPullRequestUrl = (
+  forge: string,
   forgeHost: string,
   projectPath: string,
   pullRequestNumber: number | null,
 ): string | null => {
   if (pullRequestNumber === null) return null
-  return `https://${forgeHost}/${projectPath}/pull/${pullRequestNumber}`
+  return forge === "gitlab"
+    ? `https://${forgeHost}/${projectPath}/-/merge_requests/${pullRequestNumber}`
+    : `https://${forgeHost}/${projectPath}/pull/${pullRequestNumber}`
 }

--- a/apps/harness/test/ambient-gitlab-layer.test.ts
+++ b/apps/harness/test/ambient-gitlab-layer.test.ts
@@ -28,6 +28,14 @@ const service = (
   listReadyIssues: () => Effect.succeed([]),
   hasCredentials: () => Effect.succeed(true),
   hasAmbientCredentials: () => Effect.succeed(true),
+  getOpenPullRequestNumber: () => Effect.succeed(1),
+  findOpenPullRequestNumber: () => Effect.succeed(null),
+  createDraftPullRequest: () => Effect.succeed(1),
+  updateOpenDraftPullRequestCopy: () => Effect.succeed(null),
+  countOpenNonDraftPullRequests: () => Effect.succeed(0),
+  ensureIssueCompletedWithSummary: () => Effect.void,
+  closeOpenPullRequestsForBranch: () => Effect.void,
+  deleteBranch: () => Effect.void,
   ...overrides,
 })
 

--- a/apps/harness/test/job-worker.test.ts
+++ b/apps/harness/test/job-worker.test.ts
@@ -155,6 +155,14 @@ const defaultGitlabLayer = Layer.succeed(GitLabService, {
   listReadyIssues: () => Effect.succeed([]),
   hasCredentials: () => Effect.succeed(true),
   hasAmbientCredentials: () => Effect.succeed(true),
+  getOpenPullRequestNumber: () => Effect.succeed(1),
+  findOpenPullRequestNumber: () => Effect.succeed(null),
+  createDraftPullRequest: () => Effect.succeed(1),
+  updateOpenDraftPullRequestCopy: () => Effect.succeed(null),
+  countOpenNonDraftPullRequests: () => Effect.succeed(0),
+  ensureIssueCompletedWithSummary: () => Effect.void,
+  closeOpenPullRequestsForBranch: () => Effect.void,
+  deleteBranch: () => Effect.void,
 } satisfies GitLabServiceShape)
 
 const defaultGithubLayer = Layer.merge(

--- a/apps/harness/test/keymaxxer-gitlab-layer.test.ts
+++ b/apps/harness/test/keymaxxer-gitlab-layer.test.ts
@@ -19,6 +19,17 @@ const platformLayer = BunChildProcessSpawner.layer.pipe(
   Layer.provideMerge(Layer.merge(BunFileSystem.layer, BunPath.layer)),
 )
 
+const gitlabLifecycleStub = {
+  getOpenPullRequestNumber: () => Effect.succeed(1),
+  findOpenPullRequestNumber: () => Effect.succeed(null),
+  createDraftPullRequest: () => Effect.succeed(1),
+  updateOpenDraftPullRequestCopy: () => Effect.succeed(null),
+  countOpenNonDraftPullRequests: () => Effect.succeed(0),
+  ensureIssueCompletedWithSummary: () => Effect.void,
+  closeOpenPullRequestsForBranch: () => Effect.void,
+  deleteBranch: () => Effect.void,
+} as const
+
 const repository = {
   forge: "gitlab",
   forgeHost: "git.drupalcode.org",
@@ -327,6 +338,7 @@ describe("Keymaxxer-backed GitLab layer", () => {
             ambientChecked = true
             return false
           }),
+        ...gitlabLifecycleStub,
       }),
       makeAnonymousService: () => ({
         verifyProject: () => Effect.void,
@@ -334,6 +346,7 @@ describe("Keymaxxer-backed GitLab layer", () => {
         listReadyIssues: () => Effect.succeed([]),
         hasCredentials: () => Effect.succeed(false),
         hasAmbientCredentials: () => Effect.succeed(false),
+        ...gitlabLifecycleStub,
       }),
     }).pipe(Layer.provide(keymaxxerLayer), Layer.provide(platformLayer))
 
@@ -375,6 +388,7 @@ describe("Keymaxxer-backed GitLab layer", () => {
         },
         hasCredentials: () => Effect.succeed(true),
         hasAmbientCredentials: () => Effect.succeed(true),
+        ...gitlabLifecycleStub,
       }),
     }).pipe(Layer.provide(keymaxxerLayer), Layer.provide(platformLayer))
 
@@ -417,6 +431,7 @@ describe("Keymaxxer-backed GitLab layer", () => {
         },
         hasCredentials: () => Effect.succeed(true),
         hasAmbientCredentials: () => Effect.succeed(true),
+        ...gitlabLifecycleStub,
       }),
     }).pipe(Layer.provide(keymaxxerLayer), Layer.provide(platformLayer))
 

--- a/apps/harness/test/production-sse-idle-timeout.test.ts
+++ b/apps/harness/test/production-sse-idle-timeout.test.ts
@@ -108,6 +108,14 @@ const defaultGitlab: GitLabServiceShape = {
   listReadyIssues: () => Effect.succeed([]),
   hasCredentials: () => Effect.succeed(true),
   hasAmbientCredentials: () => Effect.succeed(true),
+  getOpenPullRequestNumber: () => Effect.succeed(1),
+  findOpenPullRequestNumber: () => Effect.succeed(null),
+  createDraftPullRequest: () => Effect.succeed(1),
+  updateOpenDraftPullRequestCopy: () => Effect.succeed(null),
+  countOpenNonDraftPullRequests: () => Effect.succeed(0),
+  ensureIssueCompletedWithSummary: () => Effect.void,
+  closeOpenPullRequestsForBranch: () => Effect.void,
+  deleteBranch: () => Effect.void,
 }
 
 const freePort = async (): Promise<number> => {

--- a/apps/harness/test/work-item-issue-url.test.ts
+++ b/apps/harness/test/work-item-issue-url.test.ts
@@ -3,8 +3,19 @@ import { describe, expect, test } from "bun:test"
 
 describe("workItemIssueUrl", () => {
   test("builds GitHub Issue URL from repository identity and issue number", () => {
-    expect(workItemIssueUrl("github.com", "acme/widgets", 42)).toBe(
+    expect(workItemIssueUrl("github", "github.com", "acme/widgets", 42)).toBe(
       "https://github.com/acme/widgets/issues/42",
     )
+  })
+
+  test("builds GitLab Issue URL with the /-/issues/ path segment", () => {
+    expect(
+      workItemIssueUrl(
+        "gitlab",
+        "git.drupalcode.org",
+        "project/oauth_client",
+        3601642,
+      ),
+    ).toBe("https://git.drupalcode.org/project/oauth_client/-/issues/3601642")
   })
 })

--- a/apps/harness/test/work-item-pull-request-url.test.ts
+++ b/apps/harness/test/work-item-pull-request-url.test.ts
@@ -3,14 +3,27 @@ import { describe, expect, test } from "bun:test"
 
 describe("workItemPullRequestUrl", () => {
   test("builds GitHub PR URL from repository identity and Work Item PR number", () => {
-    expect(workItemPullRequestUrl("github.com", "acme/widgets", 42)).toBe(
-      "https://github.com/acme/widgets/pull/42",
+    expect(
+      workItemPullRequestUrl("github", "github.com", "acme/widgets", 42),
+    ).toBe("https://github.com/acme/widgets/pull/42")
+  })
+
+  test("builds GitLab MR URL with the /-/merge_requests/ path segment", () => {
+    expect(
+      workItemPullRequestUrl(
+        "gitlab",
+        "git.drupalcode.org",
+        "project/oauth_client",
+        91,
+      ),
+    ).toBe(
+      "https://git.drupalcode.org/project/oauth_client/-/merge_requests/91",
     )
   })
 
   test("returns null when no Work Item PR is recorded", () => {
     expect(
-      workItemPullRequestUrl("github.com", "acme/widgets", null),
+      workItemPullRequestUrl("github", "github.com", "acme/widgets", null),
     ).toBeNull()
   })
 })

--- a/packages/gitlab-service/src/bin/close-open-pull-requests-for-branch.ts
+++ b/packages/gitlab-service/src/bin/close-open-pull-requests-for-branch.ts
@@ -1,0 +1,26 @@
+import { Effect } from "effect"
+import { GitLabService } from "../lib/gitlab-service.js"
+import {
+  decodeArgument,
+  gitlabRepository,
+  runGitLabCli,
+  writeStandardOutput,
+} from "./cli.js"
+
+export const closeOpenPullRequestsForBranchProgram = (
+  args: ReadonlyArray<string>,
+) =>
+  Effect.gen(function* () {
+    const repository = gitlabRepository(
+      yield* decodeArgument(args[0], "forge"),
+      yield* decodeArgument(args[1], "forge host"),
+      yield* decodeArgument(args[2], "project path"),
+    )
+    const headRefName = yield* decodeArgument(args[3], "head ref name")
+    const gitlab = yield* GitLabService
+    yield* gitlab.closeOpenPullRequestsForBranch(repository, headRefName)
+    yield* writeStandardOutput("ok")
+  })
+
+if (import.meta.main)
+  runGitLabCli(closeOpenPullRequestsForBranchProgram(process.argv.slice(2)))

--- a/packages/gitlab-service/src/bin/count-open-non-draft-pull-requests.ts
+++ b/packages/gitlab-service/src/bin/count-open-non-draft-pull-requests.ts
@@ -1,0 +1,25 @@
+import { Effect } from "effect"
+import { GitLabService } from "../lib/gitlab-service.js"
+import {
+  decodeArgument,
+  gitlabRepository,
+  runGitLabCli,
+  writeStandardOutput,
+} from "./cli.js"
+
+export const countOpenNonDraftPullRequestsProgram = (
+  args: ReadonlyArray<string>,
+) =>
+  Effect.gen(function* () {
+    const repository = gitlabRepository(
+      yield* decodeArgument(args[0], "forge"),
+      yield* decodeArgument(args[1], "forge host"),
+      yield* decodeArgument(args[2], "project path"),
+    )
+    const gitlab = yield* GitLabService
+    const count = yield* gitlab.countOpenNonDraftPullRequests(repository)
+    yield* writeStandardOutput(String(count))
+  })
+
+if (import.meta.main)
+  runGitLabCli(countOpenNonDraftPullRequestsProgram(process.argv.slice(2)))

--- a/packages/gitlab-service/src/bin/create-draft-pull-request.ts
+++ b/packages/gitlab-service/src/bin/create-draft-pull-request.ts
@@ -1,0 +1,49 @@
+import { Effect, Schema } from "effect"
+import { GitLabService } from "../lib/gitlab-service.js"
+import {
+  CliArgumentError,
+  decodeArgument,
+  gitlabRepository,
+  runGitLabCli,
+  writeStandardOutput,
+} from "./cli.js"
+
+const CreateDraftPullRequestPayload = Schema.Struct({
+  headRefName: Schema.String,
+  title: Schema.String,
+  body: Schema.String,
+  baseRefName: Schema.optional(Schema.String),
+})
+
+export const createDraftPullRequestProgram = (args: ReadonlyArray<string>) =>
+  Effect.gen(function* () {
+    const repository = gitlabRepository(
+      yield* decodeArgument(args[0], "forge"),
+      yield* decodeArgument(args[1], "forge host"),
+      yield* decodeArgument(args[2], "project path"),
+    )
+    const payloadJson = yield* decodeArgument(args[3], "create draft payload")
+    const payload = yield* Schema.decodeUnknownEffect(
+      Schema.fromJsonString(CreateDraftPullRequestPayload),
+    )(payloadJson).pipe(
+      Effect.mapError(
+        () =>
+          new CliArgumentError({
+            message: `Invalid create draft pull request payload: ${payloadJson}`,
+          }),
+      ),
+    )
+    const gitlab = yield* GitLabService
+    const number = yield* gitlab.createDraftPullRequest(repository, {
+      headRefName: payload.headRefName,
+      title: payload.title,
+      body: payload.body,
+      ...(payload.baseRefName === undefined
+        ? {}
+        : { baseRefName: payload.baseRefName }),
+    })
+    yield* writeStandardOutput(String(number))
+  })
+
+if (import.meta.main)
+  runGitLabCli(createDraftPullRequestProgram(process.argv.slice(2)))

--- a/packages/gitlab-service/src/bin/delete-branch.ts
+++ b/packages/gitlab-service/src/bin/delete-branch.ts
@@ -1,0 +1,23 @@
+import { Effect } from "effect"
+import { GitLabService } from "../lib/gitlab-service.js"
+import {
+  decodeArgument,
+  gitlabRepository,
+  runGitLabCli,
+  writeStandardOutput,
+} from "./cli.js"
+
+export const deleteBranchProgram = (args: ReadonlyArray<string>) =>
+  Effect.gen(function* () {
+    const repository = gitlabRepository(
+      yield* decodeArgument(args[0], "forge"),
+      yield* decodeArgument(args[1], "forge host"),
+      yield* decodeArgument(args[2], "project path"),
+    )
+    const branchName = yield* decodeArgument(args[3], "branch name")
+    const gitlab = yield* GitLabService
+    yield* gitlab.deleteBranch(repository, branchName)
+    yield* writeStandardOutput("ok")
+  })
+
+if (import.meta.main) runGitLabCli(deleteBranchProgram(process.argv.slice(2)))

--- a/packages/gitlab-service/src/bin/ensure-issue-completed-with-summary.ts
+++ b/packages/gitlab-service/src/bin/ensure-issue-completed-with-summary.ts
@@ -1,0 +1,34 @@
+import { Effect } from "effect"
+import { GitLabService } from "../lib/gitlab-service.js"
+import {
+  decodeArgument,
+  gitlabRepository,
+  runGitLabCli,
+  writeStandardOutput,
+} from "./cli.js"
+
+export const ensureIssueCompletedWithSummaryProgram = (
+  args: ReadonlyArray<string>,
+) =>
+  Effect.gen(function* () {
+    const repository = gitlabRepository(
+      yield* decodeArgument(args[0], "forge"),
+      yield* decodeArgument(args[1], "forge host"),
+      yield* decodeArgument(args[2], "project path"),
+    )
+    const issueNumberRaw = yield* decodeArgument(args[3], "issue number")
+    const workItemId = yield* decodeArgument(args[4], "work item id")
+    const summaryMarkdown = yield* decodeArgument(args[5], "summary markdown")
+    const issueNumber = Number(issueNumberRaw)
+    const gitlab = yield* GitLabService
+    yield* gitlab.ensureIssueCompletedWithSummary(
+      repository,
+      issueNumber,
+      workItemId,
+      summaryMarkdown,
+    )
+    yield* writeStandardOutput("ok")
+  })
+
+if (import.meta.main)
+  runGitLabCli(ensureIssueCompletedWithSummaryProgram(process.argv.slice(2)))

--- a/packages/gitlab-service/src/bin/find-open-pull-request-number.ts
+++ b/packages/gitlab-service/src/bin/find-open-pull-request-number.ts
@@ -1,0 +1,27 @@
+import { Effect } from "effect"
+import { GitLabService } from "../lib/gitlab-service.js"
+import {
+  decodeArgument,
+  gitlabRepository,
+  runGitLabCli,
+  writeStandardOutput,
+} from "./cli.js"
+
+export const findOpenPullRequestNumberProgram = (args: ReadonlyArray<string>) =>
+  Effect.gen(function* () {
+    const repository = gitlabRepository(
+      yield* decodeArgument(args[0], "forge"),
+      yield* decodeArgument(args[1], "forge host"),
+      yield* decodeArgument(args[2], "project path"),
+    )
+    const headRefName = yield* decodeArgument(args[3], "head ref name")
+    const gitlab = yield* GitLabService
+    const number = yield* gitlab.findOpenPullRequestNumber(
+      repository,
+      headRefName,
+    )
+    yield* writeStandardOutput(number === null ? "" : String(number))
+  })
+
+if (import.meta.main)
+  runGitLabCli(findOpenPullRequestNumberProgram(process.argv.slice(2)))

--- a/packages/gitlab-service/src/bin/get-open-pull-request-number.ts
+++ b/packages/gitlab-service/src/bin/get-open-pull-request-number.ts
@@ -1,0 +1,27 @@
+import { Effect } from "effect"
+import { GitLabService } from "../lib/gitlab-service.js"
+import {
+  decodeArgument,
+  gitlabRepository,
+  runGitLabCli,
+  writeStandardOutput,
+} from "./cli.js"
+
+export const getOpenPullRequestNumberProgram = (args: ReadonlyArray<string>) =>
+  Effect.gen(function* () {
+    const repository = gitlabRepository(
+      yield* decodeArgument(args[0], "forge"),
+      yield* decodeArgument(args[1], "forge host"),
+      yield* decodeArgument(args[2], "project path"),
+    )
+    const headRefName = yield* decodeArgument(args[3], "head ref name")
+    const gitlab = yield* GitLabService
+    const number = yield* gitlab.getOpenPullRequestNumber(
+      repository,
+      headRefName,
+    )
+    yield* writeStandardOutput(String(number))
+  })
+
+if (import.meta.main)
+  runGitLabCli(getOpenPullRequestNumberProgram(process.argv.slice(2)))

--- a/packages/gitlab-service/src/bin/update-open-draft-pull-request-copy.ts
+++ b/packages/gitlab-service/src/bin/update-open-draft-pull-request-copy.ts
@@ -1,0 +1,47 @@
+import { Effect, Schema } from "effect"
+import { GitLabService } from "../lib/gitlab-service.js"
+import {
+  CliArgumentError,
+  decodeArgument,
+  gitlabRepository,
+  runGitLabCli,
+  writeStandardOutput,
+} from "./cli.js"
+
+const UpdateCopyPayload = Schema.Struct({
+  title: Schema.String,
+  body: Schema.String,
+})
+
+export const updateOpenDraftPullRequestCopyProgram = (
+  args: ReadonlyArray<string>,
+) =>
+  Effect.gen(function* () {
+    const repository = gitlabRepository(
+      yield* decodeArgument(args[0], "forge"),
+      yield* decodeArgument(args[1], "forge host"),
+      yield* decodeArgument(args[2], "project path"),
+    )
+    const headRefName = yield* decodeArgument(args[3], "head ref name")
+    const payloadJson = yield* decodeArgument(args[4], "update copy payload")
+    const payload = yield* Schema.decodeUnknownEffect(
+      Schema.fromJsonString(UpdateCopyPayload),
+    )(payloadJson).pipe(
+      Effect.mapError(
+        () =>
+          new CliArgumentError({
+            message: `Invalid update draft pull request payload: ${payloadJson}`,
+          }),
+      ),
+    )
+    const gitlab = yield* GitLabService
+    const number = yield* gitlab.updateOpenDraftPullRequestCopy(
+      repository,
+      headRefName,
+      { title: payload.title, body: payload.body },
+    )
+    yield* writeStandardOutput(number === null ? "" : String(number))
+  })
+
+if (import.meta.main)
+  runGitLabCli(updateOpenDraftPullRequestCopyProgram(process.argv.slice(2)))

--- a/packages/gitlab-service/src/lib/gitlab-helper-process.ts
+++ b/packages/gitlab-service/src/lib/gitlab-helper-process.ts
@@ -1,7 +1,15 @@
 import type { Effect } from "effect"
 import { runGitLabCli } from "../bin/cli.js"
+import { closeOpenPullRequestsForBranchProgram } from "../bin/close-open-pull-requests-for-branch.js"
+import { countOpenNonDraftPullRequestsProgram } from "../bin/count-open-non-draft-pull-requests.js"
+import { createDraftPullRequestProgram } from "../bin/create-draft-pull-request.js"
+import { deleteBranchProgram } from "../bin/delete-branch.js"
+import { ensureIssueCompletedWithSummaryProgram } from "../bin/ensure-issue-completed-with-summary.js"
+import { findOpenPullRequestNumberProgram } from "../bin/find-open-pull-request-number.js"
 import { getAuthenticatedUserLoginProgram } from "../bin/get-authenticated-user-login.js"
+import { getOpenPullRequestNumberProgram } from "../bin/get-open-pull-request-number.js"
 import { listReadyIssuesProgram } from "../bin/list-ready-issues.js"
+import { updateOpenDraftPullRequestCopyProgram } from "../bin/update-open-draft-pull-request-copy.js"
 import { verifyProjectProgram } from "../bin/verify-project.js"
 import { gitlabServiceBinScriptPath } from "../bin-script-path.js"
 import type { GitLabService } from "./gitlab-service.js"
@@ -14,6 +22,14 @@ export const GITLAB_HELPER_OPERATIONS = [
   "list-ready-issues",
   "get-authenticated-user-login",
   "verify-project",
+  "get-open-pull-request-number",
+  "find-open-pull-request-number",
+  "create-draft-pull-request",
+  "update-open-draft-pull-request-copy",
+  "count-open-non-draft-pull-requests",
+  "ensure-issue-completed-with-summary",
+  "close-open-pull-requests-for-branch",
+  "delete-branch",
 ] as const
 
 export type GitLabHelperOperation = (typeof GITLAB_HELPER_OPERATIONS)[number]
@@ -109,6 +125,14 @@ const programs: Record<
   "list-ready-issues": listReadyIssuesProgram,
   "get-authenticated-user-login": getAuthenticatedUserLoginProgram,
   "verify-project": verifyProjectProgram,
+  "get-open-pull-request-number": getOpenPullRequestNumberProgram,
+  "find-open-pull-request-number": findOpenPullRequestNumberProgram,
+  "create-draft-pull-request": createDraftPullRequestProgram,
+  "update-open-draft-pull-request-copy": updateOpenDraftPullRequestCopyProgram,
+  "count-open-non-draft-pull-requests": countOpenNonDraftPullRequestsProgram,
+  "ensure-issue-completed-with-summary": ensureIssueCompletedWithSummaryProgram,
+  "close-open-pull-requests-for-branch": closeOpenPullRequestsForBranchProgram,
+  "delete-branch": deleteBranchProgram,
 }
 
 /**

--- a/packages/gitlab-service/src/lib/gitlab-service-live.ts
+++ b/packages/gitlab-service/src/lib/gitlab-service-live.ts
@@ -1,6 +1,10 @@
 import { Config, Duration, Effect, Layer, Redacted, Schema } from "effect"
 import { GitLabProjectUnavailableError, GitLabRequestError } from "./errors.js"
-import { GitLabService, type GitLabServiceShape } from "./gitlab-service.js"
+import {
+  GitLabService,
+  type GitLabServiceError,
+  type GitLabServiceShape,
+} from "./gitlab-service.js"
 import type { GitLabReadyLabeledIssue, GitLabRepository } from "./types.js"
 
 const REQUEST_TIMEOUT = Duration.seconds(30)
@@ -28,6 +32,7 @@ const RequiredString = Schema.String.pipe(
 )
 const ProjectSchema = Schema.Struct({
   path_with_namespace: RequiredString,
+  default_branch: Schema.optional(Schema.NullOr(Schema.String)),
 })
 const UserSchema = Schema.Struct({
   username: RequiredString,
@@ -45,15 +50,61 @@ const IssueSchema = Schema.Struct({
     }),
   ),
 })
+const IssueStateSchema = Schema.Struct({
+  iid: PositiveInt,
+  state: Schema.Literals(["opened", "closed"]),
+})
+const NoteSchema = Schema.Struct({
+  body: Schema.NullOr(Schema.String),
+})
 const MergeRequestSchema = Schema.Struct({
   iid: PositiveInt,
   state: Schema.Literals(["opened", "merged", "closed"]),
   draft: Schema.Boolean,
   description: Schema.NullOr(Schema.String),
 })
+const OpenMergeRequestSchema = Schema.Struct({
+  iid: PositiveInt,
+  draft: Schema.Boolean,
+  title: Schema.optional(Schema.NullOr(Schema.String)),
+  description: Schema.optional(Schema.NullOr(Schema.String)),
+})
+const CreatedMergeRequestSchema = Schema.Struct({
+  iid: PositiveInt,
+  draft: Schema.optional(Schema.Boolean),
+  title: Schema.optional(Schema.NullOr(Schema.String)),
+})
 
 type GitLabIssue = typeof IssueSchema.Type
 type GitLabMergeRequest = typeof MergeRequestSchema.Type
+type OpenMergeRequest = typeof OpenMergeRequestSchema.Type
+
+/** Hidden HTML comment marker tying a completion summary to a Work Item. */
+const workItemCompletionMarker = (workItemId: string): string =>
+  `<!-- ready-for-agent:work-item:${workItemId} -->`
+
+/**
+ * GitLab draft status is title-driven on many instances (Draft:/WIP: prefixes).
+ * The REST `draft` boolean is not universally accepted on create, so Create PR
+ * and draft-copy reconcile always preserve a draft title form for open drafts.
+ */
+const DRAFT_TITLE_PREFIX = /^\s*(?:Draft|WIP)\s*:\s*/i
+
+const hasDraftTitlePrefix = (title: string): boolean =>
+  DRAFT_TITLE_PREFIX.test(title)
+
+const withDraftTitlePrefix = (title: string): string => {
+  const trimmed = title.trim()
+  if (trimmed === "") return "Draft:"
+  if (hasDraftTitlePrefix(trimmed)) return trimmed
+  return `Draft: ${trimmed}`
+}
+
+const isDraftMergeRequest = (mergeRequest: {
+  readonly draft?: boolean
+  readonly title?: string | null
+}): boolean =>
+  mergeRequest.draft === true || hasDraftTitlePrefix(mergeRequest.title ?? "")
 
 const apiBase = (repository: GitLabRepository): string =>
   `https://${repository.forgeHost}/api/v4`
@@ -141,6 +192,12 @@ const mapIssue = (
   }
 }
 
+type RequestInitOptions = {
+  readonly method?: string
+  readonly body?: unknown
+  readonly acceptEmpty?: boolean
+}
+
 export const makeGitLabService = (options: {
   readonly token?: string
   readonly fetch?: GitLabFetch
@@ -158,17 +215,35 @@ export const makeGitLabService = (options: {
     repository: GitLabRepository,
     path: string,
     message: string,
+    init: RequestInitOptions = {},
   ): Effect.Effect<unknown, GitLabRequestError> =>
     Effect.tryPromise({
       try: async () => {
+        const method = init.method ?? "GET"
         const response = await fetchImpl(`${apiBase(repository)}${path}`, {
-          headers,
+          method,
+          headers: {
+            ...headers,
+            ...(init.body === undefined
+              ? {}
+              : { "Content-Type": "application/json" }),
+          },
+          body: init.body === undefined ? undefined : JSON.stringify(init.body),
         })
         if (!response.ok) {
           throw new GitLabHttpError(
             response.status,
             `${message}: GitLab returned HTTP ${response.status}`,
           )
+        }
+        if (init.acceptEmpty === true || response.status === 204) {
+          const text = await response.text()
+          if (text.trim() === "") return null
+          try {
+            return JSON.parse(text) as unknown
+          } catch {
+            return null
+          }
         }
         return await response.json()
       },
@@ -239,6 +314,42 @@ export const makeGitLabService = (options: {
           error.statusCode === 404
             ? Effect.fail(new GitLabProjectUnavailableError(repository))
             : Effect.fail(error),
+      ),
+    )
+
+  const listOpenMergeRequestsForBranch = (
+    repository: GitLabRepository,
+    headRefName: string,
+  ): Effect.Effect<readonly OpenMergeRequest[], GitLabRequestError> =>
+    requestPages(
+      repository,
+      `${projectApiPath(repository)}/merge_requests?state=opened&source_branch=${encodeURIComponent(headRefName)}`,
+      `Failed to list open merge requests for ${repository.projectPath}:${headRefName}`,
+    ).pipe(
+      Effect.map((values) =>
+        decode(Schema.Array(OpenMergeRequestSchema), values),
+      ),
+      Effect.mapError((error) =>
+        error instanceof GitLabRequestError
+          ? error
+          : requestError(
+              `GitLab returned invalid open merge request data for ${repository.projectPath}:${headRefName}`,
+              error,
+            ),
+      ),
+    )
+
+  const findOpenMergeRequestNumberImpl = (
+    repository: GitLabRepository,
+    headRefName: string,
+  ): Effect.Effect<number | null, GitLabServiceError> =>
+    unavailableOn404(
+      repository,
+      listOpenMergeRequestsForBranch(repository, headRefName).pipe(
+        Effect.map((mergeRequests) => {
+          const first = mergeRequests[0]
+          return first === undefined ? null : first.iid
+        }),
       ),
     )
 
@@ -323,6 +434,338 @@ export const makeGitLabService = (options: {
     ),
     hasCredentials: () => Effect.succeed(options.token !== undefined),
     hasAmbientCredentials: () => Effect.succeed(options.token !== undefined),
+    getOpenPullRequestNumber: Effect.fn(
+      "GitLabService.getOpenPullRequestNumber",
+    )(function* (repository, headRefName) {
+      const number = yield* findOpenMergeRequestNumberImpl(
+        repository,
+        headRefName,
+      )
+      if (number === null) {
+        return yield* new GitLabRequestError({
+          message: `No open merge request found for ${repository.projectPath}:${headRefName}`,
+        })
+      }
+      return number
+    }),
+    findOpenPullRequestNumber: Effect.fn(
+      "GitLabService.findOpenPullRequestNumber",
+    )((repository, headRefName) =>
+      findOpenMergeRequestNumberImpl(repository, headRefName),
+    ),
+    createDraftPullRequest: Effect.fn("GitLabService.createDraftPullRequest")(
+      function* (repository, input) {
+        const project = projectApiPath(repository)
+        const projectMeta = yield* unavailableOn404(
+          repository,
+          requestUnknown(
+            repository,
+            project,
+            `Failed to resolve GitLab project metadata for ${repository.projectPath}`,
+          ).pipe(
+            Effect.map((value) => decode(ProjectSchema, value)),
+            Effect.mapError((error) =>
+              error instanceof GitLabRequestError
+                ? error
+                : requestError(
+                    `GitLab returned invalid project metadata for ${repository.projectPath}`,
+                    error,
+                  ),
+            ),
+          ),
+        )
+        const defaultBase = projectMeta.default_branch?.trim() ?? ""
+        const baseRefName =
+          input.baseRefName !== undefined && input.baseRefName.trim() !== ""
+            ? input.baseRefName.trim()
+            : defaultBase
+        if (baseRefName === "") {
+          return yield* new GitLabRequestError({
+            message: `Repository ${repository.projectPath} has no default base branch`,
+          })
+        }
+        const draftTitle = withDraftTitlePrefix(input.title)
+        const created = yield* unavailableOn404(
+          repository,
+          requestUnknown(
+            repository,
+            `${project}/merge_requests`,
+            `Failed to create draft merge request for ${repository.projectPath}:${input.headRefName}`,
+            {
+              method: "POST",
+              body: {
+                source_branch: input.headRefName,
+                target_branch: baseRefName,
+                // Title prefix is the portable draft signal; keep `draft: true`
+                // for instances that accept it (GitLab 14.2+).
+                title: draftTitle,
+                description: input.body,
+                draft: true,
+              },
+            },
+          ).pipe(
+            Effect.map((value) => decode(CreatedMergeRequestSchema, value)),
+            Effect.mapError((error) =>
+              error instanceof GitLabRequestError
+                ? error
+                : requestError(
+                    `GitLab returned an invalid merge request after create for ${repository.projectPath}:${input.headRefName}`,
+                    error,
+                  ),
+            ),
+          ),
+        )
+        if (!isDraftMergeRequest(created)) {
+          return yield* new GitLabRequestError({
+            message: `GitLab did not create a draft merge request for ${repository.projectPath}:${input.headRefName}`,
+          })
+        }
+        return created.iid
+      },
+    ),
+    updateOpenDraftPullRequestCopy: Effect.fn(
+      "GitLabService.updateOpenDraftPullRequestCopy",
+    )(function* (repository, headRefName, input) {
+      const open = yield* unavailableOn404(
+        repository,
+        listOpenMergeRequestsForBranch(repository, headRefName),
+      )
+      const details = open[0]
+      if (details === undefined) {
+        return null
+      }
+      // Non-draft open MRs (ready for review / human-edited): do not overwrite.
+      if (!isDraftMergeRequest(details)) {
+        return details.iid
+      }
+      // Preserve draft title form so reconcile never undrafts via prefix removal.
+      const desiredTitle = withDraftTitlePrefix(input.title)
+      const currentTitle = details.title ?? ""
+      const currentBody = details.description ?? ""
+      if (currentTitle === desiredTitle && currentBody === input.body) {
+        return details.iid
+      }
+      // Copy update is best-effort: open draft identity remains valid.
+      yield* requestUnknown(
+        repository,
+        `${projectApiPath(repository)}/merge_requests/${details.iid}`,
+        `Failed to update draft merge request !${details.iid} for ${repository.projectPath}`,
+        {
+          method: "PUT",
+          body: {
+            title: desiredTitle,
+            description: input.body,
+          },
+        },
+      ).pipe(Effect.asVoid, Effect.ignore)
+      return details.iid
+    }),
+    countOpenNonDraftPullRequests: Effect.fn(
+      "GitLabService.countOpenNonDraftPullRequests",
+    )((repository) =>
+      unavailableOn404(
+        repository,
+        requestPages(
+          repository,
+          `${projectApiPath(repository)}/merge_requests?state=opened&wip=no`,
+          `Failed to count open non-draft merge requests for ${repository.projectPath}`,
+        ).pipe(
+          Effect.map((values) => {
+            const decoded = decode(Schema.Array(OpenMergeRequestSchema), values)
+            // Match create/reconcile: title-prefixed drafts count as drafts even
+            // when the boolean is missing or wip=no returns an inconsistent row.
+            return decoded.filter(
+              (mergeRequest) => !isDraftMergeRequest(mergeRequest),
+            ).length
+          }),
+          Effect.mapError((error) =>
+            error instanceof GitLabRequestError
+              ? error
+              : requestError(
+                  `GitLab returned invalid merge request count data for ${repository.projectPath}`,
+                  error,
+                ),
+          ),
+        ),
+      ),
+    ),
+    ensureIssueCompletedWithSummary: Effect.fn(
+      "GitLabService.ensureIssueCompletedWithSummary",
+    )(function* (repository, issueNumber, workItemId, summaryMarkdown) {
+      if (!Number.isSafeInteger(issueNumber) || issueNumber <= 0) {
+        return yield* new GitLabRequestError({
+          message: `Invalid Issue number for ${repository.projectPath}: ${String(issueNumber)}`,
+        })
+      }
+      if (typeof workItemId !== "string" || workItemId.trim() === "") {
+        return yield* new GitLabRequestError({
+          message: `Invalid Work Item id for ${repository.projectPath}#${issueNumber}`,
+        })
+      }
+      if (
+        typeof summaryMarkdown !== "string" ||
+        summaryMarkdown.trim() === ""
+      ) {
+        return yield* new GitLabRequestError({
+          message: `Empty completion summary for ${repository.projectPath}#${issueNumber}`,
+        })
+      }
+
+      const marker = workItemCompletionMarker(workItemId)
+      const issueRef = `${repository.projectPath}#${issueNumber}`
+      const project = projectApiPath(repository)
+      const issuePath = `${project}/issues/${issueNumber}`
+
+      const issue = yield* unavailableOn404(
+        repository,
+        requestUnknown(
+          repository,
+          issuePath,
+          `Failed to load Issue ${issueRef}`,
+        ).pipe(
+          Effect.map((value) => decode(IssueStateSchema, value)),
+          Effect.mapError((error) =>
+            error instanceof GitLabRequestError
+              ? error
+              : requestError(
+                  `GitLab returned an invalid Issue for ${issueRef}`,
+                  error,
+                ),
+          ),
+        ),
+      )
+
+      const notes = yield* unavailableOn404(
+        repository,
+        requestPages(
+          repository,
+          `${issuePath}/notes?sort=asc&order_by=created_at`,
+          `Failed to list comments for Issue ${issueRef}`,
+        ).pipe(
+          Effect.map((values) => decode(Schema.Array(NoteSchema), values)),
+          Effect.mapError((error) =>
+            error instanceof GitLabRequestError
+              ? error
+              : requestError(
+                  `GitLab returned invalid notes for ${issueRef}`,
+                  error,
+                ),
+          ),
+        ),
+      )
+
+      const hasMarkedComment = notes.some(
+        (note) => typeof note.body === "string" && note.body.includes(marker),
+      )
+
+      if (!hasMarkedComment) {
+        const body = `${summaryMarkdown.trimEnd()}\n\n${marker}`
+        const posted = yield* unavailableOn404(
+          repository,
+          requestUnknown(
+            repository,
+            `${issuePath}/notes`,
+            `Failed to post completion summary on Issue ${issueRef}`,
+            {
+              method: "POST",
+              body: { body },
+            },
+          ).pipe(
+            Effect.map((value) => decode(NoteSchema, value)),
+            Effect.mapError((error) =>
+              error instanceof GitLabRequestError
+                ? error
+                : requestError(
+                    `GitLab returned an invalid note after posting on ${issueRef}`,
+                    error,
+                  ),
+            ),
+          ),
+        )
+        if (typeof posted.body !== "string" || !posted.body.includes(marker)) {
+          return yield* new GitLabRequestError({
+            message: `GitLab did not return a marked completion comment for ${issueRef}`,
+          })
+        }
+      }
+
+      if (issue.state === "closed") {
+        return
+      }
+
+      const closed = yield* unavailableOn404(
+        repository,
+        requestUnknown(
+          repository,
+          issuePath,
+          `Failed to close Issue ${issueRef}`,
+          {
+            method: "PUT",
+            body: { state_event: "close" },
+          },
+        ).pipe(
+          Effect.map((value) => decode(IssueStateSchema, value)),
+          Effect.mapError((error) =>
+            error instanceof GitLabRequestError
+              ? error
+              : requestError(
+                  `GitLab returned an invalid Issue after closing ${issueRef}`,
+                  error,
+                ),
+          ),
+        ),
+      )
+      if (closed.state !== "closed") {
+        return yield* new GitLabRequestError({
+          message: `Issue ${issueRef} is still open after close`,
+        })
+      }
+    }),
+    closeOpenPullRequestsForBranch: Effect.fn(
+      "GitLabService.closeOpenPullRequestsForBranch",
+    )(function* (repository, headRefName) {
+      const open = yield* unavailableOn404(
+        repository,
+        listOpenMergeRequestsForBranch(repository, headRefName),
+      )
+      for (const mergeRequest of open) {
+        // Missing MR between list and close is success (idempotent cleanup).
+        const closeResult = yield* requestUnknown(
+          repository,
+          `${projectApiPath(repository)}/merge_requests/${mergeRequest.iid}`,
+          `Failed to close merge request !${mergeRequest.iid} for ${repository.projectPath}`,
+          {
+            method: "PUT",
+            body: { state_event: "close" },
+          },
+        ).pipe(Effect.asVoid, Effect.result)
+        if (closeResult._tag === "Success") continue
+        if (closeResult.failure.statusCode === 404) continue
+        return yield* closeResult.failure
+      }
+    }),
+    deleteBranch: Effect.fn("GitLabService.deleteBranch")(
+      function* (repository, branchName) {
+        const result = yield* requestUnknown(
+          repository,
+          `${projectApiPath(repository)}/repository/branches/${encodeURIComponent(branchName)}`,
+          `Failed to delete branch ${branchName} on ${repository.projectPath}`,
+          {
+            method: "DELETE",
+            acceptEmpty: true,
+          },
+        ).pipe(Effect.result)
+
+        if (result._tag === "Success") {
+          return
+        }
+        const error = result.failure
+        if (error.statusCode === 404) {
+          return
+        }
+        return yield* error
+      },
+    ),
   }
 }
 

--- a/packages/gitlab-service/src/lib/gitlab-service-test.ts
+++ b/packages/gitlab-service/src/lib/gitlab-service-test.ts
@@ -1,8 +1,5 @@
 import { Effect, Layer } from "effect"
-import {
-  GitLabProjectUnavailableError,
-  type GitLabRequestError,
-} from "./errors.js"
+import { GitLabProjectUnavailableError, GitLabRequestError } from "./errors.js"
 import { GitLabService } from "./gitlab-service.js"
 import type { GitLabReadyLabeledIssue, GitLabRepository } from "./types.js"
 
@@ -10,6 +7,8 @@ export interface GitLabServiceTestFixture {
   readonly repository: GitLabRepository
   readonly issues?: readonly GitLabReadyLabeledIssue[]
   readonly operatorLogin?: string
+  readonly openPullRequestByBranch?: Readonly<Record<string, number>>
+  readonly openNonDraftPullRequestCount?: number
   readonly error?: GitLabRequestError
 }
 
@@ -25,39 +24,70 @@ export const makeGitLabServiceTest = (
   const fixtureFor = (repository: GitLabRepository) =>
     byRepository.get(key(repository))
 
+  const failOr = <A>(
+    repository: GitLabRepository,
+    succeed: (fixture: GitLabServiceTestFixture) => Effect.Effect<A, never>,
+  ) => {
+    const fixture = fixtureFor(repository)
+    if (fixture === undefined) {
+      return Effect.fail(new GitLabProjectUnavailableError(repository))
+    }
+    if (fixture.error !== undefined) return Effect.fail(fixture.error)
+    return succeed(fixture)
+  }
+
   return Layer.succeed(GitLabService, {
-    verifyProject: (repository) => {
-      const fixture = fixtureFor(repository)
-      if (fixture === undefined) {
-        return Effect.fail(new GitLabProjectUnavailableError(repository))
-      }
-      return fixture.error === undefined
-        ? Effect.void
-        : Effect.fail(fixture.error)
-    },
-    getAuthenticatedUserLogin: (repository) => {
-      const fixture = fixtureFor(repository)
-      if (fixture === undefined) {
-        return Effect.fail(new GitLabProjectUnavailableError(repository))
-      }
-      if (fixture.error !== undefined) return Effect.fail(fixture.error)
-      return Effect.succeed(fixture.operatorLogin ?? "operator")
-    },
-    listReadyIssues: (repository) => {
-      const fixture = fixtureFor(repository)
-      if (fixture === undefined) {
-        return Effect.fail(new GitLabProjectUnavailableError(repository))
-      }
-      if (fixture.error !== undefined) return Effect.fail(fixture.error)
-      return Effect.succeed(
-        [...(fixture.issues ?? [])].sort(
-          (left, right) => left.number - right.number,
+    verifyProject: (repository) => failOr(repository, () => Effect.void),
+    getAuthenticatedUserLogin: (repository) =>
+      failOr(repository, (fixture) =>
+        Effect.succeed(fixture.operatorLogin ?? "operator"),
+      ),
+    listReadyIssues: (repository) =>
+      failOr(repository, (fixture) =>
+        Effect.succeed(
+          [...(fixture.issues ?? [])].sort(
+            (left, right) => left.number - right.number,
+          ),
         ),
-      )
-    },
+      ),
     hasCredentials: (repository) =>
       Effect.succeed(fixtureFor(repository) !== undefined),
     hasAmbientCredentials: (repository) =>
       Effect.succeed(fixtureFor(repository) !== undefined),
+    getOpenPullRequestNumber: (repository, headRefName) => {
+      const fixture = fixtureFor(repository)
+      if (fixture === undefined) {
+        return Effect.fail(new GitLabProjectUnavailableError(repository))
+      }
+      if (fixture.error !== undefined) return Effect.fail(fixture.error)
+      const number = fixture.openPullRequestByBranch?.[headRefName]
+      if (number === undefined) {
+        return Effect.fail(
+          new GitLabRequestError({
+            message: `No open merge request found for ${repository.projectPath}:${headRefName}`,
+          }),
+        )
+      }
+      return Effect.succeed(number)
+    },
+    findOpenPullRequestNumber: (repository, headRefName) =>
+      failOr(repository, (fixture) =>
+        Effect.succeed(fixture.openPullRequestByBranch?.[headRefName] ?? null),
+      ),
+    createDraftPullRequest: (repository) =>
+      failOr(repository, () => Effect.succeed(1)),
+    updateOpenDraftPullRequestCopy: (repository, headRefName) =>
+      failOr(repository, (fixture) =>
+        Effect.succeed(fixture.openPullRequestByBranch?.[headRefName] ?? null),
+      ),
+    countOpenNonDraftPullRequests: (repository) =>
+      failOr(repository, (fixture) =>
+        Effect.succeed(fixture.openNonDraftPullRequestCount ?? 0),
+      ),
+    ensureIssueCompletedWithSummary: (repository) =>
+      failOr(repository, () => Effect.void),
+    closeOpenPullRequestsForBranch: (repository) =>
+      failOr(repository, () => Effect.void),
+    deleteBranch: (repository) => failOr(repository, () => Effect.void),
   })
 }

--- a/packages/gitlab-service/src/lib/gitlab-service.ts
+++ b/packages/gitlab-service/src/lib/gitlab-service.ts
@@ -38,6 +38,81 @@ export interface GitLabServiceShape {
   readonly hasAmbientCredentials: (
     repository: GitLabRepository,
   ) => Effect.Effect<boolean, GitLabRequestError>
+  /**
+   * Hard lookup of an open merge request for the exact source branch.
+   * Fails when no open MR exists.
+   */
+  readonly getOpenPullRequestNumber: (
+    repository: GitLabRepository,
+    headRefName: string,
+  ) => Effect.Effect<number, GitLabServiceError>
+  /**
+   * Soft lookup of an open merge request for the exact source branch.
+   * Returns null when none exists (does not fail).
+   */
+  readonly findOpenPullRequestNumber: (
+    repository: GitLabRepository,
+    headRefName: string,
+  ) => Effect.Effect<number | null, GitLabServiceError>
+  /**
+   * Create a draft merge request for head against the project default base
+   * (or an explicit base). Returns the new MR iid. Does not push the head
+   * branch; the caller must ensure the remote head exists.
+   */
+  readonly createDraftPullRequest: (
+    repository: GitLabRepository,
+    input: {
+      readonly headRefName: string
+      readonly title: string
+      readonly body: string
+      readonly baseRefName?: string
+    },
+  ) => Effect.Effect<number, GitLabServiceError>
+  /**
+   * When an open draft MR exists for the exact source branch, set its title
+   * and description to the provided values. Non-draft open MRs are left
+   * unchanged. Returns the open MR iid when one exists, otherwise null.
+   */
+  readonly updateOpenDraftPullRequestCopy: (
+    repository: GitLabRepository,
+    headRefName: string,
+    input: {
+      readonly title: string
+      readonly body: string
+    },
+  ) => Effect.Effect<number | null, GitLabServiceError>
+  /**
+   * Count currently open, non-draft merge requests for the project.
+   * Author, branch, labels, and Work Item ownership are ignored.
+   */
+  readonly countOpenNonDraftPullRequests: (
+    repository: GitLabRepository,
+  ) => Effect.Effect<number, GitLabServiceError>
+  /**
+   * Ensure a No-Change Outcome summary is posted once (hidden Work Item marker)
+   * and the Issue is closed. Idempotent across retries and already-closed Issues.
+   */
+  readonly ensureIssueCompletedWithSummary: (
+    repository: GitLabRepository,
+    issueNumber: number,
+    workItemId: string,
+    summaryMarkdown: string,
+  ) => Effect.Effect<void, GitLabServiceError>
+  /**
+   * Close every open merge request whose source branch matches exactly.
+   * Missing MRs are success (idempotent).
+   */
+  readonly closeOpenPullRequestsForBranch: (
+    repository: GitLabRepository,
+    headRefName: string,
+  ) => Effect.Effect<void, GitLabServiceError>
+  /**
+   * Delete a remote branch by name. Missing branches are success (idempotent).
+   */
+  readonly deleteBranch: (
+    repository: GitLabRepository,
+    branchName: string,
+  ) => Effect.Effect<void, GitLabServiceError>
 }
 
 export class GitLabService extends Context.Service<

--- a/packages/gitlab-service/test/gitlab-service.spec.ts
+++ b/packages/gitlab-service/test/gitlab-service.spec.ts
@@ -22,11 +22,15 @@ const json = (value: unknown, init: ResponseInit = {}): Response =>
 const fakeFetch = (
   responses: Readonly<Record<string, unknown | Response>>,
 ): typeof fetch =>
-  (async (input) => {
+  (async (input, init) => {
     const url = new URL(String(input))
-    const response = responses[`${url.pathname}${url.search}`]
+    const method = (init?.method ?? "GET").toUpperCase()
+    const pathKey = `${url.pathname}${url.search}`
+    const response =
+      responses[`${method} ${pathKey}`] ??
+      (method === "GET" ? responses[pathKey] : undefined)
     if (response === undefined) {
-      throw new Error(`Unexpected request: ${url.pathname}${url.search}`)
+      throw new Error(`Unexpected request: ${method} ${pathKey}`)
     }
     return response instanceof Response ? response : json(response)
   }) as typeof fetch
@@ -207,5 +211,367 @@ describe("GitLab issue-source adapter", () => {
     )
     expect(error).toBeInstanceOf(GitLabRequestError)
     expect(error.statusCode).toBe(401)
+  })
+})
+
+describe("GitLab draft MR and Close Issue adapter", () => {
+  test("creates a draft merge request against the project default base", async () => {
+    const bodies: unknown[] = []
+    const service = makeGitLabServiceFromToken("test-token", (async (
+      input,
+      init,
+    ) => {
+      const url = new URL(String(input))
+      const method = (init?.method ?? "GET").toUpperCase()
+      if (
+        method === "GET" &&
+        url.pathname === "/api/v4/projects/project%2Foauth_client"
+      ) {
+        return json({
+          path_with_namespace: "project/oauth_client",
+          default_branch: "1.x",
+        })
+      }
+      if (
+        method === "POST" &&
+        url.pathname ===
+          "/api/v4/projects/project%2Foauth_client/merge_requests"
+      ) {
+        bodies.push(JSON.parse(String(init?.body ?? "{}")))
+        return json({
+          iid: 91,
+          draft: true,
+          title: "Draft: Refresh tokens",
+        })
+      }
+      throw new Error(`Unexpected request: ${method} ${url.pathname}`)
+    }) as typeof fetch)
+
+    await expect(
+      Effect.runPromise(
+        service.createDraftPullRequest(repository, {
+          headRefName: "rfa/issue-3601642",
+          title: "Refresh tokens",
+          body: "Implements refresh.\n\nCloses #3601642",
+        }),
+      ),
+    ).resolves.toBe(91)
+    expect(bodies).toEqual([
+      {
+        source_branch: "rfa/issue-3601642",
+        target_branch: "1.x",
+        title: "Draft: Refresh tokens",
+        description: "Implements refresh.\n\nCloses #3601642",
+        draft: true,
+      },
+    ])
+  })
+
+  test("createDraftPullRequest fails when GitLab returns a non-draft MR", async () => {
+    const service = makeGitLabServiceFromToken("test-token", (async (
+      input,
+      init,
+    ) => {
+      const url = new URL(String(input))
+      const method = (init?.method ?? "GET").toUpperCase()
+      if (
+        method === "GET" &&
+        url.pathname === "/api/v4/projects/project%2Foauth_client"
+      ) {
+        return json({
+          path_with_namespace: "project/oauth_client",
+          default_branch: "1.x",
+        })
+      }
+      if (
+        method === "POST" &&
+        url.pathname ===
+          "/api/v4/projects/project%2Foauth_client/merge_requests"
+      ) {
+        return json({ iid: 91, draft: false, title: "Refresh tokens" })
+      }
+      throw new Error(`Unexpected request: ${method} ${url.pathname}`)
+    }) as typeof fetch)
+
+    const error = await Effect.runPromise(
+      service
+        .createDraftPullRequest(repository, {
+          headRefName: "rfa/issue-3601642",
+          title: "Refresh tokens",
+          body: "Closes #3601642",
+        })
+        .pipe(Effect.flip),
+    )
+    expect(error).toBeInstanceOf(GitLabRequestError)
+    expect(error.message).toContain("did not create a draft")
+  })
+
+  test("updateOpenDraftPullRequestCopy preserves the Draft title prefix", async () => {
+    const bodies: unknown[] = []
+    const service = makeGitLabServiceFromToken("test-token", (async (
+      input,
+      init,
+    ) => {
+      const url = new URL(String(input))
+      const method = (init?.method ?? "GET").toUpperCase()
+      if (
+        method === "GET" &&
+        url.pathname ===
+          "/api/v4/projects/project%2Foauth_client/merge_requests"
+      ) {
+        return json([
+          {
+            iid: 17,
+            draft: true,
+            title: "Draft: old title",
+            description: "old body",
+          },
+        ])
+      }
+      if (
+        method === "PUT" &&
+        url.pathname ===
+          "/api/v4/projects/project%2Foauth_client/merge_requests/17"
+      ) {
+        bodies.push(JSON.parse(String(init?.body ?? "{}")))
+        return json({ iid: 17, draft: true, title: "Draft: new title" })
+      }
+      throw new Error(`Unexpected request: ${method} ${url.pathname}`)
+    }) as typeof fetch)
+
+    await expect(
+      Effect.runPromise(
+        service.updateOpenDraftPullRequestCopy(repository, "rfa/issue-1", {
+          title: "new title",
+          body: "new body",
+        }),
+      ),
+    ).resolves.toBe(17)
+    expect(bodies).toEqual([
+      {
+        title: "Draft: new title",
+        description: "new body",
+      },
+    ])
+  })
+
+  test("finds open merge requests by source branch and counts non-drafts", async () => {
+    const service = makeGitLabServiceFromToken(
+      "test-token",
+      fakeFetch({
+        "/api/v4/projects/project%2Foauth_client/merge_requests?state=opened&source_branch=rfa%2Fissue-1&per_page=100&page=1":
+          [{ iid: 17, draft: true, title: "Draft", description: "body" }],
+        "/api/v4/projects/project%2Foauth_client/merge_requests?state=opened&wip=no&per_page=100&page=1":
+          [
+            { iid: 1, draft: false, title: "Ready" },
+            { iid: 2, draft: true, title: "Still draft flag" },
+            { iid: 3, draft: false, title: "Also ready" },
+            // Title-only draft (boolean missing/false) must not inflate count.
+            { iid: 4, draft: false, title: "Draft: title-only draft" },
+          ],
+      }),
+    )
+
+    await expect(
+      Effect.runPromise(
+        service.findOpenPullRequestNumber(repository, "rfa/issue-1"),
+      ),
+    ).resolves.toBe(17)
+    await expect(
+      Effect.runPromise(service.countOpenNonDraftPullRequests(repository)),
+    ).resolves.toBe(2)
+  })
+
+  test("posts a marked No-Change summary and closes the Issue", async () => {
+    const mutations: Array<{ method: string; path: string; body: unknown }> = []
+    const workItemId = "01KYQKSRTJ4N6C5F9EV37R2MZJ"
+    const summary = "No repository changes required."
+    const service = makeGitLabServiceFromToken("test-token", (async (
+      input,
+      init,
+    ) => {
+      const url = new URL(String(input))
+      const method = (init?.method ?? "GET").toUpperCase()
+      const path = `${url.pathname}${url.search}`
+      if (
+        method === "GET" &&
+        url.pathname ===
+          "/api/v4/projects/project%2Foauth_client/issues/3601642"
+      ) {
+        return json({ iid: 3601642, state: "opened" })
+      }
+      if (
+        method === "GET" &&
+        url.pathname ===
+          "/api/v4/projects/project%2Foauth_client/issues/3601642/notes"
+      ) {
+        return json([])
+      }
+      if (
+        method === "POST" &&
+        url.pathname ===
+          "/api/v4/projects/project%2Foauth_client/issues/3601642/notes"
+      ) {
+        const body = JSON.parse(String(init?.body ?? "{}")) as {
+          body: string
+        }
+        mutations.push({ method, path: url.pathname, body })
+        return json({ body: body.body })
+      }
+      if (
+        method === "PUT" &&
+        url.pathname ===
+          "/api/v4/projects/project%2Foauth_client/issues/3601642"
+      ) {
+        mutations.push({
+          method,
+          path: url.pathname,
+          body: JSON.parse(String(init?.body ?? "{}")),
+        })
+        return json({ iid: 3601642, state: "closed" })
+      }
+      throw new Error(`Unexpected request: ${method} ${path}`)
+    }) as typeof fetch)
+
+    await Effect.runPromise(
+      service.ensureIssueCompletedWithSummary(
+        repository,
+        3601642,
+        workItemId,
+        summary,
+      ),
+    )
+
+    expect(mutations).toHaveLength(2)
+    const noteMutation = mutations[0]
+    expect(noteMutation?.method).toBe("POST")
+    const noteBody = (noteMutation?.body as { body: string } | undefined)?.body
+    expect(String(noteBody)).toContain(summary)
+    expect(String(noteBody)).toContain(
+      `<!-- ready-for-agent:work-item:${workItemId} -->`,
+    )
+    expect(mutations[1]).toEqual({
+      method: "PUT",
+      path: "/api/v4/projects/project%2Foauth_client/issues/3601642",
+      body: { state_event: "close" },
+    })
+  })
+
+  test("reuses an existing marked comment without posting a duplicate", async () => {
+    const mutations: string[] = []
+    const workItemId = "01KYQKSRTJ4N6C5F9EV37R2MZJ"
+    const marker = `<!-- ready-for-agent:work-item:${workItemId} -->`
+    const service = makeGitLabServiceFromToken("test-token", (async (
+      input,
+      init,
+    ) => {
+      const url = new URL(String(input))
+      const method = (init?.method ?? "GET").toUpperCase()
+      if (
+        method === "GET" &&
+        url.pathname ===
+          "/api/v4/projects/project%2Foauth_client/issues/3601642"
+      ) {
+        return json({ iid: 3601642, state: "opened" })
+      }
+      if (
+        method === "GET" &&
+        url.pathname ===
+          "/api/v4/projects/project%2Foauth_client/issues/3601642/notes"
+      ) {
+        return json([{ body: `## Done\n\n${marker}` }])
+      }
+      if (
+        method === "POST" &&
+        url.pathname ===
+          "/api/v4/projects/project%2Foauth_client/issues/3601642/notes"
+      ) {
+        mutations.push("note")
+        return json({ body: "should not post" })
+      }
+      if (
+        method === "PUT" &&
+        url.pathname ===
+          "/api/v4/projects/project%2Foauth_client/issues/3601642"
+      ) {
+        mutations.push("close")
+        return json({ iid: 3601642, state: "closed" })
+      }
+      throw new Error(`Unexpected request: ${method} ${url.pathname}`)
+    }) as typeof fetch)
+
+    await Effect.runPromise(
+      service.ensureIssueCompletedWithSummary(
+        repository,
+        3601642,
+        workItemId,
+        "## Summary",
+      ),
+    )
+    expect(mutations).toEqual(["close"])
+  })
+
+  test("closes open merge requests for a branch and deletes the branch", async () => {
+    const mutations: string[] = []
+    const service = makeGitLabServiceFromToken("test-token", (async (
+      input,
+      init,
+    ) => {
+      const url = new URL(String(input))
+      const method = (init?.method ?? "GET").toUpperCase()
+      if (
+        method === "GET" &&
+        url.pathname ===
+          "/api/v4/projects/project%2Foauth_client/merge_requests" &&
+        url.search.includes("source_branch=rfa%2Fissue-1")
+      ) {
+        return json([
+          { iid: 10, draft: true },
+          { iid: 11, draft: false },
+        ])
+      }
+      if (
+        method === "PUT" &&
+        url.pathname.startsWith(
+          "/api/v4/projects/project%2Foauth_client/merge_requests/",
+        )
+      ) {
+        mutations.push(`close:${url.pathname.split("/").at(-1)}`)
+        return json({
+          iid: Number(url.pathname.split("/").at(-1)),
+          draft: true,
+        })
+      }
+      if (
+        method === "DELETE" &&
+        url.pathname ===
+          "/api/v4/projects/project%2Foauth_client/repository/branches/rfa%2Fissue-1"
+      ) {
+        mutations.push("delete-branch")
+        return new Response(null, { status: 204 })
+      }
+      throw new Error(
+        `Unexpected request: ${method} ${url.pathname}${url.search}`,
+      )
+    }) as typeof fetch)
+
+    await Effect.runPromise(
+      service.closeOpenPullRequestsForBranch(repository, "rfa/issue-1"),
+    )
+    await Effect.runPromise(service.deleteBranch(repository, "rfa/issue-1"))
+    expect(mutations).toEqual(["close:10", "close:11", "delete-branch"])
+  })
+
+  test("treats a missing branch as successful delete", async () => {
+    const service = makeGitLabServiceFromToken(
+      "test-token",
+      fakeFetch({
+        "DELETE /api/v4/projects/project%2Foauth_client/repository/branches/gone":
+          new Response("not found", { status: 404 }),
+      }),
+    )
+    await expect(
+      Effect.runPromise(service.deleteBranch(repository, "gone")),
+    ).resolves.toBeUndefined()
   })
 })

--- a/packages/graphql-api/src/lib/graphql-api.ts
+++ b/packages/graphql-api/src/lib/graphql-api.ts
@@ -685,17 +685,29 @@ export const createGraphqlApi = (
           }) =>
             runGraphql(
               Effect.gen(function* () {
+                const forgeRepository = {
+                  forge: repository.forge,
+                  forgeHost: repository.forgeHost,
+                  projectPath: repository.projectPath,
+                }
+                // Forge is authoritative: open non-draft PRs/MRs regardless of
+                // Work Item ownership. Credential/API failures degrade to zero
+                // so the repository list still renders.
+                if (repository.forge === "gitlab") {
+                  const gitlab = yield* GitLabService
+                  return yield* gitlab
+                    .countOpenNonDraftPullRequests(forgeRepository)
+                    .pipe(
+                      Effect.catchTags({
+                        GitLabProjectUnavailableError: () => Effect.succeed(0),
+                        GitLabRequestError: () => Effect.succeed(0),
+                      }),
+                    )
+                }
                 if (repository.forge !== "github") return 0
                 const github = yield* GitHubService
-                // GitHub is authoritative: open non-draft PRs regardless of Work
-                // Item ownership. Credential/API failures degrade to zero so the
-                // repository list still renders.
                 return yield* github
-                  .countOpenNonDraftPullRequests({
-                    forge: repository.forge,
-                    forgeHost: repository.forgeHost,
-                    projectPath: repository.projectPath,
-                  })
+                  .countOpenNonDraftPullRequests(forgeRepository)
                   .pipe(
                     Effect.catchTags({
                       GitHubRepositoryUnavailableError: () => Effect.succeed(0),

--- a/packages/graphql-api/test/graphql-api.test.ts
+++ b/packages/graphql-api/test/graphql-api.test.ts
@@ -202,6 +202,14 @@ const defaultGitlab: GitLabServiceShape = {
   listReadyIssues: () => Effect.succeed([]),
   hasCredentials: () => Effect.succeed(true),
   hasAmbientCredentials: () => Effect.succeed(true),
+  getOpenPullRequestNumber: () => Effect.succeed(1),
+  findOpenPullRequestNumber: () => Effect.succeed(null),
+  createDraftPullRequest: () => Effect.succeed(1),
+  updateOpenDraftPullRequestCopy: () => Effect.succeed(null),
+  countOpenNonDraftPullRequests: () => Effect.succeed(0),
+  ensureIssueCompletedWithSummary: () => Effect.void,
+  closeOpenPullRequestsForBranch: () => Effect.void,
+  deleteBranch: () => Effect.void,
 }
 
 const makeRuntime = (
@@ -2108,6 +2116,52 @@ describe("GraphQL API", () => {
     const third = await createGraphqlApi(runtime).fetch(graphqlRequest(query))
     expect(await third.json()).toEqual({
       data: { repositories: [{ id: repository.id, pullRequestCount: 0 }] },
+    })
+  })
+
+  test("pullRequestCount uses GitLab open non-draft MRs for GitLab Repositories", async () => {
+    await runtime.dispose()
+    const gitlabRepository = makeRepositoryRecord({
+      forge: "gitlab",
+      forgeHost: "git.drupalcode.org",
+      projectPath: "project/oauth_client",
+      localPath: "/repos/oauth-client",
+    })
+    let openNonDraft = 2
+    runtime = makeRuntime(
+      {
+        listRepositories: Effect.succeed([gitlabRepository]),
+      },
+      {},
+      {},
+      {},
+      {},
+      {},
+      {},
+      {
+        countOpenNonDraftPullRequests: () => Effect.succeed(openNonDraft),
+      },
+    )
+
+    const query = {
+      query: `query {
+        repositories { id pullRequestCount }
+      }`,
+    }
+
+    const first = await createGraphqlApi(runtime).fetch(graphqlRequest(query))
+    expect(await first.json()).toEqual({
+      data: {
+        repositories: [{ id: gitlabRepository.id, pullRequestCount: 2 }],
+      },
+    })
+
+    openNonDraft = 5
+    const second = await createGraphqlApi(runtime).fetch(graphqlRequest(query))
+    expect(await second.json()).toEqual({
+      data: {
+        repositories: [{ id: gitlabRepository.id, pullRequestCount: 5 }],
+      },
     })
   })
 

--- a/packages/issue-reconciler/test/issue-reconciler.spec.ts
+++ b/packages/issue-reconciler/test/issue-reconciler.spec.ts
@@ -205,13 +205,23 @@ const makeGitHubLayer = (
     },
   } satisfies GitHubServiceShape)
 
-const defaultGitLabLayer = Layer.succeed(GitLabService, {
+const defaultGitLabShape = {
   verifyProject: () => Effect.void,
   getAuthenticatedUserLogin: () => Effect.succeed("operator"),
   listReadyIssues: () => Effect.succeed([]),
   hasCredentials: () => Effect.succeed(true),
   hasAmbientCredentials: () => Effect.succeed(true),
-} satisfies GitLabServiceShape)
+  getOpenPullRequestNumber: () => Effect.succeed(1),
+  findOpenPullRequestNumber: () => Effect.succeed(null),
+  createDraftPullRequest: () => Effect.succeed(1),
+  updateOpenDraftPullRequestCopy: () => Effect.succeed(null),
+  countOpenNonDraftPullRequests: () => Effect.succeed(0),
+  ensureIssueCompletedWithSummary: () => Effect.void,
+  closeOpenPullRequestsForBranch: () => Effect.void,
+  deleteBranch: () => Effect.void,
+} satisfies GitLabServiceShape
+
+const defaultGitLabLayer = Layer.succeed(GitLabService, defaultGitLabShape)
 
 const runReconciliation = <A, E>(
   effect: Effect.Effect<A, E, IssueReconciler>,
@@ -298,15 +308,12 @@ describe("IssueReconciler", () => {
       }),
     ]
     const gitlab = Layer.succeed(GitLabService, {
-      verifyProject: () => Effect.void,
-      getAuthenticatedUserLogin: () => Effect.succeed("operator"),
+      ...defaultGitLabShape,
       listReadyIssues: ({ projectPath }) =>
         Effect.sync(() => {
           db.actions.push(`gitlab:${projectPath}`)
           return issues
         }),
-      hasCredentials: () => Effect.succeed(true),
-      hasAmbientCredentials: () => Effect.succeed(true),
     } satisfies GitLabServiceShape)
     const github = makeGitHubLayer([], db.actions)
 

--- a/packages/work-item-lifecycle/src/lib/close-issue.ts
+++ b/packages/work-item-lifecycle/src/lib/close-issue.ts
@@ -1,6 +1,7 @@
 import { Effect } from "effect"
 import { DbService } from "@ready-for-agent/db-service"
 import { GitHubService } from "@ready-for-agent/github-service"
+import { GitLabService } from "@ready-for-agent/gitlab-service"
 import {
   CloseIssueContextError,
   CloseIssueEligibilityError,
@@ -12,7 +13,7 @@ import type { LifecycleStepContext } from "./lifecycle-steps.js"
  * Production Close Issue Lifecycle Step for a confirmed No-Change Outcome.
  * Revalidates Issue eligibility immediately before mutation (open Leaf Issues
  * with no blockers; already-closed Issues are accepted), then idempotently
- * publishes the summary and closes the Issue as COMPLETED via GitHubService.
+ * publishes the summary and closes the Issue via the Repository's Forge service.
  */
 export const closeIssue = (context: LifecycleStepContext) =>
   Effect.gen(function* () {
@@ -34,13 +35,6 @@ export const closeIssue = (context: LifecycleStepContext) =>
       return yield* new CloseIssueContextError({
         workItemId: context.workItemId,
         message: `Repository ${context.repositoryId} was not found`,
-      })
-    }
-    if (repository.forge === "gitlab") {
-      return yield* new CloseIssueContextError({
-        workItemId: context.workItemId,
-        message:
-          "GitLab Close Issue requires GitLab issue lifecycle support; refusing to query GitHub for a GitLab Repository",
       })
     }
 
@@ -73,13 +67,25 @@ export const closeIssue = (context: LifecycleStepContext) =>
       }
     }
 
+    const forgeRepository = {
+      forge: repository.forge,
+      forgeHost: repository.forgeHost,
+      projectPath: repository.projectPath,
+    }
+    if (repository.forge === "gitlab") {
+      const gitlab = yield* GitLabService
+      yield* gitlab.ensureIssueCompletedWithSummary(
+        forgeRepository,
+        context.issueNumber,
+        context.workItemId,
+        summary,
+      )
+      return
+    }
+
     const github = yield* GitHubService
     yield* github.ensureIssueCompletedWithSummary(
-      {
-        forge: repository.forge,
-        forgeHost: repository.forgeHost,
-        projectPath: repository.projectPath,
-      },
+      forgeRepository,
       context.issueNumber,
       context.workItemId,
       summary,

--- a/packages/work-item-lifecycle/src/lib/create-pr.ts
+++ b/packages/work-item-lifecycle/src/lib/create-pr.ts
@@ -1,4 +1,4 @@
-import { Effect, FileSystem, Stream } from "effect"
+import { Duration, Effect, FileSystem, Stream } from "effect"
 import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process"
 import { SqlClient } from "effect/unstable/sql"
 import { AgentBackend, agentBackendLabel } from "@ready-for-agent/agent-backend"
@@ -7,6 +7,10 @@ import {
   type GitHubRepository,
   GitHubService,
 } from "@ready-for-agent/github-service"
+import {
+  type GitLabRepository,
+  GitLabService,
+} from "@ready-for-agent/gitlab-service"
 import { KeymaxxerService } from "@ready-for-agent/keymaxxer-service"
 import {
   AgentTurnForgeCredentialMissingError,
@@ -184,7 +188,8 @@ export const buildDeterministicPullRequestBody = (
   ].join("\n")
 
 /**
- * Hard lookup of an open PR. Failures surface as CreatePrLookupError.
+ * Soft lookup of an open PR/MR (null when none). Transport/API failures
+ * surface as CreatePrLookupError so callers can choose hard-fail vs soft-null.
  */
 const findExistingOpenPr = (
   context: LifecycleStepContext,
@@ -192,6 +197,21 @@ const findExistingOpenPr = (
   branch: string,
 ) =>
   Effect.gen(function* () {
+    if (repository.forge === "gitlab") {
+      const gitlab = yield* GitLabService
+      return yield* gitlab
+        .findOpenPullRequestNumber(toGitLabRepository(repository), branch)
+        .pipe(
+          Effect.mapError(
+            (cause) =>
+              new CreatePrLookupError({
+                repositoryId: context.repositoryId,
+                message: `Failed to look up an open merge request for ${repository.projectPath}:${branch}`,
+                cause,
+              }),
+          ),
+        )
+    }
     const github = yield* GitHubService
     return yield* github
       .findOpenPullRequestNumber(toGitHubRepository(repository), branch)
@@ -226,6 +246,21 @@ const resolveRequiredOpenPr = (
   branch: string,
 ) =>
   Effect.gen(function* () {
+    if (repository.forge === "gitlab") {
+      const gitlab = yield* GitLabService
+      return yield* gitlab
+        .getOpenPullRequestNumber(toGitLabRepository(repository), branch)
+        .pipe(
+          Effect.mapError(
+            (cause) =>
+              new CreatePrLookupError({
+                repositoryId: context.repositoryId,
+                message: `Failed to resolve the open merge request for ${repository.projectPath}:${branch}`,
+                cause,
+              }),
+          ),
+        )
+    }
     const github = yield* GitHubService
     return yield* github
       .getOpenPullRequestNumber(toGitHubRepository(repository), branch)
@@ -245,44 +280,108 @@ const resolveRequiredOpenPr = (
  * Vault secret name for native push when Keymaxxer is enabled; null for ambient
  * (Keymaxxer disabled) or when no repository secret is configured.
  */
-const resolveNativePushTokenName = (
-  repositoryId: string,
-  projectPath: string,
-) =>
+const resolveNativePushTokenName = (repository: RepositoryRecord) =>
   Effect.gen(function* () {
     const keymaxxer = yield* KeymaxxerService
     if (keymaxxer.enabled === false) {
       return null
     }
+    const isGitLab = repository.forge === "gitlab"
     return yield* keymaxxer
       .findSecret({
-        provider: "github",
-        account: projectPath,
+        provider: isGitLab ? "gitlab" : "github",
+        account: isGitLab
+          ? `${repository.forgeHost}/${repository.projectPath}`
+          : repository.projectPath,
       })
       .pipe(
         Effect.mapError(
           (cause) =>
             new CreatePrCredentialError({
-              repositoryId,
-              message:
-                "Failed to resolve the repository GitHub credential for native push",
+              repositoryId: repository.id,
+              message: `Failed to resolve the repository ${isGitLab ? "GitLab" : "GitHub"} credential for native push`,
               cause,
             }),
         ),
       )
   })
 
+const gitlabHttpsRemoteUrl = (repository: RepositoryRecord): string =>
+  `https://${repository.forgeHost}/${repository.projectPath}.git`
+
+/**
+ * Resolve ambient GitLab token for HTTPS push (Keymaxxer path unavailable).
+ * Prefers GITLAB_TOKEN, then glab host-scoped config.
+ */
+const GLAB_TOKEN_TIMEOUT = Duration.seconds(60)
+
+const resolveAmbientGitLabToken = (forgeHost: string) =>
+  Effect.gen(function* () {
+    const fromEnv = process.env.GITLAB_TOKEN?.trim()
+    if (fromEnv !== undefined && fromEnv !== "") {
+      return fromEnv
+    }
+    const spawner = yield* ChildProcessSpawner.ChildProcessSpawner
+    const command = ChildProcess.make(
+      "glab",
+      ["config", "get", "token", "--host", forgeHost],
+      { stdin: "ignore" },
+    )
+    const output = yield* Effect.scoped(
+      Effect.gen(function* () {
+        const handle = yield* spawner.spawn(command)
+        const [exitCode, stdout, stderr] = yield* Effect.all(
+          [
+            handle.exitCode,
+            Stream.decodeText(handle.stdout).pipe(Stream.mkString),
+            Stream.decodeText(handle.stderr).pipe(Stream.mkString),
+          ],
+          { concurrency: 3 },
+        )
+        return {
+          exitCode: Number(exitCode),
+          stdout: stdout.trim(),
+          stderr: stderr.trim(),
+        }
+      }),
+    ).pipe(
+      Effect.timeout(GLAB_TOKEN_TIMEOUT),
+      Effect.catch((cause) =>
+        Effect.succeed({
+          exitCode: 1,
+          stdout: "",
+          stderr: errorMessage(cause),
+        }),
+      ),
+    )
+    if (output.exitCode !== 0 || output.stdout === "") {
+      return null
+    }
+    return output.stdout
+  })
+
 /**
  * Push the Work Item branch via the harness credential path when a vault
  * secret is available (Keymaxxer runWithSecrets + HTTPS Authorization header).
- * Ambient mode (Keymaxxer disabled) uses plain git push.
+ * Ambient GitHub uses plain git push to origin. Ambient GitLab pushes over
+ * HTTPS to the Forge Host with token auth and never modifies origin.
  */
 const attemptNativePush = (
   worktreePath: string,
   branch: string,
+  repository: RepositoryRecord,
   tokenName: string | null,
 ) =>
   Effect.gen(function* () {
+    if (repository.forge === "gitlab") {
+      return yield* attemptGitLabHttpsPush(
+        worktreePath,
+        branch,
+        repository,
+        tokenName,
+      )
+    }
+
     if (tokenName === null) {
       const push = yield* runGitInWorktree(worktreePath, [
         "push",
@@ -355,12 +454,133 @@ const attemptNativePush = (
     return { ok: true as const }
   })
 
+/**
+ * Push to https://<forge-host>/<project-path>.git with token auth. Leaves the
+ * operator's SSH origin untouched (never git remote set-url).
+ */
+const attemptGitLabHttpsPush = (
+  worktreePath: string,
+  branch: string,
+  repository: RepositoryRecord,
+  tokenName: string | null,
+) =>
+  Effect.gen(function* () {
+    const remoteUrl = gitlabHttpsRemoteUrl(repository)
+    const host = repository.forgeHost
+    const refspec = `${branch}:${branch}`
+
+    if (tokenName !== null) {
+      const keymaxxer = yield* KeymaxxerService
+      // Basic auth: username oauth2, password = token (GitLab HTTPS git).
+      // Expand the vault secret inside the Keymaxxer child, then base64.
+      // Use a real assignment + `&&` — not a simple-command prefix assignment
+      // (`BASIC=… git … $BASIC`), which bash does not apply to later-word
+      // expansion (same gotcha documented for the GitHub bearer path above).
+      const command = [
+        `BASIC="$(printf 'oauth2:%s' "$${tokenName}" | (base64 -w0 2>/dev/null || base64 | tr -d '\\n'))"`,
+        "&&",
+        "git",
+        "-C",
+        shellQuote(worktreePath),
+        "-c",
+        `"http.https://${host}/.extraheader=Authorization: Basic $BASIC"`,
+        "push",
+        shellQuote(remoteUrl),
+        shellQuote(refspec),
+      ].join(" ")
+
+      const result = yield* keymaxxer
+        .runWithSecrets({
+          command,
+          cwd: worktreePath,
+          secrets: [tokenName],
+          timeoutMs: NATIVE_PUSH_TIMEOUT_MS,
+        })
+        .pipe(
+          Effect.catch((cause) =>
+            Effect.succeed({
+              exitCode: 1,
+              stdout: "",
+              stderr: `Keymaxxer runWithSecrets failed: ${errorMessage(cause)}`,
+            }),
+          ),
+        )
+
+      if (result.exitCode !== 0) {
+        const output = [result.stdout, result.stderr]
+          .map((part) => part.trim())
+          .filter((part) => part.length > 0)
+          .join("\n")
+        return {
+          ok: false as const,
+          diagnostics: boundDiagnostics(
+            `credentialed GitLab HTTPS push failed (exit ${result.exitCode})\n${output}`,
+          ),
+        }
+      }
+      return { ok: true as const }
+    }
+
+    const ambientToken = yield* resolveAmbientGitLabToken(host)
+    if (ambientToken === null) {
+      return {
+        ok: false as const,
+        diagnostics: boundDiagnostics(
+          `No ambient GitLab token available for HTTPS push to ${remoteUrl} (set GITLAB_TOKEN or authenticate glab for ${host})`,
+        ),
+      }
+    }
+
+    const basic = Buffer.from(`oauth2:${ambientToken}`, "utf8").toString(
+      "base64",
+    )
+    const push = yield* runGitInWorktree(worktreePath, [
+      "-c",
+      `http.https://${host}/.extraheader=Authorization: Basic ${basic}`,
+      "push",
+      remoteUrl,
+      refspec,
+    ])
+    if (push.exitCode !== 0) {
+      return {
+        ok: false as const,
+        diagnostics: boundDiagnostics(
+          `GitLab HTTPS push failed (exit ${push.exitCode})\n${push.output}`,
+        ),
+      }
+    }
+    return { ok: true as const }
+  })
+
 const attemptNativeCreateDraft = (
   repository: RepositoryRecord,
   branch: string,
   copy: PublicationCopy,
 ) =>
   Effect.gen(function* () {
+    if (repository.forge === "gitlab") {
+      const gitlab = yield* GitLabService
+      return yield* gitlab
+        .createDraftPullRequest(toGitLabRepository(repository), {
+          headRefName: branch,
+          title: copy.title,
+          body: copy.body,
+        })
+        .pipe(
+          Effect.map((pullRequestNumber) => ({
+            ok: true as const,
+            pullRequestNumber,
+          })),
+          Effect.catch((cause) =>
+            Effect.succeed({
+              ok: false as const,
+              diagnostics: boundDiagnostics(
+                `createDraftPullRequest failed: ${errorMessage(cause)}`,
+              ),
+            }),
+          ),
+        )
+    }
     const github = yield* GitHubService
     return yield* github
       .createDraftPullRequest(toGitHubRepository(repository), {
@@ -426,6 +646,30 @@ const softReconcileDraftCopy = (
   pullRequestNumber: number,
 ) =>
   Effect.gen(function* () {
+    if (repository.forge === "gitlab") {
+      const gitlab = yield* GitLabService
+      yield* gitlab
+        .updateOpenDraftPullRequestCopy(
+          toGitLabRepository(repository),
+          branch,
+          {
+            title: copy.title,
+            body: copy.body,
+          },
+        )
+        .pipe(
+          Effect.catch((cause) =>
+            Effect.logWarning(
+              "Failed to reconcile draft MR title/body to canonical publication copy; reusing open MR",
+              {
+                pullRequestNumber,
+                cause,
+              },
+            ).pipe(Effect.as(pullRequestNumber)),
+          ),
+        )
+      return
+    }
     const github = yield* GitHubService
     yield* github
       .updateOpenDraftPullRequestCopy(toGitHubRepository(repository), branch, {
@@ -448,6 +692,14 @@ const softReconcileDraftCopy = (
 const toGitHubRepository = (
   repository: RepositoryRecord,
 ): GitHubRepository => ({
+  forge: repository.forge,
+  forgeHost: repository.forgeHost,
+  projectPath: repository.projectPath,
+})
+
+const toGitLabRepository = (
+  repository: RepositoryRecord,
+): GitLabRepository => ({
   forge: repository.forge,
   forgeHost: repository.forgeHost,
   projectPath: repository.projectPath,
@@ -522,24 +774,17 @@ const resolveRepositoryRecord = (context: LifecycleStepContext) =>
 
 /**
  * Production Create PR Lifecycle Step.
- * Looks up an existing open PR for the exact Work Item branch (reconciling
+ * Looks up an existing open PR/MR for the exact Work Item branch (reconciling
  * draft title/body to canonical copy), otherwise pushes (harness credential
- * path) and creates a draft through the harness-owned GitHub service with the
+ * path) and creates a draft through the harness-owned Forge service with the
  * same publication copy as Commit. Continues the Implement Session only when
  * the native path does not establish the postcondition (repair fallback).
- * Success requires resolving the open PR identity for persistence.
+ * Success requires resolving the open PR/MR identity for persistence.
  */
 export const createPr = (context: LifecycleStepContext) =>
   Effect.gen(function* () {
     const worktreePath = yield* resolveWorktreePath(context)
     const repository = yield* resolveRepositoryRecord(context)
-    if (repository.forge === "gitlab") {
-      return yield* new CreatePrPostconditionError({
-        repositoryId: context.repositoryId,
-        message:
-          "GitLab Create PR requires GitLab PR lifecycle support; refusing to query GitHub for a GitLab Repository",
-      })
-    }
     const branch = workItemBranchName({
       projectPath: repository.projectPath,
       issueNumber: context.issueNumber,
@@ -547,7 +792,7 @@ export const createPr = (context: LifecycleStepContext) =>
     })
     const copy = yield* resolvePublicationCopyForCreatePr(context, worktreePath)
 
-    // Reuse an existing exact-branch open PR (also covers Retry / indeterminate).
+    // Reuse an existing exact-branch open PR/MR (also covers Retry / indeterminate).
     // Hard-fail only on lookup: without a reliable answer we must not create a
     // duplicate. Draft title/body reconcile is best-effort and must not fail
     // the step when an open PR already exists.
@@ -557,11 +802,13 @@ export const createPr = (context: LifecycleStepContext) =>
       return toCreatePrResult(existing, "native", copy)
     }
 
-    const pushTokenName = yield* resolveNativePushTokenName(
-      context.repositoryId,
-      repository.projectPath,
+    const pushTokenName = yield* resolveNativePushTokenName(repository)
+    const push = yield* attemptNativePush(
+      worktreePath,
+      branch,
+      repository,
+      pushTokenName,
     )
-    const push = yield* attemptNativePush(worktreePath, branch, pushTokenName)
     let nativeDiagnostics: string | null = push.ok ? null : push.diagnostics
 
     if (push.ok) {

--- a/packages/work-item-lifecycle/src/lib/lifecycle-steps-live.ts
+++ b/packages/work-item-lifecycle/src/lib/lifecycle-steps-live.ts
@@ -9,6 +9,7 @@ import {
 } from "@ready-for-agent/agent-backend"
 import { DbService } from "@ready-for-agent/db-service"
 import { GitHubService } from "@ready-for-agent/github-service"
+import { GitLabService } from "@ready-for-agent/gitlab-service"
 import { KeymaxxerService } from "@ready-for-agent/keymaxxer-service"
 import {
   CurrentCapturedAgentBackendId,
@@ -44,14 +45,15 @@ type StepServices =
   | AgentBackend
   | ActiveAgentBackend
   | GitHubService
+  | GitLabService
   | SqlClient.SqlClient
 
 /**
  * Production LifecycleSteps: Create Worktree through local cleanup, including
  * Assess Changes (git then optional OpenCode confirm) and Close Issue for
- * No-Change Outcomes. Captures platform, database, Keymaxxer, GitHub, Active
- * Agent Backend, and Agent Backend services so handlers remain `Effect<A, E>`
- * with no requirements.
+ * No-Change Outcomes. Captures platform, database, Keymaxxer, GitHub, GitLab,
+ * Active Agent Backend, and Agent Backend services so handlers remain
+ * `Effect<A, E>` with no requirements.
  */
 export const LifecycleStepsLive = Layer.effect(
   LifecycleSteps,
@@ -64,6 +66,7 @@ export const LifecycleStepsLive = Layer.effect(
     const fallbackAgentBackend = yield* AgentBackend
     const activeAgentBackend = yield* ActiveAgentBackend
     const github = yield* GitHubService
+    const gitlab = yield* GitLabService
     const sql = yield* SqlClient.SqlClient
     // Dispatch Agent Turns by the Work Item's captured backend (ambient) so
     // concurrent dual-backend fleets never share the process-wide proxy.
@@ -125,6 +128,7 @@ export const LifecycleStepsLive = Layer.effect(
       Layer.succeed(AgentBackend, agentBackend),
       Layer.succeed(ActiveAgentBackend, activeAgentBackend),
       Layer.succeed(GitHubService, github),
+      Layer.succeed(GitLabService, gitlab),
       Layer.succeed(SqlClient.SqlClient, sql),
     )
 

--- a/packages/work-item-lifecycle/src/lib/lifecycle-steps.ts
+++ b/packages/work-item-lifecycle/src/lib/lifecycle-steps.ts
@@ -10,6 +10,10 @@ import type {
   GitHubRequestError,
   MergePullRequestResult,
 } from "@ready-for-agent/github-service"
+import type {
+  GitLabProjectUnavailableError,
+  GitLabRequestError,
+} from "@ready-for-agent/gitlab-service"
 import type { KeymaxxerError } from "@ready-for-agent/keymaxxer-service"
 import type { AssessChangesResult } from "./assess-changes.js"
 import type { AssessChangesError } from "./assess-changes-errors.js"
@@ -121,6 +125,8 @@ export type LifecycleStepError =
   | RepositoryNotFoundError
   | GitHubRequestError
   | GitHubRepositoryUnavailableError
+  | GitLabRequestError
+  | GitLabProjectUnavailableError
   | KeymaxxerError
   | PlatformError
   | SqlError

--- a/packages/work-item-lifecycle/src/lib/remove-worktree.ts
+++ b/packages/work-item-lifecycle/src/lib/remove-worktree.ts
@@ -1,5 +1,6 @@
 import { Duration, Effect, FileSystem, Path } from "effect"
 import { DbService, type RepositoryRecord } from "@ready-for-agent/db-service"
+import { GitLabService } from "@ready-for-agent/gitlab-service"
 import { KeymaxxerService } from "@ready-for-agent/keymaxxer-service"
 import {
   CreateWorktreeRepositoryNotFoundError,
@@ -240,11 +241,49 @@ const deleteRemoteBranch = (input: {
     })
   })
 
+const removeGitLabRemoteArtifacts = (input: {
+  readonly repository: RepositoryRecord
+  readonly branchName: string
+}) =>
+  Effect.gen(function* () {
+    const gitlab = yield* GitLabService
+    const forgeRepository = {
+      forge: input.repository.forge,
+      forgeHost: input.repository.forgeHost,
+      projectPath: input.repository.projectPath,
+    }
+    yield* gitlab
+      .closeOpenPullRequestsForBranch(forgeRepository, input.branchName)
+      .pipe(
+        Effect.mapError(
+          (cause) =>
+            new RemoveWorktreeRemoteError({
+              message: "Failed to close open GitLab merge requests for cleanup",
+              branchName: input.branchName,
+              cause,
+            }),
+        ),
+      )
+    yield* gitlab.deleteBranch(forgeRepository, input.branchName).pipe(
+      Effect.mapError(
+        (cause) =>
+          new RemoveWorktreeRemoteError({
+            message: "Failed to delete remote GitLab Work Item branch",
+            branchName: input.branchName,
+            cause,
+          }),
+      ),
+    )
+  })
+
 const removeRemoteArtifacts = (input: {
   readonly repository: RepositoryRecord
   readonly branchName: string
 }) =>
   Effect.gen(function* () {
+    if (input.repository.forge === "gitlab") {
+      return yield* removeGitLabRemoteArtifacts(input)
+    }
     const tokenName = yield* resolveGithubCredential(input.repository)
     const cwd = input.repository.localPath
     yield* closeOpenPullRequests({
@@ -349,9 +388,10 @@ export const localCleanup = (
   })
 
 /**
- * Inverse of createWorktree: remove local artifacts, close any open remote PR,
- * and drop the remote branch when present. Missing artifacts are success
- * (idempotent). Missing GitHub credential fails.
+ * Inverse of createWorktree: remove local artifacts, close any open remote
+ * PR/MR, and drop the remote branch when present. Missing artifacts are
+ * success (idempotent). Missing Forge credential fails for GitHub Keymaxxer
+ * paths; GitLab cleanup uses the ambient GitLab service.
  */
 export const removeWorktree = (
   context: LifecycleStepContext,
@@ -359,17 +399,6 @@ export const removeWorktree = (
 ) =>
   Effect.gen(function* () {
     const repository = yield* resolveRepository(context.repositoryId)
-    if (repository.forge === "gitlab") {
-      return yield* new RemoveWorktreeRemoteError({
-        message:
-          "GitLab Remove Worktree requires GitLab PR lifecycle support; refusing to invoke GitHub cleanup for a GitLab Repository",
-        branchName: workItemBranchName({
-          projectPath: repository.projectPath,
-          issueNumber: context.issueNumber,
-          workItemId: context.workItemId,
-        }),
-      })
-    }
     const branchName = yield* removeLocalArtifacts(repository, context, options)
 
     yield* removeRemoteArtifacts({ repository, branchName })

--- a/packages/work-item-lifecycle/test/close-issue.spec.ts
+++ b/packages/work-item-lifecycle/test/close-issue.spec.ts
@@ -7,6 +7,10 @@ import {
   GitHubService,
   type GitHubServiceShape,
 } from "@ready-for-agent/github-service"
+import {
+  GitLabService,
+  type GitLabServiceShape,
+} from "@ready-for-agent/gitlab-service"
 import type { LifecycleStepContext } from "../src/index.js"
 import {
   CloseIssueContextError,
@@ -108,7 +112,7 @@ describe("closeIssue", () => {
     expect(error).toBeInstanceOf(CloseIssueContextError)
   })
 
-  it("fails closed before GitHub mutation for a GitLab Repository", async () => {
+  it("closes a GitLab Issue via GitLabService without calling GitHub", async () => {
     const gitlabRepository = makeRepositoryRecord({
       forge: "gitlab",
       forgeHost: "git.drupalcode.org",
@@ -127,6 +131,12 @@ describe("closeIssue", () => {
         ]),
     })
     let githubCalls = 0
+    const calls: Array<{
+      issueNumber: number
+      workItemId: string
+      summary: string
+      projectPath: string
+    }> = []
     const github = Layer.succeed(GitHubService, {
       ...unusedGithub,
       ensureIssueCompletedWithSummary: () => {
@@ -134,19 +144,51 @@ describe("closeIssue", () => {
         return Effect.void
       },
     } satisfies GitHubServiceShape)
+    const gitlab = Layer.succeed(GitLabService, {
+      verifyProject: () => Effect.void,
+      getAuthenticatedUserLogin: () => Effect.succeed("operator"),
+      listReadyIssues: () => Effect.succeed([]),
+      hasCredentials: () => Effect.succeed(true),
+      hasAmbientCredentials: () => Effect.succeed(true),
+      getOpenPullRequestNumber: () => Effect.succeed(1),
+      findOpenPullRequestNumber: () => Effect.succeed(null),
+      createDraftPullRequest: () => Effect.succeed(1),
+      updateOpenDraftPullRequestCopy: () => Effect.succeed(null),
+      countOpenNonDraftPullRequests: () => Effect.succeed(0),
+      ensureIssueCompletedWithSummary: (
+        repository,
+        issueNumber,
+        workItemId,
+        summaryMarkdown,
+      ) =>
+        Effect.sync(() => {
+          calls.push({
+            issueNumber,
+            workItemId,
+            summary: summaryMarkdown,
+            projectPath: repository.projectPath,
+          })
+        }),
+      closeOpenPullRequestsForBranch: () => Effect.void,
+      deleteBranch: () => Effect.void,
+    } satisfies GitLabServiceShape)
 
-    const error = await Effect.runPromise(
+    await Effect.runPromise(
       closeIssue({
         ...context,
         repositoryId: gitlabRepository.id,
-      }).pipe(Effect.provide(Layer.merge(db, github)), Effect.flip),
+      }).pipe(Effect.provide(Layer.mergeAll(db, github, gitlab))),
     )
 
-    expect(error).toBeInstanceOf(CloseIssueContextError)
-    expect((error as CloseIssueContextError).message).toContain(
-      "refusing to query GitHub for a GitLab Repository",
-    )
     expect(githubCalls).toBe(0)
+    expect(calls).toEqual([
+      {
+        issueNumber: 42,
+        workItemId: context.workItemId,
+        summary: "Findings complete.",
+        projectPath: "project/widgets",
+      },
+    ])
   })
 
   it("rejects an open parent Issue before mutation", async () => {

--- a/packages/work-item-lifecycle/test/create-pr.spec.ts
+++ b/packages/work-item-lifecycle/test/create-pr.spec.ts
@@ -19,6 +19,10 @@ import {
   type GitHubServiceShape,
 } from "@ready-for-agent/github-service"
 import {
+  GitLabService,
+  type GitLabServiceShape,
+} from "@ready-for-agent/gitlab-service"
+import {
   KeymaxxerError,
   KeymaxxerService,
   type KeymaxxerServiceShape,
@@ -126,6 +130,26 @@ const stubGitHub = (
     }),
   )
 
+const stubGitLab = (
+  overrides: Partial<GitLabServiceShape> = {},
+): Layer.Layer<GitLabService> =>
+  Layer.succeed(GitLabService, {
+    verifyProject: () => Effect.void,
+    getAuthenticatedUserLogin: () => Effect.succeed("test-operator"),
+    listReadyIssues: () => Effect.succeed([]),
+    hasCredentials: () => Effect.succeed(true),
+    hasAmbientCredentials: () => Effect.succeed(true),
+    getOpenPullRequestNumber: () => Effect.succeed(321),
+    findOpenPullRequestNumber: () => Effect.succeed(null),
+    createDraftPullRequest: () => Effect.succeed(321),
+    updateOpenDraftPullRequestCopy: () => Effect.succeed(null),
+    countOpenNonDraftPullRequests: () => Effect.succeed(0),
+    ensureIssueCompletedWithSummary: () => Effect.void,
+    closeOpenPullRequestsForBranch: () => Effect.void,
+    deleteBranch: () => Effect.void,
+    ...overrides,
+  } satisfies GitLabServiceShape)
+
 const stubOpencode = (
   overrides: {
     continueTurn?: (input: {
@@ -164,6 +188,7 @@ const run = <A, E>(
     E,
     | DbService
     | GitHubService
+    | GitLabService
     | KeymaxxerService
     | AgentBackend
     | ActiveAgentBackend
@@ -173,6 +198,7 @@ const run = <A, E>(
     keymaxxer?: Layer.Layer<KeymaxxerService>
     opencode?: Layer.Layer<AgentBackend>
     github?: Layer.Layer<GitHubService>
+    gitlab?: Layer.Layer<GitLabService>
     activeBackend?: Layer.Layer<ActiveAgentBackend>
   } = {},
 ): Promise<A> =>
@@ -182,6 +208,7 @@ const run = <A, E>(
         Layer.mergeAll(
           layers.db ?? stubDb,
           layers.github ?? stubGitHub(),
+          layers.gitlab ?? stubGitLab(),
           layers.keymaxxer ?? stubKeymaxxer(),
           layers.opencode ?? stubOpencode(),
           layers.activeBackend ?? stubActiveAgentBackendLayer(),
@@ -231,10 +258,15 @@ describe("createPr", () => {
     expect(error).toBeInstanceOf(CreatePrInvalidWorktreeContextError)
   })
 
-  it("fails closed before GitHub access for a GitLab Repository", () =>
+  it("creates a draft GitLab MR without calling GitHub", () =>
     withTemp(async (root) => {
       let githubCalls = 0
-      let keymaxxerCalls = 0
+      let created: {
+        headRefName: string
+        title: string
+        body: string
+      } | null = null
+      const pushCommands: string[] = []
       let agentCalls = 0
       const gitlabDb = stubDbServiceLayer({
         listRepositories: Effect.succeed([
@@ -246,19 +278,49 @@ describe("createPr", () => {
           }),
         ]),
       })
+      const context = baseContext(root, {
+        issueNumber: 3601642,
+        publicationTitle: "feat: refresh tokens",
+        publicationBody: "Implements refresh.\n\nCloses #3601642",
+      })
+      const expectedBranch = workItemBranchName({
+        projectPath: "project/widgets",
+        issueNumber: 3601642,
+        workItemId: context.workItemId,
+      })
 
-      const error = await run(createPr(baseContext(root)).pipe(Effect.flip), {
+      const result = await run(createPr(context), {
         db: gitlabDb,
         github: stubGitHub({
           findOpenPullRequestNumber: () => {
             githubCalls += 1
             return Effect.succeed(null)
           },
+          createDraftPullRequest: () => {
+            githubCalls += 1
+            return Effect.succeed(1)
+          },
+        }),
+        gitlab: stubGitLab({
+          findOpenPullRequestNumber: () => Effect.succeed(null),
+          createDraftPullRequest: (_repository, input) => {
+            created = input
+            return Effect.succeed(91)
+          },
+          updateOpenDraftPullRequestCopy: () => Effect.succeed(91),
         }),
         keymaxxer: stubKeymaxxer({
-          findSecret: () => {
-            keymaxxerCalls += 1
+          enabled: true,
+          findSecret: (input) => {
+            expect(input).toEqual({
+              provider: "gitlab",
+              account: "git.drupalcode.org/project/widgets",
+            })
             return Effect.succeed("GITLAB_TOKEN_PROJECT_WIDGETS")
+          },
+          runWithSecrets: (input) => {
+            pushCommands.push(input.command)
+            return Effect.succeed({ exitCode: 0, stdout: "", stderr: "" })
           },
         }),
         opencode: stubOpencode({
@@ -272,13 +334,93 @@ describe("createPr", () => {
         }),
       })
 
-      expect(error).toBeInstanceOf(CreatePrPostconditionError)
-      expect((error as CreatePrPostconditionError).message).toContain(
-        "refusing to query GitHub for a GitLab Repository",
-      )
+      expect(result).toMatchObject({
+        pullRequestNumber: 91,
+        completion: "native",
+        publicationTitle: "feat: refresh tokens",
+        publicationBody: "Implements refresh.\n\nCloses #3601642",
+      })
+      expect(created).toEqual({
+        headRefName: expectedBranch,
+        title: "feat: refresh tokens",
+        body: "Implements refresh.\n\nCloses #3601642",
+      })
       expect(githubCalls).toBe(0)
-      expect(keymaxxerCalls).toBe(0)
       expect(agentCalls).toBe(0)
+      expect(pushCommands).toHaveLength(1)
+      const pushCommand = pushCommands[0]!
+      expect(pushCommand).toContain(
+        "https://git.drupalcode.org/project/widgets.git",
+      )
+      expect(pushCommand).not.toContain(" origin ")
+      expect(pushCommand).toContain("Authorization: Basic $BASIC")
+      // Real shell assignment before git — not BASIC=… git … $BASIC prefix form.
+      expect(pushCommand).toContain(')" && git ')
+    }))
+  it("reuses an existing exact-branch open GitLab MR without creation", () =>
+    withTemp(async (root) => {
+      let createCalls = 0
+      let githubCalls = 0
+      let reconciled: { title: string; body: string } | null = null
+      const gitlabDb = stubDbServiceLayer({
+        listRepositories: Effect.succeed([
+          makeRepositoryRecord({
+            forge: "gitlab",
+            forgeHost: "git.drupalcode.org",
+            projectPath: "project/widgets",
+            localPath: "/repos/project-widgets",
+          }),
+        ]),
+      })
+      const context = baseContext(root, {
+        issueNumber: 3601642,
+        publicationTitle: "feat: refresh tokens",
+        publicationBody: "Implements refresh.\n\nCloses #3601642",
+      })
+
+      const result = await run(createPr(context), {
+        db: gitlabDb,
+        github: stubGitHub({
+          findOpenPullRequestNumber: () => {
+            githubCalls += 1
+            return Effect.succeed(null)
+          },
+        }),
+        gitlab: stubGitLab({
+          findOpenPullRequestNumber: () => Effect.succeed(77),
+          createDraftPullRequest: () => {
+            createCalls += 1
+            return Effect.succeed(91)
+          },
+          updateOpenDraftPullRequestCopy: (_repository, _branch, input) => {
+            reconciled = input
+            return Effect.succeed(77)
+          },
+        }),
+        keymaxxer: stubKeymaxxer({
+          enabled: false,
+          findSecret: () => Effect.succeed(null),
+        }),
+        opencode: stubOpencode({
+          continueTurn: () =>
+            Effect.succeed({
+              sessionId: "ses_implement_session",
+              assistantText: "",
+            }),
+        }),
+      })
+
+      expect(result).toMatchObject({
+        pullRequestNumber: 77,
+        completion: "native",
+        publicationTitle: "feat: refresh tokens",
+      })
+      expect(createCalls).toBe(0)
+      expect(githubCalls).toBe(0)
+      expect(reconciled).toEqual({
+        title: "feat: refresh tokens",
+        body: "Implements refresh.\n\nCloses #3601642",
+      })
     }))
 
   it("reuses an existing exact-branch open PR without creation or Agent Turn", () =>

--- a/packages/work-item-lifecycle/test/remove-worktree.spec.ts
+++ b/packages/work-item-lifecycle/test/remove-worktree.spec.ts
@@ -6,6 +6,10 @@ import { Effect, Layer, type Layer as LayerType } from "effect"
 import { DatabaseTest } from "@ready-for-agent/db/test"
 import { DbService, DbServiceLive } from "@ready-for-agent/db-service"
 import {
+  GitLabService,
+  type GitLabServiceShape,
+} from "@ready-for-agent/gitlab-service"
+import {
   KeymaxxerError,
   KeymaxxerService,
   type KeymaxxerServiceShape,
@@ -39,6 +43,26 @@ const stubKeymaxxer = (
     ...overrides,
   })
 
+const stubGitLab = (
+  overrides: Partial<GitLabServiceShape> = {},
+): Layer.Layer<GitLabService> =>
+  Layer.succeed(GitLabService, {
+    verifyProject: () => Effect.void,
+    getAuthenticatedUserLogin: () => Effect.succeed("operator"),
+    listReadyIssues: () => Effect.succeed([]),
+    hasCredentials: () => Effect.succeed(true),
+    hasAmbientCredentials: () => Effect.succeed(true),
+    getOpenPullRequestNumber: () => Effect.succeed(1),
+    findOpenPullRequestNumber: () => Effect.succeed(null),
+    createDraftPullRequest: () => Effect.succeed(1),
+    updateOpenDraftPullRequestCopy: () => Effect.succeed(null),
+    countOpenNonDraftPullRequests: () => Effect.succeed(0),
+    ensureIssueCompletedWithSummary: () => Effect.void,
+    closeOpenPullRequestsForBranch: () => Effect.void,
+    deleteBranch: () => Effect.void,
+    ...overrides,
+  } satisfies GitLabServiceShape)
+
 const run = <A, E>(
   effect: Effect.Effect<
     A,
@@ -46,14 +70,17 @@ const run = <A, E>(
     | LayerType.Layer.Success<typeof PlatformLayer>
     | LayerType.Layer.Success<typeof DbServiceLive>
     | KeymaxxerService
+    | GitLabService
   >,
   keymaxxerLayer: Layer.Layer<KeymaxxerService> = stubKeymaxxer(),
+  gitlabLayer: Layer.Layer<GitLabService> = stubGitLab(),
 ): Promise<A> =>
   Effect.runPromise(
     effect.pipe(
       Effect.provide(DbServiceLive),
       Effect.provide(DatabaseTest),
       Effect.provide(keymaxxerLayer),
+      Effect.provide(gitlabLayer),
       Effect.provide(PlatformLayer),
     ),
   )
@@ -92,14 +119,16 @@ const initBareRepository = async (root: string) => {
 }
 
 describe("removeWorktree", () => {
-  it("fails closed before local or GitHub cleanup for a GitLab Repository", async () => {
+  it("cleans up GitLab remote MRs and branch via GitLabService", async () => {
     const root = await mkdtemp(join(tmpdir(), "rfa-rm-wt-gitlab-"))
     try {
       const bare = await initBareRepository(root)
       const workItemId = makeWorkItemId()
       let keymaxxerCalls = 0
+      const closedBranches: string[] = []
+      const deletedBranches: string[] = []
 
-      const { error, path, branch } = await run(
+      const { path, branch } = await run(
         Effect.gen(function* () {
           const db = yield* DbService
           const repository = yield* db.addRepository({
@@ -127,12 +156,11 @@ describe("removeWorktree", () => {
             sessionId: null,
           } as const
           const created = yield* createWorktree(context)
-          const error = yield* removeWorktree({
+          yield* removeWorktree({
             ...context,
             worktreePath: created.worktreePath,
-          }).pipe(Effect.flip)
+          })
           return {
-            error,
             path: created.worktreePath,
             branch: workItemBranchName({
               projectPath: "project/widgets",
@@ -151,14 +179,22 @@ describe("removeWorktree", () => {
             return Effect.succeed({ exitCode: 0, stdout: "[]", stderr: "" })
           },
         }),
+        stubGitLab({
+          closeOpenPullRequestsForBranch: (_repository, headRefName) =>
+            Effect.sync(() => {
+              closedBranches.push(headRefName)
+            }),
+          deleteBranch: (_repository, branchName) =>
+            Effect.sync(() => {
+              deletedBranches.push(branchName)
+            }),
+        }),
       )
 
-      expect(error).toBeInstanceOf(RemoveWorktreeRemoteError)
-      expect((error as RemoveWorktreeRemoteError).message).toContain(
-        "refusing to invoke GitHub cleanup for a GitLab Repository",
-      )
-      expect(await Bun.file(join(path, "README.md")).exists()).toBe(true)
-      expect(await git(bare, ["branch", "--list", branch])).toContain(branch)
+      expect(await Bun.file(join(path, "README.md")).exists()).toBe(false)
+      expect(await git(bare, ["branch", "--list", branch])).toBe("")
+      expect(closedBranches).toEqual([branch])
+      expect(deletedBranches).toEqual([branch])
       expect(keymaxxerCalls).toBe(0)
     } finally {
       await rm(root, { recursive: true, force: true })

--- a/packages/work-item-lifecycle/tsconfig.lib.json
+++ b/packages/work-item-lifecycle/tsconfig.lib.json
@@ -23,6 +23,9 @@
       "path": "../github-service/tsconfig.lib.json"
     },
     {
+      "path": "../gitlab-service/tsconfig.lib.json"
+    },
+    {
       "path": "../db-service/tsconfig.lib.json"
     },
     {


### PR DESCRIPTION
## Why

GitLab Repositories could reconcile Ready-labeled Issues and run local Agent
Turns, but remote publication still failed closed: Create PR refused to open a
draft MR, Close Issue would not post a No-Change summary, and cleanup would not
delete remote branches or leftover MRs. Changed-work Work Items could not
advance past Commit with a durable Work Item PR identity.

## What changed

- **GitLabService**: draft MR create/lookup/copy update, open non-draft MR
  counts, Close Issue (hidden work-item marker note + close), close open MRs
  for a branch, and delete branch (404 = success).
- **Create PR**: forge-routed GitLab path pushes the Work Item branch to
  `https://<forge-host>/<project-path>.git` with token auth (Keymaxxer or
  ambient) without modifying SSH origin; creates a draft MR using portable
  `Draft:` titles plus `draft: true`; records the MR iid as the Work Item PR.
- **Close Issue / Remove Worktree**: GitLab routes through the Forge service;
  leftover MRs close and the remote branch is deleted via API.
- **UI / GraphQL**: forge-aware issue (`/-/issues/`) and MR
  (`/-/merge_requests/`) URLs; open non-draft counts for GitLab Repositories.
- **Review remediations**: draft title prefix create/reconcile; title-aware
  draft filtering for counts; 60s glab token timeout; Keymaxxer push uses
  `BASIC=… && git` so Basic auth expands (not bash simple-command prefix).

Pipeline watching, ready-for-review, and merge remain fail-closed for GitLab
(later tickets).

## Verification

- `gitlab-service` unit tests (create draft, close issue, cleanup, counts)
- `work-item-lifecycle` suite including GitLab create-pr / close-issue /
  remove-worktree
- `graphql-api`, `issue-reconciler`, harness URL + ambient GitLab layer tests
- `harness:build`

## Limitations

- Ambient push still resolves `GITLAB_TOKEN` / host glab independently of the
  ambient layer's injected environment.
- Ambient GitLab push may place Basic auth material on the git process argv.
- Watch PR Status Checks does not observe GitLab pipelines yet; changed-work
  Work Items stop at that step until the next phase.

Closes #568