### PR TITLE
feat(harness): add riveted metal lane headers

### DIFF
--- a/apps/harness/src/kanban-board.tsx
+++ b/apps/harness/src/kanban-board.tsx
@@ -10,6 +10,7 @@ import {
   totalElapsedMs,
   useNowMs,
 } from "./live-duration.js"
+import { MetalLaneHeader } from "./metal-lane-header.js"
 import {
   PIPELINE_LANES,
   type PipelineLaneId,
@@ -379,7 +380,7 @@ function KanbanJobsBoard() {
         <section className={ui.pipelineBoard} aria-label="Lifecycle pipeline">
           <PipelineRoute laneItems={laneItems} />
           <div className={ui.pipelineLanes}>
-            {PIPELINE_LANES.map((lane) => {
+            {PIPELINE_LANES.map((lane, laneIndex) => {
               const items = laneItems.get(lane.id) ?? []
               return (
                 <section
@@ -396,16 +397,12 @@ function KanbanJobsBoard() {
                     } as CSSProperties
                   }
                 >
-                  <header
-                    className={cx(
-                      ui.laneHeader,
-                      lane.id === "complete" && ui.laneHeaderComplete,
-                    )}
-                  >
-                    <h3 className={ui.laneTitle} id={`lane-${lane.id}`}>
-                      {lane.label}
-                    </h3>
-                  </header>
+                  <MetalLaneHeader
+                    laneId={lane.id}
+                    label={lane.label}
+                    titleId={`lane-${lane.id}`}
+                    ordinal={laneIndex + 1}
+                  />
                   {items.length === 0 ? (
                     <p className={ui.laneEmpty}>Lane clear</p>
                   ) : (

--- a/apps/harness/src/metal-lane-header.tsx
+++ b/apps/harness/src/metal-lane-header.tsx
@@ -1,0 +1,42 @@
+import type { PipelineLaneId } from "./pipeline-lanes.js"
+import { cx, ui } from "./ui.js"
+
+const RIVET_POSITION_CLASSES = [
+  { id: "nw", className: "top-[7px] left-[7px]" },
+  { id: "ne", className: "top-[7px] right-[7px]" },
+  { id: "sw", className: "bottom-[7px] left-[7px]" },
+  { id: "se", className: "right-[7px] bottom-[7px]" },
+] as const
+
+export function MetalLaneHeader({
+  laneId,
+  label,
+  titleId,
+  ordinal,
+}: {
+  readonly laneId: PipelineLaneId
+  readonly label: string
+  readonly titleId: string
+  readonly ordinal: number
+}) {
+  return (
+    <header className={ui.laneHeader} data-lane={laneId}>
+      <div className={ui.laneHeaderSheet}>
+        <span className={ui.laneHeaderGrain} aria-hidden="true" />
+        {RIVET_POSITION_CLASSES.map((rivet) => (
+          <span
+            aria-hidden="true"
+            className={cx(ui.laneHeaderRivet, rivet.className)}
+            key={rivet.id}
+          />
+        ))}
+        <span className={ui.laneHeaderCode} aria-hidden="true">
+          RFA / {String(ordinal).padStart(2, "0")}
+        </span>
+        <h3 className={ui.laneTitle} id={titleId}>
+          {label}
+        </h3>
+      </div>
+    </header>
+  )
+}

--- a/apps/harness/src/ui.ts
+++ b/apps/harness/src/ui.ts
@@ -624,19 +624,35 @@ export const ui = {
   ),
 
   laneHeader: cx(
-    "sticky top-0 z-[5] flex min-h-[5.25rem] items-end border-b-2 border-ink",
-    "bg-[var(--lane-color)] p-[0.7rem] text-[var(--lane-text,#fff)]",
+    "sticky top-0 z-[5] isolate flex min-h-[5.25rem] overflow-hidden border-b-2 border-ink",
+    "bg-[#252827] p-[3px] text-[var(--lane-text,#fff)]",
+    "[background-image:linear-gradient(90deg,#151817,#4a4e4b_48%,#1c1f1e)]",
+    "shadow-[inset_0_1px_0_rgb(255_255_255/0.45),inset_0_-1px_0_rgb(0_0_0/0.8)]",
     "max-[900px]:static max-[900px]:min-h-16",
   ),
 
-  /**
-   * Complete-lane header halo — apply when lane data-lane=complete.
-   * Parent CSS was `.pipeline-lane[data-lane=complete] .lane-header`.
-   */
-  laneHeaderComplete: "shadow-[inset_0_0_0_1px_var(--merged-halo)]",
+  laneHeaderSheet: cx(
+    "relative flex min-w-0 flex-1 items-end overflow-hidden border border-black/70",
+    "bg-[var(--lane-color)] pt-[0.72rem] pr-[1.15rem] pb-[0.72rem] pl-[1.15rem]",
+    "[background-image:linear-gradient(112deg,transparent_0_24%,rgb(255_255_255/0.06)_28%,rgb(255_255_255/0.34)_34%,rgb(255_255_255/0.05)_40%,transparent_45%_100%),repeating-linear-gradient(0deg,rgb(255_255_255/0.055)_0_1px,rgb(0_0_0/0.035)_1px_2px,transparent_2px_4px),linear-gradient(180deg,rgb(255_255_255/0.28)_0%,transparent_38%,rgb(0_0_0/0.17)_100%)]",
+    "[background-blend-mode:screen,overlay,normal]",
+    "shadow-[inset_0_1px_0_rgb(255_255_255/0.55),inset_0_-3px_4px_rgb(0_0_0/0.28),inset_1px_0_0_rgb(255_255_255/0.15),0_1px_2px_rgb(0_0_0/0.8)]",
+  ),
+
+  laneHeaderGrain:
+    "pointer-events-none absolute inset-0 z-[1] bg-[length:160px_120px] opacity-20 mix-blend-soft-light [background-image:repeating-linear-gradient(97deg,transparent_0_2px,rgb(255_255_255/0.1)_2px_3px,transparent_3px_7px),repeating-linear-gradient(3deg,rgb(0_0_0/0.055)_0_1px,transparent_1px_5px)]",
+
+  laneHeaderCode:
+    "absolute top-[0.48rem] left-[1.25rem] z-[3] font-mono text-[0.48rem] font-bold tracking-[0.14em] opacity-55",
+
+  laneHeaderRivet: cx(
+    "absolute z-[4] h-[9px] w-[9px] rounded-full",
+    "[background-image:radial-gradient(circle_at_31%_25%,#fff_0_7%,transparent_8%),radial-gradient(circle_at_36%_30%,#d8ddda_0_16%,#89908c_38%,#343837_67%,#aeb4b1_88%)]",
+    "shadow-[0_0_0_1px_rgb(0_0_0/0.7),0_1px_1px_rgb(0_0_0/0.75),inset_-1px_-1px_1px_rgb(0_0_0/0.55)]",
+  ),
 
   laneTitle:
-    "m-0 font-display text-[1.2rem] font-[950] leading-[0.85] tracking-[-0.04em] uppercase",
+    "relative z-[3] m-0 whitespace-nowrap font-display text-[clamp(0.82rem,1.05vw,1.18rem)] font-[950] leading-[0.86] tracking-[-0.035em] uppercase text-[var(--lane-text,#fff)] [text-shadow:0_1px_0_rgb(255_255_255/0.25),0_-1px_0_rgb(0_0_0/0.3),0_2px_3px_rgb(0_0_0/0.12)] max-[900px]:text-[1.18rem]",
 
   laneStack:
     "m-0 grid min-w-0 flex-[1_1_auto] list-none content-start gap-[0.55rem] p-[0.55rem]",

--- a/apps/harness/test/kanban-route.test.ts
+++ b/apps/harness/test/kanban-route.test.ts
@@ -1,9 +1,15 @@
 import { readFileSync } from "node:fs"
 import { join } from "node:path"
+import { createElement } from "react"
+import { renderToStaticMarkup } from "react-dom/server"
+import { MetalLaneHeader } from "../src/metal-lane-header.js"
 import { describe, expect, test } from "bun:test"
 
 const boardSource = () =>
   readFileSync(join(import.meta.dir, "../src/kanban-board.tsx"), "utf8")
+
+const metalLaneHeaderSource = () =>
+  readFileSync(join(import.meta.dir, "../src/metal-lane-header.tsx"), "utf8")
 
 const homeSource = () =>
   readFileSync(join(import.meta.dir, "../src/routes/index.tsx"), "utf8")
@@ -144,10 +150,11 @@ describe("kanban home board", () => {
       join(import.meta.dir, "../src/pipeline-route.tsx"),
       "utf8",
     )
+    const metalHeader = metalLaneHeaderSource()
     expect(source).toContain('aria-label="Lifecycle pipeline"')
     expect(source).toContain("pipelineLaneFor(workItem)")
     expect(source).toContain("Lane clear")
-    // Mobile switcher + lane header use {lane.label}; route furnaces live in
+    // Mobile switcher + metal header use {lane.label}; route furnaces live in
     // PipelineRoute (also {lane.label} in accessible names).
     expect(source.match(/\{lane\.label\}/g)).toHaveLength(2)
     expect(source).toContain("<PipelineRoute")
@@ -162,8 +169,9 @@ describe("kanban home board", () => {
     expect(route).toContain("ROUTE_SMOKE_MS")
     expect(route).toMatch(/jobs in \$\{lane\.label\}/)
     expect(route).toContain("prefers-reduced-motion")
-    expect(source).toContain("ui.laneHeader")
-    expect(source).toContain("ui.laneTitle")
+    expect(source).toContain("<MetalLaneHeader")
+    expect(metalHeader).toContain("ui.laneHeader")
+    expect(metalHeader).toContain("ui.laneTitle")
     expect(source).not.toContain("lane-number")
     expect(source).not.toContain("lane-count")
     expect(source).toContain("ui.queueHint")
@@ -174,6 +182,31 @@ describe("kanban home board", () => {
     expect(source).toContain("ui.queueHintMenuIllus")
     expect(source).not.toContain("Manage repos →")
     expect(source).not.toContain("work starts at your repos")
+  })
+
+  test("mounts lane names on riveted metal sheets", () => {
+    const source = metalLaneHeaderSource()
+    const ui = uiSource()
+    const html = renderToStaticMarkup(
+      createElement(MetalLaneHeader, {
+        laneId: "attention",
+        label: "Attention",
+        titleId: "lane-attention",
+        ordinal: 5,
+      }),
+    )
+    expect(html).toContain('data-lane="attention"')
+    expect(html).toContain('id="lane-attention"')
+    expect(html).toContain(">Attention</h3>")
+    expect(html).toContain("RFA / 05")
+    expect(html.match(/h-\[9px\]/g)).toHaveLength(4)
+    expect(html.match(/aria-hidden="true"/g)).toHaveLength(6)
+    expect(source).toContain("RIVET_POSITION_CLASSES")
+    expect(source).toContain("ui.laneHeaderSheet")
+    expect(source).toContain("ui.laneHeaderRivet")
+    expect(ui).toContain("laneHeaderSheet:")
+    expect(ui).toContain("laneHeaderGrain:")
+    expect(ui).toContain("laneHeaderRivet:")
   })
 
   test("Jobs strip + repository filters are sticky root chrome", () => {

--- a/docs/harness-design-system.md
+++ b/docs/harness-design-system.md
@@ -289,16 +289,19 @@ Old-dashboard simplicity: what we merged, front and center. Five quantities
 **The network** (desktop, >1500px): six-column grid; a 4px ink **route
 line** runs column-centre to column-centre behind the roundels (visual motif
 only, `aria-hidden`); each lane carries a **roundel** (2.1rem disc, lane
-fill, 2px ink border, mono lane number) riding the line. Merged's black disc
+fill, 2px ink border, mono work-item count) riding the line. Merged's black disc
 gets a white border + ink outline so it reads on the black line.
 
 ≤1500px the route line is hidden and the roundel shrinks to a 1.4rem badge
 pinned on the nameboard. ≤900px the existing single-lane mobile behavior
 stays (lane switcher below) — this is a re-skin, not a behavior change.
 
-**Lane header = nameboard**: lane-color fill, on-lane ink, 2px ink border,
-display-800 uppercase lane name + tabular count right-aligned. Sticky-on-
-scroll behavior is preserved. Lane numbers ("01"…"06") live in the roundel.
+**Lane header = nameboard**: a brushed lane-color alloy sheet in a dark metal
+frame, fixed by four dome rivets. Specular, grain, bevel, and inset-shadow
+layers give the sheet depth without an image asset. The uppercase lane name
+uses the fixed on-lane ink; a small decorative `RFA / 01`…`06` serial is
+`aria-hidden`. Sticky-on-scroll behavior is preserved. Operational counts stay
+in the route roundels and mobile lane switcher.
 
 **Lane body = platform**: open white — 1.5px ink border, no top border, no
 fill, no grey. Empty lane: centered mono uppercase letterspaced "Lane clear"

--- a/docs/kanban.md
+++ b/docs/kanban.md
@@ -71,8 +71,9 @@ The visual treatment follows the Interchange design system
 `styles.css`). The board is a dense industrial control surface: a route line
 of lane-colored roundels showing each lane’s work-item count, above flush
 six-column lanes on a grey bed with ink gutters, full-width colored headers
-(title only, same header height as before), and tickets sized to the
-Completed archive type floor.
+rendered as brushed alloy sheets in riveted dark-metal frames (lane title plus
+an `aria-hidden` serial, same header height as before), and tickets sized to
+the Completed archive type floor.
 
 ## Interaction Model
 


### PR DESCRIPTION
## Why

The pipeline's flat-color lane headers feel visually disconnected from the harness's industrial control-board chrome. The selected brushed-alloy prototype gives the top row crafted material depth while preserving the fixed lane colors operators use to scan workflow state.

## What Changed

- Render every lane header as a brushed alloy sheet in a dark metal frame with grain, specular highlights, bevel depth, and four dome rivets.
- Keep lane names as semantic headings while hiding the decorative grain, fasteners, and `RFA / 01` through `06` serials from assistive technology.
- Scale long lane names at narrow desktop widths and preserve the original mobile header height.
- Keep the treatment Tailwind-first in `ui.ts`, with focused markup tests and updated Kanban design documentation.

## Verification

Manually verified the live board at 1830x720 and 390x844: all six pane colors and rivets render correctly, the mobile single-lane layout remains intact, heading semantics are preserved, and the browser reports no errors.
