### PR TITLE
feat(claude): allow free-text Agent Model ids in Settings for Bedrock

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,12 +166,12 @@ Claude Code with `claude auth login` or `ANTHROPIC_API_KEY` before Recheck /
 Agent Turns. For **Amazon Bedrock**, set `CLAUDE_CODE_USE_BEDROCK=1` plus AWS
 credentials/region on the harness process instead of first-party login; see
 [Claude Code on Amazon Bedrock](docs/claude-code-amazon-bedrock.md) (Ready vs
-Unavailable, optional model pins, and MVP Settings limits). Harness-launched
-Claude processes disable auto-update for that session (`DISABLE_AUTOUPDATER`).
-Claude Code Agent Turns do not integrate Keymaxxer; Session Telemetry is
-unsupported in v1. Opt-in live adapter tests use `GROK_INTEGRATION=1` /
-`OPENCODE_INTEGRATION=1` / `CODEX_INTEGRATION=1` / `CLAUDE_INTEGRATION=1`;
-normal CI does not need paid model credentials.
+Unavailable, hybrid model selection: catalog aliases, Settings free-text, and
+optional env pins). Harness-launched Claude processes disable auto-update for
+that session (`DISABLE_AUTOUPDATER`). Claude Code Agent Turns do not integrate
+Keymaxxer; Session Telemetry is unsupported in v1. Opt-in live adapter tests
+use `GROK_INTEGRATION=1` / `OPENCODE_INTEGRATION=1` / `CODEX_INTEGRATION=1` /
+`CLAUDE_INTEGRATION=1`; normal CI does not need paid model credentials.
 
 # KeyMaxxer
 
@@ -201,10 +201,11 @@ backend.
 2. Can I run Claude Code through Amazon Bedrock?
 
 Yes. Export `CLAUDE_CODE_USE_BEDROCK=1` and your AWS credentials/region on the
-harness process, select Claude Code, then Recheck. Settings still lists
-floating aliases only; pin Bedrock inference profiles via Claude env vars.
-First-party login failures and Bedrock/AWS failures show different Unavailable
-messages. Details:
+harness process, select Claude Code, then Recheck. For models, pick a catalog
+alias (`haiku` / `sonnet` / `opus` / `fable`), enter a free-text Bedrock
+inference profile ID or ARN as build/review Agent Model, and/or optionally pin
+aliases with `ANTHROPIC_DEFAULT_*_MODEL`. First-party login failures and
+Bedrock/AWS failures show different Unavailable messages. Details:
 [docs/claude-code-amazon-bedrock.md](docs/claude-code-amazon-bedrock.md).
 
 3. Does the harness support a Forge other than GitHub?

--- a/apps/harness/src/agent-model-settings.ts
+++ b/apps/harness/src/agent-model-settings.ts
@@ -1,0 +1,88 @@
+/**
+ * Settings helpers for Agent Model fields (Harness Config + Repository prefs).
+ *
+ * Claude Code allows free-text model ids (Bedrock inference profile IDs/ARNs
+ * or any Claude-accepted `--model` string) in addition to the static alias
+ * catalog. Other backends stay catalog-constrained at Save (issue #806 / #805).
+ *
+ * Effort levels are a local literal (not imported from `@ready-for-agent/claude`)
+ * so this client-shared module stays free of the Claude adapter barrel.
+ */
+
+export type AgentModelOption = {
+  readonly id: string
+  readonly thinkingLevels: readonly string[]
+}
+
+/** Built-in Claude Code backend id (matches Active Agent Backend registry). */
+export const CLAUDE_AGENT_BACKEND_ID = "claude"
+
+/**
+ * Effort (thinking) options for Claude free-text models — same set as aliases
+ * (ADR 0047: low … max, no ultracode). Keep in lockstep with
+ * `CLAUDE_THINKING_LEVELS` in packages/claude (asserted in unit tests).
+ */
+export const CLAUDE_FREE_TEXT_THINKING_LEVELS: readonly string[] = [
+  "low",
+  "medium",
+  "high",
+  "xhigh",
+  "max",
+]
+
+/** True when Settings may accept non-catalog model strings for this backend. */
+export const allowsClaudeFreeTextModels = (backendId: string): boolean =>
+  backendId === CLAUDE_AGENT_BACKEND_ID
+
+/**
+ * Thinking Levels for a selected model id. Catalog membership wins when the
+ * catalog is loaded; Claude free-text (and Claude while the catalog is still
+ * pending/failed) falls back to the full Claude effort catalog so operators
+ * can set effort the same way as aliases without waiting on inspect. Other
+ * backends return [] when the model is unknown or the catalog is unavailable.
+ */
+export const thinkingLevelsForModel = (
+  backendId: string,
+  models: readonly AgentModelOption[] | undefined,
+  modelId: string,
+): readonly string[] => {
+  if (modelId.length === 0) {
+    return []
+  }
+  if (models !== undefined) {
+    const fromCatalog = models.find(
+      (model) => model.id === modelId,
+    )?.thinkingLevels
+    if (fromCatalog !== undefined) {
+      return fromCatalog
+    }
+  }
+  // Claude free-text effort is static (ADR 0047 / #806) — do not gate it on a
+  // loaded catalog. Also covers Claude aliases while preview/models is pending.
+  if (allowsClaudeFreeTextModels(backendId)) {
+    return CLAUDE_FREE_TEXT_THINKING_LEVELS
+  }
+  return []
+}
+
+/**
+ * True when a non-empty model string is absent from the loaded catalog and the
+ * backend does not allow free-text. Used to block Save and hide effort.
+ */
+export const isUnavailableCatalogModel = (input: {
+  readonly backendId: string
+  readonly modelId: string
+  readonly catalogModelIds: readonly string[]
+}): boolean =>
+  input.modelId.length > 0 &&
+  !input.catalogModelIds.includes(input.modelId) &&
+  !allowsClaudeFreeTextModels(input.backendId)
+
+export const formatVariantLabel = (variant: string): string =>
+  `${variant[0]?.toUpperCase() ?? ""}${variant.slice(1)}`
+
+export const reconcileVariantForModel = (
+  variant: string,
+  modelVariants: readonly string[],
+): string =>
+  variant.length > 0 && modelVariants.includes(variant) ? variant : ""

--- a/apps/harness/src/routes/__root.tsx
+++ b/apps/harness/src/routes/__root.tsx
@@ -23,6 +23,14 @@ import {
   useState,
 } from "react"
 import { createClient } from "@ready-for-agent/graphql-client"
+import {
+  type AgentModelOption,
+  allowsClaudeFreeTextModels,
+  formatVariantLabel,
+  isUnavailableCatalogModel,
+  reconcileVariantForModel,
+  thinkingLevelsForModel,
+} from "../agent-model-settings.js"
 import { Banner, BannerActionButton } from "../banner.js"
 import { CommittedPullRequestsDashboard } from "../committed-pr-dashboard.js"
 import { READY_FOR_AGENT_VERSION_LABEL } from "../generated/version"
@@ -92,11 +100,6 @@ const agentBackendStatusQuery = {
   },
 }
 
-type AgentModelOption = {
-  id: string
-  thinkingLevels: readonly string[]
-}
-
 type AgentBackendStatusRow = {
   backend: { id: string; label: string }
   selectedBackend: { id: string; label: string }
@@ -117,23 +120,6 @@ const modelsQuery = {
     return result.models
   },
 }
-
-const variantsForModel = (
-  models: readonly AgentModelOption[] | undefined,
-  modelId: string,
-): readonly string[] => {
-  if (modelId.length === 0 || models === undefined) return []
-  return models.find((model) => model.id === modelId)?.thinkingLevels ?? []
-}
-
-const formatVariantLabel = (variant: string): string =>
-  `${variant[0]?.toUpperCase() ?? ""}${variant.slice(1)}`
-
-const reconcileVariantForModel = (
-  variant: string,
-  modelVariants: readonly string[],
-): string =>
-  variant.length > 0 && modelVariants.includes(variant) ? variant : ""
 
 const isBuildModelConfigured = (
   config:
@@ -653,12 +639,12 @@ function SettingsChrome() {
     const parsedMaxWorkItems = Number(maxConcurrentWorkItems)
     updateConfig.mutate({
       selectedAgentBackend,
-      defaultModel: defaultModel.trim() === "" ? null : defaultModel,
+      defaultModel: defaultModel.trim() === "" ? null : defaultModel.trim(),
       defaultThinkingLevel:
-        defaultThinkingLevel.trim() === "" ? null : defaultThinkingLevel,
-      reviewModel: reviewModel.trim() === "" ? null : reviewModel,
+        defaultThinkingLevel.trim() === "" ? null : defaultThinkingLevel.trim(),
+      reviewModel: reviewModel.trim() === "" ? null : reviewModel.trim(),
       reviewThinkingLevel:
-        reviewThinkingLevel.trim() === "" ? null : reviewThinkingLevel,
+        reviewThinkingLevel.trim() === "" ? null : reviewThinkingLevel.trim(),
       maxConcurrentAgentTurns: parsedMaxSessions,
       maxConcurrentWorkItems: parsedMaxWorkItems,
     })
@@ -668,24 +654,47 @@ function SettingsChrome() {
     ? (previewModels ?? undefined)
     : models.data
   const modelIds = (catalogModels ?? []).map((model) => model.id)
-  const buildVariants = variantsForModel(catalogModels, defaultModel)
+  // Draft backend while changing; otherwise the saved/selected harness default.
+  const modelBackendId = selectedAgentBackend
+  const claudeFreeTextModels = allowsClaudeFreeTextModels(modelBackendId)
+  const buildVariants = thinkingLevelsForModel(
+    modelBackendId,
+    catalogModels,
+    defaultModel,
+  )
   const reviewThinkingLevelSourceModel =
     reviewModel.length > 0 ? reviewModel : defaultModel
-  const reviewThinkingLevels = variantsForModel(
+  const reviewThinkingLevels = thinkingLevelsForModel(
+    modelBackendId,
     catalogModels,
     reviewThinkingLevelSourceModel,
   )
-  const hasUnavailableBuildModel =
-    defaultModel.length > 0 && !modelIds.includes(defaultModel)
-  const hasUnavailableReviewModel =
-    reviewModel.length > 0 && !modelIds.includes(reviewModel)
+  // Catalog-absent models block Save only for catalog-constrained backends.
+  // Claude free-text (Bedrock profile IDs/ARNs, custom ids) is allowed (#806).
+  const hasUnavailableBuildModel = isUnavailableCatalogModel({
+    backendId: modelBackendId,
+    modelId: defaultModel,
+    catalogModelIds: modelIds,
+  })
+  const hasUnavailableReviewModel = isUnavailableCatalogModel({
+    backendId: modelBackendId,
+    modelId: reviewModel,
+    catalogModelIds: modelIds,
+  })
+  // Same catalog-gate as Save: Claude free-text is never "unavailable".
+  const buildEffortSourceUnavailable = hasUnavailableBuildModel
+  const reviewEffortSourceUnavailable = isUnavailableCatalogModel({
+    backendId: modelBackendId,
+    modelId: reviewThinkingLevelSourceModel,
+    catalogModelIds: modelIds,
+  })
   const hasCustomBuildVariant =
     defaultThinkingLevel.length > 0 &&
-    (hasUnavailableBuildModel || !buildVariants.includes(defaultThinkingLevel))
+    (buildEffortSourceUnavailable ||
+      !buildVariants.includes(defaultThinkingLevel))
   const hasCustomReviewVariant =
     reviewThinkingLevel.length > 0 &&
-    (hasUnavailableReviewModel ||
-      (reviewModel.length === 0 && hasUnavailableBuildModel) ||
+    (reviewEffortSourceUnavailable ||
       !reviewThinkingLevels.includes(reviewThinkingLevel))
   // First-run banner is about the harness default build model only; fully
   // configured Repository overrides are not hard-blocked by this guidance.
@@ -1018,55 +1027,104 @@ function SettingsChrome() {
                     <span className={ui.dialogSectionMeta}>Build · Review</span>
                   </div>
 
-                  <label className={cx(ui.dialogField, ui.dialogFieldMono)}>
-                    Build model
-                    <select
-                      className={cx(ui.dialogInput, ui.dialogInputMono)}
-                      name="defaultModel"
-                      value={defaultModel}
-                      onChange={(event) => {
-                        const nextModel = event.target.value
-                        setDefaultModel(nextModel)
-                        const nextVariants = variantsForModel(
-                          catalogModels,
-                          nextModel,
-                        )
-                        setDefaultVariant((current) =>
-                          reconcileVariantForModel(current, nextVariants),
-                        )
-                        if (reviewModel.length === 0) {
-                          setReviewVariant((current) =>
+                  {claudeFreeTextModels ? (
+                    <label className={cx(ui.dialogField, ui.dialogFieldMono)}>
+                      Build model
+                      <input
+                        className={cx(ui.dialogInput, ui.dialogInputMono)}
+                        name="defaultModel"
+                        list="harness-claude-build-models"
+                        value={defaultModel}
+                        onChange={(event) => {
+                          const nextModel = event.target.value
+                          setDefaultModel(nextModel)
+                          const nextVariants = thinkingLevelsForModel(
+                            modelBackendId,
+                            catalogModels,
+                            nextModel,
+                          )
+                          setDefaultVariant((current) =>
                             reconcileVariantForModel(current, nextVariants),
                           )
-                        }
-                      }}
-                      required={!backendChanging}
-                      disabled={modelsDisabled}
-                    >
-                      {defaultModel.length === 0 && (
-                        <option value="">
-                          {previewPending
+                          if (reviewModel.length === 0) {
+                            setReviewVariant((current) =>
+                              reconcileVariantForModel(current, nextVariants),
+                            )
+                          }
+                        }}
+                        required={!backendChanging}
+                        disabled={modelsDisabled}
+                        placeholder={
+                          previewPending
                             ? "Loading catalog…"
-                            : "Select a build model"}
-                        </option>
-                      )}
-                      {hasUnavailableBuildModel && (
-                        <option value={defaultModel}>
-                          {defaultModel} (not in Agent Model catalog)
-                        </option>
-                      )}
-                      {(catalogModels ?? []).map((model) => (
-                        <option key={model.id} value={model.id}>
-                          {model.id}
-                        </option>
-                      ))}
-                    </select>
-                    <span className={ui.dialogFieldHint}>
-                      Used for implement and other build steps.
-                    </span>
-                  </label>
+                            : "Alias or custom model ID"
+                        }
+                        autoComplete="off"
+                        spellCheck={false}
+                      />
+                      <datalist id="harness-claude-build-models">
+                        {(catalogModels ?? []).map((model) => (
+                          <option key={model.id} value={model.id} />
+                        ))}
+                      </datalist>
+                      <span className={ui.dialogFieldHint}>
+                        Catalog alias (haiku, sonnet, opus, fable) or any
+                        Claude-accepted model string (Bedrock inference profile
+                        ID/ARN). Used for implement and other build steps.
+                      </span>
+                    </label>
+                  ) : (
+                    <label className={cx(ui.dialogField, ui.dialogFieldMono)}>
+                      Build model
+                      <select
+                        className={cx(ui.dialogInput, ui.dialogInputMono)}
+                        name="defaultModel"
+                        value={defaultModel}
+                        onChange={(event) => {
+                          const nextModel = event.target.value
+                          setDefaultModel(nextModel)
+                          const nextVariants = thinkingLevelsForModel(
+                            modelBackendId,
+                            catalogModels,
+                            nextModel,
+                          )
+                          setDefaultVariant((current) =>
+                            reconcileVariantForModel(current, nextVariants),
+                          )
+                          if (reviewModel.length === 0) {
+                            setReviewVariant((current) =>
+                              reconcileVariantForModel(current, nextVariants),
+                            )
+                          }
+                        }}
+                        required={!backendChanging}
+                        disabled={modelsDisabled}
+                      >
+                        {defaultModel.length === 0 && (
+                          <option value="">
+                            {previewPending
+                              ? "Loading catalog…"
+                              : "Select a build model"}
+                          </option>
+                        )}
+                        {hasUnavailableBuildModel && (
+                          <option value={defaultModel}>
+                            {defaultModel} (not in Agent Model catalog)
+                          </option>
+                        )}
+                        {(catalogModels ?? []).map((model) => (
+                          <option key={model.id} value={model.id}>
+                            {model.id}
+                          </option>
+                        ))}
+                      </select>
+                      <span className={ui.dialogFieldHint}>
+                        Used for implement and other build steps.
+                      </span>
+                    </label>
+                  )}
 
-                  {defaultModel.length > 0 && hasUnavailableBuildModel ? (
+                  {defaultModel.length > 0 && buildEffortSourceUnavailable ? (
                     <Banner
                       className={ui.bannerCompact}
                       tone="alarm"
@@ -1117,45 +1175,83 @@ function SettingsChrome() {
                     </label>
                   )}
 
-                  <label className={cx(ui.dialogField, ui.dialogFieldMono)}>
-                    Review model
-                    <select
-                      className={cx(ui.dialogInput, ui.dialogInputMono)}
-                      name="reviewModel"
-                      value={reviewModel}
-                      disabled={modelsDisabled}
-                      onChange={(event) => {
-                        const nextModel = event.target.value
-                        setReviewModel(nextModel)
-                        const nextVariants = variantsForModel(
-                          catalogModels,
-                          nextModel.length > 0 ? nextModel : defaultModel,
-                        )
-                        setReviewVariant((current) =>
-                          reconcileVariantForModel(current, nextVariants),
-                        )
-                      }}
-                    >
-                      <option value="">Same as build model</option>
-                      {hasUnavailableReviewModel && (
-                        <option value={reviewModel}>
-                          {reviewModel} (not in Agent Model catalog)
-                        </option>
-                      )}
-                      {(catalogModels ?? []).map((model) => (
-                        <option key={`review-${model.id}`} value={model.id}>
-                          {model.id}
-                        </option>
-                      ))}
-                    </select>
-                    <span className={ui.dialogFieldHint}>
-                      Used only for the review step. Empty uses the build model.
-                    </span>
-                  </label>
+                  {claudeFreeTextModels ? (
+                    <label className={cx(ui.dialogField, ui.dialogFieldMono)}>
+                      Review model
+                      <input
+                        className={cx(ui.dialogInput, ui.dialogInputMono)}
+                        name="reviewModel"
+                        list="harness-claude-review-models"
+                        value={reviewModel}
+                        disabled={modelsDisabled}
+                        onChange={(event) => {
+                          const nextModel = event.target.value
+                          setReviewModel(nextModel)
+                          const nextVariants = thinkingLevelsForModel(
+                            modelBackendId,
+                            catalogModels,
+                            nextModel.length > 0 ? nextModel : defaultModel,
+                          )
+                          setReviewVariant((current) =>
+                            reconcileVariantForModel(current, nextVariants),
+                          )
+                        }}
+                        placeholder="Same as build model"
+                        autoComplete="off"
+                        spellCheck={false}
+                      />
+                      <datalist id="harness-claude-review-models">
+                        {(catalogModels ?? []).map((model) => (
+                          <option key={`review-${model.id}`} value={model.id} />
+                        ))}
+                      </datalist>
+                      <span className={ui.dialogFieldHint}>
+                        Optional review alias or custom Claude model ID. Empty
+                        uses the build model.
+                      </span>
+                    </label>
+                  ) : (
+                    <label className={cx(ui.dialogField, ui.dialogFieldMono)}>
+                      Review model
+                      <select
+                        className={cx(ui.dialogInput, ui.dialogInputMono)}
+                        name="reviewModel"
+                        value={reviewModel}
+                        disabled={modelsDisabled}
+                        onChange={(event) => {
+                          const nextModel = event.target.value
+                          setReviewModel(nextModel)
+                          const nextVariants = thinkingLevelsForModel(
+                            modelBackendId,
+                            catalogModels,
+                            nextModel.length > 0 ? nextModel : defaultModel,
+                          )
+                          setReviewVariant((current) =>
+                            reconcileVariantForModel(current, nextVariants),
+                          )
+                        }}
+                      >
+                        <option value="">Same as build model</option>
+                        {hasUnavailableReviewModel && (
+                          <option value={reviewModel}>
+                            {reviewModel} (not in Agent Model catalog)
+                          </option>
+                        )}
+                        {(catalogModels ?? []).map((model) => (
+                          <option key={`review-${model.id}`} value={model.id}>
+                            {model.id}
+                          </option>
+                        ))}
+                      </select>
+                      <span className={ui.dialogFieldHint}>
+                        Used only for the review step. Empty uses the build
+                        model.
+                      </span>
+                    </label>
+                  )}
 
                   {reviewThinkingLevelSourceModel.length > 0 &&
-                  ((reviewModel.length > 0 && hasUnavailableReviewModel) ||
-                    (reviewModel.length === 0 && hasUnavailableBuildModel)) ? (
+                  reviewEffortSourceUnavailable ? (
                     <Banner
                       className={ui.bannerCompact}
                       tone="alarm"
@@ -1331,10 +1427,11 @@ function SettingsChrome() {
                 updateConfig.isPending ||
                 (backendChangeBlocked && backendChanging) ||
                 (backendChanging && previewError !== null) ||
-                // Empty build model allowed on backend change (first-run style);
-                // non-empty must still be in the preview/active catalog.
+                // Empty build model allowed on backend change (first-run style).
+                // Non-empty catalog-constrained backends must stay in catalog;
+                // Claude free-text custom ids are allowed (#806).
                 (defaultModel.length > 0 && hasUnavailableBuildModel) ||
-                (!backendChanging && defaultModel.length === 0)
+                (!backendChanging && defaultModel.trim().length === 0)
               }
             >
               {updateConfig.isPending ? "Saving…" : "Save settings"}

--- a/apps/harness/src/routes/index.tsx
+++ b/apps/harness/src/routes/index.tsx
@@ -19,6 +19,14 @@ import {
   COMPLETED_WORK_ITEMS_DEFAULT_PAGE_SIZE as completedWorkItemsDefaultPageSize,
   JOBS_COMPLETED_WINDOW_HOURS as jobsCompletedWindowHours,
 } from "@ready-for-agent/work-item-lifecycle/jobs-completed-window"
+import {
+  type AgentModelOption,
+  allowsClaudeFreeTextModels,
+  formatVariantLabel,
+  isUnavailableCatalogModel,
+  reconcileVariantForModel,
+  thinkingLevelsForModel,
+} from "../agent-model-settings.js"
 import { Banner, BannerActionButton } from "../banner.js"
 import { repositoryCardCollapseId, useCardCollapsed } from "../card-collapse.js"
 import { CardCollapseToggle } from "../card-collapse-toggle.js"
@@ -107,11 +115,6 @@ const configQuery = {
   },
 }
 
-type AgentModelOption = {
-  id: string
-  thinkingLevels: readonly string[]
-}
-
 type AgentBackendInfo = {
   id: string
   label: string
@@ -198,23 +201,6 @@ const formatSessionInstant = (value: string | null | undefined): string => {
 
 const formatTokenCount = (value: number): string =>
   new Intl.NumberFormat(undefined).format(value)
-
-const variantsForModel = (
-  models: readonly AgentModelOption[] | undefined,
-  modelId: string,
-): readonly string[] => {
-  if (modelId.length === 0 || models === undefined) return []
-  return models.find((model) => model.id === modelId)?.thinkingLevels ?? []
-}
-
-const formatVariantLabel = (variant: string): string =>
-  `${variant[0]?.toUpperCase() ?? ""}${variant.slice(1)}`
-
-const reconcileVariantForModel = (
-  variant: string,
-  modelVariants: readonly string[],
-): string =>
-  variant.length > 0 && modelVariants.includes(variant) ? variant : ""
 
 /**
  * Dedicated cache identity for GitHub open non-draft Pull Request counts.
@@ -1200,12 +1186,12 @@ function RepositoryCard({
   }
 
   const currentDraftModelPrefs = (): DraftModelPrefs => ({
-    defaultModel: defaultModel.trim() === "" ? null : defaultModel,
+    defaultModel: defaultModel.trim() === "" ? null : defaultModel.trim(),
     defaultThinkingLevel:
-      defaultThinkingLevel.trim() === "" ? null : defaultThinkingLevel,
-    reviewModel: reviewModel.trim() === "" ? null : reviewModel,
+      defaultThinkingLevel.trim() === "" ? null : defaultThinkingLevel.trim(),
+    reviewModel: reviewModel.trim() === "" ? null : reviewModel.trim(),
     reviewThinkingLevel:
-      reviewThinkingLevel.trim() === "" ? null : reviewThinkingLevel,
+      reviewThinkingLevel.trim() === "" ? null : reviewThinkingLevel.trim(),
   })
 
   const draftEffectiveBackend = (
@@ -1318,12 +1304,12 @@ function RepositoryCard({
       projectPath: projectPath.trim(),
       paused,
       selectedAgentBackend,
-      defaultModel: defaultModel.trim() === "" ? null : defaultModel,
+      defaultModel: defaultModel.trim() === "" ? null : defaultModel.trim(),
       defaultThinkingLevel:
-        defaultThinkingLevel.trim() === "" ? null : defaultThinkingLevel,
-      reviewModel: reviewModel.trim() === "" ? null : reviewModel,
+        defaultThinkingLevel.trim() === "" ? null : defaultThinkingLevel.trim(),
+      reviewModel: reviewModel.trim() === "" ? null : reviewModel.trim(),
       reviewThinkingLevel:
-        reviewThinkingLevel.trim() === "" ? null : reviewThinkingLevel,
+        reviewThinkingLevel.trim() === "" ? null : reviewThinkingLevel.trim(),
       autoMerge,
       includeAllIssueAuthors,
       waitForReadyForReviewChecks,
@@ -1482,6 +1468,8 @@ function RepositoryCard({
   const catalogModels: readonly AgentModelOption[] | undefined =
     usesPreviewCatalog ? (previewModels ?? undefined) : models.data
   const modelIds = (catalogModels ?? []).map((model) => model.id)
+  const modelBackendId = draftEffective
+  const claudeFreeTextModels = allowsClaudeFreeTextModels(modelBackendId)
   const harnessBuildForSource =
     harnessDefaultModel !== "not configured" ? harnessDefaultModel : ""
   const harnessReviewForSource = !harnessReviewModel.startsWith("Build (")
@@ -1497,21 +1485,39 @@ function RepositoryCard({
         : harnessReviewForSource.length > 0
           ? harnessReviewForSource
           : harnessBuildForSource
-  const buildVariants = variantsForModel(catalogModels, buildVariantSourceModel)
-  const reviewThinkingLevels = variantsForModel(
+  const buildVariants = thinkingLevelsForModel(
+    modelBackendId,
+    catalogModels,
+    buildVariantSourceModel,
+  )
+  const reviewThinkingLevels = thinkingLevelsForModel(
+    modelBackendId,
     catalogModels,
     reviewThinkingLevelSourceModel,
   )
-  const hasUnavailableBuildModel =
-    defaultModel.length > 0 && !modelIds.includes(defaultModel)
-  const hasUnavailableReviewModel =
-    reviewModel.length > 0 && !modelIds.includes(reviewModel)
-  const buildVariantSourceUnavailable =
-    buildVariantSourceModel.length > 0 &&
-    !modelIds.includes(buildVariantSourceModel)
-  const reviewThinkingLevelSourceUnavailable =
-    reviewThinkingLevelSourceModel.length > 0 &&
-    !modelIds.includes(reviewThinkingLevelSourceModel)
+  // Catalog-absent models block Save only for catalog-constrained backends.
+  // Claude free-text (Bedrock profile IDs/ARNs, custom ids) is allowed (#806).
+  const hasUnavailableBuildModel = isUnavailableCatalogModel({
+    backendId: modelBackendId,
+    modelId: defaultModel,
+    catalogModelIds: modelIds,
+  })
+  const hasUnavailableReviewModel = isUnavailableCatalogModel({
+    backendId: modelBackendId,
+    modelId: reviewModel,
+    catalogModelIds: modelIds,
+  })
+  // Effort source may be the override or an inherited harness model string.
+  const buildVariantSourceUnavailable = isUnavailableCatalogModel({
+    backendId: modelBackendId,
+    modelId: buildVariantSourceModel,
+    catalogModelIds: modelIds,
+  })
+  const reviewThinkingLevelSourceUnavailable = isUnavailableCatalogModel({
+    backendId: modelBackendId,
+    modelId: reviewThinkingLevelSourceModel,
+    catalogModelIds: modelIds,
+  })
   const hasCustomBuildVariant =
     defaultThinkingLevel.length > 0 &&
     (buildVariantSourceUnavailable ||
@@ -1529,7 +1535,8 @@ function RepositoryCard({
       : models.isPending || config.isPending || agentBackends.isPending)
   // Only enforce "model not in catalog" when a catalog actually loaded.
   // Failed/pending override preview leaves modelIds empty and must not block
-  // non-model saves for the current effective backend.
+  // non-model saves for the current effective backend. Claude free-text is
+  // never blocked by catalog membership (#806).
   const catalogReadyForModelValidation = usesPreviewCatalog
     ? !previewPending && previewError === null && previewModels !== null
     : !models.isPending && !models.isError && models.data !== undefined
@@ -2124,57 +2131,123 @@ function RepositoryCard({
                 </Banner>
               ) : (
                 <>
-                  <label className={ui.dialogField}>
-                    Build model
-                    <select
-                      className={cx(ui.dialogInput, ui.dialogInputMono)}
-                      value={defaultModel}
-                      disabled={modelsDisabled}
-                      onChange={(event) => {
-                        const nextModel = event.target.value
-                        setDefaultModel(nextModel)
-                        const sourceModel =
-                          nextModel.length > 0
-                            ? nextModel
-                            : harnessBuildForSource
-                        const nextVariants = variantsForModel(
-                          catalogModels,
-                          sourceModel,
-                        )
-                        setDefaultVariant((current) =>
-                          reconcileVariantForModel(current, nextVariants),
-                        )
-                        if (reviewModel.length === 0) {
-                          const reviewSource =
+                  {claudeFreeTextModels ? (
+                    <label className={ui.dialogField}>
+                      Build model
+                      <input
+                        className={cx(ui.dialogInput, ui.dialogInputMono)}
+                        list={`repo-claude-build-models-${repository.id}`}
+                        value={defaultModel}
+                        disabled={modelsDisabled}
+                        onChange={(event) => {
+                          const nextModel = event.target.value
+                          setDefaultModel(nextModel)
+                          const sourceModel =
                             nextModel.length > 0
                               ? nextModel
-                              : harnessReviewForSource.length > 0
-                                ? harnessReviewForSource
-                                : harnessBuildForSource
-                          setReviewVariant((current) =>
-                            reconcileVariantForModel(
-                              current,
-                              variantsForModel(catalogModels, reviewSource),
-                            ),
+                              : harnessBuildForSource
+                          const nextVariants = thinkingLevelsForModel(
+                            modelBackendId,
+                            catalogModels,
+                            sourceModel,
                           )
-                        }
-                      }}
-                    >
-                      <option value="">
-                        Harness default ({harnessDefaultModel})
-                      </option>
-                      {hasUnavailableBuildModel && (
-                        <option value={defaultModel}>
-                          {defaultModel} (not in Agent Model catalog)
+                          setDefaultVariant((current) =>
+                            reconcileVariantForModel(current, nextVariants),
+                          )
+                          if (reviewModel.length === 0) {
+                            const reviewSource =
+                              nextModel.length > 0
+                                ? nextModel
+                                : harnessReviewForSource.length > 0
+                                  ? harnessReviewForSource
+                                  : harnessBuildForSource
+                            setReviewVariant((current) =>
+                              reconcileVariantForModel(
+                                current,
+                                thinkingLevelsForModel(
+                                  modelBackendId,
+                                  catalogModels,
+                                  reviewSource,
+                                ),
+                              ),
+                            )
+                          }
+                        }}
+                        placeholder={`Harness default (${harnessDefaultModel})`}
+                        autoComplete="off"
+                        spellCheck={false}
+                      />
+                      <datalist
+                        id={`repo-claude-build-models-${repository.id}`}
+                      >
+                        {(catalogModels ?? []).map((model) => (
+                          <option key={model.id} value={model.id} />
+                        ))}
+                      </datalist>
+                      <span className={ui.dialogFieldHint}>
+                        Empty inherits harness default. Otherwise catalog alias
+                        or any Claude-accepted model string (Bedrock profile
+                        ID/ARN).
+                      </span>
+                    </label>
+                  ) : (
+                    <label className={ui.dialogField}>
+                      Build model
+                      <select
+                        className={cx(ui.dialogInput, ui.dialogInputMono)}
+                        value={defaultModel}
+                        disabled={modelsDisabled}
+                        onChange={(event) => {
+                          const nextModel = event.target.value
+                          setDefaultModel(nextModel)
+                          const sourceModel =
+                            nextModel.length > 0
+                              ? nextModel
+                              : harnessBuildForSource
+                          const nextVariants = thinkingLevelsForModel(
+                            modelBackendId,
+                            catalogModels,
+                            sourceModel,
+                          )
+                          setDefaultVariant((current) =>
+                            reconcileVariantForModel(current, nextVariants),
+                          )
+                          if (reviewModel.length === 0) {
+                            const reviewSource =
+                              nextModel.length > 0
+                                ? nextModel
+                                : harnessReviewForSource.length > 0
+                                  ? harnessReviewForSource
+                                  : harnessBuildForSource
+                            setReviewVariant((current) =>
+                              reconcileVariantForModel(
+                                current,
+                                thinkingLevelsForModel(
+                                  modelBackendId,
+                                  catalogModels,
+                                  reviewSource,
+                                ),
+                              ),
+                            )
+                          }
+                        }}
+                      >
+                        <option value="">
+                          Harness default ({harnessDefaultModel})
                         </option>
-                      )}
-                      {(catalogModels ?? []).map((model) => (
-                        <option key={model.id} value={model.id}>
-                          {model.id}
-                        </option>
-                      ))}
-                    </select>
-                  </label>
+                        {hasUnavailableBuildModel && (
+                          <option value={defaultModel}>
+                            {defaultModel} (not in Agent Model catalog)
+                          </option>
+                        )}
+                        {(catalogModels ?? []).map((model) => (
+                          <option key={model.id} value={model.id}>
+                            {model.id}
+                          </option>
+                        ))}
+                      </select>
+                    </label>
+                  )}
                   {buildVariantSourceModel.length > 0 &&
                   buildVariantSourceUnavailable ? (
                     <Banner
@@ -2225,46 +2298,94 @@ function RepositoryCard({
                       </select>
                     </label>
                   )}
-                  <label className={ui.dialogField}>
-                    Review model
-                    <select
-                      className={cx(ui.dialogInput, ui.dialogInputMono)}
-                      value={reviewModel}
-                      disabled={modelsDisabled}
-                      onChange={(event) => {
-                        const nextModel = event.target.value
-                        setReviewModel(nextModel)
-                        const sourceModel =
-                          nextModel.length > 0
-                            ? nextModel
-                            : defaultModel.length > 0
-                              ? defaultModel
-                              : harnessReviewForSource.length > 0
-                                ? harnessReviewForSource
-                                : harnessBuildForSource
-                        setReviewVariant((current) =>
-                          reconcileVariantForModel(
-                            current,
-                            variantsForModel(catalogModels, sourceModel),
-                          ),
-                        )
-                      }}
-                    >
-                      <option value="">
-                        Harness default ({harnessReviewModel})
-                      </option>
-                      {hasUnavailableReviewModel && (
-                        <option value={reviewModel}>
-                          {reviewModel} (not in Agent Model catalog)
+                  {claudeFreeTextModels ? (
+                    <label className={ui.dialogField}>
+                      Review model
+                      <input
+                        className={cx(ui.dialogInput, ui.dialogInputMono)}
+                        list={`repo-claude-review-models-${repository.id}`}
+                        value={reviewModel}
+                        disabled={modelsDisabled}
+                        onChange={(event) => {
+                          const nextModel = event.target.value
+                          setReviewModel(nextModel)
+                          const sourceModel =
+                            nextModel.length > 0
+                              ? nextModel
+                              : defaultModel.length > 0
+                                ? defaultModel
+                                : harnessReviewForSource.length > 0
+                                  ? harnessReviewForSource
+                                  : harnessBuildForSource
+                          setReviewVariant((current) =>
+                            reconcileVariantForModel(
+                              current,
+                              thinkingLevelsForModel(
+                                modelBackendId,
+                                catalogModels,
+                                sourceModel,
+                              ),
+                            ),
+                          )
+                        }}
+                        placeholder={`Harness default (${harnessReviewModel})`}
+                        autoComplete="off"
+                        spellCheck={false}
+                      />
+                      <datalist
+                        id={`repo-claude-review-models-${repository.id}`}
+                      >
+                        {(catalogModels ?? []).map((model) => (
+                          <option key={`review-${model.id}`} value={model.id} />
+                        ))}
+                      </datalist>
+                    </label>
+                  ) : (
+                    <label className={ui.dialogField}>
+                      Review model
+                      <select
+                        className={cx(ui.dialogInput, ui.dialogInputMono)}
+                        value={reviewModel}
+                        disabled={modelsDisabled}
+                        onChange={(event) => {
+                          const nextModel = event.target.value
+                          setReviewModel(nextModel)
+                          const sourceModel =
+                            nextModel.length > 0
+                              ? nextModel
+                              : defaultModel.length > 0
+                                ? defaultModel
+                                : harnessReviewForSource.length > 0
+                                  ? harnessReviewForSource
+                                  : harnessBuildForSource
+                          setReviewVariant((current) =>
+                            reconcileVariantForModel(
+                              current,
+                              thinkingLevelsForModel(
+                                modelBackendId,
+                                catalogModels,
+                                sourceModel,
+                              ),
+                            ),
+                          )
+                        }}
+                      >
+                        <option value="">
+                          Harness default ({harnessReviewModel})
                         </option>
-                      )}
-                      {(catalogModels ?? []).map((model) => (
-                        <option key={`review-${model.id}`} value={model.id}>
-                          {model.id}
-                        </option>
-                      ))}
-                    </select>
-                  </label>
+                        {hasUnavailableReviewModel && (
+                          <option value={reviewModel}>
+                            {reviewModel} (not in Agent Model catalog)
+                          </option>
+                        )}
+                        {(catalogModels ?? []).map((model) => (
+                          <option key={`review-${model.id}`} value={model.id}>
+                            {model.id}
+                          </option>
+                        ))}
+                      </select>
+                    </label>
+                  )}
                   {reviewThinkingLevelSourceModel.length > 0 &&
                   reviewThinkingLevelSourceUnavailable ? (
                     <Banner

--- a/apps/harness/test/agent-model-settings.test.ts
+++ b/apps/harness/test/agent-model-settings.test.ts
@@ -1,0 +1,143 @@
+import { CLAUDE_THINKING_LEVELS } from "@ready-for-agent/claude"
+import {
+  CLAUDE_AGENT_BACKEND_ID,
+  CLAUDE_FREE_TEXT_THINKING_LEVELS,
+  allowsClaudeFreeTextModels,
+  isUnavailableCatalogModel,
+  thinkingLevelsForModel,
+} from "../src/agent-model-settings.js"
+import { describe, expect, test } from "bun:test"
+
+const claudeCatalog = [
+  { id: "haiku", thinkingLevels: ["low", "medium", "high", "xhigh", "max"] },
+  { id: "sonnet", thinkingLevels: ["low", "medium", "high", "xhigh", "max"] },
+  { id: "opus", thinkingLevels: ["low", "medium", "high", "xhigh", "max"] },
+  { id: "fable", thinkingLevels: ["low", "medium", "high", "xhigh", "max"] },
+] as const
+
+const catalogIds = claudeCatalog.map((model) => model.id)
+
+describe("Claude free-text Agent Model settings (issue #806)", () => {
+  test("only Claude backend allows free-text model strings", () => {
+    expect(allowsClaudeFreeTextModels(CLAUDE_AGENT_BACKEND_ID)).toBe(true)
+    expect(allowsClaudeFreeTextModels("opencode")).toBe(false)
+    expect(allowsClaudeFreeTextModels("codex")).toBe(false)
+    expect(allowsClaudeFreeTextModels("grok")).toBe(false)
+  })
+
+  test("local free-text effort set stays aligned with Claude package catalog", () => {
+    // Client helpers keep a local literal to avoid importing the adapter barrel.
+    expect([...CLAUDE_FREE_TEXT_THINKING_LEVELS]).toEqual([
+      ...CLAUDE_THINKING_LEVELS,
+    ])
+  })
+
+  test("catalog aliases still resolve thinking levels from the catalog", () => {
+    expect(thinkingLevelsForModel("claude", claudeCatalog, "sonnet")).toEqual([
+      "low",
+      "medium",
+      "high",
+      "xhigh",
+      "max",
+    ])
+  })
+
+  test("Claude free-text models offer the full Claude effort catalog", () => {
+    const freeText =
+      "arn:aws:bedrock:us-east-1:123456789012:application-inference-profile/my-profile"
+    expect(thinkingLevelsForModel("claude", claudeCatalog, freeText)).toEqual([
+      ...CLAUDE_FREE_TEXT_THINKING_LEVELS,
+    ])
+    expect(CLAUDE_FREE_TEXT_THINKING_LEVELS).toEqual([
+      "low",
+      "medium",
+      "high",
+      "xhigh",
+      "max",
+    ])
+  })
+
+  test("Claude free-text effort does not require a loaded catalog (issue #806 review)", () => {
+    const freeText =
+      "arn:aws:bedrock:us-east-1:123456789012:application-inference-profile/my-profile"
+    // models query pending / Settings just opened
+    expect(thinkingLevelsForModel("claude", undefined, freeText)).toEqual([
+      ...CLAUDE_FREE_TEXT_THINKING_LEVELS,
+    ])
+    // failed/empty preview still offers static Claude effort
+    expect(thinkingLevelsForModel("claude", [], freeText)).toEqual([
+      ...CLAUDE_FREE_TEXT_THINKING_LEVELS,
+    ])
+    // Claude aliases while catalog is pending also get the static set
+    expect(thinkingLevelsForModel("claude", undefined, "sonnet")).toEqual([
+      ...CLAUDE_FREE_TEXT_THINKING_LEVELS,
+    ])
+  })
+
+  test("other backends do not invent effort levels for unknown models", () => {
+    expect(
+      thinkingLevelsForModel("opencode", claudeCatalog, "custom-id"),
+    ).toEqual([])
+    expect(thinkingLevelsForModel("opencode", undefined, "custom-id")).toEqual(
+      [],
+    )
+  })
+
+  test("catalog membership is not required for Claude free-text at Save", () => {
+    const freeText = "us.anthropic.claude-sonnet-4-6"
+    expect(
+      isUnavailableCatalogModel({
+        backendId: "claude",
+        modelId: freeText,
+        catalogModelIds: catalogIds,
+      }),
+    ).toBe(false)
+  })
+
+  test("catalog-absent models still block Save for non-Claude backends", () => {
+    expect(
+      isUnavailableCatalogModel({
+        backendId: "opencode",
+        modelId: "missing-model",
+        catalogModelIds: ["opencode/deepseek-v4-flash-free"],
+      }),
+    ).toBe(true)
+  })
+
+  test("empty model is never treated as unavailable", () => {
+    expect(
+      isUnavailableCatalogModel({
+        backendId: "claude",
+        modelId: "",
+        catalogModelIds: catalogIds,
+      }),
+    ).toBe(false)
+  })
+})
+
+describe("Harness Settings Claude free-text surface (source contract)", () => {
+  test("harness and repository settings allow free-text Claude model fields", async () => {
+    const { readFileSync } = await import("node:fs")
+    const { join } = await import("node:path")
+    const root = readFileSync(
+      join(import.meta.dir, "../src/routes/__root.tsx"),
+      "utf8",
+    )
+    const index = readFileSync(
+      join(import.meta.dir, "../src/routes/index.tsx"),
+      "utf8",
+    )
+    expect(root).toContain("allowsClaudeFreeTextModels")
+    expect(root).toContain("harness-claude-build-models")
+    expect(root).toContain("Alias or custom model ID")
+    expect(root).toContain("Claude free-text custom ids are allowed")
+    // Save must not block Claude free-text solely for catalog absence.
+    expect(root).toContain("hasUnavailableBuildModel")
+    expect(root).toContain("isUnavailableCatalogModel")
+
+    expect(index).toContain("allowsClaudeFreeTextModels")
+    expect(index).toContain("repo-claude-build-models-")
+    expect(index).toContain("blockSaveForUnavailableBuildModel")
+    expect(index).toContain("isUnavailableCatalogModel")
+  })
+})

--- a/docs/claude-code-amazon-bedrock.md
+++ b/docs/claude-code-amazon-bedrock.md
@@ -2,8 +2,9 @@
 
 Operator note for running the **Claude Code** Agent Backend through
 [Amazon Bedrock](https://code.claude.com/docs/en/amazon-bedrock) under Ready for
-Agent. This is about readiness and process environment—not a redesign of
-Settings model pickers (see [Model selection (MVP)](#model-selection-mvp)).
+Agent. Covers readiness, process environment, and hybrid model selection
+(catalog aliases, Settings free-text, optional env pins — see
+[Model selection](#model-selection)).
 
 Upstream Claude Code setup (IAM, wizard, inference profiles, troubleshooting)
 lives in Anthropic’s docs:
@@ -72,14 +73,14 @@ Optional Claude/Bedrock-related vars (passed through when set) include pins
 below, `ANTHROPIC_BEDROCK_BASE_URL`, and others documented upstream. The
 harness does not invent a separate AWS secret store for this MVP.
 
-## Optional model pins
+## Optional model pins (complementary)
 
-Settings still offers only Claude Code’s **floating aliases** (`haiku`,
-`sonnet`, `opus`, `fable`). On Bedrock, those aliases resolve via Claude
-Code’s defaults unless you pin them.
+Env pins map **catalog aliases** to Bedrock inference profiles process-wide.
+They are complementary to Settings free-text (below), not the only selection
+path.
 
-Pin aliases to inference profile IDs (or ARNs) with Claude’s env vars, for
-example:
+When you select aliases (`haiku` / `sonnet` / `opus` / `fable`) in Settings, pin
+them with Claude’s env vars if Bedrock defaults are not what you want:
 
 ```bash
 export ANTHROPIC_DEFAULT_OPUS_MODEL='us.anthropic.claude-opus-4-8'
@@ -95,8 +96,10 @@ application inference profile ARNs, GovCloud prefixes, and so on). See
 and [model configuration](https://code.claude.com/docs/en/model-config#pin-models-for-third-party-deployments)
 for the full pin variable list (including Fable).
 
-Keep using **aliases** in Harness Settings for build/review models; pins map
-those aliases when Claude Code runs under Bedrock.
+Prefer **Settings free-text** when you need a specific Bedrock profile ID or
+ARN stored as the build/review Agent Model (multi-repo, visible prefs, no
+re-export). Prefer **pins** when operators stay on aliases and share one
+process-wide mapping.
 
 ## Ready vs Unavailable
 
@@ -122,39 +125,45 @@ the parent shell).
 First-party failures and Bedrock/AWS failures use **distinct** Unavailable
 copy so you know which stack to fix.
 
-## Model selection (MVP)
+## Model selection
 
-**In scope today**
+Hybrid selection for the **Claude Code** Agent Backend (Harness Config and
+per-Repository prefs; same backend-scoped model fields as other backends):
 
-- Ready/Unavailable for Bedrock vs first-party as above.
-- Static Settings catalog: `haiku`, `sonnet`, `opus`, `fable` only.
-- Alias resolution and Bedrock inference profile / ARN pins via Claude env
-  (or Claude’s own settings), not via free-text fields in the harness UI.
+| Path | What you do | Notes |
+| --- | --- | --- |
+| **Catalog alias** | Pick `haiku`, `sonnet`, `opus`, or `fable` | Default UX; first-party and typical Bedrock |
+| **Free-text** | Enter a non-empty Claude-accepted model string (Bedrock inference profile ID, application inference profile ARN, dated model id, etc.) as build and/or review Agent Model | Allowed even when absent from the static catalog; no ARN shape check at Save |
+| **Env pins** | Optionally pin aliases via `ANTHROPIC_DEFAULT_*_MODEL` | Maps aliases process-wide; complementary, not required for free-text |
 
-**Not in Settings yet**
+Resolved model strings are passed through as Claude `--model` on Agent Turns.
+Thinking Level / effort for free-text uses the same Claude effort set as
+aliases (`low` … `max`); unsupported model×effort combinations fail at turn
+time. Free-text is **not** gated on Bedrock readiness or `apiProvider` — the
+same Claude prefs may hold an alias or custom id on first-party or Bedrock.
 
-- Free-text Bedrock inference profile IDs or application inference profile
-  ARNs as the selected Agent Model.
+Empty / whitespace-only model values remain invalid. Invalid ids fail at turn
+time as ordinary Step Run / CLI failures (no Save-time provider validation).
+
+**Out of scope**
+
 - Dynamic listing of Bedrock models from AWS or Claude.
-
-If you need operator-chosen Bedrock model IDs stored in harness Config /
-Repository prefs, that is the follow-up: GitHub issue
-[#800](https://github.com/berenddeboer/ready-for-agent/issues/800) (*Claude
-Code: Bedrock model selection in Settings*). Until then, pin aliases with
-env (or Claude settings) and keep selecting aliases in Settings.
+- Free-text expansion for non-Claude Agent Backends (those stay
+  catalog-constrained unless already free-form by design).
 
 ## Quick checklist
 
 1. `claude` on `PATH`.
 2. `CLAUDE_CODE_USE_BEDROCK=1` (and region) available to the harness process.
 3. Valid AWS credentials for Bedrock in that same process environment.
-4. Optional: `ANTHROPIC_DEFAULT_*_MODEL` pins for aliases you use in Settings.
-5. Settings → Claude Code → Recheck Agent Backend → Ready.
-6. Build/review prefs use catalog aliases; pins handle Bedrock resolution.
+4. Settings → Claude Code → Recheck Agent Backend → Ready.
+5. Build/review prefs: catalog alias **or** free-text Bedrock profile ID/ARN
+   (stored in Harness Config / Repository model prefs).
+6. Optional: `ANTHROPIC_DEFAULT_*_MODEL` pins when you keep using aliases.
 
 ## Related
 
 - Main operator install and Agent Backend requirements: [README.md](../README.md)
 - Claude Code Agent Backend decision: [ADR 0047](adr/0047-claude-code-agent-backend.md)
 - Bedrock readiness MVP epic: [issue #799](https://github.com/berenddeboer/ready-for-agent/issues/799)
-- Model selection follow-up: [issue #800](https://github.com/berenddeboer/ready-for-agent/issues/800)
+- Model selection (hybrid aliases + free-text): [issue #800](https://github.com/berenddeboer/ready-for-agent/issues/800) / [issue #806](https://github.com/berenddeboer/ready-for-agent/issues/806)

--- a/packages/claude/test/build-args.spec.ts
+++ b/packages/claude/test/build-args.spec.ts
@@ -103,4 +103,34 @@ describe("buildRunArgs", () => {
     })
     expect(args.at(-1)).toBe("/review\nbody")
   })
+
+  it("passes free-text Bedrock inference profile ids through as --model (issue #806)", () => {
+    const freeText =
+      "arn:aws:bedrock:us-east-1:123456789012:application-inference-profile/my-profile"
+    const args = buildRunArgs({
+      prompt: "implement",
+      model: freeText,
+      thinkingLevel: "high",
+      sessionId: "11111111-1111-4111-8111-111111111111",
+    })
+    const modelFlag = args.indexOf("--model")
+    expect(modelFlag).toBeGreaterThan(0)
+    expect(args[modelFlag + 1]).toBe(freeText)
+    expect(args).toContain("--effort")
+    expect(args).toContain("high")
+  })
+
+  it("passes bare Bedrock profile ids through as --model without alias rewrite", () => {
+    const freeText = "us.anthropic.claude-sonnet-4-6"
+    const args = buildRunArgs({
+      prompt: "work",
+      model: freeText,
+      thinkingLevel: null,
+      sessionId: "11111111-1111-4111-8111-111111111111",
+    })
+    expect(args).toContain("--model")
+    expect(args[args.indexOf("--model") + 1]).toBe(freeText)
+    // Floating alias must not replace the free-text id.
+    expect(args.filter((arg) => arg === "sonnet")).toEqual([])
+  })
 })

--- a/packages/claude/test/claude.spec.ts
+++ b/packages/claude/test/claude.spec.ts
@@ -489,6 +489,36 @@ describe("Claude AgentBackend adapter (Agent Turns)", () => {
     )
   })
 
+  it("passes free-text / Bedrock model ids through as --model on turns (issue #806)", async () => {
+    const freeText =
+      "arn:aws:bedrock:us-east-1:123456789012:application-inference-profile/my-profile"
+    await withExecutable(
+      [
+        'case " $* " in *" --model "*) ;; *) exit 50 ;; esac',
+        // Exact free-text id must reach argv without alias rewrite.
+        `case " $* " in *" --model ${freeText} "*) ;; *) exit 51 ;; esac`,
+        'case " $* " in *" --effort max "*) ;; *) exit 52 ;; esac',
+        captureSessionScript,
+        successfulTurnStream(),
+      ].join("\n"),
+      async (binary) => {
+        const result = await Effect.runPromise(
+          Effect.gen(function* () {
+            const backend = yield* AgentBackend
+            return yield* backend.startTurn({
+              cwd: process.cwd(),
+              prompt: "bedrock free-text model",
+              model: freeText,
+              thinkingLevel: "max",
+              timeout: "2 seconds",
+            })
+          }).pipe(Effect.provide(provide(binary))),
+        )
+        expect(result.assistantText).toBe("ok")
+      },
+    )
+  })
+
   it("prefixes /review into the prompt on continueTurn", async () => {
     await withExecutable(
       [

--- a/packages/work-item-lifecycle/test/resolve-agent-models.spec.ts
+++ b/packages/work-item-lifecycle/test/resolve-agent-models.spec.ts
@@ -111,6 +111,27 @@ describe("resolveAgentModelSelection", () => {
     })
   })
 
+  it("passes Claude free-text / Bedrock model ids through as opaque preference strings (issue #806)", () => {
+    const freeText =
+      "arn:aws:bedrock:us-east-1:123456789012:application-inference-profile/my-profile"
+    expect(
+      resolveAgentModelSelection(
+        {
+          defaultModel: freeText,
+          defaultThinkingLevel: "high",
+          reviewModel: "us.anthropic.claude-opus-4-6",
+          reviewThinkingLevel: "max",
+        },
+        harness,
+      ),
+    ).toEqual({
+      model: freeText,
+      thinkingLevel: "high",
+      reviewModel: "us.anthropic.claude-opus-4-6",
+      reviewThinkingLevel: "max",
+    })
+  })
+
   it("falls back review model to build model when unset", () => {
     expect(resolveAgentModelSelection(null, harness)).toEqual({
       model: "anthropic/claude-sonnet-4-5",


### PR DESCRIPTION
Why

After Bedrock readiness, operators still could only pick Claude floating
aliases in Settings. Storing a Bedrock inference profile ID or application
inference profile ARN as build/review Agent Model required process env pins,
which is invisible and awkward for multi-repo harness use. #805 recorded
hybrid selection (aliases + Claude free-text; pins complementary).

What changed

- Claude Code Settings (Harness Config and per-Repository prefs) accept
  catalog aliases or non-empty free-text model strings on existing
  backend-scoped model fields.
- Free-text is Claude-scoped only; other backends stay catalog-constrained
  at Save.
- Save no longer blocks Claude models absent from CLAUDE_STATIC_CATALOG;
  empty/whitespace remain invalid; no ARN shape validation at Save.
- Free-text effort uses the same Claude set as aliases (low…max), including
  when the catalog is still loading.
- Resolved model strings continue to pass through as Claude --model.
- Operator docs (Bedrock note + README FAQ) describe hybrid selection
  (aliases + free-text + optional pins).

Verification

- Claude unit tests: free-text/--model pass-through (build-args + fake CLI
  turns); catalog alias regression.
- resolveAgentModelSelection free-text prefs test.
- Harness helper tests: Claude free-text Save gate, effort without loaded
  catalog, local effort set parity with package catalog.
- Biome clean on touched harness files.

Out of scope

Dynamic AWS/Claude model discovery, Keymaxxer AWS secrets, free-text
expansion for non-Claude backends.

Closes #806