### PR TITLE
refactor(harness): replace hand-rolled single-flight caches with Effect Cache

### DIFF
--- a/apps/harness/src/server/ambient-github-layer.ts
+++ b/apps/harness/src/server/ambient-github-layer.ts
@@ -1,4 +1,4 @@
-import { Deferred, Duration, Effect, Layer, Ref } from "effect"
+import { Cache, Duration, Effect, Exit, Fiber, Layer } from "effect"
 import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process"
 import {
   type GitHubRepositoryUnavailableError,
@@ -9,6 +9,9 @@ import {
 } from "@ready-for-agent/github-service"
 
 type GitHubServiceError = GitHubRepositoryUnavailableError | GitHubRequestError
+
+/** Unit key for the process-wide ambient GitHub CLI token cache. */
+const TOKEN_CACHE_KEY = true as const
 
 const authenticationError = (cause: unknown) =>
   new GitHubRequestError({
@@ -31,9 +34,6 @@ export const ambientGitHubLayer = (options: {
       const spawner = yield* ChildProcessSpawner.ChildProcessSpawner
       const layerScope = yield* Effect.scope
       const makeService = options.makeService ?? makeGitHubServiceFromToken
-      const tokenCache = yield* Ref.make<
-        Deferred.Deferred<string, GitHubRequestError> | undefined
-      >(undefined)
 
       const resolveGhToken = Effect.fn("AmbientGitHub.resolveGhToken")(
         function* () {
@@ -68,45 +68,27 @@ export const ambientGitHubLayer = (options: {
               })
             })
 
+      // Single-flight success cache: concurrent callers share one lookup;
+      // failures expire immediately (TTL zero, not reused); success lives until
+      // 401 invalidate. Cache.get is forked into the layer scope so canceling one
+      // requester cannot abort a shared in-flight lookup for joiners. Nested
+      // consumers must build this layer with Layer.buildWithScope (not a
+      // short-lived Effect.provide) so that scope stays open.
+      const tokenCache = yield* Cache.makeWith(
+        (_key: typeof TOKEN_CACHE_KEY) => resolveToken(),
+        {
+          capacity: 1,
+          timeToLive: (exit) =>
+            Exit.isSuccess(exit) ? Duration.infinity : Duration.zero,
+        },
+      )
+
       const acquireToken = Effect.fn("AmbientGitHub.acquireToken")(
         function* () {
-          const candidate = yield* Deferred.make<string, GitHubRequestError>()
-          type SelectedToken = {
-            readonly source: Deferred.Deferred<string, GitHubRequestError>
-            readonly owner: boolean
-          }
-          const selected = yield* Ref.modify<
-            Deferred.Deferred<string, GitHubRequestError> | undefined,
-            SelectedToken
-          >(tokenCache, (current) =>
-            current === undefined
-              ? [{ source: candidate, owner: true }, candidate]
-              : [{ source: current, owner: false }, current],
+          const fiber = yield* Cache.get(tokenCache, TOKEN_CACHE_KEY).pipe(
+            Effect.forkIn(layerScope),
           )
-
-          if (selected.owner) {
-            yield* resolveToken().pipe(
-              Effect.result,
-              Effect.flatMap((result) =>
-                (result._tag === "Failure"
-                  ? Ref.update(tokenCache, (current) =>
-                      current === candidate ? undefined : current,
-                    )
-                  : Effect.void
-                ).pipe(
-                  Effect.andThen(
-                    Deferred.complete(candidate, Effect.fromResult(result)),
-                  ),
-                ),
-              ),
-              Effect.forkIn(layerScope, { startImmediately: true }),
-            )
-          }
-
-          return {
-            source: selected.source,
-            token: yield* Deferred.await(selected.source),
-          }
+          return yield* Fiber.join(fiber)
         },
       )
 
@@ -115,7 +97,7 @@ export const ambientGitHubLayer = (options: {
           service: GitHubServiceShape,
         ) => Effect.Effect<A, GitHubServiceError>,
       ) {
-        const { source, token } = yield* acquireToken()
+        const token = yield* acquireToken()
         const first = yield* Effect.result(operation(makeService(token)))
         if (
           first._tag !== "Failure" ||
@@ -125,11 +107,15 @@ export const ambientGitHubLayer = (options: {
           return yield* Effect.fromResult(first)
         }
 
-        yield* Ref.update(tokenCache, (current) =>
-          current === source ? undefined : current,
+        // Only drop the cache entry if it still holds the token that 401'd —
+        // concurrent 401s share one refresh instead of stomping a newer token.
+        yield* Cache.invalidateWhen(
+          tokenCache,
+          TOKEN_CACHE_KEY,
+          (cached) => cached === token,
         )
         const refreshed = yield* acquireToken()
-        return yield* operation(makeService(refreshed.token))
+        return yield* operation(makeService(refreshed))
       })
 
       const authenticated = <A>(

--- a/apps/harness/src/server/ambient-gitlab-layer.ts
+++ b/apps/harness/src/server/ambient-gitlab-layer.ts
@@ -1,4 +1,4 @@
-import { Deferred, Effect, Layer, Ref } from "effect"
+import { Cache, Duration, Effect, Exit, Fiber, Layer } from "effect"
 import { ChildProcessSpawner } from "effect/unstable/process"
 import {
   type GitLabProjectUnavailableError,
@@ -38,9 +38,6 @@ export const ambientGitLabLayer = (options: {
       const makeAnonymousService =
         options.makeAnonymousService ?? (() => makeGitLabService({}))
       const ambientToken = options.environment?.GITLAB_TOKEN?.trim()
-      const tokenCache = yield* Ref.make<
-        ReadonlyMap<string, Deferred.Deferred<string, GitLabRequestError>>
-      >(new Map())
 
       const resolveGlabToken = Effect.fn("AmbientGitLab.resolveGlabToken")(
         function* (forgeHost: string) {
@@ -90,65 +87,30 @@ export const ambientGitLabLayer = (options: {
         )
       })
 
+      // Per-host single-flight success cache; failures expire immediately
+      // (TTL zero, not reused); success lives until 401 invalidate. Capacity is
+      // unbounded (same as the prior Map) so multi-host installs are not
+      // evicted. Cache.get is forked into the layer scope so canceling one
+      // requester cannot abort a shared in-flight lookup for joiners. Nested
+      // consumers must build this layer with Layer.buildWithScope (not a
+      // short-lived Effect.provide) so that scope stays open.
+      const tokenCache = yield* Cache.makeWith(
+        (forgeHost: string) => resolveToken(forgeHost),
+        {
+          capacity: Number.POSITIVE_INFINITY,
+          timeToLive: (exit) =>
+            Exit.isSuccess(exit) ? Duration.infinity : Duration.zero,
+        },
+      )
+
       const acquireToken = Effect.fn("AmbientGitLab.acquireToken")(function* (
         forgeHost: string,
       ) {
-        const candidate = yield* Deferred.make<string, GitLabRequestError>()
-        type SelectedToken = {
-          readonly source: Deferred.Deferred<string, GitLabRequestError>
-          readonly owner: boolean
-        }
-        const selected = yield* Ref.modify<
-          ReadonlyMap<string, Deferred.Deferred<string, GitLabRequestError>>,
-          SelectedToken
-        >(tokenCache, (current) => {
-          const cached = current.get(forgeHost)
-          if (cached !== undefined) {
-            return [{ source: cached, owner: false }, current]
-          }
-          const next = new Map(current)
-          next.set(forgeHost, candidate)
-          return [{ source: candidate, owner: true }, next]
-        })
-
-        if (selected.owner) {
-          yield* resolveToken(forgeHost).pipe(
-            Effect.result,
-            Effect.flatMap((result) =>
-              (result._tag === "Failure"
-                ? Ref.update(tokenCache, (current) => {
-                    if (current.get(forgeHost) !== candidate) return current
-                    const next = new Map(current)
-                    next.delete(forgeHost)
-                    return next
-                  })
-                : Effect.void
-              ).pipe(
-                Effect.andThen(
-                  Deferred.complete(candidate, Effect.fromResult(result)),
-                ),
-              ),
-            ),
-            Effect.forkIn(layerScope, { startImmediately: true }),
-          )
-        }
-
-        return {
-          source: selected.source,
-          token: yield* Deferred.await(selected.source),
-        }
+        const fiber = yield* Cache.get(tokenCache, forgeHost).pipe(
+          Effect.forkIn(layerScope),
+        )
+        return yield* Fiber.join(fiber)
       })
-
-      const invalidate = (
-        forgeHost: string,
-        source: Deferred.Deferred<string, GitLabRequestError>,
-      ) =>
-        Ref.update(tokenCache, (current) => {
-          if (current.get(forgeHost) !== source) return current
-          const next = new Map(current)
-          next.delete(forgeHost)
-          return next
-        })
 
       const run = Effect.fn("AmbientGitLab.runAuthenticated")(function* <A>(
         forgeHost: string,
@@ -156,10 +118,8 @@ export const ambientGitLabLayer = (options: {
           service: GitLabServiceShape,
         ) => Effect.Effect<A, GitLabServiceError>,
       ) {
-        const firstToken = yield* acquireToken(forgeHost)
-        const first = yield* Effect.result(
-          operation(makeService(firstToken.token)),
-        )
+        const token = yield* acquireToken(forgeHost)
+        const first = yield* Effect.result(operation(makeService(token)))
         if (
           first._tag !== "Failure" ||
           first.failure._tag !== "GitLabRequestError" ||
@@ -168,9 +128,15 @@ export const ambientGitLabLayer = (options: {
           return yield* Effect.fromResult(first)
         }
 
-        yield* invalidate(forgeHost, firstToken.source)
+        // Only drop the entry if it still holds the token that 401'd —
+        // concurrent 401s share one refresh instead of stomping a newer token.
+        yield* Cache.invalidateWhen(
+          tokenCache,
+          forgeHost,
+          (cached) => cached === token,
+        )
         const refreshed = yield* acquireToken(forgeHost)
-        return yield* operation(makeService(refreshed.token))
+        return yield* operation(makeService(refreshed))
       })
 
       const authenticated = <A>(

--- a/apps/harness/src/server/keymaxxer-github-layer.ts
+++ b/apps/harness/src/server/keymaxxer-github-layer.ts
@@ -1,4 +1,4 @@
-import { Deferred, Effect, Exit, Layer, Ref, Schema } from "effect"
+import { Cache, Duration, Effect, Exit, Fiber, Layer, Schema } from "effect"
 import {
   type GitHubHelperOperation,
   type GitHubRepository,
@@ -30,17 +30,6 @@ import {
 export const OPEN_PULL_REQUEST_COUNT_FRESHNESS_MS = 5_000
 
 type GitHubServiceError = GitHubRepositoryUnavailableError | GitHubRequestError
-
-type OpenPullRequestCountCacheEntry =
-  | {
-      readonly kind: "inflight"
-      readonly deferred: Deferred.Deferred<number, GitHubServiceError>
-    }
-  | {
-      readonly kind: "success"
-      readonly count: number
-      readonly fetchedAtMs: number
-    }
 
 const openPullRequestCountCacheKey = (repository: GitHubRepository): string =>
   [
@@ -155,10 +144,9 @@ export const keymaxxerGitHubLayer = (options: {
   /**
    * Override the successful-count freshness window (tests and experiments).
    * Defaults to {@link OPEN_PULL_REQUEST_COUNT_FRESHNESS_MS}.
+   * Expiry is driven by the Effect `Clock` (use `TestClock` in tests).
    */
   readonly openPullRequestCountFreshnessMs?: number
-  /** Injectable clock for freshness tests. Defaults to `Date.now`. */
-  readonly nowMs?: () => number
 }): Layer.Layer<GitHubService, never, KeymaxxerService> =>
   Layer.effect(
     GitHubService,
@@ -168,10 +156,6 @@ export const keymaxxerGitHubLayer = (options: {
       const countFreshnessMs =
         options.openPullRequestCountFreshnessMs ??
         OPEN_PULL_REQUEST_COUNT_FRESHNESS_MS
-      const nowMs = options.nowMs ?? Date.now
-      const openPullRequestCountCache = yield* Ref.make(
-        new Map<string, OpenPullRequestCountCacheEntry>(),
-      )
       const ensureToken = Effect.fn("KeymaxxerGitHub.ensureToken")(
         (repository: GitHubRepository) =>
           keymaxxer.findSecret({
@@ -265,89 +249,48 @@ export const keymaxxerGitHubLayer = (options: {
 
       /**
        * Process-wide single-flight + short success cache per Repository.
-       * Concurrent callers share one Keymaxxer helper; failures are never
-       * stored as a successful zero.
+       * Concurrent callers share one Keymaxxer helper; failures expire
+       * immediately (TTL zero, not reused) so they cannot surface as a
+       * successful zero. Success TTL is driven by the Effect Clock
+       * (TestClock in tests). Lookup uses the original repository object
+       * (not a lowercased key reconstruction) for secret/helper casing.
        */
+      const repositoriesByCountCacheKey = new Map<string, GitHubRepository>()
+      const openPullRequestCountCache = yield* Cache.makeWith(
+        (key: string) => {
+          const repository = repositoriesByCountCacheKey.get(key)
+          if (repository === undefined) {
+            // Should not happen: callers register before Cache.get.
+            const [forge = "", forgeHost = "", projectPath = ""] =
+              key.split("\0")
+            return fetchOpenNonDraftPullRequestCount({
+              forge,
+              forgeHost,
+              projectPath,
+            })
+          }
+          return fetchOpenNonDraftPullRequestCount(repository)
+        },
+        {
+          capacity: 256,
+          timeToLive: (exit) =>
+            Exit.isSuccess(exit)
+              ? Duration.millis(countFreshnessMs)
+              : Duration.zero,
+        },
+      )
+
       const countOpenNonDraftPullRequestsCoalesced = Effect.fn(
         "KeymaxxerGitHub.countOpenNonDraftPullRequests",
       )(function* (repository: GitHubRepository) {
         const key = openPullRequestCountCacheKey(repository)
-        const candidate = yield* Deferred.make<number, GitHubServiceError>()
-
-        type Claim =
-          | { readonly role: "owner" }
-          | {
-              readonly role: "join"
-              readonly deferred: Deferred.Deferred<number, GitHubServiceError>
-            }
-          | { readonly role: "cached"; readonly count: number }
-
-        const claim = yield* Ref.modify(
-          openPullRequestCountCache,
-          (cache): [Claim, Map<string, OpenPullRequestCountCacheEntry>] => {
-            const current = cache.get(key)
-            const observedAt = nowMs()
-            if (
-              current?.kind === "success" &&
-              observedAt - current.fetchedAtMs < countFreshnessMs
-            ) {
-              return [{ role: "cached", count: current.count }, cache]
-            }
-            if (current?.kind === "inflight") {
-              return [{ role: "join", deferred: current.deferred }, cache]
-            }
-            const next = new Map(cache)
-            next.set(key, { kind: "inflight", deferred: candidate })
-            return [{ role: "owner" }, next]
-          },
+        repositoriesByCountCacheKey.set(key, repository)
+        // Fork into the layer scope so canceling one requester cannot abort
+        // a shared in-flight helper for concurrent joiners.
+        const fiber = yield* Cache.get(openPullRequestCountCache, key).pipe(
+          Effect.forkIn(layerScope),
         )
-
-        if (claim.role === "cached") {
-          return claim.count
-        }
-        if (claim.role === "join") {
-          return yield* Deferred.await(claim.deferred)
-        }
-
-        // Use Exit (not Effect.result) so interrupt/defect also settles the
-        // shared Deferred and clears inflight; otherwise joiners could hang.
-        // Settle is uninterruptible so layer teardown cannot leave joiners
-        // waiting after the fetch Exit is already known.
-        yield* fetchOpenNonDraftPullRequestCount(repository).pipe(
-          Effect.exit,
-          Effect.flatMap((exit) =>
-            Effect.uninterruptible(
-              Effect.gen(function* () {
-                yield* Ref.update(openPullRequestCountCache, (cache) => {
-                  const next = new Map(cache)
-                  const current = next.get(key)
-                  if (
-                    current?.kind !== "inflight" ||
-                    current.deferred !== candidate
-                  ) {
-                    return cache
-                  }
-                  if (Exit.isSuccess(exit)) {
-                    next.set(key, {
-                      kind: "success",
-                      count: exit.value,
-                      fetchedAtMs: nowMs(),
-                    })
-                  } else {
-                    // Failures / interrupt must not leave a permanent inflight
-                    // entry or be stored as a successful zero.
-                    next.delete(key)
-                  }
-                  return next
-                })
-                yield* Deferred.done(candidate, exit)
-              }),
-            ),
-          ),
-          Effect.forkIn(layerScope, { startImmediately: true }),
-        )
-
-        return yield* Deferred.await(candidate)
+        return yield* Fiber.join(fiber)
       })
 
       const service: GitHubServiceShape = {

--- a/apps/harness/src/server/keymaxxer-gitlab-layer.ts
+++ b/apps/harness/src/server/keymaxxer-gitlab-layer.ts
@@ -1,4 +1,4 @@
-import { Duration, Effect, Layer, Schema } from "effect"
+import { Context, Duration, Effect, Layer, Schema } from "effect"
 import type { ChildProcessSpawner } from "effect/unstable/process"
 import {
   GITLAB_VAULT_METADATA_BUDGET_SECONDS,
@@ -159,18 +159,22 @@ export const keymaxxerGitLabLayer = (options: {
       const vaultBudget =
         options.vaultMetadataBudget ?? GITLAB_VAULT_METADATA_BUDGET
       // Build ambient fallback inside this layer so vault-first can delegate
-      // when no per-Repository secret exists (without leaking the raw vault token).
-      const ambient = yield* GitLabService.pipe(
-        Effect.provide(
-          ambientGitLabLayer({
-            workspaceRoot: options.workspaceRoot,
-            environment: options.environment,
-            resolveToken: options.resolveToken,
-            makeService: options.makeService,
-            makeAnonymousService: options.makeAnonymousService,
-          }),
-        ),
+      // when no per-Repository secret exists (without leaking the raw vault
+      // token). Use buildWithScope so ambient's layer scope stays open for the
+      // lifetime of this layer — ambient token acquisition forks into that
+      // scope, and a short-lived Effect.provide would close it immediately.
+      const layerScope = yield* Effect.scope
+      const ambientContext = yield* Layer.buildWithScope(
+        ambientGitLabLayer({
+          workspaceRoot: options.workspaceRoot,
+          environment: options.environment,
+          resolveToken: options.resolveToken,
+          makeService: options.makeService,
+          makeAnonymousService: options.makeAnonymousService,
+        }),
+        layerScope,
       )
+      const ambient = Context.get(ambientContext, GitLabService)
 
       const ensureToken = Effect.fn("KeymaxxerGitLab.ensureToken")(
         (repository: GitLabRepository) =>

--- a/apps/harness/test/ambient-github-layer.test.ts
+++ b/apps/harness/test/ambient-github-layer.test.ts
@@ -176,6 +176,8 @@ it("application scope interrupts in-flight ambient authentication", async () => 
 })
 
 it("canceling the first requester keeps shared authentication alive", async () => {
+  // Cache.get is forked into the layer scope: canceling one requester only
+  // drops its Fiber.join, while the shared lookup continues for joiners.
   const process = controlledTokenProcess()
   const runtime = ManagedRuntime.make(
     ambientGitHubLayer({
@@ -197,6 +199,35 @@ it("canceling the first requester keeps shared authentication alive", async () =
 
   try {
     expect(await second).toEqual([])
+    expect(process.startCount()).toBe(1)
+    expect(process.interrupted()).toBe(0)
+  } finally {
+    await runtime.dispose()
+  }
+})
+
+it("concurrent joiners survive cancel of the cache owner fiber", async () => {
+  const process = controlledTokenProcess()
+  const runtime = ManagedRuntime.make(
+    ambientGitHubLayer({
+      workspaceRoot: "/workspace",
+      makeService: () => serviceWithList(() => Effect.succeed([])),
+    }).pipe(Layer.provide(process.layer)),
+  )
+  await runtime.context()
+  const ownerController = new AbortController()
+  const owner = runtime
+    .runPromise(listReadyIssues, { signal: ownerController.signal })
+    .catch(() => undefined)
+  const joiner = runtime.runPromise(listReadyIssues)
+
+  await process.started
+  ownerController.abort()
+  await owner
+  process.complete("shared-token")
+
+  try {
+    expect(await joiner).toEqual([])
     expect(process.startCount()).toBe(1)
     expect(process.interrupted()).toBe(0)
   } finally {

--- a/apps/harness/test/keymaxxer-github-layer.test.ts
+++ b/apps/harness/test/keymaxxer-github-layer.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "@effect/vitest"
-import { Deferred, Effect, Exit, Fiber, Layer } from "effect"
+import { Deferred, Effect, Exit, Fiber, Layer, ManagedRuntime } from "effect"
+import { TestClock } from "effect/testing"
 import {
   GitHubRequestError,
   GitHubService,
@@ -437,7 +438,6 @@ describe("Keymaxxer-backed GitHub layer", () => {
     () =>
       Effect.gen(function* () {
         const runs: RunWithSecretsInput[] = []
-        let clock = 50_000
         const keymaxxerLayer = Layer.succeed(KeymaxxerService, {
           initialize: Effect.void,
           findSecret: () => Effect.succeed("GITHUB_TOKEN_ACME_WIDGETS"),
@@ -455,8 +455,10 @@ describe("Keymaxxer-backed GitHub layer", () => {
         const layer = keymaxxerGitHubLayer({
           workspaceRoot: "/workspace",
           openPullRequestCountFreshnessMs: 60_000,
-          nowMs: () => clock,
-        }).pipe(Layer.provide(keymaxxerLayer))
+        }).pipe(
+          Layer.provide(keymaxxerLayer),
+          Layer.provideMerge(TestClock.layer()),
+        )
 
         yield* Effect.gen(function* () {
           const github = yield* GitHubService
@@ -465,7 +467,7 @@ describe("Keymaxxer-backed GitHub layer", () => {
           )
           expect(Exit.isFailure(first)).toBe(true)
 
-          clock += 10
+          // Failure TTL is zero; no clock advance needed for a retry.
           const second =
             yield* github.countOpenNonDraftPullRequests(acmeWidgets)
           expect(second).toBe(3)
@@ -775,7 +777,7 @@ describe("Keymaxxer-backed GitHub layer", () => {
   })
 
   // Real wall-clock coordination: hold the helper open so concurrent callers
-  // join one in-flight Deferred rather than racing TestClock.
+  // join one in-flight Cache lookup rather than racing TestClock.
   it.live(
     "concurrent count requests for one Repository share one Keymaxxer helper",
     () =>
@@ -825,6 +827,63 @@ describe("Keymaxxer-backed GitHub layer", () => {
         expect(runs[0]?.secrets).toEqual(["GITHUB_TOKEN_ACME_WIDGETS"])
       }),
   )
+
+  it("concurrent count joiners survive cancel of the cache owner fiber", async () => {
+    // Cache.get is forked into the layer scope: aborting one waiter must not
+    // cancel the shared helper or fail a concurrent joiner.
+    const runs: RunWithSecretsInput[] = []
+    let releaseHelper: (() => void) | undefined
+    const helperHeld = new Promise<void>((resolve) => {
+      releaseHelper = resolve
+    })
+    let helperStarts = 0
+    const keymaxxerLayer = Layer.succeed(KeymaxxerService, {
+      initialize: Effect.void,
+      findSecret: () => Effect.succeed("GITHUB_TOKEN_ACME_WIDGETS"),
+      findSecrets: () => Effect.die("not used"),
+      hasSecret: () => Effect.die("not used"),
+      addSecret: () => Effect.die("not used"),
+      runWithSecrets: (input) =>
+        Effect.gen(function* () {
+          runs.push(input)
+          helperStarts += 1
+          yield* Effect.promise(() => helperHeld)
+          return { exitCode: 0, stdout: "7", stderr: "" }
+        }),
+    })
+    const runtime = ManagedRuntime.make(
+      keymaxxerGitHubLayer({ workspaceRoot: "/workspace" }).pipe(
+        Layer.provide(keymaxxerLayer),
+      ),
+    )
+    await runtime.context()
+
+    const countOnce = Effect.gen(function* () {
+      const github = yield* GitHubService
+      return yield* github.countOpenNonDraftPullRequests(acmeWidgets)
+    })
+
+    const ownerController = new AbortController()
+    const owner = runtime
+      .runPromise(countOnce, { signal: ownerController.signal })
+      .catch(() => undefined)
+    const joiner = runtime.runPromise(countOnce)
+
+    for (let i = 0; i < 100 && helperStarts < 1; i += 1) {
+      await Bun.sleep(5)
+    }
+    expect(helperStarts).toBe(1)
+    ownerController.abort()
+    await owner
+    releaseHelper?.()
+
+    try {
+      expect(await joiner).toBe(7)
+      expect(runs).toHaveLength(1)
+    } finally {
+      await runtime.dispose()
+    }
+  })
 
   it.effect(
     "count requests for different Repositories never share credentials or results",
@@ -877,7 +936,6 @@ describe("Keymaxxer-backed GitHub layer", () => {
     () =>
       Effect.gen(function* () {
         const runs: RunWithSecretsInput[] = []
-        let clock = 1_000
         const keymaxxerLayer = Layer.succeed(KeymaxxerService, {
           initialize: Effect.void,
           findSecret: () => Effect.succeed("GITHUB_TOKEN_ACME_WIDGETS"),
@@ -896,13 +954,15 @@ describe("Keymaxxer-backed GitHub layer", () => {
         const layer = keymaxxerGitHubLayer({
           workspaceRoot: "/workspace",
           openPullRequestCountFreshnessMs: 5_000,
-          nowMs: () => clock,
-        }).pipe(Layer.provide(keymaxxerLayer))
+        }).pipe(
+          Layer.provide(keymaxxerLayer),
+          Layer.provideMerge(TestClock.layer()),
+        )
 
         const counts = yield* Effect.gen(function* () {
           const github = yield* GitHubService
           const first = yield* github.countOpenNonDraftPullRequests(acmeWidgets)
-          clock += 1_000
+          yield* TestClock.adjust(1_000)
           const second =
             yield* github.countOpenNonDraftPullRequests(acmeWidgets)
           return [first, second] as const
@@ -918,7 +978,6 @@ describe("Keymaxxer-backed GitHub layer", () => {
     () =>
       Effect.gen(function* () {
         const runs: RunWithSecretsInput[] = []
-        let clock = 10_000
         const keymaxxerLayer = Layer.succeed(KeymaxxerService, {
           initialize: Effect.void,
           findSecret: () => Effect.succeed("GITHUB_TOKEN_ACME_WIDGETS"),
@@ -937,13 +996,15 @@ describe("Keymaxxer-backed GitHub layer", () => {
         const layer = keymaxxerGitHubLayer({
           workspaceRoot: "/workspace",
           openPullRequestCountFreshnessMs: 5_000,
-          nowMs: () => clock,
-        }).pipe(Layer.provide(keymaxxerLayer))
+        }).pipe(
+          Layer.provide(keymaxxerLayer),
+          Layer.provideMerge(TestClock.layer()),
+        )
 
         const counts = yield* Effect.gen(function* () {
           const github = yield* GitHubService
           const first = yield* github.countOpenNonDraftPullRequests(acmeWidgets)
-          clock += 5_000
+          yield* TestClock.adjust(5_000)
           const second =
             yield* github.countOpenNonDraftPullRequests(acmeWidgets)
           return [first, second] as const
@@ -959,7 +1020,6 @@ describe("Keymaxxer-backed GitHub layer", () => {
     () =>
       Effect.gen(function* () {
         const runs: RunWithSecretsInput[] = []
-        let clock = 100
         const keymaxxerLayer = Layer.succeed(KeymaxxerService, {
           initialize: Effect.void,
           findSecret: () => Effect.succeed("GITHUB_TOKEN_ACME_WIDGETS"),
@@ -984,8 +1044,10 @@ describe("Keymaxxer-backed GitHub layer", () => {
         const layer = keymaxxerGitHubLayer({
           workspaceRoot: "/workspace",
           openPullRequestCountFreshnessMs: 60_000,
-          nowMs: () => clock,
-        }).pipe(Layer.provide(keymaxxerLayer))
+        }).pipe(
+          Layer.provide(keymaxxerLayer),
+          Layer.provideMerge(TestClock.layer()),
+        )
 
         yield* Effect.gen(function* () {
           const github = yield* GitHubService
@@ -995,7 +1057,7 @@ describe("Keymaxxer-backed GitHub layer", () => {
           )
           expect(Exit.isFailure(requestFailure)).toBe(true)
 
-          clock += 10
+          // Failure TTL is zero — retries must not see a cached zero.
           const unavailable = yield* Effect.exit(
             github.countOpenNonDraftPullRequests(acmeWidgets),
           )
@@ -1006,11 +1068,9 @@ describe("Keymaxxer-backed GitHub layer", () => {
             expect(String(error)).toContain("GitHubRepositoryUnavailableError")
           }
 
-          clock += 10
           const zero = yield* github.countOpenNonDraftPullRequests(acmeWidgets)
           expect(zero).toBe(0)
 
-          clock += 10
           // Genuine zero is success-cached; failures above must not have been.
           const cachedZero =
             yield* github.countOpenNonDraftPullRequests(acmeWidgets)


### PR DESCRIPTION
### Why

Ambient GitHub/GitLab token acquisition and the Keymaxxer open-PR-count
path each reimplemented the same single-flight + success-cache protocol
(`Ref` + `Deferred`, failure rollback, 401 invalidation, TTL). That was
~200 lines of subtle concurrency code that Effect v4 `Cache` already
provides.

### What

- Ambient GitHub/GitLab: `Cache.makeWith` for token lookup (success TTL
  infinite, failure TTL zero so misses retry). 401 refresh uses
  `Cache.invalidateWhen` so concurrent 401s share one refresh.
  `Cache.get` is forked into the layer scope so canceling one waiter
  does not abort the shared lookup.
- Keymaxxer GitHub open-PR count: same Cache pattern with success TTL
  `OPEN_PULL_REQUEST_COUNT_FRESHNESS_MS`; removed injectable `nowMs` in
  favor of Effect `Clock` / `TestClock`. Original `GitHubRepository` is
  registered before `get` so helper/secret casing is preserved.
- Keymaxxer GitLab: builds ambient fallback with `Layer.buildWithScope`
  so ambient’s scope outlives construction (nested `Effect.provide`
  closed the scope and broke fallback gets when forking into it).

### Verification

- Unit tests: ambient GitHub/GitLab, keymaxxer GitHub/GitLab (including
  concurrent joiner cancel-isolation, 401 shared refresh, failure
  non-reuse, TestClock freshness).
- Pre-commit (`nx affected` lint/typecheck/test) passed on the staged
  set.

### Notes

- Side map for count cache keys is not pruned vs Cache capacity
  (accepted for typical repo counts).
- Hot-path `forkIn` on every get is intentional for cancel isolation,
  not optimized for fiber churn.

Closes #713