### PR TITLE
feat(harness): move repository management to a dedicated Repos page

### DIFF
--- a/apps/harness/e2e/steps/add-and-refresh-repository.ts
+++ b/apps/harness/e2e/steps/add-and-refresh-repository.ts
@@ -166,7 +166,26 @@ const ensureNoConfiguredRepositories = async () => {
 Given("the Harness has no configured Repositories", async ({ page }) => {
   test.setTimeout(SCENARIO_TIMEOUT_MS)
   await ensureNoConfiguredRepositories()
+  // Home keeps the dashboard and Jobs; empty-state guidance lives on /repos.
+  // Prefer collapse-independent landmarks (Jobs body may be collapsed).
   await page.goto("/")
+  await expect(
+    page.getByRole("region", { name: "Committed pull requests" }),
+  ).toBeVisible()
+  await expect(page.getByRole("heading", { name: "Jobs" })).toBeVisible()
+  await expect(
+    page
+      .getByRole("navigation", { name: "Primary" })
+      .getByRole("link", { name: "Repos" }),
+  ).toBeVisible()
+  await expect(
+    page.getByRole("region", { name: "Configured repositories" }),
+  ).toHaveCount(0)
+  await expect(
+    page.getByRole("heading", { name: "No repositories configured" }),
+  ).toHaveCount(0)
+
+  await page.goto("/repos")
   await expect(
     page.getByRole("heading", { name: "No repositories configured" }),
   ).toBeVisible()
@@ -174,16 +193,8 @@ Given("the Harness has no configured Repositories", async ({ page }) => {
     page.getByRole("region", { name: "Configured repositories" }),
   ).toHaveCount(0)
   await expect(
-    page.getByRole("region", { name: "Committed pull requests" }),
-  ).toHaveCount(0)
-  await expect(page.getByText("Today", { exact: true })).toHaveCount(0)
-  await expect(page.getByText("Yesterday", { exact: true })).toHaveCount(0)
-  await expect(page.getByText("This week", { exact: true })).toHaveCount(0)
-  await expect(page.getByText("Last week", { exact: true })).toHaveCount(0)
-  await expect(page.getByText("Two weeks ago", { exact: true })).toHaveCount(0)
-  await expect(page.getByRole("region", { name: "Jobs" })).toHaveCount(0)
-  await expect(page.getByRole("heading", { name: "Jobs" })).toHaveCount(0)
-  await expect(page.getByText("Add a repository to see jobs.")).toHaveCount(0)
+    page.getByRole("region", { name: "Add a repository" }),
+  ).toBeVisible()
 })
 
 Given("the End-to-End Fixture Repository is checked out", async ({ world }) => {
@@ -282,7 +293,7 @@ Then("the Repository appears in the Harness", async ({ page, world }) => {
   const forge = world.fixtureForge ?? "github"
   const display = world.fixtureDisplayRepository ?? displayRepositoryFor(forge)
 
-  await page.goto("/")
+  await page.goto("/repos")
   await expect(
     page.getByRole("region", { name: "Configured repositories" }),
   ).toBeVisible({ timeout: 30_000 })

--- a/apps/harness/e2e/steps/kanban-route.ts
+++ b/apps/harness/e2e/steps/kanban-route.ts
@@ -152,12 +152,15 @@ Then("I am on the Kanban board", async ({ page }) => {
 
 Then("I am on the Home dashboard", async ({ page }) => {
   await expect(page).toHaveURL(/\/$/)
-  // Home-only landmark present with zero or more Repositories (stable across
-  // the shared live-e2e database after other features add a checkout).
+  // Home keeps the dashboard + Jobs; repository management lives on /repos.
   await expect(
-    page.getByRole("region", { name: "Add a repository" }),
+    page.getByRole("region", { name: "Committed pull requests" }),
   ).toBeVisible()
+  await expect(page.getByRole("heading", { name: "Jobs" })).toBeVisible()
   await expect(
     page.getByRole("region", { name: "Lifecycle pipeline" }),
+  ).toHaveCount(0)
+  await expect(
+    page.getByRole("region", { name: "Configured repositories" }),
   ).toHaveCount(0)
 })

--- a/apps/harness/src/kanban-live.tsx
+++ b/apps/harness/src/kanban-live.tsx
@@ -10,8 +10,9 @@ import {
 
 /**
  * Mounts the Harness's existing live invalidation subscriptions for the
- * board-only route. Repository cards normally own these subscriptions on the
- * dashboard, so /kanban mounts them without rendering repository management.
+ * board-only route. Repository cards own these subscriptions on `/repos`, and
+ * Home mounts its own for Jobs, so /kanban mounts them without rendering
+ * repository management.
  */
 export function KanbanLiveUpdates({
   repositoryIds,

--- a/apps/harness/src/routeTree.gen.ts
+++ b/apps/harness/src/routeTree.gen.ts
@@ -12,6 +12,7 @@ import { Route as rootRouteImport } from './routes/__root'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as GraphqlRouteImport } from './routes/graphql'
 import { Route as KanbanRouteImport } from './routes/kanban'
+import { Route as ReposRouteImport } from './routes/repos'
 
 const IndexRoute = IndexRouteImport.update({
   id: '/',
@@ -28,35 +29,44 @@ const KanbanRoute = KanbanRouteImport.update({
   path: '/kanban',
   getParentRoute: () => rootRouteImport,
 } as any)
+const ReposRoute = ReposRouteImport.update({
+  id: '/repos',
+  path: '/repos',
+  getParentRoute: () => rootRouteImport,
+} as any)
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
   '/graphql': typeof GraphqlRoute
   '/kanban': typeof KanbanRoute
+  '/repos': typeof ReposRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
   '/graphql': typeof GraphqlRoute
   '/kanban': typeof KanbanRoute
+  '/repos': typeof ReposRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
   '/graphql': typeof GraphqlRoute
   '/kanban': typeof KanbanRoute
+  '/repos': typeof ReposRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
-  fullPaths: '/' | '/graphql' | '/kanban'
+  fullPaths: '/' | '/graphql' | '/kanban' | '/repos'
   fileRoutesByTo: FileRoutesByTo
-  to: '/' | '/graphql' | '/kanban'
-  id: '__root__' | '/' | '/graphql' | '/kanban'
+  to: '/' | '/graphql' | '/kanban' | '/repos'
+  id: '__root__' | '/' | '/graphql' | '/kanban' | '/repos'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
   GraphqlRoute: typeof GraphqlRoute
   KanbanRoute: typeof KanbanRoute
+  ReposRoute: typeof ReposRoute
 }
 
 declare module '@tanstack/react-router' {
@@ -82,6 +92,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof KanbanRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/repos': {
+      id: '/repos'
+      path: '/repos'
+      fullPath: '/repos'
+      preLoaderRoute: typeof ReposRouteImport
+      parentRoute: typeof rootRouteImport
+    }
   }
 }
 
@@ -89,6 +106,7 @@ const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   GraphqlRoute: GraphqlRoute,
   KanbanRoute: KanbanRoute,
+  ReposRoute: ReposRoute,
 }
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)

--- a/apps/harness/src/routes/__root.tsx
+++ b/apps/harness/src/routes/__root.tsx
@@ -203,6 +203,23 @@ function HomeNavIcon() {
   )
 }
 
+function ReposNavIcon() {
+  return (
+    <svg
+      aria-hidden="true"
+      className="size-3.5"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+    >
+      <path d="M4 7.5c0-1.5 3.6-2.5 8-2.5s8 1 8 2.5v9c0 1.5-3.6 2.5-8 2.5s-8-1-8-2.5v-9Z" />
+      <path d="M4 7.5c0 1.5 3.6 2.5 8 2.5s8-1 8-2.5" />
+      <path d="M4 12c0 1.5 3.6 2.5 8 2.5s8-1 8-2.5" />
+    </svg>
+  )
+}
+
 function KanbanNavIcon() {
   return (
     <svg
@@ -268,6 +285,15 @@ function RootComponent() {
               >
                 <HomeNavIcon />
                 Home
+              </Link>
+              <Link
+                to="/repos"
+                className={primaryNavLinkClassName}
+                inactiveProps={{ className: primaryNavLinkInactiveClassName }}
+                activeProps={{ className: primaryNavLinkActiveClassName }}
+              >
+                <ReposNavIcon />
+                Repos
               </Link>
               <Link
                 to="/kanban"
@@ -732,7 +758,7 @@ function SettingsButton({ leading }: { leading: ReactNode }) {
           </button>
         </div>
       )}
-      {/* Home / Kanban / Settings share one right-aligned control cluster.
+      {/* Home / Repos / Kanban / Settings share one right-aligned control cluster.
           Status banners above stay nav-level siblings (outside the cluster). */}
       <div className="ml-auto flex items-center gap-2 self-center">
         {leading}

--- a/apps/harness/src/routes/index.tsx
+++ b/apps/harness/src/routes/index.tsx
@@ -5,7 +5,7 @@ import {
   useQueryClient,
   useSuspenseQuery,
 } from "@tanstack/react-query"
-import { createFileRoute } from "@tanstack/react-router"
+import { Link, createFileRoute } from "@tanstack/react-router"
 import { type FormEvent, Suspense, useEffect, useRef, useState } from "react"
 import { createClient } from "@ready-for-agent/graphql-client"
 import { JOBS_COMPLETED_WINDOW_HOURS as jobsCompletedWindowHours } from "@ready-for-agent/work-item-lifecycle/jobs-completed-window"
@@ -527,25 +527,90 @@ export const Route = createFileRoute("/")({
 function HomePage() {
   return (
     <main className="pt-8 sm:pt-10">
-      <Suspense fallback={<RepositoryCardsSkeleton />}>
-        <HomeBody />
-      </Suspense>
+      <HomeBody />
     </main>
   )
 }
 
+/**
+ * Live invalidation for Home's Jobs list and committed-PR dashboard.
+ * Repository management owns its own subscriptions on `/repos`.
+ *
+ * Uses non-suspense queries so a repositories failure cannot unmount the
+ * dashboard. Jobs soft-fails repositories the same way (see JobsCard).
+ * Surfaces membership SSE transport-health so operators on Home still see
+ * when live updates are unavailable.
+ */
+function HomeLiveUpdates() {
+  const queryClient = useQueryClient()
+  const { data: repositories } = useQuery(repositoriesQuery)
+  const [liveUpdatesUnavailable, setLiveUpdatesUnavailable] = useState(false)
+  const repositoryIdsRef = useRef((repositories ?? []).map(({ id }) => id))
+  repositoryIdsRef.current = (repositories ?? []).map(({ id }) => id)
+
+  useEffect(() => {
+    const controller = new AbortController()
+    void followRepositoryMembershipLive({
+      queryClient,
+      repositoriesQuery,
+      signal: controller.signal,
+      onLiveUpdatesUnavailable: setLiveUpdatesUnavailable,
+    })
+    return () => controller.abort()
+  }, [queryClient])
+
+  useEffect(() => {
+    const controller = new AbortController()
+    void followRepositoryIssuesLive({
+      getRepositoryIds: () => repositoryIdsRef.current,
+      queryClient,
+      queries: {
+        repositories: repositoriesQuery,
+        issues: issuesQuery,
+        workItems: workItemsQuery,
+      },
+      signal: controller.signal,
+    })
+    return () => controller.abort()
+  }, [queryClient])
+
+  useEffect(() => {
+    const controller = new AbortController()
+    void followRepositoryWorkItemsLive({
+      getRepositoryIds: () => repositoryIdsRef.current,
+      queryClient,
+      queries: {
+        workItems: workItemsQuery,
+      },
+      signal: controller.signal,
+    })
+    return () => controller.abort()
+  }, [queryClient])
+
+  const warningPresentation = liveUpdatesWarningPresentation(
+    liveUpdatesUnavailable,
+  )
+  if (warningPresentation === null) {
+    return null
+  }
+  return (
+    <p
+      className="mb-4 border border-oxblood/40 bg-oxblood-wash px-4 py-3 text-sm text-oxblood-deep"
+      role="status"
+    >
+      {warningPresentation.message}
+    </p>
+  )
+}
+
 function HomeBody() {
-  const { data: repositories } = useSuspenseQuery(repositoriesQuery)
   const { collapsed: jobsCollapsed, toggleCollapsed: toggleJobsCollapsed } =
     useCardCollapsed(jobsCardCollapseId())
   const jobsBodyId = "jobs-card-body"
 
-  if (repositories.length === 0) {
-    return <RepositoryCards />
-  }
-
   return (
     <>
+      <HomeLiveUpdates />
       <section aria-label="Committed pull requests" className="mb-10">
         <CommittedPullRequestsDashboard />
       </section>
@@ -563,15 +628,10 @@ function HomeBody() {
         </div>
         {!jobsCollapsed && (
           <div id={jobsBodyId}>
-            <Suspense fallback={<JobsCardSkeleton />}>
-              <JobsCard />
-            </Suspense>
+            <JobsCard />
           </div>
         )}
       </section>
-      <div className="mt-10 border-t-2 border-ink pt-6">
-        <RepositoryCards />
-      </div>
     </>
   )
 }
@@ -722,7 +782,7 @@ export function CommittedPullRequestsDashboard() {
   )
 }
 
-function RepositoryCards() {
+export function RepositoryCards() {
   const queryClient = useQueryClient()
   const { data: repositories } = useSuspenseQuery(repositoriesQuery)
   const { data: addRepositoryCommand } = useSuspenseQuery(
@@ -851,7 +911,7 @@ function AddRepositoryGuidance({
   heading?: string
 }) {
   const queryClient = useQueryClient()
-  // Non-suspense: default false hides Browse until known so parent HomeBody
+  // Non-suspense: default false hides Browse until known so parent Repos
   // Suspense is not re-triggered after repositories/command already painted.
   const { data: directoryPickerAvailable = false } = useQuery(
     directoryPickerAvailableQuery,
@@ -3425,7 +3485,13 @@ function JobsCard() {
     workItemId: string
     sessionId: string
   } | null>(null)
-  const { data: repositories } = useSuspenseQuery(repositoriesQuery)
+  // Soft-fail repositories so a load error cannot unmount Home's dashboard
+  // (Suspense only catches promises; there is no ErrorBoundary on HomeBody).
+  const {
+    data: repositories = [],
+    isPending: repositoriesPending,
+    isError: repositoriesFailed,
+  } = useQuery(repositoriesQuery)
   const workingQueries = useQueries({
     queries: repositories.map((repository) =>
       jobsWorkingWorkItemsQuery(repository.id),
@@ -3488,16 +3554,38 @@ function JobsCard() {
       : selectedTab === "failed"
         ? failedQueries
         : completedQueries
-  const loading = activeQueries.some((query) => query.isLoading)
-  const failed = activeQueries.some((query) => query.isError)
+  const loading =
+    repositoriesPending || activeQueries.some((query) => query.isLoading)
+  const failed =
+    repositoriesFailed || activeQueries.some((query) => query.isError)
   const emptyMessage = jobsTabEmptyMessage(selectedTab)
   const listAriaLabel = jobsTabListAriaLabel(selectedTab)
+
+  if (repositoriesPending && repositories.length === 0) {
+    return <JobsCardSkeleton />
+  }
+
+  if (repositoriesFailed) {
+    return (
+      <article className="border border-oxblood/40 bg-oxblood-wash px-4 py-3 sm:px-5">
+        <p className="m-0 text-sm text-oxblood-deep" role="alert">
+          Could not load jobs. Please try again.
+        </p>
+      </article>
+    )
+  }
 
   if (repositories.length === 0) {
     return (
       <article className="border border-rule-2 bg-panel px-4 py-3 sm:px-5">
         <p className="m-0 font-serif text-sm italic text-ink-soft">
-          Add a repository to see jobs.
+          <Link
+            to="/repos"
+            className="text-oxblood underline decoration-rule underline-offset-4 hover:text-oxblood-deep"
+          >
+            Add a repository
+          </Link>{" "}
+          to see jobs.
         </p>
       </article>
     )
@@ -4103,7 +4191,7 @@ function RepositoryIssuesSkeleton() {
   )
 }
 
-function RepositoryCardsSkeleton() {
+export function RepositoryCardsSkeleton() {
   return (
     <section
       className="grid grid-cols-1 gap-8"

--- a/apps/harness/src/routes/repos.tsx
+++ b/apps/harness/src/routes/repos.tsx
@@ -1,0 +1,17 @@
+import { createFileRoute } from "@tanstack/react-router"
+import { Suspense } from "react"
+import { RepositoryCards, RepositoryCardsSkeleton } from "./index.js"
+
+export const Route = createFileRoute("/repos")({
+  component: ReposPage,
+})
+
+function ReposPage() {
+  return (
+    <main className="pt-8 sm:pt-10">
+      <Suspense fallback={<RepositoryCardsSkeleton />}>
+        <RepositoryCards />
+      </Suspense>
+    </main>
+  )
+}

--- a/apps/harness/test/committed-pr-dashboard.test.ts
+++ b/apps/harness/test/committed-pr-dashboard.test.ts
@@ -351,21 +351,19 @@ describe("Committed pull requests dashboard UI", () => {
     expect(dashboard).toContain("{twoWeeksAgo}")
   })
 
-  test("hides PR dashboard and Jobs when no repositories are configured", () => {
+  test("always shows PR dashboard and Jobs; repository management lives on /repos", () => {
     const source = homeSource()
     const homeBody = source.slice(
       source.indexOf("function HomeBody()"),
       source.indexOf("function CommittedPullRequestsDashboard()"),
     )
-    expect(homeBody).toContain("repositories.length === 0")
-    expect(homeBody).toContain("return <RepositoryCards />")
-    const emptyBranch = homeBody.slice(
-      homeBody.indexOf("repositories.length === 0"),
-      homeBody.indexOf("return ("),
-    )
-    expect(emptyBranch).not.toContain("<CommittedPullRequestsDashboard")
-    expect(emptyBranch).not.toContain("<JobsCard")
-    expect(emptyBranch).not.toContain('aria-label="Committed pull requests"')
-    expect(emptyBranch).not.toContain('aria-label="Jobs"')
+    expect(homeBody).toContain("<CommittedPullRequestsDashboard />")
+    expect(homeBody).toContain("<JobsCard />")
+    expect(homeBody).toContain('aria-label="Committed pull requests"')
+    expect(homeBody).toContain('aria-label="Jobs"')
+    // Repository cards / empty-state guidance moved off Home.
+    expect(homeBody).not.toContain("<RepositoryCards")
+    expect(homeBody).not.toContain("return <RepositoryCards />")
+    expect(homeBody).not.toContain("repositories.length === 0")
   })
 })

--- a/apps/harness/test/primary-nav.test.ts
+++ b/apps/harness/test/primary-nav.test.ts
@@ -8,13 +8,15 @@ const rootSource = () =>
 const stylesSource = () =>
   readFileSync(join(import.meta.dir, "../src/styles.css"), "utf8")
 
-describe("primary Home / Kanban navigation", () => {
-  test("root chrome exposes Home and Kanban Link controls", () => {
+describe("primary Home / Repos / Kanban navigation", () => {
+  test("root chrome exposes Home, Repos, and Kanban Link controls", () => {
     const source = rootSource()
     expect(source).toContain('aria-label="Primary"')
     expect(source).toContain('to="/"')
+    expect(source).toContain('to="/repos"')
     expect(source).toContain('to="/kanban"')
     expect(source).toMatch(/Home\s*<\/Link>/)
+    expect(source).toMatch(/Repos\s*<\/Link>/)
     expect(source).toMatch(/Kanban\s*<\/Link>/)
   })
 
@@ -45,7 +47,7 @@ describe("primary Home / Kanban navigation", () => {
     )
   })
 
-  test("groups Home, Kanban, and Settings in one right-aligned control cluster", () => {
+  test("groups Home, Repos, Kanban, and Settings in one right-aligned control cluster", () => {
     const source = rootSource()
     const clusterMarker =
       'className="ml-auto flex items-center gap-2 self-center"'
@@ -55,20 +57,24 @@ describe("primary Home / Kanban navigation", () => {
       /className="ml-auto inline-flex items-center gap-2 border/,
     )
 
-    // Home and Kanban are passed as leading into SettingsButton (same cluster).
+    // Home, Repos, and Kanban are passed as leading into SettingsButton (same cluster).
     const settingsBlock = source.slice(
       source.indexOf("<SettingsButton"),
       source.indexOf("</nav>"),
     )
     expect(settingsBlock).toContain("leading={")
     expect(settingsBlock).toContain('to="/"')
+    expect(settingsBlock).toContain('to="/repos"')
     expect(settingsBlock).toContain('to="/kanban"')
     expect(settingsBlock).toContain("<HomeNavIcon />")
+    expect(settingsBlock).toContain("<ReposNavIcon />")
     expect(settingsBlock).toContain("<KanbanNavIcon />")
     const homeIdx = settingsBlock.indexOf('to="/"')
+    const reposIdx = settingsBlock.indexOf('to="/repos"')
     const kanbanIdx = settingsBlock.indexOf('to="/kanban"')
     expect(homeIdx).toBeGreaterThan(-1)
-    expect(kanbanIdx).toBeGreaterThan(homeIdx)
+    expect(reposIdx).toBeGreaterThan(homeIdx)
+    expect(kanbanIdx).toBeGreaterThan(reposIdx)
 
     // Cluster wraps leading destinations and the Settings trigger.
     const clusterStart = source.indexOf(
@@ -89,14 +95,20 @@ describe("primary Home / Kanban navigation", () => {
     expect(brandIdx).toBeLessThan(source.indexOf("<SettingsButton"))
   })
 
-  test("Home and Kanban use stroke icons matching Settings icon language", () => {
+  test("Home, Repos, and Kanban use stroke icons matching Settings icon language", () => {
     const source = rootSource()
     expect(source).toContain("function HomeNavIcon()")
+    expect(source).toContain("function ReposNavIcon()")
     expect(source).toContain("function KanbanNavIcon()")
     expect(source).toContain("<HomeNavIcon />")
+    expect(source).toContain("<ReposNavIcon />")
     expect(source).toContain("<KanbanNavIcon />")
     // Icons: aria-hidden, size-3.5, stroke currentColor (same as Settings gear).
-    for (const iconFn of ["HomeNavIcon", "KanbanNavIcon"] as const) {
+    for (const iconFn of [
+      "HomeNavIcon",
+      "ReposNavIcon",
+      "KanbanNavIcon",
+    ] as const) {
       const start = source.indexOf(`function ${iconFn}(`)
       expect(start).toBeGreaterThan(-1)
       const body = source.slice(start, source.indexOf("\n}", start) + 2)
@@ -121,10 +133,10 @@ describe("primary Home / Kanban navigation", () => {
       "activeProps={{ className: primaryNavLinkActiveClassName }}",
     )
     // Home nav control (not the brand title Link) must use exact matching.
-    // Slice from the SettingsButton leading prop through the first destination.
+    // Slice from the SettingsButton leading prop through the first non-Home destination.
     const homeSwitcherLink = source.slice(
       source.indexOf("leading={"),
-      source.indexOf('to="/kanban"'),
+      source.indexOf('to="/repos"'),
     )
     expect(homeSwitcherLink).toContain('to="/"')
     expect(homeSwitcherLink).toContain("activeOptions={{ exact: true }}")
@@ -169,18 +181,21 @@ describe("primary Home / Kanban navigation", () => {
     expect(source).toMatch(
       /const primaryNavActionClassName =\s*\n?\s*"[^"]*text-ink-faint[^"]*"/,
     )
-    // Both destinations are client Links, not raw <a href> only.
+    // Destinations are client Links, not raw <a href> only.
     expect(source).not.toMatch(/<a\s+href=["']\/kanban["']/)
+    expect(source).not.toMatch(/<a\s+href=["']\/repos["']/)
     expect(source).not.toMatch(/<a\s+href=["']\/["']/)
   })
 
-  test("shared nav lives in root layout so Home and Kanban both inherit it", () => {
+  test("shared nav lives in root layout so Home, Repos, and Kanban all inherit it", () => {
     const source = rootSource()
     const rootComponent = source.slice(
       source.indexOf("function RootComponent("),
     )
+    expect(rootComponent).toContain('to="/repos"')
     expect(rootComponent).toContain('to="/kanban"')
     expect(rootComponent).toMatch(/Home\s*<\/Link>/)
+    expect(rootComponent).toMatch(/Repos\s*<\/Link>/)
     expect(rootComponent).toMatch(/Kanban\s*<\/Link>/)
     expect(rootComponent).toContain("<Outlet />")
     expect(rootComponent.indexOf("Home")).toBeLessThan(

--- a/apps/harness/test/repos-route.test.ts
+++ b/apps/harness/test/repos-route.test.ts
@@ -1,0 +1,124 @@
+import { readFileSync } from "node:fs"
+import { join } from "node:path"
+import { describe, expect, test } from "bun:test"
+
+const reposSource = () =>
+  readFileSync(join(import.meta.dir, "../src/routes/repos.tsx"), "utf8")
+
+const homeSource = () =>
+  readFileSync(join(import.meta.dir, "../src/routes/index.tsx"), "utf8")
+
+const rootSource = () =>
+  readFileSync(join(import.meta.dir, "../src/routes/__root.tsx"), "utf8")
+
+const routeTreeSource = () =>
+  readFileSync(join(import.meta.dir, "../src/routeTree.gen.ts"), "utf8")
+
+describe("/repos route", () => {
+  test("is a dedicated TanStack file route that renders repository cards", () => {
+    const source = reposSource()
+    expect(source).toContain('createFileRoute("/repos")')
+    expect(source).toContain("<RepositoryCards />")
+    expect(source).toContain("<RepositoryCardsSkeleton />")
+    expect(source).toContain('from "./index.js"')
+  })
+
+  test("is registered in the generated route tree", () => {
+    const source = routeTreeSource()
+    expect(source).toContain("from './routes/repos'")
+    expect(source).toContain("id: '/repos'")
+    expect(source).toContain("path: '/repos'")
+    expect(source).toContain("'/repos': typeof ReposRoute")
+  })
+
+  test("primary nav places Repos immediately after Home and before Kanban", () => {
+    const source = rootSource()
+    const settingsBlock = source.slice(
+      source.indexOf("<SettingsButton"),
+      source.indexOf("</nav>"),
+    )
+    const homeIdx = settingsBlock.indexOf('to="/"')
+    const reposIdx = settingsBlock.indexOf('to="/repos"')
+    const kanbanIdx = settingsBlock.indexOf('to="/kanban"')
+    expect(homeIdx).toBeGreaterThan(-1)
+    expect(reposIdx).toBeGreaterThan(homeIdx)
+    expect(kanbanIdx).toBeGreaterThan(reposIdx)
+    expect(settingsBlock).toMatch(/Repos\s*<\/Link>/)
+    // Active styling is shared with other primary destinations.
+    const reposLink = settingsBlock.slice(reposIdx, kanbanIdx)
+    expect(reposLink).toContain("primaryNavLinkClassName")
+    expect(reposLink).toContain(
+      "activeProps={{ className: primaryNavLinkActiveClassName }}",
+    )
+  })
+
+  test("Home no longer renders repository cards or add-repository guidance", () => {
+    const source = homeSource()
+    const homeBody = source.slice(
+      source.indexOf("function HomeBody()"),
+      source.indexOf("function CommittedPullRequestsDashboard()"),
+    )
+    expect(homeBody).toContain("<CommittedPullRequestsDashboard />")
+    expect(homeBody).toContain("<JobsCard />")
+    expect(homeBody).not.toContain("<RepositoryCards")
+    expect(homeBody).not.toContain("AddRepositoryGuidance")
+    expect(homeBody).not.toContain('aria-label="Configured repositories"')
+    // Empty-repo early return that replaced the dashboard is gone.
+    expect(homeBody).not.toContain("repositories.length === 0")
+    expect(homeBody).not.toContain("return <RepositoryCards />")
+  })
+
+  test("Home keeps Jobs and dashboard live updates without repository management", () => {
+    const source = homeSource()
+    expect(source).toContain("function HomeLiveUpdates()")
+    expect(source).toContain("<HomeLiveUpdates />")
+    const homeLive = source.slice(
+      source.indexOf("function HomeLiveUpdates()"),
+      source.indexOf("function HomeBody()"),
+    )
+    // Soft-fail: do not suspense-throw repositories errors over the dashboard.
+    expect(homeLive).toContain("useQuery(repositoriesQuery)")
+    expect(homeLive).not.toContain("useSuspenseQuery(repositoriesQuery)")
+    expect(homeLive).toContain("followRepositoryMembershipLive")
+    expect(homeLive).toContain("onLiveUpdatesUnavailable")
+    expect(homeLive).toContain("liveUpdatesWarningPresentation")
+    expect(homeLive).toContain("followRepositoryIssuesLive")
+    expect(homeLive).toContain("followRepositoryWorkItemsLive")
+    // Open PR header counts are repository-card chrome only.
+    expect(homeLive).not.toContain("followOpenPullRequestCountLive")
+  })
+
+  test("JobsCard soft-fails repositories so Home dashboard stays mounted", () => {
+    const source = homeSource()
+    const jobsCard = source.slice(
+      source.indexOf("function JobsCard()"),
+      source.indexOf("function JobsCardSkeleton()"),
+    )
+    expect(jobsCard).toContain("useQuery(repositoriesQuery)")
+    expect(jobsCard).not.toContain("useSuspenseQuery(repositoriesQuery)")
+    expect(jobsCard).toContain("repositoriesFailed")
+    expect(jobsCard).toContain("Could not load jobs. Please try again.")
+    // No Suspense wrapper around Jobs on Home (no suspense boundary needed).
+    const homeBody = source.slice(
+      source.indexOf("function HomeBody()"),
+      source.indexOf("function CommittedPullRequestsDashboard()"),
+    )
+    expect(homeBody).toContain("<JobsCard />")
+    expect(homeBody).not.toContain("Suspense fallback={<JobsCardSkeleton />}")
+  })
+
+  test("empty Jobs card links to /repos for add-repository discoverability", () => {
+    const source = homeSource()
+    const jobsCard = source.slice(
+      source.indexOf("function JobsCard()"),
+      source.indexOf("function JobsCardSkeleton()"),
+    )
+    const emptyBranch = jobsCard.slice(
+      jobsCard.indexOf("repositories.length === 0"),
+      jobsCard.indexOf("if (loading && activeItems.length === 0)"),
+    )
+    expect(emptyBranch).toContain('to="/repos"')
+    expect(emptyBranch).toContain("Add a repository")
+    expect(emptyBranch).toContain("to see jobs.")
+  })
+})


### PR DESCRIPTION
Why

Home mixed the committed-PR dashboard and Jobs with full
repository-management chrome. Operators need a clear dashboard surface,
and repository cards/add guidance belong on their own top-level page.

What

- Add primary nav Repos between Home and Kanban, with active-route styling.
- Add /repos that renders the existing repository cards, live updates,
  empty state, and add-repository guidance.
- Home always shows the committed-PR dashboard and Jobs; repository
  listing and add-repo guidance are no longer on Home.
- Soft-fail repositories on Home (HomeLiveUpdates + JobsCard use
  non-suspense queries) so a repositories load error cannot unmount the
  dashboard; empty Jobs links to /repos.
- Surface membership SSE transport-health on Home; keep open-PR count
  live follow on /repos.
- Update unit and e2e coverage for nav, route ownership, blank-slate
  landmarks, and repository appears on /repos.

Verification

- Harness UI unit tests for primary nav, /repos, Home soft-fail/live
  updates, dashboard, Jobs card, blank-slate guidance, and card collapse
  (all green in-session).
- Review passes after soft-fail, live-banner, and e2e landmark
  remediation.

Notes

- Optional follow-up: extract repository cards / shared live wiring out
  of the Home route mega-module (same pattern as Kanban today).

Closes #667