### PR TITLE
feat(harness): interchange phase 1 tokens, theme, nav shell, and banners

### DIFF
--- a/apps/harness/src/banner.tsx
+++ b/apps/harness/src/banner.tsx
@@ -1,0 +1,56 @@
+import type { ButtonHTMLAttributes, ReactNode } from "react"
+
+/**
+ * Interchange banner pattern (`docs/harness-design-system.md` §4.8).
+ * One frame, two tones: alarm (Attention orange) and guidance (signal yellow).
+ */
+export type BannerTone = "alarm" | "guidance"
+
+export function Banner({
+  tone,
+  tag,
+  children,
+  action,
+  role = "status",
+  className,
+}: {
+  tone: BannerTone
+  tag: string
+  children: ReactNode
+  action?: ReactNode
+  role?: "status" | "alert"
+  className?: string
+}) {
+  const classes = [
+    "banner",
+    tone === "guidance" ? "banner--guidance" : "banner--alarm",
+    className,
+  ]
+    .filter((part): part is string => part != null && part.length > 0)
+    .join(" ")
+
+  return (
+    <div className={classes} role={role}>
+      <span className="banner-tag">{tag}</span>
+      <div className="banner-body">{children}</div>
+      {action != null ? <div className="banner-action">{action}</div> : null}
+    </div>
+  )
+}
+
+/** Mini stamped plate used as the banner CTA (Open Settings, Retry, …). */
+export function BannerActionButton({
+  children,
+  className,
+  type = "button",
+  ...props
+}: ButtonHTMLAttributes<HTMLButtonElement>) {
+  const classes = ["plate-mini", className]
+    .filter((part): part is string => part != null && part.length > 0)
+    .join(" ")
+  return (
+    <button type={type} className={classes} {...props}>
+      {children}
+    </button>
+  )
+}

--- a/apps/harness/src/kanban-board.tsx
+++ b/apps/harness/src/kanban-board.tsx
@@ -1,5 +1,6 @@
 import { useQueries, useSuspenseQuery } from "@tanstack/react-query"
 import { type CSSProperties, Suspense, useState } from "react"
+import { Banner } from "./banner.js"
 import { Copy } from "./copy.js"
 import { KanbanLiveUpdates } from "./kanban-live.js"
 import {
@@ -346,11 +347,9 @@ function KanbanJobsBoard() {
     return (
       <>
         <KanbanLiveUpdates repositoryIds={repositoryIds} />
-        <article className="border-2 border-oxblood bg-oxblood-wash px-4 py-3">
-          <p className="m-0 text-sm text-oxblood-deep" role="alert">
-            Could not load jobs. Please try again.
-          </p>
-        </article>
+        <Banner tone="alarm" tag="Error" role="alert">
+          Could not load jobs. Please try again.
+        </Banner>
       </>
     )
   }

--- a/apps/harness/src/routes/__root.tsx
+++ b/apps/harness/src/routes/__root.tsx
@@ -11,6 +11,8 @@ import {
   Outlet,
   Scripts,
   createRootRouteWithContext,
+  retainSearchParams,
+  useNavigate,
 } from "@tanstack/react-router"
 import { TanStackRouterDevtools } from "@tanstack/react-router-devtools"
 import {
@@ -21,8 +23,19 @@ import {
   useState,
 } from "react"
 import { createClient } from "@ready-for-agent/graphql-client"
+import { Banner, BannerActionButton } from "../banner.js"
 import { READY_FOR_AGENT_VERSION_LABEL } from "../generated/version"
 import appCss from "../styles.css?url"
+import {
+  THEME_BOOTSTRAP_SCRIPT,
+  type ThemeMode,
+  applyThemeMode,
+  oppositeTheme,
+  parseThemeSearch,
+  readDocumentTheme,
+  themeToggleLabel,
+  withThemePin,
+} from "../theme.js"
 
 export interface RouterContext {
   queryClient: QueryClient
@@ -128,7 +141,16 @@ const isBuildModelConfigured = (
   config.defaultModel != null &&
   config.defaultModel.length > 0
 
+const FONT_STYLESHEET_HREF =
+  "https://fonts.googleapis.com/css2?family=Inter+Tight:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;700&display=swap"
+
 export const Route = createRootRouteWithContext<RouterContext>()({
+  // Theme pin is a shareable root search param; retain it on all SPA navigations
+  // so bootstrap still sees `?theme=` after Home/Repos/Completed + full reload.
+  validateSearch: (raw: Record<string, unknown>) => parseThemeSearch(raw),
+  search: {
+    middlewares: [retainSearchParams(["theme"])],
+  },
   head: () => ({
     meta: [
       { charSet: "utf-8" },
@@ -138,7 +160,16 @@ export const Route = createRootRouteWithContext<RouterContext>()({
       },
       { title: "Ready for Agent" },
     ],
-    links: [{ rel: "stylesheet", href: appCss }],
+    links: [
+      { rel: "preconnect", href: "https://fonts.googleapis.com" },
+      {
+        rel: "preconnect",
+        href: "https://fonts.gstatic.com",
+        crossOrigin: "anonymous",
+      },
+      { rel: "stylesheet", href: FONT_STYLESHEET_HREF },
+      { rel: "stylesheet", href: appCss },
+    ],
   }),
   component: RootComponent,
   shellComponent: RootDocument,
@@ -146,7 +177,7 @@ export const Route = createRootRouteWithContext<RouterContext>()({
     <div className="field-rule mx-auto mt-12 max-w-xl p-8 text-center">
       <p>Page not found.</p>
       <Link
-        className="mt-2 inline-block text-oxblood underline decoration-rule underline-offset-4 hover:text-oxblood-deep"
+        className="mt-2 inline-block text-ink underline decoration-signal underline-offset-4 hover:text-ink-dim"
         to="/"
       >
         Back home
@@ -157,11 +188,16 @@ export const Route = createRootRouteWithContext<RouterContext>()({
 
 function RootDocument({ children }: { children: ReactNode }) {
   return (
-    <html lang="en">
+    <html lang="en" suppressHydrationWarning>
       <head>
         <HeadContent />
+        <script
+          // Theme before paint: prefers-color-scheme default, ?theme= pin.
+          // biome-ignore lint/security/noDangerouslySetInnerHtml: static bootstrap only
+          dangerouslySetInnerHTML={{ __html: THEME_BOOTSTRAP_SCRIPT }}
+        />
       </head>
-      <body className="min-h-screen min-w-80 bg-paper font-sans text-ink antialiased [font-synthesis:none] [text-rendering:optimizeLegibility]">
+      <body className="min-h-screen min-w-80 bg-paper font-display text-ink antialiased [font-synthesis:none] [text-rendering:optimizeLegibility]">
         {children}
         <Scripts />
       </body>
@@ -169,27 +205,13 @@ function RootDocument({ children }: { children: ReactNode }) {
   )
 }
 
-// Shared layout only — Router merges className with active/inactive props, so
-// mutually exclusive visual utilities must not live on the base class string.
-const primaryNavLinkClassName =
-  "inline-flex items-center gap-2 border px-3 py-1.5 text-xs font-semibold tracking-[0.14em] uppercase transition focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-oxblood"
-
-// Inactive: muted gray-out; hover still reads as clickable.
-const primaryNavLinkInactiveClassName =
-  "border-rule-2 bg-panel text-ink-faint hover:border-ink-soft hover:bg-paper-2 hover:text-ink-2"
-
-// Selected: restrained contrast (stronger border/text, light fill — not a solid ink pill).
-const primaryNavLinkActiveClassName = "border-ink bg-paper-2 text-ink"
-
-// Settings is a non-route action; keep it in the same family as inactive nav.
-const primaryNavActionClassName =
-  "inline-flex items-center gap-2 border border-rule-2 bg-panel px-3 py-1.5 text-xs font-semibold tracking-[0.14em] text-ink-faint uppercase transition hover:border-ink-soft hover:bg-paper-2 hover:text-ink-2 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-oxblood"
+/** Stamped-plate base for primary nav Links (active via aria-current). */
+const mastPlateClassName = "mast-plate"
 
 function HomeNavIcon() {
   return (
     <svg
       aria-hidden="true"
-      className="size-3.5"
       viewBox="0 0 24 24"
       fill="none"
       stroke="currentColor"
@@ -206,7 +228,6 @@ function ReposNavIcon() {
   return (
     <svg
       aria-hidden="true"
-      className="size-3.5"
       viewBox="0 0 24 24"
       fill="none"
       stroke="currentColor"
@@ -223,7 +244,6 @@ function CompletedNavIcon() {
   return (
     <svg
       aria-hidden="true"
-      className="size-3.5"
       viewBox="0 0 24 24"
       fill="none"
       stroke="currentColor"
@@ -234,77 +254,89 @@ function CompletedNavIcon() {
   )
 }
 
-function RootComponent() {
-  // Chrome (title, version, primary nav, header rule) is always full-width so
-  // nav positions do not jump between routes. Repos/Completed apply their own
-  // reading-width cap on page body content only. Gutters stay on every route.
+function SettingsNavIcon() {
   return (
-    <div className="mx-auto min-h-screen w-full px-5 py-6 sm:px-8 lg:px-12">
-      <nav
-        aria-label="Primary"
-        className="primary-nav mb-2 flex flex-wrap items-start gap-x-5 gap-y-3 pb-3"
-      >
-        <div className="grid gap-1">
-          <h1 className="m-0 font-serif text-[clamp(1.6rem,3.2vw,2.25rem)] leading-none font-semibold tracking-[-0.012em]">
-            <Link
-              to="/"
-              className="text-ink hover:text-oxblood"
-              activeProps={{ className: "text-ink" }}
-              activeOptions={{ exact: true }}
-            >
-              Clanker Harness
-            </Link>
-          </h1>
-          <span
-            className="font-mono text-xs tabular-nums tracking-[0.16em] text-ink-faint uppercase"
-            title={`Ready for Agent ${READY_FOR_AGENT_VERSION_LABEL}`}
-          >
-            {READY_FOR_AGENT_VERSION_LABEL}
-          </span>
-        </div>
-        <SettingsButton
-          leading={
-            <>
-              <Link
-                to="/"
-                activeOptions={{ exact: true }}
-                className={primaryNavLinkClassName}
-                inactiveProps={{ className: primaryNavLinkInactiveClassName }}
-                activeProps={{ className: primaryNavLinkActiveClassName }}
-              >
-                <HomeNavIcon />
-                Home
-              </Link>
-              <Link
-                to="/repos"
-                className={primaryNavLinkClassName}
-                inactiveProps={{ className: primaryNavLinkInactiveClassName }}
-                activeProps={{ className: primaryNavLinkActiveClassName }}
-              >
-                <ReposNavIcon />
-                Repos
-              </Link>
-              <Link
-                to="/completed"
-                className={primaryNavLinkClassName}
-                inactiveProps={{ className: primaryNavLinkInactiveClassName }}
-                activeProps={{ className: primaryNavLinkActiveClassName }}
-              >
-                <CompletedNavIcon />
-                Completed
-              </Link>
-            </>
-          }
-        />
-      </nav>
-      <Outlet />
+    <svg
+      aria-hidden="true"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+    >
+      <path d="M12 15.5a3.5 3.5 0 1 0 0-7 3.5 3.5 0 0 0 0 7Z" />
+      <path d="M19.4 15a1.7 1.7 0 0 0 .34 1.88l.06.06-2.83 2.83-.06-.06a1.7 1.7 0 0 0-1.88-.34 1.7 1.7 0 0 0-1.03 1.56V21h-4v-.08A1.7 1.7 0 0 0 8.94 19.4a1.7 1.7 0 0 0-1.88.34l-.06.06-2.83-2.83.06-.06A1.7 1.7 0 0 0 4.57 15 1.7 1.7 0 0 0 3 14H3v-4h.08A1.7 1.7 0 0 0 4.6 8.94a1.7 1.7 0 0 0-.34-1.88L4.2 7l2.83-2.83.06.06A1.7 1.7 0 0 0 9 4.57 1.7 1.7 0 0 0 10 3V3h4v.08A1.7 1.7 0 0 0 15.06 4.6a1.7 1.7 0 0 0 1.88-.34L17 4.2 19.83 7l-.06.06A1.7 1.7 0 0 0 19.43 9 1.7 1.7 0 0 0 21 10h.08v4H21a1.7 1.7 0 0 0-1.6 1Z" />
+    </svg>
+  )
+}
+
+function RootComponent() {
+  // Chrome (masthead + lane ribbon) is full-bleed on every route so nav
+  // positions never jump. Repos/Completed cap reading width on page body only.
+  return (
+    <div className="min-h-screen w-full">
+      <SettingsChrome />
       <ReactQueryDevtools buttonPosition="bottom-left" />
       <TanStackRouterDevtools position="bottom-right" />
     </div>
   )
 }
 
-function SettingsButton({ leading }: { leading: ReactNode }) {
+function ThemeTogglePlate() {
+  // SSR-stable initial state: server and first client paint match ("light"
+  // control chrome). Page colors already follow bootstrap's data-theme; the
+  // mount effect below mirrors that onto the plate without a hydration mismatch.
+  const [theme, setTheme] = useState<ThemeMode>("light")
+  // No `from: Route.fullPath` — that roots relative nav at `/` and would send
+  // Repos/Completed operators home when only search should change.
+  const navigate = useNavigate()
+
+  useEffect(() => {
+    // Sync only — do not re-resolve/re-apply (would race a pre-effect toggle).
+    setTheme(readDocumentTheme())
+  }, [])
+
+  const targetLabel = themeToggleLabel(theme)
+
+  return (
+    <button
+      type="button"
+      className={mastPlateClassName}
+      aria-label={`Switch to ${targetLabel} theme`}
+      aria-pressed={theme === "dark"}
+      onClick={() => {
+        const next = oppositeTheme(readDocumentTheme())
+        applyThemeMode(next)
+        // Stay on the current leaf route; only pin ?theme= for bootstrap/retain.
+        void navigate({
+          to: ".",
+          search: (prev) => withThemePin(prev, next),
+          replace: true,
+          resetScroll: false,
+        })
+        setTheme(next)
+      }}
+    >
+      <ThemeMoonIcon />
+      <span>{targetLabel}</span>
+    </button>
+  )
+}
+
+function ThemeMoonIcon() {
+  return (
+    <svg
+      aria-hidden="true"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+    >
+      <path d="M21 12.8A9 9 0 1 1 11.2 3 7 7 0 0 0 21 12.8Z" />
+    </svg>
+  )
+}
+
+function SettingsChrome() {
   const dialogRef = useRef<HTMLDialogElement>(null)
   const queryClient = useQueryClient()
   const [dialogOpen, setDialogOpen] = useState(false)
@@ -717,64 +749,103 @@ function SettingsButton({ leading }: { leading: ReactNode }) {
 
   return (
     <>
-      {showBackendBanner && !dialogOpen && (
-        <div
-          className="mr-auto flex flex-wrap items-center gap-2 border border-oxblood/40 bg-oxblood-wash px-3 py-1.5 text-xs text-oxblood-deep sm:text-sm"
-          role="status"
-        >
-          <span>{bannerUnavailableReason}</span>
+      <header className="mast">
+        <div className="brand">
+          <p className="brand-kicker">
+            Ready for Agent · Operator board ·{" "}
+            <b title={`Ready for Agent ${READY_FOR_AGENT_VERSION_LABEL}`}>
+              RFA {READY_FOR_AGENT_VERSION_LABEL}
+            </b>
+          </p>
+          <h1 className="brand-wordmark">
+            <Link to="/" activeOptions={{ exact: true }}>
+              Clanker Harness
+            </Link>
+          </h1>
+          <p className="brand-sub">
+            <span className="ok">All lanes live</span>
+          </p>
+        </div>
+        <nav className="mast-nav" aria-label="Primary">
+          <Link
+            to="/"
+            activeOptions={{ exact: true }}
+            className={mastPlateClassName}
+            activeProps={{ "aria-current": "page" }}
+          >
+            <HomeNavIcon />
+            Home
+          </Link>
+          <Link
+            to="/repos"
+            className={mastPlateClassName}
+            activeProps={{ "aria-current": "page" }}
+          >
+            <ReposNavIcon />
+            Repos
+          </Link>
+          <Link
+            to="/completed"
+            className={mastPlateClassName}
+            activeProps={{ "aria-current": "page" }}
+          >
+            <CompletedNavIcon />
+            Completed
+          </Link>
           <button
             type="button"
-            className="border border-oxblood/50 bg-paper px-2 py-0.5 text-xs font-semibold text-oxblood underline-offset-2 hover:bg-oxblood hover:text-paper"
+            className={mastPlateClassName}
             onClick={openSettings}
+            aria-haspopup="dialog"
           >
-            Open Settings
+            <SettingsNavIcon />
+            Settings
           </button>
-        </div>
-      )}
-      {showUnconfiguredGuidance && !dialogOpen && !showBackendBanner && (
-        <div
-          className="mr-auto flex flex-wrap items-center gap-2 border border-oxblood/40 bg-oxblood-wash px-3 py-1.5 text-xs text-oxblood-deep sm:text-sm"
-          role="status"
-        >
-          <span>Select a default build model first</span>
-          <button
-            type="button"
-            className="border border-oxblood/50 bg-paper px-2 py-0.5 text-xs font-semibold text-oxblood underline-offset-2 hover:bg-oxblood hover:text-paper"
-            onClick={openSettings}
+          <ThemeTogglePlate />
+        </nav>
+      </header>
+      <div className="lane-ribbon" aria-hidden="true">
+        <span />
+        <span />
+        <span />
+        <span />
+        <span />
+        <span />
+      </div>
+
+      <div className="page-shell">
+        {showBackendBanner && !dialogOpen && (
+          <Banner
+            tone="alarm"
+            tag="Backend"
+            action={
+              <BannerActionButton onClick={openSettings}>
+                Open Settings
+              </BannerActionButton>
+            }
           >
-            Open Settings
-          </button>
-        </div>
-      )}
-      {/* Home / Repos / Completed / Settings share one right-aligned control cluster.
-          Status banners above stay nav-level siblings (outside the cluster). */}
-      <div className="ml-auto flex items-center gap-2 self-center">
-        {leading}
-        <button
-          type="button"
-          className={primaryNavActionClassName}
-          onClick={openSettings}
-          aria-haspopup="dialog"
-        >
-          <svg
-            aria-hidden="true"
-            className="size-3.5"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            strokeWidth="2"
+            {bannerUnavailableReason}
+          </Banner>
+        )}
+        {showUnconfiguredGuidance && !dialogOpen && !showBackendBanner && (
+          <Banner
+            tone="guidance"
+            tag="Setup"
+            action={
+              <BannerActionButton onClick={openSettings}>
+                Open Settings
+              </BannerActionButton>
+            }
           >
-            <path d="M12 15.5a3.5 3.5 0 1 0 0-7 3.5 3.5 0 0 0 0 7Z" />
-            <path d="M19.4 15a1.7 1.7 0 0 0 .34 1.88l.06.06-2.83 2.83-.06-.06a1.7 1.7 0 0 0-1.88-.34 1.7 1.7 0 0 0-1.03 1.56V21h-4v-.08A1.7 1.7 0 0 0 8.94 19.4a1.7 1.7 0 0 0-1.88.34l-.06.06-2.83-2.83.06-.06A1.7 1.7 0 0 0 4.57 15 1.7 1.7 0 0 0 3 14H3v-4h.08A1.7 1.7 0 0 0 4.6 8.94a1.7 1.7 0 0 0-.34-1.88L4.2 7l2.83-2.83.06.06A1.7 1.7 0 0 0 9 4.57 1.7 1.7 0 0 0 10 3V3h4v.08A1.7 1.7 0 0 0 15.06 4.6a1.7 1.7 0 0 0 1.88-.34L17 4.2 19.83 7l-.06.06A1.7 1.7 0 0 0 19.43 9 1.7 1.7 0 0 0 21 10h.08v4H21a1.7 1.7 0 0 0-1.6 1Z" />
-          </svg>
-          Settings
-        </button>
+            Select a default build model first
+          </Banner>
+        )}
+        <Outlet />
       </div>
 
       <dialog
         ref={dialogRef}
-        className="m-auto w-[min(92vw,32rem)] border border-rule-2 bg-panel p-0 text-ink shadow-[0_18px_50px_rgb(28_22_14_/_18%)] backdrop:bg-ink/45"
+        className="m-auto w-[min(92vw,32rem)] border border-rule-2 bg-panel p-0 text-ink shadow-[0_18px_50px_rgb(28_22_14_/_18%)] backdrop:bg-black/50"
         aria-labelledby="settings-title"
         onCancel={(event) => {
           if (updateConfig.isPending) event.preventDefault()
@@ -1202,7 +1273,7 @@ function SettingsButton({ leading }: { leading: ReactNode }) {
             </button>
             <button
               type="submit"
-              className="bg-oxblood px-4 py-2 text-sm font-semibold tracking-wide text-paper uppercase hover:bg-oxblood-deep disabled:cursor-not-allowed disabled:opacity-50"
+              className="bg-oxblood px-4 py-2 text-sm font-semibold tracking-wide text-on-solid uppercase hover:bg-oxblood-deep disabled:cursor-not-allowed disabled:opacity-50"
               disabled={
                 config.isPending ||
                 config.isError ||

--- a/apps/harness/src/routes/completed.tsx
+++ b/apps/harness/src/routes/completed.tsx
@@ -1,6 +1,7 @@
 import { useQueries, useQuery, useSuspenseQuery } from "@tanstack/react-query"
 import { createFileRoute } from "@tanstack/react-router"
 import { Suspense, useEffect, useState } from "react"
+import { Banner, BannerActionButton } from "../banner.js"
 import { CompletedWorkItemRow } from "../completed-work-item-row.js"
 import { WorkItemsLiveUpdates } from "../work-items-live-updates.js"
 import {
@@ -118,20 +119,22 @@ function CompletedWorkItemsBoard() {
     return (
       <>
         {live}
-        <article className="border border-oxblood/40 bg-oxblood-wash px-4 py-3 sm:px-5">
-          <p className="m-0 text-sm text-oxblood-deep" role="alert">
-            Could not load completed work items. Please try again.
-          </p>
-          <button
-            type="button"
-            className="mt-3 border border-rule-2 bg-paper px-3 py-1.5 text-sm font-semibold text-ink-2 transition hover:bg-paper-2 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-oxblood"
-            onClick={() => {
-              void completedQuery.refetch()
-            }}
-          >
-            Retry
-          </button>
-        </article>
+        <Banner
+          tone="alarm"
+          tag="Error"
+          role="alert"
+          action={
+            <BannerActionButton
+              onClick={() => {
+                void completedQuery.refetch()
+              }}
+            >
+              Retry
+            </BannerActionButton>
+          }
+        >
+          Could not load completed work items. Please try again.
+        </Banner>
       </>
     )
   }
@@ -167,23 +170,22 @@ function CompletedWorkItemsBoard() {
     <article className="border border-rule-2 bg-panel px-4 py-3 sm:px-5">
       {live}
       {refreshFailedWithData ? (
-        <div
-          className="mb-3 flex flex-wrap items-center justify-between gap-2 border border-oxblood/40 bg-oxblood-wash px-3 py-2"
-          role="status"
+        <Banner
+          className="mb-3"
+          tone="alarm"
+          tag="Refresh failed"
+          action={
+            <BannerActionButton
+              onClick={() => {
+                void completedQuery.refetch()
+              }}
+            >
+              Retry
+            </BannerActionButton>
+          }
         >
-          <p className="m-0 text-sm text-oxblood-deep">
-            Could not refresh completed work items. Showing last loaded page.
-          </p>
-          <button
-            type="button"
-            className="border border-rule-2 bg-paper px-2 py-1 text-xs font-semibold text-ink-2 transition hover:bg-paper-2 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-oxblood"
-            onClick={() => {
-              void completedQuery.refetch()
-            }}
-          >
-            Retry
-          </button>
-        </div>
+          Could not refresh completed work items. Showing last loaded page.
+        </Banner>
       ) : null}
       {resolvedTotalCount === 0 ? (
         <p className="m-0 font-serif text-sm italic text-ink-soft">

--- a/apps/harness/src/routes/index.tsx
+++ b/apps/harness/src/routes/index.tsx
@@ -12,6 +12,7 @@ import {
   COMPLETED_WORK_ITEMS_DEFAULT_PAGE_SIZE as completedWorkItemsDefaultPageSize,
   JOBS_COMPLETED_WINDOW_HOURS as jobsCompletedWindowHours,
 } from "@ready-for-agent/work-item-lifecycle/jobs-completed-window"
+import { Banner, BannerActionButton } from "../banner.js"
 import { repositoryCardCollapseId, useCardCollapsed } from "../card-collapse.js"
 import { CardCollapseToggle } from "../card-collapse-toggle.js"
 import {
@@ -615,12 +616,9 @@ function HomeRepositoryMembershipLive() {
     return null
   }
   return (
-    <p
-      className="mb-4 border border-oxblood/40 bg-oxblood-wash px-4 py-3 text-sm text-oxblood-deep"
-      role="status"
-    >
+    <Banner className="mb-4" tone="alarm" tag="Live">
       {warningPresentation.message}
-    </p>
+    </Banner>
   )
 }
 
@@ -653,20 +651,22 @@ function HomeContent() {
   if (isError && repositories === undefined) {
     return (
       <main className="pt-8 sm:pt-10">
-        <article className="border border-oxblood/40 bg-oxblood-wash px-4 py-3 sm:px-5">
-          <p className="m-0 text-sm text-oxblood-deep" role="alert">
-            Could not load repositories. Please try again.
-          </p>
-          <button
-            type="button"
-            className="mt-3 border border-rule-2 bg-paper px-3 py-1.5 text-sm font-semibold text-ink-2 transition hover:bg-paper-2 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-oxblood"
-            onClick={() => {
-              void refetch()
-            }}
-          >
-            Retry
-          </button>
-        </article>
+        <Banner
+          tone="alarm"
+          tag="Error"
+          role="alert"
+          action={
+            <BannerActionButton
+              onClick={() => {
+                void refetch()
+              }}
+            >
+              Retry
+            </BannerActionButton>
+          }
+        >
+          Could not load repositories. Please try again.
+        </Banner>
       </main>
     )
   }
@@ -792,11 +792,9 @@ export function CommittedPullRequestsDashboard() {
 
   if (failed) {
     return (
-      <article className="border border-oxblood/40 bg-oxblood-wash px-4 py-3 sm:px-5">
-        <p className="m-0 text-sm text-oxblood-deep" role="alert">
-          Could not load committed pull requests. Please try again.
-        </p>
-      </article>
+      <Banner tone="alarm" tag="Error" role="alert">
+        Could not load committed pull requests. Please try again.
+      </Banner>
     )
   }
 
@@ -934,12 +932,9 @@ export function RepositoryCards() {
   )
   const warning =
     warningPresentation !== null ? (
-      <p
-        className="mb-4 border border-oxblood/40 bg-oxblood-wash px-4 py-3 text-sm text-oxblood-deep"
-        role="status"
-      >
+      <Banner className="mb-4" tone="alarm" tag="Live">
         {warningPresentation.message}
-      </p>
+      </Banner>
     ) : null
 
   if (repositories.length === 0) {
@@ -1186,7 +1181,7 @@ function AddRepositoryGuidance({
             <button
               type="submit"
               disabled={busy}
-              className="bg-oxblood px-3 py-2 text-sm font-semibold tracking-wide text-paper uppercase transition hover:bg-oxblood-deep focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-oxblood disabled:cursor-wait disabled:opacity-60"
+              className="bg-oxblood px-3 py-2 text-sm font-semibold tracking-wide text-on-solid uppercase transition hover:bg-oxblood-deep focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-oxblood disabled:cursor-wait disabled:opacity-60"
             >
               {addLocalRepository.isPending
                 ? "Adding…"
@@ -2104,7 +2099,7 @@ function RepositoryCard({
       </div>
       <dialog
         ref={settingsDialogRef}
-        className="m-auto w-[min(92vw,32rem)] border border-rule-2 bg-panel p-0 text-ink shadow-[0_18px_50px_rgb(28_22_14_/_18%)] backdrop:bg-ink/45"
+        className="m-auto w-[min(92vw,32rem)] border border-rule-2 bg-panel p-0 text-ink shadow-[0_18px_50px_rgb(28_22_14_/_18%)] backdrop:bg-black/50"
         aria-labelledby={`repo-settings-title-${repository.id}`}
         onCancel={(event) => {
           if (updateSettings.isPending) event.preventDefault()
@@ -2495,7 +2490,7 @@ function RepositoryCard({
             </button>
             <button
               type="submit"
-              className="bg-oxblood px-4 py-2 text-sm font-semibold tracking-wide text-paper uppercase hover:bg-oxblood-deep disabled:cursor-wait disabled:opacity-60"
+              className="bg-oxblood px-4 py-2 text-sm font-semibold tracking-wide text-on-solid uppercase hover:bg-oxblood-deep disabled:cursor-wait disabled:opacity-60"
               disabled={
                 updateSettings.isPending ||
                 (backendChangeBlocked &&
@@ -2626,12 +2621,37 @@ function RepositoryCard({
           </dl>
           {!repository.credential.configured &&
             repository.forge === "github" && (
-              <div className="mt-5 grid gap-2 border border-oxblood/40 bg-oxblood-wash px-4 py-3 text-sm text-oxblood-deep">
-                <strong className="font-serif text-base font-semibold">
-                  GitHub token required
-                </strong>
+              <Banner
+                className="mt-5"
+                tone="alarm"
+                tag="Attention"
+                role={addGitHubToken.isError ? "alert" : "status"}
+                action={
+                  githubTokenCreated ? (
+                    <BannerActionButton
+                      disabled={addGitHubToken.isPending}
+                      onClick={() => addGitHubToken.mutate()}
+                    >
+                      {addGitHubToken.isPending
+                        ? "Waiting for Keymaxxer"
+                        : "Store in Keymaxxer"}
+                    </BannerActionButton>
+                  ) : (
+                    <a
+                      className="plate-mini"
+                      href={repository.credential.githubTokenCreationUrl}
+                      onClick={() => setGithubTokenCreated(true)}
+                      rel="noreferrer"
+                      target="_blank"
+                    >
+                      Create GitHub token
+                    </a>
+                  )
+                }
+              >
+                <p className="m-0 font-semibold">GitHub token required</p>
                 {githubTokenCreated ? (
-                  <p className="m-0">
+                  <p className="m-0 mt-1">
                     Store the generated token as{" "}
                     <code className="font-bold">
                       {repository.credential.githubTokenSecretName}
@@ -2641,7 +2661,7 @@ function RepositoryCard({
                     then store the replacement.
                   </p>
                 ) : (
-                  <p className="m-0">
+                  <p className="m-0 mt-1">
                     Create a fine-grained token, choose{" "}
                     <strong>Only select repositories</strong>, select{" "}
                     <code className="font-bold">
@@ -2653,42 +2673,47 @@ function RepositoryCard({
                     them if Actions is still read-only.
                   </p>
                 )}
-                {githubTokenCreated ? (
-                  <button
-                    type="button"
-                    className="w-fit bg-oxblood px-3 py-2 font-semibold tracking-wide text-paper uppercase transition hover:bg-oxblood-deep focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-oxblood disabled:cursor-wait disabled:opacity-60"
-                    disabled={addGitHubToken.isPending}
-                    onClick={() => addGitHubToken.mutate()}
-                  >
-                    {addGitHubToken.isPending
-                      ? "Waiting for Keymaxxer"
-                      : "Store in Keymaxxer"}
-                  </button>
-                ) : (
-                  <a
-                    className="w-fit bg-oxblood px-3 py-2 font-semibold tracking-wide text-paper no-underline uppercase transition hover:bg-oxblood-deep focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-oxblood"
-                    href={repository.credential.githubTokenCreationUrl}
-                    onClick={() => setGithubTokenCreated(true)}
-                    rel="noreferrer"
-                    target="_blank"
-                  >
-                    Create GitHub token
-                  </a>
-                )}
-                {addGitHubToken.isError && (
-                  <p className="m-0 text-oxblood-deep" role="alert">
+                {addGitHubToken.isError ? (
+                  <p className="m-0 mt-1">
                     Keymaxxer setup was cancelled or failed.
                   </p>
-                )}
-              </div>
+                ) : null}
+              </Banner>
             )}
           {!repository.credential.configured &&
             repository.forge === "gitlab" && (
-              <div className="mt-5 grid gap-2 border border-oxblood/40 bg-oxblood-wash px-4 py-3 text-sm text-oxblood-deep">
-                <strong className="font-serif text-base font-semibold">
+              <Banner
+                className="mt-5"
+                tone="alarm"
+                tag="Attention"
+                role={addGitLabToken.isError ? "alert" : "status"}
+                action={
+                  gitlabTokenCreated ? (
+                    <BannerActionButton
+                      disabled={addGitLabToken.isPending}
+                      onClick={() => addGitLabToken.mutate()}
+                    >
+                      {addGitLabToken.isPending
+                        ? "Waiting for Keymaxxer"
+                        : "Store in Keymaxxer"}
+                    </BannerActionButton>
+                  ) : (
+                    <a
+                      className="plate-mini"
+                      href={repository.credential.githubTokenCreationUrl}
+                      onClick={() => setGitlabTokenCreated(true)}
+                      rel="noreferrer"
+                      target="_blank"
+                    >
+                      Create GitLab token
+                    </a>
+                  )
+                }
+              >
+                <p className="m-0 font-semibold">
                   GitLab authentication required
-                </strong>
-                <p className="m-0">
+                </p>
+                <p className="m-0 mt-1">
                   {gitlabTokenCreated ? (
                     <>
                       Store the generated token as{" "}
@@ -2719,40 +2744,15 @@ function RepositoryCard({
                   </code>{" "}
                   before starting the Harness.
                 </p>
-                <div className="flex flex-wrap gap-2">
-                  {!gitlabTokenCreated && (
-                    <a
-                      className="w-fit bg-oxblood px-3 py-2 font-semibold tracking-wide text-paper no-underline uppercase transition hover:bg-oxblood-deep focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-oxblood"
-                      href={repository.credential.githubTokenCreationUrl}
-                      onClick={() => setGitlabTokenCreated(true)}
-                      rel="noreferrer"
-                      target="_blank"
-                    >
-                      Create GitLab token
-                    </a>
-                  )}
-                  {gitlabTokenCreated && (
-                    <button
-                      type="button"
-                      className="w-fit bg-oxblood px-3 py-2 font-semibold tracking-wide text-paper uppercase transition hover:bg-oxblood-deep focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-oxblood disabled:cursor-wait disabled:opacity-60"
-                      disabled={addGitLabToken.isPending}
-                      onClick={() => addGitLabToken.mutate()}
-                    >
-                      {addGitLabToken.isPending
-                        ? "Waiting for Keymaxxer"
-                        : "Store in Keymaxxer"}
-                    </button>
-                  )}
-                </div>
-                {addGitLabToken.isError && (
-                  <p className="m-0 text-oxblood-deep" role="alert">
+                {addGitLabToken.isError ? (
+                  <p className="m-0 mt-1">
                     Keymaxxer setup was cancelled or failed. Use ambient{" "}
                     <code className="font-bold">GITLAB_TOKEN</code> or{" "}
                     <code className="font-bold">glab auth login</code> and
                     restart the Harness if Keymaxxer is unavailable.
                   </p>
-                )}
-              </div>
+                ) : null}
+              </Banner>
             )}
           <div className="mt-5">
             <div className="mb-2 flex items-baseline justify-between gap-3">
@@ -3318,7 +3318,7 @@ export function SessionUsageDialog({
   return (
     <dialog
       ref={dialogRef}
-      className="m-auto w-[min(92vw,28rem)] border border-rule-2 bg-panel p-0 text-ink shadow-[0_18px_50px_rgb(28_22_14_/_18%)] backdrop:bg-ink/45"
+      className="m-auto w-[min(92vw,28rem)] border border-rule-2 bg-panel p-0 text-ink shadow-[0_18px_50px_rgb(28_22_14_/_18%)] backdrop:bg-black/50"
       aria-labelledby="session-usage-title"
       onClose={onClose}
     >

--- a/apps/harness/src/styles.css
+++ b/apps/harness/src/styles.css
@@ -1,17 +1,146 @@
 @import "tailwindcss";
 
+/* ==========================================================================
+   Interchange token layer (canonical) — docs/harness-design-system.md §2
+   Lane colors + fonts are theme-invariant. Neutrals / mast / plate / PR badge
+   flip under [data-theme="dark"]. Components consume these tokens only.
+   ========================================================================== */
+
+:root {
+  /* §2.1 Lane colors (fixed pipeline identity — theme-invariant) */
+  --lane-queue: #ffd21c;
+  --lane-build: #1976d2;
+  --lane-review: #7654b5;
+  --lane-pr: #168b62;
+  --lane-attention: #ff4d1c;
+  --lane-merged: #151515;
+  --lane-queue-ink: #151515;
+  --lane-build-ink: #ffffff;
+  --lane-review-ink: #ffffff;
+  --lane-pr-ink: #ffffff;
+  --lane-attention-ink: #151515;
+  --lane-merged-ink: #ffffff;
+
+  /* §2.6 Typography stacks (theme-invariant) */
+  --font-display: "Inter Tight", "Helvetica Neue", Helvetica, Arial, sans-serif;
+  --font-mono:
+    "JetBrains Mono", ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+}
+
+:root,
+[data-theme="light"] {
+  color-scheme: light;
+  /* §2.2 Neutrals */
+  --paper: #ffffff;
+  --panel: #ffffff;
+  /* Elevated / inset surfaces used by unmigrated dialogs + chips */
+  --paper-2: #f0f1ef;
+  --paper-3: #e6e8e5;
+  --ink: #151515;
+  --ink-dim: #4a4a4a;
+  --ink-faint: #8b8b8b;
+  --line-soft: rgb(21 21 21 / 0.3);
+  --line-ghost: rgb(21 21 21 / 0.12);
+  --rule: #d8c9a8;
+  --rule-2: #cbbb96;
+  --rule-soft: #e7dcc2;
+  --signal: #ffd21c;
+  --merged-halo: transparent;
+  /* Inverse text on saturated fills (oxblood CTAs) — never theme-flips */
+  --on-solid: #ffffff;
+  /* Modal scrim — always dims, never inverts with ink */
+  --scrim: rgb(21 21 21 / 0.45);
+
+  /* §2.3 Masthead (dark supergraphic band in both themes) */
+  --mast-bg: #101314;
+  --mast-ink: #ffffff;
+  --mast-dim: #b9b9b9;
+  --mast-faint: #7c7c7c;
+  --mast-plate: #2b2f33;
+  --mast-plate-hover: #3a4046;
+  --mast-plate-ink: #d7dbd9;
+  --mast-plate-rivet: rgb(0 0 0 / 0.6);
+  --mast-plate-hi: rgb(255 255 255 / 0.14);
+  --mast-plate-active: #e8ece9;
+  --mast-plate-active-ink: #101314;
+  --mast-plate-active-rivet: rgb(16 19 18 / 0.5);
+
+  /* §2.4 Stamped plates on paper */
+  --plate: #dfe4e1;
+  --plate-hover: #cfd6d2;
+  --plate-ink: #23282b;
+  --plate-rivet: rgb(16 19 18 / 0.55);
+  --plate-hi: rgb(255 255 255 / 0.65);
+  --plate-lo: rgb(16 19 18 / 0.12);
+
+  /* §2.5 PR badge */
+  --prbadge-bg: #151515;
+  --prbadge-ink: #ffffff;
+  --prbadge-border: transparent;
+}
+
+[data-theme="dark"] {
+  color-scheme: dark;
+  --paper: #15181b;
+  --panel: #1c2024;
+  --paper-2: #23282c;
+  --paper-3: #2b3035;
+  --ink: #f2f3f1;
+  --ink-dim: #c6cac8;
+  --ink-faint: #7f8583;
+  --line-soft: rgb(242 243 241 / 0.32);
+  --line-ghost: rgb(242 243 241 / 0.14);
+  --rule: rgb(242 243 241 / 0.28);
+  --rule-2: rgb(242 243 241 / 0.22);
+  --rule-soft: rgb(242 243 241 / 0.14);
+  --signal: #ffd21c;
+  --merged-halo: rgb(242 243 241 / 0.85);
+  --on-solid: #ffffff;
+  --scrim: rgb(0 0 0 / 0.55);
+
+  --mast-bg: #000000;
+  --mast-ink: #ffffff;
+  --mast-dim: #b9b9b9;
+  --mast-faint: #7c7c7c;
+  --mast-plate: #232629;
+  --mast-plate-hover: #32373b;
+  --mast-plate-ink: #d7dbd9;
+  --mast-plate-rivet: rgb(0 0 0 / 0.65);
+  --mast-plate-hi: rgb(255 255 255 / 0.12);
+  --mast-plate-active: #e8ece9;
+  --mast-plate-active-ink: #101314;
+  --mast-plate-active-rivet: rgb(16 19 18 / 0.5);
+
+  --plate: #2b2f33;
+  --plate-hover: #3a4046;
+  --plate-ink: #d7dbd9;
+  --plate-rivet: rgb(0 0 0 / 0.6);
+  --plate-hi: rgb(255 255 255 / 0.14);
+  --plate-lo: rgb(0 0 0 / 0.35);
+
+  --prbadge-bg: #151515;
+  --prbadge-ink: #f2f3f1;
+  --prbadge-border: var(--merged-halo);
+}
+
+/*
+  Tailwind @theme aliases map Interchange tokens to utilities.
+  Oxblood/wash accents stay fixed (unmigrated dialogs); surfaces + ink flip.
+*/
 @theme {
-  --color-paper: #f4ecdb;
-  --color-paper-2: #efe5d0;
-  --color-paper-3: #e9dcc1;
-  --color-panel: #fbf6ea;
-  --color-ink: #1d160e;
-  --color-ink-2: #34291c;
-  --color-ink-soft: #5b4d3b;
-  --color-ink-faint: #6e5b43;
-  --color-rule: #d8c9a8;
-  --color-rule-2: #cbbb96;
-  --color-rule-soft: #e7dcc2;
+  --color-paper: var(--paper);
+  --color-paper-2: var(--paper-2);
+  --color-paper-3: var(--paper-3);
+  --color-panel: var(--panel);
+  --color-ink: var(--ink);
+  --color-ink-2: var(--ink-dim);
+  --color-ink-soft: var(--ink-dim);
+  --color-ink-faint: var(--ink-faint);
+  --color-rule: var(--rule);
+  --color-rule-2: var(--rule-2);
+  --color-rule-soft: var(--rule-soft);
+  --color-on-solid: var(--on-solid);
+  --color-scrim: var(--scrim);
   --color-oxblood: #7a1d2a;
   --color-oxblood-deep: #5c141f;
   --color-vermilion: #b8341b;
@@ -22,18 +151,23 @@
   --color-oxblood-wash: #f0ddd9;
   --color-vermilion-wash: #f4e1d8;
   --color-violet-wash: #e7dff0;
-  /* Waiting for blockers (Queue hold) — distinct from violet Worker Slot wait */
   --color-teal: #2f5d50;
   --color-teal-wash: #e2ebe7;
+  --color-signal: var(--signal);
+  --color-lane-queue: var(--lane-queue);
+  --color-lane-build: var(--lane-build);
+  --color-lane-review: var(--lane-review);
+  --color-lane-pr: var(--lane-pr);
+  --color-lane-attention: var(--lane-attention);
+  --color-lane-merged: var(--lane-merged);
+  /* Serif kept until phase 5 teardown when no surface references it. */
   --font-serif:
     "Iowan Old Style", "Palatino Linotype", "URW Palladio L", Palatino,
     "Book Antiqua", Georgia, "Times New Roman", serif;
-  --font-sans:
-    ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto,
-    "Helvetica Neue", Arial, sans-serif;
+  --font-display: "Inter Tight", "Helvetica Neue", Helvetica, Arial, sans-serif;
+  --font-sans: "Inter Tight", "Helvetica Neue", Helvetica, Arial, sans-serif;
   --font-mono:
-    ui-monospace, "SF Mono", "Cascadia Code", "JetBrains Mono",
-    "DejaVu Sans Mono", Menlo, Consolas, monospace;
+    "JetBrains Mono", ui-monospace, "SF Mono", Menlo, Consolas, monospace;
 }
 
 @layer base {
@@ -43,34 +177,25 @@
   }
 
   body {
-    background-color: var(--color-paper);
-    background-image:
-      radial-gradient(
-        130% 90% at 50% -10%,
-        rgba(28, 22, 14, 0) 55%,
-        rgba(28, 22, 14, 0.045) 100%
-      ),
-      repeating-linear-gradient(
-        0deg,
-        rgba(28, 22, 14, 0.012) 0 1px,
-        rgba(28, 22, 14, 0) 1px 3px
-      );
-    background-attachment: fixed;
-    color: var(--color-ink);
-    font-family: var(--font-sans);
+    background-color: var(--paper);
+    color: var(--ink);
+    font-family: var(--font-display);
     font-synthesis: none;
     text-rendering: optimizeLegibility;
   }
 
   ::selection {
-    background-color: var(--color-oxblood);
-    color: var(--color-paper);
+    background-color: var(--signal);
+    color: #151515;
   }
 
   :focus-visible {
-    border-radius: 1px;
-    outline: 2px solid var(--color-oxblood);
+    outline: 2px solid var(--ink);
     outline-offset: 2px;
+  }
+
+  .mast :focus-visible {
+    outline-color: var(--signal);
   }
 
   @media (prefers-reduced-motion: reduce) {
@@ -86,6 +211,280 @@
 }
 
 @layer components {
+  /* ---------- Nav shell (§4.1) ---------- */
+
+  .mast {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: flex-end;
+    justify-content: space-between;
+    gap: 1.2rem 2.5rem;
+    padding: 1.5rem 2.2rem 1.35rem;
+    background: var(--mast-bg);
+    color: var(--mast-ink);
+  }
+
+  .brand-kicker {
+    margin: 0 0 0.5rem;
+    font-family: var(--font-mono);
+    font-size: 0.62rem;
+    letter-spacing: 0.22em;
+    text-transform: uppercase;
+    color: var(--mast-faint);
+  }
+
+  .brand-kicker b {
+    color: var(--mast-dim);
+    font-weight: 400;
+  }
+
+  .brand-wordmark {
+    margin: 0;
+    font-family: var(--font-display);
+    font-size: clamp(2rem, 4.2vw, 3.1rem);
+    font-weight: 800;
+    line-height: 0.92;
+    letter-spacing: -0.015em;
+    text-transform: uppercase;
+  }
+
+  .brand-wordmark a {
+    color: var(--mast-ink);
+    text-decoration: none;
+  }
+
+  .brand-wordmark a:hover {
+    color: var(--signal);
+  }
+
+  .brand-sub {
+    margin: 0.55rem 0 0;
+    font-family: var(--font-mono);
+    font-size: 0.66rem;
+    letter-spacing: 0.16em;
+    text-transform: uppercase;
+    color: var(--mast-dim);
+  }
+
+  .brand-sub .ok {
+    color: var(--signal);
+  }
+
+  .mast-nav {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.55rem;
+  }
+
+  /* Stamped plates on the dark masthead band (§5.3 / §4.1) */
+  .mast-plate {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    border: 2px solid #000;
+    background-color: var(--mast-plate);
+    background-image:
+      radial-gradient(
+        circle 1.6px at 7px 7px,
+        var(--mast-plate-rivet) 1.6px,
+        transparent 2.1px
+      ),
+      radial-gradient(
+        circle 1.6px at calc(100% - 7px) 7px,
+        var(--mast-plate-rivet) 1.6px,
+        transparent 2.1px
+      );
+    box-shadow:
+      inset 0 1px 0 var(--mast-plate-hi),
+      inset 0 -2px 0 rgb(0 0 0 / 0.3);
+    padding: 0.55rem 0.95rem;
+    color: var(--mast-plate-ink);
+    font-family: var(--font-mono);
+    font-size: 0.7rem;
+    font-weight: 700;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    text-decoration: none;
+    cursor: pointer;
+    transition:
+      background-color 120ms ease,
+      color 120ms ease;
+  }
+
+  .mast-plate:hover {
+    background-color: var(--mast-plate-hover);
+    color: var(--mast-ink);
+  }
+
+  .mast-plate[aria-current="page"] {
+    background-color: var(--mast-plate-active);
+    background-image:
+      radial-gradient(
+        circle 1.6px at 7px 7px,
+        var(--mast-plate-active-rivet) 1.6px,
+        transparent 2.1px
+      ),
+      radial-gradient(
+        circle 1.6px at calc(100% - 7px) 7px,
+        var(--mast-plate-active-rivet) 1.6px,
+        transparent 2.1px
+      );
+    box-shadow:
+      inset 0 1px 0 rgb(255 255 255 / 0.65),
+      inset 0 -2px 0 rgb(16 19 18 / 0.12);
+    color: var(--mast-plate-active-ink);
+  }
+
+  .mast-plate svg {
+    width: 0.9rem;
+    height: 0.9rem;
+    flex-shrink: 0;
+  }
+
+  /* Lane-colour ribbon under the masthead (visual motif only) */
+  .lane-ribbon {
+    display: flex;
+    height: 0.4rem;
+  }
+
+  .lane-ribbon > span {
+    flex: 1;
+  }
+
+  .lane-ribbon > span:nth-child(1) {
+    background: var(--lane-queue);
+  }
+  .lane-ribbon > span:nth-child(2) {
+    background: var(--lane-build);
+  }
+  .lane-ribbon > span:nth-child(3) {
+    background: var(--lane-review);
+  }
+  .lane-ribbon > span:nth-child(4) {
+    background: var(--lane-pr);
+  }
+  .lane-ribbon > span:nth-child(5) {
+    background: var(--lane-attention);
+  }
+  .lane-ribbon > span:nth-child(6) {
+    background: var(--lane-merged);
+  }
+
+  /* Page content under chrome — chrome is full-bleed; content is padded */
+  .page-shell {
+    padding: 1.6rem 2.2rem 3rem;
+  }
+
+  .page-shell > .banner {
+    margin-bottom: 1rem;
+  }
+
+  /* ---------- Banner pattern (§4.8) ---------- */
+
+  .banner {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.6rem 0.9rem;
+    border: 2px solid var(--ink);
+    background: var(--panel);
+    padding: 0.5rem 0.7rem;
+    color: var(--ink);
+  }
+
+  .banner-tag {
+    font-family: var(--font-mono);
+    font-size: 0.62rem;
+    font-weight: 700;
+    letter-spacing: 0.16em;
+    text-transform: uppercase;
+    padding: 0.18rem 0.45rem;
+    white-space: nowrap;
+    color: #151515;
+  }
+
+  .banner--alarm .banner-tag {
+    background: var(--lane-attention);
+  }
+
+  .banner--guidance .banner-tag {
+    background: var(--signal);
+  }
+
+  .banner-body {
+    margin: 0;
+    flex: 1 1 12rem;
+    font-family: var(--font-display);
+    font-size: 0.92rem;
+    font-weight: 500;
+    line-height: 1.4;
+    color: var(--ink);
+  }
+
+  .banner-body p {
+    margin: 0;
+  }
+
+  .banner-action {
+    margin-left: auto;
+  }
+
+  /* Mini stamped plate (banner actions, pagination — §5.3) */
+  .plate-mini {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    border: 2px solid var(--ink);
+    background-color: var(--plate);
+    background-image:
+      radial-gradient(
+        circle 1.4px at 6px 6px,
+        var(--plate-rivet) 1.4px,
+        transparent 1.9px
+      ),
+      radial-gradient(
+        circle 1.4px at calc(100% - 6px) 6px,
+        var(--plate-rivet) 1.4px,
+        transparent 1.9px
+      );
+    box-shadow:
+      inset 0 1px 0 var(--plate-hi),
+      inset 0 -2px 0 var(--plate-lo);
+    padding: 0.46rem 0.85rem;
+    color: var(--plate-ink);
+    font-family: var(--font-mono);
+    font-size: 0.68rem;
+    font-weight: 700;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    text-decoration: none;
+    cursor: pointer;
+    transition:
+      background-color 120ms ease,
+      color 120ms ease;
+  }
+
+  .plate-mini:hover {
+    background-color: var(--plate-hover);
+  }
+
+  .plate-mini:disabled {
+    cursor: wait;
+    opacity: 0.55;
+  }
+
+  /* Compact banner (inline inside panels / dialogs) */
+  .banner--compact {
+    padding: 0.45rem 0.6rem;
+  }
+
+  .banner--compact .banner-body {
+    font-size: 0.88rem;
+  }
+
+  /* ---------- Legacy Ledger helpers (unmigrated surfaces) ---------- */
+
   .stamp {
     display: inline-flex;
     align-items: center;
@@ -107,12 +506,6 @@
 
   .entry-rule {
     border-top: 1px solid var(--color-rule-soft);
-  }
-
-  /* Full-width bold rule under primary nav (shared across every route).
-     Visual weight matches the former Kanban board masthead separator. */
-  .primary-nav {
-    border-bottom: 0.5rem solid var(--color-ink);
   }
 
   .industrial-shell {
@@ -345,6 +738,14 @@
 }
 
 @media (max-width: 900px) {
+  .mast {
+    padding: 1.2rem 1.4rem 1.1rem;
+  }
+
+  .page-shell {
+    padding: 1.3rem 1.4rem 2.4rem;
+  }
+
   .pipeline-controls {
     display: grid;
     min-width: 0;

--- a/apps/harness/src/theme.ts
+++ b/apps/harness/src/theme.ts
@@ -1,0 +1,68 @@
+/** Theme plumbing for Interchange (`docs/harness-design-system.md` §3). */
+
+export type ThemeMode = "light" | "dark"
+
+export const THEME_QUERY_PARAM = "theme"
+
+/** Runs before paint so the first frame matches system / ?theme= pin. */
+export const THEME_BOOTSTRAP_SCRIPT = `(function(){try{var p=new URLSearchParams(location.search).get(${JSON.stringify(THEME_QUERY_PARAM)});var t=(p==="dark"||p==="light")?p:(window.matchMedia("(prefers-color-scheme: dark)").matches?"dark":"light");document.documentElement.setAttribute("data-theme",t);}catch(e){}})();`
+
+export function resolveThemeMode(
+  search: string,
+  prefersDark: boolean,
+): ThemeMode {
+  const pinned = new URLSearchParams(search).get(THEME_QUERY_PARAM)
+  if (pinned === "dark" || pinned === "light") {
+    return pinned
+  }
+  return prefersDark ? "dark" : "light"
+}
+
+export function applyThemeMode(theme: ThemeMode): void {
+  document.documentElement.setAttribute("data-theme", theme)
+}
+
+export function readDocumentTheme(): ThemeMode {
+  return document.documentElement.getAttribute("data-theme") === "dark"
+    ? "dark"
+    : "light"
+}
+
+/**
+ * Root / inherited search shape for the theme pin. Used with
+ * `validateSearch` + `retainSearchParams(['theme'])` so SPA navigations
+ * keep `?theme=` for bootstrap on reload.
+ */
+export type ThemeSearch = {
+  readonly theme?: ThemeMode
+}
+
+/** Parse unknown search (root `validateSearch`) into a typed theme pin. */
+export function parseThemeSearch(raw: Record<string, unknown>): ThemeSearch {
+  const theme = raw[THEME_QUERY_PARAM]
+  if (theme === "dark" || theme === "light") {
+    return { theme }
+  }
+  return {}
+}
+
+/**
+ * Router `search` updater: set the theme pin while preserving other params.
+ * Prefer this over `history.replaceState` so the router stays the source of
+ * truth and `retainSearchParams` can keep the pin across Links.
+ */
+export function withThemePin<T extends Record<string, unknown>>(
+  prev: T,
+  theme: ThemeMode,
+): T & { theme: ThemeMode } {
+  return { ...prev, theme }
+}
+
+/** Toggle label shows the *target* theme (moon plate → "Dark" when light). */
+export function themeToggleLabel(current: ThemeMode): string {
+  return current === "dark" ? "Light" : "Dark"
+}
+
+export function oppositeTheme(current: ThemeMode): ThemeMode {
+  return current === "dark" ? "light" : "dark"
+}

--- a/apps/harness/src/theme.ts
+++ b/apps/harness/src/theme.ts
@@ -2,7 +2,7 @@
 
 export type ThemeMode = "light" | "dark"
 
-export const THEME_QUERY_PARAM = "theme"
+const THEME_QUERY_PARAM = "theme"
 
 /** Runs before paint so the first frame matches system / ?theme= pin. */
 export const THEME_BOOTSTRAP_SCRIPT = `(function(){try{var p=new URLSearchParams(location.search).get(${JSON.stringify(THEME_QUERY_PARAM)});var t=(p==="dark"||p==="light")?p:(window.matchMedia("(prefers-color-scheme: dark)").matches?"dark":"light");document.documentElement.setAttribute("data-theme",t);}catch(e){}})();`

--- a/apps/harness/test/completed-route.test.ts
+++ b/apps/harness/test/completed-route.test.ts
@@ -33,19 +33,14 @@ describe("/completed route", () => {
     expect(tree).toContain("./routes/completed")
   })
 
-  test("marks Completed primary nav active via the shared Link active props", () => {
+  test("marks Completed primary nav active via aria-current on mast plate", () => {
     const source = rootSource()
     const completedLink = source.slice(
       source.indexOf('to="/completed"'),
       source.indexOf("</Link>", source.indexOf('to="/completed"')) + 7,
     )
-    expect(completedLink).toContain("primaryNavLinkClassName")
-    expect(completedLink).toContain(
-      "activeProps={{ className: primaryNavLinkActiveClassName }}",
-    )
-    expect(completedLink).toContain(
-      "inactiveProps={{ className: primaryNavLinkInactiveClassName }}",
-    )
+    expect(completedLink).toContain("mastPlateClassName")
+    expect(completedLink).toContain('activeProps={{ "aria-current": "page" }}')
     expect(completedLink).toContain("Completed")
   })
 

--- a/apps/harness/test/kanban-route.test.ts
+++ b/apps/harness/test/kanban-route.test.ts
@@ -403,10 +403,9 @@ describe("kanban home board", () => {
     const rootComponent = root.slice(root.indexOf("function RootComponent("))
     expect(rootComponent).not.toContain("useLocation")
     expect(rootComponent).not.toContain("isKanbanPage")
-    // Shared gutters apply on every route (single static class string).
-    expect(rootComponent).toContain(
-      'className="mx-auto min-h-screen w-full px-5 py-6 sm:px-8 lg:px-12"',
-    )
+    // Interchange chrome is full-bleed; page content uses shared page-shell padding.
+    expect(rootComponent).toContain('className="min-h-screen w-full"')
+    expect(root).toContain('className="page-shell"')
     // Shell must not pathname-gate or hardcode the reading-width cap.
     expect(rootComponent).not.toContain("max-w-[88rem]")
     expect(rootComponent).not.toContain('pathname === "/"')

--- a/apps/harness/test/primary-nav.test.ts
+++ b/apps/harness/test/primary-nav.test.ts
@@ -14,7 +14,13 @@ const reposSource = () =>
 const completedSource = () =>
   readFileSync(join(import.meta.dir, "../src/routes/completed.tsx"), "utf8")
 
-describe("primary Home / Repos / Completed navigation", () => {
+const themeSource = () =>
+  readFileSync(join(import.meta.dir, "../src/theme.ts"), "utf8")
+
+const bannerSource = () =>
+  readFileSync(join(import.meta.dir, "../src/banner.tsx"), "utf8")
+
+describe("primary Home / Repos / Completed navigation (Interchange masthead)", () => {
   test("root chrome exposes Home, Repos, and Completed Link controls", () => {
     const source = rootSource()
     expect(source).toContain('aria-label="Primary"')
@@ -24,120 +30,87 @@ describe("primary Home / Repos / Completed navigation", () => {
     expect(source).toMatch(/Home\s*<\/Link>/)
     expect(source).toMatch(/Repos\s*<\/Link>/)
     expect(source).toMatch(/Completed\s*<\/Link>/)
-    // Home replaces Kanban as the `/` nav label; board icon/label are gone.
     expect(source).not.toMatch(/Kanban\s*<\/Link>/)
     expect(source).not.toContain("function KanbanNavIcon()")
     expect(source).not.toContain("<KanbanNavIcon />")
     expect(source).toContain("function HomeNavIcon()")
     expect(source).toContain("<HomeNavIcon />")
-    // Home lives at `/` — no separate /kanban nav target.
-    const settingsBlock = source.slice(
-      source.indexOf("<SettingsButton"),
+    const navBlock = source.slice(
+      source.indexOf('aria-label="Primary"'),
       source.indexOf("</nav>"),
     )
-    expect(settingsBlock).not.toContain('to="/kanban"')
+    expect(navBlock).not.toContain('to="/kanban"')
   })
 
-  test("primary nav uses a full-width bold black divider on every route", () => {
-    // Issue #670: masthead 0.5rem rule moves under Clanker Harness nav (all routes).
+  test("masthead band + lane ribbon replace the old primary-nav rule", () => {
     const root = rootSource()
     const styles = stylesSource()
-    const navOpen = root.indexOf('aria-label="Primary"')
-    expect(navOpen).toBeGreaterThan(-1)
-    const navTag = root.slice(navOpen - 80, navOpen + 160)
-    expect(navTag).toContain("primary-nav")
-    // Thin Tailwind border is no longer the nav rule.
-    expect(navTag).not.toMatch(/border-b-2\s+border-ink/)
-    // Shared weight matches the former Kanban masthead separator.
-    const primaryNavBlock = styles.slice(
-      styles.indexOf(".primary-nav {"),
-      styles.indexOf("}", styles.indexOf(".primary-nav {")) + 1,
-    )
-    expect(primaryNavBlock).toContain(".primary-nav {")
-    expect(primaryNavBlock).toContain(
-      "border-bottom: 0.5rem solid var(--color-ink)",
-    )
-    // Divider lives in root layout above Outlet — every child route inherits it.
-    const rootComponent = root.slice(root.indexOf("function RootComponent("))
-    expect(rootComponent.indexOf("primary-nav")).toBeGreaterThan(-1)
-    expect(rootComponent.indexOf("primary-nav")).toBeLessThan(
-      rootComponent.indexOf("<Outlet />"),
+    expect(root).toContain('className="mast"')
+    expect(root).toContain('className="lane-ribbon"')
+    expect(root).toContain('aria-hidden="true"')
+    expect(root).not.toContain("primary-nav")
+    expect(styles).toContain(".mast {")
+    expect(styles).toContain("background: var(--mast-bg)")
+    expect(styles).toContain(".lane-ribbon {")
+    expect(styles).toContain("height: 0.4rem")
+    expect(styles).not.toContain(".primary-nav {")
+    // Ribbon sits above page content (Outlet).
+    const chrome = root.slice(root.indexOf("function SettingsChrome("))
+    expect(chrome.indexOf("lane-ribbon")).toBeGreaterThan(-1)
+    expect(chrome.indexOf("lane-ribbon")).toBeLessThan(
+      chrome.indexOf("<Outlet />"),
     )
   })
 
-  test("groups Home, Repos, Completed, and Settings in one right-aligned control cluster", () => {
+  test("groups Home, Repos, Completed, Settings, and theme toggle as mast plates", () => {
     const source = rootSource()
-    const clusterMarker =
-      'className="ml-auto flex items-center gap-2 self-center"'
-    expect(source).toContain(clusterMarker)
-    // ml-auto lives on the group, not only on Settings.
-    expect(source).not.toMatch(
-      /className="ml-auto inline-flex items-center gap-2 border/,
-    )
-
-    // Destinations are passed as leading into SettingsButton (same cluster).
-    const settingsBlock = source.slice(
-      source.indexOf("<SettingsButton"),
+    const navBlock = source.slice(
+      source.indexOf('aria-label="Primary"'),
       source.indexOf("</nav>"),
     )
-    expect(settingsBlock).toContain("leading={")
-    expect(settingsBlock).toContain('to="/"')
-    expect(settingsBlock).toContain('to="/repos"')
-    expect(settingsBlock).toContain('to="/completed"')
-    expect(settingsBlock).toContain("<HomeNavIcon />")
-    expect(settingsBlock).toContain("<ReposNavIcon />")
-    expect(settingsBlock).toContain("<CompletedNavIcon />")
-    // Order: Home | Repos | Completed
-    const homeIdx = settingsBlock.indexOf('to="/"')
-    const reposIdx = settingsBlock.indexOf('to="/repos"')
-    const completedIdx = settingsBlock.indexOf('to="/completed"')
+    expect(navBlock).toContain('to="/"')
+    expect(navBlock).toContain('to="/repos"')
+    expect(navBlock).toContain('to="/completed"')
+    expect(navBlock).toContain("<HomeNavIcon />")
+    expect(navBlock).toContain("<ReposNavIcon />")
+    expect(navBlock).toContain("<CompletedNavIcon />")
+    expect(navBlock).toContain("<SettingsNavIcon />")
+    expect(navBlock).toContain("Settings")
+    expect(navBlock).toContain("<ThemeTogglePlate />")
+    expect(navBlock).toContain("mastPlateClassName")
+    // Order: Home | Repos | Completed | Settings | theme
+    const homeIdx = navBlock.indexOf('to="/"')
+    const reposIdx = navBlock.indexOf('to="/repos"')
+    const completedIdx = navBlock.indexOf('to="/completed"')
+    const settingsIdx = navBlock.indexOf("Settings")
+    const themeIdx = navBlock.indexOf("<ThemeTogglePlate")
     expect(homeIdx).toBeGreaterThan(-1)
     expect(reposIdx).toBeGreaterThan(homeIdx)
     expect(completedIdx).toBeGreaterThan(reposIdx)
-
-    // Cluster wraps leading destinations and the Settings trigger.
-    const clusterStart = source.indexOf(
-      '<div className="ml-auto flex items-center gap-2 self-center">',
-    )
-    expect(clusterStart).toBeGreaterThan(-1)
-    const cluster = source.slice(
-      clusterStart,
-      source.indexOf("</div>", clusterStart),
-    )
-    expect(cluster).toContain("{leading}")
-    expect(cluster).toContain("Settings")
-    expect(cluster).toContain("primaryNavActionClassName")
-
-    // Brand title stays outside the action cluster (left side).
+    expect(settingsIdx).toBeGreaterThan(completedIdx)
+    expect(themeIdx).toBeGreaterThan(settingsIdx)
+    // Brand title stays outside the mast-nav cluster (left side).
     const brandIdx = source.indexOf("Clanker Harness")
     expect(brandIdx).toBeGreaterThan(-1)
-    expect(brandIdx).toBeLessThan(source.indexOf("<SettingsButton"))
+    expect(brandIdx).toBeLessThan(source.indexOf('aria-label="Primary"'))
   })
 
-  test("Home, Repos, and Completed use stroke icons matching Settings icon language", () => {
+  test("Home, Repos, Completed, and Settings use stroke icons", () => {
     const source = rootSource()
-    expect(source).toContain("function HomeNavIcon()")
-    expect(source).toContain("function ReposNavIcon()")
-    expect(source).toContain("function CompletedNavIcon()")
-    expect(source).toContain("<HomeNavIcon />")
-    expect(source).toContain("<ReposNavIcon />")
-    expect(source).toContain("<CompletedNavIcon />")
-    // Icons: aria-hidden, size-3.5, stroke currentColor (same as Settings gear).
     for (const iconFn of [
       "HomeNavIcon",
       "ReposNavIcon",
       "CompletedNavIcon",
+      "SettingsNavIcon",
     ] as const) {
       const start = source.indexOf(`function ${iconFn}(`)
       expect(start).toBeGreaterThan(-1)
       const body = source.slice(start, source.indexOf("\n}", start) + 2)
       expect(body).toContain('aria-hidden="true"')
-      expect(body).toContain('className="size-3.5"')
       expect(body).toContain('stroke="currentColor"')
       expect(body).toContain('strokeWidth="2"')
       expect(body).toContain('fill="none"')
     }
-    // Home uses a house path language (roof + walls), not the old board columns.
     const homeIcon = source.slice(
       source.indexOf("function HomeNavIcon("),
       source.indexOf("\n}", source.indexOf("function HomeNavIcon(")) + 2,
@@ -146,111 +119,157 @@ describe("primary Home / Repos / Completed navigation", () => {
     expect(homeIcon).not.toContain("<rect")
   })
 
-  test("uses TanStack Router Link with active route styling", () => {
+  test("uses TanStack Router Link with mast-plate active via aria-current", () => {
     const source = rootSource()
     expect(source).toContain('from "@tanstack/react-router"')
-    expect(source).toContain("primaryNavLinkClassName")
-    expect(source).toContain("primaryNavLinkInactiveClassName")
-    expect(source).toContain("primaryNavLinkActiveClassName")
-    expect(source).toContain(
-      "inactiveProps={{ className: primaryNavLinkInactiveClassName }}",
-    )
-    expect(source).toContain(
-      "activeProps={{ className: primaryNavLinkActiveClassName }}",
-    )
-    // Home nav control (not the brand title Link) must use exact matching.
-    // Slice the SettingsButton leading destinations through Repos.
-    const settingsBlock = source.slice(
-      source.indexOf("<SettingsButton"),
+    expect(source).toContain('const mastPlateClassName = "mast-plate"')
+    expect(source).toContain('activeProps={{ "aria-current": "page" }}')
+    expect(source).toContain("className={mastPlateClassName}")
+    // Home nav control must use exact matching.
+    const navBlock = source.slice(
+      source.indexOf('aria-label="Primary"'),
       source.indexOf("</nav>"),
     )
-    const homeSwitcherLink = settingsBlock.slice(
-      0,
-      settingsBlock.indexOf('to="/repos"'),
-    )
+    const homeSwitcherLink = navBlock.slice(0, navBlock.indexOf('to="/repos"'))
     expect(homeSwitcherLink).toContain('to="/"')
     expect(homeSwitcherLink).toContain("<HomeNavIcon />")
     expect(homeSwitcherLink).toContain("activeOptions={{ exact: true }}")
-    // Shared base must not carry exclusive active/inactive visual tokens —
-    // Router merges className with active/inactive props.
-    const sharedClassDecl = source.match(
-      /const primaryNavLinkClassName =\s*\n?\s*"([^"]+)"/,
-    )
-    expect(sharedClassDecl).not.toBeNull()
-    const sharedClasses = sharedClassDecl?.[1] ?? ""
-    for (const exclusive of [
-      "border-ink",
-      "bg-ink",
-      "text-paper",
-      "border-rule-2",
-      "bg-panel",
-      "text-ink-2",
-      "text-ink-faint",
-      "text-ink",
-      "bg-paper-2",
-      "hover:border-ink-soft",
-      "hover:bg-paper-2",
-      "hover:text-ink-2",
-    ]) {
-      expect(sharedClasses.split(/\s+/)).not.toContain(exclusive)
-    }
-    // Shared layout includes icon gap so label + icon share one baseline.
-    expect(sharedClasses.split(/\s+/)).toContain("gap-2")
-    expect(source).toContain(
-      'const primaryNavLinkInactiveClassName =\n  "border-rule-2 bg-panel text-ink-faint hover:border-ink-soft hover:bg-paper-2 hover:text-ink-2"',
-    )
-    // Soft selected state — not the old solid black/ink filled pill.
-    expect(source).toContain(
-      'const primaryNavLinkActiveClassName = "border-ink bg-paper-2 text-ink"',
-    )
-    expect(source).not.toContain(
-      'const primaryNavLinkActiveClassName = "border-ink bg-ink text-paper"',
-    )
-    // Settings stays in the inactive-nav visual family (not a selected route).
-    expect(source).toContain("primaryNavActionClassName")
-    expect(source).toContain("className={primaryNavActionClassName}")
-    expect(source).toMatch(
-      /const primaryNavActionClassName =\s*\n?\s*"[^"]*text-ink-faint[^"]*"/,
-    )
     // Destinations are client Links, not raw <a href> only.
     expect(source).not.toMatch(/<a\s+href=["']\/repos["']/)
     expect(source).not.toMatch(/<a\s+href=["']\/completed["']/)
     expect(source).not.toMatch(/<a\s+href=["']\/["']/)
+    // Active plate styling lives in CSS via aria-current.
+    const styles = stylesSource()
+    expect(styles).toContain('.mast-plate[aria-current="page"]')
   })
 
-  test("shared nav lives in root layout so Home, Repos, and Completed inherit it", () => {
+  test("shared nav lives in root chrome so Home, Repos, and Completed inherit it", () => {
     const source = rootSource()
-    const rootComponent = source.slice(
-      source.indexOf("function RootComponent("),
-    )
-    expect(rootComponent).toContain('to="/repos"')
-    expect(rootComponent).toContain('to="/completed"')
-    expect(rootComponent).toMatch(/Home\s*<\/Link>/)
-    expect(rootComponent).toMatch(/Repos\s*<\/Link>/)
-    expect(rootComponent).toMatch(/Completed\s*<\/Link>/)
-    expect(rootComponent).not.toMatch(/Kanban\s*<\/Link>/)
-    expect(rootComponent).toContain("<Outlet />")
-    expect(rootComponent.indexOf("Home")).toBeLessThan(
-      rootComponent.indexOf("<Outlet />"),
-    )
+    const chrome = source.slice(source.indexOf("function SettingsChrome("))
+    expect(chrome).toContain('to="/repos"')
+    expect(chrome).toContain('to="/completed"')
+    expect(chrome).toMatch(/Home\s*<\/Link>/)
+    expect(chrome).toMatch(/Repos\s*<\/Link>/)
+    expect(chrome).toMatch(/Completed\s*<\/Link>/)
+    expect(chrome).not.toMatch(/Kanban\s*<\/Link>/)
+    expect(chrome).toContain("<Outlet />")
+    expect(chrome.indexOf("Home")).toBeLessThan(chrome.indexOf("<Outlet />"))
   })
 
   test("root shell is always full-width; Repos and Completed cap page body only", () => {
-    // Issue #686: no pathname-based shell max-w; chrome never jumps.
     const root = rootSource()
     const rootComponent = root.slice(root.indexOf("function RootComponent("))
-    expect(rootComponent).toContain(
-      'className="mx-auto min-h-screen w-full px-5 py-6 sm:px-8 lg:px-12"',
-    )
+    expect(rootComponent).toContain('className="min-h-screen w-full"')
     expect(rootComponent).not.toContain("useLocation")
     expect(rootComponent).not.toContain("isKanbanPage")
     expect(rootComponent).not.toContain("max-w-[88rem]")
     expect(rootComponent).not.toContain('pathname === "/"')
+    // Page content padding is shared; chrome is full-bleed.
+    expect(root).toContain('className="page-shell"')
+    expect(stylesSource()).toContain(".page-shell {")
 
-    // Reading-width cap is on Repos / Completed content, not the shared shell.
     expect(reposSource()).toContain("max-w-[88rem]")
     expect(completedSource()).toContain("max-w-[88rem]")
     expect(reposSource()).toMatch(/className="[^"]*max-w-\[88rem\][^"]*"/)
     expect(completedSource()).toMatch(/className="[^"]*max-w-\[88rem\][^"]*"/)
+  })
+
+  test("ships Interchange token layer with light and dark themes", () => {
+    const styles = stylesSource()
+    expect(styles).toContain("--lane-queue: #ffd21c")
+    expect(styles).toContain("--lane-build: #1976d2")
+    expect(styles).toContain("--lane-review: #7654b5")
+    expect(styles).toContain("--lane-pr: #168b62")
+    expect(styles).toContain("--lane-attention: #ff4d1c")
+    expect(styles).toContain("--lane-merged: #151515")
+    expect(styles).toContain("--font-display:")
+    expect(styles).toContain("Inter Tight")
+    expect(styles).toContain("JetBrains Mono")
+    expect(styles).toContain('[data-theme="light"]')
+    expect(styles).toContain('[data-theme="dark"]')
+    expect(styles).toContain("--mast-bg:")
+    expect(styles).toContain("--plate:")
+    expect(styles).toContain("--merged-halo:")
+  })
+
+  test("loads Inter Tight and JetBrains Mono from Google Fonts", () => {
+    const source = rootSource()
+    expect(source).toContain("fonts.googleapis.com")
+    expect(source).toContain("Inter+Tight")
+    expect(source).toContain("JetBrains+Mono")
+    expect(source).toContain("wght@400;500;600;700;800")
+    expect(source).toContain("wght@400;700")
+  })
+
+  test("theme plumbing: bootstrap script, prefers-color-scheme, ?theme= pin, toggle plate", () => {
+    const root = rootSource()
+    const theme = themeSource()
+    const styles = stylesSource()
+    expect(theme).toContain("THEME_BOOTSTRAP_SCRIPT")
+    expect(theme).toContain("prefers-color-scheme")
+    expect(theme).toContain('THEME_QUERY_PARAM = "theme"')
+    expect(theme).toContain("resolveThemeMode")
+    expect(theme).toContain("withThemePin")
+    expect(theme).toContain("parseThemeSearch")
+    expect(theme).not.toContain("function pinThemeInUrl")
+    expect(root).toContain("THEME_BOOTSTRAP_SCRIPT")
+    expect(root).toContain("dangerouslySetInnerHTML")
+    expect(root).toContain("function ThemeTogglePlate()")
+    expect(root).toContain("readDocumentTheme()")
+    expect(root).toContain("retainSearchParams")
+    expect(root).toContain('retainSearchParams(["theme"])')
+    expect(root).toContain("validateSearch")
+    expect(root).toContain("withThemePin(prev, next)")
+    // Theme pin must not re-root navigation at `/` (would leave Repos/Completed).
+    expect(root).not.toContain("useNavigate({ from: Route.fullPath })")
+    expect(root).toMatch(
+      /function ThemeTogglePlate\(\)[\s\S]*?to:\s*["']\.["']/,
+    )
+    expect(root).toContain("resetScroll: false")
+    // SSR-stable initial state — do not read document in useState (hydration).
+    expect(root).toMatch(
+      /function ThemeTogglePlate\(\)[\s\S]*?useState<ThemeMode>\("light"\)/,
+    )
+    expect(root).not.toMatch(
+      /useState<ThemeMode>\(\(\)\s*=>\s*[\s\S]*?readDocumentTheme/,
+    )
+    // Mount effect only syncs state — does not re-resolve/re-apply theme.
+    expect(root).not.toMatch(
+      /function ThemeTogglePlate\(\)[\s\S]*?useEffect\(\(\) => \{[\s\S]*?resolveThemeMode/,
+    )
+    expect(root).toMatch(/Switch to \$\{targetLabel\} theme/)
+    expect(root).toContain("aria-pressed")
+    expect(root).toContain("themeToggleLabel")
+    expect(root).toContain("suppressHydrationWarning")
+    expect(styles).toContain("color-scheme: light")
+    expect(styles).toContain("color-scheme: dark")
+    // Elevated surfaces + inverse CTA ink stay contrast-safe under both themes.
+    expect(styles).toContain("--paper-2:")
+    expect(styles).toContain("--color-paper-2: var(--paper-2)")
+    expect(styles).toContain("--on-solid:")
+    expect(styles).toContain("--color-on-solid: var(--on-solid)")
+    expect(root).toContain("text-on-solid")
+    expect(root).toContain("backdrop:bg-black/50")
+    expect(root).not.toContain("backdrop:bg-ink/45")
+  })
+
+  test("banner pattern is shared and used for nav-level guidance/alarm", () => {
+    const banner = bannerSource()
+    const root = rootSource()
+    const styles = stylesSource()
+    expect(banner).toContain("tone: BannerTone")
+    expect(banner).toContain('"alarm"')
+    expect(banner).toContain('"guidance"')
+    expect(banner).toContain("banner-tag")
+    expect(styles).toContain(".banner {")
+    expect(styles).toContain(".banner--alarm")
+    expect(styles).toContain(".banner--guidance")
+    expect(styles).toContain("var(--lane-attention)")
+    expect(styles).toContain("var(--signal)")
+    expect(root).toContain('tag="Backend"')
+    expect(root).toContain('tag="Setup"')
+    expect(root).toContain('tone="alarm"')
+    expect(root).toContain('tone="guidance"')
+    expect(root).toContain("Open Settings")
   })
 })

--- a/apps/harness/test/repos-route.test.ts
+++ b/apps/harness/test/repos-route.test.ts
@@ -33,25 +33,23 @@ describe("/repos route", () => {
 
   test("primary nav places Home before Repos before Completed", () => {
     const source = rootSource()
-    const settingsBlock = source.slice(
-      source.indexOf("<SettingsButton"),
+    const navBlock = source.slice(
+      source.indexOf('aria-label="Primary"'),
       source.indexOf("</nav>"),
     )
-    const homeIdx = settingsBlock.indexOf('to="/"')
-    const reposIdx = settingsBlock.indexOf('to="/repos"')
-    const completedIdx = settingsBlock.indexOf('to="/completed"')
+    const homeIdx = navBlock.indexOf('to="/"')
+    const reposIdx = navBlock.indexOf('to="/repos"')
+    const completedIdx = navBlock.indexOf('to="/completed"')
     expect(homeIdx).toBeGreaterThan(-1)
     expect(reposIdx).toBeGreaterThan(homeIdx)
     expect(completedIdx).toBeGreaterThan(reposIdx)
-    expect(settingsBlock).toMatch(/Home\s*<\/Link>/)
-    expect(settingsBlock).toMatch(/Repos\s*<\/Link>/)
-    expect(settingsBlock).not.toMatch(/Kanban\s*<\/Link>/)
+    expect(navBlock).toMatch(/Home\s*<\/Link>/)
+    expect(navBlock).toMatch(/Repos\s*<\/Link>/)
+    expect(navBlock).not.toMatch(/Kanban\s*<\/Link>/)
     // Active styling is shared with other primary destinations.
-    const reposLink = settingsBlock.slice(reposIdx, completedIdx)
-    expect(reposLink).toContain("primaryNavLinkClassName")
-    expect(reposLink).toContain(
-      "activeProps={{ className: primaryNavLinkActiveClassName }}",
-    )
+    const reposLink = navBlock.slice(reposIdx, completedIdx)
+    expect(reposLink).toContain("mastPlateClassName")
+    expect(reposLink).toContain('activeProps={{ "aria-current": "page" }}')
   })
 
   test("Repos page body keeps the reading-width cap", () => {

--- a/apps/harness/test/theme.test.ts
+++ b/apps/harness/test/theme.test.ts
@@ -1,0 +1,39 @@
+import {
+  oppositeTheme,
+  parseThemeSearch,
+  resolveThemeMode,
+  themeToggleLabel,
+  withThemePin,
+} from "../src/theme"
+import { describe, expect, test } from "bun:test"
+
+describe("theme plumbing", () => {
+  test("?theme= pin wins over prefers-color-scheme", () => {
+    expect(resolveThemeMode("?theme=dark", false)).toBe("dark")
+    expect(resolveThemeMode("?theme=light", true)).toBe("light")
+    expect(resolveThemeMode("?theme=nope", true)).toBe("dark")
+    expect(resolveThemeMode("", true)).toBe("dark")
+    expect(resolveThemeMode("", false)).toBe("light")
+  })
+
+  test("parseThemeSearch accepts only light|dark", () => {
+    expect(parseThemeSearch({ theme: "dark" })).toEqual({ theme: "dark" })
+    expect(parseThemeSearch({ theme: "light" })).toEqual({ theme: "light" })
+    expect(parseThemeSearch({ theme: "nope" })).toEqual({})
+    expect(parseThemeSearch({})).toEqual({})
+  })
+
+  test("withThemePin preserves other search keys", () => {
+    expect(withThemePin({ page: 2 }, "dark")).toEqual({
+      page: 2,
+      theme: "dark",
+    })
+  })
+
+  test("toggle label is the target theme", () => {
+    expect(themeToggleLabel("light")).toBe("Dark")
+    expect(themeToggleLabel("dark")).toBe("Light")
+    expect(oppositeTheme("light")).toBe("dark")
+    expect(oppositeTheme("dark")).toBe("light")
+  })
+})


### PR DESCRIPTION
Land phase 1 of the Harness Interchange design system: a dual-theme token
layer, theme plumbing, the dark masthead nav shell (every route), and a
shared banner pattern with existing call sites re-skinned. Board, completed,
repos surfaces, and dialog chrome stay largely on the prior Ledger look for
later phases.

Why:

Issue 700 is the first shippable slice of the unified industrial UI. Tokens
and both themes must exist before board/archive/repos work, and the masthead
plus banners are the first operator-facing surface.

What changed:

- Token layer: lane colors, light/dark neutrals, masthead/plate/PR badge
  groups, Inter Tight + JetBrains Mono; Tailwind aliases flip with
  data-theme (including elevated paper-2 / rules for contrast).
- Theme plumbing: pre-paint bootstrap (prefers-color-scheme / theme query),
  root validateSearch + retainSearchParams for theme, toggle pins via router
  navigate (to ".", resetScroll false), SSR-stable control state.
- Nav shell: full-bleed dark masthead, stamped plates (Home / Repos /
  Completed / Settings / theme), lane ribbon, shared page shell padding.
- Banners: shared alarm/guidance Banner + mini-plate actions; nav,
  load/refresh, live, and credential call sites re-skinned (single live
  region for Keymaxxer errors).
- Contrast: text-on-solid on oxblood CTAs; theme-invariant dialog scrims
  (backdrop black/50).

Verification:

- bunx nx test harness (full package)
- Focused theme / primary-nav tests after remediation
- Harness tsc --noEmit and Biome on touched files

Limitations:

- Board network, completed archive, full repos page, and dialogs are not
  fully re-skinned (later phases).
- Masthead "All lanes live" remains static placeholder copy until real
  telemetry.
- Spec doc may land separately (PR 699); this change implements against
  that contract.

Closes #700