### PR TITLE
fix(gitlab): resolve API host from SSH remote on repository import

### DIFF
--- a/apps/harness/src/server/keymaxxer-gitlab-layer.ts
+++ b/apps/harness/src/server/keymaxxer-gitlab-layer.ts
@@ -12,6 +12,7 @@ import {
   type GitLabServiceShape,
   formatGitLabHelperShellCommand,
   gitlabVaultAccount,
+  normalizeGitLabForgeHost,
   resolveGitLabHelperChildSpawn,
 } from "@ready-for-agent/gitlab-service"
 import { KeymaxxerService } from "@ready-for-agent/keymaxxer-service"
@@ -396,16 +397,51 @@ export const keymaxxerGitLabLayer = (options: {
                   repository,
                   tokenName,
                   "verify-project",
-                  (stdout) =>
-                    stdout.trim() === "" || stdout.trim() === "ok"
-                      ? Effect.void
-                      : Effect.fail(
+                  (stdout) => {
+                    const trimmed = stdout.trim()
+                    // Legacy helpers printed "ok"; treat that as "no host change".
+                    if (trimmed === "" || trimmed === "ok") {
+                      return Effect.succeed(repository)
+                    }
+                    try {
+                      const parsed = JSON.parse(trimmed) as {
+                        readonly forge?: string
+                        readonly forgeHost?: string
+                        readonly projectPath?: string
+                      }
+                      if (
+                        typeof parsed.forgeHost !== "string" ||
+                        parsed.forgeHost.trim() === "" ||
+                        typeof parsed.projectPath !== "string" ||
+                        parsed.projectPath.trim() === ""
+                      ) {
+                        return Effect.fail(
                           requestError(
                             repository,
                             "verify GitLab project",
                             stdout,
                           ),
+                        )
+                      }
+                      return Effect.succeed({
+                        forge:
+                          typeof parsed.forge === "string" &&
+                          parsed.forge.trim() !== ""
+                            ? parsed.forge
+                            : repository.forge,
+                        forgeHost: normalizeGitLabForgeHost(parsed.forgeHost),
+                        projectPath: parsed.projectPath.trim(),
+                      })
+                    } catch {
+                      return Effect.fail(
+                        requestError(
+                          repository,
+                          "verify GitLab project",
+                          stdout,
                         ),
+                      )
+                    }
+                  },
                   "verify GitLab project",
                 ),
               (ambientService) => ambientService.verifyProject(repository),

--- a/apps/harness/test/ambient-gitlab-layer.test.ts
+++ b/apps/harness/test/ambient-gitlab-layer.test.ts
@@ -23,7 +23,7 @@ const repository = {
 const service = (
   overrides: Partial<GitLabServiceShape> = {},
 ): GitLabServiceShape => ({
-  verifyProject: () => Effect.void,
+  verifyProject: (repository) => Effect.succeed(repository),
   getAuthenticatedUserLogin: () => Effect.succeed("operator"),
   listReadyIssues: () => Effect.succeed([]),
   hasCredentials: () => Effect.succeed(true),
@@ -150,9 +150,9 @@ test("public project verification falls back to anonymous access", async () => {
     },
     makeAnonymousService: () =>
       service({
-        verifyProject: () => {
+        verifyProject: (identity) => {
           anonymousVerifications += 1
-          return Effect.void
+          return Effect.succeed(identity)
         },
         hasCredentials: () => Effect.succeed(false),
         hasAmbientCredentials: () => Effect.succeed(false),

--- a/apps/harness/test/job-worker.test.ts
+++ b/apps/harness/test/job-worker.test.ts
@@ -150,7 +150,7 @@ const keymaxxerLayer = (
   })
 
 const defaultGitlabLayer = Layer.succeed(GitLabService, {
-  verifyProject: () => Effect.void,
+  verifyProject: (repository) => Effect.succeed(repository),
   getAuthenticatedUserLogin: () => Effect.succeed("test-operator"),
   listReadyIssues: () => Effect.succeed([]),
   hasCredentials: () => Effect.succeed(true),

--- a/apps/harness/test/keymaxxer-gitlab-layer.test.ts
+++ b/apps/harness/test/keymaxxer-gitlab-layer.test.ts
@@ -244,6 +244,107 @@ describe("Keymaxxer-backed GitLab layer", () => {
     expect(error).toBeInstanceOf(GitLabProjectUnavailableError)
   })
 
+  test("verifyProject decodes JSON host rewrite from the vault helper", async () => {
+    const sshGuess = {
+      forge: "gitlab",
+      forgeHost: "git.drupal.org",
+      projectPath: "project/oauth_client",
+    } as const
+    const keymaxxerLayer = Layer.succeed(KeymaxxerService, {
+      initialize: Effect.void,
+      findSecret: ({ account }) =>
+        Effect.succeed(
+          account === "git.drupal.org/project/oauth_client"
+            ? "GITLAB_TOKEN_SSH_GUESS"
+            : null,
+        ),
+      findSecrets: () => Effect.die("not used"),
+      hasSecret: () => Effect.die("not used"),
+      addSecret: () => Effect.die("not used"),
+      runWithSecrets: () =>
+        Effect.succeed({
+          exitCode: 0,
+          stdout: JSON.stringify({
+            forge: "gitlab",
+            forgeHost: "Git.DrupalCode.Org",
+            projectPath: "project/oauth_client",
+          }),
+          stderr: "",
+        }),
+    })
+    const layer = keymaxxerGitLabLayer({ workspaceRoot: "/workspace" }).pipe(
+      Layer.provide(keymaxxerLayer),
+      Layer.provide(platformLayer),
+    )
+
+    const resolved = await Effect.runPromise(
+      Effect.gen(function* () {
+        const gitlab = yield* GitLabService
+        return yield* gitlab.verifyProject(sshGuess)
+      }).pipe(Effect.provide(layer)),
+    )
+
+    expect(resolved).toEqual({
+      forge: "gitlab",
+      forgeHost: "git.drupalcode.org",
+      projectPath: "project/oauth_client",
+    })
+  })
+
+  test("verifyProject treats legacy ok helper stdout as no host change", async () => {
+    const keymaxxerLayer = Layer.succeed(KeymaxxerService, {
+      initialize: Effect.void,
+      findSecret: () => Effect.succeed("GITLAB_TOKEN_PROJECT_OAUTH_CLIENT"),
+      findSecrets: () => Effect.die("not used"),
+      hasSecret: () => Effect.die("not used"),
+      addSecret: () => Effect.die("not used"),
+      runWithSecrets: () =>
+        Effect.succeed({ exitCode: 0, stdout: "ok", stderr: "" }),
+    })
+    const layer = keymaxxerGitLabLayer({ workspaceRoot: "/workspace" }).pipe(
+      Layer.provide(keymaxxerLayer),
+      Layer.provide(platformLayer),
+    )
+
+    const resolved = await Effect.runPromise(
+      Effect.gen(function* () {
+        const gitlab = yield* GitLabService
+        return yield* gitlab.verifyProject(repository)
+      }).pipe(Effect.provide(layer)),
+    )
+
+    expect(resolved).toEqual(repository)
+  })
+
+  test("verifyProject maps invalid helper JSON to GitLabRequestError", async () => {
+    const keymaxxerLayer = Layer.succeed(KeymaxxerService, {
+      initialize: Effect.void,
+      findSecret: () => Effect.succeed("GITLAB_TOKEN_PROJECT_OAUTH_CLIENT"),
+      findSecrets: () => Effect.die("not used"),
+      hasSecret: () => Effect.die("not used"),
+      addSecret: () => Effect.die("not used"),
+      runWithSecrets: () =>
+        Effect.succeed({
+          exitCode: 0,
+          stdout: "not-json",
+          stderr: "",
+        }),
+    })
+    const layer = keymaxxerGitLabLayer({ workspaceRoot: "/workspace" }).pipe(
+      Layer.provide(keymaxxerLayer),
+      Layer.provide(platformLayer),
+    )
+
+    const error = await Effect.runPromise(
+      Effect.gen(function* () {
+        const gitlab = yield* GitLabService
+        return yield* Effect.flip(gitlab.verifyProject(repository))
+      }).pipe(Effect.provide(layer)),
+    )
+
+    expect(error).toBeInstanceOf(GitLabRequestError)
+  })
+
   test("maps helper non-zero exit to GitLabRequestError", async () => {
     const keymaxxerLayer = Layer.succeed(KeymaxxerService, {
       initialize: Effect.void,
@@ -341,7 +442,7 @@ describe("Keymaxxer-backed GitLab layer", () => {
       workspaceRoot: "/workspace",
       // Force ambient credential probes to be a pure no (no glab/network).
       makeService: () => ({
-        verifyProject: () => Effect.void,
+        verifyProject: (repository) => Effect.succeed(repository),
         getAuthenticatedUserLogin: () => Effect.succeed("operator"),
         listReadyIssues: () => Effect.succeed([]),
         hasCredentials: () =>
@@ -357,7 +458,7 @@ describe("Keymaxxer-backed GitLab layer", () => {
         ...gitlabLifecycleStub,
       }),
       makeAnonymousService: () => ({
-        verifyProject: () => Effect.void,
+        verifyProject: (repository) => Effect.succeed(repository),
         getAuthenticatedUserLogin: () => Effect.succeed("anonymous"),
         listReadyIssues: () => Effect.succeed([]),
         hasCredentials: () => Effect.succeed(false),
@@ -396,7 +497,7 @@ describe("Keymaxxer-backed GitLab layer", () => {
       environment: { GITLAB_TOKEN: "ambient-token" },
       vaultMetadataBudget: Duration.millis(40),
       makeService: () => ({
-        verifyProject: () => Effect.void,
+        verifyProject: (repository) => Effect.succeed(repository),
         getAuthenticatedUserLogin: () => Effect.succeed("operator"),
         listReadyIssues: () => {
           ambientListCalls += 1
@@ -439,7 +540,7 @@ describe("Keymaxxer-backed GitLab layer", () => {
       workspaceRoot: "/workspace",
       environment: { GITLAB_TOKEN: "ambient-token" },
       makeService: () => ({
-        verifyProject: () => Effect.void,
+        verifyProject: (repository) => Effect.succeed(repository),
         getAuthenticatedUserLogin: () => Effect.succeed("operator"),
         listReadyIssues: () => {
           ambientListCalls += 1

--- a/apps/harness/test/production-sse-idle-timeout.test.ts
+++ b/apps/harness/test/production-sse-idle-timeout.test.ts
@@ -103,7 +103,7 @@ const defaultGithub: GitHubServiceShape = {
 }
 
 const defaultGitlab: GitLabServiceShape = {
-  verifyProject: () => Effect.void,
+  verifyProject: (repository) => Effect.succeed(repository),
   getAuthenticatedUserLogin: () => Effect.succeed("test-operator"),
   listReadyIssues: () => Effect.succeed([]),
   hasCredentials: () => Effect.succeed(true),

--- a/packages/gitlab-service/src/bin/verify-project.ts
+++ b/packages/gitlab-service/src/bin/verify-project.ts
@@ -15,8 +15,8 @@ export const verifyProjectProgram = (args: ReadonlyArray<string>) =>
       yield* decodeArgument(args[2], "project path"),
     )
     const gitlab = yield* GitLabService
-    yield* gitlab.verifyProject(repository)
-    yield* writeStandardOutput("ok")
+    const resolved = yield* gitlab.verifyProject(repository)
+    yield* writeStandardOutput(JSON.stringify(resolved))
   })
 
 if (import.meta.main) runGitLabCli(verifyProjectProgram(process.argv.slice(2)))

--- a/packages/gitlab-service/src/index.ts
+++ b/packages/gitlab-service/src/index.ts
@@ -6,6 +6,7 @@ export {
   GitLabServiceLive,
   makeGitLabService,
   makeGitLabServiceFromToken,
+  normalizeGitLabForgeHost,
 } from "./lib/gitlab-service-live.js"
 export * from "./lib/gitlab-service-test.js"
 export * from "./lib/types.js"

--- a/packages/gitlab-service/src/lib/gitlab-service-live.ts
+++ b/packages/gitlab-service/src/lib/gitlab-service-live.ts
@@ -53,6 +53,59 @@ const RequiredString = Schema.String.pipe(
 const ProjectSchema = Schema.Struct({
   path_with_namespace: RequiredString,
   default_branch: Schema.optional(Schema.NullOr(Schema.String)),
+  /** Canonical web/API host lives here; SSH remotes may use a different host. */
+  web_url: Schema.optional(Schema.NullOr(Schema.String)),
+})
+
+/**
+ * Normalize a Forge Host string (hostname or hostname:port).
+ * Keeps non-default ports so self-hosted instances on :8443 stay reachable.
+ */
+export const normalizeGitLabForgeHost = (value: string): string => {
+  const trimmed = value.trim()
+  if (trimmed === "") return trimmed
+  const withPort = /^(.+):(\d+)$/.exec(trimmed)
+  if (withPort?.[1] !== undefined && withPort[2] !== undefined) {
+    const hostname = withPort[1].toLowerCase().replace(/^www\./, "")
+    return hostname.length > 0 ? `${hostname}:${withPort[2]}` : trimmed
+  }
+  return trimmed.toLowerCase().replace(/^www\./, "")
+}
+
+/**
+ * Prefer the host from project web_url over the clone/SSH remote host.
+ * Drupal's GitLab serves SSH as git.drupal.org and HTTPS/API as git.drupalcode.org.
+ * Uses hostname + non-default port (URL.host semantics) so custom-port instances
+ * are not rewritten to portless hosts.
+ */
+const forgeHostFromProjectWebUrl = (
+  webUrl: string | null | undefined,
+  fallbackHost: string,
+): string => {
+  if (webUrl === null || webUrl === undefined || webUrl.trim() === "") {
+    return normalizeGitLabForgeHost(fallbackHost)
+  }
+  try {
+    const url = new URL(webUrl)
+    const hostname = url.hostname.toLowerCase().replace(/^www\./, "")
+    if (hostname.length === 0) return normalizeGitLabForgeHost(fallbackHost)
+    // url.port is empty for default scheme ports; keep only explicit ports.
+    return url.port === "" ? hostname : `${hostname}:${url.port}`
+  } catch {
+    return normalizeGitLabForgeHost(fallbackHost)
+  }
+}
+
+const resolvedRepositoryIdentity = (
+  repository: GitLabRepository,
+  project: {
+    readonly path_with_namespace: string
+    readonly web_url?: string | null
+  },
+): GitLabRepository => ({
+  forge: repository.forge,
+  forgeHost: forgeHostFromProjectWebUrl(project.web_url, repository.forgeHost),
+  projectPath: project.path_with_namespace,
 })
 const UserSchema = Schema.Struct({
   username: RequiredString,
@@ -727,8 +780,10 @@ export const makeGitLabService = (options: {
           projectApiPath(repository),
           `Failed to verify GitLab project ${repository.projectPath} on ${repository.forgeHost}`,
         ).pipe(
-          Effect.map((value) => decode(ProjectSchema, value)),
-          Effect.asVoid,
+          Effect.map((value) => {
+            const project = decode(ProjectSchema, value)
+            return resolvedRepositoryIdentity(repository, project)
+          }),
           Effect.mapError((error) =>
             error instanceof GitLabRequestError
               ? error

--- a/packages/gitlab-service/src/lib/gitlab-service-test.ts
+++ b/packages/gitlab-service/src/lib/gitlab-service-test.ts
@@ -45,7 +45,8 @@ export const makeGitLabServiceTest = (
   }
 
   return Layer.succeed(GitLabService, {
-    verifyProject: (repository) => failOr(repository, () => Effect.void),
+    verifyProject: (repository) =>
+      failOr(repository, (fixture) => Effect.succeed(fixture.repository)),
     getAuthenticatedUserLogin: (repository) =>
       failOr(repository, (fixture) =>
         Effect.succeed(fixture.operatorLogin ?? "operator"),

--- a/packages/gitlab-service/src/lib/gitlab-service.ts
+++ b/packages/gitlab-service/src/lib/gitlab-service.ts
@@ -18,10 +18,14 @@ export type GitLabServiceError =
   | GitLabRequestError
 
 export interface GitLabServiceShape {
-  /** Verify Forge Host + Project Path against GitLab before persistence. */
+  /**
+   * Verify Forge Host + Project Path against GitLab before persistence.
+   * Returns the repository identity with the instance's canonical API/web host
+   * (from project `web_url`) when it differs from the SSH/remote guess.
+   */
   readonly verifyProject: (
     repository: GitLabRepository,
-  ) => Effect.Effect<void, GitLabServiceError>
+  ) => Effect.Effect<GitLabRepository, GitLabServiceError>
   /** Operator Forge User for the active ambient credential. */
   readonly getAuthenticatedUserLogin: (
     repository: GitLabRepository,

--- a/packages/gitlab-service/test/gitlab-service.spec.ts
+++ b/packages/gitlab-service/test/gitlab-service.spec.ts
@@ -181,12 +181,13 @@ describe("GitLab issue-source adapter", () => {
       fakeFetch({
         "/api/v4/projects/project%2Foauth_client": {
           path_with_namespace: "project/oauth_client",
+          web_url: "https://git.drupalcode.org/project/oauth_client",
         },
       }),
     )
     await expect(
       Effect.runPromise(present.verifyProject(repository)),
-    ).resolves.toBeUndefined()
+    ).resolves.toEqual(repository)
 
     const missing = makeGitLabServiceFromToken(
       "test-token",
@@ -202,6 +203,78 @@ describe("GitLab issue-source adapter", () => {
     expect(result).toEqual(
       Result.fail(new GitLabProjectUnavailableError(repository)),
     )
+  })
+
+  test("resolves the canonical API host when SSH remote host differs", async () => {
+    const service = makeGitLabServiceFromToken(
+      "test-token",
+      fakeFetch({
+        "/api/v4/projects/project%2Foauth_client": {
+          path_with_namespace: "project/oauth_client",
+          web_url: "https://git.drupalcode.org/project/oauth_client",
+        },
+      }),
+    )
+
+    const resolved = await Effect.runPromise(
+      service.verifyProject({
+        forge: "gitlab",
+        forgeHost: "git.drupal.org",
+        projectPath: "project/oauth_client",
+      }),
+    )
+
+    expect(resolved).toEqual({
+      forge: "gitlab",
+      forgeHost: "git.drupalcode.org",
+      projectPath: "project/oauth_client",
+    })
+  })
+
+  test("keeps the guessed Forge Host when project web_url is absent", async () => {
+    const service = makeGitLabServiceFromToken(
+      "test-token",
+      fakeFetch({
+        "/api/v4/projects/group%2Fnested%2Fproject": {
+          path_with_namespace: "group/nested/project",
+        },
+      }),
+    )
+
+    const guessed = {
+      forge: "gitlab",
+      forgeHost: "gitlab.example",
+      projectPath: "group/nested/project",
+    }
+    await expect(
+      Effect.runPromise(service.verifyProject(guessed)),
+    ).resolves.toEqual(guessed)
+  })
+
+  test("preserves a non-default port from project web_url", async () => {
+    const service = makeGitLabServiceFromToken(
+      "test-token",
+      fakeFetch({
+        "/api/v4/projects/group%2Fapp": {
+          path_with_namespace: "group/app",
+          web_url: "https://gitlab.example.com:8443/group/app",
+        },
+      }),
+    )
+
+    const resolved = await Effect.runPromise(
+      service.verifyProject({
+        forge: "gitlab",
+        forgeHost: "ssh.gitlab.example.com",
+        projectPath: "group/app",
+      }),
+    )
+
+    expect(resolved).toEqual({
+      forge: "gitlab",
+      forgeHost: "gitlab.example.com:8443",
+      projectPath: "group/app",
+    })
   })
 
   test("preserves authentication status on request failures", async () => {

--- a/packages/graphql-api/src/lib/graphql-api.ts
+++ b/packages/graphql-api/src/lib/graphql-api.ts
@@ -287,9 +287,14 @@ const verifyRepositoryIdentity = Effect.fn(
   readonly forgeHost: string
   readonly projectPath: string
 }) {
-  if (identity.forge !== "gitlab") return
+  if (identity.forge !== "gitlab") return identity
   const gitlab = yield* GitLabService
-  yield* gitlab.verifyProject(identity)
+  const resolved = yield* gitlab.verifyProject(identity)
+  return {
+    forge: identity.forge,
+    forgeHost: resolved.forgeHost,
+    projectPath: resolved.projectPath,
+  }
 })
 
 const toNativeResponse = (response: unknown): Response => {
@@ -981,24 +986,28 @@ export const createGraphqlApi = (
                   nextIdentity.forgeHost !== repository.forgeHost ||
                   nextIdentity.projectPath.toLowerCase() !==
                     repository.projectPath.toLowerCase()
-                if (identityChanging) {
-                  yield* verifyRepositoryIdentity(nextIdentity)
-                }
+                // Verify (and resolve canonical API host) before persisting
+                // identity changes so SSH remote hosts do not become Forge Host.
+                const resolvedIdentity = identityChanging
+                  ? yield* verifyRepositoryIdentity(nextIdentity)
+                  : nextIdentity
                 // Coordinate with Work Item creation when the effective backend
                 // may change so Implement Now cannot capture a pre-activate id.
                 const updated = yield* active.withConfigCoordination(
                   Effect.gen(function* () {
                     const updated = yield* db.updateRepositorySettings({
                       repositoryId: args.input.repositoryId,
-                      ...(args.input.forge === undefined
+                      ...(args.input.forge === undefined && !identityChanging
                         ? {}
-                        : { forge: args.input.forge }),
-                      ...(args.input.forgeHost === undefined
+                        : { forge: resolvedIdentity.forge }),
+                      ...(args.input.forgeHost === undefined &&
+                      !identityChanging
                         ? {}
-                        : { forgeHost: args.input.forgeHost }),
-                      ...(args.input.projectPath === undefined
+                        : { forgeHost: resolvedIdentity.forgeHost }),
+                      ...(args.input.projectPath === undefined &&
+                      !identityChanging
                         ? {}
-                        : { projectPath: args.input.projectPath }),
+                        : { projectPath: resolvedIdentity.projectPath }),
                       paused: args.input.paused,
                       ...(args.input.selectedAgentBackend !== undefined
                         ? {
@@ -1074,9 +1083,14 @@ export const createGraphqlApi = (
           addRepository: async (_parent: unknown, args: AddRepositoryArgs) =>
             runGraphql(
               Effect.gen(function* () {
-                yield* verifyRepositoryIdentity(args.input)
+                const resolved = yield* verifyRepositoryIdentity(args.input)
                 const db = yield* DbService
-                const added = yield* db.addRepository(args.input)
+                const added = yield* db.addRepository({
+                  ...args.input,
+                  forge: resolved.forge,
+                  forgeHost: resolved.forgeHost,
+                  projectPath: resolved.projectPath,
+                })
                 yield* activatePollingIfCredentialed(added, {
                   metadataTimeout: keymaxxerMetadataTimeout,
                 }).pipe(
@@ -1110,11 +1124,11 @@ export const createGraphqlApi = (
                 const localGit = yield* LocalGit
                 const db = yield* DbService
                 const inspected = yield* localGit.inspect(path)
-                yield* verifyRepositoryIdentity(inspected)
+                const resolved = yield* verifyRepositoryIdentity(inspected)
                 const added = yield* db.addRepository({
-                  forge: inspected.forge,
-                  forgeHost: inspected.forgeHost,
-                  projectPath: inspected.projectPath,
+                  forge: resolved.forge,
+                  forgeHost: resolved.forgeHost,
+                  projectPath: resolved.projectPath,
                   localPath: inspected.localPath,
                   isBare: inspected.isBare,
                 })

--- a/packages/graphql-api/test/graphql-api.test.ts
+++ b/packages/graphql-api/test/graphql-api.test.ts
@@ -197,7 +197,7 @@ const defaultGithub: GitHubServiceShape = {
 }
 
 const defaultGitlab: GitLabServiceShape = {
-  verifyProject: () => Effect.void,
+  verifyProject: (repository) => Effect.succeed(repository),
   getAuthenticatedUserLogin: () => Effect.succeed("test-operator"),
   listReadyIssues: () => Effect.succeed([]),
   hasCredentials: () => Effect.succeed(true),
@@ -488,9 +488,10 @@ describe("GraphQL API", () => {
       {},
       {},
       {
-        verifyProject: ({ forgeHost, projectPath }) =>
+        verifyProject: (identity) =>
           Effect.sync(() => {
-            actions.push(`verify:${forgeHost}/${projectPath}`)
+            actions.push(`verify:${identity.forgeHost}/${identity.projectPath}`)
+            return identity
           }),
         hasCredentials: () => Effect.succeed(false),
         hasAmbientCredentials: () => Effect.succeed(false),
@@ -525,6 +526,88 @@ describe("GraphQL API", () => {
       "verify:gitlab.com/acme/widgets",
       "add:gitlab.com/acme/widgets",
     ])
+  })
+
+  test("persists the canonical GitLab API host when verify resolves a different host", async () => {
+    let addedInput: {
+      forge: "github" | "gitlab"
+      forgeHost: string
+      projectPath: string
+      localPath: string
+      isBare: boolean
+    } | null = null
+    await runtime.dispose()
+    runtime = makeRuntime(
+      {
+        addRepository: (input) => {
+          addedInput = input
+          return Effect.succeed({
+            ...repository,
+            forge: input.forge,
+            forgeHost: input.forgeHost,
+            projectPath: input.projectPath,
+            localPath: input.localPath,
+            isBare: input.isBare,
+          })
+        },
+      },
+      {},
+      {},
+      {},
+      {},
+      {
+        inspect: (path) =>
+          Effect.succeed({
+            forge: "gitlab" as const,
+            forgeHost: "git.drupal.org",
+            projectPath: "project/oauth_client",
+            localPath: path,
+            isBare: false,
+            paused: true as const,
+          }),
+      },
+      {},
+      {
+        verifyProject: (identity) =>
+          Effect.succeed({
+            forge: identity.forge,
+            forgeHost: "git.drupalcode.org",
+            projectPath: identity.projectPath,
+          }),
+        hasCredentials: () => Effect.succeed(false),
+        hasAmbientCredentials: () => Effect.succeed(false),
+      },
+    )
+
+    const response = await createGraphqlApi(runtime).fetch(
+      graphqlRequest({
+        query: `mutation AddLocal($path: String!) {
+          addLocalRepository(path: $path) {
+            forge
+            forgeHost
+            projectPath
+          }
+        }`,
+        variables: { path: "/tmp/oauth_client" },
+      }),
+    )
+
+    expect(await response.json()).toEqual({
+      data: {
+        addLocalRepository: {
+          forge: "gitlab",
+          forgeHost: "git.drupalcode.org",
+          projectPath: "project/oauth_client",
+        },
+      },
+    })
+    expect(addedInput).toEqual({
+      forge: "gitlab",
+      forgeHost: "git.drupalcode.org",
+      projectPath: "project/oauth_client",
+      localPath: "/tmp/oauth_client",
+      isBare: false,
+    })
   })
 
   test("rejects an unknown GitLab project before saving", async () => {
@@ -1782,9 +1865,9 @@ describe("GraphQL API", () => {
       {},
       {},
       {
-        verifyProject: () => {
+        verifyProject: (identity) => {
           verifications += 1
-          return Effect.void
+          return Effect.succeed(identity)
         },
       },
     )
@@ -1821,6 +1904,97 @@ describe("GraphQL API", () => {
       },
     })
     expect(verifications).toBe(0)
+  })
+
+  test("persists canonical Forge Host when updateRepositorySettings re-verifies identity", async () => {
+    const gitlabRepository = makeRepositoryRecord({
+      id: repository.id,
+      forge: "gitlab",
+      forgeHost: "git.drupal.org",
+      projectPath: "project/oauth_client",
+    })
+    let settingsInput: {
+      forgeHost?: string
+      projectPath?: string
+    } | null = null
+    await runtime.dispose()
+    runtime = makeRuntime(
+      {
+        listRepositories: Effect.succeed([gitlabRepository]),
+        updateRepositorySettings: (input) => {
+          settingsInput = {
+            forgeHost: input.forgeHost,
+            projectPath: input.projectPath,
+          }
+          return Effect.succeed({
+            ...gitlabRepository,
+            forge: input.forge ?? gitlabRepository.forge,
+            forgeHost: input.forgeHost ?? gitlabRepository.forgeHost,
+            projectPath: input.projectPath ?? gitlabRepository.projectPath,
+          })
+        },
+      },
+      {},
+      {
+        // Identity correction suspends then re-activates Issue Polling.
+        removeKeyed: () => Effect.succeed(0),
+        ensureKeyed: () => Effect.succeed(makeJobId()),
+      },
+      {},
+      {},
+      {},
+      {},
+      {
+        verifyProject: (identity) =>
+          Effect.succeed({
+            forge: identity.forge,
+            forgeHost: "git.drupalcode.org",
+            projectPath: identity.projectPath,
+          }),
+        hasCredentials: () => Effect.succeed(false),
+        hasAmbientCredentials: () => Effect.succeed(false),
+      },
+    )
+
+    const response = await createGraphqlApi(runtime).fetch(
+      graphqlRequest({
+        query: `mutation UpdateRepositorySettings($input: UpdateRepositorySettingsInput!) {
+          updateRepositorySettings(input: $input) {
+            forgeHost
+            projectPath
+          }
+        }`,
+        variables: {
+          input: {
+            repositoryId: gitlabRepository.id,
+            forge: "gitlab",
+            forgeHost: "git.drupal.org",
+            projectPath: "project/other_client",
+            paused: true,
+            defaultModel: null,
+            defaultThinkingLevel: null,
+            reviewModel: null,
+            reviewThinkingLevel: null,
+            autoMerge: false,
+            includeAllIssueAuthors: false,
+            waitForReadyForReviewChecks: true,
+          },
+        },
+      }),
+    )
+
+    expect(await response.json()).toEqual({
+      data: {
+        updateRepositorySettings: {
+          forgeHost: "git.drupalcode.org",
+          projectPath: "project/other_client",
+        },
+      },
+    })
+    expect(settingsInput).toEqual({
+      forgeHost: "git.drupalcode.org",
+      projectPath: "project/other_client",
+    })
   })
 
   test("exposes scoped gate counts on Config and Repository", async () => {

--- a/packages/issue-reconciler/test/issue-reconciler.spec.ts
+++ b/packages/issue-reconciler/test/issue-reconciler.spec.ts
@@ -206,7 +206,7 @@ const makeGitHubLayer = (
   } satisfies GitHubServiceShape)
 
 const defaultGitLabShape = {
-  verifyProject: () => Effect.void,
+  verifyProject: (repository) => Effect.succeed(repository),
   getAuthenticatedUserLogin: () => Effect.succeed("operator"),
   listReadyIssues: () => Effect.succeed([]),
   hasCredentials: () => Effect.succeed(true),

--- a/packages/local-git/src/lib/parse-forge-remote.ts
+++ b/packages/local-git/src/lib/parse-forge-remote.ts
@@ -25,7 +25,13 @@ const parseUrlRemote = (
     if (!["http:", "https:", "ssh:", "git:"].includes(url.protocol)) {
       return undefined
     }
-    return { host: url.hostname, path: url.pathname }
+    // HTTP(S) non-default ports belong in the Forge Host guess so verify can
+    // reach self-hosted GitLab on e.g. :8443. SSH/git ports are transport-only
+    // and must not be treated as the API host port.
+    const includePort =
+      (url.protocol === "http:" || url.protocol === "https:") && url.port !== ""
+    const host = includePort ? `${url.hostname}:${url.port}` : url.hostname
+    return { host, path: url.pathname }
   } catch {
     return undefined
   }
@@ -34,7 +40,9 @@ const parseUrlRemote = (
 /**
  * Guess Forge identity from a clone remote. GitHub spellings retain the
  * canonical github.com identity; every other network git host is a GitLab
- * guess that must be verified (and may be corrected) before persistence.
+ * guess. The SSH/remote host is not authoritative for GitLab Forge Host —
+ * import verifies against the Forge API and persists the instance's
+ * canonical API/web host (e.g. git.drupal.org SSH → git.drupalcode.org).
  */
 export const parseForgeRemote = (
   remoteUrl: string,

--- a/packages/local-git/test/parse-forge-remote.test.ts
+++ b/packages/local-git/test/parse-forge-remote.test.ts
@@ -57,6 +57,27 @@ describe("parseForgeRemote", () => {
     })
   })
 
+  test("keeps non-default HTTPS ports in the Forge Host guess", () => {
+    expectRemote("https://gitlab.example.com:8443/group/app.git", {
+      forge: "gitlab",
+      forgeHost: "gitlab.example.com:8443",
+      projectPath: "group/app",
+    })
+    expectRemote("http://gitlab.internal:8080/group/app", {
+      forge: "gitlab",
+      forgeHost: "gitlab.internal:8080",
+      projectPath: "group/app",
+    })
+  })
+
+  test("does not treat SSH URL ports as the API Forge Host port", () => {
+    expectRemote("ssh://git@gitlab.example.com:2222/group/app.git", {
+      forge: "gitlab",
+      forgeHost: "gitlab.example.com",
+      projectPath: "group/app",
+    })
+  })
+
   test("rejects local and malformed remotes", () => {
     expect(Option.isNone(parseForgeRemote("../owner/repo.git"))).toBe(true)
     expect(Option.isNone(parseForgeRemote("not-a-url"))).toBe(true)

--- a/packages/work-item-lifecycle/src/lib/gitlab-service-test.ts
+++ b/packages/work-item-lifecycle/src/lib/gitlab-service-test.ts
@@ -18,7 +18,7 @@ export const stubGitLabServiceLayer = (
   Layer.succeed(
     GitLabService,
     GitLabService.of({
-      verifyProject: () => Effect.void,
+      verifyProject: (repository) => Effect.succeed(repository),
       getAuthenticatedUserLogin: () => Effect.succeed("test-operator"),
       listReadyIssues: () => Effect.succeed([]),
       hasCredentials: () => Effect.succeed(true),

--- a/packages/work-item-lifecycle/test/close-issue.spec.ts
+++ b/packages/work-item-lifecycle/test/close-issue.spec.ts
@@ -145,7 +145,7 @@ describe("closeIssue", () => {
       },
     } satisfies GitHubServiceShape)
     const gitlab = Layer.succeed(GitLabService, {
-      verifyProject: () => Effect.void,
+      verifyProject: (repository) => Effect.succeed(repository),
       getAuthenticatedUserLogin: () => Effect.succeed("operator"),
       listReadyIssues: () => Effect.succeed([]),
       hasCredentials: () => Effect.succeed(true),

--- a/packages/work-item-lifecycle/test/create-pr.spec.ts
+++ b/packages/work-item-lifecycle/test/create-pr.spec.ts
@@ -134,7 +134,7 @@ const stubGitLab = (
   overrides: Partial<GitLabServiceShape> = {},
 ): Layer.Layer<GitLabService> =>
   Layer.succeed(GitLabService, {
-    verifyProject: () => Effect.void,
+    verifyProject: (repository) => Effect.succeed(repository),
     getAuthenticatedUserLogin: () => Effect.succeed("test-operator"),
     listReadyIssues: () => Effect.succeed([]),
     hasCredentials: () => Effect.succeed(true),

--- a/packages/work-item-lifecycle/test/pr-status-checks.spec.ts
+++ b/packages/work-item-lifecycle/test/pr-status-checks.spec.ts
@@ -190,7 +190,7 @@ const gitlabWith = (
   overrides: Partial<GitLabServiceShape> = {},
 ) =>
   Layer.succeed(GitLabService, {
-    verifyProject: () => Effect.void,
+    verifyProject: (repository) => Effect.succeed(repository),
     getAuthenticatedUserLogin: () => Effect.succeed("test-operator"),
     listReadyIssues: () => Effect.succeed([]),
     hasCredentials: () => Effect.succeed(true),

--- a/packages/work-item-lifecycle/test/remove-worktree.spec.ts
+++ b/packages/work-item-lifecycle/test/remove-worktree.spec.ts
@@ -47,7 +47,7 @@ const stubGitLab = (
   overrides: Partial<GitLabServiceShape> = {},
 ): Layer.Layer<GitLabService> =>
   Layer.succeed(GitLabService, {
-    verifyProject: () => Effect.void,
+    verifyProject: (repository) => Effect.succeed(repository),
     getAuthenticatedUserLogin: () => Effect.succeed("operator"),
     listReadyIssues: () => Effect.succeed([]),
     hasCredentials: () => Effect.succeed(true),


### PR DESCRIPTION
## Why

GitLab instances can serve SSH and the web/API on different hostnames.
Drupal clones use `git@git.drupal.org:...` while the API and web UI live at
`git.drupalcode.org`. Import was persisting the SSH remote host as Forge Host,
so auth guidance (`glab auth login --hostname ...`), PAT links, vault accounts,
and API calls pointed at the wrong place.

## What changed

- `GitLabService.verifyProject` now returns a resolved repository identity,
  preferring the host (and non-default port) from project `web_url` over the
  clone remote guess.
- GraphQL `addRepository`, `addLocalRepository`, and identity-changing
  `updateRepositorySettings` persist that resolved Forge Host and Project Path;
  the local git remote is left unchanged.
- Vault helper `verify-project` emits JSON identity (legacy `ok` still accepted);
  Keymaxxer decodes and normalizes the host the same way as live resolution.
- HTTPS remote guesses keep non-default ports (e.g. `:8443`) so self-hosted API
  endpoints are reachable; SSH URL ports are not treated as API ports.
- Shared `normalizeGitLabForgeHost` for casing/`www.` stripping on success and
  fallback paths.

## Verification

- Unit coverage for SSH host → API host rewrite, missing `web_url` fallback,
  custom-port `web_url`, HTTPS port guessing, and Keymaxxer JSON / legacy `ok`
  / invalid payload.
- GraphQL tests for import persistence of the canonical host and settings
  re-verify rewrite.
- Affected package tests: `gitlab-service`, `local-git`, `graphql-api`, harness
  Keymaxxer GitLab layer.

## Limitations

Already-persisted wrong SSH hosts are not auto-healed on a settings save that
does not change identity fields; operators can set the API host (or change an
identity field) to re-verify. Generic SSH aliases remain correctable guesses
when the API host cannot be determined.

Closes #639