### PR TITLE
fix(harness): prevent destination-lane flash before route transfer animation

### DIFF
--- a/apps/harness/package.json
+++ b/apps/harness/package.json
@@ -47,6 +47,7 @@
     "@types/react": "^19.0.8",
     "@types/react-dom": "^19.0.3",
     "@vitejs/plugin-react": "^6.0.4",
+    "happy-dom": "^20.11.1",
     "playwright-bdd": "^9.2.0",
     "tailwindcss": "^4.3.3",
     "vite": "^8.1.5",

--- a/apps/harness/src/pipeline-route.tsx
+++ b/apps/harness/src/pipeline-route.tsx
@@ -1,4 +1,11 @@
-import { type CSSProperties, useEffect, useMemo, useRef, useState } from "react"
+import {
+  type CSSProperties,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react"
 import { PIPELINE_LANES, type PipelineLaneId } from "./pipeline-lanes.js"
 import {
   type FlightPhase,
@@ -139,8 +146,11 @@ export function usePipelineRouteFlights(
   const trueCounts = laneSnapshotRef.current.counts
   const nextOrderedIds = laneSnapshotRef.current.orderedIdsByLane
 
-  // Seed baseline on first paint; subsequent diffs schedule travelers.
-  useEffect(() => {
+  // Layout-synchronous: seed baseline / create route flights before paint so
+  // the first visible frame already shows departing + traveler (no dest flash).
+  // Phase timers stay in passive effects below — only this assignment handoff
+  // must complete before the browser paints the authoritative placement.
+  useLayoutEffect(() => {
     if (assignmentRef.current === null) {
       assignmentRef.current = nextAssignment
       orderedIdsByLaneRef.current = nextOrderedIds

--- a/apps/harness/test/pipeline-route-flights.test.tsx
+++ b/apps/harness/test/pipeline-route-flights.test.tsx
@@ -1,0 +1,443 @@
+/**
+ * Regression: first paint after a lane assignment change must already show the
+ * departing ticket / route traveler (issue #760). Uses flushSync so layout
+ * effects run but passive effects do not — a useEffect-based reconciliation
+ * would still leave the destination ticket visible after the flush.
+ */
+import { Window } from "happy-dom"
+import {
+  type ReactElement,
+  createElement,
+  useLayoutEffect,
+  useState,
+} from "react"
+import { flushSync } from "react-dom"
+import { type Root, createRoot } from "react-dom/client"
+import { PIPELINE_LANES, type PipelineLaneId } from "../src/pipeline-lanes.js"
+import { usePipelineRouteFlights } from "../src/pipeline-route.js"
+import {
+  displayLaneCounts,
+  presentLaneColumnItems,
+  trueLaneCounts,
+} from "../src/pipeline-route-transition.js"
+import { afterEach, beforeEach, describe, expect, test } from "bun:test"
+
+type LaneItem = { readonly id: string }
+
+type FrameSnapshot = {
+  readonly flights: readonly {
+    readonly workItemId: string
+    readonly from: PipelineLaneId
+    readonly to: PipelineLaneId
+    readonly phase: string
+  }[]
+  readonly build: readonly {
+    readonly id: string
+    readonly departing: boolean
+    readonly arriving: boolean
+  }[]
+  readonly review: readonly {
+    readonly id: string
+    readonly departing: boolean
+    readonly arriving: boolean
+  }[]
+  readonly displayCounts: Readonly<Record<string, number>>
+}
+
+/** Keys this suite installs on globalThis for React-DOM + happy-dom. */
+const INSTALLED_GLOBAL_KEYS = [
+  "window",
+  "document",
+  "HTMLElement",
+  "Element",
+  "Node",
+  "DocumentFragment",
+  "SVGElement",
+  "navigator",
+  "getComputedStyle",
+  "requestAnimationFrame",
+  "cancelAnimationFrame",
+  "MutationObserver",
+  "IS_REACT_ACT_ENVIRONMENT",
+] as const
+
+type GlobalSnapshot = ReadonlyMap<
+  string,
+  { readonly had: boolean; readonly value: unknown }
+>
+
+function emptyLaneItems(): Map<PipelineLaneId, readonly LaneItem[]> {
+  return new Map(PIPELINE_LANES.map((lane) => [lane.id, [] as LaneItem[]]))
+}
+
+function snapshotGlobals(keys: readonly string[]): GlobalSnapshot {
+  const g = globalThis as unknown as Record<string, unknown>
+  const snap = new Map<
+    string,
+    { readonly had: boolean; readonly value: unknown }
+  >()
+  for (const key of keys) {
+    snap.set(key, {
+      had: Object.hasOwn(g, key),
+      value: g[key],
+    })
+  }
+  return snap
+}
+
+function restoreGlobals(snap: GlobalSnapshot): void {
+  const g = globalThis as unknown as Record<string, unknown>
+  for (const [key, entry] of snap) {
+    if (entry.had) {
+      g[key] = entry.value
+    } else {
+      delete g[key]
+    }
+  }
+}
+
+/** Assign onto globalThis without fighting happy-dom vs lib.dom structural types. */
+function setGlobal(key: string, value: unknown): void {
+  ;(globalThis as unknown as Record<string, unknown>)[key] = value
+}
+
+type InstalledDom = {
+  readonly window: Window
+  /** Close happy-dom and restore prior globalThis keys. */
+  readonly dispose: () => void
+}
+
+function installDom(args?: { readonly reducedMotion?: boolean }): InstalledDom {
+  const previous = snapshotGlobals(INSTALLED_GLOBAL_KEYS)
+  const happyWindow = new Window({ url: "https://localhost/" })
+  const reducedMotion = args?.reducedMotion ?? false
+  happyWindow.matchMedia = ((query: string) => {
+    const matches =
+      reducedMotion &&
+      String(query).includes("prefers-reduced-motion") &&
+      String(query).includes("reduce")
+    return {
+      matches,
+      media: query,
+      onchange: null,
+      addListener() {},
+      removeListener() {},
+      addEventListener() {},
+      removeEventListener() {},
+      dispatchEvent() {
+        return false
+      },
+    }
+  }) as unknown as typeof happyWindow.matchMedia
+
+  // Bridge happy-dom constructors/APIs into the globals React-DOM expects.
+  setGlobal("window", happyWindow)
+  setGlobal("document", happyWindow.document)
+  setGlobal("HTMLElement", happyWindow.HTMLElement)
+  setGlobal("Element", happyWindow.Element)
+  setGlobal("Node", happyWindow.Node)
+  setGlobal("DocumentFragment", happyWindow.DocumentFragment)
+  setGlobal("SVGElement", happyWindow.SVGElement)
+  setGlobal("navigator", happyWindow.navigator)
+  setGlobal("getComputedStyle", happyWindow.getComputedStyle.bind(happyWindow))
+  const rafTimers = new Map<number, ReturnType<typeof setTimeout>>()
+  let rafSeq = 0
+  setGlobal("requestAnimationFrame", (cb: FrameRequestCallback) => {
+    rafSeq += 1
+    const id = rafSeq
+    const timer = setTimeout(() => {
+      rafTimers.delete(id)
+      cb(Date.now())
+    }, 0)
+    rafTimers.set(id, timer)
+    return id
+  })
+  setGlobal("cancelAnimationFrame", (id: number) => {
+    const timer = rafTimers.get(id)
+    if (timer !== undefined) {
+      clearTimeout(timer)
+      rafTimers.delete(id)
+    }
+  })
+  setGlobal("MutationObserver", happyWindow.MutationObserver)
+  // Intentionally false: we use flushSync (not act) so layout effects run while
+  // passive effects stay pending — the seam that catches a useEffect regression.
+  setGlobal("IS_REACT_ACT_ENVIRONMENT", false)
+
+  let disposed = false
+  return {
+    window: happyWindow,
+    dispose: () => {
+      if (disposed) return
+      disposed = true
+      for (const timer of rafTimers.values()) clearTimeout(timer)
+      rafTimers.clear()
+      happyWindow.close()
+      restoreGlobals(previous)
+    },
+  }
+}
+
+/** happy-dom element → DOM HTMLElement for React createRoot / queries. */
+function asDomElement(node: unknown): HTMLElement {
+  return node as unknown as HTMLElement
+}
+
+function mountRootContainer(happyWindow: Window): HTMLElement {
+  const el = happyWindow.document.createElement("div")
+  happyWindow.document.body.appendChild(el)
+  return asDomElement(el)
+}
+
+/**
+ * Latest committed presentation after layout effects. Overwrites on each
+ * layout pass so intermediate empty-flight frames during setFlights flush are
+ * discarded — only the last frame of a flushSync is authoritative.
+ */
+type FrameHolder = { current: FrameSnapshot | null }
+
+function BoardProbe({
+  laneItems,
+  onFrame,
+}: {
+  readonly laneItems: ReadonlyMap<PipelineLaneId, readonly LaneItem[]>
+  readonly onFrame: (frame: FrameSnapshot) => void
+}): ReactElement {
+  const route = usePipelineRouteFlights(laneItems)
+  const workItemById = new Map<string, LaneItem>()
+  for (const items of laneItems.values()) {
+    for (const item of items) {
+      workItemById.set(item.id, item)
+    }
+  }
+
+  // Publish after layout effects of children (this probe) so the snapshot is
+  // the post-reconciliation commit — the first paint opportunity.
+  useLayoutEffect(() => {
+    const build = presentLaneColumnItems({
+      laneId: "build",
+      laneItems: laneItems.get("build") ?? [],
+      flights: route.flights,
+      workItemById,
+    }).map((entry) => ({
+      id: entry.workItem.id,
+      departing: entry.departing,
+      arriving: entry.arriving,
+    }))
+    const review = presentLaneColumnItems({
+      laneId: "review",
+      laneItems: laneItems.get("review") ?? [],
+      flights: route.flights,
+      workItemById,
+    }).map((entry) => ({
+      id: entry.workItem.id,
+      departing: entry.departing,
+      arriving: entry.arriving,
+    }))
+    const counts = displayLaneCounts(trueLaneCounts(laneItems), route.flights)
+    const displayCounts: Record<string, number> = {}
+    for (const lane of PIPELINE_LANES) {
+      displayCounts[lane.id] = counts.get(lane.id) ?? 0
+    }
+    onFrame({
+      flights: route.flights.map((flight) => ({
+        workItemId: flight.workItemId,
+        from: flight.from,
+        to: flight.to,
+        phase: flight.phase,
+      })),
+      build,
+      review,
+      displayCounts,
+    })
+  })
+
+  return createElement("div", {
+    "data-flight-count": String(route.flights.length),
+    "data-flight-phase": route.flights[0]?.phase ?? "",
+    "data-build-ids": (laneItems.get("build") ?? []).map((i) => i.id).join(","),
+    "data-review-ids": (laneItems.get("review") ?? [])
+      .map((i) => i.id)
+      .join(","),
+  })
+}
+
+function Harness({
+  initial,
+  onFrame,
+  controlRef,
+}: {
+  readonly initial: Map<PipelineLaneId, readonly LaneItem[]>
+  readonly onFrame: (frame: FrameSnapshot) => void
+  readonly controlRef: {
+    current: null | {
+      setLaneItems: (next: Map<PipelineLaneId, readonly LaneItem[]>) => void
+    }
+  }
+}): ReactElement {
+  const [laneItems, setLaneItems] = useState(initial)
+  useLayoutEffect(() => {
+    controlRef.current = { setLaneItems }
+  })
+  return createElement(BoardProbe, { laneItems, onFrame })
+}
+
+describe("usePipelineRouteFlights first paint", () => {
+  let installed: InstalledDom
+  let root: Root | null = null
+  let container: HTMLElement
+
+  /** Unmount React then let its scheduler drain while happy-dom window still exists. */
+  async function tearDownRoot(): Promise<void> {
+    if (root !== null) {
+      flushSync(() => {
+        root?.unmount()
+      })
+      root = null
+    }
+    // React may schedule a NormalPriority callback that reads `window.event`.
+    await new Promise<void>((resolve) => {
+      setTimeout(resolve, 0)
+    })
+  }
+
+  beforeEach(() => {
+    installed = installDom()
+    container = mountRootContainer(installed.window)
+    root = createRoot(container)
+  })
+
+  afterEach(async () => {
+    await tearDownRoot()
+    installed.dispose()
+  })
+
+  test("first paint after lane change keeps departing ticket and withholds destination", () => {
+    // Holder overwrites each layout pass; after flushSync it is the paint frame.
+    const frame: FrameHolder = { current: null }
+    const controlRef: {
+      current: null | {
+        setLaneItems: (next: Map<PipelineLaneId, readonly LaneItem[]>) => void
+      }
+    } = { current: null }
+
+    const buildOnly = emptyLaneItems()
+    buildOnly.set("build", [{ id: "job-1" }, { id: "job-2" }])
+
+    flushSync(() => {
+      root?.render(
+        createElement(Harness, {
+          initial: buildOnly,
+          onFrame: (next) => {
+            frame.current = next
+          },
+          controlRef,
+        }),
+      )
+    })
+
+    // Baseline settled: no invented flights on load.
+    expect(controlRef.current).not.toBeNull()
+    const baseline = frame.current
+    expect(baseline).not.toBeNull()
+    expect(baseline?.flights).toEqual([])
+    expect(baseline?.build).toEqual([
+      { id: "job-1", departing: false, arriving: false },
+      { id: "job-2", departing: false, arriving: false },
+    ])
+    expect(baseline?.review).toEqual([])
+    expect(baseline?.displayCounts.build).toBe(2)
+    expect(baseline?.displayCounts.review).toBe(0)
+
+    // Authoritative data: job-1 classifies into Review (true counts move).
+    const afterMove = emptyLaneItems()
+    afterMove.set("build", [{ id: "job-2" }])
+    afterMove.set("review", [{ id: "job-1" }])
+
+    // flushSync runs layout effects only — passive effects stay pending.
+    // Layout-sync reconciliation must already install the route flight here.
+    flushSync(() => {
+      controlRef.current?.setLaneItems(afterMove)
+    })
+
+    const firstPaint = frame.current
+    expect(firstPaint).not.toBeNull()
+    expect(firstPaint?.flights).toHaveLength(1)
+    expect(firstPaint?.flights[0]).toMatchObject({
+      workItemId: "job-1",
+      from: "build",
+      to: "review",
+      phase: "eject",
+    })
+    // Source keeps inert departing ticket at frozen order (index 0).
+    expect(firstPaint?.build).toEqual([
+      { id: "job-1", departing: true, arriving: false },
+      { id: "job-2", departing: false, arriving: false },
+    ])
+    // Destination ticket withheld until absorb.
+    expect(firstPaint?.review).toEqual([])
+    // Counts still match pre-transfer presentation.
+    expect(firstPaint?.displayCounts.build).toBe(2)
+    expect(firstPaint?.displayCounts.review).toBe(0)
+
+    // DOM after flush must not imply the transfer already finished.
+    expect(
+      container
+        .querySelector("[data-flight-count]")
+        ?.getAttribute("data-flight-count"),
+    ).toBe("1")
+    expect(
+      container
+        .querySelector("[data-flight-phase]")
+        ?.getAttribute("data-flight-phase"),
+    ).toBe("eject")
+  })
+
+  test("reduced motion snaps to destination without a route flight", async () => {
+    // Re-install with reduced motion before mounting React.
+    await tearDownRoot()
+    installed.dispose()
+    installed = installDom({ reducedMotion: true })
+    container = mountRootContainer(installed.window)
+    root = createRoot(container)
+
+    const frame: FrameHolder = { current: null }
+    const controlRef: {
+      current: null | {
+        setLaneItems: (next: Map<PipelineLaneId, readonly LaneItem[]>) => void
+      }
+    } = { current: null }
+
+    const buildOnly = emptyLaneItems()
+    buildOnly.set("build", [{ id: "job-1" }])
+
+    flushSync(() => {
+      root?.render(
+        createElement(Harness, {
+          initial: buildOnly,
+          onFrame: (next) => {
+            frame.current = next
+          },
+          controlRef,
+        }),
+      )
+    })
+
+    const afterMove = emptyLaneItems()
+    afterMove.set("review", [{ id: "job-1" }])
+
+    flushSync(() => {
+      controlRef.current?.setLaneItems(afterMove)
+    })
+
+    const firstPaint = frame.current
+    expect(firstPaint).not.toBeNull()
+    expect(firstPaint?.flights).toEqual([])
+    expect(firstPaint?.build).toEqual([])
+    expect(firstPaint?.review).toEqual([
+      { id: "job-1", departing: false, arriving: false },
+    ])
+    expect(firstPaint?.displayCounts.build).toBe(0)
+    expect(firstPaint?.displayCounts.review).toBe(1)
+  })
+})

--- a/apps/harness/test/pipeline-route-transition.test.ts
+++ b/apps/harness/test/pipeline-route-transition.test.ts
@@ -481,6 +481,156 @@ describe("nextFlightPhase / phaseDurationMs", () => {
   })
 })
 
+describe("first-frame projection after layout-sync reconciliation", () => {
+  /**
+   * Mirrors the post-layout-effect commit for a Build → Review handoff: pure
+   * composition of reconcile + create + present + counts (issue #760).
+   */
+  test("pre-absorb first frame: departing source, withheld dest, eject traveler, held counts", () => {
+    const job = { id: "job-1" }
+    const resident = { id: "job-2" }
+    const byId = new Map([
+      ["job-1", job],
+      ["job-2", resident],
+    ])
+    const previous = assignment([
+      ["job-1", "build"],
+      ["job-2", "build"],
+    ])
+    const next = assignment([
+      ["job-1", "review"],
+      ["job-2", "build"],
+    ])
+    const priorOrder = new Map<PipelineLaneId, readonly string[]>([
+      ["build", ["job-1", "job-2"]],
+      ["review", []],
+      ["queue", []],
+      ["pr", []],
+      ["attention", []],
+      ["complete", []],
+    ])
+
+    const { flights: kept, newTransitions } = reconcileFlights({
+      previous,
+      next,
+      flights: [],
+    })
+    const flights = [
+      ...kept,
+      ...newTransitions.map((transition) =>
+        createRouteFlight(
+          transition,
+          sourceOrderIndexInLane({
+            workItemId: transition.workItemId,
+            laneId: transition.from,
+            orderedIdsByLane: priorOrder,
+          }),
+        ),
+      ),
+    ]
+
+    expect(flights).toHaveLength(1)
+    expect(flights[0]?.phase).toBe("eject")
+    expect(flights[0]?.from).toBe("build")
+    expect(flights[0]?.to).toBe("review")
+    expect(flights[0]?.sourceOrderIndex).toBe(0)
+
+    // True data after the move.
+    const buildItems = [resident]
+    const reviewItems = [job]
+
+    expect(
+      presentLaneColumnItems({
+        laneId: "build",
+        laneItems: buildItems,
+        flights,
+        workItemById: byId,
+      }),
+    ).toEqual([
+      { workItem: job, departing: true, arriving: false },
+      { workItem: resident, departing: false, arriving: false },
+    ])
+    expect(
+      presentLaneColumnItems({
+        laneId: "review",
+        laneItems: reviewItems,
+        flights,
+        workItemById: byId,
+      }),
+    ).toEqual([])
+
+    const trueCounts = new Map<PipelineLaneId, number>([
+      ["queue", 0],
+      ["build", 1],
+      ["review", 1],
+      ["pr", 0],
+      ["attention", 0],
+      ["complete", 0],
+    ])
+    const display = displayLaneCounts(trueCounts, flights)
+    expect(display.get("build")).toBe(2)
+    expect(display.get("review")).toBe(0)
+  })
+
+  test("absorb (not earlier): destination ticket and true counts appear together", () => {
+    const job = { id: "job-1" }
+    const byId = new Map([["job-1", job]])
+    const trueCounts = new Map<PipelineLaneId, number>([
+      ["queue", 0],
+      ["build", 0],
+      ["review", 1],
+      ["pr", 0],
+      ["attention", 0],
+      ["complete", 0],
+    ])
+
+    for (const phase of ["eject", "travel", "enter"] as const) {
+      const flights = [
+        createRouteFlight({ workItemId: "job-1", from: "build", to: "review" }),
+      ].map((flight) => ({ ...flight, phase }))
+      expect(
+        presentLaneColumnItems({
+          laneId: "review",
+          laneItems: [job],
+          flights,
+          workItemById: byId,
+        }),
+      ).toEqual([])
+      expect(displayLaneCounts(trueCounts, flights).get("review")).toBe(0)
+      expect(displayLaneCounts(trueCounts, flights).get("build")).toBe(1)
+    }
+
+    const absorbing = [
+      {
+        ...createRouteFlight({
+          workItemId: "job-1",
+          from: "build",
+          to: "review",
+        }),
+        phase: "absorb" as const,
+      },
+    ]
+    expect(
+      presentLaneColumnItems({
+        laneId: "build",
+        laneItems: [],
+        flights: absorbing,
+        workItemById: byId,
+      }),
+    ).toEqual([])
+    expect(
+      presentLaneColumnItems({
+        laneId: "review",
+        laneItems: [job],
+        flights: absorbing,
+        workItemById: byId,
+      }),
+    ).toEqual([{ workItem: job, departing: false, arriving: true }])
+    expect(displayLaneCounts(trueCounts, absorbing).get("review")).toBe(1)
+    expect(displayLaneCounts(trueCounts, absorbing).get("build")).toBe(0)
+  })
+})
+
 describe("reconcileFlights", () => {
   test("keeps flights still targeting the work item's current lane", () => {
     const flight = createRouteFlight({

--- a/bun.lock
+++ b/bun.lock
@@ -65,6 +65,7 @@
         "@types/react": "^19.0.8",
         "@types/react-dom": "^19.0.3",
         "@vitejs/plugin-react": "^6.0.4",
+        "happy-dom": "^20.11.1",
         "playwright-bdd": "^9.2.0",
         "tailwindcss": "^4.3.3",
         "vite": "^8.1.5",
@@ -1252,6 +1253,8 @@
 
     "@types/semver": ["@types/semver@7.7.1", "", {}, "sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA=="],
 
+    "@types/whatwg-mimetype": ["@types/whatwg-mimetype@3.0.2", "", {}, "sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA=="],
+
     "@types/ws": ["@types/ws@8.18.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg=="],
 
     "@typescript/native": ["typescript@7.0.2", "", { "optionalDependencies": { "@typescript/typescript-aix-ppc64": "7.0.2", "@typescript/typescript-darwin-arm64": "7.0.2", "@typescript/typescript-darwin-x64": "7.0.2", "@typescript/typescript-freebsd-arm64": "7.0.2", "@typescript/typescript-freebsd-x64": "7.0.2", "@typescript/typescript-linux-arm": "7.0.2", "@typescript/typescript-linux-arm64": "7.0.2", "@typescript/typescript-linux-loong64": "7.0.2", "@typescript/typescript-linux-mips64el": "7.0.2", "@typescript/typescript-linux-ppc64": "7.0.2", "@typescript/typescript-linux-riscv64": "7.0.2", "@typescript/typescript-linux-s390x": "7.0.2", "@typescript/typescript-linux-x64": "7.0.2", "@typescript/typescript-netbsd-arm64": "7.0.2", "@typescript/typescript-netbsd-x64": "7.0.2", "@typescript/typescript-openbsd-arm64": "7.0.2", "@typescript/typescript-openbsd-x64": "7.0.2", "@typescript/typescript-sunos-x64": "7.0.2", "@typescript/typescript-win32-arm64": "7.0.2", "@typescript/typescript-win32-x64": "7.0.2" }, "bin": { "tsc": "bin/tsc" } }, "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA=="],
@@ -1402,6 +1405,8 @@
 
     "buffer-from": ["buffer-from@1.1.2", "", {}, "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="],
 
+    "buffer-image-size": ["buffer-image-size@0.6.4", "", { "dependencies": { "@types/node": "*" } }, "sha512-nEh+kZOPY1w+gcCMobZ6ETUp9WfibndnosbpwB1iJk/8Gt5ZF2bhS6+B6bPYz424KtwsR6Rflc3tCz1/ghX2dQ=="],
+
     "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
 
     "bytes": ["bytes@3.1.2", "", {}, "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="],
@@ -1540,6 +1545,8 @@
 
     "enquirer": ["enquirer@2.3.6", "", { "dependencies": { "ansi-colors": "^4.1.1" } }, "sha512-yjNnPr315/FjS4zIsUxYguYUPP2e1NK4d7E7ZOLiyYCcbFBiTMyID+2wvm2w6+pZ/odMA7cRkjhsPbltwBOrLg=="],
 
+    "entities": ["entities@7.0.1", "", {}, "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA=="],
+
     "env-paths": ["env-paths@2.2.1", "", {}, "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A=="],
 
     "error-ex": ["error-ex@1.3.4", "", { "dependencies": { "is-arrayish": "^0.2.1" } }, "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ=="],
@@ -1677,6 +1684,8 @@
     "gray-matter": ["gray-matter@4.0.3", "", { "dependencies": { "js-yaml": "^3.13.1", "kind-of": "^6.0.2", "section-matter": "^1.0.0", "strip-bom-string": "^1.0.0" } }, "sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q=="],
 
     "h3-v2": ["h3@2.0.1-rc.20", "", { "dependencies": { "rou3": "^0.8.1", "srvx": "^0.11.13" }, "peerDependencies": { "crossws": "^0.4.1" }, "optionalPeers": ["crossws"], "bin": { "h3": "bin/h3.mjs" } }, "sha512-28ljodXuUp0fZovdiSRq4G9OgrxCztrJe5VdYzXAB7ueRvI7pIUqLU14Xi3XqdYJ/khXjfpUOOD2EQa6CmBgsg=="],
+
+    "happy-dom": ["happy-dom@20.11.1", "", { "dependencies": { "@types/node": ">=20.0.0", "@types/whatwg-mimetype": "^3.0.2", "@types/ws": "^8.18.1", "buffer-image-size": "^0.6.4", "entities": "^7.0.1", "whatwg-mimetype": "^3.0.0", "ws": "^8.21.0" } }, "sha512-XSt8tMzbW9ymE7687xztkO1ckR7qJNQ3LywY9vlYGhGi3zXrGBHuUo2Cl1ztZaICW+1eAGdkLbj6iwVqDT33kg=="],
 
     "has-flag": ["has-flag@4.0.0", "", {}, "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="],
 
@@ -2195,6 +2204,8 @@
     "wcwidth": ["wcwidth@1.0.1", "", { "dependencies": { "defaults": "^1.0.3" } }, "sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg=="],
 
     "webpack-virtual-modules": ["webpack-virtual-modules@0.6.2", "", {}, "sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ=="],
+
+    "whatwg-mimetype": ["whatwg-mimetype@3.0.0", "", {}, "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q=="],
 
     "which": ["which@3.0.1", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "bin/which.js" } }, "sha512-XA1b62dzQzLfaEOSQFTCOd5KFf/1VSzZo7/7TUjnya6u0vGGKzU96UQBZTAThCb2j4/xjBAyii1OhRLJEivHvg=="],
 


### PR DESCRIPTION
## Why

When a Work Item advanced to the next pipeline lane, the board briefly painted
it in the destination lane before route-flight state was installed. Operators
saw a forward jump and reversal on every animated handoff because assignment
reconciliation ran in a passive effect after paint.

## What

- Reconcile lane-assignment changes into `RouteFlight` state with
  `useLayoutEffect` so the first visible frame already shows the eject-phase
  traveler, greying source ticket, withheld destination, and held counts.
- Leave phase timers, fed-state, and smoke cleanup in passive effects.
- Preserve initial-mount baseline (no invented flights) and reduced-motion snap.
- Add a `flushSync` + happy-dom first-paint regression and pure pre-absorb /
  absorb composition coverage; restore happy-dom globals after each test.

Presentation-only: lifecycle advancement, queries, and backend behavior are
unchanged. SSR may still log the usual `useLayoutEffect` no-op warning; client
paint remains layout-sync by design.

## Verification

- `bunx nx run harness:test`
- `bunx nx run harness:build`
- Focused typecheck + `pipeline-route-flights` tests after review remediation

Relates to #760.

Closes #760