### PR TITLE
fix(harness): group Home/Kanban with Settings and soften nav selection

### DIFF
--- a/apps/harness/src/routes/__root.tsx
+++ b/apps/harness/src/routes/__root.tsx
@@ -172,12 +172,52 @@ function RootDocument({ children }: { children: ReactNode }) {
 // Shared layout only — Router merges className with active/inactive props, so
 // mutually exclusive visual utilities must not live on the base class string.
 const primaryNavLinkClassName =
-  "inline-flex items-center border px-3 py-1.5 text-xs font-semibold tracking-[0.14em] uppercase transition focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-oxblood"
+  "inline-flex items-center gap-2 border px-3 py-1.5 text-xs font-semibold tracking-[0.14em] uppercase transition focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-oxblood"
 
+// Inactive: muted gray-out; hover still reads as clickable.
 const primaryNavLinkInactiveClassName =
-  "border-rule-2 bg-panel text-ink-2 hover:border-ink-soft hover:bg-paper-2"
+  "border-rule-2 bg-panel text-ink-faint hover:border-ink-soft hover:bg-paper-2 hover:text-ink-2"
 
-const primaryNavLinkActiveClassName = "border-ink bg-ink text-paper"
+// Selected: restrained contrast (stronger border/text, light fill — not a solid ink pill).
+const primaryNavLinkActiveClassName = "border-ink bg-paper-2 text-ink"
+
+// Settings is a non-route action; keep it in the same family as inactive nav.
+const primaryNavActionClassName =
+  "inline-flex items-center gap-2 border border-rule-2 bg-panel px-3 py-1.5 text-xs font-semibold tracking-[0.14em] text-ink-faint uppercase transition hover:border-ink-soft hover:bg-paper-2 hover:text-ink-2 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-oxblood"
+
+function HomeNavIcon() {
+  return (
+    <svg
+      aria-hidden="true"
+      className="size-3.5"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+    >
+      <path d="M3 10.5 12 3l9 7.5" />
+      <path d="M5 9.5V21h14V9.5" />
+      <path d="M9 21v-6h6v6" />
+    </svg>
+  )
+}
+
+function KanbanNavIcon() {
+  return (
+    <svg
+      aria-hidden="true"
+      className="size-3.5"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+    >
+      <rect x="3.5" y="4" width="4.5" height="16" rx="0.5" />
+      <rect x="9.75" y="4" width="4.5" height="10" rx="0.5" />
+      <rect x="16" y="4" width="4.5" height="13" rx="0.5" />
+    </svg>
+  )
+}
 
 function RootComponent() {
   return (
@@ -204,26 +244,31 @@ function RootComponent() {
             {READY_FOR_AGENT_VERSION_LABEL}
           </span>
         </div>
-        <div className="flex items-center gap-2 self-center">
-          <Link
-            to="/"
-            activeOptions={{ exact: true }}
-            className={primaryNavLinkClassName}
-            inactiveProps={{ className: primaryNavLinkInactiveClassName }}
-            activeProps={{ className: primaryNavLinkActiveClassName }}
-          >
-            Home
-          </Link>
-          <Link
-            to="/kanban"
-            className={primaryNavLinkClassName}
-            inactiveProps={{ className: primaryNavLinkInactiveClassName }}
-            activeProps={{ className: primaryNavLinkActiveClassName }}
-          >
-            Kanban
-          </Link>
-        </div>
-        <SettingsButton />
+        <SettingsButton
+          leading={
+            <>
+              <Link
+                to="/"
+                activeOptions={{ exact: true }}
+                className={primaryNavLinkClassName}
+                inactiveProps={{ className: primaryNavLinkInactiveClassName }}
+                activeProps={{ className: primaryNavLinkActiveClassName }}
+              >
+                <HomeNavIcon />
+                Home
+              </Link>
+              <Link
+                to="/kanban"
+                className={primaryNavLinkClassName}
+                inactiveProps={{ className: primaryNavLinkInactiveClassName }}
+                activeProps={{ className: primaryNavLinkActiveClassName }}
+              >
+                <KanbanNavIcon />
+                Kanban
+              </Link>
+            </>
+          }
+        />
       </nav>
       <Outlet />
       <ReactQueryDevtools buttonPosition="bottom-left" />
@@ -232,7 +277,7 @@ function RootComponent() {
   )
 }
 
-function SettingsButton() {
+function SettingsButton({ leading }: { leading: ReactNode }) {
   const dialogRef = useRef<HTMLDialogElement>(null)
   const queryClient = useQueryClient()
   const [dialogOpen, setDialogOpen] = useState(false)
@@ -675,25 +720,30 @@ function SettingsButton() {
           </button>
         </div>
       )}
-      <button
-        type="button"
-        className="ml-auto inline-flex items-center gap-2 border border-rule-2 bg-panel px-3 py-1.5 text-xs font-semibold tracking-[0.14em] text-ink-2 uppercase transition hover:border-ink-soft hover:bg-paper-2 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-oxblood"
-        onClick={openSettings}
-        aria-haspopup="dialog"
-      >
-        <svg
-          aria-hidden="true"
-          className="size-3.5"
-          viewBox="0 0 24 24"
-          fill="none"
-          stroke="currentColor"
-          strokeWidth="2"
+      {/* Home / Kanban / Settings share one right-aligned control cluster.
+          Status banners above stay nav-level siblings (outside the cluster). */}
+      <div className="ml-auto flex items-center gap-2 self-center">
+        {leading}
+        <button
+          type="button"
+          className={primaryNavActionClassName}
+          onClick={openSettings}
+          aria-haspopup="dialog"
         >
-          <path d="M12 15.5a3.5 3.5 0 1 0 0-7 3.5 3.5 0 0 0 0 7Z" />
-          <path d="M19.4 15a1.7 1.7 0 0 0 .34 1.88l.06.06-2.83 2.83-.06-.06a1.7 1.7 0 0 0-1.88-.34 1.7 1.7 0 0 0-1.03 1.56V21h-4v-.08A1.7 1.7 0 0 0 8.94 19.4a1.7 1.7 0 0 0-1.88.34l-.06.06-2.83-2.83.06-.06A1.7 1.7 0 0 0 4.57 15 1.7 1.7 0 0 0 3 14H3v-4h.08A1.7 1.7 0 0 0 4.6 8.94a1.7 1.7 0 0 0-.34-1.88L4.2 7l2.83-2.83.06.06A1.7 1.7 0 0 0 9 4.57 1.7 1.7 0 0 0 10 3V3h4v.08A1.7 1.7 0 0 0 15.06 4.6a1.7 1.7 0 0 0 1.88-.34L17 4.2 19.83 7l-.06.06A1.7 1.7 0 0 0 19.43 9 1.7 1.7 0 0 0 21 10h.08v4H21a1.7 1.7 0 0 0-1.6 1Z" />
-        </svg>
-        Settings
-      </button>
+          <svg
+            aria-hidden="true"
+            className="size-3.5"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+          >
+            <path d="M12 15.5a3.5 3.5 0 1 0 0-7 3.5 3.5 0 0 0 0 7Z" />
+            <path d="M19.4 15a1.7 1.7 0 0 0 .34 1.88l.06.06-2.83 2.83-.06-.06a1.7 1.7 0 0 0-1.88-.34 1.7 1.7 0 0 0-1.03 1.56V21h-4v-.08A1.7 1.7 0 0 0 8.94 19.4a1.7 1.7 0 0 0-1.88.34l-.06.06-2.83-2.83.06-.06A1.7 1.7 0 0 0 4.57 15 1.7 1.7 0 0 0 3 14H3v-4h.08A1.7 1.7 0 0 0 4.6 8.94a1.7 1.7 0 0 0-.34-1.88L4.2 7l2.83-2.83.06.06A1.7 1.7 0 0 0 9 4.57 1.7 1.7 0 0 0 10 3V3h4v.08A1.7 1.7 0 0 0 15.06 4.6a1.7 1.7 0 0 0 1.88-.34L17 4.2 19.83 7l-.06.06A1.7 1.7 0 0 0 19.43 9 1.7 1.7 0 0 0 21 10h.08v4H21a1.7 1.7 0 0 0-1.6 1Z" />
+          </svg>
+          Settings
+        </button>
+      </div>
 
       <dialog
         ref={dialogRef}

--- a/apps/harness/test/primary-nav.test.ts
+++ b/apps/harness/test/primary-nav.test.ts
@@ -11,8 +11,71 @@ describe("primary Home / Kanban navigation", () => {
     expect(source).toContain('aria-label="Primary"')
     expect(source).toContain('to="/"')
     expect(source).toContain('to="/kanban"')
-    expect(source).toMatch(/>\s*Home\s*<\/Link>/)
-    expect(source).toMatch(/>\s*Kanban\s*<\/Link>/)
+    expect(source).toMatch(/Home\s*<\/Link>/)
+    expect(source).toMatch(/Kanban\s*<\/Link>/)
+  })
+
+  test("groups Home, Kanban, and Settings in one right-aligned control cluster", () => {
+    const source = rootSource()
+    const clusterMarker =
+      'className="ml-auto flex items-center gap-2 self-center"'
+    expect(source).toContain(clusterMarker)
+    // ml-auto lives on the group, not only on Settings.
+    expect(source).not.toMatch(
+      /className="ml-auto inline-flex items-center gap-2 border/,
+    )
+
+    // Home and Kanban are passed as leading into SettingsButton (same cluster).
+    const settingsBlock = source.slice(
+      source.indexOf("<SettingsButton"),
+      source.indexOf("</nav>"),
+    )
+    expect(settingsBlock).toContain("leading={")
+    expect(settingsBlock).toContain('to="/"')
+    expect(settingsBlock).toContain('to="/kanban"')
+    expect(settingsBlock).toContain("<HomeNavIcon />")
+    expect(settingsBlock).toContain("<KanbanNavIcon />")
+    const homeIdx = settingsBlock.indexOf('to="/"')
+    const kanbanIdx = settingsBlock.indexOf('to="/kanban"')
+    expect(homeIdx).toBeGreaterThan(-1)
+    expect(kanbanIdx).toBeGreaterThan(homeIdx)
+
+    // Cluster wraps leading destinations and the Settings trigger.
+    const clusterStart = source.indexOf(
+      '<div className="ml-auto flex items-center gap-2 self-center">',
+    )
+    expect(clusterStart).toBeGreaterThan(-1)
+    const cluster = source.slice(
+      clusterStart,
+      source.indexOf("</div>", clusterStart),
+    )
+    expect(cluster).toContain("{leading}")
+    expect(cluster).toContain("Settings")
+    expect(cluster).toContain("primaryNavActionClassName")
+
+    // Brand title stays outside the action cluster (left side).
+    const brandIdx = source.indexOf("Clanker Harness")
+    expect(brandIdx).toBeGreaterThan(-1)
+    expect(brandIdx).toBeLessThan(source.indexOf("<SettingsButton"))
+  })
+
+  test("Home and Kanban use stroke icons matching Settings icon language", () => {
+    const source = rootSource()
+    expect(source).toContain("function HomeNavIcon()")
+    expect(source).toContain("function KanbanNavIcon()")
+    expect(source).toContain("<HomeNavIcon />")
+    expect(source).toContain("<KanbanNavIcon />")
+    // Icons: aria-hidden, size-3.5, stroke currentColor (same as Settings gear).
+    for (const iconFn of ["HomeNavIcon", "KanbanNavIcon"] as const) {
+      const start = source.indexOf(`function ${iconFn}(`)
+      expect(start).toBeGreaterThan(-1)
+      const body = source.slice(start, source.indexOf("\n}", start) + 2)
+      expect(body).toContain('aria-hidden="true"')
+      expect(body).toContain('className="size-3.5"')
+      expect(body).toContain('stroke="currentColor"')
+      expect(body).toContain('strokeWidth="2"')
+      expect(body).toContain('fill="none"')
+    }
   })
 
   test("uses TanStack Router Link with active route styling", () => {
@@ -28,9 +91,9 @@ describe("primary Home / Kanban navigation", () => {
       "activeProps={{ className: primaryNavLinkActiveClassName }}",
     )
     // Home nav control (not the brand title Link) must use exact matching.
-    // Slice from the switcher container through the first destination only.
+    // Slice from the SettingsButton leading prop through the first destination.
     const homeSwitcherLink = source.slice(
-      source.indexOf('<div className="flex items-center gap-2 self-center">'),
+      source.indexOf("leading={"),
       source.indexOf('to="/kanban"'),
     )
     expect(homeSwitcherLink).toContain('to="/"')
@@ -49,16 +112,32 @@ describe("primary Home / Kanban navigation", () => {
       "border-rule-2",
       "bg-panel",
       "text-ink-2",
+      "text-ink-faint",
+      "text-ink",
+      "bg-paper-2",
       "hover:border-ink-soft",
       "hover:bg-paper-2",
+      "hover:text-ink-2",
     ]) {
       expect(sharedClasses.split(/\s+/)).not.toContain(exclusive)
     }
+    // Shared layout includes icon gap so label + icon share one baseline.
+    expect(sharedClasses.split(/\s+/)).toContain("gap-2")
     expect(source).toContain(
-      'const primaryNavLinkInactiveClassName =\n  "border-rule-2 bg-panel text-ink-2 hover:border-ink-soft hover:bg-paper-2"',
+      'const primaryNavLinkInactiveClassName =\n  "border-rule-2 bg-panel text-ink-faint hover:border-ink-soft hover:bg-paper-2 hover:text-ink-2"',
     )
+    // Soft selected state — not the old solid black/ink filled pill.
     expect(source).toContain(
+      'const primaryNavLinkActiveClassName = "border-ink bg-paper-2 text-ink"',
+    )
+    expect(source).not.toContain(
       'const primaryNavLinkActiveClassName = "border-ink bg-ink text-paper"',
+    )
+    // Settings stays in the inactive-nav visual family (not a selected route).
+    expect(source).toContain("primaryNavActionClassName")
+    expect(source).toContain("className={primaryNavActionClassName}")
+    expect(source).toMatch(
+      /const primaryNavActionClassName =\s*\n?\s*"[^"]*text-ink-faint[^"]*"/,
     )
     // Both destinations are client Links, not raw <a href> only.
     expect(source).not.toMatch(/<a\s+href=["']\/kanban["']/)
@@ -71,8 +150,8 @@ describe("primary Home / Kanban navigation", () => {
       source.indexOf("function RootComponent("),
     )
     expect(rootComponent).toContain('to="/kanban"')
-    expect(rootComponent).toMatch(/>\s*Home\s*<\/Link>/)
-    expect(rootComponent).toMatch(/>\s*Kanban\s*<\/Link>/)
+    expect(rootComponent).toMatch(/Home\s*<\/Link>/)
+    expect(rootComponent).toMatch(/Kanban\s*<\/Link>/)
     expect(rootComponent).toContain("<Outlet />")
     expect(rootComponent.indexOf("Home")).toBeLessThan(
       rootComponent.indexOf("<Outlet />"),

--- a/packages/work-item-lifecycle/tsconfig.lib.json
+++ b/packages/work-item-lifecycle/tsconfig.lib.json
@@ -23,9 +23,6 @@
       "path": "../github-service/tsconfig.lib.json"
     },
     {
-      "path": "../gitlab-service/tsconfig.lib.json"
-    },
-    {
       "path": "../db-service/tsconfig.lib.json"
     },
     {


### PR DESCRIPTION
Why

Primary chrome put Home and Kanban as a mid-header pair of heavy pills next
to the brand title, while Settings sat alone on the far right with a gear
icon. That split read as two control systems, and the solid black selected
pill was louder than needed.

What changed

- Home, Kanban, and Settings share one right-aligned control cluster
  (ml-auto on the group); brand/title stays left.
- Home and Kanban get stroke icons (size-3.5, currentColor) matching
  Settings gear language, with labels kept for scanability.
- Selected route uses a restrained treatment (border-ink bg-paper-2
  text-ink); inactive destinations mute to text-ink-faint with clearer
  hover. Settings stays in the inactive visual family (non-route action).
- Router behavior is unchanged: TanStack Link + activeProps/inactiveProps,
  Home still uses exact active matching.
- Status banners from Settings remain outside the cluster so they do not
  break the control row.
- primary-nav source tests updated for cluster layout, icons, and softer
  tokens.
- Incidental nx typescript-sync cleanup: remove a duplicate gitlab-service
  project reference in work-item-lifecycle (one valid reference remains).

Verification

- bun test apps/harness/test/primary-nav.test.ts
- bunx nx test harness (full package suite)
- bunx biome check on touched files
- bunx nx sync:check after the project-reference cleanup
- Pre-commit (git hook run pre-commit) pass after staging

Notes / limitations

- No route, Kanban board, or Settings dialog behavior changes.
- Low-severity structure nits (dedicated primary-nav cluster component,
  shared muted class token, slightly less brittle cluster test slice)
  were deferred as optional follow-up.

Closes #617