### PR TITLE
fix(harness): promote PR control on Needs Human kanban tickets

### DIFF
--- a/apps/harness/src/kanban-board.tsx
+++ b/apps/harness/src/kanban-board.tsx
@@ -40,6 +40,7 @@ import { sessionWorktreeParts } from "./session-worktree-line.js"
 import { cx, ui } from "./ui.js"
 import { workItemIssueUrl } from "./work-item-issue-url.js"
 import {
+  kanbanPullRequestBadgePlacement,
   prBadgeClassName,
   statusBadgeClassNameForStatus,
 } from "./work-item-progress-chrome.js"
@@ -173,6 +174,16 @@ function PipelineTicket({
           repository.projectPath,
           workItem.pullRequestNumber,
         )
+  const prNumber = workItem.pullRequestNumber
+  const openPullRequestLabel =
+    prNumber === null ? null : `Open pull request #${prNumber}`
+  // Needs Human + PR: PR control in top status row; outcome keeps one alarm badge.
+  const prBadgePlacement = kanbanPullRequestBadgePlacement({
+    status: workItem.status,
+    pullRequestNumber: prNumber,
+    pullRequestUrl,
+  })
+  const promotePrToHeader = prBadgePlacement === "header"
   const { sessionId, worktreePath } = sessionWorktreeParts(
     workItem.sessionId,
     workItem.worktreePath,
@@ -225,15 +236,30 @@ function PipelineTicket({
       {/* Merged-lane: status is the lane itself — no COMPLETE tag or pause. */}
       {isCompleteLane ? null : (
         <div className={ui.jobTicketStatus}>
-          <span
-            className={cx(
-              ui.jobTicketState,
-              statusBadgeClassNameForStatus(workItem.status),
-            )}
-            title={workItem.stateLabel}
-          >
-            {workItem.stateLabel}
-          </span>
+          {promotePrToHeader &&
+          pullRequestUrl !== null &&
+          prNumber !== null &&
+          openPullRequestLabel !== null ? (
+            <a
+              className={prBadgeClassName}
+              href={pullRequestUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              aria-label={openPullRequestLabel}
+            >
+              PR #{prNumber} ↗
+            </a>
+          ) : (
+            <span
+              className={cx(
+                ui.jobTicketState,
+                statusBadgeClassNameForStatus(workItem.status),
+              )}
+              title={workItem.stateLabel}
+            >
+              {workItem.stateLabel}
+            </span>
+          )}
           <WorkItemPauseButton workItem={workItem} />
         </div>
       )}
@@ -277,6 +303,7 @@ function PipelineTicket({
           collapseEarlierLanes
           issueUrl={issueUrl}
           pullRequestUrl={pullRequestUrl}
+          showPullRequestBadge={!promotePrToHeader}
         />
       )}
     </li>

--- a/apps/harness/src/routes/index.tsx
+++ b/apps/harness/src/routes/index.tsx
@@ -3391,6 +3391,12 @@ export function WorkItemLifecycleStatus({
   collapseEarlierLanes = false,
   pullRequestUrl = null,
   issueUrl = null,
+  /**
+   * When false, outcome chrome omits the PR badge (Kanban promotes it into
+   * the top status row for Needs Human + PR). Default true keeps repository
+   * rows and non-promoted tickets unchanged.
+   */
+  showPullRequestBadge = true,
   onOpenSession,
 }: {
   workItem: WorkItem
@@ -3398,6 +3404,7 @@ export function WorkItemLifecycleStatus({
   collapseEarlierLanes?: boolean
   pullRequestUrl?: string | null
   issueUrl?: string | null
+  showPullRequestBadge?: boolean
   /** Opens Session usage for a session id (repos / non-compact chrome). */
   onOpenSession?: (workItemId: string, sessionId: string) => void
 }) {
@@ -3646,6 +3653,7 @@ export function WorkItemLifecycleStatus({
           pullRequestUrl={pullRequestUrl}
           completionSummary={workItem.completionSummary}
           issueUrl={issueUrl}
+          showPullRequestBadge={showPullRequestBadge}
         />
       </div>
       {workItem.lifecycleLabels.length > 0 &&

--- a/apps/harness/src/work-item-outcome-presentation.tsx
+++ b/apps/harness/src/work-item-outcome-presentation.tsx
@@ -4,6 +4,10 @@ import { prBadgeClassName } from "./work-item-progress-chrome.js"
 /**
  * Presentational outcome chrome for a Work Item: PR links for changed work, or
  * the distinct No-Change Outcome message, Issue link, and completion summary.
+ *
+ * `showPullRequestBadge` defaults true. Kanban tickets that promote the PR
+ * control into the top status row pass false so the outcome row keeps only the
+ * status badge (still linked to the PR when a URL exists).
  */
 export function WorkItemOutcomePresentation({
   state,
@@ -13,6 +17,7 @@ export function WorkItemOutcomePresentation({
   pullRequestUrl,
   completionSummary,
   issueUrl,
+  showPullRequestBadge = true,
 }: {
   state: string
   statusLabel: string
@@ -21,6 +26,7 @@ export function WorkItemOutcomePresentation({
   pullRequestUrl: string | null
   completionSummary: string | null
   issueUrl: string | null
+  showPullRequestBadge?: boolean
 }) {
   const isNoChangeComplete =
     state === "COMPLETE" &&
@@ -35,7 +41,8 @@ export function WorkItemOutcomePresentation({
   return (
     <>
       <span className="flex flex-wrap items-center justify-end gap-1">
-        {!isNoChangeComplete &&
+        {showPullRequestBadge &&
+          !isNoChangeComplete &&
           pullRequestUrl !== null &&
           prNumber !== null && (
             <a

--- a/apps/harness/src/work-item-progress-chrome.ts
+++ b/apps/harness/src/work-item-progress-chrome.ts
@@ -11,6 +11,30 @@ export const statusBadgeBaseClassName = ui.statusTag
 
 export const prBadgeClassName = ui.prBadge
 
+/**
+ * Where the Kanban ticket PR control lives.
+ *
+ * Terminal Needs Human with a PR promotes the PR badge into the top status
+ * row (replacing the duplicate stateLabel) so the outcome row keeps a single
+ * Needs Human alarm badge. All other tickets keep the PR in outcome chrome.
+ */
+export type KanbanPullRequestBadgePlacement = "header" | "outcome"
+
+export function kanbanPullRequestBadgePlacement(input: {
+  readonly status: string
+  readonly pullRequestNumber: number | null
+  readonly pullRequestUrl: string | null
+}): KanbanPullRequestBadgePlacement {
+  if (
+    input.status === "NEEDS_HUMAN" &&
+    input.pullRequestNumber !== null &&
+    input.pullRequestUrl !== null
+  ) {
+    return "header"
+  }
+  return "outcome"
+}
+
 const LANE_STYLE: Record<
   LifecyclePipelineLaneId,
   { readonly lane: string; readonly on: string }

--- a/apps/harness/test/kanban-route.test.ts
+++ b/apps/harness/test/kanban-route.test.ts
@@ -325,6 +325,40 @@ describe("kanban home board", () => {
     expect(completeBranch).toContain("<WorkItemLifecycleStatus")
   })
 
+  test("Needs Human + PR promotes PR control to top status row (issue #764)", () => {
+    // Drop duplicate top NEEDS HUMAN stateLabel; one PR control up top, one
+    // Needs Human badge in outcome chrome (showPullRequestBadge false).
+    const source = boardSource()
+    const ticket = source.slice(
+      source.indexOf("function PipelineTicket("),
+      source.indexOf("function KanbanJobsBoard()"),
+    )
+    expect(ticket).toContain("kanbanPullRequestBadgePlacement")
+    expect(ticket).toContain('prBadgePlacement === "header"')
+    expect(ticket).toContain("promotePrToHeader")
+    // Header PR reuses shared badge recipe + accessible open-in-new-tab name.
+    expect(ticket).toContain("prBadgeClassName")
+    // Escaped so the assertion matches source template text without Biome
+    // noTemplateCurlyInString on a plain string literal.
+    expect(ticket).toContain(`Open pull request #\${prNumber}`)
+    expect(ticket).toContain("PR #{prNumber} ↗")
+    expect(ticket).toContain('target="_blank"')
+    // Outcome row omits the second PR badge when the control was promoted.
+    expect(ticket).toContain("showPullRequestBadge={!promotePrToHeader}")
+    // Pause stays in the top status row with the promoted PR (or stateLabel).
+    expect(ticket).toContain("ui.jobTicketStatus")
+    expect(ticket).toContain("<WorkItemPauseButton workItem={workItem} />")
+    // Non-promoted tickets still render stateLabel in that row.
+    expect(ticket).toContain("{workItem.stateLabel}")
+    // Lifecycle still receives pullRequestUrl so Decide PR merge chips link.
+    const lifecycleCall = ticket.slice(
+      ticket.indexOf("<WorkItemLifecycleStatus"),
+      ticket.indexOf("/>", ticket.indexOf("<WorkItemLifecycleStatus")) + 2,
+    )
+    expect(lifecycleCall).toContain("pullRequestUrl={pullRequestUrl}")
+    expect(lifecycleCall).toContain("showPullRequestBadge={!promotePrToHeader}")
+  })
+
   test("Kanban tickets opt into earlier-lane lifecycle chip collapse", () => {
     // Issue #679: collapse earlier lanes on board tickets; repos reuses it.
     const source = boardSource()

--- a/apps/harness/test/work-item-outcome-presentation.test.tsx
+++ b/apps/harness/test/work-item-outcome-presentation.test.tsx
@@ -74,4 +74,45 @@ describe("WorkItemOutcomePresentation", () => {
     expect(html).not.toContain('aria-label="Completion summary"')
     expect(html).toContain("Running")
   })
+
+  test("omits the PR badge when showPullRequestBadge is false (Kanban promotion)", () => {
+    const html = renderToStaticMarkup(
+      <WorkItemOutcomePresentation
+        state="DECIDE_PR_MERGE"
+        statusLabel="Needs Human"
+        statusBadgeClassName={statusBadgeClassNameForStatus("NEEDS_HUMAN")}
+        pullRequestNumber={2418}
+        pullRequestUrl="https://github.com/acme/widgets/pull/2418"
+        completionSummary={null}
+        issueUrl="https://github.com/acme/widgets/issues/2410"
+        showPullRequestBadge={false}
+      />,
+    )
+
+    // Single Needs Human alarm; status still links to the PR when URL exists.
+    expect(html).toContain("Needs Human")
+    expect(html).not.toContain("PR #2418 ↗")
+    expect(html).not.toContain("PR #")
+    expect(html).toContain('href="https://github.com/acme/widgets/pull/2418"')
+    expect(html).toContain('aria-label="Open pull request #2418: Needs Human"')
+  })
+
+  test("keeps a status-only outcome when Needs Human has no PR", () => {
+    const html = renderToStaticMarkup(
+      <WorkItemOutcomePresentation
+        state="DECIDE_PR_MERGE"
+        statusLabel="Needs Human"
+        statusBadgeClassName={statusBadgeClassNameForStatus("NEEDS_HUMAN")}
+        pullRequestNumber={null}
+        pullRequestUrl={null}
+        completionSummary={null}
+        issueUrl="https://github.com/acme/widgets/issues/2410"
+      />,
+    )
+
+    expect(html).toContain("Needs Human")
+    expect(html).not.toContain("PR #")
+    expect(html).not.toContain("Open pull request")
+    expect(html).not.toContain('href="https://github.com')
+  })
 })

--- a/apps/harness/test/work-item-progress-chrome.test.ts
+++ b/apps/harness/test/work-item-progress-chrome.test.ts
@@ -1,6 +1,7 @@
 import { cx, ui } from "../src/ui.js"
 import {
   isStatusMessageAlarm,
+  kanbanPullRequestBadgePlacement,
   lifecycleStepChipClassName,
   lifecycleStepChipClassNameForStatus,
   prBadgeClassName,
@@ -103,5 +104,45 @@ describe("work-item-progress-chrome", () => {
     expect(isStatusMessageAlarm("NEEDS_HUMAN_REVIEW")).toBe(true)
     expect(isStatusMessageAlarm("QUEUED")).toBe(false)
     expect(isStatusMessageAlarm("RUNNING")).toBe(false)
+  })
+
+  test("promotes PR badge to Kanban header only for Needs Human with a PR", () => {
+    expect(
+      kanbanPullRequestBadgePlacement({
+        status: "NEEDS_HUMAN",
+        pullRequestNumber: 2418,
+        pullRequestUrl: "https://github.com/acme/widgets/pull/2418",
+      }),
+    ).toBe("header")
+    // No PR yet — keep top status badge; do not leave empty PR chrome.
+    expect(
+      kanbanPullRequestBadgePlacement({
+        status: "NEEDS_HUMAN",
+        pullRequestNumber: null,
+        pullRequestUrl: null,
+      }),
+    ).toBe("outcome")
+    // Non–Needs Human tickets keep outcome PR placement.
+    expect(
+      kanbanPullRequestBadgePlacement({
+        status: "RUNNING",
+        pullRequestNumber: 17,
+        pullRequestUrl: "https://github.com/acme/widgets/pull/17",
+      }),
+    ).toBe("outcome")
+    expect(
+      kanbanPullRequestBadgePlacement({
+        status: "NEEDS_HUMAN_REVIEW",
+        pullRequestNumber: 17,
+        pullRequestUrl: "https://github.com/acme/widgets/pull/17",
+      }),
+    ).toBe("outcome")
+    expect(
+      kanbanPullRequestBadgePlacement({
+        status: "COMPLETE",
+        pullRequestNumber: 17,
+        pullRequestUrl: "https://github.com/acme/widgets/pull/17",
+      }),
+    ).toBe("outcome")
   })
 })

--- a/docs/harness-design-system.md
+++ b/docs/harness-design-system.md
@@ -337,6 +337,14 @@ Anatomy (top to bottom):
 3. **Title link**: display 0.9rem/500 ink; `#nn` prefix in mono dim. Hover:
    2px underline, offset 3px, `--signal` underline color.
 4. **Status row**: status tag (§5.1) + pause/start icon button (§5.4).
+   **Needs Human exception (Kanban only, #764):** when the Work Item is
+   terminal Needs Human **and** a PR number/URL exists, the top status tag is
+   **omitted** and the PR badge (§5.5) moves into this row instead (primary
+   open-PR action). The outcome chrome below keeps a single Needs Human
+   status badge and does **not** also render a PR badge. Needs Human without
+   a PR keeps the top status tag (no empty PR slot). Non–Needs Human tickets
+   and repository issue rows keep the normal top status tag + outcome PR
+   layout. Pause stays in the status row in all cases.
 5. **Runtime lines**: mono 0.8rem `--ink-faint` — each on its own line:
    backend label; session id (underlined button + copy); worktree when set.
    (Title stays at relaxed card size; only meta under the title is larger.)
@@ -572,7 +580,9 @@ Mono 0.62–0.68rem/700 (archive uses `archiveLeg` size), **outline**: 1.5px
 ink border, transparent fill, ink text — quieter than a solid black stamp.
 0.2–0.24rem/0.5–0.55rem padding, "PR #n ↗". Hover: `--lane-pr` fill + white
 text. When the PR URL exists, the status tag links to the PR (existing
-behavior).
+behavior). On Kanban tickets in terminal Needs Human with a PR, the badge
+sits in the top status row instead of the outcome row so the card never
+shows two PR controls or two title-adjacent Needs Human tags (§4.4).
 
 ### 5.6 Stamps
 


### PR DESCRIPTION
## Why

Attention-lane Needs Human tickets with a PR showed two identical orange
`NEEDS HUMAN` tags: one under the title (`stateLabel`) and one in the
outcome row next to `PR #N`. That duplication made the card noisier
without adding information; the useful primary action is opening the PR.

## What

On Kanban tickets that are terminal Needs Human **and** have a PR
number/URL:

- Drop the top `stateLabel` status badge
- Place the existing `PR #N ↗` control in that top status row (pause
  stays there)
- Keep a single Needs Human badge in outcome chrome
- Suppress the outcome-row PR badge so there is exactly one PR control

Needs Human without a PR keeps the top status badge (no empty PR
chrome). Non–Needs Human tickets, Merged-lane cards, and repository
issue rows are unchanged. Decide PR merge chip linking, forge URL
construction, open-in-new-tab, and accessible names are preserved.

Presentation decision is centralized in
`kanbanPullRequestBadgePlacement`, with `showPullRequestBadge` on
outcome/lifecycle chrome. Design-system ticket anatomy documents the
exception.

## Verification

- `bunx nx test harness` (outcome presentation, progress chrome, and
  kanban-route presentation-seam coverage)
- `bunx nx run harness:typecheck`
- Pre-commit (lint) passed after Biome fixes in the new tests

Closes #764