### PR TITLE
fix(harness): keep chrome full-width and replace Kanban nav with Home

### DIFF
--- a/apps/harness/e2e/features/kanban-route.feature
+++ b/apps/harness/e2e/features/kanban-route.feature
@@ -18,30 +18,30 @@ Feature: View the work pipeline
     And repository management is not rendered
     And the committed pull request totals are visible above the board
 
-  Scenario: Switch from Repos to Kanban via top nav
+  Scenario: Switch from Repos to Home via top nav
     Given the Harness has no configured Repositories
     And the End-to-End Fixture Repository is checked out
     When I add the Repository with the CLI
     And I open the Repos page
     Then the Repos top nav control is active
-    And the Kanban top nav control is not active
-    When I click the Kanban top nav control
+    And the Home top nav control is not active
+    When I click the Home top nav control
     Then I am on the Kanban board
     And all six pipeline lane headers are visible
-    And the Kanban top nav control is active
+    And the Home top nav control is active
     And the Repos top nav control is not active
 
-  Scenario: Switch from Kanban to Repos via top nav
+  Scenario: Switch from Home to Repos via top nav
     Given the Harness has no configured Repositories
     And the End-to-End Fixture Repository is checked out
     When I add the Repository with the CLI
     And I navigate to the Kanban board
-    Then the Kanban top nav control is active
+    Then the Home top nav control is active
     And the Repos top nav control is not active
     When I click the Repos top nav control
     Then I am on the Repos page
     And the Repos top nav control is active
-    And the Kanban top nav control is not active
+    And the Home top nav control is not active
 
   Scenario: Legacy /kanban path lands on the home board
     Given the Harness has no configured Repositories
@@ -49,4 +49,4 @@ Feature: View the work pipeline
     When I add the Repository with the CLI
     And I navigate to the legacy Kanban path
     Then I am on the Kanban board
-    And the Kanban top nav control is active
+    And the Home top nav control is active

--- a/apps/harness/e2e/steps/kanban-route.ts
+++ b/apps/harness/e2e/steps/kanban-route.ts
@@ -56,9 +56,9 @@ When("I open the Repos page", async ({ page }) => {
   await dismissFirstRunSettings(page)
 })
 
-When("I click the Kanban top nav control", async ({ page }) => {
+When("I click the Home top nav control", async ({ page }) => {
   await primaryNav(page)
-    .getByRole("link", { name: "Kanban", exact: true })
+    .getByRole("link", { name: "Home", exact: true })
     .click()
 })
 
@@ -134,13 +134,13 @@ Then("the Repos top nav control is active", async ({ page }) => {
   await expect(repos).toHaveAttribute("aria-current", "page")
 })
 
-Then("the Kanban top nav control is active", async ({ page }) => {
-  const kanban = primaryNav(page).getByRole("link", {
-    name: "Kanban",
+Then("the Home top nav control is active", async ({ page }) => {
+  const home = primaryNav(page).getByRole("link", {
+    name: "Home",
     exact: true,
   })
-  await expect(kanban).toBeVisible()
-  await expect(kanban).toHaveAttribute("aria-current", "page")
+  await expect(home).toBeVisible()
+  await expect(home).toHaveAttribute("aria-current", "page")
 })
 
 Then("the Repos top nav control is not active", async ({ page }) => {
@@ -152,13 +152,13 @@ Then("the Repos top nav control is not active", async ({ page }) => {
   await expect(repos).not.toHaveAttribute("aria-current", "page")
 })
 
-Then("the Kanban top nav control is not active", async ({ page }) => {
-  const kanban = primaryNav(page).getByRole("link", {
-    name: "Kanban",
+Then("the Home top nav control is not active", async ({ page }) => {
+  const home = primaryNav(page).getByRole("link", {
+    name: "Home",
     exact: true,
   })
-  await expect(kanban).toBeVisible()
-  await expect(kanban).not.toHaveAttribute("aria-current", "page")
+  await expect(home).toBeVisible()
+  await expect(home).not.toHaveAttribute("aria-current", "page")
 })
 
 Then("I am on the Kanban board", async ({ page }) => {

--- a/apps/harness/src/routes/__root.tsx
+++ b/apps/harness/src/routes/__root.tsx
@@ -11,7 +11,6 @@ import {
   Outlet,
   Scripts,
   createRootRouteWithContext,
-  useLocation,
 } from "@tanstack/react-router"
 import { TanStackRouterDevtools } from "@tanstack/react-router-devtools"
 import {
@@ -186,6 +185,23 @@ const primaryNavLinkActiveClassName = "border-ink bg-paper-2 text-ink"
 const primaryNavActionClassName =
   "inline-flex items-center gap-2 border border-rule-2 bg-panel px-3 py-1.5 text-xs font-semibold tracking-[0.14em] text-ink-faint uppercase transition hover:border-ink-soft hover:bg-paper-2 hover:text-ink-2 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-oxblood"
 
+function HomeNavIcon() {
+  return (
+    <svg
+      aria-hidden="true"
+      className="size-3.5"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+    >
+      <path d="M3 10.5 12 3l9 7.5" />
+      <path d="M5.5 9.5V20h13V9.5" />
+      <path d="M10 20v-6h4v6" />
+    </svg>
+  )
+}
+
 function ReposNavIcon() {
   return (
     <svg
@@ -199,23 +215,6 @@ function ReposNavIcon() {
       <path d="M4 7.5c0-1.5 3.6-2.5 8-2.5s8 1 8 2.5v9c0 1.5-3.6 2.5-8 2.5s-8-1-8-2.5v-9Z" />
       <path d="M4 7.5c0 1.5 3.6 2.5 8 2.5s8-1 8-2.5" />
       <path d="M4 12c0 1.5 3.6 2.5 8 2.5s8-1 8-2.5" />
-    </svg>
-  )
-}
-
-function KanbanNavIcon() {
-  return (
-    <svg
-      aria-hidden="true"
-      className="size-3.5"
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2"
-    >
-      <rect x="3.5" y="4" width="4.5" height="16" rx="0.5" />
-      <rect x="9.75" y="4" width="4.5" height="10" rx="0.5" />
-      <rect x="16" y="4" width="4.5" height="13" rx="0.5" />
     </svg>
   )
 }
@@ -236,19 +235,11 @@ function CompletedNavIcon() {
 }
 
 function RootComponent() {
-  // Home (kanban board) needs the full viewport for six pipeline lanes; other
-  // routes keep the shared 88rem reading-width cap. Gutters stay on every route.
-  const pathname = useLocation({ select: (location) => location.pathname })
-  const isKanbanPage = pathname === "/"
-  const shellClassName = [
-    "mx-auto min-h-screen w-full px-5 py-6 sm:px-8 lg:px-12",
-    isKanbanPage ? undefined : "max-w-[88rem]",
-  ]
-    .filter((part): part is string => part !== undefined)
-    .join(" ")
-
+  // Chrome (title, version, primary nav, header rule) is always full-width so
+  // nav positions do not jump between routes. Repos/Completed apply their own
+  // reading-width cap on page body content only. Gutters stay on every route.
   return (
-    <div className={shellClassName}>
+    <div className="mx-auto min-h-screen w-full px-5 py-6 sm:px-8 lg:px-12">
       <nav
         aria-label="Primary"
         className="primary-nav mb-2 flex flex-wrap items-start gap-x-5 gap-y-3 pb-3"
@@ -275,6 +266,16 @@ function RootComponent() {
           leading={
             <>
               <Link
+                to="/"
+                activeOptions={{ exact: true }}
+                className={primaryNavLinkClassName}
+                inactiveProps={{ className: primaryNavLinkInactiveClassName }}
+                activeProps={{ className: primaryNavLinkActiveClassName }}
+              >
+                <HomeNavIcon />
+                Home
+              </Link>
+              <Link
                 to="/repos"
                 className={primaryNavLinkClassName}
                 inactiveProps={{ className: primaryNavLinkInactiveClassName }}
@@ -282,16 +283,6 @@ function RootComponent() {
               >
                 <ReposNavIcon />
                 Repos
-              </Link>
-              <Link
-                to="/"
-                activeOptions={{ exact: true }}
-                className={primaryNavLinkClassName}
-                inactiveProps={{ className: primaryNavLinkInactiveClassName }}
-                activeProps={{ className: primaryNavLinkActiveClassName }}
-              >
-                <KanbanNavIcon />
-                Kanban
               </Link>
               <Link
                 to="/completed"
@@ -756,7 +747,7 @@ function SettingsButton({ leading }: { leading: ReactNode }) {
           </button>
         </div>
       )}
-      {/* Repos / Kanban / Completed / Settings share one right-aligned control cluster.
+      {/* Home / Repos / Completed / Settings share one right-aligned control cluster.
           Status banners above stay nav-level siblings (outside the cluster). */}
       <div className="ml-auto flex items-center gap-2 self-center">
         {leading}

--- a/apps/harness/src/routes/completed.tsx
+++ b/apps/harness/src/routes/completed.tsx
@@ -16,8 +16,9 @@ export const Route = createFileRoute("/completed")({
 })
 
 function CompletedPage() {
+  // Reading-width cap lives on the page body only — root chrome stays full-width.
   return (
-    <main className="pt-8 sm:pt-10">
+    <main className="mx-auto max-w-[88rem] pt-8 sm:pt-10">
       <header className="mb-5">
         <p className="m-0 font-mono text-xs font-semibold tracking-[0.22em] text-oxblood uppercase">
           History

--- a/apps/harness/src/routes/repos.tsx
+++ b/apps/harness/src/routes/repos.tsx
@@ -7,8 +7,9 @@ export const Route = createFileRoute("/repos")({
 })
 
 function ReposPage() {
+  // Reading-width cap lives on the page body only — root chrome stays full-width.
   return (
-    <main className="pt-8 sm:pt-10">
+    <main className="mx-auto max-w-[88rem] pt-8 sm:pt-10">
       <Suspense fallback={<RepositoryCardsSkeleton />}>
         <RepositoryCards />
       </Suspense>

--- a/apps/harness/test/completed-route.test.ts
+++ b/apps/harness/test/completed-route.test.ts
@@ -49,6 +49,16 @@ describe("/completed route", () => {
     expect(completedLink).toContain("Completed")
   })
 
+  test("Completed page body keeps the reading-width cap", () => {
+    // Issue #686: width cap is on content, not the shared root shell.
+    const source = completedSource()
+    expect(source).toContain("max-w-[88rem]")
+    expect(source).toMatch(/className="[^"]*max-w-\[88rem\][^"]*"/)
+    const root = rootSource()
+    const rootComponent = root.slice(root.indexOf("function RootComponent("))
+    expect(rootComponent).not.toContain("max-w-[88rem]")
+  })
+
   test("queries the server-paginated completedWorkItems history API", () => {
     const index = indexSource()
     expect(index).toContain("completedWorkItemsHistoryQuery")

--- a/apps/harness/test/kanban-route.test.ts
+++ b/apps/harness/test/kanban-route.test.ts
@@ -397,25 +397,21 @@ describe("kanban home board", () => {
     expect(desktopStyles).toContain("display: none")
   })
 
-  test("uses full viewport width only on home board while other routes keep 88rem", () => {
-    // Root shell is route-aware: drop max-w-[88rem] for `/` only; gutters stay.
+  test("uses full viewport chrome on every route; home board stays uncapped under header", () => {
+    // Issue #686: root shell never takes max-w-[88rem]; Repos/Completed cap body.
     const root = rootSource()
     const rootComponent = root.slice(root.indexOf("function RootComponent("))
-    expect(rootComponent).toContain("useLocation")
-    expect(rootComponent).toContain('pathname === "/"')
-    // Shared gutters apply on every route (single base string, not duplicated).
+    expect(rootComponent).not.toContain("useLocation")
+    expect(rootComponent).not.toContain("isKanbanPage")
+    // Shared gutters apply on every route (single static class string).
     expect(rootComponent).toContain(
-      "mx-auto min-h-screen w-full px-5 py-6 sm:px-8 lg:px-12",
+      'className="mx-auto min-h-screen w-full px-5 py-6 sm:px-8 lg:px-12"',
     )
-    // 88rem remains available for non-Kanban routes, gated by the home check.
-    expect(rootComponent).toContain("max-w-[88rem]")
-    expect(rootComponent).toMatch(
-      /(?:isKanbanPage|pathname === "\/")[\s\S]{0,200}max-w-\[88rem\]|max-w-\[88rem\][\s\S]{0,200}(?:isKanbanPage|pathname === "\/")/,
-    )
-    // Cap is not a static always-on className on the wrapper.
-    expect(rootComponent).not.toMatch(/className="[^"]*max-w-\[88rem\][^"]*"/)
+    // Shell must not pathname-gate or hardcode the reading-width cap.
+    expect(rootComponent).not.toContain("max-w-[88rem]")
+    expect(rootComponent).not.toContain('pathname === "/"')
 
-    // industrial-shell must not re-impose a second width cap under Kanban.
+    // industrial-shell must not re-impose a second width cap under home board.
     const styles = stylesSource()
     const shellBlock = styles.slice(
       styles.indexOf(".industrial-shell {"),

--- a/apps/harness/test/primary-nav.test.ts
+++ b/apps/harness/test/primary-nav.test.ts
@@ -8,21 +8,29 @@ const rootSource = () =>
 const stylesSource = () =>
   readFileSync(join(import.meta.dir, "../src/styles.css"), "utf8")
 
-describe("primary Repos / Kanban / Completed navigation", () => {
-  test("root chrome exposes Repos, Kanban, and Completed Link controls without Home", () => {
+const reposSource = () =>
+  readFileSync(join(import.meta.dir, "../src/routes/repos.tsx"), "utf8")
+
+const completedSource = () =>
+  readFileSync(join(import.meta.dir, "../src/routes/completed.tsx"), "utf8")
+
+describe("primary Home / Repos / Completed navigation", () => {
+  test("root chrome exposes Home, Repos, and Completed Link controls", () => {
     const source = rootSource()
     expect(source).toContain('aria-label="Primary"')
     expect(source).toContain('to="/"')
     expect(source).toContain('to="/repos"')
     expect(source).toContain('to="/completed"')
+    expect(source).toMatch(/Home\s*<\/Link>/)
     expect(source).toMatch(/Repos\s*<\/Link>/)
-    expect(source).toMatch(/Kanban\s*<\/Link>/)
     expect(source).toMatch(/Completed\s*<\/Link>/)
-    // Distinct Home tab is gone; logo and Kanban both target `/`.
-    expect(source).not.toMatch(/Home\s*<\/Link>/)
-    expect(source).not.toContain("function HomeNavIcon()")
-    expect(source).not.toContain("<HomeNavIcon />")
-    // Kanban lives at home — no separate /kanban nav target.
+    // Home replaces Kanban as the `/` nav label; board icon/label are gone.
+    expect(source).not.toMatch(/Kanban\s*<\/Link>/)
+    expect(source).not.toContain("function KanbanNavIcon()")
+    expect(source).not.toContain("<KanbanNavIcon />")
+    expect(source).toContain("function HomeNavIcon()")
+    expect(source).toContain("<HomeNavIcon />")
+    // Home lives at `/` — no separate /kanban nav target.
     const settingsBlock = source.slice(
       source.indexOf("<SettingsButton"),
       source.indexOf("</nav>"),
@@ -57,7 +65,7 @@ describe("primary Repos / Kanban / Completed navigation", () => {
     )
   })
 
-  test("groups Repos, Kanban, Completed, and Settings in one right-aligned control cluster", () => {
+  test("groups Home, Repos, Completed, and Settings in one right-aligned control cluster", () => {
     const source = rootSource()
     const clusterMarker =
       'className="ml-auto flex items-center gap-2 self-center"'
@@ -73,19 +81,19 @@ describe("primary Repos / Kanban / Completed navigation", () => {
       source.indexOf("</nav>"),
     )
     expect(settingsBlock).toContain("leading={")
-    expect(settingsBlock).toContain('to="/repos"')
     expect(settingsBlock).toContain('to="/"')
+    expect(settingsBlock).toContain('to="/repos"')
     expect(settingsBlock).toContain('to="/completed"')
+    expect(settingsBlock).toContain("<HomeNavIcon />")
     expect(settingsBlock).toContain("<ReposNavIcon />")
-    expect(settingsBlock).toContain("<KanbanNavIcon />")
     expect(settingsBlock).toContain("<CompletedNavIcon />")
+    // Order: Home | Repos | Completed
+    const homeIdx = settingsBlock.indexOf('to="/"')
     const reposIdx = settingsBlock.indexOf('to="/repos"')
-    const kanbanIdx = settingsBlock.indexOf('to="/"')
     const completedIdx = settingsBlock.indexOf('to="/completed"')
-    expect(reposIdx).toBeGreaterThan(-1)
-    expect(kanbanIdx).toBeGreaterThan(reposIdx)
-    // Completed sits after Kanban (and after Repos).
-    expect(completedIdx).toBeGreaterThan(kanbanIdx)
+    expect(homeIdx).toBeGreaterThan(-1)
+    expect(reposIdx).toBeGreaterThan(homeIdx)
+    expect(completedIdx).toBeGreaterThan(reposIdx)
 
     // Cluster wraps leading destinations and the Settings trigger.
     const clusterStart = source.indexOf(
@@ -106,18 +114,18 @@ describe("primary Repos / Kanban / Completed navigation", () => {
     expect(brandIdx).toBeLessThan(source.indexOf("<SettingsButton"))
   })
 
-  test("Repos, Kanban, and Completed use stroke icons matching Settings icon language", () => {
+  test("Home, Repos, and Completed use stroke icons matching Settings icon language", () => {
     const source = rootSource()
+    expect(source).toContain("function HomeNavIcon()")
     expect(source).toContain("function ReposNavIcon()")
-    expect(source).toContain("function KanbanNavIcon()")
     expect(source).toContain("function CompletedNavIcon()")
+    expect(source).toContain("<HomeNavIcon />")
     expect(source).toContain("<ReposNavIcon />")
-    expect(source).toContain("<KanbanNavIcon />")
     expect(source).toContain("<CompletedNavIcon />")
     // Icons: aria-hidden, size-3.5, stroke currentColor (same as Settings gear).
     for (const iconFn of [
+      "HomeNavIcon",
       "ReposNavIcon",
-      "KanbanNavIcon",
       "CompletedNavIcon",
     ] as const) {
       const start = source.indexOf(`function ${iconFn}(`)
@@ -129,6 +137,13 @@ describe("primary Repos / Kanban / Completed navigation", () => {
       expect(body).toContain('strokeWidth="2"')
       expect(body).toContain('fill="none"')
     }
+    // Home uses a house path language (roof + walls), not the old board columns.
+    const homeIcon = source.slice(
+      source.indexOf("function HomeNavIcon("),
+      source.indexOf("\n}", source.indexOf("function HomeNavIcon(")) + 2,
+    )
+    expect(homeIcon).toContain("M3 10.5")
+    expect(homeIcon).not.toContain("<rect")
   })
 
   test("uses TanStack Router Link with active route styling", () => {
@@ -143,15 +158,19 @@ describe("primary Repos / Kanban / Completed navigation", () => {
     expect(source).toContain(
       "activeProps={{ className: primaryNavLinkActiveClassName }}",
     )
-    // Kanban nav control (not the brand title Link) must use exact matching.
-    // Slice from the Repos link through Completed so the Kanban `to="/"` is included.
-    const kanbanSwitcherLink = source.slice(
-      source.indexOf('to="/repos"'),
-      source.indexOf('to="/completed"'),
+    // Home nav control (not the brand title Link) must use exact matching.
+    // Slice the SettingsButton leading destinations through Repos.
+    const settingsBlock = source.slice(
+      source.indexOf("<SettingsButton"),
+      source.indexOf("</nav>"),
     )
-    expect(kanbanSwitcherLink).toContain('to="/"')
-    expect(kanbanSwitcherLink).toContain("<KanbanNavIcon />")
-    expect(kanbanSwitcherLink).toContain("activeOptions={{ exact: true }}")
+    const homeSwitcherLink = settingsBlock.slice(
+      0,
+      settingsBlock.indexOf('to="/repos"'),
+    )
+    expect(homeSwitcherLink).toContain('to="/"')
+    expect(homeSwitcherLink).toContain("<HomeNavIcon />")
+    expect(homeSwitcherLink).toContain("activeOptions={{ exact: true }}")
     // Shared base must not carry exclusive active/inactive visual tokens —
     // Router merges className with active/inactive props.
     const sharedClassDecl = source.match(
@@ -199,20 +218,39 @@ describe("primary Repos / Kanban / Completed navigation", () => {
     expect(source).not.toMatch(/<a\s+href=["']\/["']/)
   })
 
-  test("shared nav lives in root layout so Repos, Kanban, and Completed inherit it", () => {
+  test("shared nav lives in root layout so Home, Repos, and Completed inherit it", () => {
     const source = rootSource()
     const rootComponent = source.slice(
       source.indexOf("function RootComponent("),
     )
     expect(rootComponent).toContain('to="/repos"')
     expect(rootComponent).toContain('to="/completed"')
+    expect(rootComponent).toMatch(/Home\s*<\/Link>/)
     expect(rootComponent).toMatch(/Repos\s*<\/Link>/)
-    expect(rootComponent).toMatch(/Kanban\s*<\/Link>/)
     expect(rootComponent).toMatch(/Completed\s*<\/Link>/)
-    expect(rootComponent).not.toMatch(/Home\s*<\/Link>/)
+    expect(rootComponent).not.toMatch(/Kanban\s*<\/Link>/)
     expect(rootComponent).toContain("<Outlet />")
-    expect(rootComponent.indexOf("Repos")).toBeLessThan(
+    expect(rootComponent.indexOf("Home")).toBeLessThan(
       rootComponent.indexOf("<Outlet />"),
     )
+  })
+
+  test("root shell is always full-width; Repos and Completed cap page body only", () => {
+    // Issue #686: no pathname-based shell max-w; chrome never jumps.
+    const root = rootSource()
+    const rootComponent = root.slice(root.indexOf("function RootComponent("))
+    expect(rootComponent).toContain(
+      'className="mx-auto min-h-screen w-full px-5 py-6 sm:px-8 lg:px-12"',
+    )
+    expect(rootComponent).not.toContain("useLocation")
+    expect(rootComponent).not.toContain("isKanbanPage")
+    expect(rootComponent).not.toContain("max-w-[88rem]")
+    expect(rootComponent).not.toContain('pathname === "/"')
+
+    // Reading-width cap is on Repos / Completed content, not the shared shell.
+    expect(reposSource()).toContain("max-w-[88rem]")
+    expect(completedSource()).toContain("max-w-[88rem]")
+    expect(reposSource()).toMatch(/className="[^"]*max-w-\[88rem\][^"]*"/)
+    expect(completedSource()).toMatch(/className="[^"]*max-w-\[88rem\][^"]*"/)
   })
 })

--- a/apps/harness/test/repos-route.test.ts
+++ b/apps/harness/test/repos-route.test.ts
@@ -31,24 +31,33 @@ describe("/repos route", () => {
     expect(source).toContain("'/repos': typeof ReposRoute")
   })
 
-  test("primary nav places Repos before Kanban (home)", () => {
+  test("primary nav places Home before Repos before Completed", () => {
     const source = rootSource()
     const settingsBlock = source.slice(
       source.indexOf("<SettingsButton"),
       source.indexOf("</nav>"),
     )
+    const homeIdx = settingsBlock.indexOf('to="/"')
     const reposIdx = settingsBlock.indexOf('to="/repos"')
-    const kanbanIdx = settingsBlock.indexOf('to="/"')
-    expect(reposIdx).toBeGreaterThan(-1)
-    expect(kanbanIdx).toBeGreaterThan(reposIdx)
+    const completedIdx = settingsBlock.indexOf('to="/completed"')
+    expect(homeIdx).toBeGreaterThan(-1)
+    expect(reposIdx).toBeGreaterThan(homeIdx)
+    expect(completedIdx).toBeGreaterThan(reposIdx)
+    expect(settingsBlock).toMatch(/Home\s*<\/Link>/)
     expect(settingsBlock).toMatch(/Repos\s*<\/Link>/)
-    expect(settingsBlock).toMatch(/Kanban\s*<\/Link>/)
+    expect(settingsBlock).not.toMatch(/Kanban\s*<\/Link>/)
     // Active styling is shared with other primary destinations.
-    const reposLink = settingsBlock.slice(reposIdx, kanbanIdx)
+    const reposLink = settingsBlock.slice(reposIdx, completedIdx)
     expect(reposLink).toContain("primaryNavLinkClassName")
     expect(reposLink).toContain(
       "activeProps={{ className: primaryNavLinkActiveClassName }}",
     )
+  })
+
+  test("Repos page body keeps the reading-width cap", () => {
+    const source = reposSource()
+    expect(source).toContain("max-w-[88rem]")
+    expect(source).toMatch(/className="[^"]*max-w-\[88rem\][^"]*"/)
   })
 
   test("home shows blank slate with zero repos and board with one or more", () => {


### PR DESCRIPTION
Why

The shared shell applied a reading-width cap (`max-w-[88rem]`) on every
route except home. Switching between `/`, `/repos`, and `/completed`
reflowed the title and primary nav. After kanban-as-home (#685), the
primary nav also labeled `/` as **Kanban** instead of a first-class
**Home** control.

What changed

- Root chrome (title, version, primary nav, header rule) is always
  full-width with the same gutters; pathname-based shell
  `max-w-[88rem]` / `useLocation` gating is gone.
- **Repos** and **Completed** keep the ~88rem centered column on page
  body only (`<main>`).
- Home board content stays full-width under the header.
- Primary nav is **Home | Repos | Completed | Settings**: Home uses a
  house icon, targets exact `/`, and fully replaces the Kanban
  label/board icon.

Verification

- `bunx nx test harness` — 423 pass (primary-nav, layout-width,
  repos/completed route tests)
- Biome clean on touched harness files
- E2E feature/steps updated for Home top nav (live Playwright not
  re-run here)

Limitations

- Wide-viewport chrome alignment not screenshot-verified in this
  session.
- E2E needs fixture/sidecar to exercise the updated Home nav steps
  end-to-end.

Closes #686