### PR TITLE
feat(cli): emit versioned JSON for finite add command

### DIFF
--- a/apps/ready-for-agent/src/cli-json.test.ts
+++ b/apps/ready-for-agent/src/cli-json.test.ts
@@ -1,0 +1,75 @@
+import {
+  CLI_SCHEMA_VERSION,
+  FiniteCommandFailed,
+  buildAddSuccessDocument,
+  buildCommandErrorDocument,
+  encodeCompactJson,
+  localGitErrorCode,
+} from "./cli-json.ts"
+import { describe, expect, test } from "bun:test"
+
+describe("finite CLI JSON contract", () => {
+  test("add success document is compact camelCase with canonical repository", () => {
+    const doc = buildAddSuccessDocument({
+      id: "repo-1",
+      forge: "github",
+      forgeHost: "github.com",
+      projectPath: "owner/repo",
+      localPath: "/tmp/repo",
+      isBare: false,
+    })
+    expect(doc).toEqual({
+      schemaVersion: CLI_SCHEMA_VERSION,
+      command: "add",
+      repository: {
+        id: "repo-1",
+        forge: "github",
+        forgeHost: "github.com",
+        projectPath: "owner/repo",
+      },
+      localPath: "/tmp/repo",
+      isBare: false,
+    })
+    expect(encodeCompactJson(doc)).toBe(
+      '{"schemaVersion":1,"command":"add","repository":{"id":"repo-1","forge":"github","forgeHost":"github.com","projectPath":"owner/repo"},"localPath":"/tmp/repo","isBare":false}',
+    )
+  })
+
+  test("command-level error document is versioned and nested under error", () => {
+    const doc = buildCommandErrorDocument({
+      command: "add",
+      code: "HARNESS_UNREACHABLE",
+      message: "Harness is not running at http://127.0.0.1:1",
+    })
+    expect(doc).toEqual({
+      schemaVersion: 1,
+      command: "add",
+      error: {
+        code: "HARNESS_UNREACHABLE",
+        message: "Harness is not running at http://127.0.0.1:1",
+      },
+    })
+  })
+
+  test("FiniteCommandFailed exposes the error document", () => {
+    const failed = new FiniteCommandFailed({
+      command: "add",
+      code: "REPOSITORY_ALREADY_EXISTS",
+      message: "Repository owner/repo already exists on github.com",
+    })
+    expect(failed.document).toEqual({
+      schemaVersion: 1,
+      command: "add",
+      error: {
+        code: "REPOSITORY_ALREADY_EXISTS",
+        message: "Repository owner/repo already exists on github.com",
+      },
+    })
+  })
+
+  test("localGitErrorCode maps known tags", () => {
+    expect(localGitErrorCode("PathNotFound")).toBe("PATH_NOT_FOUND")
+    expect(localGitErrorCode("NotAGitRepository")).toBe("NOT_A_GIT_REPOSITORY")
+    expect(localGitErrorCode("Other")).toBe("LOCAL_GIT_ERROR")
+  })
+})

--- a/apps/ready-for-agent/src/cli-json.ts
+++ b/apps/ready-for-agent/src/cli-json.ts
@@ -10,7 +10,7 @@ export const CLI_SCHEMA_VERSION = 1 as const
 export type FiniteCommandName = "add"
 
 /** Canonical Repository identity shared across finite CLI JSON documents. */
-export type CanonicalRepositoryIdentity = {
+type CanonicalRepositoryIdentity = {
   readonly id: string
   readonly forge: string
   readonly forgeHost: string
@@ -25,7 +25,7 @@ export type AddSuccessDocument = {
   readonly isBare: boolean
 }
 
-export type CommandErrorBody = {
+type CommandErrorBody = {
   readonly code: string
   readonly message: string
 }

--- a/apps/ready-for-agent/src/cli-json.ts
+++ b/apps/ready-for-agent/src/cli-json.ts
@@ -1,0 +1,116 @@
+import { Runtime, Schema } from "effect"
+
+/** CLI-owned envelope version for finite operator commands. */
+export const CLI_SCHEMA_VERSION = 1 as const
+
+/**
+ * Finite operator commands that emit one versioned JSON document.
+ * Long-running `start` is intentionally excluded.
+ */
+export type FiniteCommandName = "add"
+
+/** Canonical Repository identity shared across finite CLI JSON documents. */
+export type CanonicalRepositoryIdentity = {
+  readonly id: string
+  readonly forge: string
+  readonly forgeHost: string
+  readonly projectPath: string
+}
+
+export type AddSuccessDocument = {
+  readonly schemaVersion: typeof CLI_SCHEMA_VERSION
+  readonly command: "add"
+  readonly repository: CanonicalRepositoryIdentity
+  readonly localPath: string
+  readonly isBare: boolean
+}
+
+export type CommandErrorBody = {
+  readonly code: string
+  readonly message: string
+}
+
+export type CommandErrorDocument = {
+  readonly schemaVersion: typeof CLI_SCHEMA_VERSION
+  readonly command: FiniteCommandName
+  readonly error: CommandErrorBody
+}
+
+/** Compact single-line JSON (no pretty-print whitespace). */
+export const encodeCompactJson = (value: unknown): string =>
+  JSON.stringify(value)
+
+export const buildAddSuccessDocument = (added: {
+  readonly id: string
+  readonly forge: string
+  readonly forgeHost: string
+  readonly projectPath: string
+  readonly localPath: string
+  readonly isBare: boolean
+}): AddSuccessDocument => ({
+  schemaVersion: CLI_SCHEMA_VERSION,
+  command: "add",
+  repository: {
+    id: added.id,
+    forge: added.forge,
+    forgeHost: added.forgeHost,
+    projectPath: added.projectPath,
+  },
+  localPath: added.localPath,
+  isBare: added.isBare,
+})
+
+export const buildCommandErrorDocument = (options: {
+  readonly command: FiniteCommandName
+  readonly code: string
+  readonly message: string
+}): CommandErrorDocument => ({
+  schemaVersion: CLI_SCHEMA_VERSION,
+  command: options.command,
+  error: {
+    code: options.code,
+    message: options.message,
+  },
+})
+
+const FiniteCommandNameSchema = Schema.Literals(["add"])
+
+/**
+ * Expected finite-command failure. Marked as already reported so
+ * `BunRuntime.runMain` does not pretty-print a multi-frame stack after the
+ * CLI writes the versioned JSON error document once on stderr.
+ */
+export class FiniteCommandFailed extends Schema.TaggedErrorClass<FiniteCommandFailed>()(
+  "FiniteCommandFailed",
+  {
+    command: FiniteCommandNameSchema,
+    code: Schema.String,
+    message: Schema.String,
+  },
+) {
+  override readonly [Runtime.errorReported] = false
+
+  get document(): CommandErrorDocument {
+    return buildCommandErrorDocument({
+      command: this.command,
+      code: this.code,
+      message: this.message,
+    })
+  }
+}
+
+/** Map LocalGit tagged failures to stable CLI-owned error codes. */
+export const localGitErrorCode = (tag: string): string => {
+  switch (tag) {
+    case "PathNotFound":
+      return "PATH_NOT_FOUND"
+    case "NotADirectory":
+      return "NOT_A_DIRECTORY"
+    case "NotAGitRepository":
+      return "NOT_A_GIT_REPOSITORY"
+    case "NoForgeRemote":
+      return "NO_FORGE_REMOTE"
+    default:
+      return "LOCAL_GIT_ERROR"
+  }
+}

--- a/apps/ready-for-agent/src/cli-process.test.ts
+++ b/apps/ready-for-agent/src/cli-process.test.ts
@@ -1,0 +1,276 @@
+/**
+ * Exact operator-binary process contract for finite commands.
+ *
+ * Mock GraphQL servers run in this process, so child CLI processes must be
+ * spawned asynchronously — `spawnSync` blocks the event loop and the mock
+ * never answers the request (deadlock).
+ */
+
+import { spawn, spawnSync } from "node:child_process"
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs"
+import { type Server, createServer } from "node:http"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { fileURLToPath } from "node:url"
+import { CLI_SCHEMA_VERSION, buildAddSuccessDocument } from "./cli-json.ts"
+import {
+  HARNESS_START_HINT,
+  HARNESS_UNREACHABLE_CODE,
+  harnessNotRunningMessage,
+} from "./graphql-error.ts"
+import { afterEach, beforeEach, describe, expect, test } from "bun:test"
+
+const packageRoot = fileURLToPath(new URL("..", import.meta.url))
+
+const initFixtureRepo = (repoDir: string): void => {
+  mkdirSync(repoDir)
+  writeFileSync(join(repoDir, "README.md"), "fixture\n")
+  const git = (args: string[]) =>
+    spawnSync("git", args, { cwd: repoDir, encoding: "utf8" })
+  expect(git(["init"]).status).toBe(0)
+  expect(
+    git(["remote", "add", "origin", "git@github.com:owner/repo.git"]).status,
+  ).toBe(0)
+}
+
+/**
+ * Finite commands must emit exactly one compact JSON document on the
+ * relevant stream — no banners, stacks, or progress lines mixed in.
+ */
+const parseExactlyOneJsonDocument = (text: string): unknown => {
+  const lines = text
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0)
+  expect(lines).toHaveLength(1)
+  const line = lines[0]
+  expect(line).toBeDefined()
+  if (line === undefined) {
+    throw new Error(`expected one JSON document, got:\n${text}`)
+  }
+  return JSON.parse(line)
+}
+
+const listen = (server: Server): Promise<number> =>
+  new Promise((resolve, reject) => {
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address()
+      if (address === null || typeof address === "string") {
+        reject(new Error("expected TCP address"))
+        return
+      }
+      resolve(address.port)
+    })
+    server.on("error", reject)
+  })
+
+const closeServer = (server: Server): Promise<void> =>
+  new Promise((resolve) => {
+    server.close(() => resolve())
+  })
+
+type ProcessResult = {
+  readonly status: number | null
+  readonly stdout: string
+  readonly stderr: string
+}
+
+const runAdd = (repoDir: string, graphqlUrl: string): Promise<ProcessResult> =>
+  new Promise((resolve, reject) => {
+    const child = spawn(
+      "bun",
+      [
+        "--conditions",
+        "@ready-for-agent/source",
+        "src/main.ts",
+        "add",
+        repoDir,
+      ],
+      {
+        cwd: packageRoot,
+        env: {
+          ...process.env,
+          READY_FOR_AGENT_GRAPHQL_URL: graphqlUrl,
+          // Keep CLI error JSON free of ANSI so process contracts stay exact.
+          NO_COLOR: "1",
+          FORCE_COLOR: "0",
+        },
+      },
+    )
+    let stdout = ""
+    let stderr = ""
+    child.stdout.setEncoding("utf8")
+    child.stderr.setEncoding("utf8")
+    child.stdout.on("data", (chunk: string) => {
+      stdout += chunk
+    })
+    child.stderr.on("data", (chunk: string) => {
+      stderr += chunk
+    })
+    const timer = setTimeout(() => {
+      child.kill("SIGKILL")
+      reject(new Error(`add timed out\nstdout:\n${stdout}\nstderr:\n${stderr}`))
+    }, 20_000)
+    child.on("error", (error) => {
+      clearTimeout(timer)
+      reject(error)
+    })
+    child.on("close", (status) => {
+      clearTimeout(timer)
+      resolve({ status, stdout, stderr })
+    })
+  })
+
+describe("operator binary finite-command process contract", () => {
+  let tempRoot = ""
+
+  beforeEach(() => {
+    tempRoot = mkdtempSync(join(tmpdir(), "ready-for-agent-cli-process-"))
+  })
+
+  afterEach(() => {
+    rmSync(tempRoot, { recursive: true, force: true })
+  })
+
+  test("add against unreachable GraphQL emits JSON error on stderr only", async () => {
+    const repoDir = join(tempRoot, "repo")
+    initFixtureRepo(repoDir)
+
+    const result = await runAdd(repoDir, "http://127.0.0.1:1/graphql")
+
+    expect(result.status).toBe(1)
+    expect(result.stdout.trim()).toBe("")
+    const errorDoc = parseExactlyOneJsonDocument(result.stderr)
+    expect(errorDoc).toEqual({
+      schemaVersion: CLI_SCHEMA_VERSION,
+      command: "add",
+      error: {
+        code: HARNESS_UNREACHABLE_CODE,
+        message: harnessNotRunningMessage("http://127.0.0.1:1"),
+      },
+    })
+    // Message value may embed the start hint (escaped in the JSON line).
+    expect(result.stderr).toContain(HARNESS_START_HINT)
+    expect(result.stderr.split(HARNESS_START_HINT).length - 1).toBe(1)
+    expect(result.stderr).not.toContain("Unable to connect")
+    expect(result.stderr).not.toContain("access the url")
+    expect(result.stderr).not.toMatch(/\s+at\s+\S+\s+\(/)
+    expect(result.stderr).not.toContain("FiniteCommandFailed:")
+    expect(result.stderr).not.toContain("GraphqlRequestFailed:")
+    expect(result.stderr.toLowerCase()).not.toContain("starting harness")
+    expect(result.stdout.toLowerCase()).not.toContain("starting harness")
+  })
+
+  test("add success emits one JSON document on stdout and exits 0", async () => {
+    const repoDir = join(tempRoot, "repo-success")
+    initFixtureRepo(repoDir)
+
+    const seenBodies: string[] = []
+    const server = createServer((req, res) => {
+      if (req.method !== "POST") {
+        res.writeHead(405)
+        res.end()
+        return
+      }
+      const chunks: Buffer[] = []
+      req.on("data", (chunk: Buffer) => {
+        chunks.push(chunk)
+      })
+      req.on("end", () => {
+        seenBodies.push(Buffer.concat(chunks).toString("utf8"))
+        res.writeHead(200, { "content-type": "application/json" })
+        res.end(
+          JSON.stringify({
+            data: {
+              addRepository: {
+                id: "repo-process-1",
+                forge: "github",
+                forgeHost: "github.com",
+                projectPath: "owner/repo",
+                localPath: repoDir,
+                isBare: false,
+              },
+            },
+          }),
+        )
+      })
+    })
+
+    try {
+      const port = await listen(server)
+      const result = await runAdd(repoDir, `http://127.0.0.1:${port}/graphql`)
+
+      expect(result.status).toBe(0)
+      expect(result.stderr.trim()).toBe("")
+      expect(seenBodies.some((body) => body.includes("addRepository"))).toBe(
+        true,
+      )
+      const successDoc = parseExactlyOneJsonDocument(result.stdout)
+      expect(successDoc).toEqual(
+        buildAddSuccessDocument({
+          id: "repo-process-1",
+          forge: "github",
+          forgeHost: "github.com",
+          projectPath: "owner/repo",
+          localPath: repoDir,
+          isBare: false,
+        }),
+      )
+      expect(result.stdout).not.toContain("Added repository")
+    } finally {
+      await closeServer(server)
+    }
+  })
+
+  test("add GraphQL domain failure preserves extensions.code on stderr", async () => {
+    const repoDir = join(tempRoot, "repo-domain-fail")
+    initFixtureRepo(repoDir)
+
+    const server = createServer((req, res) => {
+      if (req.method !== "POST") {
+        res.writeHead(405)
+        res.end()
+        return
+      }
+      const chunks: Buffer[] = []
+      req.on("data", (chunk: Buffer) => {
+        chunks.push(chunk)
+      })
+      req.on("end", () => {
+        res.writeHead(200, { "content-type": "application/json" })
+        res.end(
+          JSON.stringify({
+            data: null,
+            errors: [
+              {
+                message: "Repository owner/repo already exists on github.com",
+                extensions: { code: "REPOSITORY_ALREADY_EXISTS" },
+              },
+            ],
+          }),
+        )
+      })
+    })
+
+    try {
+      const port = await listen(server)
+      const result = await runAdd(repoDir, `http://127.0.0.1:${port}/graphql`)
+
+      expect(result.status).toBe(1)
+      expect(result.stdout.trim()).toBe("")
+      const errorDoc = parseExactlyOneJsonDocument(result.stderr)
+      expect(errorDoc).toEqual({
+        schemaVersion: CLI_SCHEMA_VERSION,
+        command: "add",
+        error: {
+          code: "REPOSITORY_ALREADY_EXISTS",
+          message: "Repository owner/repo already exists on github.com",
+        },
+      })
+      expect(result.stderr).not.toMatch(/\s+at\s+\S+\s+\(/)
+      expect(result.stderr).not.toContain("FiniteCommandFailed:")
+    } finally {
+      await closeServer(server)
+    }
+  })
+})

--- a/apps/ready-for-agent/src/cli.test.ts
+++ b/apps/ready-for-agent/src/cli.test.ts
@@ -1,16 +1,20 @@
 import { spawnSync } from "node:child_process"
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs"
-import { tmpdir } from "node:os"
-import { join } from "node:path"
 import { fileURLToPath } from "node:url"
 import { BunServices } from "@effect/platform-bun"
-import { afterEach, beforeEach, describe, expect, it } from "@effect/vitest"
+import { beforeEach, describe, expect, it } from "@effect/vitest"
 import { Effect, Layer } from "effect"
 import { Command } from "effect/unstable/cli"
 import { expandBareHostFlag } from "../../harness/src/server/listen-host.ts"
 import { cli } from "./cli.ts"
 import {
+  CLI_SCHEMA_VERSION,
+  FiniteCommandFailed,
+  buildAddSuccessDocument,
+  encodeCompactJson,
+} from "./cli-json.ts"
+import {
   HARNESS_START_HINT,
+  HARNESS_UNREACHABLE_CODE,
   harnessNotRunningMessage,
 } from "./graphql-error.ts"
 import { GraphqlApi, GraphqlRequestFailed } from "./services/graphql-api.ts"
@@ -36,16 +40,10 @@ const runOperator = (
 describe("operator binary CLI seam", () => {
   let started = 0
   let lastStartOptions: StartHarnessOptions | undefined
-  let tempRoot = ""
 
   beforeEach(() => {
     started = 0
     lastStartOptions = undefined
-    tempRoot = mkdtempSync(join(tmpdir(), "ready-for-agent-cli-"))
-  })
-
-  afterEach(() => {
-    rmSync(tempRoot, { recursive: true, force: true })
   })
 
   const mockStart = Layer.succeed(StartHarness, {
@@ -88,7 +86,7 @@ describe("operator binary CLI seam", () => {
   )
 
   it.live(
-    "add reports GraphQL harness-not-running failures from the service",
+    "add maps GraphQL harness-not-running failures to FiniteCommandFailed",
     () =>
       Effect.gen(function* () {
         const harnessDown = harnessNotRunningMessage()
@@ -99,6 +97,7 @@ describe("operator binary CLI seam", () => {
               addRepository: () =>
                 Effect.fail(
                   new GraphqlRequestFailed({
+                    code: HARNESS_UNREACHABLE_CODE,
                     message: harnessDown,
                   }),
                 ),
@@ -110,13 +109,50 @@ describe("operator binary CLI seam", () => {
           Effect.flip,
         )
 
-        expect(result._tag).toBe("GraphqlRequestFailed")
-        if (result._tag === "GraphqlRequestFailed") {
+        expect(result._tag).toBe("FiniteCommandFailed")
+        if (result._tag === "FiniteCommandFailed") {
+          expect(result.command).toBe("add")
+          expect(result.code).toBe(HARNESS_UNREACHABLE_CODE)
           expect(result.message).toBe(harnessDown)
           expect(result.message).toContain(HARNESS_START_HINT)
           expect(result.message).not.toContain("Unable to connect")
         }
       }),
+  )
+
+  it.live("add preserves GraphQL domain error codes", () =>
+    Effect.gen(function* () {
+      const layer = mockStart.pipe(
+        Layer.provideMerge(mockLocalGit),
+        Layer.provideMerge(
+          Layer.succeed(GraphqlApi, {
+            addRepository: () =>
+              Effect.fail(
+                new GraphqlRequestFailed({
+                  code: "REPOSITORY_ALREADY_EXISTS",
+                  message: "Repository owner/repo already exists on github.com",
+                }),
+              ),
+          }),
+        ),
+      )
+
+      const result = yield* runOperator(["add", "/tmp/repo"], layer).pipe(
+        Effect.flip,
+      )
+
+      expect(result).toBeInstanceOf(FiniteCommandFailed)
+      if (result instanceof FiniteCommandFailed) {
+        expect(result.document).toEqual({
+          schemaVersion: CLI_SCHEMA_VERSION,
+          command: "add",
+          error: {
+            code: "REPOSITORY_ALREADY_EXISTS",
+            message: "Repository owner/repo already exists on github.com",
+          },
+        })
+      }
+    }),
   )
 
   it.live("add lets the operator correct a guessed GitLab identity", () =>
@@ -177,7 +213,7 @@ describe("operator binary CLI seam", () => {
     }),
   )
 
-  it.live("add success output does not mention paused", () =>
+  it.live("add success emits exactly one versioned JSON document", () =>
     Effect.gen(function* () {
       const logs: string[] = []
       const originalLog = console.log
@@ -205,12 +241,18 @@ describe("operator binary CLI seam", () => {
 
         yield* runOperator(["add", "/tmp/repo"], layer)
 
-        const output = logs.join("\n")
-        expect(output).toContain("Added repository owner/repo")
-        expect(output).toContain("id: repo-1")
-        expect(output).toContain("local path: /tmp/repo")
-        expect(output).toContain("bare: false")
-        expect(output).not.toMatch(/paused/i)
+        expect(logs).toHaveLength(1)
+        const expected = buildAddSuccessDocument({
+          id: "repo-1",
+          forge: "github",
+          forgeHost: "github.com",
+          projectPath: "owner/repo",
+          localPath: "/tmp/repo",
+          isBare: false,
+        })
+        expect(logs[0]).toBe(encodeCompactJson(expected))
+        expect(logs[0]).not.toMatch(/paused/i)
+        expect(logs[0]).not.toContain("Added repository")
       } finally {
         console.log = originalLog
       }
@@ -288,49 +330,4 @@ describe("operator binary CLI seam", () => {
       })
     }),
   )
-
-  it("binary add against unreachable GraphQL prints harness-not-running once, no stack", () => {
-    const repoDir = join(tempRoot, "repo")
-    mkdirSync(repoDir)
-    writeFileSync(join(repoDir, "README.md"), "fixture\n")
-    const git = (args: string[]) =>
-      spawnSync("git", args, { cwd: repoDir, encoding: "utf8" })
-    expect(git(["init"]).status).toBe(0)
-    expect(
-      git(["remote", "add", "origin", "git@github.com:owner/repo.git"]).status,
-    ).toBe(0)
-
-    const result = spawnSync(
-      "bun",
-      [
-        "--conditions",
-        "@ready-for-agent/source",
-        "src/main.ts",
-        "add",
-        repoDir,
-      ],
-      {
-        cwd: packageRoot,
-        encoding: "utf8",
-        env: {
-          ...process.env,
-          READY_FOR_AGENT_GRAPHQL_URL: "http://127.0.0.1:1/graphql",
-        },
-      },
-    )
-
-    const output = `${result.stdout}\n${result.stderr}`
-    expect(result.status).not.toBe(0)
-    expect(output).toContain("Harness is not running at http://127.0.0.1:1")
-    expect(output).toContain(HARNESS_START_HINT)
-    expect(output.split(HARNESS_START_HINT).length - 1).toBe(1)
-    expect(output).not.toContain("Unable to connect")
-    expect(output).not.toContain("access the url")
-    // No multi-frame Effect / internal stack for this expected case.
-    expect(output).not.toMatch(/\s+at\s+\S+\s+\(/)
-    expect(output).not.toContain("GraphqlRequestFailed:")
-    // Child process must not boot the harness (add is GraphQL-only). Do not
-    // assert parent `started` — that counter is only for in-process mockStart.
-    expect(output.toLowerCase()).not.toContain("starting harness")
-  })
 })

--- a/apps/ready-for-agent/src/cli.ts
+++ b/apps/ready-for-agent/src/cli.ts
@@ -1,5 +1,11 @@
 import { Console, Effect, Option } from "effect"
 import { Argument, Command, Flag } from "effect/unstable/cli"
+import {
+  FiniteCommandFailed,
+  buildAddSuccessDocument,
+  encodeCompactJson,
+  localGitErrorCode,
+} from "./cli-json.ts"
 import { GraphqlApi } from "./services/graphql-api.ts"
 import { LocalGit } from "./services/local-git.ts"
 import { StartHarness } from "./services/start-harness.ts"
@@ -43,6 +49,51 @@ const startHarnessWorkflow = Effect.fn("Cli.startHarness")(function* (
   yield* startHarnessService.start({ noOpen, host })
 })
 
+const toAddCommandFailed = (error: unknown): FiniteCommandFailed => {
+  if (error instanceof FiniteCommandFailed) {
+    return error
+  }
+  if (
+    typeof error === "object" &&
+    error !== null &&
+    "_tag" in error &&
+    typeof (error as { _tag: unknown })._tag === "string"
+  ) {
+    const tagged = error as {
+      readonly _tag: string
+      readonly code?: string
+      readonly message?: string
+    }
+    if (
+      tagged._tag === "GraphqlRequestFailed" &&
+      typeof tagged.code === "string" &&
+      typeof tagged.message === "string"
+    ) {
+      return new FiniteCommandFailed({
+        command: "add",
+        code: tagged.code,
+        message: tagged.message,
+      })
+    }
+    const message =
+      error instanceof Error
+        ? error.message
+        : typeof tagged.message === "string"
+          ? tagged.message
+          : String(error)
+    return new FiniteCommandFailed({
+      command: "add",
+      code: localGitErrorCode(tagged._tag),
+      message,
+    })
+  }
+  return new FiniteCommandFailed({
+    command: "add",
+    code: "INTERNAL_ERROR",
+    message: error instanceof Error ? error.message : String(error),
+  })
+}
+
 const addRepositoryWorkflow = Effect.fn("Cli.addRepository")(function* (
   path: string,
   corrections: {
@@ -52,7 +103,9 @@ const addRepositoryWorkflow = Effect.fn("Cli.addRepository")(function* (
 ) {
   const localGit = yield* LocalGit
   const graphqlApi = yield* GraphqlApi
-  const inspected = yield* localGit.inspect(path)
+  const inspected = yield* localGit
+    .inspect(path)
+    .pipe(Effect.mapError(toAddCommandFailed))
   const repository = {
     ...inspected,
     ...(corrections.forgeHost === undefined
@@ -62,12 +115,12 @@ const addRepositoryWorkflow = Effect.fn("Cli.addRepository")(function* (
       ? {}
       : { projectPath: corrections.projectPath }),
   }
-  const added = yield* graphqlApi.addRepository(repository)
+  const added = yield* graphqlApi
+    .addRepository(repository)
+    .pipe(Effect.mapError(toAddCommandFailed))
 
-  yield* Console.log(`Added repository ${added.projectPath}`)
-  yield* Console.log(`  id: ${added.id}`)
-  yield* Console.log(`  local path: ${added.localPath}`)
-  yield* Console.log(`  bare: ${added.isBare}`)
+  // Exactly one compact JSON success document on stdout; no progress chatter.
+  yield* Console.log(encodeCompactJson(buildAddSuccessDocument(added)))
 })
 
 const startCommand = Command.make(

--- a/apps/ready-for-agent/src/graphql-error.test.ts
+++ b/apps/ready-for-agent/src/graphql-error.test.ts
@@ -1,6 +1,10 @@
+import { GenqlError } from "@ready-for-agent/graphql-client"
 import {
   DEFAULT_HARNESS_BASE_URL,
+  GRAPHQL_ERROR_CODE,
   HARNESS_START_HINT,
+  HARNESS_UNREACHABLE_CODE,
+  describeGraphqlFailure,
   formatGraphqlRequestFailure,
   harnessBaseUrlFromGraphqlUrl,
   harnessNotRunningMessage,
@@ -14,14 +18,15 @@ describe("graphql unreachable detection", () => {
       "Unable to connect. Is the computer able to access the url?",
     )
     expect(isGraphqlUnreachable(cause)).toBe(true)
-    const message = formatGraphqlRequestFailure(cause)
-    expect(message).toBe(harnessNotRunningMessage())
-    expect(message).toContain(HARNESS_START_HINT)
-    expect(message).not.toContain("Unable to connect")
-    expect(message).not.toContain("access the url")
-    expect(message).toContain(DEFAULT_HARNESS_BASE_URL)
+    const failure = describeGraphqlFailure(cause)
+    expect(failure.code).toBe(HARNESS_UNREACHABLE_CODE)
+    expect(failure.message).toBe(harnessNotRunningMessage())
+    expect(failure.message).toContain(HARNESS_START_HINT)
+    expect(failure.message).not.toContain("Unable to connect")
+    expect(failure.message).not.toContain("access the url")
+    expect(failure.message).toContain(DEFAULT_HARNESS_BASE_URL)
     // Start instruction appears once.
-    expect(message.split(HARNESS_START_HINT).length - 1).toBe(1)
+    expect(failure.message.split(HARNESS_START_HINT).length - 1).toBe(1)
   })
 
   test("detects ECONNREFUSED nested causes with configured GraphQL URL", () => {
@@ -30,15 +35,47 @@ describe("graphql unreachable detection", () => {
     })
     expect(isGraphqlUnreachable(cause)).toBe(true)
     expect(
-      formatGraphqlRequestFailure(cause, {
+      describeGraphqlFailure(cause, {
         graphqlUrl: "http://127.0.0.1:7000/graphql",
       }),
-    ).toBe(harnessNotRunningMessage("http://127.0.0.1:7000"))
+    ).toEqual({
+      code: HARNESS_UNREACHABLE_CODE,
+      message: harnessNotRunningMessage("http://127.0.0.1:7000"),
+    })
   })
 
-  test("leaves application GraphQL errors unchanged", () => {
+  test("preserves GenqlError extensions.code for domain failures", () => {
+    const cause = new GenqlError(
+      [
+        {
+          message: "Repository owner/repo already exists on github.com",
+          extensions: { code: "REPOSITORY_ALREADY_EXISTS" },
+        },
+      ],
+      null,
+    )
+    expect(isGraphqlUnreachable(cause)).toBe(false)
+    expect(describeGraphqlFailure(cause)).toEqual({
+      code: "REPOSITORY_ALREADY_EXISTS",
+      message: "Repository owner/repo already exists on github.com",
+    })
+  })
+
+  test("falls back when GenqlError has no extensions.code", () => {
+    const cause = new GenqlError([{ message: "something broke" }], null)
+    expect(describeGraphqlFailure(cause)).toEqual({
+      code: GRAPHQL_ERROR_CODE,
+      message: "something broke",
+    })
+  })
+
+  test("leaves plain application errors as GRAPHQL_ERROR", () => {
     const cause = new Error("Repository already registered")
     expect(isGraphqlUnreachable(cause)).toBe(false)
+    expect(describeGraphqlFailure(cause)).toEqual({
+      code: GRAPHQL_ERROR_CODE,
+      message: "Repository already registered",
+    })
     expect(formatGraphqlRequestFailure(cause)).toBe(
       "Repository already registered",
     )

--- a/apps/ready-for-agent/src/graphql-error.ts
+++ b/apps/ready-for-agent/src/graphql-error.ts
@@ -4,6 +4,28 @@ export const DEFAULT_HARNESS_BASE_URL = "http://127.0.0.1:6056"
 /** Single-line start remedy for unreachable-Harness failures. */
 export const HARNESS_START_HINT = "Start it with: ready-for-agent start"
 
+/** CLI-owned code when the GraphQL transport cannot reach the Harness. */
+export const HARNESS_UNREACHABLE_CODE = "HARNESS_UNREACHABLE"
+
+/**
+ * Fallback when a GraphQL response has no usable `extensions.code`.
+ * Domain failures from the Harness always supply a stable code.
+ */
+export const GRAPHQL_ERROR_CODE = "GRAPHQL_ERROR"
+
+/** Minimal GenqlError shape (generated client is @ts-nocheck; duck-type safely). */
+type GenqlErrorLike = Error & {
+  readonly errors: ReadonlyArray<{
+    readonly message?: string
+    readonly extensions?: Record<string, unknown>
+  }>
+}
+
+const isGenqlErrorLike = (cause: unknown): cause is GenqlErrorLike =>
+  cause instanceof Error &&
+  "errors" in cause &&
+  Array.isArray((cause as { errors: unknown }).errors)
+
 /**
  * Derive the operator-facing Harness base URL from a GraphQL endpoint URL
  * (strip a trailing `/graphql`). Falls back to the product default.
@@ -62,16 +84,54 @@ export type FormatGraphqlRequestFailureOptions = {
   readonly graphqlUrl?: string
 }
 
-export const formatGraphqlRequestFailure = (
+/** Structured GraphQL/transport failure for the CLI JSON error seam. */
+export type GraphqlFailureInfo = {
+  readonly code: string
+  readonly message: string
+}
+
+const graphqlErrorCode = (cause: GenqlErrorLike): string => {
+  const first = cause.errors[0]
+  const code = first?.extensions?.code
+  return typeof code === "string" && code.length > 0 ? code : GRAPHQL_ERROR_CODE
+}
+
+/**
+ * Map a GraphQL client failure to a stable code + operator-facing message.
+ * Unreachable transport uses the CLI-owned `HARNESS_UNREACHABLE` code.
+ * Domain failures retain Harness `extensions.code` from GenqlError.
+ */
+export const describeGraphqlFailure = (
   cause: unknown,
   options?: FormatGraphqlRequestFailureOptions,
-): string => {
+): GraphqlFailureInfo => {
   if (isGraphqlUnreachable(cause)) {
     const baseUrl =
       options?.graphqlUrl === undefined
         ? DEFAULT_HARNESS_BASE_URL
         : harnessBaseUrlFromGraphqlUrl(options.graphqlUrl)
-    return harnessNotRunningMessage(baseUrl)
+    return {
+      code: HARNESS_UNREACHABLE_CODE,
+      message: harnessNotRunningMessage(baseUrl),
+    }
   }
-  return cause instanceof Error ? cause.message : "GraphQL request failed"
+
+  if (isGenqlErrorLike(cause)) {
+    return {
+      code: graphqlErrorCode(cause),
+      message:
+        cause.message.length > 0 ? cause.message : "GraphQL request failed",
+    }
+  }
+
+  return {
+    code: GRAPHQL_ERROR_CODE,
+    message: cause instanceof Error ? cause.message : "GraphQL request failed",
+  }
 }
+
+/** @deprecated Prefer `describeGraphqlFailure` when a stable code is needed. */
+export const formatGraphqlRequestFailure = (
+  cause: unknown,
+  options?: FormatGraphqlRequestFailureOptions,
+): string => describeGraphqlFailure(cause, options).message

--- a/apps/ready-for-agent/src/main.ts
+++ b/apps/ready-for-agent/src/main.ts
@@ -44,15 +44,17 @@ if (isInternalKeymaxxerSidecarMode(process.argv)) {
   // Expand bare `--host` → `--host 0.0.0.0` before Effect's string flag parser.
   const args = expandBareHostFlag(process.argv.slice(2))
 
+  const { encodeCompactJson } = await import("./cli-json.ts")
+
   const program = Command.runWith(cli, {
     version: READY_FOR_AGENT_VERSION,
   })(args).pipe(
     Effect.provide(MainLive),
-    // GraphqlRequestFailed is marked [Runtime.errorReported]=false so runMain
-    // skips Cause pretty-print; surface the short message once here.
-    Effect.tapErrorTag("GraphqlRequestFailed", (error) =>
+    // FiniteCommandFailed is marked [Runtime.errorReported]=false so runMain
+    // skips Cause pretty-print; emit one versioned JSON error on stderr.
+    Effect.tapErrorTag("FiniteCommandFailed", (error) =>
       Effect.sync(() => {
-        console.error(error.message)
+        console.error(encodeCompactJson(error.document))
       }),
     ),
   )

--- a/apps/ready-for-agent/src/services/graphql-api.ts
+++ b/apps/ready-for-agent/src/services/graphql-api.ts
@@ -1,17 +1,21 @@
 import { Context, Effect, Layer, Runtime, Schema } from "effect"
 import { createClient } from "@ready-for-agent/graphql-client"
 import type { LocalRepository, RepositorySummary } from "../domain.ts"
-import { formatGraphqlRequestFailure } from "../graphql-error.ts"
+import { describeGraphqlFailure } from "../graphql-error.ts"
 import { ApplicationConfig } from "./application-config.ts"
 
 /**
  * Expected GraphQL operator failures. Marked as already reported so
  * `BunRuntime.runMain` does not pretty-print a multi-frame stack after the
- * CLI prints the user-facing `message` once (harness-down and similar).
+ * CLI writes the versioned JSON error once (harness-down and similar).
+ * `code` is the Harness `extensions.code` or a CLI-owned transport code.
  */
 export class GraphqlRequestFailed extends Schema.TaggedErrorClass<GraphqlRequestFailed>()(
   "GraphqlRequestFailed",
-  { message: Schema.String },
+  {
+    code: Schema.String,
+    message: Schema.String,
+  },
 ) {
   override readonly [Runtime.errorReported] = false
 }
@@ -60,12 +64,15 @@ export class GraphqlApi extends Context.Service<
             }
             return added
           },
-          catch: (cause) =>
-            new GraphqlRequestFailed({
-              message: formatGraphqlRequestFailure(cause, {
-                graphqlUrl: config.graphqlUrl,
-              }),
-            }),
+          catch: (cause) => {
+            const failure = describeGraphqlFailure(cause, {
+              graphqlUrl: config.graphqlUrl,
+            })
+            return new GraphqlRequestFailed({
+              code: failure.code,
+              message: failure.message,
+            })
+          },
         })
       })
 


### PR DESCRIPTION
Why

Automated operators need a stable, machine-readable CLI contract.
Human progress lines from add were not scriptable, and GraphQL domain
error codes were collapsed to plain messages before the process boundary.

What

- Finite add success writes one compact JSON document on stdout
  (schemaVersion, command, canonical repository identity, localPath, isBare).
- Command-level failures write one versioned JSON error on stderr and exit
  nonzero.
- Harness GraphQL extensions.code values survive the generated client and
  CLI seam; unreachable transport uses CLI-owned HARNESS_UNREACHABLE.
- Shared envelope helpers (cli-json) and FiniteCommandFailed for later
  finite commands; start keeps ordinary long-running logs.
- Process tests enforce single-document stdout/stderr separation, JSON
  shape, GraphQL domain failure, unreachable Harness, and exit status.

Verification

- bunx nx run ready-for-agent:typecheck
- bunx nx run ready-for-agent:test (includes cli-process contract tests)

Notes

Tracer bullet for the Intake JSON contract (issue 973 family).
candidates / intake / status are out of scope here.

Relates to #975.

Closes #975