### PR TITLE
fix(work-item-lifecycle): raise file-DB restart test timeout for CI load

### DIFF
--- a/packages/work-item-lifecycle/test/work-item-lifecycle.spec.ts
+++ b/packages/work-item-lifecycle/test/work-item-lifecycle.spec.ts
@@ -72,7 +72,11 @@ import {
   stubGitHubServiceLayer,
   stubGitLabServiceLayer,
 } from "../src/index.js"
-import { describe, expect, it } from "bun:test"
+import { describe, expect, it, setDefaultTimeout } from "bun:test"
+
+// File-backed bun:sqlite under nx parallel CI load can exceed the 5s default
+// (restart tests open a temp DB twice via makeRestartTestLayer).
+setDefaultTimeout(15_000)
 
 describe("WorkItemLifecycle", () => {
   const settledTiming = {


### PR DESCRIPTION
## Why

CI quality-gates flaked on work-item-lifecycle:test when the file-backed
SQLite restart case "persists Merge Mode Always across a harness restart"
hit Bun's default 5s timeout under parallel load (~11.5s). The assertion
never failed; the runner killed the test. Locally the same case finishes
well under 1s.

## What changed

In packages/work-item-lifecycle/test/work-item-lifecycle.spec.ts, call
setDefaultTimeout(15_000) with a short comment explaining file-backed
bun:sqlite under nx parallel CI (restart tests open a temp DB twice via
makeRestartTestLayer).

This matches the existing pattern in
apps/ready-for-agent/src/peek-selected-agent-backend.test.ts and covers
the other makeRestartTestLayer cases in the same file (Check-Start Anchor
and draft-to-ready restart). Product behavior and the
mergeMode === "always" assertion are unchanged.

## Verification

- bunx nx test work-item-lifecycle — 541 pass, 0 fail
- Focused restart case passed (~76ms locally after the timeout raise)

## Notes

Slightly longer failure wait for unrelated tests in this large suite is
intentional and acceptable for CI stability.

Closes #768