### PR TITLE
fix: preserve error cause chains in logs and Step Run diagnostics

### DIFF
--- a/apps/harness/src/server/ambient-github-layer.ts
+++ b/apps/harness/src/server/ambient-github-layer.ts
@@ -7,6 +7,7 @@ import {
   GitHubService,
   type GitHubServiceShape,
   type GitHubThrottledError,
+  extractErrorCode,
   isGitHubThrottledError,
   makeGitHubServiceFromToken,
 } from "@ready-for-agent/github-service"
@@ -40,11 +41,14 @@ const authenticatedUserCacheKey = (repository: {
     repository.projectPath.toLowerCase(),
   ].join("\0")
 
-const authenticationError = (cause: unknown) =>
-  new GitHubRequestError({
+const authenticationError = (cause: unknown) => {
+  const code = extractErrorCode(cause)
+  return new GitHubRequestError({
     message: "Failed to resolve GitHub CLI authentication",
     cause,
+    ...(code !== undefined ? { code } : {}),
   })
+}
 
 export const ambientGitHubLayer = (options: {
   readonly workspaceRoot: string

--- a/apps/harness/src/server/ambient-gitlab-layer.ts
+++ b/apps/harness/src/server/ambient-gitlab-layer.ts
@@ -1,5 +1,6 @@
 import { Cache, Duration, Effect, Exit, Fiber, Layer } from "effect"
 import { ChildProcessSpawner } from "effect/unstable/process"
+import { extractErrorCode } from "@ready-for-agent/github-service"
 import {
   type GitLabProjectUnavailableError,
   GitLabRequestError,
@@ -12,11 +13,14 @@ import {
 
 type GitLabServiceError = GitLabProjectUnavailableError | GitLabRequestError
 
-const authenticationError = (forgeHost: string, cause: unknown) =>
-  new GitLabRequestError({
+const authenticationError = (forgeHost: string, cause: unknown) => {
+  const code = extractErrorCode(cause)
+  return new GitLabRequestError({
     message: `Failed to resolve GitLab CLI authentication for ${forgeHost}`,
     cause,
+    ...(code !== undefined ? { code } : {}),
   })
+}
 
 export const ambientGitLabLayer = (options: {
   readonly workspaceRoot: string

--- a/apps/harness/src/server/job-worker.ts
+++ b/apps/harness/src/server/job-worker.ts
@@ -19,8 +19,8 @@ import {
 } from "@ready-for-agent/db-service"
 import {
   type GitHubOperationOrigin,
-  formatUserFacingError,
   isGitHubThrottledError,
+  logErrorAnnotations,
 } from "@ready-for-agent/github-service"
 import { GitLabService } from "@ready-for-agent/gitlab-service"
 import {
@@ -83,9 +83,6 @@ const currentWorkerGeneration = (): number => {
   }
   return globalState[workerGenerationKey] ?? 0
 }
-
-const formatLogError = (error: unknown): string =>
-  formatUserFacingError(error, "Unknown error")
 
 const RefreshRepositoryJob = Schema.TaggedStruct("refresh-repository", {
   repositoryId: RepositoryId,
@@ -215,7 +212,7 @@ const runQueuePollLoop = <E, R>(
       const state = yield* claimAndRun.pipe(
         Effect.catch((error) =>
           Effect.logError(`${logLabel} poll failed`, {
-            error: formatLogError(error),
+            ...logErrorAnnotations(error),
           }).pipe(Effect.as("idle" as const)),
         ),
       )
@@ -267,7 +264,7 @@ const finalizeManualRefresh = <A, E>(
       yield* Effect.logError("Refresh Job failed", {
         jobId,
         repositoryId,
-        error: formatLogError(result.failure),
+        ...logErrorAnnotations(result.failure),
       })
       yield* queue.fail(jobId, { retryable: false })
     } else {
@@ -285,7 +282,7 @@ const finalizePollingAutoHeal = <A, E>(
     if (result._tag === "Failure") {
       yield* Effect.logError("Polling Auto-heal Job failed", {
         jobId,
-        error: formatLogError(result.failure),
+        ...logErrorAnnotations(result.failure),
       })
       const delay = yield* sampleBackoff
       yield* queue.postponeKeyed(jobId, delay)
@@ -340,7 +337,7 @@ const finalizeScheduledRefresh = <A, E>(
       yield* Effect.logError("Scheduled Issue poll failed", {
         jobId,
         repositoryId,
-        error: formatLogError(result.failure),
+        ...logErrorAnnotations(result.failure),
       })
     }
 
@@ -489,7 +486,7 @@ const runLifecycleClaimLoop = (
         yield* lifecycle.recoverOrphanedStepRuns.pipe(
           Effect.catch((error) =>
             Effect.logError("Lifecycle orphan recovery failed", {
-              error: formatLogError(error),
+              ...logErrorAnnotations(error),
             }),
           ),
         )
@@ -523,7 +520,7 @@ const runLifecycleClaimLoop = (
         ),
         Effect.catch((error) =>
           Effect.logError("Lifecycle job queue poll failed", {
-            error: formatLogError(error),
+            ...logErrorAnnotations(error),
           }).pipe(Effect.as(Option.none())),
         ),
       )
@@ -556,7 +553,7 @@ const runLifecycleClaimLoop = (
               Effect.logError("Lifecycle Job lease extension failed", {
                 jobId: job.jobId,
                 ...jobContext,
-                error: formatLogError(error),
+                ...logErrorAnnotations(error),
               }).pipe(Effect.as(false)),
           }),
         )
@@ -583,7 +580,7 @@ const runLifecycleClaimLoop = (
                 jobId: job.jobId,
                 workItemId: payload.workItemId,
                 postponedUntil: payload.postponedUntil,
-                error: formatLogError(error),
+                ...logErrorAnnotations(error),
               }),
             ),
             Effect.ignore,
@@ -597,7 +594,7 @@ const runLifecycleClaimLoop = (
           Effect.logError("Work Item Lifecycle Job failed", {
             jobId: job.jobId,
             stepRunId: payload.stepRunId,
-            error: formatLogError(error),
+            ...logErrorAnnotations(error),
           }),
         ),
         Effect.ignore,
@@ -669,7 +666,7 @@ export const startJobWorker = Effect.fn("JobWorker.startJobWorker")(function* (
     Effect.catch((error) =>
       Effect.logError(
         "Failed to interrupt prior-process running Step Runs on startup",
-        { error: formatLogError(error) },
+        logErrorAnnotations(error),
       ),
     ),
   )

--- a/packages/db-schema/drizzle/20260811120000_step_run_reason_detail/migration.sql
+++ b/packages/db-schema/drizzle/20260811120000_step_run_reason_detail/migration.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `step_run` ADD `reason_detail` text;

--- a/packages/db-schema/src/schema.ts
+++ b/packages/db-schema/src/schema.ts
@@ -363,6 +363,11 @@ export const stepRun = snakeCase.table(
     finishedAt: integer({ mode: "number" }),
     reasonCode: text(),
     reasonMessage: text(),
+    /**
+     * Optional JSON diagnostic payload for failed Step Runs (cause chain +
+     * machine-readable code). Operator-facing summary stays in reasonMessage.
+     */
+    reasonDetail: text(),
     /** Present exactly when this finished Step Run was postponed for GitHub. */
     postponedUntil: integer({ mode: "number" }),
     /**

--- a/packages/db/test/run-migrations.spec.ts
+++ b/packages/db/test/run-migrations.spec.ts
@@ -104,7 +104,23 @@ describe("runMigrations", () => {
           { name: "20260730140857_unfinished_work_item_index" },
           { name: "20260807100000_postponed_step_runs" },
           { name: "20260808093000_explicit_agent_backend_selection" },
+          { name: "20260811120000_step_run_reason_detail" },
         ])
+      }).pipe(Effect.provide(SqliteTest)),
+    )
+  })
+
+  it("adds Step Run reason_detail for failure diagnostics", async () => {
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        const sql = yield* SqlClient.SqlClient
+        yield* runMigrations(defaultMigrationsFolder)
+        const columns = (yield* sql.unsafe(
+          `PRAGMA table_info(step_run)`,
+        )) as readonly { readonly name: string }[]
+        const names = new Set(columns.map((column) => column.name))
+        expect(names.has("reason_detail")).toBe(true)
+        expect(names.has("reason_message")).toBe(true)
       }).pipe(Effect.provide(SqliteTest)),
     )
   })

--- a/packages/github-service/src/index.ts
+++ b/packages/github-service/src/index.ts
@@ -1,5 +1,6 @@
 export { githubServiceBinScriptPath } from "./bin-script-path.js"
 export * from "./lib/automated-review-evidence.js"
+export * from "./lib/error-cause-chain.js"
 export * from "./lib/errors.js"
 export * from "./lib/github-helper-process.js"
 export * from "./lib/github-helper-protocol.js"

--- a/packages/github-service/src/lib/error-cause-chain.ts
+++ b/packages/github-service/src/lib/error-cause-chain.ts
@@ -1,0 +1,172 @@
+import {
+  formatUserFacingError,
+  sanitizeUserFacingText,
+} from "./user-facing-error.js"
+
+/** One link in a nested `cause` chain, for structured logs and Step Run detail. */
+export type CauseChainLink = {
+  readonly name?: string
+  readonly code?: string
+  readonly message?: string
+}
+
+/** Durable diagnostic payload stored on `step_run.reason_detail`. */
+export type StepRunReasonDetail = {
+  readonly causeChain: readonly CauseChainLink[]
+  readonly code?: string
+}
+
+const DEFAULT_MAX_DEPTH = 8
+const LINK_MESSAGE_MAX = 500
+
+const asRecord = (value: unknown): Record<string, unknown> | null =>
+  typeof value === "object" && value !== null
+    ? (value as Record<string, unknown>)
+    : null
+
+const readString = (value: unknown): string | undefined => {
+  if (typeof value !== "string") return undefined
+  const trimmed = value.trim()
+  return trimmed.length > 0 ? trimmed : undefined
+}
+
+const readCode = (value: unknown): string | undefined => {
+  if (typeof value === "string") {
+    const trimmed = value.trim()
+    return trimmed.length > 0 ? trimmed : undefined
+  }
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return String(value)
+  }
+  return undefined
+}
+
+const linkFromValue = (value: unknown): CauseChainLink | null => {
+  if (typeof value === "string") {
+    const message = sanitizeUserFacingText(value, LINK_MESSAGE_MAX)
+    return message.length > 0 ? { message } : null
+  }
+  if (typeof value === "number" || typeof value === "boolean") {
+    return { message: String(value) }
+  }
+
+  const record = asRecord(value)
+  if (record === null) return null
+
+  const name =
+    readString(record.name) ??
+    (typeof record._tag === "string" ? readString(record._tag) : undefined)
+  // Effect TimeoutError has no numeric/string code field; treat the tag as the
+  // machine-readable discriminator so logs and Step Runs can group timeouts.
+  const code =
+    readCode(record.code) ?? (name === "TimeoutError" ? "TIMEOUT" : undefined)
+  const rawMessage = readString(record.message)
+  const message =
+    rawMessage === undefined
+      ? undefined
+      : sanitizeUserFacingText(rawMessage, LINK_MESSAGE_MAX)
+
+  if (name === undefined && code === undefined && message === undefined) {
+    return null
+  }
+
+  return {
+    ...(name !== undefined ? { name } : {}),
+    ...(code !== undefined ? { code } : {}),
+    ...(message !== undefined && message.length > 0 ? { message } : {}),
+  }
+}
+
+const nextCause = (value: unknown): unknown => {
+  const record = asRecord(value)
+  if (record === null) return undefined
+  if ("cause" in record && record.cause !== undefined) {
+    return record.cause
+  }
+  // AggregateError and similar multi-cause carriers.
+  if (Array.isArray(record.errors) && record.errors.length > 0) {
+    return record.errors[0]
+  }
+  return undefined
+}
+
+/**
+ * Flatten nested `cause` / AggregateError chains into structured links.
+ * Does not produce a formatted blob — each link keeps `name` / `code` / `message`.
+ */
+export const extractCauseChain = (
+  error: unknown,
+  maxDepth = DEFAULT_MAX_DEPTH,
+): readonly CauseChainLink[] => {
+  const chain: CauseChainLink[] = []
+  const seen = new Set<unknown>()
+  let current: unknown = error
+  let depth = 0
+
+  while (
+    current !== undefined &&
+    current !== null &&
+    depth < maxDepth &&
+    !seen.has(current)
+  ) {
+    seen.add(current)
+    const link = linkFromValue(current)
+    if (link !== null) {
+      chain.push(link)
+    }
+    current = nextCause(current)
+    depth += 1
+  }
+
+  return chain
+}
+
+/** First machine-readable `code` found walking the cause chain. */
+export const extractErrorCode = (error: unknown): string | undefined => {
+  for (const link of extractCauseChain(error)) {
+    if (link.code !== undefined) {
+      return link.code
+    }
+  }
+  return undefined
+}
+
+export const buildReasonDetail = (
+  error: unknown,
+): StepRunReasonDetail | null => {
+  const causeChain = extractCauseChain(error)
+  const code = extractErrorCode(error)
+  if (causeChain.length === 0 && code === undefined) {
+    return null
+  }
+  return {
+    causeChain,
+    ...(code !== undefined ? { code } : {}),
+  }
+}
+
+export const serializeReasonDetail = (
+  detail: StepRunReasonDetail | null,
+): string | null => (detail === null ? null : JSON.stringify(detail))
+
+/**
+ * Structured log annotations for a failure: short human `error` plus
+ * `causeChain` / optional `code` so operators can distinguish TLS, auth,
+ * timeout, and transport failures without prose parsing.
+ */
+export const logErrorAnnotations = (
+  error: unknown,
+  fallback = "Unknown error",
+): {
+  readonly error: string
+  readonly causeChain: readonly CauseChainLink[]
+  readonly code?: string
+} => {
+  const causeChain = extractCauseChain(error)
+  const code = extractErrorCode(error)
+  return {
+    error: formatUserFacingError(error, fallback),
+    causeChain,
+    ...(code !== undefined ? { code } : {}),
+  }
+}

--- a/packages/github-service/src/lib/errors.ts
+++ b/packages/github-service/src/lib/errors.ts
@@ -15,6 +15,11 @@ export class GitHubRequestError extends Schema.TaggedErrorClass<GitHubRequestErr
     message: Schema.String,
     cause: Schema.optional(Schema.Defect()),
     statusCode: Schema.optional(Schema.Finite),
+    /**
+     * Machine-readable discriminator lifted from the nested cause chain
+     * (e.g. `SELF_SIGNED_CERT_IN_CHAIN`, `ENOTFOUND`) when available.
+     */
+    code: Schema.optional(Schema.String),
     /** Whether the transport failure may receive the bounded query retry. */
     retryable: Schema.optional(Schema.Boolean),
   },

--- a/packages/github-service/src/lib/github-service-live.ts
+++ b/packages/github-service/src/lib/github-service-live.ts
@@ -30,6 +30,7 @@ import {
   isRecognizedAutomatedReviewerLogin,
   isRecognizedAutomatedReviewerName,
 } from "./automated-review-evidence.js"
+import { extractErrorCode } from "./error-cause-chain.js"
 import {
   GitHubRepositoryUnavailableError,
   GitHubRequestError,
@@ -121,9 +122,11 @@ const githubRequest = <A>(
         message: cause instanceof Error ? cause.message : "",
       })
       if (throttle !== undefined) return throttle
+      const code = extractErrorCode(cause)
       return new GitHubRequestError({
         message,
         cause,
+        ...(code !== undefined ? { code } : {}),
         ...(cause instanceof GitHubHttpError
           ? {
               statusCode: cause.statusCode,
@@ -141,6 +144,7 @@ const githubRequest = <A>(
         new GitHubRequestError({
           message: `${message} timed out`,
           cause,
+          code: "TIMEOUT",
           retryable: true,
         }),
       ),
@@ -330,7 +334,14 @@ const decodeGitHubResponse = <S extends { readonly Type: unknown }>(
 ): Effect.Effect<S["Type"], GitHubRequestError> =>
   Effect.try({
     try: () => decodeSync(schema, value),
-    catch: (cause) => new GitHubRequestError({ message, cause }),
+    catch: (cause) => {
+      const code = extractErrorCode(cause)
+      return new GitHubRequestError({
+        message,
+        cause,
+        ...(code !== undefined ? { code } : {}),
+      })
+    },
   })
 
 const GitHubIssueStateSchema = Schema.Literals(["OPEN", "CLOSED"])

--- a/packages/github-service/test/github-service.spec.ts
+++ b/packages/github-service/test/github-service.spec.ts
@@ -9,10 +9,15 @@ import {
   GitHubService,
   GitHubThrottledError,
   type ReadyLabeledIssue,
+  buildReasonDetail,
+  extractCauseChain,
+  extractErrorCode,
   formatUserFacingError,
+  logErrorAnnotations,
   makeGitHubServiceFromToken,
   makeGitHubServiceTest,
   sanitizeUserFacingText,
+  serializeReasonDetail,
   stripAnsi,
 } from "../src/index.js"
 import { GenqlError } from "../src/internal/generated/runtime/error.js"
@@ -3880,6 +3885,71 @@ describe("user-facing error formatting", () => {
     expect(formatUserFacingError(error, "fallback")).toBe(
       "Failed to get pull request check status for acme/widgets",
     )
+  })
+})
+
+describe("error cause chain", () => {
+  it("walks nested causes and surfaces the leaf code", () => {
+    const leaf = Object.assign(
+      new Error("self-signed certificate in certificate chain"),
+      {
+        code: "SELF_SIGNED_CERT_IN_CHAIN",
+      },
+    )
+    const transport = new TypeError("fetch failed", { cause: leaf })
+    const wrapped = new GitHubRequestError({
+      message: "Failed to list Ready-labeled Issues for acme/widgets",
+      cause: transport,
+      code: "SELF_SIGNED_CERT_IN_CHAIN",
+    })
+
+    expect(extractErrorCode(wrapped)).toBe("SELF_SIGNED_CERT_IN_CHAIN")
+    expect(extractCauseChain(wrapped)).toEqual([
+      {
+        name: "GitHubRequestError",
+        code: "SELF_SIGNED_CERT_IN_CHAIN",
+        message: "Failed to list Ready-labeled Issues for acme/widgets",
+      },
+      {
+        name: "TypeError",
+        message: "fetch failed",
+      },
+      {
+        name: "Error",
+        code: "SELF_SIGNED_CERT_IN_CHAIN",
+        message: "self-signed certificate in certificate chain",
+      },
+    ])
+
+    const annotations = logErrorAnnotations(wrapped)
+    expect(annotations.error).toBe(
+      "Failed to list Ready-labeled Issues for acme/widgets",
+    )
+    expect(annotations.code).toBe("SELF_SIGNED_CERT_IN_CHAIN")
+    expect(annotations.causeChain).toHaveLength(3)
+
+    const detail = buildReasonDetail(wrapped)
+    expect(detail).not.toBeNull()
+    expect(detail?.code).toBe("SELF_SIGNED_CERT_IN_CHAIN")
+    expect(JSON.parse(serializeReasonDetail(detail)!)).toEqual(detail)
+  })
+
+  it("returns an empty chain for uninformative values", () => {
+    expect(extractCauseChain(null)).toEqual([])
+    expect(extractCauseChain(undefined)).toEqual([])
+    expect(extractErrorCode({})).toBeUndefined()
+    expect(buildReasonDetail(null)).toBeNull()
+  })
+
+  it("maps Effect TimeoutError to code TIMEOUT", () => {
+    const timeout = Object.assign(new Error(), {
+      name: "TimeoutError",
+      _tag: "TimeoutError",
+    })
+    expect(extractErrorCode(timeout)).toBe("TIMEOUT")
+    expect(extractCauseChain(timeout)).toEqual([
+      { name: "TimeoutError", code: "TIMEOUT" },
+    ])
   })
 })
 

--- a/packages/gitlab-service/src/lib/errors.ts
+++ b/packages/gitlab-service/src/lib/errors.ts
@@ -15,5 +15,10 @@ export class GitLabRequestError extends Schema.TaggedErrorClass<GitLabRequestErr
     message: Schema.String,
     cause: Schema.optional(Schema.Defect()),
     statusCode: Schema.optional(Schema.Finite),
+    /**
+     * Machine-readable discriminator lifted from the nested cause chain
+     * when available (e.g. TLS or DNS codes).
+     */
+    code: Schema.optional(Schema.String),
   },
 ) {}

--- a/packages/gitlab-service/src/lib/gitlab-service-live.ts
+++ b/packages/gitlab-service/src/lib/gitlab-service-live.ts
@@ -9,13 +9,14 @@ import {
   Result,
   Schema,
 } from "effect"
-import type {
-  MergePullRequestResult,
-  PrStatusCheckDiagnostic,
-  PullRequestCheckStatus,
-  PullRequestLifecycleStatus,
-  PullRequestMergeability,
-  TerminalPrStatusCheck,
+import {
+  type MergePullRequestResult,
+  type PrStatusCheckDiagnostic,
+  type PullRequestCheckStatus,
+  type PullRequestLifecycleStatus,
+  type PullRequestMergeability,
+  type TerminalPrStatusCheck,
+  extractErrorCode,
 } from "@ready-for-agent/github-service"
 import { GitLabProjectUnavailableError, GitLabRequestError } from "./errors.js"
 import {
@@ -451,14 +452,17 @@ const apiBase = (repository: GitLabRepository): string =>
 const projectApiPath = (repository: GitLabRepository): string =>
   `/projects/${encodeURIComponent(repository.projectPath)}`
 
-const requestError = (message: string, cause: unknown): GitLabRequestError =>
-  new GitLabRequestError({
+const requestError = (message: string, cause: unknown): GitLabRequestError => {
+  const code = extractErrorCode(cause)
+  return new GitLabRequestError({
     message,
     cause,
+    ...(code !== undefined ? { code } : {}),
     ...(cause instanceof GitLabHttpError
       ? { statusCode: cause.statusCode }
       : {}),
   })
+}
 
 const decode = <S extends { readonly Type: unknown }>(
   schema: S & Parameters<typeof Schema.decodeUnknownSync>[0],

--- a/packages/work-item-lifecycle/src/lib/create-pr.ts
+++ b/packages/work-item-lifecycle/src/lib/create-pr.ts
@@ -7,6 +7,7 @@ import {
   type GitHubRepository,
   GitHubService,
   isGitHubThrottledError,
+  logErrorAnnotations,
 } from "@ready-for-agent/github-service"
 import {
   type GitLabRepository,
@@ -233,6 +234,8 @@ const findExistingOpenPr = (
 /**
  * Soft lookup: transport/API failures become null so callers can fall through
  * to create-number acceptance or agent repair without aborting the step.
+ * Failures are still logged with the cause chain so "lookup broke" is not
+ * silent and indistinguishable from a genuine empty result.
  */
 const softFindExistingOpenPr = (
   context: LifecycleStepContext,
@@ -241,7 +244,18 @@ const softFindExistingOpenPr = (
 ) =>
   findExistingOpenPr(context, repository, branch).pipe(
     Effect.catch((error) =>
-      isGitHubThrottledError(error) ? Effect.fail(error) : Effect.succeed(null),
+      isGitHubThrottledError(error)
+        ? Effect.fail(error)
+        : Effect.logWarning(
+            "Soft open-PR lookup failed; treating as not found",
+            {
+              step: "create_pr",
+              repositoryId: context.repositoryId,
+              projectPath: repository.projectPath,
+              branch,
+              ...logErrorAnnotations(error),
+            },
+          ).pipe(Effect.as(null)),
     ),
   )
 

--- a/packages/work-item-lifecycle/src/lib/work-item-lifecycle.ts
+++ b/packages/work-item-lifecycle/src/lib/work-item-lifecycle.ts
@@ -29,9 +29,12 @@ import {
   GitHubService,
   type GitHubThrottledError,
   type PullRequestLifecycleStatus,
+  buildReasonDetail,
   formatUserFacingError,
   isGitHubThrottledError,
+  logErrorAnnotations,
   sanitizeUserFacingText,
+  serializeReasonDetail,
 } from "@ready-for-agent/github-service"
 import { GitLabService } from "@ready-for-agent/gitlab-service"
 import {
@@ -3226,6 +3229,15 @@ export const makeWorkItemLifecycleLive = (
             terminalFailure,
           } = input
 
+          const failureSource = Cause.squash(input.cause)
+          const failureAnnotations = logErrorAnnotations(
+            failureSource,
+            reasonMessage,
+          )
+          const reasonDetail = serializeReasonDetail(
+            buildReasonDetail(failureSource),
+          )
+
           yield* Effect.logError("Lifecycle Step handler failed", {
             workItemId: workItem.id,
             stepRunId: stepRun.id,
@@ -3233,6 +3245,10 @@ export const makeWorkItemLifecycleLive = (
             reasonCode,
             reasonMessage,
             terminal: terminalFailure !== undefined,
+            causeChain: failureAnnotations.causeChain,
+            ...(failureAnnotations.code !== undefined
+              ? { code: failureAnnotations.code }
+              : {}),
           })
 
           yield* sql
@@ -3244,9 +3260,17 @@ export const makeWorkItemLifecycleLive = (
                      finished_at = ?,
                      reason_code = ?,
                      reason_message = ?,
+                     reason_detail = ?,
                      updated_at = ?
                  WHERE id = ? AND status = 'running'`,
-                  [now, reasonCode, reasonMessage, now, stepRun.id],
+                  [
+                    now,
+                    reasonCode,
+                    reasonMessage,
+                    reasonDetail,
+                    now,
+                    stepRun.id,
+                  ],
                 )
 
                 if (terminalFailure !== undefined) {

--- a/packages/work-item-lifecycle/test/create-pr.spec.ts
+++ b/packages/work-item-lifecycle/test/create-pr.spec.ts
@@ -2,7 +2,7 @@ import { mkdtemp, rm, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { BunServices } from "@effect/platform-bun"
-import { Duration, Effect, Layer } from "effect"
+import { Duration, Effect, Layer, Logger } from "effect"
 import {
   type ActiveAgentBackend,
   AgentBackend,
@@ -687,38 +687,78 @@ describe("createPr", () => {
     withTemp(async (root) => {
       let continueCalls = 0
       let findCalls = 0
-      const result = await run(createPr(baseContext(root)), {
-        keymaxxer: stubKeymaxxer({
-          findSecret: () => Effect.succeed("GITHUB_TOKEN_ACME_WIDGETS"),
-          runWithSecrets: () =>
-            Effect.succeed({ exitCode: 0, stdout: "", stderr: "" }),
-        }),
-        github: stubGitHub({
-          findOpenPullRequestNumber: () => {
-            findCalls += 1
-            if (findCalls === 1) {
-              return Effect.succeed(null)
-            }
-            return Effect.fail(
-              new GitHubRequestError({ message: "lookup timeout" }),
-            )
-          },
-          createDraftPullRequest: () => Effect.succeed(444),
-        }),
-        opencode: stubOpencode({
-          continueTurn: () => {
-            continueCalls += 1
-            return Effect.succeed({
-              sessionId: "ses",
-              assistantText: "",
-            })
-          },
-        }),
+      const logs: unknown[] = []
+      const logger = Logger.make(({ message }) => {
+        logs.push(message)
       })
+      const leaf = Object.assign(new Error("self-signed certificate"), {
+        code: "SELF_SIGNED_CERT_IN_CHAIN",
+      })
+      const result = await Effect.runPromise(
+        createPr(baseContext(root)).pipe(
+          Effect.provide(
+            Layer.mergeAll(
+              stubDb,
+              stubGitHub({
+                findOpenPullRequestNumber: () => {
+                  findCalls += 1
+                  if (findCalls === 1) {
+                    return Effect.succeed(null)
+                  }
+                  return Effect.fail(
+                    new GitHubRequestError({
+                      message: "lookup timeout",
+                      cause: leaf,
+                      code: "SELF_SIGNED_CERT_IN_CHAIN",
+                    }),
+                  )
+                },
+                createDraftPullRequest: () => Effect.succeed(444),
+              }),
+              stubGitLab(),
+              stubKeymaxxer({
+                findSecret: () => Effect.succeed("GITHUB_TOKEN_ACME_WIDGETS"),
+                runWithSecrets: () =>
+                  Effect.succeed({ exitCode: 0, stdout: "", stderr: "" }),
+              }),
+              stubOpencode({
+                continueTurn: () => {
+                  continueCalls += 1
+                  return Effect.succeed({
+                    sessionId: "ses",
+                    assistantText: "",
+                  })
+                },
+              }),
+              stubActiveAgentBackendLayer(),
+              Logger.layer([logger]),
+            ),
+          ),
+          Effect.provide(PlatformLayer),
+        ),
+      )
 
       expect(result.pullRequestNumber).toBe(444)
       expect(result.completion).toBe("native")
       expect(continueCalls).toBe(0)
+      expect(logs).toContainEqual([
+        "Soft open-PR lookup failed; treating as not found",
+        expect.objectContaining({
+          step: "create_pr",
+          code: "SELF_SIGNED_CERT_IN_CHAIN",
+          causeChain: expect.arrayContaining([
+            expect.objectContaining({
+              name: "GitHubRequestError",
+              code: "SELF_SIGNED_CERT_IN_CHAIN",
+              message: "lookup timeout",
+            }),
+            expect.objectContaining({
+              code: "SELF_SIGNED_CERT_IN_CHAIN",
+              message: "self-signed certificate",
+            }),
+          ]),
+        }),
+      ])
     }))
 
   it("treats indeterminate create as success when lookup finds the PR", () =>

--- a/packages/work-item-lifecycle/test/work-item-lifecycle.spec.ts
+++ b/packages/work-item-lifecycle/test/work-item-lifecycle.spec.ts
@@ -8296,11 +8296,20 @@ describe("WorkItemLifecycle", () => {
     })
 
     it("records typed handler failure as Failed Step Run and leaves the pending step", () => {
+      const leaf = Object.assign(
+        new Error("self-signed certificate in certificate chain"),
+        {
+          code: "SELF_SIGNED_CERT_IN_CHAIN",
+        },
+      )
       const failingSteps: LifecycleStepsShape = {
         ...successfulSteps,
         createWorktree: () =>
           Effect.fail(
-            new LifecycleStepFailedError({ message: "worktree path busy" }),
+            new LifecycleStepFailedError({
+              message: "worktree path busy",
+              cause: leaf,
+            }),
           ),
       }
 
@@ -8309,6 +8318,7 @@ describe("WorkItemLifecycle", () => {
         Effect.gen(function* () {
           const lifecycle = yield* WorkItemLifecycle
           const queue = yield* QueueService
+          const sql = yield* SqlClient.SqlClient
           const { repository, issue } = yield* seedActionableIssue
 
           const created = yield* lifecycle.implementNow(
@@ -8332,6 +8342,31 @@ describe("WorkItemLifecycle", () => {
               run.startedAt!.getTime(),
             )
           }
+
+          const detailRows = (yield* sql.unsafe(
+            `SELECT reason_detail FROM step_run WHERE work_item_id = ?`,
+            [created.id],
+          )) as readonly { readonly reason_detail: string | null }[]
+          expect(detailRows).toHaveLength(1)
+          const detail = JSON.parse(detailRows[0]!.reason_detail!) as {
+            readonly code?: string
+            readonly causeChain: readonly {
+              readonly name?: string
+              readonly code?: string
+              readonly message?: string
+            }[]
+          }
+          expect(detail.code).toBe("SELF_SIGNED_CERT_IN_CHAIN")
+          expect(
+            detail.causeChain.some(
+              (link) => link.code === "SELF_SIGNED_CERT_IN_CHAIN",
+            ),
+          ).toBe(true)
+          expect(
+            detail.causeChain.some((link) =>
+              link.message?.includes("worktree path busy"),
+            ),
+          ).toBe(true)
 
           const remaining = yield* queue.rawClaim(WORK_ITEM_LIFECYCLE_QUEUE)
           expect(Option.isNone(remaining)).toBe(true)


### PR DESCRIPTION
Why:

Forge failures (TLS trust, DNS, timeouts, auth) were wrapped in
per-operation prose and then flattened at every display boundary.
Operators only saw messages like "Failed to list Ready-labeled Issues
for owner/repo" while the real leaf (`SELF_SIGNED_CERT_IN_CHAIN`, etc.)
never appeared in logs or step_run. That made misconfiguration
indistinguishable from GitHub/API failure (see #949 / #950).

What changed:

- Shared cause-chain helpers (extractCauseChain, extractErrorCode,
  logErrorAnnotations, reason_detail serialize) in github-service
- Job worker and lifecycle handler-failure logs emit structured
  causeChain (+ optional code) alongside the short human summary
- Optional code on GitHubRequestError / GitLabRequestError, lifted
  from nested transport causes (including TIMEOUT)
- New step_run.reason_detail column for durable JSON diagnostics on
  failed Step Runs; reason_message stays short
- Soft open-PR lookup still returns null on non-throttle failure, but
  logs a warning with branch and cause chain
- Keymaxxer helper opacity unchanged; ambient credential paths keep
  causes and lift code

Verification:

- github-service tests (cause-chain unit coverage)
- work-item-lifecycle tests (soft-lookup warning, reason_detail on
  handler failure)
- db migration tests for reason_detail
- Harness job-worker tests; staged-diff review was clean

Limitations:

- UI/GraphQL still surfaces reason_message only; full chain is in
  logs and DB reason_detail
- code is populated on the main transport construction path and always
  recoverable by walking the cause chain at log/persist sites

Closes #950