### PR TITLE
feat(harness): vault-free live e2e for default Agent Backend without OpenCode

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -103,9 +103,10 @@ jobs:
       #   if: always()
 
   # Dev smoke + live Gherkin e2e. Independent of quality-gates (parallel job).
-  # OpenCode CLI is required: live e2e first-run settings inspects the model
-  # catalog via `opencode models --verbose` (empty catalog fails the suite).
-  # Live e2e is fail-closed when the vault secret is missing (trusted main).
+  # Two live suites (issue #958): vault-free @no-backend first (no OpenCode),
+  # then vault-backed OpenCode suite (excludes @no-backend). Vault-backed
+  # e2e is fail-closed when the secret is missing (trusted main). Overnight
+  # install smoke remains the packaging multi-arch gate.
   harness:
     runs-on: ubuntu-latest
     steps:
@@ -118,9 +119,51 @@ jobs:
         with:
           bun-version: latest
 
-      # Resolve the release via authenticated GitHub API then pin the installer
-      # --version flag: bare `opencode.ai/install` hits unauthenticated
-      # /releases/latest and fails under Actions rate limits.
+      - run: bun install --no-cache --frozen-lockfile --linker=isolated && bun install --no-cache --frozen-lockfile --linker=isolated
+
+      # Restore only: quality-gates is the main cache producer.
+      - name: Restore Nx cache
+        uses: ./.github/actions/nx-cache
+        with:
+          mode: restore-main
+
+      # Dev-path GraphQL smoke (Bun + Vite SSR); no Keymaxxer vault required.
+      - name: Harness dev smoke
+        run: bunx nx run harness:smoke
+
+      # Chromium once for both live suites.
+      - name: Install Playwright Chromium
+        working-directory: apps/harness
+        run: bunx playwright install --with-deps chromium
+
+      # Product default-backend / first-run without OpenCode (vault-free).
+      - name: Live Harness e2e (no backend agents)
+        id: live-e2e-no-backend
+        run: bunx nx run harness:e2e-no-backend
+
+      - name: Upload Playwright diagnostics (no backend)
+        if: failure() && steps.live-e2e-no-backend.outcome == 'failure'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: playwright-report-no-backend
+          path: |
+            apps/harness/playwright-report/
+            apps/harness/test-results/
+          if-no-files-found: ignore
+          retention-days: 14
+
+      # Vault-backed OpenCode suite (also on PRs via pr.yml when secret available).
+      - name: Require live e2e vault key
+        env:
+          E2E_KEYMAXXER_MASTER_KEY: ${{ secrets.E2E_KEYMAXXER_MASTER_KEY }}
+        run: |
+          if [ -z "${E2E_KEYMAXXER_MASTER_KEY}" ]; then
+            echo "error: repository secret E2E_KEYMAXXER_MASTER_KEY is required for the vault-backed live Harness e2e step" >&2
+            exit 1
+          fi
+
+      # OpenCode for vault-backed suite only: first-run model catalog via
+      # `opencode models --verbose` (empty catalog fails that suite).
       - name: Install OpenCode
         env:
           GH_TOKEN: ${{ github.token }}
@@ -137,34 +180,7 @@ jobs:
       - name: Add OpenCode to PATH
         run: echo "$HOME/.opencode/bin" >> "$GITHUB_PATH"
 
-      - run: bun install --no-cache --frozen-lockfile --linker=isolated && bun install --no-cache --frozen-lockfile --linker=isolated
-
-      # Restore only: quality-gates is the main cache producer.
-      - name: Restore Nx cache
-        uses: ./.github/actions/nx-cache
-        with:
-          mode: restore-main
-
-      # Dev-path GraphQL smoke (Bun + Vite SSR); no Keymaxxer vault required.
-      # Production live e2e below remains vault-backed and separate.
-      - name: Harness dev smoke
-        run: bunx nx run harness:smoke
-
-      # Live Gherkin e2e: also runs on PRs via pr.yml (same vault secret).
-      - name: Require live e2e vault key
-        env:
-          E2E_KEYMAXXER_MASTER_KEY: ${{ secrets.E2E_KEYMAXXER_MASTER_KEY }}
-        run: |
-          if [ -z "${E2E_KEYMAXXER_MASTER_KEY}" ]; then
-            echo "error: repository secret E2E_KEYMAXXER_MASTER_KEY is required for the live Harness e2e step" >&2
-            exit 1
-          fi
-
-      - name: Install Playwright Chromium
-        working-directory: apps/harness
-        run: bunx playwright install --with-deps chromium
-
-      - name: Live Harness e2e
+      - name: Live Harness e2e (with OpenCode)
         id: live-e2e
         env:
           E2E_KEYMAXXER_MASTER_KEY: ${{ secrets.E2E_KEYMAXXER_MASTER_KEY }}

--- a/.github/workflows/overnight-install-smoke.yml
+++ b/.github/workflows/overnight-install-smoke.yml
@@ -4,6 +4,10 @@
 # harness without opencode on PATH, and asserts first-run health + default
 # Agent Backend Unavailable on linux-x64 and linux-arm64.
 #
+# Owns packaging / multi-arch published install. Product default-backend
+# behaviour in the monorepo live Gherkin suite is `harness:e2e-no-backend`
+# (@no-backend; issue #958) — do not replace or weaken this workflow with that.
+#
 # Complementary to CI/CD packed-install on main (pack-from-source, x64 only).
 name: Overnight install smoke
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -84,8 +84,9 @@ jobs:
         run: bunx nx run harness:slow-test
 
   # Dev smoke + live Gherkin e2e. Independent of quality-gates (parallel job).
-  # OpenCode CLI is required: live e2e first-run settings inspects the model
-  # catalog via `opencode models --verbose` (empty catalog fails the suite).
+  # Two live suites (issue #958): vault-free @no-backend first (no OpenCode),
+  # then vault-backed OpenCode suite (excludes @no-backend). Overnight owns
+  # published-install packaging; this job owns product behaviour.
   harness:
     runs-on: ubuntu-latest
     steps:
@@ -98,10 +99,60 @@ jobs:
         with:
           bun-version: latest
 
-      # Resolve the release via authenticated GitHub API then pin the installer
-      # --version flag: bare `opencode.ai/install` hits unauthenticated
-      # /releases/latest and fails under Actions rate limits.
+      - run: bun install --no-cache --frozen-lockfile --linker=isolated && bun install --no-cache --frozen-lockfile --linker=isolated
+
+      # Restore only: quality-gates is the PR cache producer.
+      - name: Restore Nx cache
+        uses: ./.github/actions/nx-cache
+        with:
+          mode: pr
+          pr-number: ${{ github.event.pull_request.number }}
+          allow-save: "false"
+
+      # Dev-path GraphQL smoke (Bun + Vite SSR); no Keymaxxer vault required.
+      - name: Harness dev smoke
+        run: bunx nx run harness:smoke
+
+      # Chromium once for both live suites (no-backend always; full suite when vault).
+      - name: Install Playwright Chromium
+        working-directory: apps/harness
+        run: bunx playwright install --with-deps chromium
+
+      # Product default-backend / first-run without OpenCode (vault-free; fork-safe).
+      - name: Live Harness e2e (no backend agents)
+        id: live-e2e-no-backend
+        run: bunx nx run harness:e2e-no-backend
+
+      - name: Upload Playwright diagnostics (no backend)
+        if: failure() && steps.live-e2e-no-backend.outcome == 'failure'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: playwright-report-no-backend
+          path: |
+            apps/harness/playwright-report/
+            apps/harness/test-results/
+          if-no-files-found: ignore
+          retention-days: 14
+
+      # Vault-backed OpenCode suite (same as ci-cd.yml on main).
+      # Same-repo PRs can read E2E_KEYMAXXER_MASTER_KEY; fork PRs cannot, so
+      # skip rather than fail-closed when the secret is empty.
+      - name: Check live e2e vault key
+        id: e2e-vault
+        env:
+          E2E_KEYMAXXER_MASTER_KEY: ${{ secrets.E2E_KEYMAXXER_MASTER_KEY }}
+        run: |
+          if [ -z "${E2E_KEYMAXXER_MASTER_KEY}" ]; then
+            echo "has_key=false" >> "$GITHUB_OUTPUT"
+            echo "Skipping vault-backed live Harness e2e: E2E_KEYMAXXER_MASTER_KEY is unavailable (expected for fork PRs)."
+          else
+            echo "has_key=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      # OpenCode only for the vault-backed suite: first-run model catalog via
+      # `opencode models --verbose` (empty catalog fails that suite).
       - name: Install OpenCode
+        if: steps.e2e-vault.outputs.has_key == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -115,44 +166,10 @@ jobs:
           test -n "$VERSION"
           curl -fsSL https://opencode.ai/install | bash -s -- --version "$VERSION" --no-modify-path
       - name: Add OpenCode to PATH
+        if: steps.e2e-vault.outputs.has_key == 'true'
         run: echo "$HOME/.opencode/bin" >> "$GITHUB_PATH"
 
-      - run: bun install --no-cache --frozen-lockfile --linker=isolated && bun install --no-cache --frozen-lockfile --linker=isolated
-
-      # Restore only: quality-gates is the PR cache producer.
-      - name: Restore Nx cache
-        uses: ./.github/actions/nx-cache
-        with:
-          mode: pr
-          pr-number: ${{ github.event.pull_request.number }}
-          allow-save: "false"
-
-      # Dev-path GraphQL smoke (Bun + Vite SSR); no Keymaxxer vault required.
-      # Production live e2e below remains vault-backed and separate.
-      - name: Harness dev smoke
-        run: bunx nx run harness:smoke
-
-      # Live Gherkin e2e (vault-backed, same suite as ci-cd.yml on main).
-      # Same-repo PRs can read E2E_KEYMAXXER_MASTER_KEY; fork PRs cannot, so
-      # skip rather than fail-closed when the secret is empty.
-      - name: Check live e2e vault key
-        id: e2e-vault
-        env:
-          E2E_KEYMAXXER_MASTER_KEY: ${{ secrets.E2E_KEYMAXXER_MASTER_KEY }}
-        run: |
-          if [ -z "${E2E_KEYMAXXER_MASTER_KEY}" ]; then
-            echo "has_key=false" >> "$GITHUB_OUTPUT"
-            echo "Skipping live Harness e2e: E2E_KEYMAXXER_MASTER_KEY is unavailable (expected for fork PRs)."
-          else
-            echo "has_key=true" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: Install Playwright Chromium
-        if: steps.e2e-vault.outputs.has_key == 'true'
-        working-directory: apps/harness
-        run: bunx playwright install --with-deps chromium
-
-      - name: Live Harness e2e
+      - name: Live Harness e2e (with OpenCode)
         if: steps.e2e-vault.outputs.has_key == 'true'
         id: live-e2e
         env:

--- a/apps/harness/README.md
+++ b/apps/harness/README.md
@@ -80,17 +80,30 @@ without wrapping the Harness in a second coordinator process.
 ## Live end-to-end
 
 The Gherkin operator journeys under `e2e/features/` run the production build
-against a fresh isolated Harness database. They verify adding and refreshing
-the GitHub and GitLab End-to-End Fixture Repositories through the real operator
-binary, as well as the dedicated Kanban pipeline route.
+against a fresh isolated Harness database. There are **two** live suites
+(separate Playwright / `webServer` boots; issue #958):
+
+| Target | Tag filter | Product PATH | Keymaxxer | What it covers |
+| --- | --- | --- | --- | --- |
+| `harness:e2e-no-backend` | `--grep @no-backend` | `E2E_AGENT_BACKEND_MODE=no-opencode` (ambient `opencode` stripped; fail-closed if still resolvable) | `KEYMAXXER_ENABLED=false` (vault-free) | Default Agent Backend Unavailable + first-run UI when OpenCode is absent; pure-absence and mixed-Ready (fake Claude) |
+| `harness:e2e` | `--grep-invert @no-backend` | Default (OpenCode expected in CI) | Fixture vault credential | Add/refresh fixture Repositories, Kanban, Settings history, catalog-only models, etc. |
 
 ```bash
+# Vault-free default-backend / first-run (no OpenCode install required)
+bunx nx run harness:e2e-no-backend
+
+# OpenCode-backed operator journeys (excludes @no-backend)
 bunx nx run harness:e2e
 ```
 
-Live e2e is non-interactive by default and requires a Keymaxxer credential
-before it starts the Harness, Sidecar, or CLI at all — it never falls back to
-silently prompting:
+Overnight published-install smoke (`.github/workflows/overnight-install-smoke.yml`)
+remains the packaging multi-arch gate; it does not replace these suites.
+
+### Vault-backed suite (`harness:e2e`)
+
+Non-interactive by default and requires a Keymaxxer credential before it
+starts the Harness, Sidecar, or CLI at all — it never falls back to silently
+prompting:
 
 - **Fixture vault (default, non-interactive):** set
   `E2E_KEYMAXXER_MASTER_KEY` (or the legacy `KEYMAXXER_MASTER_KEY`) to unlock
@@ -109,3 +122,14 @@ silently prompting:
 The GitLab scenario soft-skips until the fixture vault includes the GitLab
 secret; set `E2E_REQUIRE_GITLAB=1` to fail closed after bootstrap. See
 `docs/e2e-fixture.md` and `docs/adr/0021-live-harness-end-to-end-test.md`.
+
+### Vault-free suite (`harness:e2e-no-backend`)
+
+Does **not** require `E2E_KEYMAXXER_MASTER_KEY` (fork-PR safe). The supervisor
+soft-disables Keymaxxer, always prepends a fake `claude` CLI, and in
+`no-opencode` mode removes every PATH directory that provides ambient
+`opencode` / `grok` / `codex` / `claude` so a local developer install cannot
+silently green pure-absence or mixed-Ready scenarios. It fails closed if those
+binaries still resolve (except the fake `claude`). Claude readiness is toggled
+per scenario via the live-harness control protocol
+(`firstParty` / `unauthenticated`).

--- a/apps/harness/e2e/features/default-agent-backend-availability.feature
+++ b/apps/harness/e2e/features/default-agent-backend-availability.feature
@@ -1,0 +1,24 @@
+@no-backend
+Feature: Default Agent Backend availability without OpenCode
+  When coder CLIs are missing or only partially Ready, operators still get a
+  healthy UI and clear first-run guidance: the default backend must not look
+  silently Ready. Product behaviour lives here; packaging multi-arch remains
+  overnight install smoke (#937 / #958).
+
+  Scenario: Pure absence of Ready backends
+    Given Claude Code reports unauthenticated
+    When I open the home page for default-backend first-run guidance
+    Then GraphQL health is true
+    And the default Agent Backend status is UNAVAILABLE for opencode
+    And Claude Code preview status is UNAVAILABLE
+    And the UI shows default Agent Backend Unavailable guidance
+    And the UI does not list Ready Agent Backend alternatives
+
+  Scenario: Default missing with Claude Ready
+    Given Claude Code reports first-party authenticated
+    When I open the home page for default-backend first-run guidance
+    Then GraphQL health is true
+    And the default Agent Backend status is UNAVAILABLE for opencode
+    And Claude Code preview status is READY
+    And the UI shows default Agent Backend Unavailable guidance
+    And the UI lists Ready Agent Backend alternative "claude"

--- a/apps/harness/e2e/steps/default-agent-backend-availability.ts
+++ b/apps/harness/e2e/steps/default-agent-backend-availability.ts
@@ -1,0 +1,223 @@
+/**
+ * Live e2e for default Agent Backend availability without OpenCode (#958).
+ *
+ * Runs under `E2E_AGENT_BACKEND_MODE=no-opencode` + `KEYMAXXER_ENABLED=false`
+ * (`harness:e2e-no-backend`). The supervisor strips ambient `opencode` from
+ * the product PATH and soft-disables Keymaxxer; these steps only control the
+ * fake Claude readiness and assert GraphQL + first-run UI guidance.
+ */
+
+import { type Page, expect } from "@playwright/test"
+import { E2E_GRAPHQL_URL } from "../support/constants.ts"
+import { settingsDialog } from "../support/first-run-settings.ts"
+import {
+  CONTROL_FILES,
+  type FakeClaudeMode,
+  readGeneration,
+  readLiveHarnessState,
+  writeControlFile,
+} from "../support/live-harness-control.ts"
+import { Given, Then, When } from "./fixtures.ts"
+
+type GraphqlEnvelope<T> = {
+  data?: T
+  errors?: ReadonlyArray<{ message: string }>
+}
+
+const graphqlJson = async <T>(
+  query: string,
+  variables?: Record<string, unknown>,
+): Promise<T> => {
+  const response = await fetch(E2E_GRAPHQL_URL, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ query, variables }),
+  })
+  if (!response.ok) {
+    throw new Error(`GraphQL HTTP ${response.status}: ${await response.text()}`)
+  }
+  const payload = (await response.json()) as GraphqlEnvelope<T>
+  if (payload.errors?.length) {
+    throw new Error(
+      `GraphQL errors: ${payload.errors.map((e) => e.message).join("; ")}`,
+    )
+  }
+  if (payload.data === undefined) {
+    throw new Error("GraphQL response missing data")
+  }
+  return payload.data
+}
+
+const graphqlReachable = async (): Promise<boolean> => {
+  try {
+    const data = await graphqlJson<{ health: boolean }>(`query { health }`)
+    return data.health === true
+  } catch {
+    return false
+  }
+}
+
+const setClaudeModeAndRestart = async (mode: FakeClaudeMode) => {
+  const state = readLiveHarnessState()
+  const before = readGeneration(state)
+  writeControlFile(state, CONTROL_FILES.claudeMode, mode)
+  // Empty seed: only fake-CLI readiness changed.
+  writeControlFile(state, CONTROL_FILES.seedSql, "")
+  writeControlFile(state, CONTROL_FILES.restart, "1")
+  await expect
+    .poll(() => readGeneration(state), { timeout: 60_000, intervals: [250] })
+    .toBeGreaterThan(before)
+  await expect
+    .poll(graphqlReachable, { timeout: 120_000, intervals: [500] })
+    .toBe(true)
+}
+
+Given("Claude Code reports unauthenticated", async () => {
+  await setClaudeModeAndRestart("unauthenticated")
+})
+
+Given("Claude Code reports first-party authenticated", async () => {
+  await setClaudeModeAndRestart("firstParty")
+})
+
+/**
+ * First-run / Unavailable-backend Settings auto-opens. Dismiss it so the
+ * page-shell banner (issue #937 guidance) is visible for UI assertions.
+ */
+const openHomeAndDismissAutoSettings = async (page: Page) => {
+  await page.goto("/")
+  const dialog = settingsDialog(page)
+  const landmark = page
+    .getByRole("heading", { name: "No repositories configured" })
+    .or(page.getByRole("region", { name: "Lifecycle pipeline" }))
+    .or(page.getByRole("region", { name: "Configured repositories" }))
+
+  await expect(dialog.or(landmark)).toBeVisible({ timeout: 60_000 })
+
+  if (await dialog.isVisible()) {
+    await dialog.getByRole("button", { name: "Cancel" }).click()
+    await expect(dialog).toBeHidden()
+  } else {
+    // Config / backend status may still be loading; wait for auto-open then dismiss.
+    await expect(dialog).toBeVisible({ timeout: 60_000 })
+    await dialog.getByRole("button", { name: "Cancel" }).click()
+    await expect(dialog).toBeHidden()
+  }
+}
+
+When(
+  "I open the home page for default-backend first-run guidance",
+  async ({ page }) => {
+    await openHomeAndDismissAutoSettings(page)
+  },
+)
+
+Then("GraphQL health is true", async () => {
+  const data = await graphqlJson<{ health: boolean }>(`query { health }`)
+  expect(data.health).toBe(true)
+})
+
+Then(
+  "the default Agent Backend status is UNAVAILABLE for opencode",
+  async () => {
+    const data = await graphqlJson<{
+      config: { selectedAgentBackend: string }
+      agentBackendStatus: {
+        kind: string
+        reason: string | null
+        backend: { id: string }
+        selectedBackend: { id: string } | null
+      }
+    }>(`query {
+      config { selectedAgentBackend }
+      agentBackendStatus {
+        kind
+        reason
+        backend { id }
+        selectedBackend { id }
+      }
+    }`)
+
+    expect(data.config.selectedAgentBackend).toBe("opencode")
+    const status = data.agentBackendStatus
+    const selectedId = status.selectedBackend?.id ?? status.backend.id
+    expect(selectedId).toBe("opencode")
+    expect(status.kind.toUpperCase()).toBe("UNAVAILABLE")
+    // Reason must be present so operators are not left with a silent failure.
+    expect((status.reason ?? "").trim().length).toBeGreaterThan(0)
+  },
+)
+
+Then(
+  "Claude Code preview status is {word}",
+  // biome-ignore lint/correctness/noEmptyPattern: playwright-bdd requires the first argument to use the object destructuring pattern.
+  async ({}, expectedKind: string) => {
+    const data = await graphqlJson<{
+      previewAgentBackend: {
+        kind: string
+        backend: { id: string }
+      }
+    }>(
+      `query PreviewClaude($backendId: String!) {
+        previewAgentBackend(backendId: $backendId) {
+          kind
+          backend { id }
+        }
+      }`,
+      { backendId: "claude" },
+    )
+    expect(data.previewAgentBackend.backend.id).toBe("claude")
+    expect(data.previewAgentBackend.kind.toUpperCase()).toBe(
+      expectedKind.toUpperCase(),
+    )
+  },
+)
+
+/**
+ * Page-shell default-Unavailable banner (tag Backend, role status).
+ * Copy varies: pure absence uses "OpenCode: <reason>"; mixed-Ready uses
+ * "Default Agent Backend 'opencode' is not available … Ready: …" (#937).
+ */
+const backendBanner = (page: Page) =>
+  page
+    .getByRole("status")
+    .filter({ has: page.getByRole("button", { name: "Open Settings" }) })
+    .filter({
+      hasText: /OpenCode|opencode|Agent Backend|not available|unavailable/i,
+    })
+
+Then(
+  "the UI shows default Agent Backend Unavailable guidance",
+  async ({ page }) => {
+    const banner = backendBanner(page)
+    await expect(banner).toBeVisible({ timeout: 60_000 })
+    await expect(banner).toContainText(
+      /not available|unavailable|NotFound|OpenCode/i,
+    )
+    await expect(banner).toContainText(/opencode/i)
+  },
+)
+
+Then(
+  "the UI does not list Ready Agent Backend alternatives",
+  async ({ page }) => {
+    const banner = backendBanner(page)
+    await expect(banner).toBeVisible({ timeout: 60_000 })
+    // #937 mixed-Ready guidance includes "Ready: …"; pure absence must not.
+    await expect(banner).not.toContainText(/Ready:\s*\S+/i)
+  },
+)
+
+Then(
+  "the UI lists Ready Agent Backend alternative {string}",
+  async ({ page }, backendId: string) => {
+    const banner = backendBanner(page)
+    await expect(banner).toBeVisible({ timeout: 60_000 })
+    // Banner probes non-default backends via previewAgentBackend; allow time.
+    // Ready list may include several ids ("Ready: claude" or "Ready: grok, claude").
+    await expect(banner).toContainText(
+      new RegExp(`Ready:.*\\b${backendId}\\b`, "i"),
+      { timeout: 60_000 },
+    )
+  },
+)

--- a/apps/harness/e2e/support/agent-backend-path.ts
+++ b/apps/harness/e2e/support/agent-backend-path.ts
@@ -1,0 +1,154 @@
+/**
+ * Product PATH control for live e2e Agent Backend modes (issue #958).
+ *
+ * `no-opencode` must fail closed if ambient developer/CI coder CLIs would
+ * otherwise leak onto the Harness process PATH and silently green pure-absence
+ * scenarios. Fake `claude` is prepended separately; ambient `claude` dirs are
+ * stripped so only the controlled fake remains.
+ */
+
+import { accessSync, constants, existsSync } from "node:fs"
+import { delimiter, join } from "node:path"
+
+export type AgentBackendE2eMode = "default" | "no-opencode"
+
+const MODE_ENV = "E2E_AGENT_BACKEND_MODE"
+
+/**
+ * Ambient Agent Backend CLIs stripped under `no-opencode` so pure-absence and
+ * mixed-Ready scenarios only see the fake `claude` the supervisor installs.
+ * Default harness backend `opencode` is included; other first-party binaries
+ * must not report Ready from a developer PATH.
+ */
+export const NO_OPENCODE_STRIPPED_BINARIES = [
+  "opencode",
+  "grok",
+  "codex",
+  "claude",
+] as const
+
+/**
+ * Resolves the live e2e Agent Backend PATH mode. Unknown values fail closed
+ * rather than silently running as `default`.
+ */
+export const resolveAgentBackendE2eMode = (
+  environment: NodeJS.ProcessEnv = process.env,
+): AgentBackendE2eMode => {
+  const raw = environment[MODE_ENV]?.trim().toLowerCase()
+  if (raw === undefined || raw === "" || raw === "default") {
+    return "default"
+  }
+  if (raw === "no-opencode") {
+    return "no-opencode"
+  }
+  throw new Error(
+    `${MODE_ENV} must be "default" or "no-opencode", got ${JSON.stringify(environment[MODE_ENV])}`,
+  )
+}
+
+const isExecutableFile = (path: string): boolean => {
+  if (!existsSync(path)) {
+    return false
+  }
+  try {
+    accessSync(path, constants.X_OK)
+    return true
+  } catch {
+    // Present but not executable still counts as providing the name for PATH
+    // pollution purposes (e.g. a non-exec stub that would confuse which).
+    return existsSync(path)
+  }
+}
+
+/** True when `dir` contains a file named `binary` (optionally executable). */
+export const directoryProvidesBinary = (
+  dir: string,
+  binary: string,
+): boolean => {
+  if (dir.length === 0) {
+    return false
+  }
+  return isExecutableFile(join(dir, binary))
+}
+
+/**
+ * Drop every PATH entry that provides any of `binaries` so ambient installs
+ * cannot shadow the product PATH under test.
+ */
+export const pathWithoutBinaries = (
+  pathEnv: string,
+  binaries: readonly string[],
+): string =>
+  pathEnv
+    .split(delimiter)
+    .filter(
+      (dir) =>
+        dir.length > 0 &&
+        !binaries.some((binary) => directoryProvidesBinary(dir, binary)),
+    )
+    .join(delimiter)
+
+export type ResolveWhich = (
+  command: string,
+  options?: { PATH?: string },
+) => string | null
+
+/**
+ * Fail closed when ambient coder CLIs remain resolvable on the product PATH
+ * under `no-opencode` mode (except the fake `claude` we just prepended).
+ * Returns without throwing in `default` mode.
+ */
+export const assertNoAmbientAgentCliOnProductPath = (options: {
+  readonly mode: AgentBackendE2eMode
+  readonly productPath: string
+  readonly fakeCliBinDir: string
+  readonly which?: ResolveWhich
+}): void => {
+  if (options.mode !== "no-opencode") {
+    return
+  }
+  const which = options.which ?? ((command, opts) => Bun.which(command, opts))
+  for (const binary of NO_OPENCODE_STRIPPED_BINARIES) {
+    const found = which(binary, { PATH: options.productPath })
+    if (found === null) {
+      if (binary === "claude") {
+        throw new Error(
+          `${MODE_ENV}=no-opencode requires the fake claude binary on the product PATH`,
+        )
+      }
+      continue
+    }
+    // Claude must resolve only to our fake CLI bin dir, not ambient installs.
+    if (binary === "claude") {
+      const expected = join(options.fakeCliBinDir, "claude")
+      if (
+        found !== expected &&
+        !found.startsWith(`${options.fakeCliBinDir}/`)
+      ) {
+        throw new Error(
+          `${MODE_ENV}=no-opencode requires only the fake claude on PATH, but claude resolves to ${found}`,
+        )
+      }
+      continue
+    }
+    throw new Error(
+      `${MODE_ENV}=no-opencode requires ${binary} absent from the product PATH, but it resolves to ${found}`,
+    )
+  }
+}
+
+/**
+ * Build the PATH for the Harness child: always prepend the fake-CLI bin dir;
+ * in `no-opencode` mode, strip ambient Agent Backend CLI directories first.
+ */
+export const buildProductPath = (options: {
+  readonly mode: AgentBackendE2eMode
+  readonly fakeCliBinDir: string
+  readonly ambientPath: string
+}): string => {
+  const base =
+    options.mode === "no-opencode"
+      ? pathWithoutBinaries(options.ambientPath, NO_OPENCODE_STRIPPED_BINARIES)
+      : options.ambientPath
+  return `${options.fakeCliBinDir}${delimiter}${base}`
+}

--- a/apps/harness/e2e/support/clone-fixture-repo.ts
+++ b/apps/harness/e2e/support/clone-fixture-repo.ts
@@ -88,12 +88,20 @@ const keymaxxerBin = () => {
 /**
  * Fixture-vault environment for a Keymaxxer CLI/Sidecar call, or `null` when
  * policy resolves to interactive mode (ambient `~/.keymaxxer`, opted into via
- * `E2E_ALLOW_KEYMAXXER_PROMPTS=1`). Throws when no credential is available
- * and no interactive opt-in was given — see `keymaxxer-e2e-policy.ts`.
+ * `E2E_ALLOW_KEYMAXXER_PROMPTS=1`). Vault-free `@no-backend` e2e
+ * (`KEYMAXXER_ENABLED=false` → policy mode `disabled`) cannot clone fixtures
+ * and fails closed here. Throws when no credential is available and no
+ * interactive opt-in was given — see `keymaxxer-e2e-policy.ts`.
  */
 const fixtureVaultEnv = (): NodeJS.ProcessEnv | null => {
   const policy = resolveKeymaxxerE2ePolicy()
   if (policy.mode === "interactive") return null
+  if (policy.mode !== "fixture") {
+    throw new Error(
+      "Fixture Repository clone requires Keymaxxer; KEYMAXXER_ENABLED=false " +
+        "(vault-free e2e) cannot clone. Use harness:e2e for vault-backed scenarios.",
+    )
+  }
 
   const home = mkdtempSync(join(tmpdir(), "rfa-e2e-keymaxxer-home-"))
   seedFixtureVaultHome(home)

--- a/apps/harness/e2e/support/keymaxxer-e2e-policy.ts
+++ b/apps/harness/e2e/support/keymaxxer-e2e-policy.ts
@@ -1,19 +1,20 @@
 /**
  * Central non-interactive policy for live e2e's Keymaxxer usage.
  *
- * Live e2e is the one supported Harness test entry point that keeps
- * Keymaxxer enabled on purpose: it validates the production application,
- * Keymaxxer Sidecar, command-line client, and controlled Forge Repositories
- * together. That means it needs a way to run without ever prompting an
- * operator, while still allowing a human to intentionally test against their
- * own ambient vault.
+ * Vault-backed live e2e (`harness:e2e`) keeps Keymaxxer enabled on purpose:
+ * it validates the production application, Keymaxxer Sidecar, command-line
+ * client, and controlled Forge Repositories together. Vault-free live e2e
+ * (`harness:e2e-no-backend`) soft-disables Keymaxxer via
+ * `KEYMAXXER_ENABLED=false` (and clears fixture master-key env) so fork PRs
+ * still get coverage.
  *
  * `resolveKeymaxxerE2ePolicy` is the single seam both the live-Harness
  * supervisor (`start-live-harness.ts`) and the fixture-clone helper
  * (`clone-fixture-repo.ts`) call before touching Keymaxxer, so neither can
  * drift into a silent prompt: a fixture master key selects the checked-in
- * vault, `E2E_ALLOW_KEYMAXXER_PROMPTS=1` is the only way to opt into the
- * operator's ambient vault, and anything else fails closed with an
+ * vault, `KEYMAXXER_ENABLED=false` without a master key is vault-free
+ * soft-disable, `E2E_ALLOW_KEYMAXXER_PROMPTS=1` is the only way to opt into
+ * the operator's ambient vault, and anything else fails closed with an
  * actionable diagnostic.
  */
 
@@ -28,6 +29,8 @@ const fixtureVaultDir = resolve(workspaceRoot, "e2e/fixtures/keymaxxer")
 export type KeymaxxerE2ePolicy =
   | { readonly mode: "fixture"; readonly masterKey: string }
   | { readonly mode: "interactive" }
+  /** Soft-disabled product path (e.g. `@no-backend` e2e / KEYMAXXER_ENABLED=false). */
+  | { readonly mode: "disabled" }
 
 const FIXTURE_REQUIRED_MESSAGE =
   "Live e2e requires E2E_KEYMAXXER_MASTER_KEY (or the legacy KEYMAXXER_MASTER_KEY) " +
@@ -40,15 +43,22 @@ const NO_CREDENTIAL_MESSAGE = [
   "non-interactively against the checked-in fixture vault, or set",
   "E2E_ALLOW_KEYMAXXER_PROMPTS=1 to explicitly opt into interactive prompts",
   "against your ambient ~/.keymaxxer vault.",
+  "Vault-free suites set KEYMAXXER_ENABLED=false (e.g. harness:e2e-no-backend).",
 ].join(" ")
 
 /**
- * Resolves whether live e2e runs against the non-interactive fixture vault
- * or the operator's ambient vault. A fixture master key always wins. Absent
- * one, CI and explicit fixture-vault requests fail closed rather than
- * falling back to an ambient vault; local runs need the explicit
- * `E2E_ALLOW_KEYMAXXER_PROMPTS=1` opt-in to run interactively. Missing
- * credentials without that opt-in are an error, not a silent prompt.
+ * Resolves whether live e2e runs against the non-interactive fixture vault,
+ * the operator's ambient vault, or with Keymaxxer soft-disabled.
+ *
+ * Priority:
+ * 1. A non-empty fixture master key always selects fixture mode — including
+ *    when ambient `KEYMAXXER_ENABLED=false` is set from product soft-disable
+ *    docs — so vault-backed `harness:e2e` is not broken by that flag.
+ * 2. `KEYMAXXER_ENABLED=false` without a master key is vault-free soft-disable
+ *    (`harness:e2e-no-backend` clears master-key env and sets this flag).
+ * 3. CI / `E2E_USE_FIXTURE_VAULT=1` without a master key fail closed.
+ * 4. `E2E_ALLOW_KEYMAXXER_PROMPTS=1` opts into ambient interactive vault.
+ * 5. Otherwise fail closed with an actionable diagnostic (never silent prompt).
  */
 export const resolveKeymaxxerE2ePolicy = (
   environment: NodeJS.ProcessEnv = process.env,
@@ -58,6 +68,10 @@ export const resolveKeymaxxerE2ePolicy = (
     environment.KEYMAXXER_MASTER_KEY?.trim()
   if (masterKey) {
     return { mode: "fixture", masterKey }
+  }
+
+  if (environment.KEYMAXXER_ENABLED?.trim().toLowerCase() === "false") {
+    return { mode: "disabled" }
   }
 
   const fixtureRequested =

--- a/apps/harness/e2e/support/start-live-harness.ts
+++ b/apps/harness/e2e/support/start-live-harness.ts
@@ -4,6 +4,8 @@
  *
  * CI / fixture mode: temporary HOME with the checked-in encrypted vault.
  * Local mode: developer's vault; does not copy over ~/.keymaxxer.
+ * Vault-free mode (`KEYMAXXER_ENABLED=false`): no Keymaxxer Sidecar or vault
+ * (used by `@no-backend` / `harness:e2e-no-backend`, issue #958).
  *
  * The Harness runs as a supervised child so scenarios can request a restart
  * and seed legacy rows against the stopped database (issue #838); see
@@ -12,6 +14,11 @@
  * Agent Model catalog are fixed for the run: no Anthropic login, no AWS call,
  * and no billable model is ever involved. `CLAUDE_CODE_USE_BEDROCK` is
  * explicitly removed so the Harness runs in first-party configuration mode.
+ *
+ * `E2E_AGENT_BACKEND_MODE=no-opencode` strips ambient Agent Backend CLIs
+ * (`opencode`, `grok`, `codex`, ambient `claude`) from the product PATH and
+ * fails closed if they still resolve, except the controlled fake `claude`
+ * (issue #958).
  */
 
 import { type ChildProcess, spawn } from "node:child_process"
@@ -26,8 +33,13 @@ import {
   writeFileSync,
 } from "node:fs"
 import { tmpdir } from "node:os"
-import { delimiter, dirname, join, resolve } from "node:path"
+import { dirname, join, resolve } from "node:path"
 import { fileURLToPath } from "node:url"
+import {
+  assertNoAmbientAgentCliOnProductPath,
+  buildProductPath,
+  resolveAgentBackendE2eMode,
+} from "./agent-backend-path.ts"
 import { E2E_HARNESS_PORT } from "./constants.ts"
 import {
   type KeymaxxerE2ePolicy,
@@ -48,10 +60,12 @@ const port = Number(process.env.E2E_HARNESS_PORT ?? E2E_HARNESS_PORT)
 
 // Fail fast, before creating any temp dir, fake CLI, or production-build
 // check: a missing credential must never get far enough to touch the
-// Harness, Sidecar, or Keymaxxer CLI.
+// Harness, Sidecar, or Keymaxxer CLI (unless Keymaxxer is soft-disabled).
 let keymaxxerPolicy: KeymaxxerE2ePolicy
+let agentBackendMode: ReturnType<typeof resolveAgentBackendE2eMode>
 try {
   keymaxxerPolicy = resolveKeymaxxerE2ePolicy()
+  agentBackendMode = resolveAgentBackendE2eMode()
 } catch (error) {
   console.error(error instanceof Error ? error.message : String(error))
   process.exit(1)
@@ -100,9 +114,25 @@ exit 1
 )
 chmodSync(join(binDir, "claude"), 0o755)
 
+const productPath = buildProductPath({
+  mode: agentBackendMode,
+  fakeCliBinDir: binDir,
+  ambientPath: process.env.PATH ?? "",
+})
+try {
+  assertNoAmbientAgentCliOnProductPath({
+    mode: agentBackendMode,
+    productPath,
+    fakeCliBinDir: binDir,
+  })
+} catch (error) {
+  console.error(error instanceof Error ? error.message : String(error))
+  process.exit(1)
+}
+
 const env: NodeJS.ProcessEnv = {
   ...process.env,
-  PATH: `${binDir}${delimiter}${process.env.PATH ?? ""}`,
+  PATH: productPath,
   SQLITE_DATABASE_PATH: dbPath,
   PORT: String(port),
   NO_BROWSER: "1",
@@ -120,6 +150,16 @@ if (keymaxxerPolicy.mode === "fixture") {
   )
   // Fresh sidecar bound to the fixture vault — do not reuse a developer sidecar.
   delete env.KEYMAXXER_SIDECAR_URL
+  // Ambient product soft-disable must not keep Keymaxxer off when vault e2e
+  // intentionally selected fixture mode (master key wins in the policy).
+  delete env.KEYMAXXER_ENABLED
+} else if (keymaxxerPolicy.mode === "disabled") {
+  // Soft-disable product Keymaxxer (same as overnight / packed smoke). Do not
+  // seed a vault or reuse a developer sidecar.
+  env.KEYMAXXER_ENABLED = "false"
+  delete env.KEYMAXXER_SIDECAR_URL
+  delete env.KEYMAXXER_MASTER_KEY
+  delete env.E2E_KEYMAXXER_MASTER_KEY
 }
 // keymaxxerPolicy.mode === "interactive": leave the environment untouched so
 // Keymaxxer uses the operator's ambient ~/.keymaxxer vault, prompts and all.

--- a/apps/harness/project.json
+++ b/apps/harness/project.json
@@ -77,7 +77,27 @@
       "executor": "nx:run-commands",
       "options": {
         "cwd": "{projectRoot}",
-        "command": "bddgen && playwright test"
+        "command": "bddgen && playwright test --grep-invert @no-backend"
+      },
+      "dependsOn": [
+        "build",
+        {
+          "projects": ["graphql-client"],
+          "target": "generate"
+        }
+      ]
+    },
+    "e2e-no-backend": {
+      "executor": "nx:run-commands",
+      "options": {
+        "cwd": "{projectRoot}",
+        "command": "bddgen && playwright test --grep @no-backend",
+        "env": {
+          "E2E_AGENT_BACKEND_MODE": "no-opencode",
+          "KEYMAXXER_ENABLED": "false",
+          "E2E_KEYMAXXER_MASTER_KEY": "",
+          "KEYMAXXER_MASTER_KEY": ""
+        }
       },
       "dependsOn": [
         "build",

--- a/apps/harness/test/agent-backend-path.test.ts
+++ b/apps/harness/test/agent-backend-path.test.ts
@@ -1,0 +1,141 @@
+import {
+  chmodSync,
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs"
+import { tmpdir } from "node:os"
+import { delimiter, join } from "node:path"
+import {
+  assertNoAmbientAgentCliOnProductPath,
+  buildProductPath,
+  directoryProvidesBinary,
+  pathWithoutBinaries,
+  resolveAgentBackendE2eMode,
+} from "../e2e/support/agent-backend-path.ts"
+import { afterEach, describe, expect, test } from "bun:test"
+
+describe("resolveAgentBackendE2eMode", () => {
+  test("defaults to default when unset or empty", () => {
+    expect(resolveAgentBackendE2eMode({})).toBe("default")
+    expect(resolveAgentBackendE2eMode({ E2E_AGENT_BACKEND_MODE: "" })).toBe(
+      "default",
+    )
+    expect(
+      resolveAgentBackendE2eMode({ E2E_AGENT_BACKEND_MODE: "  default  " }),
+    ).toBe("default")
+  })
+
+  test("accepts no-opencode", () => {
+    expect(
+      resolveAgentBackendE2eMode({ E2E_AGENT_BACKEND_MODE: "no-opencode" }),
+    ).toBe("no-opencode")
+    expect(
+      resolveAgentBackendE2eMode({ E2E_AGENT_BACKEND_MODE: "NO-OPENCODE" }),
+    ).toBe("no-opencode")
+  })
+
+  test("fails closed on unknown values", () => {
+    expect(() =>
+      resolveAgentBackendE2eMode({ E2E_AGENT_BACKEND_MODE: "maybe" }),
+    ).toThrow(/E2E_AGENT_BACKEND_MODE/)
+  })
+})
+
+describe("pathWithoutBinaries / directoryProvidesBinary", () => {
+  let root: string | undefined
+
+  afterEach(() => {
+    if (root !== undefined) {
+      rmSync(root, { recursive: true, force: true })
+      root = undefined
+    }
+  })
+
+  test("strips directories that provide any listed binary and keeps others", () => {
+    root = mkdtempSync(join(tmpdir(), "agent-backend-path-"))
+    const withOpenCode = join(root, "with-opencode")
+    const withGrok = join(root, "with-grok")
+    const without = join(root, "plain")
+    mkdirSync(withOpenCode, { recursive: true })
+    mkdirSync(withGrok, { recursive: true })
+    mkdirSync(without, { recursive: true })
+    writeFileSync(join(withOpenCode, "opencode"), "#!/bin/sh\n")
+    chmodSync(join(withOpenCode, "opencode"), 0o755)
+    writeFileSync(join(withGrok, "grok"), "#!/bin/sh\n")
+    chmodSync(join(withGrok, "grok"), 0o755)
+
+    expect(directoryProvidesBinary(withOpenCode, "opencode")).toBe(true)
+    expect(directoryProvidesBinary(without, "opencode")).toBe(false)
+
+    const ambient = [withOpenCode, without, withGrok].join(delimiter)
+    const filtered = pathWithoutBinaries(ambient, ["opencode", "grok", "codex"])
+    expect(filtered.split(delimiter)).toEqual([without])
+  })
+})
+
+describe("buildProductPath / assertNoAmbientAgentCliOnProductPath", () => {
+  test("always prepends the fake CLI bin dir", () => {
+    const path = buildProductPath({
+      mode: "default",
+      fakeCliBinDir: "/tmp/fake-bin",
+      ambientPath: "/usr/bin",
+    })
+    expect(path.startsWith(`/tmp/fake-bin${delimiter}`)).toBe(true)
+    expect(path).toContain("/usr/bin")
+  })
+
+  test("no-opencode mode fails when which still finds opencode", () => {
+    expect(() =>
+      assertNoAmbientAgentCliOnProductPath({
+        mode: "no-opencode",
+        productPath: "/tmp/product",
+        fakeCliBinDir: "/tmp/fake-bin",
+        which: (command) =>
+          command === "opencode" ? "/leaked/opencode" : null,
+      }),
+    ).toThrow(/opencode/)
+  })
+
+  test("no-opencode mode requires fake claude and rejects ambient claude", () => {
+    expect(() =>
+      assertNoAmbientAgentCliOnProductPath({
+        mode: "no-opencode",
+        productPath: "/tmp/product",
+        fakeCliBinDir: "/tmp/fake-bin",
+        which: () => null,
+      }),
+    ).toThrow(/fake claude/)
+
+    expect(() =>
+      assertNoAmbientAgentCliOnProductPath({
+        mode: "no-opencode",
+        productPath: "/tmp/product",
+        fakeCliBinDir: "/tmp/fake-bin",
+        which: (command) => (command === "claude" ? "/ambient/claude" : null),
+      }),
+    ).toThrow(/fake claude/)
+
+    expect(() =>
+      assertNoAmbientAgentCliOnProductPath({
+        mode: "no-opencode",
+        productPath: "/tmp/fake-bin:/tmp/product",
+        fakeCliBinDir: "/tmp/fake-bin",
+        which: (command) =>
+          command === "claude" ? "/tmp/fake-bin/claude" : null,
+      }),
+    ).not.toThrow()
+  })
+
+  test("default mode never asserts absence", () => {
+    expect(() =>
+      assertNoAmbientAgentCliOnProductPath({
+        mode: "default",
+        productPath: "/tmp/product",
+        fakeCliBinDir: "/tmp/fake-bin",
+        which: () => "/anywhere/opencode",
+      }),
+    ).not.toThrow()
+  })
+})

--- a/apps/harness/test/keymaxxer-e2e-policy.test.ts
+++ b/apps/harness/test/keymaxxer-e2e-policy.test.ts
@@ -9,6 +9,25 @@ import {
 import { afterEach, describe, expect, test } from "bun:test"
 
 describe("resolveKeymaxxerE2ePolicy", () => {
+  test("fixture master key wins over ambient KEYMAXXER_ENABLED=false (vault-backed e2e)", () => {
+    const policy = resolveKeymaxxerE2ePolicy({
+      KEYMAXXER_ENABLED: "false",
+      CI: "true",
+      E2E_KEYMAXXER_MASTER_KEY: "vault-key",
+    })
+    expect(policy).toEqual({ mode: "fixture", masterKey: "vault-key" })
+  })
+
+  test("KEYMAXXER_ENABLED=false without a master key is vault-free soft-disable", () => {
+    const policy = resolveKeymaxxerE2ePolicy({
+      KEYMAXXER_ENABLED: "false",
+      CI: "true",
+      E2E_KEYMAXXER_MASTER_KEY: "",
+      KEYMAXXER_MASTER_KEY: "   ",
+    })
+    expect(policy).toEqual({ mode: "disabled" })
+  })
+
   test("selects fixture mode when E2E_KEYMAXXER_MASTER_KEY is set", () => {
     const policy = resolveKeymaxxerE2ePolicy({ E2E_KEYMAXXER_MASTER_KEY: "k" })
     expect(policy).toEqual({ mode: "fixture", masterKey: "k" })

--- a/apps/harness/test/start-live-harness-preflight.test.ts
+++ b/apps/harness/test/start-live-harness-preflight.test.ts
@@ -14,12 +14,15 @@ describe("start-live-harness preflight", () => {
   test("fails fast with an actionable diagnostic when no credential or opt-in is present", () => {
     const harnessRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..")
     const env = { ...process.env }
+    // harness:test forces KEYMAXXER_ENABLED=false; clear it so this case
+    // exercises the credential gate rather than vault-free soft-disable.
     for (const key of [
       "E2E_KEYMAXXER_MASTER_KEY",
       "KEYMAXXER_MASTER_KEY",
       "CI",
       "E2E_USE_FIXTURE_VAULT",
       "E2E_ALLOW_KEYMAXXER_PROMPTS",
+      "KEYMAXXER_ENABLED",
     ]) {
       delete env[key]
     }
@@ -48,7 +51,11 @@ describe("start-live-harness preflight", () => {
       CI: "true",
       E2E_ALLOW_KEYMAXXER_PROMPTS: "1",
     }
-    for (const key of ["E2E_KEYMAXXER_MASTER_KEY", "KEYMAXXER_MASTER_KEY"]) {
+    for (const key of [
+      "E2E_KEYMAXXER_MASTER_KEY",
+      "KEYMAXXER_MASTER_KEY",
+      "KEYMAXXER_ENABLED",
+    ]) {
       delete env[key]
     }
 
@@ -65,5 +72,40 @@ describe("start-live-harness preflight", () => {
     expect(result.status).not.toBe(0)
     expect(result.stderr).toContain("E2E_KEYMAXXER_MASTER_KEY")
     expect(result.stderr).not.toContain("Production build missing")
+  })
+
+  test("KEYMAXXER_ENABLED=false skips credential preflight (vault-free e2e)", () => {
+    const harnessRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..")
+    // Invalid agent-backend mode fails after Keymaxxer policy, without needing
+    // a missing production build (dist may already exist from a prior e2e run).
+    const env: NodeJS.ProcessEnv = {
+      ...process.env,
+      KEYMAXXER_ENABLED: "false",
+      CI: "true",
+      E2E_AGENT_BACKEND_MODE: "not-a-valid-mode",
+    }
+    for (const key of [
+      "E2E_KEYMAXXER_MASTER_KEY",
+      "KEYMAXXER_MASTER_KEY",
+      "E2E_ALLOW_KEYMAXXER_PROMPTS",
+      "E2E_USE_FIXTURE_VAULT",
+    ]) {
+      delete env[key]
+    }
+
+    const result = spawnSync(
+      process.execPath,
+      [
+        "--conditions",
+        "@ready-for-agent/source",
+        "e2e/support/start-live-harness.ts",
+      ],
+      { cwd: harnessRoot, env, encoding: "utf8", timeout: 15_000 },
+    )
+
+    expect(result.status).not.toBe(0)
+    expect(result.stderr).not.toContain("E2E_KEYMAXXER_MASTER_KEY")
+    expect(result.stderr).not.toContain("E2E_ALLOW_KEYMAXXER_PROMPTS")
+    expect(result.stderr).toContain("E2E_AGENT_BACKEND_MODE")
   })
 })

--- a/apps/harness/test/topology.test.ts
+++ b/apps/harness/test/topology.test.ts
@@ -77,7 +77,7 @@ describe("single application server topology", () => {
     expect(smokeScript).not.toContain("E2E_KEYMAXXER_MASTER_KEY")
   })
 
-  test("forces KEYMAXXER_ENABLED=false at the ordinary test-target boundary, but not for live e2e", async () => {
+  test("forces KEYMAXXER_ENABLED=false at the ordinary test-target boundary, but not for vault-backed live e2e", async () => {
     const harness = await readJson<{ targets: Record<string, Target> }>(
       "../project.json",
     )
@@ -87,9 +87,29 @@ describe("single application server topology", () => {
       "false",
     )
     expect(harness.targets.smoke?.options?.env?.KEYMAXXER_ENABLED).toBe("false")
-    // Live e2e is the one supported suite that intentionally keeps Keymaxxer
-    // enabled: it validates the real Sidecar, CLI, and fixture credentials.
+    // Vault-backed live e2e intentionally keeps Keymaxxer enabled: it validates
+    // the real Sidecar, CLI, and fixture credentials.
     expect(harness.targets.e2e?.options?.env?.KEYMAXXER_ENABLED).toBeUndefined()
+    expect(harness.targets.e2e?.options?.command).toContain(
+      "--grep-invert @no-backend",
+    )
+    // Vault-free @no-backend suite: soft-disable Keymaxxer, clear ambient
+    // master keys so fixture mode cannot win, and strip OpenCode.
+    expect(
+      harness.targets["e2e-no-backend"]?.options?.env?.KEYMAXXER_ENABLED,
+    ).toBe("false")
+    expect(
+      harness.targets["e2e-no-backend"]?.options?.env?.E2E_KEYMAXXER_MASTER_KEY,
+    ).toBe("")
+    expect(
+      harness.targets["e2e-no-backend"]?.options?.env?.KEYMAXXER_MASTER_KEY,
+    ).toBe("")
+    expect(
+      harness.targets["e2e-no-backend"]?.options?.env?.E2E_AGENT_BACKEND_MODE,
+    ).toBe("no-opencode")
+    expect(harness.targets["e2e-no-backend"]?.options?.command).toContain(
+      "--grep @no-backend",
+    )
 
     const runnerScript = await readFile(
       new URL("../scripts/run-unit-tests.sh", import.meta.url),

--- a/docs/adr/0021-live-harness-end-to-end-test.md
+++ b/docs/adr/0021-live-harness-end-to-end-test.md
@@ -12,7 +12,22 @@ Throwaway project on `git.drupalcode.org` under operator control (default Projec
 
 ## Shared run model
 
-Each run starts with an empty, isolated Harness database. A shared e2e policy (`apps/harness/e2e/support/keymaxxer-e2e-policy.ts`) gates both the live-Harness supervisor and the fixture-clone helper before either touches Keymaxxer: given `E2E_KEYMAXXER_MASTER_KEY` (or the legacy `KEYMAXXER_MASTER_KEY`), it copies the checked-in encrypted Keymaxxer vault into a temporary home and unlocks it, with `KEYMAXXER_APPROVE=deny` preventing headless prompts. CI always resolves this fixture-vault mode and fails closed if the secret is missing. Without a master key, local runs must opt in explicitly with `E2E_ALLOW_KEYMAXXER_PROMPTS=1` to use the operator's own `~/.keymaxxer` vault and prompt normally; without that opt-in, live e2e fails fast with a diagnostic before starting the Harness, Sidecar, or CLI rather than prompting silently. Scenarios have no automatic retry. Trusted `push` to `main` fail-closes if the vault secret is missing; pull requests run live e2e when the secret is available (same-repo) and skip it when unavailable (fork PRs), while still running quality gates. Playwright diagnostics are retained on failure. Scenarios assert the sentinel's fixed identity and do not reject unrelated Issues on the fixture project.
+Each run starts with an empty, isolated Harness database. Live e2e is split into **two** Nx targets / Playwright invocations (separate `webServer` boots) so product PATH and Keymaxxer policy can differ without installing OpenCode mid-suite (issue #958):
+
+| Target | Tag filter | Env | Coverage |
+| --- | --- | --- | --- |
+| `harness:e2e-no-backend` | `@no-backend` only | `E2E_AGENT_BACKEND_MODE=no-opencode`, `KEYMAXXER_ENABLED=false` | Default Agent Backend Unavailable + first-run UI when OpenCode is absent (pure-absence and mixed-Ready via fake Claude). Vault-free so fork PRs still run it. |
+| `harness:e2e` | everything except `@no-backend` | Fixture vault (below); ambient OpenCode allowed / expected in CI | Fixture Repository add/refresh, Kanban, Settings history, catalog-only Agent Models, etc. |
+
+The live-Harness supervisor (`apps/harness/e2e/support/start-live-harness.ts`) always prepends a deterministic fake `claude` binary. In `no-opencode` mode it strips PATH directories that provide ambient `opencode`, `grok`, `codex`, and `claude`, then fails closed if those binaries still resolve (except the fake `claude`). Claude readiness is scenario-controlled (`firstParty` / `unauthenticated`) via the file protocol in `live-harness-control.ts`.
+
+### Vault-backed suite
+
+A shared e2e policy (`apps/harness/e2e/support/keymaxxer-e2e-policy.ts`) gates both the live-Harness supervisor and the fixture-clone helper before either touches Keymaxxer: given `E2E_KEYMAXXER_MASTER_KEY` (or the legacy `KEYMAXXER_MASTER_KEY`), it copies the checked-in encrypted Keymaxxer vault into a temporary home and unlocks it, with `KEYMAXXER_APPROVE=deny` preventing headless prompts. CI always resolves this fixture-vault mode for `harness:e2e` and fails closed if the secret is missing on trusted `main`. Without a master key, local runs must opt in explicitly with `E2E_ALLOW_KEYMAXXER_PROMPTS=1` to use the operator's own `~/.keymaxxer` vault and prompt normally; without that opt-in, vault-backed live e2e fails fast with a diagnostic before starting the Harness, Sidecar, or CLI rather than prompting silently. Scenarios have no automatic retry. Pull requests run vault-backed live e2e when the secret is available (same-repo) and skip it when unavailable (fork PRs), while still running quality gates and the vault-free `@no-backend` suite. Playwright diagnostics are retained on failure. Scenarios assert the sentinel's fixed identity and do not reject unrelated Issues on the fixture project.
+
+### Vault-free suite
+
+`KEYMAXXER_ENABLED=false` soft-disables Keymaxxer (same product switch as overnight / packed smoke): the supervisor skips vault seeding and Sidecar coordination. No fixture clone or Forge secrets are required. Overnight published-install smoke remains the packaging multi-arch gate and is not replaced by this suite.
 
 Ordinary Harness test targets (`test`, `slow-test`, `smoke`) are a separate, credential-free concern: their Nx target environments force `KEYMAXXER_ENABLED=false`, and the unit-test runner (`scripts/run-unit-tests.sh`) exports the same override for direct invocation, so neither can inherit an ambient `KEYMAXXER_ENABLED=true` and start prompting.
 


### PR DESCRIPTION
## Why

Operators hitting a missing or only partially Ready default Agent Backend need
product-level coverage, not only overnight packaging smoke. Issue #958 splits
that from #937 overnight install: monorepo live Gherkin owns first-run /
default-backend behaviour when OpenCode is absent; overnight stays the
multi-arch published-install gate.

## What changed

- **harness:e2e-no-backend**: @no-backend scenarios with
  E2E_AGENT_BACKEND_MODE=no-opencode and vault-free Keymaxxer
  (KEYMAXXER_ENABLED=false, master-key env cleared). Supervisor strips ambient
  agent CLIs from the product PATH and fails closed if they still resolve
  (except the controlled fake claude).
- **harness:e2e**: excludes @no-backend; remains OpenCode + fixture-vault
  backed.
- **Scenarios**: pure absence (default UNAVAILABLE, Claude unauthenticated, no
  Ready alternatives) and mixed Ready (default UNAVAILABLE + Claude Ready) via
  GraphQL and page-shell banner guidance.
- **Keymaxxer policy**: fixture master key still wins over ambient
  KEYMAXXER_ENABLED=false so vault-backed e2e is not broken by product
  soft-disable; no-backend target stays vault-free.
- **CI** (pr.yml / ci-cd.yml): no-backend suite first (no OpenCode install, no
  vault secret), then vault-backed suite; Chromium once; diagnostics for both.
  Overnight ownership comment only.
- **Docs**: harness README + ADR 0021.

## Verification

- bunx nx run harness:test
- bunx nx run harness:typecheck
- bunx nx run harness:e2e-no-backend (2 scenarios green locally)
- Pre-commit (nx affected lint/typecheck/test) green after Biome + policy
  typing fixes

## Limitations

- Full vault-backed harness:e2e still needs E2E_KEYMAXXER_MASTER_KEY + OpenCode
  (CI same-repo / main).
- PATH filtering drops whole directories that host ambient agent CLIs
  (intentional fail-closed for pure-absence).
- Does not replace overnight published-install multi-arch smoke.

Closes #958