### PR TITLE
fix(harness): remove duplicate parent issue rail

### DIFF
--- a/apps/harness/src/ui.ts
+++ b/apps/harness/src/ui.ts
@@ -1108,9 +1108,8 @@ export const ui = {
   parentIssueChevronOpen: "rotate-180",
 
   parentIssueChildren: cx(
-    "relative m-0 grid list-none gap-0 border-t border-line-ghost",
+    "m-0 grid list-none gap-0 border-t border-line-ghost",
     "px-[0.65rem] pt-[0.15rem] pb-[0.55rem]",
-    "before:absolute before:top-[0.35rem] before:bottom-[0.45rem] before:left-0 before:w-0.5 before:bg-line-soft before:content-['']",
   ),
 
   lifecycleInset:

--- a/apps/harness/test/repos-interchange.test.ts
+++ b/apps/harness/test/repos-interchange.test.ts
@@ -172,7 +172,7 @@ describe("Interchange phase 4: repos page + blank slate", () => {
     expect(ui).toMatch(/lifecycleInset:[\s\S]*?border-ink/)
   })
 
-  test("parent issue groups use details card and 2px line-soft child rule", () => {
+  test("parent issue groups use an aligned details card", () => {
     const parent = sliceBetweenMarkers(
       homeSource(),
       "function ParentIssueGroup(",
@@ -199,10 +199,7 @@ describe("Interchange phase 4: repos page + blank slate", () => {
     expect(ui).toMatch(/parentIssueChevron:[\s\S]*?group-open:rotate-180/)
     expect(ui).toContain("parentIssueChildren:")
     expect(ui).toMatch(/parentIssueChildren:[\s\S]*?px-\[0\.65rem\]/)
-    // Child rule is a before: pseudo on the children recipe.
-    expect(ui).toMatch(/parentIssueChildren:[\s\S]*?before:/)
-    expect(ui).toMatch(/parentIssueChildren:[\s\S]*?before:w-0\.5/)
-    expect(ui).toMatch(/parentIssueChildren:[\s\S]*?before:bg-line-soft/)
+    expect(ui).not.toContain("before:absolute before:top-[0.35rem]")
     expect(ui).toContain("parentIssueError:")
   })
 


### PR DESCRIPTION
## Summary

- remove the redundant child-list pseudo-element that rendered beside the expanded parent border
- retain the parent border, child top divider, and aligned issue-number padding
- update the layout contract to reject the obsolete rail

## Verification

- inspected computed parent and child pseudo-element styles at `http://localhost:7000/repos?theme=light` with `agent-browser`
- `bunx nx test harness`
- `bunx nx typecheck harness`
- `bunx nx lint harness`
- `bunx nx build harness`
- pre-commit affected lint/typecheck/test matrix