### PR TITLE
fix(harness): drive Kanban lanes by lifecycle and rename Ship to PR

### DIFF
--- a/apps/harness/e2e/steps/kanban-route.ts
+++ b/apps/harness/e2e/steps/kanban-route.ts
@@ -5,7 +5,7 @@ const PIPELINE_LANE_HEADERS = [
   "Queue",
   "Build",
   "Review",
-  "Ship",
+  "PR",
   "Attention",
   "Complete",
 ] as const

--- a/apps/harness/src/pipeline-lanes.ts
+++ b/apps/harness/src/pipeline-lanes.ts
@@ -2,7 +2,7 @@ export type PipelineLaneId =
   | "queue"
   | "build"
   | "review"
-  | "ship"
+  | "pr"
   | "attention"
   | "complete"
 
@@ -10,7 +10,7 @@ export const PIPELINE_LANES = [
   { id: "queue", label: "Queue", color: "#ffd21c", text: "#151515" },
   { id: "build", label: "Build", color: "#1976d2", text: "#ffffff" },
   { id: "review", label: "Review", color: "#7654b5", text: "#ffffff" },
-  { id: "ship", label: "Ship", color: "#168b62", text: "#ffffff" },
+  { id: "pr", label: "PR", color: "#168b62", text: "#ffffff" },
   { id: "attention", label: "Attention", color: "#ff4d1c", text: "#151515" },
   { id: "complete", label: "Complete", color: "#151515", text: "#ffffff" },
 ] as const satisfies readonly {
@@ -25,6 +25,12 @@ type PipelineWorkItem = {
   readonly status: string
 }
 
+/**
+ * Kanban placement is driven by lifecycle progress, not scheduler status.
+ * Attention and Complete override every lane. Queue is only for work that
+ * cannot begin yet (blockers or worker slot). Queued step execution stays in
+ * its lifecycle lane (Build / Review / PR).
+ */
 export function pipelineLaneFor(workItem: PipelineWorkItem): PipelineLaneId {
   if (
     workItem.status === "FAILED" ||
@@ -48,7 +54,7 @@ export function pipelineLaneFor(workItem: PipelineWorkItem): PipelineLaneId {
   }
 
   if (
-    workItem.status === "QUEUED" ||
+    workItem.status === "WAITING_FOR_BLOCKERS" ||
     workItem.status === "WAITING_FOR_WORKER_SLOT"
   ) {
     return "queue"
@@ -64,14 +70,26 @@ export function pipelineLaneFor(workItem: PipelineWorkItem): PipelineLaneId {
     return "build"
   }
 
-  if (
-    workItem.state === "REVIEW" ||
-    workItem.state === "WATCH_PR_STATUS_CHECKS" ||
-    workItem.state === "RESOLVE_PR_MERGE_CONFLICT" ||
-    workItem.state === "INVESTIGATE_PR_STATUS_CHECKS"
-  ) {
+  if (workItem.state === "REVIEW") {
     return "review"
   }
 
-  return "ship"
+  if (
+    workItem.state === "COMMIT" ||
+    workItem.state === "CREATE_PR" ||
+    workItem.state === "WATCH_PR_STATUS_CHECKS" ||
+    workItem.state === "RESOLVE_PR_MERGE_CONFLICT" ||
+    workItem.state === "INVESTIGATE_PR_STATUS_CHECKS" ||
+    workItem.state === "MARK_PR_READY_FOR_REVIEW" ||
+    workItem.state === "DECIDE_PR_MERGE" ||
+    workItem.state === "MERGE_PR" ||
+    workItem.state === "CLOSE_ISSUE" ||
+    workItem.state === "LOCAL_CLEANUP"
+  ) {
+    return "pr"
+  }
+
+  // Unrecognized non-terminal state: keep off Queue so cards do not oscillate.
+  // When the lifecycle gains a step, extend Build, Review, or PR above.
+  return "pr"
 }

--- a/apps/harness/src/routes/kanban.tsx
+++ b/apps/harness/src/routes/kanban.tsx
@@ -45,7 +45,7 @@ const PIPELINE_LANE_LABELS = {
   queue: "Queue",
   build: "Build",
   review: "Review",
-  ship: "Ship",
+  pr: "PR",
   attention: "Attention",
   complete: "Complete",
 } as const satisfies Record<PipelineLaneId, string>

--- a/apps/harness/test/kanban-route.test.ts
+++ b/apps/harness/test/kanban-route.test.ts
@@ -23,7 +23,7 @@ describe("/kanban route", () => {
       "Queue",
       "Build",
       "Review",
-      "Ship",
+      "PR",
       "Attention",
       "Complete",
     ]) {

--- a/apps/harness/test/pipeline-lanes.test.ts
+++ b/apps/harness/test/pipeline-lanes.test.ts
@@ -19,7 +19,7 @@ describe("PIPELINE_LANES", () => {
       { id: "queue", label: "Queue", color: "#ffd21c" },
       { id: "build", label: "Build", color: "#1976d2" },
       { id: "review", label: "Review", color: "#7654b5" },
-      { id: "ship", label: "Ship", color: "#168b62" },
+      { id: "pr", label: "PR", color: "#168b62" },
       { id: "attention", label: "Attention", color: "#ff4d1c" },
       { id: "complete", label: "Complete", color: "#151515" },
     ])
@@ -59,20 +59,28 @@ describe("pipelineLaneFor", () => {
   )
 
   test.each([
-    { state: "MERGE_PR", status: "QUEUED", lane: "queue" },
     {
-      state: "MERGE_PR",
+      state: "CREATE_WORKTREE",
+      status: "WAITING_FOR_BLOCKERS",
+      lane: "queue",
+    },
+    {
+      state: "CREATE_WORKTREE",
       status: "WAITING_FOR_WORKER_SLOT",
       lane: "queue",
     },
-    { state: "CREATE_WORKTREE", status: "QUEUED", lane: "queue" },
     {
       state: "INSTALL_DEPENDENCIES",
       status: "WAITING_FOR_WORKER_SLOT",
       lane: "queue",
     },
+    {
+      state: "MERGE_PR",
+      status: "WAITING_FOR_WORKER_SLOT",
+      lane: "queue",
+    },
   ] satisfies readonly LaneCase[])(
-    "places $state with $status in Queue",
+    "places blocked or not-admitted $state with $status in Queue",
     ({ state, status, lane }) => {
       expect(pipelineLaneFor({ state, status })).toBe(lane)
     },
@@ -84,6 +92,9 @@ describe("pipelineLaneFor", () => {
     { state: "IMPLEMENT", status: "RUNNING", lane: "build" },
     { state: "ASSESS_CHANGES", status: "RUNNING", lane: "build" },
     { state: "PRE_COMMIT", status: "RUNNING", lane: "build" },
+    { state: "CREATE_WORKTREE", status: "QUEUED", lane: "build" },
+    { state: "IMPLEMENT", status: "QUEUED", lane: "build" },
+    { state: "PRE_COMMIT", status: "QUEUED", lane: "build" },
   ] satisfies readonly LaneCase[])(
     "places $state with $status in Build",
     ({ state, status, lane }) => {
@@ -93,21 +104,7 @@ describe("pipelineLaneFor", () => {
 
   test.each([
     { state: "REVIEW", status: "RUNNING", lane: "review" },
-    {
-      state: "WATCH_PR_STATUS_CHECKS",
-      status: "RUNNING",
-      lane: "review",
-    },
-    {
-      state: "RESOLVE_PR_MERGE_CONFLICT",
-      status: "RUNNING",
-      lane: "review",
-    },
-    {
-      state: "INVESTIGATE_PR_STATUS_CHECKS",
-      status: "RUNNING",
-      lane: "review",
-    },
+    { state: "REVIEW", status: "QUEUED", lane: "review" },
   ] satisfies readonly LaneCase[])(
     "places $state with $status in Review",
     ({ state, status, lane }) => {
@@ -116,11 +113,39 @@ describe("pipelineLaneFor", () => {
   )
 
   test.each([
-    { state: "COMMIT", status: "RUNNING", lane: "ship" },
-    { state: "CREATE_PR", status: "WAITING_FOR_BLOCKERS", lane: "ship" },
-    { state: "MERGE_PR", status: "CANCELLED", lane: "ship" },
+    { state: "COMMIT", status: "RUNNING", lane: "pr" },
+    { state: "CREATE_PR", status: "RUNNING", lane: "pr" },
+    { state: "WATCH_PR_STATUS_CHECKS", status: "RUNNING", lane: "pr" },
+    {
+      state: "WATCH_PR_STATUS_CHECKS",
+      status: "QUEUED",
+      lane: "pr",
+    },
+    {
+      state: "RESOLVE_PR_MERGE_CONFLICT",
+      status: "RUNNING",
+      lane: "pr",
+    },
+    {
+      state: "INVESTIGATE_PR_STATUS_CHECKS",
+      status: "RUNNING",
+      lane: "pr",
+    },
+    {
+      state: "MARK_PR_READY_FOR_REVIEW",
+      status: "RUNNING",
+      lane: "pr",
+    },
+    { state: "DECIDE_PR_MERGE", status: "RUNNING", lane: "pr" },
+    { state: "MERGE_PR", status: "RUNNING", lane: "pr" },
+    { state: "MERGE_PR", status: "QUEUED", lane: "pr" },
+    { state: "CLOSE_ISSUE", status: "RUNNING", lane: "pr" },
+    { state: "LOCAL_CLEANUP", status: "RUNNING", lane: "pr" },
+    { state: "COMMIT", status: "QUEUED", lane: "pr" },
+    { state: "CREATE_PR", status: "QUEUED", lane: "pr" },
+    { state: "MERGE_PR", status: "CANCELLED", lane: "pr" },
   ] satisfies readonly LaneCase[])(
-    "places unclassified $state with $status in Ship",
+    "places $state with $status in PR",
     ({ state, status, lane }) => {
       expect(pipelineLaneFor({ state, status })).toBe(lane)
     },
@@ -133,11 +158,35 @@ describe("pipelineLaneFor", () => {
       status: "SUCCEEDED",
       lane: "complete",
     },
-    { state: "IMPLEMENT", status: "QUEUED", lane: "queue" },
+    {
+      state: "WATCH_PR_STATUS_CHECKS",
+      status: "FAILED",
+      lane: "attention",
+    },
+    {
+      state: "IMPLEMENT",
+      status: "WAITING_FOR_WORKER_SLOT",
+      lane: "queue",
+    },
   ] satisfies readonly LaneCase[])(
     "applies precedence to $state with $status",
     ({ state, status, lane }) => {
       expect(pipelineLaneFor({ state, status })).toBe(lane)
     },
   )
+
+  test("does not move a pending status-check poll between Queue and PR", () => {
+    expect(
+      pipelineLaneFor({
+        state: "WATCH_PR_STATUS_CHECKS",
+        status: "RUNNING",
+      }),
+    ).toBe("pr")
+    expect(
+      pipelineLaneFor({
+        state: "WATCH_PR_STATUS_CHECKS",
+        status: "QUEUED",
+      }),
+    ).toBe("pr")
+  })
 })

--- a/docs/kanban.md
+++ b/docs/kanban.md
@@ -4,7 +4,7 @@
 
 The Kanban Pipeline is an alternate Harness work view for an operator who
 needs to understand flow at a glance: what is waiting, being built, under
-review, ready to ship, blocked, or complete.
+review, in the PR path, blocked, or complete.
 
 It was prototyped in the `redesign/kanban-pipeline` branch. The prototype
 demonstrates the interaction model and visual direction; it is not currently
@@ -29,17 +29,26 @@ The board has six ordered lanes:
 
 | Lane | Meaning | Derived from |
 | --- | --- | --- |
-| Queue | Work has not begun active lifecycle execution. | `QUEUED`, `WAITING_FOR_WORKER_SLOT` |
-| Build | Active startup and implementation work is in progress. | `CREATE_WORKTREE`, `INSTALL_DEPENDENCIES`, `IMPLEMENT`, `ASSESS_CHANGES`, `PRE_COMMIT` |
-| Review | A pull request or review/check handoff is in progress. | `REVIEW`, `WATCH_PR_STATUS_CHECKS`, `RESOLVE_PR_MERGE_CONFLICT`, `INVESTIGATE_PR_STATUS_CHECKS` |
-| Ship | Work is beyond review but not terminal. | Any non-terminal lifecycle state not classified above |
+| Queue | Work cannot begin yet: waiting for blockers or a worker slot. | `WAITING_FOR_BLOCKERS`, `WAITING_FOR_WORKER_SLOT` |
+| Build | Startup and implementation work (including queued later Build steps). | `CREATE_WORKTREE`, `INSTALL_DEPENDENCIES`, `IMPLEMENT`, `ASSESS_CHANGES`, `PRE_COMMIT` |
+| Review | Local review is in progress (including a queued Review step). | `REVIEW` |
+| PR | Commit through cleanup on the pull-request path (including queued Watch and later PR steps). | `COMMIT`, `CREATE_PR`, `WATCH_PR_STATUS_CHECKS`, `RESOLVE_PR_MERGE_CONFLICT`, `INVESTIGATE_PR_STATUS_CHECKS`, `MARK_PR_READY_FOR_REVIEW`, `DECIDE_PR_MERGE`, `MERGE_PR`, `CLOSE_ISSUE`, `LOCAL_CLEANUP` |
 | Attention | An operator or remediation decision is needed. | Failed, interrupted, needs-human statuses or states |
 | Complete | The Work Item has reached a terminal successful or abandoned state. | Complete, succeeded, or abandoned statuses or states |
 
 Lane assignment is a pure function of the current Work Item state and status.
-The function must give Attention and Complete precedence over lifecycle-step
-classification. For example, a Work Item whose last step was Review but whose
-status is `NEEDS_HUMAN` belongs in Attention.
+Placement is driven by **lifecycle progress**, not scheduler status:
+
+- Attention and Complete take precedence over every lifecycle lane.
+- Queue is only for genuine blocked or not-admitted work. A `QUEUED` step run
+  (status-check poll, agent turn, or later lifecycle step) stays in Build,
+  Review, or PR according to its state.
+- Once work has entered Build, Review, or PR, queued execution of a later step
+  in that path must not return it to Queue or an earlier lane.
+
+For example, a Work Item whose last step was Review but whose status is
+`NEEDS_HUMAN` belongs in Attention. A Work Item in `WATCH_PR_STATUS_CHECKS`
+with status `QUEUED` (pending poll cycle) stays in PR, not Queue.
 
 ## Layout And Visual Language
 
@@ -47,7 +56,7 @@ The prototype uses an industrial control-board language:
 
 - Dense, six-column board with high-contrast lane headers.
 - Fixed lane colors make the flow memorable: Queue yellow, Build blue, Review
-  violet, Ship green, Attention orange, and Complete black.
+  violet, PR green, Attention orange, and Complete black.
 - Tickets use a narrow colored edge to retain their lane association while
   keeping title, repository, status, controls, session, and worktree visible.
 - Empty lanes explicitly say `Lane clear`; an empty lane is operational
@@ -149,6 +158,8 @@ systems.
 - Board placement never changes a Work Item, repository, or lifecycle state.
 - Attention wins over lifecycle-step placement; terminal status wins over
   lifecycle-step placement.
+- Queued status-check polls and other queued later steps stay in their
+  lifecycle lane; only blockers / worker-slot holds appear in Queue.
 - Every ticket preserves access to its existing operational actions.
 - Existing Working, Failed, and Completed views remain available and keyboard
   accessible.


### PR DESCRIPTION
## Why

The Kanban classifier gave scheduler status `QUEUED` precedence over
lifecycle progress. Status-check polling and other later steps therefore
bounced cards between Queue and Review/Ship even when the Work Item had
not regressed, which looked like backward motion on the board.

## What changed

- Place cards by lifecycle state: **Queue** only for
  `WAITING_FOR_BLOCKERS` / `WAITING_FOR_WORKER_SLOT`; **Build** for
  worktree through pre-commit; **Review** for local `REVIEW` only; **PR**
  for commit through local cleanup (including `WATCH_PR_STATUS_CHECKS`).
- Keep queued step runs (status-check polls, agent turns, later Build/PR
  steps) in their lifecycle lane instead of Queue.
- Rename the **Ship** lane to **PR** (id, labels, unit/e2e expectations,
  `docs/kanban.md`).
- Explicit PR state list after review remediation; drop an unrealistic
  blockers fixture.

## Verification

- Focused `pipeline-lanes` unit tests: 46 pass.
- Earlier session run: full `nx test harness` green (358 pass).

## Notes

Presentation-only change; no lifecycle or GraphQL contract changes.

Closes #632