### PR TITLE
feat(claude): add Claude Code AgentBackend adapter (fake-CLI)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -107,6 +107,10 @@ _Avoid_: Grok (when referring to the backend), grok-build (as the config ID)
 The supported OpenAI coding Agent Backend with the stable ID `codex`. Distinct from a Codex Agent Model.
 _Avoid_: Codex (when referring to the backend), codex-build (as the config ID)
 
+**Claude Code**:
+The supported Anthropic coding Agent Backend with the stable ID `claude`. Distinct from a Claude Agent Model.
+_Avoid_: Claude (when referring to the backend), claude-code (as the config ID)
+
 **Agent Backend Unavailable**:
 A per-backend degraded state established by failed startup inspection, failed hot-activation on Save, or Recheck Agent Backend when that Agent Backend cannot execute Agent Turns or report its Agent Models. The UI, non-agent maintenance, and Agent-free Lifecycle Steps remain available. New Agent Turns and Work Item creation that need the Unavailable backend are blocked until a Recheck (or successful re-activation) for that backend succeeds; other backends are unaffected. Runtime Agent Turn failures fail only their Step Run, and the Harness never silently falls back to another backend. Unavailable does not block changing selections while the applicable idle gate allows.
 _Avoid_: Startup failure, automatic fallback, harness-wide block when another backend is healthy, Paused Repository, restart required

--- a/apps/ready-for-agent/src/host-tools-preflight.ts
+++ b/apps/ready-for-agent/src/host-tools-preflight.ts
@@ -30,6 +30,12 @@ const BACKEND_HOST_TOOLS: Record<
     installHint:
       "Install Codex CLI: https://developers.openai.com/codex/cli (binary name: codex)",
   },
+  // Claude Code binary requirement; selection/wiring lands with #779.
+  [AGENT_BACKEND_IDS.claude]: {
+    name: "claude",
+    installHint:
+      "Install Claude Code CLI: https://docs.anthropic.com/en/docs/claude-code (binary name: claude)",
+  },
 }
 
 const alwaysRequiredTools: ReadonlyArray<HostTool> = [

--- a/bun.lock
+++ b/bun.lock
@@ -126,6 +126,19 @@
         "@types/bun": "^1.3.0",
       },
     },
+    "packages/claude": {
+      "name": "@ready-for-agent/claude",
+      "version": "0.0.1",
+      "dependencies": {
+        "@ready-for-agent/agent-backend": "workspace:*",
+        "effect": "^4.0.0-beta.97",
+        "tslib": "^2.3.0",
+      },
+      "devDependencies": {
+        "@effect/platform-bun": "^4.0.0-beta.97",
+        "@types/bun": "^1.3.0",
+      },
+    },
     "packages/codex": {
       "name": "@ready-for-agent/codex",
       "version": "0.0.1",
@@ -992,6 +1005,8 @@
     "@rdfjs/types": ["@rdfjs/types@2.0.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-uyAzpugX7KekAXAHq26m3JlUIZJOC0uSBhpnefGV5i15bevDyyejoB7I+9MKeUrzXD8OOUI3+4FeV1wwQr5ihA=="],
 
     "@ready-for-agent/agent-backend": ["@ready-for-agent/agent-backend@workspace:packages/agent-backend"],
+
+    "@ready-for-agent/claude": ["@ready-for-agent/claude@workspace:packages/claude"],
 
     "@ready-for-agent/codex": ["@ready-for-agent/codex@workspace:packages/codex"],
 

--- a/ontology/context.ttl
+++ b/ontology/context.ttl
@@ -665,6 +665,28 @@ rfa:CodexBuild
   rfa:avoidanceRationale "as the config ID"@en ;
 ] .
 
+rfa:ClaudeCode
+  a owl:Class, skos:Concept, rfa:ContextTerm ;
+  skos:prefLabel "Claude Code"@en ;
+  skos:definition "The supported Anthropic coding Agent Backend with the stable ID `claude`. Distinct from a Claude Agent Model."@en ;
+  skos:hiddenLabel "Claude"@en, "claude-code"@en .
+
+[
+  a owl:Axiom ;
+  owl:annotatedSource rfa:ClaudeCode ;
+  owl:annotatedProperty skos:hiddenLabel ;
+  owl:annotatedTarget "Claude"@en ;
+  rfa:avoidanceRationale "when referring to the backend"@en ;
+] .
+
+[
+  a owl:Axiom ;
+  owl:annotatedSource rfa:ClaudeCode ;
+  owl:annotatedProperty skos:hiddenLabel ;
+  owl:annotatedTarget "claude-code"@en ;
+  rfa:avoidanceRationale "as the config ID"@en ;
+] .
+
 rfa:AgentBackendUnavailable
   a owl:Class, skos:Concept, rfa:ContextTerm ;
   skos:prefLabel "Agent Backend Unavailable"@en ;

--- a/packages/agent-backend/src/lib/types.ts
+++ b/packages/agent-backend/src/lib/types.ts
@@ -5,6 +5,8 @@ export const AGENT_BACKEND_IDS = {
   opencode: "opencode",
   grok: "grok",
   codex: "codex",
+  /** Claude Code adapter package (ADR 0047). Selectable once registered in #779. */
+  claude: "claude",
 } as const
 
 export type AgentBackendId =

--- a/packages/claude/package.json
+++ b/packages/claude/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@ready-for-agent/claude",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    "./package.json": "./package.json",
+    ".": {
+      "@ready-for-agent/source": "./src/index.ts",
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    }
+  },
+  "dependencies": {
+    "@ready-for-agent/agent-backend": "workspace:*",
+    "effect": "^4.0.0-beta.97",
+    "tslib": "^2.3.0"
+  },
+  "devDependencies": {
+    "@effect/platform-bun": "^4.0.0-beta.97",
+    "@types/bun": "^1.3.0"
+  }
+}

--- a/packages/claude/project.json
+++ b/packages/claude/project.json
@@ -1,0 +1,19 @@
+{
+  "name": "claude",
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "packages/claude/src",
+  "projectType": "library",
+  "tags": [],
+  "targets": {
+    "test": {
+      "executor": "nx:run-commands",
+      "options": {
+        "cwd": "{projectRoot}",
+        "command": "bun --conditions=@ready-for-agent/source test"
+      },
+      "inputs": ["default", "^production"],
+      "cache": true,
+      "dependsOn": ["^build"]
+    }
+  }
+}

--- a/packages/claude/src/index.ts
+++ b/packages/claude/src/index.ts
@@ -1,0 +1,7 @@
+export * from "./lib/build-args.js"
+export * from "./lib/claude.js"
+export * from "./lib/environment.js"
+export * from "./lib/parse-auth-status.js"
+export * from "./lib/parse-stream.js"
+export * from "./lib/session-telemetry-layer.js"
+export * from "./lib/types.js"

--- a/packages/claude/src/lib/build-args.ts
+++ b/packages/claude/src/lib/build-args.ts
@@ -1,0 +1,59 @@
+const commandPrefix = (command: string): string =>
+  command.startsWith("/") ? command : `/${command}`
+
+/**
+ * Build headless Claude Code argv for a new or resumed Agent Turn.
+ *
+ * Every harness launch uses print mode (`-p`), machine-readable
+ * `--output-format stream-json` with `--verbose` (required for terminal
+ * `result` events), and unattended `--dangerously-skip-permissions`. Model and
+ * optional effort are restated on every turn so mid-Session switches work.
+ *
+ * Session identity is always an exact UUID: `--session-id` on start and
+ * `--resume` on continue. Directory-scoped `--continue` and resume-forking
+ * `--fork-session` are never used (ADR 0047). `--bare` is never used so
+ * CLAUDE.md discovery and ambient OAuth work.
+ */
+export const buildRunArgs = (input: {
+  readonly prompt: string
+  readonly model: string
+  /** Null omits `--effort` so Claude uses the model default. */
+  readonly thinkingLevel: string | null
+  /** Fresh caller-supplied UUID for a new Session. */
+  readonly sessionId?: string
+  /** Opaque Session ID to resume exactly (not "most recent"). */
+  readonly resumeSessionId?: string
+  readonly command?: string
+}): ReadonlyArray<string> => {
+  const prompt =
+    input.command === undefined
+      ? input.prompt
+      : `${commandPrefix(input.command)}\n${input.prompt}`.trimEnd()
+
+  const args: string[] = [
+    "-p",
+    "--output-format",
+    "stream-json",
+    // Terminal `result` events require verbose with stream-json.
+    "--verbose",
+    "--dangerously-skip-permissions",
+    "--model",
+    input.model,
+  ]
+
+  if (input.thinkingLevel !== null) {
+    args.push("--effort", input.thinkingLevel)
+  }
+
+  if (input.resumeSessionId !== undefined) {
+    args.push("--resume", input.resumeSessionId)
+  } else if (input.sessionId !== undefined) {
+    args.push("--session-id", input.sessionId)
+  }
+
+  // Isolate the prompt after `--` so bodies that start with `-`/`--` are not
+  // consumed as CLI flags (Claude Code accepts this end-of-options form).
+  args.push("--", prompt)
+
+  return args
+}

--- a/packages/claude/src/lib/claude.ts
+++ b/packages/claude/src/lib/claude.ts
@@ -1,0 +1,249 @@
+import { randomUUID } from "node:crypto"
+import { Duration, Effect, Layer } from "effect"
+import { ChildProcessSpawner } from "effect/unstable/process"
+import {
+  AGENT_BACKEND_IDS,
+  AgentBackend,
+  AgentBackendConfigError,
+  type AgentBackendError,
+  AgentBackendExitError,
+  type ContinueTurnInput,
+  type InspectInput,
+  type StartTurnInput,
+  malformedOutput,
+  runCliCapture,
+  runCliTurn,
+} from "@ready-for-agent/agent-backend"
+import { buildRunArgs } from "./build-args.js"
+import { makeClaudeEnvironment } from "./environment.js"
+import { parseClaudeAuthStatus } from "./parse-auth-status.js"
+import {
+  claudeAssistantText,
+  createClaudeStreamParseState,
+  foldClaudeStreamLine,
+  isSuccessfulClaudeTurn,
+} from "./parse-stream.js"
+import {
+  CLAUDE_STATIC_CATALOG,
+  CLAUDE_UNAUTHENTICATED_MESSAGE,
+  type ClaudeLayerOptions,
+} from "./types.js"
+
+const DEFAULT_TIMEOUT = Duration.minutes(30)
+const DEFAULT_BINARY = "claude"
+
+const CLAUDE_BACKEND = {
+  id: AGENT_BACKEND_IDS.claude,
+  label: "Claude Code",
+} as const
+
+/** Cap CLI probe text so Unavailable reasons stay readable in the UI. */
+const clipProbeOutput = (text: string, maxChars = 240): string => {
+  const trimmed = text.trim().replace(/\s+/g, " ")
+  if (trimmed.length === 0) {
+    return "(no output)"
+  }
+  if (trimmed.length <= maxChars) {
+    return trimmed
+  }
+  return `${trimmed.slice(0, maxChars)}…`
+}
+
+/**
+ * Claude Code adapter implementing the backend-neutral AgentBackend contract.
+ *
+ * Static catalog and readiness inspection ship with this layer. Agent Turns
+ * run `claude -p` with stream-json, preassign a Session UUID via
+ * `--session-id` (reported through `onSessionId` while the first turn runs),
+ * resume later turns with `--resume`, and normalize the JSONL stream into
+ * Session ID + ordered final assistant text (issue #778 / ADR 0047).
+ */
+export class Claude {
+  static layer = (options: ClaudeLayerOptions = {}) =>
+    Layer.effect(
+      AgentBackend,
+      Effect.gen(function* () {
+        const spawner = yield* ChildProcessSpawner.ChildProcessSpawner
+        const binary = options.binary ?? DEFAULT_BINARY
+        const defaultTimeout = options.defaultTimeout ?? DEFAULT_TIMEOUT
+        const environment = makeClaudeEnvironment()
+
+        const inspect = Effect.fn("Claude.inspect")(function* (
+          input: InspectInput,
+        ) {
+          // Real `claude auth status` defaults to JSON on stdout. Capture both
+          // streams and allow non-zero exit so unauthenticated states keep
+          // text for actionable ConfigError mapping.
+          const result = yield* runCliCapture({
+            spawner,
+            binary,
+            args: ["auth", "status"],
+            cwd: input.cwd,
+            env: environment,
+            timeout: input.timeout ?? defaultTimeout,
+            allowNonZeroExit: true,
+            captureStderr: true,
+          })
+
+          const statusOutput = [result.stdout, result.stderr]
+            .filter((part) => part.length > 0)
+            .join("\n")
+          const status = parseClaudeAuthStatus(statusOutput, result.exitCode)
+          if (status.kind === "unauthenticated") {
+            return yield* new AgentBackendConfigError({
+              message: CLAUDE_UNAUTHENTICATED_MESSAGE,
+            })
+          }
+          if (status.kind === "failed") {
+            return yield* new AgentBackendConfigError({
+              message: `Claude Code readiness probe failed (claude auth status exit ${status.exitCode}): ${clipProbeOutput(statusOutput)}`,
+            })
+          }
+          if (status.kind === "malformed") {
+            return yield* malformedOutput(input.cwd, statusOutput)
+          }
+
+          return {
+            backend: CLAUDE_BACKEND,
+            models: CLAUDE_STATIC_CATALOG.map((model) => ({
+              id: model.id,
+              thinkingLevels: [...model.thinkingLevels],
+            })),
+          }
+        })
+
+        const runTurn = (input: {
+          readonly prompt: string
+          readonly cwd: string
+          readonly model: string
+          readonly thinkingLevel: string | null
+          readonly sessionId: string
+          readonly resume: boolean
+          readonly command?: string
+          readonly timeout?: Duration.Input
+          readonly onSessionId?: StartTurnInput["onSessionId"]
+        }): Effect.Effect<
+          { readonly sessionId: string; readonly assistantText: string },
+          AgentBackendError
+        > =>
+          Effect.gen(function* () {
+            // Preassigned Session ID is durable before the process exits
+            // (ADR 0031 / 0047). Report it while the first turn is still running.
+            if (!input.resume && input.onSessionId !== undefined) {
+              yield* input.onSessionId(input.sessionId).pipe(
+                Effect.catch((error) =>
+                  Effect.logWarning("Claude onSessionId observer failed", {
+                    sessionId: input.sessionId,
+                    error,
+                  }),
+                ),
+              )
+            }
+
+            const args = buildRunArgs({
+              prompt: input.prompt,
+              model: input.model,
+              thinkingLevel: input.thinkingLevel,
+              ...(input.resume
+                ? { resumeSessionId: input.sessionId }
+                : { sessionId: input.sessionId }),
+              ...(input.command !== undefined
+                ? { command: input.command }
+                : {}),
+            })
+
+            let stream = createClaudeStreamParseState()
+
+            const turn = yield* runCliTurn({
+              spawner,
+              binary,
+              args,
+              cwd: input.cwd,
+              env: environment,
+              timeout: input.timeout ?? defaultTimeout,
+              knownSessionId: input.sessionId,
+              observerLabel: "Claude Code",
+              parseLine: (line) => {
+                stream = foldClaudeStreamLine(stream, line)
+
+                if (stream.malformedLine) {
+                  return {}
+                }
+                if (stream.resultSeen && stream.isError) {
+                  return {
+                    sessionId: stream.sessionId ?? input.sessionId,
+                  }
+                }
+                if (stream.resultSeen && isSuccessfulClaudeTurn(stream)) {
+                  return {
+                    sessionId: stream.sessionId ?? input.sessionId,
+                    finalizeText: claudeAssistantText(stream),
+                  }
+                }
+                return {}
+              },
+              stdin: "ignore",
+            })
+
+            if (stream.malformedLine) {
+              return yield* malformedOutput(
+                input.cwd,
+                "(malformed stream line)",
+              )
+            }
+            if (stream.resultSeen && stream.isError) {
+              yield* Effect.logWarning("Claude Code turn result is_error", {
+                sessionId: input.sessionId,
+                message: stream.errorMessage ?? "Claude Code turn failed",
+              })
+              return yield* new AgentBackendExitError({
+                exitCode: 1,
+                cwd: input.cwd,
+                sessionId: input.sessionId,
+              })
+            }
+            if (!stream.resultSeen || !isSuccessfulClaudeTurn(stream)) {
+              return yield* malformedOutput(
+                input.cwd,
+                "(missing or unsuccessful terminal result event)",
+              )
+            }
+            if (
+              stream.sessionId !== undefined &&
+              stream.sessionId !== input.sessionId
+            ) {
+              return yield* malformedOutput(
+                input.cwd,
+                `(session id mismatch: expected ${input.sessionId}, got ${stream.sessionId})`,
+              )
+            }
+
+            return {
+              sessionId: input.sessionId,
+              assistantText: turn.assistantText,
+            }
+          })
+
+        return AgentBackend.of({
+          inspect,
+          startTurn: Effect.fn("Claude.startTurn")((input: StartTurnInput) =>
+            runTurn({
+              ...input,
+              sessionId: randomUUID(),
+              resume: false,
+            }),
+          ),
+          continueTurn: Effect.fn("Claude.continueTurn")(
+            (input: ContinueTurnInput) =>
+              runTurn({
+                ...input,
+                sessionId: input.sessionId,
+                resume: true,
+              }),
+          ),
+        })
+      }),
+    )
+
+  static layerForTests = () => Claude.layer({})
+}

--- a/packages/claude/src/lib/environment.ts
+++ b/packages/claude/src/lib/environment.ts
@@ -1,0 +1,25 @@
+import { sanitizeInheritedEnvironment } from "@ready-for-agent/agent-backend"
+
+export type MakeClaudeEnvironmentOptions = {
+  readonly environment?: Readonly<Record<string, string | undefined>>
+}
+
+/**
+ * Claude Code Agent Turns use ambient Forge authentication: inherit process
+ * env (including ambient Forge tokens and ANTHROPIC_API_KEY). Force
+ * DISABLE_AUTOUPDATER so Harness operation cannot replace the CLI under active
+ * work (ADR 0047). Claude does not support KeymaxxerMcp, so tokens are never
+ * stripped.
+ */
+export const makeClaudeEnvironment = (
+  options: MakeClaudeEnvironmentOptions = {},
+): Record<string, string> => {
+  const environment =
+    options.environment ?? (process.env as Record<string, string | undefined>)
+  return {
+    ...sanitizeInheritedEnvironment(environment, {
+      stripForgeTokens: false,
+    }),
+    DISABLE_AUTOUPDATER: "1",
+  }
+}

--- a/packages/claude/src/lib/parse-auth-status.ts
+++ b/packages/claude/src/lib/parse-auth-status.ts
@@ -1,0 +1,108 @@
+export type ClaudeAuthStatus =
+  | { readonly kind: "authenticated" }
+  | { readonly kind: "unauthenticated" }
+  | { readonly kind: "malformed" }
+  | { readonly kind: "failed"; readonly exitCode: number }
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value)
+
+/**
+ * Extract the first balanced JSON object from mixed CLI capture text so trailing
+ * stderr noise after a valid `auth status` object does not break `JSON.parse`.
+ */
+export const extractFirstJsonObject = (text: string): string | undefined => {
+  const start = text.indexOf("{")
+  if (start < 0) {
+    return undefined
+  }
+
+  let depth = 0
+  let inString = false
+  let escaped = false
+  for (let i = start; i < text.length; i++) {
+    const char = text[i]
+    if (char === undefined) {
+      break
+    }
+    if (inString) {
+      if (escaped) {
+        escaped = false
+      } else if (char === "\\") {
+        escaped = true
+      } else if (char === '"') {
+        inString = false
+      }
+      continue
+    }
+    if (char === '"') {
+      inString = true
+      continue
+    }
+    if (char === "{") {
+      depth += 1
+    } else if (char === "}") {
+      depth -= 1
+      if (depth === 0) {
+        return text.slice(start, i + 1)
+      }
+    }
+  }
+  return undefined
+}
+
+/**
+ * Interpret `claude auth status` captured text (JSON default) plus exit code.
+ *
+ * Real CLI: authenticated exits 0 with `{"loggedIn":true,...}`; unauthenticated
+ * reports `loggedIn: false` (often exit non-zero). Classification prefers the
+ * JSON `loggedIn` field so a crash without that field is not mistaken for
+ * missing auth.
+ */
+export const parseClaudeAuthStatus = (
+  output: string,
+  exitCode: number,
+): ClaudeAuthStatus => {
+  const trimmed = output.trim()
+  if (trimmed.length === 0) {
+    return exitCode === 0 ? { kind: "malformed" } : { kind: "failed", exitCode }
+  }
+
+  // Prefer the first balanced JSON object in the capture (stdout or mixed).
+  const jsonObject = extractFirstJsonObject(trimmed)
+  if (jsonObject !== undefined) {
+    try {
+      const parsed: unknown = JSON.parse(jsonObject)
+      if (isRecord(parsed) && typeof parsed.loggedIn === "boolean") {
+        return parsed.loggedIn
+          ? { kind: "authenticated" }
+          : { kind: "unauthenticated" }
+      }
+    } catch {
+      // Fall through to marker / exit-code paths.
+    }
+  }
+
+  // Human-readable fallbacks (e.g. `claude auth status --text`).
+  // Unauth markers first so "not authenticated" never matches a positive.
+  if (
+    /not (?:logged|signed) in/i.test(trimmed) ||
+    /\bunauthenticated\b/i.test(trimmed) ||
+    /you are not authenticated/i.test(trimmed) ||
+    /not authenticated/i.test(trimmed) ||
+    /authentication required/i.test(trimmed) ||
+    /please (?:log|sign) in/i.test(trimmed)
+  ) {
+    return { kind: "unauthenticated" }
+  }
+  // Positive phrases only — no `/authenticated/` (matches "unauthenticated")
+  // and no field-name heuristics like `/authMethod/`.
+  if (/\blogged in\b/i.test(trimmed)) {
+    return { kind: "authenticated" }
+  }
+
+  if (exitCode !== 0) {
+    return { kind: "failed", exitCode }
+  }
+  return { kind: "malformed" }
+}

--- a/packages/claude/src/lib/parse-stream.ts
+++ b/packages/claude/src/lib/parse-stream.ts
@@ -1,0 +1,174 @@
+/**
+ * Fold Claude Code `-p --output-format stream-json --verbose` JSONL events into
+ * ordered final assistant text and terminal success/failure.
+ *
+ * Session identity is preassigned by the adapter (`--session-id` / `--resume`);
+ * the stream may still report `session_id` for mismatch detection. Final
+ * assistant text prefers the terminal `result` string, falling back to ordered
+ * assistant text content blocks. Terminal success is `type: "result"` with
+ * `is_error` false (or success subtype); failure is `is_error` true.
+ */
+
+export type ClaudeStreamParseState = {
+  sessionId: string | undefined
+  assistantTextChunks: string[]
+  resultText: string | undefined
+  resultSeen: boolean
+  isError: boolean
+  errorMessage: string | undefined
+  malformedLine: boolean
+}
+
+export const createClaudeStreamParseState = (): ClaudeStreamParseState => ({
+  sessionId: undefined,
+  assistantTextChunks: [],
+  resultText: undefined,
+  resultSeen: false,
+  isError: false,
+  errorMessage: undefined,
+  malformedLine: false,
+})
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value)
+
+const textFromContentBlocks = (content: unknown): string[] => {
+  if (!Array.isArray(content)) {
+    return []
+  }
+  const chunks: string[] = []
+  for (const block of content) {
+    if (!isRecord(block) || block.type !== "text") {
+      continue
+    }
+    if (typeof block.text === "string" && block.text.length > 0) {
+      chunks.push(block.text)
+    }
+  }
+  return chunks
+}
+
+const errorMessageFrom = (value: unknown): string | undefined => {
+  if (typeof value === "string" && value.length > 0) {
+    return value
+  }
+  if (isRecord(value)) {
+    if (typeof value.message === "string" && value.message.length > 0) {
+      return value.message
+    }
+    if (typeof value.error === "string" && value.error.length > 0) {
+      return value.error
+    }
+  }
+  return undefined
+}
+
+/**
+ * Fold one JSONL line. Unknown event types are ignored (non-exhaustive stream).
+ * Malformed JSON or missing `type` marks the stream malformed.
+ * Once malformed or result-seen, further lines leave state unchanged for
+ * terminal fields (still ignore trailing noise after result).
+ */
+export const foldClaudeStreamLine = (
+  state: ClaudeStreamParseState,
+  line: string,
+): ClaudeStreamParseState => {
+  if (state.malformedLine || state.resultSeen) {
+    return state
+  }
+
+  const trimmed = line.trim()
+  if (trimmed.length === 0) {
+    return state
+  }
+
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(trimmed)
+  } catch {
+    return { ...state, malformedLine: true }
+  }
+
+  if (!isRecord(parsed) || typeof parsed.type !== "string") {
+    return { ...state, malformedLine: true }
+  }
+
+  const sessionId =
+    typeof parsed.session_id === "string" && parsed.session_id.length > 0
+      ? parsed.session_id
+      : state.sessionId
+
+  switch (parsed.type) {
+    case "system": {
+      // Init (and other system subtypes) may carry session_id early.
+      return { ...state, sessionId }
+    }
+    case "assistant": {
+      // Nested subagent assistant lines may carry parent_tool_use_id; keep
+      // ordered text for the root turn only so empty-result fallback matches
+      // main-agent output.
+      if (
+        parsed.parent_tool_use_id !== undefined &&
+        parsed.parent_tool_use_id !== null
+      ) {
+        return { ...state, sessionId }
+      }
+      if (!isRecord(parsed.message)) {
+        return { ...state, sessionId }
+      }
+      const chunks = textFromContentBlocks(parsed.message.content)
+      if (chunks.length === 0) {
+        return { ...state, sessionId }
+      }
+      return {
+        ...state,
+        sessionId,
+        assistantTextChunks: [...state.assistantTextChunks, ...chunks],
+      }
+    }
+    case "user":
+    case "tool_use":
+    case "tool_result":
+      // Non-assistant content does not contribute final text.
+      return { ...state, sessionId }
+    case "result": {
+      const isError =
+        parsed.is_error === true ||
+        (typeof parsed.subtype === "string" &&
+          parsed.subtype.toLowerCase().includes("error"))
+      const resultText =
+        typeof parsed.result === "string" ? parsed.result : undefined
+      const errorMessage =
+        errorMessageFrom(parsed.error) ??
+        errorMessageFrom(parsed.message) ??
+        (isError ? "Claude Code turn failed" : undefined)
+      return {
+        ...state,
+        sessionId,
+        resultSeen: true,
+        isError,
+        resultText,
+        errorMessage,
+      }
+    }
+    default:
+      // Non-exhaustive event set (stream_event, rate_limit, …).
+      return { ...state, sessionId }
+  }
+}
+
+/**
+ * Ordered final assistant text: prefer the terminal `result` string when
+ * present, otherwise joined assistant text content blocks.
+ */
+export const claudeAssistantText = (state: ClaudeStreamParseState): string => {
+  if (state.resultText !== undefined && state.resultText.length > 0) {
+    return state.resultText
+  }
+  return state.assistantTextChunks.join("")
+}
+
+export const isSuccessfulClaudeTurn = (
+  state: ClaudeStreamParseState,
+): boolean =>
+  state.resultSeen && !state.isError && state.malformedLine === false

--- a/packages/claude/src/lib/session-telemetry-layer.ts
+++ b/packages/claude/src/lib/session-telemetry-layer.ts
@@ -1,0 +1,30 @@
+import { Effect, Layer } from "effect"
+import {
+  AGENT_BACKEND_IDS,
+  SessionTelemetryProvider,
+  unsupportedSessionTelemetry,
+} from "@ready-for-agent/agent-backend"
+
+const CLAUDE_BACKEND = {
+  id: AGENT_BACKEND_IDS.claude,
+  label: "Claude Code",
+} as const
+
+/**
+ * Claude Code declares Session Telemetry unsupported (ADR 0047 v1).
+ * Provides a provider that always reports `unsupported` so composition roots
+ * can wire Claude like other backends without a null telemetry branch.
+ *
+ * Accepts an unused options bag so the export is a Layer factory matching
+ * Grok/Codex call sites (`ClaudeSessionTelemetryLive()`).
+ */
+export const ClaudeSessionTelemetryLive = (
+  _options: Record<string, never> = {},
+): Layer.Layer<SessionTelemetryProvider> =>
+  Layer.succeed(
+    SessionTelemetryProvider,
+    SessionTelemetryProvider.of({
+      getSession: (sessionId) =>
+        Effect.succeed(unsupportedSessionTelemetry(sessionId, CLAUDE_BACKEND)),
+    }),
+  )

--- a/packages/claude/src/lib/types.ts
+++ b/packages/claude/src/lib/types.ts
@@ -1,0 +1,36 @@
+import type { Duration } from "effect"
+import type { AgentModel } from "@ready-for-agent/agent-backend"
+
+export interface ClaudeLayerOptions {
+  readonly binary?: string
+  readonly defaultTimeout?: Duration.Input
+}
+
+/**
+ * Actionable readiness-failure copy when `claude auth status` reports no auth.
+ * Operators may use Claude.ai OAuth (`claude auth login`) or an API key.
+ */
+export const CLAUDE_UNAUTHENTICATED_MESSAGE =
+  "Claude Code is not authenticated. Run `claude auth login` (or set `ANTHROPIC_API_KEY`), then Recheck Agent Backend."
+
+/** Official Thinking Levels for Claude Code v1 (ADR 0047). No `ultracode`. */
+export const CLAUDE_THINKING_LEVELS = [
+  "low",
+  "medium",
+  "high",
+  "xhigh",
+  "max",
+] as const
+
+/**
+ * Adapter-bundled static model catalog for Claude Code (ADR 0047).
+ *
+ * Floating aliases only; Anthropic resolves each alias. Excludes `default`,
+ * `best`, `opusplan`, and context-window variants such as `sonnet[1m]`.
+ */
+export const CLAUDE_STATIC_CATALOG: ReadonlyArray<AgentModel> = [
+  { id: "haiku", thinkingLevels: [...CLAUDE_THINKING_LEVELS] },
+  { id: "sonnet", thinkingLevels: [...CLAUDE_THINKING_LEVELS] },
+  { id: "opus", thinkingLevels: [...CLAUDE_THINKING_LEVELS] },
+  { id: "fable", thinkingLevels: [...CLAUDE_THINKING_LEVELS] },
+]

--- a/packages/claude/test/build-args.spec.ts
+++ b/packages/claude/test/build-args.spec.ts
@@ -1,0 +1,106 @@
+import { buildRunArgs } from "../src/index.js"
+import { describe, expect, it } from "bun:test"
+
+describe("buildRunArgs", () => {
+  it("builds unattended headless print-mode args with stream-json and permissions skip", () => {
+    expect(
+      buildRunArgs({
+        prompt: "implement the issue",
+        model: "sonnet",
+        thinkingLevel: "medium",
+        sessionId: "11111111-1111-4111-8111-111111111111",
+      }),
+    ).toEqual([
+      "-p",
+      "--output-format",
+      "stream-json",
+      "--verbose",
+      "--dangerously-skip-permissions",
+      "--model",
+      "sonnet",
+      "--effort",
+      "medium",
+      "--session-id",
+      "11111111-1111-4111-8111-111111111111",
+      "--",
+      "implement the issue",
+    ])
+  })
+
+  it("isolates flag-like prompt bodies after end-of-options --", () => {
+    const args = buildRunArgs({
+      prompt: "--looks-like-a-flag",
+      model: "sonnet",
+      thinkingLevel: null,
+      sessionId: "11111111-1111-4111-8111-111111111111",
+    })
+    const endOptions = args.indexOf("--")
+    expect(endOptions).toBeGreaterThan(0)
+    expect(args[endOptions + 1]).toBe("--looks-like-a-flag")
+    expect(args.at(-1)).toBe("--looks-like-a-flag")
+  })
+
+  it("omits --effort when thinkingLevel is null", () => {
+    const args = buildRunArgs({
+      prompt: "hi",
+      model: "haiku",
+      thinkingLevel: null,
+      sessionId: "11111111-1111-4111-8111-111111111111",
+    })
+    expect(args).not.toContain("--effort")
+  })
+
+  it("resumes an exact session id rather than most-recent continue", () => {
+    const args = buildRunArgs({
+      prompt: "continue",
+      model: "opus",
+      thinkingLevel: "low",
+      resumeSessionId: "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee",
+    })
+    expect(args).toContain("--resume")
+    expect(args).toContain("aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee")
+    expect(args).not.toContain("--continue")
+    expect(args).not.toContain("--fork-session")
+    expect(args).not.toContain("--session-id")
+    expect(args).not.toContain("-c")
+  })
+
+  it("never uses --bare on lifecycle turns", () => {
+    const start = buildRunArgs({
+      prompt: "work",
+      model: "sonnet",
+      thinkingLevel: null,
+      sessionId: "11111111-1111-4111-8111-111111111111",
+    })
+    const resume = buildRunArgs({
+      prompt: "more",
+      model: "sonnet",
+      thinkingLevel: "high",
+      resumeSessionId: "11111111-1111-4111-8111-111111111111",
+    })
+    expect(start).not.toContain("--bare")
+    expect(resume).not.toContain("--bare")
+  })
+
+  it("prefixes /review command into the single-prompt body", () => {
+    const args = buildRunArgs({
+      prompt: "Review uncommitted worktree changes.",
+      model: "sonnet",
+      thinkingLevel: null,
+      resumeSessionId: "aaaaaaaa-bbbb-4ccc-8ddd-eeeeeeeeeeee",
+      command: "/review",
+    })
+    expect(args.at(-1)).toBe("/review\nReview uncommitted worktree changes.")
+    expect(args.at(-2)).toBe("--")
+  })
+
+  it("normalizes review command without a leading slash", () => {
+    const args = buildRunArgs({
+      prompt: "body",
+      model: "sonnet",
+      thinkingLevel: null,
+      command: "review",
+    })
+    expect(args.at(-1)).toBe("/review\nbody")
+  })
+})

--- a/packages/claude/test/catalog.spec.ts
+++ b/packages/claude/test/catalog.spec.ts
@@ -1,0 +1,25 @@
+import { CLAUDE_STATIC_CATALOG, CLAUDE_THINKING_LEVELS } from "../src/index.js"
+import { describe, expect, it } from "bun:test"
+
+describe("CLAUDE_STATIC_CATALOG", () => {
+  it("lists haiku, sonnet, opus, fable with official Thinking Levels only", () => {
+    expect(CLAUDE_STATIC_CATALOG.map((model) => model.id)).toEqual([
+      "haiku",
+      "sonnet",
+      "opus",
+      "fable",
+    ])
+
+    for (const model of CLAUDE_STATIC_CATALOG) {
+      expect(model.thinkingLevels).toEqual([...CLAUDE_THINKING_LEVELS])
+      expect(model.thinkingLevels).not.toContain("ultracode")
+    }
+
+    // Excluded aliases / variants must not appear.
+    const ids = CLAUDE_STATIC_CATALOG.map((model) => model.id)
+    expect(ids).not.toContain("default")
+    expect(ids).not.toContain("best")
+    expect(ids).not.toContain("opusplan")
+    expect(ids.some((id) => id.includes("[1m]"))).toBe(false)
+  })
+})

--- a/packages/claude/test/claude.spec.ts
+++ b/packages/claude/test/claude.spec.ts
@@ -1,0 +1,479 @@
+import { chmod, mkdtemp, rm, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { BunServices } from "@effect/platform-bun"
+import { Deferred, Effect, Exit, Fiber, Layer } from "effect"
+import {
+  AgentBackend,
+  AgentBackendConfigError,
+  AgentBackendExitError,
+  AgentBackendMalformedOutputError,
+  AgentBackendTimeoutError,
+  type OnSessionId,
+} from "@ready-for-agent/agent-backend"
+import {
+  CLAUDE_STATIC_CATALOG,
+  CLAUDE_UNAUTHENTICATED_MESSAGE,
+  Claude,
+} from "../src/index.js"
+import { describe, expect, it } from "bun:test"
+
+const withExecutable = async <A>(
+  body: string,
+  use: (path: string) => Promise<A>,
+): Promise<A> => {
+  const directory = await mkdtemp(join(tmpdir(), "claude-effect-test-"))
+  const path = join(directory, "claude")
+  try {
+    await writeFile(path, `#!/bin/sh\n${body}\n`)
+    await chmod(path, 0o700)
+    return await use(path)
+  } finally {
+    await rm(directory, { recursive: true, force: true })
+  }
+}
+
+const provide = (binary: string) =>
+  Claude.layer({ binary }).pipe(Layer.provide(BunServices.layer))
+
+const inspect = (binary: string, timeout = "2 seconds") =>
+  Effect.gen(function* () {
+    const backend = yield* AgentBackend
+    return yield* backend.inspect({
+      cwd: process.cwd(),
+      timeout,
+    })
+  }).pipe(Effect.provide(provide(binary)))
+
+const captureSessionScript = [
+  'sid=""',
+  'prev=""',
+  'for arg in "$@"; do',
+  '  if [ "$prev" = "--session-id" ] || [ "$prev" = "--resume" ]; then sid="$arg"; fi',
+  '  prev="$arg"',
+  "done",
+].join("\n")
+
+/** Fake stream: system init, assistant text, terminal result. */
+const successfulTurnStream = (sessionId = "$sid") =>
+  [
+    `printf '%s\\n' "{\\"type\\":\\"system\\",\\"subtype\\":\\"init\\",\\"session_id\\":\\"${sessionId}\\"}"`,
+    `printf '%s\\n' "{\\"type\\":\\"assistant\\",\\"session_id\\":\\"${sessionId}\\",\\"message\\":{\\"role\\":\\"assistant\\",\\"content\\":[{\\"type\\":\\"text\\",\\"text\\":\\"ok\\"}]}}"`,
+    `printf '%s\\n' "{\\"type\\":\\"result\\",\\"subtype\\":\\"success\\",\\"session_id\\":\\"${sessionId}\\",\\"is_error\\":false,\\"result\\":\\"ok\\"}"`,
+  ].join("\n")
+
+const startTurn = (
+  binary: string,
+  timeout: string,
+  onSessionId?: OnSessionId,
+  prompt = "test",
+  thinkingLevel: string | null = "medium",
+) =>
+  Effect.gen(function* () {
+    const backend = yield* AgentBackend
+    return yield* backend.startTurn({
+      cwd: process.cwd(),
+      prompt,
+      model: "sonnet",
+      thinkingLevel,
+      timeout,
+      ...(onSessionId !== undefined ? { onSessionId } : {}),
+    })
+  }).pipe(Effect.provide(provide(binary)))
+
+describe("Claude AgentBackend adapter (readiness inspection)", () => {
+  it("inspects authenticated CLI via JSON auth status (real CLI shape)", async () => {
+    await withExecutable(
+      [
+        'case " $* " in *" auth status "*) ;; *) exit 20 ;; esac',
+        // Env must force auto-update off on inspect too.
+        'if [ "$DISABLE_AUTOUPDATER" != "1" ]; then exit 21; fi',
+        'printf \'%s\\n\' \'{"loggedIn":true,"authMethod":"claude.ai","apiProvider":"firstParty","email":"op@example.com"}\'',
+      ].join("\n"),
+      async (binary) => {
+        const result = await Effect.runPromise(inspect(binary))
+        expect(result.backend).toEqual({
+          id: "claude",
+          label: "Claude Code",
+        })
+        expect(result.models).toEqual(
+          CLAUDE_STATIC_CATALOG.map((model) => ({
+            id: model.id,
+            thinkingLevels: [...model.thinkingLevels],
+          })),
+        )
+        expect(result.models.map((m) => m.id)).toEqual([
+          "haiku",
+          "sonnet",
+          "opus",
+          "fable",
+        ])
+        for (const model of result.models) {
+          expect(model.thinkingLevels).toEqual([
+            "low",
+            "medium",
+            "high",
+            "xhigh",
+            "max",
+          ])
+          expect(model.thinkingLevels).not.toContain("ultracode")
+        }
+      },
+    )
+  })
+
+  it("fails inspect with actionable config error when unauthenticated", async () => {
+    await withExecutable(
+      [
+        'case " $* " in *" auth status "*) ;; *) exit 20 ;; esac',
+        "printf '%s\\n' '{\"loggedIn\":false}'",
+        "exit 1",
+      ].join("\n"),
+      async (binary) => {
+        const error = await Effect.runPromise(inspect(binary).pipe(Effect.flip))
+        expect(error).toBeInstanceOf(AgentBackendConfigError)
+        if (error instanceof AgentBackendConfigError) {
+          expect(error.message).toBe(CLAUDE_UNAUTHENTICATED_MESSAGE)
+          expect(error.message).toContain("claude auth login")
+          expect(error.message).toContain("ANTHROPIC_API_KEY")
+        }
+      },
+    )
+  })
+
+  it("maps non-zero auth status without auth markers to config error with probe text", async () => {
+    await withExecutable(
+      [
+        'case " $* " in *" auth status "*) ;; *) exit 20 ;; esac',
+        "echo 'internal crash' 1>&2",
+        "exit 7",
+      ].join("\n"),
+      async (binary) => {
+        const error = await Effect.runPromise(inspect(binary).pipe(Effect.flip))
+        expect(error).toBeInstanceOf(AgentBackendConfigError)
+        if (error instanceof AgentBackendConfigError) {
+          expect(error.message).toContain("exit 7")
+          expect(error.message).toContain("internal crash")
+          expect(error.message).not.toBe(CLAUDE_UNAUTHENTICATED_MESSAGE)
+        }
+      },
+    )
+  })
+
+  it("fails inspect when auth status output is malformed", async () => {
+    await withExecutable(
+      [
+        'case " $* " in *" auth status "*) ;; *) exit 20 ;; esac',
+        "echo 'something unexpected without auth markers'",
+        "exit 0",
+      ].join("\n"),
+      async (binary) => {
+        const error = await Effect.runPromise(inspect(binary).pipe(Effect.flip))
+        expect(error).toBeInstanceOf(AgentBackendMalformedOutputError)
+      },
+    )
+  })
+
+  it("fails inspect when the binary is missing", async () => {
+    const missing = join(tmpdir(), `claude-missing-${Date.now()}`)
+    const error = await Effect.runPromise(inspect(missing).pipe(Effect.flip))
+    expect(error).toBeDefined()
+    expect(error).not.toBeInstanceOf(AgentBackendConfigError)
+    expect((error as { _tag?: string })._tag).toBe("PlatformError")
+    const reason = (error as { reason?: { _tag?: string } }).reason
+    expect(reason?._tag).toBe("NotFound")
+  })
+})
+
+describe("Claude AgentBackend adapter (Agent Turns)", () => {
+  it("requires print mode, stream-json, verbose, permissions skip, and DISABLE_AUTOUPDATER", async () => {
+    await withExecutable(
+      [
+        'case " $* " in *" -p "*) ;; *) exit 20 ;; esac',
+        'case " $* " in *" stream-json "*) ;; *) exit 21 ;; esac',
+        'case " $* " in *" --verbose "*) ;; *) exit 22 ;; esac',
+        'case " $* " in *" --dangerously-skip-permissions "*) ;; *) exit 23 ;; esac',
+        'case " $* " in *" --bare "*) exit 24 ;; esac',
+        'case " $* " in *" --continue "*) exit 25 ;; esac',
+        'case " $* " in *" --fork-session "*) exit 26 ;; esac',
+        'if [ "$DISABLE_AUTOUPDATER" != "1" ]; then exit 27; fi',
+        captureSessionScript,
+        successfulTurnStream(),
+      ].join("\n"),
+      async (binary) => {
+        const result = await Effect.runPromise(startTurn(binary, "2 seconds"))
+        expect(result.assistantText).toBe("ok")
+        expect(result.sessionId).toMatch(
+          /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i,
+        )
+      },
+    )
+  })
+
+  it("collects terminal result text", async () => {
+    await withExecutable(
+      [
+        captureSessionScript,
+        `printf '%s\\n' "{\\"type\\":\\"assistant\\",\\"session_id\\":\\"$sid\\",\\"message\\":{\\"role\\":\\"assistant\\",\\"content\\":[{\\"type\\":\\"text\\",\\"text\\":\\"first\\"}]}}"`,
+        `printf '%s\\n' "{\\"type\\":\\"result\\",\\"session_id\\":\\"$sid\\",\\"is_error\\":false,\\"result\\":\\"final answer\\"}"`,
+      ].join("\n"),
+      async (binary) => {
+        const result = await Effect.runPromise(startTurn(binary, "2 seconds"))
+        expect(result.assistantText).toBe("final answer")
+      },
+    )
+  })
+
+  it("notifies onSessionId with the preassigned UUID before process exit", async () => {
+    await withExecutable(
+      [captureSessionScript, "sleep 0.4", successfulTurnStream()].join("\n"),
+      async (binary) => {
+        const observed = await Effect.runPromise(
+          Effect.gen(function* () {
+            const deferred = yield* Deferred.make<string>()
+            const fiber = yield* Effect.forkChild(
+              startTurn(binary, "5 seconds", (sessionId) =>
+                Deferred.succeed(deferred, sessionId).pipe(Effect.asVoid),
+              ),
+            )
+            const earlySessionId = yield* Deferred.await(deferred)
+            const stillRunning = fiber.pollUnsafe() === undefined
+            const result = yield* Fiber.await(fiber)
+            return { earlySessionId, stillRunning, result }
+          }),
+        )
+
+        expect(observed.earlySessionId).toMatch(
+          /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i,
+        )
+        expect(observed.stillRunning).toBe(true)
+        expect(Exit.isSuccess(observed.result)).toBe(true)
+        if (Exit.isSuccess(observed.result)) {
+          expect(observed.result.value.sessionId).toBe(observed.earlySessionId)
+        }
+      },
+    )
+  })
+
+  it("passes --session-id on start and --resume on continue with model/effort restated", async () => {
+    await withExecutable(
+      [
+        // Continue path first when --resume is present.
+        'case " $* " in *" --resume "*)',
+        '  case " $* " in *" --model opus "*) ;; *) exit 30 ;; esac',
+        '  case " $* " in *" --effort high "*) ;; *) exit 31 ;; esac',
+        '  case " $* " in *" --session-id "*) exit 32 ;; esac',
+        '  case " $* " in *" --continue "*) exit 33 ;; esac',
+        '  case " $* " in *" --fork-session "*) exit 34 ;; esac',
+        captureSessionScript,
+        successfulTurnStream(),
+        "  exit 0",
+        "  ;;",
+        "esac",
+        // Start turn: no resume
+        'case " $* " in *" --resume "*) exit 35 ;; esac',
+        'case " $* " in *" --session-id "*) ;; *) exit 36 ;; esac',
+        'case " $* " in *" --model sonnet "*) ;; *) exit 37 ;; esac',
+        'case " $* " in *" --effort low "*) ;; *) exit 38 ;; esac',
+        captureSessionScript,
+        successfulTurnStream(),
+      ].join("\n"),
+      async (binary) => {
+        const outcome = await Effect.runPromise(
+          Effect.gen(function* () {
+            const backend = yield* AgentBackend
+            const started = yield* backend.startTurn({
+              cwd: process.cwd(),
+              prompt: "first",
+              model: "sonnet",
+              thinkingLevel: "low",
+              timeout: "2 seconds",
+            })
+            const continued = yield* backend.continueTurn({
+              cwd: process.cwd(),
+              sessionId: started.sessionId,
+              prompt: "second",
+              model: "opus",
+              thinkingLevel: "high",
+              timeout: "2 seconds",
+            })
+            return { started, continued }
+          }).pipe(Effect.provide(provide(binary))),
+        )
+
+        expect(outcome.continued.sessionId).toBe(outcome.started.sessionId)
+        expect(outcome.continued.assistantText).toBe("ok")
+      },
+    )
+  })
+
+  it("omits --effort when thinkingLevel is null", async () => {
+    await withExecutable(
+      [
+        'case " $* " in *" --effort "*) exit 11 ;; esac',
+        captureSessionScript,
+        successfulTurnStream(),
+      ].join("\n"),
+      async (binary) => {
+        await expect(
+          Effect.runPromise(
+            startTurn(binary, "2 seconds", undefined, "test", null),
+          ),
+        ).resolves.toMatchObject({ assistantText: "ok" })
+      },
+    )
+  })
+
+  it("prefixes /review into the prompt on continueTurn", async () => {
+    await withExecutable(
+      [
+        'case " $* " in *"/review"*) ;; *) exit 40 ;; esac',
+        captureSessionScript,
+        successfulTurnStream(),
+      ].join("\n"),
+      async (binary) => {
+        const result = await Effect.runPromise(
+          Effect.gen(function* () {
+            const backend = yield* AgentBackend
+            return yield* backend.continueTurn({
+              cwd: process.cwd(),
+              sessionId: "11111111-1111-4111-8111-111111111111",
+              command: "/review",
+              prompt: "Review uncommitted worktree changes.",
+              model: "sonnet",
+              thinkingLevel: null,
+              timeout: "2 seconds",
+            })
+          }).pipe(Effect.provide(provide(binary))),
+        )
+        expect(result.sessionId).toBe("11111111-1111-4111-8111-111111111111")
+        expect(result.assistantText).toBe("ok")
+      },
+    )
+  })
+
+  it("maps result is_error to exit failure with known session", async () => {
+    await withExecutable(
+      [
+        captureSessionScript,
+        `printf '%s\\n' "{\\"type\\":\\"result\\",\\"subtype\\":\\"error\\",\\"session_id\\":\\"$sid\\",\\"is_error\\":true,\\"error\\":\\"boom\\"}"`,
+      ].join("\n"),
+      async (binary) => {
+        const error = await Effect.runPromise(
+          startTurn(binary, "2 seconds").pipe(Effect.flip),
+        )
+        expect(error).toBeInstanceOf(AgentBackendExitError)
+        if (error instanceof AgentBackendExitError) {
+          expect(error.exitCode).toBe(1)
+          expect(error.sessionId).toMatch(
+            /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i,
+          )
+        }
+      },
+    )
+  })
+
+  it("maps nonzero exit with known session", async () => {
+    await withExecutable(
+      [
+        captureSessionScript,
+        `printf '%s\\n' "{\\"type\\":\\"assistant\\",\\"session_id\\":\\"$sid\\",\\"message\\":{\\"role\\":\\"assistant\\",\\"content\\":[{\\"type\\":\\"text\\",\\"text\\":\\"x\\"}]}}"`,
+        "exit 7",
+      ].join("\n"),
+      async (binary) => {
+        const error = await Effect.runPromise(
+          startTurn(binary, "2 seconds").pipe(Effect.flip),
+        )
+        expect(error).toBeInstanceOf(AgentBackendExitError)
+        if (error instanceof AgentBackendExitError) {
+          expect(error.exitCode).toBe(7)
+          expect(error.sessionId).toMatch(
+            /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i,
+          )
+        }
+      },
+    )
+  })
+
+  it("maps timeout while retaining preassigned session id", async () => {
+    await withExecutable(
+      [captureSessionScript, "sleep 10"].join("\n"),
+      async (binary) => {
+        const error = await Effect.runPromise(
+          startTurn(binary, "200 millis").pipe(Effect.flip),
+        )
+        expect(error).toBeInstanceOf(AgentBackendTimeoutError)
+        if (error instanceof AgentBackendTimeoutError) {
+          expect(error.timeoutMs).toBe(200)
+          expect(error.sessionId).toMatch(
+            /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i,
+          )
+        }
+      },
+    )
+  })
+
+  it("fails when terminal result event is missing", async () => {
+    await withExecutable(
+      [
+        captureSessionScript,
+        `printf '%s\\n' "{\\"type\\":\\"assistant\\",\\"session_id\\":\\"$sid\\",\\"message\\":{\\"role\\":\\"assistant\\",\\"content\\":[{\\"type\\":\\"text\\",\\"text\\":\\"only\\"}]}}"`,
+      ].join("\n"),
+      async (binary) => {
+        const error = await Effect.runPromise(
+          startTurn(binary, "2 seconds").pipe(Effect.flip),
+        )
+        expect(error).toBeInstanceOf(AgentBackendMalformedOutputError)
+      },
+    )
+  })
+
+  it("fails on malformed stream lines", async () => {
+    await withExecutable(
+      [
+        captureSessionScript,
+        "echo not-json",
+        `printf '%s\\n' "{\\"type\\":\\"result\\",\\"session_id\\":\\"$sid\\",\\"is_error\\":false,\\"result\\":\\"x\\"}"`,
+      ].join("\n"),
+      async (binary) => {
+        const error = await Effect.runPromise(
+          startTurn(binary, "2 seconds").pipe(Effect.flip),
+        )
+        expect(error).toBeInstanceOf(AgentBackendMalformedOutputError)
+      },
+    )
+  })
+
+  it("fails on session id mismatch in result event", async () => {
+    await withExecutable(
+      [
+        `printf '%s\\n' '{"type":"result","session_id":"00000000-0000-4000-8000-000000000099","is_error":false,"result":"x"}'`,
+      ].join("\n"),
+      async (binary) => {
+        const error = await Effect.runPromise(
+          startTurn(binary, "2 seconds").pipe(Effect.flip),
+        )
+        expect(error).toBeInstanceOf(AgentBackendMalformedOutputError)
+      },
+    )
+  })
+
+  it("cancels the process tree on fiber interruption", async () => {
+    await withExecutable(
+      ["trap 'exit 0' TERM", "sleep 30"].join("\n"),
+      async (binary) => {
+        const exit = await Effect.runPromise(
+          Effect.gen(function* () {
+            const fiber = yield* Effect.forkChild(
+              startTurn(binary, "30 seconds"),
+            )
+            yield* Effect.sleep("100 millis")
+            yield* Fiber.interrupt(fiber)
+            return yield* Fiber.await(fiber)
+          }),
+        )
+        expect(Exit.isSuccess(exit)).toBe(false)
+      },
+    )
+  })
+})

--- a/packages/claude/test/environment.spec.ts
+++ b/packages/claude/test/environment.spec.ts
@@ -1,0 +1,37 @@
+import { makeClaudeEnvironment } from "../src/index.js"
+import { describe, expect, it } from "bun:test"
+
+describe("makeClaudeEnvironment", () => {
+  it("preserves ambient Forge tokens and Anthropic credentials and disables auto-update", () => {
+    const env = makeClaudeEnvironment({
+      environment: {
+        PATH: "/usr/bin",
+        HOME: "/home/op",
+        GH_TOKEN: "secret",
+        GITHUB_TOKEN: "secret2",
+        GITLAB_TOKEN: "secret3",
+        GITLAB_TOKEN_ACME_WIDGETS: "secret4",
+        ANTHROPIC_API_KEY: "sk-ant-test",
+        KEEP: "yes",
+      },
+    })
+    expect(env.PATH).toBe("/usr/bin")
+    expect(env.KEEP).toBe("yes")
+    expect(env.DISABLE_AUTOUPDATER).toBe("1")
+    expect(env.GH_TOKEN).toBe("secret")
+    expect(env.GITHUB_TOKEN).toBe("secret2")
+    expect(env.GITLAB_TOKEN).toBe("secret3")
+    expect(env.GITLAB_TOKEN_ACME_WIDGETS).toBe("secret4")
+    expect(env.ANTHROPIC_API_KEY).toBe("sk-ant-test")
+  })
+
+  it("forces DISABLE_AUTOUPDATER even when inherited env already sets it", () => {
+    const env = makeClaudeEnvironment({
+      environment: {
+        PATH: "/usr/bin",
+        DISABLE_AUTOUPDATER: "0",
+      },
+    })
+    expect(env.DISABLE_AUTOUPDATER).toBe("1")
+  })
+})

--- a/packages/claude/test/parse-auth-status.spec.ts
+++ b/packages/claude/test/parse-auth-status.spec.ts
@@ -1,0 +1,103 @@
+import { extractFirstJsonObject, parseClaudeAuthStatus } from "../src/index.js"
+import { describe, expect, it } from "bun:test"
+
+describe("extractFirstJsonObject", () => {
+  it("returns the first balanced object and ignores trailing noise", () => {
+    expect(
+      extractFirstJsonObject(
+        '{"loggedIn":true,"authMethod":"claude.ai"}\nwarning: noise',
+      ),
+    ).toBe('{"loggedIn":true,"authMethod":"claude.ai"}')
+  })
+
+  it("handles braces inside JSON strings", () => {
+    expect(
+      extractFirstJsonObject('{"loggedIn":true,"note":"has { and } chars"}'),
+    ).toBe('{"loggedIn":true,"note":"has { and } chars"}')
+  })
+})
+
+describe("parseClaudeAuthStatus", () => {
+  it("recognizes loggedIn true JSON (real CLI shape)", () => {
+    expect(
+      parseClaudeAuthStatus(
+        JSON.stringify({
+          loggedIn: true,
+          authMethod: "claude.ai",
+          apiProvider: "firstParty",
+          email: "op@example.com",
+        }),
+        0,
+      ),
+    ).toEqual({ kind: "authenticated" })
+  })
+
+  it("recognizes loggedIn false JSON as unauthenticated", () => {
+    expect(
+      parseClaudeAuthStatus(JSON.stringify({ loggedIn: false }), 1),
+    ).toEqual({ kind: "unauthenticated" })
+  })
+
+  it("classifies authenticated JSON when stderr noise follows the object", () => {
+    expect(
+      parseClaudeAuthStatus(
+        '{"loggedIn":true,"authMethod":"claude.ai"}\nwarning: ambient noise',
+        0,
+      ),
+    ).toEqual({ kind: "authenticated" })
+  })
+
+  it("classifies unauthenticated JSON when stderr noise follows the object", () => {
+    expect(
+      parseClaudeAuthStatus(
+        '{"loggedIn":false,"authMethod":null}\nwarning: ambient noise',
+        1,
+      ),
+    ).toEqual({ kind: "unauthenticated" })
+  })
+
+  it("recognizes human-readable not logged in", () => {
+    expect(parseClaudeAuthStatus("Not logged in\n", 1)).toEqual({
+      kind: "unauthenticated",
+    })
+  })
+
+  it("treats unauthenticated human copy as unauth, not authenticated", () => {
+    expect(parseClaudeAuthStatus("You are unauthenticated.\n", 1)).toEqual({
+      kind: "unauthenticated",
+    })
+    expect(parseClaudeAuthStatus("Not authenticated\n", 1)).toEqual({
+      kind: "unauthenticated",
+    })
+  })
+
+  it("does not treat authMethod field dumps as authenticated", () => {
+    // No parseable loggedIn boolean; field name alone must not flip ready.
+    expect(
+      parseClaudeAuthStatus('prefix {"authMethod":"claude.ai"} trailing', 0),
+    ).toEqual({ kind: "malformed" })
+  })
+
+  it("recognizes human-readable logged in after unauth markers are ruled out", () => {
+    expect(parseClaudeAuthStatus("Logged in as op@example.com\n", 0)).toEqual({
+      kind: "authenticated",
+    })
+  })
+
+  it("treats non-zero exit without auth markers as failed, not unauthenticated", () => {
+    expect(parseClaudeAuthStatus("", 1)).toEqual({
+      kind: "failed",
+      exitCode: 1,
+    })
+    expect(parseClaudeAuthStatus("segfault dump\n", 139)).toEqual({
+      kind: "failed",
+      exitCode: 139,
+    })
+  })
+
+  it("treats exit-zero garbage as malformed", () => {
+    expect(parseClaudeAuthStatus("unexpected banner only\n", 0)).toEqual({
+      kind: "malformed",
+    })
+  })
+})

--- a/packages/claude/test/parse-stream.spec.ts
+++ b/packages/claude/test/parse-stream.spec.ts
@@ -1,0 +1,138 @@
+import {
+  claudeAssistantText,
+  createClaudeStreamParseState,
+  foldClaudeStreamLine,
+  isSuccessfulClaudeTurn,
+} from "../src/index.js"
+import { describe, expect, it } from "bun:test"
+
+describe("parse-stream", () => {
+  it("prefers terminal result text and marks success", () => {
+    let state = createClaudeStreamParseState()
+    state = foldClaudeStreamLine(
+      state,
+      '{"type":"system","subtype":"init","session_id":"session-1","model":"sonnet"}',
+    )
+    state = foldClaudeStreamLine(
+      state,
+      '{"type":"assistant","session_id":"session-1","message":{"id":"msg_1","type":"message","role":"assistant","content":[{"type":"text","text":"partial"}]}}',
+    )
+    state = foldClaudeStreamLine(
+      state,
+      '{"type":"result","subtype":"success","session_id":"session-1","is_error":false,"result":"Done."}',
+    )
+    expect(state.sessionId).toBe("session-1")
+    expect(claudeAssistantText(state)).toBe("Done.")
+    expect(isSuccessfulClaudeTurn(state)).toBe(true)
+  })
+
+  it("falls back to ordered assistant text when result string is empty", () => {
+    let state = createClaudeStreamParseState()
+    state = foldClaudeStreamLine(
+      state,
+      '{"type":"assistant","session_id":"s1","message":{"role":"assistant","content":[{"type":"text","text":"first"}]}}',
+    )
+    state = foldClaudeStreamLine(
+      state,
+      '{"type":"assistant","session_id":"s1","message":{"role":"assistant","content":[{"type":"text","text":" second"}]}}',
+    )
+    state = foldClaudeStreamLine(
+      state,
+      '{"type":"result","subtype":"success","session_id":"s1","is_error":false,"result":""}',
+    )
+    expect(claudeAssistantText(state)).toBe("first second")
+    expect(isSuccessfulClaudeTurn(state)).toBe(true)
+  })
+
+  it("ignores subagent assistant text with parent_tool_use_id", () => {
+    let state = createClaudeStreamParseState()
+    state = foldClaudeStreamLine(
+      state,
+      '{"type":"assistant","parent_tool_use_id":"toolu_parent","session_id":"s1","message":{"role":"assistant","content":[{"type":"text","text":"subagent noise"}]}}',
+    )
+    state = foldClaudeStreamLine(
+      state,
+      '{"type":"assistant","session_id":"s1","message":{"role":"assistant","content":[{"type":"text","text":"root"}]}}',
+    )
+    state = foldClaudeStreamLine(
+      state,
+      '{"type":"result","session_id":"s1","is_error":false,"result":""}',
+    )
+    expect(claudeAssistantText(state)).toBe("root")
+  })
+
+  it("ignores tool_use content blocks", () => {
+    let state = createClaudeStreamParseState()
+    state = foldClaudeStreamLine(
+      state,
+      '{"type":"assistant","session_id":"s1","message":{"role":"assistant","content":[{"type":"tool_use","id":"t1","name":"Bash","input":{"command":"ls"}}]}}',
+    )
+    state = foldClaudeStreamLine(
+      state,
+      '{"type":"assistant","session_id":"s1","message":{"role":"assistant","content":[{"type":"text","text":"ok"}]}}',
+    )
+    state = foldClaudeStreamLine(
+      state,
+      '{"type":"result","session_id":"s1","is_error":false,"result":"ok"}',
+    )
+    expect(claudeAssistantText(state)).toBe("ok")
+  })
+
+  it("marks non-json lines malformed", () => {
+    let state = createClaudeStreamParseState()
+    state = foldClaudeStreamLine(state, "not-json")
+    expect(state.malformedLine).toBe(true)
+  })
+
+  it("tracks result is_error as failure", () => {
+    let state = createClaudeStreamParseState()
+    state = foldClaudeStreamLine(
+      state,
+      '{"type":"result","subtype":"error","session_id":"s1","is_error":true,"result":"","error":"Permission denied"}',
+    )
+    expect(state.resultSeen).toBe(true)
+    expect(state.isError).toBe(true)
+    expect(state.errorMessage).toBe("Permission denied")
+    expect(isSuccessfulClaudeTurn(state)).toBe(false)
+  })
+
+  it("ignores empty lines and unknown event types", () => {
+    let state = createClaudeStreamParseState()
+    state = foldClaudeStreamLine(state, "")
+    state = foldClaudeStreamLine(state, "   ")
+    state = foldClaudeStreamLine(
+      state,
+      '{"type":"stream_event","event":{"type":"message_start"}}',
+    )
+    state = foldClaudeStreamLine(
+      state,
+      '{"type":"result","session_id":"s1","is_error":false,"result":"ok"}',
+    )
+    expect(state.malformedLine).toBe(false)
+    expect(isSuccessfulClaudeTurn(state)).toBe(true)
+  })
+
+  it("stops folding after malformed or result", () => {
+    let state = createClaudeStreamParseState()
+    state = foldClaudeStreamLine(state, "not-json")
+    state = foldClaudeStreamLine(
+      state,
+      '{"type":"result","session_id":"late","is_error":false,"result":"x"}',
+    )
+    expect(state.malformedLine).toBe(true)
+    expect(state.resultSeen).toBe(false)
+
+    state = createClaudeStreamParseState()
+    state = foldClaudeStreamLine(
+      state,
+      '{"type":"result","session_id":"s1","is_error":false,"result":"first"}',
+    )
+    state = foldClaudeStreamLine(
+      state,
+      '{"type":"assistant","session_id":"s1","message":{"role":"assistant","content":[{"type":"text","text":"after"}]}}',
+    )
+    expect(state.resultSeen).toBe(true)
+    expect(claudeAssistantText(state)).toBe("first")
+    expect(state.assistantTextChunks).toEqual([])
+  })
+})

--- a/packages/claude/test/session-telemetry-layer.spec.ts
+++ b/packages/claude/test/session-telemetry-layer.spec.ts
@@ -1,0 +1,26 @@
+import { Effect } from "effect"
+import { SessionTelemetryProvider } from "@ready-for-agent/agent-backend"
+import { ClaudeSessionTelemetryLive } from "../src/index.js"
+import { describe, expect, it } from "bun:test"
+
+describe("ClaudeSessionTelemetryLive", () => {
+  it("reports Session Telemetry unsupported for any session id", async () => {
+    const result = await Effect.runPromise(
+      Effect.gen(function* () {
+        const provider = yield* SessionTelemetryProvider
+        return yield* provider.getSession("any-session-id")
+      }).pipe(Effect.provide(ClaudeSessionTelemetryLive())),
+    )
+
+    expect(result).toEqual({
+      id: "any-session-id",
+      availability: "unsupported",
+      backend: { id: "claude", label: "Claude Code" },
+      model: null,
+      tokens: null,
+      cost: null,
+      createdAt: null,
+      updatedAt: null,
+    })
+  })
+})

--- a/packages/claude/tsconfig.json
+++ b/packages/claude/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ]
+}

--- a/packages/claude/tsconfig.lib.json
+++ b/packages/claude/tsconfig.lib.json
@@ -1,0 +1,17 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "tsBuildInfoFile": "dist/tsconfig.lib.tsbuildinfo",
+    "emitDeclarationOnly": false,
+    "forceConsistentCasingInFileNames": true,
+    "types": ["node", "bun"]
+  },
+  "include": ["src/**/*.ts"],
+  "references": [
+    {
+      "path": "../agent-backend/tsconfig.lib.json"
+    }
+  ]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -49,6 +49,9 @@
       "path": "./packages/codex"
     },
     {
+      "path": "./packages/claude"
+    },
+    {
       "path": "./packages/github-service"
     },
     {


### PR DESCRIPTION
## Why

Operators who use Claude Code cannot run Harness Agent Turns on that
backend until a built-in adapter exists on the shared Agent Backend
contract (ADR 0047 / #778). This change ships the adapter package and
readiness surface so later Harness wiring (#779) can select it.

## What changed

- New `@ready-for-agent/claude` package implementing `inspect`,
  `startTurn`, and `continueTurn` on `@ready-for-agent/agent-backend`
  (Grok/Codex shape).
- Static catalog: `haiku`, `sonnet`, `opus`, `fable` with Thinking
  Levels `low`–`max` via `--effort` (no `ultracode`).
- Preassigned Session UUID (`--session-id` + early `onSessionId`);
  continue with `--resume` only (never `--continue` / `--fork-session`).
- Headless turns: `-p`, `stream-json` + `--verbose`,
  `--dangerously-skip-permissions`, model restated every turn; prompt
  after end-of-options `--`; no `--bare`.
- Env forces `DISABLE_AUTOUPDATER=1`. `/review` is prompt-prefixed.
- Inspect via `claude auth status` (balanced JSON `loggedIn` + tight
  human fallbacks). Session Telemetry layer reports unsupported.
- `AGENT_BACKEND_IDS.claude` + host-tools map entry for type
  completeness; not registered as selectable (Settings / runtime
  resolve stay for #779).
- CONTEXT.md + `ontology/context.ttl` Claude Code glossary term.

## Verification

- `bunx nx test claude` (fake-CLI unit suite, including auth/stream/args
  edge cases)
- `bunx nx test agent-backend` and preflight/lifecycle-model parity
  after ontology update
- Pre-commit path green after ontology parity fix

## Out of scope / follow-ons

- Harness Settings selection, registry, and Active runtime wiring: #779
- Opt-in live `claude` integration suite: #780

Closes #778