### PR TITLE
fix(harness): honor --host on monorepo harness:dev

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,12 +42,13 @@ That boots the full Harness (UI + backend) on the monorepo dev path
 - GraphQL: `http://127.0.0.1:6056/graphql`
 - Sidecar (dev): `127.0.0.1:6057` (preserves Keymaxxer session across reloads; always loopback)
 
-Or with non-standard ports / bind host (`HOST` / `ready-for-agent start --host`,
-same semantics as Vite `server.host`; Sidecar is unchanged):
+Or with non-standard ports / bind host (`HOST` / `--host`, same semantics as
+Vite `server.host`; Sidecar is unchanged):
 
 ```
 PORT=4021 KEYMAXXER_SIDECAR_PORT=4031 bunx nx run harness:dev
 HOST=0.0.0.0 bunx nx run harness:dev
+bunx nx run harness:dev --host
 bun run ready-for-agent start --host
 ```
 

--- a/apps/harness/README.md
+++ b/apps/harness/README.md
@@ -34,6 +34,9 @@ PORT=7000 bun run ready-for-agent start
 bun run ready-for-agent start --host
 HOST=0.0.0.0 bun run ready-for-agent start
 bun run ready-for-agent start --host 192.168.1.10
+# monorepo nx targets accept the same flag / env
+PORT=7000 bunx nx run harness:dev --host
+HOST=0.0.0.0 bunx nx run harness:dev
 KEYMAXXER_SIDECAR_PORT=7001 bun run ready-for-agent start
 READY_FOR_AGENT_GRAPHQL_URL=http://127.0.0.1:7000/graphql \
   bun run ready-for-agent add /path/to/local/repo

--- a/apps/harness/project.json
+++ b/apps/harness/project.json
@@ -25,7 +25,7 @@
       "continuous": true,
       "executor": "nx:run-commands",
       "options": {
-        "command": "ROOT=\"$(cd ../.. && pwd)\" && mkdir -p \"$ROOT/tmp\" && export SQLITE_DATABASE_PATH=\"${SQLITE_DATABASE_PATH:-$ROOT/tmp/ready-for-agent.db}\" && bun --conditions @ready-for-agent/source ../../scripts/run-with-keymaxxer-sidecar.ts bash -c 'bun --conditions @ready-for-agent/source src/server/preflight.ts && bun --conditions @ready-for-agent/source ./node_modules/vite/bin/vite.js'",
+        "command": "ROOT=\"$(cd ../.. && pwd)\" && mkdir -p \"$ROOT/tmp\" && export SQLITE_DATABASE_PATH=\"${SQLITE_DATABASE_PATH:-$ROOT/tmp/ready-for-agent.db}\" && bun --conditions @ready-for-agent/source ../../scripts/run-with-keymaxxer-sidecar.ts bun --conditions @ready-for-agent/source src/server/run-dev.ts",
         "cwd": "apps/harness"
       },
       "dependsOn": [

--- a/apps/harness/src/server/run-dev.ts
+++ b/apps/harness/src/server/run-dev.ts
@@ -1,0 +1,77 @@
+/**
+ * Dev entry for `harness:dev`: preflight, then Vite.
+ *
+ * Nx appends unknown flags (e.g. `--host`) onto this process. Resolve them to
+ * `HOST` before spawning Vite so bind matches production / operator CLI.
+ */
+import { spawn, spawnSync } from "node:child_process"
+import { parseHostFlagFromArgv, resolveListenHost } from "./listen-host.ts"
+
+/** Resolve bind host for dev (CLI flag wins over HOST env). */
+export const resolveDevListenHost = (
+  argv: ReadonlyArray<string>,
+  envHost: string | undefined,
+): string =>
+  resolveListenHost({
+    flag: parseHostFlagFromArgv(argv),
+    env: envHost,
+  })
+
+/**
+ * Apply operator bind host to env only when `--host` or non-empty `HOST` is set.
+ * Leaves `HOST` unset for the default loopback path.
+ */
+export const applyDevListenHostEnv = (
+  env: NodeJS.ProcessEnv,
+  argv: ReadonlyArray<string>,
+): void => {
+  const flag = parseHostFlagFromArgv(argv)
+  const envHost = env.HOST
+  if (flag === undefined && (envHost === undefined || envHost.trim() === "")) {
+    return
+  }
+  env.HOST = resolveListenHost({ flag, env: envHost })
+}
+
+const bunArgs = (script: string) => [
+  "--conditions",
+  "@ready-for-agent/source",
+  script,
+]
+
+const main = () => {
+  applyDevListenHostEnv(process.env, process.argv)
+
+  const preflight = spawnSync(
+    process.execPath,
+    bunArgs("src/server/preflight.ts"),
+    { stdio: "inherit", env: process.env },
+  )
+  if (preflight.status !== 0) {
+    process.exit(preflight.status ?? 1)
+  }
+
+  const vite = spawn(
+    process.execPath,
+    bunArgs("./node_modules/vite/bin/vite.js"),
+    { stdio: "inherit", env: process.env },
+  )
+
+  const shutdown = (signal: NodeJS.Signals) => {
+    vite.kill(signal)
+  }
+  process.once("SIGINT", () => shutdown("SIGINT"))
+  process.once("SIGTERM", () => shutdown("SIGTERM"))
+
+  vite.on("exit", (code, signal) => {
+    if (signal) {
+      process.kill(process.pid, signal)
+      return
+    }
+    process.exit(code ?? 1)
+  })
+}
+
+if (import.meta.main) {
+  main()
+}

--- a/apps/harness/test/listen-host.test.ts
+++ b/apps/harness/test/listen-host.test.ts
@@ -11,6 +11,10 @@ import {
   resolveBrowserOpenUrl,
   resolveListenHost,
 } from "../src/server/listen-host.ts"
+import {
+  applyDevListenHostEnv,
+  resolveDevListenHost,
+} from "../src/server/run-dev.ts"
 import { describe, expect, test } from "bun:test"
 
 describe("normalizeHostToken", () => {
@@ -225,5 +229,45 @@ describe("expandBareHostFlag / parseHostFlagFromArgv", () => {
     expect(
       parseHostFlagFromArgv(["bun", "server.ts", "--no-open", "--host"]),
     ).toBe(ALL_INTERFACES_HOST)
+  })
+})
+
+describe("resolveDevListenHost", () => {
+  test("nx-appended bare --host binds all interfaces (not loopback)", () => {
+    // Regression: bash -c swallowed nx forwardAllArgs; run-dev must not.
+    expect(
+      resolveDevListenHost(
+        ["bun", "src/server/run-dev.ts", "--host"],
+        undefined,
+      ),
+    ).toBe(ALL_INTERFACES_HOST)
+    expect(
+      resolveDevListenHost(
+        ["bun", "src/server/run-dev.ts", "--host", "192.168.1.10"],
+        "127.0.0.1",
+      ),
+    ).toBe("192.168.1.10")
+  })
+
+  test("HOST env still works when flag is omitted", () => {
+    expect(resolveDevListenHost(["bun", "src/server/run-dev.ts"], "true")).toBe(
+      ALL_INTERFACES_HOST,
+    )
+  })
+})
+
+describe("applyDevListenHostEnv", () => {
+  test("writes HOST only when flag or env opts into bind", () => {
+    const bare: NodeJS.ProcessEnv = {}
+    applyDevListenHostEnv(bare, ["bun", "run-dev.ts"])
+    expect(bare.HOST).toBeUndefined()
+
+    const fromFlag: NodeJS.ProcessEnv = {}
+    applyDevListenHostEnv(fromFlag, ["bun", "run-dev.ts", "--host"])
+    expect(fromFlag.HOST).toBe(ALL_INTERFACES_HOST)
+
+    const fromEnv: NodeJS.ProcessEnv = { HOST: "true" }
+    applyDevListenHostEnv(fromEnv, ["bun", "run-dev.ts"])
+    expect(fromEnv.HOST).toBe(ALL_INTERFACES_HOST)
   })
 })

--- a/apps/harness/test/topology.test.ts
+++ b/apps/harness/test/topology.test.ts
@@ -30,12 +30,12 @@ describe("single application server topology", () => {
     expect(harness.targets.dev?.options?.command).toContain(
       "run-with-keymaxxer-sidecar",
     )
-    expect(harness.targets.dev?.options?.command).toContain(
-      "node_modules/vite/bin/vite.js",
+    // Leaf must be run-dev (not bash -c): nx forwardAllArgs append onto the
+    // sidecar wrapper argv, which must reach run-dev as process.argv.
+    expect(harness.targets.dev?.options?.command).toMatch(
+      /run-with-keymaxxer-sidecar\.ts bun --conditions @ready-for-agent\/source src\/server\/run-dev\.ts\s*$/,
     )
-    expect(harness.targets.dev?.options?.command).toContain(
-      "bun --conditions @ready-for-agent/source ./node_modules/vite/bin/vite.js",
-    )
+    expect(harness.targets.dev?.options?.command).not.toContain("bash -c")
     expect(harness.targets.dev?.options?.command).toContain(
       "export SQLITE_DATABASE_PATH",
     )

--- a/apps/harness/vite.config.ts
+++ b/apps/harness/vite.config.ts
@@ -4,12 +4,18 @@ import { tanstackStart } from "@tanstack/react-start/plugin/vite"
 import react from "@vitejs/plugin-react"
 import { defineConfig } from "vite"
 import { backendRuntimeRestart } from "./src/server/backend-runtime-restart.js"
-import { resolveListenHost } from "./src/server/listen-host.js"
+import {
+  parseHostFlagFromArgv,
+  resolveListenHost,
+} from "./src/server/listen-host.js"
 
 const workspaceRoot = fileURLToPath(new URL("../..", import.meta.url))
 
-/** Same HOST / default semantics as production lifecycle (Vite-style). */
-const listenHost = resolveListenHost({ env: process.env.HOST })
+/** Same `--host` / HOST / default semantics as production lifecycle (Vite-style). */
+const listenHost = resolveListenHost({
+  flag: parseHostFlagFromArgv(process.argv),
+  env: process.env.HOST,
+})
 const listenPort = Number(process.env.PORT ?? 6056)
 
 export default defineConfig({


### PR DESCRIPTION
## Why

`bunx nx run harness:dev --host` was documented as Vite-style non-loopback bind, but Vite stayed on `127.0.0.1`. Nx appends unknown flags onto the run-commands string; the old `bash -c '…vite…'` wrapper left `--host` outside the script as `$0`, so neither Vite argv nor `HOST` saw it. LAN access then failed even though production/`ready-for-agent start --host` worked.

## What Changed

- Route `harness:dev` through `apps/harness/src/server/run-dev.ts` (no `bash -c`) so nx-forwarded `--host` lands on the leaf process.
- Resolve bind host there and set `HOST` only when `--host` or a non-empty `HOST` is present; spawn Vite asynchronously and forward SIGINT/SIGTERM.
- `vite.config.ts` also reads `--host` from argv for direct Vite invokes.
- Docs and topology/listen-host tests cover the wiring and host resolution.

## Verification

Before: `PORT=7000 bunx nx run harness:dev --host` bound `127.0.0.1:7000`; `curl` to the LAN IP failed to connect.

After: same command path resolves `HOST=0.0.0.0` and Vite reports Network URLs / binds all interfaces.
