### PR TITLE
feat(harness): add forged scrollwork masthead

### DIFF
--- a/apps/harness/src/masthead-scrollwork.tsx
+++ b/apps/harness/src/masthead-scrollwork.tsx
@@ -1,0 +1,66 @@
+import { ui } from "./ui.js"
+
+/** Decorative forged-iron field behind the masthead content. */
+export function MastheadScrollwork() {
+  return (
+    <>
+      <span className={ui.mastScrollworkGrain} aria-hidden="true" />
+      <span className={ui.mastScrollworkVignette} aria-hidden="true" />
+      <svg
+        className={ui.mastScrollworkOrnament}
+        aria-hidden="true"
+        viewBox="0 0 1440 160"
+        preserveAspectRatio="xMidYMid slice"
+      >
+        <defs>
+          <clipPath id="masthead-scrollwork-left-third">
+            <rect width="455" height="160" />
+          </clipPath>
+          <g id="masthead-scrollwork-rails">
+            <path d="M455 80H1465" />
+            <path d="M480 80C525 80 530 34 575 34c35 0 49 34 29 50-23 18-55-2-43-25 7-14 27-14 33 1" />
+            <path d="M480 80c45 0 50 46 95 46 35 0 49-34 29-50-23-18-55 2-43 25 7 14 27 14 33-1" />
+            <path d="M705 80c45 0 50-46 95-46 35 0 49 34 29 50-23 18-55-2-43-25 7-14 27-14 33 1" />
+            <path d="M705 80c45 0 50 46 95 46 35 0 49-34 29-50-23-18-55 2-43 25 7 14 27 14 33-1" />
+            <path d="M930 80c45 0 50-46 95-46 35 0 49 34 29 50-23 18-55-2-43-25 7-14 27-14 33 1" />
+            <path d="M930 80c45 0 50 46 95 46 35 0 49-34 29-50-23-18-55 2-43 25 7 14 27 14 33-1" />
+            <path d="M1155 80c45 0 50-46 95-46 35 0 49 34 29 50-23 18-55-2-43-25 7-14 27-14 33 1" />
+            <path d="M1155 80c45 0 50 46 95 46 35 0 49-34 29-50-23-18-55 2-43 25 7 14 27 14 33-1" />
+            <path d="M675 145V31m-11 10 11-24 11 24M663 80l12-12 12 12-12 12Z" />
+            <path d="M900 145V31m-11 10 11-24 11 24M888 80l12-12 12 12-12 12Z" />
+            <path d="M1125 145V31m-11 10 11-24 11 24m-12 39 12-12 12 12-12 12Z" />
+            <path d="M1350 145V31m-11 10 11-24 11 24m-12 39 12-12 12 12-12 12Z" />
+          </g>
+        </defs>
+        <g clipPath="url(#masthead-scrollwork-left-third)">
+          <g transform="translate(-450 0)">
+            <use
+              className={ui.mastScrollworkShadow}
+              href="#masthead-scrollwork-rails"
+            />
+            <use
+              className={ui.mastScrollworkBody}
+              href="#masthead-scrollwork-rails"
+            />
+            <use
+              className={ui.mastScrollworkHighlight}
+              href="#masthead-scrollwork-rails"
+            />
+          </g>
+        </g>
+        <use
+          className={ui.mastScrollworkShadow}
+          href="#masthead-scrollwork-rails"
+        />
+        <use
+          className={ui.mastScrollworkBody}
+          href="#masthead-scrollwork-rails"
+        />
+        <use
+          className={ui.mastScrollworkHighlight}
+          href="#masthead-scrollwork-rails"
+        />
+      </svg>
+    </>
+  )
+}

--- a/apps/harness/src/routes/__root.tsx
+++ b/apps/harness/src/routes/__root.tsx
@@ -28,6 +28,7 @@ import { CommittedPullRequestsDashboard } from "../committed-pr-dashboard.js"
 import { READY_FOR_AGENT_VERSION_LABEL } from "../generated/version"
 import { JobsRepositoryFilterProvider } from "../jobs-repository-filter.js"
 import { JobsViewSwitcher } from "../jobs-view-switcher.js"
+import { MastheadScrollwork } from "../masthead-scrollwork.js"
 import { repositoriesQuery } from "../repositories-query.js"
 import appCss from "../styles.css?url"
 import {
@@ -716,7 +717,8 @@ function SettingsChrome() {
     <JobsRepositoryFilterProvider>
       <div className={ui.appChrome}>
         <header className={ui.mast}>
-          <div>
+          <MastheadScrollwork />
+          <div className={ui.mastContent}>
             <p className={ui.brandKicker}>
               Ready for Agent · Operator board ·{" "}
               <b

--- a/apps/harness/src/ui.ts
+++ b/apps/harness/src/ui.ts
@@ -43,11 +43,45 @@ const laneSwitchRivets = plateMiniRivets
 const cardMetalLight =
   "in-[html[data-theme=light]]:bg-[linear-gradient(165deg,rgb(255_255_255/0.72)_0%,rgb(255_255_255/0.18)_42%,transparent_68%),linear-gradient(180deg,#f0f2f0_0%,#e3e7e4_55%,#dfe4e1_100%)]"
 
+const mastScrollworkStroke =
+  "[fill:none] [stroke-linecap:round] [stroke-linejoin:round]"
+
 export const ui = {
   /* ---------- Nav shell (§4.1) ---------- */
 
   // bg-mast-bg (not bg-[var(--mast-bg)]) so styles.css mast focus-ring selector matches.
-  mast: "flex flex-wrap items-end justify-between gap-x-10 gap-y-[1.2rem] bg-mast-bg px-[2.2rem] pt-6 pb-[1.35rem] text-[var(--mast-ink)] max-[900px]:px-[1.4rem] max-[900px]:pt-[1.2rem] max-[900px]:pb-[1.1rem]",
+  mast: cx(
+    "relative isolate flex flex-wrap items-end justify-between overflow-hidden",
+    "gap-x-10 gap-y-[1.2rem] bg-mast-bg px-[2.2rem] pt-6 pb-[1.35rem] text-[var(--mast-ink)]",
+    "[background-image:radial-gradient(ellipse_62%_180%_at_67%_38%,rgb(78_90_84/0.14),transparent_68%),linear-gradient(105deg,rgb(0_0_0/0.45),rgb(25_37_31/0.18)_54%,rgb(0_0_0/0.55))]",
+    "max-[900px]:px-[1.4rem] max-[900px]:pt-[1.2rem] max-[900px]:pb-[1.1rem]",
+  ),
+
+  mastContent: "relative z-20",
+
+  mastScrollworkGrain:
+    "pointer-events-none absolute inset-0 z-0 opacity-75 [background-image:repeating-linear-gradient(0deg,rgb(255_255_255/0.012)_0_1px,transparent_1px_3px)]",
+
+  mastScrollworkVignette:
+    "pointer-events-none absolute inset-0 z-0 [background:linear-gradient(90deg,rgb(0_0_0/0.64)_0%,rgb(0_0_0/0.28)_31%,transparent_55%,rgb(0_0_0/0.24)_100%)] shadow-[inset_0_1px_rgb(255_255_255/0.045),inset_0_-2px_rgb(0_0_0/0.72)]",
+
+  mastScrollworkOrnament:
+    "pointer-events-none absolute inset-0 z-10 h-full w-full opacity-52 max-[640px]:w-[165%] max-[640px]:opacity-[0.38]",
+
+  mastScrollworkShadow: cx(
+    mastScrollworkStroke,
+    "[translate:0_2px] [stroke:rgb(0_0_0/0.92)] [stroke-width:11px]",
+  ),
+
+  mastScrollworkBody: cx(
+    mastScrollworkStroke,
+    "[stroke:rgb(66_76_71/0.72)] [stroke-width:7px]",
+  ),
+
+  mastScrollworkHighlight: cx(
+    mastScrollworkStroke,
+    "[translate:0_-1px] [stroke:rgb(192_203_197/0.18)] [stroke-width:1.2px]",
+  ),
 
   brandKicker:
     "m-0 mb-2 font-mono text-[0.62rem] tracking-[0.22em] uppercase text-[var(--mast-faint)]",
@@ -66,7 +100,7 @@ export const ui = {
   /** Child `.ok` inside brand-sub */
   brandSubOk: "text-signal",
 
-  mastNav: "flex flex-wrap items-center gap-[0.55rem]",
+  mastNav: "relative z-20 flex flex-wrap items-center gap-[0.55rem]",
 
   mastPlate: cx(
     "inline-flex items-center gap-2 border-2 border-black",

--- a/docs/harness-design-system.md
+++ b/docs/harness-design-system.md
@@ -126,6 +126,10 @@ keeps the light-mode platform grey rather than going lights-out.
 | `--mast-plate-active-ink` | `#101314` | `#101314` |
 | `--mast-plate-active-rivet` | `rgb(16 19 18 / 0.5)` | `rgb(16 19 18 / 0.5)` |
 
+The band carries a low-contrast, full-width forged-iron scrollwork rail behind
+the brand and controls. A matte grain, dark vignette, and bevel-highlighted
+iron strokes add depth without reducing foreground contrast.
+
 ### 2.4 Stamped plates on paper
 
 | Token | Light | Dark |
@@ -251,6 +255,9 @@ Named slots (rem), transcribed from the prototypes:
 **Masthead** — full-width dark supergraphic band (`--mast-bg`), flex with
 brand left and nav right, items baseline-aligned.
 
+- **Forged field**: ornamental wrought-iron rails span the full width behind
+  both brand and controls. Black shadow, charcoal body, and a faint upper-edge
+  highlight create forged depth; the ornament is decorative and `aria-hidden`.
 - **Brand block**: mono kicker (`--mast-faint`, product · "Operator board" ·
   version in `--mast-dim`), wordmark link in display 800 uppercase white
   (hover: `--signal`), mono sub-line with live status fragment in `--signal`.


### PR DESCRIPTION
## Why

The flat-black masthead did not carry the industrial, steampunk character used elsewhere in the harness. The selected treatment adds subtle wrought-iron depth without overpowering the wordmark, controls, or lane colors.

## What Changed

- add a decorative, full-width forged-scrollwork SVG behind the masthead content
- layer matte grain, vignette, shadow, body, and highlight treatments through the Tailwind-first UI recipes
- keep the shading translucent so the light and dark `--mast-bg` theme tokens remain effective
- document the permanent masthead treatment in the harness design system

## Verification

Inspected the running harness at desktop and mobile widths in both light and dark themes. The scrollwork spans beneath the brand and controls while foreground text and navigation remain readable.
