### PR TITLE
chore: add Nx cache to GitHub Actions CI

### DIFF
--- a/.github/actions/nx-cache/action.yml
+++ b/.github/actions/nx-cache/action.yml
@@ -1,0 +1,69 @@
+name: Nx cache
+description: Restore or save the local Nx cache with GitHub Actions cache.
+
+inputs:
+  mode:
+    description: "Cache mode: main, pr, or restore-main"
+    required: true
+  pr-number:
+    description: Pull request number for PR cache keys.
+    required: false
+    default: ""
+  allow-save:
+    description: Whether PR mode is allowed to save a cache.
+    required: false
+    default: "false"
+
+runs:
+  using: composite
+  steps:
+    # Cap local .nx/cache growth on the runner before tasks run, so the
+    # GitHub Actions cache we save stays bounded (default Nx cap is huge).
+    - name: Cap Nx local cache size
+      shell: bash
+      run: echo "NX_MAX_CACHE_SIZE=1GB" >> "$GITHUB_ENV"
+
+    - name: Restore and save main Nx cache
+      if: inputs.mode == 'main'
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      with:
+        path: .nx
+        key: nx-main-${{ github.sha }}
+        restore-keys: |
+          nx-main-
+
+    - name: Restore main Nx cache
+      if: inputs.mode == 'restore-main'
+      uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      with:
+        path: .nx
+        key: nx-main-${{ github.sha }}
+        restore-keys: |
+          nx-main-
+
+    - name: Restore and save PR Nx cache
+      if: inputs.mode == 'pr' && inputs.allow-save == 'true'
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      with:
+        path: .nx
+        key: nx-pr-${{ inputs.pr-number }}-${{ github.sha }}
+        restore-keys: |
+          nx-pr-${{ inputs.pr-number }}-
+          nx-main-
+
+    - name: Restore PR Nx cache
+      if: inputs.mode == 'pr' && inputs.allow-save != 'true'
+      uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      with:
+        path: .nx
+        key: nx-pr-${{ inputs.pr-number }}-${{ github.sha }}
+        restore-keys: |
+          nx-pr-${{ inputs.pr-number }}-
+          nx-main-
+
+    - name: Reject unknown Nx cache mode
+      if: inputs.mode != 'main' && inputs.mode != 'restore-main' && inputs.mode != 'pr'
+      shell: bash
+      run: |
+        echo "Unknown nx-cache mode: '${{ inputs.mode }}' (expected main, restore-main, or pr)" >&2
+        exit 1

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -73,6 +73,13 @@ jobs:
       # - run: bunx nx start-ci-run --distribute-on="3 linux-medium-js" --stop-agents-after="build"
 
       - run: bun install --no-cache --frozen-lockfile --linker=isolated && bun install --no-cache --frozen-lockfile --linker=isolated
+
+      # Primary main-branch cache producer (restore + save under nx-main-${{ github.sha }}).
+      - name: Restore/save Nx cache
+        uses: ./.github/actions/nx-cache
+        with:
+          mode: main
+
       - uses: nrwl/nx-set-shas@afb73a62d26e41464e9254689e1fd6122ee683c1 # v5.0.1
 
       # Prepend any command with "nx record --" to record its logs to Nx Cloud
@@ -131,6 +138,12 @@ jobs:
         run: echo "$HOME/.opencode/bin" >> "$GITHUB_PATH"
 
       - run: bun install --no-cache --frozen-lockfile --linker=isolated && bun install --no-cache --frozen-lockfile --linker=isolated
+
+      # Restore only: quality-gates is the main cache producer.
+      - name: Restore Nx cache
+        uses: ./.github/actions/nx-cache
+        with:
+          mode: restore-main
 
       # Dev-path GraphQL smoke (Bun + Vite SSR); no Keymaxxer vault required.
       # Production live e2e below remains vault-backed and separate.
@@ -207,6 +220,12 @@ jobs:
 
       - run: bun install --no-cache --frozen-lockfile --linker=isolated && bun install --no-cache --frozen-lockfile --linker=isolated
 
+      # Restore only: quality-gates is the main cache producer.
+      - name: Restore Nx cache
+        uses: ./.github/actions/nx-cache
+        with:
+          mode: restore-main
+
       - name: Packed-install Harness smoke
         id: packed-install
         env:
@@ -249,6 +268,12 @@ jobs:
           registry-url: "https://registry.npmjs.org"
 
       - run: bun install --no-cache --frozen-lockfile --linker=isolated && bun install --no-cache --frozen-lockfile --linker=isolated
+
+      # Restore only: quality-gates is the main cache producer.
+      - name: Restore Nx cache
+        uses: ./.github/actions/nx-cache
+        with:
+          mode: restore-main
 
       - name: Compute next version
         id: version

--- a/.github/workflows/cleanup-nx-cache.yml
+++ b/.github/workflows/cleanup-nx-cache.yml
@@ -1,0 +1,150 @@
+name: Cleanup Nx Cache
+
+on:
+  pull_request:
+    types:
+      - closed
+  schedule:
+    - cron: "17 3 * * *"
+  workflow_dispatch:
+
+permissions:
+  actions: write
+  contents: read
+  pull-requests: read
+
+jobs:
+  cleanup-pr-cache:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Delete PR caches
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+
+          delete_cache() {
+            local cache_id="$1"
+            local output
+            if output="$(gh cache delete "$cache_id" --repo "$GH_REPO" 2>&1)"; then
+              return
+            fi
+            if printf '%s' "$output" | grep -Eqi 'HTTP 404|not found'; then
+              echo "  cache ${cache_id} was already deleted"
+              return
+            fi
+            printf '%s\n' "$output" >&2
+            return 1
+          }
+
+          delete_pr_caches() {
+            local pass="$1"
+            echo "Pass ${pass}: deleting caches for PR ${PR_NUMBER}"
+            gh cache list \
+              --repo "$GH_REPO" \
+              --key "nx-pr-${PR_NUMBER}-" \
+              --json id,key \
+              --limit 100 \
+              --jq '.[] | "\(.id)\t\(.key)"' |
+            while IFS=$'\t' read -r cache_id cache_key; do
+              if [ -n "${cache_id:-}" ]; then
+                echo "  delete ${cache_id} (${cache_key})"
+                delete_cache "$cache_id"
+              fi
+            done
+          }
+
+          # Immediate pass for the common case.
+          delete_pr_caches 1
+
+          # In-flight PR jobs can save after close (race). Hold the runner so a
+          # second pass can catch those late saves. Cost: ~20m of ubuntu-latest
+          # per closed PR; the nightly cleanup-stale-caches job is the backstop
+          # if anything is still left after this window.
+          echo "Waiting 20m for in-flight PR jobs to finish saving..."
+          sleep 1200
+
+          # Skip pass 2 if the PR was reopened during the sleep (new CI may
+          # have written live nx-pr- caches we must not delete).
+          if ! state="$(gh pr view "$PR_NUMBER" --repo "$GH_REPO" --json state --jq .state)"; then
+            echo "Could not re-check PR ${PR_NUMBER} state; skipping pass 2" >&2
+            exit 0
+          fi
+          if [ "$state" = "OPEN" ]; then
+            echo "PR ${PR_NUMBER} is OPEN again; skipping pass 2 so live caches stay"
+            exit 0
+          fi
+
+          delete_pr_caches 2
+
+  cleanup-stale-caches:
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Prune Nx caches
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          # Keep a couple of recent main caches for restore-key fallback.
+          KEEP_MAIN: "2"
+        run: |
+          set -euo pipefail
+
+          delete_cache() {
+            local cache_id="$1"
+            local output
+            if output="$(gh cache delete "$cache_id" --repo "$GH_REPO" 2>&1)"; then
+              return
+            fi
+            if printf '%s' "$output" | grep -Eqi 'HTTP 404|not found'; then
+              echo "  cache ${cache_id} was already deleted"
+              return
+            fi
+            printf '%s\n' "$output" >&2
+            return 1
+          }
+
+          delete_ids() {
+            while IFS= read -r cache_id; do
+              if [ -n "${cache_id:-}" ]; then
+                echo "  delete ${cache_id}"
+                delete_cache "$cache_id"
+              fi
+            done
+          }
+
+          echo "==> Keep latest ${KEEP_MAIN} nx-main- caches"
+          gh cache list \
+            --repo "$GH_REPO" \
+            --key nx-main- \
+            --sort created_at \
+            --order desc \
+            --json id \
+            --limit 100 \
+            --jq ".[${KEEP_MAIN}:][].id" |
+          delete_ids
+
+          echo "==> Delete nx-pr- caches for closed PRs"
+          gh cache list \
+            --repo "$GH_REPO" \
+            --key nx-pr- \
+            --json id,key \
+            --limit 100 \
+            --jq '.[] | "\(.id)\t\(.key)"' |
+          while IFS=$'\t' read -r cache_id cache_key; do
+            pr_number="$(printf '%s' "$cache_key" | sed -n 's/^nx-pr-\([0-9][0-9]*\)-.*/\1/p')"
+            if [ -z "${pr_number:-}" ]; then
+              continue
+            fi
+            if ! state="$(gh pr view "$pr_number" --repo "$GH_REPO" --json state --jq .state)"; then
+              echo "  skip ${cache_key}: could not read PR ${pr_number}" >&2
+              continue
+            fi
+            if [ "$state" != "OPEN" ]; then
+              echo "  delete ${cache_id} (${cache_key}, pr=${pr_number}, state=${state})"
+              delete_cache "$cache_id"
+            fi
+          done

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -4,8 +4,8 @@ on:
   pull_request:
 
 permissions:
-  # upload-artifact attaches to this run; GITHUB_TOKEN does not need actions:write
-  actions: read
+  # actions: write — save PR-scoped Nx caches (same-repo PRs only)
+  actions: write
   contents: read
 
 jobs:
@@ -64,6 +64,15 @@ jobs:
         run: echo "$HOME/.opencode/bin" >> "$GITHUB_PATH"
 
       - run: bun install --no-cache --frozen-lockfile --linker=isolated && bun install --no-cache --frozen-lockfile --linker=isolated
+
+      - name: Restore/save Nx cache
+        uses: ./.github/actions/nx-cache
+        with:
+          mode: pr
+          pr-number: ${{ github.event.pull_request.number }}
+          # Forks and Dependabot get a read-only token for cache writes; restore only.
+          allow-save: ${{ github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]' }}
+
       - uses: nrwl/nx-set-shas@afb73a62d26e41464e9254689e1fd6122ee683c1 # v5.0.1
 
       - name: Quality gates
@@ -109,6 +118,14 @@ jobs:
         run: echo "$HOME/.opencode/bin" >> "$GITHUB_PATH"
 
       - run: bun install --no-cache --frozen-lockfile --linker=isolated && bun install --no-cache --frozen-lockfile --linker=isolated
+
+      # Restore only: quality-gates is the PR cache producer.
+      - name: Restore Nx cache
+        uses: ./.github/actions/nx-cache
+        with:
+          mode: pr
+          pr-number: ${{ github.event.pull_request.number }}
+          allow-save: "false"
 
       # Dev-path GraphQL smoke (Bun + Vite SSR); no Keymaxxer vault required.
       # Production live e2e below remains vault-backed and separate.


### PR DESCRIPTION
## Why

CI quality gates re-run lint, typecheck, test, and knip from a cold Nx cache on every job. That wastes runner time on unchanged work across PR pushes and main runs. We want the same GitHub Actions–backed local Nx cache pattern used elsewhere, scoped to what this repo actually runs.

## What Changed

- Added `.github/actions/nx-cache` composite action with modes `main`, `restore-main`, and `pr` (optional save), 1GB local cache cap, and fail-fast on unknown mode.
- Wired **quality-gates** as the cache producer (`main` on push, `pr` + save on same-repo non-Dependabot PRs); harness / packed-install / release restore only.
- Added `cleanup-nx-cache.yml`: delete PR caches on close (immediate + delayed pass, skip if reopened), nightly keep last two `nx-main-` and drop closed-PR caches.
- Raised PR workflow `actions: write` so same-repo PR caches can be saved.
