### PR TITLE
feat: list Repository Intake Candidates via GraphQL and CLI

### DIFF
--- a/apps/ready-for-agent/src/cli-json.test.ts
+++ b/apps/ready-for-agent/src/cli-json.test.ts
@@ -2,6 +2,7 @@ import {
   CLI_SCHEMA_VERSION,
   FiniteCommandFailed,
   buildAddSuccessDocument,
+  buildCandidatesSuccessDocument,
   buildCommandErrorDocument,
   encodeCompactJson,
   localGitErrorCode,
@@ -33,6 +34,46 @@ describe("finite CLI JSON contract", () => {
     expect(encodeCompactJson(doc)).toBe(
       '{"schemaVersion":1,"command":"add","repository":{"id":"repo-1","forge":"github","forgeHost":"github.com","projectPath":"owner/repo"},"localPath":"/tmp/repo","isBare":false}',
     )
+  })
+
+  test("candidates success document includes issuesReconciledAt and actions", () => {
+    const doc = buildCandidatesSuccessDocument({
+      repository: {
+        id: "repo-1",
+        forge: "github",
+        forgeHost: "github.com",
+        projectPath: "owner/repo",
+      },
+      issuesReconciledAt: null,
+      candidates: [
+        {
+          issueNumber: 3,
+          title: "Ready",
+          url: "https://github.com/owner/repo/issues/3",
+          action: "IMPLEMENT_NOW",
+        },
+      ],
+    })
+    expect(doc).toEqual({
+      schemaVersion: CLI_SCHEMA_VERSION,
+      command: "candidates",
+      repository: {
+        id: "repo-1",
+        forge: "github",
+        forgeHost: "github.com",
+        projectPath: "owner/repo",
+      },
+      issuesReconciledAt: null,
+      candidates: [
+        {
+          issueNumber: 3,
+          title: "Ready",
+          url: "https://github.com/owner/repo/issues/3",
+          action: "IMPLEMENT_NOW",
+        },
+      ],
+    })
+    expect(encodeCompactJson(doc)).toContain('"issuesReconciledAt":null')
   })
 
   test("command-level error document is versioned and nested under error", () => {

--- a/apps/ready-for-agent/src/cli-json.ts
+++ b/apps/ready-for-agent/src/cli-json.ts
@@ -7,10 +7,10 @@ export const CLI_SCHEMA_VERSION = 1 as const
  * Finite operator commands that emit one versioned JSON document.
  * Long-running `start` is intentionally excluded.
  */
-export type FiniteCommandName = "add"
+export type FiniteCommandName = "add" | "candidates"
 
 /** Canonical Repository identity shared across finite CLI JSON documents. */
-type CanonicalRepositoryIdentity = {
+export type CanonicalRepositoryIdentity = {
   readonly id: string
   readonly forge: string
   readonly forgeHost: string
@@ -23,6 +23,21 @@ export type AddSuccessDocument = {
   readonly repository: CanonicalRepositoryIdentity
   readonly localPath: string
   readonly isBare: boolean
+}
+
+export type IntakeCandidateAction = "IMPLEMENT_NOW" | "QUEUE"
+
+export type CandidatesSuccessDocument = {
+  readonly schemaVersion: typeof CLI_SCHEMA_VERSION
+  readonly command: "candidates"
+  readonly repository: CanonicalRepositoryIdentity
+  readonly issuesReconciledAt: string | null
+  readonly candidates: readonly {
+    readonly issueNumber: number
+    readonly title: string
+    readonly url: string
+    readonly action: IntakeCandidateAction
+  }[]
 }
 
 type CommandErrorBody = {
@@ -60,6 +75,23 @@ export const buildAddSuccessDocument = (added: {
   isBare: added.isBare,
 })
 
+export const buildCandidatesSuccessDocument = (input: {
+  readonly repository: CanonicalRepositoryIdentity
+  readonly issuesReconciledAt: string | null
+  readonly candidates: readonly {
+    readonly issueNumber: number
+    readonly title: string
+    readonly url: string
+    readonly action: IntakeCandidateAction
+  }[]
+}): CandidatesSuccessDocument => ({
+  schemaVersion: CLI_SCHEMA_VERSION,
+  command: "candidates",
+  repository: input.repository,
+  issuesReconciledAt: input.issuesReconciledAt,
+  candidates: input.candidates,
+})
+
 export const buildCommandErrorDocument = (options: {
   readonly command: FiniteCommandName
   readonly code: string
@@ -73,7 +105,7 @@ export const buildCommandErrorDocument = (options: {
   },
 })
 
-const FiniteCommandNameSchema = Schema.Literals(["add"])
+const FiniteCommandNameSchema = Schema.Literals(["add", "candidates"])
 
 /**
  * Expected finite-command failure. Marked as already reported so

--- a/apps/ready-for-agent/src/cli-process.test.ts
+++ b/apps/ready-for-agent/src/cli-process.test.ts
@@ -12,7 +12,11 @@ import { type Server, createServer } from "node:http"
 import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { fileURLToPath } from "node:url"
-import { CLI_SCHEMA_VERSION, buildAddSuccessDocument } from "./cli-json.ts"
+import {
+  CLI_SCHEMA_VERSION,
+  buildAddSuccessDocument,
+  buildCandidatesSuccessDocument,
+} from "./cli-json.ts"
 import {
   HARNESS_START_HINT,
   HARNESS_UNREACHABLE_CODE,
@@ -75,17 +79,14 @@ type ProcessResult = {
   readonly stderr: string
 }
 
-const runAdd = (repoDir: string, graphqlUrl: string): Promise<ProcessResult> =>
+const runCli = (
+  args: readonly string[],
+  graphqlUrl: string,
+): Promise<ProcessResult> =>
   new Promise((resolve, reject) => {
     const child = spawn(
       "bun",
-      [
-        "--conditions",
-        "@ready-for-agent/source",
-        "src/main.ts",
-        "add",
-        repoDir,
-      ],
+      ["--conditions", "@ready-for-agent/source", "src/main.ts", ...args],
       {
         cwd: packageRoot,
         env: {
@@ -109,7 +110,11 @@ const runAdd = (repoDir: string, graphqlUrl: string): Promise<ProcessResult> =>
     })
     const timer = setTimeout(() => {
       child.kill("SIGKILL")
-      reject(new Error(`add timed out\nstdout:\n${stdout}\nstderr:\n${stderr}`))
+      reject(
+        new Error(
+          `${args.join(" ")} timed out\nstdout:\n${stdout}\nstderr:\n${stderr}`,
+        ),
+      )
     }, 20_000)
     child.on("error", (error) => {
       clearTimeout(timer)
@@ -120,6 +125,9 @@ const runAdd = (repoDir: string, graphqlUrl: string): Promise<ProcessResult> =>
       resolve({ status, stdout, stderr })
     })
   })
+
+const runAdd = (repoDir: string, graphqlUrl: string): Promise<ProcessResult> =>
+  runCli(["add", repoDir], graphqlUrl)
 
 describe("operator binary finite-command process contract", () => {
   let tempRoot = ""
@@ -265,6 +273,187 @@ describe("operator binary finite-command process contract", () => {
         error: {
           code: "REPOSITORY_ALREADY_EXISTS",
           message: "Repository owner/repo already exists on github.com",
+        },
+      })
+      expect(result.stderr).not.toMatch(/\s+at\s+\S+\s+\(/)
+      expect(result.stderr).not.toContain("FiniteCommandFailed:")
+    } finally {
+      await closeServer(server)
+    }
+  })
+
+  test("candidates success emits one JSON document on stdout and exits 0", async () => {
+    const seenBodies: string[] = []
+    const server = createServer((req, res) => {
+      if (req.method !== "POST") {
+        res.writeHead(405)
+        res.end()
+        return
+      }
+      const chunks: Buffer[] = []
+      req.on("data", (chunk: Buffer) => {
+        chunks.push(chunk)
+      })
+      req.on("end", () => {
+        const body = Buffer.concat(chunks).toString("utf8")
+        seenBodies.push(body)
+        res.writeHead(200, { "content-type": "application/json" })
+        if (body.includes("repositories")) {
+          res.end(
+            JSON.stringify({
+              data: {
+                repositories: [
+                  {
+                    id: "repo-process-1",
+                    forge: "github",
+                    forgeHost: "github.com",
+                    projectPath: "owner/repo",
+                  },
+                ],
+              },
+            }),
+          )
+          return
+        }
+        res.end(
+          JSON.stringify({
+            data: {
+              intakeCandidates: {
+                repository: {
+                  id: "repo-process-1",
+                  forge: "github",
+                  forgeHost: "github.com",
+                  projectPath: "owner/repo",
+                  issuesReconciledAt: "2026-08-12T10:00:00.000Z",
+                },
+                candidates: [
+                  {
+                    issueNumber: 7,
+                    title: "Ready",
+                    url: "https://github.com/owner/repo/issues/7",
+                    action: "IMPLEMENT_NOW",
+                  },
+                  {
+                    issueNumber: 9,
+                    title: "Blocked",
+                    url: "https://github.com/owner/repo/issues/9",
+                    action: "QUEUE",
+                  },
+                ],
+              },
+            },
+          }),
+        )
+      })
+    })
+
+    try {
+      const port = await listen(server)
+      const result = await runCli(
+        ["candidates", "GitHub.com/Owner/Repo"],
+        `http://127.0.0.1:${port}/graphql`,
+      )
+
+      expect(result.status).toBe(0)
+      expect(result.stderr.trim()).toBe("")
+      expect(seenBodies.some((body) => body.includes("repositories"))).toBe(
+        true,
+      )
+      expect(seenBodies.some((body) => body.includes("intakeCandidates"))).toBe(
+        true,
+      )
+      const successDoc = parseExactlyOneJsonDocument(result.stdout)
+      expect(successDoc).toEqual(
+        buildCandidatesSuccessDocument({
+          repository: {
+            id: "repo-process-1",
+            forge: "github",
+            forgeHost: "github.com",
+            projectPath: "owner/repo",
+          },
+          issuesReconciledAt: "2026-08-12T10:00:00.000Z",
+          candidates: [
+            {
+              issueNumber: 7,
+              title: "Ready",
+              url: "https://github.com/owner/repo/issues/7",
+              action: "IMPLEMENT_NOW",
+            },
+            {
+              issueNumber: 9,
+              title: "Blocked",
+              url: "https://github.com/owner/repo/issues/9",
+              action: "QUEUE",
+            },
+          ],
+        }),
+      )
+    } finally {
+      await closeServer(server)
+    }
+  })
+
+  test("candidates GraphQL preflight failure preserves extensions.code on stderr", async () => {
+    const server = createServer((req, res) => {
+      if (req.method !== "POST") {
+        res.writeHead(405)
+        res.end()
+        return
+      }
+      const chunks: Buffer[] = []
+      req.on("data", (chunk: Buffer) => {
+        chunks.push(chunk)
+      })
+      req.on("end", () => {
+        const body = Buffer.concat(chunks).toString("utf8")
+        res.writeHead(200, { "content-type": "application/json" })
+        if (body.includes("repositories")) {
+          res.end(
+            JSON.stringify({
+              data: {
+                repositories: [
+                  {
+                    id: "repo-process-1",
+                    forge: "github",
+                    forgeHost: "github.com",
+                    projectPath: "owner/repo",
+                  },
+                ],
+              },
+            }),
+          )
+          return
+        }
+        res.end(
+          JSON.stringify({
+            data: null,
+            errors: [
+              {
+                message: "Agent Backend is unavailable",
+                extensions: { code: "AGENT_BACKEND_UNAVAILABLE" },
+              },
+            ],
+          }),
+        )
+      })
+    })
+
+    try {
+      const port = await listen(server)
+      const result = await runCli(
+        ["candidates", "github.com/owner/repo"],
+        `http://127.0.0.1:${port}/graphql`,
+      )
+
+      expect(result.status).toBe(1)
+      expect(result.stdout.trim()).toBe("")
+      const errorDoc = parseExactlyOneJsonDocument(result.stderr)
+      expect(errorDoc).toEqual({
+        schemaVersion: CLI_SCHEMA_VERSION,
+        command: "candidates",
+        error: {
+          code: "AGENT_BACKEND_UNAVAILABLE",
+          message: "Agent Backend is unavailable",
         },
       })
       expect(result.stderr).not.toMatch(/\s+at\s+\S+\s+\(/)

--- a/apps/ready-for-agent/src/cli.test.ts
+++ b/apps/ready-for-agent/src/cli.test.ts
@@ -10,6 +10,7 @@ import {
   CLI_SCHEMA_VERSION,
   FiniteCommandFailed,
   buildAddSuccessDocument,
+  buildCandidatesSuccessDocument,
   encodeCompactJson,
 } from "./cli-json.ts"
 import {
@@ -26,6 +27,12 @@ import {
 
 /** Package root (`apps/ready-for-agent`), independent of Bun's `import.meta.dir`. */
 const packageRoot = fileURLToPath(new URL("..", import.meta.url))
+
+const unusedGraphql = {
+  addRepository: () => Effect.die("addRepository should not run"),
+  listRepositories: Effect.die("listRepositories should not run"),
+  intakeCandidates: () => Effect.die("intakeCandidates should not run"),
+} as const
 
 const runOperator = (
   args: ReadonlyArray<string>,
@@ -72,6 +79,7 @@ describe("operator binary CLI seam", () => {
         Layer.provideMerge(mockLocalGit),
         Layer.provideMerge(
           Layer.succeed(GraphqlApi, {
+            ...unusedGraphql,
             addRepository: () => Effect.die("graphql should not run for start"),
           }),
         ),
@@ -94,6 +102,7 @@ describe("operator binary CLI seam", () => {
           Layer.provideMerge(mockLocalGit),
           Layer.provideMerge(
             Layer.succeed(GraphqlApi, {
+              ...unusedGraphql,
               addRepository: () =>
                 Effect.fail(
                   new GraphqlRequestFailed({
@@ -126,6 +135,7 @@ describe("operator binary CLI seam", () => {
         Layer.provideMerge(mockLocalGit),
         Layer.provideMerge(
           Layer.succeed(GraphqlApi, {
+            ...unusedGraphql,
             addRepository: () =>
               Effect.fail(
                 new GraphqlRequestFailed({
@@ -178,6 +188,7 @@ describe("operator binary CLI seam", () => {
         Layer.provideMerge(gitlabLocalGit),
         Layer.provideMerge(
           Layer.succeed(GraphqlApi, {
+            ...unusedGraphql,
             addRepository: (repository) =>
               Effect.sync(() => {
                 added = repository
@@ -226,6 +237,7 @@ describe("operator binary CLI seam", () => {
           Layer.provideMerge(mockLocalGit),
           Layer.provideMerge(
             Layer.succeed(GraphqlApi, {
+              ...unusedGraphql,
               addRepository: (repository) =>
                 Effect.succeed({
                   id: "repo-1",
@@ -259,7 +271,232 @@ describe("operator binary CLI seam", () => {
     }),
   )
 
-  it("binary help lists start, add, --no-open, and --host", () => {
+  it.live("candidates emits versioned JSON with ordered actions", () =>
+    Effect.gen(function* () {
+      const logs: string[] = []
+      const originalLog = console.log
+      console.log = (...args: unknown[]) => {
+        logs.push(args.map(String).join(" "))
+      }
+
+      try {
+        let requestedId: string | undefined
+        const layer = mockStart.pipe(
+          Layer.provideMerge(mockLocalGit),
+          Layer.provideMerge(
+            Layer.succeed(GraphqlApi, {
+              ...unusedGraphql,
+              listRepositories: Effect.succeed([
+                {
+                  id: "repo-1",
+                  forge: "github",
+                  forgeHost: "github.com",
+                  projectPath: "Owner/Repo",
+                },
+              ]),
+              intakeCandidates: (repositoryId) =>
+                Effect.sync(() => {
+                  requestedId = repositoryId
+                  return {
+                    repository: {
+                      id: "repo-1",
+                      forge: "github",
+                      forgeHost: "github.com",
+                      projectPath: "Owner/Repo",
+                      issuesReconciledAt: "2026-08-12T10:00:00.000Z",
+                    },
+                    candidates: [
+                      {
+                        issueNumber: 7,
+                        title: "Ready work",
+                        url: "https://github.com/Owner/Repo/issues/7",
+                        action: "IMPLEMENT_NOW" as const,
+                      },
+                      {
+                        issueNumber: 9,
+                        title: "Blocked work",
+                        url: "https://github.com/Owner/Repo/issues/9",
+                        action: "QUEUE" as const,
+                      },
+                    ],
+                  }
+                }),
+            }),
+          ),
+        )
+
+        yield* runOperator(["candidates", "GitHub.com/owner/repo"], layer)
+
+        expect(requestedId).toBe("repo-1")
+        expect(logs).toHaveLength(1)
+        expect(logs[0]).toBe(
+          encodeCompactJson(
+            buildCandidatesSuccessDocument({
+              repository: {
+                id: "repo-1",
+                forge: "github",
+                forgeHost: "github.com",
+                projectPath: "Owner/Repo",
+              },
+              issuesReconciledAt: "2026-08-12T10:00:00.000Z",
+              candidates: [
+                {
+                  issueNumber: 7,
+                  title: "Ready work",
+                  url: "https://github.com/Owner/Repo/issues/7",
+                  action: "IMPLEMENT_NOW",
+                },
+                {
+                  issueNumber: 9,
+                  title: "Blocked work",
+                  url: "https://github.com/Owner/Repo/issues/9",
+                  action: "QUEUE",
+                },
+              ],
+            }),
+          ),
+        )
+      } finally {
+        console.log = originalLog
+      }
+    }),
+  )
+
+  it.live("candidates empty list succeeds with null issuesReconciledAt", () =>
+    Effect.gen(function* () {
+      const logs: string[] = []
+      const originalLog = console.log
+      console.log = (...args: unknown[]) => {
+        logs.push(args.map(String).join(" "))
+      }
+
+      try {
+        const layer = mockStart.pipe(
+          Layer.provideMerge(mockLocalGit),
+          Layer.provideMerge(
+            Layer.succeed(GraphqlApi, {
+              ...unusedGraphql,
+              listRepositories: Effect.succeed([
+                {
+                  id: "repo-1",
+                  forge: "github",
+                  forgeHost: "github.com",
+                  projectPath: "owner/repo",
+                },
+              ]),
+              intakeCandidates: () =>
+                Effect.succeed({
+                  repository: {
+                    id: "repo-1",
+                    forge: "github",
+                    forgeHost: "github.com",
+                    projectPath: "owner/repo",
+                    issuesReconciledAt: null,
+                  },
+                  candidates: [],
+                }),
+            }),
+          ),
+        )
+
+        yield* runOperator(["candidates", "github.com/owner/repo"], layer)
+
+        expect(logs).toHaveLength(1)
+        expect(JSON.parse(logs[0] ?? "")).toEqual({
+          schemaVersion: CLI_SCHEMA_VERSION,
+          command: "candidates",
+          repository: {
+            id: "repo-1",
+            forge: "github",
+            forgeHost: "github.com",
+            projectPath: "owner/repo",
+          },
+          issuesReconciledAt: null,
+          candidates: [],
+        })
+      } finally {
+        console.log = originalLog
+      }
+    }),
+  )
+
+  it.live("candidates fails when no configured Repository matches", () =>
+    Effect.gen(function* () {
+      const layer = mockStart.pipe(
+        Layer.provideMerge(mockLocalGit),
+        Layer.provideMerge(
+          Layer.succeed(GraphqlApi, {
+            ...unusedGraphql,
+            listRepositories: Effect.succeed([]),
+          }),
+        ),
+      )
+
+      const result = yield* runOperator(
+        ["candidates", "github.com/missing/repo"],
+        layer,
+      ).pipe(Effect.flip)
+
+      expect(result).toBeInstanceOf(FiniteCommandFailed)
+      if (result instanceof FiniteCommandFailed) {
+        expect(result.document).toEqual({
+          schemaVersion: CLI_SCHEMA_VERSION,
+          command: "candidates",
+          error: {
+            code: "REPOSITORY_NOT_FOUND",
+            message: "No configured Repository matches github.com/missing/repo",
+          },
+        })
+      }
+    }),
+  )
+
+  it.live("candidates preserves GraphQL preflight error codes", () =>
+    Effect.gen(function* () {
+      const layer = mockStart.pipe(
+        Layer.provideMerge(mockLocalGit),
+        Layer.provideMerge(
+          Layer.succeed(GraphqlApi, {
+            ...unusedGraphql,
+            listRepositories: Effect.succeed([
+              {
+                id: "repo-1",
+                forge: "github",
+                forgeHost: "github.com",
+                projectPath: "owner/repo",
+              },
+            ]),
+            intakeCandidates: () =>
+              Effect.fail(
+                new GraphqlRequestFailed({
+                  code: "AGENT_BACKEND_UNAVAILABLE",
+                  message: "Agent Backend is unavailable",
+                }),
+              ),
+          }),
+        ),
+      )
+
+      const result = yield* runOperator(
+        ["candidates", "github.com/owner/repo"],
+        layer,
+      ).pipe(Effect.flip)
+
+      expect(result).toBeInstanceOf(FiniteCommandFailed)
+      if (result instanceof FiniteCommandFailed) {
+        expect(result.document).toEqual({
+          schemaVersion: CLI_SCHEMA_VERSION,
+          command: "candidates",
+          error: {
+            code: "AGENT_BACKEND_UNAVAILABLE",
+            message: "Agent Backend is unavailable",
+          },
+        })
+      }
+    }),
+  )
+
+  it("binary help lists start, add, candidates, --no-open, and --host", () => {
     const result = spawnSync(
       "bun",
       ["--conditions", "@ready-for-agent/source", "src/main.ts", "--help"],
@@ -273,6 +510,7 @@ describe("operator binary CLI seam", () => {
     expect(result.status).toBe(0)
     expect(output).toContain("start")
     expect(output).toContain("add")
+    expect(output).toContain("candidates")
     expect(output).not.toContain("remove-github-token")
     expect(output).toContain("no-open")
     expect(output).toContain("host")
@@ -286,6 +524,7 @@ describe("operator binary CLI seam", () => {
           Layer.provideMerge(mockLocalGit),
           Layer.provideMerge(
             Layer.succeed(GraphqlApi, {
+              ...unusedGraphql,
               addRepository: () =>
                 Effect.die("graphql should not run for start"),
             }),
@@ -306,6 +545,7 @@ describe("operator binary CLI seam", () => {
         Layer.provideMerge(mockLocalGit),
         Layer.provideMerge(
           Layer.succeed(GraphqlApi, {
+            ...unusedGraphql,
             addRepository: () => Effect.die("graphql should not run for start"),
           }),
         ),

--- a/apps/ready-for-agent/src/cli.ts
+++ b/apps/ready-for-agent/src/cli.ts
@@ -2,16 +2,25 @@ import { Console, Effect, Option } from "effect"
 import { Argument, Command, Flag } from "effect/unstable/cli"
 import {
   FiniteCommandFailed,
+  type FiniteCommandName,
   buildAddSuccessDocument,
+  buildCandidatesSuccessDocument,
   encodeCompactJson,
   localGitErrorCode,
 } from "./cli-json.ts"
+import { resolveRepositoryIdentity } from "./repository-identity.ts"
 import { GraphqlApi } from "./services/graphql-api.ts"
 import { LocalGit } from "./services/local-git.ts"
 import { StartHarness } from "./services/start-harness.ts"
 
 const pathArg = Argument.string("path").pipe(
   Argument.withDescription("Path to a local git repository"),
+)
+
+const repositoryIdentityArg = Argument.string("repository").pipe(
+  Argument.withDescription(
+    "Repository identity as <forge-host>/<project-path> (case-insensitive)",
+  ),
 )
 
 const noOpenFlag = Flag.boolean("no-open").pipe(
@@ -49,7 +58,10 @@ const startHarnessWorkflow = Effect.fn("Cli.startHarness")(function* (
   yield* startHarnessService.start({ noOpen, host })
 })
 
-const toAddCommandFailed = (error: unknown): FiniteCommandFailed => {
+const toFiniteCommandFailed = (
+  command: FiniteCommandName,
+  error: unknown,
+): FiniteCommandFailed => {
   if (error instanceof FiniteCommandFailed) {
     return error
   }
@@ -70,7 +82,7 @@ const toAddCommandFailed = (error: unknown): FiniteCommandFailed => {
       typeof tagged.message === "string"
     ) {
       return new FiniteCommandFailed({
-        command: "add",
+        command,
         code: tagged.code,
         message: tagged.message,
       })
@@ -82,13 +94,14 @@ const toAddCommandFailed = (error: unknown): FiniteCommandFailed => {
           ? tagged.message
           : String(error)
     return new FiniteCommandFailed({
-      command: "add",
-      code: localGitErrorCode(tagged._tag),
+      command,
+      code:
+        command === "add" ? localGitErrorCode(tagged._tag) : "INTERNAL_ERROR",
       message,
     })
   }
   return new FiniteCommandFailed({
-    command: "add",
+    command,
     code: "INTERNAL_ERROR",
     message: error instanceof Error ? error.message : String(error),
   })
@@ -105,7 +118,7 @@ const addRepositoryWorkflow = Effect.fn("Cli.addRepository")(function* (
   const graphqlApi = yield* GraphqlApi
   const inspected = yield* localGit
     .inspect(path)
-    .pipe(Effect.mapError(toAddCommandFailed))
+    .pipe(Effect.mapError((error) => toFiniteCommandFailed("add", error)))
   const repository = {
     ...inspected,
     ...(corrections.forgeHost === undefined
@@ -117,10 +130,64 @@ const addRepositoryWorkflow = Effect.fn("Cli.addRepository")(function* (
   }
   const added = yield* graphqlApi
     .addRepository(repository)
-    .pipe(Effect.mapError(toAddCommandFailed))
+    .pipe(Effect.mapError((error) => toFiniteCommandFailed("add", error)))
 
   // Exactly one compact JSON success document on stdout; no progress chatter.
   yield* Console.log(encodeCompactJson(buildAddSuccessDocument(added)))
+})
+
+const candidatesWorkflow = Effect.fn("Cli.candidates")(function* (
+  repositoryArgument: string,
+) {
+  const graphqlApi = yield* GraphqlApi
+  const repositories = yield* graphqlApi.listRepositories.pipe(
+    Effect.mapError((error) => toFiniteCommandFailed("candidates", error)),
+  )
+
+  const resolved = resolveRepositoryIdentity(repositoryArgument, repositories)
+  switch (resolved._tag) {
+    case "invalid":
+      return yield* new FiniteCommandFailed({
+        command: "candidates",
+        code: "REPOSITORY_NOT_FOUND",
+        message: `Invalid repository identity "${resolved.argument}". Use <forge-host>/<project-path>.`,
+      })
+    case "not_found":
+      return yield* new FiniteCommandFailed({
+        command: "candidates",
+        code: "REPOSITORY_NOT_FOUND",
+        message: `No configured Repository matches ${resolved.forgeHost}/${resolved.projectPath}`,
+      })
+    case "ambiguous":
+      return yield* new FiniteCommandFailed({
+        command: "candidates",
+        code: "REPOSITORY_AMBIGUOUS",
+        message: `Multiple configured Repositories match ${resolved.forgeHost}/${resolved.projectPath} (${resolved.matchCount})`,
+      })
+    case "matched":
+      break
+  }
+
+  const result = yield* graphqlApi
+    .intakeCandidates(resolved.repository.id)
+    .pipe(
+      Effect.mapError((error) => toFiniteCommandFailed("candidates", error)),
+    )
+
+  yield* Console.log(
+    encodeCompactJson(
+      buildCandidatesSuccessDocument({
+        repository: {
+          id: result.repository.id,
+          forge: result.repository.forge,
+          forgeHost: result.repository.forgeHost,
+          projectPath: result.repository.projectPath,
+        },
+        issuesReconciledAt: result.repository.issuesReconciledAt,
+        candidates: result.candidates,
+      }),
+    ),
+  )
 })
 
 const startCommand = Command.make(
@@ -152,6 +219,16 @@ const addCommand = Command.make(
   ),
 )
 
+const candidatesCommand = Command.make(
+  "candidates",
+  { repository: repositoryIdentityArg },
+  ({ repository }) => candidatesWorkflow(repository),
+).pipe(
+  Command.withDescription(
+    "List current Intake Candidates for one Repository as versioned JSON",
+  ),
+)
+
 export const cli = Command.make(
   "ready-for-agent",
   { noOpen: noOpenFlag, host: hostFlag },
@@ -159,7 +236,7 @@ export const cli = Command.make(
     startHarnessWorkflow(noOpen, Option.getOrUndefined(host)),
 ).pipe(
   Command.withDescription(
-    "Ready for Agent operator binary (start Harness, add repositories)",
+    "Ready for Agent operator binary (start Harness, add repositories, list candidates)",
   ),
-  Command.withSubcommands([startCommand, addCommand]),
+  Command.withSubcommands([startCommand, addCommand, candidatesCommand]),
 )

--- a/apps/ready-for-agent/src/repository-identity.test.ts
+++ b/apps/ready-for-agent/src/repository-identity.test.ts
@@ -1,0 +1,84 @@
+import {
+  parseRepositoryIdentityArgument,
+  resolveRepositoryIdentity,
+} from "./repository-identity.ts"
+import { describe, expect, test } from "bun:test"
+
+describe("repository identity resolution", () => {
+  test("parses forge-host/project-path including nested GitLab paths", () => {
+    expect(parseRepositoryIdentityArgument("github.com/owner/repo")).toEqual({
+      forgeHost: "github.com",
+      projectPath: "owner/repo",
+    })
+    expect(
+      parseRepositoryIdentityArgument(
+        "git.drupalcode.org/project/oauth_client",
+      ),
+    ).toEqual({
+      forgeHost: "git.drupalcode.org",
+      projectPath: "project/oauth_client",
+    })
+  })
+
+  test("rejects opaque IDs and malformed arguments", () => {
+    expect(parseRepositoryIdentityArgument("repo-01ABC")).toBeNull()
+    expect(parseRepositoryIdentityArgument("")).toBeNull()
+    expect(parseRepositoryIdentityArgument("/owner/repo")).toBeNull()
+    expect(parseRepositoryIdentityArgument("github.com/")).toBeNull()
+  })
+
+  test("matches case-insensitively and uniquely", () => {
+    const repositories = [
+      {
+        id: "repo-1",
+        forgeHost: "github.com",
+        projectPath: "Owner/Repo",
+      },
+      {
+        id: "repo-2",
+        forgeHost: "git.drupalcode.org",
+        projectPath: "project/oauth_client",
+      },
+    ]
+    expect(
+      resolveRepositoryIdentity("GitHub.com/owner/repo", repositories),
+    ).toEqual({
+      _tag: "matched",
+      repository: repositories[0]!,
+    })
+    expect(
+      resolveRepositoryIdentity("github.com/missing/repo", repositories),
+    ).toEqual({
+      _tag: "not_found",
+      forgeHost: "github.com",
+      projectPath: "missing/repo",
+    })
+    expect(resolveRepositoryIdentity("repo-1", repositories)).toEqual({
+      _tag: "invalid",
+      argument: "repo-1",
+    })
+  })
+
+  test("reports ambiguous matches when more than one repository matches", () => {
+    const repositories = [
+      {
+        id: "repo-1",
+        forgeHost: "github.com",
+        projectPath: "owner/repo",
+      },
+      {
+        id: "repo-2",
+        forgeHost: "GitHub.com",
+        projectPath: "Owner/Repo",
+      },
+    ]
+    expect(
+      resolveRepositoryIdentity("github.com/owner/repo", repositories),
+    ).toEqual({
+      _tag: "ambiguous",
+      forgeHost: "github.com",
+      projectPath: "owner/repo",
+      matchCount: 2,
+    })
+  })
+})

--- a/apps/ready-for-agent/src/repository-identity.ts
+++ b/apps/ready-for-agent/src/repository-identity.ts
@@ -1,0 +1,103 @@
+/**
+ * Parse and match explicit CLI Repository identity
+ * `<forge-host>/<project-path>` (case-insensitive, unique).
+ */
+
+export type ParsedRepositoryIdentity = {
+  readonly forgeHost: string
+  readonly projectPath: string
+}
+
+export type RepositoryIdentityMatch<
+  T extends {
+    readonly id: string
+    readonly forgeHost: string
+    readonly projectPath: string
+  },
+> =
+  | { readonly _tag: "matched"; readonly repository: T }
+  | {
+      readonly _tag: "not_found"
+      readonly forgeHost: string
+      readonly projectPath: string
+    }
+  | {
+      readonly _tag: "ambiguous"
+      readonly forgeHost: string
+      readonly projectPath: string
+      readonly matchCount: number
+    }
+  | { readonly _tag: "invalid"; readonly argument: string }
+
+/**
+ * Split at the first slash. Host and project path must both be non-empty.
+ * Does not accept an opaque Repository ID.
+ */
+export const parseRepositoryIdentityArgument = (
+  argument: string,
+): ParsedRepositoryIdentity | null => {
+  const trimmed = argument.trim()
+  const slash = trimmed.indexOf("/")
+  if (slash <= 0 || slash === trimmed.length - 1) {
+    return null
+  }
+  const forgeHost = trimmed.slice(0, slash).trim()
+  const projectPath = trimmed.slice(slash + 1).trim()
+  if (forgeHost.length === 0 || projectPath.length === 0) {
+    return null
+  }
+  return { forgeHost, projectPath }
+}
+
+const fold = (value: string): string => value.toLowerCase()
+
+/**
+ * Match one configured Repository by forge host + project path.
+ * Matching is case-insensitive; display casing is preserved on the match.
+ */
+export const resolveRepositoryIdentity = <
+  T extends {
+    readonly id: string
+    readonly forgeHost: string
+    readonly projectPath: string
+  },
+>(
+  argument: string,
+  repositories: readonly T[],
+): RepositoryIdentityMatch<T> => {
+  const parsed = parseRepositoryIdentityArgument(argument)
+  if (parsed === null) {
+    return { _tag: "invalid", argument }
+  }
+  const hostKey = fold(parsed.forgeHost)
+  const pathKey = fold(parsed.projectPath)
+  const matches = repositories.filter(
+    (repository) =>
+      fold(repository.forgeHost) === hostKey &&
+      fold(repository.projectPath) === pathKey,
+  )
+  if (matches.length === 0) {
+    return {
+      _tag: "not_found",
+      forgeHost: parsed.forgeHost,
+      projectPath: parsed.projectPath,
+    }
+  }
+  if (matches.length > 1) {
+    return {
+      _tag: "ambiguous",
+      forgeHost: parsed.forgeHost,
+      projectPath: parsed.projectPath,
+      matchCount: matches.length,
+    }
+  }
+  const repository = matches[0]
+  if (repository === undefined) {
+    return {
+      _tag: "not_found",
+      forgeHost: parsed.forgeHost,
+      projectPath: parsed.projectPath,
+    }
+  }
+  return { _tag: "matched", repository }
+}

--- a/apps/ready-for-agent/src/services/graphql-api.ts
+++ b/apps/ready-for-agent/src/services/graphql-api.ts
@@ -1,5 +1,6 @@
 import { Context, Effect, Layer, Runtime, Schema } from "effect"
 import { createClient } from "@ready-for-agent/graphql-client"
+import type { IntakeCandidateAction } from "../cli-json.ts"
 import type { LocalRepository, RepositorySummary } from "../domain.ts"
 import { describeGraphqlFailure } from "../graphql-error.ts"
 import { ApplicationConfig } from "./application-config.ts"
@@ -20,12 +21,42 @@ export class GraphqlRequestFailed extends Schema.TaggedErrorClass<GraphqlRequest
   override readonly [Runtime.errorReported] = false
 }
 
+export type ConfiguredRepository = {
+  readonly id: string
+  readonly forge: string
+  readonly forgeHost: string
+  readonly projectPath: string
+}
+
+export type IntakeCandidatesResult = {
+  readonly repository: {
+    readonly id: string
+    readonly forge: string
+    readonly forgeHost: string
+    readonly projectPath: string
+    readonly issuesReconciledAt: string | null
+  }
+  readonly candidates: readonly {
+    readonly issueNumber: number
+    readonly title: string
+    readonly url: string
+    readonly action: IntakeCandidateAction
+  }[]
+}
+
 export class GraphqlApi extends Context.Service<
   GraphqlApi,
   {
     readonly addRepository: (
       repository: LocalRepository,
     ) => Effect.Effect<RepositorySummary, GraphqlRequestFailed>
+    readonly listRepositories: Effect.Effect<
+      readonly ConfiguredRepository[],
+      GraphqlRequestFailed
+    >
+    readonly intakeCandidates: (
+      repositoryId: string,
+    ) => Effect.Effect<IntakeCandidatesResult, GraphqlRequestFailed>
   }
 >()("ready-for-agent/GraphqlApi") {
   static readonly layer = Layer.effect(
@@ -76,7 +107,93 @@ export class GraphqlApi extends Context.Service<
         })
       })
 
-      return { addRepository }
+      const listRepositories = Effect.tryPromise({
+        try: async () => {
+          const result = await client.query({
+            repositories: {
+              id: true,
+              forge: true,
+              forgeHost: true,
+              projectPath: true,
+            },
+          })
+          return result.repositories ?? []
+        },
+        catch: (cause) => {
+          const failure = describeGraphqlFailure(cause, {
+            graphqlUrl: config.graphqlUrl,
+          })
+          return new GraphqlRequestFailed({
+            code: failure.code,
+            message: failure.message,
+          })
+        },
+      }).pipe(Effect.withSpan("GraphqlApi.listRepositories"))
+
+      const intakeCandidates = Effect.fn("GraphqlApi.intakeCandidates")(
+        function* (repositoryId: string) {
+          return yield* Effect.tryPromise({
+            try: async () => {
+              const result = await client.query({
+                intakeCandidates: {
+                  __args: { repositoryId },
+                  repository: {
+                    id: true,
+                    forge: true,
+                    forgeHost: true,
+                    projectPath: true,
+                    issuesReconciledAt: true,
+                  },
+                  candidates: {
+                    issueNumber: true,
+                    title: true,
+                    url: true,
+                    action: true,
+                  },
+                },
+              })
+              const payload = result.intakeCandidates
+              if (!payload) {
+                throw new Error("intakeCandidates returned null")
+              }
+              return {
+                repository: {
+                  id: payload.repository.id,
+                  forge: payload.repository.forge,
+                  forgeHost: payload.repository.forgeHost,
+                  projectPath: payload.repository.projectPath,
+                  issuesReconciledAt:
+                    payload.repository.issuesReconciledAt ?? null,
+                },
+                candidates: payload.candidates.map(
+                  (candidate: {
+                    readonly issueNumber: number
+                    readonly title: string
+                    readonly url: string
+                    readonly action: IntakeCandidateAction
+                  }) => ({
+                    issueNumber: candidate.issueNumber,
+                    title: candidate.title,
+                    url: candidate.url,
+                    action: candidate.action,
+                  }),
+                ),
+              }
+            },
+            catch: (cause) => {
+              const failure = describeGraphqlFailure(cause, {
+                graphqlUrl: config.graphqlUrl,
+              })
+              return new GraphqlRequestFailed({
+                code: failure.code,
+                message: failure.message,
+              })
+            },
+          })
+        },
+      )
+
+      return { addRepository, listRepositories, intakeCandidates }
     }),
   )
 }

--- a/packages/graphql-api/src/lib/graphql-api.ts
+++ b/packages/graphql-api/src/lib/graphql-api.ts
@@ -35,6 +35,7 @@ import {
 } from "@ready-for-agent/gitlab-service"
 import { typeDefs } from "@ready-for-agent/graphql-schema"
 import { KeymaxxerService } from "@ready-for-agent/keymaxxer-service"
+import { classifyIntakeCandidates } from "@ready-for-agent/lifecycle-model"
 import { DirectoryPicker, LocalGit } from "@ready-for-agent/local-git"
 import type { QueueService } from "@ready-for-agent/queue-service"
 import {
@@ -46,6 +47,7 @@ import {
   filterWorkItemsByListKind,
   isJobsCompletedWorkItemState,
   isJobsWorkingWorkItem,
+  isRetryableFailedWorkItem,
 } from "@ready-for-agent/work-item-lifecycle"
 import {
   commandExistsOnPath,
@@ -65,6 +67,7 @@ import {
   repositoryCredential,
   withKeymaxxerMetadataTimeout,
 } from "./repository-credentials.js"
+import { preflightRepositoryIntake } from "./repository-intake-preflight.js"
 import { toGraphQLError } from "./to-graphql-error.js"
 import { validateAgentModelsAgainstCatalog } from "./validate-agent-models.js"
 import {
@@ -705,6 +708,53 @@ export const createGraphqlApi = <R>(
                 const issues = yield* db.listIssues(args.repositoryId)
                 return workIssueProjection(issues)
               }).pipe(Effect.withSpan("graphql-api.issues")),
+              context,
+            ),
+          intakeCandidates: async (
+            _parent: unknown,
+            args: IssuesArgs,
+            context: GraphqlRequestContext,
+          ) =>
+            runGraphql(
+              Effect.gen(function* () {
+                const db = yield* DbService
+                const lifecycle = yield* WorkItemLifecycle
+                const repositories = yield* db.listRepositories
+                const repository = repositories.find(
+                  ({ id }) => id === args.repositoryId,
+                )
+                if (repository === undefined) {
+                  return yield* new RepositoryNotFoundError({
+                    repositoryId: args.repositoryId,
+                  })
+                }
+
+                // Current Issue projection only — never request or wait for Refresh.
+                const [issues, workItems] = yield* Effect.all([
+                  db.listIssues(repository.id),
+                  lifecycle.listWorkItemsForRepository(repository.id),
+                ])
+                const candidates = classifyIntakeCandidates(
+                  issues,
+                  workItems.map((workItem) => ({
+                    issueNumber: workItem.issueNumber,
+                    id: workItem.id,
+                    state: workItem.state,
+                    canRetry: isRetryableFailedWorkItem(workItem),
+                  })),
+                )
+
+                // Empty classification is a successful no-op and skips preflight.
+                if (candidates.length > 0) {
+                  // Preflight re-reads Repository under Config coordination.
+                  yield* preflightRepositoryIntake(repository.id)
+                }
+
+                return {
+                  repository,
+                  candidates,
+                }
+              }).pipe(Effect.withSpan("graphql-api.intakeCandidates")),
               context,
             ),
           workItems: async (

--- a/packages/graphql-api/src/lib/repository-intake-preflight.ts
+++ b/packages/graphql-api/src/lib/repository-intake-preflight.ts
@@ -1,0 +1,97 @@
+import { Effect } from "effect"
+import {
+  ActiveAgentBackend,
+  isSelectableAgentBackendId,
+} from "@ready-for-agent/agent-backend"
+import {
+  type DatabaseError,
+  DbService,
+  RepositoryNotFoundError,
+} from "@ready-for-agent/db-service"
+import {
+  AgentBackendUnavailableError,
+  BuildModelNotConfiguredError,
+  agentModelCatalogViolation,
+  resolveAgentModelsForBackend,
+} from "@ready-for-agent/work-item-lifecycle"
+
+/**
+ * Shared Repository-scoped preflight for Intake Candidate listing and
+ * Repository Intake. Validates the effective Agent Backend is usable for Agent
+ * Turns and that resolved build/review Agent Models pass catalog membership
+ * when the backend reports a Ready catalog.
+ *
+ * Re-reads Repository and Harness Config inside Config coordination so the
+ * effective backend and model resolution stay consistent (same admission seam
+ * as Work Item creation).
+ */
+export const preflightRepositoryIntake = (
+  repositoryId: string,
+): Effect.Effect<
+  void,
+  | AgentBackendUnavailableError
+  | BuildModelNotConfiguredError
+  | DatabaseError
+  | RepositoryNotFoundError,
+  DbService | ActiveAgentBackend
+> =>
+  Effect.gen(function* () {
+    const db = yield* DbService
+    const activeAgentBackend = yield* ActiveAgentBackend
+
+    yield* activeAgentBackend.withConfigCoordination(
+      Effect.gen(function* () {
+        // Re-read under coordination so selectedAgentBackend and flat model
+        // columns cannot diverge from a pre-coordination snapshot while
+        // resolveAgentModelsForBackend re-lists repositories.
+        const harnessConfig = yield* db.getConfig
+        const repositories = yield* db.listRepositories
+        const repository = repositories.find(({ id }) => id === repositoryId)
+        if (repository === undefined) {
+          return yield* new RepositoryNotFoundError({ repositoryId })
+        }
+
+        const rawCaptureBackendId =
+          repository.selectedAgentBackend ?? harnessConfig.selectedAgentBackend
+        if (!isSelectableAgentBackendId(rawCaptureBackendId)) {
+          return yield* new AgentBackendUnavailableError({
+            message: `Unknown or unsupported Agent Backend: ${rawCaptureBackendId}`,
+            reason: `Unknown or unsupported Agent Backend: ${rawCaptureBackendId}`,
+          })
+        }
+        const captureBackendId = rawCaptureBackendId
+        yield* activeAgentBackend
+          .requireAgentTurnsAllowed(captureBackendId)
+          .pipe(
+            Effect.mapError(
+              (error) =>
+                new AgentBackendUnavailableError({
+                  message: error.message,
+                  reason: error.reason,
+                }),
+            ),
+          )
+
+        const selection = yield* resolveAgentModelsForBackend(
+          repositoryId,
+          captureBackendId,
+        )
+
+        const captureStatus =
+          yield* activeAgentBackend.getBackendStatus(captureBackendId)
+        if (captureStatus !== null && captureStatus.kind === "ready") {
+          const violation = agentModelCatalogViolation({
+            backendLabel: captureStatus.backend.label,
+            catalogModelIds: captureStatus.models.map((model) => model.id),
+            selection,
+            includeReviewModel: true,
+          })
+          if (violation !== null) {
+            return yield* new BuildModelNotConfiguredError({
+              message: violation,
+            })
+          }
+        }
+      }),
+    )
+  })

--- a/packages/graphql-api/test/graphql-api.test.ts
+++ b/packages/graphql-api/test/graphql-api.test.ts
@@ -6101,6 +6101,313 @@ describe("GraphQL API", () => {
     })
   })
 
+  test("lists Intake Candidates ordered with IMPLEMENT_NOW then QUEUE", async () => {
+    const actionable = {
+      ...issue,
+      id: "issue-actionable",
+      issueNumber: 12,
+      title: "Actionable leaf",
+      url: "https://github.com/acme/widgets/issues/12",
+      blockedBy: [],
+    }
+    const blocked = {
+      ...issue,
+      id: "issue-blocked",
+      issueNumber: 5,
+      title: "Blocked leaf",
+      url: "https://github.com/acme/widgets/issues/5",
+      blockedBy: [
+        {
+          issueNumber: 1,
+          issueUrl: "https://github.com/acme/widgets/issues/1",
+        },
+      ],
+    }
+    const parent = {
+      ...issue,
+      id: "issue-parent",
+      issueNumber: 3,
+      title: "Parent",
+      url: "https://github.com/acme/widgets/issues/3",
+      hasChildren: true,
+      blockedBy: [],
+    }
+    const unfinishedIssue = {
+      ...issue,
+      id: "issue-unfinished",
+      issueNumber: 20,
+      title: "Has unfinished Work Item",
+      url: "https://github.com/acme/widgets/issues/20",
+      blockedBy: [],
+    }
+    const reconciledAt = new Date("2026-08-12T10:00:00.000Z")
+    let requireAgentTurnsCalls = 0
+    await runtime.dispose()
+    runtime = makeRuntime(
+      {
+        listRepositories: Effect.succeed([
+          {
+            ...repository,
+            issuesReconciledAt: reconciledAt,
+          },
+        ]),
+        listIssues: () =>
+          Effect.succeed([actionable, blocked, parent, unfinishedIssue]),
+      },
+      {},
+      {},
+      {
+        listWorkItemsForRepository: () =>
+          Effect.succeed([
+            {
+              ...workItem,
+              issueNumber: unfinishedIssue.issueNumber,
+            },
+          ]),
+      },
+      {
+        requireAgentTurnsAllowed: () =>
+          Effect.sync(() => {
+            requireAgentTurnsCalls += 1
+          }),
+      },
+    )
+
+    const response = await createGraphqlApi(runtime).fetch(
+      graphqlRequest({
+        query: `query IntakeCandidates($repositoryId: ID!) {
+          intakeCandidates(repositoryId: $repositoryId) {
+            repository {
+              id
+              projectPath
+              issuesReconciledAt
+            }
+            candidates {
+              issueNumber
+              title
+              url
+              action
+            }
+          }
+        }`,
+        variables: { repositoryId: repository.id },
+      }),
+    )
+
+    expect(await response.json()).toEqual({
+      data: {
+        intakeCandidates: {
+          repository: {
+            id: repository.id,
+            projectPath: repository.projectPath,
+            issuesReconciledAt: "2026-08-12T10:00:00.000Z",
+          },
+          candidates: [
+            {
+              issueNumber: 12,
+              title: "Actionable leaf",
+              url: "https://github.com/acme/widgets/issues/12",
+              action: "IMPLEMENT_NOW",
+            },
+            {
+              issueNumber: 5,
+              title: "Blocked leaf",
+              url: "https://github.com/acme/widgets/issues/5",
+              action: "QUEUE",
+            },
+          ],
+        },
+      },
+    })
+    expect(requireAgentTurnsCalls).toBe(1)
+  })
+
+  test("empty Intake Candidates skip Agent Backend preflight", async () => {
+    let requireAgentTurnsCalls = 0
+    await runtime.dispose()
+    runtime = makeRuntime(
+      {
+        listIssues: () => Effect.succeed([]),
+      },
+      {},
+      {},
+      {
+        listWorkItemsForRepository: () => Effect.succeed([]),
+      },
+      {
+        requireAgentTurnsAllowed: () =>
+          Effect.sync(() => {
+            requireAgentTurnsCalls += 1
+          }),
+      },
+    )
+
+    const response = await createGraphqlApi(runtime).fetch(
+      graphqlRequest({
+        query: `query IntakeCandidates($repositoryId: ID!) {
+          intakeCandidates(repositoryId: $repositoryId) {
+            repository { id issuesReconciledAt }
+            candidates { issueNumber action }
+          }
+        }`,
+        variables: { repositoryId: repository.id },
+      }),
+    )
+
+    expect(await response.json()).toEqual({
+      data: {
+        intakeCandidates: {
+          repository: {
+            id: repository.id,
+            issuesReconciledAt: null,
+          },
+          candidates: [],
+        },
+      },
+    })
+    expect(requireAgentTurnsCalls).toBe(0)
+  })
+
+  test("nonempty Intake Candidates surface shared preflight failures", async () => {
+    const { AgentBackendUnavailableError } = await import(
+      "@ready-for-agent/agent-backend"
+    )
+    const actionable = {
+      ...issue,
+      issueNumber: 99,
+      blockedBy: [],
+    }
+    await runtime.dispose()
+    runtime = makeRuntime(
+      {
+        listIssues: () => Effect.succeed([actionable]),
+      },
+      {},
+      {},
+      {
+        listWorkItemsForRepository: () => Effect.succeed([]),
+      },
+      {
+        requireAgentTurnsAllowed: () =>
+          Effect.fail(
+            new AgentBackendUnavailableError({
+              message: "Agent Backend is unavailable",
+              reason: "CLI missing",
+            }),
+          ),
+      },
+    )
+
+    const response = await createGraphqlApi(runtime).fetch(
+      graphqlRequest({
+        query: `query IntakeCandidates($repositoryId: ID!) {
+          intakeCandidates(repositoryId: $repositoryId) {
+            candidates { issueNumber }
+          }
+        }`,
+        variables: { repositoryId: repository.id },
+      }),
+    )
+
+    expect(await response.json()).toEqual({
+      data: null,
+      errors: [
+        expect.objectContaining({
+          message: "Agent Backend is unavailable",
+          extensions: expect.objectContaining({
+            code: "AGENT_BACKEND_UNAVAILABLE",
+            reason: "CLI missing",
+          }),
+        }),
+      ],
+    })
+  })
+
+  test("Intake Candidates reject unknown repository without Refresh", async () => {
+    let listIssuesCalls = 0
+    await runtime.dispose()
+    runtime = makeRuntime({
+      listIssues: () =>
+        Effect.sync(() => {
+          listIssuesCalls += 1
+          return []
+        }),
+    })
+
+    const response = await createGraphqlApi(runtime).fetch(
+      graphqlRequest({
+        query: `query IntakeCandidates($repositoryId: ID!) {
+          intakeCandidates(repositoryId: $repositoryId) {
+            candidates { issueNumber }
+          }
+        }`,
+        variables: { repositoryId: "repo-01DOESNOTEXIST00000000000" },
+      }),
+    )
+
+    expect(await response.json()).toEqual({
+      data: null,
+      errors: [
+        expect.objectContaining({
+          extensions: expect.objectContaining({
+            code: "REPOSITORY_NOT_FOUND",
+          }),
+        }),
+      ],
+    })
+    expect(listIssuesCalls).toBe(0)
+  })
+
+  test("nonempty Intake Candidates reject resolved models missing from catalog", async () => {
+    const actionable = {
+      ...issue,
+      issueNumber: 88,
+      blockedBy: [],
+    }
+    await runtime.dispose()
+    runtime = makeRuntime(
+      {
+        listRepositories: Effect.succeed([
+          {
+            ...repository,
+            defaultModel: "stale/model-not-in-catalog",
+          },
+        ]),
+        getBackendModelPrefs: () =>
+          Effect.succeed({
+            defaultModel: null,
+            defaultThinkingLevel: null,
+            reviewModel: null,
+            reviewThinkingLevel: null,
+          }),
+        listIssues: () => Effect.succeed([actionable]),
+      },
+      {},
+      {},
+      {
+        listWorkItemsForRepository: () => Effect.succeed([]),
+      },
+    )
+
+    const response = await createGraphqlApi(runtime).fetch(
+      graphqlRequest({
+        query: `query IntakeCandidates($repositoryId: ID!) {
+          intakeCandidates(repositoryId: $repositoryId) {
+            candidates { issueNumber }
+          }
+        }`,
+        variables: { repositoryId: repository.id },
+      }),
+    )
+
+    const body = (await response.json()) as {
+      errors: Array<{ message: string; extensions: { code: string } }>
+    }
+    expect(body.errors).toHaveLength(1)
+    expect(body.errors[0]?.extensions.code).toBe("BUILD_MODEL_NOT_CONFIGURED")
+    expect(body.errors[0]?.message).toContain("stale/model-not-in-catalog")
+  })
+
   test("projects Waiting for blockers status and blocker copy", async () => {
     const held = {
       ...workItem,

--- a/packages/graphql-schema/schema.graphql
+++ b/packages/graphql-schema/schema.graphql
@@ -95,6 +95,14 @@ type Query {
   unless AVAILABLE.
   """
   session(workItemId: ID!): Session
+  """
+  Current Intake Candidates for one Repository from the Issue projection.
+  Does not request or wait for Refresh. Empty classification succeeds without
+  Agent Backend or Agent Model preflight; nonempty classification runs one
+  shared Repository preflight (effective Agent Backend readiness and resolved
+  build/review Agent Models, including catalog membership when known).
+  """
+  intakeCandidates(repositoryId: ID!): RepositoryIntakeCandidates!
 }
 
 type GitHubThrottleStatus {
@@ -411,6 +419,34 @@ type IssueReference {
 type RefreshJob {
   id: ID!
   repositoryId: ID!
+}
+
+"""
+Intended operator request for an Intake Candidate.
+"""
+enum RepositoryIntakeAction {
+  IMPLEMENT_NOW
+  QUEUE
+}
+
+"""
+A Relevant open Leaf Issue with no unfinished Work Item that currently
+qualifies for Implement Now or Queue.
+"""
+type IntakeCandidate {
+  issueNumber: Int!
+  title: String!
+  url: String!
+  action: RepositoryIntakeAction!
+}
+
+"""
+Ordered Intake Candidates for one Repository. Candidate order is Implement Now
+by ascending Issue number, then Queue by ascending Issue number.
+"""
+type RepositoryIntakeCandidates {
+  repository: Repository!
+  candidates: [IntakeCandidate!]!
 }
 
 enum WorkItemState {

--- a/packages/graphql-schema/schema.template.graphql
+++ b/packages/graphql-schema/schema.template.graphql
@@ -92,6 +92,14 @@ type Query {
   unless AVAILABLE.
   """
   session(workItemId: ID!): Session
+  """
+  Current Intake Candidates for one Repository from the Issue projection.
+  Does not request or wait for Refresh. Empty classification succeeds without
+  Agent Backend or Agent Model preflight; nonempty classification runs one
+  shared Repository preflight (effective Agent Backend readiness and resolved
+  build/review Agent Models, including catalog membership when known).
+  """
+  intakeCandidates(repositoryId: ID!): RepositoryIntakeCandidates!
 }
 
 type GitHubThrottleStatus {
@@ -408,6 +416,34 @@ type IssueReference {
 type RefreshJob {
   id: ID!
   repositoryId: ID!
+}
+
+"""
+Intended operator request for an Intake Candidate.
+"""
+enum RepositoryIntakeAction {
+  IMPLEMENT_NOW
+  QUEUE
+}
+
+"""
+A Relevant open Leaf Issue with no unfinished Work Item that currently
+qualifies for Implement Now or Queue.
+"""
+type IntakeCandidate {
+  issueNumber: Int!
+  title: String!
+  url: String!
+  action: RepositoryIntakeAction!
+}
+
+"""
+Ordered Intake Candidates for one Repository. Candidate order is Implement Now
+by ascending Issue number, then Queue by ascending Issue number.
+"""
+type RepositoryIntakeCandidates {
+  repository: Repository!
+  candidates: [IntakeCandidate!]!
 }
 
 enum WorkItemState {

--- a/packages/lifecycle-model/src/index.ts
+++ b/packages/lifecycle-model/src/index.ts
@@ -1,2 +1,3 @@
 export * from "./generated/work-item-state.js"
+export * from "./intake-candidates.js"
 export * from "./predicates.js"

--- a/packages/lifecycle-model/src/intake-candidates.ts
+++ b/packages/lifecycle-model/src/intake-candidates.ts
@@ -1,0 +1,108 @@
+import {
+  type WorkItemPredicateShape,
+  evaluateActionableIssue,
+  evaluateImplementableIssue,
+  evaluateUnfinishedWorkItem,
+} from "./predicates.js"
+
+/** Intended operator request for one Intake Candidate. */
+export type IntakeCandidateAction = "IMPLEMENT_NOW" | "QUEUE"
+
+/**
+ * One Issue that Repository Intake would currently send Implement Now or
+ * Queue for. Parents, closed/irrelevant Issues, and Issues with unfinished
+ * Work Items are never returned.
+ */
+export type IntakeCandidate = {
+  readonly issueNumber: number
+  readonly title: string
+  readonly url: string
+  readonly action: IntakeCandidateAction
+}
+
+/** Issue fields required to classify Intake Candidates. */
+export type IntakeCandidateIssueInput = {
+  readonly issueNumber: number
+  readonly title: string
+  readonly url: string
+  readonly state: string
+  readonly hasChildren: boolean
+  readonly blockedBy: readonly unknown[]
+}
+
+/** Work Item fields required to exclude unfinished Issues. */
+export type IntakeCandidateWorkItemInput = WorkItemPredicateShape & {
+  readonly issueNumber: number
+}
+
+/**
+ * Pure classifier over a Repository's current Issue projection and Work Items.
+ *
+ * Returns only ordered Intake Candidates:
+ * 1. Actionable Issues as `IMPLEMENT_NOW` (ascending Issue number)
+ * 2. Blocked open leaves with no unfinished Work Item as `QUEUE` (ascending)
+ *
+ * Uses the same leaf / implementable / actionable / unfinished predicates as
+ * Implement Now and Queue so candidate listing cannot drift from admission.
+ */
+export const classifyIntakeCandidates = (
+  issues: readonly IntakeCandidateIssueInput[],
+  workItems: readonly IntakeCandidateWorkItemInput[],
+): readonly IntakeCandidate[] => {
+  const workItemsByIssue = new Map<number, WorkItemPredicateShape[]>()
+  for (const workItem of workItems) {
+    const existing = workItemsByIssue.get(workItem.issueNumber)
+    if (existing === undefined) {
+      workItemsByIssue.set(workItem.issueNumber, [workItem])
+    } else {
+      existing.push(workItem)
+    }
+  }
+
+  const implementNow: IntakeCandidate[] = []
+  const queue: IntakeCandidate[] = []
+
+  for (const issue of issues) {
+    const issueWorkItems = workItemsByIssue.get(issue.issueNumber) ?? []
+    const predicateIssue = {
+      isCurrentIssue: true as const,
+      state: issue.state,
+      hasChildren: issue.hasChildren,
+      blockedBy: issue.blockedBy,
+    }
+
+    const actionable = evaluateActionableIssue(predicateIssue, issueWorkItems)
+    if (actionable._tag === "match") {
+      implementNow.push({
+        issueNumber: issue.issueNumber,
+        title: issue.title,
+        url: issue.url,
+        action: "IMPLEMENT_NOW",
+      })
+      continue
+    }
+
+    // Queue: open leaf with listed blockers and no unfinished Work Item.
+    // evaluateActionableIssue already failed for missing/closed/parent/unfinished.
+    const implementable = evaluateImplementableIssue(predicateIssue)
+    if (implementable._tag !== "issue_blocked") {
+      continue
+    }
+    const hasUnfinished = issueWorkItems.some(
+      (workItem) => evaluateUnfinishedWorkItem(workItem)._tag === "match",
+    )
+    if (hasUnfinished) {
+      continue
+    }
+    queue.push({
+      issueNumber: issue.issueNumber,
+      title: issue.title,
+      url: issue.url,
+      action: "QUEUE",
+    })
+  }
+
+  implementNow.sort((a, b) => a.issueNumber - b.issueNumber)
+  queue.sort((a, b) => a.issueNumber - b.issueNumber)
+  return [...implementNow, ...queue]
+}

--- a/packages/lifecycle-model/test/intake-candidates.test.ts
+++ b/packages/lifecycle-model/test/intake-candidates.test.ts
@@ -1,0 +1,129 @@
+import {
+  type IntakeCandidateIssueInput,
+  type IntakeCandidateWorkItemInput,
+  classifyIntakeCandidates,
+} from "../src/index.js"
+import { describe, expect, it } from "bun:test"
+
+const issue = (
+  overrides: Partial<IntakeCandidateIssueInput> & {
+    readonly issueNumber: number
+  },
+): IntakeCandidateIssueInput => ({
+  title: `Issue ${overrides.issueNumber}`,
+  url: `https://github.com/acme/widgets/issues/${overrides.issueNumber}`,
+  state: "OPEN",
+  hasChildren: false,
+  blockedBy: [],
+  ...overrides,
+})
+
+const workItem = (
+  overrides: Partial<IntakeCandidateWorkItemInput> & {
+    readonly issueNumber: number
+    readonly state: IntakeCandidateWorkItemInput["state"]
+  },
+): IntakeCandidateWorkItemInput => ({
+  id: `wi-${overrides.issueNumber}`,
+  canRetry: false,
+  ...overrides,
+})
+
+describe("classifyIntakeCandidates", () => {
+  it("classifies Actionable Issues as IMPLEMENT_NOW", () => {
+    const candidates = classifyIntakeCandidates(
+      [issue({ issueNumber: 10 })],
+      [],
+    )
+    expect(candidates).toEqual([
+      {
+        issueNumber: 10,
+        title: "Issue 10",
+        url: "https://github.com/acme/widgets/issues/10",
+        action: "IMPLEMENT_NOW",
+      },
+    ])
+  })
+
+  it("classifies blocked open leaves as QUEUE", () => {
+    const candidates = classifyIntakeCandidates(
+      [
+        issue({
+          issueNumber: 20,
+          blockedBy: [{ issueNumber: 1, issueUrl: "https://example/1" }],
+        }),
+      ],
+      [],
+    )
+    expect(candidates).toEqual([
+      {
+        issueNumber: 20,
+        title: "Issue 20",
+        url: "https://github.com/acme/widgets/issues/20",
+        action: "QUEUE",
+      },
+    ])
+  })
+
+  it("omits parents, closed Issues, and unfinished Work Items", () => {
+    const candidates = classifyIntakeCandidates(
+      [
+        issue({ issueNumber: 1, hasChildren: true }),
+        issue({ issueNumber: 2, state: "CLOSED" }),
+        issue({ issueNumber: 3 }),
+        issue({
+          issueNumber: 4,
+          blockedBy: [{ issueNumber: 9, issueUrl: "https://example/9" }],
+        }),
+      ],
+      [
+        workItem({ issueNumber: 3, state: "implement" }),
+        workItem({ issueNumber: 4, state: "create_worktree" }),
+      ],
+    )
+    expect(candidates).toEqual([])
+  })
+
+  it("orders IMPLEMENT_NOW then QUEUE, each by ascending Issue number", () => {
+    const candidates = classifyIntakeCandidates(
+      [
+        issue({
+          issueNumber: 30,
+          blockedBy: [{ issueNumber: 1, issueUrl: "https://example/1" }],
+        }),
+        issue({ issueNumber: 12 }),
+        issue({
+          issueNumber: 5,
+          blockedBy: [{ issueNumber: 1, issueUrl: "https://example/1" }],
+        }),
+        issue({ issueNumber: 7 }),
+      ],
+      [],
+    )
+    expect(candidates.map((c) => [c.issueNumber, c.action])).toEqual([
+      [7, "IMPLEMENT_NOW"],
+      [12, "IMPLEMENT_NOW"],
+      [5, "QUEUE"],
+      [30, "QUEUE"],
+    ])
+  })
+
+  it("treats finished Work Items as non-blocking for candidates", () => {
+    const candidates = classifyIntakeCandidates(
+      [issue({ issueNumber: 8 })],
+      [workItem({ issueNumber: 8, state: "complete" })],
+    )
+    expect(candidates).toEqual([
+      {
+        issueNumber: 8,
+        title: "Issue 8",
+        url: "https://github.com/acme/widgets/issues/8",
+        action: "IMPLEMENT_NOW",
+      },
+    ])
+  })
+
+  it("returns empty for an empty Issue projection", () => {
+    expect(classifyIntakeCandidates([], [])).toEqual([])
+  })
+})


### PR DESCRIPTION
## Why

Automated operators need a Harness-owned way to discover which Issues a
Repository can currently accept for Implement Now or Queue, without
reimplementing lifecycle eligibility, hierarchy, blockers, or unfinished
Work Item rules outside the Harness.

## What changed

- Classifier (lifecycle-model): pure classifyIntakeCandidates over the
  current Issue projection and Work Items. Actionable leaves become
  IMPLEMENT_NOW; blocked open leaves without unfinished Work Items become
  QUEUE. Parents, closed, and unfinished Issues are omitted. Order is
  Implement Now by ascending issue number, then Queue by ascending issue
  number.
- GraphQL: intakeCandidates(repositoryId) returns ordered candidates plus
  the Repository (including issuesReconciledAt). Uses the current
  projection only (no Refresh). Empty results skip Agent Backend / model
  preflight; nonempty results run one shared Repository preflight
  (effective backend readiness, resolved build/review models, catalog
  membership when known), re-reading Repository and Config under Config
  coordination so admission matches Work Item create.
- CLI: ready-for-agent candidates <forge-host>/<project-path> resolves
  identity case-insensitively and uniquely (no opaque Repository ID, no
  sole-repo inference), calls GraphQL, and emits one versioned JSON
  document (schemaVersion, command, canonical repository,
  issuesReconciledAt, candidates). Command-level failures preserve
  GraphQL extensions.code on stderr.

## Verification

- lifecycle-model classifier tests (matrix + ordering)
- graphql-api integration tests (classification, ordering, empty skip,
  preflight/catalog failures, unknown repository)
- ready-for-agent CLI seam, identity, JSON contract, and process tests
  (stdout/stderr, exit status)
- lint/typecheck on touched packages

## Notes

- Intake mutation and Kanban status CLI are out of scope (sibling issues
  under the parent automation work).
- Listing does not refresh Issues; callers may apply their own freshness
  policy from issuesReconciledAt (nullable).

Issue #976.

Closes #976