### PR TITLE
feat(harness): serialize ambient GitHub operations

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -56,6 +56,14 @@ _Avoid_: Assignee, reporter (unless matching the Forge’s author field)
 The Forge username of the authenticated principal for a Repository’s Forge credential path (Keymaxxer-injected token or ambient Forge CLI auth). Resolved via the Forge API viewer endpoint for that token during reconciliation when Include all Issue Authors is off; not a separate harness user account.
 _Avoid_: Harness user, local operator account
 
+**Harness GitHub Operation**:
+One replay-safe Harness-native action that may make one or more sequential GitHub GraphQL or REST requests while holding one GitHub Operation Coordinator permit. A successful local cache hit is not a Harness GitHub Operation because it creates no GitHub traffic; each operation must be idempotent or revalidate its remote postcondition before a mutation can be replayed.
+_Avoid_: GitHub request, GitHub task
+
+**GitHub Operation Coordinator**:
+The process-local Harness module that admits exactly one Harness GitHub Operation at a time for one application runtime. Callers choose only Operator, Lifecycle, Polling, or Background origin; normal admission is in that order with FIFO within an origin, and the globally oldest request is admitted after 60 seconds. The permit remains held through the entire active operation and is never preempted. This is not a host-wide queue or a proactive rate limiter: Agent Turns, other Harness runtimes, operator shells, Git transport, and GitHub Actions remain best-effort exclusions.
+_Avoid_: Global GitHub queue, rate limiter
+
 **Issue**:
 An issue on the Repository's Forge, identified within that Repository by a positive integer issue number (the iid in GitLab) and represented locally with its title, body, web URL, creation time, Forge state, and optional Issue Author. The harness may retain a local representation for later use, but the Forge remains authoritative. GitLab issues and merge requests come from separate per-project number sequences, so a bare GitLab number is ambiguous across the two kinds — unlike GitHub's single shared sequence.
 _Avoid_: Ticket, task (unless referring to a broader concept)

--- a/apps/harness/src/server/ambient-github-layer.ts
+++ b/apps/harness/src/server/ambient-github-layer.ts
@@ -1,12 +1,17 @@
 import { Cache, Duration, Effect, Exit, Fiber, Layer } from "effect"
 import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process"
 import {
+  type GitHubOperationOptions,
   type GitHubRepositoryUnavailableError,
   GitHubRequestError,
   GitHubService,
   type GitHubServiceShape,
   makeGitHubServiceFromToken,
 } from "@ready-for-agent/github-service"
+import {
+  GitHubOperationCoordinator,
+  type GitHubOperationOrigin,
+} from "./github-operation-coordinator.js"
 
 type GitHubServiceError = GitHubRepositoryUnavailableError | GitHubRequestError
 
@@ -26,12 +31,13 @@ export const ambientGitHubLayer = (options: {
 }): Layer.Layer<
   GitHubService,
   never,
-  ChildProcessSpawner.ChildProcessSpawner
+  ChildProcessSpawner.ChildProcessSpawner | GitHubOperationCoordinator
 > =>
   Layer.effect(
     GitHubService,
     Effect.gen(function* () {
       const spawner = yield* ChildProcessSpawner.ChildProcessSpawner
+      const coordinator = yield* GitHubOperationCoordinator
       const layerScope = yield* Effect.scope
       const makeService = options.makeService ?? makeGitHubServiceFromToken
 
@@ -119,51 +125,53 @@ export const ambientGitHubLayer = (options: {
       })
 
       const authenticated = <A>(
+        origin: GitHubOperationOrigin,
         operation: (
           service: GitHubServiceShape,
         ) => Effect.Effect<A, GitHubServiceError>,
-      ): Effect.Effect<A, GitHubServiceError> => run(operation)
+      ): Effect.Effect<A, GitHubServiceError> =>
+        coordinator.execute({ origin, operation: run(operation) })
 
       return {
         getAuthenticatedUserLogin: Effect.fn(
           "AmbientGitHub.getAuthenticatedUserLogin",
-        )((repository) =>
-          authenticated((service) =>
-            service.getAuthenticatedUserLogin(repository),
+        )((repository, operationOptions) =>
+          authenticated(operationOptions?.origin ?? "polling", (service) =>
+            service.getAuthenticatedUserLogin(repository, operationOptions),
           ),
         ),
         getOpenPullRequestNumber: Effect.fn(
           "AmbientGitHub.getOpenPullRequestNumber",
         )((repository, headRefName) =>
-          authenticated((service) =>
+          authenticated("lifecycle", (service) =>
             service.getOpenPullRequestNumber(repository, headRefName),
           ),
         ),
         findOpenPullRequestNumber: Effect.fn(
           "AmbientGitHub.findOpenPullRequestNumber",
         )((repository, headRefName) =>
-          authenticated((service) =>
+          authenticated("lifecycle", (service) =>
             service.findOpenPullRequestNumber(repository, headRefName),
           ),
         ),
         countOpenNonDraftPullRequests: Effect.fn(
           "AmbientGitHub.countOpenNonDraftPullRequests",
         )((repository) =>
-          authenticated((service) =>
+          authenticated("background", (service) =>
             service.countOpenNonDraftPullRequests(repository),
           ),
         ),
         createDraftPullRequest: Effect.fn(
           "AmbientGitHub.createDraftPullRequest",
         )((repository, input) =>
-          authenticated((service) =>
+          authenticated("lifecycle", (service) =>
             service.createDraftPullRequest(repository, input),
           ),
         ),
         updateOpenDraftPullRequestCopy: Effect.fn(
           "AmbientGitHub.updateOpenDraftPullRequestCopy",
         )((repository, headRefName, input) =>
-          authenticated((service) =>
+          authenticated("lifecycle", (service) =>
             service.updateOpenDraftPullRequestCopy(
               repository,
               headRefName,
@@ -174,14 +182,14 @@ export const ambientGitHubLayer = (options: {
         getPullRequestCheckStatus: Effect.fn(
           "AmbientGitHub.getPullRequestCheckStatus",
         )((repository, headRefName) =>
-          authenticated((service) =>
+          authenticated("lifecycle", (service) =>
             service.getPullRequestCheckStatus(repository, headRefName),
           ),
         ),
         getPrStatusCheckDiagnostics: Effect.fn(
           "AmbientGitHub.getPrStatusCheckDiagnostics",
         )((repository, checks, requestOptions) =>
-          authenticated((service) =>
+          authenticated("lifecycle", (service) =>
             service.getPrStatusCheckDiagnostics(
               repository,
               checks,
@@ -192,7 +200,7 @@ export const ambientGitHubLayer = (options: {
         observeAutomatedReviewEvidence: Effect.fn(
           "AmbientGitHub.observeAutomatedReviewEvidence",
         )((repository, headRefName, checks) =>
-          authenticated((service) =>
+          authenticated("lifecycle", (service) =>
             service.observeAutomatedReviewEvidence(
               repository,
               headRefName,
@@ -203,33 +211,33 @@ export const ambientGitHubLayer = (options: {
         getPullRequestLifecycleStatus: Effect.fn(
           "AmbientGitHub.getPullRequestLifecycleStatus",
         )((repository, headRefName) =>
-          authenticated((service) =>
+          authenticated("lifecycle", (service) =>
             service.getPullRequestLifecycleStatus(repository, headRefName),
           ),
         ),
         markPullRequestReadyForReview: Effect.fn(
           "AmbientGitHub.markPullRequestReadyForReview",
         )((repository, headRefName) =>
-          authenticated((service) =>
+          authenticated("lifecycle", (service) =>
             service.markPullRequestReadyForReview(repository, headRefName),
           ),
         ),
         mergePullRequest: Effect.fn("AmbientGitHub.mergePullRequest")(
           (repository, headRefName) =>
-            authenticated((service) =>
+            authenticated("lifecycle", (service) =>
               service.mergePullRequest(repository, headRefName),
             ),
         ),
         rerunWorkflowRun: Effect.fn("AmbientGitHub.rerunWorkflowRun")(
           (repository, workflowRunId) =>
-            authenticated((service) =>
+            authenticated("lifecycle", (service) =>
               service.rerunWorkflowRun(repository, workflowRunId),
             ),
         ),
         ensureIssueCompletedWithSummary: Effect.fn(
           "AmbientGitHub.ensureIssueCompletedWithSummary",
         )((repository, issueNumber, workItemId, summaryMarkdown) =>
-          authenticated((service) =>
+          authenticated("lifecycle", (service) =>
             service.ensureIssueCompletedWithSummary(
               repository,
               issueNumber,
@@ -239,8 +247,10 @@ export const ambientGitHubLayer = (options: {
           ),
         ),
         listReadyIssues: Effect.fn("AmbientGitHub.listReadyIssues")(
-          (repository) =>
-            authenticated((service) => service.listReadyIssues(repository)),
+          (repository, operationOptions?: GitHubOperationOptions) =>
+            authenticated(operationOptions?.origin ?? "polling", (service) =>
+              service.listReadyIssues(repository, operationOptions),
+            ),
         ),
       } satisfies GitHubServiceShape
     }),

--- a/apps/harness/src/server/application.server.ts
+++ b/apps/harness/src/server/application.server.ts
@@ -52,6 +52,7 @@ import {
   environmentConfigLayer,
   loadApplicationConfig,
 } from "./application-config.js"
+import { GitHubOperationCoordinatorLive } from "./github-operation-coordinator.js"
 import { JobWorkerLive } from "./job-worker.js"
 import { keymaxxerGitHubLayer } from "./keymaxxer-github-layer.js"
 import { keymaxxerGitLabLayer } from "./keymaxxer-gitlab-layer.js"
@@ -132,6 +133,7 @@ export const createApplication = async (
   const platformLayer = BunChildProcessSpawner.layer.pipe(
     Layer.provideMerge(Layer.merge(BunFileSystem.layer, BunPath.layer)),
   )
+  const githubOperationCoordinatorLayer = GitHubOperationCoordinatorLive
   const githubLayer =
     sidecarUrl === undefined
       ? ambientGitHubLayer({ workspaceRoot: toolCwd }).pipe(
@@ -254,7 +256,10 @@ export const createApplication = async (
           directoryPickerLayer,
           loggingLayer,
         )
-  const appLayer = applicationServices.pipe(Layer.provide(configLayer))
+  const appLayer = applicationServices.pipe(
+    Layer.provide(configLayer),
+    Layer.provide(githubOperationCoordinatorLayer),
+  )
   const runtime = ManagedRuntime.make(appLayer)
 
   try {

--- a/apps/harness/src/server/github-operation-coordinator.ts
+++ b/apps/harness/src/server/github-operation-coordinator.ts
@@ -1,0 +1,134 @@
+import { Context, Effect, Layer } from "effect"
+import type { GitHubOperationOrigin } from "@ready-for-agent/github-service"
+
+export type { GitHubOperationOrigin } from "@ready-for-agent/github-service"
+
+const originAdmissionOrder: readonly GitHubOperationOrigin[] = [
+  "operator",
+  "lifecycle",
+  "polling",
+  "background",
+]
+const AGING_MILLIS = 60_000
+
+export interface GitHubOperationCoordinatorShape {
+  /**
+   * Runs one replay-safe Harness GitHub Operation while holding the sole
+   * process-local permit. The operation may make sequential requests only.
+   */
+  readonly execute: <A, E>(input: {
+    readonly origin: GitHubOperationOrigin
+    readonly operation: Effect.Effect<A, E>
+  }) => Effect.Effect<A, E>
+}
+
+export class GitHubOperationCoordinator extends Context.Service<
+  GitHubOperationCoordinator,
+  GitHubOperationCoordinatorShape
+>()("@ready-for-agent/harness/GitHubOperationCoordinator") {}
+
+interface WaitingOperation {
+  readonly origin: GitHubOperationOrigin
+  readonly enqueuedAt: number
+  readonly start: () => void
+  readonly interrupt: () => void
+  started: boolean
+}
+
+interface CoordinatorState extends GitHubOperationCoordinatorShape {
+  readonly dispose: () => void
+}
+
+/**
+ * Construct an isolated coordinator. The injected clock makes admission tests
+ * deterministic; production uses wall-clock milliseconds.
+ */
+export const makeGitHubOperationCoordinator = (options?: {
+  readonly now?: () => number
+}): CoordinatorState => {
+  const now = options?.now ?? Date.now
+  const waiting: WaitingOperation[] = []
+  let active: WaitingOperation | undefined
+  let disposed = false
+
+  const remove = (operation: WaitingOperation): void => {
+    const index = waiting.indexOf(operation)
+    if (index !== -1) waiting.splice(index, 1)
+  }
+
+  const selectNext = (): WaitingOperation | undefined => {
+    const currentTime = now()
+    for (const operation of waiting) {
+      if (currentTime - operation.enqueuedAt >= AGING_MILLIS) return operation
+    }
+    for (const origin of originAdmissionOrder) {
+      const next = waiting.find((operation) => operation.origin === origin)
+      if (next !== undefined) return next
+    }
+    return undefined
+  }
+
+  const admitNext = (): void => {
+    if (disposed || active !== undefined) return
+    const next = selectNext()
+    if (next === undefined) return
+    remove(next)
+    next.started = true
+    active = next
+    next.start()
+  }
+
+  const release = (operation: WaitingOperation): void => {
+    if (active !== operation) return
+    active = undefined
+    admitNext()
+  }
+
+  const execute: GitHubOperationCoordinatorShape["execute"] = (input) =>
+    Effect.callback((resume) => {
+      let operation: WaitingOperation
+      operation = {
+        origin: input.origin,
+        enqueuedAt: now(),
+        started: false,
+        interrupt: () => resume(Effect.interrupt),
+        start: () => {
+          resume(
+            Effect.uninterruptible(input.operation).pipe(
+              Effect.ensuring(Effect.sync(() => release(operation))),
+            ),
+          )
+        },
+      }
+      if (disposed) {
+        operation.interrupt()
+      } else {
+        waiting.push(operation)
+        admitNext()
+      }
+      return Effect.sync(() => {
+        if (operation.started) return
+        remove(operation)
+        admitNext()
+      })
+    })
+
+  return {
+    execute,
+    dispose: () => {
+      if (disposed) return
+      disposed = true
+      const pending = waiting.splice(0)
+      for (const operation of pending) operation.interrupt()
+    },
+  }
+}
+
+/** One coordinator is scoped to the Harness application runtime that builds it. */
+export const GitHubOperationCoordinatorLive = Layer.effect(
+  GitHubOperationCoordinator,
+  Effect.acquireRelease(
+    Effect.sync(() => makeGitHubOperationCoordinator()),
+    (coordinator) => Effect.sync(coordinator.dispose),
+  ),
+)

--- a/apps/harness/src/server/job-worker.ts
+++ b/apps/harness/src/server/job-worker.ts
@@ -16,7 +16,10 @@ import {
   RepositoryNotFoundError,
   type RepositoryRecord,
 } from "@ready-for-agent/db-service"
-import { formatUserFacingError } from "@ready-for-agent/github-service"
+import {
+  type GitHubOperationOrigin,
+  formatUserFacingError,
+} from "@ready-for-agent/github-service"
 import { GitLabService } from "@ready-for-agent/gitlab-service"
 import {
   ISSUE_POLL_QUEUE,
@@ -156,9 +159,13 @@ const runPollingAutoHeal = Effect.fn("JobWorker.runPollingAutoHeal")(function* (
   })
 })
 
-const refreshRepository = Effect.fn("JobWorker.refreshRepository")(function* (
-  repositoryId: RepositoryId,
-) {
+const refreshRepository = Effect.fn("JobWorker.refreshRepository")(function* ({
+  repositoryId,
+  githubOperationOrigin,
+}: {
+  readonly repositoryId: RepositoryId
+  readonly githubOperationOrigin: GitHubOperationOrigin
+}) {
   const db = yield* DbService
   const reconciler = yield* IssueReconciler
   const repositories = yield* db.listRepositories
@@ -169,7 +176,9 @@ const refreshRepository = Effect.fn("JobWorker.refreshRepository")(function* (
   }
 
   const lifecycle = yield* WorkItemLifecycle
-  const summary = yield* reconciler.reconcile(repository)
+  const summary = yield* reconciler.reconcile(repository, {
+    githubOperation: { origin: githubOperationOrigin },
+  })
   yield* syncNeedsHumanMergeHandoffs(repositoryId)
   // Issue store is current: lift or fail Waiting for blockers Work Items.
   // Lifecycle owns Work Item mutations; reconciler only updates Issues.
@@ -351,7 +360,10 @@ const claimAndRunRefreshJob = (
         }
         case "refresh-repository": {
           const result = yield* Effect.result(
-            refreshRepository(decoded.success.repositoryId),
+            refreshRepository({
+              repositoryId: decoded.success.repositoryId,
+              githubOperationOrigin: "operator",
+            }),
           )
           yield* finalizeManualRefresh(
             job.jobId,
@@ -401,7 +413,10 @@ const claimAndRunRefreshJob = (
     }
 
     const result = yield* Effect.result(
-      refreshRepository(job.payload.repositoryId),
+      refreshRepository({
+        repositoryId: job.payload.repositoryId,
+        githubOperationOrigin: "polling",
+      }),
     )
     yield* finalizeScheduledRefresh(
       job.jobId,

--- a/apps/harness/test/ambient-github-layer.test.ts
+++ b/apps/harness/test/ambient-github-layer.test.ts
@@ -9,7 +9,15 @@ import {
   GitHubService,
   type GitHubServiceShape,
 } from "@ready-for-agent/github-service"
-import { ambientGitHubLayer } from "../src/server/ambient-github-layer.js"
+import { ambientGitHubLayer as makeAmbientGitHubLayer } from "../src/server/ambient-github-layer.js"
+import { GitHubOperationCoordinatorLive } from "../src/server/github-operation-coordinator.js"
+
+const ambientGitHubLayer = (
+  options: Parameters<typeof makeAmbientGitHubLayer>[0],
+) =>
+  makeAmbientGitHubLayer(options).pipe(
+    Layer.provide(GitHubOperationCoordinatorLive),
+  )
 
 const processLayer = BunChildProcessSpawner.layer.pipe(
   Layer.provideMerge(Layer.merge(BunFileSystem.layer, BunPath.layer)),
@@ -193,12 +201,12 @@ it("canceling the first requester keeps shared authentication alive", async () =
 
   await process.started
   controller.abort()
-  await first
   const second = runtime.runPromise(listReadyIssues)
   process.complete("shared-token")
 
   try {
     expect(await second).toEqual([])
+    await first
     expect(process.startCount()).toBe(1)
     expect(process.interrupted()).toBe(0)
   } finally {
@@ -223,11 +231,11 @@ it("concurrent joiners survive cancel of the cache owner fiber", async () => {
 
   await process.started
   ownerController.abort()
-  await owner
   process.complete("shared-token")
 
   try {
     expect(await joiner).toEqual([])
+    await owner
     expect(process.startCount()).toBe(1)
     expect(process.interrupted()).toBe(0)
   } finally {
@@ -235,32 +243,23 @@ it("concurrent joiners survive cancel of the cache owner fiber", async () => {
   }
 })
 
-it("concurrent 401 responses share one refreshed token", async () => {
+it("serialized ambient operations share a 401 token refresh", async () => {
   const resolvedTokens = ["expired-token", "fresh-token"]
   let resolutions = 0
   let expiredCalls = 0
-  let releaseExpiredCalls: () => void = () => undefined
-  const bothExpiredCallsStarted = new Promise<void>((resolve) => {
-    releaseExpiredCalls = resolve
-  })
   const layer = ambientGitHubLayer({
     workspaceRoot: "/workspace",
     resolveToken: async () => resolvedTokens[resolutions++]!,
     makeService: (token) =>
       serviceWithList(() => {
         if (token === "fresh-token") return Effect.succeed([])
-        return Effect.tryPromise({
-          try: async () => {
-            expiredCalls += 1
-            if (expiredCalls === 2) releaseExpiredCalls()
-            await bothExpiredCallsStarted
-            throw new GitHubRequestError({
-              message: "Unauthorized",
-              statusCode: 401,
-            })
-          },
-          catch: (error) => error as GitHubRequestError,
-        })
+        expiredCalls += 1
+        return Effect.fail(
+          new GitHubRequestError({
+            message: "Unauthorized",
+            statusCode: 401,
+          }),
+        )
       }),
   })
 
@@ -285,7 +284,7 @@ it("concurrent 401 responses share one refreshed token", async () => {
     }).pipe(Effect.provide(layer.pipe(Layer.provide(processLayer)))),
   )
 
-  expect(expiredCalls).toBe(2)
+  expect(expiredCalls).toBe(1)
   expect(resolutions).toBe(2)
 })
 

--- a/apps/harness/test/github-operation-coordinator.test.ts
+++ b/apps/harness/test/github-operation-coordinator.test.ts
@@ -1,0 +1,351 @@
+import { expect, it } from "@effect/vitest"
+import { Effect, ManagedRuntime } from "effect"
+import {
+  GitHubOperationCoordinator,
+  GitHubOperationCoordinatorLive,
+  type GitHubOperationCoordinatorShape,
+  type GitHubOperationOrigin,
+  makeGitHubOperationCoordinator,
+} from "../src/server/github-operation-coordinator.js"
+
+interface ActiveOperationCounter {
+  active: number
+  maximum: number
+}
+
+const controlledOperation = (input: {
+  readonly name: string
+  readonly started: string[]
+  readonly release: Map<string, () => void>
+  readonly onStart?: () => void
+  readonly activeCounter?: ActiveOperationCounter
+}): Effect.Effect<void> => {
+  let started = false
+  return Effect.callback((resume) => {
+    started = true
+    input.started.push(input.name)
+    if (input.activeCounter !== undefined) {
+      input.activeCounter.active += 1
+      input.activeCounter.maximum = Math.max(
+        input.activeCounter.maximum,
+        input.activeCounter.active,
+      )
+    }
+    input.onStart?.()
+    input.release.set(input.name, () => resume(Effect.void))
+  }).pipe(
+    Effect.ensuring(
+      Effect.sync(() => {
+        if (started && input.activeCounter !== undefined) {
+          input.activeCounter.active -= 1
+        }
+      }),
+    ),
+  )
+}
+
+const enqueue = (input: {
+  readonly coordinator: GitHubOperationCoordinatorShape
+  readonly origin: GitHubOperationOrigin
+  readonly name: string
+  readonly started: string[]
+  readonly release: Map<string, () => void>
+  readonly activeCounter?: ActiveOperationCounter
+}): Promise<void> =>
+  Effect.runPromise(
+    input.coordinator.execute({
+      origin: input.origin,
+      operation: controlledOperation(input),
+    }),
+  )
+
+const waitFor = async (predicate: () => boolean): Promise<void> => {
+  while (!predicate()) await Promise.resolve()
+}
+
+it("serializes mixed-origin operations and admits semantic priority FIFO", async () => {
+  const coordinator = makeGitHubOperationCoordinator()
+  const started: string[] = []
+  const release = new Map<string, () => void>()
+  const active = enqueue({
+    coordinator,
+    origin: "background",
+    name: "active",
+    started,
+    release,
+  })
+  await waitFor(() => started.length === 1)
+  const background = enqueue({
+    coordinator,
+    origin: "background",
+    name: "background",
+    started,
+    release,
+  })
+  const polling = enqueue({
+    coordinator,
+    origin: "polling",
+    name: "polling",
+    started,
+    release,
+  })
+  const lifecycleFirst = enqueue({
+    coordinator,
+    origin: "lifecycle",
+    name: "lifecycle-first",
+    started,
+    release,
+  })
+  const lifecycleSecond = enqueue({
+    coordinator,
+    origin: "lifecycle",
+    name: "lifecycle-second",
+    started,
+    release,
+  })
+  const operator = enqueue({
+    coordinator,
+    origin: "operator",
+    name: "operator",
+    started,
+    release,
+  })
+
+  release.get("active")?.()
+  await waitFor(() => started.length === 2)
+  release.get("operator")?.()
+  await waitFor(() => started.length === 3)
+  release.get("lifecycle-first")?.()
+  await waitFor(() => started.length === 4)
+  release.get("lifecycle-second")?.()
+  await waitFor(() => started.length === 5)
+  release.get("polling")?.()
+  await waitFor(() => started.length === 6)
+  release.get("background")?.()
+
+  await Promise.all([
+    active,
+    background,
+    polling,
+    lifecycleFirst,
+    lifecycleSecond,
+    operator,
+  ])
+  expect(started).toEqual([
+    "active",
+    "operator",
+    "lifecycle-first",
+    "lifecycle-second",
+    "polling",
+    "background",
+  ])
+})
+
+it("never exceeds one active operation", async () => {
+  const coordinator = makeGitHubOperationCoordinator()
+  const activeCounter = { active: 0, maximum: 0 }
+  const started: string[] = []
+  const release = new Map<string, () => void>()
+  const first = enqueue({
+    coordinator,
+    origin: "background",
+    name: "first",
+    started,
+    release,
+    activeCounter,
+  })
+  await waitFor(() => started.length === 1)
+  const second = enqueue({
+    coordinator,
+    origin: "operator",
+    name: "second",
+    started,
+    release,
+    activeCounter,
+  })
+  const third = enqueue({
+    coordinator,
+    origin: "polling",
+    name: "third",
+    started,
+    release,
+    activeCounter,
+  })
+
+  release.get("first")?.()
+  await waitFor(() => started.length === 2)
+  release.get("second")?.()
+  await waitFor(() => started.length === 3)
+  release.get("third")?.()
+  await Promise.all([first, second, third])
+
+  expect(activeCounter.maximum).toBe(1)
+  expect(activeCounter.active).toBe(0)
+})
+
+it("admits the globally oldest request after 60 seconds", async () => {
+  let time = 0
+  const coordinator = makeGitHubOperationCoordinator({ now: () => time })
+  const started: string[] = []
+  const release = new Map<string, () => void>()
+  const active = enqueue({
+    coordinator,
+    origin: "operator",
+    name: "active",
+    started,
+    release,
+  })
+  await waitFor(() => started.length === 1)
+  const background = enqueue({
+    coordinator,
+    origin: "background",
+    name: "old-background",
+    started,
+    release,
+  })
+  time = 60_000
+  const operator = enqueue({
+    coordinator,
+    origin: "operator",
+    name: "new-operator",
+    started,
+    release,
+  })
+
+  release.get("active")?.()
+  await waitFor(() => started.length === 2)
+  expect(started).toEqual(["active", "old-background"])
+  release.get("old-background")?.()
+  await waitFor(() => started.length === 3)
+  release.get("new-operator")?.()
+  await Promise.all([active, background, operator])
+})
+
+it("removes cancellation before dispatch without preempting the active operation", async () => {
+  const coordinator = makeGitHubOperationCoordinator()
+  const started: string[] = []
+  const release = new Map<string, () => void>()
+  const active = enqueue({
+    coordinator,
+    origin: "background",
+    name: "active",
+    started,
+    release,
+  })
+  await waitFor(() => started.length === 1)
+  const abort = new AbortController()
+  const cancelled = Effect.runPromise(
+    coordinator.execute({
+      origin: "operator",
+      operation: controlledOperation({
+        name: "cancelled",
+        started,
+        release,
+      }),
+    }),
+    { signal: abort.signal },
+  ).catch(() => undefined)
+  abort.abort()
+  await cancelled
+  expect(started).toEqual(["active"])
+
+  const next = enqueue({
+    coordinator,
+    origin: "operator",
+    name: "next",
+    started,
+    release,
+  })
+  release.get("active")?.()
+  await waitFor(() => started.length === 2)
+  expect(started).toEqual(["active", "next"])
+  release.get("next")?.()
+  await Promise.all([active, next])
+})
+
+it("keeps an active operation running after its caller cancels", async () => {
+  const coordinator = makeGitHubOperationCoordinator()
+  const started: string[] = []
+  const release = new Map<string, () => void>()
+  const abort = new AbortController()
+  const active = Effect.runPromise(
+    coordinator.execute({
+      origin: "lifecycle",
+      operation: controlledOperation({ name: "active", started, release }),
+    }),
+    { signal: abort.signal },
+  ).catch(() => undefined)
+  await waitFor(() => started.length === 1)
+  const next = enqueue({
+    coordinator,
+    origin: "operator",
+    name: "next",
+    started,
+    release,
+  })
+  abort.abort()
+  await Promise.resolve()
+  expect(started).toEqual(["active"])
+  release.get("active")?.()
+  await waitFor(() => started.length === 2)
+  release.get("next")?.()
+  await Promise.all([active, next])
+})
+
+it("isolates and disposes coordinator state per managed runtime", async () => {
+  const firstRuntime = ManagedRuntime.make(GitHubOperationCoordinatorLive)
+  const secondRuntime = ManagedRuntime.make(GitHubOperationCoordinatorLive)
+  await Promise.all([firstRuntime.context(), secondRuntime.context()])
+  const first = await firstRuntime.runPromise(GitHubOperationCoordinator)
+  const second = await secondRuntime.runPromise(GitHubOperationCoordinator)
+  const started: string[] = []
+  const release = new Map<string, () => void>()
+  try {
+    const firstRun = enqueue({
+      coordinator: first,
+      origin: "background",
+      name: "first-runtime",
+      started,
+      release,
+    })
+    const secondRun = enqueue({
+      coordinator: second,
+      origin: "background",
+      name: "second-runtime",
+      started,
+      release,
+    })
+    await waitFor(() => started.length === 2)
+    expect(started).toEqual(["first-runtime", "second-runtime"])
+    release.get("first-runtime")?.()
+    release.get("second-runtime")?.()
+    await Promise.all([firstRun, secondRun])
+
+    const active = enqueue({
+      coordinator: first,
+      origin: "background",
+      name: "disposing-active",
+      started,
+      release,
+    })
+    await waitFor(() => started.length === 3)
+    const pending = enqueue({
+      coordinator: first,
+      origin: "operator",
+      name: "disposed-pending",
+      started,
+      release,
+    }).catch(() => undefined)
+    await firstRuntime.dispose()
+    await pending
+    expect(started).toEqual([
+      "first-runtime",
+      "second-runtime",
+      "disposing-active",
+    ])
+    release.get("disposing-active")?.()
+    await active
+  } finally {
+    await Promise.all([firstRuntime.dispose(), secondRuntime.dispose()])
+  }
+})

--- a/apps/harness/test/job-worker.test.ts
+++ b/apps/harness/test/job-worker.test.ts
@@ -1404,6 +1404,7 @@ describe("Job worker", () => {
       Effect.gen(function* () {
         const claimOrder: string[] = []
         const repositoryOrder: string[] = []
+        const githubOperationOrigins: string[] = []
         const manualJob = rawJob(refreshPayload, ISSUE_REFRESH_QUEUE)
         const scheduledJob = rawJob(
           {
@@ -1424,6 +1425,7 @@ describe("Job worker", () => {
             }).pipe(Effect.forkScoped({ startImmediately: true }))
             yield* Deferred.await(done)
             expect(repositoryOrder).toEqual([repository.id, otherRepository.id])
+            expect(githubOperationOrigins).toEqual(["operator", "polling"])
             const refreshClaims = claimOrder.filter(
               (queueName) =>
                 queueName === ISSUE_REFRESH_QUEUE ||
@@ -1453,9 +1455,12 @@ describe("Job worker", () => {
             ),
             dbLayer([repository, otherRepository]),
             Layer.succeed(IssueReconciler, {
-              reconcile: (repo) =>
+              reconcile: (repo, options) =>
                 Effect.sync(() => {
                   repositoryOrder.push(repo.id)
+                  githubOperationOrigins.push(
+                    options?.githubOperation?.origin ?? "missing",
+                  )
                   return {
                     fetched: 0,
                     inserted: 0,

--- a/apps/harness/vitest.config.ts
+++ b/apps/harness/vitest.config.ts
@@ -73,6 +73,7 @@ export default defineConfig({
       "test/keymaxxer-github-layer.test.ts",
       "test/keymaxxer-gitlab-layer.test.ts",
       "test/ambient-github-layer.test.ts",
+      "test/github-operation-coordinator.test.ts",
       "test/ambient-gitlab-layer.test.ts",
       "test/application-config.test.ts",
       "test/application-runtime-disposal.test.ts",

--- a/docs/adr/0050-harness-github-operation-coordinator.md
+++ b/docs/adr/0050-harness-github-operation-coordinator.md
@@ -1,0 +1,9 @@
+# Process-local GitHub Operation Coordinator
+
+Each Harness application runtime owns one scoped **GitHub Operation Coordinator**. It admits exactly one replay-safe **Harness GitHub Operation** at a time across that runtime's ambient GitHub GraphQL and REST activity. The permit spans the complete operation, including credential acquisition, pagination, fallback requests, and sequential mutations; an active operation is never preempted and releases the permit only when it settles.
+
+Admission accepts a closed semantic origin rather than a numeric priority: Operator, Lifecycle, Polling, or Background. Normal admission follows that order with FIFO within each origin. When any request has waited 60 seconds, the globally oldest waiting request is admitted next. Cancellation before admission removes the operation; cancellation after dispatch does not revoke its permit. Successful local cache hits remain outside the coordinator because they make no GitHub request. Every operation is replay-safe: it is idempotent or revalidates the relevant remote postcondition before replaying a mutation.
+
+The coordinator is deliberately neither a host-wide queue nor a rate limiter. Its scope is one Harness runtime and it performs no proactive quota budgeting or ordinary pacing. Agent Turn GitHub access, other Harness runtimes, unrelated shells and applications, git transport, and GitHub Actions remain best-effort traffic outside the guarantee. The fixed concurrency of one is not Harness Config.
+
+The initial implementation traces the complete ambient credential path. Later work brings Keymaxxer-backed helpers and typed GitHub-throttle postponement behind the same runtime-scoped coordinator without changing this permit contract.

--- a/ontology/context.ttl
+++ b/ontology/context.ttl
@@ -372,6 +372,50 @@ rfa:OperatorForgeUser
   rfa:avoidanceRationale "CONTEXT.md prefers Operator Forge User for this concept."@en ;
 ] .
 
+rfa:HarnessGitHubOperation
+  a owl:Class, skos:Concept, rfa:ContextTerm ;
+  skos:prefLabel "Harness GitHub Operation"@en ;
+  skos:definition "One replay-safe Harness-native action that may make one or more sequential GitHub GraphQL or REST requests while holding one GitHub Operation Coordinator permit. A successful local cache hit is not a Harness GitHub Operation because it creates no GitHub traffic; each operation must be idempotent or revalidate its remote postcondition before a mutation can be replayed."@en ;
+  skos:hiddenLabel "GitHub request"@en, "GitHub task"@en .
+
+[
+  a owl:Axiom ;
+  owl:annotatedSource rfa:HarnessGitHubOperation ;
+  owl:annotatedProperty skos:hiddenLabel ;
+  owl:annotatedTarget "GitHub request"@en ;
+  rfa:avoidanceRationale "one operation may make multiple sequential requests"@en ;
+] .
+
+[
+  a owl:Axiom ;
+  owl:annotatedSource rfa:HarnessGitHubOperation ;
+  owl:annotatedProperty skos:hiddenLabel ;
+  owl:annotatedTarget "GitHub task"@en ;
+  rfa:avoidanceRationale "task is overloaded by Work Item and agent execution vocabulary"@en ;
+] .
+
+rfa:GitHubOperationCoordinator
+  a owl:Class, skos:Concept, rfa:ContextTerm ;
+  skos:prefLabel "GitHub Operation Coordinator"@en ;
+  skos:definition "The process-local Harness module that admits exactly one Harness GitHub Operation at a time for one application runtime. Callers choose only Operator, Lifecycle, Polling, or Background origin; normal admission is in that order with FIFO within an origin, and the globally oldest request is admitted after 60 seconds. The permit remains held through the entire active operation and is never preempted. This is not a host-wide queue or a proactive rate limiter: Agent Turns, other Harness runtimes, operator shells, Git transport, and GitHub Actions remain best-effort exclusions."@en ;
+  skos:hiddenLabel "Global GitHub queue"@en, "rate limiter"@en .
+
+[
+  a owl:Axiom ;
+  owl:annotatedSource rfa:GitHubOperationCoordinator ;
+  owl:annotatedProperty skos:hiddenLabel ;
+  owl:annotatedTarget "Global GitHub queue"@en ;
+  rfa:avoidanceRationale "the guarantee is scoped to one Harness runtime"@en ;
+] .
+
+[
+  a owl:Axiom ;
+  owl:annotatedSource rfa:GitHubOperationCoordinator ;
+  owl:annotatedProperty skos:hiddenLabel ;
+  owl:annotatedTarget "rate limiter"@en ;
+  rfa:avoidanceRationale "it serializes operations without proactive quota budgeting or ordinary pacing"@en ;
+] .
+
 rfa:Issue
   a owl:Class, skos:Concept, rfa:ContextTerm ;
   skos:prefLabel "Issue"@en ;

--- a/packages/github-service/src/lib/github-service.ts
+++ b/packages/github-service/src/lib/github-service.ts
@@ -18,6 +18,22 @@ import type {
   ReadyLabeledIssue,
 } from "./types.js"
 
+/**
+ * Semantic source used by the harness to order GitHub API operations.
+ *
+ * This is deliberately a closed set: callers express why the operation is
+ * happening, while the harness owns scheduling policy and numeric priorities.
+ */
+export type GitHubOperationOrigin =
+  | "operator"
+  | "lifecycle"
+  | "polling"
+  | "background"
+
+export interface GitHubOperationOptions {
+  readonly origin: GitHubOperationOrigin
+}
+
 export interface GitHubServiceShape {
   /**
    * Login of the authenticated principal for this Repository's credential
@@ -25,12 +41,14 @@ export interface GitHubServiceShape {
    */
   readonly getAuthenticatedUserLogin: (
     repository: GitHubRepository,
+    options?: GitHubOperationOptions,
   ) => Effect.Effect<
     string,
     GitHubRepositoryUnavailableError | GitHubRequestError
   >
   readonly listReadyIssues: (
     repository: GitHubRepository,
+    options?: GitHubOperationOptions,
   ) => Effect.Effect<
     readonly ReadyLabeledIssue[],
     GitHubRepositoryUnavailableError | GitHubRequestError

--- a/packages/issue-reconciler/src/lib/issue-reconciler.ts
+++ b/packages/issue-reconciler/src/lib/issue-reconciler.ts
@@ -7,6 +7,7 @@ import {
   type RepositoryRecord,
 } from "@ready-for-agent/db-service"
 import {
+  type GitHubOperationOptions,
   type GitHubRepositoryUnavailableError,
   type GitHubRequestError,
   GitHubService,
@@ -58,9 +59,15 @@ export type ReconciliationError =
   | RepositoryNotFoundError
   | DatabaseError
 
+export interface ReconciliationOptions {
+  /** Semantic source for GitHub reads made during reconciliation. */
+  readonly githubOperation?: GitHubOperationOptions
+}
+
 export interface IssueReconcilerShape {
   readonly reconcile: (
     repository: RepositoryRecord,
+    options?: ReconciliationOptions,
   ) => Effect.Effect<ReconciliationSummary, ReconciliationError>
 }
 
@@ -98,6 +105,7 @@ export const IssueReconcilerLive = Layer.effect(
 
     const reconcile = Effect.fn("IssueReconciler.reconcile")(function* (
       repository: RepositoryRecord,
+      options?: ReconciliationOptions,
     ) {
       const forgeRepository = {
         forge: repository.forge,
@@ -108,15 +116,20 @@ export const IssueReconcilerLive = Layer.effect(
       const workItemPullRequests = yield* db.listWorkItemPullRequests(
         repository.id,
       )
-      const issueSource = repository.forge === "gitlab" ? gitlab : github
       const authorScope = repository.includeAllIssueAuthors
         ? ({ includeAll: true } as const)
         : ({
             includeAll: false,
-            operatorLogin:
-              yield* issueSource.getAuthenticatedUserLogin(forgeRepository),
+            operatorLogin: yield* repository.forge === "gitlab"
+              ? gitlab.getAuthenticatedUserLogin(forgeRepository)
+              : github.getAuthenticatedUserLogin(
+                  forgeRepository,
+                  options?.githubOperation,
+                ),
           } as const)
-      const remoteIssues = yield* issueSource.listReadyIssues(forgeRepository)
+      const remoteIssues = yield* repository.forge === "gitlab"
+        ? gitlab.listReadyIssues(forgeRepository)
+        : github.listReadyIssues(forgeRepository, options?.githubOperation)
       const repositoryName = repository.projectPath.toLowerCase()
 
       const localByNumber = new Map(


### PR DESCRIPTION
Implements #873’s process-scoped GitHub Operation Coordinator for ambient Harness GitHub
traffic.

The coordinator admits one replay-safe operation at a time with semantic
Operator/Lifecycle/Polling/Background priority, FIFO ordering, 60-second
starvation aging, pending cancellation, and non-preempted active operations.
The ambient GitHub adapter now routes every service operation through that
permit, including credential refresh paths.

Manual Refresh Jobs preserve the `operator` origin through reconciliation;
scheduled refreshes use `polling`. The semantic-origin option is closed and
requires an origin when supplied. Added ontology glossary terms and ADR 0050
documenting scope, replay-safety, and exclusions.

Verification: `bunx nx run harness:typecheck`; `bunx nx run harness:test`
(630 passing tests); Biome and diff checks passed.

Closes #873