### PR TITLE
fix(harness): keep Merged pot-belly furnace unlit when occupied

### DIFF
--- a/apps/harness/src/pipeline-route-transition.ts
+++ b/apps/harness/src/pipeline-route-transition.ts
@@ -66,11 +66,12 @@ export function smokeDurationMs(kind: "eject" | "absorb"): number {
 }
 
 /**
- * Attention is a holding pen — cold mouth, no fire even when occupied.
- * Shared so UI and tests agree.
+ * Fire lights only on the four active pipeline furnaces when occupied.
+ * Attention (holding pen) and Merged/`complete` stay cold even when they hold
+ * tickets. Shared so UI and tests agree.
  */
 export function furnaceFireLit(laneId: PipelineLaneId, count: number): boolean {
-  return count > 0 && laneId !== "attention"
+  return count > 0 && laneId !== "attention" && laneId !== "complete"
 }
 
 const LANE_INDEX = new Map<PipelineLaneId, number>(

--- a/apps/harness/test/pipeline-route-transition.test.ts
+++ b/apps/harness/test/pipeline-route-transition.test.ts
@@ -310,12 +310,19 @@ describe("ROUTE_* duration constants", () => {
 })
 
 describe("furnaceFireLit", () => {
-  test("lights occupied furnaces except attention", () => {
+  test("lights only occupied active pipeline furnaces", () => {
+    expect(furnaceFireLit("queue", 1)).toBe(true)
     expect(furnaceFireLit("build", 1)).toBe(true)
     expect(furnaceFireLit("review", 2)).toBe(true)
+    expect(furnaceFireLit("pr", 1)).toBe(true)
     expect(furnaceFireLit("queue", 0)).toBe(false)
+    expect(furnaceFireLit("build", 0)).toBe(false)
+    expect(furnaceFireLit("review", 0)).toBe(false)
+    expect(furnaceFireLit("pr", 0)).toBe(false)
     expect(furnaceFireLit("attention", 3)).toBe(false)
-    expect(furnaceFireLit("complete", 1)).toBe(true)
+    expect(furnaceFireLit("attention", 0)).toBe(false)
+    expect(furnaceFireLit("complete", 1)).toBe(false)
+    expect(furnaceFireLit("complete", 0)).toBe(false)
   })
 })
 


### PR DESCRIPTION
## Why

On the kanban route line, pot-belly furnaces light fire only for active
work. Attention already stayed cold, but Merged (`complete`) still lit
whenever it held tickets because `furnaceFireLit` only excluded
`attention`.

## What

- Update `furnaceFireLit` so fire is lit only for occupied Queue /
  Build / Review / PR lanes (`count > 0` and lane is neither
  `attention` nor `complete`).
- Expand unit coverage for all six `PipelineLaneId`s empty and
  occupied; occupied Merged now expects unlit.
- No UI/CSS change: `pipeline-route.tsx` already drives fire chrome
  from `data-lit` via `furnaceFireLit`.

## Verification

- `bunx nx test harness -- test/pipeline-route-transition.test.ts`
  (including `furnaceFireLit > lights only occupied active pipeline
  furnaces`)
- Local code review of uncommitted changes: clean (no open findings)

Closes #745