### PR TITLE
docs: simplify --host bind documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,10 +205,7 @@ HOST=0.0.0.0 ready-for-agent start
 ready-for-agent start --host 192.168.1.10
 ```
 
-The flag wins when both `--host` and `HOST` are set. The readiness log shows
-the bind address (e.g. `listening on http://0.0.0.0:6056`). Browser auto-open
-uses `http://127.0.0.1:<port>/` for all-interfaces binds (browsers mishandle
-`0.0.0.0`); for a concrete `--host <addr>` it opens that address.
+The flag wins when both `--host` and `HOST` are set.
 
 When adding a repo via the CLI against a non-default port or host (Harness must
 already be running):


### PR DESCRIPTION
## Why

The README's `--host` / `HOST` section mixed operator-facing bind configuration with implementation details (readiness log wording and browser auto-open host selection). Those details are easy to go stale relative to the product and clutter the configuration docs for people who only need to know how to opt into a non-loopback bind.

## What Changed

In the "Listen on all interfaces (or a specific address)" section of `README.md`, keep the flag-precedence sentence (`--host` wins over `HOST`) and drop the readiness-log / browser auto-open notes.
