### PR TITLE
docs: restructure README for new-user onboarding, add LICENSE

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,8 +10,8 @@ covers monorepo development of Ready for Agent.
 1. [Bun](https://bun.sh/) (workspace package manager and runtime)
 2. Host tools from the product README: `git`, the selected Agent Backend on
    PATH (`opencode` by default), plus `gh` for GitHub Repositories and `curl`
-   for GitLab Repositories. Authenticate Grok with `grok login` or
-   `XAI_API_KEY` when developing against Grok Build.
+   for GitLab Repositories. Authenticate the Agent Backend per its own
+   documentation.
 3. Optional: `keymaxxer` on PATH, or `KEYMAXXER_ENTRYPOINT` pointing at an
   existing entrypoint (no hardcoded machine path). Not used by Grok Build
   Agent Turns.
@@ -61,9 +61,26 @@ the file with external write tooling (single-process WAL).
 
 # Architecture
 
-This repo is an [Nx monorepo](https://nx.dev/). Your agent will now
+This repo is an [Nx monorepo](https://nx.dev/). Your agent will know
 how to deal with this.
 
 Architecture notes are in
 [ARCHITECTURE.md](ARCHITECTURE.md) and domain language in
 [CONTEXT.md](CONTEXT.md).
+
+## Repo map
+
+- `apps/harness` — the product: web UI plus backend server
+  (`bunx nx run harness:dev` boots this)
+- `apps/ready-for-agent` — the published npm CLI wrapping the harness
+- `apps/keymaxxer-sidecar` — optional secrets sidecar
+- `packages/` — the libraries; start with:
+  - `work-item-lifecycle` — the lifecycle engine driving Work Items
+  - `lifecycle-model` — states and transitions generated from `ontology/`
+  - `agent-backend` plus `opencode`, `codex`, `grok`, `claude` — Agent
+    Backend adapters
+  - `github-service`, `gitlab-service` — Forge integrations
+  - `graphql-schema`, `graphql-api`, `graphql-client` — the GraphQL
+    contract, server, and generated client
+- `ontology/` — the machine-readable domain model, source of truth for
+  the Work Item lifecycle

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Berend de Boer
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,77 +1,166 @@
 # Ready for Agent: Clanker Harness for 150+ PRs a week
 
-Create issues in GitHub and use this harness to implement them, review
-the code, create a PR, and merge the PR. It supports a different way
-of working: you talk to your agent to create GitHub issues, and this
-harness works on them.
-
-It's a loop based around issues labelled with `ready-for-agent`. The
-harness will only show these, you select the ones you want to work on,
-and it autonomously completes the task using your preferred coding
-agent. You can even select a parent issue, and ready-for-agent will
-implement all child issues.
+Ready for Agent turns GitHub (or GitLab) issues into merged pull
+requests. You create issues and label them `ready-for-agent`; the
+harness hands each one to your preferred coding agent, which
+implements it, reviews the code, opens a PR, and merges when
+allowed. You design, you architect, you verify where needed — the
+harness removes the babysitting between issue and merged PR.
 
 <img src="ready-for-agent.png" alt="Ready for Agent" width="90%" />
 
-It very much supports a HITL workflow (Human in the Loop): you design,
-you architect, you verify where needed.
+Watch [the introduction
+video](https://www.youtube.com/watch?v=TK1OeQZswiQ) to see the tool in
+action.
 
-It works very well if you follow [the Matt Pocock
-workflow](https://www.youtube.com/watch?v=M6mYodf0dJM): start a
-grilling session, create a specification (`/to-spec`), then create
-tickets (`/to-tickets`). These tickets will be labeled with
-ready-for-agent, and show up immediately in the harness. Install his
-[Skills for Real Engineers](https://github.com/mattpocock/skills) to
-get started with this kind of workflow.
+## Quick start
+
+1. Install the prerequisites and have them on your PATH:
+   [git](https://git-scm.com/), the [GitHub CLI
+   (`gh`)](https://cli.github.com/), and at least one coding agent —
+   [OpenCode](https://opencode.ai/),
+   [Codex](https://github.com/openai/codex), [Grok
+   Build](https://docs.x.ai/), or [Claude
+   Code](https://docs.anthropic.com/en/docs/claude-code) —
+   authenticated per its own documentation.
+2. Start the harness:
+
+   ```bash
+   npx ready-for-agent@latest
+   ```
+
+   Or install it once with `npm install -g ready-for-agent` and run
+   `ready-for-agent`. The UI opens at
+   [http://127.0.0.1:6056/](http://127.0.0.1:6056/). On first run it
+   takes you to Settings to pick your coding agent and a default build
+   model and effort (thinking).
+
+3. Add a repo you have cloned locally (the UI prompts for this too):
+
+   ```bash
+   ready-for-agent add /path/to/local/repo
+   ```
+
+4. Label a GitHub issue `ready-for-agent`. It shows up in the UI
+   shortly. By default only issues you authored are listed — see
+   [Troubleshooting](#troubleshooting).
+5. Open the issue's kebab menu and pick **Implement now** to run it
+   end to end — implement, review, PR — or **Implement locally** to
+   stop before the PR and inspect the work yourself.
+
+## Requirements
+
+A supported platform: Linux, macOS, or Windows (x64 or arm64).
+
+**Always required on PATH** (start fails fast if missing):
+
+- [git](https://git-scm.com/)
+
+**Forge-specific tools** (required only when at least one repository
+uses that Forge):
+
+- [GitHub CLI (`gh`)](https://cli.github.com/) for GitHub repositories
+- [curl](https://curl.se/) for GitLab repositories. `glab` is an
+  optional ambient credential source, not a required host tool.
+
+**Coding agents** are soft prerequisites: they are inspected after
+the harness starts and never block the process or UI from starting. A
+missing or broken selected backend (default is OpenCode) is shown as
+**Agent Backend Unavailable**; open Settings to choose another
+backend, reinstall the CLI, or use Recheck after fixing it:
+
+- [OpenCode](https://opencode.ai/) (`opencode` on PATH)
+- [Codex](https://github.com/openai/codex) (`codex` on PATH)
+- [Grok Build](https://docs.x.ai/) (`grok` on PATH)
+- [Claude Code](https://docs.anthropic.com/en/docs/claude-code)
+  (`claude` on PATH)
+
+We assume your coding agent is installed and authenticated — see its
+own documentation. To run Claude Code through Amazon Bedrock instead
+of a first-party login, see
+[docs/claude-code-amazon-bedrock.md](docs/claude-code-amazon-bedrock.md).
+
+You also need:
+
+- A repo cloned locally, either "normally" or as a bare clone
+  (recommended). Install the [git-bare-worktree
+  skill](https://github.com/berenddeboer/git-bare-worktree) and let
+  your agent create this setup for you: `npx skills@latest add
+  berenddeboer/git-bare-worktree --global`
+- Ideally, a CI pipeline with automated build/test and an AI code
+  review.
+
+The harness is designed to run on your local laptop. This avoids
+cloud costs — you already paid for an extensive machine — and your
+machine is already set up for your repo, so you avoid the setup
+issues that come with running compute in the cloud.
+
+## Features
+
+- Four interchangeable coding agents — OpenCode, Codex, Grok Build,
+  and Claude Code — switchable instance-wide.
+- Per-repo agent and model overrides: expensive models for hard
+  repos, cheaper ones for the rest.
+- Auto-merge gated by an AI risk assessment: only low-risk PRs merge
+  unattended, higher risk still requires human review.
+- "Implement locally" to inspect the work before any commit or PR
+  exists.
+- Select a parent issue and it implements all child issues.
+- Runs on your laptop against your existing local clone — no cloud
+  spend, no environment drift.
+- Works with your existing Claude (or other) subscription rather than
+  metered API billing.
+- GitHub and GitLab support.
+- Human in the loop where you want it: you design, you architect, you
+  verify.
+
+## How it works
+
+The harness is a loop around issues labelled `ready-for-agent`: it
+only shows those, you pick the ones to work on, and it autonomously
+completes them using your selected coding agent. For each issue it
+creates a fresh worktree, installs packages, and asks the headless
+agent to implement the issue, review the code, create a PR, and merge
+if allowed.
 
 Steps 1 to 3 are you. Steps 4 and 5 are the harness.
 
 <img src="docs/way-of-working.png" alt="Way of Working" width="40%" />
 
-But as long as an issue has the `ready-for-agent` label, this tool can
-work on it.
+The goal of this clanker harness is to get you to that 150+ PRs a
+week nirvana. It does that by removing the time spent babysitting an
+agent and guiding it through the implementation, review, commit, and
+PR status-check stages.
 
-## How it works
+It works very well if you follow [the Matt Pocock
+workflow](https://www.youtube.com/watch?v=M6mYodf0dJM): start a
+grilling session, create a specification (`/to-spec`), then create
+tickets (`/to-tickets`). These tickets will be labeled with
+`ready-for-agent`, and show up immediately in the harness. Install his
+[Skills for Real Engineers](https://github.com/mattpocock/skills) to
+get started with this kind of workflow.
 
-The harness creates a new worktree, installs packages, and asks a
-selectable headless Agent Backend ([OpenCode](https://opencode.ai/),
-[Codex](https://github.com/openai/codex), [Grok
-Build](https://docs.x.ai/), or [Claude
-Code](https://docs.anthropic.com/en/docs/claude-code)) to implement the
-issue, review the issue, create a PR, and merge if allowed.
+But as long as an issue has the `ready-for-agent` label, this tool
+can work on it.
 
-The goal of this clanker harness is to get you to that 25+ PRs merged
-a day nirvana. It does that by removing the time spent babysitting an
-agent and guiding it through the implementation, review, commit, and PR
-status-check stages.
+### Working on issues
 
-See [the introduction
-video](https://www.youtube.com/watch?v=TK1OeQZswiQ) to see the tool in
-action.
+Currently the harness does not automatically pick issues to work
+on. Click on the kebab menu and implement an issue end to end via
+"Implement now".
 
-# Usage
+You can configure your repo to automatically merge the PR. Default is
+for human review to take place. If auto-merge is enabled, the harness
+will ask the AI about the risk of auto-merge. Only low risk PRs are
+auto-merged, higher risk still require human review.
 
-Requires a supported platform: Linux, macOS, or Windows (x64 or arm64).
+Pick the "Implement locally" option to implement the issue in the new
+worktree, but without creating a PR yet. This allows you to test and
+verify before a commit or PR exists.
 
-Run:
+## Configuration
 
-```bash
-npx ready-for-agent@latest
-```
-
-Or install the package and use the `ready-for-agent` command:
-
-```bash
-npm install -g ready-for-agent
-ready-for-agent
-```
-
-This opens the UI in the browser
-([http://127.0.0.1:6056/](http://127.0.0.1:6056/)). This shows the
-configured state. If you open this for the first time, you will be
-prompted to set a default build model and effort (thinking), and configure repos.
-
-## Stop opening a browser window
+### Stop opening a browser window
 
 Disable opening a browser window with:
 
@@ -81,7 +170,7 @@ ready-for-agent --no-open
 NO_BROWSER=1 ready-for-agent
 ```
 
-## Use a different port
+### Use a different port
 
 Use a different port than 6056:
 
@@ -89,123 +178,86 @@ Use a different port than 6056:
 PORT=7000 ready-for-agent
 ```
 
-## Configuring a repo
-
-If you open ready-for-agent without any repo configured, it will prompt. Add with:
-
-```bash
-ready-for-agent add /path/to/local/repo
-```
-
-If you use a non-default port:
+When adding a repo against a non-default port:
 
 ```bash
 READY_FOR_AGENT_GRAPHQL_URL=http://127.0.0.1:7000/graphql \
   ready-for-agent add /path/to/local/repo
 ```
 
-## Working on issues
+### Per-repo settings
 
-Currently the harness does not automatically pick issues to work
-on. Click on the kebab menu and implement this end to end via
-"Implement now".
+Each repo can override the harness-wide coding agent and build/review
+models, and enable auto-merge. This allows you to configure more
+expensive models for more complex code, and cheaper models for
+others.
 
-You can configure your repo to automatically merge the PR. Default is
-for human review to take place. If auto-merge is enabled, the harness
-will ask the AI about the risk of auto-merge. Only low risk PRs are
-auto-merged, higher risk still require human review.
-
-Pick the "Implement locally" option to implement the issue in the new
-worktree, but without creating a PR yet. This allows you to test and verify.
-
-## Assumptions
-
-- You use GitHub or GitLab.
-- You have a repo cloned locally, either "normally" or as a bare clone
-  (recommended). Install the [git-bare-worktree
-  skill](https://github.com/berenddeboer/git-bare-worktree) and let
-  your agent create this setup for you: `npx skills@latest add
-  berenddeboer/git-bare-worktree --global`
-- The harness is designed to run on your local laptop. This avoids
-  cloud costs, and you already paid for an extensive
-  machine. Secondly, your machine will be set up for your repo, so we
-  avoid the setup issues you get with running compute in the cloud.
-- Ideally, you have set up a CI pipeline with automated build/test and an AI code review.
-
-# Requirements
-
-**Always required on PATH** (start fails fast if missing):
-
-1. [git](https://git-scm.com/)
-
-**Forge-specific tools** (required only when at least one Repository uses that
-Forge):
-
-2. [GitHub CLI (`gh`)](https://cli.github.com/) for GitHub Repositories
-3. [curl](https://curl.se/) for GitLab Repositories. `glab` is an optional
-   ambient credential source, not a required host tool.
-
-**Agent Backend executables** are soft prerequisites. They are inspected after
-the Harness starts and never block the process or UI from starting. A missing or
-broken selected backend is shown as **Agent Backend Unavailable**; open Settings
-to choose another backend, reinstall the CLI, or use Recheck after fixing it:
-
-4. [OpenCode](https://opencode.ai/) (`opencode` on PATH)
-5. [Codex](https://github.com/openai/codex) (`codex` on PATH)
-6. [Grok Build](https://docs.x.ai/) (`grok` on PATH)
-7. [Claude Code](https://docs.anthropic.com/en/docs/claude-code) (`claude` on
-   PATH)
-
-Authenticate Grok Build with `grok login` or `XAI_API_KEY` before Recheck /
-Agent Turns. Harness-launched Grok processes disable auto-update for that
-session (`--no-auto-update` / `GROK_DISABLE_AUTOUPDATER`). Grok Build Agent
-Turns do not integrate Keymaxxer; Session Telemetry is live-read from on-disk
-Grok session files under `$GROK_HOME/sessions` (default `~/.grok`). Authenticate
-Claude Code with `claude auth login` or `ANTHROPIC_API_KEY` before Recheck /
-Agent Turns. For **Amazon Bedrock**, set `CLAUDE_CODE_USE_BEDROCK=1` plus AWS
-credentials/region on the harness process instead of first-party login; see
-[Claude Code on Amazon Bedrock](docs/claude-code-amazon-bedrock.md) (Ready vs
-Unavailable, **Claude Code Bedrock** Settings label, **Amazon Bedrock** provider
-status, strict profile select from the bundled AWS SDK—not the AWS CLI—and
-optional env pins for first-party aliases). Harness-launched Claude processes
-disable auto-update for that session (`DISABLE_AUTOUPDATER`). Claude Code Agent
-Turns do not integrate Keymaxxer; Session Telemetry is unsupported in v1.
-Opt-in live adapter tests use `GROK_INTEGRATION=1` / `OPENCODE_INTEGRATION=1` /
-`CODEX_INTEGRATION=1` / `CLAUDE_INTEGRATION=1` / `BEDROCK_INTEGRATION=1`
-(list-only; never invokes a model); normal CI does not need paid model
-credentials.
-
-# KeyMaxxer
+### KeyMaxxer
 
 Ready for Agent supports
 [keymaxxer](https://github.com/glommer/keymaxxer), but does not
 require it. With KeyMaxxer secrets stay encrypted, and are only
 granted to agents when they need them.
 
-Keymaxxer is automatically enabled if keymaxxer is in your path. Disable with:
+Keymaxxer is automatically enabled if keymaxxer is in your path.
+Disable with:
 
-```
+```bash
 KEYMAXXER_ENABLED=false npx ready-for-agent@latest
 ```
 
-# Frequently Asked Questions
+### Application data
 
-1. What coding cli agents are supported?
+Product state defaults to the platform data directory:
 
-Yes. Settings can select [OpenCode](https://opencode.ai/),
-[Codex](https://github.com/openai/codex), [Grok Build](https://docs.x.ai/), or
-[Claude Code](https://docs.anthropic.com/en/docs/claude-code) as the
-instance-wide Agent Backend. The change hot-activates on Save when no Work
-Items are unfinished (including Needs Human). Model catalogs and effort
-(thinking) options are backend-local, and build/review prefs are remembered per
-backend. Model selection is catalog-only for every backend: build and review
-models are picked from the Agent Backend's current catalog, never typed in.
+- Linux: `$XDG_DATA_HOME/ready-for-agent/` or `~/.local/share/ready-for-agent/`
+- macOS: `~/Library/Application Support/ready-for-agent/`
+
+The SQLite database is `ready-for-agent.db` in that directory. Set
+`SQLITE_DATABASE_PATH` to use another file. Stop the harness
+completely before opening the database with external write tooling
+(single-writer SQLite).
+
+## Troubleshooting
+
+### Startup fails with "Required host tools are missing from PATH"
+
+Install the listed tools. Only `git` and the Forge tool for your
+repositories (`gh` for GitHub, `curl` for GitLab) block startup. A
+missing coding agent never does — it shows as Unavailable instead
+(see below).
+
+### A labelled issue does not show up
+
+- The issue must carry the `ready-for-agent` label — the harness only
+  shows those.
+- By default only issues **you** authored are listed. Enable "Include
+  all Issue Authors" in the repo settings to include everyone's.
+
+### The coding agent shows as Unavailable
+
+Its executable is missing from PATH, or it is not authenticated. Fix
+that and use Recheck in Settings, or pick another backend there.
+
+## Frequently Asked Questions
+
+1. What coding CLI agents are supported?
+
+[OpenCode](https://opencode.ai/),
+[Codex](https://github.com/openai/codex), [Grok
+Build](https://docs.x.ai/), and [Claude
+Code](https://docs.anthropic.com/en/docs/claude-code). Settings
+selects the instance-wide Agent Backend; the change hot-activates on
+Save when no Work Items are unfinished. Model catalogs and effort
+(thinking) options are backend-local, and build/review preferences
+are remembered per backend. Models are always picked from the
+backend's current catalog, never typed in.
 
 2. Does the harness support a Forge other than GitHub?
 
-Yes. GitLab Repository identity, Issue reconciliation, and local Agent Turns
-through Review are supported. GitLab Pull Request lifecycle operations are
-being delivered in later phases.
+Yes. GitLab repository identity, issue reconciliation, and local
+agent work through review are supported. GitLab pull request
+lifecycle operations are being delivered in later phases.
 
 3. Can I use my Claude subscription?
 
@@ -214,70 +266,65 @@ permissible usage.
 
 4. Can I run Claude Code through Amazon Bedrock?
 
-Yes. Export `CLAUDE_CODE_USE_BEDROCK=1` and your AWS credentials/region on the
-harness process, select **Claude Code Bedrock**, then Recheck. Status shows
-**Claude Code · Amazon Bedrock**. In Bedrock mode Settings offer active
-Anthropic system-defined and application inference profiles discovered from AWS
-via the bundled SDK (no AWS CLI host tool; friendly names in Settings; ID/ARN
-stored and passed to Claude Code). First-party Claude Code offers the static
-alias catalog (`haiku`, `sonnet`, `opus`, `fable`) and never calls AWS. A model
-stored under the other provider mode is kept and shown as unavailable until you
-pick a current one — it is never rewritten or translated.
-Discovery failures leave Claude Ready with a warning but block Save until a
-discovered profile is available after Recheck; listing does not prove
-InvokeModel access. Details:
+Yes. See
 [docs/claude-code-amazon-bedrock.md](docs/claude-code-amazon-bedrock.md).
 
 5. Can I implement something locally, and then check myself?
 
-Yes, pick "Implement locally" from the kebab menu. Everything stays
-local, and no commit is made.
+Yes — pick "Implement locally" from the kebab menu; see [Working on
+issues](#working-on-issues).
 
-6. Can I specify a different model or coding agent per repo?
+6. Can I use a different model or coding agent per repo?
 
-Yes, check the repo settings. This allows you to configure more
-expensive models for more complex code, and cheaper models for others.
+Yes — see [Per-repo settings](#per-repo-settings).
 
-# Architecture
+## Glossary
 
-## The Forge is source of truth
+- **Clanker** — affectionate slang for a robot; here, the coding
+  agent doing the work.
+- **Harness** — this tool: the deterministic loop that steers
+  clankers from issue to merged PR.
+- **Forge** — the code-hosting platform for a repository: GitHub or
+  GitLab.
+- **Agent Backend** — the coding-agent CLI the harness drives:
+  OpenCode, Codex, Grok Build, or Claude Code.
+- **Work Item** — one attempt to complete an issue through the work
+  lifecycle, from implementation to merged PR.
+- **Agent Turn** — one unattended invocation of the coding agent
+  within a Work Item.
+- **Needs Human** — a Work Item state where the harness cannot
+  continue autonomously and hands back to you, recording why.
+- **Recheck** — a Settings action that revalidates a coding agent and
+  refreshes its model catalog.
+- **Metaharness** — a harness that steers agent harnesses; see
+  [metaharness.tools](https://metaharness.tools/).
 
-Issues on the configured Repository Forge (GitHub/GitLab) remain the
-source of truth; the local database is book-keeping. Style and
-guidelines come from the target repository—this harness steers an
-agent swarm on `ready-for-agent` labeled work.
+The full domain language lives in [CONTEXT.md](CONTEXT.md), derived
+from a versioned ontology under [`ontology/`](ontology/README.md).
 
-## GraphQL API
+## Architecture
 
-The backend serves a GraphQL API at `http://127.0.0.1:6056/graphql`.
-
-## Ontology-based domain model
-
-The Work Item lifecycle is driven by a machine-readable ontology under
-`ontology/` (Turtle + SHACL), not by ad-hoc enums scattered through the
-code. States, legal transitions, guards, and glossary terms are declared
-there; TypeScript types, GraphQL enums, database columns, and the runtime
-transition check are generated from or validated against it. Agents propose
-work; the ontology defines what a state means and which moves are legal.
-See [ontology/README.md](ontology/README.md) and
+Issues on the Forge remain the source of truth; the local SQLite
+database is book-keeping. The backend serves a GraphQL API at
+`http://127.0.0.1:6056/graphql`, and the Work Item lifecycle is
+driven by a machine-readable ontology rather than ad-hoc enums.
+Details in [ARCHITECTURE.md](ARCHITECTURE.md),
+[CONTEXT.md](CONTEXT.md), [ontology/README.md](ontology/README.md),
+and
 [docs/why-agentic-systems-need-ontologies.md](docs/why-agentic-systems-need-ontologies.md).
 
-## Application data
-
-Product state defaults to the platform data directory:
-
-- Linux: `$XDG_DATA_HOME/ready-for-agent/` or `~/.local/share/ready-for-agent/`
-- macOS: `~/Library/Application Support/ready-for-agent/`
-
-The SQLite database is `ready-for-agent.db` in that directory. Set
-`SQLITE_DATABASE_PATH` to use another file. Stop the harness completely before
-opening the database with external write tooling (single-writer SQLite).
-
-# Contributing
+## Contributing
 
 Contributions welcome, see [CONTRIBUTING.md](CONTRIBUTING.md).
 
-# Related work
+## License
 
-- Inspired by [this blog post](https://lovable.dev/blog/85000-in-tokens-later-scaling-agentic-coding-at-lovable) from Alexander at Lovable
-- ready-for-agent is an example of a [metaharness](https://metaharness.tools/).
+[MIT](LICENSE).
+
+## Related work
+
+- Inspired by [this blog
+  post](https://lovable.dev/blog/85000-in-tokens-later-scaling-agentic-coding-at-lovable)
+  from Alexander at Lovable
+- ready-for-agent is an example of a
+  [metaharness](https://metaharness.tools/).

--- a/docs/claude-code-amazon-bedrock.md
+++ b/docs/claude-code-amazon-bedrock.md
@@ -1,268 +1,54 @@
-# Claude Code on Amazon Bedrock with the Harness
+# Claude Code on Amazon Bedrock
 
-Operator note for running the **Claude Code** Agent Backend through
-[Amazon Bedrock](https://code.claude.com/docs/en/amazon-bedrock) under Ready for
-Agent. Covers readiness, process environment, provider visibility (**Amazon
-Bedrock** vs first-party), profile discovery, and **catalog-only** model
-selection in Settings (discovered profiles only when
-`CLAUDE_CODE_USE_BEDROCK=1` — see [Model selection](#model-selection)).
+The harness follows Claude Code's own convention: when the harness
+process has `CLAUDE_CODE_USE_BEDROCK=1`, Claude Code runs against
+Amazon Bedrock. That's all there is to it. For everything AWS-side —
+model access, IAM, credentials, region, model pins — follow
+[Anthropic's Bedrock
+documentation](https://code.claude.com/docs/en/amazon-bedrock).
 
-Upstream Claude Code setup (IAM, wizard, inference profiles, troubleshooting)
-lives in Anthropic’s docs:
+## Setup
 
-- [Claude Code on Amazon Bedrock](https://code.claude.com/docs/en/amazon-bedrock)
-- [Pin models for third-party deployments](https://code.claude.com/docs/en/model-config#pin-models-for-third-party-deployments)
-- [Environment variables](https://code.claude.com/docs/en/env-vars)
-
-## What the harness expects
-
-When Settings selects Claude Code (`claude` on `PATH`), the harness:
-
-1. Spawns `claude` for **Recheck / inspect** (`claude auth status`) and for
-   Agent Turns.
-2. **Inherits the harness process environment** for those spawns (Forge tokens,
-   Anthropic vars, AWS credential-chain vars, Bedrock enablement flags, and
-   model pin vars). The Claude adapter does not strip AWS or Bedrock-related
-   variables.
-3. Forces `DISABLE_AUTOUPDATER=1` on every Claude spawn so Harness operation
-   cannot replace the CLI mid-work.
-4. Does **not** integrate Keymaxxer for Anthropic or AWS secrets in this path.
-   Supply credentials the same way you would for a hand-run `claude`.
-5. Does **not** require the **AWS CLI** (`aws`) on `PATH`. Bedrock inference
-   profile discovery uses the **AWS SDK** bundled in the packaged harness
-   binary on every supported build target.
-
-Supported harness path: export Bedrock/AWS (and optional pins) **on the shell
-that starts** `ready-for-agent` / the harness process. Claude may also load
-`CLAUDE_CODE_USE_BEDROCK` and related values from its own
-`~/.claude/settings.json` `env` block when spawned. That Claude-only settings
-path can make Agent Turns work while **profile discovery stays unavailable**
-to the harness process: discovery and region/credential resolution use the
-harness process environment (and the ambient AWS default provider chain), not
-a full reimplementation of Claude’s settings layers. If inspect only sees
-Bedrock when the harness process itself exports the flag, treat process env as
-the supported harness configuration.
-
-## Enable Bedrock
-
-Minimum enablement for Amazon Bedrock:
+Export the flag and your AWS credentials/region on the shell that
+starts the harness:
 
 ```bash
 export CLAUDE_CODE_USE_BEDROCK=1
-export AWS_REGION=us-east-1   # or rely on profile / AWS_DEFAULT_REGION
-```
-
-Then start the harness from that environment:
-
-```bash
+export AWS_REGION=us-east-1
 npx ready-for-agent@latest
-# or: ready-for-agent / bun run ready-for-agent start
 ```
 
-In Settings, select **Claude Code Bedrock** (shown when the harness process has
-`CLAUDE_CODE_USE_BEDROCK=1`) as the default or per-Repository Agent Backend,
-then **Recheck Agent Backend**. Without that env flag, the dropdown still says
-**Claude Code** even if Claude later reports Bedrock on inspect.
+One harness-specific caveat: the env must be on the **harness
+process**. Claude Code can also read `CLAUDE_CODE_USE_BEDROCK` from
+its own `~/.claude/settings.json`, but the harness does not — with
+only that, Settings keeps saying **Claude Code** and inference
+profile discovery stays unavailable.
 
-For full AWS-side prerequisites (model access, IAM, optional `/setup-bedrock`
-wizard), follow [Claude Code on Amazon Bedrock](https://code.claude.com/docs/en/amazon-bedrock).
-
-## AWS credentials and region
-
-Claude Code uses the **default AWS credential provider chain**. Common
-operator patterns that must reach the harness process:
-
-| Mechanism | Typical env / setup |
-| --- | --- |
-| Access key | `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, optional `AWS_SESSION_TOKEN` |
-| Named profile / SSO | `AWS_PROFILE` (and a prior `aws sso login` when required) |
-| Bedrock API key | `AWS_BEARER_TOKEN_BEDROCK` |
-| Region | `AWS_REGION` and/or `AWS_DEFAULT_REGION` (or the active profile’s region) |
-
-Optional Claude/Bedrock-related vars (passed through when set) include pins
-below, `ANTHROPIC_BEDROCK_BASE_URL`, and others documented upstream. The
-harness does not invent a separate AWS secret store for this MVP.
-
-## Optional model pins (first-party / complementary)
-
-Env pins map Claude **floating aliases** to concrete model identifiers
-process-wide. In **Bedrock configuration mode** (`CLAUDE_CODE_USE_BEDROCK=1`)
-the Settings catalog no longer lists `haiku` / `sonnet` / `opus` / `fable`;
-you must pick a **discovered profile** (system profile ID or application ARN)
-from the catalog select. Pins remain useful when you still run first-party
-Claude Code aliases, or when other Claude tooling outside Settings still
-resolves aliases.
-
-```bash
-export ANTHROPIC_DEFAULT_OPUS_MODEL='us.anthropic.claude-opus-4-8'
-export ANTHROPIC_DEFAULT_SONNET_MODEL='us.anthropic.claude-sonnet-4-6'
-export ANTHROPIC_DEFAULT_HAIKU_MODEL='us.anthropic.claude-haiku-4-5-20251001-v1:0'
-# When you use the fable alias outside Bedrock catalog mode:
-# export ANTHROPIC_DEFAULT_FABLE_MODEL='…your Bedrock inference profile ID or ARN…'
-```
-
-Use IDs available in your account and region (cross-region `us.` profiles,
-application inference profile ARNs, GovCloud prefixes, and so on). See
-[pin model versions](https://code.claude.com/docs/en/amazon-bedrock#4-pin-model-versions)
-and [model configuration](https://code.claude.com/docs/en/model-config#pin-models-for-third-party-deployments)
-for the full pin variable list (including Fable).
-
-## Ready vs Unavailable
-
-Inspect classifies readiness from non-interactive `claude auth status` JSON
-(`loggedIn` + `apiProvider`), not from “missing claude.ai login implies
-Bedrock”.
-
-| Path | Typical cause | What you see | What to do |
-| --- | --- | --- | --- |
-| **First-party** (claude.ai / API key) not authenticated | No OAuth session and no usable `ANTHROPIC_API_KEY` (`loggedIn: false` on first-party) | Unavailable pointing at **`claude auth login` or `ANTHROPIC_API_KEY`** | Log in or set the API key, then Recheck |
-| **Bedrock** not ready | Claude reports `apiProvider: "bedrock"` with `loggedIn: false` (unusable Bedrock/AWS readiness) | Unavailable pointing at **AWS credentials/region and `CLAUDE_CODE_USE_BEDROCK=1`**—not first-party login | Fix harness process env / AWS access, then Recheck |
-| **Ready** (first-party) | Claude reports authenticated with `apiProvider: "firstParty"` | **Claude Code · First-party · Ready**; static alias catalog (`haiku` / `sonnet` / `opus` / `fable`) | Work Items can run Agent Turns |
-| **Ready** (Bedrock) | Claude reports authenticated with `apiProvider: "bedrock"` | **Claude Code · Amazon Bedrock · Ready**; with process env `CLAUDE_CODE_USE_BEDROCK=1`, Settings also labels the backend **Claude Code Bedrock**. Catalog is active Anthropic **system-defined** and **application** inference profiles from AWS (`ListInferenceProfiles` via the AWS SDK, ambient credentials/region). Floating aliases are **not** catalog choices. | Work Items can run Agent Turns; Save requires a discovered profile |
-| **Ready with catalog warning** | Claude is Ready on Bedrock but profile listing failed (IAM, region, throttle, credentials for control plane, etc.) | Ready status with a non-fatal warning; empty/partial catalog; Settings **blocks Save** until a discovered profile is available after Recheck | Fix IAM/`bedrock:ListInferenceProfiles`, region, or credentials, then **Recheck Agent Backend** |
-
-CLI crashes or unparseable `claude auth status` output are **not** the Bedrock
-row above: they surface as a generic readiness-probe failure (exit code /
-probe text). Still fix env/AWS if that is the underlying cause, then Recheck.
-
-After fixing env or credentials, use **Recheck Agent Backend**—you do not need
-a harness restart solely to refresh Bedrock readiness when the process env is
-already correct on the next inspect (export env before start if you changed
-the parent shell).
-
-First-party failures and Bedrock/AWS failures use **distinct** Unavailable
-copy so you know which stack to fix.
+In Settings, select **Claude Code Bedrock** as the Agent Backend and
+Recheck. Status shows **Claude Code · Amazon Bedrock** when ready.
+After fixing credentials or IAM, Recheck is enough — no harness
+restart needed, as long as the env was correct on the harness process.
 
 ## Model selection
 
-Selection for the **Claude Code** Agent Backend depends on configuration mode
-(Harness Config and per-Repository prefs):
+In Bedrock mode the model catalog is the active Anthropic inference
+profiles discovered from your AWS account and region (no AWS CLI
+needed — the harness bundles the AWS SDK). You pick a profile by
+friendly name; the stored value is the system profile ID or
+application profile ARN, passed to Claude Code as `--model`
+unchanged. The first-party aliases (`haiku`, `sonnet`, `opus`,
+`fable`) are not offered in Bedrock mode.
 
-| Path | What you do | Notes |
-| --- | --- | --- |
-| **Catalog (first-party)** | Pick `haiku`, `sonnet`, `opus`, or `fable` from a select | Static alias catalog when Claude reports first-party. Free-text entry was removed in issue #838, superseding issue #806. |
-| **Catalog (Bedrock mode)** | Pick a discovered system-defined or application inference profile from a select | Requires harness process `CLAUDE_CODE_USE_BEDROCK=1` for the **Claude Code Bedrock** Settings label. Profiles come from AWS `ListInferenceProfiles` for the harness process account/region (ACTIVE Anthropic-backed system and application). Settings show friendly name and **System** / **Application** kind; the stored value is the system profile ID or application ARN. Floating aliases are **not** offered. |
-| **Env pins** | Optionally pin first-party aliases via `ANTHROPIC_DEFAULT_*_MODEL` | Maps aliases process-wide; complementary to first-party alias selection |
-
-Agent Model selection is **catalog-only for every Agent Backend** in both
-Harness Config and Repository settings (issue #838): build and review model
-controls are selects over the current catalog, never editable inputs or
-datalist suggestions. Save is blocked while the catalog is loading, when it
-fails to load, when it returns no entries, when no build model is selected
-(Harness Config), or when the selected value is absent from the current
-catalog. The form shows the reason beside the model control.
-
-Because backend-scoped model prefs are keyed by the stable backend ID `claude`
-and are not split by provider mode, a value saved in Bedrock mode is still
-present when the harness later runs **without** `CLAUDE_CODE_USE_BEDROCK=1`
-(and vice versa). Such a value is **not** auto-deleted, rewritten, or
-translated between modes: Settings keeps showing it, marked as not in the
-current catalog, alongside the models you can pick instead. Choose a current
-model explicitly, or — in Repository settings — clear the override to inherit
-the Harness default. **Recheck Agent Backend** refreshes provider, warnings,
-and catalog atomically after AWS fixes; opening Settings also re-fetches
-provider mode and catalog so a long-open browser cannot offer models from
-before a Harness restart.
-
-The same catalog rule is enforced server-side, so a direct GraphQL
-`updateConfig` / `updateRepositorySettings` request cannot store a model the
-Agent Backend does not offer. Work Item creation and each Agent Turn also
-refuse a stored model that is absent from the current catalog, with
-configuration guidance and **without** spawning the Claude CLI.
-
-Resolved model strings are passed through as Claude `--model` on Agent Turns.
-Thinking Level / effort options come from the selected catalog entry;
-unsupported model×effort combinations fail at turn time.
-
-Empty / whitespace-only model values remain invalid for Harness Config build
-model. Empty Repository overrides keep inheriting the Harness default.
-
-### Bedrock profile discovery
-
-When inspect reports Bedrock Ready, the harness lists inference profiles with
-the **AWS SDK** Bedrock control plane bundled in the packaged binary (**not**
-the AWS CLI executable, and not a host preflight requirement). Discovery uses
-the same ambient credential chain as the harness process and resolves region
-in this order:
-
-1. `AWS_REGION`
-2. `AWS_DEFAULT_REGION`
-3. `region` on the active named profile (`AWS_PROFILE`) or `default` in the
-   shared AWS config file (`AWS_CONFIG_FILE` or `~/.aws/config`)
-4. Remaining AWS SDK default region sources when the client is constructed
-   without an explicit region
-
-Pagination is fully exhausted. Listing is scoped to the **resolved region**
-(profiles are not aggregated across regions).
-
-**IAM**
-
-- `bedrock:ListInferenceProfiles` is an **optional catalog-discovery**
-  permission on the harness IAM principal. Without it, Claude Code can still
-  be **Ready** for Agent Turns when Claude’s readiness probe succeeds.
-- Listing profiles does **not** prove `bedrock:InvokeModel` or
-  `bedrock:InvokeModelWithResponseStream` access. Actual invocation failures
-  remain ordinary Step Run / Claude CLI failures at turn time.
-
-**Warnings and refresh**
-
-Discovery failure is **non-fatal for readiness** after a successful Claude
-readiness probe: Claude Code stays Ready, the catalog may be empty or partial,
-and Settings shows an actionable warning (access denial, expired or missing
-credentials, unresolved profile/region, throttling, timeout, or generic
-control-plane failure). In Bedrock configuration mode, Save stays blocked until
-a discovered profile is available after Recheck. Warnings never include access
-keys, session tokens, bearer tokens, or raw credential payloads.
-
-**Recheck Agent Backend** retries discovery and replaces the cached provider
-metadata, warnings, and Agent Model catalog **atomically**. Repeated Preview
-and Recheck operations do not leave mixed stale catalog/warning state. Agent
-Backend Preview discovers profiles without activating Claude Code. First-party
-Claude Code and every other Agent Backend make **no** AWS discovery calls.
-
-**Catalog presentation**
-
-- System-defined profiles: executable Agent Model = inference profile ID;
-  kind `SYSTEM_DEFINED` (Settings: **System**).
-- Application profiles: executable Agent Model = profile ARN; kind
-  `APPLICATION` (Settings: **Application**).
-- Friendly `inferenceProfileName` is display-only; Claude Code always receives
-  the stored id/ARN via `--model` unchanged.
-- No Agent Backend accepts free-text model identifiers (issue #838). Catalog-
-  absent saved values are shown as unavailable until you pick a current model.
-
-**Out of scope (this path)**
-
-- Any free-text escape hatch for custom, pinned, dated, preview, or
-  context-window model strings on any Agent Backend.
-- Invoking listed profiles to prove model entitlement (no billable probe).
-- Multi-region catalog aggregation or an AWS setup wizard in the harness.
-- Configuring AWS credentials, region, or IAM from the Harness UI.
-
-## Quick checklist
-
-1. `claude` on `PATH` (the AWS CLI is **not** required).
-2. `CLAUDE_CODE_USE_BEDROCK=1` (and region) available to the **harness process**,
-   not only inside Claude Code settings.
-3. Valid AWS credentials for Bedrock in that same process environment.
-4. Settings → **Claude Code Bedrock** → Recheck Agent Backend → status shows
-   **Claude Code · Amazon Bedrock · Ready** (or Ready with a catalog warning).
-5. Build/review prefs: select a discovered system-defined profile ID or
-   application profile ARN from the catalog select (friendly name + kind shown;
-   stored executable id/ARN in Harness Config / Repository model prefs).
-6. Optional: `ANTHROPIC_DEFAULT_*_MODEL` pins when using first-party aliases
-   outside Bedrock catalog mode.
-7. Optional: grant `bedrock:ListInferenceProfiles` for catalog population.
-   Without it, Settings cannot offer profiles and Save stays blocked in Bedrock
-   mode even when Claude remains Ready for turns that already have a model.
-8. If Settings shows a discovery warning, fix IAM/region/credentials/profile
-   and Recheck until the select populates and Save unblocks.
+- Discovery needs `bedrock:ListInferenceProfiles`. If listing fails,
+  Claude Code stays Ready with a warning, but Save is blocked until a
+  profile is discovered after Recheck.
+- Listing a profile does not prove `bedrock:InvokeModel` access;
+  invocation failures surface at turn time as ordinary step failures.
+- A model saved in one provider mode (Bedrock or first-party) is kept
+  when running in the other: it shows as unavailable until you pick a
+  current one, and is never rewritten or translated.
 
 ## Related
 
-- Main operator install and Agent Backend requirements: [README.md](../README.md)
+- [Claude Code on Amazon Bedrock](https://code.claude.com/docs/en/amazon-bedrock) (Anthropic)
 - Claude Code Agent Backend decision: [ADR 0047](adr/0047-claude-code-agent-backend.md)
-- Provider + discovery epic: [issue #818](https://github.com/berenddeboer/ready-for-agent/issues/818)
-- Bedrock readiness MVP epic: [issue #799](https://github.com/berenddeboer/ready-for-agent/issues/799)
-- Model selection (hybrid aliases + free-text, superseded by #838): [issue #800](https://github.com/berenddeboer/ready-for-agent/issues/800) / [issue #806](https://github.com/berenddeboer/ready-for-agent/issues/806)
-- Catalog-only Agent Model selection across Settings: [issue #838](https://github.com/berenddeboer/ready-for-agent/issues/838)


### PR DESCRIPTION
- README: quick start first, requirements before usage, plain-English feature list, troubleshooting, glossary, proper H2/H3 outline
- CONTRIBUTING: fix typo, add tiny repo map
- Add MIT LICENSE (package.json already declared MIT)
- Trim docs/claude-code-amazon-bedrock.md to harness-specific notes, deferring AWS/Claude setup to Anthropic's docs
- Set repo homepage to the introduction video

Closes #905