### PR TITLE
feat(harness): simplify Kanban Complete-lane ticket status

### DIFF
--- a/apps/harness/src/live-duration.ts
+++ b/apps/harness/src/live-duration.ts
@@ -34,6 +34,20 @@ export function formatDuration(ms: number): string {
   return remainingMinutes === 0 ? `${hours}h` : `${hours}h ${remainingMinutes}m`
 }
 
+/**
+ * Total wall-clock elapsed time for a Work Item from creation to last state
+ * transition (for terminal items: end of the run).
+ */
+export function totalElapsedMs(
+  createdAt: string,
+  stateReadyAt: string,
+): number {
+  return Math.max(
+    0,
+    new Date(stateReadyAt).getTime() - new Date(createdAt).getTime(),
+  )
+}
+
 /** Formats job start time as a relative phrase, e.g. "Started 15 min ago". */
 export function formatStartedAgo(iso: string, nowMs = Date.now()): string {
   const elapsedMs = Math.max(0, nowMs - new Date(iso).getTime())

--- a/apps/harness/src/routes/kanban.tsx
+++ b/apps/harness/src/routes/kanban.tsx
@@ -6,12 +6,19 @@ import { CardCollapseToggle } from "../card-collapse-toggle.js"
 import { Copy } from "../copy.js"
 import { KanbanLiveUpdates } from "../kanban-live.js"
 import {
+  formatDuration,
+  formatStartedAgo,
+  totalElapsedMs,
+  useNowMs,
+} from "../live-duration.js"
+import {
   PIPELINE_LANES,
   type PipelineLaneId,
   pipelineLaneFor,
 } from "../pipeline-lanes.js"
 import { sessionWorktreeParts } from "../session-worktree-line.js"
 import { workItemIssueUrl } from "../work-item-issue-url.js"
+import { prBadgeClassName } from "../work-item-progress-chrome.js"
 import { workItemPullRequestUrl } from "../work-item-pull-request-url.js"
 import {
   CommittedPullRequestsDashboard,
@@ -129,6 +136,59 @@ function KanbanPage() {
   )
 }
 
+/**
+ * Complete-lane tickets omit per-step lifecycle chrome. Show only start time
+ * and total elapsed duration, plus a PR link when one exists.
+ *
+ * Gated by assigned lane (`laneId === "complete"`), not by which Jobs tab
+ * hosts the ticket — so Pipeline Complete-lane cards and Kanban Completed-tab
+ * rows that classify as complete share this compact view. Homepage Jobs
+ * Completed is unaffected (it never uses PipelineTicket).
+ *
+ * No-change completion-summary chrome is intentionally omitted: issue #630
+ * limits Complete-lane status to start + total duration (and PR identity).
+ */
+function PipelineCompleteSummary({
+  workItem,
+  pullRequestUrl,
+}: {
+  readonly workItem: WorkItem
+  readonly pullRequestUrl: string | null
+}) {
+  const nowMs = useNowMs(true)
+  const elapsedMs = totalElapsedMs(workItem.createdAt, workItem.stateReadyAt)
+  const elapsedLabel = `Elapsed ${formatDuration(elapsedMs)}`
+  const prNumber = workItem.pullRequestNumber
+  const openPullRequestLabel =
+    prNumber === null ? null : `Open pull request #${prNumber}`
+
+  return (
+    <div className="mt-2">
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <span className="font-mono text-xs tracking-[0.1em] text-ink-faint uppercase">
+          {formatStartedAgo(workItem.createdAt, nowMs)}
+        </span>
+        <span className="font-mono text-xs text-ink-faint">{elapsedLabel}</span>
+      </div>
+      {pullRequestUrl !== null &&
+        prNumber !== null &&
+        openPullRequestLabel !== null && (
+          <div className="mt-1.5">
+            <a
+              className={prBadgeClassName}
+              href={pullRequestUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              aria-label={openPullRequestLabel}
+            >
+              PR #{prNumber}
+            </a>
+          </div>
+        )}
+    </div>
+  )
+}
+
 function PipelineTicket({
   workItem,
   repository,
@@ -169,6 +229,7 @@ function PipelineTicket({
     workItem.worktreePath,
   )
   const lane = PIPELINE_LANES.find((candidate) => candidate.id === laneId)
+  const isCompleteLane = laneId === "complete"
 
   return (
     <li
@@ -223,12 +284,19 @@ function PipelineTicket({
           />
         )}
       </div>
-      <WorkItemLifecycleStatus
-        workItem={workItem}
-        compact
-        issueUrl={issueUrl}
-        pullRequestUrl={pullRequestUrl}
-      />
+      {isCompleteLane ? (
+        <PipelineCompleteSummary
+          workItem={workItem}
+          pullRequestUrl={pullRequestUrl}
+        />
+      ) : (
+        <WorkItemLifecycleStatus
+          workItem={workItem}
+          compact
+          issueUrl={issueUrl}
+          pullRequestUrl={pullRequestUrl}
+        />
+      )}
     </li>
   )
 }

--- a/apps/harness/test/jobs-reset-visibility.test.ts
+++ b/apps/harness/test/jobs-reset-visibility.test.ts
@@ -125,5 +125,8 @@ describe("Jobs Reset button wiring", () => {
     )
     expect(jobsCard).toContain("<WorkItemLifecycleStatus")
     expect(jobsCard).toContain("compact")
+    // Homepage isolation: Kanban Complete-lane summary must not leak here.
+    expect(jobsCard).not.toContain("PipelineCompleteSummary")
+    expect(jobsCard).not.toContain("totalElapsedMs")
   })
 })

--- a/apps/harness/test/kanban-route.test.ts
+++ b/apps/harness/test/kanban-route.test.ts
@@ -76,7 +76,62 @@ describe("/kanban route", () => {
     )
     expect(ticket).toContain("onOpenSession(workItem.id, sessionId)")
     expect(ticket).toContain("showValue={false}")
-    expect(ticket).not.toContain('laneId === "complete"')
+    // Complete lane only swaps lifecycle chrome; session/copy remain shared
+    // above that branch for every ticket.
+    expect(ticket).toContain('laneId === "complete"')
+    const sessionIndex = ticket.indexOf("onOpenSession(workItem.id, sessionId)")
+    const completeSummaryIndex = ticket.indexOf("<PipelineCompleteSummary")
+    expect(sessionIndex).toBeGreaterThan(-1)
+    expect(completeSummaryIndex).toBeGreaterThan(sessionIndex)
+  })
+
+  test("Complete-lane tickets show start time and total duration without lifecycle steps", () => {
+    const source = kanbanSource()
+    expect(source).toContain("function PipelineCompleteSummary(")
+    const summary = source.slice(
+      source.indexOf("function PipelineCompleteSummary("),
+      source.indexOf("function PipelineTicket("),
+    )
+    expect(summary).toContain("formatStartedAgo(workItem.createdAt, nowMs)")
+    expect(summary).toContain(
+      "totalElapsedMs(workItem.createdAt, workItem.stateReadyAt)",
+    )
+    expect(summary).toContain("Elapsed ${")
+    expect(summary).toContain("formatDuration(elapsedMs)")
+    expect(summary).not.toContain("lifecycleLabels")
+    expect(summary).not.toContain("WorkItemLifecycleStatus")
+    expect(summary).not.toContain("Lifecycle steps")
+    // Intentional: no-change completionSummary chrome is out of Complete-lane scope.
+    expect(summary).not.toContain("completionSummary")
+    expect(summary).not.toContain("WorkItemOutcomePresentation")
+
+    const ticket = source.slice(
+      source.indexOf("function PipelineTicket("),
+      source.indexOf("function KanbanJobsBoard()"),
+    )
+    expect(ticket).toContain('laneId === "complete"')
+    expect(ticket).toContain("<PipelineCompleteSummary")
+    // Non-complete lanes keep the full compact lifecycle status.
+    expect(ticket).toContain("<WorkItemLifecycleStatus")
+    const completeBranch = ticket.slice(ticket.indexOf("isCompleteLane ? ("))
+    expect(completeBranch).toContain("<PipelineCompleteSummary")
+    expect(completeBranch).toContain("<WorkItemLifecycleStatus")
+  })
+
+  test("Kanban list tabs share Complete-lane compact summary via pipelineLaneFor", () => {
+    // Gate is lane identity, not Pipeline vs Completed tab. Completed-tab rows
+    // that classify as complete intentionally reuse PipelineCompleteSummary;
+    // homepage Jobs Completed isolation is separate (index.tsx JobsCard).
+    const source = kanbanSource()
+    const board = source.slice(source.indexOf("function KanbanJobsBoard("))
+    expect(board).toContain("laneId={pipelineLaneFor(workItem)}")
+    expect(board).toContain("<PipelineTicket")
+    const ticket = source.slice(
+      source.indexOf("function PipelineTicket("),
+      source.indexOf("function KanbanJobsBoard()"),
+    )
+    expect(ticket).toContain('const isCompleteLane = laneId === "complete"')
+    expect(ticket).toContain("<PipelineCompleteSummary")
   })
 
   test("shows agent backend label inline before session id on pipeline tickets", () => {

--- a/apps/harness/test/live-duration.test.ts
+++ b/apps/harness/test/live-duration.test.ts
@@ -3,6 +3,7 @@ import {
   formatStartedAgo,
   isLiveDurationStatus,
   liveDurationMs,
+  totalElapsedMs,
 } from "../src/live-duration.js"
 import { describe, expect, test } from "bun:test"
 
@@ -113,5 +114,22 @@ describe("formatDuration", () => {
     expect(formatDuration(3_000)).toBe("3s")
     expect(formatDuration(78_000)).toBe("1m 18s")
     expect(formatDuration(120_000)).toBe("2m")
+  })
+})
+
+describe("totalElapsedMs", () => {
+  test("computes wall-clock elapsed from createdAt to stateReadyAt", () => {
+    const createdAt = new Date(1_000_000).toISOString()
+    const stateReadyAt = new Date(1_000_000 + 78_000).toISOString()
+    expect(totalElapsedMs(createdAt, stateReadyAt)).toBe(78_000)
+    expect(formatDuration(totalElapsedMs(createdAt, stateReadyAt))).toBe(
+      "1m 18s",
+    )
+  })
+
+  test("clamps inverted timestamps to zero", () => {
+    const createdAt = new Date(2_000_000).toISOString()
+    const stateReadyAt = new Date(1_000_000).toISOString()
+    expect(totalElapsedMs(createdAt, stateReadyAt)).toBe(0)
   })
 })


### PR DESCRIPTION
## Why

Completed Work Items in the `/kanban` Complete lane showed the full
lifecycle-step history (every stage, badge, and per-step duration). That
density is useful on the homepage Jobs views but clutters a flow board where
operators mainly need start time and total run length.

## What

- Complete-lane tickets (`laneId === "complete"`) render a compact summary:
  relative start (`formatStartedAgo`), total elapsed from
  `createdAt`/`stateReadyAt` as `Elapsed …`, and a PR link when present.
- Non-complete lanes keep compact `WorkItemLifecycleStatus` (step chips and
  outcomes).
- Homepage Jobs Completed is unchanged; only `/kanban` `PipelineTicket`
  presentation is gated.
- Kanban Completed-tab rows that classify as complete share the same
  lane-based compact view by design.
- No-change completion-summary chrome is intentionally omitted on
  Complete-lane tickets per issue scope.

## Verification

- Focused harness tests: `kanban-route`, `live-duration`,
  `jobs-reset-visibility` (Complete-lane rendering, homepage isolation,
  elapsed helper).
- `bunx nx run harness:typecheck`
- Pre-commit (lint/typecheck/test) passed after format/a11y fixes.

Closes #630