### PR TITLE
feat(harness): route Repository settings by Repository ID

### DIFF
--- a/apps/harness/e2e/features/repository-settings-browser-history.feature
+++ b/apps/harness/e2e/features/repository-settings-browser-history.feature
@@ -1,0 +1,136 @@
+Feature: Route Repository settings by Repository ID
+  Explicit Repository settings opens use `/repos/<repository-id>/settings` so
+  Back closes the dialog, Forward reopens it with saved values, and Save /
+  Cancel / Escape stay synchronized with the browser location. Direct and
+  stale links render over Repos. A configured default build model keeps
+  first-run Harness Settings from competing with these scenarios.
+
+  Background:
+    Given the Harness has no configured Repositories
+    And the Harness has a configured default build model
+
+  Scenario: Explicit open pushes /repos/<id>/settings and preserves theme search
+    Given the End-to-End Fixture Repository is checked out
+    When I add the Repository with the CLI
+    And I open the Repos page with theme dark
+    And I open Repository settings from the card menu
+    Then the browser location is the repository settings path with theme dark
+    And the Repository settings dialog is visible
+    And the Repos jobs tab is active
+
+  Scenario: Browser Back closes Repository settings and Forward reopens with saved values
+    Given the End-to-End Fixture Repository is checked out
+    When I add the Repository with the CLI
+    And I open the Repos page
+    And I open Repository settings from the card menu
+    Then the browser location is the repository settings path
+    When I change the Repository paused draft
+    And I go back in the browser
+    Then the Repository settings dialog is hidden
+    And the browser location is the repos path
+    When I go forward in the browser
+    Then the Repository settings dialog is visible
+    And the browser location is the repository settings path
+    And the Repository paused field shows the saved value not the draft
+
+  Scenario: Cancel returns to the originating Repos location
+    Given the End-to-End Fixture Repository is checked out
+    When I add the Repository with the CLI
+    And I open the Repos page
+    And I open Repository settings from the card menu
+    Then the browser location is the repository settings path
+    When I cancel the Repository settings dialog
+    Then the Repository settings dialog is hidden
+    And the browser location is the repos path
+
+  Scenario: Escape returns to the originating Repos location
+    Given the End-to-End Fixture Repository is checked out
+    When I add the Repository with the CLI
+    And I open the Repos page
+    And I open Repository settings from the card menu
+    Then the browser location is the repository settings path
+    When I press Escape in the Repository settings dialog
+    Then the Repository settings dialog is hidden
+    And the browser location is the repos path
+
+  Scenario: Successful Save returns to the originating location
+    Given the End-to-End Fixture Repository is checked out
+    When I add the Repository with the CLI
+    And I open the Repos page
+    And I open Repository settings from the card menu
+    Then the browser location is the repository settings path
+    When I save Repository settings without changing values
+    Then the Repository settings dialog is hidden
+    And the browser location is the repos path
+
+  Scenario: Failed Save keeps the dialog and settings path open
+    Given the End-to-End Fixture Repository is checked out
+    When I add the Repository with the CLI
+    And I open the Repos page
+    And I open Repository settings from the card menu
+    Then the browser location is the repository settings path
+    When Repository settings Save is forced to fail
+    And I save Repository settings expecting failure
+    Then the Repository settings dialog is visible
+    And the browser location is the repository settings path
+    And a repository settings save error is shown
+
+  Scenario: Browser Back is blocked while Save is pending
+    Given the End-to-End Fixture Repository is checked out
+    When I add the Repository with the CLI
+    And I open the Repos page
+    And I open Repository settings from the card menu
+    Then the browser location is the repository settings path
+    When Repository settings Save is delayed
+    And I start saving Repository settings
+    And I go back in the browser while Repository settings Save is pending
+    Then the Repository settings dialog is visible
+    And the browser location is the repository settings path
+    When the delayed Repository settings Save completes
+    Then the Repository settings dialog is hidden
+    And the browser location is the repos path
+
+  Scenario: Direct repository settings navigation shows the dialog over Repos
+    Given the End-to-End Fixture Repository is checked out
+    When I add the Repository with the CLI
+    And I open the repository settings path directly
+    Then the Repository settings dialog is visible
+    And the browser location is the repository settings path
+    And the Repos jobs tab is active
+    When I cancel the Repository settings dialog
+    Then the Repository settings dialog is hidden
+    And the browser location is the repos path
+
+  Scenario: Refreshing repository settings keeps the dialog open and closes to Repos
+    Given the End-to-End Fixture Repository is checked out
+    When I add the Repository with the CLI
+    And I open the repository settings path directly
+    Then the Repository settings dialog is visible
+    When I refresh the page
+    Then the Repository settings dialog is visible
+    And the browser location is the repository settings path
+    When I cancel the Repository settings dialog
+    Then the Repository settings dialog is hidden
+    And the browser location is the repos path
+
+  Scenario: Refresh after in-app open still closes to Repos with replace
+    Given the End-to-End Fixture Repository is checked out
+    When I add the Repository with the CLI
+    And I open the Repos page
+    And I open Repository settings from the card menu
+    Then the browser location is the repository settings path
+    When I refresh the page
+    Then the Repository settings dialog is visible
+    And the browser location is the repository settings path
+    When I cancel the Repository settings dialog
+    Then the Repository settings dialog is hidden
+    And the browser location is the repos path
+
+  Scenario: Missing Repository shows not-found and closes to Repos
+    When I open a stale repository settings path
+    Then the Repository not found dialog is visible
+    And the browser location is a repository settings path
+    And the Repos jobs tab is active
+    When I close the Repository not found dialog
+    Then the Repository not found dialog is hidden
+    And the browser location is the repos path

--- a/apps/harness/e2e/steps/repository-settings-browser-history.ts
+++ b/apps/harness/e2e/steps/repository-settings-browser-history.ts
@@ -1,0 +1,354 @@
+/**
+ * Playwright-BDD steps for routed Repository settings history (issue #842).
+ */
+import { type Page, expect } from "@playwright/test"
+import { E2E_GRAPHQL_URL } from "../support/constants.ts"
+import { dismissFirstRunSettingsIfPresent } from "../support/first-run-settings.ts"
+import { Then, When } from "./fixtures.ts"
+
+/** Repository settings dialog is titled with the Project Path. */
+const repositoryDialog = (page: Page) =>
+  page.locator("dialog[open]").filter({ hasText: "Repository settings" })
+
+const notFoundDialog = (page: Page) =>
+  page.getByRole("dialog", { name: "Repository not found" })
+
+const awaitCatalogSettled = async (
+  dialog: ReturnType<typeof repositoryDialog>,
+) => {
+  await expect(dialog.getByText("Loading models...")).toHaveCount(0, {
+    timeout: 30_000,
+  })
+  await expect(dialog.getByText("Loading catalog…")).toHaveCount(0, {
+    timeout: 30_000,
+  })
+}
+
+const repositorySettingsPathPattern = /\/repos\/[^/]+\/settings\/?(?:\?.*)?$/
+
+const fetchFirstRepositoryId = async (): Promise<string> => {
+  const response = await fetch(E2E_GRAPHQL_URL, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      query: "query { repositories { id projectPath } }",
+    }),
+  })
+  if (!response.ok) {
+    throw new Error(`GraphQL HTTP ${response.status}: ${await response.text()}`)
+  }
+  const payload = (await response.json()) as {
+    data?: { repositories: ReadonlyArray<{ id: string; projectPath: string }> }
+    errors?: ReadonlyArray<{ message: string }>
+  }
+  if (payload.errors?.length) {
+    throw new Error(
+      `GraphQL errors: ${payload.errors.map((e) => e.message).join("; ")}`,
+    )
+  }
+  const repositories = payload.data?.repositories ?? []
+  const first = repositories[0]
+  if (first === undefined) {
+    throw new Error("Expected at least one configured Repository")
+  }
+  return first.id
+}
+
+type UpdateRepositorySettingsIntercept = {
+  failNext: boolean
+  delay: { resolve: () => void; promise: Promise<void> } | null
+}
+
+const interceptByPage = new WeakMap<Page, UpdateRepositorySettingsIntercept>()
+
+const interceptFor = (page: Page): UpdateRepositorySettingsIntercept => {
+  let state = interceptByPage.get(page)
+  if (state === undefined) {
+    state = { failNext: false, delay: null }
+    interceptByPage.set(page, state)
+  }
+  return state
+}
+
+const installUpdateRepositorySettingsRoute = async (page: Page) => {
+  await page.unroute("**/graphql").catch(() => {})
+  await page.route("**/graphql", async (route) => {
+    const request = route.request()
+    if (request.method() !== "POST") {
+      await route.continue()
+      return
+    }
+    let query = ""
+    try {
+      const body = request.postDataJSON() as { query?: string }
+      query = body.query ?? ""
+    } catch {
+      await route.continue()
+      return
+    }
+    if (!query.includes("updateRepositorySettings")) {
+      await route.continue()
+      return
+    }
+
+    const state = interceptFor(page)
+    if (state.failNext) {
+      state.failNext = false
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          errors: [{ message: "Simulated repository settings save failure" }],
+        }),
+      })
+      return
+    }
+
+    if (state.delay !== null) {
+      const gate = state.delay
+      await gate.promise
+      await route.continue()
+      return
+    }
+
+    await route.continue()
+  })
+}
+
+When("I open the Repos page with theme dark", async ({ page }) => {
+  await page.goto("/repos?theme=dark")
+  await expect(page).toHaveURL(/theme=dark/)
+  await dismissFirstRunSettingsIfPresent(page)
+  await expect(
+    page.getByRole("region", { name: "Configured repositories" }),
+  ).toBeVisible({ timeout: 30_000 })
+})
+
+When("I open Repository settings from the card menu", async ({ page }) => {
+  await installUpdateRepositorySettingsRoute(page)
+  // Ensure we are on Repos with cards (callers usually open Repos first).
+  if (!/\/repos/.test(new URL(page.url()).pathname)) {
+    await page.goto("/repos")
+    await dismissFirstRunSettingsIfPresent(page)
+  }
+  await expect(
+    page.getByRole("region", { name: "Configured repositories" }),
+  ).toBeVisible({ timeout: 30_000 })
+  await page
+    .getByRole("button", { name: /^Actions for / })
+    .first()
+    .click()
+  await page.getByRole("menuitem", { name: "Settings" }).click()
+  const dialog = repositoryDialog(page)
+  await expect(dialog).toBeVisible()
+  await awaitCatalogSettled(dialog)
+})
+
+When("I open the repository settings path directly", async ({ page }) => {
+  await installUpdateRepositorySettingsRoute(page)
+  const repositoryId = await fetchFirstRepositoryId()
+  await page.goto(`/repos/${encodeURIComponent(repositoryId)}/settings`)
+  await expect(page).toHaveURL(repositorySettingsPathPattern)
+  const dialog = repositoryDialog(page)
+  await expect(dialog).toBeVisible({ timeout: 30_000 })
+  await awaitCatalogSettled(dialog)
+})
+
+When("I open a stale repository settings path", async ({ page }) => {
+  await page.goto("/repos/repo-stale-missing-id/settings")
+  await expect(page).toHaveURL(repositorySettingsPathPattern)
+  await dismissFirstRunSettingsIfPresent(page)
+})
+
+When("I cancel the Repository settings dialog", async ({ page }) => {
+  const dialog = repositoryDialog(page)
+  await dialog.getByRole("button", { name: "Cancel" }).click()
+  await expect(dialog).toBeHidden()
+})
+
+When("I press Escape in the Repository settings dialog", async ({ page }) => {
+  const dialog = repositoryDialog(page)
+  await expect(dialog).toBeVisible()
+  await page.keyboard.press("Escape")
+  await expect(dialog).toBeHidden()
+})
+
+When("I change the Repository paused draft", async ({ page }) => {
+  const dialog = repositoryDialog(page)
+  const checkbox = dialog.getByRole("checkbox", { name: /Paused/i })
+  await expect(checkbox).toBeVisible()
+  const wasChecked = await checkbox.isChecked()
+  await checkbox.setChecked(!wasChecked)
+  // Stash the draft expectation on the page for the Then step.
+  await page.evaluate((draftChecked) => {
+    ;(window as unknown as { __rfaPausedDraft?: boolean }).__rfaPausedDraft =
+      draftChecked
+  }, !wasChecked)
+})
+
+When(
+  "I go back in the browser while Repository settings Save is pending",
+  async ({ page }) => {
+    await page.evaluate(() => {
+      window.history.back()
+    })
+    await expect(page).toHaveURL(repositorySettingsPathPattern)
+    await expect
+      .poll(
+        async () => {
+          const dialog = repositoryDialog(page)
+          const dialogOpen = await dialog.isVisible()
+          const saving = await dialog
+            .getByRole("button", { name: "Saving…" })
+            .isVisible()
+            .catch(() => false)
+          const onSettings = repositorySettingsPathPattern.test(
+            new URL(page.url()).pathname,
+          )
+          return dialogOpen && saving && onSettings
+        },
+        { timeout: 5_000 },
+      )
+      .toBe(true)
+  },
+)
+
+When("I save Repository settings without changing values", async ({ page }) => {
+  const dialog = repositoryDialog(page)
+  await awaitCatalogSettled(dialog)
+  const save = dialog.getByRole("button", { name: "Save", exact: true })
+  await expect(save).toBeEnabled({ timeout: 15_000 })
+  await save.click()
+  await expect(dialog).toBeHidden({ timeout: 60_000 })
+})
+
+When("Repository settings Save is forced to fail", async ({ page }) => {
+  interceptFor(page).failNext = true
+  await installUpdateRepositorySettingsRoute(page)
+})
+
+When("I save Repository settings expecting failure", async ({ page }) => {
+  const dialog = repositoryDialog(page)
+  await awaitCatalogSettled(dialog)
+  const save = dialog.getByRole("button", { name: "Save", exact: true })
+  await expect(save).toBeEnabled({ timeout: 15_000 })
+  await save.click()
+  await expect(dialog).toBeVisible()
+})
+
+When("Repository settings Save is delayed", async ({ page }) => {
+  let resolveGate = () => {}
+  const promise = new Promise<void>((resolve) => {
+    resolveGate = resolve
+  })
+  interceptFor(page).delay = { resolve: resolveGate, promise }
+  await installUpdateRepositorySettingsRoute(page)
+})
+
+When("I start saving Repository settings", async ({ page }) => {
+  const dialog = repositoryDialog(page)
+  await awaitCatalogSettled(dialog)
+  const save = dialog.getByRole("button", { name: "Save", exact: true })
+  await expect(save).toBeEnabled({ timeout: 15_000 })
+  await save.click()
+  await expect(dialog.getByRole("button", { name: "Saving…" })).toBeVisible({
+    timeout: 15_000,
+  })
+})
+
+When("the delayed Repository settings Save completes", async ({ page }) => {
+  const state = interceptFor(page)
+  const gate = state.delay
+  state.delay = null
+  gate?.resolve()
+  const dialog = repositoryDialog(page)
+  await expect(dialog).toBeHidden({ timeout: 60_000 })
+})
+
+When("I close the Repository not found dialog", async ({ page }) => {
+  const dialog = notFoundDialog(page)
+  await dialog.getByRole("button", { name: "Close" }).click()
+  await expect(dialog).toBeHidden()
+})
+
+Then(
+  "the browser location is the repository settings path",
+  async ({ page }) => {
+    await expect(page).toHaveURL(repositorySettingsPathPattern)
+    const pathname = new URL(page.url()).pathname
+    // Path must use the stable Repository ID (repo-…), not a nested project path.
+    expect(pathname).toMatch(/^\/repos\/repo-[^/]+\/settings\/?$/)
+  },
+)
+
+Then(
+  "the browser location is the repository settings path with theme dark",
+  async ({ page }) => {
+    await expect(page).toHaveURL(/\/repos\/[^/]+\/settings\/?\?theme=dark$/)
+  },
+)
+
+Then("the browser location is a repository settings path", async ({ page }) => {
+  await expect(page).toHaveURL(repositorySettingsPathPattern)
+})
+
+Then("the Repository settings dialog is visible", async ({ page }) => {
+  const dialog = repositoryDialog(page)
+  await expect(dialog).toBeVisible()
+  await expect(dialog.getByText("Repository not found")).toHaveCount(0)
+})
+
+Then("the Repository settings dialog is hidden", async ({ page }) => {
+  await expect(repositoryDialog(page)).toBeHidden()
+})
+
+Then("the Repository not found dialog is visible", async ({ page }) => {
+  await expect(notFoundDialog(page)).toBeVisible({ timeout: 30_000 })
+  await expect(notFoundDialog(page).getByRole("alert")).toBeVisible()
+})
+
+Then("the Repository not found dialog is hidden", async ({ page }) => {
+  await expect(notFoundDialog(page)).toBeHidden()
+})
+
+Then("the Repos jobs tab is active", async ({ page }) => {
+  const reposTab = page
+    .getByRole("navigation", { name: "Jobs" })
+    .getByRole("link", { name: "Repos" })
+  await expect(reposTab).toHaveAttribute("aria-current", "page")
+})
+
+Then(
+  "the Repository paused field shows the saved value not the draft",
+  async ({ page }) => {
+    const dialog = repositoryDialog(page)
+    await awaitCatalogSettled(dialog)
+    const checkbox = dialog.getByRole("checkbox", { name: /Paused/i })
+    await expect(checkbox).toBeVisible()
+    const draftChecked = await page.evaluate(
+      () =>
+        (window as unknown as { __rfaPausedDraft?: boolean }).__rfaPausedDraft,
+    )
+    // Fresh fixture repos are not paused; draft flipped that, so saved is opposite.
+    if (draftChecked === true) {
+      await expect(checkbox).not.toBeChecked()
+    } else if (draftChecked === false) {
+      await expect(checkbox).toBeChecked()
+    } else {
+      // Default fixture: not paused after discarded draft.
+      await expect(checkbox).not.toBeChecked()
+    }
+  },
+)
+
+Then("a repository settings save error is shown", async ({ page }) => {
+  const dialog = repositoryDialog(page)
+  await expect(dialog.getByRole("alert")).toBeVisible()
+  await expect(dialog.getByRole("alert")).toContainText(
+    /Simulated repository settings save failure|could not be saved/i,
+  )
+})
+
+// Reuse shared "I go back/forward" and "I refresh" from settings-browser-history
+// and "browser location is the repos path" from the same module. Playwright-BDD
+// collects all step files.

--- a/apps/harness/src/routeTree.gen.ts
+++ b/apps/harness/src/routeTree.gen.ts
@@ -15,6 +15,7 @@ import { Route as GraphqlRouteImport } from './routes/graphql'
 import { Route as KanbanRouteImport } from './routes/kanban'
 import { Route as ReposRouteImport } from './routes/repos'
 import { Route as SettingsRouteImport } from './routes/settings'
+import { Route as ReposRepositoryIdSettingsRouteImport } from './routes/repos.$repositoryId.settings'
 import { Route as SessionWorkItemIdTelemetryRouteImport } from './routes/session.$workItemId.telemetry'
 
 const IndexRoute = IndexRouteImport.update({
@@ -47,6 +48,12 @@ const SettingsRoute = SettingsRouteImport.update({
   path: '/settings',
   getParentRoute: () => rootRouteImport,
 } as any)
+const ReposRepositoryIdSettingsRoute =
+  ReposRepositoryIdSettingsRouteImport.update({
+    id: '/$repositoryId/settings',
+    path: '/$repositoryId/settings',
+    getParentRoute: () => ReposRoute,
+  } as any)
 const SessionWorkItemIdTelemetryRoute =
   SessionWorkItemIdTelemetryRouteImport.update({
     id: '/session/$workItemId/telemetry',
@@ -59,8 +66,9 @@ export interface FileRoutesByFullPath {
   '/completed': typeof CompletedRoute
   '/graphql': typeof GraphqlRoute
   '/kanban': typeof KanbanRoute
-  '/repos': typeof ReposRoute
+  '/repos': typeof ReposRouteWithChildren
   '/settings': typeof SettingsRoute
+  '/repos/$repositoryId/settings': typeof ReposRepositoryIdSettingsRoute
   '/session/$workItemId/telemetry': typeof SessionWorkItemIdTelemetryRoute
 }
 export interface FileRoutesByTo {
@@ -68,8 +76,9 @@ export interface FileRoutesByTo {
   '/completed': typeof CompletedRoute
   '/graphql': typeof GraphqlRoute
   '/kanban': typeof KanbanRoute
-  '/repos': typeof ReposRoute
+  '/repos': typeof ReposRouteWithChildren
   '/settings': typeof SettingsRoute
+  '/repos/$repositoryId/settings': typeof ReposRepositoryIdSettingsRoute
   '/session/$workItemId/telemetry': typeof SessionWorkItemIdTelemetryRoute
 }
 export interface FileRoutesById {
@@ -78,8 +87,9 @@ export interface FileRoutesById {
   '/completed': typeof CompletedRoute
   '/graphql': typeof GraphqlRoute
   '/kanban': typeof KanbanRoute
-  '/repos': typeof ReposRoute
+  '/repos': typeof ReposRouteWithChildren
   '/settings': typeof SettingsRoute
+  '/repos/$repositoryId/settings': typeof ReposRepositoryIdSettingsRoute
   '/session/$workItemId/telemetry': typeof SessionWorkItemIdTelemetryRoute
 }
 export interface FileRouteTypes {
@@ -91,6 +101,7 @@ export interface FileRouteTypes {
     | '/kanban'
     | '/repos'
     | '/settings'
+    | '/repos/$repositoryId/settings'
     | '/session/$workItemId/telemetry'
   fileRoutesByTo: FileRoutesByTo
   to:
@@ -100,6 +111,7 @@ export interface FileRouteTypes {
     | '/kanban'
     | '/repos'
     | '/settings'
+    | '/repos/$repositoryId/settings'
     | '/session/$workItemId/telemetry'
   id:
     | '__root__'
@@ -109,6 +121,7 @@ export interface FileRouteTypes {
     | '/kanban'
     | '/repos'
     | '/settings'
+    | '/repos/$repositoryId/settings'
     | '/session/$workItemId/telemetry'
   fileRoutesById: FileRoutesById
 }
@@ -117,7 +130,7 @@ export interface RootRouteChildren {
   CompletedRoute: typeof CompletedRoute
   GraphqlRoute: typeof GraphqlRoute
   KanbanRoute: typeof KanbanRoute
-  ReposRoute: typeof ReposRoute
+  ReposRoute: typeof ReposRouteWithChildren
   SettingsRoute: typeof SettingsRoute
   SessionWorkItemIdTelemetryRoute: typeof SessionWorkItemIdTelemetryRoute
 }
@@ -166,6 +179,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof SettingsRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/repos/$repositoryId/settings': {
+      id: '/repos/$repositoryId/settings'
+      path: '/$repositoryId/settings'
+      fullPath: '/repos/$repositoryId/settings'
+      preLoaderRoute: typeof ReposRepositoryIdSettingsRouteImport
+      parentRoute: typeof ReposRoute
+    }
     '/session/$workItemId/telemetry': {
       id: '/session/$workItemId/telemetry'
       path: '/session/$workItemId/telemetry'
@@ -176,12 +196,22 @@ declare module '@tanstack/react-router' {
   }
 }
 
+interface ReposRouteChildren {
+  ReposRepositoryIdSettingsRoute: typeof ReposRepositoryIdSettingsRoute
+}
+
+const ReposRouteChildren: ReposRouteChildren = {
+  ReposRepositoryIdSettingsRoute: ReposRepositoryIdSettingsRoute,
+}
+
+const ReposRouteWithChildren = ReposRoute._addFileChildren(ReposRouteChildren)
+
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   CompletedRoute: CompletedRoute,
   GraphqlRoute: GraphqlRoute,
   KanbanRoute: KanbanRoute,
-  ReposRoute: ReposRoute,
+  ReposRoute: ReposRouteWithChildren,
   SettingsRoute: SettingsRoute,
   SessionWorkItemIdTelemetryRoute: SessionWorkItemIdTelemetryRoute,
 }

--- a/apps/harness/src/routed-dialog.ts
+++ b/apps/harness/src/routed-dialog.ts
@@ -10,6 +10,11 @@ export type HarnessSettingsHistoryState = {
   readonly kind: "in-app-origin"
 }
 
+/** History state marker for an explicit in-app Repository settings open. */
+export type RepositorySettingsHistoryState = {
+  readonly kind: "in-app-origin"
+}
+
 /**
  * History state marker for an explicit in-app Session Telemetry open.
  * Optional sessionId is a display hint only — the route key is Work Item ID.
@@ -78,6 +83,32 @@ export const readSessionTelemetryHistoryState = (
     : { kind: "in-app-origin", sessionId }
 }
 
+/**
+ * Read the optional Repository settings origin marker from history state.
+ * Same validation discipline as Harness Settings (issue #842).
+ */
+export const readRepositorySettingsHistoryState = (
+  state: unknown,
+): RepositorySettingsHistoryState | undefined => {
+  if (typeof state !== "object" || state === null) {
+    return undefined
+  }
+  if (!("repositorySettings" in state)) {
+    return undefined
+  }
+  const marker = (state as { repositorySettings?: unknown }).repositorySettings
+  if (typeof marker !== "object" || marker === null) {
+    return undefined
+  }
+  if (!("kind" in marker)) {
+    return undefined
+  }
+  if ((marker as { kind: unknown }).kind === "in-app-origin") {
+    return { kind: "in-app-origin" }
+  }
+  return undefined
+}
+
 /** True when the pathname is the Harness Settings overlay route. */
 export const isHarnessSettingsPath = (pathname: string): boolean =>
   pathname === "/settings" || pathname === "/settings/"
@@ -108,12 +139,48 @@ export const isSessionTelemetryPath = (pathname: string): boolean =>
   parseSessionTelemetryPath(pathname) !== undefined
 
 /**
+ * Match `/repos/<repository-id>/settings` and return the Repository ID, or
+ * undefined when the path is not a Repository settings overlay.
+ */
+export const parseRepositorySettingsRepositoryId = (
+  pathname: string,
+): string | undefined => {
+  const match = pathname.match(/^\/repos\/([^/]+)\/settings\/?$/)
+  if (match === null) {
+    return undefined
+  }
+  const repositoryId = match[1]
+  if (repositoryId === undefined || repositoryId.length === 0) {
+    return undefined
+  }
+  try {
+    return decodeURIComponent(repositoryId)
+  } catch {
+    // Malformed percent-encoding — treat as a literal segment so not-found still works.
+    return repositoryId
+  }
+}
+
+/** True when the pathname is a Repository settings overlay route. */
+export const isRepositorySettingsPath = (pathname: string): boolean =>
+  parseRepositorySettingsRepositoryId(pathname) !== undefined
+
+/**
+ * True when this pathname is the settings overlay for the given Repository ID
+ * (stable id, not Project Path).
+ */
+export const isRepositorySettingsPathFor = (
+  pathname: string,
+  repositoryId: string,
+): boolean => parseRepositorySettingsRepositoryId(pathname) === repositoryId
+
+/**
  * Routed overlays other than Harness Settings. First-run auto-open is
  * suppressed while one of these is requested so two modals never compete.
  * Paths match ADR 0048 even before every route is implemented.
  */
 export const isOtherRoutedDialogPath = (pathname: string): boolean => {
-  if (/^\/repos\/[^/]+\/settings\/?$/.test(pathname)) {
+  if (isRepositorySettingsPath(pathname)) {
     return true
   }
   if (isSessionTelemetryPath(pathname)) {
@@ -132,6 +199,15 @@ export const isPipelineBackgroundPath = (pathname: string): boolean =>
   isSessionTelemetryPath(pathname)
 
 /**
+ * Repos is the canonical background for `/repos/<id>/settings`
+ * (direct load / refresh). Includes bare `/repos`.
+ */
+export const isReposBackgroundPath = (pathname: string): boolean =>
+  pathname === "/repos" ||
+  pathname === "/repos/" ||
+  isRepositorySettingsPath(pathname)
+
+/**
  * Document-session flag: true only after an explicit in-app Session Telemetry
  * open in this SPA document. Module-level so Pipeline openers and root close
  * share it; full reload clears it so direct/refresh close uses replace → `/`.
@@ -144,3 +220,21 @@ export const markSessionTelemetryOpenedFromInApp = (): void => {
 
 export const wasSessionTelemetryOpenedFromInApp = (): boolean =>
   sessionTelemetryOpenedFromInAppThisDocument
+
+/**
+ * Document-scoped markers for explicit in-app Repository settings opens.
+ * Lives at module scope so it survives route remounts when navigating between
+ * `/repos` and `/repos/<id>/settings` (the dialog is not in root chrome).
+ * A full page load re-initializes the module and clears the set (issue #842).
+ */
+const repositorySettingsInAppOpenIds = new Set<string>()
+
+export const markRepositorySettingsOpenedFromInApp = (
+  repositoryId: string,
+): void => {
+  repositorySettingsInAppOpenIds.add(repositoryId)
+}
+
+export const wasRepositorySettingsOpenedFromInAppThisDocument = (
+  repositoryId: string,
+): boolean => repositorySettingsInAppOpenIds.has(repositoryId)

--- a/apps/harness/src/routes/index.tsx
+++ b/apps/harness/src/routes/index.tsx
@@ -5,11 +5,18 @@ import {
   useQueryClient,
   useSuspenseQuery,
 } from "@tanstack/react-query"
-import { createFileRoute } from "@tanstack/react-router"
+import {
+  createFileRoute,
+  useBlocker,
+  useNavigate,
+  useRouter,
+  useRouterState,
+} from "@tanstack/react-router"
 import {
   type CSSProperties,
   type FormEvent,
   Suspense,
+  useCallback,
   useEffect,
   useRef,
   useState,
@@ -78,6 +85,13 @@ import {
   followRepositoryWorkItemsLive,
 } from "../refresh-work-items-live.js"
 import { type Repository, repositoriesQuery } from "../repositories-query.js"
+import {
+  isRepositorySettingsPathFor,
+  markRepositorySettingsOpenedFromInApp,
+  parseRepositorySettingsRepositoryId,
+  readRepositorySettingsHistoryState,
+  wasRepositorySettingsOpenedFromInAppThisDocument,
+} from "../routed-dialog.js"
 import { SessionUsageDialog } from "../session-usage-dialog.js"
 import { sessionWorktreeParts } from "../session-worktree-line.js"
 import { cx, ui } from "../ui.js"
@@ -584,6 +598,7 @@ function EmptyRepositoriesBlankSlate() {
 
 export function RepositoryCards() {
   const queryClient = useQueryClient()
+  const pathname = useRouterState({ select: (s) => s.location.pathname })
   const { data: repositories } = useSuspenseQuery(repositoriesQuery)
   const { data: addRepositoryCommand } = useSuspenseQuery(
     addRepositoryCommandQuery,
@@ -595,6 +610,11 @@ export function RepositoryCards() {
   >({})
   const repositoryIdsRef = useRef(repositories.map(({ id }) => id))
   repositoryIdsRef.current = repositories.map(({ id }) => id)
+  // Stale `/repos/<id>/settings` links: in-dialog not-found over Repos (issue #842).
+  const routedRepositoryId = parseRepositorySettingsRepositoryId(pathname)
+  const repositoryMissing =
+    routedRepositoryId !== undefined &&
+    !repositories.some((repository) => repository.id === routedRepositoryId)
 
   // Repository membership SSE: transport health drives the live-updates
   // warning; authoritative catch-up and dedicated open-PR counts run
@@ -672,6 +692,9 @@ export function RepositoryCards() {
       <>
         {warning}
         <EmptyRepositoriesBlankSlate />
+        {repositoryMissing && routedRepositoryId !== undefined && (
+          <RepositorySettingsNotFoundDialog repositoryId={routedRepositoryId} />
+        )}
       </>
     )
   }
@@ -691,7 +714,94 @@ export function RepositoryCards() {
       <div className="mt-10 sm:mt-12">
         <AddRepositoryGuidance command={addRepositoryCommand} />
       </div>
+      {repositoryMissing && routedRepositoryId !== undefined && (
+        <RepositorySettingsNotFoundDialog repositoryId={routedRepositoryId} />
+      )}
     </>
+  )
+}
+
+/**
+ * Accessible in-dialog “Repository not found” for stale settings links
+ * (issue #842). Renders over the Repos background; Close replaces to `/repos`.
+ */
+function RepositorySettingsNotFoundDialog({
+  repositoryId,
+}: {
+  repositoryId: string
+}) {
+  const dialogRef = useRef<HTMLDialogElement>(null)
+  const navigate = useNavigate()
+  const dismissingRouteRef = useRef(false)
+
+  const leaveToRepos = () => {
+    dismissingRouteRef.current = true
+    dialogRef.current?.close()
+    void navigate({
+      to: "/repos",
+      search: (prev) => prev,
+      replace: true,
+    })
+  }
+
+  useEffect(() => {
+    const dialog = dialogRef.current
+    if (dialog === null) {
+      return
+    }
+    if (!dialog.open) {
+      dialog.showModal()
+    }
+  }, [])
+
+  return (
+    <dialog
+      ref={dialogRef}
+      className={ui.dialogPanel}
+      aria-labelledby="repo-settings-not-found-title"
+      onClose={() => {
+        if (dismissingRouteRef.current) {
+          dismissingRouteRef.current = false
+          return
+        }
+        void navigate({
+          to: "/repos",
+          search: (prev) => prev,
+          replace: true,
+        })
+      }}
+    >
+      <div className={ui.dialogHeader}>
+        <p className={ui.dialogKicker}>Repository settings</p>
+        <h2 id="repo-settings-not-found-title" className={ui.dialogTitle}>
+          Repository not found
+        </h2>
+        <p className={ui.dialogLede}>
+          No configured Repository matches this link. It may have been removed,
+          or the address is out of date.
+        </p>
+      </div>
+      <div className={ui.dialogBodySectioned}>
+        <Banner
+          className={ui.bannerCompact}
+          tone="alarm"
+          tag="Missing"
+          role="alert"
+        >
+          Repository <code>{repositoryId}</code> is not configured on this
+          Harness.
+        </Banner>
+      </div>
+      <div className={ui.dialogFooter}>
+        <button
+          type="button"
+          className={ui.platePrimary}
+          onClick={leaveToRepos}
+        >
+          Close
+        </button>
+      </div>
+    </dialog>
   )
 }
 
@@ -1006,18 +1116,43 @@ function RepositoryCard({
   repository: Repository
 }) {
   const queryClient = useQueryClient()
+  const navigate = useNavigate()
+  const router = useRouter()
+  const pathname = useRouterState({ select: (s) => s.location.pathname })
+  const repositorySettingsHistoryState = useRouterState({
+    select: (s) => readRepositorySettingsHistoryState(s.location.state),
+  })
+  // Routed `/repos/<id>/settings` open (issue #842). Dialog is route-owned.
+  const settingsOpen = isRepositorySettingsPathFor(pathname, repository.id)
+  // Optimistic open until the route commits (mirrors harness local || routed).
+  const [optimisticSettingsOpen, setOptimisticSettingsOpen] = useState(false)
+  const dialogOpen = settingsOpen || optimisticSettingsOpen
+  const dismissingRouteRef = useRef(false)
+  // Explicit in-app open markers live at module scope so remounting Repos when
+  // pushing `/repos/<id>/settings` still treats Cancel/Save as history.back().
+  // Full reload clears the module set so close uses replace → `/repos`.
+  const settingsOpenNavigatePendingRef = useRef(false)
+  // Invalidate in-flight open navigates when the operator dismisses early.
+  const settingsOpenIntentGenerationRef = useRef(0)
+  // Leave as soon as the settings route commits after an early dismiss or a
+  // successful Save that finished before navigate landed (issue #842 review).
+  const leaveWhenSettingsRouteCommitsRef = useRef(false)
+  const dismissSettingsRef = useRef<
+    (options?: { ignoreBlocker?: boolean }) => void
+  >(() => {})
   const [githubTokenCreated, setGithubTokenCreated] = useState(false)
   const [gitlabTokenCreated, setGitlabTokenCreated] = useState(false)
   const [menuOpen, setMenuOpen] = useState(false)
   const [awaitingRefresh, setAwaitingRefresh] = useState(false)
   const issuesChangeCountOnRefresh = useRef(issuesChangeCount)
   const settingsDialogRef = useRef<HTMLDialogElement>(null)
-  const [settingsOpen, setSettingsOpen] = useState(false)
-  const config = useQuery({ ...configQuery, enabled: settingsOpen })
-  const models = useQuery({ ...modelsQuery, enabled: settingsOpen })
+  // Catalog queries enable for routed open and the optimistic open window so
+  // the first paint after menu click is not a cold catalog (issue #842 review).
+  const config = useQuery({ ...configQuery, enabled: dialogOpen })
+  const models = useQuery({ ...modelsQuery, enabled: dialogOpen })
   const agentBackends = useQuery({
     ...agentBackendsQuery,
-    enabled: settingsOpen,
+    enabled: dialogOpen,
   })
   const [forge, setForge] = useState<"github" | "gitlab">(
     repository.forge === "gitlab" ? "gitlab" : "github",
@@ -1133,9 +1268,23 @@ function RepositoryCard({
       void queryClient.invalidateQueries({
         queryKey: repositoriesQuery.queryKey,
       })
-      settingsDialogRef.current?.close()
-      setSettingsOpen(false)
+      // Successful Save leaves the route (issue #842).
+      dismissSettingsRef.current({ ignoreBlocker: true })
     },
+  })
+
+  // Block Back (and other route leaves) while Save is in flight so navigation
+  // cannot race an in-progress Repository settings update (issue #842).
+  const updateSettingsPendingRef = useRef(false)
+  updateSettingsPendingRef.current = updateSettings.isPending
+  const shouldBlockRepositorySettingsLeave = useCallback(
+    () => updateSettingsPendingRef.current,
+    [],
+  )
+  useBlocker({
+    shouldBlockFn: shouldBlockRepositorySettingsLeave,
+    enableBeforeUnload: updateSettings.isPending,
+    disabled: !updateSettings.isPending || !settingsOpen,
   })
 
   const applyRepoModelPrefs = (prefs: DraftModelPrefs) => {
@@ -1218,8 +1367,12 @@ function RepositoryCard({
     }
   }
 
-  const openSettings = () => {
-    setSettingsOpen(true)
+  /**
+   * Reset form session state and refresh indefinitely-cached catalogs on open
+   * (issue #838). Shared by explicit open and routed enter (direct / Forward).
+   */
+  const prepareSettingsSessionRef = useRef(() => {})
+  prepareSettingsSessionRef.current = () => {
     previewGenerationRef.current += 1
     setPaused(repository.paused)
     setForge(repository.forge === "gitlab" ? "gitlab" : "github")
@@ -1262,8 +1415,154 @@ function RepositoryCard({
     void config.refetch()
     void models.refetch()
     void agentBackends.refetch()
-    settingsDialogRef.current?.showModal()
   }
+
+  /**
+   * Leave the `/repos/<id>/settings` route: Back to the in-app origin when
+   * this SPA session opened settings explicitly, else replace with `/repos`
+   * so Forward cannot reopen a direct-link or post-refresh entry.
+   * Stored on a ref so the route-sync effect can call the latest leave without
+   * re-running on every render (unstable function identity).
+   */
+  const leaveSettingsRouteRef = useRef<
+    (options?: { ignoreBlocker?: boolean }) => void
+  >(() => {})
+  leaveSettingsRouteRef.current = (options?: { ignoreBlocker?: boolean }) => {
+    const ignoreBlocker = options?.ignoreBlocker === true
+    const openedFromInApp =
+      wasRepositorySettingsOpenedFromInAppThisDocument(repository.id) &&
+      repositorySettingsHistoryState?.kind === "in-app-origin"
+    if (openedFromInApp && router.history.canGoBack()) {
+      router.history.back({ ignoreBlocker })
+      return
+    }
+    void navigate({
+      to: "/repos",
+      search: (prev) => prev,
+      replace: true,
+      ignoreBlocker,
+    })
+  }
+  const leaveSettingsRoute = (options?: { ignoreBlocker?: boolean }) => {
+    leaveSettingsRouteRef.current(options)
+  }
+
+  const dismissSettings = (options?: { ignoreBlocker?: boolean }) => {
+    if (updateSettings.isPending && options?.ignoreBlocker !== true) {
+      return
+    }
+    // Early leave while open navigate is still in flight (Cancel/Escape, or
+    // successful Save before the route commits). Invalidate the open intent
+    // and leave when `/repos/<id>/settings` lands so the dialog cannot reopen.
+    if (
+      !settingsOpen &&
+      (settingsOpenNavigatePendingRef.current || optimisticSettingsOpen)
+    ) {
+      settingsOpenNavigatePendingRef.current = false
+      settingsOpenIntentGenerationRef.current += 1
+      leaveWhenSettingsRouteCommitsRef.current = true
+      setOptimisticSettingsOpen(false)
+      const dialog = settingsDialogRef.current
+      // Only pair dismissingRouteRef with an actual close so onClose clears it;
+      // otherwise Escape on a later open would skip leaveSettingsRoute.
+      if (dialog?.open) {
+        dismissingRouteRef.current = true
+        dialog.close()
+      }
+      return
+    }
+    if (!settingsOpen) {
+      settingsDialogRef.current?.close()
+      return
+    }
+    leaveWhenSettingsRouteCommitsRef.current = false
+    setOptimisticSettingsOpen(false)
+    // Escape already closed the native dialog before onClose → dismissSettings.
+    // Only set dismissingRouteRef when we actually close so the flag cannot stick
+    // and break Escape on a subsequent open (issue #842 review).
+    const dialog = settingsDialogRef.current
+    if (dialog?.open) {
+      dismissingRouteRef.current = true
+      dialog.close()
+    }
+    leaveSettingsRoute(options)
+  }
+  dismissSettingsRef.current = dismissSettings
+
+  /** Explicit Repository settings openers (card menu). */
+  const openSettings = () => {
+    leaveWhenSettingsRouteCommitsRef.current = false
+    prepareSettingsSessionRef.current()
+    if (settingsOpen || settingsOpenNavigatePendingRef.current) {
+      if (
+        settingsDialogRef.current !== null &&
+        !settingsDialogRef.current.open
+      ) {
+        settingsDialogRef.current.showModal()
+      }
+      return
+    }
+    markRepositorySettingsOpenedFromInApp(repository.id)
+    const openGeneration = ++settingsOpenIntentGenerationRef.current
+    settingsOpenNavigatePendingRef.current = true
+    setOptimisticSettingsOpen(true)
+    // Open immediately so focus trap matches pre-route UX; the route effect
+    // remains the source of truth for direct/forward entry and Back close.
+    if (settingsDialogRef.current !== null && !settingsDialogRef.current.open) {
+      settingsDialogRef.current.showModal()
+    }
+    void navigate({
+      to: "/repos/$repositoryId/settings",
+      params: { repositoryId: repository.id },
+      search: (prev) => prev,
+      state: (prev) => {
+        const next = { ...prev }
+        Object.assign(next, {
+          repositorySettings: { kind: "in-app-origin" as const },
+        })
+        return next
+      },
+    }).finally(() => {
+      if (settingsOpenIntentGenerationRef.current === openGeneration) {
+        settingsOpenNavigatePendingRef.current = false
+      }
+    })
+  }
+
+  // Sync native <dialog> with the routed open flag (issue #842).
+  useEffect(() => {
+    const dialog = settingsDialogRef.current
+    if (dialog === null) {
+      return
+    }
+    if (settingsOpen) {
+      // Early dismiss or Save completed before navigate settled: leave without reopen.
+      if (leaveWhenSettingsRouteCommitsRef.current) {
+        leaveWhenSettingsRouteCommitsRef.current = false
+        setOptimisticSettingsOpen(false)
+        // Only set dismissingRouteRef when closing so it cannot stick true.
+        if (dialog.open) {
+          dismissingRouteRef.current = true
+          dialog.close()
+        }
+        leaveSettingsRouteRef.current({ ignoreBlocker: true })
+        return
+      }
+      setOptimisticSettingsOpen(false)
+      if (!dialog.open) {
+        // Entering via route (direct, Forward, or explicit navigate) needs a
+        // fresh session so abandoned drafts are not restored.
+        prepareSettingsSessionRef.current()
+        dialog.showModal()
+      }
+      return
+    }
+    setOptimisticSettingsOpen(false)
+    if (dialog.open) {
+      dismissingRouteRef.current = true
+      dialog.close()
+    }
+  }, [settingsOpen])
 
   const harnessDefaultBackendId =
     config.data?.selectedAgentBackend ?? "opencode"
@@ -1285,7 +1584,7 @@ function RepositoryCard({
   const harnessDefaultBackendFromConfig =
     config.data?.selectedAgentBackend ?? null
   useEffect(() => {
-    if (!settingsOpen || harnessDefaultBackendFromConfig === null) {
+    if (!dialogOpen || harnessDefaultBackendFromConfig === null) {
       return
     }
     const harnessDefault = harnessDefaultBackendFromConfig
@@ -1372,7 +1671,7 @@ function RepositoryCard({
         }
       }
     })()
-  }, [settingsOpen, harnessDefaultBackendFromConfig, selectedAgentBackend])
+  }, [dialogOpen, harnessDefaultBackendFromConfig, selectedAgentBackend])
 
   const inheritHarnessBuildModel = (): string => {
     if (harnessPrefsForDraft !== null) {
@@ -1505,7 +1804,7 @@ function RepositoryCard({
   // invalidate (issue #838). Treat a refresh as "no catalog yet" so no stale
   // model is offered and Save stays blocked until the current one arrives.
   const modelsLoading =
-    settingsOpen &&
+    dialogOpen &&
     (usesPreviewCatalog
       ? previewPending || config.isFetching
       : models.isFetching || config.isFetching || agentBackends.isFetching)
@@ -1953,7 +2252,15 @@ function RepositoryCard({
         onCancel={(event) => {
           if (updateSettings.isPending) event.preventDefault()
         }}
-        onClose={() => setSettingsOpen(false)}
+        onClose={() => {
+          // Escape (or other user dismiss) closes the native dialog first; keep
+          // URL + dialog synchronized, including during pending open navigate.
+          if (dismissingRouteRef.current) {
+            dismissingRouteRef.current = false
+            return
+          }
+          dismissSettings()
+        }}
       >
         <form onSubmit={saveSettings}>
           <div className={ui.dialogHeader}>
@@ -2424,10 +2731,7 @@ function RepositoryCard({
             <button
               type="button"
               className={ui.plateMini}
-              onClick={() => {
-                settingsDialogRef.current?.close()
-                setSettingsOpen(false)
-              }}
+              onClick={() => dismissSettings()}
               disabled={updateSettings.isPending}
             >
               Cancel

--- a/apps/harness/src/routes/repos.$repositoryId.settings.tsx
+++ b/apps/harness/src/routes/repos.$repositoryId.settings.tsx
@@ -1,0 +1,18 @@
+/**
+ * `/repos/<repository-id>/settings` — browser-addressable Repository settings
+ * overlay (issue #842).
+ *
+ * Nested under the Repos layout so the Repos background stays mounted. The
+ * dialog itself is owned by RepositoryCards / RepositoryCard, driven by the
+ * pathname; this route only registers the addressable location.
+ */
+import { createFileRoute } from "@tanstack/react-router"
+
+export const Route = createFileRoute("/repos/$repositoryId/settings")({
+  component: RepositorySettingsRoutePlaceholder,
+})
+
+function RepositorySettingsRoutePlaceholder() {
+  // Dialog visibility is synchronized from the URL in RepositoryCards.
+  return null
+}

--- a/apps/harness/src/routes/repos.tsx
+++ b/apps/harness/src/routes/repos.tsx
@@ -1,4 +1,4 @@
-import { createFileRoute } from "@tanstack/react-router"
+import { Outlet, createFileRoute } from "@tanstack/react-router"
 import { Suspense } from "react"
 import { RepositoryCards, RepositoryCardsSkeleton } from "./index.js"
 
@@ -6,13 +6,20 @@ export const Route = createFileRoute("/repos")({
   component: ReposPage,
 })
 
-function ReposPage() {
+/**
+ * Repos surface and layout parent for `/repos/$repositoryId/settings`
+ * (issue #842). The overlay dialog is route-driven inside RepositoryCards;
+ * child routes mount via Outlet so this page stays mounted across open/close.
+ */
+export function ReposPage() {
   // Reading-width cap lives on the page body only — root chrome stays full-width.
   return (
     <main className="mx-auto max-w-[88rem] pt-8 sm:pt-10">
       <Suspense fallback={<RepositoryCardsSkeleton />}>
         <RepositoryCards />
       </Suspense>
+      {/* Nested settings overlay route — dialog UI is path-driven above. */}
+      <Outlet />
     </main>
   )
 }

--- a/apps/harness/src/routes/repos.tsx
+++ b/apps/harness/src/routes/repos.tsx
@@ -11,7 +11,7 @@ export const Route = createFileRoute("/repos")({
  * (issue #842). The overlay dialog is route-driven inside RepositoryCards;
  * child routes mount via Outlet so this page stays mounted across open/close.
  */
-export function ReposPage() {
+function ReposPage() {
   // Reading-width cap lives on the page body only — root chrome stays full-width.
   return (
     <main className="mx-auto max-w-[88rem] pt-8 sm:pt-10">

--- a/apps/harness/test/repository-settings-agent-backend.test.ts
+++ b/apps/harness/test/repository-settings-agent-backend.test.ts
@@ -100,11 +100,21 @@ describe("Repository settings Agent Backend override", () => {
 
   test("Settings open refreshes indefinitely cached mode and catalog (issue #838)", () => {
     const source = indexSource()
+    // prepareSettingsSession runs on every open (explicit + routed enter).
+    const prepareStart = source.indexOf(
+      "prepareSettingsSessionRef.current = () => {",
+    )
+    expect(prepareStart).toBeGreaterThan(-1)
+    const prepare = source.slice(
+      prepareStart,
+      source.indexOf("const leaveSettingsRoute", prepareStart),
+    )
+    expect(prepare).toContain("void models.refetch()")
+    expect(prepare).toContain("void agentBackends.refetch()")
     const openSettings = source.slice(
       source.indexOf("const openSettings = () => {"),
       source.indexOf("const harnessDefaultBackendId"),
     )
-    expect(openSettings).toContain("void models.refetch()")
-    expect(openSettings).toContain("void agentBackends.refetch()")
+    expect(openSettings).toContain("prepareSettingsSessionRef.current()")
   })
 })

--- a/apps/harness/test/repository-settings-route.test.ts
+++ b/apps/harness/test/repository-settings-route.test.ts
@@ -27,7 +27,8 @@ describe("/repos/$repositoryId/settings route (issue #842)", () => {
     // Dialog is path-driven in RepositoryCards; route component is a placeholder.
     expect(source).toContain("return null")
     const repos = reposSource()
-    expect(repos).toContain("export function ReposPage")
+    expect(repos).toContain("function ReposPage")
+    expect(repos).toContain("component: ReposPage")
     expect(repos).toContain("<Outlet")
   })
 

--- a/apps/harness/test/repository-settings-route.test.ts
+++ b/apps/harness/test/repository-settings-route.test.ts
@@ -1,0 +1,123 @@
+import { readFileSync } from "node:fs"
+import { join } from "node:path"
+import { describe, expect, test } from "bun:test"
+
+const routeSource = () =>
+  readFileSync(
+    join(import.meta.dir, "../src/routes/repos.$repositoryId.settings.tsx"),
+    "utf8",
+  )
+
+const homeSource = () =>
+  readFileSync(join(import.meta.dir, "../src/routes/index.tsx"), "utf8")
+
+const reposSource = () =>
+  readFileSync(join(import.meta.dir, "../src/routes/repos.tsx"), "utf8")
+
+const routeTreeSource = () =>
+  readFileSync(join(import.meta.dir, "../src/routeTree.gen.ts"), "utf8")
+
+const jobsSwitcherSource = () =>
+  readFileSync(join(import.meta.dir, "../src/jobs-view-switcher.tsx"), "utf8")
+
+describe("/repos/$repositoryId/settings route (issue #842)", () => {
+  test("is a dedicated TanStack file route nested under the Repos layout", () => {
+    const source = routeSource()
+    expect(source).toContain('createFileRoute("/repos/$repositoryId/settings")')
+    // Dialog is path-driven in RepositoryCards; route component is a placeholder.
+    expect(source).toContain("return null")
+    const repos = reposSource()
+    expect(repos).toContain("export function ReposPage")
+    expect(repos).toContain("<Outlet")
+  })
+
+  test("is registered in the generated route tree under /repos", () => {
+    const source = routeTreeSource()
+    expect(source).toContain("from './routes/repos.$repositoryId.settings'")
+    expect(source).toContain("fullPath: '/repos/$repositoryId/settings'")
+    expect(source).toContain("path: '/$repositoryId/settings'")
+    expect(source).toContain("getParentRoute: () => ReposRoute")
+    expect(source).toContain(
+      "'/repos/$repositoryId/settings': typeof ReposRepositoryIdSettingsRoute",
+    )
+  })
+
+  test("explicit openers push /repos/<id>/settings with in-app origin state", () => {
+    const source = homeSource()
+    expect(source).toContain('to: "/repos/$repositoryId/settings"')
+    expect(source).toContain("params: { repositoryId: repository.id }")
+    expect(source).toContain('kind: "in-app-origin"')
+    expect(source).toContain("repositorySettings")
+    expect(source).toContain("search: (prev) => prev")
+    expect(source).toContain("markRepositorySettingsOpenedFromInApp")
+  })
+
+  test("dialog open is route-driven by stable Repository ID", () => {
+    const source = homeSource()
+    expect(source).toContain(
+      "isRepositorySettingsPathFor(pathname, repository.id)",
+    )
+    expect(source).toContain("parseRepositorySettingsRepositoryId")
+    // Must not use Project Path in the path.
+    expect(source).not.toMatch(
+      /to:\s*["'`]\/repos\/\$\{repository\.projectPath\}/,
+    )
+    expect(source).toContain("repository.projectPath")
+  })
+
+  test("dismiss leaves the route for in-app origin or replaces to Repos", () => {
+    const source = homeSource()
+    expect(source).toContain("leaveSettingsRoute")
+    expect(source).toContain("router.history.back")
+    expect(source).toContain("canGoBack()")
+    expect(source).toContain('to: "/repos"')
+    expect(source).toContain("replace: true")
+    expect(source).toContain("dismissSettings")
+    expect(source).toContain("wasRepositorySettingsOpenedFromInAppThisDocument")
+  })
+
+  test("optimistic open enables catalogs and dismiss cancels in-flight navigate", () => {
+    const source = homeSource()
+    // dialogOpen = routed || optimistic so catalog queries enable immediately.
+    expect(source).toContain("optimisticSettingsOpen")
+    expect(source).toContain(
+      "const dialogOpen = settingsOpen || optimisticSettingsOpen",
+    )
+    expect(source).toContain("enabled: dialogOpen")
+    // Cancel/Escape/Save while navigate is pending leaves when the route commits.
+    expect(source).toContain("leaveWhenSettingsRouteCommitsRef")
+    expect(source).toContain("settingsOpenIntentGenerationRef")
+    expect(source).toContain("leaveWhenSettingsRouteCommitsRef.current = true")
+    // dismissingRouteRef must only be set when actually closing the dialog
+    // (early leave and normal leave after Escape already closed the dialog).
+    expect(source).toContain(
+      "Only pair dismissingRouteRef with an actual close",
+    )
+    expect(source).toContain(
+      "Only set dismissingRouteRef when we actually close so the flag cannot stick",
+    )
+  })
+
+  test("blocks navigation while Save is pending", () => {
+    const source = homeSource()
+    expect(source).toContain("useBlocker")
+    expect(source).toContain("shouldBlockRepositorySettingsLeave")
+    expect(source).toContain("updateSettingsPendingRef")
+    expect(source).toContain(
+      "disabled: !updateSettings.isPending || !settingsOpen",
+    )
+  })
+
+  test("missing Repository renders an accessible in-dialog not-found state", () => {
+    const source = homeSource()
+    expect(source).toContain("RepositorySettingsNotFoundDialog")
+    expect(source).toContain("Repository not found")
+    expect(source).toContain('role="alert"')
+    expect(source).toContain("repositoryMissing")
+  })
+
+  test("Jobs switcher treats repository settings as Repos background", () => {
+    const switcher = jobsSwitcherSource()
+    expect(switcher).toContain('pathname.startsWith("/repos/")')
+  })
+})

--- a/apps/harness/test/routed-dialog.test.ts
+++ b/apps/harness/test/routed-dialog.test.ts
@@ -2,11 +2,18 @@ import {
   isHarnessSettingsPath,
   isOtherRoutedDialogPath,
   isPipelineBackgroundPath,
+  isReposBackgroundPath,
+  isRepositorySettingsPath,
+  isRepositorySettingsPathFor,
   isSessionTelemetryPath,
+  markRepositorySettingsOpenedFromInApp,
   markSessionTelemetryOpenedFromInApp,
+  parseRepositorySettingsRepositoryId,
   parseSessionTelemetryPath,
   readHarnessSettingsHistoryState,
+  readRepositorySettingsHistoryState,
   readSessionTelemetryHistoryState,
+  wasRepositorySettingsOpenedFromInAppThisDocument,
   wasSessionTelemetryOpenedFromInApp,
 } from "../src/routed-dialog.ts"
 import { describe, expect, test } from "bun:test"
@@ -84,5 +91,65 @@ describe("routed dialog path helpers (issues #840 / #841)", () => {
     // mark function is the public seam used by Pipeline openers.
     markSessionTelemetryOpenedFromInApp()
     expect(wasSessionTelemetryOpenedFromInApp()).toBe(true)
+  })
+})
+
+describe("Repository settings route helpers (issue #842)", () => {
+  test("parses the stable Repository ID from the settings path", () => {
+    expect(
+      parseRepositorySettingsRepositoryId("/repos/repo-01ABC/settings"),
+    ).toBe("repo-01ABC")
+    expect(
+      parseRepositorySettingsRepositoryId("/repos/repo-01ABC/settings/"),
+    ).toBe("repo-01ABC")
+    expect(parseRepositorySettingsRepositoryId("/repos")).toBeUndefined()
+    expect(
+      parseRepositorySettingsRepositoryId("/repos/repo-01ABC"),
+    ).toBeUndefined()
+    expect(parseRepositorySettingsRepositoryId("/settings")).toBeUndefined()
+    expect(parseRepositorySettingsRepositoryId("/repos/a%2Fb/settings")).toBe(
+      "a/b",
+    )
+  })
+
+  test("identifies Repository settings paths and per-id matches", () => {
+    expect(isRepositorySettingsPath("/repos/repo-1/settings")).toBe(true)
+    expect(isRepositorySettingsPath("/repos")).toBe(false)
+    expect(
+      isRepositorySettingsPathFor("/repos/repo-1/settings", "repo-1"),
+    ).toBe(true)
+    expect(
+      isRepositorySettingsPathFor("/repos/repo-1/settings", "repo-2"),
+    ).toBe(false)
+  })
+
+  test("Repos background includes /repos and repository settings overlays", () => {
+    expect(isReposBackgroundPath("/repos")).toBe(true)
+    expect(isReposBackgroundPath("/repos/")).toBe(true)
+    expect(isReposBackgroundPath("/repos/repo-1/settings")).toBe(true)
+    expect(isReposBackgroundPath("/")).toBe(false)
+    expect(isReposBackgroundPath("/settings")).toBe(false)
+  })
+
+  test("reads the Repository settings in-app origin history marker", () => {
+    expect(
+      readRepositorySettingsHistoryState({
+        repositorySettings: { kind: "in-app-origin" },
+      }),
+    ).toEqual({ kind: "in-app-origin" })
+    expect(readRepositorySettingsHistoryState({})).toBeUndefined()
+    expect(readRepositorySettingsHistoryState(null)).toBeUndefined()
+    expect(
+      readRepositorySettingsHistoryState({
+        repositorySettings: { kind: "other" },
+      }),
+    ).toBeUndefined()
+  })
+
+  test("tracks explicit in-app opens for the current document", () => {
+    const id = `repo-test-${Date.now()}`
+    expect(wasRepositorySettingsOpenedFromInAppThisDocument(id)).toBe(false)
+    markRepositorySettingsOpenedFromInApp(id)
+    expect(wasRepositorySettingsOpenedFromInAppThisDocument(id)).toBe(true)
   })
 })


### PR DESCRIPTION
## Why

Repository settings were local dialog state only, so operators could not use
Back/Forward, refresh, or bookmark a specific Repository’s settings. ADR 0048
and #840 established the routed-overlay pattern for Harness Settings; this
completes the same contract for per-Repository settings using the stable
Repository ID (not Project Path).

## What changed

- Nested route `/repos/$repositoryId/settings` under the Repos layout
  (`Outlet`) so Repos stays mounted while the overlay is open.
- Card **Settings** pushes history with an in-app origin marker; Cancel/Save/
  Escape leave via `history.back()` when appropriate, otherwise replace to
  `/repos`.
- Dialog title still shows Project Path; form fields, validation, and Save
  behavior are unchanged.
- Search params (e.g. `?theme=`) preserved on open/close.
- Back blocked while Save is pending (`useBlocker`).
- Direct load/refresh renders over Repos; missing ID shows an accessible
  in-dialog “Repository not found” state.
- Optimistic open enables catalog queries immediately; dismiss during
  in-flight open or Escape after close only pairs `dismissingRouteRef` with a
  real `dialog.close()` so URL and dialog stay in sync.
- Playwright-BDD coverage for open, Back/Forward, Save success/fail/pending,
  direct/refresh, and missing Repository.

## Verification

- Unit tests for route helpers, wiring, and agent-backend settings source
  contracts.
- Harness unit suite and biome on touched files.
- Live e2e for repository-settings browser history (11 scenarios) when
  Keymaxxer credentials are available.

## Notes

- Session Telemetry routing (`/session/.../telemetry`) is out of scope for
  this change.
- `isReposBackgroundPath` remains available for path helpers; Jobs switcher
  still treats `/repos/*` as Repos-active via existing path checks.

Closes #842