### PR TITLE
fix(harness): align repos work-item chrome with kanban tickets

### DIFF
--- a/apps/harness/src/copy.tsx
+++ b/apps/harness/src/copy.tsx
@@ -54,7 +54,7 @@ export function Copy({
       ) : null}
       <button
         type="button"
-        className={cx(ui.iconBtn, copied && ui.iconBtnCopied)}
+        className={cx(ui.iconBtnBare, copied && ui.iconBtnCopied)}
         onClick={() => {
           void handleCopy()
         }}

--- a/apps/harness/src/routes/index.tsx
+++ b/apps/harness/src/routes/index.tsx
@@ -22,6 +22,7 @@ import {
 import { Banner, BannerActionButton } from "../banner.js"
 import { repositoryCardCollapseId, useCardCollapsed } from "../card-collapse.js"
 import { CardCollapseToggle } from "../card-collapse-toggle.js"
+import { Copy } from "../copy.js"
 import {
   type GraphqlWorkItemState,
   issueActionEligibility,
@@ -59,6 +60,7 @@ import {
   completedWorkItemsHistoryQueryKeyPrefix,
   followRepositoryWorkItemsLive,
 } from "../refresh-work-items-live.js"
+import { sessionWorktreeParts } from "../session-worktree-line.js"
 import { cx, ui } from "../ui.js"
 import { workItemIssueUrl } from "../work-item-issue-url.js"
 import { canShowWorkItemResetAction } from "../work-item-job-actions.js"
@@ -2682,6 +2684,15 @@ function RepositoryIssues({
   workItemsLoading: boolean
 }) {
   const { data: issues } = useSuspenseQuery(issuesQuery(repository.id))
+  // One Session usage dialog for the whole list (not per issue row) so the
+  // fixed session-usage-title id stays unique — same pattern as Kanban/Completed.
+  const [sessionDialog, setSessionDialog] = useState<{
+    workItemId: string
+    sessionId: string
+  } | null>(null)
+  const onOpenSession = (workItemId: string, sessionId: string) => {
+    setSessionDialog({ workItemId, sessionId })
+  }
 
   if (issues.length === 0) {
     return (
@@ -2700,38 +2711,48 @@ function RepositoryIssues({
   }
 
   return (
-    <ul className={ui.repoIssuesList}>
-      {issues.map((issue) => {
-        if (issue.parent !== null) return null
-        if (!issue.hasChildren) {
+    <>
+      <ul className={ui.repoIssuesList}>
+        {issues.map((issue) => {
+          if (issue.parent !== null) return null
+          if (!issue.hasChildren) {
+            return (
+              <RepositoryIssueRow
+                issue={issue}
+                key={issue.id}
+                repository={repository}
+                workItems={workItems}
+                workItemsLoading={workItemsLoading}
+                onOpenSession={onOpenSession}
+              />
+            )
+          }
+
+          const children = childrenByParent.get(issue.issueNumber) ?? []
+          const closedChildren = children.filter(
+            (child) => child.state === "CLOSED",
+          ).length
           return (
-            <RepositoryIssueRow
-              issue={issue}
+            <ParentIssueGroup
               key={issue.id}
+              parent={issue}
+              childIssues={children}
+              closedChildren={closedChildren}
               repository={repository}
               workItems={workItems}
               workItemsLoading={workItemsLoading}
+              onOpenSession={onOpenSession}
             />
           )
-        }
-
-        const children = childrenByParent.get(issue.issueNumber) ?? []
-        const closedChildren = children.filter(
-          (child) => child.state === "CLOSED",
-        ).length
-        return (
-          <ParentIssueGroup
-            key={issue.id}
-            parent={issue}
-            childIssues={children}
-            closedChildren={closedChildren}
-            repository={repository}
-            workItems={workItems}
-            workItemsLoading={workItemsLoading}
-          />
-        )
-      })}
-    </ul>
+        })}
+      </ul>
+      <SessionUsageDialog
+        workItemId={sessionDialog?.workItemId ?? null}
+        sessionId={sessionDialog?.sessionId ?? null}
+        open={sessionDialog !== null}
+        onClose={() => setSessionDialog(null)}
+      />
+    </>
   )
 }
 
@@ -2742,6 +2763,7 @@ function ParentIssueGroup({
   repository,
   workItems,
   workItemsLoading,
+  onOpenSession,
 }: {
   parent: RepositoryIssue
   childIssues: readonly RepositoryIssue[]
@@ -2749,6 +2771,7 @@ function ParentIssueGroup({
   repository: Repository
   workItems: readonly WorkItem[]
   workItemsLoading: boolean
+  readonly onOpenSession: (workItemId: string, sessionId: string) => void
 }) {
   const queryClient = useQueryClient()
   const openChildren = childIssues.filter((child) => child.state === "OPEN")
@@ -2870,6 +2893,7 @@ function ParentIssueGroup({
               repository={repository}
               workItems={workItems}
               workItemsLoading={workItemsLoading}
+              onOpenSession={onOpenSession}
             />
           ))}
         </ul>
@@ -2883,11 +2907,13 @@ function RepositoryIssueRow({
   repository,
   workItems,
   workItemsLoading,
+  onOpenSession,
 }: {
   issue: RepositoryIssue
   repository: Repository
   workItems: readonly WorkItem[]
   workItemsLoading: boolean
+  readonly onOpenSession: (workItemId: string, sessionId: string) => void
 }) {
   const [menuOpen, setMenuOpen] = useState(false)
   const queryClient = useQueryClient()
@@ -3072,6 +3098,7 @@ function RepositoryIssueRow({
       {latestWorkItem !== undefined && (
         <WorkItemLifecycleStatus
           workItem={latestWorkItem}
+          collapseEarlierLanes
           issueUrl={
             issue.url !== ""
               ? issue.url
@@ -3088,6 +3115,7 @@ function RepositoryIssueRow({
             repository.projectPath,
             latestWorkItem.pullRequestNumber,
           )}
+          onOpenSession={onOpenSession}
         />
       )}
       {(implementNow.isError ||
@@ -3426,22 +3454,30 @@ export function WorkItemLifecycleStatus({
   workItem,
   compact = false,
   /**
-   * Kanban-only: collapse earlier Build/Review/PR lane chips into summary
-   * rows. Other surfaces leave this off for the full list.
+   * Collapse earlier Build/Review/PR lane chips into summary rows (▸ BUILD ·
+   * 5m). Used on Kanban tickets and repos issue chrome; leave off for full
+   * lists.
    */
   collapseEarlierLanes = false,
   pullRequestUrl = null,
   issueUrl = null,
+  onOpenSession,
 }: {
   workItem: WorkItem
   compact?: boolean
   collapseEarlierLanes?: boolean
   pullRequestUrl?: string | null
   issueUrl?: string | null
+  /** Opens Session usage for a session id (repos / non-compact chrome). */
+  onOpenSession?: (workItemId: string, sessionId: string) => void
 }) {
   const queryClient = useQueryClient()
   const status = workItem.status
   const heldForBlockers = status === "WAITING_FOR_BLOCKERS"
+  const { sessionId, worktreePath } = sessionWorktreeParts(
+    workItem.sessionId,
+    workItem.worktreePath,
+  )
   // Queue hold: Retry is never offered; API also sets canRetry false.
   const canRetry = compact && workItem.canRetry && !heldForBlockers
   const retriesStatusChecks =
@@ -3610,6 +3646,49 @@ export function WorkItemLifecycleStatus({
 
   return (
     <div className={compact ? "mt-2" : ui.lifecycleInset}>
+      {/*
+       * Non-compact (repos): same runtime lines as kanban tickets — agent
+       * backend, session id (Session usage + copy), worktree path + copy.
+       * Compact kanban tickets render these above this component.
+       */}
+      {!compact ? (
+        <div className={cx(ui.jobTicketRuntime, "mb-1")}>
+          <p className={ui.jobTicketRuntimeLine}>
+            {workItem.agentBackend.label}
+          </p>
+          {sessionId !== null ? (
+            <div
+              className={cx(
+                ui.jobTicketRuntimeLine,
+                "flex min-w-0 items-center gap-1",
+              )}
+            >
+              {onOpenSession !== undefined ? (
+                <button
+                  type="button"
+                  className={cx(ui.jobTicketSession, "min-w-0 truncate")}
+                  title={sessionId}
+                  onClick={() => onOpenSession(workItem.id, sessionId)}
+                >
+                  {sessionId}
+                </button>
+              ) : (
+                <span className="min-w-0 truncate" title={sessionId}>
+                  {sessionId}
+                </span>
+              )}
+              <Copy value={sessionId} showValue={false} className="shrink-0" />
+            </div>
+          ) : null}
+          {worktreePath !== null ? (
+            <Copy
+              value={worktreePath}
+              className="min-w-0 max-w-full"
+              textClassName={ui.jobTicketRuntimeLine}
+            />
+          ) : null}
+        </div>
+      ) : null}
       <div className="flex flex-wrap items-center justify-between gap-2">
         <span
           className={cx(

--- a/apps/harness/src/styles.css
+++ b/apps/harness/src/styles.css
@@ -30,9 +30,10 @@
   --lane-bed: #dedbd2;
 
   /*
-   * Merged-lane ticket fill — warm parchment (rgb(244, 241, 232)).
+   * Board ticket fill — warm parchment (rgb(244, 241, 232)).
+   * Every kanban lane (Build through Merged) uses this; not lane-specific.
    */
-  --ticket-merged: #f4f1e8;
+  --ticket-fill: #f4f1e8;
 }
 
 :root,
@@ -87,7 +88,7 @@
   --merged-halo: rgb(242 243 241 / 0.85);
   --scrim: rgb(0 0 0 / 0.55);
   /* Dark: soft lift over panel (no warm parchment). */
-  --ticket-merged: #32383d;
+  --ticket-fill: #32383d;
 
   --mast-bg: #000000;
   --mast-ink: #ffffff;
@@ -137,7 +138,7 @@
   --signal: #ffd21c;
   --merged-halo: transparent;
   --scrim: rgb(21 21 21 / 0.45);
-  --ticket-merged: #f4f1e8;
+  --ticket-fill: #f4f1e8;
   --plate: #dfe4e1;
   --plate-hover: #cfd6d2;
   --plate-ink: #23282b;

--- a/apps/harness/src/ui.ts
+++ b/apps/harness/src/ui.ts
@@ -592,12 +592,13 @@ export const ui = {
     "justify-self-start font-mono text-[0.68rem] font-bold tracking-[0.08em] uppercase text-[#151515] underline decoration-[1.5px] underline-offset-[3px] hover:bg-[#151515] hover:text-lane-queue hover:no-underline",
 
   jobTicket: cx(
-    "relative grid min-w-0 gap-[0.4rem] rounded-none border-[1.5px] border-ink bg-panel",
+    "relative grid min-w-0 gap-[0.4rem] rounded-none border-[1.5px] border-ink",
+    // Warm cream slip (lane-bed mix) — not pure white, not brushed metal.
+    // Same parchment fill in every lane so Build/Review/PR match Merged.
+    "bg-[var(--ticket-fill)]",
     "px-[0.65rem] py-[0.55rem] pr-[0.65rem] pb-[0.7rem] pl-[0.95rem]",
     "shadow-[inset_6px_0_0_var(--ticket-color,var(--ink))]",
     "data-[lane=complete]:shadow-[inset_6px_0_0_var(--ticket-color,var(--lane-merged)),inset_8px_0_0_var(--merged-halo)]",
-    // Warm cream slip (lane-bed mix) — not pure white, not brushed metal.
-    "data-[lane=complete]:!bg-[var(--ticket-merged)]",
   ),
 
   jobTicketRepo:
@@ -655,18 +656,20 @@ export const ui = {
 
   /* ---------- Status tags (§5.1) ---------- */
 
+  // Base is layout/type only — each tone owns border/fill/ink so Tailwind
+  // cascade does not leave plain `bg-transparent` winning over alarm fill.
   statusTag:
-    "inline-flex items-center whitespace-nowrap border-[1.5px] border-ink bg-transparent px-[0.4rem] py-[0.18rem] font-mono text-[0.66rem] font-bold leading-[1.2] tracking-[0.12em] uppercase text-ink-2 no-underline",
+    "inline-flex items-center whitespace-nowrap border-[1.5px] px-[0.4rem] py-[0.18rem] font-mono text-[0.66rem] font-bold leading-[1.2] tracking-[0.12em] uppercase no-underline",
 
   statusTagAlarm: "border-lane-attention bg-lane-attention text-[#151515]",
 
-  statusTagHold: "border-dashed text-ink-2",
+  statusTagHold: "border-dashed border-ink bg-transparent text-ink-2",
 
   statusTagComplete: "border-ink bg-ink text-paper",
 
-  statusTagGhost: "border-dashed border-ink-faint text-ink-2",
+  statusTagGhost: "border-dashed border-ink-faint bg-transparent text-ink-2",
 
-  statusTagPlain: "text-ink-2",
+  statusTagPlain: "border-ink bg-transparent text-ink-2",
 
   statusMessage: "mt-[0.35rem] mb-0 font-mono text-[0.6rem] text-ink-2",
 
@@ -698,12 +701,26 @@ export const ui = {
     "[&_svg]:h-[0.9rem] [&_svg]:w-[0.9rem]",
   ),
 
+  /**
+   * Borderless icon control for inline copy next to mono runtime lines.
+   * Keeps hit target; hover plate wash only (no ink box).
+   */
+  iconBtnBare: cx(
+    "inline-flex h-7 w-7 shrink-0 items-center justify-center border-0 bg-transparent p-0",
+    "cursor-pointer text-ink-2",
+    "transition-[color,background-color] duration-100 ease-in-out",
+    "hover:bg-[var(--plate-hover)] hover:text-ink",
+    "disabled:cursor-wait disabled:opacity-55",
+    "[&_svg]:h-[0.9rem] [&_svg]:w-[0.9rem]",
+  ),
+
   iconBtnArmed:
     "border-[1.5px] border-lane-attention text-lane-attention hover:bg-lane-attention hover:text-[#151515]",
 
   iconBtnPaused: "border-ink text-ink",
 
-  iconBtnCopied: "border-lane-pr text-lane-pr",
+  /** Success flash for Copy — PR-green glyph (no border box). */
+  iconBtnCopied: "text-lane-pr",
 
   iconBtnSvg: "h-[0.9rem] w-[0.9rem]",
 

--- a/apps/harness/test/copy-component.test.ts
+++ b/apps/harness/test/copy-component.test.ts
@@ -14,6 +14,9 @@ describe("Copy component", () => {
     expect(source).toContain("title={value}")
     expect(source).toContain("truncate")
     expect(source).toContain('aria-label={copied ? "Copied" : "Copy"}')
+    // Inline copy is borderless (no ink box next to mono session/worktree).
+    expect(source).toContain("ui.iconBtnBare")
+    expect(source).not.toMatch(/className=\{cx\(ui\.iconBtn,/)
     const textIndex = source.indexOf("title={value}")
     const buttonIndex = source.indexOf('type="button"')
     expect(textIndex).toBeGreaterThan(-1)

--- a/apps/harness/test/interchange-phase5.test.ts
+++ b/apps/harness/test/interchange-phase5.test.ts
@@ -138,8 +138,11 @@ describe("Interchange phase 5: dialogs, menus, chrome + Ledger teardown", () => 
     expect(ui).toMatch(/mergedPrStatsSkeleton:[\s\S]*?animate-\[skeleton-pulse/)
     // Keyframes stay in the tokens stylesheet.
     expect(styles).toContain("@keyframes skeleton-pulse")
+    expect(copy).toContain("ui.iconBtnBare")
     expect(copy).toContain("ui.iconBtnCopied")
     expect(copy).toContain("1_500")
+    expect(ui).toContain("iconBtnBare:")
+    expect(ui).toMatch(/iconBtnBare:[\s\S]*?border-0/)
     expect(ui).toContain("iconBtnCopied:")
     expect(ui).toMatch(/iconBtnCopied:[\s\S]*?text-lane-pr/)
   })

--- a/apps/harness/test/kanban-route.test.ts
+++ b/apps/harness/test/kanban-route.test.ts
@@ -262,7 +262,7 @@ describe("kanban home board", () => {
   })
 
   test("Kanban tickets opt into earlier-lane lifecycle chip collapse", () => {
-    // Issue #679: Kanban-only presentation; other surfaces leave collapse off.
+    // Issue #679: collapse earlier lanes on board tickets; repos reuses it.
     const source = boardSource()
     const ticket = source.slice(
       source.indexOf("function PipelineTicket("),
@@ -282,21 +282,19 @@ describe("kanban home board", () => {
       join(import.meta.dir, "../src/completed-work-item-row.tsx"),
       "utf8",
     )
-    // Non-Kanban call sites must not opt into collapse (default remains false).
-    const nonKanbanSources = [home, completedRow]
-    let nonKanbanCallCount = 0
-    for (const nonKanbanSource of nonKanbanSources) {
-      const calls = [
-        ...nonKanbanSource.matchAll(/<WorkItemLifecycleStatus[\s\S]*?\/>/g),
-      ].map((match) => match[0])
-      nonKanbanCallCount += calls.length
-      for (const call of calls) {
-        expect(call).not.toContain("collapseEarlierLanes")
-      }
-    }
-    expect(nonKanbanCallCount).toBeGreaterThan(0)
-    // Only the Kanban ticket path opts in; the prop defaults off elsewhere.
+    // Repos issue chrome opts in (same collapse language as Kanban).
+    const homeCalls = [
+      ...home.matchAll(/<WorkItemLifecycleStatus[\s\S]*?\/>/g),
+    ].map((match) => match[0])
+    expect(homeCalls.length).toBeGreaterThan(0)
+    expect(
+      homeCalls.some((call) => call.includes("collapseEarlierLanes")),
+    ).toBe(true)
+    // Completed archive uses journey legs, not this lifecycle collapse prop.
+    expect(completedRow).not.toContain("collapseEarlierLanes")
+    // Prop still defaults off on the component signature.
     expect(home).toContain("collapseEarlierLanes = false")
+    // Board path opts in once (ticket only).
     expect(source.match(/collapseEarlierLanes/g)).toHaveLength(1)
   })
 
@@ -414,9 +412,12 @@ describe("kanban home board", () => {
     expect(ui).toContain("sticky")
     expect(ui).toContain("jobTicket:")
     expect(ui).not.toContain("jobTicketMetalLight")
-    // Merged tickets use parchment --ticket-merged (#f4f1e8), not white/metal.
-    expect(ui).toMatch(/jobTicket:[\s\S]*?--ticket-merged/)
-    expect(stylesSource()).toContain("--ticket-merged: #f4f1e8")
+    // All board tickets use parchment --ticket-fill (#f4f1e8), not white/metal.
+    expect(ui).toMatch(/jobTicket:\s*cx\([\s\S]*?bg-\[var\(--ticket-fill\)\]/)
+    // No longer gated to Merged only.
+    expect(ui).not.toContain("data-[lane=complete]:!bg-[var(--ticket-")
+    expect(stylesSource()).toContain("--ticket-fill: #f4f1e8")
+    expect(stylesSource()).not.toContain("--ticket-merged:")
     // Dark theme must not restyle the board: light tokens re-locked on surface.
     // Tailwind utilities read --color-* (computed at :root), so aliases must
     // be re-set too — --ink alone does not fix bg-ink / text-ink / border-ink.
@@ -425,7 +426,7 @@ describe("kanban home board", () => {
       '[data-theme="dark"] [data-kanban-surface]',
     )
     expect(stylesSource()).toMatch(
-      /\[data-theme="dark"\] \[data-kanban-surface\][\s\S]*?--ticket-merged: #f4f1e8/,
+      /\[data-theme="dark"\] \[data-kanban-surface\][\s\S]*?--ticket-fill: #f4f1e8/,
     )
     expect(stylesSource()).toMatch(
       /\[data-theme="dark"\] \[data-kanban-surface\][\s\S]*?--color-ink: #151515/,

--- a/apps/harness/test/repos-interchange.test.ts
+++ b/apps/harness/test/repos-interchange.test.ts
@@ -135,6 +135,36 @@ describe("Interchange phase 4: repos page + blank slate", () => {
       "function RepositoryIssuesSkeleton(",
     )
     expect(lifecycle).toContain('compact ? "mt-2" : ui.lifecycleInset')
+    // Non-compact (repos) shows agent backend, session id + copy, worktree.
+    expect(lifecycle).toContain("{workItem.agentBackend.label}")
+    expect(lifecycle).toContain("ui.jobTicketRuntime")
+    expect(lifecycle).toContain("sessionWorktreeParts")
+    expect(lifecycle).toContain("onOpenSession")
+    expect(lifecycle).toContain("<Copy value={sessionId} showValue={false}")
+    expect(lifecycle).toContain("value={worktreePath}")
+    // Compact kanban path keeps runtime lines outside this component.
+    expect(lifecycle).toContain("{!compact ? (")
+    // Earlier-lane collapse (▸ BUILD · 5m) is shared with Kanban.
+    expect(lifecycle).toContain("collapseEarlierLanes")
+    expect(lifecycle).toContain("ui.legSummary")
+
+    const row = sliceBetweenMarkers(
+      homeSource(),
+      "function RepositoryIssueRow(",
+      "export function SessionUsageDialog(",
+    )
+    expect(row).toContain("onOpenSession=")
+    expect(row).toContain("collapseEarlierLanes")
+    // One SessionUsageDialog at RepositoryIssues — not per issue row.
+    expect(row).not.toContain("<SessionUsageDialog")
+
+    const issuesList = sliceBetweenMarkers(
+      homeSource(),
+      "function RepositoryIssues(",
+      "function ParentIssueGroup(",
+    )
+    expect(issuesList).toContain("<SessionUsageDialog")
+    expect(issuesList).toContain("onOpenSession={onOpenSession}")
 
     const ui = uiSource()
     expect(ui).toContain("lifecycleInset:")

--- a/apps/harness/test/work-item-progress-chrome.test.ts
+++ b/apps/harness/test/work-item-progress-chrome.test.ts
@@ -40,6 +40,13 @@ describe("work-item-progress-chrome", () => {
     expect(prBadgeClassName).toBe(ui.prBadge)
     expect(statusBadgeBaseClassName).not.toContain("rounded")
     expect(prBadgeClassName).not.toContain("rounded")
+    // Base must not set bg/border/ink — tones own those (alarm fill must win).
+    expect(ui.statusTag).not.toContain("bg-transparent")
+    expect(ui.statusTag).not.toContain("border-ink")
+    expect(ui.statusTagAlarm).toContain("bg-lane-attention")
+    expect(ui.statusTagAlarm).toContain("border-lane-attention")
+    expect(ui.statusTagPlain).toContain("border-ink")
+    expect(ui.statusTagPlain).toContain("bg-transparent")
     expect(statusBadgeClassNameForStatus("COMPLETE")).toContain(
       statusBadgeBaseClassName,
     )

--- a/docs/harness-design-system.md
+++ b/docs/harness-design-system.md
@@ -331,18 +331,20 @@ Anatomy (top to bottom):
    (Title stays at relaxed card size; only meta under the title is larger.)
 6. **Via lines**: mono uppercase faint, 2px `--line-soft` left border,
    padding-left ("Via Build — 14 min").
-7. **Journey legs** (§5.2): with the Kanban-only earlier-lane collapse —
-   collapsed summary rows are **consistently lane-colored** (per #695): in
-   the Review lane the Build summary is a Build-blue chip with white text
-   ("▸ BUILD · 14m"); likewise everywhere, name + summed duration only.
-   Expansion replaces the summary with that lane's chips; ephemeral local
-   state (behavior per `docs/kanban.md`, unchanged).
-8. **Merged-lane variant**: no legs; warm parchment `--ticket-merged`
-   (`#f4f1e8` / rgb(244, 241, 232) light; soft charcoal lift dark); mono
-   lines for **Started** and **Elapsed** separately; PR badge (§5.5).
+7. **Journey legs** (§5.2): earlier-lane collapse is shared by **Kanban
+   tickets and repos lifecycle chrome** — collapsed summary rows are
+   **consistently lane-colored** (per #695): in the Review lane the Build
+   summary is a Build-blue chip with white text ("▸ BUILD · 14m"); likewise
+   everywhere, name + summed duration only. Expansion replaces the summary
+   with that lane's chips; ephemeral local state (behavior per
+   `docs/kanban.md`, unchanged).
+8. **Merged-lane variant**: no per-step legs on the board; mono lines for
+   **Started** and **Elapsed** separately; PR badge (§5.5). Fill is the same
+   parchment as every other lane (see card frame below).
 
-Card frame: 1.5px ink border, `--panel` fill (Merged uses `--ticket-merged`),
-no radius, no offset shadow.
+Card frame: 1.5px ink border, warm parchment `--ticket-fill` (`#f4f1e8` /
+rgb(244, 241, 232) light; soft charcoal lift dark) in every board lane —
+not pure white, not brushed metal. No radius, no offset shadow.
 
 ### 4.5 Completed page (archive) — per #698 prototype
 
@@ -413,8 +415,10 @@ prototype, so this spec governs:
   tag (a blocked issue is queue-held — lane-consistent). Blocked rows keep
   the "Blocked by #n" mono link line; the old amber row-wash is dropped —
   the yellow tag carries the state, no wash fills in the new language.
-- **Latest work item** renders the standard lifecycle chrome (§4.4 status
-  block) inside a bordered inset panel (`--panel`, 1.5px).
+- **Latest work item** renders the standard lifecycle chrome (§4.4) inside a
+  bordered inset panel (`--panel`, 1.5px): runtime lines (agent backend,
+  session + copy, worktree + copy), STARTED / status, and earlier-lane
+  collapse for step chips (same as Kanban).
 - **Parent issue groups**: `<details>` card, 1.5px border — summary with
   parent link, "n/m closed" mono, chevron, parent actions menu; children
   with a 2px `--line-soft` left rule.


### PR DESCRIPTION
## Why

Repos issue rows only showed lifecycle step chips for in-progress work. Operators could not see agent backend, session id, or worktree without opening the Kanban board, and earlier Build steps stayed expanded as a long row of black “Succeeded” chips. Board tickets also used pure white fill while Merged used parchment, so lanes looked inconsistent. Alarm status tags lost their Attention fill to a Tailwind cascade conflict (`bg-transparent` on the base recipe), so FAILED appeared as an outline-only stamp.

## What Changed

- Board job tickets use warm parchment `--ticket-fill` in every lane (not only Merged).
- Repos lifecycle chrome shows agent backend, session id (Session usage + copy), and worktree path (copy), matching Kanban runtime lines.
- Repos opts into earlier-lane chip collapse (`▸ BUILD · duration`); expand is still ephemeral.
- One `SessionUsageDialog` per repository issues list (lifted out of each row) so the fixed dialog title id stays unique.
- Copy control uses borderless `iconBtnBare`; status tag tones own their own border/fill so FAILED keeps Attention fill.
- Design system §4.4 / §4.6 updated to match.

