### PR TITLE
fix(harness): restore complete issue-row actions

### DIFF
--- a/apps/harness/src/home-page-content.tsx
+++ b/apps/harness/src/home-page-content.tsx
@@ -2871,6 +2871,21 @@ function RepositoryIssueRow({
     },
     onSuccess: onImplementSuccess,
   })
+  const implementLocally = useMutation({
+    mutationFn: async () => {
+      const result = await graphql.mutation({
+        implementLocally: {
+          __args: {
+            repositoryId: issue.repositoryId,
+            issueNumber: issue.issueNumber,
+          },
+          ...workItemFields,
+        },
+      })
+      return result.implementLocally
+    },
+    onSuccess: onImplementSuccess,
+  })
   const queueIssue = useMutation({
     mutationFn: async () => {
       const result = await graphql.mutation({
@@ -2886,7 +2901,27 @@ function RepositoryIssueRow({
     },
     onSuccess: onImplementSuccess,
   })
-  const implementPending = implementNow.isPending || queueIssue.isPending
+  const implementPending =
+    implementNow.isPending || implementLocally.isPending || queueIssue.isPending
+  const startImplementNow = () => {
+    implementLocally.reset()
+    queueIssue.reset()
+    implementNow.mutate()
+  }
+  const startImplementLocally = () => {
+    implementNow.reset()
+    queueIssue.reset()
+    implementLocally.mutate()
+  }
+  const startQueue = () => {
+    implementNow.reset()
+    implementLocally.reset()
+    queueIssue.mutate()
+  }
+  const runMenuAction = ({ action }: { readonly action: () => void }) => {
+    setMenuOpen(false)
+    action()
+  }
 
   useEffect(() => {
     if (!menuOpen) return
@@ -2922,10 +2957,7 @@ function RepositoryIssueRow({
                 className={ui.repoIssueImplementBtn}
                 aria-label={`Implement issue #${issue.issueNumber}`}
                 disabled={implementPending}
-                onClick={() => {
-                  queueIssue.reset()
-                  implementNow.mutate()
-                }}
+                onClick={startImplementNow}
               >
                 <svg
                   aria-hidden="true"
@@ -2950,7 +2982,7 @@ function RepositoryIssueRow({
           {issue.blockedBy.length > 0 && (
             <span className={cx(ui.stamp, ui.stampBlocked)}>Blocked</span>
           )}
-          {canQueue && (
+          {(canImplement || canQueue) && (
             <span className="relative" data-issue-menu={issue.id}>
               <button
                 type="button"
@@ -2968,19 +3000,47 @@ function RepositoryIssueRow({
               </button>
               {menuOpen && (
                 <div role="menu" className={cx(ui.menuPanel, "min-w-44")}>
-                  <button
-                    type="button"
-                    role="menuitem"
-                    className={ui.menuItem}
-                    disabled={implementPending}
-                    onClick={() => {
-                      setMenuOpen(false)
-                      implementNow.reset()
-                      queueIssue.mutate()
-                    }}
-                  >
-                    {queueIssue.isPending ? "Queueing..." : "Queue"}
-                  </button>
+                  {canImplement && (
+                    <>
+                      <button
+                        type="button"
+                        role="menuitem"
+                        className={ui.menuItem}
+                        disabled={implementPending}
+                        onClick={() =>
+                          runMenuAction({ action: startImplementNow })
+                        }
+                      >
+                        {implementNow.isPending
+                          ? "Starting..."
+                          : "Implement now"}
+                      </button>
+                      <button
+                        type="button"
+                        role="menuitem"
+                        className={ui.menuItem}
+                        disabled={implementPending}
+                        onClick={() =>
+                          runMenuAction({ action: startImplementLocally })
+                        }
+                      >
+                        {implementLocally.isPending
+                          ? "Starting..."
+                          : "Implement locally"}
+                      </button>
+                    </>
+                  )}
+                  {canQueue && (
+                    <button
+                      type="button"
+                      role="menuitem"
+                      className={ui.menuItem}
+                      disabled={implementPending}
+                      onClick={() => runMenuAction({ action: startQueue })}
+                    >
+                      {queueIssue.isPending ? "Queueing..." : "Queue"}
+                    </button>
+                  )}
                 </div>
               )}
             </span>
@@ -3011,7 +3071,9 @@ function RepositoryIssueRow({
           onOpenSession={onOpenSession}
         />
       )}
-      {(implementNow.isError || queueIssue.isError) && (
+      {(implementNow.isError ||
+        implementLocally.isError ||
+        queueIssue.isError) && (
         <Banner
           className={cx(ui.bannerCompact, ui.repoIssueError)}
           tone="alarm"

--- a/apps/harness/test/repos-interchange.test.ts
+++ b/apps/harness/test/repos-interchange.test.ts
@@ -125,13 +125,46 @@ describe("Interchange phase 4: repos page + blank slate", () => {
     const implementAction = sliceBetweenMarkers(
       issues,
       "{canImplement && (",
-      "{canQueue && (",
+      "{(canImplement || canQueue) && (",
     )
-    expect(implementAction).toContain("queueIssue.reset()")
-    expect(implementAction).toContain("implementNow.mutate()")
+    expect(implementAction).toContain("onClick={startImplementNow}")
     expect(implementAction).not.toContain('aria-haspopup="menu"')
     expect(implementAction).not.toContain('role="menu"')
     expect(implementAction).not.toContain("Implement locally")
+    const actionHandlers = sliceBetweenMarkers(
+      issues,
+      "const startImplementNow = () => {",
+      "useEffect(() => {",
+    )
+    expect(actionHandlers).toContain("implementLocally.reset()")
+    expect(actionHandlers).toContain("queueIssue.reset()")
+    expect(actionHandlers).toContain("implementNow.mutate()")
+    expect(actionHandlers).toContain("implementLocally.mutate()")
+    expect(actionHandlers).toContain("queueIssue.mutate()")
+    expect(actionHandlers).toContain("const runMenuAction =")
+    const completeMenuStart = issues.indexOf("{(canImplement || canQueue) && (")
+    expect(completeMenuStart).toBeGreaterThan(-1)
+    const completeMenu = issues.slice(completeMenuStart)
+    expect(completeMenu).toContain("{canImplement && (")
+    expect(completeMenu).toContain("Implement now")
+    expect(completeMenu).toContain("Implement locally")
+    expect(completeMenu).toContain(
+      "runMenuAction({ action: startImplementNow })",
+    )
+    expect(completeMenu).toContain(
+      "runMenuAction({ action: startImplementLocally })",
+    )
+    expect(completeMenu).toContain("{canQueue && (")
+    expect(completeMenu).toContain("runMenuAction({ action: startQueue })")
+    expect(completeMenu).toContain(
+      'queueIssue.isPending ? "Queueing..." : "Queue"',
+    )
+    expect(issues.indexOf("ui.repoIssueImplementBtn")).toBeLessThan(
+      issues.indexOf("ui.repoIssueActions"),
+    )
+    expect(issues.indexOf("ui.repoIssueActions")).toBeLessThan(
+      issues.indexOf("{(canImplement || canQueue) && ("),
+    )
     expect(issues).toContain("ui.repoIssueAuthor")
     expect(issues).toContain("ui.stamp")
     expect(issues).toContain("ui.stampClosed")

--- a/apps/harness/test/waiting-for-blockers-working-row.test.ts
+++ b/apps/harness/test/waiting-for-blockers-working-row.test.ts
@@ -77,12 +77,12 @@ describe("Waiting for blockers Working-row polish", () => {
     expect(lifecycle).toContain("onReset={() => reset.mutate()}")
   })
 
-  test("Issue row starts Implement now directly; Queue stays kebab-only", () => {
+  test("Issue row keeps direct Implement and restores the complete kebab", () => {
     const source = homeSource()
     expect(source).toContain("issueActionEligibility({")
     expect(source).toContain('queueIssue.isPending ? "Queueing..." : "Queue"')
     expect(source).toContain("{canImplement && (")
-    expect(source).toContain("{canQueue && (")
+    expect(source).toContain("{(canImplement || canQueue) && (")
     // Primary blue cue after the title for implementable issues only.
     expect(source).toContain("ui.repoIssueImplementBtn")
     expect(source).toContain("ui.repoIssueImplementIcon")
@@ -91,7 +91,16 @@ describe("Waiting for blockers Working-row polish", () => {
     expect(source).toContain("Implement issue #")
     expect(source).toContain("queueIssue.reset()")
     expect(source).toContain("implementNow.mutate()")
-    expect(source).not.toContain("Implement locally")
+    expect(source).toContain("onClick={startImplementNow}")
+    // The rightmost kebab retains both implementation paths.
+    expect(source).toContain("Implement now")
+    expect(source).toContain("Implement locally")
+    expect(source).toContain("implementLocally.mutate()")
+    expect(source).toContain("runMenuAction({ action: startImplementLocally })")
+    expect(source).toMatch(
+      /implementNow\.isPending \|\|\s*implementLocally\.isPending \|\| queueIssue\.isPending/,
+    )
+    expect(source).toContain("implementLocally.isError")
     // Pending disables the primary cue (styles + behavior stay aligned).
     expect(source).toContain("disabled={implementPending}")
     expect(source).toContain('implementPending ? "Starting..." : "Implement"')

--- a/docs/harness-design-system.md
+++ b/docs/harness-design-system.md
@@ -675,11 +675,13 @@ A permanent fixture at the **foot of the Queue platform**, always rendered
   with `ready-for-agent`. When they show up in your repos, click
   **Implement**." Prefer neutral "issues" over a forge brand name. Link
   "your repos" to the Repos view.
-- **Illustration**: compact static mock of the repos-row **Implement** control
+- **Dual-entry Implement**: the compact static mock shows the repos-row control
   (Build-lane blue plate, play-triangle start icon, mono "Implement" label)
   so operators recognize the primary action on Repos. Clicking the control
-  starts implementation immediately; it does not open a choice menu.
-  Queue for blocked issues stays kebab-only and is not illustrated here.
+  starts **Implement now** immediately; it does not open a choice menu. The
+  same implementable row also keeps a rightmost kebab with the complete
+  **Implement now** and **Implement locally** actions. Queue for blocked issues
+  stays kebab-only and is not illustrated here.
 - No primary "Manage repos" CTA — keep the hint focused on label → Implement.
 - No transit glyphs (no ⇄), no "Transfer" wording anywhere.
 


### PR DESCRIPTION
## Why

Implementable rows retained the blue **Implement** shortcut but lost the rightmost
actions menu, removing access to **Implement locally**. Users need both the direct
primary action and the complete menu, while blocked rows should remain Queue-only.

## What changed

- Restored the kebab menu when an issue can be implemented or queued.
- Added **Implement now** and **Implement locally** to implementable-row menus while
  keeping the blue button as a direct **Implement now** action.
- Preserved Queue as the only action for blocked rows.
- Shared pending and error handling across all issue-start mutations.
- Centralized action handlers so the primary button and menu cannot drift in their
  reset/mutation behavior.
- Updated structural tests and the Harness design-system guidance for the dual-entry
  interaction.

## Verification

- `bunx nx run harness:lint`
- `bunx nx run harness:typecheck`
- `bunx nx run harness:test` — 545 Bun tests and 123 Vitest tests passed
- `git diff --check`

Closes #919