### PR TITLE
fix(work-item-lifecycle): prefer os.tmpdir() for non-bare worktrees

### DIFF
--- a/packages/work-item-lifecycle/src/lib/worktree-names.ts
+++ b/packages/work-item-lifecycle/src/lib/worktree-names.ts
@@ -1,3 +1,5 @@
+import { tmpdir } from "node:os"
+
 const sanitizeSegment = (value: string): string => {
   const cleaned = value
     .toLowerCase()
@@ -70,7 +72,7 @@ export const worktreeParentPath = (input: {
     return `${dirname(localPath)}/${repositoryStem(localPath)}-worktrees`
   }
 
-  const temporaryDirectory = (input.tmpDir ?? "/tmp")
+  const temporaryDirectory = (input.tmpDir ?? tmpdir())
     .trim()
     .replace(/[/\\]+$/, "")
   const path = input.projectPath.split("/").map(sanitizeSegment).join("/")

--- a/packages/work-item-lifecycle/test/worktree-names.spec.ts
+++ b/packages/work-item-lifecycle/test/worktree-names.spec.ts
@@ -1,3 +1,4 @@
+import { tmpdir } from "node:os"
 import {
   repositorySlug,
   workItemBranchName,
@@ -97,6 +98,30 @@ describe("worktree names", () => {
       }),
     ).toBe(
       "/var/tmp/ready-for-agent/acme/widgets/7-wi-01HZZZZZZZZZZZZZZZZZZZZZZZ",
+    )
+  })
+
+  it("defaults non-bare worktrees to os.tmpdir() when tmpDir is omitted", () => {
+    const temporaryDirectory = tmpdir().replace(/[/\\]+$/, "")
+
+    expect(
+      worktreeParentPath({
+        localPath: "/home/berend/src/acme/widgets",
+        isBare: false,
+        projectPath: "acme/widgets",
+      }),
+    ).toBe(`${temporaryDirectory}/ready-for-agent/acme/widgets`)
+
+    expect(
+      workItemWorktreePath({
+        localPath: "/home/berend/src/acme/widgets",
+        isBare: false,
+        projectPath: "acme/widgets",
+        issueNumber: 7,
+        workItemId: "wi-01HZZZZZZZZZZZZZZZZZZZZZZZ",
+      }),
+    ).toBe(
+      `${temporaryDirectory}/ready-for-agent/acme/widgets/7-wi-01HZZZZZZZZZZZZZZZZZZZZZZZ`,
     )
   })
 })


### PR DESCRIPTION
Why

Non-bare Issue Worktrees are documented as living under TMPDIR so the
main working tree is not polluted. Production never passes `tmpDir`, so
the path helper still hard-coded `/tmp` and ignored `$TMPDIR`.

What changed

- Default non-bare parent path in `worktreeParentPath` uses
  `tmpdir()` from `node:os` when `tmpDir` is omitted.
- Explicit `tmpDir` overrides and bare / `.bare` layouts are unchanged.
- Unit coverage asserts the default follows `os.tmpdir()` and keeps
  existing override cases.

Verification

- `worktree-names` unit tests (including under `TMPDIR=/var/tmp`)
- `bunx nx test work-item-lifecycle` (full package)
- Pre-commit (lint/typecheck/affected tests) after import-order fix

Closes #939