### PR TITLE
fix(harness): streamline empty repository issue cards

### DIFF
--- a/apps/harness/src/routes/index.tsx
+++ b/apps/harness/src/routes/index.tsx
@@ -1998,6 +1998,12 @@ function RepositoryCard({
   }, [awaitingRefresh, issuesChangeCount])
 
   const refreshingIssues = refreshIssues.isPending || awaitingRefresh
+  const { data: relevantIssues } = useQuery({
+    ...issuesQuery(repository.id),
+    enabled: repository.issuesReconciledAt !== null,
+  })
+  const hasNoRelevantIssues =
+    repository.issuesReconciledAt !== null && relevantIssues?.length === 0
 
   const addGitHubToken = useMutation({
     mutationFn: async () => {
@@ -2974,7 +2980,9 @@ function RepositoryCard({
             )}
           <div className={ui.repoIssues}>
             <div className={ui.repoIssuesHead}>
-              <h3 className={ui.repoIssuesKicker}>Relevant issues</h3>
+              {!hasNoRelevantIssues ? (
+                <h3 className={ui.repoIssuesKicker}>Relevant issues</h3>
+              ) : null}
               <button
                 type="button"
                 className={ui.iconBtn}
@@ -3021,7 +3029,7 @@ function RepositoryCard({
               </Banner>
             )}
             {repository.issuesReconciledAt === null ? (
-              <p className={ui.repoIssuesEmpty}>Not refreshed yet.</p>
+              <p className={ui.repoIssuesUnrefreshed}>Not refreshed yet.</p>
             ) : (
               <Suspense fallback={<RepositoryIssuesSkeleton />}>
                 <RepositoryIssues

--- a/apps/harness/src/ui.ts
+++ b/apps/harness/src/ui.ts
@@ -1149,6 +1149,9 @@ export const ui = {
   repoIssuesList: "m-0 grid list-none gap-0 p-0",
 
   repoIssuesEmpty:
+    "m-0 font-mono text-[0.68rem] tracking-[0.08em] text-ink-faint",
+
+  repoIssuesUnrefreshed:
     "m-0 font-mono text-[0.68rem] tracking-[0.08em] uppercase text-ink-faint",
 
   repoIssue:

--- a/apps/harness/test/repos-interchange.test.ts
+++ b/apps/harness/test/repos-interchange.test.ts
@@ -129,6 +129,41 @@ describe("Interchange phase 4: repos page + blank slate", () => {
     expect(ui).toMatch(/stampBlocked:[\s\S]*?bg-lane-queue/)
   })
 
+  test("zero relevant issues omit the kicker but retain refresh chrome", () => {
+    const card = sliceBetweenMarkers(
+      homeSource(),
+      "function RepositoryCard(",
+      "function RepositoryIssues(",
+    )
+    expect(card).toContain("const hasNoRelevantIssues =")
+    expect(card).toContain("relevantIssues?.length === 0")
+    expect(card).toContain("{!hasNoRelevantIssues ? (")
+    expect(card).toContain(
+      "<h3 className={ui.repoIssuesKicker}>Relevant issues</h3>",
+    )
+    expect(card).toContain(
+      'aria-label={\n                  refreshingIssues ? "Refreshing issues" : "Refresh issues"',
+    )
+    expect(card).toContain("ui.repoIssuesUnrefreshed")
+
+    const issues = sliceBetweenMarkers(
+      homeSource(),
+      "function RepositoryIssues(",
+      "function ParentIssueGroup(",
+    )
+    expect(issues).toContain("No issues found this harness can work on.")
+    expect(issues).toContain("ui.repoIssuesEmpty")
+
+    const ui = uiSource()
+    const emptyStyle = sliceBetweenMarkers(
+      ui,
+      "repoIssuesEmpty:",
+      "repoIssuesUnrefreshed:",
+    )
+    expect(emptyStyle).not.toContain("uppercase")
+    expect(ui).toMatch(/repoIssuesUnrefreshed:[\s\S]*?uppercase/)
+  })
+
   test("latest work item lifecycle chrome sits in 1.5px inset panel", () => {
     const lifecycle = sliceBetweenMarkers(
       homeSource(),


### PR DESCRIPTION
Repository cards with no reconciled relevant issues showed two layers of empty-state copy: the
section kicker and an all-caps message. This made the empty state read like duplicate chrome.

The card now hides the kicker only after a successful reconcile returns zero issues, while
preserving the existing refresh button and its enabled/disabled behavior. The empty message is
sentence case, and the separate “Not refreshed yet.” state retains its original header and styling.

Added a regression test for the zero-issues, refresh-control, unrefreshed, and typography behavior.

Verified with `bunx nx test harness`, `bunx nx build harness`, and the repository pre-commit hook.

Closes #855