### PR TITLE
feat(cli): run Repository Intake end to end via GraphQL and intake command

### DIFF
--- a/apps/harness/e2e/features/repository-intake-cli.feature
+++ b/apps/harness/e2e/features/repository-intake-cli.feature
@@ -1,0 +1,21 @@
+Feature: Repository Intake CLI automation
+  Automated operators discover Intake Candidates, start them through
+  Repository Intake, and inspect Kanban status through the compiled CLI and
+  real GraphQL endpoint.
+
+  Scenario: candidates then intake then status for a Fixture Repository
+    Given the Harness has no configured Repositories
+    And the Harness has a configured default build model
+    And the End-to-End Fixture Repository is checked out
+    When I add the Repository with the CLI
+    Then the Repository appears in the Harness
+    And the sentinel Issue appears after the automatic first Refresh Job
+    When I run candidates for the Fixture Repository with the CLI
+    Then candidates JSON includes the sentinel Issue as IMPLEMENT_NOW
+    When I run intake for the Fixture Repository with the CLI
+    Then intake JSON creates a Work Item for the sentinel Issue
+    When I run status for the Fixture Repository with the CLI
+    Then status JSON includes the sentinel Work Item
+    When I run candidates for the Fixture Repository with the CLI again
+    Then candidates JSON omits the sentinel Issue
+    And I clean up Work Items created by Intake

--- a/apps/harness/e2e/steps/fixtures.ts
+++ b/apps/harness/e2e/steps/fixtures.ts
@@ -6,6 +6,35 @@ export type LiveE2eWorld = {
   cleanupFixtureCheckout?: () => void
   fixtureForge?: FixtureForge
   fixtureDisplayRepository?: string
+  /** Repository Intake CLI scenario state (issue #978). */
+  intakeCandidatesResult?: {
+    readonly status: number | null
+    readonly stdout: string
+    readonly stderr: string
+    readonly document: unknown
+  }
+  intakeCandidatesRerunResult?: {
+    readonly status: number | null
+    readonly stdout: string
+    readonly stderr: string
+    readonly document: unknown
+  }
+  intakeIntakeResult?: {
+    readonly status: number | null
+    readonly stdout: string
+    readonly stderr: string
+    readonly document: unknown
+  }
+  intakeStatusResult?: {
+    readonly status: number | null
+    readonly stdout: string
+    readonly stderr: string
+    readonly document: unknown
+  }
+  intakeCreatedWorkItemId?: string
+  /** All Work Item ids created by Intake in this scenario (for teardown). */
+  intakeCreatedWorkItemIds?: readonly string[]
+  intakeRepositoryId?: string
 }
 
 export const test = base.extend<{ world: LiveE2eWorld }>({

--- a/apps/harness/e2e/steps/repository-intake-cli.ts
+++ b/apps/harness/e2e/steps/repository-intake-cli.ts
@@ -20,6 +20,9 @@ const workspaceRoot = resolve(
   "../../../..",
 )
 
+/** Operator CLI package root — run main.ts here, not via nx, for clean JSON. */
+const readyForAgentPackageRoot = resolve(workspaceRoot, "apps/ready-for-agent")
+
 const fixtureSelector = `github.com/${FIXTURE_GITHUB_REPOSITORY}`
 
 /** Bound wait for Create Worktree / failed agent steps before suite cleanup. */
@@ -93,17 +96,24 @@ const parseExactlyOneJsonDocument = (text: string): unknown => {
 }
 
 const runFiniteCli = (args: readonly string[]): CliJsonResult => {
-  const result = spawnSync("bun", ["run", "ready-for-agent", ...args], {
-    cwd: workspaceRoot,
-    env: {
-      ...process.env,
-      READY_FOR_AGENT_GRAPHQL_URL: E2E_GRAPHQL_URL,
-      NO_COLOR: "1",
-      FORCE_COLOR: "0",
+  // Invoke the operator CLI entrypoint directly (same seam as cli-process
+  // tests). `bun run ready-for-agent` goes through nx and prints banners
+  // that break the one-JSON-document contract on stdout.
+  const result = spawnSync(
+    "bun",
+    ["--conditions", "@ready-for-agent/source", "src/main.ts", ...args],
+    {
+      cwd: readyForAgentPackageRoot,
+      env: {
+        ...process.env,
+        READY_FOR_AGENT_GRAPHQL_URL: E2E_GRAPHQL_URL,
+        NO_COLOR: "1",
+        FORCE_COLOR: "0",
+      },
+      encoding: "utf8",
+      timeout: 120_000,
     },
-    encoding: "utf8",
-    timeout: 120_000,
-  })
+  )
   const stdout = result.stdout ?? ""
   const stderr = result.stderr ?? ""
   if (result.error) {

--- a/apps/harness/e2e/steps/repository-intake-cli.ts
+++ b/apps/harness/e2e/steps/repository-intake-cli.ts
@@ -1,0 +1,378 @@
+/**
+ * Live e2e for Repository Intake CLI: candidates → intake → status through
+ * the compiled operator binary and real GraphQL endpoint (issue #978).
+ */
+
+import { spawnSync } from "node:child_process"
+import { dirname, resolve } from "node:path"
+import { fileURLToPath } from "node:url"
+import { expect } from "@playwright/test"
+import {
+  E2E_GRAPHQL_URL,
+  FIXTURE_GITHUB_REPOSITORY,
+  GITHUB_SENTINEL_ISSUE_NUMBER,
+  GITHUB_SENTINEL_ISSUE_TITLE,
+  SCENARIO_TIMEOUT_MS,
+} from "../support/constants.ts"
+import { Then, When, test } from "./fixtures.ts"
+
+const workspaceRoot = resolve(
+  dirname(fileURLToPath(import.meta.url)),
+  "../../../..",
+)
+
+const fixtureSelector = `github.com/${FIXTURE_GITHUB_REPOSITORY}`
+
+/** Bound wait for Create Worktree / failed agent steps before suite cleanup. */
+const INTAKE_CLEANUP_TIMEOUT_MS = 90_000
+
+type CliJsonResult = {
+  readonly status: number | null
+  readonly stdout: string
+  readonly stderr: string
+  readonly document: unknown
+}
+
+class GraphQlRequestError extends Error {
+  readonly codes: ReadonlyArray<string>
+
+  constructor(messages: ReadonlyArray<string>, codes: ReadonlyArray<string>) {
+    super(`GraphQL errors: ${messages.join("; ")}`)
+    this.name = "GraphQlRequestError"
+    this.codes = codes
+  }
+}
+
+const graphqlRequest = async <T>(
+  query: string,
+  variables?: Record<string, unknown>,
+): Promise<T> => {
+  const response = await fetch(E2E_GRAPHQL_URL, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ query, variables }),
+  })
+  if (!response.ok) {
+    throw new Error(`GraphQL HTTP ${response.status}: ${await response.text()}`)
+  }
+  const payload = (await response.json()) as {
+    data?: T
+    errors?: ReadonlyArray<{
+      message: string
+      extensions?: { code?: string }
+    }>
+  }
+  if (payload.errors?.length) {
+    throw new GraphQlRequestError(
+      payload.errors.map((e) => e.message),
+      payload.errors.map((e) => e.extensions?.code ?? ""),
+    )
+  }
+  if (!payload.data) {
+    throw new Error("GraphQL response missing data")
+  }
+  return payload.data
+}
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
+
+const parseExactlyOneJsonDocument = (text: string): unknown => {
+  const lines = text
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0)
+  if (lines.length !== 1) {
+    throw new Error(
+      `Expected exactly one JSON document, got ${lines.length}:\n${text}`,
+    )
+  }
+  const line = lines[0]
+  if (line === undefined) {
+    throw new Error(`Expected one JSON document, got empty output:\n${text}`)
+  }
+  return JSON.parse(line)
+}
+
+const runFiniteCli = (args: readonly string[]): CliJsonResult => {
+  const result = spawnSync("bun", ["run", "ready-for-agent", ...args], {
+    cwd: workspaceRoot,
+    env: {
+      ...process.env,
+      READY_FOR_AGENT_GRAPHQL_URL: E2E_GRAPHQL_URL,
+      NO_COLOR: "1",
+      FORCE_COLOR: "0",
+    },
+    encoding: "utf8",
+    timeout: 120_000,
+  })
+  const stdout = result.stdout ?? ""
+  const stderr = result.stderr ?? ""
+  if (result.error) {
+    throw result.error
+  }
+  // Partial Intake writes success-shaped JSON to stdout with nonzero exit.
+  // Command-level failures write error JSON to stderr only.
+  const stream = stdout.trim().length > 0 ? stdout : stderr
+  let document: unknown
+  try {
+    document = parseExactlyOneJsonDocument(stream)
+  } catch (error) {
+    throw new Error(
+      [
+        `CLI ${args.join(" ")} produced invalid JSON (exit ${result.status}).`,
+        `stdout:\n${stdout}`,
+        `stderr:\n${stderr}`,
+        error instanceof Error ? error.message : String(error),
+      ].join("\n"),
+    )
+  }
+  return {
+    status: result.status,
+    stdout,
+    stderr,
+    document,
+  }
+}
+
+test.setTimeout(SCENARIO_TIMEOUT_MS)
+
+// Reuse add/refresh Given/When/Then from add-and-refresh-repository steps.
+// Configure model via settings-browser-history "configured default build model".
+
+When(
+  "I run candidates for the Fixture Repository with the CLI",
+  async ({ world }) => {
+    const result = runFiniteCli(["candidates", fixtureSelector])
+    world.intakeCandidatesResult = result
+  },
+)
+
+When(
+  "I run candidates for the Fixture Repository with the CLI again",
+  async ({ world }) => {
+    const result = runFiniteCli(["candidates", fixtureSelector])
+    world.intakeCandidatesRerunResult = result
+  },
+)
+
+When(
+  "I run intake for the Fixture Repository with the CLI",
+  async ({ world }) => {
+    const result = runFiniteCli(["intake", fixtureSelector])
+    world.intakeIntakeResult = result
+  },
+)
+
+When(
+  "I run status for the Fixture Repository with the CLI",
+  async ({ world }) => {
+    const result = runFiniteCli(["status", fixtureSelector])
+    world.intakeStatusResult = result
+  },
+)
+
+Then(
+  "candidates JSON includes the sentinel Issue as IMPLEMENT_NOW",
+  async ({ world }) => {
+    const result = world.intakeCandidatesResult as CliJsonResult | undefined
+    if (result === undefined) {
+      throw new Error("candidates CLI result missing from scenario world")
+    }
+    expect(result.status).toBe(0)
+    expect(result.stderr.trim()).toBe("")
+    const doc = result.document as {
+      command: string
+      candidates: ReadonlyArray<{
+        issueNumber: number
+        title: string
+        action: string
+      }>
+    }
+    expect(doc.command).toBe("candidates")
+    const sentinel = doc.candidates.find(
+      (candidate) => candidate.issueNumber === GITHUB_SENTINEL_ISSUE_NUMBER,
+    )
+    expect(sentinel).toBeDefined()
+    expect(sentinel?.title).toBe(GITHUB_SENTINEL_ISSUE_TITLE)
+    expect(sentinel?.action).toBe("IMPLEMENT_NOW")
+  },
+)
+
+Then(
+  "intake JSON creates a Work Item for the sentinel Issue",
+  async ({ world }) => {
+    const result = world.intakeIntakeResult as CliJsonResult | undefined
+    if (result === undefined) {
+      throw new Error("intake CLI result missing from scenario world")
+    }
+    expect(result.stderr.trim()).toBe("")
+    const doc = result.document as {
+      command: string
+      results: ReadonlyArray<{
+        issueNumber: number
+        outcome: string
+        workItem?: { id: string; state: string; status: string }
+        error?: { code: string; message: string }
+      }>
+    }
+    expect(doc.command).toBe("intake")
+    const repository = (
+      result.document as {
+        repository?: { id?: string }
+      }
+    ).repository
+    if (typeof repository?.id === "string" && repository.id.length > 0) {
+      world.intakeRepositoryId = repository.id
+    }
+    const createdIds: string[] = []
+    for (const entry of doc.results) {
+      if (
+        entry.outcome === "CREATED" &&
+        typeof entry.workItem?.id === "string" &&
+        entry.workItem.id.length > 0
+      ) {
+        createdIds.push(entry.workItem.id)
+      }
+    }
+    world.intakeCreatedWorkItemIds = createdIds
+    const sentinel = doc.results.find(
+      (entry) => entry.issueNumber === GITHUB_SENTINEL_ISSUE_NUMBER,
+    )
+    expect(sentinel).toBeDefined()
+    expect(sentinel?.outcome).toBe("CREATED")
+    expect(sentinel?.workItem?.id).toMatch(/\S/)
+    expect(sentinel?.workItem?.state).toMatch(/\S/)
+    expect(sentinel?.workItem?.status).toMatch(/\S/)
+    // Other fixture Issues may fail or succeed; only require sentinel created
+    // and a zero exit when every listed result was created.
+    const anyFailed = doc.results.some((entry) => entry.outcome === "FAILED")
+    expect(result.status).toBe(anyFailed ? 1 : 0)
+    world.intakeCreatedWorkItemId = sentinel?.workItem?.id
+  },
+)
+
+Then("status JSON includes the sentinel Work Item", async ({ world }) => {
+  const result = world.intakeStatusResult as CliJsonResult | undefined
+  if (result === undefined) {
+    throw new Error("status CLI result missing from scenario world")
+  }
+  expect(result.status).toBe(0)
+  expect(result.stderr.trim()).toBe("")
+  const doc = result.document as {
+    command: string
+    lanes: ReadonlyArray<{
+      id: string
+      workItems: ReadonlyArray<{
+        id: string
+        issueNumber: number
+        issueTitle: string | null
+      }>
+    }>
+  }
+  expect(doc.command).toBe("status")
+  expect(doc.lanes).toHaveLength(6)
+  const allRows = doc.lanes.flatMap((lane) => lane.workItems)
+  const sentinelRow = allRows.find(
+    (row) => row.issueNumber === GITHUB_SENTINEL_ISSUE_NUMBER,
+  )
+  expect(sentinelRow).toBeDefined()
+  const expectedId = world.intakeCreatedWorkItemId as string | undefined
+  if (expectedId !== undefined) {
+    expect(sentinelRow?.id).toBe(expectedId)
+  }
+})
+
+Then("candidates JSON omits the sentinel Issue", async ({ world }) => {
+  const result = world.intakeCandidatesRerunResult as CliJsonResult | undefined
+  if (result === undefined) {
+    throw new Error("candidates rerun CLI result missing from scenario world")
+  }
+  expect(result.status).toBe(0)
+  const doc = result.document as {
+    command: string
+    candidates: ReadonlyArray<{ issueNumber: number }>
+  }
+  expect(doc.command).toBe("candidates")
+  expect(
+    doc.candidates.some(
+      (candidate) => candidate.issueNumber === GITHUB_SENTINEL_ISSUE_NUMBER,
+    ),
+  ).toBe(false)
+})
+
+/**
+ * Scenario-local teardown so later e2e scenarios can remove the Repository
+ * without waiting on Create Worktree / agent Step Runs left by Intake.
+ */
+Then("I clean up Work Items created by Intake", async ({ world }) => {
+  const workItemIds = [
+    ...(world.intakeCreatedWorkItemIds ?? []),
+    ...(world.intakeCreatedWorkItemId === undefined
+      ? []
+      : [world.intakeCreatedWorkItemId]),
+  ]
+  const uniqueIds = [...new Set(workItemIds)]
+  if (uniqueIds.length === 0) {
+    return
+  }
+
+  const repositoryId = world.intakeRepositoryId
+  const deadline = Date.now() + INTAKE_CLEANUP_TIMEOUT_MS
+
+  // Wait until no Work Item for this Repository reports RUNNING (active Step Run).
+  if (repositoryId !== undefined) {
+    while (Date.now() < deadline) {
+      const listed = await graphqlRequest<{
+        workItems: ReadonlyArray<{ id: string; status: string }>
+      }>(
+        `query WorkItems($repositoryId: ID!) {
+          workItems(repositoryId: $repositoryId) {
+            id
+            status
+          }
+        }`,
+        { repositoryId },
+      )
+      const running = listed.workItems.filter(
+        (workItem) => workItem.status === "RUNNING",
+      )
+      if (running.length === 0) {
+        break
+      }
+      await sleep(500)
+    }
+  }
+
+  for (const workItemId of uniqueIds) {
+    while (true) {
+      if (Date.now() >= deadline) {
+        throw new Error(
+          `Timed out cleaning up Intake Work Item ${workItemId} after ${INTAKE_CLEANUP_TIMEOUT_MS}ms`,
+        )
+      }
+      try {
+        await graphqlRequest(
+          `mutation ResetWorkItem($workItemId: ID!) {
+            resetWorkItem(workItemId: $workItemId)
+          }`,
+          { workItemId },
+        )
+        break
+      } catch (error) {
+        if (
+          error instanceof GraphQlRequestError &&
+          (error.codes.includes("ACTIVE_STEP_RUN_EXISTS") ||
+            error.codes.includes("WORK_ITEM_NOT_FOUND"))
+        ) {
+          // Still running, or already gone after a concurrent remove — retry / skip.
+          if (error.codes.includes("WORK_ITEM_NOT_FOUND")) {
+            break
+          }
+          await sleep(500)
+          continue
+        }
+        throw error
+      }
+    }
+  }
+})

--- a/apps/harness/e2e/steps/repository-intake-cli.ts
+++ b/apps/harness/e2e/steps/repository-intake-cli.ts
@@ -12,9 +12,8 @@ import {
   FIXTURE_GITHUB_REPOSITORY,
   GITHUB_SENTINEL_ISSUE_NUMBER,
   GITHUB_SENTINEL_ISSUE_TITLE,
-  SCENARIO_TIMEOUT_MS,
 } from "../support/constants.ts"
-import { Then, When, test } from "./fixtures.ts"
+import { Then, When } from "./fixtures.ts"
 
 const workspaceRoot = resolve(
   dirname(fileURLToPath(import.meta.url)),
@@ -134,7 +133,10 @@ const runFiniteCli = (args: readonly string[]): CliJsonResult => {
   }
 }
 
-test.setTimeout(SCENARIO_TIMEOUT_MS)
+// Scenario timeout comes from playwright.config (SCENARIO_TIMEOUT_MS) and from
+// the shared Given "the Harness has no configured Repositories", which calls
+// test.setTimeout inside a running test. Do not call test.setTimeout at module
+// load — bddgen imports step files outside a test and Playwright throws.
 
 // Reuse add/refresh Given/When/Then from add-and-refresh-repository steps.
 // Configure model via settings-browser-history "configured default build model".

--- a/apps/ready-for-agent/src/cli-json.test.ts
+++ b/apps/ready-for-agent/src/cli-json.test.ts
@@ -4,8 +4,10 @@ import {
   buildAddSuccessDocument,
   buildCandidatesSuccessDocument,
   buildCommandErrorDocument,
+  buildIntakeSuccessDocument,
   buildStatusSuccessDocument,
   encodeCompactJson,
+  intakeHasFailedResults,
   localGitErrorCode,
 } from "./cli-json.ts"
 import { describe, expect, test } from "bun:test"
@@ -122,6 +124,56 @@ describe("finite CLI JSON contract", () => {
       ],
     })
     expect(encodeCompactJson(doc)).toContain('"issuesReconciledAt":null')
+  })
+
+  test("intake success document discriminates CREATED and FAILED outcomes", () => {
+    const doc = buildIntakeSuccessDocument({
+      repository: {
+        id: "repo-1",
+        forge: "github",
+        forgeHost: "github.com",
+        projectPath: "owner/repo",
+      },
+      issuesReconciledAt: "2026-08-12T10:00:00.000Z",
+      results: [
+        {
+          issueNumber: 101,
+          title: "Implement feature",
+          url: "https://github.com/owner/repo/issues/101",
+          action: "IMPLEMENT_NOW",
+          outcome: "CREATED",
+          workItem: {
+            id: "wi-1",
+            state: "CREATE_WORKTREE",
+            status: "QUEUED",
+          },
+        },
+        {
+          issueNumber: 102,
+          title: "Blocked follow-up",
+          url: "https://github.com/owner/repo/issues/102",
+          action: "QUEUE",
+          outcome: "FAILED",
+          error: {
+            code: "UNFINISHED_WORK_ITEM_EXISTS",
+            message: "Issue #102 already has an unfinished Work Item",
+          },
+        },
+      ],
+    })
+    expect(doc.command).toBe("intake")
+    expect(doc.results).toHaveLength(2)
+    expect(doc.results[0]).toMatchObject({
+      outcome: "CREATED",
+      workItem: { id: "wi-1" },
+    })
+    expect(doc.results[1]).toMatchObject({
+      outcome: "FAILED",
+      error: { code: "UNFINISHED_WORK_ITEM_EXISTS" },
+    })
+    expect(intakeHasFailedResults(doc.results)).toBe(true)
+    expect(encodeCompactJson(doc)).toContain('"outcome":"CREATED"')
+    expect(encodeCompactJson(doc)).toContain('"outcome":"FAILED"')
   })
 
   test("command-level error document is versioned and nested under error", () => {

--- a/apps/ready-for-agent/src/cli-json.ts
+++ b/apps/ready-for-agent/src/cli-json.ts
@@ -40,7 +40,7 @@ export type CandidatesSuccessDocument = {
   }[]
 }
 
-export type IntakeCreatedResult = {
+type IntakeCreatedResult = {
   readonly issueNumber: number
   readonly title: string
   readonly url: string
@@ -53,7 +53,7 @@ export type IntakeCreatedResult = {
   }
 }
 
-export type IntakeFailedResult = {
+type IntakeFailedResult = {
   readonly issueNumber: number
   readonly title: string
   readonly url: string

--- a/apps/ready-for-agent/src/cli-json.ts
+++ b/apps/ready-for-agent/src/cli-json.ts
@@ -7,7 +7,7 @@ export const CLI_SCHEMA_VERSION = 1 as const
  * Finite operator commands that emit one versioned JSON document.
  * Long-running `start` is intentionally excluded.
  */
-export type FiniteCommandName = "add" | "candidates" | "status"
+export type FiniteCommandName = "add" | "candidates" | "intake" | "status"
 
 /** Canonical Repository identity shared across finite CLI JSON documents. */
 export type CanonicalRepositoryIdentity = {
@@ -38,6 +38,42 @@ export type CandidatesSuccessDocument = {
     readonly url: string
     readonly action: IntakeCandidateAction
   }[]
+}
+
+export type IntakeCreatedResult = {
+  readonly issueNumber: number
+  readonly title: string
+  readonly url: string
+  readonly action: IntakeCandidateAction
+  readonly outcome: "CREATED"
+  readonly workItem: {
+    readonly id: string
+    readonly state: string
+    readonly status: string
+  }
+}
+
+export type IntakeFailedResult = {
+  readonly issueNumber: number
+  readonly title: string
+  readonly url: string
+  readonly action: IntakeCandidateAction
+  readonly outcome: "FAILED"
+  readonly error: {
+    readonly code: string
+    readonly message: string
+  }
+}
+
+/** Discriminated per-Issue Intake outcome for CLI JSON (CREATED | FAILED). */
+export type IntakeIssueResult = IntakeCreatedResult | IntakeFailedResult
+
+export type IntakeSuccessDocument = {
+  readonly schemaVersion: typeof CLI_SCHEMA_VERSION
+  readonly command: "intake"
+  readonly repository: CanonicalRepositoryIdentity
+  readonly issuesReconciledAt: string | null
+  readonly results: readonly IntakeIssueResult[]
 }
 
 export type StatusLaneId =
@@ -130,6 +166,23 @@ export const buildCandidatesSuccessDocument = (input: {
   candidates: input.candidates,
 })
 
+export const buildIntakeSuccessDocument = (input: {
+  readonly repository: CanonicalRepositoryIdentity
+  readonly issuesReconciledAt: string | null
+  readonly results: readonly IntakeIssueResult[]
+}): IntakeSuccessDocument => ({
+  schemaVersion: CLI_SCHEMA_VERSION,
+  command: "intake",
+  repository: input.repository,
+  issuesReconciledAt: input.issuesReconciledAt,
+  results: input.results,
+})
+
+/** True when any candidate-local failure is present (CLI exits nonzero). */
+export const intakeHasFailedResults = (
+  results: readonly IntakeIssueResult[],
+): boolean => results.some((result) => result.outcome === "FAILED")
+
 export const toCanonicalRepositoryIdentity = (repository: {
   readonly id: string
   readonly forge: string
@@ -165,7 +218,12 @@ export const buildCommandErrorDocument = (options: {
   },
 })
 
-const FiniteCommandNameSchema = Schema.Literals(["add", "candidates", "status"])
+const FiniteCommandNameSchema = Schema.Literals([
+  "add",
+  "candidates",
+  "intake",
+  "status",
+])
 
 /**
  * Expected finite-command failure. Marked as already reported so

--- a/apps/ready-for-agent/src/cli-process.test.ts
+++ b/apps/ready-for-agent/src/cli-process.test.ts
@@ -16,6 +16,7 @@ import {
   CLI_SCHEMA_VERSION,
   buildAddSuccessDocument,
   buildCandidatesSuccessDocument,
+  buildIntakeSuccessDocument,
   buildStatusSuccessDocument,
 } from "./cli-json.ts"
 import {
@@ -459,6 +460,304 @@ describe("operator binary finite-command process contract", () => {
       })
       expect(result.stderr).not.toMatch(/\s+at\s+\S+\s+\(/)
       expect(result.stderr).not.toContain("FiniteCommandFailed:")
+    } finally {
+      await closeServer(server)
+    }
+  })
+
+  test("intake complete success emits JSON on stdout and exits 0", async () => {
+    const seenBodies: string[] = []
+    const server = createServer((req, res) => {
+      if (req.method !== "POST") {
+        res.writeHead(405)
+        res.end()
+        return
+      }
+      const chunks: Buffer[] = []
+      req.on("data", (chunk: Buffer) => {
+        chunks.push(chunk)
+      })
+      req.on("end", () => {
+        const body = Buffer.concat(chunks).toString("utf8")
+        seenBodies.push(body)
+        res.writeHead(200, { "content-type": "application/json" })
+        if (body.includes("repositories")) {
+          res.end(
+            JSON.stringify({
+              data: {
+                repositories: [
+                  {
+                    id: "repo-process-1",
+                    forge: "github",
+                    forgeHost: "github.com",
+                    projectPath: "owner/repo",
+                  },
+                ],
+              },
+            }),
+          )
+          return
+        }
+        res.end(
+          JSON.stringify({
+            data: {
+              startRepositoryIntake: {
+                repository: {
+                  id: "repo-process-1",
+                  forge: "github",
+                  forgeHost: "github.com",
+                  projectPath: "owner/repo",
+                  issuesReconciledAt: "2026-08-12T10:00:00.000Z",
+                },
+                results: [
+                  {
+                    __typename: "RepositoryIntakeCreated",
+                    issueNumber: 7,
+                    title: "Ready",
+                    url: "https://github.com/owner/repo/issues/7",
+                    action: "IMPLEMENT_NOW",
+                    workItem: {
+                      id: "wi-7",
+                      state: "CREATE_WORKTREE",
+                      status: "QUEUED",
+                    },
+                  },
+                ],
+              },
+            },
+          }),
+        )
+      })
+    })
+
+    try {
+      const port = await listen(server)
+      const result = await runCli(
+        ["intake", "GitHub.com/Owner/Repo"],
+        `http://127.0.0.1:${port}/graphql`,
+      )
+
+      expect(result.status).toBe(0)
+      expect(result.stderr.trim()).toBe("")
+      expect(
+        seenBodies.some((body) => body.includes("startRepositoryIntake")),
+      ).toBe(true)
+      expect(parseExactlyOneJsonDocument(result.stdout)).toEqual(
+        buildIntakeSuccessDocument({
+          repository: {
+            id: "repo-process-1",
+            forge: "github",
+            forgeHost: "github.com",
+            projectPath: "owner/repo",
+          },
+          issuesReconciledAt: "2026-08-12T10:00:00.000Z",
+          results: [
+            {
+              issueNumber: 7,
+              title: "Ready",
+              url: "https://github.com/owner/repo/issues/7",
+              action: "IMPLEMENT_NOW",
+              outcome: "CREATED",
+              workItem: {
+                id: "wi-7",
+                state: "CREATE_WORKTREE",
+                status: "QUEUED",
+              },
+            },
+          ],
+        }),
+      )
+    } finally {
+      await closeServer(server)
+    }
+  })
+
+  test("intake partial failure emits result JSON on stdout and exits 1", async () => {
+    const server = createServer((req, res) => {
+      if (req.method !== "POST") {
+        res.writeHead(405)
+        res.end()
+        return
+      }
+      const chunks: Buffer[] = []
+      req.on("data", (chunk: Buffer) => {
+        chunks.push(chunk)
+      })
+      req.on("end", () => {
+        const body = Buffer.concat(chunks).toString("utf8")
+        res.writeHead(200, { "content-type": "application/json" })
+        if (body.includes("repositories")) {
+          res.end(
+            JSON.stringify({
+              data: {
+                repositories: [
+                  {
+                    id: "repo-process-1",
+                    forge: "github",
+                    forgeHost: "github.com",
+                    projectPath: "owner/repo",
+                  },
+                ],
+              },
+            }),
+          )
+          return
+        }
+        res.end(
+          JSON.stringify({
+            data: {
+              startRepositoryIntake: {
+                repository: {
+                  id: "repo-process-1",
+                  forge: "github",
+                  forgeHost: "github.com",
+                  projectPath: "owner/repo",
+                  issuesReconciledAt: null,
+                },
+                results: [
+                  {
+                    __typename: "RepositoryIntakeCreated",
+                    issueNumber: 7,
+                    title: "Ready",
+                    url: "https://github.com/owner/repo/issues/7",
+                    action: "IMPLEMENT_NOW",
+                    workItem: {
+                      id: "wi-7",
+                      state: "CREATE_WORKTREE",
+                      status: "QUEUED",
+                    },
+                  },
+                  {
+                    __typename: "RepositoryIntakeFailed",
+                    issueNumber: 9,
+                    title: "Race",
+                    url: "https://github.com/owner/repo/issues/9",
+                    action: "QUEUE",
+                    error: {
+                      code: "UNFINISHED_WORK_ITEM_EXISTS",
+                      message: "Issue #9 already has an unfinished Work Item",
+                    },
+                  },
+                ],
+              },
+            },
+          }),
+        )
+      })
+    })
+
+    try {
+      const port = await listen(server)
+      const result = await runCli(
+        ["intake", "github.com/owner/repo"],
+        `http://127.0.0.1:${port}/graphql`,
+      )
+
+      expect(result.status).toBe(1)
+      expect(result.stderr.trim()).toBe("")
+      expect(parseExactlyOneJsonDocument(result.stdout)).toEqual(
+        buildIntakeSuccessDocument({
+          repository: {
+            id: "repo-process-1",
+            forge: "github",
+            forgeHost: "github.com",
+            projectPath: "owner/repo",
+          },
+          issuesReconciledAt: null,
+          results: [
+            {
+              issueNumber: 7,
+              title: "Ready",
+              url: "https://github.com/owner/repo/issues/7",
+              action: "IMPLEMENT_NOW",
+              outcome: "CREATED",
+              workItem: {
+                id: "wi-7",
+                state: "CREATE_WORKTREE",
+                status: "QUEUED",
+              },
+            },
+            {
+              issueNumber: 9,
+              title: "Race",
+              url: "https://github.com/owner/repo/issues/9",
+              action: "QUEUE",
+              outcome: "FAILED",
+              error: {
+                code: "UNFINISHED_WORK_ITEM_EXISTS",
+                message: "Issue #9 already has an unfinished Work Item",
+              },
+            },
+          ],
+        }),
+      )
+    } finally {
+      await closeServer(server)
+    }
+  })
+
+  test("intake GraphQL operation failure preserves extensions.code on stderr", async () => {
+    const server = createServer((req, res) => {
+      if (req.method !== "POST") {
+        res.writeHead(405)
+        res.end()
+        return
+      }
+      const chunks: Buffer[] = []
+      req.on("data", (chunk: Buffer) => {
+        chunks.push(chunk)
+      })
+      req.on("end", () => {
+        const body = Buffer.concat(chunks).toString("utf8")
+        res.writeHead(200, { "content-type": "application/json" })
+        if (body.includes("repositories")) {
+          res.end(
+            JSON.stringify({
+              data: {
+                repositories: [
+                  {
+                    id: "repo-process-1",
+                    forge: "github",
+                    forgeHost: "github.com",
+                    projectPath: "owner/repo",
+                  },
+                ],
+              },
+            }),
+          )
+          return
+        }
+        res.end(
+          JSON.stringify({
+            data: null,
+            errors: [
+              {
+                message: "Agent Backend is unavailable",
+                extensions: { code: "AGENT_BACKEND_UNAVAILABLE" },
+              },
+            ],
+          }),
+        )
+      })
+    })
+
+    try {
+      const port = await listen(server)
+      const result = await runCli(
+        ["intake", "github.com/owner/repo"],
+        `http://127.0.0.1:${port}/graphql`,
+      )
+
+      expect(result.status).toBe(1)
+      expect(result.stdout.trim()).toBe("")
+      expect(parseExactlyOneJsonDocument(result.stderr)).toEqual({
+        schemaVersion: CLI_SCHEMA_VERSION,
+        command: "intake",
+        error: {
+          code: "AGENT_BACKEND_UNAVAILABLE",
+          message: "Agent Backend is unavailable",
+        },
+      })
     } finally {
       await closeServer(server)
     }

--- a/apps/ready-for-agent/src/cli.test.ts
+++ b/apps/ready-for-agent/src/cli.test.ts
@@ -11,6 +11,7 @@ import {
   FiniteCommandFailed,
   buildAddSuccessDocument,
   buildCandidatesSuccessDocument,
+  buildIntakeSuccessDocument,
   buildStatusSuccessDocument,
   encodeCompactJson,
 } from "./cli-json.ts"
@@ -33,6 +34,8 @@ const unusedGraphql = {
   addRepository: () => Effect.die("addRepository should not run"),
   listRepositories: Effect.die("listRepositories should not run"),
   intakeCandidates: () => Effect.die("intakeCandidates should not run"),
+  startRepositoryIntake: () =>
+    Effect.die("startRepositoryIntake should not run"),
   kanbanStatus: () => Effect.die("kanbanStatus should not run"),
 } as const
 
@@ -507,6 +510,317 @@ describe("operator binary CLI seam", () => {
     }),
   )
 
+  it.live("intake emits versioned JSON and keeps exit 0 when all created", () =>
+    Effect.gen(function* () {
+      const logs: string[] = []
+      const originalLog = console.log
+      const previousExitCode = process.exitCode
+      console.log = (...args: unknown[]) => {
+        logs.push(args.map(String).join(" "))
+      }
+      process.exitCode = undefined
+
+      try {
+        let requestedId: string | undefined
+        const layer = mockStart.pipe(
+          Layer.provideMerge(mockLocalGit),
+          Layer.provideMerge(
+            Layer.succeed(GraphqlApi, {
+              ...unusedGraphql,
+              listRepositories: Effect.succeed([
+                {
+                  id: "repo-1",
+                  forge: "github",
+                  forgeHost: "github.com",
+                  projectPath: "Owner/Repo",
+                },
+              ]),
+              startRepositoryIntake: (repositoryId) =>
+                Effect.sync(() => {
+                  requestedId = repositoryId
+                  return {
+                    repository: {
+                      id: "repo-1",
+                      forge: "github",
+                      forgeHost: "github.com",
+                      projectPath: "Owner/Repo",
+                      issuesReconciledAt: "2026-08-12T10:00:00.000Z",
+                    },
+                    results: [
+                      {
+                        issueNumber: 7,
+                        title: "Ready work",
+                        url: "https://github.com/Owner/Repo/issues/7",
+                        action: "IMPLEMENT_NOW" as const,
+                        outcome: "CREATED" as const,
+                        workItem: {
+                          id: "wi-7",
+                          state: "CREATE_WORKTREE",
+                          status: "QUEUED",
+                        },
+                      },
+                    ],
+                  }
+                }),
+            }),
+          ),
+        )
+
+        yield* runOperator(["intake", "GitHub.com/owner/repo"], layer)
+
+        expect(requestedId).toBe("repo-1")
+        expect(logs).toHaveLength(1)
+        expect(logs[0]).toBe(
+          encodeCompactJson(
+            buildIntakeSuccessDocument({
+              repository: {
+                id: "repo-1",
+                forge: "github",
+                forgeHost: "github.com",
+                projectPath: "Owner/Repo",
+              },
+              issuesReconciledAt: "2026-08-12T10:00:00.000Z",
+              results: [
+                {
+                  issueNumber: 7,
+                  title: "Ready work",
+                  url: "https://github.com/Owner/Repo/issues/7",
+                  action: "IMPLEMENT_NOW",
+                  outcome: "CREATED",
+                  workItem: {
+                    id: "wi-7",
+                    state: "CREATE_WORKTREE",
+                    status: "QUEUED",
+                  },
+                },
+              ],
+            }),
+          ),
+        )
+        expect(process.exitCode).toBe(0)
+      } finally {
+        console.log = originalLog
+        process.exitCode = previousExitCode
+      }
+    }),
+  )
+
+  it.live("intake partial failure writes stdout and sets exitCode 1", () =>
+    Effect.gen(function* () {
+      const logs: string[] = []
+      const originalLog = console.log
+      const previousExitCode = process.exitCode
+      console.log = (...args: unknown[]) => {
+        logs.push(args.map(String).join(" "))
+      }
+      process.exitCode = undefined
+
+      try {
+        const layer = mockStart.pipe(
+          Layer.provideMerge(mockLocalGit),
+          Layer.provideMerge(
+            Layer.succeed(GraphqlApi, {
+              ...unusedGraphql,
+              listRepositories: Effect.succeed([
+                {
+                  id: "repo-1",
+                  forge: "github",
+                  forgeHost: "github.com",
+                  projectPath: "owner/repo",
+                },
+              ]),
+              startRepositoryIntake: () =>
+                Effect.succeed({
+                  repository: {
+                    id: "repo-1",
+                    forge: "github",
+                    forgeHost: "github.com",
+                    projectPath: "owner/repo",
+                    issuesReconciledAt: null,
+                  },
+                  results: [
+                    {
+                      issueNumber: 7,
+                      title: "Ready",
+                      url: "https://github.com/owner/repo/issues/7",
+                      action: "IMPLEMENT_NOW" as const,
+                      outcome: "CREATED" as const,
+                      workItem: {
+                        id: "wi-7",
+                        state: "CREATE_WORKTREE",
+                        status: "QUEUED",
+                      },
+                    },
+                    {
+                      issueNumber: 9,
+                      title: "Race",
+                      url: "https://github.com/owner/repo/issues/9",
+                      action: "QUEUE" as const,
+                      outcome: "FAILED" as const,
+                      error: {
+                        code: "UNFINISHED_WORK_ITEM_EXISTS",
+                        message: "Issue #9 already has an unfinished Work Item",
+                      },
+                    },
+                  ],
+                }),
+            }),
+          ),
+        )
+
+        yield* runOperator(["intake", "github.com/owner/repo"], layer)
+
+        expect(logs).toHaveLength(1)
+        expect(JSON.parse(logs[0] ?? "")).toEqual({
+          schemaVersion: CLI_SCHEMA_VERSION,
+          command: "intake",
+          repository: {
+            id: "repo-1",
+            forge: "github",
+            forgeHost: "github.com",
+            projectPath: "owner/repo",
+          },
+          issuesReconciledAt: null,
+          results: [
+            {
+              issueNumber: 7,
+              title: "Ready",
+              url: "https://github.com/owner/repo/issues/7",
+              action: "IMPLEMENT_NOW",
+              outcome: "CREATED",
+              workItem: {
+                id: "wi-7",
+                state: "CREATE_WORKTREE",
+                status: "QUEUED",
+              },
+            },
+            {
+              issueNumber: 9,
+              title: "Race",
+              url: "https://github.com/owner/repo/issues/9",
+              action: "QUEUE",
+              outcome: "FAILED",
+              error: {
+                code: "UNFINISHED_WORK_ITEM_EXISTS",
+                message: "Issue #9 already has an unfinished Work Item",
+              },
+            },
+          ],
+        })
+        expect(process.exitCode).toBe(1)
+      } finally {
+        console.log = originalLog
+        process.exitCode = previousExitCode
+      }
+    }),
+  )
+
+  it.live("intake empty results succeed without partial exit", () =>
+    Effect.gen(function* () {
+      const logs: string[] = []
+      const originalLog = console.log
+      const previousExitCode = process.exitCode
+      console.log = (...args: unknown[]) => {
+        logs.push(args.map(String).join(" "))
+      }
+      process.exitCode = undefined
+
+      try {
+        const layer = mockStart.pipe(
+          Layer.provideMerge(mockLocalGit),
+          Layer.provideMerge(
+            Layer.succeed(GraphqlApi, {
+              ...unusedGraphql,
+              listRepositories: Effect.succeed([
+                {
+                  id: "repo-1",
+                  forge: "github",
+                  forgeHost: "github.com",
+                  projectPath: "owner/repo",
+                },
+              ]),
+              startRepositoryIntake: () =>
+                Effect.succeed({
+                  repository: {
+                    id: "repo-1",
+                    forge: "github",
+                    forgeHost: "github.com",
+                    projectPath: "owner/repo",
+                    issuesReconciledAt: null,
+                  },
+                  results: [],
+                }),
+            }),
+          ),
+        )
+
+        yield* runOperator(["intake", "github.com/owner/repo"], layer)
+
+        expect(JSON.parse(logs[0] ?? "")).toEqual({
+          schemaVersion: CLI_SCHEMA_VERSION,
+          command: "intake",
+          repository: {
+            id: "repo-1",
+            forge: "github",
+            forgeHost: "github.com",
+            projectPath: "owner/repo",
+          },
+          issuesReconciledAt: null,
+          results: [],
+        })
+        expect(process.exitCode).toBe(0)
+      } finally {
+        console.log = originalLog
+        process.exitCode = previousExitCode
+      }
+    }),
+  )
+
+  it.live("intake preserves GraphQL operation-level error codes", () =>
+    Effect.gen(function* () {
+      const layer = mockStart.pipe(
+        Layer.provideMerge(mockLocalGit),
+        Layer.provideMerge(
+          Layer.succeed(GraphqlApi, {
+            ...unusedGraphql,
+            listRepositories: Effect.succeed([
+              {
+                id: "repo-1",
+                forge: "github",
+                forgeHost: "github.com",
+                projectPath: "owner/repo",
+              },
+            ]),
+            startRepositoryIntake: () =>
+              Effect.fail(
+                new GraphqlRequestFailed({
+                  code: "AGENT_BACKEND_UNAVAILABLE",
+                  message: "Agent Backend is unavailable",
+                }),
+              ),
+          }),
+        ),
+      )
+
+      const result = yield* runOperator(
+        ["intake", "github.com/owner/repo"],
+        layer,
+      ).pipe(Effect.flip)
+
+      expect(result).toBeInstanceOf(FiniteCommandFailed)
+      if (result instanceof FiniteCommandFailed) {
+        expect(result.document).toEqual({
+          schemaVersion: CLI_SCHEMA_VERSION,
+          command: "intake",
+          error: {
+            code: "AGENT_BACKEND_UNAVAILABLE",
+            message: "Agent Backend is unavailable",
+          },
+        })
+      }
+    }),
+  )
+
   it.live("status without repository returns all-sources Kanban JSON", () =>
     Effect.gen(function* () {
       const logs: string[] = []
@@ -635,7 +949,7 @@ describe("operator binary CLI seam", () => {
     }),
   )
 
-  it("binary help lists start, add, candidates, status, --no-open, and --host", () => {
+  it("binary help lists start, add, candidates, intake, status, --no-open, and --host", () => {
     const result = spawnSync(
       "bun",
       ["--conditions", "@ready-for-agent/source", "src/main.ts", "--help"],
@@ -650,6 +964,7 @@ describe("operator binary CLI seam", () => {
     expect(output).toContain("start")
     expect(output).toContain("add")
     expect(output).toContain("candidates")
+    expect(output).toContain("intake")
     expect(output).toContain("status")
     expect(output).not.toContain("remove-github-token")
     expect(output).toContain("no-open")

--- a/apps/ready-for-agent/src/cli.ts
+++ b/apps/ready-for-agent/src/cli.ts
@@ -5,8 +5,10 @@ import {
   type FiniteCommandName,
   buildAddSuccessDocument,
   buildCandidatesSuccessDocument,
+  buildIntakeSuccessDocument,
   buildStatusSuccessDocument,
   encodeCompactJson,
+  intakeHasFailedResults,
   localGitErrorCode,
   toCanonicalRepositoryIdentity,
 } from "./cli-json.ts"
@@ -199,6 +201,65 @@ const candidatesWorkflow = Effect.fn("Cli.candidates")(function* (
   )
 })
 
+const intakeWorkflow = Effect.fn("Cli.intake")(function* (
+  repositoryArgument: string,
+) {
+  const graphqlApi = yield* GraphqlApi
+  const repositories = yield* graphqlApi.listRepositories.pipe(
+    Effect.mapError((error) => toFiniteCommandFailed("intake", error)),
+  )
+
+  const resolved = resolveRepositoryIdentity(repositoryArgument, repositories)
+  switch (resolved._tag) {
+    case "invalid":
+      return yield* new FiniteCommandFailed({
+        command: "intake",
+        code: "REPOSITORY_NOT_FOUND",
+        message: `Invalid repository identity "${resolved.argument}". Use <forge-host>/<project-path>.`,
+      })
+    case "not_found":
+      return yield* new FiniteCommandFailed({
+        command: "intake",
+        code: "REPOSITORY_NOT_FOUND",
+        message: `No configured Repository matches ${resolved.forgeHost}/${resolved.projectPath}`,
+      })
+    case "ambiguous":
+      return yield* new FiniteCommandFailed({
+        command: "intake",
+        code: "REPOSITORY_AMBIGUOUS",
+        message: `Multiple configured Repositories match ${resolved.forgeHost}/${resolved.projectPath} (${resolved.matchCount})`,
+      })
+    case "matched":
+      break
+  }
+
+  const result = yield* graphqlApi
+    .startRepositoryIntake(resolved.repository.id)
+    .pipe(Effect.mapError((error) => toFiniteCommandFailed("intake", error)))
+
+  // Complete result document on stdout even when some candidates failed.
+  yield* Console.log(
+    encodeCompactJson(
+      buildIntakeSuccessDocument({
+        repository: {
+          id: result.repository.id,
+          forge: result.repository.forge,
+          forgeHost: result.repository.forgeHost,
+          projectPath: result.repository.projectPath,
+        },
+        issuesReconciledAt: result.repository.issuesReconciledAt,
+        results: result.results,
+      }),
+    ),
+  )
+
+  // Partial Intake exits 1 while keeping the result document on stdout.
+  // Complete and empty Intake exit 0.
+  yield* Effect.sync(() => {
+    process.exitCode = intakeHasFailedResults(result.results) ? 1 : 0
+  })
+})
+
 const statusWorkflow = Effect.fn("Cli.status")(function* (
   repositoryArgument: string | undefined,
 ) {
@@ -295,6 +356,16 @@ const candidatesCommand = Command.make(
   ),
 )
 
+const intakeCommand = Command.make(
+  "intake",
+  { repository: repositoryIdentityArg },
+  ({ repository }) => intakeWorkflow(repository),
+).pipe(
+  Command.withDescription(
+    "Start every current Intake Candidate for one Repository as versioned JSON",
+  ),
+)
+
 const statusCommand = Command.make(
   "status",
   { repository: optionalRepositoryIdentityArg },
@@ -312,12 +383,13 @@ export const cli = Command.make(
     startHarnessWorkflow(noOpen, Option.getOrUndefined(host)),
 ).pipe(
   Command.withDescription(
-    "Ready for Agent operator binary (start Harness, add repositories, list candidates, Kanban status)",
+    "Ready for Agent operator binary (start Harness, add repositories, intake, Kanban status)",
   ),
   Command.withSubcommands([
     startCommand,
     addCommand,
     candidatesCommand,
+    intakeCommand,
     statusCommand,
   ]),
 )

--- a/apps/ready-for-agent/src/services/graphql-api.ts
+++ b/apps/ready-for-agent/src/services/graphql-api.ts
@@ -3,6 +3,7 @@ import { createClient } from "@ready-for-agent/graphql-client"
 import {
   type CanonicalRepositoryIdentity,
   type IntakeCandidateAction,
+  type IntakeIssueResult,
   type StatusLane,
   type StatusLaneId,
   type StatusWorkItemRow,
@@ -49,6 +50,17 @@ export type IntakeCandidatesResult = {
     readonly url: string
     readonly action: IntakeCandidateAction
   }[]
+}
+
+export type RepositoryIntakeResult = {
+  readonly repository: {
+    readonly id: string
+    readonly forge: string
+    readonly forgeHost: string
+    readonly projectPath: string
+    readonly issuesReconciledAt: string | null
+  }
+  readonly results: readonly IntakeIssueResult[]
 }
 
 export type KanbanStatusResult = {
@@ -161,6 +173,9 @@ export class GraphqlApi extends Context.Service<
     readonly intakeCandidates: (
       repositoryId: string,
     ) => Effect.Effect<IntakeCandidatesResult, GraphqlRequestFailed>
+    readonly startRepositoryIntake: (
+      repositoryId: string,
+    ) => Effect.Effect<RepositoryIntakeResult, GraphqlRequestFailed>
     readonly kanbanStatus: (
       repositoryId: string | null,
     ) => Effect.Effect<KanbanStatusResult, GraphqlRequestFailed>
@@ -286,6 +301,120 @@ export class GraphqlApi extends Context.Service<
         },
       )
 
+      const startRepositoryIntake = Effect.fn(
+        "GraphqlApi.startRepositoryIntake",
+      )(function* (repositoryId: string) {
+        return yield* Effect.tryPromise({
+          try: async () => {
+            const result = await client.mutation({
+              startRepositoryIntake: {
+                __args: { repositoryId },
+                repository: {
+                  id: true,
+                  forge: true,
+                  forgeHost: true,
+                  projectPath: true,
+                  issuesReconciledAt: true,
+                },
+                results: {
+                  on_RepositoryIntakeCreated: {
+                    __typename: true,
+                    issueNumber: true,
+                    title: true,
+                    url: true,
+                    action: true,
+                    workItem: {
+                      id: true,
+                      state: true,
+                      status: true,
+                    },
+                  },
+                  on_RepositoryIntakeFailed: {
+                    __typename: true,
+                    issueNumber: true,
+                    title: true,
+                    url: true,
+                    action: true,
+                    error: {
+                      code: true,
+                      message: true,
+                    },
+                  },
+                },
+              },
+            })
+            const payload = result.startRepositoryIntake
+            if (!payload) {
+              throw new Error("startRepositoryIntake returned null")
+            }
+            const results: IntakeIssueResult[] = []
+            for (const entry of payload.results ?? []) {
+              // Genql union selection uses on_* fragments; __typename discriminates.
+              if (
+                entry !== null &&
+                typeof entry === "object" &&
+                "__typename" in entry &&
+                entry.__typename === "RepositoryIntakeCreated" &&
+                "workItem" in entry &&
+                entry.workItem !== null &&
+                entry.workItem !== undefined
+              ) {
+                results.push({
+                  issueNumber: entry.issueNumber,
+                  title: entry.title,
+                  url: entry.url,
+                  action: entry.action,
+                  outcome: "CREATED",
+                  workItem: {
+                    id: entry.workItem.id,
+                    state: entry.workItem.state,
+                    status: entry.workItem.status,
+                  },
+                })
+                continue
+              }
+              if (
+                entry !== null &&
+                typeof entry === "object" &&
+                "__typename" in entry &&
+                entry.__typename === "RepositoryIntakeFailed" &&
+                "error" in entry &&
+                entry.error !== null &&
+                entry.error !== undefined
+              ) {
+                results.push({
+                  issueNumber: entry.issueNumber,
+                  title: entry.title,
+                  url: entry.url,
+                  action: entry.action,
+                  outcome: "FAILED",
+                  error: {
+                    code: entry.error.code,
+                    message: entry.error.message,
+                  },
+                })
+                continue
+              }
+              throw new Error(
+                "startRepositoryIntake returned an unexpected result shape",
+              )
+            }
+            return {
+              repository: {
+                id: payload.repository.id,
+                forge: payload.repository.forge,
+                forgeHost: payload.repository.forgeHost,
+                projectPath: payload.repository.projectPath,
+                issuesReconciledAt:
+                  payload.repository.issuesReconciledAt ?? null,
+              },
+              results,
+            }
+          },
+          catch: mapFailure,
+        })
+      })
+
       const kanbanStatus = Effect.fn("GraphqlApi.kanbanStatus")(function* (
         repositoryId: string | null,
       ) {
@@ -349,6 +478,7 @@ export class GraphqlApi extends Context.Service<
         addRepository,
         listRepositories,
         intakeCandidates,
+        startRepositoryIntake,
         kanbanStatus,
       }
     }),

--- a/packages/graphql-api/src/index.ts
+++ b/packages/graphql-api/src/index.ts
@@ -1,3 +1,4 @@
 export * from "./lib/add-repository-command.js"
 export * from "./lib/graphql-api.js"
 export * from "./lib/issue-polling.js"
+export * from "./lib/repository-intake.js"

--- a/packages/graphql-api/src/lib/graphql-api.ts
+++ b/packages/graphql-api/src/lib/graphql-api.ts
@@ -71,6 +71,7 @@ import {
   repositoryCredential,
   withKeymaxxerMetadataTimeout,
 } from "./repository-credentials.js"
+import { startRepositoryIntake } from "./repository-intake.js"
 import { preflightRepositoryIntake } from "./repository-intake-preflight.js"
 import { toGraphQLError } from "./to-graphql-error.js"
 import { validateAgentModelsAgainstCatalog } from "./validate-agent-models.js"
@@ -1912,6 +1913,17 @@ export const createGraphqlApi = <R>(
                   args.issueNumber,
                 )
               }).pipe(Effect.withSpan("graphql-api.queue")),
+              context,
+            ),
+          startRepositoryIntake: async (
+            _parent: unknown,
+            args: IssuesArgs,
+            context: GraphqlRequestContext,
+          ) =>
+            runGraphql(
+              startRepositoryIntake(args.repositoryId).pipe(
+                Effect.withSpan("graphql-api.startRepositoryIntake"),
+              ),
               context,
             ),
           retryWorkItem: async (

--- a/packages/graphql-api/src/lib/repository-intake.ts
+++ b/packages/graphql-api/src/lib/repository-intake.ts
@@ -1,0 +1,225 @@
+import { Effect, Result } from "effect"
+import type { ActiveAgentBackend } from "@ready-for-agent/agent-backend"
+import {
+  type DatabaseError,
+  DbService,
+  RepositoryNotFoundError,
+} from "@ready-for-agent/db-service"
+import { classifyIntakeCandidates } from "@ready-for-agent/lifecycle-model"
+import {
+  type AgentBackendUnavailableError,
+  type BuildModelNotConfiguredError,
+  type IssueBlockedError,
+  type IssueNotBlockedError,
+  type IssueNotFoundError,
+  type IssueNotOpenError,
+  type ParentIssueError,
+  type UnfinishedWorkItemExistsError,
+  WorkItemLifecycle,
+  type WorkItemRecord,
+  isRetryableFailedWorkItem,
+} from "@ready-for-agent/work-item-lifecycle"
+import { preflightRepositoryIntake } from "./repository-intake-preflight.js"
+import { toGraphQLError } from "./to-graphql-error.js"
+
+export type RepositoryIntakeAction = "IMPLEMENT_NOW" | "QUEUE"
+
+export type RepositoryIntakeIssueError = {
+  readonly code: string
+  readonly message: string
+}
+
+/** Discriminated Intake result for one Issue (GraphQL union payload). */
+export type RepositoryIntakeIssueResult =
+  | {
+      readonly __typename: "RepositoryIntakeCreated"
+      readonly issueNumber: number
+      readonly title: string
+      readonly url: string
+      readonly action: RepositoryIntakeAction
+      readonly workItem: WorkItemRecord
+    }
+  | {
+      readonly __typename: "RepositoryIntakeFailed"
+      readonly issueNumber: number
+      readonly title: string
+      readonly url: string
+      readonly action: RepositoryIntakeAction
+      readonly error: RepositoryIntakeIssueError
+    }
+
+export type RepositoryIntakeResult = {
+  readonly repository: {
+    readonly id: string
+    readonly forge: string
+    readonly forgeHost: string
+    readonly projectPath: string
+    readonly issuesReconciledAt: Date | null
+  }
+  readonly results: readonly RepositoryIntakeIssueResult[]
+}
+
+type CandidateLocalTag =
+  | "IssueNotFoundError"
+  | "IssueNotOpenError"
+  | "ParentIssueError"
+  | "IssueBlockedError"
+  | "IssueNotBlockedError"
+  | "UnfinishedWorkItemExistsError"
+
+const isTagged = (
+  error: unknown,
+): error is { readonly _tag: string } & Record<string, unknown> =>
+  typeof error === "object" &&
+  error !== null &&
+  "_tag" in error &&
+  typeof (error as { _tag: unknown })._tag === "string"
+
+/**
+ * Candidate-local races become per-Issue failed results. Everything else
+ * remains an operation-level failure that stops sequential Intake.
+ */
+export const isCandidateLocalIntakeError = (
+  error: unknown,
+): error is
+  | IssueNotFoundError
+  | IssueNotOpenError
+  | ParentIssueError
+  | IssueBlockedError
+  | IssueNotBlockedError
+  | UnfinishedWorkItemExistsError => {
+  if (!isTagged(error)) {
+    return false
+  }
+  switch (error._tag as CandidateLocalTag | string) {
+    case "IssueNotFoundError":
+    case "IssueNotOpenError":
+    case "ParentIssueError":
+    case "IssueBlockedError":
+    case "IssueNotBlockedError":
+    case "UnfinishedWorkItemExistsError":
+      return true
+    default:
+      return false
+  }
+}
+
+/**
+ * Map a candidate-local tagged failure to the stable GraphQL error code/message
+ * used for Implement Now / Queue domain errors (same `extensions.code` values).
+ */
+export const toCandidateLocalIntakeError = (
+  error: unknown,
+): RepositoryIntakeIssueError => {
+  const graphQlError = toGraphQLError(error)
+  const code =
+    typeof graphQlError.extensions?.code === "string"
+      ? graphQlError.extensions.code
+      : "INTERNAL_SERVER_ERROR"
+  return {
+    code,
+    message: graphQlError.message,
+  }
+}
+
+/**
+ * Synchronous best-effort Repository Intake:
+ * 1. Resolve Repository
+ * 2. Classify current candidates (no Refresh)
+ * 3. Empty → successful no-op without preflight
+ * 4. Nonempty → one shared preflight, then sequential Implement Now / Queue
+ *
+ * Candidate-local failures continue; infrastructure and unexpected defects fail
+ * the Effect so GraphQL surfaces an operation-level error.
+ */
+export const startRepositoryIntake = (
+  repositoryId: string,
+): Effect.Effect<
+  RepositoryIntakeResult,
+  | RepositoryNotFoundError
+  | AgentBackendUnavailableError
+  | BuildModelNotConfiguredError
+  | DatabaseError
+  | unknown,
+  DbService | WorkItemLifecycle | ActiveAgentBackend
+> =>
+  Effect.gen(function* () {
+    const db = yield* DbService
+    const lifecycle = yield* WorkItemLifecycle
+
+    const repositories = yield* db.listRepositories
+    const repository = repositories.find(({ id }) => id === repositoryId)
+    if (repository === undefined) {
+      return yield* new RepositoryNotFoundError({ repositoryId })
+    }
+
+    // Snapshot classification from the current Issue projection only.
+    const [issues, workItems] = yield* Effect.all([
+      db.listIssues(repository.id),
+      lifecycle.listWorkItemsForRepository(repository.id),
+    ])
+    const candidates = classifyIntakeCandidates(
+      issues,
+      workItems.map((workItem) => ({
+        issueNumber: workItem.issueNumber,
+        id: workItem.id,
+        state: workItem.state,
+        canRetry: isRetryableFailedWorkItem(workItem),
+      })),
+    )
+
+    if (candidates.length === 0) {
+      return {
+        repository,
+        results: [],
+      }
+    }
+
+    // Shared Repository preflight once before any Work Item is created.
+    yield* preflightRepositoryIntake(repository.id)
+
+    const results: RepositoryIntakeIssueResult[] = []
+
+    for (const candidate of candidates) {
+      // Widen error channel so Implement Now and Queue share one sequential path.
+      const attempt: Effect.Effect<WorkItemRecord, unknown> =
+        candidate.action === "IMPLEMENT_NOW"
+          ? lifecycle.implementNow(repository.id, candidate.issueNumber)
+          : lifecycle.queue(repository.id, candidate.issueNumber)
+
+      // Capture candidate-local failures as result data; rethrow operation-level.
+      const outcome = yield* Effect.result(attempt)
+      if (Result.isSuccess(outcome)) {
+        results.push({
+          __typename: "RepositoryIntakeCreated",
+          issueNumber: candidate.issueNumber,
+          title: candidate.title,
+          url: candidate.url,
+          action: candidate.action,
+          workItem: outcome.success,
+        })
+        continue
+      }
+
+      const failure = outcome.failure
+      if (isCandidateLocalIntakeError(failure)) {
+        results.push({
+          __typename: "RepositoryIntakeFailed",
+          issueNumber: candidate.issueNumber,
+          title: candidate.title,
+          url: candidate.url,
+          action: candidate.action,
+          error: toCandidateLocalIntakeError(failure),
+        })
+        continue
+      }
+
+      // Operation-level: stop processing; earlier Work Items already committed.
+      return yield* Effect.fail(failure)
+    }
+
+    return {
+      repository,
+      results,
+    }
+  })

--- a/packages/graphql-api/test/graphql-api.test.ts
+++ b/packages/graphql-api/test/graphql-api.test.ts
@@ -46,6 +46,7 @@ import { stubQueueService } from "@ready-for-agent/queue-service/test"
 import {
   IssueNotFoundError,
   STEP_RUN_REASON,
+  UnfinishedWorkItemExistsError,
   WAITING_FOR_AGENT_TURN_MESSAGE,
   WorkItemLifecycle,
   type WorkItemLifecycleShape,
@@ -6406,6 +6407,600 @@ describe("GraphQL API", () => {
     expect(body.errors).toHaveLength(1)
     expect(body.errors[0]?.extensions.code).toBe("BUILD_MODEL_NOT_CONFIGURED")
     expect(body.errors[0]?.message).toContain("stale/model-not-in-catalog")
+  })
+
+  test("startRepositoryIntake empty candidates succeeds without preflight", async () => {
+    let requireAgentTurnsCalls = 0
+    let implementCalls = 0
+    await runtime.dispose()
+    runtime = makeRuntime(
+      {
+        listIssues: () => Effect.succeed([]),
+      },
+      {},
+      {},
+      {
+        listWorkItemsForRepository: () => Effect.succeed([]),
+        implementNow: () =>
+          Effect.sync(() => {
+            implementCalls += 1
+            return workItem
+          }),
+        queue: () =>
+          Effect.sync(() => {
+            implementCalls += 1
+            return workItem
+          }),
+      },
+      {
+        requireAgentTurnsAllowed: () =>
+          Effect.sync(() => {
+            requireAgentTurnsCalls += 1
+          }),
+      },
+    )
+
+    const response = await createGraphqlApi(runtime).fetch(
+      graphqlRequest({
+        query: `mutation StartIntake($repositoryId: ID!) {
+          startRepositoryIntake(repositoryId: $repositoryId) {
+            repository { id }
+            results {
+              __typename
+              ... on RepositoryIntakeCreated { issueNumber }
+              ... on RepositoryIntakeFailed { issueNumber }
+            }
+          }
+        }`,
+        variables: { repositoryId: repository.id },
+      }),
+    )
+
+    expect(await response.json()).toEqual({
+      data: {
+        startRepositoryIntake: {
+          repository: { id: repository.id },
+          results: [],
+        },
+      },
+    })
+    expect(requireAgentTurnsCalls).toBe(0)
+    expect(implementCalls).toBe(0)
+  })
+
+  test("startRepositoryIntake processes candidates sequentially and routes Queue", async () => {
+    const actionable = {
+      ...issue,
+      id: "issue-actionable",
+      issueNumber: 12,
+      title: "Actionable leaf",
+      url: "https://github.com/acme/widgets/issues/12",
+      blockedBy: [],
+    }
+    const blocked = {
+      ...issue,
+      id: "issue-blocked",
+      issueNumber: 5,
+      title: "Blocked leaf",
+      url: "https://github.com/acme/widgets/issues/5",
+      blockedBy: [
+        {
+          issueNumber: 1,
+          issueUrl: "https://github.com/acme/widgets/issues/1",
+        },
+      ],
+    }
+    const callOrder: string[] = []
+    const createdNow = {
+      ...workItem,
+      id: "wi-implement-12",
+      issueNumber: 12,
+      issueTitle: actionable.title,
+      waitingForBlockers: false,
+      holdsWorkerSlot: true,
+    } as WorkItemRecord
+    const createdQueue = {
+      ...workItem,
+      id: "wi-queue-5",
+      issueNumber: 5,
+      issueTitle: blocked.title,
+      waitingForBlockers: true,
+      holdsWorkerSlot: false,
+      waitingSince: null,
+      stepRuns: [],
+    } as WorkItemRecord
+
+    await runtime.dispose()
+    runtime = makeRuntime(
+      {
+        listIssues: () => Effect.succeed([actionable, blocked]),
+      },
+      {},
+      {},
+      {
+        listWorkItemsForRepository: () => Effect.succeed([]),
+        implementNow: (repositoryId, issueNumber) =>
+          Effect.sync(() => {
+            callOrder.push(`implementNow:${repositoryId}:${issueNumber}`)
+            return createdNow
+          }),
+        queue: (repositoryId, issueNumber) =>
+          Effect.sync(() => {
+            callOrder.push(`queue:${repositoryId}:${issueNumber}`)
+            return createdQueue
+          }),
+      },
+    )
+
+    const response = await createGraphqlApi(runtime).fetch(
+      graphqlRequest({
+        query: `mutation StartIntake($repositoryId: ID!) {
+          startRepositoryIntake(repositoryId: $repositoryId) {
+            repository { id projectPath }
+            results {
+              __typename
+              ... on RepositoryIntakeCreated {
+                issueNumber
+                title
+                url
+                action
+                workItem { id state status }
+              }
+              ... on RepositoryIntakeFailed {
+                issueNumber
+                error { code message }
+              }
+            }
+          }
+        }`,
+        variables: { repositoryId: repository.id },
+      }),
+    )
+
+    // IMPLEMENT_NOW candidates first (issue 12), then QUEUE (issue 5).
+    expect(callOrder).toEqual([
+      `implementNow:${repository.id}:12`,
+      `queue:${repository.id}:5`,
+    ])
+    expect(await response.json()).toEqual({
+      data: {
+        startRepositoryIntake: {
+          repository: {
+            id: repository.id,
+            projectPath: repository.projectPath,
+          },
+          results: [
+            {
+              __typename: "RepositoryIntakeCreated",
+              issueNumber: 12,
+              title: "Actionable leaf",
+              url: "https://github.com/acme/widgets/issues/12",
+              action: "IMPLEMENT_NOW",
+              workItem: {
+                id: createdNow.id,
+                state: "CREATE_WORKTREE",
+                status: "RUNNING",
+              },
+            },
+            {
+              __typename: "RepositoryIntakeCreated",
+              issueNumber: 5,
+              title: "Blocked leaf",
+              url: "https://github.com/acme/widgets/issues/5",
+              action: "QUEUE",
+              workItem: {
+                id: createdQueue.id,
+                state: "CREATE_WORKTREE",
+                status: "WAITING_FOR_BLOCKERS",
+              },
+            },
+          ],
+        },
+      },
+    })
+  })
+
+  test("startRepositoryIntake continues after candidate-local failure", async () => {
+    const first = {
+      ...issue,
+      id: "issue-first",
+      issueNumber: 10,
+      title: "First actionable",
+      url: "https://github.com/acme/widgets/issues/10",
+      blockedBy: [],
+    }
+    const second = {
+      ...issue,
+      id: "issue-second",
+      issueNumber: 11,
+      title: "Second actionable",
+      url: "https://github.com/acme/widgets/issues/11",
+      blockedBy: [],
+    }
+    const createdSecond = {
+      ...workItem,
+      id: "wi-second",
+      issueNumber: 11,
+      issueTitle: second.title,
+    } as WorkItemRecord
+    const callOrder: number[] = []
+
+    await runtime.dispose()
+    runtime = makeRuntime(
+      {
+        listIssues: () => Effect.succeed([first, second]),
+      },
+      {},
+      {},
+      {
+        listWorkItemsForRepository: () => Effect.succeed([]),
+        implementNow: (_repositoryId, issueNumber) =>
+          Effect.gen(function* () {
+            callOrder.push(issueNumber)
+            if (issueNumber === 10) {
+              return yield* new UnfinishedWorkItemExistsError({
+                repositoryId: repository.id,
+                issueNumber,
+                workItemId: "wi-existing",
+              })
+            }
+            return createdSecond
+          }),
+      },
+    )
+
+    const response = await createGraphqlApi(runtime).fetch(
+      graphqlRequest({
+        query: `mutation StartIntake($repositoryId: ID!) {
+          startRepositoryIntake(repositoryId: $repositoryId) {
+            results {
+              __typename
+              ... on RepositoryIntakeCreated {
+                issueNumber
+                workItem { id }
+              }
+              ... on RepositoryIntakeFailed {
+                issueNumber
+                error { code message }
+              }
+            }
+          }
+        }`,
+        variables: { repositoryId: repository.id },
+      }),
+    )
+
+    expect(callOrder).toEqual([10, 11])
+    expect(await response.json()).toEqual({
+      data: {
+        startRepositoryIntake: {
+          results: [
+            {
+              __typename: "RepositoryIntakeFailed",
+              issueNumber: 10,
+              error: {
+                code: "UNFINISHED_WORK_ITEM_EXISTS",
+                message: `Issue #10 already has an unfinished Work Item`,
+              },
+            },
+            {
+              __typename: "RepositoryIntakeCreated",
+              issueNumber: 11,
+              workItem: { id: createdSecond.id },
+            },
+          ],
+        },
+      },
+    })
+  })
+
+  test("startRepositoryIntake stops on operation-level failure after earlier success", async () => {
+    const first = {
+      ...issue,
+      id: "issue-first",
+      issueNumber: 20,
+      title: "First",
+      url: "https://github.com/acme/widgets/issues/20",
+      blockedBy: [],
+    }
+    const second = {
+      ...issue,
+      id: "issue-second",
+      issueNumber: 21,
+      title: "Second",
+      url: "https://github.com/acme/widgets/issues/21",
+      blockedBy: [],
+    }
+    const createdFirst = {
+      ...workItem,
+      id: "wi-first",
+      issueNumber: 20,
+      issueTitle: first.title,
+    } as WorkItemRecord
+    const callOrder: number[] = []
+
+    await runtime.dispose()
+    runtime = makeRuntime(
+      {
+        listIssues: () => Effect.succeed([first, second]),
+      },
+      {},
+      {},
+      {
+        listWorkItemsForRepository: () => Effect.succeed([]),
+        implementNow: (_repositoryId, issueNumber) =>
+          Effect.gen(function* () {
+            callOrder.push(issueNumber)
+            if (issueNumber === 20) {
+              return createdFirst
+            }
+            return yield* new EnqueueError({
+              queue: "work-item-steps",
+              message: "queue infrastructure failed",
+            })
+          }),
+      },
+    )
+
+    const response = await createGraphqlApi(runtime).fetch(
+      graphqlRequest({
+        query: `mutation StartIntake($repositoryId: ID!) {
+          startRepositoryIntake(repositoryId: $repositoryId) {
+            results {
+              __typename
+              ... on RepositoryIntakeCreated { issueNumber workItem { id } }
+              ... on RepositoryIntakeFailed { issueNumber }
+            }
+          }
+        }`,
+        variables: { repositoryId: repository.id },
+      }),
+    )
+
+    // Second candidate never completed as result data — operation failed.
+    expect(callOrder).toEqual([20, 21])
+    expect(await response.json()).toEqual({
+      data: null,
+      errors: [
+        expect.objectContaining({
+          message: "queue infrastructure failed",
+          extensions: expect.objectContaining({
+            code: "ENQUEUE_ERROR",
+          }),
+        }),
+      ],
+    })
+  })
+
+  test("startRepositoryIntake runs one preflight before creating Work Items", async () => {
+    const actionable = {
+      ...issue,
+      issueNumber: 30,
+      blockedBy: [],
+    }
+    let requireAgentTurnsCalls = 0
+    let implementCalls = 0
+    await runtime.dispose()
+    runtime = makeRuntime(
+      {
+        listIssues: () => Effect.succeed([actionable]),
+      },
+      {},
+      {},
+      {
+        listWorkItemsForRepository: () => Effect.succeed([]),
+        implementNow: () =>
+          Effect.sync(() => {
+            implementCalls += 1
+            return workItem
+          }),
+      },
+      {
+        requireAgentTurnsAllowed: () =>
+          Effect.sync(() => {
+            requireAgentTurnsCalls += 1
+          }),
+      },
+    )
+
+    const response = await createGraphqlApi(runtime).fetch(
+      graphqlRequest({
+        query: `mutation StartIntake($repositoryId: ID!) {
+          startRepositoryIntake(repositoryId: $repositoryId) {
+            results {
+              __typename
+              ... on RepositoryIntakeCreated { issueNumber }
+            }
+          }
+        }`,
+        variables: { repositoryId: repository.id },
+      }),
+    )
+
+    expect(requireAgentTurnsCalls).toBe(1)
+    expect(implementCalls).toBe(1)
+    expect(await response.json()).toEqual({
+      data: {
+        startRepositoryIntake: {
+          results: [
+            {
+              __typename: "RepositoryIntakeCreated",
+              issueNumber: 30,
+            },
+          ],
+        },
+      },
+    })
+  })
+
+  test("startRepositoryIntake works when Repository is Paused", async () => {
+    const actionable = {
+      ...issue,
+      issueNumber: 31,
+      blockedBy: [],
+    }
+    await runtime.dispose()
+    runtime = makeRuntime(
+      {
+        listRepositories: Effect.succeed([
+          {
+            ...repository,
+            paused: true,
+          },
+        ]),
+        listIssues: () => Effect.succeed([actionable]),
+      },
+      {},
+      {},
+      {
+        listWorkItemsForRepository: () => Effect.succeed([]),
+        implementNow: () => Effect.succeed(workItem),
+      },
+    )
+
+    const response = await createGraphqlApi(runtime).fetch(
+      graphqlRequest({
+        query: `mutation StartIntake($repositoryId: ID!) {
+          startRepositoryIntake(repositoryId: $repositoryId) {
+            repository { id paused }
+            results {
+              __typename
+              ... on RepositoryIntakeCreated { issueNumber }
+            }
+          }
+        }`,
+        variables: { repositoryId: repository.id },
+      }),
+    )
+
+    expect(await response.json()).toEqual({
+      data: {
+        startRepositoryIntake: {
+          repository: { id: repository.id, paused: true },
+          results: [
+            {
+              __typename: "RepositoryIntakeCreated",
+              issueNumber: 31,
+            },
+          ],
+        },
+      },
+    })
+  })
+
+  test("startRepositoryIntake aborts mid-sequence and preserves earlier Work Items", async () => {
+    const first = {
+      ...issue,
+      id: "issue-abort-1",
+      issueNumber: 40,
+      title: "First",
+      url: "https://github.com/acme/widgets/issues/40",
+      blockedBy: [],
+    }
+    const second = {
+      ...issue,
+      id: "issue-abort-2",
+      issueNumber: 41,
+      title: "Second",
+      url: "https://github.com/acme/widgets/issues/41",
+      blockedBy: [],
+    }
+    const createdFirst = {
+      ...workItem,
+      id: "wi-abort-first",
+      issueNumber: 40,
+    } as WorkItemRecord
+    let secondStarted = false
+    let secondCompleted = false
+    let implementCalls = 0
+
+    await runtime.dispose()
+    runtime = makeRuntime(
+      {
+        listIssues: () => Effect.succeed([first, second]),
+      },
+      {},
+      {},
+      {
+        listWorkItemsForRepository: () => Effect.succeed([]),
+        implementNow: (_repositoryId, issueNumber) =>
+          Effect.gen(function* () {
+            implementCalls += 1
+            if (issueNumber === 40) {
+              return createdFirst
+            }
+            secondStarted = true
+            yield* Effect.sleep("30 seconds")
+            secondCompleted = true
+            return workItem
+          }),
+      },
+    )
+
+    const controller = new AbortController()
+    const fetchPromise = createGraphqlApi(runtime).fetch(
+      graphqlRequest(
+        {
+          query: `mutation StartIntake($repositoryId: ID!) {
+            startRepositoryIntake(repositoryId: $repositoryId) {
+              results {
+                __typename
+                ... on RepositoryIntakeCreated { issueNumber workItem { id } }
+              }
+            }
+          }`,
+          variables: { repositoryId: repository.id },
+        },
+        undefined,
+        controller.signal,
+      ),
+    )
+
+    await waitUntil(() => secondStarted)
+    // First Work Item already created before the second candidate blocks.
+    expect(implementCalls).toBe(2)
+    controller.abort()
+
+    await expect(fetchPromise).rejects.toMatchObject({
+      name: "AbortError",
+    })
+    await Bun.sleep(50)
+    expect(secondCompleted).toBe(false)
+  })
+
+  test("startRepositoryIntake rejects unknown repository", async () => {
+    let listIssuesCalls = 0
+    await runtime.dispose()
+    runtime = makeRuntime({
+      listIssues: () =>
+        Effect.sync(() => {
+          listIssuesCalls += 1
+          return []
+        }),
+    })
+
+    const response = await createGraphqlApi(runtime).fetch(
+      graphqlRequest({
+        query: `mutation StartIntake($repositoryId: ID!) {
+          startRepositoryIntake(repositoryId: $repositoryId) {
+            results { __typename }
+          }
+        }`,
+        variables: { repositoryId: "repo-01DOESNOTEXIST00000000000" },
+      }),
+    )
+
+    expect(await response.json()).toEqual({
+      data: null,
+      errors: [
+        expect.objectContaining({
+          extensions: expect.objectContaining({
+            code: "REPOSITORY_NOT_FOUND",
+          }),
+        }),
+      ],
+    })
+    expect(listIssuesCalls).toBe(0)
   })
 
   test("projects Waiting for blockers status and blocker copy", async () => {

--- a/packages/graphql-api/test/repository-intake.test.ts
+++ b/packages/graphql-api/test/repository-intake.test.ts
@@ -1,0 +1,65 @@
+import { EnqueueError } from "@ready-for-agent/queue-service"
+import {
+  IssueBlockedError,
+  IssueNotBlockedError,
+  IssueNotFoundError,
+  IssueNotOpenError,
+  ParentIssueError,
+  UnfinishedWorkItemExistsError,
+} from "@ready-for-agent/work-item-lifecycle"
+import {
+  isCandidateLocalIntakeError,
+  toCandidateLocalIntakeError,
+} from "../src/lib/repository-intake.js"
+import { describe, expect, test } from "bun:test"
+
+describe("Repository Intake candidate-local errors", () => {
+  test("classifies Implement Now / Queue races as candidate-local", () => {
+    const cases = [
+      new IssueNotFoundError({ repositoryId: "r", issueNumber: 1 }),
+      new IssueNotOpenError({
+        repositoryId: "r",
+        issueNumber: 2,
+        state: "CLOSED",
+      }),
+      new ParentIssueError({ repositoryId: "r", issueNumber: 3 }),
+      new IssueBlockedError({
+        repositoryId: "r",
+        issueNumber: 4,
+        blockerCount: 2,
+      }),
+      new IssueNotBlockedError({ repositoryId: "r", issueNumber: 5 }),
+      new UnfinishedWorkItemExistsError({
+        repositoryId: "r",
+        issueNumber: 6,
+        workItemId: "wi-6",
+      }),
+    ]
+    for (const error of cases) {
+      expect(isCandidateLocalIntakeError(error)).toBe(true)
+      const mapped = toCandidateLocalIntakeError(error)
+      expect(mapped.code.length).toBeGreaterThan(0)
+      expect(mapped.message.length).toBeGreaterThan(0)
+    }
+  })
+
+  test("maps unfinished Work Item race to stable code and message", () => {
+    const error = new UnfinishedWorkItemExistsError({
+      repositoryId: "repo-1",
+      issueNumber: 9,
+      workItemId: "wi-existing",
+    })
+    expect(toCandidateLocalIntakeError(error)).toEqual({
+      code: "UNFINISHED_WORK_ITEM_EXISTS",
+      message: "Issue #9 already has an unfinished Work Item",
+    })
+  })
+
+  test("treats infrastructure failures as operation-level", () => {
+    const error = new EnqueueError({
+      queue: "work-item-steps",
+      message: "queue infrastructure failed",
+    })
+    expect(isCandidateLocalIntakeError(error)).toBe(false)
+  })
+})

--- a/packages/graphql-schema/schema.graphql
+++ b/packages/graphql-schema/schema.graphql
@@ -498,6 +498,55 @@ type RepositoryIntakeCandidates {
   candidates: [IntakeCandidate!]!
 }
 
+"""
+Stable candidate-local failure for one Intake Issue. Operation-level failures
+(repository disappearance, infrastructure, cancellation, unexpected defects)
+are GraphQL errors and stop processing instead of appearing here.
+"""
+type RepositoryIntakeIssueError {
+  code: String!
+  message: String!
+}
+
+"""
+Successful Intake of one Issue through ordinary Implement Now or Queue.
+"""
+type RepositoryIntakeCreated {
+  issueNumber: Int!
+  title: String!
+  url: String!
+  action: RepositoryIntakeAction!
+  workItem: WorkItem!
+}
+
+"""
+Candidate-local Intake failure for one Issue. Processing continues with later
+candidates; earlier Work Items are not rolled back.
+"""
+type RepositoryIntakeFailed {
+  issueNumber: Int!
+  title: String!
+  url: String!
+  action: RepositoryIntakeAction!
+  error: RepositoryIntakeIssueError!
+}
+
+"""
+Per-Issue Intake outcome. Created and failed fields cannot coexist.
+"""
+union RepositoryIntakeIssueResult =
+  | RepositoryIntakeCreated
+  | RepositoryIntakeFailed
+
+"""
+Best-effort sequential Repository Intake result. Reclassifies current candidates
+at mutation time; does not accept candidate input or a plan token.
+"""
+type RepositoryIntakeResult {
+  repository: Repository!
+  results: [RepositoryIntakeIssueResult!]!
+}
+
 enum WorkItemState {
   ASSESS_CHANGES
   CLOSE_ISSUE
@@ -724,6 +773,17 @@ type Mutation {
   in Waiting for blockers (no Worker Slot, no Step Run).
   """
   queue(repositoryId: ID!, issueNumber: Int!): WorkItem!
+  """
+  Synchronous best-effort Repository Intake: reclassify current Intake
+  Candidates for one Repository, run one shared Repository preflight when the
+  set is nonempty, then process each candidate sequentially through ordinary
+  Implement Now or Queue. Candidate-local races become per-Issue failed
+  results; infrastructure, cancellation, and unexpected defects stop as
+  GraphQL errors while preserving earlier Work Items. No Intake entity or
+  persistence is created. Empty classification is a successful no-op and
+  bypasses preflight.
+  """
+  startRepositoryIntake(repositoryId: ID!): RepositoryIntakeResult!
   retryWorkItem(workItemId: ID!): WorkItem!
   pauseWorkItem(workItemId: ID!): WorkItem!
   startWorkItem(workItemId: ID!): WorkItem!

--- a/packages/graphql-schema/schema.template.graphql
+++ b/packages/graphql-schema/schema.template.graphql
@@ -495,6 +495,55 @@ type RepositoryIntakeCandidates {
   candidates: [IntakeCandidate!]!
 }
 
+"""
+Stable candidate-local failure for one Intake Issue. Operation-level failures
+(repository disappearance, infrastructure, cancellation, unexpected defects)
+are GraphQL errors and stop processing instead of appearing here.
+"""
+type RepositoryIntakeIssueError {
+  code: String!
+  message: String!
+}
+
+"""
+Successful Intake of one Issue through ordinary Implement Now or Queue.
+"""
+type RepositoryIntakeCreated {
+  issueNumber: Int!
+  title: String!
+  url: String!
+  action: RepositoryIntakeAction!
+  workItem: WorkItem!
+}
+
+"""
+Candidate-local Intake failure for one Issue. Processing continues with later
+candidates; earlier Work Items are not rolled back.
+"""
+type RepositoryIntakeFailed {
+  issueNumber: Int!
+  title: String!
+  url: String!
+  action: RepositoryIntakeAction!
+  error: RepositoryIntakeIssueError!
+}
+
+"""
+Per-Issue Intake outcome. Created and failed fields cannot coexist.
+"""
+union RepositoryIntakeIssueResult =
+  | RepositoryIntakeCreated
+  | RepositoryIntakeFailed
+
+"""
+Best-effort sequential Repository Intake result. Reclassifies current candidates
+at mutation time; does not accept candidate input or a plan token.
+"""
+type RepositoryIntakeResult {
+  repository: Repository!
+  results: [RepositoryIntakeIssueResult!]!
+}
+
 enum WorkItemState {
   WORK_ITEM_STATE_VALUES
 }
@@ -702,6 +751,17 @@ type Mutation {
   in Waiting for blockers (no Worker Slot, no Step Run).
   """
   queue(repositoryId: ID!, issueNumber: Int!): WorkItem!
+  """
+  Synchronous best-effort Repository Intake: reclassify current Intake
+  Candidates for one Repository, run one shared Repository preflight when the
+  set is nonempty, then process each candidate sequentially through ordinary
+  Implement Now or Queue. Candidate-local races become per-Issue failed
+  results; infrastructure, cancellation, and unexpected defects stop as
+  GraphQL errors while preserving earlier Work Items. No Intake entity or
+  persistence is created. Empty classification is a successful no-op and
+  bypasses preflight.
+  """
+  startRepositoryIntake(repositoryId: ID!): RepositoryIntakeResult!
   retryWorkItem(workItemId: ID!): WorkItem!
   pauseWorkItem(workItemId: ID!): WorkItem!
   startWorkItem(workItemId: ID!): WorkItem!


### PR DESCRIPTION
Adds synchronous best-effort **Repository Intake** so operators can start
every current Intake Candidate for one Repository in one finite CLI
invocation, reusing ordinary Implement Now / Queue admission instead of a
durable Intake aggregate.

**Why**
Parent work (#973) already listed candidates and Kanban status. Automated
operators still needed a single command that reclassifies current state,
prefights once, processes candidates sequentially, and returns a versioned
result document with clear partial-failure semantics.

**What changed**
- GraphQL `startRepositoryIntake(repositoryId)`: classify → empty no-op
  (skip preflight) or shared preflight → sequential Implement Now / Queue;
  candidate-local races continue as failed results; infrastructure/cancel/
  defects stop as operation-level errors; no Intake persistence.
- CLI `ready-for-agent intake <forge-host>/<project-path>`: versioned JSON
  on stdout; exit 0 for complete/empty, exit 1 for partial candidate
  failures (full document still on stdout); command-level errors on stderr.
- Tests: GraphQL (order, Queue routing, partial continue, fatal stop, abort,
  preflight, Paused); CLI unit/process JSON and exit codes; live e2e
  `candidates → intake → status` (+ rerun) with scenario-local Work Item
  reset teardown.

**Verification**
`graphql-api` and `ready-for-agent` tests/typecheck/lint (and pre-commit)
passed in this worktree. Live vault-backed e2e depends on fixture
credentials and is intended for `harness:e2e` CI.

Closes #978