### PR TITLE
fix(harness): show Reset on terminal Failed Attention cards

### DIFF
--- a/apps/harness/src/routes/index.tsx
+++ b/apps/harness/src/routes/index.tsx
@@ -3496,12 +3496,14 @@ export function WorkItemLifecycleStatus({
     (workItem.canRetry &&
       workItem.lifecycleLabels.at(-1)?.phase === "GITHUB_STATUS_CHECKS")
   // Reset cancels/deletes a Work Item (history + worktree). Compact non-terminal
-  // cards (held Queue and other unfinished work) keep it; Completed/Failed
-  // terminal history never does. Needs Human stays on Working and keeps cancel.
+  // cards (held Queue and other unfinished work) keep it; Complete/Abandoned
+  // terminal history never does. Terminal Failed Attention cards keep delete so
+  // obsolete failures can be cleared. Needs Human stays on Working and keeps cancel.
   const canReset = canShowWorkItemResetAction({
     compact,
     isTerminal: workItem.isTerminal,
     isNeedsHuman: status === "NEEDS_HUMAN",
+    isFailed: status === "FAILED",
   })
   const dataUpdatedAt = queryClient
     .getQueriesData({ queryKey: ["work-items", workItem.repositoryId] })

--- a/apps/harness/src/work-item-job-actions.ts
+++ b/apps/harness/src/work-item-job-actions.ts
@@ -3,18 +3,22 @@
  *
  * Reset deletes the Work Item, its step-run history, and its worktree. It is a
  * cancel affordance for unfinished compact cards (held Queue rows and other
- * active work), not for completed/failed terminal history.
+ * active work) and for terminal Failed Attention cards that are obsolete after
+ * a replacement Work Item exists. Complete and Abandoned history stay protected.
  *
  * Needs Human is a terminal lifecycle state but remains on the Working tab; keep
  * Reset there so operators can clear a stuck handoff when Retry is unavailable.
- * Callers pass `isNeedsHuman` from domain state/status (not a free-form string).
+ * Callers pass `isNeedsHuman` / `isFailed` from domain state/status (not free-form
+ * strings). Step-level FAILED on a non-terminal Work Item still shows Reset via
+ * the non-terminal branch — do not denylist status === "FAILED" alone.
  */
 export function canShowWorkItemResetAction(args: {
   readonly compact: boolean
   readonly isTerminal: boolean
   readonly isNeedsHuman: boolean
+  readonly isFailed: boolean
 }): boolean {
   if (!args.compact) return false
   if (!args.isTerminal) return true
-  return args.isNeedsHuman
+  return args.isNeedsHuman || args.isFailed
 }

--- a/apps/harness/test/jobs-reset-visibility.test.ts
+++ b/apps/harness/test/jobs-reset-visibility.test.ts
@@ -13,68 +13,141 @@ const lifecycleStatusSource = (): string => {
   return source.slice(start)
 }
 
-/** Scenario labels document projected GraphQL status; the gate keys on isTerminal. */
+/**
+ * Scenario labels document projected GraphQL status; the gate keys on isTerminal,
+ * isNeedsHuman, and isFailed (not free-form status denylists).
+ */
 const cases = [
   {
     name: "terminal COMPLETE history",
-    args: { compact: true, isTerminal: true, isNeedsHuman: false },
+    args: {
+      compact: true,
+      isTerminal: true,
+      isNeedsHuman: false,
+      isFailed: false,
+    },
     show: false,
   },
   {
     name: "terminal ABANDONED history",
-    args: { compact: true, isTerminal: true, isNeedsHuman: false },
+    args: {
+      compact: true,
+      isTerminal: true,
+      isNeedsHuman: false,
+      isFailed: false,
+    },
     show: false,
   },
   {
     name: "terminal FAILED history",
-    args: { compact: true, isTerminal: true, isNeedsHuman: false },
-    show: false,
+    args: {
+      compact: true,
+      isTerminal: true,
+      isNeedsHuman: false,
+      isFailed: true,
+    },
+    show: true,
   },
   {
     name: "held WAITING_FOR_BLOCKERS (non-terminal)",
-    args: { compact: true, isTerminal: false, isNeedsHuman: false },
+    args: {
+      compact: true,
+      isTerminal: false,
+      isNeedsHuman: false,
+      isFailed: false,
+    },
     show: true,
   },
   {
     name: "held WAITING_FOR_WORKER_SLOT (non-terminal)",
-    args: { compact: true, isTerminal: false, isNeedsHuman: false },
+    args: {
+      compact: true,
+      isTerminal: false,
+      isNeedsHuman: false,
+      isFailed: false,
+    },
     show: true,
   },
   {
     name: "RUNNING (non-terminal)",
-    args: { compact: true, isTerminal: false, isNeedsHuman: false },
+    args: {
+      compact: true,
+      isTerminal: false,
+      isNeedsHuman: false,
+      isFailed: false,
+    },
     show: true,
   },
   {
     // Step-level failure while the Work Item is still operational: GraphQL status
     // can be FAILED/INTERRUPTED with isTerminal false. Must still show Reset.
     name: "step-level FAILED status on non-terminal work item",
-    args: { compact: true, isTerminal: false, isNeedsHuman: false },
+    args: {
+      compact: true,
+      isTerminal: false,
+      isNeedsHuman: false,
+      isFailed: true,
+    },
     show: true,
   },
   {
     name: "step-level INTERRUPTED status on non-terminal work item",
-    args: { compact: true, isTerminal: false, isNeedsHuman: false },
+    args: {
+      compact: true,
+      isTerminal: false,
+      isNeedsHuman: false,
+      isFailed: false,
+    },
     show: true,
   },
   {
     name: "paused NEEDS_HUMAN_REVIEW (non-terminal Working)",
-    args: { compact: true, isTerminal: false, isNeedsHuman: false },
+    args: {
+      compact: true,
+      isTerminal: false,
+      isNeedsHuman: false,
+      isFailed: false,
+    },
     show: true,
   },
   {
     name: "terminal NEEDS_HUMAN Working handoff",
-    args: { compact: true, isTerminal: true, isNeedsHuman: true },
+    args: {
+      compact: true,
+      isTerminal: true,
+      isNeedsHuman: true,
+      isFailed: false,
+    },
     show: true,
   },
   {
     name: "non-compact issue row (held)",
-    args: { compact: false, isTerminal: false, isNeedsHuman: false },
+    args: {
+      compact: false,
+      isTerminal: false,
+      isNeedsHuman: false,
+      isFailed: false,
+    },
     show: false,
   },
   {
     name: "non-compact issue row (Needs Human)",
-    args: { compact: false, isTerminal: true, isNeedsHuman: true },
+    args: {
+      compact: false,
+      isTerminal: true,
+      isNeedsHuman: true,
+      isFailed: false,
+    },
+    show: false,
+  },
+  {
+    name: "non-compact issue row (terminal Failed)",
+    args: {
+      compact: false,
+      isTerminal: true,
+      isNeedsHuman: false,
+      isFailed: true,
+    },
     show: false,
   },
 ] as const
@@ -93,6 +166,7 @@ describe("Jobs Reset button wiring", () => {
     expect(lifecycle).toContain("canShowWorkItemResetAction({")
     expect(lifecycle).toContain("isTerminal: workItem.isTerminal")
     expect(lifecycle).toContain('isNeedsHuman: status === "NEEDS_HUMAN"')
+    expect(lifecycle).toContain('isFailed: status === "FAILED"')
     expect(lifecycle).toContain("resetWorkItem")
     expect(lifecycle).toContain("<WorkItemResetButton")
     expect(lifecycle).toContain("pending={reset.isPending}")
@@ -110,6 +184,8 @@ describe("Jobs Reset button wiring", () => {
     )
     expect(lifecycle).not.toContain("canReset = compact && !heldForBlockers")
     // Gate must not denylist projected FAILED status strings (step failures).
+    // Terminal Failed is allowed via isFailed; non-terminal step FAILED uses the
+    // non-terminal branch. Neither path filters with status !== "FAILED".
     expect(lifecycle).not.toMatch(
       /canShowWorkItemResetAction[\s\S]*?status\s*!==\s*"FAILED"/,
     )

--- a/apps/harness/test/waiting-for-blockers-working-row.test.ts
+++ b/apps/harness/test/waiting-for-blockers-working-row.test.ts
@@ -70,6 +70,7 @@ describe("Waiting for blockers Working-row polish", () => {
     expect(lifecycle).toContain("canShowWorkItemResetAction({")
     expect(lifecycle).toContain("isTerminal: workItem.isTerminal")
     expect(lifecycle).toContain('isNeedsHuman: status === "NEEDS_HUMAN"')
+    expect(lifecycle).toContain('isFailed: status === "FAILED"')
     expect(lifecycle).toContain("resetWorkItem")
     expect(lifecycle).toContain("<WorkItemResetButton")
     expect(lifecycle).toContain("pending={reset.isPending}")

--- a/packages/work-item-lifecycle/test/work-item-lifecycle.spec.ts
+++ b/packages/work-item-lifecycle/test/work-item-lifecycle.spec.ts
@@ -9542,26 +9542,66 @@ describe("WorkItemLifecycle", () => {
       )
     })
 
-    it("deletes terminal Work Items including Complete and Abandoned", () =>
+    it("deletes terminal Abandoned and Failed Work Items", () =>
       runTest(
         Effect.gen(function* () {
           const lifecycle = yield* WorkItemLifecycle
+          const sql = yield* SqlClient.SqlClient
           const { repository, issue } = yield* seedActionableIssue
 
-          const created = yield* lifecycle.implementNow(
+          const abandoned = yield* lifecycle.implementNow(
             repository.id,
             issue.issueNumber,
           )
-          yield* lifecycle.abandon(created.id)
+          yield* lifecycle.abandon(abandoned.id)
 
-          const deletedId = yield* lifecycle.reset(created.id)
-          expect(deletedId).toBe(created.id)
+          const deletedAbandoned = yield* lifecycle.reset(abandoned.id)
+          expect(deletedAbandoned).toBe(abandoned.id)
 
-          const listed = yield* lifecycle.listWorkItemsForIssue(
+          const afterAbandoned = yield* lifecycle.listWorkItemsForIssue(
             repository.id,
             issue.issueNumber,
           )
-          expect(listed).toHaveLength(0)
+          expect(afterAbandoned).toHaveLength(0)
+
+          const failed = yield* lifecycle.implementNow(
+            repository.id,
+            issue.issueNumber,
+          )
+          const now = Date.now()
+          yield* sql.unsafe(`DELETE FROM job_queue`)
+          yield* sql.unsafe(
+            `UPDATE step_run
+             SET status = 'failed', started_at = ?, finished_at = ?, updated_at = ?
+             WHERE id = ?`,
+            [now, now, now, failed.stepRuns[0]!.id],
+          )
+          yield* sql.unsafe(
+            `UPDATE work_item
+             SET state = 'failed',
+                 failure_code = 'issue_not_found',
+                 failure_message = 'Issue is no longer present in the Issue store',
+                 holds_worker_slot = 0,
+                 updated_at = ?
+             WHERE id = ?`,
+            [now, failed.id],
+          )
+          expect((yield* lifecycle.getWorkItem(failed.id)).state).toBe("failed")
+          expect(
+            (yield* lifecycle.getWorkItem(failed.id)).stepRuns,
+          ).toHaveLength(1)
+
+          const deletedFailed = yield* lifecycle.reset(failed.id)
+          expect(deletedFailed).toBe(failed.id)
+
+          const missing = yield* Effect.flip(lifecycle.getWorkItem(failed.id))
+          expect(missing).toBeInstanceOf(WorkItemNotFoundError)
+
+          const afterFailed = yield* lifecycle.listWorkItemsForIssue(
+            repository.id,
+            issue.issueNumber,
+          )
+          expect(afterFailed).toHaveLength(0)
         }),
       ))
 


### PR DESCRIPTION
## Why

Terminal Failed Work Items land in the Attention lane but, after #622, hid
the Reset/delete control along with Complete and Abandoned history. Operators
could not clear obsolete failure cards once the underlying problem was fixed
and a replacement Work Item existed.

## What changed

- Extended `canShowWorkItemResetAction` with `isFailed` so compact terminal
  Failed cards keep Reset alongside Needs Human.
- Wired `isFailed: status === "FAILED"` from `WorkItemLifecycleStatus`
  (existing `resetWorkItem` already deletes terminal Work Items and drops
  them from board cache).
- Complete and Abandoned history still hide Reset; non-terminal compact cards
  and Needs Human are unchanged.
- Updated the Reset visibility matrix and lifecycle coverage for terminal
  Failed reset; corrected the lifecycle example title to match
  Abandoned/Failed coverage only.

## Verification

- `bunx nx test harness -- test/jobs-reset-visibility.test.ts
  test/waiting-for-blockers-working-row.test.ts`
- `bunx nx test work-item-lifecycle -- --test-name-pattern "deletes terminal"`

Regression from #622 / `2e976fd`.

Closes #809