### PR TITLE
fix(harness): colon-suffix forge identity field labels

### DIFF
--- a/apps/harness/src/routes/index.tsx
+++ b/apps/harness/src/routes/index.tsx
@@ -984,7 +984,7 @@ function AddRepositoryGuidance({
           <fieldset className={ui.blankSlateFieldset}>
             <legend>Confirm forge identity</legend>
             <label className={ui.blankSlateField}>
-              Forge
+              Forge:
               <select
                 value={inspection.forge}
                 onChange={(event) =>
@@ -999,7 +999,7 @@ function AddRepositoryGuidance({
               </select>
             </label>
             <label className={ui.blankSlateField}>
-              Forge host
+              Forge host:
               <input
                 required
                 value={inspection.forgeHost}
@@ -1012,7 +1012,7 @@ function AddRepositoryGuidance({
               />
             </label>
             <label className={ui.blankSlateField}>
-              Project path
+              Project path:
               <input
                 required
                 value={inspection.projectPath}
@@ -1891,7 +1891,7 @@ function RepositoryCard({
             <fieldset className={ui.dialogFieldset}>
               <legend>Forge identity</legend>
               <label className={ui.dialogField}>
-                Forge
+                Forge:
                 <select
                   className={ui.dialogInput}
                   value={forge}
@@ -1904,7 +1904,7 @@ function RepositoryCard({
                 </select>
               </label>
               <label className={ui.dialogField}>
-                Forge host
+                Forge host:
                 <input
                   className={cx(ui.dialogInput, ui.dialogInputMono)}
                   required
@@ -1913,7 +1913,7 @@ function RepositoryCard({
                 />
               </label>
               <label className={ui.dialogField}>
-                Project path
+                Project path:
                 <input
                   className={cx(ui.dialogInput, ui.dialogInputMono)}
                   required

--- a/apps/harness/test/blank-slate-add-command.test.ts
+++ b/apps/harness/test/blank-slate-add-command.test.ts
@@ -82,6 +82,10 @@ describe("blank-slate add repository command", () => {
     expect(guidance).toContain("ui.platePrimary")
     expect(guidance).toContain("ui.blankSlateFieldset")
     expect(guidance).toContain("Confirm forge identity")
+    // Issue #771: label-then-colon so field name vs value is obvious.
+    expect(guidance).toContain("Forge:")
+    expect(guidance).toContain("Forge host:")
+    expect(guidance).toContain("Project path:")
     expect(guidance).toContain("ui.guidanceCode")
     expect(guidance).toContain('tone="alarm"')
     expect(guidance).toContain('role="alert"')

--- a/apps/harness/test/interchange-phase5.test.ts
+++ b/apps/harness/test/interchange-phase5.test.ts
@@ -75,6 +75,11 @@ describe("Interchange phase 5: dialogs, menus, chrome + Ledger teardown", () => 
     expect(dialog).toContain("ui.dialogInput")
     expect(dialog).toContain("ui.platePrimary")
     expect(dialog).toContain("ui.plateMini")
+    // Issue #771: Forge identity fields use label-then-colon presentation.
+    expect(dialog).toContain("Forge identity")
+    expect(dialog).toContain("Forge:")
+    expect(dialog).toContain("Forge host:")
+    expect(dialog).toContain("Project path:")
     expect(dialog).not.toContain("font-serif")
     expect(dialog).not.toContain("oxblood")
     expect(dialog).not.toContain("shadow-[")


### PR DESCRIPTION
## Why

On the blank-slate **Confirm forge identity** fieldset and the edit-repo
**Forge identity** dialog, stacked labels and controls read as two similar
lines of text, so it was unclear which line was the field name and which was
the value.

## What

Present the three forge-identity fields as **label-then-colon** on both
surfaces:

- `Forge:`
- `Forge host:`
- `Project path:`

Controls stay editable (select for forge; text inputs for host and project
path). No verification, inspection, or data-model changes — presentation
only.

## Verification

- Updated source-string pins in `blank-slate-add-command.test.ts` and
  `interchange-phase5.test.ts`
- `bun test` on those files and full `nx test harness` suite passed
- Local review found no issues

Closes #771