### PR TITLE
refactor(harness): extract Keymaxxer forge helper-invocation combinator

### DIFF
--- a/apps/harness/src/server/keymaxxer-github-layer.ts
+++ b/apps/harness/src/server/keymaxxer-github-layer.ts
@@ -6,7 +6,6 @@ import {
   GitHubRequestError,
   GitHubService,
   type GitHubServiceShape,
-  type MergePullRequestResult,
   type ReadyLabeledIssue,
   formatGitHubHelperShellCommand,
   resolveGitHubHelperChildSpawn,
@@ -22,12 +21,12 @@ import { KeymaxxerService } from "@ready-for-agent/keymaxxer-service"
  */
 export const OPEN_PULL_REQUEST_COUNT_FRESHNESS_MS = 5_000
 
-type GitHubCountError = GitHubRepositoryUnavailableError | GitHubRequestError
+type GitHubServiceError = GitHubRepositoryUnavailableError | GitHubRequestError
 
 type OpenPullRequestCountCacheEntry =
   | {
       readonly kind: "inflight"
-      readonly deferred: Deferred.Deferred<number, GitHubCountError>
+      readonly deferred: Deferred.Deferred<number, GitHubServiceError>
     }
   | {
       readonly kind: "success"
@@ -258,6 +257,82 @@ const parseIssues = (
     ),
   )
 
+/** Decode a positive integer from helper stdout (trimmed). */
+const decodePositiveInt = (
+  stdout: string,
+  repository: GitHubRepository,
+  describe: string,
+): Effect.Effect<number, GitHubRequestError> => {
+  const number = Number(stdout.trim())
+  if (!Number.isSafeInteger(number) || number <= 0) {
+    return Effect.fail(requestError(repository, describe, stdout))
+  }
+  return Effect.succeed(number)
+}
+
+/**
+ * Decode a non-negative integer from helper stdout.
+ * Empty body on exit 0 must not become `Number("") === 0`.
+ */
+const decodeNonNegativeInt = (
+  stdout: string,
+  repository: GitHubRepository,
+  describe: string,
+): Effect.Effect<number, GitHubRequestError> => {
+  const trimmed = stdout.trim()
+  if (trimmed === "") {
+    return Effect.fail(requestError(repository, describe, "empty stdout"))
+  }
+  const count = Number(trimmed)
+  if (!Number.isSafeInteger(count) || count < 0) {
+    return Effect.fail(requestError(repository, describe, stdout))
+  }
+  return Effect.succeed(count)
+}
+
+/** Decode a positive integer, or null when stdout is empty / `"null"`. */
+const decodeNullableInt = (
+  stdout: string,
+  repository: GitHubRepository,
+  describe: string,
+): Effect.Effect<number | null, GitHubRequestError> => {
+  const trimmed = stdout.trim()
+  if (trimmed === "" || trimmed === "null") {
+    return Effect.succeed(null)
+  }
+  const number = Number(trimmed)
+  if (!Number.isSafeInteger(number) || number <= 0) {
+    return Effect.fail(requestError(repository, describe, stdout))
+  }
+  return Effect.succeed(number)
+}
+
+const decodeVoid = (_stdout: string): Effect.Effect<void, never> => Effect.void
+
+const decodeNonEmptyTrimmed = (
+  stdout: string,
+  repository: GitHubRepository,
+  describe: string,
+  emptyDetail: string,
+): Effect.Effect<string, GitHubRequestError> => {
+  const value = stdout.trim()
+  if (value === "") {
+    return Effect.fail(requestError(repository, describe, emptyDetail))
+  }
+  return Effect.succeed(value)
+}
+
+const decodeJson =
+  <A, I>(
+    schema: Schema.Codec<A, I>,
+    repository: GitHubRepository,
+    describe: string,
+  ) =>
+  (stdout: string): Effect.Effect<A, GitHubRequestError> =>
+    Schema.decodeUnknownEffect(Schema.fromJsonString(schema))(stdout).pipe(
+      Effect.mapError(() => requestError(repository, describe, stdout)),
+    )
+
 export const keymaxxerGitHubLayer = (options: {
   readonly workspaceRoot: string
   /**
@@ -310,60 +385,66 @@ export const keymaxxerGitHubLayer = (options: {
           ),
       )
 
-      const fetchOpenNonDraftPullRequestCount = (
-        repository: GitHubRepository,
-      ): Effect.Effect<number, GitHubCountError> =>
+      /**
+       * Shared Keymaxxer helper invocation: token lookup, repository arg
+       * encoding, exit-code mapping, stdout decode, and KeymaxxerError →
+       * requestError. Each service method supplies only operation, args, and
+       * a decoder.
+       */
+      const callHelper = <A>(input: {
+        readonly operation: GitHubHelperOperation
+        readonly repository: GitHubRepository
+        readonly describe: string
+        readonly args?: readonly string[]
+        readonly decode: (
+          stdout: string,
+        ) => Effect.Effect<A, GitHubRequestError>
+      }): Effect.Effect<A, GitHubServiceError> =>
         Effect.gen(function* () {
-          const tokenName = yield* ensureToken(repository)
+          const tokenName = yield* ensureToken(input.repository)
           if (tokenName === null) {
-            return yield* requestError(
-              repository,
-              "count open non-draft pull requests",
-            )
+            return yield* requestError(input.repository, input.describe)
           }
-          const [forge, forgeHost, projectPath] =
-            encodedRepositoryArguments(repository)
-          const result = yield* runGitHubBin(
-            tokenName,
-            "count-open-non-draft-pull-requests",
-            [forge, forgeHost, projectPath],
+          const [forge, forgeHost, projectPath] = encodedRepositoryArguments(
+            input.repository,
           )
+          const result = yield* runGitHubBin(tokenName, input.operation, [
+            forge,
+            forgeHost,
+            projectPath,
+            ...(input.args ?? []),
+          ])
           if (result.exitCode === 2) {
-            return yield* repositoryUnavailable(repository)
+            return yield* repositoryUnavailable(input.repository)
           }
           if (result.exitCode !== 0) {
             return yield* requestError(
-              repository,
-              "count open non-draft pull requests",
+              input.repository,
+              input.describe,
               result.stderr || result.stdout,
             )
           }
-          // Empty body on exit 0 must not become Number("") === 0 and then be
-          // success-cached as a genuine open-PR count of zero.
-          const trimmed = result.stdout.trim()
-          if (trimmed === "") {
-            return yield* requestError(
-              repository,
-              "decode open non-draft pull request count",
-              "empty stdout",
-            )
-          }
-          const count = Number(trimmed)
-          if (!Number.isSafeInteger(count) || count < 0) {
-            return yield* requestError(
-              repository,
-              "decode open non-draft pull request count",
-              result.stdout,
-            )
-          }
-          return count
+          return yield* input.decode(result.stdout)
         }).pipe(
           Effect.catchTag("KeymaxxerError", () =>
-            Effect.fail(
-              requestError(repository, "count open non-draft pull requests"),
-            ),
+            Effect.fail(requestError(input.repository, input.describe)),
           ),
         )
+
+      const fetchOpenNonDraftPullRequestCount = (
+        repository: GitHubRepository,
+      ): Effect.Effect<number, GitHubServiceError> =>
+        callHelper({
+          operation: "count-open-non-draft-pull-requests",
+          repository,
+          describe: "count open non-draft pull requests",
+          decode: (stdout) =>
+            decodeNonNegativeInt(
+              stdout,
+              repository,
+              "decode open non-draft pull request count",
+            ),
+        })
 
       /**
        * Process-wide single-flight + short success cache per Repository.
@@ -374,13 +455,13 @@ export const keymaxxerGitHubLayer = (options: {
         "KeymaxxerGitHub.countOpenNonDraftPullRequests",
       )(function* (repository: GitHubRepository) {
         const key = openPullRequestCountCacheKey(repository)
-        const candidate = yield* Deferred.make<number, GitHubCountError>()
+        const candidate = yield* Deferred.make<number, GitHubServiceError>()
 
         type Claim =
           | { readonly role: "owner" }
           | {
               readonly role: "join"
-              readonly deferred: Deferred.Deferred<number, GitHubCountError>
+              readonly deferred: Deferred.Deferred<number, GitHubServiceError>
             }
           | { readonly role: "cached"; readonly count: number }
 
@@ -453,633 +534,255 @@ export const keymaxxerGitHubLayer = (options: {
       })
 
       const service: GitHubServiceShape = {
-        getAuthenticatedUserLogin: (repository) =>
-          Effect.gen(function* () {
-            const tokenName = yield* ensureToken(repository)
-            if (tokenName === null) {
-              return yield* requestError(
-                repository,
-                "resolve authenticated GitHub user",
-              )
-            }
-            const [forge, forgeHost, projectPath] =
-              encodedRepositoryArguments(repository)
-            const result = yield* runGitHubBin(
-              tokenName,
-              "get-authenticated-user-login",
-              [forge, forgeHost, projectPath],
-            )
-            if (result.exitCode === 2) {
-              return yield* repositoryUnavailable(repository)
-            }
-            if (result.exitCode !== 0) {
-              return yield* requestError(
-                repository,
-                "resolve authenticated GitHub user",
-                result.stderr || result.stdout,
-              )
-            }
-            const login = result.stdout.trim()
-            if (login === "") {
-              return yield* requestError(
+        getAuthenticatedUserLogin: Effect.fn(
+          "KeymaxxerGitHub.getAuthenticatedUserLogin",
+        )((repository) =>
+          callHelper({
+            operation: "get-authenticated-user-login",
+            repository,
+            describe: "resolve authenticated GitHub user",
+            decode: (stdout) =>
+              decodeNonEmptyTrimmed(
+                stdout,
                 repository,
                 "resolve authenticated GitHub user",
                 "empty login",
-              )
-            }
-            return login
-          }).pipe(
-            Effect.catchTag("KeymaxxerError", () =>
-              Effect.fail(
-                requestError(repository, "resolve authenticated GitHub user"),
               ),
-            ),
-          ),
-        getOpenPullRequestNumber: (repository, headRefName) =>
-          Effect.gen(function* () {
-            const tokenName = yield* ensureToken(repository)
-            if (tokenName === null) {
-              return yield* requestError(
-                repository,
-                "get open pull request number",
-              )
-            }
-            const [forge, forgeHost, projectPath] =
-              encodedRepositoryArguments(repository)
-            const head = encodeArgument(headRefName)
-            const result = yield* runGitHubBin(
-              tokenName,
-              "get-open-pr-number",
-              [forge, forgeHost, projectPath, head],
-            )
-            if (result.exitCode === 2) {
-              return yield* repositoryUnavailable(repository)
-            }
-            if (result.exitCode !== 0) {
-              return yield* requestError(
-                repository,
-                "get open pull request number",
-                result.stderr || result.stdout,
-              )
-            }
-            const number = Number(result.stdout.trim())
-            if (!Number.isSafeInteger(number) || number <= 0) {
-              return yield* requestError(
+          }),
+        ),
+        getOpenPullRequestNumber: Effect.fn(
+          "KeymaxxerGitHub.getOpenPullRequestNumber",
+        )((repository, headRefName) =>
+          callHelper({
+            operation: "get-open-pr-number",
+            repository,
+            describe: "get open pull request number",
+            args: [encodeArgument(headRefName)],
+            decode: (stdout) =>
+              decodePositiveInt(
+                stdout,
                 repository,
                 "decode open pull request number",
-                result.stdout,
-              )
-            }
-            return number
-          }).pipe(
-            Effect.catchTag("KeymaxxerError", () =>
-              Effect.fail(
-                requestError(repository, "get open pull request number"),
               ),
-            ),
-          ),
-        findOpenPullRequestNumber: (repository, headRefName) =>
-          Effect.gen(function* () {
-            const tokenName = yield* ensureToken(repository)
-            if (tokenName === null) {
-              return yield* requestError(
-                repository,
-                "find open pull request number",
-              )
-            }
-            const [forge, forgeHost, projectPath] =
-              encodedRepositoryArguments(repository)
-            const head = encodeArgument(headRefName)
-            const result = yield* runGitHubBin(
-              tokenName,
-              "find-open-pr-number",
-              [forge, forgeHost, projectPath, head],
-            )
-            if (result.exitCode === 2) {
-              return yield* repositoryUnavailable(repository)
-            }
-            if (result.exitCode !== 0) {
-              return yield* requestError(
-                repository,
-                "find open pull request number",
-                result.stderr || result.stdout,
-              )
-            }
-            const trimmed = result.stdout.trim()
-            if (trimmed === "" || trimmed === "null") {
-              return null
-            }
-            const number = Number(trimmed)
-            if (!Number.isSafeInteger(number) || number <= 0) {
-              return yield* requestError(
+          }),
+        ),
+        findOpenPullRequestNumber: Effect.fn(
+          "KeymaxxerGitHub.findOpenPullRequestNumber",
+        )((repository, headRefName) =>
+          callHelper({
+            operation: "find-open-pr-number",
+            repository,
+            describe: "find open pull request number",
+            args: [encodeArgument(headRefName)],
+            decode: (stdout) =>
+              decodeNullableInt(
+                stdout,
                 repository,
                 "decode open pull request number",
-                result.stdout,
-              )
-            }
-            return number
-          }).pipe(
-            Effect.catchTag("KeymaxxerError", () =>
-              Effect.fail(
-                requestError(repository, "find open pull request number"),
               ),
-            ),
-          ),
-        createDraftPullRequest: (repository, input) =>
-          Effect.gen(function* () {
-            const tokenName = yield* ensureToken(repository)
-            if (tokenName === null) {
-              return yield* requestError(
-                repository,
-                "create draft pull request",
-              )
-            }
-            const [forge, forgeHost, projectPath] =
-              encodedRepositoryArguments(repository)
-            const payload = encodeArgument(
-              JSON.stringify({
-                headRefName: input.headRefName,
-                title: input.title,
-                body: input.body,
-                ...(input.baseRefName === undefined
-                  ? {}
-                  : { baseRefName: input.baseRefName }),
-              }),
-            )
-            const result = yield* runGitHubBin(
-              tokenName,
-              "create-draft-pull-request",
-              [forge, forgeHost, projectPath, payload],
-            )
-            if (result.exitCode === 2) {
-              return yield* repositoryUnavailable(repository)
-            }
-            if (result.exitCode !== 0) {
-              return yield* requestError(
-                repository,
-                "create draft pull request",
-                result.stderr || result.stdout,
-              )
-            }
-            const number = Number(result.stdout.trim())
-            if (!Number.isSafeInteger(number) || number <= 0) {
-              return yield* requestError(
+          }),
+        ),
+        createDraftPullRequest: Effect.fn(
+          "KeymaxxerGitHub.createDraftPullRequest",
+        )((repository, input) =>
+          callHelper({
+            operation: "create-draft-pull-request",
+            repository,
+            describe: "create draft pull request",
+            args: [
+              encodeArgument(
+                JSON.stringify({
+                  headRefName: input.headRefName,
+                  title: input.title,
+                  body: input.body,
+                  ...(input.baseRefName === undefined
+                    ? {}
+                    : { baseRefName: input.baseRefName }),
+                }),
+              ),
+            ],
+            decode: (stdout) =>
+              decodePositiveInt(
+                stdout,
                 repository,
                 "decode created draft pull request number",
-                result.stdout,
-              )
-            }
-            return number
-          }).pipe(
-            Effect.catchTag("KeymaxxerError", () =>
-              Effect.fail(
-                requestError(repository, "create draft pull request"),
               ),
-            ),
-          ),
-        updateOpenDraftPullRequestCopy: (repository, headRefName, input) =>
-          Effect.gen(function* () {
-            const tokenName = yield* ensureToken(repository)
-            if (tokenName === null) {
-              return yield* requestError(
-                repository,
-                "update open draft pull request copy",
-              )
-            }
-            const [forge, forgeHost, projectPath] =
-              encodedRepositoryArguments(repository)
-            const payload = encodeArgument(
-              JSON.stringify({
-                headRefName,
-                title: input.title,
-                body: input.body,
-              }),
-            )
-            const result = yield* runGitHubBin(
-              tokenName,
-              "update-open-draft-pull-request-copy",
-              [forge, forgeHost, projectPath, payload],
-            )
-            if (result.exitCode === 2) {
-              return yield* repositoryUnavailable(repository)
-            }
-            if (result.exitCode !== 0) {
-              return yield* requestError(
-                repository,
-                "update open draft pull request copy",
-                result.stderr || result.stdout,
-              )
-            }
-            const trimmed = result.stdout.trim()
-            if (trimmed === "" || trimmed === "null") {
-              return null
-            }
-            const number = Number(trimmed)
-            if (!Number.isSafeInteger(number) || number <= 0) {
-              return yield* requestError(
+          }),
+        ),
+        updateOpenDraftPullRequestCopy: Effect.fn(
+          "KeymaxxerGitHub.updateOpenDraftPullRequestCopy",
+        )((repository, headRefName, input) =>
+          callHelper({
+            operation: "update-open-draft-pull-request-copy",
+            repository,
+            describe: "update open draft pull request copy",
+            args: [
+              encodeArgument(
+                JSON.stringify({
+                  headRefName,
+                  title: input.title,
+                  body: input.body,
+                }),
+              ),
+            ],
+            decode: (stdout) =>
+              decodeNullableInt(
+                stdout,
                 repository,
                 "decode updated draft pull request number",
-                result.stdout,
-              )
-            }
-            return number
-          }).pipe(
-            Effect.catchTag("KeymaxxerError", () =>
-              Effect.fail(
-                requestError(repository, "update open draft pull request copy"),
               ),
-            ),
-          ),
+          }),
+        ),
         countOpenNonDraftPullRequests: countOpenNonDraftPullRequestsCoalesced,
-        getPullRequestCheckStatus: (repository, headRefName) =>
-          Effect.gen(function* () {
-            const tokenName = yield* ensureToken(repository)
-            if (tokenName === null) {
-              return yield* requestError(
+        getPullRequestCheckStatus: Effect.fn(
+          "KeymaxxerGitHub.getPullRequestCheckStatus",
+        )((repository, headRefName) =>
+          callHelper({
+            operation: "get-pr-check-status",
+            repository,
+            describe: "get pull request check status",
+            args: [encodeArgument(headRefName)],
+            decode: (stdout) =>
+              decodeJson(
+                SerializedPullRequestCheckStatus,
                 repository,
-                "get pull request check status",
-              )
-            }
-            const [forge, forgeHost, projectPath] =
-              encodedRepositoryArguments(repository)
-            const head = encodeArgument(headRefName)
-            const result = yield* runGitHubBin(
-              tokenName,
-              "get-pr-check-status",
-              [forge, forgeHost, projectPath, head],
-            )
-            if (result.exitCode === 2) {
-              return yield* repositoryUnavailable(repository)
-            }
-            if (result.exitCode !== 0) {
-              return yield* requestError(
-                repository,
-                "get pull request check status",
-                result.stderr || result.stdout,
-              )
-            }
-            return yield* Schema.decodeUnknownEffect(
-              Schema.fromJsonString(SerializedPullRequestCheckStatus),
-            )(result.stdout).pipe(
-              Effect.map((status) => ({
-                ...status,
-                headPushedAt: decodeOptionalInstant(status.headPushedAt),
-                createdAt: decodeOptionalInstant(status.createdAt),
+                "decode pull request check status",
+              )(stdout).pipe(
+                Effect.map((status) => ({
+                  ...status,
+                  headPushedAt: decodeOptionalInstant(status.headPushedAt),
+                  createdAt: decodeOptionalInstant(status.createdAt),
+                })),
+              ),
+          }),
+        ),
+        getPrStatusCheckDiagnostics: Effect.fn(
+          "KeymaxxerGitHub.getPrStatusCheckDiagnostics",
+        )((repository, checks, options = {}) => {
+          const checksArg = encodeArgument(
+            JSON.stringify(
+              checks.map((check) => ({
+                externalId: check.externalId,
+                name: check.name,
               })),
-              Effect.mapError(() =>
-                requestError(
-                  repository,
-                  "decode pull request check status",
-                  result.stdout,
+            ),
+          )
+          const logDirectory =
+            typeof options.logDirectory === "string" &&
+            options.logDirectory.trim() !== ""
+              ? encodeArgument(options.logDirectory)
+              : ""
+          return callHelper({
+            operation: "get-pr-status-check-diagnostics",
+            repository,
+            describe: "get PR Status Check diagnostics",
+            args: logDirectory === "" ? [checksArg] : [checksArg, logDirectory],
+            decode: decodeJson(
+              SerializedPrStatusCheckDiagnostics,
+              repository,
+              "decode PR Status Check diagnostics",
+            ),
+          })
+        }),
+        observeAutomatedReviewEvidence: Effect.fn(
+          "KeymaxxerGitHub.observeAutomatedReviewEvidence",
+        )((repository, headRefName, checks) =>
+          callHelper({
+            operation: "observe-automated-review-evidence",
+            repository,
+            describe: "observe automated review evidence",
+            args: [
+              encodeArgument(headRefName),
+              encodeArgument(
+                JSON.stringify(
+                  checks.map((check) => ({
+                    externalId: check.externalId,
+                    name: check.name,
+                  })),
                 ),
               ),
-            )
-          }).pipe(
-            Effect.catchTag("KeymaxxerError", () =>
-              Effect.fail(
-                requestError(repository, "get pull request check status"),
-              ),
+            ],
+            decode: decodeJson(
+              SerializedAutomatedReviewEvidenceObservation,
+              repository,
+              "decode automated review evidence",
             ),
-          ),
-        getPrStatusCheckDiagnostics: (repository, checks, options = {}) =>
-          Effect.gen(function* () {
-            const tokenName = yield* ensureToken(repository)
-            if (tokenName === null) {
-              return yield* requestError(
-                repository,
-                "get PR Status Check diagnostics",
-              )
-            }
-            const [forge, forgeHost, projectPath] =
-              encodedRepositoryArguments(repository)
-            const checksArg = encodeArgument(
-              JSON.stringify(
-                checks.map((check) => ({
-                  externalId: check.externalId,
-                  name: check.name,
-                })),
-              ),
-            )
-            const logDirectory =
-              typeof options.logDirectory === "string" &&
-              options.logDirectory.trim() !== ""
-                ? encodeArgument(options.logDirectory)
-                : ""
-            const result = yield* runGitHubBin(
-              tokenName,
-              "get-pr-status-check-diagnostics",
-              logDirectory === ""
-                ? [forge, forgeHost, projectPath, checksArg]
-                : [forge, forgeHost, projectPath, checksArg, logDirectory],
-            )
-            if (result.exitCode === 2) {
-              return yield* repositoryUnavailable(repository)
-            }
-            if (result.exitCode !== 0) {
-              return yield* requestError(
-                repository,
-                "get PR Status Check diagnostics",
-                result.stderr || result.stdout,
-              )
-            }
-            return yield* Schema.decodeUnknownEffect(
-              Schema.fromJsonString(SerializedPrStatusCheckDiagnostics),
-            )(result.stdout).pipe(
-              Effect.mapError(() =>
-                requestError(
-                  repository,
-                  "decode PR Status Check diagnostics",
-                  result.stdout,
-                ),
-              ),
-            )
-          }).pipe(
-            Effect.catchTag("KeymaxxerError", () =>
-              Effect.fail(
-                requestError(repository, "get PR Status Check diagnostics"),
-              ),
+          }),
+        ),
+        getPullRequestLifecycleStatus: Effect.fn(
+          "KeymaxxerGitHub.getPullRequestLifecycleStatus",
+        )((repository, headRefName) =>
+          callHelper({
+            operation: "get-pr-lifecycle-status",
+            repository,
+            describe: "get pull request lifecycle status",
+            args: [encodeArgument(headRefName)],
+            decode: decodeJson(
+              SerializedPullRequestLifecycleStatus,
+              repository,
+              "decode pull request lifecycle status",
             ),
-          ),
-        observeAutomatedReviewEvidence: (repository, headRefName, checks) =>
-          Effect.gen(function* () {
-            const tokenName = yield* ensureToken(repository)
-            if (tokenName === null) {
-              return yield* requestError(
+          }),
+        ),
+        markPullRequestReadyForReview: Effect.fn(
+          "KeymaxxerGitHub.markPullRequestReadyForReview",
+        )((repository, headRefName) =>
+          callHelper({
+            operation: "mark-pr-ready-for-review",
+            repository,
+            describe: "mark pull request ready for review",
+            args: [encodeArgument(headRefName)],
+            decode: decodeVoid,
+          }),
+        ),
+        mergePullRequest: Effect.fn("KeymaxxerGitHub.mergePullRequest")(
+          (repository, headRefName) =>
+            callHelper({
+              operation: "merge-pull-request",
+              repository,
+              describe: "merge pull request",
+              args: [encodeArgument(headRefName)],
+              decode: decodeJson(
+                SerializedMergePullRequestResult,
                 repository,
-                "observe automated review evidence",
-              )
-            }
-            const [forge, forgeHost, projectPath] =
-              encodedRepositoryArguments(repository)
-            const head = encodeArgument(headRefName)
-            const checksArg = encodeArgument(
-              JSON.stringify(
-                checks.map((check) => ({
-                  externalId: check.externalId,
-                  name: check.name,
-                })),
+                "decode merge pull request result",
               ),
-            )
-            const result = yield* runGitHubBin(
-              tokenName,
-              "observe-automated-review-evidence",
-              [forge, forgeHost, projectPath, head, checksArg],
-            )
-            if (result.exitCode === 2) {
-              return yield* repositoryUnavailable(repository)
-            }
-            if (result.exitCode !== 0) {
-              return yield* requestError(
-                repository,
-                "observe automated review evidence",
-                result.stderr || result.stdout,
-              )
-            }
-            return yield* Schema.decodeUnknownEffect(
-              Schema.fromJsonString(
-                SerializedAutomatedReviewEvidenceObservation,
-              ),
-            )(result.stdout).pipe(
-              Effect.mapError(() =>
-                requestError(
-                  repository,
-                  "decode automated review evidence",
-                  result.stdout,
-                ),
-              ),
-            )
-          }).pipe(
-            Effect.catchTag("KeymaxxerError", () =>
-              Effect.fail(
-                requestError(repository, "observe automated review evidence"),
-              ),
-            ),
-          ),
-        getPullRequestLifecycleStatus: (repository, headRefName) =>
-          Effect.gen(function* () {
-            const tokenName = yield* ensureToken(repository)
-            if (tokenName === null) {
-              return yield* requestError(
-                repository,
-                "get pull request lifecycle status",
-              )
-            }
-            const [forge, forgeHost, projectPath] =
-              encodedRepositoryArguments(repository)
-            const head = encodeArgument(headRefName)
-            const result = yield* runGitHubBin(
-              tokenName,
-              "get-pr-lifecycle-status",
-              [forge, forgeHost, projectPath, head],
-            )
-            if (result.exitCode === 2) {
-              return yield* repositoryUnavailable(repository)
-            }
-            if (result.exitCode !== 0) {
-              return yield* requestError(
-                repository,
-                "get pull request lifecycle status",
-                result.stderr || result.stdout,
-              )
-            }
-            return yield* Schema.decodeUnknownEffect(
-              Schema.fromJsonString(SerializedPullRequestLifecycleStatus),
-            )(result.stdout).pipe(
-              Effect.mapError(() =>
-                requestError(
-                  repository,
-                  "decode pull request lifecycle status",
-                  result.stdout,
-                ),
-              ),
-            )
-          }).pipe(
-            Effect.catchTag("KeymaxxerError", () =>
-              Effect.fail(
-                requestError(repository, "get pull request lifecycle status"),
-              ),
-            ),
-          ),
-        markPullRequestReadyForReview: (repository, headRefName) =>
-          Effect.gen(function* () {
-            const tokenName = yield* ensureToken(repository)
-            if (tokenName === null) {
-              return yield* requestError(
-                repository,
-                "mark pull request ready for review",
-              )
-            }
-            const [forge, forgeHost, projectPath] =
-              encodedRepositoryArguments(repository)
-            const head = encodeArgument(headRefName)
-            const result = yield* runGitHubBin(
-              tokenName,
-              "mark-pr-ready-for-review",
-              [forge, forgeHost, projectPath, head],
-            )
-            if (result.exitCode === 2) {
-              return yield* repositoryUnavailable(repository)
-            }
-            if (result.exitCode !== 0) {
-              return yield* requestError(
-                repository,
-                "mark pull request ready for review",
-                result.stderr || result.stdout,
-              )
-            }
-          }).pipe(
-            Effect.catchTag("KeymaxxerError", () =>
-              Effect.fail(
-                requestError(repository, "mark pull request ready for review"),
-              ),
-            ),
-          ),
-        mergePullRequest: (repository, headRefName) =>
-          Effect.gen(function* () {
-            const tokenName = yield* ensureToken(repository)
-            if (tokenName === null) {
-              return yield* requestError(repository, "merge pull request")
-            }
-            const [forge, forgeHost, projectPath] =
-              encodedRepositoryArguments(repository)
-            const head = encodeArgument(headRefName)
-            const result = yield* runGitHubBin(
-              tokenName,
-              "merge-pull-request",
-              [forge, forgeHost, projectPath, head],
-            )
-            if (result.exitCode === 2) {
-              return yield* repositoryUnavailable(repository)
-            }
-            if (result.exitCode !== 0) {
-              return yield* requestError(
-                repository,
-                "merge pull request",
-                result.stderr || result.stdout,
-              )
-            }
-            return yield* Schema.decodeUnknownEffect(
-              Schema.fromJsonString(SerializedMergePullRequestResult),
-            )(result.stdout).pipe(
-              Effect.mapError(() =>
-                requestError(
-                  repository,
-                  "decode merge pull request result",
-                  result.stdout,
-                ),
-              ),
-            ) as Effect.Effect<MergePullRequestResult, GitHubRequestError>
-          }).pipe(
-            Effect.catchTag("KeymaxxerError", () =>
-              Effect.fail(requestError(repository, "merge pull request")),
-            ),
-          ),
-        rerunWorkflowRun: (repository, workflowRunId) =>
-          Effect.gen(function* () {
-            const tokenName = yield* ensureToken(repository)
-            if (tokenName === null) {
-              return yield* requestError(repository, "rerun workflow run")
-            }
-            const [forge, forgeHost, projectPath] =
-              encodedRepositoryArguments(repository)
-            const runId = encodeArgument(String(workflowRunId))
-            const result = yield* runGitHubBin(
-              tokenName,
-              "rerun-workflow-run",
-              [forge, forgeHost, projectPath, runId],
-            )
-            if (result.exitCode === 2) {
-              return yield* repositoryUnavailable(repository)
-            }
-            if (result.exitCode !== 0) {
-              return yield* requestError(
-                repository,
-                "rerun workflow run",
-                result.stderr || result.stdout,
-              )
-            }
-          }).pipe(
-            Effect.catchTag("KeymaxxerError", () =>
-              Effect.fail(requestError(repository, "rerun workflow run")),
-            ),
-          ),
-        ensureIssueCompletedWithSummary: (
-          repository,
-          issueNumber,
-          workItemId,
-          summaryMarkdown,
-        ) =>
-          Effect.gen(function* () {
-            const tokenName = yield* ensureToken(repository)
-            if (tokenName === null) {
-              return yield* requestError(
-                repository,
-                "complete Issue with summary",
-              )
-            }
-            const [forge, forgeHost, projectPath] =
-              encodedRepositoryArguments(repository)
-            const number = encodeArgument(String(issueNumber))
-            const workItem = encodeArgument(workItemId)
-            const summary = encodeArgument(summaryMarkdown)
-            const result = yield* runGitHubBin(
-              tokenName,
-              "ensure-issue-completed-with-summary",
-              [forge, forgeHost, projectPath, number, workItem, summary],
-            )
-            if (result.exitCode === 2) {
-              return yield* repositoryUnavailable(repository)
-            }
-            if (result.exitCode !== 0) {
-              return yield* requestError(
-                repository,
-                "complete Issue with summary",
-                result.stderr || result.stdout,
-              )
-            }
-          }).pipe(
-            Effect.catchTag("KeymaxxerError", () =>
-              Effect.fail(
-                requestError(repository, "complete Issue with summary"),
-              ),
-            ),
-          ),
-        listReadyIssues: (repository) =>
-          Effect.gen(function* () {
-            const tokenName = yield* ensureToken(repository)
-            if (tokenName === null) {
-              return yield* requestError(
-                repository,
-                "list Ready-labeled Issues",
-              )
-            }
-
-            const [forge, forgeHost, projectPath] =
-              encodedRepositoryArguments(repository)
-            const result = yield* runGitHubBin(tokenName, "list-ready-issues", [
-              forge,
-              forgeHost,
-              projectPath,
-            ])
-
-            if (result.exitCode === 2) {
-              return yield* repositoryUnavailable(repository)
-            }
-            if (result.exitCode !== 0) {
-              return yield* requestError(
-                repository,
-                "list Ready-labeled Issues",
-                result.stderr || result.stdout,
-              )
-            }
-            return yield* parseIssues(result.stdout, repository)
-          }).pipe(
-            Effect.catchTag("KeymaxxerError", () =>
-              Effect.fail(
-                requestError(repository, "list Ready-labeled Issues"),
-              ),
-            ),
-          ),
+            }),
+        ),
+        rerunWorkflowRun: Effect.fn("KeymaxxerGitHub.rerunWorkflowRun")(
+          (repository, workflowRunId) =>
+            callHelper({
+              operation: "rerun-workflow-run",
+              repository,
+              describe: "rerun workflow run",
+              args: [encodeArgument(String(workflowRunId))],
+              decode: decodeVoid,
+            }),
+        ),
+        ensureIssueCompletedWithSummary: Effect.fn(
+          "KeymaxxerGitHub.ensureIssueCompletedWithSummary",
+        )((repository, issueNumber, workItemId, summaryMarkdown) =>
+          callHelper({
+            operation: "ensure-issue-completed-with-summary",
+            repository,
+            describe: "complete Issue with summary",
+            args: [
+              encodeArgument(String(issueNumber)),
+              encodeArgument(workItemId),
+              encodeArgument(summaryMarkdown),
+            ],
+            decode: decodeVoid,
+          }),
+        ),
+        listReadyIssues: Effect.fn("KeymaxxerGitHub.listReadyIssues")(
+          (repository) =>
+            callHelper({
+              operation: "list-ready-issues",
+              repository,
+              describe: "list Ready-labeled Issues",
+              decode: (stdout) => parseIssues(stdout, repository),
+            }),
+        ),
       }
 
       return service

--- a/apps/harness/src/server/keymaxxer-gitlab-layer.ts
+++ b/apps/harness/src/server/keymaxxer-gitlab-layer.ts
@@ -233,6 +233,85 @@ const parseIssues = (
     ),
   )
 
+/** Decode a positive integer from helper stdout (trimmed). */
+const decodePositiveInt = (
+  stdout: string,
+  repository: GitLabRepository,
+  describe: string,
+): Effect.Effect<number, GitLabRequestError> => {
+  const number = Number(stdout.trim())
+  if (!Number.isSafeInteger(number) || number <= 0) {
+    return Effect.fail(requestError(repository, describe, stdout))
+  }
+  return Effect.succeed(number)
+}
+
+/**
+ * Decode a non-negative integer from helper stdout.
+ *
+ * Intentional forge difference vs GitHub: empty stdout is accepted as `0`
+ * (`Number("") === 0`). GitHub's sibling rejects empty body so a blank exit-0
+ * count cannot be success-cached as zero. Do not "align" these without a
+ * product decision and test updates on both layers.
+ */
+const decodeNonNegativeInt = (
+  stdout: string,
+  repository: GitLabRepository,
+  describe: string,
+): Effect.Effect<number, GitLabRequestError> => {
+  const count = Number(stdout.trim())
+  if (!Number.isSafeInteger(count) || count < 0) {
+    return Effect.fail(requestError(repository, describe, stdout))
+  }
+  return Effect.succeed(count)
+}
+
+/**
+ * Decode a positive integer, or null when stdout is empty.
+ * GitLab helpers emit empty stdout (not the string `"null"`) for a miss.
+ */
+const decodeNullableInt = (
+  stdout: string,
+  repository: GitLabRepository,
+  describe: string,
+): Effect.Effect<number | null, GitLabRequestError> => {
+  const trimmed = stdout.trim()
+  if (trimmed === "") {
+    return Effect.succeed(null)
+  }
+  const number = Number(trimmed)
+  if (!Number.isSafeInteger(number) || number <= 0) {
+    return Effect.fail(requestError(repository, describe, stdout))
+  }
+  return Effect.succeed(number)
+}
+
+const decodeVoid = (_stdout: string): Effect.Effect<void, never> => Effect.void
+
+const decodeNonEmptyTrimmed = (
+  stdout: string,
+  repository: GitLabRepository,
+  describe: string,
+  emptyDetail: string,
+): Effect.Effect<string, GitLabRequestError> => {
+  const value = stdout.trim()
+  if (value === "") {
+    return Effect.fail(requestError(repository, describe, emptyDetail))
+  }
+  return Effect.succeed(value)
+}
+
+const decodeJson =
+  <A, I>(
+    schema: Schema.Codec<A, I>,
+    repository: GitLabRepository,
+    describe: string,
+  ) =>
+  (stdout: string): Effect.Effect<A, GitLabRequestError> =>
+    Schema.decodeUnknownEffect(Schema.fromJsonString(schema))(stdout).pipe(
+      Effect.mapError(() => requestError(repository, describe, stdout)),
+    )
+
 /**
  * Vault-first GitLab service layer.
  *
@@ -334,37 +413,46 @@ export const keymaxxerGitLabLayer = (options: {
           ),
       )
 
-      const runVaultHelper = <A>(
-        repository: GitLabRepository,
-        tokenName: string,
-        operation: GitLabHelperOperation,
-        decode: (stdout: string) => Effect.Effect<A, GitLabServiceError>,
-        operationLabel: string,
-        extraArgs: readonly string[] = [],
-      ): Effect.Effect<A, GitLabServiceError> =>
+      /**
+       * Shared Keymaxxer helper invocation once a vault secret name is known:
+       * repository arg encoding, exit-code mapping, stdout decode, and
+       * KeymaxxerError → requestError. Callers supply operation, args, and a
+       * decoder (token name comes from {@link withVaultOrAmbient}).
+       */
+      const callHelper = <A>(input: {
+        readonly operation: GitLabHelperOperation
+        readonly repository: GitLabRepository
+        readonly tokenName: string
+        readonly describe: string
+        readonly args?: readonly string[]
+        readonly decode: (
+          stdout: string,
+        ) => Effect.Effect<A, GitLabServiceError>
+      }): Effect.Effect<A, GitLabServiceError> =>
         Effect.gen(function* () {
-          const [forge, forgeHost, projectPath] =
-            encodedRepositoryArguments(repository)
-          const result = yield* runGitLabBin(tokenName, operation, [
+          const [forge, forgeHost, projectPath] = encodedRepositoryArguments(
+            input.repository,
+          )
+          const result = yield* runGitLabBin(input.tokenName, input.operation, [
             forge,
             forgeHost,
             projectPath,
-            ...extraArgs,
+            ...(input.args ?? []),
           ])
           if (result.exitCode === 2) {
-            return yield* repositoryUnavailable(repository)
+            return yield* repositoryUnavailable(input.repository)
           }
           if (result.exitCode !== 0) {
             return yield* requestError(
-              repository,
-              operationLabel,
+              input.repository,
+              input.describe,
               result.stderr || result.stdout,
             )
           }
-          return yield* decode(result.stdout)
+          return yield* input.decode(result.stdout)
         }).pipe(
           Effect.catchTag("KeymaxxerError", () =>
-            Effect.fail(requestError(repository, operationLabel)),
+            Effect.fail(requestError(input.repository, input.describe)),
           ),
         )
 
@@ -393,11 +481,12 @@ export const keymaxxerGitLabLayer = (options: {
             withVaultOrAmbient(
               repository,
               (tokenName) =>
-                runVaultHelper(
+                callHelper({
+                  operation: "verify-project",
                   repository,
                   tokenName,
-                  "verify-project",
-                  (stdout) => {
+                  describe: "verify GitLab project",
+                  decode: (stdout) => {
                     const trimmed = stdout.trim()
                     // Legacy helpers printed "ok"; treat that as "no host change".
                     if (trimmed === "" || trimmed === "ok") {
@@ -442,8 +531,7 @@ export const keymaxxerGitLabLayer = (options: {
                       )
                     }
                   },
-                  "verify GitLab project",
-                ),
+                }),
               (ambientService) => ambientService.verifyProject(repository),
             ),
         ),
@@ -453,25 +541,19 @@ export const keymaxxerGitLabLayer = (options: {
           withVaultOrAmbient(
             repository,
             (tokenName) =>
-              runVaultHelper(
+              callHelper({
+                operation: "get-authenticated-user-login",
                 repository,
                 tokenName,
-                "get-authenticated-user-login",
-                (stdout) => {
-                  const login = stdout.trim()
-                  if (login === "") {
-                    return Effect.fail(
-                      requestError(
-                        repository,
-                        "resolve authenticated GitLab user",
-                        "empty login",
-                      ),
-                    )
-                  }
-                  return Effect.succeed(login)
-                },
-                "resolve authenticated GitLab user",
-              ),
+                describe: "resolve authenticated GitLab user",
+                decode: (stdout) =>
+                  decodeNonEmptyTrimmed(
+                    stdout,
+                    repository,
+                    "resolve authenticated GitLab user",
+                    "empty login",
+                  ),
+              }),
             (ambientService) =>
               ambientService.getAuthenticatedUserLogin(repository),
           ),
@@ -481,13 +563,13 @@ export const keymaxxerGitLabLayer = (options: {
             withVaultOrAmbient(
               repository,
               (tokenName) =>
-                runVaultHelper(
+                callHelper({
+                  operation: "list-ready-issues",
                   repository,
                   tokenName,
-                  "list-ready-issues",
-                  (stdout) => parseIssues(stdout, repository),
-                  "list Ready-labeled Issues",
-                ),
+                  describe: "list Ready-labeled Issues",
+                  decode: (stdout) => parseIssues(stdout, repository),
+                }),
               (ambientService) => ambientService.listReadyIssues(repository),
             ),
         ),
@@ -511,26 +593,19 @@ export const keymaxxerGitLabLayer = (options: {
           withVaultOrAmbient(
             repository,
             (tokenName) =>
-              runVaultHelper(
+              callHelper({
+                operation: "get-open-pull-request-number",
                 repository,
                 tokenName,
-                "get-open-pull-request-number",
-                (stdout) => {
-                  const number = Number(stdout.trim())
-                  if (!Number.isSafeInteger(number) || number <= 0) {
-                    return Effect.fail(
-                      requestError(
-                        repository,
-                        "decode open pull request number",
-                        stdout,
-                      ),
-                    )
-                  }
-                  return Effect.succeed(number)
-                },
-                "get open pull request number",
-                [encodeArgument(headRefName)],
-              ),
+                describe: "get open pull request number",
+                args: [encodeArgument(headRefName)],
+                decode: (stdout) =>
+                  decodePositiveInt(
+                    stdout,
+                    repository,
+                    "decode open pull request number",
+                  ),
+              }),
             (ambientService) =>
               ambientService.getOpenPullRequestNumber(repository, headRefName),
           ),
@@ -541,28 +616,19 @@ export const keymaxxerGitLabLayer = (options: {
           withVaultOrAmbient(
             repository,
             (tokenName) =>
-              runVaultHelper(
+              callHelper({
+                operation: "find-open-pull-request-number",
                 repository,
                 tokenName,
-                "find-open-pull-request-number",
-                (stdout) => {
-                  const trimmed = stdout.trim()
-                  if (trimmed === "") return Effect.succeed(null)
-                  const number = Number(trimmed)
-                  if (!Number.isSafeInteger(number) || number <= 0) {
-                    return Effect.fail(
-                      requestError(
-                        repository,
-                        "decode open pull request number",
-                        stdout,
-                      ),
-                    )
-                  }
-                  return Effect.succeed(number)
-                },
-                "find open pull request number",
-                [encodeArgument(headRefName)],
-              ),
+                describe: "find open pull request number",
+                args: [encodeArgument(headRefName)],
+                decode: (stdout) =>
+                  decodeNullableInt(
+                    stdout,
+                    repository,
+                    "decode open pull request number",
+                  ),
+              }),
             (ambientService) =>
               ambientService.findOpenPullRequestNumber(repository, headRefName),
           ),
@@ -573,25 +639,12 @@ export const keymaxxerGitLabLayer = (options: {
           withVaultOrAmbient(
             repository,
             (tokenName) =>
-              runVaultHelper(
+              callHelper({
+                operation: "create-draft-pull-request",
                 repository,
                 tokenName,
-                "create-draft-pull-request",
-                (stdout) => {
-                  const number = Number(stdout.trim())
-                  if (!Number.isSafeInteger(number) || number <= 0) {
-                    return Effect.fail(
-                      requestError(
-                        repository,
-                        "decode created draft pull request number",
-                        stdout,
-                      ),
-                    )
-                  }
-                  return Effect.succeed(number)
-                },
-                "create draft pull request",
-                [
+                describe: "create draft pull request",
+                args: [
                   encodeArgument(
                     JSON.stringify({
                       headRefName: input.headRefName,
@@ -603,7 +656,13 @@ export const keymaxxerGitLabLayer = (options: {
                     }),
                   ),
                 ],
-              ),
+                decode: (stdout) =>
+                  decodePositiveInt(
+                    stdout,
+                    repository,
+                    "decode created draft pull request number",
+                  ),
+              }),
             (ambientService) =>
               ambientService.createDraftPullRequest(repository, input),
           ),
@@ -614,33 +673,24 @@ export const keymaxxerGitLabLayer = (options: {
           withVaultOrAmbient(
             repository,
             (tokenName) =>
-              runVaultHelper(
+              callHelper({
+                operation: "update-open-draft-pull-request-copy",
                 repository,
                 tokenName,
-                "update-open-draft-pull-request-copy",
-                (stdout) => {
-                  const trimmed = stdout.trim()
-                  if (trimmed === "") return Effect.succeed(null)
-                  const number = Number(trimmed)
-                  if (!Number.isSafeInteger(number) || number <= 0) {
-                    return Effect.fail(
-                      requestError(
-                        repository,
-                        "decode updated draft pull request number",
-                        stdout,
-                      ),
-                    )
-                  }
-                  return Effect.succeed(number)
-                },
-                "update open draft pull request copy",
-                [
+                describe: "update open draft pull request copy",
+                args: [
                   encodeArgument(headRefName),
                   encodeArgument(
                     JSON.stringify({ title: input.title, body: input.body }),
                   ),
                 ],
-              ),
+                decode: (stdout) =>
+                  decodeNullableInt(
+                    stdout,
+                    repository,
+                    "decode updated draft pull request number",
+                  ),
+              }),
             (ambientService) =>
               ambientService.updateOpenDraftPullRequestCopy(
                 repository,
@@ -655,25 +705,18 @@ export const keymaxxerGitLabLayer = (options: {
           withVaultOrAmbient(
             repository,
             (tokenName) =>
-              runVaultHelper(
+              callHelper({
+                operation: "count-open-non-draft-pull-requests",
                 repository,
                 tokenName,
-                "count-open-non-draft-pull-requests",
-                (stdout) => {
-                  const count = Number(stdout.trim())
-                  if (!Number.isSafeInteger(count) || count < 0) {
-                    return Effect.fail(
-                      requestError(
-                        repository,
-                        "decode open non-draft pull request count",
-                        stdout,
-                      ),
-                    )
-                  }
-                  return Effect.succeed(count)
-                },
-                "count open non-draft pull requests",
-              ),
+                describe: "count open non-draft pull requests",
+                decode: (stdout) =>
+                  decodeNonNegativeInt(
+                    stdout,
+                    repository,
+                    "decode open non-draft pull request count",
+                  ),
+              }),
             (ambientService) =>
               ambientService.countOpenNonDraftPullRequests(repository),
           ),
@@ -684,30 +727,25 @@ export const keymaxxerGitLabLayer = (options: {
           withVaultOrAmbient(
             repository,
             (tokenName) =>
-              runVaultHelper(
+              callHelper({
+                operation: "get-pr-check-status",
                 repository,
                 tokenName,
-                "get-pr-check-status",
-                (stdout) =>
-                  Schema.decodeUnknownEffect(
-                    Schema.fromJsonString(SerializedPullRequestCheckStatus),
+                describe: "get pull request check status",
+                args: [encodeArgument(headRefName)],
+                decode: (stdout) =>
+                  decodeJson(
+                    SerializedPullRequestCheckStatus,
+                    repository,
+                    "decode pull request check status",
                   )(stdout).pipe(
                     Effect.map((status) => ({
                       ...status,
                       headPushedAt: decodeOptionalInstant(status.headPushedAt),
                       createdAt: decodeOptionalInstant(status.createdAt),
                     })),
-                    Effect.mapError(() =>
-                      requestError(
-                        repository,
-                        "decode pull request check status",
-                        stdout,
-                      ),
-                    ),
                   ),
-                "get pull request check status",
-                [encodeArgument(headRefName)],
-              ),
+              }),
             (ambientService) =>
               ambientService.getPullRequestCheckStatus(repository, headRefName),
           ),
@@ -731,25 +769,19 @@ export const keymaxxerGitLabLayer = (options: {
                 options.logDirectory.trim() !== ""
                   ? encodeArgument(options.logDirectory)
                   : ""
-              return runVaultHelper(
+              return callHelper({
+                operation: "get-pr-status-check-diagnostics",
                 repository,
                 tokenName,
-                "get-pr-status-check-diagnostics",
-                (stdout) =>
-                  Schema.decodeUnknownEffect(
-                    Schema.fromJsonString(SerializedPrStatusCheckDiagnostics),
-                  )(stdout).pipe(
-                    Effect.mapError(() =>
-                      requestError(
-                        repository,
-                        "decode PR Status Check diagnostics",
-                        stdout,
-                      ),
-                    ),
-                  ),
-                "get PR Status Check diagnostics",
-                logDirectory === "" ? [checksArg] : [checksArg, logDirectory],
-              )
+                describe: "get PR Status Check diagnostics",
+                args:
+                  logDirectory === "" ? [checksArg] : [checksArg, logDirectory],
+                decode: decodeJson(
+                  SerializedPrStatusCheckDiagnostics,
+                  repository,
+                  "decode PR Status Check diagnostics",
+                ),
+              })
             },
             (ambientService) =>
               ambientService.getPrStatusCheckDiagnostics(
@@ -765,14 +797,14 @@ export const keymaxxerGitLabLayer = (options: {
           withVaultOrAmbient(
             repository,
             (tokenName) =>
-              runVaultHelper(
+              callHelper({
+                operation: "mark-pr-ready-for-review",
                 repository,
                 tokenName,
-                "mark-pr-ready-for-review",
-                () => Effect.void,
-                "mark pull request ready for review",
-                [encodeArgument(headRefName)],
-              ),
+                describe: "mark pull request ready for review",
+                args: [encodeArgument(headRefName)],
+                decode: decodeVoid,
+              }),
             (ambientService) =>
               ambientService.markPullRequestReadyForReview(
                 repository,
@@ -786,25 +818,18 @@ export const keymaxxerGitLabLayer = (options: {
           withVaultOrAmbient(
             repository,
             (tokenName) =>
-              runVaultHelper(
+              callHelper({
+                operation: "get-pr-lifecycle-status",
                 repository,
                 tokenName,
-                "get-pr-lifecycle-status",
-                (stdout) =>
-                  Schema.decodeUnknownEffect(
-                    Schema.fromJsonString(SerializedPullRequestLifecycleStatus),
-                  )(stdout).pipe(
-                    Effect.mapError(() =>
-                      requestError(
-                        repository,
-                        "decode pull request lifecycle status",
-                        stdout,
-                      ),
-                    ),
-                  ),
-                "get pull request lifecycle status",
-                [encodeArgument(headRefName)],
-              ),
+                describe: "get pull request lifecycle status",
+                args: [encodeArgument(headRefName)],
+                decode: decodeJson(
+                  SerializedPullRequestLifecycleStatus,
+                  repository,
+                  "decode pull request lifecycle status",
+                ),
+              }),
             (ambientService) =>
               ambientService.getPullRequestLifecycleStatus(
                 repository,
@@ -817,25 +842,18 @@ export const keymaxxerGitLabLayer = (options: {
             withVaultOrAmbient(
               repository,
               (tokenName) =>
-                runVaultHelper(
+                callHelper({
+                  operation: "merge-pull-request",
                   repository,
                   tokenName,
-                  "merge-pull-request",
-                  (stdout) =>
-                    Schema.decodeUnknownEffect(
-                      Schema.fromJsonString(SerializedMergePullRequestResult),
-                    )(stdout).pipe(
-                      Effect.mapError(() =>
-                        requestError(
-                          repository,
-                          "decode merge pull request result",
-                          stdout,
-                        ),
-                      ),
-                    ),
-                  "merge pull request",
-                  [encodeArgument(headRefName)],
-                ),
+                  describe: "merge pull request",
+                  args: [encodeArgument(headRefName)],
+                  decode: decodeJson(
+                    SerializedMergePullRequestResult,
+                    repository,
+                    "decode merge pull request result",
+                  ),
+                }),
               (ambientService) =>
                 ambientService.mergePullRequest(repository, headRefName),
             ),
@@ -846,18 +864,18 @@ export const keymaxxerGitLabLayer = (options: {
           withVaultOrAmbient(
             repository,
             (tokenName) =>
-              runVaultHelper(
+              callHelper({
+                operation: "ensure-issue-completed-with-summary",
                 repository,
                 tokenName,
-                "ensure-issue-completed-with-summary",
-                () => Effect.void,
-                "ensure issue completed with summary",
-                [
+                describe: "ensure issue completed with summary",
+                args: [
                   encodeArgument(String(issueNumber)),
                   encodeArgument(workItemId),
                   encodeArgument(summaryMarkdown),
                 ],
-              ),
+                decode: decodeVoid,
+              }),
             (ambientService) =>
               ambientService.ensureIssueCompletedWithSummary(
                 repository,
@@ -873,14 +891,14 @@ export const keymaxxerGitLabLayer = (options: {
           withVaultOrAmbient(
             repository,
             (tokenName) =>
-              runVaultHelper(
+              callHelper({
+                operation: "close-open-pull-requests-for-branch",
                 repository,
                 tokenName,
-                "close-open-pull-requests-for-branch",
-                () => Effect.void,
-                "close open pull requests for branch",
-                [encodeArgument(headRefName)],
-              ),
+                describe: "close open pull requests for branch",
+                args: [encodeArgument(headRefName)],
+                decode: decodeVoid,
+              }),
             (ambientService) =>
               ambientService.closeOpenPullRequestsForBranch(
                 repository,
@@ -893,14 +911,14 @@ export const keymaxxerGitLabLayer = (options: {
             withVaultOrAmbient(
               repository,
               (tokenName) =>
-                runVaultHelper(
+                callHelper({
+                  operation: "delete-branch",
                   repository,
                   tokenName,
-                  "delete-branch",
-                  () => Effect.void,
-                  "delete branch",
-                  [encodeArgument(branchName)],
-                ),
+                  describe: "delete branch",
+                  args: [encodeArgument(branchName)],
+                  decode: decodeVoid,
+                }),
               (ambientService) =>
                 ambientService.deleteBranch(repository, branchName),
             ),


### PR DESCRIPTION
## Why

Keymaxxer GitHub and GitLab service methods repeated the same token lookup,
arg encoding, exit-code mapping, stdout decode, and `KeymaxxerError`
handling. GitHub methods also lacked uniform `Effect.fn` call-site spans
that GitLab already had.

## What

- Add a shared `callHelper` combinator and small stdout decoders in both
  forge layers
- Collapse GitHub methods onto `callHelper` with
  `Effect.fn("KeymaxxerGitHub.<op>")` spans
- Align GitLab's existing vault helper with the same named-arg API and
  decoders
- Preserve exit-code semantics, error messaging/sanitization, and
  forge-specific arg/decode differences (documented where intentional)
- Collapse duplicate `GitHubCountError` / `GitHubServiceError` aliases

## Verification

- `apps/harness/test/keymaxxer-github-layer.test.ts` and
  `keymaxxer-gitlab-layer.test.ts` (39 pass)
- Full harness unit suite (469 pass) during implementation
- `tsc -p apps/harness/tsconfig.app.json --noEmit` clean after the refactor

## Limitations

No intentional behavior change for helpers or vault/ambient precedence;
empty-stdout open-PR count handling remains forge-specific (GitHub rejects
empty; GitLab still accepts as `0`).

Closes #711