### PR TITLE
fix(harness): align running lifecycle chips

### DIFF
--- a/apps/harness/src/home-page-content.tsx
+++ b/apps/harness/src/home-page-content.tsx
@@ -3366,7 +3366,7 @@ export function WorkItemLifecycleStatus({
         ? `${lifecycleLabel.label} · ${formatDuration(displayDurationMs)}`
         : lifecycleLabel.label
     return (
-      <li key={lifecycleLabel.phase} className="min-w-0 max-w-full">
+      <li key={lifecycleLabel.phase} className="flex min-w-0 max-w-full">
         {linkToPullRequest ? (
           <a
             className={`${chipClassName} hover:underline`}

--- a/apps/harness/test/repos-interchange.test.ts
+++ b/apps/harness/test/repos-interchange.test.ts
@@ -248,17 +248,25 @@ describe("Interchange phase 4: repos page + blank slate", () => {
     )
     const ui = uiSource()
 
-    // The mixed row holds a button for a collapsed lane and an ol/li/span for
-    // the running focus lane. Pin both the row alignment and chip metrics.
+    // The mixed row holds a direct button for a collapsed lane and an
+    // ol/li/span for the running focus lane. The li must be a flex container:
+    // otherwise its inline-flex chip participates in an inline line box and
+    // acquires baseline leading above the visible chip.
     expect(lifecycle).toContain("className={ui.legRow}")
+    expect(lifecycle).toContain("className={ui.legSummary}")
     expect(lifecycle).toContain('key="focus-lane"')
     expect(lifecycle).toContain("isFocusLane: true")
+    const chipRenderer = sliceBetweenMarkers(
+      lifecycle,
+      "const renderLifecycleChip =",
+      "const renderChipList =",
+    )
+    expect(chipRenderer).toContain(
+      '<li key={lifecycleLabel.phase} className="flex min-w-0 max-w-full">',
+    )
     expect(ui).toMatch(
       /lifecycleLegRowClasses\s*=\s*"flex flex-wrap items-start gap-\[0\.35rem\]"/,
     )
-    expect(ui).toMatch(/lifecycleFocusRunningChip:\s*"leading-\[1\.2\]"/)
-    expect(ui).not.toMatch(/leg:\s*"[^"\n]*leading-\[1\.2\]/)
-    expect(ui).toMatch(/legSummary:[\s\S]*?leading-\[1\.2\]/)
   })
 
   test("parent issue groups use an aligned details card", () => {


### PR DESCRIPTION
The Repos lifecycle row aligned collapsed earlier-lane summaries with the focus-lane
wrapper, but the running chip still sat in an inline line box inside its list item,
leaving its visible top edge offset.

Make lifecycle chip list items flex containers so running focus-lane chips align with
adjacent collapsed summary buttons without changing chip styling, links, wrapping,
state colors, or archive presentation.

Update the Repos regression contract to assert the direct summary-button path and flex
chip-item structure rather than coupling alignment to a line-height utility.

Verification: bunx nx run harness:test passed (526 Bun tests and 92 Vitest tests).

Closes #872