### PR TITLE
refactor(harness): collapse makeResolveRuntime backend branches into one shared body

### DIFF
--- a/apps/harness/src/server/application.server.ts
+++ b/apps/harness/src/server/application.server.ts
@@ -74,47 +74,29 @@ const makeResolveRuntime = (
   platformLayer: Layer.Layer<PlatformServices>,
   sidecarUrl: string | undefined,
 ): ResolveAgentBackendRuntime => {
+  const backendLayers = (backendId: AgentBackendId) => {
+    if (backendId === AGENT_BACKEND_IDS.grok) {
+      return Layer.mergeAll(
+        Grok.layer().pipe(Layer.provide(platformLayer)),
+        GrokSessionTelemetryLive(),
+      )
+    }
+    if (backendId === AGENT_BACKEND_IDS.codex) {
+      return Layer.mergeAll(
+        Codex.layer().pipe(Layer.provide(platformLayer)),
+        CodexSessionTelemetryLive(),
+      )
+    }
+    return Layer.mergeAll(
+      Opencode.layer({
+        ...(sidecarUrl === undefined ? {} : { keymaxxerMcpUrl: sidecarUrl }),
+      }).pipe(Layer.provide(platformLayer)),
+      OpencodeSessionTelemetryLive(),
+    )
+  }
+
   return (backendId: AgentBackendId) => {
     const registration = resolveActiveRegistration(backendId)
-
-    if (registration.descriptor.id === AGENT_BACKEND_IDS.grok) {
-      return Effect.gen(function* () {
-        const adapter = yield* AgentBackend
-        const telemetry = yield* SessionTelemetryProvider
-        return {
-          registration,
-          adapter,
-          telemetry,
-        }
-      }).pipe(
-        Effect.provide(
-          Layer.mergeAll(
-            Grok.layer().pipe(Layer.provide(platformLayer)),
-            GrokSessionTelemetryLive(),
-          ),
-        ),
-      )
-    }
-
-    if (registration.descriptor.id === AGENT_BACKEND_IDS.codex) {
-      return Effect.gen(function* () {
-        const adapter = yield* AgentBackend
-        const telemetry = yield* SessionTelemetryProvider
-        return {
-          registration,
-          adapter,
-          telemetry,
-        }
-      }).pipe(
-        Effect.provide(
-          Layer.mergeAll(
-            Codex.layer().pipe(Layer.provide(platformLayer)),
-            CodexSessionTelemetryLive(),
-          ),
-        ),
-      )
-    }
-
     return Effect.gen(function* () {
       const adapter = yield* AgentBackend
       const telemetry = yield* SessionTelemetryProvider
@@ -123,18 +105,7 @@ const makeResolveRuntime = (
         adapter,
         telemetry,
       }
-    }).pipe(
-      Effect.provide(
-        Layer.mergeAll(
-          Opencode.layer({
-            ...(sidecarUrl === undefined
-              ? {}
-              : { keymaxxerMcpUrl: sidecarUrl }),
-          }).pipe(Layer.provide(platformLayer)),
-          OpencodeSessionTelemetryLive(),
-        ),
-      ),
-    )
+    }).pipe(Effect.provide(backendLayers(registration.descriptor.id)))
   }
 }
 


### PR DESCRIPTION
## Why

`makeResolveRuntime` in the harness application bootstrap repeated the same
`Effect.gen` body three times (Grok, Codex, OpenCode), differing only in which
backend + session-telemetry layer pair was provided. That made a pure wiring
change harder to read and would force a fourth copy when another backend is
added.

## What

- Extract `backendLayers(backendId)` that returns the merged adapter +
  telemetry layers for Grok, Codex, or OpenCode (including optional Keymaxxer
  MCP URL for OpenCode).
- Keep a single shared resolve body that yields `AgentBackend` and
  `SessionTelemetryProvider`, then `Effect.provide`s `backendLayers` using
  `registration.descriptor.id` (same dispatch key as before, including
  OpenCode fallback via `resolveActiveRegistration`).

No intentional behaviour change.

## Verification

- `bunx nx run harness:typecheck`
- `bunx biome check apps/harness/src/server/application.server.ts`
- `bunx nx run harness:test` (92 tests, including application runtime
  disposal)

## Notes

- Review noted that `backendLayers` still falls through to OpenCode for
  non-Grok/non-Codex ids. That matches the previous structure and the
  platform default; an exhaustive `switch`/map is deferred as optional
  follow-up when a fourth backend is added.

Closes #719