### PR TITLE
feat(lifecycle-model): generate shared lifecycle predicates

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -254,6 +254,7 @@
         "@ready-for-agent/db-service": "workspace:*",
         "@ready-for-agent/github-service": "workspace:*",
         "@ready-for-agent/gitlab-service": "workspace:*",
+        "@ready-for-agent/lifecycle-model": "workspace:*",
         "effect": "^4.0.0-beta.97",
         "tslib": "^2.3.0",
       },

--- a/ontology/rfa.ttl
+++ b/ontology/rfa.ttl
@@ -14,7 +14,7 @@
     "The Ready for Agent domain vocabulary and Work Item lifecycle model."@en ;
   dcterms:source
     <https://github.com/berenddeboer/ready-for-agent/blob/main/CONTEXT.md> ;
-  owl:versionInfo "0.3.0" .
+  owl:versionInfo "0.4.0" .
 
 rfa:ContextTerm
   a owl:Class ;
@@ -55,6 +55,143 @@ rfa:currentState
   rdfs:label "current state"@en ;
   skos:definition
     "The single operational Lifecycle Step or terminal state currently held by a Work Item."@en .
+
+rfa:isCurrentIssue
+  a owl:DatatypeProperty ;
+  rdfs:domain rfa:Issue ;
+  rdfs:range xsd:boolean ;
+  rdfs:label "is current Issue"@en ;
+  skos:definition
+    "True when the Issue is present in the current Issue store projection, whose contents are Relevant Issues."@en .
+
+rfa:isOpenIssue
+  a owl:DatatypeProperty ;
+  rdfs:domain rfa:Issue ;
+  rdfs:range xsd:boolean .
+
+rfa:hasChildren
+  a owl:DatatypeProperty ;
+  rdfs:domain rfa:Issue ;
+  rdfs:range xsd:boolean .
+
+rfa:listedBlockerCount
+  a owl:DatatypeProperty ;
+  rdfs:domain rfa:Issue ;
+  rdfs:range xsd:nonNegativeInteger .
+
+rfa:unfinishedWorkItemCount
+  a owl:DatatypeProperty ;
+  rdfs:domain rfa:Issue ;
+  rdfs:range xsd:nonNegativeInteger .
+
+rfa:isInSupportedIssueHierarchy
+  a owl:DatatypeProperty ;
+  rdfs:domain rfa:Issue ;
+  rdfs:range xsd:boolean .
+
+rfa:satisfiesClosingPullRequestCondition
+  a owl:DatatypeProperty ;
+  rdfs:domain rfa:Issue ;
+  rdfs:range xsd:boolean ;
+  rdfs:label "satisfies closing Pull Request condition"@en ;
+  skos:definition
+    "True when the Issue has no active Issue-closing Pull Request, or at least one active Issue-closing Pull Request is an owned Work Item PR."@en .
+
+rfa:isIssueAuthorIncluded
+  a owl:DatatypeProperty ;
+  rdfs:domain rfa:Issue ;
+  rdfs:range xsd:boolean .
+
+# Code generation derives executable matchers for these five classes. Each
+# class has one equivalent-class definition and no second axiom.
+rfa:LeafIssue
+  owl:equivalentClass [
+    owl:intersectionOf (
+      rfa:Issue
+      [
+        a owl:Restriction ;
+        owl:onProperty rfa:hasChildren ;
+        owl:hasValue false
+      ]
+    )
+  ] .
+
+rfa:RelevantIssue
+  owl:equivalentClass [
+    owl:intersectionOf (
+      rfa:ReadyLabeledIssue
+      [
+        a owl:Restriction ;
+        owl:onProperty rfa:isInSupportedIssueHierarchy ;
+        owl:hasValue true
+      ]
+      [
+        a owl:Restriction ;
+        owl:onProperty rfa:satisfiesClosingPullRequestCondition ;
+        owl:hasValue true
+      ]
+      [
+        a owl:Restriction ;
+        owl:onProperty rfa:isIssueAuthorIncluded ;
+        owl:hasValue true
+      ]
+    )
+  ] .
+
+rfa:ImplementableIssue
+  owl:equivalentClass [
+    owl:intersectionOf (
+      rfa:LeafIssue
+      [
+        a owl:Restriction ;
+        owl:onProperty rfa:isCurrentIssue ;
+        owl:hasValue true
+      ]
+      [
+        a owl:Restriction ;
+        owl:onProperty rfa:isOpenIssue ;
+        owl:hasValue true
+      ]
+      [
+        a owl:Restriction ;
+        owl:onProperty rfa:listedBlockerCount ;
+        owl:hasValue 0
+      ]
+    )
+  ] .
+
+rfa:ActionableIssue
+  owl:equivalentClass [
+    owl:intersectionOf (
+      rfa:ImplementableIssue
+      [
+        a owl:Restriction ;
+        owl:onProperty rfa:unfinishedWorkItemCount ;
+        owl:hasValue 0
+      ]
+    )
+  ] .
+
+rfa:UnfinishedWorkItem
+  a owl:Class ;
+  owl:equivalentClass [
+    owl:intersectionOf (
+      rfa:WorkItem
+      [
+        a owl:Restriction ;
+        owl:onProperty rfa:currentState ;
+        owl:someValuesFrom [
+          owl:complementOf [
+            owl:unionOf (
+              rfa:Complete
+              rfa:Failed
+              rfa:Abandoned
+            )
+          ]
+        ]
+      ]
+    )
+  ] .
 
 rfa:Transition
   a owl:Class ;

--- a/packages/issue-reconciler/package.json
+++ b/packages/issue-reconciler/package.json
@@ -19,6 +19,7 @@
     "@ready-for-agent/db-service": "workspace:*",
     "@ready-for-agent/github-service": "workspace:*",
     "@ready-for-agent/gitlab-service": "workspace:*",
+    "@ready-for-agent/lifecycle-model": "workspace:*",
     "effect": "^4.0.0-beta.97",
     "tslib": "^2.3.0"
   },

--- a/packages/issue-reconciler/src/lib/issue-reconciler.ts
+++ b/packages/issue-reconciler/src/lib/issue-reconciler.ts
@@ -17,6 +17,7 @@ import {
   type GitLabRequestError,
   GitLabService,
 } from "@ready-for-agent/gitlab-service"
+import { evaluateRelevantIssue } from "@ready-for-agent/lifecycle-model"
 
 export const ReconciliationSummary = Schema.Struct({
   fetched: Schema.Int.pipe(Schema.check(Schema.isGreaterThanOrEqualTo(0))),
@@ -88,57 +89,6 @@ const matches = (local: IssueRecord, remote: ReadyLabeledIssue): boolean =>
     ),
   )
 
-const isActiveClosingPullRequest = (
-  pullRequest: ReadyLabeledIssue["closingPullRequests"][number],
-  forge: RepositoryRecord["forge"],
-): boolean =>
-  pullRequest.state === "MERGED" ||
-  (pullRequest.state === "OPEN" && (forge === "gitlab" || !pullRequest.isDraft))
-
-const matchesOperatorAuthor = (
-  issueAuthor: string | null,
-  operatorLogin: string,
-): boolean =>
-  issueAuthor !== null &&
-  issueAuthor.toLowerCase() === operatorLogin.toLowerCase()
-
-const isRelevant = (
-  issue: ReadyLabeledIssue,
-  forge: RepositoryRecord["forge"],
-  repositoryName: string,
-  workItemPullRequestNumbers: ReadonlySet<number>,
-  authorScope:
-    | { readonly includeAll: true }
-    | { readonly includeAll: false; readonly operatorLogin: string },
-): boolean => {
-  const activeClosingPullRequests = issue.closingPullRequests.filter(
-    (pullRequest) => isActiveClosingPullRequest(pullRequest, forge),
-  )
-  const supportedStructure = issue.hierarchySupported
-    ? issue.parent === null
-      ? issue.state === "OPEN"
-      : issue.parent.state === "OPEN" && issue.parent.isReadyLabeled
-    : forge === "gitlab" &&
-      issue.state === "OPEN" &&
-      issue.parent === null &&
-      !issue.hasChildren
-  const structureAndClosingPrs =
-    supportedStructure &&
-    (activeClosingPullRequests.length === 0 ||
-      activeClosingPullRequests.some(
-        (pullRequest) =>
-          pullRequest.repository.toLowerCase() === repositoryName &&
-          workItemPullRequestNumbers.has(pullRequest.number),
-      ))
-  if (!structureAndClosingPrs) {
-    return false
-  }
-  if (authorScope.includeAll) {
-    return true
-  }
-  return matchesOperatorAuthor(issue.author, authorScope.operatorLogin)
-}
-
 export const IssueReconcilerLive = Layer.effect(
   IssueReconciler,
   Effect.gen(function* () {
@@ -185,14 +135,15 @@ export const IssueReconcilerLive = Layer.effect(
       }
       const remoteByNumber = new Map(
         remoteIssues
-          .filter((issue) =>
-            isRelevant(
-              issue,
-              repository.forge,
-              repositoryName,
-              workItemPullRequestsByIssue.get(issue.number) ?? new Set(),
-              authorScope,
-            ),
+          .filter(
+            (issue) =>
+              evaluateRelevantIssue(issue, {
+                forge: repository.forge,
+                repositoryName,
+                workItemPullRequestNumbers:
+                  workItemPullRequestsByIssue.get(issue.number) ?? new Set(),
+                authorScope,
+              })._tag === "match",
           )
           .map((issue) => [issue.number, issue]),
       )

--- a/packages/issue-reconciler/tsconfig.lib.json
+++ b/packages/issue-reconciler/tsconfig.lib.json
@@ -11,10 +11,13 @@
   "include": ["src/**/*.ts"],
   "references": [
     {
-      "path": "../github-service/tsconfig.lib.json"
+      "path": "../lifecycle-model/tsconfig.lib.json"
     },
     {
       "path": "../gitlab-service/tsconfig.lib.json"
+    },
+    {
+      "path": "../github-service/tsconfig.lib.json"
     },
     {
       "path": "../db-service/tsconfig.lib.json"

--- a/packages/lifecycle-model/project.json
+++ b/packages/lifecycle-model/project.json
@@ -12,7 +12,10 @@
         "command": "bun scripts/generate-lifecycle-state.ts"
       },
       "inputs": ["default", "{workspaceRoot}/ontology/rfa.ttl"],
-      "outputs": ["{projectRoot}/src/generated/work-item-state.ts"],
+      "outputs": [
+        "{projectRoot}/src/generated/work-item-state.ts",
+        "{projectRoot}/src/generated/predicate-expressions.ts"
+      ],
       "cache": false
     },
     "check-generated": {

--- a/packages/lifecycle-model/scripts/generate-lifecycle-state.ts
+++ b/packages/lifecycle-model/scripts/generate-lifecycle-state.ts
@@ -3,6 +3,7 @@ import { dirname, resolve } from "node:path"
 import { DataFactory, Parser, Store, type Term } from "n3"
 
 const namespace = {
+  owl: "http://www.w3.org/2002/07/owl#",
   rdf: "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
   rfa: "https://ready-for-agent.dev/ontology/rfa#",
   skos: "http://www.w3.org/2004/02/skos/core#",
@@ -13,6 +14,16 @@ const iri = (value: string) => DataFactory.namedNode(value)
 const term = (localName: string) => iri(`${namespace.rfa}${localName}`)
 
 const rdfType = iri(`${namespace.rdf}type`)
+const rdfFirst = iri(`${namespace.rdf}first`)
+const rdfRest = iri(`${namespace.rdf}rest`)
+const rdfNil = iri(`${namespace.rdf}nil`)
+const owlComplementOf = iri(`${namespace.owl}complementOf`)
+const owlEquivalentClass = iri(`${namespace.owl}equivalentClass`)
+const owlHasValue = iri(`${namespace.owl}hasValue`)
+const owlIntersectionOf = iri(`${namespace.owl}intersectionOf`)
+const owlOnProperty = iri(`${namespace.owl}onProperty`)
+const owlSomeValuesFrom = iri(`${namespace.owl}someValuesFrom`)
+const owlUnionOf = iri(`${namespace.owl}unionOf`)
 const skosNotation = iri(`${namespace.skos}notation`)
 const operationalLifecycleStep = term("OperationalLifecycleStep")
 const terminalWorkItemState = term("TerminalWorkItemState")
@@ -30,6 +41,223 @@ const xsdDayTimeDuration = iri(`${namespace.xsd}dayTimeDuration`)
 const packageRoot = resolve(import.meta.dir, "..")
 const ontologyPath = resolve(packageRoot, "../../ontology/rfa.ttl")
 const generatedPath = resolve(packageRoot, "src/generated/work-item-state.ts")
+const generatedPredicatePath = resolve(
+  packageRoot,
+  "src/generated/predicate-expressions.ts",
+)
+
+const predicateClassNames = [
+  "LeafIssue",
+  "ImplementableIssue",
+  "ActionableIssue",
+  "RelevantIssue",
+  "UnfinishedWorkItem",
+] as const
+
+type PredicateClassName = (typeof predicateClassNames)[number]
+
+type PredicateExpression =
+  | { readonly kind: "class"; readonly name: string }
+  | {
+      readonly kind: "intersection"
+      readonly expressions: readonly PredicateExpression[]
+    }
+  | {
+      readonly kind: "hasValue"
+      readonly property: string
+      readonly value: string | number | boolean
+    }
+  | {
+      readonly kind: "someValueOutside"
+      readonly property: string
+      readonly excludedValues: readonly string[]
+    }
+
+const localName = (value: string): string => {
+  if (!value.startsWith(namespace.rfa)) {
+    throw new Error(`Expected an rfa: term, received ${value}`)
+  }
+  return value.slice(namespace.rfa.length)
+}
+
+const rdfList = (store: Store, head: Term): readonly Term[] => {
+  const values: Term[] = []
+  const visited = new Set<string>()
+  let cursor = head
+
+  while (!cursor.equals(rdfNil)) {
+    if (visited.has(cursor.id)) {
+      throw new Error(`Cyclic RDF list at ${cursor.value}`)
+    }
+    visited.add(cursor.id)
+    values.push(onlyObject(store, cursor, rdfFirst))
+    cursor = onlyObject(store, cursor, rdfRest)
+  }
+
+  return values
+}
+
+const literalValue = (subject: Term, value: Term) => {
+  if (value.termType !== "Literal") {
+    throw new Error(`${subject.value} owl:hasValue must be a literal`)
+  }
+  if (value.datatype.equals(xsdBoolean)) {
+    if (value.value === "true" || value.value === "1") return true
+    if (value.value === "false" || value.value === "0") return false
+    throw new Error(`${subject.value} has an invalid boolean value`)
+  }
+  if (value.datatype.value.startsWith(`${namespace.xsd}`)) {
+    const number = Number(value.value)
+    if (Number.isFinite(number)) return number
+  }
+  return value.value
+}
+
+const parsePredicateExpression = (
+  store: Store,
+  expression: Term,
+): PredicateExpression => {
+  if (expression.termType === "NamedNode") {
+    return { kind: "class", name: localName(expression.value) }
+  }
+
+  const intersection = store.getObjects(expression, owlIntersectionOf, null)
+  if (intersection.length === 1 && intersection[0] !== undefined) {
+    return {
+      kind: "intersection",
+      expressions: rdfList(store, intersection[0]).map((entry) =>
+        parsePredicateExpression(store, entry),
+      ),
+    }
+  }
+
+  const property = onlyObject(store, expression, owlOnProperty)
+  if (property.termType !== "NamedNode") {
+    throw new Error(`${expression.value} owl:onProperty must be an IRI`)
+  }
+
+  const hasValues = store.getObjects(expression, owlHasValue, null)
+  if (hasValues.length === 1 && hasValues[0] !== undefined) {
+    return {
+      kind: "hasValue",
+      property: localName(property.value),
+      value: literalValue(expression, hasValues[0]),
+    }
+  }
+
+  const someValues = store.getObjects(expression, owlSomeValuesFrom, null)
+  if (someValues.length === 1 && someValues[0] !== undefined) {
+    const complement = onlyObject(store, someValues[0], owlComplementOf)
+    const union = onlyObject(store, complement, owlUnionOf)
+    return {
+      kind: "someValueOutside",
+      property: localName(property.value),
+      excludedValues: rdfList(store, union).map((entry) => {
+        if (entry.termType !== "NamedNode") {
+          throw new Error(`${entry.value} must be a named lifecycle state`)
+        }
+        return onlyNotation(store, entry)
+      }),
+    }
+  }
+
+  throw new Error(`Unsupported predicate expression at ${expression.value}`)
+}
+
+const predicateExpressions = (
+  store: Store,
+): Readonly<Record<PredicateClassName, PredicateExpression>> =>
+  Object.fromEntries(
+    predicateClassNames.map((name) => [
+      name,
+      parsePredicateExpression(
+        store,
+        onlyObject(store, term(name), owlEquivalentClass),
+      ),
+    ]),
+  ) as Readonly<Record<PredicateClassName, PredicateExpression>>
+
+const renderPredicateExpressions = (
+  expressions: Readonly<Record<PredicateClassName, PredicateExpression>>,
+) => `\
+// This file is generated from the predicate class expressions in ontology/rfa.ttl.
+// Run \`bunx nx run lifecycle-model:generate\` to update it.
+
+export type LifecyclePredicateName =
+${predicateClassNames.map((name) => `  | ${JSON.stringify(name)}`).join("\n")}
+
+type LifecyclePredicateExpression =
+  | { readonly kind: "class"; readonly name: string }
+  | {
+      readonly kind: "intersection"
+      readonly expressions: readonly LifecyclePredicateExpression[]
+    }
+  | {
+      readonly kind: "hasValue"
+      readonly property: string
+      readonly value: string | number | boolean
+    }
+  | {
+      readonly kind: "someValueOutside"
+      readonly property: string
+      readonly excludedValues: readonly string[]
+    }
+
+export interface LifecyclePredicateFacts {
+  readonly classes: ReadonlySet<string>
+  readonly properties: Readonly<Record<string, string | number | boolean>>
+}
+
+const LIFECYCLE_PREDICATE_EXPRESSIONS: Readonly<
+  Record<LifecyclePredicateName, LifecyclePredicateExpression>
+> = ${JSON.stringify(expressions, null, 2)}
+
+const matchesExpression = (
+  expression: LifecyclePredicateExpression,
+  facts: LifecyclePredicateFacts,
+  evaluating: ReadonlySet<string>,
+): boolean => {
+  switch (expression.kind) {
+    case "class": {
+      if (facts.classes.has(expression.name)) return true
+      if (!(expression.name in LIFECYCLE_PREDICATE_EXPRESSIONS)) return false
+      if (evaluating.has(expression.name)) {
+        throw new Error(\`Cyclic lifecycle predicate: \${expression.name}\`)
+      }
+      return matchesExpression(
+        LIFECYCLE_PREDICATE_EXPRESSIONS[
+          expression.name as LifecyclePredicateName
+        ],
+        facts,
+        new Set([...evaluating, expression.name]),
+      )
+    }
+    case "intersection":
+      return expression.expressions.every((entry) =>
+        matchesExpression(entry, facts, evaluating),
+      )
+    case "hasValue":
+      return facts.properties[expression.property] === expression.value
+    case "someValueOutside": {
+      const value = facts.properties[expression.property]
+      return (
+        typeof value === "string" &&
+        !expression.excludedValues.includes(value)
+      )
+    }
+  }
+}
+
+export const matchesLifecyclePredicateExpression = (
+  name: LifecyclePredicateName,
+  facts: LifecyclePredicateFacts,
+): boolean =>
+  matchesExpression(
+    LIFECYCLE_PREDICATE_EXPRESSIONS[name],
+    facts,
+    new Set([name]),
+  )
+`
 
 const onlyNotation = (store: Store, subject: Term): string => {
   const notations = store.getObjects(subject, skosNotation, null)
@@ -373,12 +601,15 @@ const generate = async () => {
     )
   }
 
-  return renderGeneratedSource(
-    operationalSteps,
-    terminalStates,
-    transitions(ontology, operationalSteps, terminalStates),
-    lifecycleStepProperties,
-  )
+  return {
+    stateSource: renderGeneratedSource(
+      operationalSteps,
+      terminalStates,
+      transitions(ontology, operationalSteps, terminalStates),
+      lifecycleStepProperties,
+    ),
+    predicateSource: renderPredicateExpressions(predicateExpressions(ontology)),
+  }
 }
 
 const check = process.argv.slice(2).includes("--check")
@@ -390,17 +621,29 @@ if (unknownArguments.length > 0) {
   throw new Error(`Unknown arguments: ${unknownArguments.join(", ")}`)
 }
 
-const generatedSource = await generate()
+const generated = await generate()
 
 if (check) {
-  const checkedInSource = await readFile(generatedPath, "utf8").catch(() => "")
-  if (checkedInSource !== generatedSource) {
+  const [checkedInStateSource, checkedInPredicateSource] = await Promise.all([
+    readFile(generatedPath, "utf8").catch(() => ""),
+    readFile(generatedPredicatePath, "utf8").catch(() => ""),
+  ])
+  if (
+    checkedInStateSource !== generated.stateSource ||
+    checkedInPredicateSource !== generated.predicateSource
+  ) {
     console.error(
-      "Generated lifecycle state is stale. Run `bunx nx run lifecycle-model:generate`.",
+      "Generated lifecycle model is stale. Run `bunx nx run lifecycle-model:generate`.",
     )
     process.exitCode = 1
   }
 } else {
-  await mkdir(dirname(generatedPath), { recursive: true })
-  await writeFile(generatedPath, generatedSource)
+  await Promise.all([
+    mkdir(dirname(generatedPath), { recursive: true }),
+    mkdir(dirname(generatedPredicatePath), { recursive: true }),
+  ])
+  await Promise.all([
+    writeFile(generatedPath, generated.stateSource),
+    writeFile(generatedPredicatePath, generated.predicateSource),
+  ])
 }

--- a/packages/lifecycle-model/src/generated/predicate-expressions.ts
+++ b/packages/lifecycle-model/src/generated/predicate-expressions.ts
@@ -1,0 +1,176 @@
+// This file is generated from the predicate class expressions in ontology/rfa.ttl.
+// Run `bunx nx run lifecycle-model:generate` to update it.
+
+export type LifecyclePredicateName =
+  | "LeafIssue"
+  | "ImplementableIssue"
+  | "ActionableIssue"
+  | "RelevantIssue"
+  | "UnfinishedWorkItem"
+
+type LifecyclePredicateExpression =
+  | { readonly kind: "class"; readonly name: string }
+  | {
+      readonly kind: "intersection"
+      readonly expressions: readonly LifecyclePredicateExpression[]
+    }
+  | {
+      readonly kind: "hasValue"
+      readonly property: string
+      readonly value: string | number | boolean
+    }
+  | {
+      readonly kind: "someValueOutside"
+      readonly property: string
+      readonly excludedValues: readonly string[]
+    }
+
+export interface LifecyclePredicateFacts {
+  readonly classes: ReadonlySet<string>
+  readonly properties: Readonly<Record<string, string | number | boolean>>
+}
+
+const LIFECYCLE_PREDICATE_EXPRESSIONS: Readonly<
+  Record<LifecyclePredicateName, LifecyclePredicateExpression>
+> = {
+  "LeafIssue": {
+    "kind": "intersection",
+    "expressions": [
+      {
+        "kind": "class",
+        "name": "Issue"
+      },
+      {
+        "kind": "hasValue",
+        "property": "hasChildren",
+        "value": false
+      }
+    ]
+  },
+  "ImplementableIssue": {
+    "kind": "intersection",
+    "expressions": [
+      {
+        "kind": "class",
+        "name": "LeafIssue"
+      },
+      {
+        "kind": "hasValue",
+        "property": "isCurrentIssue",
+        "value": true
+      },
+      {
+        "kind": "hasValue",
+        "property": "isOpenIssue",
+        "value": true
+      },
+      {
+        "kind": "hasValue",
+        "property": "listedBlockerCount",
+        "value": 0
+      }
+    ]
+  },
+  "ActionableIssue": {
+    "kind": "intersection",
+    "expressions": [
+      {
+        "kind": "class",
+        "name": "ImplementableIssue"
+      },
+      {
+        "kind": "hasValue",
+        "property": "unfinishedWorkItemCount",
+        "value": 0
+      }
+    ]
+  },
+  "RelevantIssue": {
+    "kind": "intersection",
+    "expressions": [
+      {
+        "kind": "class",
+        "name": "ReadyLabeledIssue"
+      },
+      {
+        "kind": "hasValue",
+        "property": "isInSupportedIssueHierarchy",
+        "value": true
+      },
+      {
+        "kind": "hasValue",
+        "property": "satisfiesClosingPullRequestCondition",
+        "value": true
+      },
+      {
+        "kind": "hasValue",
+        "property": "isIssueAuthorIncluded",
+        "value": true
+      }
+    ]
+  },
+  "UnfinishedWorkItem": {
+    "kind": "intersection",
+    "expressions": [
+      {
+        "kind": "class",
+        "name": "WorkItem"
+      },
+      {
+        "kind": "someValueOutside",
+        "property": "currentState",
+        "excludedValues": [
+          "complete",
+          "failed",
+          "abandoned"
+        ]
+      }
+    ]
+  }
+}
+
+const matchesExpression = (
+  expression: LifecyclePredicateExpression,
+  facts: LifecyclePredicateFacts,
+  evaluating: ReadonlySet<string>,
+): boolean => {
+  switch (expression.kind) {
+    case "class": {
+      if (facts.classes.has(expression.name)) return true
+      if (!(expression.name in LIFECYCLE_PREDICATE_EXPRESSIONS)) return false
+      if (evaluating.has(expression.name)) {
+        throw new Error(`Cyclic lifecycle predicate: ${expression.name}`)
+      }
+      return matchesExpression(
+        LIFECYCLE_PREDICATE_EXPRESSIONS[
+          expression.name as LifecyclePredicateName
+        ],
+        facts,
+        new Set([...evaluating, expression.name]),
+      )
+    }
+    case "intersection":
+      return expression.expressions.every((entry) =>
+        matchesExpression(entry, facts, evaluating),
+      )
+    case "hasValue":
+      return facts.properties[expression.property] === expression.value
+    case "someValueOutside": {
+      const value = facts.properties[expression.property]
+      return (
+        typeof value === "string" &&
+        !expression.excludedValues.includes(value)
+      )
+    }
+  }
+}
+
+export const matchesLifecyclePredicateExpression = (
+  name: LifecyclePredicateName,
+  facts: LifecyclePredicateFacts,
+): boolean =>
+  matchesExpression(
+    LIFECYCLE_PREDICATE_EXPRESSIONS[name],
+    facts,
+    new Set([name]),
+  )

--- a/packages/lifecycle-model/src/index.ts
+++ b/packages/lifecycle-model/src/index.ts
@@ -1,1 +1,2 @@
 export * from "./generated/work-item-state.js"
+export * from "./predicates.js"

--- a/packages/lifecycle-model/src/predicates.ts
+++ b/packages/lifecycle-model/src/predicates.ts
@@ -1,0 +1,311 @@
+import {
+  type LifecyclePredicateName,
+  matchesLifecyclePredicateExpression,
+} from "./generated/predicate-expressions.js"
+import type { WorkItemState } from "./generated/work-item-state.js"
+
+export interface IssuePredicateShape {
+  readonly isCurrentIssue: boolean
+  readonly state: string
+  readonly hasChildren: boolean
+  readonly blockedBy: readonly unknown[]
+}
+
+export interface WorkItemPredicateShape {
+  readonly id?: string
+  readonly state: WorkItemState
+}
+
+export interface RelevantIssuePredicateShape {
+  readonly state: string
+  readonly author: string | null
+  readonly parent: {
+    readonly state: string
+    readonly isReadyLabeled: boolean
+  } | null
+  readonly hasChildren: boolean
+  readonly hierarchySupported: boolean
+  readonly closingPullRequests: readonly {
+    readonly number: number
+    readonly repository: string
+    readonly state: "OPEN" | "MERGED" | "CLOSED"
+    readonly isDraft: boolean
+  }[]
+}
+
+export interface RelevantIssuePredicateContext {
+  readonly forge: string
+  readonly repositoryName: string
+  readonly workItemPullRequestNumbers: ReadonlySet<number>
+  readonly authorScope:
+    | { readonly includeAll: true }
+    | { readonly includeAll: false; readonly operatorLogin: string }
+}
+
+export type LifecyclePredicateFailure =
+  | { readonly _tag: "issue_missing" }
+  | { readonly _tag: "issue_not_open"; readonly state: string }
+  | { readonly _tag: "issue_not_leaf" }
+  | { readonly _tag: "issue_blocked"; readonly blockerCount: number }
+  | {
+      readonly _tag: "unfinished_work_item_exists"
+      readonly workItemId: string | null
+    }
+  | {
+      readonly _tag: "work_item_finished"
+      readonly state: "complete" | "failed" | "abandoned"
+    }
+  | { readonly _tag: "issue_hierarchy_unsupported" }
+  | {
+      readonly _tag: "issue_parent_not_open"
+      readonly state: string
+    }
+  | { readonly _tag: "issue_parent_not_ready" }
+  | { readonly _tag: "issue_closing_pull_request_unowned" }
+  | { readonly _tag: "issue_author_not_in_scope" }
+
+export interface LifecyclePredicateMatch {
+  readonly _tag: "match"
+}
+
+export type LifecyclePredicateResult<
+  Failure extends LifecyclePredicateFailure = LifecyclePredicateFailure,
+> = LifecyclePredicateMatch | Failure
+
+export type LeafIssueFailure =
+  | Extract<LifecyclePredicateFailure, { readonly _tag: "issue_missing" }>
+  | Extract<LifecyclePredicateFailure, { readonly _tag: "issue_not_leaf" }>
+
+export type ImplementableIssueFailure =
+  | LeafIssueFailure
+  | Extract<LifecyclePredicateFailure, { readonly _tag: "issue_not_open" }>
+  | Extract<LifecyclePredicateFailure, { readonly _tag: "issue_blocked" }>
+
+export type ActionableIssueFailure =
+  | ImplementableIssueFailure
+  | Extract<
+      LifecyclePredicateFailure,
+      { readonly _tag: "unfinished_work_item_exists" }
+    >
+
+export type UnfinishedWorkItemFailure = Extract<
+  LifecyclePredicateFailure,
+  { readonly _tag: "work_item_finished" }
+>
+
+export type RelevantIssueFailure = Exclude<
+  LifecyclePredicateFailure,
+  Extract<
+    LifecyclePredicateFailure,
+    {
+      readonly _tag:
+        | "issue_not_leaf"
+        | "issue_blocked"
+        | "unfinished_work_item_exists"
+        | "work_item_finished"
+    }
+  >
+>
+
+const MATCH: LifecyclePredicateMatch = { _tag: "match" }
+
+const matchesExpression = (
+  name: LifecyclePredicateName,
+  classes: readonly string[],
+  properties: Readonly<Record<string, string | number | boolean>>,
+): boolean =>
+  matchesLifecyclePredicateExpression(name, {
+    classes: new Set(classes),
+    properties,
+  })
+
+export const evaluateLeafIssue = (
+  issue: Pick<IssuePredicateShape, "hasChildren"> | null | undefined,
+): LifecyclePredicateResult<LeafIssueFailure> => {
+  if (issue == null) {
+    return { _tag: "issue_missing" }
+  }
+  if (
+    matchesExpression("LeafIssue", ["Issue"], {
+      hasChildren: issue.hasChildren,
+    })
+  ) {
+    return MATCH
+  }
+  return { _tag: "issue_not_leaf" }
+}
+
+export const evaluateImplementableIssue = (
+  issue: IssuePredicateShape | null | undefined,
+): LifecyclePredicateResult<ImplementableIssueFailure> => {
+  if (issue == null) {
+    return { _tag: "issue_missing" }
+  }
+  if (!issue.isCurrentIssue) {
+    return { _tag: "issue_missing" }
+  }
+  if (
+    matchesExpression("ImplementableIssue", ["Issue"], {
+      isCurrentIssue: issue.isCurrentIssue,
+      isOpenIssue: issue.state === "OPEN",
+      hasChildren: issue.hasChildren,
+      listedBlockerCount: issue.blockedBy.length,
+    })
+  ) {
+    return MATCH
+  }
+  if (issue.state !== "OPEN") {
+    return { _tag: "issue_not_open", state: issue.state }
+  }
+
+  const leaf = evaluateLeafIssue(issue)
+  if (leaf._tag !== "match") {
+    return leaf
+  }
+
+  if (issue.blockedBy.length > 0) {
+    return {
+      _tag: "issue_blocked",
+      blockerCount: issue.blockedBy.length,
+    }
+  }
+  throw new Error("Implementable Issue expression rejected valid facts")
+}
+
+export const evaluateUnfinishedWorkItem = (
+  workItem: WorkItemPredicateShape,
+): LifecyclePredicateResult<UnfinishedWorkItemFailure> => {
+  if (
+    matchesExpression("UnfinishedWorkItem", ["WorkItem"], {
+      currentState: workItem.state,
+    })
+  ) {
+    return MATCH
+  }
+  switch (workItem.state) {
+    case "complete":
+    case "failed":
+    case "abandoned":
+      return { _tag: "work_item_finished", state: workItem.state }
+    default:
+      return MATCH
+  }
+}
+
+export const evaluateActionableIssue = (
+  issue: IssuePredicateShape | null | undefined,
+  workItems: readonly WorkItemPredicateShape[],
+): LifecyclePredicateResult<ActionableIssueFailure> => {
+  const implementable = evaluateImplementableIssue(issue)
+  if (implementable._tag !== "match") {
+    return implementable
+  }
+
+  const unfinishedWorkItems = workItems.filter(
+    (workItem) => evaluateUnfinishedWorkItem(workItem)._tag === "match",
+  )
+  if (
+    issue !== null &&
+    issue !== undefined &&
+    matchesExpression("ActionableIssue", ["Issue"], {
+      isCurrentIssue: issue.isCurrentIssue,
+      isOpenIssue: issue.state === "OPEN",
+      hasChildren: issue.hasChildren,
+      listedBlockerCount: issue.blockedBy.length,
+      unfinishedWorkItemCount: unfinishedWorkItems.length,
+    })
+  ) {
+    return MATCH
+  }
+  const unfinished = unfinishedWorkItems[0]
+  if (unfinished !== undefined) {
+    return {
+      _tag: "unfinished_work_item_exists",
+      workItemId: unfinished.id ?? null,
+    }
+  }
+  throw new Error("Actionable Issue expression rejected valid facts")
+}
+
+const activeClosingPullRequest = (
+  pullRequest: RelevantIssuePredicateShape["closingPullRequests"][number],
+  forge: string,
+): boolean =>
+  pullRequest.state === "MERGED" ||
+  (pullRequest.state === "OPEN" && (forge === "gitlab" || !pullRequest.isDraft))
+
+export const evaluateRelevantIssue = (
+  issue: RelevantIssuePredicateShape | null | undefined,
+  context: RelevantIssuePredicateContext,
+): LifecyclePredicateResult<RelevantIssueFailure> => {
+  if (issue == null) {
+    return { _tag: "issue_missing" }
+  }
+
+  let hierarchyFailure: RelevantIssueFailure | undefined
+  if (issue.hierarchySupported) {
+    if (issue.parent === null) {
+      if (issue.state !== "OPEN") {
+        hierarchyFailure = { _tag: "issue_not_open", state: issue.state }
+      }
+    } else {
+      if (issue.parent.state !== "OPEN") {
+        hierarchyFailure = {
+          _tag: "issue_parent_not_open",
+          state: issue.parent.state,
+        }
+      } else if (!issue.parent.isReadyLabeled) {
+        hierarchyFailure = { _tag: "issue_parent_not_ready" }
+      }
+    }
+  } else {
+    if (context.forge !== "gitlab") {
+      hierarchyFailure = { _tag: "issue_hierarchy_unsupported" }
+    } else if (issue.state !== "OPEN") {
+      hierarchyFailure = { _tag: "issue_not_open", state: issue.state }
+    } else if (issue.parent !== null || issue.hasChildren) {
+      hierarchyFailure = { _tag: "issue_hierarchy_unsupported" }
+    }
+  }
+
+  const activeClosingPullRequests = issue.closingPullRequests.filter(
+    (pullRequest) => activeClosingPullRequest(pullRequest, context.forge),
+  )
+  const satisfiesClosingPullRequestCondition =
+    activeClosingPullRequests.length === 0 ||
+    activeClosingPullRequests.some(
+      (pullRequest) =>
+        pullRequest.repository.toLowerCase() === context.repositoryName &&
+        context.workItemPullRequestNumbers.has(pullRequest.number),
+    )
+  const isIssueAuthorIncluded =
+    context.authorScope.includeAll ||
+    (issue.author !== null &&
+      issue.author.toLowerCase() ===
+        context.authorScope.operatorLogin.toLowerCase())
+
+  if (
+    matchesExpression("RelevantIssue", ["ReadyLabeledIssue"], {
+      isInSupportedIssueHierarchy: hierarchyFailure === undefined,
+      satisfiesClosingPullRequestCondition,
+      isIssueAuthorIncluded,
+    })
+  ) {
+    return MATCH
+  }
+  if (hierarchyFailure !== undefined) {
+    return hierarchyFailure
+  }
+  if (
+    activeClosingPullRequests.length > 0 &&
+    !satisfiesClosingPullRequestCondition
+  ) {
+    return { _tag: "issue_closing_pull_request_unowned" }
+  }
+
+  if (!isIssueAuthorIncluded) {
+    return { _tag: "issue_author_not_in_scope" }
+  }
+
+  throw new Error("Relevant Issue expression rejected valid facts")
+}

--- a/packages/lifecycle-model/test/ontology.test.ts
+++ b/packages/lifecycle-model/test/ontology.test.ts
@@ -35,6 +35,7 @@ const owlAnnotatedSource = iri(`${namespace.owl}annotatedSource`)
 const owlAnnotatedTarget = iri(`${namespace.owl}annotatedTarget`)
 const owlAxiom = iri(`${namespace.owl}Axiom`)
 const owlDisjointWith = iri(`${namespace.owl}disjointWith`)
+const owlEquivalentClass = iri(`${namespace.owl}equivalentClass`)
 const owlMembers = iri(`${namespace.owl}members`)
 const owlNamedIndividual = iri(`${namespace.owl}NamedIndividual`)
 const owlObjectProperty = iri(`${namespace.owl}ObjectProperty`)
@@ -544,6 +545,20 @@ describe("CONTEXT.md vocabulary parity", () => {
 })
 
 describe("full vocabulary semantic distinctions", () => {
+  it("defines each shared predicate as exactly one class expression", () => {
+    for (const localName of [
+      "LeafIssue",
+      "ImplementableIssue",
+      "ActionableIssue",
+      "RelevantIssue",
+      "UnfinishedWorkItem",
+    ]) {
+      expect(
+        ontology.countQuads(term(localName), owlEquivalentClass, null, null),
+      ).toBe(1)
+    }
+  })
+
   it("keeps Repository Paused distinct from Pause Work Item", () => {
     expectDisjoint(term("Paused"), term("PauseWorkItem"))
   })

--- a/packages/lifecycle-model/test/predicates.test.ts
+++ b/packages/lifecycle-model/test/predicates.test.ts
@@ -1,0 +1,204 @@
+import {
+  type RelevantIssuePredicateContext,
+  type RelevantIssuePredicateShape,
+  type WorkItemPredicateShape,
+  evaluateActionableIssue,
+  evaluateImplementableIssue,
+  evaluateLeafIssue,
+  evaluateRelevantIssue,
+  evaluateUnfinishedWorkItem,
+} from "../src/index.js"
+import { describe, expect, it } from "bun:test"
+
+const openLeaf = {
+  isCurrentIssue: true,
+  state: "OPEN",
+  hasChildren: false,
+  blockedBy: [],
+} as const
+
+const relevantIssue = (
+  overrides: Partial<RelevantIssuePredicateShape> = {},
+): RelevantIssuePredicateShape => ({
+  state: "OPEN",
+  author: "operator",
+  parent: null,
+  hasChildren: false,
+  hierarchySupported: true,
+  closingPullRequests: [],
+  ...overrides,
+})
+
+const relevantContext = (
+  overrides: Partial<RelevantIssuePredicateContext> = {},
+): RelevantIssuePredicateContext => ({
+  forge: "github",
+  repositoryName: "owner/repository",
+  workItemPullRequestNumbers: new Set(),
+  authorScope: { includeAll: false, operatorLogin: "operator" },
+  ...overrides,
+})
+
+describe("shared lifecycle predicates", () => {
+  it("defines Leaf Issue with missing and not-leaf failures", () => {
+    expect(evaluateLeafIssue(undefined)).toEqual({ _tag: "issue_missing" })
+    expect(evaluateLeafIssue({ hasChildren: true })).toEqual({
+      _tag: "issue_not_leaf",
+    })
+    expect(evaluateLeafIssue(openLeaf)).toEqual({ _tag: "match" })
+  })
+
+  it("defines Implementable Issue with closed and blocked failures", () => {
+    expect(
+      evaluateImplementableIssue({ ...openLeaf, isCurrentIssue: false }),
+    ).toEqual({ _tag: "issue_missing" })
+    expect(
+      evaluateImplementableIssue({ ...openLeaf, state: "CLOSED" }),
+    ).toEqual({
+      _tag: "issue_not_open",
+      state: "CLOSED",
+    })
+    expect(
+      evaluateImplementableIssue({ ...openLeaf, blockedBy: [{ number: 7 }] }),
+    ).toEqual({
+      _tag: "issue_blocked",
+      blockerCount: 1,
+    })
+    expect(evaluateImplementableIssue(openLeaf)).toEqual({ _tag: "match" })
+  })
+
+  it("defines Actionable Issue with an unfinished Work Item failure", () => {
+    expect(
+      evaluateActionableIssue(openLeaf, [
+        { id: "wi-current", state: "implement" },
+      ]),
+    ).toEqual({
+      _tag: "unfinished_work_item_exists",
+      workItemId: "wi-current",
+    })
+    expect(
+      evaluateActionableIssue(openLeaf, [
+        { id: "wi-complete", state: "complete" },
+      ]),
+    ).toEqual({ _tag: "match" })
+  })
+
+  it("defines unfinished Work Item and counts Needs Human as unfinished", () => {
+    const unfinishedStates: readonly WorkItemPredicateShape["state"][] = [
+      "create_worktree",
+      "needs_human",
+    ]
+    for (const state of unfinishedStates) {
+      expect(evaluateUnfinishedWorkItem({ state })).toEqual({ _tag: "match" })
+    }
+
+    for (const state of ["complete", "failed", "abandoned"] as const) {
+      expect(evaluateUnfinishedWorkItem({ state })).toEqual({
+        _tag: "work_item_finished",
+        state,
+      })
+    }
+  })
+
+  it("defines Relevant Issue hierarchy failures", () => {
+    expect(evaluateRelevantIssue(undefined, relevantContext())).toEqual({
+      _tag: "issue_missing",
+    })
+    expect(
+      evaluateRelevantIssue(
+        relevantIssue({ hierarchySupported: false }),
+        relevantContext(),
+      ),
+    ).toEqual({ _tag: "issue_hierarchy_unsupported" })
+    expect(
+      evaluateRelevantIssue(
+        relevantIssue({
+          parent: { state: "CLOSED", isReadyLabeled: true },
+        }),
+        relevantContext(),
+      ),
+    ).toEqual({ _tag: "issue_parent_not_open", state: "CLOSED" })
+    expect(
+      evaluateRelevantIssue(
+        relevantIssue({
+          parent: { state: "OPEN", isReadyLabeled: false },
+        }),
+        relevantContext(),
+      ),
+    ).toEqual({ _tag: "issue_parent_not_ready" })
+  })
+
+  it("defines Relevant Issue closing-PR and author failures", () => {
+    expect(
+      evaluateRelevantIssue(
+        relevantIssue({
+          closingPullRequests: [
+            {
+              number: 9,
+              repository: "owner/repository",
+              state: "OPEN",
+              isDraft: false,
+            },
+          ],
+        }),
+        relevantContext(),
+      ),
+    ).toEqual({ _tag: "issue_closing_pull_request_unowned" })
+
+    expect(
+      evaluateRelevantIssue(
+        relevantIssue({
+          closingPullRequests: [
+            {
+              number: 9,
+              repository: "owner/repository",
+              state: "OPEN",
+              isDraft: false,
+            },
+          ],
+        }),
+        relevantContext({
+          repositoryName: "OWNER/REPOSITORY",
+          workItemPullRequestNumbers: new Set([9]),
+        }),
+      ),
+    ).toEqual({ _tag: "issue_closing_pull_request_unowned" })
+
+    expect(
+      evaluateRelevantIssue(
+        relevantIssue({ author: "someone-else" }),
+        relevantContext(),
+      ),
+    ).toEqual({ _tag: "issue_author_not_in_scope" })
+  })
+
+  it("matches Relevant closed children, owned PRs, and GitLab roots", () => {
+    expect(
+      evaluateRelevantIssue(
+        relevantIssue({
+          state: "CLOSED",
+          parent: { state: "OPEN", isReadyLabeled: true },
+          closingPullRequests: [
+            {
+              number: 9,
+              repository: "OWNER/REPOSITORY",
+              state: "MERGED",
+              isDraft: false,
+            },
+          ],
+        }),
+        relevantContext({ workItemPullRequestNumbers: new Set([9]) }),
+      ),
+    ).toEqual({ _tag: "match" })
+
+    expect(
+      evaluateRelevantIssue(
+        relevantIssue({ hierarchySupported: false }),
+        relevantContext({
+          forge: "gitlab",
+          authorScope: { includeAll: true },
+        }),
+      ),
+    ).toEqual({ _tag: "match" })
+  })
+})

--- a/packages/work-item-lifecycle/src/lib/work-item-lifecycle.ts
+++ b/packages/work-item-lifecycle/src/lib/work-item-lifecycle.ts
@@ -32,7 +32,12 @@ import {
   sanitizeUserFacingText,
 } from "@ready-for-agent/github-service"
 import { GitLabService } from "@ready-for-agent/gitlab-service"
-import { isAgentDependentLifecycleStep } from "@ready-for-agent/lifecycle-model"
+import {
+  evaluateActionableIssue,
+  evaluateImplementableIssue,
+  evaluateUnfinishedWorkItem,
+  isAgentDependentLifecycleStep,
+} from "@ready-for-agent/lifecycle-model"
 import {
   type AcknowledgeError,
   EnqueueError,
@@ -113,6 +118,11 @@ import {
 import { workItemBranchName } from "./worktree-names.js"
 
 export { WAITING_FOR_WORKER_SLOT_MESSAGE } from "./types.js"
+
+const currentIssuePredicateInput = <Issue extends object>(
+  issue: Issue | undefined,
+): (Issue & { readonly isCurrentIssue: true }) | undefined =>
+  issue === undefined ? undefined : { ...issue, isCurrentIssue: true }
 
 const formatSqlError = (error: SqlError): string => {
   const parts: string[] = [error.message]
@@ -1396,36 +1406,33 @@ export const makeWorkItemLifecycleLive = (
         const issue = issues.find(
           (candidate) => candidate.issueNumber === issueNumber,
         )
-
-        if (!issue) {
-          return {
-            _tag: "invalid",
-            failureCode: "issue_not_found",
-            failureMessage: `Issue #${issueNumber} is no longer present in the Issue store`,
-          }
+        const verdict = evaluateImplementableIssue(
+          currentIssuePredicateInput(issue),
+        )
+        switch (verdict._tag) {
+          case "match":
+            return { _tag: "implementable" }
+          case "issue_blocked":
+            return { _tag: "still_blocked" }
+          case "issue_missing":
+            return {
+              _tag: "invalid",
+              failureCode: "issue_not_found",
+              failureMessage: `Issue #${issueNumber} is no longer present in the Issue store`,
+            }
+          case "issue_not_open":
+            return {
+              _tag: "invalid",
+              failureCode: "issue_not_open",
+              failureMessage: `Issue #${issueNumber} is ${verdict.state}, not OPEN`,
+            }
+          case "issue_not_leaf":
+            return {
+              _tag: "invalid",
+              failureCode: "issue_is_parent",
+              failureMessage: `Issue #${issueNumber} has children and is no longer a Leaf Issue`,
+            }
         }
-
-        if (issue.state !== "OPEN") {
-          return {
-            _tag: "invalid",
-            failureCode: "issue_not_open",
-            failureMessage: `Issue #${issueNumber} is ${issue.state}, not OPEN`,
-          }
-        }
-
-        if (issue.hasChildren) {
-          return {
-            _tag: "invalid",
-            failureCode: "issue_is_parent",
-            failureMessage: `Issue #${issueNumber} has children and is no longer a Leaf Issue`,
-          }
-        }
-
-        if (issue.blockedBy.length > 0) {
-          return { _tag: "still_blocked" }
-        }
-
-        return { _tag: "implementable" }
       }
 
       const releaseWaitingForBlockers = Effect.fn(
@@ -1660,40 +1667,37 @@ export const makeWorkItemLifecycleLive = (
           const issue = issues.find(
             (candidate) => candidate.issueNumber === issueNumber,
           )
-
-          if (!issue) {
-            return {
-              ok: false as const,
-              failureCode: "issue_not_found",
-              failureMessage: `Issue #${issueNumber} is no longer present in the Issue store`,
-            }
+          const verdict = evaluateImplementableIssue(
+            currentIssuePredicateInput(issue),
+          )
+          switch (verdict._tag) {
+            case "match":
+              return { ok: true as const }
+            case "issue_missing":
+              return {
+                ok: false as const,
+                failureCode: "issue_not_found",
+                failureMessage: `Issue #${issueNumber} is no longer present in the Issue store`,
+              }
+            case "issue_not_open":
+              return {
+                ok: false as const,
+                failureCode: "issue_not_open",
+                failureMessage: `Issue #${issueNumber} is ${verdict.state}, not OPEN`,
+              }
+            case "issue_not_leaf":
+              return {
+                ok: false as const,
+                failureCode: "issue_is_parent",
+                failureMessage: `Issue #${issueNumber} has children and is no longer a Leaf Issue`,
+              }
+            case "issue_blocked":
+              return {
+                ok: false as const,
+                failureCode: "issue_blocked",
+                failureMessage: `Issue #${issueNumber} is blocked by ${verdict.blockerCount} Issue(s)`,
+              }
           }
-
-          if (issue.state !== "OPEN") {
-            return {
-              ok: false as const,
-              failureCode: "issue_not_open",
-              failureMessage: `Issue #${issueNumber} is ${issue.state}, not OPEN`,
-            }
-          }
-
-          if (issue.hasChildren) {
-            return {
-              ok: false as const,
-              failureCode: "issue_is_parent",
-              failureMessage: `Issue #${issueNumber} has children and is no longer a Leaf Issue`,
-            }
-          }
-
-          if (issue.blockedBy.length > 0) {
-            return {
-              ok: false as const,
-              failureCode: "issue_blocked",
-              failureMessage: `Issue #${issueNumber} is blocked by ${issue.blockedBy.length} Issue(s)`,
-            }
-          }
-
-          return { ok: true as const }
         })
 
       const mergeRevalidationCount = (
@@ -5063,52 +5067,44 @@ export const makeWorkItemLifecycleLive = (
           const issue = issues.find(
             (candidate) => candidate.issueNumber === issueNumber,
           )
-
-          if (!issue) {
-            return yield* new IssueNotFoundError({
-              repositoryId,
-              issueNumber,
-            })
+          const currentIssue = currentIssuePredicateInput(issue)
+          const implementable = evaluateImplementableIssue(currentIssue)
+          switch (implementable._tag) {
+            case "issue_missing":
+              return yield* new IssueNotFoundError({
+                repositoryId,
+                issueNumber,
+              })
+            case "issue_not_open":
+              return yield* new IssueNotOpenError({
+                repositoryId,
+                issueNumber,
+                state: implementable.state,
+              })
+            case "issue_not_leaf":
+              return yield* new ParentIssueError({
+                repositoryId,
+                issueNumber,
+              })
+            case "issue_blocked":
+              return yield* new IssueBlockedError({
+                repositoryId,
+                issueNumber,
+                blockerCount: implementable.blockerCount,
+              })
           }
-
-          if (issue.state !== "OPEN") {
-            return yield* new IssueNotOpenError({
-              repositoryId,
-              issueNumber,
-              state: issue.state,
-            })
-          }
-
-          if (issue.hasChildren) {
-            return yield* new ParentIssueError({
-              repositoryId,
-              issueNumber,
-            })
-          }
-
-          if (issue.blockedBy.length > 0) {
-            return yield* new IssueBlockedError({
-              repositoryId,
-              issueNumber,
-              blockerCount: issue.blockedBy.length,
-            })
-          }
+          const matchedIssue = Option.getOrThrow(Option.fromNullishOr(issue))
 
           const existing = yield* listWorkItemsForIssue(
             repositoryId,
             issueNumber,
           )
-          const unfinished = existing.find(
-            (item) =>
-              item.state !== "complete" &&
-              item.state !== "failed" &&
-              item.state !== "abandoned",
-          )
-          if (unfinished) {
+          const actionable = evaluateActionableIssue(currentIssue, existing)
+          if (actionable._tag === "unfinished_work_item_exists") {
             return yield* unfinishedWorkItemExistsError(
               repositoryId,
               issueNumber,
-              unfinished.id,
+              actionable.workItemId ?? undefined,
             )
           }
 
@@ -5177,7 +5173,7 @@ export const makeWorkItemLifecycleLive = (
                         repositoryId,
                         issueNumber,
                         agentBackendId,
-                        issue.title,
+                        matchedIssue.title,
                         step,
                         now,
                         admit ? null : now,
@@ -5335,11 +5331,7 @@ export const makeWorkItemLifecycleLive = (
           yield* listWorkItemsForRepository(repositoryId)
         const unfinishedByIssue = new Map<number, WorkItemId>()
         for (const item of repositoryWorkItems) {
-          if (
-            item.state !== "complete" &&
-            item.state !== "failed" &&
-            item.state !== "abandoned"
-          ) {
+          if (evaluateUnfinishedWorkItem(item)._tag === "match") {
             unfinishedByIssue.set(item.issueNumber, item.id)
           }
         }
@@ -5599,42 +5591,39 @@ export const makeWorkItemLifecycleLive = (
         const issue = issues.find(
           (candidate) => candidate.issueNumber === issueNumber,
         )
-
-        if (!issue) {
-          return yield* new IssueNotFoundError({
-            repositoryId,
-            issueNumber,
-          })
+        const implementable = evaluateImplementableIssue(
+          currentIssuePredicateInput(issue),
+        )
+        switch (implementable._tag) {
+          case "issue_missing":
+            return yield* new IssueNotFoundError({
+              repositoryId,
+              issueNumber,
+            })
+          case "issue_not_open":
+            return yield* new IssueNotOpenError({
+              repositoryId,
+              issueNumber,
+              state: implementable.state,
+            })
+          case "issue_not_leaf":
+            return yield* new ParentIssueError({
+              repositoryId,
+              issueNumber,
+            })
+          case "match":
+            return yield* new IssueNotBlockedError({
+              repositoryId,
+              issueNumber,
+            })
+          case "issue_blocked":
+            break
         }
-
-        if (issue.state !== "OPEN") {
-          return yield* new IssueNotOpenError({
-            repositoryId,
-            issueNumber,
-            state: issue.state,
-          })
-        }
-
-        if (issue.hasChildren) {
-          return yield* new ParentIssueError({
-            repositoryId,
-            issueNumber,
-          })
-        }
-
-        if (issue.blockedBy.length === 0) {
-          return yield* new IssueNotBlockedError({
-            repositoryId,
-            issueNumber,
-          })
-        }
+        const matchedIssue = Option.getOrThrow(Option.fromNullishOr(issue))
 
         const existing = yield* listWorkItemsForIssue(repositoryId, issueNumber)
         const unfinished = existing.find(
-          (item) =>
-            item.state !== "complete" &&
-            item.state !== "failed" &&
-            item.state !== "abandoned",
+          (item) => evaluateUnfinishedWorkItem(item)._tag === "match",
         )
         if (unfinished) {
           return yield* unfinishedWorkItemExistsError(
@@ -5696,7 +5685,7 @@ export const makeWorkItemLifecycleLive = (
                       repositoryId,
                       issueNumber,
                       agentBackendId,
-                      issue.title,
+                      matchedIssue.title,
                       step,
                       now,
                       now,


### PR DESCRIPTION
## Why

Lifecycle eligibility rules were duplicated across Issue reconciliation, Work Item creation,
revalidation, and Queue-hold release. Those copies could drift from the ontology and from each
other, especially around unfinished Work Items and operator-facing failure reasons.

## What changed

- Define Leaf, Implementable, Actionable, Relevant, and Unfinished Work Item as ontology class
  expressions.
- Generate executable predicate matchers from those expressions and enforce generated-file
  freshness.
- Export one shared evaluator per predicate with a common tagged failure vocabulary.
- Replace lifecycle creation, revalidation, Queue, and Queue-hold variants with the shared
  predicates while preserving existing errors and operator copy.
- Move Relevant Issue filtering in the Issue Reconciler to the shared evaluator.
- Treat Needs Human as unfinished and make current Issue-store membership explicit.
- Add coverage for every failure tag and preserve existing repository identity comparison
  behavior.

## Verification

- 703 focused tests passed across lifecycle-model, issue-reconciler, and work-item-lifecycle.
- All 22 affected build targets passed.
- All 30 affected lint targets passed.
- Generated-model freshness, Nx workspace sync, and diff checks passed.

The ontology remains outside the runtime hot path; generated TypeScript performs predicate
matching.

Closes #648