### PR TITLE
feat(harness): interchange phase 4 repos page and blank slate

### DIFF
--- a/apps/harness/src/card-collapse-toggle.tsx
+++ b/apps/harness/src/card-collapse-toggle.tsx
@@ -15,7 +15,7 @@ export function CardCollapseToggle({
   return (
     <button
       type="button"
-      className="inline-flex size-8 shrink-0 items-center justify-center border border-rule-2 bg-panel text-ink-soft transition hover:border-ink-soft hover:bg-paper-2 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-oxblood"
+      className="icon-btn"
       aria-expanded={!collapsed}
       aria-controls={controlsId}
       aria-label={collapsed ? `Expand ${label}` : `Collapse ${label}`}
@@ -23,7 +23,7 @@ export function CardCollapseToggle({
     >
       <svg
         aria-hidden="true"
-        className={`size-4 transition-transform ${collapsed ? "" : "rotate-180"}`}
+        className={`transition-transform ${collapsed ? "" : "rotate-180"}`}
         viewBox="0 0 24 24"
         fill="none"
         stroke="currentColor"

--- a/apps/harness/src/parent-issue-actions-menu.tsx
+++ b/apps/harness/src/parent-issue-actions-menu.tsx
@@ -1,5 +1,6 @@
 import { type MouseEvent, type ReactNode, useEffect, useState } from "react"
 import { evaluateLeafIssue } from "@ready-for-agent/lifecycle-model"
+import { Banner } from "./banner.js"
 
 export type ParentIssueActionsMenuProps = {
   readonly parentIssueNumber: number
@@ -42,61 +43,63 @@ export function ParentIssueActionsMenu({
     }
   }, [menuId, menuOpen])
 
+  // Kebab only — parent-group failures are rendered in-flow under the summary
+  // (see ParentIssueGroup). errorMessage remains for isolated unit tests of
+  // the presentational shell.
   return (
-    <span className="relative" data-parent-issue-menu={menuId}>
-      <button
-        type="button"
-        className="inline-flex size-7 items-center justify-center border border-rule-2 bg-panel text-ink-soft hover:border-ink-soft hover:bg-paper-2 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-oxblood"
-        aria-label={`Actions for parent issue #${parentIssueNumber}`}
-        aria-haspopup="menu"
-        aria-expanded={menuOpen}
-        disabled={pending}
-        onClick={(event: MouseEvent<HTMLButtonElement>) => {
-          // Keep parent <details> summary from toggling when opening the kebab.
-          event.stopPropagation()
-          setMenuOpen((open) => !open)
-        }}
-      >
-        <svg
-          aria-hidden="true"
-          className="size-4"
-          viewBox="0 0 24 24"
-          fill="currentColor"
+    <>
+      <span className="relative" data-parent-issue-menu={menuId}>
+        <button
+          type="button"
+          className="icon-btn"
+          aria-label={`Actions for parent issue #${parentIssueNumber}`}
+          aria-haspopup="menu"
+          aria-expanded={menuOpen}
+          disabled={pending}
+          onClick={(event: MouseEvent<HTMLButtonElement>) => {
+            // Keep parent <details> summary from toggling when opening the kebab.
+            event.stopPropagation()
+            setMenuOpen((open) => !open)
+          }}
         >
-          <circle cx="12" cy="5" r="1.75" />
-          <circle cx="12" cy="12" r="1.75" />
-          <circle cx="12" cy="19" r="1.75" />
-        </svg>
-      </button>
-      {menuOpen && (
-        <div
-          role="menu"
-          className="absolute top-full right-0 z-10 mt-1 min-w-56 border border-rule-2 bg-panel py-1 font-sans normal-case tracking-normal shadow-[0_12px_30px_rgb(28_22_14_/_18%)]"
-        >
-          <button
-            type="button"
-            role="menuitem"
-            className="block w-full px-3 py-2 text-left text-sm font-medium text-ink-2 hover:bg-paper-2"
-            disabled={pending}
-            onClick={(event: MouseEvent<HTMLButtonElement>) => {
-              event.stopPropagation()
-              setMenuOpen(false)
-              onImplementAllWithAutoMerge()
-            }}
+          <svg aria-hidden="true" viewBox="0 0 24 24" fill="currentColor">
+            <circle cx="12" cy="5" r="1.75" />
+            <circle cx="12" cy="12" r="1.75" />
+            <circle cx="12" cy="19" r="1.75" />
+          </svg>
+        </button>
+        {menuOpen && (
+          <div
+            role="menu"
+            className="absolute top-full right-0 z-10 mt-1 min-w-56 border-2 border-ink bg-panel py-1"
           >
-            {pending ? "Starting..." : "Implement all with auto-merge"}
-          </button>
-        </div>
-      )}
+            <button
+              type="button"
+              role="menuitem"
+              className="block w-full px-3 py-2 text-left font-mono text-[0.68rem] font-medium tracking-[0.08em] text-ink-2 uppercase hover:bg-[var(--plate-hover)]"
+              disabled={pending}
+              onClick={(event: MouseEvent<HTMLButtonElement>) => {
+                event.stopPropagation()
+                setMenuOpen(false)
+                onImplementAllWithAutoMerge()
+              }}
+            >
+              {pending ? "Starting..." : "Implement all with auto-merge"}
+            </button>
+          </div>
+        )}
+      </span>
       {errorMessage !== null && (
-        <p
-          className="absolute top-full right-0 z-10 mt-1 w-56 border border-rule-2 bg-panel px-2 py-1.5 font-sans text-xs font-normal text-oxblood-deep normal-case tracking-normal"
+        <Banner
+          className="banner--compact parent-issue-error"
+          tone="alarm"
+          tag="Error"
           role="alert"
         >
           {errorMessage}
-        </p>
+        </Banner>
       )}
-    </span>
+    </>
   )
 }
 

--- a/apps/harness/src/routes/index.tsx
+++ b/apps/harness/src/routes/index.tsx
@@ -975,10 +975,7 @@ export function RepositoryCards() {
   return (
     <>
       {warning}
-      <section
-        className="grid grid-cols-1 gap-12 sm:gap-16"
-        aria-label="Configured repositories"
-      >
+      <section className="repo-cards" aria-label="Configured repositories">
         {repositories.map((repository) => (
           <RepositoryCard
             issuesChangeCount={issuesChangeCounts[repository.id] ?? 0}
@@ -987,7 +984,7 @@ export function RepositoryCards() {
           />
         ))}
       </section>
-      <div className="mt-12 sm:mt-16">
+      <div className="mt-10 sm:mt-12">
         <AddRepositoryGuidance command={addRepositoryCommand} />
       </div>
     </>
@@ -1159,23 +1156,25 @@ function AddRepositoryGuidance({
   }
 
   return (
-    <section
-      className="border border-dashed border-rule-2 bg-panel px-6 py-12 text-center sm:px-10"
-      aria-label="Add a repository"
-    >
+    <section className="blank-slate" aria-label="Add a repository">
       {heading !== undefined ? (
-        <h2 className="m-0 font-serif text-2xl font-semibold text-ink">
-          {heading}
-        </h2>
+        <>
+          <span className="kicker-tag">Setup</span>
+          <h2 className="blank-slate-title">{heading}</h2>
+        </>
       ) : null}
       <form
-        className={`mx-auto flex w-full max-w-xl flex-col gap-3 ${heading !== undefined ? "mt-6" : "mt-0"}`}
+        className={
+          heading !== undefined
+            ? "blank-slate-form"
+            : "blank-slate-form blank-slate-form--flush"
+        }
         onSubmit={onSubmit}
       >
         <label className="sr-only" htmlFor="add-repository-path">
           Local repository path
         </label>
-        <div className="flex flex-col gap-2 sm:flex-row sm:items-stretch">
+        <div className="blank-slate-path-row">
           <input
             id="add-repository-path"
             type="text"
@@ -1191,24 +1190,20 @@ function AddRepositoryGuidance({
             autoComplete="off"
             spellCheck={false}
             disabled={busy}
-            className="min-w-0 flex-1 border border-rule-2 bg-paper px-3 py-2 font-mono text-sm text-ink-2 placeholder:text-ink-faint focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-oxblood disabled:opacity-60"
+            className="blank-slate-input"
           />
-          <div className="flex shrink-0 gap-2">
+          <div className="blank-slate-actions">
             {directoryPickerAvailable ? (
               <button
                 type="button"
                 disabled={busy}
                 onClick={() => pickDirectory.mutate()}
-                className="border border-rule-2 bg-panel px-3 py-2 text-sm font-semibold text-ink-2 transition hover:border-ink-soft hover:bg-paper-2 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-oxblood disabled:cursor-wait disabled:opacity-60"
+                className="plate-mini"
               >
                 {pickDirectory.isPending ? "Browsing…" : "Browse…"}
               </button>
             ) : null}
-            <button
-              type="submit"
-              disabled={busy}
-              className="bg-oxblood px-3 py-2 text-sm font-semibold tracking-wide text-on-solid uppercase transition hover:bg-oxblood-deep focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-oxblood disabled:cursor-wait disabled:opacity-60"
-            >
+            <button type="submit" disabled={busy} className="plate-primary">
               {addLocalRepository.isPending
                 ? "Adding…"
                 : inspectLocalRepository.isPending
@@ -1220,14 +1215,11 @@ function AddRepositoryGuidance({
           </div>
         </div>
         {inspection !== null ? (
-          <fieldset className="grid gap-3 border border-rule p-4 text-left">
-            <legend className="px-1 font-mono text-xs font-semibold tracking-[0.16em] text-ink-faint uppercase">
-              Confirm forge identity
-            </legend>
-            <label className="grid gap-1 text-sm font-semibold text-ink-2">
+          <fieldset className="blank-slate-fieldset">
+            <legend>Confirm forge identity</legend>
+            <label className="blank-slate-field">
               Forge
               <select
-                className="border border-rule-2 bg-paper px-3 py-2 font-normal"
                 value={inspection.forge}
                 onChange={(event) =>
                   setInspection({
@@ -1240,10 +1232,9 @@ function AddRepositoryGuidance({
                 <option value="gitlab">GitLab</option>
               </select>
             </label>
-            <label className="grid gap-1 text-sm font-semibold text-ink-2">
+            <label className="blank-slate-field">
               Forge host
               <input
-                className="border border-rule-2 bg-paper px-3 py-2 font-mono font-normal"
                 required
                 value={inspection.forgeHost}
                 onChange={(event) =>
@@ -1254,10 +1245,9 @@ function AddRepositoryGuidance({
                 }
               />
             </label>
-            <label className="grid gap-1 text-sm font-semibold text-ink-2">
+            <label className="blank-slate-field">
               Project path
               <input
-                className="border border-rule-2 bg-paper px-3 py-2 font-mono font-normal"
                 required
                 value={inspection.projectPath}
                 onChange={(event) =>
@@ -1268,27 +1258,29 @@ function AddRepositoryGuidance({
                 }
               />
             </label>
-            <p className="m-0 text-xs text-ink-faint">
+            <p className="blank-slate-hint">
               The project is verified against this forge before it is saved.
             </p>
           </fieldset>
         ) : null}
         {errorMessage !== null ? (
-          <p className="m-0 text-left text-sm text-oxblood-deep" role="alert">
+          <Banner
+            className="banner--compact w-full"
+            tone="alarm"
+            tag="Error"
+            role="alert"
+          >
             {errorMessage}
-          </p>
+          </Banner>
         ) : null}
       </form>
-      <p
-        className="mt-8 mb-0 text-center text-xs tracking-[0.18em] text-ink-faint uppercase"
-        aria-hidden="true"
-      >
-        --- or ---
-      </p>
-      <p className="mt-6 text-sm text-ink-soft">
+      <div className="blank-slate-divider" aria-hidden="true">
+        <span>or</span>
+      </div>
+      <p className="blank-slate-cli">
         Add a local Git repository with the operator binary:
       </p>
-      <code className="mt-4 inline-block max-w-full overflow-x-auto border border-rule-2 bg-paper px-3 py-2 font-mono text-sm text-ink-2">
+      <code className="guidance-code max-w-full overflow-x-auto">
         {command}
       </code>
     </section>
@@ -1956,9 +1948,13 @@ function RepositoryCard({
   const pauseLabel = repository.paused
     ? "Unpause repository"
     : "Pause repository"
-  const pauseButtonClass = repository.paused
-    ? "border-oxblood/50 text-oxblood hover:bg-oxblood-wash focus-visible:outline-oxblood"
-    : "border-sepia/50 text-sepia hover:bg-amber-wash focus-visible:outline-sepia"
+  const pauseButtonClassName = [
+    "icon-btn",
+    pauseFailed ? "icon-btn--armed" : null,
+    !pauseFailed && repository.paused ? "icon-btn--paused" : null,
+  ]
+    .filter((part): part is string => part != null)
+    .join(" ")
   const repositoryLabel = `${repository.projectPath}`
   // Dedicated count projection: loading/last-known must not block the card.
   const {
@@ -1982,19 +1978,17 @@ function RepositoryCard({
   const repositoryBodyId = `repository-card-body-${repository.id}`
 
   return (
-    <article className="relative min-w-0 border-t-2 border-ink-soft pt-7 first:border-t-0 first:pt-0 sm:pt-8">
-      <div
-        className={`flex flex-wrap items-start justify-between gap-x-4 gap-y-2 ${repositoryCollapsed ? "" : "mb-5"}`}
-      >
-        <h2 className="m-0 flex min-w-0 max-w-full items-baseline gap-x-2 font-serif text-2xl font-semibold tracking-[-0.012em]">
+    <article className="repo-card">
+      <div className="repo-card-head">
+        <h2 className="repo-card-title">
           <a
-            className="min-w-0 truncate text-ink hover:text-oxblood hover:underline"
+            className="repo-card-link"
             href={`https://${repository.forgeHost}/${repository.projectPath}`}
           >
             {repositoryLabel}
           </a>
           <span
-            className="shrink-0 font-mono text-sm font-semibold tracking-normal text-ink-faint tabular-nums"
+            className="repo-card-pr-count"
             title={pullRequestCountLabel}
             aria-busy={pullRequestCountLoading ? true : undefined}
           >
@@ -2002,7 +1996,7 @@ function RepositoryCard({
             <span aria-hidden="true">{pullRequestCountDisplay}</span>
           </span>
         </h2>
-        <div className="flex shrink-0 items-center gap-1">
+        <div className="repo-card-controls">
           <CardCollapseToggle
             collapsed={repositoryCollapsed}
             onToggle={toggleRepositoryCollapsed}
@@ -2011,7 +2005,7 @@ function RepositoryCard({
           />
           <button
             type="button"
-            className={`inline-flex size-8 items-center justify-center border transition focus-visible:outline-2 focus-visible:outline-offset-2 disabled:cursor-wait disabled:opacity-50 ${pauseFailed ? "border-oxblood text-oxblood hover:bg-oxblood-wash focus-visible:outline-oxblood" : pauseButtonClass}`}
+            className={pauseButtonClassName}
             disabled={pausePending}
             onClick={() =>
               repository.paused
@@ -2028,7 +2022,7 @@ function RepositoryCard({
             {pausePending ? (
               <svg
                 aria-hidden="true"
-                className="size-4 animate-spin motion-reduce:animate-none"
+                className="animate-spin motion-reduce:animate-none"
                 viewBox="0 0 24 24"
                 fill="none"
               >
@@ -2049,21 +2043,11 @@ function RepositoryCard({
                 />
               </svg>
             ) : repository.paused ? (
-              <svg
-                aria-hidden="true"
-                className="size-4"
-                viewBox="0 0 24 24"
-                fill="currentColor"
-              >
+              <svg aria-hidden="true" viewBox="0 0 24 24" fill="currentColor">
                 <path d="m8 5 11 7-11 7V5Z" />
               </svg>
             ) : (
-              <svg
-                aria-hidden="true"
-                className="size-4"
-                viewBox="0 0 24 24"
-                fill="currentColor"
-              >
+              <svg aria-hidden="true" viewBox="0 0 24 24" fill="currentColor">
                 <rect x="6" y="5" width="4" height="14" rx="1" />
                 <rect x="14" y="5" width="4" height="14" rx="1" />
               </svg>
@@ -2072,18 +2056,13 @@ function RepositoryCard({
           <span className="relative" data-repo-menu={repository.id}>
             <button
               type="button"
-              className="inline-flex size-8 items-center justify-center border border-rule-2 bg-panel text-ink-soft transition hover:border-ink-soft hover:bg-paper-2 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-oxblood"
+              className="icon-btn"
               aria-label={`Actions for ${repository.projectPath}`}
               aria-haspopup="menu"
               aria-expanded={menuOpen}
               onClick={() => setMenuOpen((open) => !open)}
             >
-              <svg
-                aria-hidden="true"
-                className="size-4"
-                viewBox="0 0 24 24"
-                fill="currentColor"
-              >
+              <svg aria-hidden="true" viewBox="0 0 24 24" fill="currentColor">
                 <circle cx="12" cy="5" r="1.75" />
                 <circle cx="12" cy="12" r="1.75" />
                 <circle cx="12" cy="19" r="1.75" />
@@ -2092,12 +2071,12 @@ function RepositoryCard({
             {menuOpen && (
               <div
                 role="menu"
-                className="absolute top-full right-0 z-10 mt-1 min-w-40 border border-rule-2 bg-panel py-1 shadow-[0_12px_30px_rgb(28_22_14_/_18%)]"
+                className="absolute top-full right-0 z-10 mt-1 min-w-40 border-2 border-ink bg-panel py-1"
               >
                 <button
                   type="button"
                   role="menuitem"
-                  className="block w-full px-3 py-2 text-left text-sm font-medium text-ink-2 hover:bg-paper-2"
+                  className="block w-full px-3 py-2 text-left font-mono text-[0.68rem] font-medium tracking-[0.08em] text-ink-2 uppercase hover:bg-[var(--plate-hover)]"
                   onClick={() => {
                     setMenuOpen(false)
                     openSettings()
@@ -2105,11 +2084,11 @@ function RepositoryCard({
                 >
                   Settings
                 </button>
-                <hr className="my-1 border-t border-rule" />
+                <hr className="my-1 border-t border-[var(--line-ghost)]" />
                 <button
                   type="button"
                   role="menuitem"
-                  className="block w-full px-3 py-2 text-left text-sm font-medium text-oxblood hover:bg-oxblood-wash disabled:cursor-wait disabled:opacity-50"
+                  className="block w-full px-3 py-2 text-left font-mono text-[0.68rem] font-medium tracking-[0.08em] text-ink uppercase hover:bg-[var(--lane-attention)] hover:text-[#151515] disabled:cursor-wait disabled:opacity-50"
                   disabled={removeRepository.isPending}
                   onClick={() => {
                     setMenuOpen(false)
@@ -2538,64 +2517,47 @@ function RepositoryCard({
       </dialog>
       {!repositoryCollapsed && (
         <div id={repositoryBodyId}>
-          <dl className="m-0 grid gap-x-8 gap-y-1.5 border-y border-rule py-3 sm:grid-cols-2">
-            <div className="flex min-w-0 items-baseline gap-1.5 text-xs">
-              <dt className="shrink-0 font-mono font-semibold tracking-[0.12em] text-ink-faint uppercase">
-                Path:
-              </dt>
-              <dd
-                className="m-0 min-w-0 truncate font-mono text-ink-2"
-                title={repository.localPath}
-              >
-                {repository.localPath}
-              </dd>
+          <dl className="repo-meta">
+            <div className="repo-meta-row">
+              <dt>Path</dt>
+              <dd title={repository.localPath}>{repository.localPath}</dd>
             </div>
-            <div className="flex min-w-0 items-baseline gap-1.5 text-xs">
-              <dt className="shrink-0 font-mono font-semibold tracking-[0.12em] text-ink-faint uppercase">
-                Checkout:
-              </dt>
-              <dd className="m-0 min-w-0 truncate font-mono text-ink-2">
-                {repository.isBare ? "Bare repository" : "Working tree"}
-              </dd>
+            <div className="repo-meta-row">
+              <dt>Checkout</dt>
+              <dd>{repository.isBare ? "Bare repository" : "Working tree"}</dd>
             </div>
-            <div className="flex min-w-0 items-baseline gap-1.5 text-xs">
-              <dt className="shrink-0 font-mono font-semibold tracking-[0.12em] text-ink-faint uppercase">
-                Agent Backend:
-              </dt>
-              <dd className="m-0 min-w-0 truncate font-mono text-ink-2">
+            <div className="repo-meta-row">
+              <dt>Agent Backend</dt>
+              <dd>
                 {repository.selectedAgentBackend === null
                   ? `Harness default (${repository.effectiveAgentBackend})`
                   : repository.effectiveAgentBackend}
               </dd>
             </div>
-            <div className="flex min-w-0 items-baseline gap-1.5 text-xs">
-              <dt className="shrink-0 font-mono font-semibold tracking-[0.12em] text-ink-faint uppercase">
-                Build model:
-              </dt>
-              <dd className="m-0 min-w-0 truncate font-mono text-ink-2">
+            <div className="repo-meta-row">
+              <dt>Build model</dt>
+              <dd>
                 {repository.defaultModel ??
                   (repository.selectedAgentBackend === null
-                    ? `Default (${
+                    ? `Harness default (${
                         config.data?.defaultModel ?? "not configured"
                       })`
                     : "Harness default")}
                 {" · "}
                 {repository.defaultThinkingLevel ??
                   (repository.selectedAgentBackend === null
-                    ? `Default (${
+                    ? `Harness default (${
                         config.data?.defaultThinkingLevel ?? "not configured"
                       })`
                     : "Harness default")}
               </dd>
             </div>
-            <div className="flex min-w-0 items-baseline gap-1.5 text-xs">
-              <dt className="shrink-0 font-mono font-semibold tracking-[0.12em] text-ink-faint uppercase">
-                Review model:
-              </dt>
-              <dd className="m-0 min-w-0 truncate font-mono text-ink-2">
+            <div className="repo-meta-row">
+              <dt>Review model</dt>
+              <dd>
                 {repository.reviewModel ??
                   (repository.selectedAgentBackend === null
-                    ? `Default (${
+                    ? `Harness default (${
                         config.data?.reviewModel ??
                         `Build (${
                           repository.defaultModel ??
@@ -2607,7 +2569,7 @@ function RepositoryCard({
                 {" · "}
                 {repository.reviewThinkingLevel ??
                   (repository.selectedAgentBackend === null
-                    ? `Default (${
+                    ? `Harness default (${
                         config.data?.reviewThinkingLevel ??
                         `Build (${
                           repository.defaultThinkingLevel ??
@@ -2618,27 +2580,19 @@ function RepositoryCard({
                     : "Harness default")}
               </dd>
             </div>
-            <div className="flex min-w-0 items-baseline gap-1.5 text-xs">
-              <dt className="shrink-0 font-mono font-semibold tracking-[0.12em] text-ink-faint uppercase">
-                Auto-merge:
-              </dt>
-              <dd className="m-0 font-mono text-ink-2">
-                {repository.autoMerge ? "Enabled" : "Disabled"}
-              </dd>
+            <div className="repo-meta-row">
+              <dt>Auto-merge</dt>
+              <dd>{repository.autoMerge ? "Enabled" : "Disabled"}</dd>
             </div>
-            <div className="flex min-w-0 items-baseline gap-1.5 text-xs">
-              <dt className="shrink-0 font-mono font-semibold tracking-[0.12em] text-ink-faint uppercase">
-                Include all Issue Authors:
-              </dt>
-              <dd className="m-0 font-mono text-ink-2">
+            <div className="repo-meta-row">
+              <dt>Include all Issue Authors</dt>
+              <dd>
                 {repository.includeAllIssueAuthors ? "Enabled" : "Disabled"}
               </dd>
             </div>
-            <div className="flex min-w-0 items-baseline gap-1.5 text-xs">
-              <dt className="shrink-0 font-mono font-semibold tracking-[0.12em] text-ink-faint uppercase">
-                Wait for ready checks:
-              </dt>
-              <dd className="m-0 font-mono text-ink-2">
+            <div className="repo-meta-row">
+              <dt>Wait for ready checks</dt>
+              <dd>
                 {repository.waitForReadyForReviewChecks
                   ? "Enabled"
                   : "Disabled"}
@@ -2654,17 +2608,19 @@ function RepositoryCard({
                 role={addGitHubToken.isError ? "alert" : "status"}
                 action={
                   githubTokenCreated ? (
-                    <BannerActionButton
+                    <button
+                      type="button"
+                      className="plate-primary"
                       disabled={addGitHubToken.isPending}
                       onClick={() => addGitHubToken.mutate()}
                     >
                       {addGitHubToken.isPending
                         ? "Waiting for Keymaxxer"
                         : "Store in Keymaxxer"}
-                    </BannerActionButton>
+                    </button>
                   ) : (
                     <a
-                      className="plate-mini"
+                      className="plate-primary"
                       href={repository.credential.githubTokenCreationUrl}
                       onClick={() => setGithubTokenCreated(true)}
                       rel="noreferrer"
@@ -2679,7 +2635,7 @@ function RepositoryCard({
                 {githubTokenCreated ? (
                   <p className="m-0 mt-1">
                     Store the generated token as{" "}
-                    <code className="font-bold">
+                    <code className="guidance-code">
                       {repository.credential.githubTokenSecretName}
                     </code>{" "}
                     in Keymaxxer. Already-created tokens are not upgraded
@@ -2690,7 +2646,7 @@ function RepositoryCard({
                   <p className="m-0 mt-1">
                     Create a fine-grained token, choose{" "}
                     <strong>Only select repositories</strong>, select{" "}
-                    <code className="font-bold">
+                    <code className="guidance-code">
                       {repository.projectPath.split("/").at(-1)}
                     </code>
                     , and allow <strong>Actions: Read and write</strong>{" "}
@@ -2715,17 +2671,19 @@ function RepositoryCard({
                 role={addGitLabToken.isError ? "alert" : "status"}
                 action={
                   gitlabTokenCreated ? (
-                    <BannerActionButton
+                    <button
+                      type="button"
+                      className="plate-primary"
                       disabled={addGitLabToken.isPending}
                       onClick={() => addGitLabToken.mutate()}
                     >
                       {addGitLabToken.isPending
                         ? "Waiting for Keymaxxer"
                         : "Store in Keymaxxer"}
-                    </BannerActionButton>
+                    </button>
                   ) : (
                     <a
-                      className="plate-mini"
+                      className="plate-primary"
                       href={repository.credential.githubTokenCreationUrl}
                       onClick={() => setGitlabTokenCreated(true)}
                       rel="noreferrer"
@@ -2743,12 +2701,12 @@ function RepositoryCard({
                   {gitlabTokenCreated ? (
                     <>
                       Store the generated token as{" "}
-                      <code className="font-bold">
+                      <code className="guidance-code">
                         {repository.credential.githubTokenSecretName}
                       </code>{" "}
                       in Keymaxxer when available (provider{" "}
-                      <code className="font-bold">gitlab</code>, account{" "}
-                      <code className="font-bold">
+                      <code className="guidance-code">gitlab</code>, account{" "}
+                      <code className="guidance-code">
                         {repository.forgeHost}/{repository.projectPath}
                       </code>
                       ). Or set ambient auth without Keymaxxer:{" "}
@@ -2757,15 +2715,15 @@ function RepositoryCard({
                     <>
                       Create a personal access token on this GitLab instance
                       with API access for{" "}
-                      <code className="font-bold">
+                      <code className="guidance-code">
                         {repository.projectPath}
                       </code>
                       . Store it in Keymaxxer when available, or set ambient
                       auth:{" "}
                     </>
                   )}
-                  <code className="font-bold">GITLAB_TOKEN</code> or{" "}
-                  <code className="font-bold">
+                  <code className="guidance-code">GITLAB_TOKEN</code> or{" "}
+                  <code className="guidance-code">
                     glab auth login --hostname {repository.forgeHost}
                   </code>{" "}
                   before starting the Harness.
@@ -2773,21 +2731,19 @@ function RepositoryCard({
                 {addGitLabToken.isError ? (
                   <p className="m-0 mt-1">
                     Keymaxxer setup was cancelled or failed. Use ambient{" "}
-                    <code className="font-bold">GITLAB_TOKEN</code> or{" "}
-                    <code className="font-bold">glab auth login</code> and
+                    <code className="guidance-code">GITLAB_TOKEN</code> or{" "}
+                    <code className="guidance-code">glab auth login</code> and
                     restart the Harness if Keymaxxer is unavailable.
                   </p>
                 ) : null}
               </Banner>
             )}
-          <div className="mt-5">
-            <div className="mb-2 flex items-baseline justify-between gap-3">
-              <h3 className="m-0 font-mono text-xs font-semibold tracking-[0.22em] text-oxblood uppercase">
-                Relevant issues
-              </h3>
+          <div className="repo-issues">
+            <div className="repo-issues-head">
+              <h3 className="repo-issues-kicker">Relevant issues</h3>
               <button
                 type="button"
-                className="inline-flex size-7 items-center justify-center border border-rule-2 bg-panel text-ink-soft transition hover:border-ink-soft hover:bg-paper-2 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-oxblood disabled:cursor-wait disabled:opacity-60"
+                className="icon-btn"
                 disabled={refreshingIssues || !repository.credential.configured}
                 onClick={() => refreshIssues.mutate()}
                 aria-label={
@@ -2803,7 +2759,11 @@ function RepositoryCard({
               >
                 <svg
                   aria-hidden="true"
-                  className={`size-4 ${refreshingIssues ? "animate-spin motion-reduce:animate-none" : ""}`}
+                  className={
+                    refreshingIssues
+                      ? "animate-spin motion-reduce:animate-none"
+                      : undefined
+                  }
                   viewBox="0 0 24 24"
                   fill="none"
                   stroke="currentColor"
@@ -2817,14 +2777,17 @@ function RepositoryCard({
               </button>
             </div>
             {refreshIssues.isError && (
-              <p className="mb-2 text-sm text-oxblood-deep" role="alert">
+              <Banner
+                className="banner--compact mb-2"
+                tone="alarm"
+                tag="Error"
+                role="alert"
+              >
                 Failed to refresh issues.
-              </p>
+              </Banner>
             )}
             {repository.issuesReconciledAt === null ? (
-              <p className="m-0 font-serif text-sm italic text-ink-soft">
-                Not refreshed yet.
-              </p>
+              <p className="repo-issues-empty">Not refreshed yet.</p>
             ) : (
               <Suspense fallback={<RepositoryIssuesSkeleton />}>
                 <RepositoryIssues
@@ -2836,9 +2799,14 @@ function RepositoryCard({
             )}
           </div>
           {removeRepository.isError && (
-            <p className="mt-3 mb-0 text-sm text-oxblood-deep" role="alert">
+            <Banner
+              className="banner--compact mt-3"
+              tone="alarm"
+              tag="Error"
+              role="alert"
+            >
               Could not remove repository. Please try again.
-            </p>
+            </Banner>
           )}
         </div>
       )}
@@ -2859,7 +2827,7 @@ function RepositoryIssues({
 
   if (issues.length === 0) {
     return (
-      <p className="m-0 font-serif text-sm italic text-ink-soft">
+      <p className="repo-issues-empty">
         No issues found this harness can work on.
       </p>
     )
@@ -2874,7 +2842,7 @@ function RepositoryIssues({
   }
 
   return (
-    <ul className="m-0 grid list-none gap-1 p-0">
+    <ul className="repo-issues-list">
       {issues.map((issue) => {
         if (issue.parent !== null) return null
         if (!issue.hasChildren) {
@@ -2982,35 +2950,28 @@ function ParentIssueGroup({
 
   return (
     <li className="min-w-0">
-      <details
-        className="group -mx-2 border border-rule-2 bg-panel px-2 py-1"
-        open
-      >
-        <summary className="grid cursor-pointer list-none grid-cols-[2.25rem_minmax(0,1fr)_auto] items-start gap-2 py-1.5 marker:content-none">
-          <span className="font-mono text-xs leading-5 font-semibold text-oxblood">
-            #{parent.issueNumber}
-          </span>
+      <details className="parent-issue" open>
+        <summary>
+          <span className="repo-issue-num">#{parent.issueNumber}</span>
           <span className="min-w-0">
             <a
-              className="font-serif text-[0.95rem] font-semibold text-ink hover:text-oxblood hover:underline"
+              className="repo-issue-title"
               href={parent.url}
               onClick={(event) => event.stopPropagation()}
             >
               {parent.title}
             </a>
             {parent.issueAuthor !== null && parent.issueAuthor !== "" && (
-              <span className="mt-0.5 block font-mono text-xs text-ink-faint">
-                {parent.issueAuthor}
-              </span>
+              <span className="repo-issue-author">{parent.issueAuthor}</span>
             )}
           </span>
-          <span className="flex shrink-0 items-center gap-1.5">
-            <span className="font-mono text-xs font-semibold tracking-[0.1em] text-ink-faint uppercase">
+          <span className="parent-issue-summary-actions">
+            <span className="parent-issue-closed-count">
               {closedChildren}/{childIssues.length} closed
             </span>
             <svg
               aria-hidden="true"
-              className="size-3.5 text-ink-faint transition-transform group-open:rotate-180"
+              className="parent-issue-chevron"
               viewBox="0 0 24 24"
               fill="none"
               stroke="currentColor"
@@ -3025,17 +2986,25 @@ function ParentIssueGroup({
                 parentIssueNumber={parent.issueNumber}
                 menuId={parent.id}
                 pending={implementAll.isPending}
-                errorMessage={
-                  implementAll.isError
-                    ? "Could not start Implement all with auto-merge. Refresh the issues and try again."
-                    : null
-                }
+                // Error Banner is in-flow under the summary (not under the kebab).
+                errorMessage={null}
                 onImplementAllWithAutoMerge={() => implementAll.mutate()}
               />
             )}
           </span>
         </summary>
-        <ul className="relative m-0 grid list-none gap-1 py-1 pl-0 before:absolute before:top-0 before:bottom-1 before:-left-2 before:w-px before:bg-rule-2">
+        {implementAll.isError && (
+          <Banner
+            className="banner--compact parent-issue-error"
+            tone="alarm"
+            tag="Error"
+            role="alert"
+          >
+            Could not start Implement all with auto-merge. Refresh the issues
+            and try again.
+          </Banner>
+        )}
+        <ul className="parent-issue-children">
           {childIssues.map((child) => (
             <RepositoryIssueRow
               issue={child}
@@ -3148,51 +3117,35 @@ function RepositoryIssueRow({
   }, [issue.id, menuOpen])
 
   return (
-    <li
-      className={`min-w-0 text-sm ${issue.blockedBy.length > 0 ? "-mx-2 border border-sepia/40 bg-amber-wash px-2 py-2" : "entry-rule py-2"}`}
-    >
-      <div className="grid min-w-0 grid-cols-[2.25rem_minmax(0,1fr)_auto] items-start gap-2">
-        <span className="font-mono text-xs leading-5 font-semibold text-oxblood">
-          #{issue.issueNumber}
-        </span>
+    <li className="repo-issue">
+      <div className="repo-issue-row">
+        <span className="repo-issue-num">#{issue.issueNumber}</span>
         <span className="min-w-0">
-          <a
-            className="font-serif text-[0.95rem] font-semibold break-words text-ink hover:text-oxblood hover:underline"
-            href={issue.url}
-          >
+          <a className="repo-issue-title" href={issue.url}>
             {issue.title}
           </a>
           {issue.issueAuthor !== null && issue.issueAuthor !== "" && (
-            <span className="mt-0.5 block font-mono text-xs text-ink-faint">
-              {issue.issueAuthor}
-            </span>
+            <span className="repo-issue-author">{issue.issueAuthor}</span>
           )}
         </span>
-        <span className="flex shrink-0 items-center gap-1">
+        <span className="repo-issue-actions">
           {issue.state === "CLOSED" && (
-            <span className="stamp border-rule-2 text-ink-faint">Closed</span>
+            <span className="stamp stamp--closed">Closed</span>
           )}
           {issue.blockedBy.length > 0 && (
-            <span className="stamp border-sepia/50 bg-amber-wash text-sepia">
-              Blocked
-            </span>
+            <span className="stamp stamp--blocked">Blocked</span>
           )}
           {(canImplement || canQueue) && (
             <span className="relative" data-issue-menu={issue.id}>
               <button
                 type="button"
-                className="inline-flex size-7 items-center justify-center border border-rule-2 bg-panel text-ink-soft hover:border-ink-soft hover:bg-paper-2 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-oxblood"
+                className="icon-btn"
                 aria-label={`Actions for issue #${issue.issueNumber}`}
                 aria-haspopup="menu"
                 aria-expanded={menuOpen}
                 onClick={() => setMenuOpen((open) => !open)}
               >
-                <svg
-                  aria-hidden="true"
-                  className="size-4"
-                  viewBox="0 0 24 24"
-                  fill="currentColor"
-                >
+                <svg aria-hidden="true" viewBox="0 0 24 24" fill="currentColor">
                   <circle cx="12" cy="5" r="1.75" />
                   <circle cx="12" cy="12" r="1.75" />
                   <circle cx="12" cy="19" r="1.75" />
@@ -3201,14 +3154,14 @@ function RepositoryIssueRow({
               {menuOpen && (
                 <div
                   role="menu"
-                  className="absolute top-full right-0 z-10 mt-1 min-w-44 border border-rule-2 bg-panel py-1 shadow-[0_12px_30px_rgb(28_22_14_/_18%)]"
+                  className="absolute top-full right-0 z-10 mt-1 min-w-44 border-2 border-ink bg-panel py-1"
                 >
                   {canImplement && (
                     <>
                       <button
                         type="button"
                         role="menuitem"
-                        className="block w-full px-3 py-2 text-left text-sm font-medium text-ink-2 hover:bg-paper-2"
+                        className="block w-full px-3 py-2 text-left font-mono text-[0.68rem] font-medium tracking-[0.08em] text-ink-2 uppercase hover:bg-[var(--plate-hover)]"
                         disabled={implementPending}
                         onClick={() => {
                           setMenuOpen(false)
@@ -3224,7 +3177,7 @@ function RepositoryIssueRow({
                       <button
                         type="button"
                         role="menuitem"
-                        className="block w-full px-3 py-2 text-left text-sm font-medium text-ink-2 hover:bg-paper-2"
+                        className="block w-full px-3 py-2 text-left font-mono text-[0.68rem] font-medium tracking-[0.08em] text-ink-2 uppercase hover:bg-[var(--plate-hover)]"
                         disabled={implementPending}
                         onClick={() => {
                           setMenuOpen(false)
@@ -3243,7 +3196,7 @@ function RepositoryIssueRow({
                     <button
                       type="button"
                       role="menuitem"
-                      className="block w-full px-3 py-2 text-left text-sm font-medium text-ink-2 hover:bg-paper-2"
+                      className="block w-full px-3 py-2 text-left font-mono text-[0.68rem] font-medium tracking-[0.08em] text-ink-2 uppercase hover:bg-[var(--plate-hover)]"
                       disabled={implementPending}
                       onClick={() => {
                         setMenuOpen(false)
@@ -3285,24 +3238,24 @@ function RepositoryIssueRow({
       {(implementNow.isError ||
         implementLocally.isError ||
         queueIssue.isError) && (
-        <p className="mt-1.5 mb-0 pl-11 text-xs text-oxblood-deep" role="alert">
+        <Banner
+          className="banner--compact repo-issue-error"
+          tone="alarm"
+          tag="Error"
+          role="alert"
+        >
           {queueIssue.isError
             ? "Could not queue issue. Refresh the issues and try again."
             : "Could not start implementation. Refresh the issues and try again."}
-        </p>
+        </Banner>
       )}
       {issue.blockedBy.length > 0 && (
-        <p className="mt-1.5 mb-0 pl-11 font-mono text-xs text-sepia">
+        <p className="repo-issue-blocked-by">
           Blocked by{" "}
           {issue.blockedBy.map((blocker, index) => (
             <span key={blocker.issueUrl}>
               {index > 0 && ", "}
-              <a
-                className="font-semibold underline decoration-rule-2 underline-offset-2 hover:text-oxblood"
-                href={blocker.issueUrl}
-              >
-                #{blocker.issueNumber}
-              </a>
+              <a href={blocker.issueUrl}>#{blocker.issueNumber}</a>
             </span>
           ))}
         </p>
@@ -3850,7 +3803,7 @@ export function WorkItemLifecycleStatus({
   )
 
   return (
-    <div className={compact ? "mt-2" : "field-rule mt-2 ml-11 px-3 py-2"}>
+    <div className={compact ? "mt-2" : "lifecycle-inset"}>
       <div className="flex flex-wrap items-center justify-between gap-2">
         <span className="job-ticket-runtime-line uppercase tracking-[0.1em]">
           {formatStartedAgo(workItem.createdAt, nowMs)}
@@ -4035,15 +3988,12 @@ function RepositoryIssuesSkeleton() {
 export function RepositoryCardsSkeleton() {
   return (
     <section
-      className="grid grid-cols-1 gap-8"
+      className="repo-cards"
       aria-label="Loading repositories"
       aria-busy="true"
     >
       {[0, 1].map((item) => (
-        <div
-          className="grid min-w-0 gap-4 border-t border-rule-2 py-5 first:border-t-0 first:pt-0"
-          key={item}
-        >
+        <div className="repo-card-skeleton" key={item}>
           <span className="block h-[0.85rem] w-[35%] animate-pulse bg-paper-2 motion-reduce:animate-none" />
           <span className="block h-[1.6rem] w-[65%] animate-pulse bg-paper-2 motion-reduce:animate-none" />
           <span className="block h-[0.85rem] w-[90%] animate-pulse bg-paper-2 motion-reduce:animate-none" />

--- a/apps/harness/src/styles.css
+++ b/apps/harness/src/styles.css
@@ -868,20 +868,6 @@
 
   /* ---------- Legacy Ledger helpers (unmigrated surfaces) ---------- */
 
-  .stamp {
-    display: inline-flex;
-    align-items: center;
-    border: 1px solid var(--color-rule-2);
-    padding: 0.0625rem 0.4375rem;
-    font-family: var(--font-sans);
-    font-size: 0.75rem;
-    font-weight: 600;
-    letter-spacing: 0.1em;
-    line-height: 1.4;
-    text-transform: uppercase;
-    white-space: nowrap;
-  }
-
   .field-rule {
     border: 1px solid var(--color-rule);
     background-color: var(--color-panel);
@@ -1693,6 +1679,590 @@
     background: var(--lane-pr);
     border-color: transparent;
     color: #fff;
+  }
+
+  /* §5.3 Primary plate (Save, Inspect/Confirm, credential CTAs) */
+  .plate-primary {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.4rem;
+    border: 2px solid var(--ink);
+    background: var(--ink);
+    color: var(--paper);
+    padding: 0.46rem 0.95rem;
+    font-family: var(--font-mono);
+    font-size: 0.68rem;
+    font-weight: 700;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    text-decoration: none;
+    cursor: pointer;
+    transition:
+      background-color 120ms ease,
+      color 120ms ease;
+  }
+
+  .plate-primary:hover {
+    background: var(--signal);
+    color: #151515;
+  }
+
+  .plate-primary:disabled {
+    cursor: wait;
+    opacity: 0.55;
+  }
+
+  /* §5.6 Stamps (exception chips — Closed, Blocked, No change) */
+  .stamp {
+    display: inline-flex;
+    align-items: center;
+    border: 1.5px solid var(--ink-faint);
+    padding: 0.2rem 0.45rem;
+    font-family: var(--font-mono);
+    font-size: 0.56rem;
+    font-weight: 700;
+    letter-spacing: 0.12em;
+    line-height: 1.2;
+    text-transform: uppercase;
+    white-space: nowrap;
+    color: var(--ink-dim);
+    background: transparent;
+  }
+
+  .stamp--closed,
+  .stamp--neutral {
+    border-style: dashed;
+    border-color: var(--ink-faint);
+    color: var(--ink-dim);
+    background: transparent;
+  }
+
+  .stamp--blocked {
+    border-style: solid;
+    border-color: var(--lane-queue);
+    background: var(--lane-queue);
+    color: #151515;
+  }
+
+  /* ---------- Repos page + blank slate (§4.6–4.7) ---------- */
+
+  .repo-cards {
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: 1.5rem;
+  }
+
+  /* Repo card: 1.5px ink-bordered ticket card */
+  .repo-card {
+    position: relative;
+    min-width: 0;
+    border: 1.5px solid var(--ink);
+    background: var(--panel);
+    padding: 1rem 1.1rem 1.15rem;
+  }
+
+  .repo-card-head {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 0.6rem 1rem;
+  }
+
+  .repo-card-title {
+    display: flex;
+    min-width: 0;
+    max-width: 100%;
+    margin: 0;
+    align-items: baseline;
+    gap: 0.55rem;
+    font-family: var(--font-display);
+    font-size: 1.06rem;
+    font-weight: 600;
+    line-height: 1.25;
+    letter-spacing: -0.01em;
+  }
+
+  .repo-card-link {
+    min-width: 0;
+    overflow: hidden;
+    color: var(--ink);
+    text-decoration: none;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .repo-card-link:hover {
+    color: var(--ink);
+    text-decoration: underline;
+    text-decoration-thickness: 2px;
+    text-underline-offset: 3px;
+    text-decoration-color: var(--signal);
+  }
+
+  .repo-card-pr-count {
+    flex-shrink: 0;
+    font-family: var(--font-mono);
+    font-size: 0.72rem;
+    font-weight: 600;
+    letter-spacing: 0.04em;
+    color: var(--ink-faint);
+    font-variant-numeric: tabular-nums;
+  }
+
+  .repo-card-controls {
+    display: flex;
+    flex-shrink: 0;
+    align-items: center;
+    gap: 0.25rem;
+  }
+
+  /* Meta table: hairline top/bottom, two columns, mono dt/dd */
+  .repo-meta {
+    display: grid;
+    gap: 0.55rem 2rem;
+    margin: 0.95rem 0 0;
+    padding: 0.75rem 0;
+    border-top: 1px solid var(--line-ghost);
+    border-bottom: 1px solid var(--line-ghost);
+  }
+
+  @media (min-width: 640px) {
+    .repo-meta {
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+  }
+
+  .repo-meta-row {
+    display: flex;
+    min-width: 0;
+    align-items: baseline;
+    gap: 0.5rem;
+  }
+
+  .repo-meta dt {
+    flex-shrink: 0;
+    margin: 0;
+    font-family: var(--font-mono);
+    font-size: 0.62rem;
+    font-weight: 700;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    color: var(--ink-faint);
+  }
+
+  .repo-meta dd {
+    margin: 0;
+    min-width: 0;
+    overflow: hidden;
+    font-family: var(--font-mono);
+    font-size: 0.7rem;
+    font-weight: 400;
+    letter-spacing: 0.02em;
+    color: var(--ink-dim);
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  /* Guidance / credential mono chips */
+  .guidance-code {
+    display: inline-block;
+    max-width: 100%;
+    overflow-x: auto;
+    border: 1.5px solid var(--ink);
+    background: var(--paper);
+    padding: 0.18rem 0.4rem;
+    font-family: var(--font-mono);
+    font-size: 0.78rem;
+    font-weight: 500;
+    color: var(--ink);
+    vertical-align: baseline;
+  }
+
+  .repo-issues {
+    margin-top: 1.1rem;
+  }
+
+  .repo-issues-head {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 0.75rem;
+    margin-bottom: 0.55rem;
+  }
+
+  .repo-issues-kicker {
+    margin: 0;
+    font-family: var(--font-mono);
+    font-size: 0.62rem;
+    font-weight: 700;
+    letter-spacing: 0.22em;
+    text-transform: uppercase;
+    color: var(--ink-faint);
+  }
+
+  .repo-issues-list {
+    display: grid;
+    gap: 0;
+    margin: 0;
+    padding: 0;
+    list-style: none;
+  }
+
+  .repo-issues-empty {
+    margin: 0;
+    font-family: var(--font-mono);
+    font-size: 0.68rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--ink-faint);
+  }
+
+  /* Issue rows — ticket anatomy; no amber wash on blocked */
+  .repo-issue {
+    min-width: 0;
+    padding: 0.55rem 0;
+    border-top: 1px solid var(--line-ghost);
+  }
+
+  .repo-issue:first-child {
+    border-top: 0;
+    padding-top: 0.15rem;
+  }
+
+  .repo-issue-row {
+    display: grid;
+    grid-template-columns: 2.4rem minmax(0, 1fr) auto;
+    align-items: start;
+    gap: 0.45rem 0.55rem;
+  }
+
+  .repo-issue-num {
+    font-family: var(--font-mono);
+    font-size: 0.72rem;
+    font-weight: 600;
+    line-height: 1.45;
+    color: var(--ink-dim);
+  }
+
+  .repo-issue-title {
+    display: block;
+    margin: 0;
+    overflow-wrap: anywhere;
+    color: var(--ink);
+    font-family: var(--font-display);
+    font-size: 0.95rem;
+    font-weight: 500;
+    line-height: 1.3;
+    text-decoration: none;
+  }
+
+  a.repo-issue-title:hover {
+    color: var(--ink);
+    text-decoration: underline;
+    text-decoration-thickness: 2px;
+    text-underline-offset: 3px;
+    text-decoration-color: var(--signal);
+  }
+
+  .repo-issue-author {
+    display: block;
+    margin-top: 0.15rem;
+    font-family: var(--font-mono);
+    font-size: 0.62rem;
+    letter-spacing: 0.06em;
+    color: var(--ink-faint);
+  }
+
+  .repo-issue-actions {
+    display: flex;
+    flex-shrink: 0;
+    align-items: center;
+    gap: 0.35rem;
+  }
+
+  .repo-issue-blocked-by {
+    margin: 0.4rem 0 0;
+    padding-left: 2.95rem;
+    font-family: var(--font-mono);
+    font-size: 0.62rem;
+    letter-spacing: 0.04em;
+    color: var(--ink-dim);
+  }
+
+  .repo-issue-blocked-by a {
+    color: var(--ink);
+    font-weight: 600;
+    text-decoration: underline;
+    text-underline-offset: 2px;
+  }
+
+  .repo-issue-blocked-by a:hover {
+    text-decoration-thickness: 2px;
+    text-decoration-color: var(--signal);
+  }
+
+  /* Indent leaf action errors under the title column (matches blocked-by line). */
+  .repo-issue-error {
+    margin: 0.4rem 0 0;
+    margin-left: 2.95rem;
+  }
+
+  /* In-flow parent implement-all error (under summary, not absolute on kebab). */
+  .parent-issue-error {
+    margin: 0.45rem 0.65rem 0.55rem;
+  }
+
+  /* Parent issue groups: details card + soft left rule for children */
+  .parent-issue {
+    min-width: 0;
+    margin: 0.35rem 0;
+    border: 1.5px solid var(--ink);
+    background: var(--panel);
+  }
+
+  .parent-issue > summary {
+    display: grid;
+    cursor: pointer;
+    list-style: none;
+    grid-template-columns: 2.4rem minmax(0, 1fr) auto;
+    align-items: start;
+    gap: 0.45rem 0.55rem;
+    padding: 0.55rem 0.65rem;
+  }
+
+  .parent-issue > summary::-webkit-details-marker {
+    display: none;
+  }
+
+  .parent-issue-closed-count {
+    font-family: var(--font-mono);
+    font-size: 0.62rem;
+    font-weight: 700;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    color: var(--ink-faint);
+  }
+
+  .parent-issue-summary-actions {
+    display: flex;
+    flex-shrink: 0;
+    align-items: center;
+    gap: 0.4rem;
+  }
+
+  .parent-issue-chevron {
+    width: 0.85rem;
+    height: 0.85rem;
+    color: var(--ink-faint);
+    transition: transform 120ms ease;
+  }
+
+  .parent-issue[open] .parent-issue-chevron {
+    transform: rotate(180deg);
+  }
+
+  .parent-issue-children {
+    position: relative;
+    display: grid;
+    gap: 0;
+    margin: 0;
+    padding: 0.15rem 0.65rem 0.55rem 0.85rem;
+    list-style: none;
+    border-top: 1px solid var(--line-ghost);
+  }
+
+  .parent-issue-children::before {
+    content: "";
+    position: absolute;
+    top: 0.35rem;
+    bottom: 0.45rem;
+    left: 0;
+    width: 2px;
+    background: var(--line-soft);
+  }
+
+  /* Latest work item lifecycle chrome in 1.5px inset panel */
+  .lifecycle-inset {
+    margin: 0.5rem 0 0 2.95rem;
+    border: 1.5px solid var(--ink);
+    background: var(--panel);
+    padding: 0.55rem 0.65rem;
+  }
+
+  /* Blank slate (§4.7) — home + repos zero-repo state */
+  .blank-slate {
+    display: grid;
+    justify-items: center;
+    border: 2px dashed var(--ink);
+    background: var(--panel);
+    padding: 2.4rem 1.5rem 2.2rem;
+    text-align: center;
+  }
+
+  @media (min-width: 640px) {
+    .blank-slate {
+      padding: 2.8rem 2.5rem 2.5rem;
+    }
+  }
+
+  .blank-slate-title {
+    margin: 0.7rem 0 0;
+    font-family: var(--font-display);
+    font-size: clamp(1.35rem, 2.6vw, 1.85rem);
+    font-weight: 800;
+    letter-spacing: -0.01em;
+    text-transform: uppercase;
+    line-height: 1.05;
+    color: var(--ink);
+  }
+
+  .blank-slate-form {
+    display: flex;
+    width: 100%;
+    max-width: 36rem;
+    flex-direction: column;
+    gap: 0.75rem;
+    margin-top: 1.4rem;
+    text-align: left;
+  }
+
+  .blank-slate-form--flush {
+    margin-top: 0;
+  }
+
+  .blank-slate-path-row {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+
+  @media (min-width: 640px) {
+    .blank-slate-path-row {
+      flex-direction: row;
+      align-items: stretch;
+    }
+  }
+
+  .blank-slate-input {
+    min-width: 0;
+    flex: 1 1 auto;
+    border: 1.5px solid var(--ink);
+    background: var(--paper);
+    padding: 0.55rem 0.7rem;
+    font-family: var(--font-mono);
+    font-size: 0.85rem;
+    color: var(--ink);
+  }
+
+  .blank-slate-input::placeholder {
+    color: var(--ink-faint);
+  }
+
+  .blank-slate-input:disabled {
+    opacity: 0.6;
+  }
+
+  .blank-slate-actions {
+    display: flex;
+    flex-shrink: 0;
+    gap: 0.45rem;
+  }
+
+  .blank-slate-fieldset {
+    display: grid;
+    gap: 0.75rem;
+    margin: 0;
+    border: 1.5px solid var(--ink);
+    padding: 0.9rem 1rem 1rem;
+  }
+
+  .blank-slate-fieldset legend {
+    padding: 0 0.35rem;
+    font-family: var(--font-mono);
+    font-size: 0.62rem;
+    font-weight: 700;
+    letter-spacing: 0.16em;
+    text-transform: uppercase;
+    color: var(--ink-faint);
+  }
+
+  .blank-slate-field {
+    display: grid;
+    gap: 0.35rem;
+    font-family: var(--font-display);
+    font-size: 0.85rem;
+    font-weight: 600;
+    color: var(--ink-dim);
+  }
+
+  .blank-slate-field select,
+  .blank-slate-field input {
+    border: 1.5px solid var(--ink);
+    background: var(--paper);
+    padding: 0.5rem 0.65rem;
+    font-family: var(--font-mono);
+    font-size: 0.85rem;
+    font-weight: 400;
+    color: var(--ink);
+  }
+
+  .blank-slate-hint {
+    margin: 0;
+    font-family: var(--font-mono);
+    font-size: 0.62rem;
+    letter-spacing: 0.04em;
+    color: var(--ink-faint);
+  }
+
+  .blank-slate-divider {
+    display: flex;
+    width: 100%;
+    max-width: 36rem;
+    align-items: center;
+    gap: 0.85rem;
+    margin-top: 1.6rem;
+  }
+
+  .blank-slate-divider::before,
+  .blank-slate-divider::after {
+    content: "";
+    flex: 1 1 auto;
+    height: 1px;
+    background: var(--line-ghost);
+  }
+
+  .blank-slate-divider span {
+    font-family: var(--font-mono);
+    font-size: 0.62rem;
+    font-weight: 700;
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+    color: var(--ink-faint);
+  }
+
+  .blank-slate-cli {
+    margin: 1rem 0 0;
+    max-width: 36rem;
+    font-family: var(--font-display);
+    font-size: 0.9rem;
+    font-weight: 500;
+    color: var(--ink-dim);
+  }
+
+  .blank-slate .guidance-code {
+    margin-top: 0.75rem;
+    padding: 0.45rem 0.7rem;
+    font-size: 0.82rem;
+  }
+
+  .repo-card-skeleton {
+    display: grid;
+    gap: 0.75rem;
+    border: 1.5px solid var(--line-ghost);
+    background: var(--panel);
+    padding: 1rem 1.1rem;
   }
 }
 

--- a/apps/harness/test/blank-slate-add-command.test.ts
+++ b/apps/harness/test/blank-slate-add-command.test.ts
@@ -71,6 +71,25 @@ describe("blank-slate add repository command", () => {
     expect(blank).toContain('heading="No repositories configured"')
   })
 
+  test("blank slate uses Interchange §4.7 Setup kicker, dashed panel, primary plate", () => {
+    const guidance = addRepositoryGuidanceSource()
+    expect(guidance).toContain('className="blank-slate"')
+    expect(guidance).toContain('className="kicker-tag"')
+    expect(guidance).toContain("Setup")
+    expect(guidance).toContain("blank-slate-title")
+    expect(guidance).toContain("blank-slate-input")
+    expect(guidance).toContain("plate-mini")
+    expect(guidance).toContain("plate-primary")
+    expect(guidance).toContain("blank-slate-fieldset")
+    expect(guidance).toContain("Confirm forge identity")
+    expect(guidance).toContain("guidance-code")
+    expect(guidance).toContain('tone="alarm"')
+    expect(guidance).toContain('role="alert"')
+    // Ledger serif / oxblood CTA language is gone from this surface.
+    expect(guidance).not.toContain("font-serif")
+    expect(guidance).not.toContain("bg-oxblood")
+  })
+
   test("shows add-repository guidance in the empty state via shared blank slate", () => {
     const cards = repositoryCardsSource()
     const emptyStart = cards.indexOf("if (repositories.length === 0)")
@@ -119,7 +138,8 @@ describe("blank-slate add repository command", () => {
     // Host folder dialog is long-lived; must not share the batched client.
     expect(guidance).toContain("graphqlUnbatched.mutation")
     expect(guidance).toContain("Browse…")
-    expect(guidance).toContain("--- or ---")
+    expect(guidance).toContain("blank-slate-divider")
+    expect(guidance).toContain(">or</")
     expect(guidance).toContain('id="add-repository-path"')
     expect(guidance).toContain('placeholder="/path/to/local/repo"')
     expect(guidance).toContain(
@@ -129,7 +149,7 @@ describe("blank-slate add repository command", () => {
     expect(guidance).toContain("pickToAddBridging")
     expect(guidance).toContain("setPickToAddBridging(true)")
 
-    const separatorAt = guidance.indexOf("--- or ---")
+    const separatorAt = guidance.indexOf("blank-slate-divider")
     const cliCopyAt = guidance.indexOf(
       "Add a local Git repository with the operator binary:",
     )

--- a/apps/harness/test/card-collapse-ui.test.ts
+++ b/apps/harness/test/card-collapse-ui.test.ts
@@ -42,6 +42,6 @@ describe("collapsible repository cards", () => {
     expect(source).toContain("aria-controls={controlsId}")
     expect(source).toContain("Expand ")
     expect(source).toContain("Collapse ")
-    expect(source).toContain("focus-visible:outline-2")
+    expect(source).toContain("icon-btn")
   })
 })

--- a/apps/harness/test/parent-issue-actions-menu.test.tsx
+++ b/apps/harness/test/parent-issue-actions-menu.test.tsx
@@ -101,6 +101,12 @@ describe("ParentIssueActionsMenu", () => {
     )
     expect(html).toContain('role="alert"')
     expect(html).toContain("Could not start Implement all with auto-merge")
+    // In-flow alarm Banner (not absolute under kebab).
+    expect(html).toContain("banner--compact")
+    expect(html).toContain("parent-issue-error")
+    expect(html).toContain("banner-tag")
+    expect(html).toContain("Error")
+    expect(html).not.toContain("absolute top-full right-0 z-10 mt-1 w-56")
   })
 
   test("menu source exposes sole menuitem label Implement all with auto-merge", () => {
@@ -118,19 +124,19 @@ describe("ParentIssueActionsMenu", () => {
     expect(source.match(/role="menuitem"/g)?.length).toBe(1)
   })
 
-  test("menu shell resets inherited mono/uppercase styles to match other app menus", () => {
+  test("menu uses Interchange mono uppercase menuitems and icon-btn trigger", () => {
     const source = readFileSync(
       join(import.meta.dir, "../src/parent-issue-actions-menu.tsx"),
       "utf8",
     )
-    // Other menus (leaf issue, repository card) use plain sans menuitems.
-    // Explicit resets keep the kebab menu correct if a parent stamp/label wraps it.
+    // §4.10 / phase 4: icon-btn trigger; mono uppercase items (no Ledger shadow).
+    expect(source).toContain('className="icon-btn"')
     expect(source).toMatch(
-      /role="menu"[\s\S]*?font-sans[\s\S]*?normal-case[\s\S]*?tracking-normal/,
+      /role="menu"[\s\S]*?border-2 border-ink[\s\S]*?role="menuitem"/,
     )
-    expect(source).toContain(
-      'className="block w-full px-3 py-2 text-left text-sm font-medium text-ink-2 hover:bg-paper-2"',
-    )
+    expect(source).toContain("font-mono")
+    expect(source).toContain("uppercase")
+    expect(source).not.toContain("shadow-[")
   })
 })
 
@@ -149,20 +155,15 @@ describe("ParentIssueGroup control order", () => {
 
     // Anchor on the UI closed-count label, not the closedChildren prop name.
     const closedLabel = group.indexOf("childIssues.length} closed")
-    const chevron = group.indexOf("group-open:rotate-180")
+    const chevron = group.indexOf("parent-issue-chevron")
     const kebab = group.indexOf("<ParentIssueActionsMenu")
     expect(closedLabel).toBeGreaterThanOrEqual(0)
     expect(chevron).toBeGreaterThan(closedLabel)
     expect(kebab).toBeGreaterThan(chevron)
 
-    // Stamp mono/uppercase applies only to the closed count, not the controls.
-    // Chevron keeps text-ink-faint for currentColor without re-wrapping the menu.
-    expect(group).toMatch(
-      /font-mono text-xs font-semibold tracking-\[0\.1em\] text-ink-faint uppercase[\s\S]*?closed/,
-    )
-    expect(group).toContain(
-      "size-3.5 text-ink-faint transition-transform group-open:rotate-180",
-    )
+    // Closed-count mono chip sits left of the chevron and kebab.
+    expect(group).toContain("parent-issue-closed-count")
+    expect(group).toContain("parent-issue-summary-actions")
     expect(group).not.toMatch(/flex shrink-0 items-center gap-1\.5 font-mono/)
   })
 })

--- a/apps/harness/test/repos-interchange.test.ts
+++ b/apps/harness/test/repos-interchange.test.ts
@@ -1,0 +1,206 @@
+import { readFileSync } from "node:fs"
+import { join } from "node:path"
+import { describe, expect, test } from "bun:test"
+
+const homeSource = () =>
+  readFileSync(join(import.meta.dir, "../src/routes/index.tsx"), "utf8")
+
+const stylesSource = () =>
+  readFileSync(join(import.meta.dir, "../src/styles.css"), "utf8")
+
+const sliceBetweenMarkers = (
+  source: string,
+  startMarker: string,
+  endMarker: string,
+): string => {
+  const start = source.indexOf(startMarker)
+  if (start < 0) {
+    throw new Error(`Start marker not found: ${startMarker}`)
+  }
+  const end = source.indexOf(endMarker, start)
+  if (end < 0) {
+    throw new Error(`End marker not found after ${startMarker}: ${endMarker}`)
+  }
+  return source.slice(start, end)
+}
+
+/**
+ * Interchange phase 4 — repos page + blank slate (issue #703 / §4.6–4.7).
+ * Structural + design-token contract tests; no behavior changes.
+ */
+describe("Interchange phase 4: repos page + blank slate", () => {
+  test("repo cards use 1.5px ticket shell, display title, mono PR count, icon controls", () => {
+    const source = homeSource()
+    // Card chrome only (settings dialog stays on Ledger until phase 5).
+    const head = sliceBetweenMarkers(source, 'className="repo-card"', "<dialog")
+    expect(head).toContain("repo-card-title")
+    expect(head).toContain("repo-card-link")
+    expect(head).toContain("repo-card-pr-count")
+    expect(head).toContain("repo-card-controls")
+    expect(head).toContain("icon-btn")
+    expect(head).not.toContain("font-serif")
+    expect(head).not.toContain("border-t-2 border-ink-soft")
+    // Pause/armed classes are composed above the JSX return.
+    expect(source).toContain("icon-btn--paused")
+    expect(source).toContain("icon-btn--armed")
+    expect(source).toContain("pauseButtonClassName")
+    expect(source).toContain('className="repo-card"')
+
+    const styles = stylesSource()
+    expect(styles).toContain(".repo-card {")
+    expect(styles).toContain("border: 1.5px solid var(--ink)")
+    expect(styles).toContain(".repo-card-title")
+    expect(styles).toContain("font-size: 1.06rem")
+    expect(styles).toContain("text-decoration-color: var(--signal)")
+  })
+
+  test("meta table is hairline two-column mono dt/dd with harness-default annotations", () => {
+    const body = sliceBetweenMarkers(
+      homeSource(),
+      'className="repo-meta"',
+      "function RepositoryIssues(",
+    )
+    expect(body).toContain("repo-meta-row")
+    expect(body).toContain("Harness default (")
+    expect(body).toContain("<dt>Path</dt>")
+    expect(body).toContain("<dt>Agent Backend</dt>")
+
+    const styles = stylesSource()
+    expect(styles).toContain(".repo-meta {")
+    expect(styles).toContain("border-top: 1px solid var(--line-ghost)")
+    expect(styles).toContain("border-bottom: 1px solid var(--line-ghost)")
+    expect(styles).toContain("grid-template-columns: repeat(2, minmax(0, 1fr))")
+  })
+
+  test("credential banners use Attention tag, primary-plate CTAs, guidance-code chips", () => {
+    const body = sliceBetweenMarkers(
+      homeSource(),
+      'className="repo-meta"',
+      "function RepositoryIssues(",
+    )
+    expect(body).toContain('tag="Attention"')
+    expect(body).toContain("GitHub token required")
+    expect(body).toContain("GitLab authentication required")
+    expect(body).toContain('className="plate-primary"')
+    expect(body).toContain("Create GitHub token")
+    expect(body).toContain("Store in Keymaxxer")
+    expect(body).toContain('className="guidance-code"')
+
+    const styles = stylesSource()
+    expect(styles).toContain(".plate-primary")
+    expect(styles).toContain(".guidance-code")
+    expect(styles).toMatch(
+      /\.plate-primary\s*\{[^}]*background:\s*var\(--ink\)/s,
+    )
+    expect(styles).toMatch(
+      /\.plate-primary:hover\s*\{[^}]*background:\s*var\(--signal\)/s,
+    )
+  })
+
+  test("relevant issues use ticket rows; Closed dashed stamp; Blocked Queue-yellow without wash", () => {
+    const issues = sliceBetweenMarkers(
+      homeSource(),
+      "function RepositoryIssueRow(",
+      "export function SessionUsageDialog(",
+    )
+    expect(issues).toContain('className="repo-issue"')
+    expect(issues).toContain("repo-issue-num")
+    expect(issues).toContain("repo-issue-title")
+    expect(issues).toContain("repo-issue-author")
+    expect(issues).toContain('className="stamp stamp--closed"')
+    expect(issues).toContain("Closed")
+    expect(issues).toContain('className="stamp stamp--blocked"')
+    expect(issues).toContain("Blocked")
+    expect(issues).toContain("repo-issue-blocked-by")
+    expect(issues).toContain("Blocked by")
+    // Old amber row-wash language is dropped.
+    expect(issues).not.toContain("bg-amber-wash")
+    expect(issues).not.toContain("border-sepia")
+    expect(issues).not.toContain("text-sepia")
+    expect(issues).not.toContain("font-serif")
+
+    const styles = stylesSource()
+    expect(styles).toContain(".stamp--closed")
+    expect(styles).toContain(".stamp--blocked")
+    expect(styles).toContain("border-style: dashed")
+    expect(styles).toContain("background: var(--lane-queue)")
+  })
+
+  test("latest work item lifecycle chrome sits in 1.5px inset panel", () => {
+    const lifecycle = sliceBetweenMarkers(
+      homeSource(),
+      "export function WorkItemLifecycleStatus(",
+      "function RepositoryIssuesSkeleton(",
+    )
+    expect(lifecycle).toContain('compact ? "mt-2" : "lifecycle-inset"')
+
+    const styles = stylesSource()
+    expect(styles).toContain(".lifecycle-inset")
+    expect(styles).toMatch(
+      /\.lifecycle-inset\s*\{[^}]*border:\s*1\.5px solid var\(--ink\)/s,
+    )
+  })
+
+  test("parent issue groups use details card and 2px line-soft child rule", () => {
+    const parent = sliceBetweenMarkers(
+      homeSource(),
+      "function ParentIssueGroup(",
+      "function RepositoryIssueRow(",
+    )
+    expect(parent).toContain('className="parent-issue"')
+    expect(parent).toContain("parent-issue-children")
+    expect(parent).toContain("parent-issue-closed-count")
+    expect(parent).toContain("repo-issue-title")
+    expect(parent).not.toContain("font-serif")
+    // Implement-all failure is in-flow under the summary (not absolute on kebab).
+    expect(parent).toContain("parent-issue-error")
+    expect(parent).toContain("implementAll.isError")
+    expect(parent).toContain('tone="alarm"')
+    expect(parent).toContain("Could not start Implement all with auto-merge")
+    expect(parent).toContain("errorMessage={null}")
+
+    const styles = stylesSource()
+    expect(styles).toContain(".parent-issue {")
+    expect(styles).toContain(".parent-issue-children::before")
+    expect(styles).toContain("width: 2px")
+    expect(styles).toContain("background: var(--line-soft)")
+    expect(styles).toContain(".parent-issue-error")
+  })
+
+  test("repos surface locks alarm Banner weighting for leaf/refresh/remove failures", () => {
+    const source = homeSource()
+    // Leaf implement/queue failures.
+    const leaf = sliceBetweenMarkers(
+      source,
+      "function RepositoryIssueRow(",
+      "export function SessionUsageDialog(",
+    )
+    expect(leaf).toContain("banner--compact repo-issue-error")
+    expect(leaf).toContain('tone="alarm"')
+    expect(leaf).toContain('tag="Error"')
+    expect(leaf).toContain("Could not queue issue")
+    expect(leaf).toContain("Could not start implementation")
+
+    // Refresh + remove failures live on the card body (after settings dialog).
+    const cardBody = sliceBetweenMarkers(
+      source,
+      'className="repo-meta"',
+      "function RepositoryIssues(",
+    )
+    expect(cardBody).toContain("Failed to refresh issues.")
+    expect(cardBody).toContain("Could not remove repository. Please try again.")
+    expect(cardBody).toContain('className="banner--compact mb-2"')
+    expect(cardBody).toContain('className="banner--compact mt-3"')
+    expect(cardBody).toContain('tone="alarm"')
+  })
+
+  test("blank slate and plate-primary styles exist for shared zero-repo surface", () => {
+    const styles = stylesSource()
+    expect(styles).toContain(".blank-slate {")
+    expect(styles).toContain("border: 2px dashed var(--ink)")
+    expect(styles).toContain(".blank-slate-title")
+    expect(styles).toContain(".blank-slate-fieldset")
+    expect(styles).toContain(".blank-slate-divider")
+    expect(styles).toContain(".plate-primary")
+  })
+})

--- a/apps/harness/test/repository-header-pr-count.test.ts
+++ b/apps/harness/test/repository-header-pr-count.test.ts
@@ -79,8 +79,7 @@ describe("repository header pull request count", () => {
     expect(header).toContain('className="sr-only"')
     expect(header).toContain("{pullRequestCountLabel}")
     expect(header).toContain('aria-hidden="true"')
-    expect(header).toContain("shrink-0")
-    expect(header).toContain("tabular-nums")
+    expect(header).toContain("repo-card-pr-count")
   })
 
   test("header uses presentation helper with isPending and isFetching", () => {

--- a/apps/harness/test/repository-settings-wait-for-ready-checks.test.ts
+++ b/apps/harness/test/repository-settings-wait-for-ready-checks.test.ts
@@ -33,6 +33,6 @@ describe("Repository settings Wait for checks to start after ready for review", 
     )
     expect(source).toContain("repository.waitForReadyForReviewChecks")
     expect(source).toContain('? "Enabled"')
-    expect(source).toContain("Wait for ready checks:")
+    expect(source).toContain("Wait for ready checks")
   })
 })


### PR DESCRIPTION
Summary

Land phase 4 of the Harness Interchange design system: re-skin the
repositories page and the shared zero-repo blank slate to the de-trained
Interchange spec (§4.6–4.7). Phases 1–3 already shipped tokens, nav/banners,
board, and completed archive; this surface had no prototype, so the written
spec governs.

Why

Issue #703 continues the unified industrial UI after phase 3. The repos page
and first-run blank slate still used Ledger density (serif titles, amber
blocked wash, oxblood CTAs, rule-bordered cards). Operators need configured
repos and setup to read as the same ticket language as the board and
archive—without behavior changes.

What changed

- Repo cards: 1.5px ink ticket shell; display projectPath link (signal
  underline); mono open-PR count; icon-btn collapse / pause / kebab.
- Meta table: hairline two-column mono dt/dd with Harness-default inherit
  annotations.
- Credential banners: phase-1 alarm Banner + Attention tag; primary-plate
  CTAs; guidance-code chips.
- Relevant issues: ticket anatomy rows; Closed = dashed neutral stamp;
  Blocked = solid Queue-yellow stamp; amber row-wash dropped; "Blocked by
  #n" mono line kept.
- Latest work item: lifecycle chrome in 1.5px inset panel
  (lifecycle-inset).
- Parent issue groups: details card; 2px --line-soft left rule for children;
  implement-all failure as in-flow alarm Banner under the summary (not
  absolute under the kebab).
- Blank slate (home + repos): dashed ink panel, Setup kicker, mono path
  field, plate-mini Browse, plate-primary submit, forge fieldset, mono "or"
  divider, CLI guidance-code, compact alarm errors.
- Review remediations: leaf implement/queue, refresh, and remove failures
  use compact alarm Banners; dead repo-card-head--collapsed removed;
  contract tests lock structure and Banner weighting.

Verification

- bunx nx test harness (full package; 455+ tests green after remediations)
- Focused: repos-interchange, blank-slate, parent-issue-actions-menu,
  card-collapse-ui, repository-header-pr-count
- Harness tsc --noEmit and Biome on touched files

Limitations

- Settings and session-usage dialogs stay on Ledger chrome (phase 5).
- Kebab menu panel/item classes remain triplicated inline Tailwind; shared
  menu CSS deferred with dialogs/menus phase.
- No behavior changes to add/pause/refresh/implement/remove/settings.

Closes #703