### PR TITLE
fix(ready-for-agent): bake release version into published UI masthead

### DIFF
--- a/apps/harness/project.json
+++ b/apps/harness/project.json
@@ -13,6 +13,12 @@
           "projects": ["ready-for-agent"],
           "target": "generate-version"
         }
+      ],
+      "inputs": [
+        "default",
+        "^production",
+        "{workspaceRoot}/apps/ready-for-agent/package.json",
+        "{projectRoot}/src/generated/version.ts"
       ]
     },
     "dev": {

--- a/apps/ready-for-agent/scripts/generate-standalone-embed.ts
+++ b/apps/ready-for-agent/scripts/generate-standalone-embed.ts
@@ -2,7 +2,11 @@
 import { mkdirSync, readdirSync, statSync, writeFileSync } from "node:fs"
 import { dirname, join, relative, resolve } from "node:path"
 import { fileURLToPath } from "node:url"
-import { writeReadyForAgentVersionFiles } from "./write-ready-for-agent-version.ts"
+import {
+  assertClientDistMatchesProductVersion,
+  readLauncherVersion,
+  writeReadyForAgentVersionFiles,
+} from "./write-ready-for-agent-version.ts"
 
 const appRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..")
 const workspaceRoot = resolve(appRoot, "../..")
@@ -32,6 +36,14 @@ if (!statSync(clientRoot, { throwIfNoEntry: false })?.isDirectory()) {
   console.error(
     `Missing harness client build at ${clientRoot}. Run harness:build first.`,
   )
+  process.exit(1)
+}
+
+const productVersion = readLauncherVersion()
+try {
+  assertClientDistMatchesProductVersion(clientRoot, productVersion)
+} catch (error) {
+  console.error(error instanceof Error ? error.message : String(error))
   process.exit(1)
 }
 
@@ -80,7 +92,7 @@ export const embeddedShellHtmlPath: string = ${shellImport} as unknown as string
 
 writeFileSync(assetsOut, assetsContent)
 
-const { version } = writeReadyForAgentVersionFiles()
+const { version } = writeReadyForAgentVersionFiles(productVersion)
 
 console.log(
   `Wrote ${assetsOut} (${files.length} assets) and version modules (v${version})`,

--- a/apps/ready-for-agent/scripts/overnight-published-install-smoke.ts
+++ b/apps/ready-for-agent/scripts/overnight-published-install-smoke.ts
@@ -23,6 +23,7 @@ import {
 import { tmpdir } from "node:os"
 import { dirname, join } from "node:path"
 import { fileURLToPath } from "node:url"
+import { parseMastheadProductVersion } from "./write-ready-for-agent-version.ts"
 
 const scriptDir = dirname(fileURLToPath(import.meta.url))
 const appRoot = join(scriptDir, "..")
@@ -359,6 +360,28 @@ try {
     if (!html.toLowerCase().includes("html")) {
       fail("GET / response did not look like HTML")
     }
+
+    // Masthead brand must show the published product version (not build placeholder).
+    // Screenshot regression: published @latest rendered "RFA V0.0.0" in the header.
+    // SSR may insert <!-- --> between text nodes ("RFA <!-- -->v…"); prefer the
+    // title attribute which stays a single string: title="Ready for Agent v…".
+    const uiVersion = parseMastheadProductVersion(html)
+    if (uiVersion === undefined) {
+      fail('GET / HTML missing masthead version "Ready for Agent v<semver>"')
+    }
+    if (uiVersion === "0.0.0") {
+      fail(
+        'UI masthead shows placeholder version "v0.0.0" (expected published product version)',
+      )
+    }
+    const cliVersion =
+      versionText.match(/\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?/)?.[0] ?? ""
+    if (cliVersion !== "" && uiVersion !== cliVersion) {
+      fail(
+        `UI masthead version v${uiVersion} does not match CLI --version ${JSON.stringify(versionText)}`,
+      )
+    }
+    log(`UI masthead version ok: v${uiVersion}`)
 
     const health = await fetch(`${base}/graphql`, {
       method: "POST",

--- a/apps/ready-for-agent/scripts/packed-install-smoke.ts
+++ b/apps/ready-for-agent/scripts/packed-install-smoke.ts
@@ -30,6 +30,7 @@ import {
   launcherManifestForNpmPublish,
 } from "@ready-for-agent/release-versioning"
 import { selectPlatformPackage } from "../bin/select-platform.js"
+import { parseMastheadProductVersion } from "./write-ready-for-agent-version.ts"
 
 const appRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..")
 const workspaceRoot = resolve(appRoot, "../..")
@@ -507,6 +508,19 @@ try {
       if (!html.toLowerCase().includes("html")) {
         fail("GET / response did not look like HTML")
       }
+
+      // Masthead must bake the packed product version (not a stale v0.0.0 UI
+      // while CLI/listen report the real semver — issue #957).
+      const uiVersion = parseMastheadProductVersion(html)
+      if (uiVersion === undefined) {
+        fail('GET / HTML missing masthead version "Ready for Agent v<semver>"')
+      }
+      if (uiVersion !== packageVersion) {
+        fail(
+          `UI masthead version v${uiVersion} does not match packed version ${packageVersion}`,
+        )
+      }
+      log(`${label}: UI masthead version ok: v${uiVersion}`)
 
       const assetMatch = html.match(/\/assets\/[A-Za-z0-9._-]+\.(?:js|css)/)
       if (assetMatch === null || assetMatch[0] === undefined) {

--- a/apps/ready-for-agent/scripts/write-ready-for-agent-version.ts
+++ b/apps/ready-for-agent/scripts/write-ready-for-agent-version.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, readFileSync, writeFileSync } from "node:fs"
+import { mkdirSync, readFileSync, readdirSync, writeFileSync } from "node:fs"
 import { dirname, join, resolve } from "node:path"
 import { fileURLToPath } from "node:url"
 
@@ -24,6 +24,76 @@ export const readLauncherVersion = (): string => {
     packageJson.version.trim() !== ""
     ? packageJson.version.trim()
     : "0.0.0"
+}
+
+/** Product version label shown in UI chrome (`v<semver>`). */
+export const productVersionLabel = (version: string): string => `v${version}`
+
+/**
+ * Semver (optional pre-release) as printed in masthead title /
+ * `Ready for Agent v…`.
+ */
+export const PRODUCT_VERSION_IN_TEXT_PATTERN =
+  /Ready for Agent v(\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?)/
+
+/**
+ * Fail-fast guard for release embeds: harness client dist must already bake the
+ * launcher product version (not a stale Nx-cached `v0.0.0` UI).
+ */
+export const assertClientDistMatchesProductVersion = (
+  clientRoot: string,
+  version: string,
+): void => {
+  const label = productVersionLabel(version)
+  const titleNeedle = `Ready for Agent ${label}`
+  const shellPath = join(clientRoot, "_shell.html")
+  let shell: string
+  try {
+    shell = readFileSync(shellPath, "utf8")
+  } catch {
+    throw new Error(
+      `Harness client shell missing at ${shellPath}. Run harness:build first.`,
+    )
+  }
+  if (!shell.includes(titleNeedle)) {
+    const found = shell.match(PRODUCT_VERSION_IN_TEXT_PATTERN)?.[0]
+    throw new Error(
+      `Harness client shell does not embed product version ${JSON.stringify(label)}` +
+        (found === undefined
+          ? " (no Ready for Agent v… title found)"
+          : ` (found ${JSON.stringify(found)})`) +
+        `. harness:build likely used a stale cache; ensure package.json version is an input to harness:build.`,
+    )
+  }
+
+  // Minified client bundles keep the label as a string literal (`v1.2.3`).
+  const assetsDir = join(clientRoot, "assets")
+  let assetNames: string[] = []
+  try {
+    assetNames = readdirSync(assetsDir).filter((name) => name.endsWith(".js"))
+  } catch {
+    throw new Error(`Harness client assets missing under ${assetsDir}`)
+  }
+  const assetHasLabel = assetNames.some((name) =>
+    readFileSync(join(assetsDir, name), "utf8").includes(label),
+  )
+  if (!assetHasLabel) {
+    throw new Error(
+      `No harness client JS asset contains ${JSON.stringify(label)}; UI masthead would show a stale version.`,
+    )
+  }
+}
+
+/**
+ * Parse masthead product version from production shell HTML.
+ * Prefers the title attribute so SSR `<!-- -->` splits between RFA and v… do
+ * not break the check.
+ */
+export const parseMastheadProductVersion = (
+  html: string,
+): string | undefined => {
+  const match = html.match(PRODUCT_VERSION_IN_TEXT_PATTERN)
+  return match?.[1]
 }
 
 /** Writes the canonical product version for CLI, Harness server, and UI. */

--- a/apps/ready-for-agent/src/target-topology.test.ts
+++ b/apps/ready-for-agent/src/target-topology.test.ts
@@ -26,7 +26,7 @@ describe("ready-for-agent target topology", () => {
       ),
     ) as {
       targets: {
-        build?: { dependsOn?: unknown[] }
+        build?: { dependsOn?: unknown[]; inputs?: unknown[] }
       }
     }
 
@@ -35,6 +35,15 @@ describe("ready-for-agent target topology", () => {
     )
     expect(JSON.stringify(project.targets.build?.dependsOn ?? [])).toContain(
       '"projects":["ready-for-agent"]',
+    )
+    // Release bumps apps/ready-for-agent/package.json after CI has cached
+    // harness:build at v0.0.0. Without this input, Nx restores the stale UI
+    // while generate-version rewrites CLI version modules (issue #957).
+    expect(JSON.stringify(project.targets.build?.inputs ?? [])).toContain(
+      "apps/ready-for-agent/package.json",
+    )
+    expect(JSON.stringify(project.targets.build?.inputs ?? [])).toContain(
+      "src/generated/version.ts",
     )
   })
 })

--- a/apps/ready-for-agent/src/write-version.test.ts
+++ b/apps/ready-for-agent/src/write-version.test.ts
@@ -1,7 +1,17 @@
-import { readFileSync } from "node:fs"
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs"
+import { tmpdir } from "node:os"
 import { dirname, join, resolve } from "node:path"
 import { fileURLToPath } from "node:url"
 import {
+  assertClientDistMatchesProductVersion,
+  parseMastheadProductVersion,
+  productVersionLabel,
   readLauncherVersion,
   writeReadyForAgentVersionFiles,
 } from "../scripts/write-ready-for-agent-version.ts"
@@ -55,5 +65,45 @@ describe("ready-for-agent version generation", () => {
     expect(readFileSync(harnessVersionPath, "utf8")).toContain(
       `READY_FOR_AGENT_VERSION = ${JSON.stringify(launcherVersion)}`,
     )
+  })
+
+  test("parseMastheadProductVersion reads title attribute, not SSR text splits", () => {
+    const html = `<b title="Ready for Agent v1.2.3">RFA <!-- -->v1.2.3</b>`
+    expect(parseMastheadProductVersion(html)).toBe("1.2.3")
+    expect(productVersionLabel("1.2.3")).toBe("v1.2.3")
+  })
+
+  test("assertClientDistMatchesProductVersion accepts matching shell and JS", () => {
+    const root = mkdtempSync(join(tmpdir(), "rfa-client-dist-"))
+    try {
+      mkdirSync(join(root, "assets"), { recursive: true })
+      writeFileSync(
+        join(root, "_shell.html"),
+        `<b title="Ready for Agent v9.8.7">RFA v9.8.7</b>`,
+      )
+      writeFileSync(join(root, "assets", "index.js"), `var xl=\`v9.8.7\`;`)
+      expect(() =>
+        assertClientDistMatchesProductVersion(root, "9.8.7"),
+      ).not.toThrow()
+    } finally {
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  test("assertClientDistMatchesProductVersion rejects stale placeholder UI", () => {
+    const root = mkdtempSync(join(tmpdir(), "rfa-client-dist-stale-"))
+    try {
+      mkdirSync(join(root, "assets"), { recursive: true })
+      writeFileSync(
+        join(root, "_shell.html"),
+        `<b title="Ready for Agent v0.0.0">RFA v0.0.0</b>`,
+      )
+      writeFileSync(join(root, "assets", "index.js"), `var xl=\`v0.0.0\`;`)
+      expect(() =>
+        assertClientDistMatchesProductVersion(root, "0.19.0"),
+      ).toThrow(/does not embed product version "v0.19.0"/)
+    } finally {
+      rmSync(root, { recursive: true, force: true })
+    }
   })
 })


### PR DESCRIPTION
Why

Published ready-for-agent (reproduced on 0.19.0) reported the correct
product version on CLI/--version and the listen log, but the Harness
masthead still showed the build placeholder RFA v0.0.0.

Release applies the real semver to apps/ready-for-agent/package.json
after CI has already cached harness:build with v0.0.0. That target did
not hash the launcher package version, so Nx restored a stale client
dist while generate-version rewrote only the TypeScript version modules
used by the binary CLI.

What

- Invalidate harness:build when the launcher version changes by adding
  apps/ready-for-agent/package.json and src/generated/version.ts as
  explicit inputs.
- Fail fast in generate-standalone-embed if the harness client dist does
  not already embed the launcher product version (stale cache cannot be
  packed).
- Assert masthead version in packed-install smoke (must match packed
  package version) and overnight published-install smoke (reject
  v0.0.0; must match CLI --version).
- Unit coverage for version parse/assert helpers and topology inputs.

Verification

- Reproduced the release path (warm 0.0.0 cache, bump package version,
  embed): before the input fix, harness:build cache-hit left v0.0.0 in
  dist; after, harness:build re-ran and dist/binary carried v0.19.0 for
  both CLI and UI title.
- bunx nx run ready-for-agent:test (45 pass).
- Overnight smoke against @latest stays red until a release that
  includes this fix is published; packed-install on the release job is
  the gate that should catch a regression before publish.

Closes #957