### PR TITLE
fix(harness): retain open PR counts during throttling

### DIFF
--- a/apps/harness/src/home-page-content.tsx
+++ b/apps/harness/src/home-page-content.tsx
@@ -176,7 +176,9 @@ const HARNESS_DEFAULT_BACKEND_VALUE = ""
 /**
  * Dedicated cache identity for GitHub open non-draft Pull Request counts.
  * Independent of {@link repositoriesQuery}: a slow or failed count must not
- * cancel or block the Configured Repositories projection.
+ * cancel or block the Configured Repositories projection. Failures remain
+ * failures so TanStack Query can retain the last successful count map, or
+ * present unavailable when there is no successful observation yet.
  */
 const openPullRequestCountsQuery = {
   queryKey: openPullRequestCountsQueryKey,

--- a/apps/harness/src/refresh-open-pull-request-count-live.ts
+++ b/apps/harness/src/refresh-open-pull-request-count-live.ts
@@ -5,7 +5,7 @@ import type { QueryClient } from "@tanstack/react-query"
  * while the tab is visible. External PR changes do not emit Work Item SSE
  * events, so Work Item invalidation alone cannot keep the header count live.
  */
-export const OPEN_PULL_REQUEST_COUNT_POLL_INTERVAL_MS = 30_000
+export const OPEN_PULL_REQUEST_COUNT_POLL_INTERVAL_MS = 120_000
 
 /**
  * Dedicated TanStack Query cache identity for GitHub-authoritative open

--- a/apps/harness/test/keymaxxer-github-layer.test.ts
+++ b/apps/harness/test/keymaxxer-github-layer.test.ts
@@ -1429,6 +1429,104 @@ describe("Keymaxxer-backed GitHub layer", () => {
   )
 
   it.effect(
+    "a throttled count cache miss reaches neither GitHub adapter before its retry deadline",
+    () =>
+      Effect.gen(function* () {
+        let keymaxxerSecretLookups = 0
+        let keymaxxerHelperRuns = 0
+        let ambientTokenResolutions = 0
+        let ambientCountOperations = 0
+        const coordinator = makeGitHubOperationCoordinator()
+        coordinator.reportThrottle(
+          new GitHubThrottledError({
+            retryAt: Date.now() + 60_000,
+            usedFallback: false,
+          }),
+        )
+        const coordinatorLayer = Layer.succeed(
+          GitHubOperationCoordinator,
+          coordinator,
+        )
+        const keymaxxerLayer = Layer.succeed(KeymaxxerService, {
+          initialize: Effect.void,
+          findSecret: () =>
+            Effect.sync(() => {
+              keymaxxerSecretLookups += 1
+              return "GITHUB_TOKEN_ACME_WIDGETS"
+            }),
+          findSecrets: () => Effect.die("not used"),
+          hasSecret: () => Effect.die("not used"),
+          addSecret: () => Effect.die("not used"),
+          runWithSecrets: () =>
+            Effect.sync(() => {
+              keymaxxerHelperRuns += 1
+              return {
+                exitCode: 0,
+                stdout: "7",
+                stderr: successfulHelperControl,
+              }
+            }),
+        })
+        const ambientService = {
+          listReadyIssues: () => Effect.die("not used"),
+          getAuthenticatedUserLogin: () => Effect.die("not used"),
+          getOpenPullRequestNumber: () => Effect.die("not used"),
+          findOpenPullRequestNumber: () => Effect.die("not used"),
+          createDraftPullRequest: () => Effect.die("not used"),
+          updateOpenDraftPullRequestCopy: () => Effect.die("not used"),
+          countOpenNonDraftPullRequests: () =>
+            Effect.sync(() => {
+              ambientCountOperations += 1
+              return 7
+            }),
+          getPullRequestCheckStatus: () => Effect.die("not used"),
+          getPrStatusCheckDiagnostics: () => Effect.die("not used"),
+          observeAutomatedReviewEvidence: () => Effect.die("not used"),
+          getPullRequestLifecycleStatus: () => Effect.die("not used"),
+          markPullRequestReadyForReview: () => Effect.die("not used"),
+          mergePullRequest: () => Effect.die("not used"),
+          rerunWorkflowRun: () => Effect.die("not used"),
+          ensureIssueCompletedWithSummary: () => Effect.die("not used"),
+        } satisfies GitHubServiceShape
+        const scope = yield* Effect.scope
+        const keymaxxerContext = yield* Layer.buildWithScope(
+          makeKeymaxxerGitHubLayer({ workspaceRoot: "/workspace" }).pipe(
+            Layer.provide(keymaxxerLayer),
+            Layer.provide(coordinatorLayer),
+          ),
+          scope,
+        )
+        const ambientContext = yield* Layer.buildWithScope(
+          ambientGitHubLayer({
+            workspaceRoot: "/workspace",
+            resolveToken: async () => {
+              ambientTokenResolutions += 1
+              return "ambient-token"
+            },
+            makeService: () => ambientService,
+          }).pipe(Layer.provide(coordinatorLayer), Layer.provide(processLayer)),
+          scope,
+        )
+        const keymaxxer = Context.get(keymaxxerContext, GitHubService)
+        const ambient = Context.get(ambientContext, GitHubService)
+
+        const [keymaxxerFailure, ambientFailure] = yield* Effect.all([
+          keymaxxer
+            .countOpenNonDraftPullRequests(acmeWidgets)
+            .pipe(Effect.flip),
+          ambient.countOpenNonDraftPullRequests(acmeWidgets).pipe(Effect.flip),
+        ])
+
+        expect(keymaxxerFailure).toBeInstanceOf(GitHubThrottledError)
+        expect(ambientFailure).toBeInstanceOf(GitHubThrottledError)
+        expect(keymaxxerSecretLookups).toBe(0)
+        expect(keymaxxerHelperRuns).toBe(0)
+        expect(ambientTokenResolutions).toBe(0)
+        expect(ambientCountOperations).toBe(0)
+      }),
+  )
+
+  it.effect(
     "raw Forge credentials stay in the Keymaxxer child and never enter the count result path",
     () =>
       Effect.gen(function* () {

--- a/apps/harness/test/refresh-open-pull-request-count-live.test.ts
+++ b/apps/harness/test/refresh-open-pull-request-count-live.test.ts
@@ -9,6 +9,14 @@ import { describe, expect, test } from "bun:test"
 
 const wait = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
 
+const waitFor = async (predicate: () => boolean): Promise<void> => {
+  for (let attempt = 0; attempt < 100; attempt += 1) {
+    if (predicate()) return
+    await Promise.resolve()
+  }
+  throw new Error("condition did not become true")
+}
+
 describe("openPullRequestCountPresentation", () => {
   test("shows a known count with singular or plural label", () => {
     expect(
@@ -74,12 +82,148 @@ describe("openPullRequestCountPresentation", () => {
 
 describe("followOpenPullRequestCountLive", () => {
   test("exports a positive poll interval for GitHub-backed counts", () => {
-    expect(OPEN_PULL_REQUEST_COUNT_POLL_INTERVAL_MS).toBeGreaterThan(0)
+    expect(OPEN_PULL_REQUEST_COUNT_POLL_INTERVAL_MS).toBe(120_000)
+  })
+
+  test("retains a last-known count map after a later count fetch fails", async () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    })
+    let calls = 0
+    const openPullRequestCountsQuery = {
+      queryKey: openPullRequestCountsQueryKey,
+      queryFn: async () => {
+        calls += 1
+        if (calls === 1) return { "repo-1": 4 }
+        throw new Error("GitHub throttled")
+      },
+    }
+
+    await queryClient.fetchQuery(openPullRequestCountsQuery)
+    await expect(
+      queryClient.fetchQuery({ ...openPullRequestCountsQuery, staleTime: 0 }),
+    ).rejects.toThrow("GitHub throttled")
+
+    const data = queryClient.getQueryData<Readonly<Record<string, number>>>(
+      openPullRequestCountsQuery.queryKey,
+    )
+    expect(data).toEqual({ "repo-1": 4 })
+    expect(
+      openPullRequestCountPresentation({
+        count: data?.["repo-1"],
+        isPending: false,
+        isFetching: false,
+      }),
+    ).toMatchObject({ display: "4", loading: false })
+  })
+
+  test("settles a first failed count fetch as unavailable rather than zero", async () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    })
+    const openPullRequestCountsQuery = {
+      queryKey: openPullRequestCountsQueryKey,
+      queryFn: async () => {
+        throw new Error("GitHub throttled")
+      },
+    }
+
+    await expect(
+      queryClient.fetchQuery(openPullRequestCountsQuery),
+    ).rejects.toThrow("GitHub throttled")
+
+    const data = queryClient.getQueryData<Readonly<Record<string, number>>>(
+      openPullRequestCountsQuery.queryKey,
+    )
+    expect(data).toBeUndefined()
+    expect(
+      openPullRequestCountPresentation({
+        count: data?.["repo-1"],
+        isPending: false,
+        isFetching: false,
+      }),
+    ).toEqual({
+      label: "Open pull requests unavailable",
+      display: "—",
+      loading: false,
+    })
   })
 
   test("uses a dedicated query key distinct from repositories", () => {
     expect(openPullRequestCountsQueryKey).toEqual(["open-pull-request-counts"])
     expect(openPullRequestCountsQueryKey).not.toEqual(["repositories"])
+  })
+
+  test("visibility refresh retains the last known count after throttling", async () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    })
+    let countFetches = 0
+    let repositoryFetches = 0
+    const openPullRequestCountsQuery = {
+      queryKey: openPullRequestCountsQueryKey,
+      queryFn: async () => {
+        countFetches += 1
+        if (countFetches === 1) return { "repo-1": 4 }
+        throw new Error("GitHub throttled")
+      },
+    }
+    const repositoriesQuery = {
+      queryKey: ["repositories"] as const,
+      queryFn: async () => {
+        repositoryFetches += 1
+        return [{ id: "repo-1" }]
+      },
+    }
+    await queryClient.fetchQuery(openPullRequestCountsQuery)
+    await queryClient.fetchQuery(repositoriesQuery)
+    repositoryFetches = 0
+
+    let visibilityState: DocumentVisibilityState = "hidden"
+    const listeners = new Map<string, EventListener>()
+    const documentRef = {
+      get visibilityState() {
+        return visibilityState
+      },
+      addEventListener: (type: string, listener: EventListener) => {
+        listeners.set(type, listener)
+      },
+      removeEventListener: (type: string) => {
+        listeners.delete(type)
+      },
+    }
+    const controller = new AbortController()
+    const follower = followOpenPullRequestCountLive({
+      queryClient,
+      openPullRequestCountsQuery,
+      signal: controller.signal,
+      documentRef,
+      pollIntervalMs: 60_000,
+    })
+
+    visibilityState = "visible"
+    listeners.get("visibilitychange")?.(new Event("visibilitychange"))
+    await waitFor(
+      () =>
+        countFetches === 2 &&
+        queryClient.getQueryState(openPullRequestCountsQuery.queryKey)
+          ?.fetchStatus === "idle",
+    )
+
+    expect(
+      queryClient.getQueryData<Readonly<Record<string, number>>>(
+        openPullRequestCountsQuery.queryKey,
+      ),
+    ).toEqual({ "repo-1": 4 })
+    expect(repositoryFetches).toBe(0)
+
+    controller.abort()
+    await follower
+    expect(
+      queryClient.getQueryData<Readonly<Record<string, number>>>(
+        openPullRequestCountsQuery.queryKey,
+      ),
+    ).toEqual({ "repo-1": 4 })
   })
 
   test("refetches only the dedicated count projection when the tab becomes visible", async () => {

--- a/packages/graphql-api/src/lib/graphql-api.ts
+++ b/packages/graphql-api/src/lib/graphql-api.ts
@@ -801,8 +801,9 @@ export const createGraphqlApi = <R>(
                   projectPath: repository.projectPath,
                 }
                 // Forge is authoritative: open non-draft PRs/MRs regardless of
-                // Work Item ownership. Credential/API failures degrade to zero
-                // so the repository list still renders.
+                // Work Item ownership. GitHub observation failures must reach
+                // the dedicated query cache: converting one to zero would
+                // overwrite a last-known count with false data.
                 if (repository.forge === "gitlab") {
                   const gitlab = yield* GitLabService
                   return yield* gitlab
@@ -816,14 +817,9 @@ export const createGraphqlApi = <R>(
                 }
                 if (repository.forge !== "github") return 0
                 const github = yield* GitHubService
-                return yield* github
-                  .countOpenNonDraftPullRequests(forgeRepository)
-                  .pipe(
-                    Effect.catchTags({
-                      GitHubRepositoryUnavailableError: () => Effect.succeed(0),
-                      GitHubRequestError: () => Effect.succeed(0),
-                    }),
-                  )
+                return yield* github.countOpenNonDraftPullRequests(
+                  forgeRepository,
+                )
               }).pipe(
                 Effect.withSpan("graphql-api.Repository.pullRequestCount"),
               ),

--- a/packages/graphql-api/test/graphql-api.test.ts
+++ b/packages/graphql-api/test/graphql-api.test.ts
@@ -18,6 +18,7 @@ import {
   GitHubRepositoryUnavailableError,
   GitHubService,
   type GitHubServiceShape,
+  GitHubThrottledError,
 } from "@ready-for-agent/github-service"
 import {
   GitLabProjectUnavailableError,
@@ -2828,7 +2829,7 @@ describe("GraphQL API", () => {
     })
   })
 
-  test("pullRequestCount degrades to zero when GitHub is unavailable", async () => {
+  test("pullRequestCount leaves a GitHub-unavailable observation unavailable", async () => {
     await runtime.dispose()
     runtime = makeRuntime(
       {
@@ -2850,8 +2851,42 @@ describe("GraphQL API", () => {
         query: `query { repositories { pullRequestCount } }`,
       }),
     )
-    expect(await response.json()).toEqual({
-      data: { repositories: [{ pullRequestCount: 0 }] },
+    expect(await response.json()).toMatchObject({
+      data: null,
+      errors: [{}],
+    })
+  })
+
+  test("pullRequestCount reports GitHub throttling instead of a successful zero", async () => {
+    const retryAt = Date.parse("2026-08-07T12:00:00.000Z")
+    await runtime.dispose()
+    runtime = makeRuntime(
+      { listRepositories: Effect.succeed([repository]) },
+      {},
+      {},
+      {},
+      {},
+      {},
+      {
+        countOpenNonDraftPullRequests: () =>
+          Effect.fail(
+            new GitHubThrottledError({ retryAt, usedFallback: false }),
+          ),
+      },
+    )
+
+    const response = await createGraphqlApi(runtime).fetch(
+      graphqlRequest({
+        query: `query { repositories { pullRequestCount } }`,
+      }),
+    )
+    expect(await response.json()).toMatchObject({
+      data: null,
+      errors: [
+        {
+          extensions: { code: "GITHUB_THROTTLED", retryAt },
+        },
+      ],
     })
   })
 


### PR DESCRIPTION
GitHub count failures were being converted to a successful zero, which could replace a valid
last-known Pull Request count.

This change lets GitHub count errors reach the dedicated query cache, so the UI retains prior
data or shows unavailable on the first failed observation. It also reduces visible-tab count
polling from 30 seconds to 120 seconds while preserving immediate targeted refreshes.

Coverage now verifies GraphQL throttling, first-load unavailable state, cached-count retention
through a throttled visibility refresh, coordinator admission before either GitHub adapter runs,
and isolation from the main repositories projection.

Verified with `bunx nx run-many -t test -p harness,graphql-api --outputStyle=static --skipNxCache`
and `bunx nx run-many -t lint -p harness,graphql-api --outputStyle=static --skipNxCache`.

Closes #882