### PR TITLE
feat(harness): route Pipeline Session Telemetry through browser history

### DIFF
--- a/apps/harness/e2e/features/session-telemetry-browser-history.feature
+++ b/apps/harness/e2e/features/session-telemetry-browser-history.feature
@@ -1,0 +1,83 @@
+Feature: Route Pipeline Session Telemetry through browser history
+  Opening Session Telemetry from Pipeline uses
+  `/session/<work-item-id>/telemetry` so Back closes the dialog, Forward
+  reopens it, and Close stays synchronized with the browser location.
+
+  Background:
+    Given the Harness has Session Telemetry fixtures
+
+  Scenario: Pipeline open pushes Work Item telemetry path and preserves theme search
+    When I open the home page with theme dark
+    And I cancel the Harness settings dialog if present
+    And I open Session Telemetry for the missing-session fixture from Pipeline
+    Then the browser location is the Session Telemetry path for the missing-session fixture with theme dark
+    And the Session usage dialog is visible
+    And the Session usage dialog shows the missing Session Telemetry state
+    And the Pipeline jobs tab is active
+
+  Scenario: Browser Back closes telemetry and Forward reopens the same Work Item
+    When I open the home page
+    And I cancel the Harness settings dialog if present
+    And I open Session Telemetry for the missing-session fixture from Pipeline
+    Then the browser location is the Session Telemetry path for the missing-session fixture
+    When I go back in the browser
+    Then the Session usage dialog is hidden
+    And the browser location is the home path
+    When I go forward in the browser
+    Then the Session usage dialog is visible
+    And the browser location is the Session Telemetry path for the missing-session fixture
+    And the Session usage dialog shows the missing Session Telemetry state
+
+  Scenario: Close returns to the originating Pipeline location
+    When I open the home page
+    And I cancel the Harness settings dialog if present
+    And I open Session Telemetry for the missing-session fixture from Pipeline
+    Then the browser location is the Session Telemetry path for the missing-session fixture
+    When I close the Session usage dialog
+    Then the Session usage dialog is hidden
+    And the browser location is the home path
+
+  Scenario: Direct telemetry navigation shows the dialog over Pipeline
+    When I open the missing-session Session Telemetry path directly
+    Then the Session usage dialog is visible
+    And the browser location is the Session Telemetry path for the missing-session fixture
+    And the Pipeline jobs tab is active
+    And the Session usage dialog shows the missing Session Telemetry state
+    When I close the Session usage dialog
+    Then the Session usage dialog is hidden
+    And the browser location is the home path
+
+  Scenario: Refreshing telemetry keeps the dialog open and closes to home
+    When I open the missing-session Session Telemetry path directly
+    Then the Session usage dialog is visible
+    When I refresh the page
+    Then the Session usage dialog is visible
+    And the browser location is the Session Telemetry path for the missing-session fixture
+    When I close the Session usage dialog
+    Then the Session usage dialog is hidden
+    And the browser location is the home path
+
+  Scenario: Missing Work Item shows not-found inside the dialog
+    When I open Session Telemetry for a missing Work Item directly
+    Then the Session usage dialog is visible
+    And the Session usage dialog shows Work Item not found
+    When I close the Session usage dialog
+    Then the Session usage dialog is hidden
+    And the browser location is the home path
+
+  Scenario: Unsupported backend telemetry remains distinct
+    When I open the unsupported Session Telemetry path directly
+    Then the Session usage dialog is visible
+    And the Session usage dialog shows the unsupported Session Telemetry state
+
+  Scenario: Query failure remains distinct from missing Work Item
+    When Session Telemetry query is forced to fail
+    And I open the missing-session Session Telemetry path directly
+    Then the Session usage dialog is visible
+    And the Session usage dialog shows a Session usage load error
+
+  Scenario: Successful Session Telemetry remains distinct
+    When Session Telemetry query returns available usage for the missing-session fixture
+    And I open the missing-session Session Telemetry path directly
+    Then the Session usage dialog is visible
+    And the Session usage dialog shows successful Session Telemetry fields

--- a/apps/harness/e2e/features/session-telemetry-browser-history.feature
+++ b/apps/harness/e2e/features/session-telemetry-browser-history.feature
@@ -5,6 +5,7 @@ Feature: Route Pipeline Session Telemetry through browser history
 
   Background:
     Given the Harness has Session Telemetry fixtures
+    And the Harness has a configured default build model
 
   Scenario: Pipeline open pushes Work Item telemetry path and preserves theme search
     When I open the home page with theme dark

--- a/apps/harness/e2e/steps/session-telemetry-browser-history.ts
+++ b/apps/harness/e2e/steps/session-telemetry-browser-history.ts
@@ -1,0 +1,286 @@
+/**
+ * Playwright-BDD steps for routed Session Telemetry history (issue #841).
+ *
+ * Shared navigation steps (home open, Back/Forward, refresh, first-run cancel,
+ * Pipeline tab assertions) live in kanban-route / settings-browser-history.
+ */
+import { type Page, expect } from "@playwright/test"
+import {
+  TELEMETRY_FIXTURE,
+  seedSessionTelemetryFixtures,
+} from "../support/session-telemetry-fixture.ts"
+import { Given, Then, When } from "./fixtures.ts"
+
+const sessionUsageDialog = (page: Page) =>
+  page.getByRole("dialog", { name: /Session$/ })
+
+const telemetryPathFor = (workItemId: string): RegExp =>
+  new RegExp(
+    `/session/${workItemId.replaceAll(/[.*+?^${}()|[\]\\]/g, "\\$&")}/telemetry/?(?:\\?.*)?$`,
+  )
+
+type SessionQueryIntercept = {
+  mode: "pass" | "fail" | "available"
+}
+
+const interceptByPage = new WeakMap<Page, SessionQueryIntercept>()
+
+const interceptFor = (page: Page): SessionQueryIntercept => {
+  let state = interceptByPage.get(page)
+  if (state === undefined) {
+    state = { mode: "pass" }
+    interceptByPage.set(page, state)
+  }
+  return state
+}
+
+const installSessionQueryRoute = async (page: Page) => {
+  await page.unroute("**/graphql").catch(() => {})
+  await page.route("**/graphql", async (route) => {
+    const request = route.request()
+    if (request.method() !== "POST") {
+      await route.continue()
+      return
+    }
+    let query = ""
+    let variables: Record<string, unknown> = {}
+    try {
+      const body = request.postDataJSON() as {
+        query?: string
+        variables?: Record<string, unknown>
+      }
+      query = body.query ?? ""
+      variables = body.variables ?? {}
+    } catch {
+      await route.continue()
+      return
+    }
+    // Top-level session(workItemId: ...) query only — not Work Item sessionId.
+    const isSessionTelemetryQuery =
+      (/\bsession\s*\(/.test(query) || query.includes("session(")) &&
+      (query.includes("workItemId") || variables.workItemId !== undefined) &&
+      (query.includes("availability") || query.includes("tokens"))
+    if (!isSessionTelemetryQuery) {
+      await route.continue()
+      return
+    }
+
+    const state = interceptFor(page)
+    if (state.mode === "fail") {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          errors: [{ message: "Simulated Session Telemetry failure" }],
+        }),
+      })
+      return
+    }
+
+    if (state.mode === "available") {
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          data: {
+            session: {
+              id: TELEMETRY_FIXTURE.missingSessionId,
+              availability: "AVAILABLE",
+              backend: { id: "opencode", label: "OpenCode" },
+              model: {
+                providerId: "openai",
+                id: "gpt-e2e",
+                thinkingLevel: "high",
+              },
+              tokens: {
+                input: 100,
+                output: 20,
+                reasoning: 5,
+                cacheRead: 50,
+                cacheWrite: 10,
+              },
+              cost: 1.25,
+              createdAt: "2026-07-14T08:00:00.000Z",
+              updatedAt: "2026-07-14T09:00:00.000Z",
+            },
+          },
+        }),
+      })
+      return
+    }
+
+    await route.continue()
+  })
+}
+
+Given("the Harness has Session Telemetry fixtures", async () => {
+  await seedSessionTelemetryFixtures()
+})
+
+When(
+  "I open Session Telemetry for the missing-session fixture from Pipeline",
+  async ({ page }) => {
+    await installSessionQueryRoute(page)
+    const sessionButton = page.getByRole("button", {
+      name: TELEMETRY_FIXTURE.missingSessionId,
+      exact: true,
+    })
+    await expect(sessionButton).toBeVisible({ timeout: 30_000 })
+    await sessionButton.click()
+    const dialog = sessionUsageDialog(page)
+    await expect(dialog).toBeVisible({ timeout: 15_000 })
+  },
+)
+
+When(
+  "I open the missing-session Session Telemetry path directly",
+  async ({ page }) => {
+    await installSessionQueryRoute(page)
+    await page.goto(
+      `/session/${TELEMETRY_FIXTURE.missingSessionWorkItemId}/telemetry`,
+    )
+    await expect(page).toHaveURL(
+      telemetryPathFor(TELEMETRY_FIXTURE.missingSessionWorkItemId),
+    )
+    await expect(sessionUsageDialog(page)).toBeVisible({ timeout: 30_000 })
+  },
+)
+
+When(
+  "I open the unsupported Session Telemetry path directly",
+  async ({ page }) => {
+    await installSessionQueryRoute(page)
+    await page.goto(
+      `/session/${TELEMETRY_FIXTURE.unsupportedWorkItemId}/telemetry`,
+    )
+    await expect(page).toHaveURL(
+      telemetryPathFor(TELEMETRY_FIXTURE.unsupportedWorkItemId),
+    )
+    await expect(sessionUsageDialog(page)).toBeVisible({ timeout: 30_000 })
+  },
+)
+
+When(
+  "I open Session Telemetry for a missing Work Item directly",
+  async ({ page }) => {
+    await installSessionQueryRoute(page)
+    await page.goto("/session/wi-e2e-does-not-exist/telemetry")
+    await expect(page).toHaveURL(telemetryPathFor("wi-e2e-does-not-exist"))
+    await expect(sessionUsageDialog(page)).toBeVisible({ timeout: 30_000 })
+  },
+)
+
+When("I close the Session usage dialog", async ({ page }) => {
+  const dialog = sessionUsageDialog(page)
+  await dialog.getByRole("button", { name: "Close" }).click()
+  await expect(dialog).toBeHidden()
+})
+
+When("Session Telemetry query is forced to fail", async ({ page }) => {
+  interceptFor(page).mode = "fail"
+  await installSessionQueryRoute(page)
+})
+
+When(
+  "Session Telemetry query returns available usage for the missing-session fixture",
+  async ({ page }) => {
+    interceptFor(page).mode = "available"
+    await installSessionQueryRoute(page)
+  },
+)
+
+Then(
+  "the browser location is the Session Telemetry path for the missing-session fixture",
+  async ({ page }) => {
+    await expect(page).toHaveURL(
+      telemetryPathFor(TELEMETRY_FIXTURE.missingSessionWorkItemId),
+    )
+  },
+)
+
+Then(
+  "the browser location is the Session Telemetry path for the missing-session fixture with theme dark",
+  async ({ page }) => {
+    await expect(page).toHaveURL(
+      new RegExp(
+        `/session/${TELEMETRY_FIXTURE.missingSessionWorkItemId}/telemetry/?\\?theme=dark$`,
+      ),
+    )
+  },
+)
+
+Then("the Session usage dialog is visible", async ({ page }) => {
+  await expect(sessionUsageDialog(page)).toBeVisible()
+})
+
+Then("the Session usage dialog is hidden", async ({ page }) => {
+  await expect(sessionUsageDialog(page)).toBeHidden()
+})
+
+Then(
+  "the Session usage dialog shows the missing Session Telemetry state",
+  async ({ page }) => {
+    const dialog = sessionUsageDialog(page)
+    await expect(dialog.getByText("Loading usage…")).toHaveCount(0, {
+      timeout: 30_000,
+    })
+    await expect(
+      dialog.getByText(/no longer has this Session locally/i),
+    ).toBeVisible({ timeout: 30_000 })
+  },
+)
+
+Then(
+  "the Session usage dialog shows the unsupported Session Telemetry state",
+  async ({ page }) => {
+    const dialog = sessionUsageDialog(page)
+    await expect(dialog.getByText("Loading usage…")).toHaveCount(0, {
+      timeout: 30_000,
+    })
+    await expect(
+      dialog.getByText(/does not provide Session Telemetry/i),
+    ).toBeVisible({ timeout: 30_000 })
+  },
+)
+
+Then("the Session usage dialog shows Work Item not found", async ({ page }) => {
+  const dialog = sessionUsageDialog(page)
+  await expect(dialog.getByText("Loading usage…")).toHaveCount(0, {
+    timeout: 30_000,
+  })
+  await expect(dialog.getByText("Work Item not found.")).toBeVisible({
+    timeout: 30_000,
+  })
+})
+
+Then(
+  "the Session usage dialog shows a Session usage load error",
+  async ({ page }) => {
+    const dialog = sessionUsageDialog(page)
+    await expect(dialog.getByText("Loading usage…")).toHaveCount(0, {
+      timeout: 30_000,
+    })
+    await expect(dialog.getByText(/Could not load Session usage/i)).toBeVisible(
+      { timeout: 30_000 },
+    )
+  },
+)
+
+Then(
+  "the Session usage dialog shows successful Session Telemetry fields",
+  async ({ page }) => {
+    const dialog = sessionUsageDialog(page)
+    await expect(dialog.getByText("Loading usage…")).toHaveCount(0, {
+      timeout: 30_000,
+    })
+    await expect(dialog.getByRole("row", { name: /Model/i })).toContainText(
+      "gpt-e2e",
+    )
+    await expect(
+      dialog.getByRole("row", { name: /Input tokens/i }),
+    ).toContainText("100")
+    await expect(dialog.getByRole("row", { name: /Cost/i })).toContainText(
+      /1\.25|\$1\.25/,
+    )
+  },
+)

--- a/apps/harness/e2e/support/constants.ts
+++ b/apps/harness/e2e/support/constants.ts
@@ -1,4 +1,5 @@
-export const E2E_HARNESS_PORT = 4174
+/** Live e2e Harness port. Override with `E2E_HARNESS_PORT` when 4174 is busy. */
+export const E2E_HARNESS_PORT = Number(process.env.E2E_HARNESS_PORT ?? 4174)
 export const E2E_BASE_URL = `http://127.0.0.1:${E2E_HARNESS_PORT}`
 export const E2E_GRAPHQL_URL = `${E2E_BASE_URL}/graphql`
 

--- a/apps/harness/e2e/support/first-run-settings.ts
+++ b/apps/harness/e2e/support/first-run-settings.ts
@@ -80,10 +80,13 @@ export const ensureConfiguredDefaultBuildModel = async (): Promise<void> => {
     models { id }
   }`)
 
-  if (
-    data.config.defaultModel !== null &&
-    data.config.defaultModel.length > 0
-  ) {
+  const catalogIds = new Set(
+    data.models.map((model) => model.id).filter((id) => id.length > 0),
+  )
+  const current = data.config.defaultModel
+  // Non-empty alone is not enough: a seeded non-catalog value (e.g. from another
+  // e2e feature's SQL fixture) still blocks Save via catalog-only gates (#841).
+  if (current !== null && current.length > 0 && catalogIds.has(current)) {
     return
   }
 

--- a/apps/harness/e2e/support/session-telemetry-fixture.ts
+++ b/apps/harness/e2e/support/session-telemetry-fixture.ts
@@ -1,0 +1,144 @@
+/**
+ * Deterministic Work Item / Session Telemetry fixtures for live e2e (issue #841).
+ *
+ * Seeds via the existing live-Harness control plane (stopped DB + restart).
+ * Does not mock router internals — only Harness persistence and optional GraphQL
+ * response shaping for outcomes that need a real OpenCode session store.
+ */
+
+import { expect } from "@playwright/test"
+import { E2E_GRAPHQL_URL } from "./constants.ts"
+import {
+  CONTROL_FILES,
+  readGeneration,
+  readLiveHarnessState,
+  writeControlFile,
+} from "./live-harness-control.ts"
+
+/**
+ * Branded entity IDs must match DB schema patterns
+ * (`repo-`/`wi-` + 26 Crockford ULID chars, no I/L/O/U). Fixed fixtures keep
+ * scenarios deterministic across restarts.
+ */
+export const TELEMETRY_FIXTURE = {
+  repositoryId: "repo-01KZD5SESS10NTE0FXX0000001",
+  projectPath: "e2e/session-telemetry",
+  /** OpenCode Work Item with a non-local Session id → MISSING telemetry. */
+  missingSessionWorkItemId: "wi-01KZD5SESS10NTE0FXX0000001",
+  missingSessionId: "ses_e2e_fixture_missing",
+  /** Claude Work Item → UNSUPPORTED Session Telemetry. */
+  unsupportedWorkItemId: "wi-01KZD5SESS10NTE0FXX0000002",
+  unsupportedSessionId: "ses_e2e_fixture_unsupported",
+} as const
+
+const sqlLiteral = (value: string) => `'${value.replaceAll("'", "''")}'`
+
+const graphqlReachable = async (): Promise<boolean> => {
+  try {
+    const response = await fetch(E2E_GRAPHQL_URL, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ query: "query { config { defaultModel } }" }),
+    })
+    return response.ok
+  } catch {
+    return false
+  }
+}
+
+const seedAndRestart = async (sql: string) => {
+  const state = readLiveHarnessState()
+  const before = readGeneration(state)
+  writeControlFile(state, CONTROL_FILES.seedSql, sql)
+  writeControlFile(state, CONTROL_FILES.restart, "1")
+  await expect
+    .poll(() => readGeneration(state), { timeout: 60_000, intervals: [250] })
+    .toBeGreaterThan(before)
+  await expect
+    .poll(graphqlReachable, { timeout: 120_000, intervals: [500] })
+    .toBe(true)
+}
+
+/**
+ * Seed a paused Repository and Work Items that appear on Pipeline with
+ * clickable Session IDs. Paused unfinished Work Items do not enqueue Step Runs.
+ */
+export const seedSessionTelemetryFixtures = async (): Promise<void> => {
+  const now = Date.now()
+  // Seed a non-empty default build model so first-run Settings does not auto-open
+  // and block Pipeline scenarios. Value need not be in the live catalog for
+  // telemetry navigation (no Save). Prefs JSON mirrors the flat columns.
+  const prefs = JSON.stringify({
+    opencode: {
+      defaultModel: "e2e-fixture-model",
+      defaultThinkingLevel: null,
+      reviewModel: null,
+      reviewThinkingLevel: null,
+    },
+  })
+  const sql = [
+    // Clear prior fixture rows so scenarios can re-seed safely.
+    `DELETE FROM work_item WHERE repository_id = ${sqlLiteral(TELEMETRY_FIXTURE.repositoryId)};`,
+    `DELETE FROM repository WHERE id = ${sqlLiteral(TELEMETRY_FIXTURE.repositoryId)};`,
+    `UPDATE config SET
+       selected_agent_backend = 'opencode',
+       default_model = 'e2e-fixture-model',
+       default_thinking_level = NULL,
+       review_model = NULL,
+       review_thinking_level = NULL,
+       backend_model_prefs = ${sqlLiteral(prefs)}
+     WHERE id = 'default';`,
+    `INSERT INTO repository (
+       id, forge, forge_host, project_path, local_path, is_bare, paused,
+       created_at, updated_at
+     ) VALUES (
+       ${sqlLiteral(TELEMETRY_FIXTURE.repositoryId)},
+       'github',
+       'github.com',
+       ${sqlLiteral(TELEMETRY_FIXTURE.projectPath)},
+       ${sqlLiteral(`/tmp/${TELEMETRY_FIXTURE.repositoryId}`)},
+       0,
+       1,
+       ${now},
+       ${now}
+     );`,
+    `INSERT INTO work_item (
+       id, repository_id, issue_number, issue_title, agent_backend,
+       state, state_ready_at, paused, holds_worker_slot, session_id,
+       created_at, updated_at
+     ) VALUES (
+       ${sqlLiteral(TELEMETRY_FIXTURE.missingSessionWorkItemId)},
+       ${sqlLiteral(TELEMETRY_FIXTURE.repositoryId)},
+       101,
+       'E2E Session Telemetry missing',
+       'opencode',
+       'implement',
+       ${now},
+       1,
+       0,
+       ${sqlLiteral(TELEMETRY_FIXTURE.missingSessionId)},
+       ${now},
+       ${now}
+     );`,
+    `INSERT INTO work_item (
+       id, repository_id, issue_number, issue_title, agent_backend,
+       state, state_ready_at, paused, holds_worker_slot, session_id,
+       created_at, updated_at
+     ) VALUES (
+       ${sqlLiteral(TELEMETRY_FIXTURE.unsupportedWorkItemId)},
+       ${sqlLiteral(TELEMETRY_FIXTURE.repositoryId)},
+       102,
+       'E2E Session Telemetry unsupported',
+       'claude',
+       'implement',
+       ${now},
+       1,
+       0,
+       ${sqlLiteral(TELEMETRY_FIXTURE.unsupportedSessionId)},
+       ${now},
+       ${now}
+     );`,
+  ].join("\n")
+
+  await seedAndRestart(sql)
+}

--- a/apps/harness/e2e/support/session-telemetry-fixture.ts
+++ b/apps/harness/e2e/support/session-telemetry-fixture.ts
@@ -62,32 +62,19 @@ const seedAndRestart = async (sql: string) => {
 /**
  * Seed a paused Repository and Work Items that appear on Pipeline with
  * clickable Session IDs. Paused unfinished Work Items do not enqueue Step Runs.
+ *
+ * Does not write `config.default_model`: a non-catalog seed would leave Save
+ * blocked for later settings-history scenarios in the same live Harness
+ * process, and `ensureConfiguredDefaultBuildModel` is the shared catalog-safe
+ * path for that. Callers that need first-run suppressed should use that helper
+ * after seeding.
  */
 export const seedSessionTelemetryFixtures = async (): Promise<void> => {
   const now = Date.now()
-  // Seed a non-empty default build model so first-run Settings does not auto-open
-  // and block Pipeline scenarios. Value need not be in the live catalog for
-  // telemetry navigation (no Save). Prefs JSON mirrors the flat columns.
-  const prefs = JSON.stringify({
-    opencode: {
-      defaultModel: "e2e-fixture-model",
-      defaultThinkingLevel: null,
-      reviewModel: null,
-      reviewThinkingLevel: null,
-    },
-  })
   const sql = [
     // Clear prior fixture rows so scenarios can re-seed safely.
     `DELETE FROM work_item WHERE repository_id = ${sqlLiteral(TELEMETRY_FIXTURE.repositoryId)};`,
     `DELETE FROM repository WHERE id = ${sqlLiteral(TELEMETRY_FIXTURE.repositoryId)};`,
-    `UPDATE config SET
-       selected_agent_backend = 'opencode',
-       default_model = 'e2e-fixture-model',
-       default_thinking_level = NULL,
-       review_model = NULL,
-       review_thinking_level = NULL,
-       backend_model_prefs = ${sqlLiteral(prefs)}
-     WHERE id = 'default';`,
     `INSERT INTO repository (
        id, forge, forge_host, project_path, local_path, is_bare, paused,
        created_at, updated_at

--- a/apps/harness/src/completed-surface.tsx
+++ b/apps/harness/src/completed-surface.tsx
@@ -7,7 +7,7 @@
 import { type ReactNode, useState } from "react"
 import { CompletedWorkItemRow } from "./completed-work-item-row.js"
 import type { Repository, WorkItem } from "./routes/index.js"
-import { SessionUsageDialog } from "./routes/index.js"
+import { SessionUsageDialog } from "./session-usage-dialog.js"
 import { ui } from "./ui.js"
 
 export type CompletedIssueLookup = {

--- a/apps/harness/src/jobs-view-switcher.tsx
+++ b/apps/harness/src/jobs-view-switcher.tsx
@@ -62,7 +62,8 @@ export function JobsViewSwitcher() {
   const pathname = useRouterState({ select: (s) => s.location.pathname })
   const onCompleted =
     pathname === "/completed" || pathname.startsWith("/completed/")
-  // `/settings` uses Pipeline as its canonical background (issue #840).
+  // `/settings` and Session Telemetry use Pipeline as canonical background
+  // (issues #840 / #841).
   const pipelineActive = isPipelineBackgroundPath(pathname)
   const reposActive = pathname === "/repos" || pathname.startsWith("/repos/")
   // Filters only drive the Pipeline board today (full in-memory item set).

--- a/apps/harness/src/kanban-board.tsx
+++ b/apps/harness/src/kanban-board.tsx
@@ -1,5 +1,5 @@
 import { useQueries, useSuspenseQuery } from "@tanstack/react-query"
-import { Link } from "@tanstack/react-router"
+import { Link, useNavigate } from "@tanstack/react-router"
 import { type CSSProperties, Suspense, useMemo, useState } from "react"
 import { Banner } from "./banner.js"
 import { Copy } from "./copy.js"
@@ -26,7 +26,6 @@ import {
   JOBS_FAILED_LIMIT,
   JobsCardSkeleton,
   type Repository,
-  SessionUsageDialog,
   type WorkItem,
   WorkItemLifecycleStatus,
   WorkItemPauseButton,
@@ -36,6 +35,7 @@ import {
   jobsWorkingWorkItemsQuery,
   repositoriesQuery,
 } from "./routes/index.js"
+import { openSessionTelemetry } from "./session-telemetry-nav.js"
 import { sessionWorktreeParts } from "./session-worktree-line.js"
 import { cx, ui } from "./ui.js"
 import { workItemIssueUrl } from "./work-item-issue-url.js"
@@ -313,10 +313,14 @@ function PipelineTicket({
 function KanbanJobsBoard() {
   const { selectedRepositoryId } = useJobsRepositoryFilter()
   const [mobileLane, setMobileLane] = useState<PipelineLaneId>("queue")
-  const [sessionDialog, setSessionDialog] = useState<{
-    readonly workItemId: string
-    readonly sessionId: string
-  } | null>(null)
+  const navigate = useNavigate()
+  const openSessionFromPipeline = (workItemId: string, sessionId: string) => {
+    void openSessionTelemetry({
+      navigate,
+      workItemId,
+      sessionId,
+    })
+  }
   const { data: repositories } = useSuspenseQuery(repositoriesQuery)
   const workingQueries = useQueries({
     queries: repositories.map((repository) =>
@@ -505,9 +509,7 @@ function KanbanJobsBoard() {
                           laneId={lane.id}
                           departing={departing}
                           arriving={arriving}
-                          onOpenSession={(workItemId, sessionId) =>
-                            setSessionDialog({ workItemId, sessionId })
-                          }
+                          onOpenSession={openSessionFromPipeline}
                         />
                       ))}
                     </ul>
@@ -555,12 +557,6 @@ function KanbanJobsBoard() {
           </div>
         </section>
       </div>
-      <SessionUsageDialog
-        workItemId={sessionDialog?.workItemId ?? null}
-        sessionId={sessionDialog?.sessionId ?? null}
-        open={sessionDialog !== null}
-        onClose={() => setSessionDialog(null)}
-      />
     </article>
   )
 }

--- a/apps/harness/src/routeTree.gen.ts
+++ b/apps/harness/src/routeTree.gen.ts
@@ -15,6 +15,7 @@ import { Route as GraphqlRouteImport } from './routes/graphql'
 import { Route as KanbanRouteImport } from './routes/kanban'
 import { Route as ReposRouteImport } from './routes/repos'
 import { Route as SettingsRouteImport } from './routes/settings'
+import { Route as SessionWorkItemIdTelemetryRouteImport } from './routes/session.$workItemId.telemetry'
 
 const IndexRoute = IndexRouteImport.update({
   id: '/',
@@ -46,6 +47,12 @@ const SettingsRoute = SettingsRouteImport.update({
   path: '/settings',
   getParentRoute: () => rootRouteImport,
 } as any)
+const SessionWorkItemIdTelemetryRoute =
+  SessionWorkItemIdTelemetryRouteImport.update({
+    id: '/session/$workItemId/telemetry',
+    path: '/session/$workItemId/telemetry',
+    getParentRoute: () => rootRouteImport,
+  } as any)
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
@@ -54,6 +61,7 @@ export interface FileRoutesByFullPath {
   '/kanban': typeof KanbanRoute
   '/repos': typeof ReposRoute
   '/settings': typeof SettingsRoute
+  '/session/$workItemId/telemetry': typeof SessionWorkItemIdTelemetryRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
@@ -62,6 +70,7 @@ export interface FileRoutesByTo {
   '/kanban': typeof KanbanRoute
   '/repos': typeof ReposRoute
   '/settings': typeof SettingsRoute
+  '/session/$workItemId/telemetry': typeof SessionWorkItemIdTelemetryRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
@@ -71,13 +80,27 @@ export interface FileRoutesById {
   '/kanban': typeof KanbanRoute
   '/repos': typeof ReposRoute
   '/settings': typeof SettingsRoute
+  '/session/$workItemId/telemetry': typeof SessionWorkItemIdTelemetryRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
   fullPaths:
-    '/' | '/completed' | '/graphql' | '/kanban' | '/repos' | '/settings'
+    | '/'
+    | '/completed'
+    | '/graphql'
+    | '/kanban'
+    | '/repos'
+    | '/settings'
+    | '/session/$workItemId/telemetry'
   fileRoutesByTo: FileRoutesByTo
-  to: '/' | '/completed' | '/graphql' | '/kanban' | '/repos' | '/settings'
+  to:
+    | '/'
+    | '/completed'
+    | '/graphql'
+    | '/kanban'
+    | '/repos'
+    | '/settings'
+    | '/session/$workItemId/telemetry'
   id:
     | '__root__'
     | '/'
@@ -86,6 +109,7 @@ export interface FileRouteTypes {
     | '/kanban'
     | '/repos'
     | '/settings'
+    | '/session/$workItemId/telemetry'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
@@ -95,6 +119,7 @@ export interface RootRouteChildren {
   KanbanRoute: typeof KanbanRoute
   ReposRoute: typeof ReposRoute
   SettingsRoute: typeof SettingsRoute
+  SessionWorkItemIdTelemetryRoute: typeof SessionWorkItemIdTelemetryRoute
 }
 
 declare module '@tanstack/react-router' {
@@ -141,6 +166,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof SettingsRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/session/$workItemId/telemetry': {
+      id: '/session/$workItemId/telemetry'
+      path: '/session/$workItemId/telemetry'
+      fullPath: '/session/$workItemId/telemetry'
+      preLoaderRoute: typeof SessionWorkItemIdTelemetryRouteImport
+      parentRoute: typeof rootRouteImport
+    }
   }
 }
 
@@ -151,6 +183,7 @@ const rootRouteChildren: RootRouteChildren = {
   KanbanRoute: KanbanRoute,
   ReposRoute: ReposRoute,
   SettingsRoute: SettingsRoute,
+  SessionWorkItemIdTelemetryRoute: SessionWorkItemIdTelemetryRoute,
 }
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)

--- a/apps/harness/src/routed-dialog.ts
+++ b/apps/harness/src/routed-dialog.ts
@@ -1,5 +1,5 @@
 /**
- * Browser-addressable overlay dialog routes (ADR 0048 / issue #840+).
+ * Browser-addressable overlay dialog routes (ADR 0048 / issues #840+).
  *
  * Explicit opens push a history entry; automatic first-run Settings stays
  * local-only and must not open when another routed overlay is requested.
@@ -8,6 +8,15 @@
 /** History state marker for an explicit in-app Harness Settings open. */
 export type HarnessSettingsHistoryState = {
   readonly kind: "in-app-origin"
+}
+
+/**
+ * History state marker for an explicit in-app Session Telemetry open.
+ * Optional sessionId is a display hint only — the route key is Work Item ID.
+ */
+export type SessionTelemetryHistoryState = {
+  readonly kind: "in-app-origin"
+  readonly sessionId?: string
 }
 
 /**
@@ -36,25 +45,102 @@ export const readHarnessSettingsHistoryState = (
   return undefined
 }
 
+/**
+ * Read the optional Session Telemetry origin marker from router/history state.
+ */
+export const readSessionTelemetryHistoryState = (
+  state: unknown,
+): SessionTelemetryHistoryState | undefined => {
+  if (typeof state !== "object" || state === null) {
+    return undefined
+  }
+  if (!("sessionTelemetry" in state)) {
+    return undefined
+  }
+  const marker = (state as { sessionTelemetry?: unknown }).sessionTelemetry
+  if (typeof marker !== "object" || marker === null) {
+    return undefined
+  }
+  if (!("kind" in marker)) {
+    return undefined
+  }
+  if ((marker as { kind: unknown }).kind !== "in-app-origin") {
+    return undefined
+  }
+  const sessionId =
+    "sessionId" in marker &&
+    typeof (marker as { sessionId: unknown }).sessionId === "string" &&
+    (marker as { sessionId: string }).sessionId.length > 0
+      ? (marker as { sessionId: string }).sessionId
+      : undefined
+  return sessionId === undefined
+    ? { kind: "in-app-origin" }
+    : { kind: "in-app-origin", sessionId }
+}
+
 /** True when the pathname is the Harness Settings overlay route. */
 export const isHarnessSettingsPath = (pathname: string): boolean =>
   pathname === "/settings" || pathname === "/settings/"
 
+/** Match `/session/<work-item-id>/telemetry` with optional trailing slash. */
+const sessionTelemetryPathPattern = /^\/session\/([^/]+)\/telemetry\/?$/
+
+/**
+ * Parse Session Telemetry route pathname. Returns the Work Item ID segment or
+ * undefined when the path is not a telemetry overlay.
+ */
+export const parseSessionTelemetryPath = (
+  pathname: string,
+): { readonly workItemId: string } | undefined => {
+  const match = sessionTelemetryPathPattern.exec(pathname)
+  if (match === null) {
+    return undefined
+  }
+  const workItemId = match[1]
+  if (workItemId === undefined || workItemId.length === 0) {
+    return undefined
+  }
+  return { workItemId }
+}
+
+/** True when the pathname is a Session Telemetry overlay route. */
+export const isSessionTelemetryPath = (pathname: string): boolean =>
+  parseSessionTelemetryPath(pathname) !== undefined
+
 /**
  * Routed overlays other than Harness Settings. First-run auto-open is
  * suppressed while one of these is requested so two modals never compete.
- * Paths match ADR 0048 even before those routes are implemented.
+ * Paths match ADR 0048 even before every route is implemented.
  */
 export const isOtherRoutedDialogPath = (pathname: string): boolean => {
   if (/^\/repos\/[^/]+\/settings\/?$/.test(pathname)) {
     return true
   }
-  if (/^\/session\/[^/]+\/telemetry\/?$/.test(pathname)) {
+  if (isSessionTelemetryPath(pathname)) {
     return true
   }
   return false
 }
 
-/** Pipeline is the canonical background for `/settings` (direct load / refresh). */
+/**
+ * Pipeline is the canonical background for `/settings` and Session Telemetry
+ * (direct load / refresh). Jobs switcher treats these as Pipeline-active.
+ */
 export const isPipelineBackgroundPath = (pathname: string): boolean =>
-  pathname === "/" || isHarnessSettingsPath(pathname)
+  pathname === "/" ||
+  isHarnessSettingsPath(pathname) ||
+  isSessionTelemetryPath(pathname)
+
+/**
+ * Document-session flag: true only after an explicit in-app Session Telemetry
+ * open in this SPA document. Module-level so Pipeline openers and root close
+ * share it; full reload clears it so direct/refresh close uses replace → `/`.
+ */
+let sessionTelemetryOpenedFromInAppThisDocument = false
+
+export const markSessionTelemetryOpenedFromInApp = (): void => {
+  sessionTelemetryOpenedFromInAppThisDocument = true
+}
+
+export const wasSessionTelemetryOpenedFromInApp = (): boolean =>
+  sessionTelemetryOpenedFromInAppThisDocument

--- a/apps/harness/src/routes/__root.tsx
+++ b/apps/harness/src/routes/__root.tsx
@@ -52,8 +52,13 @@ import { repositoriesQuery } from "../repositories-query.js"
 import {
   isHarnessSettingsPath,
   isOtherRoutedDialogPath,
+  isSessionTelemetryPath,
+  parseSessionTelemetryPath,
   readHarnessSettingsHistoryState,
+  readSessionTelemetryHistoryState,
+  wasSessionTelemetryOpenedFromInApp,
 } from "../routed-dialog.js"
+import { SessionUsageDialog } from "../session-usage-dialog.js"
 import appCss from "../styles.css?url"
 import {
   THEME_BOOTSTRAP_SCRIPT,
@@ -267,9 +272,62 @@ function RootComponent() {
   return (
     <div className="min-h-screen w-full">
       <SettingsChrome />
+      {/* Route-driven Session Telemetry overlay (issue #841); dialog is one root
+          instance so Pipeline open, Back/Forward, and direct loads share state. */}
+      <SessionTelemetryOverlay />
       <ReactQueryDevtools buttonPosition="bottom-left" />
       <TanStackRouterDevtools position="bottom-right" />
     </div>
+  )
+}
+
+/**
+ * Session Telemetry at `/session/<work-item-id>/telemetry` (ADR 0048 / #841).
+ * Explicit Pipeline opens push history; Close/Escape/Back leave the route;
+ * direct entry closes with replace → `/`.
+ */
+function SessionTelemetryOverlay() {
+  const navigate = useNavigate()
+  const router = useRouter()
+  const pathname = useRouterState({ select: (s) => s.location.pathname })
+  const telemetryHistoryState = useRouterState({
+    select: (s) => readSessionTelemetryHistoryState(s.location.state),
+  })
+  const parsed = parseSessionTelemetryPath(pathname)
+  const workItemId = parsed?.workItemId ?? null
+  const open = workItemId !== null
+  const sessionIdHint = telemetryHistoryState?.sessionId ?? null
+
+  const leaveSessionTelemetryRoute = () => {
+    // Require both history marker and same-document flag so a full reload
+    // (which restores history state) still uses replace → `/`.
+    const openedFromInApp =
+      wasSessionTelemetryOpenedFromInApp() &&
+      telemetryHistoryState?.kind === "in-app-origin"
+    if (openedFromInApp && router.history.canGoBack()) {
+      router.history.back()
+      return
+    }
+    void navigate({
+      to: "/",
+      search: (prev) => prev,
+      replace: true,
+    })
+  }
+
+  return (
+    <SessionUsageDialog
+      workItemId={workItemId}
+      sessionId={sessionIdHint}
+      open={open}
+      onClose={() => {
+        // Native dialog already closed; leave the route only when we are still
+        // on the telemetry path (Back already changed location first).
+        if (isSessionTelemetryPath(pathname)) {
+          leaveSessionTelemetryRoute()
+        }
+      }}
+    />
   )
 }
 

--- a/apps/harness/src/routes/index.tsx
+++ b/apps/harness/src/routes/index.tsx
@@ -78,6 +78,7 @@ import {
   followRepositoryWorkItemsLive,
 } from "../refresh-work-items-live.js"
 import { type Repository, repositoriesQuery } from "../repositories-query.js"
+import { SessionUsageDialog } from "../session-usage-dialog.js"
 import { sessionWorktreeParts } from "../session-worktree-line.js"
 import { cx, ui } from "../ui.js"
 import { workItemIssueUrl } from "../work-item-issue-url.js"
@@ -155,61 +156,6 @@ const agentBackendsQuery = {
 
 /** Empty select value means inherit the harness default (null override). */
 const HARNESS_DEFAULT_BACKEND_VALUE = ""
-
-const sessionQuery = (workItemId: string) => ({
-  queryKey: ["session", workItemId] as const,
-  queryFn: async () => {
-    const result = await graphql.query({
-      session: {
-        __args: { workItemId },
-        id: true,
-        availability: true,
-        backend: { id: true, label: true },
-        model: {
-          providerId: true,
-          id: true,
-          thinkingLevel: true,
-        },
-        tokens: {
-          input: true,
-          output: true,
-          reasoning: true,
-          cacheRead: true,
-          cacheWrite: true,
-        },
-        cost: true,
-        createdAt: true,
-        updatedAt: true,
-      },
-    })
-    return result.session
-  },
-})
-
-const formatSessionCost = (cost: number): string =>
-  new Intl.NumberFormat(undefined, {
-    style: "currency",
-    currency: "USD",
-    minimumFractionDigits: 2,
-    maximumFractionDigits: 4,
-  }).format(cost)
-
-const formatSessionInstant = (value: string | null | undefined): string => {
-  if (value === null || value === undefined || value === "") {
-    return "—"
-  }
-  const ms = Date.parse(value)
-  if (Number.isNaN(ms)) {
-    return value
-  }
-  return new Intl.DateTimeFormat(undefined, {
-    dateStyle: "medium",
-    timeStyle: "short",
-  }).format(ms)
-}
-
-const formatTokenCount = (value: number): string =>
-  new Intl.NumberFormat(undefined).format(value)
 
 /**
  * Dedicated cache identity for GitHub open non-draft Pull Request counts.
@@ -2808,8 +2754,9 @@ function RepositoryIssues({
   workItemsLoading: boolean
 }) {
   const { data: issues } = useSuspenseQuery(issuesQuery(repository.id))
-  // One Session usage dialog for the whole list (not per issue row) so the
-  // fixed session-usage-title id stays unique — same pattern as Kanban/Completed.
+  // One Session usage dialog for the whole list (not per issue row). Title ids
+  // are per-instance (useId) so coexistence with the root route-driven dialog
+  // remains valid until #843 unifies ownership.
   const [sessionDialog, setSessionDialog] = useState<{
     workItemId: string
     sessionId: string
@@ -3269,199 +3216,6 @@ function RepositoryIssueRow({
         </p>
       )}
     </li>
-  )
-}
-
-export function SessionUsageDialog({
-  workItemId,
-  sessionId,
-  open,
-  onClose,
-}: {
-  workItemId: string | null
-  sessionId: string | null
-  open: boolean
-  onClose: () => void
-}) {
-  const dialogRef = useRef<HTMLDialogElement>(null)
-  const enabled = open && workItemId !== null
-  const session = useQuery({
-    ...sessionQuery(workItemId ?? ""),
-    enabled,
-  })
-
-  useEffect(() => {
-    const dialog = dialogRef.current
-    if (dialog === null) return
-    if (open) {
-      if (!dialog.open) dialog.showModal()
-    } else if (dialog.open) {
-      dialog.close()
-    }
-  }, [open])
-
-  const backendLabel = session.data?.backend.label
-
-  return (
-    <dialog
-      ref={dialogRef}
-      className={cx(ui.dialogPanel, ui.dialogPanelNarrow)}
-      aria-labelledby="session-usage-title"
-      onClose={onClose}
-    >
-      <div className={cx(ui.dialogHeader, ui.dialogHeaderCompact)}>
-        <p className={ui.dialogKicker}>Session usage</p>
-        <h2
-          id="session-usage-title"
-          className={cx(ui.dialogTitle, ui.dialogTitleSm)}
-        >
-          {backendLabel ? `${backendLabel} Session` : "Session"}
-        </h2>
-        {sessionId !== null && (
-          <p
-            className="mt-1 truncate font-mono text-xs text-ink-faint"
-            title={sessionId}
-          >
-            {sessionId}
-          </p>
-        )}
-      </div>
-      <div className={cx(ui.dialogBody, ui.dialogBodyCompact)}>
-        {!enabled ? null : session.isPending ? (
-          <p className={ui.dialogLoading}>Loading usage…</p>
-        ) : session.isError ? (
-          <Banner
-            className={ui.bannerCompact}
-            tone="alarm"
-            tag="Error"
-            role="alert"
-          >
-            Could not load Session usage. Close and try again.
-          </Banner>
-        ) : session.data === null || session.data === undefined ? (
-          <Banner
-            className={ui.bannerCompact}
-            tone="guidance"
-            tag="Session"
-            role="status"
-          >
-            Work Item not found.
-          </Banner>
-        ) : session.data.availability === "UNSUPPORTED" ? (
-          <Banner
-            className={ui.bannerCompact}
-            tone="guidance"
-            tag="Session"
-            role="status"
-          >
-            {session.data.backend.label} does not provide Session Telemetry.
-          </Banner>
-        ) : session.data.availability === "MISSING" ? (
-          <Banner
-            className={ui.bannerCompact}
-            tone="guidance"
-            tag="Session"
-            role="status"
-          >
-            {session.data.backend.label} no longer has this Session locally.
-            Usage cannot be loaded.
-          </Banner>
-        ) : session.data.availability === "UNAVAILABLE" ? (
-          <div className="grid gap-3">
-            <Banner
-              className={ui.bannerCompact}
-              tone="guidance"
-              tag="Session"
-              role="status"
-            >
-              {session.data.backend.label} Session Telemetry is temporarily
-              unavailable. Retry in a moment.
-            </Banner>
-            <button
-              type="button"
-              className={cx(ui.plateMini, "justify-self-start")}
-              onClick={() => {
-                void session.refetch()
-              }}
-            >
-              Retry
-            </button>
-          </div>
-        ) : (
-          <table className={ui.dialogTable}>
-            <tbody>
-              <tr>
-                <th scope="row">Model</th>
-                <td>
-                  {session.data.model === null ||
-                  session.data.model === undefined
-                    ? "—"
-                    : [
-                        session.data.model.providerId,
-                        session.data.model.id,
-                        session.data.model.thinkingLevel,
-                      ]
-                        .filter(
-                          (part) =>
-                            part !== null && part !== undefined && part !== "",
-                        )
-                        .join(" / ")}
-                </td>
-              </tr>
-              <tr>
-                <th scope="row">Input tokens</th>
-                <td>{formatTokenCount(session.data.tokens?.input ?? 0)}</td>
-              </tr>
-              <tr>
-                <th scope="row">Output tokens</th>
-                <td>{formatTokenCount(session.data.tokens?.output ?? 0)}</td>
-              </tr>
-              <tr>
-                <th scope="row">Reasoning tokens</th>
-                <td>{formatTokenCount(session.data.tokens?.reasoning ?? 0)}</td>
-              </tr>
-              <tr>
-                <th scope="row">Cache read</th>
-                <td>{formatTokenCount(session.data.tokens?.cacheRead ?? 0)}</td>
-              </tr>
-              <tr>
-                <th scope="row">Cache write</th>
-                <td>
-                  {formatTokenCount(session.data.tokens?.cacheWrite ?? 0)}
-                </td>
-              </tr>
-              <tr>
-                <th scope="row">Cost</th>
-                <td>
-                  {session.data.cost === null || session.data.cost === undefined
-                    ? "—"
-                    : formatSessionCost(session.data.cost)}
-                </td>
-              </tr>
-              <tr>
-                <th scope="row">Created</th>
-                <td>{formatSessionInstant(session.data.createdAt)}</td>
-              </tr>
-              <tr>
-                <th scope="row">Updated</th>
-                <td>{formatSessionInstant(session.data.updatedAt)}</td>
-              </tr>
-            </tbody>
-          </table>
-        )}
-      </div>
-      <div className={cx(ui.dialogFooter, ui.dialogFooterCompact)}>
-        <button
-          type="button"
-          className={ui.plateMini}
-          onClick={() => {
-            dialogRef.current?.close()
-          }}
-        >
-          Close
-        </button>
-      </div>
-    </dialog>
   )
 }
 

--- a/apps/harness/src/routes/session.$workItemId.telemetry.tsx
+++ b/apps/harness/src/routes/session.$workItemId.telemetry.tsx
@@ -1,0 +1,14 @@
+/**
+ * `/session/<work-item-id>/telemetry` — browser-addressable Session Telemetry
+ * overlay (issue #841 / ADR 0048).
+ *
+ * The dialog lives in root chrome; this route supplies the canonical Pipeline
+ * background for direct navigation and refresh. Explicit opens from Pipeline
+ * also land here so the URL and history entry stay consistent.
+ */
+import { createFileRoute } from "@tanstack/react-router"
+import { PipelinePage } from "./index.js"
+
+export const Route = createFileRoute("/session/$workItemId/telemetry")({
+  component: PipelinePage,
+})

--- a/apps/harness/src/session-telemetry-nav.ts
+++ b/apps/harness/src/session-telemetry-nav.ts
@@ -1,0 +1,46 @@
+/**
+ * Navigate to the browser-addressable Session Telemetry overlay (issue #841).
+ *
+ * Route key is the owning Work Item ID (ADR 0048). Optional sessionId is only a
+ * history-state display hint until the session query resolves.
+ */
+
+import type { NavigateOptions, RegisteredRouter } from "@tanstack/react-router"
+import {
+  type SessionTelemetryHistoryState,
+  markSessionTelemetryOpenedFromInApp,
+} from "./routed-dialog.js"
+
+type TelemetryTo = "/session/$workItemId/telemetry"
+
+type TelemetryNavigate = (
+  options: NavigateOptions<RegisteredRouter, string, TelemetryTo>,
+) => unknown
+
+export const openSessionTelemetry = (input: {
+  readonly navigate: TelemetryNavigate
+  readonly workItemId: string
+  readonly sessionId?: string | null
+}): unknown => {
+  markSessionTelemetryOpenedFromInApp()
+  const sessionId =
+    input.sessionId !== null &&
+    input.sessionId !== undefined &&
+    input.sessionId.length > 0
+      ? input.sessionId
+      : undefined
+  const marker: SessionTelemetryHistoryState =
+    sessionId === undefined
+      ? { kind: "in-app-origin" }
+      : { kind: "in-app-origin", sessionId }
+
+  return input.navigate({
+    to: "/session/$workItemId/telemetry",
+    params: { workItemId: input.workItemId },
+    search: (prev) => prev,
+    state: (prev) =>
+      Object.assign({}, prev, {
+        sessionTelemetry: marker,
+      }),
+  })
+}

--- a/apps/harness/src/session-usage-dialog.tsx
+++ b/apps/harness/src/session-usage-dialog.tsx
@@ -1,0 +1,269 @@
+/**
+ * Session usage modal (Session Telemetry presentation).
+ *
+ * Open ownership may be local (Repos/Completed) or route-driven from root
+ * (`/session/<work-item-id>/telemetry`, issue #841). Presentation is shared.
+ */
+import { useQuery } from "@tanstack/react-query"
+import { useEffect, useId, useRef } from "react"
+import { createClient } from "@ready-for-agent/graphql-client"
+import { Banner } from "./banner.js"
+import { cx, ui } from "./ui.js"
+
+const graphql = createClient({ url: "/graphql" })
+
+const sessionQuery = (workItemId: string) => ({
+  queryKey: ["session", workItemId] as const,
+  queryFn: async () => {
+    const result = await graphql.query({
+      session: {
+        __args: { workItemId },
+        id: true,
+        availability: true,
+        backend: { id: true, label: true },
+        model: {
+          providerId: true,
+          id: true,
+          thinkingLevel: true,
+        },
+        tokens: {
+          input: true,
+          output: true,
+          reasoning: true,
+          cacheRead: true,
+          cacheWrite: true,
+        },
+        cost: true,
+        createdAt: true,
+        updatedAt: true,
+      },
+    })
+    return result.session
+  },
+})
+
+const formatSessionCost = (cost: number): string =>
+  new Intl.NumberFormat(undefined, {
+    style: "currency",
+    currency: "USD",
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 4,
+  }).format(cost)
+
+const formatSessionInstant = (value: string | null | undefined): string => {
+  if (value === null || value === undefined || value === "") {
+    return "—"
+  }
+  const ms = Date.parse(value)
+  if (Number.isNaN(ms)) {
+    return value
+  }
+  return new Intl.DateTimeFormat(undefined, {
+    dateStyle: "medium",
+    timeStyle: "short",
+  }).format(ms)
+}
+
+const formatTokenCount = (value: number): string =>
+  new Intl.NumberFormat(undefined).format(value)
+
+export function SessionUsageDialog({
+  workItemId,
+  sessionId,
+  open,
+  onClose,
+}: {
+  workItemId: string | null
+  sessionId: string | null
+  open: boolean
+  onClose: () => void
+}) {
+  const dialogRef = useRef<HTMLDialogElement>(null)
+  // Per-instance title id: root mounts a route-driven dialog while Repos/
+  // Completed still mount local ones until #843 — a fixed id would collide.
+  const titleId = `session-usage-title-${useId().replaceAll(":", "")}`
+  const enabled = open && workItemId !== null
+  const session = useQuery({
+    ...sessionQuery(workItemId ?? ""),
+    enabled,
+  })
+
+  useEffect(() => {
+    const dialog = dialogRef.current
+    if (dialog === null) return
+    if (open) {
+      if (!dialog.open) dialog.showModal()
+    } else if (dialog.open) {
+      dialog.close()
+    }
+  }, [open])
+
+  const backendLabel = session.data?.backend.label
+  // Prefer the open-time hint (Pipeline click / history state); fall back to
+  // the session query id so direct `/session/<work-item-id>/telemetry` loads
+  // still show the backend-local Session ID when available (issue #841).
+  const displaySessionId =
+    sessionId !== null && sessionId.length > 0
+      ? sessionId
+      : (session.data?.id ?? null)
+  const showSessionId = displaySessionId !== null && displaySessionId.length > 0
+
+  return (
+    <dialog
+      ref={dialogRef}
+      className={cx(ui.dialogPanel, ui.dialogPanelNarrow)}
+      aria-labelledby={titleId}
+      onClose={onClose}
+    >
+      <div className={cx(ui.dialogHeader, ui.dialogHeaderCompact)}>
+        <p className={ui.dialogKicker}>Session usage</p>
+        <h2 id={titleId} className={cx(ui.dialogTitle, ui.dialogTitleSm)}>
+          {backendLabel ? `${backendLabel} Session` : "Session"}
+        </h2>
+        {showSessionId && (
+          <p
+            className="mt-1 truncate font-mono text-xs text-ink-faint"
+            title={displaySessionId}
+          >
+            {displaySessionId}
+          </p>
+        )}
+      </div>
+      <div className={cx(ui.dialogBody, ui.dialogBodyCompact)}>
+        {!enabled ? null : session.isPending ? (
+          <p className={ui.dialogLoading}>Loading usage…</p>
+        ) : session.isError ? (
+          <Banner
+            className={ui.bannerCompact}
+            tone="alarm"
+            tag="Error"
+            role="alert"
+          >
+            Could not load Session usage. Close and try again.
+          </Banner>
+        ) : session.data === null || session.data === undefined ? (
+          <Banner
+            className={ui.bannerCompact}
+            tone="guidance"
+            tag="Session"
+            role="status"
+          >
+            Work Item not found.
+          </Banner>
+        ) : session.data.availability === "UNSUPPORTED" ? (
+          <Banner
+            className={ui.bannerCompact}
+            tone="guidance"
+            tag="Session"
+            role="status"
+          >
+            {session.data.backend.label} does not provide Session Telemetry.
+          </Banner>
+        ) : session.data.availability === "MISSING" ? (
+          <Banner
+            className={ui.bannerCompact}
+            tone="guidance"
+            tag="Session"
+            role="status"
+          >
+            {session.data.backend.label} no longer has this Session locally.
+            Usage cannot be loaded.
+          </Banner>
+        ) : session.data.availability === "UNAVAILABLE" ? (
+          <div className="grid gap-3">
+            <Banner
+              className={ui.bannerCompact}
+              tone="guidance"
+              tag="Session"
+              role="status"
+            >
+              {session.data.backend.label} Session Telemetry is temporarily
+              unavailable. Retry in a moment.
+            </Banner>
+            <button
+              type="button"
+              className={cx(ui.plateMini, "justify-self-start")}
+              onClick={() => {
+                void session.refetch()
+              }}
+            >
+              Retry
+            </button>
+          </div>
+        ) : (
+          <table className={ui.dialogTable}>
+            <tbody>
+              <tr>
+                <th scope="row">Model</th>
+                <td>
+                  {session.data.model === null ||
+                  session.data.model === undefined
+                    ? "—"
+                    : [
+                        session.data.model.providerId,
+                        session.data.model.id,
+                        session.data.model.thinkingLevel,
+                      ]
+                        .filter(
+                          (part) =>
+                            part !== null && part !== undefined && part !== "",
+                        )
+                        .join(" / ")}
+                </td>
+              </tr>
+              <tr>
+                <th scope="row">Input tokens</th>
+                <td>{formatTokenCount(session.data.tokens?.input ?? 0)}</td>
+              </tr>
+              <tr>
+                <th scope="row">Output tokens</th>
+                <td>{formatTokenCount(session.data.tokens?.output ?? 0)}</td>
+              </tr>
+              <tr>
+                <th scope="row">Reasoning tokens</th>
+                <td>{formatTokenCount(session.data.tokens?.reasoning ?? 0)}</td>
+              </tr>
+              <tr>
+                <th scope="row">Cache read</th>
+                <td>{formatTokenCount(session.data.tokens?.cacheRead ?? 0)}</td>
+              </tr>
+              <tr>
+                <th scope="row">Cache write</th>
+                <td>
+                  {formatTokenCount(session.data.tokens?.cacheWrite ?? 0)}
+                </td>
+              </tr>
+              <tr>
+                <th scope="row">Cost</th>
+                <td>
+                  {session.data.cost === null || session.data.cost === undefined
+                    ? "—"
+                    : formatSessionCost(session.data.cost)}
+                </td>
+              </tr>
+              <tr>
+                <th scope="row">Created</th>
+                <td>{formatSessionInstant(session.data.createdAt)}</td>
+              </tr>
+              <tr>
+                <th scope="row">Updated</th>
+                <td>{formatSessionInstant(session.data.updatedAt)}</td>
+              </tr>
+            </tbody>
+          </table>
+        )}
+      </div>
+      <div className={cx(ui.dialogFooter, ui.dialogFooterCompact)}>
+        <button
+          type="button"
+          className={ui.plateMini}
+          onClick={() => {
+            dialogRef.current?.close()
+          }}
+        >
+          Close
+        </button>
+      </div>
+    </dialog>
+  )
+}

--- a/apps/harness/test/interchange-phase5.test.ts
+++ b/apps/harness/test/interchange-phase5.test.ts
@@ -113,11 +113,9 @@ describe("Interchange phase 5: dialogs, menus, chrome + Ledger teardown", () => 
   })
 
   test("session usage dialog is narrow shell with table and telemetry banners", () => {
-    const home = homeSource()
-    const dialog = sliceBetween(
-      home,
-      "export function SessionUsageDialog",
-      "export function JobsCardSkeleton",
+    const dialog = readFileSync(
+      join(import.meta.dir, "../src/session-usage-dialog.tsx"),
+      "utf8",
     )
     expect(dialog).toContain("ui.dialogPanel")
     expect(dialog).toContain("ui.dialogPanelNarrow")

--- a/apps/harness/test/kanban-route.test.ts
+++ b/apps/harness/test/kanban-route.test.ts
@@ -263,7 +263,8 @@ describe("kanban home board", () => {
   test("retains board controls and excludes repository management on the board", () => {
     const source = boardSource()
     // Section collapse absence is covered by the #681 header-band test above.
-    expect(source).toContain("<SessionUsageDialog")
+    // Session Telemetry is route-driven from root (issue #841); board opens it.
+    expect(source).toContain("openSessionTelemetry")
     expect(source).toContain("<WorkItemPauseButton")
     expect(source).toContain("<WorkItemLifecycleStatus")
     expect(source).toContain("<Copy")

--- a/apps/harness/test/repos-interchange.test.ts
+++ b/apps/harness/test/repos-interchange.test.ts
@@ -103,7 +103,7 @@ describe("Interchange phase 4: repos page + blank slate", () => {
     const issues = sliceBetweenMarkers(
       homeSource(),
       "function RepositoryIssueRow(",
-      "export function SessionUsageDialog(",
+      "export function JobsCardSkeleton(",
     )
     expect(issues).toContain("ui.repoIssue")
     expect(issues).toContain("ui.repoIssueNum")
@@ -169,7 +169,7 @@ describe("Interchange phase 4: repos page + blank slate", () => {
     const row = sliceBetweenMarkers(
       homeSource(),
       "function RepositoryIssueRow(",
-      "export function SessionUsageDialog(",
+      "export function JobsCardSkeleton(",
     )
     expect(row).toContain("onOpenSession=")
     expect(row).toContain("collapseEarlierLanes")
@@ -236,7 +236,7 @@ describe("Interchange phase 4: repos page + blank slate", () => {
     const leaf = sliceBetweenMarkers(
       source,
       "function RepositoryIssueRow(",
-      "export function SessionUsageDialog(",
+      "export function JobsCardSkeleton(",
     )
     expect(leaf).toContain("ui.bannerCompact")
     expect(leaf).toContain("ui.repoIssueError")

--- a/apps/harness/test/routed-dialog.test.ts
+++ b/apps/harness/test/routed-dialog.test.ts
@@ -2,11 +2,16 @@ import {
   isHarnessSettingsPath,
   isOtherRoutedDialogPath,
   isPipelineBackgroundPath,
+  isSessionTelemetryPath,
+  markSessionTelemetryOpenedFromInApp,
+  parseSessionTelemetryPath,
   readHarnessSettingsHistoryState,
+  readSessionTelemetryHistoryState,
+  wasSessionTelemetryOpenedFromInApp,
 } from "../src/routed-dialog.ts"
 import { describe, expect, test } from "bun:test"
 
-describe("routed dialog path helpers (issue #840)", () => {
+describe("routed dialog path helpers (issues #840 / #841)", () => {
   test("identifies the Harness Settings path", () => {
     expect(isHarnessSettingsPath("/settings")).toBe(true)
     expect(isHarnessSettingsPath("/settings/")).toBe(true)
@@ -14,9 +19,22 @@ describe("routed dialog path helpers (issue #840)", () => {
     expect(isHarnessSettingsPath("/repos")).toBe(false)
   })
 
-  test("Pipeline background includes home and settings", () => {
+  test("identifies Session Telemetry paths and Work Item IDs", () => {
+    expect(isSessionTelemetryPath("/session/wi-1/telemetry")).toBe(true)
+    expect(isSessionTelemetryPath("/session/wi-1/telemetry/")).toBe(true)
+    expect(parseSessionTelemetryPath("/session/wi-abc/telemetry")).toEqual({
+      workItemId: "wi-abc",
+    })
+    expect(isSessionTelemetryPath("/session//telemetry")).toBe(false)
+    expect(isSessionTelemetryPath("/session/wi-1")).toBe(false)
+    expect(isSessionTelemetryPath("/settings")).toBe(false)
+    expect(parseSessionTelemetryPath("/repos")).toBeUndefined()
+  })
+
+  test("Pipeline background includes home, settings, and session telemetry", () => {
     expect(isPipelineBackgroundPath("/")).toBe(true)
     expect(isPipelineBackgroundPath("/settings")).toBe(true)
+    expect(isPipelineBackgroundPath("/session/wi-1/telemetry")).toBe(true)
     expect(isPipelineBackgroundPath("/repos")).toBe(false)
     expect(isPipelineBackgroundPath("/completed")).toBe(false)
   })
@@ -29,7 +47,7 @@ describe("routed dialog path helpers (issue #840)", () => {
     expect(isOtherRoutedDialogPath("/")).toBe(false)
   })
 
-  test("reads the in-app origin history marker", () => {
+  test("reads the in-app origin history marker for Settings", () => {
     expect(
       readHarnessSettingsHistoryState({
         harnessSettings: { kind: "in-app-origin" },
@@ -40,5 +58,31 @@ describe("routed dialog path helpers (issue #840)", () => {
     expect(
       readHarnessSettingsHistoryState({ harnessSettings: { kind: "other" } }),
     ).toBeUndefined()
+  })
+
+  test("reads Session Telemetry history marker with optional sessionId", () => {
+    expect(
+      readSessionTelemetryHistoryState({
+        sessionTelemetry: { kind: "in-app-origin", sessionId: "ses_1" },
+      }),
+    ).toEqual({ kind: "in-app-origin", sessionId: "ses_1" })
+    expect(
+      readSessionTelemetryHistoryState({
+        sessionTelemetry: { kind: "in-app-origin" },
+      }),
+    ).toEqual({ kind: "in-app-origin" })
+    expect(readSessionTelemetryHistoryState({})).toBeUndefined()
+    expect(
+      readSessionTelemetryHistoryState({
+        sessionTelemetry: { kind: "other" },
+      }),
+    ).toBeUndefined()
+  })
+
+  test("document-session flag tracks explicit Session Telemetry opens", () => {
+    // Module state may already be set from prior tests in this process; the
+    // mark function is the public seam used by Pipeline openers.
+    markSessionTelemetryOpenedFromInApp()
+    expect(wasSessionTelemetryOpenedFromInApp()).toBe(true)
   })
 })

--- a/apps/harness/test/session-telemetry-route.test.ts
+++ b/apps/harness/test/session-telemetry-route.test.ts
@@ -1,0 +1,96 @@
+import { readFileSync } from "node:fs"
+import { join } from "node:path"
+import { describe, expect, test } from "bun:test"
+
+const telemetryRouteSource = () =>
+  readFileSync(
+    join(import.meta.dir, "../src/routes/session.$workItemId.telemetry.tsx"),
+    "utf8",
+  )
+
+const rootSource = () =>
+  readFileSync(join(import.meta.dir, "../src/routes/__root.tsx"), "utf8")
+
+const kanbanSource = () =>
+  readFileSync(join(import.meta.dir, "../src/kanban-board.tsx"), "utf8")
+
+const navSource = () =>
+  readFileSync(join(import.meta.dir, "../src/session-telemetry-nav.ts"), "utf8")
+
+const dialogSource = () =>
+  readFileSync(join(import.meta.dir, "../src/session-usage-dialog.tsx"), "utf8")
+
+const routeTreeSource = () =>
+  readFileSync(join(import.meta.dir, "../src/routeTree.gen.ts"), "utf8")
+
+const jobsSwitcherSource = () =>
+  readFileSync(join(import.meta.dir, "../src/jobs-view-switcher.tsx"), "utf8")
+
+const routedDialogSource = () =>
+  readFileSync(join(import.meta.dir, "../src/routed-dialog.ts"), "utf8")
+
+describe("Session Telemetry route (issue #841)", () => {
+  test("is a dedicated TanStack file route over the Pipeline background", () => {
+    const source = telemetryRouteSource()
+    expect(source).toContain(
+      'createFileRoute("/session/$workItemId/telemetry")',
+    )
+    expect(source).toContain("PipelinePage")
+    expect(source).toContain('from "./index.js"')
+  })
+
+  test("is registered in the generated route tree", () => {
+    const source = routeTreeSource()
+    expect(source).toContain("from './routes/session.$workItemId.telemetry'")
+    expect(source).toContain("id: '/session/$workItemId/telemetry'")
+    expect(source).toContain("path: '/session/$workItemId/telemetry'")
+    expect(source).toContain(
+      "'/session/$workItemId/telemetry': typeof SessionWorkItemIdTelemetryRoute",
+    )
+  })
+
+  test("Pipeline openers push Work Item ID telemetry route with in-app origin", () => {
+    const kanban = kanbanSource()
+    expect(kanban).toContain("openSessionTelemetry")
+    expect(kanban).not.toContain("setSessionDialog")
+    expect(kanban).not.toContain("<SessionUsageDialog")
+
+    const nav = navSource()
+    expect(nav).toContain('to: "/session/$workItemId/telemetry"')
+    expect(nav).toContain("markSessionTelemetryOpenedFromInApp")
+    expect(nav).toContain("sessionTelemetry")
+    expect(nav).toContain('kind: "in-app-origin"')
+    expect(nav).toContain("search: (prev) => prev")
+  })
+
+  test("root owns the route-driven Session Telemetry overlay", () => {
+    const source = rootSource()
+    expect(source).toContain("SessionTelemetryOverlay")
+    expect(source).toContain("parseSessionTelemetryPath")
+    expect(source).toContain("wasSessionTelemetryOpenedFromInApp")
+    expect(source).toContain("leaveSessionTelemetryRoute")
+    expect(source).toContain("router.history.back")
+    expect(source).toContain('to: "/"')
+    expect(source).toContain("replace: true")
+    expect(source).toContain("SessionUsageDialog")
+  })
+
+  test("Jobs switcher treats Session Telemetry as Pipeline background", () => {
+    const switcher = jobsSwitcherSource()
+    expect(switcher).toContain("isPipelineBackgroundPath")
+    const helpers = routedDialogSource()
+    expect(helpers).toContain("isSessionTelemetryPath")
+    expect(helpers).toContain("parseSessionTelemetryPath")
+  })
+
+  test("dialog retains not-found and optional telemetry states", () => {
+    const dialog = dialogSource()
+    expect(dialog).toContain("Work Item not found.")
+    expect(dialog).toContain("does not provide Session Telemetry")
+    expect(dialog).toContain("no longer has this Session locally")
+    expect(dialog).toContain("Session Telemetry is temporarily")
+    expect(dialog).toContain("Loading usage…")
+    expect(dialog).toContain("Could not load Session usage")
+    expect(dialog).toContain("ui.dialogTable")
+  })
+})


### PR DESCRIPTION
## Why

Session Telemetry was only local UI state, so operators could not use
Back/Forward, refresh, bookmark, or deep-link the dialog. ADR 0048 defines
browser-addressable overlay routes; this follows the Harness Settings pattern
(`/settings`) for Session Telemetry at `/session/<work-item-id>/telemetry`
(Work Item ID is the lookup key, not the opaque backend Session ID).

## What changed

- Add TanStack route `/session/$workItemId/telemetry` with Pipeline as the
  canonical background for direct loads and refresh.
- Pipeline Session open pushes history (in-app origin marker + same-document
  flag); Back restores the origin, Forward reopens telemetry; Close/Escape stay
  synchronized with the URL.
- Direct entry and post-refresh close use replace navigation to `/` so Forward
  does not reopen a bookmarked overlay by accident.
- Search params (including `?theme=`) are preserved on open/close.
- Root owns the route-driven dialog; Repos/Completed keep local dialogs until
  the follow-up that reuses this route.
- Per-instance title ids (`useId`) avoid collisions while multiple dialog
  mounts coexist.
- Playwright-BDD fixtures seed deterministic Work Items; scenarios cover
  Pipeline open, Back/Forward, direct nav, refresh, close fallback, missing
  Work Item, and distinct telemetry outcomes without mocking the router.

## Verification

- Harness typecheck, lint, and unit tests for routed-dialog helpers / route
  structure.
- Live Harness e2e for the Session Telemetry browser-history feature (history,
  close destination, not-found, unsupported, error, and available states).

## Notes / limitations

- Repository settings routing is out of scope.
- Opening Session Telemetry from Repos and Completed still uses local dialog
  state (follow-up).

Closes #841