### PR TITLE
fix(ready-for-agent): stop printing paused on add success

### DIFF
--- a/apps/ready-for-agent/README.md
+++ b/apps/ready-for-agent/README.md
@@ -111,8 +111,8 @@ bun run ready-for-agent add /path/to/local/repo
 
 The command inspects the local git repository, calls the harness GraphQL
 endpoint at `http://127.0.0.1:6056/graphql`, and prints the persisted Repository
-fields. The path must be a git repository with a GitHub or GitLab remote, and
-new Repositories are reported as paused. `add` does not start the Harness.
+id, local path, and bare flag. The path must be a git repository with a GitHub
+or GitLab remote. `add` does not start the Harness.
 
 Override the endpoint when the harness is available elsewhere:
 

--- a/apps/ready-for-agent/src/cli.test.ts
+++ b/apps/ready-for-agent/src/cli.test.ts
@@ -139,7 +139,11 @@ describe("operator binary CLI seam", () => {
                 added = repository
                 return {
                   id: "repo-1",
-                  ...repository,
+                  forge: repository.forge,
+                  forgeHost: repository.forgeHost,
+                  projectPath: repository.projectPath,
+                  localPath: repository.localPath,
+                  isBare: repository.isBare,
                 }
               }),
           }),
@@ -162,6 +166,46 @@ describe("operator binary CLI seam", () => {
         forgeHost: "git.drupalcode.org",
         projectPath: "project/oauth_client",
       })
+    }),
+  )
+
+  it.live("add success output does not mention paused", () =>
+    Effect.gen(function* () {
+      const logs: string[] = []
+      const originalLog = console.log
+      console.log = (...args: unknown[]) => {
+        logs.push(args.map(String).join(" "))
+      }
+
+      try {
+        const layer = mockStart.pipe(
+          Layer.provideMerge(mockLocalGit),
+          Layer.provideMerge(
+            Layer.succeed(GraphqlApi, {
+              addRepository: (repository) =>
+                Effect.succeed({
+                  id: "repo-1",
+                  forge: repository.forge,
+                  forgeHost: repository.forgeHost,
+                  projectPath: repository.projectPath,
+                  localPath: repository.localPath,
+                  isBare: repository.isBare,
+                }),
+            }),
+          ),
+        )
+
+        yield* runOperator(["add", "/tmp/repo"], layer)
+
+        const output = logs.join("\n")
+        expect(output).toContain("Added repository owner/repo")
+        expect(output).toContain("id: repo-1")
+        expect(output).toContain("local path: /tmp/repo")
+        expect(output).toContain("bare: false")
+        expect(output).not.toMatch(/paused/i)
+      } finally {
+        console.log = originalLog
+      }
     }),
   )
 

--- a/apps/ready-for-agent/src/cli.ts
+++ b/apps/ready-for-agent/src/cli.ts
@@ -60,7 +60,6 @@ const addRepositoryWorkflow = Effect.fn("Cli.addRepository")(function* (
   yield* Console.log(`  id: ${added.id}`)
   yield* Console.log(`  local path: ${added.localPath}`)
   yield* Console.log(`  bare: ${added.isBare}`)
-  yield* Console.log(`  paused: ${added.paused}`)
 })
 
 const startCommand = Command.make(

--- a/apps/ready-for-agent/src/domain.ts
+++ b/apps/ready-for-agent/src/domain.ts
@@ -7,5 +7,4 @@ export type RepositorySummary = {
   readonly projectPath: string
   readonly localPath: string
   readonly isBare: boolean
-  readonly paused: boolean
 }

--- a/apps/ready-for-agent/src/services/graphql-api.ts
+++ b/apps/ready-for-agent/src/services/graphql-api.ts
@@ -52,7 +52,6 @@ export class GraphqlApi extends Context.Service<
                 projectPath: true,
                 localPath: true,
                 isBare: true,
-                paused: true,
               },
             })
             const added = result.addRepository


### PR DESCRIPTION
Why

`ready-for-agent add` printed `paused: true` on success. New operators
treated that as something they needed to undo, but start/pause is not a
productized CLI or docs surface yet (see #933 item 3 / #936). The line
added noise without an unpause path.

What changed

- Remove the `paused: …` line from add success logging in the operator CLI.
- Drop `paused` from the CLI-local `RepositorySummary` and the add mutation
  GraphQL selection set (nothing else in this package read it).
- Reword the monorepo operator README so it no longer claims new repositories
  are "reported as paused"; describe the fields that are actually printed.
- Add a CLI regression test that success stdout includes id / local path /
  bare and does not mention `paused`.

Non-goals

- No start/pause CLI subcommands or operator pause documentation.
- No change to the API/DB default for repository `paused`.
- No change to automatic issue processing behavior.

Verification

- `bunx nx run ready-for-agent:test` (unit + Effect CLI suites) green.
- Code review of the staged diff: clean against #936 acceptance criteria.

Closes #936