### PR TITLE
feat(claude): map bedrock readiness failures to AWS ConfigError copy

### DIFF
--- a/packages/claude/src/lib/claude.ts
+++ b/packages/claude/src/lib/claude.ts
@@ -24,6 +24,7 @@ import {
   isSuccessfulClaudeTurn,
 } from "./parse-stream.js"
 import {
+  CLAUDE_BEDROCK_UNAVAILABLE_MESSAGE,
   CLAUDE_STATIC_CATALOG,
   CLAUDE_UNAUTHENTICATED_MESSAGE,
   type ClaudeLayerOptions,
@@ -94,8 +95,13 @@ export class Claude {
             .join("\n")
           const status = parseClaudeAuthStatus(statusOutput, result.exitCode)
           if (status.kind === "unauthenticated") {
+            // Bedrock third-party unusable readiness must not point at
+            // `claude auth login` / first-party API key alone (#802).
             return yield* new AgentBackendConfigError({
-              message: CLAUDE_UNAUTHENTICATED_MESSAGE,
+              message:
+                status.provider === "bedrock"
+                  ? CLAUDE_BEDROCK_UNAVAILABLE_MESSAGE
+                  : CLAUDE_UNAUTHENTICATED_MESSAGE,
             })
           }
           if (status.kind === "failed") {

--- a/packages/claude/src/lib/types.ts
+++ b/packages/claude/src/lib/types.ts
@@ -18,6 +18,15 @@ export interface ClaudeLayerOptions {
 export const CLAUDE_UNAUTHENTICATED_MESSAGE =
   "Claude Code is not authenticated. Run `claude auth login` (or set `ANTHROPIC_API_KEY`), then Recheck Agent Backend."
 
+/**
+ * Actionable readiness-failure copy when Claude reports Amazon Bedrock as the
+ * provider but readiness is unusable (credentials, region, or probe failure).
+ * Primary action is AWS credentials/region — this path already implies Bedrock
+ * mode — not first-party login (issue #802 / epic #799).
+ */
+export const CLAUDE_BEDROCK_UNAVAILABLE_MESSAGE =
+  "Claude Code Amazon Bedrock is not ready. Ensure valid AWS credentials and region are available to the harness process (with CLAUDE_CODE_USE_BEDROCK=1), then Recheck Agent Backend."
+
 /** Official Thinking Levels for Claude Code v1 (ADR 0047). No `ultracode`. */
 export const CLAUDE_THINKING_LEVELS = [
   "low",

--- a/packages/claude/test/claude.spec.ts
+++ b/packages/claude/test/claude.spec.ts
@@ -12,6 +12,7 @@ import {
   type OnSessionId,
 } from "@ready-for-agent/agent-backend"
 import {
+  CLAUDE_BEDROCK_UNAVAILABLE_MESSAGE,
   CLAUDE_STATIC_CATALOG,
   CLAUDE_UNAUTHENTICATED_MESSAGE,
   Claude,
@@ -249,6 +250,29 @@ describe("Claude AgentBackend adapter (readiness inspection)", () => {
           expect(error.message).toContain("claude auth login")
           expect(error.message).toContain("ANTHROPIC_API_KEY")
           expect(error.message.toLowerCase()).not.toContain("bedrock")
+        }
+      },
+    )
+  })
+
+  it("fails Bedrock readiness with AWS/Bedrock ConfigError (not claude auth login)", async () => {
+    // Issue #802: Bedrock provider path must not steer operators to first-party
+    // `claude auth login` when the readiness probe reports Bedrock unusable.
+    await withExecutable(
+      [
+        'case " $* " in *" auth status "*) ;; *) exit 20 ;; esac',
+        'printf \'%s\\n\' \'{"loggedIn":false,"authMethod":"third_party","apiProvider":"bedrock"}\'',
+        "exit 1",
+      ].join("\n"),
+      async (binary) => {
+        const error = await Effect.runPromise(inspect(binary).pipe(Effect.flip))
+        expect(error).toBeInstanceOf(AgentBackendConfigError)
+        if (error instanceof AgentBackendConfigError) {
+          expect(error.message).toBe(CLAUDE_BEDROCK_UNAVAILABLE_MESSAGE)
+          expect(error.message.toLowerCase()).toContain("bedrock")
+          expect(error.message).toMatch(/AWS|aws/)
+          expect(error.message).not.toContain("claude auth login")
+          expect(error.message).not.toBe(CLAUDE_UNAUTHENTICATED_MESSAGE)
         }
       },
     )

--- a/packages/claude/test/parse-auth-status.spec.ts
+++ b/packages/claude/test/parse-auth-status.spec.ts
@@ -72,6 +72,20 @@ describe("parseClaudeAuthStatus", () => {
     ).toEqual({ kind: "malformed" })
   })
 
+  it("classifies Bedrock loggedIn false as unauthenticated with bedrock provider", () => {
+    // Issue #802 inspect maps this shape to Bedrock/AWS Unavailable copy.
+    expect(
+      parseClaudeAuthStatus(
+        JSON.stringify({
+          loggedIn: false,
+          authMethod: "third_party",
+          apiProvider: "bedrock",
+        }),
+        1,
+      ),
+    ).toEqual({ kind: "unauthenticated", provider: "bedrock" })
+  })
+
   it("recognizes loggedIn false JSON as unauthenticated", () => {
     expect(
       parseClaudeAuthStatus(JSON.stringify({ loggedIn: false }), 1),


### PR DESCRIPTION
Why

Operators on Claude Code via Amazon Bedrock were still at risk of seeing
first-party Unavailable copy (`claude auth login` / `ANTHROPIC_API_KEY`) when
readiness failed. Bedrock is a provider path (`apiProvider: "bedrock"`), not a
missing claude.ai login; wrong guidance wastes setup time and hides AWS
credential/region fixes.

What

- Map inspect unauthenticated + provider bedrock to
  CLAUDE_BEDROCK_UNAVAILABLE_MESSAGE (AWS credentials/region primary;
  enablement as context; Recheck Agent Backend).
- Leave first-party / unknown unauthenticated on the existing login / API-key
  message.
- Fake-CLI Bedrock failure shape and parse coverage for Bedrock unusable
  status.

Verification

- bunx nx test claude (fake-CLI inspect + parse unit tests; live integration
  remains opt-in skips).

Out of scope

- Operator docs (#804), Bedrock model selection in Settings (#800/#805).

Closes #802