### PR TITLE
test: adopt @effect/vitest for Effect unit suites

### DIFF
--- a/apps/harness/package.json
+++ b/apps/harness/package.json
@@ -40,6 +40,7 @@
     "react-dom": "^19.2.8"
   },
   "devDependencies": {
+    "@effect/vitest": "4.0.0-beta.97",
     "@playwright/test": "^1.61.1",
     "@tailwindcss/vite": "^4.3.3",
     "@types/bun": "^1.3.0",
@@ -48,6 +49,7 @@
     "@vitejs/plugin-react": "^6.0.4",
     "playwright-bdd": "^9.2.0",
     "tailwindcss": "^4.3.3",
-    "vite": "^8.1.5"
+    "vite": "^8.1.5",
+    "vitest": "^4.1.10"
   }
 }

--- a/apps/harness/project.json
+++ b/apps/harness/project.json
@@ -61,7 +61,7 @@
       "executor": "nx:run-commands",
       "options": {
         "cwd": "{projectRoot}",
-        "command": "bun --conditions=@ready-for-agent/source test test/production-sse-idle-timeout.test.ts"
+        "command": "bun --bun ./node_modules/vitest/vitest.mjs run --config vitest.config.ts test/production-sse-idle-timeout.test.ts"
       },
       "inputs": ["default", "^production"],
       "cache": true,

--- a/apps/harness/scripts/run-unit-tests.sh
+++ b/apps/harness/scripts/run-unit-tests.sh
@@ -1,27 +1,56 @@
 #!/usr/bin/env bash
-# Default Harness unit suite: parallel + exclude production SSE idle-timeout.
-# Bun 1.3.x can SIGILL-crash isolate workers under --parallel; retry without
-# workers so CI on stable Bun still gates the suite.
+# Default Harness unit suite:
+# - Bun for non-Effect suites (parallel; retry without workers on Bun isolate crash)
+# - Vitest for Effect suites that use @effect/vitest
 set -uo pipefail
 
 conditions="@ready-for-agent/source"
-ignore="**/production-sse-idle-timeout.test.ts"
+# Migrated Effect suites run under vitest; keep them out of bun test.
+effect_ignore=(
+  "**/job-worker.test.ts"
+  "**/keymaxxer-github-layer.test.ts"
+  "**/keymaxxer-gitlab-layer.test.ts"
+  "**/ambient-github-layer.test.ts"
+  "**/ambient-gitlab-layer.test.ts"
+  "**/application-config.test.ts"
+  "**/application-runtime-disposal.test.ts"
+  "**/production-sse-idle-timeout.test.ts"
+)
+# Also exclude the slow SSE suite from the default bun path (historical).
+bun_ignore=(
+  "**/production-sse-idle-timeout.test.ts"
+  "${effect_ignore[@]}"
+)
+
+ignore_args=()
+for pattern in "${bun_ignore[@]}"; do
+  ignore_args+=(--path-ignore-patterns="$pattern")
+done
+
 log="$(mktemp)"
 trap 'rm -f "$log"' EXIT
 
 set +e
-bun --conditions="$conditions" test --parallel --path-ignore-patterns="$ignore" 2>&1 | tee "$log"
+bun --conditions="$conditions" test --parallel "${ignore_args[@]}" 2>&1 | tee "$log"
 code=${PIPESTATUS[0]}
 set -e
 
-if [[ "$code" -eq 0 ]]; then
-  exit 0
+if [[ "$code" -ne 0 ]]; then
+  if grep -Eqi 'worker crashed|SIGILL|Segmentation fault' "$log"; then
+    echo "warning: bun test --parallel crashed (Bun isolate worker bug); retrying without --parallel" >&2
+    bun --conditions="$conditions" test "${ignore_args[@]}"
+    code=$?
+  fi
 fi
 
-if grep -Eqi 'worker crashed|SIGILL|Segmentation fault' "$log"; then
-  echo "warning: bun test --parallel crashed (Bun isolate worker bug); retrying without --parallel" >&2
-  bun --conditions="$conditions" test --path-ignore-patterns="$ignore"
-  exit $?
+if [[ "$code" -ne 0 ]]; then
+  exit "$code"
 fi
 
-exit "$code"
+# Effect suites (vitest + @effect/vitest). Run under Bun so packages that use
+# `bun:*` builtins (sqlite, etc.) resolve. Exclude the intentionally slow SSE
+# suite from the default gate — still available via `nx run harness:slow-test`.
+bun --bun ./node_modules/vitest/vitest.mjs run \
+  --config vitest.config.ts \
+  --exclude '**/production-sse-idle-timeout.test.ts'
+exit $?

--- a/apps/harness/test/ambient-github-layer.test.ts
+++ b/apps/harness/test/ambient-github-layer.test.ts
@@ -1,6 +1,7 @@
 import * as BunChildProcessSpawner from "@effect/platform-bun/BunChildProcessSpawner"
 import * as BunFileSystem from "@effect/platform-bun/BunFileSystem"
 import * as BunPath from "@effect/platform-bun/BunPath"
+import { expect, it } from "@effect/vitest"
 import { Effect, Layer, ManagedRuntime, Stream } from "effect"
 import { ChildProcessSpawner } from "effect/unstable/process"
 import {
@@ -9,7 +10,6 @@ import {
   type GitHubServiceShape,
 } from "@ready-for-agent/github-service"
 import { ambientGitHubLayer } from "../src/server/ambient-github-layer.js"
-import { expect, test } from "bun:test"
 
 const processLayer = BunChildProcessSpawner.layer.pipe(
   Layer.provideMerge(Layer.merge(BunFileSystem.layer, BunPath.layer)),
@@ -86,23 +86,23 @@ const listReadyIssues = Effect.gen(function* () {
   return yield* github.listReadyIssues(repository)
 })
 
-test("ambient GitHub authentication is resolved once", async () => {
-  let resolutions = 0
-  const tokens: string[] = []
-  const layer = ambientGitHubLayer({
-    workspaceRoot: "/workspace",
-    resolveToken: async () => {
-      resolutions += 1
-      return "cached-token"
-    },
-    makeService: (token) => {
-      tokens.push(token)
-      return serviceWithList(() => Effect.succeed([]))
-    },
-  })
+it.effect("ambient GitHub authentication is resolved once", () =>
+  Effect.gen(function* () {
+    let resolutions = 0
+    const tokens: string[] = []
+    const layer = ambientGitHubLayer({
+      workspaceRoot: "/workspace",
+      resolveToken: async () => {
+        resolutions += 1
+        return "cached-token"
+      },
+      makeService: (token) => {
+        tokens.push(token)
+        return serviceWithList(() => Effect.succeed([]))
+      },
+    })
 
-  await Effect.runPromise(
-    Effect.gen(function* () {
+    yield* Effect.gen(function* () {
       const github = yield* GitHubService
       yield* github.listReadyIssues({
         forge: "github",
@@ -114,47 +114,47 @@ test("ambient GitHub authentication is resolved once", async () => {
         forgeHost: "github.com",
         projectPath: "acme/two",
       })
-    }).pipe(Effect.provide(layer.pipe(Layer.provide(processLayer)))),
-  )
+    }).pipe(Effect.provide(layer.pipe(Layer.provide(processLayer))))
 
-  expect(resolutions).toBe(1)
-  expect(tokens).toEqual(["cached-token", "cached-token"])
-})
+    expect(resolutions).toBe(1)
+    expect(tokens).toEqual(["cached-token", "cached-token"])
+  }),
+)
 
-test("ambient GitHub authentication refreshes once after a 401", async () => {
-  const resolvedTokens = ["expired-token", "fresh-token"]
-  let resolutions = 0
-  const layer = ambientGitHubLayer({
-    workspaceRoot: "/workspace",
-    resolveToken: async () => resolvedTokens[resolutions++]!,
-    makeService: (token) =>
-      serviceWithList(() =>
-        token === "expired-token"
-          ? Effect.fail(
-              new GitHubRequestError({
-                message: "Unauthorized",
-                statusCode: 401,
-              }),
-            )
-          : Effect.succeed([]),
-      ),
-  })
+it.effect("ambient GitHub authentication refreshes once after a 401", () =>
+  Effect.gen(function* () {
+    const resolvedTokens = ["expired-token", "fresh-token"]
+    let resolutions = 0
+    const layer = ambientGitHubLayer({
+      workspaceRoot: "/workspace",
+      resolveToken: async () => resolvedTokens[resolutions++]!,
+      makeService: (token) =>
+        serviceWithList(() =>
+          token === "expired-token"
+            ? Effect.fail(
+                new GitHubRequestError({
+                  message: "Unauthorized",
+                  statusCode: 401,
+                }),
+              )
+            : Effect.succeed([]),
+        ),
+    })
 
-  await Effect.runPromise(
-    Effect.gen(function* () {
+    yield* Effect.gen(function* () {
       const github = yield* GitHubService
       yield* github.listReadyIssues({
         forge: "github",
         forgeHost: "github.com",
         projectPath: "acme/widgets",
       })
-    }).pipe(Effect.provide(layer.pipe(Layer.provide(processLayer)))),
-  )
+    }).pipe(Effect.provide(layer.pipe(Layer.provide(processLayer))))
 
-  expect(resolutions).toBe(2)
-})
+    expect(resolutions).toBe(2)
+  }),
+)
 
-test("application scope interrupts in-flight ambient authentication", async () => {
+it("application scope interrupts in-flight ambient authentication", async () => {
   const process = controlledTokenProcess()
   const runtime = ManagedRuntime.make(
     ambientGitHubLayer({
@@ -175,7 +175,7 @@ test("application scope interrupts in-flight ambient authentication", async () =
   }
 })
 
-test("canceling the first requester keeps shared authentication alive", async () => {
+it("canceling the first requester keeps shared authentication alive", async () => {
   const process = controlledTokenProcess()
   const runtime = ManagedRuntime.make(
     ambientGitHubLayer({
@@ -204,7 +204,7 @@ test("canceling the first requester keeps shared authentication alive", async ()
   }
 })
 
-test("concurrent 401 responses share one refreshed token", async () => {
+it("concurrent 401 responses share one refreshed token", async () => {
   const resolvedTokens = ["expired-token", "fresh-token"]
   let resolutions = 0
   let expiredCalls = 0
@@ -258,27 +258,27 @@ test("concurrent 401 responses share one refreshed token", async () => {
   expect(resolutions).toBe(2)
 })
 
-test("ambient GitHub authentication is not refreshed after a 403", async () => {
-  let resolutions = 0
-  const layer = ambientGitHubLayer({
-    workspaceRoot: "/workspace",
-    resolveToken: async () => {
-      resolutions += 1
-      return "insufficient-token"
-    },
-    makeService: () =>
-      serviceWithList(() =>
-        Effect.fail(
-          new GitHubRequestError({
-            message: "Forbidden",
-            statusCode: 403,
-          }),
+it.effect("ambient GitHub authentication is not refreshed after a 403", () =>
+  Effect.gen(function* () {
+    let resolutions = 0
+    const layer = ambientGitHubLayer({
+      workspaceRoot: "/workspace",
+      resolveToken: async () => {
+        resolutions += 1
+        return "insufficient-token"
+      },
+      makeService: () =>
+        serviceWithList(() =>
+          Effect.fail(
+            new GitHubRequestError({
+              message: "Forbidden",
+              statusCode: 403,
+            }),
+          ),
         ),
-      ),
-  })
+    })
 
-  await Effect.runPromise(
-    Effect.gen(function* () {
+    yield* Effect.gen(function* () {
       const github = yield* GitHubService
       return yield* Effect.exit(
         github.listReadyIssues({
@@ -287,42 +287,44 @@ test("ambient GitHub authentication is not refreshed after a 403", async () => {
           projectPath: "acme/widgets",
         }),
       )
-    }).pipe(Effect.provide(layer.pipe(Layer.provide(processLayer)))),
-  )
+    }).pipe(Effect.provide(layer.pipe(Layer.provide(processLayer))))
 
-  expect(resolutions).toBe(1)
-})
+    expect(resolutions).toBe(1)
+  }),
+)
 
-test("failed authentication acquisition is cleared for a later retry", async () => {
-  let resolutions = 0
-  const layer = ambientGitHubLayer({
-    workspaceRoot: "/workspace",
-    resolveToken: async () => {
-      resolutions += 1
-      if (resolutions === 1) throw new Error("gh unavailable")
-      return "recovered-token"
-    },
-    makeService: () => serviceWithList(() => Effect.succeed([])),
-  })
-
-  await Effect.runPromise(
+it.effect(
+  "failed authentication acquisition is cleared for a later retry",
+  () =>
     Effect.gen(function* () {
-      const github = yield* GitHubService
-      const first = yield* Effect.exit(
-        github.listReadyIssues({
+      let resolutions = 0
+      const layer = ambientGitHubLayer({
+        workspaceRoot: "/workspace",
+        resolveToken: async () => {
+          resolutions += 1
+          if (resolutions === 1) throw new Error("gh unavailable")
+          return "recovered-token"
+        },
+        makeService: () => serviceWithList(() => Effect.succeed([])),
+      })
+
+      yield* Effect.gen(function* () {
+        const github = yield* GitHubService
+        const first = yield* Effect.exit(
+          github.listReadyIssues({
+            forge: "github",
+            forgeHost: "github.com",
+            projectPath: "acme/widgets",
+          }),
+        )
+        expect(first._tag).toBe("Failure")
+        yield* github.listReadyIssues({
           forge: "github",
           forgeHost: "github.com",
           projectPath: "acme/widgets",
-        }),
-      )
-      expect(first._tag).toBe("Failure")
-      yield* github.listReadyIssues({
-        forge: "github",
-        forgeHost: "github.com",
-        projectPath: "acme/widgets",
-      })
-    }).pipe(Effect.provide(layer.pipe(Layer.provide(processLayer)))),
-  )
+        })
+      }).pipe(Effect.provide(layer.pipe(Layer.provide(processLayer))))
 
-  expect(resolutions).toBe(2)
-})
+      expect(resolutions).toBe(2)
+    }),
+)

--- a/apps/harness/test/ambient-gitlab-layer.test.ts
+++ b/apps/harness/test/ambient-gitlab-layer.test.ts
@@ -1,6 +1,7 @@
 import * as BunChildProcessSpawner from "@effect/platform-bun/BunChildProcessSpawner"
 import * as BunFileSystem from "@effect/platform-bun/BunFileSystem"
 import * as BunPath from "@effect/platform-bun/BunPath"
+import { expect, it } from "@effect/vitest"
 import { Effect, Layer, Stream } from "effect"
 import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process"
 import {
@@ -9,7 +10,6 @@ import {
   type GitLabServiceShape,
 } from "@ready-for-agent/gitlab-service"
 import { ambientGitLabLayer } from "../src/server/ambient-gitlab-layer.js"
-import { expect, test } from "bun:test"
 
 const processLayer = BunChildProcessSpawner.layer.pipe(
   Layer.provideMerge(Layer.merge(BunFileSystem.layer, BunPath.layer)),
@@ -122,138 +122,140 @@ const glabProcessLayer = (options: {
   }
 }
 
-test("GITLAB_TOKEN takes precedence over glab and is cached per host", async () => {
-  let resolutions = 0
-  const tokens: string[] = []
-  const layer = ambientGitLabLayer({
-    workspaceRoot: "/workspace",
-    environment: { GITLAB_TOKEN: " environment-token " },
-    resolveToken: async () => {
-      resolutions += 1
-      return "glab-token"
-    },
-    makeService: (token) => {
-      tokens.push(token)
-      return service()
-    },
-  })
-
-  await Effect.runPromise(
+it.effect(
+  "GITLAB_TOKEN takes precedence over glab and is cached per host",
+  () =>
     Effect.gen(function* () {
-      const gitlab = yield* GitLabService
-      yield* gitlab.listReadyIssues(repository)
-      yield* gitlab.getAuthenticatedUserLogin({
-        ...repository,
-        projectPath: "project/other",
+      let resolutions = 0
+      const tokens: string[] = []
+      const layer = ambientGitLabLayer({
+        workspaceRoot: "/workspace",
+        environment: { GITLAB_TOKEN: " environment-token " },
+        resolveToken: async () => {
+          resolutions += 1
+          return "glab-token"
+        },
+        makeService: (token) => {
+          tokens.push(token)
+          return service()
+        },
       })
-    }).pipe(Effect.provide(layer.pipe(Layer.provide(processLayer)))),
-  )
 
-  expect(resolutions).toBe(0)
-  expect(tokens).toEqual(["environment-token", "environment-token"])
-})
+      yield* Effect.gen(function* () {
+        const gitlab = yield* GitLabService
+        yield* gitlab.listReadyIssues(repository)
+        yield* gitlab.getAuthenticatedUserLogin({
+          ...repository,
+          projectPath: "project/other",
+        })
+      }).pipe(Effect.provide(layer.pipe(Layer.provide(processLayer))))
 
-test("glab tokens are resolved independently per GitLab host", async () => {
-  const hosts: string[] = []
-  const layer = ambientGitLabLayer({
-    workspaceRoot: "/workspace",
-    resolveToken: async (host) => {
-      hosts.push(host)
-      return `token-for-${host}`
-    },
-    makeService: () => service(),
-  })
+      expect(resolutions).toBe(0)
+      expect(tokens).toEqual(["environment-token", "environment-token"])
+    }),
+)
 
-  await Effect.runPromise(
-    Effect.gen(function* () {
+it.effect("glab tokens are resolved independently per GitLab host", () =>
+  Effect.gen(function* () {
+    const hosts: string[] = []
+    const layer = ambientGitLabLayer({
+      workspaceRoot: "/workspace",
+      resolveToken: async (host) => {
+        hosts.push(host)
+        return `token-for-${host}`
+      },
+      makeService: () => service(),
+    })
+
+    yield* Effect.gen(function* () {
       const gitlab = yield* GitLabService
       yield* gitlab.listReadyIssues(repository)
       yield* gitlab.listReadyIssues({
         ...repository,
         forgeHost: "gitlab.example.com",
       })
-    }).pipe(Effect.provide(layer.pipe(Layer.provide(processLayer)))),
-  )
+    }).pipe(Effect.provide(layer.pipe(Layer.provide(processLayer))))
 
-  expect(hosts).toEqual(["git.drupalcode.org", "gitlab.example.com"])
-})
+    expect(hosts).toEqual(["git.drupalcode.org", "gitlab.example.com"])
+  }),
+)
 
-test("authentication refreshes once after a GitLab 401", async () => {
-  const resolvedTokens = ["expired", "fresh"]
-  let resolutions = 0
-  const layer = ambientGitLabLayer({
-    workspaceRoot: "/workspace",
-    resolveToken: async () => resolvedTokens[resolutions++]!,
-    makeService: (token) =>
-      service({
-        listReadyIssues: () =>
-          token === "expired"
-            ? Effect.fail(
-                new GitLabRequestError({
-                  message: "Unauthorized",
-                  statusCode: 401,
-                }),
-              )
-            : Effect.succeed([]),
-      }),
-  })
+it.effect("authentication refreshes once after a GitLab 401", () =>
+  Effect.gen(function* () {
+    const resolvedTokens = ["expired", "fresh"]
+    let resolutions = 0
+    const layer = ambientGitLabLayer({
+      workspaceRoot: "/workspace",
+      resolveToken: async () => resolvedTokens[resolutions++]!,
+      makeService: (token) =>
+        service({
+          listReadyIssues: () =>
+            token === "expired"
+              ? Effect.fail(
+                  new GitLabRequestError({
+                    message: "Unauthorized",
+                    statusCode: 401,
+                  }),
+                )
+              : Effect.succeed([]),
+        }),
+    })
 
-  await Effect.runPromise(
-    Effect.gen(function* () {
+    yield* Effect.gen(function* () {
       const gitlab = yield* GitLabService
       yield* gitlab.listReadyIssues(repository)
-    }).pipe(Effect.provide(layer.pipe(Layer.provide(processLayer)))),
-  )
+    }).pipe(Effect.provide(layer.pipe(Layer.provide(processLayer))))
 
-  expect(resolutions).toBe(2)
-})
+    expect(resolutions).toBe(2)
+  }),
+)
 
-test("public project verification falls back to anonymous access", async () => {
-  let anonymousVerifications = 0
-  const layer = ambientGitLabLayer({
-    workspaceRoot: "/workspace",
-    resolveToken: async () => {
-      throw new Error("glab is not authenticated")
-    },
-    makeAnonymousService: () =>
-      service({
-        verifyProject: (identity) => {
-          anonymousVerifications += 1
-          return Effect.succeed(identity)
-        },
-        hasCredentials: () => Effect.succeed(false),
-        hasAmbientCredentials: () => Effect.succeed(false),
-      }),
-  })
+it.effect("public project verification falls back to anonymous access", () =>
+  Effect.gen(function* () {
+    let anonymousVerifications = 0
+    const layer = ambientGitLabLayer({
+      workspaceRoot: "/workspace",
+      resolveToken: async () => {
+        throw new Error("glab is not authenticated")
+      },
+      makeAnonymousService: () =>
+        service({
+          verifyProject: (identity) => {
+            anonymousVerifications += 1
+            return Effect.succeed(identity)
+          },
+          hasCredentials: () => Effect.succeed(false),
+          hasAmbientCredentials: () => Effect.succeed(false),
+        }),
+    })
 
-  await Effect.runPromise(
-    Effect.gen(function* () {
+    yield* Effect.gen(function* () {
       const gitlab = yield* GitLabService
       expect(yield* gitlab.hasCredentials(repository)).toBe(false)
       yield* gitlab.verifyProject(repository)
-    }).pipe(Effect.provide(layer.pipe(Layer.provide(processLayer)))),
-  )
+    }).pipe(Effect.provide(layer.pipe(Layer.provide(processLayer))))
 
-  expect(anonymousVerifications).toBe(1)
-})
+    expect(anonymousVerifications).toBe(1)
+  }),
+)
 
-test("glab login for a host is recognized for that host only", async () => {
-  const glab = glabProcessLayer({
-    hostTokens: new Map([["git.drupalcode.org", "token-for-drupalcode"]]),
-    // Non-zero exit with Token found simulates API outage resilience.
-    authenticatedExitCode: 1,
-  })
-  const tokens: string[] = []
-  const layer = ambientGitLabLayer({
-    workspaceRoot: "/workspace",
-    makeService: (token) => {
-      tokens.push(token)
-      return service()
-    },
-  })
+it.effect("glab login for a host is recognized for that host only", () =>
+  Effect.gen(function* () {
+    const glab = glabProcessLayer({
+      hostTokens: new Map([["git.drupalcode.org", "token-for-drupalcode"]]),
+      // Non-zero exit with Token found simulates API outage resilience.
+      authenticatedExitCode: 1,
+    })
+    const tokens: string[] = []
+    const layer = ambientGitLabLayer({
+      workspaceRoot: "/workspace",
+      makeService: (token) => {
+        tokens.push(token)
+        return service()
+      },
+    })
 
-  const result = await Effect.runPromise(
-    Effect.gen(function* () {
+    const result = yield* Effect.gen(function* () {
       const gitlab = yield* GitLabService
       const configured = yield* gitlab.hasCredentials(repository)
       const wrongSshHost = yield* gitlab.hasCredentials({
@@ -277,106 +279,108 @@ test("glab login for a host is recognized for that host only", async () => {
         ambientConfigured,
         ambientWrong,
       }
-    }).pipe(Effect.provide(layer.pipe(Layer.provide(glab.layer)))),
-  )
+    }).pipe(Effect.provide(layer.pipe(Layer.provide(glab.layer))))
 
-  expect(result).toEqual({
-    configured: true,
-    wrongSshHost: false,
-    arbitrary: false,
-    ambientConfigured: true,
-    ambientWrong: false,
-  })
-  expect(tokens).toEqual(["token-for-drupalcode"])
-  expect(
-    glab.commands.some(
-      (args) =>
-        args[0] === "glab" &&
-        args[1] === "auth" &&
-        args[2] === "status" &&
-        args[3] === "--hostname" &&
-        args[4] === "git.drupalcode.org" &&
-        args.includes("--show-token"),
-    ),
-  ).toBe(true)
-  expect(
-    glab.commands.some(
-      (args) =>
-        args[0] === "glab" &&
-        args[1] === "auth" &&
-        args[2] === "status" &&
-        args[3] === "--hostname" &&
-        args[4] === "not-a-real-host.example",
-    ),
-  ).toBe(true)
-  // Shared helper never uses config-get (fallback-token path).
-  expect(
-    glab.commands.some(
-      (args) =>
-        args[0] === "glab" &&
-        args[1] === "config" &&
-        args[2] === "get" &&
-        args[3] === "token",
-    ),
-  ).toBe(false)
-})
+    expect(result).toEqual({
+      configured: true,
+      wrongSshHost: false,
+      arbitrary: false,
+      ambientConfigured: true,
+      ambientWrong: false,
+    })
+    expect(tokens).toEqual(["token-for-drupalcode"])
+    expect(
+      glab.commands.some(
+        (args) =>
+          args[0] === "glab" &&
+          args[1] === "auth" &&
+          args[2] === "status" &&
+          args[3] === "--hostname" &&
+          args[4] === "git.drupalcode.org" &&
+          args.includes("--show-token"),
+      ),
+    ).toBe(true)
+    expect(
+      glab.commands.some(
+        (args) =>
+          args[0] === "glab" &&
+          args[1] === "auth" &&
+          args[2] === "status" &&
+          args[3] === "--hostname" &&
+          args[4] === "not-a-real-host.example",
+      ),
+    ).toBe(true)
+    // Shared helper never uses config-get (fallback-token path).
+    expect(
+      glab.commands.some(
+        (args) =>
+          args[0] === "glab" &&
+          args[1] === "config" &&
+          args[2] === "get" &&
+          args[3] === "token",
+      ),
+    ).toBe(false)
+  }),
+)
 
-test("unconfigured hosts do not receive credentials from glab", async () => {
-  const glab = glabProcessLayer({
-    hostTokens: new Map(),
-  })
-  const tokens: string[] = []
-  const layer = ambientGitLabLayer({
-    workspaceRoot: "/workspace",
-    makeService: (token) => {
-      tokens.push(token)
-      return service()
-    },
-  })
+it.effect("unconfigured hosts do not receive credentials from glab", () =>
+  Effect.gen(function* () {
+    const glab = glabProcessLayer({
+      hostTokens: new Map(),
+    })
+    const tokens: string[] = []
+    const layer = ambientGitLabLayer({
+      workspaceRoot: "/workspace",
+      makeService: (token) => {
+        tokens.push(token)
+        return service()
+      },
+    })
 
-  const hasCredentials = await Effect.runPromise(
-    Effect.gen(function* () {
+    const hasCredentials = yield* Effect.gen(function* () {
       const gitlab = yield* GitLabService
       return yield* gitlab.hasCredentials({
         ...repository,
         forgeHost: "not-a-real-host.example",
       })
-    }).pipe(Effect.provide(layer.pipe(Layer.provide(glab.layer)))),
-  )
+    }).pipe(Effect.provide(layer.pipe(Layer.provide(glab.layer))))
 
-  expect(hasCredentials).toBe(false)
-  expect(tokens).toEqual([])
-})
+    expect(hasCredentials).toBe(false)
+    expect(tokens).toEqual([])
+  }),
+)
 
-test("GITLAB_TOKEN still takes precedence over host-specific glab auth", async () => {
-  const glab = glabProcessLayer({
-    hostTokens: new Map([["git.drupalcode.org", "glab-token"]]),
-  })
-  const tokens: string[] = []
-  const layer = ambientGitLabLayer({
-    workspaceRoot: "/workspace",
-    environment: { GITLAB_TOKEN: " env-token " },
-    makeService: (token) => {
-      tokens.push(token)
-      return service()
-    },
-  })
-
-  await Effect.runPromise(
+it.effect(
+  "GITLAB_TOKEN still takes precedence over host-specific glab auth",
+  () =>
     Effect.gen(function* () {
-      const gitlab = yield* GitLabService
-      expect(yield* gitlab.hasCredentials(repository)).toBe(true)
-      expect(
-        yield* gitlab.hasCredentials({
-          ...repository,
-          forgeHost: "not-a-real-host.example",
-        }),
-      ).toBe(true)
-      yield* gitlab.listReadyIssues(repository)
-    }).pipe(Effect.provide(layer.pipe(Layer.provide(glab.layer)))),
-  )
+      const glab = glabProcessLayer({
+        hostTokens: new Map([["git.drupalcode.org", "glab-token"]]),
+      })
+      const tokens: string[] = []
+      const layer = ambientGitLabLayer({
+        workspaceRoot: "/workspace",
+        environment: { GITLAB_TOKEN: " env-token " },
+        makeService: (token) => {
+          tokens.push(token)
+          return service()
+        },
+      })
 
-  expect(tokens).toEqual(["env-token"])
-  // Env token short-circuits; glab must not be consulted.
-  expect(glab.commands).toEqual([])
-})
+      yield* Effect.gen(function* () {
+        const gitlab = yield* GitLabService
+        expect(yield* gitlab.hasCredentials(repository)).toBe(true)
+        expect(
+          yield* gitlab.hasCredentials({
+            ...repository,
+            forgeHost: "not-a-real-host.example",
+          }),
+        ).toBe(true)
+        yield* gitlab.listReadyIssues(repository)
+      }).pipe(Effect.provide(layer.pipe(Layer.provide(glab.layer))))
+
+      expect(tokens).toEqual(["env-token"])
+      // Env token short-circuits; glab must not be consulted.
+      expect(glab.commands).toEqual([])
+    }),
+)

--- a/apps/harness/test/application-config.test.ts
+++ b/apps/harness/test/application-config.test.ts
@@ -1,50 +1,54 @@
+import { describe, expect, it } from "@effect/vitest"
 import { Effect } from "effect"
 import {
   loadApplicationConfig,
   loadPort,
 } from "../src/server/application-config.js"
-import { describe, expect, test } from "bun:test"
 
 describe("harness application config", () => {
-  test("loads the Sidecar URL and host tool cwd from the supplied environment", async () => {
-    const config = await Effect.runPromise(
-      loadApplicationConfig({
-        HOME: "/home/operator",
-        KEYMAXXER_SIDECAR_URL: " http://127.0.0.1:6057/cap/mcp ",
+  it.effect(
+    "loads the Sidecar URL and host tool cwd from the supplied environment",
+    () =>
+      Effect.gen(function* () {
+        const config = yield* loadApplicationConfig({
+          HOME: "/home/operator",
+          KEYMAXXER_SIDECAR_URL: " http://127.0.0.1:6057/cap/mcp ",
+        })
+
+        expect(config).toEqual({
+          hostToolCwd: "/home/operator",
+          keymaxxerSidecarUrl: "http://127.0.0.1:6057/cap/mcp",
+        })
       }),
-    )
+  )
 
-    expect(config).toEqual({
-      hostToolCwd: "/home/operator",
-      keymaxxerSidecarUrl: "http://127.0.0.1:6057/cap/mcp",
-    })
-  })
-
-  test("allows Keymaxxer to be explicitly disabled", async () => {
-    const config = await Effect.runPromise(
-      loadApplicationConfig({
+  it.effect("allows Keymaxxer to be explicitly disabled", () =>
+    Effect.gen(function* () {
+      const config = yield* loadApplicationConfig({
         HOME: "/home/operator",
         KEYMAXXER_ENABLED: "false",
-      }),
-    )
+      })
 
-    expect(config.keymaxxerSidecarUrl).toBeUndefined()
-  })
+      expect(config.keymaxxerSidecarUrl).toBeUndefined()
+    }),
+  )
 
-  test("rejects an enabled configuration without a Sidecar URL", async () => {
-    const exit = await Effect.runPromise(Effect.exit(loadApplicationConfig({})))
-    expect(exit._tag).toBe("Failure")
-  })
-
-  test("loads and validates the production port", async () => {
-    expect(await Effect.runPromise(loadPort({}))).toBe(6056)
-    expect(await Effect.runPromise(loadPort({ PORT: "4300" }))).toBe(4300)
-
-    for (const value of ["0", "1.5", "65536", "not-a-port"]) {
-      const exit = await Effect.runPromise(
-        Effect.exit(loadPort({ PORT: value })),
-      )
+  it.effect("rejects an enabled configuration without a Sidecar URL", () =>
+    Effect.gen(function* () {
+      const exit = yield* Effect.exit(loadApplicationConfig({}))
       expect(exit._tag).toBe("Failure")
-    }
-  })
+    }),
+  )
+
+  it.effect("loads and validates the production port", () =>
+    Effect.gen(function* () {
+      expect(yield* loadPort({})).toBe(6056)
+      expect(yield* loadPort({ PORT: "4300" })).toBe(4300)
+
+      for (const value of ["0", "1.5", "65536", "not-a-port"]) {
+        const exit = yield* Effect.exit(loadPort({ PORT: value }))
+        expect(exit._tag).toBe("Failure")
+      }
+    }),
+  )
 })

--- a/apps/harness/test/application-runtime-disposal.test.ts
+++ b/apps/harness/test/application-runtime-disposal.test.ts
@@ -1,111 +1,126 @@
 import { mkdtemp, rm } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
+import { describe, expect, it } from "@effect/vitest"
 import { Effect, Layer } from "effect"
 import { DatabaseLive, runConfiguredMigrations } from "@ready-for-agent/db"
 import { DbService, DbServiceLive } from "@ready-for-agent/db-service"
 import type { KeymaxxerToolClient } from "@ready-for-agent/keymaxxer-service"
 import { createApplication } from "../src/server/application.server.js"
 import { environmentConfigLayer } from "../src/server/application-config.js"
-import { expect, test } from "bun:test"
 
-// Migrations + createApplication + dispose can exceed Bun's 5s default under
-// nx affected --batch load (observed ~5.2s flake). Bound higher than default.
-test(
-  "application disposal closes a lazily created authentication client",
-  async () => {
-    const directory = await mkdtemp(join(tmpdir(), "rfa-auth-runtime-"))
-    const environment = {
-      HOME: directory,
-      KEYMAXXER_SIDECAR_URL: "http://127.0.0.1:6057/application-runtime/mcp",
-      SQLITE_DATABASE_PATH: join(directory, "ready-for-agent.db"),
-    }
-    const configLayer = environmentConfigLayer(environment)
-    let application: Awaited<ReturnType<typeof createApplication>> | undefined
-    let disposed = false
-    let closeCalls = 0
-    const client: KeymaxxerToolClient = {
-      callTool: async () => ({
-        content: [
-          {
-            type: "text",
-            text: JSON.stringify([
+// Migrations + createApplication + dispose can exceed the default under load.
+// Bound higher than default via vitest options.
+describe("application runtime disposal", () => {
+  it.live(
+    "application disposal closes a lazily created authentication client",
+    () =>
+      Effect.gen(function* () {
+        // Scope finalizer always removes the temp dir (unlike try/finally + yield*).
+        const directory = yield* Effect.acquireRelease(
+          Effect.promise(() => mkdtemp(join(tmpdir(), "rfa-auth-runtime-"))),
+          (dir) =>
+            Effect.promise(() => rm(dir, { recursive: true, force: true })),
+        )
+        const environment = {
+          HOME: directory,
+          KEYMAXXER_SIDECAR_URL:
+            "http://127.0.0.1:6057/application-runtime/mcp",
+          SQLITE_DATABASE_PATH: join(directory, "ready-for-agent.db"),
+        }
+        const configLayer = environmentConfigLayer(environment)
+        let application:
+          | Awaited<ReturnType<typeof createApplication>>
+          | undefined
+        let disposed = false
+        let closeCalls = 0
+        const client: KeymaxxerToolClient = {
+          callTool: async () => ({
+            content: [
               {
-                name: "GITHUB_TOKEN_ACME_WIDGETS",
-                provider: "github",
-                account: "acme/widgets",
+                type: "text",
+                text: JSON.stringify([
+                  {
+                    name: "GITHUB_TOKEN_ACME_WIDGETS",
+                    provider: "github",
+                    account: "acme/widgets",
+                  },
+                ]),
               },
-            ]),
+            ],
+          }),
+          close: async () => {
+            closeCalls += 1
           },
-        ],
-      }),
-      close: async () => {
-        closeCalls += 1
-      },
-    }
+        }
 
-    try {
-      await Effect.runPromise(
-        runConfiguredMigrations().pipe(
-          Effect.provide(DatabaseLive.pipe(Layer.provide(configLayer))),
-        ),
-      )
-      const databaseLayer = DbServiceLive.pipe(
-        Layer.provideMerge(DatabaseLive),
-        Layer.provide(configLayer),
-      )
-      await Effect.runPromise(
-        Effect.gen(function* () {
-          const db = yield* DbService
-          yield* db.addRepository({
-            forge: "github",
-            forgeHost: "github.com",
-            projectPath: "acme/widgets",
-            localPath: join(directory, "widgets"),
-            isBare: true,
-          })
-        }).pipe(Effect.provide(databaseLayer)),
-      )
+        yield* Effect.gen(function* () {
+          yield* runConfiguredMigrations().pipe(
+            Effect.provide(DatabaseLive.pipe(Layer.provide(configLayer))),
+          )
+          const databaseLayer = DbServiceLive.pipe(
+            Layer.provideMerge(DatabaseLive),
+            Layer.provide(configLayer),
+          )
+          yield* Effect.gen(function* () {
+            const db = yield* DbService
+            yield* db.addRepository({
+              forge: "github",
+              forgeHost: "github.com",
+              projectPath: "acme/widgets",
+              localPath: join(directory, "widgets"),
+              isBare: true,
+            })
+          }).pipe(Effect.provide(databaseLayer))
 
-      application = await createApplication(environment, {
-        startWorker: false,
-        sidecarLayerOptions: {
-          createClient: async () => client,
-          fetch: async () => new Response(null, { status: 404 }),
-        },
-      })
-      const response = await application.context.graphqlApi.fetch(
-        new Request("http://127.0.0.1:6056/graphql", {
-          method: "POST",
-          headers: { "content-type": "application/json" },
-          body: JSON.stringify({
-            query: `query {
+          application = yield* Effect.promise(() =>
+            createApplication(environment, {
+              startWorker: false,
+              sidecarLayerOptions: {
+                createClient: async () => client,
+                fetch: async () => new Response(null, { status: 404 }),
+              },
+            }),
+          )
+          const response = yield* Effect.promise(() =>
+            application!.context.graphqlApi.fetch(
+              new Request("http://127.0.0.1:6056/graphql", {
+                method: "POST",
+                headers: { "content-type": "application/json" },
+                body: JSON.stringify({
+                  query: `query {
             repositoryCredentials {
               configured
               repositoryId
             }
           }`,
-          }),
-        }),
-      )
+                }),
+              }),
+            ),
+          )
 
-      expect(response.status).toBe(200)
-      expect(await response.json()).toMatchObject({
-        data: {
-          repositoryCredentials: [{ configured: true }],
-        },
-      })
-      expect(closeCalls).toBe(0)
+          expect(response.status).toBe(200)
+          expect(yield* Effect.promise(() => response.json())).toMatchObject({
+            data: {
+              repositoryCredentials: [{ configured: true }],
+            },
+          })
+          expect(closeCalls).toBe(0)
 
-      await application.dispose()
-      disposed = true
-      expect(closeCalls).toBe(1)
-    } finally {
-      if (application !== undefined && !disposed) {
-        await application.dispose()
-      }
-      await rm(directory, { recursive: true, force: true })
-    }
-  },
-  { timeout: 15_000 },
-)
+          yield* Effect.promise(() => application!.dispose())
+          disposed = true
+          expect(closeCalls).toBe(1)
+        }).pipe(
+          // Always dispose a half-built application if the body fails mid-way.
+          Effect.ensuring(
+            Effect.suspend(() =>
+              application !== undefined && !disposed
+                ? Effect.promise(() => application!.dispose())
+                : Effect.void,
+            ),
+          ),
+        )
+      }),
+    15_000,
+  )
+})

--- a/apps/harness/test/job-worker.test.ts
+++ b/apps/harness/test/job-worker.test.ts
@@ -1,3 +1,4 @@
+import { describe, expect, it } from "@effect/vitest"
 import {
   DateTime,
   Deferred,
@@ -78,7 +79,6 @@ import {
   startJobWorker,
   transferPersistedRefreshJobs,
 } from "../src/server/job-worker.js"
-import { describe, expect, test } from "bun:test"
 
 const repository = makeRepositoryRecord({
   id: RepositoryId.make("repo-01J00000000000000000000000"),
@@ -317,10 +317,8 @@ const queueLayer = (
 const runScoped = <A, E, R, LE>(
   effect: Effect.Effect<A, E, R | Scope.Scope>,
   layer: Layer.Layer<R, LE, never>,
-): Promise<A> =>
-  Effect.runPromise(
-    Effect.scoped(effect).pipe(Effect.provide(layer), Effect.orDie),
-  )
+): Effect.Effect<A> =>
+  Effect.scoped(effect).pipe(Effect.provide(layer), Effect.orDie)
 
 const readyRuntimeStatus = (): AgentBackendRuntimeStatus => ({
   backend: { id: "opencode", label: "OpenCode" },
@@ -386,404 +384,493 @@ const stubActiveAgentBackend = (): ActiveAgentBackendShape => {
 }
 
 describe("Job worker", () => {
-  test("enqueues a validated Refresh Job on the issue-refresh queue", async () => {
-    let enqueued:
-      | {
-          queue: string
-          payload: Record<string, unknown>
-          retryLimit: number | undefined
-        }
-      | undefined
-    const queue = Layer.succeed(
-      QueueService,
-      stubQueueService({
-        enqueue: (queueName, payload, options) =>
-          Effect.sync(() => {
-            enqueued = {
-              queue: queueName,
-              payload,
-              retryLimit: options?.retryLimit,
-            }
-            return makeJobId()
-          }),
-      }),
-    )
-
-    await Effect.runPromise(
-      enqueueRefreshRepositoryJob(refreshPayload.repositoryId).pipe(
-        Effect.provide(queue),
-      ),
-    )
-
-    expect(enqueued).toEqual({
-      queue: ISSUE_REFRESH_QUEUE,
-      payload: refreshPayload,
-      retryLimit: JOB_RECOVERY_RETRY_LIMIT,
-    })
-  })
-
-  test("extends a Lifecycle Job lease and leaves a live no-op unacknowledged", async () => {
-    const stepRunId = makeStepRunId()
-    const payload = WorkItemStepJob.make({ stepRunId })
-    const job = rawJob(payload, JOBS_QUEUE)
-    const dispatched = await Effect.runPromise(Deferred.make<string>())
-    const extended = await Effect.runPromise(
-      Deferred.make<{ readonly jobId: string; readonly timeoutMs: number }>(),
-    )
-    const recovered = await Effect.runPromise(Deferred.make<void>())
-    const acknowledged: string[] = []
-
-    await runScoped(
-      Effect.gen(function* () {
-        yield* runJobWorker({ idlePollInterval: Duration.zero }).pipe(
-          Effect.forkScoped({ startImmediately: true }),
-        )
-        yield* Deferred.await(recovered)
-        expect(yield* Deferred.await(dispatched)).toBe(stepRunId)
-        expect(yield* Deferred.await(extended)).toEqual({
-          jobId: job.jobId,
-          timeoutMs: Duration.toMillis(Duration.hours(2)) + 60_000,
-        })
-        yield* Effect.sleep("10 millis")
-        expect(acknowledged).toEqual([])
-      }),
-      Layer.mergeAll(
-        queueLayer(
-          [job],
-          (jobId) =>
+  it.live("enqueues a validated Refresh Job on the issue-refresh queue", () =>
+    Effect.gen(function* () {
+      let enqueued:
+        | {
+            queue: string
+            payload: Record<string, unknown>
+            retryLimit: number | undefined
+          }
+        | undefined
+      const queue = Layer.succeed(
+        QueueService,
+        stubQueueService({
+          enqueue: (queueName, payload, options) =>
             Effect.sync(() => {
-              acknowledged.push(jobId)
-            }),
-          undefined,
-          undefined,
-          (receivedStepRunId) =>
-            Deferred.succeed(dispatched, receivedStepRunId).pipe(
-              Effect.as({ _tag: "noop" as const }),
-            ),
-          (jobId, timeout) =>
-            Deferred.succeed(extended, {
-              jobId,
-              timeoutMs: Duration.toMillis(timeout),
-            }),
-          Deferred.succeed(recovered, undefined).pipe(Effect.as(0)),
-        ),
-        dbLayer(),
-        Layer.succeed(IssueReconciler, { reconcile: unused }),
-        keymaxxerLayer(),
-      ),
-    )
-  })
-
-  test("skips a stale Lifecycle Job and processes a later delivery", async () => {
-    const staleStepRunId = makeStepRunId()
-    const laterStepRunId = makeStepRunId()
-    const staleJob = rawJob(
-      WorkItemStepJob.make({ stepRunId: staleStepRunId }),
-      JOBS_QUEUE,
-    )
-    const laterJob = rawJob(
-      WorkItemStepJob.make({ stepRunId: laterStepRunId }),
-      JOBS_QUEUE,
-    )
-    const processed = await Effect.runPromise(Deferred.make<string>())
-    const extendedJobIds: string[] = []
-    const dispatchedStepRunIds: string[] = []
-
-    await runScoped(
-      Effect.gen(function* () {
-        yield* runJobWorker({ idlePollInterval: Duration.zero }).pipe(
-          Effect.forkScoped({ startImmediately: true }),
-        )
-        expect(
-          yield* Deferred.await(processed).pipe(Effect.timeout("100 millis")),
-        ).toBe(laterStepRunId)
-        expect(extendedJobIds).toEqual([staleJob.jobId, laterJob.jobId])
-        expect(dispatchedStepRunIds).toEqual([laterStepRunId])
-      }),
-      Layer.mergeAll(
-        defaultGithubLayer,
-        queueLayer(
-          [staleJob, laterJob],
-          undefined,
-          undefined,
-          undefined,
-          (stepRunId) =>
-            Effect.gen(function* () {
-              dispatchedStepRunIds.push(stepRunId)
-              yield* Deferred.succeed(processed, stepRunId)
-              return { _tag: "noop" as const }
-            }),
-          (jobId) =>
-            Effect.gen(function* () {
-              extendedJobIds.push(jobId)
-              if (jobId === staleJob.jobId) {
-                return yield* new JobNotFoundError({ jobId })
+              enqueued = {
+                queue: queueName,
+                payload,
+                retryLimit: options?.retryLimit,
               }
+              return makeJobId()
             }),
-        ),
-        dbLayer(),
-        Layer.succeed(IssueReconciler, { reconcile: unused }),
-        keymaxxerLayer(),
-      ),
-    )
-  })
+        }),
+      )
 
-  test("keeps Issue refresh operational and logs context after a Lifecycle lease extension failure", async () => {
-    const stepRunId = makeStepRunId()
-    const lifecycleJob = rawJob(WorkItemStepJob.make({ stepRunId }), JOBS_QUEUE)
-    const refreshJob = rawJob(refreshPayload)
-    const extensionAttempted = await Effect.runPromise(Deferred.make<void>())
-    const refreshAcknowledged = await Effect.runPromise(Deferred.make<string>())
-    const dispatchedStepRunIds: string[] = []
-    const logs: unknown[] = []
-    const logger = Logger.make(({ message }) => {
-      logs.push(message)
-    })
+      yield* enqueueRefreshRepositoryJob(refreshPayload.repositoryId).pipe(
+        Effect.provide(queue),
+      )
 
-    await runScoped(
+      expect(enqueued).toEqual({
+        queue: ISSUE_REFRESH_QUEUE,
+        payload: refreshPayload,
+        retryLimit: JOB_RECOVERY_RETRY_LIMIT,
+      })
+    }),
+  )
+
+  it.live(
+    "extends a Lifecycle Job lease and leaves a live no-op unacknowledged",
+    () =>
       Effect.gen(function* () {
-        yield* runJobWorker({ idlePollInterval: Duration.zero }).pipe(
-          Effect.forkScoped({ startImmediately: true }),
-        )
-        expect(
-          yield* Deferred.await(refreshAcknowledged).pipe(
-            Effect.timeout("100 millis"),
-          ),
-        ).toBe(refreshJob.jobId)
-        expect(dispatchedStepRunIds).toEqual([])
-        expect(logs).toContainEqual([
-          "Lifecycle Job lease extension failed",
-          expect.objectContaining({
-            jobId: lifecycleJob.jobId,
-            stepRunId,
-            error: "temporary lease extension failure",
+        const stepRunId = makeStepRunId()
+        const payload = WorkItemStepJob.make({ stepRunId })
+        const job = rawJob(payload, JOBS_QUEUE)
+        const dispatched = yield* Deferred.make<string>()
+        const extended = yield* Deferred.make<{
+          readonly jobId: string
+          readonly timeoutMs: number
+        }>()
+        const recovered = yield* Deferred.make<void>()
+        const acknowledged: string[] = []
+
+        yield* runScoped(
+          Effect.gen(function* () {
+            yield* runJobWorker({ idlePollInterval: Duration.zero }).pipe(
+              Effect.forkScoped({ startImmediately: true }),
+            )
+            yield* Deferred.await(recovered)
+            expect(yield* Deferred.await(dispatched)).toBe(stepRunId)
+            expect(yield* Deferred.await(extended)).toEqual({
+              jobId: job.jobId,
+              timeoutMs: Duration.toMillis(Duration.hours(2)) + 60_000,
+            })
+            yield* Effect.sleep("10 millis")
+            expect(acknowledged).toEqual([])
           }),
-        ])
-      }),
-      Layer.mergeAll(
-        defaultGithubLayer,
-        queueLayer(
-          [lifecycleJob, refreshJob],
-          (jobId) => Deferred.succeed(refreshAcknowledged, jobId),
-          undefined,
-          undefined,
-          (receivedStepRunId) =>
-            Effect.sync(() => {
-              dispatchedStepRunIds.push(receivedStepRunId)
-              return { _tag: "noop" as const }
-            }),
-          (jobId) =>
-            Effect.gen(function* () {
-              yield* Deferred.succeed(extensionAttempted, undefined)
-              return yield* new AcknowledgeError({
-                jobId,
-                message: "temporary lease extension failure",
-              })
-            }),
-        ),
-        dbLayer(),
-        Layer.succeed(IssueReconciler, {
-          reconcile: () =>
-            Deferred.await(extensionAttempted).pipe(
-              Effect.as({
-                fetched: 0,
-                inserted: 0,
-                updated: 0,
-                deleted: 0,
-                unchanged: 0,
-              }),
+          Layer.mergeAll(
+            queueLayer(
+              [job],
+              (jobId) =>
+                Effect.sync(() => {
+                  acknowledged.push(jobId)
+                }),
+              undefined,
+              undefined,
+              (receivedStepRunId) =>
+                Deferred.succeed(dispatched, receivedStepRunId).pipe(
+                  Effect.as({ _tag: "noop" as const }),
+                ),
+              (jobId, timeout) =>
+                Deferred.succeed(extended, {
+                  jobId,
+                  timeoutMs: Duration.toMillis(timeout),
+                }),
+              Deferred.succeed(recovered, undefined).pipe(Effect.as(0)),
             ),
-        }),
-        keymaxxerLayer(),
-        Logger.layer([logger]),
-      ),
-    )
-  })
-
-  test("rechecks orphan recovery while the worker is running", async () => {
-    let recoveryCalls = 0
-    const recoveredTwice = await Effect.runPromise(Deferred.make<void>())
-    const recover = Effect.gen(function* () {
-      recoveryCalls += 1
-      if (recoveryCalls === 2) {
-        yield* Deferred.succeed(recoveredTwice, undefined)
-      }
-      return 0
-    })
-
-    await runScoped(
-      Effect.gen(function* () {
-        yield* runJobWorker({
-          idlePollInterval: Duration.zero,
-          orphanRecoveryInterval: Duration.zero,
-        }).pipe(Effect.forkScoped({ startImmediately: true }))
-        yield* Deferred.await(recoveredTwice).pipe(Effect.timeout("100 millis"))
-        expect(recoveryCalls).toBeGreaterThanOrEqual(2)
-      }),
-      Layer.mergeAll(
-        defaultGithubLayer,
-        queueLayer(
-          [],
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          recover,
-        ),
-        dbLayer(),
-        Layer.succeed(IssueReconciler, { reconcile: unused }),
-        keymaxxerLayer(),
-      ),
-    )
-  })
-
-  test("reconciles the Issue store and acknowledges after success", async () => {
-    const jobs: RawJob[] = []
-    let job: RawJob | undefined
-    const acknowledged = await Effect.runPromise(Deferred.make<string>())
-    const queue = queueLayer(jobs, (jobId) =>
-      Deferred.succeed(acknowledged, jobId),
-    )
-    const database = DbServiceLive.pipe(Layer.provideMerge(DatabaseTest))
-    const github = Layer.succeed(GitHubService, {
-      getOpenPullRequestNumber: () => Effect.succeed(1),
-      findOpenPullRequestNumber: () => Effect.succeed(1),
-      createDraftPullRequest: () => Effect.succeed(1),
-      updateOpenDraftPullRequestCopy: () => Effect.succeed(1),
-      countOpenNonDraftPullRequests: () => Effect.succeed(0),
-      getPullRequestCheckStatus: () =>
-        Effect.succeed({
-          _tag: "succeeded",
-          terminalChecks: [],
-          mergeability: "mergeable",
-          baseRefName: "main",
-          headPushedAt: null,
-          headSha: null,
-          createdAt: null,
-          isDraft: null,
-        }),
-      getPrStatusCheckDiagnostics: () => Effect.succeed([]),
-      observeAutomatedReviewEvidence: () =>
-        Effect.succeed({
-          _tag: "ambiguous" as const,
-          reason: "Automated review evidence observation is not configured",
-        }),
-      getPullRequestLifecycleStatus: () =>
-        Effect.succeed({ _tag: "open" as const }),
-      markPullRequestReadyForReview: () => Effect.void,
-      mergePullRequest: () => Effect.succeed({ _tag: "merged" }),
-      rerunWorkflowRun: () => Effect.void,
-      ensureIssueCompletedWithSummary: () => Effect.void,
-      getAuthenticatedUserLogin: () => Effect.succeed("test-operator"),
-      listReadyIssues: () =>
-        Effect.succeed([
-          {
-            number: 57,
-            title: "Execute queued Refresh Jobs in Harness",
-            body: "Worker acceptance criteria",
-            url: "https://github.com/acme/widgets/issues/57",
-            createdAt: new Date("2026-07-14T00:00:00.000Z"),
-            state: "OPEN" as const,
-            author: "test-operator",
-            parent: null,
-            parentPosition: null,
-            hasChildren: false,
-            hierarchySupported: true,
-            blockedBy: [],
-            closingPullRequests: [],
-          },
-        ]),
-    } satisfies GitHubServiceShape)
-    const reconciler = IssueReconcilerLive.pipe(
-      Layer.provideMerge(database),
-      Layer.provideMerge(github),
-      Layer.provideMerge(defaultGitlabLayer),
-    )
-    const layer = Layer.mergeAll(
-      database,
-      reconciler,
-      queue,
-      keymaxxerLayer(),
-      defaultGithubLayer,
-    )
-
-    await runScoped(
-      Effect.gen(function* () {
-        const db = yield* DbService
-        const added = yield* db.addRepository({
-          forge: repository.forge,
-          forgeHost: repository.forgeHost,
-          projectPath: repository.projectPath,
-          localPath: repository.localPath,
-          isBare: true,
-        })
-        job = rawJob({
-          _tag: "refresh-repository",
-          repositoryId: RepositoryId.make(added.id),
-        })
-        jobs.push(job)
-
-        yield* runJobWorker({ idlePollInterval: Duration.zero }).pipe(
-          Effect.forkScoped({ startImmediately: true }),
+            dbLayer(),
+            Layer.succeed(IssueReconciler, { reconcile: unused }),
+            keymaxxerLayer(),
+          ),
         )
-        expect(yield* Deferred.await(acknowledged)).toBe(job.jobId)
-        const issues = yield* db.listIssues(added.id)
-        expect(issues.map(({ issueNumber }) => issueNumber)).toEqual([57])
       }),
-      layer,
-    )
-  })
+  )
 
-  test("marks malformed and unknown payloads terminal", async () => {
-    for (const { payload, queue } of [
-      {
-        payload: { _tag: "refresh-repository", repositoryId: "invalid" },
-        queue: ISSUE_REFRESH_QUEUE,
-      },
-      {
-        payload: { _tag: "unknown-job", repositoryId: repository.id },
-        queue: ISSUE_REFRESH_QUEUE,
-      },
-      {
-        payload: { _tag: "unknown-job", stepRunId: "srun-bad" },
-        queue: JOBS_QUEUE,
-      },
-    ]) {
-      const job = rawJob(payload, queue)
-      const failed = await Effect.runPromise(Deferred.make<string>())
-      await runScoped(
+  it.live("skips a stale Lifecycle Job and processes a later delivery", () =>
+    Effect.gen(function* () {
+      const staleStepRunId = makeStepRunId()
+      const laterStepRunId = makeStepRunId()
+      const staleJob = rawJob(
+        WorkItemStepJob.make({ stepRunId: staleStepRunId }),
+        JOBS_QUEUE,
+      )
+      const laterJob = rawJob(
+        WorkItemStepJob.make({ stepRunId: laterStepRunId }),
+        JOBS_QUEUE,
+      )
+      const processed = yield* Deferred.make<string>()
+      const extendedJobIds: string[] = []
+      const dispatchedStepRunIds: string[] = []
+
+      yield* runScoped(
         Effect.gen(function* () {
           yield* runJobWorker({ idlePollInterval: Duration.zero }).pipe(
             Effect.forkScoped({ startImmediately: true }),
           )
-          expect(yield* Deferred.await(failed)).toBe(job.jobId)
+          expect(
+            yield* Deferred.await(processed).pipe(Effect.timeout("100 millis")),
+          ).toBe(laterStepRunId)
+          expect(extendedJobIds).toEqual([staleJob.jobId, laterJob.jobId])
+          expect(dispatchedStepRunIds).toEqual([laterStepRunId])
         }),
         Layer.mergeAll(
           defaultGithubLayer,
-          queueLayer([job], undefined, (jobId) =>
-            Deferred.succeed(failed, jobId),
+          queueLayer(
+            [staleJob, laterJob],
+            undefined,
+            undefined,
+            undefined,
+            (stepRunId) =>
+              Effect.gen(function* () {
+                dispatchedStepRunIds.push(stepRunId)
+                yield* Deferred.succeed(processed, stepRunId)
+                return { _tag: "noop" as const }
+              }),
+            (jobId) =>
+              Effect.gen(function* () {
+                extendedJobIds.push(jobId)
+                if (jobId === staleJob.jobId) {
+                  return yield* new JobNotFoundError({ jobId })
+                }
+              }),
           ),
           dbLayer(),
           Layer.succeed(IssueReconciler, { reconcile: unused }),
           keymaxxerLayer(),
         ),
       )
-    }
-  })
+    }),
+  )
 
-  test("publishes Issues-changed invalidation only after successful reconciliation", async () => {
-    const successJob = rawJob(refreshPayload)
-    const failureJob = rawJob(refreshPayload)
-    const acknowledged = await Effect.runPromise(Deferred.make<string>())
-    const failed = await Effect.runPromise(Deferred.make<string>())
-    const notifications: string[] = []
-    let calls = 0
-    const reconciler = Layer.succeed(IssueReconciler, {
-      reconcile: () =>
+  it.live(
+    "keeps Issue refresh operational and logs context after a Lifecycle lease extension failure",
+    () =>
+      Effect.gen(function* () {
+        const stepRunId = makeStepRunId()
+        const lifecycleJob = rawJob(
+          WorkItemStepJob.make({ stepRunId }),
+          JOBS_QUEUE,
+        )
+        const refreshJob = rawJob(refreshPayload)
+        const extensionAttempted = yield* Deferred.make<void>()
+        const refreshAcknowledged = yield* Deferred.make<string>()
+        const dispatchedStepRunIds: string[] = []
+        const logs: unknown[] = []
+        const logger = Logger.make(({ message }) => {
+          logs.push(message)
+        })
+
+        yield* runScoped(
+          Effect.gen(function* () {
+            yield* runJobWorker({ idlePollInterval: Duration.zero }).pipe(
+              Effect.forkScoped({ startImmediately: true }),
+            )
+            expect(
+              yield* Deferred.await(refreshAcknowledged).pipe(
+                Effect.timeout("100 millis"),
+              ),
+            ).toBe(refreshJob.jobId)
+            expect(dispatchedStepRunIds).toEqual([])
+            expect(logs).toContainEqual([
+              "Lifecycle Job lease extension failed",
+              expect.objectContaining({
+                jobId: lifecycleJob.jobId,
+                stepRunId,
+                error: "temporary lease extension failure",
+              }),
+            ])
+          }),
+          Layer.mergeAll(
+            defaultGithubLayer,
+            queueLayer(
+              [lifecycleJob, refreshJob],
+              (jobId) => Deferred.succeed(refreshAcknowledged, jobId),
+              undefined,
+              undefined,
+              (receivedStepRunId) =>
+                Effect.sync(() => {
+                  dispatchedStepRunIds.push(receivedStepRunId)
+                  return { _tag: "noop" as const }
+                }),
+              (jobId) =>
+                Effect.gen(function* () {
+                  yield* Deferred.succeed(extensionAttempted, undefined)
+                  return yield* new AcknowledgeError({
+                    jobId,
+                    message: "temporary lease extension failure",
+                  })
+                }),
+            ),
+            dbLayer(),
+            Layer.succeed(IssueReconciler, {
+              reconcile: () =>
+                Deferred.await(extensionAttempted).pipe(
+                  Effect.as({
+                    fetched: 0,
+                    inserted: 0,
+                    updated: 0,
+                    deleted: 0,
+                    unchanged: 0,
+                  }),
+                ),
+            }),
+            keymaxxerLayer(),
+            Logger.layer([logger]),
+          ),
+        )
+      }),
+  )
+
+  it.live("rechecks orphan recovery while the worker is running", () =>
+    Effect.gen(function* () {
+      let recoveryCalls = 0
+      const recoveredTwice = yield* Deferred.make<void>()
+      const recover = Effect.gen(function* () {
+        recoveryCalls += 1
+        if (recoveryCalls === 2) {
+          yield* Deferred.succeed(recoveredTwice, undefined)
+        }
+        return 0
+      })
+
+      yield* runScoped(
         Effect.gen(function* () {
-          calls += 1
-          if (calls === 1) {
+          yield* runJobWorker({
+            idlePollInterval: Duration.zero,
+            orphanRecoveryInterval: Duration.zero,
+          }).pipe(Effect.forkScoped({ startImmediately: true }))
+          yield* Deferred.await(recoveredTwice).pipe(
+            Effect.timeout("100 millis"),
+          )
+          expect(recoveryCalls).toBeGreaterThanOrEqual(2)
+        }),
+        Layer.mergeAll(
+          defaultGithubLayer,
+          queueLayer(
+            [],
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            recover,
+          ),
+          dbLayer(),
+          Layer.succeed(IssueReconciler, { reconcile: unused }),
+          keymaxxerLayer(),
+        ),
+      )
+    }),
+  )
+
+  it.live("reconciles the Issue store and acknowledges after success", () =>
+    Effect.gen(function* () {
+      const jobs: RawJob[] = []
+      let job: RawJob | undefined
+      const acknowledged = yield* Deferred.make<string>()
+      const queue = queueLayer(jobs, (jobId) =>
+        Deferred.succeed(acknowledged, jobId),
+      )
+      const database = DbServiceLive.pipe(Layer.provideMerge(DatabaseTest))
+      const github = Layer.succeed(GitHubService, {
+        getOpenPullRequestNumber: () => Effect.succeed(1),
+        findOpenPullRequestNumber: () => Effect.succeed(1),
+        createDraftPullRequest: () => Effect.succeed(1),
+        updateOpenDraftPullRequestCopy: () => Effect.succeed(1),
+        countOpenNonDraftPullRequests: () => Effect.succeed(0),
+        getPullRequestCheckStatus: () =>
+          Effect.succeed({
+            _tag: "succeeded",
+            terminalChecks: [],
+            mergeability: "mergeable",
+            baseRefName: "main",
+            headPushedAt: null,
+            headSha: null,
+            createdAt: null,
+            isDraft: null,
+          }),
+        getPrStatusCheckDiagnostics: () => Effect.succeed([]),
+        observeAutomatedReviewEvidence: () =>
+          Effect.succeed({
+            _tag: "ambiguous" as const,
+            reason: "Automated review evidence observation is not configured",
+          }),
+        getPullRequestLifecycleStatus: () =>
+          Effect.succeed({ _tag: "open" as const }),
+        markPullRequestReadyForReview: () => Effect.void,
+        mergePullRequest: () => Effect.succeed({ _tag: "merged" }),
+        rerunWorkflowRun: () => Effect.void,
+        ensureIssueCompletedWithSummary: () => Effect.void,
+        getAuthenticatedUserLogin: () => Effect.succeed("test-operator"),
+        listReadyIssues: () =>
+          Effect.succeed([
+            {
+              number: 57,
+              title: "Execute queued Refresh Jobs in Harness",
+              body: "Worker acceptance criteria",
+              url: "https://github.com/acme/widgets/issues/57",
+              createdAt: new Date("2026-07-14T00:00:00.000Z"),
+              state: "OPEN" as const,
+              author: "test-operator",
+              parent: null,
+              parentPosition: null,
+              hasChildren: false,
+              hierarchySupported: true,
+              blockedBy: [],
+              closingPullRequests: [],
+            },
+          ]),
+      } satisfies GitHubServiceShape)
+      const reconciler = IssueReconcilerLive.pipe(
+        Layer.provideMerge(database),
+        Layer.provideMerge(github),
+        Layer.provideMerge(defaultGitlabLayer),
+      )
+      const layer = Layer.mergeAll(
+        database,
+        reconciler,
+        queue,
+        keymaxxerLayer(),
+        defaultGithubLayer,
+      )
+
+      yield* runScoped(
+        Effect.gen(function* () {
+          const db = yield* DbService
+          const added = yield* db.addRepository({
+            forge: repository.forge,
+            forgeHost: repository.forgeHost,
+            projectPath: repository.projectPath,
+            localPath: repository.localPath,
+            isBare: true,
+          })
+          job = rawJob({
+            _tag: "refresh-repository",
+            repositoryId: RepositoryId.make(added.id),
+          })
+          jobs.push(job)
+
+          yield* runJobWorker({ idlePollInterval: Duration.zero }).pipe(
+            Effect.forkScoped({ startImmediately: true }),
+          )
+          expect(yield* Deferred.await(acknowledged)).toBe(job.jobId)
+          const issues = yield* db.listIssues(added.id)
+          expect(issues.map(({ issueNumber }) => issueNumber)).toEqual([57])
+        }),
+        layer,
+      )
+    }),
+  )
+
+  it.live("marks malformed and unknown payloads terminal", () =>
+    Effect.gen(function* () {
+      for (const { payload, queue } of [
+        {
+          payload: { _tag: "refresh-repository", repositoryId: "invalid" },
+          queue: ISSUE_REFRESH_QUEUE,
+        },
+        {
+          payload: { _tag: "unknown-job", repositoryId: repository.id },
+          queue: ISSUE_REFRESH_QUEUE,
+        },
+        {
+          payload: { _tag: "unknown-job", stepRunId: "srun-bad" },
+          queue: JOBS_QUEUE,
+        },
+      ]) {
+        const job = rawJob(payload, queue)
+        const failed = yield* Deferred.make<string>()
+        yield* runScoped(
+          Effect.gen(function* () {
+            yield* runJobWorker({ idlePollInterval: Duration.zero }).pipe(
+              Effect.forkScoped({ startImmediately: true }),
+            )
+            expect(yield* Deferred.await(failed)).toBe(job.jobId)
+          }),
+          Layer.mergeAll(
+            defaultGithubLayer,
+            queueLayer([job], undefined, (jobId) =>
+              Deferred.succeed(failed, jobId),
+            ),
+            dbLayer(),
+            Layer.succeed(IssueReconciler, { reconcile: unused }),
+            keymaxxerLayer(),
+          ),
+        )
+      }
+    }),
+  )
+
+  it.live(
+    "publishes Issues-changed invalidation only after successful reconciliation",
+    () =>
+      Effect.gen(function* () {
+        const successJob = rawJob(refreshPayload)
+        const failureJob = rawJob(refreshPayload)
+        const acknowledged = yield* Deferred.make<string>()
+        const failed = yield* Deferred.make<string>()
+        const notifications: string[] = []
+        let calls = 0
+        const reconciler = Layer.succeed(IssueReconciler, {
+          reconcile: () =>
+            Effect.gen(function* () {
+              calls += 1
+              if (calls === 1) {
+                return {
+                  fetched: 0,
+                  inserted: 0,
+                  updated: 0,
+                  deleted: 0,
+                  unchanged: 0,
+                }
+              }
+              return yield* new DatabaseError({
+                message: "reconciliation failed",
+              })
+            }),
+        } satisfies IssueReconcilerShape)
+
+        yield* runScoped(
+          Effect.gen(function* () {
+            yield* runJobWorker({ idlePollInterval: Duration.zero }).pipe(
+              Effect.forkScoped({ startImmediately: true }),
+            )
+            expect(yield* Deferred.await(acknowledged)).toBe(successJob.jobId)
+            expect(notifications).toEqual([repository.id])
+            expect(yield* Deferred.await(failed)).toBe(failureJob.jobId)
+            expect(notifications).toEqual([repository.id])
+          }),
+          Layer.mergeAll(
+            defaultGithubLayer,
+            queueLayer(
+              [successJob, failureJob],
+              (jobId) => Deferred.succeed(acknowledged, jobId),
+              (jobId) => Deferred.succeed(failed, jobId),
+            ),
+            dbLayer([repository], (repositoryId) =>
+              Effect.sync(() => {
+                notifications.push(repositoryId)
+              }),
+            ),
+            reconciler,
+            keymaxxerLayer(),
+          ),
+        )
+      }),
+  )
+
+  it.live("delivers only successful worker invalidations through GraphQL", () =>
+    Effect.gen(function* () {
+      const jobs: RawJob[] = []
+      const acknowledged = yield* Deferred.make<string>()
+      const failed = yield* Deferred.make<string>()
+      let reconciliations = 0
+      const database = DbServiceLive.pipe(Layer.provideMerge(DatabaseTest))
+      const queue = queueLayer(
+        jobs,
+        (jobId) => Deferred.succeed(acknowledged, jobId),
+        (jobId) => Deferred.succeed(failed, jobId),
+      )
+      const reconciler = Layer.succeed(IssueReconciler, {
+        reconcile: () =>
+          Effect.gen(function* () {
+            reconciliations += 1
+            if (reconciliations === 2) {
+              return yield* new DatabaseError({
+                message: "reconciliation failed",
+              })
+            }
             return {
               fetched: 0,
               inserted: 0,
@@ -791,117 +878,67 @@ describe("Job worker", () => {
               deleted: 0,
               unchanged: 0,
             }
-          }
-          return yield* new DatabaseError({
-            message: "reconciliation failed",
-          })
-        }),
-    } satisfies IssueReconcilerShape)
-
-    await runScoped(
-      Effect.gen(function* () {
-        yield* runJobWorker({ idlePollInterval: Duration.zero }).pipe(
-          Effect.forkScoped({ startImmediately: true }),
-        )
-        expect(yield* Deferred.await(acknowledged)).toBe(successJob.jobId)
-        expect(notifications).toEqual([repository.id])
-        expect(yield* Deferred.await(failed)).toBe(failureJob.jobId)
-        expect(notifications).toEqual([repository.id])
-      }),
-      Layer.mergeAll(
-        defaultGithubLayer,
-        queueLayer(
-          [successJob, failureJob],
-          (jobId) => Deferred.succeed(acknowledged, jobId),
-          (jobId) => Deferred.succeed(failed, jobId),
+          }),
+      } satisfies IssueReconcilerShape)
+      const sessionStore = Layer.succeed(OpencodeSessionStore, {
+        getSession: (id) =>
+          Effect.succeed({
+            id,
+            availability: "missing" as const,
+            model: null,
+            tokens: null,
+            cost: null,
+            createdAt: null,
+            updatedAt: null,
+          }),
+      })
+      const localGit = Layer.succeed(LocalGit, {
+        inspect: () =>
+          Effect.die("local git not used in issue subscription test"),
+      })
+      const directoryPicker = Layer.succeed(DirectoryPicker, {
+        available: Effect.succeed(false),
+        pick: Effect.succeed(null),
+      })
+      const controller = new AbortController()
+      // Scope finalizer always aborts the subscription and disposes the runtime
+      // (JS try/finally + yield* does not run on Effect failure).
+      const runtime = yield* Effect.acquireRelease(
+        Effect.sync(() =>
+          ManagedRuntime.make(
+            Layer.mergeAll(
+              database,
+              queue,
+              reconciler,
+              keymaxxerLayer(),
+              Layer.succeed(ActiveAgentBackend, stubActiveAgentBackend()),
+              sessionStore,
+              defaultGithubLayer,
+              localGit,
+              directoryPicker,
+            ),
+          ),
         ),
-        dbLayer([repository], (repositoryId) =>
-          Effect.sync(() => {
-            notifications.push(repositoryId)
+        (managed) =>
+          Effect.promise(() => {
+            controller.abort()
+            return managed.dispose()
+          }),
+      )
+
+      const added = yield* Effect.promise(() =>
+        runtime.runPromise(
+          Effect.gen(function* () {
+            const db = yield* DbService
+            return yield* db.addRepository({
+              forge: repository.forge,
+              forgeHost: repository.forgeHost,
+              projectPath: repository.projectPath,
+              localPath: repository.localPath,
+              isBare: true,
+            })
           }),
         ),
-        reconciler,
-        keymaxxerLayer(),
-      ),
-    )
-  })
-
-  test("delivers only successful worker invalidations through GraphQL", async () => {
-    const jobs: RawJob[] = []
-    const acknowledged = await Effect.runPromise(Deferred.make<string>())
-    const failed = await Effect.runPromise(Deferred.make<string>())
-    let reconciliations = 0
-    const database = DbServiceLive.pipe(Layer.provideMerge(DatabaseTest))
-    const queue = queueLayer(
-      jobs,
-      (jobId) => Deferred.succeed(acknowledged, jobId),
-      (jobId) => Deferred.succeed(failed, jobId),
-    )
-    const reconciler = Layer.succeed(IssueReconciler, {
-      reconcile: () =>
-        Effect.gen(function* () {
-          reconciliations += 1
-          if (reconciliations === 2) {
-            return yield* new DatabaseError({
-              message: "reconciliation failed",
-            })
-          }
-          return {
-            fetched: 0,
-            inserted: 0,
-            updated: 0,
-            deleted: 0,
-            unchanged: 0,
-          }
-        }),
-    } satisfies IssueReconcilerShape)
-    const sessionStore = Layer.succeed(OpencodeSessionStore, {
-      getSession: (id) =>
-        Effect.succeed({
-          id,
-          availability: "missing" as const,
-          model: null,
-          tokens: null,
-          cost: null,
-          createdAt: null,
-          updatedAt: null,
-        }),
-    })
-    const localGit = Layer.succeed(LocalGit, {
-      inspect: () =>
-        Effect.die("local git not used in issue subscription test"),
-    })
-    const directoryPicker = Layer.succeed(DirectoryPicker, {
-      available: Effect.succeed(false),
-      pick: Effect.succeed(null),
-    })
-    const runtime = ManagedRuntime.make(
-      Layer.mergeAll(
-        database,
-        queue,
-        reconciler,
-        keymaxxerLayer(),
-        Layer.succeed(ActiveAgentBackend, stubActiveAgentBackend()),
-        sessionStore,
-        defaultGithubLayer,
-        localGit,
-        directoryPicker,
-      ),
-    )
-    const controller = new AbortController()
-
-    try {
-      const added = await runtime.runPromise(
-        Effect.gen(function* () {
-          const db = yield* DbService
-          return yield* db.addRepository({
-            forge: repository.forge,
-            forgeHost: repository.forgeHost,
-            projectPath: repository.projectPath,
-            localPath: repository.localPath,
-            isBare: true,
-          })
-        }),
       )
       const successJob = rawJob({
         _tag: "refresh-repository",
@@ -913,24 +950,27 @@ describe("Job worker", () => {
       })
       jobs.push(successJob, failureJob)
 
-      const response = await createGraphqlApi(runtime).fetch(
-        new Request("http://127.0.0.1:6056/graphql", {
-          method: "POST",
-          headers: {
-            accept: "text/event-stream",
-            "content-type": "application/json",
-          },
-          body: JSON.stringify({
-            query: `subscription {
+      const response = yield* Effect.promise(() =>
+        createGraphqlApi(runtime).fetch(
+          new Request("http://127.0.0.1:6056/graphql", {
+            method: "POST",
+            headers: {
+              accept: "text/event-stream",
+              "content-type": "application/json",
+            },
+            body: JSON.stringify({
+              query: `subscription {
               issuesChanged(repositoryId: "${added.id}")
             }`,
+            }),
+            signal: controller.signal,
           }),
-          signal: controller.signal,
-        }),
+        ),
       )
       const reader = response.body?.getReader()
       if (reader === undefined) throw new Error("Subscription has no body")
 
+      // Keep Promise/await in a plain async IIFE — not inside Effect.gen.
       const invalidation = (async () => {
         let event = ""
         const decoder = new TextDecoder()
@@ -943,1361 +983,1435 @@ describe("Job worker", () => {
         }
         return event
       })()
-      await Bun.sleep(0)
-      runtime.runFork(runJobWorker())
+      yield* Effect.sleep("0 millis")
+      yield* Effect.sync(() => runtime.runFork(runJobWorker()))
 
-      expect(await runtime.runPromise(Deferred.await(acknowledged))).toBe(
-        successJob.jobId,
+      expect(
+        yield* Effect.promise(() =>
+          runtime.runPromise(Deferred.await(acknowledged)),
+        ),
+      ).toBe(successJob.jobId)
+      expect(yield* Effect.promise(() => invalidation)).toContain(
+        '"data":{"issuesChanged":true}',
       )
-      expect(await invalidation).toContain('"data":{"issuesChanged":true}')
 
-      expect(await runtime.runPromise(Deferred.await(failed))).toBe(
-        failureJob.jobId,
-      )
+      expect(
+        yield* Effect.promise(() => runtime.runPromise(Deferred.await(failed))),
+      ).toBe(failureJob.jobId)
       const secondEvent = reader
         .read()
         .then(({ value }) =>
           value === undefined ? "" : new TextDecoder().decode(value),
         )
         .catch(() => "")
-      const unexpectedInvalidation = await Promise.race([
-        secondEvent.then((chunk) =>
-          chunk.includes('"data":{"issuesChanged":true}'),
+      const unexpectedInvalidation = yield* Effect.race(
+        Effect.promise(() =>
+          secondEvent.then((chunk) =>
+            chunk.includes('"data":{"issuesChanged":true}'),
+          ),
         ),
-        Bun.sleep(20).then(() => false),
-      ])
+        Effect.sleep("20 millis").pipe(Effect.as(false)),
+      )
       expect(unexpectedInvalidation).toBe(false)
-    } finally {
-      controller.abort()
-      await runtime.dispose()
-    }
-  })
+    }),
+  )
 
-  test("marks a caught Refresh Job failure terminal", async () => {
-    const job = rawJob(refreshPayload)
-    const failed = await Effect.runPromise(Deferred.make<string>())
-    const reconciler = Layer.succeed(IssueReconciler, {
-      reconcile: () =>
-        Effect.fail(new DatabaseError({ message: "reconciliation failed" })),
-    } satisfies IssueReconcilerShape)
+  it.live("marks a caught Refresh Job failure terminal", () =>
+    Effect.gen(function* () {
+      const job = rawJob(refreshPayload)
+      const failed = yield* Deferred.make<string>()
+      const reconciler = Layer.succeed(IssueReconciler, {
+        reconcile: () =>
+          Effect.fail(new DatabaseError({ message: "reconciliation failed" })),
+      } satisfies IssueReconcilerShape)
 
-    await runScoped(
-      Effect.gen(function* () {
-        yield* runJobWorker({ idlePollInterval: Duration.zero }).pipe(
-          Effect.forkScoped({ startImmediately: true }),
-        )
-        expect(yield* Deferred.await(failed)).toBe(job.jobId)
-      }),
-      Layer.mergeAll(
-        defaultGithubLayer,
-        queueLayer([job], undefined, (jobId) =>
-          Deferred.succeed(failed, jobId),
-        ),
-        dbLayer(),
-        reconciler,
-        keymaxxerLayer(),
-      ),
-    )
-  })
-
-  test("executes duplicate Refresh Jobs serially across repositories", async () => {
-    const jobs = [
-      rawJob(refreshPayload),
-      rawJob({
-        _tag: "refresh-repository",
-        repositoryId: RepositoryId.make(otherRepository.id),
-      }),
-    ]
-    const firstStarted = await Effect.runPromise(Deferred.make<void>())
-    const releaseFirst = await Effect.runPromise(Deferred.make<void>())
-    const secondStarted = await Effect.runPromise(Deferred.make<void>())
-    let calls = 0
-    let active = 0
-    let maximumActive = 0
-    const reconciler = Layer.succeed(IssueReconciler, {
-      reconcile: () =>
+      yield* runScoped(
         Effect.gen(function* () {
-          calls += 1
-          active += 1
-          maximumActive = Math.max(maximumActive, active)
-          if (calls === 1) {
-            yield* Deferred.succeed(firstStarted, undefined)
-            yield* Deferred.await(releaseFirst)
-          } else {
-            yield* Deferred.succeed(secondStarted, undefined)
-          }
-          active -= 1
-          return {
-            fetched: 0,
-            inserted: 0,
-            updated: 0,
-            deleted: 0,
-            unchanged: 0,
-          }
+          yield* runJobWorker({ idlePollInterval: Duration.zero }).pipe(
+            Effect.forkScoped({ startImmediately: true }),
+          )
+          expect(yield* Deferred.await(failed)).toBe(job.jobId)
         }),
-    } satisfies IssueReconcilerShape)
-
-    await runScoped(
-      Effect.gen(function* () {
-        yield* runJobWorker({ idlePollInterval: Duration.zero }).pipe(
-          Effect.forkScoped({ startImmediately: true }),
-        )
-        yield* Deferred.await(firstStarted)
-        expect(calls).toBe(1)
-        yield* Deferred.succeed(releaseFirst, undefined)
-        yield* Deferred.await(secondStarted)
-        expect(maximumActive).toBe(1)
-      }),
-      Layer.mergeAll(
-        defaultGithubLayer,
-        queueLayer(jobs),
-        dbLayer([repository, otherRepository]),
-        reconciler,
-        keymaxxerLayer(),
-      ),
-    )
-  })
-
-  test("runs Work Item lifecycle jobs while Issue refresh is active", async () => {
-    const refreshJob = rawJob(refreshPayload)
-    const stepRunId = makeStepRunId()
-    const lifecycleJob = rawJob(WorkItemStepJob.make({ stepRunId }), JOBS_QUEUE)
-    const jobs = [refreshJob, lifecycleJob]
-    const refreshStarted = await Effect.runPromise(Deferred.make<void>())
-    const releaseRefresh = await Effect.runPromise(Deferred.make<void>())
-    const lifecycleDispatched = await Effect.runPromise(Deferred.make<string>())
-    const lifecycleLeaseExtended = await Effect.runPromise(
-      Deferred.make<string>(),
-    )
-    let refreshActiveDuringLifecycle = false
-
-    const reconciler = Layer.succeed(IssueReconciler, {
-      reconcile: () =>
-        Effect.gen(function* () {
-          yield* Deferred.succeed(refreshStarted, undefined)
-          yield* Deferred.await(releaseRefresh)
-          return {
-            fetched: 0,
-            inserted: 0,
-            updated: 0,
-            deleted: 0,
-            unchanged: 0,
-          }
-        }),
-    } satisfies IssueReconcilerShape)
-
-    await runScoped(
-      Effect.gen(function* () {
-        yield* runJobWorker({ idlePollInterval: Duration.zero }).pipe(
-          Effect.forkScoped({ startImmediately: true }),
-        )
-        yield* Deferred.await(refreshStarted)
-        expect(yield* Deferred.await(lifecycleDispatched)).toBe(stepRunId)
-        expect(refreshActiveDuringLifecycle).toBe(true)
-        expect(yield* Deferred.await(lifecycleLeaseExtended)).toBe(
-          lifecycleJob.jobId,
-        )
-        yield* Deferred.succeed(releaseRefresh, undefined)
-      }),
-      Layer.mergeAll(
-        defaultGithubLayer,
-        queueLayer(
-          jobs,
-          undefined,
-          undefined,
-          undefined,
-          (receivedStepRunId) =>
-            Effect.gen(function* () {
-              refreshActiveDuringLifecycle = true
-              yield* Deferred.succeed(lifecycleDispatched, receivedStepRunId)
-              return { _tag: "noop" as const }
-            }),
-          (jobId) => Deferred.succeed(lifecycleLeaseExtended, jobId),
+        Layer.mergeAll(
+          defaultGithubLayer,
+          queueLayer([job], undefined, (jobId) =>
+            Deferred.succeed(failed, jobId),
+          ),
+          dbLayer(),
+          reconciler,
+          keymaxxerLayer(),
         ),
-        dbLayer(),
-        reconciler,
-        keymaxxerLayer(),
-      ),
-    )
-  })
+      )
+    }),
+  )
 
-  test("runs multiple lifecycle jobs concurrently up to Config capacity", async () => {
-    const firstStepRunId = makeStepRunId()
-    const secondStepRunId = makeStepRunId()
-    const jobs = [
-      rawJob(WorkItemStepJob.make({ stepRunId: firstStepRunId }), JOBS_QUEUE),
-      rawJob(WorkItemStepJob.make({ stepRunId: secondStepRunId }), JOBS_QUEUE),
-    ]
-    const firstStarted = await Effect.runPromise(Deferred.make<void>())
-    const secondStarted = await Effect.runPromise(Deferred.make<void>())
-    const release = await Effect.runPromise(Deferred.make<void>())
-    let active = 0
-    let maximumActive = 0
-    const seen = new Set<string>()
-
-    await runScoped(
-      Effect.gen(function* () {
-        yield* runJobWorker({ idlePollInterval: Duration.zero }).pipe(
-          Effect.forkScoped({ startImmediately: true }),
-        )
-        yield* Deferred.await(firstStarted)
-        yield* Deferred.await(secondStarted)
-        expect(maximumActive).toBe(2)
-        expect(seen).toEqual(new Set([firstStepRunId, secondStepRunId]))
-        yield* Deferred.succeed(release, undefined)
-      }),
-      Layer.mergeAll(
-        defaultGithubLayer,
-        queueLayer(jobs, undefined, undefined, undefined, (stepRunId) =>
+  it.live("executes duplicate Refresh Jobs serially across repositories", () =>
+    Effect.gen(function* () {
+      const jobs = [
+        rawJob(refreshPayload),
+        rawJob({
+          _tag: "refresh-repository",
+          repositoryId: RepositoryId.make(otherRepository.id),
+        }),
+      ]
+      const firstStarted = yield* Deferred.make<void>()
+      const releaseFirst = yield* Deferred.make<void>()
+      const secondStarted = yield* Deferred.make<void>()
+      let calls = 0
+      let active = 0
+      let maximumActive = 0
+      const reconciler = Layer.succeed(IssueReconciler, {
+        reconcile: () =>
           Effect.gen(function* () {
-            seen.add(stepRunId)
+            calls += 1
             active += 1
             maximumActive = Math.max(maximumActive, active)
-            if (stepRunId === firstStepRunId) {
+            if (calls === 1) {
               yield* Deferred.succeed(firstStarted, undefined)
+              yield* Deferred.await(releaseFirst)
             } else {
               yield* Deferred.succeed(secondStarted, undefined)
             }
-            yield* Deferred.await(release)
             active -= 1
-            return { _tag: "noop" as const }
+            return {
+              fetched: 0,
+              inserted: 0,
+              updated: 0,
+              deleted: 0,
+              unchanged: 0,
+            }
           }),
-        ),
-        dbLayer(),
-        Layer.succeed(IssueReconciler, {
-          reconcile: () =>
-            Effect.succeed({
-              fetched: 0,
-              inserted: 0,
-              updated: 0,
-              deleted: 0,
-              unchanged: 0,
-            }),
-        } satisfies IssueReconcilerShape),
-        keymaxxerLayer(),
-      ),
-    )
-  })
+      } satisfies IssueReconcilerShape)
 
-  test("recovers after a queue infrastructure error", async () => {
-    const job = rawJob(refreshPayload)
-    const acknowledged = await Effect.runPromise(Deferred.make<void>())
-    let refreshClaims = 0
-    const claim = (queueName: string) => {
-      if (queueName !== ISSUE_REFRESH_QUEUE) {
-        return Effect.succeed(Option.none())
-      }
-      refreshClaims += 1
-      return refreshClaims === 1
-        ? Effect.fail(
-            new ClaimError({
-              queue: ISSUE_REFRESH_QUEUE,
-              message: "temporarily down",
-            }),
+      yield* runScoped(
+        Effect.gen(function* () {
+          yield* runJobWorker({ idlePollInterval: Duration.zero }).pipe(
+            Effect.forkScoped({ startImmediately: true }),
           )
-        : Effect.succeed(refreshClaims === 2 ? Option.some(job) : Option.none())
-    }
-
-    await runScoped(
-      Effect.gen(function* () {
-        yield* runJobWorker({ idlePollInterval: Duration.zero }).pipe(
-          Effect.forkScoped({ startImmediately: true }),
-        )
-        yield* Deferred.await(acknowledged)
-        expect(refreshClaims).toBe(2)
-      }),
-      Layer.mergeAll(
-        defaultGithubLayer,
-        queueLayer(
-          [],
-          () => Deferred.succeed(acknowledged, undefined),
-          undefined,
-          claim,
+          yield* Deferred.await(firstStarted)
+          expect(calls).toBe(1)
+          yield* Deferred.succeed(releaseFirst, undefined)
+          yield* Deferred.await(secondStarted)
+          expect(maximumActive).toBe(1)
+        }),
+        Layer.mergeAll(
+          defaultGithubLayer,
+          queueLayer(jobs),
+          dbLayer([repository, otherRepository]),
+          reconciler,
+          keymaxxerLayer(),
         ),
-        dbLayer(),
-        Layer.succeed(IssueReconciler, {
-          reconcile: () =>
-            Effect.succeed({
+      )
+    }),
+  )
+
+  it.live("runs Work Item lifecycle jobs while Issue refresh is active", () =>
+    Effect.gen(function* () {
+      const refreshJob = rawJob(refreshPayload)
+      const stepRunId = makeStepRunId()
+      const lifecycleJob = rawJob(
+        WorkItemStepJob.make({ stepRunId }),
+        JOBS_QUEUE,
+      )
+      const jobs = [refreshJob, lifecycleJob]
+      const refreshStarted = yield* Deferred.make<void>()
+      const releaseRefresh = yield* Deferred.make<void>()
+      const lifecycleDispatched = yield* Deferred.make<string>()
+      const lifecycleLeaseExtended = yield* Deferred.make<string>()
+      let refreshActiveDuringLifecycle = false
+
+      const reconciler = Layer.succeed(IssueReconciler, {
+        reconcile: () =>
+          Effect.gen(function* () {
+            yield* Deferred.succeed(refreshStarted, undefined)
+            yield* Deferred.await(releaseRefresh)
+            return {
               fetched: 0,
               inserted: 0,
               updated: 0,
               deleted: 0,
               unchanged: 0,
-            }),
+            }
+          }),
+      } satisfies IssueReconcilerShape)
+
+      yield* runScoped(
+        Effect.gen(function* () {
+          yield* runJobWorker({ idlePollInterval: Duration.zero }).pipe(
+            Effect.forkScoped({ startImmediately: true }),
+          )
+          yield* Deferred.await(refreshStarted)
+          expect(yield* Deferred.await(lifecycleDispatched)).toBe(stepRunId)
+          expect(refreshActiveDuringLifecycle).toBe(true)
+          expect(yield* Deferred.await(lifecycleLeaseExtended)).toBe(
+            lifecycleJob.jobId,
+          )
+          yield* Deferred.succeed(releaseRefresh, undefined)
         }),
-        keymaxxerLayer(),
-      ),
-    )
-  })
-
-  test("scope disposal interrupts an active Job without queue finalization", async () => {
-    const job = rawJob(refreshPayload)
-    const started = await Effect.runPromise(Deferred.make<void>())
-    const interrupted = await Effect.runPromise(Deferred.make<void>())
-    let finalized = false
-    const reconciler = Layer.succeed(IssueReconciler, {
-      reconcile: () =>
-        Deferred.succeed(started, undefined).pipe(
-          Effect.andThen(Effect.never),
-          Effect.ensuring(
-            Deferred.succeed(interrupted, undefined).pipe(Effect.asVoid),
+        Layer.mergeAll(
+          defaultGithubLayer,
+          queueLayer(
+            jobs,
+            undefined,
+            undefined,
+            undefined,
+            (receivedStepRunId) =>
+              Effect.gen(function* () {
+                refreshActiveDuringLifecycle = true
+                yield* Deferred.succeed(lifecycleDispatched, receivedStepRunId)
+                return { _tag: "noop" as const }
+              }),
+            (jobId) => Deferred.succeed(lifecycleLeaseExtended, jobId),
           ),
+          dbLayer(),
+          reconciler,
+          keymaxxerLayer(),
         ),
-    } satisfies IssueReconcilerShape)
+      )
+    }),
+  )
 
-    await runScoped(
+  it.live(
+    "runs multiple lifecycle jobs concurrently up to Config capacity",
+    () =>
       Effect.gen(function* () {
-        yield* Effect.scoped(
+        const firstStepRunId = makeStepRunId()
+        const secondStepRunId = makeStepRunId()
+        const jobs = [
+          rawJob(
+            WorkItemStepJob.make({ stepRunId: firstStepRunId }),
+            JOBS_QUEUE,
+          ),
+          rawJob(
+            WorkItemStepJob.make({ stepRunId: secondStepRunId }),
+            JOBS_QUEUE,
+          ),
+        ]
+        const firstStarted = yield* Deferred.make<void>()
+        const secondStarted = yield* Deferred.make<void>()
+        const release = yield* Deferred.make<void>()
+        let active = 0
+        let maximumActive = 0
+        const seen = new Set<string>()
+
+        yield* runScoped(
           Effect.gen(function* () {
             yield* runJobWorker({ idlePollInterval: Duration.zero }).pipe(
               Effect.forkScoped({ startImmediately: true }),
             )
-            yield* Deferred.await(started)
+            yield* Deferred.await(firstStarted)
+            yield* Deferred.await(secondStarted)
+            expect(maximumActive).toBe(2)
+            expect(seen).toEqual(new Set([firstStepRunId, secondStepRunId]))
+            yield* Deferred.succeed(release, undefined)
           }),
+          Layer.mergeAll(
+            defaultGithubLayer,
+            queueLayer(jobs, undefined, undefined, undefined, (stepRunId) =>
+              Effect.gen(function* () {
+                seen.add(stepRunId)
+                active += 1
+                maximumActive = Math.max(maximumActive, active)
+                if (stepRunId === firstStepRunId) {
+                  yield* Deferred.succeed(firstStarted, undefined)
+                } else {
+                  yield* Deferred.succeed(secondStarted, undefined)
+                }
+                yield* Deferred.await(release)
+                active -= 1
+                return { _tag: "noop" as const }
+              }),
+            ),
+            dbLayer(),
+            Layer.succeed(IssueReconciler, {
+              reconcile: () =>
+                Effect.succeed({
+                  fetched: 0,
+                  inserted: 0,
+                  updated: 0,
+                  deleted: 0,
+                  unchanged: 0,
+                }),
+            } satisfies IssueReconcilerShape),
+            keymaxxerLayer(),
+          ),
         )
-        yield* Deferred.await(interrupted)
-        expect(finalized).toBe(false)
       }),
-      Layer.mergeAll(
-        defaultGithubLayer,
-        queueLayer(
-          [job],
-          () => Effect.sync(() => (finalized = true)),
-          () => Effect.sync(() => (finalized = true)),
-        ),
-        dbLayer(),
-        reconciler,
-        keymaxxerLayer(),
-      ),
-    )
-  })
+  )
 
-  test("transfers persisted Refresh Jobs into the issue-refresh queue once", async () => {
-    const database = DbServiceLive.pipe(Layer.provideMerge(DatabaseTest))
-    const queue = SqliteQueueServiceLive.pipe(Layer.provideMerge(database))
-    const layer = Layer.mergeAll(database, queue)
-
-    await Effect.runPromise(
-      Effect.gen(function* () {
-        const service = yield* QueueService
-        const retainedId = yield* service.enqueue(
-          JOBS_QUEUE,
-          {
-            _tag: "refresh-repository",
-            repositoryId: RepositoryId.make(repository.id),
-          },
-          { retryLimit: JOB_RECOVERY_RETRY_LIMIT },
-        )
-        const lifecycleId = yield* service.enqueue(
-          JOBS_QUEUE,
-          WorkItemStepJob.make({ stepRunId: makeStepRunId() }),
-          { retryLimit: JOB_RECOVERY_RETRY_LIMIT },
-        )
-
-        const moved = yield* transferPersistedRefreshJobs
-        expect(moved).toBe(1)
-        const movedAgain = yield* transferPersistedRefreshJobs
-        expect(movedAgain).toBe(0)
-
-        const fromLifecycle = yield* service.rawClaim(JOBS_QUEUE)
-        expect(Option.isSome(fromLifecycle)).toBe(true)
-        if (Option.isSome(fromLifecycle)) {
-          expect(fromLifecycle.value.jobId).toBe(lifecycleId)
-          expect(fromLifecycle.value.payload).toMatchObject({
-            _tag: "work-item-step",
-          })
+  it.live("recovers after a queue infrastructure error", () =>
+    Effect.gen(function* () {
+      const job = rawJob(refreshPayload)
+      const acknowledged = yield* Deferred.make<void>()
+      let refreshClaims = 0
+      const claim = (queueName: string) => {
+        if (queueName !== ISSUE_REFRESH_QUEUE) {
+          return Effect.succeed(Option.none())
         }
+        refreshClaims += 1
+        return refreshClaims === 1
+          ? Effect.fail(
+              new ClaimError({
+                queue: ISSUE_REFRESH_QUEUE,
+                message: "temporarily down",
+              }),
+            )
+          : Effect.succeed(
+              refreshClaims === 2 ? Option.some(job) : Option.none(),
+            )
+      }
 
-        const fromRefresh = yield* service.rawClaim(ISSUE_REFRESH_QUEUE)
-        expect(Option.isSome(fromRefresh)).toBe(true)
-        if (Option.isSome(fromRefresh)) {
-          expect(fromRefresh.value.jobId).toBe(retainedId)
-          expect(fromRefresh.value.payload).toEqual({
-            _tag: "refresh-repository",
-            repositoryId: repository.id,
-          })
-        }
+      yield* runScoped(
+        Effect.gen(function* () {
+          yield* runJobWorker({ idlePollInterval: Duration.zero }).pipe(
+            Effect.forkScoped({ startImmediately: true }),
+          )
+          yield* Deferred.await(acknowledged)
+          expect(refreshClaims).toBe(2)
+        }),
+        Layer.mergeAll(
+          defaultGithubLayer,
+          queueLayer(
+            [],
+            () => Deferred.succeed(acknowledged, undefined),
+            undefined,
+            claim,
+          ),
+          dbLayer(),
+          Layer.succeed(IssueReconciler, {
+            reconcile: () =>
+              Effect.succeed({
+                fetched: 0,
+                inserted: 0,
+                updated: 0,
+                deleted: 0,
+                unchanged: 0,
+              }),
+          }),
+          keymaxxerLayer(),
+        ),
+      )
+    }),
+  )
 
-        const noDuplicate = yield* service.rawClaim(ISSUE_REFRESH_QUEUE)
-        expect(Option.isNone(noDuplicate)).toBe(true)
-      }).pipe(Effect.provide(layer), Effect.orDie),
-    )
-  })
-
-  test("checks high-priority Refresh Jobs before scheduled Issue polls", async () => {
-    const claimOrder: string[] = []
-    const repositoryOrder: string[] = []
-    const manualJob = rawJob(refreshPayload, ISSUE_REFRESH_QUEUE)
-    const scheduledJob = rawJob(
-      {
-        _tag: "refresh-repository",
-        repositoryId: RepositoryId.make(otherRepository.id),
-      },
-      ISSUE_POLL_QUEUE,
-      otherRepository.id,
-    )
-    const jobs = [scheduledJob, manualJob]
-    const done = await Effect.runPromise(Deferred.make<void>())
-
-    await runScoped(
+  it.live(
+    "scope disposal interrupts an active Job without queue finalization",
+    () =>
       Effect.gen(function* () {
-        yield* runJobWorker({
-          idlePollInterval: Duration.zero,
-          samplePollingDelay: Effect.succeed(Duration.seconds(120)),
-        }).pipe(Effect.forkScoped({ startImmediately: true }))
-        yield* Deferred.await(done)
-        expect(repositoryOrder).toEqual([repository.id, otherRepository.id])
-        const refreshClaims = claimOrder.filter(
-          (queueName) =>
-            queueName === ISSUE_REFRESH_QUEUE || queueName === ISSUE_POLL_QUEUE,
+        const job = rawJob(refreshPayload)
+        const started = yield* Deferred.make<void>()
+        const interrupted = yield* Deferred.make<void>()
+        let finalized = false
+        const reconciler = Layer.succeed(IssueReconciler, {
+          reconcile: () =>
+            Deferred.succeed(started, undefined).pipe(
+              Effect.andThen(Effect.never),
+              Effect.ensuring(
+                Deferred.succeed(interrupted, undefined).pipe(Effect.asVoid),
+              ),
+            ),
+        } satisfies IssueReconcilerShape)
+
+        yield* runScoped(
+          Effect.gen(function* () {
+            yield* Effect.scoped(
+              Effect.gen(function* () {
+                yield* runJobWorker({ idlePollInterval: Duration.zero }).pipe(
+                  Effect.forkScoped({ startImmediately: true }),
+                )
+                yield* Deferred.await(started)
+              }),
+            )
+            yield* Deferred.await(interrupted)
+            expect(finalized).toBe(false)
+          }),
+          Layer.mergeAll(
+            defaultGithubLayer,
+            queueLayer(
+              [job],
+              () => Effect.sync(() => (finalized = true)),
+              () => Effect.sync(() => (finalized = true)),
+            ),
+            dbLayer(),
+            reconciler,
+            keymaxxerLayer(),
+          ),
         )
-        expect(refreshClaims[0]).toBe(ISSUE_REFRESH_QUEUE)
-        expect(refreshClaims).toContain(ISSUE_POLL_QUEUE)
       }),
-      Layer.mergeAll(
-        defaultGithubLayer,
-        queueLayer(
-          jobs,
-          undefined,
-          undefined,
-          (queueName) =>
-            Effect.sync(() => {
-              claimOrder.push(queueName)
-              const index = jobs.findIndex((job) => job.queue === queueName)
-              if (index === -1) return Option.none()
-              const [job] = jobs.splice(index, 1)
-              return Option.some(job)
-            }),
-          undefined,
-          undefined,
-          undefined,
-          () => Deferred.succeed(done, undefined),
-        ),
-        dbLayer([repository, otherRepository]),
-        Layer.succeed(IssueReconciler, {
-          reconcile: (repo) =>
-            Effect.sync(() => {
-              repositoryOrder.push(repo.id)
-              return {
-                fetched: 0,
-                inserted: 0,
-                updated: 0,
-                deleted: 0,
-                unchanged: 0,
-              }
-            }),
-        }),
-        keymaxxerLayer(),
-      ),
-    )
-  })
+  )
 
-  test("postpones a successful scheduled poll by the sampled cadence", async () => {
-    const job = rawJob(refreshPayload, ISSUE_POLL_QUEUE, repository.id)
-    const postponed = await Effect.runPromise(
-      Deferred.make<{ jobId: string; delayMs: number }>(),
-    )
-    const notifications: string[] = []
-
-    await runScoped(
+  it.live(
+    "transfers persisted Refresh Jobs into the issue-refresh queue once",
+    () =>
       Effect.gen(function* () {
-        yield* runJobWorker({
-          idlePollInterval: Duration.zero,
-          samplePollingDelay: Effect.succeed(Duration.seconds(137)),
-        }).pipe(Effect.forkScoped({ startImmediately: true }))
-        expect(yield* Deferred.await(postponed)).toEqual({
-          jobId: job.jobId,
-          delayMs: 137_000,
-        })
-        expect(notifications).toEqual([repository.id])
-      }),
-      Layer.mergeAll(
-        defaultGithubLayer,
-        queueLayer(
-          [job],
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          (jobId, delay) =>
-            Deferred.succeed(postponed, {
-              jobId,
-              delayMs: Duration.toMillis(delay),
-            }),
-        ),
-        dbLayer([repository], (repositoryId) =>
-          Effect.sync(() => {
-            notifications.push(repositoryId)
-          }),
-        ),
-        Layer.succeed(IssueReconciler, {
-          reconcile: () =>
-            Effect.succeed({
-              fetched: 0,
-              inserted: 0,
-              updated: 0,
-              deleted: 0,
-              unchanged: 0,
-            }),
-        }),
-        keymaxxerLayer(),
-      ),
-    )
-  })
+        const database = DbServiceLive.pipe(Layer.provideMerge(DatabaseTest))
+        const queue = SqliteQueueServiceLive.pipe(Layer.provideMerge(database))
+        const layer = Layer.mergeAll(database, queue)
 
-  test("postpones a failed scheduled poll without publishing success", async () => {
-    const job = rawJob(refreshPayload, ISSUE_POLL_QUEUE, repository.id)
-    const postponed = await Effect.runPromise(Deferred.make<string>())
-    const notifications: string[] = []
-    let failed = false
+        yield* Effect.gen(function* () {
+          const service = yield* QueueService
+          const retainedId = yield* service.enqueue(
+            JOBS_QUEUE,
+            {
+              _tag: "refresh-repository",
+              repositoryId: RepositoryId.make(repository.id),
+            },
+            { retryLimit: JOB_RECOVERY_RETRY_LIMIT },
+          )
+          const lifecycleId = yield* service.enqueue(
+            JOBS_QUEUE,
+            WorkItemStepJob.make({ stepRunId: makeStepRunId() }),
+            { retryLimit: JOB_RECOVERY_RETRY_LIMIT },
+          )
 
-    await runScoped(
-      Effect.gen(function* () {
-        yield* runJobWorker({
-          idlePollInterval: Duration.zero,
-          samplePollingDelay: Effect.succeed(Duration.seconds(120)),
-        }).pipe(Effect.forkScoped({ startImmediately: true }))
-        expect(yield* Deferred.await(postponed)).toBe(job.jobId)
-        expect(notifications).toEqual([])
-        expect(failed).toBe(false)
-      }),
-      Layer.mergeAll(
-        defaultGithubLayer,
-        queueLayer(
-          [job],
-          undefined,
-          () =>
-            Effect.sync(() => {
-              failed = true
-            }),
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          (jobId) => Deferred.succeed(postponed, jobId),
-        ),
-        dbLayer([repository], (repositoryId) =>
-          Effect.sync(() => {
-            notifications.push(repositoryId)
-          }),
-        ),
-        Layer.succeed(IssueReconciler, {
-          reconcile: () =>
-            Effect.fail(new DatabaseError({ message: "scheduled fail" })),
-        }),
-        keymaxxerLayer(),
-      ),
-    )
-  })
+          const moved = yield* transferPersistedRefreshJobs
+          expect(moved).toBe(1)
+          const movedAgain = yield* transferPersistedRefreshJobs
+          expect(movedAgain).toBe(0)
 
-  test("finalizes a scheduled poll without recurrence when the Repository is missing", async () => {
-    const job = rawJob(refreshPayload, ISSUE_POLL_QUEUE, repository.id)
-    const acknowledged = await Effect.runPromise(Deferred.make<string>())
-    let postponed = false
-
-    await runScoped(
-      Effect.gen(function* () {
-        yield* runJobWorker({
-          idlePollInterval: Duration.zero,
-          samplePollingDelay: Effect.succeed(Duration.seconds(120)),
-        }).pipe(Effect.forkScoped({ startImmediately: true }))
-        expect(yield* Deferred.await(acknowledged)).toBe(job.jobId)
-        expect(postponed).toBe(false)
-      }),
-      Layer.mergeAll(
-        defaultGithubLayer,
-        queueLayer(
-          [job],
-          (jobId) => Deferred.succeed(acknowledged, jobId),
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          () =>
-            Effect.sync(() => {
-              postponed = true
-            }),
-        ),
-        dbLayer([]),
-        Layer.succeed(IssueReconciler, { reconcile: unused }),
-        keymaxxerLayer(),
-      ),
-    )
-  })
-
-  test("finalizes a scheduled poll without recurrence when uncredentialed", async () => {
-    const job = rawJob(refreshPayload, ISSUE_POLL_QUEUE, repository.id)
-    const acknowledged = await Effect.runPromise(Deferred.make<string>())
-    let postponed = false
-
-    await runScoped(
-      Effect.gen(function* () {
-        yield* runJobWorker({
-          idlePollInterval: Duration.zero,
-          samplePollingDelay: Effect.succeed(Duration.seconds(120)),
-        }).pipe(Effect.forkScoped({ startImmediately: true }))
-        expect(yield* Deferred.await(acknowledged)).toBe(job.jobId)
-        expect(postponed).toBe(false)
-      }),
-      Layer.mergeAll(
-        defaultGithubLayer,
-        queueLayer(
-          [job],
-          (jobId) => Deferred.succeed(acknowledged, jobId),
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          () =>
-            Effect.sync(() => {
-              postponed = true
-            }),
-        ),
-        dbLayer(),
-        Layer.succeed(IssueReconciler, {
-          reconcile: () =>
-            Effect.fail(new DatabaseError({ message: "no credential" })),
-        }),
-        keymaxxerLayer(new Set()),
-      ),
-    )
-  })
-
-  test("does not alter a scheduled entry when a manual Refresh Job runs", async () => {
-    const scheduledJob = rawJob(refreshPayload, ISSUE_POLL_QUEUE, repository.id)
-    const manualJob = rawJob(refreshPayload)
-    const jobs = [manualJob]
-    const acknowledged = await Effect.runPromise(Deferred.make<string>())
-    let postponed = false
-
-    await runScoped(
-      Effect.gen(function* () {
-        yield* runJobWorker({
-          idlePollInterval: Duration.zero,
-          samplePollingDelay: Effect.succeed(Duration.seconds(120)),
-        }).pipe(Effect.forkScoped({ startImmediately: true }))
-        expect(yield* Deferred.await(acknowledged)).toBe(manualJob.jobId)
-        expect(postponed).toBe(false)
-        expect(jobs).toEqual([])
-        // Scheduled job remains unclaimed in its queue (not in the jobs list
-        // because we only enqueued the manual job).
-        expect(scheduledJob.queue).toBe(ISSUE_POLL_QUEUE)
-      }),
-      Layer.mergeAll(
-        defaultGithubLayer,
-        queueLayer(
-          jobs,
-          (jobId) => Deferred.succeed(acknowledged, jobId),
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          () =>
-            Effect.sync(() => {
-              postponed = true
-            }),
-        ),
-        dbLayer(),
-        Layer.succeed(IssueReconciler, {
-          reconcile: () =>
-            Effect.succeed({
-              fetched: 0,
-              inserted: 0,
-              updated: 0,
-              deleted: 0,
-              unchanged: 0,
-            }),
-        }),
-        keymaxxerLayer(),
-      ),
-    )
-  })
-
-  test("polls a Paused Repository on the scheduled cadence", async () => {
-    const paused = makeRepositoryRecord({
-      id: repository.id,
-      paused: true,
-    })
-    const job = rawJob(refreshPayload, ISSUE_POLL_QUEUE, paused.id)
-    const postponed = await Effect.runPromise(Deferred.make<string>())
-
-    await runScoped(
-      Effect.gen(function* () {
-        yield* runJobWorker({
-          idlePollInterval: Duration.zero,
-          samplePollingDelay: Effect.succeed(Duration.seconds(125)),
-        }).pipe(Effect.forkScoped({ startImmediately: true }))
-        expect(yield* Deferred.await(postponed)).toBe(job.jobId)
-      }),
-      Layer.mergeAll(
-        defaultGithubLayer,
-        queueLayer(
-          [job],
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          (jobId) => Deferred.succeed(postponed, jobId),
-        ),
-        dbLayer([paused]),
-        Layer.succeed(IssueReconciler, {
-          reconcile: (repo) =>
-            Effect.sync(() => {
-              expect(repo.paused).toBe(true)
-              return {
-                fetched: 0,
-                inserted: 0,
-                updated: 0,
-                deleted: 0,
-                unchanged: 0,
-              }
-            }),
-        }),
-        keymaxxerLayer(),
-      ),
-    )
-  })
-
-  test("polls a credentialed GitLab Repository while Paused", async () => {
-    const pausedGitlab = makeRepositoryRecord({
-      id: repository.id,
-      forge: "gitlab",
-      forgeHost: "git.drupalcode.org",
-      projectPath: "project/oauth_client",
-      paused: true,
-    })
-    const job = rawJob(refreshPayload, ISSUE_POLL_QUEUE, pausedGitlab.id)
-    const postponed = await Effect.runPromise(Deferred.make<string>())
-
-    await runScoped(
-      Effect.gen(function* () {
-        yield* runJobWorker({
-          idlePollInterval: Duration.zero,
-          samplePollingDelay: Effect.succeed(Duration.seconds(125)),
-        }).pipe(Effect.forkScoped({ startImmediately: true }))
-        expect(yield* Deferred.await(postponed)).toBe(job.jobId)
-      }),
-      Layer.mergeAll(
-        defaultGithubLayer,
-        queueLayer(
-          [job],
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          (jobId) => Deferred.succeed(postponed, jobId),
-        ),
-        dbLayer([pausedGitlab]),
-        Layer.succeed(IssueReconciler, {
-          reconcile: (repo) =>
-            Effect.sync(() => {
-              expect(repo.forge).toBe("gitlab")
-              expect(repo.paused).toBe(true)
-              return {
-                fetched: 0,
-                inserted: 0,
-                updated: 0,
-                deleted: 0,
-                unchanged: 0,
-              }
-            }),
-        }),
-        // GitHub has no credential, proving GitLab ambient auth owns this
-        // Repository's polling eligibility.
-        keymaxxerLayer(new Set()),
-      ),
-    )
-  })
-
-  test("persists a scheduled entry across worker restarts without replaying", async () => {
-    const database = DbServiceLive.pipe(Layer.provideMerge(DatabaseTest))
-    const queue = SqliteQueueServiceLive.pipe(Layer.provideMerge(database))
-    const reconciliations: string[] = []
-    const reconciler = Layer.succeed(IssueReconciler, {
-      reconcile: (repo) =>
-        Effect.sync(() => {
-          reconciliations.push(repo.id)
-          return {
-            fetched: 0,
-            inserted: 0,
-            updated: 0,
-            deleted: 0,
-            unchanged: 0,
+          const fromLifecycle = yield* service.rawClaim(JOBS_QUEUE)
+          expect(Option.isSome(fromLifecycle)).toBe(true)
+          if (Option.isSome(fromLifecycle)) {
+            expect(fromLifecycle.value.jobId).toBe(lifecycleId)
+            expect(fromLifecycle.value.payload).toMatchObject({
+              _tag: "work-item-step",
+            })
           }
-        }),
-    } satisfies IssueReconcilerShape)
-    const lifecycle = Layer.succeed(WorkItemLifecycle, {
-      maxDurations: {
-        create_worktree: Duration.minutes(5),
-        install_dependencies: Duration.minutes(15),
-        implement: Duration.hours(2),
-        assess_changes: Duration.minutes(5),
-        pre_commit: Duration.hours(2),
-        review: Duration.hours(1),
-        commit: Duration.minutes(5),
-        create_pr: Duration.minutes(10),
-        watch_pr_status_checks: Duration.minutes(5),
-        resolve_pr_merge_conflict: Duration.hours(2),
-        investigate_pr_status_checks: Duration.hours(2),
-        mark_pr_ready_for_review: Duration.minutes(5),
-        decide_pr_merge: Duration.minutes(15),
-        merge_pr: Duration.minutes(5),
-        close_issue: Duration.minutes(5),
-        local_cleanup: Duration.minutes(5),
-      },
-      implementNow: unused,
-      implementLocally: unused,
-      implementAllWithAutoMerge: unused,
-      queue: unused,
-      recoverOrphanedStepRuns: Effect.succeed(0),
-      interruptRunningStepRunsFromPriorWorker: Effect.succeed(0),
-      runStep: () => Effect.succeed({ _tag: "noop" as const }),
-      retry: unused,
-      pause: unused,
-      start: unused,
-      abandon: unused,
-      reset: unused,
-      getWorkItem: unused,
-      listWorkItemsForIssue: unused,
-      listWorkItemsForRepository: () => Effect.succeed([]),
-      listCompletedWorkItems: () =>
-        Effect.succeed({ items: [], page: 1, pageSize: 20, totalCount: 0 }),
-      ownsSessionId: () => Effect.succeed(false),
-      countCommittedPullRequests: () => Effect.succeed(0),
-      continueAfterHumanPrOutcome: unused,
-      admitWaitingWorkItems: Effect.succeed(0),
-      releaseWaitingForBlockers: () => Effect.succeed(0),
-    })
 
-    await Effect.runPromise(
+          const fromRefresh = yield* service.rawClaim(ISSUE_REFRESH_QUEUE)
+          expect(Option.isSome(fromRefresh)).toBe(true)
+          if (Option.isSome(fromRefresh)) {
+            expect(fromRefresh.value.jobId).toBe(retainedId)
+            expect(fromRefresh.value.payload).toEqual({
+              _tag: "refresh-repository",
+              repositoryId: repository.id,
+            })
+          }
+
+          const noDuplicate = yield* service.rawClaim(ISSUE_REFRESH_QUEUE)
+          expect(Option.isNone(noDuplicate)).toBe(true)
+        }).pipe(Effect.provide(layer), Effect.orDie)
+      }),
+  )
+
+  it.live(
+    "checks high-priority Refresh Jobs before scheduled Issue polls",
+    () =>
       Effect.gen(function* () {
-        const db = yield* DbService
-        const service = yield* QueueService
-        const added = yield* db.addRepository({
-          forge: repository.forge,
-          forgeHost: repository.forgeHost,
-          projectPath: repository.projectPath,
-          localPath: repository.localPath,
-          isBare: true,
-        })
-        yield* service.ensureKeyed(
-          ISSUE_POLL_QUEUE,
-          added.id,
+        const claimOrder: string[] = []
+        const repositoryOrder: string[] = []
+        const manualJob = rawJob(refreshPayload, ISSUE_REFRESH_QUEUE)
+        const scheduledJob = rawJob(
           {
             _tag: "refresh-repository",
-            repositoryId: RepositoryId.make(added.id),
+            repositoryId: RepositoryId.make(otherRepository.id),
           },
-          Duration.zero,
-          { retryLimit: JOB_RECOVERY_RETRY_LIMIT },
+          ISSUE_POLL_QUEUE,
+          otherRepository.id,
         )
+        const jobs = [scheduledJob, manualJob]
+        const done = yield* Deferred.make<void>()
 
-        yield* Effect.scoped(
+        yield* runScoped(
           Effect.gen(function* () {
             yield* runJobWorker({
               idlePollInterval: Duration.zero,
               samplePollingDelay: Effect.succeed(Duration.seconds(120)),
             }).pipe(Effect.forkScoped({ startImmediately: true }))
-            while (reconciliations.length < 1) {
-              yield* Effect.sleep("5 millis")
-            }
+            yield* Deferred.await(done)
+            expect(repositoryOrder).toEqual([repository.id, otherRepository.id])
+            const refreshClaims = claimOrder.filter(
+              (queueName) =>
+                queueName === ISSUE_REFRESH_QUEUE ||
+                queueName === ISSUE_POLL_QUEUE,
+            )
+            expect(refreshClaims[0]).toBe(ISSUE_REFRESH_QUEUE)
+            expect(refreshClaims).toContain(ISSUE_POLL_QUEUE)
           }),
-        )
-
-        expect(reconciliations).toEqual([added.id])
-
-        const keyed = yield* service.listKeyed(ISSUE_POLL_QUEUE)
-        expect(keyed).toHaveLength(1)
-        expect(keyed[0]?.key).toBe(added.id)
-        expect(keyed[0]?.attempts).toBe(0)
-
-        // Not immediately available again (postponed 120s).
-        const claimNow = yield* service.rawClaim(ISSUE_POLL_QUEUE)
-        expect(Option.isNone(claimNow)).toBe(true)
-      }).pipe(
-        Effect.provide(
           Layer.mergeAll(
             defaultGithubLayer,
-            database,
-            queue,
-            reconciler,
-            keymaxxerLayer(),
-            lifecycle,
-          ),
-        ),
-        Effect.orDie,
-      ),
-    )
-  })
-
-  test("startup interrupts Step Runs left running by a prior worker process", async () => {
-    const database = DbServiceLive.pipe(Layer.provideMerge(DatabaseTest))
-    const queue = SqliteQueueServiceLive.pipe(Layer.provideMerge(database))
-    let priorWorkerInterruptCalls = 0
-    const lifecycle = Layer.succeed(WorkItemLifecycle, {
-      maxDurations: {
-        create_worktree: Duration.minutes(5),
-        install_dependencies: Duration.minutes(15),
-        implement: Duration.hours(2),
-        assess_changes: Duration.minutes(5),
-        pre_commit: Duration.hours(2),
-        review: Duration.hours(1),
-        commit: Duration.minutes(5),
-        create_pr: Duration.minutes(10),
-        watch_pr_status_checks: Duration.minutes(5),
-        resolve_pr_merge_conflict: Duration.hours(2),
-        investigate_pr_status_checks: Duration.hours(2),
-        mark_pr_ready_for_review: Duration.minutes(5),
-        decide_pr_merge: Duration.minutes(15),
-        merge_pr: Duration.minutes(5),
-        close_issue: Duration.minutes(5),
-        local_cleanup: Duration.minutes(5),
-      },
-      implementNow: unused,
-      implementLocally: unused,
-      implementAllWithAutoMerge: unused,
-      queue: unused,
-      recoverOrphanedStepRuns: Effect.succeed(0),
-      interruptRunningStepRunsFromPriorWorker: Effect.sync(() => {
-        priorWorkerInterruptCalls += 1
-        return 1
-      }),
-      runStep: () => Effect.succeed({ _tag: "noop" as const }),
-      retry: unused,
-      pause: unused,
-      start: unused,
-      abandon: unused,
-      reset: unused,
-      getWorkItem: unused,
-      listWorkItemsForIssue: unused,
-      listWorkItemsForRepository: () => Effect.succeed([]),
-      listCompletedWorkItems: () =>
-        Effect.succeed({ items: [], page: 1, pageSize: 20, totalCount: 0 }),
-      ownsSessionId: () => Effect.succeed(false),
-      countCommittedPullRequests: () => Effect.succeed(0),
-      continueAfterHumanPrOutcome: unused,
-      admitWaitingWorkItems: Effect.succeed(0),
-      releaseWaitingForBlockers: () => Effect.succeed(0),
-    })
-
-    await Effect.runPromise(
-      Effect.scoped(
-        Effect.gen(function* () {
-          yield* startJobWorker({
-            idlePollInterval: Duration.zero,
-            samplePollingDelay: Effect.succeed(Duration.seconds(120)),
-          })
-          expect(priorWorkerInterruptCalls).toBe(1)
-        }),
-      ).pipe(
-        Effect.provide(
-          Layer.mergeAll(
-            defaultGithubLayer,
-            database,
-            queue,
+            queueLayer(
+              jobs,
+              undefined,
+              undefined,
+              (queueName) =>
+                Effect.sync(() => {
+                  claimOrder.push(queueName)
+                  const index = jobs.findIndex((job) => job.queue === queueName)
+                  if (index === -1) return Option.none()
+                  const [job] = jobs.splice(index, 1)
+                  return Option.some(job)
+                }),
+              undefined,
+              undefined,
+              undefined,
+              () => Deferred.succeed(done, undefined),
+            ),
+            dbLayer([repository, otherRepository]),
             Layer.succeed(IssueReconciler, {
-              reconcile: () => Effect.die("not used"),
+              reconcile: (repo) =>
+                Effect.sync(() => {
+                  repositoryOrder.push(repo.id)
+                  return {
+                    fetched: 0,
+                    inserted: 0,
+                    updated: 0,
+                    deleted: 0,
+                    unchanged: 0,
+                  }
+                }),
             }),
             keymaxxerLayer(),
-            lifecycle,
           ),
+        )
+      }),
+  )
+
+  it.live("postpones a successful scheduled poll by the sampled cadence", () =>
+    Effect.gen(function* () {
+      const job = rawJob(refreshPayload, ISSUE_POLL_QUEUE, repository.id)
+      const postponed = yield* Deferred.make<{
+        jobId: string
+        delayMs: number
+      }>()
+      const notifications: string[] = []
+
+      yield* runScoped(
+        Effect.gen(function* () {
+          yield* runJobWorker({
+            idlePollInterval: Duration.zero,
+            samplePollingDelay: Effect.succeed(Duration.seconds(137)),
+          }).pipe(Effect.forkScoped({ startImmediately: true }))
+          expect(yield* Deferred.await(postponed)).toEqual({
+            jobId: job.jobId,
+            delayMs: 137_000,
+          })
+          expect(notifications).toEqual([repository.id])
+        }),
+        Layer.mergeAll(
+          defaultGithubLayer,
+          queueLayer(
+            [job],
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            (jobId, delay) =>
+              Deferred.succeed(postponed, {
+                jobId,
+                delayMs: Duration.toMillis(delay),
+              }),
+          ),
+          dbLayer([repository], (repositoryId) =>
+            Effect.sync(() => {
+              notifications.push(repositoryId)
+            }),
+          ),
+          Layer.succeed(IssueReconciler, {
+            reconcile: () =>
+              Effect.succeed({
+                fetched: 0,
+                inserted: 0,
+                updated: 0,
+                deleted: 0,
+                unchanged: 0,
+              }),
+          }),
+          keymaxxerLayer(),
         ),
-        Effect.orDie,
-      ),
-    )
-  })
+      )
+    }),
+  )
 
-  test("startup enqueues one Polling Auto-heal Job without awaiting repair", async () => {
-    const database = DbServiceLive.pipe(Layer.provideMerge(DatabaseTest))
-    const queue = SqliteQueueServiceLive.pipe(Layer.provideMerge(database))
-    const lifecycle = Layer.succeed(WorkItemLifecycle, {
-      maxDurations: {
-        create_worktree: Duration.minutes(5),
-        install_dependencies: Duration.minutes(15),
-        implement: Duration.hours(2),
-        assess_changes: Duration.minutes(5),
-        pre_commit: Duration.hours(2),
-        review: Duration.hours(1),
-        commit: Duration.minutes(5),
-        create_pr: Duration.minutes(10),
-        watch_pr_status_checks: Duration.minutes(5),
-        resolve_pr_merge_conflict: Duration.hours(2),
-        investigate_pr_status_checks: Duration.hours(2),
-        mark_pr_ready_for_review: Duration.minutes(5),
-        decide_pr_merge: Duration.minutes(15),
-        merge_pr: Duration.minutes(5),
-        close_issue: Duration.minutes(5),
-        local_cleanup: Duration.minutes(5),
-      },
-      implementNow: unused,
-      implementLocally: unused,
-      implementAllWithAutoMerge: unused,
-      queue: unused,
-      recoverOrphanedStepRuns: Effect.succeed(0),
-      interruptRunningStepRunsFromPriorWorker: Effect.succeed(0),
-      runStep: () => Effect.succeed({ _tag: "noop" as const }),
-      retry: unused,
-      pause: unused,
-      start: unused,
-      abandon: unused,
-      reset: unused,
-      getWorkItem: unused,
-      listWorkItemsForIssue: unused,
-      listWorkItemsForRepository: () => Effect.succeed([]),
-      listCompletedWorkItems: () =>
-        Effect.succeed({ items: [], page: 1, pageSize: 20, totalCount: 0 }),
-      ownsSessionId: () => Effect.succeed(false),
-      countCommittedPullRequests: () => Effect.succeed(0),
-      continueAfterHumanPrOutcome: unused,
-      admitWaitingWorkItems: Effect.succeed(0),
-      releaseWaitingForBlockers: () => Effect.succeed(0),
-    })
-    // Block Keymaxxer so auto-heal cannot finish during startup.
-    const blockedKeymaxxer = Layer.succeed(KeymaxxerService, {
-      initialize: Effect.void,
-      findSecret: () => Effect.never,
-      findSecrets: () => Effect.die("not used"),
-      hasSecret: () => Effect.die("not used"),
-      addSecret: () => Effect.die("not used"),
-      runWithSecrets: () => Effect.die("not used"),
-    })
+  it.live("postpones a failed scheduled poll without publishing success", () =>
+    Effect.gen(function* () {
+      const job = rawJob(refreshPayload, ISSUE_POLL_QUEUE, repository.id)
+      const postponed = yield* Deferred.make<string>()
+      const notifications: string[] = []
+      let failed = false
 
-    await Effect.runPromise(
+      yield* runScoped(
+        Effect.gen(function* () {
+          yield* runJobWorker({
+            idlePollInterval: Duration.zero,
+            samplePollingDelay: Effect.succeed(Duration.seconds(120)),
+          }).pipe(Effect.forkScoped({ startImmediately: true }))
+          expect(yield* Deferred.await(postponed)).toBe(job.jobId)
+          expect(notifications).toEqual([])
+          expect(failed).toBe(false)
+        }),
+        Layer.mergeAll(
+          defaultGithubLayer,
+          queueLayer(
+            [job],
+            undefined,
+            () =>
+              Effect.sync(() => {
+                failed = true
+              }),
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            (jobId) => Deferred.succeed(postponed, jobId),
+          ),
+          dbLayer([repository], (repositoryId) =>
+            Effect.sync(() => {
+              notifications.push(repositoryId)
+            }),
+          ),
+          Layer.succeed(IssueReconciler, {
+            reconcile: () =>
+              Effect.fail(new DatabaseError({ message: "scheduled fail" })),
+          }),
+          keymaxxerLayer(),
+        ),
+      )
+    }),
+  )
+
+  it.live(
+    "finalizes a scheduled poll without recurrence when the Repository is missing",
+    () =>
       Effect.gen(function* () {
-        const db = yield* DbService
-        const service = yield* QueueService
-        // Ensure auto-heal must consult Keymaxxer (and therefore blocks).
-        yield* db.addRepository({
-          forge: repository.forge,
-          forgeHost: repository.forgeHost,
-          projectPath: repository.projectPath,
-          localPath: repository.localPath,
-          isBare: true,
+        const job = rawJob(refreshPayload, ISSUE_POLL_QUEUE, repository.id)
+        const acknowledged = yield* Deferred.make<string>()
+        let postponed = false
+
+        yield* runScoped(
+          Effect.gen(function* () {
+            yield* runJobWorker({
+              idlePollInterval: Duration.zero,
+              samplePollingDelay: Effect.succeed(Duration.seconds(120)),
+            }).pipe(Effect.forkScoped({ startImmediately: true }))
+            expect(yield* Deferred.await(acknowledged)).toBe(job.jobId)
+            expect(postponed).toBe(false)
+          }),
+          Layer.mergeAll(
+            defaultGithubLayer,
+            queueLayer(
+              [job],
+              (jobId) => Deferred.succeed(acknowledged, jobId),
+              undefined,
+              undefined,
+              undefined,
+              undefined,
+              undefined,
+              () =>
+                Effect.sync(() => {
+                  postponed = true
+                }),
+            ),
+            dbLayer([]),
+            Layer.succeed(IssueReconciler, { reconcile: unused }),
+            keymaxxerLayer(),
+          ),
+        )
+      }),
+  )
+
+  it.live(
+    "finalizes a scheduled poll without recurrence when uncredentialed",
+    () =>
+      Effect.gen(function* () {
+        const job = rawJob(refreshPayload, ISSUE_POLL_QUEUE, repository.id)
+        const acknowledged = yield* Deferred.make<string>()
+        let postponed = false
+
+        yield* runScoped(
+          Effect.gen(function* () {
+            yield* runJobWorker({
+              idlePollInterval: Duration.zero,
+              samplePollingDelay: Effect.succeed(Duration.seconds(120)),
+            }).pipe(Effect.forkScoped({ startImmediately: true }))
+            expect(yield* Deferred.await(acknowledged)).toBe(job.jobId)
+            expect(postponed).toBe(false)
+          }),
+          Layer.mergeAll(
+            defaultGithubLayer,
+            queueLayer(
+              [job],
+              (jobId) => Deferred.succeed(acknowledged, jobId),
+              undefined,
+              undefined,
+              undefined,
+              undefined,
+              undefined,
+              () =>
+                Effect.sync(() => {
+                  postponed = true
+                }),
+            ),
+            dbLayer(),
+            Layer.succeed(IssueReconciler, {
+              reconcile: () =>
+                Effect.fail(new DatabaseError({ message: "no credential" })),
+            }),
+            keymaxxerLayer(new Set()),
+          ),
+        )
+      }),
+  )
+
+  it.live(
+    "does not alter a scheduled entry when a manual Refresh Job runs",
+    () =>
+      Effect.gen(function* () {
+        const scheduledJob = rawJob(
+          refreshPayload,
+          ISSUE_POLL_QUEUE,
+          repository.id,
+        )
+        const manualJob = rawJob(refreshPayload)
+        const jobs = [manualJob]
+        const acknowledged = yield* Deferred.make<string>()
+        let postponed = false
+
+        yield* runScoped(
+          Effect.gen(function* () {
+            yield* runJobWorker({
+              idlePollInterval: Duration.zero,
+              samplePollingDelay: Effect.succeed(Duration.seconds(120)),
+            }).pipe(Effect.forkScoped({ startImmediately: true }))
+            expect(yield* Deferred.await(acknowledged)).toBe(manualJob.jobId)
+            expect(postponed).toBe(false)
+            expect(jobs).toEqual([])
+            // Scheduled job remains unclaimed in its queue (not in the jobs list
+            // because we only enqueued the manual job).
+            expect(scheduledJob.queue).toBe(ISSUE_POLL_QUEUE)
+          }),
+          Layer.mergeAll(
+            defaultGithubLayer,
+            queueLayer(
+              jobs,
+              (jobId) => Deferred.succeed(acknowledged, jobId),
+              undefined,
+              undefined,
+              undefined,
+              undefined,
+              undefined,
+              () =>
+                Effect.sync(() => {
+                  postponed = true
+                }),
+            ),
+            dbLayer(),
+            Layer.succeed(IssueReconciler, {
+              reconcile: () =>
+                Effect.succeed({
+                  fetched: 0,
+                  inserted: 0,
+                  updated: 0,
+                  deleted: 0,
+                  unchanged: 0,
+                }),
+            }),
+            keymaxxerLayer(),
+          ),
+        )
+      }),
+  )
+
+  it.live("polls a Paused Repository on the scheduled cadence", () =>
+    Effect.gen(function* () {
+      const paused = makeRepositoryRecord({
+        id: repository.id,
+        paused: true,
+      })
+      const job = rawJob(refreshPayload, ISSUE_POLL_QUEUE, paused.id)
+      const postponed = yield* Deferred.make<string>()
+
+      yield* runScoped(
+        Effect.gen(function* () {
+          yield* runJobWorker({
+            idlePollInterval: Duration.zero,
+            samplePollingDelay: Effect.succeed(Duration.seconds(125)),
+          }).pipe(Effect.forkScoped({ startImmediately: true }))
+          expect(yield* Deferred.await(postponed)).toBe(job.jobId)
+        }),
+        Layer.mergeAll(
+          defaultGithubLayer,
+          queueLayer(
+            [job],
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            (jobId) => Deferred.succeed(postponed, jobId),
+          ),
+          dbLayer([paused]),
+          Layer.succeed(IssueReconciler, {
+            reconcile: (repo) =>
+              Effect.sync(() => {
+                expect(repo.paused).toBe(true)
+                return {
+                  fetched: 0,
+                  inserted: 0,
+                  updated: 0,
+                  deleted: 0,
+                  unchanged: 0,
+                }
+              }),
+          }),
+          keymaxxerLayer(),
+        ),
+      )
+    }),
+  )
+
+  it.live("polls a credentialed GitLab Repository while Paused", () =>
+    Effect.gen(function* () {
+      const pausedGitlab = makeRepositoryRecord({
+        id: repository.id,
+        forge: "gitlab",
+        forgeHost: "git.drupalcode.org",
+        projectPath: "project/oauth_client",
+        paused: true,
+      })
+      const job = rawJob(refreshPayload, ISSUE_POLL_QUEUE, pausedGitlab.id)
+      const postponed = yield* Deferred.make<string>()
+
+      yield* runScoped(
+        Effect.gen(function* () {
+          yield* runJobWorker({
+            idlePollInterval: Duration.zero,
+            samplePollingDelay: Effect.succeed(Duration.seconds(125)),
+          }).pipe(Effect.forkScoped({ startImmediately: true }))
+          expect(yield* Deferred.await(postponed)).toBe(job.jobId)
+        }),
+        Layer.mergeAll(
+          defaultGithubLayer,
+          queueLayer(
+            [job],
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            (jobId) => Deferred.succeed(postponed, jobId),
+          ),
+          dbLayer([pausedGitlab]),
+          Layer.succeed(IssueReconciler, {
+            reconcile: (repo) =>
+              Effect.sync(() => {
+                expect(repo.forge).toBe("gitlab")
+                expect(repo.paused).toBe(true)
+                return {
+                  fetched: 0,
+                  inserted: 0,
+                  updated: 0,
+                  deleted: 0,
+                  unchanged: 0,
+                }
+              }),
+          }),
+          // GitHub has no credential, proving GitLab ambient auth owns this
+          // Repository's polling eligibility.
+          keymaxxerLayer(new Set()),
+        ),
+      )
+    }),
+  )
+
+  it.live(
+    "persists a scheduled entry across worker restarts without replaying",
+    () =>
+      Effect.gen(function* () {
+        const database = DbServiceLive.pipe(Layer.provideMerge(DatabaseTest))
+        const queue = SqliteQueueServiceLive.pipe(Layer.provideMerge(database))
+        const reconciliations: string[] = []
+        const reconciler = Layer.succeed(IssueReconciler, {
+          reconcile: (repo) =>
+            Effect.sync(() => {
+              reconciliations.push(repo.id)
+              return {
+                fetched: 0,
+                inserted: 0,
+                updated: 0,
+                deleted: 0,
+                unchanged: 0,
+              }
+            }),
+        } satisfies IssueReconcilerShape)
+        const lifecycle = Layer.succeed(WorkItemLifecycle, {
+          maxDurations: {
+            create_worktree: Duration.minutes(5),
+            install_dependencies: Duration.minutes(15),
+            implement: Duration.hours(2),
+            assess_changes: Duration.minutes(5),
+            pre_commit: Duration.hours(2),
+            review: Duration.hours(1),
+            commit: Duration.minutes(5),
+            create_pr: Duration.minutes(10),
+            watch_pr_status_checks: Duration.minutes(5),
+            resolve_pr_merge_conflict: Duration.hours(2),
+            investigate_pr_status_checks: Duration.hours(2),
+            mark_pr_ready_for_review: Duration.minutes(5),
+            decide_pr_merge: Duration.minutes(15),
+            merge_pr: Duration.minutes(5),
+            close_issue: Duration.minutes(5),
+            local_cleanup: Duration.minutes(5),
+          },
+          implementNow: unused,
+          implementLocally: unused,
+          implementAllWithAutoMerge: unused,
+          queue: unused,
+          recoverOrphanedStepRuns: Effect.succeed(0),
+          interruptRunningStepRunsFromPriorWorker: Effect.succeed(0),
+          runStep: () => Effect.succeed({ _tag: "noop" as const }),
+          retry: unused,
+          pause: unused,
+          start: unused,
+          abandon: unused,
+          reset: unused,
+          getWorkItem: unused,
+          listWorkItemsForIssue: unused,
+          listWorkItemsForRepository: () => Effect.succeed([]),
+          listCompletedWorkItems: () =>
+            Effect.succeed({ items: [], page: 1, pageSize: 20, totalCount: 0 }),
+          ownsSessionId: () => Effect.succeed(false),
+          countCommittedPullRequests: () => Effect.succeed(0),
+          continueAfterHumanPrOutcome: unused,
+          admitWaitingWorkItems: Effect.succeed(0),
+          releaseWaitingForBlockers: () => Effect.succeed(0),
         })
+
+        yield* Effect.gen(function* () {
+          const db = yield* DbService
+          const service = yield* QueueService
+          const added = yield* db.addRepository({
+            forge: repository.forge,
+            forgeHost: repository.forgeHost,
+            projectPath: repository.projectPath,
+            localPath: repository.localPath,
+            isBare: true,
+          })
+          yield* service.ensureKeyed(
+            ISSUE_POLL_QUEUE,
+            added.id,
+            {
+              _tag: "refresh-repository",
+              repositoryId: RepositoryId.make(added.id),
+            },
+            Duration.zero,
+            { retryLimit: JOB_RECOVERY_RETRY_LIMIT },
+          )
+
+          yield* Effect.scoped(
+            Effect.gen(function* () {
+              yield* runJobWorker({
+                idlePollInterval: Duration.zero,
+                samplePollingDelay: Effect.succeed(Duration.seconds(120)),
+              }).pipe(Effect.forkScoped({ startImmediately: true }))
+              while (reconciliations.length < 1) {
+                yield* Effect.sleep("5 millis")
+              }
+            }),
+          )
+
+          expect(reconciliations).toEqual([added.id])
+
+          const keyed = yield* service.listKeyed(ISSUE_POLL_QUEUE)
+          expect(keyed).toHaveLength(1)
+          expect(keyed[0]?.key).toBe(added.id)
+          expect(keyed[0]?.attempts).toBe(0)
+
+          // Not immediately available again (postponed 120s).
+          const claimNow = yield* service.rawClaim(ISSUE_POLL_QUEUE)
+          expect(Option.isNone(claimNow)).toBe(true)
+        }).pipe(
+          Effect.provide(
+            Layer.mergeAll(
+              defaultGithubLayer,
+              database,
+              queue,
+              reconciler,
+              keymaxxerLayer(),
+              lifecycle,
+            ),
+          ),
+          Effect.orDie,
+        )
+      }),
+  )
+
+  it.live(
+    "startup interrupts Step Runs left running by a prior worker process",
+    () =>
+      Effect.gen(function* () {
+        const database = DbServiceLive.pipe(Layer.provideMerge(DatabaseTest))
+        const queue = SqliteQueueServiceLive.pipe(Layer.provideMerge(database))
+        let priorWorkerInterruptCalls = 0
+        const lifecycle = Layer.succeed(WorkItemLifecycle, {
+          maxDurations: {
+            create_worktree: Duration.minutes(5),
+            install_dependencies: Duration.minutes(15),
+            implement: Duration.hours(2),
+            assess_changes: Duration.minutes(5),
+            pre_commit: Duration.hours(2),
+            review: Duration.hours(1),
+            commit: Duration.minutes(5),
+            create_pr: Duration.minutes(10),
+            watch_pr_status_checks: Duration.minutes(5),
+            resolve_pr_merge_conflict: Duration.hours(2),
+            investigate_pr_status_checks: Duration.hours(2),
+            mark_pr_ready_for_review: Duration.minutes(5),
+            decide_pr_merge: Duration.minutes(15),
+            merge_pr: Duration.minutes(5),
+            close_issue: Duration.minutes(5),
+            local_cleanup: Duration.minutes(5),
+          },
+          implementNow: unused,
+          implementLocally: unused,
+          implementAllWithAutoMerge: unused,
+          queue: unused,
+          recoverOrphanedStepRuns: Effect.succeed(0),
+          interruptRunningStepRunsFromPriorWorker: Effect.sync(() => {
+            priorWorkerInterruptCalls += 1
+            return 1
+          }),
+          runStep: () => Effect.succeed({ _tag: "noop" as const }),
+          retry: unused,
+          pause: unused,
+          start: unused,
+          abandon: unused,
+          reset: unused,
+          getWorkItem: unused,
+          listWorkItemsForIssue: unused,
+          listWorkItemsForRepository: () => Effect.succeed([]),
+          listCompletedWorkItems: () =>
+            Effect.succeed({ items: [], page: 1, pageSize: 20, totalCount: 0 }),
+          ownsSessionId: () => Effect.succeed(false),
+          countCommittedPullRequests: () => Effect.succeed(0),
+          continueAfterHumanPrOutcome: unused,
+          admitWaitingWorkItems: Effect.succeed(0),
+          releaseWaitingForBlockers: () => Effect.succeed(0),
+        })
+
         yield* Effect.scoped(
           Effect.gen(function* () {
             yield* startJobWorker({
               idlePollInterval: Duration.zero,
               samplePollingDelay: Effect.succeed(Duration.seconds(120)),
             })
-            // startJobWorker returns after durable enqueue + forking workers,
-            // without waiting for auto-heal to finish (blocked on Keymaxxer).
-            const autoHeal = yield* service.listKeyed(ISSUE_REFRESH_QUEUE)
-            expect(autoHeal).toHaveLength(1)
-            expect(autoHeal[0]?.key).toBe(POLLING_AUTO_HEAL_KEY)
-            expect(autoHeal[0]?.payload).toEqual({
-              _tag: "polling-auto-heal",
-            })
-            // Repair has not completed: no schedules yet.
-            expect(yield* service.listKeyed(ISSUE_POLL_QUEUE)).toEqual([])
+            expect(priorWorkerInterruptCalls).toBe(1)
           }),
-        )
-      }).pipe(
-        Effect.provide(
-          Layer.mergeAll(
-            defaultGithubLayer,
-            database,
-            queue,
-            Layer.succeed(IssueReconciler, {
-              reconcile: () => Effect.die("not used"),
-            }),
-            blockedKeymaxxer,
-            lifecycle,
-          ),
-        ),
-        Effect.orDie,
-      ),
-    )
-  })
-
-  test("repeated startup scheduling does not create unbounded Auto-heal Jobs", async () => {
-    const database = DbServiceLive.pipe(Layer.provideMerge(DatabaseTest))
-    const queue = SqliteQueueServiceLive.pipe(Layer.provideMerge(database))
-
-    await Effect.runPromise(
-      Effect.gen(function* () {
-        const service = yield* QueueService
-        const first = yield* enqueuePollingAutoHealJob
-        const second = yield* enqueuePollingAutoHealJob
-        const third = yield* enqueuePollingAutoHealJob
-        expect(first.created).toBe(true)
-        expect(second.created).toBe(false)
-        expect(third.created).toBe(false)
-        expect(second.jobId).toBe(first.jobId)
-        expect(third.jobId).toBe(first.jobId)
-        const keyed = yield* service.listKeyed(ISSUE_REFRESH_QUEUE)
-        expect(keyed).toHaveLength(1)
-        expect(keyed[0]?.key).toBe(POLLING_AUTO_HEAL_KEY)
-      }).pipe(Effect.provide(Layer.mergeAll(database, queue)), Effect.orDie),
-    )
-  })
-
-  test("auto-heal repairs missing schedules, orphans, due times, and first refreshes", async () => {
-    const database = DbServiceLive.pipe(Layer.provideMerge(DatabaseTest))
-    const queue = SqliteQueueServiceLive.pipe(Layer.provideMerge(database))
-    const reconciliations: string[] = []
-    const reconciler = Layer.succeed(IssueReconciler, {
-      reconcile: (repo) =>
-        Effect.sync(() => {
-          reconciliations.push(repo.id)
-          return {
-            fetched: 0,
-            inserted: 0,
-            updated: 0,
-            deleted: 0,
-            unchanged: 0,
-          }
-        }),
-    } satisfies IssueReconcilerShape)
-    const lifecycle = Layer.succeed(WorkItemLifecycle, {
-      maxDurations: {
-        create_worktree: Duration.minutes(5),
-        install_dependencies: Duration.minutes(15),
-        implement: Duration.hours(2),
-        assess_changes: Duration.minutes(5),
-        pre_commit: Duration.hours(2),
-        review: Duration.hours(1),
-        commit: Duration.minutes(5),
-        create_pr: Duration.minutes(10),
-        watch_pr_status_checks: Duration.minutes(5),
-        resolve_pr_merge_conflict: Duration.hours(2),
-        investigate_pr_status_checks: Duration.hours(2),
-        mark_pr_ready_for_review: Duration.minutes(5),
-        decide_pr_merge: Duration.minutes(15),
-        merge_pr: Duration.minutes(5),
-        close_issue: Duration.minutes(5),
-        local_cleanup: Duration.minutes(5),
-      },
-      implementNow: unused,
-      implementLocally: unused,
-      implementAllWithAutoMerge: unused,
-      queue: unused,
-      recoverOrphanedStepRuns: Effect.succeed(0),
-      interruptRunningStepRunsFromPriorWorker: Effect.succeed(0),
-      runStep: () => Effect.succeed({ _tag: "noop" as const }),
-      retry: unused,
-      pause: unused,
-      start: unused,
-      abandon: unused,
-      reset: unused,
-      getWorkItem: unused,
-      listWorkItemsForIssue: unused,
-      listWorkItemsForRepository: () => Effect.succeed([]),
-      listCompletedWorkItems: () =>
-        Effect.succeed({ items: [], page: 1, pageSize: 20, totalCount: 0 }),
-      ownsSessionId: () => Effect.succeed(false),
-      countCommittedPullRequests: () => Effect.succeed(0),
-      continueAfterHumanPrOutcome: unused,
-      admitWaitingWorkItems: Effect.succeed(0),
-      releaseWaitingForBlockers: () => Effect.succeed(0),
-    })
-
-    await Effect.runPromise(
-      Effect.gen(function* () {
-        const db = yield* DbService
-        const service = yield* QueueService
-        const credentialed = yield* db.addRepository({
-          forge: repository.forge,
-          forgeHost: repository.forgeHost,
-          projectPath: repository.projectPath,
-          localPath: repository.localPath,
-          isBare: true,
-        })
-        const uncredentialed = yield* db.addRepository({
-          forge: "github",
-          forgeHost: "github.com",
-          projectPath: "other/uncredentialed",
-          localPath: "/repos/other/uncredentialed.git",
-          isBare: true,
-        })
-        const preserved = yield* service.ensureKeyed(
-          ISSUE_POLL_QUEUE,
-          credentialed.id,
-          {
-            _tag: "refresh-repository",
-            repositoryId: RepositoryId.make(credentialed.id),
-          },
-          Duration.millis(90_000),
-          { retryLimit: JOB_RECOVERY_RETRY_LIMIT },
-        )
-        const preservedBefore = yield* service.listKeyed(ISSUE_POLL_QUEUE)
-        const preservedAvailableAt = DateTime.toEpochMillis(
-          preservedBefore.find((entry) => entry.key === credentialed.id)!
-            .availableAt,
-        )
-        yield* service.ensureKeyed(
-          ISSUE_POLL_QUEUE,
-          uncredentialed.id,
-          {
-            _tag: "refresh-repository",
-            repositoryId: RepositoryId.make(uncredentialed.id),
-          },
-          Duration.seconds(30),
-          { retryLimit: JOB_RECOVERY_RETRY_LIMIT },
-        )
-        yield* service.ensureKeyed(
-          ISSUE_POLL_QUEUE,
-          "repo-deleted-orphan",
-          {
-            _tag: "refresh-repository",
-            repositoryId: RepositoryId.make("repo-01J00000000000000000000099"),
-          },
-          Duration.seconds(30),
-          { retryLimit: JOB_RECOVERY_RETRY_LIMIT },
-        )
-
-        const missing = yield* db.addRepository({
-          forge: otherRepository.forge,
-          forgeHost: otherRepository.forgeHost,
-          projectPath: otherRepository.projectPath,
-          localPath: otherRepository.localPath,
-          isBare: true,
-        })
-
-        yield* Effect.scoped(
-          Effect.gen(function* () {
-            yield* startJobWorker({
-              idlePollInterval: Duration.zero,
-              samplePollingDelay: Effect.succeed(Duration.seconds(142)),
-            })
-            // Wait until auto-heal finishes and the missing repo's first refresh runs.
-            while (
-              !(
-                reconciliations.includes(missing.id) &&
-                (yield* service.listKeyed(ISSUE_REFRESH_QUEUE)).every(
-                  (entry) => entry.key !== POLLING_AUTO_HEAL_KEY,
-                )
-              )
-            ) {
-              yield* Effect.sleep("5 millis")
-            }
-          }),
-        )
-
-        const schedules = yield* service.listKeyed(ISSUE_POLL_QUEUE)
-        expect(schedules.map((entry) => entry.key).sort()).toEqual(
-          [credentialed.id, missing.id].sort(),
-        )
-        const preservedEntry = schedules.find(
-          (entry) => entry.key === credentialed.id,
-        )
-        expect(preservedEntry?.jobId).toBe(preserved.jobId)
-        expect(
-          Math.abs(
-            DateTime.toEpochMillis(preservedEntry!.availableAt) -
-              preservedAvailableAt,
-          ),
-        ).toBeLessThan(2_000)
-
-        const missingEntry = schedules.find((entry) => entry.key === missing.id)
-        expect(missingEntry).toBeDefined()
-        expect(
-          DateTime.toEpochMillis(missingEntry!.availableAt) - Date.now(),
-        ).toBeGreaterThan(100_000)
-
-        // Manual first refresh for the repaired Repository was accepted and run.
-        expect(reconciliations).toContain(missing.id)
-        // Existing correct schedule was not reset into an immediate poll.
-        expect(reconciliations).not.toContain(credentialed.id)
-      }).pipe(
-        Effect.provide(
-          Layer.mergeAll(
-            defaultGithubLayer,
-            database,
-            queue,
-            reconciler,
-            keymaxxerLayer(
-              new Set([
-                `${repository.projectPath}`,
-                `${otherRepository.projectPath}`,
-              ]),
+        ).pipe(
+          Effect.provide(
+            Layer.mergeAll(
+              defaultGithubLayer,
+              database,
+              queue,
+              Layer.succeed(IssueReconciler, {
+                reconcile: () => Effect.die("not used"),
+              }),
+              keymaxxerLayer(),
+              lifecycle,
             ),
-            lifecycle,
           ),
-        ),
-        Effect.orDie,
-      ),
-    )
-  })
+          Effect.orDie,
+        )
+      }),
+  )
 
-  test("auto-heal retries with backoff until Keymaxxer succeeds", async () => {
-    const database = DbServiceLive.pipe(Layer.provideMerge(DatabaseTest))
-    const queue = SqliteQueueServiceLive.pipe(Layer.provideMerge(database))
-    let findSecretCalls = 0
-    const keymaxxer = Layer.succeed(KeymaxxerService, {
-      initialize: Effect.void,
-      findSecret: ({ account, provider }) =>
-        Effect.gen(function* () {
-          findSecretCalls += 1
-          if (findSecretCalls < 3) {
-            return yield* new KeymaxxerError({
-              operation: "findSecret",
-              message: "Keymaxxer unavailable",
-            })
-          }
-          return provider === "github" &&
-            account === `${repository.projectPath}`
-            ? `GITHUB_TOKEN`
-            : null
-        }),
-      findSecrets: () => Effect.die("not used"),
-      hasSecret: () => Effect.die("not used"),
-      addSecret: () => Effect.die("not used"),
-      runWithSecrets: () => Effect.die("not used"),
-    })
-    const lifecycle = Layer.succeed(WorkItemLifecycle, {
-      maxDurations: {
-        create_worktree: Duration.minutes(5),
-        install_dependencies: Duration.minutes(15),
-        implement: Duration.hours(2),
-        assess_changes: Duration.minutes(5),
-        pre_commit: Duration.hours(2),
-        review: Duration.hours(1),
-        commit: Duration.minutes(5),
-        create_pr: Duration.minutes(10),
-        watch_pr_status_checks: Duration.minutes(5),
-        resolve_pr_merge_conflict: Duration.hours(2),
-        investigate_pr_status_checks: Duration.hours(2),
-        mark_pr_ready_for_review: Duration.minutes(5),
-        decide_pr_merge: Duration.minutes(15),
-        merge_pr: Duration.minutes(5),
-        close_issue: Duration.minutes(5),
-        local_cleanup: Duration.minutes(5),
-      },
-      implementNow: unused,
-      implementLocally: unused,
-      implementAllWithAutoMerge: unused,
-      queue: unused,
-      recoverOrphanedStepRuns: Effect.succeed(0),
-      interruptRunningStepRunsFromPriorWorker: Effect.succeed(0),
-      runStep: () => Effect.succeed({ _tag: "noop" as const }),
-      retry: unused,
-      pause: unused,
-      start: unused,
-      abandon: unused,
-      reset: unused,
-      getWorkItem: unused,
-      listWorkItemsForIssue: unused,
-      listWorkItemsForRepository: () => Effect.succeed([]),
-      listCompletedWorkItems: () =>
-        Effect.succeed({ items: [], page: 1, pageSize: 20, totalCount: 0 }),
-      ownsSessionId: () => Effect.succeed(false),
-      countCommittedPullRequests: () => Effect.succeed(0),
-      continueAfterHumanPrOutcome: unused,
-      admitWaitingWorkItems: Effect.succeed(0),
-      releaseWaitingForBlockers: () => Effect.succeed(0),
-    })
-
-    await Effect.runPromise(
+  it.live(
+    "startup enqueues one Polling Auto-heal Job without awaiting repair",
+    () =>
       Effect.gen(function* () {
+        const database = DbServiceLive.pipe(Layer.provideMerge(DatabaseTest))
+        const queue = SqliteQueueServiceLive.pipe(Layer.provideMerge(database))
+        const lifecycle = Layer.succeed(WorkItemLifecycle, {
+          maxDurations: {
+            create_worktree: Duration.minutes(5),
+            install_dependencies: Duration.minutes(15),
+            implement: Duration.hours(2),
+            assess_changes: Duration.minutes(5),
+            pre_commit: Duration.hours(2),
+            review: Duration.hours(1),
+            commit: Duration.minutes(5),
+            create_pr: Duration.minutes(10),
+            watch_pr_status_checks: Duration.minutes(5),
+            resolve_pr_merge_conflict: Duration.hours(2),
+            investigate_pr_status_checks: Duration.hours(2),
+            mark_pr_ready_for_review: Duration.minutes(5),
+            decide_pr_merge: Duration.minutes(15),
+            merge_pr: Duration.minutes(5),
+            close_issue: Duration.minutes(5),
+            local_cleanup: Duration.minutes(5),
+          },
+          implementNow: unused,
+          implementLocally: unused,
+          implementAllWithAutoMerge: unused,
+          queue: unused,
+          recoverOrphanedStepRuns: Effect.succeed(0),
+          interruptRunningStepRunsFromPriorWorker: Effect.succeed(0),
+          runStep: () => Effect.succeed({ _tag: "noop" as const }),
+          retry: unused,
+          pause: unused,
+          start: unused,
+          abandon: unused,
+          reset: unused,
+          getWorkItem: unused,
+          listWorkItemsForIssue: unused,
+          listWorkItemsForRepository: () => Effect.succeed([]),
+          listCompletedWorkItems: () =>
+            Effect.succeed({ items: [], page: 1, pageSize: 20, totalCount: 0 }),
+          ownsSessionId: () => Effect.succeed(false),
+          countCommittedPullRequests: () => Effect.succeed(0),
+          continueAfterHumanPrOutcome: unused,
+          admitWaitingWorkItems: Effect.succeed(0),
+          releaseWaitingForBlockers: () => Effect.succeed(0),
+        })
+        // Block Keymaxxer so auto-heal cannot finish during startup.
+        const blockedKeymaxxer = Layer.succeed(KeymaxxerService, {
+          initialize: Effect.void,
+          findSecret: () => Effect.never,
+          findSecrets: () => Effect.die("not used"),
+          hasSecret: () => Effect.die("not used"),
+          addSecret: () => Effect.die("not used"),
+          runWithSecrets: () => Effect.die("not used"),
+        })
+
+        yield* Effect.gen(function* () {
+          const db = yield* DbService
+          const service = yield* QueueService
+          // Ensure auto-heal must consult Keymaxxer (and therefore blocks).
+          yield* db.addRepository({
+            forge: repository.forge,
+            forgeHost: repository.forgeHost,
+            projectPath: repository.projectPath,
+            localPath: repository.localPath,
+            isBare: true,
+          })
+          yield* Effect.scoped(
+            Effect.gen(function* () {
+              yield* startJobWorker({
+                idlePollInterval: Duration.zero,
+                samplePollingDelay: Effect.succeed(Duration.seconds(120)),
+              })
+              // startJobWorker returns after durable enqueue + forking workers,
+              // without waiting for auto-heal to finish (blocked on Keymaxxer).
+              const autoHeal = yield* service.listKeyed(ISSUE_REFRESH_QUEUE)
+              expect(autoHeal).toHaveLength(1)
+              expect(autoHeal[0]?.key).toBe(POLLING_AUTO_HEAL_KEY)
+              expect(autoHeal[0]?.payload).toEqual({
+                _tag: "polling-auto-heal",
+              })
+              // Repair has not completed: no schedules yet.
+              expect(yield* service.listKeyed(ISSUE_POLL_QUEUE)).toEqual([])
+            }),
+          )
+        }).pipe(
+          Effect.provide(
+            Layer.mergeAll(
+              defaultGithubLayer,
+              database,
+              queue,
+              Layer.succeed(IssueReconciler, {
+                reconcile: () => Effect.die("not used"),
+              }),
+              blockedKeymaxxer,
+              lifecycle,
+            ),
+          ),
+          Effect.orDie,
+        )
+      }),
+  )
+
+  it.live(
+    "repeated startup scheduling does not create unbounded Auto-heal Jobs",
+    () =>
+      Effect.gen(function* () {
+        const database = DbServiceLive.pipe(Layer.provideMerge(DatabaseTest))
+        const queue = SqliteQueueServiceLive.pipe(Layer.provideMerge(database))
+
+        yield* Effect.gen(function* () {
+          const service = yield* QueueService
+          const first = yield* enqueuePollingAutoHealJob
+          const second = yield* enqueuePollingAutoHealJob
+          const third = yield* enqueuePollingAutoHealJob
+          expect(first.created).toBe(true)
+          expect(second.created).toBe(false)
+          expect(third.created).toBe(false)
+          expect(second.jobId).toBe(first.jobId)
+          expect(third.jobId).toBe(first.jobId)
+          const keyed = yield* service.listKeyed(ISSUE_REFRESH_QUEUE)
+          expect(keyed).toHaveLength(1)
+          expect(keyed[0]?.key).toBe(POLLING_AUTO_HEAL_KEY)
+        }).pipe(Effect.provide(Layer.mergeAll(database, queue)), Effect.orDie)
+      }),
+  )
+
+  it.live(
+    "auto-heal repairs missing schedules, orphans, due times, and first refreshes",
+    () =>
+      Effect.gen(function* () {
+        const database = DbServiceLive.pipe(Layer.provideMerge(DatabaseTest))
+        const queue = SqliteQueueServiceLive.pipe(Layer.provideMerge(database))
+        const reconciliations: string[] = []
+        const reconciler = Layer.succeed(IssueReconciler, {
+          reconcile: (repo) =>
+            Effect.sync(() => {
+              reconciliations.push(repo.id)
+              return {
+                fetched: 0,
+                inserted: 0,
+                updated: 0,
+                deleted: 0,
+                unchanged: 0,
+              }
+            }),
+        } satisfies IssueReconcilerShape)
+        const lifecycle = Layer.succeed(WorkItemLifecycle, {
+          maxDurations: {
+            create_worktree: Duration.minutes(5),
+            install_dependencies: Duration.minutes(15),
+            implement: Duration.hours(2),
+            assess_changes: Duration.minutes(5),
+            pre_commit: Duration.hours(2),
+            review: Duration.hours(1),
+            commit: Duration.minutes(5),
+            create_pr: Duration.minutes(10),
+            watch_pr_status_checks: Duration.minutes(5),
+            resolve_pr_merge_conflict: Duration.hours(2),
+            investigate_pr_status_checks: Duration.hours(2),
+            mark_pr_ready_for_review: Duration.minutes(5),
+            decide_pr_merge: Duration.minutes(15),
+            merge_pr: Duration.minutes(5),
+            close_issue: Duration.minutes(5),
+            local_cleanup: Duration.minutes(5),
+          },
+          implementNow: unused,
+          implementLocally: unused,
+          implementAllWithAutoMerge: unused,
+          queue: unused,
+          recoverOrphanedStepRuns: Effect.succeed(0),
+          interruptRunningStepRunsFromPriorWorker: Effect.succeed(0),
+          runStep: () => Effect.succeed({ _tag: "noop" as const }),
+          retry: unused,
+          pause: unused,
+          start: unused,
+          abandon: unused,
+          reset: unused,
+          getWorkItem: unused,
+          listWorkItemsForIssue: unused,
+          listWorkItemsForRepository: () => Effect.succeed([]),
+          listCompletedWorkItems: () =>
+            Effect.succeed({ items: [], page: 1, pageSize: 20, totalCount: 0 }),
+          ownsSessionId: () => Effect.succeed(false),
+          countCommittedPullRequests: () => Effect.succeed(0),
+          continueAfterHumanPrOutcome: unused,
+          admitWaitingWorkItems: Effect.succeed(0),
+          releaseWaitingForBlockers: () => Effect.succeed(0),
+        })
+
+        yield* Effect.gen(function* () {
+          const db = yield* DbService
+          const service = yield* QueueService
+          const credentialed = yield* db.addRepository({
+            forge: repository.forge,
+            forgeHost: repository.forgeHost,
+            projectPath: repository.projectPath,
+            localPath: repository.localPath,
+            isBare: true,
+          })
+          const uncredentialed = yield* db.addRepository({
+            forge: "github",
+            forgeHost: "github.com",
+            projectPath: "other/uncredentialed",
+            localPath: "/repos/other/uncredentialed.git",
+            isBare: true,
+          })
+          const preserved = yield* service.ensureKeyed(
+            ISSUE_POLL_QUEUE,
+            credentialed.id,
+            {
+              _tag: "refresh-repository",
+              repositoryId: RepositoryId.make(credentialed.id),
+            },
+            Duration.millis(90_000),
+            { retryLimit: JOB_RECOVERY_RETRY_LIMIT },
+          )
+          const preservedBefore = yield* service.listKeyed(ISSUE_POLL_QUEUE)
+          const preservedAvailableAt = DateTime.toEpochMillis(
+            preservedBefore.find((entry) => entry.key === credentialed.id)!
+              .availableAt,
+          )
+          yield* service.ensureKeyed(
+            ISSUE_POLL_QUEUE,
+            uncredentialed.id,
+            {
+              _tag: "refresh-repository",
+              repositoryId: RepositoryId.make(uncredentialed.id),
+            },
+            Duration.seconds(30),
+            { retryLimit: JOB_RECOVERY_RETRY_LIMIT },
+          )
+          yield* service.ensureKeyed(
+            ISSUE_POLL_QUEUE,
+            "repo-deleted-orphan",
+            {
+              _tag: "refresh-repository",
+              repositoryId: RepositoryId.make(
+                "repo-01J00000000000000000000099",
+              ),
+            },
+            Duration.seconds(30),
+            { retryLimit: JOB_RECOVERY_RETRY_LIMIT },
+          )
+
+          const missing = yield* db.addRepository({
+            forge: otherRepository.forge,
+            forgeHost: otherRepository.forgeHost,
+            projectPath: otherRepository.projectPath,
+            localPath: otherRepository.localPath,
+            isBare: true,
+          })
+
+          yield* Effect.scoped(
+            Effect.gen(function* () {
+              yield* startJobWorker({
+                idlePollInterval: Duration.zero,
+                samplePollingDelay: Effect.succeed(Duration.seconds(142)),
+              })
+              // Wait until auto-heal finishes and the missing repo's first refresh runs.
+              while (
+                !(
+                  reconciliations.includes(missing.id) &&
+                  (yield* service.listKeyed(ISSUE_REFRESH_QUEUE)).every(
+                    (entry) => entry.key !== POLLING_AUTO_HEAL_KEY,
+                  )
+                )
+              ) {
+                yield* Effect.sleep("5 millis")
+              }
+            }),
+          )
+
+          const schedules = yield* service.listKeyed(ISSUE_POLL_QUEUE)
+          expect(schedules.map((entry) => entry.key).sort()).toEqual(
+            [credentialed.id, missing.id].sort(),
+          )
+          const preservedEntry = schedules.find(
+            (entry) => entry.key === credentialed.id,
+          )
+          expect(preservedEntry?.jobId).toBe(preserved.jobId)
+          expect(
+            Math.abs(
+              DateTime.toEpochMillis(preservedEntry!.availableAt) -
+                preservedAvailableAt,
+            ),
+          ).toBeLessThan(2_000)
+
+          const missingEntry = schedules.find(
+            (entry) => entry.key === missing.id,
+          )
+          expect(missingEntry).toBeDefined()
+          expect(
+            DateTime.toEpochMillis(missingEntry!.availableAt) - Date.now(),
+          ).toBeGreaterThan(100_000)
+
+          // Manual first refresh for the repaired Repository was accepted and run.
+          expect(reconciliations).toContain(missing.id)
+          // Existing correct schedule was not reset into an immediate poll.
+          expect(reconciliations).not.toContain(credentialed.id)
+        }).pipe(
+          Effect.provide(
+            Layer.mergeAll(
+              defaultGithubLayer,
+              database,
+              queue,
+              reconciler,
+              keymaxxerLayer(
+                new Set([
+                  `${repository.projectPath}`,
+                  `${otherRepository.projectPath}`,
+                ]),
+              ),
+              lifecycle,
+            ),
+          ),
+          Effect.orDie,
+        )
+      }),
+  )
+
+  it.live("auto-heal retries with backoff until Keymaxxer succeeds", () =>
+    Effect.gen(function* () {
+      const database = DbServiceLive.pipe(Layer.provideMerge(DatabaseTest))
+      const queue = SqliteQueueServiceLive.pipe(Layer.provideMerge(database))
+      let findSecretCalls = 0
+      const keymaxxer = Layer.succeed(KeymaxxerService, {
+        initialize: Effect.void,
+        findSecret: ({ account, provider }) =>
+          Effect.gen(function* () {
+            findSecretCalls += 1
+            if (findSecretCalls < 3) {
+              return yield* new KeymaxxerError({
+                operation: "findSecret",
+                message: "Keymaxxer unavailable",
+              })
+            }
+            return provider === "github" &&
+              account === `${repository.projectPath}`
+              ? `GITHUB_TOKEN`
+              : null
+          }),
+        findSecrets: () => Effect.die("not used"),
+        hasSecret: () => Effect.die("not used"),
+        addSecret: () => Effect.die("not used"),
+        runWithSecrets: () => Effect.die("not used"),
+      })
+      const lifecycle = Layer.succeed(WorkItemLifecycle, {
+        maxDurations: {
+          create_worktree: Duration.minutes(5),
+          install_dependencies: Duration.minutes(15),
+          implement: Duration.hours(2),
+          assess_changes: Duration.minutes(5),
+          pre_commit: Duration.hours(2),
+          review: Duration.hours(1),
+          commit: Duration.minutes(5),
+          create_pr: Duration.minutes(10),
+          watch_pr_status_checks: Duration.minutes(5),
+          resolve_pr_merge_conflict: Duration.hours(2),
+          investigate_pr_status_checks: Duration.hours(2),
+          mark_pr_ready_for_review: Duration.minutes(5),
+          decide_pr_merge: Duration.minutes(15),
+          merge_pr: Duration.minutes(5),
+          close_issue: Duration.minutes(5),
+          local_cleanup: Duration.minutes(5),
+        },
+        implementNow: unused,
+        implementLocally: unused,
+        implementAllWithAutoMerge: unused,
+        queue: unused,
+        recoverOrphanedStepRuns: Effect.succeed(0),
+        interruptRunningStepRunsFromPriorWorker: Effect.succeed(0),
+        runStep: () => Effect.succeed({ _tag: "noop" as const }),
+        retry: unused,
+        pause: unused,
+        start: unused,
+        abandon: unused,
+        reset: unused,
+        getWorkItem: unused,
+        listWorkItemsForIssue: unused,
+        listWorkItemsForRepository: () => Effect.succeed([]),
+        listCompletedWorkItems: () =>
+          Effect.succeed({ items: [], page: 1, pageSize: 20, totalCount: 0 }),
+        ownsSessionId: () => Effect.succeed(false),
+        countCommittedPullRequests: () => Effect.succeed(0),
+        continueAfterHumanPrOutcome: unused,
+        admitWaitingWorkItems: Effect.succeed(0),
+        releaseWaitingForBlockers: () => Effect.succeed(0),
+      })
+
+      yield* Effect.gen(function* () {
         const db = yield* DbService
         const service = yield* QueueService
         const added = yield* db.addRepository({
@@ -2350,131 +2464,133 @@ describe("Job worker", () => {
           ),
         ),
         Effect.orDie,
-      ),
-    )
-  })
+      )
+    }),
+  )
 
-  test("successful auto-heal does not disturb queued manual Refresh Jobs", async () => {
-    const database = DbServiceLive.pipe(Layer.provideMerge(DatabaseTest))
-    const queue = SqliteQueueServiceLive.pipe(Layer.provideMerge(database))
-    const reconciliations: string[] = []
-    const reconciler = Layer.succeed(IssueReconciler, {
-      reconcile: (repo) =>
-        Effect.sync(() => {
-          reconciliations.push(repo.id)
-          return {
-            fetched: 0,
-            inserted: 0,
-            updated: 0,
-            deleted: 0,
-            unchanged: 0,
-          }
-        }),
-    } satisfies IssueReconcilerShape)
-    const lifecycle = Layer.succeed(WorkItemLifecycle, {
-      maxDurations: {
-        create_worktree: Duration.minutes(5),
-        install_dependencies: Duration.minutes(15),
-        implement: Duration.hours(2),
-        assess_changes: Duration.minutes(5),
-        pre_commit: Duration.hours(2),
-        review: Duration.hours(1),
-        commit: Duration.minutes(5),
-        create_pr: Duration.minutes(10),
-        watch_pr_status_checks: Duration.minutes(5),
-        resolve_pr_merge_conflict: Duration.hours(2),
-        investigate_pr_status_checks: Duration.hours(2),
-        mark_pr_ready_for_review: Duration.minutes(5),
-        decide_pr_merge: Duration.minutes(15),
-        merge_pr: Duration.minutes(5),
-        close_issue: Duration.minutes(5),
-        local_cleanup: Duration.minutes(5),
-      },
-      implementNow: unused,
-      implementLocally: unused,
-      implementAllWithAutoMerge: unused,
-      queue: unused,
-      recoverOrphanedStepRuns: Effect.succeed(0),
-      interruptRunningStepRunsFromPriorWorker: Effect.succeed(0),
-      runStep: () => Effect.succeed({ _tag: "noop" as const }),
-      retry: unused,
-      pause: unused,
-      start: unused,
-      abandon: unused,
-      reset: unused,
-      getWorkItem: unused,
-      listWorkItemsForIssue: unused,
-      listWorkItemsForRepository: () => Effect.succeed([]),
-      listCompletedWorkItems: () =>
-        Effect.succeed({ items: [], page: 1, pageSize: 20, totalCount: 0 }),
-      ownsSessionId: () => Effect.succeed(false),
-      countCommittedPullRequests: () => Effect.succeed(0),
-      continueAfterHumanPrOutcome: unused,
-      admitWaitingWorkItems: Effect.succeed(0),
-      releaseWaitingForBlockers: () => Effect.succeed(0),
-    })
-
-    await Effect.runPromise(
+  it.live(
+    "successful auto-heal does not disturb queued manual Refresh Jobs",
+    () =>
       Effect.gen(function* () {
-        const db = yield* DbService
-        const service = yield* QueueService
-        const added = yield* db.addRepository({
-          forge: repository.forge,
-          forgeHost: repository.forgeHost,
-          projectPath: repository.projectPath,
-          localPath: repository.localPath,
-          isBare: true,
-        })
-        const manualId = yield* service.enqueue(
-          ISSUE_REFRESH_QUEUE,
-          {
-            _tag: "refresh-repository",
-            repositoryId: RepositoryId.make(added.id),
+        const database = DbServiceLive.pipe(Layer.provideMerge(DatabaseTest))
+        const queue = SqliteQueueServiceLive.pipe(Layer.provideMerge(database))
+        const reconciliations: string[] = []
+        const reconciler = Layer.succeed(IssueReconciler, {
+          reconcile: (repo) =>
+            Effect.sync(() => {
+              reconciliations.push(repo.id)
+              return {
+                fetched: 0,
+                inserted: 0,
+                updated: 0,
+                deleted: 0,
+                unchanged: 0,
+              }
+            }),
+        } satisfies IssueReconcilerShape)
+        const lifecycle = Layer.succeed(WorkItemLifecycle, {
+          maxDurations: {
+            create_worktree: Duration.minutes(5),
+            install_dependencies: Duration.minutes(15),
+            implement: Duration.hours(2),
+            assess_changes: Duration.minutes(5),
+            pre_commit: Duration.hours(2),
+            review: Duration.hours(1),
+            commit: Duration.minutes(5),
+            create_pr: Duration.minutes(10),
+            watch_pr_status_checks: Duration.minutes(5),
+            resolve_pr_merge_conflict: Duration.hours(2),
+            investigate_pr_status_checks: Duration.hours(2),
+            mark_pr_ready_for_review: Duration.minutes(5),
+            decide_pr_merge: Duration.minutes(15),
+            merge_pr: Duration.minutes(5),
+            close_issue: Duration.minutes(5),
+            local_cleanup: Duration.minutes(5),
           },
-          { retryLimit: JOB_RECOVERY_RETRY_LIMIT },
-        )
+          implementNow: unused,
+          implementLocally: unused,
+          implementAllWithAutoMerge: unused,
+          queue: unused,
+          recoverOrphanedStepRuns: Effect.succeed(0),
+          interruptRunningStepRunsFromPriorWorker: Effect.succeed(0),
+          runStep: () => Effect.succeed({ _tag: "noop" as const }),
+          retry: unused,
+          pause: unused,
+          start: unused,
+          abandon: unused,
+          reset: unused,
+          getWorkItem: unused,
+          listWorkItemsForIssue: unused,
+          listWorkItemsForRepository: () => Effect.succeed([]),
+          listCompletedWorkItems: () =>
+            Effect.succeed({ items: [], page: 1, pageSize: 20, totalCount: 0 }),
+          ownsSessionId: () => Effect.succeed(false),
+          countCommittedPullRequests: () => Effect.succeed(0),
+          continueAfterHumanPrOutcome: unused,
+          admitWaitingWorkItems: Effect.succeed(0),
+          releaseWaitingForBlockers: () => Effect.succeed(0),
+        })
 
-        yield* Effect.scoped(
-          Effect.gen(function* () {
-            yield* startJobWorker({
-              idlePollInterval: Duration.zero,
-              samplePollingDelay: Effect.succeed(Duration.seconds(120)),
-            })
-            while (!reconciliations.includes(added.id)) {
-              yield* Effect.sleep("5 millis")
-            }
-            // Allow the worker to drain high-priority work.
-            yield* Effect.sleep("50 millis")
-          }),
-        )
+        yield* Effect.gen(function* () {
+          const db = yield* DbService
+          const service = yield* QueueService
+          const added = yield* db.addRepository({
+            forge: repository.forge,
+            forgeHost: repository.forgeHost,
+            projectPath: repository.projectPath,
+            localPath: repository.localPath,
+            isBare: true,
+          })
+          const manualId = yield* service.enqueue(
+            ISSUE_REFRESH_QUEUE,
+            {
+              _tag: "refresh-repository",
+              repositoryId: RepositoryId.make(added.id),
+            },
+            { retryLimit: JOB_RECOVERY_RETRY_LIMIT },
+          )
 
-        expect(
-          reconciliations.filter((id) => id === added.id).length,
-        ).toBeGreaterThanOrEqual(1)
-        // Manual job identity was accepted before auto-heal; after drain it is gone.
-        const remaining = yield* service.rawClaim(ISSUE_REFRESH_QUEUE)
-        expect(Option.isNone(remaining)).toBe(true)
-        // The schedule exists and auto-heal is finalized.
-        const schedules = yield* service.listKeyed(ISSUE_POLL_QUEUE)
-        expect(schedules.map((entry) => entry.key)).toEqual([added.id])
-        const autoHeal = yield* service.listKeyed(ISSUE_REFRESH_QUEUE)
-        expect(
-          autoHeal.filter((entry) => entry.key === POLLING_AUTO_HEAL_KEY),
-        ).toHaveLength(0)
-        void manualId
-      }).pipe(
-        Effect.provide(
-          Layer.mergeAll(
-            defaultGithubLayer,
-            database,
-            queue,
-            reconciler,
-            keymaxxerLayer(),
-            lifecycle,
+          yield* Effect.scoped(
+            Effect.gen(function* () {
+              yield* startJobWorker({
+                idlePollInterval: Duration.zero,
+                samplePollingDelay: Effect.succeed(Duration.seconds(120)),
+              })
+              while (!reconciliations.includes(added.id)) {
+                yield* Effect.sleep("5 millis")
+              }
+              // Allow the worker to drain high-priority work.
+              yield* Effect.sleep("50 millis")
+            }),
+          )
+
+          expect(
+            reconciliations.filter((id) => id === added.id).length,
+          ).toBeGreaterThanOrEqual(1)
+          // Manual job identity was accepted before auto-heal; after drain it is gone.
+          const remaining = yield* service.rawClaim(ISSUE_REFRESH_QUEUE)
+          expect(Option.isNone(remaining)).toBe(true)
+          // The schedule exists and auto-heal is finalized.
+          const schedules = yield* service.listKeyed(ISSUE_POLL_QUEUE)
+          expect(schedules.map((entry) => entry.key)).toEqual([added.id])
+          const autoHeal = yield* service.listKeyed(ISSUE_REFRESH_QUEUE)
+          expect(
+            autoHeal.filter((entry) => entry.key === POLLING_AUTO_HEAL_KEY),
+          ).toHaveLength(0)
+          void manualId
+        }).pipe(
+          Effect.provide(
+            Layer.mergeAll(
+              defaultGithubLayer,
+              database,
+              queue,
+              reconciler,
+              keymaxxerLayer(),
+              lifecycle,
+            ),
           ),
-        ),
-        Effect.orDie,
-      ),
-    )
-  })
+          Effect.orDie,
+        )
+      }),
+  )
 })

--- a/apps/harness/test/keymaxxer-github-layer.test.ts
+++ b/apps/harness/test/keymaxxer-github-layer.test.ts
@@ -1,4 +1,5 @@
-import { Effect, Exit, Layer } from "effect"
+import { describe, expect, it } from "@effect/vitest"
+import { Deferred, Effect, Exit, Fiber, Layer } from "effect"
 import {
   GitHubRequestError,
   GitHubService,
@@ -11,7 +12,6 @@ import {
   OPEN_PULL_REQUEST_COUNT_FRESHNESS_MS,
   keymaxxerGitHubLayer,
 } from "../src/server/keymaxxer-github-layer.js"
-import { describe, expect, test } from "bun:test"
 
 const acmeWidgets = {
   forge: "github",
@@ -26,69 +26,72 @@ const acmeGadgets = {
 } as const
 
 describe("Keymaxxer-backed GitHub layer", () => {
-  test("does not prompt Keymaxxer when a repository token is missing", async () => {
-    let addCalled = false
-    const runs: RunWithSecretsInput[] = []
-    const keymaxxerLayer = Layer.succeed(KeymaxxerService, {
-      initialize: Effect.void,
-      findSecret: () => Effect.succeed(null),
-      findSecrets: () => Effect.die("not used"),
-      hasSecret: () => Effect.die("not used"),
-      addSecret: () =>
-        Effect.sync(() => {
-          addCalled = true
-          return true
-        }),
-      runWithSecrets: (input) => {
-        runs.push(input)
-        return Effect.succeed({ exitCode: 0, stdout: "[]", stderr: "" })
-      },
-    })
-    const layer = keymaxxerGitHubLayer({ workspaceRoot: "/workspace" }).pipe(
-      Layer.provide(keymaxxerLayer),
-    )
-
-    const exit = await Effect.runPromise(
+  it.effect(
+    "does not prompt Keymaxxer when a repository token is missing",
+    () =>
       Effect.gen(function* () {
-        const github = yield* GitHubService
-        return yield* Effect.exit(
-          github.listReadyIssues({
-            forge: "github",
-            forgeHost: "github.com",
-            projectPath: "foo-bar/baz",
-          }),
-        )
-      }).pipe(Effect.provide(layer)),
-    )
+        let addCalled = false
+        const runs: RunWithSecretsInput[] = []
+        const keymaxxerLayer = Layer.succeed(KeymaxxerService, {
+          initialize: Effect.void,
+          findSecret: () => Effect.succeed(null),
+          findSecrets: () => Effect.die("not used"),
+          hasSecret: () => Effect.die("not used"),
+          addSecret: () =>
+            Effect.sync(() => {
+              addCalled = true
+              return true
+            }),
+          runWithSecrets: (input) => {
+            runs.push(input)
+            return Effect.succeed({ exitCode: 0, stdout: "[]", stderr: "" })
+          },
+        })
+        const layer = keymaxxerGitHubLayer({
+          workspaceRoot: "/workspace",
+        }).pipe(Layer.provide(keymaxxerLayer))
 
-    expect(exit._tag).toBe("Failure")
-    expect(addCalled).toBe(false)
-    expect(runs).toHaveLength(0)
-  })
+        const exit = yield* Effect.gen(function* () {
+          const github = yield* GitHubService
+          return yield* Effect.exit(
+            github.listReadyIssues({
+              forge: "github",
+              forgeHost: "github.com",
+              projectPath: "foo-bar/baz",
+            }),
+          )
+        }).pipe(Effect.provide(layer))
 
-  test("selects colliding token names by Repository account", async () => {
-    const runs: RunWithSecretsInput[] = []
-    const tokens = new Map([
-      ["foo-bar/baz", "TOKEN_FOR_FIRST_REPOSITORY"],
-      ["foo/bar-baz", "TOKEN_FOR_SECOND_REPOSITORY"],
-    ])
-    const keymaxxerLayer = Layer.succeed(KeymaxxerService, {
-      initialize: Effect.void,
-      findSecret: ({ account }) => Effect.succeed(tokens.get(account) ?? null),
-      findSecrets: () => Effect.die("not used"),
-      hasSecret: () => Effect.die("not used"),
-      addSecret: () => Effect.die("not used"),
-      runWithSecrets: (input) => {
-        runs.push(input)
-        return Effect.succeed({ exitCode: 0, stdout: "[]", stderr: "" })
-      },
-    })
-    const layer = keymaxxerGitHubLayer({ workspaceRoot: "/workspace" }).pipe(
-      Layer.provide(keymaxxerLayer),
-    )
+        expect(exit._tag).toBe("Failure")
+        expect(addCalled).toBe(false)
+        expect(runs).toHaveLength(0)
+      }),
+  )
 
-    await Effect.runPromise(
-      Effect.gen(function* () {
+  it.effect("selects colliding token names by Repository account", () =>
+    Effect.gen(function* () {
+      const runs: RunWithSecretsInput[] = []
+      const tokens = new Map([
+        ["foo-bar/baz", "TOKEN_FOR_FIRST_REPOSITORY"],
+        ["foo/bar-baz", "TOKEN_FOR_SECOND_REPOSITORY"],
+      ])
+      const keymaxxerLayer = Layer.succeed(KeymaxxerService, {
+        initialize: Effect.void,
+        findSecret: ({ account }) =>
+          Effect.succeed(tokens.get(account) ?? null),
+        findSecrets: () => Effect.die("not used"),
+        hasSecret: () => Effect.die("not used"),
+        addSecret: () => Effect.die("not used"),
+        runWithSecrets: (input) => {
+          runs.push(input)
+          return Effect.succeed({ exitCode: 0, stdout: "[]", stderr: "" })
+        },
+      })
+      const layer = keymaxxerGitHubLayer({ workspaceRoot: "/workspace" }).pipe(
+        Layer.provide(keymaxxerLayer),
+      )
+
+      yield* Effect.gen(function* () {
         const github = yield* GitHubService
         yield* github.listReadyIssues({
           forge: "github",
@@ -100,226 +103,425 @@ describe("Keymaxxer-backed GitHub layer", () => {
           forgeHost: "github.com",
           projectPath: "foo/bar-baz",
         })
-      }).pipe(Effect.provide(layer)),
-    )
+      }).pipe(Effect.provide(layer))
 
-    expect(runs.map(({ secrets }) => secrets)).toEqual([
-      ["TOKEN_FOR_FIRST_REPOSITORY"],
-      ["TOKEN_FOR_SECOND_REPOSITORY"],
-    ])
-  })
+      expect(runs.map(({ secrets }) => secrets)).toEqual([
+        ["TOKEN_FOR_FIRST_REPOSITORY"],
+        ["TOKEN_FOR_SECOND_REPOSITORY"],
+      ])
+    }),
+  )
 
-  test("obtains the configured repository GitHub token through Keymaxxer", async () => {
-    const runs: RunWithSecretsInput[] = []
-    const keymaxxerLayer = Layer.succeed(KeymaxxerService, {
-      initialize: Effect.void,
-      findSecret: ({ account }) =>
-        Effect.succeed(
-          account === "acme/widgets" ? "GITHUB_TOKEN_ACME_WIDGETS" : null,
-        ),
-      findSecrets: () => Effect.die("not used"),
-      hasSecret: () => Effect.die("not used"),
-      addSecret: () => Effect.die("not used"),
-      runWithSecrets: (input) => {
-        runs.push(input)
-        return Effect.succeed({
-          exitCode: 0,
-          stdout: JSON.stringify([
-            {
-              number: 7,
-              title: "Ready issue",
-              body: "Issue body",
-              url: "https://github.com/acme/widgets/issues/7",
-              createdAt: "2026-07-07T12:00:00.000Z",
-              state: "OPEN",
-              author: "octocat",
-              hierarchySupported: true,
-              closingPullRequests: [],
-              hasChildren: false,
-              parentPosition: 0,
-              parent: {
-                number: 1,
-                url: "https://github.com/acme/widgets/issues/1",
-                state: "OPEN",
-                isReadyLabeled: true,
-              },
-              blockedBy: [
+  it.effect(
+    "obtains the configured repository GitHub token through Keymaxxer",
+    () =>
+      Effect.gen(function* () {
+        const runs: RunWithSecretsInput[] = []
+        const keymaxxerLayer = Layer.succeed(KeymaxxerService, {
+          initialize: Effect.void,
+          findSecret: ({ account }) =>
+            Effect.succeed(
+              account === "acme/widgets" ? "GITHUB_TOKEN_ACME_WIDGETS" : null,
+            ),
+          findSecrets: () => Effect.die("not used"),
+          hasSecret: () => Effect.die("not used"),
+          addSecret: () => Effect.die("not used"),
+          runWithSecrets: (input) => {
+            runs.push(input)
+            return Effect.succeed({
+              exitCode: 0,
+              stdout: JSON.stringify([
                 {
-                  number: 3,
-                  url: "https://github.com/acme/widgets/issues/3",
+                  number: 7,
+                  title: "Ready issue",
+                  body: "Issue body",
+                  url: "https://github.com/acme/widgets/issues/7",
+                  createdAt: "2026-07-07T12:00:00.000Z",
+                  state: "OPEN",
+                  author: "octocat",
+                  hierarchySupported: true,
+                  closingPullRequests: [],
+                  hasChildren: false,
+                  parentPosition: 0,
+                  parent: {
+                    number: 1,
+                    url: "https://github.com/acme/widgets/issues/1",
+                    state: "OPEN",
+                    isReadyLabeled: true,
+                  },
+                  blockedBy: [
+                    {
+                      number: 3,
+                      url: "https://github.com/acme/widgets/issues/3",
+                    },
+                  ],
+                },
+              ]),
+              stderr: "",
+            })
+          },
+        })
+        const layer = keymaxxerGitHubLayer({
+          workspaceRoot: "/workspace",
+        }).pipe(Layer.provide(keymaxxerLayer))
+
+        const results = yield* Effect.gen(function* () {
+          const github = yield* GitHubService
+          return yield* Effect.all(
+            [
+              github.listReadyIssues({
+                forge: "github",
+                forgeHost: "github.com",
+                projectPath: "acme/widgets",
+              }),
+              github.listReadyIssues({
+                forge: "github",
+                forgeHost: "github.com",
+                projectPath: "acme/widgets",
+              }),
+            ],
+            { concurrency: "unbounded" },
+          )
+        }).pipe(Effect.provide(layer))
+
+        expect(results[0]?.[0]?.createdAt).toEqual(
+          new Date("2026-07-07T12:00:00.000Z"),
+        )
+        expect(results[0]?.[0]?.blockedBy).toEqual([
+          {
+            number: 3,
+            url: "https://github.com/acme/widgets/issues/3",
+          },
+        ])
+        expect(results[0]?.[0]?.parent).toEqual({
+          number: 1,
+          url: "https://github.com/acme/widgets/issues/1",
+          state: "OPEN",
+          isReadyLabeled: true,
+        })
+        expect(runs).toHaveLength(2)
+        expect(runs.map(({ secrets }) => secrets)).toEqual([
+          ["GITHUB_TOKEN_ACME_WIDGETS"],
+          ["GITHUB_TOKEN_ACME_WIDGETS"],
+        ])
+        expect(
+          runs[0]?.command.startsWith(
+            'GITHUB_TOKEN="$GITHUB_TOKEN_ACME_WIDGETS" ',
+          ),
+        ).toBe(true)
+        expect(runs[0]?.command).toContain("list-ready-issues.ts")
+        expect(runs[0]?.command).toMatch(
+          /"--conditions" "@ready-for-agent\/source" "\/.*list-ready-issues\.ts"/,
+        )
+        expect(runs[0]?.command).not.toContain(
+          "--ready-for-agent-internal-github-helper",
+        )
+        expect(runs[0]?.cwd).toBe("/workspace")
+        expect(runs[0]?.command).not.toContain("Ready issue")
+      }),
+  )
+
+  it.effect("checks a PR branch through the configured repository token", () =>
+    Effect.gen(function* () {
+      const runs: RunWithSecretsInput[] = []
+      const keymaxxerLayer = Layer.succeed(KeymaxxerService, {
+        initialize: Effect.void,
+        findSecret: () => Effect.succeed("GITHUB_TOKEN_ACME_WIDGETS"),
+        findSecrets: () => Effect.die("not used"),
+        hasSecret: () => Effect.die("not used"),
+        addSecret: () => Effect.die("not used"),
+        runWithSecrets: (input) => {
+          runs.push(input)
+          return Effect.succeed({
+            exitCode: 0,
+            stdout: JSON.stringify({
+              _tag: "failed",
+              mergeability: "conflicting",
+              baseRefName: "develop",
+              headPushedAt: null,
+              headSha: null,
+              createdAt: null,
+              isDraft: null,
+              terminalChecks: [
+                {
+                  externalId: "checkrun:1",
+                  name: "lint",
+                  outcome: "red",
                 },
               ],
+            }),
+            stderr: "",
+          })
+        },
+      })
+      const layer = keymaxxerGitHubLayer({ workspaceRoot: "/workspace" }).pipe(
+        Layer.provide(keymaxxerLayer),
+      )
+
+      const status = yield* Effect.gen(function* () {
+        const github = yield* GitHubService
+        return yield* github.getPullRequestCheckStatus(
+          {
+            forge: "github",
+            forgeHost: "github.com",
+            projectPath: "acme/widgets",
+          },
+          "rfa/acme-widgets/42/wi-test",
+        )
+      }).pipe(Effect.provide(layer))
+
+      expect(status).toEqual({
+        _tag: "failed",
+        mergeability: "conflicting",
+        baseRefName: "develop",
+        headPushedAt: null,
+        headSha: null,
+        createdAt: null,
+        isDraft: null,
+        terminalChecks: [
+          {
+            externalId: "checkrun:1",
+            name: "lint",
+            outcome: "red",
+          },
+        ],
+      })
+      expect(runs[0]?.command).toContain("get-pr-check-status.ts")
+      expect(runs[0]?.command).toContain('"--conditions"')
+      expect(runs[0]?.secrets).toEqual(["GITHUB_TOKEN_ACME_WIDGETS"])
+    }),
+  )
+
+  it.effect("maps unparseable PR check-status instants to null", () =>
+    Effect.gen(function* () {
+      const keymaxxerLayer = Layer.succeed(KeymaxxerService, {
+        initialize: Effect.void,
+        findSecret: () => Effect.succeed("GITHUB_TOKEN_ACME_WIDGETS"),
+        findSecrets: () => Effect.die("not used"),
+        hasSecret: () => Effect.die("not used"),
+        addSecret: () => Effect.die("not used"),
+        runWithSecrets: () =>
+          Effect.succeed({
+            exitCode: 0,
+            stdout: JSON.stringify({
+              _tag: "succeeded",
+              mergeability: "mergeable",
+              baseRefName: "main",
+              headPushedAt: "not-a-date",
+              headSha: "abc123",
+              createdAt: "garbage",
+              isDraft: false,
+              terminalChecks: [
+                {
+                  externalId: "checkrun:1",
+                  name: "lint",
+                  outcome: "green",
+                },
+              ],
+            }),
+            stderr: "",
+          }),
+      })
+      const layer = keymaxxerGitHubLayer({ workspaceRoot: "/workspace" }).pipe(
+        Layer.provide(keymaxxerLayer),
+      )
+
+      const status = yield* Effect.gen(function* () {
+        const github = yield* GitHubService
+        return yield* github.getPullRequestCheckStatus(
+          {
+            forge: "github",
+            forgeHost: "github.com",
+            projectPath: "acme/widgets",
+          },
+          "rfa/acme-widgets/42/wi-test",
+        )
+      }).pipe(Effect.provide(layer))
+
+      expect(status).toEqual({
+        _tag: "succeeded",
+        mergeability: "mergeable",
+        baseRefName: "main",
+        headPushedAt: null,
+        headSha: "abc123",
+        createdAt: null,
+        isDraft: false,
+        terminalChecks: [
+          {
+            externalId: "checkrun:1",
+            name: "lint",
+            outcome: "green",
+          },
+        ],
+      })
+    }),
+  )
+
+  it.effect(
+    "resolves an open PR number through the configured repository token",
+    () =>
+      Effect.gen(function* () {
+        const runs: RunWithSecretsInput[] = []
+        const keymaxxerLayer = Layer.succeed(KeymaxxerService, {
+          initialize: Effect.void,
+          findSecret: () => Effect.succeed("GITHUB_TOKEN_ACME_WIDGETS"),
+          findSecrets: () => Effect.die("not used"),
+          hasSecret: () => Effect.die("not used"),
+          addSecret: () => Effect.die("not used"),
+          runWithSecrets: (input) => {
+            runs.push(input)
+            return Effect.succeed({ exitCode: 0, stdout: "321", stderr: "" })
+          },
+        })
+        const layer = keymaxxerGitHubLayer({
+          workspaceRoot: "/workspace",
+        }).pipe(Layer.provide(keymaxxerLayer))
+
+        const number = yield* Effect.gen(function* () {
+          const github = yield* GitHubService
+          return yield* github.getOpenPullRequestNumber(
+            {
+              forge: "github",
+              forgeHost: "github.com",
+              projectPath: "acme/widgets",
             },
-          ]),
-          stderr: "",
-        })
-      },
-    })
-    const layer = keymaxxerGitHubLayer({
-      workspaceRoot: "/workspace",
-    }).pipe(Layer.provide(keymaxxerLayer))
+            "rfa/acme-widgets/42/wi-test",
+          )
+        }).pipe(Effect.provide(layer))
 
-    const results = await Effect.runPromise(
+        expect(number).toBe(321)
+        expect(runs[0]?.command).toContain("get-open-pr-number.ts")
+        expect(runs[0]?.command).toContain('"--conditions"')
+      }),
+  )
+
+  it.effect(
+    "counts open non-draft pull requests through the configured repository token",
+    () =>
       Effect.gen(function* () {
-        const github = yield* GitHubService
-        return yield* Effect.all(
-          [
-            github.listReadyIssues({
-              forge: "github",
-              forgeHost: "github.com",
-              projectPath: "acme/widgets",
-            }),
-            github.listReadyIssues({
-              forge: "github",
-              forgeHost: "github.com",
-              projectPath: "acme/widgets",
-            }),
-          ],
-          { concurrency: "unbounded" },
-        )
-      }).pipe(Effect.provide(layer)),
-    )
-
-    expect(results[0]?.[0]?.createdAt).toEqual(
-      new Date("2026-07-07T12:00:00.000Z"),
-    )
-    expect(results[0]?.[0]?.blockedBy).toEqual([
-      {
-        number: 3,
-        url: "https://github.com/acme/widgets/issues/3",
-      },
-    ])
-    expect(results[0]?.[0]?.parent).toEqual({
-      number: 1,
-      url: "https://github.com/acme/widgets/issues/1",
-      state: "OPEN",
-      isReadyLabeled: true,
-    })
-    expect(runs).toHaveLength(2)
-    expect(runs.map(({ secrets }) => secrets)).toEqual([
-      ["GITHUB_TOKEN_ACME_WIDGETS"],
-      ["GITHUB_TOKEN_ACME_WIDGETS"],
-    ])
-    expect(runs[0]?.command).toStartWith(
-      'GITHUB_TOKEN="$GITHUB_TOKEN_ACME_WIDGETS" ',
-    )
-    expect(runs[0]?.command).toContain("list-ready-issues.ts")
-    expect(runs[0]?.command).toMatch(
-      /"--conditions" "@ready-for-agent\/source" "\/.*list-ready-issues\.ts"/,
-    )
-    expect(runs[0]?.command).not.toContain(
-      "--ready-for-agent-internal-github-helper",
-    )
-    expect(runs[0]?.cwd).toBe("/workspace")
-    expect(runs[0]?.command).not.toContain("Ready issue")
-  })
-
-  test("checks a PR branch through the configured repository token", async () => {
-    const runs: RunWithSecretsInput[] = []
-    const keymaxxerLayer = Layer.succeed(KeymaxxerService, {
-      initialize: Effect.void,
-      findSecret: () => Effect.succeed("GITHUB_TOKEN_ACME_WIDGETS"),
-      findSecrets: () => Effect.die("not used"),
-      hasSecret: () => Effect.die("not used"),
-      addSecret: () => Effect.die("not used"),
-      runWithSecrets: (input) => {
-        runs.push(input)
-        return Effect.succeed({
-          exitCode: 0,
-          stdout: JSON.stringify({
-            _tag: "failed",
-            mergeability: "conflicting",
-            baseRefName: "develop",
-            headPushedAt: null,
-            headSha: null,
-            createdAt: null,
-            isDraft: null,
-            terminalChecks: [
-              {
-                externalId: "checkrun:1",
-                name: "lint",
-                outcome: "red",
-              },
-            ],
-          }),
-          stderr: "",
+        const runs: RunWithSecretsInput[] = []
+        const keymaxxerLayer = Layer.succeed(KeymaxxerService, {
+          initialize: Effect.void,
+          findSecret: () => Effect.succeed("GITHUB_TOKEN_ACME_WIDGETS"),
+          findSecrets: () => Effect.die("not used"),
+          hasSecret: () => Effect.die("not used"),
+          addSecret: () => Effect.die("not used"),
+          runWithSecrets: (input) => {
+            runs.push(input)
+            return Effect.succeed({ exitCode: 0, stdout: "4", stderr: "" })
+          },
         })
-      },
-    })
-    const layer = keymaxxerGitHubLayer({ workspaceRoot: "/workspace" }).pipe(
-      Layer.provide(keymaxxerLayer),
-    )
+        const layer = keymaxxerGitHubLayer({
+          workspaceRoot: "/workspace",
+        }).pipe(Layer.provide(keymaxxerLayer))
 
-    const status = await Effect.runPromise(
-      Effect.gen(function* () {
-        const github = yield* GitHubService
-        return yield* github.getPullRequestCheckStatus(
-          {
+        const count = yield* Effect.gen(function* () {
+          const github = yield* GitHubService
+          return yield* github.countOpenNonDraftPullRequests({
             forge: "github",
             forgeHost: "github.com",
             projectPath: "acme/widgets",
-          },
-          "rfa/acme-widgets/42/wi-test",
+          })
+        }).pipe(Effect.provide(layer))
+
+        expect(count).toBe(4)
+        expect(runs[0]?.command).toContain(
+          "count-open-non-draft-pull-requests.ts",
         )
-      }).pipe(Effect.provide(layer)),
-    )
+        expect(runs[0]?.secrets).toEqual(["GITHUB_TOKEN_ACME_WIDGETS"])
+      }),
+  )
 
-    expect(status).toEqual({
-      _tag: "failed",
-      mergeability: "conflicting",
-      baseRefName: "develop",
-      headPushedAt: null,
-      headSha: null,
-      createdAt: null,
-      isDraft: null,
-      terminalChecks: [
-        {
-          externalId: "checkrun:1",
-          name: "lint",
-          outcome: "red",
-        },
-      ],
-    })
-    expect(runs[0]?.command).toContain("get-pr-check-status.ts")
-    expect(runs[0]?.command).toContain('"--conditions"')
-    expect(runs[0]?.secrets).toEqual(["GITHUB_TOKEN_ACME_WIDGETS"])
-  })
+  it.effect(
+    "empty stdout on exit 0 is a decode error and is not success-cached as zero",
+    () =>
+      Effect.gen(function* () {
+        const runs: RunWithSecretsInput[] = []
+        let clock = 50_000
+        const keymaxxerLayer = Layer.succeed(KeymaxxerService, {
+          initialize: Effect.void,
+          findSecret: () => Effect.succeed("GITHUB_TOKEN_ACME_WIDGETS"),
+          findSecrets: () => Effect.die("not used"),
+          hasSecret: () => Effect.die("not used"),
+          addSecret: () => Effect.die("not used"),
+          runWithSecrets: (input) => {
+            runs.push(input)
+            if (runs.length === 1) {
+              return Effect.succeed({ exitCode: 0, stdout: "   ", stderr: "" })
+            }
+            return Effect.succeed({ exitCode: 0, stdout: "3", stderr: "" })
+          },
+        })
+        const layer = keymaxxerGitHubLayer({
+          workspaceRoot: "/workspace",
+          openPullRequestCountFreshnessMs: 60_000,
+          nowMs: () => clock,
+        }).pipe(Layer.provide(keymaxxerLayer))
 
-  test("maps unparseable PR check-status instants to null", async () => {
-    const keymaxxerLayer = Layer.succeed(KeymaxxerService, {
-      initialize: Effect.void,
-      findSecret: () => Effect.succeed("GITHUB_TOKEN_ACME_WIDGETS"),
-      findSecrets: () => Effect.die("not used"),
-      hasSecret: () => Effect.die("not used"),
-      addSecret: () => Effect.die("not used"),
-      runWithSecrets: () =>
-        Effect.succeed({
-          exitCode: 0,
-          stdout: JSON.stringify({
-            _tag: "succeeded",
-            mergeability: "mergeable",
-            baseRefName: "main",
-            headPushedAt: "not-a-date",
-            headSha: "abc123",
-            createdAt: "garbage",
-            isDraft: false,
-            terminalChecks: [
-              {
-                externalId: "checkrun:1",
-                name: "lint",
-                outcome: "green",
-              },
-            ],
-          }),
-          stderr: "",
+        yield* Effect.gen(function* () {
+          const github = yield* GitHubService
+          const first = yield* Effect.exit(
+            github.countOpenNonDraftPullRequests(acmeWidgets),
+          )
+          expect(Exit.isFailure(first)).toBe(true)
+
+          clock += 10
+          const second =
+            yield* github.countOpenNonDraftPullRequests(acmeWidgets)
+          expect(second).toBe(3)
+        }).pipe(Effect.provide(layer))
+
+        expect(runs).toHaveLength(2)
+      }),
+  )
+
+  it.effect("decodes no_checks and pending terminalChecks from the bin", () =>
+    Effect.gen(function* () {
+      const responses = [
+        JSON.stringify({
+          _tag: "no_checks",
+          mergeability: "mergeable",
+          baseRefName: "main",
+          headPushedAt: null,
+          headSha: null,
+          createdAt: null,
+          isDraft: null,
         }),
-    })
-    const layer = keymaxxerGitHubLayer({ workspaceRoot: "/workspace" }).pipe(
-      Layer.provide(keymaxxerLayer),
-    )
+        JSON.stringify({
+          _tag: "pending",
+          mergeability: "unknown",
+          baseRefName: "main",
+          headPushedAt: null,
+          headSha: null,
+          createdAt: null,
+          isDraft: null,
+          terminalChecks: [
+            {
+              externalId: "status:SC_ci",
+              name: "ci",
+              outcome: "green",
+            },
+          ],
+        }),
+      ]
+      const keymaxxerLayer = Layer.succeed(KeymaxxerService, {
+        initialize: Effect.void,
+        findSecret: () => Effect.succeed("GITHUB_TOKEN_ACME_WIDGETS"),
+        findSecrets: () => Effect.die("not used"),
+        hasSecret: () => Effect.die("not used"),
+        addSecret: () => Effect.die("not used"),
+        runWithSecrets: () =>
+          Effect.succeed({
+            exitCode: 0,
+            stdout: responses.shift()!,
+            stderr: "",
+          }),
+      })
+      const layer = keymaxxerGitHubLayer({ workspaceRoot: "/workspace" }).pipe(
+        Layer.provide(keymaxxerLayer),
+      )
 
-    const status = await Effect.runPromise(
-      Effect.gen(function* () {
+      const noChecks = yield* Effect.gen(function* () {
         const github = yield* GitHubService
         return yield* github.getPullRequestCheckStatus(
           {
@@ -327,141 +529,10 @@ describe("Keymaxxer-backed GitHub layer", () => {
             forgeHost: "github.com",
             projectPath: "acme/widgets",
           },
-          "rfa/acme-widgets/42/wi-test",
+          "branch",
         )
-      }).pipe(Effect.provide(layer)),
-    )
-
-    expect(status).toEqual({
-      _tag: "succeeded",
-      mergeability: "mergeable",
-      baseRefName: "main",
-      headPushedAt: null,
-      headSha: "abc123",
-      createdAt: null,
-      isDraft: false,
-      terminalChecks: [
-        {
-          externalId: "checkrun:1",
-          name: "lint",
-          outcome: "green",
-        },
-      ],
-    })
-  })
-
-  test("resolves an open PR number through the configured repository token", async () => {
-    const runs: RunWithSecretsInput[] = []
-    const keymaxxerLayer = Layer.succeed(KeymaxxerService, {
-      initialize: Effect.void,
-      findSecret: () => Effect.succeed("GITHUB_TOKEN_ACME_WIDGETS"),
-      findSecrets: () => Effect.die("not used"),
-      hasSecret: () => Effect.die("not used"),
-      addSecret: () => Effect.die("not used"),
-      runWithSecrets: (input) => {
-        runs.push(input)
-        return Effect.succeed({ exitCode: 0, stdout: "321", stderr: "" })
-      },
-    })
-    const layer = keymaxxerGitHubLayer({ workspaceRoot: "/workspace" }).pipe(
-      Layer.provide(keymaxxerLayer),
-    )
-
-    const number = await Effect.runPromise(
-      Effect.gen(function* () {
-        const github = yield* GitHubService
-        return yield* github.getOpenPullRequestNumber(
-          {
-            forge: "github",
-            forgeHost: "github.com",
-            projectPath: "acme/widgets",
-          },
-          "rfa/acme-widgets/42/wi-test",
-        )
-      }).pipe(Effect.provide(layer)),
-    )
-
-    expect(number).toBe(321)
-    expect(runs[0]?.command).toContain("get-open-pr-number.ts")
-    expect(runs[0]?.command).toContain('"--conditions"')
-  })
-
-  test("counts open non-draft pull requests through the configured repository token", async () => {
-    const runs: RunWithSecretsInput[] = []
-    const keymaxxerLayer = Layer.succeed(KeymaxxerService, {
-      initialize: Effect.void,
-      findSecret: () => Effect.succeed("GITHUB_TOKEN_ACME_WIDGETS"),
-      findSecrets: () => Effect.die("not used"),
-      hasSecret: () => Effect.die("not used"),
-      addSecret: () => Effect.die("not used"),
-      runWithSecrets: (input) => {
-        runs.push(input)
-        return Effect.succeed({ exitCode: 0, stdout: "4", stderr: "" })
-      },
-    })
-    const layer = keymaxxerGitHubLayer({ workspaceRoot: "/workspace" }).pipe(
-      Layer.provide(keymaxxerLayer),
-    )
-
-    const count = await Effect.runPromise(
-      Effect.gen(function* () {
-        const github = yield* GitHubService
-        return yield* github.countOpenNonDraftPullRequests({
-          forge: "github",
-          forgeHost: "github.com",
-          projectPath: "acme/widgets",
-        })
-      }).pipe(Effect.provide(layer)),
-    )
-
-    expect(count).toBe(4)
-    expect(runs[0]?.command).toContain("count-open-non-draft-pull-requests.ts")
-    expect(runs[0]?.secrets).toEqual(["GITHUB_TOKEN_ACME_WIDGETS"])
-  })
-
-  test("empty stdout on exit 0 is a decode error and is not success-cached as zero", async () => {
-    const runs: RunWithSecretsInput[] = []
-    let clock = 50_000
-    const keymaxxerLayer = Layer.succeed(KeymaxxerService, {
-      initialize: Effect.void,
-      findSecret: () => Effect.succeed("GITHUB_TOKEN_ACME_WIDGETS"),
-      findSecrets: () => Effect.die("not used"),
-      hasSecret: () => Effect.die("not used"),
-      addSecret: () => Effect.die("not used"),
-      runWithSecrets: (input) => {
-        runs.push(input)
-        if (runs.length === 1) {
-          return Effect.succeed({ exitCode: 0, stdout: "   ", stderr: "" })
-        }
-        return Effect.succeed({ exitCode: 0, stdout: "3", stderr: "" })
-      },
-    })
-    const layer = keymaxxerGitHubLayer({
-      workspaceRoot: "/workspace",
-      openPullRequestCountFreshnessMs: 60_000,
-      nowMs: () => clock,
-    }).pipe(Layer.provide(keymaxxerLayer))
-
-    await Effect.runPromise(
-      Effect.gen(function* () {
-        const github = yield* GitHubService
-        const first = yield* Effect.exit(
-          github.countOpenNonDraftPullRequests(acmeWidgets),
-        )
-        expect(Exit.isFailure(first)).toBe(true)
-
-        clock += 10
-        const second = yield* github.countOpenNonDraftPullRequests(acmeWidgets)
-        expect(second).toBe(3)
-      }).pipe(Effect.provide(layer)),
-    )
-
-    expect(runs).toHaveLength(2)
-  })
-
-  test("decodes no_checks and pending terminalChecks from the bin", async () => {
-    const responses = [
-      JSON.stringify({
+      }).pipe(Effect.provide(layer))
+      expect(noChecks).toEqual({
         _tag: "no_checks",
         mergeability: "mergeable",
         baseRefName: "main",
@@ -469,8 +540,20 @@ describe("Keymaxxer-backed GitHub layer", () => {
         headSha: null,
         createdAt: null,
         isDraft: null,
-      }),
-      JSON.stringify({
+      })
+
+      const pending = yield* Effect.gen(function* () {
+        const github = yield* GitHubService
+        return yield* github.getPullRequestCheckStatus(
+          {
+            forge: "github",
+            forgeHost: "github.com",
+            projectPath: "acme/widgets",
+          },
+          "branch",
+        )
+      }).pipe(Effect.provide(layer))
+      expect(pending).toEqual({
         _tag: "pending",
         mergeability: "unknown",
         baseRefName: "main",
@@ -485,199 +568,134 @@ describe("Keymaxxer-backed GitHub layer", () => {
             outcome: "green",
           },
         ],
-      }),
-    ]
-    const keymaxxerLayer = Layer.succeed(KeymaxxerService, {
-      initialize: Effect.void,
-      findSecret: () => Effect.succeed("GITHUB_TOKEN_ACME_WIDGETS"),
-      findSecrets: () => Effect.die("not used"),
-      hasSecret: () => Effect.die("not used"),
-      addSecret: () => Effect.die("not used"),
-      runWithSecrets: () =>
-        Effect.succeed({
-          exitCode: 0,
-          stdout: responses.shift()!,
-          stderr: "",
-        }),
-    })
-    const layer = keymaxxerGitHubLayer({ workspaceRoot: "/workspace" }).pipe(
-      Layer.provide(keymaxxerLayer),
-    )
+      })
+    }),
+  )
 
-    const noChecks = await Effect.runPromise(
+  it.effect(
+    "marks a PR ready for review through the configured repository token",
+    () =>
       Effect.gen(function* () {
-        const github = yield* GitHubService
-        return yield* github.getPullRequestCheckStatus(
-          {
-            forge: "github",
-            forgeHost: "github.com",
-            projectPath: "acme/widgets",
+        const runs: RunWithSecretsInput[] = []
+        const keymaxxerLayer = Layer.succeed(KeymaxxerService, {
+          initialize: Effect.void,
+          findSecret: () => Effect.succeed("GITHUB_TOKEN_ACME_WIDGETS"),
+          findSecrets: () => Effect.die("not used"),
+          hasSecret: () => Effect.die("not used"),
+          addSecret: () => Effect.die("not used"),
+          runWithSecrets: (input) => {
+            runs.push(input)
+            return Effect.succeed({
+              exitCode: 0,
+              stdout: JSON.stringify({ _tag: "ready" }),
+              stderr: "",
+            })
           },
-          "branch",
-        )
-      }).pipe(Effect.provide(layer)),
-    )
-    expect(noChecks).toEqual({
-      _tag: "no_checks",
-      mergeability: "mergeable",
-      baseRefName: "main",
-      headPushedAt: null,
-      headSha: null,
-      createdAt: null,
-      isDraft: null,
-    })
-
-    const pending = await Effect.runPromise(
-      Effect.gen(function* () {
-        const github = yield* GitHubService
-        return yield* github.getPullRequestCheckStatus(
-          {
-            forge: "github",
-            forgeHost: "github.com",
-            projectPath: "acme/widgets",
-          },
-          "branch",
-        )
-      }).pipe(Effect.provide(layer)),
-    )
-    expect(pending).toEqual({
-      _tag: "pending",
-      mergeability: "unknown",
-      baseRefName: "main",
-      headPushedAt: null,
-      headSha: null,
-      createdAt: null,
-      isDraft: null,
-      terminalChecks: [
-        {
-          externalId: "status:SC_ci",
-          name: "ci",
-          outcome: "green",
-        },
-      ],
-    })
-  })
-
-  test("marks a PR ready for review through the configured repository token", async () => {
-    const runs: RunWithSecretsInput[] = []
-    const keymaxxerLayer = Layer.succeed(KeymaxxerService, {
-      initialize: Effect.void,
-      findSecret: () => Effect.succeed("GITHUB_TOKEN_ACME_WIDGETS"),
-      findSecrets: () => Effect.die("not used"),
-      hasSecret: () => Effect.die("not used"),
-      addSecret: () => Effect.die("not used"),
-      runWithSecrets: (input) => {
-        runs.push(input)
-        return Effect.succeed({
-          exitCode: 0,
-          stdout: JSON.stringify({ _tag: "ready" }),
-          stderr: "",
         })
-      },
-    })
-    const layer = keymaxxerGitHubLayer({ workspaceRoot: "/workspace" }).pipe(
-      Layer.provide(keymaxxerLayer),
-    )
+        const layer = keymaxxerGitHubLayer({
+          workspaceRoot: "/workspace",
+        }).pipe(Layer.provide(keymaxxerLayer))
 
-    await Effect.runPromise(
-      Effect.gen(function* () {
-        const github = yield* GitHubService
-        yield* github.markPullRequestReadyForReview(
-          {
-            forge: "github",
-            forgeHost: "github.com",
-            projectPath: "acme/widgets",
-          },
-          "rfa/acme-widgets/42/wi-test",
-        )
-      }).pipe(Effect.provide(layer)),
-    )
-
-    expect(runs[0]?.command).toContain("mark-pr-ready-for-review.ts")
-    expect(runs[0]?.command).toContain('"--conditions"')
-    expect(runs[0]?.secrets).toEqual(["GITHUB_TOKEN_ACME_WIDGETS"])
-  })
-
-  test("sanitizes ANSI Effect dumps from CLI stderr into plain GitHubRequestError messages", async () => {
-    const esc = String.fromCharCode(0x1b)
-    const ansiDump = `{\n  ${esc}[0m_tag${esc}[2m:${esc}[0m ${esc}[32m"GitHubRequestError"${esc}[0m,\n  ${esc}[0mmessage${esc}[2m:${esc}[0m ${esc}[32m"HTTP 401: Bad credentials"${esc}[0m,\n}`
-    const keymaxxerLayer = Layer.succeed(KeymaxxerService, {
-      initialize: Effect.void,
-      findSecret: () => Effect.succeed("GITHUB_TOKEN_ACME_WIDGETS"),
-      findSecrets: () => Effect.die("not used"),
-      hasSecret: () => Effect.die("not used"),
-      addSecret: () => Effect.die("not used"),
-      runWithSecrets: () =>
-        Effect.succeed({
-          exitCode: 1,
-          stdout: "",
-          stderr: ansiDump,
-        }),
-    })
-    const layer = keymaxxerGitHubLayer({ workspaceRoot: "/workspace" }).pipe(
-      Layer.provide(keymaxxerLayer),
-    )
-
-    const error = await Effect.runPromise(
-      Effect.gen(function* () {
-        const github = yield* GitHubService
-        return yield* github
-          .getPullRequestCheckStatus(
+        yield* Effect.gen(function* () {
+          const github = yield* GitHubService
+          yield* github.markPullRequestReadyForReview(
             {
               forge: "github",
               forgeHost: "github.com",
-              projectPath: "processfocus/monorepo",
+              projectPath: "acme/widgets",
             },
-            "branch",
+            "rfa/acme-widgets/42/wi-test",
           )
-          .pipe(Effect.flip)
-      }).pipe(Effect.provide(layer)),
-    )
+        }).pipe(Effect.provide(layer))
 
-    expect(error).toBeInstanceOf(GitHubRequestError)
-    expect(error.message).toBe(
-      "Failed to get pull request check status for processfocus/monorepo: HTTP 401: Bad credentials",
-    )
-    expect(error.message.includes(`${esc}[`)).toBe(false)
-    expect(error.message).not.toContain("_tag")
-  })
+        expect(runs[0]?.command).toContain("mark-pr-ready-for-review.ts")
+        expect(runs[0]?.command).toContain('"--conditions"')
+        expect(runs[0]?.secrets).toEqual(["GITHUB_TOKEN_ACME_WIDGETS"])
+      }),
+  )
 
-  test("merges a PR through the configured repository token", async () => {
-    const runs: RunWithSecretsInput[] = []
-    const serializedOutcomes = [
-      { _tag: "merged" },
-      {
-        _tag: "revalidation",
-        reason: "head_changed",
-        message: "Head changed",
-      },
-      {
-        _tag: "needs_human",
-        reason: "merge_rejected",
-        message: "Merge rejected",
-      },
-    ] as const
-    const keymaxxerLayer = Layer.succeed(KeymaxxerService, {
-      initialize: Effect.void,
-      findSecret: () => Effect.succeed("GITHUB_TOKEN_ACME_WIDGETS"),
-      findSecrets: () => Effect.die("not used"),
-      hasSecret: () => Effect.die("not used"),
-      addSecret: () => Effect.die("not used"),
-      runWithSecrets: (input) => {
-        runs.push(input)
-        return Effect.succeed({
-          exitCode: 0,
-          stdout: JSON.stringify(serializedOutcomes[runs.length - 1]),
-          stderr: "",
-        })
-      },
-    })
-    const layer = keymaxxerGitHubLayer({ workspaceRoot: "/workspace" }).pipe(
-      Layer.provide(keymaxxerLayer),
-    )
-
-    const outcomes = await Effect.runPromise(
+  it.effect(
+    "sanitizes ANSI Effect dumps from CLI stderr into plain GitHubRequestError messages",
+    () =>
       Effect.gen(function* () {
+        const esc = String.fromCharCode(0x1b)
+        const ansiDump = `{\n  ${esc}[0m_tag${esc}[2m:${esc}[0m ${esc}[32m"GitHubRequestError"${esc}[0m,\n  ${esc}[0mmessage${esc}[2m:${esc}[0m ${esc}[32m"HTTP 401: Bad credentials"${esc}[0m,\n}`
+        const keymaxxerLayer = Layer.succeed(KeymaxxerService, {
+          initialize: Effect.void,
+          findSecret: () => Effect.succeed("GITHUB_TOKEN_ACME_WIDGETS"),
+          findSecrets: () => Effect.die("not used"),
+          hasSecret: () => Effect.die("not used"),
+          addSecret: () => Effect.die("not used"),
+          runWithSecrets: () =>
+            Effect.succeed({
+              exitCode: 1,
+              stdout: "",
+              stderr: ansiDump,
+            }),
+        })
+        const layer = keymaxxerGitHubLayer({
+          workspaceRoot: "/workspace",
+        }).pipe(Layer.provide(keymaxxerLayer))
+
+        const error = yield* Effect.gen(function* () {
+          const github = yield* GitHubService
+          return yield* github
+            .getPullRequestCheckStatus(
+              {
+                forge: "github",
+                forgeHost: "github.com",
+                projectPath: "processfocus/monorepo",
+              },
+              "branch",
+            )
+            .pipe(Effect.flip)
+        }).pipe(Effect.provide(layer))
+
+        expect(error).toBeInstanceOf(GitHubRequestError)
+        expect(error.message).toBe(
+          "Failed to get pull request check status for processfocus/monorepo: HTTP 401: Bad credentials",
+        )
+        expect(error.message.includes(`${esc}[`)).toBe(false)
+        expect(error.message).not.toContain("_tag")
+      }),
+  )
+
+  it.effect("merges a PR through the configured repository token", () =>
+    Effect.gen(function* () {
+      const runs: RunWithSecretsInput[] = []
+      const serializedOutcomes = [
+        { _tag: "merged" },
+        {
+          _tag: "revalidation",
+          reason: "head_changed",
+          message: "Head changed",
+        },
+        {
+          _tag: "needs_human",
+          reason: "merge_rejected",
+          message: "Merge rejected",
+        },
+      ] as const
+      const keymaxxerLayer = Layer.succeed(KeymaxxerService, {
+        initialize: Effect.void,
+        findSecret: () => Effect.succeed("GITHUB_TOKEN_ACME_WIDGETS"),
+        findSecrets: () => Effect.die("not used"),
+        hasSecret: () => Effect.die("not used"),
+        addSecret: () => Effect.die("not used"),
+        runWithSecrets: (input) => {
+          runs.push(input)
+          return Effect.succeed({
+            exitCode: 0,
+            stdout: JSON.stringify(serializedOutcomes[runs.length - 1]),
+            stderr: "",
+          })
+        },
+      })
+      const layer = keymaxxerGitHubLayer({ workspaceRoot: "/workspace" }).pipe(
+        Layer.provide(keymaxxerLayer),
+      )
+
+      const outcomes = yield* Effect.gen(function* () {
         const github = yield* GitHubService
         return yield* Effect.forEach(serializedOutcomes, () =>
           github.mergePullRequest(
@@ -689,50 +707,50 @@ describe("Keymaxxer-backed GitHub layer", () => {
             "rfa/acme-widgets/42/wi-test",
           ),
         )
-      }).pipe(Effect.provide(layer)),
-    )
+      }).pipe(Effect.provide(layer))
 
-    expect(runs[0]?.command).toContain("merge-pull-request.ts")
-    expect(runs[0]?.command).toContain('"--conditions"')
-    expect(runs[0]?.secrets).toEqual(["GITHUB_TOKEN_ACME_WIDGETS"])
-    expect(outcomes).toEqual([...serializedOutcomes])
-  })
+      expect(runs[0]?.command).toContain("merge-pull-request.ts")
+      expect(runs[0]?.command).toContain('"--conditions"')
+      expect(runs[0]?.secrets).toEqual(["GITHUB_TOKEN_ACME_WIDGETS"])
+      expect(outcomes).toEqual([...serializedOutcomes])
+    }),
+  )
 
-  test("rejects malformed Ready Issue fields through Schema", async () => {
-    const keymaxxerLayer = Layer.succeed(KeymaxxerService, {
-      initialize: Effect.void,
-      findSecret: () => Effect.succeed("GITHUB_TOKEN_ACME_WIDGETS"),
-      findSecrets: () => Effect.die("not used"),
-      hasSecret: () => Effect.die("not used"),
-      addSecret: () => Effect.die("not used"),
-      runWithSecrets: () =>
-        Effect.succeed({
-          exitCode: 0,
-          stdout: JSON.stringify([
-            {
-              number: 0,
-              title: " ",
-              body: "Issue body",
-              url: "not-a-url",
-              createdAt: "not-a-date",
-              state: "OPEN",
-              hierarchySupported: true,
-              hasChildren: false,
-              parentPosition: -1,
-              parent: null,
-              blockedBy: [],
-              closingPullRequests: [],
-            },
-          ]),
-          stderr: "",
-        }),
-    })
-    const layer = keymaxxerGitHubLayer({ workspaceRoot: "/workspace" }).pipe(
-      Layer.provide(keymaxxerLayer),
-    )
+  it.effect("rejects malformed Ready Issue fields through Schema", () =>
+    Effect.gen(function* () {
+      const keymaxxerLayer = Layer.succeed(KeymaxxerService, {
+        initialize: Effect.void,
+        findSecret: () => Effect.succeed("GITHUB_TOKEN_ACME_WIDGETS"),
+        findSecrets: () => Effect.die("not used"),
+        hasSecret: () => Effect.die("not used"),
+        addSecret: () => Effect.die("not used"),
+        runWithSecrets: () =>
+          Effect.succeed({
+            exitCode: 0,
+            stdout: JSON.stringify([
+              {
+                number: 0,
+                title: " ",
+                body: "Issue body",
+                url: "not-a-url",
+                createdAt: "not-a-date",
+                state: "OPEN",
+                hierarchySupported: true,
+                hasChildren: false,
+                parentPosition: -1,
+                parent: null,
+                blockedBy: [],
+                closingPullRequests: [],
+              },
+            ]),
+            stderr: "",
+          }),
+      })
+      const layer = keymaxxerGitHubLayer({ workspaceRoot: "/workspace" }).pipe(
+        Layer.provide(keymaxxerLayer),
+      )
 
-    const error = await Effect.runPromise(
-      Effect.gen(function* () {
+      const error = yield* Effect.gen(function* () {
         const github = yield* GitHubService
         return yield* github
           .listReadyIssues({
@@ -741,289 +759,303 @@ describe("Keymaxxer-backed GitHub layer", () => {
             projectPath: "acme/widgets",
           })
           .pipe(Effect.flip)
-      }).pipe(Effect.provide(layer)),
-    )
+      }).pipe(Effect.provide(layer))
 
-    expect(error).toBeInstanceOf(GitHubRequestError)
-    expect(error.message).toBe(
-      "Failed to list Ready-labeled Issues for acme/widgets",
-    )
-  })
+      expect(error).toBeInstanceOf(GitHubRequestError)
+      expect(error.message).toBe(
+        "Failed to list Ready-labeled Issues for acme/widgets",
+      )
+    }),
+  )
 
-  test("freshness window is shorter than the UI open-PR count poll interval", () => {
+  it("freshness window is shorter than the UI open-PR count poll interval", () => {
     // UI poll is 30_000ms; reuse must expire so automatic refresh can observe changes.
     expect(OPEN_PULL_REQUEST_COUNT_FRESHNESS_MS).toBeGreaterThan(0)
     expect(OPEN_PULL_REQUEST_COUNT_FRESHNESS_MS).toBeLessThan(30_000)
   })
 
-  test("concurrent count requests for one Repository share one Keymaxxer helper", async () => {
-    const runs: RunWithSecretsInput[] = []
-    let releaseHelper: (() => void) | undefined
-    const helperHeld = new Promise<void>((resolve) => {
-      releaseHelper = resolve
-    })
-    let helperStarts = 0
-    const keymaxxerLayer = Layer.succeed(KeymaxxerService, {
-      initialize: Effect.void,
-      findSecret: () => Effect.succeed("GITHUB_TOKEN_ACME_WIDGETS"),
-      findSecrets: () => Effect.die("not used"),
-      hasSecret: () => Effect.die("not used"),
-      addSecret: () => Effect.die("not used"),
-      runWithSecrets: (input) =>
-        Effect.gen(function* () {
-          runs.push(input)
-          helperStarts += 1
-          yield* Effect.promise(() => helperHeld)
-          return { exitCode: 0, stdout: "7", stderr: "" }
-        }),
-    })
-    const layer = keymaxxerGitHubLayer({ workspaceRoot: "/workspace" }).pipe(
-      Layer.provide(keymaxxerLayer),
-    )
-
-    const countsPromise = Effect.runPromise(
+  // Real wall-clock coordination: hold the helper open so concurrent callers
+  // join one in-flight Deferred rather than racing TestClock.
+  it.live(
+    "concurrent count requests for one Repository share one Keymaxxer helper",
+    () =>
       Effect.gen(function* () {
-        const github = yield* GitHubService
-        return yield* Effect.all(
-          [
-            github.countOpenNonDraftPullRequests(acmeWidgets),
-            github.countOpenNonDraftPullRequests(acmeWidgets),
-          ],
-          { concurrency: 2 },
-        )
-      }).pipe(Effect.provide(layer)),
-    )
-
-    for (let i = 0; i < 100 && helperStarts < 1; i += 1) {
-      await Bun.sleep(5)
-    }
-    expect(helperStarts).toBe(1)
-    releaseHelper?.()
-    const counts = await countsPromise
-
-    expect(counts).toEqual([7, 7])
-    expect(runs).toHaveLength(1)
-    expect(runs[0]?.command).toContain("count-open-non-draft-pull-requests.ts")
-    expect(runs[0]?.secrets).toEqual(["GITHUB_TOKEN_ACME_WIDGETS"])
-  })
-
-  test("count requests for different Repositories never share credentials or results", async () => {
-    const runs: RunWithSecretsInput[] = []
-    const tokens = new Map([
-      ["acme/widgets", "TOKEN_WIDGETS"],
-      ["acme/gadgets", "TOKEN_GADGETS"],
-    ])
-    const keymaxxerLayer = Layer.succeed(KeymaxxerService, {
-      initialize: Effect.void,
-      findSecret: ({ account }) => Effect.succeed(tokens.get(account) ?? null),
-      findSecrets: () => Effect.die("not used"),
-      hasSecret: () => Effect.die("not used"),
-      addSecret: () => Effect.die("not used"),
-      runWithSecrets: (input) => {
-        runs.push(input)
-        const stdout = input.secrets[0] === "TOKEN_WIDGETS" ? "2" : "9"
-        return Effect.succeed({ exitCode: 0, stdout, stderr: "" })
-      },
-    })
-    const layer = keymaxxerGitHubLayer({ workspaceRoot: "/workspace" }).pipe(
-      Layer.provide(keymaxxerLayer),
-    )
-
-    const counts = await Effect.runPromise(
-      Effect.gen(function* () {
-        const github = yield* GitHubService
-        return yield* Effect.all(
-          [
-            github.countOpenNonDraftPullRequests(acmeWidgets),
-            github.countOpenNonDraftPullRequests(acmeGadgets),
-          ],
-          { concurrency: 2 },
-        )
-      }).pipe(Effect.provide(layer)),
-    )
-
-    expect(counts).toEqual([2, 9])
-    expect(runs).toHaveLength(2)
-    expect(runs.map(({ secrets }) => secrets).sort()).toEqual([
-      ["TOKEN_GADGETS"],
-      ["TOKEN_WIDGETS"],
-    ])
-  })
-
-  test("closely spaced successful counts reuse the freshness window without a second helper", async () => {
-    const runs: RunWithSecretsInput[] = []
-    let clock = 1_000
-    const keymaxxerLayer = Layer.succeed(KeymaxxerService, {
-      initialize: Effect.void,
-      findSecret: () => Effect.succeed("GITHUB_TOKEN_ACME_WIDGETS"),
-      findSecrets: () => Effect.die("not used"),
-      hasSecret: () => Effect.die("not used"),
-      addSecret: () => Effect.die("not used"),
-      runWithSecrets: (input) => {
-        runs.push(input)
-        return Effect.succeed({
-          exitCode: 0,
-          stdout: String(runs.length),
-          stderr: "",
+        const runs: RunWithSecretsInput[] = []
+        const helperStarted = yield* Deferred.make<void>()
+        const releaseHelper = yield* Deferred.make<void>()
+        const keymaxxerLayer = Layer.succeed(KeymaxxerService, {
+          initialize: Effect.void,
+          findSecret: () => Effect.succeed("GITHUB_TOKEN_ACME_WIDGETS"),
+          findSecrets: () => Effect.die("not used"),
+          hasSecret: () => Effect.die("not used"),
+          addSecret: () => Effect.die("not used"),
+          runWithSecrets: (input) =>
+            Effect.gen(function* () {
+              runs.push(input)
+              yield* Deferred.succeed(helperStarted, undefined)
+              yield* Deferred.await(releaseHelper)
+              return { exitCode: 0, stdout: "7", stderr: "" }
+            }),
         })
-      },
-    })
-    const layer = keymaxxerGitHubLayer({
-      workspaceRoot: "/workspace",
-      openPullRequestCountFreshnessMs: 5_000,
-      nowMs: () => clock,
-    }).pipe(Layer.provide(keymaxxerLayer))
+        const layer = keymaxxerGitHubLayer({
+          workspaceRoot: "/workspace",
+        }).pipe(Layer.provide(keymaxxerLayer))
 
-    const counts = await Effect.runPromise(
+        const fiber = yield* Effect.gen(function* () {
+          const github = yield* GitHubService
+          return yield* Effect.all(
+            [
+              github.countOpenNonDraftPullRequests(acmeWidgets),
+              github.countOpenNonDraftPullRequests(acmeWidgets),
+            ],
+            { concurrency: 2 },
+          )
+        }).pipe(Effect.provide(layer), Effect.forkChild)
+
+        yield* Deferred.await(helperStarted)
+        expect(runs).toHaveLength(1)
+        yield* Deferred.succeed(releaseHelper, undefined)
+        const counts = yield* Fiber.join(fiber)
+
+        expect(counts).toEqual([7, 7])
+        expect(runs).toHaveLength(1)
+        expect(runs[0]?.command).toContain(
+          "count-open-non-draft-pull-requests.ts",
+        )
+        expect(runs[0]?.secrets).toEqual(["GITHUB_TOKEN_ACME_WIDGETS"])
+      }),
+  )
+
+  it.effect(
+    "count requests for different Repositories never share credentials or results",
+    () =>
       Effect.gen(function* () {
-        const github = yield* GitHubService
-        const first = yield* github.countOpenNonDraftPullRequests(acmeWidgets)
-        clock += 1_000
-        const second = yield* github.countOpenNonDraftPullRequests(acmeWidgets)
-        return [first, second] as const
-      }).pipe(Effect.provide(layer)),
-    )
-
-    expect(counts).toEqual([1, 1])
-    expect(runs).toHaveLength(1)
-  })
-
-  test("expiry permits a later request to observe a changed GitHub count", async () => {
-    const runs: RunWithSecretsInput[] = []
-    let clock = 10_000
-    const keymaxxerLayer = Layer.succeed(KeymaxxerService, {
-      initialize: Effect.void,
-      findSecret: () => Effect.succeed("GITHUB_TOKEN_ACME_WIDGETS"),
-      findSecrets: () => Effect.die("not used"),
-      hasSecret: () => Effect.die("not used"),
-      addSecret: () => Effect.die("not used"),
-      runWithSecrets: (input) => {
-        runs.push(input)
-        return Effect.succeed({
-          exitCode: 0,
-          stdout: String(runs.length * 3),
-          stderr: "",
+        const runs: RunWithSecretsInput[] = []
+        const tokens = new Map([
+          ["acme/widgets", "TOKEN_WIDGETS"],
+          ["acme/gadgets", "TOKEN_GADGETS"],
+        ])
+        const keymaxxerLayer = Layer.succeed(KeymaxxerService, {
+          initialize: Effect.void,
+          findSecret: ({ account }) =>
+            Effect.succeed(tokens.get(account) ?? null),
+          findSecrets: () => Effect.die("not used"),
+          hasSecret: () => Effect.die("not used"),
+          addSecret: () => Effect.die("not used"),
+          runWithSecrets: (input) => {
+            runs.push(input)
+            const stdout = input.secrets[0] === "TOKEN_WIDGETS" ? "2" : "9"
+            return Effect.succeed({ exitCode: 0, stdout, stderr: "" })
+          },
         })
-      },
-    })
-    const layer = keymaxxerGitHubLayer({
-      workspaceRoot: "/workspace",
-      openPullRequestCountFreshnessMs: 5_000,
-      nowMs: () => clock,
-    }).pipe(Layer.provide(keymaxxerLayer))
+        const layer = keymaxxerGitHubLayer({
+          workspaceRoot: "/workspace",
+        }).pipe(Layer.provide(keymaxxerLayer))
 
-    const counts = await Effect.runPromise(
+        const counts = yield* Effect.gen(function* () {
+          const github = yield* GitHubService
+          return yield* Effect.all(
+            [
+              github.countOpenNonDraftPullRequests(acmeWidgets),
+              github.countOpenNonDraftPullRequests(acmeGadgets),
+            ],
+            { concurrency: 2 },
+          )
+        }).pipe(Effect.provide(layer))
+
+        expect(counts).toEqual([2, 9])
+        expect(runs).toHaveLength(2)
+        expect(runs.map(({ secrets }) => secrets).sort()).toEqual([
+          ["TOKEN_GADGETS"],
+          ["TOKEN_WIDGETS"],
+        ])
+      }),
+  )
+
+  it.effect(
+    "closely spaced successful counts reuse the freshness window without a second helper",
+    () =>
       Effect.gen(function* () {
-        const github = yield* GitHubService
-        const first = yield* github.countOpenNonDraftPullRequests(acmeWidgets)
-        clock += 5_000
-        const second = yield* github.countOpenNonDraftPullRequests(acmeWidgets)
-        return [first, second] as const
-      }).pipe(Effect.provide(layer)),
-    )
+        const runs: RunWithSecretsInput[] = []
+        let clock = 1_000
+        const keymaxxerLayer = Layer.succeed(KeymaxxerService, {
+          initialize: Effect.void,
+          findSecret: () => Effect.succeed("GITHUB_TOKEN_ACME_WIDGETS"),
+          findSecrets: () => Effect.die("not used"),
+          hasSecret: () => Effect.die("not used"),
+          addSecret: () => Effect.die("not used"),
+          runWithSecrets: (input) => {
+            runs.push(input)
+            return Effect.succeed({
+              exitCode: 0,
+              stdout: String(runs.length),
+              stderr: "",
+            })
+          },
+        })
+        const layer = keymaxxerGitHubLayer({
+          workspaceRoot: "/workspace",
+          openPullRequestCountFreshnessMs: 5_000,
+          nowMs: () => clock,
+        }).pipe(Layer.provide(keymaxxerLayer))
 
-    expect(counts).toEqual([3, 6])
-    expect(runs).toHaveLength(2)
-  })
+        const counts = yield* Effect.gen(function* () {
+          const github = yield* GitHubService
+          const first = yield* github.countOpenNonDraftPullRequests(acmeWidgets)
+          clock += 1_000
+          const second =
+            yield* github.countOpenNonDraftPullRequests(acmeWidgets)
+          return [first, second] as const
+        }).pipe(Effect.provide(layer))
 
-  test("GitHub and Keymaxxer failures are not stored as successful zero counts", async () => {
-    const runs: RunWithSecretsInput[] = []
-    let clock = 100
-    const keymaxxerLayer = Layer.succeed(KeymaxxerService, {
-      initialize: Effect.void,
-      findSecret: () => Effect.succeed("GITHUB_TOKEN_ACME_WIDGETS"),
-      findSecrets: () => Effect.die("not used"),
-      hasSecret: () => Effect.die("not used"),
-      addSecret: () => Effect.die("not used"),
-      runWithSecrets: (input) => {
-        runs.push(input)
-        if (runs.length === 1) {
-          return Effect.succeed({
-            exitCode: 1,
-            stdout: "",
-            stderr: "upstream boom",
-          })
-        }
-        if (runs.length === 2) {
-          return Effect.succeed({ exitCode: 2, stdout: "", stderr: "" })
-        }
-        return Effect.succeed({ exitCode: 0, stdout: "0", stderr: "" })
-      },
-    })
-    const layer = keymaxxerGitHubLayer({
-      workspaceRoot: "/workspace",
-      openPullRequestCountFreshnessMs: 60_000,
-      nowMs: () => clock,
-    }).pipe(Layer.provide(keymaxxerLayer))
+        expect(counts).toEqual([1, 1])
+        expect(runs).toHaveLength(1)
+      }),
+  )
 
-    await Effect.runPromise(
+  it.effect(
+    "expiry permits a later request to observe a changed GitHub count",
+    () =>
       Effect.gen(function* () {
-        const github = yield* GitHubService
+        const runs: RunWithSecretsInput[] = []
+        let clock = 10_000
+        const keymaxxerLayer = Layer.succeed(KeymaxxerService, {
+          initialize: Effect.void,
+          findSecret: () => Effect.succeed("GITHUB_TOKEN_ACME_WIDGETS"),
+          findSecrets: () => Effect.die("not used"),
+          hasSecret: () => Effect.die("not used"),
+          addSecret: () => Effect.die("not used"),
+          runWithSecrets: (input) => {
+            runs.push(input)
+            return Effect.succeed({
+              exitCode: 0,
+              stdout: String(runs.length * 3),
+              stderr: "",
+            })
+          },
+        })
+        const layer = keymaxxerGitHubLayer({
+          workspaceRoot: "/workspace",
+          openPullRequestCountFreshnessMs: 5_000,
+          nowMs: () => clock,
+        }).pipe(Layer.provide(keymaxxerLayer))
 
-        const requestFailure = yield* Effect.exit(
-          github.countOpenNonDraftPullRequests(acmeWidgets),
-        )
-        expect(Exit.isFailure(requestFailure)).toBe(true)
+        const counts = yield* Effect.gen(function* () {
+          const github = yield* GitHubService
+          const first = yield* github.countOpenNonDraftPullRequests(acmeWidgets)
+          clock += 5_000
+          const second =
+            yield* github.countOpenNonDraftPullRequests(acmeWidgets)
+          return [first, second] as const
+        }).pipe(Effect.provide(layer))
 
-        clock += 10
-        const unavailable = yield* Effect.exit(
-          github.countOpenNonDraftPullRequests(acmeWidgets),
-        )
-        expect(Exit.isFailure(unavailable)).toBe(true)
-        if (Exit.isFailure(unavailable)) {
-          const error = unavailable.cause
-          // Ensure we did not swallow unavailable into a cached zero.
-          expect(String(error)).toContain("GitHubRepositoryUnavailableError")
-        }
+        expect(counts).toEqual([3, 6])
+        expect(runs).toHaveLength(2)
+      }),
+  )
 
-        clock += 10
-        const zero = yield* github.countOpenNonDraftPullRequests(acmeWidgets)
-        expect(zero).toBe(0)
-
-        clock += 10
-        // Genuine zero is success-cached; failures above must not have been.
-        const cachedZero =
-          yield* github.countOpenNonDraftPullRequests(acmeWidgets)
-        expect(cachedZero).toBe(0)
-      }).pipe(Effect.provide(layer)),
-    )
-
-    expect(runs).toHaveLength(3)
-  })
-
-  test("raw Forge credentials stay in the Keymaxxer child and never enter the count result path", async () => {
-    const secretName = "GITHUB_TOKEN_ACME_WIDGETS"
-    const rawToken = "ghp_this_must_never_appear_in_harness_memory_path"
-    const runs: RunWithSecretsInput[] = []
-    const keymaxxerLayer = Layer.succeed(KeymaxxerService, {
-      initialize: Effect.void,
-      findSecret: () => Effect.succeed(secretName),
-      findSecrets: () => Effect.die("not used"),
-      hasSecret: () => Effect.die("not used"),
-      addSecret: () => Effect.die("not used"),
-      runWithSecrets: (input) => {
-        runs.push(input)
-        // Keymaxxer injects the secret by name into the child env; the Harness
-        // only sees the secret name and the child's decoded stdout count.
-        expect(input.secrets).toEqual([secretName])
-        expect(input.command).toContain(`GITHUB_TOKEN="$${secretName}"`)
-        expect(JSON.stringify(input)).not.toContain(rawToken)
-        return Effect.succeed({ exitCode: 0, stdout: "5", stderr: "" })
-      },
-    })
-    const layer = keymaxxerGitHubLayer({ workspaceRoot: "/workspace" }).pipe(
-      Layer.provide(keymaxxerLayer),
-    )
-
-    const count = await Effect.runPromise(
+  it.effect(
+    "GitHub and Keymaxxer failures are not stored as successful zero counts",
+    () =>
       Effect.gen(function* () {
-        const github = yield* GitHubService
-        return yield* github.countOpenNonDraftPullRequests(acmeWidgets)
-      }).pipe(Effect.provide(layer)),
-    )
+        const runs: RunWithSecretsInput[] = []
+        let clock = 100
+        const keymaxxerLayer = Layer.succeed(KeymaxxerService, {
+          initialize: Effect.void,
+          findSecret: () => Effect.succeed("GITHUB_TOKEN_ACME_WIDGETS"),
+          findSecrets: () => Effect.die("not used"),
+          hasSecret: () => Effect.die("not used"),
+          addSecret: () => Effect.die("not used"),
+          runWithSecrets: (input) => {
+            runs.push(input)
+            if (runs.length === 1) {
+              return Effect.succeed({
+                exitCode: 1,
+                stdout: "",
+                stderr: "upstream boom",
+              })
+            }
+            if (runs.length === 2) {
+              return Effect.succeed({ exitCode: 2, stdout: "", stderr: "" })
+            }
+            return Effect.succeed({ exitCode: 0, stdout: "0", stderr: "" })
+          },
+        })
+        const layer = keymaxxerGitHubLayer({
+          workspaceRoot: "/workspace",
+          openPullRequestCountFreshnessMs: 60_000,
+          nowMs: () => clock,
+        }).pipe(Layer.provide(keymaxxerLayer))
 
-    expect(count).toBe(5)
-    expect(runs).toHaveLength(1)
-    expect(JSON.stringify(runs)).not.toContain(rawToken)
-  })
+        yield* Effect.gen(function* () {
+          const github = yield* GitHubService
+
+          const requestFailure = yield* Effect.exit(
+            github.countOpenNonDraftPullRequests(acmeWidgets),
+          )
+          expect(Exit.isFailure(requestFailure)).toBe(true)
+
+          clock += 10
+          const unavailable = yield* Effect.exit(
+            github.countOpenNonDraftPullRequests(acmeWidgets),
+          )
+          expect(Exit.isFailure(unavailable)).toBe(true)
+          if (Exit.isFailure(unavailable)) {
+            const error = unavailable.cause
+            // Ensure we did not swallow unavailable into a cached zero.
+            expect(String(error)).toContain("GitHubRepositoryUnavailableError")
+          }
+
+          clock += 10
+          const zero = yield* github.countOpenNonDraftPullRequests(acmeWidgets)
+          expect(zero).toBe(0)
+
+          clock += 10
+          // Genuine zero is success-cached; failures above must not have been.
+          const cachedZero =
+            yield* github.countOpenNonDraftPullRequests(acmeWidgets)
+          expect(cachedZero).toBe(0)
+        }).pipe(Effect.provide(layer))
+
+        expect(runs).toHaveLength(3)
+      }),
+  )
+
+  it.effect(
+    "raw Forge credentials stay in the Keymaxxer child and never enter the count result path",
+    () =>
+      Effect.gen(function* () {
+        const secretName = "GITHUB_TOKEN_ACME_WIDGETS"
+        const rawToken = "ghp_this_must_never_appear_in_harness_memory_path"
+        const runs: RunWithSecretsInput[] = []
+        const keymaxxerLayer = Layer.succeed(KeymaxxerService, {
+          initialize: Effect.void,
+          findSecret: () => Effect.succeed(secretName),
+          findSecrets: () => Effect.die("not used"),
+          hasSecret: () => Effect.die("not used"),
+          addSecret: () => Effect.die("not used"),
+          runWithSecrets: (input) => {
+            runs.push(input)
+            // Keymaxxer injects the secret by name into the child env; the Harness
+            // only sees the secret name and the child's decoded stdout count.
+            expect(input.secrets).toEqual([secretName])
+            expect(input.command).toContain(`GITHUB_TOKEN="$${secretName}"`)
+            expect(JSON.stringify(input)).not.toContain(rawToken)
+            return Effect.succeed({ exitCode: 0, stdout: "5", stderr: "" })
+          },
+        })
+        const layer = keymaxxerGitHubLayer({
+          workspaceRoot: "/workspace",
+        }).pipe(Layer.provide(keymaxxerLayer))
+
+        const count = yield* Effect.gen(function* () {
+          const github = yield* GitHubService
+          return yield* github.countOpenNonDraftPullRequests(acmeWidgets)
+        }).pipe(Effect.provide(layer))
+
+        expect(count).toBe(5)
+        expect(runs).toHaveLength(1)
+        expect(JSON.stringify(runs)).not.toContain(rawToken)
+      }),
+  )
 })

--- a/apps/harness/test/keymaxxer-gitlab-layer.test.ts
+++ b/apps/harness/test/keymaxxer-gitlab-layer.test.ts
@@ -1,6 +1,7 @@
 import * as BunChildProcessSpawner from "@effect/platform-bun/BunChildProcessSpawner"
 import * as BunFileSystem from "@effect/platform-bun/BunFileSystem"
 import * as BunPath from "@effect/platform-bun/BunPath"
+import { describe, expect, it } from "@effect/vitest"
 import { Duration, Effect, Layer } from "effect"
 import {
   GitLabProjectUnavailableError,
@@ -13,7 +14,6 @@ import {
   keymaxxerError,
 } from "@ready-for-agent/keymaxxer-service"
 import { keymaxxerGitLabLayer } from "../src/server/keymaxxer-gitlab-layer.js"
-import { describe, expect, test } from "bun:test"
 
 const platformLayer = BunChildProcessSpawner.layer.pipe(
   Layer.provideMerge(Layer.merge(BunFileSystem.layer, BunPath.layer)),
@@ -55,66 +55,72 @@ const repository = {
 const vaultAccount = "git.drupalcode.org/project/oauth_client"
 
 describe("Keymaxxer-backed GitLab layer", () => {
-  test("does not prompt Keymaxxer when a repository token is missing and falls back to ambient", async () => {
-    let addCalled = false
-    const runs: RunWithSecretsInput[] = []
-    const keymaxxerLayer = Layer.succeed(KeymaxxerService, {
-      initialize: Effect.void,
-      findSecret: () => Effect.succeed(null),
-      findSecrets: () => Effect.die("not used"),
-      hasSecret: () => Effect.die("not used"),
-      addSecret: () =>
-        Effect.sync(() => {
-          addCalled = true
-          return true
-        }),
-      runWithSecrets: (input) => {
-        runs.push(input)
-        return Effect.succeed({ exitCode: 0, stdout: "[]", stderr: "" })
-      },
-    })
-    const layer = keymaxxerGitLabLayer({
-      workspaceRoot: "/workspace",
-      environment: { GITLAB_TOKEN: "ambient-token" },
-      // Ambient path is exercised via real ambient layer with env token.
-    }).pipe(Layer.provide(keymaxxerLayer), Layer.provide(platformLayer))
-
-    // Without vault secret, ambient hasCredentials should be true.
-    await Effect.runPromise(
+  it.effect(
+    "does not prompt Keymaxxer when a repository token is missing and falls back to ambient",
+    () =>
       Effect.gen(function* () {
-        const gitlab = yield* GitLabService
-        expect(yield* gitlab.hasCredentials(repository)).toBe(true)
-      }).pipe(Effect.provide(layer)),
-    )
+        let addCalled = false
+        const runs: RunWithSecretsInput[] = []
+        const keymaxxerLayer = Layer.succeed(KeymaxxerService, {
+          initialize: Effect.void,
+          findSecret: () => Effect.succeed(null),
+          findSecrets: () => Effect.die("not used"),
+          hasSecret: () => Effect.die("not used"),
+          addSecret: () =>
+            Effect.sync(() => {
+              addCalled = true
+              return true
+            }),
+          runWithSecrets: (input) => {
+            runs.push(input)
+            return Effect.succeed({ exitCode: 0, stdout: "[]", stderr: "" })
+          },
+        })
+        const layer = keymaxxerGitLabLayer({
+          workspaceRoot: "/workspace",
+          environment: { GITLAB_TOKEN: "ambient-token" },
+          // Ambient path is exercised via real ambient layer with env token.
+        }).pipe(Layer.provide(keymaxxerLayer), Layer.provide(platformLayer))
 
-    expect(addCalled).toBe(false)
-    expect(runs).toHaveLength(0)
-  })
+        // Without vault secret, ambient hasCredentials should be true.
+        yield* Effect.gen(function* () {
+          const gitlab = yield* GitLabService
+          expect(yield* gitlab.hasCredentials(repository)).toBe(true)
+        }).pipe(Effect.provide(layer))
 
-  test("selects vault secrets by forge-host/project-path account", async () => {
-    const runs: RunWithSecretsInput[] = []
-    const tokens = new Map([
-      ["git.drupalcode.org/project/oauth_client", "GITLAB_TOKEN_DRUPAL_OAUTH"],
-      ["gitlab.example.com/group/app", "GITLAB_TOKEN_EXAMPLE_APP"],
-    ])
-    const keymaxxerLayer = Layer.succeed(KeymaxxerService, {
-      initialize: Effect.void,
-      findSecret: ({ account }) => Effect.succeed(tokens.get(account) ?? null),
-      findSecrets: () => Effect.die("not used"),
-      hasSecret: () => Effect.die("not used"),
-      addSecret: () => Effect.die("not used"),
-      runWithSecrets: (input) => {
-        runs.push(input)
-        return Effect.succeed({ exitCode: 0, stdout: "[]", stderr: "" })
-      },
-    })
-    const layer = keymaxxerGitLabLayer({ workspaceRoot: "/workspace" }).pipe(
-      Layer.provide(keymaxxerLayer),
-      Layer.provide(platformLayer),
-    )
+        expect(addCalled).toBe(false)
+        expect(runs).toHaveLength(0)
+      }),
+  )
 
-    await Effect.runPromise(
-      Effect.gen(function* () {
+  it.effect("selects vault secrets by forge-host/project-path account", () =>
+    Effect.gen(function* () {
+      const runs: RunWithSecretsInput[] = []
+      const tokens = new Map([
+        [
+          "git.drupalcode.org/project/oauth_client",
+          "GITLAB_TOKEN_DRUPAL_OAUTH",
+        ],
+        ["gitlab.example.com/group/app", "GITLAB_TOKEN_EXAMPLE_APP"],
+      ])
+      const keymaxxerLayer = Layer.succeed(KeymaxxerService, {
+        initialize: Effect.void,
+        findSecret: ({ account }) =>
+          Effect.succeed(tokens.get(account) ?? null),
+        findSecrets: () => Effect.die("not used"),
+        hasSecret: () => Effect.die("not used"),
+        addSecret: () => Effect.die("not used"),
+        runWithSecrets: (input) => {
+          runs.push(input)
+          return Effect.succeed({ exitCode: 0, stdout: "[]", stderr: "" })
+        },
+      })
+      const layer = keymaxxerGitLabLayer({ workspaceRoot: "/workspace" }).pipe(
+        Layer.provide(keymaxxerLayer),
+        Layer.provide(platformLayer),
+      )
+
+      yield* Effect.gen(function* () {
         const gitlab = yield* GitLabService
         yield* gitlab.listReadyIssues(repository)
         yield* gitlab.listReadyIssues({
@@ -122,727 +128,757 @@ describe("Keymaxxer-backed GitLab layer", () => {
           forgeHost: "gitlab.example.com",
           projectPath: "group/app",
         })
-      }).pipe(Effect.provide(layer)),
-    )
+      }).pipe(Effect.provide(layer))
 
-    expect(runs.map(({ secrets }) => secrets)).toEqual([
-      ["GITLAB_TOKEN_DRUPAL_OAUTH"],
-      ["GITLAB_TOKEN_EXAMPLE_APP"],
-    ])
-    for (const run of runs) {
-      expect(run.command).toContain('GITLAB_TOKEN="$')
-      expect(run.command).toMatch(/list-ready-issues/)
-    }
-  })
+      expect(runs.map(({ secrets }) => secrets)).toEqual([
+        ["GITLAB_TOKEN_DRUPAL_OAUTH"],
+        ["GITLAB_TOKEN_EXAMPLE_APP"],
+      ])
+      for (const run of runs) {
+        expect(run.command).toContain('GITLAB_TOKEN="$')
+        expect(run.command).toMatch(/list-ready-issues/)
+      }
+    }),
+  )
 
-  test("vault secret takes precedence over ambient GITLAB_TOKEN", async () => {
-    const runs: RunWithSecretsInput[] = []
-    const keymaxxerLayer = Layer.succeed(KeymaxxerService, {
-      initialize: Effect.void,
-      findSecret: ({ provider, account }) =>
-        Effect.succeed(
-          provider === "gitlab" && account === vaultAccount
-            ? "GITLAB_TOKEN_PROJECT_OAUTH_CLIENT"
-            : null,
-        ),
-      findSecrets: () => Effect.die("not used"),
-      hasSecret: () => Effect.die("not used"),
-      addSecret: () => Effect.die("not used"),
-      runWithSecrets: (input) => {
-        runs.push(input)
-        return Effect.succeed({
-          exitCode: 0,
-          stdout: JSON.stringify([
-            {
-              number: 7,
-              title: "Ready issue",
-              body: "Issue body",
-              url: "https://git.drupalcode.org/project/oauth_client/-/issues/7",
-              createdAt: "2026-07-07T12:00:00.000Z",
-              state: "OPEN",
-              author: "alice",
-              hierarchySupported: false,
-              closingPullRequests: [],
-              hasChildren: false,
-              parentPosition: null,
-              parent: null,
-              blockedBy: [],
-            },
-          ]),
-          stderr: "",
-        })
-      },
-    })
-    const layer = keymaxxerGitLabLayer({
-      workspaceRoot: "/workspace",
-      environment: { GITLAB_TOKEN: "must-not-be-used-in-harness" },
-    }).pipe(Layer.provide(keymaxxerLayer), Layer.provide(platformLayer))
+  it.effect("vault secret takes precedence over ambient GITLAB_TOKEN", () =>
+    Effect.gen(function* () {
+      const runs: RunWithSecretsInput[] = []
+      const keymaxxerLayer = Layer.succeed(KeymaxxerService, {
+        initialize: Effect.void,
+        findSecret: ({ provider, account }) =>
+          Effect.succeed(
+            provider === "gitlab" && account === vaultAccount
+              ? "GITLAB_TOKEN_PROJECT_OAUTH_CLIENT"
+              : null,
+          ),
+        findSecrets: () => Effect.die("not used"),
+        hasSecret: () => Effect.die("not used"),
+        addSecret: () => Effect.die("not used"),
+        runWithSecrets: (input) => {
+          runs.push(input)
+          return Effect.succeed({
+            exitCode: 0,
+            stdout: JSON.stringify([
+              {
+                number: 7,
+                title: "Ready issue",
+                body: "Issue body",
+                url: "https://git.drupalcode.org/project/oauth_client/-/issues/7",
+                createdAt: "2026-07-07T12:00:00.000Z",
+                state: "OPEN",
+                author: "alice",
+                hierarchySupported: false,
+                closingPullRequests: [],
+                hasChildren: false,
+                parentPosition: null,
+                parent: null,
+                blockedBy: [],
+              },
+            ]),
+            stderr: "",
+          })
+        },
+      })
+      const layer = keymaxxerGitLabLayer({
+        workspaceRoot: "/workspace",
+        environment: { GITLAB_TOKEN: "must-not-be-used-in-harness" },
+      }).pipe(Layer.provide(keymaxxerLayer), Layer.provide(platformLayer))
 
-    const issues = await Effect.runPromise(
-      Effect.gen(function* () {
+      const issues = yield* Effect.gen(function* () {
         const gitlab = yield* GitLabService
         return yield* gitlab.listReadyIssues(repository)
-      }).pipe(Effect.provide(layer)),
-    )
+      }).pipe(Effect.provide(layer))
 
-    expect(issues).toHaveLength(1)
-    expect(issues[0]!.number).toBe(7)
-    expect(runs).toHaveLength(1)
-    expect(runs[0]!.secrets).toEqual(["GITLAB_TOKEN_PROJECT_OAUTH_CLIENT"])
-    expect(runs[0]!.command).toContain(
-      'GITLAB_TOKEN="$GITLAB_TOKEN_PROJECT_OAUTH_CLIENT"',
-    )
-  })
+      expect(issues).toHaveLength(1)
+      expect(issues[0]!.number).toBe(7)
+      expect(runs).toHaveLength(1)
+      expect(runs[0]!.secrets).toEqual(["GITLAB_TOKEN_PROJECT_OAUTH_CLIENT"])
+      expect(runs[0]!.command).toContain(
+        'GITLAB_TOKEN="$GITLAB_TOKEN_PROJECT_OAUTH_CLIENT"',
+      )
+    }),
+  )
 
-  test("hasCredentials is true when vault holds the secret", async () => {
-    const keymaxxerLayer = Layer.succeed(KeymaxxerService, {
-      initialize: Effect.void,
-      findSecret: ({ account }) =>
-        Effect.succeed(
-          account === vaultAccount ? "GITLAB_TOKEN_PROJECT_OAUTH_CLIENT" : null,
-        ),
-      findSecrets: () => Effect.die("not used"),
-      hasSecret: () => Effect.die("not used"),
-      addSecret: () => Effect.die("not used"),
-      runWithSecrets: () => Effect.die("not used"),
-    })
-    const layer = keymaxxerGitLabLayer({ workspaceRoot: "/workspace" }).pipe(
-      Layer.provide(keymaxxerLayer),
-      Layer.provide(platformLayer),
-    )
+  it.effect("hasCredentials is true when vault holds the secret", () =>
+    Effect.gen(function* () {
+      const keymaxxerLayer = Layer.succeed(KeymaxxerService, {
+        initialize: Effect.void,
+        findSecret: ({ account }) =>
+          Effect.succeed(
+            account === vaultAccount
+              ? "GITLAB_TOKEN_PROJECT_OAUTH_CLIENT"
+              : null,
+          ),
+        findSecrets: () => Effect.die("not used"),
+        hasSecret: () => Effect.die("not used"),
+        addSecret: () => Effect.die("not used"),
+        runWithSecrets: () => Effect.die("not used"),
+      })
+      const layer = keymaxxerGitLabLayer({ workspaceRoot: "/workspace" }).pipe(
+        Layer.provide(keymaxxerLayer),
+        Layer.provide(platformLayer),
+      )
 
-    await Effect.runPromise(
-      Effect.gen(function* () {
+      yield* Effect.gen(function* () {
         const gitlab = yield* GitLabService
         expect(yield* gitlab.hasCredentials(repository)).toBe(true)
-      }).pipe(Effect.provide(layer)),
-    )
-  })
+      }).pipe(Effect.provide(layer))
+    }),
+  )
 
-  test("maps helper exit code 2 to project unavailable", async () => {
-    const keymaxxerLayer = Layer.succeed(KeymaxxerService, {
-      initialize: Effect.void,
-      findSecret: () => Effect.succeed("GITLAB_TOKEN_PROJECT_OAUTH_CLIENT"),
-      findSecrets: () => Effect.die("not used"),
-      hasSecret: () => Effect.die("not used"),
-      addSecret: () => Effect.die("not used"),
-      runWithSecrets: () =>
-        Effect.succeed({ exitCode: 2, stdout: "", stderr: "" }),
-    })
-    const layer = keymaxxerGitLabLayer({ workspaceRoot: "/workspace" }).pipe(
-      Layer.provide(keymaxxerLayer),
-      Layer.provide(platformLayer),
-    )
+  it.effect("maps helper exit code 2 to project unavailable", () =>
+    Effect.gen(function* () {
+      const keymaxxerLayer = Layer.succeed(KeymaxxerService, {
+        initialize: Effect.void,
+        findSecret: () => Effect.succeed("GITLAB_TOKEN_PROJECT_OAUTH_CLIENT"),
+        findSecrets: () => Effect.die("not used"),
+        hasSecret: () => Effect.die("not used"),
+        addSecret: () => Effect.die("not used"),
+        runWithSecrets: () =>
+          Effect.succeed({ exitCode: 2, stdout: "", stderr: "" }),
+      })
+      const layer = keymaxxerGitLabLayer({ workspaceRoot: "/workspace" }).pipe(
+        Layer.provide(keymaxxerLayer),
+        Layer.provide(platformLayer),
+      )
 
-    const error = await Effect.runPromise(
-      Effect.gen(function* () {
+      const error = yield* Effect.gen(function* () {
         const gitlab = yield* GitLabService
         return yield* Effect.flip(gitlab.listReadyIssues(repository))
-      }).pipe(Effect.provide(layer)),
-    )
+      }).pipe(Effect.provide(layer))
 
-    expect(error).toBeInstanceOf(GitLabProjectUnavailableError)
-  })
+      expect(error).toBeInstanceOf(GitLabProjectUnavailableError)
+    }),
+  )
 
-  test("verifyProject decodes JSON host rewrite from the vault helper", async () => {
-    const sshGuess = {
-      forge: "gitlab",
-      forgeHost: "git.drupal.org",
-      projectPath: "project/oauth_client",
-    } as const
-    const keymaxxerLayer = Layer.succeed(KeymaxxerService, {
-      initialize: Effect.void,
-      findSecret: ({ account }) =>
-        Effect.succeed(
-          account === "git.drupal.org/project/oauth_client"
-            ? "GITLAB_TOKEN_SSH_GUESS"
-            : null,
-        ),
-      findSecrets: () => Effect.die("not used"),
-      hasSecret: () => Effect.die("not used"),
-      addSecret: () => Effect.die("not used"),
-      runWithSecrets: () =>
-        Effect.succeed({
-          exitCode: 0,
-          stdout: JSON.stringify({
-            forge: "gitlab",
-            forgeHost: "Git.DrupalCode.Org",
-            projectPath: "project/oauth_client",
+  it.effect(
+    "verifyProject decodes JSON host rewrite from the vault helper",
+    () =>
+      Effect.gen(function* () {
+        const sshGuess = {
+          forge: "gitlab",
+          forgeHost: "git.drupal.org",
+          projectPath: "project/oauth_client",
+        } as const
+        const keymaxxerLayer = Layer.succeed(KeymaxxerService, {
+          initialize: Effect.void,
+          findSecret: ({ account }) =>
+            Effect.succeed(
+              account === "git.drupal.org/project/oauth_client"
+                ? "GITLAB_TOKEN_SSH_GUESS"
+                : null,
+            ),
+          findSecrets: () => Effect.die("not used"),
+          hasSecret: () => Effect.die("not used"),
+          addSecret: () => Effect.die("not used"),
+          runWithSecrets: () =>
+            Effect.succeed({
+              exitCode: 0,
+              stdout: JSON.stringify({
+                forge: "gitlab",
+                forgeHost: "Git.DrupalCode.Org",
+                projectPath: "project/oauth_client",
+              }),
+              stderr: "",
+            }),
+        })
+        const layer = keymaxxerGitLabLayer({
+          workspaceRoot: "/workspace",
+        }).pipe(Layer.provide(keymaxxerLayer), Layer.provide(platformLayer))
+
+        const resolved = yield* Effect.gen(function* () {
+          const gitlab = yield* GitLabService
+          return yield* gitlab.verifyProject(sshGuess)
+        }).pipe(Effect.provide(layer))
+
+        expect(resolved).toEqual({
+          forge: "gitlab",
+          forgeHost: "git.drupalcode.org",
+          projectPath: "project/oauth_client",
+        })
+      }),
+  )
+
+  it.effect(
+    "verifyProject treats legacy ok helper stdout as no host change",
+    () =>
+      Effect.gen(function* () {
+        const keymaxxerLayer = Layer.succeed(KeymaxxerService, {
+          initialize: Effect.void,
+          findSecret: () => Effect.succeed("GITLAB_TOKEN_PROJECT_OAUTH_CLIENT"),
+          findSecrets: () => Effect.die("not used"),
+          hasSecret: () => Effect.die("not used"),
+          addSecret: () => Effect.die("not used"),
+          runWithSecrets: () =>
+            Effect.succeed({ exitCode: 0, stdout: "ok", stderr: "" }),
+        })
+        const layer = keymaxxerGitLabLayer({
+          workspaceRoot: "/workspace",
+        }).pipe(Layer.provide(keymaxxerLayer), Layer.provide(platformLayer))
+
+        const resolved = yield* Effect.gen(function* () {
+          const gitlab = yield* GitLabService
+          return yield* gitlab.verifyProject(repository)
+        }).pipe(Effect.provide(layer))
+
+        expect(resolved).toEqual(repository)
+      }),
+  )
+
+  it.effect(
+    "verifyProject maps invalid helper JSON to GitLabRequestError",
+    () =>
+      Effect.gen(function* () {
+        const keymaxxerLayer = Layer.succeed(KeymaxxerService, {
+          initialize: Effect.void,
+          findSecret: () => Effect.succeed("GITLAB_TOKEN_PROJECT_OAUTH_CLIENT"),
+          findSecrets: () => Effect.die("not used"),
+          hasSecret: () => Effect.die("not used"),
+          addSecret: () => Effect.die("not used"),
+          runWithSecrets: () =>
+            Effect.succeed({
+              exitCode: 0,
+              stdout: "not-json",
+              stderr: "",
+            }),
+        })
+        const layer = keymaxxerGitLabLayer({
+          workspaceRoot: "/workspace",
+        }).pipe(Layer.provide(keymaxxerLayer), Layer.provide(platformLayer))
+
+        const error = yield* Effect.gen(function* () {
+          const gitlab = yield* GitLabService
+          return yield* Effect.flip(gitlab.verifyProject(repository))
+        }).pipe(Effect.provide(layer))
+
+        expect(error).toBeInstanceOf(GitLabRequestError)
+      }),
+  )
+
+  it.effect("maps helper non-zero exit to GitLabRequestError", () =>
+    Effect.gen(function* () {
+      const keymaxxerLayer = Layer.succeed(KeymaxxerService, {
+        initialize: Effect.void,
+        findSecret: () => Effect.succeed("GITLAB_TOKEN_PROJECT_OAUTH_CLIENT"),
+        findSecrets: () => Effect.die("not used"),
+        hasSecret: () => Effect.die("not used"),
+        addSecret: () => Effect.die("not used"),
+        runWithSecrets: () =>
+          Effect.succeed({
+            exitCode: 1,
+            stdout: "",
+            stderr: "permission denied",
           }),
-          stderr: "",
-        }),
-    })
-    const layer = keymaxxerGitLabLayer({ workspaceRoot: "/workspace" }).pipe(
-      Layer.provide(keymaxxerLayer),
-      Layer.provide(platformLayer),
-    )
+      })
+      const layer = keymaxxerGitLabLayer({ workspaceRoot: "/workspace" }).pipe(
+        Layer.provide(keymaxxerLayer),
+        Layer.provide(platformLayer),
+      )
 
-    const resolved = await Effect.runPromise(
-      Effect.gen(function* () {
-        const gitlab = yield* GitLabService
-        return yield* gitlab.verifyProject(sshGuess)
-      }).pipe(Effect.provide(layer)),
-    )
-
-    expect(resolved).toEqual({
-      forge: "gitlab",
-      forgeHost: "git.drupalcode.org",
-      projectPath: "project/oauth_client",
-    })
-  })
-
-  test("verifyProject treats legacy ok helper stdout as no host change", async () => {
-    const keymaxxerLayer = Layer.succeed(KeymaxxerService, {
-      initialize: Effect.void,
-      findSecret: () => Effect.succeed("GITLAB_TOKEN_PROJECT_OAUTH_CLIENT"),
-      findSecrets: () => Effect.die("not used"),
-      hasSecret: () => Effect.die("not used"),
-      addSecret: () => Effect.die("not used"),
-      runWithSecrets: () =>
-        Effect.succeed({ exitCode: 0, stdout: "ok", stderr: "" }),
-    })
-    const layer = keymaxxerGitLabLayer({ workspaceRoot: "/workspace" }).pipe(
-      Layer.provide(keymaxxerLayer),
-      Layer.provide(platformLayer),
-    )
-
-    const resolved = await Effect.runPromise(
-      Effect.gen(function* () {
-        const gitlab = yield* GitLabService
-        return yield* gitlab.verifyProject(repository)
-      }).pipe(Effect.provide(layer)),
-    )
-
-    expect(resolved).toEqual(repository)
-  })
-
-  test("verifyProject maps invalid helper JSON to GitLabRequestError", async () => {
-    const keymaxxerLayer = Layer.succeed(KeymaxxerService, {
-      initialize: Effect.void,
-      findSecret: () => Effect.succeed("GITLAB_TOKEN_PROJECT_OAUTH_CLIENT"),
-      findSecrets: () => Effect.die("not used"),
-      hasSecret: () => Effect.die("not used"),
-      addSecret: () => Effect.die("not used"),
-      runWithSecrets: () =>
-        Effect.succeed({
-          exitCode: 0,
-          stdout: "not-json",
-          stderr: "",
-        }),
-    })
-    const layer = keymaxxerGitLabLayer({ workspaceRoot: "/workspace" }).pipe(
-      Layer.provide(keymaxxerLayer),
-      Layer.provide(platformLayer),
-    )
-
-    const error = await Effect.runPromise(
-      Effect.gen(function* () {
-        const gitlab = yield* GitLabService
-        return yield* Effect.flip(gitlab.verifyProject(repository))
-      }).pipe(Effect.provide(layer)),
-    )
-
-    expect(error).toBeInstanceOf(GitLabRequestError)
-  })
-
-  test("maps helper non-zero exit to GitLabRequestError", async () => {
-    const keymaxxerLayer = Layer.succeed(KeymaxxerService, {
-      initialize: Effect.void,
-      findSecret: () => Effect.succeed("GITLAB_TOKEN_PROJECT_OAUTH_CLIENT"),
-      findSecrets: () => Effect.die("not used"),
-      hasSecret: () => Effect.die("not used"),
-      addSecret: () => Effect.die("not used"),
-      runWithSecrets: () =>
-        Effect.succeed({
-          exitCode: 1,
-          stdout: "",
-          stderr: "permission denied",
-        }),
-    })
-    const layer = keymaxxerGitLabLayer({ workspaceRoot: "/workspace" }).pipe(
-      Layer.provide(keymaxxerLayer),
-      Layer.provide(platformLayer),
-    )
-
-    const error = await Effect.runPromise(
-      Effect.gen(function* () {
+      const error = yield* Effect.gen(function* () {
         const gitlab = yield* GitLabService
         return yield* Effect.flip(gitlab.getAuthenticatedUserLogin(repository))
-      }).pipe(Effect.provide(layer)),
-    )
+      }).pipe(Effect.provide(layer))
 
-    expect(error).toBeInstanceOf(GitLabRequestError)
-    expect(error.message).toContain("permission denied")
-  })
+      expect(error).toBeInstanceOf(GitLabRequestError)
+      expect(error.message).toContain("permission denied")
+    }),
+  )
 
-  test("hasCredentials falls through to ambient when vault lookup fails", async () => {
-    const keymaxxerLayer = Layer.succeed(KeymaxxerService, {
-      initialize: Effect.void,
-      findSecret: () =>
-        Effect.fail(keymaxxerError("findSecret", "sidecar unavailable")),
-      findSecrets: () => Effect.die("not used"),
-      hasSecret: () => Effect.die("not used"),
-      addSecret: () => Effect.die("not used"),
-      runWithSecrets: () => Effect.die("not used"),
-    })
-    const layer = keymaxxerGitLabLayer({
-      workspaceRoot: "/workspace",
-      environment: { GITLAB_TOKEN: "ambient-token" },
-    }).pipe(Layer.provide(keymaxxerLayer), Layer.provide(platformLayer))
-
-    await Effect.runPromise(
+  it.effect(
+    "hasCredentials falls through to ambient when vault lookup fails",
+    () =>
       Effect.gen(function* () {
-        const gitlab = yield* GitLabService
-        expect(yield* gitlab.hasCredentials(repository)).toBe(true)
-      }).pipe(Effect.provide(layer)),
-    )
-  })
-
-  test("hasCredentials reaches ambient when vault findSecret hangs past budget", async () => {
-    const started = Date.now()
-    const keymaxxerLayer = Layer.succeed(KeymaxxerService, {
-      initialize: Effect.void,
-      findSecret: () => Effect.never,
-      findSecrets: () => Effect.die("not used"),
-      hasSecret: () => Effect.die("not used"),
-      addSecret: () => Effect.die("not used"),
-      runWithSecrets: () => Effect.die("not used"),
-    })
-    const layer = keymaxxerGitLabLayer({
-      workspaceRoot: "/workspace",
-      environment: { GITLAB_TOKEN: "ambient-token" },
-      vaultMetadataBudget: Duration.millis(40),
-    }).pipe(Layer.provide(keymaxxerLayer), Layer.provide(platformLayer))
-
-    await Effect.runPromise(
-      Effect.gen(function* () {
-        const gitlab = yield* GitLabService
-        expect(yield* gitlab.hasCredentials(repository)).toBe(true)
-        // Ambient-only probe never re-enters the hung vault path.
-        expect(yield* gitlab.hasAmbientCredentials(repository)).toBe(true)
-      }).pipe(Effect.provide(layer)),
-    )
-    expect(Date.now() - started).toBeLessThan(2_000)
-  })
-
-  test("hasCredentials fails open when vault is unavailable and ambient is absent", async () => {
-    // Vault-only repos must keep polling membership during temporary Keymaxxer
-    // outages (job-worker drops schedules on false).
-    let ambientChecked = false
-    const keymaxxerLayer = Layer.succeed(KeymaxxerService, {
-      initialize: Effect.void,
-      findSecret: () =>
-        Effect.fail(keymaxxerError("findSecret", "sidecar unavailable")),
-      findSecrets: () => Effect.die("not used"),
-      hasSecret: () => Effect.die("not used"),
-      addSecret: () => Effect.die("not used"),
-      runWithSecrets: () => Effect.die("not used"),
-    })
-    const layer = keymaxxerGitLabLayer({
-      workspaceRoot: "/workspace",
-      // Force ambient credential probes to be a pure no (no glab/network).
-      makeService: () => ({
-        verifyProject: (repository) => Effect.succeed(repository),
-        getAuthenticatedUserLogin: () => Effect.succeed("operator"),
-        listReadyIssues: () => Effect.succeed([]),
-        hasCredentials: () =>
-          Effect.sync(() => {
-            ambientChecked = true
-            return false
-          }),
-        hasAmbientCredentials: () =>
-          Effect.sync(() => {
-            ambientChecked = true
-            return false
-          }),
-        ...gitlabLifecycleStub,
-      }),
-      makeAnonymousService: () => ({
-        verifyProject: (repository) => Effect.succeed(repository),
-        getAuthenticatedUserLogin: () => Effect.succeed("anonymous"),
-        listReadyIssues: () => Effect.succeed([]),
-        hasCredentials: () => Effect.succeed(false),
-        hasAmbientCredentials: () => Effect.succeed(false),
-        ...gitlabLifecycleStub,
-      }),
-    }).pipe(Layer.provide(keymaxxerLayer), Layer.provide(platformLayer))
-
-    await Effect.runPromise(
-      Effect.gen(function* () {
-        const gitlab = yield* GitLabService
-        // Probe failure is not a clean miss: treat as still credentialed and
-        // do not consult ambient for membership (fail open).
-        expect(yield* gitlab.hasCredentials(repository)).toBe(true)
-      }).pipe(Effect.provide(layer)),
-    )
-    expect(ambientChecked).toBe(false)
-  })
-
-  test("listReadyIssues reaches ambient when vault findSecret hangs past budget", async () => {
-    const runs: RunWithSecretsInput[] = []
-    let ambientListCalls = 0
-    const keymaxxerLayer = Layer.succeed(KeymaxxerService, {
-      initialize: Effect.void,
-      findSecret: () => Effect.never,
-      findSecrets: () => Effect.die("not used"),
-      hasSecret: () => Effect.die("not used"),
-      addSecret: () => Effect.die("not used"),
-      runWithSecrets: (input) => {
-        runs.push(input)
-        return Effect.succeed({ exitCode: 0, stdout: "[]", stderr: "" })
-      },
-    })
-    const layer = keymaxxerGitLabLayer({
-      workspaceRoot: "/workspace",
-      environment: { GITLAB_TOKEN: "ambient-token" },
-      vaultMetadataBudget: Duration.millis(40),
-      makeService: () => ({
-        verifyProject: (repository) => Effect.succeed(repository),
-        getAuthenticatedUserLogin: () => Effect.succeed("operator"),
-        listReadyIssues: () => {
-          ambientListCalls += 1
-          return Effect.succeed([])
-        },
-        hasCredentials: () => Effect.succeed(true),
-        hasAmbientCredentials: () => Effect.succeed(true),
-        ...gitlabLifecycleStub,
-      }),
-    }).pipe(Layer.provide(keymaxxerLayer), Layer.provide(platformLayer))
-
-    const started = Date.now()
-    await Effect.runPromise(
-      Effect.gen(function* () {
-        const gitlab = yield* GitLabService
-        expect(yield* gitlab.listReadyIssues(repository)).toEqual([])
-      }).pipe(Effect.provide(layer)),
-    )
-    expect(runs).toHaveLength(0)
-    expect(ambientListCalls).toBe(1)
-    expect(Date.now() - started).toBeLessThan(2_000)
-  })
-
-  test("operations fall through to ambient when vault lookup fails", async () => {
-    const runs: RunWithSecretsInput[] = []
-    let ambientListCalls = 0
-    const keymaxxerLayer = Layer.succeed(KeymaxxerService, {
-      initialize: Effect.void,
-      findSecret: () =>
-        Effect.fail(keymaxxerError("findSecret", "sidecar unavailable")),
-      findSecrets: () => Effect.die("not used"),
-      hasSecret: () => Effect.die("not used"),
-      addSecret: () => Effect.die("not used"),
-      runWithSecrets: (input) => {
-        runs.push(input)
-        return Effect.succeed({ exitCode: 0, stdout: "[]", stderr: "" })
-      },
-    })
-    const layer = keymaxxerGitLabLayer({
-      workspaceRoot: "/workspace",
-      environment: { GITLAB_TOKEN: "ambient-token" },
-      makeService: () => ({
-        verifyProject: (repository) => Effect.succeed(repository),
-        getAuthenticatedUserLogin: () => Effect.succeed("operator"),
-        listReadyIssues: () => {
-          ambientListCalls += 1
-          return Effect.succeed([])
-        },
-        hasCredentials: () => Effect.succeed(true),
-        hasAmbientCredentials: () => Effect.succeed(true),
-        ...gitlabLifecycleStub,
-      }),
-    }).pipe(Layer.provide(keymaxxerLayer), Layer.provide(platformLayer))
-
-    await Effect.runPromise(
-      Effect.gen(function* () {
-        const gitlab = yield* GitLabService
-        expect(yield* gitlab.listReadyIssues(repository)).toEqual([])
-      }).pipe(Effect.provide(layer)),
-    )
-    expect(runs).toHaveLength(0)
-    expect(ambientListCalls).toBe(1)
-  })
-
-  test("helper KeymaxxerError after a resolved secret stays fail-closed", async () => {
-    const keymaxxerLayer = Layer.succeed(KeymaxxerService, {
-      initialize: Effect.void,
-      findSecret: () => Effect.succeed("GITLAB_TOKEN_PROJECT_OAUTH_CLIENT"),
-      findSecrets: () => Effect.die("not used"),
-      hasSecret: () => Effect.die("not used"),
-      addSecret: () => Effect.die("not used"),
-      runWithSecrets: () =>
-        Effect.fail(keymaxxerError("runWithSecrets", "use denied")),
-    })
-    const layer = keymaxxerGitLabLayer({
-      workspaceRoot: "/workspace",
-      environment: { GITLAB_TOKEN: "must-not-fallback" },
-    }).pipe(Layer.provide(keymaxxerLayer), Layer.provide(platformLayer))
-
-    const error = await Effect.runPromise(
-      Effect.gen(function* () {
-        const gitlab = yield* GitLabService
-        return yield* Effect.flip(gitlab.listReadyIssues(repository))
-      }).pipe(Effect.provide(layer)),
-    )
-
-    expect(error).toBeInstanceOf(GitLabRequestError)
-    expect(error.message).toContain("list Ready-labeled Issues")
-  })
-
-  test("checks a merge-request branch through the vault secret and rehydrates dates", async () => {
-    const runs: RunWithSecretsInput[] = []
-    const keymaxxerLayer = Layer.succeed(KeymaxxerService, {
-      initialize: Effect.void,
-      findSecret: ({ account }) =>
-        Effect.succeed(
-          account === vaultAccount ? "GITLAB_TOKEN_PROJECT_OAUTH_CLIENT" : null,
-        ),
-      findSecrets: () => Effect.die("not used"),
-      hasSecret: () => Effect.die("not used"),
-      addSecret: () => Effect.die("not used"),
-      runWithSecrets: (input) => {
-        runs.push(input)
-        return Effect.succeed({
-          exitCode: 0,
-          stdout: JSON.stringify({
-            _tag: "failed",
-            mergeability: "mergeable",
-            baseRefName: "1.0.x",
-            headPushedAt: "2026-07-20T10:04:00.000Z",
-            headSha: "deadbeef",
-            createdAt: "2026-07-20T10:00:00.000Z",
-            isDraft: true,
-            terminalChecks: [
-              {
-                externalId: "gitlab-job:2",
-                name: "phpunit",
-                outcome: "red",
-              },
-            ],
-          }),
-          stderr: "",
+        const keymaxxerLayer = Layer.succeed(KeymaxxerService, {
+          initialize: Effect.void,
+          findSecret: () =>
+            Effect.fail(keymaxxerError("findSecret", "sidecar unavailable")),
+          findSecrets: () => Effect.die("not used"),
+          hasSecret: () => Effect.die("not used"),
+          addSecret: () => Effect.die("not used"),
+          runWithSecrets: () => Effect.die("not used"),
         })
-      },
-    })
-    const layer = keymaxxerGitLabLayer({ workspaceRoot: "/workspace" }).pipe(
-      Layer.provide(keymaxxerLayer),
-      Layer.provide(platformLayer),
-    )
+        const layer = keymaxxerGitLabLayer({
+          workspaceRoot: "/workspace",
+          environment: { GITLAB_TOKEN: "ambient-token" },
+        }).pipe(Layer.provide(keymaxxerLayer), Layer.provide(platformLayer))
 
-    const status = await Effect.runPromise(
+        yield* Effect.gen(function* () {
+          const gitlab = yield* GitLabService
+          expect(yield* gitlab.hasCredentials(repository)).toBe(true)
+        }).pipe(Effect.provide(layer))
+      }),
+  )
+
+  // Real wall-clock budget: vault findSecret hangs until Duration elapses.
+  it.live(
+    "hasCredentials reaches ambient when vault findSecret hangs past budget",
+    () =>
       Effect.gen(function* () {
-        const gitlab = yield* GitLabService
-        return yield* gitlab.getPullRequestCheckStatus(
-          repository,
-          "rfa/project-oauth-client/42/wi-test",
-        )
-      }).pipe(Effect.provide(layer)),
-    )
+        const started = Date.now()
+        const keymaxxerLayer = Layer.succeed(KeymaxxerService, {
+          initialize: Effect.void,
+          findSecret: () => Effect.never,
+          findSecrets: () => Effect.die("not used"),
+          hasSecret: () => Effect.die("not used"),
+          addSecret: () => Effect.die("not used"),
+          runWithSecrets: () => Effect.die("not used"),
+        })
+        const layer = keymaxxerGitLabLayer({
+          workspaceRoot: "/workspace",
+          environment: { GITLAB_TOKEN: "ambient-token" },
+          vaultMetadataBudget: Duration.millis(40),
+        }).pipe(Layer.provide(keymaxxerLayer), Layer.provide(platformLayer))
 
-    expect(status).toEqual({
-      _tag: "failed",
-      mergeability: "mergeable",
-      baseRefName: "1.0.x",
-      headPushedAt: new Date("2026-07-20T10:04:00.000Z"),
-      headSha: "deadbeef",
-      createdAt: new Date("2026-07-20T10:00:00.000Z"),
-      isDraft: true,
-      terminalChecks: [
-        {
-          externalId: "gitlab-job:2",
-          name: "phpunit",
-          outcome: "red",
+        yield* Effect.gen(function* () {
+          const gitlab = yield* GitLabService
+          expect(yield* gitlab.hasCredentials(repository)).toBe(true)
+          // Ambient-only probe never re-enters the hung vault path.
+          expect(yield* gitlab.hasAmbientCredentials(repository)).toBe(true)
+        }).pipe(Effect.provide(layer))
+        expect(Date.now() - started).toBeLessThan(2_000)
+      }),
+  )
+
+  it.effect(
+    "hasCredentials fails open when vault is unavailable and ambient is absent",
+    () =>
+      Effect.gen(function* () {
+        // Vault-only repos must keep polling membership during temporary Keymaxxer
+        // outages (job-worker drops schedules on false).
+        let ambientChecked = false
+        const keymaxxerLayer = Layer.succeed(KeymaxxerService, {
+          initialize: Effect.void,
+          findSecret: () =>
+            Effect.fail(keymaxxerError("findSecret", "sidecar unavailable")),
+          findSecrets: () => Effect.die("not used"),
+          hasSecret: () => Effect.die("not used"),
+          addSecret: () => Effect.die("not used"),
+          runWithSecrets: () => Effect.die("not used"),
+        })
+        const layer = keymaxxerGitLabLayer({
+          workspaceRoot: "/workspace",
+          // Force ambient credential probes to be a pure no (no glab/network).
+          makeService: () => ({
+            verifyProject: (repository) => Effect.succeed(repository),
+            getAuthenticatedUserLogin: () => Effect.succeed("operator"),
+            listReadyIssues: () => Effect.succeed([]),
+            hasCredentials: () =>
+              Effect.sync(() => {
+                ambientChecked = true
+                return false
+              }),
+            hasAmbientCredentials: () =>
+              Effect.sync(() => {
+                ambientChecked = true
+                return false
+              }),
+            ...gitlabLifecycleStub,
+          }),
+          makeAnonymousService: () => ({
+            verifyProject: (repository) => Effect.succeed(repository),
+            getAuthenticatedUserLogin: () => Effect.succeed("anonymous"),
+            listReadyIssues: () => Effect.succeed([]),
+            hasCredentials: () => Effect.succeed(false),
+            hasAmbientCredentials: () => Effect.succeed(false),
+            ...gitlabLifecycleStub,
+          }),
+        }).pipe(Layer.provide(keymaxxerLayer), Layer.provide(platformLayer))
+
+        yield* Effect.gen(function* () {
+          const gitlab = yield* GitLabService
+          // Probe failure is not a clean miss: treat as still credentialed and
+          // do not consult ambient for membership (fail open).
+          expect(yield* gitlab.hasCredentials(repository)).toBe(true)
+        }).pipe(Effect.provide(layer))
+        expect(ambientChecked).toBe(false)
+      }),
+  )
+
+  // Real wall-clock budget: vault findSecret hangs until Duration elapses.
+  it.live(
+    "listReadyIssues reaches ambient when vault findSecret hangs past budget",
+    () =>
+      Effect.gen(function* () {
+        const runs: RunWithSecretsInput[] = []
+        let ambientListCalls = 0
+        const keymaxxerLayer = Layer.succeed(KeymaxxerService, {
+          initialize: Effect.void,
+          findSecret: () => Effect.never,
+          findSecrets: () => Effect.die("not used"),
+          hasSecret: () => Effect.die("not used"),
+          addSecret: () => Effect.die("not used"),
+          runWithSecrets: (input) => {
+            runs.push(input)
+            return Effect.succeed({ exitCode: 0, stdout: "[]", stderr: "" })
+          },
+        })
+        const layer = keymaxxerGitLabLayer({
+          workspaceRoot: "/workspace",
+          environment: { GITLAB_TOKEN: "ambient-token" },
+          vaultMetadataBudget: Duration.millis(40),
+          makeService: () => ({
+            verifyProject: (repository) => Effect.succeed(repository),
+            getAuthenticatedUserLogin: () => Effect.succeed("operator"),
+            listReadyIssues: () => {
+              ambientListCalls += 1
+              return Effect.succeed([])
+            },
+            hasCredentials: () => Effect.succeed(true),
+            hasAmbientCredentials: () => Effect.succeed(true),
+            ...gitlabLifecycleStub,
+          }),
+        }).pipe(Layer.provide(keymaxxerLayer), Layer.provide(platformLayer))
+
+        const started = Date.now()
+        yield* Effect.gen(function* () {
+          const gitlab = yield* GitLabService
+          expect(yield* gitlab.listReadyIssues(repository)).toEqual([])
+        }).pipe(Effect.provide(layer))
+        expect(runs).toHaveLength(0)
+        expect(ambientListCalls).toBe(1)
+        expect(Date.now() - started).toBeLessThan(2_000)
+      }),
+  )
+
+  it.effect("operations fall through to ambient when vault lookup fails", () =>
+    Effect.gen(function* () {
+      const runs: RunWithSecretsInput[] = []
+      let ambientListCalls = 0
+      const keymaxxerLayer = Layer.succeed(KeymaxxerService, {
+        initialize: Effect.void,
+        findSecret: () =>
+          Effect.fail(keymaxxerError("findSecret", "sidecar unavailable")),
+        findSecrets: () => Effect.die("not used"),
+        hasSecret: () => Effect.die("not used"),
+        addSecret: () => Effect.die("not used"),
+        runWithSecrets: (input) => {
+          runs.push(input)
+          return Effect.succeed({ exitCode: 0, stdout: "[]", stderr: "" })
         },
-      ],
-    })
-    expect(runs[0]?.command).toContain("get-pr-check-status")
-    expect(runs[0]?.command).toContain('GITLAB_TOKEN="$')
-    expect(runs[0]?.secrets).toEqual(["GITLAB_TOKEN_PROJECT_OAUTH_CLIENT"])
-  })
+      })
+      const layer = keymaxxerGitLabLayer({
+        workspaceRoot: "/workspace",
+        environment: { GITLAB_TOKEN: "ambient-token" },
+        makeService: () => ({
+          verifyProject: (repository) => Effect.succeed(repository),
+          getAuthenticatedUserLogin: () => Effect.succeed("operator"),
+          listReadyIssues: () => {
+            ambientListCalls += 1
+            return Effect.succeed([])
+          },
+          hasCredentials: () => Effect.succeed(true),
+          hasAmbientCredentials: () => Effect.succeed(true),
+          ...gitlabLifecycleStub,
+        }),
+      }).pipe(Layer.provide(keymaxxerLayer), Layer.provide(platformLayer))
 
-  test("loads PR Status Check diagnostics through the vault secret", async () => {
-    const runs: RunWithSecretsInput[] = []
-    const keymaxxerLayer = Layer.succeed(KeymaxxerService, {
-      initialize: Effect.void,
-      findSecret: ({ account }) =>
-        Effect.succeed(
-          account === vaultAccount ? "GITLAB_TOKEN_PROJECT_OAUTH_CLIENT" : null,
-        ),
-      findSecrets: () => Effect.die("not used"),
-      hasSecret: () => Effect.die("not used"),
-      addSecret: () => Effect.die("not used"),
-      runWithSecrets: (input) => {
-        runs.push(input)
-        return Effect.succeed({
-          exitCode: 0,
-          stdout: JSON.stringify([
+      yield* Effect.gen(function* () {
+        const gitlab = yield* GitLabService
+        expect(yield* gitlab.listReadyIssues(repository)).toEqual([])
+      }).pipe(Effect.provide(layer))
+      expect(runs).toHaveLength(0)
+      expect(ambientListCalls).toBe(1)
+    }),
+  )
+
+  it.effect(
+    "helper KeymaxxerError after a resolved secret stays fail-closed",
+    () =>
+      Effect.gen(function* () {
+        const keymaxxerLayer = Layer.succeed(KeymaxxerService, {
+          initialize: Effect.void,
+          findSecret: () => Effect.succeed("GITLAB_TOKEN_PROJECT_OAUTH_CLIENT"),
+          findSecrets: () => Effect.die("not used"),
+          hasSecret: () => Effect.die("not used"),
+          addSecret: () => Effect.die("not used"),
+          runWithSecrets: () =>
+            Effect.fail(keymaxxerError("runWithSecrets", "use denied")),
+        })
+        const layer = keymaxxerGitLabLayer({
+          workspaceRoot: "/workspace",
+          environment: { GITLAB_TOKEN: "must-not-fallback" },
+        }).pipe(Layer.provide(keymaxxerLayer), Layer.provide(platformLayer))
+
+        const error = yield* Effect.gen(function* () {
+          const gitlab = yield* GitLabService
+          return yield* Effect.flip(gitlab.listReadyIssues(repository))
+        }).pipe(Effect.provide(layer))
+
+        expect(error).toBeInstanceOf(GitLabRequestError)
+        expect(error.message).toContain("list Ready-labeled Issues")
+      }),
+  )
+
+  it.effect(
+    "checks a merge-request branch through the vault secret and rehydrates dates",
+    () =>
+      Effect.gen(function* () {
+        const runs: RunWithSecretsInput[] = []
+        const keymaxxerLayer = Layer.succeed(KeymaxxerService, {
+          initialize: Effect.void,
+          findSecret: ({ account }) =>
+            Effect.succeed(
+              account === vaultAccount
+                ? "GITLAB_TOKEN_PROJECT_OAUTH_CLIENT"
+                : null,
+            ),
+          findSecrets: () => Effect.die("not used"),
+          hasSecret: () => Effect.die("not used"),
+          addSecret: () => Effect.die("not used"),
+          runWithSecrets: (input) => {
+            runs.push(input)
+            return Effect.succeed({
+              exitCode: 0,
+              stdout: JSON.stringify({
+                _tag: "failed",
+                mergeability: "mergeable",
+                baseRefName: "1.0.x",
+                headPushedAt: "2026-07-20T10:04:00.000Z",
+                headSha: "deadbeef",
+                createdAt: "2026-07-20T10:00:00.000Z",
+                isDraft: true,
+                terminalChecks: [
+                  {
+                    externalId: "gitlab-job:2",
+                    name: "phpunit",
+                    outcome: "red",
+                  },
+                ],
+              }),
+              stderr: "",
+            })
+          },
+        })
+        const layer = keymaxxerGitLabLayer({
+          workspaceRoot: "/workspace",
+        }).pipe(Layer.provide(keymaxxerLayer), Layer.provide(platformLayer))
+
+        const status = yield* Effect.gen(function* () {
+          const gitlab = yield* GitLabService
+          return yield* gitlab.getPullRequestCheckStatus(
+            repository,
+            "rfa/project-oauth-client/42/wi-test",
+          )
+        }).pipe(Effect.provide(layer))
+
+        expect(status).toEqual({
+          _tag: "failed",
+          mergeability: "mergeable",
+          baseRefName: "1.0.x",
+          headPushedAt: new Date("2026-07-20T10:04:00.000Z"),
+          headSha: "deadbeef",
+          createdAt: new Date("2026-07-20T10:00:00.000Z"),
+          isDraft: true,
+          terminalChecks: [
             {
               externalId: "gitlab-job:2",
               name: "phpunit",
-              source: "gitlab-job",
-              htmlUrl:
-                "https://git.drupalcode.org/project/oauth_client/-/jobs/2",
-              logFetch: {
-                _tag: "ok",
-                excerpt: "FAIL: expected true\n",
-                localPath: null,
-              },
+              outcome: "red",
             },
-          ]),
-          stderr: "",
+          ],
         })
-      },
-    })
-    const layer = keymaxxerGitLabLayer({ workspaceRoot: "/workspace" }).pipe(
-      Layer.provide(keymaxxerLayer),
-      Layer.provide(platformLayer),
-    )
+        expect(runs[0]?.command).toContain("get-pr-check-status")
+        expect(runs[0]?.command).toContain('GITLAB_TOKEN="$')
+        expect(runs[0]?.secrets).toEqual(["GITLAB_TOKEN_PROJECT_OAUTH_CLIENT"])
+      }),
+  )
 
-    const diagnostics = await Effect.runPromise(
-      Effect.gen(function* () {
+  it.effect("loads PR Status Check diagnostics through the vault secret", () =>
+    Effect.gen(function* () {
+      const runs: RunWithSecretsInput[] = []
+      const keymaxxerLayer = Layer.succeed(KeymaxxerService, {
+        initialize: Effect.void,
+        findSecret: ({ account }) =>
+          Effect.succeed(
+            account === vaultAccount
+              ? "GITLAB_TOKEN_PROJECT_OAUTH_CLIENT"
+              : null,
+          ),
+        findSecrets: () => Effect.die("not used"),
+        hasSecret: () => Effect.die("not used"),
+        addSecret: () => Effect.die("not used"),
+        runWithSecrets: (input) => {
+          runs.push(input)
+          return Effect.succeed({
+            exitCode: 0,
+            stdout: JSON.stringify([
+              {
+                externalId: "gitlab-job:2",
+                name: "phpunit",
+                source: "gitlab-job",
+                htmlUrl:
+                  "https://git.drupalcode.org/project/oauth_client/-/jobs/2",
+                logFetch: {
+                  _tag: "ok",
+                  excerpt: "FAIL: expected true\n",
+                  localPath: null,
+                },
+              },
+            ]),
+            stderr: "",
+          })
+        },
+      })
+      const layer = keymaxxerGitLabLayer({ workspaceRoot: "/workspace" }).pipe(
+        Layer.provide(keymaxxerLayer),
+        Layer.provide(platformLayer),
+      )
+
+      const diagnostics = yield* Effect.gen(function* () {
         const gitlab = yield* GitLabService
         return yield* gitlab.getPrStatusCheckDiagnostics(
           repository,
           [{ externalId: "gitlab-job:2", name: "phpunit" }],
           { logDirectory: "/tmp/worktree/.ready-for-agent/status-check-logs" },
         )
-      }).pipe(Effect.provide(layer)),
-    )
+      }).pipe(Effect.provide(layer))
 
-    expect(diagnostics).toEqual([
-      {
-        externalId: "gitlab-job:2",
-        name: "phpunit",
-        source: "gitlab-job",
-        htmlUrl: "https://git.drupalcode.org/project/oauth_client/-/jobs/2",
-        logFetch: {
-          _tag: "ok",
-          excerpt: "FAIL: expected true\n",
-          localPath: null,
+      expect(diagnostics).toEqual([
+        {
+          externalId: "gitlab-job:2",
+          name: "phpunit",
+          source: "gitlab-job",
+          htmlUrl: "https://git.drupalcode.org/project/oauth_client/-/jobs/2",
+          logFetch: {
+            _tag: "ok",
+            excerpt: "FAIL: expected true\n",
+            localPath: null,
+          },
         },
-      },
-    ])
-    expect(runs[0]?.command).toContain("get-pr-status-check-diagnostics")
-    expect(runs[0]?.secrets).toEqual(["GITLAB_TOKEN_PROJECT_OAUTH_CLIENT"])
-  })
+      ])
+      expect(runs[0]?.command).toContain("get-pr-status-check-diagnostics")
+      expect(runs[0]?.secrets).toEqual(["GITLAB_TOKEN_PROJECT_OAUTH_CLIENT"])
+    }),
+  )
 
-  test("marks a merge request ready for review through the vault secret", async () => {
-    const runs: RunWithSecretsInput[] = []
-    const keymaxxerLayer = Layer.succeed(KeymaxxerService, {
-      initialize: Effect.void,
-      findSecret: ({ account }) =>
-        Effect.succeed(
-          account === vaultAccount ? "GITLAB_TOKEN_PROJECT_OAUTH_CLIENT" : null,
-        ),
-      findSecrets: () => Effect.die("not used"),
-      hasSecret: () => Effect.die("not used"),
-      addSecret: () => Effect.die("not used"),
-      runWithSecrets: (input) => {
-        runs.push(input)
-        return Effect.succeed({
-          exitCode: 0,
-          stdout: JSON.stringify({ _tag: "ready" }),
-          stderr: "",
-        })
-      },
-    })
-    const layer = keymaxxerGitLabLayer({ workspaceRoot: "/workspace" }).pipe(
-      Layer.provide(keymaxxerLayer),
-      Layer.provide(platformLayer),
-    )
-
-    await Effect.runPromise(
+  it.effect(
+    "marks a merge request ready for review through the vault secret",
+    () =>
       Effect.gen(function* () {
-        const gitlab = yield* GitLabService
-        yield* gitlab.markPullRequestReadyForReview(
-          repository,
-          "rfa/project-oauth-client/42/wi-test",
-        )
-      }).pipe(Effect.provide(layer)),
-    )
-
-    expect(runs[0]?.command).toContain("mark-pr-ready-for-review")
-    expect(runs[0]?.command).toContain('GITLAB_TOKEN="$')
-    expect(runs[0]?.secrets).toEqual(["GITLAB_TOKEN_PROJECT_OAUTH_CLIENT"])
-  })
-
-  test("merges a merge request through the vault secret", async () => {
-    const runs: RunWithSecretsInput[] = []
-    const keymaxxerLayer = Layer.succeed(KeymaxxerService, {
-      initialize: Effect.void,
-      findSecret: ({ account }) =>
-        Effect.succeed(
-          account === vaultAccount ? "GITLAB_TOKEN_PROJECT_OAUTH_CLIENT" : null,
-        ),
-      findSecrets: () => Effect.die("not used"),
-      hasSecret: () => Effect.die("not used"),
-      addSecret: () => Effect.die("not used"),
-      runWithSecrets: (input) => {
-        runs.push(input)
-        return Effect.succeed({
-          exitCode: 0,
-          stdout: JSON.stringify({ _tag: "merged" }),
-          stderr: "",
+        const runs: RunWithSecretsInput[] = []
+        const keymaxxerLayer = Layer.succeed(KeymaxxerService, {
+          initialize: Effect.void,
+          findSecret: ({ account }) =>
+            Effect.succeed(
+              account === vaultAccount
+                ? "GITLAB_TOKEN_PROJECT_OAUTH_CLIENT"
+                : null,
+            ),
+          findSecrets: () => Effect.die("not used"),
+          hasSecret: () => Effect.die("not used"),
+          addSecret: () => Effect.die("not used"),
+          runWithSecrets: (input) => {
+            runs.push(input)
+            return Effect.succeed({
+              exitCode: 0,
+              stdout: JSON.stringify({ _tag: "ready" }),
+              stderr: "",
+            })
+          },
         })
-      },
-    })
-    const layer = keymaxxerGitLabLayer({ workspaceRoot: "/workspace" }).pipe(
-      Layer.provide(keymaxxerLayer),
-      Layer.provide(platformLayer),
-    )
+        const layer = keymaxxerGitLabLayer({
+          workspaceRoot: "/workspace",
+        }).pipe(Layer.provide(keymaxxerLayer), Layer.provide(platformLayer))
 
-    const result = await Effect.runPromise(
-      Effect.gen(function* () {
+        yield* Effect.gen(function* () {
+          const gitlab = yield* GitLabService
+          yield* gitlab.markPullRequestReadyForReview(
+            repository,
+            "rfa/project-oauth-client/42/wi-test",
+          )
+        }).pipe(Effect.provide(layer))
+
+        expect(runs[0]?.command).toContain("mark-pr-ready-for-review")
+        expect(runs[0]?.command).toContain('GITLAB_TOKEN="$')
+        expect(runs[0]?.secrets).toEqual(["GITLAB_TOKEN_PROJECT_OAUTH_CLIENT"])
+      }),
+  )
+
+  it.effect("merges a merge request through the vault secret", () =>
+    Effect.gen(function* () {
+      const runs: RunWithSecretsInput[] = []
+      const keymaxxerLayer = Layer.succeed(KeymaxxerService, {
+        initialize: Effect.void,
+        findSecret: ({ account }) =>
+          Effect.succeed(
+            account === vaultAccount
+              ? "GITLAB_TOKEN_PROJECT_OAUTH_CLIENT"
+              : null,
+          ),
+        findSecrets: () => Effect.die("not used"),
+        hasSecret: () => Effect.die("not used"),
+        addSecret: () => Effect.die("not used"),
+        runWithSecrets: (input) => {
+          runs.push(input)
+          return Effect.succeed({
+            exitCode: 0,
+            stdout: JSON.stringify({ _tag: "merged" }),
+            stderr: "",
+          })
+        },
+      })
+      const layer = keymaxxerGitLabLayer({ workspaceRoot: "/workspace" }).pipe(
+        Layer.provide(keymaxxerLayer),
+        Layer.provide(platformLayer),
+      )
+
+      const result = yield* Effect.gen(function* () {
         const gitlab = yield* GitLabService
         return yield* gitlab.mergePullRequest(
           repository,
           "rfa/project-oauth-client/42/wi-test",
         )
-      }).pipe(Effect.provide(layer)),
-    )
+      }).pipe(Effect.provide(layer))
 
-    expect(result).toEqual({ _tag: "merged" })
-    expect(runs[0]?.command).toContain("merge-pull-request")
-    expect(runs[0]?.command).toContain('GITLAB_TOKEN="$')
-    expect(runs[0]?.secrets).toEqual(["GITLAB_TOKEN_PROJECT_OAUTH_CLIENT"])
-  })
+      expect(result).toEqual({ _tag: "merged" })
+      expect(runs[0]?.command).toContain("merge-pull-request")
+      expect(runs[0]?.command).toContain('GITLAB_TOKEN="$')
+      expect(runs[0]?.secrets).toEqual(["GITLAB_TOKEN_PROJECT_OAUTH_CLIENT"])
+    }),
+  )
 
-  test("loads merge request lifecycle status through the vault secret", async () => {
-    const runs: RunWithSecretsInput[] = []
-    const keymaxxerLayer = Layer.succeed(KeymaxxerService, {
-      initialize: Effect.void,
-      findSecret: ({ account }) =>
-        Effect.succeed(
-          account === vaultAccount ? "GITLAB_TOKEN_PROJECT_OAUTH_CLIENT" : null,
-        ),
-      findSecrets: () => Effect.die("not used"),
-      hasSecret: () => Effect.die("not used"),
-      addSecret: () => Effect.die("not used"),
-      runWithSecrets: (input) => {
-        runs.push(input)
-        return Effect.succeed({
-          exitCode: 0,
-          stdout: JSON.stringify({ _tag: "open" }),
-          stderr: "",
-        })
-      },
-    })
-    const layer = keymaxxerGitLabLayer({ workspaceRoot: "/workspace" }).pipe(
-      Layer.provide(keymaxxerLayer),
-      Layer.provide(platformLayer),
-    )
-
-    const status = await Effect.runPromise(
+  it.effect(
+    "loads merge request lifecycle status through the vault secret",
+    () =>
       Effect.gen(function* () {
-        const gitlab = yield* GitLabService
-        return yield* gitlab.getPullRequestLifecycleStatus(
-          repository,
-          "rfa/project-oauth-client/42/wi-test",
-        )
-      }).pipe(Effect.provide(layer)),
-    )
+        const runs: RunWithSecretsInput[] = []
+        const keymaxxerLayer = Layer.succeed(KeymaxxerService, {
+          initialize: Effect.void,
+          findSecret: ({ account }) =>
+            Effect.succeed(
+              account === vaultAccount
+                ? "GITLAB_TOKEN_PROJECT_OAUTH_CLIENT"
+                : null,
+            ),
+          findSecrets: () => Effect.die("not used"),
+          hasSecret: () => Effect.die("not used"),
+          addSecret: () => Effect.die("not used"),
+          runWithSecrets: (input) => {
+            runs.push(input)
+            return Effect.succeed({
+              exitCode: 0,
+              stdout: JSON.stringify({ _tag: "open" }),
+              stderr: "",
+            })
+          },
+        })
+        const layer = keymaxxerGitLabLayer({
+          workspaceRoot: "/workspace",
+        }).pipe(Layer.provide(keymaxxerLayer), Layer.provide(platformLayer))
 
-    expect(status).toEqual({ _tag: "open" })
-    expect(runs[0]?.command).toContain("get-pr-lifecycle-status")
-    expect(runs[0]?.secrets).toEqual(["GITLAB_TOKEN_PROJECT_OAUTH_CLIENT"])
-  })
+        const status = yield* Effect.gen(function* () {
+          const gitlab = yield* GitLabService
+          return yield* gitlab.getPullRequestLifecycleStatus(
+            repository,
+            "rfa/project-oauth-client/42/wi-test",
+          )
+        }).pipe(Effect.provide(layer))
+
+        expect(status).toEqual({ _tag: "open" })
+        expect(runs[0]?.command).toContain("get-pr-lifecycle-status")
+        expect(runs[0]?.secrets).toEqual(["GITLAB_TOKEN_PROJECT_OAUTH_CLIENT"])
+      }),
+  )
 })

--- a/apps/harness/test/production-sse-idle-timeout.test.ts
+++ b/apps/harness/test/production-sse-idle-timeout.test.ts
@@ -1,4 +1,5 @@
 import { createServer } from "node:net"
+import { afterEach, describe, expect, it } from "@effect/vitest"
 import { Duration, Effect, Layer, ManagedRuntime, PubSub, Stream } from "effect"
 import {
   ActiveAgentBackend,
@@ -38,7 +39,6 @@ import {
   PRODUCTION_HTTP_IDLE_TIMEOUT_SECONDS,
   startProductionLifecycle,
 } from "../src/server/production-lifecycle.ts"
-import { afterEach, describe, expect, test } from "bun:test"
 
 /**
  * GraphQL Yoga production SSE ping interval (seconds). Source of truth is
@@ -246,7 +246,7 @@ describe("production GraphQL SSE idle timeout", () => {
     }
   })
 
-  test("declares an idle timeout longer than Yoga's production heartbeat", () => {
+  it("declares an idle timeout longer than Yoga's production heartbeat", () => {
     // Guards the production constant against accidental regression below the
     // Yoga interval documented in YOGA_SSE_HEARTBEAT_INTERVAL_SECONDS.
     expect(PRODUCTION_HTTP_IDLE_TIMEOUT_SECONDS).toBeGreaterThanOrEqual(30)
@@ -257,7 +257,7 @@ describe("production GraphQL SSE idle timeout", () => {
     expect(YOGA_SSE_HEARTBEAT_INTERVAL_SECONDS).toBeGreaterThan(10)
   })
 
-  test("keeps quiet Repository, Issue, and Work Item subscriptions alive across heartbeats", async () => {
+  it("keeps quiet Repository, Issue, and Work Item subscriptions alive across heartbeats", async () => {
     // Yoga shortens SSE pings under NODE_ENV=test (300ms). Force production
     // cadence so this exercises the real 12s heartbeat vs Bun idle timeout.
     // Restore in an outer finally so setup failures cannot leave NODE_ENV set.

--- a/apps/harness/vitest.config.ts
+++ b/apps/harness/vitest.config.ts
@@ -1,0 +1,84 @@
+import { readFileSync, readdirSync } from "node:fs"
+import { dirname, join, resolve } from "node:path"
+import { fileURLToPath } from "node:url"
+import { type AliasOptions, defineConfig } from "vitest/config"
+
+const harnessRoot = dirname(fileURLToPath(import.meta.url))
+const workspaceRoot = resolve(harnessRoot, "../..")
+
+type PackageExports = Record<
+  string,
+  string | { "@ready-for-agent/source"?: string }
+>
+
+/**
+ * Map each workspace package export that exposes `@ready-for-agent/source` to
+ * its TypeScript entry so Vitest does not need built `dist/`. Mirrors the
+ * export condition Bun/Nx use for monorepo source runs.
+ *
+ * Uses exact-match regex aliases so `@scope/name/test` is not resolved as
+ * `@scope/name` + `/test` on the file path.
+ */
+const workspacePackageAlias = (): AliasOptions => {
+  const entries: Array<{ find: RegExp; replacement: string }> = []
+  for (const group of ["packages", "apps"] as const) {
+    const groupDir = join(workspaceRoot, group)
+    for (const entry of readdirSync(groupDir, { withFileTypes: true })) {
+      if (!entry.isDirectory()) continue
+      const packageDir = join(groupDir, entry.name)
+      const packageJsonPath = join(packageDir, "package.json")
+      try {
+        const pkg = JSON.parse(readFileSync(packageJsonPath, "utf8")) as {
+          name?: string
+          exports?: PackageExports
+        }
+        if (pkg.name === undefined || pkg.exports === undefined) continue
+        for (const [exportPath, target] of Object.entries(pkg.exports)) {
+          if (typeof target === "string" || target === undefined) continue
+          const source = target["@ready-for-agent/source"]
+          if (source === undefined) continue
+          const aliasKey =
+            exportPath === "."
+              ? pkg.name
+              : `${pkg.name}/${exportPath.replace(/^\.\//, "")}`
+          entries.push({
+            find: new RegExp(
+              `^${aliasKey.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}$`,
+            ),
+            replacement: join(packageDir, source),
+          })
+        }
+      } catch {
+        // skip packages without a resolvable package.json
+      }
+    }
+  }
+  // Longer import ids first so nested export paths win over package roots.
+  entries.sort((a, b) => b.find.source.length - a.find.source.length)
+  return entries
+}
+
+/**
+ * Effect-first unit suites that import from `@effect/vitest`.
+ * Remaining Harness tests still run under `bun test` (see scripts/run-unit-tests.sh).
+ */
+export default defineConfig({
+  resolve: {
+    alias: workspacePackageAlias(),
+    conditions: ["@ready-for-agent/source", "import", "module", "default"],
+  },
+  test: {
+    include: [
+      "test/job-worker.test.ts",
+      "test/keymaxxer-github-layer.test.ts",
+      "test/keymaxxer-gitlab-layer.test.ts",
+      "test/ambient-github-layer.test.ts",
+      "test/ambient-gitlab-layer.test.ts",
+      "test/application-config.test.ts",
+      "test/application-runtime-disposal.test.ts",
+      "test/production-sse-idle-timeout.test.ts",
+    ],
+    // production-sse-idle-timeout is intentionally long; run via vitest when included.
+    testTimeout: 30_000,
+  },
+})

--- a/apps/ready-for-agent/package.json
+++ b/apps/ready-for-agent/package.json
@@ -41,8 +41,10 @@
     "effect": "^4.0.0-beta.97"
   },
   "devDependencies": {
+    "@effect/vitest": "4.0.0-beta.97",
     "@ready-for-agent/release-versioning": "workspace:*",
-    "@types/bun": "^1.3.0"
+    "@types/bun": "^1.3.0",
+    "vitest": "^4.1.10"
   },
   "engines": {
     "node": ">=20"

--- a/apps/ready-for-agent/project.json
+++ b/apps/ready-for-agent/project.json
@@ -99,7 +99,7 @@
       "executor": "nx:run-commands",
       "options": {
         "cwd": "{projectRoot}",
-        "command": "bun --conditions=@ready-for-agent/source test --timeout=15000"
+        "command": "bash scripts/run-unit-tests.sh"
       },
       "inputs": ["default", "^production"],
       "cache": true,

--- a/apps/ready-for-agent/scripts/run-unit-tests.sh
+++ b/apps/ready-for-agent/scripts/run-unit-tests.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Bun for non-Effect suites; Vitest (+ @effect/vitest) for Effect suites.
+set -uo pipefail
+
+conditions="@ready-for-agent/source"
+effect_ignore=(
+  "**/cli.test.ts"
+  "**/services/application-config.test.ts"
+)
+
+ignore_args=()
+for pattern in "${effect_ignore[@]}"; do
+  ignore_args+=(--path-ignore-patterns="$pattern")
+done
+
+set +e
+# Match the 15s default used for ready-for-agent Bun suites on main (host-binary
+# smoke can exceed the Bun default under load).
+bun --conditions="$conditions" test --timeout=15000 "${ignore_args[@]}"
+code=$?
+set -e
+
+if [[ "$code" -ne 0 ]]; then
+  exit "$code"
+fi
+
+bun --bun ./node_modules/vitest/vitest.mjs run --config vitest.config.ts
+exit $?

--- a/apps/ready-for-agent/src/cli.test.ts
+++ b/apps/ready-for-agent/src/cli.test.ts
@@ -2,7 +2,9 @@ import { spawnSync } from "node:child_process"
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
+import { fileURLToPath } from "node:url"
 import { BunServices } from "@effect/platform-bun"
+import { afterEach, beforeEach, describe, expect, it } from "@effect/vitest"
 import { Effect, Layer } from "effect"
 import { Command } from "effect/unstable/cli"
 import { cli } from "./cli.ts"
@@ -10,7 +12,9 @@ import { HARNESS_START_HINT } from "./graphql-error.ts"
 import { GraphqlApi, GraphqlRequestFailed } from "./services/graphql-api.ts"
 import { LocalGit } from "./services/local-git.ts"
 import { StartHarness } from "./services/start-harness.ts"
-import { afterEach, beforeEach, describe, expect, test } from "bun:test"
+
+/** Package root (`apps/ready-for-agent`), independent of Bun's `import.meta.dir`. */
+const packageRoot = fileURLToPath(new URL("..", import.meta.url))
 
 const runOperator = (
   args: ReadonlyArray<string>,
@@ -53,84 +57,88 @@ describe("operator binary CLI seam", () => {
       }),
   })
 
-  test("default and start invoke the harness start seam", async () => {
-    const layer = mockStart.pipe(
-      Layer.provideMerge(mockLocalGit),
-      Layer.provideMerge(
-        Layer.succeed(GraphqlApi, {
-          addRepository: () => Effect.die("graphql should not run for start"),
-        }),
-      ),
-    )
+  it.live("default and start invoke the harness start seam", () =>
+    Effect.gen(function* () {
+      const layer = mockStart.pipe(
+        Layer.provideMerge(mockLocalGit),
+        Layer.provideMerge(
+          Layer.succeed(GraphqlApi, {
+            addRepository: () => Effect.die("graphql should not run for start"),
+          }),
+        ),
+      )
 
-    await Effect.runPromise(runOperator([], layer))
-    expect(started).toBe(1)
+      yield* runOperator([], layer)
+      expect(started).toBe(1)
 
-    await Effect.runPromise(runOperator(["start"], layer))
-    expect(started).toBe(2)
-  })
+      yield* runOperator(["start"], layer)
+      expect(started).toBe(2)
+    }),
+  )
 
-  test("add reports GraphQL start-hint failures from the service", async () => {
-    const layer = mockStart.pipe(
-      Layer.provideMerge(mockLocalGit),
-      Layer.provideMerge(
-        Layer.succeed(GraphqlApi, {
-          addRepository: () =>
-            Effect.fail(
-              new GraphqlRequestFailed({
-                message: `Unable to connect\n\n${HARNESS_START_HINT}`,
+  it.live("add reports GraphQL start-hint failures from the service", () =>
+    Effect.gen(function* () {
+      const layer = mockStart.pipe(
+        Layer.provideMerge(mockLocalGit),
+        Layer.provideMerge(
+          Layer.succeed(GraphqlApi, {
+            addRepository: () =>
+              Effect.fail(
+                new GraphqlRequestFailed({
+                  message: `Unable to connect\n\n${HARNESS_START_HINT}`,
+                }),
+              ),
+          }),
+        ),
+      )
+
+      const result = yield* runOperator(["add", "/tmp/repo"], layer).pipe(
+        Effect.flip,
+      )
+
+      expect(result._tag).toBe("GraphqlRequestFailed")
+      if (result._tag === "GraphqlRequestFailed") {
+        expect(result.message).toContain(HARNESS_START_HINT)
+      }
+    }),
+  )
+
+  it.live("add lets the operator correct a guessed GitLab identity", () =>
+    Effect.gen(function* () {
+      let added:
+        | {
+            readonly forgeHost: string
+            readonly projectPath: string
+          }
+        | undefined
+      const gitlabLocalGit = Layer.succeed(LocalGit, {
+        inspect: (path) =>
+          Effect.succeed({
+            forge: "gitlab" as const,
+            forgeHost: "git.drupal.org",
+            projectPath: "project/oauth_client",
+            localPath: path,
+            isBare: false,
+            paused: true as const,
+          }),
+      })
+      const layer = mockStart.pipe(
+        Layer.provideMerge(gitlabLocalGit),
+        Layer.provideMerge(
+          Layer.succeed(GraphqlApi, {
+            addRepository: (repository) =>
+              Effect.sync(() => {
+                added = repository
+                return {
+                  id: "repo-1",
+                  ...repository,
+                }
               }),
-            ),
-        }),
-      ),
-    )
+          }),
+        ),
+      )
 
-    const result = await Effect.runPromise(
-      runOperator(["add", "/tmp/repo"], layer).pipe(Effect.flip),
-    )
-
-    expect(result._tag).toBe("GraphqlRequestFailed")
-    if (result._tag === "GraphqlRequestFailed") {
-      expect(result.message).toContain(HARNESS_START_HINT)
-    }
-  })
-
-  test("add lets the operator correct a guessed GitLab identity", async () => {
-    let added:
-      | {
-          readonly forgeHost: string
-          readonly projectPath: string
-        }
-      | undefined
-    const gitlabLocalGit = Layer.succeed(LocalGit, {
-      inspect: (path) =>
-        Effect.succeed({
-          forge: "gitlab" as const,
-          forgeHost: "git.drupal.org",
-          projectPath: "project/oauth_client",
-          localPath: path,
-          isBare: false,
-          paused: true as const,
-        }),
-    })
-    const layer = mockStart.pipe(
-      Layer.provideMerge(gitlabLocalGit),
-      Layer.provideMerge(
-        Layer.succeed(GraphqlApi, {
-          addRepository: (repository) =>
-            Effect.sync(() => {
-              added = repository
-              return {
-                id: "repo-1",
-                ...repository,
-              }
-            }),
-        }),
-      ),
-    )
-
-    await Effect.runPromise(
-      runOperator(
+      yield* runOperator(
         [
           "add",
           "--forge-host",
@@ -140,21 +148,21 @@ describe("operator binary CLI seam", () => {
           "/tmp/repo",
         ],
         layer,
-      ),
-    )
+      )
 
-    expect(added).toMatchObject({
-      forgeHost: "git.drupalcode.org",
-      projectPath: "project/oauth_client",
-    })
-  })
+      expect(added).toMatchObject({
+        forgeHost: "git.drupalcode.org",
+        projectPath: "project/oauth_client",
+      })
+    }),
+  )
 
-  test("binary help lists start, add, and --no-open", () => {
+  it("binary help lists start, add, and --no-open", () => {
     const result = spawnSync(
       "bun",
       ["--conditions", "@ready-for-agent/source", "src/main.ts", "--help"],
       {
-        cwd: join(import.meta.dir, ".."),
+        cwd: packageRoot,
         encoding: "utf8",
       },
     )
@@ -167,24 +175,29 @@ describe("operator binary CLI seam", () => {
     expect(output).toContain("no-open")
   })
 
-  test("default and start accept --no-open without starting GraphQL commands", async () => {
-    const layer = mockStart.pipe(
-      Layer.provideMerge(mockLocalGit),
-      Layer.provideMerge(
-        Layer.succeed(GraphqlApi, {
-          addRepository: () => Effect.die("graphql should not run for start"),
-        }),
-      ),
-    )
+  it.live(
+    "default and start accept --no-open without starting GraphQL commands",
+    () =>
+      Effect.gen(function* () {
+        const layer = mockStart.pipe(
+          Layer.provideMerge(mockLocalGit),
+          Layer.provideMerge(
+            Layer.succeed(GraphqlApi, {
+              addRepository: () =>
+                Effect.die("graphql should not run for start"),
+            }),
+          ),
+        )
 
-    await Effect.runPromise(runOperator(["--no-open"], layer))
-    expect(started).toBe(1)
+        yield* runOperator(["--no-open"], layer)
+        expect(started).toBe(1)
 
-    await Effect.runPromise(runOperator(["start", "--no-open"], layer))
-    expect(started).toBe(2)
-  })
+        yield* runOperator(["start", "--no-open"], layer)
+        expect(started).toBe(2)
+      }),
+  )
 
-  test("binary add against unreachable GraphQL prints start hint", () => {
+  it("binary add against unreachable GraphQL prints start hint", () => {
     const repoDir = join(tempRoot, "repo")
     mkdirSync(repoDir)
     writeFileSync(join(repoDir, "README.md"), "fixture\n")
@@ -205,7 +218,7 @@ describe("operator binary CLI seam", () => {
         repoDir,
       ],
       {
-        cwd: join(import.meta.dir, ".."),
+        cwd: packageRoot,
         encoding: "utf8",
         env: {
           ...process.env,

--- a/apps/ready-for-agent/src/services/application-config.test.ts
+++ b/apps/ready-for-agent/src/services/application-config.test.ts
@@ -1,53 +1,58 @@
+import { describe, expect, it } from "@effect/vitest"
 import { ConfigProvider, Effect } from "effect"
 import { resolveDefaultDatabasePath } from "../product-data-dir.ts"
 import { ApplicationConfig } from "./application-config.ts"
-import { describe, expect, test } from "bun:test"
 
-const loadConfig = (values: Record<string, string>) =>
+const withConfig = (values: Record<string, string>) =>
   Effect.gen(function* () {
     return yield* ApplicationConfig
   }).pipe(
     Effect.provide(ApplicationConfig.layer),
     Effect.provide(ConfigProvider.layer(ConfigProvider.fromUnknown(values))),
-    Effect.runPromise,
   )
 
 describe("ApplicationConfig", () => {
-  test("loads GraphQL, database, and browser environment through Config", async () => {
-    const config = await loadConfig({
-      READY_FOR_AGENT_GRAPHQL_URL: "https://example.test/graphql",
-      HOME: "/home/operator",
-      XDG_DATA_HOME: "/var/operator-data",
-      SQLITE_DATABASE_PATH: "/custom/product.db",
-      NO_BROWSER: "true",
-      PORT: "4300",
-    })
-
-    expect(config.graphqlUrl).toBe("https://example.test/graphql")
-    expect(config.databasePath).toBe("/custom/product.db")
-    expect(config.browserEnv).toEqual({ NO_BROWSER: "true", PORT: "4300" })
-  })
-
-  test("preserves defaults and blank database override semantics", async () => {
-    const config = await loadConfig({
-      HOME: "/home/operator",
-      SQLITE_DATABASE_PATH: "  ",
-    })
-
-    expect(config.graphqlUrl).toBe("http://127.0.0.1:6056/graphql")
-    // Match the pure product-path resolver for this host platform (linux /
-    // darwin / win32). Platform-specific shapes are covered in
-    // product-data-dir.test.ts; this asserts Config wiring only.
-    expect(config.databasePath).toBe(
-      resolveDefaultDatabasePath({
-        env: {
+  it.effect(
+    "loads GraphQL, database, and browser environment through Config",
+    () =>
+      Effect.gen(function* () {
+        const config = yield* withConfig({
+          READY_FOR_AGENT_GRAPHQL_URL: "https://example.test/graphql",
           HOME: "/home/operator",
-          SQLITE_DATABASE_PATH: "  ",
-        },
-        platform: config.platform,
-        home: "/home/operator",
+          XDG_DATA_HOME: "/var/operator-data",
+          SQLITE_DATABASE_PATH: "/custom/product.db",
+          NO_BROWSER: "true",
+          PORT: "4300",
+        })
+
+        expect(config.graphqlUrl).toBe("https://example.test/graphql")
+        expect(config.databasePath).toBe("/custom/product.db")
+        expect(config.browserEnv).toEqual({ NO_BROWSER: "true", PORT: "4300" })
       }),
-    )
-    expect(config.browserEnv.NO_BROWSER).toBeUndefined()
-  })
+  )
+
+  it.effect("preserves defaults and blank database override semantics", () =>
+    Effect.gen(function* () {
+      const config = yield* withConfig({
+        HOME: "/home/operator",
+        SQLITE_DATABASE_PATH: "  ",
+      })
+
+      expect(config.graphqlUrl).toBe("http://127.0.0.1:6056/graphql")
+      // Match the pure product-path resolver for this host platform (linux /
+      // darwin / win32). Platform-specific shapes are covered in
+      // product-data-dir.test.ts; this asserts Config wiring only.
+      expect(config.databasePath).toBe(
+        resolveDefaultDatabasePath({
+          env: {
+            HOME: "/home/operator",
+            SQLITE_DATABASE_PATH: "  ",
+          },
+          platform: config.platform,
+          home: "/home/operator",
+        }),
+      )
+      expect(config.browserEnv.NO_BROWSER).toBeUndefined()
+    }),
+  )
 })

--- a/apps/ready-for-agent/test/stubs/client-assets.ts
+++ b/apps/ready-for-agent/test/stubs/client-assets.ts
@@ -1,0 +1,6 @@
+/**
+ * Vitest stub for generated embed assets so Effect unit suites do not load
+ * harness `dist/client` HTML/JS as modules (generate-embed output).
+ */
+export const embeddedClientAssets: Readonly<Record<string, string>> = {}
+export const embeddedShellHtmlPath = "index.html"

--- a/apps/ready-for-agent/vitest.config.ts
+++ b/apps/ready-for-agent/vitest.config.ts
@@ -1,0 +1,82 @@
+import { readFileSync, readdirSync } from "node:fs"
+import { dirname, join, resolve } from "node:path"
+import { fileURLToPath } from "node:url"
+import { type AliasOptions, defineConfig } from "vitest/config"
+
+const appRoot = dirname(fileURLToPath(import.meta.url))
+const workspaceRoot = resolve(appRoot, "../..")
+
+type PackageExports = Record<
+  string,
+  string | { "@ready-for-agent/source"?: string }
+>
+
+const workspacePackageAlias = (): AliasOptions => {
+  const entries: Array<{ find: RegExp; replacement: string }> = []
+  for (const group of ["packages", "apps"] as const) {
+    const groupDir = join(workspaceRoot, group)
+    for (const entry of readdirSync(groupDir, { withFileTypes: true })) {
+      if (!entry.isDirectory()) continue
+      const packageDir = join(groupDir, entry.name)
+      try {
+        const pkg = JSON.parse(
+          readFileSync(join(packageDir, "package.json"), "utf8"),
+        ) as { name?: string; exports?: PackageExports }
+        if (pkg.name === undefined || pkg.exports === undefined) continue
+        for (const [exportPath, target] of Object.entries(pkg.exports)) {
+          if (typeof target === "string" || target === undefined) continue
+          const source = target["@ready-for-agent/source"]
+          if (source === undefined) continue
+          const aliasKey =
+            exportPath === "."
+              ? pkg.name
+              : `${pkg.name}/${exportPath.replace(/^\.\//, "")}`
+          entries.push({
+            find: new RegExp(
+              `^${aliasKey.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}$`,
+            ),
+            replacement: join(packageDir, source),
+          })
+        }
+      } catch {
+        // skip
+      }
+    }
+  }
+  entries.sort((a, b) => b.find.source.length - a.find.source.length)
+  return entries
+}
+
+const clientAssetsStub = join(appRoot, "test/stubs/client-assets.ts")
+
+/**
+ * Effect suites under this package use `@effect/vitest`. Pure non-Effect tests
+ * remain on `bun test` via the project test target.
+ */
+export default defineConfig({
+  plugins: [
+    {
+      name: "stub-embedded-client-assets",
+      enforce: "pre",
+      // generate-embed writes Bun `with { type: "file" }` imports of harness HTML;
+      // Vitest must not parse those as modules. Match relative and absolute ids.
+      resolveId(source) {
+        const normalized = source.replaceAll("\\", "/")
+        if (
+          normalized.endsWith("generated/client-assets.ts") ||
+          normalized.endsWith("generated/client-assets")
+        ) {
+          return clientAssetsStub
+        }
+        return undefined
+      },
+    },
+  ],
+  resolve: {
+    alias: workspacePackageAlias(),
+    conditions: ["@ready-for-agent/source", "import", "module", "default"],
+  },
+  test: {
+    include: ["src/cli.test.ts", "src/services/application-config.test.ts"],
+  },
+})

--- a/bun.lock
+++ b/bun.lock
@@ -58,6 +58,7 @@
         "react-dom": "^19.2.8",
       },
       "devDependencies": {
+        "@effect/vitest": "4.0.0-beta.97",
         "@playwright/test": "^1.61.1",
         "@tailwindcss/vite": "^4.3.3",
         "@types/bun": "^1.3.0",
@@ -67,6 +68,7 @@
         "playwright-bdd": "^9.2.0",
         "tailwindcss": "^4.3.3",
         "vite": "^8.1.5",
+        "vitest": "^4.1.10",
       },
     },
     "apps/keymaxxer-sidecar": {
@@ -96,8 +98,10 @@
         "effect": "^4.0.0-beta.97",
       },
       "devDependencies": {
+        "@effect/vitest": "4.0.0-beta.97",
         "@ready-for-agent/release-versioning": "workspace:*",
         "@types/bun": "^1.3.0",
+        "vitest": "^4.1.10",
       },
       "optionalDependencies": {
         "ready-for-agent-darwin-arm64": "0.0.0",


### PR DESCRIPTION
Why

Effect unit tests were bridged with repeated Effect.runPromise, hand-built
runtimes, and real wall-clock sleeps. That loses interruption and failure
reporting from @effect/vitest, blocks TestClock for time-dependent paths,
and makes scoped cleanup easy to get wrong.

What

- Add @effect/vitest + Vitest (matching effect@^4.0.0-beta.97) to harness
  and ready-for-agent
- Dual-run unit suites: Bun for non-Effect tests; Vitest under bun --bun
  for Effect suites (so bun:* still works)
- Migrate priority Effect suites to it.effect / it.live with per-test
  Effect.provide layers:
  - harness: job-worker, keymaxxer GitHub/GitLab layers, ambient layers,
    application config, runtime disposal, production SSE idle-timeout
    (slow-test)
  - ready-for-agent: CLI and application-config Effect tests
- Prefer it.live for real-time worker/poll/hang-budget tests; it.effect
  for pure Effect paths
- Fix cleanup regressions from JS try/finally + yield* using
  Effect.acquireRelease / Effect.ensuring
- Stub generate-embed client-assets under ready-for-agent Vitest so HTML
  file imports are not parsed as modules

Verification

- nx run harness:test (Bun + Effect Vitest gate, SSE excluded by default)
- Vitest: job-worker, keymaxxer layers, disposal, ready-for-agent suites
- harness typecheck after runScoped / cleanup fixes
- Pre-commit affected lint, typecheck, test passed after remediation

Limitations

- Dual bun-ignore / vitest-include lists are still manual (drift risk if a
  suite is migrated only on one side)
- Open-PR count freshness still uses injectable nowMs; full TestClock for
  that cache pairs with the effect/Cache migration
- Production SSE suite remains on the slow-test target, not the default
  harness gate

Closes #716