### PR TITLE
feat(harness): interchange phase 5 dialogs, menus, chrome + Ledger teardown

### DIFF
--- a/apps/harness/src/parent-issue-actions-menu.tsx
+++ b/apps/harness/src/parent-issue-actions-menu.tsx
@@ -69,14 +69,11 @@ export function ParentIssueActionsMenu({
           </svg>
         </button>
         {menuOpen && (
-          <div
-            role="menu"
-            className="absolute top-full right-0 z-10 mt-1 min-w-56 border-2 border-ink bg-panel py-1"
-          >
+          <div role="menu" className="menu-panel min-w-56">
             <button
               type="button"
               role="menuitem"
-              className="block w-full px-3 py-2 text-left font-mono text-[0.68rem] font-medium tracking-[0.08em] text-ink-2 uppercase hover:bg-[var(--plate-hover)]"
+              className="menu-item"
               disabled={pending}
               onClick={(event: MouseEvent<HTMLButtonElement>) => {
                 event.stopPropagation()

--- a/apps/harness/src/routes/__root.tsx
+++ b/apps/harness/src/routes/__root.tsx
@@ -174,7 +174,7 @@ export const Route = createRootRouteWithContext<RouterContext>()({
   component: RootComponent,
   shellComponent: RootDocument,
   notFoundComponent: () => (
-    <div className="field-rule mx-auto mt-12 max-w-xl p-8 text-center">
+    <div className="not-found-panel">
       <p>Page not found.</p>
       <Link
         className="mt-2 inline-block text-ink underline decoration-signal underline-offset-4 hover:text-ink-dim"
@@ -845,7 +845,7 @@ function SettingsChrome() {
 
       <dialog
         ref={dialogRef}
-        className="m-auto w-[min(92vw,32rem)] border border-rule-2 bg-panel p-0 text-ink shadow-[0_18px_50px_rgb(28_22_14_/_18%)] backdrop:bg-black/50"
+        className="dialog-panel"
         aria-labelledby="settings-title"
         onCancel={(event) => {
           if (updateConfig.isPending) event.preventDefault()
@@ -853,25 +853,24 @@ function SettingsChrome() {
         onClose={() => setDialogOpen(false)}
       >
         <form onSubmit={saveSettings}>
-          <div className="border-b border-rule px-6 py-5">
-            <p className="font-mono text-xs font-semibold tracking-[0.22em] text-oxblood uppercase">
-              Harness defaults
-            </p>
-            <h2
-              id="settings-title"
-              className="mt-1.5 font-serif text-2xl font-semibold tracking-[-0.01em]"
-            >
+          <div className="dialog-header">
+            <p className="dialog-kicker">Harness defaults</p>
+            <h2 id="settings-title" className="dialog-title">
               Harness settings
             </h2>
-            <p className="mt-1.5 text-sm text-ink-soft">
+            <p className="dialog-lede">
               Defaults for agent sessions and Agent Turn concurrency.
             </p>
             {showUnconfiguredGuidance && (
-              <p className="mt-3 border border-oxblood/40 bg-oxblood-wash p-3 text-sm text-oxblood-deep">
+              <Banner
+                className="banner--compact mt-3"
+                tone="guidance"
+                tag="Setup"
+              >
                 Select a default agent backend, and default build model.
                 Optionally select a different review model (recommended). You
                 can override this per configured repo.
-              </p>
+              </Banner>
             )}
             {!backendChanging &&
               (unavailableStatuses.length > 0 ||
@@ -884,34 +883,41 @@ function SettingsChrome() {
                       ? [defaultStatus as AgentBackendStatusRow]
                       : []
                   ).map((row) => (
-                    <p
+                    <Banner
                       key={row.backend.id}
-                      className="border border-oxblood/40 bg-oxblood-wash p-3 text-sm text-oxblood-deep"
+                      className="banner--compact"
+                      tone="alarm"
+                      tag="Backend"
+                      role="alert"
                     >
                       <span className="font-semibold">{row.backend.label}</span>
                       {": "}
                       {row.reason ?? "Agent Backend is unavailable."}
-                    </p>
+                    </Banner>
                   ))}
                 </div>
               )}
           </div>
 
-          <div className="grid gap-5 px-6 py-5">
+          <div className="dialog-body">
             {config.isPending || modelsLoading ? (
-              <p className="text-sm text-ink-soft">Loading settings...</p>
+              <p className="dialog-loading">Loading settings...</p>
             ) : config.isError ||
               (!backendChanging &&
                 (models.isError || backendStatus.isError)) ? (
-              <p className="border border-oxblood/40 bg-oxblood-wash p-3 text-sm text-oxblood-deep">
+              <Banner
+                className="banner--compact"
+                tone="alarm"
+                tag="Error"
+                role="alert"
+              >
                 Settings could not be loaded. Close this dialog and try again.
-              </p>
+              </Banner>
             ) : (
               <>
-                <label className="grid min-w-0 gap-1.5 text-sm font-semibold">
+                <label className="dialog-field">
                   Default Agent Backend
                   <select
-                    className="w-full min-w-0 border border-rule-2 bg-paper px-3 py-2 text-sm font-normal outline-none focus:border-oxblood focus:ring-2 focus:ring-oxblood/15 disabled:cursor-not-allowed disabled:opacity-60"
                     name="selectedAgentBackend"
                     value={selectedAgentBackend}
                     disabled={backendChangeBlocked || updateConfig.isPending}
@@ -927,7 +933,7 @@ function SettingsChrome() {
                       ),
                     )}
                   </select>
-                  <span className="text-xs font-normal text-ink-faint">
+                  <span className="dialog-field-hint">
                     {backendChangeBlocked
                       ? `${blockingUnfinishedWorkItemCount} unfinished Work Item${
                           blockingUnfinishedWorkItemCount === 1 ? "" : "s"
@@ -941,14 +947,12 @@ function SettingsChrome() {
                   </span>
                 </label>
 
-                <div className="grid gap-2">
-                  <div className="flex flex-wrap items-center justify-between gap-2">
-                    <p className="m-0 text-xs font-semibold tracking-[0.12em] text-ink-faint uppercase">
-                      Active Agent Backends
-                    </p>
+                <div className="dialog-status-block">
+                  <div className="dialog-status-head">
+                    <p className="dialog-status-label">Active Agent Backends</p>
                     <button
                       type="button"
-                      className="border border-rule-2 bg-paper px-2 py-1 text-xs font-semibold text-ink-2 hover:bg-paper-2 disabled:opacity-50"
+                      className="plate-mini"
                       disabled={recheckBusy || backendChanging}
                       onClick={() => {
                         void recheckAllBackends()
@@ -966,14 +970,9 @@ function SettingsChrome() {
                     const isDefault = row.backend.id === savedAgentBackend
                     const rowRechecking = recheckingBackendId === row.backend.id
                     return (
-                      <div
-                        key={row.backend.id}
-                        className="flex flex-wrap items-center justify-between gap-2 border border-rule bg-paper-2 px-3 py-2"
-                      >
-                        <p className="m-0 text-xs text-ink-soft">
-                          <span className="font-semibold text-ink-2">
-                            {row.backend.label}
-                          </span>
+                      <div key={row.backend.id} className="dialog-status-row">
+                        <p className="m-0">
+                          <strong>{row.backend.label}</strong>
                           {isDefault ? " · Default" : null}
                           {row.kind === "READY" ? " · Ready" : " · Unavailable"}
                           {backendChanging &&
@@ -986,7 +985,7 @@ function SettingsChrome() {
                         </p>
                         <button
                           type="button"
-                          className="border border-rule-2 bg-paper px-2 py-1 text-xs font-semibold text-ink-2 hover:bg-paper-2 disabled:opacity-50"
+                          className="plate-mini"
                           disabled={recheckBusy || backendChanging}
                           onClick={() => {
                             setRecheckAllFailures([])
@@ -1001,24 +1000,28 @@ function SettingsChrome() {
                     )
                   })}
                   {statuses.length === 0 && defaultStatus === undefined && (
-                    <p className="m-0 text-xs text-ink-soft">
+                    <p className="dialog-loading">
                       No Active Agent Backend status yet.
                     </p>
                   )}
                 </div>
 
                 {backendChanging && previewError !== null && (
-                  <p className="border border-oxblood/40 bg-oxblood-wash p-3 text-sm text-oxblood-deep">
+                  <Banner
+                    className="banner--compact"
+                    tone="alarm"
+                    tag="Preview"
+                    role="alert"
+                  >
                     Preview failed: {previewError}. Model fields stay disabled
                     until preview succeeds. Active backend is unchanged until
                     Save.
-                  </p>
+                  </Banner>
                 )}
 
-                <label className="grid min-w-0 gap-1.5 text-sm font-semibold">
+                <label className="dialog-field dialog-field-mono">
                   Build model
                   <select
-                    className="w-full min-w-0 border border-rule-2 bg-paper px-3 py-2 font-mono text-sm font-normal outline-none focus:border-oxblood focus:ring-2 focus:ring-oxblood/15 disabled:cursor-not-allowed disabled:opacity-60"
                     name="defaultModel"
                     value={defaultModel}
                     onChange={(event) => {
@@ -1058,27 +1061,31 @@ function SettingsChrome() {
                       </option>
                     ))}
                   </select>
-                  <span className="text-xs font-normal text-ink-faint">
+                  <span className="dialog-field-hint">
                     Used for implement and other build steps.
                   </span>
                 </label>
 
                 {defaultModel.length > 0 && hasUnavailableBuildModel ? (
-                  <p className="border border-oxblood/40 bg-oxblood-wash p-3 text-sm text-oxblood-deep">
+                  <Banner
+                    className="banner--compact"
+                    tone="alarm"
+                    tag="Model"
+                    role="alert"
+                  >
                     Build effort (thinking) is unavailable — the selected model
                     is not in the Agent Model catalog. Choose another build
                     model.
-                  </p>
+                  </Banner>
                 ) : defaultModel.length > 0 && buildVariants.length === 0 ? (
-                  <p className="bg-paper-2 p-3 text-sm text-ink-soft">
+                  <p className="dialog-note">
                     Build effort (thinking) is unavailable — this model has no
                     effort (thinking) options.
                   </p>
                 ) : (
-                  <label className="grid min-w-0 gap-1.5 text-sm font-semibold">
+                  <label className="dialog-field">
                     Build effort (thinking)
                     <select
-                      className="w-full min-w-0 border border-rule-2 bg-paper px-3 py-2 text-sm font-normal outline-none focus:border-oxblood focus:ring-2 focus:ring-oxblood/15 disabled:cursor-not-allowed disabled:opacity-60"
                       name="defaultThinkingLevel"
                       value={defaultThinkingLevel}
                       onChange={(event) =>
@@ -1102,17 +1109,16 @@ function SettingsChrome() {
                         </option>
                       ))}
                     </select>
-                    <span className="text-xs font-normal text-ink-faint">
+                    <span className="dialog-field-hint">
                       Optional effort (thinking) for this model. Options come
                       from the selected model.
                     </span>
                   </label>
                 )}
 
-                <label className="grid min-w-0 gap-1.5 text-sm font-semibold">
+                <label className="dialog-field dialog-field-mono">
                   Review model
                   <select
-                    className="w-full min-w-0 border border-rule-2 bg-paper px-3 py-2 font-mono text-sm font-normal outline-none focus:border-oxblood focus:ring-2 focus:ring-oxblood/15 disabled:cursor-not-allowed disabled:opacity-60"
                     name="reviewModel"
                     value={reviewModel}
                     disabled={modelsDisabled}
@@ -1140,7 +1146,7 @@ function SettingsChrome() {
                       </option>
                     ))}
                   </select>
-                  <span className="text-xs font-normal text-ink-faint">
+                  <span className="dialog-field-hint">
                     Used only for the review step. Empty uses the build model.
                   </span>
                 </label>
@@ -1148,22 +1154,26 @@ function SettingsChrome() {
                 {reviewThinkingLevelSourceModel.length > 0 &&
                 ((reviewModel.length > 0 && hasUnavailableReviewModel) ||
                   (reviewModel.length === 0 && hasUnavailableBuildModel)) ? (
-                  <p className="border border-oxblood/40 bg-oxblood-wash p-3 text-sm text-oxblood-deep">
+                  <Banner
+                    className="banner--compact"
+                    tone="alarm"
+                    tag="Model"
+                    role="alert"
+                  >
                     Review effort (thinking) is unavailable — the selected model
                     is not in the Agent Model catalog. Choose another model or
                     use the build model.
-                  </p>
+                  </Banner>
                 ) : reviewThinkingLevelSourceModel.length > 0 &&
                   reviewThinkingLevels.length === 0 ? (
-                  <p className="bg-paper-2 p-3 text-sm text-ink-soft">
+                  <p className="dialog-note">
                     Review effort (thinking) is unavailable — this model has no
                     effort (thinking) options.
                   </p>
                 ) : (
-                  <label className="grid min-w-0 gap-1.5 text-sm font-semibold">
+                  <label className="dialog-field">
                     Review effort (thinking)
                     <select
-                      className="w-full min-w-0 border border-rule-2 bg-paper px-3 py-2 text-sm font-normal outline-none focus:border-oxblood focus:ring-2 focus:ring-oxblood/15 disabled:cursor-not-allowed disabled:opacity-60"
                       name="reviewThinkingLevel"
                       value={reviewThinkingLevel}
                       onChange={(event) => setReviewVariant(event.target.value)}
@@ -1188,10 +1198,9 @@ function SettingsChrome() {
                   </label>
                 )}
 
-                <label className="grid min-w-0 gap-1.5 text-sm font-semibold">
+                <label className="dialog-field">
                   Max concurrent Agent Turns
                   <input
-                    className="w-full min-w-0 border border-rule-2 bg-paper px-3 py-2 text-sm font-normal outline-none focus:border-oxblood focus:ring-2 focus:ring-oxblood/15"
                     name="maxConcurrentAgentTurns"
                     type="number"
                     min={1}
@@ -1202,16 +1211,15 @@ function SettingsChrome() {
                       setMaxConcurrentOpencodeSessions(event.target.value)
                     }
                   />
-                  <span className="text-xs font-normal text-ink-faint">
+                  <span className="dialog-field-hint">
                     Caps how many Agent Turn CLI processes run at once (default
                     2). Agent-free steps and model listing are not counted.
                   </span>
                 </label>
 
-                <label className="grid min-w-0 gap-1.5 text-sm font-semibold">
+                <label className="dialog-field">
                   Max concurrent Work Items
                   <input
-                    className="w-full min-w-0 border border-rule-2 bg-paper px-3 py-2 text-sm font-normal outline-none focus:border-oxblood focus:ring-2 focus:ring-oxblood/15"
                     name="maxConcurrentWorkItems"
                     type="number"
                     min={1}
@@ -1222,7 +1230,7 @@ function SettingsChrome() {
                       setMaxConcurrentWorkItems(event.target.value)
                     }
                   />
-                  <span className="text-xs font-normal text-ink-faint">
+                  <span className="dialog-field-hint">
                     Caps how many Work Items may be Admitted at once (Worker
                     Slots, default 5). Extra Implement requests wait for a free
                     slot.
@@ -1232,37 +1240,52 @@ function SettingsChrome() {
             )}
 
             {updateConfig.isError && (
-              <p className="border border-oxblood/40 bg-oxblood-wash p-3 text-sm text-oxblood-deep">
+              <Banner
+                className="banner--compact"
+                tone="alarm"
+                tag="Error"
+                role="alert"
+              >
                 {updateConfig.error instanceof Error
                   ? updateConfig.error.message
                   : "Settings could not be saved. Check the values and try again."}
-              </p>
+              </Banner>
             )}
             {recheckAllFailures.length > 0 && (
-              <p className="border border-oxblood/40 bg-oxblood-wash p-3 text-sm text-oxblood-deep">
+              <Banner
+                className="banner--compact"
+                tone="alarm"
+                tag="Recheck"
+                role="alert"
+              >
                 Recheck failed for{" "}
                 {recheckAllFailures.length === 1
                   ? recheckAllFailures[0]
                   : recheckAllFailures.join(", ")}
                 . Other backends may have refreshed. Try again after fixing
                 those Agent Backends.
-              </p>
+              </Banner>
             )}
             {recheckAllFailures.length === 0 && recheckBackend.isError && (
-              <p className="border border-oxblood/40 bg-oxblood-wash p-3 text-sm text-oxblood-deep">
+              <Banner
+                className="banner--compact"
+                tone="alarm"
+                tag="Recheck"
+                role="alert"
+              >
                 Recheck failed
                 {recheckBackend.variables !== undefined
                   ? ` for ${backendLabelForId(recheckBackend.variables)}`
                   : ""}
                 . Try again after fixing that Agent Backend.
-              </p>
+              </Banner>
             )}
           </div>
 
-          <div className="flex justify-end gap-3 border-t border-rule bg-paper-2 px-6 py-4">
+          <div className="dialog-footer">
             <button
               type="button"
-              className="border border-rule-2 px-4 py-2 text-sm font-semibold text-ink-soft hover:bg-paper"
+              className="plate-mini"
               onClick={() => {
                 dialogRef.current?.close()
                 setDialogOpen(false)
@@ -1273,7 +1296,8 @@ function SettingsChrome() {
             </button>
             <button
               type="submit"
-              className="bg-oxblood px-4 py-2 text-sm font-semibold tracking-wide text-on-solid uppercase hover:bg-oxblood-deep disabled:cursor-not-allowed disabled:opacity-50"
+              className="plate-primary"
+              aria-busy={updateConfig.isPending || undefined}
               disabled={
                 config.isPending ||
                 config.isError ||
@@ -1287,7 +1311,7 @@ function SettingsChrome() {
                 (!backendChanging && defaultModel.length === 0)
               }
             >
-              {updateConfig.isPending ? "Saving..." : "Save settings"}
+              {updateConfig.isPending ? "Saving…" : "Save settings"}
             </button>
           </div>
         </form>

--- a/apps/harness/src/routes/completed.tsx
+++ b/apps/harness/src/routes/completed.tsx
@@ -56,8 +56,8 @@ function CompletedListSkeleton() {
         aria-label="Loading completed work items"
         aria-busy="true"
       >
-        <span className="block h-14 animate-pulse bg-[var(--line-ghost)] motion-reduce:animate-none" />
-        <span className="block h-14 animate-pulse bg-[var(--line-ghost)] motion-reduce:animate-none" />
+        <span className="skeleton h-14" />
+        <span className="skeleton h-14" />
       </div>
     </section>
   )

--- a/apps/harness/src/routes/index.tsx
+++ b/apps/harness/src/routes/index.tsx
@@ -650,8 +650,8 @@ function HomeContent() {
           aria-label="Loading home"
           aria-busy="true"
         >
-          <span className="block h-10 w-[40%] animate-pulse bg-paper-2 motion-reduce:animate-none" />
-          <span className="block h-24 animate-pulse bg-paper-2 motion-reduce:animate-none" />
+          <span className="skeleton h-10 w-[40%]" />
+          <span className="skeleton h-24" />
         </div>
       </main>
     )
@@ -691,8 +691,8 @@ function HomeContent() {
               aria-label="Loading add repository guidance"
               aria-busy="true"
             >
-              <span className="block h-10 w-[50%] animate-pulse bg-paper-2 motion-reduce:animate-none" />
-              <span className="block h-32 animate-pulse bg-paper-2 motion-reduce:animate-none" />
+              <span className="skeleton h-10 w-[50%]" />
+              <span className="skeleton h-32" />
             </div>
           }
         >
@@ -797,19 +797,19 @@ export function CommittedPullRequestsDashboard() {
         </header>
         <div className="merged-pr-stats-grid">
           <div className="merged-pr-stats-cell">
-            <span className="merged-pr-stats-skeleton animate-pulse motion-reduce:animate-none" />
+            <span className="merged-pr-stats-skeleton" />
           </div>
           <div className="merged-pr-stats-cell">
-            <span className="merged-pr-stats-skeleton animate-pulse motion-reduce:animate-none" />
+            <span className="merged-pr-stats-skeleton" />
           </div>
           <div className="merged-pr-stats-cell">
-            <span className="merged-pr-stats-skeleton animate-pulse motion-reduce:animate-none" />
+            <span className="merged-pr-stats-skeleton" />
           </div>
           <div className="merged-pr-stats-cell">
-            <span className="merged-pr-stats-skeleton animate-pulse motion-reduce:animate-none" />
+            <span className="merged-pr-stats-skeleton" />
           </div>
           <div className="merged-pr-stats-cell">
-            <span className="merged-pr-stats-skeleton animate-pulse motion-reduce:animate-none" />
+            <span className="merged-pr-stats-skeleton" />
           </div>
         </div>
       </article>
@@ -1203,7 +1203,12 @@ function AddRepositoryGuidance({
                 {pickDirectory.isPending ? "Browsing…" : "Browse…"}
               </button>
             ) : null}
-            <button type="submit" disabled={busy} className="plate-primary">
+            <button
+              type="submit"
+              disabled={busy}
+              className="plate-primary"
+              aria-busy={busy || undefined}
+            >
               {addLocalRepository.isPending
                 ? "Adding…"
                 : inspectLocalRepository.isPending
@@ -2069,14 +2074,11 @@ function RepositoryCard({
               </svg>
             </button>
             {menuOpen && (
-              <div
-                role="menu"
-                className="absolute top-full right-0 z-10 mt-1 min-w-40 border-2 border-ink bg-panel py-1"
-              >
+              <div role="menu" className="menu-panel min-w-40">
                 <button
                   type="button"
                   role="menuitem"
-                  className="block w-full px-3 py-2 text-left font-mono text-[0.68rem] font-medium tracking-[0.08em] text-ink-2 uppercase hover:bg-[var(--plate-hover)]"
+                  className="menu-item"
                   onClick={() => {
                     setMenuOpen(false)
                     openSettings()
@@ -2084,11 +2086,11 @@ function RepositoryCard({
                 >
                   Settings
                 </button>
-                <hr className="my-1 border-t border-[var(--line-ghost)]" />
+                <hr className="menu-sep" />
                 <button
                   type="button"
                   role="menuitem"
-                  className="block w-full px-3 py-2 text-left font-mono text-[0.68rem] font-medium tracking-[0.08em] text-ink uppercase hover:bg-[var(--lane-attention)] hover:text-[#151515] disabled:cursor-wait disabled:opacity-50"
+                  className="menu-item menu-item--destructive"
                   disabled={removeRepository.isPending}
                   onClick={() => {
                     setMenuOpen(false)
@@ -2104,7 +2106,7 @@ function RepositoryCard({
       </div>
       <dialog
         ref={settingsDialogRef}
-        className="m-auto w-[min(92vw,32rem)] border border-rule-2 bg-panel p-0 text-ink shadow-[0_18px_50px_rgb(28_22_14_/_18%)] backdrop:bg-black/50"
+        className="dialog-panel"
         aria-labelledby={`repo-settings-title-${repository.id}`}
         onCancel={(event) => {
           if (updateSettings.isPending) event.preventDefault()
@@ -2112,31 +2114,27 @@ function RepositoryCard({
         onClose={() => setSettingsOpen(false)}
       >
         <form onSubmit={saveSettings}>
-          <div className="border-b border-rule px-6 py-5">
-            <p className="font-mono text-xs font-semibold tracking-[0.22em] text-oxblood uppercase">
-              Repository settings
-            </p>
+          <div className="dialog-header">
+            <p className="dialog-kicker">Repository settings</p>
             <h2
               id={`repo-settings-title-${repository.id}`}
-              className="mt-1.5 font-serif text-2xl font-semibold tracking-[-0.01em]"
+              className="dialog-title dialog-title--path"
             >
               {repository.projectPath}
             </h2>
-            <p className="mt-1.5 text-sm text-ink-soft">
+            <p className="dialog-lede">
               Overrides apply on the next Agent Turn. Empty model fields use
               harness defaults for this Repository&apos;s effective Agent
               Backend.
             </p>
           </div>
-          <div className="grid gap-5 px-6 py-5">
-            <fieldset className="grid gap-3 border border-rule p-4">
-              <legend className="px-1 font-mono text-xs font-semibold tracking-[0.16em] text-ink-faint uppercase">
-                Forge identity
-              </legend>
-              <label className="grid gap-1.5 text-sm font-semibold text-ink-2">
+          <div className="dialog-body">
+            <fieldset className="dialog-fieldset">
+              <legend>Forge identity</legend>
+              <label className="dialog-field">
                 Forge
                 <select
-                  className="w-full border border-rule-2 bg-paper px-3 py-2 text-sm font-normal outline-none focus:border-oxblood focus:ring-2 focus:ring-oxblood/15"
+                  className="dialog-input"
                   value={forge}
                   onChange={(event) =>
                     setForge(event.target.value as "github" | "gitlab")
@@ -2146,72 +2144,72 @@ function RepositoryCard({
                   <option value="gitlab">GitLab</option>
                 </select>
               </label>
-              <label className="grid gap-1.5 text-sm font-semibold text-ink-2">
+              <label className="dialog-field">
                 Forge host
                 <input
-                  className="w-full border border-rule-2 bg-paper px-3 py-2 font-mono text-sm font-normal outline-none focus:border-oxblood focus:ring-2 focus:ring-oxblood/15"
+                  className="dialog-input dialog-input--mono"
                   required
                   value={forgeHost}
                   onChange={(event) => setForgeHost(event.target.value)}
                 />
               </label>
-              <label className="grid gap-1.5 text-sm font-semibold text-ink-2">
+              <label className="dialog-field">
                 Project path
                 <input
-                  className="w-full border border-rule-2 bg-paper px-3 py-2 font-mono text-sm font-normal outline-none focus:border-oxblood focus:ring-2 focus:ring-oxblood/15"
+                  className="dialog-input dialog-input--mono"
                   required
                   value={projectPath}
                   onChange={(event) => setProjectPath(event.target.value)}
                 />
               </label>
-              <span className="text-xs text-ink-faint">
+              <span className="dialog-field-hint">
                 GitLab identities are verified before Save. Identity changes are
                 blocked after this Repository has any Work Item.
               </span>
             </fieldset>
-            <label className="flex items-center gap-3 text-sm font-semibold text-ink-2">
+            <label className="dialog-check">
               <input
                 type="checkbox"
-                className="size-4 accent-oxblood"
+                className="size-4"
                 checked={paused}
                 onChange={(event) => setPaused(event.target.checked)}
               />
               Paused
-              <span className="font-normal text-ink-faint">
+              <span className="dialog-field-hint">
                 Skip autonomous work selection
               </span>
             </label>
-            <label className="flex items-center gap-3 text-sm font-semibold text-ink-2">
+            <label className="dialog-check">
               <input
                 type="checkbox"
-                className="size-4 accent-oxblood"
+                className="size-4"
                 checked={autoMerge}
                 onChange={(event) => setAutoMerge(event.target.checked)}
               />
               Auto-merge
-              <span className="font-normal text-ink-faint">
+              <span className="dialog-field-hint">
                 Allow clanker merge when risk is low
               </span>
             </label>
-            <label className="flex items-center gap-3 text-sm font-semibold text-ink-2">
+            <label className="dialog-check">
               <input
                 type="checkbox"
-                className="size-4 accent-oxblood"
+                className="size-4"
                 checked={includeAllIssueAuthors}
                 onChange={(event) =>
                   setIncludeAllIssueAuthors(event.target.checked)
                 }
               />
               Include all Issue Authors
-              <span className="font-normal text-ink-faint">
+              <span className="dialog-field-hint">
                 Relevant Issues from every author after Refresh
               </span>
             </label>
-            <label className="grid gap-1.5 text-sm font-semibold text-ink-2">
+            <label className="dialog-field">
               <span className="flex items-center gap-3">
                 <input
                   type="checkbox"
-                  className="size-4 accent-oxblood"
+                  className="size-4"
                   checked={waitForReadyForReviewChecks}
                   onChange={(event) =>
                     setWaitForReadyForReviewChecks(event.target.checked)
@@ -2219,17 +2217,17 @@ function RepositoryCard({
                 />
                 Wait for checks to start after ready for review
               </span>
-              <span className="font-normal text-ink-faint">
+              <span className="dialog-field-hint">
                 Wait up to 90 seconds for workflows that start after a PR is
                 marked ready for review. If this repository has no such
                 workflows, turn off this setting to skip the wait.
               </span>
             </label>
 
-            <label className="grid min-w-0 gap-1.5 text-sm font-semibold">
+            <label className="dialog-field">
               Agent Backend
               <select
-                className="w-full min-w-0 border border-rule-2 bg-paper px-3 py-2 text-sm font-normal outline-none focus:border-oxblood focus:ring-2 focus:ring-oxblood/15 disabled:cursor-not-allowed disabled:opacity-60"
+                className="dialog-input"
                 name="selectedAgentBackend"
                 value={selectedAgentBackend ?? HARNESS_DEFAULT_BACKEND_VALUE}
                 disabled={
@@ -2258,7 +2256,7 @@ function RepositoryCard({
                   </option>
                 ))}
               </select>
-              <span className="text-xs font-normal text-ink-faint">
+              <span className="dialog-field-hint">
                 {backendChangeBlocked
                   ? `${repository.blockingUnfinishedWorkItemCount} unfinished Work Item${
                       repository.blockingUnfinishedWorkItemCount === 1
@@ -2270,34 +2268,49 @@ function RepositoryCard({
             </label>
 
             {agentBackends.isError && (
-              <p className="border border-oxblood/40 bg-oxblood-wash p-3 text-sm text-oxblood-deep">
+              <Banner
+                className="banner--compact"
+                tone="alarm"
+                tag="Error"
+                role="alert"
+              >
                 Agent Backends list could not be loaded. You can still inherit
                 the harness default; override options may be incomplete.
-              </p>
+              </Banner>
             )}
 
             {usesPreviewCatalog && previewError !== null && (
-              <p className="border border-oxblood/40 bg-oxblood-wash p-3 text-sm text-oxblood-deep">
+              <Banner
+                className="banner--compact"
+                tone="alarm"
+                tag="Error"
+                role="alert"
+              >
                 Preview failed: {previewError}. Model fields stay disabled until
                 preview succeeds.
                 {backendDraftChanging
                   ? " Changing the effective backend cannot be saved until preview succeeds."
                   : " Non-model settings can still be saved."}
-              </p>
+              </Banner>
             )}
 
             {modelsLoading ? (
-              <p className="text-sm text-ink-soft">Loading models...</p>
+              <p className="dialog-loading">Loading models...</p>
             ) : !usesPreviewCatalog && models.isError ? (
-              <p className="border border-oxblood/40 bg-oxblood-wash p-3 text-sm text-oxblood-deep">
+              <Banner
+                className="banner--compact"
+                tone="alarm"
+                tag="Error"
+                role="alert"
+              >
                 Models could not be loaded.
-              </p>
+              </Banner>
             ) : (
               <>
-                <label className="grid min-w-0 gap-1.5 text-sm font-semibold">
+                <label className="dialog-field">
                   Build model
                   <select
-                    className="w-full min-w-0 border border-rule-2 bg-paper px-3 py-2 font-mono text-sm font-normal outline-none focus:border-oxblood focus:ring-2 focus:ring-oxblood/15 disabled:cursor-not-allowed disabled:opacity-60"
+                    className="dialog-input dialog-input--mono"
                     value={defaultModel}
                     disabled={modelsDisabled}
                     onChange={(event) => {
@@ -2345,23 +2358,28 @@ function RepositoryCard({
                 </label>
                 {buildVariantSourceModel.length > 0 &&
                 buildVariantSourceUnavailable ? (
-                  <p className="border border-oxblood/40 bg-oxblood-wash p-3 text-sm text-oxblood-deep">
+                  <Banner
+                    className="banner--compact"
+                    tone="alarm"
+                    tag="Error"
+                    role="alert"
+                  >
                     Build effort (thinking) override is unavailable — the
                     selected model is not in the Agent Model catalog. Use
                     harness default or pick another model.
-                  </p>
+                  </Banner>
                 ) : buildVariantSourceModel.length > 0 &&
                   buildVariants.length === 0 ? (
-                  <p className="bg-paper-2 p-3 text-sm text-ink-soft">
+                  <p className="dialog-note">
                     Build effort (thinking) override is unavailable — this model
                     has no effort (thinking) options. Use harness default or
                     pick another model.
                   </p>
                 ) : (
-                  <label className="grid min-w-0 gap-1.5 text-sm font-semibold">
+                  <label className="dialog-field">
                     Build effort (thinking)
                     <select
-                      className="w-full min-w-0 border border-rule-2 bg-paper px-3 py-2 text-sm font-normal outline-none focus:border-oxblood focus:ring-2 focus:ring-oxblood/15 disabled:cursor-not-allowed disabled:opacity-60"
+                      className="dialog-input"
                       value={defaultThinkingLevel}
                       onChange={(event) =>
                         setDefaultVariant(event.target.value)
@@ -2388,10 +2406,10 @@ function RepositoryCard({
                     </select>
                   </label>
                 )}
-                <label className="grid min-w-0 gap-1.5 text-sm font-semibold">
+                <label className="dialog-field">
                   Review model
                   <select
-                    className="w-full min-w-0 border border-rule-2 bg-paper px-3 py-2 font-mono text-sm font-normal outline-none focus:border-oxblood focus:ring-2 focus:ring-oxblood/15 disabled:cursor-not-allowed disabled:opacity-60"
+                    className="dialog-input dialog-input--mono"
                     value={reviewModel}
                     disabled={modelsDisabled}
                     onChange={(event) => {
@@ -2430,23 +2448,28 @@ function RepositoryCard({
                 </label>
                 {reviewThinkingLevelSourceModel.length > 0 &&
                 reviewThinkingLevelSourceUnavailable ? (
-                  <p className="border border-oxblood/40 bg-oxblood-wash p-3 text-sm text-oxblood-deep">
+                  <Banner
+                    className="banner--compact"
+                    tone="alarm"
+                    tag="Error"
+                    role="alert"
+                  >
                     Review effort (thinking) override is unavailable — the
                     selected model is not in the Agent Model catalog. Use
                     harness default or pick another model.
-                  </p>
+                  </Banner>
                 ) : reviewThinkingLevelSourceModel.length > 0 &&
                   reviewThinkingLevels.length === 0 ? (
-                  <p className="bg-paper-2 p-3 text-sm text-ink-soft">
+                  <p className="dialog-note">
                     Review effort (thinking) override is unavailable — this
                     model has no effort (thinking) options. Use harness default
                     or pick another model.
                   </p>
                 ) : (
-                  <label className="grid min-w-0 gap-1.5 text-sm font-semibold">
+                  <label className="dialog-field">
                     Review effort (thinking)
                     <select
-                      className="w-full min-w-0 border border-rule-2 bg-paper px-3 py-2 text-sm font-normal outline-none focus:border-oxblood focus:ring-2 focus:ring-oxblood/15 disabled:cursor-not-allowed disabled:opacity-60"
+                      className="dialog-input"
                       value={reviewThinkingLevel}
                       onChange={(event) => setReviewVariant(event.target.value)}
                       disabled={
@@ -2474,17 +2497,22 @@ function RepositoryCard({
               </>
             )}
             {updateSettings.isError && (
-              <p className="border border-oxblood/40 bg-oxblood-wash p-3 text-sm text-oxblood-deep">
+              <Banner
+                className="banner--compact"
+                tone="alarm"
+                tag="Error"
+                role="alert"
+              >
                 {updateSettings.error instanceof Error
                   ? updateSettings.error.message
                   : "Settings could not be saved. Try again."}
-              </p>
+              </Banner>
             )}
           </div>
-          <div className="flex justify-end gap-3 border-t border-rule bg-paper-2 px-6 py-4">
+          <div className="dialog-footer">
             <button
               type="button"
-              className="border border-rule-2 px-4 py-2 text-sm font-semibold text-ink-soft hover:bg-paper"
+              className="plate-mini"
               onClick={() => {
                 settingsDialogRef.current?.close()
                 setSettingsOpen(false)
@@ -2495,7 +2523,8 @@ function RepositoryCard({
             </button>
             <button
               type="submit"
-              className="bg-oxblood px-4 py-2 text-sm font-semibold tracking-wide text-on-solid uppercase hover:bg-oxblood-deep disabled:cursor-wait disabled:opacity-60"
+              className="plate-primary"
+              aria-busy={updateSettings.isPending || undefined}
               disabled={
                 updateSettings.isPending ||
                 (backendChangeBlocked &&
@@ -2510,7 +2539,7 @@ function RepositoryCard({
                 blockSaveForUnavailableBuildModel
               }
             >
-              {updateSettings.isPending ? "Saving..." : "Save"}
+              {updateSettings.isPending ? "Saving…" : "Save"}
             </button>
           </div>
         </form>
@@ -2612,6 +2641,7 @@ function RepositoryCard({
                       type="button"
                       className="plate-primary"
                       disabled={addGitHubToken.isPending}
+                      aria-busy={addGitHubToken.isPending || undefined}
                       onClick={() => addGitHubToken.mutate()}
                     >
                       {addGitHubToken.isPending
@@ -2675,6 +2705,7 @@ function RepositoryCard({
                       type="button"
                       className="plate-primary"
                       disabled={addGitLabToken.isPending}
+                      aria-busy={addGitLabToken.isPending || undefined}
                       onClick={() => addGitLabToken.mutate()}
                     >
                       {addGitLabToken.isPending
@@ -3152,16 +3183,13 @@ function RepositoryIssueRow({
                 </svg>
               </button>
               {menuOpen && (
-                <div
-                  role="menu"
-                  className="absolute top-full right-0 z-10 mt-1 min-w-44 border-2 border-ink bg-panel py-1"
-                >
+                <div role="menu" className="menu-panel min-w-44">
                   {canImplement && (
                     <>
                       <button
                         type="button"
                         role="menuitem"
-                        className="block w-full px-3 py-2 text-left font-mono text-[0.68rem] font-medium tracking-[0.08em] text-ink-2 uppercase hover:bg-[var(--plate-hover)]"
+                        className="menu-item"
                         disabled={implementPending}
                         onClick={() => {
                           setMenuOpen(false)
@@ -3177,7 +3205,7 @@ function RepositoryIssueRow({
                       <button
                         type="button"
                         role="menuitem"
-                        className="block w-full px-3 py-2 text-left font-mono text-[0.68rem] font-medium tracking-[0.08em] text-ink-2 uppercase hover:bg-[var(--plate-hover)]"
+                        className="menu-item"
                         disabled={implementPending}
                         onClick={() => {
                           setMenuOpen(false)
@@ -3196,7 +3224,7 @@ function RepositoryIssueRow({
                     <button
                       type="button"
                       role="menuitem"
-                      className="block w-full px-3 py-2 text-left font-mono text-[0.68rem] font-medium tracking-[0.08em] text-ink-2 uppercase hover:bg-[var(--plate-hover)]"
+                      className="menu-item"
                       disabled={implementPending}
                       onClick={() => {
                         setMenuOpen(false)
@@ -3297,18 +3325,13 @@ export function SessionUsageDialog({
   return (
     <dialog
       ref={dialogRef}
-      className="m-auto w-[min(92vw,28rem)] border border-rule-2 bg-panel p-0 text-ink shadow-[0_18px_50px_rgb(28_22_14_/_18%)] backdrop:bg-black/50"
+      className="dialog-panel dialog-panel--narrow"
       aria-labelledby="session-usage-title"
       onClose={onClose}
     >
-      <div className="border-b border-rule px-5 py-4">
-        <p className="font-mono text-xs font-semibold tracking-[0.22em] text-oxblood uppercase">
-          Session usage
-        </p>
-        <h2
-          id="session-usage-title"
-          className="mt-1.5 font-serif text-lg font-semibold"
-        >
+      <div className="dialog-header dialog-header--compact">
+        <p className="dialog-kicker">Session usage</p>
+        <h2 id="session-usage-title" className="dialog-title dialog-title--sm">
           {backendLabel ? `${backendLabel} Session` : "Session"}
         </h2>
         {sessionId !== null && (
@@ -3320,50 +3343,60 @@ export function SessionUsageDialog({
           </p>
         )}
       </div>
-      <div className="px-5 py-4">
+      <div className="dialog-body dialog-body--compact">
         {!enabled ? null : session.isPending ? (
-          <p className="m-0 text-sm text-ink-soft">Loading usage…</p>
+          <p className="dialog-loading">Loading usage…</p>
         ) : session.isError ? (
-          <p
-            className="m-0 border border-oxblood/40 bg-oxblood-wash p-3 text-sm text-oxblood-deep"
+          <Banner
+            className="banner--compact"
+            tone="alarm"
+            tag="Error"
             role="alert"
           >
             Could not load Session usage. Close and try again.
-          </p>
+          </Banner>
         ) : session.data === null || session.data === undefined ? (
-          <p
-            className="m-0 border border-oxblood/40 bg-oxblood-wash p-3 text-sm text-oxblood-deep"
+          <Banner
+            className="banner--compact"
+            tone="guidance"
+            tag="Session"
             role="status"
           >
             Work Item not found.
-          </p>
+          </Banner>
         ) : session.data.availability === "UNSUPPORTED" ? (
-          <p
-            className="m-0 border border-oxblood/40 bg-oxblood-wash p-3 text-sm text-oxblood-deep"
+          <Banner
+            className="banner--compact"
+            tone="guidance"
+            tag="Session"
             role="status"
           >
             {session.data.backend.label} does not provide Session Telemetry.
-          </p>
+          </Banner>
         ) : session.data.availability === "MISSING" ? (
-          <p
-            className="m-0 border border-oxblood/40 bg-oxblood-wash p-3 text-sm text-oxblood-deep"
+          <Banner
+            className="banner--compact"
+            tone="guidance"
+            tag="Session"
             role="status"
           >
             {session.data.backend.label} no longer has this Session locally.
             Usage cannot be loaded.
-          </p>
+          </Banner>
         ) : session.data.availability === "UNAVAILABLE" ? (
           <div className="grid gap-3">
-            <p
-              className="m-0 border border-oxblood/40 bg-oxblood-wash p-3 text-sm text-oxblood-deep"
+            <Banner
+              className="banner--compact"
+              tone="guidance"
+              tag="Session"
               role="status"
             >
               {session.data.backend.label} Session Telemetry is temporarily
               unavailable. Retry in a moment.
-            </p>
+            </Banner>
             <button
               type="button"
-              className="justify-self-start border border-rule-2 bg-paper px-3 py-1.5 text-sm font-semibold text-ink-2 transition hover:bg-paper-2 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-oxblood"
+              className="plate-mini justify-self-start"
               onClick={() => {
                 void session.refetch()
               }}
@@ -3372,16 +3405,11 @@ export function SessionUsageDialog({
             </button>
           </div>
         ) : (
-          <table className="w-full border-collapse text-left text-sm">
+          <table className="dialog-table">
             <tbody>
-              <tr className="border-b border-rule-soft">
-                <th
-                  className="py-1.5 pr-3 font-semibold text-ink-soft"
-                  scope="row"
-                >
-                  Model
-                </th>
-                <td className="py-1.5 font-mono text-ink-2">
+              <tr>
+                <th scope="row">Model</th>
+                <td>
                   {session.data.model === null ||
                   session.data.model === undefined
                     ? "—"
@@ -3397,104 +3425,52 @@ export function SessionUsageDialog({
                         .join(" / ")}
                 </td>
               </tr>
-              <tr className="border-b border-rule-soft">
-                <th
-                  className="py-1.5 pr-3 font-semibold text-ink-soft"
-                  scope="row"
-                >
-                  Input tokens
-                </th>
-                <td className="py-1.5 tabular-nums text-ink-2">
-                  {formatTokenCount(session.data.tokens?.input ?? 0)}
-                </td>
+              <tr>
+                <th scope="row">Input tokens</th>
+                <td>{formatTokenCount(session.data.tokens?.input ?? 0)}</td>
               </tr>
-              <tr className="border-b border-rule-soft">
-                <th
-                  className="py-1.5 pr-3 font-semibold text-ink-soft"
-                  scope="row"
-                >
-                  Output tokens
-                </th>
-                <td className="py-1.5 tabular-nums text-ink-2">
-                  {formatTokenCount(session.data.tokens?.output ?? 0)}
-                </td>
+              <tr>
+                <th scope="row">Output tokens</th>
+                <td>{formatTokenCount(session.data.tokens?.output ?? 0)}</td>
               </tr>
-              <tr className="border-b border-rule-soft">
-                <th
-                  className="py-1.5 pr-3 font-semibold text-ink-soft"
-                  scope="row"
-                >
-                  Reasoning tokens
-                </th>
-                <td className="py-1.5 tabular-nums text-ink-2">
-                  {formatTokenCount(session.data.tokens?.reasoning ?? 0)}
-                </td>
+              <tr>
+                <th scope="row">Reasoning tokens</th>
+                <td>{formatTokenCount(session.data.tokens?.reasoning ?? 0)}</td>
               </tr>
-              <tr className="border-b border-rule-soft">
-                <th
-                  className="py-1.5 pr-3 font-semibold text-ink-soft"
-                  scope="row"
-                >
-                  Cache read
-                </th>
-                <td className="py-1.5 tabular-nums text-ink-2">
-                  {formatTokenCount(session.data.tokens?.cacheRead ?? 0)}
-                </td>
+              <tr>
+                <th scope="row">Cache read</th>
+                <td>{formatTokenCount(session.data.tokens?.cacheRead ?? 0)}</td>
               </tr>
-              <tr className="border-b border-rule-soft">
-                <th
-                  className="py-1.5 pr-3 font-semibold text-ink-soft"
-                  scope="row"
-                >
-                  Cache write
-                </th>
-                <td className="py-1.5 tabular-nums text-ink-2">
+              <tr>
+                <th scope="row">Cache write</th>
+                <td>
                   {formatTokenCount(session.data.tokens?.cacheWrite ?? 0)}
                 </td>
               </tr>
-              <tr className="border-b border-rule-soft">
-                <th
-                  className="py-1.5 pr-3 font-semibold text-ink-soft"
-                  scope="row"
-                >
-                  Cost
-                </th>
-                <td className="py-1.5 tabular-nums text-ink-2">
+              <tr>
+                <th scope="row">Cost</th>
+                <td>
                   {session.data.cost === null || session.data.cost === undefined
                     ? "—"
                     : formatSessionCost(session.data.cost)}
                 </td>
               </tr>
-              <tr className="border-b border-rule-soft">
-                <th
-                  className="py-1.5 pr-3 font-semibold text-ink-soft"
-                  scope="row"
-                >
-                  Created
-                </th>
-                <td className="py-1.5 text-ink-2">
-                  {formatSessionInstant(session.data.createdAt)}
-                </td>
+              <tr>
+                <th scope="row">Created</th>
+                <td>{formatSessionInstant(session.data.createdAt)}</td>
               </tr>
               <tr>
-                <th
-                  className="py-1.5 pr-3 font-semibold text-ink-soft"
-                  scope="row"
-                >
-                  Updated
-                </th>
-                <td className="py-1.5 text-ink-2">
-                  {formatSessionInstant(session.data.updatedAt)}
-                </td>
+                <th scope="row">Updated</th>
+                <td>{formatSessionInstant(session.data.updatedAt)}</td>
               </tr>
             </tbody>
           </table>
         )}
       </div>
-      <div className="flex justify-end border-t border-rule px-5 py-3">
+      <div className="dialog-footer dialog-footer--compact">
         <button
           type="button"
-          className="border border-rule-2 bg-paper px-3 py-1.5 text-sm font-semibold text-ink-2 transition hover:bg-paper-2 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-oxblood"
+          className="plate-mini"
           onClick={() => {
             dialogRef.current?.close()
           }}
@@ -3509,14 +3485,14 @@ export function SessionUsageDialog({
 export function JobsCardSkeleton() {
   return (
     <article
-      className="border border-rule-2 bg-panel px-4 py-3 sm:px-5"
+      className="border border-line-ghost bg-panel px-4 py-3 sm:px-5"
       role="status"
       aria-label="Loading jobs"
       aria-busy="true"
     >
       <div className="grid gap-2">
-        <span className="block h-12 animate-pulse bg-paper-2 motion-reduce:animate-none" />
-        <span className="block h-12 animate-pulse bg-paper-2 motion-reduce:animate-none" />
+        <span className="skeleton h-12" />
+        <span className="skeleton h-12" />
       </div>
     </article>
   )
@@ -3956,16 +3932,26 @@ export function WorkItemLifecycleStatus({
         </div>
       )}
       {reset.isError && (
-        <p className="mt-1.5 mb-0 text-xs text-oxblood-deep" role="alert">
+        <Banner
+          className="banner--compact mt-1.5"
+          tone="alarm"
+          tag="Error"
+          role="alert"
+        >
           Could not reset this job.
-        </p>
+        </Banner>
       )}
       {retry.isError && (
-        <p className="mt-1.5 mb-0 text-xs text-oxblood-deep" role="alert">
+        <Banner
+          className="banner--compact mt-1.5"
+          tone="alarm"
+          tag="Error"
+          role="alert"
+        >
           {retriesStatusChecks
             ? "Could not retry these checks."
             : "Could not retry this job."}
-        </p>
+        </Banner>
       )}
     </div>
   )
@@ -3979,8 +3965,8 @@ function RepositoryIssuesSkeleton() {
       aria-label="Loading issues"
       aria-busy="true"
     >
-      <span className="block h-4 w-[85%] animate-pulse bg-paper-2 motion-reduce:animate-none" />
-      <span className="block h-4 w-[65%] animate-pulse bg-paper-2 motion-reduce:animate-none" />
+      <span className="skeleton h-4 w-[85%]" />
+      <span className="skeleton h-4 w-[65%]" />
     </div>
   )
 }
@@ -3994,9 +3980,9 @@ export function RepositoryCardsSkeleton() {
     >
       {[0, 1].map((item) => (
         <div className="repo-card-skeleton" key={item}>
-          <span className="block h-[0.85rem] w-[35%] animate-pulse bg-paper-2 motion-reduce:animate-none" />
-          <span className="block h-[1.6rem] w-[65%] animate-pulse bg-paper-2 motion-reduce:animate-none" />
-          <span className="block h-[0.85rem] w-[90%] animate-pulse bg-paper-2 motion-reduce:animate-none" />
+          <span className="skeleton h-[0.85rem] w-[35%]" />
+          <span className="skeleton h-[1.6rem] w-[65%]" />
+          <span className="skeleton h-[0.85rem] w-[90%]" />
         </div>
       ))}
     </section>

--- a/apps/harness/src/styles.css
+++ b/apps/harness/src/styles.css
@@ -33,21 +33,13 @@
   /* §2.2 Neutrals */
   --paper: #ffffff;
   --panel: #ffffff;
-  /* Elevated / inset surfaces used by unmigrated dialogs + chips */
-  --paper-2: #f0f1ef;
-  --paper-3: #e6e8e5;
   --ink: #151515;
   --ink-dim: #4a4a4a;
   --ink-faint: #8b8b8b;
   --line-soft: rgb(21 21 21 / 0.3);
   --line-ghost: rgb(21 21 21 / 0.12);
-  --rule: #d8c9a8;
-  --rule-2: #cbbb96;
-  --rule-soft: #e7dcc2;
   --signal: #ffd21c;
   --merged-halo: transparent;
-  /* Inverse text on saturated fills (oxblood CTAs) — never theme-flips */
-  --on-solid: #ffffff;
   /* Modal scrim — always dims, never inverts with ink */
   --scrim: rgb(21 21 21 / 0.45);
 
@@ -83,19 +75,13 @@
   color-scheme: dark;
   --paper: #15181b;
   --panel: #1c2024;
-  --paper-2: #23282c;
-  --paper-3: #2b3035;
   --ink: #f2f3f1;
   --ink-dim: #c6cac8;
   --ink-faint: #7f8583;
   --line-soft: rgb(242 243 241 / 0.32);
   --line-ghost: rgb(242 243 241 / 0.14);
-  --rule: rgb(242 243 241 / 0.28);
-  --rule-2: rgb(242 243 241 / 0.22);
-  --rule-soft: rgb(242 243 241 / 0.14);
   --signal: #ffd21c;
   --merged-halo: rgb(242 243 241 / 0.85);
-  --on-solid: #ffffff;
   --scrim: rgb(0 0 0 / 0.55);
 
   --mast-bg: #000000;
@@ -125,34 +111,18 @@
 
 /*
   Tailwind @theme aliases map Interchange tokens to utilities.
-  Oxblood/wash accents stay fixed (unmigrated dialogs); surfaces + ink flip.
+  Surfaces + ink flip with data-theme; lane colors stay fixed.
 */
 @theme {
   --color-paper: var(--paper);
-  --color-paper-2: var(--paper-2);
-  --color-paper-3: var(--paper-3);
   --color-panel: var(--panel);
   --color-ink: var(--ink);
   --color-ink-2: var(--ink-dim);
   --color-ink-soft: var(--ink-dim);
   --color-ink-faint: var(--ink-faint);
-  --color-rule: var(--rule);
-  --color-rule-2: var(--rule-2);
-  --color-rule-soft: var(--rule-soft);
-  --color-on-solid: var(--on-solid);
+  --color-line-soft: var(--line-soft);
+  --color-line-ghost: var(--line-ghost);
   --color-scrim: var(--scrim);
-  --color-oxblood: #7a1d2a;
-  --color-oxblood-deep: #5c141f;
-  --color-vermilion: #b8341b;
-  --color-sepia: #6c4f20;
-  --color-olive: #4a5d2c;
-  --color-olive-wash: #eef0e2;
-  --color-amber-wash: #f3e6c8;
-  --color-oxblood-wash: #f0ddd9;
-  --color-vermilion-wash: #f4e1d8;
-  --color-violet-wash: #e7dff0;
-  --color-teal: #2f5d50;
-  --color-teal-wash: #e2ebe7;
   --color-signal: var(--signal);
   --color-lane-queue: var(--lane-queue);
   --color-lane-build: var(--lane-build);
@@ -160,10 +130,6 @@
   --color-lane-pr: var(--lane-pr);
   --color-lane-attention: var(--lane-attention);
   --color-lane-merged: var(--lane-merged);
-  /* Serif kept until phase 5 teardown when no surface references it. */
-  --font-serif:
-    "Iowan Old Style", "Palatino Linotype", "URW Palladio L", Palatino,
-    "Book Antiqua", Georgia, "Times New Roman", serif;
   --font-display: "Inter Tight", "Helvetica Neue", Helvetica, Arial, sans-serif;
   --font-sans: "Inter Tight", "Helvetica Neue", Helvetica, Arial, sans-serif;
   --font-mono:
@@ -866,15 +832,382 @@
     gap: 0.5rem;
   }
 
-  /* ---------- Legacy Ledger helpers (unmigrated surfaces) ---------- */
+  /* ---------- Dialogs (§4.9) ---------- */
 
-  .field-rule {
-    border: 1px solid var(--color-rule);
-    background-color: var(--color-panel);
+  .dialog-panel {
+    margin: auto;
+    width: min(92vw, 32rem);
+    border: 2px solid var(--ink);
+    background: var(--paper);
+    color: var(--ink);
+    padding: 0;
+    box-shadow: none;
   }
 
-  .entry-rule {
-    border-top: 1px solid var(--color-rule-soft);
+  .dialog-panel::backdrop {
+    background: var(--scrim);
+  }
+
+  .dialog-panel--narrow {
+    width: min(92vw, 28rem);
+  }
+
+  .dialog-header {
+    border-bottom: 1px solid var(--line-ghost);
+    padding: 1.25rem 1.5rem;
+  }
+
+  .dialog-header--compact {
+    padding: 1rem 1.25rem;
+  }
+
+  .dialog-kicker {
+    margin: 0;
+    font-family: var(--font-mono);
+    font-size: 0.62rem;
+    font-weight: 700;
+    letter-spacing: 0.16em;
+    text-transform: uppercase;
+    color: var(--ink-faint);
+  }
+
+  .dialog-title {
+    margin: 0.5rem 0 0;
+    font-family: var(--font-display);
+    font-size: clamp(1.2rem, 2.4vw, 1.45rem);
+    font-weight: 800;
+    letter-spacing: -0.01em;
+    text-transform: uppercase;
+    line-height: 1.05;
+    color: var(--ink);
+  }
+
+  .dialog-title--sm {
+    font-size: 1.1rem;
+  }
+
+  /* Forge paths keep true case (case-sensitive hosts / project paths). */
+  .dialog-title--path {
+    text-transform: none;
+    letter-spacing: -0.01em;
+    word-break: break-all;
+  }
+
+  .dialog-lede {
+    margin: 0.45rem 0 0;
+    font-family: var(--font-display);
+    font-size: 0.92rem;
+    line-height: 1.4;
+    color: var(--ink-dim);
+  }
+
+  .dialog-body {
+    display: grid;
+    gap: 1.15rem;
+    padding: 1.25rem 1.5rem;
+  }
+
+  .dialog-body--compact {
+    padding: 1rem 1.25rem;
+  }
+
+  .dialog-footer {
+    display: flex;
+    justify-content: flex-end;
+    gap: 0.75rem;
+    border-top: 1px solid var(--line-ghost);
+    background: var(--panel);
+    padding: 0.9rem 1.5rem;
+  }
+
+  .dialog-footer--compact {
+    padding: 0.75rem 1.25rem;
+  }
+
+  .dialog-field {
+    display: grid;
+    min-width: 0;
+    gap: 0.4rem;
+    font-family: var(--font-display);
+    font-size: 0.88rem;
+    font-weight: 600;
+    color: var(--ink);
+  }
+
+  .dialog-field > select,
+  .dialog-field > input:not([type="checkbox"]),
+  .dialog-input {
+    width: 100%;
+    min-width: 0;
+    border: 1.5px solid var(--ink);
+    background: var(--paper);
+    padding: 0.5rem 0.7rem;
+    font-size: 0.88rem;
+    font-weight: 400;
+    color: var(--ink);
+  }
+
+  /* Match global :focus-visible (2px ink) — do not zero outline on fields. */
+  .dialog-field > select:focus-visible,
+  .dialog-field > input:not([type="checkbox"]):focus-visible,
+  .dialog-input:focus-visible {
+    outline: 2px solid var(--ink);
+    outline-offset: 2px;
+  }
+
+  .dialog-field > select:disabled,
+  .dialog-field > input:not([type="checkbox"]):disabled,
+  .dialog-input:disabled {
+    color: var(--ink-faint);
+    cursor: not-allowed;
+    opacity: 0.7;
+  }
+
+  .dialog-field-mono > select,
+  .dialog-field-mono > input:not([type="checkbox"]),
+  .dialog-input--mono {
+    font-family: var(--font-mono);
+  }
+
+  .dialog-field-hint {
+    font-family: var(--font-mono);
+    font-size: 0.68rem;
+    font-weight: 400;
+    letter-spacing: 0.02em;
+    color: var(--ink-faint);
+  }
+
+  .dialog-check {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.75rem;
+    font-family: var(--font-display);
+    font-size: 0.88rem;
+    font-weight: 600;
+    color: var(--ink-dim);
+  }
+
+  .dialog-check input[type="checkbox"],
+  .dialog-field input[type="checkbox"] {
+    width: 1rem;
+    height: 1rem;
+    accent-color: var(--signal);
+  }
+
+  .dialog-check .dialog-field-hint {
+    flex: 1 1 100%;
+    margin-left: 1.75rem;
+  }
+
+  .dialog-status-block {
+    display: grid;
+    gap: 0.5rem;
+  }
+
+  .dialog-status-head {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.5rem;
+  }
+
+  .dialog-status-label {
+    margin: 0;
+    font-family: var(--font-mono);
+    font-size: 0.62rem;
+    font-weight: 700;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    color: var(--ink-faint);
+  }
+
+  .dialog-status-row {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.5rem;
+    border: 1px solid var(--line-ghost);
+    background: var(--panel);
+    padding: 0.5rem 0.75rem;
+    font-family: var(--font-mono);
+    font-size: 0.72rem;
+    color: var(--ink-dim);
+  }
+
+  .dialog-status-row strong {
+    font-weight: 700;
+    color: var(--ink);
+  }
+
+  .dialog-fieldset {
+    display: grid;
+    gap: 0.75rem;
+    margin: 0;
+    border: 1.5px solid var(--ink);
+    padding: 0.9rem 1rem 1rem;
+  }
+
+  .dialog-fieldset legend {
+    padding: 0 0.35rem;
+    font-family: var(--font-mono);
+    font-size: 0.62rem;
+    font-weight: 700;
+    letter-spacing: 0.16em;
+    text-transform: uppercase;
+    color: var(--ink-faint);
+  }
+
+  .dialog-note {
+    margin: 0;
+    border: 1px solid var(--line-ghost);
+    background: var(--panel);
+    padding: 0.65rem 0.75rem;
+    font-family: var(--font-display);
+    font-size: 0.88rem;
+    line-height: 1.4;
+    color: var(--ink-dim);
+  }
+
+  .dialog-loading {
+    margin: 0;
+    font-family: var(--font-display);
+    font-size: 0.88rem;
+    color: var(--ink-dim);
+  }
+
+  .dialog-table {
+    width: 100%;
+    border-collapse: collapse;
+    text-align: left;
+  }
+
+  .dialog-table th {
+    padding: 0.4rem 0.75rem 0.4rem 0;
+    font-family: var(--font-display);
+    font-size: 0.88rem;
+    font-weight: 600;
+    color: var(--ink-dim);
+  }
+
+  .dialog-table td {
+    padding: 0.4rem 0;
+    font-family: var(--font-mono);
+    font-size: 0.85rem;
+    font-variant-numeric: tabular-nums;
+    color: var(--ink);
+  }
+
+  .dialog-table tr {
+    border-bottom: 1px solid var(--line-ghost);
+  }
+
+  .dialog-table tr:last-child {
+    border-bottom: 0;
+  }
+
+  /* No-change completion summary (Interchange panel; display body text) */
+  .completion-summary {
+    margin-top: 0.4rem;
+    border: 1.5px solid var(--ink);
+    background: var(--panel);
+    padding: 0.5rem 0.65rem;
+  }
+
+  .completion-summary p {
+    margin: 0;
+    font-family: var(--font-display);
+    font-size: 0.88rem;
+    line-height: 1.4;
+    color: var(--ink-dim);
+    white-space: pre-wrap;
+  }
+
+  .not-found-panel {
+    margin: 3rem auto 0;
+    max-width: 36rem;
+    border: 2px solid var(--ink);
+    background: var(--panel);
+    padding: 2rem;
+    text-align: center;
+  }
+
+  /* ---------- Menus (§4.10) ---------- */
+
+  .menu-panel {
+    position: absolute;
+    top: 100%;
+    right: 0;
+    z-index: 10;
+    margin-top: 0.25rem;
+    min-width: 10rem;
+    border: 2px solid var(--ink);
+    background: var(--panel);
+    padding: 0.25rem 0;
+    box-shadow: none;
+  }
+
+  .menu-item {
+    display: block;
+    width: 100%;
+    border: 0;
+    background: transparent;
+    padding: 0.5rem 0.75rem;
+    text-align: left;
+    font-family: var(--font-mono);
+    font-size: 0.68rem;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--ink-dim);
+    cursor: pointer;
+  }
+
+  .menu-item:is(:hover, :focus-visible) {
+    background: var(--plate-hover);
+    color: var(--ink);
+  }
+
+  .menu-item--destructive:is(:hover, :focus-visible) {
+    background: var(--lane-attention);
+    color: #151515;
+  }
+
+  .menu-item:disabled {
+    cursor: wait;
+    opacity: 0.5;
+  }
+
+  .menu-sep {
+    margin: 0.25rem 0;
+    border: 0;
+    border-top: 1px solid var(--line-ghost);
+  }
+
+  /* ---------- Skeletons (§4.11) ---------- */
+
+  .skeleton {
+    display: block;
+    background: var(--line-ghost);
+    animation: skeleton-pulse 1.2s ease-in-out infinite;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .skeleton {
+      animation: none;
+    }
+  }
+
+  @keyframes skeleton-pulse {
+    0%,
+    100% {
+      opacity: 1;
+    }
+    50% {
+      opacity: 0.45;
+    }
   }
 
   /* ---------- Board shell + merged-PR stats (§4.2–4.4, §5, §6) ---------- */
@@ -993,6 +1326,7 @@
     height: 2.75rem;
     margin: 0.55rem 0.15rem 0.7rem;
     background: var(--line-ghost);
+    animation: skeleton-pulse 1.2s ease-in-out infinite;
   }
 
   .merged-pr-stats-cell .merged-pr-stats-skeleton {
@@ -1001,6 +1335,12 @@
 
   [data-theme="dark"] .merged-pr-stats-skeleton {
     background: rgb(255 255 255 / 0.1);
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .merged-pr-stats-skeleton {
+      animation: none;
+    }
   }
 
   .merged-pr-stats-body {
@@ -1709,8 +2049,13 @@
   }
 
   .plate-primary:disabled {
-    cursor: wait;
+    cursor: not-allowed;
     opacity: 0.55;
+  }
+
+  /* Pending mutations only — validation-disabled stays not-allowed. */
+  .plate-primary:disabled[aria-busy="true"] {
+    cursor: wait;
   }
 
   /* §5.6 Stamps (exception chips — Closed, Blocked, No change) */

--- a/apps/harness/src/work-item-outcome-presentation.tsx
+++ b/apps/harness/src/work-item-outcome-presentation.tsx
@@ -67,7 +67,7 @@ export function WorkItemOutcomePresentation({
         <div className="mt-1.5 w-full basis-full">
           {issueUrl !== null && issueUrl !== "" ? (
             <a
-              className="m-0 text-xs font-semibold tracking-wide text-ink-2 uppercase underline decoration-rule underline-offset-4 hover:text-oxblood"
+              className="m-0 font-mono text-xs font-semibold tracking-wide text-ink-2 uppercase underline decoration-signal underline-offset-4 hover:text-ink"
               href={issueUrl}
               target="_blank"
               rel="noopener noreferrer"
@@ -75,18 +75,16 @@ export function WorkItemOutcomePresentation({
               Issue closed without repository changes
             </a>
           ) : (
-            <p className="m-0 text-xs font-semibold tracking-wide text-ink-2 uppercase">
+            <p className="m-0 font-mono text-xs font-semibold tracking-wide text-ink-2 uppercase">
               Issue closed without repository changes
             </p>
           )}
           {summary !== "" && (
             <section
-              className="field-rule mt-1.5 px-2 py-1.5"
+              className="completion-summary"
               aria-label="Completion summary"
             >
-              <p className="m-0 whitespace-pre-wrap font-serif text-sm text-ink-soft">
-                {summary}
-              </p>
+              <p>{summary}</p>
             </section>
           )}
         </div>

--- a/apps/harness/test/interchange-phase5.test.ts
+++ b/apps/harness/test/interchange-phase5.test.ts
@@ -1,0 +1,195 @@
+import { readFileSync } from "node:fs"
+import { join } from "node:path"
+import { describe, expect, test } from "bun:test"
+
+const rootSource = () =>
+  readFileSync(join(import.meta.dir, "../src/routes/__root.tsx"), "utf8")
+
+const homeSource = () =>
+  readFileSync(join(import.meta.dir, "../src/routes/index.tsx"), "utf8")
+
+const stylesSource = () =>
+  readFileSync(join(import.meta.dir, "../src/styles.css"), "utf8")
+
+const copySource = () =>
+  readFileSync(join(import.meta.dir, "../src/copy.tsx"), "utf8")
+
+const outcomeSource = () =>
+  readFileSync(
+    join(import.meta.dir, "../src/work-item-outcome-presentation.tsx"),
+    "utf8",
+  )
+
+const kanbanDoc = () =>
+  readFileSync(join(import.meta.dir, "../../../docs/kanban.md"), "utf8")
+
+const sliceBetween = (source: string, start: string, end: string): string => {
+  const s = source.indexOf(start)
+  if (s < 0) throw new Error(`Start not found: ${start}`)
+  const e = source.indexOf(end, s)
+  if (e < 0) throw new Error(`End not found after ${start}: ${end}`)
+  return source.slice(s, e)
+}
+
+/**
+ * Interchange phase 5 — dialogs, menus, chrome + Ledger teardown (#704).
+ */
+describe("Interchange phase 5: dialogs, menus, chrome + Ledger teardown", () => {
+  test("settings dialog uses shared Interchange shell (panel, kicker, plates)", () => {
+    const root = rootSource()
+    const dialog = sliceBetween(root, "<dialog", "</dialog>")
+    expect(dialog).toContain('className="dialog-panel"')
+    expect(dialog).toContain("dialog-header")
+    expect(dialog).toContain("dialog-kicker")
+    expect(dialog).toContain("dialog-title")
+    expect(dialog).toContain("dialog-lede")
+    expect(dialog).toContain("dialog-body")
+    expect(dialog).toContain("dialog-footer")
+    expect(dialog).toContain("dialog-field")
+    expect(dialog).toContain("dialog-status-row")
+    expect(dialog).toContain('className="plate-mini"')
+    expect(dialog).toContain('className="plate-primary"')
+    expect(dialog).toContain("Save settings")
+    expect(dialog).toContain("Cancel")
+    // Compact banners replace oxblood wash callouts.
+    expect(dialog).toContain("banner--compact")
+    expect(dialog).not.toContain("font-serif")
+    expect(dialog).not.toContain("oxblood")
+    expect(dialog).not.toContain("shadow-[")
+    expect(dialog).not.toContain("backdrop:bg-")
+  })
+
+  test("repository settings dialog matches the same shell contract", () => {
+    const home = homeSource()
+    const dialog = sliceBetween(home, "ref={settingsDialogRef}", "</dialog>")
+    expect(dialog).toContain('className="dialog-panel"')
+    expect(dialog).toContain("dialog-header")
+    expect(dialog).toContain("dialog-kicker")
+    expect(dialog).toContain("dialog-title")
+    expect(dialog).toContain("dialog-fieldset")
+    expect(dialog).toContain("dialog-check")
+    expect(dialog).toContain("dialog-input")
+    expect(dialog).toContain('className="plate-primary"')
+    expect(dialog).toContain('className="plate-mini"')
+    expect(dialog).not.toContain("font-serif")
+    expect(dialog).not.toContain("oxblood")
+    expect(dialog).not.toContain("shadow-[")
+    const styles = stylesSource()
+    expect(styles).toContain('.dialog-check input[type="checkbox"]')
+    expect(styles).toContain("accent-color: var(--signal)")
+  })
+
+  test("session usage dialog is narrow shell with table and telemetry banners", () => {
+    const home = homeSource()
+    const dialog = sliceBetween(
+      home,
+      "export function SessionUsageDialog",
+      "export function JobsCardSkeleton",
+    )
+    expect(dialog).toContain("dialog-panel dialog-panel--narrow")
+    expect(dialog).toContain("dialog-kicker")
+    expect(dialog).toContain("dialog-title")
+    expect(dialog).toContain("dialog-table")
+    expect(dialog).toContain("banner--compact")
+    expect(dialog).toContain('tag="Session"')
+    expect(dialog).toContain('className="plate-mini"')
+    expect(dialog).not.toContain("font-serif")
+    expect(dialog).not.toContain("oxblood")
+    expect(dialog).not.toContain("shadow-[")
+  })
+
+  test("menus use flush menu-panel (no drop shadow) and destructive Attention hover/focus", () => {
+    const home = homeSource()
+    const styles = stylesSource()
+    expect(home).toContain('className="menu-panel min-w-40"')
+    expect(home).toContain("menu-item menu-item--destructive")
+    expect(home).toContain('className="menu-sep"')
+    expect(styles).toContain(".menu-panel")
+    expect(styles).toContain("box-shadow: none")
+    expect(styles).toContain(
+      ".menu-item--destructive:is(:hover, :focus-visible)",
+    )
+    expect(styles).toMatch(
+      /\.menu-item--destructive:is\(:hover, :focus-visible\)\s*\{[^}]*background:\s*var\(--lane-attention\)/s,
+    )
+    expect(home).not.toContain("shadow-[")
+  })
+
+  test("chrome: skeletons use line-ghost bars; copy keeps PR-green success glyph", () => {
+    const home = homeSource()
+    const styles = stylesSource()
+    const copy = copySource()
+    const completed = readFileSync(
+      join(import.meta.dir, "../src/routes/completed.tsx"),
+      "utf8",
+    )
+    expect(home).toContain('className="skeleton')
+    expect(completed).toContain('className="skeleton h-14"')
+    expect(home).toContain('className="merged-pr-stats-skeleton"')
+    expect(home).not.toContain("merged-pr-stats-skeleton animate-pulse")
+    expect(styles).toContain(".skeleton")
+    expect(styles).toContain("background: var(--line-ghost)")
+    expect(styles).toMatch(
+      /\.merged-pr-stats-skeleton\s*\{[^}]*animation:\s*skeleton-pulse/s,
+    )
+    expect(copy).toContain("icon-btn--copied")
+    expect(copy).toContain("1_500")
+    expect(styles).toContain(".icon-btn--copied")
+    expect(styles).toMatch(
+      /\.icon-btn--copied\s*\{[^}]*color:\s*var\(--lane-pr\)/s,
+    )
+  })
+
+  test("dialog fields keep focus-visible outline; primary plate wait only when busy", () => {
+    const styles = stylesSource()
+    expect(styles).not.toMatch(/\.dialog-input\s*\{[^}]*outline:\s*none/s)
+    expect(styles).toContain(".dialog-field > select:focus-visible")
+    expect(styles).toContain("outline: 2px solid var(--ink)")
+    expect(styles).toContain('.plate-primary:disabled[aria-busy="true"]')
+    expect(styles).toMatch(
+      /\.plate-primary:disabled\s*\{[^}]*cursor:\s*not-allowed/s,
+    )
+    const root = rootSource()
+    const home = homeSource()
+    expect(root).toContain("aria-busy={updateConfig.isPending || undefined}")
+    expect(home).toContain("aria-busy={updateSettings.isPending || undefined}")
+    expect(home).toContain("dialog-title dialog-title--path")
+  })
+
+  test("Ledger teardown: no serif/oxblood/washes/field-rule; stamps stay Interchange", () => {
+    const styles = stylesSource()
+    const root = rootSource()
+    const home = homeSource()
+    const outcome = outcomeSource()
+    const completed = readFileSync(
+      join(import.meta.dir, "../src/routes/completed.tsx"),
+      "utf8",
+    )
+    const parentMenu = readFileSync(
+      join(import.meta.dir, "../src/parent-issue-actions-menu.tsx"),
+      "utf8",
+    )
+    const all = `${styles}\n${root}\n${home}\n${outcome}\n${completed}\n${parentMenu}`
+
+    expect(all).not.toContain("font-serif")
+    expect(all).not.toContain("oxblood")
+    expect(all).not.toContain("field-rule")
+    expect(all).not.toContain("entry-rule")
+    expect(all).not.toContain("--color-sepia")
+    expect(all).not.toContain("--color-olive")
+    expect(all).not.toContain("--color-teal")
+    expect(all).not.toContain("--font-serif")
+    expect(all).not.toContain("--paper-2")
+    expect(all).not.toContain("shadow-[")
+    // Interchange exception stamps remain (§5.6).
+    expect(styles).toContain(".stamp--closed")
+    expect(styles).toContain(".stamp--blocked")
+    expect(outcome).toContain("completion-summary")
+  })
+
+  test("kanban.md points at harness-design-system.md", () => {
+    const doc = kanbanDoc()
+    expect(doc).toContain("docs/harness-design-system.md")
+    expect(doc).toContain("Interchange")
+  })
+})

--- a/apps/harness/test/parent-issue-actions-menu.test.tsx
+++ b/apps/harness/test/parent-issue-actions-menu.test.tsx
@@ -129,14 +129,23 @@ describe("ParentIssueActionsMenu", () => {
       join(import.meta.dir, "../src/parent-issue-actions-menu.tsx"),
       "utf8",
     )
-    // §4.10 / phase 4: icon-btn trigger; mono uppercase items (no Ledger shadow).
+    // §4.10: icon-btn trigger; shared menu-panel / menu-item (no Ledger shadow).
     expect(source).toContain('className="icon-btn"')
     expect(source).toMatch(
-      /role="menu"[\s\S]*?border-2 border-ink[\s\S]*?role="menuitem"/,
+      /role="menu"[\s\S]*?menu-panel[\s\S]*?role="menuitem"/,
     )
-    expect(source).toContain("font-mono")
-    expect(source).toContain("uppercase")
+    expect(source).toContain('className="menu-item"')
     expect(source).not.toContain("shadow-[")
+    const styles = readFileSync(
+      join(import.meta.dir, "../src/styles.css"),
+      "utf8",
+    )
+    expect(styles).toContain(".menu-panel")
+    expect(styles).toContain(".menu-item")
+    expect(styles).toMatch(
+      /\.menu-item\s*\{[^}]*font-family:\s*var\(--font-mono\)/s,
+    )
+    expect(styles).toMatch(/\.menu-item\s*\{[^}]*text-transform:\s*uppercase/s)
   })
 })
 

--- a/apps/harness/test/primary-nav.test.ts
+++ b/apps/harness/test/primary-nav.test.ts
@@ -243,14 +243,15 @@ describe("primary Home / Repos / Completed navigation (Interchange masthead)", (
     expect(root).toContain("suppressHydrationWarning")
     expect(styles).toContain("color-scheme: light")
     expect(styles).toContain("color-scheme: dark")
-    // Elevated surfaces + inverse CTA ink stay contrast-safe under both themes.
-    expect(styles).toContain("--paper-2:")
-    expect(styles).toContain("--color-paper-2: var(--paper-2)")
-    expect(styles).toContain("--on-solid:")
-    expect(styles).toContain("--color-on-solid: var(--on-solid)")
-    expect(root).toContain("text-on-solid")
-    expect(root).toContain("backdrop:bg-black/50")
-    expect(root).not.toContain("backdrop:bg-ink/45")
+    // Dialog scrim token (phase 5) — theme-invariant dimming, not ink-derived.
+    expect(styles).toContain("--scrim:")
+    expect(styles).toContain(".dialog-panel::backdrop")
+    expect(styles).toContain("background: var(--scrim)")
+    expect(root).toContain('className="dialog-panel"')
+    // Ledger oxblood / elevated paper-2 palette is gone after phase 5 teardown.
+    expect(styles).not.toContain("--paper-2:")
+    expect(styles).not.toContain("--color-oxblood")
+    expect(styles).not.toContain("--font-serif")
   })
 
   test("banner pattern is shared and used for nav-level guidance/alarm", () => {

--- a/docs/kanban.md
+++ b/docs/kanban.md
@@ -66,10 +66,10 @@ The prototype uses an industrial control-board language:
 - Repository management and intake live on `/repos`, not under the board.
 
 The visual treatment follows the Interchange design system
-(`docs/harness-design-system.md` when present; otherwise the harness CSS
-token layer). The essential design idea is the board structure, fixed lane
-identity, open white platforms with lane-color nameboards, and compact
-operator-facing tickets — not the older Ledger concrete fills or serif stack.
+(`docs/harness-design-system.md`). The essential design idea is the board
+structure, fixed lane identity, open white platforms with lane-color
+nameboards, and compact operator-facing tickets — not the older Ledger
+concrete fills or serif stack.
 
 ## Interaction Model
 


### PR DESCRIPTION
## Summary

Land phase 5 of the Harness Interchange design system: re-skin settings,
repository settings, and session-usage dialogs; consolidate kebab menus and
loading/copy chrome; tear down remaining Ledger tokens and helpers once no
surfaces reference them. Completes the migration sequence after phases 1–4
(tokens/nav, board, archive, repos).

## Why

Issue #704 is the last surface slice of the unified industrial UI. Dialogs and
menus still used Ledger density (serif titles, oxblood washes/CTAs, drop
shadows, rule borders). After board/archive/repos, operators still hit those
surfaces on every settings save and repo action. Spec §4.9–4.11 / §9.5:
migrate them, then delete the old palette and classes.

## What changed

- **Dialogs (§4.9):** Shared `dialog-panel` shell (2px ink, scrim backdrop, no
  shadow); kicker/title/lede; field grid + 1.5px ink inputs; signal accent
  checkboxes; status rows; hairline footer with Cancel mini plate + Save
  primary plate; compact Banner callouts; session-usage narrow panel + table +
  telemetry guidance banners.
- **Menus (§4.10):** Shared `menu-panel` / `menu-item` (flush, no drop shadow);
  mono uppercase items; destructive hover/focus = Attention fill; parent-issue
  errors stay compact alarm banners.
- **Chrome (§4.11):** Shared `.skeleton` (line-ghost pulse, motion-reduce-safe);
  merged-PR and completed loaders aligned; copy control keeps PR-green success
  glyph.
- **A11y / polish (review remediation):** Dialog fields keep `:focus-visible`
  outline; menu items share hover/focus treatments; primary plate uses
  `cursor: wait` only when `aria-busy`; forge path titles preserve case via
  `dialog-title--path`.
- **Ledger teardown (§9.5):** Remove oxblood/sepia/olive/teal washes, serif
  stack, paper-2/rule tokens, field-rule/entry-rule, offset shadows. Keep
  Interchange exception stamps (§5.6). Point `docs/kanban.md` at
  `docs/harness-design-system.md`.

Behavior (dialog show/hide, menu dismissal, form contracts / control names) is
unchanged so role-based e2e selectors remain valid.

## Verification

- `bun --conditions=@ready-for-agent/source test` in `apps/harness` — 464 pass
- New/updated contract tests in `apps/harness/test/interchange-phase5.test.ts`
  (dialog shell, menus, skeletons, focus-visible, teardown)
- Second local review: clean after remediation

Closes #704