### PR TITLE
fix(harness): theme-driven Agent Backend warning text contrast

### DIFF
--- a/apps/harness/src/agent-backend-warnings.tsx
+++ b/apps/harness/src/agent-backend-warnings.tsx
@@ -1,0 +1,27 @@
+import { ui } from "./ui.js"
+
+/**
+ * Non-fatal Agent Backend warnings (Bedrock discovery guidance, …) rendered as
+ * `role="status"` lines. Shared by Harness Config Active status, Harness Config
+ * backend Preview status, and Repository Settings backend Preview status so all
+ * three keep one accessible warning presentation (#830).
+ *
+ * Readability is theme-driven via `ui.dialogStatusWarning` — a Tailwind `dark:`
+ * variant would follow the browser/OS preference instead of the visible Harness
+ * surface and paint pale text on a light status row.
+ */
+export function AgentBackendWarnings({
+  warnings,
+}: {
+  warnings: readonly string[]
+}) {
+  return (
+    <>
+      {warnings.map((warning) => (
+        <p key={warning} className={ui.dialogStatusWarning} role="status">
+          {warning}
+        </p>
+      ))}
+    </>
+  )
+}

--- a/apps/harness/src/routes/__root.tsx
+++ b/apps/harness/src/routes/__root.tsx
@@ -24,6 +24,7 @@ import {
 } from "react"
 import { createClient } from "@ready-for-agent/graphql-client"
 import { formatAgentBackendStatusTrail } from "../agent-backend-status-label.js"
+import { AgentBackendWarnings } from "../agent-backend-warnings.js"
 import {
   type AgentModelOption,
   CLAUDE_AGENT_BACKEND_ID,
@@ -1152,16 +1153,9 @@ function SettingsChrome() {
                                 reason: reasonForRow,
                               })}
                             </p>
-                            {kindForRow === "READY" &&
-                              warningsForRow.map((warning) => (
-                                <p
-                                  key={warning}
-                                  className="m-0 mt-1 text-sm text-amber-800 dark:text-amber-200"
-                                  role="status"
-                                >
-                                  {warning}
-                                </p>
-                              ))}
+                            {kindForRow === "READY" && (
+                              <AgentBackendWarnings warnings={warningsForRow} />
+                            )}
                           </div>
                           <button
                             type="button"
@@ -1206,17 +1200,11 @@ function SettingsChrome() {
                                     reason: previewError,
                                   })}
                             </p>
-                            {!previewPending &&
-                              previewError === null &&
-                              previewWarnings.map((warning) => (
-                                <p
-                                  key={warning}
-                                  className="m-0 mt-1 text-sm text-amber-800 dark:text-amber-200"
-                                  role="status"
-                                >
-                                  {warning}
-                                </p>
-                              ))}
+                            {!previewPending && previewError === null && (
+                              <AgentBackendWarnings
+                                warnings={previewWarnings}
+                              />
+                            )}
                           </div>
                         </div>
                       )}

--- a/apps/harness/src/routes/index.tsx
+++ b/apps/harness/src/routes/index.tsx
@@ -20,6 +20,7 @@ import {
   JOBS_COMPLETED_WINDOW_HOURS as jobsCompletedWindowHours,
 } from "@ready-for-agent/work-item-lifecycle/jobs-completed-window"
 import { formatAgentBackendStatusLabel } from "../agent-backend-status-label.js"
+import { AgentBackendWarnings } from "../agent-backend-warnings.js"
 import {
   type AgentModelOption,
   CLAUDE_AGENT_BACKEND_ID,
@@ -2257,16 +2258,9 @@ function RepositoryCard({
                       // Reason text is on the Banner below when preview fails.
                     })}
                   </p>
-                  {previewError === null &&
-                    previewWarnings.map((warning) => (
-                      <p
-                        key={warning}
-                        className="m-0 mt-1 text-sm text-amber-800 dark:text-amber-200"
-                        role="status"
-                      >
-                        {warning}
-                      </p>
-                    ))}
+                  {previewError === null && (
+                    <AgentBackendWarnings warnings={previewWarnings} />
+                  )}
                 </div>
               )}
 

--- a/apps/harness/src/styles.css
+++ b/apps/harness/src/styles.css
@@ -51,6 +51,12 @@
   --signal: #ffd21c;
   --merged-halo: transparent;
   --scrim: rgb(21 21 21 / 0.45);
+  /*
+   * Non-fatal warning text (Agent Backend status / preview). Burnt end of the
+   * warning ramp so small text clears WCAG AA on paper, panel, dialog-stage,
+   * and plate. Theme-driven — never a prefers-color-scheme variant (#830).
+   */
+  --warn-ink: #7c3a00;
 
   --mast-bg: #101314;
   --mast-ink: #ffffff;
@@ -90,6 +96,8 @@
   --signal: #ffd21c;
   --merged-halo: rgb(242 243 241 / 0.85);
   --scrim: rgb(0 0 0 / 0.55);
+  /* Pale end of the same warning ramp — AA on every dark surface. */
+  --warn-ink: #fcd34d;
   /* Dark: soft lift over panel (no warm parchment). */
   --ticket-fill: #32383d;
 
@@ -142,6 +150,7 @@
   --signal: #ffd21c;
   --merged-halo: transparent;
   --scrim: rgb(21 21 21 / 0.45);
+  --warn-ink: #7c3a00;
   --ticket-fill: #f4f1e8;
   --plate: #dfe4e1;
   --plate-hover: #cfd6d2;
@@ -165,6 +174,7 @@
   --color-line-ghost: rgb(21 21 21 / 0.12);
   --color-scrim: rgb(21 21 21 / 0.45);
   --color-signal: #ffd21c;
+  --color-warn-ink: #7c3a00;
   --color-merged-halo: transparent;
   --color-plate: #dfe4e1;
   --color-plate-hover: #cfd6d2;
@@ -190,6 +200,7 @@
   --color-line-ghost: var(--line-ghost);
   --color-scrim: var(--scrim);
   --color-signal: var(--signal);
+  --color-warn-ink: var(--warn-ink);
   --color-merged-halo: var(--merged-halo);
   --color-lane-queue: var(--lane-queue);
   --color-lane-build: var(--lane-build);

--- a/apps/harness/src/ui.ts
+++ b/apps/harness/src/ui.ts
@@ -535,6 +535,24 @@ export const ui = {
   dialogStatusRowStrong: "font-bold text-ink",
 
   /**
+   * Non-fatal warning line inside a status row / status label (Agent Backend
+   * discovery warnings). One shared recipe for all three render sites.
+   *
+   * Color comes from `--warn-ink`, which flips with `[data-theme]` — not with
+   * Tailwind's `dark:` (`prefers-color-scheme`) variant. A light Harness
+   * surface under a dark OS preference would otherwise paint pale warning
+   * text on pale plate (#830). The left rule carries the warning state
+   * structurally so emphasis is not color-only.
+   */
+  dialogStatusWarning: cx(
+    "m-0 mt-1 border-l-2 border-warn-ink pl-2",
+    "text-sm font-semibold text-warn-ink",
+    // Warning sentences are body copy, not microcopy: the status-row parents
+    // set mono (and dialogStatusLabel sets uppercase), which both inherit.
+    "font-display leading-[1.4] tracking-normal normal-case",
+  ),
+
+  /**
    * Fieldset shell aligned with dialogSection (identity / grouped options).
    * Prefer dialogSection + dialogSectionHead for new sectioned settings.
    */

--- a/apps/harness/test/agent-backend-warning-contrast.test.tsx
+++ b/apps/harness/test/agent-backend-warning-contrast.test.tsx
@@ -1,0 +1,208 @@
+import { readFileSync } from "node:fs"
+import { join } from "node:path"
+import { renderToStaticMarkup } from "react-dom/server"
+import { AgentBackendWarnings } from "../src/agent-backend-warnings.js"
+import { ui } from "../src/ui.js"
+import {
+  WCAG_AA_NORMAL_TEXT,
+  compileHarnessCss,
+  contrastRatio,
+  renderWithTheme,
+} from "./support/rendered-theme.js"
+import { beforeAll, describe, expect, test } from "bun:test"
+
+/**
+ * Issue #830: non-fatal Agent Backend warnings must follow the visible Harness
+ * theme, not the browser/OS `prefers-color-scheme`. The regression was a pale
+ * amber `dark:` variant winning inside a light dialog and painting pale yellow
+ * on the light grey status row.
+ *
+ * Class names are never spelled out literally in this file: Tailwind scans
+ * `test/` too, so a literal utility in a comment emits a dead rule into the
+ * production bundle. Assertions build them from substrings instead.
+ */
+
+const BEDROCK_WARNING =
+  "Bedrock profile discovery failed: check AWS credentials, region, and IAM permissions for bedrock:ListInferenceProfiles."
+
+const rootSource = () =>
+  readFileSync(join(import.meta.dir, "../src/routes/__root.tsx"), "utf8")
+
+const indexSource = () =>
+  readFileSync(join(import.meta.dir, "../src/routes/index.tsx"), "utf8")
+
+const warningsMarkup = () =>
+  renderToStaticMarkup(<AgentBackendWarnings warnings={[BEDROCK_WARNING]} />)
+
+/**
+ * The three real warning render sites, each wrapped in the chrome its route
+ * actually mounts it in — the parent supplies the background the warning is
+ * read against.
+ */
+const WARNING_SITES = [
+  {
+    id: "harness-active",
+    label: "Active Agent Backend status row",
+    // __root.tsx: dialogBodySectioned → dialogSection → dialogStatusRow
+    html: `<div class="${ui.dialogBodySectioned}"><section class="${ui.dialogSection}"><div class="${ui.dialogStatusRow}"><div class="min-w-0 flex-1"><p class="m-0">Claude Code · Ready</p>${warningsMarkup()}</div></div></section></div>`,
+  },
+  {
+    id: "harness-preview",
+    label: "unsaved backend Preview status row",
+    html: `<div class="${ui.dialogBodySectioned}"><section class="${ui.dialogSection}"><div class="${ui.dialogStatusRow}"><div class="min-w-0 flex-1"><p class="m-0">Claude Code · Previewing selection</p>${warningsMarkup()}</div></div></section></div>`,
+  },
+  {
+    id: "repository-preview",
+    label: "Repository Settings backend Preview status",
+    // index.tsx: dialogBodySectioned → dialogSection → dialogStatusLabel
+    html: `<div class="${ui.dialogBodySectioned}"><section class="${ui.dialogSection}"><div class="${ui.dialogStatusLabel}"><p class="m-0">Claude Code · Ready</p>${warningsMarkup()}</div></div></section></div>`,
+  },
+] as const
+
+/** Every class token the fixtures use, so Tailwind emits those utilities. */
+const fixtureCandidates = (): readonly string[] => {
+  const found = new Set<string>()
+  for (const site of WARNING_SITES) {
+    for (const match of site.html.matchAll(/class="([^"]*)"/g)) {
+      for (const token of match[1].split(/\s+/)) {
+        if (token !== "") found.add(token)
+      }
+    }
+  }
+  return [...found]
+}
+
+let css = ""
+
+beforeAll(async () => {
+  css = await compileHarnessCss(fixtureCandidates())
+})
+
+describe("Agent Backend warning contrast", () => {
+  test("light Harness theme stays readable when the browser prefers dark", () => {
+    for (const site of WARNING_SITES) {
+      const rendered = renderWithTheme({
+        css,
+        html: site.html,
+        theme: "light",
+        prefersColorScheme: "dark",
+      })
+      try {
+        const foreground = rendered.colorOf('p[role="status"]')
+        const background = rendered.backgroundOf('p[role="status"]')
+        const ratio = contrastRatio(foreground, background)
+        expect(
+          ratio,
+          `${site.label}: ${foreground} on ${background} = ${ratio.toFixed(2)}:1`,
+        ).toBeGreaterThanOrEqual(WCAG_AA_NORMAL_TEXT)
+        // Warning text is warning-colored, not plain inherited row ink: the
+        // dark-preference pale variant must not have won on a light surface.
+        expect(foreground).toBe(rendered.rootToken("--warn-ink"))
+      } finally {
+        rendered.dispose()
+      }
+    }
+  })
+
+  test("dark Harness theme keeps warning contrast when the browser prefers light", () => {
+    for (const site of WARNING_SITES) {
+      const rendered = renderWithTheme({
+        css,
+        html: site.html,
+        theme: "dark",
+        prefersColorScheme: "light",
+      })
+      try {
+        const foreground = rendered.colorOf('p[role="status"]')
+        const background = rendered.backgroundOf('p[role="status"]')
+        const ratio = contrastRatio(foreground, background)
+        expect(
+          ratio,
+          `${site.label}: ${foreground} on ${background} = ${ratio.toFixed(2)}:1`,
+        ).toBeGreaterThanOrEqual(WCAG_AA_NORMAL_TEXT)
+        expect(foreground).toBe(rendered.rootToken("--warn-ink"))
+      } finally {
+        rendered.dispose()
+      }
+    }
+  })
+
+  test("warning ink flips with the Harness theme, not the OS preference", () => {
+    const [site] = WARNING_SITES
+    const lightUnderDarkPreference = renderWithTheme({
+      css,
+      html: site.html,
+      theme: "light",
+      prefersColorScheme: "dark",
+    })
+    const lightUnderLightPreference = renderWithTheme({
+      css,
+      html: site.html,
+      theme: "light",
+      prefersColorScheme: "light",
+    })
+    const darkUnderDarkPreference = renderWithTheme({
+      css,
+      html: site.html,
+      theme: "dark",
+      prefersColorScheme: "dark",
+    })
+    try {
+      // OS preference does not move the warning color…
+      expect(lightUnderDarkPreference.colorOf('p[role="status"]')).toBe(
+        lightUnderLightPreference.colorOf('p[role="status"]'),
+      )
+      // …but the Harness theme does.
+      expect(darkUnderDarkPreference.colorOf('p[role="status"]')).not.toBe(
+        lightUnderDarkPreference.colorOf('p[role="status"]'),
+      )
+    } finally {
+      lightUnderDarkPreference.dispose()
+      lightUnderLightPreference.dispose()
+      darkUnderDarkPreference.dispose()
+    }
+  })
+
+  test("warning state carries a structural cue beyond color", () => {
+    const [site] = WARNING_SITES
+    const rendered = renderWithTheme({
+      css,
+      html: site.html,
+      theme: "light",
+      prefersColorScheme: "dark",
+    })
+    try {
+      expect(
+        rendered.styleOf('p[role="status"]', "border-left-width"),
+      ).not.toBe("0px")
+      expect(rendered.styleOf('p[role="status"]', "font-weight")).toBe("600")
+    } finally {
+      rendered.dispose()
+    }
+  })
+
+  test("all three sites share one warning presentation", () => {
+    const root = rootSource()
+    const index = indexSource()
+    // One shared component, wired at Active + Preview (harness) and Repository.
+    expect(root).toContain("AgentBackendWarnings")
+    expect(index).toContain("AgentBackendWarnings")
+    expect(root.match(/<AgentBackendWarnings/g)?.length).toBe(2)
+    expect(index.match(/<AgentBackendWarnings/g)?.length).toBe(1)
+    // No per-site color utilities, and no media-preference text variant.
+    // Assembled at runtime so Tailwind's scanner does not see a real class.
+    const amberText = ["text", "amber"].join("-")
+    const darkTextVariant = `${["dark", "text"].join(":")}-`
+    for (const source of [root, index]) {
+      expect(source).not.toContain(amberText)
+      expect(source).not.toContain(darkTextVariant)
+    }
+    // Non-fatal semantics preserved at the shared component.
+    expect(
+      readFileSync(
+        join(import.meta.dir, "../src/agent-backend-warnings.tsx"),
+        "utf8",
+      ),
+    ).toContain('role="status"')
+  })
+})

--- a/apps/harness/test/support/rendered-theme.ts
+++ b/apps/harness/test/support/rendered-theme.ts
@@ -1,0 +1,213 @@
+import { readFileSync } from "node:fs"
+import { createRequire } from "node:module"
+import { dirname, join } from "node:path"
+import { Window } from "happy-dom"
+
+/**
+ * Render harness markup against the *real* compiled stylesheet so tests can
+ * assert computed color behavior (theme tokens, contrast) instead of grepping
+ * source for a color name.
+ */
+
+const harnessRoot = join(import.meta.dir, "../..")
+const require_ = createRequire(import.meta.url)
+
+/**
+ * Strip `@layer` wrappers, hoisting their contents in place.
+ *
+ * happy-dom does not implement cascade layers: a rule inside `@layer` is
+ * parsed but never applied, so every Tailwind utility would compute as unset.
+ * Layer *order* does not matter here — Tailwind already emits theme → base →
+ * utilities in source order, and specificity resolves the rest.
+ */
+function unwrapCssLayers(css: string): string {
+  let out = ""
+  let index = 0
+  while (index < css.length) {
+    const at = css.indexOf("@layer", index)
+    if (at === -1) {
+      out += css.slice(index)
+      break
+    }
+    out += css.slice(index, at)
+    const brace = css.indexOf("{", at)
+    const semicolon = css.indexOf(";", at)
+    // Statement form (`@layer theme, base;`) declares order only — drop it.
+    if (brace === -1 || (semicolon !== -1 && semicolon < brace)) {
+      if (semicolon === -1) break
+      index = semicolon + 1
+      continue
+    }
+    let depth = 1
+    let cursor = brace + 1
+    while (cursor < css.length && depth > 0) {
+      const char = css[cursor]
+      if (char === "{") depth += 1
+      else if (char === "}") depth -= 1
+      cursor += 1
+    }
+    out += unwrapCssLayers(css.slice(brace + 1, cursor - 1))
+    index = cursor
+  }
+  return out
+}
+
+/**
+ * Compile `src/styles.css` (tokens + `@theme` + base) plus the given candidate
+ * class names through Tailwind, exactly as the Vite build does.
+ */
+export async function compileHarnessCss(
+  candidates: readonly string[],
+): Promise<string> {
+  const { compile } = await import("tailwindcss")
+  const stylesPath = join(harnessRoot, "src/styles.css")
+  const compiler = await compile(readFileSync(stylesPath, "utf8"), {
+    base: join(harnessRoot, "src"),
+    loadStylesheet: async (id: string) => {
+      if (id !== "tailwindcss") {
+        throw new Error(`unexpected stylesheet import: ${id}`)
+      }
+      const path = require_.resolve("tailwindcss/index.css")
+      return {
+        path,
+        base: dirname(path),
+        content: readFileSync(path, "utf8"),
+      }
+    },
+  })
+  return unwrapCssLayers(compiler.build([...candidates]))
+}
+
+export type ThemeMode = "light" | "dark"
+
+export type RenderedTheme = {
+  /** Computed color of the first element matching `selector`. */
+  readonly colorOf: (selector: string) => string
+  /** Computed background color, walking up to the nearest painted ancestor. */
+  readonly backgroundOf: (selector: string) => string
+  /** Any computed style property of the first element matching `selector`. */
+  readonly styleOf: (selector: string, property: string) => string
+  /**
+   * Value of a custom property on `<html>`. Read at the root because happy-dom
+   * does not inherit custom properties into descendants' computed styles.
+   */
+  readonly rootToken: (property: string) => string
+  readonly dispose: () => void
+}
+
+/**
+ * Mount `html` under a pinned Harness theme while the emulated browser reports
+ * its own `prefers-color-scheme`. The two differ on purpose: that mismatch is
+ * the #830 regression seam.
+ */
+export function renderWithTheme(args: {
+  readonly css: string
+  readonly html: string
+  readonly theme: ThemeMode
+  readonly prefersColorScheme: ThemeMode
+}): RenderedTheme {
+  const window = new Window({
+    url: "https://localhost/",
+    settings: { device: { prefersColorScheme: args.prefersColorScheme } },
+  })
+  const { document } = window
+  document.write(
+    `<!doctype html><html data-theme="${args.theme}"><head><style>${args.css}</style></head><body>${args.html}</body></html>`,
+  )
+
+  const requireElement = (selector: string) => {
+    const element = document.querySelector(selector)
+    if (element === null) {
+      throw new Error(`no element matched ${selector}`)
+    }
+    return element
+  }
+
+  const isPainted = (color: string) =>
+    color !== "" && color !== "transparent" && color !== "rgba(0, 0, 0, 0)"
+
+  return {
+    colorOf: (selector) => {
+      const color = window.getComputedStyle(requireElement(selector)).color
+      // happy-dom cannot compute `oklch()` (Tailwind's palette format) and
+      // yields "". Fail loudly rather than silently comparing empty strings.
+      if (color === "") {
+        throw new Error(`computed color for ${selector} is unresolvable`)
+      }
+      return color
+    },
+    backgroundOf: (selector) => {
+      let node: ReturnType<typeof requireElement> | null =
+        requireElement(selector)
+      while (node !== null) {
+        const background = window.getComputedStyle(node).backgroundColor
+        if (isPainted(background)) return background
+        node = node.parentElement
+      }
+      return ""
+    },
+    styleOf: (selector, property) =>
+      window
+        .getComputedStyle(requireElement(selector))
+        .getPropertyValue(property),
+    rootToken: (property) =>
+      window
+        .getComputedStyle(document.documentElement)
+        .getPropertyValue(property),
+    dispose: () => {
+      window.close()
+    },
+  }
+}
+
+/** Relative luminance per WCAG 2.1 §relative luminance. */
+function relativeLuminance(rgb: readonly [number, number, number]): number {
+  const [r, g, b] = rgb.map((channel) => {
+    const c = channel / 255
+    return c <= 0.03928 ? c / 12.92 : ((c + 0.055) / 1.055) ** 2.4
+  })
+  return 0.2126 * r + 0.7152 * g + 0.0722 * b
+}
+
+/** Parse `#rgb`, `#rrggbb`, `rgb(r g b)`, or `rgb(r, g, b)`. */
+function parseCssColor(value: string): readonly [number, number, number] {
+  const text = value.trim()
+  const hex = /^#([0-9a-f]{3}|[0-9a-f]{6})$/i.exec(text)
+  if (hex !== null) {
+    const digits = hex[1]
+    const full =
+      digits.length === 3
+        ? digits
+            .split("")
+            .map((d) => d + d)
+            .join("")
+        : digits
+    return [
+      parseInt(full.slice(0, 2), 16),
+      parseInt(full.slice(2, 4), 16),
+      parseInt(full.slice(4, 6), 16),
+    ]
+  }
+  const channels = text
+    .replace(/^rgba?\(/i, "")
+    .replace(/\)$/, "")
+    .split(/[\s,/]+/)
+    .filter((part) => part !== "")
+    .slice(0, 3)
+    .map(Number)
+  if (channels.length !== 3 || channels.some(Number.isNaN)) {
+    throw new Error(`unsupported color: ${value}`)
+  }
+  return [channels[0], channels[1], channels[2]]
+}
+
+/** WCAG 2.1 contrast ratio between two opaque colors (1–21). */
+export function contrastRatio(a: string, b: string): number {
+  const first = relativeLuminance(parseCssColor(a))
+  const second = relativeLuminance(parseCssColor(b))
+  const [lighter, darker] = first > second ? [first, second] : [second, first]
+  return (lighter + 0.05) / (darker + 0.05)
+}
+
+/** WCAG AA floor for normal-size body text. */
+export const WCAG_AA_NORMAL_TEXT = 4.5

--- a/docs/harness-design-system.md
+++ b/docs/harness-design-system.md
@@ -85,6 +85,7 @@ Light (`:root`, `[data-theme="light"]`):
 | `--line-ghost` | `rgb(21 21 21 / 0.12)` | hairlines, ghost borders |
 | `--signal` | `#ffd21c` | accent: selection, hover, kicker tags (= Queue yellow) |
 | `--merged-halo` | `transparent` | halo behind Merged black (not needed on white) |
+| `--warn-ink` | `#7c3a00` | non-fatal warning text (Agent Backend status/preview) |
 
 Dark (`[data-theme="dark"]`):
 
@@ -100,6 +101,7 @@ Dark (`[data-theme="dark"]`):
 | `--line-ghost` | `rgb(242 243 241 / 0.14)` |
 | `--signal` | `#ffd21c` (unchanged) |
 | `--merged-halo` | `rgb(242 243 241 / 0.85)` |
+| `--warn-ink` | `#fcd34d` |
 
 **The Merged halo rule.** Merged black `#151515` vanishes on dark paper, so
 every Merged-black element — roundel, nameboard edge, ticket line bar, stamp,
@@ -110,6 +112,15 @@ compensation; everything else is a straight token swap.
 **Lane bed is theme-invariant.** `--lane-bed: #dedbd2` (warm grey column fill
 under the colored nameboards) is the same in light and dark — the Kanban
 keeps the light-mode platform grey rather than going lights-out.
+
+**The warning-ink rule.** Non-fatal warning text uses `--warn-ink` — burnt
+end of the warning ramp on light, pale end on dark — and both ends clear
+4.5:1 on every surface a warning lands on (paper, panel, dialog stage,
+plate). Warning color comes from the theme token, **never** from a Tailwind
+`dark:` variant: `dark:` compiles to `prefers-color-scheme`, so a light
+Harness surface under a dark OS preference would paint the pale ink on pale
+plate (#830). Like the plate group, `--warn-ink` is re-locked to its light
+value inside `[data-theme="dark"] [data-kanban-surface]`.
 
 ### 2.3 Masthead (dark supergraphic band in **both** themes)
 
@@ -518,6 +529,12 @@ Shared shell (native `<dialog>`):
   accent-color `--signal`.
 - **Status rows** (backend health): plate-fill inset boxes (ink border, top
   highlight), mono status text; Recheck actions use mini plates.
+  **Non-fatal warning lines** inside a status row or status label: readable
+  body copy (display ~0.82rem/600, not inherited mono microcopy) in
+  `--warn-ink` with a 2px left rule in the same ink, so the warning state is
+  structural as well as colored (§7). One shared recipe
+  (`ui.dialogStatusWarning`, rendered by `AgentBackendWarnings`) covers every
+  site; `role="status"` and the non-fatal semantics are behavior.
 - **Footer**: hairline top border, `--panel` fill, right-aligned — **all
   buttons** are riveted stamped plates (Cancel + Save share the same plate
   recipe as Recheck / mini plates; no solid-ink primary). Save pending =
@@ -658,6 +675,9 @@ A permanent fixture at the **foot of the Queue platform**, always rendered
 - On-lane text colors are fixed pairs (§2.1) — do not derive them.
 - Body text contrast ≥ 4.5:1 in both themes; mono micro-labels ≥ 3:1
   (large/short-label exception), which the token pairs satisfy.
+- Text color follows the Harness theme token, never a Tailwind `dark:`
+  (`prefers-color-scheme`) variant — the OS preference and the visible surface
+  can disagree, which breaks contrast (§2.2 warning-ink rule).
 - All interactive elements keep the global 2px focus outline; on the
   masthead it flips to `--signal`.
 - Existing ARIA semantics (tabs, lane switcher `aria-pressed`, `aria-live`

--- a/knip.json
+++ b/knip.json
@@ -15,14 +15,14 @@
         "src/router.tsx",
         "src/server.ts",
         "src/styles.css",
-        "test/**/*.test.ts",
+        "test/**/*.test.{ts,tsx}",
         "playwright.config.ts",
         "e2e/steps/**/*.ts",
         "e2e/support/**/*.ts"
       ],
       "project": [
         "src/**/*.{ts,tsx}",
-        "test/**/*.ts",
+        "test/**/*.{ts,tsx}",
         "e2e/**/*.{ts,tsx}",
         "playwright.config.ts"
       ]


### PR DESCRIPTION
### Why

Non-fatal Agent Backend warnings (Bedrock discovery guidance) were styled
`text-amber-800 dark:text-amber-200`. Tailwind's `dark:` variant compiles to
`@media (prefers-color-scheme: dark)`, which follows the **browser/OS**
preference — not the Harness `data-theme` attribute that actually decides what
is on screen. With a dark OS preference and a light Harness theme, the pale
variant won inside a light dialog and painted pale yellow on the light grey
status plate: effectively unreadable.

### What changed

- **New `--warn-ink` theme token** (`apps/harness/src/styles.css`): `#7c3a00`
  light / `#fcd34d` dark, plus the `--color-warn-ink` `@theme` alias so Tailwind
  utilities resolve. Re-locked to its light value inside
  `[data-theme="dark"] [data-kanban-surface]`, as that block requires for both
  the semantic token and the alias.
- **One shared recipe** `ui.dialogStatusWarning` (`apps/harness/src/ui.ts`)
  replacing the duplicated per-site color utilities.
- **One shared component** `AgentBackendWarnings`
  (`apps/harness/src/agent-backend-warnings.tsx`), wired at all three render
  sites: Harness Config Active status, Harness Config backend Preview, and
  Repository Settings backend Preview.
- **Structural cue, not color alone**: 2px left rule in the same warn ink plus
  `font-semibold`, per §7 of the design system.
- **Typography fix found along the way**: the Repository Settings site nests
  inside `dialogStatusLabel`, so it inherited `font-mono` + `uppercase` + wide
  tracking — a full AWS troubleshooting sentence rendered as shouted microcopy.
  The recipe now resets to display body copy.
- **Docs** (`docs/harness-design-system.md`): `--warn-ink` added to both §2.2
  role tables, a "warning-ink rule" note, the §4.9 status-row warning
  treatment, and a §7 rule that text color follows the theme token and never a
  `dark:` media variant — so the pattern is not reintroduced on a different
  surface.

Wording, `role="status"`, layout, and non-fatal semantics are unchanged. No
change to Bedrock discovery behavior or warning classification.

### Verification

- **New rendered test**
  `apps/harness/test/agent-backend-warning-contrast.test.tsx` compiles the
  *real* `src/styles.css` through Tailwind and mounts each site's actual chrome
  in happy-dom, asserting computed contrast rather than grepping source for a
  color name. Covers: light theme under a dark OS preference, dark theme under a
  light OS preference, ink flipping with theme but not OS preference, the
  structural cue, and one-component-for-three-sites.
- Measured contrast (WCAG AA floor 4.5:1) on every surface a warning can land
  on — light `#7c3a00`: plate 6.63, paper 8.53, dialog-stage 7.78; dark
  `#fcd34d`: plate 9.35, paper 7.38, dialog-stage 10.43.
- **Confirmed the test detects the regression**: temporarily restoring the old
  amber classes fails 3 of the 5 tests. This mattered — happy-dom cannot compute
  `oklch()`, so a contrast-ratio-only test would have passed against the bug by
  silently falling back to inherited row ink. The support module now throws on an
  unresolvable computed color and pins the foreground to `--warn-ink`.
- `harness:test` (470 bun / 92 vitest), `typecheck`, `lint`, `build` pass
  uncached; `nx affected -t test typecheck lint --base=main` and
  `nx run-many -t knip` green across 31 projects.

### Notes / limitations

- `knip.json`'s harness globs widened from `test/**/*.test.ts` to
  `test/**/*.{ts,tsx}` — without it the new `.test.tsx` file is not an entry, so
  its imports are not followed and the support module is reported unused. Scoped
  to the `apps/harness` workspace block only.
- The test support module (`test/support/rendered-theme.ts`) works around three
  happy-dom gaps: no cascade-layer support (`@layer` wrappers are unwrapped), no
  `oklch()` computation, and no custom-property inheritance into descendants
  (tokens are read at `documentElement`).
- Class names are never written literally in the test file: Tailwind scans
  `test/` too, and a literal utility even in a comment emitted a dead
  `dark:text-amber-200` rule into the production bundle during development.
  Negative assertions assemble their strings at runtime; the built CSS was
  checked to confirm zero amber rules remain.


Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

Closes #830