### PR TITLE
feat(harness): interchange phase 3 completed archive surface

### DIFF
--- a/apps/harness/src/archive-legs.ts
+++ b/apps/harness/src/archive-legs.ts
@@ -14,7 +14,7 @@ import {
   sumLaneDurationMs,
 } from "./pipeline-lanes.js"
 
-export type ArchiveLegKind = "done" | "skip" | "fail"
+type ArchiveLegKind = "done" | "skip" | "fail"
 
 /** CSS custom props for lane-coloured done legs. */
 export type ArchiveLegLane = "build" | "review" | "pr"
@@ -147,7 +147,7 @@ export const isArchiveAbandoned = (
   workItem: Pick<ArchiveWorkItemInput, "status" | "state">,
 ): boolean => workItem.status === "ABANDONED" || workItem.state === "ABANDONED"
 
-export const isArchiveComplete = (
+const isArchiveComplete = (
   workItem: Pick<ArchiveWorkItemInput, "status" | "state">,
 ): boolean =>
   workItem.status === "COMPLETE" ||

--- a/apps/harness/src/archive-legs.ts
+++ b/apps/harness/src/archive-legs.ts
@@ -1,0 +1,465 @@
+/**
+ * Archive journey-leg planning for the Completed page
+ * (`docs/harness-design-system.md` §4.5 / §5.2, wayfinder #698 prototype).
+ *
+ * The archive is terminal Complete / Abandoned only. Legs are a condensed
+ * BUILD → REVIEW → CHECKS / MERGE (or PR / NO PR NEEDED) view — not the full
+ * fine-grained lifecycle chip list used on the board.
+ */
+
+import { formatDuration } from "./live-duration.js"
+import {
+  type LifecycleLabelChip,
+  lifecycleLaneForPhase,
+  sumLaneDurationMs,
+} from "./pipeline-lanes.js"
+
+export type ArchiveLegKind = "done" | "skip" | "fail"
+
+/** CSS custom props for lane-coloured done legs. */
+export type ArchiveLegLane = "build" | "review" | "pr"
+
+export type ArchiveLeg = {
+  readonly id: string
+  readonly label: string
+  readonly kind: ArchiveLegKind
+  readonly durationMs: number | null
+  /** Lane colour for done legs; fail always uses Attention. */
+  readonly lane: ArchiveLegLane | null
+}
+
+export type ArchiveWorkItemInput = {
+  readonly status: string
+  readonly state: string
+  readonly pullRequestNumber: number | null
+  readonly completionSummary: string | null
+  readonly lifecycleLabels: readonly LifecycleLabelChip[]
+}
+
+const BUILD_PHASES = new Set([
+  "CREATE_WORKTREE",
+  "INSTALL_DEPENDENCIES",
+  "IMPLEMENT",
+  "ASSESS_CHANGES",
+  "PRE_COMMIT",
+])
+
+const REVIEW_PHASES = new Set(["REVIEW"])
+
+const CHECKS_PHASES = new Set([
+  "GITHUB_STATUS_CHECKS",
+  "WATCH_PR_STATUS_CHECKS",
+  "INVESTIGATE_PR_STATUS_CHECKS",
+])
+
+const MERGE_PHASES = new Set(["MERGE_PR"])
+
+/** PR-path phases that are neither checks nor merge (commit, create PR, …). */
+const OTHER_PR_PHASES = new Set([
+  "COMMIT",
+  "CREATE_PR",
+  "RESOLVE_PR_MERGE_CONFLICT",
+  "MARK_PR_READY_FOR_REVIEW",
+  "DECIDE_PR_MERGE",
+  "CLOSE_ISSUE",
+  "LOCAL_CLEANUP",
+])
+
+type GroupId = "build" | "review" | "checks" | "merge" | "pr_other"
+
+type GroupOutcome = {
+  readonly id: GroupId
+  readonly chips: readonly LifecycleLabelChip[]
+  readonly durationMs: number | null
+  readonly hasAny: boolean
+  readonly hasSucceeded: boolean
+  readonly hasFailed: boolean
+}
+
+const isFailedStatus = (status: string): boolean =>
+  status === "FAILED" || status === "INTERRUPTED"
+
+const isSucceededStatus = (status: string): boolean =>
+  status === "SUCCEEDED" || status === "COMPLETE"
+
+const groupForPhase = (phase: string): GroupId | null => {
+  if (BUILD_PHASES.has(phase)) return "build"
+  if (REVIEW_PHASES.has(phase)) return "review"
+  if (CHECKS_PHASES.has(phase)) return "checks"
+  if (MERGE_PHASES.has(phase)) return "merge"
+  if (OTHER_PR_PHASES.has(phase)) return "pr_other"
+  // Fall back to pipeline lane mapping for unknown phases.
+  const lane = lifecycleLaneForPhase(phase)
+  if (lane === "build") return "build"
+  if (lane === "review") return "review"
+  if (lane === "pr") return "pr_other"
+  return null
+}
+
+const collectGroups = (
+  labels: readonly LifecycleLabelChip[],
+): Record<GroupId, GroupOutcome> => {
+  const buckets: Record<GroupId, LifecycleLabelChip[]> = {
+    build: [],
+    review: [],
+    checks: [],
+    merge: [],
+    pr_other: [],
+  }
+  for (const label of labels) {
+    const group = groupForPhase(label.phase)
+    if (group === null) continue
+    buckets[group].push(label)
+  }
+  const toOutcome = (id: GroupId): GroupOutcome => {
+    const chips = buckets[id]
+    return {
+      id,
+      chips,
+      durationMs: sumLaneDurationMs(chips),
+      hasAny: chips.length > 0,
+      hasSucceeded: chips.some((chip) => isSucceededStatus(chip.status)),
+      hasFailed: chips.some((chip) => isFailedStatus(chip.status)),
+    }
+  }
+  return {
+    build: toOutcome("build"),
+    review: toOutcome("review"),
+    checks: toOutcome("checks"),
+    merge: toOutcome("merge"),
+    pr_other: toOutcome("pr_other"),
+  }
+}
+
+/** Terminal Complete with a no-change summary (and no PR). */
+export const isArchiveNoChangeComplete = (
+  workItem: Pick<
+    ArchiveWorkItemInput,
+    "status" | "state" | "pullRequestNumber" | "completionSummary"
+  >,
+): boolean =>
+  (workItem.status === "COMPLETE" || workItem.state === "COMPLETE") &&
+  workItem.pullRequestNumber === null &&
+  workItem.completionSummary !== null &&
+  workItem.completionSummary.trim() !== ""
+
+export const isArchiveAbandoned = (
+  workItem: Pick<ArchiveWorkItemInput, "status" | "state">,
+): boolean => workItem.status === "ABANDONED" || workItem.state === "ABANDONED"
+
+export const isArchiveComplete = (
+  workItem: Pick<ArchiveWorkItemInput, "status" | "state">,
+): boolean =>
+  workItem.status === "COMPLETE" ||
+  workItem.status === "SUCCEEDED" ||
+  workItem.state === "COMPLETE"
+
+const doneLeg = (
+  id: string,
+  label: string,
+  lane: ArchiveLegLane,
+  durationMs: number | null,
+): ArchiveLeg => ({
+  id,
+  label,
+  kind: "done",
+  durationMs,
+  lane,
+})
+
+const skipLeg = (id: string, label: string): ArchiveLeg => ({
+  id,
+  label,
+  kind: "skip",
+  durationMs: null,
+  lane: null,
+})
+
+const failLeg = (
+  id: string,
+  label: string,
+  durationMs: number | null,
+): ArchiveLeg => ({
+  id,
+  label,
+  kind: "fail",
+  durationMs,
+  lane: null,
+})
+
+/**
+ * Format a leg duration for the archive chip, e.g. "14M" / "1M 30S".
+ * Matches the prototype's uppercase mono leg labels.
+ */
+export function formatArchiveLegDuration(ms: number): string {
+  return formatDuration(ms).toUpperCase()
+}
+
+/** Text content of a leg chip including mark and optional duration. */
+export function archiveLegText(leg: ArchiveLeg): string {
+  const mark = leg.kind === "done" ? "✓" : leg.kind === "fail" ? "✕" : "○"
+  if (leg.durationMs === null) {
+    return `${mark} ${leg.label}`
+  }
+  return `${mark} ${leg.label} · ${formatArchiveLegDuration(leg.durationMs)}`
+}
+
+/** CSS variables for a lane-coloured done leg. */
+export function archiveLegLaneStyle(lane: ArchiveLegLane): {
+  "--leg-lane": string
+  "--leg-on-lane": string
+} {
+  switch (lane) {
+    case "build":
+      return {
+        "--leg-lane": "var(--lane-build)",
+        "--leg-on-lane": "var(--lane-build-ink)",
+      }
+    case "review":
+      return {
+        "--leg-lane": "var(--lane-review)",
+        "--leg-on-lane": "var(--lane-review-ink)",
+      }
+    case "pr":
+      return {
+        "--leg-lane": "var(--lane-pr)",
+        "--leg-on-lane": "var(--lane-pr-ink)",
+      }
+  }
+}
+
+/**
+ * Plan condensed archive journey legs for a terminal Work Item.
+ *
+ * - Complete + PR: BUILD / REVIEW / CHECKS / MERGE as done (lane-coloured).
+ * - Complete + no change: done build (+ optional review) + "NO PR NEEDED" skip.
+ * - Abandoned: done groups, optional ✕ fail at chronological position, then
+ *   dashed unreached REVIEW / PR. Retryable failures never appear here.
+ */
+/**
+ * Emit non-failed PR subgroups as done legs (CHECKS then MERGE, or PR for
+ * other PR-path phases). Used for abandoned progress that did not fail.
+ */
+const pushDonePrSubgroups = (
+  legs: ArchiveLeg[],
+  groups: Record<GroupId, GroupOutcome>,
+): void => {
+  if (groups.checks.hasAny && !groups.checks.hasFailed) {
+    legs.push(doneLeg("checks", "CHECKS", "pr", groups.checks.durationMs))
+  }
+  if (groups.merge.hasAny && !groups.merge.hasFailed) {
+    legs.push(doneLeg("merge", "MERGE", "pr", groups.merge.durationMs))
+  } else if (
+    !groups.checks.hasAny &&
+    !groups.merge.hasAny &&
+    groups.pr_other.hasAny &&
+    !groups.pr_other.hasFailed
+  ) {
+    legs.push(
+      doneLeg("pr", "PR", "pr", sumLaneDurationMs(groups.pr_other.chips)),
+    )
+  }
+}
+
+export function planArchiveLegs(
+  workItem: ArchiveWorkItemInput,
+): readonly ArchiveLeg[] {
+  const groups = collectGroups(workItem.lifecycleLabels)
+  const abandoned = isArchiveAbandoned(workItem)
+  const complete = isArchiveComplete(workItem)
+  const noChange = isArchiveNoChangeComplete(workItem)
+  const hasPr =
+    workItem.pullRequestNumber !== null && workItem.pullRequestNumber > 0
+
+  if (complete && noChange) {
+    const legs: ArchiveLeg[] = []
+    if (groups.build.hasAny || groups.build.hasSucceeded) {
+      legs.push(doneLeg("build", "BUILD", "build", groups.build.durationMs))
+    } else {
+      // Still show BUILD as done when the item completed without step data.
+      legs.push(doneLeg("build", "BUILD", "build", null))
+    }
+    if (groups.review.hasSucceeded) {
+      legs.push(doneLeg("review", "REVIEW", "review", groups.review.durationMs))
+    }
+    legs.push(skipLeg("no_pr", "NO PR NEEDED"))
+    return legs
+  }
+
+  if (complete && hasPr) {
+    // Full PR path: always four lane-coloured legs when the run completed.
+    return [
+      doneLeg(
+        "build",
+        "BUILD",
+        "build",
+        groups.build.hasAny ? groups.build.durationMs : null,
+      ),
+      doneLeg(
+        "review",
+        "REVIEW",
+        "review",
+        groups.review.hasAny ? groups.review.durationMs : null,
+      ),
+      doneLeg(
+        "checks",
+        "CHECKS",
+        "pr",
+        groups.checks.hasAny ? groups.checks.durationMs : null,
+      ),
+      doneLeg(
+        "merge",
+        "MERGE",
+        "pr",
+        groups.merge.hasAny ? groups.merge.durationMs : null,
+      ),
+    ]
+  }
+
+  if (complete) {
+    // Complete without PR number and without summary — show done groups only.
+    const legs: ArchiveLeg[] = []
+    if (groups.build.hasAny) {
+      legs.push(doneLeg("build", "BUILD", "build", groups.build.durationMs))
+    }
+    if (groups.review.hasAny) {
+      legs.push(doneLeg("review", "REVIEW", "review", groups.review.durationMs))
+    }
+    if (groups.checks.hasAny) {
+      legs.push(doneLeg("checks", "CHECKS", "pr", groups.checks.durationMs))
+    }
+    if (groups.merge.hasAny) {
+      legs.push(doneLeg("merge", "MERGE", "pr", groups.merge.durationMs))
+    }
+    if (legs.length === 0) {
+      legs.push(doneLeg("build", "BUILD", "build", null))
+    }
+    return legs
+  }
+
+  // Abandoned (and any other terminal archive row).
+  const legs: ArchiveLeg[] = []
+  let failedEmitted = false
+
+  const pushGroup = (
+    group: GroupOutcome,
+    doneLabel: string,
+    lane: ArchiveLegLane,
+  ): "done" | "fail" | "none" => {
+    if (!group.hasAny) return "none"
+    if (group.hasFailed && abandoned) {
+      legs.push(failLeg(group.id, doneLabel, group.durationMs))
+      failedEmitted = true
+      return "fail"
+    }
+    if (group.hasSucceeded || group.hasAny) {
+      // Abandoned groups are fail-first (handled above). Here: presence with
+      // no failure → done. Non-abandoned fail chips stay off the archive.
+      if (group.hasFailed && !abandoned) {
+        return "none"
+      }
+      legs.push(doneLeg(group.id, doneLabel, lane, group.durationMs))
+      return "done"
+    }
+    return "none"
+  }
+
+  const buildResult = pushGroup(groups.build, "BUILD", "build")
+  if (failedEmitted) {
+    // Chronological: failed BUILD stops the line; remaining are unreached.
+    legs.push(skipLeg("review", "REVIEW"))
+    legs.push(skipLeg("pr", "PR"))
+    return legs
+  }
+
+  const reviewResult = pushGroup(groups.review, "REVIEW", "review")
+  if (failedEmitted) {
+    legs.push(skipLeg("pr", "PR"))
+    return legs
+  }
+
+  // PR umbrella for checks / merge / other PR phases on abandoned paths.
+  const prChips = [
+    ...groups.checks.chips,
+    ...groups.merge.chips,
+    ...groups.pr_other.chips,
+  ]
+  const prFailed = prChips.some((chip) => isFailedStatus(chip.status))
+  const prSucceeded = prChips.some((chip) => isSucceededStatus(chip.status))
+  const prAny = prChips.length > 0
+
+  if (prFailed && abandoned) {
+    // Chronological: keep successful earlier PR legs, then ✕ at the failure.
+    if (groups.checks.hasFailed) {
+      // CHECKS failed first — no prior PR sub-leg to keep.
+      legs.push(failLeg("checks", "CHECKS", groups.checks.durationMs))
+    } else if (groups.merge.hasFailed) {
+      if (groups.checks.hasAny && !groups.checks.hasFailed) {
+        legs.push(doneLeg("checks", "CHECKS", "pr", groups.checks.durationMs))
+      }
+      legs.push(failLeg("merge", "MERGE", groups.merge.durationMs))
+    } else {
+      // pr_other failed: keep non-failed checks/merge, then ✕ PR with only
+      // pr_other duration (do not re-sum CHECKS/MERGE already shown).
+      if (groups.checks.hasAny && !groups.checks.hasFailed) {
+        legs.push(doneLeg("checks", "CHECKS", "pr", groups.checks.durationMs))
+      }
+      if (groups.merge.hasAny && !groups.merge.hasFailed) {
+        legs.push(doneLeg("merge", "MERGE", "pr", groups.merge.durationMs))
+      }
+      legs.push(failLeg("pr", "PR", groups.pr_other.durationMs))
+    }
+    return legs
+  }
+
+  if (prSucceeded || prAny) {
+    pushDonePrSubgroups(legs, groups)
+    // Abandoned journeys that stopped mid-PR still show unreached MERGE when
+    // merge never ran (complete+PR always paints the four-leg path).
+    if (
+      abandoned &&
+      !groups.merge.hasAny &&
+      !legs.some((leg) => leg.id === "merge" || leg.id === "pr")
+    ) {
+      legs.push(skipLeg("merge", "MERGE"))
+    }
+    return legs
+  }
+
+  // Unreached tails for abandoned rows.
+  if (abandoned) {
+    // True "never left the queue" only when nothing is on the line yet.
+    if (legs.length === 0) {
+      return [
+        skipLeg("build", "BUILD"),
+        skipLeg("review", "REVIEW"),
+        skipLeg("pr", "PR"),
+      ]
+    }
+    if (buildResult === "none") {
+      // Partial projection: progress without BUILD chips — keep progress.
+      legs.unshift(skipLeg("build", "BUILD"))
+    }
+    if (reviewResult === "none" && !legs.some((leg) => leg.id === "review")) {
+      legs.push(skipLeg("review", "REVIEW"))
+    }
+    if (
+      !legs.some(
+        (leg) => leg.id === "pr" || leg.id === "checks" || leg.id === "merge",
+      )
+    ) {
+      legs.push(skipLeg("pr", "PR"))
+    }
+    return legs
+  }
+
+  // Fallback: whatever progress we have.
+  if (legs.length === 0) {
+    return [
+      skipLeg("build", "BUILD"),
+      skipLeg("review", "REVIEW"),
+      skipLeg("pr", "PR"),
+    ]
+  }
+  return legs
+}

--- a/apps/harness/src/completed-work-item-row.tsx
+++ b/apps/harness/src/completed-work-item-row.tsx
@@ -1,6 +1,21 @@
+import type { CSSProperties } from "react"
+import {
+  archiveLegLaneStyle,
+  archiveLegText,
+  isArchiveAbandoned,
+  isArchiveNoChangeComplete,
+  planArchiveLegs,
+} from "./archive-legs.js"
 import { Copy } from "./copy.js"
+import {
+  formatDuration,
+  formatSessionShort,
+  formatTerminalAgo,
+  totalElapsedMs,
+  useNowMs,
+  worktreeLeafName,
+} from "./live-duration.js"
 import type { Repository, WorkItem } from "./routes/index.js"
-import { WorkItemLifecycleStatus, WorkItemPauseButton } from "./routes/index.js"
 import { sessionWorktreeParts } from "./session-worktree-line.js"
 import { workItemIssueUrl } from "./work-item-issue-url.js"
 import { workItemPullRequestUrl } from "./work-item-pull-request-url.js"
@@ -11,9 +26,12 @@ export type CompletedWorkItemIssueLookup = {
 }
 
 /**
- * Completed Work Item list row shared by the Jobs Completed tab and the
- * historical Completed page (repository identity, issue link, agent/session,
- * lifecycle status, PR/outcome badges).
+ * Completed Work Item archive row for the historical Completed page
+ * (`docs/harness-design-system.md` §4.5, wayfinder #698 prototype).
+ *
+ * Complete rows: 6px Merged line bar, no stamp. Abandoned rows: dashed border,
+ * ghosted title, dashed ABANDONED stamp. Footer carries lane-coloured archive
+ * legs plus a PR badge or dashed "No change" tag.
  */
 export function CompletedWorkItemRow({
   workItem,
@@ -26,6 +44,9 @@ export function CompletedWorkItemRow({
   readonly issue: CompletedWorkItemIssueLookup | undefined
   readonly onOpenSession: (workItemId: string, sessionId: string) => void
 }) {
+  const nowMs = useNowMs(true)
+  const abandoned = isArchiveAbandoned(workItem)
+  const noChange = isArchiveNoChangeComplete(workItem)
   const repositoryLabel =
     repository === undefined ? workItem.repositoryId : repository.projectPath
   const issueTitle = issue?.title ?? workItem.issueTitle ?? undefined
@@ -40,102 +61,149 @@ export function CompletedWorkItemRow({
             repository.projectPath,
             workItem.issueNumber,
           )
+  const pullRequestUrl =
+    repository === undefined
+      ? null
+      : workItemPullRequestUrl(
+          repository.forge,
+          repository.forgeHost,
+          repository.projectPath,
+          workItem.pullRequestNumber,
+        )
+  const prNumber = workItem.pullRequestNumber
   const issueIdentity =
     issueTitle === undefined
       ? `#${workItem.issueNumber}`
       : `#${workItem.issueNumber} · ${issueTitle}`
-  const issueIdentityContent = (
-    <>
-      <span className="font-mono">#{workItem.issueNumber}</span>
-      {issueTitle !== undefined && (
-        <span className="font-serif"> · {issueTitle}</span>
-      )}
-    </>
-  )
   const { sessionId, worktreePath } = sessionWorktreeParts(
     workItem.sessionId,
     workItem.worktreePath,
   )
+  const legs = planArchiveLegs(workItem)
+  const elapsedMs = totalElapsedMs(workItem.createdAt, workItem.stateReadyAt)
+  const terminalVerb = abandoned
+    ? "Withdrawn"
+    : prNumber !== null
+      ? "Merged"
+      : "Finished"
+  const terminalAgo = formatTerminalAgo(
+    workItem.stateReadyAt,
+    terminalVerb,
+    nowMs,
+  )
+  const elapsedLabel = `Elapsed ${formatDuration(elapsedMs)}`
+  const summary = workItem.completionSummary?.trim() ?? ""
 
   return (
-    <li className="entry-rule min-w-0 px-1 py-2">
-      <div className="flex flex-wrap items-start justify-between gap-x-3 gap-y-2">
-        <div className="min-w-0">
-          <p className="m-0 truncate font-mono text-xs font-semibold tracking-[0.12em] text-ink-faint uppercase">
+    <li
+      className={
+        abandoned
+          ? "archive-row archive-row--abandoned"
+          : "archive-row archive-row--complete"
+      }
+    >
+      <div className="archive-row-top">
+        <div style={{ minWidth: 0 }}>
+          <p className="archive-repo" title={repositoryLabel}>
             {repositoryLabel}
           </p>
           {issueUrl !== null && issueUrl !== "" ? (
-            <a
-              className="m-0 mt-0.5 block truncate text-sm font-semibold text-oxblood hover:underline"
-              href={issueUrl}
-              title={issueIdentity}
-            >
-              {issueIdentityContent}
+            <a className="archive-title" href={issueUrl} title={issueIdentity}>
+              <span className="num">#{workItem.issueNumber}</span>
+              {issueTitle !== undefined ? ` · ${issueTitle}` : null}
             </a>
           ) : (
-            <p
-              className="m-0 mt-0.5 truncate text-sm font-semibold text-oxblood"
-              title={issueIdentity}
-            >
-              {issueIdentityContent}
+            <p className="archive-title" title={issueIdentity}>
+              <span className="num">#{workItem.issueNumber}</span>
+              {issueTitle !== undefined ? ` · ${issueTitle}` : null}
             </p>
           )}
         </div>
-        <div className="flex shrink-0 items-center gap-1">
-          <span className="stamp border-rule-2 text-ink-2">
-            {workItem.stateLabel}
+        {abandoned ? (
+          <span className="archive-stamp archive-stamp--abandoned">
+            Abandoned
           </span>
-          <WorkItemPauseButton workItem={workItem} />
-        </div>
+        ) : null}
       </div>
-      <p className="mt-1 mb-0 flex min-w-0 flex-wrap items-center gap-1">
-        <span className="shrink-0 font-mono text-xs text-ink-faint">
-          {workItem.agentBackend.label}
-        </span>
-        {(sessionId !== null || worktreePath !== null) && (
-          <span className="shrink-0 font-mono text-xs text-ink-faint">-</span>
-        )}
-        {sessionId !== null && (
-          <span className="inline-flex min-w-0 max-w-full items-center gap-1">
+
+      <p className="archive-meta">
+        {workItem.agentBackend.label}
+        {sessionId !== null ? (
+          <>
+            {" — "}
             <button
               type="button"
-              className="min-w-0 truncate font-mono text-xs text-ink-faint underline-offset-2 hover:text-oxblood hover:underline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-oxblood"
+              className="sess"
               title={sessionId}
               onClick={() => {
                 onOpenSession(workItem.id, sessionId)
               }}
             >
-              {sessionId}
-            </button>
-            <Copy value={sessionId} className="shrink-0" showValue={false} />
-          </span>
+              {formatSessionShort(sessionId)}
+            </button>{" "}
+            <Copy
+              value={sessionId}
+              className="inline-flex shrink-0"
+              showValue={false}
+            />
+          </>
+        ) : (
+          " — No session"
         )}
-        {sessionId !== null && worktreePath !== null && (
-          <span className="shrink-0 font-mono text-xs text-ink-faint">-</span>
-        )}
-        {worktreePath !== null && (
-          <Copy
-            value={worktreePath}
-            className="min-w-0 max-w-full"
-            textClassName="font-mono text-xs text-ink-faint"
-          />
-        )}
+        {worktreePath !== null ? (
+          <>
+            {" — WT "}
+            <span title={worktreePath}>{worktreeLeafName(worktreePath)}</span>
+          </>
+        ) : null}
+        {` · ${terminalAgo} · ${elapsedLabel}`}
       </p>
-      <WorkItemLifecycleStatus
-        workItem={workItem}
-        compact
-        issueUrl={issueUrl}
-        pullRequestUrl={
-          repository === undefined
-            ? null
-            : workItemPullRequestUrl(
-                repository.forge,
-                repository.forgeHost,
-                repository.projectPath,
-                workItem.pullRequestNumber,
-              )
-        }
-      />
+
+      {noChange && summary !== "" ? (
+        <p className="archive-summary">“{summary}”</p>
+      ) : null}
+
+      <div className="archive-foot">
+        {legs.map((leg) => {
+          const text = archiveLegText(leg)
+          if (leg.kind === "done" && leg.lane !== null) {
+            return (
+              <span
+                key={leg.id}
+                className="leg leg--lane"
+                style={archiveLegLaneStyle(leg.lane) as CSSProperties}
+              >
+                {text}
+              </span>
+            )
+          }
+          if (leg.kind === "fail") {
+            return (
+              <span key={leg.id} className="leg leg--fail">
+                {text}
+              </span>
+            )
+          }
+          return (
+            <span key={leg.id} className="leg leg--skip">
+              {text}
+            </span>
+          )
+        })}
+        {noChange ? (
+          <span className="nochange">No change</span>
+        ) : pullRequestUrl !== null && prNumber !== null ? (
+          <a
+            className="prbadge"
+            href={pullRequestUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            aria-label={`Open pull request #${prNumber}`}
+          >
+            PR #{prNumber} ↗
+          </a>
+        ) : null}
+      </div>
     </li>
   )
 }

--- a/apps/harness/src/live-duration.ts
+++ b/apps/harness/src/live-duration.ts
@@ -50,16 +50,54 @@ export function totalElapsedMs(
 
 /** Formats job start time as a relative phrase, e.g. "Started 15 min ago". */
 export function formatStartedAgo(iso: string, nowMs = Date.now()): string {
+  return formatRelativeAgo(iso, nowMs, "Started")
+}
+
+/**
+ * Relative age phrase for terminal archive rows, e.g. "Merged 38 min ago",
+ * "Withdrawn 2 d ago", "Finished yesterday".
+ */
+export function formatTerminalAgo(
+  iso: string,
+  verb: "Merged" | "Withdrawn" | "Finished",
+  nowMs = Date.now(),
+): string {
+  return formatRelativeAgo(iso, nowMs, verb)
+}
+
+function formatRelativeAgo(iso: string, nowMs: number, verb: string): string {
   const elapsedMs = Math.max(0, nowMs - new Date(iso).getTime())
   const seconds = Math.floor(elapsedMs / 1000)
-  if (seconds < 60) return "Started just now"
+  if (seconds < 60) return `${verb} just now`
   const minutes = Math.floor(seconds / 60)
-  if (minutes < 60) return `Started ${minutes} min ago`
+  if (minutes < 60) return `${verb} ${minutes} min ago`
   const hours = Math.floor(minutes / 60)
-  if (hours < 24)
-    return hours === 1 ? "Started 1 hour ago" : `Started ${hours} hours ago`
+  if (hours < 24) {
+    if (verb === "Started") {
+      return hours === 1 ? `${verb} 1 hour ago` : `${verb} ${hours} hours ago`
+    }
+    // Archive prototype prefers compact "2 h ago".
+    return hours === 1 ? `${verb} 1 h ago` : `${verb} ${hours} h ago`
+  }
   const days = Math.floor(hours / 24)
-  return days === 1 ? "Started 1 day ago" : `Started ${days} days ago`
+  if (verb !== "Started") {
+    return days === 1 ? `${verb} yesterday` : `${verb} ${days} d ago`
+  }
+  return days === 1 ? `${verb} 1 day ago` : `${verb} ${days} days ago`
+}
+
+/** Short session id for archive meta, e.g. "9a2c…55e8". */
+export function formatSessionShort(sessionId: string): string {
+  if (sessionId.length <= 10) return sessionId
+  return `${sessionId.slice(0, 4)}…${sessionId.slice(-4)}`
+}
+
+/** Worktree leaf name for archive meta, e.g. "worktree3". */
+export function worktreeLeafName(worktreePath: string): string {
+  const normalized = worktreePath.replace(/[/\\]+$/, "")
+  const parts = normalized.split(/[/\\]/)
+  const leaf = parts[parts.length - 1]
+  return leaf !== undefined && leaf !== "" ? leaf : worktreePath
 }
 
 /** Local wall-clock tick for animating live durations and relative ages. */

--- a/apps/harness/src/routes/completed.tsx
+++ b/apps/harness/src/routes/completed.tsx
@@ -19,19 +19,18 @@ export const Route = createFileRoute("/completed")({
 function CompletedPage() {
   // Reading-width cap lives on the page body only — root chrome stays full-width.
   return (
-    <main className="mx-auto max-w-[88rem] pt-8 sm:pt-10">
-      <header className="mb-5">
-        <p className="m-0 font-mono text-xs font-semibold tracking-[0.22em] text-oxblood uppercase">
-          History
-        </p>
-        <h1 className="mt-1.5 font-serif text-[clamp(1.5rem,2.8vw,2rem)] font-semibold tracking-[-0.01em]">
-          Completed work items
-        </h1>
-        <p className="mt-1.5 max-w-2xl text-sm text-ink-soft">
-          Historical Complete and Abandoned Work Items across every repository,
-          newest first. The Kanban Completed tab still shows only the last
-          rolling window; this page is the full archive.
-        </p>
+    <main className="mx-auto max-w-[88rem]">
+      <header className="pagehead">
+        <div>
+          <span className="kicker-tag">History</span>
+          <h1>Completed work items</h1>
+          <p className="lede">
+            Complete and abandoned work across every repository, newest first.
+            The board&apos;s Completed tab shows the last rolling window; this
+            page is the full archive.
+          </p>
+        </div>
+        <p className="pagehead-note">Newest first · All repositories</p>
       </header>
       <Suspense fallback={<CompletedListSkeleton />}>
         <CompletedWorkItemsBoard />
@@ -42,17 +41,25 @@ function CompletedPage() {
 
 function CompletedListSkeleton() {
   return (
-    <article
-      className="border border-rule-2 bg-panel px-4 py-3 sm:px-5"
-      role="status"
-      aria-label="Loading completed work items"
-      aria-busy="true"
-    >
-      <div className="grid gap-2">
-        <span className="block h-12 animate-pulse bg-paper-2 motion-reduce:animate-none" />
-        <span className="block h-12 animate-pulse bg-paper-2 motion-reduce:animate-none" />
+    <section className="archive" aria-label="Loading completed work items">
+      <div className="archive-line" aria-hidden="true">
+        <span className="roundel">06</span>
       </div>
-    </article>
+      <header className="nameboard">
+        <h2>Full archive</h2>
+        <span className="nb-sub">Complete + abandoned</span>
+        <span className="nb-count">…</span>
+      </header>
+      <div
+        className="archive-body"
+        role="status"
+        aria-label="Loading completed work items"
+        aria-busy="true"
+      >
+        <span className="block h-14 animate-pulse bg-[var(--line-ghost)] motion-reduce:animate-none" />
+        <span className="block h-14 animate-pulse bg-[var(--line-ghost)] motion-reduce:animate-none" />
+      </div>
+    </section>
   )
 }
 
@@ -167,63 +174,70 @@ function CompletedWorkItemsBoard() {
     completedQuery.isError && completedQuery.data !== undefined
 
   return (
-    <article className="border border-rule-2 bg-panel px-4 py-3 sm:px-5">
+    <>
       {live}
-      {refreshFailedWithData ? (
-        <Banner
-          className="mb-3"
-          tone="alarm"
-          tag="Refresh failed"
-          action={
-            <BannerActionButton
-              onClick={() => {
-                void completedQuery.refetch()
-              }}
-            >
-              Retry
-            </BannerActionButton>
-          }
-        >
-          Could not refresh completed work items. Showing last loaded page.
-        </Banner>
-      ) : null}
-      {resolvedTotalCount === 0 ? (
-        <p className="m-0 font-serif text-sm italic text-ink-soft">
-          No completed work items yet.
-        </p>
-      ) : items.length === 0 ? (
-        <p className="m-0 font-serif text-sm italic text-ink-soft">
-          No completed work items on this page.
-        </p>
-      ) : (
-        <ul
-          className="m-0 grid min-w-0 list-none gap-1 p-0"
-          aria-label="Completed work items"
-        >
-          {items.map((workItem) => (
-            <CompletedWorkItemRow
-              key={workItem.id}
-              workItem={workItem}
-              repository={repositoryById.get(workItem.repositoryId)}
-              issue={issueByRepoAndNumber.get(
-                `${workItem.repositoryId}:${workItem.issueNumber}`,
-              )}
-              onOpenSession={(workItemId, sessionId) => {
-                setSessionDialog({ workItemId, sessionId })
-              }}
-            />
-          ))}
-        </ul>
-      )}
+      <section className="archive" aria-label="Completed work items archive">
+        <div className="archive-line" aria-hidden="true">
+          <span className="roundel">06</span>
+        </div>
+        <header className="nameboard">
+          <h2>Full archive</h2>
+          <span className="nb-sub">Complete + abandoned</span>
+          <span className="nb-count">
+            {resolvedTotalCount}
+            <span className="sr-only"> completed work items</span>
+          </span>
+        </header>
 
-      <nav
-        className="mt-4 flex flex-wrap items-center justify-between gap-3 border-t border-rule pt-3"
-        aria-label="Completed work items pagination"
-      >
-        <p
-          className="m-0 font-mono text-xs tracking-[0.08em] text-ink-faint uppercase"
-          aria-live="polite"
-        >
+        <div className="archive-body">
+          {refreshFailedWithData ? (
+            <Banner
+              tone="alarm"
+              tag="Refresh failed"
+              action={
+                <BannerActionButton
+                  onClick={() => {
+                    void completedQuery.refetch()
+                  }}
+                >
+                  Retry
+                </BannerActionButton>
+              }
+            >
+              Could not refresh completed work items. Showing last loaded page.
+            </Banner>
+          ) : null}
+
+          {resolvedTotalCount === 0 ? (
+            <p className="archive-empty" role="status">
+              No completed work items yet
+            </p>
+          ) : items.length === 0 ? (
+            <p className="archive-empty" role="status">
+              No completed work items on this page
+            </p>
+          ) : (
+            <ul className="archive-rows" aria-label="Completed work items">
+              {items.map((workItem) => (
+                <CompletedWorkItemRow
+                  key={workItem.id}
+                  workItem={workItem}
+                  repository={repositoryById.get(workItem.repositoryId)}
+                  issue={issueByRepoAndNumber.get(
+                    `${workItem.repositoryId}:${workItem.issueNumber}`,
+                  )}
+                  onOpenSession={(workItemId, sessionId) => {
+                    setSessionDialog({ workItemId, sessionId })
+                  }}
+                />
+              ))}
+            </ul>
+          )}
+        </div>
+      </section>
+
+      <nav className="pager" aria-label="Completed work items pagination">
+        <p className="pager-note" aria-live="polite">
           Page {currentPage} of {resolvedTotalPages}
           {resolvedTotalCount > 0 && items.length > 0
             ? ` · ${rangeStart}–${rangeEnd} of ${resolvedTotalCount}`
@@ -234,28 +248,30 @@ function CompletedWorkItemsBoard() {
             ? ` · ${resolvedPageSize} per page`
             : null}
         </p>
-        <div className="flex items-center gap-2">
+        <div className="pager-btns">
           <button
             type="button"
-            className="border border-rule-2 bg-paper px-3 py-1.5 text-sm font-semibold text-ink-2 transition hover:bg-paper-2 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-oxblood disabled:cursor-not-allowed disabled:opacity-50"
+            className="plate-mini"
             disabled={!hasPreviousPage || completedQuery.isFetching}
+            aria-busy={completedQuery.isFetching || undefined}
             aria-label="Previous page of completed work items"
             onClick={() => {
               setPage((current) => Math.max(1, current - 1))
             }}
           >
-            Previous
+            ← Prev
           </button>
           <button
             type="button"
-            className="border border-rule-2 bg-paper px-3 py-1.5 text-sm font-semibold text-ink-2 transition hover:bg-paper-2 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-oxblood disabled:cursor-not-allowed disabled:opacity-50"
+            className="plate-mini"
             disabled={!hasNextPage || completedQuery.isFetching}
+            aria-busy={completedQuery.isFetching || undefined}
             aria-label="Next page of completed work items"
             onClick={() => {
               setPage((current) => current + 1)
             }}
           >
-            Next
+            Next →
           </button>
         </div>
       </nav>
@@ -268,6 +284,6 @@ function CompletedWorkItemsBoard() {
           setSessionDialog(null)
         }}
       />
-    </article>
+    </>
   )
 }

--- a/apps/harness/src/styles.css
+++ b/apps/harness/src/styles.css
@@ -470,8 +470,13 @@
   }
 
   .plate-mini:disabled {
-    cursor: wait;
+    cursor: not-allowed;
     opacity: 0.55;
+  }
+
+  /* Fetching (aria-busy) — wait cursor only while a request is in flight */
+  .plate-mini:disabled[aria-busy="true"] {
+    cursor: wait;
   }
 
   /* Compact banner (inline inside panels / dialogs) */
@@ -481,6 +486,384 @@
 
   .banner--compact .banner-body {
     font-size: 0.88rem;
+  }
+
+  /* ---------- Completed archive surface (§4.5 / #698 prototype) ---------- */
+
+  .pagehead {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: flex-end;
+    justify-content: space-between;
+    gap: 0.8rem 2rem;
+    margin-bottom: 1.7rem;
+  }
+
+  .kicker-tag {
+    display: inline-block;
+    background: var(--signal);
+    color: #151515;
+    font-family: var(--font-mono);
+    font-size: 0.64rem;
+    font-weight: 700;
+    letter-spacing: 0.2em;
+    text-transform: uppercase;
+    padding: 0.18rem 0.5rem;
+  }
+
+  .pagehead h1 {
+    margin: 0.6rem 0 0;
+    font-family: var(--font-display);
+    font-size: clamp(1.7rem, 3.2vw, 2.4rem);
+    font-weight: 800;
+    letter-spacing: -0.01em;
+    text-transform: uppercase;
+    line-height: 0.95;
+    color: var(--ink);
+  }
+
+  .lede {
+    margin: 0.6rem 0 0;
+    max-width: 44rem;
+    font-family: var(--font-display);
+    font-size: 0.98rem;
+    line-height: 1.45;
+    color: var(--ink-dim);
+  }
+
+  .pagehead-note {
+    margin: 0;
+    font-family: var(--font-mono);
+    font-size: 0.68rem;
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+    color: var(--ink-faint);
+    white-space: nowrap;
+  }
+
+  .archive {
+    margin-top: 0.5rem;
+  }
+
+  /* Route-line fragment with the Merged (06) roundel riding it */
+  .archive-line {
+    position: relative;
+    height: 1.3rem;
+  }
+
+  .archive-line::before {
+    content: "";
+    position: absolute;
+    top: 0.55rem;
+    left: 0;
+    right: 0;
+    height: 4px;
+    background: var(--ink);
+  }
+
+  .roundel {
+    position: absolute;
+    top: 0;
+    left: 2.2rem;
+    width: 2.1rem;
+    height: 2.1rem;
+    display: grid;
+    place-items: center;
+    border-radius: 50%;
+    background: var(--lane-merged);
+    color: #ffffff;
+    border: 2px solid #ffffff;
+    font-family: var(--font-mono);
+    font-size: 0.68rem;
+    font-weight: 700;
+  }
+
+  /* Merged-black nameboard — halo via --merged-halo in dark mode */
+  .nameboard {
+    display: flex;
+    align-items: baseline;
+    gap: 0.6rem;
+    padding: 0.5rem 0.8rem 0.55rem;
+    background: var(--lane-merged);
+    color: #ffffff;
+    border: 2px solid var(--ink);
+    box-shadow: 0 0 0 1px var(--merged-halo);
+  }
+
+  .nameboard h2 {
+    margin: 0;
+    font-family: var(--font-display);
+    font-size: 1.05rem;
+    font-weight: 800;
+    letter-spacing: 0.07em;
+    text-transform: uppercase;
+  }
+
+  .nb-sub {
+    font-family: var(--font-mono);
+    font-size: 0.66rem;
+    letter-spacing: 0.16em;
+    text-transform: uppercase;
+    color: rgb(255 255 255 / 0.65);
+  }
+
+  .nb-count {
+    margin-left: auto;
+    font-family: var(--font-display);
+    font-size: 1.5rem;
+    font-weight: 800;
+    line-height: 1;
+    font-variant-numeric: tabular-nums;
+  }
+
+  .archive-body {
+    border: 1.5px solid var(--ink);
+    border-top: 0;
+    background: var(--panel);
+    padding: 0.8rem;
+    display: grid;
+    gap: 0.6rem;
+    align-content: start;
+  }
+
+  .archive-body > .banner {
+    margin: 0;
+  }
+
+  .archive-rows {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: grid;
+    gap: 0.6rem;
+  }
+
+  .archive-row {
+    border: 1.5px solid var(--ink);
+    padding: 0.6rem 0.75rem 0.7rem 1rem;
+    display: grid;
+    gap: 0.38rem;
+    min-width: 0;
+  }
+
+  /* Complete: 6px Merged line bar; white halo hairline in dark via --merged-halo */
+  .archive-row--complete {
+    box-shadow:
+      inset 6px 0 0 var(--lane-merged),
+      inset 8px 0 0 var(--merged-halo);
+  }
+
+  /* Abandoned: dashed, ghosted — never reached the end of the line */
+  .archive-row--abandoned {
+    border-style: dashed;
+    border-color: var(--ink-faint);
+  }
+
+  .archive-row-top {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 0.3rem 0.8rem;
+  }
+
+  .archive-repo {
+    margin: 0;
+    font-family: var(--font-mono);
+    font-size: 0.68rem;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    color: var(--ink-faint);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .archive-title {
+    margin: 0.15rem 0 0;
+    font-family: var(--font-display);
+    font-size: 1.06rem;
+    font-weight: 600;
+    line-height: 1.3;
+    color: var(--ink);
+    text-decoration: none;
+    display: inline-block;
+    max-width: 100%;
+  }
+
+  a.archive-title:hover {
+    text-decoration: underline;
+    text-decoration-thickness: 2px;
+    text-underline-offset: 3px;
+    text-decoration-color: var(--signal);
+  }
+
+  .archive-title .num {
+    font-family: var(--font-mono);
+    font-size: 0.8rem;
+    font-weight: 400;
+    color: var(--ink-dim);
+  }
+
+  .archive-row--abandoned .archive-title {
+    color: var(--ink-dim);
+  }
+
+  /* Exception stamp only (ABANDONED) — Complete is unstamped on this page */
+  .archive-stamp {
+    flex-shrink: 0;
+    font-family: var(--font-mono);
+    font-size: 0.66rem;
+    font-weight: 700;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    padding: 0.22rem 0.5rem;
+  }
+
+  .archive-stamp--abandoned {
+    background: transparent;
+    color: var(--ink-dim);
+    border: 1.5px dashed var(--ink-faint);
+  }
+
+  .archive-meta {
+    margin: 0;
+    font-family: var(--font-mono);
+    font-size: 0.7rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--ink-faint);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .archive-meta .sess {
+    color: var(--ink-dim);
+    text-decoration: underline;
+    text-underline-offset: 2px;
+    cursor: pointer;
+    background: none;
+    border: 0;
+    padding: 0;
+    font: inherit;
+    letter-spacing: inherit;
+    text-transform: inherit;
+  }
+
+  .archive-meta .sess:hover {
+    color: var(--ink);
+  }
+
+  .archive-summary {
+    margin: 0;
+    font-family: var(--font-mono);
+    font-size: 0.7rem;
+    letter-spacing: 0.02em;
+    text-transform: none;
+    color: var(--ink-dim);
+  }
+
+  .archive-foot {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.35rem;
+  }
+
+  /* Journey-leg chips — archive uses relaxed 0.62rem + lane colour for done */
+  .leg {
+    font-family: var(--font-mono);
+    font-size: 0.62rem;
+    letter-spacing: 0.06em;
+    border: 1.5px solid var(--ink);
+    color: var(--ink-dim);
+    padding: 0.2rem 0.44rem;
+    white-space: nowrap;
+  }
+
+  .leg--lane {
+    background: var(--leg-lane);
+    color: var(--leg-on-lane);
+    border-color: var(--leg-lane);
+    font-weight: 700;
+  }
+
+  .leg--skip {
+    border-style: dashed;
+    color: var(--ink-faint);
+    border-color: var(--line-soft);
+  }
+
+  .leg--fail {
+    background: var(--lane-attention);
+    color: var(--lane-attention-ink);
+    border-color: var(--lane-attention);
+    font-weight: 700;
+  }
+
+  .prbadge {
+    margin-left: auto;
+    background: var(--prbadge-bg);
+    color: var(--prbadge-ink);
+    border: 1.5px solid var(--prbadge-border);
+    font-family: var(--font-mono);
+    font-size: 0.68rem;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    padding: 0.24rem 0.55rem;
+    text-decoration: none;
+  }
+
+  a.prbadge:hover {
+    background: var(--lane-pr);
+    color: #ffffff;
+    border-color: var(--lane-pr);
+  }
+
+  .nochange {
+    margin-left: auto;
+    font-family: var(--font-mono);
+    font-size: 0.64rem;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    color: var(--ink-faint);
+    border: 1.5px dashed var(--line-soft);
+    padding: 0.2rem 0.45rem;
+  }
+
+  .archive-empty {
+    margin: 0;
+    padding: 2.6rem 0.5rem;
+    text-align: center;
+    font-family: var(--font-mono);
+    font-size: 0.7rem;
+    letter-spacing: 0.26em;
+    text-transform: uppercase;
+    color: var(--ink-faint);
+  }
+
+  .pager {
+    margin-top: 1.1rem;
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.7rem 1.2rem;
+  }
+
+  .pager-note {
+    margin: 0;
+    font-family: var(--font-mono);
+    font-size: 0.68rem;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    color: var(--ink-faint);
+  }
+
+  .pager-btns {
+    display: flex;
+    gap: 0.5rem;
   }
 
   /* ---------- Legacy Ledger helpers (unmigrated surfaces) ---------- */
@@ -744,6 +1127,18 @@
 
   .page-shell {
     padding: 1.3rem 1.4rem 2.4rem;
+  }
+
+  .pagehead-note {
+    display: none;
+  }
+
+  .roundel {
+    left: 1rem;
+  }
+
+  .archive-row {
+    padding-left: 0.85rem;
   }
 
   .pipeline-controls {

--- a/apps/harness/test/archive-legs.test.ts
+++ b/apps/harness/test/archive-legs.test.ts
@@ -1,0 +1,225 @@
+import {
+  archiveLegText,
+  formatArchiveLegDuration,
+  planArchiveLegs,
+} from "../src/archive-legs.js"
+import { describe, expect, test } from "bun:test"
+
+const chip = (
+  phase: string,
+  status: string,
+  durationMs: number | null = null,
+) => ({
+  phase,
+  label: `${phase}: ${status}`,
+  status,
+  durationMs,
+})
+
+describe("planArchiveLegs", () => {
+  test("complete with PR shows BUILD / REVIEW / CHECKS / MERGE done legs", () => {
+    const legs = planArchiveLegs({
+      status: "COMPLETE",
+      state: "COMPLETE",
+      pullRequestNumber: 700,
+      completionSummary: null,
+      lifecycleLabels: [
+        chip("IMPLEMENT", "SUCCEEDED", 14 * 60_000),
+        chip("REVIEW", "SUCCEEDED", 6 * 60_000),
+        chip("GITHUB_STATUS_CHECKS", "SUCCEEDED", 2 * 60_000),
+        chip("MERGE_PR", "SUCCEEDED", 60_000),
+      ],
+    })
+    expect(legs.map((leg) => [leg.label, leg.kind, leg.lane])).toEqual([
+      ["BUILD", "done", "build"],
+      ["REVIEW", "done", "review"],
+      ["CHECKS", "done", "pr"],
+      ["MERGE", "done", "pr"],
+    ])
+    expect(archiveLegText(legs[0]!)).toBe("✓ BUILD · 14M")
+    expect(archiveLegText(legs[2]!)).toBe("✓ CHECKS · 2M")
+  })
+
+  test("complete no-change shows BUILD done and NO PR NEEDED skip", () => {
+    const legs = planArchiveLegs({
+      status: "COMPLETE",
+      state: "COMPLETE",
+      pullRequestNumber: null,
+      completionSummary: "Already covered — no code change required.",
+      lifecycleLabels: [chip("IMPLEMENT", "SUCCEEDED", 10 * 60_000)],
+    })
+    expect(legs.map((leg) => [leg.label, leg.kind])).toEqual([
+      ["BUILD", "done"],
+      ["NO PR NEEDED", "skip"],
+    ])
+    expect(archiveLegText(legs[1]!)).toBe("○ NO PR NEEDED")
+  })
+
+  test("abandoned after build shows done BUILD and unreached REVIEW / PR", () => {
+    const legs = planArchiveLegs({
+      status: "ABANDONED",
+      state: "ABANDONED",
+      pullRequestNumber: null,
+      completionSummary: null,
+      lifecycleLabels: [chip("IMPLEMENT", "SUCCEEDED", 11 * 60_000)],
+    })
+    expect(legs.map((leg) => [leg.label, leg.kind])).toEqual([
+      ["BUILD", "done"],
+      ["REVIEW", "skip"],
+      ["PR", "skip"],
+    ])
+  })
+
+  test("abandoned with no steps shows all unreached", () => {
+    const legs = planArchiveLegs({
+      status: "ABANDONED",
+      state: "ABANDONED",
+      pullRequestNumber: null,
+      completionSummary: null,
+      lifecycleLabels: [],
+    })
+    expect(legs.map((leg) => [leg.label, leg.kind])).toEqual([
+      ["BUILD", "skip"],
+      ["REVIEW", "skip"],
+      ["PR", "skip"],
+    ])
+  })
+
+  test("failed-then-abandoned renders Attention fail leg then unreached", () => {
+    const legs = planArchiveLegs({
+      status: "ABANDONED",
+      state: "ABANDONED",
+      pullRequestNumber: null,
+      completionSummary: null,
+      lifecycleLabels: [
+        chip("IMPLEMENT", "SUCCEEDED", 8 * 60_000),
+        chip("REVIEW", "FAILED", 3 * 60_000),
+      ],
+    })
+    expect(legs.map((leg) => [leg.label, leg.kind])).toEqual([
+      ["BUILD", "done"],
+      ["REVIEW", "fail"],
+      ["PR", "skip"],
+    ])
+    expect(archiveLegText(legs[1]!)).toBe("✕ REVIEW · 3M")
+  })
+
+  test("failed BUILD then abandoned shows ✕ BUILD and unreached REVIEW / PR", () => {
+    const legs = planArchiveLegs({
+      status: "ABANDONED",
+      state: "ABANDONED",
+      pullRequestNumber: null,
+      completionSummary: null,
+      lifecycleLabels: [chip("IMPLEMENT", "FAILED", 4 * 60_000)],
+    })
+    expect(legs.map((leg) => [leg.label, leg.kind])).toEqual([
+      ["BUILD", "fail"],
+      ["REVIEW", "skip"],
+      ["PR", "skip"],
+    ])
+  })
+
+  test("failed CHECKS then abandoned keeps prior done legs", () => {
+    const legs = planArchiveLegs({
+      status: "ABANDONED",
+      state: "ABANDONED",
+      pullRequestNumber: null,
+      completionSummary: null,
+      lifecycleLabels: [
+        chip("IMPLEMENT", "SUCCEEDED", 10 * 60_000),
+        chip("REVIEW", "SUCCEEDED", 5 * 60_000),
+        chip("GITHUB_STATUS_CHECKS", "FAILED", 2 * 60_000),
+      ],
+    })
+    expect(legs.map((leg) => [leg.label, leg.kind])).toEqual([
+      ["BUILD", "done"],
+      ["REVIEW", "done"],
+      ["CHECKS", "fail"],
+    ])
+  })
+
+  test("failed MERGE after successful CHECKS keeps done CHECKS before ✕ MERGE", () => {
+    const legs = planArchiveLegs({
+      status: "ABANDONED",
+      state: "ABANDONED",
+      pullRequestNumber: null,
+      completionSummary: null,
+      lifecycleLabels: [
+        chip("IMPLEMENT", "SUCCEEDED", 10 * 60_000),
+        chip("REVIEW", "SUCCEEDED", 5 * 60_000),
+        chip("GITHUB_STATUS_CHECKS", "SUCCEEDED", 2 * 60_000),
+        chip("MERGE_PR", "FAILED", 60_000),
+      ],
+    })
+    expect(legs.map((leg) => [leg.label, leg.kind])).toEqual([
+      ["BUILD", "done"],
+      ["REVIEW", "done"],
+      ["CHECKS", "done"],
+      ["MERGE", "fail"],
+    ])
+    expect(archiveLegText(legs[2]!)).toBe("✓ CHECKS · 2M")
+    expect(archiveLegText(legs[3]!)).toBe("✕ MERGE · 1M")
+  })
+
+  test("abandoned with REVIEW but missing BUILD chips keeps REVIEW progress", () => {
+    const legs = planArchiveLegs({
+      status: "ABANDONED",
+      state: "ABANDONED",
+      pullRequestNumber: null,
+      completionSummary: null,
+      lifecycleLabels: [chip("REVIEW", "SUCCEEDED", 6 * 60_000)],
+    })
+    expect(legs.map((leg) => [leg.label, leg.kind])).toEqual([
+      ["BUILD", "skip"],
+      ["REVIEW", "done"],
+      ["PR", "skip"],
+    ])
+  })
+
+  test("failed DECIDE_PR after CHECKS uses pr_other duration only on ✕ PR", () => {
+    const legs = planArchiveLegs({
+      status: "ABANDONED",
+      state: "ABANDONED",
+      pullRequestNumber: null,
+      completionSummary: null,
+      lifecycleLabels: [
+        chip("IMPLEMENT", "SUCCEEDED", 10 * 60_000),
+        chip("REVIEW", "SUCCEEDED", 5 * 60_000),
+        chip("GITHUB_STATUS_CHECKS", "SUCCEEDED", 2 * 60_000),
+        chip("DECIDE_PR_MERGE", "FAILED", 90_000),
+      ],
+    })
+    expect(legs.map((leg) => [leg.label, leg.kind, leg.durationMs])).toEqual([
+      ["BUILD", "done", 10 * 60_000],
+      ["REVIEW", "done", 5 * 60_000],
+      ["CHECKS", "done", 2 * 60_000],
+      ["PR", "fail", 90_000],
+    ])
+    expect(archiveLegText(legs[3]!)).toBe("✕ PR · 1M 30S")
+  })
+
+  test("abandoned after successful CHECKS only appends unreached MERGE", () => {
+    const legs = planArchiveLegs({
+      status: "ABANDONED",
+      state: "ABANDONED",
+      pullRequestNumber: null,
+      completionSummary: null,
+      lifecycleLabels: [
+        chip("IMPLEMENT", "SUCCEEDED", 10 * 60_000),
+        chip("REVIEW", "SUCCEEDED", 5 * 60_000),
+        chip("GITHUB_STATUS_CHECKS", "SUCCEEDED", 2 * 60_000),
+      ],
+    })
+    expect(legs.map((leg) => [leg.label, leg.kind])).toEqual([
+      ["BUILD", "done"],
+      ["REVIEW", "done"],
+      ["CHECKS", "done"],
+      ["MERGE", "skip"],
+    ])
+  })
+
+  test("formatArchiveLegDuration uppercases compact duration units", () => {
+    expect(formatArchiveLegDuration(90_000)).toBe("1M 30S")
+    expect(formatArchiveLegDuration(14 * 60_000)).toBe("14M")
+  })
+})

--- a/apps/harness/test/completed-route.test.ts
+++ b/apps/harness/test/completed-route.test.ts
@@ -17,6 +17,9 @@ const rowSource = () =>
     "utf8",
   )
 
+const stylesSource = () =>
+  readFileSync(join(import.meta.dir, "../src/styles.css"), "utf8")
+
 const routeTreeSource = () =>
   readFileSync(join(import.meta.dir, "../src/routeTree.gen.ts"), "utf8")
 
@@ -69,6 +72,37 @@ describe("/completed route", () => {
     expect(source).toContain("COMPLETED_WORK_ITEMS_PAGE_SIZE")
   })
 
+  test("renders Interchange archive slab: pagehead, nameboard, 06 roundel", () => {
+    const source = completedSource()
+    expect(source).toContain('className="pagehead"')
+    expect(source).toContain('className="kicker-tag"')
+    expect(source).toContain("History")
+    expect(source).toContain("Completed work items")
+    expect(source).toContain('className="lede"')
+    expect(source).toContain('className="pagehead-note"')
+    expect(source).toContain("Newest first · All repositories")
+    expect(source).toContain('className="archive"')
+    expect(source).toContain('className="archive-line"')
+    expect(source).toContain('className="roundel"')
+    expect(source).toContain(">06</")
+    expect(source).toContain('className="nameboard"')
+    expect(source).toContain("Full archive")
+    expect(source).toContain("Complete + abandoned")
+    expect(source).toContain('className="nb-count"')
+    expect(source).toContain('className="archive-body"')
+    expect(source).toContain('className="archive-empty"')
+    expect(source).toContain("No completed work items yet")
+
+    const styles = stylesSource()
+    expect(styles).toContain(".archive-row--complete")
+    expect(styles).toContain(".archive-row--abandoned")
+    expect(styles).toContain(".archive-stamp--abandoned")
+    expect(styles).toContain(".leg--lane")
+    expect(styles).toContain(".leg--fail")
+    expect(styles).toContain("--merged-halo")
+    expect(styles).toContain(".plate-mini")
+  })
+
   test("reuses CompletedWorkItemRow for historical completed cards", () => {
     const source = completedSource()
     expect(source).toContain("<CompletedWorkItemRow")
@@ -78,16 +112,28 @@ describe("/completed route", () => {
     expect(row).toContain("export function CompletedWorkItemRow(")
     expect(row).toContain("workItem.agentBackend.label")
     expect(row).toContain("onOpenSession")
-    expect(row).toContain("<WorkItemLifecycleStatus")
+    expect(row).toContain("planArchiveLegs")
+    expect(row).toContain("archive-row--complete")
+    expect(row).toContain("archive-row--abandoned")
+    expect(row).toContain("archive-stamp--abandoned")
+    expect(row).toContain("Abandoned")
+    expect(row).toContain("No change")
+    expect(row).toContain("prbadge")
     expect(row).toContain("workItemIssueUrl")
     expect(row).toContain("workItemPullRequestUrl")
+    // Complete is unstamped; board lifecycle chrome stays off this surface.
+    expect(row).not.toContain("WorkItemLifecycleStatus")
+    expect(row).not.toContain("stateLabel")
   })
 
   test("exposes accessible previous/next pagination with current page indication", () => {
     const source = completedSource()
     expect(source).toContain('aria-label="Completed work items pagination"')
-    expect(source).toContain("Previous")
-    expect(source).toContain("Next")
+    expect(source).toContain("← Prev")
+    expect(source).toContain("Next →")
+    expect(source).toContain('className="plate-mini"')
+    expect(source).toContain('className="pager"')
+    expect(source).toContain('className="pager-note"')
     expect(source).toContain(
       'aria-label="Previous page of completed work items"',
     )
@@ -102,8 +148,8 @@ describe("/completed route", () => {
 
   test("handles empty archive vs empty page, loading, and error states", () => {
     const source = completedSource()
-    expect(source).toContain("No completed work items yet.")
-    expect(source).toContain("No completed work items on this page.")
+    expect(source).toContain("No completed work items yet")
+    expect(source).toContain("No completed work items on this page")
     expect(source).toContain("resolvedTotalCount === 0")
     expect(source).toContain("setPage(totalPages)")
     expect(source).toContain("Loading completed work items")

--- a/apps/harness/test/live-duration.test.ts
+++ b/apps/harness/test/live-duration.test.ts
@@ -1,9 +1,12 @@
 import {
   formatDuration,
+  formatSessionShort,
   formatStartedAgo,
+  formatTerminalAgo,
   isLiveDurationStatus,
   liveDurationMs,
   totalElapsedMs,
+  worktreeLeafName,
 } from "../src/live-duration.js"
 import { describe, expect, test } from "bun:test"
 
@@ -106,6 +109,38 @@ describe("formatStartedAgo", () => {
     expect(formatStartedAgo(createdAt, 1_000_000 + 15 * 60_000)).toBe(
       "Started 15 min ago",
     )
+  })
+})
+
+describe("formatTerminalAgo", () => {
+  test("uses compact archive relative phrases", () => {
+    const at = new Date(1_000_000).toISOString()
+    expect(formatTerminalAgo(at, "Merged", 1_000_000 + 38 * 60_000)).toBe(
+      "Merged 38 min ago",
+    )
+    expect(formatTerminalAgo(at, "Merged", 1_000_000 + 2 * 3_600_000)).toBe(
+      "Merged 2 h ago",
+    )
+    expect(formatTerminalAgo(at, "Withdrawn", 1_000_000 + 25 * 3_600_000)).toBe(
+      "Withdrawn yesterday",
+    )
+    expect(formatTerminalAgo(at, "Finished", 1_000_000 + 3 * 86_400_000)).toBe(
+      "Finished 3 d ago",
+    )
+  })
+})
+
+describe("formatSessionShort", () => {
+  test("shortens long session ids with an ellipsis", () => {
+    expect(formatSessionShort("9a2c55e8b1d0")).toBe("9a2c…b1d0")
+    expect(formatSessionShort("short")).toBe("short")
+  })
+})
+
+describe("worktreeLeafName", () => {
+  test("returns the path leaf for archive meta", () => {
+    expect(worktreeLeafName("/tmp/rfa/worktree3")).toBe("worktree3")
+    expect(worktreeLeafName("worktree5/")).toBe("worktree5")
   })
 })
 


### PR DESCRIPTION
Land phase 3 of the Harness Interchange design system: re-skin the historical
Completed page as the archive surface from the de-trained Interchange spec and
the approved #698 prototype (prototype wins on this surface).

Why:

Issue #702 is the third shippable Interchange slice. Phase 1 already landed
tokens, theme plumbing, masthead nav, and banners. The Completed page still
used Ledger density (serif titles, COMPLETE stamps, board lifecycle chrome).
Operators need the full archive to read as the end of the pipeline —
Merged-black nameboard, relaxed type, and journey legs that continue board
lane colour without reintroducing board failure chrome.

What changed:

- Page shell: signal History kicker, display title, lede, mono note; archive
  slab with route-line fragment, 06 roundel, Merged-black nameboard (count +
  Complete + abandoned), panel body, empty mono status, plate-mini Prev/Next
  with aria-live pager note.
- Rows: Complete = 6px Merged bar, no stamp; Abandoned = dashed border,
  ghosted title, dashed ABANDONED stamp only. Meta (backend, short session +
  copy, WT leaf, Merged/Withdrawn/Finished ago, elapsed); no-change summary
  quotes + No change tag; PR badge when present.
- Archive legs (planArchiveLegs): done BUILD/REVIEW/CHECKS/MERGE
  lane-coloured; unreached dashed; failed-then-abandoned Attention fail in
  chronological order (including prior done PR sub-legs and pr_other-only fail
  duration); unreached MERGE after mid-PR abandon when merge never ran.
- CSS: pagehead, nameboard/roundel/halo, archive rows/legs/prbadge/pager;
  plate-mini disabled uses not-allowed, wait only under aria-busy while
  fetching.
- Shared terminal ago helpers keep board formatStartedAgo long-form; archive
  uses compact phrases.

Verification:

- bunx nx test harness (full package; green after remediations)
- Focused archive-legs + completed-route tests covering complete/no-change/
  abandoned and fail paths
- Harness tsc --noEmit and Biome on touched files

Limitations:

- Archive behaviour (filtering, paging logic) is unchanged — visual surface
  only.
- Board, repos, and dialogs remain on prior treatments for later Interchange
  phases.
- Per-row relative-time tick (useNowMs) is unchanged; lifting a board-level
  timer is left as optional polish.

Closes #702