### PR TITLE
fix(gitlab): require host-scoped glab auth for ambient credentials

### DIFF
--- a/apps/harness/scripts/dev-smoke.ts
+++ b/apps/harness/scripts/dev-smoke.ts
@@ -18,6 +18,11 @@ const sidecarWrapper = resolve(
 
 const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
 
+/** Overall wait for cold CI Vite first boot (empty dep graph, no Nx cache). */
+const GRAPHQL_HEALTH_TIMEOUT_MS = 360_000
+/** Cap each poll so a hung TCP/fetch cannot outrun the overall deadline. */
+const GRAPHQL_HEALTH_POLL_MS = 5_000
+
 const waitForGraphqlHealth = async (
   baseUrl: string,
   timeoutMs: number,
@@ -33,11 +38,15 @@ const waitForGraphqlHealth = async (
         }`,
       )
     }
+    const remainingMs = deadline - Date.now()
+    if (remainingMs <= 0) break
+    const pollMs = Math.min(GRAPHQL_HEALTH_POLL_MS, remainingMs)
     try {
       const response = await fetch(`${baseUrl}/graphql`, {
         method: "POST",
         headers: { "content-type": "application/json" },
         body: JSON.stringify({ query: "{ health }" }),
+        signal: AbortSignal.timeout(pollMs),
       })
       if (response.status === 200) {
         const payload = (await response.json()) as {
@@ -158,7 +167,11 @@ const cleanup = async () => {
 }
 
 try {
-  await waitForGraphqlHealth(baseUrl, 120_000, () => !childExited)
+  await waitForGraphqlHealth(
+    baseUrl,
+    GRAPHQL_HEALTH_TIMEOUT_MS,
+    () => !childExited,
+  )
 
   const root = await fetch(`${baseUrl}/`, { redirect: "manual" })
   if (root.status <= 0) {

--- a/apps/harness/src/server/ambient-gitlab-layer.ts
+++ b/apps/harness/src/server/ambient-gitlab-layer.ts
@@ -1,5 +1,5 @@
-import { Deferred, Duration, Effect, Layer, Ref } from "effect"
-import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process"
+import { Deferred, Effect, Layer, Ref } from "effect"
+import { ChildProcessSpawner } from "effect/unstable/process"
 import {
   type GitLabProjectUnavailableError,
   GitLabRequestError,
@@ -7,6 +7,7 @@ import {
   type GitLabServiceShape,
   makeGitLabService,
   makeGitLabServiceFromToken,
+  resolveGlabHostToken,
 } from "@ready-for-agent/gitlab-service"
 
 type GitLabServiceError = GitLabProjectUnavailableError | GitLabRequestError
@@ -43,27 +44,19 @@ export const ambientGitLabLayer = (options: {
 
       const resolveGlabToken = Effect.fn("AmbientGitLab.resolveGlabToken")(
         function* (forgeHost: string) {
-          const output = yield* spawner
-            .string(
-              ChildProcess.make(
-                "glab",
-                ["config", "get", "token", "--host", forgeHost],
-                {
-                  cwd: options.workspaceRoot,
-                  stdin: "ignore",
-                  stderr: "inherit",
-                },
-              ),
-            )
-            .pipe(
-              Effect.timeout(Duration.seconds(60)),
-              Effect.mapError((cause) => authenticationError(forgeHost, cause)),
-            )
-          const token = output.trim()
-          if (token === "") {
+          // Host-specific: shared helper uses `glab auth status --hostname
+          // --show-token` so unconfigured hosts (and config-get fallback tokens)
+          // are rejected, while local tokens still work when the Forge API is
+          // briefly unreachable.
+          const token = yield* resolveGlabHostToken({
+            forgeHost,
+            spawner,
+            cwd: options.workspaceRoot,
+          })
+          if (token === null) {
             return yield* authenticationError(
               forgeHost,
-              "GitLab CLI did not return an authentication token",
+              `GitLab CLI is not authenticated for ${forgeHost}`,
             )
           }
           return token

--- a/apps/harness/test/ambient-gitlab-layer.test.ts
+++ b/apps/harness/test/ambient-gitlab-layer.test.ts
@@ -1,7 +1,8 @@
 import * as BunChildProcessSpawner from "@effect/platform-bun/BunChildProcessSpawner"
 import * as BunFileSystem from "@effect/platform-bun/BunFileSystem"
 import * as BunPath from "@effect/platform-bun/BunPath"
-import { Effect, Layer } from "effect"
+import { Effect, Layer, Stream } from "effect"
+import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process"
 import {
   GitLabRequestError,
   GitLabService,
@@ -15,7 +16,7 @@ const processLayer = BunChildProcessSpawner.layer.pipe(
 )
 
 const repository = {
-  forge: "gitlab",
+  forge: "gitlab" as const,
   forgeHost: "git.drupalcode.org",
   projectPath: "project/oauth_client",
 }
@@ -54,6 +55,72 @@ const service = (
   deleteBranch: () => Effect.void,
   ...overrides,
 })
+
+/**
+ * Simulates glab CLI for ambient credential resolution via
+ * `glab auth status --hostname <host> --show-token`.
+ *
+ * Hosts in `hostTokens` emit an unmasked Token found line (optionally with a
+ * non-zero exit code to simulate API outage). Other hosts emit the unconfigured
+ * host error with no token.
+ */
+const glabProcessLayer = (options: {
+  readonly hostTokens: ReadonlyMap<string, string>
+  /** Exit code for authenticated hosts (1 simulates API failure with token). */
+  readonly authenticatedExitCode?: number
+}) => {
+  const commands: Array<ReadonlyArray<string>> = []
+  const encoder = new TextEncoder()
+
+  const service = ChildProcessSpawner.make((command) =>
+    Effect.sync(() => {
+      if (!ChildProcess.isStandardCommand(command)) {
+        throw new Error("expected standard command")
+      }
+      const args = [command.command, ...command.args]
+      commands.push(args)
+      const hostIndex = command.args.indexOf("--hostname")
+      const host = hostIndex >= 0 ? (command.args[hostIndex + 1] ?? "") : ""
+      const token = options.hostTokens.get(host)
+      const showToken = command.args.includes("--show-token")
+      const body =
+        token === undefined || !showToken
+          ? `X ${host} has not been authenticated with glab\n`
+          : `${host}\n  x API call failed\n  ✓ Token found: ${token}\nERROR\nX could not authenticate\n`
+      const bytes = encoder.encode(body)
+      const exitCode = ChildProcessSpawner.ExitCode(
+        token === undefined ? 1 : (options.authenticatedExitCode ?? 0),
+      )
+      return ChildProcessSpawner.makeHandle({
+        pid: ChildProcessSpawner.ProcessId(1),
+        exitCode: Effect.succeed(exitCode),
+        isRunning: Effect.succeed(false),
+        kill: () => Effect.void,
+        stdin: {
+          onStart: () => Effect.void,
+          onInput: () => Effect.void,
+          onEnd: () => Effect.void,
+        } as never,
+        stdout: Stream.succeed(bytes),
+        stderr: Stream.empty,
+        all: Stream.succeed(bytes),
+        getInputFd: () =>
+          ({
+            onStart: () => Effect.void,
+            onInput: () => Effect.void,
+            onEnd: () => Effect.void,
+          }) as never,
+        getOutputFd: () => Stream.empty,
+        unref: Effect.succeed(Effect.void),
+      })
+    }),
+  )
+
+  return {
+    commands,
+    layer: Layer.succeed(ChildProcessSpawner.ChildProcessSpawner, service),
+  }
+}
 
 test("GITLAB_TOKEN takes precedence over glab and is cached per host", async () => {
   let resolutions = 0
@@ -168,4 +235,148 @@ test("public project verification falls back to anonymous access", async () => {
   )
 
   expect(anonymousVerifications).toBe(1)
+})
+
+test("glab login for a host is recognized for that host only", async () => {
+  const glab = glabProcessLayer({
+    hostTokens: new Map([["git.drupalcode.org", "token-for-drupalcode"]]),
+    // Non-zero exit with Token found simulates API outage resilience.
+    authenticatedExitCode: 1,
+  })
+  const tokens: string[] = []
+  const layer = ambientGitLabLayer({
+    workspaceRoot: "/workspace",
+    makeService: (token) => {
+      tokens.push(token)
+      return service()
+    },
+  })
+
+  const result = await Effect.runPromise(
+    Effect.gen(function* () {
+      const gitlab = yield* GitLabService
+      const configured = yield* gitlab.hasCredentials(repository)
+      const wrongSshHost = yield* gitlab.hasCredentials({
+        ...repository,
+        forgeHost: "git.drupal.org",
+      })
+      const arbitrary = yield* gitlab.hasCredentials({
+        ...repository,
+        forgeHost: "not-a-real-host.example",
+      })
+      const ambientConfigured = yield* gitlab.hasAmbientCredentials(repository)
+      const ambientWrong = yield* gitlab.hasAmbientCredentials({
+        ...repository,
+        forgeHost: "git.drupal.org",
+      })
+      yield* gitlab.listReadyIssues(repository)
+      return {
+        configured,
+        wrongSshHost,
+        arbitrary,
+        ambientConfigured,
+        ambientWrong,
+      }
+    }).pipe(Effect.provide(layer.pipe(Layer.provide(glab.layer)))),
+  )
+
+  expect(result).toEqual({
+    configured: true,
+    wrongSshHost: false,
+    arbitrary: false,
+    ambientConfigured: true,
+    ambientWrong: false,
+  })
+  expect(tokens).toEqual(["token-for-drupalcode"])
+  expect(
+    glab.commands.some(
+      (args) =>
+        args[0] === "glab" &&
+        args[1] === "auth" &&
+        args[2] === "status" &&
+        args[3] === "--hostname" &&
+        args[4] === "git.drupalcode.org" &&
+        args.includes("--show-token"),
+    ),
+  ).toBe(true)
+  expect(
+    glab.commands.some(
+      (args) =>
+        args[0] === "glab" &&
+        args[1] === "auth" &&
+        args[2] === "status" &&
+        args[3] === "--hostname" &&
+        args[4] === "not-a-real-host.example",
+    ),
+  ).toBe(true)
+  // Shared helper never uses config-get (fallback-token path).
+  expect(
+    glab.commands.some(
+      (args) =>
+        args[0] === "glab" &&
+        args[1] === "config" &&
+        args[2] === "get" &&
+        args[3] === "token",
+    ),
+  ).toBe(false)
+})
+
+test("unconfigured hosts do not receive credentials from glab", async () => {
+  const glab = glabProcessLayer({
+    hostTokens: new Map(),
+  })
+  const tokens: string[] = []
+  const layer = ambientGitLabLayer({
+    workspaceRoot: "/workspace",
+    makeService: (token) => {
+      tokens.push(token)
+      return service()
+    },
+  })
+
+  const hasCredentials = await Effect.runPromise(
+    Effect.gen(function* () {
+      const gitlab = yield* GitLabService
+      return yield* gitlab.hasCredentials({
+        ...repository,
+        forgeHost: "not-a-real-host.example",
+      })
+    }).pipe(Effect.provide(layer.pipe(Layer.provide(glab.layer)))),
+  )
+
+  expect(hasCredentials).toBe(false)
+  expect(tokens).toEqual([])
+})
+
+test("GITLAB_TOKEN still takes precedence over host-specific glab auth", async () => {
+  const glab = glabProcessLayer({
+    hostTokens: new Map([["git.drupalcode.org", "glab-token"]]),
+  })
+  const tokens: string[] = []
+  const layer = ambientGitLabLayer({
+    workspaceRoot: "/workspace",
+    environment: { GITLAB_TOKEN: " env-token " },
+    makeService: (token) => {
+      tokens.push(token)
+      return service()
+    },
+  })
+
+  await Effect.runPromise(
+    Effect.gen(function* () {
+      const gitlab = yield* GitLabService
+      expect(yield* gitlab.hasCredentials(repository)).toBe(true)
+      expect(
+        yield* gitlab.hasCredentials({
+          ...repository,
+          forgeHost: "not-a-real-host.example",
+        }),
+      ).toBe(true)
+      yield* gitlab.listReadyIssues(repository)
+    }).pipe(Effect.provide(layer.pipe(Layer.provide(glab.layer)))),
+  )
+
+  expect(tokens).toEqual(["env-token"])
+  // Env token short-circuits; glab must not be consulted.
+  expect(glab.commands).toEqual([])
 })

--- a/apps/harness/test/topology.test.ts
+++ b/apps/harness/test/topology.test.ts
@@ -72,6 +72,8 @@ describe("single application server topology", () => {
       "bun --conditions @ready-for-agent/source ./node_modules/vite/bin/vite.js",
     )
     expect(smokeScript).toContain("{ health }")
+    expect(smokeScript).toContain("AbortSignal.timeout")
+    expect(smokeScript).toContain("GRAPHQL_HEALTH_TIMEOUT_MS")
     expect(smokeScript).not.toContain("E2E_KEYMAXXER_MASTER_KEY")
   })
 

--- a/packages/gitlab-service/src/index.ts
+++ b/packages/gitlab-service/src/index.ts
@@ -8,4 +8,5 @@ export {
   makeGitLabServiceFromToken,
 } from "./lib/gitlab-service-live.js"
 export * from "./lib/gitlab-service-test.js"
+export * from "./lib/glab-host-token.js"
 export * from "./lib/types.js"

--- a/packages/gitlab-service/src/lib/glab-host-token.ts
+++ b/packages/gitlab-service/src/lib/glab-host-token.ts
@@ -1,0 +1,83 @@
+import { Duration, Effect, Stream } from "effect"
+import { ChildProcess, type ChildProcessSpawner } from "effect/unstable/process"
+
+/**
+ * Prefer this over `glab config get token --host`, which can exit successfully
+ * with a fallback token for hosts that were never authenticated.
+ *
+ * `glab auth status --hostname <host> --show-token` is host-specific. Exit code
+ * alone is not enough: glab can exit non-zero when the Forge API is unreachable
+ * even though a local token for that host is present. Parse the unmasked
+ * Token found line instead (exit code is ignored).
+ *
+ * Line shapes (glab versions differ):
+ * - `Token found: <token>` (glab through ~1.110)
+ * - `Token found in <source>: <token>` (glab main, e.g. keyring / config file)
+ */
+export const GLAB_HOST_TOKEN_TIMEOUT = Duration.seconds(60)
+
+/**
+ * Matches both historical and current glab show-token lines. Captures the last
+ * colon-separated unmasked token on the line.
+ */
+const TOKEN_FOUND_LINE = /Token found(?:\s+in\s+[^:\n]+)?:\s+(\S+)/g
+
+/** Extract an unmasked token from `glab auth status --show-token` output. */
+export const parseGlabAuthStatusShowToken = (
+  combinedOutput: string,
+): string | null => {
+  const matches = combinedOutput.matchAll(TOKEN_FOUND_LINE)
+  let found: string | null = null
+  for (const match of matches) {
+    const token = match[1]
+    if (token === undefined || token === "") continue
+    // Without --show-token glab prints asterisks; reject masked values.
+    if (token.includes("*")) continue
+    found = token
+  }
+  return found
+}
+
+export type ResolveGlabHostTokenOptions = {
+  readonly forgeHost: string
+  readonly spawner: ChildProcessSpawner.ChildProcessSpawner["Service"]
+  readonly cwd?: string
+  readonly timeout?: Duration.Duration
+}
+
+/**
+ * Resolve a host-scoped glab token, or null when the host is not authenticated
+ * (or the CLI is unavailable / times out).
+ */
+export const resolveGlabHostToken = (
+  options: ResolveGlabHostTokenOptions,
+): Effect.Effect<string | null> =>
+  Effect.gen(function* () {
+    const timeout = options.timeout ?? GLAB_HOST_TOKEN_TIMEOUT
+    const command = ChildProcess.make(
+      "glab",
+      ["auth", "status", "--hostname", options.forgeHost, "--show-token"],
+      {
+        cwd: options.cwd,
+        stdin: "ignore",
+      },
+    )
+    const combined = yield* Effect.scoped(
+      Effect.gen(function* () {
+        const handle = yield* options.spawner.spawn(command)
+        const [, stdout, stderr] = yield* Effect.all(
+          [
+            handle.exitCode,
+            Stream.decodeText(handle.stdout).pipe(Stream.mkString),
+            Stream.decodeText(handle.stderr).pipe(Stream.mkString),
+          ],
+          { concurrency: 3 },
+        )
+        return `${stdout}\n${stderr}`
+      }),
+    ).pipe(
+      Effect.timeout(timeout),
+      Effect.orElseSucceed(() => ""),
+    )
+    return parseGlabAuthStatusShowToken(combined)
+  })

--- a/packages/gitlab-service/test/glab-host-token.spec.ts
+++ b/packages/gitlab-service/test/glab-host-token.spec.ts
@@ -1,0 +1,165 @@
+import { Effect, Stream } from "effect"
+import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process"
+import {
+  parseGlabAuthStatusShowToken,
+  resolveGlabHostToken,
+} from "../src/lib/glab-host-token.js"
+import { describe, expect, test } from "bun:test"
+
+describe("parseGlabAuthStatusShowToken", () => {
+  test("extracts an unmasked token from legacy show-token output", () => {
+    const output = `
+git.drupalcode.org
+  ✓ Logged in to git.drupalcode.org as berend (keyring)
+  ✓ Token found: abcd.01.real-token-value
+`
+    expect(parseGlabAuthStatusShowToken(output)).toBe(
+      "abcd.01.real-token-value",
+    )
+  })
+
+  test("extracts token from glab main 'Token found in <source>:' shape", () => {
+    const keyring = `
+git.drupalcode.org
+  ✓ Logged in to git.drupalcode.org as berend (keyring)
+  ✓ Token found in operating system keyring: abcd.01.from-keyring
+`
+    expect(parseGlabAuthStatusShowToken(keyring)).toBe("abcd.01.from-keyring")
+
+    const plaintext = `
+gitlab.example.com
+  ✓ Token found in configuration file (plaintext): cfg-token-value
+`
+    expect(parseGlabAuthStatusShowToken(plaintext)).toBe("cfg-token-value")
+  })
+
+  test("rejects masked tokens (status without --show-token)", () => {
+    const legacy = `
+git.drupalcode.org
+  ✓ Token found: **************************
+`
+    expect(parseGlabAuthStatusShowToken(legacy)).toBeNull()
+
+    const withSource = `
+git.drupalcode.org
+  ✓ Token found in operating system keyring: **************************
+`
+    expect(parseGlabAuthStatusShowToken(withSource)).toBeNull()
+  })
+
+  test("returns null when the host is not authenticated", () => {
+    const output = `
+X not-a-real-host.example has not been authenticated with glab; run \`glab auth login --hostname not-a-real-host.example\` to authenticate.
+`
+    expect(parseGlabAuthStatusShowToken(output)).toBeNull()
+  })
+
+  test("accepts token present when API call failed (offline/outage)", () => {
+    const output = `
+git.drupalcode.org
+  x git.drupalcode.org: API call failed: Get "https://git.drupalcode.org/api/v4/user": connection refused
+  ✓ Token found in operating system keyring: host-local-token
+ERROR
+X could not authenticate to one or more of the configured GitLab instances.
+`
+    expect(parseGlabAuthStatusShowToken(output)).toBe("host-local-token")
+  })
+})
+
+describe("resolveGlabHostToken", () => {
+  const mockSpawner = (options: {
+    readonly hostTokens: ReadonlyMap<string, string>
+    readonly exitCode?: number
+  }) => {
+    const commands: Array<ReadonlyArray<string>> = []
+    const encoder = new TextEncoder()
+    const service = ChildProcessSpawner.make((command) =>
+      Effect.sync(() => {
+        if (!ChildProcess.isStandardCommand(command)) {
+          throw new Error("expected standard command")
+        }
+        commands.push([command.command, ...command.args])
+        const hostIndex = command.args.indexOf("--hostname")
+        const host = hostIndex >= 0 ? (command.args[hostIndex + 1] ?? "") : ""
+        const token = options.hostTokens.get(host)
+        const showToken = command.args.includes("--show-token")
+        const body =
+          token === undefined || !showToken
+            ? `X ${host} has not been authenticated with glab\n`
+            : `${host}\n  x API call failed\n  ✓ Token found: ${token}\nERROR\nX could not authenticate\n`
+        const bytes = encoder.encode(body)
+        return ChildProcessSpawner.makeHandle({
+          pid: ChildProcessSpawner.ProcessId(1),
+          exitCode: Effect.succeed(
+            ChildProcessSpawner.ExitCode(
+              token === undefined ? 1 : (options.exitCode ?? 1),
+            ),
+          ),
+          isRunning: Effect.succeed(false),
+          kill: () => Effect.void,
+          stdin: {
+            onStart: () => Effect.void,
+            onInput: () => Effect.void,
+            onEnd: () => Effect.void,
+          } as never,
+          stdout: Stream.succeed(bytes),
+          stderr: Stream.empty,
+          all: Stream.succeed(bytes),
+          getInputFd: () =>
+            ({
+              onStart: () => Effect.void,
+              onInput: () => Effect.void,
+              onEnd: () => Effect.void,
+            }) as never,
+          getOutputFd: () => Stream.empty,
+          unref: Effect.succeed(Effect.void),
+        })
+      }),
+    )
+    return { commands, service }
+  }
+
+  test("accepts host token even when glab exits non-zero after API failure", async () => {
+    const glab = mockSpawner({
+      hostTokens: new Map([["git.drupalcode.org", "token-for-drupalcode"]]),
+      exitCode: 1,
+    })
+
+    const token = await Effect.runPromise(
+      resolveGlabHostToken({
+        forgeHost: "git.drupalcode.org",
+        spawner: glab.service,
+      }),
+    )
+
+    expect(token).toBe("token-for-drupalcode")
+    expect(glab.commands[0]).toEqual([
+      "glab",
+      "auth",
+      "status",
+      "--hostname",
+      "git.drupalcode.org",
+      "--show-token",
+    ])
+  })
+
+  test("rejects unconfigured hosts (no config-get fallback path)", async () => {
+    const glab = mockSpawner({
+      hostTokens: new Map([["git.drupalcode.org", "token-for-drupalcode"]]),
+    })
+
+    const token = await Effect.runPromise(
+      resolveGlabHostToken({
+        forgeHost: "not-a-real-host.example",
+        spawner: glab.service,
+      }),
+    )
+
+    expect(token).toBeNull()
+    expect(
+      glab.commands.some(
+        (args) => args.includes("config") && args.includes("token"),
+      ),
+    ).toBe(false)
+  })
+})

--- a/packages/work-item-lifecycle/src/lib/create-pr.ts
+++ b/packages/work-item-lifecycle/src/lib/create-pr.ts
@@ -1,4 +1,4 @@
-import { Duration, Effect, FileSystem, Stream } from "effect"
+import { Effect, FileSystem, Stream } from "effect"
 import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process"
 import { SqlClient } from "effect/unstable/sql"
 import { AgentBackend, agentBackendLabel } from "@ready-for-agent/agent-backend"
@@ -10,6 +10,7 @@ import {
 import {
   type GitLabRepository,
   GitLabService,
+  resolveGlabHostToken,
 } from "@ready-for-agent/gitlab-service"
 import { KeymaxxerService } from "@ready-for-agent/keymaxxer-service"
 import {
@@ -311,10 +312,8 @@ const gitlabHttpsRemoteUrl = (repository: RepositoryRecord): string =>
 
 /**
  * Resolve ambient GitLab token for HTTPS push (Keymaxxer path unavailable).
- * Prefers GITLAB_TOKEN, then glab host-scoped config.
+ * Prefers GITLAB_TOKEN, then host-authenticated glab via shared helper.
  */
-const GLAB_TOKEN_TIMEOUT = Duration.seconds(60)
-
 const resolveAmbientGitLabToken = (forgeHost: string) =>
   Effect.gen(function* () {
     const fromEnv = process.env.GITLAB_TOKEN?.trim()
@@ -322,42 +321,7 @@ const resolveAmbientGitLabToken = (forgeHost: string) =>
       return fromEnv
     }
     const spawner = yield* ChildProcessSpawner.ChildProcessSpawner
-    const command = ChildProcess.make(
-      "glab",
-      ["config", "get", "token", "--host", forgeHost],
-      { stdin: "ignore" },
-    )
-    const output = yield* Effect.scoped(
-      Effect.gen(function* () {
-        const handle = yield* spawner.spawn(command)
-        const [exitCode, stdout, stderr] = yield* Effect.all(
-          [
-            handle.exitCode,
-            Stream.decodeText(handle.stdout).pipe(Stream.mkString),
-            Stream.decodeText(handle.stderr).pipe(Stream.mkString),
-          ],
-          { concurrency: 3 },
-        )
-        return {
-          exitCode: Number(exitCode),
-          stdout: stdout.trim(),
-          stderr: stderr.trim(),
-        }
-      }),
-    ).pipe(
-      Effect.timeout(GLAB_TOKEN_TIMEOUT),
-      Effect.catch((cause) =>
-        Effect.succeed({
-          exitCode: 1,
-          stdout: "",
-          stderr: errorMessage(cause),
-        }),
-      ),
-    )
-    if (output.exitCode !== 0 || output.stdout === "") {
-      return null
-    }
-    return output.stdout
+    return yield* resolveGlabHostToken({ forgeHost, spawner })
   })
 
 /**


### PR DESCRIPTION
## Why

Ambient GitLab credential detection used
`glab config get token --host <forge-host>`. That command can exit
successfully with a fallback token for hosts that were never authenticated
(for example `git.drupal.org` or an arbitrary hostname when only
`git.drupalcode.org` is logged in). The harness then reported credentials as
available and could activate Issue Polling for the wrong Forge Host, only to
fail later on real API calls.

## What changed

- Added shared `resolveGlabHostToken` / `parseGlabAuthStatusShowToken` in
  `@ready-for-agent/gitlab-service`.
- Resolve ambient glab tokens via a single host-scoped call:
  `glab auth status --hostname <forge-host> --show-token`
- Accept a token only when an unmasked `Token found` line is present for that
  host. Supports both shapes:
  - `Token found: <token>` (current glab)
  - `Token found in <source>: <token>` (glab main / keyring / config)
- Ignore non-zero exit when a local token is still printed (Forge API outage),
  so presence of a host token is not lost to a failed probe.
- Do **not** use `glab config get token --host` for ambient acceptance
  (avoids fallback-token false positives).
- Wire the helper into:
  - harness ambient GitLab layer (`hasCredentials` /
    `hasAmbientCredentials` / authenticated operations)
  - create-pr ambient HTTPS push token resolution
- Keep `GITLAB_TOKEN` as the highest-priority ambient credential
  (short-circuits glab).

## Verification

- Unit tests for parser shapes (legacy, source form, masked rejection,
  outage + token).
- Ambient layer tests: host isolation (`git.drupalcode.org` vs
  `git.drupal.org` / arbitrary host), unconfigured hosts, `GITLAB_TOKEN`
  precedence.
- Related keymaxxer GitLab layer and create-pr suites still pass; pre-commit
  typecheck/lint/test path green after mock `unref` typing fix.

## Limitations

- First uncached host resolve still runs glab’s live auth-status probe (can
  be slow if the Forge API is unreachable; ambient caches successful
  per-host tokens afterward).
- Spawn/timeout failures soft-fail as “no token” rather than a distinct
  diagnostic error.

Closes #638