### PR TITLE
feat(harness): route Harness Settings through browser history

### DIFF
--- a/apps/harness/e2e/features/settings-browser-history.feature
+++ b/apps/harness/e2e/features/settings-browser-history.feature
@@ -1,0 +1,131 @@
+Feature: Route Harness Settings through browser history
+  Explicit Harness Settings opens use `/settings` so Back closes the dialog,
+  Forward reopens it, and Save / Cancel / Escape stay synchronized with the
+  browser location. Automatic first-run Settings stays local-only.
+
+  Scenario: Explicit Settings open pushes /settings and preserves theme search
+    Given the Harness has no configured Repositories
+    When I open the home page with theme dark
+    And I cancel the Harness settings dialog if present
+    And I open Harness settings from the masthead
+    Then the browser location is the settings path with theme dark
+    And the Harness settings dialog is visible
+    And the Pipeline jobs tab is active
+
+  Scenario: Browser Back closes Settings and Forward reopens with saved values
+    Given the Harness has no configured Repositories
+    When I open the home page
+    And I cancel the Harness settings dialog if present
+    And I open Harness settings from the masthead
+    Then the browser location is the settings path
+    When I change the max concurrent Agent Turns draft to "9"
+    And I go back in the browser
+    Then the Harness settings dialog is hidden
+    And the browser location is the home path
+    When I go forward in the browser
+    Then the Harness settings dialog is visible
+    And the browser location is the settings path
+    And the max concurrent Agent Turns field shows the saved value not "9"
+
+  Scenario: Cancel returns to the originating location
+    Given the Harness has no configured Repositories
+    When I open the Repos page
+    And I cancel the Harness settings dialog if present
+    And I open Harness settings from the masthead
+    Then the browser location is the settings path
+    When I cancel the Harness settings dialog
+    Then the Harness settings dialog is hidden
+    And the browser location is the repos path
+
+  Scenario: Escape returns to the originating location
+    Given the Harness has no configured Repositories
+    When I open the home page
+    And I cancel the Harness settings dialog if present
+    And I open Harness settings from the masthead
+    Then the browser location is the settings path
+    When I press Escape in the Harness settings dialog
+    Then the Harness settings dialog is hidden
+    And the browser location is the home path
+
+  Scenario: Successful Save returns to the originating location
+    Given the Harness has no configured Repositories
+    And the Harness has a configured default build model
+    When I open the home page
+    And I cancel the Harness settings dialog if present
+    And I open Harness settings from the masthead
+    Then the browser location is the settings path
+    When I save Harness settings without changing values
+    Then the Harness settings dialog is hidden
+    And the browser location is the home path
+
+  Scenario: Failed Save keeps the dialog and /settings open
+    Given the Harness has no configured Repositories
+    And the Harness has a configured default build model
+    When I open the home page
+    And I cancel the Harness settings dialog if present
+    And I open Harness settings from the masthead
+    Then the browser location is the settings path
+    When Harness settings Save is forced to fail
+    And I save Harness settings expecting failure
+    Then the Harness settings dialog is visible
+    And the browser location is the settings path
+    And a settings save error is shown
+
+  Scenario: Browser Back is blocked while Save is pending
+    Given the Harness has no configured Repositories
+    And the Harness has a configured default build model
+    When I open the home page
+    And I cancel the Harness settings dialog if present
+    And I open Harness settings from the masthead
+    Then the browser location is the settings path
+    When Harness settings Save is delayed
+    And I start saving Harness settings
+    And I go back in the browser while Save is pending
+    Then the Harness settings dialog is visible
+    And the browser location is the settings path
+    When the delayed Harness settings Save completes
+    Then the Harness settings dialog is hidden
+    And the browser location is the home path
+
+  Scenario: Direct /settings navigation shows the dialog over Pipeline
+    Given the Harness has no configured Repositories
+    When I open the settings path directly
+    Then the Harness settings dialog is visible
+    And the browser location is the settings path
+    And the Pipeline jobs tab is active
+    When I cancel the Harness settings dialog
+    Then the Harness settings dialog is hidden
+    And the browser location is the home path
+
+  Scenario: Refreshing /settings keeps the dialog open and closes to home
+    Given the Harness has no configured Repositories
+    When I open the settings path directly
+    Then the Harness settings dialog is visible
+    When I refresh the page
+    Then the Harness settings dialog is visible
+    And the browser location is the settings path
+    When I cancel the Harness settings dialog
+    Then the Harness settings dialog is hidden
+    And the browser location is the home path
+
+  Scenario: Refresh after in-app open still closes to home with replace
+    Given the Harness has no configured Repositories
+    When I open the Repos page
+    And I cancel the Harness settings dialog if present
+    And I open Harness settings from the masthead
+    Then the browser location is the settings path
+    When I refresh the page
+    Then the Harness settings dialog is visible
+    And the browser location is the settings path
+    When I cancel the Harness settings dialog
+    Then the Harness settings dialog is hidden
+    And the browser location is the home path
+
+  Scenario: First-run Settings does not change the URL
+    Given the Harness is empty with first-run settings required
+    When I open the home page
+    Then the Harness settings dialog is visible
+    And the browser location is the home path
+    When I complete and save Harness settings
+    Then the Harness settings dialog is hidden
+    And the browser location is the home path

--- a/apps/harness/e2e/steps/settings-browser-history.ts
+++ b/apps/harness/e2e/steps/settings-browser-history.ts
@@ -1,0 +1,275 @@
+/**
+ * Playwright-BDD steps for routed Harness Settings history (issue #840).
+ */
+import { type Page, expect } from "@playwright/test"
+import {
+  ensureConfiguredDefaultBuildModel,
+  settingsDialog,
+} from "../support/first-run-settings.ts"
+import { Given, Then, When } from "./fixtures.ts"
+
+const awaitCatalogSettled = async (
+  dialog: ReturnType<typeof settingsDialog>,
+) => {
+  await expect(dialog.getByText("Loading settings...")).toHaveCount(0, {
+    timeout: 30_000,
+  })
+  await expect(dialog.getByText("Loading catalog…")).toHaveCount(0, {
+    timeout: 30_000,
+  })
+}
+
+const maxConcurrentTurnsInput = (page: Page) =>
+  settingsDialog(page).locator('input[name="maxConcurrentAgentTurns"]')
+
+/** Match `/settings` optionally with search params. */
+const settingsPathPattern = /\/settings\/?(?:\?.*)?$/
+const reposPathPattern = /\/repos\/?(?:\?.*)?$/
+
+type UpdateConfigIntercept = {
+  failNext: boolean
+  delay: { resolve: () => void; promise: Promise<void> } | null
+}
+
+const interceptByPage = new WeakMap<Page, UpdateConfigIntercept>()
+
+const interceptFor = (page: Page): UpdateConfigIntercept => {
+  let state = interceptByPage.get(page)
+  if (state === undefined) {
+    state = { failNext: false, delay: null }
+    interceptByPage.set(page, state)
+  }
+  return state
+}
+
+const installUpdateConfigRoute = async (page: Page) => {
+  // Replace any prior handler for this page so scenario flags apply.
+  await page.unroute("**/graphql").catch(() => {})
+  await page.route("**/graphql", async (route) => {
+    const request = route.request()
+    if (request.method() !== "POST") {
+      await route.continue()
+      return
+    }
+    let query = ""
+    try {
+      const body = request.postDataJSON() as { query?: string }
+      query = body.query ?? ""
+    } catch {
+      await route.continue()
+      return
+    }
+    if (!query.includes("updateConfig")) {
+      await route.continue()
+      return
+    }
+
+    const state = interceptFor(page)
+    if (state.failNext) {
+      state.failNext = false
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          errors: [{ message: "Simulated settings save failure" }],
+        }),
+      })
+      return
+    }
+
+    if (state.delay !== null) {
+      const gate = state.delay
+      await gate.promise
+      await route.continue()
+      return
+    }
+
+    await route.continue()
+  })
+}
+
+/**
+ * Savable Harness Config for Save-history scenarios. Complements zero-repo
+ * Givens that dismiss first-run without choosing a build model.
+ */
+Given("the Harness has a configured default build model", async () => {
+  await ensureConfiguredDefaultBuildModel()
+})
+
+When("I open the home page with theme dark", async ({ page }) => {
+  await page.goto("/?theme=dark")
+  await expect(page).toHaveURL(/theme=dark/)
+})
+
+When("I open Harness settings from the masthead", async ({ page }) => {
+  await installUpdateConfigRoute(page)
+  await page.getByRole("button", { name: "Settings" }).first().click()
+  const dialog = settingsDialog(page)
+  await expect(dialog).toBeVisible()
+  await awaitCatalogSettled(dialog)
+})
+
+When("I open the settings path directly", async ({ page }) => {
+  await installUpdateConfigRoute(page)
+  await page.goto("/settings")
+  await expect(page).toHaveURL(settingsPathPattern)
+  const dialog = settingsDialog(page)
+  await expect(dialog).toBeVisible({ timeout: 30_000 })
+  await awaitCatalogSettled(dialog)
+})
+
+When("I cancel the Harness settings dialog", async ({ page }) => {
+  const dialog = settingsDialog(page)
+  await dialog.getByRole("button", { name: "Cancel" }).click()
+  await expect(dialog).toBeHidden()
+})
+
+When("I press Escape in the Harness settings dialog", async ({ page }) => {
+  const dialog = settingsDialog(page)
+  await expect(dialog).toBeVisible()
+  await page.keyboard.press("Escape")
+  await expect(dialog).toBeHidden()
+})
+
+When(
+  "I change the max concurrent Agent Turns draft to {string}",
+  async ({ page }, value: string) => {
+    const input = maxConcurrentTurnsInput(page)
+    await expect(input).toBeVisible()
+    await input.fill(value)
+    await expect(input).toHaveValue(value)
+  },
+)
+
+When("I go back in the browser", async ({ page }) => {
+  await page.goBack()
+})
+
+When("I go forward in the browser", async ({ page }) => {
+  await page.goForward()
+})
+
+When("I go back in the browser while Save is pending", async ({ page }) => {
+  // useBlocker prevents the history transition; do not wait for a navigation.
+  await page.evaluate(() => {
+    window.history.back()
+  })
+  // Poll for stability instead of a fixed sleep (blocker must keep /settings).
+  await expect(page).toHaveURL(settingsPathPattern)
+  await expect
+    .poll(
+      async () => {
+        const dialog = settingsDialog(page)
+        const dialogOpen = await dialog.isVisible()
+        const saving = await dialog
+          .getByRole("button", { name: "Saving…" })
+          .isVisible()
+          .catch(() => false)
+        const onSettings = settingsPathPattern.test(
+          new URL(page.url()).pathname,
+        )
+        return dialogOpen && saving && onSettings
+      },
+      { timeout: 5_000 },
+    )
+    .toBe(true)
+})
+
+When("I refresh the page", async ({ page }) => {
+  await page.reload()
+})
+
+When("I save Harness settings without changing values", async ({ page }) => {
+  const dialog = settingsDialog(page)
+  await awaitCatalogSettled(dialog)
+  const save = dialog.getByRole("button", { name: "Save settings" })
+  await expect(save).toBeEnabled({ timeout: 15_000 })
+  await save.click()
+  await expect(dialog).toBeHidden({ timeout: 60_000 })
+})
+
+When("Harness settings Save is forced to fail", async ({ page }) => {
+  interceptFor(page).failNext = true
+  await installUpdateConfigRoute(page)
+})
+
+When("I save Harness settings expecting failure", async ({ page }) => {
+  const dialog = settingsDialog(page)
+  await awaitCatalogSettled(dialog)
+  const save = dialog.getByRole("button", { name: "Save settings" })
+  await expect(save).toBeEnabled({ timeout: 15_000 })
+  await save.click()
+  // Failed Save must keep the dialog open.
+  await expect(dialog).toBeVisible()
+})
+
+When("Harness settings Save is delayed", async ({ page }) => {
+  let resolveGate = () => {}
+  const promise = new Promise<void>((resolve) => {
+    resolveGate = resolve
+  })
+  interceptFor(page).delay = { resolve: resolveGate, promise }
+  await installUpdateConfigRoute(page)
+})
+
+When("I start saving Harness settings", async ({ page }) => {
+  const dialog = settingsDialog(page)
+  await awaitCatalogSettled(dialog)
+  const save = dialog.getByRole("button", { name: "Save settings" })
+  await expect(save).toBeEnabled({ timeout: 15_000 })
+  await save.click()
+  await expect(dialog.getByRole("button", { name: "Saving…" })).toBeVisible({
+    timeout: 15_000,
+  })
+})
+
+When("the delayed Harness settings Save completes", async ({ page }) => {
+  const state = interceptFor(page)
+  const gate = state.delay
+  state.delay = null
+  gate?.resolve()
+  const dialog = settingsDialog(page)
+  await expect(dialog).toBeHidden({ timeout: 60_000 })
+})
+
+Then("the browser location is the settings path", async ({ page }) => {
+  await expect(page).toHaveURL(settingsPathPattern)
+})
+
+Then(
+  "the browser location is the settings path with theme dark",
+  async ({ page }) => {
+    await expect(page).toHaveURL(/\/settings\/?\?theme=dark$/)
+  },
+)
+
+Then("the browser location is the home path", async ({ page }) => {
+  await expect(page).not.toHaveURL(settingsPathPattern)
+  const url = new URL(page.url())
+  expect(url.pathname === "/" || url.pathname === "").toBe(true)
+})
+
+Then("the browser location is the repos path", async ({ page }) => {
+  await expect(page).toHaveURL(reposPathPattern)
+})
+
+Then(
+  "the max concurrent Agent Turns field shows the saved value not {string}",
+  async ({ page }, draft: string) => {
+    const dialog = settingsDialog(page)
+    await awaitCatalogSettled(dialog)
+    const input = maxConcurrentTurnsInput(page)
+    await expect(input).toBeVisible()
+    await expect(input).not.toHaveValue(draft)
+    // Default concurrency is 2 agent turns in a fresh harness.
+    await expect(input).toHaveValue("2")
+  },
+)
+
+Then("a settings save error is shown", async ({ page }) => {
+  const dialog = settingsDialog(page)
+  await expect(dialog.getByRole("alert")).toBeVisible()
+  await expect(dialog.getByRole("alert")).toContainText(
+    /Simulated settings save failure|could not be saved/i,
+  )
+})

--- a/apps/harness/e2e/support/first-run-settings.ts
+++ b/apps/harness/e2e/support/first-run-settings.ts
@@ -12,37 +12,117 @@ const pageLandmark = (page: Page) =>
     .or(page.getByRole("region", { name: "Lifecycle pipeline" }))
     .or(page.getByRole("region", { name: "Configured repositories" }))
 
-/** True when harness has no default build model (first-run Settings auto-opens). */
-const isFirstRunSettingsRequired = async (): Promise<boolean> => {
+const graphqlJson = async <T>(
+  query: string,
+  variables?: Record<string, unknown>,
+): Promise<T> => {
   const response = await fetch(E2E_GRAPHQL_URL, {
     method: "POST",
     headers: { "content-type": "application/json" },
-    body: JSON.stringify({
-      query: `query { config { defaultModel } }`,
-    }),
+    body: JSON.stringify({ query, variables }),
   })
   if (!response.ok) {
     throw new Error(
-      `GraphQL HTTP ${response.status} while checking first-run settings: ${await response.text()}`,
+      `GraphQL HTTP ${response.status} while preparing settings: ${await response.text()}`,
     )
   }
   const payload = (await response.json()) as {
-    data?: { config?: { defaultModel: string | null } }
+    data?: T
     errors?: ReadonlyArray<{ message: string }>
   }
   if (payload.errors?.length) {
     throw new Error(
-      `GraphQL errors while checking first-run settings: ${payload.errors
+      `GraphQL errors while preparing settings: ${payload.errors
         .map((e) => e.message)
         .join("; ")}`,
     )
   }
-  const defaultModel = payload.data?.config?.defaultModel
+  if (payload.data === undefined) {
+    throw new Error("GraphQL response missing data while preparing settings")
+  }
+  return payload.data
+}
+
+/** True when harness has no default build model (first-run Settings auto-opens). */
+const isFirstRunSettingsRequired = async (): Promise<boolean> => {
+  const data = await graphqlJson<{
+    config: { defaultModel: string | null }
+  }>(`query { config { defaultModel } }`)
+  const defaultModel = data.config.defaultModel
   return (
     defaultModel === null ||
     defaultModel === undefined ||
     defaultModel.length === 0
   )
+}
+
+/**
+ * Ensure Harness Config has a catalog build model so Save is not blocked by
+ * first-run emptiness. Used by history scenarios that cancel first-run and
+ * then Save (issue #840 review) — independent of suite order.
+ */
+export const ensureConfiguredDefaultBuildModel = async (): Promise<void> => {
+  const data = await graphqlJson<{
+    config: {
+      selectedAgentBackend: string
+      defaultModel: string | null
+      maxConcurrentAgentTurns: number
+      maxConcurrentWorkItems: number
+    }
+    models: ReadonlyArray<{ id: string }>
+  }>(`query {
+    config {
+      selectedAgentBackend
+      defaultModel
+      maxConcurrentAgentTurns
+      maxConcurrentWorkItems
+    }
+    models { id }
+  }`)
+
+  if (
+    data.config.defaultModel !== null &&
+    data.config.defaultModel.length > 0
+  ) {
+    return
+  }
+
+  const modelId = data.models.find((model) => model.id.length > 0)?.id
+  if (modelId === undefined) {
+    throw new Error(
+      "Cannot configure default build model: Agent Model catalog is empty",
+    )
+  }
+
+  const updated = await graphqlJson<{
+    updateConfig: { defaultModel: string | null }
+  }>(
+    `mutation UpdateConfig($input: UpdateConfigInput!) {
+      updateConfig(input: $input) {
+        defaultModel
+      }
+    }`,
+    {
+      input: {
+        selectedAgentBackend: data.config.selectedAgentBackend,
+        defaultModel: modelId,
+        defaultThinkingLevel: null,
+        reviewModel: null,
+        reviewThinkingLevel: null,
+        maxConcurrentAgentTurns: data.config.maxConcurrentAgentTurns,
+        maxConcurrentWorkItems: data.config.maxConcurrentWorkItems,
+      },
+    },
+  )
+
+  if (
+    updated.updateConfig.defaultModel === null ||
+    updated.updateConfig.defaultModel.length === 0
+  ) {
+    throw new Error(
+      `Expected non-empty defaultModel after configure, got ${JSON.stringify(updated.updateConfig.defaultModel)}`,
+    )
+  }
 }
 
 /**

--- a/apps/harness/src/jobs-view-switcher.tsx
+++ b/apps/harness/src/jobs-view-switcher.tsx
@@ -9,6 +9,7 @@
  */
 import { Link, useRouterState } from "@tanstack/react-router"
 import { JobsRepositoryFilters } from "./jobs-repository-filter.js"
+import { isPipelineBackgroundPath } from "./routed-dialog.js"
 import { cx, ui } from "./ui.js"
 
 function PipelineTabIcon() {
@@ -61,7 +62,8 @@ export function JobsViewSwitcher() {
   const pathname = useRouterState({ select: (s) => s.location.pathname })
   const onCompleted =
     pathname === "/completed" || pathname.startsWith("/completed/")
-  const pipelineActive = pathname === "/"
+  // `/settings` uses Pipeline as its canonical background (issue #840).
+  const pipelineActive = isPipelineBackgroundPath(pathname)
   const reposActive = pathname === "/repos" || pathname.startsWith("/repos/")
   // Filters only drive the Pipeline board today (full in-memory item set).
   const showRepositoryFilters = pipelineActive

--- a/apps/harness/src/routeTree.gen.ts
+++ b/apps/harness/src/routeTree.gen.ts
@@ -14,6 +14,7 @@ import { Route as CompletedRouteImport } from './routes/completed'
 import { Route as GraphqlRouteImport } from './routes/graphql'
 import { Route as KanbanRouteImport } from './routes/kanban'
 import { Route as ReposRouteImport } from './routes/repos'
+import { Route as SettingsRouteImport } from './routes/settings'
 
 const IndexRoute = IndexRouteImport.update({
   id: '/',
@@ -40,6 +41,11 @@ const ReposRoute = ReposRouteImport.update({
   path: '/repos',
   getParentRoute: () => rootRouteImport,
 } as any)
+const SettingsRoute = SettingsRouteImport.update({
+  id: '/settings',
+  path: '/settings',
+  getParentRoute: () => rootRouteImport,
+} as any)
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
@@ -47,6 +53,7 @@ export interface FileRoutesByFullPath {
   '/graphql': typeof GraphqlRoute
   '/kanban': typeof KanbanRoute
   '/repos': typeof ReposRoute
+  '/settings': typeof SettingsRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
@@ -54,6 +61,7 @@ export interface FileRoutesByTo {
   '/graphql': typeof GraphqlRoute
   '/kanban': typeof KanbanRoute
   '/repos': typeof ReposRoute
+  '/settings': typeof SettingsRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
@@ -62,13 +70,22 @@ export interface FileRoutesById {
   '/graphql': typeof GraphqlRoute
   '/kanban': typeof KanbanRoute
   '/repos': typeof ReposRoute
+  '/settings': typeof SettingsRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
-  fullPaths: '/' | '/completed' | '/graphql' | '/kanban' | '/repos'
+  fullPaths:
+    '/' | '/completed' | '/graphql' | '/kanban' | '/repos' | '/settings'
   fileRoutesByTo: FileRoutesByTo
-  to: '/' | '/completed' | '/graphql' | '/kanban' | '/repos'
-  id: '__root__' | '/' | '/completed' | '/graphql' | '/kanban' | '/repos'
+  to: '/' | '/completed' | '/graphql' | '/kanban' | '/repos' | '/settings'
+  id:
+    | '__root__'
+    | '/'
+    | '/completed'
+    | '/graphql'
+    | '/kanban'
+    | '/repos'
+    | '/settings'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
@@ -77,6 +94,7 @@ export interface RootRouteChildren {
   GraphqlRoute: typeof GraphqlRoute
   KanbanRoute: typeof KanbanRoute
   ReposRoute: typeof ReposRoute
+  SettingsRoute: typeof SettingsRoute
 }
 
 declare module '@tanstack/react-router' {
@@ -116,6 +134,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ReposRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/settings': {
+      id: '/settings'
+      path: '/settings'
+      fullPath: '/settings'
+      preLoaderRoute: typeof SettingsRouteImport
+      parentRoute: typeof rootRouteImport
+    }
   }
 }
 
@@ -125,6 +150,7 @@ const rootRouteChildren: RootRouteChildren = {
   GraphqlRoute: GraphqlRoute,
   KanbanRoute: KanbanRoute,
   ReposRoute: ReposRoute,
+  SettingsRoute: SettingsRoute,
 }
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)

--- a/apps/harness/src/routed-dialog.ts
+++ b/apps/harness/src/routed-dialog.ts
@@ -1,0 +1,60 @@
+/**
+ * Browser-addressable overlay dialog routes (ADR 0048 / issue #840+).
+ *
+ * Explicit opens push a history entry; automatic first-run Settings stays
+ * local-only and must not open when another routed overlay is requested.
+ */
+
+/** History state marker for an explicit in-app Harness Settings open. */
+export type HarnessSettingsHistoryState = {
+  readonly kind: "in-app-origin"
+}
+
+/**
+ * Read the optional Settings origin marker from router/history state.
+ * HistoryState is an open bag at runtime; we validate before trusting it.
+ */
+export const readHarnessSettingsHistoryState = (
+  state: unknown,
+): HarnessSettingsHistoryState | undefined => {
+  if (typeof state !== "object" || state === null) {
+    return undefined
+  }
+  if (!("harnessSettings" in state)) {
+    return undefined
+  }
+  const marker = (state as { harnessSettings?: unknown }).harnessSettings
+  if (typeof marker !== "object" || marker === null) {
+    return undefined
+  }
+  if (!("kind" in marker)) {
+    return undefined
+  }
+  if ((marker as { kind: unknown }).kind === "in-app-origin") {
+    return { kind: "in-app-origin" }
+  }
+  return undefined
+}
+
+/** True when the pathname is the Harness Settings overlay route. */
+export const isHarnessSettingsPath = (pathname: string): boolean =>
+  pathname === "/settings" || pathname === "/settings/"
+
+/**
+ * Routed overlays other than Harness Settings. First-run auto-open is
+ * suppressed while one of these is requested so two modals never compete.
+ * Paths match ADR 0048 even before those routes are implemented.
+ */
+export const isOtherRoutedDialogPath = (pathname: string): boolean => {
+  if (/^\/repos\/[^/]+\/settings\/?$/.test(pathname)) {
+    return true
+  }
+  if (/^\/session\/[^/]+\/telemetry\/?$/.test(pathname)) {
+    return true
+  }
+  return false
+}
+
+/** Pipeline is the canonical background for `/settings` (direct load / refresh). */
+export const isPipelineBackgroundPath = (pathname: string): boolean =>
+  pathname === "/" || isHarnessSettingsPath(pathname)

--- a/apps/harness/src/routes/__root.tsx
+++ b/apps/harness/src/routes/__root.tsx
@@ -12,12 +12,16 @@ import {
   Scripts,
   createRootRouteWithContext,
   retainSearchParams,
+  useBlocker,
   useNavigate,
+  useRouter,
+  useRouterState,
 } from "@tanstack/react-router"
 import { TanStackRouterDevtools } from "@tanstack/react-router-devtools"
 import {
   type FormEvent,
   type ReactNode,
+  useCallback,
   useEffect,
   useRef,
   useState,
@@ -45,6 +49,11 @@ import { JobsRepositoryFilterProvider } from "../jobs-repository-filter.js"
 import { JobsViewSwitcher } from "../jobs-view-switcher.js"
 import { MastheadScrollwork } from "../masthead-scrollwork.js"
 import { repositoriesQuery } from "../repositories-query.js"
+import {
+  isHarnessSettingsPath,
+  isOtherRoutedDialogPath,
+  readHarnessSettingsHistoryState,
+} from "../routed-dialog.js"
 import appCss from "../styles.css?url"
 import {
   THEME_BOOTSTRAP_SCRIPT,
@@ -303,7 +312,30 @@ function ThemeMoonIcon() {
 function SettingsChrome() {
   const dialogRef = useRef<HTMLDialogElement>(null)
   const queryClient = useQueryClient()
-  const [dialogOpen, setDialogOpen] = useState(false)
+  const navigate = useNavigate()
+  const router = useRouter()
+  const pathname = useRouterState({ select: (s) => s.location.pathname })
+  const settingsHistoryState = useRouterState({
+    select: (s) => readHarnessSettingsHistoryState(s.location.state),
+  })
+  // Routed `/settings` open (explicit / direct / forward). First-run stays
+  // local-only and never pushes this path (issue #840).
+  const routedSettingsOpen = isHarnessSettingsPath(pathname)
+  const [localSettingsOpen, setLocalSettingsOpen] = useState(false)
+  const dialogOpen = routedSettingsOpen || localSettingsOpen
+  // Prevent onClose from double-navigating when we close as part of leaveRoute.
+  const dismissingRouteRef = useRef(false)
+  // True only after an explicit in-app open in this SPA document session.
+  // History state alone is not enough: HTML5 restores state across full reload,
+  // but refresh/direct entry must still close with replace → `/` (issue #840).
+  const settingsOpenedFromInAppThisSessionRef = useRef(false)
+  // Coalesce rapid masthead clicks before the first `/settings` navigate commits.
+  const settingsOpenNavigatePendingRef = useRef(false)
+  // Mutation onSuccess is registered before dismissSettings is defined; call
+  // through a ref so Save can still leave the route after a successful update.
+  const dismissSettingsRef = useRef<
+    (options?: { ignoreBlocker?: boolean }) => void
+  >(() => {})
   const [autoOpenAttempted, setAutoOpenAttempted] = useState(false)
   const config = useQuery(configQuery)
   const backendStatus = useQuery(agentBackendStatusQuery)
@@ -349,6 +381,7 @@ function SettingsChrome() {
   const backendChangeBlocked = blockingUnfinishedWorkItemCount > 0
   // Hydrate editable form fields once per dialog-open session. Live WI refresh
   // refetches config (counts) often; re-applying full config.data would wipe drafts.
+  // Forward/explicit re-open resets this so abandoned drafts are not restored.
   const formHydratedForOpenRef = useRef(false)
 
   useEffect(() => {
@@ -409,9 +442,23 @@ function SettingsChrome() {
       // effectiveAgentBackend / blocking counts on Repository cards depend on
       // the harness default; refresh so inheriting repos do not stay stale.
       void queryClient.invalidateQueries({ queryKey: ["repositories"] })
-      dialogRef.current?.close()
-      setDialogOpen(false)
+      dismissSettingsRef.current({ ignoreBlocker: true })
     },
+  })
+
+  // Block Back (and other route leaves) while Save is in flight so navigation
+  // cannot race an in-progress configuration update (issue #840).
+  const updateConfigPendingRef = useRef(false)
+  updateConfigPendingRef.current = updateConfig.isPending
+  // Stable identity so useBlocker does not tear down/re-register every render.
+  const shouldBlockSettingsLeave = useCallback(
+    () => updateConfigPendingRef.current,
+    [],
+  )
+  useBlocker({
+    shouldBlockFn: shouldBlockSettingsLeave,
+    enableBeforeUnload: updateConfig.isPending,
+    disabled: !updateConfig.isPending,
   })
 
   const [recheckingBackendId, setRecheckingBackendId] = useState<string | null>(
@@ -612,8 +659,14 @@ function SettingsChrome() {
     }
   }
 
-  const openSettings = () => {
-    setDialogOpen(true)
+  /**
+   * Reset form session state and refresh indefinitely-cached catalogs on open
+   * (issue #838). Shared by explicit open, routed enter, and first-run.
+   * Stored on a ref so the dialog-open effect can call the latest session
+   * preparer without listing an unstable function in its dependency array.
+   */
+  const prepareSettingsSessionRef = useRef(() => {})
+  prepareSettingsSessionRef.current = () => {
     // Allow one hydrate for this open (effect or inline below).
     formHydratedForOpenRef.current = false
     // Discard any in-flight preview from a previous dialog session.
@@ -646,18 +699,137 @@ function SettingsChrome() {
     setRecheckAllFailures([])
     updateConfig.reset()
     recheckBackend.reset()
-    dialogRef.current?.showModal()
+  }
+  const prepareSettingsSession = () => {
+    prepareSettingsSessionRef.current()
   }
 
+  /**
+   * Leave the `/settings` route: Back to the in-app origin when this SPA
+   * session opened Settings explicitly, else replace with Pipeline so
+   * Forward cannot reopen a direct-link or post-refresh entry.
+   */
+  const leaveSettingsRoute = (options?: { ignoreBlocker?: boolean }) => {
+    const ignoreBlocker = options?.ignoreBlocker === true
+    // Require both history marker and same-document session flag so a full
+    // reload (which restores history state) still uses replace → `/`.
+    const openedFromInApp =
+      settingsOpenedFromInAppThisSessionRef.current &&
+      settingsHistoryState?.kind === "in-app-origin"
+    if (openedFromInApp && router.history.canGoBack()) {
+      router.history.back({ ignoreBlocker })
+      return
+    }
+    void navigate({
+      to: "/",
+      search: (prev) => prev,
+      replace: true,
+      ignoreBlocker,
+    })
+  }
+
+  /**
+   * Close Settings: local first-run only closes the native dialog; routed
+   * opens also leave `/settings` (Save / Cancel / Escape share this path).
+   */
+  const dismissSettings = (options?: { ignoreBlocker?: boolean }) => {
+    if (updateConfig.isPending && options?.ignoreBlocker !== true) {
+      return
+    }
+    if (routedSettingsOpen) {
+      dismissingRouteRef.current = true
+      dialogRef.current?.close()
+      setLocalSettingsOpen(false)
+      leaveSettingsRoute(options)
+      return
+    }
+    dialogRef.current?.close()
+    setLocalSettingsOpen(false)
+  }
+  dismissSettingsRef.current = dismissSettings
+
+  /** Explicit Settings openers (masthead, setup/backend guidance). */
+  const openSettings = () => {
+    prepareSettingsSession()
+    if (routedSettingsOpen || settingsOpenNavigatePendingRef.current) {
+      // Already on `/settings`, or a push is in flight: keep URL, refresh.
+      if (dialogRef.current !== null && !dialogRef.current.open) {
+        dialogRef.current.showModal()
+      }
+      return
+    }
+    settingsOpenedFromInAppThisSessionRef.current = true
+    settingsOpenNavigatePendingRef.current = true
+    // Open immediately so focus trap matches pre-route UX; the route effect
+    // remains the source of truth for direct/forward entry and Back close.
+    if (dialogRef.current !== null && !dialogRef.current.open) {
+      dialogRef.current.showModal()
+    }
+    void navigate({
+      to: "/settings",
+      search: (prev) => prev,
+      state: (prev) => {
+        // HistoryState is an open bag; mark this entry as an explicit in-app open
+        // so Cancel/Save/Escape can history.back() instead of replace-to-home.
+        const next = { ...prev }
+        Object.assign(next, {
+          harnessSettings: { kind: "in-app-origin" as const },
+        })
+        return next
+      },
+    }).finally(() => {
+      settingsOpenNavigatePendingRef.current = false
+    })
+  }
+
+  // Sync native <dialog> with routed + local open flags.
+  useEffect(() => {
+    const dialog = dialogRef.current
+    if (dialog === null) {
+      return
+    }
+    if (dialogOpen) {
+      if (!dialog.open) {
+        // Entering via route (direct, Forward, or explicit navigate) needs a
+        // fresh session so abandoned drafts are not restored.
+        prepareSettingsSessionRef.current()
+        dialog.showModal()
+      }
+      return
+    }
+    if (dialog.open) {
+      dismissingRouteRef.current = true
+      dialog.close()
+    }
+  }, [dialogOpen])
+
+  // Automatic first-run: local-only, no URL change, suppressed while another
+  // routed dialog is requested (Repository settings / Session Telemetry).
   useEffect(() => {
     if (autoOpenAttempted || !config.isSuccess || buildConfigured) {
       return
     }
+    if (isOtherRoutedDialogPath(pathname)) {
+      // Suppress this pass only — do not burn autoOpenAttempted so first-run
+      // can still open after the competing overlay is dismissed (ADR 0048).
+      return
+    }
+    if (routedSettingsOpen) {
+      // Direct `/settings` already owns the dialog.
+      setAutoOpenAttempted(true)
+      return
+    }
     setAutoOpenAttempted(true)
-    setDialogOpen(true)
+    setLocalSettingsOpen(true)
     updateConfig.reset()
-    dialogRef.current?.showModal()
-  }, [autoOpenAttempted, buildConfigured, config.isSuccess, updateConfig.reset])
+  }, [
+    autoOpenAttempted,
+    buildConfigured,
+    config.isSuccess,
+    pathname,
+    routedSettingsOpen,
+    updateConfig.reset,
+  ])
 
   const savedAgentBackend = config.data?.selectedAgentBackend ?? "opencode"
   const backendChanging = selectedAgentBackend !== savedAgentBackend
@@ -932,9 +1104,23 @@ function SettingsChrome() {
         className={ui.dialogPanel}
         aria-labelledby="settings-title"
         onCancel={(event) => {
-          if (updateConfig.isPending) event.preventDefault()
+          if (updateConfig.isPending) {
+            event.preventDefault()
+          }
         }}
-        onClose={() => setDialogOpen(false)}
+        onClose={() => {
+          // Escape (or other user dismiss) closes the native dialog first; if
+          // we are still on `/settings`, leave the route so URL and UI match.
+          if (dismissingRouteRef.current) {
+            dismissingRouteRef.current = false
+            setLocalSettingsOpen(false)
+            return
+          }
+          setLocalSettingsOpen(false)
+          if (isHarnessSettingsPath(pathname)) {
+            leaveSettingsRoute()
+          }
+        }}
       >
         <form onSubmit={saveSettings}>
           <div className={ui.dialogHeader}>
@@ -1492,8 +1678,7 @@ function SettingsChrome() {
               type="button"
               className={ui.plateMini}
               onClick={() => {
-                dialogRef.current?.close()
-                setDialogOpen(false)
+                dismissSettings()
               }}
               disabled={updateConfig.isPending}
             >

--- a/apps/harness/src/routes/index.tsx
+++ b/apps/harness/src/routes/index.tsx
@@ -498,17 +498,17 @@ const patchWorkItemsCaches = (
 }
 
 export const Route = createFileRoute("/")({
-  component: HomePage,
+  component: PipelinePage,
 })
 
 /**
- * Home is the kanban board when repositories exist; otherwise the same
- * add-repo blank slate as `/repos` (no empty pipeline).
+ * Pipeline page body (home board or empty blank slate). Also used as the
+ * canonical background under the `/settings` overlay route (issue #840).
  *
  * Membership SSE stays mounted on both paths so CLI add/remove refreshes the
  * blank-slate ↔ board gate without navigating away (issue #684 review).
  */
-function HomePage() {
+export function PipelinePage() {
   return (
     <>
       <HomeRepositoryMembershipLive />

--- a/apps/harness/src/routes/settings.tsx
+++ b/apps/harness/src/routes/settings.tsx
@@ -1,0 +1,13 @@
+/**
+ * `/settings` — browser-addressable Harness Settings overlay (issue #840).
+ *
+ * The dialog itself lives in root chrome; this route supplies the canonical
+ * Pipeline background for direct navigation and refresh. Explicit opens from
+ * other pages also land here so the URL and history entry stay consistent.
+ */
+import { createFileRoute } from "@tanstack/react-router"
+import { PipelinePage } from "./index.js"
+
+export const Route = createFileRoute("/settings")({
+  component: PipelinePage,
+})

--- a/apps/harness/test/harness-settings-backend-change.test.ts
+++ b/apps/harness/test/harness-settings-backend-change.test.ts
@@ -107,11 +107,14 @@ describe("Harness settings Agent Backend change", () => {
 
   test("Settings open refreshes indefinitely cached mode and catalog (issue #838)", () => {
     const source = rootSource()
-    const openSettings = source.slice(
-      source.indexOf("const openSettings = () => {"),
-      source.indexOf("dialogRef.current?.showModal()"),
+    const prepare = source.slice(
+      source.indexOf("prepareSettingsSessionRef.current = () => {"),
+      source.indexOf("const leaveSettingsRoute"),
     )
-    expect(openSettings).toContain("void models.refetch()")
-    expect(openSettings).toContain("void backendStatus.refetch()")
+    expect(prepare).toContain("void models.refetch()")
+    expect(prepare).toContain("void backendStatus.refetch()")
+    // Explicit openers still prepare then push `/settings` (issue #840).
+    expect(source).toContain('to: "/settings"')
+    expect(source).toContain("prepareSettingsSession()")
   })
 })

--- a/apps/harness/test/routed-dialog.test.ts
+++ b/apps/harness/test/routed-dialog.test.ts
@@ -1,0 +1,44 @@
+import {
+  isHarnessSettingsPath,
+  isOtherRoutedDialogPath,
+  isPipelineBackgroundPath,
+  readHarnessSettingsHistoryState,
+} from "../src/routed-dialog.ts"
+import { describe, expect, test } from "bun:test"
+
+describe("routed dialog path helpers (issue #840)", () => {
+  test("identifies the Harness Settings path", () => {
+    expect(isHarnessSettingsPath("/settings")).toBe(true)
+    expect(isHarnessSettingsPath("/settings/")).toBe(true)
+    expect(isHarnessSettingsPath("/")).toBe(false)
+    expect(isHarnessSettingsPath("/repos")).toBe(false)
+  })
+
+  test("Pipeline background includes home and settings", () => {
+    expect(isPipelineBackgroundPath("/")).toBe(true)
+    expect(isPipelineBackgroundPath("/settings")).toBe(true)
+    expect(isPipelineBackgroundPath("/repos")).toBe(false)
+    expect(isPipelineBackgroundPath("/completed")).toBe(false)
+  })
+
+  test("detects other routed overlays for first-run suppression", () => {
+    expect(isOtherRoutedDialogPath("/repos/abc/settings")).toBe(true)
+    expect(isOtherRoutedDialogPath("/session/wi-1/telemetry")).toBe(true)
+    expect(isOtherRoutedDialogPath("/settings")).toBe(false)
+    expect(isOtherRoutedDialogPath("/repos")).toBe(false)
+    expect(isOtherRoutedDialogPath("/")).toBe(false)
+  })
+
+  test("reads the in-app origin history marker", () => {
+    expect(
+      readHarnessSettingsHistoryState({
+        harnessSettings: { kind: "in-app-origin" },
+      }),
+    ).toEqual({ kind: "in-app-origin" })
+    expect(readHarnessSettingsHistoryState({})).toBeUndefined()
+    expect(readHarnessSettingsHistoryState(null)).toBeUndefined()
+    expect(
+      readHarnessSettingsHistoryState({ harnessSettings: { kind: "other" } }),
+    ).toBeUndefined()
+  })
+})

--- a/apps/harness/test/settings-route.test.ts
+++ b/apps/harness/test/settings-route.test.ts
@@ -1,0 +1,96 @@
+import { readFileSync } from "node:fs"
+import { join } from "node:path"
+import { describe, expect, test } from "bun:test"
+
+const settingsSource = () =>
+  readFileSync(join(import.meta.dir, "../src/routes/settings.tsx"), "utf8")
+
+const rootSource = () =>
+  readFileSync(join(import.meta.dir, "../src/routes/__root.tsx"), "utf8")
+
+const routedDialogSource = () =>
+  readFileSync(join(import.meta.dir, "../src/routed-dialog.ts"), "utf8")
+
+const routeTreeSource = () =>
+  readFileSync(join(import.meta.dir, "../src/routeTree.gen.ts"), "utf8")
+
+const jobsSwitcherSource = () =>
+  readFileSync(join(import.meta.dir, "../src/jobs-view-switcher.tsx"), "utf8")
+
+describe("/settings route (issue #840)", () => {
+  test("is a dedicated TanStack file route over the Pipeline background", () => {
+    const source = settingsSource()
+    expect(source).toContain('createFileRoute("/settings")')
+    expect(source).toContain("PipelinePage")
+    expect(source).toContain('from "./index.js"')
+  })
+
+  test("is registered in the generated route tree", () => {
+    const source = routeTreeSource()
+    expect(source).toContain("from './routes/settings'")
+    expect(source).toContain("id: '/settings'")
+    expect(source).toContain("path: '/settings'")
+    expect(source).toContain("'/settings': typeof SettingsRoute")
+  })
+
+  test("explicit openers push /settings with in-app origin state", () => {
+    const source = rootSource()
+    expect(source).toContain('to: "/settings"')
+    expect(source).toContain('kind: "in-app-origin"')
+    expect(source).toContain("harnessSettings")
+    expect(source).toContain("search: (prev) => prev")
+  })
+
+  test("first-run auto-open stays local-only and yields to other routed dialogs", () => {
+    const source = rootSource()
+    expect(source).toContain("setLocalSettingsOpen(true)")
+    expect(source).toContain("isOtherRoutedDialogPath(pathname)")
+    // First-run must not navigate to /settings.
+    const autoOpenStart = source.indexOf("Automatic first-run")
+    expect(autoOpenStart).toBeGreaterThan(-1)
+    const autoOpen = source.slice(
+      autoOpenStart,
+      source.indexOf("const backendChanging"),
+    )
+    expect(autoOpen).toContain("setLocalSettingsOpen(true)")
+    expect(autoOpen).not.toContain('to: "/settings"')
+    expect(autoOpen).toContain("isOtherRoutedDialogPath(pathname)")
+    // Competing overlays suppress this pass without burning autoOpenAttempted.
+    const competing = autoOpen.slice(
+      autoOpen.indexOf("isOtherRoutedDialogPath"),
+      autoOpen.indexOf("if (routedSettingsOpen)"),
+    )
+    expect(competing).toContain("return")
+    expect(competing).not.toContain("setAutoOpenAttempted(true)")
+  })
+
+  test("dismiss leaves the route for in-app origin or replaces to Pipeline", () => {
+    const source = rootSource()
+    expect(source).toContain("leaveSettingsRoute")
+    expect(source).toContain("router.history.back")
+    expect(source).toContain("canGoBack()")
+    expect(source).toContain('to: "/"')
+    expect(source).toContain("replace: true")
+    expect(source).toContain("dismissSettings")
+    // Reload must not treat restored history state alone as in-app origin.
+    expect(source).toContain("settingsOpenedFromInAppThisSessionRef")
+    expect(source).toContain("settingsOpenedFromInAppThisSessionRef.current &&")
+  })
+
+  test("blocks navigation while Save is pending", () => {
+    const source = rootSource()
+    expect(source).toContain("useBlocker")
+    expect(source).toContain("shouldBlockSettingsLeave")
+    expect(source).toContain("updateConfigPendingRef")
+    expect(source).toContain("disabled: !updateConfig.isPending")
+  })
+
+  test("Jobs switcher treats /settings as Pipeline background", () => {
+    const switcher = jobsSwitcherSource()
+    expect(switcher).toContain("isPipelineBackgroundPath")
+    const helpers = routedDialogSource()
+    expect(helpers).toContain("isHarnessSettingsPath")
+    expect(helpers).toContain('pathname === "/settings"')
+    expect(helpers).toContain("isOtherRoutedDialogPath")
+  })
+})


### PR DESCRIPTION
## Why

Harness Settings was controlled only by local UI state, so operators could not
use Back/Forward, refresh, or bookmark the dialog. ADR 0048 defines
browser-addressable overlay routes; this change establishes that pattern for
Harness Settings (`/settings`) so later Repository settings and Session
Telemetry slices can follow the same contract.

## What changed

- Add a TanStack `/settings` file route that renders Pipeline as the canonical
  background for direct loads and refresh.
- Explicit openers (masthead Settings, setup/backend guidance) push `/settings`
  while preserving unrelated search params (including `?theme=`).
- In-app origin is tracked with history state plus a same-document session flag
  so Cancel/Escape/successful Save use `history.back()` when appropriate, while
  refresh or direct entry still close with replace navigation to `/`.
- Failed Save stays on `/settings`; `useBlocker` blocks leave while Save is
  pending.
- Automatic first-run Settings remains local-only (no URL change) and yields to
  other routed overlay paths without permanently burning the auto-open attempt.
- Optimistic `showModal` on explicit open; double-click navigate coalescing;
  Jobs switcher treats `/settings` as Pipeline background.
- Playwright-BDD coverage for open/URL/search, Back/Forward, Cancel/Escape/Save,
  failed and pending Save, direct load, refresh close destination, first-run
  URL stability, and a configured-build-model precondition for Save scenarios.

## Verification

- Harness typecheck and unit tests for settings/route helpers.
- Live Harness e2e (`nx e2e harness`) including the new settings browser-history
  feature (full suite green in this worktree).

## Notes / limitations

- Repository settings and Session Telemetry routes are out of scope (follow-up
  issues).
- Setup/Backend banner “Open Settings” is not given a dedicated e2e scenario; it
  shares the same explicit `openSettings` path as the masthead.

Closes #840