### PR TITLE
fix(github-service): diagnose corporate TLS inspection instead of retrying as GitHub failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,6 +239,34 @@ repositories (`gh` for GitHub, `glab` for GitLab) block startup. A
 missing coding agent never does — it shows as Unavailable instead
 (see below).
 
+### Startup fails with "Cannot establish a trusted TLS connection"
+
+Corporate TLS-inspection proxies (Netskope, Zscaler, Palo Alto,
+mitmproxy, and similar) present a private root CA. `git`, `gh`, and
+`curl` usually trust it via the OS keychain, but Ready for Agent runs
+on Bun, which does **not** read that store — every GitHub/GitLab API
+call then fails with a certificate error such as
+`SELF_SIGNED_CERT_IN_CHAIN`.
+
+On startup the harness probes each configured forge API host. When
+TLS trust fails it stops immediately and prints the remedy. Export
+your corporate root CA and point Bun at it with
+`NODE_EXTRA_CA_CERTS` (honoured by the compiled binary as well):
+
+```bash
+# macOS — Netskope example (adjust -c to your proxy CA common name):
+security find-certificate -a -c certadmin -p \
+  /Library/Keychains/System.keychain > ~/.config/corp-ca.pem
+export NODE_EXTRA_CA_CERTS=~/.config/corp-ca.pem
+
+# Linux — use the PEM your IT provides:
+export NODE_EXTRA_CA_CERTS=/path/to/corp-root-ca.pem
+```
+
+Set the variable in your shell profile (or the service unit that
+starts the harness) so it applies on every launch, then restart
+`ready-for-agent`.
+
 ### A labelled issue does not show up
 
 - The issue must carry the `ready-for-agent` label — the harness only

--- a/apps/harness/src/server/ambient-github-layer.ts
+++ b/apps/harness/src/server/ambient-github-layer.ts
@@ -2,9 +2,9 @@ import { Cache, Duration, Effect, Exit, Fiber, Layer, Option } from "effect"
 import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process"
 import {
   type GitHubOperationOptions,
-  type GitHubRepositoryUnavailableError,
   GitHubRequestError,
   GitHubService,
+  type GitHubServiceError,
   type GitHubServiceShape,
   type GitHubThrottledError,
   isGitHubThrottledError,
@@ -14,11 +14,6 @@ import {
   GitHubOperationCoordinator,
   type GitHubOperationOrigin,
 } from "./github-operation-coordinator.js"
-
-type GitHubServiceError =
-  | GitHubRepositoryUnavailableError
-  | GitHubRequestError
-  | GitHubThrottledError
 
 /** Unit key for the process-wide ambient GitHub CLI token cache. */
 const TOKEN_CACHE_KEY = true as const

--- a/apps/harness/src/server/keymaxxer-github-layer.ts
+++ b/apps/harness/src/server/keymaxxer-github-layer.ts
@@ -11,15 +11,19 @@ import {
 import {
   GITHUB_HELPER_AUTHENTICATION_EXIT_CODE,
   GITHUB_HELPER_THROTTLED_EXIT_CODE,
+  GITHUB_HELPER_TLS_TRUST_EXIT_CODE,
   type GitHubHelperOperation,
   type GitHubOperationOptions,
   type GitHubRepository,
   GitHubRepositoryUnavailableError,
   GitHubRequestError,
   GitHubService,
+  type GitHubServiceError,
   type GitHubServiceShape,
   GitHubThrottledError,
+  GitHubTlsTrustError,
   formatGitHubHelperShellCommand,
+  formatTlsTrustRemediation,
   parseGitHubHelperControl,
   resolveGitHubHelperChildSpawn,
 } from "@ready-for-agent/github-service"
@@ -46,11 +50,6 @@ import {
  * automatic visible-tab refresh still observes GitHub changes after expiry.
  */
 export const OPEN_PULL_REQUEST_COUNT_FRESHNESS_MS = 5_000
-
-type GitHubServiceError =
-  | GitHubRepositoryUnavailableError
-  | GitHubRequestError
-  | GitHubThrottledError
 
 interface CountLookup {
   readonly fiber: Fiber.Fiber<number, GitHubServiceError>
@@ -309,6 +308,25 @@ export const keymaxxerGitHubLayer = (options: {
                   input.repository,
                   input.describe,
                 )
+              }
+              if (result.exitCode === GITHUB_HELPER_TLS_TRUST_EXIT_CODE) {
+                const control = parseGitHubHelperControl(result.stderr)
+                if (control?.kind !== "github-tls-trust") {
+                  return yield* requestError(input.repository, input.describe)
+                }
+                const operationMessage = requestError(
+                  input.repository,
+                  input.describe,
+                ).message
+                return yield* new GitHubTlsTrustError({
+                  message: formatTlsTrustRemediation({
+                    host: control.host,
+                    code: control.code,
+                    operationMessage,
+                  }),
+                  host: control.host,
+                  code: control.code,
+                })
               }
               if (result.exitCode !== 0) {
                 return yield* requestError(input.repository, input.describe)

--- a/apps/ready-for-agent/src/forge-tls-preflight.test.ts
+++ b/apps/ready-for-agent/src/forge-tls-preflight.test.ts
@@ -1,0 +1,60 @@
+import { checkForgeTlsTrust } from "./forge-tls-preflight.ts"
+import { describe, expect, setDefaultTimeout, test } from "bun:test"
+
+setDefaultTimeout(15_000)
+
+describe("forge TLS preflight", () => {
+  test("succeeds when every endpoint returns an HTTP response", async () => {
+    let calls = 0
+    const result = await checkForgeTlsTrust({
+      endpoints: [
+        { forge: "github", host: "api.github.com", path: "/" },
+        { forge: "gitlab", host: "gitlab.example", path: "/api/v4/version" },
+      ],
+      fetchImpl: async () => {
+        calls += 1
+        return new Response("ok", { status: 200 })
+      },
+      readIssuer: async () => null,
+    })
+    expect(result).toEqual({ ok: true })
+    expect(calls).toBe(2)
+  })
+
+  test("fails loudly on TLS trust errors and includes remediation", async () => {
+    const openssl = Object.assign(
+      new Error("self-signed certificate in certificate chain"),
+      { code: "SELF_SIGNED_CERT_IN_CHAIN" },
+    )
+    const result = await checkForgeTlsTrust({
+      endpoints: [{ forge: "github", host: "api.github.com", path: "/" }],
+      fetchImpl: async () => {
+        throw new TypeError("fetch failed", { cause: openssl })
+      },
+      readIssuer: async () => "Netskope Inc. / certadmin",
+    })
+    expect(result.ok).toBe(false)
+    if (result.ok) return
+    expect(result.host).toBe("api.github.com")
+    expect(result.code).toBe("SELF_SIGNED_CERT_IN_CHAIN")
+    expect(result.issuer).toBe("Netskope Inc. / certadmin")
+    expect(result.message).toContain("NODE_EXTRA_CA_CERTS")
+    expect(result.message).toContain("Netskope Inc. / certadmin")
+    expect(result.message).toContain("api.github.com")
+  })
+
+  test("ignores non-TLS transport failures so cold start is not blocked", async () => {
+    const result = await checkForgeTlsTrust({
+      endpoints: [{ forge: "github", host: "api.github.com", path: "/" }],
+      fetchImpl: async () => {
+        throw Object.assign(new Error("connect ECONNREFUSED"), {
+          code: "ECONNREFUSED",
+        })
+      },
+      readIssuer: async () => {
+        throw new Error("should not probe issuer for non-TLS failures")
+      },
+    })
+    expect(result).toEqual({ ok: true })
+  })
+})

--- a/apps/ready-for-agent/src/forge-tls-preflight.ts
+++ b/apps/ready-for-agent/src/forge-tls-preflight.ts
@@ -1,0 +1,155 @@
+import * as tls from "node:tls"
+import {
+  findTlsTrustCode,
+  formatTlsTrustRemediation,
+} from "@ready-for-agent/github-service"
+import type { ForgeApiEndpoint } from "./peek-repository-forges.ts"
+
+export type ForgeTlsPreflightFetch = (
+  input: Parameters<typeof fetch>[0],
+  init?: RequestInit,
+) => Promise<Response>
+
+export type ForgeTlsPreflightResult =
+  | { readonly ok: true }
+  | {
+      readonly ok: false
+      readonly host: string
+      readonly code: string
+      readonly issuer: string | null
+      readonly message: string
+    }
+
+export type ForgeTlsPreflightOptions = {
+  readonly endpoints: ReadonlyArray<ForgeApiEndpoint>
+  readonly fetchImpl?: ForgeTlsPreflightFetch
+  readonly timeoutMs?: number
+  /**
+   * Optional issuer probe (defaults to a short `tls.connect` with
+   * `rejectUnauthorized: false` so the presented chain can be read after a
+   * trust failure).
+   */
+  readonly readIssuer?: (host: string) => Promise<string | null>
+}
+
+const DEFAULT_TIMEOUT_MS = 15_000
+
+const parseHostPort = (
+  host: string,
+): { readonly hostname: string; readonly port: number } => {
+  const withPort = /^(.+):(\d+)$/.exec(host)
+  if (withPort?.[1] !== undefined && withPort[2] !== undefined) {
+    const port = Number(withPort[2])
+    if (Number.isSafeInteger(port) && port > 0 && port <= 65_535) {
+      return { hostname: withPort[1], port }
+    }
+  }
+  return { hostname: host, port: 443 }
+}
+
+/**
+ * After a trust failure, reconnect without verification so we can name the
+ * private CA (Netskope / Zscaler / etc.) in the operator message.
+ */
+export const readPresentedCertificateIssuer = (
+  host: string,
+  timeoutMs = 5_000,
+): Promise<string | null> => {
+  const { hostname, port } = parseHostPort(host)
+  return new Promise((resolve) => {
+    let settled = false
+    const finish = (issuer: string | null) => {
+      if (settled) return
+      settled = true
+      resolve(issuer)
+    }
+
+    const socket = tls.connect(
+      {
+        host: hostname,
+        port,
+        servername: hostname,
+        rejectUnauthorized: false,
+        timeout: timeoutMs,
+      },
+      () => {
+        const cert = socket.getPeerCertificate(true)
+        socket.end()
+        finish(formatPeerCertificateIssuer(cert))
+      },
+    )
+    socket.on("error", () => {
+      finish(null)
+    })
+    socket.on("timeout", () => {
+      socket.destroy()
+      finish(null)
+    })
+  })
+}
+
+const readIssuerField = (issuer: object, key: string): string | null => {
+  if (!(key in issuer)) return null
+  const value = Reflect.get(issuer, key)
+  if (typeof value !== "string" || value.trim() === "") return null
+  return value.trim()
+}
+
+/** PeerCertificate.issuer is an OpenSSL name object; read O/CN without casts. */
+const formatPeerCertificateIssuer = (cert: unknown): string | null => {
+  if (cert === null || typeof cert !== "object") return null
+  if (!("issuer" in cert)) return null
+  const issuer = Reflect.get(cert, "issuer")
+  if (issuer === null || typeof issuer !== "object") return null
+  const organization = readIssuerField(issuer, "O")
+  const commonName = readIssuerField(issuer, "CN")
+  if (organization !== null && commonName !== null) {
+    return `${organization} / ${commonName}`
+  }
+  return organization ?? commonName
+}
+
+/**
+ * Cheap HTTPS probe per configured forge API host. Only TLS trust failures
+ * fail the preflight; network blips and HTTP auth errors do not block start.
+ */
+export const checkForgeTlsTrust = async (
+  options: ForgeTlsPreflightOptions,
+): Promise<ForgeTlsPreflightResult> => {
+  const fetchImpl = options.fetchImpl ?? fetch
+  const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS
+  const readIssuer = options.readIssuer ?? readPresentedCertificateIssuer
+
+  for (const endpoint of options.endpoints) {
+    const url = `https://${endpoint.host}${endpoint.path}`
+    try {
+      await fetchImpl(url, {
+        method: "GET",
+        redirect: "manual",
+        signal: AbortSignal.timeout(timeoutMs),
+      })
+      // Any HTTP response means the TLS handshake succeeded.
+    } catch (cause) {
+      const code = findTlsTrustCode(cause)
+      if (code === undefined) {
+        // DNS / connect / timeout: do not block cold start.
+        continue
+      }
+      const issuer = await readIssuer(endpoint.host)
+      const message = formatTlsTrustRemediation({
+        host: endpoint.host,
+        code,
+        issuer,
+      })
+      return {
+        ok: false,
+        host: endpoint.host,
+        code,
+        issuer,
+        message,
+      }
+    }
+  }
+
+  return { ok: true }
+}

--- a/apps/ready-for-agent/src/forge-tls-preflight.ts
+++ b/apps/ready-for-agent/src/forge-tls-preflight.ts
@@ -5,7 +5,7 @@ import {
 } from "@ready-for-agent/github-service"
 import type { ForgeApiEndpoint } from "./peek-repository-forges.ts"
 
-export type ForgeTlsPreflightFetch = (
+type ForgeTlsPreflightFetch = (
   input: Parameters<typeof fetch>[0],
   init?: RequestInit,
 ) => Promise<Response>
@@ -51,7 +51,7 @@ const parseHostPort = (
  * After a trust failure, reconnect without verification so we can name the
  * private CA (Netskope / Zscaler / etc.) in the operator message.
  */
-export const readPresentedCertificateIssuer = (
+const readPresentedCertificateIssuer = (
   host: string,
   timeoutMs = 5_000,
 ): Promise<string | null> => {

--- a/apps/ready-for-agent/src/peek-repository-forges.test.ts
+++ b/apps/ready-for-agent/src/peek-repository-forges.test.ts
@@ -1,7 +1,10 @@
 import { mkdtempSync, rmSync } from "node:fs"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
-import { peekRepositoryForges } from "./peek-repository-forges.ts"
+import {
+  peekForgeApiEndpoints,
+  peekRepositoryForges,
+} from "./peek-repository-forges.ts"
 import { Database } from "bun:sqlite"
 import { afterEach, describe, expect, setDefaultTimeout, test } from "bun:test"
 
@@ -16,7 +19,8 @@ const ensureRepositoryTable = (db: Database): void => {
   db.run(`
     CREATE TABLE IF NOT EXISTS repository (
       id TEXT PRIMARY KEY,
-      forge TEXT NOT NULL DEFAULT 'github'
+      forge TEXT NOT NULL DEFAULT 'github',
+      forge_host TEXT NOT NULL DEFAULT 'github.com'
     )
   `)
 }
@@ -78,5 +82,69 @@ describe("peekRepositoryForges", () => {
       db.close()
     }
     expect(peekRepositoryForges(path)).toEqual(["github"])
+  })
+})
+
+describe("peekForgeApiEndpoints", () => {
+  let roots: string[] = []
+
+  afterEach(() => {
+    for (const root of roots) {
+      rmSync(root, { recursive: true, force: true })
+    }
+    roots = []
+  })
+
+  test("returns no endpoints when there are no Repositories", () => {
+    expect(peekForgeApiEndpoints(":memory:")).toEqual([])
+  })
+
+  test("maps GitHub Repositories to api.github.com once", () => {
+    const { path, root } = createTempDb()
+    roots.push(root)
+    const db = new Database(path, { create: true })
+    try {
+      ensureRepositoryTable(db)
+      db.run(
+        `INSERT INTO repository (id, forge, forge_host) VALUES ('r1', 'github', 'github.com')`,
+      )
+      db.run(
+        `INSERT INTO repository (id, forge, forge_host) VALUES ('r2', 'github', 'github.com')`,
+      )
+    } finally {
+      db.close()
+    }
+    expect(peekForgeApiEndpoints(path)).toEqual([
+      { forge: "github", host: "api.github.com", path: "/" },
+    ])
+  })
+
+  test("includes each distinct GitLab forge host", () => {
+    const { path, root } = createTempDb()
+    roots.push(root)
+    const db = new Database(path, { create: true })
+    try {
+      ensureRepositoryTable(db)
+      db.run(
+        `INSERT INTO repository (id, forge, forge_host) VALUES ('g1', 'gitlab', 'gitlab.com')`,
+      )
+      db.run(
+        `INSERT INTO repository (id, forge, forge_host) VALUES ('g2', 'gitlab', 'git.drupalcode.org')`,
+      )
+      db.run(
+        `INSERT INTO repository (id, forge, forge_host) VALUES ('gh', 'github', 'github.com')`,
+      )
+    } finally {
+      db.close()
+    }
+    expect(peekForgeApiEndpoints(path)).toEqual([
+      { forge: "github", host: "api.github.com", path: "/" },
+      {
+        forge: "gitlab",
+        host: "git.drupalcode.org",
+        path: "/api/v4/version",
+      },
+      { forge: "gitlab", host: "gitlab.com", path: "/api/v4/version" },
+    ])
   })
 })

--- a/apps/ready-for-agent/src/peek-repository-forges.ts
+++ b/apps/ready-for-agent/src/peek-repository-forges.ts
@@ -20,6 +20,21 @@ export type RepositoryForge = "github" | "gitlab"
 
 const REPOSITORY_FORGES: ReadonlyArray<RepositoryForge> = ["github", "gitlab"]
 
+/** HTTPS endpoint a cold-start TLS preflight should probe. */
+export type ForgeApiEndpoint = {
+  readonly forge: RepositoryForge
+  /** Hostname (and optional :port) used for the TLS handshake. */
+  readonly host: string
+  /** Path that yields a cheap HTTP response once TLS succeeds. */
+  readonly path: string
+}
+
+const GITHUB_API_ENDPOINT: ForgeApiEndpoint = {
+  forge: "github",
+  host: "api.github.com",
+  path: "/",
+}
+
 /**
  * Cold-start Forge preflight set from persisted Repositories.
  *
@@ -70,6 +85,97 @@ export const peekRepositoryForges = (
           (typeof count === "number" && count > 0) ||
           (typeof count === "bigint" && count > 0n)
         return hasRows ? ["github"] : []
+      }
+    } finally {
+      db.close()
+    }
+  } catch {
+    return []
+  }
+}
+
+const normalizeHost = (value: string): string => {
+  const trimmed = value.trim().toLowerCase()
+  if (trimmed === "") return trimmed
+  return trimmed.replace(/^www\./, "")
+}
+
+/**
+ * Distinct forge API endpoints for TLS trust preflight.
+ *
+ * GitHub always probes `api.github.com` (one API host for all GitHub.com
+ * Repositories). GitLab probes each distinct `forge_host` (self-hosted
+ * instances differ). Empty/missing databases return no endpoints.
+ */
+export const peekForgeApiEndpoints = (
+  databasePath: string,
+): ReadonlyArray<ForgeApiEndpoint> => {
+  const filePath = resolveFilePath(databasePath)
+  if (filePath === undefined) {
+    return []
+  }
+
+  try {
+    const db = new Database(filePath, { readonly: true, create: false })
+    try {
+      const hasRepositoryTable =
+        db
+          .query(
+            `SELECT name
+           FROM sqlite_master
+           WHERE type = 'table' AND name = 'repository'
+           LIMIT 1`,
+          )
+          .values().length > 0
+      if (!hasRepositoryTable) {
+        return []
+      }
+
+      try {
+        const rows = db
+          .query(
+            `SELECT DISTINCT
+               lower(trim(forge)) AS forge,
+               lower(trim(forge_host)) AS forge_host
+             FROM repository`,
+          )
+          .values()
+        const endpoints: ForgeApiEndpoint[] = []
+        let hasGitHub = false
+        const gitlabHosts = new Set<string>()
+        for (const [forge, forgeHost] of rows) {
+          if (forge === "github") {
+            hasGitHub = true
+            continue
+          }
+          if (forge === "gitlab" && typeof forgeHost === "string") {
+            const host = normalizeHost(forgeHost)
+            if (host !== "") {
+              gitlabHosts.add(host)
+            }
+          }
+        }
+        if (hasGitHub) {
+          endpoints.push(GITHUB_API_ENDPOINT)
+        }
+        for (const host of [...gitlabHosts].sort()) {
+          endpoints.push({
+            forge: "gitlab",
+            host,
+            // Public metadata; succeeds without a token once TLS is trusted.
+            path: "/api/v4/version",
+          })
+        }
+        return endpoints
+      } catch {
+        // Pre-identity schema: non-empty repository table implies GitHub only.
+        const count = db
+          .query(`SELECT COUNT(*) AS count FROM repository`)
+          .values()[0]?.[0]
+        const hasRows =
+          (typeof count === "number" && count > 0) ||
+          (typeof count === "bigint" && count > 0n)
+        return hasRows ? [GITHUB_API_ENDPOINT] : []
       }
     } finally {
       db.close()

--- a/apps/ready-for-agent/src/services/start-harness.ts
+++ b/apps/ready-for-agent/src/services/start-harness.ts
@@ -6,8 +6,12 @@ import {
   resolveUiUrl,
   shouldOpenBrowser,
 } from "../browser-open.ts"
+import { checkForgeTlsTrust } from "../forge-tls-preflight.ts"
 import { checkHostTools } from "../host-tools-preflight.ts"
-import { peekRepositoryForges } from "../peek-repository-forges.ts"
+import {
+  peekForgeApiEndpoints,
+  peekRepositoryForges,
+} from "../peek-repository-forges.ts"
 import { bootStandaloneProduction } from "../standalone-boot.ts"
 import { ApplicationConfig } from "./application-config.ts"
 
@@ -88,6 +92,23 @@ export class StartHarness extends Context.Service<
         )
         if (!result.ok) {
           return yield* new StartHarnessFailed({ detail: result.message })
+        }
+
+        const endpoints = peekForgeApiEndpoints(config.databasePath)
+        if (endpoints.length > 0) {
+          const tls = yield* Effect.tryPromise({
+            try: () => checkForgeTlsTrust({ endpoints }),
+            catch: (cause) =>
+              new StartHarnessFailed({
+                detail:
+                  cause instanceof Error
+                    ? cause.message
+                    : "Forge TLS preflight failed",
+              }),
+          })
+          if (!tls.ok) {
+            return yield* new StartHarnessFailed({ detail: tls.message })
+          }
         }
       })
 

--- a/packages/github-service/src/bin/cli.ts
+++ b/packages/github-service/src/bin/cli.ts
@@ -6,12 +6,15 @@ import {
   GitHubRequestError,
   type GitHubThrottledError,
   isGitHubThrottledError,
+  isGitHubTlsTrustError,
 } from "../lib/errors.js"
 import {
   GITHUB_HELPER_AUTHENTICATION_EXIT_CODE,
   GITHUB_HELPER_THROTTLED_EXIT_CODE,
+  GITHUB_HELPER_TLS_TRUST_EXIT_CODE,
   githubHelperSuccess,
   githubHelperThrottled,
+  githubHelperTlsTrust,
   serializeGitHubHelperControl,
 } from "../lib/github-helper-protocol.js"
 import type { GitHubService } from "../lib/github-service.js"
@@ -85,6 +88,16 @@ export const runGitHubCli = <A, E>(
         if (isGitHubThrottledError(error)) {
           writeThrottle(error)
           process.exitCode = GITHUB_HELPER_THROTTLED_EXIT_CODE
+          return
+        }
+        if (isGitHubTlsTrustError(error)) {
+          // Non-secret host + OpenSSL code only; parent rebuilds remediation.
+          process.stderr.write(
+            `${serializeGitHubHelperControl(
+              githubHelperTlsTrust({ host: error.host, code: error.code }),
+            )}\n`,
+          )
+          process.exitCode = GITHUB_HELPER_TLS_TRUST_EXIT_CODE
           return
         }
         if (error instanceof CliArgumentError) {

--- a/packages/github-service/src/index.ts
+++ b/packages/github-service/src/index.ts
@@ -12,5 +12,6 @@ export {
 export * from "./lib/github-service-test.js"
 export * from "./lib/github-throttle.js"
 export * from "./lib/open-non-draft-pull-request-count.js"
+export * from "./lib/tls-trust.js"
 export * from "./lib/types.js"
 export * from "./lib/user-facing-error.js"

--- a/packages/github-service/src/lib/errors.ts
+++ b/packages/github-service/src/lib/errors.ts
@@ -21,6 +21,24 @@ export class GitHubRequestError extends Schema.TaggedErrorClass<GitHubRequestErr
 ) {}
 
 /**
+ * Permanent TLS certificate trust failure talking to the GitHub API host.
+ * Not retryable for the process lifetime (missing private CA / MITM root).
+ */
+export class GitHubTlsTrustError extends Schema.TaggedErrorClass<GitHubTlsTrustError>()(
+  "GitHubTlsTrustError",
+  {
+    message: Schema.String,
+    /** API hostname that failed trust (typically api.github.com). */
+    host: Schema.String,
+    /** OpenSSL / Node TLS error code (e.g. SELF_SIGNED_CERT_IN_CHAIN). */
+    code: Schema.String,
+    /** Issuer O/CN when preflight could read the presented chain. */
+    issuer: Schema.optional(Schema.NullOr(Schema.String)),
+    cause: Schema.optional(Schema.Defect()),
+  },
+) {}
+
+/**
  * Explicit, non-secret GitHub flow-control evidence. `retryAt` is epoch
  * milliseconds so a process-local coordinator and GraphQL can share it without
  * locale or clock-format ambiguity.
@@ -42,7 +60,16 @@ export const isGitHubThrottledError = (
   "_tag" in value &&
   value._tag === "GitHubThrottledError"
 
+export const isGitHubTlsTrustError = (
+  value: unknown,
+): value is GitHubTlsTrustError =>
+  typeof value === "object" &&
+  value !== null &&
+  "_tag" in value &&
+  value._tag === "GitHubTlsTrustError"
+
 export type GitHubServiceError =
   | GitHubRepositoryUnavailableError
   | GitHubRequestError
+  | GitHubTlsTrustError
   | GitHubThrottledError

--- a/packages/github-service/src/lib/github-helper-protocol.ts
+++ b/packages/github-service/src/lib/github-helper-protocol.ts
@@ -10,6 +10,11 @@ export const GITHUB_HELPER_PROTOCOL_VERSION = 1 as const
 export const GITHUB_HELPER_THROTTLED_EXIT_CODE = 3 as const
 /** Typed helper exit used by the Keymaxxer parent to invalidate auth caches. */
 export const GITHUB_HELPER_AUTHENTICATION_EXIT_CODE = 4 as const
+/**
+ * Permanent TLS certificate trust failure. Non-secret host + OpenSSL code only;
+ * the parent rebuilds operator-facing remediation (no API/token material).
+ */
+export const GITHUB_HELPER_TLS_TRUST_EXIT_CODE = 5 as const
 
 export interface GitHubHelperThrottle {
   readonly retryAt: number
@@ -30,7 +35,18 @@ export interface GitHubHelperThrottled {
   readonly usedFallback: boolean
 }
 
-export type GitHubHelperControl = GitHubHelperSuccess | GitHubHelperThrottled
+/** Non-secret TLS trust evidence for the Keymaxxer parent. */
+export interface GitHubHelperTlsTrust {
+  readonly version: typeof GITHUB_HELPER_PROTOCOL_VERSION
+  readonly kind: "github-tls-trust"
+  readonly host: string
+  readonly code: string
+}
+
+export type GitHubHelperControl =
+  | GitHubHelperSuccess
+  | GitHubHelperThrottled
+  | GitHubHelperTlsTrust
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === "object" && value !== null
@@ -41,6 +57,14 @@ const isThrottle = (value: unknown): value is GitHubHelperThrottle =>
   Number.isSafeInteger(value.retryAt) &&
   value.retryAt > 0 &&
   typeof value.usedFallback === "boolean"
+
+const isTlsTrustFields = (
+  value: Record<string, unknown>,
+): value is { readonly host: string; readonly code: string } =>
+  typeof value.host === "string" &&
+  value.host.trim() !== "" &&
+  typeof value.code === "string" &&
+  value.code.trim() !== ""
 
 /**
  * Strictly recognizes only the current helper protocol. Unknown, malformed,
@@ -79,6 +103,14 @@ export const parseGitHubHelperControl = (
       usedFallback: value.usedFallback,
     }
   }
+  if (value.kind === "github-tls-trust" && isTlsTrustFields(value)) {
+    return {
+      version: GITHUB_HELPER_PROTOCOL_VERSION,
+      kind: "github-tls-trust",
+      host: value.host.trim(),
+      code: value.code.trim(),
+    }
+  }
   return undefined
 }
 
@@ -108,4 +140,14 @@ export const githubHelperThrottled = (
   kind: "github-throttled",
   retryAt: throttle.retryAt,
   usedFallback: throttle.usedFallback,
+})
+
+export const githubHelperTlsTrust = (input: {
+  readonly host: string
+  readonly code: string
+}): GitHubHelperTlsTrust => ({
+  version: GITHUB_HELPER_PROTOCOL_VERSION,
+  kind: "github-tls-trust",
+  host: input.host,
+  code: input.code,
 })

--- a/packages/github-service/src/lib/github-service-live.ts
+++ b/packages/github-service/src/lib/github-service-live.ts
@@ -34,6 +34,7 @@ import {
   GitHubRepositoryUnavailableError,
   GitHubRequestError,
   type GitHubThrottledError,
+  GitHubTlsTrustError,
   isGitHubThrottledError,
 } from "./errors.js"
 import { GitHubService, type GitHubServiceShape } from "./github-service.js"
@@ -41,6 +42,11 @@ import {
   githubThrottleFromResponse,
   githubThrottleFromSuccessfulResponse,
 } from "./github-throttle.js"
+import {
+  findTlsTrustCode,
+  formatTlsTrustRemediation,
+  githubApiHost,
+} from "./tls-trust.js"
 import type {
   GitHubIssueReference,
   GitHubIssueState,
@@ -106,14 +112,40 @@ type GitHubFetch = (
 /** Observes explicit, non-secret quota evidence from successful responses. */
 export type GitHubThrottleObserver = (throttle: GitHubThrottledError) => void
 
+const tlsTrustErrorFromCause = (
+  message: string,
+  cause: unknown,
+): GitHubTlsTrustError | undefined => {
+  const code = findTlsTrustCode(cause)
+  if (code === undefined) {
+    return undefined
+  }
+  const host = githubApiHost()
+  return new GitHubTlsTrustError({
+    message: formatTlsTrustRemediation({
+      host,
+      code,
+      operationMessage: message,
+    }),
+    host,
+    code,
+    cause,
+  })
+}
+
 const githubRequest = <A>(
   message: string,
   request: (signal: AbortSignal) => Promise<A>,
-): Effect.Effect<A, GitHubRequestError | GitHubThrottledError> =>
+): Effect.Effect<
+  A,
+  GitHubRequestError | GitHubThrottledError | GitHubTlsTrustError
+> =>
   Effect.tryPromise({
     try: request,
     catch: (cause) => {
       if (isGitHubThrottledError(cause)) return cause
+      const tlsTrust = tlsTrustErrorFromCause(message, cause)
+      if (tlsTrust !== undefined) return tlsTrust
       const throttle = githubThrottleFromResponse({
         statusCode: cause instanceof GitHubHttpError ? cause.statusCode : 0,
         headers:
@@ -150,7 +182,10 @@ const githubRequest = <A>(
 const githubQuery = <A>(
   message: string,
   request: (signal: AbortSignal) => Promise<A>,
-): Effect.Effect<A, GitHubRequestError | GitHubThrottledError> =>
+): Effect.Effect<
+  A,
+  GitHubRequestError | GitHubThrottledError | GitHubTlsTrustError
+> =>
   githubRequest(message, request).pipe(
     Effect.retry({
       schedule: Schedule.addDelay(Schedule.recurs(2), () =>
@@ -268,7 +303,7 @@ export type LoadPrStatusCheckDiagnostics = (
   signal?: AbortSignal,
 ) => Effect.Effect<
   readonly PrStatusCheckDiagnostic[],
-  GitHubRequestError | GitHubThrottledError
+  GitHubRequestError | GitHubThrottledError | GitHubTlsTrustError
 >
 
 /** Rerun an entire GitHub Actions workflow run. */
@@ -286,7 +321,7 @@ export type ObserveAutomatedReviewEvidence = (
   signal?: AbortSignal,
 ) => Effect.Effect<
   AutomatedReviewEvidenceObservation,
-  GitHubRequestError | GitHubThrottledError
+  GitHubRequestError | GitHubThrottledError | GitHubTlsTrustError
 >
 
 const emptyTerminalChecks: readonly TerminalPrStatusCheck[] = []
@@ -959,6 +994,7 @@ const findOpenPullRequestDetailsImpl = (
   | GitHubApiRepositoryUnavailableError
   | GitHubRequestError
   | GitHubThrottledError
+  | GitHubTlsTrustError
 > =>
   Effect.gen(function* () {
     const result = yield* githubQuery(
@@ -1022,6 +1058,7 @@ const findOpenPullRequestNumberImpl = (
   | GitHubApiRepositoryUnavailableError
   | GitHubRequestError
   | GitHubThrottledError
+  | GitHubTlsTrustError
 > =>
   Effect.gen(function* () {
     // Number-only query: do not require GraphQL id (update paths use details).
@@ -1433,6 +1470,7 @@ const makeGitHubApiService = (
       string | null,
       | GitHubRequestError
       | GitHubThrottledError
+      | GitHubTlsTrustError
       | GitHubApiRepositoryUnavailableError
     > =>
       Effect.gen(function* () {

--- a/packages/github-service/src/lib/open-non-draft-pull-request-count.ts
+++ b/packages/github-service/src/lib/open-non-draft-pull-request-count.ts
@@ -11,15 +11,22 @@
 import {
   GITHUB_HELPER_AUTHENTICATION_EXIT_CODE,
   GITHUB_HELPER_THROTTLED_EXIT_CODE,
+  GITHUB_HELPER_TLS_TRUST_EXIT_CODE,
   type GitHubHelperThrottle,
   githubHelperSuccess,
   githubHelperThrottled,
+  githubHelperTlsTrust,
   serializeGitHubHelperControl,
 } from "./github-helper-protocol.js"
 import {
   githubThrottleFromResponse,
   githubThrottleFromSuccessfulResponse,
 } from "./github-throttle.js"
+import {
+  findTlsTrustCode,
+  formatTlsTrustRemediation,
+  githubApiHost,
+} from "./tls-trust.js"
 
 const GITHUB_GRAPHQL_URL = "https://api.github.com/graphql"
 const PAGE_SIZE = 100
@@ -69,10 +76,17 @@ export type OpenNonDraftPullRequestCountThrottled = {
   readonly usedFallback: boolean
 }
 
+export type OpenNonDraftPullRequestCountTlsTrust = {
+  readonly _tag: "tls-trust"
+  readonly host: string
+  readonly code: string
+}
+
 export type OpenNonDraftPullRequestCountResult =
   | OpenNonDraftPullRequestCountOk
   | OpenNonDraftPullRequestCountUnavailable
   | OpenNonDraftPullRequestCountThrottled
+  | OpenNonDraftPullRequestCountTlsTrust
   | OpenNonDraftPullRequestCountFailed
 
 export type OpenNonDraftPullRequestCountInput = {
@@ -113,6 +127,20 @@ class CountHttpError extends Error {
 class CountThrottledError extends Error {
   constructor(readonly throttle: GitHubHelperThrottle) {
     super("GitHub throttled")
+  }
+}
+
+class CountTlsTrustError extends Error {
+  constructor(
+    readonly host: string,
+    readonly code: string,
+  ) {
+    super(
+      formatTlsTrustRemediation({
+        host,
+        code,
+      }),
+    )
   }
 }
 
@@ -229,6 +257,10 @@ const withTimeoutAndRetry = async <A>(
       return value
     } catch (cause) {
       if (cause instanceof CountThrottledError) throw cause
+      const tlsCode = findTlsTrustCode(cause)
+      if (tlsCode !== undefined) {
+        throw new CountTlsTrustError(githubApiHost(), tlsCode)
+      }
       const statusCode =
         cause instanceof CountHttpError ? cause.statusCode : undefined
       const timedOut =
@@ -338,13 +370,20 @@ export const countOpenNonDraftPullRequestsLite = async (
         usedFallback: cause.throttle.usedFallback,
       }
     }
-    const statusCode =
-      typeof cause === "object" &&
-      cause !== null &&
-      "statusCode" in cause &&
-      typeof (cause as { statusCode: unknown }).statusCode === "number"
-        ? (cause as { statusCode: number }).statusCode
-        : undefined
+    if (cause instanceof CountTlsTrustError) {
+      return {
+        _tag: "tls-trust",
+        host: cause.host,
+        code: cause.code,
+      }
+    }
+    let statusCode: number | undefined
+    if (typeof cause === "object" && cause !== null && "statusCode" in cause) {
+      const raw = Reflect.get(cause, "statusCode")
+      if (typeof raw === "number") {
+        statusCode = raw
+      }
+    }
     const message = `Failed to count open pull requests for ${label}`
     return statusCode === undefined
       ? { _tag: "error", message }
@@ -415,6 +454,15 @@ export const runOpenNonDraftPullRequestCountCli = async (
         exitCode: GITHUB_HELPER_THROTTLED_EXIT_CODE,
         stdout: "",
         stderr: serializeGitHubHelperControl(githubHelperThrottled(result)),
+      }
+    }
+    if (result._tag === "tls-trust") {
+      return {
+        exitCode: GITHUB_HELPER_TLS_TRUST_EXIT_CODE,
+        stdout: "",
+        stderr: serializeGitHubHelperControl(
+          githubHelperTlsTrust({ host: result.host, code: result.code }),
+        ),
       }
     }
     return {

--- a/packages/github-service/src/lib/tls-trust.ts
+++ b/packages/github-service/src/lib/tls-trust.ts
@@ -1,0 +1,108 @@
+/**
+ * TLS trust failures for forge HTTPS (corporate MITM, missing private CA, etc.).
+ *
+ * Bun/Node `fetch` does not read the OS trust store. Operators typically see
+ * `git`/`gh`/`curl` succeed while Ready for Agent fails with OpenSSL codes such
+ * as `SELF_SIGNED_CERT_IN_CHAIN`. These conditions are permanent for the process
+ * lifetime and must not be retried as transient transport errors.
+ */
+
+/** OpenSSL / Node TLS codes that indicate a non-retryable certificate trust failure. */
+export const TLS_TRUST_ERROR_CODES = new Set([
+  "SELF_SIGNED_CERT_IN_CHAIN",
+  "UNABLE_TO_VERIFY_LEAF_SIGNATURE",
+  "DEPTH_ZERO_SELF_SIGNED_CERT",
+  "CERT_HAS_EXPIRED",
+  "CERT_NOT_YET_VALID",
+  "CERT_UNTRUSTED",
+  "CERT_REJECTED",
+  "UNABLE_TO_GET_ISSUER_CERT",
+  "UNABLE_TO_GET_ISSUER_CERT_LOCALLY",
+  "UNABLE_TO_GET_CRL",
+  "CERT_SIGNATURE_FAILURE",
+  "INVALID_CA",
+  "PATH_LENGTH_EXCEEDED",
+  "HOSTNAME_MISMATCH",
+  "ERR_TLS_CERT_ALTNAME_INVALID",
+])
+
+const GITHUB_API_HOST = "api.github.com"
+
+/**
+ * Walk a nested `cause` chain (TypeError fetch failed → OpenSSL error) and
+ * return the first recognized TLS trust code, if any.
+ */
+const readUnknownField = (value: object, key: string): unknown =>
+  key in value ? Reflect.get(value, key) : undefined
+
+export const findTlsTrustCode = (cause: unknown): string | undefined => {
+  const seen = new Set<unknown>()
+  let current: unknown = cause
+  while (current !== undefined && current !== null && !seen.has(current)) {
+    seen.add(current)
+    if (typeof current === "object") {
+      const code = readUnknownField(current, "code")
+      if (typeof code === "string" && TLS_TRUST_ERROR_CODES.has(code)) {
+        return code
+      }
+      current = readUnknownField(current, "cause")
+      continue
+    }
+    break
+  }
+  return undefined
+}
+
+export const isTlsTrustFailure = (cause: unknown): boolean =>
+  findTlsTrustCode(cause) !== undefined
+
+/** Host used by the live GitHub GraphQL/REST client. */
+export const githubApiHost = (): string => GITHUB_API_HOST
+
+export type TlsTrustRemediationInput = {
+  readonly host: string
+  readonly code?: string
+  readonly issuer?: string | null
+  /** Optional operation-level prefix (e.g. "Failed to list Ready-labeled Issues…"). */
+  readonly operationMessage?: string
+}
+
+/**
+ * Operator-facing copy that names corporate TLS inspection and the
+ * `NODE_EXTRA_CA_CERTS` remedy. Bun honours that env var in the compiled binary.
+ */
+export const formatTlsTrustRemediation = (
+  input: TlsTrustRemediationInput,
+): string => {
+  const host = input.host.trim() === "" ? GITHUB_API_HOST : input.host.trim()
+  const issuer =
+    typeof input.issuer === "string" && input.issuer.trim() !== ""
+      ? input.issuer.trim()
+      : null
+  const issuerLine =
+    issuer === null
+      ? "The certificate chain is signed by a private or corporate CA rather than a public CA, which usually means a TLS-inspection proxy (Netskope, Zscaler, Palo Alto, mitmproxy, etc.)."
+      : `The certificate chain is signed by "${issuer}" rather than a public CA, which usually means a corporate TLS-inspection proxy.`
+
+  const lines = [
+    `Cannot establish a trusted TLS connection to ${host}.`,
+    issuerLine,
+    "git/gh/curl trust it via the OS trust store, but Ready for Agent does not read that store.",
+    "Export the root CA and point NODE_EXTRA_CA_CERTS at it:",
+    "  # macOS (Netskope example — adjust -c to match your proxy CA common name):",
+    "  security find-certificate -a -c certadmin -p /Library/Keychains/System.keychain > ~/.config/corp-ca.pem",
+    "  export NODE_EXTRA_CA_CERTS=~/.config/corp-ca.pem",
+    "  # Linux: export NODE_EXTRA_CA_CERTS=/path/to/corp-root-ca.pem",
+  ]
+  if (input.code !== undefined && input.code.trim() !== "") {
+    lines.splice(1, 0, `TLS error code: ${input.code.trim()}.`)
+  }
+  const body = lines.join("\n")
+  if (
+    input.operationMessage !== undefined &&
+    input.operationMessage.trim() !== ""
+  ) {
+    return `${input.operationMessage.trim()}\n${body}`
+  }
+  return body
+}

--- a/packages/github-service/test/github-service.spec.ts
+++ b/packages/github-service/test/github-service.spec.ts
@@ -8,6 +8,7 @@ import {
   GitHubRequestError,
   GitHubService,
   GitHubThrottledError,
+  GitHubTlsTrustError,
   type ReadyLabeledIssue,
   formatUserFacingError,
   makeGitHubServiceFromToken,
@@ -201,6 +202,58 @@ describe("GitHubService live implementation", () => {
       expect((error as GitHubRequestError).statusCode).toBe(401)
       expect(requests).toBe(1)
     }),
+  )
+
+  it.effect(
+    "classifies TLS certificate trust failures as non-retryable GitHubTlsTrustError",
+    () =>
+      Effect.gen(function* () {
+        let requests = 0
+        const openssl = Object.assign(
+          new Error("self-signed certificate in certificate chain"),
+          { code: "SELF_SIGNED_CERT_IN_CHAIN" },
+        )
+        const service = makeGitHubServiceFromToken("token", async () => {
+          requests += 1
+          throw new TypeError("fetch failed", { cause: openssl })
+        })
+
+        const error = yield* service
+          .listReadyIssues(repository)
+          .pipe(Effect.flip)
+
+        expect(error).toBeInstanceOf(GitHubTlsTrustError)
+        expect(error._tag).toBe("GitHubTlsTrustError")
+        expect(error.code).toBe("SELF_SIGNED_CERT_IN_CHAIN")
+        expect(error.host).toBe("api.github.com")
+        expect(error.message).toContain("NODE_EXTRA_CA_CERTS")
+        expect(error.message).toContain("trusted TLS connection")
+        // Permanent for the process: no bounded query retries.
+        expect(requests).toBe(1)
+      }),
+  )
+
+  it.effect(
+    "does not retry UNABLE_TO_VERIFY_LEAF_SIGNATURE as a transient error",
+    () =>
+      Effect.gen(function* () {
+        let requests = 0
+        const openssl = Object.assign(new Error("unable to verify"), {
+          code: "UNABLE_TO_VERIFY_LEAF_SIGNATURE",
+        })
+        const service = makeGitHubServiceFromToken("token", async () => {
+          requests += 1
+          throw new TypeError("fetch failed", { cause: openssl })
+        })
+
+        const error = yield* service
+          .getOpenPullRequestNumber(repository, "rfa/branch")
+          .pipe(Effect.flip)
+
+        expect(error).toBeInstanceOf(GitHubTlsTrustError)
+        expect(error.code).toBe("UNABLE_TO_VERIFY_LEAF_SIGNATURE")
+        expect(requests).toBe(1)
+      }),
   )
 
   it.effect("aborts an in-flight request when interrupted", () =>

--- a/packages/github-service/test/open-non-draft-pull-request-count.spec.ts
+++ b/packages/github-service/test/open-non-draft-pull-request-count.spec.ts
@@ -4,6 +4,7 @@ import { afterEach, describe, expect, test } from "vitest"
 import {
   GITHUB_HELPER_AUTHENTICATION_EXIT_CODE,
   GITHUB_HELPER_THROTTLED_EXIT_CODE,
+  GITHUB_HELPER_TLS_TRUST_EXIT_CODE,
   parseGitHubHelperControl,
 } from "../src/lib/github-helper-protocol.js"
 import {
@@ -160,6 +161,32 @@ describe("countOpenNonDraftPullRequestsLite", () => {
       expect(result.statusCode).toBe(401)
       expect(result.message).not.toContain("bad-token")
     }
+  })
+
+  test("does not retry TLS trust failures and returns tls-trust", async () => {
+    let calls = 0
+    const openssl = Object.assign(
+      new Error("self-signed certificate in certificate chain"),
+      { code: "SELF_SIGNED_CERT_IN_CHAIN" },
+    )
+    const result = await countOpenNonDraftPullRequestsLite({
+      token: "test-token",
+      owner: "acme",
+      name: "widgets",
+      sleepMs: async () => {
+        throw new Error("TLS trust failures must not sleep/retry")
+      },
+      fetchImpl: async () => {
+        calls += 1
+        throw new TypeError("fetch failed", { cause: openssl })
+      },
+    })
+    expect(calls).toBe(1)
+    expect(result).toEqual({
+      _tag: "tls-trust",
+      host: "api.github.com",
+      code: "SELF_SIGNED_CERT_IN_CHAIN",
+    })
   })
 
   test("returns an explicit throttle without retrying a 429 response", async () => {
@@ -357,6 +384,32 @@ describe("runOpenNonDraftPullRequestCountCli", () => {
     )
 
     expect(result.exitCode).toBe(GITHUB_HELPER_AUTHENTICATION_EXIT_CODE)
+  })
+
+  test("serializes TLS trust failures as versioned non-secret control", async () => {
+    const openssl = Object.assign(
+      new Error("self-signed certificate in certificate chain"),
+      { code: "SELF_SIGNED_CERT_IN_CHAIN" },
+    )
+    const result = await runOpenNonDraftPullRequestCountCli(
+      [encode("github"), encode("github.com"), encode("acme/widgets")],
+      {
+        env: { GITHUB_TOKEN: "test-token" },
+        fetchImpl: async () => {
+          throw new TypeError("fetch failed", { cause: openssl })
+        },
+      },
+    )
+
+    expect(result.exitCode).toBe(GITHUB_HELPER_TLS_TRUST_EXIT_CODE)
+    expect(result.stdout).toBe("")
+    expect(parseGitHubHelperControl(result.stderr)).toEqual({
+      version: 1,
+      kind: "github-tls-trust",
+      host: "api.github.com",
+      code: "SELF_SIGNED_CERT_IN_CHAIN",
+    })
+    expect(result.stderr).not.toContain("test-token")
   })
 
   test("exits 1 without a token and does not call GitHub", async () => {

--- a/packages/github-service/test/tls-trust.spec.ts
+++ b/packages/github-service/test/tls-trust.spec.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest"
+import {
+  githubHelperTlsTrust,
+  parseGitHubHelperControl,
+  serializeGitHubHelperControl,
+} from "../src/lib/github-helper-protocol.js"
+import {
+  findTlsTrustCode,
+  formatTlsTrustRemediation,
+  isTlsTrustFailure,
+} from "../src/lib/tls-trust.js"
+
+describe("TLS trust helpers", () => {
+  it("finds nested OpenSSL codes under TypeError fetch failed", () => {
+    const openssl = Object.assign(
+      new Error("self-signed certificate in certificate chain"),
+      { code: "SELF_SIGNED_CERT_IN_CHAIN" },
+    )
+    const fetchFailed = new TypeError("fetch failed", { cause: openssl })
+    expect(findTlsTrustCode(fetchFailed)).toBe("SELF_SIGNED_CERT_IN_CHAIN")
+    expect(isTlsTrustFailure(fetchFailed)).toBe(true)
+  })
+
+  it("returns undefined for ordinary transport failures", () => {
+    expect(findTlsTrustCode(new TypeError("fetch failed"))).toBeUndefined()
+    expect(
+      findTlsTrustCode(
+        Object.assign(new Error("connect ECONNREFUSED"), {
+          code: "ECONNREFUSED",
+        }),
+      ),
+    ).toBeUndefined()
+    expect(isTlsTrustFailure(new Error("boom"))).toBe(false)
+  })
+
+  it("formats remediation that names NODE_EXTRA_CA_CERTS and the host", () => {
+    const message = formatTlsTrustRemediation({
+      host: "api.github.com",
+      code: "SELF_SIGNED_CERT_IN_CHAIN",
+      issuer: "Netskope Inc. / certadmin",
+      operationMessage: "Failed to list Ready-labeled Issues for acme/widgets",
+    })
+    expect(message).toContain(
+      "Failed to list Ready-labeled Issues for acme/widgets",
+    )
+    expect(message).toContain("api.github.com")
+    expect(message).toContain("SELF_SIGNED_CERT_IN_CHAIN")
+    expect(message).toContain("Netskope Inc. / certadmin")
+    expect(message).toContain("NODE_EXTRA_CA_CERTS")
+    expect(message).toContain("OS trust store")
+  })
+
+  it("round-trips non-secret TLS trust helper control records", () => {
+    const serialized = serializeGitHubHelperControl(
+      githubHelperTlsTrust({
+        host: "api.github.com",
+        code: "SELF_SIGNED_CERT_IN_CHAIN",
+      }),
+    )
+    expect(parseGitHubHelperControl(serialized)).toEqual({
+      version: 1,
+      kind: "github-tls-trust",
+      host: "api.github.com",
+      code: "SELF_SIGNED_CERT_IN_CHAIN",
+    })
+    expect(
+      parseGitHubHelperControl(
+        JSON.stringify({
+          version: 1,
+          kind: "github-tls-trust",
+          host: "",
+          code: "SELF_SIGNED_CERT_IN_CHAIN",
+        }),
+      ),
+    ).toBeUndefined()
+  })
+})

--- a/packages/issue-reconciler/src/lib/issue-reconciler.ts
+++ b/packages/issue-reconciler/src/lib/issue-reconciler.ts
@@ -12,6 +12,7 @@ import {
   type GitHubRequestError,
   GitHubService,
   type GitHubThrottledError,
+  type GitHubTlsTrustError,
   type ReadyLabeledIssue,
 } from "@ready-for-agent/github-service"
 import {
@@ -54,6 +55,7 @@ export class ReconciliationMutationError extends Schema.TaggedErrorClass<Reconci
 export type ReconciliationError =
   | GitHubRepositoryUnavailableError
   | GitHubRequestError
+  | GitHubTlsTrustError
   | GitHubThrottledError
   | GitLabProjectUnavailableError
   | GitLabRequestError

--- a/packages/work-item-lifecycle/src/lib/lifecycle-steps.ts
+++ b/packages/work-item-lifecycle/src/lib/lifecycle-steps.ts
@@ -9,6 +9,7 @@ import type {
   GitHubRepositoryUnavailableError,
   GitHubRequestError,
   GitHubThrottledError,
+  GitHubTlsTrustError,
   MergePullRequestResult,
 } from "@ready-for-agent/github-service"
 import type {
@@ -125,6 +126,7 @@ export type LifecycleStepError =
   | DatabaseError
   | RepositoryNotFoundError
   | GitHubRequestError
+  | GitHubTlsTrustError
   | GitHubThrottledError
   | GitHubRepositoryUnavailableError
   | GitLabRequestError


### PR DESCRIPTION
## Why

Corporate TLS-inspection proxies (e.g. Netskope) present a private root CA
that git/gh/curl trust via the OS keychain, but Bun does not. Every GitHub
API fetch failed with SELF_SIGNED_CERT_IN_CHAIN while the harness looked
healthy: poll and Step errors named GitHub, permanent cert failures were
treated as retryable, and there was no startup signal or NODE_EXTRA_CA_CERTS
guidance.

## What changed

- Classify TLS OpenSSL codes as non-retryable GitHubTlsTrustError (no query
  retries).
- Startup forge TLS preflight probes api.github.com and each GitLab forge
  host; fail loudly with issuer when readable and remediation.
- Keymaxxer: helper exit code 5 + non-secret github-tls-trust control; parent
  rebuilds operator remediation.
- Count-lite returns tls-trust; reconciler and lifecycle error unions updated.
- Document NODE_EXTRA_CA_CERTS in README troubleshooting.

## Verification

- github-service unit tests (TLS classification, non-retry, protocol, count)
- github-service typecheck
- ready-for-agent forge TLS / peek-endpoint unit tests
- Pre-commit affected checks (including issue-reconciler error channel)

## Limitations

- Preflight uses an unauthenticated HTTPS probe (TLS handshake only).
- Remediation copy is MITM / NODE_EXTRA_CA_CERTS-centric for all TLS codes.
- Lifecycle step messages keep the 500-char cap; full remedy on preflight and
  uncapped poll logs.

Closes #949