### PR TITLE
fix(harness): fade destination cards at absorb handoff

### DIFF
--- a/apps/harness/src/kanban-board.tsx
+++ b/apps/harness/src/kanban-board.tsx
@@ -18,7 +18,10 @@ import {
   pipelineLaneFor,
 } from "./pipeline-lanes.js"
 import { PipelineRoute, usePipelineRouteFlights } from "./pipeline-route.js"
-import { presentLaneColumnItems } from "./pipeline-route-transition.js"
+import {
+  ROUTE_TRANSITION_MS,
+  presentLaneColumnItems,
+} from "./pipeline-route-transition.js"
 import {
   JOBS_FAILED_LIMIT,
   JobsCardSkeleton,
@@ -132,6 +135,7 @@ function PipelineTicket({
   issue,
   laneId,
   departing = false,
+  arriving = false,
   onOpenSession,
 }: {
   readonly workItem: WorkItem
@@ -140,6 +144,11 @@ function PipelineTicket({
   readonly laneId: PipelineLaneId
   /** In-flight on the route line — stay in source lane, greyed out. */
   readonly departing?: boolean
+  /**
+   * Destination lane during absorb — opacity fades from transparent to full
+   * over the absorb phase (no layout/transform motion).
+   */
+  readonly arriving?: boolean
   readonly onOpenSession: (workItemId: string, sessionId: string) => void
 }) {
   const repositoryLabel = repository?.projectPath ?? workItem.repositoryId
@@ -170,16 +179,31 @@ function PipelineTicket({
   )
   const lane = PIPELINE_LANES.find((candidate) => candidate.id === laneId)
   const isCompleteLane = laneId === "complete"
+  const ticketStyle = {
+    "--ticket-color": lane?.color ?? "#151515",
+    ...(arriving
+      ? {
+          // Opacity-only; duration tracks absorb so the card finishes with smoke.
+          animation: `ticket-arrive ${ROUTE_TRANSITION_MS.absorb}ms ease-out both`,
+        }
+      : {}),
+  } as CSSProperties
 
   return (
     <li
-      className={cx(ui.jobTicket, departing && ui.jobTicketDeparting)}
+      className={cx(
+        ui.jobTicket,
+        departing && ui.jobTicketDeparting,
+        arriving && ui.jobTicketArriving,
+      )}
       data-lane={laneId}
       data-departing={departing ? "true" : undefined}
-      aria-busy={departing || undefined}
+      data-arriving={arriving ? "true" : undefined}
+      aria-busy={departing || arriving || undefined}
       // inert blocks mouse and keyboard; pointer-events-none alone is not enough.
-      {...(departing ? { inert: true } : {})}
-      style={{ "--ticket-color": lane?.color ?? "#151515" } as CSSProperties}
+      // Arriving cards start fully transparent — keep them inert for the fade.
+      {...(departing || arriving ? { inert: true } : {})}
+      style={ticketStyle}
     >
       <p className={ui.jobTicketRepo} title={repositoryLabel}>
         {repositoryLabel}
@@ -345,7 +369,7 @@ function KanbanJobsBoard() {
     ]),
   )
 
-  // Route flights delay dest counts; tickets stay greyed in source until absorb.
+  // Route flights: grey source until absorb, then dest card fades in with smoke.
   const routeFlights = usePipelineRouteFlights(laneItems)
 
   const workItemById = useMemo(() => {
@@ -408,8 +432,7 @@ function KanbanJobsBoard() {
           />
           <div className={ui.pipelineLanes}>
             {PIPELINE_LANES.map((lane, laneIndex) => {
-              // Departing tickets stay greyed in the source lane; arrivals wait
-              // until the route traveler is absorbed before appearing in dest.
+              // Pre-absorb: grey source placeholder; absorb: dest card arrives.
               const items = presentLaneColumnItems({
                 laneId: lane.id,
                 laneItems: laneItems.get(lane.id) ?? [],
@@ -441,7 +464,7 @@ function KanbanJobsBoard() {
                     <p className={ui.laneEmpty}>Lane clear</p>
                   ) : (
                     <ul className={ui.laneStack}>
-                      {items.map(({ workItem, departing }) => (
+                      {items.map(({ workItem, departing, arriving }) => (
                         <PipelineTicket
                           key={workItem.id}
                           workItem={workItem}
@@ -454,6 +477,7 @@ function KanbanJobsBoard() {
                           )}
                           laneId={lane.id}
                           departing={departing}
+                          arriving={arriving}
                           onOpenSession={(workItemId, sessionId) =>
                             setSessionDialog({ workItemId, sessionId })
                           }

--- a/apps/harness/src/pipeline-route-transition.ts
+++ b/apps/harness/src/pipeline-route-transition.ts
@@ -10,10 +10,16 @@ export type PlannedTransition = {
 }
 
 /**
- * Phases of a route-line furnace handoff. Destination display count stays
- * delayed until the flight is removed after `absorb` finishes.
+ * Phases of a route-line furnace handoff. Presentation handoff (source grey
+ * removed, destination card + counts catch up) happens when the flight enters
+ * `absorb` — the card fades in while the absorb smoke bellows.
  */
 export type FlightPhase = "eject" | "travel" | "enter" | "absorb"
+
+/** True while the traveler is still en route (not yet the absorb handoff). */
+export function isPreAbsorbPhase(phase: FlightPhase): boolean {
+  return phase !== "absorb"
+}
 
 export type RouteFlight = {
   readonly id: string
@@ -154,16 +160,18 @@ export function trueLaneCounts(
 }
 
 /**
- * How many in-flight travelers are still waiting to be absorbed into `lane`.
+ * How many in-flight travelers are still waiting to hand off into `lane`.
  * While a flight is active its work item already lives in `to` in real data,
- * so the destination display must subtract these until absorb completes.
+ * so the destination display must subtract these until absorb starts.
+ * Flights already in `absorb` have handed off (counts catch up with the card).
  */
 export function countPendingArrivals(
-  flights: readonly Pick<RouteFlight, "to">[],
+  flights: readonly Pick<RouteFlight, "to" | "phase">[],
   lane: PipelineLaneId,
 ): number {
   let count = 0
   for (const flight of flights) {
+    if (!isPreAbsorbPhase(flight.phase)) continue
     if (flight.to === lane) count += 1
   }
   return count
@@ -173,8 +181,8 @@ export function countPendingArrivals(
  * Presentation count for one stop. Never negative.
  *
  * - Destination stays flat until absorb (subtract pending arrivals).
- * - Source keeps the departing job until the flight ends (add pending
- *   departures) so furnace counts match greyed-out cards still in the lane.
+ * - Source keeps the departing job until absorb (add pending departures)
+ *   so furnace counts match greyed-out cards still in the lane.
  */
 export function displayLaneCount(args: {
   readonly trueCount: number
@@ -189,14 +197,17 @@ export function displayLaneCount(args: {
 
 /**
  * Display counts for every pipeline lane given true counts and active flights.
+ * Pre-absorb flights pad the source and hold the destination; absorb is the
+ * handoff so both lanes show true counts for that traveler.
  */
 export function displayLaneCounts(
   trueCounts: ReadonlyMap<PipelineLaneId, number>,
-  flights: readonly Pick<RouteFlight, "from" | "to">[],
+  flights: readonly Pick<RouteFlight, "from" | "to" | "phase">[],
 ): Map<PipelineLaneId, number> {
   const pendingArrivals = new Map<PipelineLaneId, number>()
   const pendingDepartures = new Map<PipelineLaneId, number>()
   for (const flight of flights) {
+    if (!isPreAbsorbPhase(flight.phase)) continue
     pendingArrivals.set(flight.to, (pendingArrivals.get(flight.to) ?? 0) + 1)
     pendingDepartures.set(
       flight.from,
@@ -218,13 +229,23 @@ export function displayLaneCounts(
   return display
 }
 
+export type LaneColumnPresentationItem<T extends { readonly id: string }> = {
+  readonly workItem: T
+  /** Grey placeholder still parked in the source lane (pre-absorb). */
+  readonly departing: boolean
+  /** Real card in the destination lane fading in during absorb. */
+  readonly arriving: boolean
+}
+
 /**
  * Tickets to render in a lane column during route flights.
  *
  * Real data already places a moved job in the destination lane. Presentation:
- * - Keep it in the **source** lane while in flight (greyed “departing”),
- *   inserted at `sourceOrderIndex` so mid-stack cards do not jump to the end.
- * - Hold it out of the **destination** lane until absorb finishes.
+ * - **Pre-absorb** (`eject` / `travel` / `enter`): keep a grey “departing”
+ *   card in the **source** lane at `sourceOrderIndex`; hold the job out of
+ *   the **destination** lane.
+ * - **Absorb**: drop the source placeholder and show the real card in the
+ *   destination as `arriving` so opacity can fade in with the smoke bellow.
  */
 export function presentLaneColumnItems<
   T extends { readonly id: string },
@@ -233,29 +254,42 @@ export function presentLaneColumnItems<
   readonly laneItems: readonly T[]
   readonly flights: readonly Pick<
     RouteFlight,
-    "workItemId" | "from" | "to" | "sourceOrderIndex"
+    "workItemId" | "from" | "to" | "sourceOrderIndex" | "phase"
   >[]
   readonly workItemById: ReadonlyMap<string, T>
-}): readonly { readonly workItem: T; readonly departing: boolean }[] {
+}): readonly LaneColumnPresentationItem<T>[] {
   const departing: {
     workItemId: string
     sourceOrderIndex: number
   }[] = []
-  const arrivingIds = new Set<string>()
+  /** Destination suppress set: still en route (pre-absorb). */
+  const enRouteToLane = new Set<string>()
+  /** Destination absorb set: handoff started — render as arriving. */
+  const absorbingIntoLane = new Set<string>()
   for (const flight of args.flights) {
-    if (flight.from === args.laneId) {
+    if (flight.from === args.laneId && isPreAbsorbPhase(flight.phase)) {
       departing.push({
         workItemId: flight.workItemId,
         sourceOrderIndex: flight.sourceOrderIndex,
       })
     }
-    if (flight.to === args.laneId) arrivingIds.add(flight.workItemId)
+    if (flight.to === args.laneId) {
+      if (isPreAbsorbPhase(flight.phase)) {
+        enRouteToLane.add(flight.workItemId)
+      } else {
+        absorbingIntoLane.add(flight.workItemId)
+      }
+    }
   }
 
-  const residents: { workItem: T; departing: boolean }[] = []
+  const residents: LaneColumnPresentationItem<T>[] = []
   for (const item of args.laneItems) {
-    if (arrivingIds.has(item.id)) continue
-    residents.push({ workItem: item, departing: false })
+    if (enRouteToLane.has(item.id)) continue
+    residents.push({
+      workItem: item,
+      departing: false,
+      arriving: absorbingIntoLane.has(item.id),
+    })
   }
 
   // Insert greys at frozen source indices (stable mid-stack, not append-only).
@@ -270,7 +304,11 @@ export function presentLaneColumnItems<
     const workItem = args.workItemById.get(workItemId)
     if (workItem === undefined) continue
     const insertAt = Math.min(Math.max(0, sourceOrderIndex), result.length)
-    result.splice(insertAt, 0, { workItem, departing: true })
+    result.splice(insertAt, 0, {
+      workItem,
+      departing: true,
+      arriving: false,
+    })
     seen.add(workItemId)
   }
 
@@ -289,7 +327,8 @@ export function laneCenterPercent(laneId: PipelineLaneId): number {
 
 /**
  * Advance a flight to the next phase, or `null` when absorb is done and the
- * flight should be removed (destination count may then catch up).
+ * flight should be removed (card fade and counts already handed off at absorb
+ * start; removal only ends the flight bookkeeping and lingering traveler).
  */
 export function nextFlightPhase(phase: FlightPhase): FlightPhase | null {
   switch (phase) {

--- a/apps/harness/src/pipeline-route-transition.ts
+++ b/apps/harness/src/pipeline-route-transition.ts
@@ -17,7 +17,7 @@ export type PlannedTransition = {
 export type FlightPhase = "eject" | "travel" | "enter" | "absorb"
 
 /** True while the traveler is still en route (not yet the absorb handoff). */
-export function isPreAbsorbPhase(phase: FlightPhase): boolean {
+function isPreAbsorbPhase(phase: FlightPhase): boolean {
   return phase !== "absorb"
 }
 

--- a/apps/harness/src/pipeline-route.tsx
+++ b/apps/harness/src/pipeline-route.tsx
@@ -92,8 +92,8 @@ export type PipelineRouteFlights = {
 
 /**
  * Own route-line flight state from true lane assignment. Shared by the route
- * chrome and the board so furnace counts and greyed departing tickets stay
- * aligned with travelers.
+ * chrome and the board so furnace counts, greyed departing tickets, and the
+ * absorb-arrival fade stay aligned with travelers.
  */
 export function usePipelineRouteFlights(
   laneItems: ReadonlyMap<PipelineLaneId, readonly { readonly id: string }[]>,
@@ -353,7 +353,8 @@ function useLingeringSmoke(
 /**
  * Desktop route line: pot-belly furnace stops with optional coal-lump traveler
  * when a work item changes pipeline lane. Presentation only — real counts come
- * from the board’s work-item data; display counts are delayed until absorb.
+ * from the board’s work-item data; display counts stay delayed through
+ * pre-absorb phases and catch up when the flight enters absorb.
  */
 export function PipelineRoute({
   flights,

--- a/apps/harness/src/styles.css
+++ b/apps/harness/src/styles.css
@@ -314,6 +314,21 @@
   }
 }
 
+/*
+ * Destination work-item card fade at absorb handoff (issue #750).
+ * Opacity only — no transform/layout motion so the lane stack stays still.
+ * Duration is set inline from ROUTE_TRANSITION_MS.absorb (~1200ms) so the
+ * card is fully visible just before the 1400ms smoke plume clears.
+ */
+@keyframes ticket-arrive {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
 @keyframes furnace-fed {
   0% {
     filter: brightness(1);

--- a/apps/harness/src/ui.ts
+++ b/apps/harness/src/ui.ts
@@ -789,6 +789,14 @@ export const ui = {
     "border-ink-faint shadow-[inset_6px_0_0_var(--ink-faint)]",
   ),
 
+  /**
+   * Destination ticket during absorb — marker only. All arrive motion stays on
+   * the `ticket-arrive` keyframe + inline duration (ROUTE_TRANSITION_MS.absorb).
+   * Do not add layout/transform utilities here; opacity-only is required so the
+   * lane stack is undisturbed. prefers-reduced-motion collapses the keyframe.
+   */
+  jobTicketArriving: "job-ticket-arriving",
+
   jobTicketRepo:
     "m-0 min-w-0 overflow-hidden text-ellipsis whitespace-nowrap font-mono text-[0.68rem] font-normal leading-[1.2] tracking-[0.1em] uppercase text-ink-faint",
 

--- a/apps/harness/test/kanban-route.test.ts
+++ b/apps/harness/test/kanban-route.test.ts
@@ -526,10 +526,33 @@ describe("kanban home board", () => {
     expect(stylesSource()).not.toContain("--flame-base-delay")
     expect(ui).toContain("routeTraveler:")
     expect(ui).toContain("jobTicketDeparting:")
+    // Absorb-handoff destination fade (issue #750): opacity-only keyframe.
+    expect(ui).toContain("jobTicketArriving:")
     // Phase durations come from ROUTE_*_MS via inline style, not Tailwind literals.
     expect(ui).toContain("ROUTE_TRANSITION_MS")
     expect(stylesSource()).toContain("@keyframes furnace-eject")
     expect(stylesSource()).toContain("@keyframes furnace-absorb")
+    expect(stylesSource()).toContain("@keyframes ticket-arrive")
+    // Extract the ticket-arrive block only (nested braces in from/to).
+    const ticketArrive = stylesSource().match(
+      /@keyframes ticket-arrive\s*\{[\s\S]*?\n\}/,
+    )?.[0]
+    expect(ticketArrive).toBeDefined()
+    expect(ticketArrive).toContain("opacity: 0")
+    expect(ticketArrive).toContain("opacity: 1")
+    // Opacity only — no transform so the lane stack is undisturbed.
+    expect(ticketArrive).not.toContain("transform")
+    // Ticket wires arriving marker + absorb-duration opacity animation.
+    const ticket = boardSource().slice(
+      boardSource().indexOf("function PipelineTicket("),
+      boardSource().indexOf("function KanbanJobsBoard()"),
+    )
+    expect(ticket).toContain('data-arriving={arriving ? "true" : undefined}')
+    expect(ticket).toContain("ui.jobTicketArriving")
+    expect(ticket).toContain("ticket-arrive")
+    expect(ticket).toContain("ROUTE_TRANSITION_MS.absorb")
+    // Transparent fade must not leave links focusable/clickable mid-arrival.
+    expect(ticket).toContain("departing || arriving ? { inert: true }")
     expect(stylesSource()).toContain("@keyframes furnace-smoke-puff")
     expect(stylesSource()).toContain("@keyframes route-travel")
     // Eject/enter must not rotate (avoids phase-handoff snaps).

--- a/apps/harness/test/pipeline-route-transition.test.ts
+++ b/apps/harness/test/pipeline-route-transition.test.ts
@@ -116,7 +116,7 @@ describe("displayLaneCount / displayLaneCounts", () => {
     expect(displayLaneCount({ trueCount: 0, pendingArrivals: 2 })).toBe(0)
   })
 
-  test("source keeps departing job; dest holds arrival until absorb", () => {
+  test("pre-absorb: source keeps departing job; dest holds arrival", () => {
     // True data after move: build lost one, review gained one.
     const trueCounts = new Map<PipelineLaneId, number>([
       ["queue", 0],
@@ -126,12 +126,31 @@ describe("displayLaneCount / displayLaneCounts", () => {
       ["attention", 0],
       ["complete", 0],
     ])
-    const flights: Pick<RouteFlight, "from" | "to">[] = [
-      { from: "build", to: "review" },
+    for (const phase of ["eject", "travel", "enter"] as const) {
+      const flights: Pick<RouteFlight, "from" | "to" | "phase">[] = [
+        { from: "build", to: "review", phase },
+      ]
+      const display = displayLaneCounts(trueCounts, flights)
+      expect(display.get("build")).toBe(4)
+      expect(display.get("review")).toBe(0)
+    }
+  })
+
+  test("absorb handoff: source and dest expose true counts", () => {
+    const trueCounts = new Map<PipelineLaneId, number>([
+      ["queue", 0],
+      ["build", 3],
+      ["review", 1],
+      ["pr", 0],
+      ["attention", 0],
+      ["complete", 0],
+    ])
+    const flights: Pick<RouteFlight, "from" | "to" | "phase">[] = [
+      { from: "build", to: "review", phase: "absorb" },
     ]
     const display = displayLaneCounts(trueCounts, flights)
-    expect(display.get("build")).toBe(4)
-    expect(display.get("review")).toBe(0)
+    expect(display.get("build")).toBe(3)
+    expect(display.get("review")).toBe(1)
   })
 
   test("overlapping arrivals stack without losing the final true count", () => {
@@ -143,19 +162,26 @@ describe("displayLaneCount / displayLaneCounts", () => {
       ["attention", 0],
       ["complete", 0],
     ])
-    const flights: Pick<RouteFlight, "from" | "to">[] = [
-      { from: "build", to: "review" },
-      { from: "build", to: "review" },
+    const flights: Pick<RouteFlight, "from" | "to" | "phase">[] = [
+      { from: "build", to: "review", phase: "travel" },
+      { from: "build", to: "review", phase: "enter" },
     ]
     const mid = displayLaneCounts(trueCounts, flights)
     expect(mid.get("review")).toBe(1)
+    const oneAbsorbing: Pick<RouteFlight, "from" | "to" | "phase">[] = [
+      { from: "build", to: "review", phase: "absorb" },
+      { from: "build", to: "review", phase: "travel" },
+    ]
+    const mixed = displayLaneCounts(trueCounts, oneAbsorbing)
+    // One still pending, one already handed off.
+    expect(mixed.get("review")).toBe(2)
     const done = displayLaneCounts(trueCounts, [])
     expect(done.get("review")).toBe(3)
   })
 })
 
 describe("presentLaneColumnItems", () => {
-  test("keeps departing ticket in source and holds it out of dest", () => {
+  test("pre-absorb: keeps departing ticket in source and holds it out of dest", () => {
     const a = { id: "a" }
     const b = { id: "b" }
     const byId = new Map([
@@ -163,38 +189,68 @@ describe("presentLaneColumnItems", () => {
       ["b", b],
     ])
     // True data: a already moved to review; a was index 0, b remains alone.
+    for (const phase of ["eject", "travel", "enter"] as const) {
+      const flights = [
+        {
+          workItemId: "a",
+          from: "build" as const,
+          to: "review" as const,
+          sourceOrderIndex: 0,
+          phase,
+        },
+      ]
+      const source = presentLaneColumnItems({
+        laneId: "build",
+        laneItems: [b],
+        flights,
+        workItemById: byId,
+      })
+      expect(source).toEqual([
+        { workItem: a, departing: true, arriving: false },
+        { workItem: b, departing: false, arriving: false },
+      ])
+
+      const dest = presentLaneColumnItems({
+        laneId: "review",
+        laneItems: [a],
+        flights,
+        workItemById: byId,
+      })
+      expect(dest).toEqual([])
+    }
+  })
+
+  test("absorb: drops source placeholder and returns dest card as arriving", () => {
+    const a = { id: "a" }
+    const b = { id: "b" }
+    const byId = new Map([
+      ["a", a],
+      ["b", b],
+    ])
+    const flights = [
+      {
+        workItemId: "a",
+        from: "build" as const,
+        to: "review" as const,
+        sourceOrderIndex: 0,
+        phase: "absorb" as const,
+      },
+    ]
     const source = presentLaneColumnItems({
       laneId: "build",
       laneItems: [b],
-      flights: [
-        {
-          workItemId: "a",
-          from: "build",
-          to: "review",
-          sourceOrderIndex: 0,
-        },
-      ],
+      flights,
       workItemById: byId,
     })
-    expect(source).toEqual([
-      { workItem: a, departing: true },
-      { workItem: b, departing: false },
-    ])
+    expect(source).toEqual([{ workItem: b, departing: false, arriving: false }])
 
     const dest = presentLaneColumnItems({
       laneId: "review",
       laneItems: [a],
-      flights: [
-        {
-          workItemId: "a",
-          from: "build",
-          to: "review",
-          sourceOrderIndex: 0,
-        },
-      ],
+      flights,
       workItemById: byId,
     })
-    expect(dest).toEqual([])
+    expect(dest).toEqual([{ workItem: a, departing: false, arriving: true }])
   })
 
   test("inserts departing ticket at frozen sourceOrderIndex mid-stack", () => {
@@ -216,21 +272,63 @@ describe("presentLaneColumnItems", () => {
           from: "build",
           to: "review",
           sourceOrderIndex: 1,
+          phase: "travel",
         },
       ],
       workItemById: byId,
     })
     expect(source.map((entry) => entry.workItem.id)).toEqual(["a", "b", "c"])
     expect(source[1]?.departing).toBe(true)
+    expect(source[1]?.arriving).toBe(false)
+  })
+
+  test("multi-arrival: only absorb-phase dest cards mark arriving", () => {
+    const a = { id: "a" }
+    const b = { id: "b" }
+    const resident = { id: "resident" }
+    const byId = new Map([
+      ["a", a],
+      ["b", b],
+      ["resident", resident],
+    ])
+    const flights = [
+      {
+        workItemId: "a",
+        from: "build" as const,
+        to: "review" as const,
+        sourceOrderIndex: 0,
+        phase: "absorb" as const,
+      },
+      {
+        workItemId: "b",
+        from: "build" as const,
+        to: "review" as const,
+        sourceOrderIndex: 1,
+        phase: "travel" as const,
+      },
+    ]
+    const dest = presentLaneColumnItems({
+      laneId: "review",
+      // True data already has both arrivals plus a resident.
+      laneItems: [a, b, resident],
+      flights,
+      workItemById: byId,
+    })
+    // b still en route → suppressed; a absorbing → arriving; resident stays.
+    expect(dest).toEqual([
+      { workItem: a, departing: false, arriving: true },
+      { workItem: resident, departing: false, arriving: false },
+    ])
   })
 })
 
 describe("countPendingArrivals", () => {
-  test("counts only flights targeting the given lane", () => {
+  test("counts only pre-absorb flights targeting the given lane", () => {
     const flights = [
-      { to: "review" as const },
-      { to: "pr" as const },
-      { to: "review" as const },
+      { to: "review" as const, phase: "travel" as const },
+      { to: "pr" as const, phase: "enter" as const },
+      { to: "review" as const, phase: "eject" as const },
+      { to: "review" as const, phase: "absorb" as const },
     ]
     expect(countPendingArrivals(flights, "review")).toBe(2)
     expect(countPendingArrivals(flights, "pr")).toBe(1)


### PR DESCRIPTION
## Why

During lane transitions, the destination work-item card stayed hidden for the
whole furnace `absorb` phase and only mounted when absorb finished. That put
the card on screen after the destination furnace had already done most of its
smoke bellow, so the handoff felt late.

## What

Move presentation handoff to absorb **start**, driven by existing flight phase
(no extra timer):

- **Pre-absorb** (`eject` / `travel` / `enter`): grey departing placeholder
  stays in the source lane; destination card is withheld; furnace counts stay
  delayed.
- **Absorb**: drop the source placeholder; render the real destination card as
  `arriving` with an opacity-only `ticket-arrive` fade timed to
  `ROUTE_TRANSITION_MS.absorb` (1200ms, finishes just before the 1400ms smoke
  clears); switch source/destination furnace counts at the same handoff.
- Arriving cards are `inert` while fading so near-transparent links are not
  focusable/clickable.
- Non-transition appearances still snap in; `prefers-reduced-motion` still
  collapses the animation via the global base rule.
- Furnace absorb, fed glow, traveler, and lingering-smoke timings are
  unchanged.

Phase-aware helpers live in `presentLaneColumnItems` / `displayLaneCounts` /
`countPendingArrivals`. Chrome tests cover the arrival keyframe (opacity-only)
and ticket wiring.

## Verification

- `bunx nx test harness` (unit + vitest)
- `bunx nx run harness:typecheck`
- Pre-commit (`lint` / `typecheck` / `test` via affected) after format fix

Closes #750