### PR TITLE
feat(harness): drive visual Kanban from server kanbanStatus projection

### DIFF
--- a/apps/harness/src/home-page-content.tsx
+++ b/apps/harness/src/home-page-content.tsx
@@ -21,10 +21,7 @@ import {
   useState,
 } from "react"
 import { createClient } from "@ready-for-agent/graphql-client"
-import {
-  COMPLETED_WORK_ITEMS_DEFAULT_PAGE_SIZE as completedWorkItemsDefaultPageSize,
-  JOBS_COMPLETED_WINDOW_HOURS as jobsCompletedWindowHours,
-} from "@ready-for-agent/work-item-lifecycle/jobs-completed-window"
+import { COMPLETED_WORK_ITEMS_DEFAULT_PAGE_SIZE as completedWorkItemsDefaultPageSize } from "@ready-for-agent/work-item-lifecycle/jobs-completed-window"
 import { formatAgentBackendStatusLabel } from "./agent-backend-status-label.js"
 import { AgentBackendWarnings } from "./agent-backend-warnings.js"
 import { AgentModelSelect } from "./agent-model-select.js"
@@ -68,8 +65,10 @@ import {
 import {
   type LifecycleLabelChip,
   type LifecyclePipelineLaneId,
+  type PipelineLaneId,
   lifecycleFocusLaneFor,
   lifecycleLaneForPhase,
+  pipelineLaneIdFromServerLaneId,
   planLifecycleChipPresentation,
 } from "./pipeline-lanes.js"
 import {
@@ -90,6 +89,7 @@ import {
 import {
   completedWorkItemsHistoryQueryKeyPrefix,
   followRepositoryWorkItemsLive,
+  kanbanStatusQueryKeyPrefix,
 } from "./refresh-work-items-live.js"
 import { type Repository, repositoriesQuery } from "./repositories-query.js"
 import {
@@ -335,15 +335,7 @@ type WorkItemsQueryOptions = {
   readonly limit?: number
 }
 
-/**
- * Rolling window hours for Jobs Completed (same source as server filter).
- * Filtering uses Work Item stateReadyAt within JOBS_COMPLETED_WINDOW_MS on the API.
- * Kept in the query key so a window-hours change busts the client cache.
- */
-const JOBS_COMPLETED_WINDOW_HOURS = jobsCompletedWindowHours
-/** Failed history window (fixed item cap; independent of Completed). */
-export const JOBS_FAILED_LIMIT = 15
-/** Historical Completed page size (server-paginated; not the Jobs 24 h tab). */
+/** Historical Completed page size (server-paginated archive on /completed). */
 export const COMPLETED_WORK_ITEMS_PAGE_SIZE = completedWorkItemsDefaultPageSize
 
 export const workItemsQuery = (
@@ -375,24 +367,62 @@ export const workItemsQuery = (
   }
 }
 
-export const jobsWorkingWorkItemsQuery = (repositoryId: string) =>
-  workItemsQuery(repositoryId, { listKind: "WORKING" })
-
-export const jobsFailedWorkItemsQuery = (repositoryId: string) =>
-  workItemsQuery(repositoryId, {
-    listKind: "FAILED",
-    limit: JOBS_FAILED_LIMIT,
-  })
-
-export const jobsCompletedWorkItemsQuery = (repositoryId: string) => {
-  const base = workItemsQuery(repositoryId, {
-    listKind: "COMPLETED",
-  })
-  return {
-    ...base,
-    queryKey: [...base.queryKey, JOBS_COMPLETED_WINDOW_HOURS] as const,
-  }
+/** Server `kanbanStatus` projection used by the visual board. */
+export type KanbanStatusProjection = {
+  readonly repositoryId: string | null
+  readonly lanes: readonly {
+    readonly id: PipelineLaneId
+    readonly label: string
+    readonly count: number
+    readonly workItems: readonly WorkItem[]
+  }[]
 }
+
+/**
+ * Server-owned six-lane Kanban projection. When `repositoryId` is null, covers
+ * every configured Repository (filter applied server-side after the shared
+ * source windows). Lane membership and ordering are authoritative; the board
+ * does not reclassify.
+ */
+export const kanbanStatusQuery = (repositoryId: string | null) => ({
+  queryKey: [...kanbanStatusQueryKeyPrefix, repositoryId] as const,
+  // No cross-key placeholder: a repository filter switch must not paint the
+  // previous source set under the new selection while the projection loads.
+  queryFn: async (): Promise<KanbanStatusProjection> => {
+    const result = await graphql.query({
+      kanbanStatus: {
+        __args: repositoryId === null ? {} : { repositoryId },
+        repository: { id: true },
+        lanes: {
+          id: true,
+          label: true,
+          count: true,
+          workItems: {
+            workItem: workItemFields,
+          },
+        },
+      },
+    })
+    const status = result.kanbanStatus
+    const lanes: KanbanStatusProjection["lanes"][number][] = []
+    for (const lane of status.lanes) {
+      const pipelineLaneId = pipelineLaneIdFromServerLaneId(lane.id)
+      if (pipelineLaneId === null) {
+        throw new Error(`Unknown Kanban lane id from server: ${lane.id}`)
+      }
+      lanes.push({
+        id: pipelineLaneId,
+        label: lane.label,
+        count: lane.count,
+        workItems: lane.workItems.map((row) => row.workItem),
+      })
+    }
+    return {
+      repositoryId: status.repository?.id ?? null,
+      lanes,
+    }
+  },
+})
 
 export type CompletedWorkItemsPage = {
   readonly items: readonly WorkItem[]
@@ -405,7 +435,7 @@ export type CompletedWorkItemsPage = {
 
 /**
  * Historical Completed Work Items across all repositories (server-paginated).
- * Distinct from jobsCompletedWorkItemsQuery (per-repo, 24 h window).
+ * Distinct from the Kanban Merged lane (rolling 24 h via `kanbanStatus`).
  */
 export const completedWorkItemsHistoryQuery = (page: number) => ({
   queryKey: [
@@ -446,6 +476,49 @@ const patchWorkItemsCaches = (
     queryKey: ["work-items", repositoryId],
   })) {
     queryClient.setQueryData<readonly WorkItem[]>(queryKey, update)
+  }
+
+  // Board tickets come from the server Kanban projection. Keep nested Work
+  // Item rows in sync for pause/start/retry so controls stay responsive without
+  // waiting for the next SSE refresh. Reset (delete) may leave an empty lane
+  // slot until the projection refetches membership.
+  for (const [
+    queryKey,
+    data,
+  ] of queryClient.getQueriesData<KanbanStatusProjection>({
+    queryKey: kanbanStatusQueryKeyPrefix,
+  })) {
+    if (data === undefined) continue
+    let changed = false
+    const lanes = data.lanes.map((lane) => {
+      // Only lanes that already hold this repository's items can change from
+      // pause/start/retry/reset patches scoped by repositoryId.
+      if (!lane.workItems.some((item) => item.repositoryId === repositoryId)) {
+        return lane
+      }
+      const nextItems = update(lane.workItems)
+      if (nextItems === undefined) {
+        return lane
+      }
+      const same =
+        nextItems.length === lane.workItems.length &&
+        nextItems.every((item, index) => item === lane.workItems[index])
+      if (same) {
+        return lane
+      }
+      changed = true
+      return {
+        ...lane,
+        workItems: nextItems,
+        count: nextItems.length,
+      }
+    })
+    if (changed) {
+      queryClient.setQueryData<KanbanStatusProjection>(queryKey, {
+        ...data,
+        lanes,
+      })
+    }
   }
 }
 
@@ -3302,16 +3375,16 @@ export function WorkItemLifecycleStatus({
     isNeedsHuman: status === "NEEDS_HUMAN",
     isFailed: status === "FAILED",
   })
-  const dataUpdatedAt = queryClient
-    .getQueriesData({ queryKey: ["work-items", workItem.repositoryId] })
-    .reduce(
-      (latest, [queryKey]) =>
-        Math.max(
-          latest,
-          queryClient.getQueryState(queryKey)?.dataUpdatedAt ?? 0,
-        ),
-      0,
-    )
+  const dataUpdatedAt = [
+    ...queryClient.getQueriesData({
+      queryKey: ["work-items", workItem.repositoryId],
+    }),
+    ...queryClient.getQueriesData({ queryKey: kanbanStatusQueryKeyPrefix }),
+  ].reduce(
+    (latest, [queryKey]) =>
+      Math.max(latest, queryClient.getQueryState(queryKey)?.dataUpdatedAt ?? 0),
+    0,
+  )
   const nowMs = useNowMs(true)
   const [expandedEarlierLanes, setExpandedEarlierLanes] = useState(
     () => new Set<LifecyclePipelineLaneId>(),

--- a/apps/harness/src/kanban-board.tsx
+++ b/apps/harness/src/kanban-board.tsx
@@ -1,19 +1,16 @@
-import { useQueries, useSuspenseQuery } from "@tanstack/react-query"
+import { useQueries, useQuery, useSuspenseQuery } from "@tanstack/react-query"
 import { Link, useNavigate } from "@tanstack/react-router"
 import { type CSSProperties, Suspense, useMemo, useState } from "react"
 import { Banner } from "./banner.js"
 import { Copy } from "./copy.js"
 import {
-  JOBS_FAILED_LIMIT,
   JobsCardSkeleton,
   type Repository,
   type WorkItem,
   WorkItemLifecycleStatus,
   WorkItemPauseButton,
   issuesQuery,
-  jobsCompletedWorkItemsQuery,
-  jobsFailedWorkItemsQuery,
-  jobsWorkingWorkItemsQuery,
+  kanbanStatusQuery,
   repositoriesQuery,
 } from "./home-page-content.js"
 import { useJobsRepositoryFilter } from "./jobs-repository-filter.js"
@@ -25,11 +22,7 @@ import {
   useNowMs,
 } from "./live-duration.js"
 import { MetalLaneHeader } from "./metal-lane-header.js"
-import {
-  PIPELINE_LANES,
-  type PipelineLaneId,
-  pipelineLaneFor,
-} from "./pipeline-lanes.js"
+import { PIPELINE_LANES, type PipelineLaneId } from "./pipeline-lanes.js"
 import { PipelineRoute, usePipelineRouteFlights } from "./pipeline-route.js"
 import {
   ROUTE_TRANSITION_MS,
@@ -45,18 +38,6 @@ import {
   statusBadgeClassNameForStatus,
 } from "./work-item-progress-chrome.js"
 import { workItemPullRequestUrl } from "./work-item-pull-request-url.js"
-
-const sortNewestFirst = (items: readonly WorkItem[]): readonly WorkItem[] =>
-  items
-    .slice()
-    .sort((left, right) => right.createdAt.localeCompare(left.createdAt))
-
-const sortCompletedNewestFirst = (
-  items: readonly WorkItem[],
-): readonly WorkItem[] =>
-  items
-    .slice()
-    .sort((left, right) => right.stateReadyAt.localeCompare(left.stateReadyAt))
 
 const repositoryIssueKey = (
   repositoryId: string,
@@ -322,21 +303,14 @@ function KanbanJobsBoard() {
     })
   }
   const { data: repositories } = useSuspenseQuery(repositoriesQuery)
-  const workingQueries = useQueries({
-    queries: repositories.map((repository) =>
-      jobsWorkingWorkItemsQuery(repository.id),
-    ),
-  })
-  const failedQueries = useQueries({
-    queries: repositories.map((repository) =>
-      jobsFailedWorkItemsQuery(repository.id),
-    ),
-  })
-  const completedQueries = useQueries({
-    queries: repositories.map((repository) =>
-      jobsCompletedWorkItemsQuery(repository.id),
-    ),
-  })
+  // Server-owned lane membership, source windows, and ordering. Optional
+  // repository filter is applied after the shared global source set.
+  const {
+    data: kanbanStatus,
+    isLoading: kanbanLoading,
+    isError: kanbanFailed,
+  } = useQuery(kanbanStatusQuery(selectedRepositoryId))
+  // Issue titles/URLs enrich tickets; membership never comes from this list.
   const issueQueries = useQueries({
     queries: repositories.map((repository) => issuesQuery(repository.id)),
   })
@@ -358,64 +332,37 @@ function KanbanJobsBoard() {
     }
   }
 
-  const workingItems = sortNewestFirst(
-    workingQueries.flatMap((query) => query.data ?? []),
-  )
-  const failedItems = sortNewestFirst(
-    failedQueries.flatMap((query) => query.data ?? []),
-  ).slice(0, JOBS_FAILED_LIMIT)
-  const completedItems = sortCompletedNewestFirst(
-    completedQueries.flatMap((query) => query.data ?? []),
-  )
-  // Preserve per-list recency: Working/Failed by createdAt, Completed by
-  // stateReadyAt. Do not re-sort the merge by createdAt or Merged-lane order
-  // drifts from completed history.
-  const pipelineItems = Array.from(
-    new Map(
-      [...workingItems, ...failedItems, ...completedItems].map((item) => [
-        item.id,
-        item,
-      ]),
-    ).values(),
-  )
-  const activeQueries = [
-    ...workingQueries,
-    ...failedQueries,
-    ...completedQueries,
-  ]
-  const loading = activeQueries.some((query) => query.isLoading)
-  const failed = activeQueries.some((query) => query.isError)
-  const visiblePipelineItems =
-    selectedRepositoryId === null
-      ? pipelineItems
-      : pipelineItems.filter(
-          (item) => item.repositoryId === selectedRepositoryId,
-        )
-  const laneItems = new Map(
-    PIPELINE_LANES.map((lane) => [
-      lane.id,
-      visiblePipelineItems.filter(
-        (workItem) => pipelineLaneFor(workItem) === lane.id,
-      ),
-    ]),
-  )
+  const laneItems = useMemo(() => {
+    const map = new Map<PipelineLaneId, readonly WorkItem[]>(
+      PIPELINE_LANES.map((lane) => [lane.id, [] as const]),
+    )
+    if (kanbanStatus === undefined) {
+      return map
+    }
+    for (const lane of kanbanStatus.lanes) {
+      map.set(lane.id, lane.workItems)
+    }
+    return map
+  }, [kanbanStatus])
 
   // Route flights: grey source until absorb, then dest card fades in with smoke.
   const routeFlights = usePipelineRouteFlights(laneItems)
 
   const workItemById = useMemo(() => {
     const map = new Map<string, WorkItem>()
-    for (const item of visiblePipelineItems) {
-      map.set(item.id, item)
+    for (const items of laneItems.values()) {
+      for (const item of items) {
+        map.set(item.id, item)
+      }
     }
     return map
-  }, [visiblePipelineItems])
+  }, [laneItems])
 
-  if (loading && pipelineItems.length === 0) {
+  if (kanbanLoading && kanbanStatus === undefined) {
     return <JobsCardSkeleton />
   }
 
-  if (failed) {
+  if (kanbanFailed && kanbanStatus === undefined) {
     return (
       <>
         <KanbanLiveUpdates repositoryIds={repositoryIds} />

--- a/apps/harness/src/pipeline-lanes.ts
+++ b/apps/harness/src/pipeline-lanes.ts
@@ -37,8 +37,9 @@ const LIFECYCLE_LANE_LABEL: Record<LifecyclePipelineLaneId, string> = {
 }
 
 /**
- * Work Item states that place a ticket in Build. Shared with chip phase
- * grouping so board placement and Kanban chip collapse stay aligned.
+ * Work Item states that group chips under Build. Shared with chip phase
+ * grouping so Kanban earlier-lane collapse stays aligned with the server
+ * board model in docs/kanban.md.
  */
 const BUILD_LIFECYCLE_STATES = [
   "CREATE_WORKTREE",
@@ -77,54 +78,30 @@ const PR_PHASES = new Set<string>([
   "GITHUB_STATUS_CHECKS",
 ])
 
-type PipelineWorkItem = {
-  readonly state: string
-  readonly status: string
-}
-
 /**
- * Kanban placement is driven by lifecycle progress, not scheduler status.
- * Attention and Merged override every lane. Queue is only for work that
- * cannot begin yet (blockers or worker slot). Queued step execution stays in
- * its lifecycle lane (Build / Review / PR).
+ * Map GraphQL `KanbanLaneId` (QUEUE…MERGED) onto board `PipelineLaneId`
+ * (queue…complete). Board placement comes from the server projection; this
+ * only translates enum casing/names for UI chrome.
  */
-export function pipelineLaneFor(workItem: PipelineWorkItem): PipelineLaneId {
-  if (
-    workItem.status === "FAILED" ||
-    workItem.status === "INTERRUPTED" ||
-    workItem.status === "NEEDS_HUMAN" ||
-    workItem.status === "NEEDS_HUMAN_REVIEW" ||
-    workItem.state === "FAILED" ||
-    workItem.state === "NEEDS_HUMAN"
-  ) {
-    return "attention"
+export function pipelineLaneIdFromServerLaneId(
+  id: string,
+): PipelineLaneId | null {
+  switch (id) {
+    case "QUEUE":
+      return "queue"
+    case "BUILD":
+      return "build"
+    case "REVIEW":
+      return "review"
+    case "PR":
+      return "pr"
+    case "ATTENTION":
+      return "attention"
+    case "MERGED":
+      return "complete"
+    default:
+      return null
   }
-
-  if (
-    workItem.status === "COMPLETE" ||
-    workItem.status === "SUCCEEDED" ||
-    workItem.status === "ABANDONED" ||
-    workItem.state === "COMPLETE" ||
-    workItem.state === "ABANDONED"
-  ) {
-    return "complete"
-  }
-
-  if (
-    workItem.status === "WAITING_FOR_BLOCKERS" ||
-    workItem.status === "WAITING_FOR_WORKER_SLOT"
-  ) {
-    return "queue"
-  }
-
-  const lifecycleLane = lifecycleLaneForState(workItem.state)
-  if (lifecycleLane !== null) {
-    return lifecycleLane
-  }
-
-  // Unrecognized non-terminal state: keep off Queue so cards do not oscillate.
-  // When the lifecycle gains a step, extend Build, Review, or PR above.
-  return "pr"
 }
 
 /** Map a Work Item operational state to its lifecycle lane (ignores status). */

--- a/apps/harness/src/refresh-issues-live.ts
+++ b/apps/harness/src/refresh-issues-live.ts
@@ -1,5 +1,6 @@
 import type { QueryClient } from "@tanstack/react-query"
 import { streamIssuesChanged } from "./issues-live.js"
+import { kanbanStatusQueryKeyPrefix } from "./refresh-work-items-live.js"
 
 export type RepositoryIssuesLiveQueries = {
   repositories: {
@@ -80,12 +81,35 @@ export const followRepositoryIssuesLive = async ({
     )
   }
 
+  /** Active server Kanban projections stay aligned when Issues drive Work Items. */
+  const refreshKanbanStatus = async () => {
+    if (signal.aborted) return
+    await queryClient.cancelQueries({ queryKey: kanbanStatusQueryKeyPrefix })
+    const cached = queryClient
+      .getQueryCache()
+      .findAll({ queryKey: kanbanStatusQueryKeyPrefix })
+    const active = cached.filter((query) => query.isActive())
+    await Promise.all(
+      active.map(async (query) => {
+        if (signal.aborted) return
+        const queryFn = query.options.queryFn
+        if (typeof queryFn !== "function") return
+        await queryClient.fetchQuery({
+          queryKey: query.queryKey,
+          queryFn: queryFn as (context: unknown) => Promise<unknown>,
+          staleTime: 0,
+        })
+      }),
+    )
+  }
+
   const refresh = async (repositoryId: string) => {
     onRepositoryChanged?.(repositoryId)
     await Promise.all([
       fetchFresh(queries.repositories),
       fetchFresh(queries.issues(repositoryId)),
       refreshWorkItems(repositoryId),
+      refreshKanbanStatus(),
     ])
   }
 
@@ -97,6 +121,7 @@ export const followRepositoryIssuesLive = async ({
         fetchFresh(queries.issues(repositoryId)),
       ),
       ...repositoryIds.map((repositoryId) => refreshWorkItems(repositoryId)),
+      refreshKanbanStatus(),
     ])
   }
 

--- a/apps/harness/src/refresh-work-items-live.ts
+++ b/apps/harness/src/refresh-work-items-live.ts
@@ -11,6 +11,12 @@ export const completedWorkItemsHistoryQueryKeyPrefix = [
   "completed-work-items",
 ] as const
 
+/**
+ * Server-owned six-lane Kanban projection (`kanbanStatus`). Optional repository
+ * filter is the second key segment (`null` = all sources).
+ */
+export const kanbanStatusQueryKeyPrefix = ["kanban-status"] as const
+
 const configQueryKey = ["config"] as const
 /**
  * Per-repo unfinished gate (`blockingUnfinishedWorkItemCount`) lives here.
@@ -207,7 +213,7 @@ export const followRepositoryWorkItemsLive = async ({
 
   /**
    * Refetch every work-items cache for the repository (default list plus any
-   * Jobs Working/Failed/Completed listKind variants already in the query cache).
+   * listKind variants already in the query cache, e.g. repository cards).
    */
   const refreshWorkItems = async (repositoryId: string) => {
     if (signal.aborted) return
@@ -268,6 +274,17 @@ export const followRepositoryWorkItemsLive = async ({
     })
   }
 
+  /**
+   * Refresh active server Kanban projections (all-sources and filtered).
+   * Inactive filter variants stay cached until remounted.
+   */
+  const refreshKanbanStatus = async () => {
+    if (signal.aborted) return
+    await refreshCachedQueries(kanbanStatusQueryKeyPrefix, {
+      activeOnly: true,
+    })
+  }
+
   const refresh = async (repositoryId: string) => {
     // Do not await counts here: the SSE subscriber awaits each onChange, so
     // awaiting aggregates would serialize one full count refresh per event and
@@ -278,6 +295,7 @@ export const followRepositoryWorkItemsLive = async ({
     void refreshCompletedWorkItemsHistory()
     await Promise.all([
       refreshWorkItems(repositoryId),
+      refreshKanbanStatus(),
       // Harness Settings includes the global unfinished Work Item count.
       refreshCachedQueries(configQueryKey),
       // Repository settings backend gate uses per-repo blocking counts.
@@ -293,6 +311,7 @@ export const followRepositoryWorkItemsLive = async ({
     scheduleOpenPullRequestCounts()
     await Promise.all([
       ...repositoryIds.map((repositoryId) => refreshWorkItems(repositoryId)),
+      refreshKanbanStatus(),
       // Connect/visibility still await active history so the open archive is current.
       refreshCompletedWorkItemsHistory(),
       refreshCommittedPullRequestsCounts(),
@@ -344,6 +363,9 @@ export const followRepositoryWorkItemsLive = async ({
     void queryClient.cancelQueries({ queryKey: ["work-items"] })
     void queryClient.cancelQueries({
       queryKey: completedWorkItemsHistoryQueryKeyPrefix,
+    })
+    void queryClient.cancelQueries({
+      queryKey: kanbanStatusQueryKeyPrefix,
     })
     // Do not cancel openPullRequestCountsQueryKey: that projection is owned by
     // followOpenPullRequestCountLive; this follower only schedules invalidation.

--- a/apps/harness/test/jobs-reset-visibility.test.ts
+++ b/apps/harness/test/jobs-reset-visibility.test.ts
@@ -192,14 +192,17 @@ describe("Jobs Reset button wiring", () => {
   })
 
   test("kanban completed tickets still render compact lifecycle outside Merged lane", () => {
-    const source = homeSource()
+    const home = homeSource()
     const board = readFileSync(
       join(import.meta.dir, "../src/kanban-board.tsx"),
       "utf8",
     )
-    expect(source).toContain('listKind: "COMPLETED"')
-    expect(source).toContain("JOBS_COMPLETED_WINDOW_HOURS")
-    expect(source).not.toContain("JOBS_COMPLETED_LIMIT")
+    // Board membership is server kanbanStatus (includes Merged window); archive
+    // remains the separate completedWorkItemsHistoryQuery path.
+    expect(home).toContain("kanbanStatusQuery")
+    expect(home).toContain("completedWorkItemsHistoryQuery")
+    expect(home).not.toContain("jobsCompletedWorkItemsQuery")
+    expect(home).not.toContain("JOBS_COMPLETED_LIMIT")
     // Non-Merged pipeline tickets keep compact lifecycle + Reset wiring.
     const ticket = board.slice(
       board.indexOf("function PipelineTicket("),

--- a/apps/harness/test/kanban-route.test.ts
+++ b/apps/harness/test/kanban-route.test.ts
@@ -157,7 +157,9 @@ describe("kanban home board", () => {
     )
     const metalHeader = metalLaneHeaderSource()
     expect(source).toContain('aria-label="Lifecycle pipeline"')
-    expect(source).toContain("pipelineLaneFor(workItem)")
+    // Membership comes from server projection, not client classification.
+    expect(source).toContain("kanbanStatusQuery")
+    expect(source).not.toContain("pipelineLaneFor")
     expect(source).toContain("Lane clear")
     // Mobile switcher + metal header use {lane.label}; route furnaces live in
     // PipelineRoute (also {lane.label} in accessible names).
@@ -411,12 +413,13 @@ describe("kanban home board", () => {
     expect(source.match(/collapseEarlierLanes/g)).toHaveLength(1)
   })
 
-  test("Merged-lane compact summary is gated by pipelineLaneFor lane id", () => {
+  test("Merged-lane compact summary is gated by server lane id complete", () => {
     // Completed history uses archive cards on /completed/*; pipeline Merged
-    // still uses PipelineCompleteSummary when laneId === "complete".
+    // still uses PipelineCompleteSummary when laneId === "complete" (MERGED).
     const source = boardSource()
     const board = source.slice(source.indexOf("function KanbanJobsBoard("))
-    expect(board).toContain("pipelineLaneFor(workItem)")
+    expect(board).toContain("kanbanStatusQuery")
+    expect(board).not.toContain("pipelineLaneFor")
     expect(board).toContain("<PipelineTicket")
     const ticket = source.slice(
       source.indexOf("function PipelineTicket("),
@@ -424,8 +427,8 @@ describe("kanban home board", () => {
     )
     expect(ticket).toContain('const isCompleteLane = laneId === "complete"')
     expect(ticket).toContain("<PipelineCompleteSummary")
-    // No local completed-tab ticket list on the home board.
-    expect(board).not.toContain("laneId={pipelineLaneFor(workItem)}")
+    // Lane comes from the server projection map, not client reclassification.
+    expect(board).toContain("laneId={lane.id}")
   })
 
   test("shows agent backend and session id on separate runtime lines", () => {
@@ -495,13 +498,31 @@ describe("kanban home board", () => {
     )
   })
 
-  test("reuses existing queries and live invalidation without polling", () => {
-    // Working/Failed list queries still feed the Pipeline board merge; they are
-    // not tab panels. Completed tab still uses jobsCompletedWorkItemsQuery.
+  test("consumes server kanbanStatus projection with live invalidation and no polling", () => {
+    // Board membership is one server projection; issue/repo queries enrich only.
     const source = boardSource()
-    expect(source).toContain("jobsWorkingWorkItemsQuery")
-    expect(source).toContain("jobsFailedWorkItemsQuery")
-    expect(source).toContain("jobsCompletedWorkItemsQuery")
+    const home = readFileSync(
+      join(import.meta.dir, "../src/home-page-content.tsx"),
+      "utf8",
+    )
+    expect(source).toContain("kanbanStatusQuery")
+    expect(source).toContain("selectedRepositoryId")
+    expect(home).toContain("kanbanStatus:")
+    expect(home).toContain("kanbanStatusQueryKeyPrefix")
+    // Filter switches must not paint the previous source set under a new key.
+    const kanbanQuery = home.slice(
+      home.indexOf("export const kanbanStatusQuery"),
+      home.indexOf("export type CompletedWorkItemsPage"),
+    )
+    expect(kanbanQuery).not.toMatch(/placeholderData\s*:/)
+    // Client no longer assembles Working/Failed/Completed source windows.
+    expect(source).not.toContain("jobsWorkingWorkItemsQuery")
+    expect(source).not.toContain("jobsFailedWorkItemsQuery")
+    expect(source).not.toContain("jobsCompletedWorkItemsQuery")
+    expect(source).not.toContain("JOBS_FAILED_LIMIT")
+    expect(source).not.toContain("pipelineLaneFor")
+    expect(source).not.toContain("sortNewestFirst")
+    expect(source).not.toContain("sortCompletedNewestFirst")
     expect(source).toContain("issuesQuery")
     expect(source).toContain("repositoriesQuery")
     expect(source).toContain("<KanbanLiveUpdates")
@@ -510,25 +531,29 @@ describe("kanban home board", () => {
     expect(source).not.toMatch(
       /selectedTab === "working"|selectedTab === "failed"/,
     )
+    // Query construction lives in home-page-content; board does not open a client.
     expect(source).not.toContain("queryFn:")
     expect(source).not.toContain("createClient(")
     expect(source).not.toContain("setInterval")
     expect(source).not.toContain("refetchInterval")
   })
 
-  test("Pipeline preserves Completed stateReadyAt order instead of re-sorting by createdAt", () => {
+  test("defers lane membership and ordering to the server projection", () => {
+    // Server GraphQL suite owns window/precedence/order proofs; board only maps.
     const source = boardSource()
     const board = source.slice(source.indexOf("function KanbanJobsBoard("))
-    expect(board).toContain("sortCompletedNewestFirst")
-    expect(board).toContain("const pipelineItems = Array.from(")
-    expect(board).not.toMatch(/const pipelineItems\s*=\s*sortNewestFirst\s*\(/)
+    expect(board).toContain("kanbanStatusQuery(selectedRepositoryId)")
+    expect(board).toContain("map.set(lane.id, lane.workItems)")
+    expect(board).not.toContain("pipelineLaneFor")
+    expect(board).not.toContain(".sort(")
+    expect(board).not.toContain("slice(0, JOBS_FAILED_LIMIT)")
   })
 
   test("starts live invalidation after the initial board queries settle", () => {
     const source = boardSource()
     const loadingBranch = source.slice(
-      source.indexOf("if (loading && pipelineItems.length === 0)"),
-      source.indexOf("if (failed)"),
+      source.indexOf("if (kanbanLoading && kanbanStatus === undefined)"),
+      source.indexOf("if (kanbanFailed && kanbanStatus === undefined)"),
     )
     expect(loadingBranch).toContain("<JobsCardSkeleton />")
     expect(loadingBranch).not.toContain("<KanbanLiveUpdates")

--- a/apps/harness/test/pipeline-lanes.test.ts
+++ b/apps/harness/test/pipeline-lanes.test.ts
@@ -2,22 +2,15 @@ import {
   type LifecycleLabelChip,
   type LifecyclePipelineLaneId,
   PIPELINE_LANES,
-  type PipelineLaneId,
   earlierLifecycleLanes,
   lifecycleFocusLaneFor,
   lifecycleLaneForPhase,
   lifecycleLaneForState,
-  pipelineLaneFor,
+  pipelineLaneIdFromServerLaneId,
   planLifecycleChipPresentation,
   sumLaneDurationMs,
 } from "../src/pipeline-lanes.js"
 import { describe, expect, test } from "bun:test"
-
-type LaneCase = {
-  readonly state: string
-  readonly status: string
-  readonly lane: PipelineLaneId
-}
 
 describe("PIPELINE_LANES", () => {
   test("defines the ordered pipeline lanes and their fixed colors", () => {
@@ -34,173 +27,20 @@ describe("PIPELINE_LANES", () => {
   })
 })
 
-describe("pipelineLaneFor", () => {
-  test.each([
-    { state: "REVIEW", status: "FAILED", lane: "attention" },
-    { state: "IMPLEMENT", status: "INTERRUPTED", lane: "attention" },
-    { state: "MERGE_PR", status: "NEEDS_HUMAN", lane: "attention" },
-    {
-      state: "WATCH_PR_STATUS_CHECKS",
-      status: "NEEDS_HUMAN_REVIEW",
-      lane: "attention",
-    },
-    { state: "FAILED", status: "RUNNING", lane: "attention" },
-    { state: "NEEDS_HUMAN", status: "RUNNING", lane: "attention" },
-  ] satisfies readonly LaneCase[])(
-    "places $state with $status in Attention",
-    ({ state, status, lane }) => {
-      expect(pipelineLaneFor({ state, status })).toBe(lane)
-    },
-  )
+describe("pipelineLaneIdFromServerLaneId", () => {
+  // Board placement is server-owned; this only maps GraphQL enum ids to UI ids.
+  test("maps each GraphQL KanbanLaneId onto board PipelineLaneId", () => {
+    expect(pipelineLaneIdFromServerLaneId("QUEUE")).toBe("queue")
+    expect(pipelineLaneIdFromServerLaneId("BUILD")).toBe("build")
+    expect(pipelineLaneIdFromServerLaneId("REVIEW")).toBe("review")
+    expect(pipelineLaneIdFromServerLaneId("PR")).toBe("pr")
+    expect(pipelineLaneIdFromServerLaneId("ATTENTION")).toBe("attention")
+    expect(pipelineLaneIdFromServerLaneId("MERGED")).toBe("complete")
+  })
 
-  test.each([
-    { state: "MERGE_PR", status: "SUCCEEDED", lane: "complete" },
-    { state: "LOCAL_CLEANUP", status: "COMPLETE", lane: "complete" },
-    { state: "MERGE_PR", status: "ABANDONED", lane: "complete" },
-    { state: "COMPLETE", status: "RUNNING", lane: "complete" },
-    { state: "ABANDONED", status: "RUNNING", lane: "complete" },
-  ] satisfies readonly LaneCase[])(
-    "places $state with $status in Merged",
-    ({ state, status, lane }) => {
-      expect(pipelineLaneFor({ state, status })).toBe(lane)
-    },
-  )
-
-  test.each([
-    {
-      state: "CREATE_WORKTREE",
-      status: "WAITING_FOR_BLOCKERS",
-      lane: "queue",
-    },
-    {
-      state: "CREATE_WORKTREE",
-      status: "WAITING_FOR_WORKER_SLOT",
-      lane: "queue",
-    },
-    {
-      state: "INSTALL_DEPENDENCIES",
-      status: "WAITING_FOR_WORKER_SLOT",
-      lane: "queue",
-    },
-    {
-      state: "MERGE_PR",
-      status: "WAITING_FOR_WORKER_SLOT",
-      lane: "queue",
-    },
-  ] satisfies readonly LaneCase[])(
-    "places blocked or not-admitted $state with $status in Queue",
-    ({ state, status, lane }) => {
-      expect(pipelineLaneFor({ state, status })).toBe(lane)
-    },
-  )
-
-  test.each([
-    { state: "CREATE_WORKTREE", status: "RUNNING", lane: "build" },
-    { state: "INSTALL_DEPENDENCIES", status: "RUNNING", lane: "build" },
-    { state: "IMPLEMENT", status: "RUNNING", lane: "build" },
-    { state: "ASSESS_CHANGES", status: "RUNNING", lane: "build" },
-    { state: "PRE_COMMIT", status: "RUNNING", lane: "build" },
-    { state: "CREATE_WORKTREE", status: "QUEUED", lane: "build" },
-    { state: "IMPLEMENT", status: "QUEUED", lane: "build" },
-    { state: "PRE_COMMIT", status: "QUEUED", lane: "build" },
-  ] satisfies readonly LaneCase[])(
-    "places $state with $status in Build",
-    ({ state, status, lane }) => {
-      expect(pipelineLaneFor({ state, status })).toBe(lane)
-    },
-  )
-
-  test.each([
-    { state: "REVIEW", status: "RUNNING", lane: "review" },
-    { state: "REVIEW", status: "QUEUED", lane: "review" },
-  ] satisfies readonly LaneCase[])(
-    "places $state with $status in Review",
-    ({ state, status, lane }) => {
-      expect(pipelineLaneFor({ state, status })).toBe(lane)
-    },
-  )
-
-  test.each([
-    { state: "COMMIT", status: "RUNNING", lane: "pr" },
-    { state: "CREATE_PR", status: "RUNNING", lane: "pr" },
-    { state: "WATCH_PR_STATUS_CHECKS", status: "RUNNING", lane: "pr" },
-    {
-      state: "WATCH_PR_STATUS_CHECKS",
-      status: "QUEUED",
-      lane: "pr",
-    },
-    {
-      state: "WATCH_PR_STATUS_CHECKS",
-      status: "WAITING_FOR_GITHUB",
-      lane: "pr",
-    },
-    {
-      state: "RESOLVE_PR_MERGE_CONFLICT",
-      status: "RUNNING",
-      lane: "pr",
-    },
-    {
-      state: "INVESTIGATE_PR_STATUS_CHECKS",
-      status: "RUNNING",
-      lane: "pr",
-    },
-    {
-      state: "MARK_PR_READY_FOR_REVIEW",
-      status: "RUNNING",
-      lane: "pr",
-    },
-    { state: "DECIDE_PR_MERGE", status: "RUNNING", lane: "pr" },
-    { state: "MERGE_PR", status: "RUNNING", lane: "pr" },
-    { state: "MERGE_PR", status: "QUEUED", lane: "pr" },
-    { state: "CLOSE_ISSUE", status: "RUNNING", lane: "pr" },
-    { state: "LOCAL_CLEANUP", status: "RUNNING", lane: "pr" },
-    { state: "COMMIT", status: "QUEUED", lane: "pr" },
-    { state: "CREATE_PR", status: "QUEUED", lane: "pr" },
-    { state: "MERGE_PR", status: "CANCELLED", lane: "pr" },
-  ] satisfies readonly LaneCase[])(
-    "places $state with $status in PR",
-    ({ state, status, lane }) => {
-      expect(pipelineLaneFor({ state, status })).toBe(lane)
-    },
-  )
-
-  test.each([
-    { state: "COMPLETE", status: "FAILED", lane: "attention" },
-    {
-      state: "CREATE_WORKTREE",
-      status: "SUCCEEDED",
-      lane: "complete",
-    },
-    {
-      state: "WATCH_PR_STATUS_CHECKS",
-      status: "FAILED",
-      lane: "attention",
-    },
-    {
-      state: "IMPLEMENT",
-      status: "WAITING_FOR_WORKER_SLOT",
-      lane: "queue",
-    },
-  ] satisfies readonly LaneCase[])(
-    "applies precedence to $state with $status",
-    ({ state, status, lane }) => {
-      expect(pipelineLaneFor({ state, status })).toBe(lane)
-    },
-  )
-
-  test("does not move a pending status-check poll between Queue and PR", () => {
-    expect(
-      pipelineLaneFor({
-        state: "WATCH_PR_STATUS_CHECKS",
-        status: "RUNNING",
-      }),
-    ).toBe("pr")
-    expect(
-      pipelineLaneFor({
-        state: "WATCH_PR_STATUS_CHECKS",
-        status: "QUEUED",
-      }),
-    ).toBe("pr")
+  test("returns null for unknown lane ids", () => {
+    expect(pipelineLaneIdFromServerLaneId("unknown")).toBeNull()
+    expect(pipelineLaneIdFromServerLaneId("complete")).toBeNull()
   })
 })
 

--- a/apps/harness/test/refresh-work-items-live.test.ts
+++ b/apps/harness/test/refresh-work-items-live.test.ts
@@ -4,6 +4,7 @@ import {
   committedPullRequestsCountQueryKeyPrefix,
   completedWorkItemsHistoryQueryKeyPrefix,
   followRepositoryWorkItemsLive,
+  kanbanStatusQueryKeyPrefix,
 } from "../src/refresh-work-items-live.js"
 import { describe, expect, test } from "bun:test"
 
@@ -162,6 +163,97 @@ describe("Repository Work Item live-query coordination", () => {
     )
     expect(onChange).toBeDefined()
 
+    controller.abort()
+    await live
+  })
+
+  test("an invalidation refetches active kanbanStatus projections", async () => {
+    const repositoryId = "repo-01JSELECTED000000000000000"
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    })
+
+    type KanbanPayload = {
+      readonly lanes: readonly { readonly id: string; readonly count: number }[]
+    }
+
+    let workItemsFetches = 0
+    let kanbanFetches = 0
+    let kanbanPayload: KanbanPayload = {
+      lanes: [{ id: "QUEUE", count: 0 }],
+    }
+
+    const workItemsQuery = {
+      queryKey: ["work-items", repositoryId] as const,
+      queryFn: async () => {
+        workItemsFetches += 1
+        return []
+      },
+    }
+    const kanbanStatusQuery = {
+      queryKey: [...kanbanStatusQueryKeyPrefix, null] as const,
+      queryFn: async (): Promise<KanbanPayload> => {
+        kanbanFetches += 1
+        return kanbanPayload
+      },
+    }
+
+    // Active observer so activeOnly refresh includes the projection.
+    const unsubscribeKanban = observeQuery(queryClient, kanbanStatusQuery)
+    await queryClient.fetchQuery({ ...workItemsQuery, staleTime: 0 })
+    await queryClient.fetchQuery({ ...kanbanStatusQuery, staleTime: 0 })
+    const kanbanFetchesAfterMount = kanbanFetches
+
+    let releaseInvalidation: (() => void) | undefined
+    const invalidation = new Promise<void>((resolve) => {
+      releaseInvalidation = resolve
+    })
+    let connected: (() => void) | undefined
+    const connectedPromise = new Promise<void>((resolve) => {
+      connected = resolve
+    })
+
+    const controller = new AbortController()
+    const live = followRepositoryWorkItemsLive({
+      getRepositoryIds: () => [repositoryId],
+      queryClient,
+      queries: {
+        workItems: () => workItemsQuery,
+      },
+      signal: controller.signal,
+      retryDelayMs: 10,
+      stream: async ({ onConnected, onChange, signal }) => {
+        await onConnected()
+        connected?.()
+        await invalidation
+        if (signal.aborted) return
+        await onChange(repositoryId)
+        await new Promise<void>((resolve) => {
+          if (signal.aborted) {
+            resolve()
+            return
+          }
+          signal.addEventListener("abort", () => resolve(), { once: true })
+        })
+      },
+    })
+
+    await connectedPromise
+    kanbanPayload = { lanes: [{ id: "BUILD", count: 1 }] }
+    const kanbanBeforeChange = kanbanFetches
+    releaseInvalidation?.()
+    await Bun.sleep(20)
+
+    expect(kanbanFetches).toBeGreaterThan(kanbanBeforeChange)
+    expect(kanbanFetches).toBeGreaterThan(kanbanFetchesAfterMount)
+    expect(
+      queryClient.getQueryData<KanbanPayload>(kanbanStatusQuery.queryKey),
+    ).toEqual({
+      lanes: [{ id: "BUILD", count: 1 }],
+    })
+    expect(workItemsFetches).toBeGreaterThan(1)
+
+    unsubscribeKanban()
     controller.abort()
     await live
   })

--- a/docs/kanban.md
+++ b/docs/kanban.md
@@ -88,8 +88,9 @@ Completed uses wider archive-style cards (journey legs, forge PR/MR badge,
 full session id) in a responsive grid and keeps repository filters in the
 sticky chrome.
 
-There are no separate Working or Failed list tabs. Pipeline still assembles
-tickets from the existing working, failed, and completed Work Item queries.
+There are no separate Working or Failed list tabs. Pipeline membership comes
+from the server `kanbanStatus` projection (shared with CLI status), not from
+client-side Working / Failed / Completed list assembly.
 
 The existing arrow-key tab behavior, selected-tab ARIA semantics,
 retry/reset/start/pause actions, Session usage dialog, issue links, and
@@ -98,13 +99,14 @@ pull-request links remain available.
 Repository filters sit above the board:
 
 - `All sources` shows every repository.
-- A repository filter limits every lane and the Completed tab to that
-  repository.
-- Filter selection is local UI state and does not alter repository settings or
-  the underlying queries.
+- A repository filter limits every Pipeline lane to that repository via the
+  shared projection (`kanbanStatus(repositoryId)` after the global source set).
+- Filter selection is local UI state and does not alter repository settings; it
+  selects which projection query the board loads. The Completed archive uses
+  its own history query and filters on `/completed`.
 
-Tickets remain sorted newest first within each lane. This gives recency without
-destroying the flow grouping supplied by the board.
+Tickets remain sorted newest first within each lane by the server projection.
+This gives recency without destroying the flow grouping supplied by the board.
 
 ## Ticket lifecycle chips (lane-scoped collapse)
 
@@ -188,19 +190,20 @@ workflow.
 The board should reuse existing Harness data boundaries behind that projection:
 
 - Repository list from the existing repository query.
-- Existing working, failed, and completed Work Item queries.
-- Existing issue queries to enrich ticket titles and URLs.
+- Server `kanbanStatus` GraphQL projection for lane membership and ordering.
+- Existing issue queries to enrich ticket titles and URLs only (not membership).
 - Existing Work Item controls, lifecycle-status presentation, Session usage
   dialog, copy control, and repository/action mutations.
 
-The projection should deduplicate Work Items assembled from the three list
-queries by Work Item ID before assigning lanes. The board should not create an
-additional polling loop.
+The server projection deduplicates Work Items from the shared source set by
+Work Item ID before assigning lanes. The board must not reassemble Working /
+Failed / Completed lists or reclassify lanes client-side, and must not create
+an additional polling loop.
 
 Keep lifecycle-chip presentation helpers close to the board module. Keep the
-lane classifier in the server projection and cover it with focused tests; it
-is a presentation policy that needs deliberate updates if the lifecycle gains
-new states.
+lane classifier in the server projection and cover it with GraphQL integration
+tests; the browser suite verifies consumption of that projection without
+duplicating classification cases.
 
 ## Route Seam
 

--- a/packages/graphql-api/src/lib/kanban-projection.ts
+++ b/packages/graphql-api/src/lib/kanban-projection.ts
@@ -1,11 +1,11 @@
 /**
  * Server-owned Kanban projection: lane membership, source windows, and
- * per-lane ordering. Shared by GraphQL `kanbanStatus` and (later) the visual
- * board so lane meaning cannot drift between clients.
+ * per-lane ordering. Shared by GraphQL `kanbanStatus`, the visual board, and
+ * CLI status so lane meaning cannot drift between clients.
  *
- * Lane rules match `docs/kanban.md` / harness `pipelineLaneFor`. Status and
- * state comparisons are case-insensitive so domain (lowercase) and GraphQL
- * (uppercase) shapes both classify correctly.
+ * Lane rules match `docs/kanban.md`. Status and state comparisons are
+ * case-insensitive so domain (lowercase) and GraphQL (uppercase) shapes both
+ * classify correctly.
  */
 import {
   JOBS_COMPLETED_WINDOW_MS,


### PR DESCRIPTION
Why

CLI status and the visual board must share one Harness-owned Kanban
projection so lane membership, source windows, and ordering cannot drift.
The board still assembled Working/Failed/Completed lists and classified
lanes in the browser after #977 landed the server projection.

What changed

- Home Pipeline loads kanbanStatus(repositoryId?) for membership and order;
  maps GraphQL lane ids to UI lanes (MERGED to complete).
- Removes client pipelineLaneFor, failed-cap merge, and client-side sort.
- Live Work Item / Issues SSE refreshes active kanban-status caches;
  pause/start/retry/reset patch nested ticket fields without reclassifying.
- Repository filter uses the server argument (no cross-key placeholder that
  painted the previous source set under a new filter).
- Keeps ticket controls, issue enrichment, lifecycle-chip collapse, route
  flights, mobile lane selector, zero-repo blank slate, Completed archive.
- Browser tests assert projection consumption; GraphQL suite remains
  authoritative for membership, windows, filtering, and ordering.
- Updates docs/kanban.md for the server-owned board model.

Verification

- bunx nx run-many -t typecheck,lint,test,knip -p harness
- Focused: kanban-route, pipeline-lanes, refresh-work-items-live
- bunx nx test graphql-api (kanban projection / kanbanStatus suite)

Notes

Optimistic control patches update ticket fields in place; lane moves wait
for SSE or a fresh kanbanStatus fetch (no client reclassification).

Closes #979