### PR TITLE
test(harness): e2e first-run settings save to blank slate

### DIFF
--- a/apps/harness/e2e/features/kanban-route.feature
+++ b/apps/harness/e2e/features/kanban-route.feature
@@ -2,9 +2,20 @@ Feature: View the work pipeline
   Operators use the home Kanban board to monitor delivery without
   repository management competing with the pipeline.
 
+  Scenario: First-run settings save leads to add-repo blank slate
+    Given the Harness is empty with first-run settings required
+    When I open the home page
+    Then the Harness settings dialog is visible
+    When I complete and save Harness settings
+    Then the Harness settings dialog is hidden
+    And the add-repository blank slate is visible
+    And the blank slate instructs me to add a repository first
+    And the kanban board is not rendered
+
   Scenario: Home shows add-repo blank slate when no repositories
     Given the Harness has no configured Repositories
     When I open the home page
+    And I cancel the Harness settings dialog if present
     Then the add-repository blank slate is visible
     And the kanban board is not rendered
 

--- a/apps/harness/e2e/steps/add-and-refresh-repository.ts
+++ b/apps/harness/e2e/steps/add-and-refresh-repository.ts
@@ -19,6 +19,7 @@ import {
   SENTINEL_EXPECT_TIMEOUT_MS,
   gitlabSentinelIssueNumber,
 } from "../support/constants.ts"
+import { dismissFirstRunSettingsIfPresent } from "../support/first-run-settings.ts"
 import { Given, Then, When, test } from "./fixtures.ts"
 
 const workspaceRoot = resolve(
@@ -163,11 +164,132 @@ const ensureNoConfiguredRepositories = async () => {
   }
 }
 
+/**
+ * Ensure no default build model so first-run Settings auto-opens on the next
+ * load. Same-backend updateConfig rejects an empty model; clear by switching
+ * Agent Backend with an empty model (first-run style), then switch back to the
+ * original backend still with an empty model so the shared e2e process keeps
+ * the prior default backend identity.
+ */
+const ensureFirstRunSettingsRequired = async () => {
+  const data = await graphqlRequest<{
+    config: {
+      selectedAgentBackend: string
+      defaultModel: string | null
+      maxConcurrentAgentTurns: number
+      maxConcurrentWorkItems: number
+    }
+    agentBackends: ReadonlyArray<{ id: string }>
+  }>(
+    `query {
+      config {
+        selectedAgentBackend
+        defaultModel
+        maxConcurrentAgentTurns
+        maxConcurrentWorkItems
+      }
+      agentBackends { id }
+    }`,
+  )
+  if (
+    data.config.defaultModel === null ||
+    data.config.defaultModel.length === 0
+  ) {
+    return
+  }
+
+  const originalBackend = data.config.selectedAgentBackend
+  const alternate = data.agentBackends.find(
+    (backend) => backend.id !== originalBackend,
+  )
+  if (alternate === undefined) {
+    throw new Error(
+      "Cannot restore first-run settings: default build model is set and no alternate Agent Backend is available to clear it",
+    )
+  }
+
+  const clearModelInput = (selectedAgentBackend: string) => ({
+    selectedAgentBackend,
+    defaultModel: null,
+    defaultThinkingLevel: null,
+    reviewModel: null,
+    reviewThinkingLevel: null,
+    maxConcurrentAgentTurns: data.config.maxConcurrentAgentTurns,
+    maxConcurrentWorkItems: data.config.maxConcurrentWorkItems,
+  })
+
+  // Backend change allows empty model; same-backend empty model is rejected.
+  const clearedOnAlternate = await graphqlRequest<{
+    updateConfig: {
+      defaultModel: string | null
+      selectedAgentBackend: string
+    }
+  }>(
+    `mutation UpdateConfig($input: UpdateConfigInput!) {
+      updateConfig(input: $input) {
+        defaultModel
+        selectedAgentBackend
+      }
+    }`,
+    { input: clearModelInput(alternate.id) },
+  )
+  if (
+    clearedOnAlternate.updateConfig.defaultModel !== null &&
+    clearedOnAlternate.updateConfig.defaultModel.length > 0
+  ) {
+    throw new Error(
+      `Expected empty defaultModel after switching to ${alternate.id}, got ${JSON.stringify(clearedOnAlternate.updateConfig.defaultModel)}`,
+    )
+  }
+  if (clearedOnAlternate.updateConfig.selectedAgentBackend !== alternate.id) {
+    throw new Error(
+      `Expected selectedAgentBackend ${alternate.id} after clear, got ${clearedOnAlternate.updateConfig.selectedAgentBackend}`,
+    )
+  }
+
+  // Return to the original backend while still unconfigured (first-run style).
+  const restored = await graphqlRequest<{
+    updateConfig: {
+      defaultModel: string | null
+      selectedAgentBackend: string
+    }
+  }>(
+    `mutation UpdateConfig($input: UpdateConfigInput!) {
+      updateConfig(input: $input) {
+        defaultModel
+        selectedAgentBackend
+      }
+    }`,
+    { input: clearModelInput(originalBackend) },
+  )
+  if (
+    restored.updateConfig.defaultModel !== null &&
+    restored.updateConfig.defaultModel.length > 0
+  ) {
+    throw new Error(
+      `Expected empty defaultModel after restoring ${originalBackend}, got ${JSON.stringify(restored.updateConfig.defaultModel)}`,
+    )
+  }
+  if (restored.updateConfig.selectedAgentBackend !== originalBackend) {
+    throw new Error(
+      `Expected selectedAgentBackend ${originalBackend} after restore, got ${restored.updateConfig.selectedAgentBackend}`,
+    )
+  }
+}
+
+Given("the Harness is empty with first-run settings required", async () => {
+  test.setTimeout(SCENARIO_TIMEOUT_MS)
+  await ensureNoConfiguredRepositories()
+  await ensureFirstRunSettingsRequired()
+})
+
 Given("the Harness has no configured Repositories", async ({ page }) => {
   test.setTimeout(SCENARIO_TIMEOUT_MS)
   await ensureNoConfiguredRepositories()
   // Zero repos: home shows the add-repo blank slate (not an empty kanban board).
+  // First-run Settings may auto-open; dismiss so blank-slate assertions resolve.
   await page.goto("/")
+  await dismissFirstRunSettingsIfPresent(page)
   await expect(
     page.getByRole("heading", { name: "No repositories configured" }),
   ).toBeVisible()
@@ -190,6 +312,7 @@ Given("the Harness has no configured Repositories", async ({ page }) => {
   ).toHaveCount(0)
 
   await page.goto("/repos")
+  await dismissFirstRunSettingsIfPresent(page)
   await expect(
     page.getByRole("heading", { name: "No repositories configured" }),
   ).toBeVisible()
@@ -298,6 +421,7 @@ Then("the Repository appears in the Harness", async ({ page, world }) => {
   const display = world.fixtureDisplayRepository ?? displayRepositoryFor(forge)
 
   await page.goto("/repos")
+  await dismissFirstRunSettingsIfPresent(page)
   await expect(
     page.getByRole("region", { name: "Configured repositories" }),
   ).toBeVisible({ timeout: 30_000 })

--- a/apps/harness/e2e/steps/kanban-route.ts
+++ b/apps/harness/e2e/steps/kanban-route.ts
@@ -1,4 +1,9 @@
 import { type Page, expect } from "@playwright/test"
+import {
+  completeAndSaveFirstRunSettings,
+  dismissFirstRunSettingsIfPresent,
+  settingsDialog,
+} from "../support/first-run-settings.ts"
 import { Then, When } from "./fixtures.ts"
 
 const PIPELINE_LANE_HEADERS = [
@@ -21,39 +26,35 @@ const COMMITTED_PULL_REQUEST_PERIODS = [
 const primaryNav = (page: Page) =>
   page.getByRole("navigation", { name: "Primary" })
 
-const dismissFirstRunSettings = async (page: Page) => {
-  // The isolated E2E database has no default build model, so first-run
-  // Settings opens automatically. Dismiss it to exercise the route beneath.
-  const settingsDialog = page.getByRole("dialog", {
-    name: "Harness settings",
-  })
-  await expect(settingsDialog).toBeVisible()
-  await settingsDialog.getByRole("button", { name: "Cancel" }).click()
-  await expect(settingsDialog).toBeHidden()
-}
-
 When("I navigate to the Kanban board", async ({ page }) => {
   await page.goto("/")
   await expect(page).toHaveURL(/\/$/)
-  await dismissFirstRunSettings(page)
+  await dismissFirstRunSettingsIfPresent(page)
 })
 
 When("I open the home page", async ({ page }) => {
   await page.goto("/")
   await expect(page).toHaveURL(/\/$/)
-  await dismissFirstRunSettings(page)
+})
+
+When("I complete and save Harness settings", async ({ page }) => {
+  await completeAndSaveFirstRunSettings(page)
+})
+
+When("I cancel the Harness settings dialog if present", async ({ page }) => {
+  await dismissFirstRunSettingsIfPresent(page)
 })
 
 When("I navigate to the legacy Kanban path", async ({ page }) => {
   await page.goto("/kanban")
   await expect(page).toHaveURL(/\/$/)
-  await dismissFirstRunSettings(page)
+  await dismissFirstRunSettingsIfPresent(page)
 })
 
 When("I open the Repos page", async ({ page }) => {
   await page.goto("/repos")
   await expect(page).toHaveURL(/\/repos$/)
-  await dismissFirstRunSettings(page)
+  await dismissFirstRunSettingsIfPresent(page)
 })
 
 When("I click the Home top nav control", async ({ page }) => {
@@ -180,6 +181,9 @@ Then("I am on the Repos page", async ({ page }) => {
 })
 
 Then("the add-repository blank slate is visible", async ({ page }) => {
+  // Pure visibility assert — do not Cancel here (would mask post-Save re-open).
+  // Callers that open under unconfigured first-run should cancel explicitly.
+  await expect(settingsDialog(page)).toBeHidden()
   await expect(
     page.getByRole("heading", { name: "No repositories configured" }),
   ).toBeVisible()
@@ -187,6 +191,46 @@ Then("the add-repository blank slate is visible", async ({ page }) => {
     page.getByRole("region", { name: "Add a repository" }),
   ).toBeVisible()
 })
+
+Then("the Harness settings dialog is visible", async ({ page }) => {
+  await expect(settingsDialog(page)).toBeVisible({ timeout: 30_000 })
+})
+
+Then("the Harness settings dialog is hidden", async ({ page }) => {
+  await expect(settingsDialog(page)).toBeHidden()
+})
+
+Then(
+  "the blank slate instructs me to add a repository first",
+  async ({ page }) => {
+    const guidance = page.getByRole("region", { name: "Add a repository" })
+    await expect(guidance).toBeVisible()
+    await expect(
+      page.getByRole("heading", { name: "No repositories configured" }),
+    ).toBeVisible()
+
+    const pathField = page.locator("#add-repository-path")
+    await expect(pathField).toBeVisible()
+    await expect(pathField).toHaveAttribute(
+      "placeholder",
+      "/path/to/local/repo",
+    )
+
+    await expect(
+      guidance.getByText(
+        "Add a local Git repository with the operator binary:",
+        { exact: true },
+      ),
+    ).toBeVisible()
+
+    // Dynamic CLI string from GraphQL — assert the visible command (do not
+    // hard-code npx vs binary).
+    const commandCode = guidance.locator("code")
+    await expect(commandCode).toBeVisible()
+    const commandText = (await commandCode.innerText()).trim()
+    expect(commandText).toMatch(/ready-for-agent add \/path\/to\/local\/repo$/)
+  },
+)
 
 Then("the kanban board is not rendered", async ({ page }) => {
   await expect(

--- a/apps/harness/e2e/support/first-run-settings.ts
+++ b/apps/harness/e2e/support/first-run-settings.ts
@@ -1,0 +1,169 @@
+import { type Page, expect } from "@playwright/test"
+import { E2E_GRAPHQL_URL } from "./constants.ts"
+
+export const settingsDialog = (page: Page) =>
+  page.getByRole("dialog", {
+    name: "Harness settings",
+  })
+
+const pageLandmark = (page: Page) =>
+  page
+    .getByRole("heading", { name: "No repositories configured" })
+    .or(page.getByRole("region", { name: "Lifecycle pipeline" }))
+    .or(page.getByRole("region", { name: "Configured repositories" }))
+
+/** True when harness has no default build model (first-run Settings auto-opens). */
+const isFirstRunSettingsRequired = async (): Promise<boolean> => {
+  const response = await fetch(E2E_GRAPHQL_URL, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      query: `query { config { defaultModel } }`,
+    }),
+  })
+  if (!response.ok) {
+    throw new Error(
+      `GraphQL HTTP ${response.status} while checking first-run settings: ${await response.text()}`,
+    )
+  }
+  const payload = (await response.json()) as {
+    data?: { config?: { defaultModel: string | null } }
+    errors?: ReadonlyArray<{ message: string }>
+  }
+  if (payload.errors?.length) {
+    throw new Error(
+      `GraphQL errors while checking first-run settings: ${payload.errors
+        .map((e) => e.message)
+        .join("; ")}`,
+    )
+  }
+  const defaultModel = payload.data?.config?.defaultModel
+  return (
+    defaultModel === null ||
+    defaultModel === undefined ||
+    defaultModel.length === 0
+  )
+}
+
+/**
+ * First-run Settings auto-opens after config loads when no default build
+ * model is set. After Save (or when already configured), it does not.
+ * Cancel only when present so multi-scenario e2e stays stable.
+ *
+ * Gates the late wait on GraphQL config: when a build model is already set,
+ * skip the auto-open poll entirely. When first-run is required, wait for the
+ * dialog (config may load after landmarks paint) then Cancel.
+ */
+export const dismissFirstRunSettingsIfPresent = async (page: Page) => {
+  const dialog = settingsDialog(page)
+  const landmark = pageLandmark(page)
+
+  await expect(dialog.or(landmark)).toBeVisible({ timeout: 30_000 })
+
+  if (await dialog.isVisible()) {
+    await dialog.getByRole("button", { name: "Cancel" }).click()
+    await expect(dialog).toBeHidden()
+    return
+  }
+
+  const firstRunRequired = await isFirstRunSettingsRequired()
+  if (!firstRunRequired) {
+    // Configured: auto-open will not run — do not burn a late-dialog timeout.
+    await expect(dialog).toBeHidden()
+    return
+  }
+
+  // Unconfigured: landmarks may paint before config; wait for auto-open.
+  await expect(dialog).toBeVisible({ timeout: 30_000 })
+  await dialog.getByRole("button", { name: "Cancel" }).click()
+  await expect(dialog).toBeHidden()
+}
+
+/**
+ * Complete first-run settings: prefer OpenCode when listed (shared e2e
+ * default), otherwise keep the current backend; pick a build model from the
+ * live catalog; Save.
+ */
+export const completeAndSaveFirstRunSettings = async (page: Page) => {
+  const dialog = settingsDialog(page)
+  await expect(dialog).toBeVisible()
+  await expect(dialog.getByText("Loading settings...")).toHaveCount(0, {
+    timeout: 30_000,
+  })
+
+  const backendSelect = dialog.locator('select[name="selectedAgentBackend"]')
+  await expect(backendSelect).toBeVisible()
+  await expect
+    .poll(async () => backendSelect.locator("option").count(), {
+      timeout: 30_000,
+    })
+    .toBeGreaterThan(0)
+
+  // Prefer opencode (usual harness default) when present so a prior first-run
+  // reset that switched backends does not leave the suite on an alternate.
+  const opencodeOption = backendSelect.locator('option[value="opencode"]')
+  if ((await opencodeOption.count()) > 0) {
+    await backendSelect.selectOption("opencode")
+  } else {
+    const current = await backendSelect.inputValue()
+    if (current.length === 0) {
+      const firstValue = await backendSelect
+        .locator("option")
+        .first()
+        .getAttribute("value")
+      if (firstValue != null && firstValue.length > 0) {
+        await backendSelect.selectOption(firstValue)
+      }
+    }
+  }
+
+  // Backend change may re-load the model catalog via preview.
+  await expect(dialog.getByText("Loading settings...")).toHaveCount(0, {
+    timeout: 30_000,
+  })
+  await expect(dialog.getByText("Loading catalog…")).toHaveCount(0, {
+    timeout: 30_000,
+  })
+
+  const modelSelect = dialog.locator('select[name="defaultModel"]')
+  await expect(modelSelect).toBeVisible()
+  // Wait until catalog options exist beyond the empty placeholder.
+  await expect
+    .poll(
+      async () => {
+        const options = modelSelect.locator("option")
+        const count = await options.count()
+        if (count === 0) return 0
+        let real = 0
+        for (let i = 0; i < count; i += 1) {
+          const value = await options.nth(i).getAttribute("value")
+          if (value != null && value.length > 0) real += 1
+        }
+        return real
+      },
+      { timeout: 60_000 },
+    )
+    .toBeGreaterThan(0)
+
+  const modelOptions = modelSelect.locator("option")
+  const modelCount = await modelOptions.count()
+  let selectedModel: string | null = null
+  for (let i = 0; i < modelCount; i += 1) {
+    const value = await modelOptions.nth(i).getAttribute("value")
+    if (value != null && value.length > 0) {
+      selectedModel = value
+      break
+    }
+  }
+  if (selectedModel === null) {
+    throw new Error(
+      "Harness settings has no build model options for the isolated e2e backend catalog",
+    )
+  }
+  await modelSelect.selectOption(selectedModel)
+
+  const saveButton = dialog.getByRole("button", { name: "Save settings" })
+  await expect(saveButton).toBeEnabled({ timeout: 15_000 })
+  await saveButton.click()
+  await expect(dialog).toBeHidden({ timeout: 30_000 })
+}


### PR DESCRIPTION
## Summary

Adds a Playwright/Gherkin e2e scenario for the true first-run path: an empty
Harness auto-opens **Harness settings**, the operator completes and **saves**
(not Cancel), and home then shows the **No repositories configured** blank
slate with path/CLI guidance—without driving the OS directory picker.

Existing scenarios still rely on Cancel (or skip first-run when already
configured). Shared helpers keep both paths stable on the single shared e2e
Harness process.

## Changes

- New scenario in `kanban-route.feature`: first-run Save → add-repo blank slate
- `e2e/support/first-run-settings.ts`: complete/save settings; dismiss first-run
  only when needed (GraphQL-gated on empty `defaultModel`)
- First-run reset via backend-switch clear (server rejects same-backend empty
  model), then restore original backend still unconfigured
- Blank-slate asserts require the settings dialog hidden (no Cancel masking
  post-Save re-open); explicit cancel step where first-run may still be open
- Blank-slate guidance asserts path placeholder, CLI copy, and dynamic
  `addRepositoryCommand` without hard-coding `npx` vs binary

## Verification

- `bunx nx run harness:e2e -- --grep "View the work pipeline"` — 6 scenarios
  pass
- Related unit tests (`blank-slate-add-command`, harness settings) pass
- Pre-commit (lint/typecheck/affected) passes after Biome format fixes

## Limitations

- Does not exercise Browse… / host folder dialog (out of scope for #688)
- Does not add a repository in this scenario (covered by CLI add scenarios)
- Save path needs a ready agent backend with a non-empty model catalog in the
  e2e environment

Closes #688