### PR TITLE
fix(lifecycle): run review in the parent session

### DIFF
--- a/packages/work-item-lifecycle/src/lib/review.ts
+++ b/packages/work-item-lifecycle/src/lib/review.ts
@@ -85,7 +85,7 @@ export type ReviewResult =
     }
   | { readonly _tag: "needs_human"; readonly reason: string }
 
-/** Machine-readable outcome of the reviewing (/review) pass only. */
+/** Machine-readable outcome of the reviewing pass only. */
 export type ReviewingPassResult =
   | { readonly _tag: "clean" }
   | { readonly _tag: "has_findings"; readonly severity: ReviewSeverity }
@@ -110,8 +110,6 @@ export type ApplyReviewResult =
 export type RerunAssessmentResult =
   | { readonly _tag: "accepted"; readonly reason: string }
   | { readonly _tag: "rerun_required"; readonly reason: string }
-
-export const REVIEW_AGENT_COMMAND = "/review"
 
 const SEVERITY_RUBRIC = [
   "Severity measures finding impact, not expected fix effort:",
@@ -152,7 +150,7 @@ export const buildReviewingPrompt = () =>
 
 const buildReviewVerdictPrompt = () =>
   [
-    "The /review command immediately above has completed.",
+    "The reviewing pass immediately above has completed.",
     "Do not review again, edit files, or add explanatory prose.",
     SEVERITY_RUBRIC,
     "Classify the existing report. If it reported any Review Findings, respond exactly:",
@@ -508,7 +506,6 @@ export const review = (context: LifecycleStepContext) =>
       const reviewing = yield* agentBackend
         .continueTurn({
           sessionId,
-          command: REVIEW_AGENT_COMMAND,
           prompt: buildReviewingPrompt(),
           cwd: worktreePath,
           model: context.reviewModel,

--- a/packages/work-item-lifecycle/src/lib/types.ts
+++ b/packages/work-item-lifecycle/src/lib/types.ts
@@ -335,7 +335,7 @@ export const STEP_RUN_REASON = {
    * before the backend CLI is spawned.
    */
   agentModelNotInCatalog: "agent_model_not_in_catalog",
-  /** Mid-run: Review is running the reviewing (/review) OpenCode pass. */
+  /** Mid-run: Review is running the reviewing OpenCode pass. */
   reviewReviewing: "review_reviewing",
   /** Mid-run: Review is applying findings with the build model. */
   reviewApplyingFindings: "review_applying_findings",

--- a/packages/work-item-lifecycle/test/review.spec.ts
+++ b/packages/work-item-lifecycle/test/review.spec.ts
@@ -18,7 +18,6 @@ import {
   CurrentStepRun,
   MAX_REVIEW_FIX_ROUNDS,
   PreCommitOpenCodeError,
-  REVIEW_AGENT_COMMAND,
   REVIEW_APPLYING_FINDINGS_MESSAGE,
   REVIEW_ASSESSING_RERUN_MESSAGE,
   REVIEW_FIX_LIMIT_REASON,
@@ -400,11 +399,7 @@ describe("parseRerunAssessmentResult", () => {
   })
 })
 
-const isReviewingTurn = (input: {
-  readonly command?: string
-  readonly prompt: string
-}): boolean =>
-  input.command === REVIEW_AGENT_COMMAND ||
+const isReviewingTurn = (input: { readonly prompt: string }): boolean =>
   input.prompt === buildReviewingPrompt()
 
 const isAssessmentTurn = (input: { readonly prompt: string }): boolean =>
@@ -430,7 +425,6 @@ describe("buildReviewingPrompt", () => {
     expect(prompt.startsWith('"')).toBe(false)
     expect(prompt.endsWith('"')).toBe(false)
     expect(prompt.startsWith("/review")).toBe(false)
-    expect(REVIEW_AGENT_COMMAND).toBe("/review")
   })
 })
 
@@ -462,7 +456,7 @@ describe("review", () => {
       expect(error).toBeInstanceOf(ReviewSessionContextMissingError)
     }))
 
-  it("continues the Implement Session with /review contract and review model", () =>
+  it("continues the Implement Session with the review contract and review model", () =>
     withTemp(async (root) => {
       let continued: {
         sessionId: string
@@ -511,7 +505,7 @@ describe("review", () => {
       expect(Duration.toMillis(continued!.timeout!)).toBe(
         Duration.toMillis(Duration.minutes(45)),
       )
-      expect(continued!.command).toBe(REVIEW_AGENT_COMMAND)
+      expect(continued!.command).toBeUndefined()
       expect(continued!.prompt).toBe(buildReviewingPrompt())
       expect(continued!.prompt.startsWith('"')).toBe(false)
       expect(continued!.prompt.endsWith('"')).toBe(false)
@@ -546,7 +540,7 @@ describe("review", () => {
       expect(result).toEqual({ _tag: "clean" })
     }))
 
-  it("requests a verdict when /review summarizes a nested clean result without its marker", () =>
+  it("requests a verdict when the reviewing pass omits its marker", () =>
     withTemp(async (root) => {
       const continues: Array<{ prompt: string; command?: string }> = []
       const result = await run(
@@ -572,7 +566,7 @@ describe("review", () => {
 
       expect(result).toEqual({ _tag: "clean" })
       expect(continues).toHaveLength(2)
-      expect(continues[0]!.command).toBe(REVIEW_AGENT_COMMAND)
+      expect(continues[0]!.command).toBeUndefined()
       expect(continues[1]!.command).toBeUndefined()
       expect(continues[1]!.prompt).toContain(
         "READY_FOR_AGENT_RESULT: REVIEW_CLEAN",
@@ -585,11 +579,9 @@ describe("review", () => {
       )
     }))
 
-  it("enters a Review Fix Round from normalized /review child findings (not parent REVIEW_FIXED)", () =>
+  it("enters a Review Fix Round from reviewing findings", () =>
     withTemp(async (root) => {
-      // Models the OpenCode adapter contract after #439: command turns return
-      // only the nested reviewer text, never the automatic parent resume.
-      const normalizedChildReview = [
+      const reviewingPassResult = [
         "## Review Findings",
         "- Medium: example finding",
         "",
@@ -606,10 +598,10 @@ describe("review", () => {
                 ? { command: input.command }
                 : {}),
             })
-            if (input.command === REVIEW_AGENT_COMMAND) {
+            if (isReviewingTurn(input)) {
               return Effect.succeed({
                 sessionId: "ses_implement_session",
-                assistantText: normalizedChildReview,
+                assistantText: reviewingPassResult,
               })
             }
             return Effect.succeed({
@@ -627,17 +619,16 @@ describe("review", () => {
         reason: "follow-up",
       })
       expect(continues).toHaveLength(2)
-      expect(continues[0]!.command).toBe(REVIEW_AGENT_COMMAND)
+      expect(continues[0]!.command).toBeUndefined()
       expect(continues[1]!.command).toBeUndefined()
       expect(continues[1]!.prompt).toContain("Interpret those findings")
       expect(continues[1]!.prompt).toContain("REVIEW_HAS_FINDINGS: medium")
-      // Parent resume marker must not be accepted as the reviewing outcome.
       expect(parseReviewResult("READY_FOR_AGENT_RESULT: REVIEW_FIXED")).toBe(
         null,
       )
     }))
 
-  it("classifies severity on the fallback verdict without another /review command", () =>
+  it("classifies severity on the fallback verdict without another reviewing pass", () =>
     withTemp(async (root) => {
       const continues: Array<{
         prompt: string
@@ -689,7 +680,7 @@ describe("review", () => {
         reason: "follow-up ticket",
       })
       expect(continues).toHaveLength(3)
-      expect(continues[0]!.command).toBe(REVIEW_AGENT_COMMAND)
+      expect(continues[0]!.command).toBeUndefined()
       expect(continues[0]!.model).toBe("opencode/review-model")
       expect(continues[1]!.command).toBeUndefined()
       expect(continues[1]!.model).toBe("opencode/review-model")
@@ -742,7 +733,7 @@ describe("review", () => {
       expect(continues).toHaveLength(2)
       expect(continues[0]!.model).toBe("opencode/review-model")
       expect(continues[0]!.thinkingLevel).toBe("max")
-      expect(continues[0]!.command).toBe(REVIEW_AGENT_COMMAND)
+      expect(continues[0]!.command).toBeUndefined()
       expect(continues[0]!.prompt).toBe(buildReviewingPrompt())
       expect(continues[1]!.model).toBe("opencode/build-model")
       expect(continues[1]!.thinkingLevel).toBe("high")
@@ -934,14 +925,14 @@ describe("review", () => {
       expect(continues).toHaveLength(3)
       expect(continues[0]!.model).toBe("opencode/review-model")
       expect(continues[0]!.thinkingLevel).toBe("max")
-      expect(continues[0]!.command).toBe(REVIEW_AGENT_COMMAND)
+      expect(continues[0]!.command).toBeUndefined()
       expect(continues[0]!.prompt).toBe(buildReviewingPrompt())
       expect(continues[1]!.model).toBe("opencode/build-model")
       expect(continues[1]!.thinkingLevel).toBe("high")
       expect(continues[1]!.prompt).toContain("REVIEW_FIXED")
       expect(continues[2]!.model).toBe("opencode/review-model")
       expect(continues[2]!.thinkingLevel).toBe("max")
-      expect(continues[2]!.command).toBe(REVIEW_AGENT_COMMAND)
+      expect(continues[2]!.command).toBeUndefined()
       expect(continues[2]!.prompt).toBe(buildReviewingPrompt())
       expect(continues.some((turn) => isAssessmentTurn(turn))).toBe(false)
     }))
@@ -995,7 +986,7 @@ describe("review", () => {
       expect(result).toEqual({ _tag: "clean" })
       expect(continues).toHaveLength(3)
       expect(continues.some((turn) => isAssessmentTurn(turn))).toBe(false)
-      expect(continues[2]!.command).toBe(REVIEW_AGENT_COMMAND)
+      expect(continues[2]!.command).toBeUndefined()
     }))
 
   it("runs Pre-Commit then re-reviews after high FIXED_AND_DEFERRED without assessment", () =>
@@ -1047,14 +1038,14 @@ describe("review", () => {
 
       expect(result).toEqual({ _tag: "clean" })
       expect(continues).toHaveLength(3)
-      expect(continues[0]!.command).toBe(REVIEW_AGENT_COMMAND)
+      expect(continues[0]!.command).toBeUndefined()
       expect(continues[1]!.model).toBe("opencode/build-model")
       expect(continues[1]!.prompt).toContain("REVIEW_FIXED_AND_DEFERRED")
-      expect(continues[2]!.command).toBe(REVIEW_AGENT_COMMAND)
+      expect(continues[2]!.command).toBeUndefined()
       expect(continues.some((turn) => isAssessmentTurn(turn))).toBe(false)
     }))
 
-  it("accepts low-severity FIXED without a second review-model command", () =>
+  it("accepts low-severity FIXED without a second review-model pass", () =>
     withTempGit(async (root) => {
       await writeHook(root, "#!/usr/bin/env bash\nexit 0\n")
       await writeFile(join(root, "change.txt"), "fixed\n")
@@ -1112,7 +1103,7 @@ describe("review", () => {
       })
       expect(continues).toHaveLength(3)
       expect(continues[0]!.model).toBe("opencode/review-model")
-      expect(continues[0]!.command).toBe(REVIEW_AGENT_COMMAND)
+      expect(continues[0]!.command).toBeUndefined()
       expect(continues[1]!.model).toBe("opencode/build-model")
       expect(continues[1]!.prompt).toContain("REVIEW_FIXED")
       expect(continues[2]!.model).toBe("opencode/build-model")
@@ -1223,11 +1214,11 @@ describe("review", () => {
 
       expect(result).toEqual({ _tag: "clean" })
       expect(continues).toHaveLength(4)
-      expect(continues[0]!.command).toBe(REVIEW_AGENT_COMMAND)
+      expect(continues[0]!.command).toBeUndefined()
       expect(continues[1]!.model).toBe("opencode/build-model")
       expect(continues[2]!.model).toBe("opencode/build-model")
       expect(isAssessmentTurn(continues[2]!)).toBe(true)
-      expect(continues[3]!.command).toBe(REVIEW_AGENT_COMMAND)
+      expect(continues[3]!.command).toBeUndefined()
       expect(continues[3]!.model).toBe("opencode/review-model")
     }))
 


### PR DESCRIPTION
The Review step passed OpenCode's reserved `/review` command, which forks a child
subagent. A child permission request can remain unanswered in headless mode and hold
the Review step until its one-hour timeout.

The reviewing pass now continues the existing Implement session with the review
prompt only, retaining its model, thinking level, timeout, and result parsing.
Review tests now assert that no command is sent, including re-review passes; stale
child-session test terminology was also removed.

Verification:
- `bunx nx test work-item-lifecycle --skipNxCache --outputStyle=static` (574 passing)
- `bunx nx build work-item-lifecycle --skipNxCache --outputStyle=static`
- Focused review test run (56 passing)

`nx format:check` could not run because this checkout lacks the `prettier` module.

Closes #871