### PR TITLE
feat(claude): wire session telemetry provider

### DIFF
--- a/apps/harness/e2e/support/session-telemetry-fixture.ts
+++ b/apps/harness/e2e/support/session-telemetry-fixture.ts
@@ -28,7 +28,7 @@ export const TELEMETRY_FIXTURE = {
   missingSessionId: "ses_e2e_fixture_missing",
   missingSessionIssueNumber: 101,
   missingSessionIssueId: "issue-01KZD5SESS10NTE0FXX0000001",
-  /** Claude Work Item → UNSUPPORTED Session Telemetry. */
+  /** Codex Build Work Item → UNSUPPORTED Session Telemetry. */
   unsupportedWorkItemId: "wi-01KZD5SESS10NTE0FXX0000002",
   unsupportedSessionId: "ses_e2e_fixture_unsupported",
   unsupportedIssueNumber: 102,
@@ -183,7 +183,7 @@ export const seedSessionTelemetryFixtures = async (): Promise<void> => {
        ${sqlLiteral(TELEMETRY_FIXTURE.repositoryId)},
        ${TELEMETRY_FIXTURE.unsupportedIssueNumber},
        'E2E Session Telemetry unsupported',
-       'claude',
+       'codex',
        'implement',
        ${now},
        1,

--- a/packages/agent-backend/src/lib/registry.ts
+++ b/packages/agent-backend/src/lib/registry.ts
@@ -114,7 +114,7 @@ const CLAUDE_REGISTRATION: AgentBackendRegistration = {
     label: CLAUDE_CODE_LABEL,
   },
   capabilities: [
-    { _tag: "SessionTelemetry", supported: false },
+    { _tag: "SessionTelemetry", supported: true },
     { _tag: "KeymaxxerMcp", supported: false },
   ],
 }

--- a/packages/agent-backend/test/registry.spec.ts
+++ b/packages/agent-backend/test/registry.spec.ts
@@ -111,7 +111,7 @@ describe("Agent Backend registry", () => {
 
     const claude = getBuiltInAgentBackend(AGENT_BACKEND_IDS.claude)
     expect(claude).toBeDefined()
-    expect(capabilitySupported(claude!, "SessionTelemetry")).toBe(false)
+    expect(capabilitySupported(claude!, "SessionTelemetry")).toBe(true)
     expect(capabilitySupported(claude!, "KeymaxxerMcp")).toBe(false)
   })
 })

--- a/packages/claude/src/lib/session-telemetry-layer.ts
+++ b/packages/claude/src/lib/session-telemetry-layer.ts
@@ -1,30 +1,58 @@
 import { Effect, Layer } from "effect"
 import {
   AGENT_BACKEND_IDS,
+  type SessionTelemetry,
   SessionTelemetryProvider,
-  unsupportedSessionTelemetry,
 } from "@ready-for-agent/agent-backend"
+import {
+  type ClaudeSession,
+  ClaudeSessionStore,
+  ClaudeSessionStoreLive,
+  type ClaudeSessionStoreOptions,
+} from "./session-store.js"
 
 const CLAUDE_BACKEND = {
   id: AGENT_BACKEND_IDS.claude,
   label: "Claude Code",
 } as const
 
+const toSessionTelemetry = (session: ClaudeSession): SessionTelemetry => ({
+  id: session.id,
+  availability: session.availability,
+  backend: CLAUDE_BACKEND,
+  model:
+    session.model === null
+      ? null
+      : {
+          providerId: session.model.providerId,
+          id: session.model.id,
+          thinkingLevel: session.model.thinkingLevel,
+        },
+  tokens: session.tokens,
+  cost: session.cost,
+  createdAt: session.createdAt,
+  updatedAt: session.updatedAt,
+})
+
 /**
- * Claude Code declares Session Telemetry unsupported (ADR 0047 v1).
- * Provides a provider that always reports `unsupported` so composition roots
- * can wire Claude like other backends without a null telemetry branch.
- *
- * Accepts an unused options bag so the export is a Layer factory matching
- * Grok/Codex call sites (`ClaudeSessionTelemetryLive()`).
+ * Expose Claude Code's file-backed transcript Session Telemetry through the
+ * generic provider. The backend label remains Claude Code in Bedrock mode;
+ * the transcript model supplies the effective provider identity.
  */
 export const ClaudeSessionTelemetryLive = (
-  _options: Record<string, never> = {},
-): Layer.Layer<SessionTelemetryProvider> =>
-  Layer.succeed(
+  options: ClaudeSessionStoreOptions = {},
+): Layer.Layer<SessionTelemetryProvider | ClaudeSessionStore> => {
+  const storeLayer = ClaudeSessionStoreLive(options)
+  const providerLayer = Layer.effect(
     SessionTelemetryProvider,
-    SessionTelemetryProvider.of({
-      getSession: (sessionId) =>
-        Effect.succeed(unsupportedSessionTelemetry(sessionId, CLAUDE_BACKEND)),
+    Effect.gen(function* () {
+      const store = yield* ClaudeSessionStore
+      return SessionTelemetryProvider.of({
+        getSession: (sessionId) =>
+          store.getSession(sessionId).pipe(Effect.map(toSessionTelemetry)),
+      })
     }),
-  )
+  ).pipe(Layer.provide(storeLayer))
+
+  return Layer.merge(storeLayer, providerLayer)
+}

--- a/packages/claude/test/session-telemetry-layer.spec.ts
+++ b/packages/claude/test/session-telemetry-layer.spec.ts
@@ -1,26 +1,130 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
 import { Effect } from "effect"
 import { SessionTelemetryProvider } from "@ready-for-agent/agent-backend"
 import { ClaudeSessionTelemetryLive } from "../src/index.js"
 import { describe, expect, it } from "bun:test"
 
 describe("ClaudeSessionTelemetryLive", () => {
-  it("reports Session Telemetry unsupported for any session id", async () => {
-    const result = await Effect.runPromise(
+  const getSession = (input: {
+    readonly claudeConfigDir: string
+    readonly sessionId: string
+  }) =>
+    Effect.runPromise(
       Effect.gen(function* () {
         const provider = yield* SessionTelemetryProvider
-        return yield* provider.getSession("any-session-id")
-      }).pipe(Effect.provide(ClaudeSessionTelemetryLive())),
+        return yield* provider.getSession(input.sessionId)
+      }).pipe(
+        Effect.provide(
+          ClaudeSessionTelemetryLive({
+            claudeConfigDir: input.claudeConfigDir,
+          }),
+        ),
+      ),
     )
 
-    expect(result).toEqual({
-      id: "any-session-id",
-      availability: "unsupported",
-      backend: { id: "claude", label: "Claude Code" },
-      model: null,
-      tokens: null,
-      cost: null,
-      createdAt: null,
-      updatedAt: null,
-    })
+  const writeTranscript = (input: {
+    readonly claudeConfigDir: string
+    readonly sessionId: string
+    readonly model: string
+    readonly effort: string
+  }) => {
+    const path = join(
+      input.claudeConfigDir,
+      "projects",
+      "-work-repo",
+      `${input.sessionId}.jsonl`,
+    )
+    mkdirSync(join(path, ".."), { recursive: true })
+    writeFileSync(
+      path,
+      JSON.stringify({
+        type: "assistant",
+        timestamp: "2026-08-05T04:27:47.143Z",
+        effort: input.effort,
+        message: {
+          model: input.model,
+          usage: {
+            input_tokens: 10,
+            output_tokens: 4,
+            cache_read_input_tokens: 30,
+            cache_creation_input_tokens: 5,
+          },
+        },
+      }),
+    )
+  }
+
+  it("maps transcript-store sessions with the static Claude Code label", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "claude-session-telemetry-"))
+    try {
+      writeTranscript({
+        claudeConfigDir: dir,
+        sessionId: "anthropic-session",
+        model: "claude-sonnet-5",
+        effort: "low",
+      })
+      writeTranscript({
+        claudeConfigDir: dir,
+        sessionId: "bedrock-session",
+        model:
+          "arn:aws:bedrock:us-east-1:123456789012:inference-profile/us.anthropic.claude-sonnet-4-5-v1:0",
+        effort: "medium",
+      })
+
+      await expect(
+        getSession({ claudeConfigDir: dir, sessionId: "anthropic-session" }),
+      ).resolves.toMatchObject({
+        id: "anthropic-session",
+        availability: "available",
+        backend: { id: "claude", label: "Claude Code" },
+        model: {
+          providerId: "anthropic",
+          id: "claude-sonnet-5",
+          thinkingLevel: "low",
+        },
+        tokens: {
+          input: 10,
+          output: 4,
+          reasoning: 0,
+          cacheRead: 30,
+          cacheWrite: 5,
+        },
+      })
+      await expect(
+        getSession({ claudeConfigDir: dir, sessionId: "bedrock-session" }),
+      ).resolves.toMatchObject({
+        id: "bedrock-session",
+        availability: "available",
+        backend: { id: "claude", label: "Claude Code" },
+        model: {
+          providerId: "bedrock",
+          thinkingLevel: "medium",
+        },
+      })
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it("maps an absent transcript to missing", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "claude-session-telemetry-"))
+    try {
+      await expect(
+        getSession({ claudeConfigDir: dir, sessionId: "missing-session" }),
+      ).resolves.toEqual({
+        id: "missing-session",
+        availability: "missing",
+        backend: { id: "claude", label: "Claude Code" },
+        model: null,
+        tokens: null,
+        cost: null,
+        createdAt: null,
+        updatedAt: null,
+      })
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
   })
 })


### PR DESCRIPTION
Claude Code sessions already have a transcript-backed telemetry store. This change exposes it
through the backend-neutral Session Telemetry provider so Work Item session usage can render
in the existing dialog.

- Map transcript-store results into `SessionTelemetry` with the static `Claude Code` backend
  label.
- Preserve Anthropic and Bedrock model-provider identity from transcript models, and return
  `missing` when no transcript is captured.
- Mark Claude Code telemetry as supported while retaining Codex Build as unsupported.
- Replace the unsupported-provider test with transcript-backed Anthropic, Bedrock, and
  missing-session coverage.

Verification:

- `bunx nx test claude`
- `bunx nx test agent-backend`
- `bunx nx test graphql-api`
- `bunx nx typecheck claude`
- `bunx nx typecheck agent-backend`
- `bunx nx lint claude`
- `bunx nx lint agent-backend`
- `git diff --check`

Closes #868