### PR TITLE
fix(harness): enlarge repos empty guidance and mid-align label chips

### DIFF
--- a/apps/harness/src/ui.ts
+++ b/apps/harness/src/ui.ts
@@ -1138,7 +1138,7 @@ export const ui = {
     "m-0 min-w-0 overflow-hidden text-ellipsis whitespace-nowrap font-mono text-[0.9rem] font-normal tracking-[0.01em] text-ink",
 
   guidanceCode:
-    "inline-block max-w-full overflow-x-auto border-[1.5px] border-ink bg-paper px-[0.4rem] py-[0.18rem] align-baseline font-mono text-[0.78rem] font-medium text-ink",
+    "inline-block max-w-full overflow-x-auto border-[1.5px] border-ink bg-paper px-[0.4rem] py-[0.18rem] align-middle font-mono text-[0.78rem] font-medium text-ink",
 
   repoIssues: "mt-[1.1rem]",
 
@@ -1150,7 +1150,7 @@ export const ui = {
   repoIssuesList: "m-0 grid list-none gap-0 p-0",
 
   repoIssuesEmpty:
-    "m-0 font-mono text-[0.68rem] tracking-[0.08em] text-ink-faint",
+    "m-0 font-mono text-[0.72rem] tracking-[0.08em] text-ink-faint",
 
   repoIssuesUnrefreshed:
     "m-0 font-mono text-[0.68rem] tracking-[0.08em] uppercase text-ink-faint",

--- a/apps/harness/test/repos-interchange.test.ts
+++ b/apps/harness/test/repos-interchange.test.ts
@@ -230,7 +230,13 @@ describe("Interchange phase 4: repos page + blank slate", () => {
       "repoIssuesEmpty:",
       "repoIssuesUnrefreshed:",
     )
+    // Empty guidance is one mono notch above meta chrome (issue #929).
+    expect(emptyStyle).toContain("text-[0.72rem]")
+    expect(emptyStyle).not.toContain("text-[0.68rem]")
     expect(emptyStyle).not.toContain("uppercase")
+    // Inline ready-for-agent chip mid-aligns with surrounding sentence.
+    expect(ui).toMatch(/guidanceCode:[\s\S]*?align-middle/)
+    expect(ui).not.toMatch(/guidanceCode:[\s\S]*?align-baseline/)
     expect(ui).toMatch(/repoIssuesUnrefreshed:[\s\S]*?uppercase/)
   })
 


### PR DESCRIPTION
Why

On the Repos surface, a repository with no relevant issues shows faint
empty-state guidance. That copy was one mono step smaller than nearby
instructional text (same size as "not refreshed" meta chrome), so it was
hard to read. The inline ready-for-agent chip also sat on the baseline
while its bordered box was taller than the line, so it looked off-center
in the sentence.

What changed

- Bump ui.repoIssuesEmpty from text-[0.68rem] to text-[0.72rem]
  (one mono notch).
- Switch shared ui.guidanceCode from align-baseline to align-middle so
  padded border chips mid-align with surrounding prose (including
  credential banners and blank-slate chips).
- Extend the repos interchange source-guard so empty-state size and chip
  alignment stay locked.

No empty-state copy, kicker size, issue-list behavior, or Queue-hint
surface changes.

Verification

- bunx nx test harness — unit/source-guard tests passed, including the
  updated zero-issues empty-state assertions.
- Review of the staged diff: no Standards or Spec findings.

Refs #929

Closes #929