### PR TITLE
feat(harness): select and run Claude Code as an Agent Backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,9 +35,10 @@ work on it.
 
 The harness creates a new worktree, installs packages, and asks a
 selectable headless Agent Backend ([OpenCode](https://opencode.ai/),
-[Codex](https://github.com/openai/codex), or [Grok
-Build](https://docs.x.ai/)) to implement the issue, review the issue,
-create a PR, and merge if allowed.
+[Codex](https://github.com/openai/codex), [Grok
+Build](https://docs.x.ai/), or [Claude
+Code](https://docs.anthropic.com/en/docs/claude-code)) to implement the
+issue, review the issue, create a PR, and merge if allowed.
 
 The goal of this clanker harness is to get you to that 25+ PRs merged
 a day nirvana. It does that by removing the time spent babysitting an
@@ -153,15 +154,20 @@ required; default is OpenCode):
    selected Agent Backend
 6. [Grok Build](https://docs.x.ai/) (`grok` on PATH) when Grok Build is the
    selected Agent Backend
+7. [Claude Code](https://docs.anthropic.com/en/docs/claude-code) (`claude` on
+   PATH) when Claude Code is the selected Agent Backend
 
 Authenticate Grok Build with `grok login` or `XAI_API_KEY` before Recheck /
 Agent Turns. Harness-launched Grok processes disable auto-update for that
 session (`--no-auto-update` / `GROK_DISABLE_AUTOUPDATER`). Grok Build Agent
 Turns do not integrate Keymaxxer; Session Telemetry is live-read from on-disk
-Grok session files under `$GROK_HOME/sessions` (default `~/.grok`). Opt-in live
-adapter tests use `GROK_INTEGRATION=1` / `OPENCODE_INTEGRATION=1` /
-`CODEX_INTEGRATION=1` / `CLAUDE_INTEGRATION=1`; normal CI does not need paid
-model credentials.
+Grok session files under `$GROK_HOME/sessions` (default `~/.grok`). Authenticate
+Claude Code with `claude auth login` or `ANTHROPIC_API_KEY` before Recheck /
+Agent Turns. Harness-launched Claude processes disable auto-update for that
+session (`DISABLE_AUTOUPDATER`). Claude Code Agent Turns do not integrate
+Keymaxxer; Session Telemetry is unsupported in v1. Opt-in live adapter tests
+use `GROK_INTEGRATION=1` / `OPENCODE_INTEGRATION=1` / `CODEX_INTEGRATION=1` /
+`CLAUDE_INTEGRATION=1`; normal CI does not need paid model credentials.
 
 # KeyMaxxer
 
@@ -181,8 +187,9 @@ KEYMAXXER_ENABLED=false npx ready-for-agent@latest
 1. Is there support for agents other than OpenCode?
 
 Yes. Settings can select [OpenCode](https://opencode.ai/),
-[Codex](https://github.com/openai/codex), or [Grok Build](https://docs.x.ai/) as
-the instance-wide Agent Backend. The change hot-activates on Save when no Work
+[Codex](https://github.com/openai/codex), [Grok Build](https://docs.x.ai/), or
+[Claude Code](https://docs.anthropic.com/en/docs/claude-code) as the
+instance-wide Agent Backend. The change hot-activates on Save when no Work
 Items are unfinished (including Needs Human). Model catalogs and effort
 (thinking) options are backend-local, and build/review prefs are remembered per
 backend.

--- a/apps/harness/package.json
+++ b/apps/harness/package.json
@@ -23,6 +23,7 @@
     "@ready-for-agent/keymaxxer-service": "workspace:*",
     "@ready-for-agent/lifecycle-model": "workspace:*",
     "@ready-for-agent/local-git": "workspace:*",
+    "@ready-for-agent/claude": "workspace:*",
     "@ready-for-agent/codex": "workspace:*",
     "@ready-for-agent/grok": "workspace:*",
     "@ready-for-agent/opencode": "workspace:*",

--- a/apps/harness/src/server/application.server.ts
+++ b/apps/harness/src/server/application.server.ts
@@ -22,6 +22,7 @@ import {
   isSelectableAgentBackendId,
   resolveActiveRegistration,
 } from "@ready-for-agent/agent-backend"
+import { Claude, ClaudeSessionTelemetryLive } from "@ready-for-agent/claude"
 import { Codex, CodexSessionTelemetryLive } from "@ready-for-agent/codex"
 import { DatabaseLive } from "@ready-for-agent/db"
 import { DbService, DbServiceLive } from "@ready-for-agent/db-service"
@@ -85,6 +86,12 @@ const makeResolveRuntime = (
       return Layer.mergeAll(
         Codex.layer().pipe(Layer.provide(platformLayer)),
         CodexSessionTelemetryLive(),
+      )
+    }
+    if (backendId === AGENT_BACKEND_IDS.claude) {
+      return Layer.mergeAll(
+        Claude.layer().pipe(Layer.provide(platformLayer)),
+        ClaudeSessionTelemetryLive(),
       )
     }
     return Layer.mergeAll(

--- a/apps/harness/tsconfig.app.json
+++ b/apps/harness/tsconfig.app.json
@@ -47,6 +47,9 @@
       "path": "../../packages/codex/tsconfig.lib.json"
     },
     {
+      "path": "../../packages/claude/tsconfig.lib.json"
+    },
+    {
       "path": "../../packages/local-git/tsconfig.lib.json"
     },
     {

--- a/apps/ready-for-agent/src/host-tools-preflight.test.ts
+++ b/apps/ready-for-agent/src/host-tools-preflight.test.ts
@@ -138,6 +138,28 @@ describe("host tools preflight", () => {
     expect(missingCodex.message).toContain("Codex Build")
   })
 
+  test("requires claude when only Claude Code is selected", () => {
+    const withClaude = checkHostTools(
+      (command) => ["git", "gh", "claude"].includes(command),
+      { selectedAgentBackendIds: ["claude"] },
+    )
+    expect(withClaude.ok).toBe(true)
+
+    const missingClaude = checkHostTools(
+      (command) => ["git", "gh", "opencode"].includes(command),
+      { selectedAgentBackendIds: ["claude"] },
+    )
+    expect(missingClaude.ok).toBe(false)
+    if (missingClaude.ok) return
+    expect(missingClaude.missing.map((tool) => tool.name)).toEqual(["claude"])
+    expect(missingClaude.message).toContain("claude")
+    expect(missingClaude.message).toContain("Claude Code")
+    expect(missingClaude.message).toContain(
+      "https://docs.anthropic.com/en/docs/claude-code",
+    )
+    expect(missingClaude.message).not.toContain("opencode")
+  })
+
   test("passes without keymaxxer", () => {
     const result = checkHostTools((command) =>
       ["git", "gh", "opencode"].includes(command),

--- a/apps/ready-for-agent/src/host-tools-preflight.ts
+++ b/apps/ready-for-agent/src/host-tools-preflight.ts
@@ -30,7 +30,6 @@ const BACKEND_HOST_TOOLS: Record<
     installHint:
       "Install Codex CLI: https://developers.openai.com/codex/cli (binary name: codex)",
   },
-  // Claude Code binary requirement; selection/wiring lands with #779.
   [AGENT_BACKEND_IDS.claude]: {
     name: "claude",
     installHint:

--- a/bun.lock
+++ b/bun.lock
@@ -31,6 +31,7 @@
       "dependencies": {
         "@effect/platform-bun": "^4.0.0-beta.97",
         "@ready-for-agent/agent-backend": "workspace:*",
+        "@ready-for-agent/claude": "workspace:*",
         "@ready-for-agent/codex": "workspace:*",
         "@ready-for-agent/db": "workspace:*",
         "@ready-for-agent/db-service": "workspace:*",

--- a/packages/agent-backend/src/lib/registry.ts
+++ b/packages/agent-backend/src/lib/registry.ts
@@ -44,11 +44,23 @@ const CODEX_REGISTRATION: AgentBackendRegistration = {
   ],
 }
 
+const CLAUDE_REGISTRATION: AgentBackendRegistration = {
+  descriptor: {
+    id: AGENT_BACKEND_IDS.claude,
+    label: "Claude Code",
+  },
+  capabilities: [
+    { _tag: "SessionTelemetry", supported: false },
+    { _tag: "KeymaxxerMcp", supported: false },
+  ],
+}
+
 /** Production selectable backends registered at build time. */
 const BUILT_IN_REGISTRY: ReadonlyArray<AgentBackendRegistration> = [
   OPENCODE_REGISTRATION,
   GROK_REGISTRATION,
   CODEX_REGISTRATION,
+  CLAUDE_REGISTRATION,
 ]
 
 export const listBuiltInAgentBackends =

--- a/packages/agent-backend/src/lib/types.ts
+++ b/packages/agent-backend/src/lib/types.ts
@@ -5,7 +5,7 @@ export const AGENT_BACKEND_IDS = {
   opencode: "opencode",
   grok: "grok",
   codex: "codex",
-  /** Claude Code adapter package (ADR 0047). Selectable once registered in #779. */
+  /** Claude Code adapter package (ADR 0047). */
   claude: "claude",
 } as const
 

--- a/packages/agent-backend/test/registry.spec.ts
+++ b/packages/agent-backend/test/registry.spec.ts
@@ -11,12 +11,13 @@ import {
 import { describe, expect, it } from "bun:test"
 
 describe("Agent Backend registry", () => {
-  it("exposes OpenCode, Grok Build, and Codex Build as selectable production backends", () => {
+  it("exposes OpenCode, Grok Build, Codex Build, and Claude Code as selectable production backends", () => {
     const backends = listBuiltInAgentBackends()
     expect(backends.map((entry) => entry.descriptor.id)).toEqual([
       AGENT_BACKEND_IDS.opencode,
       AGENT_BACKEND_IDS.grok,
       AGENT_BACKEND_IDS.codex,
+      AGENT_BACKEND_IDS.claude,
     ])
     expect(defaultAgentBackendId).toBe(AGENT_BACKEND_IDS.opencode)
     expect(getBuiltInAgentBackend("missing")).toBeUndefined()
@@ -26,16 +27,20 @@ describe("Agent Backend registry", () => {
     expect(
       getBuiltInAgentBackend(AGENT_BACKEND_IDS.codex)?.descriptor.label,
     ).toBe("Codex Build")
+    expect(
+      getBuiltInAgentBackend(AGENT_BACKEND_IDS.claude)?.descriptor.label,
+    ).toBe("Claude Code")
   })
 
   it("maps backend ids to operator-visible labels for failure copy", () => {
     expect(agentBackendLabel(AGENT_BACKEND_IDS.opencode)).toBe("OpenCode")
     expect(agentBackendLabel(AGENT_BACKEND_IDS.grok)).toBe("Grok Build")
     expect(agentBackendLabel(AGENT_BACKEND_IDS.codex)).toBe("Codex Build")
+    expect(agentBackendLabel(AGENT_BACKEND_IDS.claude)).toBe("Claude Code")
     expect(agentBackendLabel("unknown-backend")).toBe("unknown-backend")
   })
 
-  it("declares typed capabilities for OpenCode, Grok Build, and Codex Build", () => {
+  it("declares typed capabilities for OpenCode, Grok Build, Codex Build, and Claude Code", () => {
     const opencode = getBuiltInAgentBackend(AGENT_BACKEND_IDS.opencode)
     expect(opencode).toBeDefined()
     expect(capabilitySupported(opencode!, "SessionTelemetry")).toBe(true)
@@ -50,6 +55,11 @@ describe("Agent Backend registry", () => {
     expect(codex).toBeDefined()
     expect(capabilitySupported(codex!, "SessionTelemetry")).toBe(false)
     expect(capabilitySupported(codex!, "KeymaxxerMcp")).toBe(false)
+
+    const claude = getBuiltInAgentBackend(AGENT_BACKEND_IDS.claude)
+    expect(claude).toBeDefined()
+    expect(capabilitySupported(claude!, "SessionTelemetry")).toBe(false)
+    expect(capabilitySupported(claude!, "KeymaxxerMcp")).toBe(false)
   })
 })
 


### PR DESCRIPTION
## Why

Operators who use Anthropic’s Claude Code CLI could not choose it as a Harness
Agent Backend. The adapter package shipped in #778; this change makes Claude
Code first-class and selectable (ADR 0047 / issue #779).

## What changed

- Register built-in backend id `claude` with label **Claude Code**; Session
  Telemetry and Keymaxxer MCP unsupported
- Wire `Claude.layer()` / `ClaudeSessionTelemetryLive()` into harness
  `makeResolveRuntime` so Active / selected-or-in-use backends hot-activate and
  route Agent Turns
- Host cold-start preflight requires the `claude` binary (with install hint)
  when Claude is selected-or-in-use
- Package/tsconfig/lock dependency on `@ready-for-agent/claude`; README documents
  Claude Code selection and auth
- OpenCode remains the default; Grok and Codex paths unchanged

Selection, Repository override, Preview/Recheck, Work Item capture, and
Unavailable behavior use existing registry-driven paths
(`listBuiltInAgentBackends` / `isSelectableAgentBackendId` / ActiveAgentBackend).

## Verification

- `nx test agent-backend` (registry + Active paths)
- `nx test claude` (adapter fake-CLI suite)
- Host-tools preflight tests (Claude-only selection)
- `nx run harness:typecheck`
- Local review: no findings

## Limitations

- No opt-in live Claude integration suite in this change
- Session Telemetry remains unsupported for Claude Code in v1

Closes #779