### PR TITLE
fix(harness): regroup repository summary metadata

### DIFF
--- a/apps/harness/src/home-page-content.tsx
+++ b/apps/harness/src/home-page-content.tsx
@@ -2319,6 +2319,12 @@ function RepositoryCard({
               </dd>
             </div>
             <div className={ui.repoMetaRow}>
+              <dt>Include all Issue Authors</dt>
+              <dd>
+                {repository.includeAllIssueAuthors ? "Enabled" : "Disabled"}
+              </dd>
+            </div>
+            <div className={ui.repoMetaRow}>
               <dt>Build model</dt>
               <dd>
                 {repository.defaultModel ??
@@ -2365,22 +2371,16 @@ function RepositoryCard({
               </dd>
             </div>
             <div className={ui.repoMetaRow}>
-              <dt>Auto-merge</dt>
-              <dd>{repository.autoMerge ? "Enabled" : "Disabled"}</dd>
-            </div>
-            <div className={ui.repoMetaRow}>
-              <dt>Include all Issue Authors</dt>
-              <dd>
-                {repository.includeAllIssueAuthors ? "Enabled" : "Disabled"}
-              </dd>
-            </div>
-            <div className={ui.repoMetaRow}>
               <dt>Wait for ready checks</dt>
               <dd>
                 {repository.waitForReadyForReviewChecks
                   ? "Enabled"
                   : "Disabled"}
               </dd>
+            </div>
+            <div className={ui.repoMetaRow}>
+              <dt>Auto-merge</dt>
+              <dd>{repository.autoMerge ? "Enabled" : "Disabled"}</dd>
             </div>
           </dl>
           {!repository.credential.configured &&

--- a/apps/harness/test/repos-interchange.test.ts
+++ b/apps/harness/test/repos-interchange.test.ts
@@ -60,15 +60,25 @@ describe("Interchange phase 4: repos page + blank slate", () => {
   })
 
   test("meta table is hairline two-column mono dt/dd with harness-default annotations", () => {
-    const body = sliceBetweenMarkers(
+    const meta = sliceBetweenMarkers(
       homeSource(),
       "className={ui.repoMeta}",
-      "function RepositoryIssues(",
+      "</dl>",
     )
-    expect(body).toContain("ui.repoMetaRow")
-    expect(body).toContain("Harness default (")
-    expect(body).toContain("<dt>Path</dt>")
-    expect(body).toContain("<dt>Agent Backend</dt>")
+    expect(meta).toContain("ui.repoMetaRow")
+    expect(meta).toContain("Harness default (")
+    expect(
+      Array.from(meta.matchAll(/<dt>([^<]+)<\/dt>/g), (match) => match[1]),
+    ).toEqual([
+      "Path",
+      "Checkout",
+      "Agent Backend",
+      "Include all Issue Authors",
+      "Build model",
+      "Review model",
+      "Wait for ready checks",
+      "Auto-merge",
+    ])
 
     const ui = uiSource()
     expect(ui).toContain("repoMeta:")


### PR DESCRIPTION
## Why

The expanded Repository card paired unrelated settings across its two-column
metadata grid, making the summary harder to scan.

## What changed

- Reordered the existing metadata rows so Agent Backend pairs with Include all
  Issue Authors, Build model pairs with Review model, and Wait for ready checks
  pairs with Auto-merge.
- Kept Path and Checkout first and preserved all labels, values, fallback logic,
  settings behavior, API wiring, and persistence.
- Added a regression assertion for the exact metadata label order.

## Verification

- `bunx nx test harness` — 540 Bun tests and 123 Vitest tests passed.
- `bunx nx build harness`
- Biome check for both changed files.
- `git diff --check`

Closes #915