### PR TITLE
feat(claude): preserve Bedrock and AWS env on Claude spawns

### DIFF
--- a/packages/claude/src/lib/claude.ts
+++ b/packages/claude/src/lib/claude.ts
@@ -66,7 +66,11 @@ export class Claude {
         const spawner = yield* ChildProcessSpawner.ChildProcessSpawner
         const binary = options.binary ?? DEFAULT_BINARY
         const defaultTimeout = options.defaultTimeout ?? DEFAULT_TIMEOUT
-        const environment = makeClaudeEnvironment()
+        const environment = makeClaudeEnvironment(
+          options.environment !== undefined
+            ? { environment: options.environment }
+            : {},
+        )
 
         const inspect = Effect.fn("Claude.inspect")(function* (
           input: InspectInput,

--- a/packages/claude/src/lib/environment.ts
+++ b/packages/claude/src/lib/environment.ts
@@ -5,11 +5,18 @@ export type MakeClaudeEnvironmentOptions = {
 }
 
 /**
- * Claude Code Agent Turns use ambient Forge authentication: inherit process
- * env (including ambient Forge tokens and ANTHROPIC_API_KEY). Force
- * DISABLE_AUTOUPDATER so Harness operation cannot replace the CLI under active
- * work (ADR 0047). Claude does not support KeymaxxerMcp, so tokens are never
- * stripped.
+ * Claude Code Agent Turns use ambient credentials: inherit process env
+ * (Forge tokens, ANTHROPIC_API_KEY, and Amazon Bedrock / AWS credential
+ * chain vars such as CLAUDE_CODE_USE_BEDROCK, AWS_ACCESS_KEY_ID,
+ * AWS_SECRET_ACCESS_KEY, AWS_SESSION_TOKEN, AWS_REGION / AWS_DEFAULT_REGION,
+ * AWS_PROFILE, AWS_BEARER_TOKEN_BEDROCK). The shared sanitizer only strips
+ * optional Forge tokens when requested; Claude never requests that strip, so
+ * Bedrock enablement and AWS credentials reach inspect and turn spawns the
+ * same way they would for a hand-run `claude` (issue #803 / epic #799).
+ *
+ * Force DISABLE_AUTOUPDATER so Harness operation cannot replace the CLI under
+ * active work (ADR 0047). No Keymaxxer integration for Anthropic or AWS
+ * secrets in v1.
  */
 export const makeClaudeEnvironment = (
   options: MakeClaudeEnvironmentOptions = {},

--- a/packages/claude/src/lib/types.ts
+++ b/packages/claude/src/lib/types.ts
@@ -4,6 +4,11 @@ import type { AgentModel } from "@ready-for-agent/agent-backend"
 export interface ClaudeLayerOptions {
   readonly binary?: string
   readonly defaultTimeout?: Duration.Input
+  /**
+   * Override process environment for Claude inspect/turn spawns (tests).
+   * Production omits this so the harness process env is inherited.
+   */
+  readonly environment?: Readonly<Record<string, string | undefined>>
 }
 
 /**

--- a/packages/claude/test/claude.spec.ts
+++ b/packages/claude/test/claude.spec.ts
@@ -33,17 +33,27 @@ const withExecutable = async <A>(
   }
 }
 
-const provide = (binary: string) =>
-  Claude.layer({ binary }).pipe(Layer.provide(BunServices.layer))
+const provide = (
+  binary: string,
+  environment?: Readonly<Record<string, string | undefined>>,
+) =>
+  Claude.layer({
+    binary,
+    ...(environment !== undefined ? { environment } : {}),
+  }).pipe(Layer.provide(BunServices.layer))
 
-const inspect = (binary: string, timeout = "2 seconds") =>
+const inspect = (
+  binary: string,
+  timeout = "2 seconds",
+  environment?: Readonly<Record<string, string | undefined>>,
+) =>
   Effect.gen(function* () {
     const backend = yield* AgentBackend
     return yield* backend.inspect({
       cwd: process.cwd(),
       timeout,
     })
-  }).pipe(Effect.provide(provide(binary)))
+  }).pipe(Effect.provide(provide(binary, environment)))
 
 const captureSessionScript = [
   'sid=""',
@@ -68,6 +78,7 @@ const startTurn = (
   onSessionId?: OnSessionId,
   prompt = "test",
   thinkingLevel: string | null = "medium",
+  environment?: Readonly<Record<string, string | undefined>>,
 ) =>
   Effect.gen(function* () {
     const backend = yield* AgentBackend
@@ -79,7 +90,7 @@ const startTurn = (
       timeout,
       ...(onSessionId !== undefined ? { onSessionId } : {}),
     })
-  }).pipe(Effect.provide(provide(binary)))
+  }).pipe(Effect.provide(provide(binary, environment)))
 
 describe("Claude AgentBackend adapter (readiness inspection)", () => {
   it("inspects authenticated CLI via JSON auth status (real CLI shape)", async () => {
@@ -157,6 +168,49 @@ describe("Claude AgentBackend adapter (readiness inspection)", () => {
             "max",
           ])
         }
+      },
+    )
+  })
+
+  it("forwards Bedrock and AWS env on inspect while forcing DISABLE_AUTOUPDATER", async () => {
+    // Issue #803: fake CLI proves layer-provided Bedrock/AWS vars reach the
+    // child, and auto-update stays disabled under Harness.
+    await withExecutable(
+      [
+        'case " $* " in *" auth status "*) ;; *) exit 20 ;; esac',
+        'if [ "$DISABLE_AUTOUPDATER" != "1" ]; then exit 21; fi',
+        'if [ "$CLAUDE_CODE_USE_BEDROCK" != "1" ]; then exit 30; fi',
+        'if [ "$AWS_REGION" != "us-east-1" ]; then exit 31; fi',
+        'if [ "$AWS_ACCESS_KEY_ID" != "AKIAEXAMPLE" ]; then exit 32; fi',
+        'if [ "$AWS_SECRET_ACCESS_KEY" != "secret" ]; then exit 33; fi',
+        'if [ "$AWS_SESSION_TOKEN" != "session" ]; then exit 34; fi',
+        'if [ "$AWS_PROFILE" != "bedrock-op" ]; then exit 35; fi',
+        'if [ "$AWS_BEARER_TOKEN_BEDROCK" != "bedrock-bearer" ]; then exit 36; fi',
+        'printf \'%s\\n\' \'{"loggedIn":true,"authMethod":"third_party","apiProvider":"bedrock"}\'',
+      ].join("\n"),
+      async (binary) => {
+        const result = await Effect.runPromise(
+          inspect(binary, "2 seconds", {
+            PATH: process.env.PATH,
+            CLAUDE_CODE_USE_BEDROCK: "1",
+            AWS_REGION: "us-east-1",
+            AWS_ACCESS_KEY_ID: "AKIAEXAMPLE",
+            AWS_SECRET_ACCESS_KEY: "secret",
+            AWS_SESSION_TOKEN: "session",
+            AWS_PROFILE: "bedrock-op",
+            AWS_BEARER_TOKEN_BEDROCK: "bedrock-bearer",
+          }),
+        )
+        expect(result.backend).toEqual({
+          id: "claude",
+          label: "Claude Code",
+        })
+        expect(result.models.map((m) => m.id)).toEqual([
+          "haiku",
+          "sonnet",
+          "opus",
+          "fable",
+        ])
       },
     )
   })
@@ -265,6 +319,34 @@ describe("Claude AgentBackend adapter (Agent Turns)", () => {
         expect(result.sessionId).toMatch(
           /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i,
         )
+      },
+    )
+  })
+
+  it("forwards Bedrock and AWS env on turns while forcing DISABLE_AUTOUPDATER", async () => {
+    // Issue #803: same env preservation as inspect for Agent Turn spawns.
+    await withExecutable(
+      [
+        'case " $* " in *" -p "*) ;; *) exit 20 ;; esac',
+        'if [ "$DISABLE_AUTOUPDATER" != "1" ]; then exit 27; fi',
+        'if [ "$CLAUDE_CODE_USE_BEDROCK" != "1" ]; then exit 40; fi',
+        'if [ "$AWS_REGION" != "eu-west-1" ]; then exit 41; fi',
+        'if [ "$AWS_ACCESS_KEY_ID" != "AKIAEXAMPLE" ]; then exit 42; fi',
+        'if [ "$AWS_DEFAULT_REGION" != "eu-west-1" ]; then exit 43; fi',
+        captureSessionScript,
+        successfulTurnStream(),
+      ].join("\n"),
+      async (binary) => {
+        const result = await Effect.runPromise(
+          startTurn(binary, "2 seconds", undefined, "test", "medium", {
+            PATH: process.env.PATH,
+            CLAUDE_CODE_USE_BEDROCK: "1",
+            AWS_REGION: "eu-west-1",
+            AWS_DEFAULT_REGION: "eu-west-1",
+            AWS_ACCESS_KEY_ID: "AKIAEXAMPLE",
+          }),
+        )
+        expect(result.assistantText).toBe("ok")
       },
     )
   })

--- a/packages/claude/test/environment.spec.ts
+++ b/packages/claude/test/environment.spec.ts
@@ -25,6 +25,40 @@ describe("makeClaudeEnvironment", () => {
     expect(env.ANTHROPIC_API_KEY).toBe("sk-ant-test")
   })
 
+  it("preserves Bedrock enablement and standard AWS credential chain env vars", () => {
+    // Issue #803: operators who export Bedrock/AWS on the harness process
+    // must see the same provider behaviour as running Claude themselves.
+    const env = makeClaudeEnvironment({
+      environment: {
+        PATH: "/usr/bin",
+        CLAUDE_CODE_USE_BEDROCK: "1",
+        AWS_ACCESS_KEY_ID: "AKIAEXAMPLE",
+        AWS_SECRET_ACCESS_KEY: "secret",
+        AWS_SESSION_TOKEN: "session",
+        AWS_REGION: "us-east-1",
+        AWS_DEFAULT_REGION: "us-west-2",
+        AWS_PROFILE: "bedrock-op",
+        AWS_BEARER_TOKEN_BEDROCK: "bedrock-bearer",
+        ANTHROPIC_DEFAULT_SONNET_MODEL:
+          "us.anthropic.claude-sonnet-4-20250514-v1:0",
+        KEEP: "yes",
+      },
+    })
+    expect(env.CLAUDE_CODE_USE_BEDROCK).toBe("1")
+    expect(env.AWS_ACCESS_KEY_ID).toBe("AKIAEXAMPLE")
+    expect(env.AWS_SECRET_ACCESS_KEY).toBe("secret")
+    expect(env.AWS_SESSION_TOKEN).toBe("session")
+    expect(env.AWS_REGION).toBe("us-east-1")
+    expect(env.AWS_DEFAULT_REGION).toBe("us-west-2")
+    expect(env.AWS_PROFILE).toBe("bedrock-op")
+    expect(env.AWS_BEARER_TOKEN_BEDROCK).toBe("bedrock-bearer")
+    expect(env.ANTHROPIC_DEFAULT_SONNET_MODEL).toBe(
+      "us.anthropic.claude-sonnet-4-20250514-v1:0",
+    )
+    expect(env.KEEP).toBe("yes")
+    expect(env.DISABLE_AUTOUPDATER).toBe("1")
+  })
+
   it("forces DISABLE_AUTOUPDATER even when inherited env already sets it", () => {
     const env = makeClaudeEnvironment({
       environment: {


### PR DESCRIPTION
## Why

Operators who enable Amazon Bedrock for Claude Code export
`CLAUDE_CODE_USE_BEDROCK` and standard AWS credential/region variables on
the harness process. Inspect and Agent Turn spawns already inherited
process env without stripping those names, but nothing proved that
contract: environment tests only covered Forge tokens and
`ANTHROPIC_API_KEY`, and the layer could not inject env for fake-CLI
assertions. Without that, Bedrock readiness (#801) could pass while
spawns still failed to receive the provider switch and AWS chain the
operator set on the harness.

## What

- Document in `makeClaudeEnvironment` that Bedrock enablement and AWS
  credential-chain vars (access key, secret, session token, region /
  default region, profile, Bedrock bearer token, alias pin vars) are
  inherited; only optional Forge-token stripping applies, and Claude
  never enables it. No Keymaxxer path for AWS secrets.
- Force `DISABLE_AUTOUPDATER=1` after the inherited env spread (unchanged
  policy from ADR 0047).
- Add optional `ClaudeLayerOptions.environment` for tests so the layer
  can pass a controlled env into inspect and turn spawns (production
  still inherits the harness process env).
- Unit tests: Bedrock/AWS vars survive the helper; auto-update stays
  forced.
- Fake-CLI tests: inspect and turn children see layer-provided
  Bedrock/AWS vars and `DISABLE_AUTOUPDATER=1`.

## Verification

- `bunx nx test claude` (56 pass, 2 opt-in integration skips).
- Pre-commit (Biome / affected lint) after format wrap on the long
  Bedrock model pin string in `environment.spec.ts`.
- Local review: clean (0 bugs / suggestions / nits).

## Out of scope

- Bedrock-specific Unavailable messaging (#802).
- Operator Bedrock setup docs (#804).
- Non-alias Bedrock model IDs / Settings free-text (model-selection
  follow-up).

Closes #803