### PR TITLE
fix(harness): surface stale issue projections and back off failed polls

### DIFF
--- a/apps/harness/src/home-page-content.tsx
+++ b/apps/harness/src/home-page-content.tsx
@@ -51,6 +51,10 @@ import {
   issueActionEligibility,
 } from "./issue-action-eligibility.js"
 import {
+  formatLastRefreshedAgo,
+  isIssueProjectionStale,
+} from "./issue-projection-freshness.js"
+import {
   formatDuration,
   formatStartedAgo,
   isLiveDurationStatus,
@@ -1550,6 +1554,13 @@ function RepositoryCard({
   })
   const hasNoRelevantIssues =
     repository.issuesReconciledAt !== null && relevantIssues?.length === 0
+  // Wall-clock tick so a previously-fresh projection can cross the stale
+  // threshold while this card stays mounted (failed polls never invalidate).
+  const nowMs = useNowMs(repository.issuesReconciledAt !== null, 30_000)
+  const issuesProjectionStale = isIssueProjectionStale(
+    repository.issuesReconciledAt,
+    nowMs,
+  )
 
   const addGitHubToken = useMutation({
     mutationFn: async () => {
@@ -2577,13 +2588,29 @@ function RepositoryCard({
             {repository.issuesReconciledAt === null ? (
               <p className={ui.repoIssuesUnrefreshed}>Not refreshed yet.</p>
             ) : (
-              <Suspense fallback={<RepositoryIssuesSkeleton />}>
-                <RepositoryIssues
-                  repository={repository}
-                  workItems={workItems}
-                  workItemsLoading={workItemsLoading}
-                />
-              </Suspense>
+              <>
+                {issuesProjectionStale && (
+                  <Banner
+                    className={cx(ui.bannerCompact, "mb-2")}
+                    tone="guidance"
+                    tag="Stale"
+                    role="status"
+                  >
+                    {formatLastRefreshedAgo(
+                      repository.issuesReconciledAt,
+                      nowMs,
+                    )}
+                    . Issues may be out of date.
+                  </Banner>
+                )}
+                <Suspense fallback={<RepositoryIssuesSkeleton />}>
+                  <RepositoryIssues
+                    repository={repository}
+                    workItems={workItems}
+                    workItemsLoading={workItemsLoading}
+                  />
+                </Suspense>
+              </>
             )}
           </div>
           {removeRepository.isError && (

--- a/apps/harness/src/issue-projection-freshness.ts
+++ b/apps/harness/src/issue-projection-freshness.ts
@@ -1,0 +1,68 @@
+/**
+ * Client-side freshness for a Repository's Issue projection.
+ *
+ * Scheduled Issue polls run about every 60–90s
+ * (`ISSUE_POLLING_BASE_SECONDS` + jitter in `@ready-for-agent/graphql-api`).
+ * Only successful reconciliation advances `issuesReconciledAt`. A non-null
+ * timestamp that is older than a small multiple of that cadence means the
+ * Issues on screen must not be trusted as current — whether the Harness is
+ * failing polls, paused, or not running.
+ *
+ * No server schema change: the client already receives `issuesReconciledAt`.
+ */
+
+/** Upper bound of one healthy poll quiet period (base 60s + jitter 30s). */
+export const ISSUE_POLL_CADENCE_UPPER_MS = 90_000
+
+/** How many cadence upper bounds without a successful refresh before stale. */
+export const ISSUE_PROJECTION_STALE_MULTIPLE = 5
+
+/** Age after which a non-null `issuesReconciledAt` is treated as stale. */
+export const ISSUE_PROJECTION_STALE_AFTER_MS =
+  ISSUE_POLL_CADENCE_UPPER_MS * ISSUE_PROJECTION_STALE_MULTIPLE
+
+/**
+ * True when the projection has a last-success timestamp older than the
+ * staleness threshold. `null` is "never refreshed" (different UI), not stale.
+ */
+export function isIssueProjectionStale(
+  issuesReconciledAt: string | null,
+  nowMs: number,
+  staleAfterMs: number = ISSUE_PROJECTION_STALE_AFTER_MS,
+): boolean {
+  if (issuesReconciledAt === null) return false
+  const reconciledAtMs = Date.parse(issuesReconciledAt)
+  if (Number.isNaN(reconciledAtMs)) return false
+  return nowMs - reconciledAtMs > staleAfterMs
+}
+
+/**
+ * Relative age caption for a stale Issue list, e.g.
+ * "Last refreshed 13 hours ago".
+ */
+export function formatLastRefreshedAgo(
+  issuesReconciledAt: string,
+  nowMs: number = Date.now(),
+): string {
+  const reconciledAtMs = Date.parse(issuesReconciledAt)
+  if (Number.isNaN(reconciledAtMs)) return "Last refreshed at an unknown time"
+  const elapsedMs = Math.max(0, nowMs - reconciledAtMs)
+  const seconds = Math.floor(elapsedMs / 1000)
+  if (seconds < 60) return "Last refreshed just now"
+  const minutes = Math.floor(seconds / 60)
+  if (minutes < 60) {
+    return minutes === 1
+      ? "Last refreshed 1 min ago"
+      : `Last refreshed ${minutes} min ago`
+  }
+  const hours = Math.floor(minutes / 60)
+  if (hours < 24) {
+    return hours === 1
+      ? "Last refreshed 1 hour ago"
+      : `Last refreshed ${hours} hours ago`
+  }
+  const days = Math.floor(hours / 24)
+  return days === 1
+    ? "Last refreshed 1 day ago"
+    : `Last refreshed ${days} days ago`
+}

--- a/apps/harness/src/issue-projection-freshness.ts
+++ b/apps/harness/src/issue-projection-freshness.ts
@@ -12,10 +12,10 @@
  */
 
 /** Upper bound of one healthy poll quiet period (base 60s + jitter 30s). */
-export const ISSUE_POLL_CADENCE_UPPER_MS = 90_000
+const ISSUE_POLL_CADENCE_UPPER_MS = 90_000
 
 /** How many cadence upper bounds without a successful refresh before stale. */
-export const ISSUE_PROJECTION_STALE_MULTIPLE = 5
+const ISSUE_PROJECTION_STALE_MULTIPLE = 5
 
 /** Age after which a non-null `issuesReconciledAt` is treated as stale. */
 export const ISSUE_PROJECTION_STALE_AFTER_MS =

--- a/apps/harness/src/server/job-worker.ts
+++ b/apps/harness/src/server/job-worker.ts
@@ -30,6 +30,7 @@ import {
   POLLING_AUTO_HEAL_BACKOFF,
   POLLING_AUTO_HEAL_KEY,
   enqueuePollingAutoHealJob,
+  issuePollFailureBackoff,
   repairPollingSchedules,
   sampleIssuePollingDelay,
 } from "@ready-for-agent/graphql-api"
@@ -59,6 +60,14 @@ const ORPHAN_RECOVERY_INTERVAL = Duration.seconds(30)
 const REFRESH_REPOSITORY_TAG = "refresh-repository"
 /** Modest concurrency for credential probes (Keymaxxer / GitLab). */
 const CREDENTIAL_CHECK_CONCURRENCY = 4
+
+/**
+ * Process-local consecutive failure counts for scheduled Issue polls.
+ * `postponeKeyed` resets queue `job_attempts`, so recurrence failure is
+ * unobservable through the queue; this Map is the only consecutive-failure
+ * memory. Cleared on success and on process restart (healthy first retry).
+ */
+const consecutiveScheduledPollFailures = new Map<string, number>()
 
 /**
  * Process-global generation so HMR/runtime restarts retire zombie workers that
@@ -334,13 +343,22 @@ const finalizeScheduledRefresh = <A, E>(
         )
         return
       }
+      const consecutiveFailures =
+        (consecutiveScheduledPollFailures.get(repositoryId) ?? 0) + 1
+      consecutiveScheduledPollFailures.set(repositoryId, consecutiveFailures)
+      const delay = issuePollFailureBackoff(consecutiveFailures)
       yield* Effect.logError("Scheduled Issue poll failed", {
         jobId,
         repositoryId,
+        consecutiveFailures,
+        nextDelayMs: Duration.toMillis(delay),
         ...logErrorAnnotations(result.failure),
       })
+      yield* queue.postponeKeyed(jobId, delay)
+      return
     }
 
+    consecutiveScheduledPollFailures.delete(repositoryId)
     const delay = yield* sampleDelay
     yield* queue.postponeKeyed(jobId, delay)
   })

--- a/apps/harness/test/issue-projection-freshness.test.ts
+++ b/apps/harness/test/issue-projection-freshness.test.ts
@@ -1,0 +1,82 @@
+import {
+  ISSUE_PROJECTION_STALE_AFTER_MS,
+  formatLastRefreshedAgo,
+  isIssueProjectionStale,
+} from "../src/issue-projection-freshness.js"
+import { describe, expect, test } from "bun:test"
+
+describe("isIssueProjectionStale", () => {
+  const nowMs = Date.parse("2026-08-11T10:00:00.000Z")
+
+  test("null is not stale (never refreshed is a different UI state)", () => {
+    expect(isIssueProjectionStale(null, nowMs)).toBe(false)
+  })
+
+  test("a fresh timestamp is not stale", () => {
+    const recent = new Date(nowMs - 60_000).toISOString()
+    expect(isIssueProjectionStale(recent, nowMs)).toBe(false)
+  })
+
+  test("a timestamp just under the threshold is not stale", () => {
+    const almost = new Date(
+      nowMs - ISSUE_PROJECTION_STALE_AFTER_MS,
+    ).toISOString()
+    expect(isIssueProjectionStale(almost, nowMs)).toBe(false)
+  })
+
+  test("a timestamp older than the threshold is stale", () => {
+    const old = new Date(
+      nowMs - ISSUE_PROJECTION_STALE_AFTER_MS - 1,
+    ).toISOString()
+    expect(isIssueProjectionStale(old, nowMs)).toBe(true)
+  })
+
+  test("thirteen-hour-old projection from the #951 incident is stale", () => {
+    const thirteenHoursAgo = new Date(nowMs - 13 * 60 * 60 * 1000).toISOString()
+    expect(isIssueProjectionStale(thirteenHoursAgo, nowMs)).toBe(true)
+  })
+
+  test("unparseable timestamps are not treated as stale", () => {
+    expect(isIssueProjectionStale("not-a-date", nowMs)).toBe(false)
+  })
+})
+
+describe("formatLastRefreshedAgo", () => {
+  const nowMs = Date.parse("2026-08-11T10:00:00.000Z")
+
+  test("formats minutes, hours, and days for the stale caption", () => {
+    expect(
+      formatLastRefreshedAgo(new Date(nowMs - 45_000).toISOString(), nowMs),
+    ).toBe("Last refreshed just now")
+    expect(
+      formatLastRefreshedAgo(
+        new Date(nowMs - 15 * 60_000).toISOString(),
+        nowMs,
+      ),
+    ).toBe("Last refreshed 15 min ago")
+    expect(
+      formatLastRefreshedAgo(
+        new Date(nowMs - 60 * 60_000).toISOString(),
+        nowMs,
+      ),
+    ).toBe("Last refreshed 1 hour ago")
+    expect(
+      formatLastRefreshedAgo(
+        new Date(nowMs - 13 * 60 * 60_000).toISOString(),
+        nowMs,
+      ),
+    ).toBe("Last refreshed 13 hours ago")
+    expect(
+      formatLastRefreshedAgo(
+        new Date(nowMs - 26 * 60 * 60_000).toISOString(),
+        nowMs,
+      ),
+    ).toBe("Last refreshed 1 day ago")
+    expect(
+      formatLastRefreshedAgo(
+        new Date(nowMs - 3 * 24 * 60 * 60_000).toISOString(),
+        nowMs,
+      ),
+    ).toBe("Last refreshed 3 days ago")
+  })
+})

--- a/apps/harness/test/job-worker.test.ts
+++ b/apps/harness/test/job-worker.test.ts
@@ -1672,8 +1672,24 @@ describe("Job worker", () => {
 
   it.live("postpones a failed scheduled poll without publishing success", () =>
     Effect.gen(function* () {
-      const job = rawJob(refreshPayload, ISSUE_POLL_QUEUE, repository.id)
-      const postponed = yield* Deferred.make<string>()
+      // Unique Repository id so process-local consecutive-failure counts start
+      // at 0; keep default projectPath so keymaxxerLayer credentials match.
+      const failingRepo = makeRepositoryRecord({
+        id: RepositoryId.make("repo-01J0000000000000000000000A"),
+        paused: true,
+      })
+      const job = rawJob(
+        {
+          _tag: "refresh-repository" as const,
+          repositoryId: failingRepo.id,
+        },
+        ISSUE_POLL_QUEUE,
+        failingRepo.id,
+      )
+      const postponed = yield* Deferred.make<{
+        jobId: string
+        delayMs: number
+      }>()
       const notifications: string[] = []
       let failed = false
 
@@ -1681,9 +1697,14 @@ describe("Job worker", () => {
         Effect.gen(function* () {
           yield* runJobWorker({
             idlePollInterval: Duration.zero,
+            // Success path samples cadence; failure must ignore this and back off.
             samplePollingDelay: Effect.succeed(Duration.seconds(120)),
           }).pipe(Effect.forkScoped({ startImmediately: true }))
-          expect(yield* Deferred.await(postponed)).toBe(job.jobId)
+          expect(yield* Deferred.await(postponed)).toEqual({
+            jobId: job.jobId,
+            // First consecutive failure: healthy base (60s), not the sample delay.
+            delayMs: 60_000,
+          })
           expect(notifications).toEqual([])
           expect(failed).toBe(false)
         }),
@@ -1700,9 +1721,13 @@ describe("Job worker", () => {
             undefined,
             undefined,
             undefined,
-            (jobId) => Deferred.succeed(postponed, jobId),
+            (jobId, delay) =>
+              Deferred.succeed(postponed, {
+                jobId,
+                delayMs: Duration.toMillis(delay),
+              }),
           ),
-          dbLayer([repository], (repositoryId) =>
+          dbLayer([failingRepo], (repositoryId) =>
             Effect.sync(() => {
               notifications.push(repositoryId)
             }),
@@ -1715,6 +1740,85 @@ describe("Job worker", () => {
         ),
       )
     }),
+  )
+
+  it.live(
+    "backs off successive scheduled poll failures and resets after success",
+    () =>
+      Effect.gen(function* () {
+        // Unique id; default projectPath stays credentialed via keymaxxerLayer.
+        const backoffRepo = makeRepositoryRecord({
+          id: RepositoryId.make("repo-01J0000000000000000000000B"),
+          paused: true,
+        })
+        const failPayload = {
+          _tag: "refresh-repository" as const,
+          repositoryId: backoffRepo.id,
+        }
+        const firstJob = rawJob(failPayload, ISSUE_POLL_QUEUE, backoffRepo.id)
+        const secondJob = rawJob(failPayload, ISSUE_POLL_QUEUE, backoffRepo.id)
+        const successJob = rawJob(failPayload, ISSUE_POLL_QUEUE, backoffRepo.id)
+        const delays: number[] = []
+        const done = yield* Deferred.make<void>()
+        let reconcileCalls = 0
+
+        // Sequential claims across high-priority probe + poll queue.
+        const pendingJobs = [firstJob, secondJob, successJob]
+
+        yield* runScoped(
+          Effect.gen(function* () {
+            yield* runJobWorker({
+              idlePollInterval: Duration.zero,
+              samplePollingDelay: Effect.succeed(Duration.seconds(137)),
+            }).pipe(Effect.forkScoped({ startImmediately: true }))
+            yield* Deferred.await(done)
+            expect(delays).toEqual([60_000, 120_000, 137_000])
+          }),
+          Layer.mergeAll(
+            defaultGithubLayer,
+            queueLayer(
+              [],
+              undefined,
+              undefined,
+              (queueName) =>
+                Effect.sync(() => {
+                  if (queueName !== ISSUE_POLL_QUEUE) return Option.none()
+                  const next = pendingJobs.shift()
+                  return next === undefined ? Option.none() : Option.some(next)
+                }),
+              undefined,
+              undefined,
+              undefined,
+              (_jobId, delay) =>
+                Effect.gen(function* () {
+                  delays.push(Duration.toMillis(delay))
+                  if (delays.length === 3) {
+                    yield* Deferred.succeed(done, undefined)
+                  }
+                }),
+            ),
+            dbLayer([backoffRepo]),
+            Layer.succeed(IssueReconciler, {
+              reconcile: () => {
+                reconcileCalls += 1
+                if (reconcileCalls <= 2) {
+                  return Effect.fail(
+                    new DatabaseError({ message: "scheduled fail" }),
+                  )
+                }
+                return Effect.succeed({
+                  fetched: 0,
+                  inserted: 0,
+                  updated: 0,
+                  deleted: 0,
+                  unchanged: 0,
+                })
+              },
+            }),
+            keymaxxerLayer(),
+          ),
+        )
+      }),
   )
 
   it.live(

--- a/apps/harness/test/repos-interchange.test.ts
+++ b/apps/harness/test/repos-interchange.test.ts
@@ -210,6 +210,11 @@ describe("Interchange phase 4: repos page + blank slate", () => {
       'aria-label={\n                  refreshingIssues ? "Refreshing issues" : "Refresh issues"',
     )
     expect(card).toContain("ui.repoIssuesUnrefreshed")
+    // Stale projection caption (#951): guidance banner when issuesReconciledAt is old.
+    expect(card).toContain("isIssueProjectionStale")
+    expect(card).toContain("formatLastRefreshedAgo")
+    expect(card).toContain('tag="Stale"')
+    expect(card).toContain("Issues may be out of date.")
 
     const issues = sliceBetweenMarkers(
       homeSource(),

--- a/packages/graphql-api/src/lib/issue-polling.ts
+++ b/packages/graphql-api/src/lib/issue-polling.ts
@@ -19,8 +19,36 @@ export const ISSUE_POLLING_BASE_SECONDS = 60
 /** Inclusive upper bound for additive jitter seconds (0–30). */
 export const ISSUE_POLLING_JITTER_SECONDS = 30
 
+/**
+ * Ceiling for consecutive scheduled-poll failure backoff (15 minutes).
+ * Permanent failures (expired token, TLS, renamed repo) must not keep the
+ * full healthy cadence forever — see issue #951.
+ */
+export const ISSUE_POLL_FAILURE_MAX_SECONDS = 15 * 60
+
 /** Default backoff when a Polling Auto-heal Job fails (no tight loop). */
 export const POLLING_AUTO_HEAL_BACKOFF = Duration.seconds(5)
+
+/**
+ * Quiet period after the Nth consecutive scheduled poll failure (1-based).
+ * Grows exponentially from the healthy base and caps at
+ * {@link ISSUE_POLL_FAILURE_MAX_SECONDS}. Count 0 or negative falls back to
+ * the healthy base (callers should prefer sampling jitter on success).
+ */
+export const issuePollFailureBackoffSeconds = (
+  consecutiveFailures: number,
+): number => {
+  if (consecutiveFailures <= 0) return ISSUE_POLLING_BASE_SECONDS
+  const exponent = Math.min(consecutiveFailures - 1, 31)
+  const seconds = ISSUE_POLLING_BASE_SECONDS * 2 ** exponent
+  return Math.min(seconds, ISSUE_POLL_FAILURE_MAX_SECONDS)
+}
+
+/** Duration form of {@link issuePollFailureBackoffSeconds}. */
+export const issuePollFailureBackoff = (
+  consecutiveFailures: number,
+): Duration.Duration =>
+  Duration.seconds(issuePollFailureBackoffSeconds(consecutiveFailures))
 
 const RefreshRepositoryJobPayload = (repositoryId: string) => ({
   _tag: "refresh-repository" as const,

--- a/packages/graphql-api/test/issue-polling.test.ts
+++ b/packages/graphql-api/test/issue-polling.test.ts
@@ -15,9 +15,11 @@ import { stubQueueService } from "@ready-for-agent/queue-service/test"
 import {
   ISSUE_POLLING_BASE_SECONDS,
   ISSUE_POLLING_JITTER_SECONDS,
+  ISSUE_POLL_FAILURE_MAX_SECONDS,
   ISSUE_POLL_QUEUE,
   ISSUE_REFRESH_QUEUE,
   activateRepositoryPolling,
+  issuePollFailureBackoffSeconds,
   repairPollingSchedules,
   suspendRepositoryPolling,
 } from "../src/lib/issue-polling.js"
@@ -32,6 +34,27 @@ const repoOrphan = "repo-01J00000000000000000000003"
 const repoAdded = "repo-01J00000000000000000000004"
 
 describe("issue-polling", () => {
+  test("issuePollFailureBackoffSeconds grows exponentially to a ceiling", () => {
+    expect(issuePollFailureBackoffSeconds(0)).toBe(ISSUE_POLLING_BASE_SECONDS)
+    expect(issuePollFailureBackoffSeconds(1)).toBe(ISSUE_POLLING_BASE_SECONDS)
+    expect(issuePollFailureBackoffSeconds(2)).toBe(
+      ISSUE_POLLING_BASE_SECONDS * 2,
+    )
+    expect(issuePollFailureBackoffSeconds(3)).toBe(
+      ISSUE_POLLING_BASE_SECONDS * 4,
+    )
+    expect(issuePollFailureBackoffSeconds(4)).toBe(
+      ISSUE_POLLING_BASE_SECONDS * 8,
+    )
+    // 60 * 2^5 = 1920 > 900 → capped.
+    expect(issuePollFailureBackoffSeconds(6)).toBe(
+      ISSUE_POLL_FAILURE_MAX_SECONDS,
+    )
+    expect(issuePollFailureBackoffSeconds(20)).toBe(
+      ISSUE_POLL_FAILURE_MAX_SECONDS,
+    )
+  })
+
   test("activateRepositoryPolling ensures keyed schedule and first refresh", async () => {
     const ensured: Array<{
       queue: string


### PR DESCRIPTION
Why

When scheduled Issue reconciliation fails indefinitely (expired token, TLS,
renamed repo, forge outage, etc.), the UI still showed a healthy Repository
with the last successful Issue list. `issuesReconciledAt` was treated only as
null vs non-null, so multi-hour-old data looked current. Failures were only
logged, then rescheduled at the normal ~60–90s cadence, so permanent failures
spammed the log and the forge.

What changed

Client-side staleness (no schema change)
- Treat a non-null `issuesReconciledAt` older than 5x the poll upper bound
  (7.5 minutes) as a stale Issue projection.
- On the Repository card, show a guidance Stale banner with a relative caption
  (e.g. "Last refreshed 13 hours ago") and note that Issues may be out of date;
  still show the list so operators can see what is cached.
- Tick the wall clock so a mounted card can cross the threshold without a
  successful poll invalidation.

Scheduled-poll failure backoff
- Track consecutive failures per Repository in process memory (`postponeKeyed`
  resets queue `job_attempts`, so the queue cannot count this).
- On failure, postpone with exponential backoff from the healthy base
  (60s → … → 15m cap); log `consecutiveFailures` and `nextDelayMs`.
- On success, clear the counter and restore the normal sampled cadence.
  GitHub throttle postponement is unchanged and does not count toward failure
  backoff.

Intentionally not in this change: a durable consecutive-failure count or
last-error field on the Repository (that would need an ARCHITECTURE.md
decision).

Verification

- Unit tests for freshness helpers, issue-poll backoff math, job-worker
  failure/success delay paths, and repos interchange wiring for the Stale
  banner.
- `graphql-api` and `harness` typecheck; pre-commit lint/typecheck/test green
  after Biome format fixes.

Limitations

- Staleness is inferred from last-success age only — it does not distinguish
  "polls failing" from "Harness not running."
- Failure backoff counters are process-local and reset on restart.
- Stale UI is on the Repository Issues card; it does not add a new GraphQL
  field or job-status snapshot.

Closes #951