### PR TITLE
feat(agent-backend): fail fast when a CLI Agent Turn never starts

### DIFF
--- a/docs/adr/0031-built-in-headless-agent-backends.md
+++ b/docs/adr/0031-built-in-headless-agent-backends.md
@@ -10,13 +10,18 @@ A compatible Agent Backend must:
 - accept an explicit Agent Model and optional backend-defined Thinking Level on every turn, including switching them within one Session;
 - expose an instance-wide Agent Model catalog through atomic readiness inspection;
 - emit machine-readable output that the adapter can normalize to the Session ID and ordered final assistant text;
+- begin emitting that output within a bounded startup window (60 seconds) of spawn;
 - provide the `/review` Agent Command at runtime; and
 - tolerate bounded termination of the whole Agent Turn process tree on timeout, Reset, or Harness shutdown.
 
 Project-instruction file conventions are backend-native rather than part of this contract. Runtime Agent Turn failures fail only the current Step Run; Agent Backend Unavailable is established only by startup inspection or an explicit recheck.
+
+The startup window is enforced only until the first stdout output arrives, then disarmed for the rest of the turn: a legitimate long-running tool call (build, test suite) may produce no output for many minutes, so a mid-turn inactivity bound would be unsafe. A turn that never starts fails with a distinct never-started error rather than the overall turn timeout, so the failure is diagnosable as a broken CLI, bad auth, or bad configuration instead of exhausted time.
 
 The shared `maxConcurrentAgentTurns` limit defaults to two and bounds in-flight CLI turns rather than durable Sessions. CI uses fake-CLI conformance suites and generic lifecycle tests; authenticated live adapter tests remain opt-in.
 
 ## Consequences
 
 Grok Build is the first additional adapter, with stable ID `grok`. It runs with auto-update disabled so Harness operation cannot replace the CLI underneath active work. The adapter initially uses ambient `gh` authentication and does not integrate Keymaxxer.
+
+A backend whose first machine-readable output can legitimately lag more than a minute behind spawn must raise its own startup window rather than rely on the shared default.

--- a/packages/agent-backend/src/lib/agent-backend.ts
+++ b/packages/agent-backend/src/lib/agent-backend.ts
@@ -6,6 +6,7 @@ import type {
   AgentBackendExitError,
   AgentBackendMalformedOutputError,
   AgentBackendSessionIdMissingError,
+  AgentBackendStartupTimeoutError,
   AgentBackendTimeoutError,
 } from "./errors.js"
 import type {
@@ -20,6 +21,7 @@ export type AgentBackendError =
   | AgentBackendConfigError
   | AgentBackendExitError
   | AgentBackendTimeoutError
+  | AgentBackendStartupTimeoutError
   | AgentBackendSessionIdMissingError
   | AgentBackendMalformedOutputError
   | PlatformError

--- a/packages/agent-backend/src/lib/cli-runner.ts
+++ b/packages/agent-backend/src/lib/cli-runner.ts
@@ -1,4 +1,4 @@
-import { Duration, Effect, Ref, Result, Stream } from "effect"
+import { Deferred, Duration, Effect, Ref, Result, Stream } from "effect"
 import type { PlatformError } from "effect/PlatformError"
 import { ChildProcess, type ChildProcessSpawner } from "effect/unstable/process"
 import type { ChildProcessHandle } from "effect/unstable/process/ChildProcessSpawner"
@@ -10,6 +10,7 @@ import {
   AgentBackendExitError,
   AgentBackendMalformedOutputError,
   AgentBackendSessionIdMissingError,
+  AgentBackendStartupTimeoutError,
   AgentBackendTimeoutError,
 } from "./errors.js"
 import { killProcessTree } from "./kill-process-tree.js"
@@ -18,9 +19,17 @@ import type { OnSessionId } from "./types.js"
 /** Graceful terminate then force-kill bound for the Agent Turn process tree. */
 export const DEFAULT_FORCE_KILL_AFTER = Duration.seconds(2)
 
+/**
+ * Window from spawn to the first stdout output of an Agent Turn. A CLI that
+ * crashes or hangs before emitting anything otherwise burns the whole turn
+ * timeout while holding the Work Item.
+ */
+export const DEFAULT_STARTUP_TIMEOUT = Duration.seconds(60)
+
 export type AgentBackendCliError =
   | AgentBackendExitError
   | AgentBackendTimeoutError
+  | AgentBackendStartupTimeoutError
   | AgentBackendSessionIdMissingError
   | AgentBackendMalformedOutputError
   | PlatformError
@@ -71,6 +80,14 @@ export type RunCliTurnInput = {
   readonly onSessionId?: OnSessionId
   readonly parseLine: (line: string) => CliLineEvent
   readonly observerLabel?: string
+  /**
+   * Startup-only inactivity bound: when no stdout output arrives within this
+   * window of spawn, the process tree is reaped and the turn fails with
+   * AgentBackendStartupTimeoutError. Disarmed by the first output, so a
+   * long-running tool call mid-turn is never cut short. Defaults to
+   * {@link DEFAULT_STARTUP_TIMEOUT}.
+   */
+  readonly startupTimeout?: Duration.Input
 }
 
 const commandOptions = (input: {
@@ -184,6 +201,12 @@ export const runCliCapture = (
 /**
  * Run a CLI Agent Turn: stream stdout lines, observe early Session ID, fold
  * ordered assistant text, require a Session ID on success.
+ *
+ * A startup-only inactivity bound fails the turn as soon as it is clear the CLI
+ * never started (no stdout output within `startupTimeout` of spawn) instead of
+ * holding the Work Item for the whole turn timeout. The first stdout output
+ * disarms it, because a legitimate mid-turn tool call (build, test suite) can
+ * stay silent for many minutes.
  */
 export const runCliTurn = (
   input: RunCliTurnInput,
@@ -195,6 +218,8 @@ export const runCliTurn = (
     const spawner = input.spawner
     const timeoutMs = Duration.toMillis(input.timeout)
     const forceKillAfter = input.forceKillAfter ?? DEFAULT_FORCE_KILL_AFTER
+    const startupTimeout = input.startupTimeout ?? DEFAULT_STARTUP_TIMEOUT
+    const startupTimeoutMs = Duration.toMillis(startupTimeout)
     const knownSessionId = input.knownSessionId
     const seenSessionId = yield* Ref.make(knownSessionId)
     const sessionIdNotified = yield* Ref.make(false)
@@ -214,7 +239,35 @@ export const runCliTurn = (
           terminateCliTree(handle, forceKillAfter),
         )
 
+        // Disarms the startup bound on the first stdout output rather than the
+        // first parsed line, so a CLI that streams one large slow line still
+        // counts as started.
+        const started = yield* Deferred.make<void>()
+        const startupWatchdog = Deferred.await(started).pipe(
+          Effect.timeoutOrElse({
+            duration: startupTimeout,
+            orElse: () =>
+              Effect.logWarning(
+                `${observerLabel} produced no output within the startup window`,
+                { cwd: input.cwd, startupTimeoutMs },
+              ).pipe(
+                Effect.andThen(
+                  new AgentBackendStartupTimeoutError({
+                    cwd: input.cwd,
+                    startupTimeoutMs,
+                    ...(knownSessionId !== undefined
+                      ? { sessionId: knownSessionId }
+                      : {}),
+                  }),
+                ),
+              ),
+          }),
+          // Started: never wins the race, so the turn is bounded only by timeout.
+          Effect.andThen(Effect.never),
+        )
+
         const collectOutput = Stream.decodeText(handle.stdout).pipe(
+          Stream.tap(() => Deferred.succeed(started, undefined)),
           Stream.splitLines,
           Stream.runFoldEffect(
             (): {
@@ -291,6 +344,10 @@ export const runCliTurn = (
         const [exitOutcome, output] = yield* Effect.all(
           [handle.exitCode.pipe(Effect.result), collectOutput],
           { concurrency: 2 },
+        ).pipe(
+          // raceFirst so the armed watchdog failure ends the turn immediately
+          // instead of waiting for the silent CLI to exit on its own.
+          Effect.raceFirst(startupWatchdog),
         )
 
         return {

--- a/packages/agent-backend/src/lib/errors.ts
+++ b/packages/agent-backend/src/lib/errors.ts
@@ -37,6 +37,20 @@ export class AgentBackendTimeoutError extends Schema.TaggedErrorClass<AgentBacke
   },
 ) {}
 
+/**
+ * The Agent Turn CLI produced no stdout output within the startup window, so
+ * it never began the turn (bad auth, broken config, crash during startup).
+ * Distinct from AgentBackendTimeoutError, which means the turn ran out of time.
+ */
+export class AgentBackendStartupTimeoutError extends Schema.TaggedErrorClass<AgentBackendStartupTimeoutError>()(
+  "AgentBackendStartupTimeoutError",
+  {
+    cwd: Schema.String,
+    startupTimeoutMs: Schema.Finite,
+    sessionId: Schema.optionalKey(Schema.String),
+  },
+) {}
+
 export class AgentBackendSessionIdMissingError extends Schema.TaggedErrorClass<AgentBackendSessionIdMissingError>()(
   "AgentBackendSessionIdMissingError",
   {

--- a/packages/agent-backend/test/cli-runner.spec.ts
+++ b/packages/agent-backend/test/cli-runner.spec.ts
@@ -7,6 +7,7 @@ import { ChildProcessSpawner } from "effect/unstable/process"
 import {
   AgentBackendExitError,
   AgentBackendSessionIdMissingError,
+  AgentBackendStartupTimeoutError,
   AgentBackendTimeoutError,
   runCliCapture,
   runCliTurn,
@@ -473,6 +474,177 @@ describe("runCliTurn", () => {
     } finally {
       await rm(markerDir, { recursive: true, force: true })
     }
+  })
+
+  it("fails within the startup window when the CLI emits nothing", async () => {
+    const markerDir = await mkdtemp(join(tmpdir(), "agent-backend-startup-"))
+    const grandPidFile = join(markerDir, "grand.pid")
+    try {
+      await withExecutable(
+        [
+          // Silent hang after spawning a descendant: the failure mode the
+          // startup window exists for (bad auth, broken config, crash).
+          `setsid sh -c 'echo $$ > "${grandPidFile}"; sleep 100' &`,
+          `while [ ! -s "${grandPidFile}" ]; do sleep 0.01; done`,
+          "sleep 100",
+        ].join("\n"),
+        async (binary) => {
+          const startedAt = Date.now()
+          const error = await Effect.runPromise(
+            withSpawner((spawner) =>
+              runCliTurn({
+                spawner,
+                binary,
+                args: [],
+                cwd: process.cwd(),
+                env: sanitizeInheritedEnvironment(),
+                timeout: Duration.seconds(30),
+                startupTimeout: Duration.millis(300),
+                forceKillAfter: Duration.millis(100),
+                knownSessionId: "ses_startup",
+                parseLine: parseSimpleLine,
+              }).pipe(Effect.flip),
+            ),
+          )
+          const elapsed = Date.now() - startedAt
+
+          expect(error).toEqual(
+            new AgentBackendStartupTimeoutError({
+              cwd: process.cwd(),
+              startupTimeoutMs: 300,
+              sessionId: "ses_startup",
+            }),
+          )
+          // Startup window, not the 30 second turn timeout.
+          expect(elapsed).toBeLessThan(5_000)
+
+          const grandPid = Number(
+            (
+              await Bun.file(grandPidFile)
+                .text()
+                .catch(() => "")
+            ).trim(),
+          )
+          expect(Number.isFinite(grandPid) && grandPid > 0).toBe(true)
+          expect(isPidAlive(grandPid)).toBe(false)
+        },
+      )
+    } finally {
+      await rm(markerDir, { recursive: true, force: true })
+    }
+  })
+
+  it("omits the session id when a silent CLI has no known session", async () => {
+    await withExecutable("sleep 100", async (binary) => {
+      const error = await Effect.runPromise(
+        withSpawner((spawner) =>
+          runCliTurn({
+            spawner,
+            binary,
+            args: [],
+            cwd: process.cwd(),
+            env: sanitizeInheritedEnvironment(),
+            timeout: Duration.seconds(30),
+            startupTimeout: Duration.millis(200),
+            forceKillAfter: Duration.millis(100),
+            parseLine: parseSimpleLine,
+          }).pipe(Effect.flip),
+        ),
+      )
+      expect(error).toEqual(
+        new AgentBackendStartupTimeoutError({
+          cwd: process.cwd(),
+          startupTimeoutMs: 200,
+        }),
+      )
+    })
+  })
+
+  it("reports the exit code when a silent CLI exits before the startup window", async () => {
+    await withExecutable("exit 7", async (binary) => {
+      const error = await Effect.runPromise(
+        withSpawner((spawner) =>
+          runCliTurn({
+            spawner,
+            binary,
+            args: [],
+            cwd: process.cwd(),
+            env: sanitizeInheritedEnvironment(),
+            timeout: Duration.seconds(5),
+            startupTimeout: Duration.seconds(5),
+            parseLine: parseSimpleLine,
+          }).pipe(Effect.flip),
+        ),
+      )
+      expect(error).toEqual(
+        new AgentBackendExitError({ exitCode: 7, cwd: process.cwd() }),
+      )
+    })
+  })
+
+  it("disarms the startup window once the CLI emits output", async () => {
+    await withExecutable(
+      [
+        // Output arrives inside the startup window, then a long silence like a
+        // legitimate build or test-suite tool call. Only the turn timeout applies.
+        `printf '%s\\n' '{"sessionID":"ses_quiet"}'`,
+        "sleep 100",
+      ].join("\n"),
+      async (binary) => {
+        const error = await Effect.runPromise(
+          withSpawner((spawner) =>
+            runCliTurn({
+              spawner,
+              binary,
+              args: [],
+              cwd: process.cwd(),
+              env: sanitizeInheritedEnvironment(),
+              timeout: Duration.millis(600),
+              startupTimeout: Duration.millis(200),
+              forceKillAfter: Duration.millis(100),
+              parseLine: parseSimpleLine,
+            }).pipe(Effect.flip),
+          ),
+        )
+        expect(error).toEqual(
+          new AgentBackendTimeoutError({
+            cwd: process.cwd(),
+            timeoutMs: 600,
+            sessionId: "ses_quiet",
+          }),
+        )
+      },
+    )
+  })
+
+  it("completes a slow turn whose first output beats the startup window", async () => {
+    await withExecutable(
+      [
+        `printf '%s\\n' '{"sessionID":"ses_slow"}'`,
+        "sleep 0.5",
+        `printf '%s\\n' '{"text":"late"}'`,
+      ].join("\n"),
+      async (binary) => {
+        const result = await Effect.runPromise(
+          withSpawner((spawner) =>
+            runCliTurn({
+              spawner,
+              binary,
+              args: [],
+              cwd: process.cwd(),
+              env: sanitizeInheritedEnvironment(),
+              timeout: Duration.seconds(5),
+              startupTimeout: Duration.millis(250),
+              parseLine: parseSimpleLine,
+            }),
+          ),
+        )
+        expect(result).toEqual({
+          sessionId: "ses_slow",
+          assistantText: "late",
+        })
+      },
+    )
   })
 
   it("returns cleanly when the CLI exits on its own", async () => {


### PR DESCRIPTION
Why: a backend CLI that hangs before writing a single stdout line (bad
auth, broken config, crash during startup) held the Work Item for the
whole 30-minute turn timeout, and the resulting failure was
indistinguishable from a turn that legitimately ran out of time.

What: runCliTurn now arms a startup-only inactivity bound (default 60s,
overridable via RunCliTurnInput.startupTimeout). When no stdout output
arrives within the window, the process tree is reaped and the turn fails
with the new AgentBackendStartupTimeoutError. The first stdout output
disarms it, so a long-running mid-turn tool call (build, test suite) is
never cut short and only the overall turn timeout applies. All four CLI
adapters (opencode, claude, codex, grok) inherit this via runCliTurn.

Verification: nx test/typecheck/lint/knip agent-backend, nx affected
-t typecheck,lint,test, whole-workspace run-many.


Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

Closes #831