### PR TITLE
fix(harness): hide job Reset on completed history

### DIFF
--- a/apps/harness/src/routes/index.tsx
+++ b/apps/harness/src/routes/index.tsx
@@ -46,6 +46,7 @@ import {
 } from "../refresh-work-items-live.js"
 import { sessionWorktreeParts } from "../session-worktree-line.js"
 import { workItemIssueUrl } from "../work-item-issue-url.js"
+import { canShowWorkItemResetAction } from "../work-item-job-actions.js"
 import { WorkItemOutcomePresentation } from "../work-item-outcome-presentation.js"
 import {
   lifecycleStepChipClassName,
@@ -3857,8 +3858,14 @@ export function WorkItemLifecycleStatus({
     workItem.state === "INVESTIGATE_PR_STATUS_CHECKS" ||
     (workItem.canRetry &&
       workItem.lifecycleLabels.at(-1)?.phase === "GITHUB_STATUS_CHECKS")
-  // Reset is the cancel affordance for held Queue rows (and compact jobs generally).
-  const canReset = compact
+  // Reset cancels/deletes a Work Item (history + worktree). Compact non-terminal
+  // cards (held Queue and other unfinished work) keep it; Completed/Failed
+  // terminal history never does. Needs Human stays on Working and keeps cancel.
+  const canReset = canShowWorkItemResetAction({
+    compact,
+    isTerminal: workItem.isTerminal,
+    isNeedsHuman: status === "NEEDS_HUMAN",
+  })
   const dataUpdatedAt = queryClient
     .getQueriesData({ queryKey: ["work-items", workItem.repositoryId] })
     .reduce(

--- a/apps/harness/src/work-item-job-actions.ts
+++ b/apps/harness/src/work-item-job-actions.ts
@@ -1,0 +1,20 @@
+/**
+ * Jobs / Kanban action visibility for Work Item lifecycle controls.
+ *
+ * Reset deletes the Work Item, its step-run history, and its worktree. It is a
+ * cancel affordance for unfinished compact cards (held Queue rows and other
+ * active work), not for completed/failed terminal history.
+ *
+ * Needs Human is a terminal lifecycle state but remains on the Working tab; keep
+ * Reset there so operators can clear a stuck handoff when Retry is unavailable.
+ * Callers pass `isNeedsHuman` from domain state/status (not a free-form string).
+ */
+export function canShowWorkItemResetAction(args: {
+  readonly compact: boolean
+  readonly isTerminal: boolean
+  readonly isNeedsHuman: boolean
+}): boolean {
+  if (!args.compact) return false
+  if (!args.isTerminal) return true
+  return args.isNeedsHuman
+}

--- a/apps/harness/test/jobs-reset-visibility.test.ts
+++ b/apps/harness/test/jobs-reset-visibility.test.ts
@@ -1,0 +1,128 @@
+import { readFileSync } from "node:fs"
+import { join } from "node:path"
+import { canShowWorkItemResetAction } from "../src/work-item-job-actions.js"
+import { describe, expect, test } from "bun:test"
+
+const homeSource = () =>
+  readFileSync(join(import.meta.dir, "../src/routes/index.tsx"), "utf8")
+
+const lifecycleStatusSource = (): string => {
+  const source = homeSource()
+  const start = source.indexOf("function WorkItemLifecycleStatus(")
+  expect(start).toBeGreaterThan(-1)
+  return source.slice(start)
+}
+
+/** Scenario labels document projected GraphQL status; the gate keys on isTerminal. */
+const cases = [
+  {
+    name: "terminal COMPLETE history",
+    args: { compact: true, isTerminal: true, isNeedsHuman: false },
+    show: false,
+  },
+  {
+    name: "terminal ABANDONED history",
+    args: { compact: true, isTerminal: true, isNeedsHuman: false },
+    show: false,
+  },
+  {
+    name: "terminal FAILED history",
+    args: { compact: true, isTerminal: true, isNeedsHuman: false },
+    show: false,
+  },
+  {
+    name: "held WAITING_FOR_BLOCKERS (non-terminal)",
+    args: { compact: true, isTerminal: false, isNeedsHuman: false },
+    show: true,
+  },
+  {
+    name: "held WAITING_FOR_WORKER_SLOT (non-terminal)",
+    args: { compact: true, isTerminal: false, isNeedsHuman: false },
+    show: true,
+  },
+  {
+    name: "RUNNING (non-terminal)",
+    args: { compact: true, isTerminal: false, isNeedsHuman: false },
+    show: true,
+  },
+  {
+    // Step-level failure while the Work Item is still operational: GraphQL status
+    // can be FAILED/INTERRUPTED with isTerminal false. Must still show Reset.
+    name: "step-level FAILED status on non-terminal work item",
+    args: { compact: true, isTerminal: false, isNeedsHuman: false },
+    show: true,
+  },
+  {
+    name: "step-level INTERRUPTED status on non-terminal work item",
+    args: { compact: true, isTerminal: false, isNeedsHuman: false },
+    show: true,
+  },
+  {
+    name: "paused NEEDS_HUMAN_REVIEW (non-terminal Working)",
+    args: { compact: true, isTerminal: false, isNeedsHuman: false },
+    show: true,
+  },
+  {
+    name: "terminal NEEDS_HUMAN Working handoff",
+    args: { compact: true, isTerminal: true, isNeedsHuman: true },
+    show: true,
+  },
+  {
+    name: "non-compact issue row (held)",
+    args: { compact: false, isTerminal: false, isNeedsHuman: false },
+    show: false,
+  },
+  {
+    name: "non-compact issue row (Needs Human)",
+    args: { compact: false, isTerminal: true, isNeedsHuman: true },
+    show: false,
+  },
+] as const
+
+describe("canShowWorkItemResetAction", () => {
+  for (const scenario of cases) {
+    test(scenario.name, () => {
+      expect(canShowWorkItemResetAction(scenario.args)).toBe(scenario.show)
+    })
+  }
+})
+
+describe("Jobs Reset button wiring", () => {
+  test("WorkItemLifecycleStatus uses the shared Reset visibility helper", () => {
+    const lifecycle = lifecycleStatusSource()
+    expect(lifecycle).toContain("canShowWorkItemResetAction({")
+    expect(lifecycle).toContain("isTerminal: workItem.isTerminal")
+    expect(lifecycle).toContain('isNeedsHuman: status === "NEEDS_HUMAN"')
+    expect(lifecycle).toContain("resetWorkItem")
+    expect(lifecycle).toContain(
+      'aria-label={reset.isPending ? "Resetting job" : "Reset job"}',
+    )
+  })
+
+  test("held Queue rows are not denylisted for Reset the way Retry is", () => {
+    const lifecycle = lifecycleStatusSource()
+    expect(lifecycle).toContain(
+      'const heldForBlockers = status === "WAITING_FOR_BLOCKERS"',
+    )
+    expect(lifecycle).toContain(
+      "const canRetry = compact && workItem.canRetry && !heldForBlockers",
+    )
+    expect(lifecycle).not.toContain("canReset = compact && !heldForBlockers")
+    // Gate must not denylist projected FAILED status strings (step failures).
+    expect(lifecycle).not.toMatch(
+      /canShowWorkItemResetAction[\s\S]*?status\s*!==\s*"FAILED"/,
+    )
+  })
+
+  test("Jobs Completed tab still renders compact lifecycle status", () => {
+    const source = homeSource()
+    expect(source).toContain('listKind: "COMPLETED"')
+    expect(source).toContain("JOBS_COMPLETED_LIMIT")
+    const jobsCard = source.slice(
+      source.indexOf("function JobsCard("),
+      source.indexOf("function WorkItemPauseButton("),
+    )
+    expect(jobsCard).toContain("<WorkItemLifecycleStatus")
+    expect(jobsCard).toContain("compact")
+  })
+})

--- a/apps/harness/test/waiting-for-blockers-working-row.test.ts
+++ b/apps/harness/test/waiting-for-blockers-working-row.test.ts
@@ -68,7 +68,9 @@ describe("Waiting for blockers Working-row polish", () => {
     expect(lifecycle).toContain(
       "const canRetry = compact && workItem.canRetry && !heldForBlockers",
     )
-    expect(lifecycle).toContain("const canReset = compact")
+    expect(lifecycle).toContain("canShowWorkItemResetAction({")
+    expect(lifecycle).toContain("isTerminal: workItem.isTerminal")
+    expect(lifecycle).toContain('isNeedsHuman: status === "NEEDS_HUMAN"')
     expect(lifecycle).toContain("resetWorkItem")
     expect(lifecycle).toContain(
       'aria-label={reset.isPending ? "Resetting job" : "Reset job"}',


### PR DESCRIPTION
## Why

Completed Jobs cards used compact lifecycle status with
`canReset = compact`, so finished history entries showed the
trash/Reset control. Reset deletes the Work Item, step-run
history, and worktree, which is wrong for completed-history
rows. Held Queue rows still need a cancel affordance.

## What changed

- Extracted `canShowWorkItemResetAction` for Jobs/Kanban Reset
  visibility.
- Compact non-terminal work (including held Queue) still gets
  Reset.
- Terminal Completed/Failed/Abandoned history never gets Reset.
- Terminal Needs Human on Working keeps Reset so stuck handoffs
  remain cancelable.
- Unit coverage for the visibility matrix and lifecycle wiring.

## Verification

- `bunx nx test harness -- test/jobs-reset-visibility.test.ts
  test/waiting-for-blockers-working-row.test.ts`

Closes #622