### PR TITLE
feat(harness): polish pot-belly furnace route-line transitions

### DIFF
--- a/apps/harness/src/kanban-board.tsx
+++ b/apps/harness/src/kanban-board.tsx
@@ -1,5 +1,5 @@
 import { useQueries, useSuspenseQuery } from "@tanstack/react-query"
-import { type CSSProperties, Suspense, useState } from "react"
+import { type CSSProperties, Suspense, useMemo, useState } from "react"
 import { Banner } from "./banner.js"
 import { Copy } from "./copy.js"
 import { useJobsRepositoryFilter } from "./jobs-repository-filter.js"
@@ -16,7 +16,8 @@ import {
   type PipelineLaneId,
   pipelineLaneFor,
 } from "./pipeline-lanes.js"
-import { PipelineRoute } from "./pipeline-route.js"
+import { PipelineRoute, usePipelineRouteFlights } from "./pipeline-route.js"
+import { presentLaneColumnItems } from "./pipeline-route-transition.js"
 import {
   JOBS_FAILED_LIMIT,
   JobsCardSkeleton,
@@ -129,12 +130,15 @@ function PipelineTicket({
   repository,
   issue,
   laneId,
+  departing = false,
   onOpenSession,
 }: {
   readonly workItem: WorkItem
   readonly repository: Repository | undefined
   readonly issue: { readonly title: string; readonly url: string } | undefined
   readonly laneId: PipelineLaneId
+  /** In-flight on the route line — stay in source lane, greyed out. */
+  readonly departing?: boolean
   readonly onOpenSession: (workItemId: string, sessionId: string) => void
 }) {
   const repositoryLabel = repository?.projectPath ?? workItem.repositoryId
@@ -168,8 +172,12 @@ function PipelineTicket({
 
   return (
     <li
-      className={ui.jobTicket}
+      className={cx(ui.jobTicket, departing && ui.jobTicketDeparting)}
       data-lane={laneId}
+      data-departing={departing ? "true" : undefined}
+      aria-busy={departing || undefined}
+      // inert blocks mouse and keyboard; pointer-events-none alone is not enough.
+      {...(departing ? { inert: true } : {})}
       style={{ "--ticket-color": lane?.color ?? "#151515" } as CSSProperties}
     >
       <p className={ui.jobTicketRepo} title={repositoryLabel}>
@@ -336,6 +344,17 @@ function KanbanJobsBoard() {
     ]),
   )
 
+  // Route flights delay dest counts; tickets stay greyed in source until absorb.
+  const routeFlights = usePipelineRouteFlights(laneItems)
+
+  const workItemById = useMemo(() => {
+    const map = new Map<string, WorkItem>()
+    for (const item of visiblePipelineItems) {
+      map.set(item.id, item)
+    }
+    return map
+  }, [visiblePipelineItems])
+
   if (loading && pipelineItems.length === 0) {
     return <JobsCardSkeleton />
   }
@@ -373,15 +392,29 @@ function KanbanJobsBoard() {
               }
             >
               <span className={ui.laneSwitchSwatch} aria-hidden="true" />
-              {lane.label} {laneItems.get(lane.id)?.length ?? 0}
+              {lane.label}{" "}
+              {routeFlights.displayCounts.get(lane.id) ??
+                laneItems.get(lane.id)?.length ??
+                0}
             </button>
           ))}
         </fieldset>
         <section className={ui.pipelineBoard} aria-label="Lifecycle pipeline">
-          <PipelineRoute laneItems={laneItems} />
+          <PipelineRoute
+            flights={routeFlights.flights}
+            fedLanes={routeFlights.fedLanes}
+            displayCounts={routeFlights.displayCounts}
+          />
           <div className={ui.pipelineLanes}>
             {PIPELINE_LANES.map((lane, laneIndex) => {
-              const items = laneItems.get(lane.id) ?? []
+              // Departing tickets stay greyed in the source lane; arrivals wait
+              // until the route traveler is absorbed before appearing in dest.
+              const items = presentLaneColumnItems({
+                laneId: lane.id,
+                laneItems: laneItems.get(lane.id) ?? [],
+                flights: routeFlights.flights,
+                workItemById,
+              })
               return (
                 <section
                   className={ui.pipelineLane}
@@ -407,7 +440,7 @@ function KanbanJobsBoard() {
                     <p className={ui.laneEmpty}>Lane clear</p>
                   ) : (
                     <ul className={ui.laneStack}>
-                      {items.map((workItem) => (
+                      {items.map(({ workItem, departing }) => (
                         <PipelineTicket
                           key={workItem.id}
                           workItem={workItem}
@@ -419,6 +452,7 @@ function KanbanJobsBoard() {
                             ),
                           )}
                           laneId={lane.id}
+                          departing={departing}
                           onOpenSession={(workItemId, sessionId) =>
                             setSessionDialog({ workItemId, sessionId })
                           }

--- a/apps/harness/src/pipeline-route-transition.ts
+++ b/apps/harness/src/pipeline-route-transition.ts
@@ -21,30 +21,57 @@ export type RouteFlight = {
   readonly from: PipelineLaneId
   readonly to: PipelineLaneId
   readonly phase: FlightPhase
+  /**
+   * Index of the work item in the source lane’s order at departure time.
+   * Used so the greyed card stays mid-stack instead of jumping to the end.
+   */
+  readonly sourceOrderIndex: number
 }
 
-/** Choreography durations (ms). Kept modest so multi-step moves stay legible. */
+/**
+ * Choreography durations (ms). Intentionally unhurried (~3.9s total) so the
+ * furnace handoff reads on a real board. Concurrent mid-flight replans cancel
+ * and restart from the new edge — expected cost of the slower timing.
+ *
+ *   eject 700 + travel 1600 + enter 400 + absorb 1200 = 3900 ms
+ */
 export const ROUTE_TRANSITION_MS = {
-  eject: 320,
-  travel: 700,
-  enter: 280,
-  absorb: 450,
+  eject: 700,
+  travel: 1600,
+  enter: 400,
+  absorb: 1200,
 } as const satisfies Record<FlightPhase, number>
 
 /** Brief post-absorb “fed” glow on the destination furnace. */
-export const ROUTE_FED_MS = 300
+export const ROUTE_FED_MS = 500
 
 /**
- * Stack smoke duration (ms). Shared for eject and absorb — a short puff while
- * the furnace is active, not a distinct light/heavy pair.
+ * Stack smoke duration (ms). Plume is timer-driven and may outlast the
+ * eject/absorb phase so puffs finish rising after the furnace settles.
+ * Eject uses a shorter burst (see smokeDurationMs).
  */
-export const ROUTE_SMOKE_MS = ROUTE_TRANSITION_MS.absorb
+export const ROUTE_SMOKE_MS = 1400
 
 export const ROUTE_TRANSITION_TOTAL_MS =
   ROUTE_TRANSITION_MS.eject +
   ROUTE_TRANSITION_MS.travel +
   ROUTE_TRANSITION_MS.enter +
   ROUTE_TRANSITION_MS.absorb
+
+/** Smoke wall-clock for a given kind (decoupled from phase unmount). */
+export function smokeDurationMs(kind: "eject" | "absorb"): number {
+  return kind === "eject"
+    ? Math.min(ROUTE_SMOKE_MS, ROUTE_TRANSITION_MS.eject + 200)
+    : ROUTE_SMOKE_MS
+}
+
+/**
+ * Attention is a holding pen — cold mouth, no fire even when occupied.
+ * Shared so UI and tests agree.
+ */
+export function furnaceFireLit(laneId: PipelineLaneId, count: number): boolean {
+  return count > 0 && laneId !== "attention"
+}
 
 const LANE_INDEX = new Map<PipelineLaneId, number>(
   PIPELINE_LANES.map((lane, index) => [lane.id, index]),
@@ -142,14 +169,21 @@ export function countPendingArrivals(
 }
 
 /**
- * Presentation count for one stop. Never negative. Source already matches true
- * data when the traveler left; only destination is delayed.
+ * Presentation count for one stop. Never negative.
+ *
+ * - Destination stays flat until absorb (subtract pending arrivals).
+ * - Source keeps the departing job until the flight ends (add pending
+ *   departures) so furnace counts match greyed-out cards still in the lane.
  */
 export function displayLaneCount(args: {
   readonly trueCount: number
   readonly pendingArrivals: number
+  readonly pendingDepartures?: number
 }): number {
-  return Math.max(0, args.trueCount - args.pendingArrivals)
+  return Math.max(
+    0,
+    args.trueCount - args.pendingArrivals + (args.pendingDepartures ?? 0),
+  )
 }
 
 /**
@@ -157,22 +191,89 @@ export function displayLaneCount(args: {
  */
 export function displayLaneCounts(
   trueCounts: ReadonlyMap<PipelineLaneId, number>,
-  flights: readonly Pick<RouteFlight, "to">[],
+  flights: readonly Pick<RouteFlight, "from" | "to">[],
 ): Map<PipelineLaneId, number> {
-  const pendingByLane = new Map<PipelineLaneId, number>()
+  const pendingArrivals = new Map<PipelineLaneId, number>()
+  const pendingDepartures = new Map<PipelineLaneId, number>()
   for (const flight of flights) {
-    pendingByLane.set(flight.to, (pendingByLane.get(flight.to) ?? 0) + 1)
+    pendingArrivals.set(flight.to, (pendingArrivals.get(flight.to) ?? 0) + 1)
+    pendingDepartures.set(
+      flight.from,
+      (pendingDepartures.get(flight.from) ?? 0) + 1,
+    )
   }
   const display = new Map<PipelineLaneId, number>()
   for (const lane of PIPELINE_LANES) {
     const trueCount = trueCounts.get(lane.id) ?? 0
-    const pending = pendingByLane.get(lane.id) ?? 0
     display.set(
       lane.id,
-      displayLaneCount({ trueCount, pendingArrivals: pending }),
+      displayLaneCount({
+        trueCount,
+        pendingArrivals: pendingArrivals.get(lane.id) ?? 0,
+        pendingDepartures: pendingDepartures.get(lane.id) ?? 0,
+      }),
     )
   }
   return display
+}
+
+/**
+ * Tickets to render in a lane column during route flights.
+ *
+ * Real data already places a moved job in the destination lane. Presentation:
+ * - Keep it in the **source** lane while in flight (greyed “departing”),
+ *   inserted at `sourceOrderIndex` so mid-stack cards do not jump to the end.
+ * - Hold it out of the **destination** lane until absorb finishes.
+ */
+export function presentLaneColumnItems<
+  T extends { readonly id: string },
+>(args: {
+  readonly laneId: PipelineLaneId
+  readonly laneItems: readonly T[]
+  readonly flights: readonly Pick<
+    RouteFlight,
+    "workItemId" | "from" | "to" | "sourceOrderIndex"
+  >[]
+  readonly workItemById: ReadonlyMap<string, T>
+}): readonly { readonly workItem: T; readonly departing: boolean }[] {
+  const departing: {
+    workItemId: string
+    sourceOrderIndex: number
+  }[] = []
+  const arrivingIds = new Set<string>()
+  for (const flight of args.flights) {
+    if (flight.from === args.laneId) {
+      departing.push({
+        workItemId: flight.workItemId,
+        sourceOrderIndex: flight.sourceOrderIndex,
+      })
+    }
+    if (flight.to === args.laneId) arrivingIds.add(flight.workItemId)
+  }
+
+  const residents: { workItem: T; departing: boolean }[] = []
+  for (const item of args.laneItems) {
+    if (arrivingIds.has(item.id)) continue
+    residents.push({ workItem: item, departing: false })
+  }
+
+  // Insert greys at frozen source indices (stable mid-stack, not append-only).
+  const result = [...residents]
+  const seen = new Set(result.map((entry) => entry.workItem.id))
+  const sortedDeparting = departing
+    .slice()
+    .sort((left, right) => left.sourceOrderIndex - right.sourceOrderIndex)
+
+  for (const { workItemId, sourceOrderIndex } of sortedDeparting) {
+    if (seen.has(workItemId)) continue
+    const workItem = args.workItemById.get(workItemId)
+    if (workItem === undefined) continue
+    const insertAt = Math.min(Math.max(0, sourceOrderIndex), result.length)
+    result.splice(insertAt, 0, { workItem, departing: true })
+    seen.add(workItemId)
+  }
+
+  return result
 }
 
 /**
@@ -253,12 +354,31 @@ function createFlightId(workItemId: string): string {
   return `route-flight-${flightSeq}-${workItemId}`
 }
 
-export function createRouteFlight(transition: PlannedTransition): RouteFlight {
+export function createRouteFlight(
+  transition: PlannedTransition,
+  sourceOrderIndex = 0,
+): RouteFlight {
   return {
     id: createFlightId(transition.workItemId),
     workItemId: transition.workItemId,
     from: transition.from,
     to: transition.to,
     phase: "eject",
+    sourceOrderIndex: Math.max(0, sourceOrderIndex),
   }
+}
+
+/**
+ * Index of `workItemId` among items assigned to `lane` in a prior ordered
+ * id list (source lane snapshot at departure). Falls back to 0.
+ */
+export function sourceOrderIndexInLane(args: {
+  readonly workItemId: string
+  readonly laneId: PipelineLaneId
+  readonly orderedIdsByLane: ReadonlyMap<PipelineLaneId, readonly string[]>
+}): number {
+  const order = args.orderedIdsByLane.get(args.laneId)
+  if (order === undefined) return 0
+  const index = order.indexOf(args.workItemId)
+  return index < 0 ? 0 : index
 }

--- a/apps/harness/src/pipeline-route.tsx
+++ b/apps/harness/src/pipeline-route.tsx
@@ -3,18 +3,20 @@ import { PIPELINE_LANES, type PipelineLaneId } from "./pipeline-lanes.js"
 import {
   type FlightPhase,
   ROUTE_FED_MS,
-  ROUTE_SMOKE_MS,
   ROUTE_TRANSITION_MS,
   type RouteFlight,
   assignmentsEqual,
   createRouteFlight,
   displayLaneCounts,
+  furnaceFireLit,
   laneAssignmentFromLaneItems,
   laneCenterPercent,
   laneItemsAssignmentKey,
   nextFlightPhase,
   phaseDurationMs,
   reconcileFlights,
+  smokeDurationMs,
+  sourceOrderIndexInLane,
   trueLaneCounts,
 } from "./pipeline-route-transition.js"
 import { cx, ui } from "./ui.js"
@@ -41,27 +43,24 @@ function furnacePhaseForLane(
   return "idle"
 }
 
-function smokeActiveForLane(
-  laneId: PipelineLaneId,
-  flights: readonly RouteFlight[],
-): boolean {
-  for (const flight of flights) {
-    if (flight.from === laneId && flight.phase === "eject") return true
-    if (flight.to === laneId && flight.phase === "absorb") return true
-  }
-  return false
+type SmokeKind = "eject" | "absorb"
+
+type LingeringSmoke = {
+  readonly kind: SmokeKind
+  readonly key: string
+  readonly smokeMs: number
 }
 
 /** Inline furnace phase animation so durations track ROUTE_*_MS constants. */
 function furnacePhaseStyle(phase: FurnacePhase): CSSProperties | undefined {
   if (phase === "eject") {
     return {
-      animation: `furnace-eject ${ROUTE_TRANSITION_MS.eject}ms ease-out`,
+      animation: `furnace-eject ${ROUTE_TRANSITION_MS.eject}ms cubic-bezier(0.4, 0, 0.2, 1)`,
     }
   }
   if (phase === "absorb") {
     return {
-      animation: `furnace-absorb ${ROUTE_TRANSITION_MS.absorb}ms ease-out`,
+      animation: `furnace-absorb ${ROUTE_TRANSITION_MS.absorb}ms cubic-bezier(0.4, 0, 0.2, 1)`,
     }
   }
   if (phase === "fed") {
@@ -72,24 +71,42 @@ function furnacePhaseStyle(phase: FurnacePhase): CSSProperties | undefined {
   return undefined
 }
 
+function orderedIdsByLaneFromItems(
+  laneItems: ReadonlyMap<PipelineLaneId, readonly { readonly id: string }[]>,
+): Map<PipelineLaneId, readonly string[]> {
+  const ordered = new Map<PipelineLaneId, readonly string[]>()
+  for (const lane of PIPELINE_LANES) {
+    ordered.set(
+      lane.id,
+      (laneItems.get(lane.id) ?? []).map((item) => item.id),
+    )
+  }
+  return ordered
+}
+
+export type PipelineRouteFlights = {
+  readonly flights: readonly RouteFlight[]
+  readonly fedLanes: ReadonlySet<PipelineLaneId>
+  readonly displayCounts: ReadonlyMap<PipelineLaneId, number>
+}
+
 /**
- * Desktop route line: pot-belly furnace stops with optional coal-lump traveler
- * when a work item changes pipeline lane. Presentation only — real counts come
- * from `laneItems`; destination display is delayed until absorb finishes.
+ * Own route-line flight state from true lane assignment. Shared by the route
+ * chrome and the board so furnace counts and greyed departing tickets stay
+ * aligned with travelers.
  */
-export function PipelineRoute({
-  laneItems,
-}: {
-  readonly laneItems: ReadonlyMap<
-    PipelineLaneId,
-    readonly { readonly id: string }[]
-  >
-}) {
+export function usePipelineRouteFlights(
+  laneItems: ReadonlyMap<PipelineLaneId, readonly { readonly id: string }[]>,
+): PipelineRouteFlights {
   const [flights, setFlights] = useState<readonly RouteFlight[]>([])
   const [fedLanes, setFedLanes] = useState<ReadonlySet<PipelineLaneId>>(
     () => new Set(),
   )
   const assignmentRef = useRef<Map<string, PipelineLaneId> | null>(null)
+  /** Source-lane id order from the last committed assignment (pre-move). */
+  const orderedIdsByLaneRef = useRef<Map<PipelineLaneId, readonly string[]>>(
+    orderedIdsByLaneFromItems(laneItems),
+  )
   const flightsRef = useRef(flights)
   flightsRef.current = flights
   const phaseTimersRef = useRef(
@@ -105,6 +122,7 @@ export function PipelineRoute({
     key: string
     assignment: Map<string, PipelineLaneId>
     counts: Map<PipelineLaneId, number>
+    orderedIdsByLane: Map<PipelineLaneId, readonly string[]>
   } | null>(null)
   if (
     laneSnapshotRef.current === null ||
@@ -114,34 +132,43 @@ export function PipelineRoute({
       key: assignmentKey,
       assignment: laneAssignmentFromLaneItems(laneItems),
       counts: trueLaneCounts(laneItems),
+      orderedIdsByLane: orderedIdsByLaneFromItems(laneItems),
     }
   }
   const nextAssignment = laneSnapshotRef.current.assignment
   const trueCounts = laneSnapshotRef.current.counts
+  const nextOrderedIds = laneSnapshotRef.current.orderedIdsByLane
 
   // Seed baseline on first paint; subsequent diffs schedule travelers.
   useEffect(() => {
     if (assignmentRef.current === null) {
       assignmentRef.current = nextAssignment
+      orderedIdsByLaneRef.current = nextOrderedIds
       return
     }
 
     if (assignmentsEqual(assignmentRef.current, nextAssignment)) {
+      orderedIdsByLaneRef.current = nextOrderedIds
       return
     }
 
     if (prefersReducedMotion()) {
       assignmentRef.current = nextAssignment
+      orderedIdsByLaneRef.current = nextOrderedIds
       setFlights((current) => (current.length === 0 ? current : []))
       return
     }
 
+    // Snapshot source order *before* advancing the assignment — that is the
+    // pre-move stack position for greying cards mid-column.
+    const priorOrder = orderedIdsByLaneRef.current
     const { flights: kept, newTransitions } = reconcileFlights({
       previous: assignmentRef.current,
       next: nextAssignment,
       flights: flightsRef.current,
     })
     assignmentRef.current = nextAssignment
+    orderedIdsByLaneRef.current = nextOrderedIds
 
     if (newTransitions.length === 0) {
       if (kept.length !== flightsRef.current.length) {
@@ -150,9 +177,18 @@ export function PipelineRoute({
       return
     }
 
-    const created = newTransitions.map(createRouteFlight)
+    const created = newTransitions.map((transition) =>
+      createRouteFlight(
+        transition,
+        sourceOrderIndexInLane({
+          workItemId: transition.workItemId,
+          laneId: transition.from,
+          orderedIdsByLane: priorOrder,
+        }),
+      ),
+    )
     setFlights([...kept, ...created])
-  }, [nextAssignment])
+  }, [nextAssignment, nextOrderedIds])
 
   // Advance each flight through eject → travel → enter → absorb → remove.
   useEffect(() => {
@@ -224,18 +260,130 @@ export function PipelineRoute({
     [trueCounts, flights],
   )
 
+  return { flights, fedLanes, displayCounts }
+}
+
+/**
+ * Active smoke triggers for the current flight phase (start of plume only).
+ * Lingering is handled by `useLingeringSmoke` so the DOM stays mounted for
+ * the full smokeDurationMs.
+ */
+function activeSmokeTriggers(
+  flights: readonly RouteFlight[],
+): readonly { laneId: PipelineLaneId; kind: SmokeKind; key: string }[] {
+  const triggers: { laneId: PipelineLaneId; kind: SmokeKind; key: string }[] =
+    []
+  for (const flight of flights) {
+    if (flight.phase === "eject") {
+      triggers.push({
+        laneId: flight.from,
+        kind: "eject",
+        key: `${flight.id}:eject`,
+      })
+    } else if (flight.phase === "absorb") {
+      triggers.push({
+        laneId: flight.to,
+        kind: "absorb",
+        key: `${flight.id}:absorb`,
+      })
+    }
+  }
+  return triggers
+}
+
+/**
+ * Keep smoke mounted for its full smokeMs even after the flight leaves
+ * eject/absorb, so plumes are not cut short by phase transitions.
+ */
+function useLingeringSmoke(
+  flights: readonly RouteFlight[],
+): ReadonlyMap<PipelineLaneId, LingeringSmoke> {
+  const [smokeByLane, setSmokeByLane] = useState(
+    () => new Map<PipelineLaneId, LingeringSmoke>(),
+  )
+  const timersRef = useRef(
+    new Map<PipelineLaneId, ReturnType<typeof setTimeout>>(),
+  )
+
+  useEffect(() => {
+    const triggers = activeSmokeTriggers(flights)
+    for (const trigger of triggers) {
+      setSmokeByLane((current) => {
+        const existing = current.get(trigger.laneId)
+        if (existing?.key === trigger.key) return current
+        const smokeMs = smokeDurationMs(trigger.kind)
+        const next = new Map(current)
+        next.set(trigger.laneId, {
+          kind: trigger.kind,
+          key: trigger.key,
+          smokeMs,
+        })
+        const priorTimer = timersRef.current.get(trigger.laneId)
+        if (priorTimer !== undefined) clearTimeout(priorTimer)
+        const laneId = trigger.laneId
+        const key = trigger.key
+        timersRef.current.set(
+          laneId,
+          setTimeout(() => {
+            timersRef.current.delete(laneId)
+            setSmokeByLane((prev) => {
+              const live = prev.get(laneId)
+              if (live === undefined || live.key !== key) return prev
+              const copy = new Map(prev)
+              copy.delete(laneId)
+              return copy
+            })
+          }, smokeMs),
+        )
+        return next
+      })
+    }
+  }, [flights])
+
+  useEffect(() => {
+    return () => {
+      for (const timer of timersRef.current.values()) clearTimeout(timer)
+      timersRef.current.clear()
+    }
+  }, [])
+
+  return smokeByLane
+}
+
+/**
+ * Desktop route line: pot-belly furnace stops with optional coal-lump traveler
+ * when a work item changes pipeline lane. Presentation only — real counts come
+ * from the board’s work-item data; display counts are delayed until absorb.
+ */
+export function PipelineRoute({
+  flights,
+  fedLanes,
+  displayCounts,
+}: {
+  readonly flights: readonly RouteFlight[]
+  readonly fedLanes: ReadonlySet<PipelineLaneId>
+  readonly displayCounts: ReadonlyMap<PipelineLaneId, number>
+}) {
+  const lingeringSmoke = useLingeringSmoke(flights)
+
   return (
     <div className={ui.pipelineRoute}>
+      <div className={ui.pipelineRouteSpine} aria-hidden="true">
+        <span className={ui.pipelineRouteSpineBore} />
+        <span className={ui.pipelineRouteSpineRivets} />
+      </div>
       {PIPELINE_LANES.map((lane) => {
         const count = displayCounts.get(lane.id) ?? 0
         const phase = furnacePhaseForLane(lane.id, flights, fedLanes)
-        const smokeActive = smokeActiveForLane(lane.id, flights)
         const phaseMotion = furnacePhaseStyle(phase)
+        const fireLit = furnaceFireLit(lane.id, count)
+        const smoke = lingeringSmoke.get(lane.id)
         return (
           <span
             className={ui.laneRoundel}
             data-lane={lane.id}
             data-phase={phase === "idle" ? undefined : phase}
+            data-lit={fireLit ? "true" : "false"}
             key={lane.id}
             role="img"
             aria-label={`${count} jobs in ${lane.label}`}
@@ -253,28 +401,46 @@ export function PipelineRoute({
               data-lane={lane.id}
               aria-hidden="true"
             >
-              <span className={ui.laneFurnaceCount}>{count}</span>
-              <span className={ui.laneFurnaceMouth} />
+              <span className={ui.laneFurnaceBand} aria-hidden="true" />
               <span
                 className={ui.laneFurnaceGlow}
-                data-lit={count > 0 ? "true" : "false"}
+                data-lit={fireLit ? "true" : "false"}
               />
+              <span className={ui.laneFurnaceCount}>{count}</span>
+              <span className={ui.laneFurnaceMouth} aria-hidden="true">
+                <span
+                  className={ui.laneFurnaceFire}
+                  data-lit={fireLit ? "true" : "false"}
+                >
+                  <span
+                    className={ui.laneFurnaceEmber}
+                    data-lit={fireLit ? "true" : "false"}
+                  />
+                  <span
+                    className={ui.laneFurnaceFlame}
+                    data-lit={fireLit ? "true" : "false"}
+                    data-i="0"
+                  />
+                  <span
+                    className={ui.laneFurnaceFlame}
+                    data-lit={fireLit ? "true" : "false"}
+                    data-i="1"
+                  />
+                  <span
+                    className={ui.laneFurnaceFlame}
+                    data-lit={fireLit ? "true" : "false"}
+                    data-i="2"
+                  />
+                </span>
+              </span>
             </span>
-            <span
-              className={ui.laneFurnaceSmoke}
-              data-active={smokeActive ? "true" : "false"}
-              aria-hidden="true"
-              style={
-                smokeActive
-                  ? {
-                      animation: `furnace-smoke ${ROUTE_SMOKE_MS}ms ease-out forwards`,
-                    }
-                  : undefined
-              }
-            >
-              <span className={ui.laneFurnaceSmokePuff} aria-hidden="true" />
-              <span className={ui.laneFurnaceSmokePuffAlt} aria-hidden="true" />
-            </span>
+            {smoke !== undefined ? (
+              <FurnaceSmoke
+                key={smoke.key}
+                kind={smoke.kind}
+                smokeMs={smoke.smokeMs}
+              />
+            ) : null}
           </span>
         )
       })}
@@ -282,6 +448,29 @@ export function PipelineRoute({
         <RouteTraveler key={flight.id} flight={flight} />
       ))}
     </div>
+  )
+}
+
+function FurnaceSmoke({
+  kind,
+  smokeMs,
+}: {
+  readonly kind: SmokeKind
+  readonly smokeMs: number
+}) {
+  return (
+    <span
+      className={ui.laneFurnaceSmoke}
+      data-kind={kind}
+      aria-hidden="true"
+      style={{ ["--smoke-ms" as string]: `${smokeMs}ms` }}
+    >
+      <span className={ui.laneFurnaceSmokePuff} data-i="0" />
+      <span className={ui.laneFurnaceSmokePuff} data-i="1" />
+      <span className={ui.laneFurnaceSmokePuff} data-i="2" />
+      <span className={ui.laneFurnaceSmokePuff} data-i="3" />
+      <span className={ui.laneFurnaceSmokePuff} data-i="4" />
+    </span>
   )
 }
 
@@ -295,10 +484,11 @@ function RouteTraveler({ flight }: { readonly flight: RouteFlight }) {
 
   if (flight.phase === "eject") {
     style.left = `${from}%`
-    style.animation = `route-traveler-eject ${ROUTE_TRANSITION_MS.eject}ms ease-out forwards`
+    // Scale/opacity only — rotation lives solely on travel so phases do not snap.
+    style.animation = `route-traveler-eject ${ROUTE_TRANSITION_MS.eject}ms cubic-bezier(0.2, 0.85, 0.3, 1.1) forwards`
   } else if (flight.phase === "travel") {
     style.left = `${from}%`
-    style.animation = `route-travel ${ROUTE_TRANSITION_MS.travel}ms ease-in-out forwards`
+    style.animation = `route-travel ${ROUTE_TRANSITION_MS.travel}ms cubic-bezier(0.45, 0.05, 0.25, 1) forwards`
   } else if (flight.phase === "enter") {
     style.left = `${to}%`
     style.animation = `route-traveler-enter ${ROUTE_TRANSITION_MS.enter}ms ease-in forwards`

--- a/apps/harness/src/styles.css
+++ b/apps/harness/src/styles.css
@@ -268,40 +268,49 @@
 }
 
 /*
- * Pipeline route-line furnace choreography (issue #737).
+ * Pipeline route-line furnace choreography (issue #737, pot-belly A).
  * Longer motion is intentional for lane changes only; plate transitions stay 120ms.
  * Honored by the global prefers-reduced-motion base rule (durations collapse).
  */
 @keyframes furnace-eject {
   0% {
-    transform: scale(1);
+    transform: scale(1, 1);
   }
-  35% {
-    transform: scale(0.92, 1.06);
+  18% {
+    transform: scale(1.12, 0.9);
   }
-  70% {
-    transform: scale(1.06, 0.94);
+  42% {
+    transform: scale(0.88, 1.14);
+  }
+  68% {
+    transform: scale(1.06, 0.96);
   }
   100% {
-    transform: scale(1);
+    transform: scale(1, 1);
   }
 }
 
 @keyframes furnace-absorb {
   0% {
-    transform: scale(1);
+    transform: scale(1, 1);
   }
-  25% {
-    transform: scale(0.94, 1.04);
-  }
-  55% {
+  12% {
     transform: scale(1.08, 0.92);
   }
-  80% {
-    transform: scale(0.98, 1.03);
+  28% {
+    transform: scale(0.82, 1.12);
+  }
+  48% {
+    transform: scale(1.18, 0.88);
+  }
+  68% {
+    transform: scale(0.94, 1.06);
+  }
+  82% {
+    transform: scale(1.04, 0.98);
   }
   100% {
-    transform: scale(1);
+    transform: scale(1, 1);
   }
 }
 
@@ -310,42 +319,230 @@
     filter: brightness(1);
   }
   40% {
-    filter: brightness(1.18);
+    filter: brightness(1.28);
   }
   100% {
     filter: brightness(1);
   }
 }
 
-@keyframes furnace-smoke {
+/* Per-puff stack smoke — host mounts with a remount key so this restarts. */
+@keyframes furnace-smoke-puff {
   0% {
     opacity: 0;
-    transform: translate(-50%, 0.15rem) scale(0.4);
+    transform: translate(calc(-50% + var(--sx, 0px)), 0.1rem) scale(0.45);
   }
-  25% {
-    opacity: 0.55;
+  18% {
+    opacity: 0.92;
   }
   100% {
     opacity: 0;
-    transform: translate(-50%, -0.7rem) scale(1.15);
+    transform: translate(calc(-50% + var(--sx, 0px)), -1.35rem) scale(1.85);
   }
 }
 
+/*
+ * Smoke puffs: class is on each span; --smoke-ms comes from the host style.
+ * data-i staggers delay and horizontal drift.
+ */
+.lane-furnace-smoke-puff {
+  animation: furnace-smoke-puff var(--smoke-ms, 1.1s) ease-out forwards;
+  --sx: 0px;
+}
+.lane-furnace-smoke-puff[data-i="0"] {
+  --sx: -0.15rem;
+  animation-delay: 0ms;
+}
+.lane-furnace-smoke-puff[data-i="1"] {
+  --sx: 0.28rem;
+  width: 0.48rem;
+  height: 0.48rem;
+  animation-delay: 90ms;
+}
+.lane-furnace-smoke-puff[data-i="2"] {
+  --sx: -0.32rem;
+  width: 0.65rem;
+  height: 0.65rem;
+  animation-delay: 180ms;
+}
+.lane-furnace-smoke-puff[data-i="3"] {
+  --sx: 0.12rem;
+  width: 0.72rem;
+  height: 0.72rem;
+  animation-delay: 270ms;
+}
+.lane-furnace-smoke-puff[data-i="4"] {
+  --sx: 0.38rem;
+  width: 0.5rem;
+  height: 0.5rem;
+  animation-delay: 360ms;
+}
+
+/*
+ * Slow fire simulation (lit furnaces only). Unhurried — reads as coals
+ * breathing, not a disco. Stagger via data-i / animation-delay on layers.
+ */
+@keyframes furnace-fire-ember {
+  0%,
+  100% {
+    opacity: 0.55;
+    transform: scaleX(1) scaleY(0.85);
+    filter: brightness(0.85) saturate(0.95);
+  }
+  35% {
+    opacity: 0.9;
+    transform: scaleX(1.08) scaleY(1.05);
+    filter: brightness(1.15) saturate(1.1);
+  }
+  62% {
+    opacity: 0.7;
+    transform: scaleX(0.96) scaleY(0.92);
+    filter: brightness(1) saturate(1);
+  }
+}
+
+@keyframes furnace-fire-flame {
+  0%,
+  100% {
+    opacity: 0.35;
+    transform: translateX(-50%) scaleY(0.55) scaleX(0.9) rotate(-4deg);
+    filter: brightness(0.9);
+  }
+  22% {
+    opacity: 0.85;
+    transform: translateX(-50%) scaleY(1.05) scaleX(1) rotate(3deg);
+    filter: brightness(1.2);
+  }
+  48% {
+    opacity: 0.5;
+    transform: translateX(-50%) scaleY(0.7) scaleX(0.95) rotate(-2deg);
+    filter: brightness(1);
+  }
+  74% {
+    opacity: 0.95;
+    transform: translateX(-50%) scaleY(1.15) scaleX(1.05) rotate(5deg);
+    filter: brightness(1.25);
+  }
+}
+
+@keyframes furnace-fire-bloom {
+  0%,
+  100% {
+    opacity: 0.25;
+    transform: translateX(-50%) scale(0.9);
+  }
+  40% {
+    opacity: 0.55;
+    transform: translateX(-50%) scale(1.08);
+  }
+  70% {
+    opacity: 0.35;
+    transform: translateX(-50%) scale(0.95);
+  }
+}
+
+.lane-furnace-ember[data-lit="true"] {
+  animation: furnace-fire-ember 6.5s ease-in-out infinite;
+}
+
+.lane-furnace-flame[data-lit="true"] {
+  left: 50%;
+  height: 70%;
+  transform-origin: 50% 100%;
+  animation: furnace-fire-flame 4.8s ease-in-out infinite;
+}
+
+.lane-furnace-flame[data-i="0"] {
+  left: 32%;
+  width: 26%;
+  height: 65%;
+  animation-duration: 5.4s;
+  animation-delay: 0s;
+}
+
+.lane-furnace-flame[data-i="1"] {
+  left: 50%;
+  width: 30%;
+  height: 78%;
+  animation-duration: 4.6s;
+  animation-delay: -1.8s;
+}
+
+.lane-furnace-flame[data-i="2"] {
+  left: 68%;
+  width: 24%;
+  height: 60%;
+  animation-duration: 5.9s;
+  animation-delay: -3.2s;
+}
+
+/* Per-furnace phase offset so six mouths don't pulse in lockstep.
+   Each lane sets per-tongue delays (queue included — never blanket-override). */
+.lane-furnace[data-lane="queue"] .lane-furnace-flame[data-i="0"] {
+  animation-delay: -0.4s;
+}
+.lane-furnace[data-lane="queue"] .lane-furnace-flame[data-i="1"] {
+  animation-delay: -2.1s;
+}
+.lane-furnace[data-lane="queue"] .lane-furnace-flame[data-i="2"] {
+  animation-delay: -3.6s;
+}
+.lane-furnace[data-lane="build"] .lane-furnace-flame[data-i="0"] {
+  animation-delay: -0.9s;
+}
+.lane-furnace[data-lane="build"] .lane-furnace-flame[data-i="1"] {
+  animation-delay: -2.4s;
+}
+.lane-furnace[data-lane="build"] .lane-furnace-flame[data-i="2"] {
+  animation-delay: -3.8s;
+}
+.lane-furnace[data-lane="review"] .lane-furnace-flame[data-i="0"] {
+  animation-delay: -1.5s;
+}
+.lane-furnace[data-lane="review"] .lane-furnace-flame[data-i="1"] {
+  animation-delay: -0.3s;
+}
+.lane-furnace[data-lane="review"] .lane-furnace-flame[data-i="2"] {
+  animation-delay: -2.7s;
+}
+.lane-furnace[data-lane="pr"] .lane-furnace-flame[data-i="0"] {
+  animation-delay: -2.1s;
+}
+.lane-furnace[data-lane="pr"] .lane-furnace-flame[data-i="1"] {
+  animation-delay: -3.5s;
+}
+.lane-furnace[data-lane="pr"] .lane-furnace-flame[data-i="2"] {
+  animation-delay: -0.6s;
+}
+.lane-furnace[data-lane="complete"] .lane-furnace-flame[data-i="0"] {
+  animation-delay: -0.7s;
+}
+.lane-furnace[data-lane="complete"] .lane-furnace-flame[data-i="1"] {
+  animation-delay: -2.9s;
+}
+.lane-furnace[data-lane="complete"] .lane-furnace-flame[data-i="2"] {
+  animation-delay: -1.6s;
+}
+
+/*
+ * Traveler motion: roll only during travel. Eject/enter use scale + opacity
+ * only so phase handoffs do not snap orientation.
+ */
 @keyframes route-travel {
   from {
     left: var(--travel-from);
-    transform: translate(-50%, -50%) scale(1);
+    transform: translate(-50%, -50%) scale(1) rotate(0deg);
   }
   to {
     left: var(--travel-to);
-    transform: translate(-50%, -50%) scale(1);
+    transform: translate(-50%, -50%) scale(1) rotate(720deg);
   }
 }
 
 @keyframes route-traveler-eject {
   from {
-    transform: translate(-50%, -50%) scale(0.25);
-    opacity: 0.4;
+    transform: translate(-50%, -50%) scale(0.12);
+    opacity: 0.5;
   }
   to {
     transform: translate(-50%, -50%) scale(1);
@@ -359,8 +556,8 @@
     opacity: 1;
   }
   to {
-    transform: translate(-50%, -50%) scale(0.2);
-    opacity: 0.35;
+    transform: translate(-50%, -50%) scale(0.12);
+    opacity: 0;
   }
 }
 

--- a/apps/harness/src/ui.ts
+++ b/apps/harness/src/ui.ts
@@ -541,11 +541,36 @@ export const ui = {
     "mt-[1.6rem] grid gap-[0.55rem] max-[900px]:mt-[0.85rem] max-[900px]:gap-0",
 
   /**
-   * Route spine + pot-belly furnace stops. Spine is centered on the furnace
-   * belly (not the stack). Stack sits above; mouth hangs on the belly bottom.
+   * Route spine + pot-belly furnace stops. Spine is a brass pneumatic tube
+   * (see pipelineRouteSpine) centered on the furnace belly; stack sits above
+   * and has room to vent smoke (overflow visible + top padding).
    */
-  pipelineRoute:
-    "relative grid min-h-[3.1rem] grid-cols-6 items-end pb-[0.15rem] before:pointer-events-none before:absolute before:top-[calc(100%-1.2rem)] before:right-[calc(100%/12)] before:left-[calc(100%/12)] before:h-1 before:-translate-y-1/2 before:bg-ink before:content-[''] max-[900px]:hidden",
+  pipelineRoute: cx(
+    "relative grid min-h-[3.6rem] grid-cols-6 items-end overflow-visible",
+    "pt-[1.1rem] pb-[0.2rem] max-[900px]:hidden",
+  ),
+
+  /** Brass tube with dark bore + rivets — replaces the plain ink hairline. */
+  pipelineRouteSpine: cx(
+    "pointer-events-none absolute top-[calc(100%-1.25rem)] right-[calc(100%/12)] left-[calc(100%/12)]",
+    "z-0 h-[0.7rem] -translate-y-1/2 rounded-[0.35rem]",
+    "border-2 border-ink",
+    "bg-[linear-gradient(180deg,#d4b483_0%,#b08d57_38%,#6b4f2a_100%)]",
+    "shadow-[inset_0_1px_0_rgb(255_255_255/0.35),inset_0_-2px_0_rgb(0_0_0/0.25)]",
+  ),
+
+  pipelineRouteSpineBore: cx(
+    "absolute top-[0.14rem] right-[0.28rem] bottom-[0.14rem] left-[0.28rem] rounded-[0.2rem]",
+    "border border-black/50",
+    "bg-[linear-gradient(180deg,#1a1a1a_0%,#2e2e2e_50%,#121212_100%)]",
+  ),
+
+  /** Sparse brass rivets along the tube (repeating dots). */
+  pipelineRouteSpineRivets: cx(
+    "absolute inset-0 rounded-[0.35rem] opacity-90",
+    "bg-[radial-gradient(circle,#d4b483_0_1.2px,transparent_1.4px)]",
+    "[background-size:1.15rem_100%] [background-position:0.35rem_50%] bg-repeat-x",
+  ),
 
   /**
    * Pot-belly furnace stop (idle + animated phases via data-phase).
@@ -553,65 +578,112 @@ export const ui = {
    * Phase motion durations are applied from ROUTE_TRANSITION_MS / ROUTE_FED_MS
    * in pipeline-route.tsx (inline style) so JS timers and CSS stay lockstep.
    */
-  laneRoundel:
-    "lane-furnace relative z-[1] mx-auto grid w-[2.1rem] justify-items-center",
+  laneRoundel: cx(
+    "lane-furnace relative z-[1] mx-auto grid w-[2.45rem] justify-items-center",
+    "origin-[50%_85%]",
+  ),
 
   laneFurnaceStack: cx(
-    "relative z-[2] mb-[-1px] h-[0.55rem] w-[0.42rem]",
-    "rounded-t-[1px] border border-b-0 border-[#2a2a2a] bg-[#3a3a3a]",
-    "before:absolute before:-top-[0.18rem] before:left-1/2 before:h-[0.2rem] before:w-[0.62rem]",
-    "before:-translate-x-1/2 before:rounded-[1px] before:border before:border-[#2a2a2a]",
-    "before:bg-[linear-gradient(180deg,#c9a227_0%,#8a7018_100%)] before:content-['']",
+    "relative z-[2] mb-[-2px] h-[0.7rem] w-[0.48rem]",
+    "border border-b-0 border-ink bg-[#3a3a3a]",
+    "shadow-[inset_0_1px_0_rgb(255_255_255/0.12)]",
+    // Brass chimney lip
+    "before:absolute before:-top-[0.22rem] before:left-1/2 before:h-[0.26rem] before:w-[0.72rem]",
+    "before:-translate-x-1/2 before:border before:border-ink",
+    "before:bg-[linear-gradient(180deg,#d4b483_0%,#b08d57_45%,#6b4f2a_100%)] before:content-['']",
+    // Small soot rim under the lip
+    "after:absolute after:top-0 after:left-1/2 after:h-[0.12rem] after:w-[0.48rem]",
+    "after:-translate-x-1/2 after:bg-black/35 after:content-['']",
   ),
 
   laneFurnaceBody: cx(
-    "relative grid h-[2.1rem] w-[2.1rem] place-items-center rounded-full",
+    "relative grid h-[2.35rem] w-[2.35rem] place-items-center rounded-full",
     "border-2 border-ink bg-[var(--lane-color)]",
     "font-mono text-[0.78rem] font-extrabold leading-none tracking-[0.02em] tabular-nums text-[var(--lane-text,#fff)]",
+    // Belly shading — pot-belly depth
+    "shadow-[inset_0_-10px_14px_rgb(0_0_0/0.28),inset_0_3px_0_rgb(255_255_255/0.18)]",
     "data-[lane=complete]:border-white data-[lane=complete]:outline data-[lane=complete]:outline-2 data-[lane=complete]:outline-ink",
   ),
 
-  laneFurnaceCount: "relative z-[1] tabular-nums",
+  /** Faint dashed rivet band around the pot. */
+  laneFurnaceBand: cx(
+    "pointer-events-none absolute inset-[4px] z-0 rounded-full",
+    "border border-dashed border-black/20",
+  ),
+
+  laneFurnaceCount: "relative z-[1] -translate-y-[0.15rem] tabular-nums",
 
   /** Dark firebox mouth at the bottom of the belly — traveler enter/exit. */
   laneFurnaceMouth: cx(
-    "pointer-events-none absolute bottom-[0.12rem] left-1/2 z-[2] h-[0.38rem] w-[0.72rem]",
-    "-translate-x-1/2 rounded-[50%] border border-[#1a1a1a] bg-[#1a1a1a]",
-    "shadow-[inset_0_1px_0_rgb(255_255_255/0.08)]",
-  ),
-
-  /** Coal glow in the mouth when the stop holds jobs. */
-  laneFurnaceGlow: cx(
-    "pointer-events-none absolute bottom-[0.16rem] left-1/2 z-[3] h-[0.22rem] w-[0.42rem]",
-    "-translate-x-1/2 rounded-[50%] bg-[radial-gradient(ellipse_at_center,#ff8a2a_0%,#ff4d1c_45%,transparent_75%)]",
-    "opacity-0 data-[lit=true]:opacity-90",
+    "pointer-events-none absolute bottom-[0.14rem] left-1/2 z-[2] h-[0.55rem] w-[1.1rem]",
+    "-translate-x-1/2 overflow-hidden rounded-[0.08rem_0.08rem_0.5rem_0.5rem]",
+    "border-[1.5px] border-ink",
+    "bg-[radial-gradient(ellipse_at_50%_30%,#3a2010_0%,#1a1410_70%)]",
+    "shadow-[inset_0_2px_4px_rgb(0_0_0/0.6)]",
   ),
 
   /**
-   * Stack smoke host. Duration applied from ROUTE_SMOKE_MS in pipeline-route
-   * when data-active; shared puff for eject and absorb.
+   * Slow fire simulation inside the mouth when the stop holds jobs.
+   * Layers: coal bed + 3 staggered flame tongues (keyframes in styles.css).
+   */
+  laneFurnaceFire: cx(
+    "pointer-events-none absolute inset-0 z-[1] opacity-0",
+    "data-[lit=true]:opacity-100",
+  ),
+
+  /** Warm coal bed — slow breathe under the tongues. */
+  laneFurnaceEmber: cx(
+    "lane-furnace-ember absolute bottom-0 left-[10%] right-[10%] h-[55%]",
+    "rounded-[40%] bg-[radial-gradient(ellipse_at_50%_80%,#ff8a2a_0%,#c04010_45%,transparent_75%)]",
+    "opacity-0 data-[lit=true]:opacity-100",
+  ),
+
+  /** Individual flame tongue — data-i staggers phase in styles.css. */
+  laneFurnaceFlame: cx(
+    "lane-furnace-flame absolute bottom-[10%] w-[28%] rounded-[40%_40%_20%_20%/60%_60%_30%_30%]",
+    "opacity-0 data-[lit=true]:opacity-100",
+    "bg-[radial-gradient(ellipse_at_50%_80%,#ffe08a_0%,#ff6a1a_40%,#c02808_75%,transparent_90%)]",
+    "mix-blend-screen",
+  ),
+
+  /**
+   * Soft bloom above the mouth into the belly — only when lit.
+   * Kept separate so the count stays readable.
+   */
+  laneFurnaceGlow: cx(
+    "pointer-events-none absolute bottom-[0.35rem] left-1/2 z-[0] h-[0.55rem] w-[0.85rem]",
+    "-translate-x-1/2 rounded-[50%]",
+    "bg-[radial-gradient(ellipse_at_center,rgb(255_100_30/0.55)_0%,transparent_70%)]",
+    "opacity-0 data-[lit=true]:opacity-100",
+    "data-[lit=true]:animate-[furnace-fire-bloom_5.5s_ease-in-out_infinite]",
+  ),
+
+  /**
+   * Stack smoke host — sits above the chimney lip. Puffs animate via
+   * furnace-smoke-puff keyframes; --smoke-ms set inline from ROUTE_SMOKE_MS.
    */
   laneFurnaceSmoke: cx(
-    "pointer-events-none absolute -top-[0.35rem] left-1/2 z-[3] h-[0.9rem] w-[0.7rem]",
-    "-translate-x-1/2 opacity-0",
+    "pointer-events-none absolute -top-[1.35rem] left-1/2 z-[5] h-[1.6rem] w-[1.4rem]",
+    "-translate-x-1/2 overflow-visible",
   ),
 
+  /** Stagger/offset via [data-i] rules in styles.css (furnace-smoke-puff). */
   laneFurnaceSmokePuff: cx(
-    "absolute bottom-0 left-1/2 h-[0.35rem] w-[0.35rem] -translate-x-1/2",
-    "rounded-full bg-[rgb(80_80_80/0.45)]",
-  ),
-
-  laneFurnaceSmokePuffAlt: cx(
-    "absolute bottom-[0.15rem] left-[35%] h-[0.28rem] w-[0.28rem]",
-    "rounded-full bg-[rgb(100_100_100/0.35)]",
+    "lane-furnace-smoke-puff absolute bottom-0 left-1/2 h-[0.55rem] w-[0.55rem]",
+    "rounded-full opacity-0",
+    "bg-[radial-gradient(circle,rgb(200_200_196/0.92)_0%,rgb(140_140_136/0.4)_55%,transparent_72%)]",
   ),
 
   /** Coal-lump traveler rolling along the route spine. */
   routeTraveler: cx(
-    "pointer-events-none absolute top-[calc(100%-1.2rem)] z-[4] h-[0.55rem] w-[0.55rem]",
-    "-translate-x-1/2 -translate-y-1/2 rounded-[45%_40%_50%_42%]",
-    "border border-[#2a1a0a] bg-[radial-gradient(circle_at_30%_30%,#5a3a1a_0%,#2a1808_70%,#1a1005_100%)]",
-    "shadow-[inset_1px_1px_0_rgb(255_255_255/0.12)]",
+    "pointer-events-none absolute top-[calc(100%-1.25rem)] z-[4] h-[0.65rem] w-[0.7rem]",
+    "-translate-x-1/2 -translate-y-1/2 rounded-[45%_55%_50%_50%]",
+    "border-[1.5px] border-ink",
+    "bg-[radial-gradient(circle_at_30%_30%,#5a4a3a_0%,#1a1410_70%)]",
+    "shadow-[inset_0_1px_0_rgb(255_255_255/0.12)]",
+    // Ember highlight
+    "after:absolute after:top-[22%] after:left-[18%] after:h-[30%] after:w-[35%] after:rounded-full",
+    "after:bg-[rgb(255_100_30/0.45)] after:blur-[0.5px] after:content-['']",
   ),
 
   pipelineLanes:
@@ -702,6 +774,17 @@ export const ui = {
     "px-[0.65rem] py-[0.55rem] pr-[0.65rem] pb-[0.7rem] pl-[0.95rem]",
     "shadow-[inset_6px_0_0_var(--ticket-color,var(--ink))]",
     "data-[lane=complete]:shadow-[inset_6px_0_0_var(--ticket-color,var(--lane-merged)),inset_8px_0_0_var(--merged-halo)]",
+  ),
+
+  /**
+   * Ticket still parked in the source lane while the route traveler is en
+   * route — faded, desaturated. Pair with the HTML `inert` attribute on the
+   * ticket so keyboard focus cannot reach controls (pointer-events alone
+   * is not enough).
+   */
+  jobTicketDeparting: cx(
+    "pointer-events-none select-none opacity-40 grayscale",
+    "border-ink-faint shadow-[inset_6px_0_0_var(--ink-faint)]",
   ),
 
   jobTicketRepo:

--- a/apps/harness/test/kanban-route.test.ts
+++ b/apps/harness/test/kanban-route.test.ts
@@ -166,9 +166,13 @@ describe("kanban home board", () => {
     expect(route).toContain("ui.laneFurnaceSmokePuff")
     expect(route).toContain("laneItemsAssignmentKey")
     expect(route).toContain("ROUTE_FED_MS")
-    expect(route).toContain("ROUTE_SMOKE_MS")
+    expect(route).toContain("smokeDurationMs")
+    expect(route).toContain("furnaceFireLit")
+    expect(route).toContain("useLingeringSmoke")
     expect(route).toMatch(/jobs in \$\{lane\.label\}/)
     expect(route).toContain("prefers-reduced-motion")
+    // Attention stays cold even when occupied.
+    expect(route).toContain("furnaceFireLit(lane.id, count)")
     expect(source).toContain("<MetalLaneHeader")
     expect(metalHeader).toContain("ui.laneHeader")
     expect(metalHeader).toContain("ui.laneTitle")
@@ -491,22 +495,42 @@ describe("kanban home board", () => {
     // Desktop layout lives on recipe strings (no separate media block).
     expect(ui).toContain("pipelineBoard:")
     expect(ui).toContain("pipelineRoute:")
-    // Route spine uses before: pseudo utilities.
-    expect(ui).toMatch(/pipelineRoute:[\s\S]*?before:/)
+    // Brass pneumatic tube spine (not a plain ink hairline).
+    expect(ui).toContain("pipelineRouteSpine:")
+    expect(ui).toContain("pipelineRouteSpineBore:")
     expect(ui).toContain("laneRoundel:")
     // Pot-belly furnace chrome (issue #737).
     expect(ui).toContain("laneFurnaceStack:")
     expect(ui).toContain("laneFurnaceBody:")
+    expect(ui).toContain("laneFurnaceBand:")
     expect(ui).toContain("laneFurnaceMouth:")
+    expect(ui).toContain("laneFurnaceFire:")
+    expect(ui).toContain("laneFurnaceEmber:")
+    expect(ui).toContain("laneFurnaceFlame:")
     expect(ui).toContain("laneFurnaceGlow:")
     expect(ui).toContain("laneFurnaceSmokePuff:")
-    expect(ui).toContain("laneFurnaceSmokePuffAlt:")
+    expect(stylesSource()).toContain("@keyframes furnace-fire-flame")
+    expect(stylesSource()).toContain("@keyframes furnace-fire-ember")
+    // Queue flames use per-tongue delays (no blanket lockstep override).
+    expect(stylesSource()).toContain(
+      '.lane-furnace[data-lane="queue"] .lane-furnace-flame[data-i="0"]',
+    )
+    expect(stylesSource()).not.toContain("--flame-base-delay")
     expect(ui).toContain("routeTraveler:")
+    expect(ui).toContain("jobTicketDeparting:")
     // Phase durations come from ROUTE_*_MS via inline style, not Tailwind literals.
     expect(ui).toContain("ROUTE_TRANSITION_MS")
     expect(stylesSource()).toContain("@keyframes furnace-eject")
     expect(stylesSource()).toContain("@keyframes furnace-absorb")
+    expect(stylesSource()).toContain("@keyframes furnace-smoke-puff")
     expect(stylesSource()).toContain("@keyframes route-travel")
+    // Eject/enter must not rotate (avoids phase-handoff snaps).
+    expect(stylesSource()).toMatch(
+      /@keyframes route-traveler-eject\s*\{[^}]*scale\(0\.12\)[^}]*\}/s,
+    )
+    expect(stylesSource()).not.toMatch(
+      /@keyframes route-traveler-eject\s*\{[^}]*rotate\(/s,
+    )
     expect(ui).toContain("pipelineLanes:")
     expect(ui).toContain("grid-cols-6")
     expect(ui).toContain("gap-0.5")

--- a/apps/harness/test/pipeline-route-transition.test.ts
+++ b/apps/harness/test/pipeline-route-transition.test.ts
@@ -10,13 +10,17 @@ import {
   createRouteFlight,
   displayLaneCount,
   displayLaneCounts,
+  furnaceFireLit,
   laneAssignmentFromLaneItems,
   laneCenterPercent,
   laneItemsAssignmentKey,
   nextFlightPhase,
   phaseDurationMs,
   planLaneTransitions,
+  presentLaneColumnItems,
   reconcileFlights,
+  smokeDurationMs,
+  sourceOrderIndexInLane,
   trueLaneCounts,
 } from "../src/pipeline-route-transition.js"
 import { describe, expect, test } from "bun:test"
@@ -98,24 +102,36 @@ describe("displayLaneCount / displayLaneCounts", () => {
     expect(displayLaneCount({ trueCount: 1, pendingArrivals: 1 })).toBe(0)
   })
 
+  test("keeps source count while departures are still in flight", () => {
+    expect(
+      displayLaneCount({
+        trueCount: 3,
+        pendingArrivals: 0,
+        pendingDepartures: 1,
+      }),
+    ).toBe(4)
+  })
+
   test("never shows a negative count", () => {
     expect(displayLaneCount({ trueCount: 0, pendingArrivals: 2 })).toBe(0)
   })
 
-  test("source matches true count when no pending arrivals there", () => {
+  test("source keeps departing job; dest holds arrival until absorb", () => {
+    // True data after move: build lost one, review gained one.
     const trueCounts = new Map<PipelineLaneId, number>([
       ["queue", 0],
-      ["build", 1],
-      ["review", 2],
+      ["build", 3],
+      ["review", 1],
       ["pr", 0],
       ["attention", 0],
       ["complete", 0],
     ])
-    const flights: Pick<RouteFlight, "to">[] = [{ to: "review" }]
+    const flights: Pick<RouteFlight, "from" | "to">[] = [
+      { from: "build", to: "review" },
+    ]
     const display = displayLaneCounts(trueCounts, flights)
-    // Source already decremented in true data; dest holds +1 until absorb.
-    expect(display.get("build")).toBe(1)
-    expect(display.get("review")).toBe(1)
+    expect(display.get("build")).toBe(4)
+    expect(display.get("review")).toBe(0)
   })
 
   test("overlapping arrivals stack without losing the final true count", () => {
@@ -127,14 +143,85 @@ describe("displayLaneCount / displayLaneCounts", () => {
       ["attention", 0],
       ["complete", 0],
     ])
-    const flights: Pick<RouteFlight, "to">[] = [
-      { to: "review" },
-      { to: "review" },
+    const flights: Pick<RouteFlight, "from" | "to">[] = [
+      { from: "build", to: "review" },
+      { from: "build", to: "review" },
     ]
     const mid = displayLaneCounts(trueCounts, flights)
     expect(mid.get("review")).toBe(1)
     const done = displayLaneCounts(trueCounts, [])
     expect(done.get("review")).toBe(3)
+  })
+})
+
+describe("presentLaneColumnItems", () => {
+  test("keeps departing ticket in source and holds it out of dest", () => {
+    const a = { id: "a" }
+    const b = { id: "b" }
+    const byId = new Map([
+      ["a", a],
+      ["b", b],
+    ])
+    // True data: a already moved to review; a was index 0, b remains alone.
+    const source = presentLaneColumnItems({
+      laneId: "build",
+      laneItems: [b],
+      flights: [
+        {
+          workItemId: "a",
+          from: "build",
+          to: "review",
+          sourceOrderIndex: 0,
+        },
+      ],
+      workItemById: byId,
+    })
+    expect(source).toEqual([
+      { workItem: a, departing: true },
+      { workItem: b, departing: false },
+    ])
+
+    const dest = presentLaneColumnItems({
+      laneId: "review",
+      laneItems: [a],
+      flights: [
+        {
+          workItemId: "a",
+          from: "build",
+          to: "review",
+          sourceOrderIndex: 0,
+        },
+      ],
+      workItemById: byId,
+    })
+    expect(dest).toEqual([])
+  })
+
+  test("inserts departing ticket at frozen sourceOrderIndex mid-stack", () => {
+    const a = { id: "a" }
+    const b = { id: "b" }
+    const c = { id: "c" }
+    const byId = new Map([
+      ["a", a],
+      ["b", b],
+      ["c", c],
+    ])
+    // Prior order was a, b, c; b left (index 1); a and c remain.
+    const source = presentLaneColumnItems({
+      laneId: "build",
+      laneItems: [a, c],
+      flights: [
+        {
+          workItemId: "b",
+          from: "build",
+          to: "review",
+          sourceOrderIndex: 1,
+        },
+      ],
+      workItemById: byId,
+    })
+    expect(source.map((entry) => entry.workItem.id)).toEqual(["a", "b", "c"])
+    expect(source[1]?.departing).toBe(true)
   })
 })
 
@@ -201,9 +288,14 @@ describe("laneItemsAssignmentKey", () => {
 })
 
 describe("ROUTE_* duration constants", () => {
-  test("fed and smoke durations stay aligned with the phase table", () => {
+  test("fed and smoke durations stay positive and total matches phases", () => {
     expect(ROUTE_FED_MS).toBeGreaterThan(0)
-    expect(ROUTE_SMOKE_MS).toBe(ROUTE_TRANSITION_MS.absorb)
+    // Smoke plume is longer than a single phase so puffs read clearly.
+    expect(ROUTE_SMOKE_MS).toBeGreaterThanOrEqual(ROUTE_TRANSITION_MS.absorb)
+    expect(smokeDurationMs("absorb")).toBe(ROUTE_SMOKE_MS)
+    expect(smokeDurationMs("eject")).toBeLessThanOrEqual(
+      ROUTE_TRANSITION_MS.eject + 200,
+    )
     expect(ROUTE_TRANSITION_MS.eject).toBeGreaterThan(0)
     expect(ROUTE_TRANSITION_MS.travel).toBeGreaterThan(0)
     expect(ROUTE_TRANSITION_MS.enter).toBeGreaterThan(0)
@@ -214,6 +306,49 @@ describe("ROUTE_* duration constants", () => {
         ROUTE_TRANSITION_MS.enter +
         ROUTE_TRANSITION_MS.absorb,
     )
+  })
+})
+
+describe("furnaceFireLit", () => {
+  test("lights occupied furnaces except attention", () => {
+    expect(furnaceFireLit("build", 1)).toBe(true)
+    expect(furnaceFireLit("review", 2)).toBe(true)
+    expect(furnaceFireLit("queue", 0)).toBe(false)
+    expect(furnaceFireLit("attention", 3)).toBe(false)
+    expect(furnaceFireLit("complete", 1)).toBe(true)
+  })
+})
+
+describe("sourceOrderIndexInLane", () => {
+  test("returns the index of the work item in the prior source order", () => {
+    const orderedIdsByLane = new Map<PipelineLaneId, readonly string[]>([
+      ["build", ["a", "b", "c"]],
+    ])
+    expect(
+      sourceOrderIndexInLane({
+        workItemId: "b",
+        laneId: "build",
+        orderedIdsByLane,
+      }),
+    ).toBe(1)
+    expect(
+      sourceOrderIndexInLane({
+        workItemId: "missing",
+        laneId: "build",
+        orderedIdsByLane,
+      }),
+    ).toBe(0)
+  })
+})
+
+describe("createRouteFlight", () => {
+  test("records sourceOrderIndex for mid-stack greying", () => {
+    const flight = createRouteFlight(
+      { workItemId: "a", from: "build", to: "review" },
+      2,
+    )
+    expect(flight.sourceOrderIndex).toBe(2)
+    expect(flight.phase).toBe("eject")
   })
 })
 

--- a/biome.json
+++ b/biome.json
@@ -15,7 +15,8 @@
       "!!**/.nx",
       "!!**/generated",
       "!!**/routeTree.gen.ts",
-      "!!**/drizzle"
+      "!!**/drizzle",
+      "!!**/prototypes/**"
     ]
   },
   "formatter": {


### PR DESCRIPTION
## Why

#738 landed pot-belly furnace stops and lane-transition animation on the pipeline route line. Manual tryouts and a structured local review showed gaps that made the handoff harder to trust: smoke cut off when the flight phase ended, departing tickets stayed keyboard-focusable, greyed cards jumped to the bottom of the stack, and the Attention furnace incorrectly shared the fire treatment.

## What Changed

- **Lingering stack smoke** — plumes stay mounted for full `smokeDurationMs` after eject/absorb instead of unmounting with the phase.
- **Departing tickets** — stay in the source lane, greyed out, with HTML `inert` so mouse and keyboard cannot act on them mid-flight; reinsert at frozen `sourceOrderIndex` so mid-stack cards do not jump to the end.
- **Slow fire simulation** on occupied furnaces; **Attention stays cold** (`furnaceFireLit`).
- **Brass pneumatic-tube spine**, stronger pot-belly chrome, unhurried choreography (~3.9s).
- Traveler **rotation only during travel** (no eject/enter snap); queue flame tongues use per-index stagger.
- Dropped unused `inFlightIds` / `laneItems` prop on `PipelineRoute`.
- Biome ignores `**/prototypes/**` so throwaway HTML demos do not fail harness lint.
- Unit coverage for fire lighting, smoke durations, mid-stack presentation, and route-line chrome.

Follow-up polish to the route-line work from #737 / #738.