### PR TITLE
feat(harness): pot-belly furnace route-line stops with lane-transition animation

### DIFF
--- a/apps/harness/src/kanban-board.tsx
+++ b/apps/harness/src/kanban-board.tsx
@@ -15,6 +15,7 @@ import {
   type PipelineLaneId,
   pipelineLaneFor,
 } from "./pipeline-lanes.js"
+import { PipelineRoute } from "./pipeline-route.js"
 import {
   JOBS_FAILED_LIMIT,
   JobsCardSkeleton,
@@ -376,28 +377,7 @@ function KanbanJobsBoard() {
           ))}
         </fieldset>
         <section className={ui.pipelineBoard} aria-label="Lifecycle pipeline">
-          <div className={ui.pipelineRoute}>
-            {PIPELINE_LANES.map((lane) => {
-              const count = laneItems.get(lane.id)?.length ?? 0
-              return (
-                <span
-                  className={ui.laneRoundel}
-                  data-lane={lane.id}
-                  key={lane.id}
-                  role="img"
-                  aria-label={`${count} jobs in ${lane.label}`}
-                  style={
-                    {
-                      "--lane-color": lane.color,
-                      "--lane-text": lane.text,
-                    } as CSSProperties
-                  }
-                >
-                  {count}
-                </span>
-              )
-            })}
-          </div>
+          <PipelineRoute laneItems={laneItems} />
           <div className={ui.pipelineLanes}>
             {PIPELINE_LANES.map((lane) => {
               const items = laneItems.get(lane.id) ?? []

--- a/apps/harness/src/pipeline-route-transition.ts
+++ b/apps/harness/src/pipeline-route-transition.ts
@@ -1,0 +1,264 @@
+import { PIPELINE_LANES, type PipelineLaneId } from "./pipeline-lanes.js"
+
+/** Work-item id → current pipeline lane. */
+export type LaneAssignment = ReadonlyMap<string, PipelineLaneId>
+
+export type PlannedTransition = {
+  readonly workItemId: string
+  readonly from: PipelineLaneId
+  readonly to: PipelineLaneId
+}
+
+/**
+ * Phases of a route-line furnace handoff. Destination display count stays
+ * delayed until the flight is removed after `absorb` finishes.
+ */
+export type FlightPhase = "eject" | "travel" | "enter" | "absorb"
+
+export type RouteFlight = {
+  readonly id: string
+  readonly workItemId: string
+  readonly from: PipelineLaneId
+  readonly to: PipelineLaneId
+  readonly phase: FlightPhase
+}
+
+/** Choreography durations (ms). Kept modest so multi-step moves stay legible. */
+export const ROUTE_TRANSITION_MS = {
+  eject: 320,
+  travel: 700,
+  enter: 280,
+  absorb: 450,
+} as const satisfies Record<FlightPhase, number>
+
+/** Brief post-absorb “fed” glow on the destination furnace. */
+export const ROUTE_FED_MS = 300
+
+/**
+ * Stack smoke duration (ms). Shared for eject and absorb — a short puff while
+ * the furnace is active, not a distinct light/heavy pair.
+ */
+export const ROUTE_SMOKE_MS = ROUTE_TRANSITION_MS.absorb
+
+export const ROUTE_TRANSITION_TOTAL_MS =
+  ROUTE_TRANSITION_MS.eject +
+  ROUTE_TRANSITION_MS.travel +
+  ROUTE_TRANSITION_MS.enter +
+  ROUTE_TRANSITION_MS.absorb
+
+const LANE_INDEX = new Map<PipelineLaneId, number>(
+  PIPELINE_LANES.map((lane, index) => [lane.id, index]),
+)
+
+/** Content equality for work-item → lane maps (ignores Map identity). */
+export function assignmentsEqual(
+  left: LaneAssignment,
+  right: LaneAssignment,
+): boolean {
+  if (left.size !== right.size) return false
+  for (const [workItemId, lane] of left) {
+    if (right.get(workItemId) !== lane) return false
+  }
+  return true
+}
+
+/**
+ * Diff previous vs next work-item lane maps. Only items present in both with a
+ * changed lane become transitions. Appearances and disappearances are silent
+ * (counts snap with the data — no traveler).
+ */
+export function planLaneTransitions(
+  previous: LaneAssignment,
+  next: LaneAssignment,
+): readonly PlannedTransition[] {
+  const planned: PlannedTransition[] = []
+  for (const [workItemId, to] of next) {
+    const from = previous.get(workItemId)
+    if (from === undefined || from === to) continue
+    planned.push({ workItemId, from, to })
+  }
+  return planned
+}
+
+/**
+ * Build a work-item → lane map from per-lane item lists (kanban board shape).
+ */
+export function laneAssignmentFromLaneItems(
+  laneItems: ReadonlyMap<PipelineLaneId, readonly { readonly id: string }[]>,
+): Map<string, PipelineLaneId> {
+  const assignment = new Map<string, PipelineLaneId>()
+  for (const [laneId, items] of laneItems) {
+    for (const item of items) {
+      assignment.set(item.id, laneId)
+    }
+  }
+  return assignment
+}
+
+/**
+ * Stable content fingerprint for lane item lists (ids + lanes). Ignores Map
+ * identity so React memos/effects do not thrash when the parent rebuilds Maps.
+ */
+export function laneItemsAssignmentKey(
+  laneItems: ReadonlyMap<PipelineLaneId, readonly { readonly id: string }[]>,
+): string {
+  const parts: string[] = []
+  for (const [laneId, items] of laneItems) {
+    for (const item of items) {
+      parts.push(`${item.id}:${laneId}`)
+    }
+  }
+  parts.sort()
+  return parts.join("|")
+}
+
+/**
+ * True per-lane counts from lane item lists.
+ */
+export function trueLaneCounts(
+  laneItems: ReadonlyMap<PipelineLaneId, readonly unknown[]>,
+): Map<PipelineLaneId, number> {
+  const counts = new Map<PipelineLaneId, number>()
+  for (const lane of PIPELINE_LANES) {
+    counts.set(lane.id, laneItems.get(lane.id)?.length ?? 0)
+  }
+  return counts
+}
+
+/**
+ * How many in-flight travelers are still waiting to be absorbed into `lane`.
+ * While a flight is active its work item already lives in `to` in real data,
+ * so the destination display must subtract these until absorb completes.
+ */
+export function countPendingArrivals(
+  flights: readonly Pick<RouteFlight, "to">[],
+  lane: PipelineLaneId,
+): number {
+  let count = 0
+  for (const flight of flights) {
+    if (flight.to === lane) count += 1
+  }
+  return count
+}
+
+/**
+ * Presentation count for one stop. Never negative. Source already matches true
+ * data when the traveler left; only destination is delayed.
+ */
+export function displayLaneCount(args: {
+  readonly trueCount: number
+  readonly pendingArrivals: number
+}): number {
+  return Math.max(0, args.trueCount - args.pendingArrivals)
+}
+
+/**
+ * Display counts for every pipeline lane given true counts and active flights.
+ */
+export function displayLaneCounts(
+  trueCounts: ReadonlyMap<PipelineLaneId, number>,
+  flights: readonly Pick<RouteFlight, "to">[],
+): Map<PipelineLaneId, number> {
+  const pendingByLane = new Map<PipelineLaneId, number>()
+  for (const flight of flights) {
+    pendingByLane.set(flight.to, (pendingByLane.get(flight.to) ?? 0) + 1)
+  }
+  const display = new Map<PipelineLaneId, number>()
+  for (const lane of PIPELINE_LANES) {
+    const trueCount = trueCounts.get(lane.id) ?? 0
+    const pending = pendingByLane.get(lane.id) ?? 0
+    display.set(
+      lane.id,
+      displayLaneCount({ trueCount, pendingArrivals: pending }),
+    )
+  }
+  return display
+}
+
+/**
+ * Horizontal center of a stop on the six-column route, as a percentage of the
+ * route width (matches CSS grid column midpoints).
+ */
+export function laneCenterPercent(laneId: PipelineLaneId): number {
+  const index = LANE_INDEX.get(laneId)
+  if (index === undefined) return 0
+  return ((index + 0.5) / PIPELINE_LANES.length) * 100
+}
+
+/**
+ * Advance a flight to the next phase, or `null` when absorb is done and the
+ * flight should be removed (destination count may then catch up).
+ */
+export function nextFlightPhase(phase: FlightPhase): FlightPhase | null {
+  switch (phase) {
+    case "eject":
+      return "travel"
+    case "travel":
+      return "enter"
+    case "enter":
+      return "absorb"
+    case "absorb":
+      return null
+    default: {
+      const _exhaustive: never = phase
+      return _exhaustive
+    }
+  }
+}
+
+/** Duration of the current phase in ms. */
+export function phaseDurationMs(phase: FlightPhase): number {
+  return ROUTE_TRANSITION_MS[phase]
+}
+
+/**
+ * Reconcile in-flight travelers with the latest assignment.
+ *
+ * - Drop flights whose work item vanished or already sits somewhere other than
+ *   the flight destination (mid-flight replan would be wrong to keep).
+ * - Return planned transitions for new lane changes, skipping work items that
+ *   already have an active flight to the same destination.
+ */
+export function reconcileFlights(args: {
+  readonly previous: LaneAssignment
+  readonly next: LaneAssignment
+  readonly flights: readonly RouteFlight[]
+}): {
+  readonly flights: readonly RouteFlight[]
+  readonly newTransitions: readonly PlannedTransition[]
+} {
+  const kept: RouteFlight[] = []
+  const activeWorkItems = new Set<string>()
+  for (const flight of args.flights) {
+    const current = args.next.get(flight.workItemId)
+    if (current === undefined) continue
+    if (current !== flight.to) continue
+    kept.push(flight)
+    activeWorkItems.add(flight.workItemId)
+  }
+
+  const planned = planLaneTransitions(args.previous, args.next)
+  const newTransitions = planned.filter(
+    (transition) => !activeWorkItems.has(transition.workItemId),
+  )
+
+  return { flights: kept, newTransitions }
+}
+
+let flightSeq = 0
+
+/** Stable-enough unique id for a route flight (client-only presentation). */
+export function createFlightId(workItemId: string): string {
+  flightSeq += 1
+  return `route-flight-${flightSeq}-${workItemId}`
+}
+
+export function createRouteFlight(transition: PlannedTransition): RouteFlight {
+  return {
+    id: createFlightId(transition.workItemId),
+    workItemId: transition.workItemId,
+    from: transition.from,
+    to: transition.to,
+    phase: "eject",
+  }
+}

--- a/apps/harness/src/pipeline-route-transition.ts
+++ b/apps/harness/src/pipeline-route-transition.ts
@@ -248,7 +248,7 @@ export function reconcileFlights(args: {
 let flightSeq = 0
 
 /** Stable-enough unique id for a route flight (client-only presentation). */
-export function createFlightId(workItemId: string): string {
+function createFlightId(workItemId: string): string {
   flightSeq += 1
   return `route-flight-${flightSeq}-${workItemId}`
 }

--- a/apps/harness/src/pipeline-route.tsx
+++ b/apps/harness/src/pipeline-route.tsx
@@ -1,0 +1,321 @@
+import { type CSSProperties, useEffect, useMemo, useRef, useState } from "react"
+import { PIPELINE_LANES, type PipelineLaneId } from "./pipeline-lanes.js"
+import {
+  type FlightPhase,
+  ROUTE_FED_MS,
+  ROUTE_SMOKE_MS,
+  ROUTE_TRANSITION_MS,
+  type RouteFlight,
+  assignmentsEqual,
+  createRouteFlight,
+  displayLaneCounts,
+  laneAssignmentFromLaneItems,
+  laneCenterPercent,
+  laneItemsAssignmentKey,
+  nextFlightPhase,
+  phaseDurationMs,
+  reconcileFlights,
+  trueLaneCounts,
+} from "./pipeline-route-transition.js"
+import { cx, ui } from "./ui.js"
+
+function prefersReducedMotion(): boolean {
+  if (typeof window === "undefined" || !("matchMedia" in window)) {
+    return false
+  }
+  return window.matchMedia("(prefers-reduced-motion: reduce)").matches
+}
+
+type FurnacePhase = FlightPhase | "fed" | "idle"
+
+function furnacePhaseForLane(
+  laneId: PipelineLaneId,
+  flights: readonly RouteFlight[],
+  fedLanes: ReadonlySet<PipelineLaneId>,
+): FurnacePhase {
+  for (const flight of flights) {
+    if (flight.from === laneId && flight.phase === "eject") return "eject"
+    if (flight.to === laneId && flight.phase === "absorb") return "absorb"
+  }
+  if (fedLanes.has(laneId)) return "fed"
+  return "idle"
+}
+
+function smokeActiveForLane(
+  laneId: PipelineLaneId,
+  flights: readonly RouteFlight[],
+): boolean {
+  for (const flight of flights) {
+    if (flight.from === laneId && flight.phase === "eject") return true
+    if (flight.to === laneId && flight.phase === "absorb") return true
+  }
+  return false
+}
+
+/** Inline furnace phase animation so durations track ROUTE_*_MS constants. */
+function furnacePhaseStyle(phase: FurnacePhase): CSSProperties | undefined {
+  if (phase === "eject") {
+    return {
+      animation: `furnace-eject ${ROUTE_TRANSITION_MS.eject}ms ease-out`,
+    }
+  }
+  if (phase === "absorb") {
+    return {
+      animation: `furnace-absorb ${ROUTE_TRANSITION_MS.absorb}ms ease-out`,
+    }
+  }
+  if (phase === "fed") {
+    return {
+      animation: `furnace-fed ${ROUTE_FED_MS}ms ease-out`,
+    }
+  }
+  return undefined
+}
+
+/**
+ * Desktop route line: pot-belly furnace stops with optional coal-lump traveler
+ * when a work item changes pipeline lane. Presentation only — real counts come
+ * from `laneItems`; destination display is delayed until absorb finishes.
+ */
+export function PipelineRoute({
+  laneItems,
+}: {
+  readonly laneItems: ReadonlyMap<
+    PipelineLaneId,
+    readonly { readonly id: string }[]
+  >
+}) {
+  const [flights, setFlights] = useState<readonly RouteFlight[]>([])
+  const [fedLanes, setFedLanes] = useState<ReadonlySet<PipelineLaneId>>(
+    () => new Set(),
+  )
+  const assignmentRef = useRef<Map<string, PipelineLaneId> | null>(null)
+  const flightsRef = useRef(flights)
+  flightsRef.current = flights
+  const phaseTimersRef = useRef(
+    new Map<string, ReturnType<typeof setTimeout>>(),
+  )
+  const fedTimersRef = useRef(
+    new Map<PipelineLaneId, ReturnType<typeof setTimeout>>(),
+  )
+
+  // Fingerprint ignores Map identity from the parent rebuilding laneItems.
+  const assignmentKey = laneItemsAssignmentKey(laneItems)
+  const laneSnapshotRef = useRef<{
+    key: string
+    assignment: Map<string, PipelineLaneId>
+    counts: Map<PipelineLaneId, number>
+  } | null>(null)
+  if (
+    laneSnapshotRef.current === null ||
+    laneSnapshotRef.current.key !== assignmentKey
+  ) {
+    laneSnapshotRef.current = {
+      key: assignmentKey,
+      assignment: laneAssignmentFromLaneItems(laneItems),
+      counts: trueLaneCounts(laneItems),
+    }
+  }
+  const nextAssignment = laneSnapshotRef.current.assignment
+  const trueCounts = laneSnapshotRef.current.counts
+
+  // Seed baseline on first paint; subsequent diffs schedule travelers.
+  useEffect(() => {
+    if (assignmentRef.current === null) {
+      assignmentRef.current = nextAssignment
+      return
+    }
+
+    if (assignmentsEqual(assignmentRef.current, nextAssignment)) {
+      return
+    }
+
+    if (prefersReducedMotion()) {
+      assignmentRef.current = nextAssignment
+      setFlights((current) => (current.length === 0 ? current : []))
+      return
+    }
+
+    const { flights: kept, newTransitions } = reconcileFlights({
+      previous: assignmentRef.current,
+      next: nextAssignment,
+      flights: flightsRef.current,
+    })
+    assignmentRef.current = nextAssignment
+
+    if (newTransitions.length === 0) {
+      if (kept.length !== flightsRef.current.length) {
+        setFlights(kept)
+      }
+      return
+    }
+
+    const created = newTransitions.map(createRouteFlight)
+    setFlights([...kept, ...created])
+  }, [nextAssignment])
+
+  // Advance each flight through eject → travel → enter → absorb → remove.
+  useEffect(() => {
+    for (const flight of flights) {
+      if (phaseTimersRef.current.has(flight.id)) continue
+      const scheduledPhase = flight.phase
+      const timer = setTimeout(() => {
+        phaseTimersRef.current.delete(flight.id)
+        // Skip if reconcile cancelled the flight or phase already advanced.
+        const live = flightsRef.current.find(
+          (candidate) => candidate.id === flight.id,
+        )
+        if (live === undefined || live.phase !== scheduledPhase) return
+
+        const next = nextFlightPhase(scheduledPhase)
+        if (next === null) {
+          setFlights((current) =>
+            current.filter((candidate) => candidate.id !== flight.id),
+          )
+          setFedLanes((current) => {
+            const nextSet = new Set(current)
+            nextSet.add(flight.to)
+            return nextSet
+          })
+          const existingFed = fedTimersRef.current.get(flight.to)
+          if (existingFed !== undefined) clearTimeout(existingFed)
+          const fedTimer = setTimeout(() => {
+            fedTimersRef.current.delete(flight.to)
+            setFedLanes((current) => {
+              if (!current.has(flight.to)) return current
+              const nextSet = new Set(current)
+              nextSet.delete(flight.to)
+              return nextSet
+            })
+          }, ROUTE_FED_MS)
+          fedTimersRef.current.set(flight.to, fedTimer)
+          return
+        }
+        setFlights((current) =>
+          current.map((candidate) =>
+            candidate.id === flight.id
+              ? { ...candidate, phase: next }
+              : candidate,
+          ),
+        )
+      }, phaseDurationMs(scheduledPhase))
+      phaseTimersRef.current.set(flight.id, timer)
+    }
+
+    // Drop timers for flights that were cancelled/reconciled away.
+    for (const [flightId, timer] of phaseTimersRef.current) {
+      if (flights.some((flight) => flight.id === flightId)) continue
+      clearTimeout(timer)
+      phaseTimersRef.current.delete(flightId)
+    }
+  }, [flights])
+
+  useEffect(() => {
+    return () => {
+      for (const timer of phaseTimersRef.current.values()) clearTimeout(timer)
+      phaseTimersRef.current.clear()
+      for (const timer of fedTimersRef.current.values()) clearTimeout(timer)
+      fedTimersRef.current.clear()
+    }
+  }, [])
+
+  const displayCounts = useMemo(
+    () => displayLaneCounts(trueCounts, flights),
+    [trueCounts, flights],
+  )
+
+  return (
+    <div className={ui.pipelineRoute}>
+      {PIPELINE_LANES.map((lane) => {
+        const count = displayCounts.get(lane.id) ?? 0
+        const phase = furnacePhaseForLane(lane.id, flights, fedLanes)
+        const smokeActive = smokeActiveForLane(lane.id, flights)
+        const phaseMotion = furnacePhaseStyle(phase)
+        return (
+          <span
+            className={ui.laneRoundel}
+            data-lane={lane.id}
+            data-phase={phase === "idle" ? undefined : phase}
+            key={lane.id}
+            role="img"
+            aria-label={`${count} jobs in ${lane.label}`}
+            style={
+              {
+                "--lane-color": lane.color,
+                "--lane-text": lane.text,
+                ...phaseMotion,
+              } as CSSProperties
+            }
+          >
+            <span className={ui.laneFurnaceStack} aria-hidden="true" />
+            <span
+              className={ui.laneFurnaceBody}
+              data-lane={lane.id}
+              aria-hidden="true"
+            >
+              <span className={ui.laneFurnaceCount}>{count}</span>
+              <span className={ui.laneFurnaceMouth} />
+              <span
+                className={ui.laneFurnaceGlow}
+                data-lit={count > 0 ? "true" : "false"}
+              />
+            </span>
+            <span
+              className={ui.laneFurnaceSmoke}
+              data-active={smokeActive ? "true" : "false"}
+              aria-hidden="true"
+              style={
+                smokeActive
+                  ? {
+                      animation: `furnace-smoke ${ROUTE_SMOKE_MS}ms ease-out forwards`,
+                    }
+                  : undefined
+              }
+            >
+              <span className={ui.laneFurnaceSmokePuff} aria-hidden="true" />
+              <span className={ui.laneFurnaceSmokePuffAlt} aria-hidden="true" />
+            </span>
+          </span>
+        )
+      })}
+      {flights.map((flight) => (
+        <RouteTraveler key={flight.id} flight={flight} />
+      ))}
+    </div>
+  )
+}
+
+function RouteTraveler({ flight }: { readonly flight: RouteFlight }) {
+  const from = laneCenterPercent(flight.from)
+  const to = laneCenterPercent(flight.to)
+  const style: CSSProperties & Record<string, string | number> = {
+    "--travel-from": `${from}%`,
+    "--travel-to": `${to}%`,
+  }
+
+  if (flight.phase === "eject") {
+    style.left = `${from}%`
+    style.animation = `route-traveler-eject ${ROUTE_TRANSITION_MS.eject}ms ease-out forwards`
+  } else if (flight.phase === "travel") {
+    style.left = `${from}%`
+    style.animation = `route-travel ${ROUTE_TRANSITION_MS.travel}ms ease-in-out forwards`
+  } else if (flight.phase === "enter") {
+    style.left = `${to}%`
+    style.animation = `route-traveler-enter ${ROUTE_TRANSITION_MS.enter}ms ease-in forwards`
+  } else {
+    // Absorb: traveler already swallowed; hide.
+    style.left = `${to}%`
+    style.opacity = 0
+  }
+
+  return (
+    <span
+      className={cx(ui.routeTraveler)}
+      style={style}
+      aria-hidden="true"
+      data-phase={flight.phase}
+      data-from={flight.from}
+      data-to={flight.to}
+    />
+  )
+}

--- a/apps/harness/src/styles.css
+++ b/apps/harness/src/styles.css
@@ -267,6 +267,103 @@
   }
 }
 
+/*
+ * Pipeline route-line furnace choreography (issue #737).
+ * Longer motion is intentional for lane changes only; plate transitions stay 120ms.
+ * Honored by the global prefers-reduced-motion base rule (durations collapse).
+ */
+@keyframes furnace-eject {
+  0% {
+    transform: scale(1);
+  }
+  35% {
+    transform: scale(0.92, 1.06);
+  }
+  70% {
+    transform: scale(1.06, 0.94);
+  }
+  100% {
+    transform: scale(1);
+  }
+}
+
+@keyframes furnace-absorb {
+  0% {
+    transform: scale(1);
+  }
+  25% {
+    transform: scale(0.94, 1.04);
+  }
+  55% {
+    transform: scale(1.08, 0.92);
+  }
+  80% {
+    transform: scale(0.98, 1.03);
+  }
+  100% {
+    transform: scale(1);
+  }
+}
+
+@keyframes furnace-fed {
+  0% {
+    filter: brightness(1);
+  }
+  40% {
+    filter: brightness(1.18);
+  }
+  100% {
+    filter: brightness(1);
+  }
+}
+
+@keyframes furnace-smoke {
+  0% {
+    opacity: 0;
+    transform: translate(-50%, 0.15rem) scale(0.4);
+  }
+  25% {
+    opacity: 0.55;
+  }
+  100% {
+    opacity: 0;
+    transform: translate(-50%, -0.7rem) scale(1.15);
+  }
+}
+
+@keyframes route-travel {
+  from {
+    left: var(--travel-from);
+    transform: translate(-50%, -50%) scale(1);
+  }
+  to {
+    left: var(--travel-to);
+    transform: translate(-50%, -50%) scale(1);
+  }
+}
+
+@keyframes route-traveler-eject {
+  from {
+    transform: translate(-50%, -50%) scale(0.25);
+    opacity: 0.4;
+  }
+  to {
+    transform: translate(-50%, -50%) scale(1);
+    opacity: 1;
+  }
+}
+
+@keyframes route-traveler-enter {
+  from {
+    transform: translate(-50%, -50%) scale(1);
+    opacity: 1;
+  }
+  to {
+    transform: translate(-50%, -50%) scale(0.2);
+    opacity: 0.35;
+  }
+}
+
 /* Native <dialog> backdrop — no Tailwind equivalent for ::backdrop on dialog */
 @utility dialog-backdrop {
   &::backdrop {

--- a/apps/harness/src/ui.ts
+++ b/apps/harness/src/ui.ts
@@ -540,14 +540,78 @@ export const ui = {
   pipelineBoard:
     "mt-[1.6rem] grid gap-[0.55rem] max-[900px]:mt-[0.85rem] max-[900px]:gap-0",
 
+  /**
+   * Route spine + pot-belly furnace stops. Spine is centered on the furnace
+   * belly (not the stack). Stack sits above; mouth hangs on the belly bottom.
+   */
   pipelineRoute:
-    "relative grid min-h-[2.1rem] grid-cols-6 items-center before:pointer-events-none before:absolute before:top-1/2 before:right-[calc(100%/12)] before:left-[calc(100%/12)] before:h-1 before:-translate-y-1/2 before:bg-ink before:content-[''] max-[900px]:hidden",
+    "relative grid min-h-[3.1rem] grid-cols-6 items-end pb-[0.15rem] before:pointer-events-none before:absolute before:top-[calc(100%-1.2rem)] before:right-[calc(100%/12)] before:left-[calc(100%/12)] before:h-1 before:-translate-y-1/2 before:bg-ink before:content-[''] max-[900px]:hidden",
 
-  laneRoundel: cx(
-    "relative z-[1] mx-auto grid h-[2.1rem] min-w-[2.1rem] place-items-center rounded-full",
-    "border-2 border-ink bg-[var(--lane-color)] px-[0.4rem]",
+  /**
+   * Pot-belly furnace stop (idle + animated phases via data-phase).
+   * Outer shell keeps accessible name; chrome is aria-hidden.
+   * Phase motion durations are applied from ROUTE_TRANSITION_MS / ROUTE_FED_MS
+   * in pipeline-route.tsx (inline style) so JS timers and CSS stay lockstep.
+   */
+  laneRoundel:
+    "lane-furnace relative z-[1] mx-auto grid w-[2.1rem] justify-items-center",
+
+  laneFurnaceStack: cx(
+    "relative z-[2] mb-[-1px] h-[0.55rem] w-[0.42rem]",
+    "rounded-t-[1px] border border-b-0 border-[#2a2a2a] bg-[#3a3a3a]",
+    "before:absolute before:-top-[0.18rem] before:left-1/2 before:h-[0.2rem] before:w-[0.62rem]",
+    "before:-translate-x-1/2 before:rounded-[1px] before:border before:border-[#2a2a2a]",
+    "before:bg-[linear-gradient(180deg,#c9a227_0%,#8a7018_100%)] before:content-['']",
+  ),
+
+  laneFurnaceBody: cx(
+    "relative grid h-[2.1rem] w-[2.1rem] place-items-center rounded-full",
+    "border-2 border-ink bg-[var(--lane-color)]",
     "font-mono text-[0.78rem] font-extrabold leading-none tracking-[0.02em] tabular-nums text-[var(--lane-text,#fff)]",
     "data-[lane=complete]:border-white data-[lane=complete]:outline data-[lane=complete]:outline-2 data-[lane=complete]:outline-ink",
+  ),
+
+  laneFurnaceCount: "relative z-[1] tabular-nums",
+
+  /** Dark firebox mouth at the bottom of the belly — traveler enter/exit. */
+  laneFurnaceMouth: cx(
+    "pointer-events-none absolute bottom-[0.12rem] left-1/2 z-[2] h-[0.38rem] w-[0.72rem]",
+    "-translate-x-1/2 rounded-[50%] border border-[#1a1a1a] bg-[#1a1a1a]",
+    "shadow-[inset_0_1px_0_rgb(255_255_255/0.08)]",
+  ),
+
+  /** Coal glow in the mouth when the stop holds jobs. */
+  laneFurnaceGlow: cx(
+    "pointer-events-none absolute bottom-[0.16rem] left-1/2 z-[3] h-[0.22rem] w-[0.42rem]",
+    "-translate-x-1/2 rounded-[50%] bg-[radial-gradient(ellipse_at_center,#ff8a2a_0%,#ff4d1c_45%,transparent_75%)]",
+    "opacity-0 data-[lit=true]:opacity-90",
+  ),
+
+  /**
+   * Stack smoke host. Duration applied from ROUTE_SMOKE_MS in pipeline-route
+   * when data-active; shared puff for eject and absorb.
+   */
+  laneFurnaceSmoke: cx(
+    "pointer-events-none absolute -top-[0.35rem] left-1/2 z-[3] h-[0.9rem] w-[0.7rem]",
+    "-translate-x-1/2 opacity-0",
+  ),
+
+  laneFurnaceSmokePuff: cx(
+    "absolute bottom-0 left-1/2 h-[0.35rem] w-[0.35rem] -translate-x-1/2",
+    "rounded-full bg-[rgb(80_80_80/0.45)]",
+  ),
+
+  laneFurnaceSmokePuffAlt: cx(
+    "absolute bottom-[0.15rem] left-[35%] h-[0.28rem] w-[0.28rem]",
+    "rounded-full bg-[rgb(100_100_100/0.35)]",
+  ),
+
+  /** Coal-lump traveler rolling along the route spine. */
+  routeTraveler: cx(
+    "pointer-events-none absolute top-[calc(100%-1.2rem)] z-[4] h-[0.55rem] w-[0.55rem]",
+    "-translate-x-1/2 -translate-y-1/2 rounded-[45%_40%_50%_42%]",
+    "border border-[#2a1a0a] bg-[radial-gradient(circle_at_30%_30%,#5a3a1a_0%,#2a1808_70%,#1a1005_100%)]",
+    "shadow-[inset_1px_1px_0_rgb(255_255_255/0.12)]",
   ),
 
   pipelineLanes:
@@ -952,9 +1016,10 @@ export const ui = {
  *    — ::backdrop is not available as a Tailwind variant on the dialog element
  *      in a portable way; keep in styles.css.
  *
- * 2. @keyframes skeleton-pulse
+ * 2. @keyframes skeleton-pulse, furnace-*, route-travel, route-traveler-*
  *    — Keyframes stay in styles.css; utilities reference
- *      animate-[skeleton-pulse_1.2s_ease-in-out_infinite].
+ *      animate-[skeleton-pulse_1.2s_ease-in-out_infinite]. Furnace / traveler
+ *      motion for #737 uses inline style.animation with ROUTE_*_MS durations.
  *
  * 3. Parent-only BEM modifiers that only style descendants
  *    (banner--alarm / banner--guidance → .banner-tag):

--- a/apps/harness/test/kanban-route.test.ts
+++ b/apps/harness/test/kanban-route.test.ts
@@ -140,13 +140,28 @@ describe("kanban home board", () => {
 
   test("renders all six lifecycle lanes as an accessible pipeline", () => {
     const source = boardSource()
+    const route = readFileSync(
+      join(import.meta.dir, "../src/pipeline-route.tsx"),
+      "utf8",
+    )
     expect(source).toContain('aria-label="Lifecycle pipeline"')
     expect(source).toContain("pipelineLaneFor(workItem)")
     expect(source).toContain("Lane clear")
-    // Mobile switcher + route roundel aria-label + lane header each use {lane.label}.
-    expect(source.match(/\{lane\.label\}/g)).toHaveLength(3)
-    expect(source).toContain("ui.pipelineRoute")
-    expect(source).toContain("ui.laneRoundel")
+    // Mobile switcher + lane header use {lane.label}; route furnaces live in
+    // PipelineRoute (also {lane.label} in accessible names).
+    expect(source.match(/\{lane\.label\}/g)).toHaveLength(2)
+    expect(source).toContain("<PipelineRoute")
+    expect(source).toContain('from "./pipeline-route.js"')
+    expect(route).toContain("ui.pipelineRoute")
+    expect(route).toContain("ui.laneRoundel")
+    expect(route).toContain("ui.laneFurnaceStack")
+    expect(route).toContain("ui.laneFurnaceMouth")
+    expect(route).toContain("ui.laneFurnaceSmokePuff")
+    expect(route).toContain("laneItemsAssignmentKey")
+    expect(route).toContain("ROUTE_FED_MS")
+    expect(route).toContain("ROUTE_SMOKE_MS")
+    expect(route).toMatch(/jobs in \$\{lane\.label\}/)
+    expect(route).toContain("prefers-reduced-motion")
     expect(source).toContain("ui.laneHeader")
     expect(source).toContain("ui.laneTitle")
     expect(source).not.toContain("lane-number")
@@ -446,6 +461,19 @@ describe("kanban home board", () => {
     // Route spine uses before: pseudo utilities.
     expect(ui).toMatch(/pipelineRoute:[\s\S]*?before:/)
     expect(ui).toContain("laneRoundel:")
+    // Pot-belly furnace chrome (issue #737).
+    expect(ui).toContain("laneFurnaceStack:")
+    expect(ui).toContain("laneFurnaceBody:")
+    expect(ui).toContain("laneFurnaceMouth:")
+    expect(ui).toContain("laneFurnaceGlow:")
+    expect(ui).toContain("laneFurnaceSmokePuff:")
+    expect(ui).toContain("laneFurnaceSmokePuffAlt:")
+    expect(ui).toContain("routeTraveler:")
+    // Phase durations come from ROUTE_*_MS via inline style, not Tailwind literals.
+    expect(ui).toContain("ROUTE_TRANSITION_MS")
+    expect(stylesSource()).toContain("@keyframes furnace-eject")
+    expect(stylesSource()).toContain("@keyframes furnace-absorb")
+    expect(stylesSource()).toContain("@keyframes route-travel")
     expect(ui).toContain("pipelineLanes:")
     expect(ui).toContain("grid-cols-6")
     expect(ui).toContain("gap-0.5")

--- a/apps/harness/test/pipeline-route-transition.test.ts
+++ b/apps/harness/test/pipeline-route-transition.test.ts
@@ -1,0 +1,313 @@
+import { PIPELINE_LANES, type PipelineLaneId } from "../src/pipeline-lanes.js"
+import {
+  ROUTE_FED_MS,
+  ROUTE_SMOKE_MS,
+  ROUTE_TRANSITION_MS,
+  ROUTE_TRANSITION_TOTAL_MS,
+  type RouteFlight,
+  assignmentsEqual,
+  countPendingArrivals,
+  createRouteFlight,
+  displayLaneCount,
+  displayLaneCounts,
+  laneAssignmentFromLaneItems,
+  laneCenterPercent,
+  laneItemsAssignmentKey,
+  nextFlightPhase,
+  phaseDurationMs,
+  planLaneTransitions,
+  reconcileFlights,
+  trueLaneCounts,
+} from "../src/pipeline-route-transition.js"
+import { describe, expect, test } from "bun:test"
+
+const assignment = (
+  entries: readonly (readonly [string, PipelineLaneId])[],
+): Map<string, PipelineLaneId> => new Map(entries)
+
+describe("assignmentsEqual", () => {
+  test("compares content, not Map identity", () => {
+    const left = assignment([["a", "build"]])
+    const right = assignment([["a", "build"]])
+    expect(left).not.toBe(right)
+    expect(assignmentsEqual(left, right)).toBe(true)
+    expect(assignmentsEqual(left, assignment([["a", "review"]]))).toBe(false)
+    expect(assignmentsEqual(left, assignment([]))).toBe(false)
+  })
+})
+
+describe("planLaneTransitions", () => {
+  test("returns empty when assignments are identical", () => {
+    const map = assignment([
+      ["a", "build"],
+      ["b", "review"],
+    ])
+    expect(planLaneTransitions(map, map)).toEqual([])
+  })
+
+  test("plans a single Build → Review move", () => {
+    const previous = assignment([["job-1", "build"]])
+    const next = assignment([["job-1", "review"]])
+    expect(planLaneTransitions(previous, next)).toEqual([
+      { workItemId: "job-1", from: "build", to: "review" },
+    ])
+  })
+
+  test("plans non-adjacent moves without inventing intermediate stops", () => {
+    const previous = assignment([["job-1", "build"]])
+    const next = assignment([["job-1", "pr"]])
+    expect(planLaneTransitions(previous, next)).toEqual([
+      { workItemId: "job-1", from: "build", to: "pr" },
+    ])
+  })
+
+  test("plans multiple concurrent moves", () => {
+    const previous = assignment([
+      ["a", "build"],
+      ["b", "build"],
+      ["c", "review"],
+    ])
+    const next = assignment([
+      ["a", "review"],
+      ["b", "review"],
+      ["c", "pr"],
+    ])
+    expect(planLaneTransitions(previous, next)).toEqual([
+      { workItemId: "a", from: "build", to: "review" },
+      { workItemId: "b", from: "build", to: "review" },
+      { workItemId: "c", from: "review", to: "pr" },
+    ])
+  })
+
+  test("ignores items that only appear or only disappear", () => {
+    const previous = assignment([
+      ["gone", "build"],
+      ["stays", "review"],
+    ])
+    const next = assignment([
+      ["new", "queue"],
+      ["stays", "review"],
+    ])
+    expect(planLaneTransitions(previous, next)).toEqual([])
+  })
+})
+
+describe("displayLaneCount / displayLaneCounts", () => {
+  test("delays destination count while arrivals are pending", () => {
+    expect(displayLaneCount({ trueCount: 3, pendingArrivals: 1 })).toBe(2)
+    expect(displayLaneCount({ trueCount: 1, pendingArrivals: 1 })).toBe(0)
+  })
+
+  test("never shows a negative count", () => {
+    expect(displayLaneCount({ trueCount: 0, pendingArrivals: 2 })).toBe(0)
+  })
+
+  test("source matches true count when no pending arrivals there", () => {
+    const trueCounts = new Map<PipelineLaneId, number>([
+      ["queue", 0],
+      ["build", 1],
+      ["review", 2],
+      ["pr", 0],
+      ["attention", 0],
+      ["complete", 0],
+    ])
+    const flights: Pick<RouteFlight, "to">[] = [{ to: "review" }]
+    const display = displayLaneCounts(trueCounts, flights)
+    // Source already decremented in true data; dest holds +1 until absorb.
+    expect(display.get("build")).toBe(1)
+    expect(display.get("review")).toBe(1)
+  })
+
+  test("overlapping arrivals stack without losing the final true count", () => {
+    const trueCounts = new Map<PipelineLaneId, number>([
+      ["queue", 0],
+      ["build", 0],
+      ["review", 3],
+      ["pr", 0],
+      ["attention", 0],
+      ["complete", 0],
+    ])
+    const flights: Pick<RouteFlight, "to">[] = [
+      { to: "review" },
+      { to: "review" },
+    ]
+    const mid = displayLaneCounts(trueCounts, flights)
+    expect(mid.get("review")).toBe(1)
+    const done = displayLaneCounts(trueCounts, [])
+    expect(done.get("review")).toBe(3)
+  })
+})
+
+describe("countPendingArrivals", () => {
+  test("counts only flights targeting the given lane", () => {
+    const flights = [
+      { to: "review" as const },
+      { to: "pr" as const },
+      { to: "review" as const },
+    ]
+    expect(countPendingArrivals(flights, "review")).toBe(2)
+    expect(countPendingArrivals(flights, "pr")).toBe(1)
+    expect(countPendingArrivals(flights, "build")).toBe(0)
+  })
+})
+
+describe("laneAssignmentFromLaneItems / trueLaneCounts", () => {
+  test("builds assignment and counts from lane item lists", () => {
+    const laneItems = new Map(
+      PIPELINE_LANES.map((lane) => [lane.id, [] as { id: string }[]]),
+    )
+    laneItems.set("build", [{ id: "a" }, { id: "b" }])
+    laneItems.set("review", [{ id: "c" }])
+    const assignmentMap = laneAssignmentFromLaneItems(laneItems)
+    expect(assignmentMap.get("a")).toBe("build")
+    expect(assignmentMap.get("b")).toBe("build")
+    expect(assignmentMap.get("c")).toBe("review")
+    const counts = trueLaneCounts(laneItems)
+    expect(counts.get("build")).toBe(2)
+    expect(counts.get("review")).toBe(1)
+    expect(counts.get("queue")).toBe(0)
+  })
+})
+
+describe("laneItemsAssignmentKey", () => {
+  test("is stable across Map identity for the same id/lane pairs", () => {
+    const left = new Map(
+      PIPELINE_LANES.map((lane) => [lane.id, [] as { id: string }[]]),
+    )
+    left.set("build", [{ id: "a" }])
+    left.set("review", [{ id: "b" }])
+    const right = new Map(
+      PIPELINE_LANES.map((lane) => [lane.id, [] as { id: string }[]]),
+    )
+    right.set("review", [{ id: "b" }])
+    right.set("build", [{ id: "a" }])
+    expect(left).not.toBe(right)
+    expect(laneItemsAssignmentKey(left)).toBe(laneItemsAssignmentKey(right))
+  })
+
+  test("changes when a work item moves lane", () => {
+    const before = new Map(
+      PIPELINE_LANES.map((lane) => [lane.id, [] as { id: string }[]]),
+    )
+    before.set("build", [{ id: "a" }])
+    const after = new Map(
+      PIPELINE_LANES.map((lane) => [lane.id, [] as { id: string }[]]),
+    )
+    after.set("review", [{ id: "a" }])
+    expect(laneItemsAssignmentKey(before)).not.toBe(
+      laneItemsAssignmentKey(after),
+    )
+  })
+})
+
+describe("ROUTE_* duration constants", () => {
+  test("fed and smoke durations stay aligned with the phase table", () => {
+    expect(ROUTE_FED_MS).toBeGreaterThan(0)
+    expect(ROUTE_SMOKE_MS).toBe(ROUTE_TRANSITION_MS.absorb)
+    expect(ROUTE_TRANSITION_MS.eject).toBeGreaterThan(0)
+    expect(ROUTE_TRANSITION_MS.travel).toBeGreaterThan(0)
+    expect(ROUTE_TRANSITION_MS.enter).toBeGreaterThan(0)
+    expect(ROUTE_TRANSITION_MS.absorb).toBeGreaterThan(0)
+    expect(ROUTE_TRANSITION_TOTAL_MS).toBe(
+      ROUTE_TRANSITION_MS.eject +
+        ROUTE_TRANSITION_MS.travel +
+        ROUTE_TRANSITION_MS.enter +
+        ROUTE_TRANSITION_MS.absorb,
+    )
+  })
+})
+
+describe("laneCenterPercent", () => {
+  test("places six stops at column midpoints", () => {
+    expect(laneCenterPercent("queue")).toBeCloseTo(100 / 12)
+    expect(laneCenterPercent("build")).toBeCloseTo(300 / 12)
+    expect(laneCenterPercent("complete")).toBeCloseTo(1100 / 12)
+  })
+})
+
+describe("nextFlightPhase / phaseDurationMs", () => {
+  test("walks eject → travel → enter → absorb → done", () => {
+    expect(nextFlightPhase("eject")).toBe("travel")
+    expect(nextFlightPhase("travel")).toBe("enter")
+    expect(nextFlightPhase("enter")).toBe("absorb")
+    expect(nextFlightPhase("absorb")).toBe(null)
+  })
+
+  test("phase durations match the choreography table", () => {
+    expect(phaseDurationMs("eject")).toBe(ROUTE_TRANSITION_MS.eject)
+    expect(phaseDurationMs("travel")).toBe(ROUTE_TRANSITION_MS.travel)
+    expect(phaseDurationMs("enter")).toBe(ROUTE_TRANSITION_MS.enter)
+    expect(phaseDurationMs("absorb")).toBe(ROUTE_TRANSITION_MS.absorb)
+  })
+})
+
+describe("reconcileFlights", () => {
+  test("keeps flights still targeting the work item's current lane", () => {
+    const flight = createRouteFlight({
+      workItemId: "job-1",
+      from: "build",
+      to: "review",
+    })
+    const previous = assignment([["job-1", "build"]])
+    const next = assignment([["job-1", "review"]])
+    const result = reconcileFlights({
+      previous,
+      next,
+      flights: [flight],
+    })
+    expect(result.flights).toHaveLength(1)
+    expect(result.newTransitions).toEqual([])
+  })
+
+  test("drops flights when the work item vanishes", () => {
+    const flight = createRouteFlight({
+      workItemId: "job-1",
+      from: "build",
+      to: "review",
+    })
+    const result = reconcileFlights({
+      previous: assignment([["job-1", "build"]]),
+      next: assignment([]),
+      flights: [flight],
+    })
+    expect(result.flights).toEqual([])
+    expect(result.newTransitions).toEqual([])
+  })
+
+  test("drops stale flights and plans a new transition when lane changes mid-flight", () => {
+    const flight = createRouteFlight({
+      workItemId: "job-1",
+      from: "build",
+      to: "review",
+    })
+    // After the first move was detected, previous assignment already advanced
+    // to review; a second live update moves the item to PR mid-flight.
+    const previous = assignment([["job-1", "review"]])
+    const next = assignment([["job-1", "pr"]])
+    const result = reconcileFlights({
+      previous,
+      next,
+      flights: [flight],
+    })
+    expect(result.flights).toEqual([])
+    expect(result.newTransitions).toEqual([
+      { workItemId: "job-1", from: "review", to: "pr" },
+    ])
+  })
+
+  test("does not double-plan a work item already in flight to the same dest", () => {
+    const flight = createRouteFlight({
+      workItemId: "job-1",
+      from: "build",
+      to: "review",
+    })
+    // previous still says build so planLaneTransitions would re-emit — but
+    // reconcile suppresses because a flight already covers it.
+    const result = reconcileFlights({
+      previous: assignment([["job-1", "build"]]),
+      next: assignment([["job-1", "review"]]),
+      flights: [flight],
+    })
+    expect(result.newTransitions).toEqual([])
+  })
+})


### PR DESCRIPTION
## Why

Pipeline route-line counts jumped instantly when a work item changed lane
(e.g. Build → Review), with no motion cue. Operators needed a legible
Interchange-style handoff without verbal transit jargon.

## What

- Replace plain route-line roundels with pot-belly furnace stops (lane color,
  stack + brass lip, firebox mouth, coal glow when count > 0; Merged halo
  preserved).
- On per-work-item lane change, run eject → travel (coal lump) → enter →
  absorb + stack smoke, then increment the destination count only after
  absorb.
- Pure planner (pipeline-route-transition.ts) for transitions, delayed
  display counts, mid-flight reconcile, and reduced-motion snap;
  PipelineRoute owns presentation timers and chrome.
- Durations locked via ROUTE_*_MS inline animations; assignment fingerprint
  avoids thrash when the board rebuilds Maps each render.

Out of scope: ticket-card motion, sound, lane semantics, mobile furnace
animation (route line remains desktop-only).

## Verification

- Unit tests for planner/reconcile/display counts/fingerprints/durations.
- Kanban source tests for furnace chrome + reduced-motion hook.
- nx test harness passed during implementation; focused bun tests re-run
  after review remediations.

## Limitations

- React fake-timer coverage of the phase orchestrator is deferred; pure
  helpers are covered.
- Exploratory prototype HTML was not on main; variant A is the production
  implementation.

Refs #737

Closes #737