### PR TITLE
feat(harness): show completed jobs from the last rolling 24 hours

### DIFF
--- a/apps/harness/src/routes/index.tsx
+++ b/apps/harness/src/routes/index.tsx
@@ -8,6 +8,7 @@ import {
 import { createFileRoute } from "@tanstack/react-router"
 import { type FormEvent, Suspense, useEffect, useRef, useState } from "react"
 import { createClient } from "@ready-for-agent/graphql-client"
+import { JOBS_COMPLETED_WINDOW_HOURS as jobsCompletedWindowHours } from "@ready-for-agent/work-item-lifecycle/jobs-completed-window"
 import {
   jobsCardCollapseId,
   repositoryCardCollapseId,
@@ -412,6 +413,7 @@ export type WorkItem = {
   worktreePath: string | null
   completionSummary: string | null
   createdAt: string
+  stateReadyAt: string
   lifecycleLabels: readonly {
     phase: string
     label: string
@@ -441,6 +443,7 @@ const workItemFields = {
   worktreePath: true,
   completionSummary: true,
   createdAt: true,
+  stateReadyAt: true,
   lifecycleLabels: {
     phase: true,
     label: true,
@@ -456,9 +459,12 @@ type WorkItemsQueryOptions = {
   readonly limit?: number
 }
 
-/** Completed history window (successful finished outcomes). */
-export const JOBS_COMPLETED_LIMIT = 15
-/** Failed history window, independent of JOBS_COMPLETED_LIMIT. */
+/**
+ * Rolling window hours for Jobs Completed labels (same source as server filter).
+ * Filtering uses Work Item stateReadyAt within JOBS_COMPLETED_WINDOW_MS on the API.
+ */
+export const JOBS_COMPLETED_WINDOW_HOURS = jobsCompletedWindowHours
+/** Failed history window (fixed item cap; independent of Completed). */
 export const JOBS_FAILED_LIMIT = 15
 
 export const workItemsQuery = (
@@ -502,7 +508,6 @@ export const jobsFailedWorkItemsQuery = (repositoryId: string) =>
 export const jobsCompletedWorkItemsQuery = (repositoryId: string) =>
   workItemsQuery(repositoryId, {
     listKind: "COMPLETED",
-    limit: JOBS_COMPLETED_LIMIT,
   })
 
 const committedPullRequestsCountQuery = (from: string, to: string) => ({
@@ -3174,22 +3179,24 @@ function RepositoryIssueRow({
 
 type JobsTab = "working" | "failed" | "completed"
 
+const JOBS_COMPLETED_TAB_LABEL = `Completed last ${JOBS_COMPLETED_WINDOW_HOURS} h`
+
 const JOBS_TABS = [
   { id: "working", label: "Working" },
   { id: "failed", label: "Failed" },
-  { id: "completed", label: "Completed" },
+  { id: "completed", label: JOBS_COMPLETED_TAB_LABEL },
 ] as const satisfies readonly { id: JobsTab; label: string }[]
 
 const jobsTabEmptyMessage = (tab: JobsTab): string => {
   if (tab === "working") return "No working jobs."
   if (tab === "failed") return "No failed jobs."
-  return "No completed jobs."
+  return `No jobs completed in the last ${JOBS_COMPLETED_WINDOW_HOURS} h.`
 }
 
 const jobsTabListAriaLabel = (tab: JobsTab): string => {
   if (tab === "working") return "Working jobs"
   if (tab === "failed") return "Failed jobs"
-  return "Completed jobs"
+  return JOBS_COMPLETED_TAB_LABEL
 }
 
 export function SessionUsageDialog({
@@ -3476,15 +3483,21 @@ function JobsCard() {
     items
       .slice()
       .sort((left, right) => right.createdAt.localeCompare(left.createdAt))
+  const sortCompletedNewestFirst = (items: readonly WorkItem[]) =>
+    items
+      .slice()
+      .sort((left, right) =>
+        right.stateReadyAt.localeCompare(left.stateReadyAt),
+      )
   const workingItems = sortNewestFirst(
     workingQueries.flatMap((query) => query.data ?? []),
   )
   const failedItems = sortNewestFirst(
     failedQueries.flatMap((query) => query.data ?? []),
   ).slice(0, JOBS_FAILED_LIMIT)
-  const completedItems = sortNewestFirst(
+  const completedItems = sortCompletedNewestFirst(
     completedQueries.flatMap((query) => query.data ?? []),
-  ).slice(0, JOBS_COMPLETED_LIMIT)
+  )
   const activeItems =
     selectedTab === "working"
       ? workingItems

--- a/apps/harness/src/routes/kanban.tsx
+++ b/apps/harness/src/routes/kanban.tsx
@@ -15,7 +15,7 @@ import { workItemIssueUrl } from "../work-item-issue-url.js"
 import { workItemPullRequestUrl } from "../work-item-pull-request-url.js"
 import {
   CommittedPullRequestsDashboard,
-  JOBS_COMPLETED_LIMIT,
+  JOBS_COMPLETED_WINDOW_HOURS,
   JOBS_FAILED_LIMIT,
   JobsCardSkeleton,
   type Repository,
@@ -32,11 +32,13 @@ import {
 
 type JobsTab = "pipeline" | "working" | "failed" | "completed"
 
+const JOBS_COMPLETED_TAB_LABEL = `Completed last ${JOBS_COMPLETED_WINDOW_HOURS} h`
+
 const JOBS_TABS = [
   { id: "pipeline", label: "Pipeline" },
   { id: "working", label: "Working" },
   { id: "failed", label: "Failed" },
-  { id: "completed", label: "Completed" },
+  { id: "completed", label: JOBS_COMPLETED_TAB_LABEL },
 ] as const satisfies readonly { id: JobsTab; label: string }[]
 
 const PIPELINE_LANE_LABELS = {
@@ -51,19 +53,26 @@ const PIPELINE_LANE_LABELS = {
 const jobsTabEmptyMessage = (tab: Exclude<JobsTab, "pipeline">): string => {
   if (tab === "working") return "No working jobs."
   if (tab === "failed") return "No failed jobs."
-  return "No completed jobs."
+  return `No jobs completed in the last ${JOBS_COMPLETED_WINDOW_HOURS} h.`
 }
 
 const jobsTabListAriaLabel = (tab: Exclude<JobsTab, "pipeline">): string => {
   if (tab === "working") return "Working jobs"
   if (tab === "failed") return "Failed jobs"
-  return "Completed jobs"
+  return JOBS_COMPLETED_TAB_LABEL
 }
 
 const sortNewestFirst = (items: readonly WorkItem[]): readonly WorkItem[] =>
   items
     .slice()
     .sort((left, right) => right.createdAt.localeCompare(left.createdAt))
+
+const sortCompletedNewestFirst = (
+  items: readonly WorkItem[],
+): readonly WorkItem[] =>
+  items
+    .slice()
+    .sort((left, right) => right.stateReadyAt.localeCompare(left.stateReadyAt))
 
 const repositoryIssueKey = (
   repositoryId: string,
@@ -277,18 +286,19 @@ function KanbanJobsBoard() {
   const failedItems = sortNewestFirst(
     failedQueries.flatMap((query) => query.data ?? []),
   ).slice(0, JOBS_FAILED_LIMIT)
-  const completedItems = sortNewestFirst(
+  const completedItems = sortCompletedNewestFirst(
     completedQueries.flatMap((query) => query.data ?? []),
-  ).slice(0, JOBS_COMPLETED_LIMIT)
-  const pipelineItems = sortNewestFirst(
-    Array.from(
-      new Map(
-        [...workingItems, ...failedItems, ...completedItems].map((item) => [
-          item.id,
-          item,
-        ]),
-      ).values(),
-    ),
+  )
+  // Preserve per-list recency: Working/Failed by createdAt, Completed by
+  // stateReadyAt. Do not re-sort the merge by createdAt or Complete-lane order
+  // drifts from the Completed tab.
+  const pipelineItems = Array.from(
+    new Map(
+      [...workingItems, ...failedItems, ...completedItems].map((item) => [
+        item.id,
+        item,
+      ]),
+    ).values(),
   )
   const repositoryFilteredItems = (items: readonly WorkItem[]) =>
     selectedRepositoryId === null

--- a/apps/harness/test/committed-pr-dashboard.test.ts
+++ b/apps/harness/test/committed-pr-dashboard.test.ts
@@ -264,6 +264,7 @@ describe("Committed pull requests dashboard UI", () => {
     expect(dashboard).toContain("bounds.twoWeeksAgoFrom")
     expect(dashboard).toContain("bounds.twoWeeksAgoTo")
     expect(dashboard).not.toContain("workItems")
+    expect(dashboard).not.toContain("JOBS_COMPLETED_WINDOW_HOURS")
     expect(dashboard).not.toContain("JOBS_COMPLETED_LIMIT")
   })
 

--- a/apps/harness/test/jobs-card-no-polling.test.ts
+++ b/apps/harness/test/jobs-card-no-polling.test.ts
@@ -33,26 +33,51 @@ describe("JobsCard live updates", () => {
     expect(jobsCard).toContain('role="tabpanel"')
     expect(source).toContain('label: "Working"')
     expect(source).toContain('label: "Failed"')
-    expect(source).toContain('label: "Completed"')
+    expect(source).toContain("JOBS_COMPLETED_TAB_LABEL")
+    expect(source).toContain(
+      "Completed last $" + "{JOBS_COMPLETED_WINDOW_HOURS} h",
+    )
     expect(jobsCard).toContain('useState<JobsTab>("working")')
     expect(jobsCard).toContain("jobsWorkingWorkItemsQuery")
     expect(jobsCard).toContain("jobsFailedWorkItemsQuery")
     expect(jobsCard).toContain("jobsCompletedWorkItemsQuery")
     expect(source).toContain("No working jobs.")
     expect(source).toContain("No failed jobs.")
-    expect(source).toContain("No completed jobs.")
+    expect(source).toContain(
+      "No jobs completed in the last $" + "{JOBS_COMPLETED_WINDOW_HOURS} h.",
+    )
     expect(source).toContain("Working jobs")
     expect(source).toContain("Failed jobs")
-    expect(source).toContain("Completed jobs")
+    expect(source).toContain("JOBS_COMPLETED_TAB_LABEL")
     expect(jobsCard).not.toContain('aria-label="All jobs"')
     expect(source).toContain('listKind: "WORKING"')
     expect(source).toContain('listKind: "FAILED"')
     expect(source).toContain('listKind: "COMPLETED"')
-    expect(source).toContain("JOBS_COMPLETED_LIMIT = 15")
+    expect(source).toContain("JOBS_COMPLETED_WINDOW_HOURS")
+    expect(source).toContain(
+      'from "@ready-for-agent/work-item-lifecycle/jobs-completed-window"',
+    )
+    expect(source).toContain("jobsCompletedWindowHours")
+    // Client must not import the lifecycle barrel (pulls server deps into Vite).
+    expect(source).not.toMatch(
+      /from "@ready-for-agent\/work-item-lifecycle"(?!\/)/,
+    )
+    expect(source).not.toContain("JOBS_COMPLETED_LIMIT")
     expect(source).toContain("JOBS_FAILED_LIMIT = 15")
-    const workingTabIndex = source.indexOf('label: "Working"')
-    const failedTabIndex = source.indexOf('label: "Failed"')
-    const completedTabIndex = source.indexOf('label: "Completed"')
+    expect(source).not.toMatch(
+      /listKind:\s*"COMPLETED"[\s\S]{0,80}limit:\s*JOBS_COMPLETED/,
+    )
+    const jobsTabsBlock = source.slice(
+      source.indexOf("const JOBS_TABS = ["),
+      source.indexOf(
+        "] as const satisfies readonly { id: JobsTab; label: string }[]",
+      ),
+    )
+    const workingTabIndex = jobsTabsBlock.indexOf('label: "Working"')
+    const failedTabIndex = jobsTabsBlock.indexOf('label: "Failed"')
+    const completedTabIndex = jobsTabsBlock.indexOf(
+      "label: JOBS_COMPLETED_TAB_LABEL",
+    )
     expect(workingTabIndex).toBeGreaterThan(-1)
     expect(failedTabIndex).toBeGreaterThan(workingTabIndex)
     expect(completedTabIndex).toBeGreaterThan(failedTabIndex)

--- a/apps/harness/test/jobs-reset-visibility.test.ts
+++ b/apps/harness/test/jobs-reset-visibility.test.ts
@@ -117,7 +117,8 @@ describe("Jobs Reset button wiring", () => {
   test("Jobs Completed tab still renders compact lifecycle status", () => {
     const source = homeSource()
     expect(source).toContain('listKind: "COMPLETED"')
-    expect(source).toContain("JOBS_COMPLETED_LIMIT")
+    expect(source).toContain("JOBS_COMPLETED_WINDOW_HOURS")
+    expect(source).not.toContain("JOBS_COMPLETED_LIMIT")
     const jobsCard = source.slice(
       source.indexOf("function JobsCard("),
       source.indexOf("function WorkItemPauseButton("),

--- a/apps/harness/test/kanban-route.test.ts
+++ b/apps/harness/test/kanban-route.test.ts
@@ -39,7 +39,12 @@ describe("/kanban route", () => {
     expect(source).toContain('{ id: "pipeline", label: "Pipeline" }')
     expect(source).toContain('{ id: "working", label: "Working" }')
     expect(source).toContain('{ id: "failed", label: "Failed" }')
-    expect(source).toContain('{ id: "completed", label: "Completed" }')
+    expect(source).toContain(
+      '{ id: "completed", label: JOBS_COMPLETED_TAB_LABEL }',
+    )
+    expect(source).toContain(
+      "Completed last $" + "{JOBS_COMPLETED_WINDOW_HOURS} h",
+    )
     expect(source).toContain('role="tablist"')
     expect(source).toContain('role="tab"')
     expect(source).toContain("aria-selected={selected}")
@@ -106,6 +111,14 @@ describe("/kanban route", () => {
     expect(source).not.toContain("createClient(")
     expect(source).not.toContain("setInterval")
     expect(source).not.toContain("refetchInterval")
+  })
+
+  test("Pipeline preserves Completed stateReadyAt order instead of re-sorting by createdAt", () => {
+    const source = kanbanSource()
+    const board = source.slice(source.indexOf("function KanbanJobsBoard("))
+    expect(board).toContain("sortCompletedNewestFirst")
+    expect(board).toContain("const pipelineItems = Array.from(")
+    expect(board).not.toMatch(/const pipelineItems\s*=\s*sortNewestFirst\s*\(/)
   })
 
   test("starts live invalidation after the initial board queries settle", () => {

--- a/docs/kanban.md
+++ b/docs/kanban.md
@@ -67,7 +67,8 @@ The Jobs area has four tabs:
 1. Pipeline is the default and renders the six lanes.
 2. Working retains the existing active-work list.
 3. Failed retains the existing failed-work list.
-4. Completed retains the existing completed-work list.
+4. Completed last 24 h shows every work item completed in the rolling previous
+   24 hours (no fixed item limit).
 
 The existing arrow-key tab behavior, selected-tab ARIA semantics, Jobs collapse
 control, retry/reset/start/pause actions, Session usage dialog, issue links,

--- a/packages/graphql-api/src/lib/graphql-api.ts
+++ b/packages/graphql-api/src/lib/graphql-api.ts
@@ -572,12 +572,18 @@ export const createGraphqlApi = (
                 const lifecycle = yield* WorkItemLifecycle
                 const listKind = toWorkItemsListKind(args.listKind)
                 const limit = args.limit
+                const nowMs = Date.now()
                 if (args.issueNumber !== undefined) {
                   const workItems = yield* lifecycle.listWorkItemsForIssue(
                     args.repositoryId,
                     args.issueNumber,
                   )
-                  return filterWorkItemsByListKind(workItems, listKind, limit)
+                  return filterWorkItemsByListKind(
+                    workItems,
+                    listKind,
+                    limit,
+                    nowMs,
+                  )
                 }
                 const db = yield* DbService
                 const [workItems, issues] = yield* Effect.all([
@@ -593,7 +599,12 @@ export const createGraphqlApi = (
                     isJobsWorkingWorkItem(workItem) ||
                     relevantIssueNumbers.has(workItem.issueNumber),
                 )
-                return filterWorkItemsByListKind(visible, listKind, limit)
+                return filterWorkItemsByListKind(
+                  visible,
+                  listKind,
+                  limit,
+                  nowMs,
+                )
               }).pipe(Effect.withSpan("graphql-api.workItems")),
             ),
           committedPullRequestsCount: async (

--- a/packages/graphql-api/test/graphql-api.test.ts
+++ b/packages/graphql-api/test/graphql-api.test.ts
@@ -4107,29 +4107,48 @@ describe("GraphQL API", () => {
     })
   })
 
-  test("filters Completed Work Items newest-first with limit", async () => {
-    const baseTime = Date.parse("2026-01-01T00:00:00.000Z")
-    const completed = Array.from({ length: 18 }, (_, index) => ({
+  test("filters Completed Work Items to rolling last 24 hours without a fixed limit", async () => {
+    const nowMs = Date.now()
+    const hourMs = 60 * 60 * 1000
+    const completedRecent = Array.from({ length: 18 }, (_, index) => {
+      const readyAt = nowMs - index * 10 * 60 * 1000
+      return {
+        ...workItem,
+        id: makeWorkItemId(),
+        state: (index % 2 === 0 ? "complete" : "abandoned") as
+          | "complete"
+          | "abandoned",
+        createdAt: new Date(readyAt - hourMs),
+        updatedAt: new Date(readyAt),
+        stateReadyAt: new Date(readyAt),
+        stepRuns: [],
+      }
+    })
+    const completedTooOld = {
       ...workItem,
       id: makeWorkItemId(),
-      state: (index % 2 === 0 ? "complete" : "abandoned") as
-        | "complete"
-        | "abandoned",
-      createdAt: new Date(baseTime + index * 1000),
+      state: "complete" as const,
+      createdAt: new Date(nowMs - 48 * hourMs),
+      updatedAt: new Date(nowMs - 25 * hourMs),
+      stateReadyAt: new Date(nowMs - 25 * hourMs),
       stepRuns: [],
-    }))
+    }
     const needsHuman = {
       ...workItem,
       id: makeWorkItemId(),
       state: "needs_human" as const,
-      createdAt: new Date(baseTime + 50_000),
+      createdAt: new Date(nowMs - 1000),
+      updatedAt: new Date(nowMs - 1000),
+      stateReadyAt: new Date(nowMs - 1000),
       stepRuns: [],
     }
     const terminalFailed = {
       ...workItem,
       id: makeWorkItemId(),
       state: "failed" as const,
-      createdAt: new Date(baseTime + 40_000),
+      createdAt: new Date(nowMs - 2000),
+      updatedAt: new Date(nowMs - 2000),
+      stateReadyAt: new Date(nowMs - 2000),
       stepRuns: [],
     }
     await runtime.dispose()
@@ -4141,21 +4160,25 @@ describe("GraphQL API", () => {
       {},
       {
         listWorkItemsForRepository: () =>
-          Effect.succeed([...completed, needsHuman, terminalFailed]),
+          Effect.succeed([
+            ...completedRecent,
+            completedTooOld,
+            needsHuman,
+            terminalFailed,
+          ]),
       },
     )
 
     const response = await createGraphqlApi(runtime).fetch(
       graphqlRequest({
-        query: `query WorkItems($repositoryId: ID!, $listKind: WorkItemsListKind, $limit: Int) {
-          workItems(repositoryId: $repositoryId, listKind: $listKind, limit: $limit) {
+        query: `query WorkItems($repositoryId: ID!, $listKind: WorkItemsListKind) {
+          workItems(repositoryId: $repositoryId, listKind: $listKind) {
             id state
           }
         }`,
         variables: {
           repositoryId: repository.id,
           listKind: "COMPLETED",
-          limit: 15,
         },
       }),
     )
@@ -4163,19 +4186,22 @@ describe("GraphQL API", () => {
     const body = (await response.json()) as {
       data: { workItems: readonly { id: string; state: string }[] }
     }
-    expect(body.data.workItems).toHaveLength(15)
+    expect(body.data.workItems).toHaveLength(18)
+    expect(body.data.workItems.map((item) => item.id)).not.toContain(
+      completedTooOld.id,
+    )
     expect(
       body.data.workItems.every(
         (item) => item.state !== "NEEDS_HUMAN" && item.state !== "FAILED",
       ),
     ).toBe(true)
     expect(body.data.workItems.map((item) => item.id)).toEqual(
-      completed
+      completedRecent
         .slice()
         .sort(
-          (left, right) => right.createdAt.getTime() - left.createdAt.getTime(),
+          (left, right) =>
+            right.stateReadyAt.getTime() - left.stateReadyAt.getTime(),
         )
-        .slice(0, 15)
         .map((item) => item.id),
     )
   })
@@ -4394,13 +4420,16 @@ describe("GraphQL API", () => {
   })
 
   test("keeps complete and abandoned Work Items in COMPLETED when Issue is absent", async () => {
+    const nowMs = Date.now()
     const completeOrphan = {
       ...workItem,
       id: makeWorkItemId(),
       issueNumber: 201,
       issueTitle: "Completed issue title",
       state: "complete" as const,
-      createdAt: new Date("2026-03-01T00:00:00.000Z"),
+      createdAt: new Date(nowMs - 3_600_000),
+      updatedAt: new Date(nowMs - 2_000_000),
+      stateReadyAt: new Date(nowMs - 2_000_000),
       stepRuns: [],
     }
     const abandonedOrphan = {
@@ -4409,7 +4438,9 @@ describe("GraphQL API", () => {
       issueNumber: 202,
       issueTitle: null,
       state: "abandoned" as const,
-      createdAt: new Date("2026-03-02T00:00:00.000Z"),
+      createdAt: new Date(nowMs - 1_800_000),
+      updatedAt: new Date(nowMs - 1_000_000),
+      stateReadyAt: new Date(nowMs - 1_000_000),
       stepRuns: [],
     }
     const failedOrphan = {
@@ -4417,7 +4448,9 @@ describe("GraphQL API", () => {
       id: makeWorkItemId(),
       issueNumber: 203,
       state: "failed" as const,
-      createdAt: new Date("2026-03-03T00:00:00.000Z"),
+      createdAt: new Date(nowMs - 500_000),
+      updatedAt: new Date(nowMs - 500_000),
+      stateReadyAt: new Date(nowMs - 500_000),
       stepRuns: [],
     }
     await runtime.dispose()

--- a/packages/graphql-schema/schema.graphql
+++ b/packages/graphql-schema/schema.graphql
@@ -50,9 +50,11 @@ type Query {
   listKind WORKING: unfinished Work Items (including retryable failed or
   interrupted Step Runs) plus Needs Human (no history cap from the Jobs card).
   listKind FAILED: non-retryable terminal failures only, newest createdAt first.
-  Pass limit (e.g. 15) to bound Failed history — independent of the Completed limit.
-  listKind COMPLETED: Complete and Abandoned only, newest createdAt first;
-  pass limit (e.g. 15) to bound finished history. Terminal failed is not included.
+  Pass limit (e.g. 15) to bound Failed history — independent of Completed.
+  listKind COMPLETED: Complete and Abandoned only, with stateReadyAt in the
+  rolling previous JOBS_COMPLETED_WINDOW_MS (24 hours), newest stateReadyAt
+  first, no default item cap. Optional limit may still bound the window.
+  Terminal failed is not included.
   """
   workItems(
     repositoryId: ID!

--- a/packages/work-item-lifecycle/package.json
+++ b/packages/work-item-lifecycle/package.json
@@ -13,6 +13,12 @@
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
       "default": "./dist/index.js"
+    },
+    "./jobs-completed-window": {
+      "@ready-for-agent/source": "./src/lib/jobs-completed-window.ts",
+      "types": "./dist/lib/jobs-completed-window.d.ts",
+      "import": "./dist/lib/jobs-completed-window.js",
+      "default": "./dist/lib/jobs-completed-window.js"
     }
   },
   "dependencies": {

--- a/packages/work-item-lifecycle/src/lib/jobs-completed-window.ts
+++ b/packages/work-item-lifecycle/src/lib/jobs-completed-window.ts
@@ -1,0 +1,11 @@
+/**
+ * Rolling window for Jobs Completed (Complete and Abandoned).
+ * Membership uses stateReadyAt (entry into the terminal state), not a calendar day.
+ * JOBS_COMPLETED_WINDOW_HOURS is derived so UI labels stay aligned with the filter.
+ *
+ * This module is dependency-free so the harness client may import it without
+ * pulling server lifecycle code into the Vite bundle.
+ */
+export const JOBS_COMPLETED_WINDOW_MS = 24 * 60 * 60 * 1000
+export const JOBS_COMPLETED_WINDOW_HOURS =
+  JOBS_COMPLETED_WINDOW_MS / (60 * 60 * 1000)

--- a/packages/work-item-lifecycle/src/lib/types.ts
+++ b/packages/work-item-lifecycle/src/lib/types.ts
@@ -1,5 +1,11 @@
 import { Duration, Schema } from "effect"
 import { ulid } from "ulidx"
+import {
+  JOBS_COMPLETED_WINDOW_HOURS,
+  JOBS_COMPLETED_WINDOW_MS,
+} from "./jobs-completed-window.js"
+
+export { JOBS_COMPLETED_WINDOW_HOURS, JOBS_COMPLETED_WINDOW_MS }
 
 export const WorkItemId = Schema.String.pipe(
   Schema.check(Schema.isPattern(/^wi-[0-9A-HJKMNP-TV-Z]{26}$/)),
@@ -257,6 +263,16 @@ const newestCreatedFirst = <T extends { readonly createdAt: Date }>(
     .slice()
     .sort((left, right) => right.createdAt.getTime() - left.createdAt.getTime())
 
+const newestStateReadyFirst = <T extends { readonly stateReadyAt: Date }>(
+  items: readonly T[],
+): T[] =>
+  items
+    .slice()
+    .sort(
+      (left, right) =>
+        right.stateReadyAt.getTime() - left.stateReadyAt.getTime(),
+    )
+
 const applyLimit = <T>(
   items: readonly T[],
   limit: number | undefined,
@@ -264,7 +280,10 @@ const applyLimit = <T>(
 
 /**
  * Filter Work Items for Jobs Working / Failed / Completed lists.
- * Failed and Completed are ordered by createdAt newest-first (recency for last-N windows).
+ * Failed is ordered by createdAt newest-first (recency for last-N windows).
+ * Completed is Complete/Abandoned with stateReadyAt in the rolling previous
+ * JOBS_COMPLETED_WINDOW_MS (from nowMs), ordered by stateReadyAt newest-first,
+ * with no default item cap (optional limit still applies when provided).
  * Working preserves input order. Omitting listKind returns the input unchanged.
  */
 export const filterWorkItemsByListKind = <
@@ -272,11 +291,13 @@ export const filterWorkItemsByListKind = <
     readonly state: WorkItemState
     readonly failureCode?: string | null
     readonly createdAt: Date
+    readonly stateReadyAt: Date
   },
 >(
   workItems: readonly T[],
   listKind: WorkItemsListKind | undefined,
   limit?: number,
+  nowMs: number = Date.now(),
 ): readonly T[] => {
   if (listKind === undefined) {
     return workItems
@@ -290,9 +311,14 @@ export const filterWorkItemsByListKind = <
       limit,
     )
   }
+  const windowStartMs = nowMs - JOBS_COMPLETED_WINDOW_MS
   return applyLimit(
-    newestCreatedFirst(
-      workItems.filter((item) => isJobsCompletedWorkItemState(item.state)),
+    newestStateReadyFirst(
+      workItems.filter(
+        (item) =>
+          isJobsCompletedWorkItemState(item.state) &&
+          item.stateReadyAt.getTime() >= windowStartMs,
+      ),
     ),
     limit,
   )

--- a/packages/work-item-lifecycle/test/jobs-list-filter.spec.ts
+++ b/packages/work-item-lifecycle/test/jobs-list-filter.spec.ts
@@ -1,4 +1,5 @@
 import {
+  JOBS_COMPLETED_WINDOW_MS,
   type OperationalLifecycleStep,
   type StepRunStatus,
   type WorkItemState,
@@ -10,16 +11,20 @@ import {
 } from "../src/lib/types.js"
 import { describe, expect, it } from "bun:test"
 
+const NOW_MS = Date.parse("2026-07-30T12:00:00.000Z")
+
 const item = (
   state: WorkItemState,
   createdAtMs: number,
   latestStepStatus?: StepRunStatus,
   failureCode: string | null = null,
   latestStep?: OperationalLifecycleStep,
+  stateReadyAtMs: number = createdAtMs,
 ) => ({
   state,
   failureCode,
   createdAt: new Date(createdAtMs),
+  stateReadyAt: new Date(stateReadyAtMs),
   stepRuns:
     latestStepStatus === undefined
       ? []
@@ -110,14 +115,14 @@ describe("Jobs list membership", () => {
 
 describe("filterWorkItemsByListKind", () => {
   const items = [
-    item("complete", 1000),
-    item("implement", 2000, "running"),
-    item("needs_human", 3000),
-    item("failed", 4000, "failed"),
-    item("abandoned", 5000),
-    item("create_worktree", 6000, "queued"),
-    item("pre_commit", 7000, "failed"),
-    item("review", 8000, "interrupted"),
+    item("complete", NOW_MS - 8000),
+    item("implement", NOW_MS - 7000, "running"),
+    item("needs_human", NOW_MS - 6000),
+    item("failed", NOW_MS - 5000, "failed"),
+    item("abandoned", NOW_MS - 4000),
+    item("create_worktree", NOW_MS - 3000, "queued"),
+    item("pre_commit", NOW_MS - 2000, "failed"),
+    item("review", NOW_MS - 1000, "interrupted"),
   ]
 
   it("returns the input unchanged when listKind is omitted", () => {
@@ -144,7 +149,9 @@ describe("filterWorkItemsByListKind", () => {
 
   it("filters Completed to Complete/Abandoned newest-first without terminal failed", () => {
     expect(
-      filterWorkItemsByListKind(items, "completed").map((i) => i.state),
+      filterWorkItemsByListKind(items, "completed", undefined, NOW_MS).map(
+        (i) => i.state,
+      ),
     ).toEqual(["abandoned", "complete"])
   })
 
@@ -158,26 +165,122 @@ describe("filterWorkItemsByListKind", () => {
     expect(limited[14]!.createdAt.getTime()).toBe(500)
   })
 
-  it("limits Completed to the newest N by createdAt", () => {
+  it("includes every Completed item within the rolling 24h window without a fixed limit", () => {
     const many = Array.from({ length: 20 }, (_, index) =>
-      item(index % 2 === 0 ? "complete" : "abandoned", index * 100),
+      item(
+        index % 2 === 0 ? "complete" : "abandoned",
+        NOW_MS - index * 60_000,
+        undefined,
+        null,
+        undefined,
+        NOW_MS - index * 60_000,
+      ),
     )
-    const limited = filterWorkItemsByListKind(many, "completed", 15)
+    const filtered = filterWorkItemsByListKind(
+      many,
+      "completed",
+      undefined,
+      NOW_MS,
+    )
+    expect(filtered).toHaveLength(20)
+    expect(filtered[0]!.stateReadyAt.getTime()).toBe(NOW_MS)
+    expect(filtered[19]!.stateReadyAt.getTime()).toBe(NOW_MS - 19 * 60_000)
+  })
+
+  it("excludes Completed items whose stateReadyAt is older than 24 hours", () => {
+    const recent = item(
+      "complete",
+      NOW_MS - 1_000,
+      undefined,
+      null,
+      undefined,
+      NOW_MS - 1_000,
+    )
+    const atBoundary = item(
+      "abandoned",
+      NOW_MS - JOBS_COMPLETED_WINDOW_MS,
+      undefined,
+      null,
+      undefined,
+      NOW_MS - JOBS_COMPLETED_WINDOW_MS,
+    )
+    const tooOld = item(
+      "complete",
+      NOW_MS - JOBS_COMPLETED_WINDOW_MS - 1,
+      undefined,
+      null,
+      undefined,
+      NOW_MS - JOBS_COMPLETED_WINDOW_MS - 1,
+    )
+    expect(
+      filterWorkItemsByListKind(
+        [recent, atBoundary, tooOld],
+        "completed",
+        undefined,
+        NOW_MS,
+      ).map((i) => i.stateReadyAt.getTime()),
+    ).toEqual([
+      recent.stateReadyAt.getTime(),
+      atBoundary.stateReadyAt.getTime(),
+    ])
+  })
+
+  it("orders Completed by stateReadyAt (completion), not createdAt", () => {
+    const olderCompletion = item(
+      "complete",
+      NOW_MS - 10_000,
+      undefined,
+      null,
+      undefined,
+      NOW_MS - 2_000,
+    )
+    const newerCompletion = item(
+      "abandoned",
+      NOW_MS - 20_000,
+      undefined,
+      null,
+      undefined,
+      NOW_MS - 1_000,
+    )
+    expect(
+      filterWorkItemsByListKind(
+        [olderCompletion, newerCompletion],
+        "completed",
+        undefined,
+        NOW_MS,
+      ).map((i) => i.state),
+    ).toEqual(["abandoned", "complete"])
+  })
+
+  it("applies optional limit after the Completed window, newest stateReadyAt first", () => {
+    const many = Array.from({ length: 20 }, (_, index) =>
+      item(
+        index % 2 === 0 ? "complete" : "abandoned",
+        NOW_MS - index * 60_000,
+        undefined,
+        null,
+        undefined,
+        NOW_MS - index * 60_000,
+      ),
+    )
+    const limited = filterWorkItemsByListKind(many, "completed", 15, NOW_MS)
     expect(limited).toHaveLength(15)
-    expect(limited[0]!.createdAt.getTime()).toBe(1900)
-    expect(limited[14]!.createdAt.getTime()).toBe(500)
+    expect(limited[0]!.stateReadyAt.getTime()).toBe(NOW_MS)
+    expect(limited[14]!.stateReadyAt.getTime()).toBe(NOW_MS - 14 * 60_000)
   })
 
   it("does not put Needs Human or Failed under Completed even with limit", () => {
     const mixed = [
-      item("needs_human", 9000),
-      item("complete", 8000),
-      item("failed", 7000, "failed"),
-      item("implement", 6000, "failed"),
-      item("abandoned", 5000),
+      item("needs_human", NOW_MS - 1000),
+      item("complete", NOW_MS - 2000),
+      item("failed", NOW_MS - 3000, "failed"),
+      item("implement", NOW_MS - 4000, "failed"),
+      item("abandoned", NOW_MS - 5000),
     ]
     expect(
-      filterWorkItemsByListKind(mixed, "completed", 15).map((i) => i.state),
+      filterWorkItemsByListKind(mixed, "completed", 15, NOW_MS).map(
+        (i) => i.state,
+      ),
     ).toEqual(["complete", "abandoned"])
   })
 


### PR DESCRIPTION
## Why

The Jobs Completed list used a fixed cap of 15 items sorted by create
time. Operators could miss recent completions when volume was high, and
older noise still appeared when volume was low. The product goal is a
rolling last-24-hours view of successful finished work.

## What changed

- COMPLETED listKind filters Complete/Abandoned Work Items whose
  stateReadyAt falls in the rolling previous JOBS_COMPLETED_WINDOW_MS
  (24h), ordered by completion time, with no default item cap (optional
  limit still applies after the window).
- Home Jobs and Kanban drop JOBS_COMPLETED_LIMIT, query COMPLETED without
  a limit, label the tab "Completed last 24 h", and sort multi-repo
  results by stateReadyAt.
- Pipeline Complete keeps Completed-tab order instead of re-sorting the
  merged list by createdAt.
- Shared window constants live in a dependency-free jobs-completed-window
  module, exported as
  @ready-for-agent/work-item-lifecycle/jobs-completed-window so the
  client UI does not import the lifecycle barrel (avoids pulling server
  deps into the Vite build).
- GraphQL schema docs and kanban docs describe the rolling window.

## Verification

- Unit tests for membership, 24h boundary, completion-time order, and
  optional post-window limit.
- GraphQL API tests for in-window COMPLETED membership without a fixed
  cap.
- Harness source tests for labels, no limit, client import path, and
  Pipeline order.
- harness:typecheck, harness:build, and pre-commit (lint / typecheck /
  test on affected projects) passed after the client import fix.

## Notes

Failed history remains a separate fixed-size window (JOBS_FAILED_LIMIT).
Completion time is stateReadyAt for terminal Complete/Abandoned, not
calendar-day boundaries.

Closes #618