### PR TITLE
refactor(harness): share keymaxxer forge helper wire schemas

### DIFF
--- a/apps/harness/src/server/forge-helper-schemas.ts
+++ b/apps/harness/src/server/forge-helper-schemas.ts
@@ -1,0 +1,236 @@
+/**
+ * Shared wire-format schemas and helpers for Keymaxxer-backed forge helper
+ * processes (GitHub and GitLab).
+ *
+ * Producer helpers JSON.stringify domain values; these schemas decode stdout
+ * back into typed service shapes so both layers cannot drift.
+ */
+import { Effect, Schema, SchemaTransformation } from "effect"
+import type { ReadyLabeledIssue } from "@ready-for-agent/github-service"
+import { sanitizeUserFacingText } from "@ready-for-agent/github-service"
+
+/** Minimal repository identity shared by GitHub and GitLab forge types. */
+type ForgeRepositoryRef = {
+  readonly forge: string
+  readonly forgeHost: string
+  readonly projectPath: string
+}
+
+const PositiveInt = Schema.Int.pipe(Schema.check(Schema.isGreaterThan(0)))
+const NonNegativeInt = Schema.Int.pipe(
+  Schema.check(Schema.isGreaterThanOrEqualTo(0)),
+)
+const RequiredString = Schema.String.pipe(
+  Schema.check(
+    Schema.makeFilter((value: string) =>
+      value.trim() === "" ? "Expected a non-empty string" : undefined,
+    ),
+  ),
+)
+const UrlString = Schema.String.pipe(
+  Schema.check(
+    Schema.makeFilter((value: string) => {
+      try {
+        new URL(value)
+        return undefined
+      } catch {
+        return "Invalid URL"
+      }
+    }),
+  ),
+)
+
+/**
+ * Helper wire values for optional instants: JSON null or an ISO-ish string.
+ * Invalid / unparseable strings decode to null (same as the former
+ * `decodeOptionalInstant` post-step), never to Invalid Date.
+ */
+const OptionalInstantFromString = Schema.NullOr(Schema.String).pipe(
+  Schema.decodeTo(
+    Schema.NullOr(Schema.Date),
+    SchemaTransformation.transform({
+      decode: (value) => {
+        if (value === null) {
+          return null
+        }
+        const parsed = new Date(value)
+        if (Number.isNaN(parsed.getTime())) {
+          return null
+        }
+        return parsed
+      },
+      encode: (value) => (value === null ? null : value.toISOString()),
+    }),
+  ),
+)
+
+const SerializedIssue = Schema.Struct({
+  number: PositiveInt,
+  title: RequiredString,
+  body: Schema.String,
+  url: UrlString,
+  createdAt: Schema.DateFromString,
+  state: Schema.Literals(["OPEN", "CLOSED"]),
+  author: Schema.NullOr(RequiredString),
+  hierarchySupported: Schema.Boolean,
+  hasChildren: Schema.Boolean,
+  parentPosition: Schema.NullOr(NonNegativeInt),
+  parent: Schema.NullOr(
+    Schema.Struct({
+      number: PositiveInt,
+      url: UrlString,
+      state: Schema.Literals(["OPEN", "CLOSED"]),
+      isReadyLabeled: Schema.Boolean,
+    }),
+  ),
+  blockedBy: Schema.Array(
+    Schema.Struct({
+      number: PositiveInt,
+      url: UrlString,
+    }),
+  ),
+  closingPullRequests: Schema.Array(
+    Schema.Struct({
+      number: PositiveInt,
+      repository: RequiredString,
+      state: Schema.Literals(["OPEN", "MERGED", "CLOSED"]),
+      isDraft: Schema.Boolean,
+    }),
+  ),
+})
+
+const SerializedIssues = Schema.Array(SerializedIssue)
+
+const SerializedTerminalPrStatusCheck = Schema.Struct({
+  externalId: Schema.String,
+  name: Schema.String,
+  outcome: Schema.Literals(["green", "red"]),
+})
+
+const SerializedPrStatusCheckLogFetch = Schema.Union([
+  Schema.TaggedStruct("ok", {
+    excerpt: Schema.String,
+    localPath: Schema.NullOr(Schema.String),
+  }),
+  Schema.TaggedStruct("unavailable", {
+    reason: Schema.String,
+  }),
+])
+
+const SerializedPrStatusCheckDiagnostic = Schema.Struct({
+  externalId: Schema.String,
+  name: Schema.String,
+  source: Schema.Literals(["actions-job", "status", "gitlab-job", "unknown"]),
+  htmlUrl: Schema.NullOr(Schema.String),
+  logFetch: SerializedPrStatusCheckLogFetch,
+})
+
+export const SerializedPrStatusCheckDiagnostics = Schema.Array(
+  SerializedPrStatusCheckDiagnostic,
+)
+
+const SerializedPullRequestCheckStatusFields = {
+  mergeability: Schema.Literals(["mergeable", "conflicting", "unknown"]),
+  baseRefName: Schema.NullOr(Schema.String),
+  headPushedAt: OptionalInstantFromString,
+  headSha: Schema.NullOr(Schema.String),
+  createdAt: OptionalInstantFromString,
+  isDraft: Schema.NullOr(Schema.Boolean),
+} as const
+
+export const SerializedPullRequestCheckStatus = Schema.Union([
+  Schema.TaggedStruct("pending", {
+    terminalChecks: Schema.Array(SerializedTerminalPrStatusCheck),
+    ...SerializedPullRequestCheckStatusFields,
+  }),
+  Schema.TaggedStruct("expected", {
+    terminalChecks: Schema.Array(SerializedTerminalPrStatusCheck),
+    ...SerializedPullRequestCheckStatusFields,
+  }),
+  Schema.TaggedStruct("no_checks", {
+    ...SerializedPullRequestCheckStatusFields,
+  }),
+  Schema.TaggedStruct("succeeded", {
+    terminalChecks: Schema.Array(SerializedTerminalPrStatusCheck),
+    ...SerializedPullRequestCheckStatusFields,
+  }),
+  Schema.TaggedStruct("failed", {
+    terminalChecks: Schema.Array(SerializedTerminalPrStatusCheck),
+    ...SerializedPullRequestCheckStatusFields,
+  }),
+  Schema.TaggedStruct("closed", {
+    ...SerializedPullRequestCheckStatusFields,
+  }),
+])
+
+export const SerializedPullRequestLifecycleStatus = Schema.Union([
+  Schema.TaggedStruct("open", {}),
+  Schema.TaggedStruct("merged", {}),
+  Schema.TaggedStruct("closed", {}),
+  Schema.TaggedStruct("not_found", {}),
+])
+
+export const SerializedMergePullRequestResult = Schema.Union([
+  Schema.TaggedStruct("merged", {}),
+  Schema.TaggedStruct("revalidation", {
+    reason: Schema.Literals([
+      "head_changed",
+      "checks_not_green",
+      "mergeability_changed",
+    ]),
+    message: RequiredString,
+  }),
+  Schema.TaggedStruct("needs_human", {
+    reason: Schema.Literals(["closed_unmerged", "merge_rejected"]),
+    message: RequiredString,
+  }),
+])
+
+/**
+ * Factory for forge-specific request errors (`GitHubRequestError` /
+ * `GitLabRequestError`). Keeps message shaping identical across layers.
+ */
+export const makeRequestError =
+  <E>(ErrorClass: new (args: { readonly message: string }) => E) =>
+  (repository: ForgeRepositoryRef, operation: string, detail?: string): E => {
+    const cleaned =
+      detail === undefined || detail.trim() === ""
+        ? ""
+        : sanitizeUserFacingText(detail, 300)
+    return new ErrorClass({
+      message:
+        cleaned === ""
+          ? `Failed to ${operation} for ${repository.projectPath}`
+          : `Failed to ${operation} for ${repository.projectPath}: ${cleaned}`,
+    })
+  }
+
+export const encodeArgument = (value: string) =>
+  Buffer.from(value, "utf8").toString("base64url")
+
+export const encodedRepositoryArguments = (repository: ForgeRepositoryRef) =>
+  [
+    encodeArgument(repository.forge),
+    encodeArgument(repository.forgeHost),
+    encodeArgument(repository.projectPath),
+  ] as const
+
+export const parseSerializedIssues =
+  <E>(
+    requestError: (
+      repository: ForgeRepositoryRef,
+      operation: string,
+      detail?: string,
+    ) => E,
+  ) =>
+  (
+    stdout: string,
+    repository: ForgeRepositoryRef,
+  ): Effect.Effect<readonly ReadyLabeledIssue[], E> =>
+    Schema.decodeUnknownEffect(Schema.fromJsonString(SerializedIssues))(
+      stdout,
+    ).pipe(
+      Effect.mapError(() =>
+        requestError(repository, "list Ready-labeled Issues"),
+      ),
+    )

--- a/apps/harness/src/server/keymaxxer-github-layer.ts
+++ b/apps/harness/src/server/keymaxxer-github-layer.ts
@@ -6,12 +6,20 @@ import {
   GitHubRequestError,
   GitHubService,
   type GitHubServiceShape,
-  type ReadyLabeledIssue,
   formatGitHubHelperShellCommand,
   resolveGitHubHelperChildSpawn,
-  sanitizeUserFacingText,
 } from "@ready-for-agent/github-service"
 import { KeymaxxerService } from "@ready-for-agent/keymaxxer-service"
+import {
+  SerializedMergePullRequestResult,
+  SerializedPrStatusCheckDiagnostics,
+  SerializedPullRequestCheckStatus,
+  SerializedPullRequestLifecycleStatus,
+  encodeArgument,
+  encodedRepositoryArguments,
+  makeRequestError,
+  parseSerializedIssues,
+} from "./forge-helper-schemas.js"
 
 /**
  * Successful Keymaxxer-backed open non-draft PR counts may be reused for this
@@ -41,94 +49,7 @@ const openPullRequestCountCacheKey = (repository: GitHubRepository): string =>
     repository.projectPath.toLowerCase(),
   ].join("\0")
 
-const PositiveInt = Schema.Int.pipe(Schema.check(Schema.isGreaterThan(0)))
-const NonNegativeInt = Schema.Int.pipe(
-  Schema.check(Schema.isGreaterThanOrEqualTo(0)),
-)
-const RequiredString = Schema.String.pipe(
-  Schema.check(
-    Schema.makeFilter((value: string) =>
-      value.trim() === "" ? "Expected a non-empty string" : undefined,
-    ),
-  ),
-)
-const UrlString = Schema.String.pipe(
-  Schema.check(
-    Schema.makeFilter((value: string) => {
-      try {
-        new URL(value)
-        return undefined
-      } catch {
-        return "Invalid URL"
-      }
-    }),
-  ),
-)
-
-const SerializedIssue = Schema.Struct({
-  number: PositiveInt,
-  title: RequiredString,
-  body: Schema.String,
-  url: UrlString,
-  createdAt: Schema.DateFromString,
-  state: Schema.Literals(["OPEN", "CLOSED"]),
-  author: Schema.NullOr(RequiredString),
-  hierarchySupported: Schema.Boolean,
-  hasChildren: Schema.Boolean,
-  parentPosition: Schema.NullOr(NonNegativeInt),
-  parent: Schema.NullOr(
-    Schema.Struct({
-      number: PositiveInt,
-      url: UrlString,
-      state: Schema.Literals(["OPEN", "CLOSED"]),
-      isReadyLabeled: Schema.Boolean,
-    }),
-  ),
-  blockedBy: Schema.Array(
-    Schema.Struct({
-      number: PositiveInt,
-      url: UrlString,
-    }),
-  ),
-  closingPullRequests: Schema.Array(
-    Schema.Struct({
-      number: PositiveInt,
-      repository: RequiredString,
-      state: Schema.Literals(["OPEN", "MERGED", "CLOSED"]),
-      isDraft: Schema.Boolean,
-    }),
-  ),
-})
-
-const SerializedIssues = Schema.Array(SerializedIssue)
-const SerializedTerminalPrStatusCheck = Schema.Struct({
-  externalId: Schema.String,
-  name: Schema.String,
-  outcome: Schema.Literals(["green", "red"]),
-})
-
-const SerializedPrStatusCheckLogFetch = Schema.Union([
-  Schema.TaggedStruct("ok", {
-    excerpt: Schema.String,
-    localPath: Schema.NullOr(Schema.String),
-  }),
-  Schema.TaggedStruct("unavailable", {
-    reason: Schema.String,
-  }),
-])
-
-const SerializedPrStatusCheckDiagnostic = Schema.Struct({
-  externalId: Schema.String,
-  name: Schema.String,
-  source: Schema.Literals(["actions-job", "status", "gitlab-job", "unknown"]),
-  htmlUrl: Schema.NullOr(Schema.String),
-  logFetch: SerializedPrStatusCheckLogFetch,
-})
-
-const SerializedPrStatusCheckDiagnostics = Schema.Array(
-  SerializedPrStatusCheckDiagnostic,
-)
-
+/** GitHub-only helper wire format (no GitLab counterpart). */
 const SerializedAutomatedReviewEvidenceObservation = Schema.Union([
   Schema.TaggedStruct("none", {
     reason: Schema.Literals(["green-no-review-evidence"]),
@@ -146,116 +67,12 @@ const SerializedAutomatedReviewEvidenceObservation = Schema.Union([
   }),
 ])
 
-const SerializedPullRequestCheckStatusFields = {
-  mergeability: Schema.Literals(["mergeable", "conflicting", "unknown"]),
-  baseRefName: Schema.NullOr(Schema.String),
-  headPushedAt: Schema.NullOr(Schema.String),
-  headSha: Schema.NullOr(Schema.String),
-  createdAt: Schema.NullOr(Schema.String),
-  isDraft: Schema.NullOr(Schema.Boolean),
-} as const
-
-const SerializedPullRequestCheckStatus = Schema.Union([
-  Schema.TaggedStruct("pending", {
-    terminalChecks: Schema.Array(SerializedTerminalPrStatusCheck),
-    ...SerializedPullRequestCheckStatusFields,
-  }),
-  Schema.TaggedStruct("expected", {
-    terminalChecks: Schema.Array(SerializedTerminalPrStatusCheck),
-    ...SerializedPullRequestCheckStatusFields,
-  }),
-  Schema.TaggedStruct("no_checks", {
-    ...SerializedPullRequestCheckStatusFields,
-  }),
-  Schema.TaggedStruct("succeeded", {
-    terminalChecks: Schema.Array(SerializedTerminalPrStatusCheck),
-    ...SerializedPullRequestCheckStatusFields,
-  }),
-  Schema.TaggedStruct("failed", {
-    terminalChecks: Schema.Array(SerializedTerminalPrStatusCheck),
-    ...SerializedPullRequestCheckStatusFields,
-  }),
-  Schema.TaggedStruct("closed", {
-    ...SerializedPullRequestCheckStatusFields,
-  }),
-])
-
-const decodeOptionalInstant = (value: string | null): Date | null => {
-  if (value === null) {
-    return null
-  }
-  const parsed = new Date(value)
-  if (Number.isNaN(parsed.getTime())) {
-    return null
-  }
-  return parsed
-}
-
-const SerializedPullRequestLifecycleStatus = Schema.Union([
-  Schema.TaggedStruct("open", {}),
-  Schema.TaggedStruct("merged", {}),
-  Schema.TaggedStruct("closed", {}),
-  Schema.TaggedStruct("not_found", {}),
-])
-
-const SerializedMergePullRequestResult = Schema.Union([
-  Schema.TaggedStruct("merged", {}),
-  Schema.TaggedStruct("revalidation", {
-    reason: Schema.Literals([
-      "head_changed",
-      "checks_not_green",
-      "mergeability_changed",
-    ]),
-    message: RequiredString,
-  }),
-  Schema.TaggedStruct("needs_human", {
-    reason: Schema.Literals(["closed_unmerged", "merge_rejected"]),
-    message: RequiredString,
-  }),
-])
-
-const requestError = (
-  repository: GitHubRepository,
-  operation: string,
-  detail?: string,
-) => {
-  const cleaned =
-    detail === undefined || detail.trim() === ""
-      ? ""
-      : sanitizeUserFacingText(detail, 300)
-  return new GitHubRequestError({
-    message:
-      cleaned === ""
-        ? `Failed to ${operation} for ${repository.projectPath}`
-        : `Failed to ${operation} for ${repository.projectPath}: ${cleaned}`,
-  })
-}
-
-const encodeArgument = (value: string) =>
-  Buffer.from(value, "utf8").toString("base64url")
-
-const encodedRepositoryArguments = (repository: GitHubRepository) => {
-  return [
-    encodeArgument(repository.forge),
-    encodeArgument(repository.forgeHost),
-    encodeArgument(repository.projectPath),
-  ] as const
-}
+const requestError = makeRequestError(GitHubRequestError)
 
 const repositoryUnavailable = (repository: GitHubRepository) =>
   new GitHubRepositoryUnavailableError(repository)
 
-const parseIssues = (
-  stdout: string,
-  repository: GitHubRepository,
-): Effect.Effect<readonly ReadyLabeledIssue[], GitHubRequestError> =>
-  Schema.decodeUnknownEffect(Schema.fromJsonString(SerializedIssues))(
-    stdout,
-  ).pipe(
-    Effect.mapError(() =>
-      requestError(repository, "list Ready-labeled Issues"),
-    ),
-  )
+const parseIssues = parseSerializedIssues(requestError)
 
 /** Decode a positive integer from helper stdout (trimmed). */
 const decodePositiveInt = (
@@ -642,18 +459,11 @@ export const keymaxxerGitHubLayer = (options: {
             repository,
             describe: "get pull request check status",
             args: [encodeArgument(headRefName)],
-            decode: (stdout) =>
-              decodeJson(
-                SerializedPullRequestCheckStatus,
-                repository,
-                "decode pull request check status",
-              )(stdout).pipe(
-                Effect.map((status) => ({
-                  ...status,
-                  headPushedAt: decodeOptionalInstant(status.headPushedAt),
-                  createdAt: decodeOptionalInstant(status.createdAt),
-                })),
-              ),
+            decode: decodeJson(
+              SerializedPullRequestCheckStatus,
+              repository,
+              "decode pull request check status",
+            ),
           }),
         ),
         getPrStatusCheckDiagnostics: Effect.fn(

--- a/apps/harness/src/server/keymaxxer-gitlab-layer.ts
+++ b/apps/harness/src/server/keymaxxer-gitlab-layer.ts
@@ -1,11 +1,9 @@
 import { Duration, Effect, Layer, Schema } from "effect"
 import type { ChildProcessSpawner } from "effect/unstable/process"
-import { sanitizeUserFacingText } from "@ready-for-agent/github-service"
 import {
   GITLAB_VAULT_METADATA_BUDGET_SECONDS,
   type GitLabHelperOperation,
   GitLabProjectUnavailableError,
-  type GitLabReadyLabeledIssue,
   type GitLabRepository,
   GitLabRequestError,
   GitLabService,
@@ -17,6 +15,16 @@ import {
 } from "@ready-for-agent/gitlab-service"
 import { KeymaxxerService } from "@ready-for-agent/keymaxxer-service"
 import { ambientGitLabLayer } from "./ambient-gitlab-layer.js"
+import {
+  SerializedMergePullRequestResult,
+  SerializedPrStatusCheckDiagnostics,
+  SerializedPullRequestCheckStatus,
+  SerializedPullRequestLifecycleStatus,
+  encodeArgument,
+  encodedRepositoryArguments,
+  makeRequestError,
+  parseSerializedIssues,
+} from "./forge-helper-schemas.js"
 
 type GitLabServiceError = GitLabProjectUnavailableError | GitLabRequestError
 
@@ -34,204 +42,12 @@ type VaultSecretProbe =
   | { readonly kind: "miss" }
   | { readonly kind: "unavailable" }
 
-const PositiveInt = Schema.Int.pipe(Schema.check(Schema.isGreaterThan(0)))
-const NonNegativeInt = Schema.Int.pipe(
-  Schema.check(Schema.isGreaterThanOrEqualTo(0)),
-)
-const RequiredString = Schema.String.pipe(
-  Schema.check(
-    Schema.makeFilter((value: string) =>
-      value.trim() === "" ? "Expected a non-empty string" : undefined,
-    ),
-  ),
-)
-const UrlString = Schema.String.pipe(
-  Schema.check(
-    Schema.makeFilter((value: string) => {
-      try {
-        new URL(value)
-        return undefined
-      } catch {
-        return "Invalid URL"
-      }
-    }),
-  ),
-)
-
-const SerializedIssue = Schema.Struct({
-  number: PositiveInt,
-  title: RequiredString,
-  body: Schema.String,
-  url: UrlString,
-  createdAt: Schema.DateFromString,
-  state: Schema.Literals(["OPEN", "CLOSED"]),
-  author: Schema.NullOr(RequiredString),
-  hierarchySupported: Schema.Boolean,
-  hasChildren: Schema.Boolean,
-  parentPosition: Schema.NullOr(NonNegativeInt),
-  parent: Schema.NullOr(
-    Schema.Struct({
-      number: PositiveInt,
-      url: UrlString,
-      state: Schema.Literals(["OPEN", "CLOSED"]),
-      isReadyLabeled: Schema.Boolean,
-    }),
-  ),
-  blockedBy: Schema.Array(
-    Schema.Struct({
-      number: PositiveInt,
-      url: UrlString,
-    }),
-  ),
-  closingPullRequests: Schema.Array(
-    Schema.Struct({
-      number: PositiveInt,
-      repository: RequiredString,
-      state: Schema.Literals(["OPEN", "MERGED", "CLOSED"]),
-      isDraft: Schema.Boolean,
-    }),
-  ),
-})
-
-const SerializedIssues = Schema.Array(SerializedIssue)
-
-const SerializedTerminalPrStatusCheck = Schema.Struct({
-  externalId: Schema.String,
-  name: Schema.String,
-  outcome: Schema.Literals(["green", "red"]),
-})
-
-const SerializedPrStatusCheckLogFetch = Schema.Union([
-  Schema.TaggedStruct("ok", {
-    excerpt: Schema.String,
-    localPath: Schema.NullOr(Schema.String),
-  }),
-  Schema.TaggedStruct("unavailable", {
-    reason: Schema.String,
-  }),
-])
-
-const SerializedPrStatusCheckDiagnostic = Schema.Struct({
-  externalId: Schema.String,
-  name: Schema.String,
-  source: Schema.Literals(["actions-job", "status", "gitlab-job", "unknown"]),
-  htmlUrl: Schema.NullOr(Schema.String),
-  logFetch: SerializedPrStatusCheckLogFetch,
-})
-
-const SerializedPrStatusCheckDiagnostics = Schema.Array(
-  SerializedPrStatusCheckDiagnostic,
-)
-
-const SerializedPullRequestCheckStatusFields = {
-  mergeability: Schema.Literals(["mergeable", "conflicting", "unknown"]),
-  baseRefName: Schema.NullOr(Schema.String),
-  headPushedAt: Schema.NullOr(Schema.String),
-  headSha: Schema.NullOr(Schema.String),
-  createdAt: Schema.NullOr(Schema.String),
-  isDraft: Schema.NullOr(Schema.Boolean),
-} as const
-
-const SerializedPullRequestCheckStatus = Schema.Union([
-  Schema.TaggedStruct("pending", {
-    terminalChecks: Schema.Array(SerializedTerminalPrStatusCheck),
-    ...SerializedPullRequestCheckStatusFields,
-  }),
-  Schema.TaggedStruct("expected", {
-    terminalChecks: Schema.Array(SerializedTerminalPrStatusCheck),
-    ...SerializedPullRequestCheckStatusFields,
-  }),
-  Schema.TaggedStruct("no_checks", {
-    ...SerializedPullRequestCheckStatusFields,
-  }),
-  Schema.TaggedStruct("succeeded", {
-    terminalChecks: Schema.Array(SerializedTerminalPrStatusCheck),
-    ...SerializedPullRequestCheckStatusFields,
-  }),
-  Schema.TaggedStruct("failed", {
-    terminalChecks: Schema.Array(SerializedTerminalPrStatusCheck),
-    ...SerializedPullRequestCheckStatusFields,
-  }),
-  Schema.TaggedStruct("closed", {
-    ...SerializedPullRequestCheckStatusFields,
-  }),
-])
-
-const SerializedPullRequestLifecycleStatus = Schema.Union([
-  Schema.TaggedStruct("open", {}),
-  Schema.TaggedStruct("merged", {}),
-  Schema.TaggedStruct("closed", {}),
-  Schema.TaggedStruct("not_found", {}),
-])
-
-const SerializedMergePullRequestResult = Schema.Union([
-  Schema.TaggedStruct("merged", {}),
-  Schema.TaggedStruct("revalidation", {
-    reason: Schema.Literals([
-      "head_changed",
-      "checks_not_green",
-      "mergeability_changed",
-    ]),
-    message: RequiredString,
-  }),
-  Schema.TaggedStruct("needs_human", {
-    reason: Schema.Literals(["closed_unmerged", "merge_rejected"]),
-    message: RequiredString,
-  }),
-])
-
-const decodeOptionalInstant = (value: string | null): Date | null => {
-  if (value === null) {
-    return null
-  }
-  const parsed = new Date(value)
-  if (Number.isNaN(parsed.getTime())) {
-    return null
-  }
-  return parsed
-}
-
-const requestError = (
-  repository: GitLabRepository,
-  operation: string,
-  detail?: string,
-) => {
-  const cleaned =
-    detail === undefined || detail.trim() === ""
-      ? ""
-      : sanitizeUserFacingText(detail, 300)
-  return new GitLabRequestError({
-    message:
-      cleaned === ""
-        ? `Failed to ${operation} for ${repository.projectPath}`
-        : `Failed to ${operation} for ${repository.projectPath}: ${cleaned}`,
-  })
-}
-
-const encodeArgument = (value: string) =>
-  Buffer.from(value, "utf8").toString("base64url")
-
-const encodedRepositoryArguments = (repository: GitLabRepository) =>
-  [
-    encodeArgument(repository.forge),
-    encodeArgument(repository.forgeHost),
-    encodeArgument(repository.projectPath),
-  ] as const
+const requestError = makeRequestError(GitLabRequestError)
 
 const repositoryUnavailable = (repository: GitLabRepository) =>
   new GitLabProjectUnavailableError(repository)
 
-const parseIssues = (
-  stdout: string,
-  repository: GitLabRepository,
-): Effect.Effect<readonly GitLabReadyLabeledIssue[], GitLabRequestError> =>
-  Schema.decodeUnknownEffect(Schema.fromJsonString(SerializedIssues))(
-    stdout,
-  ).pipe(
-    Effect.mapError(() =>
-      requestError(repository, "list Ready-labeled Issues"),
-    ),
-  )
+const parseIssues = parseSerializedIssues(requestError)
 
 /** Decode a positive integer from helper stdout (trimmed). */
 const decodePositiveInt = (
@@ -733,18 +549,11 @@ export const keymaxxerGitLabLayer = (options: {
                 tokenName,
                 describe: "get pull request check status",
                 args: [encodeArgument(headRefName)],
-                decode: (stdout) =>
-                  decodeJson(
-                    SerializedPullRequestCheckStatus,
-                    repository,
-                    "decode pull request check status",
-                  )(stdout).pipe(
-                    Effect.map((status) => ({
-                      ...status,
-                      headPushedAt: decodeOptionalInstant(status.headPushedAt),
-                      createdAt: decodeOptionalInstant(status.createdAt),
-                    })),
-                  ),
+                decode: decodeJson(
+                  SerializedPullRequestCheckStatus,
+                  repository,
+                  "decode pull request check status",
+                ),
               }),
             (ambientService) =>
               ambientService.getPullRequestCheckStatus(repository, headRefName),

--- a/apps/harness/test/keymaxxer-github-layer.test.ts
+++ b/apps/harness/test/keymaxxer-github-layer.test.ts
@@ -285,6 +285,71 @@ describe("Keymaxxer-backed GitHub layer", () => {
     expect(runs[0]?.secrets).toEqual(["GITHUB_TOKEN_ACME_WIDGETS"])
   })
 
+  test("maps unparseable PR check-status instants to null", async () => {
+    const keymaxxerLayer = Layer.succeed(KeymaxxerService, {
+      initialize: Effect.void,
+      findSecret: () => Effect.succeed("GITHUB_TOKEN_ACME_WIDGETS"),
+      findSecrets: () => Effect.die("not used"),
+      hasSecret: () => Effect.die("not used"),
+      addSecret: () => Effect.die("not used"),
+      runWithSecrets: () =>
+        Effect.succeed({
+          exitCode: 0,
+          stdout: JSON.stringify({
+            _tag: "succeeded",
+            mergeability: "mergeable",
+            baseRefName: "main",
+            headPushedAt: "not-a-date",
+            headSha: "abc123",
+            createdAt: "garbage",
+            isDraft: false,
+            terminalChecks: [
+              {
+                externalId: "checkrun:1",
+                name: "lint",
+                outcome: "green",
+              },
+            ],
+          }),
+          stderr: "",
+        }),
+    })
+    const layer = keymaxxerGitHubLayer({ workspaceRoot: "/workspace" }).pipe(
+      Layer.provide(keymaxxerLayer),
+    )
+
+    const status = await Effect.runPromise(
+      Effect.gen(function* () {
+        const github = yield* GitHubService
+        return yield* github.getPullRequestCheckStatus(
+          {
+            forge: "github",
+            forgeHost: "github.com",
+            projectPath: "acme/widgets",
+          },
+          "rfa/acme-widgets/42/wi-test",
+        )
+      }).pipe(Effect.provide(layer)),
+    )
+
+    expect(status).toEqual({
+      _tag: "succeeded",
+      mergeability: "mergeable",
+      baseRefName: "main",
+      headPushedAt: null,
+      headSha: "abc123",
+      createdAt: null,
+      isDraft: false,
+      terminalChecks: [
+        {
+          externalId: "checkrun:1",
+          name: "lint",
+          outcome: "green",
+        },
+      ],
+    })
+  })
+
   test("resolves an open PR number through the configured repository token", async () => {
     const runs: RunWithSecretsInput[] = []
     const keymaxxerLayer = Layer.succeed(KeymaxxerService, {

--- a/apps/ready-for-agent/project.json
+++ b/apps/ready-for-agent/project.json
@@ -99,7 +99,7 @@
       "executor": "nx:run-commands",
       "options": {
         "cwd": "{projectRoot}",
-        "command": "bun --conditions=@ready-for-agent/source test"
+        "command": "bun --conditions=@ready-for-agent/source test --timeout=15000"
       },
       "inputs": ["default", "^production"],
       "cache": true,

--- a/apps/ready-for-agent/src/peek-selected-agent-backend.test.ts
+++ b/apps/ready-for-agent/src/peek-selected-agent-backend.test.ts
@@ -7,7 +7,11 @@ import {
   peekSelectedAgentBackendIds,
 } from "./peek-selected-agent-backend.ts"
 import { Database } from "bun:sqlite"
-import { afterEach, describe, expect, test } from "bun:test"
+import { afterEach, describe, expect, setDefaultTimeout, test } from "bun:test"
+
+// File-backed bun:sqlite under nx parallel CI load can exceed the 5s default
+// (first temp-db opens have timed out at ~5.6s while later cases settle to ms).
+setDefaultTimeout(15_000)
 
 const createTempDb = (): { readonly path: string; readonly root: string } => {
   const root = mkdtempSync(join(tmpdir(), "rfa-peek-backend-"))


### PR DESCRIPTION
## Why

The Keymaxxer-backed GitHub and GitLab layers each defined the same
helper-process wire schemas and helpers nearly verbatim. Any change to
the shared format had to be made twice and could drift silently.

## What

- Extract shared schemas and helpers into
  `apps/harness/src/server/forge-helper-schemas.ts` (issue fields, PR
  check status / diagnostics, lifecycle, merge result, `encodeArgument` /
  repository args, `parseSerializedIssues`, `makeRequestError`).
- Decode `headPushedAt` / `createdAt` via Schema
  (`OptionalInstantFromString`: invalid strings → `null`), dropping the
  manual post-step in both layers.
- Keep GitHub-only automated-review evidence and forge-specific integer
  stdout decoders local to each layer.
- Keep intermediate schema building blocks module-local; export only
  what the layers import.
- Add a regression test that unparseable check-status instants map to
  `null`.

## Verification

- `bunx nx run harness:test` — 468 pass, 0 fail
- Biome clean on touched files

Closes #712