### PR TITLE
fix(harness): restore empty relevant issues heading

### DIFF
--- a/apps/harness/src/home-page-content.tsx
+++ b/apps/harness/src/home-page-content.tsx
@@ -2526,9 +2526,9 @@ function RepositoryCard({
             )}
           <div className={ui.repoIssues}>
             <div className={ui.repoIssuesHead}>
-              {!hasNoRelevantIssues ? (
-                <h3 className={ui.repoIssuesKicker}>Relevant issues</h3>
-              ) : null}
+              <h3 className={ui.repoIssuesKicker}>
+                {hasNoRelevantIssues ? "No relevant issues" : "Relevant issues"}
+              </h3>
               <button
                 type="button"
                 className={ui.iconBtn}
@@ -2625,7 +2625,10 @@ function RepositoryIssues({
   if (issues.length === 0) {
     return (
       <p className={ui.repoIssuesEmpty}>
-        No issues found this harness can work on.
+        Label GitHub/GitLab issues with{" "}
+        <code className={ui.guidanceCode}>ready-for-agent</code> for them to
+        show up here. If an issue is a child issue, the parent itself cannot be
+        a child issue too.
       </p>
     )
   }

--- a/apps/harness/test/repos-interchange.test.ts
+++ b/apps/harness/test/repos-interchange.test.ts
@@ -152,7 +152,7 @@ describe("Interchange phase 4: repos page + blank slate", () => {
     expect(ui).toMatch(/stampBlocked:[\s\S]*?bg-lane-queue/)
   })
 
-  test("zero relevant issues omit the kicker but retain refresh chrome", () => {
+  test("zero relevant issues retain heading chrome and explain how to add them", () => {
     const card = sliceBetweenMarkers(
       homeSource(),
       "function RepositoryCard(",
@@ -160,9 +160,8 @@ describe("Interchange phase 4: repos page + blank slate", () => {
     )
     expect(card).toContain("const hasNoRelevantIssues =")
     expect(card).toContain("relevantIssues?.length === 0")
-    expect(card).toContain("{!hasNoRelevantIssues ? (")
     expect(card).toContain(
-      "<h3 className={ui.repoIssuesKicker}>Relevant issues</h3>",
+      '<h3 className={ui.repoIssuesKicker}>\n                {hasNoRelevantIssues ? "No relevant issues" : "Relevant issues"}',
     )
     expect(card).toContain(
       'aria-label={\n                  refreshingIssues ? "Refreshing issues" : "Refresh issues"',
@@ -174,7 +173,12 @@ describe("Interchange phase 4: repos page + blank slate", () => {
       "function RepositoryIssues(",
       "function ParentIssueGroup(",
     )
-    expect(issues).toContain("No issues found this harness can work on.")
+    expect(issues).toContain("Label GitHub/GitLab issues with")
+    expect(issues).toContain("ready-for-agent")
+    expect(issues).toContain("for them to\n        show up here.")
+    expect(issues).toContain(
+      "If an issue is a child issue, the parent itself cannot be\n        a child issue too.",
+    )
     expect(issues).toContain("ui.repoIssuesEmpty")
 
     const ui = uiSource()


### PR DESCRIPTION
## Why

Repositories with zero relevant issues lost the section kicker, which left the refresh control
aligned on the left and provided little guidance about how issues become eligible.

## What changed

- Always render the Relevant Issues section heading so the refresh control retains the same
  right-aligned layout in empty and populated states.
- Show `No relevant issues` for the empty state while preserving `Relevant issues` when issues
  exist.
- Explain that GitHub/GitLab issues need the `ready-for-agent` label and clarify the supported
  one-level parent/child hierarchy.
- Update the Repos interchange contract test to cover the restored heading and guidance copy.

## Verification

- `bunx nx run harness:test --testPathPattern=repos-interchange.test.ts`
- `bunx nx run harness:build`
- `bunx biome check apps/harness/src/home-page-content.tsx`
  `apps/harness/test/repos-interchange.test.ts`
- Uncommitted-change review completed with no findings.

This is a presentation-only change; reconciliation and relevance rules are unchanged.

Closes #910