### PR TITLE
feat(codex): harden session telemetry availability and safe lookup

### DIFF
--- a/packages/codex/src/lib/session-store.ts
+++ b/packages/codex/src/lib/session-store.ts
@@ -307,10 +307,86 @@ const findIndexedRollout = (input: {
   return null
 }
 
+const sessionsRootLookup = (
+  codexHome: string,
+):
+  | { readonly kind: "found"; readonly path: string }
+  | { readonly kind: "missing" }
+  | { readonly kind: "unavailable" } => {
+  const sessionsRoot = join(codexHome, "sessions")
+  try {
+    if (!statSync(sessionsRoot).isDirectory()) {
+      return { kind: "unavailable" }
+    }
+  } catch (error) {
+    return isMissingPathError(error)
+      ? { kind: "missing" }
+      : { kind: "unavailable" }
+  }
+  return { kind: "found", path: sessionsRoot }
+}
+
+/** Filename pattern used by the sessions-tree scan for a Session ID. */
+const isScannedRolloutFileName = (
+  fileName: string,
+  sessionId: string,
+): boolean =>
+  fileName.startsWith("rollout-") && fileName.endsWith(`-${sessionId}.jsonl`)
+
+const sameResolvedPath = (left: string, right: string): boolean => {
+  if (left === right) {
+    return true
+  }
+  try {
+    return realpathSync(left) === realpathSync(right)
+  } catch {
+    return false
+  }
+}
+
 /**
- * Locate a unique date-partitioned Codex rollout by its filename Session ID.
+ * Scan date-partitioned rollouts under the sessions tree by filename Session ID.
  * Symlinks are not followed, and duplicate suffix matches are unavailable
  * rather than being attributed arbitrarily.
+ */
+const findScannedRollout = (input: {
+  readonly sessionsRoot: string
+  readonly sessionId: string
+  /** Skip an already-tried index path when falling back after a mismatch. */
+  readonly excludePath?: string
+}): CodexRolloutLookup => {
+  const scan = scanRolloutDirectory({
+    directory: input.sessionsRoot,
+    fileSuffix: `-${input.sessionId}.jsonl`,
+  })
+  if (scan.kind === "unavailable") {
+    return scan
+  }
+  const excludePath = input.excludePath
+  const paths =
+    excludePath === undefined
+      ? scan.paths
+      : scan.paths.filter((path) => !sameResolvedPath(path, excludePath))
+  if (paths.length === 0) {
+    return { kind: "missing" }
+  }
+  if (paths.length > 1) {
+    return { kind: "unavailable" }
+  }
+  const path = paths[0]
+  return path === undefined
+    ? { kind: "missing" }
+    : {
+        kind: "found",
+        path,
+        indexCreatedAt: null,
+        indexUpdatedAt: null,
+      }
+}
+
+/**
+ * Locate a unique Codex rollout: prefer a trustworthy threads index hit, then
+ * fall back to scanning date-partitioned rollout filenames by Session ID.
  */
 export const findCodexSessionRollout = (input: {
   readonly codexHome: string
@@ -321,20 +397,14 @@ export const findCodexSessionRollout = (input: {
     return { kind: "missing" }
   }
 
-  const sessionsRoot = join(input.codexHome, "sessions")
-  try {
-    if (!statSync(sessionsRoot).isDirectory()) {
-      return { kind: "unavailable" }
-    }
-  } catch (error) {
-    return isMissingPathError(error)
-      ? { kind: "missing" }
-      : { kind: "unavailable" }
+  const sessionsRoot = sessionsRootLookup(input.codexHome)
+  if (sessionsRoot.kind !== "found") {
+    return sessionsRoot
   }
 
   const indexed = findIndexedRollout({
     codexHome: input.codexHome,
-    sessionsRoot,
+    sessionsRoot: sessionsRoot.path,
     sessionId: id,
   })
   if (indexed !== null) {
@@ -346,28 +416,10 @@ export const findCodexSessionRollout = (input: {
     }
   }
 
-  const scan = scanRolloutDirectory({
-    directory: sessionsRoot,
-    fileSuffix: `-${id}.jsonl`,
+  return findScannedRollout({
+    sessionsRoot: sessionsRoot.path,
+    sessionId: id,
   })
-  if (scan.kind === "unavailable") {
-    return scan
-  }
-  if (scan.paths.length === 0) {
-    return { kind: "missing" }
-  }
-  if (scan.paths.length > 1) {
-    return { kind: "unavailable" }
-  }
-  const path = scan.paths[0]
-  return path === undefined
-    ? { kind: "missing" }
-    : {
-        kind: "found",
-        path,
-        indexCreatedAt: null,
-        indexUpdatedAt: null,
-      }
 }
 
 type CodexRolloutFold = {
@@ -515,6 +567,70 @@ const missing = (id: string): CodexSessionUnavailable => ({
   updatedAt: null,
 })
 
+type ParsedRollout =
+  | { readonly kind: "available"; readonly session: CodexSessionAvailable }
+  | { readonly kind: "unreadable" }
+  /** Readable but no trustworthy `session_meta` identity. */
+  | { readonly kind: "corrupt" }
+  /** Readable session_meta for a different Session ID. */
+  | { readonly kind: "wrong_session" }
+
+const parseRolloutAt = (input: {
+  readonly sessionId: string
+  readonly path: string
+  readonly indexCreatedAt: string | null
+  readonly indexUpdatedAt: string | null
+}): ParsedRollout => {
+  let raw: string
+  try {
+    raw = readFileSync(input.path, "utf8")
+  } catch {
+    return { kind: "unreadable" }
+  }
+  const fold = foldCodexRollout(raw)
+  if (fold.sessionId === null) {
+    return { kind: "corrupt" }
+  }
+  if (fold.sessionId !== input.sessionId) {
+    return { kind: "wrong_session" }
+  }
+  return {
+    kind: "available",
+    session: {
+      id: input.sessionId,
+      availability: "available",
+      model: fold.model,
+      tokens: fold.tokens,
+      cost: null,
+      createdAt: fold.createdAt ?? input.indexCreatedAt,
+      updatedAt: fold.updatedAt ?? input.indexUpdatedAt,
+    },
+  }
+}
+
+const sessionFromLookup = (input: {
+  readonly sessionId: string
+  readonly lookup: CodexRolloutLookup
+}): CodexSession => {
+  if (input.lookup.kind === "missing") {
+    return missing(input.sessionId)
+  }
+  if (input.lookup.kind === "unavailable") {
+    return unavailable(input.sessionId)
+  }
+  const parsed = parseRolloutAt({
+    sessionId: input.sessionId,
+    path: input.lookup.path,
+    indexCreatedAt: input.lookup.indexCreatedAt,
+    indexUpdatedAt: input.lookup.indexUpdatedAt,
+  })
+  if (parsed.kind === "available") {
+    return parsed.session
+  }
+  // Scanned filename matched the Session ID but content is unusable.
+  return unavailable(input.sessionId)
+}
+
 const readCodexSessionFromDisk = (input: {
   readonly codexHome: string
   readonly sessionId: string
@@ -524,37 +640,63 @@ const readCodexSessionFromDisk = (input: {
     return missing(id)
   }
 
-  const lookup = findCodexSessionRollout({
-    codexHome: input.codexHome,
-    sessionId: id,
-  })
-  if (lookup.kind === "missing") {
+  const sessionsRoot = sessionsRootLookup(input.codexHome)
+  if (sessionsRoot.kind === "missing") {
     return missing(id)
   }
-  if (lookup.kind === "unavailable") {
+  if (sessionsRoot.kind === "unavailable") {
     return unavailable(id)
   }
 
-  let raw: string
-  try {
-    raw = readFileSync(lookup.path, "utf8")
-  } catch {
-    return unavailable(id)
-  }
-  const fold = foldCodexRollout(raw)
-  if (fold.sessionId !== id) {
+  const indexed = findIndexedRollout({
+    codexHome: input.codexHome,
+    sessionsRoot: sessionsRoot.path,
+    sessionId: id,
+  })
+  if (indexed !== null) {
+    const parsed = parseRolloutAt({
+      sessionId: id,
+      path: indexed.path,
+      indexCreatedAt: indexed.createdAt,
+      indexUpdatedAt: indexed.updatedAt,
+    })
+    if (parsed.kind === "available") {
+      return parsed.session
+    }
+    // Mismatched, stale, corrupt, or unreadable index paths fall through to a
+    // sessions-tree scan so a trustworthy unique rollout can still win.
+    const scanned = findScannedRollout({
+      sessionsRoot: sessionsRoot.path,
+      sessionId: id,
+      excludePath: indexed.path,
+    })
+    if (scanned.kind === "found") {
+      return sessionFromLookup({ sessionId: id, lookup: scanned })
+    }
+    if (scanned.kind === "unavailable") {
+      return unavailable(id)
+    }
+    // No alternate rollout after excluding the index path.
+    // Unreadable/corrupt index targets stay UNAVAILABLE.
+    // wrong_session: MISSING only when the index pointed at a non-scan path for
+    // a different Session (no matching Session for this id). If the index path
+    // itself is a scan-pattern rollout for this id, match pure-scan behaviour
+    // and report UNAVAILABLE for untrustworthy identity — not MISSING.
+    if (parsed.kind === "wrong_session") {
+      return isScannedRolloutFileName(basename(indexed.path), id)
+        ? unavailable(id)
+        : missing(id)
+    }
     return unavailable(id)
   }
 
-  return {
-    id,
-    availability: "available",
-    model: fold.model,
-    tokens: fold.tokens,
-    cost: null,
-    createdAt: fold.createdAt ?? lookup.indexCreatedAt,
-    updatedAt: fold.updatedAt ?? lookup.indexUpdatedAt,
-  }
+  return sessionFromLookup({
+    sessionId: id,
+    lookup: findScannedRollout({
+      sessionsRoot: sessionsRoot.path,
+      sessionId: id,
+    }),
+  })
 }
 
 export const makeCodexSessionStore = (

--- a/packages/codex/test/session-store.spec.ts
+++ b/packages/codex/test/session-store.spec.ts
@@ -1,4 +1,5 @@
 import {
+  chmodSync,
   mkdirSync,
   mkdtempSync,
   rmSync,
@@ -11,6 +12,9 @@ import { Effect } from "effect"
 import {
   CodexSessionStore,
   CodexSessionStoreLive,
+  findCodexSessionRollout,
+  foldCodexRollout,
+  isSafeCodexSessionIdSegment,
   resolveCodexHome,
 } from "../src/lib/session-store.js"
 import { Database } from "bun:sqlite"
@@ -42,6 +46,151 @@ const writeScannedRollout = (input: {
   return path
 }
 
+const writeThreadsIndex = (input: {
+  readonly codexHome: string
+  readonly sessionId: string
+  readonly rolloutPath: string
+  readonly createdAt?: number
+  readonly updatedAt?: number
+}): void => {
+  const db = new Database(join(input.codexHome, "state_5.sqlite"))
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS threads (
+      id TEXT PRIMARY KEY,
+      rollout_path TEXT NOT NULL,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL
+    )
+  `)
+  db.query(
+    "INSERT OR REPLACE INTO threads (id, rollout_path, created_at, updated_at) VALUES (?, ?, ?, ?)",
+  ).run(
+    input.sessionId,
+    input.rolloutPath,
+    input.createdAt ?? 0,
+    input.updatedAt ?? 0,
+  )
+  db.close()
+}
+
+const tokenCountLine = (input: {
+  readonly timestamp: string
+  readonly total: {
+    readonly input: number
+    readonly output: number
+    readonly reasoning: number
+    readonly cacheRead: number
+    readonly cacheWrite: number
+  }
+  readonly last?: {
+    readonly input: number
+    readonly output: number
+    readonly reasoning: number
+    readonly cacheRead: number
+    readonly cacheWrite: number
+  }
+}) => ({
+  timestamp: input.timestamp,
+  type: "event_msg",
+  payload: {
+    type: "token_count",
+    info: {
+      ...(input.last === undefined
+        ? {}
+        : {
+            last_token_usage: {
+              input_tokens: input.last.input,
+              output_tokens: input.last.output,
+              reasoning_output_tokens: input.last.reasoning,
+              cached_input_tokens: input.last.cacheRead,
+              cache_write_input_tokens: input.last.cacheWrite,
+            },
+          }),
+      total_token_usage: {
+        input_tokens: input.total.input,
+        output_tokens: input.total.output,
+        reasoning_output_tokens: input.total.reasoning,
+        cached_input_tokens: input.total.cacheRead,
+        cache_write_input_tokens: input.total.cacheWrite,
+      },
+    },
+  },
+})
+
+describe("isSafeCodexSessionIdSegment", () => {
+  it("accepts opaque single-segment Session IDs and rejects path escapes", () => {
+    expect(
+      isSafeCodexSessionIdSegment("019fab2c-9466-7432-ad16-9de23f94f2db"),
+    ).toBe(true)
+    expect(isSafeCodexSessionIdSegment("abc..def")).toBe(true)
+    for (const id of [
+      "",
+      ".",
+      "..",
+      "../outside",
+      "a/b",
+      "a\\b",
+      "/etc/passwd",
+      "\0null",
+    ]) {
+      expect(isSafeCodexSessionIdSegment(id)).toBe(false)
+    }
+  })
+})
+
+describe("foldCodexRollout", () => {
+  it("uses only the last total_token_usage and never sums last_token_usage", () => {
+    const fold = foldCodexRollout(
+      [
+        JSON.stringify({
+          type: "session_meta",
+          payload: { id: "session-last-wins" },
+        }),
+        JSON.stringify(
+          tokenCountLine({
+            timestamp: "2026-08-08T01:00:00.000Z",
+            total: {
+              input: 100,
+              output: 20,
+              reasoning: 5,
+              cacheRead: 60,
+              cacheWrite: 7,
+            },
+          }),
+        ),
+        JSON.stringify(
+          tokenCountLine({
+            timestamp: "2026-08-08T01:01:00.000Z",
+            last: {
+              input: 50,
+              output: 10,
+              reasoning: 2,
+              cacheRead: 30,
+              cacheWrite: 3,
+            },
+            total: {
+              input: 250,
+              output: 45,
+              reasoning: 11,
+              cacheRead: 140,
+              cacheWrite: 13,
+            },
+          }),
+        ),
+      ].join("\n"),
+    )
+
+    expect(fold.sessionId).toBe("session-last-wins")
+    expect(fold.tokens).toEqual({
+      input: 250,
+      output: 45,
+      reasoning: 11,
+      cacheRead: 140,
+      cacheWrite: 13,
+    })
+  })
+})
+
 describe("CodexSessionStore", () => {
   it("uses the Codex threads index for rollout location and timestamps", async () => {
     const codexHome = mkdtempSync(join(tmpdir(), "codex-session-store-"))
@@ -57,24 +206,13 @@ describe("CodexSessionStore", () => {
         })}\n`,
       )
 
-      const db = new Database(join(codexHome, "state_5.sqlite"))
-      db.exec(`
-        CREATE TABLE threads (
-          id TEXT PRIMARY KEY,
-          rollout_path TEXT NOT NULL,
-          created_at INTEGER NOT NULL,
-          updated_at INTEGER NOT NULL
-        )
-      `)
-      db.query(
-        "INSERT INTO threads (id, rollout_path, created_at, updated_at) VALUES (?, ?, ?, ?)",
-      ).run(
+      writeThreadsIndex({
+        codexHome,
         sessionId,
         rolloutPath,
-        Date.parse("2026-08-08T02:00:00.000Z") / 1000,
-        Date.parse("2026-08-08T03:00:00.000Z") / 1000,
-      )
-      db.close()
+        createdAt: Date.parse("2026-08-08T02:00:00.000Z") / 1000,
+        updatedAt: Date.parse("2026-08-08T03:00:00.000Z") / 1000,
+      })
 
       await expect(getSession({ codexHome, sessionId })).resolves.toEqual({
         id: sessionId,
@@ -91,6 +229,257 @@ describe("CodexSessionStore", () => {
         createdAt: "2026-08-08T02:00:00.000Z",
         updatedAt: "2026-08-08T03:00:00.000Z",
       })
+    } finally {
+      rmSync(codexHome, { recursive: true, force: true })
+    }
+  })
+
+  it("falls back to the sessions tree when the threads index is missing", async () => {
+    const codexHome = mkdtempSync(join(tmpdir(), "codex-session-store-"))
+    try {
+      const sessionId = "scan-only-session"
+      writeScannedRollout({
+        codexHome,
+        partition: join("2026", "02", "01"),
+        sessionId,
+        raw: `${JSON.stringify({
+          type: "session_meta",
+          payload: { id: sessionId },
+        })}\n`,
+      })
+
+      await expect(getSession({ codexHome, sessionId })).resolves.toMatchObject(
+        {
+          id: sessionId,
+          availability: "available",
+          tokens: {
+            input: 0,
+            output: 0,
+            reasoning: 0,
+            cacheRead: 0,
+            cacheWrite: 0,
+          },
+        },
+      )
+    } finally {
+      rmSync(codexHome, { recursive: true, force: true })
+    }
+  })
+
+  it("falls back to a unique scanned rollout when the index path is stale", async () => {
+    const codexHome = mkdtempSync(join(tmpdir(), "codex-session-store-"))
+    try {
+      const sessionId = "stale-index-session"
+      const sessionsRoot = join(codexHome, "sessions")
+      mkdirSync(sessionsRoot, { recursive: true })
+      // Index points at a path that no longer exists; findIndexedRollout skips it.
+      writeThreadsIndex({
+        codexHome,
+        sessionId,
+        rolloutPath: join(sessionsRoot, "gone-rollout.jsonl"),
+      })
+      writeScannedRollout({
+        codexHome,
+        partition: join("2026", "03", "01"),
+        sessionId,
+        raw: `${JSON.stringify({
+          type: "session_meta",
+          payload: { id: sessionId },
+        })}\n`,
+      })
+
+      await expect(getSession({ codexHome, sessionId })).resolves.toMatchObject(
+        {
+          id: sessionId,
+          availability: "available",
+        },
+      )
+    } finally {
+      rmSync(codexHome, { recursive: true, force: true })
+    }
+  })
+
+  it("falls back to a unique scanned rollout when the index path is for another Session", async () => {
+    const codexHome = mkdtempSync(join(tmpdir(), "codex-session-store-"))
+    try {
+      const sessionId = "wanted-session"
+      const sessionsRoot = join(codexHome, "sessions")
+      mkdirSync(sessionsRoot, { recursive: true })
+      const wrongPath = join(sessionsRoot, "wrong-session.jsonl")
+      writeFileSync(
+        wrongPath,
+        `${JSON.stringify({
+          type: "session_meta",
+          payload: { id: "other-session" },
+        })}\n`,
+      )
+      writeThreadsIndex({
+        codexHome,
+        sessionId,
+        rolloutPath: wrongPath,
+      })
+      writeScannedRollout({
+        codexHome,
+        partition: join("2026", "03", "02"),
+        sessionId,
+        raw: [
+          JSON.stringify({
+            type: "session_meta",
+            payload: { id: sessionId },
+          }),
+          JSON.stringify(
+            tokenCountLine({
+              timestamp: "2026-08-08T04:00:00.000Z",
+              total: {
+                input: 9,
+                output: 4,
+                reasoning: 1,
+                cacheRead: 2,
+                cacheWrite: 0,
+              },
+            }),
+          ),
+        ].join("\n"),
+      })
+
+      await expect(getSession({ codexHome, sessionId })).resolves.toEqual({
+        id: sessionId,
+        availability: "available",
+        model: null,
+        tokens: {
+          input: 9,
+          output: 4,
+          reasoning: 1,
+          cacheRead: 2,
+          cacheWrite: 0,
+        },
+        cost: null,
+        createdAt: "2026-08-08T04:00:00.000Z",
+        updatedAt: "2026-08-08T04:00:00.000Z",
+      })
+    } finally {
+      rmSync(codexHome, { recursive: true, force: true })
+    }
+  })
+
+  it("returns MISSING when the index points at another Session and no rollout matches", async () => {
+    const codexHome = mkdtempSync(join(tmpdir(), "codex-session-store-"))
+    try {
+      const sessionId = "wanted-absent"
+      const sessionsRoot = join(codexHome, "sessions")
+      mkdirSync(sessionsRoot, { recursive: true })
+      const wrongPath = join(sessionsRoot, "other-only.jsonl")
+      writeFileSync(
+        wrongPath,
+        `${JSON.stringify({
+          type: "session_meta",
+          payload: { id: "other-session" },
+        })}\n`,
+      )
+      writeThreadsIndex({
+        codexHome,
+        sessionId,
+        rolloutPath: wrongPath,
+      })
+
+      await expect(getSession({ codexHome, sessionId })).resolves.toEqual({
+        id: sessionId,
+        availability: "missing",
+        model: null,
+        tokens: null,
+        cost: null,
+        createdAt: null,
+        updatedAt: null,
+      })
+    } finally {
+      rmSync(codexHome, { recursive: true, force: true })
+    }
+  })
+
+  it("returns UNAVAILABLE when a scan-pattern rollout has mismatched identity (index or scan)", async () => {
+    const codexHome = mkdtempSync(join(tmpdir(), "codex-session-store-"))
+    try {
+      const sessionId = "name-claims-id"
+      const mismatched = `${JSON.stringify({
+        type: "session_meta",
+        payload: { id: "actually-other-session" },
+      })}\n`
+
+      // Pure scan: filename claims sessionId but session_meta does not.
+      writeScannedRollout({
+        codexHome,
+        partition: join("2026", "03", "03"),
+        sessionId,
+        raw: mismatched,
+      })
+      await expect(getSession({ codexHome, sessionId })).resolves.toMatchObject(
+        {
+          id: sessionId,
+          availability: "unavailable",
+          tokens: null,
+        },
+      )
+
+      // Same unusable file reached only via the threads index must not flip to
+      // MISSING (availability must match the pure-scan outcome above).
+      const codexHomeIndexed = mkdtempSync(
+        join(tmpdir(), "codex-session-store-indexed-"),
+      )
+      try {
+        const sessionsRoot = join(codexHomeIndexed, "sessions")
+        mkdirSync(sessionsRoot, { recursive: true })
+        const indexedPath = join(
+          sessionsRoot,
+          `rollout-indexed-${sessionId}.jsonl`,
+        )
+        writeFileSync(indexedPath, mismatched)
+        writeThreadsIndex({
+          codexHome: codexHomeIndexed,
+          sessionId,
+          rolloutPath: indexedPath,
+        })
+        await expect(
+          getSession({ codexHome: codexHomeIndexed, sessionId }),
+        ).resolves.toMatchObject({
+          id: sessionId,
+          availability: "unavailable",
+          tokens: null,
+        })
+      } finally {
+        rmSync(codexHomeIndexed, { recursive: true, force: true })
+      }
+    } finally {
+      rmSync(codexHome, { recursive: true, force: true })
+    }
+  })
+
+  it("falls back to scan when the threads schema is mismatched", async () => {
+    const codexHome = mkdtempSync(join(tmpdir(), "codex-session-store-"))
+    try {
+      const sessionId = "schema-mismatch-session"
+      const db = new Database(join(codexHome, "state_5.sqlite"))
+      db.exec(`CREATE TABLE threads (id TEXT PRIMARY KEY, notes TEXT)`)
+      db.query("INSERT INTO threads (id, notes) VALUES (?, ?)").run(
+        sessionId,
+        "no rollout path column",
+      )
+      db.close()
+      writeScannedRollout({
+        codexHome,
+        partition: join("2026", "04", "01"),
+        sessionId,
+        raw: `${JSON.stringify({
+          type: "session_meta",
+          payload: { id: sessionId },
+        })}\n`,
+      })
+
+      await expect(getSession({ codexHome, sessionId })).resolves.toMatchObject(
+        {
+          id: sessionId,
+          availability: "available",
+        },
+      )
     } finally {
       rmSync(codexHome, { recursive: true, force: true })
     }
@@ -116,19 +505,11 @@ describe("CodexSessionStore", () => {
       )
       symlinkSync(outsideRollout, indexedPath)
 
-      const db = new Database(join(codexHome, "state_5.sqlite"))
-      db.exec(`
-        CREATE TABLE threads (
-          id TEXT PRIMARY KEY,
-          rollout_path TEXT NOT NULL,
-          created_at INTEGER NOT NULL,
-          updated_at INTEGER NOT NULL
-        )
-      `)
-      db.query(
-        "INSERT INTO threads (id, rollout_path, created_at, updated_at) VALUES (?, ?, ?, ?)",
-      ).run(sessionId, indexedPath, 0, 0)
-      db.close()
+      writeThreadsIndex({
+        codexHome,
+        sessionId,
+        rolloutPath: indexedPath,
+      })
 
       await expect(getSession({ codexHome, sessionId })).resolves.toMatchObject(
         {
@@ -142,24 +523,52 @@ describe("CodexSessionStore", () => {
     }
   })
 
-  it("returns missing for absent and unsafe Session IDs", async () => {
+  it("returns MISSING for a safe Session ID with no matching Codex Session", async () => {
     const codexHome = mkdtempSync(join(tmpdir(), "codex-session-store-"))
     try {
       mkdirSync(join(codexHome, "sessions"))
       await expect(
         getSession({ codexHome, sessionId: "missing-session" }),
-      ).resolves.toMatchObject({
+      ).resolves.toEqual({
         id: "missing-session",
         availability: "missing",
         model: null,
         tokens: null,
+        cost: null,
+        createdAt: null,
+        updatedAt: null,
       })
-      await expect(
-        getSession({ codexHome, sessionId: "../outside" }),
-      ).resolves.toMatchObject({
-        id: "../outside",
-        availability: "missing",
-      })
+    } finally {
+      rmSync(codexHome, { recursive: true, force: true })
+    }
+  })
+
+  it("rejects unsafe Session ID path segments without path escape as non-AVAILABLE", async () => {
+    const codexHome = mkdtempSync(join(tmpdir(), "codex-session-store-"))
+    try {
+      mkdirSync(join(codexHome, "sessions"), { recursive: true })
+      // Plant a decoy outside the intended lookup to ensure no escape succeeds.
+      const outside = join(codexHome, "escaped.jsonl")
+      writeFileSync(
+        outside,
+        `${JSON.stringify({
+          type: "session_meta",
+          payload: { id: "escaped" },
+        })}\n`,
+      )
+
+      for (const sessionId of ["", "..", "../escaped", "a/b", "/etc/passwd"]) {
+        await expect(
+          getSession({ codexHome, sessionId }),
+        ).resolves.toMatchObject({
+          id: sessionId.trim() === "" ? "" : sessionId.trim(),
+          availability: "missing",
+          tokens: null,
+        })
+        expect(findCodexSessionRollout({ codexHome, sessionId })).toEqual({
+          kind: "missing",
+        })
+      }
     } finally {
       rmSync(codexHome, { recursive: true, force: true })
     }
@@ -204,7 +613,7 @@ describe("CodexSessionStore", () => {
     }
   })
 
-  it("returns unavailable for corrupt identity or ambiguous rollouts", async () => {
+  it("returns UNAVAILABLE for unusably corrupt Session data", async () => {
     const codexHome = mkdtempSync(join(tmpdir(), "codex-session-store-"))
     try {
       writeScannedRollout({
@@ -215,8 +624,61 @@ describe("CodexSessionStore", () => {
       })
       await expect(
         getSession({ codexHome, sessionId: "corrupt-session" }),
-      ).resolves.toMatchObject({ availability: "unavailable" })
+      ).resolves.toEqual({
+        id: "corrupt-session",
+        availability: "unavailable",
+        model: null,
+        tokens: null,
+        cost: null,
+        createdAt: null,
+        updatedAt: null,
+      })
+    } finally {
+      rmSync(codexHome, { recursive: true, force: true })
+    }
+  })
 
+  it("returns UNAVAILABLE when the uniquely indexed rollout is unreadable", async () => {
+    const codexHome = mkdtempSync(join(tmpdir(), "codex-session-store-"))
+    try {
+      const sessionId = "unreadable-indexed"
+      const sessionsRoot = join(codexHome, "sessions")
+      mkdirSync(sessionsRoot, { recursive: true })
+      const rolloutPath = join(sessionsRoot, "locked-rollout.jsonl")
+      writeFileSync(
+        rolloutPath,
+        `${JSON.stringify({
+          type: "session_meta",
+          payload: { id: sessionId },
+        })}\n`,
+      )
+      chmodSync(rolloutPath, 0)
+      writeThreadsIndex({
+        codexHome,
+        sessionId,
+        rolloutPath,
+      })
+
+      await expect(getSession({ codexHome, sessionId })).resolves.toMatchObject(
+        {
+          id: sessionId,
+          availability: "unavailable",
+          tokens: null,
+        },
+      )
+    } finally {
+      try {
+        chmodSync(join(codexHome, "sessions", "locked-rollout.jsonl"), 0o644)
+      } catch {
+        // Best-effort restore before recursive delete.
+      }
+      rmSync(codexHome, { recursive: true, force: true })
+    }
+  })
+
+  it("returns UNAVAILABLE for ambiguous duplicate rollouts without unique index resolution", async () => {
+    const codexHome = mkdtempSync(join(tmpdir(), "codex-session-store-"))
+    try {
       for (const day of ["02", "03"]) {
         writeScannedRollout({
           codexHome,
@@ -230,7 +692,72 @@ describe("CodexSessionStore", () => {
       }
       await expect(
         getSession({ codexHome, sessionId: "duplicate-session" }),
-      ).resolves.toMatchObject({ availability: "unavailable" })
+      ).resolves.toMatchObject({
+        id: "duplicate-session",
+        availability: "unavailable",
+        tokens: null,
+      })
+    } finally {
+      rmSync(codexHome, { recursive: true, force: true })
+    }
+  })
+
+  it("prefers a unique threads index hit even when filename suffix scan would be ambiguous", async () => {
+    const codexHome = mkdtempSync(join(tmpdir(), "codex-session-store-"))
+    try {
+      const sessionId = "indexed-unique-session"
+      for (const day of ["04", "05"]) {
+        writeScannedRollout({
+          codexHome,
+          partition: join("2026", "01", day),
+          sessionId,
+          raw: `${JSON.stringify({
+            type: "session_meta",
+            payload: { id: sessionId },
+          })}\n`,
+        })
+      }
+      const preferred = join(codexHome, "sessions", "preferred-rollout.jsonl")
+      writeFileSync(
+        preferred,
+        [
+          JSON.stringify({
+            type: "session_meta",
+            payload: { id: sessionId },
+          }),
+          JSON.stringify(
+            tokenCountLine({
+              timestamp: "2026-08-08T05:00:00.000Z",
+              total: {
+                input: 3,
+                output: 1,
+                reasoning: 0,
+                cacheRead: 0,
+                cacheWrite: 0,
+              },
+            }),
+          ),
+        ].join("\n"),
+      )
+      writeThreadsIndex({
+        codexHome,
+        sessionId,
+        rolloutPath: preferred,
+      })
+
+      await expect(getSession({ codexHome, sessionId })).resolves.toMatchObject(
+        {
+          id: sessionId,
+          availability: "available",
+          tokens: {
+            input: 3,
+            output: 1,
+            reasoning: 0,
+            cacheRead: 0,
+            cacheWrite: 0,
+          },
+        },
+      )
     } finally {
       rmSync(codexHome, { recursive: true, force: true })
     }

--- a/packages/codex/test/session-telemetry-layer.spec.ts
+++ b/packages/codex/test/session-telemetry-layer.spec.ts
@@ -124,4 +124,71 @@ describe("CodexSessionTelemetryLive", () => {
       rmSync(codexHome, { recursive: true, force: true })
     }
   })
+
+  it("maps a safe missing Session to MISSING with Codex Build provenance", async () => {
+    const codexHome = mkdtempSync(join(tmpdir(), "codex-telemetry-"))
+    try {
+      mkdirSync(join(codexHome, "sessions"), { recursive: true })
+      await expect(
+        getTelemetry({ codexHome, sessionId: "no-such-session" }),
+      ).resolves.toEqual({
+        id: "no-such-session",
+        availability: "missing",
+        backend: { id: "codex", label: "Codex Build" },
+        model: null,
+        tokens: null,
+        cost: null,
+        createdAt: null,
+        updatedAt: null,
+      })
+    } finally {
+      rmSync(codexHome, { recursive: true, force: true })
+    }
+  })
+
+  it("maps unusable corrupt Session data to UNAVAILABLE with null metrics", async () => {
+    const codexHome = mkdtempSync(join(tmpdir(), "codex-telemetry-"))
+    try {
+      const sessionId = "corrupt-telemetry-session"
+      const sessionDirectory = join(codexHome, "sessions", "2026", "08", "08")
+      mkdirSync(sessionDirectory, { recursive: true })
+      writeFileSync(
+        join(
+          sessionDirectory,
+          `rollout-2026-08-08T01-02-03-${sessionId}.jsonl`,
+        ),
+        "not-json\n",
+      )
+
+      await expect(getTelemetry({ codexHome, sessionId })).resolves.toEqual({
+        id: sessionId,
+        availability: "unavailable",
+        backend: { id: "codex", label: "Codex Build" },
+        model: null,
+        tokens: null,
+        cost: null,
+        createdAt: null,
+        updatedAt: null,
+      })
+    } finally {
+      rmSync(codexHome, { recursive: true, force: true })
+    }
+  })
+
+  it("maps unsafe Session ID path segments to non-AVAILABLE telemetry", async () => {
+    const codexHome = mkdtempSync(join(tmpdir(), "codex-telemetry-"))
+    try {
+      mkdirSync(join(codexHome, "sessions"), { recursive: true })
+      await expect(
+        getTelemetry({ codexHome, sessionId: "../escape" }),
+      ).resolves.toMatchObject({
+        id: "../escape",
+        availability: "missing",
+        backend: { id: "codex", label: "Codex Build" },
+        tokens: null,
+      })
+    } finally {
+      rmSync(codexHome, { recursive: true, force: true })
+    }
+  })
 })


### PR DESCRIPTION
## Why

Issue #911 made Codex Session Telemetry AVAILABLE from on-disk
rollouts, but operators still need correct non-success outcomes:
MISSING when a Session is gone, UNAVAILABLE when data cannot be
trusted, and rejection of path-unsafe Session IDs. Lookup must prefer
a trustworthy threads index and fall back to scanning date-partitioned
rollouts without arbitrary picks or false zero AVAILABLE reports
(#912).

## What changed

- Prefer Codex threads index for rollout location; fall back to a
  unique sessions-tree scan when the index is missing,
  schema-mismatched, stale, or points at unusable content.
- Map safe absent Sessions to MISSING; unreadable, corrupt, or
  ambiguous identity to UNAVAILABLE with null metrics.
- Reject unsafe Session ID segments (absolute paths, `..`, separators,
  empty) before IO, consistent with sibling backends.
- Keep last cumulative `total_token_usage` as Session totals (do not
  sum `last_token_usage`).
- Align index vs scan availability: scan-pattern rollouts with
  mismatched `session_meta` stay UNAVAILABLE whether discovered via
  index or walk; non-scan wrong-session index hits with no alternate
  stay MISSING.
- Exclude already-tried index paths using resolved path equality
  during fallback.
- Expand fixture coverage at the Codex Session store and Session
  Telemetry provider seams.

## Verification

- `bunx nx run-many --targets=typecheck,lint,test --projects=codex
  --skip-nx-cache` — 65 passed, 2 integration tests skipped.

## Limitations

- Live-read only of Codex-owned rollouts; the harness still does not
  persist usage or invent USD cost.
- Export `findCodexSessionRollout` remains a path locator; full
  availability semantics live on `getSession` / the telemetry
  provider.

Closes #912