### PR TITLE
feat(agents): symlink .agents/skills into .claude/skills for discovery

### DIFF
--- a/.claude/skills/audit-opencode-session-tokens
+++ b/.claude/skills/audit-opencode-session-tokens
@@ -1,0 +1,1 @@
+../../.agents/skills/audit-opencode-session-tokens

--- a/.claude/skills/code-review
+++ b/.claude/skills/code-review
@@ -1,0 +1,1 @@
+../../.agents/skills/code-review

--- a/.claude/skills/codebase-design
+++ b/.claude/skills/codebase-design
@@ -1,0 +1,1 @@
+../../.agents/skills/codebase-design

--- a/.claude/skills/diagnosing-bugs
+++ b/.claude/skills/diagnosing-bugs
@@ -1,0 +1,1 @@
+../../.agents/skills/diagnosing-bugs

--- a/.claude/skills/domain-modeling
+++ b/.claude/skills/domain-modeling
@@ -1,0 +1,1 @@
+../../.agents/skills/domain-modeling

--- a/.claude/skills/grill-me
+++ b/.claude/skills/grill-me
@@ -1,0 +1,1 @@
+../../.agents/skills/grill-me

--- a/.claude/skills/grill-with-docs
+++ b/.claude/skills/grill-with-docs
@@ -1,0 +1,1 @@
+../../.agents/skills/grill-with-docs

--- a/.claude/skills/grilling
+++ b/.claude/skills/grilling
@@ -1,0 +1,1 @@
+../../.agents/skills/grilling

--- a/.claude/skills/handoff
+++ b/.claude/skills/handoff
@@ -1,0 +1,1 @@
+../../.agents/skills/handoff

--- a/.claude/skills/improve-codebase-architecture
+++ b/.claude/skills/improve-codebase-architecture
@@ -1,0 +1,1 @@
+../../.agents/skills/improve-codebase-architecture

--- a/.claude/skills/prototype
+++ b/.claude/skills/prototype
@@ -1,0 +1,1 @@
+../../.agents/skills/prototype

--- a/.claude/skills/setup-matt-pocock-skills
+++ b/.claude/skills/setup-matt-pocock-skills
@@ -1,0 +1,1 @@
+../../.agents/skills/setup-matt-pocock-skills

--- a/.claude/skills/tdd
+++ b/.claude/skills/tdd
@@ -1,0 +1,1 @@
+../../.agents/skills/tdd

--- a/.claude/skills/to-spec
+++ b/.claude/skills/to-spec
@@ -1,0 +1,1 @@
+../../.agents/skills/to-spec

--- a/.claude/skills/to-tickets
+++ b/.claude/skills/to-tickets
@@ -1,0 +1,1 @@
+../../.agents/skills/to-tickets

--- a/.claude/skills/triage
+++ b/.claude/skills/triage
@@ -1,0 +1,1 @@
+../../.agents/skills/triage

--- a/.claude/skills/wayfinder
+++ b/.claude/skills/wayfinder
@@ -1,0 +1,1 @@
+../../.agents/skills/wayfinder

--- a/.claude/skills/writing-great-skills
+++ b/.claude/skills/writing-great-skills
@@ -1,0 +1,1 @@
+../../.agents/skills/writing-great-skills

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,12 @@
 ## Agent skills
 
+Skill content lives under `.agents/skills/<name>/SKILL.md` — the shared,
+multi-agent source of truth. Claude Code only discovers skills under
+`.claude/skills/`, so every skill directory there is a symlink back into
+`.agents/skills/` (e.g. `.claude/skills/tdd -> ../../.agents/skills/tdd`).
+When adding a new skill under `.agents/skills/`, add the matching symlink:
+`ln -s ../../.agents/skills/<name> .claude/skills/<name>`.
+
 ### Issue tracker
 
 Issues live in GitHub Issues for berenddeboer/ready-for-agent (via `gh`). See `docs/agents/issue-tracker.md`.


### PR DESCRIPTION
Why:

Skill content lives under `.agents/skills/<name>/SKILL.md`, the shared multi-agent source of
truth. Claude Code only discovers skills under `.claude/skills/`, so only the 6 skills that
already had a symlink there (`ontology-change`, the four `principle-*` skills,
`typescript-best-practices`) were usable from Claude Code. The other 18 — including `tdd`,
`code-review`, `triage`, `grilling`, `wayfinder`, `domain-modeling`, and more — were invisible
to it.

What changed:

- Added a `.claude/skills/<name> -> ../../.agents/skills/<name>` symlink for every one of the
  18 previously-unlinked skill directories, matching the relative-path style of the existing 6
  links. No skill content was moved, copied, or edited — this is wiring only.
- Documented the convention in `AGENTS.md` (symlinked as `CLAUDE.md`) under "Agent skills":
  where skill content lives, why the `.claude/skills` symlinks exist, and the exact
  `ln -s ../../.agents/skills/<name> .claude/skills/<name>` command to run when adding a new
  skill, so the symlink set stays in sync going forward.

Verification:

- Confirmed 1:1 correspondence: all 24 directories under `.agents/skills/` contain a
  `SKILL.md`, and all 24 now have a matching entry under `.claude/skills/`.
- Walked every symlink and confirmed `.claude/skills/<name>/SKILL.md` resolves and is
  readable — no broken links.
- Confirmed the new symlinks are plain git-trackable symlinks (not ignored, not directory-tree
  copies), consistent with the 6 pre-existing links.
- Live evidence in this session: previously-invisible skills (`tdd`, `code-review`, `triage`,
  etc.) now appear in Claude Code's own skill-discovery listing after the symlinks were added.

Limitations:

- No automated check keeps the symlink set in sync with `.agents/skills/` going forward; the
  issue treats this as optional, and the documented convention plus a simple `ln -s` command is
  the agreed-upon mitigation rather than a script or CI gate.

Closes #788