### PR TITLE
feat(cli): expose Kanban status via GraphQL and status command

### DIFF
--- a/apps/ready-for-agent/src/cli-json.test.ts
+++ b/apps/ready-for-agent/src/cli-json.test.ts
@@ -4,6 +4,7 @@ import {
   buildAddSuccessDocument,
   buildCandidatesSuccessDocument,
   buildCommandErrorDocument,
+  buildStatusSuccessDocument,
   encodeCompactJson,
   localGitErrorCode,
 } from "./cli-json.ts"
@@ -34,6 +35,53 @@ describe("finite CLI JSON contract", () => {
     expect(encodeCompactJson(doc)).toBe(
       '{"schemaVersion":1,"command":"add","repository":{"id":"repo-1","forge":"github","forgeHost":"github.com","projectPath":"owner/repo"},"localPath":"/tmp/repo","isBare":false}',
     )
+  })
+
+  test("status success document includes six lanes and null repository", () => {
+    const doc = buildStatusSuccessDocument({
+      repository: null,
+      lanes: [
+        {
+          id: "QUEUE",
+          label: "Queue",
+          count: 1,
+          workItems: [
+            {
+              repository: {
+                id: "repo-1",
+                forge: "github",
+                forgeHost: "github.com",
+                projectPath: "owner/repo",
+              },
+              id: "wi-1",
+              issueNumber: 102,
+              issueTitle: "Blocked follow-up",
+              state: "CREATE_WORKTREE",
+              status: "WAITING_FOR_BLOCKERS",
+              statusMessage: "Waiting for blocking Issues",
+              paused: false,
+              pullRequestNumber: null,
+              createdAt: "2026-08-12T10:00:00.000Z",
+              updatedAt: "2026-08-12T10:00:00.000Z",
+              stateReadyAt: "2026-08-12T10:00:00.000Z",
+              postponedUntil: null,
+            },
+          ],
+        },
+        { id: "BUILD", label: "Build", count: 0, workItems: [] },
+        { id: "REVIEW", label: "Review", count: 0, workItems: [] },
+        { id: "PR", label: "PR", count: 0, workItems: [] },
+        { id: "ATTENTION", label: "Attention", count: 0, workItems: [] },
+        { id: "MERGED", label: "Merged", count: 0, workItems: [] },
+      ],
+    })
+    expect(doc.schemaVersion).toBe(1)
+    expect(doc.command).toBe("status")
+    expect(doc.repository).toBeNull()
+    expect(doc.lanes).toHaveLength(6)
+    expect(doc.lanes[0]?.workItems[0]?.pullRequestNumber).toBeNull()
+    expect(encodeCompactJson(doc)).toContain('"command":"status"')
+    expect(encodeCompactJson(doc)).toContain('"pullRequestNumber":null')
   })
 
   test("candidates success document includes issuesReconciledAt and actions", () => {

--- a/apps/ready-for-agent/src/cli-json.ts
+++ b/apps/ready-for-agent/src/cli-json.ts
@@ -165,11 +165,7 @@ export const buildCommandErrorDocument = (options: {
   },
 })
 
-const FiniteCommandNameSchema = Schema.Literals([
-  "add",
-  "candidates",
-  "status",
-])
+const FiniteCommandNameSchema = Schema.Literals(["add", "candidates", "status"])
 
 /**
  * Expected finite-command failure. Marked as already reported so

--- a/apps/ready-for-agent/src/cli-json.ts
+++ b/apps/ready-for-agent/src/cli-json.ts
@@ -7,7 +7,7 @@ export const CLI_SCHEMA_VERSION = 1 as const
  * Finite operator commands that emit one versioned JSON document.
  * Long-running `start` is intentionally excluded.
  */
-export type FiniteCommandName = "add" | "candidates"
+export type FiniteCommandName = "add" | "candidates" | "status"
 
 /** Canonical Repository identity shared across finite CLI JSON documents. */
 export type CanonicalRepositoryIdentity = {
@@ -38,6 +38,44 @@ export type CandidatesSuccessDocument = {
     readonly url: string
     readonly action: IntakeCandidateAction
   }[]
+}
+
+export type StatusLaneId =
+  | "QUEUE"
+  | "BUILD"
+  | "REVIEW"
+  | "PR"
+  | "ATTENTION"
+  | "MERGED"
+
+export type StatusWorkItemRow = {
+  readonly repository: CanonicalRepositoryIdentity
+  readonly id: string
+  readonly issueNumber: number
+  readonly issueTitle: string | null
+  readonly state: string
+  readonly status: string
+  readonly statusMessage: string | null
+  readonly paused: boolean
+  readonly pullRequestNumber: number | null
+  readonly createdAt: string
+  readonly updatedAt: string
+  readonly stateReadyAt: string
+  readonly postponedUntil: string | null
+}
+
+export type StatusLane = {
+  readonly id: StatusLaneId
+  readonly label: string
+  readonly count: number
+  readonly workItems: readonly StatusWorkItemRow[]
+}
+
+export type StatusSuccessDocument = {
+  readonly schemaVersion: typeof CLI_SCHEMA_VERSION
+  readonly command: "status"
+  readonly repository: CanonicalRepositoryIdentity | null
+  readonly lanes: readonly StatusLane[]
 }
 
 type CommandErrorBody = {
@@ -92,6 +130,28 @@ export const buildCandidatesSuccessDocument = (input: {
   candidates: input.candidates,
 })
 
+export const toCanonicalRepositoryIdentity = (repository: {
+  readonly id: string
+  readonly forge: string
+  readonly forgeHost: string
+  readonly projectPath: string
+}): CanonicalRepositoryIdentity => ({
+  id: repository.id,
+  forge: repository.forge,
+  forgeHost: repository.forgeHost,
+  projectPath: repository.projectPath,
+})
+
+export const buildStatusSuccessDocument = (options: {
+  readonly repository: CanonicalRepositoryIdentity | null
+  readonly lanes: readonly StatusLane[]
+}): StatusSuccessDocument => ({
+  schemaVersion: CLI_SCHEMA_VERSION,
+  command: "status",
+  repository: options.repository,
+  lanes: options.lanes,
+})
+
 export const buildCommandErrorDocument = (options: {
   readonly command: FiniteCommandName
   readonly code: string
@@ -105,7 +165,11 @@ export const buildCommandErrorDocument = (options: {
   },
 })
 
-const FiniteCommandNameSchema = Schema.Literals(["add", "candidates"])
+const FiniteCommandNameSchema = Schema.Literals([
+  "add",
+  "candidates",
+  "status",
+])
 
 /**
  * Expected finite-command failure. Marked as already reported so

--- a/apps/ready-for-agent/src/cli-process.test.ts
+++ b/apps/ready-for-agent/src/cli-process.test.ts
@@ -16,6 +16,7 @@ import {
   CLI_SCHEMA_VERSION,
   buildAddSuccessDocument,
   buildCandidatesSuccessDocument,
+  buildStatusSuccessDocument,
 } from "./cli-json.ts"
 import {
   HARNESS_START_HINT,
@@ -461,5 +462,177 @@ describe("operator binary finite-command process contract", () => {
     } finally {
       await closeServer(server)
     }
+  })
+
+  test("status without repository emits six empty lanes on stdout", async () => {
+    const emptyStatusLanes = [
+      { id: "QUEUE" as const, label: "Queue", count: 0, workItems: [] },
+      { id: "BUILD" as const, label: "Build", count: 0, workItems: [] },
+      { id: "REVIEW" as const, label: "Review", count: 0, workItems: [] },
+      { id: "PR" as const, label: "PR", count: 0, workItems: [] },
+      { id: "ATTENTION" as const, label: "Attention", count: 0, workItems: [] },
+      { id: "MERGED" as const, label: "Merged", count: 0, workItems: [] },
+    ]
+    const server = createServer((req, res) => {
+      if (req.method !== "POST") {
+        res.writeHead(405)
+        res.end()
+        return
+      }
+      const chunks: Buffer[] = []
+      req.on("data", (chunk: Buffer) => {
+        chunks.push(chunk)
+      })
+      req.on("end", () => {
+        const body = Buffer.concat(chunks).toString("utf8")
+        res.writeHead(200, { "content-type": "application/json" })
+        if (body.includes("kanbanStatus")) {
+          res.end(
+            JSON.stringify({
+              data: {
+                kanbanStatus: {
+                  repository: null,
+                  lanes: emptyStatusLanes,
+                },
+              },
+            }),
+          )
+          return
+        }
+        res.end(
+          JSON.stringify({ data: null, errors: [{ message: "unexpected" }] }),
+        )
+      })
+    })
+
+    try {
+      const port = await listen(server)
+      const result = await runCli(
+        ["status"],
+        `http://127.0.0.1:${port}/graphql`,
+      )
+
+      expect(result.status).toBe(0)
+      expect(result.stderr.trim()).toBe("")
+      expect(parseExactlyOneJsonDocument(result.stdout)).toEqual(
+        buildStatusSuccessDocument({
+          repository: null,
+          lanes: emptyStatusLanes,
+        }),
+      )
+    } finally {
+      await closeServer(server)
+    }
+  })
+
+  test("status with repository selector resolves then queries kanbanStatus", async () => {
+    const emptyStatusLanes = [
+      { id: "QUEUE" as const, label: "Queue", count: 0, workItems: [] },
+      { id: "BUILD" as const, label: "Build", count: 0, workItems: [] },
+      { id: "REVIEW" as const, label: "Review", count: 0, workItems: [] },
+      { id: "PR" as const, label: "PR", count: 0, workItems: [] },
+      { id: "ATTENTION" as const, label: "Attention", count: 0, workItems: [] },
+      { id: "MERGED" as const, label: "Merged", count: 0, workItems: [] },
+    ]
+    const seenBodies: string[] = []
+    const server = createServer((req, res) => {
+      if (req.method !== "POST") {
+        res.writeHead(405)
+        res.end()
+        return
+      }
+      const chunks: Buffer[] = []
+      req.on("data", (chunk: Buffer) => {
+        chunks.push(chunk)
+      })
+      req.on("end", () => {
+        const body = Buffer.concat(chunks).toString("utf8")
+        seenBodies.push(body)
+        res.writeHead(200, { "content-type": "application/json" })
+        if (body.includes("repositories")) {
+          res.end(
+            JSON.stringify({
+              data: {
+                repositories: [
+                  {
+                    id: "repo-process-1",
+                    forge: "github",
+                    forgeHost: "github.com",
+                    projectPath: "owner/repo",
+                  },
+                ],
+              },
+            }),
+          )
+          return
+        }
+        if (body.includes("kanbanStatus")) {
+          res.end(
+            JSON.stringify({
+              data: {
+                kanbanStatus: {
+                  repository: {
+                    id: "repo-process-1",
+                    forge: "github",
+                    forgeHost: "github.com",
+                    projectPath: "owner/repo",
+                  },
+                  lanes: emptyStatusLanes,
+                },
+              },
+            }),
+          )
+          return
+        }
+        res.end(
+          JSON.stringify({ data: null, errors: [{ message: "unexpected" }] }),
+        )
+      })
+    })
+
+    try {
+      const port = await listen(server)
+      const result = await runCli(
+        ["status", "github.com/owner/repo"],
+        `http://127.0.0.1:${port}/graphql`,
+      )
+
+      expect(result.status).toBe(0)
+      expect(result.stderr.trim()).toBe("")
+      expect(seenBodies.some((body) => body.includes("repositories"))).toBe(
+        true,
+      )
+      expect(seenBodies.some((body) => body.includes("kanbanStatus"))).toBe(
+        true,
+      )
+      expect(parseExactlyOneJsonDocument(result.stdout)).toEqual(
+        buildStatusSuccessDocument({
+          repository: {
+            id: "repo-process-1",
+            forge: "github",
+            forgeHost: "github.com",
+            projectPath: "owner/repo",
+          },
+          lanes: emptyStatusLanes,
+        }),
+      )
+    } finally {
+      await closeServer(server)
+    }
+  })
+
+  test("status against unreachable GraphQL emits JSON error on stderr only", async () => {
+    const result = await runCli(["status"], "http://127.0.0.1:1/graphql")
+
+    expect(result.status).toBe(1)
+    expect(result.stdout.trim()).toBe("")
+    expect(parseExactlyOneJsonDocument(result.stderr)).toEqual({
+      schemaVersion: CLI_SCHEMA_VERSION,
+      command: "status",
+      error: {
+        code: HARNESS_UNREACHABLE_CODE,
+        message: harnessNotRunningMessage("http://127.0.0.1:1"),
+      },
+    })
   })
 })

--- a/apps/ready-for-agent/src/cli.test.ts
+++ b/apps/ready-for-agent/src/cli.test.ts
@@ -628,8 +628,7 @@ describe("operator binary CLI seam", () => {
           command: "status",
           error: {
             code: "REPOSITORY_NOT_FOUND",
-            message:
-              "No configured Repository matches github.com/missing/repo",
+            message: "No configured Repository matches github.com/missing/repo",
           },
         })
       }

--- a/apps/ready-for-agent/src/cli.test.ts
+++ b/apps/ready-for-agent/src/cli.test.ts
@@ -11,6 +11,7 @@ import {
   FiniteCommandFailed,
   buildAddSuccessDocument,
   buildCandidatesSuccessDocument,
+  buildStatusSuccessDocument,
   encodeCompactJson,
 } from "./cli-json.ts"
 import {
@@ -32,7 +33,17 @@ const unusedGraphql = {
   addRepository: () => Effect.die("addRepository should not run"),
   listRepositories: Effect.die("listRepositories should not run"),
   intakeCandidates: () => Effect.die("intakeCandidates should not run"),
+  kanbanStatus: () => Effect.die("kanbanStatus should not run"),
 } as const
+
+const emptyStatusLanes = [
+  { id: "QUEUE" as const, label: "Queue", count: 0, workItems: [] },
+  { id: "BUILD" as const, label: "Build", count: 0, workItems: [] },
+  { id: "REVIEW" as const, label: "Review", count: 0, workItems: [] },
+  { id: "PR" as const, label: "PR", count: 0, workItems: [] },
+  { id: "ATTENTION" as const, label: "Attention", count: 0, workItems: [] },
+  { id: "MERGED" as const, label: "Merged", count: 0, workItems: [] },
+]
 
 const runOperator = (
   args: ReadonlyArray<string>,
@@ -496,7 +507,136 @@ describe("operator binary CLI seam", () => {
     }),
   )
 
-  it("binary help lists start, add, candidates, --no-open, and --host", () => {
+  it.live("status without repository returns all-sources Kanban JSON", () =>
+    Effect.gen(function* () {
+      const logs: string[] = []
+      const originalLog = console.log
+      console.log = (...args: unknown[]) => {
+        logs.push(args.map(String).join(" "))
+      }
+      try {
+        const layer = mockStart.pipe(
+          Layer.provideMerge(mockLocalGit),
+          Layer.provideMerge(
+            Layer.succeed(GraphqlApi, {
+              ...unusedGraphql,
+              kanbanStatus: (repositoryId) => {
+                expect(repositoryId).toBeNull()
+                return Effect.succeed({
+                  repository: null,
+                  lanes: emptyStatusLanes,
+                })
+              },
+            }),
+          ),
+        )
+
+        yield* runOperator(["status"], layer)
+
+        expect(logs).toHaveLength(1)
+        expect(logs[0]).toBe(
+          encodeCompactJson(
+            buildStatusSuccessDocument({
+              repository: null,
+              lanes: emptyStatusLanes,
+            }),
+          ),
+        )
+      } finally {
+        console.log = originalLog
+      }
+    }),
+  )
+
+  it.live("status with repository selector scopes GraphQL by resolved id", () =>
+    Effect.gen(function* () {
+      const logs: string[] = []
+      const originalLog = console.log
+      console.log = (...args: unknown[]) => {
+        logs.push(args.map(String).join(" "))
+      }
+      try {
+        const layer = mockStart.pipe(
+          Layer.provideMerge(mockLocalGit),
+          Layer.provideMerge(
+            Layer.succeed(GraphqlApi, {
+              ...unusedGraphql,
+              listRepositories: Effect.succeed([
+                {
+                  id: "repo-1",
+                  forge: "github",
+                  forgeHost: "github.com",
+                  projectPath: "Owner/Repo",
+                },
+              ]),
+              kanbanStatus: (repositoryId) => {
+                expect(repositoryId).toBe("repo-1")
+                return Effect.succeed({
+                  repository: {
+                    id: "repo-1",
+                    forge: "github",
+                    forgeHost: "github.com",
+                    projectPath: "Owner/Repo",
+                  },
+                  lanes: emptyStatusLanes,
+                })
+              },
+            }),
+          ),
+        )
+
+        yield* runOperator(["status", "GitHub.COM/owner/repo"], layer)
+
+        expect(logs).toHaveLength(1)
+        expect(JSON.parse(logs[0]!)).toMatchObject({
+          schemaVersion: CLI_SCHEMA_VERSION,
+          command: "status",
+          repository: {
+            id: "repo-1",
+            forge: "github",
+            forgeHost: "github.com",
+            projectPath: "Owner/Repo",
+          },
+        })
+      } finally {
+        console.log = originalLog
+      }
+    }),
+  )
+
+  it.live("status fails with REPOSITORY_NOT_FOUND for unknown selector", () =>
+    Effect.gen(function* () {
+      const layer = mockStart.pipe(
+        Layer.provideMerge(mockLocalGit),
+        Layer.provideMerge(
+          Layer.succeed(GraphqlApi, {
+            ...unusedGraphql,
+            listRepositories: Effect.succeed([]),
+          }),
+        ),
+      )
+
+      const result = yield* runOperator(
+        ["status", "github.com/missing/repo"],
+        layer,
+      ).pipe(Effect.flip)
+
+      expect(result).toBeInstanceOf(FiniteCommandFailed)
+      if (result instanceof FiniteCommandFailed) {
+        expect(result.document).toEqual({
+          schemaVersion: CLI_SCHEMA_VERSION,
+          command: "status",
+          error: {
+            code: "REPOSITORY_NOT_FOUND",
+            message:
+              "No configured Repository matches github.com/missing/repo",
+          },
+        })
+      }
+    }),
+  )
+
+  it("binary help lists start, add, candidates, status, --no-open, and --host", () => {
     const result = spawnSync(
       "bun",
       ["--conditions", "@ready-for-agent/source", "src/main.ts", "--help"],
@@ -511,6 +651,7 @@ describe("operator binary CLI seam", () => {
     expect(output).toContain("start")
     expect(output).toContain("add")
     expect(output).toContain("candidates")
+    expect(output).toContain("status")
     expect(output).not.toContain("remove-github-token")
     expect(output).toContain("no-open")
     expect(output).toContain("host")

--- a/apps/ready-for-agent/src/cli.ts
+++ b/apps/ready-for-agent/src/cli.ts
@@ -213,10 +213,7 @@ const statusWorkflow = Effect.fn("Cli.status")(function* (
     const repositories = yield* graphqlApi.listRepositories.pipe(
       Effect.mapError((error) => toFiniteCommandFailed("status", error)),
     )
-    const resolved = resolveRepositoryIdentity(
-      repositoryArgument,
-      repositories,
-    )
+    const resolved = resolveRepositoryIdentity(repositoryArgument, repositories)
     switch (resolved._tag) {
       case "invalid":
         return yield* new FiniteCommandFailed({

--- a/apps/ready-for-agent/src/cli.ts
+++ b/apps/ready-for-agent/src/cli.ts
@@ -5,8 +5,10 @@ import {
   type FiniteCommandName,
   buildAddSuccessDocument,
   buildCandidatesSuccessDocument,
+  buildStatusSuccessDocument,
   encodeCompactJson,
   localGitErrorCode,
+  toCanonicalRepositoryIdentity,
 } from "./cli-json.ts"
 import { resolveRepositoryIdentity } from "./repository-identity.ts"
 import { GraphqlApi } from "./services/graphql-api.ts"
@@ -21,6 +23,13 @@ const repositoryIdentityArg = Argument.string("repository").pipe(
   Argument.withDescription(
     "Repository identity as <forge-host>/<project-path> (case-insensitive)",
   ),
+)
+
+const optionalRepositoryIdentityArg = Argument.string("repository").pipe(
+  Argument.withDescription(
+    "Optional repository identity as <forge-host>/<project-path> (case-insensitive)",
+  ),
+  Argument.optional,
 )
 
 const noOpenFlag = Flag.boolean("no-open").pipe(
@@ -190,6 +199,66 @@ const candidatesWorkflow = Effect.fn("Cli.candidates")(function* (
   )
 })
 
+const statusWorkflow = Effect.fn("Cli.status")(function* (
+  repositoryArgument: string | undefined,
+) {
+  const graphqlApi = yield* GraphqlApi
+
+  let repositoryId: string | null = null
+  let scopedRepository: ReturnType<
+    typeof toCanonicalRepositoryIdentity
+  > | null = null
+
+  if (repositoryArgument !== undefined) {
+    const repositories = yield* graphqlApi.listRepositories.pipe(
+      Effect.mapError((error) => toFiniteCommandFailed("status", error)),
+    )
+    const resolved = resolveRepositoryIdentity(
+      repositoryArgument,
+      repositories,
+    )
+    switch (resolved._tag) {
+      case "invalid":
+        return yield* new FiniteCommandFailed({
+          command: "status",
+          code: "REPOSITORY_NOT_FOUND",
+          message: `Invalid repository identity "${resolved.argument}". Use <forge-host>/<project-path>.`,
+        })
+      case "not_found":
+        return yield* new FiniteCommandFailed({
+          command: "status",
+          code: "REPOSITORY_NOT_FOUND",
+          message: `No configured Repository matches ${resolved.forgeHost}/${resolved.projectPath}`,
+        })
+      case "ambiguous":
+        return yield* new FiniteCommandFailed({
+          command: "status",
+          code: "REPOSITORY_AMBIGUOUS",
+          message: `Multiple configured Repositories match ${resolved.forgeHost}/${resolved.projectPath} (${resolved.matchCount})`,
+        })
+      case "matched":
+        repositoryId = resolved.repository.id
+        scopedRepository = toCanonicalRepositoryIdentity(resolved.repository)
+        break
+    }
+  }
+
+  const status = yield* graphqlApi
+    .kanbanStatus(repositoryId)
+    .pipe(Effect.mapError((error) => toFiniteCommandFailed("status", error)))
+
+  yield* Console.log(
+    encodeCompactJson(
+      buildStatusSuccessDocument({
+        // Prefer the identity resolved from the operator selector when scoped;
+        // otherwise use the GraphQL projection's repository (null for all).
+        repository: scopedRepository ?? status.repository,
+        lanes: status.lanes,
+      }),
+    ),
+  )
+})
+
 const startCommand = Command.make(
   "start",
   { noOpen: noOpenFlag, host: hostFlag },
@@ -229,6 +298,16 @@ const candidatesCommand = Command.make(
   ),
 )
 
+const statusCommand = Command.make(
+  "status",
+  { repository: optionalRepositoryIdentityArg },
+  ({ repository }) => statusWorkflow(Option.getOrUndefined(repository)),
+).pipe(
+  Command.withDescription(
+    "Print the current six-lane Kanban status as versioned JSON (optional <forge-host>/<project-path>)",
+  ),
+)
+
 export const cli = Command.make(
   "ready-for-agent",
   { noOpen: noOpenFlag, host: hostFlag },
@@ -236,7 +315,12 @@ export const cli = Command.make(
     startHarnessWorkflow(noOpen, Option.getOrUndefined(host)),
 ).pipe(
   Command.withDescription(
-    "Ready for Agent operator binary (start Harness, add repositories, list candidates)",
+    "Ready for Agent operator binary (start Harness, add repositories, list candidates, Kanban status)",
   ),
-  Command.withSubcommands([startCommand, addCommand, candidatesCommand]),
+  Command.withSubcommands([
+    startCommand,
+    addCommand,
+    candidatesCommand,
+    statusCommand,
+  ]),
 )

--- a/apps/ready-for-agent/src/services/graphql-api.ts
+++ b/apps/ready-for-agent/src/services/graphql-api.ts
@@ -1,6 +1,13 @@
 import { Context, Effect, Layer, Runtime, Schema } from "effect"
 import { createClient } from "@ready-for-agent/graphql-client"
-import type { IntakeCandidateAction } from "../cli-json.ts"
+import {
+  type CanonicalRepositoryIdentity,
+  type IntakeCandidateAction,
+  type StatusLane,
+  type StatusLaneId,
+  type StatusWorkItemRow,
+  toCanonicalRepositoryIdentity,
+} from "../cli-json.ts"
 import type { LocalRepository, RepositorySummary } from "../domain.ts"
 import { describeGraphqlFailure } from "../graphql-error.ts"
 import { ApplicationConfig } from "./application-config.ts"
@@ -44,6 +51,103 @@ export type IntakeCandidatesResult = {
   }[]
 }
 
+export type KanbanStatusResult = {
+  readonly repository: CanonicalRepositoryIdentity | null
+  readonly lanes: readonly StatusLane[]
+}
+
+const isStatusLaneId = (value: string): value is StatusLaneId => {
+  switch (value) {
+    case "QUEUE":
+    case "BUILD":
+    case "REVIEW":
+    case "PR":
+    case "ATTENTION":
+    case "MERGED":
+      return true
+    default:
+      return false
+  }
+}
+
+const toStatusWorkItemRow = (row: {
+  readonly repository: {
+    readonly id: string
+    readonly forge: string
+    readonly forgeHost: string
+    readonly projectPath: string
+  }
+  readonly workItem: {
+    readonly id: string
+    readonly issueNumber: number
+    readonly issueTitle: string | null
+    readonly state: string
+    readonly status: string
+    readonly statusMessage: string | null
+    readonly paused: boolean
+    readonly pullRequestNumber: number | null
+    readonly createdAt: string
+    readonly updatedAt: string
+    readonly stateReadyAt: string
+    readonly postponedUntil: string | null
+  }
+}): StatusWorkItemRow => ({
+  repository: toCanonicalRepositoryIdentity(row.repository),
+  id: row.workItem.id,
+  issueNumber: row.workItem.issueNumber,
+  issueTitle: row.workItem.issueTitle,
+  state: row.workItem.state,
+  status: row.workItem.status,
+  statusMessage: row.workItem.statusMessage,
+  paused: row.workItem.paused,
+  pullRequestNumber: row.workItem.pullRequestNumber,
+  createdAt: row.workItem.createdAt,
+  updatedAt: row.workItem.updatedAt,
+  stateReadyAt: row.workItem.stateReadyAt,
+  postponedUntil: row.workItem.postponedUntil,
+})
+
+const toStatusLanes = (
+  lanes: readonly {
+    readonly id: string
+    readonly label: string
+    readonly count: number
+    readonly workItems: readonly {
+      readonly repository: {
+        readonly id: string
+        readonly forge: string
+        readonly forgeHost: string
+        readonly projectPath: string
+      }
+      readonly workItem: {
+        readonly id: string
+        readonly issueNumber: number
+        readonly issueTitle: string | null
+        readonly state: string
+        readonly status: string
+        readonly statusMessage: string | null
+        readonly paused: boolean
+        readonly pullRequestNumber: number | null
+        readonly createdAt: string
+        readonly updatedAt: string
+        readonly stateReadyAt: string
+        readonly postponedUntil: string | null
+      }
+    }[]
+  }[],
+): readonly StatusLane[] =>
+  lanes.map((lane) => {
+    if (!isStatusLaneId(lane.id)) {
+      throw new Error(`Unexpected Kanban lane id from GraphQL: ${lane.id}`)
+    }
+    return {
+      id: lane.id,
+      label: lane.label,
+      count: lane.count,
+      workItems: lane.workItems.map(toStatusWorkItemRow),
+    }
+  })
+
 export class GraphqlApi extends Context.Service<
   GraphqlApi,
   {
@@ -57,6 +161,9 @@ export class GraphqlApi extends Context.Service<
     readonly intakeCandidates: (
       repositoryId: string,
     ) => Effect.Effect<IntakeCandidatesResult, GraphqlRequestFailed>
+    readonly kanbanStatus: (
+      repositoryId: string | null,
+    ) => Effect.Effect<KanbanStatusResult, GraphqlRequestFailed>
   }
 >()("ready-for-agent/GraphqlApi") {
   static readonly layer = Layer.effect(
@@ -64,6 +171,16 @@ export class GraphqlApi extends Context.Service<
     Effect.gen(function* () {
       const config = yield* ApplicationConfig
       const client = createClient({ url: config.graphqlUrl })
+
+      const mapFailure = (cause: unknown): GraphqlRequestFailed => {
+        const failure = describeGraphqlFailure(cause, {
+          graphqlUrl: config.graphqlUrl,
+        })
+        return new GraphqlRequestFailed({
+          code: failure.code,
+          message: failure.message,
+        })
+      }
 
       const addRepository = Effect.fn("GraphqlApi.addRepository")(function* (
         repository: LocalRepository,
@@ -95,15 +212,7 @@ export class GraphqlApi extends Context.Service<
             }
             return added
           },
-          catch: (cause) => {
-            const failure = describeGraphqlFailure(cause, {
-              graphqlUrl: config.graphqlUrl,
-            })
-            return new GraphqlRequestFailed({
-              code: failure.code,
-              message: failure.message,
-            })
-          },
+          catch: mapFailure,
         })
       })
 
@@ -119,15 +228,7 @@ export class GraphqlApi extends Context.Service<
           })
           return result.repositories ?? []
         },
-        catch: (cause) => {
-          const failure = describeGraphqlFailure(cause, {
-            graphqlUrl: config.graphqlUrl,
-          })
-          return new GraphqlRequestFailed({
-            code: failure.code,
-            message: failure.message,
-          })
-        },
+        catch: mapFailure,
       }).pipe(Effect.withSpan("GraphqlApi.listRepositories"))
 
       const intakeCandidates = Effect.fn("GraphqlApi.intakeCandidates")(
@@ -180,20 +281,76 @@ export class GraphqlApi extends Context.Service<
                 ),
               }
             },
-            catch: (cause) => {
-              const failure = describeGraphqlFailure(cause, {
-                graphqlUrl: config.graphqlUrl,
-              })
-              return new GraphqlRequestFailed({
-                code: failure.code,
-                message: failure.message,
-              })
-            },
+            catch: mapFailure,
           })
         },
       )
 
-      return { addRepository, listRepositories, intakeCandidates }
+      const kanbanStatus = Effect.fn("GraphqlApi.kanbanStatus")(function* (
+        repositoryId: string | null,
+      ) {
+        return yield* Effect.tryPromise({
+          try: async () => {
+            const result = await client.query({
+              kanbanStatus: {
+                __args: repositoryId === null ? {} : { repositoryId },
+                repository: {
+                  id: true,
+                  forge: true,
+                  forgeHost: true,
+                  projectPath: true,
+                },
+                lanes: {
+                  id: true,
+                  label: true,
+                  count: true,
+                  workItems: {
+                    repository: {
+                      id: true,
+                      forge: true,
+                      forgeHost: true,
+                      projectPath: true,
+                    },
+                    workItem: {
+                      id: true,
+                      issueNumber: true,
+                      issueTitle: true,
+                      state: true,
+                      status: true,
+                      statusMessage: true,
+                      paused: true,
+                      pullRequestNumber: true,
+                      createdAt: true,
+                      updatedAt: true,
+                      stateReadyAt: true,
+                      postponedUntil: true,
+                    },
+                  },
+                },
+              },
+            })
+            const status = result.kanbanStatus
+            if (!status) {
+              throw new Error("kanbanStatus returned null")
+            }
+            return {
+              repository:
+                status.repository === null || status.repository === undefined
+                  ? null
+                  : toCanonicalRepositoryIdentity(status.repository),
+              lanes: toStatusLanes(status.lanes ?? []),
+            }
+          },
+          catch: mapFailure,
+        })
+      })
+
+      return {
+        addRepository,
+        listRepositories,
+        intakeCandidates,
+        kanbanStatus,
+      }
     }),
   )
 }

--- a/packages/graphql-api/src/lib/graphql-api.ts
+++ b/packages/graphql-api/src/lib/graphql-api.ts
@@ -59,6 +59,10 @@ import {
   suspendRepositoryPolling,
 } from "./issue-polling.js"
 import {
+  buildKanbanSourceSet,
+  projectKanbanLanes,
+} from "./kanban-projection.js"
+import {
   RepositoryCredentialError,
   activatePollingIfCredentialed,
   githubTokenSecretName,
@@ -183,6 +187,10 @@ const normalizeCompletedWorkItemsPage = (
 
 type SessionArgs = {
   workItemId: string
+}
+
+type KanbanStatusArgs = {
+  repositoryId?: string | null
 }
 
 const toGraphqlSessionAvailability = (
@@ -883,6 +891,102 @@ export const createGraphqlApi = <R>(
                 })
                 return toGraphqlSession(session)
               }).pipe(Effect.withSpan("graphql-api.session")),
+              context,
+            ),
+          kanbanStatus: async (
+            _parent: unknown,
+            args: KanbanStatusArgs,
+            context: GraphqlRequestContext,
+          ) =>
+            runGraphql(
+              Effect.gen(function* () {
+                const db = yield* DbService
+                const lifecycle = yield* WorkItemLifecycle
+                const repositories = yield* db.listRepositories
+                const filterRepositoryId = args.repositoryId ?? null
+                const filteredRepository =
+                  filterRepositoryId === null
+                    ? null
+                    : (repositories.find(
+                        (repository) => repository.id === filterRepositoryId,
+                      ) ?? null)
+                if (
+                  filterRepositoryId !== null &&
+                  filteredRepository === null
+                ) {
+                  return yield* new RepositoryNotFoundError({
+                    repositoryId: filterRepositoryId,
+                  })
+                }
+
+                // Shared global source set first; optional Repository filter
+                // applies after failed/completed windows are built.
+                const perRepository = yield* Effect.forEach(
+                  repositories,
+                  (repository) =>
+                    Effect.gen(function* () {
+                      const [workItems, issues] = yield* Effect.all([
+                        lifecycle.listWorkItemsForRepository(repository.id),
+                        db.listIssues(repository.id),
+                      ])
+                      const relevantIssueNumbers = new Set(
+                        issues.map((issue) => issue.issueNumber),
+                      )
+                      return workItems.filter(
+                        (workItem) =>
+                          isJobsCompletedWorkItemState(workItem.state) ||
+                          isJobsWorkingWorkItem(workItem) ||
+                          relevantIssueNumbers.has(workItem.issueNumber),
+                      )
+                    }),
+                  { concurrency: "unbounded" },
+                )
+                const nowMs = Date.now()
+                const source = buildKanbanSourceSet(perRepository.flat(), nowMs)
+                const visible =
+                  filterRepositoryId === null
+                    ? source
+                    : source.filter(
+                        (workItem) =>
+                          workItem.repositoryId === filterRepositoryId,
+                      )
+                const repositoryById = new Map<
+                  string,
+                  (typeof repositories)[number]
+                >(repositories.map((repository) => [repository.id, repository]))
+                const classifiable = visible.flatMap((workItem) => {
+                  const repository = repositoryById.get(workItem.repositoryId)
+                  if (repository === undefined) {
+                    return []
+                  }
+                  return [
+                    {
+                      id: workItem.id,
+                      repositoryId: workItem.repositoryId,
+                      state: workItem.state,
+                      status: workItemStatus(workItem),
+                      failureCode: workItem.failureCode,
+                      createdAt: workItem.createdAt,
+                      stateReadyAt: workItem.stateReadyAt,
+                      repository,
+                      workItem,
+                    },
+                  ]
+                })
+                const lanes = projectKanbanLanes(classifiable).map((lane) => ({
+                  id: lane.id,
+                  label: lane.label,
+                  count: lane.count,
+                  workItems: lane.workItems.map((entry) => ({
+                    repository: entry.repository,
+                    workItem: entry.workItem,
+                  })),
+                }))
+                return {
+                  repository: filteredRepository,
+                  lanes,
+                }
+              }).pipe(Effect.withSpan("graphql-api.kanbanStatus")),
               context,
             ),
         },

--- a/packages/graphql-api/src/lib/kanban-projection.ts
+++ b/packages/graphql-api/src/lib/kanban-projection.ts
@@ -1,0 +1,225 @@
+/**
+ * Server-owned Kanban projection: lane membership, source windows, and
+ * per-lane ordering. Shared by GraphQL `kanbanStatus` and (later) the visual
+ * board so lane meaning cannot drift between clients.
+ *
+ * Lane rules match `docs/kanban.md` / harness `pipelineLaneFor`. Status and
+ * state comparisons are case-insensitive so domain (lowercase) and GraphQL
+ * (uppercase) shapes both classify correctly.
+ */
+import {
+  JOBS_COMPLETED_WINDOW_MS,
+  type WorkItemState,
+  isJobsCompletedWorkItemState,
+  isJobsFailedWorkItem,
+  isJobsWorkingWorkItem,
+} from "@ready-for-agent/work-item-lifecycle"
+
+/** Globally newest terminal failures included in the Kanban source set. */
+export const KANBAN_FAILED_LIMIT = 15
+
+export const KANBAN_LANE_IDS = [
+  "QUEUE",
+  "BUILD",
+  "REVIEW",
+  "PR",
+  "ATTENTION",
+  "MERGED",
+] as const
+
+export type KanbanLaneId = (typeof KANBAN_LANE_IDS)[number]
+
+export type KanbanLaneDefinition = {
+  readonly id: KanbanLaneId
+  readonly label: string
+}
+
+/** Fixed lane order and labels for every Kanban projection response. */
+export const KANBAN_LANES = [
+  { id: "QUEUE", label: "Queue" },
+  { id: "BUILD", label: "Build" },
+  { id: "REVIEW", label: "Review" },
+  { id: "PR", label: "PR" },
+  { id: "ATTENTION", label: "Attention" },
+  { id: "MERGED", label: "Merged" },
+] as const satisfies readonly KanbanLaneDefinition[]
+
+const BUILD_LIFECYCLE_STATES = new Set([
+  "CREATE_WORKTREE",
+  "INSTALL_DEPENDENCIES",
+  "IMPLEMENT",
+  "ASSESS_CHANGES",
+  "PRE_COMMIT",
+])
+
+const REVIEW_LIFECYCLE_STATES = new Set(["REVIEW"])
+
+const PR_LIFECYCLE_STATES = new Set([
+  "COMMIT",
+  "CREATE_PR",
+  "WATCH_PR_STATUS_CHECKS",
+  "RESOLVE_PR_MERGE_CONFLICT",
+  "INVESTIGATE_PR_STATUS_CHECKS",
+  "MARK_PR_READY_FOR_REVIEW",
+  "DECIDE_PR_MERGE",
+  "MERGE_PR",
+  "CLOSE_ISSUE",
+  "LOCAL_CLEANUP",
+])
+
+const normalizeToken = (value: string): string => value.toUpperCase()
+
+/**
+ * Classify one Work Item into a Kanban lane from lifecycle state + operator
+ * status. Attention and Merged override every lifecycle lane; Queue is only
+ * blockers / worker-slot holds; queued later steps stay in Build/Review/PR.
+ */
+export function kanbanLaneFor(workItem: {
+  readonly state: string
+  readonly status: string
+}): KanbanLaneId {
+  const state = normalizeToken(workItem.state)
+  const status = normalizeToken(workItem.status)
+
+  if (
+    status === "FAILED" ||
+    status === "INTERRUPTED" ||
+    status === "NEEDS_HUMAN" ||
+    status === "NEEDS_HUMAN_REVIEW" ||
+    state === "FAILED" ||
+    state === "NEEDS_HUMAN"
+  ) {
+    return "ATTENTION"
+  }
+
+  if (
+    status === "COMPLETE" ||
+    status === "SUCCEEDED" ||
+    status === "ABANDONED" ||
+    state === "COMPLETE" ||
+    state === "ABANDONED"
+  ) {
+    return "MERGED"
+  }
+
+  if (
+    status === "WAITING_FOR_BLOCKERS" ||
+    status === "WAITING_FOR_WORKER_SLOT"
+  ) {
+    return "QUEUE"
+  }
+
+  if (BUILD_LIFECYCLE_STATES.has(state)) {
+    return "BUILD"
+  }
+  if (REVIEW_LIFECYCLE_STATES.has(state)) {
+    return "REVIEW"
+  }
+  if (PR_LIFECYCLE_STATES.has(state)) {
+    return "PR"
+  }
+
+  // Unrecognized non-terminal state: keep off Queue so cards do not oscillate.
+  return "PR"
+}
+
+type SourceMembershipItem = {
+  readonly id: string
+  readonly state: WorkItemState
+  readonly failureCode?: string | null
+  readonly createdAt: Date
+  readonly stateReadyAt: Date
+}
+
+const newestCreatedFirst = <T extends { readonly createdAt: Date }>(
+  items: readonly T[],
+): T[] =>
+  items
+    .slice()
+    .sort((left, right) => right.createdAt.getTime() - left.createdAt.getTime())
+
+const newestStateReadyFirst = <T extends { readonly stateReadyAt: Date }>(
+  items: readonly T[],
+): T[] =>
+  items
+    .slice()
+    .sort(
+      (left, right) =>
+        right.stateReadyAt.getTime() - left.stateReadyAt.getTime(),
+    )
+
+/**
+ * Shared Kanban source set: all working Work Items, the globally newest
+ * {@link KANBAN_FAILED_LIMIT} terminal failures, and Complete/Abandoned items
+ * with stateReadyAt in the rolling previous 24 hours. Deduplicated by id.
+ * Callers apply an optional Repository filter after this set is built.
+ */
+export function buildKanbanSourceSet<T extends SourceMembershipItem>(
+  workItems: readonly T[],
+  nowMs: number = Date.now(),
+): readonly T[] {
+  const working = workItems.filter(isJobsWorkingWorkItem)
+  const failed = newestCreatedFirst(
+    workItems.filter(isJobsFailedWorkItem),
+  ).slice(0, KANBAN_FAILED_LIMIT)
+  const windowStartMs = nowMs - JOBS_COMPLETED_WINDOW_MS
+  const completed = workItems.filter(
+    (item) =>
+      isJobsCompletedWorkItemState(item.state) &&
+      item.stateReadyAt.getTime() >= windowStartMs,
+  )
+
+  const byId = new Map<string, T>()
+  for (const item of [...working, ...failed, ...completed]) {
+    byId.set(item.id, item)
+  }
+  return [...byId.values()]
+}
+
+export type KanbanProjectableItem = SourceMembershipItem & {
+  readonly repositoryId: string
+  readonly status: string
+}
+
+export type ProjectedKanbanLane<T extends KanbanProjectableItem> = {
+  readonly id: KanbanLaneId
+  readonly label: string
+  readonly count: number
+  readonly workItems: readonly T[]
+}
+
+/**
+ * Assign source-set items to the six fixed lanes, then order:
+ * Queue/Build/Review/PR/Attention by createdAt newest-first; Merged by
+ * stateReadyAt newest-first.
+ */
+export function projectKanbanLanes<T extends KanbanProjectableItem>(
+  sourceItems: readonly T[],
+): readonly ProjectedKanbanLane<T>[] {
+  const buckets = new Map<KanbanLaneId, T[]>()
+  for (const id of KANBAN_LANE_IDS) {
+    buckets.set(id, [])
+  }
+
+  for (const item of sourceItems) {
+    const lane = kanbanLaneFor({ state: item.state, status: item.status })
+    const bucket = buckets.get(lane)
+    if (bucket !== undefined) {
+      bucket.push(item)
+    }
+  }
+
+  return KANBAN_LANES.map((lane) => {
+    const raw = buckets.get(lane.id) ?? []
+    const ordered =
+      lane.id === "MERGED"
+        ? newestStateReadyFirst(raw)
+        : newestCreatedFirst(raw)
+    return {
+      id: lane.id,
+      label: lane.label,
+      count: ordered.length,
+      workItems: ordered,
+    }
+  })
+}

--- a/packages/graphql-api/src/lib/kanban-projection.ts
+++ b/packages/graphql-api/src/lib/kanban-projection.ts
@@ -18,7 +18,7 @@ import {
 /** Globally newest terminal failures included in the Kanban source set. */
 export const KANBAN_FAILED_LIMIT = 15
 
-export const KANBAN_LANE_IDS = [
+const KANBAN_LANE_IDS = [
   "QUEUE",
   "BUILD",
   "REVIEW",

--- a/packages/graphql-api/test/graphql-api.test.ts
+++ b/packages/graphql-api/test/graphql-api.test.ts
@@ -7689,4 +7689,480 @@ describe("GraphQL API", () => {
       ],
     })
   })
+
+  test("kanbanStatus returns six empty lanes for all repositories", async () => {
+    await runtime.dispose()
+    runtime = makeRuntime(
+      {
+        listRepositories: Effect.succeed([repository]),
+        listIssues: () => Effect.succeed([]),
+      },
+      {},
+      {},
+      {
+        listWorkItemsForRepository: () => Effect.succeed([]),
+      },
+    )
+
+    const response = await createGraphqlApi(runtime).fetch(
+      graphqlRequest({
+        query: `query {
+          kanbanStatus {
+            repository { id }
+            lanes { id label count workItems { workItem { id } } }
+          }
+        }`,
+      }),
+    )
+
+    expect(await response.json()).toEqual({
+      data: {
+        kanbanStatus: {
+          repository: null,
+          lanes: [
+            { id: "QUEUE", label: "Queue", count: 0, workItems: [] },
+            { id: "BUILD", label: "Build", count: 0, workItems: [] },
+            { id: "REVIEW", label: "Review", count: 0, workItems: [] },
+            { id: "PR", label: "PR", count: 0, workItems: [] },
+            { id: "ATTENTION", label: "Attention", count: 0, workItems: [] },
+            { id: "MERGED", label: "Merged", count: 0, workItems: [] },
+          ],
+        },
+      },
+    })
+  })
+
+  test("kanbanStatus with zero configured Repositories is a successful empty board", async () => {
+    await runtime.dispose()
+    runtime = makeRuntime(
+      {
+        listRepositories: Effect.succeed([]),
+        listIssues: () => Effect.succeed([]),
+      },
+      {},
+      {},
+      {
+        listWorkItemsForRepository: () => Effect.succeed([]),
+      },
+    )
+
+    const response = await createGraphqlApi(runtime).fetch(
+      graphqlRequest({
+        query: `query {
+          kanbanStatus {
+            repository { id }
+            lanes { id count workItems { workItem { id } } }
+          }
+        }`,
+      }),
+    )
+
+    expect(await response.json()).toEqual({
+      data: {
+        kanbanStatus: {
+          repository: null,
+          lanes: [
+            { id: "QUEUE", count: 0, workItems: [] },
+            { id: "BUILD", count: 0, workItems: [] },
+            { id: "REVIEW", count: 0, workItems: [] },
+            { id: "PR", count: 0, workItems: [] },
+            { id: "ATTENTION", count: 0, workItems: [] },
+            { id: "MERGED", count: 0, workItems: [] },
+          ],
+        },
+      },
+    })
+  })
+
+  test("kanbanStatus keeps only the globally newest 15 terminal failures", async () => {
+    const now = Date.parse("2026-08-12T12:00:00.000Z")
+    const failures = Array.from({ length: 18 }, (_, index) => {
+      const issueNumber = 100 + index
+      return {
+        workItem: {
+          ...workItem,
+          id: `wi-failed-${index}`,
+          repositoryId: repository.id,
+          issueNumber,
+          state: "failed" as const,
+          createdAt: new Date(now - index * 1_000),
+          stateReadyAt: new Date(now - index * 1_000),
+          stepRuns: [],
+        } as WorkItemRecord,
+        issue: {
+          ...issue,
+          id: `issue-failed-${index}`,
+          issueNumber,
+          title: `Failure ${index}`,
+          url: `https://github.com/acme/widgets/issues/${issueNumber}`,
+        },
+      }
+    })
+
+    await runtime.dispose()
+    runtime = makeRuntime(
+      {
+        listRepositories: Effect.succeed([repository]),
+        listIssues: () => Effect.succeed(failures.map((entry) => entry.issue)),
+      },
+      {},
+      {},
+      {
+        listWorkItemsForRepository: () =>
+          Effect.succeed(failures.map((entry) => entry.workItem)),
+      },
+    )
+
+    const response = await createGraphqlApi(runtime).fetch(
+      graphqlRequest({
+        query: `query {
+          kanbanStatus {
+            lanes {
+              id
+              count
+              workItems { workItem { id } }
+            }
+          }
+        }`,
+      }),
+    )
+    const json = (await response.json()) as {
+      data: {
+        kanbanStatus: {
+          lanes: readonly {
+            id: string
+            count: number
+            workItems: readonly { workItem: { id: string } }[]
+          }[]
+        }
+      }
+    }
+    const attention = json.data.kanbanStatus.lanes.find(
+      (lane) => lane.id === "ATTENTION",
+    )
+    expect(attention?.count).toBe(15)
+    expect(attention?.workItems.map((row) => row.workItem.id)).toEqual(
+      Array.from({ length: 15 }, (_, index) => `wi-failed-${index}`),
+    )
+  })
+
+  test("kanbanStatus classifies lanes, windows, ordering, and repository filter", async () => {
+    const now = Date.parse("2026-08-12T12:00:00.000Z")
+    const otherRepo = makeRepositoryRecord({
+      id: "repo-01J00000000000000000000001",
+      projectPath: "acme/other",
+      localPath: "/repos/acme/other.git",
+    })
+
+    const queueItem = {
+      ...workItem,
+      id: "wi-queue",
+      repositoryId: repository.id,
+      issueNumber: 10,
+      state: "create_worktree" as const,
+      waitingForBlockers: true,
+      holdsWorkerSlot: false,
+      createdAt: new Date(now - 5_000),
+      stateReadyAt: new Date(now - 5_000),
+      stepRuns: [],
+    } as WorkItemRecord
+    const buildItem = {
+      ...workItem,
+      id: "wi-build",
+      repositoryId: repository.id,
+      issueNumber: 11,
+      state: "implement" as const,
+      createdAt: new Date(now - 4_000),
+      stateReadyAt: new Date(now - 4_000),
+      stepRuns: [
+        {
+          ...workItem.stepRuns[0]!,
+          id: "srun-build",
+          workItemId: "wi-build",
+          step: "implement" as const,
+          status: "running" as const,
+        },
+      ],
+    } as WorkItemRecord
+    const attentionWorking = {
+      ...workItem,
+      id: "wi-attention-working",
+      repositoryId: repository.id,
+      issueNumber: 12,
+      state: "review" as const,
+      createdAt: new Date(now - 3_000),
+      stateReadyAt: new Date(now - 3_000),
+      stepRuns: [
+        {
+          ...workItem.stepRuns[0]!,
+          id: "srun-attention",
+          workItemId: "wi-attention-working",
+          step: "review" as const,
+          status: "failed" as const,
+          finishedAt: new Date(now - 2_900),
+        },
+      ],
+    } as WorkItemRecord
+    const terminalFailed = {
+      ...workItem,
+      id: "wi-failed",
+      repositoryId: otherRepo.id,
+      issueNumber: 20,
+      state: "failed" as const,
+      createdAt: new Date(now - 1_000),
+      stateReadyAt: new Date(now - 1_000),
+      stepRuns: [],
+    } as WorkItemRecord
+    const merged = {
+      ...workItem,
+      id: "wi-merged",
+      repositoryId: repository.id,
+      issueNumber: 13,
+      state: "complete" as const,
+      createdAt: new Date(now - 20_000),
+      stateReadyAt: new Date(now - 2_000),
+      stepRuns: [],
+    } as WorkItemRecord
+    const oldMerged = {
+      ...workItem,
+      id: "wi-old-merged",
+      repositoryId: repository.id,
+      issueNumber: 14,
+      state: "complete" as const,
+      createdAt: new Date(now - 100_000),
+      // Far outside the rolling 24h window regardless of wall-clock skew in tests.
+      stateReadyAt: new Date(now - 7 * 24 * 60 * 60 * 1000),
+      stepRuns: [],
+    } as WorkItemRecord
+    const queuedStatusCheck = {
+      ...workItem,
+      id: "wi-pr-queued",
+      repositoryId: repository.id,
+      issueNumber: 15,
+      state: "watch_pr_status_checks" as const,
+      createdAt: new Date(now - 500),
+      stateReadyAt: new Date(now - 500),
+      pullRequestNumber: 99,
+      stepRuns: [
+        {
+          ...workItem.stepRuns[0]!,
+          id: "srun-watch",
+          workItemId: "wi-pr-queued",
+          step: "watch_pr_status_checks" as const,
+          status: "queued" as const,
+          startedAt: null,
+          executionDurationMs: null,
+        },
+      ],
+    } as WorkItemRecord
+
+    const byRepo = new Map<string, WorkItemRecord[]>([
+      [
+        repository.id,
+        [
+          queueItem,
+          buildItem,
+          attentionWorking,
+          merged,
+          oldMerged,
+          queuedStatusCheck,
+        ],
+      ],
+      [otherRepo.id, [terminalFailed]],
+    ])
+
+    const otherIssue = {
+      ...issue,
+      id: "issue-other",
+      repositoryId: otherRepo.id,
+      issueNumber: terminalFailed.issueNumber,
+      title: "Other repo failure",
+      url: "https://github.com/acme/other/issues/20",
+    }
+
+    await runtime.dispose()
+    runtime = makeRuntime(
+      {
+        listRepositories: Effect.succeed([repository, otherRepo]),
+        listIssues: (repositoryId) =>
+          Effect.succeed(
+            repositoryId === otherRepo.id
+              ? [otherIssue]
+              : [
+                  issue,
+                  {
+                    ...issue,
+                    id: "issue-10",
+                    issueNumber: 10,
+                  },
+                  {
+                    ...issue,
+                    id: "issue-11",
+                    issueNumber: 11,
+                  },
+                  {
+                    ...issue,
+                    id: "issue-12",
+                    issueNumber: 12,
+                  },
+                  {
+                    ...issue,
+                    id: "issue-13",
+                    issueNumber: 13,
+                  },
+                  {
+                    ...issue,
+                    id: "issue-14",
+                    issueNumber: 14,
+                  },
+                  {
+                    ...issue,
+                    id: "issue-15",
+                    issueNumber: 15,
+                  },
+                ],
+          ),
+      },
+      {},
+      {},
+      {
+        listWorkItemsForRepository: (repositoryId) =>
+          Effect.succeed(byRepo.get(repositoryId) ?? []),
+      },
+    )
+
+    const allResponse = await createGraphqlApi(runtime).fetch(
+      graphqlRequest({
+        query: `query {
+          kanbanStatus {
+            repository { id }
+            lanes {
+              id
+              count
+              workItems {
+                repository { id projectPath }
+                workItem {
+                  id
+                  issueNumber
+                  state
+                  status
+                  pullRequestNumber
+                }
+              }
+            }
+          }
+        }`,
+      }),
+    )
+    const allJson = (await allResponse.json()) as {
+      data: {
+        kanbanStatus: {
+          repository: null
+          lanes: readonly {
+            id: string
+            count: number
+            workItems: readonly {
+              repository: { id: string; projectPath: string }
+              workItem: {
+                id: string
+                issueNumber: number
+                state: string
+                status: string
+                pullRequestNumber: number | null
+              }
+            }[]
+          }[]
+        }
+      }
+    }
+    const lanesById = Object.fromEntries(
+      allJson.data.kanbanStatus.lanes.map((lane) => [lane.id, lane]),
+    )
+    expect(allJson.data.kanbanStatus.repository).toBeNull()
+    expect(lanesById.QUEUE?.workItems.map((row) => row.workItem.id)).toEqual([
+      "wi-queue",
+    ])
+    expect(lanesById.BUILD?.workItems.map((row) => row.workItem.id)).toEqual([
+      "wi-build",
+    ])
+    expect(lanesById.PR?.workItems.map((row) => row.workItem.id)).toEqual([
+      "wi-pr-queued",
+    ])
+    expect(lanesById.PR?.workItems[0]?.workItem.pullRequestNumber).toBe(99)
+    // Attention newest-first by createdAt: terminal failed (other repo) first.
+    expect(
+      lanesById.ATTENTION?.workItems.map((row) => row.workItem.id),
+    ).toEqual(["wi-failed", "wi-attention-working"])
+    expect(lanesById.MERGED?.workItems.map((row) => row.workItem.id)).toEqual([
+      "wi-merged",
+    ])
+    expect(lanesById.REVIEW?.workItems).toEqual([])
+
+    const filteredResponse = await createGraphqlApi(runtime).fetch(
+      graphqlRequest({
+        query: `query Kanban($repositoryId: ID) {
+          kanbanStatus(repositoryId: $repositoryId) {
+            repository { id projectPath }
+            lanes {
+              id
+              workItems {
+                repository { id }
+                workItem { id }
+              }
+            }
+          }
+        }`,
+        variables: { repositoryId: repository.id },
+      }),
+    )
+    const filteredJson = (await filteredResponse.json()) as {
+      data: {
+        kanbanStatus: {
+          repository: { id: string; projectPath: string }
+          lanes: readonly {
+            id: string
+            workItems: readonly { workItem: { id: string } }[]
+          }[]
+        }
+      }
+    }
+    expect(filteredJson.data.kanbanStatus.repository).toEqual({
+      id: repository.id,
+      projectPath: repository.projectPath,
+    })
+    const filteredById = Object.fromEntries(
+      filteredJson.data.kanbanStatus.lanes.map((lane) => [lane.id, lane]),
+    )
+    // Global failed cap still includes other-repo failures in the source set,
+    // but the repository filter drops them after that set is built.
+    expect(
+      filteredById.ATTENTION?.workItems.map((row) => row.workItem.id),
+    ).toEqual(["wi-attention-working"])
+    expect(
+      filteredJson.data.kanbanStatus.lanes
+        .flatMap((lane) => lane.workItems)
+        .every((row) => row.workItem.id !== "wi-failed"),
+    ).toBe(true)
+  })
+
+  test("kanbanStatus returns REPOSITORY_NOT_FOUND for unknown repositoryId", async () => {
+    const response = await createGraphqlApi(runtime).fetch(
+      graphqlRequest({
+        query: `query {
+          kanbanStatus(repositoryId: "missing-repo") {
+            repository { id }
+            lanes { id }
+          }
+        }`,
+      }),
+    )
+    expect(await response.json()).toEqual({
+      data: null,
+      errors: [
+        expect.objectContaining({
+          extensions: { code: "REPOSITORY_NOT_FOUND" },
+        }),
+      ],
+    })
+  })
 })

--- a/packages/graphql-api/test/kanban-projection.test.ts
+++ b/packages/graphql-api/test/kanban-projection.test.ts
@@ -1,0 +1,283 @@
+import {
+  JOBS_COMPLETED_WINDOW_MS,
+  type WorkItemState,
+} from "@ready-for-agent/work-item-lifecycle"
+import {
+  KANBAN_FAILED_LIMIT,
+  KANBAN_LANES,
+  buildKanbanSourceSet,
+  kanbanLaneFor,
+  projectKanbanLanes,
+} from "../src/lib/kanban-projection.js"
+import { describe, expect, test } from "bun:test"
+
+const NOW_MS = Date.parse("2026-08-12T12:00:00.000Z")
+
+type Fixture = {
+  readonly id: string
+  readonly repositoryId: string
+  readonly state: WorkItemState
+  readonly status: string
+  readonly failureCode?: string | null
+  readonly createdAt: Date
+  readonly stateReadyAt: Date
+}
+
+const item = (
+  overrides: Partial<Fixture> & Pick<Fixture, "id" | "state" | "status">,
+): Fixture => ({
+  repositoryId: "repo-a",
+  failureCode: null,
+  createdAt: new Date(NOW_MS),
+  stateReadyAt: new Date(NOW_MS),
+  ...overrides,
+})
+
+describe("KANBAN_LANES", () => {
+  test("defines six fixed lanes in operator order", () => {
+    expect(KANBAN_LANES.map(({ id, label }) => ({ id, label }))).toEqual([
+      { id: "QUEUE", label: "Queue" },
+      { id: "BUILD", label: "Build" },
+      { id: "REVIEW", label: "Review" },
+      { id: "PR", label: "PR" },
+      { id: "ATTENTION", label: "Attention" },
+      { id: "MERGED", label: "Merged" },
+    ])
+  })
+})
+
+describe("kanbanLaneFor", () => {
+  test.each([
+    { state: "review", status: "failed", lane: "ATTENTION" },
+    { state: "implement", status: "interrupted", lane: "ATTENTION" },
+    { state: "merge_pr", status: "needs_human", lane: "ATTENTION" },
+    {
+      state: "watch_pr_status_checks",
+      status: "needs_human_review",
+      lane: "ATTENTION",
+    },
+    { state: "failed", status: "running", lane: "ATTENTION" },
+    { state: "needs_human", status: "running", lane: "ATTENTION" },
+    { state: "COMPLETE", status: "FAILED", lane: "ATTENTION" },
+  ] as const)(
+    "places $state / $status in Attention",
+    ({ state, status, lane }) => {
+      expect(kanbanLaneFor({ state, status })).toBe(lane)
+    },
+  )
+
+  test.each([
+    { state: "merge_pr", status: "succeeded", lane: "MERGED" },
+    { state: "local_cleanup", status: "complete", lane: "MERGED" },
+    { state: "merge_pr", status: "abandoned", lane: "MERGED" },
+    { state: "complete", status: "running", lane: "MERGED" },
+    { state: "abandoned", status: "running", lane: "MERGED" },
+  ] as const)(
+    "places $state / $status in Merged",
+    ({ state, status, lane }) => {
+      expect(kanbanLaneFor({ state, status })).toBe(lane)
+    },
+  )
+
+  test.each([
+    {
+      state: "create_worktree",
+      status: "waiting_for_blockers",
+      lane: "QUEUE",
+    },
+    {
+      state: "create_worktree",
+      status: "waiting_for_worker_slot",
+      lane: "QUEUE",
+    },
+    {
+      state: "implement",
+      status: "waiting_for_worker_slot",
+      lane: "QUEUE",
+    },
+    {
+      state: "merge_pr",
+      status: "waiting_for_worker_slot",
+      lane: "QUEUE",
+    },
+  ] as const)(
+    "places blocked or not-admitted $state in Queue",
+    ({ state, status, lane }) => {
+      expect(kanbanLaneFor({ state, status })).toBe(lane)
+    },
+  )
+
+  test.each([
+    { state: "create_worktree", status: "running", lane: "BUILD" },
+    { state: "install_dependencies", status: "running", lane: "BUILD" },
+    { state: "implement", status: "running", lane: "BUILD" },
+    { state: "assess_changes", status: "running", lane: "BUILD" },
+    { state: "pre_commit", status: "queued", lane: "BUILD" },
+    { state: "review", status: "queued", lane: "REVIEW" },
+    { state: "watch_pr_status_checks", status: "queued", lane: "PR" },
+    { state: "commit", status: "running", lane: "PR" },
+    { state: "create_pr", status: "queued", lane: "PR" },
+    { state: "merge_pr", status: "cancelled", lane: "PR" },
+  ] as const)(
+    "places lifecycle progress $state / $status in $lane",
+    ({ state, status, lane }) => {
+      expect(kanbanLaneFor({ state, status })).toBe(lane)
+    },
+  )
+
+  test("does not send a pending status-check poll to Queue", () => {
+    expect(
+      kanbanLaneFor({
+        state: "WATCH_PR_STATUS_CHECKS",
+        status: "QUEUED",
+      }),
+    ).toBe("PR")
+  })
+})
+
+describe("buildKanbanSourceSet", () => {
+  test("includes working, newest 15 terminal failures, and 24h completed", () => {
+    const working = item({
+      id: "w1",
+      state: "implement",
+      status: "running",
+      createdAt: new Date(NOW_MS - 1_000),
+    })
+    const needsHuman = item({
+      id: "nh1",
+      state: "needs_human",
+      status: "needs_human",
+      createdAt: new Date(NOW_MS - 2_000),
+    })
+    const completed = item({
+      id: "c1",
+      state: "complete",
+      status: "complete",
+      stateReadyAt: new Date(NOW_MS - 60_000),
+      createdAt: new Date(NOW_MS - 3_000),
+    })
+    const oldCompleted = item({
+      id: "c-old",
+      state: "complete",
+      status: "complete",
+      stateReadyAt: new Date(NOW_MS - JOBS_COMPLETED_WINDOW_MS - 1),
+      createdAt: new Date(NOW_MS - 4_000),
+    })
+    const failed = Array.from({ length: KANBAN_FAILED_LIMIT + 3 }, (_, i) =>
+      item({
+        id: `f${i}`,
+        state: "failed",
+        status: "failed",
+        createdAt: new Date(NOW_MS - i * 1_000),
+      }),
+    )
+
+    const source = buildKanbanSourceSet(
+      [working, needsHuman, completed, oldCompleted, ...failed],
+      NOW_MS,
+    )
+    const ids = new Set(source.map((entry) => entry.id))
+
+    expect(ids.has("w1")).toBe(true)
+    expect(ids.has("nh1")).toBe(true)
+    expect(ids.has("c1")).toBe(true)
+    expect(ids.has("c-old")).toBe(false)
+    expect(
+      source
+        .filter((entry) => entry.state === "failed")
+        .map((entry) => entry.id),
+    ).toEqual(Array.from({ length: KANBAN_FAILED_LIMIT }, (_, i) => `f${i}`))
+  })
+
+  test("deduplicates by Work Item id", () => {
+    const shared = item({
+      id: "shared",
+      state: "implement",
+      status: "running",
+    })
+    const source = buildKanbanSourceSet([shared, shared], NOW_MS)
+    expect(source).toHaveLength(1)
+  })
+})
+
+describe("projectKanbanLanes", () => {
+  test("returns empty lanes in fixed order", () => {
+    const lanes = projectKanbanLanes([])
+    expect(lanes.map((lane) => ({ id: lane.id, count: lane.count }))).toEqual([
+      { id: "QUEUE", count: 0 },
+      { id: "BUILD", count: 0 },
+      { id: "REVIEW", count: 0 },
+      { id: "PR", count: 0 },
+      { id: "ATTENTION", count: 0 },
+      { id: "MERGED", count: 0 },
+    ])
+    for (const lane of lanes) {
+      expect(lane.workItems).toEqual([])
+    }
+  })
+
+  test("orders non-Merged lanes by createdAt newest first", () => {
+    const older = item({
+      id: "older",
+      state: "implement",
+      status: "running",
+      createdAt: new Date(NOW_MS - 10_000),
+    })
+    const newer = item({
+      id: "newer",
+      state: "implement",
+      status: "running",
+      createdAt: new Date(NOW_MS - 1_000),
+    })
+    const lanes = projectKanbanLanes([older, newer])
+    const build = lanes.find((lane) => lane.id === "BUILD")
+    expect(build?.workItems.map((entry) => entry.id)).toEqual([
+      "newer",
+      "older",
+    ])
+  })
+
+  test("orders Merged by stateReadyAt newest first", () => {
+    const older = item({
+      id: "older-merged",
+      state: "complete",
+      status: "complete",
+      createdAt: new Date(NOW_MS - 1_000),
+      stateReadyAt: new Date(NOW_MS - 10_000),
+    })
+    const newer = item({
+      id: "newer-merged",
+      state: "complete",
+      status: "complete",
+      createdAt: new Date(NOW_MS - 20_000),
+      stateReadyAt: new Date(NOW_MS - 1_000),
+    })
+    const lanes = projectKanbanLanes([older, newer])
+    const merged = lanes.find((lane) => lane.id === "MERGED")
+    expect(merged?.workItems.map((entry) => entry.id)).toEqual([
+      "newer-merged",
+      "older-merged",
+    ])
+  })
+
+  test("Attention mixes working and failed by createdAt newest first", () => {
+    const workingAttention = item({
+      id: "working-attention",
+      state: "implement",
+      status: "failed",
+      createdAt: new Date(NOW_MS - 5_000),
+    })
+    const terminalFailed = item({
+      id: "terminal-failed",
+      state: "failed",
+      status: "failed",
+      createdAt: new Date(NOW_MS - 1_000),
+    })
+    const lanes = projectKanbanLanes([workingAttention, terminalFailed])
+    const attention = lanes.find((lane) => lane.id === "ATTENTION")
+    expect(attention?.workItems.map((entry) => entry.id)).toEqual([
+      "terminal-failed",
+      "working-attention",
+    ])
+  })
+})

--- a/packages/graphql-schema/schema.graphql
+++ b/packages/graphql-schema/schema.graphql
@@ -103,6 +103,14 @@ type Query {
   build/review Agent Models, including catalog membership when known).
   """
   intakeCandidates(repositoryId: ID!): RepositoryIntakeCandidates!
+  """
+  Current six-lane Kanban projection. When repositoryId is omitted, includes
+  Work Items from every configured Repository. When set, filters after the
+  shared global source set is built (working + newest 15 terminal failures +
+  Complete/Abandoned in the rolling previous 24 hours). Always returns all six
+  lanes in fixed order, including empty lanes.
+  """
+  kanbanStatus(repositoryId: ID): KanbanStatus!
 }
 
 type GitHubThrottleStatus {
@@ -253,6 +261,47 @@ type Session {
   cost: Float
   createdAt: String
   updatedAt: String
+}
+
+"""
+Kanban pipeline lane identity. Fixed order: Queue, Build, Review, PR,
+Attention, Merged.
+"""
+enum KanbanLaneId {
+  QUEUE
+  BUILD
+  REVIEW
+  PR
+  ATTENTION
+  MERGED
+}
+
+"""
+One Work Item row in a Kanban lane, with its owning Repository identity.
+"""
+type KanbanWorkItem {
+  repository: Repository!
+  workItem: WorkItem!
+}
+
+"""
+One Kanban lane with membership and count. Empty lanes still appear with
+count 0 and an empty workItems list.
+"""
+type KanbanLane {
+  id: KanbanLaneId!
+  label: String!
+  count: Int!
+  workItems: [KanbanWorkItem!]!
+}
+
+"""
+Non-visual Kanban status projection. repository is null when the query covers
+all configured Repositories; otherwise it is the filtered Repository.
+"""
+type KanbanStatus {
+  repository: Repository
+  lanes: [KanbanLane!]!
 }
 
 """

--- a/packages/graphql-schema/schema.template.graphql
+++ b/packages/graphql-schema/schema.template.graphql
@@ -100,6 +100,14 @@ type Query {
   build/review Agent Models, including catalog membership when known).
   """
   intakeCandidates(repositoryId: ID!): RepositoryIntakeCandidates!
+  """
+  Current six-lane Kanban projection. When repositoryId is omitted, includes
+  Work Items from every configured Repository. When set, filters after the
+  shared global source set is built (working + newest 15 terminal failures +
+  Complete/Abandoned in the rolling previous 24 hours). Always returns all six
+  lanes in fixed order, including empty lanes.
+  """
+  kanbanStatus(repositoryId: ID): KanbanStatus!
 }
 
 type GitHubThrottleStatus {
@@ -250,6 +258,47 @@ type Session {
   cost: Float
   createdAt: String
   updatedAt: String
+}
+
+"""
+Kanban pipeline lane identity. Fixed order: Queue, Build, Review, PR,
+Attention, Merged.
+"""
+enum KanbanLaneId {
+  QUEUE
+  BUILD
+  REVIEW
+  PR
+  ATTENTION
+  MERGED
+}
+
+"""
+One Work Item row in a Kanban lane, with its owning Repository identity.
+"""
+type KanbanWorkItem {
+  repository: Repository!
+  workItem: WorkItem!
+}
+
+"""
+One Kanban lane with membership and count. Empty lanes still appear with
+count 0 and an empty workItems list.
+"""
+type KanbanLane {
+  id: KanbanLaneId!
+  label: String!
+  count: Int!
+  workItems: [KanbanWorkItem!]!
+}
+
+"""
+Non-visual Kanban status projection. repository is null when the query covers
+all configured Repositories; otherwise it is the filtered Repository.
+"""
+type KanbanStatus {
+  repository: Repository
+  lanes: [KanbanLane!]!
 }
 
 """


### PR DESCRIPTION
Why

Automated operators need a non-visual, one-shot view of the six-lane
Kanban without reimplementing lifecycle placement or source windows.
Issue #977 expands the Intake/Kanban CLI work by making the Harness own
the authoritative projection and exposing it through GraphQL and
`ready-for-agent status`.

What changed

- Server projection (kanban-projection): fixed Queue, Build, Review, PR,
  Attention, Merged order; Attention/Merged precedence; Queue only for
  blockers / worker-slot holds; source set = all working Work Items +
  newest 15 terminal failures + Complete/Abandoned in the rolling 24h
  window; optional repository filter after that set; lane ordering by
  createdAt (non-Merged) / stateReadyAt (Merged).
- GraphQL kanbanStatus(repositoryId: ID): KanbanStatus! with nested
  repository + Work Item rows; empty lanes always present; unknown
  repository returns REPOSITORY_NOT_FOUND.
- CLI ready-for-agent status [<forge-host>/<project-path>]: versioned
  JSON success on stdout; all repos when the selector is omitted; same
  case-insensitive unique selector rules as future candidates;
  forge-neutral fields such as pullRequestNumber.
- Review remediation: removed casts / dead selector branch, shared
  canonical repository identity helper, and GraphQL coverage for zero
  repositories and the exact 15-failure window. Dual client/server lane
  classifiers remain until the board migration (#979).

Verification

- graphql-api tests for lane membership, windows, ordering, filter,
  empty/zero-repo boards, and failed cap
- ready-for-agent CLI unit/process/Vitest seam tests for status JSON,
  selector resolution, and stderr error contract

Limitations

- Visual Kanban still uses the browser classifier until #979.
- No watch mode, streaming status, or historical Completed status API.

Closes #977