### PR TITLE
fix(db): only log when database migrations actually apply

### DIFF
--- a/apps/harness/src/server/production-lifecycle.ts
+++ b/apps/harness/src/server/production-lifecycle.ts
@@ -16,7 +16,11 @@ import {
 } from "effect"
 import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process"
 import type { ChildProcessHandle } from "effect/unstable/process/ChildProcessSpawner"
-import { DatabaseLive, runConfiguredMigrations } from "@ready-for-agent/db"
+import {
+  DatabaseLive,
+  logMigrationsAppliedIfAny,
+  runConfiguredMigrations,
+} from "@ready-for-agent/db"
 import {
   KEYMAXXER_SIDECAR_URL_PREFIX,
   type SidecarChildSpawn,
@@ -223,9 +227,9 @@ const applyProductionMigrations = async (
       Effect.provide(
         DatabaseLive.pipe(Layer.provide(environmentConfigLayer(environment))),
       ),
-      Effect.tap(() =>
+      Effect.tap((result) =>
         Effect.sync(() => {
-          console.info("Database migrations applied")
+          logMigrationsAppliedIfAny(result)
         }),
       ),
     ),

--- a/packages/db/src/bin/migrate.ts
+++ b/packages/db/src/bin/migrate.ts
@@ -1,12 +1,15 @@
 import { Effect } from "effect"
 import { DatabaseLive } from "../lib/database-live.js"
-import { runConfiguredMigrations } from "../lib/run-migrations.js"
+import {
+  logMigrationsAppliedIfAny,
+  runConfiguredMigrations,
+} from "../lib/run-migrations.js"
 
 const program = runConfiguredMigrations().pipe(
   Effect.provide(DatabaseLive),
-  Effect.tap(() =>
+  Effect.tap((result) =>
     Effect.sync(() => {
-      console.info("Database migrations applied")
+      logMigrationsAppliedIfAny(result)
     }),
   ),
 )

--- a/packages/db/src/lib/run-migrations.ts
+++ b/packages/db/src/lib/run-migrations.ts
@@ -33,11 +33,46 @@ export type MigrationSource = {
   readonly sql: string
 }
 
+/** A migration that was newly applied in this run (not already in __drizzle_migrations). */
+export type AppliedMigration = {
+  readonly name: string
+  readonly hash: string
+}
+
+/** Outcome of a migration run: which migrations were applied this time. */
+export type MigrationRunResult = {
+  readonly applied: ReadonlyArray<AppliedMigration>
+}
+
 type MigrationRecord = {
   readonly hash: string
   readonly name: string
   readonly folderMillis: number
   readonly statements: ReadonlyArray<string>
+}
+
+/**
+ * User-facing success line when migrations actually ran.
+ * Returns null when nothing was applied (startup should stay quiet).
+ */
+export const migrationsAppliedLogMessage = (
+  result: MigrationRunResult,
+): string | null => {
+  const count = result.applied.length
+  if (count === 0) {
+    return null
+  }
+  return count === 1
+    ? "Applied 1 database migration"
+    : `Applied ${count} database migrations`
+}
+
+/** Log only when at least one migration was applied. */
+export const logMigrationsAppliedIfAny = (result: MigrationRunResult): void => {
+  const message = migrationsAppliedLogMessage(result)
+  if (message !== null) {
+    console.info(message)
+  }
 }
 
 export class MigrationReadError extends Schema.TaggedErrorClass<MigrationReadError>()(
@@ -99,6 +134,7 @@ const applyMigrationRecords = Effect.fn("applyMigrationRecords")(function* (
     ),
   )
   const appliedHashes = new Set(appliedRows.map((row) => row.hash))
+  const newlyApplied: Array<AppliedMigration> = []
 
   for (const migration of migrations) {
     if (appliedHashes.has(migration.hash)) {
@@ -124,41 +160,46 @@ const applyMigrationRecords = Effect.fn("applyMigrationRecords")(function* (
         `
       }),
     )
+    newlyApplied.push({ name: migration.name, hash: migration.hash })
   }
+
+  return { applied: newlyApplied } satisfies MigrationRunResult
 })
 
 /**
  * Apply Drizzle migration SQL sources via the current SqlClient.
  * Skips migrations already recorded in __drizzle_migrations.
+ * Returns which migrations were newly applied in this run.
  */
 export const runMigrationsFromSources = Effect.fn("runMigrationsFromSources")(
   function* (sources: ReadonlyArray<MigrationSource>) {
-    yield* applyMigrationRecords(toMigrationRecords(sources))
+    return yield* applyMigrationRecords(toMigrationRecords(sources))
   },
 )
 
 /**
  * Apply Drizzle migration SQL files via the current SqlClient.
  * Skips migrations already recorded in __drizzle_migrations.
+ * Returns which migrations were newly applied in this run.
  */
 export const runMigrations = Effect.fn("runMigrations")(function* (
   migrationsFolder: string,
 ) {
   const sources = yield* readMigrationSourcesFromFolder(migrationsFolder)
-  yield* runMigrationsFromSources(sources)
+  return yield* runMigrationsFromSources(sources)
 })
 
 /**
  * Run migrations using embedded SQL when present, otherwise MIGRATIONS_FOLDER
  * (defaults to db-schema/drizzle on disk).
+ * Returns which migrations were newly applied in this run.
  */
 export const runConfiguredMigrations = Effect.fn("runConfiguredMigrations")(
   function* () {
     if (embeddedMigrationSources.length > 0) {
-      yield* runMigrationsFromSources(embeddedMigrationSources)
-      return
+      return yield* runMigrationsFromSources(embeddedMigrationSources)
     }
     const migrationsFolder = yield* MigrationsFolderConfig
-    yield* runMigrations(migrationsFolder)
+    return yield* runMigrations(migrationsFolder)
   },
 )

--- a/packages/db/test/run-migrations.spec.ts
+++ b/packages/db/test/run-migrations.spec.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto"
 import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
@@ -6,7 +7,9 @@ import { SqlClient } from "effect/unstable/sql"
 import { SqliteTest } from "../src/lib/database-test.js"
 import {
   defaultMigrationsFolder,
+  migrationsAppliedLogMessage,
   runMigrations,
+  runMigrationsFromSources,
 } from "../src/lib/run-migrations.js"
 import { afterEach, describe, expect, it } from "bun:test"
 
@@ -29,7 +32,115 @@ afterEach(async () => {
   )
 })
 
+describe("migrationsAppliedLogMessage", () => {
+  it("returns null when no migrations were applied", () => {
+    expect(migrationsAppliedLogMessage({ applied: [] })).toBeNull()
+  })
+
+  it("describes a single applied migration", () => {
+    expect(
+      migrationsAppliedLogMessage({
+        applied: [{ name: "20260101000000_one", hash: "abc" }],
+      }),
+    ).toBe("Applied 1 database migration")
+  })
+
+  it("describes multiple applied migrations with a count", () => {
+    expect(
+      migrationsAppliedLogMessage({
+        applied: [
+          { name: "20260101000000_one", hash: "abc" },
+          { name: "20260102000000_two", hash: "def" },
+        ],
+      }),
+    ).toBe("Applied 2 database migrations")
+  })
+})
+
 describe("runMigrations", () => {
+  it("returns newly applied migrations and nothing on a second run", async () => {
+    const firstSql = "CREATE TABLE first_table (id integer);"
+    const secondSql = "CREATE TABLE second_table (id integer);"
+    const folder = await migrationFolder("20260101000000_first", firstSql)
+    const secondFolder = join(folder, "20260102000000_second")
+    await mkdir(secondFolder)
+    await writeFile(join(secondFolder, "migration.sql"), secondSql)
+
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        const first = yield* runMigrations(folder)
+        expect(first.applied).toEqual([
+          {
+            name: "20260101000000_first",
+            hash: createHash("sha256").update(firstSql).digest("hex"),
+          },
+          {
+            name: "20260102000000_second",
+            hash: createHash("sha256").update(secondSql).digest("hex"),
+          },
+        ])
+        expect(migrationsAppliedLogMessage(first)).toBe(
+          "Applied 2 database migrations",
+        )
+
+        const second = yield* runMigrations(folder)
+        expect(second.applied).toEqual([])
+        expect(migrationsAppliedLogMessage(second)).toBeNull()
+      }).pipe(Effect.provide(SqliteTest)),
+    )
+  })
+
+  it("returns only migrations that were not already recorded", async () => {
+    const existingSql = "CREATE TABLE already_there (id integer);"
+    const pendingSql = "CREATE TABLE newly_there (id integer);"
+    const existingHash = createHash("sha256").update(existingSql).digest("hex")
+    const pendingHash = createHash("sha256").update(pendingSql).digest("hex")
+
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        const sql = yield* SqlClient.SqlClient
+        yield* sql`
+          CREATE TABLE __drizzle_migrations (
+            id INTEGER PRIMARY KEY,
+            hash text NOT NULL,
+            created_at numeric,
+            name text,
+            applied_at TEXT
+          )
+        `
+        yield* sql`
+          INSERT INTO __drizzle_migrations (hash, created_at, name, applied_at)
+          VALUES (
+            ${existingHash},
+            ${20260101000000},
+            ${"20260101000000_existing"},
+            ${"2026-01-01T00:00:00.000Z"}
+          )
+        `
+
+        const result = yield* runMigrationsFromSources([
+          { name: "20260101000000_existing", sql: existingSql },
+          { name: "20260102000000_pending", sql: pendingSql },
+        ])
+
+        expect(result.applied).toEqual([
+          { name: "20260102000000_pending", hash: pendingHash },
+        ])
+        expect(migrationsAppliedLogMessage(result)).toBe(
+          "Applied 1 database migration",
+        )
+
+        const tables = yield* sql`
+          SELECT name FROM sqlite_master
+          WHERE type = 'table' AND name IN ('already_there', 'newly_there')
+          ORDER BY name
+        `
+        // existing was skipped (hash already recorded), so only pending ran
+        expect(tables).toEqual([{ name: "newly_there" }])
+      }).pipe(Effect.provide(SqliteTest)),
+    )
+  })
+
   it("rolls back all statements when a migration fails", async () => {
     const folder = await migrationFolder(
       "20260714120000_broken",


### PR DESCRIPTION
## Why

Every `ready-for-agent start` (and the standalone migrate bin) printed
`Database migrations applied` even when the database was already up to date
and zero migrations ran. Routine restarts looked like schema work had happened.

## What changed

- Migration runner APIs (`runMigrations*`, `runConfiguredMigrations`) now
  return `{ applied: ReadonlyArray<{ name, hash }> }` for migrations newly
  applied in that run.
- Shared helpers `migrationsAppliedLogMessage` /
  `logMigrationsAppliedIfAny` log only when `applied.length > 0`, with a
  count-based success line (`Applied N database migration(s)`).
- Production start (`applyProductionMigrations`) and `packages/db` migrate bin
  both use the shared helper.

No change to which migrations run or when—return metadata and logging only.

## Verification

- `bunx nx test db` (including new applied-count / log-message coverage)
- `bunx nx typecheck db` / `bunx nx typecheck harness`
- `bunx nx test harness` and `production-lifecycle.test.ts`

Closes #962