### PR TITLE
feat(harness): teach ready-for-agent workflow in Queue hint

### DIFF
--- a/apps/harness/src/kanban-board.tsx
+++ b/apps/harness/src/kanban-board.tsx
@@ -1,5 +1,4 @@
 import { useQueries, useSuspenseQuery } from "@tanstack/react-query"
-import { Link } from "@tanstack/react-router"
 import { type CSSProperties, Suspense, useState } from "react"
 import { Banner } from "./banner.js"
 import { Copy } from "./copy.js"
@@ -453,11 +452,38 @@ function KanbanJobsBoard() {
                     <aside className={ui.queueHint}>
                       <span className={ui.queueHintTag}>Queue</span>
                       <p className={ui.queueHintText}>
-                        Feed the queue — work starts at your repos.
+                        Feed the queue — label issues with{" "}
+                        <code className={ui.queueHintCode}>
+                          ready-for-agent
+                        </code>
+                        . When they show up in your repos, click{" "}
+                        <strong className={ui.queueHintAction}>
+                          Implement now
+                        </strong>
+                        .
                       </p>
-                      <Link to="/repos" className={ui.queueHintLink}>
-                        Manage repos →
-                      </Link>
+                      <div className={ui.queueHintMenuIllus} aria-hidden="true">
+                        <span className={ui.queueHintMenuKebab}>
+                          <svg
+                            viewBox="0 0 24 24"
+                            fill="currentColor"
+                            className="h-3.5 w-3.5"
+                            aria-hidden="true"
+                          >
+                            <circle cx="12" cy="5" r="1.75" />
+                            <circle cx="12" cy="12" r="1.75" />
+                            <circle cx="12" cy="19" r="1.75" />
+                          </svg>
+                        </span>
+                        <div className={ui.queueHintMenuPanel}>
+                          <span className={ui.queueHintMenuItem}>
+                            Implement now
+                          </span>
+                          <span className={ui.queueHintMenuItem}>
+                            Implement locally
+                          </span>
+                        </div>
+                      </div>
                     </aside>
                   )}
                 </section>

--- a/apps/harness/src/ui.ts
+++ b/apps/harness/src/ui.ts
@@ -588,8 +588,28 @@ export const ui = {
   queueHintText:
     "m-0 font-display text-[0.9rem] font-medium leading-[1.35] text-[#151515]",
 
-  queueHintLink:
-    "justify-self-start font-mono text-[0.68rem] font-bold tracking-[0.08em] uppercase text-[#151515] underline decoration-[1.5px] underline-offset-[3px] hover:bg-[#151515] hover:text-lane-queue hover:no-underline",
+  /** Inline mono chip for the ready-for-agent label name. */
+  queueHintCode:
+    "rounded-none border border-[#151515] bg-[#151515] px-[0.28rem] py-[0.05rem] font-mono text-[0.72rem] font-bold tracking-[0.02em] text-lane-queue",
+
+  /** Emphasize the Implement now control name inside the hint body. */
+  queueHintAction: "font-semibold not-italic",
+
+  /**
+   * Compact static mock of the repos issue ⋮ menu (Implement now /
+   * Implement locally) — decorative, under the hint copy. Matches the
+   * industrial menu chrome (ink border, mono uppercase items, ⋮ trigger).
+   */
+  queueHintMenuIllus: "mt-[0.1rem] flex w-fit flex-col items-end gap-[0.2rem]",
+
+  queueHintMenuKebab:
+    "inline-flex h-6 w-6 shrink-0 items-center justify-center border border-[#151515] bg-[var(--panel,#ffffff)] text-[#151515]",
+
+  queueHintMenuPanel:
+    "min-w-[9.5rem] border-2 border-[#151515] bg-[var(--panel,#ffffff)] py-0.5 shadow-none",
+
+  queueHintMenuItem:
+    "block px-2.5 py-1.5 font-mono text-[0.62rem] font-bold tracking-[0.08em] uppercase text-[#151515]",
 
   jobTicket: cx(
     "relative grid min-w-0 gap-[0.4rem] rounded-none border-[1.5px] border-ink",

--- a/apps/harness/test/kanban-route.test.ts
+++ b/apps/harness/test/kanban-route.test.ts
@@ -152,9 +152,13 @@ describe("kanban home board", () => {
     expect(source).not.toContain("lane-number")
     expect(source).not.toContain("lane-count")
     expect(source).toContain("ui.queueHint")
-    expect(source).toContain("Feed the queue — work starts at your repos.")
-    expect(source).toContain("Manage repos →")
-    expect(source).toContain('to="/repos"')
+    expect(source).toContain("Feed the queue — label issues with")
+    expect(source).toContain("ready-for-agent")
+    expect(source).toContain("Implement now")
+    expect(source).toContain("Implement locally")
+    expect(source).toContain("ui.queueHintMenuIllus")
+    expect(source).not.toContain("Manage repos →")
+    expect(source).not.toContain("work starts at your repos")
   })
 
   test("Jobs strip + repository filters are sticky root chrome", () => {
@@ -442,6 +446,9 @@ describe("kanban home board", () => {
     // Lane switcher hidden on desktop, grid on mobile.
     expect(ui).toMatch(/laneSwitcher:[\s\S]*?hidden/)
     expect(ui).toContain("queueHint:")
+    expect(ui).toContain("queueHintMenuIllus:")
+    expect(ui).toContain("queueHintMenuItem:")
+    expect(ui).not.toContain("queueHintLink:")
     // Counts live in route roundels; header keeps title only.
     expect(ui).not.toContain("laneNumber:")
     expect(ui).not.toContain("laneCount:")

--- a/docs/harness-design-system.md
+++ b/docs/harness-design-system.md
@@ -573,14 +573,18 @@ Stamps mark exceptions only — defaults go unstamped.
 ## 6. Queue discoverability hint ("Feed the queue")
 
 A permanent fixture at the **foot of the Queue platform**, always rendered
-(not only when the lane is empty), linking to `/repos`:
+(not only when the lane is empty):
 
 - **Panel**: `--lane-queue` fill, 2px ink border, 0.6–0.7rem padding.
 - **Tag**: solid ink fill, Queue-yellow mono uppercase text ("Queue").
-- **Copy** (plain words, per #695): "Feed the queue — work starts at your
-  repos."
-- **Link**: mono 0.62rem/700 uppercase, ink, 1.5px underline offset 3px —
-  "Manage repos →"; hover = ink fill, Queue-yellow text, no underline.
+- **Copy** (plain words; workflow per #730): "Feed the queue — label issues
+  with `ready-for-agent`. When they show up in your repos, click
+  **Implement now**." Prefer neutral "issues" over a forge brand name.
+- **Illustration**: compact static mock of the repos issue ⋮ menu showing
+  **Implement now** and **Implement locally** (decorative, `aria-hidden`)
+  so operators recognize the control on Repos.
+- No primary "Manage repos" CTA — keep the hint focused on label → Implement
+  now.
 - No transit glyphs (no ⇄), no "Transfer" wording anywhere.
 
 ## 7. Accessibility
@@ -600,7 +604,7 @@ A permanent fixture at the **foot of the Queue platform**, always rendered
 The metaphor stays visual; the words are plain. Banned vocabulary (from
 #695): "Transfer / change here", "system map", "Network key", "Departed",
 "Six-stop work network — all lines running", "Service board". Plain
-replacements: "Feed the queue — work starts at your repos", "Merged PR
+replacements: "Feed the queue — label issues with ready-for-agent…", "Merged PR
 throughput", "Clanker Harness" (masthead status under “Ready for Agent”),
 "Full archive". Roundels,
 route lines, and lane numbers (01–06) stay as pure graphics with


### PR DESCRIPTION
## Why

The Queue column foot hint told operators that work starts at their repos and
pushed **Manage repos** as the main action. That skipped the real workflow:
label forge issues `ready-for-agent`, wait until they appear under Repos, then
start them with **Implement now**.

## What changed

- Replaced Queue hint copy with neutral wording that names the
  `ready-for-agent` label and **Implement now** (GitHub/GitLab-agnostic
  “issues”).
- Dropped the Manage repos primary CTA and unused `Link` import.
- Added a compact decorative ⋮ menu mock (Implement now / Implement locally)
  under the hint, styled for the industrial queue-yellow card and marked
  `aria-hidden`.
- Extended `ui.ts` recipes for the label chip, action emphasis, and menu
  illustration; removed unused `queueHintLink`.
- Updated kanban route source-string tests and the design-system §6 / voice
  contract.

## Verification

- `bunx nx test harness` (including kanban-route assertions)
- `bunx nx run harness:typecheck`
- Pre-commit (`harness:lint` / Biome) after a11y `aria-hidden` on the
  decorative SVG and format cleanup
- Local review: no open findings

Behavior of Implement now / Implement locally and label polling is unchanged.

Closes #730