### PR TITLE
fix(harness): drop Working and Failed tabs from Kanban

### DIFF
--- a/apps/harness/src/routes/kanban.tsx
+++ b/apps/harness/src/routes/kanban.tsx
@@ -37,28 +37,16 @@ import {
   repositoriesQuery,
 } from "./index.js"
 
-type JobsTab = "pipeline" | "working" | "failed" | "completed"
+type JobsTab = "pipeline" | "completed"
 
 const JOBS_COMPLETED_TAB_LABEL = `Completed last ${JOBS_COMPLETED_WINDOW_HOURS} h`
 
 const JOBS_TABS = [
   { id: "pipeline", label: "Pipeline" },
-  { id: "working", label: "Working" },
-  { id: "failed", label: "Failed" },
   { id: "completed", label: JOBS_COMPLETED_TAB_LABEL },
 ] as const satisfies readonly { id: JobsTab; label: string }[]
 
-const jobsTabEmptyMessage = (tab: Exclude<JobsTab, "pipeline">): string => {
-  if (tab === "working") return "No working jobs."
-  if (tab === "failed") return "No failed jobs."
-  return `No jobs completed in the last ${JOBS_COMPLETED_WINDOW_HOURS} h.`
-}
-
-const jobsTabListAriaLabel = (tab: Exclude<JobsTab, "pipeline">): string => {
-  if (tab === "working") return "Working jobs"
-  if (tab === "failed") return "Failed jobs"
-  return JOBS_COMPLETED_TAB_LABEL
-}
+const JOBS_COMPLETED_EMPTY_MESSAGE = `No jobs completed in the last ${JOBS_COMPLETED_WINDOW_HOURS} h.`
 
 const sortNewestFirst = (items: readonly WorkItem[]): readonly WorkItem[] =>
   items
@@ -358,23 +346,14 @@ function KanbanJobsBoard() {
     selectedRepositoryId === null
       ? items
       : items.filter((item) => item.repositoryId === selectedRepositoryId)
-  const selectedListTab = selectedTab === "pipeline" ? null : selectedTab
   const activeItems =
-    selectedListTab === null
-      ? pipelineItems
-      : selectedListTab === "working"
-        ? workingItems
-        : selectedListTab === "failed"
-          ? failedItems
-          : completedItems
+    selectedTab === "pipeline" ? pipelineItems : completedItems
+  // Working/Failed list queries still feed the Pipeline board merge; Completed
+  // tab uses completed queries only. There are no Working/Failed tabs on Kanban.
   const activeQueries =
-    selectedListTab === null
+    selectedTab === "pipeline"
       ? [...workingQueries, ...failedQueries, ...completedQueries]
-      : selectedListTab === "working"
-        ? workingQueries
-        : selectedListTab === "failed"
-          ? failedQueries
-          : completedQueries
+      : completedQueries
   const loading = activeQueries.some((query) => query.isLoading)
   const failed = activeQueries.some((query) => query.isError)
   const visibleItems = repositoryFilteredItems(activeItems)
@@ -437,8 +416,6 @@ function KanbanJobsBoard() {
                 }}
               >
                 {tab.label}
-                {tab.id === "working" && ` (${workingItems.length})`}
-                {tab.id === "failed" && ` (${failedItems.length})`}
                 {tab.id === "completed" && ` (${completedItems.length})`}
               </button>
             )
@@ -472,7 +449,7 @@ function KanbanJobsBoard() {
         id={`jobs-panel-${selectedTab}`}
         aria-labelledby={`jobs-tab-${selectedTab}`}
       >
-        {selectedListTab === null ? (
+        {selectedTab === "pipeline" ? (
           <>
             <fieldset className="lane-switcher">
               <legend className="sr-only">Pipeline lane</legend>
@@ -553,13 +530,11 @@ function KanbanJobsBoard() {
             </section>
           </>
         ) : visibleItems.length === 0 ? (
-          <p className="pipeline-list-empty">
-            {jobsTabEmptyMessage(selectedListTab)}
-          </p>
+          <p className="pipeline-list-empty">{JOBS_COMPLETED_EMPTY_MESSAGE}</p>
         ) : (
           <ul
             className="pipeline-list m-0 grid list-none gap-2"
-            aria-label={jobsTabListAriaLabel(selectedListTab)}
+            aria-label={JOBS_COMPLETED_TAB_LABEL}
           >
             {visibleItems.map((workItem) => {
               const repository = repositoryById.get(workItem.repositoryId)

--- a/apps/harness/test/kanban-route.test.ts
+++ b/apps/harness/test/kanban-route.test.ts
@@ -61,22 +61,58 @@ describe("/kanban route", () => {
     expect(source.match(/\{lane\.label\}/g)).toHaveLength(2)
   })
 
-  test("retains accessible tabs, keyboard navigation, and repository filtering", () => {
+  test("retains accessible two-tab control, keyboard navigation, and repository filtering", () => {
+    // Issue #675: Working and Failed tabs are Home-only; Kanban keeps Pipeline
+    // (default) and Completed last 24 h.
     const source = kanbanSource()
+    expect(source).toContain('type JobsTab = "pipeline" | "completed"')
     expect(source).toContain('{ id: "pipeline", label: "Pipeline" }')
-    expect(source).toContain('{ id: "working", label: "Working" }')
-    expect(source).toContain('{ id: "failed", label: "Failed" }')
     expect(source).toContain(
       '{ id: "completed", label: JOBS_COMPLETED_TAB_LABEL }',
     )
     expect(source).toContain(
       "Completed last $" + "{JOBS_COMPLETED_WINDOW_HOURS} h",
     )
+    expect(source).not.toContain('{ id: "working", label: "Working" }')
+    expect(source).not.toContain('{ id: "failed", label: "Failed" }')
+    expect(source).not.toContain('label: "Working"')
+    expect(source).not.toContain('label: "Failed"')
+    expect(source).not.toContain("No working jobs.")
+    expect(source).not.toContain("No failed jobs.")
+    expect(source).not.toContain("Working jobs")
+    expect(source).not.toContain("Failed jobs")
+    expect(source).not.toContain('tab.id === "working"')
+    expect(source).not.toContain('tab.id === "failed"')
+    expect(source).not.toContain('selectedListTab === "working"')
+    expect(source).not.toContain('selectedListTab === "failed"')
+    expect(source).toContain("JOBS_COMPLETED_EMPTY_MESSAGE")
+    expect(source).toContain(
+      "No jobs completed in the last $" + "{JOBS_COMPLETED_WINDOW_HOURS} h.",
+    )
+    // Tab strip order: Pipeline then Completed only.
+    const jobsTabsBlock = source.slice(
+      source.indexOf("const JOBS_TABS = ["),
+      source.indexOf(
+        "] as const satisfies readonly { id: JobsTab; label: string }[]",
+      ),
+    )
+    const pipelineTabIndex = jobsTabsBlock.indexOf('label: "Pipeline"')
+    const completedTabIndex = jobsTabsBlock.indexOf(
+      "label: JOBS_COMPLETED_TAB_LABEL",
+    )
+    expect(pipelineTabIndex).toBeGreaterThan(-1)
+    expect(completedTabIndex).toBeGreaterThan(pipelineTabIndex)
+    expect(jobsTabsBlock).not.toContain("Working")
+    expect(jobsTabsBlock).not.toContain("Failed")
+    // Keyboard cycles only between the two remaining tabs.
     expect(source).toContain('role="tablist"')
     expect(source).toContain('role="tab"')
     expect(source).toContain("aria-selected={selected}")
     expect(source).toContain('event.key === "ArrowRight"')
     expect(source).toContain('event.key === "ArrowLeft"')
+    expect(source).toContain(
+      "(tabIndex + delta + JOBS_TABS.length) % JOBS_TABS.length",
+    )
     expect(source).toContain("All sources")
     expect(source).toContain("aria-pressed={selectedRepositoryId === null}")
     expect(source).toContain(
@@ -182,6 +218,8 @@ describe("/kanban route", () => {
   })
 
   test("reuses existing queries and live invalidation without polling", () => {
+    // Working/Failed list queries still feed the Pipeline board merge; they are
+    // not tab panels. Completed tab still uses jobsCompletedWorkItemsQuery.
     const source = kanbanSource()
     expect(source).toContain("jobsWorkingWorkItemsQuery")
     expect(source).toContain("jobsFailedWorkItemsQuery")
@@ -189,6 +227,11 @@ describe("/kanban route", () => {
     expect(source).toContain("issuesQuery")
     expect(source).toContain("repositoriesQuery")
     expect(source).toContain("<KanbanLiveUpdates")
+    // No Working/Failed tab selection that isolates those query sets for a list.
+    expect(source).not.toContain("selectedListTab")
+    expect(source).not.toMatch(
+      /selectedTab === "working"|selectedTab === "failed"/,
+    )
     expect(source).not.toContain("queryFn:")
     expect(source).not.toContain("createClient(")
     expect(source).not.toContain("setInterval")

--- a/docs/kanban.md
+++ b/docs/kanban.md
@@ -71,13 +71,15 @@ operator-facing ticket, rather than the prototype's exact palette or fonts.
 
 ## Interaction Model
 
-The Jobs area has four tabs:
+The Jobs area has two tabs:
 
 1. Pipeline is the default and renders the six lanes.
-2. Working retains the existing active-work list.
-3. Failed retains the existing failed-work list.
-4. Completed last 24 h shows every work item completed in the rolling previous
+2. Completed last 24 h shows every work item completed in the rolling previous
    24 hours (no fixed item limit).
+
+Working and Failed list tabs remain on the Home Jobs card only; Kanban does not
+duplicate those lists. Pipeline still assembles tickets from the existing
+working, failed, and completed Work Item queries.
 
 The existing arrow-key tab behavior, selected-tab ARIA semantics, Jobs collapse
 control, retry/reset/start/pause actions, Session usage dialog, issue links,
@@ -87,7 +89,7 @@ presentation, not a reduced-action overview.
 Repository filters sit above the board:
 
 - `All sources` shows every repository.
-- A repository filter limits every lane and every non-Pipeline tab to that
+- A repository filter limits every lane and the Completed tab to that
   repository.
 - Filter selection is local UI state and does not alter repository settings or
   the underlying queries.
@@ -161,9 +163,9 @@ systems.
 - Queued status-check polls and other queued later steps stay in their
   lifecycle lane; only blockers / worker-slot holds appear in Queue.
 - Every ticket preserves access to its existing operational actions.
-- Existing Working, Failed, and Completed views remain available and keyboard
-  accessible.
-- Repository filtering applies consistently to both board and list views.
+- Pipeline and Completed remain available and keyboard accessible; Working and
+  Failed lists stay on Home only.
+- Repository filtering applies consistently to both board and Completed list.
 - Desktop shows all six lanes; mobile shows a selected lane without horizontal
   page overflow.
 - No new polling or GraphQL contract is introduced.


### PR DESCRIPTION
## Why

Kanban Jobs had four tabs (Pipeline, Working, Failed, Completed). Working
and Failed duplicated the Home Jobs lists and added noise to a view meant
for flow. Issue #675 asks to keep only Pipeline and Completed last 24 h on
`/kanban`.

## What changed

- Kanban tab strip is **Pipeline** (default) then **Completed last 24 h**
  only; arrow-key navigation cycles those two tabs.
- Removed Working/Failed tab labels, counts, empty states, list panels, and
  tab-selection branching.
- Pipeline still merges working, failed, and completed Work Item queries
  for the six-lane board (data sources, not tabs).
- Completed tab behavior (24 h window, sorting, cards, repository filters,
  empty state, count) is unchanged.
- Home Jobs (`index.tsx`) still has Working / Failed / Completed.
- Updated `kanban-route` tests and `docs/kanban.md` for the two-tab model.
- Review follow-up: clarified a comment so it does not imply Working/Failed
  queries feed the Completed tab.

## Verification

- `apps/harness/test/kanban-route.test.ts` and
  `jobs-card-no-polling.test.ts` (Home still three tabs).
- Full `harness:test` suite passed (376 tests).

## Limitations

No e2e scenario was re-run for tab-strip UI; coverage is route/unit source
tests plus the existing Kanban e2e steps that already assert the default
Pipeline tab.

Closes #675