### PR TITLE
fix(harness): use full viewport width on Kanban only

### DIFF
--- a/apps/harness/src/routes/__root.tsx
+++ b/apps/harness/src/routes/__root.tsx
@@ -11,6 +11,7 @@ import {
   Outlet,
   Scripts,
   createRootRouteWithContext,
+  useLocation,
 } from "@tanstack/react-router"
 import { TanStackRouterDevtools } from "@tanstack/react-router-devtools"
 import {
@@ -220,8 +221,19 @@ function KanbanNavIcon() {
 }
 
 function RootComponent() {
+  // Kanban needs the full viewport for six pipeline lanes; other routes keep
+  // the shared 88rem reading-width cap. Gutters stay on every route.
+  const pathname = useLocation({ select: (location) => location.pathname })
+  const isKanbanPage = pathname === "/kanban"
+  const shellClassName = [
+    "mx-auto min-h-screen w-full px-5 py-6 sm:px-8 lg:px-12",
+    isKanbanPage ? undefined : "max-w-[88rem]",
+  ]
+    .filter((part): part is string => part !== undefined)
+    .join(" ")
+
   return (
-    <div className="mx-auto min-h-screen w-full max-w-[88rem] px-5 py-6 sm:px-8 lg:px-12">
+    <div className={shellClassName}>
       <nav
         aria-label="Primary"
         className="mb-2 flex flex-wrap items-start gap-x-5 gap-y-3 border-b-2 border-ink pb-3"

--- a/apps/harness/src/styles.css
+++ b/apps/harness/src/styles.css
@@ -113,7 +113,6 @@
     --industrial-ink: #151515;
     --industrial-paper: #f4f1e8;
     --industrial-concrete: #dedbd2;
-    max-width: 100rem;
     margin-inline: auto;
   }
 

--- a/apps/harness/test/kanban-route.test.ts
+++ b/apps/harness/test/kanban-route.test.ts
@@ -5,6 +5,9 @@ import { describe, expect, test } from "bun:test"
 const kanbanSource = () =>
   readFileSync(join(import.meta.dir, "../src/routes/kanban.tsx"), "utf8")
 
+const rootSource = () =>
+  readFileSync(join(import.meta.dir, "../src/routes/__root.tsx"), "utf8")
+
 const stylesSource = () =>
   readFileSync(join(import.meta.dir, "../src/styles.css"), "utf8")
 
@@ -204,6 +207,35 @@ describe("/kanban route", () => {
     expect(desktopStyles).toContain(".job-ticket")
     expect(desktopStyles).toContain(".lane-switcher")
     expect(desktopStyles).toContain("display: none")
+  })
+
+  test("uses full viewport width only on /kanban while other routes keep 88rem", () => {
+    // Root shell is route-aware: drop max-w-[88rem] for Kanban only; gutters stay.
+    const root = rootSource()
+    const rootComponent = root.slice(root.indexOf("function RootComponent("))
+    expect(rootComponent).toContain("useLocation")
+    expect(rootComponent).toContain('pathname === "/kanban"')
+    // Shared gutters apply on every route (single base string, not duplicated).
+    expect(rootComponent).toContain(
+      "mx-auto min-h-screen w-full px-5 py-6 sm:px-8 lg:px-12",
+    )
+    // 88rem remains available for non-Kanban routes, gated by the Kanban check.
+    expect(rootComponent).toContain("max-w-[88rem]")
+    expect(rootComponent).toMatch(
+      /(?:isKanbanPage|pathname === "\/kanban")[\s\S]{0,200}max-w-\[88rem\]|max-w-\[88rem\][\s\S]{0,200}(?:isKanbanPage|pathname === "\/kanban")/,
+    )
+    // Cap is not a static always-on className on the wrapper.
+    expect(rootComponent).not.toMatch(/className="[^"]*max-w-\[88rem\][^"]*"/)
+
+    // industrial-shell must not re-impose a second width cap under Kanban.
+    const styles = stylesSource()
+    const shellBlock = styles.slice(
+      styles.indexOf(".industrial-shell {"),
+      styles.indexOf("}", styles.indexOf(".industrial-shell {")) + 1,
+    )
+    expect(shellBlock).toContain(".industrial-shell {")
+    expect(shellBlock).not.toContain("max-width: 100rem")
+    expect(shellBlock).not.toMatch(/max-width\s*:/)
   })
 
   test("uses a touch-scrollable repository row and three-column lane selector on mobile", () => {


### PR DESCRIPTION
## Why

The `/kanban` six-lane pipeline was squeezed by two nested max-width caps:
the shared root shell at `88rem` and `.industrial-shell` at `100rem`. On
desktop that forced avoidable chip/control wrapping and made tickets harder
to scan. Home and other routes should keep the constrained reading width.

## What changed

- Make the shared root layout in `apps/harness/src/routes/__root.tsx`
  route-aware via `useLocation`: drop `max-w-[88rem]` only when
  `pathname === "/kanban"`.
- Keep existing responsive gutters (`px-5` / `sm:px-8` / `lg:px-12`) on
  every route; compose shell classes from a single base plus a conditional
  `max-w-[88rem]` so gutters stay shared.
- Remove the redundant `max-width: 100rem` from `.industrial-shell` so the
  board can fill the route wrapper.
- Add source-level coverage that full-width is scoped to `/kanban`,
  non-Kanban routes retain the 88rem cap, and industrial-shell no longer
  re-caps width.
- Leave the six-column desktop pipeline, ticket/chip styling, and mobile
  single-lane selector (`900px`) unchanged.

## Verification

- `bunx nx test harness` (including `/kanban` full-width coverage)
- `bunx nx build harness`

## Notes

Coverage is source-level (consistent with existing harness layout tests),
not a browser layout assertion.

Closes #660