### PR TITLE
fix(harness): label terminal Kanban lane as Merged

### DIFF
--- a/apps/harness/e2e/steps/kanban-route.ts
+++ b/apps/harness/e2e/steps/kanban-route.ts
@@ -7,7 +7,7 @@ const PIPELINE_LANE_HEADERS = [
   "Review",
   "PR",
   "Attention",
-  "Complete",
+  "Merged",
 ] as const
 
 const COMMITTED_PULL_REQUEST_PERIODS = [

--- a/apps/harness/src/pipeline-lanes.ts
+++ b/apps/harness/src/pipeline-lanes.ts
@@ -12,7 +12,7 @@ export const PIPELINE_LANES = [
   { id: "review", label: "Review", color: "#7654b5", text: "#ffffff" },
   { id: "pr", label: "PR", color: "#168b62", text: "#ffffff" },
   { id: "attention", label: "Attention", color: "#ff4d1c", text: "#151515" },
-  { id: "complete", label: "Complete", color: "#151515", text: "#ffffff" },
+  { id: "complete", label: "Merged", color: "#151515", text: "#ffffff" },
 ] as const satisfies readonly {
   id: PipelineLaneId
   label: string
@@ -27,7 +27,7 @@ type PipelineWorkItem = {
 
 /**
  * Kanban placement is driven by lifecycle progress, not scheduler status.
- * Attention and Complete override every lane. Queue is only for work that
+ * Attention and Merged override every lane. Queue is only for work that
  * cannot begin yet (blockers or worker slot). Queued step execution stays in
  * its lifecycle lane (Build / Review / PR).
  */

--- a/apps/harness/src/routes/kanban.tsx
+++ b/apps/harness/src/routes/kanban.tsx
@@ -48,15 +48,6 @@ const JOBS_TABS = [
   { id: "completed", label: JOBS_COMPLETED_TAB_LABEL },
 ] as const satisfies readonly { id: JobsTab; label: string }[]
 
-const PIPELINE_LANE_LABELS = {
-  queue: "Queue",
-  build: "Build",
-  review: "Review",
-  pr: "PR",
-  attention: "Attention",
-  complete: "Complete",
-} as const satisfies Record<PipelineLaneId, string>
-
 const jobsTabEmptyMessage = (tab: Exclude<JobsTab, "pipeline">): string => {
   if (tab === "working") return "No working jobs."
   if (tab === "failed") return "No failed jobs."
@@ -137,16 +128,16 @@ function KanbanPage() {
 }
 
 /**
- * Complete-lane tickets omit per-step lifecycle chrome. Show only start time
+ * Merged-lane tickets omit per-step lifecycle chrome. Show only start time
  * and total elapsed duration, plus a PR link when one exists.
  *
  * Gated by assigned lane (`laneId === "complete"`), not by which Jobs tab
- * hosts the ticket — so Pipeline Complete-lane cards and Kanban Completed-tab
+ * hosts the ticket — so Pipeline Merged-lane cards and Kanban Completed-tab
  * rows that classify as complete share this compact view. Homepage Jobs
  * Completed is unaffected (it never uses PipelineTicket).
  *
  * No-change completion-summary chrome is intentionally omitted: issue #630
- * limits Complete-lane status to start + total duration (and PR identity).
+ * limits Merged-lane status to start + total duration (and PR identity).
  */
 function PipelineCompleteSummary({
   workItem,
@@ -358,7 +349,7 @@ function KanbanJobsBoard() {
     completedQueries.flatMap((query) => query.data ?? []),
   )
   // Preserve per-list recency: Working/Failed by createdAt, Completed by
-  // stateReadyAt. Do not re-sort the merge by createdAt or Complete-lane order
+  // stateReadyAt. Do not re-sort the merge by createdAt or Merged-lane order
   // drifts from the Completed tab.
   const pipelineItems = Array.from(
     new Map(
@@ -499,8 +490,7 @@ function KanbanJobsBoard() {
                   key={lane.id}
                   onClick={() => setMobileLane(lane.id)}
                 >
-                  {PIPELINE_LANE_LABELS[lane.id]}{" "}
-                  {laneItems.get(lane.id)?.length ?? 0}
+                  {lane.label} {laneItems.get(lane.id)?.length ?? 0}
                 </button>
               ))}
             </fieldset>
@@ -529,7 +519,7 @@ function KanbanJobsBoard() {
                           0{laneIndex + 1} / 06
                         </span>
                         <h3 className="lane-title" id={`lane-${lane.id}`}>
-                          {PIPELINE_LANE_LABELS[lane.id]}
+                          {lane.label}
                         </h3>
                       </div>
                       <span className="lane-count">

--- a/apps/harness/test/jobs-reset-visibility.test.ts
+++ b/apps/harness/test/jobs-reset-visibility.test.ts
@@ -125,7 +125,7 @@ describe("Jobs Reset button wiring", () => {
     )
     expect(jobsCard).toContain("<WorkItemLifecycleStatus")
     expect(jobsCard).toContain("compact")
-    // Homepage isolation: Kanban Complete-lane summary must not leak here.
+    // Homepage isolation: Kanban Merged-lane summary must not leak here.
     expect(jobsCard).not.toContain("PipelineCompleteSummary")
     expect(jobsCard).not.toContain("totalElapsedMs")
   })

--- a/apps/harness/test/kanban-route.test.ts
+++ b/apps/harness/test/kanban-route.test.ts
@@ -19,19 +19,10 @@ describe("/kanban route", () => {
 
   test("renders all six lifecycle lanes as an accessible pipeline", () => {
     const source = kanbanSource()
-    for (const label of [
-      "Queue",
-      "Build",
-      "Review",
-      "PR",
-      "Attention",
-      "Complete",
-    ]) {
-      expect(source).toContain(`"${label}"`)
-    }
     expect(source).toContain('aria-label="Lifecycle pipeline"')
     expect(source).toContain("pipelineLaneFor(workItem)")
     expect(source).toContain("Lane clear")
+    expect(source.match(/\{lane\.label\}/g)).toHaveLength(2)
   })
 
   test("retains accessible tabs, keyboard navigation, and repository filtering", () => {
@@ -76,7 +67,7 @@ describe("/kanban route", () => {
     )
     expect(ticket).toContain("onOpenSession(workItem.id, sessionId)")
     expect(ticket).toContain("showValue={false}")
-    // Complete lane only swaps lifecycle chrome; session/copy remain shared
+    // Merged lane only swaps lifecycle chrome; session/copy remain shared
     // above that branch for every ticket.
     expect(ticket).toContain('laneId === "complete"')
     const sessionIndex = ticket.indexOf("onOpenSession(workItem.id, sessionId)")
@@ -85,7 +76,7 @@ describe("/kanban route", () => {
     expect(completeSummaryIndex).toBeGreaterThan(sessionIndex)
   })
 
-  test("Complete-lane tickets show start time and total duration without lifecycle steps", () => {
+  test("Merged-lane tickets show start time and total duration without lifecycle steps", () => {
     const source = kanbanSource()
     expect(source).toContain("function PipelineCompleteSummary(")
     const summary = source.slice(
@@ -101,7 +92,7 @@ describe("/kanban route", () => {
     expect(summary).not.toContain("lifecycleLabels")
     expect(summary).not.toContain("WorkItemLifecycleStatus")
     expect(summary).not.toContain("Lifecycle steps")
-    // Intentional: no-change completionSummary chrome is out of Complete-lane scope.
+    // Intentional: no-change completionSummary chrome is out of Merged-lane scope.
     expect(summary).not.toContain("completionSummary")
     expect(summary).not.toContain("WorkItemOutcomePresentation")
 
@@ -111,14 +102,14 @@ describe("/kanban route", () => {
     )
     expect(ticket).toContain('laneId === "complete"')
     expect(ticket).toContain("<PipelineCompleteSummary")
-    // Non-complete lanes keep the full compact lifecycle status.
+    // Non-Merged lanes keep the full compact lifecycle status.
     expect(ticket).toContain("<WorkItemLifecycleStatus")
     const completeBranch = ticket.slice(ticket.indexOf("isCompleteLane ? ("))
     expect(completeBranch).toContain("<PipelineCompleteSummary")
     expect(completeBranch).toContain("<WorkItemLifecycleStatus")
   })
 
-  test("Kanban list tabs share Complete-lane compact summary via pipelineLaneFor", () => {
+  test("Kanban list tabs share Merged-lane compact summary via pipelineLaneFor", () => {
     // Gate is lane identity, not Pipeline vs Completed tab. Completed-tab rows
     // that classify as complete intentionally reuse PipelineCompleteSummary;
     // homepage Jobs Completed isolation is separate (index.tsx JobsCard).

--- a/apps/harness/test/pipeline-lanes.test.ts
+++ b/apps/harness/test/pipeline-lanes.test.ts
@@ -21,7 +21,7 @@ describe("PIPELINE_LANES", () => {
       { id: "review", label: "Review", color: "#7654b5" },
       { id: "pr", label: "PR", color: "#168b62" },
       { id: "attention", label: "Attention", color: "#ff4d1c" },
-      { id: "complete", label: "Complete", color: "#151515" },
+      { id: "complete", label: "Merged", color: "#151515" },
     ])
   })
 })
@@ -52,7 +52,7 @@ describe("pipelineLaneFor", () => {
     { state: "COMPLETE", status: "RUNNING", lane: "complete" },
     { state: "ABANDONED", status: "RUNNING", lane: "complete" },
   ] satisfies readonly LaneCase[])(
-    "places $state with $status in Complete",
+    "places $state with $status in Merged",
     ({ state, status, lane }) => {
       expect(pipelineLaneFor({ state, status })).toBe(lane)
     },

--- a/docs/kanban.md
+++ b/docs/kanban.md
@@ -4,7 +4,7 @@
 
 The Kanban Pipeline is an alternate Harness work view for an operator who
 needs to understand flow at a glance: what is waiting, being built, under
-review, in the PR path, blocked, or complete.
+review, in the PR path, blocked, or merged.
 
 It was prototyped in the `redesign/kanban-pipeline` branch. The prototype
 demonstrates the interaction model and visual direction; it is not currently
@@ -34,12 +34,12 @@ The board has six ordered lanes:
 | Review | Local review is in progress (including a queued Review step). | `REVIEW` |
 | PR | Commit through cleanup on the pull-request path (including queued Watch and later PR steps). | `COMMIT`, `CREATE_PR`, `WATCH_PR_STATUS_CHECKS`, `RESOLVE_PR_MERGE_CONFLICT`, `INVESTIGATE_PR_STATUS_CHECKS`, `MARK_PR_READY_FOR_REVIEW`, `DECIDE_PR_MERGE`, `MERGE_PR`, `CLOSE_ISSUE`, `LOCAL_CLEANUP` |
 | Attention | An operator or remediation decision is needed. | Failed, interrupted, needs-human statuses or states |
-| Complete | The Work Item has reached a terminal successful or abandoned state. | Complete, succeeded, or abandoned statuses or states |
+| Merged | The Work Item has reached a terminal successful or abandoned state. | Complete, succeeded, or abandoned statuses or states |
 
 Lane assignment is a pure function of the current Work Item state and status.
 Placement is driven by **lifecycle progress**, not scheduler status:
 
-- Attention and Complete take precedence over every lifecycle lane.
+- Attention and Merged take precedence over every lifecycle lane.
 - Queue is only for genuine blocked or not-admitted work. A `QUEUED` step run
   (status-check poll, agent turn, or later lifecycle step) stays in Build,
   Review, or PR according to its state.
@@ -56,7 +56,7 @@ The prototype uses an industrial control-board language:
 
 - Dense, six-column board with high-contrast lane headers.
 - Fixed lane colors make the flow memorable: Queue yellow, Build blue, Review
-  violet, PR green, Attention orange, and Complete black.
+  violet, PR green, Attention orange, and Merged black.
 - Tickets use a narrow colored edge to retain their lane association while
   keeping title, repository, status, controls, session, and worktree visible.
 - Empty lanes explicitly say `Lane clear`; an empty lane is operational


### PR DESCRIPTION
## Why

The Kanban terminal lane represented merged work but was displayed as “Complete,” which could be
confused with broader lifecycle and job-completion terminology.

## What changed

- Renamed the terminal Kanban lane’s visible desktop and mobile label to “Merged.”
- Consolidated both views on the canonical pipeline lane label to prevent future drift.
- Updated focused tests, E2E steps, comments, and Kanban documentation.
- Preserved the internal `complete` lane ID, terminal classification behavior, and the Jobs
  “Completed” terminology.

## Verification

- `bunx nx affected -t lint,typecheck,test`
- 444 tests passed across the affected projects.
- `git diff --check`

Closes #654