### PR TITLE
refactor(ready-for-agent): replace browser readiness poll with Effect retry/timeout

### DIFF
--- a/apps/ready-for-agent/scripts/run-unit-tests.sh
+++ b/apps/ready-for-agent/scripts/run-unit-tests.sh
@@ -4,6 +4,7 @@ set -uo pipefail
 
 conditions="@ready-for-agent/source"
 effect_ignore=(
+  "**/browser-open.test.ts"
   "**/cli.test.ts"
   "**/services/application-config.test.ts"
 )

--- a/apps/ready-for-agent/src/browser-open.test.ts
+++ b/apps/ready-for-agent/src/browser-open.test.ts
@@ -1,3 +1,6 @@
+import { describe, expect, it } from "@effect/vitest"
+import { Effect, Exit, Fiber } from "effect"
+import { TestClock } from "effect/testing"
 import {
   type BrowserSpawn,
   browserOpenCommand,
@@ -6,18 +9,25 @@ import {
   resolveUiUrl,
   shouldOpenBrowser,
 } from "./browser-open.ts"
-import { describe, expect, test } from "bun:test"
+
+/** Spin until a side-effect counter reaches `n` (real Promise probes). */
+const waitForCount = (read: () => number, n: number) =>
+  Effect.gen(function* () {
+    while (read() < n) {
+      yield* Effect.yieldNow
+    }
+  })
 
 describe("browser open policy", () => {
-  test("opens by default", () => {
+  it("opens by default", () => {
     expect(shouldOpenBrowser({ noOpenFlag: false, env: {} })).toBe(true)
   })
 
-  test("--no-open disables browser open", () => {
+  it("--no-open disables browser open", () => {
     expect(shouldOpenBrowser({ noOpenFlag: true, env: {} })).toBe(false)
   })
 
-  test("NO_BROWSER disables browser open", () => {
+  it("NO_BROWSER disables browser open", () => {
     expect(
       shouldOpenBrowser({ noOpenFlag: false, env: { NO_BROWSER: "1" } }),
     ).toBe(false)
@@ -26,7 +36,7 @@ describe("browser open policy", () => {
     ).toBe(false)
   })
 
-  test("explicit false-like NO_BROWSER keeps open enabled", () => {
+  it("explicit false-like NO_BROWSER keeps open enabled", () => {
     expect(
       shouldOpenBrowser({ noOpenFlag: false, env: { NO_BROWSER: "0" } }),
     ).toBe(true)
@@ -35,12 +45,12 @@ describe("browser open policy", () => {
     ).toBe(true)
   })
 
-  test("UI URL uses PORT or default 6056", () => {
+  it("UI URL uses PORT or default 6056", () => {
     expect(resolveUiUrl({})).toBe("http://127.0.0.1:6056/")
     expect(resolveUiUrl({ PORT: "4300" })).toBe("http://127.0.0.1:4300/")
   })
 
-  test("browser open command is platform-appropriate", () => {
+  it("browser open command is platform-appropriate", () => {
     expect(browserOpenCommand("linux", "http://127.0.0.1:6056/")).toEqual({
       command: "xdg-open",
       args: ["http://127.0.0.1:6056/"],
@@ -57,7 +67,7 @@ describe("browser open policy", () => {
 })
 
 describe("launchDetachedBrowser", () => {
-  test("registers error handler before unref", () => {
+  it("registers error handler before unref", () => {
     const order: string[] = []
     const spawnImpl: BrowserSpawn = () => ({
       on(event) {
@@ -76,7 +86,7 @@ describe("launchDetachedBrowser", () => {
     expect(order).toEqual(["on-error", "unref"])
   })
 
-  test("swallows asynchronous spawn errors without throwing", async () => {
+  it("swallows asynchronous spawn errors without throwing", async () => {
     let errorListener: ((error: Error) => void) | undefined
     const spawnImpl: BrowserSpawn = () => ({
       on(event, listener) {
@@ -95,10 +105,10 @@ describe("launchDetachedBrowser", () => {
     ).not.toThrow()
     expect(errorListener).toBeTypeOf("function")
     expect(() => errorListener?.(new Error("ENOENT"))).not.toThrow()
-    await Bun.sleep(0)
+    await Promise.resolve()
   })
 
-  test("swallows synchronous spawn throws without throwing", () => {
+  it("swallows synchronous spawn throws without throwing", () => {
     const spawnImpl: BrowserSpawn = () => {
       throw new Error("spawn sync failure")
     }
@@ -109,98 +119,202 @@ describe("launchDetachedBrowser", () => {
 })
 
 describe("openBrowserWhenReady", () => {
-  test("launches at most once after readiness is observed", async () => {
-    let fetches = 0
-    let launches = 0
-    await openBrowserWhenReady("linux", "http://127.0.0.1:6056/", {
-      fetch: async () => {
-        fetches += 1
-        return { status: 200, body: null }
-      },
-      launch: () => {
-        launches += 1
-      },
-      sleep: async () => {
-        throw new Error("should not poll after launch")
-      },
-    })
-    expect(fetches).toBe(1)
-    expect(launches).toBe(1)
-  })
+  it.effect("launches at most once after readiness is observed", () =>
+    Effect.gen(function* () {
+      let fetches = 0
+      let launches = 0
+      const fiber = yield* Effect.forkChild(
+        openBrowserWhenReady("linux", "http://127.0.0.1:6056/", {
+          fetch: async () => {
+            fetches += 1
+            return { status: 200, body: null }
+          },
+          launch: () => {
+            launches += 1
+          },
+        }),
+      )
+      // Probe completes, then the post-readiness 1ms sleep parks on TestClock.
+      yield* waitForCount(() => fetches, 1)
+      yield* Effect.yieldNow
+      yield* TestClock.adjust("1 millis")
+      yield* Fiber.join(fiber)
+      expect(fetches).toBe(1)
+      expect(launches).toBe(1)
+    }),
+  )
 
-  test("stops the readiness poll when the AbortSignal is aborted", async () => {
-    const controller = new AbortController()
-    let fetches = 0
-    let launches = 0
+  it.effect("stops the readiness poll when the fiber is interrupted", () =>
+    Effect.gen(function* () {
+      let fetches = 0
+      let launches = 0
+      const fiber = yield* Effect.forkChild(
+        openBrowserWhenReady("linux", "http://127.0.0.1:6056/", {
+          fetch: async () => {
+            fetches += 1
+            throw new Error("ECONNREFUSED")
+          },
+          launch: () => {
+            launches += 1
+          },
+        }),
+      )
+      // Wait until the first real Promise probe has run (and failed) so the
+      // fiber is past tryPromise before we interrupt.
+      yield* waitForCount(() => fetches, 1)
+      yield* Effect.yieldNow
+      yield* Fiber.interrupt(fiber)
+      const exit = yield* Fiber.await(fiber)
+      expect(Exit.hasInterrupts(exit)).toBe(true)
+      expect(launches).toBe(0)
+      expect(fetches).toBeGreaterThanOrEqual(1)
+    }),
+  )
 
-    await openBrowserWhenReady("linux", "http://127.0.0.1:6056/", {
-      signal: controller.signal,
-      fetch: async () => {
-        fetches += 1
-        throw new Error("ECONNREFUSED")
-      },
-      sleep: async () => {
-        controller.abort()
-      },
-      launch: () => {
-        launches += 1
-      },
-      timeoutMs: 60_000,
-      pollIntervalMs: 1,
-    })
+  it.effect("aborts an in-flight probe when the fiber is interrupted", () =>
+    Effect.gen(function* () {
+      let launches = 0
+      // Hang the probe until interrupted; tryPromise aborts the AbortSignal.
+      const fiber = yield* Effect.forkChild(
+        openBrowserWhenReady("linux", "http://127.0.0.1:6056/", {
+          fetch: (_url, init) =>
+            new Promise((_resolve, reject) => {
+              const signal = init?.signal
+              if (signal === undefined) {
+                return
+              }
+              if (signal.aborted) {
+                reject(new Error("aborted"))
+                return
+              }
+              signal.addEventListener(
+                "abort",
+                () => {
+                  reject(new Error("aborted"))
+                },
+                { once: true },
+              )
+            }),
+          launch: () => {
+            launches += 1
+          },
+        }),
+      )
+      yield* Effect.yieldNow
+      yield* Fiber.interrupt(fiber)
+      const exit = yield* Fiber.await(fiber)
+      expect(Exit.hasInterrupts(exit)).toBe(true)
+      expect(launches).toBe(0)
+    }),
+  )
 
-    expect(launches).toBe(0)
-    expect(fetches).toBe(1)
-  })
-
-  test("does not launch when aborted after readiness is observed", async () => {
-    const controller = new AbortController()
-    let launches = 0
-
-    await openBrowserWhenReady("linux", "http://127.0.0.1:6056/", {
-      signal: controller.signal,
-      fetch: async () => {
-        controller.abort()
-        return { status: 200, body: null }
-      },
-      launch: () => {
-        launches += 1
-      },
-    })
-
-    expect(launches).toBe(0)
-  })
-
-  test("opener failure does not reject the readiness task", async () => {
-    await expect(
-      openBrowserWhenReady("linux", "http://127.0.0.1:6056/", {
-        fetch: async () => ({ status: 200, body: null }),
-        launch: () => {
-          throw new Error("opener failed")
-        },
+  it.effect(
+    "does not launch when interrupted after readiness is observed",
+    () =>
+      Effect.gen(function* () {
+        let fetches = 0
+        let launches = 0
+        const fiber = yield* Effect.forkChild(
+          openBrowserWhenReady("linux", "http://127.0.0.1:6056/", {
+            fetch: async () => {
+              fetches += 1
+              return { status: 200, body: null }
+            },
+            launch: () => {
+              launches += 1
+            },
+          }),
+        )
+        // Successful probe completes; fiber parks on the 1ms post-readiness
+        // sleep (TestClock). Interrupt before advancing the clock so launch
+        // never runs — Effect-native stand-in for the old AbortSignal check.
+        yield* waitForCount(() => fetches, 1)
+        yield* Effect.yieldNow
+        yield* Fiber.interrupt(fiber)
+        const exit = yield* Fiber.await(fiber)
+        expect(Exit.hasInterrupts(exit)).toBe(true)
+        expect(launches).toBe(0)
+        expect(fetches).toBe(1)
       }),
-    ).resolves.toBeUndefined()
-  })
+  )
 
-  test("polls until ready then launches once", async () => {
-    let fetches = 0
-    let launches = 0
-    await openBrowserWhenReady("linux", "http://127.0.0.1:6056/", {
-      fetch: async () => {
-        fetches += 1
-        if (fetches < 3) {
-          throw new Error("not ready")
-        }
-        return { status: 200, body: null }
-      },
-      sleep: async () => {},
-      launch: () => {
-        launches += 1
-      },
-      timeoutMs: 60_000,
-      pollIntervalMs: 1,
-    })
-    expect(fetches).toBe(3)
-    expect(launches).toBe(1)
-  })
+  it.effect("opener failure does not fail the readiness task", () =>
+    Effect.gen(function* () {
+      let fetches = 0
+      const fiber = yield* Effect.forkChild(
+        openBrowserWhenReady("linux", "http://127.0.0.1:6056/", {
+          fetch: async () => {
+            fetches += 1
+            return { status: 200, body: null }
+          },
+          launch: () => {
+            throw new Error("opener failed")
+          },
+        }),
+      )
+      yield* waitForCount(() => fetches, 1)
+      yield* Effect.yieldNow
+      yield* TestClock.adjust("1 millis")
+      yield* Fiber.join(fiber)
+    }),
+  )
+
+  it.effect("polls until ready then launches once", () =>
+    Effect.gen(function* () {
+      let fetches = 0
+      let launches = 0
+      const fiber = yield* Effect.forkChild(
+        openBrowserWhenReady("linux", "http://127.0.0.1:6056/", {
+          fetch: async () => {
+            fetches += 1
+            if (fetches < 3) {
+              throw new Error("not ready")
+            }
+            return { status: 200, body: null }
+          },
+          launch: () => {
+            launches += 1
+          },
+        }),
+      )
+      // Each spaced delay is registered only after its preceding probe
+      // Promise settles — wait for that before advancing TestClock.
+      yield* waitForCount(() => fetches, 1)
+      yield* Effect.yieldNow
+      yield* TestClock.adjust("250 millis")
+      yield* waitForCount(() => fetches, 2)
+      yield* Effect.yieldNow
+      yield* TestClock.adjust("250 millis")
+      // Third probe succeeds; advance past the post-readiness 1ms sleep.
+      yield* waitForCount(() => fetches, 3)
+      yield* Effect.yieldNow
+      yield* TestClock.adjust("1 millis")
+      yield* Fiber.join(fiber)
+      expect(fetches).toBe(3)
+      expect(launches).toBe(1)
+    }),
+  )
+
+  it.effect("gives up after the overall readiness timeout", () =>
+    Effect.gen(function* () {
+      let fetches = 0
+      let launches = 0
+      const fiber = yield* Effect.forkChild(
+        openBrowserWhenReady("linux", "http://127.0.0.1:6056/", {
+          fetch: async () => {
+            fetches += 1
+            throw new Error("never ready")
+          },
+          launch: () => {
+            launches += 1
+          },
+        }),
+      )
+      yield* waitForCount(() => fetches, 1)
+      yield* Effect.yieldNow
+      yield* TestClock.adjust("60 seconds")
+      yield* Fiber.join(fiber)
+      expect(launches).toBe(0)
+    }),
+  )
 })

--- a/apps/ready-for-agent/src/browser-open.ts
+++ b/apps/ready-for-agent/src/browser-open.ts
@@ -1,4 +1,5 @@
 import { spawn } from "node:child_process"
+import { Data, Effect, Schedule } from "effect"
 
 export type BrowserOpenEnv = Partial<
   Record<"NO_BROWSER" | "PORT", string | undefined>
@@ -6,8 +7,10 @@ export type BrowserOpenEnv = Partial<
 
 const DEFAULT_UI_PORT = 6056
 const DEFAULT_UI_HOST = "127.0.0.1"
-const DEFAULT_READY_TIMEOUT_MS = 60_000
-const DEFAULT_POLL_INTERVAL_MS = 250
+/** Overall deadline for the readiness poll (Effect.timeout). */
+const DEFAULT_READY_TIMEOUT = "60 seconds" as const
+/** Delay between failed probe attempts (Schedule.spaced). */
+const DEFAULT_POLL_INTERVAL = "250 millis" as const
 
 /** Minimal child surface used by the detached browser launcher (testable). */
 type DetachedBrowserChild = {
@@ -102,79 +105,64 @@ export const launchDetachedBrowser = (
   }
 }
 
+/** One probe attempt failed (connection refused, non-positive status, etc.). */
+class UiNotReady extends Data.TaggedError("UiNotReady")<{
+  readonly url: string
+}> {}
+
 export type OpenBrowserWhenReadyOptions = {
-  readonly signal?: AbortSignal
+  /** Override for tests; production uses `globalThis.fetch`. */
   readonly fetch?: (
     input: string,
     init?: RequestInit,
   ) => Promise<Pick<Response, "status" | "body">>
-  readonly sleep?: (ms: number) => Promise<void>
+  /** Override for tests; production uses `launchDetachedBrowser`. */
   readonly launch?: (platform: string, url: string) => void
-  readonly now?: () => number
-  readonly timeoutMs?: number
-  readonly pollIntervalMs?: number
 }
 
 /**
  * Poll until the UI URL responds, then launch the platform opener once.
  *
- * Owned by the caller: pass an `AbortSignal` (e.g. from Effect.tryPromise) so
- * the poll stops when startup completes, fails, or is interrupted. The browser
- * process itself is not canceled on abort.
+ * Best-effort by construction (`Effect.ignore`): never fails the caller.
+ * Interrupt the fiber (e.g. via `Effect.forkScoped` when the scope closes) to
+ * stop the poll — including an in-flight fetch when the probe observes the
+ * fiber's `AbortSignal`. The browser process itself is not owned or canceled.
  */
 export const openBrowserWhenReady = (
   platform: string,
   url: string,
   options: OpenBrowserWhenReadyOptions = {},
-): Promise<void> => {
-  const signal = options.signal
+): Effect.Effect<void> => {
   const fetchImpl = options.fetch ?? globalThis.fetch.bind(globalThis)
-  const sleep =
-    options.sleep ?? ((ms: number) => Bun.sleep(ms) as Promise<void>)
   const launch = options.launch ?? launchDetachedBrowser
-  const now = options.now ?? Date.now
-  const timeoutMs = options.timeoutMs ?? DEFAULT_READY_TIMEOUT_MS
-  const pollIntervalMs = options.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS
-  const deadline = now() + timeoutMs
 
-  const aborted = (): boolean => signal?.aborted === true
-
-  const poll = async (): Promise<void> => {
-    while (now() < deadline) {
-      if (aborted()) {
-        return
+  const probeUi = Effect.tryPromise({
+    try: async (signal) => {
+      const response = await fetchImpl(url, {
+        redirect: "manual",
+        signal,
+      })
+      void response.body?.cancel?.()
+      if (!(response.status > 0)) {
+        throw new Error("UI not ready")
       }
+    },
+    catch: () => new UiNotReady({ url }),
+  })
 
-      try {
-        const response = await fetchImpl(url, {
-          redirect: "manual",
-          signal,
-        })
-        void response.body?.cancel?.()
-        if (response.status > 0) {
-          if (aborted()) {
-            return
-          }
-          try {
-            launch(platform, url)
-          } catch {
-            // Opener failure is best-effort.
-          }
-          return
-        }
-      } catch {
-        if (aborted()) {
-          return
-        }
-        // Port not ready yet, or fetch aborted.
-      }
-
-      if (aborted()) {
-        return
-      }
-      await sleep(pollIntervalMs)
+  return Effect.gen(function* () {
+    yield* probeUi.pipe(
+      Effect.retry(Schedule.spaced(DEFAULT_POLL_INTERVAL)),
+      Effect.timeout(DEFAULT_READY_TIMEOUT),
+    )
+    // Clock-backed interrupt checkpoint after readiness (same role as the old
+    // post-readiness AbortSignal check). Parks on Effect Clock so a closing
+    // scope can cancel launch, and tests can assert with TestClock + interrupt.
+    yield* Effect.sleep("1 millis")
+    try {
+      launch(platform, url)
+    } catch {
+      // Opener failure is best-effort.
     }
-  }
-
-  return poll()
+  }).pipe(Effect.ignore)
 }

--- a/apps/ready-for-agent/src/services/start-harness.ts
+++ b/apps/ready-for-agent/src/services/start-harness.ts
@@ -148,14 +148,10 @@ export class StartHarness extends Context.Service<
               })
             ) {
               const url = resolveUiUrl(config.browserEnv)
-              // Best-effort: never fail start; AbortSignal cancels the poll only.
-              yield* Effect.promise(async (signal) => {
-                try {
-                  await openBrowserWhenReady(config.platform, url, { signal })
-                } catch {
-                  // Opener / poll failures must not surface as fiber failures.
-                }
-              }).pipe(Effect.forkScoped({ startImmediately: true }))
+              // Best-effort Effect (retry/timeout/ignore); scope interrupt stops the poll.
+              yield* openBrowserWhenReady(config.platform, url).pipe(
+                Effect.forkScoped({ startImmediately: true }),
+              )
             }
 
             const code = yield* spawner.exitCode(

--- a/apps/ready-for-agent/vitest.config.ts
+++ b/apps/ready-for-agent/vitest.config.ts
@@ -77,6 +77,10 @@ export default defineConfig({
     conditions: ["@ready-for-agent/source", "import", "module", "default"],
   },
   test: {
-    include: ["src/cli.test.ts", "src/services/application-config.test.ts"],
+    include: [
+      "src/browser-open.test.ts",
+      "src/cli.test.ts",
+      "src/services/application-config.test.ts",
+    ],
   },
 })


### PR DESCRIPTION
## Why

`openBrowserWhenReady` used a hand-rolled async poll loop (deadline arithmetic,
multi-point `AbortSignal` checks, injectable `sleep`/`now`/`timeoutMs` for
tests, nested try/catch). The monorepo start path then re-wrapped that Promise
in `Effect.promise` with another best-effort swallow. That shape is better
expressed with Effect retry, timeout, interruption, and `Effect.ignore`.

## What changed

- Rewrote `openBrowserWhenReady` as an Effect: probe via `tryPromise` (fiber
  `AbortSignal` aborts in-flight fetch) → `retry(Schedule.spaced("250 millis"))`
  → `timeout("60 seconds")` → short interruptible post-readiness sleep → sync
  best-effort launch → `Effect.ignore`.
- `start-harness` forks the Effect with `Effect.forkScoped` (no Promise
  wrapper); scope close still cancels the poll only; the browser process stays
  detached.
- Dropped time/`AbortSignal` injection; tests use `@effect/vitest` +
  `TestClock` and `Fiber.interrupt`, with wait-for-count barriers before clock
  advances.
- `UiNotReady` is an internal `Data.TaggedError` retry token.
- `launchDetachedBrowser` remains synchronous fire-and-forget (unchanged
  ownership model). Harness sibling `browser-open` is out of scope.

## Verification

- `apps/ready-for-agent` Vitest suite for `browser-open.test.ts` (16 tests)
- Biome clean on touched files
- Full package smoke that needs generate-embed/host binary was not the gate for
  this change; host-binary failure in a dirty worktree was pre-existing missing
  generated assets, unrelated to this rewrite

Closes #717