### PR TITLE
fix(harness): restore right-side rivets on mast and Jobs tabs

### DIFF
--- a/apps/harness/src/ui.ts
+++ b/apps/harness/src/ui.ts
@@ -13,13 +13,25 @@ export function cx(...parts: Array<string | false | null | undefined>): string {
 
 /**
  * Rivet-plate background images (stamped industrial chrome).
- * Multi-layer radial gradients at the corners.
+ * Multi-layer radial gradients at the top corners.
+ *
+ * Right-edge positions must use `calc(100% - Npx)` (spaces around `-`).
+ * Tailwind arbitrary values encode those spaces as `_`, so write
+ * `calc(100%_-_Npx)`. Bare `calc(100%-Npx)` is invalid CSS and drops the
+ * right-hand rivet entirely.
  */
 const mastPlateRivets =
-  "[background-image:radial-gradient(circle_1.6px_at_7px_7px,var(--mast-plate-rivet)_1.6px,transparent_2.1px),radial-gradient(circle_1.6px_at_calc(100%-7px)_7px,var(--mast-plate-rivet)_1.6px,transparent_2.1px)]"
+  "[background-image:radial-gradient(circle_1.6px_at_7px_7px,var(--mast-plate-rivet)_1.6px,transparent_2.1px),radial-gradient(circle_1.6px_at_calc(100%_-_7px)_7px,var(--mast-plate-rivet)_1.6px,transparent_2.1px)]"
 
 const plateMiniRivets =
-  "[background-image:radial-gradient(circle_1.4px_at_6px_6px,var(--plate-rivet)_1.4px,transparent_1.9px),radial-gradient(circle_1.4px_at_calc(100%-6px)_6px,var(--plate-rivet)_1.4px,transparent_1.9px)]"
+  "[background-image:radial-gradient(circle_1.4px_at_6px_6px,var(--plate-rivet)_1.4px,transparent_1.9px),radial-gradient(circle_1.4px_at_calc(100%_-_6px)_6px,var(--plate-rivet)_1.4px,transparent_1.9px)]"
+
+/**
+ * Active Jobs tab rivets: paper-colored dots contrast on `bg-ink` in both
+ * themes. Full static string (variant + property) so Tailwind can scan it.
+ */
+const pipelineTabActiveRivets =
+  "aria-[current=page]:[background-image:radial-gradient(circle_1.4px_at_6px_6px,var(--paper)_1.4px,transparent_1.9px),radial-gradient(circle_1.4px_at_calc(100%_-_6px)_6px,var(--paper)_1.4px,transparent_1.9px)]"
 
 const laneSwitchRivets = plateMiniRivets
 
@@ -67,8 +79,8 @@ export const ui = {
     "hover:bg-[var(--mast-plate-hover)] hover:text-[var(--mast-ink)]",
     "aria-[current=page]:bg-[var(--mast-plate-active)] aria-[current=page]:text-[var(--mast-plate-active-ink)]",
     "aria-[current=page]:shadow-[inset_0_1px_0_rgb(255_255_255/0.65),inset_0_-2px_0_rgb(16_19_18/0.12)]",
-    // active rivets via arbitrary variant on same element
-    "aria-[current=page]:[background-image:radial-gradient(circle_1.6px_at_7px_7px,var(--mast-plate-active-rivet)_1.6px,transparent_2.1px),radial-gradient(circle_1.6px_at_calc(100%-7px)_7px,var(--mast-plate-active-rivet)_1.6px,transparent_2.1px)]",
+    // Active rivets via arbitrary variant on same element (valid calc for right edge).
+    "aria-[current=page]:[background-image:radial-gradient(circle_1.6px_at_7px_7px,var(--mast-plate-active-rivet)_1.6px,transparent_2.1px),radial-gradient(circle_1.6px_at_calc(100%_-_7px)_7px,var(--mast-plate-active-rivet)_1.6px,transparent_2.1px)]",
     "[&_svg]:h-[0.9rem] [&_svg]:w-[0.9rem] [&_svg]:shrink-0",
   ),
 
@@ -514,10 +526,14 @@ export const ui = {
   pipelineTab: cx(
     "relative inline-flex appearance-none items-center gap-[0.4rem]",
     "-ml-0.5 border-2 border-ink bg-paper px-4 py-2 first:ml-0",
+    // Shared mini-plate rivets (top-left + top-right) — same recipe as plateMini.
+    plateMiniRivets,
     "cursor-pointer font-display text-[0.72rem] font-bold tracking-[0.14em] uppercase text-ink-2 no-underline",
     "hover:text-ink",
     // Active route — navigation list (aria-current), not ARIA tabs (aria-selected).
     "aria-[current=page]:bg-ink aria-[current=page]:text-paper",
+    // Keep right-hand rivets visible on the inverted ink fill (both themes).
+    pipelineTabActiveRivets,
     "[&_svg]:h-[0.85rem] [&_svg]:w-[0.85rem] [&_svg]:shrink-0",
   ),
 

--- a/apps/harness/test/primary-nav.test.ts
+++ b/apps/harness/test/primary-nav.test.ts
@@ -209,6 +209,49 @@ describe("primary navigation (Interchange masthead + Jobs switcher)", () => {
     expect(ui).toMatch(/mastPlate:[\s\S]*?aria-\[current=page\]/)
   })
 
+  test("mast plates and Jobs tabs share right-side rivet treatment", () => {
+    const ui = uiSource()
+    const root = rootSource()
+    const switcher = switcherSource()
+
+    // Valid CSS calc spacing for the right-edge rivet (Tailwind `_` → space).
+    // Bare `calc(100%-Npx)` is invalid and drops the right-hand rivet.
+    expect(ui).toContain("calc(100%_-_7px)")
+    expect(ui).toContain("calc(100%_-_6px)")
+    expect(ui).not.toMatch(/calc\(100%-\d+px\)/)
+
+    // Shared recipes use theme rivet tokens (no image assets).
+    expect(ui).toMatch(
+      /mastPlateRivets[\s\S]*?--mast-plate-rivet[\s\S]*?calc\(100%_-_7px\)/,
+    )
+    expect(ui).toMatch(
+      /plateMiniRivets[\s\S]*?--plate-rivet[\s\S]*?calc\(100%_-_6px\)/,
+    )
+    // Mast plate recipe consumes the mast rivet recipe.
+    expect(ui).toMatch(/mastPlate:[\s\S]*?mastPlateRivets/)
+    // Active mast plate keeps right-hand rivets via active token.
+    expect(ui).toMatch(
+      /mastPlate:[\s\S]*?aria-\[current=page\]:\[background-image:[\s\S]*?--mast-plate-active-rivet[\s\S]*?calc\(100%_-_7px\)/,
+    )
+
+    // Jobs mode tabs reuse mini-plate rivets + active override on ink fill.
+    expect(ui).toMatch(/pipelineTab:[\s\S]*?plateMiniRivets/)
+    expect(ui).toMatch(
+      /pipelineTab:[\s\S]*?pipelineTabActiveRivets|pipelineTab:[\s\S]*?aria-\[current=page\]:\[background-image:[\s\S]*?--paper/,
+    )
+    expect(ui).toMatch(
+      /pipelineTabActiveRivets[\s\S]*?--paper[\s\S]*?calc\(100%_-_6px\)/,
+    )
+
+    // Theme + Settings share mastPlate; Jobs tabs share pipelineTab — no
+    // per-control decorative rivet DOM.
+    expect(root).toContain("const mastPlateClassName = ui.mastPlate")
+    expect(root).toContain("<ThemeTogglePlate />")
+    expect(switcher).toContain("className={ui.pipelineTab}")
+    expect(switcher).not.toMatch(/rivet/i)
+    expect(root).not.toMatch(/className=\{[^}]*rivet/i)
+  })
+
   test("shared Jobs switcher lives in root chrome above Outlet", () => {
     const source = rootSource()
     const chrome = source.slice(source.indexOf("function SettingsChrome("))


### PR DESCRIPTION
## Why

Stamped-metal mast controls (theme toggle, Settings) and Jobs mode tabs
(Pipeline, Repos, Completed) were missing a clearly visible rivet on the
right edge. Right-edge positions used bare `calc(100%-Npx)`, which is invalid
CSS (the `-` operator needs spaces), so the second radial-gradient layer never
painted. Jobs tabs also had no rivet recipe at all.

## What changed

- Encode valid right-edge calc as Tailwind `calc(100%_-_Npx)` in
  `mastPlateRivets`, `plateMiniRivets`, and the active mast-plate override.
- Apply shared `plateMiniRivets` to `ui.pipelineTab`.
- Add `pipelineTabActiveRivets` (`--paper` dots on `bg-ink`) so active Jobs
  tabs keep visible rivets in light and dark themes.
- Extend `primary-nav.test.ts` for calc spacing, shared recipes/tokens, and
  no per-control decorative rivet DOM.

## Verification

- `bun test apps/harness/test/primary-nav.test.ts`
- Full harness unit suite (bun + vitest)
- `bunx nx run harness:lint`
- `bunx nx run harness:typecheck`
- Local code review: clean (no open findings)

## Notes

Theme and Settings continue to share `ui.mastPlate`; Jobs destinations share
`ui.pipelineTab`. No image assets or per-button rivet markup.

Closes #752