### PR TITLE
fix(harness): keep kanban ticket runtime lines inside the card

### DIFF
--- a/apps/harness/src/completed-work-item-row.tsx
+++ b/apps/harness/src/completed-work-item-row.tsx
@@ -189,11 +189,7 @@ export function CompletedWorkItemRow({
             >
               {sessionId}
             </button>{" "}
-            <Copy
-              value={sessionId}
-              className="inline-flex shrink-0"
-              showValue={false}
-            />
+            <Copy value={sessionId} showValue={false} className="shrink-0" />
           </>
         ) : (
           " — No session"

--- a/apps/harness/src/copy.tsx
+++ b/apps/harness/src/copy.tsx
@@ -42,11 +42,16 @@ export function Copy({
 
   return (
     <span
-      className={`inline-flex min-w-0 max-w-full items-center gap-1 ${className ?? ""}`}
+      className={cx(
+        // inline-flex: stays on one line in archive meta paragraphs, and still
+        // shrinks inside ticket flex/grid rows when min-w-0 max-w-full apply.
+        "inline-flex min-w-0 max-w-full items-center gap-1",
+        className,
+      )}
     >
       {showValue ? (
         <span
-          className={`min-w-0 truncate ${textClassName ?? ""}`}
+          className={cx("min-w-0 flex-1 truncate", textClassName)}
           title={value}
         >
           {value}
@@ -54,7 +59,7 @@ export function Copy({
       ) : null}
       <button
         type="button"
-        className={cx(ui.iconBtnBare, copied && ui.iconBtnCopied)}
+        className={cx(ui.iconBtnBare, "shrink-0", copied && ui.iconBtnCopied)}
         onClick={() => {
           void handleCopy()
         }}

--- a/apps/harness/src/kanban-board.tsx
+++ b/apps/harness/src/kanban-board.tsx
@@ -195,6 +195,7 @@ function PipelineTicket({
               ui.jobTicketState,
               statusBadgeClassNameForStatus(workItem.status),
             )}
+            title={workItem.stateLabel}
           >
             {workItem.stateLabel}
           </span>
@@ -207,12 +208,12 @@ function PipelineTicket({
           <div
             className={cx(
               ui.jobTicketRuntimeLine,
-              "flex min-w-0 items-center gap-1",
+              "flex min-w-0 max-w-full items-center gap-1",
             )}
           >
             <button
               type="button"
-              className={cx(ui.jobTicketSession, "min-w-0 truncate")}
+              className={cx(ui.jobTicketSession, "min-w-0 flex-1 truncate")}
               title={sessionId}
               onClick={() => onOpenSession(workItem.id, sessionId)}
             >

--- a/apps/harness/src/routes/index.tsx
+++ b/apps/harness/src/routes/index.tsx
@@ -3526,13 +3526,18 @@ export function WorkItemLifecycleStatus({
       chipLane !== null
         ? (lifecycleLaneCssVars(chipLane) as CSSProperties)
         : undefined
-    const duration = displayDurationMs !== null && (
-      <span className="ml-1 opacity-90">
-        · {formatDuration(displayDurationMs)}
-      </span>
-    )
+    const duration =
+      displayDurationMs !== null ? (
+        <span className="ml-1 shrink-0 opacity-90">
+          · {formatDuration(displayDurationMs)}
+        </span>
+      ) : null
+    const chipTitle =
+      displayDurationMs !== null
+        ? `${lifecycleLabel.label} · ${formatDuration(displayDurationMs)}`
+        : lifecycleLabel.label
     return (
-      <li key={lifecycleLabel.phase}>
+      <li key={lifecycleLabel.phase} className="min-w-0 max-w-full">
         {linkToPullRequest ? (
           <a
             className={`${chipClassName} hover:underline`}
@@ -3540,14 +3545,15 @@ export function WorkItemLifecycleStatus({
             target="_blank"
             rel="noopener noreferrer"
             aria-label={`${openPullRequestLabel}: ${lifecycleLabel.label}`}
+            title={chipTitle}
             style={chipStyle}
           >
-            {lifecycleLabel.label}
+            <span className="min-w-0 truncate">{lifecycleLabel.label}</span>
             {duration}
           </a>
         ) : (
-          <span className={chipClassName} style={chipStyle}>
-            {lifecycleLabel.label}
+          <span className={chipClassName} style={chipStyle} title={chipTitle}>
+            <span className="min-w-0 truncate">{lifecycleLabel.label}</span>
             {duration}
           </span>
         )}
@@ -3565,7 +3571,8 @@ export function WorkItemLifecycleStatus({
     <ol
       id={options?.id}
       className={
-        options?.className ?? "mt-2 mb-0 flex list-none flex-wrap gap-1 p-0"
+        options?.className ??
+        "mt-2 mb-0 flex min-w-0 max-w-full list-none flex-wrap gap-1 p-0"
       }
       aria-label={options?.ariaLabel ?? "Lifecycle steps"}
     >
@@ -3574,7 +3581,9 @@ export function WorkItemLifecycleStatus({
   )
 
   return (
-    <div className={compact ? "mt-2" : ui.lifecycleInset}>
+    <div
+      className={cx(compact ? "mt-2" : ui.lifecycleInset, "min-w-0 max-w-full")}
+    >
       {/*
        * Non-compact (repos): same runtime lines as kanban tickets — agent
        * backend, session id (Session usage + copy), worktree path + copy.
@@ -3589,20 +3598,20 @@ export function WorkItemLifecycleStatus({
             <div
               className={cx(
                 ui.jobTicketRuntimeLine,
-                "flex min-w-0 items-center gap-1",
+                "flex min-w-0 max-w-full items-center gap-1",
               )}
             >
               {onOpenSession !== undefined ? (
                 <button
                   type="button"
-                  className={cx(ui.jobTicketSession, "min-w-0 truncate")}
+                  className={cx(ui.jobTicketSession, "min-w-0 flex-1 truncate")}
                   title={sessionId}
                   onClick={() => onOpenSession(workItem.id, sessionId)}
                 >
                   {sessionId}
                 </button>
               ) : (
-                <span className="min-w-0 truncate" title={sessionId}>
+                <span className="min-w-0 flex-1 truncate" title={sessionId}>
                   {sessionId}
                 </span>
               )}
@@ -3673,7 +3682,7 @@ export function WorkItemLifecycleStatus({
                       renderChipList(block.chips, {
                         id: chipsId,
                         className:
-                          "mt-1 mb-0 flex list-none flex-wrap gap-1 p-0",
+                          "mt-1 mb-0 flex min-w-0 max-w-full list-none flex-wrap gap-1 p-0",
                         ariaLabel: `${block.laneLabel} lifecycle steps`,
                       })}
                   </div>
@@ -3682,9 +3691,10 @@ export function WorkItemLifecycleStatus({
               if (block.kind === "focus-lane") {
                 if (block.chips.length === 0) return null
                 return (
-                  <div key="focus-lane">
+                  <div key="focus-lane" className="min-w-0 max-w-full">
                     {renderChipList(block.chips, {
-                      className: "m-0 flex list-none flex-wrap gap-1 p-0",
+                      className:
+                        "m-0 flex min-w-0 max-w-full list-none flex-wrap gap-1 p-0",
                       ariaLabel: "Current lifecycle steps",
                     })}
                   </div>

--- a/apps/harness/src/ui.ts
+++ b/apps/harness/src/ui.ts
@@ -281,7 +281,8 @@ export const ui = {
    * Journey-leg chips — board density floor (0.56rem) is the shared base.
    * Completed archive composes `archiveLeg` for a larger relaxed size.
    */
-  leg: "inline-flex items-center whitespace-nowrap border-[1.5px] border-ink bg-transparent px-[0.38rem] py-[0.16rem] font-mono text-[0.56rem] tracking-[0.06em] text-ink-2 no-underline",
+  // max-w-full + truncate: long lifecycle labels stay inside ticket columns.
+  leg: "inline-flex max-w-full min-w-0 items-center overflow-hidden text-ellipsis whitespace-nowrap border-[1.5px] border-ink bg-transparent px-[0.38rem] py-[0.16rem] font-mono text-[0.56rem] tracking-[0.06em] text-ink-2 no-underline",
 
   /**
    * Completed-card journey legs — readable body-adjacent mono (board is
@@ -574,7 +575,7 @@ export const ui = {
     "m-0 font-display text-[1.2rem] font-[950] leading-[0.85] tracking-[-0.04em] uppercase",
 
   laneStack:
-    "m-0 grid flex-[1_1_auto] list-none content-start gap-[0.55rem] p-[0.55rem]",
+    "m-0 grid min-w-0 flex-[1_1_auto] list-none content-start gap-[0.55rem] p-[0.55rem]",
 
   laneEmpty:
     "m-2 border-t border-dashed border-[rgb(21_21_21/0.35)] pt-4 font-mono text-[0.7rem] font-bold leading-[1.4] tracking-[0.08em] uppercase text-[#4a4a4a]",
@@ -612,7 +613,9 @@ export const ui = {
     "block px-2.5 py-1.5 font-mono text-[0.62rem] font-bold tracking-[0.08em] uppercase text-[#151515]",
 
   jobTicket: cx(
-    "relative grid min-w-0 gap-[0.4rem] rounded-none border-[1.5px] border-ink",
+    // minmax(0,1fr): single column may shrink below long mono min-content so
+    // runtime lines / chips ellipsize inside the ticket instead of overflowing.
+    "relative grid min-w-0 grid-cols-[minmax(0,1fr)] gap-[0.4rem] rounded-none border-[1.5px] border-ink",
     // Warm cream slip (lane-bed mix) — not pure white, not brushed metal.
     // Same parchment fill in every lane so Build/Review/PR match Merged.
     "bg-[var(--ticket-fill)]",
@@ -622,27 +625,27 @@ export const ui = {
   ),
 
   jobTicketRepo:
-    "m-0 overflow-hidden text-ellipsis whitespace-nowrap font-mono text-[0.68rem] font-normal leading-[1.2] tracking-[0.1em] uppercase text-ink-faint",
+    "m-0 min-w-0 overflow-hidden text-ellipsis whitespace-nowrap font-mono text-[0.68rem] font-normal leading-[1.2] tracking-[0.1em] uppercase text-ink-faint",
 
   jobTicketTitle:
-    "m-0 block font-display text-[1.06rem] font-semibold leading-[1.3] text-ink no-underline [overflow-wrap:anywhere]",
+    "m-0 block min-w-0 max-w-full font-display text-[1.06rem] font-semibold leading-[1.3] text-ink no-underline [overflow-wrap:anywhere]",
 
   jobTicketTitleLink:
     "hover:text-ink hover:underline hover:decoration-signal hover:decoration-2 hover:underline-offset-[3px]",
 
   jobTicketNum: "font-mono text-[0.8rem] text-ink-2",
 
-  jobTicketStatus: "flex items-center justify-between gap-[0.4rem]",
+  jobTicketStatus: "flex min-w-0 items-center justify-between gap-[0.4rem]",
 
-  jobTicketState: "m-0 inline-block",
+  jobTicketState: "m-0 min-w-0 max-w-full truncate",
 
-  jobTicketRuntime: "mt-0 grid gap-[0.2rem] border-t-0 pt-0",
+  jobTicketRuntime: "mt-0 grid min-w-0 max-w-full gap-[0.2rem] border-t-0 pt-0",
 
   jobTicketRuntimeLine:
-    "m-0 min-w-0 overflow-hidden text-ellipsis whitespace-nowrap font-mono text-[0.8rem] leading-[1.4] tracking-[0.04em] text-ink-faint",
+    "m-0 min-w-0 max-w-full overflow-hidden text-ellipsis whitespace-nowrap font-mono text-[0.8rem] leading-[1.4] tracking-[0.04em] text-ink-faint",
 
   jobTicketSession:
-    "cursor-pointer border-0 bg-transparent p-0 font-inherit text-ink-2 underline underline-offset-2 hover:text-ink",
+    "min-w-0 max-w-full cursor-pointer border-0 bg-transparent p-0 text-left font-inherit text-ink-2 underline underline-offset-2 hover:text-ink",
 
   pipelineList:
     "mt-6 grid grid-cols-[repeat(auto-fit,minmax(min(100%,18rem),1fr))] border-2 border-ink bg-panel p-3",
@@ -678,8 +681,9 @@ export const ui = {
 
   // Base is layout/type only — each tone owns border/fill/ink so Tailwind
   // cascade does not leave plain `bg-transparent` winning over alarm fill.
+  // max-w-full + truncate keeps long labels inside narrow kanban tickets.
   statusTag:
-    "inline-flex items-center whitespace-nowrap border-[1.5px] px-[0.4rem] py-[0.18rem] font-mono text-[0.66rem] font-bold leading-[1.2] tracking-[0.12em] uppercase no-underline",
+    "inline-flex max-w-full min-w-0 items-center overflow-hidden text-ellipsis whitespace-nowrap border-[1.5px] px-[0.4rem] py-[0.18rem] font-mono text-[0.66rem] font-bold leading-[1.2] tracking-[0.12em] uppercase no-underline",
 
   statusTagAlarm: "border-lane-attention bg-lane-attention text-[#151515]",
 
@@ -700,8 +704,8 @@ export const ui = {
   /* ---------- Journey-leg chips (board §5.2) — see also `leg*` above ---------- */
 
   legSummary: cx(
-    "inline-flex max-w-full cursor-pointer items-center gap-[0.35rem]",
-    "border-[1.5px] border-ink bg-[var(--leg-lane,var(--lane-build))] px-[0.38rem] py-[0.16rem]",
+    "inline-flex max-w-full min-w-0 cursor-pointer items-center gap-[0.35rem]",
+    "overflow-hidden border-[1.5px] border-ink bg-[var(--leg-lane,var(--lane-build))] px-[0.38rem] py-[0.16rem]",
     "font-mono text-[0.56rem] font-bold tracking-[0.06em] uppercase whitespace-nowrap text-[var(--leg-on,#fff)]",
     "hover:brightness-105",
   ),
@@ -886,7 +890,7 @@ export const ui = {
   ),
 
   lifecycleInset:
-    "mt-2 mb-0 ml-[2.95rem] border-[1.5px] border-ink bg-panel px-[0.65rem] py-[0.55rem]",
+    "mt-2 mb-0 ml-[2.95rem] min-w-0 max-w-full border-[1.5px] border-ink bg-panel px-[0.65rem] py-[0.55rem]",
 
   blankSlate:
     "grid justify-items-center border-2 border-dashed border-ink bg-panel px-6 pt-[2.4rem] pb-[2.2rem] text-center sm:px-10 sm:pt-[2.8rem] sm:pb-10",

--- a/apps/harness/test/copy-component.test.ts
+++ b/apps/harness/test/copy-component.test.ts
@@ -22,4 +22,18 @@ describe("Copy component", () => {
     expect(textIndex).toBeGreaterThan(-1)
     expect(buttonIndex).toBeGreaterThan(textIndex)
   })
+
+  test("shrinks long values and keeps the copy control visible (issue #733)", () => {
+    const source = readFileSync(
+      join(import.meta.dir, "../src/copy.tsx"),
+      "utf8",
+    )
+    // inline-flex: safe in archive meta paragraphs and ticket flex/grid rows.
+    expect(source).toContain(
+      '"inline-flex min-w-0 max-w-full items-center gap-1"',
+    )
+    // Value shrinks; copy glyph does not.
+    expect(source).toContain('"min-w-0 flex-1 truncate"')
+    expect(source).toMatch(/ui\.iconBtnBare,\s*"shrink-0"/)
+  })
 })

--- a/apps/harness/test/kanban-route.test.ts
+++ b/apps/harness/test/kanban-route.test.ts
@@ -342,6 +342,47 @@ describe("kanban home board", () => {
     expect(sessionButtonIndex).toBeGreaterThan(labelIndex)
   })
 
+  test("contains long runtime lines and copy controls inside the ticket (issue #733)", () => {
+    // Flex/grid min-width defaults let mono session/worktree rows paint past
+    // the ticket border (esp. Attention). Structural recipes + shrink chain.
+    const ui = uiSource()
+    expect(ui).toMatch(/jobTicket:\s*cx\([\s\S]*?grid-cols-\[minmax\(0,1fr\)\]/)
+    expect(ui).toMatch(/jobTicketRuntime:\s*"[^"]*min-w-0/)
+    expect(ui).toMatch(/jobTicketRuntimeLine:\s*"[^"]*max-w-full/)
+    expect(ui).toMatch(/jobTicketStatus:\s*"[^"]*min-w-0/)
+    expect(ui).toMatch(/jobTicketState:\s*"[^"]*truncate/)
+    expect(ui).toMatch(/laneStack:\s*"[^"]*min-w-0/)
+    // Status tags and journey legs truncate long labels within the card.
+    expect(ui).toMatch(/statusTag:\s*"[^"]*max-w-full[^"]*min-w-0/)
+    expect(ui).toMatch(/leg:\s*"[^"]*max-w-full[^"]*min-w-0/)
+
+    const ticket = boardSource().slice(
+      boardSource().indexOf("function PipelineTicket("),
+      boardSource().indexOf("function KanbanJobsBoard()"),
+    )
+    // Session value shrinks; copy control stays shrink-0 and fully clickable.
+    expect(ticket).toContain('"min-w-0 flex-1 truncate"')
+    expect(ticket).toContain(
+      '<Copy value={sessionId} showValue={false} className="shrink-0" />',
+    )
+    expect(ticket).toContain('"flex min-w-0 max-w-full items-center gap-1"')
+    expect(ticket).toContain('className="min-w-0 max-w-full"')
+    expect(ticket).toContain("textClassName={ui.jobTicketRuntimeLine}")
+
+    // Lifecycle chips: truncating label + non-shrinking duration + title.
+    const home = homeSource()
+    const lifecycle = home.slice(
+      home.indexOf("export function WorkItemLifecycleStatus("),
+      home.indexOf("function RepositoryIssuesSkeleton("),
+    )
+    expect(lifecycle).toContain('className="min-w-0 truncate"')
+    expect(lifecycle).toContain('className="ml-1 shrink-0 opacity-90"')
+    expect(lifecycle).toContain("title={chipTitle}")
+    expect(lifecycle).toContain(
+      "min-w-0 max-w-full list-none flex-wrap gap-1 p-0",
+    )
+  })
+
   test("reuses existing queries and live invalidation without polling", () => {
     // Working/Failed list queries still feed the Pipeline board merge; they are
     // not tab panels. Completed tab still uses jobsCompletedWorkItemsQuery.


### PR DESCRIPTION
## Why

Kanban job tickets (especially in the Attention lane) let long mono session
ids, worktree paths, and lifecycle chip labels expand past the ticket border.
Flex/grid min-content defaults prevented ellipsis, so copy controls painted
outside the card.

## What changed

- Ticket shell uses `grid-cols-[minmax(0,1fr)]` plus a `min-w-0` /
  `max-w-full` shrink chain on lane stack, runtime rows, status, and chips.
- Session/worktree rows: value truncates (`flex-1`); copy glyph stays
  `shrink-0` and clickable.
- `Copy` stays `inline-flex` so Completed archive meta lines keep an inline
  control while tickets still shrink.
- Lifecycle chips: truncating label, non-shrinking duration, full text in
  `title`.
- Source-contract tests for ticket recipes, Copy shrink chain, and chip
  structure.

## Verification

- Harness unit tests for kanban route, Copy, and related interchange
  surfaces.
- Typecheck clean for harness; pre-commit lint/format passed after Biome
  format.

## Limitations

- Coverage is source-string contracts, not DOM overflow measurement.
- Shared `statusTag` / `leg` truncation is global; non-board surfaces may
  ellipsize long labels without always having `title` (wide archive
  mitigates most cases).

Closes #733