### PR TITLE
feat(github): add replay-safe remote cleanup

### DIFF
--- a/apps/harness/src/server/ambient-github-layer.ts
+++ b/apps/harness/src/server/ambient-github-layer.ts
@@ -266,7 +266,7 @@ export const ambientGitHubLayer = (options: {
         closeOpenPullRequestsAndDeleteBranch: Effect.fn(
           "AmbientGitHub.closeOpenPullRequestsAndDeleteBranch",
         )((repository, headRefName) =>
-          authenticated("operator", (service) =>
+          authenticated("operator", repository, (service) =>
             service.closeOpenPullRequestsAndDeleteBranch(
               repository,
               headRefName,

--- a/apps/harness/src/server/ambient-github-layer.ts
+++ b/apps/harness/src/server/ambient-github-layer.ts
@@ -263,6 +263,16 @@ export const ambientGitHubLayer = (options: {
             service.findOpenPullRequestNumber(repository, headRefName),
           ),
         ),
+        closeOpenPullRequestsAndDeleteBranch: Effect.fn(
+          "AmbientGitHub.closeOpenPullRequestsAndDeleteBranch",
+        )((repository, headRefName) =>
+          authenticated("operator", (service) =>
+            service.closeOpenPullRequestsAndDeleteBranch(
+              repository,
+              headRefName,
+            ),
+          ),
+        ),
         countOpenNonDraftPullRequests: Effect.fn(
           "AmbientGitHub.countOpenNonDraftPullRequests",
         )((repository) =>

--- a/apps/harness/src/server/keymaxxer-github-layer.ts
+++ b/apps/harness/src/server/keymaxxer-github-layer.ts
@@ -589,6 +589,18 @@ export const keymaxxerGitHubLayer = (options: {
               ),
           }),
         ),
+        closeOpenPullRequestsAndDeleteBranch: Effect.fn(
+          "KeymaxxerGitHub.closeOpenPullRequestsAndDeleteBranch",
+        )((repository, headRefName) =>
+          callHelper({
+            operation: "close-open-pull-requests-and-delete-branch",
+            repository,
+            describe: "close open pull requests and delete remote branch",
+            args: [encodeArgument(headRefName)],
+            origin: "operator",
+            decode: decodeVoid,
+          }),
+        ),
         createDraftPullRequest: Effect.fn(
           "KeymaxxerGitHub.createDraftPullRequest",
         )((repository, input) =>

--- a/apps/harness/test/ambient-github-layer.test.ts
+++ b/apps/harness/test/ambient-github-layer.test.ts
@@ -36,6 +36,7 @@ const serviceWithList = (
   getAuthenticatedUserLogin: () => Effect.die("not used"),
   getOpenPullRequestNumber: () => Effect.die("not used"),
   findOpenPullRequestNumber: () => Effect.die("not used"),
+  closeOpenPullRequestsAndDeleteBranch: () => Effect.die("not used"),
   createDraftPullRequest: () => Effect.die("not used"),
   updateOpenDraftPullRequestCopy: () => Effect.die("not used"),
   countOpenNonDraftPullRequests: () => Effect.succeed(0),
@@ -251,6 +252,33 @@ it.effect(
 
       expect(tokenIndex).toBe(2)
     }),
+)
+
+it.effect("runs remote cleanup through the ambient coordinator operation", () =>
+  Effect.gen(function* () {
+    const cleanups: string[] = []
+    const layer = ambientGitHubLayer({
+      workspaceRoot: "/workspace",
+      resolveToken: async () => "ambient-token",
+      makeService: () => ({
+        ...serviceWithList(() => Effect.succeed([])),
+        closeOpenPullRequestsAndDeleteBranch: (_repository, headRefName) =>
+          Effect.sync(() => {
+            cleanups.push(headRefName)
+          }),
+      }),
+    })
+
+    yield* Effect.gen(function* () {
+      const github = yield* GitHubService
+      yield* github.closeOpenPullRequestsAndDeleteBranch(
+        repository,
+        "rfa/issue-881",
+      )
+    }).pipe(Effect.provide(layer.pipe(Layer.provide(processLayer))))
+
+    expect(cleanups).toEqual(["rfa/issue-881"])
+  }),
 )
 
 it.effect("ambient GitHub authentication refreshes once after a 401", () =>

--- a/apps/harness/test/job-worker.test.ts
+++ b/apps/harness/test/job-worker.test.ts
@@ -188,6 +188,7 @@ const defaultGithubLayer = Layer.merge(
   Layer.succeed(GitHubService, {
     getOpenPullRequestNumber: () => Effect.succeed(1),
     findOpenPullRequestNumber: () => Effect.succeed(1),
+    closeOpenPullRequestsAndDeleteBranch: () => Effect.void,
     createDraftPullRequest: () => Effect.succeed(1),
     updateOpenDraftPullRequestCopy: () => Effect.succeed(1),
     countOpenNonDraftPullRequests: () => Effect.succeed(0),
@@ -744,6 +745,7 @@ describe("Job worker", () => {
       const github = Layer.succeed(GitHubService, {
         getOpenPullRequestNumber: () => Effect.succeed(1),
         findOpenPullRequestNumber: () => Effect.succeed(1),
+        closeOpenPullRequestsAndDeleteBranch: () => Effect.void,
         createDraftPullRequest: () => Effect.succeed(1),
         updateOpenDraftPullRequestCopy: () => Effect.succeed(1),
         countOpenNonDraftPullRequests: () => Effect.succeed(0),

--- a/apps/harness/test/keymaxxer-github-layer.test.ts
+++ b/apps/harness/test/keymaxxer-github-layer.test.ts
@@ -286,6 +286,47 @@ describe("Keymaxxer-backed GitHub layer", () => {
       }),
   )
 
+  it.effect(
+    "runs remote cleanup as one native helper without exposing a token",
+    () =>
+      Effect.gen(function* () {
+        const runs: RunWithSecretsInput[] = []
+        const keymaxxerLayer = Layer.succeed(KeymaxxerService, {
+          initialize: Effect.void,
+          findSecret: () => Effect.succeed("GITHUB_TOKEN_ACME_WIDGETS"),
+          findSecrets: () => Effect.die("not used"),
+          hasSecret: () => Effect.die("not used"),
+          addSecret: () => Effect.die("not used"),
+          runWithSecrets: (input) => {
+            runs.push(input)
+            return Effect.succeed({
+              exitCode: 0,
+              stdout: "",
+              stderr: successfulHelperControl,
+            })
+          },
+        })
+        const layer = keymaxxerGitHubLayer({
+          workspaceRoot: "/workspace",
+        }).pipe(Layer.provide(keymaxxerLayer))
+
+        yield* Effect.gen(function* () {
+          const github = yield* GitHubService
+          yield* github.closeOpenPullRequestsAndDeleteBranch(
+            acmeWidgets,
+            "rfa/issue-881",
+          )
+        }).pipe(Effect.provide(layer))
+
+        expect(runs).toHaveLength(1)
+        expect(runs[0]?.secrets).toEqual(["GITHUB_TOKEN_ACME_WIDGETS"])
+        expect(runs[0]?.command).toContain(
+          "close-open-pull-requests-and-delete-branch",
+        )
+        expect(runs[0]?.command).not.toContain("gh pr")
+      }),
+  )
+
   it.effect("selects colliding token names by Repository account", () =>
     Effect.gen(function* () {
       const runs: RunWithSecretsInput[] = []
@@ -1695,6 +1736,7 @@ describe("Keymaxxer-backed GitHub layer", () => {
           getAuthenticatedUserLogin: () => Effect.die("not used"),
           getOpenPullRequestNumber: () => Effect.die("not used"),
           findOpenPullRequestNumber: () => Effect.die("not used"),
+          closeOpenPullRequestsAndDeleteBranch: () => Effect.die("not used"),
           createDraftPullRequest: () => Effect.die("not used"),
           updateOpenDraftPullRequestCopy: () => Effect.die("not used"),
           countOpenNonDraftPullRequests: () => Effect.die("not used"),

--- a/apps/harness/test/keymaxxer-github-layer.test.ts
+++ b/apps/harness/test/keymaxxer-github-layer.test.ts
@@ -1835,6 +1835,7 @@ describe("Keymaxxer-backed GitHub layer", () => {
           getAuthenticatedUserLogin: () => Effect.die("not used"),
           getOpenPullRequestNumber: () => Effect.die("not used"),
           findOpenPullRequestNumber: () => Effect.die("not used"),
+          closeOpenPullRequestsAndDeleteBranch: () => Effect.die("not used"),
           createDraftPullRequest: () => Effect.die("not used"),
           updateOpenDraftPullRequestCopy: () => Effect.die("not used"),
           countOpenNonDraftPullRequests: () =>

--- a/apps/harness/test/production-sse-idle-timeout.test.ts
+++ b/apps/harness/test/production-sse-idle-timeout.test.ts
@@ -76,6 +76,7 @@ const defaultGithub: GitHubServiceShape = {
   getAuthenticatedUserLogin: () => Effect.succeed("test-operator"),
   getOpenPullRequestNumber: () => Effect.succeed(1),
   findOpenPullRequestNumber: () => Effect.succeed(1),
+  closeOpenPullRequestsAndDeleteBranch: () => Effect.void,
   createDraftPullRequest: () => Effect.succeed(1),
   updateOpenDraftPullRequestCopy: () => Effect.succeed(1),
   countOpenNonDraftPullRequests: () => Effect.succeed(0),

--- a/bun.lock
+++ b/bun.lock
@@ -2208,8 +2208,6 @@
 
     "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
-    "tsx": ["tsx@4.23.0", "", { "dependencies": { "esbuild": "~0.28.0" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "bin": { "tsx": "dist/cli.mjs" } }, "sha512-eUdUIaCr963q2h5u3+QwvYp0+eqPvn+egeqZUm0hwERCqqx1E3kK5ehbGCvqSE5MQAULr67ww0cA3jKc3YkM1w=="],
-
     "type-fest": ["type-fest@1.4.0", "", {}, "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA=="],
 
     "type-is": ["type-is@2.1.0", "", { "dependencies": { "content-type": "^2.0.0", "media-typer": "^1.1.0", "mime-types": "^3.0.0" } }, "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA=="],
@@ -2458,8 +2456,6 @@
 
     "slice-ansi/is-fullwidth-code-point": ["is-fullwidth-code-point@4.0.0", "", {}, "sha512-O4L094N2/dZ7xqVdrXhh9r1KODPJpFms8B5sGdJLPy664AgvXsreZUyCQQNItZRDlYug4xStLjNp/sz3HvBowQ=="],
 
-    "tsx/esbuild": ["esbuild@0.28.1", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.28.1", "@esbuild/android-arm": "0.28.1", "@esbuild/android-arm64": "0.28.1", "@esbuild/android-x64": "0.28.1", "@esbuild/darwin-arm64": "0.28.1", "@esbuild/darwin-x64": "0.28.1", "@esbuild/freebsd-arm64": "0.28.1", "@esbuild/freebsd-x64": "0.28.1", "@esbuild/linux-arm": "0.28.1", "@esbuild/linux-arm64": "0.28.1", "@esbuild/linux-ia32": "0.28.1", "@esbuild/linux-loong64": "0.28.1", "@esbuild/linux-mips64el": "0.28.1", "@esbuild/linux-ppc64": "0.28.1", "@esbuild/linux-riscv64": "0.28.1", "@esbuild/linux-s390x": "0.28.1", "@esbuild/linux-x64": "0.28.1", "@esbuild/netbsd-arm64": "0.28.1", "@esbuild/netbsd-x64": "0.28.1", "@esbuild/openbsd-arm64": "0.28.1", "@esbuild/openbsd-x64": "0.28.1", "@esbuild/openharmony-arm64": "0.28.1", "@esbuild/sunos-x64": "0.28.1", "@esbuild/win32-arm64": "0.28.1", "@esbuild/win32-ia32": "0.28.1", "@esbuild/win32-x64": "0.28.1" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw=="],
-
     "type-is/content-type": ["content-type@2.0.0", "", {}, "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ=="],
 
     "type-is/mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
@@ -2559,58 +2555,6 @@
     "rdf-dataset-ext/readable-stream/buffer": ["buffer@6.0.3", "", { "dependencies": { "base64-js": "^1.3.1", "ieee754": "^1.2.1" } }, "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA=="],
 
     "send/mime-types/mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
-
-    "tsx/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.28.1", "", { "os": "aix", "cpu": "ppc64" }, "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ=="],
-
-    "tsx/esbuild/@esbuild/android-arm": ["@esbuild/android-arm@0.28.1", "", { "os": "android", "cpu": "arm" }, "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ=="],
-
-    "tsx/esbuild/@esbuild/android-arm64": ["@esbuild/android-arm64@0.28.1", "", { "os": "android", "cpu": "arm64" }, "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg=="],
-
-    "tsx/esbuild/@esbuild/android-x64": ["@esbuild/android-x64@0.28.1", "", { "os": "android", "cpu": "x64" }, "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng=="],
-
-    "tsx/esbuild/@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.28.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q=="],
-
-    "tsx/esbuild/@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.28.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ=="],
-
-    "tsx/esbuild/@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.28.1", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw=="],
-
-    "tsx/esbuild/@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.28.1", "", { "os": "freebsd", "cpu": "x64" }, "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ=="],
-
-    "tsx/esbuild/@esbuild/linux-arm": ["@esbuild/linux-arm@0.28.1", "", { "os": "linux", "cpu": "arm" }, "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ=="],
-
-    "tsx/esbuild/@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.28.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g=="],
-
-    "tsx/esbuild/@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.28.1", "", { "os": "linux", "cpu": "ia32" }, "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w=="],
-
-    "tsx/esbuild/@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.28.1", "", { "os": "linux", "cpu": "none" }, "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg=="],
-
-    "tsx/esbuild/@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.28.1", "", { "os": "linux", "cpu": "none" }, "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ=="],
-
-    "tsx/esbuild/@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.28.1", "", { "os": "linux", "cpu": "ppc64" }, "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ=="],
-
-    "tsx/esbuild/@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.28.1", "", { "os": "linux", "cpu": "none" }, "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ=="],
-
-    "tsx/esbuild/@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.28.1", "", { "os": "linux", "cpu": "s390x" }, "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag=="],
-
-    "tsx/esbuild/@esbuild/linux-x64": ["@esbuild/linux-x64@0.28.1", "", { "os": "linux", "cpu": "x64" }, "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA=="],
-
-    "tsx/esbuild/@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.28.1", "", { "os": "none", "cpu": "arm64" }, "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw=="],
-
-    "tsx/esbuild/@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.28.1", "", { "os": "none", "cpu": "x64" }, "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg=="],
-
-    "tsx/esbuild/@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.28.1", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q=="],
-
-    "tsx/esbuild/@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.28.1", "", { "os": "openbsd", "cpu": "x64" }, "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw=="],
-
-    "tsx/esbuild/@esbuild/openharmony-arm64": ["@esbuild/openharmony-arm64@0.28.1", "", { "os": "none", "cpu": "arm64" }, "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg=="],
-
-    "tsx/esbuild/@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.28.1", "", { "os": "sunos", "cpu": "x64" }, "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ=="],
-
-    "tsx/esbuild/@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.28.1", "", { "os": "win32", "cpu": "arm64" }, "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA=="],
-
-    "tsx/esbuild/@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.28.1", "", { "os": "win32", "cpu": "ia32" }, "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg=="],
-
-    "tsx/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.28.1", "", { "os": "win32", "cpu": "x64" }, "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A=="],
 
     "type-is/mime-types/mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
 

--- a/packages/github-service/github.graphql
+++ b/packages/github-service/github.graphql
@@ -20,6 +20,7 @@ type Mutation {
   mergePullRequest(input: MergePullRequestInput!): MergePullRequestPayload
   createPullRequest(input: CreatePullRequestInput!): CreatePullRequestPayload
   updatePullRequest(input: UpdatePullRequestInput!): UpdatePullRequestPayload
+  deleteRef(input: DeleteRefInput!): DeleteRefPayload
   addComment(input: AddCommentInput!): AddCommentPayload
   closeIssue(input: CloseIssueInput!): CloseIssuePayload
 }
@@ -41,8 +42,23 @@ type CreatePullRequestPayload {
 
 input UpdatePullRequestInput {
   pullRequestId: ID!
+  state: PullRequestUpdateState
   title: String
   body: String
+  clientMutationId: String
+}
+
+enum PullRequestUpdateState {
+  OPEN
+  CLOSED
+}
+
+input DeleteRefInput {
+  refId: ID!
+  clientMutationId: String
+}
+
+type DeleteRefPayload {
   clientMutationId: String
 }
 
@@ -121,6 +137,7 @@ type Repository {
   id: ID!
   nameWithOwner: String!
   defaultBranchRef: Ref
+  ref(qualifiedName: String!): Ref
   issues(first: Int, after: String, labels: [String!]): IssueConnection!
   issue(number: Int!): Issue
   pullRequests(
@@ -132,6 +149,7 @@ type Repository {
 }
 
 type Ref {
+  id: ID!
   name: String!
 }
 

--- a/packages/github-service/src/bin/close-open-pull-requests-and-delete-branch.ts
+++ b/packages/github-service/src/bin/close-open-pull-requests-and-delete-branch.ts
@@ -1,0 +1,23 @@
+import { Effect } from "effect"
+import { GitHubService } from "../lib/github-service.js"
+import { decodeArgument, githubRepository, runGitHubCli } from "./cli.js"
+
+export const closeOpenPullRequestsAndDeleteBranchProgram = (
+  args: ReadonlyArray<string>,
+) =>
+  Effect.gen(function* () {
+    const forge = yield* decodeArgument(args[0], "forge")
+    const forgeHost = yield* decodeArgument(args[1], "forge host")
+    const projectPath = yield* decodeArgument(args[2], "project path")
+    const headRefName = yield* decodeArgument(args[3], "head ref")
+    const github = yield* GitHubService
+    yield* github.closeOpenPullRequestsAndDeleteBranch(
+      githubRepository(forge, forgeHost, projectPath),
+      headRefName,
+    )
+  })
+
+if (import.meta.main)
+  runGitHubCli(
+    closeOpenPullRequestsAndDeleteBranchProgram(process.argv.slice(2)),
+  )

--- a/packages/github-service/src/lib/github-helper-process.ts
+++ b/packages/github-service/src/lib/github-helper-process.ts
@@ -1,5 +1,6 @@
 import type { Effect } from "effect"
 import { runGitHubCli } from "../bin/cli.js"
+import { closeOpenPullRequestsAndDeleteBranchProgram } from "../bin/close-open-pull-requests-and-delete-branch.js"
 import { runCountOpenNonDraftPullRequestsProgram } from "../bin/count-open-non-draft-pull-requests.js"
 import { createDraftPullRequestProgram } from "../bin/create-draft-pull-request.js"
 import { ensureIssueCompletedWithSummaryProgram } from "../bin/ensure-issue-completed-with-summary.js"
@@ -27,6 +28,7 @@ export const GITHUB_HELPER_OPERATIONS = [
   "get-authenticated-user-login",
   "get-open-pr-number",
   "find-open-pr-number",
+  "close-open-pull-requests-and-delete-branch",
   "count-open-non-draft-pull-requests",
   "create-draft-pull-request",
   "update-open-draft-pull-request-copy",
@@ -139,6 +141,8 @@ const programs: Record<
   "get-authenticated-user-login": getAuthenticatedUserLoginProgram,
   "get-open-pr-number": getOpenPullRequestNumberProgram,
   "find-open-pr-number": findOpenPullRequestNumberProgram,
+  "close-open-pull-requests-and-delete-branch":
+    closeOpenPullRequestsAndDeleteBranchProgram,
   "create-draft-pull-request": createDraftPullRequestProgram,
   "update-open-draft-pull-request-copy": updateOpenDraftPullRequestCopyProgram,
   "get-pr-check-status": getPrCheckStatusProgram,

--- a/packages/github-service/src/lib/github-service-live.ts
+++ b/packages/github-service/src/lib/github-service-live.ts
@@ -322,6 +322,17 @@ const decodeSync = <S extends { readonly Type: unknown }>(
   value: unknown,
 ): S["Type"] => Schema.decodeUnknownSync(schema)(value)
 
+/** Decode external GraphQL data into a typed request failure, never a defect. */
+const decodeGitHubResponse = <S extends { readonly Type: unknown }>(
+  schema: S & Parameters<typeof Schema.decodeUnknownSync>[0],
+  value: unknown,
+  message: string,
+): Effect.Effect<S["Type"], GitHubRequestError> =>
+  Effect.try({
+    try: () => decodeSync(schema, value),
+    catch: (cause) => new GitHubRequestError({ message, cause }),
+  })
+
 const GitHubIssueStateSchema = Schema.Literals(["OPEN", "CLOSED"])
 const GitHubMergeableSchema = Schema.Literals([
   "MERGEABLE",
@@ -393,6 +404,52 @@ const ReadyLabeledIssueFieldsSchema = Schema.Struct({
 const AuthenticatedUserLoginSchema = Schema.Struct({
   login: RequiredString,
 })
+const CleanupPullRequestPageSchema = Schema.Struct({
+  repository: Schema.NullOr(
+    Schema.Struct({
+      pullRequests: Schema.Struct({
+        nodes: Schema.NullOr(
+          Schema.Array(
+            Schema.NullOr(
+              Schema.Struct({
+                id: RequiredString,
+                state: Schema.Literal("OPEN"),
+              }),
+            ),
+          ),
+        ),
+        pageInfo: Schema.Struct({
+          endCursor: Schema.NullOr(Schema.String),
+          hasNextPage: Schema.Boolean,
+        }),
+      }),
+    }),
+  ),
+})
+const CleanupBranchRefResultSchema = Schema.Struct({
+  repository: Schema.NullOr(
+    Schema.Struct({
+      ref: Schema.NullOr(Schema.Struct({ id: RequiredString })),
+    }),
+  ),
+})
+const CleanupPullRequestMutationSchema = Schema.Struct({
+  updatePullRequest: Schema.NullOr(
+    Schema.Struct({
+      pullRequest: Schema.NullOr(
+        Schema.Struct({ state: Schema.Literal("CLOSED") }),
+      ),
+    }),
+  ),
+})
+const CleanupDeleteRefMutationSchema = Schema.Struct({
+  deleteRef: Schema.NullOr(
+    Schema.Struct({ clientMutationId: Schema.NullOr(Schema.String) }),
+  ),
+})
+type CleanupPullRequestPage = typeof CleanupPullRequestPageSchema.Type
+type CleanupBranchRefResult = typeof CleanupBranchRefResultSchema.Type
+type CleanupPullRequestMutation = typeof CleanupPullRequestMutationSchema.Type
 
 const uniqueTerminalChecks = (
   checks: readonly TerminalPrStatusCheck[],
@@ -1258,6 +1315,207 @@ const makeGitHubApiService = (
     "GitHubService.findOpenPullRequestNumber",
   )(function* (repository, headRefName) {
     return yield* findOpenPullRequestNumberImpl(client, repository, headRefName)
+  }),
+  closeOpenPullRequestsAndDeleteBranch: Effect.fn(
+    "GitHubService.closeOpenPullRequestsAndDeleteBranch",
+  )(function* (repository, headRefName) {
+    if (typeof headRefName !== "string" || headRefName.trim() === "") {
+      return yield* new GitHubRequestError({
+        message: `Invalid pull request head branch for ${repository.owner}/${repository.name}`,
+      })
+    }
+
+    const pullRequestIds: string[] = []
+    let cursor: string | null = null
+    for (;;) {
+      const afterCursor: string | null = cursor
+      const page: CleanupPullRequestPage = yield* githubQuery(
+        `Failed to list open pull requests for cleanup on ${repository.owner}/${repository.name}:${headRefName}`,
+        (signal) =>
+          client.query(
+            {
+              repository: {
+                __args: repository,
+                pullRequests: {
+                  __args: {
+                    first: PAGE_SIZE,
+                    states: ["OPEN" as const],
+                    headRefName,
+                    ...(afterCursor === null ? {} : { after: afterCursor }),
+                  },
+                  nodes: {
+                    id: true,
+                    state: true,
+                  },
+                  pageInfo: {
+                    endCursor: true,
+                    hasNextPage: true,
+                  },
+                },
+              },
+            },
+            signal,
+          ),
+      ).pipe(
+        Effect.flatMap((result) =>
+          decodeGitHubResponse(
+            CleanupPullRequestPageSchema,
+            result,
+            `GitHub returned invalid open pull request data while cleaning ${repository.owner}/${repository.name}:${headRefName}`,
+          ),
+        ),
+      )
+      if (page.repository === null) {
+        return yield* new GitHubApiRepositoryUnavailableError(repository)
+      }
+      for (const pullRequest of page.repository.pullRequests.nodes ?? []) {
+        if (pullRequest === null) continue
+        pullRequestIds.push(pullRequest.id)
+      }
+      const { pageInfo } = page.repository.pullRequests
+      if (pageInfo.hasNextPage !== true) break
+      if (
+        typeof pageInfo.endCursor !== "string" ||
+        pageInfo.endCursor.trim() === ""
+      ) {
+        return yield* new GitHubRequestError({
+          message: `GitHub returned an invalid pull request page while cleaning ${repository.owner}/${repository.name}:${headRefName}`,
+        })
+      }
+      cursor = pageInfo.endCursor
+    }
+
+    if (pullRequestIds.length > 0) {
+      const mutate = client.mutation
+      if (mutate === undefined) {
+        return yield* new GitHubRequestError({
+          message: `GitHub GraphQL client does not support mutations for ${repository.owner}/${repository.name}`,
+        })
+      }
+      for (const pullRequestId of pullRequestIds) {
+        const mutation: CleanupPullRequestMutation = yield* githubRequest(
+          `Failed to close pull request for cleanup on ${repository.owner}/${repository.name}:${headRefName}`,
+          (signal) =>
+            mutate(
+              {
+                updatePullRequest: {
+                  __args: {
+                    input: {
+                      pullRequestId,
+                      state: "CLOSED" as const,
+                    },
+                  },
+                  pullRequest: {
+                    state: true,
+                  },
+                },
+              },
+              signal,
+            ),
+        ).pipe(
+          Effect.flatMap((response) =>
+            decodeGitHubResponse(
+              CleanupPullRequestMutationSchema,
+              response,
+              `GitHub returned invalid pull request closure data while cleaning ${repository.owner}/${repository.name}:${headRefName}`,
+            ),
+          ),
+        )
+        if (mutation.updatePullRequest?.pullRequest?.state !== "CLOSED") {
+          return yield* new GitHubRequestError({
+            message: `GitHub did not confirm pull request closure for ${repository.owner}/${repository.name}:${headRefName}`,
+          })
+        }
+      }
+    }
+
+    const loadBranchRef = (): Effect.Effect<
+      string | null,
+      | GitHubRequestError
+      | GitHubThrottledError
+      | GitHubApiRepositoryUnavailableError
+    > =>
+      Effect.gen(function* () {
+        const result: CleanupBranchRefResult = yield* githubQuery(
+          `Failed to find remote branch for cleanup on ${repository.owner}/${repository.name}:${headRefName}`,
+          (signal) =>
+            client.query(
+              {
+                repository: {
+                  __args: repository,
+                  ref: {
+                    __args: {
+                      qualifiedName: `refs/heads/${headRefName}`,
+                    },
+                    id: true,
+                  },
+                },
+              },
+              signal,
+            ),
+        ).pipe(
+          Effect.flatMap((response) =>
+            decodeGitHubResponse(
+              CleanupBranchRefResultSchema,
+              response,
+              `GitHub returned invalid branch reference data while cleaning ${repository.owner}/${repository.name}:${headRefName}`,
+            ),
+          ),
+        )
+        if (result.repository === null) {
+          return yield* new GitHubApiRepositoryUnavailableError(repository)
+        }
+        const ref = result.repository.ref
+        if (ref === null) return null
+        return ref.id
+      })
+
+    const refId = yield* loadBranchRef()
+    if (refId === null) return
+    const mutate = client.mutation
+    if (mutate === undefined) {
+      return yield* new GitHubRequestError({
+        message: `GitHub GraphQL client does not support mutations for ${repository.owner}/${repository.name}`,
+      })
+    }
+    yield* githubRequest(
+      `Failed to delete remote branch for cleanup on ${repository.owner}/${repository.name}:${headRefName}`,
+      (signal) =>
+        mutate(
+          {
+            deleteRef: {
+              __args: { input: { refId } },
+              clientMutationId: true,
+            },
+          },
+          signal,
+        ),
+    ).pipe(
+      Effect.flatMap((response) =>
+        decodeGitHubResponse(
+          CleanupDeleteRefMutationSchema,
+          response,
+          `GitHub returned invalid remote branch deletion data while cleaning ${repository.owner}/${repository.name}:${headRefName}`,
+        ),
+      ),
+      Effect.filterOrFail(
+        (result) => result.deleteRef !== null,
+        () =>
+          new GitHubRequestError({
+            message: `GitHub did not confirm remote branch deletion for ${repository.owner}/${repository.name}:${headRefName}`,
+          }),
+      ),
+      // A concurrent branch deletion is the same successful postcondition.
+      // Revalidate only ordinary request failures: a throttle must propagate
+      // immediately without spending another request.
+      Effect.catchTag("GitHubRequestError", (error) =>
+        loadBranchRef().pipe(
+          Effect.flatMap((remainingRefId) =>
+            remainingRefId === null ? Effect.void : Effect.fail(error),
+          ),
+        ),
+      ),
+    )
   }),
   createDraftPullRequest: Effect.fn("GitHubService.createDraftPullRequest")(
     function* (repository, input) {
@@ -2493,6 +2751,9 @@ export const makeGitHubService = (
     getOpenPullRequestNumber: adaptRepository(service.getOpenPullRequestNumber),
     findOpenPullRequestNumber: adaptRepository(
       service.findOpenPullRequestNumber,
+    ),
+    closeOpenPullRequestsAndDeleteBranch: adaptRepository(
+      service.closeOpenPullRequestsAndDeleteBranch,
     ),
     countOpenNonDraftPullRequests: adaptRepository(
       service.countOpenNonDraftPullRequests,

--- a/packages/github-service/src/lib/github-service-test.ts
+++ b/packages/github-service/src/lib/github-service-test.ts
@@ -40,6 +40,7 @@ export const makeGitHubServiceTest = (
     getAuthenticatedUserLogin: () => Effect.succeed("test-operator"),
     getOpenPullRequestNumber: () => Effect.succeed(1),
     findOpenPullRequestNumber: () => Effect.succeed(1),
+    closeOpenPullRequestsAndDeleteBranch: () => Effect.void,
     countOpenNonDraftPullRequests: () => Effect.succeed(0),
     createDraftPullRequest: () => Effect.succeed(1),
     updateOpenDraftPullRequestCopy: () => Effect.succeed(1),

--- a/packages/github-service/src/lib/github-service.ts
+++ b/packages/github-service/src/lib/github-service.ts
@@ -148,6 +148,16 @@ export interface GitHubServiceShape {
     workItemId: string,
     summaryMarkdown: string,
   ) => Effect.Effect<void, GitHubServiceError>
+  /**
+   * Close every currently-open pull request for the exact head branch, then
+   * remove that remote branch. The operation re-lists open pull requests on
+   * every invocation, so a retry after a partial completion only closes the
+   * remaining PRs. An absent branch is the successful postcondition.
+   */
+  readonly closeOpenPullRequestsAndDeleteBranch: (
+    repository: GitHubRepository,
+    headRefName: string,
+  ) => Effect.Effect<void, GitHubServiceError>
 }
 
 export class GitHubService extends Context.Service<

--- a/packages/github-service/test/github-service.spec.ts
+++ b/packages/github-service/test/github-service.spec.ts
@@ -307,6 +307,308 @@ describe("GitHubService live implementation", () => {
     ).toBe(99)
   })
 
+  it("closes every matching open pull request sequentially before deleting its branch", async () => {
+    const mutations: unknown[] = []
+    let queries = 0
+    const service = makeGitHubService({
+      query: () => {
+        queries += 1
+        return Promise.resolve(
+          queries === 1
+            ? {
+                repository: {
+                  pullRequests: {
+                    nodes: [
+                      { id: "PR_1", state: "OPEN" },
+                      { id: "PR_2", state: "OPEN" },
+                    ],
+                    pageInfo: { endCursor: null, hasNextPage: false },
+                  },
+                },
+              }
+            : { repository: { ref: { id: "REF_branch" } } },
+        ) as never
+      },
+      mutation: (request) => {
+        mutations.push(request)
+        if (mutations.length < 3) {
+          return Promise.resolve({
+            updatePullRequest: { pullRequest: { state: "CLOSED" } },
+          }) as never
+        }
+        return Promise.resolve({
+          deleteRef: { clientMutationId: null },
+        }) as never
+      },
+    })
+
+    await Effect.runPromise(
+      service.closeOpenPullRequestsAndDeleteBranch(repository, "rfa/issue-881"),
+    )
+
+    expect(mutations).toHaveLength(3)
+    expect(mutations[0]).toMatchObject({
+      updatePullRequest: {
+        __args: { input: { pullRequestId: "PR_1", state: "CLOSED" } },
+      },
+    })
+    expect(mutations[1]).toMatchObject({
+      updatePullRequest: {
+        __args: { input: { pullRequestId: "PR_2", state: "CLOSED" } },
+      },
+    })
+    expect(mutations[2]).toMatchObject({
+      deleteRef: { __args: { input: { refId: "REF_branch" } } },
+    })
+  })
+
+  it("closes one matching open pull request before deleting its branch", async () => {
+    const mutations: unknown[] = []
+    let queries = 0
+    const service = makeGitHubService({
+      query: () => {
+        queries += 1
+        return Promise.resolve(
+          queries === 1
+            ? {
+                repository: {
+                  pullRequests: {
+                    nodes: [{ id: "PR_1", state: "OPEN" }],
+                    pageInfo: { endCursor: null, hasNextPage: false },
+                  },
+                },
+              }
+            : { repository: { ref: { id: "REF_branch" } } },
+        ) as never
+      },
+      mutation: (request) => {
+        mutations.push(request)
+        return Promise.resolve(
+          mutations.length === 1
+            ? { updatePullRequest: { pullRequest: { state: "CLOSED" } } }
+            : { deleteRef: { clientMutationId: null } },
+        ) as never
+      },
+    })
+
+    await Effect.runPromise(
+      service.closeOpenPullRequestsAndDeleteBranch(repository, "rfa/issue-881"),
+    )
+
+    expect(mutations).toHaveLength(2)
+    expect(mutations[0]).toMatchObject({
+      updatePullRequest: {
+        __args: { input: { pullRequestId: "PR_1", state: "CLOSED" } },
+      },
+    })
+    expect(mutations[1]).toMatchObject({
+      deleteRef: { __args: { input: { refId: "REF_branch" } } },
+    })
+  })
+
+  it("returns a typed request error for malformed cleanup data", async () => {
+    const service = makeGitHubService({
+      query: () => Promise.resolve({ repository: {} }) as never,
+    })
+
+    const error = await Effect.runPromise(
+      service
+        .closeOpenPullRequestsAndDeleteBranch(repository, "rfa/issue-881")
+        .pipe(Effect.flip),
+    )
+
+    expect(error).toBeInstanceOf(GitHubRequestError)
+    expect(error.message).toContain("invalid open pull request data")
+  })
+
+  it("treats zero matching pull requests and a missing branch as cleanup success", async () => {
+    let queries = 0
+    let mutations = 0
+    const service = makeGitHubService({
+      query: () => {
+        queries += 1
+        return Promise.resolve(
+          queries === 1
+            ? {
+                repository: {
+                  pullRequests: {
+                    nodes: [],
+                    pageInfo: { endCursor: null, hasNextPage: false },
+                  },
+                },
+              }
+            : { repository: { ref: null } },
+        ) as never
+      },
+      mutation: () => {
+        mutations += 1
+        return Promise.resolve({}) as never
+      },
+    })
+
+    await Effect.runPromise(
+      service.closeOpenPullRequestsAndDeleteBranch(repository, "rfa/issue-881"),
+    )
+
+    expect(queries).toBe(2)
+    expect(mutations).toBe(0)
+  })
+
+  it("keeps a malformed branch-delete response distinguishable from throttling", async () => {
+    let queries = 0
+    const service = makeGitHubService({
+      query: () => {
+        queries += 1
+        return Promise.resolve(
+          queries === 1
+            ? {
+                repository: {
+                  pullRequests: {
+                    nodes: [],
+                    pageInfo: { endCursor: null, hasNextPage: false },
+                  },
+                },
+              }
+            : { repository: { ref: { id: "REF_branch" } } },
+        ) as never
+      },
+      mutation: () => Promise.resolve({ deleteRef: null }) as never,
+    })
+
+    const error = await Effect.runPromise(
+      service
+        .closeOpenPullRequestsAndDeleteBranch(repository, "rfa/issue-881")
+        .pipe(Effect.flip),
+    )
+
+    expect(error).toBeInstanceOf(GitHubRequestError)
+    expect(error.message).toContain("did not confirm remote branch deletion")
+  })
+
+  it("returns a typed request error for malformed pull request closure data", async () => {
+    const service = makeGitHubService({
+      query: () =>
+        Promise.resolve({
+          repository: {
+            pullRequests: {
+              nodes: [{ id: "PR_1", state: "OPEN" }],
+              pageInfo: { endCursor: null, hasNextPage: false },
+            },
+          },
+        }) as never,
+      mutation: () => Promise.resolve(null) as never,
+    })
+
+    const error = await Effect.runPromise(
+      service
+        .closeOpenPullRequestsAndDeleteBranch(repository, "rfa/issue-881")
+        .pipe(Effect.flip),
+    )
+
+    expect(error).toBeInstanceOf(GitHubRequestError)
+    expect(error.message).toContain("invalid pull request closure data")
+  })
+
+  it("returns a typed request error for malformed branch deletion data", async () => {
+    let queries = 0
+    const service = makeGitHubService({
+      query: () => {
+        queries += 1
+        return Promise.resolve(
+          queries === 1
+            ? {
+                repository: {
+                  pullRequests: {
+                    nodes: [],
+                    pageInfo: { endCursor: null, hasNextPage: false },
+                  },
+                },
+              }
+            : { repository: { ref: { id: "REF_branch" } } },
+        ) as never
+      },
+      mutation: () => Promise.resolve({}) as never,
+    })
+
+    const error = await Effect.runPromise(
+      service
+        .closeOpenPullRequestsAndDeleteBranch(repository, "rfa/issue-881")
+        .pipe(Effect.flip),
+    )
+
+    expect(error).toBeInstanceOf(GitHubRequestError)
+    expect(error.message).toContain("invalid remote branch deletion data")
+  })
+
+  it("replays partial cleanup without re-closing an already-closed pull request", async () => {
+    let attempt = 0
+    const closedPullRequests: string[] = []
+    const service = makeGitHubService({
+      query: () => {
+        attempt += 1
+        if (attempt === 1) {
+          return Promise.resolve({
+            repository: {
+              pullRequests: {
+                nodes: [
+                  { id: "PR_1", state: "OPEN" },
+                  { id: "PR_2", state: "OPEN" },
+                ],
+                pageInfo: { endCursor: null, hasNextPage: false },
+              },
+            },
+          }) as never
+        }
+        if (attempt === 2) {
+          return Promise.resolve({
+            repository: {
+              pullRequests: {
+                nodes: [{ id: "PR_2", state: "OPEN" }],
+                pageInfo: { endCursor: null, hasNextPage: false },
+              },
+            },
+          }) as never
+        }
+        return Promise.resolve({
+          repository: { ref: { id: "REF_branch" } },
+        }) as never
+      },
+      mutation: (request) => {
+        const update = "updatePullRequest" in request
+        if (update) {
+          const id = request.updatePullRequest.__args.input.pullRequestId
+          closedPullRequests.push(id)
+          if (id === "PR_2" && closedPullRequests.length === 2) {
+            return Promise.reject(
+              new GitHubThrottledError({
+                retryAt: Date.now() + 60_000,
+                usedFallback: false,
+              }),
+            )
+          }
+          return Promise.resolve({
+            updatePullRequest: { pullRequest: { state: "CLOSED" } },
+          }) as never
+        }
+        return Promise.resolve({
+          deleteRef: { clientMutationId: null },
+        }) as never
+      },
+    })
+
+    const throttled = await Effect.runPromise(
+      service
+        .closeOpenPullRequestsAndDeleteBranch(repository, "rfa/issue-881")
+        .pipe(Effect.flip),
+    )
+    expect(throttled).toBeInstanceOf(GitHubThrottledError)
+
+    await Effect.runPromise(
+      service.closeOpenPullRequestsAndDeleteBranch(repository, "rfa/issue-881"),
+    )
+    expect(closedPullRequests).toEqual(["PR_1", "PR_2", "PR_2"])
+  })
+
   it("updates open draft PR copy and leaves non-draft PRs unchanged", async () => {
     const mutations: unknown[] = []
     const draftService = makeGitHubService({

--- a/packages/graphql-api/test/graphql-api.test.ts
+++ b/packages/graphql-api/test/graphql-api.test.ts
@@ -175,6 +175,7 @@ const defaultGithub: GitHubServiceShape = {
   getAuthenticatedUserLogin: () => Effect.succeed("test-operator"),
   getOpenPullRequestNumber: () => Effect.succeed(1),
   findOpenPullRequestNumber: () => Effect.succeed(1),
+  closeOpenPullRequestsAndDeleteBranch: () => Effect.void,
   createDraftPullRequest: () => Effect.succeed(1),
   updateOpenDraftPullRequestCopy: () => Effect.succeed(1),
   countOpenNonDraftPullRequests: () => Effect.succeed(0),

--- a/packages/work-item-lifecycle/src/lib/github-service-test.ts
+++ b/packages/work-item-lifecycle/src/lib/github-service-test.ts
@@ -19,6 +19,7 @@ export const stubGitHubServiceLayer = (
       listReadyIssues: () => Effect.succeed([]),
       getOpenPullRequestNumber: () => Effect.succeed(1),
       findOpenPullRequestNumber: () => Effect.succeed(1),
+      closeOpenPullRequestsAndDeleteBranch: () => Effect.void,
       createDraftPullRequest: () => Effect.succeed(1),
       updateOpenDraftPullRequestCopy: () => Effect.succeed(1),
       countOpenNonDraftPullRequests: () => Effect.succeed(0),

--- a/packages/work-item-lifecycle/src/lib/remove-worktree.ts
+++ b/packages/work-item-lifecycle/src/lib/remove-worktree.ts
@@ -1,20 +1,15 @@
 import { Duration, Effect, FileSystem, Path } from "effect"
 import { DbService, type RepositoryRecord } from "@ready-for-agent/db-service"
+import { GitHubService } from "@ready-for-agent/github-service"
 import { GitLabService } from "@ready-for-agent/gitlab-service"
-import { KeymaxxerService } from "@ready-for-agent/keymaxxer-service"
 import {
   CreateWorktreeRepositoryNotFoundError,
   GitCommandError,
 } from "./create-worktree-errors.js"
 import { type GitRepository, gitExitCode, runGit } from "./git.js"
 import type { LifecycleStepContext } from "./lifecycle-steps.js"
-import {
-  RemoveWorktreeCredentialError,
-  RemoveWorktreeRemoteError,
-} from "./remove-worktree-errors.js"
+import { RemoveWorktreeRemoteError } from "./remove-worktree-errors.js"
 import { workItemBranchName, workItemWorktreePath } from "./worktree-names.js"
-
-const REMOTE_CLEANUP_TIMEOUT = Duration.seconds(60)
 
 /** Brief pause before a single automatic retry of a transient worktree delete. */
 const WORKTREE_REMOVE_RETRY_DELAY = Duration.seconds(1)
@@ -93,182 +88,6 @@ const removeResidualDirectoryWithRetry = (path: string) =>
     yield* removeDirectoryIfPresent(path).pipe(Effect.ignore)
   })
 
-const shellQuote = (value: string) => `'${value.replaceAll("'", `'"'"'`)}'`
-
-const credentialedCommand = (
-  tokenName: string | null,
-  parts: ReadonlyArray<string>,
-) =>
-  [
-    ...(tokenName === null
-      ? []
-      : [`GH_TOKEN="$${tokenName}"`, `GITHUB_TOKEN="$${tokenName}"`]),
-    ...parts.map(shellQuote),
-  ].join(" ")
-
-const resolveGithubCredential = (repository: RepositoryRecord) =>
-  Effect.gen(function* () {
-    const keymaxxer = yield* KeymaxxerService
-    if (keymaxxer.enabled === false) return null
-    const account = `${repository.projectPath}`
-    const tokenName = yield* keymaxxer
-      .findSecret({
-        provider: "github",
-        account,
-      })
-      .pipe(
-        Effect.mapError(
-          (cause) =>
-            new RemoveWorktreeCredentialError({
-              repositoryId: repository.id,
-              message: "Failed to resolve the repository GitHub credential",
-              cause,
-            }),
-        ),
-      )
-    if (tokenName === null) {
-      return yield* new RemoveWorktreeCredentialError({
-        repositoryId: repository.id,
-        message: `No GitHub credential is configured for ${account}`,
-      })
-    }
-    return tokenName
-  })
-
-const runRemoteCommand = (input: {
-  readonly tokenName: string | null
-  readonly cwd: string
-  readonly parts: ReadonlyArray<string>
-  readonly branchName: string
-  readonly allowNonZero?: boolean
-}) =>
-  Effect.gen(function* () {
-    const keymaxxer = yield* KeymaxxerService
-    const result = yield* keymaxxer
-      .runWithSecrets({
-        command: credentialedCommand(input.tokenName, input.parts),
-        cwd: input.cwd,
-        secrets: input.tokenName === null ? [] : [input.tokenName],
-        timeoutMs: Duration.toMillis(REMOTE_CLEANUP_TIMEOUT),
-      })
-      .pipe(
-        Effect.mapError(
-          (cause) =>
-            new RemoveWorktreeRemoteError({
-              message: "Failed to clean up remote PR or branch",
-              branchName: input.branchName,
-              cause,
-            }),
-        ),
-      )
-    if (result.exitCode !== 0 && input.allowNonZero !== true) {
-      return yield* new RemoveWorktreeRemoteError({
-        message: "Failed to clean up remote PR or branch",
-        branchName: input.branchName,
-      })
-    }
-    return result
-  })
-
-const closeOpenPullRequests = (input: {
-  readonly repository: RepositoryRecord
-  readonly branchName: string
-  readonly tokenName: string | null
-  readonly cwd: string
-}) =>
-  Effect.gen(function* () {
-    const repo = `${input.repository.projectPath}`
-    const listed = yield* runRemoteCommand({
-      tokenName: input.tokenName,
-      cwd: input.cwd,
-      branchName: input.branchName,
-      parts: [
-        "gh",
-        "pr",
-        "list",
-        "--repo",
-        repo,
-        "--head",
-        input.branchName,
-        "--state",
-        "open",
-        "--json",
-        "number",
-      ],
-    })
-
-    const pullRequests = yield* Effect.try({
-      try: () =>
-        JSON.parse(listed.stdout.trim() || "[]") as ReadonlyArray<{
-          readonly number: number
-        }>,
-      catch: (cause) =>
-        new RemoveWorktreeRemoteError({
-          message: "Failed to parse open pull request list for remote cleanup",
-          branchName: input.branchName,
-          cause,
-        }),
-    })
-
-    for (const pullRequest of pullRequests) {
-      yield* runRemoteCommand({
-        tokenName: input.tokenName,
-        cwd: input.cwd,
-        branchName: input.branchName,
-        parts: [
-          "gh",
-          "pr",
-          "close",
-          String(pullRequest.number),
-          "--repo",
-          repo,
-        ],
-      })
-    }
-  })
-
-const deleteRemoteBranch = (input: {
-  readonly repository: RepositoryRecord
-  readonly branchName: string
-  readonly tokenName: string | null
-  readonly cwd: string
-}) =>
-  Effect.gen(function* () {
-    const repo = `${input.repository.projectPath}`
-    // Missing remote branch is success (idempotent); other failures fail cleanup.
-    const result = yield* runRemoteCommand({
-      tokenName: input.tokenName,
-      cwd: input.cwd,
-      branchName: input.branchName,
-      allowNonZero: true,
-      parts: [
-        "gh",
-        "api",
-        "-X",
-        "DELETE",
-        `repos/${repo}/git/refs/heads/${input.branchName}`,
-      ],
-    })
-    if (result.exitCode === 0) {
-      return
-    }
-    const stderr = result.stderr.toLowerCase()
-    const stdout = result.stdout.toLowerCase()
-    if (
-      result.exitCode === 1 &&
-      (stderr.includes("not found") ||
-        stdout.includes("not found") ||
-        stderr.includes("reference does not exist") ||
-        stdout.includes("reference does not exist"))
-    ) {
-      return
-    }
-    return yield* new RemoveWorktreeRemoteError({
-      message: "Failed to delete remote Work Item branch",
-      branchName: input.branchName,
-    })
-  })
-
 const removeGitLabRemoteArtifacts = (input: {
   readonly repository: RepositoryRecord
   readonly branchName: string
@@ -304,6 +123,26 @@ const removeGitLabRemoteArtifacts = (input: {
     )
   })
 
+const removeGitHubRemoteArtifacts = (input: {
+  readonly repository: RepositoryRecord
+  readonly branchName: string
+}) =>
+  Effect.gen(function* () {
+    const github = yield* GitHubService
+    const forgeRepository = {
+      forge: input.repository.forge,
+      forgeHost: input.repository.forgeHost,
+      projectPath: input.repository.projectPath,
+    }
+    // This is deliberately one service operation. Ambient and Keymaxxer
+    // adapters therefore retain their coordinator permit across list, every
+    // sequential close, and the final branch delete.
+    yield* github.closeOpenPullRequestsAndDeleteBranch(
+      forgeRepository,
+      input.branchName,
+    )
+  })
+
 const removeRemoteArtifacts = (input: {
   readonly repository: RepositoryRecord
   readonly branchName: string
@@ -312,20 +151,7 @@ const removeRemoteArtifacts = (input: {
     if (input.repository.forge === "gitlab") {
       return yield* removeGitLabRemoteArtifacts(input)
     }
-    const tokenName = yield* resolveGithubCredential(input.repository)
-    const cwd = input.repository.localPath
-    yield* closeOpenPullRequests({
-      repository: input.repository,
-      branchName: input.branchName,
-      tokenName,
-      cwd,
-    })
-    yield* deleteRemoteBranch({
-      repository: input.repository,
-      branchName: input.branchName,
-      tokenName,
-      cwd,
-    })
+    yield* removeGitHubRemoteArtifacts(input)
   })
 
 const removeLocalArtifacts = (
@@ -450,8 +276,8 @@ export const localCleanup = (
 /**
  * Inverse of createWorktree: remove local artifacts, close any open remote
  * PR/MR, and drop the remote branch when present. Missing artifacts are
- * success (idempotent). Missing Forge credential fails for GitHub Keymaxxer
- * paths; GitLab cleanup uses the ambient GitLab service.
+ * success (idempotent). GitHub uses the coordinator-backed GitHub service;
+ * GitLab cleanup uses the ambient GitLab service.
  */
 export const removeWorktree = (
   context: LifecycleStepContext,
@@ -467,5 +293,4 @@ export const removeWorktree = (
 export type RemoveWorktreeError =
   | CreateWorktreeRepositoryNotFoundError
   | GitCommandError
-  | RemoveWorktreeCredentialError
   | RemoveWorktreeRemoteError

--- a/packages/work-item-lifecycle/src/lib/work-item-lifecycle.ts
+++ b/packages/work-item-lifecycle/src/lib/work-item-lifecycle.ts
@@ -30,6 +30,7 @@ import {
   GitHubThrottledError,
   type PullRequestLifecycleStatus,
   formatUserFacingError,
+  isGitHubThrottledError,
   sanitizeUserFacingText,
 } from "@ready-for-agent/github-service"
 import { GitLabService } from "@ready-for-agent/gitlab-service"
@@ -671,6 +672,7 @@ export type ContinueAfterHumanPrOutcomeError =
 export type ResetError =
   | WorkItemNotFoundError
   | ResetCleanupError
+  | GitHubThrottledError
   | WorkItemLifecycleDatabaseError
   | AcknowledgeError
   | JobNotFoundError
@@ -5257,13 +5259,14 @@ export const makeWorkItemLifecycleLive = (
           const cleanupContext = toLifecycleStepContext(currentWorkItem)
 
           yield* steps.removeWorktree(cleanupContext).pipe(
-            Effect.mapError(
-              (cause) =>
-                new ResetCleanupError({
-                  workItemId,
-                  message: `Failed to remove worktree for Work Item ${workItemId}`,
-                  cause,
-                }),
+            Effect.mapError((cause) =>
+              isGitHubThrottledError(cause)
+                ? cause
+                : new ResetCleanupError({
+                    workItemId,
+                    message: `Failed to remove worktree for Work Item ${workItemId}`,
+                    cause,
+                  }),
             ),
           )
 

--- a/packages/work-item-lifecycle/test/remove-worktree.spec.ts
+++ b/packages/work-item-lifecycle/test/remove-worktree.spec.ts
@@ -13,18 +13,20 @@ import { Effect, FileSystem, Layer, type Layer as LayerType } from "effect"
 import { DatabaseTest } from "@ready-for-agent/db/test"
 import { DbService, DbServiceLive } from "@ready-for-agent/db-service"
 import {
+  GitHubRequestError,
+  GitHubService,
+  type GitHubServiceShape,
+  GitHubThrottledError,
+} from "@ready-for-agent/github-service"
+import {
   GitLabService,
   type GitLabServiceShape,
 } from "@ready-for-agent/gitlab-service"
 import {
-  KeymaxxerError,
   KeymaxxerService,
   type KeymaxxerServiceShape,
-  type RunWithSecretsInput,
 } from "@ready-for-agent/keymaxxer-service"
 import {
-  RemoveWorktreeCredentialError,
-  RemoveWorktreeRemoteError,
   createWorktree,
   localCleanup,
   makeWorkItemId,
@@ -90,6 +92,43 @@ const stubGitLab = (
     ...overrides,
   } satisfies GitLabServiceShape)
 
+const stubGitHub = (
+  overrides: Partial<GitHubServiceShape> = {},
+): Layer.Layer<GitHubService> =>
+  Layer.succeed(GitHubService, {
+    getAuthenticatedUserLogin: () => Effect.succeed("test-operator"),
+    listReadyIssues: () => Effect.succeed([]),
+    getOpenPullRequestNumber: () => Effect.succeed(1),
+    findOpenPullRequestNumber: () => Effect.succeed(null),
+    closeOpenPullRequestsAndDeleteBranch: () => Effect.void,
+    countOpenNonDraftPullRequests: () => Effect.succeed(0),
+    createDraftPullRequest: () => Effect.succeed(1),
+    updateOpenDraftPullRequestCopy: () => Effect.succeed(null),
+    getPullRequestCheckStatus: () =>
+      Effect.succeed({
+        _tag: "succeeded",
+        terminalChecks: [],
+        mergeability: "mergeable",
+        baseRefName: "main",
+        headPushedAt: null,
+        headSha: null,
+        createdAt: null,
+        isDraft: null,
+      }),
+    getPrStatusCheckDiagnostics: () => Effect.succeed([]),
+    observeAutomatedReviewEvidence: () =>
+      Effect.succeed({
+        _tag: "ambiguous" as const,
+        reason: "Automated review evidence observation is not configured",
+      }),
+    getPullRequestLifecycleStatus: () => Effect.succeed({ _tag: "open" }),
+    markPullRequestReadyForReview: () => Effect.void,
+    mergePullRequest: () => Effect.succeed({ _tag: "merged" }),
+    rerunWorkflowRun: () => Effect.void,
+    ensureIssueCompletedWithSummary: () => Effect.void,
+    ...overrides,
+  } satisfies GitHubServiceShape)
+
 /**
  * FileSystem layer that fails residual `remove` for a sticky path so Local
  * cleanup's residual postcondition can be forced after retries.
@@ -139,6 +178,7 @@ const run = <A, E>(
     | LayerType.Layer.Success<typeof DbServiceLive>
     | KeymaxxerService
     | GitLabService
+    | GitHubService
   >,
   keymaxxerLayer: Layer.Layer<KeymaxxerService> = stubKeymaxxer(),
   gitlabLayer: Layer.Layer<GitLabService> = stubGitLab(),
@@ -147,12 +187,14 @@ const run = <A, E>(
     never,
     FileSystem.FileSystem
   >,
+  githubLayer: Layer.Layer<GitHubService> = stubGitHub(),
 ): Promise<A> => {
   const withServices = effect.pipe(
     Effect.provide(DbServiceLive),
     Effect.provide(DatabaseTest),
     Effect.provide(keymaxxerLayer),
     Effect.provide(gitlabLayer),
+    Effect.provide(githubLayer),
   )
   const withPlatform =
     fileSystemOverlay === undefined
@@ -985,7 +1027,11 @@ describe("removeWorktree", () => {
         issueNumber: 42,
         workItemId,
       })
-      const commands: string[] = []
+      const cleanups: Array<{
+        readonly projectPath: string
+        readonly branchName: string
+      }> = []
+      let keymaxxerCalls = 0
 
       await run(
         Effect.gen(function* () {
@@ -1022,31 +1068,32 @@ describe("removeWorktree", () => {
           yield* removeWorktree(context)
         }),
         stubKeymaxxer({
-          findSecret: () => Effect.succeed("GITHUB_TOKEN_ACME_WIDGETS"),
-          runWithSecrets: (input: RunWithSecretsInput) => {
-            commands.push(input.command)
-            if (input.command.includes("'gh' 'pr' 'list'")) {
-              return Effect.succeed({
-                exitCode: 0,
-                stdout: '[{"number":77}]',
-                stderr: "",
-              })
-            }
+          findSecret: () => {
+            keymaxxerCalls += 1
+            return Effect.succeed("GITHUB_TOKEN_ACME_WIDGETS")
+          },
+          runWithSecrets: () => {
+            keymaxxerCalls += 1
             return Effect.succeed({ exitCode: 0, stdout: "", stderr: "" })
           },
         }),
+        stubGitLab(),
+        undefined,
+        stubGitHub({
+          closeOpenPullRequestsAndDeleteBranch: (repository, branchName) =>
+            Effect.sync(() => {
+              cleanups.push({
+                projectPath: repository.projectPath,
+                branchName,
+              })
+            }),
+        }),
       )
 
-      expect(commands.length).toBe(3)
-      expect(commands[0]).toContain('GH_TOKEN="$GITHUB_TOKEN_ACME_WIDGETS"')
-      expect(commands[0]).toContain('GITHUB_TOKEN="$GITHUB_TOKEN_ACME_WIDGETS"')
-      expect(commands[0]).toContain("'gh' 'pr' 'list'")
-      expect(commands[0]).toContain(branch)
-      expect(commands[0]).toContain("acme/widgets")
-      expect(commands[1]).toContain("'gh' 'pr' 'close' '77'")
-      expect(commands[1]).toContain("acme/widgets")
-      expect(commands[2]).toContain("'gh' 'api' '-X' 'DELETE'")
-      expect(commands[2]).toContain(`git/refs/heads/${branch}`)
+      expect(cleanups).toEqual([
+        { projectPath: "acme/widgets", branchName: branch },
+      ])
+      expect(keymaxxerCalls).toBe(0)
     } finally {
       await rm(root, { recursive: true, force: true })
     }
@@ -1057,8 +1104,7 @@ describe("removeWorktree", () => {
     try {
       const bare = await initBareRepository(root)
       const workItemId = makeWorkItemId()
-      let listCalls = 0
-      let deleteCalls = 0
+      let cleanupCalls = 0
 
       await run(
         Effect.gen(function* () {
@@ -1091,37 +1137,24 @@ describe("removeWorktree", () => {
             sessionId: null,
           })
         }),
-        stubKeymaxxer({
-          runWithSecrets: (input) => {
-            if (input.command.includes("'gh' 'pr' 'list'")) {
-              listCalls += 1
-              return Effect.succeed({
-                exitCode: 0,
-                stdout: "[]",
-                stderr: "",
-              })
-            }
-            if (input.command.includes("git/refs/heads/")) {
-              deleteCalls += 1
-              return Effect.succeed({
-                exitCode: 1,
-                stdout: "",
-                stderr: "Not Found",
-              })
-            }
-            return Effect.succeed({ exitCode: 0, stdout: "", stderr: "" })
-          },
+        stubKeymaxxer(),
+        stubGitLab(),
+        undefined,
+        stubGitHub({
+          closeOpenPullRequestsAndDeleteBranch: () =>
+            Effect.sync(() => {
+              cleanupCalls += 1
+            }),
         }),
       )
 
-      expect(listCalls).toBe(1)
-      expect(deleteCalls).toBe(1)
+      expect(cleanupCalls).toBe(1)
     } finally {
       await rm(root, { recursive: true, force: true })
     }
   })
 
-  it("fails when no GitHub credential is configured", async () => {
+  it("preserves native GitHub throttling for the Reset caller", async () => {
     const root = await mkdtemp(join(tmpdir(), "rfa-rm-wt-no-cred-"))
     try {
       const bare = await initBareRepository(root)
@@ -1158,19 +1191,27 @@ describe("removeWorktree", () => {
             sessionId: null,
           }).pipe(Effect.flip)
         }),
-        stubKeymaxxer({ findSecret: () => Effect.succeed(null) }),
+        stubKeymaxxer(),
+        stubGitLab(),
+        undefined,
+        stubGitHub({
+          closeOpenPullRequestsAndDeleteBranch: () =>
+            Effect.fail(
+              new GitHubThrottledError({
+                retryAt: Date.now() + 60_000,
+                usedFallback: false,
+              }),
+            ),
+        }),
       )
 
-      expect(error).toBeInstanceOf(RemoveWorktreeCredentialError)
-      expect((error as RemoveWorktreeCredentialError).message).toContain(
-        "No GitHub credential is configured for acme/widgets",
-      )
+      expect(error).toBeInstanceOf(GitHubThrottledError)
     } finally {
       await rm(root, { recursive: true, force: true })
     }
   })
 
-  it("maps Keymaxxer remote command failure", async () => {
+  it("preserves native GitHub request errors", async () => {
     const root = await mkdtemp(join(tmpdir(), "rfa-rm-wt-remote-fail-"))
     try {
       const bare = await initBareRepository(root)
@@ -1207,18 +1248,18 @@ describe("removeWorktree", () => {
             sessionId: null,
           }).pipe(Effect.flip)
         }),
-        stubKeymaxxer({
-          runWithSecrets: () =>
+        stubKeymaxxer(),
+        stubGitLab(),
+        undefined,
+        stubGitHub({
+          closeOpenPullRequestsAndDeleteBranch: () =>
             Effect.fail(
-              new KeymaxxerError({
-                operation: "runWithSecrets",
-                message: "process failed",
-              }),
+              new GitHubRequestError({ message: "network unavailable" }),
             ),
         }),
       )
 
-      expect(error).toBeInstanceOf(RemoveWorktreeRemoteError)
+      expect(error).toBeInstanceOf(GitHubRequestError)
     } finally {
       await rm(root, { recursive: true, force: true })
     }


### PR DESCRIPTION
## Why

Reset cleanup previously depended on human-oriented `gh pr` output parsing. That path
could not provide consistent coordinator, retry, and typed-throttle behavior across
credential modes.

## What changed

- Added one native GitHub operation that lists matching open pull requests, closes them
  sequentially, then deletes the remote branch.
- Routed both Ambient and Keymaxxer paths through that operation so the coordinator
  permit spans the whole cleanup while Keymaxxer keeps credentials isolated.
- Preserved replay safety for partial cleanup, already-closed pull requests, and
  already-missing branches.
- Propagated GitHub throttling through Reset as an actionable typed error.
- Schema-decoded every cleanup query and mutation response so malformed GitHub data
  returns `GitHubRequestError` rather than defecting or falsely confirming deletion.

## Verification

- `bunx nx run github-service:typecheck --skip-nx-cache`
- `bunx nx run github-service:test --skip-nx-cache` (123 tests)
- Biome and diff whitespace checks
- Pre-commit passed after regenerating the Bun lockfile.

Closes #881