### PR TITLE
fix(harness): show active worktree setup in Kanban Build

### DIFF
--- a/apps/harness/src/pipeline-lanes.ts
+++ b/apps/harness/src/pipeline-lanes.ts
@@ -49,14 +49,14 @@ export function pipelineLaneFor(workItem: PipelineWorkItem): PipelineLaneId {
 
   if (
     workItem.status === "QUEUED" ||
-    workItem.status === "WAITING_FOR_WORKER_SLOT" ||
-    workItem.state === "CREATE_WORKTREE" ||
-    workItem.state === "INSTALL_DEPENDENCIES"
+    workItem.status === "WAITING_FOR_WORKER_SLOT"
   ) {
     return "queue"
   }
 
   if (
+    workItem.state === "CREATE_WORKTREE" ||
+    workItem.state === "INSTALL_DEPENDENCIES" ||
     workItem.state === "IMPLEMENT" ||
     workItem.state === "ASSESS_CHANGES" ||
     workItem.state === "PRE_COMMIT"

--- a/apps/harness/test/pipeline-lanes.test.ts
+++ b/apps/harness/test/pipeline-lanes.test.ts
@@ -65,8 +65,12 @@ describe("pipelineLaneFor", () => {
       status: "WAITING_FOR_WORKER_SLOT",
       lane: "queue",
     },
-    { state: "CREATE_WORKTREE", status: "RUNNING", lane: "queue" },
-    { state: "INSTALL_DEPENDENCIES", status: "RUNNING", lane: "queue" },
+    { state: "CREATE_WORKTREE", status: "QUEUED", lane: "queue" },
+    {
+      state: "INSTALL_DEPENDENCIES",
+      status: "WAITING_FOR_WORKER_SLOT",
+      lane: "queue",
+    },
   ] satisfies readonly LaneCase[])(
     "places $state with $status in Queue",
     ({ state, status, lane }) => {
@@ -75,6 +79,8 @@ describe("pipelineLaneFor", () => {
   )
 
   test.each([
+    { state: "CREATE_WORKTREE", status: "RUNNING", lane: "build" },
+    { state: "INSTALL_DEPENDENCIES", status: "RUNNING", lane: "build" },
     { state: "IMPLEMENT", status: "RUNNING", lane: "build" },
     { state: "ASSESS_CHANGES", status: "RUNNING", lane: "build" },
     { state: "PRE_COMMIT", status: "RUNNING", lane: "build" },

--- a/docs/kanban.md
+++ b/docs/kanban.md
@@ -29,8 +29,8 @@ The board has six ordered lanes:
 
 | Lane | Meaning | Derived from |
 | --- | --- | --- |
-| Queue | Work has not reached an active implementation step. | `QUEUED`, `WAITING_FOR_WORKER_SLOT`, `CREATE_WORKTREE`, `INSTALL_DEPENDENCIES` |
-| Build | Implementation work is in progress. | `IMPLEMENT`, `ASSESS_CHANGES`, `PRE_COMMIT` |
+| Queue | Work has not begun active lifecycle execution. | `QUEUED`, `WAITING_FOR_WORKER_SLOT` |
+| Build | Active startup and implementation work is in progress. | `CREATE_WORKTREE`, `INSTALL_DEPENDENCIES`, `IMPLEMENT`, `ASSESS_CHANGES`, `PRE_COMMIT` |
 | Review | A pull request or review/check handoff is in progress. | `REVIEW`, `WATCH_PR_STATUS_CHECKS`, `RESOLVE_PR_MERGE_CONFLICT`, `INVESTIGATE_PR_STATUS_CHECKS` |
 | Ship | Work is beyond review but not terminal. | Any non-terminal lifecycle state not classified above |
 | Attention | An operator or remediation decision is needed. | Failed, interrupted, needs-human statuses or states |


### PR DESCRIPTION
## Why

Running `CREATE_WORKTREE` and `INSTALL_DEPENDENCIES` Work Items were
classified into the Queue lane even though they run only after admission,
consume a worker slot, and are the start of active lifecycle work. That hid
startup activity from the Build lane and made Queue look busier than it was.

## What changed

- `pipelineLaneFor` treats Queue as not-yet-active execution only: `QUEUED`
  and `WAITING_FOR_WORKER_SLOT` (any next step).
- Active startup joins Build with implementation: `CREATE_WORKTREE`,
  `INSTALL_DEPENDENCIES`, `IMPLEMENT`, `ASSESS_CHANGES`, `PRE_COMMIT`.
- Attention and Complete still take precedence over lifecycle-step placement.
- Focused classifier tests and `docs/kanban.md` lane table updated to match.

## Verification

- `bun --conditions=@ready-for-agent/source test test/pipeline-lanes.test.ts`
  (31 pass)
- Full harness suite green (`bunx nx test harness`, 341 pass)
- Local review: no findings

## Limitations

- Presentation-only classifier; does not change lifecycle state or job
  scheduling.

Closes #629