### PR TITLE
fix(harness): align running lifecycle focus chips

### DIFF
--- a/apps/harness/src/routes/index.tsx
+++ b/apps/harness/src/routes/index.tsx
@@ -3773,7 +3773,13 @@ export function WorkItemLifecycleStatus({
       return next
     })
   }
-  const renderLifecycleChip = (lifecycleLabel: LifecycleLabelChip) => {
+  const renderLifecycleChip = ({
+    lifecycleLabel,
+    isFocusLane = false,
+  }: {
+    readonly lifecycleLabel: LifecycleLabelChip
+    readonly isFocusLane?: boolean
+  }) => {
     const displayDurationMs = liveDurationMs(
       lifecycleLabel.durationMs,
       isLiveDurationStatus(lifecycleLabel.status),
@@ -3786,8 +3792,11 @@ export function WorkItemLifecycleStatus({
       openPullRequestLabel !== null &&
       lifecycleLabel.phase === "DECIDE_PR_MERGE" &&
       lifecycleLabel.status === "NEEDS_HUMAN"
-    const chipClassName = lifecycleStepChipClassNameForStatus(
-      lifecycleLabel.status,
+    const chipClassName = cx(
+      lifecycleStepChipClassNameForStatus(lifecycleLabel.status),
+      isFocusLane && lifecycleLabel.status === "RUNNING"
+        ? ui.lifecycleFocusRunningChip
+        : null,
     )
     // Only RUNNING chips take current-lane fill; needs-human/fail use Attention.
     const chipLane =
@@ -3838,6 +3847,7 @@ export function WorkItemLifecycleStatus({
       readonly id?: string
       readonly className?: string
       readonly ariaLabel?: string
+      readonly isFocusLane?: boolean
     },
   ) => (
     <ol
@@ -3848,7 +3858,12 @@ export function WorkItemLifecycleStatus({
       }
       aria-label={options?.ariaLabel ?? "Lifecycle steps"}
     >
-      {chips.map(renderLifecycleChip)}
+      {chips.map((lifecycleLabel) =>
+        renderLifecycleChip({
+          lifecycleLabel,
+          isFocusLane: options?.isFocusLane,
+        }),
+      )}
     </ol>
   )
 
@@ -3964,6 +3979,7 @@ export function WorkItemLifecycleStatus({
                         className:
                           "m-0 flex min-w-0 max-w-full list-none flex-wrap gap-1 p-0",
                         ariaLabel: "Current lifecycle steps",
+                        isFocusLane: true,
                       })}
                     </div>
                   )

--- a/apps/harness/src/ui.ts
+++ b/apps/harness/src/ui.ts
@@ -43,12 +43,11 @@ const cardMetalLight =
 const mastScrollworkStroke =
   "[fill:none] [stroke-linecap:round] [stroke-linejoin:round]"
 
-/**
- * Horizontal wrap row for collapsed journey-leg summaries (archive footer +
- * Kanban/repos lifecycle chrome). Shared so both surfaces stay dense and
- * consistent — not a vertical stack of BUILD / REVIEW / PR|MR.
- */
-const legRowClasses = "flex flex-wrap items-center gap-[0.35rem]"
+/** Horizontal lifecycle row: top-align a summary button and a chip list. */
+const lifecycleLegRowClasses = "flex flex-wrap items-start gap-[0.35rem]"
+
+/** Archive footer keeps its established centered journey-leg alignment. */
+const archiveFootClasses = "flex flex-wrap items-center gap-[0.35rem]"
 
 export const ui = {
   /* ---------- Nav shell (§4.1) ---------- */
@@ -323,11 +322,11 @@ export const ui = {
 
   archiveJourney: "grid min-w-0 gap-[0.45rem]",
 
-  /** Collapsed journey legs on one wrap line — see `legRowClasses`. */
-  legRow: legRowClasses,
+  /** Collapsed lifecycle legs on one wrap line — see `lifecycleLegRowClasses`. */
+  legRow: lifecycleLegRowClasses,
 
-  /** Archive footer alias of `legRow` (call-site clarity on completed cards). */
-  archiveFoot: legRowClasses,
+  /** Completed-card journey legs preserve their existing centered alignment. */
+  archiveFoot: archiveFootClasses,
 
   /**
    * Journey-leg chips — board density floor (0.56rem) is the shared base.
@@ -1009,9 +1008,12 @@ export const ui = {
   legSummary: cx(
     "inline-flex max-w-full min-w-0 cursor-pointer items-center gap-[0.35rem]",
     "overflow-hidden border-[1.5px] border-ink bg-[var(--leg-lane,var(--lane-build))] px-[0.38rem] py-[0.16rem]",
-    "font-mono text-[0.56rem] font-bold tracking-[0.06em] uppercase whitespace-nowrap text-[var(--leg-on,#fff)]",
+    "font-mono text-[0.56rem] font-bold leading-[1.2] tracking-[0.06em] uppercase whitespace-nowrap text-[var(--leg-on,#fff)]",
     "hover:brightness-105",
   ),
+
+  /** Matches `legSummary` metrics only for a running focus-lane chip. */
+  lifecycleFocusRunningChip: "leading-[1.2]",
 
   /**
    * Multi-block lifecycle chrome: summary leg row on top, expanded chip

--- a/apps/harness/test/repos-interchange.test.ts
+++ b/apps/harness/test/repos-interchange.test.ts
@@ -191,14 +191,39 @@ describe("Interchange phase 4: repos page + blank slate", () => {
     expect(ui).toContain("lifecycleInset:")
     expect(ui).toMatch(/lifecycleInset:[\s\S]*?border-\[1\.5px\]/)
     expect(ui).toMatch(/lifecycleInset:[\s\S]*?border-ink/)
-    // Shared horizontal leg-row recipe (lifecycle chrome + archive foot).
+    // Both surfaces keep horizontal journey legs, while the lifecycle row
+    // specifically top-aligns its mixed button and chip-list controls.
     expect(ui).toContain("legRow:")
     expect(ui).toContain("lifecycleLegBlocks:")
     expect(ui).toMatch(
-      /legRowClasses\s*=\s*"flex flex-wrap items-center gap-\[0\.35rem\]"/,
+      /lifecycleLegRowClasses\s*=\s*"flex flex-wrap items-start gap-\[0\.35rem\]"/,
     )
-    expect(ui).toContain("archiveFoot: legRowClasses")
-    expect(ui).toContain("legRow: legRowClasses")
+    expect(ui).toMatch(
+      /archiveFootClasses\s*=\s*"flex flex-wrap items-center gap-\[0\.35rem\]"/,
+    )
+    expect(ui).toContain("archiveFoot: archiveFootClasses")
+    expect(ui).toContain("legRow: lifecycleLegRowClasses")
+  })
+
+  test("running focus chips align with collapsed earlier-lane summaries", () => {
+    const lifecycle = sliceBetweenMarkers(
+      homeSource(),
+      "export function WorkItemLifecycleStatus(",
+      "function RepositoryIssuesSkeleton(",
+    )
+    const ui = uiSource()
+
+    // The mixed row holds a button for a collapsed lane and an ol/li/span for
+    // the running focus lane. Pin both the row alignment and chip metrics.
+    expect(lifecycle).toContain("className={ui.legRow}")
+    expect(lifecycle).toContain('key="focus-lane"')
+    expect(lifecycle).toContain("isFocusLane: true")
+    expect(ui).toMatch(
+      /lifecycleLegRowClasses\s*=\s*"flex flex-wrap items-start gap-\[0\.35rem\]"/,
+    )
+    expect(ui).toMatch(/lifecycleFocusRunningChip:\s*"leading-\[1\.2\]"/)
+    expect(ui).not.toMatch(/leg:\s*"[^"\n]*leading-\[1\.2\]/)
+    expect(ui).toMatch(/legSummary:[\s\S]*?leading-\[1\.2\]/)
   })
 
   test("parent issue groups use an aligned details card", () => {


### PR DESCRIPTION
Fixes the mixed lifecycle row shown while Build is collapsed and Review is
running.

The lifecycle row now top-aligns its summary button and focus-lane chip list.
The running focus chip uses the same line-height as the collapsed summary.
The alignment is scoped to that path; archive footer alignment and general
lifecycle chip metrics remain unchanged.

Added regression coverage for the running-focus/earlier-summary combination.

Verification:
- `bunx nx run harness:test --skip-nx-cache`
- Biome check on touched Harness files

Closes #858