### PR TITLE
ci: parallelize quality gates and harness smoke/e2e

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -96,7 +96,8 @@ jobs:
       #   if: always()
 
   # Dev smoke + live Gherkin e2e. Independent of quality-gates (parallel job).
-  # OpenCode CLI is not installed here: smoke/e2e do not invoke it.
+  # OpenCode CLI is required: live e2e first-run settings inspects the model
+  # catalog via `opencode models --verbose` (empty catalog fails the suite).
   # Live e2e is fail-closed when the vault secret is missing (trusted main).
   harness:
     runs-on: ubuntu-latest
@@ -109,6 +110,25 @@ jobs:
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version: latest
+
+      # Resolve the release via authenticated GitHub API then pin the installer
+      # --version flag: bare `opencode.ai/install` hits unauthenticated
+      # /releases/latest and fails under Actions rate limits.
+      - name: Install OpenCode
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          VERSION=$(curl -fsSL \
+            -H "Authorization: Bearer ${GH_TOKEN}" \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/repos/anomalyco/opencode/releases/latest \
+            | sed -n 's/.*"tag_name": *"v\([^"]*\)".*/\1/p')
+          test -n "$VERSION"
+          curl -fsSL https://opencode.ai/install | bash -s -- --version "$VERSION" --no-modify-path
+      - name: Add OpenCode to PATH
+        run: echo "$HOME/.opencode/bin" >> "$GITHUB_PATH"
 
       - run: bun install --no-cache --frozen-lockfile --linker=isolated && bun install --no-cache --frozen-lockfile --linker=isolated
 

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -32,7 +32,9 @@ jobs:
           # Built-in GITHUB_TOKEN only; pinact uses it for release/tag lookups.
           github_token: ${{ github.token }}
 
-  main:
+  # Quality gates + cheap harness slow-test (SSE idle-timeout). Parallel with
+  # `harness` (smoke + live e2e); no artifact handoff between the two.
+  quality-gates:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -89,6 +91,27 @@ jobs:
       - name: Harness slow tests
         run: bunx nx run harness:slow-test
 
+      # Nx Cloud recommends fixes for failures to help you get CI green faster. Learn more: https://nx.dev/ci/features/self-healing-ci
+      # - run: bun nx fix-ci
+      #   if: always()
+
+  # Dev smoke + live Gherkin e2e. Independent of quality-gates (parallel job).
+  # OpenCode CLI is not installed here: smoke/e2e do not invoke it.
+  # Live e2e is fail-closed when the vault secret is missing (trusted main).
+  harness:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          filter: tree:0
+          fetch-depth: 0
+
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version: latest
+
+      - run: bun install --no-cache --frozen-lockfile --linker=isolated && bun install --no-cache --frozen-lockfile --linker=isolated
+
       # Dev-path GraphQL smoke (Bun + Vite SSR); no Keymaxxer vault required.
       # Production live e2e below remains vault-backed and separate.
       - name: Harness dev smoke
@@ -126,10 +149,6 @@ jobs:
             apps/harness/test-results/
           if-no-files-found: ignore
           retention-days: 14
-
-      # Nx Cloud recommends fixes for failures to help you get CI green faster. Learn more: https://nx.dev/ci/features/self-healing-ci
-      # - run: bun nx fix-ci
-      #   if: always()
 
   # Distribution-boundary gate: pack launcher + host platform package, install
   # outside the checkout, run without Bun/Nx. Complementary to live Gherkin e2e.
@@ -185,9 +204,9 @@ jobs:
 
   release:
     # Manual release only, from main (never on PR/push).
-    # Requires quality gates + packed-install distribution smoke before publish.
+    # Requires quality gates + harness smoke/e2e + packed-install before publish.
     if: github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main'
-    needs: [main, packed-install, pinact]
+    needs: [quality-gates, harness, packed-install, pinact]
     runs-on: ubuntu-latest
     permissions:
       actions: write

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -29,7 +29,9 @@ jobs:
           # Built-in GITHUB_TOKEN only; pinact uses it for release/tag lookups.
           github_token: ${{ github.token }}
 
-  main:
+  # Quality gates + cheap harness slow-test (SSE idle-timeout). Parallel with
+  # `harness` (smoke + live e2e); no artifact handoff between the two.
+  quality-gates:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -71,6 +73,22 @@ jobs:
       # default suite can run with Bun --parallel. Keep the real heartbeat gate.
       - name: Harness slow tests
         run: bunx nx run harness:slow-test
+
+  # Dev smoke + live Gherkin e2e. Independent of quality-gates (parallel job).
+  # OpenCode CLI is not installed here: smoke/e2e do not invoke it.
+  harness:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          filter: tree:0
+          fetch-depth: 0
+
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          bun-version: latest
+
+      - run: bun install --no-cache --frozen-lockfile --linker=isolated && bun install --no-cache --frozen-lockfile --linker=isolated
 
       # Dev-path GraphQL smoke (Bun + Vite SSR); no Keymaxxer vault required.
       # Production live e2e below remains vault-backed and separate.

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -75,7 +75,8 @@ jobs:
         run: bunx nx run harness:slow-test
 
   # Dev smoke + live Gherkin e2e. Independent of quality-gates (parallel job).
-  # OpenCode CLI is not installed here: smoke/e2e do not invoke it.
+  # OpenCode CLI is required: live e2e first-run settings inspects the model
+  # catalog via `opencode models --verbose` (empty catalog fails the suite).
   harness:
     runs-on: ubuntu-latest
     steps:
@@ -87,6 +88,25 @@ jobs:
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version: latest
+
+      # Resolve the release via authenticated GitHub API then pin the installer
+      # --version flag: bare `opencode.ai/install` hits unauthenticated
+      # /releases/latest and fails under Actions rate limits.
+      - name: Install OpenCode
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          VERSION=$(curl -fsSL \
+            -H "Authorization: Bearer ${GH_TOKEN}" \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/repos/anomalyco/opencode/releases/latest \
+            | sed -n 's/.*"tag_name": *"v\([^"]*\)".*/\1/p')
+          test -n "$VERSION"
+          curl -fsSL https://opencode.ai/install | bash -s -- --version "$VERSION" --no-modify-path
+      - name: Add OpenCode to PATH
+        run: echo "$HOME/.opencode/bin" >> "$GITHUB_PATH"
 
       - run: bun install --no-cache --frozen-lockfile --linker=isolated && bun install --no-cache --frozen-lockfile --linker=isolated
 

--- a/docs/e2e-fixture.md
+++ b/docs/e2e-fixture.md
@@ -213,17 +213,31 @@ These leave the developer's real Keymaxxer vault untouched.
 
 ## CI gating
 
-Live Gherkin e2e runs after lint/typecheck/unit tests on trusted pushes to
-`main` (`.github/workflows/ci-cd.yml`) and on pull requests
-(`.github/workflows/pr.yml`), with Playwright Chromium installed when the
-vault secret is available. Both workflows unlock the fixture vault with
-repository secret `E2E_KEYMAXXER_MASTER_KEY`.
+Live Gherkin e2e runs in a dedicated **`harness`** job (dev smoke + live e2e)
+in parallel with **`quality-gates`** (`lint` / `knip` / `test` / `typecheck`
+plus harness slow-test) on trusted pushes to `main`
+(`.github/workflows/ci-cd.yml`) and on pull requests
+(`.github/workflows/pr.yml`). Playwright Chromium is installed only when the
+vault secret is available (always on `main`; same-repo PRs only). Both
+workflows unlock the fixture vault with repository secret
+`E2E_KEYMAXXER_MASTER_KEY`.
 
 | Event | Secret available | Policy |
 | --- | --- | --- |
 | `push` to `main` | required | Fail closed if missing |
 | Same-repo PR | yes | Run live e2e |
-| Fork PR | no (secrets not exposed) | Skip live e2e (log + continue); quality gates still run |
+| Fork PR | no (secrets not exposed) | Skip live e2e only (log + continue); `harness` still runs smoke; quality-gates and pinact still run |
+
+Required status checks (after the former monolithic `main` job was split):
+
+| Workflow | Require |
+| --- | --- |
+| **PR** | `quality-gates`, `harness`, `pinact` |
+| **CI/CD** | `quality-gates`, `harness`, `packed-install`, `pinact` |
+
+If branch protection or a ruleset still names `main`, update it when this lands
+or merges can stall (stale check never completes) or under-gate e2e (if only
+`quality-gates` is re-added).
 
 See ADR 0021. GitHub and GitLab scenarios share that single
 `bunx nx run harness:e2e` step.


### PR DESCRIPTION
## Why

PR and main CI ran quality gates, harness slow-test, smoke, and live e2e
as sequential steps in one job. Those suites do not hand off artifacts,
so wall-clock paid for artificial serialization. GitHub Actions only
parallelizes across jobs.

## What

Split the former monolithic `main` job into two independent parallel
jobs in both `.github/workflows/pr.yml` and `.github/workflows/ci-cd.yml`:

- **`quality-gates`**: `nx affected` lint/knip/test/typecheck (push) or
  `run-many` on `workflow_dispatch`; plus `harness:slow-test`. OpenCode
  install stays here for unit paths that need it.
- **`harness`**: `harness:smoke` then live Gherkin e2e. No OpenCode
  install. Playwright Chromium only when e2e will run.

Unchanged policy:

- **PR / fork**: missing `E2E_KEYMAXXER_MASTER_KEY` skips live e2e with
  a log; smoke, quality-gates, and pinact still run.
- **Main**: vault secret missing fails closed.
- **`packed-install`**: still an independent job; release now `needs`
  `[quality-gates, harness, packed-install, pinact]`.

`docs/e2e-fixture.md` documents the parallel layout, fork smoke
behavior, and the required status check names after the `main` rename.

## Verification

- YAML parse of both workflows; job graphs and `release.needs` checked.
- `actionlint` clean on both workflow files.
- Spot-checked OpenCode only on quality-gates (plus existing
  packed-install/release paths), slow-test only on quality-gates,
  smoke/e2e only on harness, pinact-compliant action SHAs retained.

## Operator note

Required checks that still name `main` must move to `quality-gates` and
`harness` (plus existing `pinact`; on CI/CD also `packed-install`) or
merges can stall or under-gate e2e. See the table in
`docs/e2e-fixture.md`.

Related to #746.

Closes #746