### PR TITLE
fix(harness): name empty issues guidance by repository forge

### DIFF
--- a/apps/harness/src/home-page-content.tsx
+++ b/apps/harness/src/home-page-content.tsx
@@ -2625,7 +2625,7 @@ function RepositoryIssues({
   if (issues.length === 0) {
     return (
       <p className={ui.repoIssuesEmpty}>
-        Label GitHub/GitLab issues with{" "}
+        Label {repository.forge === "gitlab" ? "GitLab" : "GitHub"} issues with{" "}
         <code className={ui.guidanceCode}>ready-for-agent</code> for them to
         show up here. If an issue is a child issue, the parent itself cannot be
         a child issue too.

--- a/apps/harness/test/repos-interchange.test.ts
+++ b/apps/harness/test/repos-interchange.test.ts
@@ -216,7 +216,10 @@ describe("Interchange phase 4: repos page + blank slate", () => {
       "function RepositoryIssues(",
       "function ParentIssueGroup(",
     )
-    expect(issues).toContain("Label GitHub/GitLab issues with")
+    expect(issues).toContain(
+      'Label {repository.forge === "gitlab" ? "GitLab" : "GitHub"} issues with',
+    )
+    expect(issues).not.toContain("Label GitHub/GitLab issues with")
     expect(issues).toContain("ready-for-agent")
     expect(issues).toContain("for them to\n        show up here.")
     expect(issues).toContain(


### PR DESCRIPTION
When a Repository has no relevant Issues, the repos empty state still
said "Label GitHub/GitLab issues…", which is wrong for a single-forge repo.

- Empty-state copy in `RepositoryIssues` uses `repository.forge` so operators
  see "GitHub" or "GitLab" only.
- Interchange test updated for forge-aware copy and to reject the combined
  string.

Verified with `bunx nx test harness` (all harness unit tests passed).
Uncommitted review found no issues.

Implements #945.

Closes #945