### PR TITLE
feat(lifecycle-model): add validated lifecycle ontology

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -281,6 +281,15 @@
         "@types/bun": "^1.3.0",
       },
     },
+    "packages/lifecycle-model": {
+      "name": "@ready-for-agent/lifecycle-model",
+      "version": "0.0.1",
+      "devDependencies": {
+        "@types/n3": "^1.26.1",
+        "n3": "^2.1.1",
+        "rdf-validate-shacl": "^0.6.5",
+      },
+    },
     "packages/local-git": {
       "name": "@ready-for-agent/local-git",
       "version": "0.0.1",
@@ -948,6 +957,22 @@
 
     "@playwright/test": ["@playwright/test@1.61.1", "", { "dependencies": { "playwright": "1.61.1" }, "bin": { "playwright": "cli.js" } }, "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig=="],
 
+    "@rdfjs/data-model": ["@rdfjs/data-model@2.1.2", "", { "bin": { "rdfjs-data-model-test": "bin/test.js" } }, "sha512-yoSVlyCltqbaCTse3uSdf5Vo3q4UskcTm+3klaUQTwOq7Z5aCZLtLPZatXTPzr+S0WEcjTZvD++A+r3QmgamsA=="],
+
+    "@rdfjs/dataset": ["@rdfjs/dataset@2.0.3", "", { "bin": { "rdfjs-dataset-test": "bin/test.js" } }, "sha512-Ur6M0nDFXMJWNYe1IBDBaQV/nIwRbe3+I58syOHnzZNbe7ZHumUOS/0XQ1+9WYF31tmQU7w741MRn6W3J+OTeg=="],
+
+    "@rdfjs/environment": ["@rdfjs/environment@1.0.0", "", {}, "sha512-+S5YjSvfoQR5r7YQCRCCVHvIEyrWia7FJv2gqM3s5EDfotoAQmFeBagApa9c/eQFi5EiNhmBECE5nB8LIxTaHg=="],
+
+    "@rdfjs/namespace": ["@rdfjs/namespace@2.0.1", "", { "dependencies": { "@rdfjs/data-model": "^2.0.1" } }, "sha512-U85NWVGnL3gWvOZ4eXwUcv3/bom7PAcutSBQqmVWvOaslPy+kDzAJCH1WYBLpdQd4yMmJ+bpJcDl9rcHtXeixg=="],
+
+    "@rdfjs/term-map": ["@rdfjs/term-map@2.0.2", "", { "dependencies": { "@rdfjs/to-ntriples": "^3.0.1" } }, "sha512-EJ2FmmdEUsSR/tU1nrizRLWzH24YzhuvesrbUWxC3Fs0ilYNdtTbg0RaFJDUnJF3HkbNBQe8Zrt/uvU/hcKnHg=="],
+
+    "@rdfjs/term-set": ["@rdfjs/term-set@2.0.3", "", { "dependencies": { "@rdfjs/to-ntriples": "^3.0.1" } }, "sha512-DyXrKWEx+mtAFUZVU7bc3Va6/KZ8PsIp0RVdyWT9jfDgI/HCvNisZaBtAcm+SYTC45o+7WLkbudkk1bfaKVB0A=="],
+
+    "@rdfjs/to-ntriples": ["@rdfjs/to-ntriples@3.0.1", "", {}, "sha512-gjoPAvh4j7AbGMjcDn/8R4cW+d/FPtbfbMM0uQXkyfBFtNUW2iVgrqsgJ65roLc54Y9A2TTFaeeTGSvY9a0HCQ=="],
+
+    "@rdfjs/types": ["@rdfjs/types@2.0.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-uyAzpugX7KekAXAHq26m3JlUIZJOC0uSBhpnefGV5i15bevDyyejoB7I+9MKeUrzXD8OOUI3+4FeV1wwQr5ihA=="],
+
     "@ready-for-agent/agent-backend": ["@ready-for-agent/agent-backend@workspace:packages/agent-backend"],
 
     "@ready-for-agent/codex": ["@ready-for-agent/codex@workspace:packages/codex"],
@@ -979,6 +1004,8 @@
     "@ready-for-agent/keymaxxer-sidecar": ["@ready-for-agent/keymaxxer-sidecar@workspace:apps/keymaxxer-sidecar"],
 
     "@ready-for-agent/layer-turso-local": ["@ready-for-agent/layer-turso-local@workspace:packages/layer-turso-local"],
+
+    "@ready-for-agent/lifecycle-model": ["@ready-for-agent/lifecycle-model@workspace:packages/lifecycle-model"],
 
     "@ready-for-agent/local-git": ["@ready-for-agent/local-git@workspace:packages/local-git"],
 
@@ -1168,6 +1195,8 @@
 
     "@teppeis/multimaps": ["@teppeis/multimaps@3.0.0", "", {}, "sha512-ID7fosbc50TbT0MK0EG12O+gAP3W3Aa/Pz4DaTtQtEvlc9Odaqi0de+xuZ7Li2GtK4HzEX7IuRWS/JmZLksR3Q=="],
 
+    "@tpluscode/rdf-ns-builders": ["@tpluscode/rdf-ns-builders@5.0.0", "", { "dependencies": { "@rdfjs/data-model": "^2.1.0", "@rdfjs/namespace": "^2.0.1", "@rdfjs/types": "^2", "@types/rdfjs__namespace": "^2.0.10", "@zazuko/prefixes": "^2.3.0" } }, "sha512-rtMFbArdief+s0z2A3TOb/gNe5O5xn9LDiEpilCf6lGYCUIfyqoOvZY80fS/eILwcF2Mj6cUQN1WBQ+1neJmaw=="],
+
     "@tursodatabase/database": ["@tursodatabase/database@0.7.1", "", { "dependencies": { "@tursodatabase/database-common": "^0.7.1" }, "optionalDependencies": { "@tursodatabase/database-darwin-arm64": "0.7.1", "@tursodatabase/database-linux-arm64-gnu": "0.7.1", "@tursodatabase/database-linux-x64-gnu": "0.7.1", "@tursodatabase/database-win32-x64-msvc": "0.7.1" } }, "sha512-RPEkpAoxKk0aY8spsUpT0MID7AUq7CHnqHOkA0zTG546XPkP/mkkQr1ZwpUer69z4BItSaDq+OQ3XrxVOFfsHg=="],
 
     "@tursodatabase/database-common": ["@tursodatabase/database-common@0.7.1", "", {}, "sha512-tyEKiRJDZSqLTbJQYhvY9Q2pGbBMwhKb8YS5T9TNOaDy1HvZMDbiypYqvtBw04f02QladUIsmpVBlsmFDb+RFA=="],
@@ -1192,9 +1221,13 @@
 
     "@types/estree": ["@types/estree@1.0.9", "", {}, "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg=="],
 
+    "@types/n3": ["@types/n3@1.26.1", "", { "dependencies": { "@rdfjs/types": "*", "@types/node": "*" } }, "sha512-TilYHzpU6ecXVJAbV+6o17Z8ZkWLWx6ZJD3IluaU4RiGHxqjU2or9fopxFHS6iXS6qcl5Mg1K3wSx9L8xxJaJQ=="],
+
     "@types/node": ["@types/node@26.1.1", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw=="],
 
     "@types/parse-json": ["@types/parse-json@4.0.2", "", {}, "sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw=="],
+
+    "@types/rdfjs__namespace": ["@types/rdfjs__namespace@2.0.10", "", { "dependencies": { "@rdfjs/types": "*" } }, "sha512-xoVzEIOxcpyteEmzaj94MSBbrBFs+vqv05joMhzLEiPRwsBBDnhkdBCaaDxR1Tf7wOW0kB2R1IYe4C3vEBFPgA=="],
 
     "@types/react": ["@types/react@19.2.17", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw=="],
 
@@ -1264,6 +1297,8 @@
 
     "@vitest/utils": ["@vitest/utils@4.1.10", "", { "dependencies": { "@vitest/pretty-format": "4.1.10", "convert-source-map": "^2.0.0", "tinyrainbow": "^3.1.0" } }, "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA=="],
 
+    "@vocabulary/sh": ["@vocabulary/sh@1.1.6", "", { "peerDependencies": { "@rdfjs/types": "^2.0.0" } }, "sha512-8IfAQoKh57THz8LA2+n1jaY/VC2XaqMNSsJgzBKSSrj20y5PSMAawb6dMsxoLxqDIPBDs1TFRl/9CijUnwbBUA=="],
+
     "@whatwg-node/disposablestack": ["@whatwg-node/disposablestack@0.0.6", "", { "dependencies": { "@whatwg-node/promise-helpers": "^1.0.0", "tslib": "^2.6.3" } }, "sha512-LOtTn+JgJvX8WfBVJtF08TGrdjuFzGJc4mkP8EdDI8ADbvO7kiexYep1o8dwnt0okb0jYclCDXF13xU7Ge4zSw=="],
 
     "@whatwg-node/events": ["@whatwg-node/events@0.1.2", "", { "dependencies": { "tslib": "^2.6.3" } }, "sha512-ApcWxkrs1WmEMS2CaLLFUEem/49erT3sxIVjpzU5f6zmVcnijtDSrhoK2zVobOIikZJdH63jdAXOrvjf6eOUNQ=="],
@@ -1278,7 +1313,11 @@
 
     "@yarnpkg/lockfile": ["@yarnpkg/lockfile@1.1.0", "", {}, "sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ=="],
 
+    "@zazuko/prefixes": ["@zazuko/prefixes@2.6.1", "", {}, "sha512-fbOadP7twxt0ZYT9mgIC+xQMk6f3pYYLI5a/2UJ/mc/ygqb/NoVv2ryK3lTtoi74xwkdpUeDwIuFQSosowzUgg=="],
+
     "@zkochan/js-yaml": ["@zkochan/js-yaml@0.0.7", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-nrUSn7hzt7J6JWgWGz78ZYI8wj+gdIJdk0Ynjpp8l+trkn58Uqsf6RYrYkEK+3X18EX+TNdtJI0WxAtc+L84SQ=="],
+
+    "abort-controller": ["abort-controller@3.0.0", "", { "dependencies": { "event-target-shim": "^5.0.0" } }, "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg=="],
 
     "accepts": ["accepts@2.0.0", "", { "dependencies": { "mime-types": "^3.0.0", "negotiator": "^1.0.0" } }, "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng=="],
 
@@ -1379,6 +1418,8 @@
     "cliui": ["cliui@8.0.1", "", { "dependencies": { "string-width": "^4.2.0", "strip-ansi": "^6.0.1", "wrap-ansi": "^7.0.0" } }, "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ=="],
 
     "clone": ["clone@1.0.4", "", {}, "sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg=="],
+
+    "clownface": ["clownface@2.0.3", "", { "dependencies": { "@rdfjs/data-model": "^2.0.1", "@rdfjs/environment": "0 - 1", "@rdfjs/namespace": "^2.0.0" } }, "sha512-E76TBJ7CgU9+/5paSAvuNdMO+fzFThnvRVtidosktYppYkXM8V7tid8Ezzo8S1OmoWxKUam3yfkZlfCid4OiJQ=="],
 
     "clsx": ["clsx@2.1.1", "", {}, "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA=="],
 
@@ -1518,7 +1559,11 @@
 
     "etag": ["etag@1.8.1", "", {}, "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg=="],
 
+    "event-target-shim": ["event-target-shim@5.0.1", "", {}, "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ=="],
+
     "eventemitter3": ["eventemitter3@5.0.4", "", {}, "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw=="],
+
+    "events": ["events@3.3.0", "", {}, "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q=="],
 
     "eventsource": ["eventsource@3.0.7", "", { "dependencies": { "eventsource-parser": "^3.0.1" } }, "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA=="],
 
@@ -1790,6 +1835,8 @@
 
     "multipasta": ["multipasta@0.2.8", "", {}, "sha512-ZPWuMKyv0cSO29f7hozp+k6+crZbQijV8ipMvxNxRf2SwtYGTX1ZX89Kd20VV4H9Znonx+EQn+iy1wGQsJ+b+Q=="],
 
+    "n3": ["n3@2.1.1", "", { "dependencies": { "buffer": "^6.0.3", "readable-stream": "^4.0.0" } }, "sha512-kqg8ers6Lc+uAmHeS+ycd3b8mC4x8wr8V8Fi6+w7l4hX6b0KZ5bT05Tf49qM2mujwaqZT3+08zcgtXgfxivbVQ=="],
+
     "nanoid": ["nanoid@3.3.16", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q=="],
 
     "native-fetch": ["native-fetch@4.0.2", "", { "peerDependencies": { "undici": "*" } }, "sha512-4QcVlKFtv2EYVS5MBgsGX5+NWKtbDbIECdUXDBGDMAZXq3Jkv9zf+y8iS7Ub8fEdga3GpYeazp9gauNqXHJOCg=="],
@@ -1868,6 +1915,8 @@
 
     "prettier": ["prettier@2.8.8", "", { "bin": { "prettier": "bin-prettier.js" } }, "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q=="],
 
+    "process": ["process@0.11.10", "", {}, "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A=="],
+
     "proxy-addr": ["proxy-addr@2.0.7", "", { "dependencies": { "forwarded": "0.2.0", "ipaddr.js": "1.9.1" } }, "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg=="],
 
     "proxy-from-env": ["proxy-from-env@2.1.0", "", {}, "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA=="],
@@ -1881,6 +1930,18 @@
     "range-parser": ["range-parser@1.3.0", "", {}, "sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw=="],
 
     "raw-body": ["raw-body@3.0.2", "", { "dependencies": { "bytes": "~3.1.2", "http-errors": "~2.0.1", "iconv-lite": "~0.7.0", "unpipe": "~1.0.0" } }, "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA=="],
+
+    "rdf-canonize": ["rdf-canonize@3.4.0", "", { "dependencies": { "setimmediate": "^1.0.5" } }, "sha512-fUeWjrkOO0t1rg7B2fdyDTvngj+9RlUyL92vOdiB7c0FPguWVsniIMjEtHH+meLBO9rzkUlUzBVXgWrjI8P9LA=="],
+
+    "rdf-data-factory": ["rdf-data-factory@2.0.2", "", { "dependencies": { "@rdfjs/types": "^2.0.0" } }, "sha512-WzPoYHwQYWvIP9k+7IBLY1b4nIDitzAK4mA37WumAF/Cjvu/KOtYJH9IPZnUTWNSd5K2+pq4vrcE9WZC4sRHhg=="],
+
+    "rdf-dataset-ext": ["rdf-dataset-ext@1.1.0", "", { "dependencies": { "rdf-canonize": "^3.0.0", "readable-stream": "3 - 4" } }, "sha512-CH85RfRKN9aSlbju8T7aM8hgCSWMBsh2eh/tGxUUtWMN+waxi6iFDt8/r4PAEmKaEA82guimZJ4ISbmJ2rvWQg=="],
+
+    "rdf-literal": ["rdf-literal@2.0.0", "", { "dependencies": { "rdf-data-factory": "^2.0.0" } }, "sha512-jlQ+h7EvnXmncmk8OzOYR8T3gNfd4g0LQXbflHkEkancic8dh0Tdt5RiRq8vUFndjIeNHt1RWeA5TAj6rgrtng=="],
+
+    "rdf-validate-datatype": ["rdf-validate-datatype@0.2.2", "", { "dependencies": { "@rdfjs/term-map": "^2.0.0", "@tpluscode/rdf-ns-builders": "3 - 5" } }, "sha512-mH9qL8i0WBbZ6HJCA26BB6V+WV2MraKvitez3SV0QegBWVQ4wYO49CgfFBzoAYg6tlnhFXl9MkrOAQ07X2N1FA=="],
+
+    "rdf-validate-shacl": ["rdf-validate-shacl@0.6.5", "", { "dependencies": { "@rdfjs/data-model": "^2.1.0", "@rdfjs/dataset": "^2.0.2", "@rdfjs/environment": "^1.0.0", "@rdfjs/namespace": "^2.0.1", "@rdfjs/term-set": "^2.0.3", "@rdfjs/types": "1 - 2", "@vocabulary/sh": "^1.1.6", "clownface": "^2.0.3", "debug": "^4.3.2", "rdf-dataset-ext": "^1.1.0", "rdf-literal": "^2.0.0", "rdf-validate-datatype": "^0.2.2" } }, "sha512-rwIibopSixDE8ecA9x0c7oTVxdMWxGiJh7h3uJ+WS2h4lq2nx3DZVO7rJvwa5kZpDq9QEFPoyZINAUyfaaoN4Q=="],
 
     "react": ["react@19.2.8", "", {}, "sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw=="],
 
@@ -1973,6 +2034,8 @@
     "serve-static": ["serve-static@2.2.1", "", { "dependencies": { "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "parseurl": "^1.3.3", "send": "^1.2.0" } }, "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw=="],
 
     "set-blocking": ["set-blocking@2.0.0", "", {}, "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw=="],
+
+    "setimmediate": ["setimmediate@1.0.5", "", {}, "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA=="],
 
     "setprototypeof": ["setprototypeof@1.2.0", "", {}, "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="],
 
@@ -2274,6 +2337,10 @@
 
     "micromatch/picomatch": ["picomatch@2.3.2", "", {}, "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="],
 
+    "n3/buffer": ["buffer@6.0.3", "", { "dependencies": { "base64-js": "^1.3.1", "ieee754": "^1.2.1" } }, "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA=="],
+
+    "n3/readable-stream": ["readable-stream@4.7.0", "", { "dependencies": { "abort-controller": "^3.0.0", "buffer": "^6.0.3", "events": "^3.3.0", "process": "^0.11.10", "string_decoder": "^1.3.0" } }, "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg=="],
+
     "nx/semver": ["semver@7.8.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA=="],
 
     "nx/smol-toml": ["smol-toml@1.6.1", "", {}, "sha512-dWUG8F5sIIARXih1DTaQAX4SsiTXhInKf1buxdY9DIg4ZYPZK5nGM1VRIYmEbDbsHt7USo99xSLFu5Q1IqTmsg=="],
@@ -2287,6 +2354,8 @@
     "playwright/fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
 
     "playwright-bdd/mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
+
+    "rdf-dataset-ext/readable-stream": ["readable-stream@4.7.0", "", { "dependencies": { "abort-controller": "^3.0.0", "buffer": "^6.0.3", "events": "^3.3.0", "process": "^0.11.10", "string_decoder": "^1.3.0" } }, "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg=="],
 
     "rolldown/@oxc-project/types": ["@oxc-project/types@0.139.0", "", {}, "sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw=="],
 
@@ -2393,6 +2462,8 @@
     "log-update/wrap-ansi/string-width": ["string-width@5.1.2", "", { "dependencies": { "eastasianwidth": "^0.2.0", "emoji-regex": "^9.2.2", "strip-ansi": "^7.0.1" } }, "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA=="],
 
     "playwright-bdd/mime-types/mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
+
+    "rdf-dataset-ext/readable-stream/buffer": ["buffer@6.0.3", "", { "dependencies": { "base64-js": "^1.3.1", "ieee754": "^1.2.1" } }, "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA=="],
 
     "send/mime-types/mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
 

--- a/ontology/fixtures/contradictory.ttl
+++ b/ontology/fixtures/contradictory.ttl
@@ -1,0 +1,6 @@
+@prefix example: <https://ready-for-agent.dev/ontology/examples#> .
+@prefix rfa: <https://ready-for-agent.dev/ontology/rfa#> .
+
+example:contradictory-work-item
+  a rfa:WorkItem, rfa:Implement, rfa:Complete ;
+  rfa:currentState rfa:Implement, rfa:Complete .

--- a/ontology/fixtures/invalid.ttl
+++ b/ontology/fixtures/invalid.ttl
@@ -1,0 +1,6 @@
+@prefix example: <https://ready-for-agent.dev/ontology/examples#> .
+@prefix rfa: <https://ready-for-agent.dev/ontology/rfa#> .
+
+example:invalid-work-item
+  a rfa:WorkItem ;
+  rfa:currentState example:ProbablyDone .

--- a/ontology/fixtures/manifest.json
+++ b/ontology/fixtures/manifest.json
@@ -1,0 +1,28 @@
+{
+  "fixtures": [
+    {
+      "file": "valid.ttl",
+      "category": "valid",
+      "conforms": true,
+      "consistent": true
+    },
+    {
+      "file": "invalid.ttl",
+      "category": "invalid",
+      "conforms": false,
+      "consistent": true
+    },
+    {
+      "file": "missing-fact.ttl",
+      "category": "missing-fact",
+      "conforms": false,
+      "consistent": true
+    },
+    {
+      "file": "contradictory.ttl",
+      "category": "contradictory",
+      "conforms": false,
+      "consistent": false
+    }
+  ]
+}

--- a/ontology/fixtures/missing-fact.ttl
+++ b/ontology/fixtures/missing-fact.ttl
@@ -1,0 +1,5 @@
+@prefix example: <https://ready-for-agent.dev/ontology/examples#> .
+@prefix rfa: <https://ready-for-agent.dev/ontology/rfa#> .
+
+example:missing-state-work-item
+  a rfa:WorkItem .

--- a/ontology/fixtures/valid.ttl
+++ b/ontology/fixtures/valid.ttl
@@ -1,0 +1,6 @@
+@prefix example: <https://ready-for-agent.dev/ontology/examples#> .
+@prefix rfa: <https://ready-for-agent.dev/ontology/rfa#> .
+
+example:valid-work-item
+  a rfa:WorkItem ;
+  rfa:currentState rfa:Implement .

--- a/ontology/rfa.ttl
+++ b/ontology/rfa.ttl
@@ -1,0 +1,256 @@
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix rfa: <https://ready-for-agent.dev/ontology/rfa#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+
+<https://ready-for-agent.dev/ontology/rfa>
+  a owl:Ontology ;
+  dcterms:title "Ready for Agent Work Item lifecycle ontology"@en ;
+  dcterms:description
+    "The operational Lifecycle Steps and terminal Work Item states."@en ;
+  dcterms:source
+    <https://github.com/berenddeboer/ready-for-agent/blob/main/CONTEXT.md> ;
+  owl:versionInfo "0.1.0" .
+
+rfa:LifecycleState
+  a owl:Class ;
+  skos:prefLabel "Lifecycle state"@en ;
+  skos:definition
+    "The next action required for a Work Item, or a terminal Work Item state."@en .
+
+rfa:OperationalLifecycleStep
+  a owl:Class ;
+  rdfs:subClassOf rfa:LifecycleState ;
+  owl:disjointWith rfa:TerminalWorkItemState ;
+  skos:prefLabel "Operational Lifecycle Step"@en ;
+  skos:definition
+    "A non-terminal Lifecycle Step that the harness can run for a Work Item."@en .
+
+rfa:TerminalWorkItemState
+  a owl:Class ;
+  rdfs:subClassOf rfa:LifecycleState ;
+  skos:prefLabel "terminal Work Item state"@en ;
+  skos:definition
+    "A Lifecycle state in which ordinary Work Item advancement has stopped."@en .
+
+rfa:WorkItem
+  a owl:Class ;
+  skos:prefLabel "Work Item"@en ;
+  skos:definition
+    "A durable record of one operator-requested attempt to complete a Leaf Issue's objective through the work lifecycle."@en .
+
+rfa:currentState
+  a owl:ObjectProperty ;
+  rdfs:domain rfa:WorkItem ;
+  rdfs:range rfa:LifecycleState ;
+  skos:prefLabel "current state"@en ;
+  skos:definition
+    "The single operational Lifecycle Step or terminal state currently held by a Work Item."@en .
+
+rfa:CreateWorktree
+  a owl:Class, owl:NamedIndividual, skos:Concept,
+    rfa:OperationalLifecycleStep ;
+  rdfs:subClassOf rfa:OperationalLifecycleStep ;
+  skos:notation "create_worktree" ;
+  skos:prefLabel "Create Worktree"@en ;
+  skos:definition
+    "The Lifecycle Step that creates the Work Item's isolated Git worktree and records its starting commit."@en .
+
+rfa:InstallDependencies
+  a owl:Class, owl:NamedIndividual, skos:Concept,
+    rfa:OperationalLifecycleStep ;
+  rdfs:subClassOf rfa:OperationalLifecycleStep ;
+  skos:notation "install_dependencies" ;
+  skos:prefLabel "Install Dependencies"@en ;
+  skos:definition
+    "The Lifecycle Step that installs the Repository dependencies required to work on the Work Item."@en .
+
+rfa:Implement
+  a owl:Class, owl:NamedIndividual, skos:Concept,
+    rfa:OperationalLifecycleStep ;
+  rdfs:subClassOf rfa:OperationalLifecycleStep ;
+  skos:notation "implement" ;
+  skos:prefLabel "Implement"@en ;
+  skos:definition
+    "The Lifecycle Step that starts or continues the Work Item's Session with an Agent Turn to complete the Issue's objective."@en .
+
+rfa:AssessChanges
+  a owl:Class, owl:NamedIndividual, skos:Concept,
+    rfa:OperationalLifecycleStep ;
+  rdfs:subClassOf rfa:OperationalLifecycleStep ;
+  skos:notation "assess_changes" ;
+  skos:prefLabel "Assess Changes"@en ;
+  skos:definition
+    "The Lifecycle Step after Implement that determines whether the Work Item produced repository changes before repository quality gates run."@en .
+
+rfa:PreCommit
+  a owl:Class, owl:NamedIndividual, skos:Concept,
+    rfa:OperationalLifecycleStep ;
+  rdfs:subClassOf rfa:OperationalLifecycleStep ;
+  skos:notation "pre_commit" ;
+  skos:prefLabel "Pre-Commit"@en ;
+  skos:definition
+    "The Lifecycle Step that runs the Repository's git pre-commit hook on staged Work Item changes before Review."@en .
+
+rfa:Review
+  a owl:Class, owl:NamedIndividual, skos:Concept,
+    rfa:OperationalLifecycleStep ;
+  rdfs:subClassOf rfa:OperationalLifecycleStep ;
+  skos:notation "review" ;
+  skos:prefLabel "Review"@en ;
+  skos:definition
+    "The Lifecycle Step after Pre-Commit that critiques the Work Item's repository changes and may apply accepted Review Findings before Commit."@en .
+
+rfa:Commit
+  a owl:Class, owl:NamedIndividual, skos:Concept,
+    rfa:OperationalLifecycleStep ;
+  rdfs:subClassOf rfa:OperationalLifecycleStep ;
+  skos:notation "commit" ;
+  skos:prefLabel "Commit"@en ;
+  skos:definition
+    "The Lifecycle Step after successful Review that creates the local git commit for the Work Item's changes."@en .
+
+rfa:CreatePr
+  a owl:Class, owl:NamedIndividual, skos:Concept,
+    rfa:OperationalLifecycleStep ;
+  rdfs:subClassOf rfa:OperationalLifecycleStep ;
+  skos:notation "create_pr" ;
+  skos:prefLabel "Create PR"@en ;
+  skos:definition
+    "The Lifecycle Step that pushes committed Work Item changes and creates their draft pull request."@en .
+
+rfa:WatchPrStatusChecks
+  a owl:Class, owl:NamedIndividual, skos:Concept,
+    rfa:OperationalLifecycleStep ;
+  rdfs:subClassOf rfa:OperationalLifecycleStep ;
+  skos:notation "watch_pr_status_checks" ;
+  skos:prefLabel "Watch PR Status Checks"@en ;
+  skos:definition
+    "The Lifecycle Step that observes the Work Item PR for merge conflicts, Status Check Handoffs, and settled completion conditions."@en .
+
+rfa:ResolvePrMergeConflict
+  a owl:Class, owl:NamedIndividual, skos:Concept,
+    rfa:OperationalLifecycleStep ;
+  rdfs:subClassOf rfa:OperationalLifecycleStep ;
+  skos:notation "resolve_pr_merge_conflict" ;
+  skos:prefLabel "Resolve PR Merge Conflict"@en ;
+  skos:definition
+    "The Lifecycle Step that asks the Work Item's Implement Session to rebase a conflicting pull-request branch."@en .
+
+rfa:InvestigatePrStatusChecks
+  a owl:Class, owl:NamedIndividual, skos:Concept,
+    rfa:OperationalLifecycleStep ;
+  rdfs:subClassOf rfa:OperationalLifecycleStep ;
+  skos:notation "investigate_pr_status_checks" ;
+  skos:prefLabel "Investigate PR Status Checks"@en ;
+  skos:definition
+    "The Lifecycle Step that processes a durable Status Check Handoff in the Work Item's Implement Session."@en .
+
+rfa:MarkPrReadyForReview
+  a owl:Class, owl:NamedIndividual, skos:Concept,
+    rfa:OperationalLifecycleStep ;
+  rdfs:subClassOf rfa:OperationalLifecycleStep ;
+  skos:notation "mark_pr_ready_for_review" ;
+  skos:prefLabel "Mark PR Ready for Review"@en ;
+  skos:definition
+    "The Lifecycle Step that changes a settled draft Work Item PR to ready for review."@en .
+
+rfa:DecidePrMerge
+  a owl:Class, owl:NamedIndividual, skos:Concept,
+    rfa:OperationalLifecycleStep ;
+  rdfs:subClassOf rfa:OperationalLifecycleStep ;
+  skos:notation "decide_pr_merge" ;
+  skos:prefLabel "Decide PR Merge"@en ;
+  skos:definition
+    "The Lifecycle Step that decides whether a settled Work Item PR may be merged by the harness or requires a human."@en .
+
+rfa:MergePr
+  a owl:Class, owl:NamedIndividual, skos:Concept,
+    rfa:OperationalLifecycleStep ;
+  rdfs:subClassOf rfa:OperationalLifecycleStep ;
+  skos:notation "merge_pr" ;
+  skos:prefLabel "Merge PR"@en ;
+  skos:definition
+    "The Lifecycle Step that revalidates and merges an approved Work Item PR through its Forge."@en .
+
+rfa:CloseIssue
+  a owl:Class, owl:NamedIndividual, skos:Concept,
+    rfa:OperationalLifecycleStep ;
+  rdfs:subClassOf rfa:OperationalLifecycleStep ;
+  skos:notation "close_issue" ;
+  skos:prefLabel "Close Issue"@en ;
+  skos:definition
+    "The Lifecycle Step that publishes a No-Change Outcome's completion summary and closes the Work Item's Issue."@en .
+
+rfa:LocalCleanup
+  a owl:Class, owl:NamedIndividual, skos:Concept,
+    rfa:OperationalLifecycleStep ;
+  rdfs:subClassOf rfa:OperationalLifecycleStep ;
+  skos:notation "local_cleanup" ;
+  skos:prefLabel "local cleanup"@en ;
+  skos:definition
+    "The Lifecycle Step that removes the Work Item's local worktree and branch after its remote outcome is finished."@en .
+
+rfa:Complete
+  a owl:Class, owl:NamedIndividual, skos:Concept,
+    rfa:TerminalWorkItemState ;
+  rdfs:subClassOf rfa:TerminalWorkItemState ;
+  skos:notation "complete" ;
+  skos:prefLabel "Complete"@en ;
+  skos:definition
+    "A terminal Work Item state whose remote outcome and local cleanup have both finished."@en .
+
+rfa:Failed
+  a owl:Class, owl:NamedIndividual, skos:Concept,
+    rfa:TerminalWorkItemState ;
+  rdfs:subClassOf rfa:TerminalWorkItemState ;
+  skos:notation "failed" ;
+  skos:prefLabel "Failed"@en ;
+  skos:definition
+    "A terminal Work Item state that cannot advance because a lifecycle precondition was not met."@en .
+
+rfa:NeedsHuman
+  a owl:Class, owl:NamedIndividual, skos:Concept,
+    rfa:TerminalWorkItemState ;
+  rdfs:subClassOf rfa:TerminalWorkItemState ;
+  skos:notation "needs_human" ;
+  skos:prefLabel "Needs Human"@en ;
+  skos:definition
+    "A Work Item state that cannot continue autonomously and records the intervention required from a human."@en .
+
+rfa:Abandoned
+  a owl:Class, owl:NamedIndividual, skos:Concept,
+    rfa:TerminalWorkItemState ;
+  rdfs:subClassOf rfa:TerminalWorkItemState ;
+  skos:notation "abandoned" ;
+  skos:prefLabel "Abandoned"@en ;
+  skos:definition
+    "A terminal Work Item state that preserves history after the attempt is stopped without completion."@en .
+
+[
+  a owl:AllDisjointClasses ;
+  owl:members (
+    rfa:CreateWorktree
+    rfa:InstallDependencies
+    rfa:Implement
+    rfa:AssessChanges
+    rfa:PreCommit
+    rfa:Review
+    rfa:Commit
+    rfa:CreatePr
+    rfa:WatchPrStatusChecks
+    rfa:ResolvePrMergeConflict
+    rfa:InvestigatePrStatusChecks
+    rfa:MarkPrReadyForReview
+    rfa:DecidePrMerge
+    rfa:MergePr
+    rfa:CloseIssue
+    rfa:LocalCleanup
+    rfa:Complete
+    rfa:Failed
+    rfa:NeedsHuman
+    rfa:Abandoned
+  )
+] .

--- a/ontology/shapes.ttl
+++ b/ontology/shapes.ttl
@@ -1,0 +1,98 @@
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix rfa: <https://ready-for-agent.dev/ontology/rfa#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+
+rfa:LifecycleVocabularyShape
+  a sh:NodeShape ;
+  sh:targetClass rfa:OperationalLifecycleStep ;
+  sh:targetClass rfa:TerminalWorkItemState ;
+  sh:property [
+    sh:path rdf:type ;
+    sh:hasValue owl:Class ;
+    sh:message "Every lifecycle term must be declared as an OWL class."@en ;
+  ] ;
+  sh:property [
+    sh:path rdf:type ;
+    sh:hasValue skos:Concept ;
+    sh:message "Every lifecycle term must be declared as a SKOS concept."@en ;
+  ] ;
+  sh:property [
+    sh:path skos:notation ;
+    sh:minCount 1 ;
+    sh:maxCount 1 ;
+    sh:datatype <http://www.w3.org/2001/XMLSchema#string> ;
+    sh:message "Every lifecycle term must have one runtime notation."@en ;
+  ] ;
+  sh:property [
+    sh:path skos:prefLabel ;
+    sh:minCount 1 ;
+    sh:maxCount 1 ;
+    sh:languageIn ("en") ;
+    sh:uniqueLang true ;
+    sh:message "Every lifecycle term must have one English preferred label."@en ;
+  ] ;
+  sh:property [
+    sh:path skos:definition ;
+    sh:minCount 1 ;
+    sh:maxCount 1 ;
+    sh:languageIn ("en") ;
+    sh:uniqueLang true ;
+    sh:message "Every lifecycle term must have one English definition."@en ;
+  ] .
+
+rfa:OperationalLifecycleStepShape
+  a sh:NodeShape ;
+  sh:targetClass rfa:OperationalLifecycleStep ;
+  sh:property [
+    sh:path rdfs:subClassOf ;
+    sh:hasValue rfa:OperationalLifecycleStep ;
+    sh:message
+      "Every operational term must specialize Operational Lifecycle Step."@en ;
+  ] .
+
+rfa:TerminalWorkItemStateShape
+  a sh:NodeShape ;
+  sh:targetClass rfa:TerminalWorkItemState ;
+  sh:property [
+    sh:path rdfs:subClassOf ;
+    sh:hasValue rfa:TerminalWorkItemState ;
+    sh:message
+      "Every terminal term must specialize terminal Work Item state."@en ;
+  ] .
+
+rfa:WorkItemShape
+  a sh:NodeShape ;
+  sh:targetClass rfa:WorkItem ;
+  sh:property [
+    sh:path rfa:currentState ;
+    sh:minCount 1 ;
+    sh:maxCount 1 ;
+    sh:nodeKind sh:IRI ;
+    sh:in (
+      rfa:CreateWorktree
+      rfa:InstallDependencies
+      rfa:Implement
+      rfa:AssessChanges
+      rfa:PreCommit
+      rfa:Review
+      rfa:Commit
+      rfa:CreatePr
+      rfa:WatchPrStatusChecks
+      rfa:ResolvePrMergeConflict
+      rfa:InvestigatePrStatusChecks
+      rfa:MarkPrReadyForReview
+      rfa:DecidePrMerge
+      rfa:MergePr
+      rfa:CloseIssue
+      rfa:LocalCleanup
+      rfa:Complete
+      rfa:Failed
+      rfa:NeedsHuman
+      rfa:Abandoned
+    ) ;
+    sh:message
+      "A Work Item must have exactly one declared lifecycle state."@en ;
+  ] .

--- a/packages/lifecycle-model/package.json
+++ b/packages/lifecycle-model/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "@ready-for-agent/lifecycle-model",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "devDependencies": {
+    "@types/n3": "^1.26.1",
+    "n3": "^2.1.1",
+    "rdf-validate-shacl": "^0.6.5"
+  }
+}

--- a/packages/lifecycle-model/project.json
+++ b/packages/lifecycle-model/project.json
@@ -1,0 +1,22 @@
+{
+  "name": "lifecycle-model",
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "packages/lifecycle-model/test",
+  "projectType": "library",
+  "tags": [],
+  "targets": {
+    "test": {
+      "executor": "nx:run-commands",
+      "options": {
+        "cwd": "{projectRoot}",
+        "command": "bun test"
+      },
+      "inputs": [
+        "default",
+        "{workspaceRoot}/ontology/**/*.ttl",
+        "{workspaceRoot}/ontology/fixtures/manifest.json"
+      ],
+      "cache": true
+    }
+  }
+}

--- a/packages/lifecycle-model/test/ontology.test.ts
+++ b/packages/lifecycle-model/test/ontology.test.ts
@@ -1,0 +1,460 @@
+import { readFileSync, readdirSync } from "node:fs"
+import { resolve } from "node:path"
+import type { Term } from "n3"
+import { DataFactory, Parser, Store } from "n3"
+import SHACLValidator from "rdf-validate-shacl"
+import { describe, expect, it } from "bun:test"
+
+const ontologyRoot = resolve(import.meta.dir, "../../../ontology")
+const fixturesRoot = resolve(ontologyRoot, "fixtures")
+
+const namespace = {
+  owl: "http://www.w3.org/2002/07/owl#",
+  rdf: "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+  rdfs: "http://www.w3.org/2000/01/rdf-schema#",
+  rfa: "https://ready-for-agent.dev/ontology/rfa#",
+  sh: "http://www.w3.org/ns/shacl#",
+  skos: "http://www.w3.org/2004/02/skos/core#",
+} as const
+
+const iri = (value: string) => DataFactory.namedNode(value)
+const term = (localName: string) => iri(`${namespace.rfa}${localName}`)
+
+const rdfType = iri(`${namespace.rdf}type`)
+const rdfFirst = iri(`${namespace.rdf}first`)
+const rdfRest = iri(`${namespace.rdf}rest`)
+const rdfNil = iri(`${namespace.rdf}nil`)
+const rdfsSubClassOf = iri(`${namespace.rdfs}subClassOf`)
+const owlClass = iri(`${namespace.owl}Class`)
+const owlAllDisjointClasses = iri(`${namespace.owl}AllDisjointClasses`)
+const owlDisjointWith = iri(`${namespace.owl}disjointWith`)
+const owlMembers = iri(`${namespace.owl}members`)
+const skosConcept = iri(`${namespace.skos}Concept`)
+const skosDefinition = iri(`${namespace.skos}definition`)
+const skosNotation = iri(`${namespace.skos}notation`)
+const skosPrefLabel = iri(`${namespace.skos}prefLabel`)
+const shIn = iri(`${namespace.sh}in`)
+const shPath = iri(`${namespace.sh}path`)
+
+const operationalClass = term("OperationalLifecycleStep")
+const terminalClass = term("TerminalWorkItemState")
+
+const expectedOperationalTerms = {
+  CreateWorktree: ["create_worktree", "Create Worktree"],
+  InstallDependencies: ["install_dependencies", "Install Dependencies"],
+  Implement: ["implement", "Implement"],
+  AssessChanges: ["assess_changes", "Assess Changes"],
+  PreCommit: ["pre_commit", "Pre-Commit"],
+  Review: ["review", "Review"],
+  Commit: ["commit", "Commit"],
+  CreatePr: ["create_pr", "Create PR"],
+  WatchPrStatusChecks: ["watch_pr_status_checks", "Watch PR Status Checks"],
+  ResolvePrMergeConflict: [
+    "resolve_pr_merge_conflict",
+    "Resolve PR Merge Conflict",
+  ],
+  InvestigatePrStatusChecks: [
+    "investigate_pr_status_checks",
+    "Investigate PR Status Checks",
+  ],
+  MarkPrReadyForReview: [
+    "mark_pr_ready_for_review",
+    "Mark PR Ready for Review",
+  ],
+  DecidePrMerge: ["decide_pr_merge", "Decide PR Merge"],
+  MergePr: ["merge_pr", "Merge PR"],
+  CloseIssue: ["close_issue", "Close Issue"],
+  LocalCleanup: ["local_cleanup", "local cleanup"],
+} as const
+
+const expectedTerminalTerms = {
+  Complete: ["complete", "Complete"],
+  Failed: ["failed", "Failed"],
+  NeedsHuman: ["needs_human", "Needs Human"],
+  Abandoned: ["abandoned", "Abandoned"],
+} as const
+
+const expectedStateIris = [
+  ...Object.keys(expectedOperationalTerms),
+  ...Object.keys(expectedTerminalTerms),
+].map((localName) => `${namespace.rfa}${localName}`)
+
+const parseTurtle = (path: string) => {
+  const source = readFileSync(path, "utf8")
+  const quads = new Parser({
+    baseIRI: `file://${path}`,
+    format: "Turtle",
+  }).parse(source)
+
+  return new Store(quads)
+}
+
+const ontology = parseTurtle(resolve(ontologyRoot, "rfa.ttl"))
+const shapes = parseTurtle(resolve(ontologyRoot, "shapes.ttl"))
+
+const getOnlyObject = (store: Store, subject: Term, predicate: Term) => {
+  const objects = store.getObjects(subject, predicate, null)
+  expect(objects).toHaveLength(1)
+
+  const object = objects[0]
+  if (object === undefined) {
+    throw new Error(`Missing object for ${subject.value} ${predicate.value}`)
+  }
+
+  return object
+}
+
+const getOnlyLiteral = (store: Store, subject: Term, predicate: Term) => {
+  const object = getOnlyObject(store, subject, predicate)
+  if (object.termType !== "Literal") {
+    throw new Error(
+      `Expected a literal for ${subject.value} ${predicate.value}`,
+    )
+  }
+
+  return object
+}
+
+const readRdfList = (store: Store, head: Term) => {
+  const values: Term[] = []
+  const visited = new Set<string>()
+  let current = head
+
+  while (!current.equals(rdfNil)) {
+    const key = `${current.termType}:${current.value}`
+    if (visited.has(key)) {
+      throw new Error(`Cyclic RDF list at ${key}`)
+    }
+    visited.add(key)
+
+    values.push(getOnlyObject(store, current, rdfFirst))
+    current = getOnlyObject(store, current, rdfRest)
+  }
+
+  return values
+}
+
+const expectExactIris = (actual: Iterable<Term>, expected: string[]) => {
+  const actualIris = [...actual].map(({ value }) => value).sort()
+  expect(actualIris).toEqual([...expected].sort())
+}
+
+interface DisjointnessViolation {
+  readonly kind: "class" | "individual"
+  readonly subject: string
+  readonly disjointClasses: readonly [string, string]
+}
+
+const namedIri = (value: Term, context: string) => {
+  if (value.termType !== "NamedNode") {
+    throw new Error(`${context} must be a named IRI, got ${value.termType}`)
+  }
+
+  return value.value
+}
+
+const pairKey = (first: string, second: string) =>
+  [first, second].sort().join("\u0000")
+
+const superclassClosure = (store: Store, classIri: string) => {
+  const closure = new Set([classIri])
+  const pending = [classIri]
+
+  for (const current of pending) {
+    for (const parent of store.getObjects(iri(current), rdfsSubClassOf, null)) {
+      const parentIri = namedIri(parent, "rdfs:subClassOf object")
+      if (!closure.has(parentIri)) {
+        closure.add(parentIri)
+        pending.push(parentIri)
+      }
+    }
+  }
+
+  return closure
+}
+
+const findDisjointnessViolations = (store: Store) => {
+  const disjointPairs = new Set<string>()
+  const classes = new Set<string>()
+
+  const addDisjointPair = (first: string, second: string) => {
+    classes.add(first)
+    classes.add(second)
+    disjointPairs.add(pairKey(first, second))
+  }
+
+  for (const quad of store.getQuads(null, owlDisjointWith, null, null)) {
+    addDisjointPair(
+      namedIri(quad.subject, "owl:disjointWith subject"),
+      namedIri(quad.object, "owl:disjointWith object"),
+    )
+  }
+
+  for (const axiom of store.getSubjects(rdfType, owlAllDisjointClasses, null)) {
+    const members = readRdfList(
+      store,
+      getOnlyObject(store, axiom, owlMembers),
+    ).map((member) => namedIri(member, "owl:members entry"))
+
+    for (const [index, first] of members.entries()) {
+      for (const second of members.slice(index + 1)) {
+        addDisjointPair(first, second)
+      }
+    }
+  }
+
+  for (const quad of store.getQuads(null, rdfsSubClassOf, null, null)) {
+    classes.add(namedIri(quad.subject, "rdfs:subClassOf subject"))
+    classes.add(namedIri(quad.object, "rdfs:subClassOf object"))
+  }
+
+  for (const declaredClass of store.getSubjects(rdfType, owlClass, null)) {
+    classes.add(namedIri(declaredClass, "owl:Class subject"))
+  }
+
+  const firstDisjointPair = (classIris: Iterable<string>) => {
+    const expandedClasses = [...classIris].sort()
+    for (const [index, first] of expandedClasses.entries()) {
+      for (const second of expandedClasses.slice(index + 1)) {
+        if (disjointPairs.has(pairKey(first, second))) {
+          return [first, second] as const
+        }
+      }
+    }
+
+    return undefined
+  }
+
+  const violations: DisjointnessViolation[] = []
+
+  for (const classIri of [...classes].sort()) {
+    const disjointClasses = firstDisjointPair(
+      superclassClosure(store, classIri),
+    )
+    if (disjointClasses !== undefined) {
+      violations.push({
+        kind: "class",
+        subject: classIri,
+        disjointClasses,
+      })
+    }
+  }
+
+  const individuals = new Map<string, Set<string>>()
+  for (const quad of store.getQuads(null, rdfType, null, null)) {
+    const types = individuals.get(quad.subject.value) ?? new Set<string>()
+    types.add(namedIri(quad.object, "rdf:type object"))
+    individuals.set(quad.subject.value, types)
+  }
+
+  for (const [individual, directTypes] of [...individuals].sort()) {
+    const inferredTypes = new Set<string>()
+    for (const directType of directTypes) {
+      for (const inferredType of superclassClosure(store, directType)) {
+        inferredTypes.add(inferredType)
+      }
+    }
+
+    const disjointClasses = firstDisjointPair(inferredTypes)
+    if (disjointClasses !== undefined) {
+      violations.push({
+        kind: "individual",
+        subject: individual,
+        disjointClasses,
+      })
+    }
+  }
+
+  return violations
+}
+
+const expectLifecycleTerm = (
+  store: Store,
+  localName: string,
+  notation: string,
+  label: string,
+  parent: Term,
+) => {
+  const subject = term(localName)
+
+  expect(store.countQuads(subject, rdfType, owlClass, null)).toBe(1)
+  expect(store.countQuads(subject, rdfType, skosConcept, null)).toBe(1)
+  expect(store.countQuads(subject, rdfType, parent, null)).toBe(1)
+  expect(store.countQuads(subject, rdfsSubClassOf, parent, null)).toBe(1)
+
+  const actualNotation = getOnlyLiteral(store, subject, skosNotation)
+  expect(actualNotation.value).toBe(notation)
+
+  const actualLabel = getOnlyLiteral(store, subject, skosPrefLabel)
+  expect(actualLabel.value).toBe(label)
+  expect(actualLabel.language).toBe("en")
+
+  const definition = getOnlyLiteral(store, subject, skosDefinition)
+  expect(definition.language).toBe("en")
+  expect(definition.value.length).toBeGreaterThan(20)
+}
+
+describe("rfa lifecycle ontology", () => {
+  it("declares exactly the operational Lifecycle Steps from CONTEXT.md", () => {
+    const actualTerms = ontology.getSubjects(rdfType, operationalClass, null)
+    const expectedIris = Object.keys(expectedOperationalTerms).map(
+      (localName) => `${namespace.rfa}${localName}`,
+    )
+    expectExactIris(actualTerms, expectedIris)
+
+    for (const [localName, [notation, label]] of Object.entries(
+      expectedOperationalTerms,
+    )) {
+      expectLifecycleTerm(
+        ontology,
+        localName,
+        notation,
+        label,
+        operationalClass,
+      )
+    }
+  })
+
+  it("declares exactly the terminal Work Item states from CONTEXT.md", () => {
+    const actualTerms = ontology.getSubjects(rdfType, terminalClass, null)
+    const expectedIris = Object.keys(expectedTerminalTerms).map(
+      (localName) => `${namespace.rfa}${localName}`,
+    )
+    expectExactIris(actualTerms, expectedIris)
+
+    for (const [localName, [notation, label]] of Object.entries(
+      expectedTerminalTerms,
+    )) {
+      expectLifecycleTerm(ontology, localName, notation, label, terminalClass)
+    }
+  })
+
+  it("keeps the operational and terminal state classes disjoint", () => {
+    expect(
+      ontology.countQuads(
+        operationalClass,
+        owlDisjointWith,
+        terminalClass,
+        null,
+      ),
+    ).toBe(1)
+
+    const disjointAxioms = ontology.getSubjects(
+      rdfType,
+      owlAllDisjointClasses,
+      null,
+    )
+    expect(disjointAxioms).toHaveLength(1)
+
+    const members = getOnlyObject(ontology, disjointAxioms[0]!, owlMembers)
+    expectExactIris(readRdfList(ontology, members), expectedStateIris)
+  })
+
+  it("has no disjoint class contradictions", () => {
+    expect(findDisjointnessViolations(ontology)).toEqual([])
+  })
+
+  it("detects an axiom that makes a lifecycle class contradictory", () => {
+    const inconsistentOntology = new Store(
+      ontology.getQuads(null, null, null, null),
+    )
+    inconsistentOntology.addQuad(
+      term("Implement"),
+      rdfsSubClassOf,
+      term("Complete"),
+    )
+
+    expect(
+      findDisjointnessViolations(inconsistentOntology).some(
+        ({ kind, subject }) =>
+          kind === "class" && subject === term("Implement").value,
+      ),
+    ).toBe(true)
+  })
+
+  it("keeps the Work Item shape in parity with the declared state space", () => {
+    const currentStateProperties = shapes.getSubjects(
+      shPath,
+      term("currentState"),
+      null,
+    )
+    expect(currentStateProperties).toHaveLength(1)
+
+    const allowedStates = getOnlyObject(
+      shapes,
+      currentStateProperties[0]!,
+      shIn,
+    )
+    expectExactIris(readRdfList(shapes, allowedStates), expectedStateIris)
+  })
+
+  it("conforms to its own lifecycle vocabulary shapes", async () => {
+    const report = await new SHACLValidator(shapes).validate(ontology)
+    expect(report.conforms).toBe(true)
+    expect(report.results).toHaveLength(0)
+  })
+})
+
+interface Fixture {
+  readonly file: string
+  readonly category: "valid" | "invalid" | "missing-fact" | "contradictory"
+  readonly conforms: boolean
+  readonly consistent: boolean
+}
+
+interface FixtureManifest {
+  readonly fixtures: readonly Fixture[]
+}
+
+const fixtureManifest = JSON.parse(
+  readFileSync(resolve(fixturesRoot, "manifest.json"), "utf8"),
+) as FixtureManifest
+
+const expectedFixtureVerdicts = {
+  valid: { conforms: true, consistent: true },
+  invalid: { conforms: false, consistent: true },
+  "missing-fact": { conforms: false, consistent: true },
+  contradictory: { conforms: false, consistent: false },
+} as const
+
+describe("SHACL and consistency fixture corpus", () => {
+  it("asserts one fixture and verdict for every required category", () => {
+    const actualCategories = fixtureManifest.fixtures
+      .map(({ category }) => category)
+      .sort()
+    expect(actualCategories).toEqual(
+      Object.keys(expectedFixtureVerdicts).sort(),
+    )
+
+    for (const fixture of fixtureManifest.fixtures) {
+      expect({
+        conforms: fixture.conforms,
+        consistent: fixture.consistent,
+      }).toEqual(expectedFixtureVerdicts[fixture.category])
+    }
+
+    const declaredFiles = fixtureManifest.fixtures
+      .map(({ file }) => file)
+      .sort()
+    const corpusFiles = readdirSync(fixturesRoot)
+      .filter((file) => file.endsWith(".ttl"))
+      .sort()
+    expect(declaredFiles).toEqual(corpusFiles)
+  })
+
+  for (const fixture of fixtureManifest.fixtures) {
+    it(`${fixture.category} graph has its asserted verdict`, async () => {
+      const data = parseTurtle(resolve(fixturesRoot, fixture.file))
+      const report = await new SHACLValidator(shapes).validate(data)
+      expect(report.conforms).toBe(fixture.conforms)
+
+      const dataAndOntology = new Store([
+        ...ontology.getQuads(null, null, null, null),
+        ...data.getQuads(null, null, null, null),
+      ])
+      expect(findDisjointnessViolations(dataAndOntology).length === 0).toBe(
+        fixture.consistent,
+      )
+    })
+  }
+})


### PR DESCRIPTION
## Why

Formalize the Work Item lifecycle state space from `CONTEXT.md` as a machine-readable
ontology and validate it in CI without introducing RDF dependencies into runtime packages.

## What changed

- Added the `rfa:` Turtle ontology covering all operational Lifecycle Steps and terminal Work
  Item states, with SKOS labels and definitions.
- Added SHACL shapes for lifecycle vocabulary terms and Work Item current-state constraints.
- Added valid, invalid, missing-fact, and contradictory fixture graphs with pinned SHACL
  and semantic-consistency verdicts.
- Added the `lifecycle-model` Nx package with development-only RDF tooling.
- Added subclass and disjointness reasoning so inconsistent ontology axioms and
  contradictory fixtures fail validation, including a corrupted-axiom regression test.

## Verification

- `bunx nx test lifecycle-model --skip-nx-cache` — 12 tests passed
- `bunx nx run-many -t lint knip -p lifecycle-model --skip-nx-cache`
- `bunx biome check packages/lifecycle-model/test/ontology.test.ts ontology`
- `git diff --check`

## Limitations

Ontology reasoning and SHACL validation run only during development and CI; this change
intentionally adds no runtime RDF dependency.

Closes #641