### PR TITLE
fix(work-item-lifecycle): accept trailing READY_FOR_AGENT_RESULT marker amid prose

### DIFF
--- a/apps/harness/e2e/steps/catalog-only-agent-model.ts
+++ b/apps/harness/e2e/steps/catalog-only-agent-model.ts
@@ -146,7 +146,8 @@ Given(
 
 Given(
   "the Harness runs Claude Code with the {string} Agent Model",
-  async (_fixtures, model: string) => {
+  // biome-ignore lint/correctness/noEmptyPattern: playwright-bdd requires the first argument to use the object destructuring pattern, even when no fixtures are needed.
+  async ({}, model: string) => {
     await seedClaudeHarnessDefault(model)
   },
 )

--- a/packages/work-item-lifecycle/src/lib/review.ts
+++ b/packages/work-item-lifecycle/src/lib/review.ts
@@ -174,28 +174,35 @@ export const buildRerunAssessmentPrompt = () =>
     "when a full reviewing pass is required.",
   ].join("\n")
 
-const uniqueFinalResultLine = (output: string): string | null => {
-  const lines = output.split("\n").map((line) => line.trim())
-  const nonEmptyLines = lines.filter((line) => line !== "")
-  const resultLines = lines.filter((line) =>
-    /^READY_FOR_AGENT_RESULT:/i.test(line),
-  )
-  const finalLine = nonEmptyLines.at(-1)
+const candidateResultLines = (output: string): string[] =>
+  output
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => /^READY_FOR_AGENT_RESULT:/i.test(line))
 
-  if (
-    resultLines.length !== 1 ||
-    finalLine === undefined ||
-    finalLine !== resultLines[0]
-  ) {
-    return null
+/**
+ * Try each candidate READY_FOR_AGENT_RESULT line (in order) against
+ * `tryParseLine` and keep the last one that parses to a valid, known
+ * marker. Explanatory prose around or between candidates, and earlier
+ * candidates that don't parse (or are superseded by a later valid one),
+ * are ignored. Returns null only when no candidate parses.
+ */
+const lastValidResult = <T>(
+  output: string,
+  tryParseLine: (line: string) => T | null,
+): T | null => {
+  let result: T | null = null
+  for (const line of candidateResultLines(output)) {
+    const parsed = tryParseLine(line)
+    if (parsed !== null) {
+      result = parsed
+    }
   }
-  return finalLine
+  return result
 }
 
 const hasResultLine = (output: string): boolean =>
-  output
-    .split("\n")
-    .some((line) => /^READY_FOR_AGENT_RESULT:/i.test(line.trim()))
+  candidateResultLines(output).length > 0
 
 const parseSeverity = (raw: string): ReviewSeverity | null => {
   const value = raw.trim().toLowerCase()
@@ -215,23 +222,12 @@ const parseDeferredSeverity = (raw: string): DeferredReviewSeverity | null => {
 
 const boundReason = (reason: string): string => reason.trim().slice(0, 500)
 
-/**
- * Parse the unique final READY_FOR_AGENT_RESULT line from a reviewing pass.
- * Returns null for missing, duplicate, non-final, or unrecognized markers.
- */
-export const parseReviewResult = (
-  output: string,
-): ReviewingPassResult | null => {
-  const finalLine = uniqueFinalResultLine(output)
-  if (finalLine === null) {
-    return null
-  }
-
-  if (/^READY_FOR_AGENT_RESULT:\s*REVIEW_CLEAN$/i.test(finalLine)) {
+const tryParseReviewLine = (line: string): ReviewingPassResult | null => {
+  if (/^READY_FOR_AGENT_RESULT:\s*REVIEW_CLEAN$/i.test(line)) {
     return { _tag: "clean" }
   }
 
-  const hasFindings = finalLine.match(
+  const hasFindings = line.match(
     /^READY_FOR_AGENT_RESULT:\s*REVIEW_HAS_FINDINGS\s*:\s*(.+)$/i,
   )
   if (hasFindings?.[1] !== undefined) {
@@ -245,22 +241,19 @@ export const parseReviewResult = (
 }
 
 /**
- * Parse the unique final READY_FOR_AGENT_RESULT line from an apply-findings pass.
- * Returns null for missing, duplicate, non-final, or unrecognized markers.
+ * Parse the last valid READY_FOR_AGENT_RESULT marker from a reviewing pass,
+ * tolerating explanatory prose and other non-matching candidate lines.
+ * Returns null only when no candidate line parses to a known marker.
  */
-export const parseApplyReviewResult = (
-  output: string,
-): ApplyReviewResult | null => {
-  const finalLine = uniqueFinalResultLine(output)
-  if (finalLine === null) {
-    return null
-  }
+export const parseReviewResult = (output: string): ReviewingPassResult | null =>
+  lastValidResult(output, tryParseReviewLine)
 
-  if (/^READY_FOR_AGENT_RESULT:\s*REVIEW_FIXED$/i.test(finalLine)) {
+const tryParseApplyReviewLine = (line: string): ApplyReviewResult | null => {
+  if (/^READY_FOR_AGENT_RESULT:\s*REVIEW_FIXED$/i.test(line)) {
     return { _tag: "fixed" }
   }
 
-  const fixedAndDeferred = finalLine.match(
+  const fixedAndDeferred = line.match(
     /^READY_FOR_AGENT_RESULT:\s*REVIEW_FIXED_AND_DEFERRED\s*:\s*(low|medium)\s*:\s*(.+)$/i,
   )
   if (
@@ -278,7 +271,7 @@ export const parseApplyReviewResult = (
     }
   }
 
-  const deferred = finalLine.match(
+  const deferred = line.match(
     /^READY_FOR_AGENT_RESULT:\s*REVIEW_DEFERRED\s*:\s*(low|medium)\s*:\s*(.+)$/i,
   )
   if (
@@ -296,7 +289,7 @@ export const parseApplyReviewResult = (
     }
   }
 
-  const cleared = finalLine.match(
+  const cleared = line.match(
     /^READY_FOR_AGENT_RESULT:\s*REVIEW_CLEARED\s*:\s*(.+)$/i,
   )
   if (cleared?.[1] !== undefined && cleared[1].trim() !== "") {
@@ -306,7 +299,7 @@ export const parseApplyReviewResult = (
     }
   }
 
-  const unresolvedHigh = finalLine.match(
+  const unresolvedHigh = line.match(
     /^READY_FOR_AGENT_RESULT:\s*REVIEW_UNRESOLVED_HIGH\s*:\s*(.+)$/i,
   )
   if (unresolvedHigh?.[1] !== undefined && unresolvedHigh[1].trim() !== "") {
@@ -320,18 +313,18 @@ export const parseApplyReviewResult = (
 }
 
 /**
- * Parse the unique final READY_FOR_AGENT_RESULT line from a Review Rerun Assessment.
- * Returns null for missing, duplicate, non-final, or unrecognized markers.
+ * Parse the last valid READY_FOR_AGENT_RESULT marker from an apply-findings
+ * pass, tolerating explanatory prose and other non-matching candidate lines.
+ * Returns null only when no candidate line parses to a known marker.
  */
-export const parseRerunAssessmentResult = (
+export const parseApplyReviewResult = (
   output: string,
-): RerunAssessmentResult | null => {
-  const finalLine = uniqueFinalResultLine(output)
-  if (finalLine === null) {
-    return null
-  }
+): ApplyReviewResult | null => lastValidResult(output, tryParseApplyReviewLine)
 
-  const notRequired = finalLine.match(
+const tryParseRerunAssessmentLine = (
+  line: string,
+): RerunAssessmentResult | null => {
+  const notRequired = line.match(
     /^READY_FOR_AGENT_RESULT:\s*REVIEW_RERUN_NOT_REQUIRED\s*:\s*(.+)$/i,
   )
   if (notRequired?.[1] !== undefined && notRequired[1].trim() !== "") {
@@ -341,7 +334,7 @@ export const parseRerunAssessmentResult = (
     }
   }
 
-  const required = finalLine.match(
+  const required = line.match(
     /^READY_FOR_AGENT_RESULT:\s*REVIEW_RERUN_REQUIRED\s*:\s*(.+)$/i,
   )
   if (required?.[1] !== undefined && required[1].trim() !== "") {
@@ -353,6 +346,16 @@ export const parseRerunAssessmentResult = (
 
   return null
 }
+
+/**
+ * Parse the last valid READY_FOR_AGENT_RESULT marker from a Review Rerun
+ * Assessment, tolerating explanatory prose and other non-matching candidate
+ * lines. Returns null only when no candidate line parses to a known marker.
+ */
+export const parseRerunAssessmentResult = (
+  output: string,
+): RerunAssessmentResult | null =>
+  lastValidResult(output, tryParseRerunAssessmentLine)
 
 const resolveWorktreePath = (context: LifecycleStepContext) =>
   Effect.gen(function* () {
@@ -530,7 +533,7 @@ export const review = (context: LifecycleStepContext) =>
       if (reviewingParsed === null) {
         return yield* new ReviewResultError({
           workItemId: context.workItemId,
-          message: `${agentBackendLabel(context.agentBackend)} did not report a unique final READY_FOR_AGENT_RESULT: REVIEW_CLEAN or REVIEW_HAS_FINDINGS: <low|medium|high>`,
+          message: `${agentBackendLabel(context.agentBackend)} did not report a valid READY_FOR_AGENT_RESULT: REVIEW_CLEAN or REVIEW_HAS_FINDINGS: <low|medium|high>`,
         })
       }
 
@@ -574,7 +577,7 @@ export const review = (context: LifecycleStepContext) =>
       if (applyParsed === null) {
         return yield* new ReviewResultError({
           workItemId: context.workItemId,
-          message: `${agentBackendLabel(context.agentBackend)} did not report a unique final READY_FOR_AGENT_RESULT: REVIEW_FIXED, REVIEW_FIXED_AND_DEFERRED: <low|medium>: <reason>, REVIEW_DEFERRED: <low|medium>: <reason>, REVIEW_CLEARED: <reason>, or REVIEW_UNRESOLVED_HIGH: <reason>`,
+          message: `${agentBackendLabel(context.agentBackend)} did not report a valid READY_FOR_AGENT_RESULT: REVIEW_FIXED, REVIEW_FIXED_AND_DEFERRED: <low|medium>: <reason>, REVIEW_DEFERRED: <low|medium>: <reason>, REVIEW_CLEARED: <reason>, or REVIEW_UNRESOLVED_HIGH: <reason>`,
         })
       }
 
@@ -654,7 +657,7 @@ export const review = (context: LifecycleStepContext) =>
         const assessmentParsed = parseRerunAssessmentResult(
           assessment.assistantText,
         )
-        // Missing/duplicate/malformed/ambiguous → conservative full reviewing pass
+        // Missing or malformed → conservative full reviewing pass
         if (assessmentParsed?._tag === "accepted") {
           return {
             _tag: "accepted" as const,

--- a/packages/work-item-lifecycle/test/review.spec.ts
+++ b/packages/work-item-lifecycle/test/review.spec.ts
@@ -192,8 +192,7 @@ describe("parseReviewResult", () => {
     ).toEqual({ _tag: "has_findings", severity: "high" })
   })
 
-  it("rejects missing, duplicate, non-final, unsevered, or unknown markers", () => {
-    expect(parseReviewResult("no result line")).toBeNull()
+  it("accepts the last valid marker amid duplicates or trailing prose", () => {
     expect(
       parseReviewResult(
         [
@@ -201,12 +200,16 @@ describe("parseReviewResult", () => {
           "READY_FOR_AGENT_RESULT: REVIEW_HAS_FINDINGS: low",
         ].join("\n"),
       ),
-    ).toBeNull()
+    ).toEqual({ _tag: "has_findings", severity: "low" })
     expect(
       parseReviewResult(
         "READY_FOR_AGENT_RESULT: REVIEW_CLEAN\nAdditional output",
       ),
-    ).toBeNull()
+    ).toEqual({ _tag: "clean" })
+  })
+
+  it("rejects missing, unsevered, or unknown markers", () => {
+    expect(parseReviewResult("no result line")).toBeNull()
     expect(
       parseReviewResult("READY_FOR_AGENT_RESULT: REVIEW_HAS_FINDINGS"),
     ).toBeNull()
@@ -257,8 +260,7 @@ describe("parseApplyReviewResult", () => {
     })
   })
 
-  it("rejects missing, duplicate, blank, high-deferred, or reviewing-only markers", () => {
-    expect(parseApplyReviewResult("no result line")).toBeNull()
+  it("accepts the last valid marker amid duplicates or trailing prose", () => {
     expect(
       parseApplyReviewResult(
         [
@@ -266,12 +268,16 @@ describe("parseApplyReviewResult", () => {
           "READY_FOR_AGENT_RESULT: REVIEW_CLEARED: x",
         ].join("\n"),
       ),
-    ).toBeNull()
+    ).toEqual({ _tag: "cleared", reason: "x" })
     expect(
       parseApplyReviewResult(
         "READY_FOR_AGENT_RESULT: REVIEW_FIXED\ntrailing prose",
       ),
-    ).toBeNull()
+    ).toEqual({ _tag: "fixed" })
+  })
+
+  it("rejects missing, blank, high-deferred, or reviewing-only markers", () => {
+    expect(parseApplyReviewResult("no result line")).toBeNull()
     expect(
       parseApplyReviewResult("READY_FOR_AGENT_RESULT: REVIEW_DEFERRED:"),
     ).toBeNull()
@@ -352,8 +358,7 @@ describe("parseRerunAssessmentResult", () => {
     })
   })
 
-  it("rejects missing, duplicate, blank, non-final, or foreign markers", () => {
-    expect(parseRerunAssessmentResult("no result line")).toBeNull()
+  it("accepts the last valid marker amid duplicates or trailing prose", () => {
     expect(
       parseRerunAssessmentResult(
         [
@@ -361,12 +366,16 @@ describe("parseRerunAssessmentResult", () => {
           "READY_FOR_AGENT_RESULT: REVIEW_RERUN_REQUIRED: b",
         ].join("\n"),
       ),
-    ).toBeNull()
+    ).toEqual({ _tag: "rerun_required", reason: "b" })
     expect(
       parseRerunAssessmentResult(
         "READY_FOR_AGENT_RESULT: REVIEW_RERUN_NOT_REQUIRED: ok\ntrailing",
       ),
-    ).toBeNull()
+    ).toEqual({ _tag: "accepted", reason: "ok" })
+  })
+
+  it("rejects missing, blank, or foreign markers", () => {
+    expect(parseRerunAssessmentResult("no result line")).toBeNull()
     expect(
       parseRerunAssessmentResult(
         "READY_FOR_AGENT_RESULT: REVIEW_RERUN_NOT_REQUIRED:",
@@ -1839,11 +1848,11 @@ describe("review", () => {
       expect((error as ReviewResultError).message).toContain("REVIEW_FIXED")
     }))
 
-  it("fails when READY_FOR_AGENT_RESULT lines are duplicated", () =>
+  it("accepts the last valid marker when READY_FOR_AGENT_RESULT lines are duplicated", () =>
     withTemp(async (root) => {
       let continues = 0
-      const error = await run(
-        review(baseContext(root)).pipe(Effect.flip),
+      const outcome = await run(
+        review(baseContext(root)),
         stubOpencode({
           continueTurn: () => {
             continues += 1
@@ -1857,19 +1866,20 @@ describe("review", () => {
                 })
               : Effect.succeed({
                   sessionId: "ses_implement_session",
-                  assistantText: "READY_FOR_AGENT_RESULT: REVIEW_CLEAN",
+                  assistantText:
+                    "READY_FOR_AGENT_RESULT: REVIEW_CLEARED: false positive",
                 })
           },
         }),
       )
-      expect(error).toBeInstanceOf(ReviewResultError)
-      expect(continues).toBe(1)
+      expect(outcome).toEqual({ _tag: "cleared", reason: "false positive" })
+      expect(continues).toBe(2)
     }))
 
-  it("fails when READY_FOR_AGENT_RESULT is not the final line", () =>
+  it("accepts a valid marker even when trailing prose follows it", () =>
     withTemp(async (root) => {
-      const error = await run(
-        review(baseContext(root)).pipe(Effect.flip),
+      const outcome = await run(
+        review(baseContext(root)),
         stubOpencode({
           continueTurn: () =>
             Effect.succeed({
@@ -1879,7 +1889,7 @@ describe("review", () => {
             }),
         }),
       )
-      expect(error).toBeInstanceOf(ReviewResultError)
+      expect(outcome).toEqual({ _tag: "clean" })
     }))
 
   it("maps OpenCode exit failure", () =>


### PR DESCRIPTION
## Why

The reviewing, apply-findings, and rerun-assessment parsers in `review.ts` required the
`READY_FOR_AGENT_RESULT: ...` marker to be *both* the sole matching line in the output *and* the
literal final non-empty line. When a reviewing pass produced a well-formed, unambiguous marker but
trailed it with explanatory prose (or an earlier draft-shaped line also happened to match the
marker prefix), the Step Run either burned an extra Agent Turn re-asking for a bare verdict or
failed outright with "did not report a unique final READY_FOR_AGENT_RESULT: ..." — even though a
correct answer was clearly present. This was observed in Work Item 838, where a valid
`REVIEW_HAS_FINDINGS: medium` marker was rejected because the aggregated report included prose
around it.

## What changed

- Replaced the strict `uniqueFinalResultLine` helper with `candidateResultLines` + a generic
  `lastValidResult(output, tryParseLine)` helper that scans every line matching
  `/^READY_FOR_AGENT_RESULT:/i`, tries to parse each against the known valid patterns, and keeps
  the **last** one that parses successfully. Lines that don't parse (stray mentions, malformed
  severities, foreign markers) are ignored rather than causing an outright rejection.
- Extracted per-line matching logic into `tryParseReviewLine`, `tryParseApplyReviewLine`, and
  `tryParseRerunAssessmentLine`, each driven through `lastValidResult` from `parseReviewResult`,
  `parseApplyReviewResult`, and `parseRerunAssessmentResult` respectively.
- `null` is now returned only when *no* candidate line parses to a valid, known marker — the "sole
  occurrence" and "must be the final line" constraints are gone, but a candidate must still fully
  match one of the known result patterns (correct keyword, valid severity, non-empty reason where
  required), so garbage or foreign markers are still rejected.
- Updated the two `ReviewResultError` messages from "did not report a unique final ..." to "did not
  report a valid ..." to match the relaxed semantics, and corrected a now-stale comment in the
  rerun-assessment branch that referenced duplicate/ambiguous markers forcing a conservative
  rerun.

## Verification

- Updated `review.spec.ts` unit tests for all three parsers: cases with duplicate or non-final valid
  markers now assert the last valid one is accepted; cases with no valid marker anywhere still
  assert `null`.
- Updated the two `review()` integration tests that previously asserted failure on duplicated/non-
  final markers to instead assert the Step Run now succeeds, accepting the last valid marker (one
  exercises the duplicate-markers path landing on `REVIEW_HAS_FINDINGS` → apply →
  `REVIEW_CLEARED`; the other exercises a marker followed by trailing prose landing on
  `REVIEW_CLEAN`).
- `bun test` for `work-item-lifecycle`: 560 pass / 0 fail.
- `nx typecheck` and `nx lint` for `work-item-lifecycle`: both clean.

Closes #845