### PR TITLE
fix(queue): postpone throttled refresh jobs

### DIFF
--- a/apps/harness/src/server/job-worker.ts
+++ b/apps/harness/src/server/job-worker.ts
@@ -1,6 +1,7 @@
 import "@tanstack/react-start/server-only"
 import {
   Clock,
+  DateTime,
   Duration,
   Effect,
   Layer,
@@ -19,6 +20,7 @@ import {
 import {
   type GitHubOperationOrigin,
   formatUserFacingError,
+  isGitHubThrottledError,
 } from "@ready-for-agent/github-service"
 import { GitLabService } from "@ready-for-agent/gitlab-service"
 import {
@@ -249,6 +251,18 @@ const finalizeManualRefresh = <A, E>(
   Effect.gen(function* () {
     const queue = yield* QueueService
     if (result._tag === "Failure") {
+      if (isGitHubThrottledError(result.failure)) {
+        yield* Effect.logWarning("Refresh Job postponed by GitHub throttling", {
+          jobId,
+          repositoryId,
+          retryAt: result.failure.retryAt,
+        })
+        yield* queue.postpone(
+          jobId,
+          DateTime.makeUnsafe(result.failure.retryAt),
+        )
+        return
+      }
       yield* Effect.logError("Refresh Job failed", {
         jobId,
         repositoryId,
@@ -311,6 +325,17 @@ const finalizeScheduledRefresh = <A, E>(
     }
 
     if (result._tag === "Failure") {
+      if (isGitHubThrottledError(result.failure)) {
+        yield* Effect.logWarning(
+          "Scheduled Issue poll postponed by GitHub throttling",
+          { jobId, repositoryId, retryAt: result.failure.retryAt },
+        )
+        yield* queue.postpone(
+          jobId,
+          DateTime.makeUnsafe(result.failure.retryAt),
+        )
+        return
+      }
       yield* Effect.logError("Scheduled Issue poll failed", {
         jobId,
         repositoryId,

--- a/apps/harness/test/job-worker.test.ts
+++ b/apps/harness/test/job-worker.test.ts
@@ -34,6 +34,7 @@ import {
 import {
   GitHubService,
   type GitHubServiceShape,
+  GitHubThrottledError,
 } from "@ready-for-agent/github-service"
 import {
   GitLabService,
@@ -239,6 +240,10 @@ const queueLayer = (
   interruptRunningStepRunsFromPriorWorker: Effect.Effect<number> = Effect.succeed(
     0,
   ),
+  onPostpone: (
+    jobId: string,
+    availableAt: DateTime.Utc,
+  ) => Effect.Effect<unknown> = () => Effect.void,
 ) =>
   Layer.mergeAll(
     defaultGithubLayer,
@@ -248,6 +253,8 @@ const queueLayer = (
         reviveExhaustedKeyed: () => Effect.void,
         postponeKeyed: (jobId, delay) =>
           onPostponeKeyed(jobId, delay).pipe(Effect.asVoid),
+        postpone: (jobId, availableAt) =>
+          onPostpone(jobId, availableAt).pipe(Effect.asVoid),
         rawClaim: (queueName, visibilityTimeout) =>
           Effect.gen(function* () {
             expect(Duration.toMillis(visibilityTimeout ?? Duration.zero)).toBe(
@@ -1049,6 +1056,66 @@ describe("Job worker", () => {
     }),
   )
 
+  it.live("postpones a throttled Refresh Job at its exact retry deadline", () =>
+    Effect.gen(function* () {
+      const job = rawJob(refreshPayload)
+      const retryAt = Date.now() + 120_000
+      const postponed = yield* Deferred.make<{
+        jobId: string
+        availableAt: number
+      }>()
+      let acknowledged = false
+      let failed = false
+
+      yield* runScoped(
+        Effect.gen(function* () {
+          yield* runJobWorker({ idlePollInterval: Duration.zero }).pipe(
+            Effect.forkScoped({ startImmediately: true }),
+          )
+          expect(yield* Deferred.await(postponed)).toEqual({
+            jobId: job.jobId,
+            availableAt: retryAt,
+          })
+          expect(acknowledged).toBe(false)
+          expect(failed).toBe(false)
+        }),
+        Layer.mergeAll(
+          defaultGithubLayer,
+          queueLayer(
+            [job],
+            () =>
+              Effect.sync(() => {
+                acknowledged = true
+              }),
+            () =>
+              Effect.sync(() => {
+                failed = true
+              }),
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            undefined,
+            (jobId, availableAt) =>
+              Deferred.succeed(postponed, {
+                jobId,
+                availableAt: DateTime.toEpochMillis(availableAt),
+              }),
+          ),
+          dbLayer(),
+          Layer.succeed(IssueReconciler, {
+            reconcile: () =>
+              Effect.fail(
+                new GitHubThrottledError({ retryAt, usedFallback: false }),
+              ),
+          }),
+          keymaxxerLayer(),
+        ),
+      )
+    }),
+  )
+
   it.live("executes duplicate Refresh Jobs serially across repositories", () =>
     Effect.gen(function* () {
       const jobs = [
@@ -1582,6 +1649,71 @@ describe("Job worker", () => {
   )
 
   it.live(
+    "postpones a throttled scheduled poll at its retry deadline without cadence sampling",
+    () =>
+      Effect.gen(function* () {
+        const job = rawJob(refreshPayload, ISSUE_POLL_QUEUE, repository.id)
+        const retryAt = Date.now() + 120_000
+        const postponed = yield* Deferred.make<{
+          jobId: string
+          availableAt: number
+        }>()
+        let acknowledged = false
+        let failed = false
+
+        yield* runScoped(
+          Effect.gen(function* () {
+            yield* runJobWorker({
+              idlePollInterval: Duration.zero,
+              samplePollingDelay: Effect.die(
+                "Throttle must not sample cadence",
+              ),
+            }).pipe(Effect.forkScoped({ startImmediately: true }))
+            expect(yield* Deferred.await(postponed)).toEqual({
+              jobId: job.jobId,
+              availableAt: retryAt,
+            })
+            expect(acknowledged).toBe(false)
+            expect(failed).toBe(false)
+          }),
+          Layer.mergeAll(
+            defaultGithubLayer,
+            queueLayer(
+              [job],
+              () =>
+                Effect.sync(() => {
+                  acknowledged = true
+                }),
+              () =>
+                Effect.sync(() => {
+                  failed = true
+                }),
+              undefined,
+              undefined,
+              undefined,
+              undefined,
+              undefined,
+              undefined,
+              (jobId, availableAt) =>
+                Deferred.succeed(postponed, {
+                  jobId,
+                  availableAt: DateTime.toEpochMillis(availableAt),
+                }),
+            ),
+            dbLayer(),
+            Layer.succeed(IssueReconciler, {
+              reconcile: () =>
+                Effect.fail(
+                  new GitHubThrottledError({ retryAt, usedFallback: false }),
+                ),
+            }),
+            keymaxxerLayer(),
+          ),
+        )
+      }),
+  )
+
+  it.live(
     "finalizes a scheduled poll without recurrence when the Repository is missing",
     () =>
       Effect.gen(function* () {
@@ -1828,16 +1960,42 @@ describe("Job worker", () => {
   )
 
   it.live(
-    "persists a scheduled entry across worker restarts without replaying",
+    "durably postpones manual and repeated scheduled throttled polls across worker restarts",
     () =>
       Effect.gen(function* () {
         const database = DbServiceLive.pipe(Layer.provideMerge(DatabaseTest))
         const queue = SqliteQueueServiceLive.pipe(Layer.provideMerge(database))
         const reconciliations: string[] = []
+        const firstThrottle = yield* Deferred.make<number>()
+        const secondThrottle = yield* Deferred.make<number>()
+        const manualThrottle = yield* Deferred.make<number>()
+        let completedAt = 0
+        let throttleManualRefresh = false
         const reconciler = Layer.succeed(IssueReconciler, {
           reconcile: (repo) =>
-            Effect.sync(() => {
+            Effect.gen(function* () {
               reconciliations.push(repo.id)
+              if (throttleManualRefresh) {
+                throttleManualRefresh = false
+                const retryAt = Date.now() + 1_000
+                yield* Deferred.succeed(manualThrottle, retryAt)
+                return yield* new GitHubThrottledError({
+                  retryAt,
+                  usedFallback: false,
+                })
+              }
+              if (reconciliations.length <= 2) {
+                const retryAt = Date.now() + 150
+                yield* Deferred.succeed(
+                  reconciliations.length === 1 ? firstThrottle : secondThrottle,
+                  retryAt,
+                )
+                return yield* new GitHubThrottledError({
+                  retryAt,
+                  usedFallback: false,
+                })
+              }
+              completedAt = Date.now()
               return {
                 fetched: 0,
                 inserted: 0,
@@ -1911,28 +2069,155 @@ describe("Job worker", () => {
             { retryLimit: JOB_RECOVERY_RETRY_LIMIT },
           )
 
+          const waitForPostponedEntry = (retryAt: number) =>
+            Effect.gen(function* () {
+              for (let attempt = 0; attempt < 100; attempt += 1) {
+                const [entry] = yield* service.listKeyed(ISSUE_POLL_QUEUE)
+                if (
+                  entry !== undefined &&
+                  entry.attempts === 0 &&
+                  DateTime.toEpochMillis(entry.availableAt) === retryAt
+                ) {
+                  return entry
+                }
+                yield* Effect.sleep(Duration.millis(5))
+              }
+              return yield* Effect.die(
+                "Scheduled poll was not durably postponed",
+              )
+            })
+
+          const waitForManualPostpone = () =>
+            Effect.gen(function* () {
+              for (let attempt = 0; attempt < 100; attempt += 1) {
+                const stats = yield* service.getStats(ISSUE_REFRESH_QUEUE)
+                if (
+                  stats.pending === 1 &&
+                  stats.processing === 0 &&
+                  stats.deadLetter === 0
+                ) {
+                  return
+                }
+                yield* Effect.sleep(Duration.millis(5))
+              }
+              return yield* Effect.die(
+                "Manual Refresh Job was not durably postponed",
+              )
+            })
+
+          const firstRetryAt = yield* Effect.scoped(
+            Effect.gen(function* () {
+              yield* runJobWorker({
+                idlePollInterval: Duration.zero,
+                samplePollingDelay: Effect.succeed(Duration.seconds(67)),
+              }).pipe(Effect.forkScoped({ startImmediately: true }))
+              const retryAt = yield* Deferred.await(firstThrottle)
+              const entry = yield* waitForPostponedEntry(retryAt)
+              expect(entry.key).toBe(added.id)
+              expect(entry.attempts).toBe(0)
+              return retryAt
+            }),
+          )
+
+          const afterFirstThrottle = yield* waitForPostponedEntry(firstRetryAt)
+          expect(afterFirstThrottle.key).toBe(added.id)
+          expect(afterFirstThrottle.attempts).toBe(0)
+
+          const secondRetryAt = yield* Effect.scoped(
+            Effect.gen(function* () {
+              yield* runJobWorker({
+                idlePollInterval: Duration.zero,
+                samplePollingDelay: Effect.succeed(Duration.seconds(67)),
+              }).pipe(Effect.forkScoped({ startImmediately: true }))
+              yield* Effect.sleep(Duration.millis(25))
+              expect(reconciliations).toEqual([added.id])
+              const retryAt = yield* Deferred.await(secondThrottle)
+              const entry = yield* waitForPostponedEntry(retryAt)
+              expect(entry.key).toBe(added.id)
+              expect(entry.attempts).toBe(0)
+              return retryAt
+            }),
+          )
+
+          const afterSecondThrottle =
+            yield* waitForPostponedEntry(secondRetryAt)
+          expect(afterSecondThrottle.key).toBe(added.id)
+          expect(afterSecondThrottle.attempts).toBe(0)
+
           yield* Effect.scoped(
             Effect.gen(function* () {
               yield* runJobWorker({
                 idlePollInterval: Duration.zero,
-                samplePollingDelay: Effect.succeed(Duration.seconds(120)),
+                samplePollingDelay: Effect.succeed(Duration.seconds(67)),
               }).pipe(Effect.forkScoped({ startImmediately: true }))
-              while (reconciliations.length < 1) {
+              yield* Effect.sleep(Duration.millis(25))
+              expect(reconciliations).toEqual([added.id, added.id])
+              while (reconciliations.length < 3) {
                 yield* Effect.sleep("5 millis")
               }
             }),
           )
 
-          expect(reconciliations).toEqual([added.id])
+          expect(reconciliations).toEqual([added.id, added.id, added.id])
+          expect(completedAt).toBeGreaterThan(0)
 
           const keyed = yield* service.listKeyed(ISSUE_POLL_QUEUE)
           expect(keyed).toHaveLength(1)
-          expect(keyed[0]?.key).toBe(added.id)
-          expect(keyed[0]?.attempts).toBe(0)
+          const [scheduledEntry] = keyed
+          if (scheduledEntry === undefined) {
+            return yield* Effect.die("Scheduled poll entry disappeared")
+          }
+          expect(scheduledEntry.key).toBe(added.id)
+          expect(scheduledEntry.attempts).toBe(0)
+          const nextAvailableAt = DateTime.toEpochMillis(
+            scheduledEntry.availableAt,
+          )
+          expect(nextAvailableAt).toBeGreaterThanOrEqual(completedAt + 66_000)
+          expect(nextAvailableAt).toBeLessThanOrEqual(completedAt + 68_000)
 
-          // Not immediately available again (postponed 120s).
-          const claimNow = yield* service.rawClaim(ISSUE_POLL_QUEUE)
-          expect(Option.isNone(claimNow)).toBe(true)
+          yield* service.enqueue(ISSUE_REFRESH_QUEUE, {
+            _tag: "refresh-repository",
+            repositoryId: RepositoryId.make(added.id),
+          })
+          throttleManualRefresh = true
+
+          const manualRetryAt = yield* Effect.scoped(
+            Effect.gen(function* () {
+              yield* runJobWorker({
+                idlePollInterval: Duration.zero,
+                samplePollingDelay: Effect.succeed(Duration.seconds(67)),
+              }).pipe(Effect.forkScoped({ startImmediately: true }))
+              const retryAt = yield* Deferred.await(manualThrottle)
+              yield* waitForManualPostpone()
+              return retryAt
+            }),
+          )
+
+          expect(Date.now()).toBeLessThan(manualRetryAt)
+          expect(yield* service.rawClaim(ISSUE_REFRESH_QUEUE)).toEqual(
+            Option.none(),
+          )
+
+          yield* Effect.scoped(
+            Effect.gen(function* () {
+              yield* runJobWorker({
+                idlePollInterval: Duration.zero,
+                samplePollingDelay: Effect.succeed(Duration.seconds(67)),
+              }).pipe(Effect.forkScoped({ startImmediately: true }))
+              yield* Effect.sleep(Duration.millis(25))
+              expect(reconciliations).toEqual([
+                added.id,
+                added.id,
+                added.id,
+                added.id,
+              ])
+            }),
+          )
+          expect(yield* service.getStats(ISSUE_REFRESH_QUEUE)).toEqual({
+            pending: 1,
+            processing: 0,
+            deadLetter: 0,
+          })
         }).pipe(
           Effect.provide(
             Layer.mergeAll(

--- a/packages/queue-service/src/lib/queue-service.ts
+++ b/packages/queue-service/src/lib/queue-service.ts
@@ -1,4 +1,4 @@
-import type { Duration } from "effect"
+import type { DateTime, Duration } from "effect"
 import { Context, Effect, Option, Schema } from "effect"
 import type {
   AcknowledgeError,
@@ -192,6 +192,16 @@ export interface QueueServiceShape {
   readonly postponeKeyed: (
     jobId: string,
     delay: Duration.Duration,
+  ) => Effect.Effect<void, AcknowledgeError | JobNotFoundError>
+
+  /**
+   * Postpone a claimed entry in place until an exact deadline: preserve its
+   * identity, release its claim, and reset delivery attempts. Unlike
+   * `postponeKeyed`, this also supports one-shot unkeyed jobs.
+   */
+  readonly postpone: (
+    jobId: string,
+    availableAt: DateTime.Utc,
   ) => Effect.Effect<void, AcknowledgeError | JobNotFoundError>
 
   /**

--- a/packages/queue-service/src/lib/test-fixtures.ts
+++ b/packages/queue-service/src/lib/test-fixtures.ts
@@ -14,6 +14,7 @@ export const stubQueueService = (
   listKeyed: () => unexpected("listKeyed"),
   reviveExhaustedKeyed: () => unexpected("reviveExhaustedKeyed"),
   postponeKeyed: () => unexpected("postponeKeyed"),
+  postpone: () => unexpected("postpone"),
   removeKeyed: () => unexpected("removeKeyed"),
   rawClaim: () => unexpected("rawClaim"),
   acknowledge: () => unexpected("acknowledge"),

--- a/packages/sqlite-queue-service/src/lib/sqlite-queue-service.ts
+++ b/packages/sqlite-queue-service/src/lib/sqlite-queue-service.ts
@@ -506,6 +506,38 @@ export const SqliteQueueServiceLive = Layer.effect(
             message: "Cannot postpone an unclaimed keyed job",
           })
         }),
+      postpone: (jobId: string, availableAt: DateTime.Utc) =>
+        Effect.gen(function* () {
+          const now = yield* Clock.currentTimeMillis
+          const rows = yield* retrySqliteBusy(
+            sql.unsafe(
+              `UPDATE job_queue
+               SET locked_until = NULL,
+                   job_attempts = 0,
+                   available_at = ?,
+                   updated_at = ?
+               WHERE id = ?
+                 AND locked_until IS NOT NULL
+               RETURNING id`,
+              [DateTime.toEpochMillis(availableAt), now, jobId],
+            ),
+          ).pipe(Effect.mapError((error) => toAcknowledgeError(jobId, error)))
+          const updated = yield* decodeIdRows(rows).pipe(
+            Effect.mapError((error) => toAcknowledgeSchemaError(jobId, error)),
+          )
+          if (updated[0]) return
+          const existing = yield* sql
+            .unsafe(`SELECT id FROM job_queue WHERE id = ?`, [jobId])
+            .pipe(Effect.mapError((error) => toAcknowledgeError(jobId, error)))
+          const decoded = yield* decodeIdRows(existing).pipe(
+            Effect.mapError((error) => toAcknowledgeSchemaError(jobId, error)),
+          )
+          if (!decoded[0]) return yield* new JobNotFoundError({ jobId })
+          return yield* new AcknowledgeError({
+            jobId,
+            message: "Cannot postpone an unclaimed job",
+          })
+        }),
       removeKeyed: (queue: string, key: string) =>
         Effect.gen(function* () {
           yield* validateQueueName(queue)

--- a/packages/sqlite-queue-service/test/sqlite-queue-service.spec.ts
+++ b/packages/sqlite-queue-service/test/sqlite-queue-service.spec.ts
@@ -698,6 +698,47 @@ describe("SqliteQueueService", () => {
         }),
       ))
 
+    it("postpones a claimed unkeyed entry in place at its exact deadline", () =>
+      runTest(
+        Effect.gen(function* () {
+          const queue = yield* QueueService
+          const sql = yield* SqlClient.SqlClient
+          const jobId = yield* queue.enqueue("manual-postpone-queue", {
+            kind: "manual-refresh",
+          })
+          const claimed = yield* queue.rawClaim("manual-postpone-queue")
+          expect(Option.isSome(claimed)).toBe(true)
+          if (Option.isNone(claimed)) return
+          expect(claimed.value.jobId).toBe(jobId)
+          expect(claimed.value.key).toBeNull()
+          expect(claimed.value.attempts).toBe(1)
+
+          const retryAt = DateTime.makeUnsafe(Date.now() + 120_000)
+          yield* queue.postpone(claimed.value.jobId, retryAt)
+
+          expect(
+            Option.isNone(yield* queue.rawClaim("manual-postpone-queue")),
+          ).toBe(true)
+
+          const stats = yield* queue.getStats("manual-postpone-queue")
+          expect(stats).toEqual({ pending: 1, processing: 0, deadLetter: 0 })
+          const rows = yield* sql.unsafe(
+            `SELECT id, key, job_attempts, available_at, locked_until
+             FROM job_queue WHERE id = ?`,
+            [jobId],
+          )
+          expect(rows).toEqual([
+            {
+              id: jobId,
+              key: null,
+              job_attempts: 0,
+              available_at: DateTime.toEpochMillis(retryAt),
+              locked_until: null,
+            },
+          ])
+        }),
+      ))
+
     it("makes a postponed entry claimable after its delay elapses", () =>
       runTest(
         Effect.gen(function* () {

--- a/packages/work-item-lifecycle/src/lib/sync-needs-human-merge-handoffs.ts
+++ b/packages/work-item-lifecycle/src/lib/sync-needs-human-merge-handoffs.ts
@@ -2,12 +2,34 @@ import { Effect } from "effect"
 import { DbService } from "@ready-for-agent/db-service"
 import {
   GitHubService,
+  type GitHubThrottledError,
   type PullRequestCheckStatus,
   type PullRequestLifecycleStatus,
+  isGitHubThrottledError,
 } from "@ready-for-agent/github-service"
 import { GitLabService } from "@ready-for-agent/gitlab-service"
 import { WorkItemLifecycle } from "./work-item-lifecycle.js"
 import { workItemBranchName } from "./worktree-names.js"
+
+const skipNonThrottleLookupFailure = <A>(
+  lookup: Effect.Effect<A, unknown>,
+  input: {
+    readonly message: string
+    readonly repositoryId: string
+    readonly workItemId: string
+  },
+): Effect.Effect<A | null, GitHubThrottledError> =>
+  lookup.pipe(
+    Effect.catch((error) =>
+      isGitHubThrottledError(error)
+        ? Effect.fail(error)
+        : Effect.logWarning(input.message, {
+            workItemId: input.workItemId,
+            repositoryId: input.repositoryId,
+            error: String(error),
+          }).pipe(Effect.as(null)),
+    ),
+  )
 
 /**
  * After Issue reconciliation, advance Work Items whose Work Item PR was merged
@@ -16,7 +38,8 @@ import { workItemBranchName } from "./worktree-names.js"
  * and for open-PR Needs Human handoffs observe mergeability (ADR 0046):
  * Decide/Merge Needs Human + conflicting → Resolve PR Merge Conflict;
  * Resolve Needs Human + no longer conflicting → Watch PR Status Checks.
- * Forge lookup failures are skipped so Refresh still succeeds.
+ * Non-throttle Forge lookup failures are skipped so Refresh still succeeds;
+ * explicit GitHub throttles propagate to durably postpone the Refresh Job.
  */
 export const syncNeedsHumanMergeHandoffs = (repositoryId: string) =>
   Effect.gen(function* () {
@@ -74,18 +97,12 @@ export const syncNeedsHumanMergeHandoffs = (repositoryId: string) =>
           ? gitlab.getPullRequestLifecycleStatus(repository, headRefName)
           : github.getPullRequestLifecycleStatus(repository, headRefName)
 
-      const status = yield* lifecycleLookup.pipe(
-        Effect.catch((error) =>
-          Effect.logWarning(
-            "Skipping Work Item PR merge outcome: PR lifecycle lookup failed",
-            {
-              workItemId: workItem.id,
-              repositoryId,
-              error: String(error),
-            },
-          ).pipe(Effect.as(null)),
-        ),
-      )
+      const status = yield* skipNonThrottleLookupFailure(lifecycleLookup, {
+        message:
+          "Skipping Work Item PR merge outcome: PR lifecycle lookup failed",
+        workItemId: workItem.id,
+        repositoryId,
+      })
 
       if (status === null) {
         continue
@@ -145,17 +162,14 @@ export const syncNeedsHumanMergeHandoffs = (repositoryId: string) =>
             ? gitlab.getPullRequestCheckStatus(repository, headRefName)
             : github.getPullRequestCheckStatus(repository, headRefName)
 
-        const checkStatus = yield* checkStatusLookup.pipe(
-          Effect.catch((error) =>
-            Effect.logWarning(
+        const checkStatus = yield* skipNonThrottleLookupFailure(
+          checkStatusLookup,
+          {
+            message:
               "Skipping Needs Human mergeability: PR check status lookup failed",
-              {
-                workItemId: workItem.id,
-                repositoryId,
-                error: String(error),
-              },
-            ).pipe(Effect.as(null)),
-          ),
+            workItemId: workItem.id,
+            repositoryId,
+          },
         )
 
         if (checkStatus === null) {

--- a/packages/work-item-lifecycle/test/sync-needs-human-merge-handoffs.spec.ts
+++ b/packages/work-item-lifecycle/test/sync-needs-human-merge-handoffs.spec.ts
@@ -5,6 +5,8 @@ import { DbService, DbServiceLive } from "@ready-for-agent/db-service"
 import {
   GitHubService,
   type GitHubServiceShape,
+  GitHubThrottledError,
+  type PullRequestCheckStatus,
   type PullRequestLifecycleStatus,
 } from "@ready-for-agent/github-service"
 import { QueueService } from "@ready-for-agent/queue-service"
@@ -71,11 +73,22 @@ describe("syncNeedsHumanMergeHandoffs", () => {
 
   type Mergeability = "mergeable" | "conflicting" | "unknown"
   type CheckStatusTag = "succeeded" | "closed"
+  type GitHubLookupOverrides = {
+    readonly checkStatus?: () => Effect.Effect<
+      PullRequestCheckStatus,
+      GitHubThrottledError
+    >
+    readonly lifecycleStatus?: () => Effect.Effect<
+      PullRequestLifecycleStatus,
+      GitHubThrottledError
+    >
+  }
 
   const githubWith = (
     getStatus: () => PullRequestLifecycleStatus,
     getMergeability: () => Mergeability = () => "mergeable",
     getCheckStatusTag: () => CheckStatusTag = () => "succeeded",
+    overrides: GitHubLookupOverrides = {},
   ) =>
     Layer.succeed(GitHubService, {
       getAuthenticatedUserLogin: () => Effect.succeed("test-operator"),
@@ -85,6 +98,7 @@ describe("syncNeedsHumanMergeHandoffs", () => {
       createDraftPullRequest: () => Effect.succeed(1),
       countOpenNonDraftPullRequests: () => Effect.succeed(0),
       getPullRequestCheckStatus: () =>
+        overrides.checkStatus?.() ??
         Effect.succeed(
           getCheckStatusTag() === "closed"
             ? {
@@ -113,7 +127,8 @@ describe("syncNeedsHumanMergeHandoffs", () => {
           _tag: "ambiguous" as const,
           reason: "Automated review evidence observation is not configured",
         }),
-      getPullRequestLifecycleStatus: () => Effect.succeed(getStatus()),
+      getPullRequestLifecycleStatus: () =>
+        overrides.lifecycleStatus?.() ?? Effect.succeed(getStatus()),
       markPullRequestReadyForReview: () => Effect.void,
       mergePullRequest: () => Effect.succeed({ _tag: "merged" }),
       rerunWorkflowRun: () => Effect.void,
@@ -140,12 +155,18 @@ describe("syncNeedsHumanMergeHandoffs", () => {
     gitlab: Parameters<typeof stubGitLabServiceLayer>[0] = {},
     getMergeability: () => Mergeability = () => "mergeable",
     getCheckStatusTag: () => CheckStatusTag = () => "succeeded",
+    githubLookupOverrides: GitHubLookupOverrides = {},
   ) =>
     WorkItemLifecycleLive.pipe(
       Layer.provideMerge(stubActiveAgentBackendLayer()),
       // githubWith controls GitHub PR lifecycle for syncNeedsHumanMergeHandoffs.
       Layer.provideMerge(
-        githubWith(getStatus, getMergeability, getCheckStatusTag),
+        githubWith(
+          getStatus,
+          getMergeability,
+          getCheckStatusTag,
+          githubLookupOverrides,
+        ),
       ),
       Layer.provideMerge(stubGitLabServiceLayer(gitlab)),
       Layer.provideMerge(
@@ -304,6 +325,85 @@ describe("syncNeedsHumanMergeHandoffs", () => {
         const still = yield* lifecycle.getWorkItem(created.id)
         expect(still.state).toBe("needs_human")
       }).pipe(Effect.provide(makeLayer({ _tag: "open" }))),
+    )
+  })
+
+  it("propagates GitHub throttling from PR lifecycle observation", async () => {
+    const throttle = new GitHubThrottledError({
+      retryAt: 1_750_000_000_000,
+      usedFallback: false,
+    })
+    let throttled = false
+
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        const { repository } = yield* driveToNeedsHuman()
+        throttled = true
+        const error = yield* syncNeedsHumanMergeHandoffs(repository.id).pipe(
+          Effect.flip,
+        )
+        expect(error).toBe(throttle)
+      }).pipe(
+        Effect.provide(
+          makeLayerWithStatus(
+            () => ({ _tag: "open" }),
+            successfulSteps,
+            {},
+            () => "mergeable",
+            () => "succeeded",
+            {
+              lifecycleStatus: () =>
+                throttled
+                  ? Effect.fail(throttle)
+                  : Effect.succeed({ _tag: "open" }),
+            },
+          ),
+        ),
+      ),
+    )
+  })
+
+  it("propagates GitHub throttling from mergeability observation", async () => {
+    const throttle = new GitHubThrottledError({
+      retryAt: 1_750_000_000_000,
+      usedFallback: false,
+    })
+    let throttled = false
+
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        const { repository } = yield* driveToNeedsHuman()
+        throttled = true
+        const error = yield* syncNeedsHumanMergeHandoffs(repository.id).pipe(
+          Effect.flip,
+        )
+        expect(error).toBe(throttle)
+      }).pipe(
+        Effect.provide(
+          makeLayerWithStatus(
+            () => ({ _tag: "open" }),
+            successfulSteps,
+            {},
+            () => "mergeable",
+            () => "succeeded",
+            {
+              checkStatus: () =>
+                throttled
+                  ? Effect.fail(throttle)
+                  : Effect.succeed({
+                      _tag: "succeeded",
+                      terminalChecks: [],
+                      mergeability: "mergeable",
+                      baseRefName: "main",
+                      headPushedAt: null,
+                      headSha: null,
+                      createdAt: null,
+                      isDraft: null,
+                    }),
+            },
+          ),
+        ),
+      ),
     )
   })
 


### PR DESCRIPTION
GitHub rate-limit responses previously let accepted refresh work be treated as ordinary failure or
recurrence. This change preserves the claimed queue entry and defers it until GitHub's explicit
retry deadline.

- add exact-deadline queue postponement for claimed keyed and unkeyed entries, resetting delivery
  attempts
- postpone manual Refresh Jobs and scheduled Issue Polling on GitHubThrottledError without
  acknowledgement, dead-lettering, cadence sampling, or false freshness notifications
- propagate GitHub throttling through Needs Human merge-handoff lookups instead of swallowing it
  as a generic Forge lookup failure
- add durable SQLite worker coverage for manual and scheduled throttling, worker restarts,
  repeated throttles, and resumed scheduled cadence

Verified with bunx nx test harness, bunx nx run-many --target=typecheck --projects=harness,
bunx nx run-many --target=lint --projects=harness, and git diff --check.

Closes #879