### PR TITLE
feat(lifecycle): model postponed GitHub waits

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -287,6 +287,10 @@ _Avoid_: Queued (alone), Waiting for Worker Slot, blocked Issue (the Issue is bl
 The state of an unfinished, non-paused Work Item that is not Waiting for blockers and has not yet been Admitted because all Worker Slots are occupied. It does not occupy a Worker Slot and has no Step Run and no lifecycle job until admission. Operators may create more Work Items than the Worker Slot bound with no separate cap on how many may wait; those extras remain Waiting for Worker Slot until admitted **FIFO by time entered this state** (creation time if never admitted; re-queue time after Start when no slot was free; the same creation time applies when a former Waiting for blockers Work Item joins this line). No priority by Repository, Issue age, or operator. Operator-visible status is Waiting for worker slot with a message that a worker slot must become available; the current Lifecycle Step is unchanged and is not queued until admission.
 _Avoid_: Queued Step Run, paused, Not Implemented, Waiting for blockers
 
+**Waiting for GitHub**:
+A derived Work Item hold whose latest Step Run is a Postponed Step Run with a durable wake contract and retry deadline. It is not a Lifecycle Step, Work Item state, Queue hold, or Worker Slot wait: the Work Item remains in its current pipeline lane, holds no Worker Slot, and owns no queued or running Step Run. It clears only when later lifecycle progress supersedes that Postponed history; Pause, Waiting for blockers, and Waiting for Worker Slot take presentation precedence.
+_Avoid_: Queue, Waiting for Worker Slot, paused, Work Item state
+
 **Implement Now**:
 An explicit operator request that creates a Work Item for an Actionable Issue and seeks Worker Slot admission immediately. Work Items are not created automatically by Issue reconciliation or eligibility discovery. Creation is allowed when all Worker Slots are occupied; the new Work Item is then Waiting for Worker Slot rather than rejected. Creation is hard-blocked while the Repository's effective Agent Backend is Unavailable or no build Agent Model can be resolved for that backend from Repository settings or Harness Config (`Select a default build model first`). Distinct from Queue, which creates a Work Item only for a blocked open leaf and holds it until Implementable.
 _Avoid_: Auto-implement, enqueue Issue, Queue
@@ -398,11 +402,15 @@ A highest-priority request given to the Work Item's Implement Session by Resolve
 _Avoid_: PR Status Check, conflict status check
 
 **Step Run**:
-A durable record of one scheduled execution attempt for a Work Item's Lifecycle Step, created when that attempt is queued and recording when it starts, finishes, and succeeds, fails, is interrupted, or is cancelled before starting. Retried steps produce additional Step Runs rather than replacing earlier attempts, allowing queue wait and execution duration to be measured separately.
+A durable record of one scheduled execution attempt for a Work Item's Lifecycle Step, created when that attempt is queued and recording when it starts, finishes, and succeeds, fails, is interrupted, is postponed, or is cancelled before starting. Retried steps produce additional Step Runs rather than replacing earlier attempts, allowing queue wait and execution duration to be measured separately.
 _Avoid_: Step duration, job attempt
 
+**Postponed Step Run**:
+A finished Step Run outcome that records `postponed` and one retry deadline (`postponedUntil`) because its next GitHub attempt must wait. It is immutable history, not a failed or successful attempt, and it cannot be retried manually; a later durable wake creates a fresh Step Run through ordinary admission. A Postponed Step Run derives Waiting for GitHub without adding a Work Item lifecycle state or hold flag.
+_Avoid_: Deferred Review Finding, Queued Step Run, Retry, Failed Step Run
+
 **Retry**:
-An explicit operator request to create a new Step Run for a Work Item whose previous run failed. Lifecycle failures are not retried automatically. A failed Step Run has already released the Worker Slot; Retry must re-acquire a Worker Slot, and if none is free the Work Item becomes Waiting for Worker Slot with no Step Run until re-admission. A Needs Human outcome from Investigate PR Status Checks is also retryable: Retry clears the handoff reason, reopens the exact Status Check Handoff consumed by that attempt, and runs Investigate again in the existing Implement Session. A Needs Human outcome from exhausting Review Fix Rounds is also retryable: Retry clears the reason, resets the round counter, and re-enters Review at a fresh reviewing pass in the existing Implement Session. Persisted terminal Failed records with failure code `pr_status_checks_unresolved` from older harness behavior remain retryable by restoring Watch PR Status Checks. Retry is not allowed while a Work Item is paused; the operator must Start first.
+An explicit operator request to create a new Step Run for a Work Item whose previous run failed. Lifecycle failures are not retried automatically. A failed Step Run has already released the Worker Slot; Retry must re-acquire a Worker Slot, and if none is free the Work Item becomes Waiting for Worker Slot with no Step Run until re-admission. A Needs Human outcome from Investigate PR Status Checks is also retryable: Retry clears the handoff reason, reopens the exact Status Check Handoff consumed by that attempt, and runs Investigate again in the existing Implement Session. A Needs Human outcome from exhausting Review Fix Rounds is also retryable: Retry clears the reason, resets the round counter, and re-enters Review at a fresh reviewing pass in the existing Implement Session. Persisted terminal Failed records with failure code `pr_status_checks_unresolved` from older harness behavior remain retryable by restoring Watch PR Status Checks. Retry is unavailable for a Postponed Step Run and while a Work Item is paused; the operator must Start first.
 _Avoid_: Queue redelivery, resume
 
 **Pause Work Item**:
@@ -418,7 +426,7 @@ A transition that moves a Work Item with no running Step Run to the terminal Aba
 _Avoid_: Delete, cancel
 
 **Reset**:
-An operator-directed erasure of a Work Item that stops queued or running Step Runs, removes the Git worktree and branch, and deletes the Work Item and its Step Run history so the Issue returns to Not Implemented. Unlike Abandon, Reset does not preserve history. Reset is allowed while paused, Waiting for Worker Slot, or Waiting for blockers and removes the Work Item entirely, releasing a Worker Slot if one was held (including when a Step Run is still finishing after Pause). Waiting for blockers has no worktree yet; Reset is the operator cancel for a queued intent.
+An operator-directed erasure of a Work Item that stops queued or running Step Runs, removes the Git worktree and branch, and deletes the Work Item and its Step Run history so the Issue returns to Not Implemented. Unlike Abandon, Reset does not preserve history. Reset is allowed while paused, Waiting for GitHub, Waiting for Worker Slot, or Waiting for blockers and removes the Work Item entirely, releasing a Worker Slot if one was held (including when a Step Run is still finishing after Pause). Waiting for blockers has no worktree yet; Reset is the operator cancel for a queued intent.
 _Avoid_: Abandon, Retry, cancel
 
 **Failed Work Item**:

--- a/apps/harness/src/home-page-content.tsx
+++ b/apps/harness/src/home-page-content.tsx
@@ -252,12 +252,14 @@ type WorkItemStatus =
   | "FAILED"
   | "INTERRUPTED"
   | "CANCELLED"
+  | "POSTPONED"
   | "COMPLETE"
   | "ABANDONED"
   | "NEEDS_HUMAN"
   | "NEEDS_HUMAN_REVIEW"
   | "WAITING_FOR_WORKER_SLOT"
   | "WAITING_FOR_BLOCKERS"
+  | "WAITING_FOR_GITHUB"
 
 export type WorkItem = {
   id: string
@@ -271,6 +273,7 @@ export type WorkItem = {
   status: WorkItemStatus
   statusLabel: string
   statusMessage: string | null
+  postponedUntil: string | null
   paused: boolean
   canRetry: boolean
   isTerminal: boolean
@@ -301,6 +304,7 @@ const workItemFields = {
   status: true,
   statusLabel: true,
   statusMessage: true,
+  postponedUntil: true,
   paused: true,
   canRetry: true,
   isTerminal: true,
@@ -3397,7 +3401,10 @@ export function WorkItemLifecycleStatus({
         ? `${lifecycleLabel.label} · ${formatDuration(displayDurationMs)}`
         : lifecycleLabel.label
     return (
-      <li key={lifecycleLabel.phase} className="flex min-w-0 max-w-full">
+      <li
+        key={`${lifecycleLabel.phase}-${lifecycleLabel.label}`}
+        className="flex min-w-0 max-w-full"
+      >
         {linkToPullRequest ? (
           <a
             className={`${chipClassName} hover:underline`}

--- a/apps/harness/src/work-item-progress-chrome.ts
+++ b/apps/harness/src/work-item-progress-chrome.ts
@@ -72,7 +72,8 @@ export function statusBadgeClassNameForStatus(status: string): string {
         : status === "ABANDONED" || status === "CANCELLED"
           ? ui.statusTagGhost
           : status === "WAITING_FOR_WORKER_SLOT" ||
-              status === "WAITING_FOR_BLOCKERS"
+              status === "WAITING_FOR_BLOCKERS" ||
+              status === "WAITING_FOR_GITHUB"
             ? ui.statusTagHold
             : ui.statusTagPlain
   return cx(statusBadgeBaseClassName, tone)

--- a/apps/harness/test/pipeline-lanes.test.ts
+++ b/apps/harness/test/pipeline-lanes.test.ts
@@ -130,6 +130,11 @@ describe("pipelineLaneFor", () => {
       lane: "pr",
     },
     {
+      state: "WATCH_PR_STATUS_CHECKS",
+      status: "WAITING_FOR_GITHUB",
+      lane: "pr",
+    },
+    {
       state: "RESOLVE_PR_MERGE_CONFLICT",
       status: "RUNNING",
       lane: "pr",

--- a/apps/harness/test/repos-interchange.test.ts
+++ b/apps/harness/test/repos-interchange.test.ts
@@ -274,7 +274,7 @@ describe("Interchange phase 4: repos page + blank slate", () => {
       "const renderChipList =",
     )
     expect(chipRenderer).toContain(
-      '<li key={lifecycleLabel.phase} className="flex min-w-0 max-w-full">',
+      `key={\`\${lifecycleLabel.phase}-\${lifecycleLabel.label}\`}`,
     )
     expect(ui).toMatch(
       /lifecycleLegRowClasses\s*=\s*"flex flex-wrap items-start gap-\[0\.35rem\]"/,

--- a/apps/harness/test/work-item-lifecycle-status.test.tsx
+++ b/apps/harness/test/work-item-lifecycle-status.test.tsx
@@ -1,0 +1,55 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { renderToStaticMarkup } from "react-dom/server"
+import {
+  type WorkItem,
+  WorkItemLifecycleStatus,
+} from "../src/home-page-content.js"
+import { describe, expect, test } from "bun:test"
+
+const waitingForGitHubWorkItem = {
+  id: "wi-01J00000000000000000000000",
+  repositoryId: "repo-1",
+  issueNumber: 874,
+  issueTitle: "Model Postponed Step Runs and Waiting for GitHub",
+  pullRequestNumber: 42,
+  agentBackend: { id: "opencode", label: "OpenCode" },
+  state: "WATCH_PR_STATUS_CHECKS",
+  stateLabel: "GitHub status checks",
+  status: "WAITING_FOR_GITHUB",
+  statusLabel: "Waiting for GitHub",
+  statusMessage: "Waiting for GitHub until 2026-08-07T12:00:00.000Z",
+  postponedUntil: "2026-08-07T12:00:00.000Z",
+  paused: false,
+  canRetry: false,
+  isTerminal: false,
+  failureCode: null,
+  sessionId: null,
+  worktreePath: null,
+  completionSummary: null,
+  createdAt: "2026-08-07T11:00:00.000Z",
+  stateReadyAt: "2026-08-07T11:00:00.000Z",
+  lifecycleLabels: [
+    {
+      phase: "GITHUB_STATUS_CHECKS",
+      label: "GitHub status checks: Postponed",
+      status: "POSTPONED",
+      durationMs: 0,
+    },
+  ],
+} satisfies WorkItem
+
+describe("WorkItemLifecycleStatus", () => {
+  test("renders the GitHub hold, retry deadline, and Postponed history without Retry", () => {
+    const queryClient = new QueryClient()
+    const html = renderToStaticMarkup(
+      <QueryClientProvider client={queryClient}>
+        <WorkItemLifecycleStatus workItem={waitingForGitHubWorkItem} compact />
+      </QueryClientProvider>,
+    )
+
+    expect(html).toContain("Waiting for GitHub")
+    expect(html).toContain("Waiting for GitHub until 2026-08-07T12:00:00.000Z")
+    expect(html).toContain("GitHub status checks: Postponed")
+    expect(html).not.toContain(">Retry<")
+  })
+})

--- a/apps/harness/test/work-item-progress-chrome.test.ts
+++ b/apps/harness/test/work-item-progress-chrome.test.ts
@@ -68,18 +68,21 @@ describe("work-item-progress-chrome", () => {
     )
   })
 
-  test("Waiting for blockers and worker slot share hold treatment, distinct from Queued", () => {
+  test("all derived waits share hold treatment, distinct from Queued", () => {
     const blockers = statusBadgeClassNameForStatus("WAITING_FOR_BLOCKERS")
     const workerSlot = statusBadgeClassNameForStatus("WAITING_FOR_WORKER_SLOT")
+    const github = statusBadgeClassNameForStatus("WAITING_FOR_GITHUB")
     const queued = statusBadgeClassNameForStatus("QUEUED")
     const running = statusBadgeClassNameForStatus("RUNNING")
 
     expect(blockers).toBe(cx(ui.statusTag, ui.statusTagHold))
     expect(workerSlot).toBe(cx(ui.statusTag, ui.statusTagHold))
+    expect(github).toBe(cx(ui.statusTag, ui.statusTagHold))
     expect(queued).toBe(cx(ui.statusTag, ui.statusTagPlain))
     expect(running).toBe(cx(ui.statusTag, ui.statusTagPlain))
 
     expect(blockers).toBe(workerSlot)
+    expect(blockers).toBe(github)
     expect(blockers).not.toBe(queued)
     expect(blockers).not.toBe(running)
   })

--- a/ontology/context.ttl
+++ b/ontology/context.ttl
@@ -1863,6 +1863,44 @@ rfa:WaitingForWorkerSlot
   rfa:avoidanceRationale "CONTEXT.md prefers Waiting for Worker Slot for this concept."@en ;
 ] .
 
+rfa:WaitingForGitHub
+  a owl:Class, skos:Concept, rfa:ContextTerm ;
+  skos:prefLabel "Waiting for GitHub"@en ;
+  skos:definition "A derived Work Item hold whose latest Step Run is a Postponed Step Run with a durable wake contract and retry deadline. It is not a Lifecycle Step, Work Item state, Queue hold, or Worker Slot wait: the Work Item remains in its current pipeline lane, holds no Worker Slot, and owns no queued or running Step Run. It clears only when later lifecycle progress supersedes that Postponed history; Pause, Waiting for blockers, and Waiting for Worker Slot take presentation precedence."@en ;
+  skos:hiddenLabel "Queue"@en, "Waiting for Worker Slot"@en, "paused"@en, "Work Item state"@en .
+
+[
+  a owl:Axiom ;
+  owl:annotatedSource rfa:WaitingForGitHub ;
+  owl:annotatedProperty skos:hiddenLabel ;
+  owl:annotatedTarget "Queue"@en ;
+  rfa:avoidanceRationale "CONTEXT.md prefers Waiting for GitHub for this concept."@en ;
+] .
+
+[
+  a owl:Axiom ;
+  owl:annotatedSource rfa:WaitingForGitHub ;
+  owl:annotatedProperty skos:hiddenLabel ;
+  owl:annotatedTarget "Waiting for Worker Slot"@en ;
+  rfa:avoidanceRationale "Waiting for GitHub is an independent hold."@en ;
+] .
+
+[
+  a owl:Axiom ;
+  owl:annotatedSource rfa:WaitingForGitHub ;
+  owl:annotatedProperty skos:hiddenLabel ;
+  owl:annotatedTarget "paused"@en ;
+  rfa:avoidanceRationale "Pause is an explicit operator instruction with higher presentation precedence."@en ;
+] .
+
+[
+  a owl:Axiom ;
+  owl:annotatedSource rfa:WaitingForGitHub ;
+  owl:annotatedProperty skos:hiddenLabel ;
+  owl:annotatedTarget "Work Item state"@en ;
+  rfa:avoidanceRationale "Waiting for GitHub is derived from Step Run history rather than persisted as a lifecycle state."@en ;
+] .
+
 rfa:ImplementNow
   a owl:Class, skos:Concept, rfa:ContextTerm ;
   skos:prefLabel "Implement Now"@en ;
@@ -2328,7 +2366,7 @@ rfa:MergeConflictHandoff
 rfa:StepRun
   a owl:Class, skos:Concept, rfa:ContextTerm ;
   skos:prefLabel "Step Run"@en ;
-  skos:definition "A durable record of one scheduled execution attempt for a Work Item's Lifecycle Step, created when that attempt is queued and recording when it starts, finishes, and succeeds, fails, is interrupted, or is cancelled before starting. Retried steps produce additional Step Runs rather than replacing earlier attempts, allowing queue wait and execution duration to be measured separately."@en ;
+  skos:definition "A durable record of one scheduled execution attempt for a Work Item's Lifecycle Step, created when that attempt is queued and recording when it starts, finishes, and succeeds, fails, is interrupted, is postponed, or is cancelled before starting. Retried steps produce additional Step Runs rather than replacing earlier attempts, allowing queue wait and execution duration to be measured separately."@en ;
   skos:hiddenLabel "Step duration"@en, "job attempt"@en .
 
 [
@@ -2347,10 +2385,48 @@ rfa:StepRun
   rfa:avoidanceRationale "CONTEXT.md prefers Step Run for this concept."@en ;
 ] .
 
+rfa:PostponedStepRun
+  a owl:Class, skos:Concept, rfa:ContextTerm ;
+  skos:prefLabel "Postponed Step Run"@en ;
+  skos:definition "A finished Step Run outcome that records `postponed` and one retry deadline (`postponedUntil`) because its next GitHub attempt must wait. It is immutable history, not a failed or successful attempt, and it cannot be retried manually; a later durable wake creates a fresh Step Run through ordinary admission. A Postponed Step Run derives Waiting for GitHub without adding a Work Item lifecycle state or hold flag."@en ;
+  skos:hiddenLabel "Deferred Review Finding"@en, "Queued Step Run"@en, "Retry"@en, "Failed Step Run"@en .
+
+[
+  a owl:Axiom ;
+  owl:annotatedSource rfa:PostponedStepRun ;
+  owl:annotatedProperty skos:hiddenLabel ;
+  owl:annotatedTarget "Deferred Review Finding"@en ;
+  rfa:avoidanceRationale "Review Findings may be deferred, but a Postponed Step Run is an execution outcome."@en ;
+] .
+
+[
+  a owl:Axiom ;
+  owl:annotatedSource rfa:PostponedStepRun ;
+  owl:annotatedProperty skos:hiddenLabel ;
+  owl:annotatedTarget "Queued Step Run"@en ;
+  rfa:avoidanceRationale "Postponed is a finished outcome and has no active queue job."@en ;
+] .
+
+[
+  a owl:Axiom ;
+  owl:annotatedSource rfa:PostponedStepRun ;
+  owl:annotatedProperty skos:hiddenLabel ;
+  owl:annotatedTarget "Retry"@en ;
+  rfa:avoidanceRationale "The durable wake, rather than an operator Retry, creates a fresh attempt."@en ;
+] .
+
+[
+  a owl:Axiom ;
+  owl:annotatedSource rfa:PostponedStepRun ;
+  owl:annotatedProperty skos:hiddenLabel ;
+  owl:annotatedTarget "Failed Step Run"@en ;
+  rfa:avoidanceRationale "Postponed is an independent finished outcome, not a failure."@en ;
+] .
+
 rfa:Retry
   a owl:Class, skos:Concept, rfa:ContextTerm ;
   skos:prefLabel "Retry"@en ;
-  skos:definition "An explicit operator request to create a new Step Run for a Work Item whose previous run failed. Lifecycle failures are not retried automatically. A failed Step Run has already released the Worker Slot; Retry must re-acquire a Worker Slot, and if none is free the Work Item becomes Waiting for Worker Slot with no Step Run until re-admission. A Needs Human outcome from Investigate PR Status Checks is also retryable: Retry clears the handoff reason, reopens the exact Status Check Handoff consumed by that attempt, and runs Investigate again in the existing Implement Session. A Needs Human outcome from exhausting Review Fix Rounds is also retryable: Retry clears the reason, resets the round counter, and re-enters Review at a fresh reviewing pass in the existing Implement Session. Persisted terminal Failed records with failure code `pr_status_checks_unresolved` from older harness behavior remain retryable by restoring Watch PR Status Checks. Retry is not allowed while a Work Item is paused; the operator must Start first."@en ;
+  skos:definition "An explicit operator request to create a new Step Run for a Work Item whose previous run failed. Lifecycle failures are not retried automatically. A failed Step Run has already released the Worker Slot; Retry must re-acquire a Worker Slot, and if none is free the Work Item becomes Waiting for Worker Slot with no Step Run until re-admission. A Needs Human outcome from Investigate PR Status Checks is also retryable: Retry clears the handoff reason, reopens the exact Status Check Handoff consumed by that attempt, and runs Investigate again in the existing Implement Session. A Needs Human outcome from exhausting Review Fix Rounds is also retryable: Retry clears the reason, resets the round counter, and re-enters Review at a fresh reviewing pass in the existing Implement Session. Persisted terminal Failed records with failure code `pr_status_checks_unresolved` from older harness behavior remain retryable by restoring Watch PR Status Checks. Retry is unavailable for a Postponed Step Run and while a Work Item is paused; the operator must Start first."@en ;
   skos:hiddenLabel "Queue redelivery"@en, "resume"@en .
 
 [
@@ -2478,7 +2554,7 @@ rfa:Abandon
 rfa:Reset
   a owl:Class, skos:Concept, rfa:ContextTerm ;
   skos:prefLabel "Reset"@en ;
-  skos:definition "An operator-directed erasure of a Work Item that stops queued or running Step Runs, removes the Git worktree and branch, and deletes the Work Item and its Step Run history so the Issue returns to Not Implemented. Unlike Abandon, Reset does not preserve history. Reset is allowed while paused, Waiting for Worker Slot, or Waiting for blockers and removes the Work Item entirely, releasing a Worker Slot if one was held (including when a Step Run is still finishing after Pause). Waiting for blockers has no worktree yet; Reset is the operator cancel for a queued intent."@en ;
+  skos:definition "An operator-directed erasure of a Work Item that stops queued or running Step Runs, removes the Git worktree and branch, and deletes the Work Item and its Step Run history so the Issue returns to Not Implemented. Unlike Abandon, Reset does not preserve history. Reset is allowed while paused, Waiting for GitHub, Waiting for Worker Slot, or Waiting for blockers and removes the Work Item entirely, releasing a Worker Slot if one was held (including when a Step Run is still finishing after Pause). Waiting for blockers has no worktree yet; Reset is the operator cancel for a queued intent."@en ;
   skos:hiddenLabel "Abandon"@en, "Retry"@en, "cancel"@en .
 
 [

--- a/packages/db-schema/drizzle/20260807100000_postponed_step_runs/migration.sql
+++ b/packages/db-schema/drizzle/20260807100000_postponed_step_runs/migration.sql
@@ -1,0 +1,20 @@
+ALTER TABLE `step_run` ADD `postponed_until` integer;--> statement-breakpoint
+
+-- `postponed_until` is an outcome attribute, not a second Work Item hold.
+-- SQLite cannot add a CHECK constraint to an existing table, so enforce the
+-- same invariant for both new rows and later outcome updates at the boundary.
+CREATE TRIGGER `step_run_postponed_until_insert`
+BEFORE INSERT ON `step_run`
+WHEN (NEW.`status` = 'postponed' AND (NEW.`finished_at` IS NULL OR NEW.`postponed_until` IS NULL))
+  OR (NEW.`status` <> 'postponed' AND NEW.`postponed_until` IS NOT NULL)
+BEGIN
+  SELECT RAISE(ABORT, 'step_run_postponed_until_invariant');
+END;--> statement-breakpoint
+
+CREATE TRIGGER `step_run_postponed_until_update`
+BEFORE UPDATE OF `status`, `finished_at`, `postponed_until` ON `step_run`
+WHEN (NEW.`status` = 'postponed' AND (NEW.`finished_at` IS NULL OR NEW.`postponed_until` IS NULL))
+  OR (NEW.`status` <> 'postponed' AND NEW.`postponed_until` IS NOT NULL)
+BEGIN
+  SELECT RAISE(ABORT, 'step_run_postponed_until_invariant');
+END;

--- a/packages/db-schema/src/schema.ts
+++ b/packages/db-schema/src/schema.ts
@@ -352,6 +352,7 @@ export const stepRun = snakeCase.table(
         "failed",
         "interrupted",
         "cancelled",
+        "postponed",
       ],
     }).notNull(),
     queueJobId: text(),
@@ -360,6 +361,8 @@ export const stepRun = snakeCase.table(
     finishedAt: integer({ mode: "number" }),
     reasonCode: text(),
     reasonMessage: text(),
+    /** Present exactly when this finished Step Run was postponed for GitHub. */
+    postponedUntil: integer({ mode: "number" }),
     /**
      * Cumulative ms spent blocked on an OpenCode session slot (completed waits).
      * Excluded from max-duration / visibility-lease productive time.

--- a/packages/db/test/run-migrations.spec.ts
+++ b/packages/db/test/run-migrations.spec.ts
@@ -102,6 +102,7 @@ describe("runMigrations", () => {
           { name: "20260729120000_work_item_publication_copy" },
           { name: "20260729160000_forge_identity_foundation" },
           { name: "20260730140857_unfinished_work_item_index" },
+          { name: "20260807100000_postponed_step_runs" },
         ])
       }).pipe(Effect.provide(SqliteTest)),
     )
@@ -943,6 +944,89 @@ describe("runMigrations", () => {
         expect(rows).toEqual([
           { id: "repo-1", wait_for_ready_for_review_checks: 1 },
           { id: "repo-2", wait_for_ready_for_review_checks: 1 },
+        ])
+      }).pipe(Effect.provide(SqliteTest)),
+    )
+  })
+
+  it("enforces Postponed Step Run deadlines", async () => {
+    const migrationSql = await readFile(
+      join(
+        import.meta.dir,
+        "../../db-schema/drizzle/20260807100000_postponed_step_runs/migration.sql",
+      ),
+      "utf8",
+    )
+
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        const sql = yield* SqlClient.SqlClient
+        yield* sql.unsafe(
+          `CREATE TABLE step_run (
+             id text PRIMARY KEY,
+             status text NOT NULL,
+             finished_at integer
+           )`,
+        )
+        for (const statement of migrationSql.split(
+          "--> statement-breakpoint",
+        )) {
+          if (statement.trim().length > 0) {
+            yield* sql.unsafe(statement)
+          }
+        }
+
+        yield* sql.unsafe(
+          `INSERT INTO step_run (id, status, finished_at, postponed_until)
+           VALUES ('queued', 'queued', NULL, NULL), ('postponed', 'postponed', 122, 123)`,
+        )
+
+        const missingDeadline = yield* Effect.exit(
+          sql.unsafe(
+            `INSERT INTO step_run (id, status, finished_at, postponed_until)
+             VALUES ('missing-deadline', 'postponed', 122, NULL)`,
+          ),
+        )
+        const missingFinishedAt = yield* Effect.exit(
+          sql.unsafe(
+            `INSERT INTO step_run (id, status, finished_at, postponed_until)
+             VALUES ('missing-finished-at', 'postponed', NULL, 123)`,
+          ),
+        )
+        const strayDeadline = yield* Effect.exit(
+          sql.unsafe(
+            `INSERT INTO step_run (id, status, finished_at, postponed_until)
+             VALUES ('stray-deadline', 'queued', NULL, 123)`,
+          ),
+        )
+        const clearingFinishedAt = yield* Effect.exit(
+          sql.unsafe(
+            `UPDATE step_run SET finished_at = NULL WHERE id = 'postponed'`,
+          ),
+        )
+
+        expect(missingDeadline._tag).toBe("Failure")
+        expect(missingFinishedAt._tag).toBe("Failure")
+        expect(strayDeadline._tag).toBe("Failure")
+        expect(clearingFinishedAt._tag).toBe("Failure")
+        expect(
+          yield* sql.unsafe(
+            `SELECT id, status, finished_at, postponed_until
+             FROM step_run ORDER BY id`,
+          ),
+        ).toEqual([
+          {
+            id: "postponed",
+            status: "postponed",
+            finished_at: 122,
+            postponed_until: 123,
+          },
+          {
+            id: "queued",
+            status: "queued",
+            finished_at: null,
+            postponed_until: null,
+          },
         ])
       }).pipe(Effect.provide(SqliteTest)),
     )

--- a/packages/graphql-api/src/lib/graphql-api.ts
+++ b/packages/graphql-api/src/lib/graphql-api.ts
@@ -71,6 +71,7 @@ import {
   workIssueProjection,
   workItemCanRetry,
   workItemIsTerminal,
+  workItemPostponedUntil,
   workItemStateLabel,
   workItemStatus,
   workItemStatusMessage,
@@ -849,6 +850,8 @@ export const createGraphqlApi = (
               }).pipe(Effect.withSpan("graphql-api.WorkItem.statusMessage")),
             )
           },
+          postponedUntil: (workItem: WorkItemRecord) =>
+            workItemPostponedUntil(workItem)?.toISOString() ?? null,
           paused: (workItem: WorkItemRecord) => workItem.paused,
           canRetry: workItemCanRetry,
           isTerminal: workItemIsTerminal,

--- a/packages/graphql-api/src/lib/work-item-projection.ts
+++ b/packages/graphql-api/src/lib/work-item-projection.ts
@@ -59,12 +59,14 @@ export type WorkItemStatus =
   | "failed"
   | "interrupted"
   | "cancelled"
+  | "postponed"
   | "complete"
   | "abandoned"
   | "needs_human"
   | "needs_human_review"
   | "waiting_for_worker_slot"
   | "waiting_for_blockers"
+  | "waiting_for_github"
 
 type LifecyclePhase =
   | Exclude<
@@ -109,7 +111,9 @@ const lifecyclePhaseLabel = (phase: LifecyclePhase): string => {
 }
 
 export const statusLabel = (status: WorkItemStatus): string =>
-  status.replaceAll("_", " ").replace(/^./, (first) => first.toUpperCase())
+  status === "waiting_for_github"
+    ? "Waiting for GitHub"
+    : status.replaceAll("_", " ").replace(/^./, (first) => first.toUpperCase())
 
 const latestStepRun = (workItem: WorkItemRecord): StepRunRecord | undefined =>
   workItem.stepRuns.at(-1)
@@ -127,6 +131,43 @@ export const workItemIsTerminal = (
   workItem: WorkItemRecord,
 ): workItem is WorkItemRecord & { readonly state: TerminalWorkItemState } =>
   isTerminalWorkItemState(workItem.state)
+
+const hasActiveStepRunBeforeLatest = (workItem: WorkItemRecord): boolean =>
+  workItem.stepRuns
+    .slice(0, -1)
+    .some(
+      (stepRun) => stepRun.status === "queued" || stepRun.status === "running",
+    )
+
+/** Holds that always take precedence over a derived GitHub wait. */
+const higherPriorityWorkItemStatus = (
+  workItem: WorkItemRecord,
+): WorkItemStatus | null => {
+  if (workItemIsTerminal(workItem)) return workItem.state
+  if (workItem.waitingForBlockers) return "waiting_for_blockers"
+  if (workItem.waitingSince !== null) return "waiting_for_worker_slot"
+  if (workItem.paused) return "needs_human_review"
+  return null
+}
+
+/**
+ * The authoritative retry deadline is visible only while the Postponed Step
+ * Run forms the current GitHub hold. Higher-precedence holds and impossible
+ * active-resource combinations must not leak a stale wake deadline.
+ */
+export const workItemPostponedUntil = (
+  workItem: WorkItemRecord,
+): Date | null => {
+  if (
+    higherPriorityWorkItemStatus(workItem) !== null ||
+    workItem.holdsWorkerSlot ||
+    hasActiveStepRunBeforeLatest(workItem)
+  ) {
+    return null
+  }
+  const latest = latestStepRun(workItem)
+  return latest?.status === "postponed" ? latest.postponedUntil : null
+}
 
 export const workItemCanRetry = (workItem: WorkItemRecord): boolean => {
   if (
@@ -157,11 +198,9 @@ export const workItemCanRetry = (workItem: WorkItemRecord): boolean => {
 }
 
 export const workItemStatus = (workItem: WorkItemRecord): WorkItemStatus => {
-  // Terminal states always win over flags, which may lag UPDATE.
-  if (isTerminalWorkItemState(workItem.state)) return workItem.state
-  if (workItem.waitingForBlockers) return "waiting_for_blockers"
-  if (workItem.waitingSince != null) return "waiting_for_worker_slot"
-  if (workItem.paused) return "needs_human_review"
+  const higherPriorityStatus = higherPriorityWorkItemStatus(workItem)
+  if (higherPriorityStatus !== null) return higherPriorityStatus
+  if (workItemPostponedUntil(workItem) !== null) return "waiting_for_github"
   const latest = latestStepRun(workItem)
   if (latest === undefined) return "queued"
   return stepRunDisplayStatus(latest)
@@ -194,6 +233,13 @@ export const workItemStatusMessage = (
   }
   if (workItem.waitingSince != null) {
     return WAITING_FOR_WORKER_SLOT_MESSAGE
+  }
+  if (workItem.paused) {
+    return workItem.failureMessage
+  }
+  const postponedUntil = workItemPostponedUntil(workItem)
+  if (postponedUntil !== null) {
+    return `Waiting for GitHub until ${postponedUntil.toISOString()}`
   }
   if (workItem.failureMessage != null) {
     return workItem.failureMessage
@@ -246,7 +292,7 @@ export const lifecycleLabels = (workItem: WorkItemRecord) => {
       ? lifecyclePhase(finalStepRun.step)
       : null
 
-  return [...latestRuns].map(([phase, stepRun]) => {
+  return [...latestRuns].flatMap(([phase, stepRun]) => {
     const status: WorkItemStatus =
       phase === finalPhase ? "needs_human" : stepRunDisplayStatus(stepRun)
     const reviewRunningPhase =
@@ -279,12 +325,27 @@ export const lifecycleLabels = (workItem: WorkItemRecord) => {
                 stepRun.reasonCode !== STEP_RUN_REASON.mergeRevalidation
               ? "Merged"
               : statusLabel(status)
-    return {
+    const latestLabel = {
       phase: phase.toUpperCase(),
       label: `${lifecyclePhaseLabel(phase)}: ${outcome}`,
       status: status.toUpperCase(),
       durationMs: cumulativeExecutionDurationMs(runsByPhase.get(phase) ?? []),
     }
+    const priorPostponedCount = (runsByPhase.get(phase) ?? [])
+      .slice(0, -1)
+      .filter((run) => run.status === "postponed").length
+    if (priorPostponedCount === 0) return [latestLabel]
+
+    const attemptLabel = priorPostponedCount === 1 ? "attempt" : "attempts"
+    return [
+      {
+        phase: phase.toUpperCase(),
+        label: `${lifecyclePhaseLabel(phase)}: Postponed (${priorPostponedCount} prior ${attemptLabel})`,
+        status: "POSTPONED",
+        durationMs: null,
+      },
+      latestLabel,
+    ]
   })
 }
 

--- a/packages/graphql-api/test/work-item-projection.test.ts
+++ b/packages/graphql-api/test/work-item-projection.test.ts
@@ -2,6 +2,11 @@ import type { WorkItemRecord } from "@ready-for-agent/work-item-lifecycle"
 import {
   cumulativeExecutionDurationMs,
   lifecycleLabels,
+  statusLabel,
+  workItemCanRetry,
+  workItemPostponedUntil,
+  workItemStatus,
+  workItemStatusMessage,
 } from "../src/lib/work-item-projection.js"
 import { describe, expect, test } from "bun:test"
 
@@ -16,6 +21,7 @@ const baseStepRun = {
   finishedAt: new Date("2026-07-14T08:38:36.000Z"),
   reasonCode: null,
   reasonMessage: null,
+  postponedUntil: null,
   queueWaitMs: 1_000,
   executionDurationMs: 2_315_000, // 38m 35s
 }
@@ -49,6 +55,11 @@ const baseWorkItem = {
   stepRuns: [baseStepRun],
 } as WorkItemRecord
 
+const workItemWith = (overrides: Partial<WorkItemRecord>): WorkItemRecord => ({
+  ...baseWorkItem,
+  ...overrides,
+})
+
 describe("cumulativeExecutionDurationMs", () => {
   test("returns null when no attempt has started", () => {
     expect(
@@ -75,6 +86,122 @@ describe("cumulativeExecutionDurationMs", () => {
         { executionDurationMs: 12_000 },
       ]),
     ).toBe(2_315_000 + 45_000 + 12_000)
+  })
+})
+
+describe("Postponed Step Run projection", () => {
+  const postponedUntil = new Date("2026-08-07T12:00:00.000Z")
+  const postponedStepRun = {
+    ...baseStepRun,
+    step: "watch_pr_status_checks",
+    status: "postponed",
+    finishedAt: new Date("2026-08-07T11:00:00.000Z"),
+    postponedUntil,
+  } satisfies WorkItemRecord["stepRuns"][number]
+  const postponed = workItemWith({
+    state: "watch_pr_status_checks",
+    holdsWorkerSlot: false,
+    stepRuns: [postponedStepRun],
+  })
+  const postponedWorkItemWith = (
+    overrides: Partial<WorkItemRecord>,
+  ): WorkItemRecord => ({ ...postponed, ...overrides })
+
+  test("derives Waiting for GitHub from latest postponed history and deadline", () => {
+    expect(workItemStatus(postponed)).toBe("waiting_for_github")
+    expect(statusLabel(workItemStatus(postponed))).toBe("Waiting for GitHub")
+    expect(workItemPostponedUntil(postponed)).toEqual(postponedUntil)
+    expect(workItemStatusMessage(postponed)).toBe(
+      "Waiting for GitHub until 2026-08-07T12:00:00.000Z",
+    )
+    expect(workItemCanRetry(postponed)).toBe(false)
+    expect(lifecycleLabels(postponed)).toEqual([
+      {
+        phase: "GITHUB_STATUS_CHECKS",
+        label: "GitHub status checks: Postponed",
+        status: "POSTPONED",
+        durationMs: 2_315_000,
+      },
+    ])
+  })
+
+  test("keeps lifecycle hold precedence without a duplicate persisted flag", () => {
+    const paused = postponedWorkItemWith({ paused: true })
+    expect(workItemStatus(paused)).toBe("needs_human_review")
+    expect(workItemPostponedUntil(paused)).toBeNull()
+    expect(workItemStatusMessage(paused)).toBeNull()
+    expect(
+      workItemStatus(
+        postponedWorkItemWith({
+          paused: true,
+          waitingSince: new Date("2026-08-07T11:30:00.000Z"),
+        }),
+      ),
+    ).toBe("waiting_for_worker_slot")
+    expect(
+      workItemStatus(
+        postponedWorkItemWith({
+          waitingSince: new Date("2026-08-07T11:30:00.000Z"),
+          waitingForBlockers: true,
+        }),
+      ),
+    ).toBe("waiting_for_blockers")
+    expect(workItemStatus(postponedWorkItemWith({ state: "complete" }))).toBe(
+      "complete",
+    )
+  })
+
+  test("does not derive a GitHub hold from contradictory active resources", () => {
+    const workerSlotHeld = postponedWorkItemWith({ holdsWorkerSlot: true })
+    expect(workItemStatus(workerSlotHeld)).toBe("postponed")
+    expect(workItemPostponedUntil(workerSlotHeld)).toBeNull()
+
+    const activeHistory = postponedWorkItemWith({
+      stepRuns: [
+        {
+          ...baseStepRun,
+          step: "watch_pr_status_checks",
+          status: "running",
+          finishedAt: null,
+          postponedUntil: null,
+        } satisfies WorkItemRecord["stepRuns"][number],
+        postponedStepRun,
+      ],
+    })
+    expect(workItemStatus(activeHistory)).toBe("postponed")
+    expect(workItemPostponedUntil(activeHistory)).toBeNull()
+  })
+
+  test("retains Postponed history after a durable wake starts a fresh attempt", () => {
+    const resumed = postponedWorkItemWith({
+      stepRuns: [
+        postponedStepRun,
+        {
+          ...baseStepRun,
+          id: "srun-01J00000000000000000000001",
+          step: "watch_pr_status_checks",
+          status: "queued",
+          finishedAt: null,
+          postponedUntil: null,
+          executionDurationMs: null,
+        } satisfies WorkItemRecord["stepRuns"][number],
+      ],
+    })
+
+    expect(lifecycleLabels(resumed)).toEqual([
+      {
+        phase: "GITHUB_STATUS_CHECKS",
+        label: "GitHub status checks: Postponed (1 prior attempt)",
+        status: "POSTPONED",
+        durationMs: null,
+      },
+      {
+        phase: "GITHUB_STATUS_CHECKS",
+        label: "GitHub status checks: Queued",
+        status: "QUEUED",
+        durationMs: 2_315_000,
+      },
+    ])
   })
 })
 

--- a/packages/graphql-schema/schema.graphql
+++ b/packages/graphql-schema/schema.graphql
@@ -431,6 +431,11 @@ enum WorkItemStatus {
   FAILED
   INTERRUPTED
   CANCELLED
+  """
+  Finished Step Run outcome. The Work Item is Waiting for GitHub when its
+  latest Step Run is postponed with a retry deadline.
+  """
+  POSTPONED
   COMPLETE
   ABANDONED
   NEEDS_HUMAN
@@ -441,6 +446,11 @@ enum WorkItemStatus {
   Distinct from Waiting for Worker Slot and from Step Run / Agent Turn Queued.
   """
   WAITING_FOR_BLOCKERS
+  """
+  Derived from the latest Postponed Step Run and its durable wake contract.
+  This is not a Work Item lifecycle state.
+  """
+  WAITING_FOR_GITHUB
 }
 
 enum LifecyclePhase {
@@ -503,6 +513,11 @@ type WorkItem {
   status: WorkItemStatus!
   statusLabel: String!
   statusMessage: String
+  """
+  Retry deadline on the latest Postponed Step Run. Null unless the Work Item
+  is Waiting for GitHub.
+  """
+  postponedUntil: String
   paused: Boolean!
   canRetry: Boolean!
   isTerminal: Boolean!

--- a/packages/graphql-schema/schema.template.graphql
+++ b/packages/graphql-schema/schema.template.graphql
@@ -409,6 +409,11 @@ enum WorkItemStatus {
   FAILED
   INTERRUPTED
   CANCELLED
+  """
+  Finished Step Run outcome. The Work Item is Waiting for GitHub when its
+  latest Step Run is postponed with a retry deadline.
+  """
+  POSTPONED
   COMPLETE
   ABANDONED
   NEEDS_HUMAN
@@ -419,6 +424,11 @@ enum WorkItemStatus {
   Distinct from Waiting for Worker Slot and from Step Run / Agent Turn Queued.
   """
   WAITING_FOR_BLOCKERS
+  """
+  Derived from the latest Postponed Step Run and its durable wake contract.
+  This is not a Work Item lifecycle state.
+  """
+  WAITING_FOR_GITHUB
 }
 
 enum LifecyclePhase {
@@ -481,6 +491,11 @@ type WorkItem {
   status: WorkItemStatus!
   statusLabel: String!
   statusMessage: String
+  """
+  Retry deadline on the latest Postponed Step Run. Null unless the Work Item
+  is Waiting for GitHub.
+  """
+  postponedUntil: String
   paused: Boolean!
   canRetry: Boolean!
   isTerminal: Boolean!

--- a/packages/work-item-lifecycle/src/lib/types.ts
+++ b/packages/work-item-lifecycle/src/lib/types.ts
@@ -51,6 +51,7 @@ export const StepRunStatus = Schema.Literals([
   "failed",
   "interrupted",
   "cancelled",
+  "postponed",
 ])
 export type StepRunStatus = typeof StepRunStatus.Type
 
@@ -62,11 +63,10 @@ export type StepRunStatus = typeof StepRunStatus.Type
 export const MergeMode = Schema.Literals(["ordinary", "always"])
 export type MergeMode = typeof MergeMode.Type
 
-export interface StepRunRecord {
+interface StepRunRecordBase {
   readonly id: StepRunId
   readonly workItemId: WorkItemId
   readonly step: OperationalLifecycleStep
-  readonly status: StepRunStatus
   readonly queueJobId: string | null
   readonly queuedAt: Date
   readonly startedAt: Date | null
@@ -78,6 +78,25 @@ export interface StepRunRecord {
   /** Time from start until finish/now; null when execution never began. */
   readonly executionDurationMs: number | null
 }
+
+/** A finished attempt held for GitHub's durable retry deadline. */
+export type PostponedStepRunRecord = Omit<StepRunRecordBase, "finishedAt"> & {
+  readonly status: "postponed"
+  readonly finishedAt: Date
+  readonly postponedUntil: Date
+}
+
+/** Every non-postponed outcome has no GitHub retry deadline. */
+export type NonPostponedStepRunRecord = StepRunRecordBase & {
+  readonly status: Exclude<StepRunStatus, "postponed">
+  readonly postponedUntil: null
+}
+
+/**
+ * A persisted Step Run makes its outcome/deadline invariant unrepresentable
+ * in lifecycle code; the SQLite migration enforces the same contract.
+ */
+export type StepRunRecord = PostponedStepRunRecord | NonPostponedStepRunRecord
 
 export interface WorkItemRecord {
   readonly id: WorkItemId

--- a/packages/work-item-lifecycle/src/lib/work-item-lifecycle.ts
+++ b/packages/work-item-lifecycle/src/lib/work-item-lifecycle.ts
@@ -334,13 +334,14 @@ type StepRunRow = {
   readonly finished_at: number | null
   readonly reason_code: string | null
   readonly reason_message: string | null
+  readonly postponed_until: number | null
   readonly session_wait_ms: number | null
   readonly session_wait_started_at: number | null
 }
 
 const STEP_RUN_SELECT_COLUMNS = `id, work_item_id, step, status, queue_job_id, queued_at,
                         started_at, finished_at, reason_code, reason_message,
-                        session_wait_ms, session_wait_started_at`
+                        postponed_until, session_wait_ms, session_wait_started_at`
 
 const deriveQueueWaitMs = (row: StepRunRow, nowMs: number): number => {
   const endMs = row.started_at ?? row.finished_at ?? nowMs
@@ -358,20 +359,36 @@ const deriveExecutionDurationMs = (
   return Math.max(0, endMs - row.started_at)
 }
 
-const toStepRunRecord = (row: StepRunRow, nowMs: number): StepRunRecord => ({
-  id: row.id as StepRunId,
-  workItemId: row.work_item_id as WorkItemId,
-  step: row.step,
-  status: row.status,
-  queueJobId: row.queue_job_id,
-  queuedAt: new Date(row.queued_at),
-  startedAt: row.started_at === null ? null : new Date(row.started_at),
-  finishedAt: row.finished_at === null ? null : new Date(row.finished_at),
-  reasonCode: row.reason_code,
-  reasonMessage: row.reason_message,
-  queueWaitMs: deriveQueueWaitMs(row, nowMs),
-  executionDurationMs: deriveExecutionDurationMs(row, nowMs),
-})
+const toStepRunRecord = (row: StepRunRow, nowMs: number): StepRunRecord => {
+  const common = {
+    id: row.id as StepRunId,
+    workItemId: row.work_item_id as WorkItemId,
+    step: row.step,
+    queueJobId: row.queue_job_id,
+    queuedAt: new Date(row.queued_at),
+    startedAt: row.started_at === null ? null : new Date(row.started_at),
+    finishedAt: row.finished_at === null ? null : new Date(row.finished_at),
+    reasonCode: row.reason_code,
+    reasonMessage: row.reason_message,
+    queueWaitMs: deriveQueueWaitMs(row, nowMs),
+    executionDurationMs: deriveExecutionDurationMs(row, nowMs),
+  }
+  if (row.status === "postponed") {
+    if (row.postponed_until === null) {
+      throw new Error("Postponed Step Run is missing postponed_until")
+    }
+    if (row.finished_at === null) {
+      throw new Error("Postponed Step Run is missing finished_at")
+    }
+    return {
+      ...common,
+      status: "postponed",
+      finishedAt: new Date(row.finished_at),
+      postponedUntil: new Date(row.postponed_until),
+    }
+  }
+  return { ...common, status: row.status, postponedUntil: null }
+}
 
 const toWorkItemRecord = (
   row: WorkItemRow,


### PR DESCRIPTION
Implements #874

- Adds the ontology-backed glossary, persisted `postponed` Step Run outcome, and `postponedUntil` invariant enforced by SQLite migration triggers.
- Projects the derived hold through GraphQL and Harness while preserving the existing lifecycle lane, showing the retry deadline and Postponed history without exposing Retry.
- Keeps active-run uniqueness limited to queued/running runs and centralizes hold precedence so terminal, blocker, worker-slot, and paused states suppress the GitHub deadline consistently.
- Adds persistence, projection, contradictory-state, pipeline-lane, and UI coverage. No production lifecycle path writes the new outcome in this change.

Verification: `bunx nx run graphql-api:test --skip-nx-cache` (135 passing), `bunx nx run work-item-lifecycle:test --skip-nx-cache`, `bunx nx run harness:test --skip-nx-cache`, staged whitespace checks, and delegated pre-commit all pass.

Closes #874