### PR TITLE
feat(claude): ready on Bedrock auth status for inspect

### DIFF
--- a/packages/claude/src/lib/parse-auth-status.ts
+++ b/packages/claude/src/lib/parse-auth-status.ts
@@ -1,11 +1,32 @@
+/**
+ * Claude Code `apiProvider` as reported by `claude auth status` JSON.
+ * Used for readiness classification (first-party vs Amazon Bedrock, issue #801).
+ * Unknown when the field is absent or not a recognized value.
+ */
+export type ClaudeAuthProvider = "firstParty" | "bedrock" | "unknown"
+
 export type ClaudeAuthStatus =
-  | { readonly kind: "authenticated" }
-  | { readonly kind: "unauthenticated" }
+  | { readonly kind: "authenticated"; readonly provider: ClaudeAuthProvider }
+  | { readonly kind: "unauthenticated"; readonly provider: ClaudeAuthProvider }
   | { readonly kind: "malformed" }
   | { readonly kind: "failed"; readonly exitCode: number }
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === "object" && value !== null && !Array.isArray(value)
+
+/**
+ * Map Claude’s reported `apiProvider` string. Classification uses this field
+ * (and `loggedIn`), never “missing claude.ai login implies Bedrock”.
+ */
+export const readClaudeAuthProvider = (value: unknown): ClaudeAuthProvider => {
+  if (value === "bedrock") {
+    return "bedrock"
+  }
+  if (value === "firstParty") {
+    return "firstParty"
+  }
+  return "unknown"
+}
 
 /**
  * Extract the first balanced JSON object from mixed CLI capture text so trailing
@@ -54,10 +75,15 @@ export const extractFirstJsonObject = (text: string): string | undefined => {
 /**
  * Interpret `claude auth status` captured text (JSON default) plus exit code.
  *
- * Real CLI: authenticated exits 0 with `{"loggedIn":true,...}`; unauthenticated
- * reports `loggedIn: false` (often exit non-zero). Classification prefers the
- * JSON `loggedIn` field so a crash without that field is not mistaken for
- * missing auth.
+ * Real CLI shapes:
+ * - First-party ready: `{"loggedIn":true,"authMethod":"claude.ai","apiProvider":"firstParty",...}`
+ * - Bedrock ready: `{"loggedIn":true,"authMethod":"third_party","apiProvider":"bedrock"}`
+ * - Unauthenticated: `loggedIn: false` (often exit non-zero), first-party path
+ *
+ * Classification prefers JSON `loggedIn` plus `apiProvider` so:
+ * - Bedrock third-party auth is Ready when Claude reports it
+ * - Missing claude.ai login is never inferred as Bedrock
+ * - A crash without `loggedIn` is not mistaken for missing auth
  */
 export const parseClaudeAuthStatus = (
   output: string,
@@ -74,9 +100,13 @@ export const parseClaudeAuthStatus = (
     try {
       const parsed: unknown = JSON.parse(jsonObject)
       if (isRecord(parsed) && typeof parsed.loggedIn === "boolean") {
+        const provider = readClaudeAuthProvider(parsed.apiProvider)
+        // Ready for first-party OAuth/API key and for Bedrock third-party when
+        // Claude reports loggedIn true (verified Bedrock shape uses
+        // apiProvider "bedrock" + authMethod "third_party").
         return parsed.loggedIn
-          ? { kind: "authenticated" }
-          : { kind: "unauthenticated" }
+          ? { kind: "authenticated", provider }
+          : { kind: "unauthenticated", provider }
       }
     } catch {
       // Fall through to marker / exit-code paths.
@@ -93,12 +123,12 @@ export const parseClaudeAuthStatus = (
     /authentication required/i.test(trimmed) ||
     /please (?:log|sign) in/i.test(trimmed)
   ) {
-    return { kind: "unauthenticated" }
+    return { kind: "unauthenticated", provider: "unknown" }
   }
   // Positive phrases only — no `/authenticated/` (matches "unauthenticated")
   // and no field-name heuristics like `/authMethod/`.
   if (/\blogged in\b/i.test(trimmed)) {
-    return { kind: "authenticated" }
+    return { kind: "authenticated", provider: "unknown" }
   }
 
   if (exitCode !== 0) {

--- a/packages/claude/test/claude.spec.ts
+++ b/packages/claude/test/claude.spec.ts
@@ -122,6 +122,45 @@ describe("Claude AgentBackend adapter (readiness inspection)", () => {
     )
   })
 
+  it("inspects Ready when auth status is Bedrock third-party (static alias catalog)", async () => {
+    await withExecutable(
+      [
+        'case " $* " in *" auth status "*) ;; *) exit 20 ;; esac',
+        'if [ "$DISABLE_AUTOUPDATER" != "1" ]; then exit 21; fi',
+        // Real Claude Code Bedrock shape (issue #801 / epic #799).
+        'printf \'%s\\n\' \'{"loggedIn":true,"authMethod":"third_party","apiProvider":"bedrock"}\'',
+      ].join("\n"),
+      async (binary) => {
+        const result = await Effect.runPromise(inspect(binary))
+        expect(result.backend).toEqual({
+          id: "claude",
+          label: "Claude Code",
+        })
+        expect(result.models.map((m) => m.id)).toEqual([
+          "haiku",
+          "sonnet",
+          "opus",
+          "fable",
+        ])
+        expect(result.models).toEqual(
+          CLAUDE_STATIC_CATALOG.map((model) => ({
+            id: model.id,
+            thinkingLevels: [...model.thinkingLevels],
+          })),
+        )
+        for (const model of result.models) {
+          expect(model.thinkingLevels).toEqual([
+            "low",
+            "medium",
+            "high",
+            "xhigh",
+            "max",
+          ])
+        }
+      },
+    )
+  })
+
   it("fails inspect with actionable config error when unauthenticated", async () => {
     await withExecutable(
       [
@@ -136,6 +175,26 @@ describe("Claude AgentBackend adapter (readiness inspection)", () => {
           expect(error.message).toBe(CLAUDE_UNAUTHENTICATED_MESSAGE)
           expect(error.message).toContain("claude auth login")
           expect(error.message).toContain("ANTHROPIC_API_KEY")
+        }
+      },
+    )
+  })
+
+  it("keeps first-party loggedIn false on the login/API-key path (not Bedrock)", async () => {
+    await withExecutable(
+      [
+        'case " $* " in *" auth status "*) ;; *) exit 20 ;; esac',
+        'printf \'%s\\n\' \'{"loggedIn":false,"authMethod":null,"apiProvider":"firstParty"}\'',
+        "exit 1",
+      ].join("\n"),
+      async (binary) => {
+        const error = await Effect.runPromise(inspect(binary).pipe(Effect.flip))
+        expect(error).toBeInstanceOf(AgentBackendConfigError)
+        if (error instanceof AgentBackendConfigError) {
+          expect(error.message).toBe(CLAUDE_UNAUTHENTICATED_MESSAGE)
+          expect(error.message).toContain("claude auth login")
+          expect(error.message).toContain("ANTHROPIC_API_KEY")
+          expect(error.message.toLowerCase()).not.toContain("bedrock")
         }
       },
     )

--- a/packages/claude/test/parse-auth-status.spec.ts
+++ b/packages/claude/test/parse-auth-status.spec.ts
@@ -29,13 +29,53 @@ describe("parseClaudeAuthStatus", () => {
         }),
         0,
       ),
-    ).toEqual({ kind: "authenticated" })
+    ).toEqual({ kind: "authenticated", provider: "firstParty" })
+  })
+
+  it("recognizes Bedrock third-party auth status as authenticated (real CLI shape)", () => {
+    // Verified under CLAUDE_CODE_USE_BEDROCK: loggedIn true, third_party, bedrock.
+    expect(
+      parseClaudeAuthStatus(
+        JSON.stringify({
+          loggedIn: true,
+          authMethod: "third_party",
+          apiProvider: "bedrock",
+        }),
+        0,
+      ),
+    ).toEqual({ kind: "authenticated", provider: "bedrock" })
+  })
+
+  it("classifies Bedrock from apiProvider, not from missing claude.ai login", () => {
+    // First-party not logged in must never be inferred as Bedrock readiness.
+    expect(
+      parseClaudeAuthStatus(
+        JSON.stringify({
+          loggedIn: false,
+          authMethod: null,
+          apiProvider: "firstParty",
+        }),
+        1,
+      ),
+    ).toEqual({ kind: "unauthenticated", provider: "firstParty" })
+
+    expect(
+      parseClaudeAuthStatus(JSON.stringify({ loggedIn: false }), 1),
+    ).toEqual({ kind: "unauthenticated", provider: "unknown" })
+
+    // apiProvider alone without a loggedIn boolean is not ready.
+    expect(
+      parseClaudeAuthStatus(
+        JSON.stringify({ apiProvider: "bedrock", authMethod: "third_party" }),
+        0,
+      ),
+    ).toEqual({ kind: "malformed" })
   })
 
   it("recognizes loggedIn false JSON as unauthenticated", () => {
     expect(
       parseClaudeAuthStatus(JSON.stringify({ loggedIn: false }), 1),
-    ).toEqual({ kind: "unauthenticated" })
+    ).toEqual({ kind: "unauthenticated", provider: "unknown" })
   })
 
   it("classifies authenticated JSON when stderr noise follows the object", () => {
@@ -44,7 +84,7 @@ describe("parseClaudeAuthStatus", () => {
         '{"loggedIn":true,"authMethod":"claude.ai"}\nwarning: ambient noise',
         0,
       ),
-    ).toEqual({ kind: "authenticated" })
+    ).toEqual({ kind: "authenticated", provider: "unknown" })
   })
 
   it("classifies unauthenticated JSON when stderr noise follows the object", () => {
@@ -53,21 +93,24 @@ describe("parseClaudeAuthStatus", () => {
         '{"loggedIn":false,"authMethod":null}\nwarning: ambient noise',
         1,
       ),
-    ).toEqual({ kind: "unauthenticated" })
+    ).toEqual({ kind: "unauthenticated", provider: "unknown" })
   })
 
   it("recognizes human-readable not logged in", () => {
     expect(parseClaudeAuthStatus("Not logged in\n", 1)).toEqual({
       kind: "unauthenticated",
+      provider: "unknown",
     })
   })
 
   it("treats unauthenticated human copy as unauth, not authenticated", () => {
     expect(parseClaudeAuthStatus("You are unauthenticated.\n", 1)).toEqual({
       kind: "unauthenticated",
+      provider: "unknown",
     })
     expect(parseClaudeAuthStatus("Not authenticated\n", 1)).toEqual({
       kind: "unauthenticated",
+      provider: "unknown",
     })
   })
 
@@ -81,6 +124,7 @@ describe("parseClaudeAuthStatus", () => {
   it("recognizes human-readable logged in after unauth markers are ruled out", () => {
     expect(parseClaudeAuthStatus("Logged in as op@example.com\n", 0)).toEqual({
       kind: "authenticated",
+      provider: "unknown",
     })
   })
 


### PR DESCRIPTION
## Why

Operators running Claude Code through Amazon Bedrock report a third-party
provider shape (`apiProvider: "bedrock"`, `authMethod: "third_party"`,
`loggedIn: true`), not a first-party claude.ai login. Inspect already treated
`loggedIn: true` as ready, but classification did not record Claude's reported
provider, and there was no explicit Bedrock coverage—so Bedrock readiness was
easy to confuse with the first-party login path and harder to extend for
follow-up Unavailable copy (#802).

## What

- Tag `parseClaudeAuthStatus` results with `provider` from Claude's
  `apiProvider` (`firstParty` | `bedrock` | `unknown`).
- Treat the verified Bedrock ready JSON as authenticated so
  `AgentBackend.inspect` returns backend id `claude` and the existing static
  alias catalog (haiku/sonnet/opus/fable) with the same thinking levels.
- Keep Ready gated on `loggedIn === true`; do not infer Bedrock from a missing
  claude.ai login. First-party `loggedIn: false` still yields the existing
  login / `ANTHROPIC_API_KEY` ConfigError.

## Verification

- `bunx nx test claude` (fake-CLI inspect + parse unit tests; live integration
  tests remain opt-in skips).
- Pre-commit (Biome / affected lint) after format fix on
  `readClaudeAuthProvider`.

## Out of scope

- Bedrock-specific Unavailable messaging (#802).
- AWS / `CLAUDE_CODE_USE_BEDROCK` env preservation (#803).
- Operator docs (#804).
- Non-alias Bedrock model IDs / Settings free-text (follow-up model selection).

Closes #801