### PR TITLE
fix(harness): remove redundant mast kicker labels

### DIFF
--- a/apps/harness/src/routes/__root.tsx
+++ b/apps/harness/src/routes/__root.tsx
@@ -718,7 +718,6 @@ function SettingsChrome() {
         <header className={ui.mast}>
           <div>
             <p className={ui.brandKicker}>
-              Ready for Agent · Operator board ·{" "}
               <b
                 className={ui.brandKickerB}
                 title={`Ready for Agent ${READY_FOR_AGENT_VERSION_LABEL}`}

--- a/apps/harness/test/primary-nav.test.ts
+++ b/apps/harness/test/primary-nav.test.ts
@@ -132,6 +132,29 @@ describe("primary navigation (Interchange masthead + Jobs switcher)", () => {
     expect(productLineIdx).toBeLessThan(source.indexOf('aria-label="Primary"'))
   })
 
+  // Issue #753: small kicker no longer duplicates product / board labels.
+  test("brand kicker shows version only; wordmark and Clanker Harness remain", () => {
+    const source = rootSource()
+    const brandBlock = source.slice(
+      source.indexOf("className={ui.mast}"),
+      source.indexOf('aria-label="Primary"'),
+    )
+    const kickerStart = brandBlock.indexOf("ui.brandKicker")
+    const wordmarkStart = brandBlock.indexOf("ui.brandWordmark")
+    expect(kickerStart).toBeGreaterThan(-1)
+    expect(wordmarkStart).toBeGreaterThan(kickerStart)
+    const kicker = brandBlock.slice(kickerStart, wordmarkStart)
+    expect(kicker).toContain("RFA {READY_FOR_AGENT_VERSION_LABEL}")
+    // Visible kicker text only — not the optional title= tooltip string.
+    expect(kicker).not.toMatch(/>\s*Ready for Agent/)
+    expect(kicker).not.toContain("Operator board")
+    expect(source).not.toContain("Ready for Agent · Operator board")
+    // Main wordmark + subtitle stay in the brand block.
+    expect(brandBlock).toContain("Ready for Agent\n")
+    expect(brandBlock).toContain("Clanker Harness")
+    expect(brandBlock).toContain("ui.brandSub")
+  })
+
   test("Jobs switcher and Settings use stroke icons", () => {
     const root = rootSource()
     const switcher = switcherSource()

--- a/docs/harness-design-system.md
+++ b/docs/harness-design-system.md
@@ -251,9 +251,10 @@ Named slots (rem), transcribed from the prototypes:
 **Masthead** — full-width dark supergraphic band (`--mast-bg`), flex with
 brand left and nav right, items baseline-aligned.
 
-- **Brand block**: mono kicker (`--mast-faint`, product · "Operator board" ·
-  version in `--mast-dim`), wordmark link in display 800 uppercase white
-  (hover: `--signal`), mono sub-line with live status fragment in `--signal`.
+- **Brand block**: mono kicker with version only (`--mast-dim`; product name
+  and "Operator board" are not repeated here), wordmark link in display 800
+  uppercase white (hover: `--signal`), mono sub-line with live status fragment
+  in `--signal`.
 - **Primary nav** — B's flush stamped plates, replacing D's system-map stops:
   Home, Repos, Completed, Settings (button, `aria-haspopup="dialog"`), plus
   the theme-toggle plate. Plate anatomy (§5.3): 2px black border, rivet dots,


### PR DESCRIPTION
## Why

The mast brand kicker repeated context already shown by the main wordmark
and page chrome: uppercase **Ready for Agent** and **Operator board** sat
above the large **Ready for Agent** heading and **Clanker Harness**
subtitle. That small line added noise without helping orientation (#753).

## What changed

- Drop the visible kicker prefix `Ready for Agent · Operator board ·` from
  the root mast in `__root.tsx`.
- Keep the version-only kicker (`RFA {version}`), the h1 wordmark link,
  the Clanker Harness subtitle, and existing mast spacing recipes.
- Align the design-system brand-block note with version-only kicker copy.
- Add a `primary-nav` regression test that asserts the kicker no longer
  shows those labels while wordmark and subtitle remain (tooltip `title`
  text is not treated as visible kicker content).

## Verification

- `bun test apps/harness/test/primary-nav.test.ts` (14 pass)
- Biome check on the touched harness TS files
- Local code review of uncommitted changes: clean (no open findings)

## Notes

No layout recipe changes; shorter kicker text reuses the existing
`brandKicker` margin so desktop/mobile spacing should stay balanced.

Closes #753