### PR TITLE
fix(harness): show GraphQL start-work errors on Relevant Issues Banners

### DIFF
--- a/apps/harness/src/home-page-content.tsx
+++ b/apps/harness/src/home-page-content.tsx
@@ -101,6 +101,7 @@ import {
 } from "./routed-dialog.js"
 import { openSessionTelemetry } from "./session-telemetry-nav.js"
 import { sessionWorktreeParts } from "./session-worktree-line.js"
+import { startWorkBannerMessage } from "./start-work-banner-message.js"
 import { cx, ui } from "./ui.js"
 import { workItemIssueUrl } from "./work-item-issue-url.js"
 import { canShowWorkItemResetAction } from "./work-item-job-actions.js"
@@ -2904,8 +2905,11 @@ function ParentIssueGroup({
             tag="Error"
             role="alert"
           >
-            Could not start Implement all with auto-merge. Refresh the issues
-            and try again.
+            {startWorkBannerMessage({
+              error: implementAll.error,
+              fallback:
+                "Could not start Implement all with auto-merge. Refresh the issues and try again.",
+            })}
           </Banner>
         )}
         <ul className={ui.parentIssueChildren}>
@@ -3112,9 +3116,16 @@ function RepositoryIssueRow({
               tag="Error"
               role="alert"
             >
-              {queueIssue.isError
-                ? "Could not queue issue. Refresh the issues and try again."
-                : "Could not start implementation. Refresh the issues and try again."}
+              {startWorkBannerMessage({
+                error: queueIssue.isError
+                  ? queueIssue.error
+                  : implementNow.isError
+                    ? implementNow.error
+                    : implementLocally.error,
+                fallback: queueIssue.isError
+                  ? "Could not queue issue. Refresh the issues and try again."
+                  : "Could not start implementation. Refresh the issues and try again.",
+              })}
             </Banner>
           )}
           {issue.blockedBy.length > 0 && (

--- a/apps/harness/src/start-work-banner-message.ts
+++ b/apps/harness/src/start-work-banner-message.ts
@@ -1,0 +1,8 @@
+export const startWorkBannerMessage = ({
+  error,
+  fallback,
+}: {
+  readonly error: unknown
+  readonly fallback: string
+}): string =>
+  error instanceof Error && error.message !== "" ? error.message : fallback

--- a/apps/harness/test/repos-interchange.test.ts
+++ b/apps/harness/test/repos-interchange.test.ts
@@ -422,6 +422,8 @@ describe("Interchange phase 4: repos page + blank slate", () => {
     expect(parent).toContain("ui.parentIssueError")
     expect(parent).toContain("implementAll.isError")
     expect(parent).toContain('tone="alarm"')
+    expect(parent).toContain("startWorkBannerMessage")
+    expect(parent).toContain("implementAll.error")
     expect(parent).toContain("Could not start Implement all with auto-merge")
     expect(parent).toContain("errorMessage={null}")
 
@@ -460,6 +462,10 @@ describe("Interchange phase 4: repos page + blank slate", () => {
     expect(leaf).toContain("ui.repoIssueError")
     expect(leaf).toContain('tone="alarm"')
     expect(leaf).toContain('tag="Error"')
+    expect(leaf).toContain("startWorkBannerMessage")
+    expect(leaf).toContain("queueIssue.error")
+    expect(leaf).toContain("implementNow.error")
+    expect(leaf).toContain("implementLocally.error")
     expect(leaf).toContain("Could not queue issue")
     expect(leaf).toContain("Could not start implementation")
 

--- a/apps/harness/test/start-work-banner-message.test.ts
+++ b/apps/harness/test/start-work-banner-message.test.ts
@@ -1,0 +1,54 @@
+import { startWorkBannerMessage } from "../src/start-work-banner-message.js"
+import { describe, expect, test } from "bun:test"
+
+const catalogMessage =
+  'Build Agent Model "grok-4.5" is not in the current Grok Build Agent Model catalog. Choose a model the Agent Backend currently offers in Settings, then start this work again.'
+
+const startFallback =
+  "Could not start implementation. Refresh the issues and try again."
+
+const queueFallback = "Could not queue issue. Refresh the issues and try again."
+
+const implementAllFallback =
+  "Could not start Implement all with auto-merge. Refresh the issues and try again."
+
+describe("start-work Banner copy (issue #992)", () => {
+  test("shows a present GraphQL Error.message instead of the generic fallback", () => {
+    expect(
+      startWorkBannerMessage({
+        error: new Error(catalogMessage),
+        fallback: startFallback,
+      }),
+    ).toBe(catalogMessage)
+  })
+
+  test("keeps each action's generic fallback when the failure is not an Error", () => {
+    expect(
+      startWorkBannerMessage({
+        error: "BUILD_MODEL_NOT_CONFIGURED",
+        fallback: startFallback,
+      }),
+    ).toBe(startFallback)
+    expect(
+      startWorkBannerMessage({
+        error: { message: catalogMessage },
+        fallback: queueFallback,
+      }),
+    ).toBe(queueFallback)
+    expect(
+      startWorkBannerMessage({
+        error: null,
+        fallback: implementAllFallback,
+      }),
+    ).toBe(implementAllFallback)
+  })
+
+  test("keeps the generic fallback when Error.message is empty", () => {
+    expect(
+      startWorkBannerMessage({
+        error: new Error(""),
+        fallback: startFallback,
+      }),
+    ).toBe(startFallback)
+  })
+})


### PR DESCRIPTION
Relevant Issues start-work actions (Implement now, Implement locally,
Queue, and Implement all with auto-merge) always showed a generic
"refresh the issues" hint when the mutation failed. Operators hitting
catalog admission (`BUILD_MODEL_NOT_CONFIGURED`) or other GraphQL
reasons could not tell a Settings/catalog problem or an unfinished Work
Item from a missing Issue.

The existing compact alarm Banner now shows a non-empty GraphQL
`Error.message`, matching Repository settings and add-repository. Each
action keeps its current generic fallback when the thrown value is not
an `Error` or the message is empty. Banner chrome, reset-on-switch, and
GraphQL error mapping are unchanged.

Verification: `bunx nx test harness` (555 bun + 126 vitest). Copy
selection is locked in `startWorkBannerMessage` unit tests plus the
existing Repos interchange source-string and parent-menu chrome tests.
Review follow-up removed a parent-menu test that only echoed an unused
`errorMessage` prop.

No e2e or lifecycle/API tests were added; those messages already exist.
Catalog completeness remains #991.

Closes #992