### PR TITLE
docs: link README prerequisites to Requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ action.
 
 ## Quick start
 
-1. Install the prerequisites and have them on your PATH:
+1. Install the [prerequisites](#requirements) and have them on your PATH:
    [git](https://git-scm.com/), the [GitHub CLI
    (`gh`)](https://cli.github.com/), and at least one coding agent —
    [OpenCode](https://opencode.ai/),


### PR DESCRIPTION
## Why

Quick start tells people to install the prerequisites, but that list lives under Requirements. New readers should be able to jump there without scrolling for the section by hand.

## What Changed

In README Quick start step 1, make "prerequisites" an in-page link to `#requirements`.