### PR TITLE
fix(harness): put collapsed lifecycle legs on one wrap line

### DIFF
--- a/apps/harness/src/routes/index.tsx
+++ b/apps/harness/src/routes/index.tsx
@@ -3680,20 +3680,23 @@ export function WorkItemLifecycleStatus({
         (chipBlocks.length === 1 && chipBlocks[0]?.kind === "full-list" ? (
           renderChipList(chipBlocks[0].chips)
         ) : (
-          <div className="mt-2 flex flex-col gap-1">
-            {chipBlocks.map((block) => {
-              if (block.kind === "earlier-lane") {
-                const chipsId = `lifecycle-lane-${workItem.id}-${block.lane}`
-                const durationLabel =
-                  block.durationMs === null
-                    ? null
-                    : formatDuration(block.durationMs)
-                const summaryStyle = lifecycleLaneCssVars(
-                  block.lane,
-                ) as CSSProperties
-                return (
-                  <div key={block.lane} className="min-w-0">
+          // Summary legs share one wrap row (like archive foot); expanded
+          // fine-grained chips are full-width strips beneath that row.
+          <div className={ui.lifecycleLegBlocks}>
+            <div className={ui.legRow}>
+              {chipBlocks.map((block) => {
+                if (block.kind === "earlier-lane") {
+                  const chipsId = `lifecycle-lane-${workItem.id}-${block.lane}`
+                  const durationLabel =
+                    block.durationMs === null
+                      ? null
+                      : formatDuration(block.durationMs)
+                  const summaryStyle = lifecycleLaneCssVars(
+                    block.lane,
+                  ) as CSSProperties
+                  return (
                     <button
+                      key={block.lane}
                       type="button"
                       className={ui.legSummary}
                       style={summaryStyle}
@@ -3707,29 +3710,48 @@ export function WorkItemLifecycleStatus({
                       <span>{block.laneLabel}</span>
                       {durationLabel !== null && <span>· {durationLabel}</span>}
                     </button>
-                    {block.expanded &&
-                      renderChipList(block.chips, {
-                        id: chipsId,
+                  )
+                }
+                if (block.kind === "focus-lane") {
+                  if (block.chips.length === 0) return null
+                  return (
+                    <div key="focus-lane" className="min-w-0 max-w-full">
+                      {renderChipList(block.chips, {
                         className:
-                          "mt-1 mb-0 flex min-w-0 max-w-full list-none flex-wrap gap-1 p-0",
-                        ariaLabel: `${block.laneLabel} lifecycle steps`,
+                          "m-0 flex min-w-0 max-w-full list-none flex-wrap gap-1 p-0",
+                        ariaLabel: "Current lifecycle steps",
                       })}
-                  </div>
-                )
-              }
-              if (block.kind === "focus-lane") {
-                if (block.chips.length === 0) return null
+                    </div>
+                  )
+                }
                 return (
-                  <div key="focus-lane" className="min-w-0 max-w-full">
+                  <div key="full-list" className="min-w-0 max-w-full">
                     {renderChipList(block.chips, {
                       className:
                         "m-0 flex min-w-0 max-w-full list-none flex-wrap gap-1 p-0",
-                      ariaLabel: "Current lifecycle steps",
                     })}
                   </div>
                 )
+              })}
+            </div>
+            {chipBlocks.map((block) => {
+              if (block.kind !== "earlier-lane" || !block.expanded) {
+                return null
               }
-              return <div key="full-list">{renderChipList(block.chips)}</div>
+              const chipsId = `lifecycle-lane-${workItem.id}-${block.lane}`
+              return (
+                <div
+                  key={`${block.lane}-expanded`}
+                  className="min-w-0 max-w-full"
+                >
+                  {renderChipList(block.chips, {
+                    id: chipsId,
+                    className:
+                      "m-0 flex min-w-0 max-w-full list-none flex-wrap gap-1 p-0",
+                    ariaLabel: `${block.laneLabel} lifecycle steps`,
+                  })}
+                </div>
+              )
             })}
           </div>
         ))}

--- a/apps/harness/src/ui.ts
+++ b/apps/harness/src/ui.ts
@@ -46,6 +46,13 @@ const cardMetalLight =
 const mastScrollworkStroke =
   "[fill:none] [stroke-linecap:round] [stroke-linejoin:round]"
 
+/**
+ * Horizontal wrap row for collapsed journey-leg summaries (archive footer +
+ * Kanban/repos lifecycle chrome). Shared so both surfaces stay dense and
+ * consistent — not a vertical stack of BUILD / REVIEW / PR|MR.
+ */
+const legRowClasses = "flex flex-wrap items-center gap-[0.35rem]"
+
 export const ui = {
   /* ---------- Nav shell (§4.1) ---------- */
 
@@ -321,7 +328,11 @@ export const ui = {
 
   archiveJourney: "grid min-w-0 gap-[0.45rem]",
 
-  archiveFoot: "flex flex-wrap items-center gap-[0.35rem]",
+  /** Collapsed journey legs on one wrap line — see `legRowClasses`. */
+  legRow: legRowClasses,
+
+  /** Archive footer alias of `legRow` (call-site clarity on completed cards). */
+  archiveFoot: legRowClasses,
 
   /**
    * Journey-leg chips — board density floor (0.56rem) is the shared base.
@@ -932,6 +943,12 @@ export const ui = {
     "font-mono text-[0.56rem] font-bold tracking-[0.06em] uppercase whitespace-nowrap text-[var(--leg-on,#fff)]",
     "hover:brightness-105",
   ),
+
+  /**
+   * Multi-block lifecycle chrome: summary leg row on top, expanded chip
+   * strips full-width beneath (same pattern as archive journey).
+   */
+  lifecycleLegBlocks: "mt-2 flex min-w-0 max-w-full flex-col gap-1",
 
   /* ---------- Icon buttons (§5.4) ---------- */
 

--- a/apps/harness/test/repos-interchange.test.ts
+++ b/apps/harness/test/repos-interchange.test.ts
@@ -159,6 +159,11 @@ describe("Interchange phase 4: repos page + blank slate", () => {
     expect(collapseAllPredicate).not.toContain("SUCCEEDED")
     expect(lifecycle).toContain("forgeChangeRequestShort")
     expect(lifecycle).toContain("ui.legSummary")
+    // Collapsed BUILD/REVIEW/PR|MR legs share one wrap row (#784), not a
+    // vertical stack — same density language as archive foot legs.
+    expect(lifecycle).toContain("ui.lifecycleLegBlocks")
+    expect(lifecycle).toContain("ui.legRow")
+    expect(lifecycle).not.toContain("flex flex-col gap-1")
 
     const row = sliceBetweenMarkers(
       homeSource(),
@@ -183,6 +188,14 @@ describe("Interchange phase 4: repos page + blank slate", () => {
     expect(ui).toContain("lifecycleInset:")
     expect(ui).toMatch(/lifecycleInset:[\s\S]*?border-\[1\.5px\]/)
     expect(ui).toMatch(/lifecycleInset:[\s\S]*?border-ink/)
+    // Shared horizontal leg-row recipe (lifecycle chrome + archive foot).
+    expect(ui).toContain("legRow:")
+    expect(ui).toContain("lifecycleLegBlocks:")
+    expect(ui).toMatch(
+      /legRowClasses\s*=\s*"flex flex-wrap items-center gap-\[0\.35rem\]"/,
+    )
+    expect(ui).toContain("archiveFoot: legRowClasses")
+    expect(ui).toContain("legRow: legRowClasses")
   })
 
   test("parent issue groups use an aligned details card", () => {

--- a/docs/harness-design-system.md
+++ b/docs/harness-design-system.md
@@ -351,11 +351,15 @@ Anatomy (top to bottom):
 6. **Via lines**: mono uppercase faint, 2px `--line-soft` left border,
    padding-left ("Via Build — 14 min").
 7. **Journey legs** (§5.2): earlier-lane collapse is shared by **Kanban
-   tickets and repos lifecycle chrome** — collapsed summary rows are
-   **consistently lane-colored** (per #695): in the Review lane the Build
-   summary is a Build-blue chip with white text ("▸ BUILD · 14m"); likewise
-   everywhere, name + summed duration only. Expansion replaces the summary
-   with that lane's chips; ephemeral local state (behavior per
+   tickets and repos lifecycle chrome** — collapsed summary chips are
+   **consistently lane-colored** (per #695) and sit on **one horizontal wrap
+   row** (per #784), not stacked as separate lines: in the Review lane the
+   Build summary is a Build-blue chip with white text ("▸ BUILD · 14m");
+   likewise everywhere, name + summed duration only. Multiple collapsed
+   legs (e.g. BUILD + REVIEW on a PR-focus ticket, or BUILD + REVIEW +
+   PR|MR on terminal COMPLETE) share that single wrap line. Expanding a
+   leg keeps the summary row intact and reveals that lane's fine-grained
+   chips as a full-width strip beneath; ephemeral local state (behavior per
    `docs/kanban.md`, unchanged).
 8. **Merged-lane variant**: no per-step legs on the board; mono lines for
    **Started** and **Elapsed** separately; PR badge (§5.5). Fill is the same
@@ -441,9 +445,14 @@ prototype, so this spec governs:
   reached lifecycle lane (BUILD, REVIEW, and **PR** on GitHub / **MR** on
   GitLab) collapses by default into expandable journey-style legs — PR is not
   left as a permanent full chip strip just because focus falls back to the
-  last phase. Duration on each leg is the sum of that lane’s chip
-  `durationMs` (same rules as earlier-lane summaries / archive legs §4.5).
-  Non-complete work still expands only the current focus lane.
+  last phase. Collapsed legs share **one horizontal wrap row** (same density
+  language as archive footer legs §4.5; not one vertical line per leg).
+  Expanding a leg leaves the summary row in place and shows that lane’s
+  fine-grained chips in a strip under the row. Duration on each leg is the
+  sum of that lane’s chip `durationMs` (same rules as earlier-lane summaries
+  / archive legs §4.5). Non-complete work still expands only the current
+  focus lane; when multiple earlier-lane summaries are present they use the
+  same single-line wrap treatment.
 - **Parent issue groups**: `<details>` card, 1.5px border — summary with
   parent link, "n/m closed" mono, chevron, parent actions menu; children
   with a 2px `--line-soft` left rule.
@@ -545,6 +554,14 @@ fill color, never small text on white — body-text contrast stays ≥ 4.5:1).
 
 Mono 0.56rem (board) / 0.85rem (archive), 1.5px ink border; board padding
 0.16–0.2rem/0.38–0.44rem, archive legs 0.4rem/0.7rem. Whitespace-nowrap.
+
+**Collapsed multi-leg layout (Kanban tickets, repos lifecycle chrome, archive
+footer):** summary legs share one `flex flex-wrap` row (`ui.legRow` /
+`ui.archiveFoot`). They wrap only when card/column width requires it — never
+stacked as one vertical line per leg by default (#784). Expanded detail is a
+full-width chip strip under that row (summary buttons stay on the row with
+▸/▾). Keep `aria-expanded` / `aria-controls` on each expandable leg button.
+
 Five states:
 
 | State | Treatment | Example |

--- a/docs/kanban.md
+++ b/docs/kanban.md
@@ -130,6 +130,9 @@ least one chip, show one summary row instead of those chips:
 
 - Collapsed: `▸ {Lane name}  {duration}`
 - Expanded: `▾ {Lane name}  {duration}` plus that lane’s chips underneath
+- Multiple earlier-lane summaries share **one horizontal wrap row** (same
+  density as repos COMPLETE legs / archive foot); they wrap only when the
+  ticket column is too narrow.
 
 Rules:
 
@@ -138,10 +141,11 @@ Rules:
   format like chip durations. Not live-ticking.
 - Expand/collapse is **per earlier lane**, independent, and **ephemeral**
   (local UI state; not persisted).
-- Expanding a summary **replaces** the collapsed row with the header + chips
-  for that lane; other earlier lanes stay summaries until expanded.
+- Expanding a summary keeps the summary buttons on the wrap row (▸ → ▾) and
+  reveals that lane’s chips as a full-width strip beneath; other earlier
+  lanes stay summaries until expanded.
 - **Current-focus-lane chips** are always fully listed after all earlier-lane
-  blocks.
+  summary buttons (same wrap row when space allows).
 - Do **not** auto-expand an earlier lane because a chip there failed or needs
   human; Attention and the status badge carry alarm. Optional later: tint a
   summary when any chip in that lane is non-success.
@@ -225,5 +229,6 @@ Shared pieces:
 - Lane classifier, tab keyboard behavior, filtering, and mobile lane selection
   are covered by tests.
 - Kanban tickets collapse earlier-lane lifecycle chips into per-lane summary
-  rows (name + summed duration); focus-lane chips stay expanded; expand state
-  is local and ephemeral; Home chip rows are unaffected.
+  chips on one wrap row (name + summed duration); focus-lane chips stay
+  expanded; expand state is local and ephemeral; Home chip rows are
+  unaffected.


### PR DESCRIPTION
## Why

On `/repos`, collapsed journey-leg summaries (BUILD / REVIEW / PR|MR) for a
work item were stacked on separate lines via a column flex layout. Scanning
completed and mid-flight items without expanding was needlessly tall. The
Completed archive already puts condensed legs on one wrap row; repos and
shared Kanban lifecycle chrome should match that denser default.

## What changed

- **`WorkItemLifecycleStatus` multi-block layout** — collapsed earlier-lane
  summary buttons share one horizontal wrap row; expanded fine-grained step
  chips render as full-width strips beneath that row (same structure as
  archive foot legs). Expand/collapse and `aria-expanded` /
  `aria-controls` are unchanged.
- **Shared UI recipes** — `ui.legRow` (and `archiveFoot` via shared
  `legRowClasses`) plus `ui.lifecycleLegBlocks` for the outer stack.
- **Docs** — `docs/harness-design-system.md` (§4.4, §4.6, §5.2) and
  `docs/kanban.md` describe the inline/wrap collapsed default.
- **Tests** — `repos-interchange` source-slice assertions lock the multi-leg
  container recipes and shared class string.

Planning logic in `planLifecycleChipPresentation` is unchanged (which lanes
collapse and duration rules stay the same).

## Verification

- `bunx nx test harness` (unit suites including `repos-interchange`,
  pipeline-lanes, kanban-route)
- Biome check on touched harness TS/TSX
- Local review: no open findings

## Notes

Kanban tickets share this chrome, so they get the same wrap-row density;
narrow columns wrap as intended. Expanded step chips still reflow freely
and are not forced onto one line.

Closes #784