### PR TITLE
fix(harness): same-line forge identity fields on blank slate

### DIFF
--- a/apps/harness/src/routes/index.tsx
+++ b/apps/harness/src/routes/index.tsx
@@ -987,6 +987,7 @@ function AddRepositoryGuidance({
             <label className={ui.blankSlateField}>
               Forge:
               <select
+                className={ui.blankSlateFieldControl}
                 value={inspection.forge}
                 onChange={(event) =>
                   setInspection({
@@ -1002,6 +1003,7 @@ function AddRepositoryGuidance({
             <label className={ui.blankSlateField}>
               Forge host:
               <input
+                className={ui.blankSlateFieldControl}
                 required
                 value={inspection.forgeHost}
                 onChange={(event) =>
@@ -1015,6 +1017,7 @@ function AddRepositoryGuidance({
             <label className={ui.blankSlateField}>
               Project path:
               <input
+                className={ui.blankSlateFieldControl}
                 required
                 value={inspection.projectPath}
                 onChange={(event) =>

--- a/apps/harness/src/ui.ts
+++ b/apps/harness/src/ui.ts
@@ -1225,11 +1225,17 @@ export const ui = {
   blankSlateFieldsetLegend:
     "px-[0.35rem] font-mono text-[0.62rem] font-bold tracking-[0.16em] uppercase text-ink-faint",
 
+  /**
+   * Label + control on one row (Label: [value]). Label text is the first
+   * child; apply blankSlateFieldControl on the select/input.
+   */
   blankSlateField:
-    "grid gap-[0.35rem] font-display text-[0.85rem] font-semibold text-ink-2",
+    "flex min-w-0 flex-wrap items-center gap-x-3 gap-y-1 font-display text-[0.85rem] font-semibold text-ink-2",
 
-  blankSlateFieldControl:
-    "border-[1.5px] border-ink bg-paper px-[0.65rem] py-2 font-mono text-[0.85rem] font-normal text-ink",
+  blankSlateFieldControl: cx(
+    "min-w-0 flex-1 border-[1.5px] border-ink bg-paper px-[0.65rem] py-2",
+    "font-mono text-[0.85rem] font-normal text-ink",
+  ),
 
   blankSlateHint:
     "m-0 font-mono text-[0.62rem] tracking-[0.04em] text-ink-faint",

--- a/apps/harness/test/blank-slate-add-command.test.ts
+++ b/apps/harness/test/blank-slate-add-command.test.ts
@@ -82,10 +82,15 @@ describe("blank-slate add repository command", () => {
     expect(guidance).toContain("ui.platePrimary")
     expect(guidance).toContain("ui.blankSlateFieldset")
     expect(guidance).toContain("Confirm forge identity")
-    // Issue #771: label-then-colon so field name vs value is obvious.
+    // Issue #771: label-then-colon + control chrome; same-line label/value.
+    // All three controls must carry blankSlateFieldControl (token-defined but
+    // unwired was the original regression after the Tailwind migration).
     expect(guidance).toContain("Forge:")
     expect(guidance).toContain("Forge host:")
     expect(guidance).toContain("Project path:")
+    expect(
+      guidance.match(/className=\{ui\.blankSlateFieldControl\}/g)?.length,
+    ).toBe(3)
     expect(guidance).toContain("ui.guidanceCode")
     expect(guidance).toContain('tone="alarm"')
     expect(guidance).toContain('role="alert"')

--- a/apps/harness/test/repos-interchange.test.ts
+++ b/apps/harness/test/repos-interchange.test.ts
@@ -267,6 +267,12 @@ describe("Interchange phase 4: repos page + blank slate", () => {
     expect(ui).toContain("blankSlateTitle:")
     expect(ui).toContain("blankSlateFieldset:")
     expect(ui).toContain("blankSlateDivider:")
+    // Confirm forge identity: same-line label + control chrome (issue #771).
+    expect(ui).toMatch(/blankSlateField:[\s\S]*?\bflex\b/)
+    expect(ui).toMatch(/blankSlateField:[\s\S]*?items-center/)
+    expect(ui).toContain("blankSlateFieldControl:")
+    expect(ui).toMatch(/blankSlateFieldControl:[\s\S]*?flex-1/)
+    expect(ui).toMatch(/blankSlateFieldControl:[\s\S]*?border-\[1\.5px\]/)
     expect(ui).toContain("platePrimary:")
   })
 })


### PR DESCRIPTION
## Why

On the blank-slate **Confirm forge identity** fieldset, stacked labels and values still read as similar lines of text. #772 only added colon suffixes; after the Tailwind migration, `blankSlateFieldControl` was defined but never applied to the forge select/inputs, so the values looked like plain body text rather than controls.

## What

- Lay each forge identity field as **label + control on one row** (`blankSlateField` flex layout)
- Wire `ui.blankSlateFieldControl` on Forge, Forge host, and Project path controls (border/mono chrome, `flex-1`)
- Strengthen interchange contracts so all three control applications and the same-line recipe cannot regress silently

Closes #771