### PR TITLE
fix(ready-for-agent): allow Settings-first startup without OpenCode

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,9 @@ Forge):
    ambient credential source, not a required host tool.
 
 **Agent Backend executable** (only the backend selected in Settings is
-required; default is OpenCode):
+required; default is OpenCode). On a first run, before any backend selection is
+stored, no Agent Backend executable is required so the Harness can open
+Settings:
 
 4. [OpenCode](https://opencode.ai/) (`opencode` on PATH) when OpenCode is the
    selected Agent Backend

--- a/apps/ready-for-agent/README.md
+++ b/apps/ready-for-agent/README.md
@@ -61,10 +61,12 @@ This boots the full Harness (UI + backend) on the existing monorepo dev path
 
 Before start, the binary checks that required host tools are on `PATH`: `git`,
 the selected Agent Backend executable (`opencode` by default), plus `gh` when a
-GitHub Repository exists and `curl` when a GitLab Repository exists. `glab` is
-an optional ambient GitLab credential source. The AWS CLI is **not** required
-for Claude Code Bedrock profile discovery (bundled AWS SDK). Missing required
-tools fail immediately with install hints. Keymaxxer is optional
+GitHub Repository exists and `curl` when a GitLab Repository exists. On a
+first run, before a backend selection is stored, it requires no Agent Backend
+executable so Settings can be used to choose one. `glab` is an optional ambient
+GitLab credential source. The AWS CLI is **not** required for Claude Code
+Bedrock profile discovery (bundled AWS SDK). Missing required tools fail
+immediately with install hints. Keymaxxer is optional
 (`KEYMAXXER_ENTRYPOINT` or `keymaxxer` on PATH); ambient Forge auth still works
 without it.
 

--- a/apps/ready-for-agent/src/host-binary.test.ts
+++ b/apps/ready-for-agent/src/host-binary.test.ts
@@ -80,6 +80,9 @@ describe("compiled host binary ambient-auth smoke", () => {
   let databasePath = ""
   let restrictedBin = ""
   let port = 0
+  let firstRunDatabasePath = ""
+  let firstRunBin = ""
+  let firstRunPort = 0
 
   beforeAll(async () => {
     if (!hostSelection.ok) {
@@ -120,9 +123,13 @@ describe("compiled host binary ambient-auth smoke", () => {
     runCwd = join(fixtureRoot, "unrelated-cwd")
     databasePath = join(fixtureRoot, "data", "ready-for-agent.db")
     restrictedBin = join(fixtureRoot, "bin")
+    firstRunDatabasePath = join(fixtureRoot, "first-run", "ready-for-agent.db")
+    firstRunBin = join(fixtureRoot, "first-run-bin")
     mkdirSync(runCwd, { recursive: true })
     mkdirSync(dirname(databasePath), { recursive: true })
     mkdirSync(restrictedBin, { recursive: true })
+    mkdirSync(dirname(firstRunDatabasePath), { recursive: true })
+    mkdirSync(firstRunBin, { recursive: true })
 
     // Required host tools only — no bun/nx/aws on PATH for the product process.
     // Bedrock profile discovery is bundled via the AWS SDK (issue #822); the
@@ -138,10 +145,21 @@ describe("compiled host binary ambient-auth smoke", () => {
         { mode: 0o755 },
       )
     }
+
+    const git = Bun.which("git")
+    if (git === null) {
+      throw new Error("Host tool git is required for this test")
+    }
+    writeFileSync(
+      join(firstRunBin, "git"),
+      `#!/usr/bin/env bash\nexec ${JSON.stringify(git)} "$@"\n`,
+      { mode: 0o755 },
+    )
     // Explicitly leave `aws` off PATH even when installed on the host.
     expect(Bun.which("aws", { PATH: restrictedBin })).toBeNull()
 
     port = 18_000 + Math.floor(Math.random() * 1000)
+    firstRunPort = port + 1_000
   }, 600_000)
 
   afterAll(() => {
@@ -201,10 +219,24 @@ describe("compiled host binary ambient-auth smoke", () => {
     expect(helpText).toContain("start")
     expect(helpText).not.toContain("remove-github-token")
 
-    const startOnce = async () => {
+    const startOnce = async ({
+      binPath = restrictedBin,
+      dbPath = databasePath,
+      serverPort = port,
+    }: {
+      readonly binPath?: string
+      readonly dbPath?: string
+      readonly serverPort?: number
+    } = {}) => {
+      const startEnv: NodeJS.ProcessEnv = {
+        ...env,
+        PATH: binPath,
+        PORT: String(serverPort),
+        SQLITE_DATABASE_PATH: dbPath,
+      }
       const child = spawn(binaryPath, ["--no-open"], {
         cwd: runCwd,
-        env,
+        env: startEnv,
         stdio: ["ignore", "pipe", "pipe"],
         detached: true,
       })
@@ -218,7 +250,7 @@ describe("compiled host binary ambient-auth smoke", () => {
       child.stderr?.on("data", (chunk: string) => {
         stderr += chunk
       })
-      const base = `http://127.0.0.1:${port}`
+      const base = `http://127.0.0.1:${serverPort}`
       try {
         const root = await waitForHttp(`${base}/`, 60_000)
         expect(root.status).toBe(200)
@@ -277,6 +309,20 @@ describe("compiled host binary ambient-auth smoke", () => {
         await sleep(500)
       }
     }
+
+    // Fresh installs must reach Settings without the default OpenCode binary.
+    expect(Bun.which("opencode", { PATH: firstRunBin })).toBeNull()
+    await startOnce({
+      binPath: firstRunBin,
+      dbPath: firstRunDatabasePath,
+      serverPort: firstRunPort,
+    })
+    // The bootstrap-created OpenCode default is not an operator selection.
+    await startOnce({
+      binPath: firstRunBin,
+      dbPath: firstRunDatabasePath,
+      serverPort: firstRunPort,
+    })
 
     await startOnce()
     // Restart against the same database — migrations must be idempotent.

--- a/apps/ready-for-agent/src/host-tools-preflight.test.ts
+++ b/apps/ready-for-agent/src/host-tools-preflight.test.ts
@@ -17,6 +17,15 @@ describe("host tools preflight", () => {
     expect(result.ok).toBe(true)
   })
 
+  test("requires no Agent Backend executable before the first backend selection", () => {
+    const result = checkHostTools((command) => command === "git", {
+      selectedAgentBackendIds: [],
+      repositoryForges: [],
+    })
+
+    expect(result).toEqual({ ok: true })
+  })
+
   test("requires gh only when a GitHub Repository exists", () => {
     const githubOnly = checkHostTools(
       (command) => ["git", "gh", "opencode"].includes(command),

--- a/apps/ready-for-agent/src/host-tools-preflight.ts
+++ b/apps/ready-for-agent/src/host-tools-preflight.ts
@@ -72,7 +72,8 @@ export type HostToolsPreflightOptions = {
    * Selected Agent Backend ids that cold-start preflight must cover
    * (harness default ∪ Repository overrides). Unknown ids are ignored.
    * Combined with {@link selectedAgentBackendId} when both are set; if neither
-   * yields a selectable id, OpenCode is required.
+   * yields a selectable id, OpenCode is required unless an explicit empty list
+   * says no backend has been selected yet.
    */
   readonly selectedAgentBackendIds?: ReadonlyArray<string>
   /**
@@ -118,7 +119,11 @@ const resolveRequiredAgentBackendIds = (
     resolved.push(value)
   }
 
-  return resolved.length > 0 ? resolved : [defaultAgentBackendId]
+  if (resolved.length > 0) return resolved
+
+  return options.selectedAgentBackendIds !== undefined && raw.length === 0
+    ? []
+    : [defaultAgentBackendId]
 }
 
 const resolveRequiredAgentBackendBinaries = (
@@ -175,11 +180,15 @@ export const checkHostTools = (
     ...forgeTools.map((tool) => tool.name),
   ].join(" and ")
 
+  const backendRequirement =
+    backendIds.length === 0
+      ? "No Agent Backend executable is required until one is selected in Settings."
+      : `Only selected Agent Backend executable(s) (${backendSummary}) are required alongside ${requiredBaseTools}.`
   const lines = [
     "Required host tools are missing from PATH:",
     ...missingRequired.map((tool) => `  - ${tool.name}: ${tool.installHint}`),
     "",
-    `Only selected Agent Backend executable(s) (${backendSummary}) are required alongside ${requiredBaseTools}.`,
+    backendRequirement,
     "Install the tools above, then run ready-for-agent again.",
     "Keymaxxer is optional and does not block start.",
   ]

--- a/apps/ready-for-agent/src/peek-selected-agent-backend.test.ts
+++ b/apps/ready-for-agent/src/peek-selected-agent-backend.test.ts
@@ -30,6 +30,16 @@ const ensureConfigTable = (db: Database): void => {
   `)
 }
 
+const ensureConfigSelectionTable = (db: Database): void => {
+  db.run(`
+    CREATE TABLE IF NOT EXISTS config (
+      id TEXT PRIMARY KEY DEFAULT 'default',
+      selected_agent_backend TEXT NOT NULL DEFAULT 'opencode',
+      agent_backend_configured_at INTEGER
+    )
+  `)
+}
+
 const ensureRepositoryTable = (db: Database): void => {
   db.run(`
     CREATE TABLE IF NOT EXISTS repository (
@@ -50,12 +60,46 @@ describe("peekSelectedAgentBackendIds", () => {
     roots = []
   })
 
-  test("missing DB defaults safely to OpenCode only", () => {
+  test("missing DB has no persisted backend selection", () => {
     expect(
       peekSelectedAgentBackendIds("/no/such/path/ready-for-agent.db"),
-    ).toEqual(["opencode"])
-    expect(peekSelectedAgentBackendIds(":memory:")).toEqual(["opencode"])
-    expect(peekSelectedAgentBackendIds("")).toEqual(["opencode"])
+    ).toEqual([])
+    expect(peekSelectedAgentBackendIds(":memory:")).toEqual([])
+    expect(peekSelectedAgentBackendIds("")).toEqual([])
+  })
+
+  test("seeded default remains unselected until Settings saves a backend", () => {
+    const { path, root } = createTempDb()
+    roots.push(root)
+    const db = openWritable(path)
+    try {
+      ensureConfigSelectionTable(db)
+      db.run(
+        `INSERT INTO config (id, selected_agent_backend) VALUES ('default', 'opencode')`,
+      )
+    } finally {
+      db.close()
+    }
+
+    expect(peekSelectedAgentBackendIds(path)).toEqual([])
+  })
+
+  test("requires a backend explicitly saved in Settings", () => {
+    const { path, root } = createTempDb()
+    roots.push(root)
+    const db = openWritable(path)
+    try {
+      ensureConfigSelectionTable(db)
+      db.run(
+        `INSERT INTO config (
+           id, selected_agent_backend, agent_backend_configured_at
+         ) VALUES ('default', 'claude', 1)`,
+      )
+    } finally {
+      db.close()
+    }
+
+    expect(peekSelectedAgentBackendIds(path)).toEqual(["claude"])
   })
 
   test("default only when no repository overrides", () => {

--- a/apps/ready-for-agent/src/peek-selected-agent-backend.ts
+++ b/apps/ready-for-agent/src/peek-selected-agent-backend.ts
@@ -1,3 +1,4 @@
+import { existsSync } from "node:fs"
 import {
   defaultAgentBackendId,
   isSelectableAgentBackendId,
@@ -30,29 +31,81 @@ const normalizeBackendId = (
   return isSelectableAgentBackendId(trimmed) ? trimmed : undefined
 }
 
-const readConfigBackendId = (db: Database): string => {
+type PersistedBackendSelection =
+  | { readonly kind: "unselected" }
+  | { readonly kind: "selected"; readonly backendId: string }
+
+const selectedBackend = (
+  backendId: string | null | undefined,
+): PersistedBackendSelection => ({
+  kind: "selected",
+  backendId: normalizeBackendId(backendId) ?? defaultAgentBackendId,
+})
+
+const readPersistedConfigBackendSelection = (
+  db: Database,
+): PersistedBackendSelection => {
   try {
+    const configTable = db
+      .query(
+        `SELECT 1
+         FROM sqlite_master
+         WHERE type = 'table' AND name = 'config'
+         LIMIT 1`,
+      )
+      .get()
+    if (configTable === null) return { kind: "unselected" }
+
     const configRow = db
       .query(
-        `SELECT selected_agent_backend AS selectedAgentBackend
+        `SELECT selected_agent_backend AS selectedAgentBackend,
+                agent_backend_configured_at AS agentBackendConfiguredAt
          FROM config
          WHERE id = 'default'
          LIMIT 1`,
       )
-      .get() as { selectedAgentBackend?: string } | null
-    return (
-      normalizeBackendId(configRow?.selectedAgentBackend) ??
-      defaultAgentBackendId
-    )
+      .get() as {
+      selectedAgentBackend?: string
+      agentBackendConfiguredAt?: number | null
+    } | null
+    if (configRow === null || configRow.agentBackendConfiguredAt === null) {
+      return { kind: "unselected" }
+    }
+    return selectedBackend(configRow.selectedAgentBackend)
   } catch {
-    // Config table may be missing on first-run / pre-migration DBs.
-    return defaultAgentBackendId
+    // Pre-marker Config rows belong to existing installations, where the
+    // default was already enforced as a host-tool requirement.
+    try {
+      const configRow = db
+        .query(
+          `SELECT selected_agent_backend AS selectedAgentBackend
+           FROM config
+           WHERE id = 'default'
+           LIMIT 1`,
+        )
+        .get() as { selectedAgentBackend?: string } | null
+      return configRow === null
+        ? { kind: "unselected" }
+        : selectedBackend(configRow.selectedAgentBackend)
+    } catch {
+      // An unreadable existing DB must retain the conservative host preflight.
+      return selectedBackend(defaultAgentBackendId)
+    }
   }
 }
 
+const readConfigBackendId = (db: Database): string =>
+  (() => {
+    const selection = readPersistedConfigBackendSelection(db)
+    return selection.kind === "selected"
+      ? selection.backendId
+      : defaultAgentBackendId
+  })()
+
 /**
  * Read Harness Config's selected Agent Backend without starting the full app.
- * Missing DB or row defaults to OpenCode so first-run preflight stays correct.
+ * Missing DB or row returns the product default for direct callers that need a
+ * backend value. First-run preflight uses the plural peek below instead.
  * Does not include Repository overrides (use {@link peekSelectedAgentBackendIds}).
  */
 export const peekSelectedAgentBackendId = (databasePath: string): string => {
@@ -77,22 +130,34 @@ export const peekSelectedAgentBackendId = (databasePath: string): string => {
  * Cold-start host-tools preflight set: harness config default unioned with
  * every distinct non-null Repository Agent Backend override.
  *
- * Missing DB / unreadable DB / empty config defaults safely to OpenCode only.
+ * A bootstrap-seeded default is not a persisted selection until Settings saves
+ * it. First-run can therefore reach Settings across restarts.
  * Unknown or blank backend ids are ignored (never required as host tools).
  */
 export const peekSelectedAgentBackendIds = (
   databasePath: string,
 ): ReadonlyArray<string> => {
+  if (databasePath.startsWith("libsql:")) {
+    // The local SQLite peeker cannot inspect a remote URL; retain the existing
+    // conservative preflight rather than treating it as a pristine database.
+    return [defaultAgentBackendId]
+  }
   const filePath = resolveFilePath(databasePath)
   if (filePath === undefined) {
-    return [defaultAgentBackendId]
+    return []
+  }
+  if (!existsSync(filePath)) {
+    return []
   }
 
   try {
     const db = new Database(filePath, { readonly: true, create: false })
     try {
       const ids = new Set<string>()
-      ids.add(readConfigBackendId(db))
+      const configSelection = readPersistedConfigBackendSelection(db)
+      if (configSelection.kind === "selected") {
+        ids.add(configSelection.backendId)
+      }
 
       try {
         const overrideRows = db

--- a/apps/ready-for-agent/src/services/start-harness.ts
+++ b/apps/ready-for-agent/src/services/start-harness.ts
@@ -88,7 +88,10 @@ export class StartHarness extends Context.Service<
         const repositoryForges = peekRepositoryForges(config.databasePath)
         const result = checkHostTools(
           (command) => Bun.which(command) !== null,
-          { selectedAgentBackendIds, repositoryForges },
+          {
+            selectedAgentBackendIds,
+            repositoryForges,
+          },
         )
         if (!result.ok) {
           return yield* new StartHarnessFailed({ detail: result.message })

--- a/packages/db-schema/drizzle/20260808093000_explicit_agent_backend_selection/migration.sql
+++ b/packages/db-schema/drizzle/20260808093000_explicit_agent_backend_selection/migration.sql
@@ -1,0 +1,8 @@
+ALTER TABLE `config` ADD `agent_backend_configured_at` integer;--> statement-breakpoint
+
+-- Preserve existing installations' established preflight behavior. New
+-- databases run this migration before their config row is created, leaving the
+-- marker null until Settings explicitly saves an Agent Backend.
+UPDATE `config`
+SET `agent_backend_configured_at` = `updated_at`
+WHERE `agent_backend_configured_at` IS NULL;

--- a/packages/db-schema/src/schema.ts
+++ b/packages/db-schema/src/schema.ts
@@ -73,6 +73,8 @@ export const config = snakeCase.table("config", {
   id: text().primaryKey().default("default"),
   /** Active Agent Backend for the Harness instance (OpenCode by default). */
   selectedAgentBackend: text().notNull().default("opencode"),
+  /** Set only after an operator saves the Harness Agent Backend selection. */
+  agentBackendConfiguredAt: integer({ mode: "number" }),
   defaultModel: text(),
   defaultThinkingLevel: text(),
   reviewModel: text(),

--- a/packages/db-service/src/lib/db-service.ts
+++ b/packages/db-service/src/lib/db-service.ts
@@ -861,8 +861,8 @@ export const DbServiceLive = Layer.effect(
                    id, selected_agent_backend, default_model, default_thinking_level,
                    review_model, review_thinking_level, backend_model_prefs,
                    max_concurrent_agent_turns, max_concurrent_work_items,
-                   created_at, updated_at
-                 ) VALUES ('default', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                   agent_backend_configured_at, created_at, updated_at
+                 ) VALUES ('default', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                  ON CONFLICT (id) DO UPDATE SET
                    selected_agent_backend = excluded.selected_agent_backend,
                    default_model = excluded.default_model,
@@ -872,6 +872,7 @@ export const DbServiceLive = Layer.effect(
                    backend_model_prefs = excluded.backend_model_prefs,
                    max_concurrent_agent_turns = excluded.max_concurrent_agent_turns,
                    max_concurrent_work_items = excluded.max_concurrent_work_items,
+                   agent_backend_configured_at = excluded.agent_backend_configured_at,
                    updated_at = excluded.updated_at
                  RETURNING ${configSelect}`,
                 [
@@ -883,6 +884,7 @@ export const DbServiceLive = Layer.effect(
                   backendModelPrefs,
                   maxConcurrentAgentTurns,
                   maxConcurrentWorkItems,
+                  now,
                   now,
                   now,
                 ],

--- a/packages/db/test/run-migrations.spec.ts
+++ b/packages/db/test/run-migrations.spec.ts
@@ -103,6 +103,7 @@ describe("runMigrations", () => {
           { name: "20260729160000_forge_identity_foundation" },
           { name: "20260730140857_unfinished_work_item_index" },
           { name: "20260807100000_postponed_step_runs" },
+          { name: "20260808093000_explicit_agent_backend_selection" },
         ])
       }).pipe(Effect.provide(SqliteTest)),
     )
@@ -1026,6 +1027,53 @@ describe("runMigrations", () => {
             status: "queued",
             finished_at: null,
             postponed_until: null,
+          },
+        ])
+      }).pipe(Effect.provide(SqliteTest)),
+    )
+  })
+
+  it("marks existing Agent Backend selections as explicitly configured", async () => {
+    const migrationSql = await readFile(
+      join(
+        import.meta.dir,
+        "../../db-schema/drizzle/20260808093000_explicit_agent_backend_selection/migration.sql",
+      ),
+      "utf8",
+    )
+
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        const sql = yield* SqlClient.SqlClient
+        yield* sql.unsafe(
+          `CREATE TABLE config (
+             id text PRIMARY KEY,
+             selected_agent_backend text NOT NULL,
+             updated_at integer NOT NULL
+           )`,
+        )
+        yield* sql.unsafe(
+          `INSERT INTO config (id, selected_agent_backend, updated_at)
+           VALUES ('default', 'claude', 123)`,
+        )
+
+        for (const statement of migrationSql.split(
+          "--> statement-breakpoint",
+        )) {
+          if (statement.trim().length > 0) {
+            yield* sql.unsafe(statement)
+          }
+        }
+
+        expect(
+          yield* sql.unsafe(
+            `SELECT selected_agent_backend, agent_backend_configured_at
+             FROM config WHERE id = 'default'`,
+          ),
+        ).toEqual([
+          {
+            selected_agent_backend: "claude",
+            agent_backend_configured_at: 123,
           },
         ])
       }).pipe(Effect.provide(SqliteTest)),


### PR DESCRIPTION
## Why

A fresh `ready-for-agent` installation seeded OpenCode as its default backend,
causing host-tool preflight to fail when `opencode` was absent—even when another
supported backend was available. This prevented operators from reaching Settings
to choose their backend.

## What changed

- Treat the bootstrap-seeded backend default as unselected until Settings is
  explicitly saved.
- Persist an explicit backend-selection marker when configuration is saved, so
  the Settings-first behavior survives restarts.
- Add a migration that marks existing configurations as explicitly selected,
  preserving their current preflight behavior.
- Keep backend requirements for repository overrides and conservatively require
  OpenCode when an existing database cannot be inspected.
- Update operator documentation and add first-run, restart, preflight, and
  migration coverage.

## Verification

- `bunx nx run db:test`
- `bunx nx run db-schema:typecheck`
- `bunx nx run ready-for-agent:lint`
- `bunx nx run ready-for-agent:typecheck`
- `bunx nx run ready-for-agent:test`

The host-binary smoke test verifies two consecutive first-run starts with only
`git` available on `PATH` and no `opencode`.

Closes #904