### PR TITLE
feat(harness): route Session Telemetry from Repos and Completed

### DIFF
--- a/apps/harness/e2e/features/session-telemetry-browser-history.feature
+++ b/apps/harness/e2e/features/session-telemetry-browser-history.feature
@@ -1,6 +1,6 @@
-Feature: Route Pipeline Session Telemetry through browser history
-  Opening Session Telemetry from Pipeline uses
-  `/session/<work-item-id>/telemetry` so Back closes the dialog, Forward
+Feature: Route Session Telemetry through browser history
+  Opening Session Telemetry from Pipeline, Repos, or Completed uses the same
+  `/session/<work-item-id>/telemetry` path so Back closes the dialog, Forward
   reopens it, and Close stays synchronized with the browser location.
 
   Background:
@@ -37,6 +37,64 @@ Feature: Route Pipeline Session Telemetry through browser history
     When I close the Session usage dialog
     Then the Session usage dialog is hidden
     And the browser location is the home path
+
+  Scenario: Repos open uses the same canonical telemetry route
+    When I open the Repos page
+    And I cancel the Harness settings dialog if present
+    And I open Session Telemetry for the missing-session fixture from Repos
+    Then the browser location is the Session Telemetry path for the missing-session fixture
+    And the Session usage dialog is visible
+    And the Session usage dialog shows the missing Session Telemetry state
+
+  Scenario: Browser Back and Forward from Repos restore origin and reopen
+    When I open the Repos page
+    And I cancel the Harness settings dialog if present
+    And I open Session Telemetry for the missing-session fixture from Repos
+    Then the browser location is the Session Telemetry path for the missing-session fixture
+    When I go back in the browser
+    Then the Session usage dialog is hidden
+    And the browser location is the repos path
+    When I go forward in the browser
+    Then the Session usage dialog is visible
+    And the browser location is the Session Telemetry path for the missing-session fixture
+
+  Scenario: Close returns to the originating Repos location
+    When I open the Repos page
+    And I cancel the Harness settings dialog if present
+    And I open Session Telemetry for the missing-session fixture from Repos
+    Then the browser location is the Session Telemetry path for the missing-session fixture
+    When I close the Session usage dialog
+    Then the Session usage dialog is hidden
+    And the browser location is the repos path
+
+  Scenario: Completed open uses the same canonical telemetry route
+    When I open the Completed page
+    And I cancel the Harness settings dialog if present
+    And I open Session Telemetry for the completed fixture from Completed
+    Then the browser location is the Session Telemetry path for the completed fixture
+    And the Session usage dialog is visible
+    And the Session usage dialog shows the missing Session Telemetry state
+
+  Scenario: Browser Back and Forward from Completed restore origin and reopen
+    When I open the Completed page
+    And I cancel the Harness settings dialog if present
+    And I open Session Telemetry for the completed fixture from Completed
+    Then the browser location is the Session Telemetry path for the completed fixture
+    When I go back in the browser
+    Then the Session usage dialog is hidden
+    And the browser location is the completed path
+    When I go forward in the browser
+    Then the Session usage dialog is visible
+    And the browser location is the Session Telemetry path for the completed fixture
+
+  Scenario: Close returns to the originating Completed location
+    When I open the Completed page
+    And I cancel the Harness settings dialog if present
+    And I open Session Telemetry for the completed fixture from Completed
+    Then the browser location is the Session Telemetry path for the completed fixture
+    When I close the Session usage dialog
+    Then the Session usage dialog is hidden
+    And the browser location is the completed path
 
   Scenario: Direct telemetry navigation shows the dialog over Pipeline
     When I open the missing-session Session Telemetry path directly

--- a/apps/harness/e2e/steps/session-telemetry-browser-history.ts
+++ b/apps/harness/e2e/steps/session-telemetry-browser-history.ts
@@ -1,5 +1,6 @@
 /**
- * Playwright-BDD steps for routed Session Telemetry history (issue #841).
+ * Playwright-BDD steps for routed Session Telemetry history
+ * (issues #841 / #843).
  *
  * Shared navigation steps (home open, Back/Forward, refresh, first-run cancel,
  * Pipeline tab assertions) live in kanban-route / settings-browser-history.
@@ -18,6 +19,19 @@ const telemetryPathFor = (workItemId: string): RegExp =>
   new RegExp(
     `/session/${workItemId.replaceAll(/[.*+?^${}()|[\]\\]/g, "\\$&")}/telemetry/?(?:\\?.*)?$`,
   )
+
+const completedPathPattern = /\/completed\/?(?:\?.*)?$/
+
+const openSessionButton = async (page: Page, sessionId: string) => {
+  const sessionButton = page.getByRole("button", {
+    name: sessionId,
+    exact: true,
+  })
+  await expect(sessionButton).toBeVisible({ timeout: 30_000 })
+  await sessionButton.click()
+  const dialog = sessionUsageDialog(page)
+  await expect(dialog).toBeVisible({ timeout: 15_000 })
+}
 
 type SessionQueryIntercept = {
   mode: "pass" | "fail" | "available"
@@ -121,14 +135,28 @@ When(
   "I open Session Telemetry for the missing-session fixture from Pipeline",
   async ({ page }) => {
     await installSessionQueryRoute(page)
-    const sessionButton = page.getByRole("button", {
-      name: TELEMETRY_FIXTURE.missingSessionId,
-      exact: true,
-    })
-    await expect(sessionButton).toBeVisible({ timeout: 30_000 })
-    await sessionButton.click()
-    const dialog = sessionUsageDialog(page)
-    await expect(dialog).toBeVisible({ timeout: 15_000 })
+    await openSessionButton(page, TELEMETRY_FIXTURE.missingSessionId)
+  },
+)
+
+When(
+  "I open Session Telemetry for the missing-session fixture from Repos",
+  async ({ page }) => {
+    await installSessionQueryRoute(page)
+    await openSessionButton(page, TELEMETRY_FIXTURE.missingSessionId)
+  },
+)
+
+When("I open the Completed page", async ({ page }) => {
+  await page.goto("/completed")
+  await expect(page).toHaveURL(completedPathPattern)
+})
+
+When(
+  "I open Session Telemetry for the completed fixture from Completed",
+  async ({ page }) => {
+    await installSessionQueryRoute(page)
+    await openSessionButton(page, TELEMETRY_FIXTURE.completedSessionId)
   },
 )
 
@@ -199,6 +227,15 @@ Then(
 )
 
 Then(
+  "the browser location is the Session Telemetry path for the completed fixture",
+  async ({ page }) => {
+    await expect(page).toHaveURL(
+      telemetryPathFor(TELEMETRY_FIXTURE.completedWorkItemId),
+    )
+  },
+)
+
+Then(
   "the browser location is the Session Telemetry path for the missing-session fixture with theme dark",
   async ({ page }) => {
     await expect(page).toHaveURL(
@@ -208,6 +245,10 @@ Then(
     )
   },
 )
+
+Then("the browser location is the completed path", async ({ page }) => {
+  await expect(page).toHaveURL(completedPathPattern)
+})
 
 Then("the Session usage dialog is visible", async ({ page }) => {
   await expect(sessionUsageDialog(page)).toBeVisible()

--- a/apps/harness/e2e/support/first-run-settings.ts
+++ b/apps/harness/e2e/support/first-run-settings.ts
@@ -11,6 +11,13 @@ const pageLandmark = (page: Page) =>
     .getByRole("heading", { name: "No repositories configured" })
     .or(page.getByRole("region", { name: "Lifecycle pipeline" }))
     .or(page.getByRole("region", { name: "Configured repositories" }))
+    // Completed archive body (issue #843 Session Telemetry origin).
+    .or(page.getByRole("list", { name: "All completed work items" }))
+    .or(
+      page.getByRole("status").filter({
+        hasText: /No completed work items|Loading completed work items/i,
+      }),
+    )
 
 const graphqlJson = async <T>(
   query: string,

--- a/apps/harness/e2e/support/session-telemetry-fixture.ts
+++ b/apps/harness/e2e/support/session-telemetry-fixture.ts
@@ -26,9 +26,22 @@ export const TELEMETRY_FIXTURE = {
   /** OpenCode Work Item with a non-local Session id → MISSING telemetry. */
   missingSessionWorkItemId: "wi-01KZD5SESS10NTE0FXX0000001",
   missingSessionId: "ses_e2e_fixture_missing",
+  missingSessionIssueNumber: 101,
+  missingSessionIssueId: "issue-01KZD5SESS10NTE0FXX0000001",
   /** Claude Work Item → UNSUPPORTED Session Telemetry. */
   unsupportedWorkItemId: "wi-01KZD5SESS10NTE0FXX0000002",
   unsupportedSessionId: "ses_e2e_fixture_unsupported",
+  unsupportedIssueNumber: 102,
+  unsupportedIssueId: "issue-01KZD5SESS10NTE0FXX0000002",
+  /**
+   * Complete Work Item for the Completed archive surface (issue #843).
+   * Distinct Session id so openers are unambiguous when both surfaces list
+   * session buttons.
+   */
+  completedWorkItemId: "wi-01KZD5SESS10NTE0FXX0000003",
+  completedSessionId: "ses_e2e_fixture_completed",
+  completedIssueNumber: 103,
+  completedIssueId: "issue-01KZD5SESS10NTE0FXX0000003",
 } as const
 
 const sqlLiteral = (value: string) => `'${value.replaceAll("'", "''")}'`
@@ -60,8 +73,9 @@ const seedAndRestart = async (sql: string) => {
 }
 
 /**
- * Seed a paused Repository and Work Items that appear on Pipeline with
- * clickable Session IDs. Paused unfinished Work Items do not enqueue Step Runs.
+ * Seed a paused Repository, projected Issues, and Work Items so Session
+ * Telemetry openers are clickable on Pipeline, Repos, and Completed.
+ * Paused unfinished Work Items do not enqueue Step Runs.
  *
  * Does not write `config.default_model`: a non-catalog seed would leave Save
  * blocked for later settings-history scenarios in the same live Harness
@@ -74,10 +88,13 @@ export const seedSessionTelemetryFixtures = async (): Promise<void> => {
   const sql = [
     // Clear prior fixture rows so scenarios can re-seed safely.
     `DELETE FROM work_item WHERE repository_id = ${sqlLiteral(TELEMETRY_FIXTURE.repositoryId)};`,
+    `DELETE FROM issue WHERE repository_id = ${sqlLiteral(TELEMETRY_FIXTURE.repositoryId)};`,
     `DELETE FROM repository WHERE id = ${sqlLiteral(TELEMETRY_FIXTURE.repositoryId)};`,
+    // issues_reconciled_at must be set so Repos renders the projected issues
+    // list (and Session openers) without requiring a live Forge refresh.
     `INSERT INTO repository (
        id, forge, forge_host, project_path, local_path, is_bare, paused,
-       created_at, updated_at
+       issues_reconciled_at, created_at, updated_at
      ) VALUES (
        ${sqlLiteral(TELEMETRY_FIXTURE.repositoryId)},
        'github',
@@ -86,6 +103,56 @@ export const seedSessionTelemetryFixtures = async (): Promise<void> => {
        ${sqlLiteral(`/tmp/${TELEMETRY_FIXTURE.repositoryId}`)},
        0,
        1,
+       ${now},
+       ${now},
+       ${now}
+     );`,
+    // Projected issues so Repos lists lifecycle chrome (and Completed titles).
+    `INSERT INTO issue (
+       id, repository_id, issue_number, title, body, url, state,
+       github_created_at, has_children, created_at, updated_at
+     ) VALUES (
+       ${sqlLiteral(TELEMETRY_FIXTURE.missingSessionIssueId)},
+       ${sqlLiteral(TELEMETRY_FIXTURE.repositoryId)},
+       ${TELEMETRY_FIXTURE.missingSessionIssueNumber},
+       'E2E Session Telemetry missing',
+       '',
+       ${sqlLiteral(`https://github.com/${TELEMETRY_FIXTURE.projectPath}/issues/${TELEMETRY_FIXTURE.missingSessionIssueNumber}`)},
+       'OPEN',
+       ${now},
+       0,
+       ${now},
+       ${now}
+     );`,
+    `INSERT INTO issue (
+       id, repository_id, issue_number, title, body, url, state,
+       github_created_at, has_children, created_at, updated_at
+     ) VALUES (
+       ${sqlLiteral(TELEMETRY_FIXTURE.unsupportedIssueId)},
+       ${sqlLiteral(TELEMETRY_FIXTURE.repositoryId)},
+       ${TELEMETRY_FIXTURE.unsupportedIssueNumber},
+       'E2E Session Telemetry unsupported',
+       '',
+       ${sqlLiteral(`https://github.com/${TELEMETRY_FIXTURE.projectPath}/issues/${TELEMETRY_FIXTURE.unsupportedIssueNumber}`)},
+       'OPEN',
+       ${now},
+       0,
+       ${now},
+       ${now}
+     );`,
+    `INSERT INTO issue (
+       id, repository_id, issue_number, title, body, url, state,
+       github_created_at, has_children, created_at, updated_at
+     ) VALUES (
+       ${sqlLiteral(TELEMETRY_FIXTURE.completedIssueId)},
+       ${sqlLiteral(TELEMETRY_FIXTURE.repositoryId)},
+       ${TELEMETRY_FIXTURE.completedIssueNumber},
+       'E2E Session Telemetry completed',
+       '',
+       ${sqlLiteral(`https://github.com/${TELEMETRY_FIXTURE.projectPath}/issues/${TELEMETRY_FIXTURE.completedIssueNumber}`)},
+       'CLOSED',
+       ${now},
+       0,
        ${now},
        ${now}
      );`,
@@ -96,7 +163,7 @@ export const seedSessionTelemetryFixtures = async (): Promise<void> => {
      ) VALUES (
        ${sqlLiteral(TELEMETRY_FIXTURE.missingSessionWorkItemId)},
        ${sqlLiteral(TELEMETRY_FIXTURE.repositoryId)},
-       101,
+       ${TELEMETRY_FIXTURE.missingSessionIssueNumber},
        'E2E Session Telemetry missing',
        'opencode',
        'implement',
@@ -114,7 +181,7 @@ export const seedSessionTelemetryFixtures = async (): Promise<void> => {
      ) VALUES (
        ${sqlLiteral(TELEMETRY_FIXTURE.unsupportedWorkItemId)},
        ${sqlLiteral(TELEMETRY_FIXTURE.repositoryId)},
-       102,
+       ${TELEMETRY_FIXTURE.unsupportedIssueNumber},
        'E2E Session Telemetry unsupported',
        'claude',
        'implement',
@@ -122,6 +189,24 @@ export const seedSessionTelemetryFixtures = async (): Promise<void> => {
        1,
        0,
        ${sqlLiteral(TELEMETRY_FIXTURE.unsupportedSessionId)},
+       ${now},
+       ${now}
+     );`,
+    `INSERT INTO work_item (
+       id, repository_id, issue_number, issue_title, agent_backend,
+       state, state_ready_at, paused, holds_worker_slot, session_id,
+       created_at, updated_at
+     ) VALUES (
+       ${sqlLiteral(TELEMETRY_FIXTURE.completedWorkItemId)},
+       ${sqlLiteral(TELEMETRY_FIXTURE.repositoryId)},
+       ${TELEMETRY_FIXTURE.completedIssueNumber},
+       'E2E Session Telemetry completed',
+       'opencode',
+       'complete',
+       ${now},
+       0,
+       0,
+       ${sqlLiteral(TELEMETRY_FIXTURE.completedSessionId)},
        ${now},
        ${now}
      );`,

--- a/apps/harness/src/completed-surface.tsx
+++ b/apps/harness/src/completed-surface.tsx
@@ -4,10 +4,11 @@
  * Primary Jobs switcher (Pipeline | Repos | Completed) lives in sticky root
  * chrome — this surface only keeps the card body.
  */
-import { type ReactNode, useState } from "react"
+import { useNavigate } from "@tanstack/react-router"
+import type { ReactNode } from "react"
 import { CompletedWorkItemRow } from "./completed-work-item-row.js"
 import type { Repository, WorkItem } from "./routes/index.js"
-import { SessionUsageDialog } from "./session-usage-dialog.js"
+import { openSessionTelemetry } from "./session-telemetry-nav.js"
 import { ui } from "./ui.js"
 
 export type CompletedIssueLookup = {
@@ -51,10 +52,15 @@ export function CompletedCardGrid({
   readonly emptyMessage: string
   readonly ariaLabel: string
 }) {
-  const [sessionDialog, setSessionDialog] = useState<{
-    readonly workItemId: string
-    readonly sessionId: string
-  } | null>(null)
+  // Session Telemetry is route-owned at root (`/session/<work-item-id>/telemetry`).
+  const navigate = useNavigate()
+  const onOpenSession = (workItemId: string, sessionId: string) => {
+    void openSessionTelemetry({
+      navigate,
+      workItemId,
+      sessionId,
+    })
+  }
 
   if (items.length === 0) {
     return (
@@ -65,30 +71,18 @@ export function CompletedCardGrid({
   }
 
   return (
-    <>
-      <ul className={ui.completedCardGrid} aria-label={ariaLabel}>
-        {items.map((workItem) => (
-          <CompletedWorkItemRow
-            key={workItem.id}
-            workItem={workItem}
-            repository={repositoryById.get(workItem.repositoryId)}
-            issue={issueByRepoAndNumber.get(
-              repositoryIssueKey(workItem.repositoryId, workItem.issueNumber),
-            )}
-            onOpenSession={(workItemId, sessionId) => {
-              setSessionDialog({ workItemId, sessionId })
-            }}
-          />
-        ))}
-      </ul>
-      <SessionUsageDialog
-        workItemId={sessionDialog?.workItemId ?? null}
-        sessionId={sessionDialog?.sessionId ?? null}
-        open={sessionDialog !== null}
-        onClose={() => {
-          setSessionDialog(null)
-        }}
-      />
-    </>
+    <ul className={ui.completedCardGrid} aria-label={ariaLabel}>
+      {items.map((workItem) => (
+        <CompletedWorkItemRow
+          key={workItem.id}
+          workItem={workItem}
+          repository={repositoryById.get(workItem.repositoryId)}
+          issue={issueByRepoAndNumber.get(
+            repositoryIssueKey(workItem.repositoryId, workItem.issueNumber),
+          )}
+          onOpenSession={onOpenSession}
+        />
+      ))}
+    </ul>
   )
 }

--- a/apps/harness/src/jobs-view-switcher.tsx
+++ b/apps/harness/src/jobs-view-switcher.tsx
@@ -63,7 +63,8 @@ export function JobsViewSwitcher() {
   const onCompleted =
     pathname === "/completed" || pathname.startsWith("/completed/")
   // `/settings` and Session Telemetry use Pipeline as canonical background
-  // (issues #840 / #841).
+  // (issues #840 / #841 / #843). Explicit opens from Repos or Completed share
+  // that background while the overlay is open; Close/Back restore the origin.
   const pipelineActive = isPipelineBackgroundPath(pathname)
   const reposActive = pathname === "/repos" || pathname.startsWith("/repos/")
   // Filters only drive the Pipeline board today (full in-memory item set).

--- a/apps/harness/src/routes/__root.tsx
+++ b/apps/harness/src/routes/__root.tsx
@@ -272,8 +272,9 @@ function RootComponent() {
   return (
     <div className="min-h-screen w-full">
       <SettingsChrome />
-      {/* Route-driven Session Telemetry overlay (issue #841); dialog is one root
-          instance so Pipeline open, Back/Forward, and direct loads share state. */}
+      {/* Route-driven Session Telemetry overlay (issues #841 / #843); one root
+          instance so Pipeline/Repos/Completed open, Back/Forward, and direct
+          loads share ownership. */}
       <SessionTelemetryOverlay />
       <ReactQueryDevtools buttonPosition="bottom-left" />
       <TanStackRouterDevtools position="bottom-right" />
@@ -282,9 +283,9 @@ function RootComponent() {
 }
 
 /**
- * Session Telemetry at `/session/<work-item-id>/telemetry` (ADR 0048 / #841).
- * Explicit Pipeline opens push history; Close/Escape/Back leave the route;
- * direct entry closes with replace → `/`.
+ * Session Telemetry at `/session/<work-item-id>/telemetry` (ADR 0048 / #841 / #843).
+ * Explicit opens from Pipeline, Repos, or Completed push history; Close/Escape/
+ * Back leave the route; direct entry closes with replace → `/`.
  */
 function SessionTelemetryOverlay() {
   const navigate = useNavigate()

--- a/apps/harness/src/routes/index.tsx
+++ b/apps/harness/src/routes/index.tsx
@@ -92,7 +92,7 @@ import {
   readRepositorySettingsHistoryState,
   wasRepositorySettingsOpenedFromInAppThisDocument,
 } from "../routed-dialog.js"
-import { SessionUsageDialog } from "../session-usage-dialog.js"
+import { openSessionTelemetry } from "../session-telemetry-nav.js"
 import { sessionWorktreeParts } from "../session-worktree-line.js"
 import { cx, ui } from "../ui.js"
 import { workItemIssueUrl } from "../work-item-issue-url.js"
@@ -3058,15 +3058,14 @@ function RepositoryIssues({
   workItemsLoading: boolean
 }) {
   const { data: issues } = useSuspenseQuery(issuesQuery(repository.id))
-  // One Session usage dialog for the whole list (not per issue row). Title ids
-  // are per-instance (useId) so coexistence with the root route-driven dialog
-  // remains valid until #843 unifies ownership.
-  const [sessionDialog, setSessionDialog] = useState<{
-    workItemId: string
-    sessionId: string
-  } | null>(null)
+  // Session Telemetry is route-owned at root (`/session/<work-item-id>/telemetry`).
+  const navigate = useNavigate()
   const onOpenSession = (workItemId: string, sessionId: string) => {
-    setSessionDialog({ workItemId, sessionId })
+    void openSessionTelemetry({
+      navigate,
+      workItemId,
+      sessionId,
+    })
   }
 
   if (issues.length === 0) {
@@ -3086,48 +3085,40 @@ function RepositoryIssues({
   }
 
   return (
-    <>
-      <ul className={ui.repoIssuesList}>
-        {issues.map((issue) => {
-          if (issue.parent !== null) return null
-          if (!issue.hasChildren) {
-            return (
-              <RepositoryIssueRow
-                issue={issue}
-                key={issue.id}
-                repository={repository}
-                workItems={workItems}
-                workItemsLoading={workItemsLoading}
-                onOpenSession={onOpenSession}
-              />
-            )
-          }
-
-          const children = childrenByParent.get(issue.issueNumber) ?? []
-          const closedChildren = children.filter(
-            (child) => child.state === "CLOSED",
-          ).length
+    <ul className={ui.repoIssuesList}>
+      {issues.map((issue) => {
+        if (issue.parent !== null) return null
+        if (!issue.hasChildren) {
           return (
-            <ParentIssueGroup
+            <RepositoryIssueRow
+              issue={issue}
               key={issue.id}
-              parent={issue}
-              childIssues={children}
-              closedChildren={closedChildren}
               repository={repository}
               workItems={workItems}
               workItemsLoading={workItemsLoading}
               onOpenSession={onOpenSession}
             />
           )
-        })}
-      </ul>
-      <SessionUsageDialog
-        workItemId={sessionDialog?.workItemId ?? null}
-        sessionId={sessionDialog?.sessionId ?? null}
-        open={sessionDialog !== null}
-        onClose={() => setSessionDialog(null)}
-      />
-    </>
+        }
+
+        const children = childrenByParent.get(issue.issueNumber) ?? []
+        const closedChildren = children.filter(
+          (child) => child.state === "CLOSED",
+        ).length
+        return (
+          <ParentIssueGroup
+            key={issue.id}
+            parent={issue}
+            childIssues={children}
+            closedChildren={closedChildren}
+            repository={repository}
+            workItems={workItems}
+            workItemsLoading={workItemsLoading}
+            onOpenSession={onOpenSession}
+          />
+        )
+      })}
+    </ul>
   )
 }
 

--- a/apps/harness/src/routes/session.$workItemId.telemetry.tsx
+++ b/apps/harness/src/routes/session.$workItemId.telemetry.tsx
@@ -1,10 +1,11 @@
 /**
  * `/session/<work-item-id>/telemetry` — browser-addressable Session Telemetry
- * overlay (issue #841 / ADR 0048).
+ * overlay (issues #841 / #843 / ADR 0048).
  *
  * The dialog lives in root chrome; this route supplies the canonical Pipeline
- * background for direct navigation and refresh. Explicit opens from Pipeline
- * also land here so the URL and history entry stay consistent.
+ * background for direct navigation and refresh. Explicit opens from Pipeline,
+ * Repos, and Completed also land here so the URL and history entry stay
+ * consistent; Close uses history.back when the open was in-app.
  */
 import { createFileRoute } from "@tanstack/react-router"
 import { PipelinePage } from "./index.js"

--- a/apps/harness/src/session-telemetry-nav.ts
+++ b/apps/harness/src/session-telemetry-nav.ts
@@ -1,5 +1,6 @@
 /**
- * Navigate to the browser-addressable Session Telemetry overlay (issue #841).
+ * Navigate to the browser-addressable Session Telemetry overlay
+ * (issues #841 / #843). Shared by Pipeline, Repos, and Completed.
  *
  * Route key is the owning Work Item ID (ADR 0048). Optional sessionId is only a
  * history-state display hint until the session query resolves.

--- a/apps/harness/src/session-usage-dialog.tsx
+++ b/apps/harness/src/session-usage-dialog.tsx
@@ -1,8 +1,9 @@
 /**
  * Session usage modal (Session Telemetry presentation).
  *
- * Open ownership may be local (Repos/Completed) or route-driven from root
- * (`/session/<work-item-id>/telemetry`, issue #841). Presentation is shared.
+ * Open ownership is route-driven from root
+ * (`/session/<work-item-id>/telemetry`, issues #841 / #843). Pipeline, Repos,
+ * and Completed open the same path; this component only presents state.
  */
 import { useQuery } from "@tanstack/react-query"
 import { useEffect, useId, useRef } from "react"
@@ -79,8 +80,8 @@ export function SessionUsageDialog({
   onClose: () => void
 }) {
   const dialogRef = useRef<HTMLDialogElement>(null)
-  // Per-instance title id: root mounts a route-driven dialog while Repos/
-  // Completed still mount local ones until #843 — a fixed id would collide.
+  // useId keeps the accessible title stable if more than one mount ever
+  // coexists (tests, transitions). Root is the sole production owner.
   const titleId = `session-usage-title-${useId().replaceAll(":", "")}`
   const enabled = open && workItemId !== null
   const session = useQuery({

--- a/apps/harness/test/repos-interchange.test.ts
+++ b/apps/harness/test/repos-interchange.test.ts
@@ -174,7 +174,7 @@ describe("Interchange phase 4: repos page + blank slate", () => {
     expect(row).toContain("onOpenSession=")
     expect(row).toContain("collapseEarlierLanes")
     expect(row).toContain("forge={repository.forge}")
-    // One SessionUsageDialog at RepositoryIssues — not per issue row.
+    // Session Telemetry is root-route owned (#843) — no local dialog here.
     expect(row).not.toContain("<SessionUsageDialog")
 
     const issuesList = sliceBetweenMarkers(
@@ -182,8 +182,10 @@ describe("Interchange phase 4: repos page + blank slate", () => {
       "function RepositoryIssues(",
       "function ParentIssueGroup(",
     )
-    expect(issuesList).toContain("<SessionUsageDialog")
+    expect(issuesList).toContain("openSessionTelemetry")
     expect(issuesList).toContain("onOpenSession={onOpenSession}")
+    expect(issuesList).not.toContain("<SessionUsageDialog")
+    expect(issuesList).not.toContain("setSessionDialog")
 
     const ui = uiSource()
     expect(ui).toContain("lifecycleInset:")

--- a/apps/harness/test/session-telemetry-route.test.ts
+++ b/apps/harness/test/session-telemetry-route.test.ts
@@ -14,6 +14,12 @@ const rootSource = () =>
 const kanbanSource = () =>
   readFileSync(join(import.meta.dir, "../src/kanban-board.tsx"), "utf8")
 
+const indexSource = () =>
+  readFileSync(join(import.meta.dir, "../src/routes/index.tsx"), "utf8")
+
+const completedSurfaceSource = () =>
+  readFileSync(join(import.meta.dir, "../src/completed-surface.tsx"), "utf8")
+
 const navSource = () =>
   readFileSync(join(import.meta.dir, "../src/session-telemetry-nav.ts"), "utf8")
 
@@ -29,7 +35,7 @@ const jobsSwitcherSource = () =>
 const routedDialogSource = () =>
   readFileSync(join(import.meta.dir, "../src/routed-dialog.ts"), "utf8")
 
-describe("Session Telemetry route (issue #841)", () => {
+describe("Session Telemetry route (issues #841 / #843)", () => {
   test("is a dedicated TanStack file route over the Pipeline background", () => {
     const source = telemetryRouteSource()
     expect(source).toContain(
@@ -49,11 +55,22 @@ describe("Session Telemetry route (issue #841)", () => {
     )
   })
 
-  test("Pipeline openers push Work Item ID telemetry route with in-app origin", () => {
+  test("Pipeline, Repos, and Completed openers push the same telemetry route", () => {
     const kanban = kanbanSource()
     expect(kanban).toContain("openSessionTelemetry")
     expect(kanban).not.toContain("setSessionDialog")
     expect(kanban).not.toContain("<SessionUsageDialog")
+
+    const index = indexSource()
+    expect(index).toContain("openSessionTelemetry")
+    expect(index).not.toContain("setSessionDialog")
+    expect(index).not.toContain("<SessionUsageDialog")
+
+    const completed = completedSurfaceSource()
+    expect(completed).toContain("openSessionTelemetry")
+    expect(completed).not.toContain("setSessionDialog")
+    expect(completed).not.toContain("<SessionUsageDialog")
+    expect(completed).not.toContain('from "./session-usage-dialog.js"')
 
     const nav = navSource()
     expect(nav).toContain('to: "/session/$workItemId/telemetry"')


### PR DESCRIPTION
## Why

Session Telemetry from Repos and Completed still used local dialog state after
Pipeline was moved to `/session/<work-item-id>/telemetry` (#841). Operators could
not use Back/Forward, bookmark the overlay, or share a single addressable
capability across Jobs surfaces. ADR 0048 requires one route-owned model for
Pipeline, Repos, and Completed.

## What changed

- Repos and Completed open Session Telemetry through shared
  `openSessionTelemetry` (Work Item ID route key, in-app origin marker,
  preserved search params).
- Remove surface-owned `SessionUsageDialog` mounts; root keeps sole
  route-driven ownership so Close/Back restore Repos or Completed rather than
  the direct-link Pipeline fallback.
- E2E fixtures seed projected issues and a completed Work Item; scenarios
  cover open, Back/Forward, and immediate Close from Repos and Completed, plus
  the existing Pipeline and direct-navigation cases.
- Review follow-up: Jobs switcher comment cites #843; Repos/Completed e2e
  mirror Pipeline's open / history / Close split.

## Verification

- `harness:typecheck`, `harness:lint`, `harness:test`
- Playwright-BDD Session Telemetry browser-history feature (Pipeline, Repos,
  Completed, direct load, refresh, not-found, optional telemetry outcomes)

## Notes

- Canonical background for the telemetry route remains Pipeline (same as
  Settings); origin restore relies on history.back for in-app opens.

Closes #843