### PR TITLE
fix(harness): auto-size relevant-issue numbers and baseline-align titles

### DIFF
--- a/apps/harness/src/home-page-content.tsx
+++ b/apps/harness/src/home-page-content.tsx
@@ -2973,7 +2973,12 @@ function RepositoryIssueRow({
     <li className={ui.repoIssue}>
       <div className={ui.repoIssueRow}>
         <span className={ui.repoIssueNum}>#{issue.issueNumber}</span>
-        <span className="min-w-0">
+        {/*
+          Flow container (div, not span): title column holds block companions
+          (lifecycle, Banner, blocked-by <p>) under the title when the number
+          track grows for long GitLab iids.
+        */}
+        <div className="min-w-0">
           <span className={ui.repoIssueTitleRow}>
             <a className={ui.repoIssueTitleInline} href={issue.url}>
               {issue.title}
@@ -3001,7 +3006,56 @@ function RepositoryIssueRow({
           {issue.issueAuthor !== null && issue.issueAuthor !== "" && (
             <span className={ui.repoIssueAuthor}>{issue.issueAuthor}</span>
           )}
-        </span>
+          {latestWorkItem !== undefined && (
+            <WorkItemLifecycleStatus
+              workItem={latestWorkItem}
+              collapseEarlierLanes
+              forge={repository.forge}
+              issueUrl={
+                issue.url !== ""
+                  ? issue.url
+                  : workItemIssueUrl(
+                      repository.forge,
+                      repository.forgeHost,
+                      repository.projectPath,
+                      latestWorkItem.issueNumber,
+                    )
+              }
+              pullRequestUrl={workItemPullRequestUrl(
+                repository.forge,
+                repository.forgeHost,
+                repository.projectPath,
+                latestWorkItem.pullRequestNumber,
+              )}
+              onOpenSession={onOpenSession}
+            />
+          )}
+          {(implementNow.isError ||
+            implementLocally.isError ||
+            queueIssue.isError) && (
+            <Banner
+              className={cx(ui.bannerCompact, ui.repoIssueError)}
+              tone="alarm"
+              tag="Error"
+              role="alert"
+            >
+              {queueIssue.isError
+                ? "Could not queue issue. Refresh the issues and try again."
+                : "Could not start implementation. Refresh the issues and try again."}
+            </Banner>
+          )}
+          {issue.blockedBy.length > 0 && (
+            <p className={ui.repoIssueBlockedBy}>
+              Blocked by{" "}
+              {issue.blockedBy.map((blocker, index) => (
+                <span key={blocker.issueUrl}>
+                  {index > 0 && ", "}
+                  <a href={blocker.issueUrl}>#{blocker.issueNumber}</a>
+                </span>
+              ))}
+            </p>
+          )}
+        </div>
         <span className={ui.repoIssueActions}>
           {issue.state === "CLOSED" && (
             <span className={cx(ui.stamp, ui.stampClosed)}>Closed</span>
@@ -3074,55 +3128,6 @@ function RepositoryIssueRow({
           )}
         </span>
       </div>
-      {latestWorkItem !== undefined && (
-        <WorkItemLifecycleStatus
-          workItem={latestWorkItem}
-          collapseEarlierLanes
-          forge={repository.forge}
-          issueUrl={
-            issue.url !== ""
-              ? issue.url
-              : workItemIssueUrl(
-                  repository.forge,
-                  repository.forgeHost,
-                  repository.projectPath,
-                  latestWorkItem.issueNumber,
-                )
-          }
-          pullRequestUrl={workItemPullRequestUrl(
-            repository.forge,
-            repository.forgeHost,
-            repository.projectPath,
-            latestWorkItem.pullRequestNumber,
-          )}
-          onOpenSession={onOpenSession}
-        />
-      )}
-      {(implementNow.isError ||
-        implementLocally.isError ||
-        queueIssue.isError) && (
-        <Banner
-          className={cx(ui.bannerCompact, ui.repoIssueError)}
-          tone="alarm"
-          tag="Error"
-          role="alert"
-        >
-          {queueIssue.isError
-            ? "Could not queue issue. Refresh the issues and try again."
-            : "Could not start implementation. Refresh the issues and try again."}
-        </Banner>
-      )}
-      {issue.blockedBy.length > 0 && (
-        <p className={ui.repoIssueBlockedBy}>
-          Blocked by{" "}
-          {issue.blockedBy.map((blocker, index) => (
-            <span key={blocker.issueUrl}>
-              {index > 0 && ", "}
-              <a href={blocker.issueUrl}>#{blocker.issueNumber}</a>
-            </span>
-          ))}
-        </p>
-      )}
     </li>
   )
 }

--- a/apps/harness/src/ui.ts
+++ b/apps/harness/src/ui.ts
@@ -1178,11 +1178,18 @@ export const ui = {
   repoIssue:
     "min-w-0 border-t border-line-ghost py-[0.55rem] first:border-t-0 first:pt-[0.15rem]",
 
+  /**
+   * Number track is `auto` so short GitHub `#793` and long GitLab iids
+   * (`#3595864`, up to 8 digits) size to content — never overflow into the
+   * title. `items-baseline` keeps mono `#n` and display title on one line.
+   * Companions (blocked-by / error / lifecycle) live in the title column so
+   * they stay aligned without a fixed rem gutter that drifts with width.
+   */
   repoIssueRow:
-    "grid grid-cols-[2.4rem_minmax(0,1fr)_auto] items-start gap-x-[0.55rem] gap-y-[0.45rem]",
+    "grid grid-cols-[auto_minmax(0,1fr)_auto] items-baseline gap-x-[0.55rem] gap-y-[0.45rem]",
 
   repoIssueNum:
-    "font-mono text-[0.72rem] font-semibold leading-[1.45] text-ink-2",
+    "shrink-0 whitespace-nowrap tabular-nums font-mono text-[0.72rem] font-semibold leading-[1.45] text-ink-2",
 
   /**
    * Title + inline blue Implement control (play icon + label) on one wrapping
@@ -1227,21 +1234,24 @@ export const ui = {
 
   repoIssueActions: "flex shrink-0 items-center gap-[0.35rem]",
 
+  /** Nested under title column — no fixed left gutter (see repoIssueRow). */
   repoIssueBlockedBy:
-    "mt-[0.4rem] mb-0 pl-[2.95rem] font-mono text-[0.62rem] tracking-[0.04em] text-ink-2",
+    "mt-[0.4rem] mb-0 font-mono text-[0.62rem] tracking-[0.04em] text-ink-2",
 
   repoIssueBlockedByLink:
     "font-semibold text-ink underline underline-offset-2 hover:decoration-2 hover:decoration-signal",
 
-  repoIssueError: "mt-[0.4rem] mb-0 ml-[2.95rem]",
+  /** Nested under title column — no fixed left gutter (see repoIssueRow). */
+  repoIssueError: "mt-[0.4rem] mb-0",
 
   parentIssueError: "mx-[0.65rem] mt-[0.45rem] mb-[0.55rem]",
 
   parentIssue:
     "group mx-[calc(-0.65rem-1.5px)] my-[0.35rem] min-w-0 border-[1.5px] border-ink bg-panel",
 
+  /** Same number/title grid rules as `repoIssueRow` (auto track + baseline). */
   parentIssueSummary:
-    "grid cursor-pointer list-none grid-cols-[2.4rem_minmax(0,1fr)_auto] items-start gap-x-[0.55rem] gap-y-[0.45rem] px-[0.65rem] py-[0.55rem] [&::-webkit-details-marker]:hidden",
+    "grid cursor-pointer list-none grid-cols-[auto_minmax(0,1fr)_auto] items-baseline gap-x-[0.55rem] gap-y-[0.45rem] px-[0.65rem] py-[0.55rem] [&::-webkit-details-marker]:hidden",
 
   parentIssueClosedCount:
     "font-mono text-[0.62rem] font-bold tracking-[0.1em] uppercase text-ink-faint",
@@ -1262,8 +1272,12 @@ export const ui = {
     "px-[0.65rem] pt-[0.15rem] pb-[0.55rem]",
   ),
 
+  /**
+   * Lifecycle chrome under the title column on relevant-issue rows — no
+   * fixed left gutter (companions share the title track; see repoIssueRow).
+   */
   lifecycleInset:
-    "mt-2 mb-0 ml-[2.95rem] min-w-0 max-w-full border-[1.5px] border-ink bg-panel px-[0.65rem] py-[0.55rem]",
+    "mt-2 mb-0 min-w-0 max-w-full border-[1.5px] border-ink bg-panel px-[0.65rem] py-[0.55rem]",
 
   blankSlate:
     "grid justify-items-center border-2 border-dashed border-ink bg-panel px-6 pt-[2.4rem] pb-[2.2rem] text-center sm:px-10 sm:pt-[2.8rem] sm:pb-10",

--- a/apps/harness/test/repos-interchange.test.ts
+++ b/apps/harness/test/repos-interchange.test.ts
@@ -173,6 +173,17 @@ describe("Interchange phase 4: repos page + blank slate", () => {
     expect(issues).toContain("Blocked")
     expect(issues).toContain("ui.repoIssueBlockedBy")
     expect(issues).toContain("Blocked by")
+    // Companions (lifecycle / error / blocked-by) live in the title column so
+    // long GitLab iids can widen the number track without a fixed rem gutter.
+    // Title column is a flow <div> (not <span>) so Banner / lifecycle / <p> are valid.
+    const titleColumn = sliceBetweenMarkers(
+      issues,
+      '<div className="min-w-0">',
+      "className={ui.repoIssueActions}",
+    )
+    expect(titleColumn).toContain("WorkItemLifecycleStatus")
+    expect(titleColumn).toContain("ui.repoIssueError")
+    expect(titleColumn).toContain("ui.repoIssueBlockedBy")
     // Old amber row-wash language is dropped.
     expect(issues).not.toContain("bg-amber-wash")
     expect(issues).not.toContain("border-sepia")
@@ -193,6 +204,48 @@ describe("Interchange phase 4: repos page + blank slate", () => {
     expect(ui).not.toContain("repoIssueImplementMenu:")
     expect(ui).toMatch(/stampClosed:[\s\S]*?border-dashed/)
     expect(ui).toMatch(/stampBlocked:[\s\S]*?bg-lane-queue/)
+    // Issue #969: auto number track + baseline (not fixed 2.4rem / items-start).
+    // whitespace-nowrap + tabular-nums keep short (#793) and long (#3595864)
+    // GitLab iids fully readable without overlapping the title.
+    const repoIssueRow = sliceBetweenMarkers(
+      ui,
+      "repoIssueRow:",
+      "repoIssueNum:",
+    )
+    expect(repoIssueRow).toContain("grid-cols-[auto_minmax(0,1fr)_auto]")
+    expect(repoIssueRow).toContain("items-baseline")
+    expect(repoIssueRow).not.toContain("2.4rem")
+    expect(repoIssueRow).not.toContain("items-start")
+    const repoIssueNum = sliceBetweenMarkers(
+      ui,
+      "repoIssueNum:",
+      "repoIssueTitleRow:",
+    )
+    expect(repoIssueNum).toContain("whitespace-nowrap")
+    expect(repoIssueNum).toContain("tabular-nums")
+    expect(repoIssueNum).toContain("shrink-0")
+    // Companions no longer use the obsolete 2.4rem+gap (=2.95rem) gutter.
+    const blockedBy = sliceBetweenMarkers(
+      ui,
+      "repoIssueBlockedBy:",
+      "repoIssueBlockedByLink:",
+    )
+    expect(blockedBy).not.toContain("2.95rem")
+    expect(blockedBy).not.toContain("pl-[")
+    const repoIssueError = sliceBetweenMarkers(
+      ui,
+      "repoIssueError:",
+      "parentIssueError:",
+    )
+    expect(repoIssueError).not.toContain("2.95rem")
+    expect(repoIssueError).not.toContain("ml-[")
+    const lifecycleInset = sliceBetweenMarkers(
+      ui,
+      "lifecycleInset:",
+      "blankSlate:",
+    )
+    expect(lifecycleInset).not.toContain("2.95rem")
+    expect(lifecycleInset).not.toContain("ml-[")
   })
 
   test("zero relevant issues retain heading chrome and explain how to add them", () => {
@@ -382,6 +435,17 @@ describe("Interchange phase 4: repos page + blank slate", () => {
     expect(ui).toMatch(/parentIssueChildren:[\s\S]*?px-\[0\.65rem\]/)
     expect(ui).not.toContain("before:absolute before:top-[0.35rem]")
     expect(ui).toContain("parentIssueError:")
+    // Issue #969: parent summary matches leaf number/title alignment rules.
+    const parentSummary = sliceBetweenMarkers(
+      ui,
+      "parentIssueSummary:",
+      "parentIssueClosedCount:",
+    )
+    expect(parentSummary).toContain("grid-cols-[auto_minmax(0,1fr)_auto]")
+    expect(parentSummary).toContain("items-baseline")
+    expect(parentSummary).not.toContain("2.4rem")
+    expect(parentSummary).not.toContain("items-start")
+    expect(parent).toContain("ui.repoIssueNum")
   })
 
   test("repos surface locks alarm Banner weighting for leaf/refresh/remove failures", () => {

--- a/docs/harness-design-system.md
+++ b/docs/harness-design-system.md
@@ -461,10 +461,16 @@ prototype, so this spec governs:
   copy keeps `<code>` chips (mono, 1.5px ink border, paper fill).
 - **Relevant issues section**: mono kicker + refresh icon button; issue rows
   use ticket anatomy (mono `#nn`, display title link, author sub-line).
-  Stamps: **Closed** = dashed neutral stamp; **Blocked** = solid Queue-yellow
-  tag (a blocked issue is queue-held — lane-consistent). Blocked rows keep
-  the "Blocked by #n" mono link line; the old amber row-wash is dropped —
-  the yellow tag carries the state, no wash fills in the new language.
+  Number track is **auto** (`whitespace-nowrap tabular-nums`) so short GitHub
+  numbers and long GitLab iids (7–8 digits) never overflow into the title;
+  row grids use **`items-baseline`** so `#n` and the display title share one
+  optical line (parent summary rows match). Blocked-by / error / lifecycle
+  companions sit in the **title column** (not a fixed rem left gutter) so they
+  stay under the title when the number track grows. Stamps: **Closed** =
+  dashed neutral stamp; **Blocked** = solid Queue-yellow tag (a blocked issue
+  is queue-held — lane-consistent). Blocked rows keep the "Blocked by #n"
+  mono link line; the old amber row-wash is dropped — the yellow tag carries
+  the state, no wash fills in the new language.
 - **Latest work item** renders the standard lifecycle chrome (§4.4) inside a
   bordered inset panel (`--panel`, 1.5px): runtime lines (agent backend,
   session + copy, worktree + copy), STARTED / status, and earlier-lane


### PR DESCRIPTION
## Why

Relevant Issues used a fixed `2.4rem` number column and `items-start`, so
short GitHub numbers sat off the title baseline and long GitLab iids
(e.g. `#3595864`) overflowed into the title. Companion gutters assumed that
fixed width (`2.95rem`).

## What

- `repoIssueRow` / `parentIssueSummary`: auto track + `items-baseline`
- `repoIssueNum`: `shrink-0 whitespace-nowrap tabular-nums`
- Leaf companions (lifecycle, error Banner, blocked-by) nest in a flow
  title-column `div` so gutters track auto width without invalid
  block-in-span markup
- Drop obsolete `pl-/ml-[2.95rem]` on companion tokens
- Update structural tests and harness design-system note

## Verification

- `bunx nx test harness` (full suite) after the layout change
- `repos-interchange.test.ts` covers auto/baseline tokens, number classes,
  title-column companions, and parent parity
- Pre-commit / Biome format clean after single-line `toContain` fix

## Notes

Visual stamps/actions still sit in the right grid track; document order
places companions before the actions column by design.

Closes #969