### PR TITLE
fix(harness): start implementation from primary action

### DIFF
--- a/apps/harness/src/home-page-content.tsx
+++ b/apps/harness/src/home-page-content.tsx
@@ -2866,21 +2866,6 @@ function RepositoryIssueRow({
     },
     onSuccess: onImplementSuccess,
   })
-  const implementLocally = useMutation({
-    mutationFn: async () => {
-      const result = await graphql.mutation({
-        implementLocally: {
-          __args: {
-            repositoryId: issue.repositoryId,
-            issueNumber: issue.issueNumber,
-          },
-          ...workItemFields,
-        },
-      })
-      return result.implementLocally
-    },
-    onSuccess: onImplementSuccess,
-  })
   const queueIssue = useMutation({
     mutationFn: async () => {
       const result = await graphql.mutation({
@@ -2896,8 +2881,7 @@ function RepositoryIssueRow({
     },
     onSuccess: onImplementSuccess,
   })
-  const implementPending =
-    implementNow.isPending || implementLocally.isPending || queueIssue.isPending
+  const implementPending = implementNow.isPending || queueIssue.isPending
 
   useEffect(() => {
     if (!menuOpen) return
@@ -2928,71 +2912,26 @@ function RepositoryIssueRow({
               {issue.title}
             </a>
             {canImplement && (
-              <span className="relative" data-issue-menu={issue.id}>
-                <button
-                  type="button"
-                  className={ui.repoIssueImplementBtn}
-                  aria-label={`Implement issue #${issue.issueNumber}`}
-                  aria-haspopup="menu"
-                  aria-expanded={menuOpen}
-                  disabled={implementPending}
-                  onClick={() => {
-                    if (implementPending) return
-                    setMenuOpen((open) => !open)
-                  }}
+              <button
+                type="button"
+                className={ui.repoIssueImplementBtn}
+                aria-label={`Implement issue #${issue.issueNumber}`}
+                disabled={implementPending}
+                onClick={() => {
+                  queueIssue.reset()
+                  implementNow.mutate()
+                }}
+              >
+                <svg
+                  aria-hidden="true"
+                  className={ui.repoIssueImplementIcon}
+                  viewBox="0 0 24 24"
+                  fill="currentColor"
                 >
-                  <svg
-                    aria-hidden="true"
-                    className={ui.repoIssueImplementIcon}
-                    viewBox="0 0 24 24"
-                    fill="currentColor"
-                  >
-                    <path d="M8 5.14v13.72a1 1 0 0 0 1.53.85l10.12-6.86a1 1 0 0 0 0-1.7L9.53 4.29A1 1 0 0 0 8 5.14Z" />
-                  </svg>
-                  {implementPending ? "Starting..." : "Implement"}
-                </button>
-                {menuOpen && !implementPending && (
-                  <div
-                    role="menu"
-                    className={cx(
-                      ui.menuPanel,
-                      ui.repoIssueImplementMenu,
-                      "min-w-44",
-                    )}
-                  >
-                    <button
-                      type="button"
-                      role="menuitem"
-                      className={ui.menuItem}
-                      disabled={implementPending}
-                      onClick={() => {
-                        setMenuOpen(false)
-                        implementLocally.reset()
-                        queueIssue.reset()
-                        implementNow.mutate()
-                      }}
-                    >
-                      {implementNow.isPending ? "Starting..." : "Implement now"}
-                    </button>
-                    <button
-                      type="button"
-                      role="menuitem"
-                      className={ui.menuItem}
-                      disabled={implementPending}
-                      onClick={() => {
-                        setMenuOpen(false)
-                        implementNow.reset()
-                        queueIssue.reset()
-                        implementLocally.mutate()
-                      }}
-                    >
-                      {implementLocally.isPending
-                        ? "Starting..."
-                        : "Implement locally"}
-                    </button>
-                  </div>
-                )}
-              </span>
+                  <path d="M8 5.14v13.72a1 1 0 0 0 1.53.85l10.12-6.86a1 1 0 0 0 0-1.7L9.53 4.29A1 1 0 0 0 8 5.14Z" />
+                </svg>
+                {implementPending ? "Starting..." : "Implement"}
+              </button>
             )}
           </span>
           {issue.issueAuthor !== null && issue.issueAuthor !== "" && (
@@ -3032,7 +2971,6 @@ function RepositoryIssueRow({
                     onClick={() => {
                       setMenuOpen(false)
                       implementNow.reset()
-                      implementLocally.reset()
                       queueIssue.mutate()
                     }}
                   >
@@ -3068,9 +3006,7 @@ function RepositoryIssueRow({
           onOpenSession={onOpenSession}
         />
       )}
-      {(implementNow.isError ||
-        implementLocally.isError ||
-        queueIssue.isError) && (
+      {(implementNow.isError || queueIssue.isError) && (
         <Banner
           className={cx(ui.bannerCompact, ui.repoIssueError)}
           tone="alarm"

--- a/apps/harness/src/kanban-board.tsx
+++ b/apps/harness/src/kanban-board.tsx
@@ -539,14 +539,6 @@ function KanbanJobsBoard() {
                           </svg>
                           Implement
                         </span>
-                        <div className={ui.queueHintMenuPanel}>
-                          <span className={ui.queueHintMenuItem}>
-                            Implement now
-                          </span>
-                          <span className={ui.queueHintMenuItem}>
-                            Implement locally
-                          </span>
-                        </div>
                       </div>
                     </aside>
                   )}

--- a/apps/harness/src/ui.ts
+++ b/apps/harness/src/ui.ts
@@ -880,9 +880,8 @@ export const ui = {
     "text-[#151515] underline underline-offset-2 hover:decoration-2 hover:decoration-signal focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#151515]",
 
   /**
-   * Compact static mock of the repos issue Implement control + menu
-   * (Implement now / Implement locally) — decorative, under the hint copy.
-   * Matches the blue start button + industrial menu chrome.
+   * Compact static mock of the repos issue Implement control — decorative,
+   * under the hint copy. Matches the blue start button.
    */
   queueHintMenuIllus:
     "mt-[0.1rem] flex w-fit flex-col items-start gap-[0.2rem]",
@@ -894,12 +893,6 @@ export const ui = {
   ),
 
   queueHintImplementIcon: "h-[0.8rem] w-[0.8rem] shrink-0",
-
-  queueHintMenuPanel:
-    "min-w-[9.5rem] border-2 border-[#151515] bg-[var(--panel,#ffffff)] py-0.5 shadow-none",
-
-  queueHintMenuItem:
-    "block px-2.5 py-1.5 font-mono text-[0.62rem] font-bold tracking-[0.08em] uppercase text-[#151515]",
 
   jobTicket: cx(
     // minmax(0,1fr): single column may shrink below long mono min-content so
@@ -1194,8 +1187,8 @@ export const ui = {
     "hover:text-ink hover:underline hover:decoration-signal hover:decoration-2 hover:underline-offset-[3px]",
 
   /**
-   * Visible Implement menu trigger after the issue title — Build-lane blue so
-   * the basic “start work” path is obvious. Queue stays off this cue.
+   * Visible Implement action after the issue title — Build-lane blue so the
+   * basic “start work” path is obvious. Queue stays off this cue.
    * min-h-7 matches iconBtn hit target for the promoted primary action.
    */
   repoIssueImplementBtn: cx(
@@ -1208,9 +1201,6 @@ export const ui = {
   ),
 
   repoIssueImplementIcon: "h-[0.8rem] w-[0.8rem] shrink-0",
-
-  /** Left-anchored menu under the inline Implement trigger (not right-edge kebab). */
-  repoIssueImplementMenu: "left-0 right-auto",
 
   repoIssueAuthor:
     "mt-[0.15rem] block font-mono text-[0.62rem] tracking-[0.06em] text-ink-faint",

--- a/apps/harness/test/kanban-route.test.ts
+++ b/apps/harness/test/kanban-route.test.ts
@@ -186,12 +186,12 @@ describe("kanban home board", () => {
     expect(source).toContain("ui.queueHint")
     expect(source).toContain("Feed the queue — label issues with")
     expect(source).toContain("ready-for-agent")
-    expect(source).toContain("Implement now")
-    expect(source).toContain("Implement locally")
     expect(source).toContain("ui.queueHintMenuIllus")
     expect(source).toContain("ui.queueHintImplementBtn")
     expect(source).toContain("ui.queueHintImplementIcon")
     expect(source).toContain("click Implement.")
+    expect(source).not.toContain("Implement now")
+    expect(source).not.toContain("Implement locally")
     expect(source).not.toContain("ui.queueHintMenuKebab")
     // Issue #742: no redundant Queue tag; blue Implement control teaches
     // the repos path; "your repos" links to the Repos view.
@@ -656,7 +656,9 @@ describe("kanban home board", () => {
     expect(ui).toMatch(/laneSwitcher:[\s\S]*?hidden/)
     expect(ui).toContain("queueHint:")
     expect(ui).toContain("queueHintMenuIllus:")
-    expect(ui).toContain("queueHintMenuItem:")
+    expect(ui).toContain("queueHintImplementBtn:")
+    expect(ui).not.toContain("queueHintMenuPanel:")
+    expect(ui).not.toContain("queueHintMenuItem:")
     expect(ui).toContain("queueHintLink:")
     // Issue #742: tag chip and bold action emphasis removed from empty-state.
     expect(ui).not.toContain("queueHintTag:")

--- a/apps/harness/test/repos-interchange.test.ts
+++ b/apps/harness/test/repos-interchange.test.ts
@@ -112,6 +112,16 @@ describe("Interchange phase 4: repos page + blank slate", () => {
     expect(issues).toContain("ui.repoIssueImplementBtn")
     expect(issues).toContain("ui.repoIssueImplementIcon")
     expect(issues).toContain("disabled={implementPending}")
+    const implementAction = sliceBetweenMarkers(
+      issues,
+      "{canImplement && (",
+      "{canQueue && (",
+    )
+    expect(implementAction).toContain("queueIssue.reset()")
+    expect(implementAction).toContain("implementNow.mutate()")
+    expect(implementAction).not.toContain('aria-haspopup="menu"')
+    expect(implementAction).not.toContain('role="menu"')
+    expect(implementAction).not.toContain("Implement locally")
     expect(issues).toContain("ui.repoIssueAuthor")
     expect(issues).toContain("ui.stamp")
     expect(issues).toContain("ui.stampClosed")
@@ -137,6 +147,7 @@ describe("Interchange phase 4: repos page + blank slate", () => {
     expect(ui).toMatch(/repoIssueTitle:\s*\n\s*"m-0 block /)
     expect(ui).toMatch(/repoIssueImplementBtn:[\s\S]*?bg-lane-build/)
     expect(ui).toMatch(/repoIssueImplementBtn:[\s\S]*?min-h-7/)
+    expect(ui).not.toContain("repoIssueImplementMenu:")
     expect(ui).toMatch(/stampClosed:[\s\S]*?border-dashed/)
     expect(ui).toMatch(/stampBlocked:[\s\S]*?bg-lane-queue/)
   })

--- a/apps/harness/test/waiting-for-blockers-working-row.test.ts
+++ b/apps/harness/test/waiting-for-blockers-working-row.test.ts
@@ -77,21 +77,21 @@ describe("Waiting for blockers Working-row polish", () => {
     expect(lifecycle).toContain("onReset={() => reset.mutate()}")
   })
 
-  test("Issue row offers inline Implement cue for basic cases; Queue stays kebab-only", () => {
+  test("Issue row starts Implement now directly; Queue stays kebab-only", () => {
     const source = homeSource()
     expect(source).toContain("issueActionEligibility({")
     expect(source).toContain('queueIssue.isPending ? "Queueing..." : "Queue"')
     expect(source).toContain("{canImplement && (")
     expect(source).toContain("{canQueue && (")
-    expect(source).toContain("Implement now")
-    expect(source).toContain("Implement locally")
     // Primary blue cue after the title for implementable issues only.
     expect(source).toContain("ui.repoIssueImplementBtn")
     expect(source).toContain("ui.repoIssueImplementIcon")
     expect(source).toContain("ui.repoIssueTitleRow")
     expect(source).toContain("ui.repoIssueTitleInline")
-    expect(source).toContain("ui.repoIssueImplementMenu")
     expect(source).toContain("Implement issue #")
+    expect(source).toContain("queueIssue.reset()")
+    expect(source).toContain("implementNow.mutate()")
+    expect(source).not.toContain("Implement locally")
     // Pending disables the primary cue (styles + behavior stay aligned).
     expect(source).toContain("disabled={implementPending}")
     expect(source).toContain('implementPending ? "Starting..." : "Implement"')

--- a/docs/harness-design-system.md
+++ b/docs/harness-design-system.md
@@ -677,8 +677,8 @@ A permanent fixture at the **foot of the Queue platform**, always rendered
   "your repos" to the Repos view.
 - **Illustration**: compact static mock of the repos-row **Implement** control
   (Build-lane blue plate, play-triangle start icon, mono "Implement" label)
-  with a menu panel listing **Implement now** and **Implement locally**
-  (decorative, `aria-hidden`) so operators recognize the primary cue on Repos.
+  so operators recognize the primary action on Repos. Clicking the control
+  starts implementation immediately; it does not open a choice menu.
   Queue for blocked issues stays kebab-only and is not illustrated here.
 - No primary "Manage repos" CTA — keep the hint focused on label → Implement.
 - No transit glyphs (no ⇄), no "Transfer" wording anywhere.


### PR DESCRIPTION
Summary

- Make the Repos issue-row `Implement` control immediately invoke the existing
  Implement now flow.
- Remove the implementation-choice menu and its local implementation path from
  that primary control.
- Update the Queue hint, design-system guidance, and UI structural tests to
  describe and enforce the direct action.

Verification

- `bunx nx run harness:lint`
- `bunx nx run harness:typecheck`
- `bunx nx run harness:test` — 534 Bun tests and 98 Vitest tests passed.

Closes #889