### PR TITLE
fix(grok): include dash-listed models and grok-4.6 xhigh in inspect catalog

### DIFF
--- a/packages/grok/src/lib/parse-models.ts
+++ b/packages/grok/src/lib/parse-models.ts
@@ -1,4 +1,7 @@
-import { GROK_DEFAULT_THINKING_LEVELS } from "./types.js"
+import {
+  GROK_4_6_THINKING_LEVELS,
+  GROK_DEFAULT_THINKING_LEVELS,
+} from "./types.js"
 
 export type ParsedGrokModels = {
   readonly models: ReadonlyArray<{
@@ -10,7 +13,14 @@ export type ParsedGrokModels = {
 }
 
 const MODEL_LINE =
-  /^\s*\*\s+([A-Za-z0-9][A-Za-z0-9._-]*)(?:\s+\((?:default|.*?)\))?\s*$/
+  /^\s*[*-]\s+([A-Za-z0-9][A-Za-z0-9._-]*)(?:\s+\((?:default|.*?)\))?\s*$/
+
+const THINKING_LEVELS_BY_MODEL: Readonly<Record<string, readonly string[]>> = {
+  "grok-4.6": GROK_4_6_THINKING_LEVELS,
+}
+
+const thinkingLevelsForGrokModel = (id: string): readonly string[] =>
+  THINKING_LEVELS_BY_MODEL[id] ?? GROK_DEFAULT_THINKING_LEVELS
 
 const UNAUTHENTICATED_MARKERS = [
   /you are not authenticated/i,
@@ -21,8 +31,9 @@ const UNAUTHENTICATED_MARKERS = [
 ]
 
 /**
- * Parse `grok models` plain-text catalog. Unauthenticated banners are treated
- * as inspection failure even when the CLI exits successfully.
+ * Parse `grok models` plain-text catalog. Star and dash bullets are both
+ * current catalog entries. Unauthenticated banners are treated as inspection
+ * failure even when the CLI exits successfully.
  */
 export const parseGrokModelsOutput = (stdout: string): ParsedGrokModels => {
   const authenticated = !UNAUTHENTICATED_MARKERS.some((marker) =>
@@ -43,7 +54,7 @@ export const parseGrokModelsOutput = (stdout: string): ParsedGrokModels => {
     seen.add(id)
     models.push({
       id,
-      thinkingLevels: [...GROK_DEFAULT_THINKING_LEVELS],
+      thinkingLevels: [...thinkingLevelsForGrokModel(id)],
     })
   }
 

--- a/packages/grok/src/lib/types.ts
+++ b/packages/grok/src/lib/types.ts
@@ -7,3 +7,11 @@ export interface GrokLayerOptions {
 
 /** Installed CLI effort values advertised on every catalog model when global. */
 export const GROK_DEFAULT_THINKING_LEVELS = ["high", "medium", "low"] as const
+
+/** CLI-advertised effort values for grok-4.6 only. Other Grok models omit xhigh. */
+export const GROK_4_6_THINKING_LEVELS = [
+  "xhigh",
+  "high",
+  "medium",
+  "low",
+] as const

--- a/packages/grok/test/grok.spec.ts
+++ b/packages/grok/test/grok.spec.ts
@@ -285,10 +285,11 @@ describe("Grok AgentBackend adapter", () => {
         "cat <<'EOF'",
         "You are logged in with grok.com.",
         "",
-        "Default model: grok-4.5",
+        "Default model: grok-4.6",
         "",
         "Available models:",
-        "  * grok-4.5 (default)",
+        "  * grok-4.6 (default)",
+        "  - grok-4.5",
         "EOF",
       ].join("\n"),
       async (binary) => {
@@ -303,6 +304,10 @@ describe("Grok AgentBackend adapter", () => {
         )
         expect(result.backend).toEqual({ id: "grok", label: "Grok Build" })
         expect(result.models).toEqual([
+          {
+            id: "grok-4.6",
+            thinkingLevels: ["xhigh", "high", "medium", "low"],
+          },
           {
             id: "grok-4.5",
             thinkingLevels: ["high", "medium", "low"],

--- a/packages/grok/test/parse-models.spec.ts
+++ b/packages/grok/test/parse-models.spec.ts
@@ -1,6 +1,17 @@
 import { parseGrokModelsOutput } from "../src/index.js"
 import { describe, expect, it } from "bun:test"
 
+/** Grok CLI 1.0.3: default marked with `*`, other models listed with `-`. */
+const GROK_CLI_1_0_3_MODELS_STDOUT = [
+  "You are logged in with grok.com.",
+  "",
+  "Default model: grok-4.6",
+  "",
+  "Available models:",
+  "  * grok-4.6 (default)",
+  "  - grok-4.5",
+].join("\n")
+
 describe("parseGrokModelsOutput", () => {
   it("parses authenticated model catalog with default thinking levels", () => {
     const parsed = parseGrokModelsOutput(
@@ -26,6 +37,39 @@ describe("parseGrokModelsOutput", () => {
         thinkingLevels: ["high", "medium", "low"],
       },
     ])
+  })
+
+  it("includes dash-listed models from mixed-bullet grok models output", () => {
+    const parsed = parseGrokModelsOutput(GROK_CLI_1_0_3_MODELS_STDOUT)
+    expect(parsed.authenticated).toBe(true)
+    expect(parsed.complete).toBe(true)
+    expect(parsed.models.map((model) => model.id)).toEqual([
+      "grok-4.6",
+      "grok-4.5",
+    ])
+  })
+
+  it("assigns grok-4.6 xhigh thinking levels and default levels to other models", () => {
+    const parsed = parseGrokModelsOutput(
+      `${GROK_CLI_1_0_3_MODELS_STDOUT}\n  - grok-future-model`,
+    )
+    expect(parsed.models).toEqual([
+      {
+        id: "grok-4.6",
+        thinkingLevels: ["xhigh", "high", "medium", "low"],
+      },
+      {
+        id: "grok-4.5",
+        thinkingLevels: ["high", "medium", "low"],
+      },
+      {
+        id: "grok-future-model",
+        thinkingLevels: ["high", "medium", "low"],
+      },
+    ])
+    expect(
+      parsed.models.find((model) => model.id === "grok-4.5")?.thinkingLevels,
+    ).not.toContain("xhigh")
   })
 
   it("treats explicit unauthenticated output as inspection failure input", () => {


### PR DESCRIPTION
## Why

Grok CLI 1.0.3 still lists `grok-4.5` under Available models, but marks
the default with `*` and other models with `-`. Grok Build inspect
parsed only `*` bullets, so a stored `grok-4.5` selection disappeared
from the Agent Model catalog and catalog-only Settings treated it as
unavailable.

The same inspect path stamped every Grok model with Thinking Levels
`high`, `medium`, and `low`. `grok-4.6` also advertises `xhigh`;
`grok-4.5` does not. This is CLI format drift plus a stale Thinking
Level set, not a product decision to retire `grok-4.5` (#991).

## What changed

- `parseGrokModelsOutput` treats both `*` and `-` model lines as
  current catalog entries. The older all-`*` listing still works.
- After a model id is parsed, Thinking Levels come from a small
  exact-id map: `grok-4.6` gets `xhigh`, `high`, `medium`, `low`; every
  other Grok model, including `grok-4.5`, keeps `high`, `medium`,
  `low`.
- Unauthenticated banners and empty listings still fail closed.
- Settings, GraphQL membership, and Agent Turn admission are
  unchanged. They consume whatever inspect reports.

## Verification

- `bunx nx test grok`: mixed-bullet CLI 1.0.3 fixture, older all-`*`
  listing, per-model Thinking Levels, and the existing
  unauthenticated/empty-catalog cases. The inspect unit test uses
  mixed-bullet stdout. Live Grok integration tests remain skipped (no
  billed turn required).
- Local review found no findings. No remediation was required.

## Limitations

Operators refresh a stored inspect catalog with Recheck Agent Backend
(or the next successful inspect) after deploy. Unknown future Grok
model ids get the default three levels. Catalog membership still
follows whatever the current CLI lists.

Closes #991