### PR TITLE
feat(harness): interchange phase 2 board — stats, network, tickets, queue hint

### DIFF
--- a/apps/harness/src/copy.tsx
+++ b/apps/harness/src/copy.tsx
@@ -53,7 +53,7 @@ export function Copy({
       ) : null}
       <button
         type="button"
-        className="inline-flex size-5 shrink-0 items-center justify-center text-ink-faint transition hover:bg-paper-2 hover:text-oxblood focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-oxblood"
+        className={`icon-btn${copied ? " icon-btn--copied" : ""}`}
         onClick={() => {
           void handleCopy()
         }}
@@ -63,7 +63,6 @@ export function Copy({
         {copied ? (
           <svg
             aria-hidden="true"
-            className="size-3.5 text-olive"
             viewBox="0 0 24 24"
             fill="none"
             stroke="currentColor"
@@ -76,7 +75,6 @@ export function Copy({
         ) : (
           <svg
             aria-hidden="true"
-            className="size-3.5"
             viewBox="0 0 24 24"
             fill="none"
             stroke="currentColor"

--- a/apps/harness/src/kanban-board.tsx
+++ b/apps/harness/src/kanban-board.tsx
@@ -1,4 +1,5 @@
 import { useQueries, useSuspenseQuery } from "@tanstack/react-query"
+import { Link } from "@tanstack/react-router"
 import { type CSSProperties, Suspense, useState } from "react"
 import { Banner } from "./banner.js"
 import { Copy } from "./copy.js"
@@ -32,7 +33,10 @@ import {
 } from "./routes/index.js"
 import { sessionWorktreeParts } from "./session-worktree-line.js"
 import { workItemIssueUrl } from "./work-item-issue-url.js"
-import { prBadgeClassName } from "./work-item-progress-chrome.js"
+import {
+  prBadgeClassName,
+  statusBadgeClassNameForStatus,
+} from "./work-item-progress-chrome.js"
 import { workItemPullRequestUrl } from "./work-item-pull-request-url.js"
 
 type JobsTab = "pipeline" | "completed"
@@ -108,17 +112,16 @@ function PipelineCompleteSummary({
     prNumber === null ? null : `Open pull request #${prNumber}`
 
   return (
-    <div className="mt-2">
-      <div className="flex flex-wrap items-center justify-between gap-2">
-        <span className="font-mono text-xs tracking-[0.1em] text-ink-faint uppercase">
-          {formatStartedAgo(workItem.createdAt, nowMs)}
-        </span>
-        <span className="font-mono text-xs text-ink-faint">{elapsedLabel}</span>
-      </div>
+    <div className="mt-1 grid gap-1.5">
+      <p className="job-ticket-runtime-line">
+        {formatStartedAgo(workItem.createdAt, nowMs)}
+        {" · "}
+        {elapsedLabel}
+      </p>
       {pullRequestUrl !== null &&
         prNumber !== null &&
         openPullRequestLabel !== null && (
-          <div className="mt-1.5">
+          <div>
             <a
               className={prBadgeClassName}
               href={pullRequestUrl}
@@ -126,7 +129,7 @@ function PipelineCompleteSummary({
               rel="noopener noreferrer"
               aria-label={openPullRequestLabel}
             >
-              PR #{prNumber}
+              PR #{prNumber} ↗
             </a>
           </div>
         )}
@@ -179,6 +182,7 @@ function PipelineTicket({
   return (
     <li
       className="job-ticket"
+      data-lane={laneId}
       style={{ "--ticket-color": lane?.color ?? "#151515" } as CSSProperties}
     >
       <p className="job-ticket-repo" title={repositoryLabel}>
@@ -186,32 +190,34 @@ function PipelineTicket({
       </p>
       {issueUrl !== null && issueUrl !== "" ? (
         <a className="job-ticket-title" href={issueUrl}>
-          <span className="font-mono">#{workItem.issueNumber}</span>
+          <span className="job-ticket-num">#{workItem.issueNumber}</span>
           {issueTitle === undefined ? null : ` ${issueTitle}`}
         </a>
       ) : (
         <span className="job-ticket-title">
-          <span className="font-mono">#{workItem.issueNumber}</span>
+          <span className="job-ticket-num">#{workItem.issueNumber}</span>
           {issueTitle === undefined ? null : ` ${issueTitle}`}
         </span>
       )}
-      <div className="flex items-center justify-between gap-2">
-        <span className="job-ticket-state">{workItem.stateLabel}</span>
+      <div className="job-ticket-status">
+        <span
+          className={`job-ticket-state ${statusBadgeClassNameForStatus(workItem.status)}`}
+        >
+          {workItem.stateLabel}
+        </span>
         <WorkItemPauseButton workItem={workItem} />
       </div>
       <div className="job-ticket-runtime">
-        <div className="flex min-w-0 items-center gap-1">
-          <span className="shrink-0 font-mono text-xs text-ink-faint">
-            {workItem.agentBackend.label}
-          </span>
+        <div className="job-ticket-runtime-line flex min-w-0 items-center gap-1">
+          <span className="shrink-0">{workItem.agentBackend.label}</span>
           {sessionId !== null && (
             <>
-              <span className="shrink-0 font-mono text-xs text-ink-faint">
-                -
+              <span className="shrink-0" aria-hidden="true">
+                —
               </span>
               <button
                 type="button"
-                className="min-w-0 truncate font-mono text-xs text-ink-faint underline-offset-2 hover:text-oxblood hover:underline"
+                className="job-ticket-session min-w-0 truncate"
                 title={sessionId}
                 onClick={() => onOpenSession(workItem.id, sessionId)}
               >
@@ -225,7 +231,7 @@ function PipelineTicket({
           <Copy
             value={worktreePath}
             className="min-w-0 max-w-full"
-            textClassName="font-mono text-xs text-ink-faint"
+            textClassName="job-ticket-runtime-line"
           />
         )}
       </div>
@@ -431,7 +437,13 @@ function KanbanJobsBoard() {
                   aria-controls={`lane-panel-${lane.id}`}
                   key={lane.id}
                   onClick={() => setMobileLane(lane.id)}
+                  style={
+                    {
+                      "--lane-color": lane.color,
+                    } as CSSProperties
+                  }
                 >
+                  <span className="lane-switch-swatch" aria-hidden="true" />
                   {lane.label} {laneItems.get(lane.id)?.length ?? 0}
                 </button>
               ))}
@@ -439,61 +451,74 @@ function KanbanJobsBoard() {
             <section className="pipeline-board" aria-label="Lifecycle pipeline">
               {PIPELINE_LANES.map((lane, laneIndex) => {
                 const items = laneItems.get(lane.id) ?? []
+                const laneNumber = String(laneIndex + 1).padStart(2, "0")
                 return (
                   <section
                     className="pipeline-lane"
+                    data-lane={lane.id}
                     data-mobile-active={mobileLane === lane.id}
                     id={`lane-panel-${lane.id}`}
                     key={lane.id}
                     aria-labelledby={`lane-${lane.id}`}
+                    style={
+                      {
+                        "--lane-color": lane.color,
+                        "--lane-text": lane.text,
+                      } as CSSProperties
+                    }
                   >
-                    <header
-                      className="lane-header"
-                      style={
-                        {
-                          "--lane-color": lane.color,
-                          "--lane-text": lane.text,
-                        } as CSSProperties
-                      }
-                    >
-                      <div>
-                        <span className="lane-number">
-                          0{laneIndex + 1} / 06
-                        </span>
+                    <div className="lane-chrome">
+                      <span className="lane-roundel" aria-hidden="true">
+                        {laneNumber}
+                      </span>
+                      <header className="lane-header">
                         <h3 className="lane-title" id={`lane-${lane.id}`}>
                           {lane.label}
                         </h3>
-                      </div>
-                      <span className="lane-count">
-                        {items.length}
-                        <span className="sr-only"> jobs</span>
-                      </span>
-                    </header>
-                    {items.length === 0 ? (
-                      <p className="lane-empty">Lane clear</p>
-                    ) : (
-                      <ul className="lane-stack m-0 list-none">
-                        {items.map((workItem) => (
-                          <PipelineTicket
-                            key={workItem.id}
-                            workItem={workItem}
-                            repository={repositoryById.get(
-                              workItem.repositoryId,
-                            )}
-                            issue={issueByRepoAndNumber.get(
-                              repositoryIssueKey(
+                        <span className="lane-count">
+                          {items.length}
+                          <span className="sr-only"> jobs</span>
+                        </span>
+                      </header>
+                    </div>
+                    <div className="lane-platform">
+                      {items.length === 0 ? (
+                        <p className="lane-empty">Lane clear</p>
+                      ) : (
+                        <ul className="lane-stack">
+                          {items.map((workItem) => (
+                            <PipelineTicket
+                              key={workItem.id}
+                              workItem={workItem}
+                              repository={repositoryById.get(
                                 workItem.repositoryId,
-                                workItem.issueNumber,
-                              ),
-                            )}
-                            laneId={lane.id}
-                            onOpenSession={(workItemId, sessionId) =>
-                              setSessionDialog({ workItemId, sessionId })
-                            }
-                          />
-                        ))}
-                      </ul>
-                    )}
+                              )}
+                              issue={issueByRepoAndNumber.get(
+                                repositoryIssueKey(
+                                  workItem.repositoryId,
+                                  workItem.issueNumber,
+                                ),
+                              )}
+                              laneId={lane.id}
+                              onOpenSession={(workItemId, sessionId) =>
+                                setSessionDialog({ workItemId, sessionId })
+                              }
+                            />
+                          ))}
+                        </ul>
+                      )}
+                      {lane.id === "queue" && (
+                        <aside className="queue-hint">
+                          <span className="queue-hint-tag">Queue</span>
+                          <p className="queue-hint-text">
+                            Feed the queue — work starts at your repos.
+                          </p>
+                          <Link to="/repos" className="queue-hint-link">
+                            Manage repos →
+                          </Link>
+                        </aside>
+                      )}
+                    </div>
                   </section>
                 )
               })}

--- a/apps/harness/src/routes/index.tsx
+++ b/apps/harness/src/routes/index.tsx
@@ -6,7 +6,14 @@ import {
   useSuspenseQuery,
 } from "@tanstack/react-query"
 import { createFileRoute } from "@tanstack/react-router"
-import { type FormEvent, Suspense, useEffect, useRef, useState } from "react"
+import {
+  type CSSProperties,
+  type FormEvent,
+  Suspense,
+  useEffect,
+  useRef,
+  useState,
+} from "react"
 import { createClient } from "@ready-for-agent/graphql-client"
 import {
   COMPLETED_WORK_ITEMS_DEFAULT_PAGE_SIZE as completedWorkItemsDefaultPageSize,
@@ -39,6 +46,7 @@ import {
   type LifecycleLabelChip,
   type LifecyclePipelineLaneId,
   lifecycleFocusLaneFor,
+  lifecycleLaneForPhase,
   planLifecycleChipPresentation,
 } from "../pipeline-lanes.js"
 import { followRepositoryIssuesLive } from "../refresh-issues-live.js"
@@ -60,7 +68,8 @@ import { workItemIssueUrl } from "../work-item-issue-url.js"
 import { canShowWorkItemResetAction } from "../work-item-job-actions.js"
 import { WorkItemOutcomePresentation } from "../work-item-outcome-presentation.js"
 import {
-  lifecycleStepChipClassName,
+  lifecycleLaneCssVars,
+  lifecycleStepChipClassNameForStatus,
   statusBadgeClassNameForStatus,
   statusMessageClassNameForStatus,
 } from "../work-item-progress-chrome.js"
@@ -774,17 +783,34 @@ export function CommittedPullRequestsDashboard() {
   if (loading) {
     return (
       <article
-        className="border border-rule-2 bg-panel px-4 py-4 sm:px-5"
+        className="merged-pr-stats"
         role="status"
         aria-label="Loading committed pull requests"
         aria-busy="true"
       >
-        <div className="grid grid-cols-2 gap-4 sm:grid-cols-5">
-          <span className="block h-10 animate-pulse bg-paper-2 motion-reduce:animate-none" />
-          <span className="block h-10 animate-pulse bg-paper-2 motion-reduce:animate-none" />
-          <span className="block h-10 animate-pulse bg-paper-2 motion-reduce:animate-none" />
-          <span className="block h-10 animate-pulse bg-paper-2 motion-reduce:animate-none" />
-          <span className="block h-10 animate-pulse bg-paper-2 motion-reduce:animate-none" />
+        <header className="merged-pr-stats-head">
+          <span className="merged-pr-stats-tag">Merged</span>
+          <h2 className="merged-pr-stats-title">Merged PR throughput</h2>
+          <span className="merged-pr-stats-note">
+            Qty per period · local time
+          </span>
+        </header>
+        <div className="merged-pr-stats-grid">
+          <div className="merged-pr-stats-cell">
+            <span className="merged-pr-stats-skeleton animate-pulse motion-reduce:animate-none" />
+          </div>
+          <div className="merged-pr-stats-cell">
+            <span className="merged-pr-stats-skeleton animate-pulse motion-reduce:animate-none" />
+          </div>
+          <div className="merged-pr-stats-cell">
+            <span className="merged-pr-stats-skeleton animate-pulse motion-reduce:animate-none" />
+          </div>
+          <div className="merged-pr-stats-cell">
+            <span className="merged-pr-stats-skeleton animate-pulse motion-reduce:animate-none" />
+          </div>
+          <div className="merged-pr-stats-cell">
+            <span className="merged-pr-stats-skeleton animate-pulse motion-reduce:animate-none" />
+          </div>
         </div>
       </article>
     )
@@ -792,9 +818,22 @@ export function CommittedPullRequestsDashboard() {
 
   if (failed) {
     return (
-      <Banner tone="alarm" tag="Error" role="alert">
-        Could not load committed pull requests. Please try again.
-      </Banner>
+      <article className="merged-pr-stats">
+        <header className="merged-pr-stats-head">
+          <span className="merged-pr-stats-tag">Merged</span>
+          <h2 className="merged-pr-stats-title">Merged PR throughput</h2>
+        </header>
+        <div className="merged-pr-stats-body">
+          <Banner
+            tone="alarm"
+            tag="Error"
+            role="alert"
+            className="banner--compact"
+          >
+            Could not load committed pull requests. Please try again.
+          </Banner>
+        </div>
+      </article>
     )
   }
 
@@ -805,47 +844,34 @@ export function CommittedPullRequestsDashboard() {
   const twoWeeksAgo = twoWeeksAgoQuery.data ?? 0
 
   return (
-    <article className="border border-rule-2 bg-panel px-4 py-4 sm:px-5">
-      <div className="grid grid-cols-2 gap-4 sm:grid-cols-5">
-        <div>
-          <p className="m-0 font-mono text-xs font-semibold tracking-[0.16em] text-ink-faint uppercase">
-            Today
-          </p>
-          <p className="mt-1 mb-0 font-serif text-[clamp(1.4rem,2.2vw,2rem)] leading-none font-semibold text-ink tabular-nums">
-            {today}
-          </p>
+    <article className="merged-pr-stats">
+      <header className="merged-pr-stats-head">
+        <span className="merged-pr-stats-tag">Merged</span>
+        <h2 className="merged-pr-stats-title">Merged PR throughput</h2>
+        <span className="merged-pr-stats-note">
+          Qty per period · local time
+        </span>
+      </header>
+      <div className="merged-pr-stats-grid">
+        <div className="merged-pr-stats-cell">
+          <span className="merged-pr-stats-num">{today}</span>
+          <span className="merged-pr-stats-label">Today</span>
         </div>
-        <div>
-          <p className="m-0 font-mono text-xs font-semibold tracking-[0.16em] text-ink-faint uppercase">
-            Yesterday
-          </p>
-          <p className="mt-1 mb-0 font-serif text-[clamp(1.4rem,2.2vw,2rem)] leading-none font-semibold text-ink tabular-nums">
-            {yesterday}
-          </p>
+        <div className="merged-pr-stats-cell">
+          <span className="merged-pr-stats-num">{yesterday}</span>
+          <span className="merged-pr-stats-label">Yesterday</span>
         </div>
-        <div>
-          <p className="m-0 font-mono text-xs font-semibold tracking-[0.16em] text-ink-faint uppercase">
-            This week
-          </p>
-          <p className="mt-1 mb-0 font-serif text-[clamp(1.4rem,2.2vw,2rem)] leading-none font-semibold text-ink tabular-nums">
-            {thisWeek}
-          </p>
+        <div className="merged-pr-stats-cell">
+          <span className="merged-pr-stats-num">{thisWeek}</span>
+          <span className="merged-pr-stats-label">This week</span>
         </div>
-        <div>
-          <p className="m-0 font-mono text-xs font-semibold tracking-[0.16em] text-ink-faint uppercase">
-            Last week
-          </p>
-          <p className="mt-1 mb-0 font-serif text-[clamp(1.4rem,2.2vw,2rem)] leading-none font-semibold text-ink tabular-nums">
-            {lastWeek}
-          </p>
+        <div className="merged-pr-stats-cell">
+          <span className="merged-pr-stats-num">{lastWeek}</span>
+          <span className="merged-pr-stats-label">Last week</span>
         </div>
-        <div>
-          <p className="m-0 font-mono text-xs font-semibold tracking-[0.16em] text-ink-faint uppercase">
-            Two weeks ago
-          </p>
-          <p className="mt-1 mb-0 font-serif text-[clamp(1.4rem,2.2vw,2rem)] leading-none font-semibold text-ink tabular-nums">
-            {twoWeeksAgo}
-          </p>
+        <div className="merged-pr-stats-cell">
+          <span className="merged-pr-stats-num">{twoWeeksAgo}</span>
+          <span className="merged-pr-stats-label">Two weeks ago</span>
         </div>
       </div>
     </article>
@@ -3584,14 +3610,17 @@ export function WorkItemPauseButton({ workItem }: { workItem: WorkItem }) {
   const pending = pause.isPending || start.isPending
   const failed = pause.isError || start.isError
   const label = workItem.paused ? "Start job" : "Pause job"
-  const buttonClass = workItem.paused
-    ? "border-oxblood/50 text-oxblood hover:bg-oxblood-wash focus-visible:outline-oxblood"
-    : "border-sepia/50 text-sepia hover:bg-amber-wash focus-visible:outline-sepia"
+
+  const pauseClass = failed
+    ? "icon-btn icon-btn--armed"
+    : workItem.paused
+      ? "icon-btn icon-btn--paused"
+      : "icon-btn"
 
   return (
     <button
       type="button"
-      className={`inline-flex size-8 shrink-0 items-center justify-center border transition focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-wait disabled:opacity-50 ${failed ? "border-oxblood text-oxblood hover:bg-oxblood-wash focus-visible:outline-oxblood" : buttonClass}`}
+      className={pauseClass}
       disabled={pending}
       onClick={() => (workItem.paused ? start.mutate() : pause.mutate())}
       aria-label={pending ? `${label} in progress` : label}
@@ -3600,7 +3629,7 @@ export function WorkItemPauseButton({ workItem }: { workItem: WorkItem }) {
       {pending ? (
         <svg
           aria-hidden="true"
-          className="size-4 animate-spin motion-reduce:animate-none"
+          className="animate-spin motion-reduce:animate-none"
           viewBox="0 0 24 24"
           fill="none"
         >
@@ -3621,21 +3650,11 @@ export function WorkItemPauseButton({ workItem }: { workItem: WorkItem }) {
           />
         </svg>
       ) : workItem.paused ? (
-        <svg
-          aria-hidden="true"
-          className="size-4"
-          viewBox="0 0 24 24"
-          fill="currentColor"
-        >
+        <svg aria-hidden="true" viewBox="0 0 24 24" fill="currentColor">
           <path d="m8 5 11 7-11 7V5Z" />
         </svg>
       ) : (
-        <svg
-          aria-hidden="true"
-          className="size-4"
-          viewBox="0 0 24 24"
-          fill="currentColor"
-        >
+        <svg aria-hidden="true" viewBox="0 0 24 24" fill="currentColor">
           <rect x="6" y="5" width="4" height="14" rx="1" />
           <rect x="14" y="5" width="4" height="14" rx="1" />
         </svg>
@@ -3771,10 +3790,21 @@ export function WorkItemLifecycleStatus({
       openPullRequestLabel !== null &&
       lifecycleLabel.phase === "DECIDE_PR_MERGE" &&
       lifecycleLabel.status === "NEEDS_HUMAN"
-    const chipClassName = lifecycleStepChipClassName
+    const chipClassName = lifecycleStepChipClassNameForStatus(
+      lifecycleLabel.status,
+    )
+    // Only RUNNING chips take current-lane fill; needs-human/fail use Attention.
+    const chipLane =
+      lifecycleLabel.status === "RUNNING"
+        ? lifecycleLaneForPhase(lifecycleLabel.phase)
+        : null
+    const chipStyle =
+      chipLane !== null
+        ? (lifecycleLaneCssVars(chipLane) as CSSProperties)
+        : undefined
     const duration = displayDurationMs !== null && (
-      <span className="ml-1 font-mono text-ink-faint">
-        {formatDuration(displayDurationMs)}
+      <span className="ml-1 opacity-90">
+        · {formatDuration(displayDurationMs)}
       </span>
     )
     return (
@@ -3786,12 +3816,13 @@ export function WorkItemLifecycleStatus({
             target="_blank"
             rel="noopener noreferrer"
             aria-label={`${openPullRequestLabel}: ${lifecycleLabel.label}`}
+            style={chipStyle}
           >
             {lifecycleLabel.label}
             {duration}
           </a>
         ) : (
-          <span className={chipClassName}>
+          <span className={chipClassName} style={chipStyle}>
             {lifecycleLabel.label}
             {duration}
           </span>
@@ -3821,7 +3852,7 @@ export function WorkItemLifecycleStatus({
   return (
     <div className={compact ? "mt-2" : "field-rule mt-2 ml-11 px-3 py-2"}>
       <div className="flex flex-wrap items-center justify-between gap-2">
-        <span className="font-mono text-xs tracking-[0.1em] text-ink-faint uppercase">
+        <span className="job-ticket-runtime-line uppercase tracking-[0.1em]">
           {formatStartedAgo(workItem.createdAt, nowMs)}
         </span>
         <WorkItemOutcomePresentation
@@ -3846,11 +3877,15 @@ export function WorkItemLifecycleStatus({
                   block.durationMs === null
                     ? null
                     : formatDuration(block.durationMs)
+                const summaryStyle = lifecycleLaneCssVars(
+                  block.lane,
+                ) as CSSProperties
                 return (
                   <div key={block.lane} className="min-w-0">
                     <button
                       type="button"
-                      className="inline-flex max-w-full items-center gap-2 border border-rule-2 bg-paper px-1.5 py-1 text-xs text-ink-2 transition hover:border-oxblood hover:text-oxblood focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-oxblood"
+                      className="leg-summary"
+                      style={summaryStyle}
                       aria-expanded={block.expanded}
                       aria-controls={block.expanded ? chipsId : undefined}
                       onClick={() => toggleEarlierLane(block.lane)}
@@ -3859,11 +3894,7 @@ export function WorkItemLifecycleStatus({
                         {block.expanded ? "▾" : "▸"}
                       </span>
                       <span>{block.laneLabel}</span>
-                      {durationLabel !== null && (
-                        <span className="font-mono text-ink-faint">
-                          {durationLabel}
-                        </span>
-                      )}
+                      {durationLabel !== null && <span>· {durationLabel}</span>}
                     </button>
                     {block.expanded &&
                       renderChipList(block.chips, {
@@ -3891,7 +3922,12 @@ export function WorkItemLifecycleStatus({
           </div>
         ))}
       {workItem.statusMessage !== null && (
-        <p className={`mt-1.5 mb-0 text-xs ${statusMessageClassName}`}>
+        <p className={statusMessageClassName}>
+          {statusMessageClassName.includes("status-message--alarm") ? (
+            <span className="status-message-mark" aria-hidden="true">
+              ▲{" "}
+            </span>
+          ) : null}
           {workItem.statusMessage}
         </p>
       )}
@@ -3900,7 +3936,7 @@ export function WorkItemLifecycleStatus({
           {canReset && (
             <button
               type="button"
-              className="inline-flex size-7 items-center justify-center border border-rule-2 bg-panel text-oxblood transition hover:bg-oxblood-wash hover:text-oxblood-deep focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-oxblood disabled:cursor-wait disabled:opacity-60"
+              className="icon-btn icon-btn--armed"
               disabled={actionsPending}
               onClick={() => reset.mutate()}
               aria-label={reset.isPending ? "Resetting job" : "Reset job"}
@@ -3909,7 +3945,7 @@ export function WorkItemLifecycleStatus({
               {reset.isPending ? (
                 <svg
                   aria-hidden="true"
-                  className="size-4 animate-spin motion-reduce:animate-none"
+                  className="animate-spin motion-reduce:animate-none"
                   viewBox="0 0 24 24"
                   fill="none"
                 >
@@ -3932,7 +3968,6 @@ export function WorkItemLifecycleStatus({
               ) : (
                 <svg
                   aria-hidden="true"
-                  className="size-4"
                   viewBox="0 0 24 24"
                   fill="none"
                   stroke="currentColor"
@@ -3952,7 +3987,7 @@ export function WorkItemLifecycleStatus({
           {canRetry && (
             <button
               type="button"
-              className="border border-rule-2 bg-paper px-2.5 py-1 text-xs font-semibold text-ink-2 transition hover:border-oxblood hover:text-oxblood disabled:cursor-wait disabled:opacity-60"
+              className="plate-mini"
               disabled={actionsPending}
               onClick={() => retry.mutate()}
             >

--- a/apps/harness/src/styles.css
+++ b/apps/harness/src/styles.css
@@ -508,168 +508,439 @@
     border-top: 1px solid var(--color-rule-soft);
   }
 
+  /* ---------- Board shell + merged-PR stats (§4.2–4.4, §5, §6) ---------- */
+
   .industrial-shell {
-    --industrial-ink: #151515;
-    --industrial-paper: #f4f1e8;
-    --industrial-concrete: #dedbd2;
     margin-inline: auto;
   }
 
-  .industrial-shell > section[aria-label="Committed pull requests"] > article {
-    border: 2px solid var(--industrial-ink);
-    background: var(--industrial-paper);
-    box-shadow: 5px 5px 0 var(--industrial-ink);
+  /* §4.2 Merged-PR stats — light: paper panel; dark: departure-board slab */
+  .merged-pr-stats {
+    border: 2px solid var(--ink);
+    background: var(--panel);
+    color: var(--ink);
   }
 
+  [data-theme="dark"] .merged-pr-stats {
+    background: var(--mast-bg);
+    color: var(--mast-ink);
+  }
+
+  .merged-pr-stats-head {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.7rem;
+    padding: 0.5rem 0.9rem;
+    border-bottom: 1px solid var(--line-ghost);
+  }
+
+  [data-theme="dark"] .merged-pr-stats-head {
+    border-bottom-color: rgb(255 255 255 / 0.22);
+  }
+
+  .merged-pr-stats-tag {
+    background: var(--signal);
+    color: #151515;
+    font-family: var(--font-mono);
+    font-size: 0.6rem;
+    font-weight: 700;
+    letter-spacing: 0.16em;
+    text-transform: uppercase;
+    padding: 0.18rem 0.5rem;
+    white-space: nowrap;
+  }
+
+  .merged-pr-stats-title {
+    margin: 0;
+    font-family: var(--font-display);
+    font-size: 0.85rem;
+    font-weight: 600;
+    letter-spacing: 0.2em;
+    text-transform: uppercase;
+    color: inherit;
+  }
+
+  .merged-pr-stats-note {
+    margin-left: auto;
+    font-family: var(--font-mono);
+    font-size: 0.58rem;
+    letter-spacing: 0.14em;
+    color: var(--ink-faint);
+    text-transform: uppercase;
+  }
+
+  [data-theme="dark"] .merged-pr-stats-note {
+    color: var(--mast-faint);
+  }
+
+  .merged-pr-stats-grid {
+    display: grid;
+    grid-template-columns: repeat(5, minmax(0, 1fr));
+  }
+
+  .merged-pr-stats-cell {
+    display: grid;
+    gap: 0.15rem;
+    padding: 0.6rem 0.9rem 0.75rem;
+    border-left: 1px solid var(--line-ghost);
+  }
+
+  .merged-pr-stats-cell:first-child {
+    border-left: 0;
+  }
+
+  [data-theme="dark"] .merged-pr-stats-cell {
+    border-left-color: rgb(255 255 255 / 0.14);
+  }
+
+  [data-theme="dark"] .merged-pr-stats-cell:first-child {
+    border-left: 0;
+  }
+
+  .merged-pr-stats-num {
+    font-family: var(--font-display);
+    font-size: clamp(2.1rem, 3vw, 2.9rem);
+    font-weight: 700;
+    line-height: 1;
+    font-variant-numeric: tabular-nums;
+    color: inherit;
+  }
+
+  .merged-pr-stats-label {
+    font-family: var(--font-mono);
+    font-size: 0.6rem;
+    letter-spacing: 0.2em;
+    text-transform: uppercase;
+    color: var(--ink-faint);
+  }
+
+  [data-theme="dark"] .merged-pr-stats-label {
+    color: var(--mast-dim);
+  }
+
+  .merged-pr-stats-skeleton {
+    display: block;
+    height: 2.75rem;
+    margin: 0.55rem 0.15rem 0.7rem;
+    background: var(--line-ghost);
+  }
+
+  .merged-pr-stats-cell .merged-pr-stats-skeleton {
+    margin: 0.15rem 0;
+  }
+
+  [data-theme="dark"] .merged-pr-stats-skeleton {
+    background: rgb(255 255 255 / 0.1);
+  }
+
+  .merged-pr-stats-body {
+    padding: 0.55rem 0.7rem 0.7rem;
+  }
+
+  /* §4.3 Controls row — on paper, no panel fill */
   .pipeline-controls {
     display: flex;
     flex-wrap: wrap;
+    align-items: center;
     justify-content: space-between;
-    gap: 0.75rem;
-    padding: 0.75rem;
-    border: 2px solid var(--industrial-ink);
-    border-bottom: 0;
-    background: var(--industrial-paper);
+    gap: 0.8rem 1.5rem;
+    margin-top: 0;
+    padding: 0;
+    border: 0;
+    background: transparent;
   }
 
-  .pipeline-tabs,
-  .repository-filters,
-  .lane-switcher {
+  .pipeline-tabs {
     display: flex;
     min-width: 0;
     margin: 0;
     padding: 0;
     border: 0;
     flex-wrap: wrap;
-    gap: 0.35rem;
   }
 
-  .pipeline-tab,
-  .repository-filter,
-  .lane-switch {
-    border: 1px solid var(--industrial-ink);
-    background: transparent;
-    padding: 0.45rem 0.65rem;
-    color: var(--industrial-ink);
+  .repository-filters {
+    display: flex;
+    min-width: 0;
+    margin: 0;
+    padding: 0;
+    border: 0;
+    flex-wrap: wrap;
+  }
+
+  .pipeline-tab {
+    appearance: none;
+    background: var(--paper);
+    border: 2px solid var(--ink);
+    margin-left: -2px;
+    padding: 0.5rem 1rem;
+    color: var(--ink-dim);
+    font-family: var(--font-display);
+    font-size: 0.72rem;
+    font-weight: 700;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    cursor: pointer;
+  }
+
+  .pipeline-tab:first-child {
+    margin-left: 0;
+  }
+
+  .pipeline-tab:hover {
+    color: var(--ink);
+    position: relative;
+  }
+
+  .pipeline-tab[aria-selected="true"] {
+    background: var(--ink);
+    color: var(--paper);
+    position: relative;
+  }
+
+  .repository-filter {
+    appearance: none;
+    background: var(--paper);
+    border: 1px solid var(--line-soft);
+    margin-left: -1px;
+    padding: 0.42rem 0.75rem;
+    color: var(--ink-faint);
     font-family: var(--font-mono);
-    font-size: 0.66rem;
-    font-weight: 800;
-    line-height: 1;
+    font-size: 0.62rem;
     letter-spacing: 0.04em;
     text-transform: uppercase;
+    cursor: pointer;
   }
 
-  .pipeline-tab:hover,
-  .repository-filter:hover,
-  .lane-switch:hover {
-    background: var(--color-paper-3);
+  .repository-filter:first-child {
+    margin-left: 0;
   }
 
-  .pipeline-tab[aria-selected="true"],
-  .repository-filter[aria-pressed="true"],
-  .lane-switch[aria-pressed="true"] {
-    background: var(--industrial-ink);
-    color: var(--industrial-paper);
+  .repository-filter:hover {
+    border-color: var(--ink);
+    color: var(--ink);
+    position: relative;
   }
 
+  .repository-filter[aria-pressed="true"] {
+    border-color: var(--ink);
+    color: var(--ink);
+    font-weight: 700;
+    position: relative;
+    box-shadow: inset 0 -3px 0 var(--ink);
+  }
+
+  /* §4.3 Network — six platforms on a route line */
   .pipeline-board {
+    position: relative;
+    margin-top: 1.6rem;
+    padding-top: 1.15rem;
     display: grid;
     grid-template-columns: repeat(6, minmax(0, 1fr));
-    border: 2px solid var(--industrial-ink);
-    background: var(--industrial-ink);
-    gap: 2px;
+    gap: 0.9rem;
+    align-items: start;
+    border: 0;
+    background: transparent;
+  }
+
+  .pipeline-board::before {
+    content: "";
+    position: absolute;
+    top: calc(1.15rem + 1.05rem - 2px);
+    left: calc(100% / 12);
+    right: calc(100% / 12);
+    height: 4px;
+    background: var(--ink);
+    pointer-events: none;
   }
 
   .pipeline-lane {
+    position: relative;
+    z-index: 1;
     min-width: 0;
-    min-height: 23rem;
-    background: var(--industrial-concrete);
+    min-height: 0;
+    background: transparent;
+  }
+
+  /* Nameboard stack: roundel + header. Sticky unit ≤1500px so badge pins with title. */
+  .lane-chrome {
+    position: relative;
+  }
+
+  .lane-roundel {
+    margin: 0 auto;
+    width: 2.1rem;
+    height: 2.1rem;
+    display: grid;
+    place-items: center;
+    border-radius: 50%;
+    background: var(--lane-color);
+    color: var(--lane-text, #fff);
+    border: 2px solid var(--ink);
+    font-family: var(--font-mono);
+    font-size: 0.68rem;
+    font-weight: 700;
+    letter-spacing: 0.02em;
+  }
+
+  .pipeline-lane[data-lane="complete"] .lane-roundel {
+    border-color: #fff;
+    outline: 2px solid var(--ink);
   }
 
   .lane-header {
     position: sticky;
     top: 0;
     z-index: 5;
+    margin-top: 0.45rem;
     display: flex;
-    align-items: end;
-    justify-content: space-between;
-    min-height: 5.25rem;
-    padding: 0.7rem;
-    border-bottom: 2px solid var(--industrial-ink);
+    align-items: baseline;
+    gap: 0.5rem;
+    min-height: 0;
+    padding: 0.42rem 0.65rem 0.48rem;
+    border: 2px solid var(--ink);
+    border-bottom: 2px solid var(--ink);
     background: var(--lane-color);
-    color: var(--lane-text, white);
+    color: var(--lane-text, #fff);
   }
 
-  .lane-number {
-    display: block;
-    margin-bottom: 0.3rem;
-    font-family: var(--font-mono);
-    font-size: 0.58rem;
-    font-weight: 800;
-    line-height: 1;
-    opacity: 0.75;
+  .pipeline-lane[data-lane="complete"] .lane-header {
+    box-shadow: inset 0 0 0 1px var(--merged-halo);
   }
 
   .lane-title {
     margin: 0;
-    font-size: 1.2rem;
-    font-weight: 950;
-    line-height: 0.85;
-    letter-spacing: -0.04em;
+    font-family: var(--font-display);
+    font-size: 1.05rem;
+    font-weight: 800;
+    line-height: 1.1;
+    letter-spacing: 0.07em;
     text-transform: uppercase;
   }
 
   .lane-count {
-    font-family: var(--font-mono);
-    font-size: 2rem;
-    font-weight: 950;
-    line-height: 0.8;
+    margin-left: auto;
+    font-family: var(--font-display);
+    font-size: 1.5rem;
+    font-weight: 800;
+    line-height: 1;
+    font-variant-numeric: tabular-nums;
+  }
+
+  /* Open white platform — no grey fills */
+  .lane-platform {
+    border: 1.5px solid var(--ink);
+    border-top: 0;
+    padding: 0.65rem;
+    display: grid;
+    gap: 0.65rem;
+    align-content: start;
+    min-height: 9rem;
+    background: transparent;
   }
 
   .lane-stack {
     display: grid;
     align-content: start;
-    gap: 0.55rem;
-    padding: 0.55rem;
+    gap: 0.65rem;
+    margin: 0;
+    padding: 0;
+    list-style: none;
   }
 
   .lane-empty {
-    margin: 0.5rem;
-    padding-top: 1rem;
-    border-top: 1px dashed #777;
-    color: #666;
+    margin: 0;
+    padding: 1.6rem 0.4rem;
+    text-align: center;
+    border: 0;
+    color: var(--ink-faint);
     font-family: var(--font-mono);
-    font-size: 0.67rem;
-    font-weight: 700;
+    font-size: 0.62rem;
+    font-weight: 400;
     line-height: 1.4;
+    letter-spacing: 0.26em;
     text-transform: uppercase;
   }
 
+  /* §6 Queue discoverability hint — always at foot of Queue platform */
+  .queue-hint {
+    display: grid;
+    gap: 0.45rem;
+    border: 2px solid var(--ink);
+    background: var(--lane-queue);
+    padding: 0.65rem 0.7rem;
+    color: #151515;
+  }
+
+  .queue-hint-tag {
+    justify-self: start;
+    background: #151515;
+    color: var(--lane-queue);
+    font-family: var(--font-mono);
+    font-size: 0.56rem;
+    font-weight: 700;
+    letter-spacing: 0.16em;
+    text-transform: uppercase;
+    padding: 0.16rem 0.4rem;
+  }
+
+  .queue-hint-text {
+    margin: 0;
+    font-family: var(--font-display);
+    font-size: 0.82rem;
+    font-weight: 500;
+    line-height: 1.35;
+    color: #151515;
+  }
+
+  .queue-hint-link {
+    justify-self: start;
+    font-family: var(--font-mono);
+    font-size: 0.62rem;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: #151515;
+    text-decoration: underline;
+    text-decoration-thickness: 1.5px;
+    text-underline-offset: 3px;
+  }
+
+  .queue-hint-link:hover {
+    background: #151515;
+    color: var(--lane-queue);
+    text-decoration: none;
+  }
+
+  /* §4.4 Job tickets */
   .job-ticket {
     position: relative;
     min-width: 0;
-    border: 2px solid var(--industrial-ink);
-    background: var(--industrial-paper);
-    padding: 0.65rem;
-    box-shadow: 2px 2px 0 var(--industrial-ink);
+    display: grid;
+    gap: 0.4rem;
+    border: 1.5px solid var(--ink);
+    border-radius: 0;
+    background: var(--panel);
+    padding: 0.55rem 0.65rem 0.7rem 0.95rem;
+    box-shadow: inset 6px 0 0 var(--ticket-color, var(--ink));
   }
 
-  .job-ticket::before {
-    content: "";
-    position: absolute;
-    inset: 0 auto 0 0;
-    width: 4px;
-    background: var(--ticket-color, var(--industrial-ink));
+  .job-ticket[data-lane="complete"] {
+    box-shadow:
+      inset 6px 0 0 var(--ticket-color, var(--lane-merged)),
+      inset 8px 0 0 var(--merged-halo);
   }
 
   .job-ticket-repo {
-    margin: 0 0 0.4rem 0.35rem;
+    margin: 0;
     overflow: hidden;
-    color: var(--color-ink-faint);
+    color: var(--ink-faint);
     font-family: var(--font-mono);
-    font-size: 0.68rem;
-    font-weight: 800;
-    line-height: 1;
+    font-size: 0.58rem;
+    font-weight: 400;
+    line-height: 1.2;
+    letter-spacing: 0.1em;
     text-overflow: ellipsis;
     text-transform: uppercase;
     white-space: nowrap;
@@ -677,63 +948,407 @@
 
   .job-ticket-title {
     display: block;
-    margin-left: 0.35rem;
+    margin: 0;
     overflow-wrap: anywhere;
-    color: var(--industrial-ink);
-    font-size: 0.76rem;
-    font-weight: 800;
-    line-height: 1.25;
+    color: var(--ink);
+    font-family: var(--font-display);
+    font-size: 0.9rem;
+    font-weight: 500;
+    line-height: 1.28;
     text-decoration: none;
   }
 
-  .job-ticket-title:hover {
-    color: var(--color-oxblood);
+  .job-ticket-title .job-ticket-num {
+    font-family: var(--font-mono);
+    font-size: 0.72rem;
+    color: var(--ink-dim);
+  }
+
+  a.job-ticket-title:hover {
+    color: var(--ink);
     text-decoration: underline;
     text-decoration-thickness: 2px;
+    text-underline-offset: 3px;
+    text-decoration-color: var(--signal);
+  }
+
+  .job-ticket-status {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.4rem;
   }
 
   .job-ticket-state {
     display: inline-block;
-    margin: 0.55rem 0 0 0.35rem;
-    border: 1px solid currentColor;
-    padding: 0.2rem 0.35rem;
-    font-family: var(--font-mono);
-    font-size: 0.65rem;
-    font-weight: 800;
-    line-height: 1;
-    letter-spacing: 0.04em;
-    text-transform: uppercase;
+    margin: 0;
   }
 
   .job-ticket-runtime {
     display: grid;
-    gap: 0.25rem;
-    margin-top: 0.5rem;
-    padding-top: 0.5rem;
-    border-top: 1px solid rgb(21 21 21 / 20%);
+    gap: 0.2rem;
+    margin-top: 0;
+    padding-top: 0;
+    border-top: 0;
+  }
+
+  .job-ticket-runtime-line {
+    margin: 0;
+    min-width: 0;
+    overflow: hidden;
+    color: var(--ink-faint);
+    font-family: var(--font-mono);
+    font-size: 0.6rem;
+    line-height: 1.35;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .job-ticket-session {
+    color: var(--ink-dim);
+    text-decoration: underline;
+    text-underline-offset: 2px;
+    background: transparent;
+    border: 0;
+    padding: 0;
+    font: inherit;
+    cursor: pointer;
+  }
+
+  .job-ticket-session:hover {
+    color: var(--ink);
   }
 
   .pipeline-list {
-    border: 2px solid var(--industrial-ink);
-    background: var(--industrial-concrete);
+    margin-top: 1.5rem;
+    border: 2px solid var(--ink);
+    background: var(--panel);
     padding: 0.75rem;
     grid-template-columns: repeat(auto-fit, minmax(min(100%, 18rem), 1fr));
   }
 
   .pipeline-list-empty {
-    margin: 0;
-    border: 2px solid var(--industrial-ink);
-    background: var(--industrial-concrete);
-    padding: 1.5rem;
-    color: var(--color-ink-faint);
+    margin: 1.5rem 0 0;
+    border: 0;
+    background: transparent;
+    padding: 1.6rem 0.4rem;
+    color: var(--ink-faint);
     font-family: var(--font-mono);
-    font-size: 0.75rem;
-    font-weight: 700;
+    font-size: 0.62rem;
+    font-weight: 400;
+    letter-spacing: 0.2em;
+    text-align: center;
     text-transform: uppercase;
   }
 
+  /* Mobile lane switcher hidden on desktop */
   .lane-switcher {
     display: none;
+    min-width: 0;
+    margin: 0;
+    padding: 0;
+    border: 0;
+  }
+
+  .lane-switch {
+    appearance: none;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.35rem;
+    min-width: 0;
+    border: 2px solid var(--ink);
+    background-color: var(--plate);
+    background-image:
+      radial-gradient(
+        circle 1.4px at 6px 6px,
+        var(--plate-rivet) 1.4px,
+        transparent 1.9px
+      ),
+      radial-gradient(
+        circle 1.4px at calc(100% - 6px) 6px,
+        var(--plate-rivet) 1.4px,
+        transparent 1.9px
+      );
+    box-shadow:
+      inset 0 1px 0 var(--plate-hi),
+      inset 0 -2px 0 var(--plate-lo);
+    padding: 0.46rem 0.5rem;
+    color: var(--plate-ink);
+    font-family: var(--font-mono);
+    font-size: 0.62rem;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    cursor: pointer;
+  }
+
+  .lane-switch-swatch {
+    width: 0.55rem;
+    height: 0.55rem;
+    flex-shrink: 0;
+    background: var(--lane-color, var(--ink));
+    border: 1px solid var(--ink);
+  }
+
+  .lane-switch:hover {
+    background-color: var(--plate-hover);
+  }
+
+  .lane-switch[aria-pressed="true"] {
+    background: var(--ink);
+    background-image: none;
+    color: var(--paper);
+    box-shadow: none;
+  }
+
+  .lane-switch[aria-pressed="true"] .lane-switch-swatch {
+    border-color: var(--paper);
+  }
+
+  /* §5.1 Status tags */
+  .status-tag {
+    display: inline-flex;
+    align-items: center;
+    border: 1.5px solid var(--ink);
+    padding: 0.18rem 0.4rem;
+    font-family: var(--font-mono);
+    font-size: 0.56rem;
+    font-weight: 700;
+    letter-spacing: 0.12em;
+    line-height: 1.2;
+    text-transform: uppercase;
+    white-space: nowrap;
+    color: var(--ink-dim);
+    background: transparent;
+    text-decoration: none;
+  }
+
+  .status-tag--alarm {
+    background: var(--lane-attention);
+    border-color: var(--lane-attention);
+    color: #151515;
+  }
+
+  .status-tag--hold {
+    border-style: dashed;
+    color: var(--ink-dim);
+  }
+
+  .status-tag--complete {
+    background: var(--ink);
+    border-color: var(--ink);
+    color: var(--paper);
+  }
+
+  .status-tag--ghost {
+    border-style: dashed;
+    border-color: var(--ink-faint);
+    color: var(--ink-dim);
+  }
+
+  .status-tag--plain {
+    color: var(--ink-dim);
+  }
+
+  .status-message {
+    margin: 0.35rem 0 0;
+    font-family: var(--font-mono);
+    font-size: 0.6rem;
+    color: var(--ink-dim);
+  }
+
+  /* Alarm body = ink (≥4.5:1); Attention only on the ▲ mark (§5.1) */
+  .status-message--alarm {
+    color: var(--ink);
+  }
+
+  .status-message-mark {
+    color: var(--lane-attention);
+  }
+
+  /* §5.2 Journey-leg chips */
+  .leg {
+    display: inline-flex;
+    align-items: center;
+    font-family: var(--font-mono);
+    font-size: 0.56rem;
+    letter-spacing: 0.06em;
+    border: 1.5px solid var(--ink);
+    color: var(--ink-dim);
+    padding: 0.16rem 0.38rem;
+    white-space: nowrap;
+    background: transparent;
+    text-decoration: none;
+  }
+
+  .leg--done {
+    background: var(--ink);
+    color: var(--paper);
+    border-color: var(--ink);
+  }
+
+  .leg--run {
+    background: var(--leg-lane, var(--lane-build));
+    color: var(--leg-on, #fff);
+    border-color: var(--ink);
+  }
+
+  .leg--next {
+    border-style: dashed;
+    color: var(--ink-faint);
+  }
+
+  .leg--fail {
+    background: var(--lane-attention);
+    color: #151515;
+    border-color: var(--lane-attention);
+    font-weight: 700;
+  }
+
+  .leg--lane {
+    background: var(--leg-lane, var(--ink));
+    color: var(--leg-on, #fff);
+    border-color: var(--ink);
+  }
+
+  .leg-summary {
+    display: inline-flex;
+    max-width: 100%;
+    align-items: center;
+    gap: 0.35rem;
+    border: 1.5px solid var(--ink);
+    background: var(--leg-lane, var(--lane-build));
+    color: var(--leg-on, #fff);
+    padding: 0.16rem 0.38rem;
+    font-family: var(--font-mono);
+    font-size: 0.56rem;
+    font-weight: 700;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    white-space: nowrap;
+    cursor: pointer;
+  }
+
+  .leg-summary:hover {
+    filter: brightness(1.05);
+  }
+
+  /* §5.4 Icon buttons */
+  .icon-btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 1.75rem;
+    height: 1.75rem;
+    flex-shrink: 0;
+    border: 1px solid var(--line-ghost);
+    background: transparent;
+    color: var(--ink-faint);
+    padding: 0;
+    cursor: pointer;
+    transition:
+      border-color 120ms ease,
+      color 120ms ease,
+      background-color 120ms ease;
+  }
+
+  .icon-btn:hover {
+    border-color: var(--ink);
+    color: var(--ink);
+  }
+
+  .icon-btn:disabled {
+    cursor: wait;
+    opacity: 0.55;
+  }
+
+  .icon-btn--armed {
+    border: 1.5px solid var(--lane-attention);
+    color: var(--lane-attention);
+  }
+
+  .icon-btn--armed:hover {
+    background: var(--lane-attention);
+    color: #151515;
+  }
+
+  /* Paused job control: full ink so play glyph is glanceable (§5.4 ghost + ink) */
+  .icon-btn--paused {
+    border-color: var(--ink);
+    color: var(--ink);
+  }
+
+  .icon-btn--copied {
+    color: var(--lane-pr);
+    border-color: var(--lane-pr);
+  }
+
+  .icon-btn svg {
+    width: 0.9rem;
+    height: 0.9rem;
+  }
+
+  /* §5.5 PR badge */
+  .pr-badge {
+    display: inline-flex;
+    align-items: center;
+    border: 1px solid var(--prbadge-border);
+    background: var(--prbadge-bg);
+    color: var(--prbadge-ink);
+    font-family: var(--font-mono);
+    font-size: 0.62rem;
+    font-weight: 700;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    text-decoration: none;
+    padding: 0.2rem 0.5rem;
+    white-space: nowrap;
+  }
+
+  .pr-badge:hover {
+    background: var(--lane-pr);
+    border-color: transparent;
+    color: #fff;
+  }
+}
+
+/* ≤1500px: hide route line; roundel becomes nameboard badge on sticky chrome */
+@media (max-width: 1500px) {
+  .pipeline-board {
+    padding-top: 0;
+    margin-top: 1.2rem;
+  }
+
+  .pipeline-board::before {
+    display: none;
+  }
+
+  .lane-chrome {
+    position: sticky;
+    top: 0;
+    z-index: 5;
+  }
+
+  .lane-roundel {
+    position: absolute;
+    top: 0.35rem;
+    left: 0.45rem;
+    z-index: 6;
+    width: 1.4rem;
+    height: 1.4rem;
+    margin: 0;
+    font-size: 0.55rem;
+  }
+
+  .pipeline-lane[data-lane="complete"] .lane-roundel {
+    outline-width: 1px;
+  }
+
+  .lane-header {
+    position: static;
+    margin-top: 0;
+    padding-left: 2.1rem;
   }
 }
 
@@ -751,6 +1366,22 @@
     min-width: 0;
   }
 
+  .merged-pr-stats-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .merged-pr-stats-cell:nth-child(odd) {
+    border-left: 0;
+  }
+
+  .merged-pr-stats-cell:nth-child(n + 3) {
+    border-top: 1px solid var(--line-ghost);
+  }
+
+  [data-theme="dark"] .merged-pr-stats-cell:nth-child(n + 3) {
+    border-top-color: rgb(255 255 255 / 0.14);
+  }
+
   .repository-filters {
     width: 100%;
     max-width: 100%;
@@ -759,7 +1390,7 @@
     overscroll-behavior-inline: contain;
     padding-bottom: 0.45rem;
     scroll-snap-type: inline proximity;
-    scrollbar-color: var(--industrial-ink) var(--industrial-concrete);
+    scrollbar-color: var(--ink) var(--panel);
     scrollbar-width: thin;
     touch-action: pan-x;
   }
@@ -774,10 +1405,11 @@
     width: 100%;
     max-width: 100%;
     grid-template-columns: repeat(3, minmax(0, 1fr));
-    padding: 0.55rem;
-    border: 2px solid var(--industrial-ink);
-    border-bottom: 0;
-    background: var(--industrial-concrete);
+    gap: 0.35rem;
+    margin-top: 1rem;
+    padding: 0;
+    border: 0;
+    background: transparent;
   }
 
   .lane-switch {
@@ -789,6 +1421,8 @@
 
   .pipeline-board {
     display: block;
+    margin-top: 0.85rem;
+    padding-top: 0;
   }
 
   .pipeline-lane {
@@ -802,6 +1436,6 @@
 
   .lane-header {
     position: static;
-    min-height: 4rem;
+    min-height: 0;
   }
 }

--- a/apps/harness/src/work-item-outcome-presentation.tsx
+++ b/apps/harness/src/work-item-outcome-presentation.tsx
@@ -44,7 +44,7 @@ export function WorkItemOutcomePresentation({
               rel="noopener noreferrer"
               aria-label={openPullRequestLabel ?? undefined}
             >
-              PR #{prNumber}
+              PR #{prNumber} ↗
             </a>
           )}
         {!isNoChangeComplete &&

--- a/apps/harness/src/work-item-progress-chrome.ts
+++ b/apps/harness/src/work-item-progress-chrome.ts
@@ -1,41 +1,97 @@
 /**
- * Shared Jobs card progress chrome: lifecycle chips, status badges, PR badges.
- * Minimum type size is Tailwind `text-xs` (0.75rem) — no sub-xs rem utilities.
+ * Shared Jobs progress chrome: lifecycle chips, status tags, PR badges.
+ * Interchange component classes (§5.1–5.2, §5.5). Board density floors at
+ * 0.56rem mono; prefer CSS classes over Tailwind rem utilities.
  */
+import type { LifecyclePipelineLaneId } from "./pipeline-lanes.js"
+
+/** @deprecated Prefer CSS component classes; kept for test/source compatibility. */
 export const jobsProgressMinTextClassName = "text-xs"
 
-export const lifecycleStepChipClassName = `border border-rule-2 bg-paper px-1.5 py-1 ${jobsProgressMinTextClassName} text-ink-2`
+export const lifecycleStepChipClassName = "leg leg--done"
 
-export const statusBadgeBaseClassName = `inline-flex items-center border px-2 py-0.5 ${jobsProgressMinTextClassName} font-bold tracking-wide uppercase`
+export const statusBadgeBaseClassName = "status-tag"
 
-export const prBadgeClassName = `stamp border-rule-2 ${jobsProgressMinTextClassName} text-ink-2 no-underline hover:border-oxblood hover:text-oxblood hover:underline`
+export const prBadgeClassName = "pr-badge"
+
+const LANE_STYLE: Record<
+  LifecyclePipelineLaneId,
+  { readonly lane: string; readonly on: string }
+> = {
+  build: { lane: "var(--lane-build)", on: "var(--lane-build-ink)" },
+  review: { lane: "var(--lane-review)", on: "var(--lane-review-ink)" },
+  pr: { lane: "var(--lane-pr)", on: "var(--lane-pr-ink)" },
+}
 
 /**
- * Badge tone by operator-visible status.
- * Waiting for blockers (Queue hold) is teal — distinct from violet Waiting for
- * Worker Slot and from bare Step Run / Agent Turn Queued (oxblood default).
+ * CSS custom properties for a lifecycle lane's chip / summary fill pair.
+ * Used for running journey legs and lane-colored collapsed summaries.
+ */
+export function lifecycleLaneCssVars(lane: LifecyclePipelineLaneId): {
+  readonly "--leg-lane": string
+  readonly "--leg-on": string
+} {
+  const style = LANE_STYLE[lane]
+  return { "--leg-lane": style.lane, "--leg-on": style.on }
+}
+
+/**
+ * Badge tone by operator-visible status (§5.1).
+ * Hold statuses share dashed treatment; alarms share Attention fill.
  */
 export function statusBadgeClassNameForStatus(status: string): string {
   const tone =
-    status === "FAILED" || status === "INTERRUPTED"
-      ? "border-oxblood/40 bg-oxblood-wash text-oxblood"
+    status === "FAILED" ||
+    status === "INTERRUPTED" ||
+    status === "NEEDS_HUMAN" ||
+    status === "NEEDS_HUMAN_REVIEW"
+      ? "status-tag--alarm"
       : status === "COMPLETE" || status === "SUCCEEDED"
-        ? "border-olive/40 bg-olive-wash text-olive"
+        ? "status-tag--complete"
         : status === "ABANDONED" || status === "CANCELLED"
-          ? "border-rule-2 bg-paper-2 text-ink-faint"
-          : status === "NEEDS_HUMAN" || status === "NEEDS_HUMAN_REVIEW"
-            ? "border-sepia/40 bg-amber-wash text-sepia"
-            : status === "WAITING_FOR_WORKER_SLOT"
-              ? "border-violet-300 bg-violet-wash text-violet-800"
-              : status === "WAITING_FOR_BLOCKERS"
-                ? "border-teal/40 bg-teal-wash text-teal"
-                : "border-oxblood/30 bg-oxblood-wash text-oxblood"
+          ? "status-tag--ghost"
+          : status === "WAITING_FOR_WORKER_SLOT" ||
+              status === "WAITING_FOR_BLOCKERS"
+            ? "status-tag--hold"
+            : "status-tag--plain"
   return `${statusBadgeBaseClassName} ${tone}`
 }
 
-/** Message line tone under the status badge (wait holds vs failure copy). */
+/**
+ * Journey-leg chip class for a step status (§5.2 board treatment).
+ * Running chips also need `lifecycleLaneCssVars` for current-lane fill.
+ * Needs-human steps share the Attention fill with failures (status tags
+ * already use alarm); they are not lane-colored "in progress" fills.
+ * DECIDE_PR_MERGE still links externally via call-site markup.
+ */
+export function lifecycleStepChipClassNameForStatus(status: string): string {
+  if (
+    status === "FAILED" ||
+    status === "INTERRUPTED" ||
+    status === "NEEDS_HUMAN" ||
+    status === "NEEDS_HUMAN_REVIEW"
+  ) {
+    return "leg leg--fail"
+  }
+  if (status === "RUNNING") {
+    return "leg leg--run"
+  }
+  if (status === "SUCCEEDED" || status === "COMPLETE") {
+    return "leg leg--done"
+  }
+  // QUEUED / unreached / other holds
+  return "leg leg--next"
+}
+
+/** Message line under the status tag (§5.1). Alarm statuses get ▲ via CSS. */
 export function statusMessageClassNameForStatus(status: string): string {
-  if (status === "WAITING_FOR_WORKER_SLOT") return "text-violet-800"
-  if (status === "WAITING_FOR_BLOCKERS") return "text-teal"
-  return "text-oxblood-deep"
+  if (
+    status === "FAILED" ||
+    status === "INTERRUPTED" ||
+    status === "NEEDS_HUMAN" ||
+    status === "NEEDS_HUMAN_REVIEW"
+  ) {
+    return "status-message status-message--alarm"
+  }
+  return "status-message"
 }

--- a/apps/harness/src/work-item-progress-chrome.ts
+++ b/apps/harness/src/work-item-progress-chrome.ts
@@ -5,9 +5,6 @@
  */
 import type { LifecyclePipelineLaneId } from "./pipeline-lanes.js"
 
-/** @deprecated Prefer CSS component classes; kept for test/source compatibility. */
-export const jobsProgressMinTextClassName = "text-xs"
-
 export const lifecycleStepChipClassName = "leg leg--done"
 
 export const statusBadgeBaseClassName = "status-tag"

--- a/apps/harness/test/committed-pr-dashboard.test.ts
+++ b/apps/harness/test/committed-pr-dashboard.test.ts
@@ -309,11 +309,19 @@ describe("Committed pull requests dashboard UI", () => {
     expect(source).toContain('aria-label="Loading committed pull requests"')
     expect(source).toContain('role="status"')
     expect(source).toContain('aria-busy="true"')
-    expect(source).toContain("grid-cols-5")
+    expect(source).toContain("merged-pr-stats-grid")
+    expect(source).toContain("merged-pr-stats-skeleton")
     expect(source).toContain(
       "Could not load committed pull requests. Please try again.",
     )
     expect(source).toContain('role="alert"')
+    // Failure banner sits inside the stats panel (§4.2).
+    const failedBranch = source.slice(
+      source.indexOf("if (failed)"),
+      source.indexOf("const today = todayQuery.data"),
+    )
+    expect(failedBranch).toContain('className="merged-pr-stats"')
+    expect(failedBranch).toContain("banner--compact")
     // Board mounts dashboard as a sibling of the pipeline (no Suspense around it).
     expect(board).toContain("<CommittedPullRequestsDashboard />")
     expect(board).toContain("<KanbanJobsBoard />")
@@ -352,6 +360,8 @@ describe("Committed pull requests dashboard UI", () => {
     expect(dashboard).toContain("{thisWeek}")
     expect(dashboard).toContain("{lastWeek}")
     expect(dashboard).toContain("{twoWeeksAgo}")
+    expect(dashboard).toContain("Merged PR throughput")
+    expect(dashboard).toContain("merged-pr-stats")
   })
 
   test("board shows PR dashboard and pipeline; zero repos use blank slate", () => {

--- a/apps/harness/test/kanban-route.test.ts
+++ b/apps/harness/test/kanban-route.test.ts
@@ -131,7 +131,14 @@ describe("kanban home board", () => {
     expect(source).toContain('aria-label="Lifecycle pipeline"')
     expect(source).toContain("pipelineLaneFor(workItem)")
     expect(source).toContain("Lane clear")
+    // Mobile switcher + nameboard each render {lane.label}.
     expect(source.match(/\{lane\.label\}/g)).toHaveLength(2)
+    expect(source).toContain("lane-roundel")
+    expect(source).toContain("lane-platform")
+    expect(source).toContain("queue-hint")
+    expect(source).toContain("Feed the queue — work starts at your repos.")
+    expect(source).toContain("Manage repos →")
+    expect(source).toContain('to="/repos"')
   })
 
   test("retains accessible two-tab control, keyboard navigation, and repository filtering", () => {
@@ -385,16 +392,30 @@ describe("kanban home board", () => {
   })
 
   test("keeps the six-column board and sticky lane headers on desktop", () => {
-    const desktopStyles = stylesSource().split("@media (max-width: 900px)")[0]
+    // Strip the ≤1500px roundel fallback and the ≤900px mobile block.
+    const styles = stylesSource()
+    const desktopStyles = styles.split("@media (max-width: 1500px)")[0]
     expect(desktopStyles).toContain(".pipeline-board")
     expect(desktopStyles).toContain(
       "grid-template-columns: repeat(6, minmax(0, 1fr))",
     )
+    expect(desktopStyles).toContain(".pipeline-board::before")
+    expect(desktopStyles).toContain(".lane-roundel")
+    expect(desktopStyles).toContain(".lane-chrome")
+    expect(desktopStyles).toContain(".lane-platform")
     expect(desktopStyles).toContain(".lane-header")
     expect(desktopStyles).toContain("position: sticky")
     expect(desktopStyles).toContain(".job-ticket")
+    expect(desktopStyles).toContain("inset 6px 0 0")
     expect(desktopStyles).toContain(".lane-switcher")
     expect(desktopStyles).toContain("display: none")
+    expect(desktopStyles).toContain(".queue-hint")
+    expect(desktopStyles).not.toContain("--industrial-concrete")
+    // ≤1500px pins the nameboard stack (chrome), not a free-floating absolute roundel alone.
+    const midStyles = stylesSource().split("@media (max-width: 1500px)")[1]
+    expect(midStyles).toBeDefined()
+    expect(midStyles).toContain(".lane-chrome")
+    expect(midStyles).toContain("position: sticky")
   })
 
   test("uses full viewport chrome on every route; home board stays uncapped under header", () => {

--- a/apps/harness/test/waiting-for-blockers-working-row.test.ts
+++ b/apps/harness/test/waiting-for-blockers-working-row.test.ts
@@ -15,31 +15,26 @@ const stylesSource = () =>
   readFileSync(join(import.meta.dir, "../src/styles.css"), "utf8")
 
 describe("Waiting for blockers Working-row polish", () => {
-  test("badge chrome uses teal for blockers, violet for worker slot, oxblood for Queued", () => {
+  test("badge chrome uses Interchange hold tags for blockers and worker slot", () => {
+    // Spec §5.1: both holds share dashed status-tag--hold; distinction is the label.
     const chrome = chromeSource()
     expect(chrome).toContain('status === "WAITING_FOR_WORKER_SLOT"')
     expect(chrome).toContain('status === "WAITING_FOR_BLOCKERS"')
-    expect(chrome).toContain("bg-teal-wash text-teal")
-    expect(chrome).toContain("bg-violet-wash text-violet-800")
-    expect(chrome).toContain("bg-oxblood-wash text-oxblood")
-    // Shared violet for both wait holds must not remain.
-    expect(chrome).not.toMatch(
-      /WAITING_FOR_WORKER_SLOT\s*\|\|\s*\n?\s*status === "WAITING_FOR_BLOCKERS"/,
-    )
-    expect(stylesSource()).toContain("--color-teal:")
-    expect(stylesSource()).toContain("--color-teal-wash:")
+    expect(chrome).toContain("status-tag--hold")
+    expect(chrome).toContain("status-tag--plain")
+    expect(chrome).toContain("status-tag--alarm")
+    expect(stylesSource()).toContain(".status-tag--hold")
+    expect(stylesSource()).toContain("border-style: dashed")
   })
 
-  test("status message uses distinct wait-hold tones via shared helper", () => {
+  test("status message uses shared helper with alarm prefix for failures", () => {
     const source = homeSource()
     expect(source).toContain("statusMessageClassNameForStatus")
     expect(source).toContain("statusMessageClassName")
     expect(chromeSource()).toContain(
       "export function statusMessageClassNameForStatus",
     )
-    expect(chromeSource()).toContain(
-      'if (status === "WAITING_FOR_BLOCKERS") return "text-teal"',
-    )
+    expect(chromeSource()).toContain("status-message--alarm")
   })
 
   test("Pause/Start control is omitted while Waiting for blockers", () => {

--- a/apps/harness/test/work-item-outcome-presentation.test.tsx
+++ b/apps/harness/test/work-item-outcome-presentation.test.tsx
@@ -48,14 +48,11 @@ describe("WorkItemOutcomePresentation", () => {
       />,
     )
 
-    expect(html).toContain("PR #17")
+    expect(html).toContain("PR #17 ↗")
     expect(html).toContain('href="https://github.com/acme/widgets/pull/17"')
     expect(html).toContain("Open pull request #17")
     expect(html).toContain("Complete")
     expect(html).toContain(prBadgeClassName)
-    expect(html).toContain("text-xs")
-    expect(html).not.toContain("0.65rem")
-    expect(html).not.toContain("0.6rem")
     expect(html).not.toContain("Issue closed without repository changes")
     expect(html).not.toContain('aria-label="Completion summary"')
   })

--- a/apps/harness/test/work-item-progress-chrome.test.ts
+++ b/apps/harness/test/work-item-progress-chrome.test.ts
@@ -1,6 +1,6 @@
 import {
-  jobsProgressMinTextClassName,
   lifecycleStepChipClassName,
+  lifecycleStepChipClassNameForStatus,
   prBadgeClassName,
   statusBadgeBaseClassName,
   statusBadgeClassNameForStatus,
@@ -8,67 +8,79 @@ import {
 } from "../src/work-item-progress-chrome.js"
 import { describe, expect, test } from "bun:test"
 
-const forbiddenSubXsRem = ["0.6rem", "0.65rem", "0.7rem"] as const
-
-function assertMinTextXs(className: string) {
-  expect(className).toContain(jobsProgressMinTextClassName)
-  expect(className).toContain("text-xs")
-  for (const rem of forbiddenSubXsRem) {
-    expect(className).not.toContain(rem)
-  }
-}
-
 describe("work-item-progress-chrome", () => {
-  test("lifecycle step chips use shared text-xs minimum (no sub-xs rem)", () => {
-    assertMinTextXs(lifecycleStepChipClassName)
+  test("lifecycle step chips use Interchange leg classes (no radius)", () => {
+    expect(lifecycleStepChipClassName).toContain("leg")
     expect(lifecycleStepChipClassName).not.toContain("rounded")
-    expect(lifecycleStepChipClassName).toContain("border")
+    expect(lifecycleStepChipClassNameForStatus("SUCCEEDED")).toBe(
+      "leg leg--done",
+    )
+    expect(lifecycleStepChipClassNameForStatus("RUNNING")).toBe("leg leg--run")
+    expect(lifecycleStepChipClassNameForStatus("QUEUED")).toBe("leg leg--next")
+    expect(lifecycleStepChipClassNameForStatus("FAILED")).toBe("leg leg--fail")
+    // Needs-human shares Attention fill with failures — not lane-colored "run".
+    expect(lifecycleStepChipClassNameForStatus("NEEDS_HUMAN")).toBe(
+      "leg leg--fail",
+    )
+    expect(lifecycleStepChipClassNameForStatus("NEEDS_HUMAN_REVIEW")).toBe(
+      "leg leg--fail",
+    )
   })
 
-  test("status badge base and PR badge share text-xs minimum", () => {
-    assertMinTextXs(statusBadgeBaseClassName)
-    assertMinTextXs(prBadgeClassName)
+  test("status tags and PR badge use Interchange component classes", () => {
+    expect(statusBadgeBaseClassName).toBe("status-tag")
+    expect(prBadgeClassName).toBe("pr-badge")
     expect(statusBadgeBaseClassName).not.toContain("rounded")
     expect(prBadgeClassName).not.toContain("rounded")
-    expect(statusBadgeBaseClassName).toContain("border")
-    expect(prBadgeClassName).toContain("border")
     expect(statusBadgeClassNameForStatus("COMPLETE")).toContain(
       statusBadgeBaseClassName,
     )
-    assertMinTextXs(statusBadgeClassNameForStatus("COMPLETE"))
-    assertMinTextXs(statusBadgeClassNameForStatus("FAILED"))
-    assertMinTextXs(statusBadgeClassNameForStatus("RUNNING"))
+    expect(statusBadgeClassNameForStatus("COMPLETE")).toContain(
+      "status-tag--complete",
+    )
+    expect(statusBadgeClassNameForStatus("FAILED")).toContain(
+      "status-tag--alarm",
+    )
+    expect(statusBadgeClassNameForStatus("RUNNING")).toContain(
+      "status-tag--plain",
+    )
+    expect(statusBadgeClassNameForStatus("NEEDS_HUMAN")).toContain(
+      "status-tag--alarm",
+    )
+    expect(statusBadgeClassNameForStatus("NEEDS_HUMAN_REVIEW")).toContain(
+      "status-tag--alarm",
+    )
   })
 
-  test("Waiting for blockers badge tone is distinct from Worker Slot and Queued", () => {
+  test("Waiting for blockers and worker slot share hold treatment, distinct from Queued", () => {
     const blockers = statusBadgeClassNameForStatus("WAITING_FOR_BLOCKERS")
     const workerSlot = statusBadgeClassNameForStatus("WAITING_FOR_WORKER_SLOT")
     const queued = statusBadgeClassNameForStatus("QUEUED")
     const running = statusBadgeClassNameForStatus("RUNNING")
 
-    expect(blockers).toContain("bg-teal-wash")
-    expect(blockers).toContain("text-teal")
-    expect(workerSlot).toContain("bg-violet-wash")
-    expect(workerSlot).toContain("text-violet-800")
-    expect(queued).toContain("bg-oxblood-wash")
-    expect(queued).toContain("text-oxblood")
+    expect(blockers).toContain("status-tag--hold")
+    expect(workerSlot).toContain("status-tag--hold")
+    expect(queued).toContain("status-tag--plain")
+    expect(running).toContain("status-tag--plain")
 
-    expect(blockers).not.toBe(workerSlot)
+    expect(blockers).toBe(workerSlot)
     expect(blockers).not.toBe(queued)
     expect(blockers).not.toBe(running)
-    expect(workerSlot).not.toBe(queued)
-    assertMinTextXs(blockers)
-    assertMinTextXs(workerSlot)
   })
 
-  test("status message tone matches wait-hold badges", () => {
+  test("status message tone marks alarm statuses for ▲ prefix", () => {
     expect(statusMessageClassNameForStatus("WAITING_FOR_BLOCKERS")).toBe(
-      "text-teal",
+      "status-message",
     )
     expect(statusMessageClassNameForStatus("WAITING_FOR_WORKER_SLOT")).toBe(
-      "text-violet-800",
+      "status-message",
     )
-    expect(statusMessageClassNameForStatus("QUEUED")).toBe("text-oxblood-deep")
-    expect(statusMessageClassNameForStatus("FAILED")).toBe("text-oxblood-deep")
+    expect(statusMessageClassNameForStatus("QUEUED")).toBe("status-message")
+    expect(statusMessageClassNameForStatus("FAILED")).toBe(
+      "status-message status-message--alarm",
+    )
+    expect(statusMessageClassNameForStatus("NEEDS_HUMAN")).toBe(
+      "status-message status-message--alarm",
+    )
   })
 })

--- a/docs/kanban.md
+++ b/docs/kanban.md
@@ -65,9 +65,11 @@ The prototype uses an industrial control-board language:
   throughput and in-flight flow are visible together.
 - Repository management and intake live on `/repos`, not under the board.
 
-The visual treatment may be adapted to the active Harness design system. The
-essential design idea is the board structure, fixed lane identity, and compact
-operator-facing ticket, rather than the prototype's exact palette or fonts.
+The visual treatment follows the Interchange design system
+(`docs/harness-design-system.md` when present; otherwise the harness CSS
+token layer). The essential design idea is the board structure, fixed lane
+identity, open white platforms with lane-color nameboards, and compact
+operator-facing tickets — not the older Ledger concrete fills or serif stack.
 
 ## Interaction Model
 


### PR DESCRIPTION
Summary

Land phase 2 of the Harness Interchange design system on the kanban home board:
merged-PR throughput, controls, six-lane network, job tickets, shared section 5
chrome, and the Queue discoverability hint. Phase 1 tokens, themes, and nav shell
already shipped; this is the surface where the motif lives.

Why

Issue #701 continues the unified industrial UI after phase 1. Migrating the board
forces token usage to settle (open white platforms, lane-color nameboards/roundels,
hard borders, dual-theme stats) without changing board structure or lifecycle
behavior.

What changed

- Merged-PR stats: light paper panel vs dark departure-board slab; in-panel
  skeletons and compact failure banner; "Merged PR throughput" header.
- Controls: joined ink tabs; repository filters with inset active underline.
- Network: route line + roundels on wide viewports; <=1500px sticky nameboard
  chrome with badge roundels; open platforms; mobile mini-plate lane switcher.
- Tickets: lane edge bars (Merged halo in dark), status tags, journey legs,
  lane-colored earlier-lane summaries, Merged compact meta + PR badge.
- Section 5 components: status tags, leg chips (NEEDS_HUMAN -> Attention fail
  fill), icon buttons (including paused tone), PR badges; shared with other
  surfaces that reuse the helpers.
- Queue hint: permanent Queue-yellow panel at the foot of Queue -> Manage repos
  (/repos).
- Completed 24 h tab: same tickets on a bordered panel surface.
- Docs note in docs/kanban.md pointing at Interchange treatment.

Verification

- bunx nx test harness (full package, 431 pass)
- Harness tsc --noEmit and Biome on touched files during implementation
- Review remediations: NEEDS_HUMAN chip/tag Attention alignment, sticky
  lane-chrome at <=1500px, alarm message ink body + markup mark, paused icon
  button contrast

Limitations

- Archive page, repos page layout, and dialogs remain for later phases.
- Shared section 5 chrome also updates progress presentation on Repos/Completed
  rows that use the same helpers (intentional component-level migration).

Closes #701