### PR TITLE
feat(harness): collapse earlier-lane lifecycle chips on Kanban tickets

### DIFF
--- a/apps/harness/src/pipeline-lanes.ts
+++ b/apps/harness/src/pipeline-lanes.ts
@@ -6,6 +6,9 @@ export type PipelineLaneId =
   | "attention"
   | "complete"
 
+/** Lifecycle lanes that host step chips (Build → Review → PR order). */
+export type LifecyclePipelineLaneId = "build" | "review" | "pr"
+
 export const PIPELINE_LANES = [
   { id: "queue", label: "Queue", color: "#ffd21c", text: "#151515" },
   { id: "build", label: "Build", color: "#1976d2", text: "#ffffff" },
@@ -19,6 +22,60 @@ export const PIPELINE_LANES = [
   color: string
   text: string
 }[]
+
+/** Ordered lifecycle lanes used for earlier-lane chip collapse. */
+export const LIFECYCLE_PIPELINE_LANE_ORDER = [
+  "build",
+  "review",
+  "pr",
+] as const satisfies readonly LifecyclePipelineLaneId[]
+
+const LIFECYCLE_LANE_LABEL: Record<LifecyclePipelineLaneId, string> = {
+  build: "Build",
+  review: "Review",
+  pr: "PR",
+}
+
+/**
+ * Work Item states that place a ticket in Build. Shared with chip phase
+ * grouping so board placement and Kanban chip collapse stay aligned.
+ */
+export const BUILD_LIFECYCLE_STATES = [
+  "CREATE_WORKTREE",
+  "INSTALL_DEPENDENCIES",
+  "IMPLEMENT",
+  "ASSESS_CHANGES",
+  "PRE_COMMIT",
+] as const
+
+/** Work Item states that place a ticket in Review. */
+export const REVIEW_LIFECYCLE_STATES = ["REVIEW"] as const
+
+/**
+ * Work Item states that place a ticket in PR (Commit through local cleanup).
+ * Chip phase GITHUB_STATUS_CHECKS is the collapsed watch/investigate phase
+ * and also maps to PR even though it is not a Work Item state.
+ */
+export const PR_LIFECYCLE_STATES = [
+  "COMMIT",
+  "CREATE_PR",
+  "WATCH_PR_STATUS_CHECKS",
+  "RESOLVE_PR_MERGE_CONFLICT",
+  "INVESTIGATE_PR_STATUS_CHECKS",
+  "MARK_PR_READY_FOR_REVIEW",
+  "DECIDE_PR_MERGE",
+  "MERGE_PR",
+  "CLOSE_ISSUE",
+  "LOCAL_CLEANUP",
+] as const
+
+const BUILD_PHASES = new Set<string>(BUILD_LIFECYCLE_STATES)
+const REVIEW_PHASES = new Set<string>(REVIEW_LIFECYCLE_STATES)
+const PR_PHASES = new Set<string>([
+  ...PR_LIFECYCLE_STATES,
+  // Collapsed GitHub status-checks phase from lifecycleLabels projection.
+  "GITHUB_STATUS_CHECKS",
+])
 
 type PipelineWorkItem = {
   readonly state: string
@@ -60,36 +117,215 @@ export function pipelineLaneFor(workItem: PipelineWorkItem): PipelineLaneId {
     return "queue"
   }
 
-  if (
-    workItem.state === "CREATE_WORKTREE" ||
-    workItem.state === "INSTALL_DEPENDENCIES" ||
-    workItem.state === "IMPLEMENT" ||
-    workItem.state === "ASSESS_CHANGES" ||
-    workItem.state === "PRE_COMMIT"
-  ) {
-    return "build"
-  }
-
-  if (workItem.state === "REVIEW") {
-    return "review"
-  }
-
-  if (
-    workItem.state === "COMMIT" ||
-    workItem.state === "CREATE_PR" ||
-    workItem.state === "WATCH_PR_STATUS_CHECKS" ||
-    workItem.state === "RESOLVE_PR_MERGE_CONFLICT" ||
-    workItem.state === "INVESTIGATE_PR_STATUS_CHECKS" ||
-    workItem.state === "MARK_PR_READY_FOR_REVIEW" ||
-    workItem.state === "DECIDE_PR_MERGE" ||
-    workItem.state === "MERGE_PR" ||
-    workItem.state === "CLOSE_ISSUE" ||
-    workItem.state === "LOCAL_CLEANUP"
-  ) {
-    return "pr"
+  const lifecycleLane = lifecycleLaneForState(workItem.state)
+  if (lifecycleLane !== null) {
+    return lifecycleLane
   }
 
   // Unrecognized non-terminal state: keep off Queue so cards do not oscillate.
   // When the lifecycle gains a step, extend Build, Review, or PR above.
   return "pr"
+}
+
+/** Map a Work Item operational state to its lifecycle lane (ignores status). */
+export function lifecycleLaneForState(
+  state: string,
+): LifecyclePipelineLaneId | null {
+  if ((BUILD_LIFECYCLE_STATES as readonly string[]).includes(state)) {
+    return "build"
+  }
+  if ((REVIEW_LIFECYCLE_STATES as readonly string[]).includes(state)) {
+    return "review"
+  }
+  if ((PR_LIFECYCLE_STATES as readonly string[]).includes(state)) {
+    return "pr"
+  }
+  return null
+}
+
+/**
+ * Map a lifecycle chip phase to Build / Review / PR. Matches board placement
+ * phase sets; GITHUB_STATUS_CHECKS counts as PR.
+ */
+export function lifecycleLaneForPhase(
+  phase: string,
+): LifecyclePipelineLaneId | null {
+  if (BUILD_PHASES.has(phase)) return "build"
+  if (REVIEW_PHASES.has(phase)) return "review"
+  if (PR_PHASES.has(phase)) return "pr"
+  return null
+}
+
+export function lifecycleLaneLabel(lane: LifecyclePipelineLaneId): string {
+  return LIFECYCLE_LANE_LABEL[lane]
+}
+
+/**
+ * Chip focus lane for Kanban collapse. Uses lifecycle progress from state
+ * alone so Attention tickets still expand the Build/Review/PR path they are
+ * on. Queue hold statuses do not collapse (chips are usually absent).
+ */
+export function lifecycleFocusLaneFor(workItem: {
+  readonly state: string
+  readonly status: string
+  readonly lifecycleLabels?: readonly { readonly phase: string }[]
+}): LifecyclePipelineLaneId | null {
+  if (
+    workItem.status === "WAITING_FOR_BLOCKERS" ||
+    workItem.status === "WAITING_FOR_WORKER_SLOT"
+  ) {
+    return null
+  }
+
+  const fromState = lifecycleLaneForState(workItem.state)
+  if (fromState !== null) {
+    return fromState
+  }
+
+  // Terminal / attention state values (FAILED, NEEDS_HUMAN, COMPLETE, …):
+  // fall back to the latest chip phase so earlier lanes can still collapse.
+  const labels = workItem.lifecycleLabels
+  if (labels === undefined || labels.length === 0) {
+    return null
+  }
+  for (let index = labels.length - 1; index >= 0; index -= 1) {
+    const label = labels[index]
+    if (label === undefined) continue
+    const lane = lifecycleLaneForPhase(label.phase)
+    if (lane !== null) {
+      return lane
+    }
+  }
+  return null
+}
+
+/** Lifecycle lanes strictly earlier than focus, in Build → Review → PR order. */
+export function earlierLifecycleLanes(
+  focusLane: LifecyclePipelineLaneId,
+): readonly LifecyclePipelineLaneId[] {
+  const focusIndex = LIFECYCLE_PIPELINE_LANE_ORDER.indexOf(focusLane)
+  if (focusIndex <= 0) {
+    return []
+  }
+  return LIFECYCLE_PIPELINE_LANE_ORDER.slice(0, focusIndex)
+}
+
+export type LifecycleLabelChip = {
+  readonly phase: string
+  readonly label: string
+  readonly status: string
+  readonly durationMs: number | null
+}
+
+/**
+ * Sum chip durations for a lane summary. Null durations are omitted; returns
+ * null when every chip has a null duration (no sum to display).
+ */
+export function sumLaneDurationMs(
+  chips: readonly Pick<LifecycleLabelChip, "durationMs">[],
+): number | null {
+  let total = 0
+  let hasDuration = false
+  for (const chip of chips) {
+    if (chip.durationMs === null) continue
+    hasDuration = true
+    total += chip.durationMs
+  }
+  return hasDuration ? total : null
+}
+
+export type LifecycleChipPresentationBlock =
+  | {
+      readonly kind: "earlier-lane"
+      readonly lane: LifecyclePipelineLaneId
+      readonly laneLabel: string
+      readonly durationMs: number | null
+      readonly expanded: boolean
+      readonly chips: readonly LifecycleLabelChip[]
+    }
+  | {
+      readonly kind: "focus-lane"
+      readonly lane: LifecyclePipelineLaneId | null
+      readonly chips: readonly LifecycleLabelChip[]
+    }
+  | {
+      readonly kind: "full-list"
+      readonly chips: readonly LifecycleLabelChip[]
+    }
+
+/**
+ * Plan Kanban (or full) chip presentation. When collapse is off or focus is
+ * unknown, returns a single full-list block. Expanded earlier lanes are those
+ * present in `expandedEarlierLanes` (ephemeral UI set).
+ */
+export function planLifecycleChipPresentation(
+  labels: readonly LifecycleLabelChip[],
+  options: {
+    readonly collapseEarlierLanes: boolean
+    readonly focusLane: LifecyclePipelineLaneId | null
+    readonly expandedEarlierLanes: ReadonlySet<LifecyclePipelineLaneId>
+  },
+): readonly LifecycleChipPresentationBlock[] {
+  if (
+    !options.collapseEarlierLanes ||
+    options.focusLane === null ||
+    labels.length === 0
+  ) {
+    return [{ kind: "full-list", chips: labels }]
+  }
+
+  const byLane = new Map<LifecyclePipelineLaneId, LifecycleLabelChip[]>()
+  const ungrouped: LifecycleLabelChip[] = []
+  for (const label of labels) {
+    const lane = lifecycleLaneForPhase(label.phase)
+    if (lane === null) {
+      ungrouped.push(label)
+      continue
+    }
+    const existing = byLane.get(lane)
+    if (existing === undefined) {
+      byLane.set(lane, [label])
+    } else {
+      existing.push(label)
+    }
+  }
+
+  const blocks: LifecycleChipPresentationBlock[] = []
+  for (const earlier of earlierLifecycleLanes(options.focusLane)) {
+    const chips = byLane.get(earlier)
+    if (chips === undefined || chips.length === 0) continue
+    blocks.push({
+      kind: "earlier-lane",
+      lane: earlier,
+      laneLabel: lifecycleLaneLabel(earlier),
+      durationMs: sumLaneDurationMs(chips),
+      expanded: options.expandedEarlierLanes.has(earlier),
+      chips,
+    })
+  }
+
+  // Focus-lane chips always expanded. Also surface any later-lane chips (and
+  // ungrouped phases) so a focus that lags retained history never drops steps.
+  const focusIndex = LIFECYCLE_PIPELINE_LANE_ORDER.indexOf(options.focusLane)
+  const laterChips: LifecycleLabelChip[] = []
+  for (const lane of LIFECYCLE_PIPELINE_LANE_ORDER.slice(focusIndex + 1)) {
+    const chips = byLane.get(lane)
+    if (chips !== undefined && chips.length > 0) {
+      laterChips.push(...chips)
+    }
+  }
+  const focusChips = [
+    ...(byLane.get(options.focusLane) ?? []),
+    ...laterChips,
+    ...ungrouped,
+  ]
+  if (focusChips.length > 0 || blocks.length === 0) {
+    blocks.push({
+      kind: "focus-lane",
+      lane: options.focusLane,
+      chips: focusChips,
+    })
+  }
+
+  return blocks
 }

--- a/apps/harness/src/pipeline-lanes.ts
+++ b/apps/harness/src/pipeline-lanes.ts
@@ -24,7 +24,7 @@ export const PIPELINE_LANES = [
 }[]
 
 /** Ordered lifecycle lanes used for earlier-lane chip collapse. */
-export const LIFECYCLE_PIPELINE_LANE_ORDER = [
+const LIFECYCLE_PIPELINE_LANE_ORDER = [
   "build",
   "review",
   "pr",
@@ -40,7 +40,7 @@ const LIFECYCLE_LANE_LABEL: Record<LifecyclePipelineLaneId, string> = {
  * Work Item states that place a ticket in Build. Shared with chip phase
  * grouping so board placement and Kanban chip collapse stay aligned.
  */
-export const BUILD_LIFECYCLE_STATES = [
+const BUILD_LIFECYCLE_STATES = [
   "CREATE_WORKTREE",
   "INSTALL_DEPENDENCIES",
   "IMPLEMENT",
@@ -49,14 +49,14 @@ export const BUILD_LIFECYCLE_STATES = [
 ] as const
 
 /** Work Item states that place a ticket in Review. */
-export const REVIEW_LIFECYCLE_STATES = ["REVIEW"] as const
+const REVIEW_LIFECYCLE_STATES = ["REVIEW"] as const
 
 /**
  * Work Item states that place a ticket in PR (Commit through local cleanup).
  * Chip phase GITHUB_STATUS_CHECKS is the collapsed watch/investigate phase
  * and also maps to PR even though it is not a Work Item state.
  */
-export const PR_LIFECYCLE_STATES = [
+const PR_LIFECYCLE_STATES = [
   "COMMIT",
   "CREATE_PR",
   "WATCH_PR_STATUS_CHECKS",
@@ -156,7 +156,7 @@ export function lifecycleLaneForPhase(
   return null
 }
 
-export function lifecycleLaneLabel(lane: LifecyclePipelineLaneId): string {
+function lifecycleLaneLabel(lane: LifecyclePipelineLaneId): string {
   return LIFECYCLE_LANE_LABEL[lane]
 }
 

--- a/apps/harness/src/routes/index.tsx
+++ b/apps/harness/src/routes/index.tsx
@@ -40,6 +40,12 @@ import {
   ParentIssueActionsMenu,
   isParentImplementAllWithAutoMergeEligible,
 } from "../parent-issue-actions-menu.js"
+import {
+  type LifecycleLabelChip,
+  type LifecyclePipelineLaneId,
+  lifecycleFocusLaneFor,
+  planLifecycleChipPresentation,
+} from "../pipeline-lanes.js"
 import { followRepositoryIssuesLive } from "../refresh-issues-live.js"
 import {
   followOpenPullRequestCountLive,
@@ -3976,11 +3982,17 @@ export function WorkItemPauseButton({ workItem }: { workItem: WorkItem }) {
 export function WorkItemLifecycleStatus({
   workItem,
   compact = false,
+  /**
+   * Kanban-only: collapse earlier Build/Review/PR lane chips into summary
+   * rows. Home Jobs and other surfaces leave this off for the full list.
+   */
+  collapseEarlierLanes = false,
   pullRequestUrl = null,
   issueUrl = null,
 }: {
   workItem: WorkItem
   compact?: boolean
+  collapseEarlierLanes?: boolean
   pullRequestUrl?: string | null
   issueUrl?: string | null
 }) {
@@ -4014,6 +4026,9 @@ export function WorkItemLifecycleStatus({
       0,
     )
   const nowMs = useNowMs(true)
+  const [expandedEarlierLanes, setExpandedEarlierLanes] = useState(
+    () => new Set<LifecyclePipelineLaneId>(),
+  )
   const patchWorkItem = (updated: WorkItem) => {
     patchWorkItemsCaches(queryClient, workItem.repositoryId, (current) =>
       current?.map((candidate) =>
@@ -4059,6 +4074,84 @@ export function WorkItemLifecycleStatus({
     prNumber === null &&
     workItem.completionSummary !== null &&
     workItem.completionSummary.trim() !== ""
+  const focusLane = collapseEarlierLanes
+    ? lifecycleFocusLaneFor(workItem)
+    : null
+  const chipBlocks = planLifecycleChipPresentation(workItem.lifecycleLabels, {
+    collapseEarlierLanes,
+    focusLane,
+    expandedEarlierLanes,
+  })
+  const toggleEarlierLane = (lane: LifecyclePipelineLaneId) => {
+    setExpandedEarlierLanes((current) => {
+      const next = new Set(current)
+      if (next.has(lane)) {
+        next.delete(lane)
+      } else {
+        next.add(lane)
+      }
+      return next
+    })
+  }
+  const renderLifecycleChip = (lifecycleLabel: LifecycleLabelChip) => {
+    const displayDurationMs = liveDurationMs(
+      lifecycleLabel.durationMs,
+      isLiveDurationStatus(lifecycleLabel.status),
+      dataUpdatedAt,
+      nowMs,
+    )
+    const linkToPullRequest =
+      !isNoChangeComplete &&
+      pullRequestUrl !== null &&
+      openPullRequestLabel !== null &&
+      lifecycleLabel.phase === "DECIDE_PR_MERGE" &&
+      lifecycleLabel.status === "NEEDS_HUMAN"
+    const chipClassName = lifecycleStepChipClassName
+    const duration = displayDurationMs !== null && (
+      <span className="ml-1 font-mono text-ink-faint">
+        {formatDuration(displayDurationMs)}
+      </span>
+    )
+    return (
+      <li key={lifecycleLabel.phase}>
+        {linkToPullRequest ? (
+          <a
+            className={`${chipClassName} hover:underline`}
+            href={pullRequestUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            aria-label={`${openPullRequestLabel}: ${lifecycleLabel.label}`}
+          >
+            {lifecycleLabel.label}
+            {duration}
+          </a>
+        ) : (
+          <span className={chipClassName}>
+            {lifecycleLabel.label}
+            {duration}
+          </span>
+        )}
+      </li>
+    )
+  }
+  const renderChipList = (
+    chips: readonly LifecycleLabelChip[],
+    options?: {
+      readonly id?: string
+      readonly className?: string
+      readonly ariaLabel?: string
+    },
+  ) => (
+    <ol
+      id={options?.id}
+      className={
+        options?.className ?? "mt-2 mb-0 flex list-none flex-wrap gap-1 p-0"
+      }
+      aria-label={options?.ariaLabel ?? "Lifecycle steps"}
+    >
+      {chips.map(renderLifecycleChip)}
+    </ol>
+  )
 
   return (
     <div className={compact ? "mt-2" : "field-rule mt-2 ml-11 px-3 py-2"}>
@@ -4076,54 +4169,62 @@ export function WorkItemLifecycleStatus({
           issueUrl={issueUrl}
         />
       </div>
-      {workItem.lifecycleLabels.length > 0 && (
-        <ol
-          className="mt-2 mb-0 flex list-none flex-wrap gap-1 p-0"
-          aria-label="Lifecycle steps"
-        >
-          {workItem.lifecycleLabels.map((lifecycleLabel) => {
-            const displayDurationMs = liveDurationMs(
-              lifecycleLabel.durationMs,
-              isLiveDurationStatus(lifecycleLabel.status),
-              dataUpdatedAt,
-              nowMs,
-            )
-            const linkToPullRequest =
-              !isNoChangeComplete &&
-              pullRequestUrl !== null &&
-              openPullRequestLabel !== null &&
-              lifecycleLabel.phase === "DECIDE_PR_MERGE" &&
-              lifecycleLabel.status === "NEEDS_HUMAN"
-            const chipClassName = lifecycleStepChipClassName
-            const duration = displayDurationMs !== null && (
-              <span className="ml-1 font-mono text-ink-faint">
-                {formatDuration(displayDurationMs)}
-              </span>
-            )
-            return (
-              <li key={lifecycleLabel.phase}>
-                {linkToPullRequest ? (
-                  <a
-                    className={`${chipClassName} hover:underline`}
-                    href={pullRequestUrl}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    aria-label={`${openPullRequestLabel}: ${lifecycleLabel.label}`}
-                  >
-                    {lifecycleLabel.label}
-                    {duration}
-                  </a>
-                ) : (
-                  <span className={chipClassName}>
-                    {lifecycleLabel.label}
-                    {duration}
-                  </span>
-                )}
-              </li>
-            )
-          })}
-        </ol>
-      )}
+      {workItem.lifecycleLabels.length > 0 &&
+        (chipBlocks.length === 1 && chipBlocks[0]?.kind === "full-list" ? (
+          renderChipList(chipBlocks[0].chips)
+        ) : (
+          <div className="mt-2 flex flex-col gap-1">
+            {chipBlocks.map((block) => {
+              if (block.kind === "earlier-lane") {
+                const chipsId = `lifecycle-lane-${workItem.id}-${block.lane}`
+                const durationLabel =
+                  block.durationMs === null
+                    ? null
+                    : formatDuration(block.durationMs)
+                return (
+                  <div key={block.lane} className="min-w-0">
+                    <button
+                      type="button"
+                      className="inline-flex max-w-full items-center gap-2 border border-rule-2 bg-paper px-1.5 py-1 text-xs text-ink-2 transition hover:border-oxblood hover:text-oxblood focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-oxblood"
+                      aria-expanded={block.expanded}
+                      aria-controls={block.expanded ? chipsId : undefined}
+                      onClick={() => toggleEarlierLane(block.lane)}
+                    >
+                      <span aria-hidden="true">
+                        {block.expanded ? "▾" : "▸"}
+                      </span>
+                      <span>{block.laneLabel}</span>
+                      {durationLabel !== null && (
+                        <span className="font-mono text-ink-faint">
+                          {durationLabel}
+                        </span>
+                      )}
+                    </button>
+                    {block.expanded &&
+                      renderChipList(block.chips, {
+                        id: chipsId,
+                        className:
+                          "mt-1 mb-0 flex list-none flex-wrap gap-1 p-0",
+                        ariaLabel: `${block.laneLabel} lifecycle steps`,
+                      })}
+                  </div>
+                )
+              }
+              if (block.kind === "focus-lane") {
+                if (block.chips.length === 0) return null
+                return (
+                  <div key="focus-lane">
+                    {renderChipList(block.chips, {
+                      className: "m-0 flex list-none flex-wrap gap-1 p-0",
+                      ariaLabel: "Current lifecycle steps",
+                    })}
+                  </div>
+                )
+              }
+              return <div key="full-list">{renderChipList(block.chips)}</div>
+            })}
+          </div>
+        ))}
       {workItem.statusMessage !== null && (
         <p className={`mt-1.5 mb-0 text-xs ${statusMessageClassName}`}>
           {workItem.statusMessage}

--- a/apps/harness/src/routes/kanban.tsx
+++ b/apps/harness/src/routes/kanban.tsx
@@ -267,6 +267,7 @@ function PipelineTicket({
         <WorkItemLifecycleStatus
           workItem={workItem}
           compact
+          collapseEarlierLanes
           issueUrl={issueUrl}
           pullRequestUrl={pullRequestUrl}
         />

--- a/apps/harness/test/kanban-route.test.ts
+++ b/apps/harness/test/kanban-route.test.ts
@@ -174,11 +174,54 @@ describe("/kanban route", () => {
     )
     expect(ticket).toContain('laneId === "complete"')
     expect(ticket).toContain("<PipelineCompleteSummary")
-    // Non-Merged lanes keep the full compact lifecycle status.
+    // Non-Merged lanes keep compact lifecycle status with earlier-lane collapse.
     expect(ticket).toContain("<WorkItemLifecycleStatus")
+    expect(ticket).toContain("collapseEarlierLanes")
     const completeBranch = ticket.slice(ticket.indexOf("isCompleteLane ? ("))
     expect(completeBranch).toContain("<PipelineCompleteSummary")
     expect(completeBranch).toContain("<WorkItemLifecycleStatus")
+  })
+
+  test("Kanban tickets opt into earlier-lane lifecycle chip collapse", () => {
+    // Issue #679: Kanban-only presentation; Home Jobs leaves collapseEarlierLanes off.
+    const source = kanbanSource()
+    const ticket = source.slice(
+      source.indexOf("function PipelineTicket("),
+      source.indexOf("function KanbanJobsBoard()"),
+    )
+    expect(ticket).toContain("collapseEarlierLanes")
+    // Prop is only on the non-Merged WorkItemLifecycleStatus branch.
+    const lifecycleCall = ticket.slice(
+      ticket.indexOf("<WorkItemLifecycleStatus"),
+      ticket.indexOf("/>", ticket.indexOf("<WorkItemLifecycleStatus")) + 2,
+    )
+    expect(lifecycleCall).toContain("collapseEarlierLanes")
+    expect(lifecycleCall).toContain("compact")
+
+    const home = readFileSync(
+      join(import.meta.dir, "../src/routes/index.tsx"),
+      "utf8",
+    )
+    const completedRow = readFileSync(
+      join(import.meta.dir, "../src/completed-work-item-row.tsx"),
+      "utf8",
+    )
+    // Non-Kanban call sites must not opt into collapse (default remains false).
+    const nonKanbanSources = [home, completedRow]
+    let nonKanbanCallCount = 0
+    for (const nonKanbanSource of nonKanbanSources) {
+      const calls = [
+        ...nonKanbanSource.matchAll(/<WorkItemLifecycleStatus[\s\S]*?\/>/g),
+      ].map((match) => match[0])
+      nonKanbanCallCount += calls.length
+      for (const call of calls) {
+        expect(call).not.toContain("collapseEarlierLanes")
+      }
+    }
+    expect(nonKanbanCallCount).toBeGreaterThan(0)
+    // Only the Kanban ticket path opts in; the prop defaults off elsewhere.
+    expect(home).toContain("collapseEarlierLanes = false")
+    expect(source.match(/collapseEarlierLanes/g)).toHaveLength(1)
   })
 
   test("Kanban list tabs share Merged-lane compact summary via pipelineLaneFor", () => {

--- a/apps/harness/test/pipeline-lanes.test.ts
+++ b/apps/harness/test/pipeline-lanes.test.ts
@@ -1,7 +1,15 @@
 import {
+  type LifecycleLabelChip,
+  type LifecyclePipelineLaneId,
   PIPELINE_LANES,
   type PipelineLaneId,
+  earlierLifecycleLanes,
+  lifecycleFocusLaneFor,
+  lifecycleLaneForPhase,
+  lifecycleLaneForState,
   pipelineLaneFor,
+  planLifecycleChipPresentation,
+  sumLaneDurationMs,
 } from "../src/pipeline-lanes.js"
 import { describe, expect, test } from "bun:test"
 
@@ -188,5 +196,320 @@ describe("pipelineLaneFor", () => {
         status: "QUEUED",
       }),
     ).toBe("pr")
+  })
+})
+
+describe("lifecycleLaneForPhase", () => {
+  test.each([
+    ["CREATE_WORKTREE", "build"],
+    ["INSTALL_DEPENDENCIES", "build"],
+    ["IMPLEMENT", "build"],
+    ["ASSESS_CHANGES", "build"],
+    ["PRE_COMMIT", "build"],
+    ["REVIEW", "review"],
+    ["COMMIT", "pr"],
+    ["CREATE_PR", "pr"],
+    ["WATCH_PR_STATUS_CHECKS", "pr"],
+    ["INVESTIGATE_PR_STATUS_CHECKS", "pr"],
+    ["GITHUB_STATUS_CHECKS", "pr"],
+    ["RESOLVE_PR_MERGE_CONFLICT", "pr"],
+    ["MARK_PR_READY_FOR_REVIEW", "pr"],
+    ["DECIDE_PR_MERGE", "pr"],
+    ["MERGE_PR", "pr"],
+    ["CLOSE_ISSUE", "pr"],
+    ["LOCAL_CLEANUP", "pr"],
+  ] as const)("maps phase %s to %s", (phase, lane) => {
+    expect(lifecycleLaneForPhase(phase)).toBe(lane)
+  })
+
+  test("returns null for unknown phases", () => {
+    expect(lifecycleLaneForPhase("UNKNOWN_PHASE")).toBeNull()
+  })
+})
+
+describe("lifecycleLaneForState", () => {
+  test("mirrors Build / Review / PR placement sets without status overrides", () => {
+    expect(lifecycleLaneForState("IMPLEMENT")).toBe("build")
+    expect(lifecycleLaneForState("REVIEW")).toBe("review")
+    expect(lifecycleLaneForState("CREATE_PR")).toBe("pr")
+    expect(lifecycleLaneForState("FAILED")).toBeNull()
+    expect(lifecycleLaneForState("NEEDS_HUMAN")).toBeNull()
+  })
+})
+
+describe("lifecycleFocusLaneFor", () => {
+  test("uses lifecycle state for Build / Review / PR tickets", () => {
+    expect(
+      lifecycleFocusLaneFor({ state: "IMPLEMENT", status: "RUNNING" }),
+    ).toBe("build")
+    expect(lifecycleFocusLaneFor({ state: "REVIEW", status: "QUEUED" })).toBe(
+      "review",
+    )
+    expect(
+      lifecycleFocusLaneFor({
+        state: "WATCH_PR_STATUS_CHECKS",
+        status: "RUNNING",
+      }),
+    ).toBe("pr")
+  })
+
+  test("Attention tickets still focus the lifecycle lane from state", () => {
+    expect(lifecycleFocusLaneFor({ state: "REVIEW", status: "FAILED" })).toBe(
+      "review",
+    )
+    expect(
+      lifecycleFocusLaneFor({
+        state: "MERGE_PR",
+        status: "NEEDS_HUMAN",
+      }),
+    ).toBe("pr")
+    expect(
+      lifecycleFocusLaneFor({
+        state: "IMPLEMENT",
+        status: "INTERRUPTED",
+      }),
+    ).toBe("build")
+  })
+
+  test("Queue hold statuses disable chip-collapse focus", () => {
+    expect(
+      lifecycleFocusLaneFor({
+        state: "CREATE_WORKTREE",
+        status: "WAITING_FOR_BLOCKERS",
+      }),
+    ).toBeNull()
+    expect(
+      lifecycleFocusLaneFor({
+        state: "IMPLEMENT",
+        status: "WAITING_FOR_WORKER_SLOT",
+      }),
+    ).toBeNull()
+  })
+
+  test("falls back to the latest chip phase when state is non-operational", () => {
+    expect(
+      lifecycleFocusLaneFor({
+        state: "FAILED",
+        status: "FAILED",
+        lifecycleLabels: [{ phase: "IMPLEMENT" }, { phase: "REVIEW" }],
+      }),
+    ).toBe("review")
+  })
+})
+
+describe("earlierLifecycleLanes", () => {
+  test("returns earlier lanes in Build → Review → PR order", () => {
+    expect(earlierLifecycleLanes("build")).toEqual([])
+    expect(earlierLifecycleLanes("review")).toEqual(["build"])
+    expect(earlierLifecycleLanes("pr")).toEqual(["build", "review"])
+  })
+})
+
+describe("sumLaneDurationMs", () => {
+  test("sums non-null chip durations and skips nulls", () => {
+    expect(
+      sumLaneDurationMs([
+        { durationMs: 1_000 },
+        { durationMs: null },
+        { durationMs: 2_500 },
+      ]),
+    ).toBe(3_500)
+  })
+
+  test("returns null when every duration is null", () => {
+    expect(
+      sumLaneDurationMs([{ durationMs: null }, { durationMs: null }]),
+    ).toBeNull()
+  })
+})
+
+function chip(
+  phase: string,
+  durationMs: number | null = 1_000,
+): LifecycleLabelChip {
+  return {
+    phase,
+    label: `${phase}: Succeeded`,
+    status: "SUCCEEDED",
+    durationMs,
+  }
+}
+
+describe("planLifecycleChipPresentation", () => {
+  const buildReviewPr: readonly LifecycleLabelChip[] = [
+    chip("CREATE_WORKTREE", 10_000),
+    chip("IMPLEMENT", 30_000),
+    chip("REVIEW", 20_000),
+    chip("COMMIT", 5_000),
+    chip("CREATE_PR", 8_000),
+  ]
+
+  test("PR focus collapses Build and Review as earlier-lane summaries", () => {
+    const blocks = planLifecycleChipPresentation(buildReviewPr, {
+      collapseEarlierLanes: true,
+      focusLane: "pr",
+      expandedEarlierLanes: new Set(),
+    })
+    expect(blocks).toEqual([
+      {
+        kind: "earlier-lane",
+        lane: "build",
+        laneLabel: "Build",
+        durationMs: 40_000,
+        expanded: false,
+        chips: [chip("CREATE_WORKTREE", 10_000), chip("IMPLEMENT", 30_000)],
+      },
+      {
+        kind: "earlier-lane",
+        lane: "review",
+        laneLabel: "Review",
+        durationMs: 20_000,
+        expanded: false,
+        chips: [chip("REVIEW", 20_000)],
+      },
+      {
+        kind: "focus-lane",
+        lane: "pr",
+        chips: [chip("COMMIT", 5_000), chip("CREATE_PR", 8_000)],
+      },
+    ])
+  })
+
+  test("Review focus collapses Build only; Review chips stay expanded", () => {
+    const labels = [chip("IMPLEMENT", 12_000), chip("REVIEW", 9_000)] as const
+    const blocks = planLifecycleChipPresentation(labels, {
+      collapseEarlierLanes: true,
+      focusLane: "review",
+      expandedEarlierLanes: new Set(),
+    })
+    expect(blocks).toEqual([
+      {
+        kind: "earlier-lane",
+        lane: "build",
+        laneLabel: "Build",
+        durationMs: 12_000,
+        expanded: false,
+        chips: [chip("IMPLEMENT", 12_000)],
+      },
+      {
+        kind: "focus-lane",
+        lane: "review",
+        chips: [chip("REVIEW", 9_000)],
+      },
+    ])
+  })
+
+  test("Build focus shows no earlier-lane summaries", () => {
+    const labels = [chip("CREATE_WORKTREE"), chip("IMPLEMENT")] as const
+    const blocks = planLifecycleChipPresentation(labels, {
+      collapseEarlierLanes: true,
+      focusLane: "build",
+      expandedEarlierLanes: new Set(),
+    })
+    expect(blocks).toEqual([
+      {
+        kind: "focus-lane",
+        lane: "build",
+        chips: [chip("CREATE_WORKTREE"), chip("IMPLEMENT")],
+      },
+    ])
+  })
+
+  test("expanding one earlier lane is independent of the others", () => {
+    const collapsed = planLifecycleChipPresentation(buildReviewPr, {
+      collapseEarlierLanes: true,
+      focusLane: "pr",
+      expandedEarlierLanes: new Set(),
+    })
+    const expandedBuild = planLifecycleChipPresentation(buildReviewPr, {
+      collapseEarlierLanes: true,
+      focusLane: "pr",
+      expandedEarlierLanes: new Set<LifecyclePipelineLaneId>(["build"]),
+    })
+    expect(
+      collapsed
+        .filter((block) => block.kind === "earlier-lane")
+        .map((block) => [block.lane, block.expanded]),
+    ).toEqual([
+      ["build", false],
+      ["review", false],
+    ])
+    expect(
+      expandedBuild
+        .filter((block) => block.kind === "earlier-lane")
+        .map((block) => [block.lane, block.expanded]),
+    ).toEqual([
+      ["build", true],
+      ["review", false],
+    ])
+  })
+
+  test("non-Kanban path keeps the full chip list (no lane summaries)", () => {
+    const blocks = planLifecycleChipPresentation(buildReviewPr, {
+      collapseEarlierLanes: false,
+      focusLane: "pr",
+      expandedEarlierLanes: new Set(),
+    })
+    expect(blocks).toEqual([{ kind: "full-list", chips: buildReviewPr }])
+  })
+
+  test("Queue / missing focus keeps the full chip list", () => {
+    const blocks = planLifecycleChipPresentation(buildReviewPr, {
+      collapseEarlierLanes: true,
+      focusLane: null,
+      expandedEarlierLanes: new Set(),
+    })
+    expect(blocks).toEqual([{ kind: "full-list", chips: buildReviewPr }])
+  })
+
+  test("summary duration equals the sum of that lane’s chip durations", () => {
+    const blocks = planLifecycleChipPresentation(
+      [
+        chip("CREATE_WORKTREE", 1_000),
+        chip("IMPLEMENT", null),
+        chip("PRE_COMMIT", 4_000),
+        chip("REVIEW", 2_000),
+      ],
+      {
+        collapseEarlierLanes: true,
+        focusLane: "review",
+        expandedEarlierLanes: new Set(),
+      },
+    )
+    const build = blocks.find(
+      (block) => block.kind === "earlier-lane" && block.lane === "build",
+    )
+    expect(build).toMatchObject({
+      kind: "earlier-lane",
+      durationMs: 5_000,
+    })
+    if (build?.kind === "earlier-lane") {
+      expect(sumLaneDurationMs(build.chips)).toBe(build.durationMs)
+    }
+  })
+
+  test("later-than-focus chips stay expanded after focus-lane chips", () => {
+    // Defensive: if focus lags retained history, do not drop later steps.
+    const labels = [
+      chip("IMPLEMENT", 10_000),
+      chip("REVIEW", 20_000),
+      chip("CREATE_PR", 5_000),
+    ] as const
+    const blocks = planLifecycleChipPresentation(labels, {
+      collapseEarlierLanes: true,
+      focusLane: "build",
+      expandedEarlierLanes: new Set(),
+    })
+    expect(blocks).toEqual([
+      {
+        kind: "focus-lane",
+        lane: "build",
+        chips: [
+          chip("IMPLEMENT", 10_000),
+          chip("REVIEW", 20_000),
+          chip("CREATE_PR", 5_000),
+        ],
+      },
+    ])
   })
 })


### PR DESCRIPTION
## Why

Kanban tickets rendered every lifecycle chip that had ever run. In Review
or PR, earlier Build (and Review) chips crowded the card and buried the
steps that matter for the current lane. Operators scanning the PR lane
need Commit / Create PR / status-check progress, not a wall of succeeded
Create worktree → Review chips.

## What

Kanban-only lane-scoped chip collapse (Home Jobs and other surfaces keep
the full list):

- Shared Build / Review / PR phase sets in `pipeline-lanes` for placement
  and chip grouping
- Earlier lifecycle lanes collapse to `▸ {Lane} {summed duration}`
  summaries
- Per-lane expand/collapse is independent and ephemeral (not persisted)
- Focus-lane chips stay fully expanded; Attention focuses by lifecycle
  state while staying in the Attention column
- Queue leaves chips unchanged; Merged still uses the compact complete
  summary (no step chips)
- Summary duration sums chip `durationMs` values (nulls skipped), not
  live-ticking

Review follow-ups: `aria-controls` only when expanded; later-than-focus
chips retained; non-Kanban call sites covered in tests.

## Verification

- `bunx nx test harness` (includes new `planLifecycleChipPresentation`
  and Kanban opt-in/out coverage)
- `bunx nx run harness:lint`
- `bunx nx run harness:typecheck`

Closes #679