### PR TITLE
fix(harness): remove Kanban masthead and bold primary-nav divider

### DIFF
--- a/apps/harness/src/routes/__root.tsx
+++ b/apps/harness/src/routes/__root.tsx
@@ -236,7 +236,7 @@ function RootComponent() {
     <div className={shellClassName}>
       <nav
         aria-label="Primary"
-        className="mb-2 flex flex-wrap items-start gap-x-5 gap-y-3 border-b-2 border-ink pb-3"
+        className="primary-nav mb-2 flex flex-wrap items-start gap-x-5 gap-y-3 pb-3"
       >
         <div className="grid gap-1">
           <h1 className="m-0 font-serif text-[clamp(1.6rem,3.2vw,2.25rem)] leading-none font-semibold tracking-[-0.012em]">

--- a/apps/harness/src/routes/kanban.tsx
+++ b/apps/harness/src/routes/kanban.tsx
@@ -87,12 +87,7 @@ function KanbanPage() {
   const jobsBodyId = "kanban-jobs-card-body"
 
   return (
-    <main className="industrial-shell pt-8 sm:pt-10">
-      <header className="board-masthead">
-        <p className="board-kicker">Autonomous delivery control</p>
-        <h1 className="board-title">Work pipeline</h1>
-        <p className="board-deck">Live production flow from intake to merge.</p>
-      </header>
+    <main className="industrial-shell pt-6 sm:pt-8">
       <section aria-label="Committed pull requests" className="mb-5">
         <CommittedPullRequestsDashboard />
       </section>

--- a/apps/harness/src/styles.css
+++ b/apps/harness/src/styles.css
@@ -109,50 +109,17 @@
     border-top: 1px solid var(--color-rule-soft);
   }
 
+  /* Full-width bold rule under primary nav (shared across every route).
+     Visual weight matches the former Kanban board masthead separator. */
+  .primary-nav {
+    border-bottom: 0.5rem solid var(--color-ink);
+  }
+
   .industrial-shell {
     --industrial-ink: #151515;
     --industrial-paper: #f4f1e8;
     --industrial-concrete: #dedbd2;
     margin-inline: auto;
-  }
-
-  .board-masthead {
-    display: grid;
-    grid-template-columns: 1fr auto;
-    align-items: end;
-    margin-bottom: 1rem;
-    padding: clamp(2rem, 6vw, 5rem) 0 1.1rem;
-    border-bottom: 0.5rem solid var(--industrial-ink);
-  }
-
-  .board-kicker {
-    grid-column: 1 / -1;
-    margin: 0 0 0.5rem;
-    font-family: var(--font-mono);
-    font-size: 0.68rem;
-    font-weight: 800;
-    line-height: 1;
-    letter-spacing: 0.15em;
-    text-transform: uppercase;
-  }
-
-  .board-title {
-    margin: 0;
-    font-size: clamp(3rem, 8vw, 7.5rem);
-    font-weight: 950;
-    line-height: 0.8;
-    letter-spacing: -0.07em;
-    text-transform: uppercase;
-  }
-
-  .board-deck {
-    max-width: 17rem;
-    margin: 0 0 0.25rem 2rem;
-    font-family: var(--font-mono);
-    font-size: 0.78rem;
-    font-weight: 700;
-    line-height: 1.35;
-    text-transform: uppercase;
   }
 
   .industrial-shell > section[aria-label="Committed pull requests"] > article {
@@ -431,14 +398,6 @@
 }
 
 @media (max-width: 900px) {
-  .board-masthead {
-    display: block;
-  }
-
-  .board-deck {
-    margin: 1rem 0 0;
-  }
-
   .pipeline-controls {
     display: grid;
     min-width: 0;

--- a/apps/harness/test/kanban-route.test.ts
+++ b/apps/harness/test/kanban-route.test.ts
@@ -20,6 +20,39 @@ describe("/kanban route", () => {
     expect(source).toContain("<KanbanJobsBoard />")
   })
 
+  test("does not render the former board masthead (title, deck, or separator)", () => {
+    // Issue #670: decorative masthead is removed; content starts under primary nav.
+    const source = kanbanSource()
+    expect(source).not.toContain("board-masthead")
+    expect(source).not.toContain("board-kicker")
+    expect(source).not.toContain("board-title")
+    expect(source).not.toContain("board-deck")
+    expect(source).not.toContain("Autonomous delivery control")
+    expect(source).not.toContain("Work pipeline")
+    expect(source).not.toContain("Live production flow from intake to merge.")
+
+    // Committed PR dashboard is the first content landmark under main.
+    const main = source.slice(source.indexOf("<main"))
+    const firstSection = main.indexOf("<section")
+    expect(firstSection).toBeGreaterThan(-1)
+    expect(main.slice(firstSection, firstSection + 80)).toContain(
+      'aria-label="Committed pull requests"',
+    )
+    // Intentional top spacing only — no masthead-sized clamp padding.
+    expect(source).toMatch(/industrial-shell pt-6 sm:pt-8/)
+  })
+
+  test("drops obsolete masthead styles while keeping industrial pipeline chrome", () => {
+    const styles = stylesSource()
+    expect(styles).not.toContain(".board-masthead")
+    expect(styles).not.toContain(".board-kicker")
+    expect(styles).not.toContain(".board-title")
+    expect(styles).not.toContain(".board-deck")
+    // Pipeline board language remains.
+    expect(styles).toContain(".pipeline-board")
+    expect(styles).toContain(".industrial-shell")
+  })
+
   test("renders all six lifecycle lanes as an accessible pipeline", () => {
     const source = kanbanSource()
     expect(source).toContain('aria-label="Lifecycle pipeline"')

--- a/apps/harness/test/primary-nav.test.ts
+++ b/apps/harness/test/primary-nav.test.ts
@@ -5,6 +5,9 @@ import { describe, expect, test } from "bun:test"
 const rootSource = () =>
   readFileSync(join(import.meta.dir, "../src/routes/__root.tsx"), "utf8")
 
+const stylesSource = () =>
+  readFileSync(join(import.meta.dir, "../src/styles.css"), "utf8")
+
 describe("primary Home / Kanban navigation", () => {
   test("root chrome exposes Home and Kanban Link controls", () => {
     const source = rootSource()
@@ -13,6 +16,33 @@ describe("primary Home / Kanban navigation", () => {
     expect(source).toContain('to="/kanban"')
     expect(source).toMatch(/Home\s*<\/Link>/)
     expect(source).toMatch(/Kanban\s*<\/Link>/)
+  })
+
+  test("primary nav uses a full-width bold black divider on every route", () => {
+    // Issue #670: masthead 0.5rem rule moves under Clanker Harness nav (all routes).
+    const root = rootSource()
+    const styles = stylesSource()
+    const navOpen = root.indexOf('aria-label="Primary"')
+    expect(navOpen).toBeGreaterThan(-1)
+    const navTag = root.slice(navOpen - 80, navOpen + 160)
+    expect(navTag).toContain("primary-nav")
+    // Thin Tailwind border is no longer the nav rule.
+    expect(navTag).not.toMatch(/border-b-2\s+border-ink/)
+    // Shared weight matches the former Kanban masthead separator.
+    const primaryNavBlock = styles.slice(
+      styles.indexOf(".primary-nav {"),
+      styles.indexOf("}", styles.indexOf(".primary-nav {")) + 1,
+    )
+    expect(primaryNavBlock).toContain(".primary-nav {")
+    expect(primaryNavBlock).toContain(
+      "border-bottom: 0.5rem solid var(--color-ink)",
+    )
+    // Divider lives in root layout above Outlet — every child route inherits it.
+    const rootComponent = root.slice(root.indexOf("function RootComponent("))
+    expect(rootComponent.indexOf("primary-nav")).toBeGreaterThan(-1)
+    expect(rootComponent.indexOf("primary-nav")).toBeLessThan(
+      rootComponent.indexOf("<Outlet />"),
+    )
   })
 
   test("groups Home, Kanban, and Settings in one right-aligned control cluster", () => {


### PR DESCRIPTION
## Why

The Kanban masthead (kicker, "Work pipeline" title, deck copy, and thick
black rule) was decorative only and pushed the committed-PR dashboard and
Pipeline board down the page. Operators need the live floor immediately
under primary nav, with one consistent divider on every route.

## What changed

- Removed the Kanban board masthead markup and obsolete `.board-masthead` /
  `.board-kicker` / `.board-title` / `.board-deck` styles (including mobile
  overrides).
- Moved the masthead’s **0.5rem** bold black rule onto shared primary nav
  via a root-layout `.primary-nav` class so Home, Kanban, and other routes
  get the same full-width divider under Clanker Harness.
- Tightened Kanban top spacing (`pt-6 sm:pt-8`) so content starts without
  a masthead-sized empty gap.
- Left Pipeline controls, jobs tabs/filters/collapse, board lanes, and the
  committed-PR dashboard unchanged.

## Verification

- `bunx nx test harness` — 376 pass (includes updated `kanban-route` and
  `primary-nav` source tests for masthead removal and shared nav divider).
- Local code review: clean (no open findings).

## Notes

- Visual weight uses `var(--color-ink)` on primary nav (global token); the
  old masthead used industrial ink only under `.industrial-shell`.
- Residual risk is visual spacing under real desktop/mobile layouts, not
  functional pipeline behavior.

Closes #670