### PR TITLE
feat(harness): green ready plate for Confirm and add after inspect

### DIFF
--- a/apps/harness/src/pipeline-page.tsx
+++ b/apps/harness/src/pipeline-page.tsx
@@ -390,7 +390,11 @@ export function AddRepositoryGuidance({
             <button
               type="submit"
               disabled={busy}
-              className={ui.platePrimary}
+              className={
+                inspection !== null || addLocalRepository.isPending
+                  ? ui.plateReady
+                  : ui.platePrimary
+              }
               aria-busy={busy || undefined}
             >
               {addLocalRepository.isPending

--- a/apps/harness/src/ui.ts
+++ b/apps/harness/src/ui.ts
@@ -1068,7 +1068,7 @@ export const ui = {
     "hover:border-lane-pr hover:bg-lane-pr hover:text-white",
   ),
 
-  /* ---------- Primary plate (§5.3) ---------- */
+  /* ---------- Primary + ready plates (§5.3) ---------- */
 
   /**
    * Riveted stamped-plate twin of plateMini (not solid-ink fill). Hierarchy is
@@ -1085,6 +1085,26 @@ export const ui = {
     "cursor-pointer transition-[background-color,color] duration-100 ease-in-out",
     "hover:bg-[var(--plate-hover)]",
     "disabled:cursor-not-allowed disabled:opacity-55",
+    "disabled:aria-busy:cursor-wait",
+  ),
+
+  /**
+   * Verified / ready-to-commit plate. Same riveted chrome as platePrimary
+   * (rivets, ink border, top bevel, mono uppercase), but PR-green fill and
+   * light text so a successful inspect reads as safe to commit. Reusable for
+   * future “verified, safe to commit” actions; currently wired only on
+   * Confirm and add after repo inspect.
+   */
+  plateReady: cx(
+    "inline-flex items-center justify-center gap-[0.4rem] border-2 border-ink",
+    "bg-lane-pr text-white",
+    plateMiniRivets,
+    "shadow-[inset_0_1px_0_var(--plate-hi)]",
+    "px-[0.95rem] py-[0.46rem]",
+    "font-mono text-[0.68rem] font-bold tracking-[0.12em] uppercase no-underline",
+    "cursor-pointer transition-[background-color,color,filter] duration-100 ease-in-out",
+    "hover:brightness-110",
+    "disabled:cursor-not-allowed disabled:opacity-55 disabled:hover:brightness-100",
     "disabled:aria-busy:cursor-wait",
   ),
 

--- a/apps/harness/test/blank-slate-add-command.test.ts
+++ b/apps/harness/test/blank-slate-add-command.test.ts
@@ -100,6 +100,25 @@ describe("blank-slate add repository command", () => {
     expect(guidance).not.toContain("bg-oxblood")
   })
 
+  test("Confirm and add uses plateReady; Inspect stays platePrimary; Browse stays plateMini", () => {
+    const guidance = addRepositoryGuidanceSource()
+    // Issue #946: green ready plate only after successful inspect / while adding.
+    expect(guidance).toContain("ui.plateReady")
+    expect(guidance).toContain(
+      "inspection !== null || addLocalRepository.isPending",
+    )
+    expect(guidance).toContain("? ui.plateReady")
+    expect(guidance).toContain(": ui.platePrimary")
+    // Browse remains neutral mini plate (className precedes the label).
+    expect(guidance).toMatch(/className=\{ui\.plateMini\}[\s\S]*?Browse…/)
+    // Labels cycle Inspect → Confirm and add → Adding…; success is form clear.
+    expect(guidance).toContain('"Inspect"')
+    expect(guidance).toContain('"Confirm and add"')
+    expect(guidance).toContain('"Adding…"')
+    expect(guidance).toContain('setPath("")')
+    expect(guidance).toContain("setInspection(null)")
+  })
+
   test("shows add-repository guidance in the empty state via shared blank slate", () => {
     const cards = repositoryCardsSource()
     const emptyStart = cards.indexOf("if (repositories.length === 0)")

--- a/apps/harness/test/interchange-phase5.test.ts
+++ b/apps/harness/test/interchange-phase5.test.ts
@@ -183,7 +183,7 @@ describe("Interchange phase 5: dialogs, menus, chrome + Ledger teardown", () => 
     // Slice each recipe so later recipes with bottom bevels don't false-match.
     const platePrimaryBlock = ui.slice(
       ui.indexOf("platePrimary:"),
-      ui.indexOf("/* ---------- Stamps"),
+      ui.indexOf("plateReady:"),
     )
     const plateMiniBlock = ui.slice(
       ui.indexOf("plateMini:"),
@@ -197,6 +197,20 @@ describe("Interchange phase 5: dialogs, menus, chrome + Ledger teardown", () => 
     expect(plateMiniBlock).not.toContain("inset_0_-2px")
     expect(ui).toMatch(/platePrimary:[\s\S]*?disabled:aria-busy:cursor-wait/)
     expect(ui).toMatch(/platePrimary:[\s\S]*?disabled:cursor-not-allowed/)
+    // Ready plate: PR-green fill + light text; same rivets/bevel/disabled chrome.
+    // Slice to the next section so later stamps/lanes do not false-match.
+    const plateReadyBlock = ui.slice(
+      ui.indexOf("plateReady:"),
+      ui.indexOf("/* ---------- Stamps"),
+    )
+    expect(plateReadyBlock).toContain("bg-lane-pr")
+    expect(plateReadyBlock).toContain("text-white")
+    expect(plateReadyBlock).toContain("plateMiniRivets")
+    expect(plateReadyBlock).toContain("inset_0_1px_0_var(--plate-hi)")
+    expect(plateReadyBlock).not.toContain("inset_0_-2px")
+    expect(plateReadyBlock).toContain("hover:brightness-110")
+    expect(plateReadyBlock).toContain("disabled:opacity-55")
+    expect(plateReadyBlock).toContain("disabled:aria-busy:cursor-wait")
     const root = rootSource()
     const home = homeSource()
     expect(root).toContain("aria-busy={updateConfig.isPending || undefined}")

--- a/docs/harness-design-system.md
+++ b/docs/harness-design-system.md
@@ -637,6 +637,13 @@ underline).
   stamped-plate twin of mini** — same `--plate` fill, rivets, and top-only
   bevel (not solid-ink fill). Hierarchy is position/label only so Cancel and
   Save cannot drift. Pending state = label swap ("Saving…"), no spinner.
+- **Ready plate** (`ui.plateReady`): same riveted chrome as primary (rivets,
+  ink border, top bevel, mono uppercase), but **PR-green** (`--lane-pr`) fill
+  and light/white text. Use for **verified, safe-to-commit** actions after a
+  successful check (e.g. **Confirm and add** / **Adding…** on the add-
+  repository form once inspect succeeds). Browse and pre-inspect **Inspect**
+  stay on mini/primary. Hover = slight brightness lift; disabled =
+  `opacity-55` (+ wait cursor when `aria-busy`).
 
 ### 5.4 Icon buttons (pause/start, reset, refresh, collapse, copy)
 


### PR DESCRIPTION
Why:

On the add-repository blank slate, Browse and the submit action shared the
same neutral stamped-plate look. After a successful path inspect it was
unclear that the path was accepted and that the next click would commit
the repository.

What:

- Add ui.plateReady next to platePrimary: same riveted chrome (rivets, ink
  border, top bevel, mono uppercase), PR-green (--lane-pr) fill and white
  text, hover brightness lift, and usual disabled/aria-busy conventions.
- In AddRepositoryGuidance, use plateReady when inspection is non-null or
  add is in flight (Confirm and add / Adding); keep Inspect / Inspecting
  on platePrimary and Browse on plateMini.
- Document the ready plate briefly in docs/harness-design-system.md.
  No other primary CTAs and no success toast.

Addresses #946.

Verification:

- Unit tests: blank-slate-add-command, interchange-phase5, repos-interchange
- bunx biome check on touched harness sources/tests
- bunx nx typecheck harness

Closes #946