### PR TITLE
fix(harness): preserve telemetry origins and Completed pagination

### DIFF
--- a/apps/harness/e2e/features/session-telemetry-browser-history.feature
+++ b/apps/harness/e2e/features/session-telemetry-browser-history.feature
@@ -15,6 +15,7 @@ Feature: Route Session Telemetry through browser history
     And the Session usage dialog is visible
     And the Session usage dialog shows the missing Session Telemetry state
     And the Pipeline jobs tab is active
+    And the Pipeline remains visible under the dialog
 
   Scenario: Browser Back closes telemetry and Forward reopens the same Work Item
     When I open the home page
@@ -45,6 +46,8 @@ Feature: Route Session Telemetry through browser history
     Then the browser location is the Session Telemetry path for the missing-session fixture
     And the Session usage dialog is visible
     And the Session usage dialog shows the missing Session Telemetry state
+    And the Repos jobs tab is active
+    And Repos remains visible under the dialog
 
   Scenario: Browser Back and Forward from Repos restore origin and reopen
     When I open the Repos page
@@ -95,6 +98,77 @@ Feature: Route Session Telemetry through browser history
     When I close the Session usage dialog
     Then the Session usage dialog is hidden
     And the browser location is the completed path
+
+  Scenario: Completed Next pushes page 2 into the URL
+    When I open the Completed page
+    And I cancel the Harness settings dialog if present
+    And I navigate to the next Completed page
+    Then the browser location is Completed page 2
+    And Completed page 2 is visible
+
+  Scenario: Completed page 2 is directly addressable
+    When I open Completed page 2 directly
+    And I cancel the Harness settings dialog if present
+    Then the browser location is Completed page 2
+    And Completed page 2 is visible
+
+  Scenario: Invalid Completed page search resolves to canonical page 1
+    When I open Completed with invalid page search
+    And I cancel the Harness settings dialog if present
+    Then the browser location is canonical Completed page 1
+
+  Scenario: Page-2 telemetry retains Completed page and scroll on Close
+    When I open Completed page 2 directly
+    And I cancel the Harness settings dialog if present
+    And I open Session Telemetry for the page-2 fixture from Completed
+    Then the browser location is the Session Telemetry path for the page-2 fixture
+    And the Session usage dialog is visible
+    And Completed page 2 remains visible under the dialog
+    And the Completed jobs tab is active
+    And the Completed scroll position is preserved
+    When I close the Session usage dialog
+    Then the browser location is Completed page 2
+    And Completed page 2 is visible
+    And the Completed scroll position is preserved
+
+  Scenario: Back and Forward retain Completed page 2 and reopen telemetry
+    When I open Completed page 2 directly
+    And I cancel the Harness settings dialog if present
+    And I open Session Telemetry for the page-2 fixture from Completed
+    Then the browser location is the Session Telemetry path for the page-2 fixture
+    When I go back in the browser
+    Then the Session usage dialog is hidden
+    And the browser location is Completed page 2
+    And Completed page 2 is visible
+    And the Completed scroll position is preserved
+    When I go forward in the browser
+    Then the Session usage dialog is visible
+    And the browser location is the Session Telemetry path for the page-2 fixture
+    And Completed page 2 remains visible under the dialog
+    And the Completed jobs tab is active
+
+  Scenario: Escape returns to Completed page 2
+    When I open Completed page 2 directly
+    And I cancel the Harness settings dialog if present
+    And I open Session Telemetry for the page-2 fixture from Completed
+    When I press Escape
+    Then the Session usage dialog is hidden
+    And the browser location is Completed page 2
+    And Completed page 2 is visible
+
+  Scenario: Refreshing an in-app masked telemetry URL uses canonical Pipeline
+    When I open Completed page 2 directly
+    And I cancel the Harness settings dialog if present
+    And I open Session Telemetry for the page-2 fixture from Completed
+    Then the browser location is the Session Telemetry path for the page-2 fixture
+    When I refresh the page
+    Then the Session usage dialog is visible
+    And the browser location is the Session Telemetry path for the page-2 fixture
+    And the Pipeline jobs tab is active
+    And the Pipeline remains visible under the dialog
+    When I close the Session usage dialog
+    Then the Session usage dialog is hidden
+    And the browser location is the home path
 
   Scenario: Direct telemetry navigation shows the dialog over Pipeline
     When I open the missing-session Session Telemetry path directly

--- a/apps/harness/e2e/steps/session-telemetry-browser-history.ts
+++ b/apps/harness/e2e/steps/session-telemetry-browser-history.ts
@@ -21,6 +21,8 @@ const telemetryPathFor = (workItemId: string): RegExp =>
   )
 
 const completedPathPattern = /\/completed\/?(?:\?.*)?$/
+const completedPageTwoPathPattern = /\/completed\/?\?page=2$/
+const telemetryOriginScrollByPage = new WeakMap<Page, number>()
 
 const openSessionButton = async (page: Page, sessionId: string) => {
   const sessionButton = page.getByRole("button", {
@@ -152,6 +154,25 @@ When("I open the Completed page", async ({ page }) => {
   await expect(page).toHaveURL(completedPathPattern)
 })
 
+When("I open Completed page 2 directly", async ({ page }) => {
+  await page.goto("/completed?page=2")
+  await expect(page).toHaveURL(completedPageTwoPathPattern)
+  await expect(
+    page.getByRole("navigation", { name: "Completed work items pagination" }),
+  ).toContainText("Page 2 of", { timeout: 30_000 })
+})
+
+When("I open Completed with invalid page search", async ({ page }) => {
+  await page.goto("/completed?page=invalid")
+})
+
+When("I navigate to the next Completed page", async ({ page }) => {
+  await page
+    .getByRole("button", { name: "Next page of completed work items" })
+    .click()
+  await expect(page).toHaveURL(completedPageTwoPathPattern)
+})
+
 When(
   "I open Session Telemetry for the completed fixture from Completed",
   async ({ page }) => {
@@ -159,6 +180,30 @@ When(
     await openSessionButton(page, TELEMETRY_FIXTURE.completedSessionId)
   },
 )
+
+When(
+  "I open Session Telemetry for the page-2 fixture from Completed",
+  async ({ page }) => {
+    await installSessionQueryRoute(page)
+    const sessionButton = page.getByRole("button", {
+      name: TELEMETRY_FIXTURE.completedPageTwoSessionId,
+      exact: true,
+    })
+    await expect(sessionButton).toBeVisible({ timeout: 30_000 })
+    await sessionButton.scrollIntoViewIfNeeded()
+    telemetryOriginScrollByPage.set(
+      page,
+      await page.evaluate(() => window.scrollY),
+    )
+    await sessionButton.click()
+    await expect(sessionUsageDialog(page)).toBeVisible({ timeout: 15_000 })
+  },
+)
+
+When("I press Escape", async ({ page }) => {
+  await page.keyboard.press("Escape")
+  await expect(sessionUsageDialog(page)).toBeHidden()
+})
 
 When(
   "I open the missing-session Session Telemetry path directly",
@@ -236,6 +281,16 @@ Then(
 )
 
 Then(
+  "the browser location is the Session Telemetry path for the page-2 fixture",
+  async ({ page }) => {
+    await expect(page).toHaveURL(
+      telemetryPathFor(TELEMETRY_FIXTURE.completedPageTwoWorkItemId),
+    )
+    expect(new URL(page.url()).searchParams.has("page")).toBe(false)
+  },
+)
+
+Then(
   "the browser location is the Session Telemetry path for the missing-session fixture with theme dark",
   async ({ page }) => {
     await expect(page).toHaveURL(
@@ -248,6 +303,67 @@ Then(
 
 Then("the browser location is the completed path", async ({ page }) => {
   await expect(page).toHaveURL(completedPathPattern)
+})
+
+Then("the browser location is Completed page 2", async ({ page }) => {
+  await expect(page).toHaveURL(completedPageTwoPathPattern)
+})
+
+Then("the browser location is canonical Completed page 1", async ({ page }) => {
+  await expect(page).toHaveURL(/\/completed\/?$/)
+  await expect(
+    page.getByRole("navigation", { name: "Completed work items pagination" }),
+  ).toContainText("Page 1 of")
+})
+
+Then("Completed page 2 is visible", async ({ page }) => {
+  await expect(
+    page.getByRole("navigation", { name: "Completed work items pagination" }),
+  ).toContainText("Page 2 of")
+  await expect(
+    page.getByRole("button", {
+      name: TELEMETRY_FIXTURE.completedPageTwoSessionId,
+      exact: true,
+    }),
+  ).toBeVisible()
+})
+
+Then("Completed page 2 remains visible under the dialog", async ({ page }) => {
+  await expect(sessionUsageDialog(page)).toBeVisible()
+  await expect(
+    page.getByRole("navigation", { name: "Completed work items pagination" }),
+  ).toContainText("Page 2 of")
+})
+
+Then("the Completed jobs tab is active", async ({ page }) => {
+  await expect(
+    page.getByRole("navigation", { name: "Jobs" }).getByRole("link", {
+      name: "Completed",
+      exact: true,
+    }),
+  ).toHaveAttribute("aria-current", "page")
+})
+
+Then("the Pipeline remains visible under the dialog", async ({ page }) => {
+  await expect(
+    page.getByRole("region", { name: "Lifecycle pipeline" }),
+  ).toBeVisible()
+})
+
+Then("Repos remains visible under the dialog", async ({ page }) => {
+  await expect(
+    page.getByRole("region", { name: "Configured repositories" }),
+  ).toBeVisible()
+})
+
+Then("the Completed scroll position is preserved", async ({ page }) => {
+  const origin = telemetryOriginScrollByPage.get(page)
+  if (origin === undefined) {
+    throw new Error("Completed scroll origin was not recorded")
+  }
+  const current = await page.evaluate(() => window.scrollY)
+  expect(origin).toBeGreaterThan(0)
+  expect(current).toBe(origin)
 })
 
 Then("the Session usage dialog is visible", async ({ page }) => {

--- a/apps/harness/e2e/steps/session-telemetry-browser-history.ts
+++ b/apps/harness/e2e/steps/session-telemetry-browser-history.ts
@@ -168,7 +168,7 @@ When("I open Completed with invalid page search", async ({ page }) => {
 
 When("I navigate to the next Completed page", async ({ page }) => {
   await page
-    .getByRole("button", { name: "Next page of completed work items" })
+    .getByRole("link", { name: "Next page of completed work items" })
     .click()
   await expect(page).toHaveURL(completedPageTwoPathPattern)
 })

--- a/apps/harness/e2e/support/session-telemetry-fixture.ts
+++ b/apps/harness/e2e/support/session-telemetry-fixture.ts
@@ -42,6 +42,11 @@ export const TELEMETRY_FIXTURE = {
   completedSessionId: "ses_e2e_fixture_completed",
   completedIssueNumber: 103,
   completedIssueId: "issue-01KZD5SESS10NTE0FXX0000003",
+  /** Complete Work Item pinned to page 2 of the Completed archive. */
+  completedPageTwoWorkItemId: "wi-01KZD5SESS10NTE0FXX0000004",
+  completedPageTwoSessionId: "ses_e2e_fixture_completed_page_two",
+  completedPageTwoIssueNumber: 104,
+  completedPageTwoIssueId: "issue-01KZD5SESS10NTE0FXX0000004",
 } as const
 
 const sqlLiteral = (value: string) => `'${value.replaceAll("'", "''")}'`
@@ -85,6 +90,39 @@ const seedAndRestart = async (sql: string) => {
  */
 export const seedSessionTelemetryFixtures = async (): Promise<void> => {
   const now = Date.now()
+  // Keep both Completed pages deterministic even when other e2e scenarios have
+  // terminal Work Items. Future fixture timestamps sort ahead of all ordinary
+  // rows: page 1 has the existing telemetry fixture + 19 fillers, and page 2
+  // has the dedicated page-two fixture + 19 fillers.
+  const completedOrderBase = now + 10_000_000_000
+  const fillerWorkItems = Array.from({ length: 38 }, (_, index) => {
+    const issueNumber = 200 + index
+    const order =
+      index < 19
+        ? completedOrderBase + 199 - index
+        : index < 33
+          ? completedOrderBase + 69 - (index - 19)
+          : completedOrderBase + 49 - (index - 33)
+    const id = `wi-01KZD5SESS10NTE0F${String(index + 1).padStart(9, "0")}`
+    return `INSERT INTO work_item (
+       id, repository_id, issue_number, issue_title, agent_backend,
+       state, state_ready_at, paused, holds_worker_slot, session_id,
+       created_at, updated_at
+     ) VALUES (
+       ${sqlLiteral(id)},
+       ${sqlLiteral(TELEMETRY_FIXTURE.repositoryId)},
+       ${issueNumber},
+       ${sqlLiteral(`E2E Completed pagination filler ${index + 1}`)},
+       'opencode',
+       'complete',
+       ${order},
+       0,
+       0,
+       NULL,
+       ${order},
+       ${order}
+     );`
+  })
   const sql = [
     // Clear prior fixture rows so scenarios can re-seed safely.
     `DELETE FROM work_item WHERE repository_id = ${sqlLiteral(TELEMETRY_FIXTURE.repositoryId)};`,
@@ -119,6 +157,22 @@ export const seedSessionTelemetryFixtures = async (): Promise<void> => {
        '',
        ${sqlLiteral(`https://github.com/${TELEMETRY_FIXTURE.projectPath}/issues/${TELEMETRY_FIXTURE.missingSessionIssueNumber}`)},
        'OPEN',
+       ${now},
+       0,
+       ${now},
+       ${now}
+     );`,
+    `INSERT INTO issue (
+       id, repository_id, issue_number, title, body, url, state,
+       github_created_at, has_children, created_at, updated_at
+     ) VALUES (
+       ${sqlLiteral(TELEMETRY_FIXTURE.completedPageTwoIssueId)},
+       ${sqlLiteral(TELEMETRY_FIXTURE.repositoryId)},
+       ${TELEMETRY_FIXTURE.completedPageTwoIssueNumber},
+       'E2E Session Telemetry completed page two',
+       '',
+       ${sqlLiteral(`https://github.com/${TELEMETRY_FIXTURE.projectPath}/issues/${TELEMETRY_FIXTURE.completedPageTwoIssueNumber}`)},
+       'CLOSED',
        ${now},
        0,
        ${now},
@@ -203,13 +257,33 @@ export const seedSessionTelemetryFixtures = async (): Promise<void> => {
        'E2E Session Telemetry completed',
        'opencode',
        'complete',
-       ${now},
+       ${completedOrderBase + 200},
        0,
        0,
        ${sqlLiteral(TELEMETRY_FIXTURE.completedSessionId)},
-       ${now},
-       ${now}
+       ${completedOrderBase + 200},
+       ${completedOrderBase + 200}
      );`,
+    ...fillerWorkItems.slice(0, 19),
+    `INSERT INTO work_item (
+       id, repository_id, issue_number, issue_title, agent_backend,
+       state, state_ready_at, paused, holds_worker_slot, session_id,
+       created_at, updated_at
+     ) VALUES (
+       ${sqlLiteral(TELEMETRY_FIXTURE.completedPageTwoWorkItemId)},
+       ${sqlLiteral(TELEMETRY_FIXTURE.repositoryId)},
+       ${TELEMETRY_FIXTURE.completedPageTwoIssueNumber},
+       'E2E Session Telemetry completed page two',
+       'opencode',
+       'complete',
+       ${completedOrderBase + 50},
+       0,
+       0,
+       ${sqlLiteral(TELEMETRY_FIXTURE.completedPageTwoSessionId)},
+       ${completedOrderBase + 50},
+       ${completedOrderBase + 50}
+     );`,
+    ...fillerWorkItems.slice(19),
   ].join("\n")
 
   await seedAndRestart(sql)

--- a/apps/harness/src/completed-search.ts
+++ b/apps/harness/src/completed-search.ts
@@ -26,9 +26,3 @@ export const parseCompletedSearch = (
 /** Page 1 is canonical as bare `/completed`; later pages carry `?page=`. */
 export const completedPageSearch = (page: number): CompletedSearch =>
   page <= 1 ? {} : { page }
-
-/** Whether the address bar already uses the canonical search for this page. */
-export const isCompletedPageSearchCanonical = (input: {
-  readonly rawPage: unknown
-  readonly page: number
-}): boolean => input.rawPage === (input.page === 1 ? undefined : input.page)

--- a/apps/harness/src/completed-search.ts
+++ b/apps/harness/src/completed-search.ts
@@ -1,0 +1,34 @@
+export type CompletedSearch = {
+  readonly page?: number
+}
+
+const positiveInteger = (value: unknown): number | undefined => {
+  const parsed =
+    typeof value === "number"
+      ? value
+      : typeof value === "string" && /^\d+$/.test(value)
+        ? Number(value)
+        : Number.NaN
+
+  return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : undefined
+}
+
+/** Validate the Completed archive's URL-owned page at the router boundary. */
+export const parseCompletedSearch = (
+  raw: Record<string, unknown>,
+): CompletedSearch => {
+  const page = positiveInteger(raw.page)
+  // TanStack merges validated search over raw search, so an explicit
+  // undefined is required to prevent invalid/page-1 input leaking through.
+  return { page: page === 1 ? undefined : page }
+}
+
+/** Page 1 is canonical as bare `/completed`; later pages carry `?page=`. */
+export const completedPageSearch = (page: number): CompletedSearch =>
+  page <= 1 ? {} : { page }
+
+/** Whether the address bar already uses the canonical search for this page. */
+export const isCompletedPageSearchCanonical = (input: {
+  readonly rawPage: unknown
+  readonly page: number
+}): boolean => input.rawPage === (input.page === 1 ? undefined : input.page)

--- a/apps/harness/src/jobs-view-switcher.tsx
+++ b/apps/harness/src/jobs-view-switcher.tsx
@@ -62,9 +62,9 @@ export function JobsViewSwitcher() {
   const pathname = useRouterState({ select: (s) => s.location.pathname })
   const onCompleted =
     pathname === "/completed" || pathname.startsWith("/completed/")
-  // `/settings` and Session Telemetry use Pipeline as canonical background
-  // (issues #840 / #841 / #843). Explicit opens from Repos or Completed share
-  // that background while the overlay is open; Close/Back restore the origin.
+  // Direct `/settings` and telemetry loads use Pipeline as their canonical
+  // background. Masked telemetry opens retain the runtime origin pathname, so
+  // the originating Jobs tab remains active (issues #840–#843 / #906).
   const pipelineActive = isPipelineBackgroundPath(pathname)
   const reposActive = pathname === "/repos" || pathname.startsWith("/repos/")
   // Filters only drive the Pipeline board today (full in-memory item set).

--- a/apps/harness/src/routed-dialog.ts
+++ b/apps/harness/src/routed-dialog.ts
@@ -190,8 +190,8 @@ export const isOtherRoutedDialogPath = (pathname: string): boolean => {
 }
 
 /**
- * Pipeline is the canonical background for `/settings` and Session Telemetry
- * (direct load / refresh). Jobs switcher treats these as Pipeline-active.
+ * Pipeline is the canonical background for `/settings` and directly loaded
+ * Session Telemetry. Masked in-app telemetry keeps its origin pathname here.
  */
 export const isPipelineBackgroundPath = (pathname: string): boolean =>
   pathname === "/" ||

--- a/apps/harness/src/routes/__root.tsx
+++ b/apps/harness/src/routes/__root.tsx
@@ -295,18 +295,20 @@ function RootComponent() {
 }
 
 /**
- * Session Telemetry at `/session/<work-item-id>/telemetry` (ADR 0048 / #841 / #843).
- * Explicit opens from Pipeline, Repos, or Completed push history; Close/Escape/
- * Back leave the route; direct entry closes with replace → `/`.
+ * Session Telemetry at `/session/<work-item-id>/telemetry` (ADR 0048 / #841 / #843 / #906).
+ * In-app opens mask the retained runtime surface; direct entry uses the
+ * canonical Pipeline route. Close/Escape/Back leave the public overlay URL.
  */
 function SessionTelemetryOverlay() {
   const navigate = useNavigate()
   const router = useRouter()
-  const pathname = useRouterState({ select: (s) => s.location.pathname })
+  const telemetryPathname = useRouterState({
+    select: (s) => s.location.maskedLocation?.pathname ?? s.location.pathname,
+  })
   const telemetryHistoryState = useRouterState({
     select: (s) => readSessionTelemetryHistoryState(s.location.state),
   })
-  const parsed = parseSessionTelemetryPath(pathname)
+  const parsed = parseSessionTelemetryPath(telemetryPathname)
   const workItemId = parsed?.workItemId ?? null
   const open = workItemId !== null
   const sessionIdHint = telemetryHistoryState?.sessionId ?? null
@@ -336,7 +338,7 @@ function SessionTelemetryOverlay() {
       onClose={() => {
         // Native dialog already closed; leave the route only when we are still
         // on the telemetry path (Back already changed location first).
-        if (isSessionTelemetryPath(pathname)) {
+        if (isSessionTelemetryPath(telemetryPathname)) {
           leaveSessionTelemetryRoute()
         }
       }}

--- a/apps/harness/src/routes/completed.tsx
+++ b/apps/harness/src/routes/completed.tsx
@@ -1,7 +1,16 @@
 import { useQueries, useQuery, useSuspenseQuery } from "@tanstack/react-query"
-import { createFileRoute } from "@tanstack/react-router"
-import { Suspense, useEffect, useState } from "react"
+import {
+  createFileRoute,
+  useNavigate,
+  useRouterState,
+} from "@tanstack/react-router"
+import { Suspense, useEffect } from "react"
 import { Banner, BannerActionButton } from "../banner.js"
+import {
+  completedPageSearch,
+  isCompletedPageSearchCanonical,
+  parseCompletedSearch,
+} from "../completed-search.js"
 import {
   CompletedCardGrid,
   CompletedSurface,
@@ -20,6 +29,7 @@ import { WorkItemsLiveUpdates } from "../work-items-live-updates.js"
  * Full completed-work archive (server-paginated). Sticky Jobs chrome links here.
  */
 export const Route = createFileRoute("/completed")({
+  validateSearch: (raw: Record<string, unknown>) => parseCompletedSearch(raw),
   component: CompletedPage,
 })
 
@@ -40,7 +50,16 @@ function CompletedPage() {
 }
 
 function CompletedBoard() {
-  const [page, setPage] = useState(1)
+  const navigate = useNavigate({ from: Route.fullPath })
+  const { page: searchPage } = Route.useSearch()
+  const page = searchPage ?? 1
+  const rawPage = useRouterState({
+    select: (state) => state.location.search.page,
+  })
+  const pageSearchIsCanonical = isCompletedPageSearchCanonical({
+    rawPage,
+    page,
+  })
   const { data: repositories } = useSuspenseQuery(repositoriesQuery)
   const repositoryIds = repositories.map(({ id }) => id)
   const completedQuery = useQuery(completedWorkItemsHistoryQuery(page))
@@ -74,13 +93,35 @@ function CompletedBoard() {
         ? 1
         : Math.max(1, Math.ceil(totalCount / pageSize))
 
+  // Validation makes the query safe immediately; replace malformed aliases
+  // (`?page=1`, fractional, zero, negative, or text) with the canonical URL.
+  useEffect(() => {
+    if (pageSearchIsCanonical) return
+    void navigate({
+      to: "/completed",
+      search: (prev) => ({
+        ...prev,
+        page: completedPageSearch(page).page,
+      }),
+      replace: true,
+      resetScroll: false,
+    })
+  }, [navigate, page, pageSearchIsCanonical])
+
   // When history shrinks under us (SSE refresh), clamp past the last page.
   useEffect(() => {
     if (totalPages === undefined) return
     if (page > totalPages) {
-      setPage(totalPages)
+      void navigate({
+        to: "/completed",
+        search: (prev) => ({
+          ...prev,
+          page: completedPageSearch(totalPages).page,
+        }),
+        replace: true,
+      })
     }
-  }, [page, totalPages])
+  }, [navigate, page, totalPages])
 
   // Live updates must outlive pending/error UI. Unmounting on skeleton aborts
   // the follower and cancels the completed-work-items query prefix mid-fetch.
@@ -211,7 +252,13 @@ function CompletedBoard() {
               aria-busy={completedQuery.isFetching || undefined}
               aria-label="Previous page of completed work items"
               onClick={() => {
-                setPage((current) => Math.max(1, current - 1))
+                void navigate({
+                  to: "/completed",
+                  search: (prev) => ({
+                    ...prev,
+                    page: completedPageSearch(Math.max(1, page - 1)).page,
+                  }),
+                })
               }}
             >
               ← Prev
@@ -223,7 +270,13 @@ function CompletedBoard() {
               aria-busy={completedQuery.isFetching || undefined}
               aria-label="Next page of completed work items"
               onClick={() => {
-                setPage((current) => current + 1)
+                void navigate({
+                  to: "/completed",
+                  search: (prev) => ({
+                    ...prev,
+                    page: completedPageSearch(page + 1).page,
+                  }),
+                })
               }}
             >
               Next →

--- a/apps/harness/src/routes/completed.tsx
+++ b/apps/harness/src/routes/completed.tsx
@@ -1,10 +1,11 @@
 import { useQueries, useQuery, useSuspenseQuery } from "@tanstack/react-query"
 import {
+  Link,
   createFileRoute,
   useNavigate,
   useRouterState,
 } from "@tanstack/react-router"
-import { Suspense, useEffect } from "react"
+import { type ReactNode, Suspense, useEffect } from "react"
 import { Banner, BannerActionButton } from "../banner.js"
 import {
   completedPageSearch,
@@ -46,6 +47,52 @@ function CompletedPage() {
     >
       <CompletedBoard />
     </Suspense>
+  )
+}
+
+function CompletedPageLink({
+  targetPage,
+  disabled,
+  busy,
+  label,
+  children,
+}: {
+  readonly targetPage: number
+  readonly disabled: boolean
+  readonly busy: boolean
+  readonly label: string
+  readonly children: ReactNode
+}) {
+  if (disabled) {
+    return (
+      <button
+        type="button"
+        className={ui.plateMini}
+        disabled
+        aria-busy={busy || undefined}
+        aria-label={label}
+      >
+        {children}
+      </button>
+    )
+  }
+
+  // Keep the pager useful while a streamed Suspense boundary is becoming
+  // interactive: the href is a native fallback until Link attaches its SPA
+  // navigation handler.
+  return (
+    <Link
+      from={Route.fullPath}
+      to="/completed"
+      search={(prev) => ({
+        ...prev,
+        page: completedPageSearch(targetPage).page,
+      })}
+      className={ui.plateMini}
+      aria-label={label}
+    >
+      {children}
+    </Link>
   )
 }
 
@@ -245,42 +292,22 @@ function CompletedBoard() {
               : null}
           </p>
           <div className={ui.pagerBtns}>
-            <button
-              type="button"
-              className={ui.plateMini}
+            <CompletedPageLink
+              targetPage={Math.max(1, page - 1)}
               disabled={!hasPreviousPage || completedQuery.isFetching}
-              aria-busy={completedQuery.isFetching || undefined}
-              aria-label="Previous page of completed work items"
-              onClick={() => {
-                void navigate({
-                  to: "/completed",
-                  search: (prev) => ({
-                    ...prev,
-                    page: completedPageSearch(Math.max(1, page - 1)).page,
-                  }),
-                })
-              }}
+              busy={completedQuery.isFetching}
+              label="Previous page of completed work items"
             >
               ← Prev
-            </button>
-            <button
-              type="button"
-              className={ui.plateMini}
+            </CompletedPageLink>
+            <CompletedPageLink
+              targetPage={page + 1}
               disabled={!hasNextPage || completedQuery.isFetching}
-              aria-busy={completedQuery.isFetching || undefined}
-              aria-label="Next page of completed work items"
-              onClick={() => {
-                void navigate({
-                  to: "/completed",
-                  search: (prev) => ({
-                    ...prev,
-                    page: completedPageSearch(page + 1).page,
-                  }),
-                })
-              }}
+              busy={completedQuery.isFetching}
+              label="Next page of completed work items"
             >
               Next →
-            </button>
+            </CompletedPageLink>
           </div>
         </nav>
       </CompletedSurface>

--- a/apps/harness/src/routes/completed.tsx
+++ b/apps/harness/src/routes/completed.tsx
@@ -1,15 +1,9 @@
 import { useQueries, useQuery, useSuspenseQuery } from "@tanstack/react-query"
-import {
-  Link,
-  createFileRoute,
-  useNavigate,
-  useRouterState,
-} from "@tanstack/react-router"
+import { Link, createFileRoute, useNavigate } from "@tanstack/react-router"
 import { type ReactNode, Suspense, useEffect } from "react"
 import { Banner, BannerActionButton } from "../banner.js"
 import {
   completedPageSearch,
-  isCompletedPageSearchCanonical,
   parseCompletedSearch,
 } from "../completed-search.js"
 import {
@@ -100,13 +94,6 @@ function CompletedBoard() {
   const navigate = useNavigate({ from: Route.fullPath })
   const { page: searchPage } = Route.useSearch()
   const page = searchPage ?? 1
-  const rawPage = useRouterState({
-    select: (state) => state.location.search.page,
-  })
-  const pageSearchIsCanonical = isCompletedPageSearchCanonical({
-    rawPage,
-    page,
-  })
   const { data: repositories } = useSuspenseQuery(repositoriesQuery)
   const repositoryIds = repositories.map(({ id }) => id)
   const completedQuery = useQuery(completedWorkItemsHistoryQuery(page))
@@ -139,21 +126,6 @@ function CompletedBoard() {
       : totalCount === 0
         ? 1
         : Math.max(1, Math.ceil(totalCount / pageSize))
-
-  // Validation makes the query safe immediately; replace malformed aliases
-  // (`?page=1`, fractional, zero, negative, or text) with the canonical URL.
-  useEffect(() => {
-    if (pageSearchIsCanonical) return
-    void navigate({
-      to: "/completed",
-      search: (prev) => ({
-        ...prev,
-        page: completedPageSearch(page).page,
-      }),
-      replace: true,
-      resetScroll: false,
-    })
-  }, [navigate, page, pageSearchIsCanonical])
 
   // When history shrinks under us (SSE refresh), clamp past the last page.
   useEffect(() => {

--- a/apps/harness/src/routes/session.$workItemId.telemetry.tsx
+++ b/apps/harness/src/routes/session.$workItemId.telemetry.tsx
@@ -3,9 +3,8 @@
  * overlay (issues #841 / #843 / ADR 0048).
  *
  * The dialog lives in root chrome; this route supplies the canonical Pipeline
- * background for direct navigation and refresh. Explicit opens from Pipeline,
- * Repos, and Completed also land here so the URL and history entry stay
- * consistent; Close uses history.back when the open was in-app.
+ * background for direct navigation and refresh. In-app opens retain their
+ * runtime route and mask it with this public URL; Close uses history.back.
  */
 import { createFileRoute } from "@tanstack/react-router"
 import { PipelinePage } from "../pipeline-page.js"

--- a/apps/harness/src/session-telemetry-nav.ts
+++ b/apps/harness/src/session-telemetry-nav.ts
@@ -1,6 +1,6 @@
 /**
  * Navigate to the browser-addressable Session Telemetry overlay
- * (issues #841 / #843). Shared by Pipeline, Repos, and Completed.
+ * (issues #841 / #843 / #906). Shared by Pipeline, Repos, and Completed.
  *
  * Route key is the owning Work Item ID (ADR 0048). Optional sessionId is only a
  * history-state display hint until the session query resolves.
@@ -15,7 +15,7 @@ import {
 type TelemetryTo = "/session/$workItemId/telemetry"
 
 type TelemetryNavigate = (
-  options: NavigateOptions<RegisteredRouter, string, TelemetryTo>,
+  options: NavigateOptions<RegisteredRouter, string, ".", string, TelemetryTo>,
 ) => unknown
 
 export const openSessionTelemetry = (input: {
@@ -36,12 +36,22 @@ export const openSessionTelemetry = (input: {
       : { kind: "in-app-origin", sessionId }
 
   return input.navigate({
-    to: "/session/$workItemId/telemetry",
-    params: { workItemId: input.workItemId },
+    // Keep the current surface as the runtime route. Root chrome reads the
+    // public telemetry request from location.maskedLocation.
+    to: ".",
     search: (prev) => prev,
     state: (prev) =>
       Object.assign({}, prev, {
         sessionTelemetry: marker,
       }),
+    mask: {
+      to: "/session/$workItemId/telemetry",
+      params: { workItemId: input.workItemId },
+      // Page belongs to the retained Completed runtime location, not the
+      // public telemetry URL. Only the root theme pin is shareable here.
+      search: (prev) => ({ theme: prev.theme }),
+      unmaskOnReload: true,
+    },
+    resetScroll: false,
   })
 }

--- a/apps/harness/test/completed-route.test.ts
+++ b/apps/harness/test/completed-route.test.ts
@@ -210,16 +210,22 @@ describe("Completed surface routes", () => {
     expect(source).toContain("className={ui.plateMini}")
     expect(source).toContain("className={ui.pager}")
     expect(source).toContain("className={ui.pagerNote}")
-    expect(source).toContain(
-      'aria-label="Previous page of completed work items"',
-    )
-    expect(source).toContain('aria-label="Next page of completed work items"')
+    expect(source).toContain('label="Previous page of completed work items"')
+    expect(source).toContain('label="Next page of completed work items"')
+    expect(source).toContain("aria-label={label}")
     expect(source).toContain("disabled={!hasPreviousPage")
     expect(source).toContain("disabled={!hasNextPage")
     expect(source).toContain("Page {currentPage} of {resolvedTotalPages}")
     expect(source).toContain("rangeStart")
     expect(source).toContain("rangeEnd")
     expect(source).toContain('aria-live="polite"')
+  })
+
+  test("keeps enabled pagination navigable before React attaches handlers", () => {
+    const source = completedSource()
+    expect(source).toContain("function CompletedPageLink(")
+    expect(source).toContain("<Link")
+    expect(source).toContain("page: completedPageSearch(targetPage).page")
   })
 
   test("handles empty, loading, and error states", () => {

--- a/apps/harness/test/completed-route.test.ts
+++ b/apps/harness/test/completed-route.test.ts
@@ -226,6 +226,10 @@ describe("Completed surface routes", () => {
     expect(source).toContain("function CompletedPageLink(")
     expect(source).toContain("<Link")
     expect(source).toContain("page: completedPageSearch(targetPage).page")
+    // Route.useSearch and router location update through different stores.
+    // Comparing them in an effect can race and undo a valid page navigation.
+    expect(source).not.toContain("useRouterState")
+    expect(source).not.toContain("pageSearchIsCanonical")
   })
 
   test("handles empty, loading, and error states", () => {

--- a/apps/harness/test/completed-route.test.ts
+++ b/apps/harness/test/completed-route.test.ts
@@ -201,6 +201,9 @@ describe("Completed surface routes", () => {
 
   test("exposes accessible previous/next pagination", () => {
     const source = completedSource()
+    expect(source).toContain("Route.useSearch()")
+    expect(source).toContain("useNavigate")
+    expect(source).not.toContain("useState(1)")
     expect(source).toContain('aria-label="Completed work items pagination"')
     expect(source).toContain("← Prev")
     expect(source).toContain("Next →")
@@ -223,7 +226,8 @@ describe("Completed surface routes", () => {
     const source = completedSource()
     expect(source).toContain("No completed work items yet")
     expect(source).toContain("No completed work items on this page")
-    expect(source).toContain("setPage(totalPages)")
+    expect(source).toContain("completedPageSearch(totalPages)")
+    expect(source).toContain("replace: true")
     expect(source).toContain("Could not load completed work items")
     expect(source).toContain(
       "completedQuery.isError && completedQuery.data === undefined",

--- a/apps/harness/test/completed-search.test.ts
+++ b/apps/harness/test/completed-search.test.ts
@@ -1,0 +1,51 @@
+import {
+  completedPageSearch,
+  isCompletedPageSearchCanonical,
+  parseCompletedSearch,
+} from "../src/completed-search.js"
+import { describe, expect, test } from "bun:test"
+
+describe("Completed route search", () => {
+  test.each([
+    [{}, { page: undefined }],
+    [{ page: undefined }, { page: undefined }],
+    [{ page: "invalid" }, { page: undefined }],
+    [{ page: 1.5 }, { page: undefined }],
+    [{ page: "1.5" }, { page: undefined }],
+    [{ page: 0 }, { page: undefined }],
+    [{ page: -1 }, { page: undefined }],
+  ] as const)(
+    "defaults invalid or absent page search to page 1",
+    (raw, expected) => {
+      expect(parseCompletedSearch(raw)).toEqual(expected)
+    },
+  )
+
+  test.each([
+    [{ page: 2 }, { page: 2 }],
+    [{ page: "2" }, { page: 2 }],
+  ] as const)("accepts a positive integer page", (raw, expected) => {
+    expect(parseCompletedSearch(raw)).toEqual(expected)
+  })
+
+  test("uses the bare /completed search for page 1", () => {
+    expect(completedPageSearch(1)).toEqual({})
+    expect(completedPageSearch(2)).toEqual({ page: 2 })
+  })
+
+  test.each([
+    [{ rawPage: undefined, page: 1 }, true],
+    [{ rawPage: 1, page: 1 }, false],
+    [{ rawPage: 0, page: 1 }, false],
+    [{ rawPage: -1, page: 1 }, false],
+    [{ rawPage: 1.5, page: 1 }, false],
+    [{ rawPage: "invalid", page: 1 }, false],
+    [{ rawPage: 2, page: 2 }, true],
+    [{ rawPage: "2", page: 2 }, false],
+  ] as const)(
+    "recognizes canonical Completed page search",
+    (input, expected) => {
+      expect(isCompletedPageSearchCanonical(input)).toBe(expected)
+    },
+  )
+})

--- a/apps/harness/test/completed-search.test.ts
+++ b/apps/harness/test/completed-search.test.ts
@@ -1,6 +1,5 @@
 import {
   completedPageSearch,
-  isCompletedPageSearchCanonical,
   parseCompletedSearch,
 } from "../src/completed-search.js"
 import { describe, expect, test } from "bun:test"
@@ -32,20 +31,4 @@ describe("Completed route search", () => {
     expect(completedPageSearch(1)).toEqual({})
     expect(completedPageSearch(2)).toEqual({ page: 2 })
   })
-
-  test.each([
-    [{ rawPage: undefined, page: 1 }, true],
-    [{ rawPage: 1, page: 1 }, false],
-    [{ rawPage: 0, page: 1 }, false],
-    [{ rawPage: -1, page: 1 }, false],
-    [{ rawPage: 1.5, page: 1 }, false],
-    [{ rawPage: "invalid", page: 1 }, false],
-    [{ rawPage: 2, page: 2 }, true],
-    [{ rawPage: "2", page: 2 }, false],
-  ] as const)(
-    "recognizes canonical Completed page search",
-    (input, expected) => {
-      expect(isCompletedPageSearchCanonical(input)).toBe(expected)
-    },
-  )
 })

--- a/apps/harness/test/session-telemetry-route.test.ts
+++ b/apps/harness/test/session-telemetry-route.test.ts
@@ -35,8 +35,8 @@ const jobsSwitcherSource = () =>
 const routedDialogSource = () =>
   readFileSync(join(import.meta.dir, "../src/routed-dialog.ts"), "utf8")
 
-describe("Session Telemetry route (issues #841 / #843)", () => {
-  test("is a dedicated TanStack file route over the Pipeline background", () => {
+describe("Session Telemetry route (issues #841 / #843 / #906)", () => {
+  test("is a dedicated TanStack file route with a canonical Pipeline background", () => {
     const source = telemetryRouteSource()
     expect(source).toContain(
       'createFileRoute("/session/$workItemId/telemetry")',
@@ -75,6 +75,7 @@ describe("Session Telemetry route (issues #841 / #843)", () => {
 
     const nav = navSource()
     expect(nav).toContain('to: "/session/$workItemId/telemetry"')
+    expect(nav).toContain("mask:")
     expect(nav).toContain("markSessionTelemetryOpenedFromInApp")
     expect(nav).toContain("sessionTelemetry")
     expect(nav).toContain('kind: "in-app-origin"')
@@ -84,6 +85,7 @@ describe("Session Telemetry route (issues #841 / #843)", () => {
   test("root owns the route-driven Session Telemetry overlay", () => {
     const source = rootSource()
     expect(source).toContain("SessionTelemetryOverlay")
+    expect(source).toContain("maskedLocation")
     expect(source).toContain("parseSessionTelemetryPath")
     expect(source).toContain("wasSessionTelemetryOpenedFromInApp")
     expect(source).toContain("leaveSessionTelemetryRoute")
@@ -93,9 +95,12 @@ describe("Session Telemetry route (issues #841 / #843)", () => {
     expect(source).toContain("SessionUsageDialog")
   })
 
-  test("Jobs switcher treats Session Telemetry as Pipeline background", () => {
+  test("Jobs switcher derives the active background from the runtime route", () => {
     const switcher = jobsSwitcherSource()
     expect(switcher).toContain("isPipelineBackgroundPath")
+    expect(switcher).not.toContain(
+      "Explicit opens from Repos or Completed share",
+    )
     const helpers = routedDialogSource()
     expect(helpers).toContain("isSessionTelemetryPath")
     expect(helpers).toContain("parseSessionTelemetryPath")


### PR DESCRIPTION
## Why

Opening Session Telemetry from Completed page 2 replaced the originating
surface with Pipeline and returned users to Completed page 1. Completed
pagination was local React state, so it could not survive browser navigation
or be addressed directly.

## What changed

- Use TanStack Router masking for in-app telemetry opens, retaining the Pipeline,
  Repos, or Completed runtime route behind the public telemetry URL.
- Unmask telemetry URLs on reload so direct navigation and refresh still use the
  canonical Pipeline background.
- Preserve the originating Jobs tab, theme search, browser history, and scroll
  position.
- Move Completed pagination into validated route search: `/completed` for page 1
  and `?page=N` for later pages.
- Canonicalize invalid page searches, push explicit pagination changes, and
  replace history when clamping an out-of-range page.
- Extend deterministic Playwright-BDD fixtures and scenarios for page-2
  navigation, retained backgrounds, Close/Escape, Back/Forward, refresh, and
  scroll restoration.

## Verification

- `bunx nx affected -t lint,typecheck,test` — passed, including 558 Harness
  tests.
- BDD generation and Playwright test discovery — passed; 55 scenarios
  discovered, including the new invalid-search regression.
- `git diff --check` — passed.

Full live Playwright execution was unavailable because
`E2E_KEYMAXXER_MASTER_KEY` is not configured in this environment.

Closes #906