### PR TITLE
fix(db): enforce Needs Human as unfinished

### DIFF
--- a/packages/db-schema/drizzle/20260730140857_unfinished_work_item_index/migration.sql
+++ b/packages/db-schema/drizzle/20260730140857_unfinished_work_item_index/migration.sql
@@ -1,0 +1,7 @@
+-- Install the stricter protection first. If unexpected legacy conflicts exist,
+-- index creation fails without removing the database's existing protection.
+CREATE UNIQUE INDEX `work_item_one_unfinished_v4_uidx` ON `work_item` (`repository_id`,`issue_number`) WHERE "work_item"."state" NOT IN ('complete', 'failed', 'abandoned');--> statement-breakpoint
+DROP INDEX IF EXISTS `work_item_one_unfinished_v2_uidx`;--> statement-breakpoint
+DROP INDEX IF EXISTS `work_item_one_unfinished_uidx`;--> statement-breakpoint
+DROP TRIGGER IF EXISTS `work_item_one_unfinished_v3_insert`;--> statement-breakpoint
+DROP TRIGGER IF EXISTS `work_item_one_unfinished_v3_update`;

--- a/packages/db-schema/src/schema.ts
+++ b/packages/db-schema/src/schema.ts
@@ -357,11 +357,9 @@ export const workItem = snakeCase.table(
       .$defaultFn(() => Date.now()),
   },
   (t) => [
-    uniqueIndex("work_item_one_unfinished_v2_uidx")
+    uniqueIndex("work_item_one_unfinished_v4_uidx")
       .on(t.repositoryId, t.issueNumber)
-      .where(
-        sql`${t.state} NOT IN ('complete', 'failed', 'abandoned', 'needs_human')`,
-      ),
+      .where(sql`${t.state} NOT IN ('complete', 'failed', 'abandoned')`),
     index("work_item_repository_issue_created_idx").on(
       t.repositoryId,
       t.issueNumber,

--- a/packages/db/test/run-migrations.spec.ts
+++ b/packages/db/test/run-migrations.spec.ts
@@ -101,6 +101,7 @@ describe("runMigrations", () => {
           { name: "20260728120000_work_item_merge_mode" },
           { name: "20260729120000_work_item_publication_copy" },
           { name: "20260729160000_forge_identity_foundation" },
+          { name: "20260730140857_unfinished_work_item_index" },
         ])
       }).pipe(Effect.provide(SqliteTest)),
     )
@@ -311,6 +312,243 @@ describe("runMigrations", () => {
         expect(rows).toEqual([
           { id: "new-attempt", state: "abandoned" },
           { id: "old-handoff", state: "local_cleanup" },
+        ])
+      }).pipe(Effect.provide(SqliteTest)),
+    )
+  })
+
+  it("replaces the unfinished Work Item guards on a populated database without losing history", async () => {
+    const migrationSql = await readFile(
+      join(
+        import.meta.dir,
+        "../../db-schema/drizzle/20260730140857_unfinished_work_item_index/migration.sql",
+      ),
+      "utf8",
+    )
+    const folder = await migrationFolder(
+      "20260730140857_unfinished_work_item_index",
+      migrationSql,
+    )
+    const states = [
+      "create_worktree",
+      "install_dependencies",
+      "implement",
+      "assess_changes",
+      "pre_commit",
+      "review",
+      "commit",
+      "create_pr",
+      "watch_pr_status_checks",
+      "resolve_pr_merge_conflict",
+      "investigate_pr_status_checks",
+      "mark_pr_ready_for_review",
+      "decide_pr_merge",
+      "merge_pr",
+      "close_issue",
+      "local_cleanup",
+      "complete",
+      "failed",
+      "abandoned",
+      "needs_human",
+    ] as const
+
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        const sql = yield* SqlClient.SqlClient
+        yield* sql.unsafe(`
+          CREATE TABLE work_item (
+            id text PRIMARY KEY,
+            repository_id text NOT NULL,
+            issue_number integer NOT NULL,
+            state text NOT NULL
+          )
+        `)
+        yield* sql.unsafe(`
+          CREATE TABLE step_run (
+            id text PRIMARY KEY,
+            work_item_id text NOT NULL,
+            step text NOT NULL
+          )
+        `)
+        yield* sql.unsafe(`
+          CREATE UNIQUE INDEX work_item_one_unfinished_v2_uidx
+          ON work_item (repository_id, issue_number)
+          WHERE state NOT IN ('complete', 'failed', 'abandoned', 'needs_human')
+        `)
+        yield* sql.unsafe(`
+          CREATE TRIGGER work_item_one_unfinished_v3_insert
+          BEFORE INSERT ON work_item
+          WHEN NEW.state NOT IN ('complete', 'failed', 'abandoned')
+            AND EXISTS (
+              SELECT 1 FROM work_item
+              WHERE repository_id = NEW.repository_id
+                AND issue_number = NEW.issue_number
+                AND state NOT IN ('complete', 'failed', 'abandoned')
+            )
+          BEGIN
+            SELECT RAISE(ABORT, 'work_item_one_unfinished_v3_uidx');
+          END
+        `)
+        yield* sql.unsafe(`
+          CREATE TRIGGER work_item_one_unfinished_v3_update
+          BEFORE UPDATE OF repository_id, issue_number, state ON work_item
+          WHEN NEW.state NOT IN ('complete', 'failed', 'abandoned')
+            AND EXISTS (
+              SELECT 1 FROM work_item
+              WHERE id <> NEW.id
+                AND repository_id = NEW.repository_id
+                AND issue_number = NEW.issue_number
+                AND state NOT IN ('complete', 'failed', 'abandoned')
+            )
+          BEGIN
+            SELECT RAISE(ABORT, 'work_item_one_unfinished_v3_uidx');
+          END
+        `)
+
+        for (const [index, state] of states.entries()) {
+          const issueNumber =
+            state === "complete" ||
+            state === "failed" ||
+            state === "abandoned" ||
+            state === "needs_human"
+              ? 900
+              : index + 1
+          yield* sql.unsafe(
+            `INSERT INTO work_item (id, repository_id, issue_number, state)
+             VALUES (?, 'repo-1', ?, ?)`,
+            [`wi-${state}`, issueNumber, state],
+          )
+          yield* sql.unsafe(
+            `INSERT INTO step_run (id, work_item_id, step) VALUES (?, ?, ?)`,
+            [`srun-${state}`, `wi-${state}`, state],
+          )
+        }
+
+        const workItemsBefore = yield* sql.unsafe(
+          `SELECT id, repository_id, issue_number, state
+           FROM work_item
+           ORDER BY id`,
+        )
+        const stepRunsBefore = yield* sql.unsafe(
+          `SELECT id, work_item_id, step FROM step_run ORDER BY id`,
+        )
+
+        const migration = yield* Effect.exit(runMigrations(folder))
+        expect(migration._tag).toBe("Success")
+
+        const workItemsAfter = yield* sql.unsafe(
+          `SELECT id, repository_id, issue_number, state
+           FROM work_item
+           ORDER BY id`,
+        )
+        const stepRunsAfter = yield* sql.unsafe(
+          `SELECT id, work_item_id, step FROM step_run ORDER BY id`,
+        )
+        expect(workItemsAfter).toEqual(workItemsBefore)
+        expect(stepRunsAfter).toEqual(stepRunsBefore)
+
+        const indexes = (yield* sql.unsafe(`
+          SELECT name, sql
+          FROM sqlite_master
+          WHERE type = 'index'
+            AND name LIKE 'work_item_one_unfinished%'
+        `)) as readonly {
+          readonly name: string
+          readonly sql: string
+        }[]
+        expect(indexes).toHaveLength(1)
+        expect(indexes[0]?.name).toBe("work_item_one_unfinished_v4_uidx")
+        expect(indexes[0]?.sql).toContain(
+          "NOT IN ('complete', 'failed', 'abandoned')",
+        )
+        expect(indexes[0]?.sql).not.toContain("needs_human")
+
+        const triggers = yield* sql.unsafe(`
+          SELECT name
+          FROM sqlite_master
+          WHERE type = 'trigger'
+            AND name LIKE 'work_item_one_unfinished_v3_%'
+        `)
+        expect(triggers).toEqual([])
+
+        const needsHumanConflict = yield* Effect.exit(
+          sql.unsafe(
+            `INSERT INTO work_item (id, repository_id, issue_number, state)
+             VALUES ('wi-conflict', 'repo-1', 900, 'implement')`,
+          ),
+        )
+        expect(needsHumanConflict._tag).toBe("Failure")
+
+        yield* sql.unsafe(
+          `INSERT INTO work_item (id, repository_id, issue_number, state)
+           VALUES ('wi-later-history', 'repo-1', 900, 'complete')`,
+        )
+        const preservedHistory = yield* sql.unsafe(
+          `SELECT id FROM work_item WHERE issue_number = 900 ORDER BY id`,
+        )
+        expect(preservedHistory).toEqual([
+          { id: "wi-abandoned" },
+          { id: "wi-complete" },
+          { id: "wi-failed" },
+          { id: "wi-later-history" },
+          { id: "wi-needs_human" },
+        ])
+      }).pipe(Effect.provide(SqliteTest)),
+    )
+  })
+
+  it("keeps the old index and rows when unexpected legacy conflicts block the replacement", async () => {
+    const migrationSql = await readFile(
+      join(
+        import.meta.dir,
+        "../../db-schema/drizzle/20260730140857_unfinished_work_item_index/migration.sql",
+      ),
+      "utf8",
+    )
+    const folder = await migrationFolder(
+      "20260730140857_unfinished_work_item_index",
+      migrationSql,
+    )
+
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        const sql = yield* SqlClient.SqlClient
+        yield* sql.unsafe(`
+          CREATE TABLE work_item (
+            id text PRIMARY KEY,
+            repository_id text NOT NULL,
+            issue_number integer NOT NULL,
+            state text NOT NULL
+          )
+        `)
+        yield* sql.unsafe(`
+          CREATE UNIQUE INDEX work_item_one_unfinished_v2_uidx
+          ON work_item (repository_id, issue_number)
+          WHERE state NOT IN ('complete', 'failed', 'abandoned', 'needs_human')
+        `)
+        yield* sql.unsafe(`
+          INSERT INTO work_item VALUES
+            ('wi-handoff', 'repo-1', 42, 'needs_human'),
+            ('wi-conflict', 'repo-1', 42, 'implement')
+        `)
+
+        const migration = yield* Effect.exit(runMigrations(folder))
+        expect(migration._tag).toBe("Failure")
+
+        const indexes = yield* sql.unsafe(`
+          SELECT name
+          FROM sqlite_master
+          WHERE type = 'index'
+            AND name LIKE 'work_item_one_unfinished%'
+          ORDER BY name
+        `)
+        expect(indexes).toEqual([{ name: "work_item_one_unfinished_v2_uidx" }])
+        const rows = yield* sql.unsafe(
+          `SELECT id, state FROM work_item ORDER BY id`,
+        )
+        expect(rows).toEqual([
+          { id: "wi-conflict", state: "implement" },
+          { id: "wi-handoff", state: "needs_human" },
         ])
       }).pipe(Effect.provide(SqliteTest)),
     )

--- a/packages/work-item-lifecycle/src/lib/work-item-lifecycle.ts
+++ b/packages/work-item-lifecycle/src/lib/work-item-lifecycle.ts
@@ -143,6 +143,7 @@ const isUnfinishedWorkItemUniqueViolation = (error: SqlError): boolean => {
     (message.includes("work_item_one_unfinished_uidx") ||
       message.includes("work_item_one_unfinished_v2_uidx") ||
       message.includes("work_item_one_unfinished_v3_uidx") ||
+      message.includes("work_item_one_unfinished_v4_uidx") ||
       (message.includes("work_item.repository_id") &&
         message.includes("work_item.issue_number")))
   )


### PR DESCRIPTION
## Why

The application already treated Needs Human Work Items as unfinished, but the database’s partial
unique index did not. That left the final database invariant weaker than the creation gate.

## What changed

- Replace the old partial unique index with a v4 index that excludes only Complete, Failed, and
  Abandoned.
- Install the stricter index before removing historical indexes and triggers, preserving existing
  protection if unexpected legacy conflicts prevent migration.
- Recognize the new index identity while retaining historical unique-violation recovery paths.
- Add migration coverage for every Work Item state, preserved Work Item and Step Run history, raw
  database rejection beside Needs Human, and defensive rollback.

## Verification

- DB suite: 15 tests passed.
- DbService suite: 53 tests passed.
- Work Item Lifecycle suite: 527 tests passed.
- Affected Nx lint and typecheck targets passed.
- Review completed with no findings.

Closes #642