### PR TITLE
fix(gitlab): settle Watch on merged-results pipelines

### DIFF
--- a/apps/harness/test/work-item-lifecycle-status.test.tsx
+++ b/apps/harness/test/work-item-lifecycle-status.test.tsx
@@ -14,7 +14,7 @@ const waitingForGitHubWorkItem = {
   pullRequestNumber: 42,
   agentBackend: { id: "opencode", label: "OpenCode" },
   state: "WATCH_PR_STATUS_CHECKS",
-  stateLabel: "GitHub status checks",
+  stateLabel: "Status checks",
   status: "WAITING_FOR_GITHUB",
   statusLabel: "Waiting for GitHub",
   statusMessage: "Waiting for GitHub until 2026-08-07T12:00:00.000Z",
@@ -31,7 +31,7 @@ const waitingForGitHubWorkItem = {
   lifecycleLabels: [
     {
       phase: "GITHUB_STATUS_CHECKS",
-      label: "GitHub status checks: Postponed",
+      label: "Status checks: Postponed",
       status: "POSTPONED",
       durationMs: 0,
     },
@@ -49,7 +49,7 @@ describe("WorkItemLifecycleStatus", () => {
 
     expect(html).toContain("Waiting for GitHub")
     expect(html).toContain("Waiting for GitHub until 2026-08-07T12:00:00.000Z")
-    expect(html).toContain("GitHub status checks: Postponed")
+    expect(html).toContain("Status checks: Postponed")
     expect(html).not.toContain(">Retry<")
   })
 })

--- a/packages/gitlab-service/src/lib/gitlab-service-live.ts
+++ b/packages/gitlab-service/src/lib/gitlab-service-live.ts
@@ -152,6 +152,15 @@ const HeadPipelineSchema = Schema.Struct({
   id: PositiveInt,
   status: Schema.optional(Schema.NullOr(Schema.String)),
   sha: Schema.optional(Schema.NullOr(Schema.String)),
+  /**
+   * GitLab pipeline ref. Merged-results pipelines use
+   * `refs/merge-requests/<iid>/merge` (SHA is never the source tip). Detached
+   * MR head pipelines use `…/head` (SHA is the source tip). Branch pipelines
+   * use the branch name. Only the merged-results form skips tip-SHA equality.
+   */
+  ref: Schema.optional(Schema.NullOr(Schema.String)),
+  /** GitLab pipeline source (`push`, `merge_request_event`, …); decoded for fidelity. */
+  source: Schema.optional(Schema.NullOr(Schema.String)),
   created_at: Schema.optional(Schema.NullOr(Schema.String)),
 })
 const MergeRequestCheckSchema = Schema.Struct({
@@ -423,18 +432,47 @@ const isDraftMergeRequest = (mergeRequest: {
   mergeRequest.draft === true || hasDraftTitlePrefix(mergeRequest.title ?? "")
 
 /**
- * True when the MR tip and the attached head_pipeline SHA are both known and
- * disagree. Watch must not settle green, and Merge must not treat the pipeline
- * as green, until GitLab attaches a pipeline for the current tip.
+ * Merged-results pipelines run on `refs/merge-requests/<iid>/merge`; their
+ * pipeline SHA is the temporary merge commit, never the source-branch tip.
+ * Tip-aligned MR pipelines (`…/head`, branch ref, or source-only
+ * `merge_request_event`) still use SHA equality for stale-after-push detection.
+ */
+const MERGED_RESULTS_PIPELINE_REF = /^refs\/merge-requests\/\d+\/merge$/
+
+/**
+ * True when head_pipeline is a merged-results pipeline. Only this shape is
+ * exempt from tip-SHA equality while GitLab still attaches it as head_pipeline.
+ */
+const isMergedResultsHeadPipeline = (headPipeline: {
+  readonly ref?: string | null
+}): boolean => {
+  const ref =
+    typeof headPipeline.ref === "string" ? headPipeline.ref.trim() : ""
+  return ref !== "" && MERGED_RESULTS_PIPELINE_REF.test(ref)
+}
+
+/**
+ * True when the attached head_pipeline is for a prior tip and must not settle
+ * green (Watch) or pass merge pre-checks.
+ *
+ * Branch and tip-aligned MR pipelines: treat a known SHA mismatch with the MR
+ * tip as stale (left behind after a push until GitLab replaces head_pipeline).
+ *
+ * Merged-results pipelines (`refs/merge-requests/<iid>/merge`): the pipeline
+ * SHA is the temporary merge commit, not the source tip — never stale solely
+ * because of that mismatch while GitLab still exposes them as head_pipeline.
  */
 const isStaleHeadPipelineForTip = (mergeRequest: {
   readonly sha?: string | null
   readonly head_pipeline?: {
     readonly sha?: string | null
+    readonly ref?: string | null
+    readonly source?: string | null
   } | null
 }): boolean => {
   const headPipeline = mergeRequest.head_pipeline
   if (headPipeline === null || headPipeline === undefined) return false
+  if (isMergedResultsHeadPipeline(headPipeline)) return false
   const mrHead =
     typeof mergeRequest.sha === "string" && mergeRequest.sha.trim() !== ""
       ? mergeRequest.sha.trim()
@@ -1138,8 +1176,11 @@ export const makeGitLabService = (options: {
           ...snapshot,
         } satisfies PullRequestCheckStatus
       }
-      // Pipeline still reports a prior tip after a concurrent push: keep
-      // watching (pending) so Merge does not thrash revalidation on a stale green.
+      // Branch or tip-aligned MR pipeline still reports a prior tip after a
+      // concurrent push: keep watching (pending) so Merge does not thrash
+      // revalidation on a stale green. Merged-results pipelines
+      // (`refs/merge-requests/N/merge`) are never stale solely because their
+      // SHA differs from the source tip.
       if (isStaleHeadPipelineForTip(mergeRequest)) {
         return {
           _tag: "pending",
@@ -1498,9 +1539,10 @@ export const makeGitLabService = (options: {
          * Job-level pipeline rollup for merge pre-checks. Matches Watch so
          * allow_failure failures and manual/canceled/skipped jobs do not block
          * merge, while hard-fail and still-running pipelines revalidate.
-         * A head_pipeline whose SHA is not the MR tip is treated as not green so
-         * a concurrent push cannot merge an untested head under a stale success
-         * (same tip-freshness rule as Watch pending).
+         * A tip-aligned head_pipeline whose SHA is not the MR tip is treated as
+         * not green so a concurrent push cannot merge an untested head under a
+         * stale success (same tip-freshness rule as Watch pending). Merged-
+         * results pipelines are excluded from that SHA rule.
          */
         const pipelineBlockingReason = (
           mergeRequest: MergeRequestCheck,

--- a/packages/gitlab-service/test/gitlab-service.spec.ts
+++ b/packages/gitlab-service/test/gitlab-service.spec.ts
@@ -790,7 +790,7 @@ describe("GitLab PR status checks and ready-for-review", () => {
     })
   })
 
-  test("keeps watching when head_pipeline SHA is behind the MR tip", async () => {
+  test("keeps watching when a branch head_pipeline SHA is behind the MR tip", async () => {
     let jobsListed = 0
     const service = makeGitLabServiceFromToken("test-token", (async (
       input,
@@ -815,8 +815,14 @@ describe("GitLab PR status checks and ready-for-review", () => {
           target_branch: "main",
           detailed_merge_status: "mergeable",
           merge_status: "can_be_merged",
-          // Successful pipeline is still for the previous tip after a push.
-          head_pipeline: { id: 1, status: "success", sha: "old-tip" },
+          // Branch pipeline left behind after a push (not a merge-results run).
+          head_pipeline: {
+            id: 1,
+            status: "success",
+            sha: "old-tip",
+            ref: "rfa/branch",
+            source: "push",
+          },
         })
       }
       if (method === "GET" && url.pathname.includes("/repository/commits/")) {
@@ -842,7 +848,157 @@ describe("GitLab PR status checks and ready-for-review", () => {
     )
     expect(status._tag).toBe("pending")
     expect(status).toMatchObject({ headSha: "new-tip" })
-    // Do not roll up jobs for a pipeline that is not the MR tip.
+    // Do not roll up jobs for a branch pipeline that is not the MR tip.
+    expect(jobsListed).toBe(0)
+  })
+
+  test("settles merged-results head_pipeline even when pipeline SHA differs from MR tip", async () => {
+    // Bible MR !17 shape: merged-results pipeline on refs/merge-requests/N/merge
+    // with allow_failure fails that must not block green.
+    const tipSha = "7f8cdf7765c1b3b0cdb39899545c265d5986de2f"
+    const mergeCommitSha = "63a74a1fbd7979f3ee75470a4c1591964570655b"
+    let jobsListed = 0
+    const service = makeGitLabServiceFromToken("test-token", (async (
+      input,
+      init,
+    ) => {
+      const url = new URL(String(input))
+      const method = (init?.method ?? "GET").toUpperCase()
+      if (
+        method === "GET" &&
+        url.pathname.endsWith("/merge_requests") &&
+        url.search.includes("state=opened")
+      ) {
+        return json([{ iid: 17, draft: false }])
+      }
+      if (method === "GET" && url.pathname.endsWith("/merge_requests/17")) {
+        return json({
+          iid: 17,
+          state: "opened",
+          draft: false,
+          title: "Bible fix",
+          sha: tipSha,
+          target_branch: "1.0.x",
+          detailed_merge_status: "mergeable",
+          merge_status: "can_be_merged",
+          head_pipeline: {
+            id: 919685,
+            status: "success",
+            sha: mergeCommitSha,
+            ref: "refs/merge-requests/17/merge",
+            source: "merge_request_event",
+          },
+        })
+      }
+      if (method === "GET" && url.pathname.includes("/repository/commits/")) {
+        return json({
+          id: tipSha,
+          committed_date: "2026-07-20T10:04:00.000Z",
+        })
+      }
+      if (method === "GET" && url.pathname.includes("/pipelines/919685/jobs")) {
+        jobsListed += 1
+        return json([
+          {
+            id: 1,
+            name: "test",
+            status: "success",
+            allow_failure: false,
+            web_url: "https://git.drupalcode.org/project/bible/-/jobs/1",
+          },
+          {
+            id: 2,
+            name: "cspell",
+            status: "failed",
+            allow_failure: true,
+            web_url: "https://git.drupalcode.org/project/bible/-/jobs/2",
+          },
+          {
+            id: 3,
+            name: "eslint",
+            status: "failed",
+            allow_failure: true,
+            web_url: "https://git.drupalcode.org/project/bible/-/jobs/3",
+          },
+        ])
+      }
+      if (method === "GET" && url.pathname.includes("/bridges")) {
+        return json([])
+      }
+      throw new Error(`Unexpected: ${method} ${url.pathname}${url.search}`)
+    }) as typeof fetch)
+
+    const status = await Effect.runPromise(
+      service.getPullRequestCheckStatus(repository, "rfa/branch"),
+    )
+    expect(status._tag).toBe("succeeded")
+    expect(status).toMatchObject({ headSha: tipSha })
+    expect(jobsListed).toBe(1)
+    if (status._tag !== "succeeded") return
+    expect(status.terminalChecks).toEqual([
+      { externalId: "gitlab-job:1", name: "test", outcome: "green" },
+    ])
+  })
+
+  test("keeps watching when a tip-aligned MR head_pipeline SHA is behind the tip", async () => {
+    // source=merge_request_event alone (or …/head) does not exempt SHA equality:
+    // only merged-results refs skip tip matching after a concurrent push.
+    let jobsListed = 0
+    const service = makeGitLabServiceFromToken("test-token", (async (
+      input,
+      init,
+    ) => {
+      const url = new URL(String(input))
+      const method = (init?.method ?? "GET").toUpperCase()
+      if (
+        method === "GET" &&
+        url.pathname.endsWith("/merge_requests") &&
+        url.search.includes("state=opened")
+      ) {
+        return json([{ iid: 12, draft: false }])
+      }
+      if (method === "GET" && url.pathname.endsWith("/merge_requests/12")) {
+        return json({
+          iid: 12,
+          state: "opened",
+          draft: false,
+          title: "fix",
+          sha: "new-tip",
+          target_branch: "main",
+          detailed_merge_status: "mergeable",
+          merge_status: "can_be_merged",
+          head_pipeline: {
+            id: 42,
+            status: "success",
+            sha: "old-tip",
+            ref: "refs/merge-requests/12/head",
+            source: "merge_request_event",
+          },
+        })
+      }
+      if (method === "GET" && url.pathname.includes("/repository/commits/")) {
+        return json({
+          id: "new-tip",
+          committed_date: "2026-07-20T10:04:00.000Z",
+        })
+      }
+      if (method === "GET" && url.pathname.includes("/pipelines/42/jobs")) {
+        jobsListed += 1
+        return json([
+          { id: 9, name: "lint", status: "success", allow_failure: false },
+        ])
+      }
+      if (method === "GET" && url.pathname.includes("/bridges")) {
+        return json([])
+      }
+      throw new Error(`Unexpected: ${method} ${url.pathname}${url.search}`)
+    }) as typeof fetch)
+
+    const status = await Effect.runPromise(
+      service.getPullRequestCheckStatus(repository, "rfa/branch"),
+    )
+    expect(status._tag).toBe("pending")
+    expect(status).toMatchObject({ headSha: "new-tip" })
     expect(jobsListed).toBe(0)
   })
 
@@ -1854,6 +2010,75 @@ describe("GitLab PR status checks and ready-for-review", () => {
     expect(jobsUrl).toContain("/pipelines/1/jobs")
   })
 
+  test("mergePullRequest merges when merged-results pipeline SHA differs from tip", async () => {
+    const tipSha = "7f8cdf7765c1b3b0cdb39899545c265d5986de2f"
+    const mergeCommitSha = "63a74a1fbd7979f3ee75470a4c1591964570655b"
+    let putCount = 0
+    const service = makeGitLabServiceFromToken("test-token", (async (
+      input,
+      init,
+    ) => {
+      const url = new URL(String(input))
+      const method = (init?.method ?? "GET").toUpperCase()
+      if (
+        method === "GET" &&
+        url.pathname.endsWith("/merge_requests") &&
+        url.search.includes("state=opened")
+      ) {
+        return json([{ iid: 17, draft: false }])
+      }
+      if (method === "GET" && url.pathname.endsWith("/merge_requests/17")) {
+        return json({
+          iid: 17,
+          state: "opened",
+          draft: false,
+          title: "Bible fix",
+          sha: tipSha,
+          target_branch: "1.0.x",
+          detailed_merge_status: "mergeable",
+          merge_status: "can_be_merged",
+          has_conflicts: false,
+          head_pipeline: {
+            id: 919685,
+            status: "success",
+            sha: mergeCommitSha,
+            ref: "refs/merge-requests/17/merge",
+            source: "merge_request_event",
+          },
+        })
+      }
+      if (method === "GET" && url.pathname.includes("/pipelines/919685/jobs")) {
+        return json([
+          { id: 1, name: "test", status: "success", allow_failure: false },
+          { id: 2, name: "cspell", status: "failed", allow_failure: true },
+        ])
+      }
+      if (method === "GET" && url.pathname.includes("/bridges")) {
+        return json([])
+      }
+      if (
+        method === "PUT" &&
+        url.pathname.endsWith("/merge_requests/17/merge")
+      ) {
+        putCount += 1
+        return json({
+          iid: 17,
+          state: "merged",
+          draft: false,
+          title: "Bible fix",
+          sha: tipSha,
+        })
+      }
+      throw new Error(`Unexpected: ${method} ${url.pathname}${url.search}`)
+    }) as typeof fetch)
+
+    const result = await Effect.runPromise(
+      service.mergePullRequest(repository, "rfa/branch"),
+    )
+    expect(result).toEqual({ _tag: "merged" })
+    expect(putCount).toBe(1)
+  })
+
   test("mergePullRequest is idempotent when already merged", async () => {
     let putCount = 0
     const service = makeGitLabServiceFromToken("test-token", (async (
@@ -1994,14 +2219,20 @@ describe("GitLab PR status checks and ready-for-review", () => {
       "checks_not_green",
     ],
     [
-      "a stale successful pipeline for a prior tip",
+      "a stale successful branch pipeline for a prior tip",
       {
         draft: false,
         title: "Ready",
         detailed_merge_status: "mergeable",
         merge_status: "can_be_merged",
         has_conflicts: false,
-        head_pipeline: { id: 1, status: "success", sha: "old-tip" },
+        head_pipeline: {
+          id: 1,
+          status: "success",
+          sha: "old-tip",
+          ref: "rfa/branch",
+          source: "push",
+        },
         jobs: [
           { id: 1, name: "test", status: "success", allow_failure: false },
         ],

--- a/packages/graphql-api/src/lib/work-item-projection.ts
+++ b/packages/graphql-api/src/lib/work-item-projection.ts
@@ -96,7 +96,8 @@ const lifecyclePhaseLabel = (phase: LifecyclePhase): string => {
     case "resolve_pr_merge_conflict":
       return "Resolve PR merge conflict"
     case "github_status_checks":
-      return "GitHub status checks"
+      // Forge-neutral: same Watch phase for GitHub checks and GitLab pipeline jobs.
+      return "Status checks"
     case "mark_pr_ready_for_review":
       return "Mark PR ready for review"
     case "decide_pr_merge":

--- a/packages/graphql-api/test/graphql-api.test.ts
+++ b/packages/graphql-api/test/graphql-api.test.ts
@@ -4055,7 +4055,7 @@ describe("GraphQL API", () => {
       data: {
         workItems: [
           {
-            stateLabel: "GitHub status checks",
+            stateLabel: "Status checks",
             status: "QUEUED",
             statusLabel: "Queued",
             statusMessage: null,
@@ -4079,7 +4079,7 @@ describe("GraphQL API", () => {
               },
               {
                 phase: "GITHUB_STATUS_CHECKS",
-                label: "GitHub status checks: Queued",
+                label: "Status checks: Queued",
                 status: "QUEUED",
               },
             ],
@@ -4094,7 +4094,7 @@ describe("GraphQL API", () => {
             lifecycleLabels: [
               {
                 phase: "GITHUB_STATUS_CHECKS",
-                label: "GitHub status checks: Needs human",
+                label: "Status checks: Needs human",
                 status: "NEEDS_HUMAN",
               },
             ],
@@ -4293,7 +4293,7 @@ describe("GraphQL API", () => {
         workItems: [
           {
             state: "WATCH_PR_STATUS_CHECKS",
-            stateLabel: "GitHub status checks",
+            stateLabel: "Status checks",
             status: "NEEDS_HUMAN_REVIEW",
             statusLabel: "Needs human review",
             statusMessage: reason,
@@ -4308,7 +4308,7 @@ describe("GraphQL API", () => {
               },
               {
                 phase: "GITHUB_STATUS_CHECKS",
-                label: "GitHub status checks: Succeeded",
+                label: "Status checks: Succeeded",
                 status: "SUCCEEDED",
               },
             ],
@@ -4372,7 +4372,7 @@ describe("GraphQL API", () => {
         workItems: [
           {
             state: "INVESTIGATE_PR_STATUS_CHECKS",
-            stateLabel: "GitHub status checks",
+            stateLabel: "Status checks",
             status: "NEEDS_HUMAN_REVIEW",
             statusLabel: "Needs human review",
             statusMessage: reason,
@@ -4387,7 +4387,7 @@ describe("GraphQL API", () => {
               },
               {
                 phase: "GITHUB_STATUS_CHECKS",
-                label: "GitHub status checks: Succeeded",
+                label: "Status checks: Succeeded",
                 status: "SUCCEEDED",
               },
             ],

--- a/packages/graphql-api/test/work-item-projection.test.ts
+++ b/packages/graphql-api/test/work-item-projection.test.ts
@@ -118,7 +118,7 @@ describe("Postponed Step Run projection", () => {
     expect(lifecycleLabels(postponed)).toEqual([
       {
         phase: "GITHUB_STATUS_CHECKS",
-        label: "GitHub status checks: Postponed",
+        label: "Status checks: Postponed",
         status: "POSTPONED",
         durationMs: 2_315_000,
       },
@@ -191,13 +191,13 @@ describe("Postponed Step Run projection", () => {
     expect(lifecycleLabels(resumed)).toEqual([
       {
         phase: "GITHUB_STATUS_CHECKS",
-        label: "GitHub status checks: Postponed (1 prior attempt)",
+        label: "Status checks: Postponed (1 prior attempt)",
         status: "POSTPONED",
         durationMs: null,
       },
       {
         phase: "GITHUB_STATUS_CHECKS",
-        label: "GitHub status checks: Queued",
+        label: "Status checks: Queued",
         status: "QUEUED",
         durationMs: 2_315_000,
       },


### PR DESCRIPTION
Why

GitLab Work Items could sit forever in Watch PR Status Checks when the host
used merged-results pipelines (e.g. DrupalCode). Those pipelines run on
`refs/merge-requests/N/merge`, so `head_pipeline.sha` is a temporary merge
commit and never equals the MR source tip. Tip-SHA equality treated that as
"stale" and requeued Watch without listing jobs, so green pipelines never
settled.

What

- Skip tip-SHA stale detection only for merged-results refs
  (`refs/merge-requests/<iid>/merge`); branch and tip-aligned MR pipelines
  (`…/head`, push) still keep watching when the pipeline SHA lags the tip.
- Decode optional `head_pipeline.ref` / `source` for that classification.
- Apply the same rule on merge pre-check so green merged-results can merge.
- Rename the lifecycle projection label from "GitHub status checks" to
  forge-neutral "Status checks" (phase enum unchanged).

Verification

- `nx test gitlab-service` (merged-results settle + tip-aligned/branch stale
  + merge path)
- `nx test graphql-api` and harness lifecycle-status projection expectations

Limitations

- Classification depends on `head_pipeline.ref` being present for
  merged-results; if a host omits it, SHA equality still applies.
- After a push, freshness still trusts GitLab's current `head_pipeline`
  attachment for `…/merge` (no parent-commit cross-check).

Closes #981