### PR TITLE
fix(github): preserve throttling through Keymaxxer helpers

### DIFF
--- a/apps/harness/src/server/keymaxxer-github-layer.ts
+++ b/apps/harness/src/server/keymaxxer-github-layer.ts
@@ -9,6 +9,7 @@ import {
   Schema,
 } from "effect"
 import {
+  GITHUB_HELPER_THROTTLED_EXIT_CODE,
   type GitHubHelperOperation,
   type GitHubOperationOptions,
   type GitHubRepository,
@@ -16,8 +17,9 @@ import {
   GitHubRequestError,
   GitHubService,
   type GitHubServiceShape,
-  type GitHubThrottledError,
+  GitHubThrottledError,
   formatGitHubHelperShellCommand,
+  parseGitHubHelperControl,
   resolveGitHubHelperChildSpawn,
 } from "@ready-for-agent/github-service"
 import { KeymaxxerService } from "@ready-for-agent/keymaxxer-service"
@@ -84,7 +86,17 @@ const SerializedAutomatedReviewEvidenceObservation = Schema.Union([
   }),
 ])
 
-const requestError = makeRequestError(GitHubRequestError)
+/**
+ * Helper output is an untrusted credential boundary. Do not copy it into
+ * request errors: those errors can be returned via GraphQL and logged by the
+ * caller. The optional detail parameter preserves the shared parser callback
+ * shape while deliberately discarding any helper-supplied text.
+ */
+const requestError = (
+  repository: GitHubRepository,
+  operation: string,
+  _detail?: string,
+) => makeRequestError(GitHubRequestError)(repository, operation)
 
 const repositoryUnavailable = (repository: GitHubRepository) =>
   new GitHubRepositoryUnavailableError(repository)
@@ -99,7 +111,7 @@ const decodePositiveInt = (
 ): Effect.Effect<number, GitHubRequestError> => {
   const number = Number(stdout.trim())
   if (!Number.isSafeInteger(number) || number <= 0) {
-    return Effect.fail(requestError(repository, describe, stdout))
+    return Effect.fail(requestError(repository, describe))
   }
   return Effect.succeed(number)
 }
@@ -119,7 +131,7 @@ const decodeNonNegativeInt = (
   }
   const count = Number(trimmed)
   if (!Number.isSafeInteger(count) || count < 0) {
-    return Effect.fail(requestError(repository, describe, stdout))
+    return Effect.fail(requestError(repository, describe))
   }
   return Effect.succeed(count)
 }
@@ -136,7 +148,7 @@ const decodeNullableInt = (
   }
   const number = Number(trimmed)
   if (!Number.isSafeInteger(number) || number <= 0) {
-    return Effect.fail(requestError(repository, describe, stdout))
+    return Effect.fail(requestError(repository, describe))
   }
   return Effect.succeed(number)
 }
@@ -164,7 +176,7 @@ const decodeJson =
   ) =>
   (stdout: string): Effect.Effect<A, GitHubRequestError> =>
     Schema.decodeUnknownEffect(Schema.fromJsonString(schema))(stdout).pipe(
-      Effect.mapError(() => requestError(repository, describe, stdout)),
+      Effect.mapError(() => requestError(repository, describe)),
     )
 
 export const keymaxxerGitHubLayer = (options: {
@@ -256,14 +268,35 @@ export const keymaxxerGitHubLayer = (options: {
             if (result.exitCode === 2) {
               return yield* repositoryUnavailable(input.repository)
             }
-            if (result.exitCode !== 0) {
-              return yield* requestError(
-                input.repository,
-                input.describe,
-                result.stderr || result.stdout,
+            if (result.exitCode === GITHUB_HELPER_THROTTLED_EXIT_CODE) {
+              const control = parseGitHubHelperControl(result.stderr)
+              if (control?.kind !== "github-throttled") {
+                return yield* requestError(input.repository, input.describe)
+              }
+              return yield* coordinator.reportThrottle(
+                new GitHubThrottledError({
+                  retryAt: control.retryAt,
+                  usedFallback: control.usedFallback,
+                }),
               )
             }
-            return yield* input.decode(result.stdout)
+            if (result.exitCode !== 0) {
+              return yield* requestError(input.repository, input.describe)
+            }
+            const control = parseGitHubHelperControl(result.stderr)
+            if (control?.kind !== "success") {
+              return yield* requestError(input.repository, input.describe)
+            }
+            const value = yield* input.decode(result.stdout)
+            if (control.throttle !== null) {
+              coordinator.reportThrottle(
+                new GitHubThrottledError({
+                  retryAt: control.throttle.retryAt,
+                  usedFallback: control.throttle.usedFallback,
+                }),
+              )
+            }
+            return value
           }).pipe(
             Effect.catchTag("KeymaxxerError", () =>
               Effect.fail(requestError(input.repository, input.describe)),

--- a/apps/harness/test/keymaxxer-github-layer.test.ts
+++ b/apps/harness/test/keymaxxer-github-layer.test.ts
@@ -16,6 +16,10 @@ import {
   GitHubRequestError,
   GitHubService,
   type GitHubServiceShape,
+  GitHubThrottledError,
+  githubHelperSuccess,
+  githubHelperThrottled,
+  serializeGitHubHelperControl,
 } from "@ready-for-agent/github-service"
 import {
   KeymaxxerService,
@@ -55,6 +59,10 @@ const acmeGadgets = {
   projectPath: "acme/gadgets",
 } as const
 
+const successfulHelperControl = serializeGitHubHelperControl(
+  githubHelperSuccess(),
+)
+
 describe("Keymaxxer-backed GitHub layer", () => {
   it.effect(
     "does not prompt Keymaxxer when a repository token is missing",
@@ -74,7 +82,11 @@ describe("Keymaxxer-backed GitHub layer", () => {
             }),
           runWithSecrets: (input) => {
             runs.push(input)
-            return Effect.succeed({ exitCode: 0, stdout: "[]", stderr: "" })
+            return Effect.succeed({
+              exitCode: 0,
+              stdout: "[]",
+              stderr: successfulHelperControl,
+            })
           },
         })
         const layer = keymaxxerGitHubLayer({
@@ -114,7 +126,11 @@ describe("Keymaxxer-backed GitHub layer", () => {
         addSecret: () => Effect.die("not used"),
         runWithSecrets: (input) => {
           runs.push(input)
-          return Effect.succeed({ exitCode: 0, stdout: "[]", stderr: "" })
+          return Effect.succeed({
+            exitCode: 0,
+            stdout: "[]",
+            stderr: successfulHelperControl,
+          })
         },
       })
       const layer = keymaxxerGitHubLayer({ workspaceRoot: "/workspace" }).pipe(
@@ -187,7 +203,7 @@ describe("Keymaxxer-backed GitHub layer", () => {
                   ],
                 },
               ]),
-              stderr: "",
+              stderr: successfulHelperControl,
             })
           },
         })
@@ -280,7 +296,7 @@ describe("Keymaxxer-backed GitHub layer", () => {
                 },
               ],
             }),
-            stderr: "",
+            stderr: successfulHelperControl,
           })
         },
       })
@@ -349,7 +365,7 @@ describe("Keymaxxer-backed GitHub layer", () => {
                 },
               ],
             }),
-            stderr: "",
+            stderr: successfulHelperControl,
           }),
       })
       const layer = keymaxxerGitHubLayer({ workspaceRoot: "/workspace" }).pipe(
@@ -400,7 +416,11 @@ describe("Keymaxxer-backed GitHub layer", () => {
           addSecret: () => Effect.die("not used"),
           runWithSecrets: (input) => {
             runs.push(input)
-            return Effect.succeed({ exitCode: 0, stdout: "321", stderr: "" })
+            return Effect.succeed({
+              exitCode: 0,
+              stdout: "321",
+              stderr: successfulHelperControl,
+            })
           },
         })
         const layer = keymaxxerGitHubLayer({
@@ -438,7 +458,11 @@ describe("Keymaxxer-backed GitHub layer", () => {
           addSecret: () => Effect.die("not used"),
           runWithSecrets: (input) => {
             runs.push(input)
-            return Effect.succeed({ exitCode: 0, stdout: "4", stderr: "" })
+            return Effect.succeed({
+              exitCode: 0,
+              stdout: "4",
+              stderr: successfulHelperControl,
+            })
           },
         })
         const layer = keymaxxerGitHubLayer({
@@ -476,9 +500,17 @@ describe("Keymaxxer-backed GitHub layer", () => {
           runWithSecrets: (input) => {
             runs.push(input)
             if (runs.length === 1) {
-              return Effect.succeed({ exitCode: 0, stdout: "   ", stderr: "" })
+              return Effect.succeed({
+                exitCode: 0,
+                stdout: "   ",
+                stderr: successfulHelperControl,
+              })
             }
-            return Effect.succeed({ exitCode: 0, stdout: "3", stderr: "" })
+            return Effect.succeed({
+              exitCode: 0,
+              stdout: "3",
+              stderr: successfulHelperControl,
+            })
           },
         })
         const layer = keymaxxerGitHubLayer({
@@ -545,7 +577,7 @@ describe("Keymaxxer-backed GitHub layer", () => {
           Effect.succeed({
             exitCode: 0,
             stdout: responses.shift()!,
-            stderr: "",
+            stderr: successfulHelperControl,
           }),
       })
       const layer = keymaxxerGitHubLayer({ workspaceRoot: "/workspace" }).pipe(
@@ -619,7 +651,7 @@ describe("Keymaxxer-backed GitHub layer", () => {
             return Effect.succeed({
               exitCode: 0,
               stdout: JSON.stringify({ _tag: "ready" }),
-              stderr: "",
+              stderr: successfulHelperControl,
             })
           },
         })
@@ -646,11 +678,12 @@ describe("Keymaxxer-backed GitHub layer", () => {
   )
 
   it.effect(
-    "sanitizes ANSI Effect dumps from CLI stderr into plain GitHubRequestError messages",
+    "does not surface raw helper stderr in GitHubRequestError messages",
     () =>
       Effect.gen(function* () {
         const esc = String.fromCharCode(0x1b)
-        const ansiDump = `{\n  ${esc}[0m_tag${esc}[2m:${esc}[0m ${esc}[32m"GitHubRequestError"${esc}[0m,\n  ${esc}[0mmessage${esc}[2m:${esc}[0m ${esc}[32m"HTTP 401: Bad credentials"${esc}[0m,\n}`
+        const secret = "ghp_helper_stderr_must_not_escape"
+        const ansiDump = `{\n  ${esc}[0m_tag${esc}[2m:${esc}[0m ${esc}[32m"GitHubRequestError"${esc}[0m,\n  ${esc}[0mmessage${esc}[2m:${esc}[0m ${esc}[32m"HTTP 401: Bad credentials ${secret}"${esc}[0m,\n}`
         const keymaxxerLayer = Layer.succeed(KeymaxxerService, {
           initialize: Effect.void,
           findSecret: () => Effect.succeed("GITHUB_TOKEN_ACME_WIDGETS"),
@@ -684,10 +717,46 @@ describe("Keymaxxer-backed GitHub layer", () => {
 
         expect(error).toBeInstanceOf(GitHubRequestError)
         expect(error.message).toBe(
-          "Failed to get pull request check status for processfocus/monorepo: HTTP 401: Bad credentials",
+          "Failed to get pull request check status for processfocus/monorepo",
         )
         expect(error.message.includes(`${esc}[`)).toBe(false)
         expect(error.message).not.toContain("_tag")
+        expect(error.message).not.toContain("Bad credentials")
+        expect(error.message).not.toContain(secret)
+      }),
+  )
+
+  it.effect(
+    "does not surface raw successful-helper stdout in decode errors",
+    () =>
+      Effect.gen(function* () {
+        const secret = "ghp_helper_stdout_must_not_escape"
+        const keymaxxerLayer = Layer.succeed(KeymaxxerService, {
+          initialize: Effect.void,
+          findSecret: () => Effect.succeed("GITHUB_TOKEN_ACME_WIDGETS"),
+          findSecrets: () => Effect.die("not used"),
+          hasSecret: () => Effect.die("not used"),
+          addSecret: () => Effect.die("not used"),
+          runWithSecrets: () =>
+            Effect.succeed({
+              exitCode: 0,
+              stdout: secret,
+              stderr: successfulHelperControl,
+            }),
+        })
+        const layer = keymaxxerGitHubLayer({
+          workspaceRoot: "/workspace",
+        }).pipe(Layer.provide(keymaxxerLayer))
+
+        const error = yield* Effect.gen(function* () {
+          const github = yield* GitHubService
+          return yield* github
+            .countOpenNonDraftPullRequests(acmeWidgets)
+            .pipe(Effect.flip)
+        }).pipe(Effect.provide(layer))
+
+        expect(error).toBeInstanceOf(GitHubRequestError)
+        expect(error.message).not.toContain(secret)
       }),
   )
 
@@ -718,7 +787,7 @@ describe("Keymaxxer-backed GitHub layer", () => {
           return Effect.succeed({
             exitCode: 0,
             stdout: JSON.stringify(serializedOutcomes[runs.length - 1]),
-            stderr: "",
+            stderr: successfulHelperControl,
           })
         },
       })
@@ -774,7 +843,7 @@ describe("Keymaxxer-backed GitHub layer", () => {
                 closingPullRequests: [],
               },
             ]),
-            stderr: "",
+            stderr: successfulHelperControl,
           }),
       })
       const layer = keymaxxerGitHubLayer({ workspaceRoot: "/workspace" }).pipe(
@@ -825,7 +894,11 @@ describe("Keymaxxer-backed GitHub layer", () => {
               runs.push(input)
               yield* Deferred.succeed(helperStarted, undefined)
               yield* Deferred.await(releaseHelper)
-              return { exitCode: 0, stdout: "7", stderr: "" }
+              return {
+                exitCode: 0,
+                stdout: "7",
+                stderr: successfulHelperControl,
+              }
             }),
         })
         const layer = keymaxxerGitHubLayer({
@@ -876,7 +949,7 @@ describe("Keymaxxer-backed GitHub layer", () => {
           runs.push(input)
           helperStarts += 1
           yield* Effect.promise(() => helperHeld)
-          return { exitCode: 0, stdout: "7", stderr: "" }
+          return { exitCode: 0, stdout: "7", stderr: successfulHelperControl }
         }),
     })
     const runtime = ManagedRuntime.make(
@@ -948,14 +1021,14 @@ describe("Keymaxxer-backed GitHub layer", () => {
         Effect.gen(function* () {
           if (input.command.includes("count-open-non-draft-pull-requests.ts")) {
             countHelperStarts += 1
-            return { exitCode: 0, stdout: "7", stderr: "" }
+            return { exitCode: 0, stdout: "7", stderr: successfulHelperControl }
           }
           signalActiveHelperStart()
           yield* Effect.promise(() => activeHelperHeld)
           return {
             exitCode: 0,
             stdout: JSON.stringify({ _tag: "open" }),
-            stderr: "",
+            stderr: successfulHelperControl,
           }
         }),
     })
@@ -1018,7 +1091,11 @@ describe("Keymaxxer-backed GitHub layer", () => {
           runWithSecrets: (input) => {
             runs.push(input)
             const stdout = input.secrets[0] === "TOKEN_WIDGETS" ? "2" : "9"
-            return Effect.succeed({ exitCode: 0, stdout, stderr: "" })
+            return Effect.succeed({
+              exitCode: 0,
+              stdout,
+              stderr: successfulHelperControl,
+            })
           },
         })
         const layer = keymaxxerGitHubLayer({
@@ -1061,7 +1138,7 @@ describe("Keymaxxer-backed GitHub layer", () => {
             return Effect.succeed({
               exitCode: 0,
               stdout: String(runs.length),
-              stderr: "",
+              stderr: successfulHelperControl,
             })
           },
         })
@@ -1103,7 +1180,7 @@ describe("Keymaxxer-backed GitHub layer", () => {
             return Effect.succeed({
               exitCode: 0,
               stdout: String(runs.length * 3),
-              stderr: "",
+              stderr: successfulHelperControl,
             })
           },
         })
@@ -1150,9 +1227,17 @@ describe("Keymaxxer-backed GitHub layer", () => {
               })
             }
             if (runs.length === 2) {
-              return Effect.succeed({ exitCode: 2, stdout: "", stderr: "" })
+              return Effect.succeed({
+                exitCode: 2,
+                stdout: "",
+                stderr: "",
+              })
             }
-            return Effect.succeed({ exitCode: 0, stdout: "0", stderr: "" })
+            return Effect.succeed({
+              exitCode: 0,
+              stdout: "0",
+              stderr: successfulHelperControl,
+            })
           },
         })
         const layer = keymaxxerGitHubLayer({
@@ -1214,14 +1299,18 @@ describe("Keymaxxer-backed GitHub layer", () => {
               if (
                 input.command.includes("count-open-non-draft-pull-requests.ts")
               ) {
-                return { exitCode: 0, stdout: "8", stderr: "" }
+                return {
+                  exitCode: 0,
+                  stdout: "8",
+                  stderr: successfulHelperControl,
+                }
               }
               yield* Deferred.succeed(lifecycleHelperStarted, undefined)
               yield* Deferred.await(releaseLifecycleHelper)
               return {
                 exitCode: 0,
                 stdout: JSON.stringify({ _tag: "open" }),
-                stderr: "",
+                stderr: successfulHelperControl,
               }
             }),
         })
@@ -1272,7 +1361,7 @@ describe("Keymaxxer-backed GitHub layer", () => {
               return {
                 exitCode: 0,
                 stdout: JSON.stringify({ _tag: "open" }),
-                stderr: "",
+                stderr: successfulHelperControl,
               }
             }),
         })
@@ -1359,7 +1448,11 @@ describe("Keymaxxer-backed GitHub layer", () => {
             expect(input.secrets).toEqual([secretName])
             expect(input.command).toContain(`GITHUB_TOKEN="$${secretName}"`)
             expect(JSON.stringify(input)).not.toContain(rawToken)
-            return Effect.succeed({ exitCode: 0, stdout: "5", stderr: "" })
+            return Effect.succeed({
+              exitCode: 0,
+              stdout: "5",
+              stderr: successfulHelperControl,
+            })
           },
         })
         const layer = keymaxxerGitHubLayer({
@@ -1374,6 +1467,167 @@ describe("Keymaxxer-backed GitHub layer", () => {
         expect(count).toBe(5)
         expect(runs).toHaveLength(1)
         expect(JSON.stringify(runs)).not.toContain(rawToken)
+      }),
+  )
+
+  it.effect(
+    "reconstructs a typed GitHub throttle from a full helper control result",
+    () =>
+      Effect.gen(function* () {
+        const retryAt = Date.now() + 60_000
+        let helperRuns = 0
+        const keymaxxerLayer = Layer.succeed(KeymaxxerService, {
+          initialize: Effect.void,
+          findSecret: () => Effect.succeed("GITHUB_TOKEN_ACME_WIDGETS"),
+          findSecrets: () => Effect.die("not used"),
+          hasSecret: () => Effect.die("not used"),
+          addSecret: () => Effect.die("not used"),
+          runWithSecrets: () => {
+            helperRuns += 1
+            return Effect.succeed({
+              exitCode: 3,
+              stdout: "",
+              stderr: serializeGitHubHelperControl(
+                githubHelperThrottled({ retryAt, usedFallback: false }),
+              ),
+            })
+          },
+        })
+        const layer = keymaxxerGitHubLayer({
+          workspaceRoot: "/workspace",
+        }).pipe(Layer.provide(keymaxxerLayer))
+
+        const [first, second] = yield* Effect.gen(function* () {
+          const github = yield* GitHubService
+          const first = yield* github
+            .getOpenPullRequestNumber(acmeWidgets, "first")
+            .pipe(Effect.flip)
+          const second = yield* github
+            .getOpenPullRequestNumber(acmeWidgets, "second")
+            .pipe(Effect.flip)
+          return [first, second] as const
+        }).pipe(Effect.provide(layer))
+        expect(first).toBeInstanceOf(GitHubThrottledError)
+        if (first instanceof GitHubThrottledError) {
+          expect(first.retryAt).toBe(retryAt)
+        }
+        expect(second).toBeInstanceOf(GitHubThrottledError)
+        expect(helperRuns).toBe(1)
+      }),
+  )
+
+  it.effect(
+    "fails malformed helper throttle results without guessing or exposing their payload",
+    () =>
+      Effect.gen(function* () {
+        const secret = "ghp_helper_protocol_secret"
+        const keymaxxerLayer = Layer.succeed(KeymaxxerService, {
+          initialize: Effect.void,
+          findSecret: () => Effect.succeed("GITHUB_TOKEN_ACME_WIDGETS"),
+          findSecrets: () => Effect.die("not used"),
+          hasSecret: () => Effect.die("not used"),
+          addSecret: () => Effect.die("not used"),
+          runWithSecrets: () =>
+            Effect.succeed({
+              exitCode: 3,
+              stdout: "",
+              stderr: JSON.stringify({
+                version: 99,
+                kind: "github-throttled",
+                retryAt: Date.now() + 60_000,
+                usedFallback: false,
+                secret,
+              }),
+            }),
+        })
+        const layer = keymaxxerGitHubLayer({
+          workspaceRoot: "/workspace",
+        }).pipe(Layer.provide(keymaxxerLayer))
+        const error = yield* Effect.gen(function* () {
+          const github = yield* GitHubService
+          return yield* github
+            .getOpenPullRequestNumber(acmeWidgets, "branch")
+            .pipe(Effect.flip)
+        }).pipe(Effect.provide(layer))
+
+        expect(error).toBeInstanceOf(GitHubRequestError)
+        expect(error.message).not.toContain(secret)
+      }),
+  )
+
+  it.effect(
+    "rejects successful helper results without the required control record",
+    () =>
+      Effect.gen(function* () {
+        const keymaxxerLayer = Layer.succeed(KeymaxxerService, {
+          initialize: Effect.void,
+          findSecret: () => Effect.succeed("GITHUB_TOKEN_ACME_WIDGETS"),
+          findSecrets: () => Effect.die("not used"),
+          hasSecret: () => Effect.die("not used"),
+          addSecret: () => Effect.die("not used"),
+          runWithSecrets: () =>
+            Effect.succeed({ exitCode: 0, stdout: "7", stderr: "" }),
+        })
+        const layer = keymaxxerGitHubLayer({
+          workspaceRoot: "/workspace",
+        }).pipe(Layer.provide(keymaxxerLayer))
+        const error = yield* Effect.gen(function* () {
+          const github = yield* GitHubService
+          return yield* github
+            .getOpenPullRequestNumber(acmeWidgets, "branch")
+            .pipe(Effect.flip)
+        }).pipe(Effect.provide(layer))
+
+        expect(error).toBeInstanceOf(GitHubRequestError)
+      }),
+  )
+
+  it.effect(
+    "closes future Keymaxxer admission after a successful final-quota helper result",
+    () =>
+      Effect.gen(function* () {
+        const retryAt = Date.now() + 60_000
+        let helperRuns = 0
+        const keymaxxerLayer = Layer.succeed(KeymaxxerService, {
+          initialize: Effect.void,
+          findSecret: () => Effect.succeed("GITHUB_TOKEN_ACME_WIDGETS"),
+          findSecrets: () => Effect.die("not used"),
+          hasSecret: () => Effect.die("not used"),
+          addSecret: () => Effect.die("not used"),
+          runWithSecrets: () => {
+            helperRuns += 1
+            return Effect.succeed({
+              exitCode: 0,
+              stdout: "7",
+              stderr: serializeGitHubHelperControl(
+                githubHelperSuccess({
+                  throttle: { retryAt, usedFallback: false },
+                }),
+              ),
+            })
+          },
+        })
+        const layer = keymaxxerGitHubLayer({
+          workspaceRoot: "/workspace",
+        }).pipe(Layer.provide(keymaxxerLayer))
+
+        const [first, second] = yield* Effect.gen(function* () {
+          const github = yield* GitHubService
+          const first = yield* github.getOpenPullRequestNumber(
+            acmeWidgets,
+            "first",
+          )
+          const second = yield* github
+            .getOpenPullRequestNumber(acmeWidgets, "second")
+            .pipe(Effect.flip)
+          return [first, second] as const
+        }).pipe(Effect.provide(layer))
+        expect(first).toBe(7)
+        expect(second).toBeInstanceOf(GitHubThrottledError)
+        if (second instanceof GitHubThrottledError) {
+          expect(second.retryAt).toBe(retryAt)
+        }
+        expect(helperRuns).toBe(1)
       }),
   )
 })

--- a/docs/adr/0004-development-keymaxxer-sidecar.md
+++ b/docs/adr/0004-development-keymaxxer-sidecar.md
@@ -8,6 +8,16 @@ Ready for Agent uses a shared backend Keymaxxer Service that never exposes raw s
 - Development uses `scripts/run-with-keymaxxer-sidecar.ts` so the sidecar survives Vite reloads. Production uses one lifecycle owner (`apps/harness/src/server/production-lifecycle.ts`) that starts the sidecar as a lifecycle-owned child by re-executing the same program in an internal non-product mode (`--ready-for-agent-internal-keymaxxer-sidecar`), captures the stdout bootstrap line `KEYMAXXER_SIDECAR_URL=http://127.0.0.1:<port>/<capability>/mcp` through a private pipe, and keeps that URL in memory only. Compiled binaries need no external Bun runtime and no workspace TypeScript Sidecar entrypoint.
 - There is no unauthenticated `/health` route. Readiness is TCP listen; auth is the unguessable path capability (#113).
 
+## Serialization boundaries
+
+The Sidecar's human-dialog lane prevents competing vault unlock and approval
+dialogs; it is not a GitHub request queue. The Harness-owned, process-local
+**GitHub Operation Coordinator** admits a complete Keymaxxer-backed GitHub
+operation before secret lookup and helper dispatch, and keeps its permit until
+the helper settles. The Sidecar remains responsible only for vault interaction
+and named-secret injection, so it neither owns coordinator state nor derives
+GitHub throttling from helper stderr.
+
 ## Security
 
 - Bind `127.0.0.1` only. MCP lives only at `/<capability>/mcp`.

--- a/packages/github-service/src/bin/cli.ts
+++ b/packages/github-service/src/bin/cli.ts
@@ -1,14 +1,19 @@
 import * as BunFileSystem from "@effect/platform-bun/BunFileSystem"
 import * as BunRuntime from "@effect/platform-bun/BunRuntime"
 import { Effect, Layer, Schema } from "effect"
-import { GitHubRepositoryUnavailableError } from "../lib/errors.js"
+import {
+  GitHubRepositoryUnavailableError,
+  type GitHubThrottledError,
+  isGitHubThrottledError,
+} from "../lib/errors.js"
+import {
+  GITHUB_HELPER_THROTTLED_EXIT_CODE,
+  githubHelperSuccess,
+  githubHelperThrottled,
+  serializeGitHubHelperControl,
+} from "../lib/github-helper-protocol.js"
 import type { GitHubService } from "../lib/github-service.js"
-import { GitHubServiceLive } from "../lib/github-service-live.js"
-import { formatUserFacingError } from "../lib/user-facing-error.js"
-
-const GitHubServiceCliLive = GitHubServiceLive.pipe(
-  Layer.provide(BunFileSystem.layer),
-)
+import { makeGitHubServiceLive } from "../lib/github-service-live.js"
 
 export class CliArgumentError extends Schema.TaggedErrorClass<CliArgumentError>()(
   "CliArgumentError",
@@ -38,20 +43,60 @@ export const writeStandardOutput = (value: string): Effect.Effect<void> =>
 
 export const runGitHubCli = <A, E>(
   program: Effect.Effect<A, E, GitHubService>,
-): void =>
+): void => {
+  let observedThrottle: GitHubThrottledError | undefined
+  const observeThrottle = (throttle: GitHubThrottledError): void => {
+    if (
+      observedThrottle === undefined ||
+      throttle.retryAt > observedThrottle.retryAt
+    ) {
+      observedThrottle = throttle
+    }
+  }
+  const githubServiceCliLive = makeGitHubServiceLive(observeThrottle).pipe(
+    Layer.provide(BunFileSystem.layer),
+  )
+  const writeControl = (control: ReturnType<typeof githubHelperSuccess>) =>
+    process.stderr.write(`${serializeGitHubHelperControl(control)}\n`)
+  const writeThrottle = (throttle: GitHubThrottledError) =>
+    process.stderr.write(
+      `${serializeGitHubHelperControl(githubHelperThrottled(throttle))}\n`,
+    )
+
   program.pipe(
-    Effect.provide(GitHubServiceCliLive),
+    Effect.provide(githubServiceCliLive),
+    Effect.tap(() =>
+      Effect.sync(() =>
+        writeControl(
+          observedThrottle === undefined
+            ? githubHelperSuccess()
+            : githubHelperSuccess({ throttle: observedThrottle }),
+        ),
+      ),
+    ),
     Effect.catch((error) =>
       Effect.sync(() => {
         if (error instanceof GitHubRepositoryUnavailableError) {
           process.exitCode = 2
           return
         }
-        process.stderr.write(
-          `${formatUserFacingError(error, "Command failed")}\n`,
-        )
+        if (isGitHubThrottledError(error)) {
+          writeThrottle(error)
+          process.exitCode = GITHUB_HELPER_THROTTLED_EXIT_CODE
+          return
+        }
+        if (error instanceof CliArgumentError) {
+          process.stderr.write(`${error.message}\n`)
+          process.exitCode = 1
+          return
+        }
+        // Child stderr crosses the Keymaxxer credential boundary. Errors from
+        // remote APIs or Effect defects can contain arbitrary request data, so
+        // keep the user-facing failure deliberately non-diagnostic here.
+        process.stderr.write("GitHub helper command failed\n")
         process.exitCode = 1
       }),
     ),
     BunRuntime.runMain,
   )
+}

--- a/packages/github-service/src/index.ts
+++ b/packages/github-service/src/index.ts
@@ -2,10 +2,12 @@ export { githubServiceBinScriptPath } from "./bin-script-path.js"
 export * from "./lib/automated-review-evidence.js"
 export * from "./lib/errors.js"
 export * from "./lib/github-helper-process.js"
+export * from "./lib/github-helper-protocol.js"
 export * from "./lib/github-service.js"
 export {
   GitHubServiceLive,
   makeGitHubServiceFromToken,
+  makeGitHubServiceLive,
 } from "./lib/github-service-live.js"
 export * from "./lib/github-service-test.js"
 export * from "./lib/github-throttle.js"

--- a/packages/github-service/src/lib/github-helper-protocol.ts
+++ b/packages/github-service/src/lib/github-helper-protocol.ts
@@ -1,0 +1,109 @@
+/**
+ * Machine-readable control records written by GitHub helpers to stderr.
+ *
+ * Helper stdout remains the operation's existing data contract. Stderr carries
+ * this separate, deliberately tiny control plane so a parent can distinguish
+ * an explicit GitHub throttle from a human-oriented command failure without
+ * receiving credential material.
+ */
+export const GITHUB_HELPER_PROTOCOL_VERSION = 1 as const
+export const GITHUB_HELPER_THROTTLED_EXIT_CODE = 3 as const
+
+export interface GitHubHelperThrottle {
+  readonly retryAt: number
+  readonly usedFallback: boolean
+}
+
+export interface GitHubHelperSuccess {
+  readonly version: typeof GITHUB_HELPER_PROTOCOL_VERSION
+  readonly kind: "success"
+  /** Present only when a successful response exhausted the final quota. */
+  readonly throttle: GitHubHelperThrottle | null
+}
+
+export interface GitHubHelperThrottled {
+  readonly version: typeof GITHUB_HELPER_PROTOCOL_VERSION
+  readonly kind: "github-throttled"
+  readonly retryAt: number
+  readonly usedFallback: boolean
+}
+
+export type GitHubHelperControl = GitHubHelperSuccess | GitHubHelperThrottled
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null
+
+const isThrottle = (value: unknown): value is GitHubHelperThrottle =>
+  isRecord(value) &&
+  typeof value.retryAt === "number" &&
+  Number.isSafeInteger(value.retryAt) &&
+  value.retryAt > 0 &&
+  typeof value.usedFallback === "boolean"
+
+/**
+ * Strictly recognizes only the current helper protocol. Unknown, malformed,
+ * and future records deliberately produce `undefined`: callers must treat
+ * them as ordinary helper failures, never as a guessed throttle.
+ */
+export const parseGitHubHelperControl = (
+  text: string,
+): GitHubHelperControl | undefined => {
+  let value: unknown
+  try {
+    value = JSON.parse(text)
+  } catch {
+    return undefined
+  }
+  if (
+    !isRecord(value) ||
+    value.version !== GITHUB_HELPER_PROTOCOL_VERSION ||
+    typeof value.kind !== "string"
+  ) {
+    return undefined
+  }
+  if (value.kind === "success") {
+    if (value.throttle !== null && !isThrottle(value.throttle)) return undefined
+    return {
+      version: GITHUB_HELPER_PROTOCOL_VERSION,
+      kind: "success",
+      throttle: value.throttle,
+    }
+  }
+  if (value.kind === "github-throttled" && isThrottle(value)) {
+    return {
+      version: GITHUB_HELPER_PROTOCOL_VERSION,
+      kind: "github-throttled",
+      retryAt: value.retryAt,
+      usedFallback: value.usedFallback,
+    }
+  }
+  return undefined
+}
+
+/** This serializer accepts only non-secret protocol fields. */
+export const serializeGitHubHelperControl = (
+  value: GitHubHelperControl,
+): string => JSON.stringify(value)
+
+export const githubHelperSuccess = (input?: {
+  readonly throttle?: GitHubHelperThrottle
+}): GitHubHelperSuccess => ({
+  version: GITHUB_HELPER_PROTOCOL_VERSION,
+  kind: "success",
+  throttle:
+    input?.throttle === undefined
+      ? null
+      : {
+          retryAt: input.throttle.retryAt,
+          usedFallback: input.throttle.usedFallback,
+        },
+})
+
+export const githubHelperThrottled = (
+  throttle: GitHubHelperThrottle,
+): GitHubHelperThrottled => ({
+  version: GITHUB_HELPER_PROTOCOL_VERSION,
+  kind: "github-throttled",
+  retryAt: throttle.retryAt,
+  usedFallback: throttle.usedFallback,
+})

--- a/packages/github-service/src/lib/github-service-live.ts
+++ b/packages/github-service/src/lib/github-service-live.ts
@@ -3224,11 +3224,22 @@ export const makeGitHubServiceFromToken = (
   )
 }
 
-export const GitHubServiceLive = Layer.effect(
-  GitHubService,
-  Effect.gen(function* () {
-    const token = yield* Config.redacted("GITHUB_TOKEN")
-    const fs = yield* FileSystem.FileSystem
-    return makeGitHubServiceFromToken(Redacted.value(token), fetch, fs)
-  }),
-)
+/** Builds a live service and optionally observes successful final-quota use. */
+export const makeGitHubServiceLive = (
+  observeThrottle?: GitHubThrottleObserver,
+): Layer.Layer<GitHubService, Config.ConfigError, FileSystem.FileSystem> =>
+  Layer.effect(
+    GitHubService,
+    Effect.gen(function* () {
+      const token = yield* Config.redacted("GITHUB_TOKEN")
+      const fs = yield* FileSystem.FileSystem
+      return makeGitHubServiceFromToken(
+        Redacted.value(token),
+        fetch,
+        fs,
+        observeThrottle,
+      )
+    }),
+  )
+
+export const GitHubServiceLive = makeGitHubServiceLive()

--- a/packages/github-service/src/lib/open-non-draft-pull-request-count.ts
+++ b/packages/github-service/src/lib/open-non-draft-pull-request-count.ts
@@ -8,6 +8,17 @@
  * 500ms delay (no retry on HTTP 401), repository-unavailable when GitHub
  * returns a null repository.
  */
+import {
+  GITHUB_HELPER_THROTTLED_EXIT_CODE,
+  type GitHubHelperThrottle,
+  githubHelperSuccess,
+  githubHelperThrottled,
+  serializeGitHubHelperControl,
+} from "./github-helper-protocol.js"
+import {
+  githubThrottleFromResponse,
+  githubThrottleFromSuccessfulResponse,
+} from "./github-throttle.js"
 
 const GITHUB_GRAPHQL_URL = "https://api.github.com/graphql"
 const PAGE_SIZE = 100
@@ -37,6 +48,8 @@ export type OpenNonDraftPullRequestCountFetch = (
 export type OpenNonDraftPullRequestCountOk = {
   readonly _tag: "ok"
   readonly count: number
+  /** Explicit final-quota evidence observed while completing the count. */
+  readonly throttle?: GitHubHelperThrottle
 }
 
 export type OpenNonDraftPullRequestCountUnavailable = {
@@ -49,9 +62,16 @@ export type OpenNonDraftPullRequestCountFailed = {
   readonly statusCode?: number
 }
 
+export type OpenNonDraftPullRequestCountThrottled = {
+  readonly _tag: "throttled"
+  readonly retryAt: number
+  readonly usedFallback: boolean
+}
+
 export type OpenNonDraftPullRequestCountResult =
   | OpenNonDraftPullRequestCountOk
   | OpenNonDraftPullRequestCountUnavailable
+  | OpenNonDraftPullRequestCountThrottled
   | OpenNonDraftPullRequestCountFailed
 
 export type OpenNonDraftPullRequestCountInput = {
@@ -82,9 +102,16 @@ type GraphQlPage = {
 class CountHttpError extends Error {
   constructor(
     readonly statusCode: number,
+    readonly headers: Headers,
     message: string,
   ) {
     super(message)
+  }
+}
+
+class CountThrottledError extends Error {
+  constructor(readonly throttle: GitHubHelperThrottle) {
+    super("GitHub throttled")
   }
 }
 
@@ -123,6 +150,7 @@ const fetchGraphQlPage = async (
     readonly name: string
     readonly after: string | null
     readonly fetchImpl: OpenNonDraftPullRequestCountFetch
+    readonly observeSuccessfulThrottle: (throttle: GitHubHelperThrottle) => void
   },
   signal: AbortSignal,
 ): Promise<GraphQlPage> => {
@@ -146,10 +174,14 @@ const fetchGraphQlPage = async (
 
   if (!response.ok) {
     const body = await response.text()
-    throw new CountHttpError(
-      response.status,
-      `${response.statusText}: ${body.slice(0, 300)}`,
-    )
+    const message = `${response.statusText}: ${body.slice(0, 300)}`
+    const throttle = githubThrottleFromResponse({
+      statusCode: response.status,
+      headers: response.headers,
+      message,
+    })
+    if (throttle !== undefined) throw new CountThrottledError(throttle)
+    throw new CountHttpError(response.status, response.headers, message)
   }
 
   const page = (await response.json()) as GraphQlPage
@@ -164,8 +196,18 @@ const fetchGraphQlPage = async (
           : "GraphQL error",
       )
       .join("\n")
+    const throttle = githubThrottleFromResponse({
+      statusCode: response.status,
+      headers: response.headers,
+      message,
+    })
+    if (throttle !== undefined) throw new CountThrottledError(throttle)
     throw new Error(message)
   }
+  const throttle = githubThrottleFromSuccessfulResponse({
+    headers: response.headers,
+  })
+  if (throttle !== undefined) input.observeSuccessfulThrottle(throttle)
   return page
 }
 
@@ -185,6 +227,7 @@ const withTimeoutAndRetry = async <A>(
       const value: A = await request(controller.signal)
       return value
     } catch (cause) {
+      if (cause instanceof CountThrottledError) throw cause
       const statusCode =
         cause instanceof CountHttpError ? cause.statusCode : undefined
       const timedOut =
@@ -226,6 +269,15 @@ export const countOpenNonDraftPullRequestsLite = async (
   const label = projectLabel(input.owner, input.name)
   let count = 0
   let cursor: string | null = null
+  let observedThrottle: GitHubHelperThrottle | undefined
+  const observeSuccessfulThrottle = (throttle: GitHubHelperThrottle): void => {
+    if (
+      observedThrottle === undefined ||
+      throttle.retryAt > observedThrottle.retryAt
+    ) {
+      observedThrottle = throttle
+    }
+  }
 
   try {
     for (;;) {
@@ -240,6 +292,7 @@ export const countOpenNonDraftPullRequestsLite = async (
               name: input.name,
               after: afterCursor,
               fetchImpl,
+              observeSuccessfulThrottle,
             },
             signal,
           ),
@@ -273,8 +326,17 @@ export const countOpenNonDraftPullRequestsLite = async (
       }
       cursor = pageInfo.endCursor
     }
-    return { _tag: "ok", count }
+    return observedThrottle === undefined
+      ? { _tag: "ok", count }
+      : { _tag: "ok", count, throttle: observedThrottle }
   } catch (cause) {
+    if (cause instanceof CountThrottledError) {
+      return {
+        _tag: "throttled",
+        retryAt: cause.throttle.retryAt,
+        usedFallback: cause.throttle.usedFallback,
+      }
+    }
     const statusCode =
       typeof cause === "object" &&
       cause !== null &&
@@ -282,10 +344,7 @@ export const countOpenNonDraftPullRequestsLite = async (
       typeof (cause as { statusCode: unknown }).statusCode === "number"
         ? (cause as { statusCode: number }).statusCode
         : undefined
-    const message =
-      cause instanceof Error && cause.message.trim() !== ""
-        ? cause.message
-        : `Failed to count open pull requests for ${label}`
+    const message = `Failed to count open pull requests for ${label}`
     return statusCode === undefined
       ? { _tag: "error", message }
       : { _tag: "error", message, statusCode }
@@ -337,25 +396,36 @@ export const runOpenNonDraftPullRequestCountCli = async (
     })
 
     if (result._tag === "ok") {
-      return { exitCode: 0, stdout: String(result.count), stderr: "" }
+      return {
+        exitCode: 0,
+        stdout: String(result.count),
+        stderr: serializeGitHubHelperControl(
+          result.throttle === undefined
+            ? githubHelperSuccess()
+            : githubHelperSuccess({ throttle: result.throttle }),
+        ),
+      }
     }
     if (result._tag === "unavailable") {
       return { exitCode: 2, stdout: "", stderr: "" }
     }
-    return {
-      exitCode: 1,
-      stdout: "",
-      stderr: `${result.message}\n`,
+    if (result._tag === "throttled") {
+      return {
+        exitCode: GITHUB_HELPER_THROTTLED_EXIT_CODE,
+        stdout: "",
+        stderr: serializeGitHubHelperControl(githubHelperThrottled(result)),
+      }
     }
-  } catch (cause) {
-    const message =
-      cause instanceof Error && cause.message.trim() !== ""
-        ? cause.message
-        : "Command failed"
     return {
       exitCode: 1,
       stdout: "",
-      stderr: `${message}\n`,
+      stderr: "Failed to count open pull requests\n",
+    }
+  } catch {
+    return {
+      exitCode: 1,
+      stdout: "",
+      stderr: "Failed to count open pull requests\n",
     }
   }
 }

--- a/packages/github-service/test/open-non-draft-pull-request-count.spec.ts
+++ b/packages/github-service/test/open-non-draft-pull-request-count.spec.ts
@@ -2,6 +2,10 @@ import { spawn } from "node:child_process"
 import { fileURLToPath } from "node:url"
 import { afterEach, describe, expect, test } from "vitest"
 import {
+  GITHUB_HELPER_THROTTLED_EXIT_CODE,
+  parseGitHubHelperControl,
+} from "../src/lib/github-helper-protocol.js"
+import {
   countOpenNonDraftPullRequestsLite,
   runOpenNonDraftPullRequestCountCli,
 } from "../src/lib/open-non-draft-pull-request-count.js"
@@ -129,7 +133,9 @@ describe("countOpenNonDraftPullRequestsLite", () => {
     expect(calls).toBe(3)
     expect(sleeps).toEqual([500, 500])
     if (result._tag === "error") {
-      expect(result.message).toContain("Something went wrong")
+      expect(result.message).toBe(
+        "Failed to count open pull requests for acme/widgets",
+      )
     }
   })
 
@@ -152,6 +158,36 @@ describe("countOpenNonDraftPullRequestsLite", () => {
     if (result._tag === "error") {
       expect(result.statusCode).toBe(401)
       expect(result.message).not.toContain("bad-token")
+    }
+  })
+
+  test("returns an explicit throttle without retrying a 429 response", async () => {
+    let calls = 0
+    const sleeps: number[] = []
+    const before = Date.now()
+    const result = await countOpenNonDraftPullRequestsLite({
+      token: "test-token",
+      owner: "acme",
+      name: "widgets",
+      sleepMs: async (ms) => {
+        sleeps.push(ms)
+      },
+      fetchImpl: async () => {
+        calls += 1
+        return new Response("secondary rate limit", {
+          status: 429,
+          statusText: "Too Many Requests",
+          headers: { "Retry-After": "120" },
+        })
+      },
+    })
+
+    expect(calls).toBe(1)
+    expect(sleeps).toEqual([])
+    expect(result._tag).toBe("throttled")
+    if (result._tag === "throttled") {
+      expect(result.retryAt).toBeGreaterThanOrEqual(before + 120_000)
+      expect(result.usedFallback).toBe(false)
     }
   })
 
@@ -227,7 +263,71 @@ describe("runOpenNonDraftPullRequestCountCli", () => {
           }),
       },
     )
-    expect(result).toEqual({ exitCode: 0, stdout: "2", stderr: "" })
+    expect(result.exitCode).toBe(0)
+    expect(result.stdout).toBe("2")
+    expect(parseGitHubHelperControl(result.stderr)).toEqual({
+      version: 1,
+      kind: "success",
+      throttle: null,
+    })
+  })
+
+  test("serializes a throttled count as the versioned non-secret control result", async () => {
+    const result = await runOpenNonDraftPullRequestCountCli(
+      [encode("github"), encode("github.com"), encode("acme/widgets")],
+      {
+        env: { GITHUB_TOKEN: "test-token" },
+        fetchImpl: async () =>
+          new Response("secondary rate limit", {
+            status: 429,
+            statusText: "Too Many Requests",
+            headers: { "Retry-After": "120" },
+          }),
+      },
+    )
+
+    expect(result.exitCode).toBe(GITHUB_HELPER_THROTTLED_EXIT_CODE)
+    expect(result.stdout).toBe("")
+    const control = parseGitHubHelperControl(result.stderr)
+    expect(control?.kind).toBe("github-throttled")
+    expect(result.stderr).not.toContain("test-token")
+  })
+
+  test("preserves final-quota evidence after a successful count", async () => {
+    const resetAt = Math.floor(Date.now() / 1_000) + 3_600
+    const result = await runOpenNonDraftPullRequestCountCli(
+      [encode("github"), encode("github.com"), encode("acme/widgets")],
+      {
+        env: { GITHUB_TOKEN: "test-token" },
+        fetchImpl: async () =>
+          new Response(
+            JSON.stringify({
+              data: {
+                repository: {
+                  pullRequests: {
+                    nodes: [],
+                    pageInfo: { endCursor: null, hasNextPage: false },
+                  },
+                },
+              },
+            }),
+            {
+              headers: {
+                "Content-Type": "application/json",
+                "X-RateLimit-Remaining": "0",
+                "X-RateLimit-Reset": String(resetAt),
+              },
+            },
+          ),
+      },
+    )
+
+    expect(result.exitCode).toBe(0)
+    expect(parseGitHubHelperControl(result.stderr)).toEqual({
+      version: 1,
+      kind: "success",
+      throttle: { retryAt: resetAt * 1_000, usedFallback: false },
+    })
   })
 
   test("exits 2 when the repository is unavailable", async () => {
@@ -265,7 +365,7 @@ describe("runOpenNonDraftPullRequestCountCli", () => {
       { env: { GITHUB_TOKEN: "test-token" } },
     )
     expect(result.exitCode).toBe(1)
-    expect(result.stderr).toContain("Missing project path argument")
+    expect(result.stderr).toBe("Failed to count open pull requests\n")
   })
 })
 


### PR DESCRIPTION
## Why

Keymaxxer-backed GitHub operations previously lost typed throttle information at
the helper boundary, preventing the Harness coordinator from applying the same
admission control as ambient GitHub access.

## What changed

- Added a versioned, non-secret helper control protocol for explicit throttles
  and successful final-quota observations.
- Updated full and lightweight PR-count helpers to emit structured control
  records.
- Reconstructed typed throttles in the Harness and closed future coordinator
  admission after final-quota success.
- Hardened helper error boundaries so raw child stdout/stderr cannot reach
  request errors, GraphQL, or logs.
- Clarified the Keymaxxer ADR and added protocol, parity, credential-isolation,
  and malformed-record coverage.

## Verification

- `bunx nx test github-service` (115 passing)
- `bunx nx test harness` (537 passing)
- `bunx nx typecheck github-service`
- `bunx nx typecheck harness`
- `bunx nx lint github-service`
- `bunx nx lint harness`
- `git diff HEAD --check`

Closes #877