### PR TITLE
fix(harness): polish Queue empty-state hint tag, emphasis, and repos link

### DIFF
--- a/apps/harness/src/kanban-board.tsx
+++ b/apps/harness/src/kanban-board.tsx
@@ -1,4 +1,5 @@
 import { useQueries, useSuspenseQuery } from "@tanstack/react-query"
+import { Link } from "@tanstack/react-router"
 import { type CSSProperties, Suspense, useState } from "react"
 import { Banner } from "./banner.js"
 import { Copy } from "./copy.js"
@@ -428,17 +429,16 @@ function KanbanJobsBoard() {
                   )}
                   {lane.id === "queue" && (
                     <aside className={ui.queueHint}>
-                      <span className={ui.queueHintTag}>Queue</span>
                       <p className={ui.queueHintText}>
                         Feed the queue — label issues with{" "}
                         <code className={ui.queueHintCode}>
                           ready-for-agent
                         </code>
-                        . When they show up in your repos, click{" "}
-                        <strong className={ui.queueHintAction}>
-                          Implement now
-                        </strong>
-                        .
+                        . When they show up in{" "}
+                        <Link to="/repos" className={ui.queueHintLink}>
+                          your repos
+                        </Link>
+                        , click Implement now.
                       </p>
                       <div className={ui.queueHintMenuIllus} aria-hidden="true">
                         <span className={ui.queueHintMenuKebab}>

--- a/apps/harness/src/ui.ts
+++ b/apps/harness/src/ui.ts
@@ -663,9 +663,6 @@ export const ui = {
   queueHint:
     "m-[0.55rem] mt-auto grid gap-[0.45rem] border-2 border-ink bg-lane-queue px-[0.7rem] py-[0.65rem] text-[#151515]",
 
-  queueHintTag:
-    "justify-self-start bg-[#151515] px-[0.4rem] py-[0.16rem] font-mono text-[0.62rem] font-bold tracking-[0.16em] uppercase text-lane-queue",
-
   queueHintText:
     "m-0 font-display text-[0.9rem] font-medium leading-[1.35] text-[#151515]",
 
@@ -673,8 +670,13 @@ export const ui = {
   queueHintCode:
     "rounded-none border border-[#151515] bg-[#151515] px-[0.28rem] py-[0.05rem] font-mono text-[0.72rem] font-bold tracking-[0.02em] text-lane-queue",
 
-  /** Emphasize the Implement now control name inside the hint body. */
-  queueHintAction: "font-semibold not-italic",
+  /**
+   * Inline nav link to /repos inside the queue empty-state hint ("your
+   * repos"). Underline + focus ring so it reads as a control on the yellow
+   * lane card.
+   */
+  queueHintLink:
+    "text-[#151515] underline underline-offset-2 hover:decoration-2 hover:decoration-signal focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#151515]",
 
   /**
    * Compact static mock of the repos issue ⋮ menu (Implement now /

--- a/apps/harness/test/kanban-route.test.ts
+++ b/apps/harness/test/kanban-route.test.ts
@@ -180,6 +180,14 @@ describe("kanban home board", () => {
     expect(source).toContain("Implement now")
     expect(source).toContain("Implement locally")
     expect(source).toContain("ui.queueHintMenuIllus")
+    // Issue #742: no redundant Queue tag; "Implement now" is plain body text;
+    // "your repos" links to the Repos view.
+    expect(source).not.toContain("ui.queueHintTag")
+    expect(source).not.toContain("ui.queueHintAction")
+    expect(source).not.toContain("<strong")
+    expect(source).toContain('to="/repos"')
+    expect(source).toContain("ui.queueHintLink")
+    expect(source).toContain("your repos")
     expect(source).not.toContain("Manage repos →")
     expect(source).not.toContain("work starts at your repos")
   })
@@ -550,7 +558,10 @@ describe("kanban home board", () => {
     expect(ui).toContain("queueHint:")
     expect(ui).toContain("queueHintMenuIllus:")
     expect(ui).toContain("queueHintMenuItem:")
-    expect(ui).not.toContain("queueHintLink:")
+    expect(ui).toContain("queueHintLink:")
+    // Issue #742: tag chip and bold action emphasis removed from empty-state.
+    expect(ui).not.toContain("queueHintTag:")
+    expect(ui).not.toContain("queueHintAction:")
     // Counts live in route roundels; header keeps title only.
     expect(ui).not.toContain("laneNumber:")
     expect(ui).not.toContain("laneCount:")


### PR DESCRIPTION
Why

The Queue lane empty-state card repeated the lane name, over-emphasized
"Implement now" in the body copy, and left "your repos" as plain text even
though operators need a direct jump to the Repos view.

What

- Drop the redundant top "Queue" chip (`queueHintTag`); the lane header
  already labels the column.
- Render "Implement now" as plain body text (no <strong> /
  `queueHintAction`).
- Link "your repos" to `/repos` via TanStack Router with underline and
  focus-ring styling (`queueHintLink`).
- Leave the decorative menu illustration (Implement now / Implement
  locally) unchanged.
- Remove dead `queueHintTag` / `queueHintAction` tokens; update
  `kanban-route` source-scan tests for the new contract.

Verification

- `bunx nx test harness` (unit + vitest suites green)
- `bunx nx run harness:typecheck`
- Local code review: clean (no open findings)

Implements the polish requested in #742.

Closes #742