### PR TITLE
fix(harness): drop pipeline Jobs header band and collapse

### DIFF
--- a/apps/harness/src/routes/kanban.tsx
+++ b/apps/harness/src/routes/kanban.tsx
@@ -1,8 +1,6 @@
 import { useQueries, useSuspenseQuery } from "@tanstack/react-query"
 import { createFileRoute } from "@tanstack/react-router"
 import { type CSSProperties, Suspense, useState } from "react"
-import { jobsCardCollapseId, useCardCollapsed } from "../card-collapse.js"
-import { CardCollapseToggle } from "../card-collapse-toggle.js"
 import { Copy } from "../copy.js"
 import { KanbanLiveUpdates } from "../kanban-live.js"
 import {
@@ -70,41 +68,15 @@ export const Route = createFileRoute("/kanban")({
 })
 
 function KanbanPage() {
-  const { collapsed: jobsCollapsed, toggleCollapsed: toggleJobsCollapsed } =
-    useCardCollapsed(jobsCardCollapseId())
-  const jobsBodyId = "kanban-jobs-card-body"
-
   return (
     <main className="industrial-shell pt-6 sm:pt-8">
       <section aria-label="Committed pull requests" className="mb-5">
         <CommittedPullRequestsDashboard />
       </section>
       <section aria-label="Jobs" className="pipeline-section">
-        <div className="section-rail">
-          <div>
-            <p className="section-index">01 / Live floor</p>
-            <h2 className="section-title">Pipeline</h2>
-          </div>
-          <div className="flex items-center gap-3">
-            <span className="live-marker">
-              <span aria-hidden="true" />
-              Live
-            </span>
-            <CardCollapseToggle
-              collapsed={jobsCollapsed}
-              onToggle={toggleJobsCollapsed}
-              controlsId={jobsBodyId}
-              label="Jobs"
-            />
-          </div>
-        </div>
-        {!jobsCollapsed && (
-          <div id={jobsBodyId}>
-            <Suspense fallback={<JobsCardSkeleton />}>
-              <KanbanJobsBoard />
-            </Suspense>
-          </div>
-        )}
+        <Suspense fallback={<JobsCardSkeleton />}>
+          <KanbanJobsBoard />
+        </Suspense>
       </section>
     </main>
   )

--- a/apps/harness/src/styles.css
+++ b/apps/harness/src/styles.css
@@ -128,53 +128,6 @@
     box-shadow: 5px 5px 0 var(--industrial-ink);
   }
 
-  .section-rail {
-    display: flex;
-    align-items: end;
-    justify-content: space-between;
-    gap: 1rem;
-    padding: 1rem 0 0.75rem;
-  }
-
-  .section-index {
-    margin: 0 0 0.2rem;
-    color: var(--color-ink-faint);
-    font-family: var(--font-mono);
-    font-size: 0.65rem;
-    font-weight: 800;
-    line-height: 1;
-    letter-spacing: 0.12em;
-    text-transform: uppercase;
-  }
-
-  .section-title {
-    margin: 0;
-    font-size: clamp(1.6rem, 3vw, 2.6rem);
-    font-weight: 950;
-    line-height: 0.95;
-    letter-spacing: -0.04em;
-    text-transform: uppercase;
-  }
-
-  .live-marker {
-    display: inline-flex;
-    align-items: center;
-    gap: 0.4rem;
-    font-family: var(--font-mono);
-    font-size: 0.65rem;
-    font-weight: 800;
-    line-height: 1;
-    letter-spacing: 0.1em;
-    text-transform: uppercase;
-  }
-
-  .live-marker span {
-    width: 0.55rem;
-    height: 0.55rem;
-    background: #009c68;
-    animation: industrial-pulse 1.8s steps(2) infinite;
-  }
-
   .pipeline-controls {
     display: flex;
     flex-wrap: wrap;
@@ -388,12 +341,6 @@
 
   .lane-switcher {
     display: none;
-  }
-}
-
-@keyframes industrial-pulse {
-  50% {
-    opacity: 0.3;
   }
 }
 

--- a/apps/harness/test/kanban-route.test.ts
+++ b/apps/harness/test/kanban-route.test.ts
@@ -42,14 +42,56 @@ describe("/kanban route", () => {
     expect(source).toMatch(/industrial-shell pt-6 sm:pt-8/)
   })
 
-  test("drops obsolete masthead styles while keeping industrial pipeline chrome", () => {
+  test("does not render the Jobs section header band (eyebrow, title, LIVE, collapse)", () => {
+    // Issue #681: header band is gone; board mounts unconditionally. Tab/source
+    // filter chrome stays inside KanbanJobsBoard (see tabs/filtering test).
+    const source = kanbanSource()
+    expect(source).not.toContain("section-rail")
+    expect(source).not.toContain("section-index")
+    expect(source).not.toContain("section-title")
+    expect(source).not.toContain("live-marker")
+    expect(source).not.toContain("01 / Live floor")
+    expect(source).not.toContain("Live floor")
+    expect(source).not.toContain("<CardCollapseToggle")
+    expect(source).not.toContain("jobsCardCollapseId")
+    expect(source).not.toContain("useCardCollapsed")
+    expect(source).not.toContain("jobsCollapsed")
+    expect(source).not.toContain("kanban-jobs-card-body")
+    expect(source).toContain("<KanbanJobsBoard />")
+    expect(source).not.toContain("!jobsCollapsed &&")
+
+    // KanbanPage itself has no title/eyebrow chrome above the board.
+    const page = source.slice(
+      source.indexOf("function KanbanPage("),
+      source.indexOf("function PipelineCompleteSummary"),
+    )
+    expect(page).not.toContain("section-rail")
+    expect(page).not.toContain("Pipeline</h2>")
+    expect(page).toContain("<KanbanJobsBoard />")
+
+    // Filter controls remain the board's leading chrome (before the lane grid).
+    const board = source.slice(source.indexOf("function KanbanJobsBoard("))
+    const controlsIndex = board.indexOf("pipeline-controls")
+    const pipelineBoardIndex = board.indexOf("pipeline-board")
+    expect(controlsIndex).toBeGreaterThan(-1)
+    expect(pipelineBoardIndex).toBeGreaterThan(controlsIndex)
+  })
+
+  test("drops obsolete masthead and section-header styles while keeping industrial pipeline chrome", () => {
     const styles = stylesSource()
     expect(styles).not.toContain(".board-masthead")
     expect(styles).not.toContain(".board-kicker")
     expect(styles).not.toContain(".board-title")
     expect(styles).not.toContain(".board-deck")
+    // Issue #681: section-rail header band styles are gone.
+    expect(styles).not.toContain(".section-rail")
+    expect(styles).not.toContain(".section-index")
+    expect(styles).not.toContain(".section-title")
+    expect(styles).not.toContain(".live-marker")
+    expect(styles).not.toContain("industrial-pulse")
     // Pipeline board language remains.
     expect(styles).toContain(".pipeline-board")
+    expect(styles).toContain(".pipeline-controls")
     expect(styles).toContain(".industrial-shell")
   })
 
@@ -122,7 +164,7 @@ describe("/kanban route", () => {
 
   test("retains board controls and excludes repository management", () => {
     const source = kanbanSource()
-    expect(source).toContain("<CardCollapseToggle")
+    // Section collapse absence is covered by the #681 header-band test above.
     expect(source).toContain("<SessionUsageDialog")
     expect(source).toContain("<WorkItemPauseButton")
     expect(source).toContain("<WorkItemLifecycleStatus")


### PR DESCRIPTION
Why

The pipeline page middle header (eyebrow, large title, LIVE marker,
collapse) was product noise. Filter tabs and source chips should be
the primary chrome under the app shell (#681).

What changed

- Removed the Jobs section header band on /kanban (01 / Live floor,
  Pipeline title, LIVE indicator, collapse control).
- Always mount KanbanJobsBoard (no section collapse gate or
  localStorage collapse state on this page).
- Deleted unused styles: section-rail, section-index, section-title,
  live-marker, industrial-pulse.
- Home Jobs/repo collapse is unchanged.
- Tests assert header/collapse absence, retained filter chrome order
  (pipeline-controls before pipeline-board), and obsolete CSS cleanup.

Verification

- bun unit tests for apps/harness/test/kanban-route.test.ts (18 pass)
- Earlier session: full harness test suite and harness:lint clean
  after the implementation

Limitations

- Source-string route tests only; no e2e visual check of the header
  gap in this session.

Closes #681