### PR TITLE
chore: raise bunfig minimumReleaseAge to 2 days

### DIFF
--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,3 +1,3 @@
 [install]
-# Only install package versions published at least 4 hours ago
-minimumReleaseAge = 14400
+# Only install package versions published at least 2 days ago
+minimumReleaseAge = 172800


### PR DESCRIPTION
## Why

Newly published package versions can be compromised or yanked soon after
release. The install policy already blocked versions younger than 4 hours;
48 hours is a stronger supply-chain guard for Bun installs.

## What changed

In `bunfig.toml`, `minimumReleaseAge` moves from `14400` (4 hours) to
`172800` (2 days). The comment above the setting matches the new policy.
No other install settings were changed.

## Verification

- Confirmed `172800 === 2 * 24 * 60 * 60`
- Confirmed no other repo docs or tests still describe the 4-hour policy
- Review of the staged one-file change found no findings

Closes #943