### PR TITLE
fix(harness): collapse PR lane on COMPLETE repos lifecycle chrome

### DIFF
--- a/apps/harness/src/pipeline-lanes.ts
+++ b/apps/harness/src/pipeline-lanes.ts
@@ -254,9 +254,19 @@ export type LifecycleChipPresentationBlock =
     }
 
 /**
- * Plan Kanban (or full) chip presentation. When collapse is off or focus is
- * unknown, returns a single full-list block. Expanded earlier lanes are those
- * present in `expandedEarlierLanes` (ephemeral UI set).
+ * Plan Kanban / repos chip presentation. When collapse is off or focus is
+ * unknown (and not collapse-all), returns a single full-list block.
+ *
+ * Modes when `collapseEarlierLanes` is on:
+ * - **Focus lane** (default): earlier Build/Review/PR lanes collapse into
+ *   expandable summaries; the focus lane stays a full chip list.
+ * - **All reached** (`collapseAllReachedLanes`): every reached lifecycle lane
+ *   collapses — used for terminal COMPLETE repos chrome so PR is not left as
+ *   a permanent expanded strip (`docs/harness-design-system.md` §4.6).
+ *
+ * Expanded collapsed lanes are those present in `expandedEarlierLanes`
+ * (ephemeral UI set). Optional `prLaneLabel` overrides the PR-lane summary
+ * text (e.g. "MR" on GitLab).
  */
 export function planLifecycleChipPresentation(
   labels: readonly LifecycleLabelChip[],
@@ -264,12 +274,21 @@ export function planLifecycleChipPresentation(
     readonly collapseEarlierLanes: boolean
     readonly focusLane: LifecyclePipelineLaneId | null
     readonly expandedEarlierLanes: ReadonlySet<LifecyclePipelineLaneId>
+    /**
+     * Collapse every reached lifecycle lane (BUILD / REVIEW / PR|MR) as
+     * expandable journey-style summaries. Used for terminal COMPLETE work
+     * items under repos chrome. When true, `focusLane` is ignored.
+     */
+    readonly collapseAllReachedLanes?: boolean
+    /** Label for the PR lifecycle lane summary (default "PR"; use "MR" on GitLab). */
+    readonly prLaneLabel?: string
   },
 ): readonly LifecycleChipPresentationBlock[] {
+  const collapseAll = options.collapseAllReachedLanes === true
   if (
     !options.collapseEarlierLanes ||
-    options.focusLane === null ||
-    labels.length === 0
+    labels.length === 0 ||
+    (!collapseAll && options.focusLane === null)
   ) {
     return [{ kind: "full-list", chips: labels }]
   }
@@ -290,23 +309,57 @@ export function planLifecycleChipPresentation(
     }
   }
 
+  const laneSummaryLabel = (lane: LifecyclePipelineLaneId): string => {
+    if (lane === "pr" && options.prLaneLabel !== undefined) {
+      return options.prLaneLabel
+    }
+    return lifecycleLaneLabel(lane)
+  }
+
+  const collapsedLaneBlock = (
+    lane: LifecyclePipelineLaneId,
+    chips: readonly LifecycleLabelChip[],
+  ): LifecycleChipPresentationBlock => ({
+    kind: "earlier-lane",
+    lane,
+    laneLabel: laneSummaryLabel(lane),
+    durationMs: sumLaneDurationMs(chips),
+    expanded: options.expandedEarlierLanes.has(lane),
+    chips,
+  })
+
+  // COMPLETE journey: every reached lane is a condensed expandable leg.
+  if (collapseAll) {
+    const blocks: LifecycleChipPresentationBlock[] = []
+    for (const lane of LIFECYCLE_PIPELINE_LANE_ORDER) {
+      const chips = byLane.get(lane)
+      if (chips === undefined || chips.length === 0) continue
+      blocks.push(collapsedLaneBlock(lane, chips))
+    }
+    if (ungrouped.length > 0) {
+      blocks.push({ kind: "focus-lane", lane: null, chips: ungrouped })
+    }
+    if (blocks.length === 0) {
+      return [{ kind: "full-list", chips: labels }]
+    }
+    return blocks
+  }
+
+  const focusLane = options.focusLane
+  if (focusLane === null) {
+    return [{ kind: "full-list", chips: labels }]
+  }
+
   const blocks: LifecycleChipPresentationBlock[] = []
-  for (const earlier of earlierLifecycleLanes(options.focusLane)) {
+  for (const earlier of earlierLifecycleLanes(focusLane)) {
     const chips = byLane.get(earlier)
     if (chips === undefined || chips.length === 0) continue
-    blocks.push({
-      kind: "earlier-lane",
-      lane: earlier,
-      laneLabel: lifecycleLaneLabel(earlier),
-      durationMs: sumLaneDurationMs(chips),
-      expanded: options.expandedEarlierLanes.has(earlier),
-      chips,
-    })
+    blocks.push(collapsedLaneBlock(earlier, chips))
   }
 
   // Focus-lane chips always expanded. Also surface any later-lane chips (and
   // ungrouped phases) so a focus that lags retained history never drops steps.
-  const focusIndex = LIFECYCLE_PIPELINE_LANE_ORDER.indexOf(options.focusLane)
+  const focusIndex = LIFECYCLE_PIPELINE_LANE_ORDER.indexOf(focusLane)
   const laterChips: LifecycleLabelChip[] = []
   for (const lane of LIFECYCLE_PIPELINE_LANE_ORDER.slice(focusIndex + 1)) {
     const chips = byLane.get(lane)
@@ -315,14 +368,14 @@ export function planLifecycleChipPresentation(
     }
   }
   const focusChips = [
-    ...(byLane.get(options.focusLane) ?? []),
+    ...(byLane.get(focusLane) ?? []),
     ...laterChips,
     ...ungrouped,
   ]
   if (focusChips.length > 0 || blocks.length === 0) {
     blocks.push({
       kind: "focus-lane",
-      lane: options.focusLane,
+      lane: focusLane,
       chips: focusChips,
     })
   }

--- a/apps/harness/src/routes/index.tsx
+++ b/apps/harness/src/routes/index.tsx
@@ -23,6 +23,7 @@ import { Banner, BannerActionButton } from "../banner.js"
 import { repositoryCardCollapseId, useCardCollapsed } from "../card-collapse.js"
 import { CardCollapseToggle } from "../card-collapse-toggle.js"
 import { Copy } from "../copy.js"
+import { forgeChangeRequestShort } from "../forge-change-request.js"
 import {
   type GraphqlWorkItemState,
   issueActionEligibility,
@@ -3029,6 +3030,7 @@ function RepositoryIssueRow({
         <WorkItemLifecycleStatus
           workItem={latestWorkItem}
           collapseEarlierLanes
+          forge={repository.forge}
           issueUrl={
             issue.url !== ""
               ? issue.url
@@ -3386,9 +3388,15 @@ export function WorkItemLifecycleStatus({
   /**
    * Collapse earlier Build/Review/PR lane chips into summary rows (▸ BUILD ·
    * 5m). Used on Kanban tickets and repos issue chrome; leave off for full
-   * lists.
+   * lists. Terminal COMPLETE also collapses the PR|MR lane (all reached
+   * journey legs) so finished runs match archive-style condensed chrome.
    */
   collapseEarlierLanes = false,
+  /**
+   * Repository forge for PR vs MR lane summary labels on collapsed COMPLETE
+   * chrome. Optional; defaults to GitHub wording.
+   */
+  forge = null,
   pullRequestUrl = null,
   issueUrl = null,
   /**
@@ -3402,6 +3410,7 @@ export function WorkItemLifecycleStatus({
   workItem: WorkItem
   compact?: boolean
   collapseEarlierLanes?: boolean
+  forge?: string | null
   pullRequestUrl?: string | null
   issueUrl?: string | null
   showPullRequestBadge?: boolean
@@ -3490,13 +3499,24 @@ export function WorkItemLifecycleStatus({
     prNumber === null &&
     workItem.completionSummary !== null &&
     workItem.completionSummary.trim() !== ""
-  const focusLane = collapseEarlierLanes
-    ? lifecycleFocusLaneFor(workItem)
-    : null
+  // Terminal COMPLETE only: collapse every reached lane (including PR|MR), not
+  // only earlier-than-focus. Do not use status === "SUCCEEDED" — that is the
+  // latest step-run outcome and can appear mid-lifecycle while state is still
+  // operational (repos would then hide the focus strip). Non-complete work
+  // keeps focus-lane chips expanded.
+  const collapseAllReachedLanes =
+    collapseEarlierLanes &&
+    (status === "COMPLETE" || workItem.state === "COMPLETE")
+  const focusLane =
+    collapseEarlierLanes && !collapseAllReachedLanes
+      ? lifecycleFocusLaneFor(workItem)
+      : null
   const chipBlocks = planLifecycleChipPresentation(workItem.lifecycleLabels, {
     collapseEarlierLanes,
     focusLane,
     expandedEarlierLanes,
+    collapseAllReachedLanes,
+    prLaneLabel: forgeChangeRequestShort(forge),
   })
   const toggleEarlierLane = (lane: LifecyclePipelineLaneId) => {
     setExpandedEarlierLanes((current) => {

--- a/apps/harness/test/pipeline-lanes.test.ts
+++ b/apps/harness/test/pipeline-lanes.test.ts
@@ -512,4 +512,123 @@ describe("planLifecycleChipPresentation", () => {
       },
     ])
   })
+
+  test("COMPLETE collapse-all condenses Build, Review, and PR (no focus strip)", () => {
+    // Repos COMPLETE chrome: PR must not stay a permanent expanded black strip.
+    const blocks = planLifecycleChipPresentation(buildReviewPr, {
+      collapseEarlierLanes: true,
+      focusLane: "pr",
+      expandedEarlierLanes: new Set(),
+      collapseAllReachedLanes: true,
+    })
+    expect(blocks).toEqual([
+      {
+        kind: "earlier-lane",
+        lane: "build",
+        laneLabel: "Build",
+        durationMs: 40_000,
+        expanded: false,
+        chips: [chip("CREATE_WORKTREE", 10_000), chip("IMPLEMENT", 30_000)],
+      },
+      {
+        kind: "earlier-lane",
+        lane: "review",
+        laneLabel: "Review",
+        durationMs: 20_000,
+        expanded: false,
+        chips: [chip("REVIEW", 20_000)],
+      },
+      {
+        kind: "earlier-lane",
+        lane: "pr",
+        laneLabel: "PR",
+        durationMs: 13_000,
+        expanded: false,
+        chips: [chip("COMMIT", 5_000), chip("CREATE_PR", 8_000)],
+      },
+    ])
+    expect(blocks.some((block) => block.kind === "focus-lane")).toBe(false)
+  })
+
+  test("COMPLETE collapse-all sums each lane’s chip durations", () => {
+    const labels = [
+      chip("IMPLEMENT", 12_000),
+      chip("PRE_COMMIT", null),
+      chip("REVIEW", 9_000),
+      chip("COMMIT", 3_000),
+      chip("MERGE_PR", 7_000),
+      chip("LOCAL_CLEANUP", null),
+    ] as const
+    const blocks = planLifecycleChipPresentation(labels, {
+      collapseEarlierLanes: true,
+      focusLane: null,
+      expandedEarlierLanes: new Set(),
+      collapseAllReachedLanes: true,
+    })
+    expect(
+      blocks
+        .filter((block) => block.kind === "earlier-lane")
+        .map((block) => [block.lane, block.durationMs]),
+    ).toEqual([
+      ["build", 12_000],
+      ["review", 9_000],
+      ["pr", 10_000],
+    ])
+  })
+
+  test("COMPLETE collapse-all uses forge PR|MR lane label and expand state", () => {
+    const collapsed = planLifecycleChipPresentation(buildReviewPr, {
+      collapseEarlierLanes: true,
+      focusLane: null,
+      expandedEarlierLanes: new Set(),
+      collapseAllReachedLanes: true,
+      prLaneLabel: "MR",
+    })
+    const prLeg = collapsed.find(
+      (block) => block.kind === "earlier-lane" && block.lane === "pr",
+    )
+    expect(prLeg).toMatchObject({
+      kind: "earlier-lane",
+      laneLabel: "MR",
+      expanded: false,
+    })
+
+    const expandedPr = planLifecycleChipPresentation(buildReviewPr, {
+      collapseEarlierLanes: true,
+      focusLane: null,
+      expandedEarlierLanes: new Set<LifecyclePipelineLaneId>(["pr"]),
+      collapseAllReachedLanes: true,
+      prLaneLabel: "MR",
+    })
+    expect(
+      expandedPr
+        .filter((block) => block.kind === "earlier-lane")
+        .map((block) => [block.lane, block.expanded]),
+    ).toEqual([
+      ["build", false],
+      ["review", false],
+      ["pr", true],
+    ])
+  })
+
+  test("non-complete focus path still expands current lane only", () => {
+    // Regression: collapse-all must not change in-flight PR focus behavior.
+    const blocks = planLifecycleChipPresentation(buildReviewPr, {
+      collapseEarlierLanes: true,
+      focusLane: "pr",
+      expandedEarlierLanes: new Set(),
+      collapseAllReachedLanes: false,
+    })
+    expect(blocks.map((block) => block.kind)).toEqual([
+      "earlier-lane",
+      "earlier-lane",
+      "focus-lane",
+    ])
+    const focus = blocks.find((block) => block.kind === "focus-lane")
+    expect(focus).toMatchObject({
+      kind: "focus-lane",
+      lane: "pr",
+      chips: [chip("COMMIT", 5_000), chip("CREATE_PR", 8_000)],
+    })
+  })
 })

--- a/apps/harness/test/repos-interchange.test.ts
+++ b/apps/harness/test/repos-interchange.test.ts
@@ -146,6 +146,18 @@ describe("Interchange phase 4: repos page + blank slate", () => {
     expect(lifecycle).toContain("{!compact ? (")
     // Earlier-lane collapse (▸ BUILD · 5m) is shared with Kanban.
     expect(lifecycle).toContain("collapseEarlierLanes")
+    // COMPLETE collapses all reached lanes (including PR|MR), not only earlier.
+    expect(lifecycle).toContain("collapseAllReachedLanes")
+    expect(lifecycle).toContain('status === "COMPLETE"')
+    expect(lifecycle).toContain('workItem.state === "COMPLETE"')
+    // Mid-lifecycle step-run SUCCEEDED must not trigger collapse-all (focus strip).
+    const collapseAllPredicate = sliceBetweenMarkers(
+      lifecycle,
+      "const collapseAllReachedLanes =",
+      "const focusLane =",
+    )
+    expect(collapseAllPredicate).not.toContain("SUCCEEDED")
+    expect(lifecycle).toContain("forgeChangeRequestShort")
     expect(lifecycle).toContain("ui.legSummary")
 
     const row = sliceBetweenMarkers(
@@ -155,6 +167,7 @@ describe("Interchange phase 4: repos page + blank slate", () => {
     )
     expect(row).toContain("onOpenSession=")
     expect(row).toContain("collapseEarlierLanes")
+    expect(row).toContain("forge={repository.forge}")
     // One SessionUsageDialog at RepositoryIssues — not per issue row.
     expect(row).not.toContain("<SessionUsageDialog")
 

--- a/docs/harness-design-system.md
+++ b/docs/harness-design-system.md
@@ -437,7 +437,13 @@ prototype, so this spec governs:
 - **Latest work item** renders the standard lifecycle chrome (§4.4) inside a
   bordered inset panel (`--panel`, 1.5px): runtime lines (agent backend,
   session + copy, worktree + copy), STARTED / status, and earlier-lane
-  collapse for step chips (same as Kanban).
+  collapse for step chips (same as Kanban). For **terminal COMPLETE**, every
+  reached lifecycle lane (BUILD, REVIEW, and **PR** on GitHub / **MR** on
+  GitLab) collapses by default into expandable journey-style legs — PR is not
+  left as a permanent full chip strip just because focus falls back to the
+  last phase. Duration on each leg is the sum of that lane’s chip
+  `durationMs` (same rules as earlier-lane summaries / archive legs §4.5).
+  Non-complete work still expands only the current focus lane.
 - **Parent issue groups**: `<details>` card, 1.5px border — summary with
   parent link, "n/m closed" mono, chevron, parent actions menu; children
   with a 2px `--line-soft` left rule.


### PR DESCRIPTION
Why

On Repos, a terminal COMPLETE latest work item already condensed BUILD and
REVIEW into lane-colored journey legs, but left the PR path as a full strip of
black step chips. That noise came from earlier-lane collapse treating the last
phase (PR) as the permanent focus lane after COMPLETE.

What changed

- Extended planLifecycleChipPresentation with collapseAllReachedLanes: every
  reached BUILD / REVIEW / PR lane becomes an expandable condensed leg (summed
  durationMs), not a permanent focus strip.
- WorkItemLifecycleStatus enables that mode only for terminal COMPLETE (status
  or state), with forge-aware PR / MR labels on repos chrome.
- Non-complete work still expands only the current focus lane; Kanban in-flight
  collapse and the Completed archive are unchanged.
- Documented the COMPLETE journey-leg behavior in
  docs/harness-design-system.md section 4.6.

Verification

- Unit tests: apps/harness/test/pipeline-lanes.test.ts (COMPLETE collapse-all,
  duration sums, MR label/expand, non-complete focus still expanded).
- Wiring tests: apps/harness/test/repos-interchange.test.ts (collapse-all gate;
  mid-lifecycle SUCCEEDED must not trigger collapse-all).
- Review remediation: drop bare status === SUCCEEDED so a finished step
  mid-lifecycle cannot hide the focus strip on Repos.

Notes

Presentation reuses the existing earlier-lane expand UI for condensed legs
(including PR under COMPLETE); expand state remains ephemeral local UI only.

Closes #774