### PR TITLE
feat(work-item-lifecycle): refresh merge conflict handoffs from Needs Human

### DIFF
--- a/packages/work-item-lifecycle/src/lib/sync-needs-human-merge-handoffs.ts
+++ b/packages/work-item-lifecycle/src/lib/sync-needs-human-merge-handoffs.ts
@@ -2,6 +2,7 @@ import { Effect } from "effect"
 import { DbService } from "@ready-for-agent/db-service"
 import {
   GitHubService,
+  type PullRequestCheckStatus,
   type PullRequestLifecycleStatus,
 } from "@ready-for-agent/github-service"
 import { GitLabService } from "@ready-for-agent/gitlab-service"
@@ -11,8 +12,11 @@ import { workItemBranchName } from "./worktree-names.js"
 /**
  * After Issue reconciliation, advance Work Items whose Work Item PR was merged
  * (any unfinished operational step or Needs Human with a Work Item PR) to local
- * cleanup, and Abandon merge-related Needs Human when the PR was closed
- * unmerged. Forge lookup failures are skipped so Refresh still succeeds.
+ * cleanup, Abandon merge-related Needs Human when the PR was closed unmerged,
+ * and for open-PR Needs Human handoffs observe mergeability (ADR 0046):
+ * Decide/Merge Needs Human + conflicting → Resolve PR Merge Conflict;
+ * Resolve Needs Human + no longer conflicting → Watch PR Status Checks.
+ * Forge lookup failures are skipped so Refresh still succeeds.
  */
 export const syncNeedsHumanMergeHandoffs = (repositoryId: string) =>
   Effect.gen(function* () {
@@ -49,6 +53,12 @@ export const syncNeedsHumanMergeHandoffs = (repositoryId: string) =>
         latest !== undefined &&
         (latest.step === "decide_pr_merge" || latest.step === "merge_pr") &&
         latest.status === "succeeded"
+      const isResolveNeedsHuman =
+        workItem.state === "needs_human" &&
+        latest !== undefined &&
+        latest.step === "resolve_pr_merge_conflict" &&
+        latest.status === "succeeded"
+      const isClosedUnmergedEligible = isMergeNeedsHuman || isResolveNeedsHuman
 
       const headRefName = workItemBranchName({
         projectPath: repository.projectPath,
@@ -99,8 +109,8 @@ export const syncNeedsHumanMergeHandoffs = (repositoryId: string) =>
         continue
       }
 
-      // Closed-unmerged outside merge-related Needs Human is out of scope.
-      if (status._tag === "closed" && isMergeNeedsHuman) {
+      // Closed-unmerged: Decide/Merge/Resolve Needs Human only (ADR 0039 / 0046).
+      if (status._tag === "closed" && isClosedUnmergedEligible) {
         const didAdvance = yield* lifecycle
           .continueAfterHumanPrOutcome(workItem.id, "closed_unmerged")
           .pipe(
@@ -117,6 +127,94 @@ export const syncNeedsHumanMergeHandoffs = (repositoryId: string) =>
           )
         if (didAdvance) {
           advanced += 1
+        }
+        continue
+      }
+
+      // Open PR: mergeability for Decide/Merge or Resolve Needs Human (ADR 0046).
+      // Reuse Watch's check-status path as the mergeability source of truth.
+      if (
+        status._tag === "open" &&
+        (isMergeNeedsHuman || isResolveNeedsHuman)
+      ) {
+        const checkStatusLookup: Effect.Effect<
+          PullRequestCheckStatus,
+          unknown
+        > =
+          repository.forge === "gitlab"
+            ? gitlab.getPullRequestCheckStatus(repository, headRefName)
+            : github.getPullRequestCheckStatus(repository, headRefName)
+
+        const checkStatus = yield* checkStatusLookup.pipe(
+          Effect.catch((error) =>
+            Effect.logWarning(
+              "Skipping Needs Human mergeability: PR check status lookup failed",
+              {
+                workItemId: workItem.id,
+                repositoryId,
+                error: String(error),
+              },
+            ).pipe(Effect.as(null)),
+          ),
+        )
+
+        if (checkStatus === null) {
+          continue
+        }
+
+        // Lifecycle said open, but check-status can still see closed (TOCTOU).
+        // Do not trust mergeability alone: Watch prioritizes closed first, and a
+        // false merge_conflict_cleared advance leaves Resolve NH stuck as
+        // watch_pr_status_checks Needs Human (not closed-unmerged eligible).
+        // Skip so the next Refresh re-reads lifecycle and abandons/merges.
+        if (checkStatus._tag === "closed") {
+          continue
+        }
+
+        // Unknown mergeability is a no-op; still-conflicting Resolve stays parked.
+        if (checkStatus.mergeability === "unknown") {
+          continue
+        }
+
+        if (isMergeNeedsHuman && checkStatus.mergeability === "conflicting") {
+          const didAdvance = yield* lifecycle
+            .continueAfterHumanPrOutcome(workItem.id, "merge_conflict")
+            .pipe(
+              Effect.as(true),
+              Effect.catch((error) =>
+                Effect.logWarning(
+                  "Failed to advance Decide/Merge Needs Human after observed merge conflict",
+                  {
+                    workItemId: workItem.id,
+                    error: String(error),
+                  },
+                ).pipe(Effect.as(false)),
+              ),
+            )
+          if (didAdvance) {
+            advanced += 1
+          }
+          continue
+        }
+
+        if (isResolveNeedsHuman && checkStatus.mergeability === "mergeable") {
+          const didAdvance = yield* lifecycle
+            .continueAfterHumanPrOutcome(workItem.id, "merge_conflict_cleared")
+            .pipe(
+              Effect.as(true),
+              Effect.catch((error) =>
+                Effect.logWarning(
+                  "Failed to advance Resolve Needs Human after merge conflict cleared",
+                  {
+                    workItemId: workItem.id,
+                    error: String(error),
+                  },
+                ).pipe(Effect.as(false)),
+              ),
+            )
+          if (didAdvance) {
+            advanced += 1
+          }
         }
       }
     }

--- a/packages/work-item-lifecycle/src/lib/work-item-lifecycle.ts
+++ b/packages/work-item-lifecycle/src/lib/work-item-lifecycle.ts
@@ -603,7 +603,11 @@ export type AbandonError =
   | AcknowledgeError
   | JobNotFoundError
 
-export type HumanPrOutcome = "merged" | "closed_unmerged"
+export type HumanPrOutcome =
+  | "merged"
+  | "closed_unmerged"
+  | "merge_conflict"
+  | "merge_conflict_cleared"
 
 export type ContinueAfterHumanPrOutcomeError =
   | WorkItemNotFoundError
@@ -757,8 +761,11 @@ export interface WorkItemLifecycleShape {
    * Items paused for closed Issue + open/indeterminate PR) that owns a Work
    * Item PR: interrupt/cancel active Step Runs, clear pause and operator
    * reason, re-acquire a Worker Slot (or wait if none free), then local
-   * cleanup toward Complete. `closed_unmerged` remains limited to merge-related
-   * Needs Human handoffs.
+   * cleanup toward Complete. `closed_unmerged` Abandons Decide/Merge/Resolve
+   * Needs Human handoffs. `merge_conflict` advances Decide/Merge Needs Human
+   * to Resolve PR Merge Conflict; `merge_conflict_cleared` advances Resolve
+   * Needs Human to Watch PR Status Checks. Both re-acquire a Worker Slot
+   * (or wait if none free) like other Needs Human exits.
    */
   readonly continueAfterHumanPrOutcome: (
     workItemId: string,
@@ -4140,6 +4147,22 @@ export const makeWorkItemLifecycleLive = (
         row.pull_request_number !== null &&
         (latestStep === "decide_pr_merge" || latestStep === "merge_pr")
 
+      const isResolveNeedsHumanHandoff = (
+        row: WorkItemRow,
+        latestStep: OperationalLifecycleStep | null,
+      ): boolean =>
+        row.state === "needs_human" &&
+        row.pull_request_number !== null &&
+        latestStep === "resolve_pr_merge_conflict"
+
+      /** Closed-unmerged Abandon eligibility (ADR 0039 / 0046). */
+      const isClosedUnmergedAbandonHandoff = (
+        row: WorkItemRow,
+        latestStep: OperationalLifecycleStep | null,
+      ): boolean =>
+        isMergeNeedsHumanHandoff(row, latestStep) ||
+        isResolveNeedsHumanHandoff(row, latestStep)
+
       const loadLatestStep = (
         workItemId: string,
       ): Effect.Effect<
@@ -4458,11 +4481,11 @@ export const makeWorkItemLifecycleLive = (
 
         if (outcome === "closed_unmerged") {
           const latestStep = yield* loadLatestStep(workItemId)
-          if (!isMergeNeedsHumanHandoff(workItem, latestStep)) {
+          if (!isClosedUnmergedAbandonHandoff(workItem, latestStep)) {
             return yield* new NeedsHumanHandoffNotEligibleError({
               workItemId,
               reason:
-                "Work Item is not a merge-related Needs Human handoff with a Work Item PR",
+                "Work Item is not a Decide/Merge/Resolve Needs Human handoff with a Work Item PR",
             })
           }
           return yield* abandon(workItemId).pipe(
@@ -4480,6 +4503,116 @@ export const makeWorkItemLifecycleLive = (
               })
             }),
           )
+        }
+
+        if (
+          outcome === "merge_conflict" ||
+          outcome === "merge_conflict_cleared"
+        ) {
+          const latestStep = yield* loadLatestStep(workItemId)
+          const eligible =
+            outcome === "merge_conflict"
+              ? isMergeNeedsHumanHandoff(workItem, latestStep)
+              : isResolveNeedsHumanHandoff(workItem, latestStep)
+          if (!eligible) {
+            return yield* new NeedsHumanHandoffNotEligibleError({
+              workItemId,
+              reason:
+                outcome === "merge_conflict"
+                  ? "Work Item is not a Decide/Merge Needs Human handoff with a Work Item PR"
+                  : "Work Item is not a Resolve PR Merge Conflict Needs Human handoff with a Work Item PR",
+            })
+          }
+
+          const nextState =
+            outcome === "merge_conflict"
+              ? ("resolve_pr_merge_conflict" as const)
+              : ("watch_pr_status_checks" as const)
+
+          const now = yield* Clock.currentTimeMillis
+
+          yield* sql
+            .withTransaction(
+              Effect.gen(function* () {
+                const current = yield* loadWorkItemRow(workItemId)
+                if (!current) {
+                  return yield* new WorkItemNotFoundError({ workItemId })
+                }
+                const currentLatest = yield* loadLatestStep(workItemId)
+                const stillEligible =
+                  outcome === "merge_conflict"
+                    ? isMergeNeedsHumanHandoff(current, currentLatest)
+                    : isResolveNeedsHumanHandoff(current, currentLatest)
+                if (!stillEligible) {
+                  return yield* new NeedsHumanHandoffNotEligibleError({
+                    workItemId,
+                    reason:
+                      "Work Item is no longer eligible for mergeability advance",
+                  })
+                }
+
+                const updated = (yield* sql.unsafe(
+                  `UPDATE work_item
+                   SET state = ?,
+                       state_ready_at = ?,
+                       failure_code = NULL,
+                       failure_message = NULL,
+                       updated_at = ?
+                   WHERE id = ?
+                     AND state = 'needs_human'
+                   RETURNING id`,
+                  [nextState, now, now, workItemId],
+                )) as readonly { readonly id: string }[]
+
+                if (!updated[0]) {
+                  return yield* new NeedsHumanHandoffNotEligibleError({
+                    workItemId,
+                    reason:
+                      "Work Item is no longer eligible for mergeability advance",
+                  })
+                }
+
+                const acquired = yield* tryAcquireWorkerSlot(workItemId, now)
+                if (!acquired) {
+                  return true
+                }
+
+                const stillActive = (yield* sql.unsafe(
+                  `SELECT id FROM step_run
+                   WHERE work_item_id = ?
+                     AND status IN ('queued', 'running')
+                   LIMIT 1`,
+                  [workItemId],
+                )) as readonly { readonly id: string }[]
+                if (stillActive[0]) {
+                  return true
+                }
+
+                yield* enqueueStepRunForWorkItem(workItemId, nextState, now)
+                return true
+              }).pipe((mutation) =>
+                applyLifecycleTransition(
+                  workItemId,
+                  nextState,
+                  mutation,
+                  (applied) => applied === true,
+                ),
+              ),
+            )
+            .pipe(Effect.catch(mapContinueAfterHumanPrOutcomeTransactionError))
+
+          const advanced = yield* getWorkItem(workItemId).pipe(
+            Effect.catchTag(
+              "WorkItemNotFoundError",
+              (error) =>
+                new WorkItemLifecycleDatabaseError({
+                  message: `Work Item missing after mergeability advance: ${error.workItemId}`,
+                  cause: error,
+                }),
+            ),
+          )
+          yield* notifyWorkItemsChanged(advanced.repositoryId)
+          return advanced
         }
 
         // Merged: supersede any unfinished Work Item that owns a Work Item PR.

--- a/packages/work-item-lifecycle/test/remove-worktree.spec.ts
+++ b/packages/work-item-lifecycle/test/remove-worktree.spec.ts
@@ -32,7 +32,11 @@ import {
   workItemBranchName,
   workItemWorktreePath,
 } from "../src/index.js"
-import { describe, expect, it } from "bun:test"
+import { describe, expect, it, setDefaultTimeout } from "bun:test"
+
+// Real git + worktree-remove shims under nx parallel CI load can exceed the
+// default 5s (Directory-not-empty retry cases create a bare repo and worktree).
+setDefaultTimeout(15_000)
 
 const PlatformLayer = BunServices.layer
 

--- a/packages/work-item-lifecycle/test/sync-needs-human-merge-handoffs.spec.ts
+++ b/packages/work-item-lifecycle/test/sync-needs-human-merge-handoffs.spec.ts
@@ -69,7 +69,14 @@ describe("syncNeedsHumanMergeHandoffs", () => {
     removeWorktree: () => Effect.void,
   }
 
-  const githubWith = (getStatus: () => PullRequestLifecycleStatus) =>
+  type Mergeability = "mergeable" | "conflicting" | "unknown"
+  type CheckStatusTag = "succeeded" | "closed"
+
+  const githubWith = (
+    getStatus: () => PullRequestLifecycleStatus,
+    getMergeability: () => Mergeability = () => "mergeable",
+    getCheckStatusTag: () => CheckStatusTag = () => "succeeded",
+  ) =>
     Layer.succeed(GitHubService, {
       getAuthenticatedUserLogin: () => Effect.succeed("test-operator"),
       listReadyIssues: () => Effect.succeed([]),
@@ -78,16 +85,28 @@ describe("syncNeedsHumanMergeHandoffs", () => {
       createDraftPullRequest: () => Effect.succeed(1),
       countOpenNonDraftPullRequests: () => Effect.succeed(0),
       getPullRequestCheckStatus: () =>
-        Effect.succeed({
-          _tag: "succeeded",
-          terminalChecks: [],
-          mergeability: "mergeable",
-          baseRefName: "main",
-          headPushedAt: null,
-          headSha: null,
-          createdAt: null,
-          isDraft: null,
-        }),
+        Effect.succeed(
+          getCheckStatusTag() === "closed"
+            ? {
+                _tag: "closed" as const,
+                mergeability: getMergeability(),
+                baseRefName: "main",
+                headPushedAt: null,
+                headSha: null,
+                createdAt: null,
+                isDraft: null,
+              }
+            : {
+                _tag: "succeeded" as const,
+                terminalChecks: [],
+                mergeability: getMergeability(),
+                baseRefName: "main",
+                headPushedAt: null,
+                headSha: null,
+                createdAt: null,
+                isDraft: null,
+              },
+        ),
       getPrStatusCheckDiagnostics: () => Effect.succeed([]),
       observeAutomatedReviewEvidence: () =>
         Effect.succeed({
@@ -104,17 +123,30 @@ describe("syncNeedsHumanMergeHandoffs", () => {
   const makeLayer = (
     status: PullRequestLifecycleStatus,
     steps: LifecycleStepsShape = successfulSteps,
-  ) => makeLayerWithStatus(() => status, steps)
+    mergeability: Mergeability = "mergeable",
+    checkStatusTag: CheckStatusTag = "succeeded",
+  ) =>
+    makeLayerWithStatus(
+      () => status,
+      steps,
+      {},
+      () => mergeability,
+      () => checkStatusTag,
+    )
 
   const makeLayerWithStatus = (
     getStatus: () => PullRequestLifecycleStatus,
     steps: LifecycleStepsShape = successfulSteps,
     gitlab: Parameters<typeof stubGitLabServiceLayer>[0] = {},
+    getMergeability: () => Mergeability = () => "mergeable",
+    getCheckStatusTag: () => CheckStatusTag = () => "succeeded",
   ) =>
     WorkItemLifecycleLive.pipe(
       Layer.provideMerge(stubActiveAgentBackendLayer()),
       // githubWith controls GitHub PR lifecycle for syncNeedsHumanMergeHandoffs.
-      Layer.provideMerge(githubWith(getStatus)),
+      Layer.provideMerge(
+        githubWith(getStatus, getMergeability, getCheckStatusTag),
+      ),
       Layer.provideMerge(stubGitLabServiceLayer(gitlab)),
       Layer.provideMerge(
         Layer.succeed(LifecycleSteps, LifecycleSteps.of(steps)),
@@ -684,6 +716,231 @@ describe("syncNeedsHumanMergeHandoffs", () => {
         expect(completed.holdsWorkerSlot).toBe(false)
         expect(completed.worktreePath).toBeNull()
       }).pipe(Effect.provide(makeLayerWithStatus(() => prStatus, steps))),
+    )
+  })
+
+  const resolveNeedsHumanSteps: LifecycleStepsShape = {
+    ...successfulSteps,
+    watchPrStatusChecks: () =>
+      Effect.succeed({
+        _tag: "conflict" as const,
+        retiredCheckIds: [],
+        createdAt: new Date(0),
+        headSha: "conflict-head",
+        headPushedAt: new Date(0),
+        isDraft: false,
+      }),
+    resolvePrMergeConflict: () =>
+      Effect.succeed({
+        _tag: "needs_human",
+        reason: "Merge conflict requires human resolution",
+      }),
+  }
+
+  const driveToResolveNeedsHuman = Effect.gen(function* () {
+    const db = yield* DbService
+    const lifecycle = yield* WorkItemLifecycle
+    yield* db.updateConfig({
+      selectedAgentBackend: "opencode",
+      defaultModel: "opencode/deepseek-v4-flash-free",
+      defaultThinkingLevel: "low",
+      reviewModel: null,
+      reviewThinkingLevel: null,
+      maxConcurrentAgentTurns: 2,
+      maxConcurrentWorkItems: 5,
+    })
+    const repository = yield* db.addRepository({
+      forge: "github",
+      forgeHost: "github.com",
+      projectPath: "acme/widgets",
+      localPath: "/repos/acme/widgets.git",
+      isBare: true,
+    })
+    yield* db.storeIssue({
+      repositoryId: repository.id,
+      issueNumber: 42,
+      title: "Implement feature",
+      body: "Issue body",
+      url: "https://github.com/acme/widgets/issues/42",
+      state: "OPEN",
+      githubCreatedAt: new Date("2026-01-15T12:00:00.000Z"),
+      issueAuthor: null,
+      parent: null,
+      parentPosition: null,
+      hasChildren: false,
+      blockedBy: [],
+    })
+    const created = yield* lifecycle.implementNow(repository.id, 42)
+    // create…create_pr (8) + watch→resolve + resolve→needs_human
+    for (let index = 0; index < 10; index += 1) {
+      yield* makeQueuedJobsAvailable
+      yield* claimAndRunPending
+    }
+    const needsHuman = yield* lifecycle.getWorkItem(created.id)
+    expect(needsHuman.state).toBe("needs_human")
+    expect(needsHuman.stepRuns.at(-1)?.step).toBe("resolve_pr_merge_conflict")
+    return { repository, created, lifecycle }
+  })
+
+  it("advances Decide Needs Human to Resolve when Refresh sees a conflicting open PR", async () => {
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        const { repository, created, lifecycle } = yield* driveToNeedsHuman()
+        expect(yield* syncNeedsHumanMergeHandoffs(repository.id)).toBe(1)
+        const advanced = yield* lifecycle.getWorkItem(created.id)
+        expect(advanced.state).toBe("resolve_pr_merge_conflict")
+        expect(advanced.failureCode).toBeNull()
+        expect(advanced.failureMessage).toBeNull()
+        expect(advanced.holdsWorkerSlot).toBe(true)
+        expect(
+          advanced.stepRuns.some(
+            (run) =>
+              run.step === "resolve_pr_merge_conflict" &&
+              run.status === "queued",
+          ),
+        ).toBe(true)
+      }).pipe(
+        Effect.provide(
+          makeLayer({ _tag: "open" }, successfulSteps, "conflicting"),
+        ),
+      ),
+    )
+  })
+
+  it("advances Merge Needs Human to Resolve when Refresh sees a conflicting open PR", async () => {
+    const steps: LifecycleStepsShape = {
+      ...successfulSteps,
+      decidePrMerge: () => Effect.succeed({ _tag: "clanker_merge" }),
+      mergePr: () =>
+        Effect.succeed({
+          _tag: "needs_human",
+          reason: "merge_rejected",
+          message: "GitHub rejected the unchanged mergeable pull request",
+        }),
+    }
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        const { repository, created, lifecycle } = yield* driveToMergeNeedsHuman
+        expect(yield* syncNeedsHumanMergeHandoffs(repository.id)).toBe(1)
+        const advanced = yield* lifecycle.getWorkItem(created.id)
+        expect(advanced.state).toBe("resolve_pr_merge_conflict")
+        expect(advanced.holdsWorkerSlot).toBe(true)
+      }).pipe(
+        Effect.provide(makeLayer({ _tag: "open" }, steps, "conflicting")),
+      ),
+    )
+  })
+
+  it("advances Resolve Needs Human to Watch when Refresh sees mergeability recovered", async () => {
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        const { repository, created, lifecycle } =
+          yield* driveToResolveNeedsHuman
+        expect(yield* syncNeedsHumanMergeHandoffs(repository.id)).toBe(1)
+        const advanced = yield* lifecycle.getWorkItem(created.id)
+        expect(advanced.state).toBe("watch_pr_status_checks")
+        expect(advanced.failureCode).toBeNull()
+        expect(advanced.holdsWorkerSlot).toBe(true)
+        expect(
+          advanced.stepRuns.some(
+            (run) =>
+              run.step === "watch_pr_status_checks" && run.status === "queued",
+          ),
+        ).toBe(true)
+      }).pipe(
+        Effect.provide(
+          makeLayer({ _tag: "open" }, resolveNeedsHumanSteps, "mergeable"),
+        ),
+      ),
+    )
+  })
+
+  it("leaves Resolve Needs Human parked when the open PR is still conflicting", async () => {
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        const { repository, created, lifecycle } =
+          yield* driveToResolveNeedsHuman
+        expect(yield* syncNeedsHumanMergeHandoffs(repository.id)).toBe(0)
+        const still = yield* lifecycle.getWorkItem(created.id)
+        expect(still.state).toBe("needs_human")
+        expect(still.stepRuns.at(-1)?.step).toBe("resolve_pr_merge_conflict")
+      }).pipe(
+        Effect.provide(
+          makeLayer({ _tag: "open" }, resolveNeedsHumanSteps, "conflicting"),
+        ),
+      ),
+    )
+  })
+
+  it("does not transition Needs Human when mergeability is unknown", async () => {
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        const { repository, created, lifecycle } = yield* driveToNeedsHuman()
+        expect(yield* syncNeedsHumanMergeHandoffs(repository.id)).toBe(0)
+        const still = yield* lifecycle.getWorkItem(created.id)
+        expect(still.state).toBe("needs_human")
+        expect(still.stepRuns.at(-1)?.step).toBe("decide_pr_merge")
+      }).pipe(
+        Effect.provide(makeLayer({ _tag: "open" }, successfulSteps, "unknown")),
+      ),
+    )
+  })
+
+  it("does not advance Resolve Needs Human when check-status reports closed after lifecycle open (TOCTOU)", async () => {
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        const { repository, created, lifecycle } =
+          yield* driveToResolveNeedsHuman
+        // Lifecycle still open; check-status already closed+mergeable must not
+        // clear to Watch (would leave non-abandonable watch Needs Human).
+        expect(yield* syncNeedsHumanMergeHandoffs(repository.id)).toBe(0)
+        const still = yield* lifecycle.getWorkItem(created.id)
+        expect(still.state).toBe("needs_human")
+        expect(still.stepRuns.at(-1)?.step).toBe("resolve_pr_merge_conflict")
+      }).pipe(
+        Effect.provide(
+          makeLayer(
+            { _tag: "open" },
+            resolveNeedsHumanSteps,
+            "mergeable",
+            "closed",
+          ),
+        ),
+      ),
+    )
+  })
+
+  it("abandons Resolve Needs Human when Refresh sees the PR closed unmerged", async () => {
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        const { repository, created, lifecycle } =
+          yield* driveToResolveNeedsHuman
+        expect(yield* syncNeedsHumanMergeHandoffs(repository.id)).toBe(1)
+        const abandoned = yield* lifecycle.getWorkItem(created.id)
+        expect(abandoned.state).toBe("abandoned")
+        expect(abandoned.worktreePath).toBeNull()
+      }).pipe(
+        Effect.provide(
+          makeLayer({ _tag: "closed" }, resolveNeedsHumanSteps, "conflicting"),
+        ),
+      ),
+    )
+  })
+
+  it("merged still supersedes Resolve Needs Human", async () => {
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        const { repository, created, lifecycle } =
+          yield* driveToResolveNeedsHuman
+        expect(yield* syncNeedsHumanMergeHandoffs(repository.id)).toBe(1)
+        const advanced = yield* lifecycle.getWorkItem(created.id)
+        expect(advanced.state).toBe("local_cleanup")
+        expect(advanced.failureCode).toBeNull()
+      }).pipe(
+        Effect.provide(
+          makeLayer({ _tag: "merged" }, resolveNeedsHumanSteps, "conflicting"),
+        ),
+      ),
     )
   })
 

--- a/packages/work-item-lifecycle/test/work-item-lifecycle.spec.ts
+++ b/packages/work-item-lifecycle/test/work-item-lifecycle.spec.ts
@@ -72,7 +72,11 @@ import {
   stubGitHubServiceLayer,
   stubGitLabServiceLayer,
 } from "../src/index.js"
-import { describe, expect, it } from "bun:test"
+import { describe, expect, it, setDefaultTimeout } from "bun:test"
+
+// File-backed bun:sqlite under nx parallel CI load can exceed the 5s default
+// (restart tests open a temp DB twice via makeRestartTestLayer).
+setDefaultTimeout(15_000)
 
 describe("WorkItemLifecycle", () => {
   const settledTiming = {


### PR DESCRIPTION
## Why

While a Work Item sits in Needs Human waiting for human merge, the base can
advance and conflict the Work Item PR. Refresh already handled **merged** and
closed-unmerged Decide/Merge handoffs (ADR 0020 / 0039) but never inspected
**mergeability**, so Attention cards stayed stuck until a human fixed or merged
the PR. Domain transitions for this path landed in #766 (ADR 0046); this change
is the runtime wiring.

## What

- On successful Refresh, open Decide/Merge Needs Human with
  `mergeability === conflicting` advances to Resolve PR Merge Conflict
  (`merge_conflict` / `refresh_observed_merge_conflict`).
- Resolve Needs Human whose open PR is again mergeable advances to Watch PR
  Status Checks (`merge_conflict_cleared`) so settle/Decide/Merge can run again.
- Still-conflicting Resolve Needs Human and `unknown` mergeability stay parked
  (no thrash).
- Closed-unmerged Abandon eligibility now includes Resolve Needs Human.
- Mergeability comes from Watch’s `getPullRequestCheckStatus` source of truth;
  lifecycle-open + check-status-closed TOCTOU is a no-op so the next Refresh
  can abandon/merge correctly.
- Worker slot re-acquire / waiting matches other Needs Human exits; mergeability
  state updates use `RETURNING` like the merged cleanup path.

## Verification

- `packages/work-item-lifecycle` typecheck and full package tests (548) green.
- Focused `sync-needs-human-merge-handoffs` suite (20 cases): conflict → Resolve,
  cleared → Watch, still conflicting / unknown / closed-check TOCTOU stay,
  Resolve closed → Abandon, merged supersedes.
- Review pass clean after TOCTOU and RETURNING remediation.

## Limitations

- Discovery remains Refresh-only (no dedicated Needs Human PR poll loop).
- Broader matrix (GitLab mergeability, capacity-wait admission, check-status
  failure skip) not expanded beyond the core contract and TOCTOU regression.

Closes #767