### PR TITLE
feat(harness): stamped-plate hierarchy for settings dialogs

### DIFF
--- a/apps/harness/src/routes/__root.tsx
+++ b/apps/harness/src/routes/__root.tsx
@@ -859,7 +859,7 @@ function SettingsChrome() {
               )}
           </div>
 
-          <div className={ui.dialogBody}>
+          <div className={ui.dialogBodySectioned}>
             {config.isPending || modelsLoading ? (
               <p className={ui.dialogLoading}>Loading settings...</p>
             ) : config.isError ||
@@ -875,329 +875,393 @@ function SettingsChrome() {
               </Banner>
             ) : (
               <>
-                <label className={ui.dialogField}>
-                  Default Agent Backend
-                  <select
-                    name="selectedAgentBackend"
-                    value={selectedAgentBackend}
-                    disabled={backendChangeBlocked || updateConfig.isPending}
-                    onChange={(event) => {
-                      void applyAgentBackendSelection(event.target.value)
-                    }}
-                  >
-                    {(backendStatus.data?.agentBackends ?? []).map(
-                      (backend) => (
-                        <option key={backend.id} value={backend.id}>
-                          {backend.label}
-                        </option>
-                      ),
-                    )}
-                  </select>
-                  <span className={ui.dialogFieldHint}>
-                    {backendChangeBlocked
-                      ? `${blockingUnfinishedWorkItemCount} unfinished Work Item${
-                          blockingUnfinishedWorkItemCount === 1 ? "" : "s"
-                        } on Repositories inheriting the harness default — finish or abandon them before changing the default Agent Backend.${
-                          unfinishedWorkItemCount >
-                          blockingUnfinishedWorkItemCount
-                            ? ` (${unfinishedWorkItemCount} unfinished fleet-wide.)`
-                            : ""
-                        }`
-                      : "Activates immediately on Save when no inheriting Work Items are unfinished. Model prefs are remembered per backend. Repository overrides are independent."}
-                  </span>
-                </label>
-
-                <div className={ui.dialogStatusBlock}>
-                  <div className={ui.dialogStatusHead}>
-                    <p className={ui.dialogStatusLabel}>
-                      Active Agent Backends
-                    </p>
-                    <button
-                      type="button"
-                      className={ui.plateMini}
-                      disabled={recheckBusy || backendChanging}
-                      onClick={() => {
-                        void recheckAllBackends()
+                <section
+                  className={ui.dialogSection}
+                  aria-labelledby="settings-sec-agent"
+                >
+                  <div className={ui.dialogSectionHead}>
+                    <h3
+                      id="settings-sec-agent"
+                      className={ui.dialogSectionTitle}
+                    >
+                      Agent backend
+                    </h3>
+                    <span className={ui.dialogSectionMeta}>
+                      Session default
+                    </span>
+                  </div>
+                  <label className={ui.dialogField}>
+                    Default Agent Backend
+                    <select
+                      className={ui.dialogInput}
+                      name="selectedAgentBackend"
+                      value={selectedAgentBackend}
+                      disabled={backendChangeBlocked || updateConfig.isPending}
+                      onChange={(event) => {
+                        void applyAgentBackendSelection(event.target.value)
                       }}
                     >
-                      {recheckAllPending ? "Rechecking all…" : "Recheck all"}
-                    </button>
-                  </div>
-                  {(statuses.length > 0
-                    ? statuses
-                    : defaultStatus !== undefined
-                      ? [defaultStatus as AgentBackendStatusRow]
-                      : []
-                  ).map((row) => {
-                    const isDefault = row.backend.id === savedAgentBackend
-                    const rowRechecking = recheckingBackendId === row.backend.id
-                    return (
-                      <div key={row.backend.id} className={ui.dialogStatusRow}>
-                        <p className="m-0">
-                          <strong>{row.backend.label}</strong>
-                          {isDefault ? " · Default" : null}
-                          {row.kind === "READY" ? " · Ready" : " · Unavailable"}
-                          {backendChanging &&
-                          row.backend.id === selectedAgentBackend
-                            ? " · Previewing selection"
-                            : null}
-                          {row.kind === "UNAVAILABLE" && row.reason !== null
-                            ? ` — ${row.reason}`
-                            : null}
-                        </p>
-                        <button
-                          type="button"
-                          className={ui.plateMini}
-                          disabled={recheckBusy || backendChanging}
-                          onClick={() => {
-                            setRecheckAllFailures([])
-                            recheckBackend.mutate(row.backend.id)
-                          }}
+                      {(backendStatus.data?.agentBackends ?? []).map(
+                        (backend) => (
+                          <option key={backend.id} value={backend.id}>
+                            {backend.label}
+                          </option>
+                        ),
+                      )}
+                    </select>
+                    <span className={ui.dialogFieldHint}>
+                      {backendChangeBlocked
+                        ? `${blockingUnfinishedWorkItemCount} unfinished Work Item${
+                            blockingUnfinishedWorkItemCount === 1 ? "" : "s"
+                          } on Repositories inheriting the harness default — finish or abandon them before changing the default Agent Backend.${
+                            unfinishedWorkItemCount >
+                            blockingUnfinishedWorkItemCount
+                              ? ` (${unfinishedWorkItemCount} unfinished fleet-wide.)`
+                              : ""
+                          }`
+                        : "Activates immediately on Save when no inheriting Work Items are unfinished. Model prefs are remembered per backend. Repository overrides are independent."}
+                    </span>
+                  </label>
+
+                  <div className={ui.dialogStatusBlock}>
+                    <div className={ui.dialogStatusHead}>
+                      <p className={ui.dialogStatusLabel}>
+                        Active Agent Backends
+                      </p>
+                      <button
+                        type="button"
+                        className={ui.plateMini}
+                        disabled={recheckBusy || backendChanging}
+                        onClick={() => {
+                          void recheckAllBackends()
+                        }}
+                      >
+                        {recheckAllPending ? "Rechecking all…" : "Recheck all"}
+                      </button>
+                    </div>
+                    {(statuses.length > 0
+                      ? statuses
+                      : defaultStatus !== undefined
+                        ? [defaultStatus as AgentBackendStatusRow]
+                        : []
+                    ).map((row) => {
+                      const isDefault = row.backend.id === savedAgentBackend
+                      const rowRechecking =
+                        recheckingBackendId === row.backend.id
+                      return (
+                        <div
+                          key={row.backend.id}
+                          className={ui.dialogStatusRow}
                         >
-                          {rowRechecking
-                            ? "Rechecking…"
-                            : `Recheck ${row.backend.label}`}
-                        </button>
-                      </div>
-                    )
-                  })}
-                  {statuses.length === 0 && defaultStatus === undefined && (
-                    <p className={ui.dialogLoading}>
-                      No Active Agent Backend status yet.
-                    </p>
+                          <p className="m-0">
+                            <strong>{row.backend.label}</strong>
+                            {isDefault ? " · Default" : null}
+                            {row.kind === "READY"
+                              ? " · Ready"
+                              : " · Unavailable"}
+                            {backendChanging &&
+                            row.backend.id === selectedAgentBackend
+                              ? " · Previewing selection"
+                              : null}
+                            {row.kind === "UNAVAILABLE" && row.reason !== null
+                              ? ` — ${row.reason}`
+                              : null}
+                          </p>
+                          <button
+                            type="button"
+                            className={ui.plateMini}
+                            disabled={recheckBusy || backendChanging}
+                            onClick={() => {
+                              setRecheckAllFailures([])
+                              recheckBackend.mutate(row.backend.id)
+                            }}
+                          >
+                            {rowRechecking
+                              ? "Rechecking…"
+                              : `Recheck ${row.backend.label}`}
+                          </button>
+                        </div>
+                      )
+                    })}
+                    {statuses.length === 0 && defaultStatus === undefined && (
+                      <p className={ui.dialogLoading}>
+                        No Active Agent Backend status yet.
+                      </p>
+                    )}
+                  </div>
+
+                  {backendChanging && previewError !== null && (
+                    <Banner
+                      className={ui.bannerCompact}
+                      tone="alarm"
+                      tag="Preview"
+                      role="alert"
+                    >
+                      Preview failed: {previewError}. Model fields stay disabled
+                      until preview succeeds. Active backend is unchanged until
+                      Save.
+                    </Banner>
                   )}
-                </div>
+                </section>
 
-                {backendChanging && previewError !== null && (
-                  <Banner
-                    className={ui.bannerCompact}
-                    tone="alarm"
-                    tag="Preview"
-                    role="alert"
-                  >
-                    Preview failed: {previewError}. Model fields stay disabled
-                    until preview succeeds. Active backend is unchanged until
-                    Save.
-                  </Banner>
-                )}
+                <section
+                  className={ui.dialogSection}
+                  aria-labelledby="settings-sec-models"
+                >
+                  <div className={ui.dialogSectionHead}>
+                    <h3
+                      id="settings-sec-models"
+                      className={ui.dialogSectionTitle}
+                    >
+                      Models
+                    </h3>
+                    <span className={ui.dialogSectionMeta}>Build · Review</span>
+                  </div>
 
-                <label className={cx(ui.dialogField, ui.dialogFieldMono)}>
-                  Build model
-                  <select
-                    name="defaultModel"
-                    value={defaultModel}
-                    onChange={(event) => {
-                      const nextModel = event.target.value
-                      setDefaultModel(nextModel)
-                      const nextVariants = variantsForModel(
-                        catalogModels,
-                        nextModel,
-                      )
-                      setDefaultVariant((current) =>
-                        reconcileVariantForModel(current, nextVariants),
-                      )
-                      if (reviewModel.length === 0) {
-                        setReviewVariant((current) =>
+                  <label className={cx(ui.dialogField, ui.dialogFieldMono)}>
+                    Build model
+                    <select
+                      className={cx(ui.dialogInput, ui.dialogInputMono)}
+                      name="defaultModel"
+                      value={defaultModel}
+                      onChange={(event) => {
+                        const nextModel = event.target.value
+                        setDefaultModel(nextModel)
+                        const nextVariants = variantsForModel(
+                          catalogModels,
+                          nextModel,
+                        )
+                        setDefaultVariant((current) =>
                           reconcileVariantForModel(current, nextVariants),
                         )
-                      }
-                    }}
-                    required={!backendChanging}
-                    disabled={modelsDisabled}
-                  >
-                    {defaultModel.length === 0 && (
-                      <option value="">
-                        {previewPending
-                          ? "Loading catalog…"
-                          : "Select a build model"}
-                      </option>
-                    )}
-                    {hasUnavailableBuildModel && (
-                      <option value={defaultModel}>
-                        {defaultModel} (not in Agent Model catalog)
-                      </option>
-                    )}
-                    {(catalogModels ?? []).map((model) => (
-                      <option key={model.id} value={model.id}>
-                        {model.id}
-                      </option>
-                    ))}
-                  </select>
-                  <span className={ui.dialogFieldHint}>
-                    Used for implement and other build steps.
-                  </span>
-                </label>
-
-                {defaultModel.length > 0 && hasUnavailableBuildModel ? (
-                  <Banner
-                    className={ui.bannerCompact}
-                    tone="alarm"
-                    tag="Model"
-                    role="alert"
-                  >
-                    Build effort (thinking) is unavailable — the selected model
-                    is not in the Agent Model catalog. Choose another build
-                    model.
-                  </Banner>
-                ) : defaultModel.length > 0 && buildVariants.length === 0 ? (
-                  <p className={ui.dialogNote}>
-                    Build effort (thinking) is unavailable — this model has no
-                    effort (thinking) options.
-                  </p>
-                ) : (
-                  <label className={ui.dialogField}>
-                    Build effort (thinking)
-                    <select
-                      name="defaultThinkingLevel"
-                      value={defaultThinkingLevel}
-                      onChange={(event) =>
-                        setDefaultVariant(event.target.value)
-                      }
-                      disabled={modelsDisabled || defaultModel.length === 0}
+                        if (reviewModel.length === 0) {
+                          setReviewVariant((current) =>
+                            reconcileVariantForModel(current, nextVariants),
+                          )
+                        }
+                      }}
+                      required={!backendChanging}
+                      disabled={modelsDisabled}
                     >
-                      <option value="">
-                        {buildVariants.length === 0
-                          ? "Model default (no effort (thinking) options)"
-                          : "Model default"}
-                      </option>
-                      {hasCustomBuildVariant && (
-                        <option value={defaultThinkingLevel}>
-                          {formatVariantLabel(defaultThinkingLevel)}
+                      {defaultModel.length === 0 && (
+                        <option value="">
+                          {previewPending
+                            ? "Loading catalog…"
+                            : "Select a build model"}
                         </option>
                       )}
-                      {buildVariants.map((variant) => (
-                        <option key={variant} value={variant}>
-                          {formatVariantLabel(variant)}
+                      {hasUnavailableBuildModel && (
+                        <option value={defaultModel}>
+                          {defaultModel} (not in Agent Model catalog)
+                        </option>
+                      )}
+                      {(catalogModels ?? []).map((model) => (
+                        <option key={model.id} value={model.id}>
+                          {model.id}
                         </option>
                       ))}
                     </select>
                     <span className={ui.dialogFieldHint}>
-                      Optional effort (thinking) for this model. Options come
-                      from the selected model.
+                      Used for implement and other build steps.
                     </span>
                   </label>
-                )}
 
-                <label className={cx(ui.dialogField, ui.dialogFieldMono)}>
-                  Review model
-                  <select
-                    name="reviewModel"
-                    value={reviewModel}
-                    disabled={modelsDisabled}
-                    onChange={(event) => {
-                      const nextModel = event.target.value
-                      setReviewModel(nextModel)
-                      const nextVariants = variantsForModel(
-                        catalogModels,
-                        nextModel.length > 0 ? nextModel : defaultModel,
-                      )
-                      setReviewVariant((current) =>
-                        reconcileVariantForModel(current, nextVariants),
-                      )
-                    }}
-                  >
-                    <option value="">Same as build model</option>
-                    {hasUnavailableReviewModel && (
-                      <option value={reviewModel}>
-                        {reviewModel} (not in Agent Model catalog)
-                      </option>
-                    )}
-                    {(catalogModels ?? []).map((model) => (
-                      <option key={`review-${model.id}`} value={model.id}>
-                        {model.id}
-                      </option>
-                    ))}
-                  </select>
-                  <span className={ui.dialogFieldHint}>
-                    Used only for the review step. Empty uses the build model.
-                  </span>
-                </label>
-
-                {reviewThinkingLevelSourceModel.length > 0 &&
-                ((reviewModel.length > 0 && hasUnavailableReviewModel) ||
-                  (reviewModel.length === 0 && hasUnavailableBuildModel)) ? (
-                  <Banner
-                    className={ui.bannerCompact}
-                    tone="alarm"
-                    tag="Model"
-                    role="alert"
-                  >
-                    Review effort (thinking) is unavailable — the selected model
-                    is not in the Agent Model catalog. Choose another model or
-                    use the build model.
-                  </Banner>
-                ) : reviewThinkingLevelSourceModel.length > 0 &&
-                  reviewThinkingLevels.length === 0 ? (
-                  <p className={ui.dialogNote}>
-                    Review effort (thinking) is unavailable — this model has no
-                    effort (thinking) options.
-                  </p>
-                ) : (
-                  <label className={ui.dialogField}>
-                    Review effort (thinking)
-                    <select
-                      name="reviewThinkingLevel"
-                      value={reviewThinkingLevel}
-                      onChange={(event) => setReviewVariant(event.target.value)}
-                      disabled={
-                        modelsDisabled ||
-                        reviewThinkingLevelSourceModel.length === 0 ||
-                        reviewThinkingLevels.length === 0
-                      }
+                  {defaultModel.length > 0 && hasUnavailableBuildModel ? (
+                    <Banner
+                      className={ui.bannerCompact}
+                      tone="alarm"
+                      tag="Model"
+                      role="alert"
                     >
-                      <option value="">Same as build effort (thinking)</option>
-                      {hasCustomReviewVariant && (
-                        <option value={reviewThinkingLevel}>
-                          {formatVariantLabel(reviewThinkingLevel)}
+                      Build effort (thinking) is unavailable — the selected
+                      model is not in the Agent Model catalog. Choose another
+                      build model.
+                    </Banner>
+                  ) : defaultModel.length > 0 && buildVariants.length === 0 ? (
+                    <p className={ui.dialogNote}>
+                      Build effort (thinking) is unavailable — this model has no
+                      effort (thinking) options.
+                    </p>
+                  ) : (
+                    <label className={ui.dialogField}>
+                      Build effort (thinking)
+                      <select
+                        className={ui.dialogInput}
+                        name="defaultThinkingLevel"
+                        value={defaultThinkingLevel}
+                        onChange={(event) =>
+                          setDefaultVariant(event.target.value)
+                        }
+                        disabled={modelsDisabled || defaultModel.length === 0}
+                      >
+                        <option value="">
+                          {buildVariants.length === 0
+                            ? "Model default (no effort (thinking) options)"
+                            : "Model default"}
+                        </option>
+                        {hasCustomBuildVariant && (
+                          <option value={defaultThinkingLevel}>
+                            {formatVariantLabel(defaultThinkingLevel)}
+                          </option>
+                        )}
+                        {buildVariants.map((variant) => (
+                          <option key={variant} value={variant}>
+                            {formatVariantLabel(variant)}
+                          </option>
+                        ))}
+                      </select>
+                      <span className={ui.dialogFieldHint}>
+                        Optional effort (thinking) for this model. Options come
+                        from the selected model.
+                      </span>
+                    </label>
+                  )}
+
+                  <label className={cx(ui.dialogField, ui.dialogFieldMono)}>
+                    Review model
+                    <select
+                      className={cx(ui.dialogInput, ui.dialogInputMono)}
+                      name="reviewModel"
+                      value={reviewModel}
+                      disabled={modelsDisabled}
+                      onChange={(event) => {
+                        const nextModel = event.target.value
+                        setReviewModel(nextModel)
+                        const nextVariants = variantsForModel(
+                          catalogModels,
+                          nextModel.length > 0 ? nextModel : defaultModel,
+                        )
+                        setReviewVariant((current) =>
+                          reconcileVariantForModel(current, nextVariants),
+                        )
+                      }}
+                    >
+                      <option value="">Same as build model</option>
+                      {hasUnavailableReviewModel && (
+                        <option value={reviewModel}>
+                          {reviewModel} (not in Agent Model catalog)
                         </option>
                       )}
-                      {reviewThinkingLevels.map((variant) => (
-                        <option key={`review-${variant}`} value={variant}>
-                          {formatVariantLabel(variant)}
+                      {(catalogModels ?? []).map((model) => (
+                        <option key={`review-${model.id}`} value={model.id}>
+                          {model.id}
                         </option>
                       ))}
                     </select>
+                    <span className={ui.dialogFieldHint}>
+                      Used only for the review step. Empty uses the build model.
+                    </span>
                   </label>
-                )}
 
-                <label className={ui.dialogField}>
-                  Max concurrent Agent Turns
-                  <input
-                    name="maxConcurrentAgentTurns"
-                    type="number"
-                    min={1}
-                    step={1}
-                    required
-                    value={maxConcurrentAgentTurns}
-                    onChange={(event) =>
-                      setMaxConcurrentOpencodeSessions(event.target.value)
-                    }
-                  />
-                  <span className={ui.dialogFieldHint}>
-                    Caps how many Agent Turn CLI processes run at once (default
-                    2). Agent-free steps and model listing are not counted.
-                  </span>
-                </label>
+                  {reviewThinkingLevelSourceModel.length > 0 &&
+                  ((reviewModel.length > 0 && hasUnavailableReviewModel) ||
+                    (reviewModel.length === 0 && hasUnavailableBuildModel)) ? (
+                    <Banner
+                      className={ui.bannerCompact}
+                      tone="alarm"
+                      tag="Model"
+                      role="alert"
+                    >
+                      Review effort (thinking) is unavailable — the selected
+                      model is not in the Agent Model catalog. Choose another
+                      model or use the build model.
+                    </Banner>
+                  ) : reviewThinkingLevelSourceModel.length > 0 &&
+                    reviewThinkingLevels.length === 0 ? (
+                    <p className={ui.dialogNote}>
+                      Review effort (thinking) is unavailable — this model has
+                      no effort (thinking) options.
+                    </p>
+                  ) : (
+                    <label className={ui.dialogField}>
+                      Review effort (thinking)
+                      <select
+                        className={ui.dialogInput}
+                        name="reviewThinkingLevel"
+                        value={reviewThinkingLevel}
+                        onChange={(event) =>
+                          setReviewVariant(event.target.value)
+                        }
+                        disabled={
+                          modelsDisabled ||
+                          reviewThinkingLevelSourceModel.length === 0 ||
+                          reviewThinkingLevels.length === 0
+                        }
+                      >
+                        <option value="">
+                          Same as build effort (thinking)
+                        </option>
+                        {hasCustomReviewVariant && (
+                          <option value={reviewThinkingLevel}>
+                            {formatVariantLabel(reviewThinkingLevel)}
+                          </option>
+                        )}
+                        {reviewThinkingLevels.map((variant) => (
+                          <option key={`review-${variant}`} value={variant}>
+                            {formatVariantLabel(variant)}
+                          </option>
+                        ))}
+                      </select>
+                    </label>
+                  )}
+                </section>
 
-                <label className={ui.dialogField}>
-                  Max concurrent Work Items
-                  <input
-                    name="maxConcurrentWorkItems"
-                    type="number"
-                    min={1}
-                    step={1}
-                    required
-                    value={maxConcurrentWorkItems}
-                    onChange={(event) =>
-                      setMaxConcurrentWorkItems(event.target.value)
-                    }
-                  />
-                  <span className={ui.dialogFieldHint}>
-                    Caps how many Work Items may be Admitted at once (Worker
-                    Slots, default 5). Extra Implement requests wait for a free
-                    slot.
-                  </span>
-                </label>
+                <section
+                  className={ui.dialogSection}
+                  aria-labelledby="settings-sec-concurrency"
+                >
+                  <div className={ui.dialogSectionHead}>
+                    <h3
+                      id="settings-sec-concurrency"
+                      className={ui.dialogSectionTitle}
+                    >
+                      Concurrency
+                    </h3>
+                    <span className={ui.dialogSectionMeta}>Fleet caps</span>
+                  </div>
+
+                  <label className={ui.dialogField}>
+                    Max concurrent Agent Turns
+                    <input
+                      className={ui.dialogInput}
+                      name="maxConcurrentAgentTurns"
+                      type="number"
+                      min={1}
+                      step={1}
+                      required
+                      value={maxConcurrentAgentTurns}
+                      onChange={(event) =>
+                        setMaxConcurrentOpencodeSessions(event.target.value)
+                      }
+                    />
+                    <span className={ui.dialogFieldHint}>
+                      Caps how many Agent Turn CLI processes run at once
+                      (default 2). Agent-free steps and model listing are not
+                      counted.
+                    </span>
+                  </label>
+
+                  <label className={ui.dialogField}>
+                    Max concurrent Work Items
+                    <input
+                      className={ui.dialogInput}
+                      name="maxConcurrentWorkItems"
+                      type="number"
+                      min={1}
+                      step={1}
+                      required
+                      value={maxConcurrentWorkItems}
+                      onChange={(event) =>
+                        setMaxConcurrentWorkItems(event.target.value)
+                      }
+                    />
+                    <span className={ui.dialogFieldHint}>
+                      Caps how many Work Items may be Admitted at once (Worker
+                      Slots, default 5). Extra Implement requests wait for a
+                      free slot.
+                    </span>
+                  </label>
+                </section>
               </>
             )}
 

--- a/apps/harness/src/routes/index.tsx
+++ b/apps/harness/src/routes/index.tsx
@@ -1888,9 +1888,20 @@ function RepositoryCard({
               Backend.
             </p>
           </div>
-          <div className={ui.dialogBody}>
-            <fieldset className={ui.dialogFieldset}>
-              <legend>Forge identity</legend>
+          <div className={ui.dialogBodySectioned}>
+            <section
+              className={ui.dialogSection}
+              aria-labelledby={`repo-sec-identity-${repository.id}`}
+            >
+              <div className={ui.dialogSectionHead}>
+                <h3
+                  id={`repo-sec-identity-${repository.id}`}
+                  className={ui.dialogSectionTitle}
+                >
+                  Forge identity
+                </h3>
+                <span className={ui.dialogSectionMeta}>Path</span>
+              </div>
               <label className={ui.dialogField}>
                 Forge:
                 <select
@@ -1926,336 +1937,385 @@ function RepositoryCard({
                 GitLab identities are verified before Save. Identity changes are
                 blocked after this Repository has any Work Item.
               </span>
-            </fieldset>
-            <label className={ui.dialogCheck}>
-              <input
-                type="checkbox"
-                className="size-4"
-                checked={paused}
-                onChange={(event) => setPaused(event.target.checked)}
-              />
-              Paused
-              <span className={ui.dialogFieldHint}>
-                Skip autonomous work selection
-              </span>
-            </label>
-            <label className={ui.dialogCheck}>
-              <input
-                type="checkbox"
-                className="size-4"
-                checked={autoMerge}
-                onChange={(event) => setAutoMerge(event.target.checked)}
-              />
-              Auto-merge
-              <span className={ui.dialogFieldHint}>
-                Allow clanker merge when risk is low
-              </span>
-            </label>
-            <label className={ui.dialogCheck}>
-              <input
-                type="checkbox"
-                className="size-4"
-                checked={includeAllIssueAuthors}
-                onChange={(event) =>
-                  setIncludeAllIssueAuthors(event.target.checked)
-                }
-              />
-              Include all Issue Authors
-              <span className={ui.dialogFieldHint}>
-                Relevant Issues from every author after Refresh
-              </span>
-            </label>
-            <label className={ui.dialogField}>
-              <span className="flex items-center gap-3">
+            </section>
+
+            <section
+              className={ui.dialogSection}
+              aria-labelledby={`repo-sec-options-${repository.id}`}
+            >
+              <div className={ui.dialogSectionHead}>
+                <h3
+                  id={`repo-sec-options-${repository.id}`}
+                  className={ui.dialogSectionTitle}
+                >
+                  Options
+                </h3>
+                <span className={ui.dialogSectionMeta}>Repo preferences</span>
+              </div>
+              <label className={ui.dialogCheck}>
                 <input
                   type="checkbox"
-                  className="size-4"
-                  checked={waitForReadyForReviewChecks}
+                  className={ui.dialogCheckInput}
+                  checked={paused}
+                  onChange={(event) => setPaused(event.target.checked)}
+                />
+                Paused
+                <span className={cx(ui.dialogFieldHint, ui.dialogCheckHint)}>
+                  Skip autonomous work selection
+                </span>
+              </label>
+              <label className={ui.dialogCheck}>
+                <input
+                  type="checkbox"
+                  className={ui.dialogCheckInput}
+                  checked={autoMerge}
+                  onChange={(event) => setAutoMerge(event.target.checked)}
+                />
+                Auto-merge
+                <span className={cx(ui.dialogFieldHint, ui.dialogCheckHint)}>
+                  Allow clanker merge when risk is low
+                </span>
+              </label>
+              <label className={ui.dialogCheck}>
+                <input
+                  type="checkbox"
+                  className={ui.dialogCheckInput}
+                  checked={includeAllIssueAuthors}
                   onChange={(event) =>
-                    setWaitForReadyForReviewChecks(event.target.checked)
+                    setIncludeAllIssueAuthors(event.target.checked)
                   }
                 />
-                Wait for checks to start after ready for review
-              </span>
-              <span className={ui.dialogFieldHint}>
-                Wait up to 90 seconds for workflows that start after a PR is
-                marked ready for review. If this repository has no such
-                workflows, turn off this setting to skip the wait.
-              </span>
-            </label>
+                Include all Issue Authors
+                <span className={cx(ui.dialogFieldHint, ui.dialogCheckHint)}>
+                  Relevant Issues from every author after Refresh
+                </span>
+              </label>
+              <label className={ui.dialogField}>
+                <span className="flex items-center gap-3">
+                  <input
+                    type="checkbox"
+                    className={ui.dialogCheckInput}
+                    checked={waitForReadyForReviewChecks}
+                    onChange={(event) =>
+                      setWaitForReadyForReviewChecks(event.target.checked)
+                    }
+                  />
+                  Wait for checks to start after ready for review
+                </span>
+                <span className={ui.dialogFieldHint}>
+                  Wait up to 90 seconds for workflows that start after a PR is
+                  marked ready for review. If this repository has no such
+                  workflows, turn off this setting to skip the wait.
+                </span>
+              </label>
+            </section>
 
-            <label className={ui.dialogField}>
-              Agent Backend
-              <select
-                className={ui.dialogInput}
-                name="selectedAgentBackend"
-                value={selectedAgentBackend ?? HARNESS_DEFAULT_BACKEND_VALUE}
-                disabled={
-                  backendChangeBlocked ||
-                  updateSettings.isPending ||
-                  agentBackends.isPending
-                }
-                onChange={(event) => {
-                  applyAgentBackendSelection(event.target.value)
-                }}
-              >
-                <option value={HARNESS_DEFAULT_BACKEND_VALUE}>
-                  Harness default ({harnessDefaultBackendLabel})
-                </option>
-                {selectedAgentBackend !== null &&
-                  !(agentBackends.data ?? []).some(
-                    (backend) => backend.id === selectedAgentBackend,
-                  ) && (
-                    <option value={selectedAgentBackend}>
-                      {selectedAgentBackend}
-                    </option>
-                  )}
-                {(agentBackends.data ?? []).map((backend) => (
-                  <option key={backend.id} value={backend.id}>
-                    {backend.label}
+            <section
+              className={ui.dialogSection}
+              aria-labelledby={`repo-sec-agent-${repository.id}`}
+            >
+              <div className={ui.dialogSectionHead}>
+                <h3
+                  id={`repo-sec-agent-${repository.id}`}
+                  className={ui.dialogSectionTitle}
+                >
+                  Agent backend
+                </h3>
+                <span className={ui.dialogSectionMeta}>Override</span>
+              </div>
+              <label className={ui.dialogField}>
+                Agent Backend
+                <select
+                  className={ui.dialogInput}
+                  name="selectedAgentBackend"
+                  value={selectedAgentBackend ?? HARNESS_DEFAULT_BACKEND_VALUE}
+                  disabled={
+                    backendChangeBlocked ||
+                    updateSettings.isPending ||
+                    agentBackends.isPending
+                  }
+                  onChange={(event) => {
+                    applyAgentBackendSelection(event.target.value)
+                  }}
+                >
+                  <option value={HARNESS_DEFAULT_BACKEND_VALUE}>
+                    Harness default ({harnessDefaultBackendLabel})
                   </option>
-                ))}
-              </select>
-              <span className={ui.dialogFieldHint}>
-                {backendChangeBlocked
-                  ? `${repository.blockingUnfinishedWorkItemCount} unfinished Work Item${
-                      repository.blockingUnfinishedWorkItemCount === 1
-                        ? ""
-                        : "s"
-                    } on this Repository — finish or abandon them before changing Agent Backend.`
-                  : "Harness default inherits the global selection. Override activates on Save when the effective backend changes. Model fields in this dialog are stashed per backend while open; empty means inherit harness for that effective backend."}
-              </span>
-            </label>
+                  {selectedAgentBackend !== null &&
+                    !(agentBackends.data ?? []).some(
+                      (backend) => backend.id === selectedAgentBackend,
+                    ) && (
+                      <option value={selectedAgentBackend}>
+                        {selectedAgentBackend}
+                      </option>
+                    )}
+                  {(agentBackends.data ?? []).map((backend) => (
+                    <option key={backend.id} value={backend.id}>
+                      {backend.label}
+                    </option>
+                  ))}
+                </select>
+                <span className={ui.dialogFieldHint}>
+                  {backendChangeBlocked
+                    ? `${repository.blockingUnfinishedWorkItemCount} unfinished Work Item${
+                        repository.blockingUnfinishedWorkItemCount === 1
+                          ? ""
+                          : "s"
+                      } on this Repository — finish or abandon them before changing Agent Backend.`
+                    : "Harness default inherits the global selection. Override activates on Save when the effective backend changes. Model fields in this dialog are stashed per backend while open; empty means inherit harness for that effective backend."}
+                </span>
+              </label>
 
-            {agentBackends.isError && (
-              <Banner
-                className={ui.bannerCompact}
-                tone="alarm"
-                tag="Error"
-                role="alert"
-              >
-                Agent Backends list could not be loaded. You can still inherit
-                the harness default; override options may be incomplete.
-              </Banner>
-            )}
+              {agentBackends.isError && (
+                <Banner
+                  className={ui.bannerCompact}
+                  tone="alarm"
+                  tag="Error"
+                  role="alert"
+                >
+                  Agent Backends list could not be loaded. You can still inherit
+                  the harness default; override options may be incomplete.
+                </Banner>
+              )}
 
-            {usesPreviewCatalog && previewError !== null && (
-              <Banner
-                className={ui.bannerCompact}
-                tone="alarm"
-                tag="Error"
-                role="alert"
-              >
-                Preview failed: {previewError}. Model fields stay disabled until
-                preview succeeds.
-                {backendDraftChanging
-                  ? " Changing the effective backend cannot be saved until preview succeeds."
-                  : " Non-model settings can still be saved."}
-              </Banner>
-            )}
+              {usesPreviewCatalog && previewError !== null && (
+                <Banner
+                  className={ui.bannerCompact}
+                  tone="alarm"
+                  tag="Error"
+                  role="alert"
+                >
+                  Preview failed: {previewError}. Model fields stay disabled
+                  until preview succeeds.
+                  {backendDraftChanging
+                    ? " Changing the effective backend cannot be saved until preview succeeds."
+                    : " Non-model settings can still be saved."}
+                </Banner>
+              )}
+            </section>
 
-            {modelsLoading ? (
-              <p className={ui.dialogLoading}>Loading models...</p>
-            ) : !usesPreviewCatalog && models.isError ? (
-              <Banner
-                className={ui.bannerCompact}
-                tone="alarm"
-                tag="Error"
-                role="alert"
-              >
-                Models could not be loaded.
-              </Banner>
-            ) : (
-              <>
-                <label className={ui.dialogField}>
-                  Build model
-                  <select
-                    className={cx(ui.dialogInput, ui.dialogInputMono)}
-                    value={defaultModel}
-                    disabled={modelsDisabled}
-                    onChange={(event) => {
-                      const nextModel = event.target.value
-                      setDefaultModel(nextModel)
-                      const sourceModel =
-                        nextModel.length > 0 ? nextModel : harnessBuildForSource
-                      const nextVariants = variantsForModel(
-                        catalogModels,
-                        sourceModel,
-                      )
-                      setDefaultVariant((current) =>
-                        reconcileVariantForModel(current, nextVariants),
-                      )
-                      if (reviewModel.length === 0) {
-                        const reviewSource =
+            <section
+              className={ui.dialogSection}
+              aria-labelledby={`repo-sec-models-${repository.id}`}
+            >
+              <div className={ui.dialogSectionHead}>
+                <h3
+                  id={`repo-sec-models-${repository.id}`}
+                  className={ui.dialogSectionTitle}
+                >
+                  Models
+                </h3>
+                <span className={ui.dialogSectionMeta}>Build · Review</span>
+              </div>
+
+              {modelsLoading ? (
+                <p className={ui.dialogLoading}>Loading models...</p>
+              ) : !usesPreviewCatalog && models.isError ? (
+                <Banner
+                  className={ui.bannerCompact}
+                  tone="alarm"
+                  tag="Error"
+                  role="alert"
+                >
+                  Models could not be loaded.
+                </Banner>
+              ) : (
+                <>
+                  <label className={ui.dialogField}>
+                    Build model
+                    <select
+                      className={cx(ui.dialogInput, ui.dialogInputMono)}
+                      value={defaultModel}
+                      disabled={modelsDisabled}
+                      onChange={(event) => {
+                        const nextModel = event.target.value
+                        setDefaultModel(nextModel)
+                        const sourceModel =
                           nextModel.length > 0
                             ? nextModel
-                            : harnessReviewForSource.length > 0
-                              ? harnessReviewForSource
-                              : harnessBuildForSource
+                            : harnessBuildForSource
+                        const nextVariants = variantsForModel(
+                          catalogModels,
+                          sourceModel,
+                        )
+                        setDefaultVariant((current) =>
+                          reconcileVariantForModel(current, nextVariants),
+                        )
+                        if (reviewModel.length === 0) {
+                          const reviewSource =
+                            nextModel.length > 0
+                              ? nextModel
+                              : harnessReviewForSource.length > 0
+                                ? harnessReviewForSource
+                                : harnessBuildForSource
+                          setReviewVariant((current) =>
+                            reconcileVariantForModel(
+                              current,
+                              variantsForModel(catalogModels, reviewSource),
+                            ),
+                          )
+                        }
+                      }}
+                    >
+                      <option value="">
+                        Harness default ({harnessDefaultModel})
+                      </option>
+                      {hasUnavailableBuildModel && (
+                        <option value={defaultModel}>
+                          {defaultModel} (not in Agent Model catalog)
+                        </option>
+                      )}
+                      {(catalogModels ?? []).map((model) => (
+                        <option key={model.id} value={model.id}>
+                          {model.id}
+                        </option>
+                      ))}
+                    </select>
+                  </label>
+                  {buildVariantSourceModel.length > 0 &&
+                  buildVariantSourceUnavailable ? (
+                    <Banner
+                      className={ui.bannerCompact}
+                      tone="alarm"
+                      tag="Error"
+                      role="alert"
+                    >
+                      Build effort (thinking) override is unavailable — the
+                      selected model is not in the Agent Model catalog. Use
+                      harness default or pick another model.
+                    </Banner>
+                  ) : buildVariantSourceModel.length > 0 &&
+                    buildVariants.length === 0 ? (
+                    <p className={ui.dialogNote}>
+                      Build effort (thinking) override is unavailable — this
+                      model has no effort (thinking) options. Use harness
+                      default or pick another model.
+                    </p>
+                  ) : (
+                    <label className={ui.dialogField}>
+                      Build effort (thinking)
+                      <select
+                        className={ui.dialogInput}
+                        value={defaultThinkingLevel}
+                        onChange={(event) =>
+                          setDefaultVariant(event.target.value)
+                        }
+                        disabled={
+                          modelsDisabled ||
+                          (buildVariantSourceModel.length > 0 &&
+                            buildVariants.length === 0)
+                        }
+                      >
+                        <option value="">
+                          Harness default ({harnessDefaultVariant})
+                        </option>
+                        {hasCustomBuildVariant && (
+                          <option value={defaultThinkingLevel}>
+                            {formatVariantLabel(defaultThinkingLevel)}
+                          </option>
+                        )}
+                        {buildVariants.map((variant) => (
+                          <option key={variant} value={variant}>
+                            {formatVariantLabel(variant)}
+                          </option>
+                        ))}
+                      </select>
+                    </label>
+                  )}
+                  <label className={ui.dialogField}>
+                    Review model
+                    <select
+                      className={cx(ui.dialogInput, ui.dialogInputMono)}
+                      value={reviewModel}
+                      disabled={modelsDisabled}
+                      onChange={(event) => {
+                        const nextModel = event.target.value
+                        setReviewModel(nextModel)
+                        const sourceModel =
+                          nextModel.length > 0
+                            ? nextModel
+                            : defaultModel.length > 0
+                              ? defaultModel
+                              : harnessReviewForSource.length > 0
+                                ? harnessReviewForSource
+                                : harnessBuildForSource
                         setReviewVariant((current) =>
                           reconcileVariantForModel(
                             current,
-                            variantsForModel(catalogModels, reviewSource),
+                            variantsForModel(catalogModels, sourceModel),
                           ),
                         )
-                      }
-                    }}
-                  >
-                    <option value="">
-                      Harness default ({harnessDefaultModel})
-                    </option>
-                    {hasUnavailableBuildModel && (
-                      <option value={defaultModel}>
-                        {defaultModel} (not in Agent Model catalog)
-                      </option>
-                    )}
-                    {(catalogModels ?? []).map((model) => (
-                      <option key={model.id} value={model.id}>
-                        {model.id}
-                      </option>
-                    ))}
-                  </select>
-                </label>
-                {buildVariantSourceModel.length > 0 &&
-                buildVariantSourceUnavailable ? (
-                  <Banner
-                    className={ui.bannerCompact}
-                    tone="alarm"
-                    tag="Error"
-                    role="alert"
-                  >
-                    Build effort (thinking) override is unavailable — the
-                    selected model is not in the Agent Model catalog. Use
-                    harness default or pick another model.
-                  </Banner>
-                ) : buildVariantSourceModel.length > 0 &&
-                  buildVariants.length === 0 ? (
-                  <p className={ui.dialogNote}>
-                    Build effort (thinking) override is unavailable — this model
-                    has no effort (thinking) options. Use harness default or
-                    pick another model.
-                  </p>
-                ) : (
-                  <label className={ui.dialogField}>
-                    Build effort (thinking)
-                    <select
-                      className={ui.dialogInput}
-                      value={defaultThinkingLevel}
-                      onChange={(event) =>
-                        setDefaultVariant(event.target.value)
-                      }
-                      disabled={
-                        modelsDisabled ||
-                        (buildVariantSourceModel.length > 0 &&
-                          buildVariants.length === 0)
-                      }
+                      }}
                     >
                       <option value="">
-                        Harness default ({harnessDefaultVariant})
+                        Harness default ({harnessReviewModel})
                       </option>
-                      {hasCustomBuildVariant && (
-                        <option value={defaultThinkingLevel}>
-                          {formatVariantLabel(defaultThinkingLevel)}
+                      {hasUnavailableReviewModel && (
+                        <option value={reviewModel}>
+                          {reviewModel} (not in Agent Model catalog)
                         </option>
                       )}
-                      {buildVariants.map((variant) => (
-                        <option key={variant} value={variant}>
-                          {formatVariantLabel(variant)}
+                      {(catalogModels ?? []).map((model) => (
+                        <option key={`review-${model.id}`} value={model.id}>
+                          {model.id}
                         </option>
                       ))}
                     </select>
                   </label>
-                )}
-                <label className={ui.dialogField}>
-                  Review model
-                  <select
-                    className={cx(ui.dialogInput, ui.dialogInputMono)}
-                    value={reviewModel}
-                    disabled={modelsDisabled}
-                    onChange={(event) => {
-                      const nextModel = event.target.value
-                      setReviewModel(nextModel)
-                      const sourceModel =
-                        nextModel.length > 0
-                          ? nextModel
-                          : defaultModel.length > 0
-                            ? defaultModel
-                            : harnessReviewForSource.length > 0
-                              ? harnessReviewForSource
-                              : harnessBuildForSource
-                      setReviewVariant((current) =>
-                        reconcileVariantForModel(
-                          current,
-                          variantsForModel(catalogModels, sourceModel),
-                        ),
-                      )
-                    }}
-                  >
-                    <option value="">
-                      Harness default ({harnessReviewModel})
-                    </option>
-                    {hasUnavailableReviewModel && (
-                      <option value={reviewModel}>
-                        {reviewModel} (not in Agent Model catalog)
-                      </option>
-                    )}
-                    {(catalogModels ?? []).map((model) => (
-                      <option key={`review-${model.id}`} value={model.id}>
-                        {model.id}
-                      </option>
-                    ))}
-                  </select>
-                </label>
-                {reviewThinkingLevelSourceModel.length > 0 &&
-                reviewThinkingLevelSourceUnavailable ? (
-                  <Banner
-                    className={ui.bannerCompact}
-                    tone="alarm"
-                    tag="Error"
-                    role="alert"
-                  >
-                    Review effort (thinking) override is unavailable — the
-                    selected model is not in the Agent Model catalog. Use
-                    harness default or pick another model.
-                  </Banner>
-                ) : reviewThinkingLevelSourceModel.length > 0 &&
-                  reviewThinkingLevels.length === 0 ? (
-                  <p className={ui.dialogNote}>
-                    Review effort (thinking) override is unavailable — this
-                    model has no effort (thinking) options. Use harness default
-                    or pick another model.
-                  </p>
-                ) : (
-                  <label className={ui.dialogField}>
-                    Review effort (thinking)
-                    <select
-                      className={ui.dialogInput}
-                      value={reviewThinkingLevel}
-                      onChange={(event) => setReviewVariant(event.target.value)}
-                      disabled={
-                        modelsDisabled ||
-                        (reviewThinkingLevelSourceModel.length > 0 &&
-                          reviewThinkingLevels.length === 0)
-                      }
+                  {reviewThinkingLevelSourceModel.length > 0 &&
+                  reviewThinkingLevelSourceUnavailable ? (
+                    <Banner
+                      className={ui.bannerCompact}
+                      tone="alarm"
+                      tag="Error"
+                      role="alert"
                     >
-                      <option value="">
-                        Harness default ({harnessReviewVariant})
-                      </option>
-                      {hasCustomReviewVariant && (
-                        <option value={reviewThinkingLevel}>
-                          {formatVariantLabel(reviewThinkingLevel)}
+                      Review effort (thinking) override is unavailable — the
+                      selected model is not in the Agent Model catalog. Use
+                      harness default or pick another model.
+                    </Banner>
+                  ) : reviewThinkingLevelSourceModel.length > 0 &&
+                    reviewThinkingLevels.length === 0 ? (
+                    <p className={ui.dialogNote}>
+                      Review effort (thinking) override is unavailable — this
+                      model has no effort (thinking) options. Use harness
+                      default or pick another model.
+                    </p>
+                  ) : (
+                    <label className={ui.dialogField}>
+                      Review effort (thinking)
+                      <select
+                        className={ui.dialogInput}
+                        value={reviewThinkingLevel}
+                        onChange={(event) =>
+                          setReviewVariant(event.target.value)
+                        }
+                        disabled={
+                          modelsDisabled ||
+                          (reviewThinkingLevelSourceModel.length > 0 &&
+                            reviewThinkingLevels.length === 0)
+                        }
+                      >
+                        <option value="">
+                          Harness default ({harnessReviewVariant})
                         </option>
-                      )}
-                      {reviewThinkingLevels.map((variant) => (
-                        <option key={`review-${variant}`} value={variant}>
-                          {formatVariantLabel(variant)}
-                        </option>
-                      ))}
-                    </select>
-                  </label>
-                )}
-              </>
-            )}
+                        {hasCustomReviewVariant && (
+                          <option value={reviewThinkingLevel}>
+                            {formatVariantLabel(reviewThinkingLevel)}
+                          </option>
+                        )}
+                        {reviewThinkingLevels.map((variant) => (
+                          <option key={`review-${variant}`} value={variant}>
+                            {formatVariantLabel(variant)}
+                          </option>
+                        ))}
+                      </select>
+                    </label>
+                  )}
+                </>
+              )}
+            </section>
+
             {updateSettings.isError && (
               <Banner
                 className={ui.bannerCompact}

--- a/apps/harness/src/styles.css
+++ b/apps/harness/src/styles.css
@@ -41,6 +41,8 @@
   color-scheme: light;
   --paper: #ffffff;
   --panel: #ffffff;
+  /* Muted stage behind sectioned settings dialogs (prototype D). */
+  --dialog-stage: #f3f5f3;
   --ink: #151515;
   --ink-dim: #4a4a4a;
   --ink-faint: #8b8b8b;
@@ -79,6 +81,7 @@
   color-scheme: dark;
   --paper: #3a3f44;
   --panel: #2a2f34;
+  --dialog-stage: #23272b;
   --ink: #f2f3f1;
   --ink-dim: #c6cac8;
   --ink-faint: #7f8583;
@@ -130,6 +133,7 @@
   color: #151515;
   --paper: #ffffff;
   --panel: #ffffff;
+  --dialog-stage: #f3f5f3;
   --ink: #151515;
   --ink-dim: #4a4a4a;
   --ink-faint: #8b8b8b;
@@ -152,6 +156,7 @@
   /* Tailwind @theme aliases — must re-bind so utilities re-resolve. */
   --color-paper: #ffffff;
   --color-panel: #ffffff;
+  --color-dialog-stage: #f3f5f3;
   --color-ink: #151515;
   --color-ink-2: #4a4a4a;
   --color-ink-soft: #4a4a4a;
@@ -176,6 +181,7 @@
 @theme {
   --color-paper: var(--paper);
   --color-panel: var(--panel);
+  --color-dialog-stage: var(--dialog-stage);
   --color-ink: var(--ink);
   --color-ink-2: var(--ink-dim);
   --color-ink-soft: var(--ink-dim);

--- a/apps/harness/src/ui.ts
+++ b/apps/harness/src/ui.ts
@@ -192,11 +192,17 @@ export const ui = {
 
   bannerAction: "ml-auto",
 
+  /**
+   * Stamped mini plate. Top-left + top-right rivets; top inset highlight only
+   * (no bottom `-2px` strip — that reads as an extra bar under wider plates
+   * in dark mode, esp. Save / dialog actions). Shared by Cancel, Recheck,
+   * pagination, banner actions, and platePrimary (riveted twin).
+   */
   plateMini: cx(
     "inline-flex items-center gap-[0.4rem] border-2 border-ink",
     "bg-[var(--plate)] text-[var(--plate-ink)]",
     plateMiniRivets,
-    "shadow-[inset_0_1px_0_var(--plate-hi),inset_0_-2px_0_var(--plate-lo)]",
+    "shadow-[inset_0_1px_0_var(--plate-hi)]",
     "px-[0.85rem] py-[0.46rem]",
     "font-mono text-[0.68rem] font-bold tracking-[0.12em] uppercase no-underline",
     "cursor-pointer transition-[background-color,color] duration-100 ease-in-out",
@@ -428,6 +434,12 @@ export const ui = {
 
   dialogBody: "grid gap-[1.15rem] px-6 py-5",
 
+  /**
+   * Sectioned settings body (prototype D): muted stage behind bordered
+   * section cards. Token: `--dialog-stage` (not plain `--panel`).
+   */
+  dialogBodySectioned: "grid gap-[0.85rem] bg-dialog-stage px-5 py-[1.15rem]",
+
   dialogBodyCompact: "px-5 py-4",
 
   dialogFooter:
@@ -435,14 +447,43 @@ export const ui = {
 
   dialogFooterCompact: "px-5 py-3",
 
-  dialogField:
-    "grid min-w-0 gap-[0.4rem] font-display text-[0.88rem] font-semibold text-ink",
+  /**
+   * Stamped-plate section card: hard ink border, paper fill, stacked fields.
+   * Pair with dialogSectionHead / Title / Meta.
+   */
+  dialogSection: cx(
+    "grid gap-[0.95rem] border-[1.5px] border-ink bg-paper",
+    "px-[1.1rem] pt-4 pb-[1.1rem]",
+  ),
 
+  dialogSectionHead: cx(
+    "flex items-baseline justify-between gap-2",
+    "border-b-2 border-ink pb-[0.55rem]",
+  ),
+
+  dialogSectionTitle:
+    "m-0 font-display text-[0.78rem] font-extrabold tracking-[0.06em] uppercase text-ink",
+
+  dialogSectionMeta:
+    "font-mono text-[0.58rem] tracking-[0.1em] uppercase text-ink-faint",
+
+  /**
+   * Field label on paper — medium weight, ink-dim — distinct from the plate
+   * control value (bold plate-ink).
+   */
+  dialogField:
+    "grid min-w-0 gap-[0.4rem] font-display text-[0.8rem] font-semibold text-ink-2",
+
+  /**
+   * Physical plate control (select / number input): plate fill, ink border,
+   * bold value, top inset highlight. Apply on the control element.
+   */
   dialogInput: cx(
-    "w-full min-w-0 border-[1.5px] border-ink bg-paper px-[0.7rem] py-2",
-    "text-[0.88rem] font-normal text-ink",
+    "w-full min-w-0 border-[1.5px] border-ink",
+    "bg-[var(--plate)] px-[0.75rem] py-[0.6rem] text-[0.95rem] font-bold text-[var(--plate-ink)]",
+    "shadow-[inset_0_1px_0_var(--plate-hi),inset_0_-1px_0_var(--plate-lo)]",
     "focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ink",
-    "disabled:cursor-not-allowed disabled:text-ink-faint disabled:opacity-70",
+    "disabled:cursor-not-allowed disabled:opacity-70",
   ),
 
   dialogInputMono: "font-mono",
@@ -450,8 +491,11 @@ export const ui = {
   dialogFieldMono:
     "[&>select]:font-mono [&>input:not([type=checkbox])]:font-mono",
 
+  /**
+   * Readable body-size hint (not mono microcopy). ~0.82rem display, ink-dim.
+   */
   dialogFieldHint:
-    "font-mono text-[0.68rem] font-normal tracking-[0.02em] text-ink-faint",
+    "font-display text-[0.82rem] font-normal leading-[1.45] text-ink-2",
 
   dialogCheck:
     "flex flex-wrap items-center gap-3 font-display text-[0.88rem] font-semibold text-ink-2",
@@ -467,13 +511,26 @@ export const ui = {
   dialogStatusLabel:
     "m-0 font-mono text-[0.62rem] font-bold tracking-[0.12em] uppercase text-ink-faint",
 
-  dialogStatusRow:
-    "flex flex-wrap items-center justify-between gap-2 border border-line-ghost bg-panel px-3 py-2 font-mono text-[0.72rem] text-ink-2",
+  /**
+   * Backend status row as a plate inset (matches section control language).
+   */
+  dialogStatusRow: cx(
+    "flex flex-wrap items-center justify-between gap-2",
+    "border border-ink bg-[var(--plate)] px-3 py-2",
+    "font-mono text-[0.72rem] text-[var(--plate-ink)]",
+    "shadow-[inset_0_1px_0_var(--plate-hi)]",
+  ),
 
   dialogStatusRowStrong: "font-bold text-ink",
 
-  dialogFieldset:
-    "m-0 grid gap-3 border-[1.5px] border-ink px-4 pt-[0.9rem] pb-4",
+  /**
+   * Fieldset shell aligned with dialogSection (identity / grouped options).
+   * Prefer dialogSection + dialogSectionHead for new sectioned settings.
+   */
+  dialogFieldset: cx(
+    "m-0 grid gap-[0.95rem] border-[1.5px] border-ink bg-paper",
+    "px-[1.1rem] pt-4 pb-[1.1rem]",
+  ),
 
   dialogFieldsetLegend:
     "px-[0.35rem] font-mono text-[0.62rem] font-bold tracking-[0.16em] uppercase text-ink-faint",
@@ -983,12 +1040,20 @@ export const ui = {
 
   /* ---------- Primary plate (§5.3) ---------- */
 
+  /**
+   * Riveted stamped-plate twin of plateMini (not solid-ink fill). Hierarchy is
+   * position/label only — Cancel and Save share the same plate recipe so
+   * dialogs cannot drift. Top highlight only (see plateMini).
+   */
   platePrimary: cx(
     "inline-flex items-center justify-center gap-[0.4rem] border-2 border-ink",
-    "bg-ink px-[0.95rem] py-[0.46rem] text-paper",
+    "bg-[var(--plate)] text-[var(--plate-ink)]",
+    plateMiniRivets,
+    "shadow-[inset_0_1px_0_var(--plate-hi)]",
+    "px-[0.95rem] py-[0.46rem]",
     "font-mono text-[0.68rem] font-bold tracking-[0.12em] uppercase no-underline",
     "cursor-pointer transition-[background-color,color] duration-100 ease-in-out",
-    "hover:bg-signal hover:text-[#151515]",
+    "hover:bg-[var(--plate-hover)]",
     "disabled:cursor-not-allowed disabled:opacity-55",
     "disabled:aria-busy:cursor-wait",
   ),

--- a/apps/harness/test/interchange-phase5.test.ts
+++ b/apps/harness/test/interchange-phase5.test.ts
@@ -46,14 +46,22 @@ describe("Interchange phase 5: dialogs, menus, chrome + Ledger teardown", () => 
     expect(dialog).toContain("ui.dialogKicker")
     expect(dialog).toContain("ui.dialogTitle")
     expect(dialog).toContain("ui.dialogLede")
-    expect(dialog).toContain("ui.dialogBody")
+    expect(dialog).toContain("ui.dialogBodySectioned")
+    expect(dialog).toContain("ui.dialogSection")
+    expect(dialog).toContain("ui.dialogSectionHead")
+    expect(dialog).toContain("ui.dialogSectionTitle")
     expect(dialog).toContain("ui.dialogFooter")
     expect(dialog).toContain("ui.dialogField")
+    expect(dialog).toContain("ui.dialogInput")
     expect(dialog).toContain("ui.dialogStatusRow")
     expect(dialog).toContain("ui.plateMini")
     expect(dialog).toContain("ui.platePrimary")
     expect(dialog).toContain("Save settings")
     expect(dialog).toContain("Cancel")
+    // Prototype D section cards
+    expect(dialog).toContain("Agent backend")
+    expect(dialog).toContain("Models")
+    expect(dialog).toContain("Concurrency")
     // Compact banners replace oxblood wash callouts.
     expect(dialog).toContain("ui.bannerCompact")
     expect(dialog).not.toContain("font-serif")
@@ -70,7 +78,9 @@ describe("Interchange phase 5: dialogs, menus, chrome + Ledger teardown", () => 
     expect(dialog).toContain("ui.dialogHeader")
     expect(dialog).toContain("ui.dialogKicker")
     expect(dialog).toContain("ui.dialogTitle")
-    expect(dialog).toContain("ui.dialogFieldset")
+    expect(dialog).toContain("ui.dialogBodySectioned")
+    expect(dialog).toContain("ui.dialogSection")
+    expect(dialog).toContain("ui.dialogSectionHead")
     expect(dialog).toContain("ui.dialogCheck")
     expect(dialog).toContain("ui.dialogInput")
     expect(dialog).toContain("ui.platePrimary")
@@ -80,6 +90,11 @@ describe("Interchange phase 5: dialogs, menus, chrome + Ledger teardown", () => 
     expect(dialog).toContain("Forge:")
     expect(dialog).toContain("Forge host:")
     expect(dialog).toContain("Project path:")
+    expect(dialog).toContain("Agent backend")
+    expect(dialog).toContain("Models")
+    expect(dialog).toContain("Options")
+    expect(dialog).toContain("ui.dialogCheckInput")
+    expect(dialog).toContain("ui.dialogCheckHint")
     expect(dialog).not.toContain("font-serif")
     expect(dialog).not.toContain("oxblood")
     expect(dialog).not.toContain("shadow-[")
@@ -87,6 +102,14 @@ describe("Interchange phase 5: dialogs, menus, chrome + Ledger teardown", () => 
     expect(ui).toContain("dialogCheck:")
     expect(ui).toContain("dialogCheckInput:")
     expect(ui).toMatch(/dialogCheckInput:[\s\S]*?accent-signal/)
+    expect(ui).toContain("dialogBodySectioned:")
+    expect(ui).toMatch(/dialogBodySectioned:[\s\S]*?bg-dialog-stage/)
+    expect(ui).toContain("dialogSection:")
+    expect(ui).toMatch(/dialogInput:[\s\S]*?--plate/)
+    expect(ui).toMatch(/dialogFieldHint:[\s\S]*?text-ink-2/)
+    const styles = stylesSource()
+    expect(styles).toContain("--dialog-stage:")
+    expect(styles).toContain("--color-dialog-stage:")
   })
 
   test("session usage dialog is narrow shell with table and telemetry banners", () => {
@@ -158,6 +181,22 @@ describe("Interchange phase 5: dialogs, menus, chrome + Ledger teardown", () => 
     expect(ui).not.toMatch(/dialogInput:[\s\S]*?outline-none/)
     expect(ui).toMatch(/dialogInput:[\s\S]*?focus-visible:outline/)
     expect(ui).toMatch(/dialogInput:[\s\S]*?focus-visible:outline-ink/)
+    // Primary is riveted plate twin of mini (not solid-ink fill).
+    // Slice each recipe so later recipes with bottom bevels don't false-match.
+    const platePrimaryBlock = ui.slice(
+      ui.indexOf("platePrimary:"),
+      ui.indexOf("/* ---------- Stamps"),
+    )
+    const plateMiniBlock = ui.slice(
+      ui.indexOf("plateMini:"),
+      ui.indexOf("bannerCompact:"),
+    )
+    expect(platePrimaryBlock).toContain("--plate")
+    expect(platePrimaryBlock).toContain("plateMiniRivets")
+    expect(platePrimaryBlock).toContain("inset_0_1px_0_var(--plate-hi)")
+    expect(platePrimaryBlock).not.toContain("inset_0_-2px")
+    expect(plateMiniBlock).toContain("inset_0_1px_0_var(--plate-hi)")
+    expect(plateMiniBlock).not.toContain("inset_0_-2px")
     expect(ui).toMatch(/platePrimary:[\s\S]*?disabled:aria-busy:cursor-wait/)
     expect(ui).toMatch(/platePrimary:[\s\S]*?disabled:cursor-not-allowed/)
     const root = rootSource()

--- a/apps/harness/test/repos-interchange.test.ts
+++ b/apps/harness/test/repos-interchange.test.ts
@@ -94,8 +94,9 @@ describe("Interchange phase 4: repos page + blank slate", () => {
     const ui = uiSource()
     expect(ui).toContain("platePrimary:")
     expect(ui).toContain("guidanceCode:")
-    expect(ui).toMatch(/platePrimary:[\s\S]*?bg-ink/)
-    expect(ui).toMatch(/platePrimary:[\s\S]*?hover:bg-signal/)
+    // Riveted stamped-plate twin of mini (not solid-ink primary).
+    expect(ui).toMatch(/platePrimary:[\s\S]*?--plate/)
+    expect(ui).toMatch(/platePrimary:[\s\S]*?hover:bg-\[var\(--plate-hover\)\]/)
   })
 
   test("relevant issues use ticket rows; Closed dashed stamp; Blocked Queue-yellow without wash", () => {

--- a/docs/harness-design-system.md
+++ b/docs/harness-design-system.md
@@ -77,6 +77,7 @@ Light (`:root`, `[data-theme="light"]`):
 | --- | --- | --- |
 | `--paper` | `#ffffff` | page background |
 | `--panel` | `#ffffff` | card/archive bodies |
+| `--dialog-stage` | `#f3f5f3` | muted stage behind sectioned settings dialogs |
 | `--ink` | `#151515` | text, borders, route line |
 | `--ink-dim` | `#4a4a4a` | secondary text, chip text |
 | `--ink-faint` | `#8b8b8b` | meta text, empty states |
@@ -91,6 +92,7 @@ Dark (`[data-theme="dark"]`):
 | --- | --- |
 | `--paper` | `#3a3f44` |
 | `--panel` | `#2a2f34` |
+| `--dialog-stage` | `#23272b` |
 | `--ink` | `#f2f3f1` |
 | `--ink-dim` | `#c6cac8` |
 | `--ink-faint` | `#7f8583` |
@@ -207,12 +209,13 @@ prototypes.)
   `--line-soft` / `--line-ghost` separators, filter buttons.
 - **Radius: none.** The only circles are roundels and nav dots
   (`border-radius: 50%`).
-- **Shadows: inset only.** Plate bevel
-  (`inset 0 1px 0 var(--plate-hi), inset 0 -2px 0 var(--plate-lo)`), ticket
-  lane bar (`inset 6px 0 0 var(--lane)`), active-filter underline
-  (`inset 0 -3px 0 var(--ink)`). **No offset block shadows and no drop
-  shadows anywhere** — the Ledger `5px 5px 0` / `2px 2px 0` blocks and the
-  menu drop shadow are gone; elevation reads through the hard border.
+- **Shadows: inset only.** Plate bevels are inset-only: mini/primary plates
+  use **top highlight only** (`inset 0 1px 0 var(--plate-hi)`) so wide
+  buttons do not grow a dark bottom bar; mast plates may still use a bottom
+  strip. Ticket lane bar (`inset 6px 0 0 var(--lane)`), active-filter
+  underline (`inset 0 -3px 0 var(--ink)`). **No offset block shadows and no
+  drop shadows anywhere** — the Ledger `5px 5px 0` / `2px 2px 0` blocks and
+  the menu drop shadow are gone; elevation reads through the hard border.
 
 ### 2.8 Spacing
 
@@ -456,8 +459,8 @@ prototype, so this spec governs:
 - Signal kicker tag ("Setup"), display heading "No repositories configured".
 - Add-repo form: mono path input (1.5px ink border, focus = global ink
   outline), "Browse…" mini plate (when available), primary submit plate
-  (solid ink, label cycles Inspect → Inspecting… → Confirm and add →
-  Adding…).
+  (riveted plate twin of mini — same recipe as dialog Save; label cycles
+  Inspect → Inspecting… → Confirm and add → Adding…).
 - "Confirm forge identity" fieldset: 1.5px ink border, mono uppercase legend.
 - Divider: hairline + mono "or"; operator-binary hint with a mono `<code>`
   command chip.
@@ -488,17 +491,33 @@ Shared shell (native `<dialog>`):
   themes.
 - **Header**: mono kicker (signal tag or plain mono eyebrow), display title,
   lede in `--ink-dim`. Guidance/alarm callouts = compact banners (§4.8).
-- **Fields**: label grid; inputs/selects 1.5px ink border, paper fill, mono
-  or display per content; focus = global `:focus-visible`; disabled dims to
-  `--ink-faint`; helper lines mono `--ink-faint`. Checkboxes keep native
-  control, accent-color `--signal`.
-- **Status rows** (backend health): `--panel` inset boxes, mono status text.
-- **Footer**: hairline top border, `--panel` fill, right-aligned — Cancel
-  (stamped mini plate) + Save (solid ink plate, white uppercase mono label,
-  "Saving…" pending).
-- **Session usage table**: borderless; row labels display, values mono
-  tabular; telemetry-state boxes (UNSUPPORTED/MISSING/UNAVAILABLE) as compact
-  guidance banners.
+- **Sectioned settings body** (harness + repo settings — prototype D stamped
+  plates): muted stage behind cards (`--dialog-stage`: `#f3f5f3` light /
+  `#23272b` dark).
+  **Section cards** use 1.5px ink border, `--paper` fill, heavy 2px ink head
+  rule with display title (0.78rem/800 uppercase) + optional mono meta
+  (0.58rem faint). Groups: Agent backend / Models / Concurrency (harness);
+  Forge identity / Options / Agent backend / Models (repo). Full-width stacked
+  field rows — do not side-by-side effort fields.
+- **Fields**: label on paper — display 0.8rem/600 `--ink-dim` (not the same
+  weight/color as the control value). **Controls** (selects / number inputs)
+  are physical plate objects: `--plate` fill, 1.5px ink border, bold
+  `--plate-ink` value text (~0.95rem), inset top highlight (and light bottom
+  plate-lo line); mono for model IDs. Focus = global `:focus-visible`;
+  disabled dims opacity. **Hints** readable body size (~0.82rem display,
+  `--ink-dim`) — not mono microcopy. Checkboxes keep native control,
+  accent-color `--signal`.
+- **Status rows** (backend health): plate-fill inset boxes (ink border, top
+  highlight), mono status text; Recheck actions use mini plates.
+- **Footer**: hairline top border, `--panel` fill, right-aligned — **all
+  buttons** are riveted stamped plates (Cancel + Save share the same plate
+  recipe as Recheck / mini plates; no solid-ink primary). Save pending =
+  label swap ("Saving…"), no spinner. Top inset highlight only on plates —
+  no bottom `-2px` strip (reads as an extra bar under wider buttons in dark
+  mode).
+- **Session usage table**: plain body (not sectioned stage); borderless
+  table; row labels display, values mono tabular; telemetry-state boxes
+  (UNSUPPORTED/MISSING/UNAVAILABLE) as compact guidance banners.
 
 ### 4.10 Menus
 
@@ -564,13 +583,14 @@ underline).
   (radial-gradient 1.6px at top corners), bevel
   (`inset 0 1px 0 hi, inset 0 -2px 0 rgb(0 0 0 / 0.3)`), mono 0.7rem/700
   uppercase; hover `--mast-plate-hover`; active = light plate.
-- **Mini plate** (pagination, banner actions, Browse, Cancel): 2px ink
-  border, `--plate` fill, same rivet/bevel pattern (1.4px dots), mono
-  0.68rem/700 uppercase; hover `--plate-hover`.
-- **Primary plate** (Save, Inspect/Confirm, credential CTAs): solid `--ink`
-  fill, `--paper` uppercase mono label, 2px ink border; hover inverts to
-  `--signal` fill / `#151515` text. Pending state = label swap ("Saving…"),
-  no spinner.
+- **Mini plate** (pagination, banner actions, Browse, Cancel, Recheck): 2px
+  ink border, `--plate` fill, top-left + top-right rivets (1.4px dots),
+  **top inset highlight only** (`inset 0 1px 0 var(--plate-hi)` — no bottom
+  `-2px` strip), mono 0.68rem/700 uppercase; hover `--plate-hover`.
+- **Primary plate** (Save, credential CTAs, other dialog actions): **riveted
+  stamped-plate twin of mini** — same `--plate` fill, rivets, and top-only
+  bevel (not solid-ink fill). Hierarchy is position/label only so Cancel and
+  Save cannot drift. Pending state = label swap ("Saving…"), no spinner.
 
 ### 5.4 Icon buttons (pause/start, reset, refresh, collapse, copy)
 


### PR DESCRIPTION
## Why

Harness and repository settings dialogs mixed labels with selected values,
used tiny mono hints, stacked fields without clear sections, and mixed
riveted mini plates with a solid-ink Save. Prototype D (stamped plates) was
signed off as the hierarchy direction for #785.

## What changed

- Shared UI recipes: sectioned settings body (`dialogBodySectioned` +
  `--dialog-stage`), section cards, plate-styled `dialogInput`, readable
  display hints, riveted `platePrimary` twin of `plateMini` (top highlight
  only — no bottom bar on wide Save)
- Harness settings: Agent backend / Models / Concurrency section cards;
  full-width stacked field order unchanged
- Repository settings: Forge identity / Options / Agent backend / Models
  with the same plate controls and riveted Cancel/Save
- Design system §2.2 / §4.7 / §4.9 / §5.3 updated for the new plate and
  dialog contracts
- Interchange contract tests for section inventory, plate recipes, and
  stage token wiring

Settings values, save gates, Recheck, backend preview, and validation are
unchanged — visual hierarchy only. Prototype HTML was not shipped.

## Verification

- `bunx nx run harness:lint`
- `bunx nx test harness` (full unit suite)
- Focused: `interchange-phase5`, `repos-interchange`, `primary-nav`
- Local review: clean after remediation (`--dialog-stage` token, Options
  check recipes, design-system §4.7)

## Limitations

- Global riveted `platePrimary` also covers blank-slate and credential CTAs
  (intentional shared recipe so dialogs cannot drift)
- No automated save-gate unit extraction in this change (behavior
  untouched)

Closes #785