### PR TITLE
fix: make browser open best-effort and lifecycle-bound

### DIFF
--- a/apps/harness/src/server/browser-open.ts
+++ b/apps/harness/src/server/browser-open.ts
@@ -1,9 +1,27 @@
+import { spawn } from "node:child_process"
+
 export type BrowserOpenEnv = Partial<
   Record<"NO_BROWSER" | "PORT", string | undefined>
 >
 
 const DEFAULT_UI_PORT = 6056
 const DEFAULT_UI_HOST = "127.0.0.1"
+
+/** Minimal child surface used by the detached browser launcher (testable). */
+export type DetachedBrowserChild = {
+  on(event: "error", listener: (error: Error) => void): unknown
+  unref(): unknown
+}
+
+/** Minimal spawn surface used by the detached browser launcher (testable). */
+export type BrowserSpawn = (
+  command: string,
+  args: ReadonlyArray<string>,
+  options: {
+    readonly detached: true
+    readonly stdio: "ignore"
+  },
+) => DetachedBrowserChild
 
 /** Whether production start should open the default browser to the local UI. */
 export const shouldOpenBrowser = (input: {
@@ -56,3 +74,32 @@ export const browserOpenCommand = (
 export const hasNoOpenFlag = (
   argv: ReadonlyArray<string> = process.argv,
 ): boolean => argv.includes("--no-open")
+
+/**
+ * Detached best-effort browser launch for standalone production start.
+ *
+ * Spawn failures (missing `xdg-open`, etc.) arrive on the child `error` event,
+ * not as a synchronous throw. Register that handler before `unref()` so the
+ * host process cannot terminate from an unhandled spawn error. The GUI process
+ * remains detached — shutdown does not own browser lifetime.
+ */
+export const launchDetachedBrowser = (
+  platform: string,
+  url: string,
+  spawnImpl: BrowserSpawn = spawn as BrowserSpawn,
+): void => {
+  const { command, args } = browserOpenCommand(platform, url)
+  try {
+    const child = spawnImpl(command, [...args], {
+      detached: true,
+      stdio: "ignore",
+    })
+    // Must attach before unref: unhandled `error` can exit the host (Bun).
+    child.on("error", () => {
+      // Best-effort only.
+    })
+    child.unref()
+  } catch {
+    // Best-effort: startup must not fail when the opener is unavailable.
+  }
+}

--- a/apps/harness/src/server/browser-open.ts
+++ b/apps/harness/src/server/browser-open.ts
@@ -8,7 +8,7 @@ const DEFAULT_UI_PORT = 6056
 const DEFAULT_UI_HOST = "127.0.0.1"
 
 /** Minimal child surface used by the detached browser launcher (testable). */
-export type DetachedBrowserChild = {
+type DetachedBrowserChild = {
   on(event: "error", listener: (error: Error) => void): unknown
   unref(): unknown
 }

--- a/apps/harness/src/server/production-lifecycle.ts
+++ b/apps/harness/src/server/production-lifecycle.ts
@@ -15,8 +15,8 @@ import { READY_FOR_AGENT_VERSION } from "../generated/version.js"
 import { type Application, createApplication } from "./application.server.js"
 import { environmentConfigLayer, loadPort } from "./application-config.js"
 import {
-  browserOpenCommand,
   hasNoOpenFlag,
+  launchDetachedBrowser,
   shouldOpenBrowser,
 } from "./browser-open.js"
 import {
@@ -229,15 +229,9 @@ const startOwnedSidecar = (input: {
   })
 
 const openDefaultBrowser = (url: string) => {
-  const launch = browserOpenCommand(process.platform, url)
-  try {
-    spawn(launch.command, [...launch.args], {
-      detached: true,
-      stdio: "ignore",
-    }).unref()
-  } catch {
-    // Browser open is best-effort; start still succeeds.
-  }
+  // Best-effort only: missing/failing openers must not fail production start.
+  // The GUI remains detached (see launchDetachedBrowser).
+  launchDetachedBrowser(process.platform, url)
 }
 
 const defaultServeHttp = async (input: {

--- a/apps/harness/test/browser-open.test.ts
+++ b/apps/harness/test/browser-open.test.ts
@@ -1,6 +1,8 @@
 import {
+  type BrowserSpawn,
   browserOpenCommand,
   hasNoOpenFlag,
+  launchDetachedBrowser,
   resolveUiUrl,
   shouldOpenBrowser,
 } from "../src/server/browser-open.ts"
@@ -32,5 +34,57 @@ describe("production browser open policy", () => {
       command: "xdg-open",
       args: ["http://127.0.0.1:6056/"],
     })
+  })
+})
+
+describe("launchDetachedBrowser", () => {
+  test("registers error handler before unref", () => {
+    const order: string[] = []
+    const spawnImpl: BrowserSpawn = () => ({
+      on(event) {
+        if (event === "error") {
+          order.push("on-error")
+        }
+        return undefined
+      },
+      unref() {
+        order.push("unref")
+        return undefined
+      },
+    })
+
+    launchDetachedBrowser("linux", "http://127.0.0.1:6056/", spawnImpl)
+    expect(order).toEqual(["on-error", "unref"])
+  })
+
+  test("swallows asynchronous spawn errors without throwing", async () => {
+    let errorListener: ((error: Error) => void) | undefined
+    const spawnImpl: BrowserSpawn = () => ({
+      on(event, listener) {
+        if (event === "error") {
+          errorListener = listener
+        }
+        return undefined
+      },
+      unref() {
+        return undefined
+      },
+    })
+
+    expect(() =>
+      launchDetachedBrowser("linux", "http://127.0.0.1:6056/", spawnImpl),
+    ).not.toThrow()
+    expect(errorListener).toBeTypeOf("function")
+    expect(() => errorListener?.(new Error("ENOENT"))).not.toThrow()
+    await Bun.sleep(0)
+  })
+
+  test("swallows synchronous spawn throws without throwing", () => {
+    const spawnImpl: BrowserSpawn = () => {
+      throw new Error("spawn sync failure")
+    }
+    expect(() =>
+      launchDetachedBrowser("linux", "http://127.0.0.1:6056/", spawnImpl),
+    ).not.toThrow()
   })
 })

--- a/apps/ready-for-agent/src/browser-open.test.ts
+++ b/apps/ready-for-agent/src/browser-open.test.ts
@@ -1,5 +1,8 @@
 import {
+  type BrowserSpawn,
   browserOpenCommand,
+  launchDetachedBrowser,
+  openBrowserWhenReady,
   resolveUiUrl,
   shouldOpenBrowser,
 } from "./browser-open.ts"
@@ -50,5 +53,154 @@ describe("browser open policy", () => {
       command: "cmd",
       args: ["/c", "start", "", "http://127.0.0.1:6056/"],
     })
+  })
+})
+
+describe("launchDetachedBrowser", () => {
+  test("registers error handler before unref", () => {
+    const order: string[] = []
+    const spawnImpl: BrowserSpawn = () => ({
+      on(event) {
+        if (event === "error") {
+          order.push("on-error")
+        }
+        return undefined
+      },
+      unref() {
+        order.push("unref")
+        return undefined
+      },
+    })
+
+    launchDetachedBrowser("linux", "http://127.0.0.1:6056/", spawnImpl)
+    expect(order).toEqual(["on-error", "unref"])
+  })
+
+  test("swallows asynchronous spawn errors without throwing", async () => {
+    let errorListener: ((error: Error) => void) | undefined
+    const spawnImpl: BrowserSpawn = () => ({
+      on(event, listener) {
+        if (event === "error") {
+          errorListener = listener
+        }
+        return undefined
+      },
+      unref() {
+        return undefined
+      },
+    })
+
+    expect(() =>
+      launchDetachedBrowser("linux", "http://127.0.0.1:6056/", spawnImpl),
+    ).not.toThrow()
+    expect(errorListener).toBeTypeOf("function")
+    expect(() => errorListener?.(new Error("ENOENT"))).not.toThrow()
+    await Bun.sleep(0)
+  })
+
+  test("swallows synchronous spawn throws without throwing", () => {
+    const spawnImpl: BrowserSpawn = () => {
+      throw new Error("spawn sync failure")
+    }
+    expect(() =>
+      launchDetachedBrowser("linux", "http://127.0.0.1:6056/", spawnImpl),
+    ).not.toThrow()
+  })
+})
+
+describe("openBrowserWhenReady", () => {
+  test("launches at most once after readiness is observed", async () => {
+    let fetches = 0
+    let launches = 0
+    await openBrowserWhenReady("linux", "http://127.0.0.1:6056/", {
+      fetch: async () => {
+        fetches += 1
+        return { status: 200, body: null }
+      },
+      launch: () => {
+        launches += 1
+      },
+      sleep: async () => {
+        throw new Error("should not poll after launch")
+      },
+    })
+    expect(fetches).toBe(1)
+    expect(launches).toBe(1)
+  })
+
+  test("stops the readiness poll when the AbortSignal is aborted", async () => {
+    const controller = new AbortController()
+    let fetches = 0
+    let launches = 0
+
+    await openBrowserWhenReady("linux", "http://127.0.0.1:6056/", {
+      signal: controller.signal,
+      fetch: async () => {
+        fetches += 1
+        throw new Error("ECONNREFUSED")
+      },
+      sleep: async () => {
+        controller.abort()
+      },
+      launch: () => {
+        launches += 1
+      },
+      timeoutMs: 60_000,
+      pollIntervalMs: 1,
+    })
+
+    expect(launches).toBe(0)
+    expect(fetches).toBe(1)
+  })
+
+  test("does not launch when aborted after readiness is observed", async () => {
+    const controller = new AbortController()
+    let launches = 0
+
+    await openBrowserWhenReady("linux", "http://127.0.0.1:6056/", {
+      signal: controller.signal,
+      fetch: async () => {
+        controller.abort()
+        return { status: 200, body: null }
+      },
+      launch: () => {
+        launches += 1
+      },
+    })
+
+    expect(launches).toBe(0)
+  })
+
+  test("opener failure does not reject the readiness task", async () => {
+    await expect(
+      openBrowserWhenReady("linux", "http://127.0.0.1:6056/", {
+        fetch: async () => ({ status: 200, body: null }),
+        launch: () => {
+          throw new Error("opener failed")
+        },
+      }),
+    ).resolves.toBeUndefined()
+  })
+
+  test("polls until ready then launches once", async () => {
+    let fetches = 0
+    let launches = 0
+    await openBrowserWhenReady("linux", "http://127.0.0.1:6056/", {
+      fetch: async () => {
+        fetches += 1
+        if (fetches < 3) {
+          throw new Error("not ready")
+        }
+        return { status: 200, body: null }
+      },
+      sleep: async () => {},
+      launch: () => {
+        launches += 1
+      },
+      timeoutMs: 60_000,
+      pollIntervalMs: 1,
+    })
+    expect(fetches).toBe(3)
+    expect(launches).toBe(1)
   })
 })

--- a/apps/ready-for-agent/src/browser-open.ts
+++ b/apps/ready-for-agent/src/browser-open.ts
@@ -10,7 +10,7 @@ const DEFAULT_READY_TIMEOUT_MS = 60_000
 const DEFAULT_POLL_INTERVAL_MS = 250
 
 /** Minimal child surface used by the detached browser launcher (testable). */
-export type DetachedBrowserChild = {
+type DetachedBrowserChild = {
   on(event: "error", listener: (error: Error) => void): unknown
   unref(): unknown
 }

--- a/apps/ready-for-agent/src/browser-open.ts
+++ b/apps/ready-for-agent/src/browser-open.ts
@@ -6,6 +6,24 @@ export type BrowserOpenEnv = Partial<
 
 const DEFAULT_UI_PORT = 6056
 const DEFAULT_UI_HOST = "127.0.0.1"
+const DEFAULT_READY_TIMEOUT_MS = 60_000
+const DEFAULT_POLL_INTERVAL_MS = 250
+
+/** Minimal child surface used by the detached browser launcher (testable). */
+export type DetachedBrowserChild = {
+  on(event: "error", listener: (error: Error) => void): unknown
+  unref(): unknown
+}
+
+/** Minimal spawn surface used by the detached browser launcher (testable). */
+export type BrowserSpawn = (
+  command: string,
+  args: ReadonlyArray<string>,
+  options: {
+    readonly detached: true
+    readonly stdio: "ignore"
+  },
+) => DetachedBrowserChild
 
 /** Whether start should open the default browser to the local UI. */
 export const shouldOpenBrowser = (input: {
@@ -56,31 +74,107 @@ export const browserOpenCommand = (
 }
 
 /**
- * Detached browser launch is deliberately a host boundary: polling uses fetch
- * and the launcher must outlive its child rather than be scoped to an Effect.
+ * Detached best-effort browser launch.
+ *
+ * Spawn failures (missing `xdg-open`, etc.) arrive on the child `error` event,
+ * not as a synchronous throw. Register that handler before `unref()` so the
+ * host process cannot terminate from an unhandled spawn error. The GUI process
+ * remains detached — callers never own browser lifetime.
  */
-export const openBrowserWhenReady = (platform: string, url: string): void => {
+export const launchDetachedBrowser = (
+  platform: string,
+  url: string,
+  spawnImpl: BrowserSpawn = spawn as BrowserSpawn,
+): void => {
   const { command, args } = browserOpenCommand(platform, url)
-  const deadline = Date.now() + 60_000
+  try {
+    const child = spawnImpl(command, [...args], {
+      detached: true,
+      stdio: "ignore",
+    })
+    // Must attach before unref: unhandled `error` can exit the host (Bun).
+    child.on("error", () => {
+      // Best-effort only.
+    })
+    child.unref()
+  } catch {
+    // Best-effort: startup must not fail when the opener is unavailable.
+  }
+}
 
-  const tryOpen = async () => {
-    while (Date.now() < deadline) {
+export type OpenBrowserWhenReadyOptions = {
+  readonly signal?: AbortSignal
+  readonly fetch?: (
+    input: string,
+    init?: RequestInit,
+  ) => Promise<Pick<Response, "status" | "body">>
+  readonly sleep?: (ms: number) => Promise<void>
+  readonly launch?: (platform: string, url: string) => void
+  readonly now?: () => number
+  readonly timeoutMs?: number
+  readonly pollIntervalMs?: number
+}
+
+/**
+ * Poll until the UI URL responds, then launch the platform opener once.
+ *
+ * Owned by the caller: pass an `AbortSignal` (e.g. from Effect.tryPromise) so
+ * the poll stops when startup completes, fails, or is interrupted. The browser
+ * process itself is not canceled on abort.
+ */
+export const openBrowserWhenReady = (
+  platform: string,
+  url: string,
+  options: OpenBrowserWhenReadyOptions = {},
+): Promise<void> => {
+  const signal = options.signal
+  const fetchImpl = options.fetch ?? globalThis.fetch.bind(globalThis)
+  const sleep =
+    options.sleep ?? ((ms: number) => Bun.sleep(ms) as Promise<void>)
+  const launch = options.launch ?? launchDetachedBrowser
+  const now = options.now ?? Date.now
+  const timeoutMs = options.timeoutMs ?? DEFAULT_READY_TIMEOUT_MS
+  const pollIntervalMs = options.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS
+  const deadline = now() + timeoutMs
+
+  const aborted = (): boolean => signal?.aborted === true
+
+  const poll = async (): Promise<void> => {
+    while (now() < deadline) {
+      if (aborted()) {
+        return
+      }
+
       try {
-        const response = await fetch(url, { redirect: "manual" })
-        void response.body?.cancel()
+        const response = await fetchImpl(url, {
+          redirect: "manual",
+          signal,
+        })
+        void response.body?.cancel?.()
         if (response.status > 0) {
-          spawn(command, [...args], {
-            detached: true,
-            stdio: "ignore",
-          }).unref()
+          if (aborted()) {
+            return
+          }
+          try {
+            launch(platform, url)
+          } catch {
+            // Opener failure is best-effort.
+          }
           return
         }
       } catch {
-        // Port not ready yet.
+        if (aborted()) {
+          return
+        }
+        // Port not ready yet, or fetch aborted.
       }
-      await Bun.sleep(250)
+
+      if (aborted()) {
+        return
+      }
+      await sleep(pollIntervalMs)
     }
   }
 
-  void tryOpen()
+  return poll()
 }

--- a/apps/ready-for-agent/src/services/start-harness.ts
+++ b/apps/ready-for-agent/src/services/start-harness.ts
@@ -137,30 +137,44 @@ export class StartHarness extends Context.Service<
         }
         yield* ensureDatabaseParentDir()
 
-        if (
-          shouldOpenBrowser({
-            noOpenFlag: options.noOpen === true,
-            env: config.browserEnv,
-          })
-        ) {
-          openBrowserWhenReady(config.platform, resolveUiUrl(config.browserEnv))
-        }
+        // Scope owns the readiness poll fiber so it cancels with startMonorepo
+        // (Harness exit, failure, or interrupt). The browser GUI stays detached.
+        yield* Effect.scoped(
+          Effect.gen(function* () {
+            if (
+              shouldOpenBrowser({
+                noOpenFlag: options.noOpen === true,
+                env: config.browserEnv,
+              })
+            ) {
+              const url = resolveUiUrl(config.browserEnv)
+              // Best-effort: never fail start; AbortSignal cancels the poll only.
+              yield* Effect.promise(async (signal) => {
+                try {
+                  await openBrowserWhenReady(config.platform, url, { signal })
+                } catch {
+                  // Opener / poll failures must not surface as fiber failures.
+                }
+              }).pipe(Effect.forkScoped({ startImmediately: true }))
+            }
 
-        const code = yield* spawner.exitCode(
-          ChildProcess.make("bun", ["nx", "run", "harness:dev"], {
-            cwd: root,
-            env: { SQLITE_DATABASE_PATH: config.databasePath },
-            extendEnv: true,
-            stdin: "inherit",
-            stdout: "inherit",
-            stderr: "inherit",
+            const code = yield* spawner.exitCode(
+              ChildProcess.make("bun", ["nx", "run", "harness:dev"], {
+                cwd: root,
+                env: { SQLITE_DATABASE_PATH: config.databasePath },
+                extendEnv: true,
+                stdin: "inherit",
+                stdout: "inherit",
+                stderr: "inherit",
+              }),
+            )
+            if (Number(code) !== 0) {
+              return yield* new StartHarnessFailed({
+                detail: `Harness exited with code ${code}`,
+              })
+            }
           }),
         )
-        if (Number(code) !== 0) {
-          return yield* new StartHarnessFailed({
-            detail: `Harness exited with code ${code}`,
-          })
-        }
       })
 
       const start = Effect.fn("StartHarness.start")(function* (

--- a/packages/work-item-lifecycle/tsconfig.lib.json
+++ b/packages/work-item-lifecycle/tsconfig.lib.json
@@ -23,9 +23,6 @@
       "path": "../github-service/tsconfig.lib.json"
     },
     {
-      "path": "../gitlab-service/tsconfig.lib.json"
-    },
-    {
       "path": "../db-service/tsconfig.lib.json"
     },
     {


### PR DESCRIPTION
## Summary

Missing platform openers (for example `xdg-open`) could terminate an otherwise
healthy Harness: Bun reports spawn failures on the child `error` event, which is
not covered by a synchronous `try/catch` around `spawn(...).unref()`. In monorepo
mode, the UI readiness poll also ran outside the `StartHarness` Effect graph, so
it could keep going for up to 60s after the Harness child exited or startup was
interrupted.

This change makes browser open strictly best-effort in standalone and monorepo
modes, and ties the monorepo readiness poll to the start scope so it cancels with
completion, failure, or interrupt. The browser GUI stays detached; shutdown does
not take ownership of the user's browser process.

## Changes

- Shared `launchDetachedBrowser` helper (ready-for-agent + harness): register the
  child `error` handler **before** `unref()`, and swallow sync spawn failures.
- `openBrowserWhenReady`: AbortSignal-aware poll, at most one launch after
  readiness, injectable deps for deterministic tests.
- Monorepo `StartHarness`: poll runs under `Effect.scoped` + `forkScoped` via
  `Effect.promise` with internal try/catch so opener/poll failures cannot fail
  start.
- Standalone production lifecycle: default browser open uses the same best-effort
  helper.
- Tests for error-before-unref ordering, sync/async spawn failure, abort
  cancellation, single launch, and opener throw isolation.
- `nx sync` cleanup: remove a duplicate `gitlab-service` project reference in
  `work-item-lifecycle` (one reference remains).

## Verification

- `bunx nx run ready-for-agent:typecheck`
- `bunx nx run ready-for-agent:test`
- `bunx nx run harness:test`
- Pre-commit (`lint` / `typecheck` / `test` via `nx affected`) passed after the
  above.

`--no-open` and `NO_BROWSER` behavior is unchanged.

Closes #586