### PR TITLE
fix(harness): align parent issue rows

### DIFF
--- a/apps/harness/src/routes/index.tsx
+++ b/apps/harness/src/routes/index.tsx
@@ -2762,7 +2762,7 @@ function ParentIssueGroup({
   return (
     <li className="min-w-0">
       <details className={ui.parentIssue} open>
-        <summary>
+        <summary className={ui.parentIssueSummary}>
           <span className={ui.repoIssueNum}>#{parent.issueNumber}</span>
           <span className="min-w-0">
             <a

--- a/apps/harness/src/ui.ts
+++ b/apps/harness/src/ui.ts
@@ -1087,7 +1087,8 @@ export const ui = {
 
   parentIssueError: "mx-[0.65rem] mt-[0.45rem] mb-[0.55rem]",
 
-  parentIssue: "my-[0.35rem] min-w-0 border-[1.5px] border-ink bg-panel",
+  parentIssue:
+    "group mx-[calc(-0.65rem-1.5px)] my-[0.35rem] min-w-0 border-[1.5px] border-ink bg-panel",
 
   parentIssueSummary:
     "grid cursor-pointer list-none grid-cols-[2.4rem_minmax(0,1fr)_auto] items-start gap-x-[0.55rem] gap-y-[0.45rem] px-[0.65rem] py-[0.55rem] [&::-webkit-details-marker]:hidden",
@@ -1098,7 +1099,7 @@ export const ui = {
   parentIssueSummaryActions: "flex shrink-0 items-center gap-[0.4rem]",
 
   parentIssueChevron:
-    "h-[0.85rem] w-[0.85rem] text-ink transition-transform duration-100 ease-in-out",
+    "h-[0.85rem] w-[0.85rem] text-ink transition-transform duration-100 ease-in-out group-open:rotate-180",
 
   /**
    * Rotate chevron when details is open.
@@ -1108,7 +1109,7 @@ export const ui = {
 
   parentIssueChildren: cx(
     "relative m-0 grid list-none gap-0 border-t border-line-ghost",
-    "px-[0.65rem] pt-[0.15rem] pr-[0.65rem] pb-[0.55rem] pl-[0.85rem]",
+    "px-[0.65rem] pt-[0.15rem] pb-[0.55rem]",
     "before:absolute before:top-[0.35rem] before:bottom-[0.45rem] before:left-0 before:w-0.5 before:bg-line-soft before:content-['']",
   ),
 

--- a/apps/harness/test/repos-interchange.test.ts
+++ b/apps/harness/test/repos-interchange.test.ts
@@ -179,6 +179,7 @@ describe("Interchange phase 4: repos page + blank slate", () => {
       "function RepositoryIssueRow(",
     )
     expect(parent).toContain("ui.parentIssue")
+    expect(parent).toContain("ui.parentIssueSummary")
     expect(parent).toContain("ui.parentIssueChildren")
     expect(parent).toContain("ui.parentIssueClosedCount")
     expect(parent).toContain("ui.repoIssueTitle")
@@ -192,7 +193,12 @@ describe("Interchange phase 4: repos page + blank slate", () => {
 
     const ui = uiSource()
     expect(ui).toContain("parentIssue:")
+    expect(ui).toMatch(/parentIssue:[\s\S]*?"group /)
+    expect(ui).toContain("mx-[calc(-0.65rem-1.5px)]")
+    expect(ui).toMatch(/parentIssueSummary:[\s\S]*?px-\[0\.65rem\]/)
+    expect(ui).toMatch(/parentIssueChevron:[\s\S]*?group-open:rotate-180/)
     expect(ui).toContain("parentIssueChildren:")
+    expect(ui).toMatch(/parentIssueChildren:[\s\S]*?px-\[0\.65rem\]/)
     // Child rule is a before: pseudo on the children recipe.
     expect(ui).toMatch(/parentIssueChildren:[\s\S]*?before:/)
     expect(ui).toMatch(/parentIssueChildren:[\s\S]*?before:w-0\.5/)


### PR DESCRIPTION
## Summary

- restore inner spacing for parent issue summaries
- bleed parent group borders outward while keeping all GitHub issue numbers in one column
- preserve open/collapsed feedback on the custom parent chevron
- lock the layout recipe with contract coverage

## Verification

- `bunx nx test harness`
- `bunx nx typecheck harness`
- `bunx nx lint harness`
- `bunx nx build harness`
- pre-commit `bunx nx affected -t lint,typecheck,test --batch`