### PR TITLE
feat(harness): add copper reset control

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,7 @@ node_modules
 /apps/harness/playwright-report/
 /apps/harness/test-results/
 /apps/harness/.features-gen/
+/apps/harness/prototypes/
 /libpeerconnection.log
 npm-debug.log
 yarn-error.log

--- a/apps/harness/src/routes/index.tsx
+++ b/apps/harness/src/routes/index.tsx
@@ -74,6 +74,7 @@ import {
   statusMessageClassNameForStatus,
 } from "../work-item-progress-chrome.js"
 import { workItemPullRequestUrl } from "../work-item-pull-request-url.js"
+import { WorkItemResetButton } from "../work-item-reset-button.js"
 
 // Re-export for callers that still import from the home route module.
 export type { Repository } from "../repositories-query.js"
@@ -3717,55 +3718,11 @@ export function WorkItemLifecycleStatus({
       {(canReset || canRetry) && (
         <div className="mt-2 flex flex-wrap gap-2">
           {canReset && (
-            <button
-              type="button"
-              className={cx(ui.iconBtn, ui.iconBtnArmed)}
+            <WorkItemResetButton
+              pending={reset.isPending}
               disabled={actionsPending}
-              onClick={() => reset.mutate()}
-              aria-label={reset.isPending ? "Resetting job" : "Reset job"}
-              title={reset.isPending ? "Resetting..." : "Reset"}
-            >
-              {reset.isPending ? (
-                <svg
-                  aria-hidden="true"
-                  className="animate-spin motion-reduce:animate-none"
-                  viewBox="0 0 24 24"
-                  fill="none"
-                >
-                  <circle
-                    className="opacity-25"
-                    cx="12"
-                    cy="12"
-                    r="9"
-                    stroke="currentColor"
-                    strokeWidth="3"
-                  />
-                  <path
-                    className="opacity-75"
-                    d="M12 3a9 9 0 0 1 9 9"
-                    stroke="currentColor"
-                    strokeWidth="3"
-                    strokeLinecap="round"
-                  />
-                </svg>
-              ) : (
-                <svg
-                  aria-hidden="true"
-                  viewBox="0 0 24 24"
-                  fill="none"
-                  stroke="currentColor"
-                  strokeWidth="2"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                >
-                  <path d="M3 6h18" />
-                  <path d="M8 6V4h8v2" />
-                  <path d="m19 6-1 14H6L5 6" />
-                  <path d="M10 11v5" />
-                  <path d="M14 11v5" />
-                </svg>
-              )}
-            </button>
+              onReset={() => reset.mutate()}
+            />
           )}
           {canRetry && (
             <button

--- a/apps/harness/src/styles.css
+++ b/apps/harness/src/styles.css
@@ -561,6 +561,69 @@
   }
 }
 
+/* Compact copper Work Item reset control. Repeats only while reset is pending. */
+@keyframes work-item-reset-lid {
+  0%,
+  100% {
+    transform: translate(0, 0) rotate(0);
+  }
+  18%,
+  64% {
+    transform: translate(0.05rem, -0.3rem) rotate(27deg);
+  }
+  78% {
+    transform: translate(0.02rem, -0.05rem) rotate(4deg);
+  }
+}
+
+@keyframes work-item-reset-ticket {
+  0%,
+  12% {
+    opacity: 0;
+    transform: translateY(-0.35rem) rotate(8deg) scale(1);
+  }
+  22% {
+    opacity: 1;
+  }
+  58% {
+    opacity: 1;
+    transform: translateY(0.95rem) rotate(-13deg) scale(0.72);
+  }
+  68%,
+  100% {
+    opacity: 0;
+    transform: translateY(1.2rem) rotate(-20deg) scale(0.3);
+  }
+}
+
+@keyframes work-item-reset-bin {
+  0%,
+  55%,
+  100% {
+    transform: scale(1);
+  }
+  66% {
+    transform: scale(1.04, 0.94);
+  }
+  75% {
+    transform: scale(0.98, 1.03);
+  }
+}
+
+@keyframes work-item-reset-steam {
+  0% {
+    opacity: 0;
+    transform: translate(0, 0) scale(0.35);
+  }
+  25% {
+    opacity: 0.52;
+  }
+  100% {
+    opacity: 0;
+    transform: translate(0.2rem, -0.65rem) scale(1.6);
+  }
+}
+
 /* Native <dialog> backdrop — no Tailwind equivalent for ::backdrop on dialog */
 @utility dialog-backdrop {
   &::backdrop {

--- a/apps/harness/src/ui.ts
+++ b/apps/harness/src/ui.ts
@@ -1117,7 +1117,7 @@ export const ui = {
  *    — ::backdrop is not available as a Tailwind variant on the dialog element
  *      in a portable way; keep in styles.css.
  *
- * 2. @keyframes skeleton-pulse, furnace-*, route-travel, route-traveler-*
+ * 2. @keyframes skeleton-pulse, furnace-*, route-*, work-item-reset-*
  *    — Keyframes stay in styles.css; utilities reference
  *      animate-[skeleton-pulse_1.2s_ease-in-out_infinite]. Furnace / traveler
  *      motion for #737 uses inline style.animation with ROUTE_*_MS durations.

--- a/apps/harness/src/work-item-reset-button.tsx
+++ b/apps/harness/src/work-item-reset-button.tsx
@@ -1,0 +1,64 @@
+export function WorkItemResetButton({
+  pending,
+  disabled,
+  onReset,
+}: {
+  readonly pending: boolean
+  readonly disabled: boolean
+  readonly onReset: () => void
+}) {
+  const label = pending ? "Resetting job" : "Reset job"
+
+  return (
+    <button
+      type="button"
+      className="group relative isolate block h-[2.125rem] w-9 shrink-0 cursor-pointer border-0 bg-transparent p-0 text-ink disabled:cursor-wait disabled:opacity-55 data-[pending=true]:opacity-100"
+      disabled={disabled}
+      onClick={onReset}
+      aria-label={label}
+      aria-busy={pending}
+      title={pending ? "Resetting..." : "Reset"}
+      data-pending={pending}
+      data-work-item-reset-control
+    >
+      <span
+        aria-hidden="true"
+        className="pointer-events-none absolute right-1 bottom-[-0.15rem] left-1 -z-10 h-2 rounded-[50%] bg-black/30 blur-[3px] transition-transform duration-100 group-hover:scale-x-105"
+      />
+      <span
+        aria-hidden="true"
+        className="pointer-events-none absolute top-[-0.1rem] left-[0.86rem] z-[4] grid h-[0.65rem] w-2 place-items-center border border-[#1d1d1d] bg-[#f6f0d7] font-mono text-[0.22rem] font-extrabold text-[#3f3a31] opacity-0 shadow-[0_1px_2px_rgb(0_0_0/0.35)] rotate-[8deg] group-data-[pending=true]:animate-[work-item-reset-ticket_1.35s_ease-in-out_infinite]"
+      >
+        #
+      </span>
+      <span
+        aria-hidden="true"
+        className="pointer-events-none absolute right-[0.22rem] bottom-0 left-[0.22rem] z-[2] h-[1.48rem] overflow-hidden rounded-t-[0.18rem] rounded-b-[0.38rem] border border-[#35170f] bg-[radial-gradient(circle_at_68%_17%,rgb(81_38_23/0.48)_0_1px,transparent_1.6px),radial-gradient(circle_at_22%_73%,rgb(239_173_117/0.24)_0_1px,transparent_1.8px),repeating-linear-gradient(0deg,transparent_0_4px,rgb(43_18_11/0.2)_4px_5px),linear-gradient(92deg,#3d1a11_0%,#854126_11%,#d48a58_31%,#9f5432_52%,#e19a68_68%,#73341f_86%,#32140d_100%)] shadow-[inset_2px_0_2px_rgb(255_204_154/0.2),inset_-3px_0_3px_rgb(32_11_6/0.38),inset_0_-4px_5px_rgb(41_15_7/0.25),0_1px_0_#1c0c08] [clip-path:polygon(5%_0,95%_0,84%_100%,16%_100%)] transition-[filter] duration-150 group-hover:saturate-[1.16] group-hover:brightness-105 group-data-[pending=true]:animate-[work-item-reset-bin_1.35s_ease-in-out_infinite]"
+      >
+        <span className="absolute top-[0.3rem] right-[0.05rem] left-[0.05rem] h-[0.14rem] border-y border-[#4d2114] bg-[linear-gradient(#dc8c54,#6f321f_45%,#b9623a_70%,#4a2015)] shadow-[0_1px_2px_rgb(39_14_7/0.35)]" />
+        <span className="absolute right-[0.05rem] bottom-[0.24rem] left-[0.05rem] h-[0.14rem] border-y border-[#4d2114] bg-[linear-gradient(#dc8c54,#6f321f_45%,#b9623a_70%,#4a2015)] shadow-[0_1px_2px_rgb(39_14_7/0.35)]" />
+        <span className="absolute top-[0.57rem] left-1/2 grid h-2 w-2 -translate-x-1/2 place-items-center rounded-full border border-[#432015] bg-[radial-gradient(circle_at_38%_30%,#e5aa75,#8a4329_55%,#3d1a10)] font-display text-[0.28rem] font-black text-[#3b190f] shadow-[inset_0_1px_rgb(255_220_174/0.35),0_1px_1px_rgb(35_11_5/0.5)]">
+          R
+        </span>
+      </span>
+      <span
+        aria-hidden="true"
+        className="pointer-events-none absolute top-[0.4rem] left-[0.04rem] z-[5] h-[0.52rem] w-[2.17rem] origin-[90%_58%] rounded-[50%] border border-[#32140d] bg-[radial-gradient(ellipse_at_45%_20%,#efb07b_0%,#b96b43_34%,#71351f_67%,#30120b_100%)] shadow-[inset_0_1px_1px_rgb(255_223_184/0.38),inset_0_-2px_1px_rgb(45_14_7/0.52),0_1px_1px_rgb(37_12_6/0.42)] transition-transform duration-150 group-hover:-translate-y-px group-hover:-rotate-3 group-data-[pending=true]:animate-[work-item-reset-lid_1.35s_ease-in-out_infinite]"
+      >
+        <span className="absolute top-[-0.06rem] right-[0.24rem] bottom-[-0.06rem] left-[0.24rem] rounded-[50%] border border-[rgb(72_30_18/0.76)]" />
+      </span>
+      <span
+        aria-hidden="true"
+        className="pointer-events-none absolute top-[0.05rem] left-[0.68rem] z-[6] h-[0.4rem] w-[0.88rem] origin-[86%_90%] rounded-t-[0.35rem] border-[0.1rem] border-b-0 border-[#49251b] shadow-[inset_0.05rem_0_#b6704c,0_1px_1px_rgb(0_0_0/0.5)] group-data-[pending=true]:animate-[work-item-reset-lid_1.35s_ease-in-out_infinite]"
+      />
+      <span
+        aria-hidden="true"
+        className="pointer-events-none absolute top-[0.66rem] right-[0.02rem] z-[7] h-[0.16rem] w-[0.28rem] rounded-[0.12rem] border border-[#2f130c] bg-[linear-gradient(#c67648,#552719)]"
+      />
+      <span
+        aria-hidden="true"
+        className="pointer-events-none absolute top-0 right-[0.28rem] z-[8] h-[0.3rem] w-[0.3rem] rounded-full bg-[#857c72] opacity-0 blur-[1px] group-data-[pending=true]:animate-[work-item-reset-steam_1.35s_ease-in-out_0.7s_infinite]"
+      />
+    </button>
+  )
+}

--- a/apps/harness/test/jobs-reset-visibility.test.ts
+++ b/apps/harness/test/jobs-reset-visibility.test.ts
@@ -94,9 +94,10 @@ describe("Jobs Reset button wiring", () => {
     expect(lifecycle).toContain("isTerminal: workItem.isTerminal")
     expect(lifecycle).toContain('isNeedsHuman: status === "NEEDS_HUMAN"')
     expect(lifecycle).toContain("resetWorkItem")
-    expect(lifecycle).toContain(
-      'aria-label={reset.isPending ? "Resetting job" : "Reset job"}',
-    )
+    expect(lifecycle).toContain("<WorkItemResetButton")
+    expect(lifecycle).toContain("pending={reset.isPending}")
+    expect(lifecycle).toContain("disabled={actionsPending}")
+    expect(lifecycle).toContain("onReset={() => reset.mutate()}")
   })
 
   test("held Queue rows are not denylisted for Reset the way Retry is", () => {

--- a/apps/harness/test/waiting-for-blockers-working-row.test.ts
+++ b/apps/harness/test/waiting-for-blockers-working-row.test.ts
@@ -71,9 +71,9 @@ describe("Waiting for blockers Working-row polish", () => {
     expect(lifecycle).toContain("isTerminal: workItem.isTerminal")
     expect(lifecycle).toContain('isNeedsHuman: status === "NEEDS_HUMAN"')
     expect(lifecycle).toContain("resetWorkItem")
-    expect(lifecycle).toContain(
-      'aria-label={reset.isPending ? "Resetting job" : "Reset job"}',
-    )
+    expect(lifecycle).toContain("<WorkItemResetButton")
+    expect(lifecycle).toContain("pending={reset.isPending}")
+    expect(lifecycle).toContain("onReset={() => reset.mutate()}")
   })
 
   test("Issue kebab offers Queue and Implement actions from shared eligibility", () => {

--- a/apps/harness/test/work-item-reset-button.test.tsx
+++ b/apps/harness/test/work-item-reset-button.test.tsx
@@ -1,0 +1,35 @@
+import { renderToStaticMarkup } from "react-dom/server"
+import { WorkItemResetButton } from "../src/work-item-reset-button.js"
+import { describe, expect, test } from "bun:test"
+
+describe("WorkItemResetButton", () => {
+  test("renders the compact copper reset control with an accessible label", () => {
+    const html = renderToStaticMarkup(
+      <WorkItemResetButton
+        pending={false}
+        disabled={false}
+        onReset={() => undefined}
+      />,
+    )
+
+    expect(html).toContain('aria-label="Reset job"')
+    expect(html).toContain('aria-busy="false"')
+    expect(html).toContain("data-work-item-reset-control")
+    expect(html).toContain("h-[2.125rem] w-9")
+    expect(html).toContain(">R</span>")
+    expect(html).not.toContain("<svg")
+  })
+
+  test("announces and animates the pending reset", () => {
+    const html = renderToStaticMarkup(
+      <WorkItemResetButton pending disabled onReset={() => undefined} />,
+    )
+
+    expect(html).toContain('aria-label="Resetting job"')
+    expect(html).toContain('aria-busy="true"')
+    expect(html).toContain('data-pending="true"')
+    expect(html).toContain("disabled")
+    expect(html).toContain("work-item-reset-ticket")
+    expect(html).toContain("work-item-reset-lid")
+  })
+})


### PR DESCRIPTION
## Why

The Work Item reset action used a generic trash icon that did not match the Harness's industrial visual language. The replacement needs to remain compact beside Retry while making the destructive action immediately recognizable.

## What Changed

- replace the inline reset icon with a dedicated, accessible compact copper trashcan control
- preserve the existing reset mutation, disabled state, error handling, and idle/pending labels
- animate the lid, discarded ticket, bin, and steam while reset is pending, with the existing reduced-motion policy
- add focused component and lifecycle-wiring tests
- ignore throwaway Harness prototypes in Git

## Verification

Rendered the production `WorkItemResetButton` against the built Harness CSS at desktop and mobile widths. The idle and pending states, Retry alignment, accessible labels, and pending animation rendered without browser errors or horizontal overflow.
