### PR TITLE
feat(e2e): add GitLab fixture parity for live harness Gherkin

### DIFF
--- a/apps/harness/README.md
+++ b/apps/harness/README.md
@@ -71,15 +71,21 @@ without wrapping the Harness in a second coordinator process.
 
 The Gherkin operator journeys under `e2e/features/` run the production build
 against a fresh isolated Harness database. They verify adding and refreshing
-the private End-to-End Fixture Repository through the real operator binary, as
-well as the dedicated Kanban pipeline route.
+the GitHub and GitLab End-to-End Fixture Repositories through the real operator
+binary, as well as the dedicated Kanban pipeline route.
 
 ```bash
 bunx nx run harness:e2e
 ```
 
-Local runs leave `~/.keymaxxer` untouched and use your matching
-`provider=github` / `account=berenddeboer/test-ready-for-agent` credential
-(normal Keymaxxer prompts allowed). CI will unlock the checked-in fixture vault
-with `E2E_KEYMAXXER_MASTER_KEY` (see `docs/e2e-fixture.md` and
-`docs/adr/0021-live-harness-end-to-end-test.md`).
+Local runs leave `~/.keymaxxer` untouched and use your matching fixture
+credentials (normal Keymaxxer prompts allowed):
+
+- GitHub: `provider=github` / `account=berenddeboer/test-ready-for-agent`
+- GitLab: `provider=gitlab` /
+  `account=git.drupalcode.org/<fixture-project-path>`
+
+CI unlocks the checked-in fixture vault with `E2E_KEYMAXXER_MASTER_KEY`. The
+GitLab scenario soft-skips until that vault includes the GitLab secret; set
+`E2E_REQUIRE_GITLAB=1` to fail closed after bootstrap. See `docs/e2e-fixture.md`
+and `docs/adr/0021-live-harness-end-to-end-test.md`.

--- a/apps/harness/e2e/features/add-and-refresh-repository.feature
+++ b/apps/harness/e2e/features/add-and-refresh-repository.feature
@@ -2,9 +2,16 @@ Feature: Add and refresh a Repository
   Operators add a local checkout through the CLI and rely on credential
   activation's automatic first Refresh Job to surface Relevant Issues.
 
-  Scenario: Add and refresh a Repository
+  Scenario: Add and refresh a GitHub Repository
     Given the Harness has no configured Repositories
     And the End-to-End Fixture Repository is checked out
+    When I add the Repository with the CLI
+    Then the Repository appears in the Harness
+    And the sentinel Issue appears after the automatic first Refresh Job
+
+  Scenario: Add and refresh a GitLab Repository
+    Given the Harness has no configured Repositories
+    And the GitLab End-to-End Fixture Repository is checked out
     When I add the Repository with the CLI
     Then the Repository appears in the Harness
     And the sentinel Issue appears after the automatic first Refresh Job

--- a/apps/harness/e2e/steps/add-and-refresh-repository.ts
+++ b/apps/harness/e2e/steps/add-and-refresh-repository.ts
@@ -11,7 +11,7 @@ import {
 import {
   E2E_GRAPHQL_URL,
   FIXTURE_GITHUB_REPOSITORY,
-  FIXTURE_GITLAB_REPOSITORY,
+  FIXTURE_GITLAB_PROJECT_PATH,
   GITHUB_SENTINEL_ISSUE_NUMBER,
   GITHUB_SENTINEL_ISSUE_TITLE,
   GITLAB_SENTINEL_ISSUE_TITLE,
@@ -27,7 +27,7 @@ const workspaceRoot = resolve(
 )
 
 const displayRepositoryFor = (forge: FixtureForge): string =>
-  forge === "gitlab" ? FIXTURE_GITLAB_REPOSITORY : FIXTURE_GITHUB_REPOSITORY
+  forge === "gitlab" ? FIXTURE_GITLAB_PROJECT_PATH : FIXTURE_GITHUB_REPOSITORY
 
 const sentinelFor = (forge: FixtureForge) =>
   forge === "gitlab"

--- a/apps/harness/e2e/steps/add-and-refresh-repository.ts
+++ b/apps/harness/e2e/steps/add-and-refresh-repository.ts
@@ -2,14 +2,22 @@ import { spawnSync } from "node:child_process"
 import { dirname, resolve } from "node:path"
 import { fileURLToPath } from "node:url"
 import { expect } from "@playwright/test"
-import { cloneFixtureRepository } from "../support/clone-fixture-repo.ts"
+import {
+  type FixtureForge,
+  cloneFixtureRepository,
+  gitlabFixtureSpec,
+  hasFixtureCredential,
+} from "../support/clone-fixture-repo.ts"
 import {
   E2E_GRAPHQL_URL,
-  FIXTURE_REPOSITORY,
+  FIXTURE_GITHUB_REPOSITORY,
+  FIXTURE_GITLAB_REPOSITORY,
+  GITHUB_SENTINEL_ISSUE_NUMBER,
+  GITHUB_SENTINEL_ISSUE_TITLE,
+  GITLAB_SENTINEL_ISSUE_TITLE,
   SCENARIO_TIMEOUT_MS,
   SENTINEL_EXPECT_TIMEOUT_MS,
-  SENTINEL_ISSUE_NUMBER,
-  SENTINEL_ISSUE_TITLE,
+  gitlabSentinelIssueNumber,
 } from "../support/constants.ts"
 import { Given, Then, When, test } from "./fixtures.ts"
 
@@ -18,8 +26,146 @@ const workspaceRoot = resolve(
   "../../../..",
 )
 
+const displayRepositoryFor = (forge: FixtureForge): string =>
+  forge === "gitlab" ? FIXTURE_GITLAB_REPOSITORY : FIXTURE_GITHUB_REPOSITORY
+
+const sentinelFor = (forge: FixtureForge) =>
+  forge === "gitlab"
+    ? {
+        number: gitlabSentinelIssueNumber(),
+        title: GITLAB_SENTINEL_ISSUE_TITLE,
+      }
+    : {
+        number: GITHUB_SENTINEL_ISSUE_NUMBER,
+        title: GITHUB_SENTINEL_ISSUE_TITLE,
+      }
+
+class GraphQlRequestError extends Error {
+  readonly codes: ReadonlyArray<string>
+
+  constructor(messages: ReadonlyArray<string>, codes: ReadonlyArray<string>) {
+    super(`GraphQL errors: ${messages.join("; ")}`)
+    this.name = "GraphQlRequestError"
+    this.codes = codes
+  }
+}
+
+const graphqlRequest = async <T>(
+  query: string,
+  variables?: Record<string, unknown>,
+): Promise<T> => {
+  const response = await fetch(E2E_GRAPHQL_URL, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ query, variables }),
+  })
+  if (!response.ok) {
+    throw new Error(`GraphQL HTTP ${response.status}: ${await response.text()}`)
+  }
+  const payload = (await response.json()) as {
+    data?: T
+    errors?: ReadonlyArray<{
+      message: string
+      extensions?: { code?: string }
+    }>
+  }
+  if (payload.errors?.length) {
+    throw new GraphQlRequestError(
+      payload.errors.map((e) => e.message),
+      payload.errors.map((e) => e.extensions?.code ?? ""),
+    )
+  }
+  if (!payload.data) {
+    throw new Error("GraphQL response missing data")
+  }
+  return payload.data
+}
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
+
+const isRunningStepRemoveError = (error: unknown): boolean => {
+  if (error instanceof GraphQlRequestError) {
+    if (error.codes.includes("REPOSITORY_HAS_RUNNING_STEP")) {
+      return true
+    }
+  }
+  const message = error instanceof Error ? error.message : String(error)
+  return (
+    /REPOSITORY_HAS_RUNNING_STEP/i.test(message) ||
+    /has a running Step Run/i.test(message) ||
+    /RepositoryHasRunningStep/i.test(message)
+  )
+}
+
+/**
+ * Clear leftover Repositories so multi-scenario e2e shares one Harness process.
+ * Retries briefly when remove is blocked by a still-running Step Run.
+ */
+const ensureNoConfiguredRepositories = async () => {
+  const deadline = Date.now() + 30_000
+  let attempt = 0
+  while (true) {
+    attempt += 1
+    const listed = await graphqlRequest<{
+      repositories: ReadonlyArray<{ id: string }>
+    }>(`query { repositories { id } }`)
+    if (listed.repositories.length === 0) {
+      return
+    }
+
+    let blockedByRunningStep = false
+    const failures: string[] = []
+    for (const repository of listed.repositories) {
+      try {
+        await graphqlRequest(
+          `mutation RemoveRepository($repositoryId: ID!) {
+            removeRepository(repositoryId: $repositoryId)
+          }`,
+          { repositoryId: repository.id },
+        )
+      } catch (error) {
+        if (isRunningStepRemoveError(error)) {
+          blockedByRunningStep = true
+          failures.push(error instanceof Error ? error.message : String(error))
+          continue
+        }
+        throw error
+      }
+    }
+
+    // When no remove was classified as running-step blocked, re-list and return
+    // only if empty; otherwise retry until the deadline (blocked path re-lists
+    // at the top of the next loop iteration).
+    if (!blockedByRunningStep) {
+      const remaining = await graphqlRequest<{
+        repositories: ReadonlyArray<{ id: string }>
+      }>(`query { repositories { id } }`)
+      if (remaining.repositories.length === 0) {
+        return
+      }
+    }
+
+    if (Date.now() >= deadline) {
+      throw new Error(
+        [
+          "Could not clear configured Repositories",
+          blockedByRunningStep
+            ? "because a Step Run is still running"
+            : "after remove mutations",
+          `(after ${attempt} attempts over ~30s).`,
+          "Multi-scenario e2e shares one Harness process; wait for refresh/work",
+          "to finish, or restart the e2e webServer.",
+          ...failures,
+        ].join(" "),
+      )
+    }
+    await sleep(500)
+  }
+}
+
 Given("the Harness has no configured Repositories", async ({ page }) => {
   test.setTimeout(SCENARIO_TIMEOUT_MS)
+  await ensureNoConfiguredRepositories()
   await page.goto("/")
   await expect(
     page.getByRole("heading", { name: "No repositories configured" }),
@@ -41,10 +187,64 @@ Given("the Harness has no configured Repositories", async ({ page }) => {
 })
 
 Given("the End-to-End Fixture Repository is checked out", async ({ world }) => {
-  const { checkoutPath, cleanup } = await cloneFixtureRepository()
+  const { checkoutPath, cleanup, spec } = await cloneFixtureRepository("github")
   world.fixtureCheckoutPath = checkoutPath
   world.cleanupFixtureCheckout = cleanup
+  world.fixtureForge = "github"
+  world.fixtureDisplayRepository = spec.displayRepository
 })
+
+Given(
+  "the GitLab End-to-End Fixture Repository is checked out",
+  async ({ world }) => {
+    const spec = gitlabFixtureSpec()
+    // Soft-skip until the dual-secret fixture vault is regenerated (operator
+    // step after the throwaway project and PAT exist). Hard-require with
+    // E2E_REQUIRE_GITLAB=1 so CI can fail closed once the vault includes
+    // the GitLab credential. Infrastructure errors (missing master key,
+    // keymaxxer list failure) always throw rather than soft-skipping.
+    let hasCredential: boolean
+    try {
+      hasCredential = hasFixtureCredential(spec)
+    } catch (error) {
+      const detail = error instanceof Error ? error.message : String(error)
+      throw new Error(
+        [
+          "Could not inspect the Keymaxxer vault for the GitLab e2e credential.",
+          detail,
+        ].join(" "),
+      )
+    }
+    if (!hasCredential) {
+      const requireGitlab =
+        process.env.E2E_REQUIRE_GITLAB === "1" ||
+        process.env.E2E_REQUIRE_GITLAB === "true"
+      const message = [
+        "GitLab e2e credential is not present in the Keymaxxer vault.",
+        `Expected secret ${spec.secretName} (provider=gitlab account=${spec.account}).`,
+        "Create the throwaway fixture on git.drupalcode.org, mint a PAT, and run",
+        "./scripts/regenerate-e2e-keymaxxer-vault.sh --with-gitlab",
+        "(see docs/e2e-fixture.md).",
+        "Set E2E_REQUIRE_GITLAB=1 to fail instead of skipping.",
+      ].join(" ")
+      if (requireGitlab) {
+        throw new Error(message)
+      }
+      test.skip(true, message)
+      return
+    }
+
+    const {
+      checkoutPath,
+      cleanup,
+      spec: cloneSpec,
+    } = await cloneFixtureRepository("gitlab")
+    world.fixtureCheckoutPath = checkoutPath
+    world.cleanupFixtureCheckout = cleanup
+    world.fixtureForge = "gitlab"
+    world.fixtureDisplayRepository = cloneSpec.displayRepository
+  },
+)
 
 When("I add the Repository with the CLI", async ({ world }) => {
   const checkoutPath = world.fixtureCheckoutPath
@@ -78,27 +278,30 @@ When("I add the Repository with the CLI", async ({ world }) => {
   }
 })
 
-Then("the Repository appears in the Harness", async ({ page }) => {
+Then("the Repository appears in the Harness", async ({ page, world }) => {
+  const forge = world.fixtureForge ?? "github"
+  const display = world.fixtureDisplayRepository ?? displayRepositoryFor(forge)
+
   await page.goto("/")
   await expect(
     page.getByRole("region", { name: "Configured repositories" }),
   ).toBeVisible({ timeout: 30_000 })
-  await expect(
-    page.getByRole("link", { name: FIXTURE_REPOSITORY }),
-  ).toBeVisible()
+  await expect(page.getByRole("link", { name: display })).toBeVisible()
 })
 
 Then(
   "the sentinel Issue appears after the automatic first Refresh Job",
-  async ({ page }) => {
+  async ({ page, world }) => {
+    const forge = world.fixtureForge ?? "github"
+    const sentinel = sentinelFor(forge)
     // Tolerate unrelated Issues; only require the permanent sentinel identity.
     await expect(
-      page.getByText(`#${SENTINEL_ISSUE_NUMBER}`, { exact: true }),
+      page.getByText(`#${sentinel.number}`, { exact: true }),
     ).toBeVisible({
       timeout: SENTINEL_EXPECT_TIMEOUT_MS,
     })
-    await expect(
-      page.getByRole("link", { name: SENTINEL_ISSUE_TITLE }),
-    ).toBeVisible({ timeout: SENTINEL_EXPECT_TIMEOUT_MS })
+    await expect(page.getByRole("link", { name: sentinel.title })).toBeVisible({
+      timeout: SENTINEL_EXPECT_TIMEOUT_MS,
+    })
   },
 )

--- a/apps/harness/e2e/steps/fixtures.ts
+++ b/apps/harness/e2e/steps/fixtures.ts
@@ -1,8 +1,11 @@
 import { test as base, createBdd } from "playwright-bdd"
+import type { FixtureForge } from "../support/clone-fixture-repo.ts"
 
 export type LiveE2eWorld = {
   fixtureCheckoutPath?: string
   cleanupFixtureCheckout?: () => void
+  fixtureForge?: FixtureForge
+  fixtureDisplayRepository?: string
 }
 
 export const test = base.extend<{ world: LiveE2eWorld }>({

--- a/apps/harness/e2e/support/clone-fixture-repo.ts
+++ b/apps/harness/e2e/support/clone-fixture-repo.ts
@@ -14,7 +14,25 @@ import {
   KeymaxxerService,
   sidecarKeymaxxerLayer,
 } from "@ready-for-agent/keymaxxer-service"
-import { FIXTURE_REPOSITORY, FIXTURE_SECRET_NAME } from "./constants.ts"
+import {
+  FIXTURE_GITHUB_REPOSITORY,
+  FIXTURE_GITHUB_SECRET_NAME,
+  FIXTURE_GITLAB_FORGE_HOST,
+  FIXTURE_GITLAB_PROJECT_PATH,
+  FIXTURE_GITLAB_SECRET_NAME,
+  FIXTURE_GITLAB_VAULT_ACCOUNT,
+} from "./constants.ts"
+
+export type FixtureForge = "github" | "gitlab"
+
+export type FixtureCloneSpec = {
+  readonly forge: FixtureForge
+  readonly secretName: string
+  readonly provider: "github" | "gitlab"
+  readonly account: string
+  readonly displayRepository: string
+  readonly cloneUrlTemplate: (secretName: string) => string
+}
 
 class CloneFixtureError extends Data.TaggedError("CloneFixtureError")<{
   readonly message: string
@@ -24,12 +42,40 @@ const supportDir = dirname(fileURLToPath(import.meta.url))
 const workspaceRoot = resolve(supportDir, "../../../..")
 const fixtureVaultDir = resolve(workspaceRoot, "e2e/fixtures/keymaxxer")
 
-const missingCredentialMessage = [
-  `Live e2e requires a Keymaxxer credential for account ${FIXTURE_REPOSITORY}`,
-  `(canonical name ${FIXTURE_SECRET_NAME}, provider=github).`,
-  "Add that secret to your vault, or set E2E_KEYMAXXER_MASTER_KEY / KEYMAXXER_MASTER_KEY",
-  "to use the checked-in fixture vault.",
-].join(" ")
+export const githubFixtureSpec = (): FixtureCloneSpec => ({
+  forge: "github",
+  secretName: FIXTURE_GITHUB_SECRET_NAME,
+  provider: "github",
+  account: FIXTURE_GITHUB_REPOSITORY,
+  displayRepository: FIXTURE_GITHUB_REPOSITORY,
+  cloneUrlTemplate: (secretName) =>
+    `https://x-access-token:\${${secretName}}@github.com/${FIXTURE_GITHUB_REPOSITORY}.git`,
+})
+
+export const gitlabFixtureSpec = (): FixtureCloneSpec => ({
+  forge: "gitlab",
+  secretName: FIXTURE_GITLAB_SECRET_NAME,
+  provider: "gitlab",
+  account: FIXTURE_GITLAB_VAULT_ACCOUNT,
+  displayRepository: FIXTURE_GITLAB_PROJECT_PATH,
+  // GitLab HTTPS clones authenticate as oauth2:<token> (see Create PR push).
+  cloneUrlTemplate: (secretName) =>
+    `https://oauth2:\${${secretName}}@${FIXTURE_GITLAB_FORGE_HOST}/${FIXTURE_GITLAB_PROJECT_PATH}.git`,
+})
+
+const missingCredentialMessage = (spec: FixtureCloneSpec) => {
+  const regenHint =
+    spec.forge === "gitlab"
+      ? "Regenerate with: ./scripts/regenerate-e2e-keymaxxer-vault.sh --with-gitlab (see docs/e2e-fixture.md)."
+      : "Regenerate with: ./scripts/regenerate-e2e-keymaxxer-vault.sh (see docs/e2e-fixture.md)."
+  return [
+    `Live e2e requires a Keymaxxer credential for account ${spec.account}`,
+    `(canonical name ${spec.secretName}, provider=${spec.provider}).`,
+    "Add that secret to your vault, or set E2E_KEYMAXXER_MASTER_KEY / KEYMAXXER_MASTER_KEY",
+    "to use the checked-in fixture vault.",
+    regenHint,
+  ].join(" ")
+}
 
 const keymaxxerBin = () => {
   const workspaceBin = resolve(workspaceRoot, "node_modules/.bin/keymaxxer")
@@ -77,7 +123,7 @@ const fixtureVaultEnv = (): NodeJS.ProcessEnv | null => {
   }
 }
 
-const assertSecretPresentViaCli = (env: NodeJS.ProcessEnv) => {
+const listKeymaxxerOutput = (env: NodeJS.ProcessEnv): string => {
   const listed = spawnSync(keymaxxerBin(), ["list"], {
     env,
     encoding: "utf8",
@@ -86,19 +132,50 @@ const assertSecretPresentViaCli = (env: NodeJS.ProcessEnv) => {
   if (listed.status !== 0) {
     throw new Error(
       [
-        "Failed to list Keymaxxer secrets before cloning the fixture Repository.",
+        "Failed to list Keymaxxer secrets before cloning a fixture Repository.",
         listed.stderr?.trim() ||
           listed.stdout?.trim() ||
-          missingCredentialMessage,
+          "keymaxxer list failed",
       ].join("\n"),
     )
   }
-  const output = `${listed.stdout}\n${listed.stderr}`
-  if (
-    !output.includes(FIXTURE_SECRET_NAME) &&
-    !output.includes(FIXTURE_REPOSITORY)
-  ) {
-    throw new Error(missingCredentialMessage)
+  return `${listed.stdout}\n${listed.stderr}`
+}
+
+/**
+ * Whether the fixture vault (or ambient vault when not in fixture mode)
+ * currently lists the given e2e credential. Used to soft-skip the GitLab
+ * scenario until the operator regenerates the dual-secret vault.
+ *
+ * Infrastructure failures (missing master key, keymaxxer list errors) throw;
+ * only a successful list that lacks the secret returns false.
+ */
+export const hasFixtureCredential = (
+  spec: FixtureCloneSpec = gitlabFixtureSpec(),
+): boolean => {
+  let fixtureHome: string | undefined
+  try {
+    const fixtureEnv = fixtureVaultEnv()
+    if (fixtureEnv?.HOME) {
+      fixtureHome = fixtureEnv.HOME
+    }
+    const env = fixtureEnv ?? process.env
+    const output = listKeymaxxerOutput(env)
+    return output.includes(spec.secretName) || output.includes(spec.account)
+  } finally {
+    if (fixtureHome) {
+      rmSync(fixtureHome, { recursive: true, force: true })
+    }
+  }
+}
+
+const assertSecretPresentViaCli = (
+  env: NodeJS.ProcessEnv,
+  spec: FixtureCloneSpec,
+) => {
+  const output = listKeymaxxerOutput(env)
+  if (!output.includes(spec.secretName) && !output.includes(spec.account)) {
+    throw new Error(missingCredentialMessage(spec))
   }
 }
 
@@ -107,21 +184,25 @@ export const keymaxxerRunArgs = (
   command: string,
 ): string[] => ["run", "--secrets", secretName, "--", command]
 
-const cloneViaCli = (checkoutParent: string, env: NodeJS.ProcessEnv) => {
-  assertSecretPresentViaCli(env)
+const cloneViaCli = (
+  checkoutParent: string,
+  env: NodeJS.ProcessEnv,
+  spec: FixtureCloneSpec,
+) => {
+  assertSecretPresentViaCli(env, spec)
   const dest = join(checkoutParent, "repo")
   const cloneCommand = [
     "git",
     "clone",
     "--depth",
     "1",
-    `"https://x-access-token:\${${FIXTURE_SECRET_NAME}}@github.com/${FIXTURE_REPOSITORY}.git"`,
+    `"${spec.cloneUrlTemplate(spec.secretName)}"`,
     `"${dest}"`,
   ].join(" ")
 
   const result = spawnSync(
     keymaxxerBin(),
-    keymaxxerRunArgs(FIXTURE_SECRET_NAME, cloneCommand),
+    keymaxxerRunArgs(spec.secretName, cloneCommand),
     {
       env,
       encoding: "utf8",
@@ -139,28 +220,32 @@ const cloneViaCli = (checkoutParent: string, env: NodeJS.ProcessEnv) => {
       detail.toLowerCase().includes("unknown secret") ||
       detail.toLowerCase().includes("no such secret")
     ) {
-      throw new Error(`${missingCredentialMessage}\n${detail}`)
+      throw new Error(`${missingCredentialMessage(spec)}\n${detail}`)
     }
     throw new Error(
-      `Failed to clone ${FIXTURE_REPOSITORY} through Keymaxxer.\n${detail}`,
+      `Failed to clone ${spec.displayRepository} through Keymaxxer.\n${detail}`,
     )
   }
   return dest
 }
 
-const cloneViaSidecar = async (checkoutParent: string, sidecarUrl: string) => {
+const cloneViaSidecar = async (
+  checkoutParent: string,
+  sidecarUrl: string,
+  spec: FixtureCloneSpec,
+) => {
   const dest = join(checkoutParent, "repo")
 
   const program = Effect.gen(function* () {
     const keymaxxer = yield* KeymaxxerService
     yield* keymaxxer.initialize
     const secretName = yield* keymaxxer.findSecret({
-      provider: "github",
-      account: FIXTURE_REPOSITORY,
+      provider: spec.provider,
+      account: spec.account,
     })
     if (secretName === null) {
       return yield* new CloneFixtureError({
-        message: missingCredentialMessage,
+        message: missingCredentialMessage(spec),
       })
     }
     const cloneCommand = [
@@ -168,7 +253,7 @@ const cloneViaSidecar = async (checkoutParent: string, sidecarUrl: string) => {
       "clone",
       "--depth",
       "1",
-      `"https://x-access-token:\${${secretName}}@github.com/${FIXTURE_REPOSITORY}.git"`,
+      `"${spec.cloneUrlTemplate(secretName)}"`,
       `"${dest}"`,
     ].join(" ")
     const result = yield* keymaxxer.runWithSecrets({
@@ -180,7 +265,7 @@ const cloneViaSidecar = async (checkoutParent: string, sidecarUrl: string) => {
     if (result.exitCode !== 0 || !existsSync(join(dest, ".git"))) {
       return yield* new CloneFixtureError({
         message: [
-          `Failed to clone ${FIXTURE_REPOSITORY} through Keymaxxer Sidecar.`,
+          `Failed to clone ${spec.displayRepository} through Keymaxxer Sidecar.`,
           result.stderr.trim() ||
             result.stdout.trim() ||
             `exit ${result.exitCode}`,
@@ -196,35 +281,51 @@ const cloneViaSidecar = async (checkoutParent: string, sidecarUrl: string) => {
 }
 
 /**
- * Clone the private End-to-End Fixture Repository through Keymaxxer into a
- * fresh temporary checkout. Leaves ~/.keymaxxer untouched in local mode.
+ * Clone an End-to-End Fixture Repository through Keymaxxer into a fresh
+ * temporary checkout. Leaves ~/.keymaxxer untouched in local mode.
  */
-export const cloneFixtureRepository = async (): Promise<{
+export const cloneFixtureRepository = async (
+  forge: FixtureForge = "github",
+): Promise<{
   readonly checkoutPath: string
   readonly cleanup: () => void
+  readonly spec: FixtureCloneSpec
 }> => {
+  const spec = forge === "gitlab" ? gitlabFixtureSpec() : githubFixtureSpec()
   const checkoutParent = mkdtempSync(
-    join(tmpdir(), "rfa-e2e-fixture-checkout-"),
+    join(tmpdir(), `rfa-e2e-${forge}-fixture-checkout-`),
   )
+  let fixtureVaultHome: string | undefined
   const cleanup = () => {
     rmSync(checkoutParent, { recursive: true, force: true })
+    if (fixtureVaultHome) {
+      rmSync(fixtureVaultHome, { recursive: true, force: true })
+      fixtureVaultHome = undefined
+    }
   }
 
   try {
     const fixtureEnv = fixtureVaultEnv()
     if (fixtureEnv !== null) {
-      const checkoutPath = cloneViaCli(checkoutParent, fixtureEnv)
-      return { checkoutPath, cleanup }
+      if (fixtureEnv.HOME) {
+        fixtureVaultHome = fixtureEnv.HOME
+      }
+      const checkoutPath = cloneViaCli(checkoutParent, fixtureEnv, spec)
+      return { checkoutPath, cleanup, spec }
     }
 
     const sidecarUrl = process.env.KEYMAXXER_SIDECAR_URL?.trim()
     if (sidecarUrl) {
-      const checkoutPath = await cloneViaSidecar(checkoutParent, sidecarUrl)
-      return { checkoutPath, cleanup }
+      const checkoutPath = await cloneViaSidecar(
+        checkoutParent,
+        sidecarUrl,
+        spec,
+      )
+      return { checkoutPath, cleanup, spec }
     }
 
-    const checkoutPath = cloneViaCli(checkoutParent, process.env)
-    return { checkoutPath, cleanup }
+    const checkoutPath = cloneViaCli(checkoutParent, process.env, spec)
+    return { checkoutPath, cleanup, spec }
   } catch (error) {
     cleanup()
     throw error

--- a/apps/harness/e2e/support/constants.ts
+++ b/apps/harness/e2e/support/constants.ts
@@ -19,11 +19,10 @@ export const GITHUB_SENTINEL_ISSUE_TITLE =
 // support local bootstrap before constants are locked.
 export const FIXTURE_GITLAB_FORGE_HOST =
   process.env.E2E_GITLAB_FORGE_HOST?.trim() || "git.drupalcode.org"
+/** Project Path and UI display identity for the GitLab fixture Repository. */
 export const FIXTURE_GITLAB_PROJECT_PATH =
   process.env.E2E_GITLAB_PROJECT_PATH?.trim() ||
   "sandbox/berend-test-ready-for-agent"
-/** Display identity shown in the Harness UI (Project Path). */
-export const FIXTURE_GITLAB_REPOSITORY = FIXTURE_GITLAB_PROJECT_PATH
 /**
  * Keymaxxer account is `<forge-host>/<project-path>` with provider=gitlab.
  * Canonical secret name follows the GitHub fixture naming convention.

--- a/apps/harness/e2e/support/constants.ts
+++ b/apps/harness/e2e/support/constants.ts
@@ -2,17 +2,71 @@ export const E2E_HARNESS_PORT = 4174
 export const E2E_BASE_URL = `http://127.0.0.1:${E2E_HARNESS_PORT}`
 export const E2E_GRAPHQL_URL = `${E2E_BASE_URL}/graphql`
 
+// --- GitHub End-to-End Fixture Repository ---
 export const FIXTURE_GITHUB_OWNER = "berenddeboer"
 export const FIXTURE_GITHUB_REPO = "test-ready-for-agent"
-export const FIXTURE_REPOSITORY = `${FIXTURE_GITHUB_OWNER}/${FIXTURE_GITHUB_REPO}`
-export const FIXTURE_SECRET_NAME =
+export const FIXTURE_GITHUB_REPOSITORY = `${FIXTURE_GITHUB_OWNER}/${FIXTURE_GITHUB_REPO}`
+export const FIXTURE_GITHUB_SECRET_NAME =
   "GITHUB_TOKEN_BERENDDEBOER_TEST_READY_FOR_AGENT"
 
-export const SENTINEL_ISSUE_NUMBER = 22
-export const SENTINEL_ISSUE_TITLE = "E2E fixture: Ready-labeled Issue refresh"
+export const GITHUB_SENTINEL_ISSUE_NUMBER = 22
+export const GITHUB_SENTINEL_ISSUE_TITLE =
+  "E2E fixture: Ready-labeled Issue refresh"
 
-/** Bounded wait for clone + CLI + one GitHub refresh + subscription. */
-export const SCENARIO_TIMEOUT_MS = 180_000
+// --- GitLab End-to-End Fixture Repository (git.drupalcode.org) ---
+// Project path and sentinel iid are fixed identities once the operator
+// provisions the throwaway sandbox (see docs/e2e-fixture.md). Env overrides
+// support local bootstrap before constants are locked.
+export const FIXTURE_GITLAB_FORGE_HOST =
+  process.env.E2E_GITLAB_FORGE_HOST?.trim() || "git.drupalcode.org"
+export const FIXTURE_GITLAB_PROJECT_PATH =
+  process.env.E2E_GITLAB_PROJECT_PATH?.trim() ||
+  "sandbox/berend-test-ready-for-agent"
+/** Display identity shown in the Harness UI (Project Path). */
+export const FIXTURE_GITLAB_REPOSITORY = FIXTURE_GITLAB_PROJECT_PATH
+/**
+ * Keymaxxer account is `<forge-host>/<project-path>` with provider=gitlab.
+ * Canonical secret name follows the GitHub fixture naming convention.
+ */
+export const FIXTURE_GITLAB_VAULT_ACCOUNT = `${FIXTURE_GITLAB_FORGE_HOST}/${FIXTURE_GITLAB_PROJECT_PATH}`
+export const FIXTURE_GITLAB_SECRET_NAME =
+  "GITLAB_TOKEN_GIT_DRUPALCODE_ORG_SANDBOX_BEREND_TEST_READY_FOR_AGENT"
+
+const parsePositiveIssueNumber = (
+  raw: string | undefined,
+  fallback: number,
+): number => {
+  const source = raw?.trim()
+  if (source === undefined || source === "") {
+    return fallback
+  }
+  const parsed = Number(source)
+  if (!Number.isSafeInteger(parsed) || parsed < 1) {
+    throw new Error(
+      `E2E_GITLAB_SENTINEL_ISSUE_NUMBER must be a positive integer, got ${JSON.stringify(raw)}`,
+    )
+  }
+  return parsed
+}
+
+/**
+ * Sentinel iid for the GitLab fixture. Parsed lazily so a bad
+ * `E2E_GITLAB_SENTINEL_ISSUE_NUMBER` only breaks the GitLab scenario, not the
+ * whole Playwright suite at module import.
+ * Bootstrap placeholder is `1` until setup-gitlab-e2e-fixture.sh locks the real iid.
+ */
+export const gitlabSentinelIssueNumber = (): number =>
+  parsePositiveIssueNumber(process.env.E2E_GITLAB_SENTINEL_ISSUE_NUMBER, 1)
+
+export const GITLAB_SENTINEL_ISSUE_TITLE =
+  "E2E fixture: Ready-labeled Issue refresh"
+
+/**
+ * Bounded wait for clone + CLI + one Forge refresh + subscription.
+ * Sized for dual-scenario runs that may spend up to ~30s clearing Repositories
+ * before a 120s sentinel wait (GitHub then GitLab share one Harness process).
+ */
+export const SCENARIO_TIMEOUT_MS = 240_000
 /** Eventual UI assertions after the automatic first Refresh Job. */
 export const SENTINEL_EXPECT_TIMEOUT_MS = 120_000
 export const HARNESS_START_TIMEOUT_MS = 180_000

--- a/apps/harness/test/application-runtime-disposal.test.ts
+++ b/apps/harness/test/application-runtime-disposal.test.ts
@@ -9,97 +9,103 @@ import { createApplication } from "../src/server/application.server.js"
 import { environmentConfigLayer } from "../src/server/application-config.js"
 import { expect, test } from "bun:test"
 
-test("application disposal closes a lazily created authentication client", async () => {
-  const directory = await mkdtemp(join(tmpdir(), "rfa-auth-runtime-"))
-  const environment = {
-    HOME: directory,
-    KEYMAXXER_SIDECAR_URL: "http://127.0.0.1:6057/application-runtime/mcp",
-    SQLITE_DATABASE_PATH: join(directory, "ready-for-agent.db"),
-  }
-  const configLayer = environmentConfigLayer(environment)
-  let application: Awaited<ReturnType<typeof createApplication>> | undefined
-  let disposed = false
-  let closeCalls = 0
-  const client: KeymaxxerToolClient = {
-    callTool: async () => ({
-      content: [
-        {
-          type: "text",
-          text: JSON.stringify([
-            {
-              name: "GITHUB_TOKEN_ACME_WIDGETS",
-              provider: "github",
-              account: "acme/widgets",
-            },
-          ]),
-        },
-      ],
-    }),
-    close: async () => {
-      closeCalls += 1
-    },
-  }
-
-  try {
-    await Effect.runPromise(
-      runConfiguredMigrations().pipe(
-        Effect.provide(DatabaseLive.pipe(Layer.provide(configLayer))),
-      ),
-    )
-    const databaseLayer = DbServiceLive.pipe(
-      Layer.provideMerge(DatabaseLive),
-      Layer.provide(configLayer),
-    )
-    await Effect.runPromise(
-      Effect.gen(function* () {
-        const db = yield* DbService
-        yield* db.addRepository({
-          forge: "github",
-          forgeHost: "github.com",
-          projectPath: "acme/widgets",
-          localPath: join(directory, "widgets"),
-          isBare: true,
-        })
-      }).pipe(Effect.provide(databaseLayer)),
-    )
-
-    application = await createApplication(environment, {
-      startWorker: false,
-      sidecarLayerOptions: {
-        createClient: async () => client,
-        fetch: async () => new Response(null, { status: 404 }),
+// Migrations + createApplication + dispose can exceed Bun's 5s default under
+// nx affected --batch load (observed ~5.2s flake). Bound higher than default.
+test(
+  "application disposal closes a lazily created authentication client",
+  async () => {
+    const directory = await mkdtemp(join(tmpdir(), "rfa-auth-runtime-"))
+    const environment = {
+      HOME: directory,
+      KEYMAXXER_SIDECAR_URL: "http://127.0.0.1:6057/application-runtime/mcp",
+      SQLITE_DATABASE_PATH: join(directory, "ready-for-agent.db"),
+    }
+    const configLayer = environmentConfigLayer(environment)
+    let application: Awaited<ReturnType<typeof createApplication>> | undefined
+    let disposed = false
+    let closeCalls = 0
+    const client: KeymaxxerToolClient = {
+      callTool: async () => ({
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify([
+              {
+                name: "GITHUB_TOKEN_ACME_WIDGETS",
+                provider: "github",
+                account: "acme/widgets",
+              },
+            ]),
+          },
+        ],
+      }),
+      close: async () => {
+        closeCalls += 1
       },
-    })
-    const response = await application.context.graphqlApi.fetch(
-      new Request("http://127.0.0.1:6056/graphql", {
-        method: "POST",
-        headers: { "content-type": "application/json" },
-        body: JSON.stringify({
-          query: `query {
+    }
+
+    try {
+      await Effect.runPromise(
+        runConfiguredMigrations().pipe(
+          Effect.provide(DatabaseLive.pipe(Layer.provide(configLayer))),
+        ),
+      )
+      const databaseLayer = DbServiceLive.pipe(
+        Layer.provideMerge(DatabaseLive),
+        Layer.provide(configLayer),
+      )
+      await Effect.runPromise(
+        Effect.gen(function* () {
+          const db = yield* DbService
+          yield* db.addRepository({
+            forge: "github",
+            forgeHost: "github.com",
+            projectPath: "acme/widgets",
+            localPath: join(directory, "widgets"),
+            isBare: true,
+          })
+        }).pipe(Effect.provide(databaseLayer)),
+      )
+
+      application = await createApplication(environment, {
+        startWorker: false,
+        sidecarLayerOptions: {
+          createClient: async () => client,
+          fetch: async () => new Response(null, { status: 404 }),
+        },
+      })
+      const response = await application.context.graphqlApi.fetch(
+        new Request("http://127.0.0.1:6056/graphql", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({
+            query: `query {
             repositoryCredentials {
               configured
               repositoryId
             }
           }`,
+          }),
         }),
-      }),
-    )
+      )
 
-    expect(response.status).toBe(200)
-    expect(await response.json()).toMatchObject({
-      data: {
-        repositoryCredentials: [{ configured: true }],
-      },
-    })
-    expect(closeCalls).toBe(0)
+      expect(response.status).toBe(200)
+      expect(await response.json()).toMatchObject({
+        data: {
+          repositoryCredentials: [{ configured: true }],
+        },
+      })
+      expect(closeCalls).toBe(0)
 
-    await application.dispose()
-    disposed = true
-    expect(closeCalls).toBe(1)
-  } finally {
-    if (application !== undefined && !disposed) {
       await application.dispose()
+      disposed = true
+      expect(closeCalls).toBe(1)
+    } finally {
+      if (application !== undefined && !disposed) {
+        await application.dispose()
+      }
+      await rm(directory, { recursive: true, force: true })
     }
-    await rm(directory, { recursive: true, force: true })
-  }
-})
+  },
+  { timeout: 15_000 },
+)

--- a/apps/harness/test/clone-fixture-repo-keymaxxer-args.test.ts
+++ b/apps/harness/test/clone-fixture-repo-keymaxxer-args.test.ts
@@ -1,5 +1,16 @@
 import { spawnSync } from "node:child_process"
-import { keymaxxerRunArgs } from "../e2e/support/clone-fixture-repo.ts"
+import {
+  githubFixtureSpec,
+  gitlabFixtureSpec,
+  keymaxxerRunArgs,
+} from "../e2e/support/clone-fixture-repo.ts"
+import {
+  FIXTURE_GITHUB_REPOSITORY,
+  FIXTURE_GITHUB_SECRET_NAME,
+  FIXTURE_GITLAB_FORGE_HOST,
+  FIXTURE_GITLAB_PROJECT_PATH,
+  FIXTURE_GITLAB_SECRET_NAME,
+} from "../e2e/support/constants.ts"
 import { describe, expect, test } from "bun:test"
 
 const runAsKeymaxxerJoins = (restAfterDashDash: string[]) => {
@@ -38,5 +49,30 @@ describe("keymaxxer fixture clone command args", () => {
 
     expect(fixed.status).toBe(0)
     expect(fixed.stdout.trim()).toBe("retained-arg")
+  })
+})
+
+describe("fixture clone specs", () => {
+  test("GitHub clone URL injects the canonical secret name", () => {
+    const spec = githubFixtureSpec()
+    expect(spec.secretName).toBe(FIXTURE_GITHUB_SECRET_NAME)
+    expect(spec.account).toBe(FIXTURE_GITHUB_REPOSITORY)
+    expect(spec.cloneUrlTemplate(spec.secretName)).toContain(
+      `x-access-token:\${${FIXTURE_GITHUB_SECRET_NAME}}@github.com/${FIXTURE_GITHUB_REPOSITORY}.git`,
+    )
+  })
+
+  test("GitLab clone URL uses oauth2 token auth on the Forge Host", () => {
+    const spec = gitlabFixtureSpec()
+    expect(spec.secretName).toBe(FIXTURE_GITLAB_SECRET_NAME)
+    expect(spec.provider).toBe("gitlab")
+    expect(spec.account).toBe(
+      `${FIXTURE_GITLAB_FORGE_HOST}/${FIXTURE_GITLAB_PROJECT_PATH}`,
+    )
+    const url = spec.cloneUrlTemplate(spec.secretName)
+    expect(url).toContain(
+      `oauth2:\${${FIXTURE_GITLAB_SECRET_NAME}}@${FIXTURE_GITLAB_FORGE_HOST}/`,
+    )
+    expect(url).toContain(`${FIXTURE_GITLAB_PROJECT_PATH}.git`)
   })
 })

--- a/docs/adr/0021-live-harness-end-to-end-test.md
+++ b/docs/adr/0021-live-harness-end-to-end-test.md
@@ -1,5 +1,17 @@
-# Validate Harness end to end against a controlled GitHub Repository
+# Validate Harness end to end against controlled Forge Repositories
 
-Harness end-to-end validation runs the production-built application, worker, Keymaxxer Sidecar, command-line client, and browser against the private End-to-End Fixture Repository `berenddeboer/test-ready-for-agent`, without GraphQL or GitHub mocks. Executable Gherkin via `playwright-bdd` adds the Repository from a fresh local checkout through the real CLI and waits for credential activation's automatic first Refresh Job to make sentinel Issue `#22`, `E2E fixture: Ready-labeled Issue refresh`, visible in the UI.
+Harness end-to-end validation runs the production-built application, worker, Keymaxxer Sidecar, command-line client, and browser against controlled End-to-End Fixture Repositories, without GraphQL or Forge mocks. Executable Gherkin via `playwright-bdd` adds each Repository from a fresh local checkout through the real CLI and waits for credential activation's automatic first Refresh Job to make the permanent Ready-labeled sentinel Issue visible in the UI.
 
-Each run starts with an empty, isolated Harness database. CI copies a checked-in encrypted Keymaxxer vault containing only the read-only `GITHUB_TOKEN_BERENDDEBOER_TEST_READY_FOR_AGENT` credential into a temporary home and unlocks it with the GitHub Actions secret `E2E_KEYMAXXER_MASTER_KEY`; `KEYMAXXER_APPROVE=deny` prevents headless prompts and fails closed. Local runs instead leave `~/.keymaxxer` untouched and may prompt normally. The live scenario has no automatic retry, runs only after the existing checks on trusted pushes to `main`, and retains Playwright diagnostics on failure.
+## GitHub fixture
+
+Private Repository `berenddeboer/test-ready-for-agent`, sentinel Issue `#22`, title `E2E fixture: Ready-labeled Issue refresh`. Clone uses Keymaxxer secret `GITHUB_TOKEN_BERENDDEBOER_TEST_READY_FOR_AGENT` (`provider=github`, `account=berenddeboer/test-ready-for-agent`).
+
+## GitLab fixture
+
+Throwaway project on `git.drupalcode.org` under operator control (default Project Path `sandbox/berend-test-ready-for-agent`), permanent open Ready-labeled sentinel with the same title convention, no blockers, and no Issue-closing MR. Clone uses Keymaxxer secret `GITLAB_TOKEN_GIT_DRUPALCODE_ORG_SANDBOX_BEREND_TEST_READY_FOR_AGENT` (`provider=gitlab`, `account=git.drupalcode.org/<project-path>`). HTTPS clone authenticates as `oauth2:<token>`. Operator bootstrap and Drupal.org API limitations are documented in `docs/e2e-fixture.md` and `scripts/setup-gitlab-e2e-fixture.sh`. Until the dual-secret vault includes the GitLab credential, the GitLab scenario soft-skips; `E2E_REQUIRE_GITLAB=1` fails closed.
+
+## Shared run model
+
+Each run starts with an empty, isolated Harness database. CI copies a checked-in encrypted Keymaxxer vault into a temporary home and unlocks it with the GitHub Actions secret `E2E_KEYMAXXER_MASTER_KEY`; `KEYMAXXER_APPROVE=deny` prevents headless prompts and fails closed. Local runs instead leave `~/.keymaxxer` untouched and may prompt normally. Scenarios have no automatic retry, run only after the existing checks on trusted pushes to `main`, and retain Playwright diagnostics on failure. Scenarios assert the sentinel's fixed identity and do not reject unrelated Issues on the fixture project.
+
+Work Item creation, Agent Turns, pull request / merge request creation, status checks, review, merge, and cleanup remain out of scope for the automated live e2e (operator demos may exercise the full GitLab lifecycle separately with write credentials).

--- a/docs/e2e-fixture.md
+++ b/docs/e2e-fixture.md
@@ -1,9 +1,11 @@
-# End-to-End Fixture Repository and Keymaxxer vault
+# End-to-End Fixture Repositories and Keymaxxer vault
 
-Live Harness end-to-end validation uses a controlled private Repository and a
-checked-in encrypted Keymaxxer vault that never holds the master key.
+Live Harness end-to-end validation uses controlled Fixture Repositories and a
+checked-in encrypted Keymaxxer vault that never holds the master key. GitHub
+and GitLab scenarios share the same vault, CI gate, and Gherkin wiring under
+`apps/harness/e2e`.
 
-## End-to-End Fixture Repository
+## GitHub End-to-End Fixture Repository
 
 - Repository: `berenddeboer/test-ready-for-agent` (private)
 - Sentinel Issue: `#22`
@@ -11,6 +13,67 @@ checked-in encrypted Keymaxxer vault that never holds the master key.
 - Must stay open and labeled `ready-for-agent`
 - No hierarchy, no blockers, no Issue-closing pull request
 - Non-sentinel Issues such as `#11` and `#18` must not carry `ready-for-agent`
+- Scenarios do not reject unrelated Issues
+
+## GitLab End-to-End Fixture Repository
+
+- Forge Host: `git.drupalcode.org`
+- Project Path (default): `sandbox/berend-test-ready-for-agent`
+  - Override with `E2E_GITLAB_PROJECT_PATH` during bootstrap
+- Sentinel Issue: fixed title `E2E fixture: Ready-labeled Issue refresh`
+  - Lock the iid via `E2E_GITLAB_SENTINEL_ISSUE_NUMBER` or the default in
+    `gitlabSentinelIssueNumber()` after first creation
+- Must stay open and labeled `ready-for-agent`
+- No hierarchy, no blockers, no Issue-closing merge request
+- Scenarios do not reject unrelated Issues (same convention as GitHub)
+
+### Operator bootstrap (one-time)
+
+Drupal.org blocks project creation and many project-setting mutations through
+the GitLab REST API. Provision the throwaway project in the UI:
+
+1. Create a sandbox (or other project you control) on Drupal.org so it appears
+   under `git.drupalcode.org`.
+2. In GitLab project settings, **enable Issues** (sandboxes and many
+   `project/*` namespaces default Issues off). Enable CI/CD only if you will
+   exercise pipeline watching manually.
+3. **Push at least one commit** on the default branch (empty projects fail
+   `git clone --depth 1` and vault regeneration `git ls-remote`).
+4. Export the path if it differs from the default:
+
+   ```bash
+   export E2E_GITLAB_PROJECT_PATH='sandbox/<your-path>'
+   ```
+
+   The Keymaxxer **secret name** stays fixed
+   (`GITLAB_TOKEN_GIT_DRUPALCODE_ORG_SANDBOX_BEREND_TEST_READY_FOR_AGENT`) even
+   when the path override changes; only the vault `account` metadata and clone
+   URL follow `E2E_GITLAB_PROJECT_PATH` / `E2E_GITLAB_FORGE_HOST`.
+
+5. With a write-capable PAT or `glab` session, create the label and sentinel:
+
+   ```bash
+   ./scripts/setup-gitlab-e2e-fixture.sh
+   ```
+
+6. Lock the printed sentinel iid via `E2E_GITLAB_SENTINEL_ISSUE_NUMBER` or the
+   default in `gitlabSentinelIssueNumber()`
+   (`apps/harness/e2e/support/constants.ts`).
+7. Mint a **read-only** personal access token at
+   `https://git.drupalcode.org/-/user_settings/personal_access_tokens` with
+   `read_api` and `read_repository` (no write scopes for CI).
+8. Regenerate the dual-secret vault (below), run the isolated GitLab clone
+   smoke test, then commit the encrypted vault files.
+
+The automated Gherkin scenario mirrors GitHub: add the Repository through the
+CLI and assert the sentinel appears after the automatic first Refresh Job. Full
+lifecycle demos (Implement → draft MR → pipeline → merge → Issue close) remain
+operator-driven with write credentials and Auto-merge, same out-of-scope
+boundary as the original GitHub live e2e (ADR 0021).
+
+Until the GitLab secret is present in the checked-in vault, the GitLab scenario
+**soft-skips** so trusted `main` CI stays green. Set `E2E_REQUIRE_GITLAB=1` to
+fail closed once the vault includes the GitLab credential.
 
 ## Checked-in vault
 
@@ -21,13 +84,13 @@ Path: `e2e/fixtures/keymaxxer/`
 | `vault.db` | Encrypted Keymaxxer database |
 | `vault.meta.json` | Non-secret cipher metadata (`kdf: "none"` for external master key) |
 
-The vault contains only:
+The vault always contains the GitHub fixture credential. After GitLab bootstrap
+it also contains the GitLab fixture credential:
 
-- Name: `GITHUB_TOKEN_BERENDDEBOER_TEST_READY_FOR_AGENT`
-- `provider=github`
-- `account=berenddeboer/test-ready-for-agent`
-- `environment=test`
-- `access=read-only`
+| Secret name | provider | account | access |
+| --- | --- | --- | --- |
+| `GITHUB_TOKEN_BERENDDEBOER_TEST_READY_FOR_AGENT` | `github` | `berenddeboer/test-ready-for-agent` | read-only |
+| `GITLAB_TOKEN_GIT_DRUPALCODE_ORG_SANDBOX_BEREND_TEST_READY_FOR_AGENT` | `gitlab` | `git.drupalcode.org/<project-path>` | read-only |
 
 The master key is **not** committed. CI supplies it as the repository Actions
 secret `E2E_KEYMAXXER_MASTER_KEY` (exposed to the e2e step as
@@ -55,6 +118,30 @@ When the token approaches expiry, create a replacement, regenerate the vault,
 and commit the new encrypted files. Keep the same master key when possible so
 `E2E_KEYMAXXER_MASTER_KEY` does not need to change.
 
+## GitLab personal access token
+
+Create a personal access token on the Forge Host:
+
+1. Open `https://git.drupalcode.org/-/user_settings/personal_access_tokens`
+2. Scopes for CI: `read_api`, `read_repository`
+3. Restrict to the fixture project when the instance supports project-scoped
+   tokens; otherwise rotate promptly
+4. Expiration: match your org's policy (document the date next to the vault
+   regeneration commit)
+
+For local **setup** of the sentinel Issue only, a temporary write-capable token
+is acceptable. Pass `E2E_ALLOW_GITLAB_WRITE_TOKEN=1` when regenerating so the
+probe allows issue-create; regenerate again with a read-only token before
+relying on CI.
+
+Keymaxxer metadata (must match harness lookup):
+
+- `provider=gitlab`
+- `account=<forge-host>/<project-path>` (for example
+  `git.drupalcode.org/sandbox/berend-test-ready-for-agent`)
+- `environment=test`
+- `access=read-only`
+
 ## Regenerate the vault
 
 Requires workspace `keymaxxer@0.2.1` (`bun install` pins it in the lockfile).
@@ -65,11 +152,20 @@ Requires workspace `keymaxxer@0.2.1` (`bun install` pins it in the lockfile).
 export E2E_KEYMAXXER_MASTER_KEY
 # paste/export the 64-hex value into the env only
 
+# GitHub-only (bootstrap era, before dual-secret vault):
 ./scripts/regenerate-e2e-keymaxxer-vault.sh
-# paste the fine-grained token at the hidden prompt (or pipe it on stdin)
+# paste the fine-grained GitHub token at the hidden prompt (or pipe it on stdin)
+# After the vault contains the GitLab secret, this form refuses to run unless
+# you pass --github-only (explicitly drops GitLab) or --with-gitlab.
+
+# GitHub + GitLab (required once the GitLab fixture project exists):
+export E2E_GITLAB_PROJECT_PATH='sandbox/berend-test-ready-for-agent'  # if non-default
+./scripts/regenerate-e2e-keymaxxer-vault.sh --with-gitlab
+# paste GitHub token, then GitLab PAT (two prompts / two stdin lines)
 
 # Or generate a new master key file (mode 0600), then set the Actions secret:
-./scripts/regenerate-e2e-keymaxxer-vault.sh --write-master-key-to /tmp/e2e-keymaxxer-master.key
+./scripts/regenerate-e2e-keymaxxer-vault.sh --with-gitlab \
+  --write-master-key-to /tmp/e2e-keymaxxer-master.key
 gh secret set E2E_KEYMAXXER_MASTER_KEY < /tmp/e2e-keymaxxer-master.key
 shred -u /tmp/e2e-keymaxxer-master.key 2>/dev/null || rm -f /tmp/e2e-keymaxxer-master.key
 ```
@@ -77,12 +173,15 @@ shred -u /tmp/e2e-keymaxxer-master.key 2>/dev/null || rm -f /tmp/e2e-keymaxxer-m
 Rules enforced by the script:
 
 - Temporary `HOME` only — never copies over or reads `~/.keymaxxer`
-- Token value enters through stdin (hidden on a TTY), never as a CLI argument
+- Token values enter through stdin (hidden on a TTY), never as CLI arguments
 - Master key only via `E2E_KEYMAXXER_MASTER_KEY` or `--write-master-key-to`
-- Probes that Issues/Contents writes are denied
+- Probes that GitHub Issues/Contents writes are denied
+- With `--with-gitlab`, probes project/issue/MR reads and prefers a read-only PAT
 - Commits only the encrypted `vault.db` and `vault.meta.json`
 
 ## Isolated clone smoke test
+
+### GitHub
 
 ```bash
 TMP_HOME=$(mktemp -d)
@@ -95,4 +194,26 @@ bunx keymaxxer@0.2.1 run --secrets GITHUB_TOKEN_BERENDDEBOER_TEST_READY_FOR_AGEN
   bash -c 'git clone "https://x-access-token:${GITHUB_TOKEN_BERENDDEBOER_TEST_READY_FOR_AGENT}@github.com/berenddeboer/test-ready-for-agent.git" /tmp/test-ready-for-agent-e2e-clone'
 ```
 
-This leaves the developer's real Keymaxxer vault untouched.
+### GitLab
+
+```bash
+TMP_HOME=$(mktemp -d)
+mkdir -p "$TMP_HOME/.keymaxxer"
+cp e2e/fixtures/keymaxxer/vault.db e2e/fixtures/keymaxxer/vault.meta.json "$TMP_HOME/.keymaxxer/"
+export HOME="$TMP_HOME"
+export KEYMAXXER_MASTER_KEY
+export KEYMAXXER_APPROVE=deny
+SECRET=GITLAB_TOKEN_GIT_DRUPALCODE_ORG_SANDBOX_BEREND_TEST_READY_FOR_AGENT
+PROJECT_PATH="${E2E_GITLAB_PROJECT_PATH:-sandbox/berend-test-ready-for-agent}"
+bunx keymaxxer@0.2.1 run --secrets "$SECRET" -- \
+  bash -c "git clone \"https://oauth2:\${${SECRET}}@git.drupalcode.org/${PROJECT_PATH}.git\" /tmp/gitlab-e2e-clone"
+```
+
+These leave the developer's real Keymaxxer vault untouched.
+
+## CI gating
+
+Live Gherkin e2e runs only on trusted pushes to `main` (not on pull requests),
+after lint/typecheck/unit tests, with Playwright Chromium installed. See
+`.github/workflows/ci-cd.yml` and ADR 0021. GitHub and GitLab scenarios share
+that single `bunx nx run harness:e2e` step.

--- a/packages/graphql-api/src/lib/to-graphql-error.ts
+++ b/packages/graphql-api/src/lib/to-graphql-error.ts
@@ -6,6 +6,7 @@ type TaggedError = {
   readonly field?: string
   readonly repositoryId?: string
   readonly workItemId?: string
+  readonly stepRunId?: string
   readonly issueNumber?: number
   readonly state?: string
   readonly blockerCount?: number
@@ -226,6 +227,16 @@ export const toGraphQLError = (error: unknown): GraphQLError => {
       return gql(
         `Repository not found: ${error.repositoryId}`,
         "REPOSITORY_NOT_FOUND",
+      )
+    case "RepositoryHasRunningStepError":
+      return gql(
+        `Repository ${error.repositoryId} has a running Step Run and cannot be removed`,
+        "REPOSITORY_HAS_RUNNING_STEP",
+        {
+          repositoryId: error.repositoryId,
+          workItemId: error.workItemId,
+          stepRunId: error.stepRunId,
+        },
       )
     case "PathNotFound":
       return gql(

--- a/packages/graphql-api/test/to-graphql-error.test.ts
+++ b/packages/graphql-api/test/to-graphql-error.test.ts
@@ -1,0 +1,24 @@
+import { toGraphQLError } from "../src/lib/to-graphql-error.js"
+import { describe, expect, test } from "bun:test"
+
+describe("toGraphQLError", () => {
+  test("maps RepositoryHasRunningStepError to REPOSITORY_HAS_RUNNING_STEP", () => {
+    const error = {
+      _tag: "RepositoryHasRunningStepError" as const,
+      repositoryId: "repo-1",
+      workItemId: "wi-1",
+      stepRunId: "sr-1",
+    }
+
+    const gqlError = toGraphQLError(error)
+
+    expect(gqlError.message).toContain("running Step Run")
+    expect(gqlError.message).toContain("repo-1")
+    expect(gqlError.extensions).toMatchObject({
+      code: "REPOSITORY_HAS_RUNNING_STEP",
+      repositoryId: "repo-1",
+      workItemId: "wi-1",
+      stepRunId: "sr-1",
+    })
+  })
+})

--- a/scripts/regenerate-e2e-keymaxxer-vault.sh
+++ b/scripts/regenerate-e2e-keymaxxer-vault.sh
@@ -4,37 +4,56 @@
 # Isolation: uses a temporary HOME so the developer's real ~/.keymaxxer is never
 # read or overwritten.
 #
-# Secrets:
-#   - Fine-grained GitHub token for berenddeboer/test-ready-for-agent is read
-#     from stdin (hidden when interactive). Never pass it as a CLI argument.
-#   - Master key comes from E2E_KEYMAXXER_MASTER_KEY (64 hex chars). When unset,
-#     a new key is generated and written only via --write-master-key-to.
+# Secrets (never pass tokens as CLI arguments):
+#   - Fine-grained GitHub token for berenddeboer/test-ready-for-agent (stdin)
+#   - Optional GitLab PAT for the git.drupalcode.org fixture (second stdin line,
+#     or --with-gitlab with a second prompt / piped line)
+#   - Master key from E2E_KEYMAXXER_MASTER_KEY (64 hex). When unset, a new key
+#     is generated only via --write-master-key-to.
 #
-# Required token (create in GitHub UI, 90-day expiry initially):
+# GitHub token (create in GitHub UI, 90-day expiry initially):
 #   name: e2e-test-ready-for-agent-readonly
 #   repository: berenddeboer/test-ready-for-agent only
 #   permissions (read): Contents, Metadata, Issues, Pull requests
 #
+# GitLab token (create at https://git.drupalcode.org/-/user_settings/personal_access_tokens):
+#   scopes: read_api, read_repository (write scopes only for lifecycle demos)
+#   account metadata: provider=gitlab account=git.drupalcode.org/<project-path>
+#
 # After regeneration, set the Actions secret without echoing the key:
 #   gh secret set E2E_KEYMAXXER_MASTER_KEY < /path/to/master.key
 #
-# Rotation expectation: fine-grained tokens expire after 90 days; regenerate the
-# vault (and rotate the Actions secret if the master key changed) before expiry.
+# Rotation: regenerate before fine-grained token expiry (GitHub ~90 days).
 set -euo pipefail
 
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 FIXTURE_DIR="${ROOT}/e2e/fixtures/keymaxxer"
-SECRET_NAME="GITHUB_TOKEN_BERENDDEBOER_TEST_READY_FOR_AGENT"
-REPO="berenddeboer/test-ready-for-agent"
+GITHUB_SECRET_NAME="GITHUB_TOKEN_BERENDDEBOER_TEST_READY_FOR_AGENT"
+GITHUB_REPO="berenddeboer/test-ready-for-agent"
+GITLAB_FORGE_HOST="${E2E_GITLAB_FORGE_HOST:-git.drupalcode.org}"
+GITLAB_PROJECT_PATH="${E2E_GITLAB_PROJECT_PATH:-sandbox/berend-test-ready-for-agent}"
+GITLAB_VAULT_ACCOUNT="${GITLAB_FORGE_HOST}/${GITLAB_PROJECT_PATH}"
+# Stable Keymaxxer name (does not change when E2E_GITLAB_PROJECT_PATH overrides
+# the account path). Keep in sync with apps/harness/e2e/support/constants.ts.
+GITLAB_SECRET_NAME="GITLAB_TOKEN_GIT_DRUPALCODE_ORG_SANDBOX_BEREND_TEST_READY_FOR_AGENT"
 WRITE_MASTER_KEY_TO=""
+WITH_GITLAB=0
+# Explicit GitHub-only rebuild after dual-secret bootstrap (drops GitLab secret).
+GITHUB_ONLY=0
 
 usage() {
   cat <<'EOF'
 Usage: regenerate-e2e-keymaxxer-vault.sh [options]
 
 Reads the fine-grained GitHub token from stdin (hidden if a TTY).
+With --with-gitlab, also reads a GitLab PAT (second line / second prompt).
 
 Options:
+  --with-gitlab                Include the GitLab e2e fixture credential.
+  --github-only                Allow rewriting the vault without GitLab even
+                               when the committed vault already has the GitLab
+                               secret (drops that secret). Prefer --with-gitlab
+                               for normal rotation after GitLab bootstrap.
   --write-master-key-to PATH   When generating a new master key, write it only
                                to PATH (mode 0600). Required if
                                E2E_KEYMAXXER_MASTER_KEY is unset.
@@ -43,11 +62,21 @@ Options:
 Environment:
   E2E_KEYMAXXER_MASTER_KEY     Existing 64-hex master key (preferred for
                                rotation that keeps the Actions secret).
+  E2E_GITLAB_FORGE_HOST        Default git.drupalcode.org
+  E2E_GITLAB_PROJECT_PATH       Default sandbox/berend-test-ready-for-agent
 EOF
 }
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
+    --with-gitlab)
+      WITH_GITLAB=1
+      shift
+      ;;
+    --github-only)
+      GITHUB_ONLY=1
+      shift
+      ;;
     --write-master-key-to)
       WRITE_MASTER_KEY_TO="${2:?--write-master-key-to requires a path}"
       shift 2
@@ -63,6 +92,11 @@ while [[ $# -gt 0 ]]; do
       ;;
   esac
 done
+
+if [[ "${WITH_GITLAB}" -eq 1 && "${GITHUB_ONLY}" -eq 1 ]]; then
+  echo "error: --with-gitlab and --github-only are mutually exclusive" >&2
+  exit 2
+fi
 
 keymaxxer_bin() {
   if [[ -x "${ROOT}/node_modules/.bin/keymaxxer" ]]; then
@@ -100,19 +134,75 @@ fi
 export KEYMAXXER_MASTER_KEY="${E2E_KEYMAXXER_MASTER_KEY}"
 export KEYMAXXER_APPROVE=deny
 
-if [[ -t 0 ]]; then
-  echo "Paste the fine-grained GitHub token for ${REPO} (input hidden), then Enter:" >&2
-  # shellcheck disable=SC2162
-  IFS= read -r -s TOKEN
-  echo >&2
-else
-  TOKEN="$(cat)"
+# Refuse to silently drop an existing dual-secret fixture vault.
+if [[ "${WITH_GITLAB}" -eq 0 && "${GITHUB_ONLY}" -eq 0 ]]; then
+  if [[ -f "${FIXTURE_DIR}/vault.db" && -f "${FIXTURE_DIR}/vault.meta.json" ]]; then
+    GUARD_HOME="$(mktemp -d "${TMPDIR:-/tmp}/rfa-e2e-keymaxxer-guard.XXXXXX")"
+    mkdir -p "${GUARD_HOME}/.keymaxxer"
+    cp -f "${FIXTURE_DIR}/vault.db" "${FIXTURE_DIR}/vault.meta.json" "${GUARD_HOME}/.keymaxxer/"
+    set +e
+    GUARD_LIST="$(
+      HOME="${GUARD_HOME}" KEYMAXXER_MASTER_KEY="${KEYMAXXER_MASTER_KEY}" KEYMAXXER_APPROVE=deny \
+        run_keymaxxer list 2>"${GUARD_HOME}/list.err"
+    )"
+    GUARD_STATUS=$?
+    set -e
+    GUARD_ERR="$(cat "${GUARD_HOME}/list.err" 2>/dev/null || true)"
+    rm -rf "${GUARD_HOME}"
+    if [[ "${GUARD_STATUS}" -ne 0 ]]; then
+      cat <<EOF >&2
+error: could not list the committed fixture vault to check for ${GITLAB_SECRET_NAME}
+(keymaxxer exit ${GUARD_STATUS}). Refusing GitHub-only regeneration to avoid
+silently dropping a dual-secret vault.
+
+  - Prefer:  ./scripts/regenerate-e2e-keymaxxer-vault.sh --with-gitlab
+  - Or pass: --github-only  (explicitly discard any GitLab secret)
+  - Ensure E2E_KEYMAXXER_MASTER_KEY matches the committed vault
+
+${GUARD_ERR}
+EOF
+      exit 1
+    fi
+    if grep -q "${GITLAB_SECRET_NAME}" <<<"${GUARD_LIST}"; then
+      cat <<EOF >&2
+error: committed fixture vault already contains ${GITLAB_SECRET_NAME}.
+
+Regenerating without --with-gitlab would drop the GitLab e2e credential.
+  - Prefer:  ./scripts/regenerate-e2e-keymaxxer-vault.sh --with-gitlab
+  - Or pass: --github-only  (explicitly discard the GitLab secret)
+EOF
+      exit 1
+    fi
+  fi
 fi
 
-TOKEN="$(printf '%s' "${TOKEN}" | tr -d '\r\n')"
-if [[ -z "${TOKEN}" ]]; then
-  echo "error: empty token on stdin" >&2
+read_secret_line() {
+  local prompt="$1"
+  local value=""
+  if [[ -t 0 ]]; then
+    echo "${prompt}" >&2
+    # shellcheck disable=SC2162
+    IFS= read -r -s value
+    echo >&2
+  else
+    IFS= read -r value || true
+  fi
+  printf '%s' "${value}" | tr -d '\r\n'
+}
+
+GITHUB_TOKEN="$(read_secret_line "Paste the fine-grained GitHub token for ${GITHUB_REPO} (input hidden), then Enter:")"
+if [[ -z "${GITHUB_TOKEN}" ]]; then
+  echo "error: empty GitHub token on stdin" >&2
   exit 1
+fi
+
+GITLAB_TOKEN=""
+if [[ "${WITH_GITLAB}" -eq 1 ]]; then
+  GITLAB_TOKEN="$(read_secret_line "Paste the GitLab PAT for ${GITLAB_VAULT_ACCOUNT} (input hidden), then Enter:")"
+  if [[ -z "${GITLAB_TOKEN}" ]]; then
+    echo "error: empty GitLab token (--with-gitlab requires a PAT)" >&2
+    exit 1
+  fi
 fi
 
 TMP_HOME="$(mktemp -d "${TMPDIR:-/tmp}/rfa-e2e-keymaxxer.XXXXXX")"
@@ -127,36 +217,65 @@ chmod 700 "${HOME}/.keymaxxer"
 
 run_keymaxxer init
 
-printf '%s' "${TOKEN}" | run_keymaxxer set "${SECRET_NAME}" \
+printf '%s' "${GITHUB_TOKEN}" | run_keymaxxer set "${GITHUB_SECRET_NAME}" \
   --provider github \
-  --account "${REPO}" \
+  --account "${GITHUB_REPO}" \
   --env test \
   --access read-only \
-  --description "Read-only e2e fixture token for ${REPO} (90-day rotation)"
+  --description "Read-only e2e fixture token for ${GITHUB_REPO} (90-day rotation)"
+
+if [[ "${WITH_GITLAB}" -eq 1 ]]; then
+  printf '%s' "${GITLAB_TOKEN}" | run_keymaxxer set "${GITLAB_SECRET_NAME}" \
+    --provider gitlab \
+    --account "${GITLAB_VAULT_ACCOUNT}" \
+    --env test \
+    --access read-only \
+    --description "Read-only e2e fixture token for ${GITLAB_VAULT_ACCOUNT}"
+fi
 
 LIST_OUT="$(run_keymaxxer list)"
-if ! grep -q "${SECRET_NAME}" <<<"${LIST_OUT}"; then
-  echo "error: vault does not contain ${SECRET_NAME}" >&2
+if ! grep -q "${GITHUB_SECRET_NAME}" <<<"${LIST_OUT}"; then
+  echo "error: vault does not contain ${GITHUB_SECRET_NAME}" >&2
   echo "${LIST_OUT}" >&2
   exit 1
 fi
-OTHER="$(grep -E '^[A-Z][A-Z0-9_]*' <<<"${LIST_OUT}" | grep -v "${SECRET_NAME}" || true)"
-if [[ -n "${OTHER}" ]]; then
-  echo "error: vault must contain only ${SECRET_NAME}; also found:" >&2
-  echo "${OTHER}" >&2
+if [[ "${WITH_GITLAB}" -eq 1 ]] && ! grep -q "${GITLAB_SECRET_NAME}" <<<"${LIST_OUT}"; then
+  echo "error: vault does not contain ${GITLAB_SECRET_NAME}" >&2
+  echo "${LIST_OUT}" >&2
   exit 1
 fi
 
-PROBE_SCRIPT="${TMP_HOME}/probe-token-permissions.sh"
+EXPECTED_COUNT=1
+[[ "${WITH_GITLAB}" -eq 1 ]] && EXPECTED_COUNT=2
+SECRET_LINES="$(grep -E '^[A-Z][A-Z0-9_]*' <<<"${LIST_OUT}" || true)"
+ACTUAL_COUNT="$(grep -c . <<<"${SECRET_LINES}" || true)"
+if [[ "${ACTUAL_COUNT}" -ne "${EXPECTED_COUNT}" ]]; then
+  echo "error: vault must contain exactly ${EXPECTED_COUNT} secret(s); list was:" >&2
+  echo "${LIST_OUT}" >&2
+  exit 1
+fi
+if [[ "${WITH_GITLAB}" -eq 0 ]]; then
+  OTHER="$(grep -E '^[A-Z][A-Z0-9_]*' <<<"${LIST_OUT}" | grep -v "${GITHUB_SECRET_NAME}" || true)"
+  if [[ -n "${OTHER}" ]]; then
+    echo "error: vault must contain only ${GITHUB_SECRET_NAME}; also found:" >&2
+    echo "${OTHER}" >&2
+    exit 1
+  fi
+fi
+
+# --- GitHub permission probe ---
+# Body path under $HOME (the isolated TMP_HOME vault env) to avoid /tmp races.
+PROBE_SCRIPT="${TMP_HOME}/probe-github-token-permissions.sh"
 cat >"${PROBE_SCRIPT}" <<'PROBE'
 #!/usr/bin/env bash
 set -euo pipefail
 tok="${GITHUB_TOKEN_BERENDDEBOER_TEST_READY_FOR_AGENT:?}"
 repo="berenddeboer/test-ready-for-agent"
+probe_body="${HOME}/rfa-e2e-github-probe-body.json"
 api() {
   local method="$1" path="$2"
   shift 2
-  curl -sS -o /tmp/rfa-e2e-probe-body.json -w "%{http_code}" \
+  curl -sS -o "${probe_body}" -w "%{http_code}" \
     -X "${method}" \
     -H "Authorization: Bearer ${tok}" \
     -H "Accept: application/vnd.github+json" \
@@ -187,7 +306,7 @@ if [[ "${code}" != "403" && "${code}" != "404" ]]; then
 fi
 code="$(api PUT "/repos/${repo}/contents/.e2e-permission-probe" -d '{"message":"e2e permission probe","content":"eA=="}')"
 if [[ "${code}" == "201" || "${code}" == "200" ]]; then
-  sha="$(sed -n 's/.*"sha": *"\([^"]*\)".*/\1/p' /tmp/rfa-e2e-probe-body.json | head -1)"
+  sha="$(sed -n 's/.*"sha": *"\([^"]*\)".*/\1/p' "${probe_body}" | head -1)"
   if [[ -n "${sha}" ]]; then
     api DELETE "/repos/${repo}/contents/.e2e-permission-probe" \
       -d "{\"message\":\"remove e2e permission probe\",\"sha\":\"${sha}\"}" >/dev/null || true
@@ -205,16 +324,103 @@ elif [[ "${code}" != "403" && "${code}" != "404" ]]; then
 fi
 PROBE
 chmod 700 "${PROBE_SCRIPT}"
+run_keymaxxer run --secrets "${GITHUB_SECRET_NAME}" -- "${PROBE_SCRIPT}"
 
-run_keymaxxer run --secrets "${SECRET_NAME}" -- "${PROBE_SCRIPT}"
+# --- GitLab permission probe (optional) ---
+if [[ "${WITH_GITLAB}" -eq 1 ]]; then
+  GITLAB_PROBE="${TMP_HOME}/probe-gitlab-token-permissions.sh"
+  # Probe body stays under TMP_HOME so concurrent regenerations do not collide.
+  GITLAB_PROBE_BODY="${TMP_HOME}/rfa-e2e-gitlab-probe-body.json"
+  cat >"${GITLAB_PROBE}" <<PROBE
+#!/usr/bin/env bash
+set -euo pipefail
+tok="\${${GITLAB_SECRET_NAME}:?}"
+host="${GITLAB_FORGE_HOST}"
+project_path="${GITLAB_PROJECT_PATH}"
+probe_body="${GITLAB_PROBE_BODY}"
+encoded="\$(python3 -c "import urllib.parse; print(urllib.parse.quote('\${project_path}', safe=''))")"
+api() {
+  local method="\$1" path="\$2"
+  shift 2
+  curl -sS -o "\${probe_body}" -w "%{http_code}" \\
+    -X "\${method}" \\
+    -H "PRIVATE-TOKEN: \${tok}" \\
+    "https://\${host}/api/v4\${path}" \\
+    "\$@"
+}
+
+code="\$(api GET "/user")"
+if [[ "\${code}" != "200" ]]; then
+  echo "error: GitLab GET /user returned HTTP \${code}" >&2
+  exit 1
+fi
+code="\$(api GET "/projects/\${encoded}")"
+if [[ "\${code}" != "200" ]]; then
+  echo "error: GitLab GET project \${project_path} returned HTTP \${code}" >&2
+  echo "hint: create the throwaway fixture project and ensure the PAT can read it" >&2
+  exit 1
+fi
+code="\$(api GET "/projects/\${encoded}/issues?per_page=1")"
+if [[ "\${code}" != "200" ]]; then
+  echo "error: GitLab GET issues returned HTTP \${code} (Issues must be enabled on the fixture project)" >&2
+  exit 1
+fi
+code="\$(api GET "/projects/\${encoded}/merge_requests?per_page=1")"
+if [[ "\${code}" != "200" ]]; then
+  echo "error: GitLab GET merge_requests returned HTTP \${code}" >&2
+  exit 1
+fi
+# Prefer read-only: issue create should fail for CI tokens.
+code="\$(api POST "/projects/\${encoded}/issues" -d "title=e2e-permission-probe&description=must fail")"
+if [[ "\${code}" == "201" ]]; then
+  iid="\$(sed -n 's/.*"iid": *\\([0-9]*\\).*/\\1/p' "\${probe_body}" | head -1)"
+  if [[ -n "\${iid}" ]]; then
+    api DELETE "/projects/\${encoded}/issues/\${iid}" >/dev/null || true
+  fi
+  if [[ "\${E2E_ALLOW_GITLAB_WRITE_TOKEN:-}" == "1" ]]; then
+    echo "warning: GitLab token can create Issues; use read_api-only for CI when possible" >&2
+  else
+    echo "error: GitLab token must not create Issues (got HTTP \${code}); use read_api + read_repository" >&2
+    echo "hint: set E2E_ALLOW_GITLAB_WRITE_TOKEN=1 only for local bootstrap of the sentinel Issue" >&2
+    exit 1
+  fi
+elif [[ "\${code}" != "403" && "\${code}" != "401" && "\${code}" != "404" ]]; then
+  echo "error: unexpected GitLab issue-create probe HTTP \${code}" >&2
+  exit 1
+fi
+
+# Git HTTPS clone uses oauth2:<token> and requires read_repository (not just read_api).
+# Fail regeneration if ls-remote cannot authenticate/read, or if the repo has no refs.
+set +e
+ls_out="\$(git ls-remote "https://oauth2:\${tok}@\${host}/\${project_path}.git" 2>"\${HOME}/ls-remote.err")"
+ls_status=\$?
+set -e
+if [[ "\${ls_status}" -ne 0 ]]; then
+  echo "error: git ls-remote failed for \${host}/\${project_path} (exit \${ls_status})" >&2
+  echo "hint: PAT needs read_repository; project must be cloneable over HTTPS" >&2
+  cat "\${HOME}/ls-remote.err" >&2 || true
+  exit 1
+fi
+if [[ -z "\${ls_out}" ]]; then
+  echo "error: git ls-remote returned no refs for \${host}/\${project_path}" >&2
+  echo "hint: push an initial commit on the default branch before regenerating the vault" >&2
+  exit 1
+fi
+echo "✓ git ls-remote succeeded for \${host}/\${project_path}" >&2
+PROBE
+  chmod 700 "${GITLAB_PROBE}"
+  run_keymaxxer run --secrets "${GITLAB_SECRET_NAME}" -- "${GITLAB_PROBE}"
+fi
 
 # Flush multiprocess WAL into vault.db so only vault.db + vault.meta.json need committing.
+# Quoted heredoc: expected count is passed only via process.argv (not shell expansion).
 CHECKPOINT_SCRIPT="${TMP_HOME}/checkpoint-vault.mjs"
 cat >"${CHECKPOINT_SCRIPT}" <<'JS'
 import { connect } from "@tursodatabase/database"
 import { unlinkSync } from "node:fs"
 
 const path = process.argv[2]
+const expected = Number(process.argv[3] ?? "1")
 const hexkey = process.env.KEYMAXXER_MASTER_KEY
 if (!hexkey || !/^[0-9a-fA-F]{64}$/.test(hexkey)) {
   console.error("error: KEYMAXXER_MASTER_KEY must be 64 hex characters")
@@ -226,8 +432,10 @@ const db = await connect(path, {
 try {
   await db.prepare("PRAGMA wal_checkpoint(TRUNCATE)").get()
   const row = await db.prepare("select count(*) as c from secrets").get()
-  if (!row || Number(row.c) !== 1) {
-    console.error(`error: expected exactly 1 secret after checkpoint, got ${row?.c}`)
+  if (!row || Number(row.c) !== expected) {
+    console.error(
+      `error: expected exactly ${expected} secret(s) after checkpoint, got ${row?.c}`,
+    )
     process.exit(1)
   }
 } finally {
@@ -243,7 +451,7 @@ for (const side of [`${path}-wal`, `${path}-shm`, `${path}-tshm`]) {
 JS
 (
   cd "${ROOT}"
-  bun "${CHECKPOINT_SCRIPT}" "${HOME}/.keymaxxer/vault.db"
+  bun "${CHECKPOINT_SCRIPT}" "${HOME}/.keymaxxer/vault.db" "${EXPECTED_COUNT}"
 )
 
 mkdir -p "${FIXTURE_DIR}"
@@ -262,14 +470,25 @@ VERIFY_LIST="$(
     run_keymaxxer list
 )"
 rm -rf "${VERIFY_HOME}"
-if ! grep -q "${SECRET_NAME}" <<<"${VERIFY_LIST}"; then
-  echo "error: verified fixture vault is missing ${SECRET_NAME}" >&2
+if ! grep -q "${GITHUB_SECRET_NAME}" <<<"${VERIFY_LIST}"; then
+  echo "error: verified fixture vault is missing ${GITHUB_SECRET_NAME}" >&2
+  echo "${VERIFY_LIST}" >&2
+  exit 1
+fi
+if [[ "${WITH_GITLAB}" -eq 1 ]] && ! grep -q "${GITLAB_SECRET_NAME}" <<<"${VERIFY_LIST}"; then
+  echo "error: verified fixture vault is missing ${GITLAB_SECRET_NAME}" >&2
   echo "${VERIFY_LIST}" >&2
   exit 1
 fi
 
 echo "✓ Wrote ${FIXTURE_DIR}/vault.db and vault.meta.json" >&2
-echo "  secret: ${SECRET_NAME}" >&2
-echo "  metadata: provider=github account=${REPO} environment=test access=read-only" >&2
+echo "  github secret: ${GITHUB_SECRET_NAME}" >&2
+echo "  github metadata: provider=github account=${GITHUB_REPO} environment=test access=read-only" >&2
+if [[ "${WITH_GITLAB}" -eq 1 ]]; then
+  echo "  gitlab secret: ${GITLAB_SECRET_NAME}" >&2
+  echo "  gitlab metadata: provider=gitlab account=${GITLAB_VAULT_ACCOUNT} environment=test access=read-only" >&2
+else
+  echo "  gitlab secret: (omitted — re-run with --with-gitlab after the fixture project exists)" >&2
+fi
 echo "  master key: not written to the repository (use E2E_KEYMAXXER_MASTER_KEY in CI)" >&2
-echo "  rotate the fine-grained token within 90 days and re-run this script" >&2
+echo "  rotate tokens on schedule and re-run this script" >&2

--- a/scripts/setup-gitlab-e2e-fixture.sh
+++ b/scripts/setup-gitlab-e2e-fixture.sh
@@ -1,0 +1,244 @@
+#!/usr/bin/env bash
+# Bootstrap the GitLab End-to-End Fixture Repository on git.drupalcode.org.
+#
+# Drupal.org blocks creating projects and toggling Issues via the GitLab API
+# (mutations return a HTML git-error page). Create the throwaway project and
+# enable Issues in the Drupal.org / GitLab UI first, then run this script with
+# a PAT that can manage Issues and labels (local bootstrap only — CI uses
+# read-only).
+#
+# Prerequisites:
+#   - glab authenticated to git.drupalcode.org, OR GITLAB_TOKEN / PRIVATE-TOKEN
+#   - Project exists at E2E_GITLAB_PROJECT_PATH (default:
+#     sandbox/berend-test-ready-for-agent) with Issues enabled
+#   - Label ready-for-agent will be created if missing
+#   - Sentinel Issue with the fixed title will be created if missing
+#
+# Prints the sentinel iid to lock into apps/harness/e2e/support/constants.ts
+# (or export E2E_GITLAB_SENTINEL_ISSUE_NUMBER for local runs).
+set -euo pipefail
+
+HOST="${E2E_GITLAB_FORGE_HOST:-git.drupalcode.org}"
+PROJECT_PATH="${E2E_GITLAB_PROJECT_PATH:-sandbox/berend-test-ready-for-agent}"
+SENTINEL_TITLE="E2E fixture: Ready-labeled Issue refresh"
+READY_LABEL="ready-for-agent"
+READY_COLOR="#0E8A16"
+BODY_FILE="$(mktemp "${TMPDIR:-/tmp}/rfa-gitlab-fixture-body.XXXXXX")"
+trap 'rm -f "${BODY_FILE}"' EXIT
+
+encoded_path() {
+  python3 -c "import urllib.parse,sys; print(urllib.parse.quote(sys.argv[1], safe=''))" "$1"
+}
+
+resolve_token() {
+  if [[ -n "${GITLAB_TOKEN:-}" ]]; then
+    printf '%s' "${GITLAB_TOKEN}"
+    return
+  fi
+  if [[ -n "${PRIVATE_TOKEN:-}" ]]; then
+    printf '%s' "${PRIVATE_TOKEN}"
+    return
+  fi
+  if command -v glab >/dev/null 2>&1; then
+    local from_glab
+    from_glab="$(glab config get token --host "${HOST}" 2>/dev/null || true)"
+    if [[ -n "${from_glab}" && "${from_glab}" != "null" ]]; then
+      printf '%s' "${from_glab}"
+      return
+    fi
+  fi
+  echo "error: set GITLAB_TOKEN or authenticate glab to ${HOST}" >&2
+  exit 1
+}
+
+TOKEN="$(resolve_token)"
+ENC="$(encoded_path "${PROJECT_PATH}")"
+API="https://${HOST}/api/v4"
+
+api_code() {
+  local method="$1" path="$2"
+  shift 2
+  curl -sS -o "${BODY_FILE}" -w "%{http_code}" \
+    -X "${method}" \
+    -H "PRIVATE-TOKEN: ${TOKEN}" \
+    -H "Content-Type: application/json" \
+    "${API}${path}" \
+    "$@"
+}
+
+echo "Checking project ${PROJECT_PATH} on ${HOST}..." >&2
+code="$(api_code GET "/projects/${ENC}")"
+if [[ "${code}" != "200" ]]; then
+  cat <<EOF >&2
+error: project not found or inaccessible (HTTP ${code}).
+
+Create a throwaway project on ${HOST} under operator control, then re-run:
+
+  1. On Drupal.org, create a sandbox (or other project you control).
+  2. Open the GitLab project settings and enable Issues (and CI if you will
+     exercise pipelines). Drupal.org often defaults Issues off for sandboxes
+     and many project/* namespaces.
+  3. Export the path and re-run:
+       export E2E_GITLAB_PROJECT_PATH='sandbox/<your-path>'
+       $0
+
+Canonical path used by CI constants (override with E2E_GITLAB_PROJECT_PATH):
+  sandbox/berend-test-ready-for-agent
+EOF
+  exit 1
+fi
+
+issues_enabled="$(python3 -c "import json; print(json.load(open('${BODY_FILE}')).get('issues_enabled'))")"
+if [[ "${issues_enabled}" != "True" && "${issues_enabled}" != "true" ]]; then
+  echo "error: Issues are disabled on ${PROJECT_PATH}. Enable Issues in GitLab project settings." >&2
+  exit 1
+fi
+echo "✓ Project reachable with Issues enabled" >&2
+
+empty_repo="$(python3 -c "import json; print(json.load(open('${BODY_FILE}')).get('empty_repo'))")"
+default_branch="$(python3 -c "import json; print(json.load(open('${BODY_FILE}')).get('default_branch') or '')")"
+if [[ "${empty_repo}" == "True" || "${empty_repo}" == "true" || -z "${default_branch}" ]]; then
+  cat <<EOF >&2
+error: project ${PROJECT_PATH} has no default branch / is empty.
+
+Live e2e runs \`git clone --depth 1\` and fails on empty GitLab projects.
+Push an initial commit on the default branch (e.g. README), then re-run.
+EOF
+  exit 1
+fi
+echo "✓ Project has default branch ${default_branch}" >&2
+
+# Ensure ready-for-agent label
+code="$(api_code GET "/projects/${ENC}/labels?per_page=100")"
+if [[ "${code}" != "200" ]]; then
+  echo "error: failed to list labels (HTTP ${code})" >&2
+  cat "${BODY_FILE}" >&2
+  exit 1
+fi
+if ! python3 -c "
+import json
+labels = json.load(open('${BODY_FILE}'))
+raise SystemExit(0 if any(l.get('name') == '${READY_LABEL}' for l in labels) else 1)
+"; then
+  echo "Creating label ${READY_LABEL}..." >&2
+  code="$(api_code POST "/projects/${ENC}/labels" \
+    -d "{\"name\":\"${READY_LABEL}\",\"color\":\"${READY_COLOR}\",\"description\":\"Ready for Agent\"}")"
+  if [[ "${code}" != "201" && "${code}" != "200" ]]; then
+    echo "error: failed to create label (HTTP ${code})" >&2
+    cat "${BODY_FILE}" >&2
+    exit 1
+  fi
+  echo "✓ Created label ${READY_LABEL}" >&2
+else
+  echo "✓ Label ${READY_LABEL} already exists" >&2
+fi
+
+# Find open Issue with exact sentinel title (paginate lightly)
+SENTINEL_IID=""
+page=1
+while [[ "${page}" -le 10 ]]; do
+  code="$(api_code GET "/projects/${ENC}/issues?state=opened&per_page=100&page=${page}")"
+  if [[ "${code}" != "200" ]]; then
+    echo "error: failed to list issues (HTTP ${code})" >&2
+    cat "${BODY_FILE}" >&2
+    exit 1
+  fi
+  SENTINEL_IID="$(
+    python3 -c "
+import json
+title = '''${SENTINEL_TITLE}'''
+for issue in json.load(open('${BODY_FILE}')):
+    if issue.get('title') == title:
+        print(issue['iid'])
+        break
+"
+  )"
+  if [[ -n "${SENTINEL_IID}" ]]; then
+    break
+  fi
+  count="$(python3 -c "import json; print(len(json.load(open('${BODY_FILE}'))))")"
+  if [[ "${count}" -lt 100 ]]; then
+    break
+  fi
+  page=$((page + 1))
+done
+
+if [[ -z "${SENTINEL_IID}" ]]; then
+  echo "Creating sentinel Issue..." >&2
+  payload="$(
+    python3 -c "
+import json
+print(json.dumps({
+  'title': '''${SENTINEL_TITLE}''',
+  'description': '''Permanent sentinel Issue for Ready for Agent live e2e.
+
+Keep this Issue open and labeled ready-for-agent.
+No hierarchy, no blockers, no Issue-closing merge request.
+Scenarios tolerate unrelated Issues on this project.
+''',
+  'labels': '${READY_LABEL}',
+}))
+"
+  )"
+  code="$(api_code POST "/projects/${ENC}/issues" -d "${payload}")"
+  if [[ "${code}" != "201" ]]; then
+    echo "error: failed to create sentinel Issue (HTTP ${code})" >&2
+    cat "${BODY_FILE}" >&2
+    exit 1
+  fi
+  SENTINEL_IID="$(python3 -c "import json; print(json.load(open('${BODY_FILE}'))['iid'])")"
+  echo "✓ Created sentinel Issue #${SENTINEL_IID}" >&2
+else
+  echo "✓ Sentinel Issue already open as #${SENTINEL_IID}" >&2
+  code="$(api_code PUT "/projects/${ENC}/issues/${SENTINEL_IID}" \
+    -d "{\"add_labels\":\"${READY_LABEL}\"}")"
+  if [[ "${code}" != "200" ]]; then
+    echo "error: failed to ensure ${READY_LABEL} on Issue #${SENTINEL_IID} (HTTP ${code})" >&2
+    cat "${BODY_FILE}" >&2
+    exit 1
+  fi
+fi
+
+# Assert the Ready label stuck (create path and re-label path).
+code="$(api_code GET "/projects/${ENC}/issues/${SENTINEL_IID}")"
+if [[ "${code}" != "200" ]]; then
+  echo "error: failed to re-fetch sentinel Issue #${SENTINEL_IID} (HTTP ${code})" >&2
+  cat "${BODY_FILE}" >&2
+  exit 1
+fi
+if ! python3 -c "
+import json
+issue = json.load(open('${BODY_FILE}'))
+labels = issue.get('labels') or []
+names = [l.get('name') if isinstance(l, dict) else l for l in labels]
+raise SystemExit(0 if '${READY_LABEL}' in names else 1)
+"; then
+  echo "error: sentinel Issue #${SENTINEL_IID} is missing label ${READY_LABEL}" >&2
+  cat "${BODY_FILE}" >&2
+  exit 1
+fi
+echo "✓ Sentinel Issue #${SENTINEL_IID} carries ${READY_LABEL}" >&2
+
+cat <<EOF
+
+Fixture ready:
+  Forge Host:    ${HOST}
+  Project Path:  ${PROJECT_PATH}
+  Sentinel iid:  ${SENTINEL_IID}
+  Title:         ${SENTINEL_TITLE}
+  Label:         ${READY_LABEL}
+
+Next steps:
+  1. Lock the sentinel iid (env override or default in gitlabSentinelIssueNumber):
+       export E2E_GITLAB_SENTINEL_ISSUE_NUMBER=${SENTINEL_IID}
+       export E2E_GITLAB_PROJECT_PATH='${PROJECT_PATH}'
+  2. Mint a read-only PAT (read_api, read_repository) for CI.
+  3. Regenerate the dual-secret fixture vault (probes API + git ls-remote):
+       export E2E_KEYMAXXER_MASTER_KEY   # existing Actions master key
+       export E2E_GITLAB_PROJECT_PATH='${PROJECT_PATH}'
+       ./scripts/regenerate-e2e-keymaxxer-vault.sh --with-gitlab
+       # paste GitHub fine-grained token, then GitLab PAT
+  4. Run the isolated GitLab clone smoke test (docs/e2e-fixture.md), then commit
+     e2e/fixtures/keymaxxer/vault.db and vault.meta.json
+  5. Run: E2E_REQUIRE_GITLAB=1 bunx nx run harness:e2e
+EOF


### PR DESCRIPTION
## Why

GitLab lifecycle support is complete on the product path, but live e2e only
exercised the GitHub fixture. Phase 6 of the GitLab forge work needs the same
operator journey against a controlled throwaway project on git.drupalcode.org.

## What changed

- Gherkin scenario for add + refresh of a GitLab End-to-End Fixture Repository
  (mirrors GitHub; unrelated Issues tolerated)
- Forge-aware fixture clone (`oauth2:` HTTPS, vault account `host/project-path`)
  and dual-secret vault regeneration (`--with-gitlab`, fail-closed dual-secret
  guard, `git ls-remote` + empty-repo probes)
- Soft-skip when the GitLab vault secret is absent; `E2E_REQUIRE_GITLAB=1`
  fails closed
- Multi-scenario cleanup via GraphQL remove with
  `REPOSITORY_HAS_RUNNING_STEP` mapping/retry
- Operator bootstrap script and docs (`docs/e2e-fixture.md`, ADR 0021)

## Verification

- harness typecheck/lint; graphql-api tests including
  `REPOSITORY_HAS_RUNNING_STEP` mapping
- clone-fixture unit tests; pre-commit / `nx affected` lint·typecheck·test

## Limitations

- Fixture project/PAT/dual-secret vault remain operator bootstrap (Drupal.org
  blocks API project creation). Until the vault includes the GitLab secret, CI
  soft-skips that scenario.
- Automated e2e stays add+refresh only (no Implement → MR → merge), same as
  GitHub live e2e.

Closes #572