### PR TITLE
feat(lifecycle-model): generate state space from ontology

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -284,6 +284,10 @@
     "packages/lifecycle-model": {
       "name": "@ready-for-agent/lifecycle-model",
       "version": "0.0.1",
+      "dependencies": {
+        "effect": "^4.0.0-beta.97",
+        "tslib": "^2.3.0",
+      },
       "devDependencies": {
         "@types/n3": "^1.26.1",
         "n3": "^2.1.1",

--- a/packages/lifecycle-model/package.json
+++ b/packages/lifecycle-model/package.json
@@ -3,6 +3,22 @@
   "version": "0.0.1",
   "private": true,
   "type": "module",
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    "./package.json": "./package.json",
+    ".": {
+      "@ready-for-agent/source": "./src/index.ts",
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    }
+  },
+  "dependencies": {
+    "effect": "^4.0.0-beta.97",
+    "tslib": "^2.3.0"
+  },
   "devDependencies": {
     "@types/n3": "^1.26.1",
     "n3": "^2.1.1",

--- a/packages/lifecycle-model/project.json
+++ b/packages/lifecycle-model/project.json
@@ -1,21 +1,43 @@
 {
   "name": "lifecycle-model",
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
-  "sourceRoot": "packages/lifecycle-model/test",
+  "sourceRoot": "packages/lifecycle-model/src",
   "projectType": "library",
   "tags": [],
   "targets": {
-    "test": {
+    "generate": {
       "executor": "nx:run-commands",
       "options": {
         "cwd": "{projectRoot}",
-        "command": "bun test"
+        "command": "bun scripts/generate-lifecycle-state.ts"
+      },
+      "inputs": ["default", "{workspaceRoot}/ontology/rfa.ttl"],
+      "outputs": ["{projectRoot}/src/generated/work-item-state.ts"],
+      "cache": false
+    },
+    "check-generated": {
+      "executor": "nx:run-commands",
+      "options": {
+        "cwd": "{projectRoot}",
+        "command": "bun scripts/generate-lifecycle-state.ts --check"
+      },
+      "inputs": ["default", "{workspaceRoot}/ontology/rfa.ttl"],
+      "cache": true
+    },
+    "test": {
+      "executor": "nx:run-commands",
+      "dependsOn": ["check-generated"],
+      "options": {
+        "cwd": "{projectRoot}",
+        "command": "bun --conditions=@ready-for-agent/source test"
       },
       "inputs": [
         "default",
+        "^production",
         "{workspaceRoot}/CONTEXT.md",
         "{workspaceRoot}/ontology/**/*.ttl",
-        "{workspaceRoot}/ontology/fixtures/manifest.json"
+        "{workspaceRoot}/ontology/fixtures/manifest.json",
+        "{workspaceRoot}/packages/work-item-lifecycle/src/lib/types.ts"
       ],
       "cache": true
     }

--- a/packages/lifecycle-model/scripts/generate-lifecycle-state.ts
+++ b/packages/lifecycle-model/scripts/generate-lifecycle-state.ts
@@ -1,0 +1,133 @@
+import { mkdir, readFile, writeFile } from "node:fs/promises"
+import { dirname, resolve } from "node:path"
+import { DataFactory, Parser, Store, type Term } from "n3"
+
+const namespace = {
+  rdf: "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+  rfa: "https://ready-for-agent.dev/ontology/rfa#",
+  skos: "http://www.w3.org/2004/02/skos/core#",
+} as const
+
+const iri = (value: string) => DataFactory.namedNode(value)
+const term = (localName: string) => iri(`${namespace.rfa}${localName}`)
+
+const rdfType = iri(`${namespace.rdf}type`)
+const skosNotation = iri(`${namespace.skos}notation`)
+const operationalLifecycleStep = term("OperationalLifecycleStep")
+const terminalWorkItemState = term("TerminalWorkItemState")
+
+const packageRoot = resolve(import.meta.dir, "..")
+const ontologyPath = resolve(packageRoot, "../../ontology/rfa.ttl")
+const generatedPath = resolve(packageRoot, "src/generated/work-item-state.ts")
+
+const onlyNotation = (store: Store, subject: Term): string => {
+  const notations = store.getObjects(subject, skosNotation, null)
+  if (notations.length !== 1) {
+    throw new Error(
+      `${subject.value} must have exactly one skos:notation; found ${notations.length}`,
+    )
+  }
+
+  const notation = notations[0]
+  if (notation?.termType !== "Literal" || notation.value.length === 0) {
+    throw new Error(`${subject.value} must have a non-empty literal notation`)
+  }
+
+  return notation.value
+}
+
+const notationsForClass = (
+  store: Store,
+  classTerm: Term,
+): readonly string[] => {
+  const values = store
+    .getSubjects(rdfType, classTerm, null)
+    .map((subject) => onlyNotation(store, subject))
+    .sort()
+
+  if (values.length === 0) {
+    throw new Error(`No lifecycle terms found for ${classTerm.value}`)
+  }
+
+  const duplicate = values.find((value, index) => value === values[index - 1])
+  if (duplicate !== undefined) {
+    throw new Error(`Duplicate lifecycle notation: ${duplicate}`)
+  }
+
+  return values
+}
+
+const renderTuple = (name: string, values: readonly string[]) => `\
+export const ${name} = [
+${values.map((value) => `  ${JSON.stringify(value)},`).join("\n")}
+] as const
+`
+
+const renderGeneratedSource = (
+  operationalSteps: readonly string[],
+  terminalStates: readonly string[],
+) => `\
+// This file is generated from ontology/rfa.ttl.
+// Run \`bunx nx run lifecycle-model:generate\` to update it.
+
+import { Schema } from "effect"
+
+${renderTuple("OPERATIONAL_LIFECYCLE_STEPS", operationalSteps)}
+export const OperationalLifecycleStep = Schema.Literals(
+  OPERATIONAL_LIFECYCLE_STEPS,
+)
+export type OperationalLifecycleStep =
+  typeof OperationalLifecycleStep.Type
+
+${renderTuple("TERMINAL_WORK_ITEM_STATES", terminalStates)}
+export const TerminalWorkItemState = Schema.Literals(
+  TERMINAL_WORK_ITEM_STATES,
+)
+export type TerminalWorkItemState = typeof TerminalWorkItemState.Type
+
+export const WORK_ITEM_STATES = [
+  ...OPERATIONAL_LIFECYCLE_STEPS,
+  ...TERMINAL_WORK_ITEM_STATES,
+] as const
+
+export const WorkItemState = Schema.Literals(WORK_ITEM_STATES)
+export type WorkItemState = typeof WorkItemState.Type
+`
+
+const generate = async () => {
+  const source = await readFile(ontologyPath, "utf8")
+  const quads = new Parser({
+    baseIRI: `file://${ontologyPath}`,
+    format: "Turtle",
+  }).parse(source)
+  const ontology = new Store(quads)
+
+  return renderGeneratedSource(
+    notationsForClass(ontology, operationalLifecycleStep),
+    notationsForClass(ontology, terminalWorkItemState),
+  )
+}
+
+const check = process.argv.slice(2).includes("--check")
+const unknownArguments = process.argv
+  .slice(2)
+  .filter((argument) => argument !== "--check")
+
+if (unknownArguments.length > 0) {
+  throw new Error(`Unknown arguments: ${unknownArguments.join(", ")}`)
+}
+
+const generatedSource = await generate()
+
+if (check) {
+  const checkedInSource = await readFile(generatedPath, "utf8").catch(() => "")
+  if (checkedInSource !== generatedSource) {
+    console.error(
+      "Generated lifecycle state is stale. Run `bunx nx run lifecycle-model:generate`.",
+    )
+    process.exitCode = 1
+  }
+} else {
+  await mkdir(dirname(generatedPath), { recursive: true })
+  await writeFile(generatedPath, generatedSource)
+}

--- a/packages/lifecycle-model/src/generated/work-item-state.ts
+++ b/packages/lifecycle-model/src/generated/work-item-state.ts
@@ -1,0 +1,49 @@
+// This file is generated from ontology/rfa.ttl.
+// Run `bunx nx run lifecycle-model:generate` to update it.
+
+import { Schema } from "effect"
+
+export const OPERATIONAL_LIFECYCLE_STEPS = [
+  "assess_changes",
+  "close_issue",
+  "commit",
+  "create_pr",
+  "create_worktree",
+  "decide_pr_merge",
+  "implement",
+  "install_dependencies",
+  "investigate_pr_status_checks",
+  "local_cleanup",
+  "mark_pr_ready_for_review",
+  "merge_pr",
+  "pre_commit",
+  "resolve_pr_merge_conflict",
+  "review",
+  "watch_pr_status_checks",
+] as const
+
+export const OperationalLifecycleStep = Schema.Literals(
+  OPERATIONAL_LIFECYCLE_STEPS,
+)
+export type OperationalLifecycleStep =
+  typeof OperationalLifecycleStep.Type
+
+export const TERMINAL_WORK_ITEM_STATES = [
+  "abandoned",
+  "complete",
+  "failed",
+  "needs_human",
+] as const
+
+export const TerminalWorkItemState = Schema.Literals(
+  TERMINAL_WORK_ITEM_STATES,
+)
+export type TerminalWorkItemState = typeof TerminalWorkItemState.Type
+
+export const WORK_ITEM_STATES = [
+  ...OPERATIONAL_LIFECYCLE_STEPS,
+  ...TERMINAL_WORK_ITEM_STATES,
+] as const
+
+export const WorkItemState = Schema.Literals(WORK_ITEM_STATES)
+export type WorkItemState = typeof WorkItemState.Type

--- a/packages/lifecycle-model/src/index.ts
+++ b/packages/lifecycle-model/src/index.ts
@@ -1,0 +1,1 @@
+export * from "./generated/work-item-state.js"

--- a/packages/lifecycle-model/test/generated-state.test.ts
+++ b/packages/lifecycle-model/test/generated-state.test.ts
@@ -1,0 +1,44 @@
+import { resolve } from "node:path"
+import {
+  OPERATIONAL_LIFECYCLE_STEPS,
+  OperationalLifecycleStep,
+  TERMINAL_WORK_ITEM_STATES,
+  TerminalWorkItemState,
+  WORK_ITEM_STATES,
+  WorkItemState,
+} from "../src/index.js"
+import { describe, expect, it } from "bun:test"
+
+const existingDeclarationsPath = resolve(
+  import.meta.dir,
+  "../../work-item-lifecycle/src/lib/types.ts",
+)
+const {
+  OperationalLifecycleStep: ExistingOperationalLifecycleStep,
+  TerminalWorkItemState: ExistingTerminalWorkItemState,
+} = await import(existingDeclarationsPath)
+
+const sorted = (values: readonly string[]) => [...values].sort()
+
+describe("generated lifecycle state", () => {
+  it("matches the existing hand-written state space", () => {
+    expect(OPERATIONAL_LIFECYCLE_STEPS).toEqual(
+      sorted(ExistingOperationalLifecycleStep.literals),
+    )
+    expect(TERMINAL_WORK_ITEM_STATES).toEqual(
+      sorted(ExistingTerminalWorkItemState.literals),
+    )
+    expect(WORK_ITEM_STATES).toEqual([
+      ...OPERATIONAL_LIFECYCLE_STEPS,
+      ...TERMINAL_WORK_ITEM_STATES,
+    ])
+  })
+
+  it("exports schemas backed by the generated typed arrays", () => {
+    expect(OperationalLifecycleStep.literals).toEqual(
+      OPERATIONAL_LIFECYCLE_STEPS,
+    )
+    expect(TerminalWorkItemState.literals).toEqual(TERMINAL_WORK_ITEM_STATES)
+    expect(WorkItemState.literals).toEqual(WORK_ITEM_STATES)
+  })
+})

--- a/packages/lifecycle-model/tsconfig.json
+++ b/packages/lifecycle-model/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ]
+}

--- a/packages/lifecycle-model/tsconfig.lib.json
+++ b/packages/lifecycle-model/tsconfig.lib.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "tsBuildInfoFile": "dist/tsconfig.lib.tsbuildinfo",
+    "emitDeclarationOnly": false,
+    "forceConsistentCasingInFileNames": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"],
+  "references": []
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -71,6 +71,9 @@
     },
     {
       "path": "./packages/gitlab-service"
+    },
+    {
+      "path": "./packages/lifecycle-model"
     }
   ]
 }


### PR DESCRIPTION
## Why

The Work Item state space was maintained separately from the ontology, allowing runtime declarations
and the domain model to drift. This establishes the generated `lifecycle-model` seam required by
#643 while leaving current consumers unchanged.

## What changed

- Added a generator that reads lifecycle classes and `skos:notation` values from
  `ontology/rfa.ttl`.
- Checked in deterministically sorted operational-step, terminal-state, and combined Work Item state
  tuples with matching Effect Schema literal unions and inferred types.
- Exposed the generated artifacts through the package entrypoint and added its build configuration.
- Added Nx `generate` and `check-generated` targets, with the freshness check running as part of the
  package test target used by CI.
- Added parity coverage against the existing hand-written lifecycle declarations, which remain in
  place for the later consumer-migration ticket.

## Verification

- `bun nx affected -t lint knip test typecheck --base=origin/main` — passed across 30 affected
  projects and 131 tasks.
- `bunx nx run lifecycle-model:build` — passed.
- Lifecycle-model suite — 135 tests passed.
- Confirmed a deliberately stale generated file fails check mode.
- Confirmed two consecutive generation runs produce identical output.

## Limitations

Consumer packages are intentionally not rewired in this change; their existing declarations remain
until the follow-up migration.

Closes #643