### PR TITLE
refactor(lifecycle-model): derive consumer state spaces

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -149,6 +149,7 @@
       "name": "@ready-for-agent/db-schema",
       "version": "0.0.1",
       "dependencies": {
+        "@ready-for-agent/lifecycle-model": "workspace:*",
         "drizzle-orm": "1.0.0-rc.4-5d5b77c",
         "tslib": "^2.3.0",
         "ulidx": "^2.4.1",
@@ -228,6 +229,9 @@
     "packages/graphql-schema": {
       "name": "@ready-for-agent/graphql-schema",
       "version": "0.0.1",
+      "devDependencies": {
+        "@ready-for-agent/lifecycle-model": "workspace:*",
+      },
     },
     "packages/grok": {
       "name": "@ready-for-agent/grok",
@@ -393,6 +397,7 @@
         "@ready-for-agent/github-service": "workspace:*",
         "@ready-for-agent/gitlab-service": "workspace:*",
         "@ready-for-agent/keymaxxer-service": "workspace:*",
+        "@ready-for-agent/lifecycle-model": "workspace:*",
         "@ready-for-agent/queue-service": "workspace:*",
         "effect": "^4.0.0-beta.97",
         "tslib": "^2.3.0",

--- a/packages/db-schema/package.json
+++ b/packages/db-schema/package.json
@@ -23,6 +23,7 @@
     "name": "db-schema"
   },
   "dependencies": {
+    "@ready-for-agent/lifecycle-model": "workspace:*",
     "drizzle-orm": "1.0.0-rc.4-5d5b77c",
     "tslib": "^2.3.0",
     "ulidx": "^2.4.1"

--- a/packages/db-schema/src/schema.ts
+++ b/packages/db-schema/src/schema.ts
@@ -7,6 +7,10 @@ import {
   uniqueIndex,
 } from "drizzle-orm/sqlite-core"
 import { ulid } from "ulidx"
+import {
+  OPERATIONAL_LIFECYCLE_STEPS,
+  WORK_ITEM_STATES,
+} from "@ready-for-agent/lifecycle-model"
 
 export const repository = snakeCase.table(
   "repository",
@@ -231,30 +235,7 @@ export const workItem = snakeCase.table(
     pullRequestNumber: integer(),
     /** Active Agent Backend captured at Work Item creation (provenance). */
     agentBackend: text().notNull().default("opencode"),
-    state: text({
-      enum: [
-        "create_worktree",
-        "install_dependencies",
-        "implement",
-        "assess_changes",
-        "pre_commit",
-        "review",
-        "commit",
-        "create_pr",
-        "watch_pr_status_checks",
-        "resolve_pr_merge_conflict",
-        "investigate_pr_status_checks",
-        "mark_pr_ready_for_review",
-        "decide_pr_merge",
-        "merge_pr",
-        "close_issue",
-        "local_cleanup",
-        "complete",
-        "failed",
-        "abandoned",
-        "needs_human",
-      ],
-    }).notNull(),
+    state: text({ enum: WORK_ITEM_STATES }).notNull(),
     stateReadyAt: integer({ mode: "number" }).notNull(),
     paused: integer({ mode: "boolean" }).notNull().default(false),
     /**
@@ -283,26 +264,7 @@ export const workItem = snakeCase.table(
      * When set, successful advancement into this Lifecycle Step pauses the Work
      * Item (no Step Run enqueued) so the operator can inspect local work.
      */
-    pauseBeforeStep: text({
-      enum: [
-        "create_worktree",
-        "install_dependencies",
-        "implement",
-        "assess_changes",
-        "pre_commit",
-        "review",
-        "commit",
-        "create_pr",
-        "watch_pr_status_checks",
-        "resolve_pr_merge_conflict",
-        "investigate_pr_status_checks",
-        "mark_pr_ready_for_review",
-        "decide_pr_merge",
-        "merge_pr",
-        "close_issue",
-        "local_cleanup",
-      ],
-    }),
+    pauseBeforeStep: text({ enum: OPERATIONAL_LIFECYCLE_STEPS }),
     worktreePath: text(),
     /**
      * Exact commit OID at Create Worktree success; Assess Changes baseline.
@@ -381,26 +343,7 @@ export const stepRun = snakeCase.table(
     workItemId: text()
       .notNull()
       .references(() => workItem.id, { onDelete: "cascade" }),
-    step: text({
-      enum: [
-        "create_worktree",
-        "install_dependencies",
-        "implement",
-        "assess_changes",
-        "pre_commit",
-        "review",
-        "commit",
-        "create_pr",
-        "watch_pr_status_checks",
-        "resolve_pr_merge_conflict",
-        "investigate_pr_status_checks",
-        "mark_pr_ready_for_review",
-        "decide_pr_merge",
-        "merge_pr",
-        "close_issue",
-        "local_cleanup",
-      ],
-    }).notNull(),
+    step: text({ enum: OPERATIONAL_LIFECYCLE_STEPS }).notNull(),
     status: text({
       enum: [
         "queued",

--- a/packages/db-schema/tsconfig.lib.json
+++ b/packages/db-schema/tsconfig.lib.json
@@ -9,5 +9,9 @@
     "types": ["node"]
   },
   "include": ["src/**/*.ts"],
-  "references": []
+  "references": [
+    {
+      "path": "../lifecycle-model/tsconfig.lib.json"
+    }
+  ]
 }

--- a/packages/graphql-schema/package.json
+++ b/packages/graphql-schema/package.json
@@ -18,5 +18,8 @@
   },
   "scripts": {
     "typecheck": "tsc --noEmit -p tsconfig.lib.json"
+  },
+  "devDependencies": {
+    "@ready-for-agent/lifecycle-model": "workspace:*"
   }
 }

--- a/packages/graphql-schema/project.json
+++ b/packages/graphql-schema/project.json
@@ -7,15 +7,24 @@
   "targets": {
     "generate": {
       "executor": "nx:run-commands",
+      "dependsOn": ["^build"],
       "options": {
         "cwd": "{projectRoot}",
         "command": "bun scripts/generate-type-defs.ts"
       },
       "inputs": [
-        "{projectRoot}/schema.graphql",
-        "{projectRoot}/scripts/generate-type-defs.ts"
+        "^production",
+        "{projectRoot}/schema.template.graphql",
+        "{projectRoot}/scripts/generate-type-defs.ts",
+        {
+          "dependentTasksOutputFiles": "**/*",
+          "transitive": false
+        }
       ],
-      "outputs": ["{projectRoot}/src/type-defs.gen.ts"],
+      "outputs": [
+        "{projectRoot}/schema.graphql",
+        "{projectRoot}/src/type-defs.gen.ts"
+      ],
       "cache": true
     },
     "build": {
@@ -26,7 +35,7 @@
       "inputs": [
         "default",
         "^production",
-        "{projectRoot}/schema.graphql",
+        "{projectRoot}/schema.template.graphql",
         {
           "dependentTasksOutputFiles": "**/*",
           "transitive": false
@@ -38,7 +47,7 @@
       "inputs": [
         "default",
         "^production",
-        "{projectRoot}/schema.graphql",
+        "{projectRoot}/schema.template.graphql",
         {
           "dependentTasksOutputFiles": "**/*",
           "transitive": false

--- a/packages/graphql-schema/schema.template.graphql
+++ b/packages/graphql-schema/schema.template.graphql
@@ -1,6 +1,3 @@
-# This file is generated from schema.template.graphql and lifecycle-model.
-# Run `bunx nx run graphql-schema:generate` to update it.
-
 type Query {
   health: Boolean!
   """
@@ -314,26 +311,7 @@ type RefreshJob {
 }
 
 enum WorkItemState {
-  ASSESS_CHANGES
-  CLOSE_ISSUE
-  COMMIT
-  CREATE_PR
-  CREATE_WORKTREE
-  DECIDE_PR_MERGE
-  IMPLEMENT
-  INSTALL_DEPENDENCIES
-  INVESTIGATE_PR_STATUS_CHECKS
-  LOCAL_CLEANUP
-  MARK_PR_READY_FOR_REVIEW
-  MERGE_PR
-  PRE_COMMIT
-  RESOLVE_PR_MERGE_CONFLICT
-  REVIEW
-  WATCH_PR_STATUS_CHECKS
-  ABANDONED
-  COMPLETE
-  FAILED
-  NEEDS_HUMAN
+  WORK_ITEM_STATE_VALUES
 }
 
 enum WorkItemStatus {

--- a/packages/graphql-schema/scripts/generate-type-defs.ts
+++ b/packages/graphql-schema/scripts/generate-type-defs.ts
@@ -2,12 +2,39 @@
 import { readFileSync, writeFileSync } from "node:fs"
 import { dirname, join, resolve } from "node:path"
 import { fileURLToPath } from "node:url"
+import { WORK_ITEM_STATES } from "@ready-for-agent/lifecycle-model"
 
 const packageRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..")
+const schemaTemplatePath = join(packageRoot, "schema.template.graphql")
 const schemaPath = join(packageRoot, "schema.graphql")
 const outFile = join(packageRoot, "src/type-defs.gen.ts")
-const schema = readFileSync(schemaPath, "utf8")
+const schemaTemplate = readFileSync(schemaTemplatePath, "utf8")
+const workItemStateEnumPlaceholder = `enum WorkItemState {
+  WORK_ITEM_STATE_VALUES
+}`
 
+if (
+  schemaTemplate.indexOf(workItemStateEnumPlaceholder) === -1 ||
+  schemaTemplate.indexOf(workItemStateEnumPlaceholder) !==
+    schemaTemplate.lastIndexOf(workItemStateEnumPlaceholder)
+) {
+  throw new Error(
+    "schema.template.graphql must contain exactly one WorkItemState placeholder enum",
+  )
+}
+
+const workItemStateValues = WORK_ITEM_STATES.map(
+  (state) => `  ${state.toUpperCase()}`,
+).join("\n")
+const workItemStateEnum = `enum WorkItemState {
+${workItemStateValues}
+}`
+const schema = `# This file is generated from schema.template.graphql and lifecycle-model.
+# Run \`bunx nx run graphql-schema:generate\` to update it.
+
+${schemaTemplate.replace(workItemStateEnumPlaceholder, workItemStateEnum)}`
+
+writeFileSync(schemaPath, schema)
 writeFileSync(
   outFile,
   `/** Generated from schema.graphql — do not edit. */

--- a/packages/graphql-schema/tsconfig.lib.json
+++ b/packages/graphql-schema/tsconfig.lib.json
@@ -8,5 +8,10 @@
     "forceConsistentCasingInFileNames": true,
     "types": ["node"]
   },
-  "include": ["src/**/*.ts"]
+  "include": ["src/**/*.ts"],
+  "references": [
+    {
+      "path": "../lifecycle-model/tsconfig.lib.json"
+    }
+  ]
 }

--- a/packages/lifecycle-model/project.json
+++ b/packages/lifecycle-model/project.json
@@ -36,8 +36,7 @@
         "^production",
         "{workspaceRoot}/CONTEXT.md",
         "{workspaceRoot}/ontology/**/*.ttl",
-        "{workspaceRoot}/ontology/fixtures/manifest.json",
-        "{workspaceRoot}/packages/work-item-lifecycle/src/lib/types.ts"
+        "{workspaceRoot}/ontology/fixtures/manifest.json"
       ],
       "cache": true
     }

--- a/packages/lifecycle-model/test/generated-state.test.ts
+++ b/packages/lifecycle-model/test/generated-state.test.ts
@@ -1,4 +1,3 @@
-import { resolve } from "node:path"
 import {
   OPERATIONAL_LIFECYCLE_STEPS,
   OperationalLifecycleStep,
@@ -9,25 +8,8 @@ import {
 } from "../src/index.js"
 import { describe, expect, it } from "bun:test"
 
-const existingDeclarationsPath = resolve(
-  import.meta.dir,
-  "../../work-item-lifecycle/src/lib/types.ts",
-)
-const {
-  OperationalLifecycleStep: ExistingOperationalLifecycleStep,
-  TerminalWorkItemState: ExistingTerminalWorkItemState,
-} = await import(existingDeclarationsPath)
-
-const sorted = (values: readonly string[]) => [...values].sort()
-
 describe("generated lifecycle state", () => {
-  it("matches the existing hand-written state space", () => {
-    expect(OPERATIONAL_LIFECYCLE_STEPS).toEqual(
-      sorted(ExistingOperationalLifecycleStep.literals),
-    )
-    expect(TERMINAL_WORK_ITEM_STATES).toEqual(
-      sorted(ExistingTerminalWorkItemState.literals),
-    )
+  it("composes the complete state space from operational and terminal states", () => {
     expect(WORK_ITEM_STATES).toEqual([
       ...OPERATIONAL_LIFECYCLE_STEPS,
       ...TERMINAL_WORK_ITEM_STATES,

--- a/packages/work-item-lifecycle/package.json
+++ b/packages/work-item-lifecycle/package.json
@@ -27,6 +27,7 @@
     "@ready-for-agent/github-service": "workspace:*",
     "@ready-for-agent/gitlab-service": "workspace:*",
     "@ready-for-agent/keymaxxer-service": "workspace:*",
+    "@ready-for-agent/lifecycle-model": "workspace:*",
     "@ready-for-agent/queue-service": "workspace:*",
     "effect": "^4.0.0-beta.97",
     "tslib": "^2.3.0",

--- a/packages/work-item-lifecycle/src/lib/types.ts
+++ b/packages/work-item-lifecycle/src/lib/types.ts
@@ -1,11 +1,24 @@
 import { Duration, Schema } from "effect"
 import { ulid } from "ulidx"
 import {
+  OperationalLifecycleStep,
+  TERMINAL_WORK_ITEM_STATES,
+  TerminalWorkItemState,
+  WorkItemState,
+} from "@ready-for-agent/lifecycle-model"
+import {
   JOBS_COMPLETED_WINDOW_HOURS,
   JOBS_COMPLETED_WINDOW_MS,
 } from "./jobs-completed-window.js"
 
-export { JOBS_COMPLETED_WINDOW_HOURS, JOBS_COMPLETED_WINDOW_MS }
+export {
+  JOBS_COMPLETED_WINDOW_HOURS,
+  JOBS_COMPLETED_WINDOW_MS,
+  OperationalLifecycleStep,
+  TERMINAL_WORK_ITEM_STATES,
+  TerminalWorkItemState,
+  WorkItemState,
+}
 
 export const WorkItemId = Schema.String.pipe(
   Schema.check(Schema.isPattern(/^wi-[0-9A-HJKMNP-TV-Z]{26}$/)),
@@ -22,40 +35,6 @@ export const StepRunId = Schema.String.pipe(
 export type StepRunId = typeof StepRunId.Type
 
 export const makeStepRunId = (): StepRunId => StepRunId.make(`srun-${ulid()}`)
-
-export const OperationalLifecycleStep = Schema.Literals([
-  "create_worktree",
-  "install_dependencies",
-  "implement",
-  "assess_changes",
-  "pre_commit",
-  "review",
-  "commit",
-  "create_pr",
-  "watch_pr_status_checks",
-  "resolve_pr_merge_conflict",
-  "investigate_pr_status_checks",
-  "mark_pr_ready_for_review",
-  "decide_pr_merge",
-  "merge_pr",
-  "close_issue",
-  "local_cleanup",
-])
-export type OperationalLifecycleStep = typeof OperationalLifecycleStep.Type
-
-export const TerminalWorkItemState = Schema.Literals([
-  "complete",
-  "failed",
-  "abandoned",
-  "needs_human",
-])
-export type TerminalWorkItemState = typeof TerminalWorkItemState.Type
-
-export const WorkItemState = Schema.Union([
-  OperationalLifecycleStep,
-  TerminalWorkItemState,
-])
-export type WorkItemState = typeof WorkItemState.Type
 
 export const StepRunStatus = Schema.Literals([
   "queued",
@@ -190,8 +169,6 @@ export const WorkItemStepJob = Schema.TaggedStruct("work-item-step", {
   stepRunId: StepRunId,
 })
 export type WorkItemStepJob = typeof WorkItemStepJob.Type
-
-export const TERMINAL_WORK_ITEM_STATES = TerminalWorkItemState.literals
 
 export const isTerminalWorkItemState = (
   state: WorkItemState,

--- a/packages/work-item-lifecycle/tsconfig.lib.json
+++ b/packages/work-item-lifecycle/tsconfig.lib.json
@@ -33,6 +33,9 @@
     },
     {
       "path": "../db/tsconfig.lib.json"
+    },
+    {
+      "path": "../lifecycle-model/tsconfig.lib.json"
     }
   ]
 }


### PR DESCRIPTION
## Why

Work Item states and lifecycle steps were repeated across the database schema, lifecycle package,
and GraphQL SDL, allowing those declarations to drift from the ontology-generated lifecycle model.

## What changed

- Derive the three Drizzle state/step enums from `WORK_ITEM_STATES` and
  `OPERATIONAL_LIFECYCLE_STEPS`.
- Re-export Work Item state, operational step, and terminal-state schemas and types from
  `lifecycle-model` instead of declaring local literal unions.
- Generate the GraphQL `WorkItemState` enum from the same model through a guarded SDL template.
- Retire the temporary generated-versus-handwritten equivalence test and update package,
  TypeScript, Nx, and lockfile dependencies.

This is a source-of-truth consolidation only; it does not change lifecycle behavior or require a
database migration.

## Verification

- Uncached typechecks for db-schema, db-service, work-item-lifecycle, graphql-schema,
  graphql-api, and harness.
- Uncached tests for db, db-service, lifecycle-model, work-item-lifecycle, graphql-api, and harness.
- Full affected lint and Knip checks.
- Deterministic GraphQL regeneration and lifecycle generated-code validation.
- Pre-commit hook and review pass clean.

Closes #645