### PR TITLE
feat(harness): steampunk theme lever and Settings cog

### DIFF
--- a/apps/harness/src/routes/__root.tsx
+++ b/apps/harness/src/routes/__root.tsx
@@ -223,9 +223,7 @@ function RootDocument({ children }: { children: ReactNode }) {
   )
 }
 
-/** Stamped-plate base for primary nav controls (active via aria-current). */
-const mastPlateClassName = ui.mastPlate
-
+/** Hub icon inside the Settings cog core (prototype B sunburst). */
 function SettingsNavIcon() {
   return (
     <svg
@@ -235,8 +233,29 @@ function SettingsNavIcon() {
       stroke="currentColor"
       strokeWidth="2"
     >
-      <path d="M12 15.5a3.5 3.5 0 1 0 0-7 3.5 3.5 0 0 0 0 7Z" />
-      <path d="M19.4 15a1.7 1.7 0 0 0 .34 1.88l.06.06-2.83 2.83-.06-.06a1.7 1.7 0 0 0-1.88-.34 1.7 1.7 0 0 0-1.03 1.56V21h-4v-.08A1.7 1.7 0 0 0 8.94 19.4a1.7 1.7 0 0 0-1.88.34l-.06.06-2.83-2.83.06-.06A1.7 1.7 0 0 0 4.57 15 1.7 1.7 0 0 0 3 14H3v-4h.08A1.7 1.7 0 0 0 4.6 8.94a1.7 1.7 0 0 0-.34-1.88L4.2 7l2.83-2.83.06.06A1.7 1.7 0 0 0 9 4.57 1.7 1.7 0 0 0 10 3V3h4v.08A1.7 1.7 0 0 0 15.06 4.6a1.7 1.7 0 0 0 1.88-.34L17 4.2 19.83 7l-.06.06A1.7 1.7 0 0 0 19.43 9 1.7 1.7 0 0 0 21 10h.08v4H21a1.7 1.7 0 0 0-1.6 1Z" />
+      <circle cx="12" cy="12" r="3" />
+      <path d="M12 2v2M12 20v2M2 12h2M20 12h2M4.9 4.9l1.4 1.4M17.7 17.7l1.4 1.4M4.9 19.1l1.4-1.4M17.7 6.3l1.4-1.4" />
+    </svg>
+  )
+}
+
+/**
+ * Solid brass gear silhouette for Settings (prototype B).
+ * True gear path — not a conic-gradient pie (that never grows teeth).
+ * 12 teeth, hub hole covered by `.core`. Path is static (viewBox 0 0 64 64).
+ */
+const SETTINGS_COG_TEETH_PATH =
+  "M 26.00 9.59 L 29.82 8.90 L 29.18 2.13 L 34.82 2.13 L 34.18 8.90 L 38.00 9.59 L 41.66 10.91 L 44.49 4.72 L 49.38 7.55 L 45.44 13.09 L 48.40 15.60 L 50.91 18.56 L 56.45 14.62 L 59.28 19.51 L 53.09 22.34 L 54.41 26.00 L 55.10 29.82 L 61.87 29.18 L 61.87 34.82 L 55.10 34.18 L 54.41 38.00 L 53.09 41.66 L 59.28 44.49 L 56.45 49.38 L 50.91 45.44 L 48.40 48.40 L 45.44 50.91 L 49.38 56.45 L 44.49 59.28 L 41.66 53.09 L 38.00 54.41 L 34.18 55.10 L 34.82 61.87 L 29.18 61.87 L 29.82 55.10 L 26.00 54.41 L 22.34 53.09 L 19.51 59.28 L 14.62 56.45 L 18.56 50.91 L 15.60 48.40 L 13.09 45.44 L 7.55 49.38 L 4.72 44.49 L 10.91 41.66 L 9.59 38.00 L 8.90 34.18 L 2.13 34.82 L 2.13 29.18 L 8.90 29.82 L 9.59 26.00 L 10.91 22.34 L 4.72 19.51 L 7.55 14.62 L 13.09 18.56 L 15.60 15.60 L 18.56 13.09 L 14.62 7.55 L 19.51 4.72 L 22.34 10.91 L 26.00 9.59 Z M 45.50 32.00 A 13.5 13.5 0 1 0 18.50 32.00 A 13.5 13.5 0 1 0 45.50 32.00 Z"
+
+function SettingsCogTeeth() {
+  return (
+    <svg
+      className="teeth"
+      aria-hidden="true"
+      viewBox="0 0 64 64"
+      fill="currentColor"
+    >
+      <path d={SETTINGS_COG_TEETH_PATH} fillRule="evenodd" />
     </svg>
   )
 }
@@ -254,10 +273,14 @@ function RootComponent() {
   )
 }
 
+/**
+ * Switchboard lever for light/dark — exact DOM/CSS of prototype C (.c-lever).
+ * Lever up = light; down = dark. Visible label is the *target* theme.
+ */
 function ThemeTogglePlate() {
   // SSR-stable initial state: server and first client paint match ("light"
   // control chrome). Page colors already follow bootstrap's data-theme; the
-  // mount effect below mirrors that onto the plate without a hydration mismatch.
+  // mount effect below mirrors that onto the lever without a hydration mismatch.
   const [theme, setTheme] = useState<ThemeMode>("light")
   // No `from: Route.fullPath` — that roots relative nav at `/` and would send
   // Repos/Completed operators home when only search should change.
@@ -273,7 +296,7 @@ function ThemeTogglePlate() {
   return (
     <button
       type="button"
-      className={mastPlateClassName}
+      className={ui.mastThemeLever}
       aria-label={`Switch to ${targetLabel} theme`}
       aria-pressed={theme === "dark"}
       onClick={() => {
@@ -289,23 +312,13 @@ function ThemeTogglePlate() {
         setTheme(next)
       }}
     >
-      <ThemeMoonIcon />
-      <span>{targetLabel}</span>
+      <span className="cradle">
+        <span className="slot" aria-hidden="true" />
+        <span className="stem" aria-hidden="true" />
+        <span className="handle" aria-hidden="true" />
+      </span>
+      <span className="tag">{targetLabel}</span>
     </button>
-  )
-}
-
-function ThemeMoonIcon() {
-  return (
-    <svg
-      aria-hidden="true"
-      viewBox="0 0 24 24"
-      fill="none"
-      stroke="currentColor"
-      strokeWidth="2"
-    >
-      <path d="M21 12.8A9 9 0 1 1 11.2 3 7 7 0 0 0 21 12.8Z" />
-    </svg>
   )
 }
 
@@ -1038,14 +1051,21 @@ function SettingsChrome() {
           </div>
           <nav className={ui.mastNav} aria-label="Primary">
             <ThemeTogglePlate />
+            {/* Settings cog — prototype B gear (SVG teeth + iron core). */}
             <button
               type="button"
-              className={mastPlateClassName}
+              className={ui.mastSettingsCog}
               onClick={openSettings}
               aria-haspopup="dialog"
+              aria-label="Settings"
             >
-              <SettingsNavIcon />
-              Settings
+              <span className="cog-body" aria-hidden="true">
+                <SettingsCogTeeth />
+                <span className="core">
+                  <SettingsNavIcon />
+                </span>
+              </span>
+              <span className="label-ring">Settings</span>
             </button>
           </nav>
         </header>

--- a/apps/harness/src/styles.css
+++ b/apps/harness/src/styles.css
@@ -70,6 +70,11 @@
   --mast-plate-active: #e8ece9;
   --mast-plate-active-ink: #101314;
   --mast-plate-active-rivet: rgb(16 19 18 / 0.5);
+  /* Steampunk instrument accents on the dark mast (theme-invariant).
+   * Values match apps/harness/prototypes/steampunk-mast-buttons.html. */
+  --mast-brass: #c9a04a;
+  --mast-brass-hi: #f0d78a;
+  --mast-brass-lo: #7a5a1e;
 
   --plate: #dfe4e1;
   --plate-hover: #cfd6d2;
@@ -113,6 +118,9 @@
   --mast-plate-active: #e8ece9;
   --mast-plate-active-ink: #101314;
   --mast-plate-active-rivet: rgb(16 19 18 / 0.5);
+  --mast-brass: #c9a04a;
+  --mast-brass-hi: #f0d78a;
+  --mast-brass-lo: #7a5a1e;
 
   --plate: #2b2f33;
   --plate-hover: #3a4046;
@@ -218,6 +226,9 @@
   --color-mast-plate-ink: var(--mast-plate-ink);
   --color-mast-plate-active: var(--mast-plate-active);
   --color-mast-plate-active-ink: var(--mast-plate-active-ink);
+  --color-mast-brass: var(--mast-brass);
+  --color-mast-brass-hi: var(--mast-brass-hi);
+  --color-mast-brass-lo: var(--mast-brass-lo);
   --color-plate: var(--plate);
   --color-plate-hover: var(--plate-hover);
   --color-plate-ink: var(--plate-ink);
@@ -271,6 +282,180 @@
       transition-duration: 0.001ms !important;
     }
   }
+}
+
+/*
+ * Mast instruments — prototype B (Settings cog) + C (theme lever).
+ * Visual source: apps/harness/prototypes/steampunk-mast-buttons.html
+ * Gear body is an SVG path (conic-gradient only ever draws a circular pie,
+ * not a true gear silhouette).
+ */
+.mast-settings-cog {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.35rem;
+  width: 3.4rem;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  background: transparent;
+  color: var(--mast-brass);
+}
+
+.mast-settings-cog .cog-body {
+  position: relative;
+  display: block;
+  width: 3.4rem;
+  height: 3.4rem;
+  flex-shrink: 0;
+}
+
+.mast-settings-cog .teeth {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  color: var(--mast-brass);
+  filter: drop-shadow(0 3px 4px rgb(0 0 0 / 0.55));
+  pointer-events: none;
+}
+
+.mast-settings-cog .core {
+  position: absolute;
+  inset: 22%;
+  z-index: 1;
+  border-radius: 50%;
+  background: radial-gradient(circle at 35% 30%, #3a4046, #15181b 70%);
+  border: 2px solid var(--mast-brass-lo);
+  box-shadow:
+    inset 0 2px 0 rgb(255 255 255 / 0.12),
+    inset 0 -2px 4px rgb(0 0 0 / 0.5),
+    0 0 0 2px var(--mast-brass);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--mast-brass-hi);
+}
+
+.mast-settings-cog .core svg {
+  width: 1.1rem;
+  height: 1.1rem;
+}
+
+.mast-settings-cog .label-ring {
+  font-family: var(--font-mono);
+  font-size: 0.55rem;
+  font-weight: 700;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--mast-brass);
+  white-space: nowrap;
+  text-shadow: 0 1px 2px #000;
+  line-height: 1.2;
+}
+
+.mast-settings-cog:hover .teeth {
+  filter: brightness(1.12) drop-shadow(0 3px 4px rgb(0 0 0 / 0.55));
+}
+
+.mast-theme-lever {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.35rem;
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 0;
+  color: inherit;
+}
+
+.mast-theme-lever .cradle {
+  position: relative;
+  display: block;
+  width: 2.4rem;
+  /* Match .mast-settings-cog .cog-body so both instruments top-align cleanly. */
+  height: 3.4rem;
+  flex-shrink: 0;
+  background: linear-gradient(180deg, #3a4046 0%, #1a1e22 100%);
+  border: 2px solid #0a0c0e;
+  border-radius: 0.35rem;
+  box-shadow:
+    inset 0 2px 0 rgb(255 255 255 / 0.08),
+    inset 0 -3px 6px rgb(0 0 0 / 0.5),
+    0 0 0 1px var(--mast-brass-lo),
+    0 4px 8px rgb(0 0 0 / 0.4);
+}
+
+.mast-theme-lever .slot {
+  position: absolute;
+  left: 50%;
+  top: 0.45rem;
+  bottom: 0.45rem;
+  width: 6px;
+  transform: translateX(-50%);
+  background: #0a0c0e;
+  border-radius: 3px;
+  box-shadow: inset 0 0 4px #000;
+}
+
+.mast-theme-lever .handle {
+  position: absolute;
+  left: 50%;
+  width: 1.35rem;
+  height: 1.35rem;
+  margin-left: -0.675rem;
+  border-radius: 50%;
+  background: radial-gradient(
+    circle at 35% 30%,
+    var(--mast-brass-hi),
+    var(--mast-brass) 50%,
+    var(--mast-brass-lo)
+  );
+  box-shadow:
+    0 2px 4px rgb(0 0 0 / 0.5),
+    inset 0 1px 0 rgb(255 255 255 / 0.4),
+    0 0 0 2px #1a1206;
+  transition: top 0.28s cubic-bezier(0.34, 1.3, 0.64, 1);
+  top: 0.35rem; /* light = up */
+  z-index: 2;
+}
+
+.mast-theme-lever[aria-pressed="true"] .handle {
+  top: calc(100% - 1.7rem); /* dark = down */
+}
+
+.mast-theme-lever .stem {
+  position: absolute;
+  left: 50%;
+  width: 4px;
+  margin-left: -2px;
+  background: linear-gradient(90deg, #5a5040, var(--mast-brass), #5a5040);
+  top: 0.9rem;
+  height: 1.1rem;
+  transition:
+    top 0.28s cubic-bezier(0.34, 1.3, 0.64, 1),
+    height 0.28s cubic-bezier(0.34, 1.3, 0.64, 1);
+  z-index: 1;
+}
+
+.mast-theme-lever[aria-pressed="true"] .stem {
+  top: 1.4rem;
+  height: 0.9rem;
+}
+
+.mast-theme-lever .tag {
+  font-family: var(--font-mono);
+  font-size: 0.55rem;
+  font-weight: 700;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--mast-brass);
+  text-align: center;
+  line-height: 1.2;
+  text-shadow: 0 1px 2px #000;
 }
 
 /* Essentials utilities cannot express cleanly */

--- a/apps/harness/src/theme.ts
+++ b/apps/harness/src/theme.ts
@@ -58,7 +58,7 @@ export function withThemePin<T extends Record<string, unknown>>(
   return { ...prev, theme }
 }
 
-/** Toggle label shows the *target* theme (moon plate → "Dark" when light). */
+/** Toggle label shows the *target* theme (lever → "Dark" when light). */
 export function themeToggleLabel(current: ThemeMode): string {
   return current === "dark" ? "Light" : "Dark"
 }

--- a/apps/harness/src/ui.ts
+++ b/apps/harness/src/ui.ts
@@ -20,9 +20,6 @@ export function cx(...parts: Array<string | false | null | undefined>): string {
  * `calc(100%_-_Npx)`. Bare `calc(100%-Npx)` is invalid CSS and drops the
  * right-hand rivet entirely.
  */
-const mastPlateRivets =
-  "[background-image:radial-gradient(circle_1.6px_at_7px_7px,var(--mast-plate-rivet)_1.6px,transparent_2.1px),radial-gradient(circle_1.6px_at_calc(100%_-_7px)_7px,var(--mast-plate-rivet)_1.6px,transparent_2.1px)]"
-
 const plateMiniRivets =
   "[background-image:radial-gradient(circle_1.4px_at_6px_6px,var(--plate-rivet)_1.4px,transparent_1.9px),radial-gradient(circle_1.4px_at_calc(100%_-_6px)_6px,var(--plate-rivet)_1.4px,transparent_1.9px)]"
 
@@ -57,6 +54,8 @@ export const ui = {
   /* ---------- Nav shell (§4.1) ---------- */
 
   // bg-mast-bg (not bg-[var(--mast-bg)]) so styles.css mast focus-ring selector matches.
+  // overflow-hidden clips the mobile-wide scrollwork ornament (165% width) so it
+  // cannot create horizontal page scroll; instrument labels are in-flow, not clipped.
   mast: cx(
     "relative isolate flex flex-wrap items-end justify-between overflow-hidden",
     "gap-x-10 gap-y-[1.2rem] bg-mast-bg px-[2.2rem] pt-6 pb-[1.35rem] text-[var(--mast-ink)]",
@@ -107,26 +106,16 @@ export const ui = {
   /** Child `.ok` inside brand-sub */
   brandSubOk: "text-signal",
 
-  mastNav: "relative z-20 flex flex-wrap items-center gap-[0.55rem]",
+  // items-start: top-align lever cradle + settings cog (labels hang below).
+  mastNav:
+    "relative z-20 flex flex-wrap items-start gap-x-[1.15rem] gap-y-[0.55rem]",
 
-  mastPlate: cx(
-    "inline-flex items-center gap-2 border-2 border-black",
-    "bg-[var(--mast-plate)] text-[var(--mast-plate-ink)]",
-    mastPlateRivets,
-    "shadow-[inset_0_1px_0_var(--mast-plate-hi),inset_0_-2px_0_rgb(0_0_0/0.3)]",
-    "px-[0.95rem] py-[0.55rem]",
-    "font-mono text-[0.7rem] font-bold tracking-[0.14em] uppercase no-underline",
-    "cursor-pointer transition-[background-color,color] duration-100 ease-in-out",
-    "hover:bg-[var(--mast-plate-hover)] hover:text-[var(--mast-ink)]",
-    "aria-[current=page]:bg-[var(--mast-plate-active)] aria-[current=page]:text-[var(--mast-plate-active-ink)]",
-    "aria-[current=page]:shadow-[inset_0_1px_0_rgb(255_255_255/0.65),inset_0_-2px_0_rgb(16_19_18/0.12)]",
-    // Active rivets via arbitrary variant on same element (valid calc for right edge).
-    "aria-[current=page]:[background-image:radial-gradient(circle_1.6px_at_7px_7px,var(--mast-plate-active-rivet)_1.6px,transparent_2.1px),radial-gradient(circle_1.6px_at_calc(100%_-_7px)_7px,var(--mast-plate-active-rivet)_1.6px,transparent_2.1px)]",
-    "[&_svg]:h-[0.9rem] [&_svg]:w-[0.9rem] [&_svg]:shrink-0",
-  ),
-
-  /** Standalone if SVG is not nested under mastPlate */
-  mastPlateSvg: "h-[0.9rem] w-[0.9rem] shrink-0",
+  /**
+   * Theme lever + Settings cog: visual recipes in styles.css (prototype C / B).
+   * Class names are production hooks; child anatomy uses .cradle / .teeth / etc.
+   */
+  mastThemeLever: "mast-theme-lever",
+  mastSettingsCog: "mast-settings-cog",
 
   laneRibbon:
     "flex h-[0.4rem] [&>span]:flex-1 [&>span:nth-child(1)]:bg-lane-queue [&>span:nth-child(2)]:bg-lane-build [&>span:nth-child(3)]:bg-lane-review [&>span:nth-child(4)]:bg-lane-pr [&>span:nth-child(5)]:bg-lane-attention [&>span:nth-child(6)]:bg-lane-merged",

--- a/apps/harness/test/primary-nav.test.ts
+++ b/apps/harness/test/primary-nav.test.ts
@@ -105,16 +105,28 @@ describe("primary navigation (Interchange masthead + Jobs switcher)", () => {
     )
   })
 
-  test("mast plates are Settings and theme only; brand stays left", () => {
+  test("mast instruments are Settings cog + theme lever; brand stays left", () => {
     const source = rootSource()
     const navBlock = source.slice(
       source.indexOf('aria-label="Primary"'),
       source.indexOf("</nav>"),
     )
     expect(navBlock).toContain("<SettingsNavIcon />")
+    expect(navBlock).toContain("<SettingsCogTeeth />")
+    expect(navBlock).toContain('className="cog-body"')
+    expect(navBlock).toContain('className="core"')
+    expect(navBlock).toContain('className="label-ring"')
     expect(navBlock).toContain("Settings")
+    // e2e contract: catalog-only steps use getByRole("button", { name: "Settings" }).
+    expect(navBlock).toContain('aria-label="Settings"')
     expect(navBlock).toContain("<ThemeTogglePlate />")
-    expect(navBlock).toContain("mastPlateClassName")
+    expect(navBlock).toContain("ui.mastSettingsCog")
+    // Lever recipe lives inside ThemeTogglePlate (outside the nav slice).
+    expect(source).toContain("ui.mastThemeLever")
+    expect(source).toContain('className="cradle"')
+    expect(source).toContain('className="handle"')
+    expect(source).not.toContain("lamp circuit")
+    expect(source).toContain("SETTINGS_COG_TEETH_PATH")
     // Theme left of Settings (rightmost control stays Settings).
     const settingsIdx = navBlock.indexOf("Settings")
     const themeIdx = navBlock.indexOf("<ThemeTogglePlate")
@@ -212,11 +224,23 @@ describe("primary navigation (Interchange masthead + Jobs switcher)", () => {
     expect(ui).toMatch(/pipelineTab:[\s\S]*?\[&_svg\]/)
   })
 
-  test("mast plates keep stamped styling; brand home link is exact", () => {
+  test("mast instruments use lever + cog recipes; brand home link is exact", () => {
     const source = rootSource()
+    const ui = uiSource()
+    const styles = stylesSource()
     expect(source).toContain('from "@tanstack/react-router"')
-    expect(source).toContain("const mastPlateClassName = ui.mastPlate")
-    expect(source).toContain("className={mastPlateClassName}")
+    expect(source).toContain("ui.mastThemeLever")
+    expect(source).toContain("ui.mastSettingsCog")
+    expect(ui).toContain('mastThemeLever: "mast-theme-lever"')
+    expect(ui).toContain('mastSettingsCog: "mast-settings-cog"')
+    // Exact prototype B/C CSS lives in styles.css (SVG gear + lever handle).
+    expect(styles).toContain(".mast-settings-cog")
+    expect(styles).toContain(".mast-settings-cog .teeth")
+    expect(styles).toContain(".mast-settings-cog .core")
+    expect(styles).toContain(".mast-theme-lever")
+    expect(styles).toContain('.mast-theme-lever[aria-pressed="true"] .handle')
+    expect(source).not.toContain("lamp circuit")
+    expect(source).toContain("SETTINGS_COG_TEETH_PATH")
     // Wordmark still lands on pipeline home with exact matching.
     const brand = source.slice(
       source.indexOf("ui.brandWordmark"),
@@ -227,34 +251,25 @@ describe("primary navigation (Interchange masthead + Jobs switcher)", () => {
     // Destinations are client Links, not raw <a href> only.
     expect(source).not.toMatch(/<a\s+href=["']\/repos["']/)
     expect(source).not.toMatch(/<a\s+href=["']\/["']/)
-    // Active plate styling lives on the recipe via aria-current.
-    const ui = uiSource()
-    expect(ui).toMatch(/mastPlate:[\s\S]*?aria-\[current=page\]/)
+    // Dead stamped mast-plate recipe must not return (instruments replaced it).
+    expect(ui).not.toMatch(/\bmastPlate\s*:/)
+    expect(ui).not.toContain("mastPlateRivets")
   })
 
-  test("mast plates and Jobs tabs share right-side rivet treatment", () => {
+  test("Jobs tabs keep right-side rivet treatment; mast instruments are lever + cog", () => {
     const ui = uiSource()
     const root = rootSource()
+    const styles = stylesSource()
     const switcher = switcherSource()
 
     // Valid CSS calc spacing for the right-edge rivet (Tailwind `_` → space).
     // Bare `calc(100%-Npx)` is invalid and drops the right-hand rivet.
-    expect(ui).toContain("calc(100%_-_7px)")
     expect(ui).toContain("calc(100%_-_6px)")
     expect(ui).not.toMatch(/calc\(100%-\d+px\)/)
 
-    // Shared recipes use theme rivet tokens (no image assets).
-    expect(ui).toMatch(
-      /mastPlateRivets[\s\S]*?--mast-plate-rivet[\s\S]*?calc\(100%_-_7px\)/,
-    )
+    // Jobs mini-plate rivets use theme tokens (no image assets).
     expect(ui).toMatch(
       /plateMiniRivets[\s\S]*?--plate-rivet[\s\S]*?calc\(100%_-_6px\)/,
-    )
-    // Mast plate recipe consumes the mast rivet recipe.
-    expect(ui).toMatch(/mastPlate:[\s\S]*?mastPlateRivets/)
-    // Active mast plate keeps right-hand rivets via active token.
-    expect(ui).toMatch(
-      /mastPlate:[\s\S]*?aria-\[current=page\]:\[background-image:[\s\S]*?--mast-plate-active-rivet[\s\S]*?calc\(100%_-_7px\)/,
     )
 
     // Jobs mode tabs reuse mini-plate rivets + active override on ink fill.
@@ -266,10 +281,14 @@ describe("primary navigation (Interchange masthead + Jobs switcher)", () => {
       /pipelineTabActiveRivets[\s\S]*?--paper[\s\S]*?calc\(100%_-_6px\)/,
     )
 
-    // Theme + Settings share mastPlate; Jobs tabs share pipelineTab — no
-    // per-control decorative rivet DOM.
-    expect(root).toContain("const mastPlateClassName = ui.mastPlate")
+    // Theme lever + Settings cog; Jobs tabs stay pipelineTab — no decorative
+    // rivet DOM on either surface.
+    expect(root).toContain("ui.mastThemeLever")
+    expect(root).toContain("ui.mastSettingsCog")
     expect(root).toContain("<ThemeTogglePlate />")
+    expect(styles).toContain(".mast-theme-lever .handle")
+    expect(styles).toContain(".mast-settings-cog .teeth")
+    expect(root).toContain("function SettingsCogTeeth")
     expect(switcher).toContain("className={ui.pipelineTab}")
     expect(switcher).not.toMatch(/rivet/i)
     expect(root).not.toMatch(/className=\{[^}]*rivet/i)
@@ -339,10 +358,11 @@ describe("primary navigation (Interchange masthead + Jobs switcher)", () => {
     expect(source).toContain("wght@400;700")
   })
 
-  test("theme plumbing: bootstrap script, prefers-color-scheme, ?theme= pin, toggle plate", () => {
+  test("theme plumbing: bootstrap script, prefers-color-scheme, ?theme= pin, toggle lever", () => {
     const root = rootSource()
     const theme = themeSource()
     const styles = stylesSource()
+    const ui = uiSource()
     expect(theme).toContain("THEME_BOOTSTRAP_SCRIPT")
     expect(theme).toContain("prefers-color-scheme")
     expect(theme).toContain('THEME_QUERY_PARAM = "theme"')
@@ -378,16 +398,21 @@ describe("primary navigation (Interchange masthead + Jobs switcher)", () => {
     expect(root).toMatch(/Switch to \$\{targetLabel\} theme/)
     expect(root).toContain("aria-pressed")
     expect(root).toContain("themeToggleLabel")
+    // Lever chrome (prototype C) — pressed = dark, handle drops via CSS.
+    expect(root).toContain("ui.mastThemeLever")
+    expect(root).toContain('className="handle"')
+    expect(styles).toContain('.mast-theme-lever[aria-pressed="true"] .handle')
     expect(root).toContain("suppressHydrationWarning")
     expect(styles).toContain("color-scheme: light")
     expect(styles).toContain("color-scheme: dark")
+    expect(styles).toContain("--mast-brass:")
     // Dialog scrim token (phase 5) — theme-invariant dimming, not ink-derived.
     expect(styles).toContain("--scrim:")
     // Backdrop via custom Tailwind utility (dialog-backdrop on dialogPanel).
     expect(styles).toContain("@utility dialog-backdrop")
     expect(styles).toContain("::backdrop")
     expect(styles).toContain("background: var(--scrim)")
-    expect(uiSource()).toMatch(/dialogPanel:[\s\S]*?dialog-backdrop/)
+    expect(ui).toMatch(/dialogPanel:[\s\S]*?dialog-backdrop/)
     expect(root).toContain("ui.dialogPanel")
     // Ledger oxblood / elevated paper-2 palette is gone after phase 5 teardown.
     expect(styles).not.toContain("--paper-2:")

--- a/docs/harness-design-system.md
+++ b/docs/harness-design-system.md
@@ -138,10 +138,15 @@ value inside `[data-theme="dark"] [data-kanban-surface]`.
 | `--mast-plate-active` | `#e8ece9` | `#e8ece9` |
 | `--mast-plate-active-ink` | `#101314` | `#101314` |
 | `--mast-plate-active-rivet` | `rgb(16 19 18 / 0.5)` | `rgb(16 19 18 / 0.5)` |
+| `--mast-brass` | `#c9a04a` | `#c9a04a` |
+| `--mast-brass-hi` | `#f0d78a` | `#f0d78a` |
+| `--mast-brass-lo` | `#7a5a1e` | `#7a5a1e` |
 
 The band carries a low-contrast, full-width forged-iron scrollwork rail behind
 the brand and controls. A matte grain, dark vignette, and bevel-highlighted
-iron strokes add depth without reducing foreground contrast.
+iron strokes add depth without reducing foreground contrast. Brass tokens
+accent the theme lever and Settings cog (theme-invariant on the always-dark
+mast).
 
 ### 2.4 Stamped plates on paper
 
@@ -255,9 +260,10 @@ Named slots (rem), transcribed from the prototypes:
 
 - One token set; `[data-theme="dark"]` overrides the neutral/masthead/plate
   groups on `<html>`. Lane colors and fonts live outside the themed blocks.
-- Default follows `prefers-color-scheme`; a **theme-toggle plate** in the
-  masthead nav flips light/dark (moon icon, label = target theme,
-  `aria-pressed`). `?theme=light|dark` may pin a theme for sharing.
+- Default follows `prefers-color-scheme`; a **theme-toggle lever** in the
+  masthead nav flips light/dark (switchboard handle: up = light, down = dark;
+  mono label = target theme, `aria-pressed`). `?theme=light|dark` may pin a
+  theme for sharing.
 - The masthead band stays dark in both themes (§2.3).
 - Merged-PR stats use paper fill in both themes (§4.2) — no pitch-black
   departure slab in dark.
@@ -276,11 +282,18 @@ brand left and nav right, items baseline-aligned.
   and "Operator board" are not repeated here), wordmark link in display 800
   uppercase white (hover: `--signal`), mono sub-line with live status fragment
   in `--signal`.
-- **Primary nav** — B's flush stamped plates, replacing D's system-map stops:
-  Home, Repos, Completed, Settings (button, `aria-haspopup="dialog"`), plus
-  the theme-toggle plate. Plate anatomy (§5.3): 2px black border, rivet dots,
-  mono uppercase 0.7rem/700, icon (0.9rem inline SVG) + label; active page =
-  light plate (`--mast-plate-active` ink) with `aria-current="page"`.
+- **Primary nav instruments** — theme lever + Settings cog on the right
+  (Pipeline / Repos / Completed live under the Jobs switcher, not the mast):
+  - **Theme lever**: iron cradle, brass stem/handle; handle up when light,
+    down when dark (`aria-pressed`); mono brass legend shows the *target*
+    theme (same as before).
+  - **Settings cog**: brass SVG gear around an iron core with stroke
+    **sunburst / hub** icon; mono "Settings" legend; button
+    `aria-haspopup="dialog"` and accessible name `"Settings"`
+    (`aria-label` + visible text for e2e `getByRole`).
+  - Brass accents use `--mast-brass` / `-hi` / `-lo`. Instrument CSS lives in
+    `styles.css` (`.mast-theme-lever`, `.mast-settings-cog`). Jobs tabs still
+    use mini-plate rivets (§5.3).
 - **Lane ribbon**: 0.4rem strip directly under the masthead — six equal
   segments in lane-color order. Purely visual, `aria-hidden`.
 - **Not-found route**: standard panel + "Back home" link, same language.
@@ -613,14 +626,13 @@ underline).
 
 ### 5.3 Stamped plates (buttons)
 
-- **Nav plate**: 2px `#000` border, `--mast-plate` fill, rivet dots
-  (radial-gradient 1.6px at top corners), bevel
-  (`inset 0 1px 0 hi, inset 0 -2px 0 rgb(0 0 0 / 0.3)`), mono 0.7rem/700
-  uppercase; hover `--mast-plate-hover`; active = light plate.
-- **Mini plate** (pagination, banner actions, Browse, Cancel, Recheck): 2px
-  ink border, `--plate` fill, top-left + top-right rivets (1.4px dots),
-  **top inset highlight only** (`inset 0 1px 0 var(--plate-hi)` — no bottom
-  `-2px` strip), mono 0.68rem/700 uppercase; hover `--plate-hover`.
+- **Mast instruments** (theme lever + Settings cog): not stamped plates — see
+  §4.1. Tokens `--mast-plate*` remain on the theme layer for historical
+  chrome continuity but have no mast-nav recipe consumer.
+- **Mini plate** (pagination, banner actions, Browse, Cancel, Recheck, Jobs
+  tabs): 2px ink border, `--plate` fill, top-left + top-right rivets (1.4px
+  dots), **top inset highlight only** (`inset 0 1px 0 var(--plate-hi)` — no
+  bottom `-2px` strip), mono 0.68rem/700 uppercase; hover `--plate-hover`.
 - **Primary plate** (Save, credential CTAs, other dialog actions): **riveted
   stamped-plate twin of mini** — same `--plate` fill, rivets, and top-only
   bevel (not solid-ink fill). Hierarchy is position/label only so Cancel and


### PR DESCRIPTION
## Why

The masthead Dark/Settings controls still read as flat stamped chips. Operators wanted stronger steampunk instrument affordances that fit Interchange without changing theme pin or Settings dialog behavior.

We prototyped five directions and chose **Settings from variant B** (gear instrument) and **theme from variant C** (switchboard lever).

## What Changed

- **Theme**: switchboard lever (handle up = light, down = dark); mono target label Dark/Light; same `?theme=` pin, SSR-stable chrome, and `aria-pressed` contract.
- **Settings**: brass SVG gear with iron core and sunburst hub; accessible name remains `"Settings"` for e2e.
- **Tokens/CSS**: `--mast-brass*` and `.mast-theme-lever` / `.mast-settings-cog` recipes in `styles.css`.
- **Chrome hygiene**: mast keeps `overflow-hidden` (scrollwork clip); top-aligned instruments; removed dead `mastPlate` recipe; design-system §4.1/§5.3 updated; primary-nav tests lock the new contracts.
