### PR TITLE
test(harness): reuse Session Telemetry fixtures without per-scenario restart

### DIFF
--- a/apps/harness/e2e/steps/catalog-only-agent-model.ts
+++ b/apps/harness/e2e/steps/catalog-only-agent-model.ts
@@ -14,15 +14,14 @@
  */
 
 import { type Locator, type Page, expect } from "@playwright/test"
-import { E2E_GRAPHQL_URL } from "../support/constants.ts"
 import { dismissFirstRunSettingsIfPresent } from "../support/first-run-settings.ts"
 import {
   CONTROL_FILES,
   type FakeClaudeMode,
-  readGeneration,
   readLiveHarnessState,
   writeControlFile,
 } from "../support/live-harness-control.ts"
+import { seedLiveHarnessAndRestart } from "../support/live-harness-seed.ts"
 import { Given, Then, When } from "./fixtures.ts"
 
 /** Bedrock inference profile an operator had stored before switching modes. */
@@ -69,37 +68,6 @@ const awaitCatalogSettled = async (dialog: Locator) => {
   })
 }
 
-const graphqlReachable = async (): Promise<boolean> => {
-  try {
-    const response = await fetch(E2E_GRAPHQL_URL, {
-      method: "POST",
-      headers: { "content-type": "application/json" },
-      body: JSON.stringify({ query: "query { config { defaultModel } }" }),
-    })
-    return response.ok
-  } catch {
-    return false
-  }
-}
-
-/**
- * Seed SQL against the *stopped* database, then restart and wait for the new
- * process to serve GraphQL again. The supervisor owns both the database file
- * and the child process, so steps only drop a request in its control directory.
- */
-const seedAndRestart = async (sql: string) => {
-  const state = readLiveHarnessState()
-  const before = readGeneration(state)
-  writeControlFile(state, CONTROL_FILES.seedSql, sql)
-  writeControlFile(state, CONTROL_FILES.restart, "1")
-  await expect
-    .poll(() => readGeneration(state), { timeout: 60_000, intervals: [250] })
-    .toBeGreaterThan(before)
-  await expect
-    .poll(graphqlReachable, { timeout: 120_000, intervals: [500] })
-    .toBe(true)
-}
-
 const setClaudeMode = (mode: FakeClaudeMode) => {
   const state = readLiveHarnessState()
   writeControlFile(state, CONTROL_FILES.claudeMode, mode)
@@ -122,7 +90,7 @@ const seedClaudeHarnessDefault = async (buildModel: string) => {
       reviewThinkingLevel: null,
     },
   })
-  await seedAndRestart(
+  await seedLiveHarnessAndRestart(
     [
       "UPDATE config SET",
       "  selected_agent_backend = 'claude',",
@@ -165,7 +133,7 @@ When(
     })
     // Inherit the harness Agent Backend (NULL override) so the Repository's
     // Effective backend is Claude Code and its catalog is the global one.
-    await seedAndRestart(
+    await seedLiveHarnessAndRestart(
       [
         "UPDATE repository SET",
         "  selected_agent_backend = NULL,",
@@ -224,7 +192,7 @@ When(
   async () => {
     setClaudeMode("unauthenticated")
     // Restart with no seed: only the Agent Backend's readiness changed.
-    await seedAndRestart("")
+    await seedLiveHarnessAndRestart("")
   },
 )
 

--- a/apps/harness/e2e/steps/default-agent-backend-availability.ts
+++ b/apps/harness/e2e/steps/default-agent-backend-availability.ts
@@ -13,10 +13,10 @@ import { settingsDialog } from "../support/first-run-settings.ts"
 import {
   CONTROL_FILES,
   type FakeClaudeMode,
-  readGeneration,
   readLiveHarnessState,
   writeControlFile,
 } from "../support/live-harness-control.ts"
+import { seedLiveHarnessAndRestart } from "../support/live-harness-seed.ts"
 import { Given, Then, When } from "./fixtures.ts"
 
 type GraphqlEnvelope<T> = {
@@ -48,28 +48,11 @@ const graphqlJson = async <T>(
   return payload.data
 }
 
-const graphqlReachable = async (): Promise<boolean> => {
-  try {
-    const data = await graphqlJson<{ health: boolean }>(`query { health }`)
-    return data.health === true
-  } catch {
-    return false
-  }
-}
-
 const setClaudeModeAndRestart = async (mode: FakeClaudeMode) => {
   const state = readLiveHarnessState()
-  const before = readGeneration(state)
   writeControlFile(state, CONTROL_FILES.claudeMode, mode)
   // Empty seed: only fake-CLI readiness changed.
-  writeControlFile(state, CONTROL_FILES.seedSql, "")
-  writeControlFile(state, CONTROL_FILES.restart, "1")
-  await expect
-    .poll(() => readGeneration(state), { timeout: 60_000, intervals: [250] })
-    .toBeGreaterThan(before)
-  await expect
-    .poll(graphqlReachable, { timeout: 120_000, intervals: [500] })
-    .toBe(true)
+  await seedLiveHarnessAndRestart("")
 }
 
 Given("Claude Code reports unauthenticated", async () => {

--- a/apps/harness/e2e/support/live-harness-seed.ts
+++ b/apps/harness/e2e/support/live-harness-seed.ts
@@ -1,0 +1,128 @@
+/**
+ * Idempotent live-e2e persistence seeds (issue #994).
+ *
+ * SQL still goes through the supervisor's stopped-database control plane, but
+ * a seed is applied only when the caller reports the rows missing. Re-seeding
+ * is a no-op for that live Harness process; restart happens only when a write
+ * against the stopped database is required. Catalog-only Agent Model and
+ * Claude readiness changes keep calling {@link seedLiveHarnessAndRestart}
+ * because those scenarios need a new child process.
+ */
+
+import { E2E_GRAPHQL_URL } from "./constants.ts"
+import {
+  CONTROL_FILES,
+  type LiveHarnessState,
+  readGeneration,
+  readLiveHarnessState,
+  writeControlFile,
+} from "./live-harness-control.ts"
+
+export type LiveHarnessPersistenceOutcome =
+  | { readonly kind: "already-present" }
+  | { readonly kind: "seeded" }
+
+export type LiveHarnessSeedControl = {
+  readonly readState: () => LiveHarnessState
+  readonly readGeneration: (state: LiveHarnessState) => number
+  readonly writeControlFile: (
+    state: LiveHarnessState,
+    file: (typeof CONTROL_FILES)[keyof typeof CONTROL_FILES],
+    contents: string,
+  ) => void
+  readonly waitForRestart: (input: {
+    readonly state: LiveHarnessState
+    readonly generationBefore: number
+  }) => Promise<void>
+}
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
+
+const pollUntil = async (
+  probe: () => boolean | Promise<boolean>,
+  options: {
+    readonly timeoutMs: number
+    readonly intervalMs: number
+    readonly message: string
+  },
+): Promise<void> => {
+  const deadline = Date.now() + options.timeoutMs
+  while (Date.now() < deadline) {
+    if (await probe()) {
+      return
+    }
+    await sleep(options.intervalMs)
+  }
+  throw new Error(options.message)
+}
+
+const liveHarnessGraphqlReachable = async (): Promise<boolean> => {
+  try {
+    const response = await fetch(E2E_GRAPHQL_URL, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ query: "query { health }" }),
+    })
+    if (!response.ok) {
+      return false
+    }
+    const payload = (await response.json()) as {
+      data?: { health?: boolean }
+    }
+    return payload.data?.health === true
+  } catch {
+    return false
+  }
+}
+
+const defaultControl: LiveHarnessSeedControl = {
+  readState: readLiveHarnessState,
+  readGeneration,
+  writeControlFile,
+  waitForRestart: async ({ state, generationBefore }) => {
+    await pollUntil(() => readGeneration(state) > generationBefore, {
+      timeoutMs: 60_000,
+      intervalMs: 250,
+      message: `Live Harness did not restart after seed (generation still ${String(generationBefore)})`,
+    })
+    await pollUntil(liveHarnessGraphqlReachable, {
+      timeoutMs: 120_000,
+      intervalMs: 500,
+      message: "Live Harness GraphQL did not become reachable after restart",
+    })
+  },
+}
+
+/**
+ * Apply SQL against the stopped Harness database and wait for a new child.
+ * Use when the write cannot happen while the process holds the file, or when
+ * a restart is itself the behavior under test.
+ */
+export const seedLiveHarnessAndRestart = async (
+  sql: string,
+  control: LiveHarnessSeedControl = defaultControl,
+): Promise<void> => {
+  const state = control.readState()
+  const generationBefore = control.readGeneration(state)
+  control.writeControlFile(state, CONTROL_FILES.seedSql, sql)
+  control.writeControlFile(state, CONTROL_FILES.restart, "1")
+  await control.waitForRestart({ state, generationBefore })
+}
+
+/**
+ * Seed live-Harness persistence if the rows are not already present.
+ * Restarts only when a write against the stopped database is required.
+ */
+export const ensureLiveHarnessPersistence = async (
+  input: {
+    readonly alreadyPresent: () => Promise<boolean>
+    readonly sql: string
+  },
+  control: LiveHarnessSeedControl = defaultControl,
+): Promise<LiveHarnessPersistenceOutcome> => {
+  if (await input.alreadyPresent()) {
+    return { kind: "already-present" }
+  }
+  await seedLiveHarnessAndRestart(input.sql, control)
+  return { kind: "seeded" }
+}

--- a/apps/harness/e2e/support/session-telemetry-fixture.ts
+++ b/apps/harness/e2e/support/session-telemetry-fixture.ts
@@ -1,19 +1,15 @@
 /**
  * Deterministic Work Item / Session Telemetry fixtures for live e2e (issue #841).
  *
- * Seeds via the existing live-Harness control plane (stopped DB + restart).
- * Does not mock router internals — only Harness persistence and optional GraphQL
- * response shaping for outcomes that need a real OpenCode session store.
+ * Seeds once per live Harness process via {@link ensureLiveHarnessPersistence}:
+ * the first call writes rows against the stopped database and restarts; later
+ * calls no-op when the fixtures are already present. Does not mock router
+ * internals — only Harness persistence and optional GraphQL response shaping
+ * for outcomes that need a real OpenCode session store.
  */
 
-import { expect } from "@playwright/test"
 import { E2E_GRAPHQL_URL } from "./constants.ts"
-import {
-  CONTROL_FILES,
-  readGeneration,
-  readLiveHarnessState,
-  writeControlFile,
-} from "./live-harness-control.ts"
+import { ensureLiveHarnessPersistence } from "./live-harness-seed.ts"
 
 /**
  * Branded entity IDs must match DB schema patterns
@@ -49,32 +45,60 @@ export const TELEMETRY_FIXTURE = {
   completedPageTwoIssueId: "issue-01KZD5SESS10NTE0FXX0000004",
 } as const
 
+/** Named Session Telemetry Work Items the operator-visible scenarios open. */
+export const SESSION_TELEMETRY_FIXTURE_WORK_ITEM_IDS = [
+  TELEMETRY_FIXTURE.missingSessionWorkItemId,
+  TELEMETRY_FIXTURE.codexMissingWorkItemId,
+  TELEMETRY_FIXTURE.completedWorkItemId,
+  TELEMETRY_FIXTURE.completedPageTwoWorkItemId,
+] as const
+
+/** Completed archive fillers that pin the page-2 fixture. */
+const SESSION_TELEMETRY_FILLER_COUNT = 38
+
+/** Named Work Items plus Completed pagination fillers. */
+export const SESSION_TELEMETRY_FIXTURE_WORK_ITEM_COUNT =
+  SESSION_TELEMETRY_FIXTURE_WORK_ITEM_IDS.length +
+  SESSION_TELEMETRY_FILLER_COUNT
+
+export const sessionTelemetryFixturesArePresent = (
+  workItems: ReadonlyArray<{ readonly id: string }>,
+): boolean => {
+  const ids = new Set(workItems.map((item) => item.id))
+  return (
+    SESSION_TELEMETRY_FIXTURE_WORK_ITEM_IDS.every((id) => ids.has(id)) &&
+    workItems.length >= SESSION_TELEMETRY_FIXTURE_WORK_ITEM_COUNT
+  )
+}
+
 const sqlLiteral = (value: string) => `'${value.replaceAll("'", "''")}'`
 
-const graphqlReachable = async (): Promise<boolean> => {
+const sessionTelemetryFixturesPresent = async (): Promise<boolean> => {
   try {
     const response = await fetch(E2E_GRAPHQL_URL, {
       method: "POST",
       headers: { "content-type": "application/json" },
-      body: JSON.stringify({ query: "query { config { defaultModel } }" }),
+      body: JSON.stringify({
+        query: `query SessionTelemetryFixtures($repositoryId: ID!) {
+          workItems(repositoryId: $repositoryId) { id }
+        }`,
+        variables: { repositoryId: TELEMETRY_FIXTURE.repositoryId },
+      }),
     })
-    return response.ok
+    if (!response.ok) {
+      return false
+    }
+    const payload = (await response.json()) as {
+      data?: { workItems?: ReadonlyArray<{ id: string }> }
+      errors?: ReadonlyArray<{ message: string }>
+    }
+    if (payload.errors?.length || payload.data?.workItems === undefined) {
+      return false
+    }
+    return sessionTelemetryFixturesArePresent(payload.data.workItems)
   } catch {
     return false
   }
-}
-
-const seedAndRestart = async (sql: string) => {
-  const state = readLiveHarnessState()
-  const before = readGeneration(state)
-  writeControlFile(state, CONTROL_FILES.seedSql, sql)
-  writeControlFile(state, CONTROL_FILES.restart, "1")
-  await expect
-    .poll(() => readGeneration(state), { timeout: 60_000, intervals: [250] })
-    .toBeGreaterThan(before)
-  await expect
-    .poll(graphqlReachable, { timeout: 120_000, intervals: [500] })
-    .toBe(true)
 }
 
 /**
@@ -95,16 +119,18 @@ export const seedSessionTelemetryFixtures = async (): Promise<void> => {
   // rows: page 1 has the existing telemetry fixture + 19 fillers, and page 2
   // has the dedicated page-two fixture + 19 fillers.
   const completedOrderBase = now + 10_000_000_000
-  const fillerWorkItems = Array.from({ length: 38 }, (_, index) => {
-    const issueNumber = 200 + index
-    const order =
-      index < 19
-        ? completedOrderBase + 199 - index
-        : index < 33
-          ? completedOrderBase + 69 - (index - 19)
-          : completedOrderBase + 49 - (index - 33)
-    const id = `wi-01KZD5SESS10NTE0F${String(index + 1).padStart(9, "0")}`
-    return `INSERT INTO work_item (
+  const fillerWorkItems = Array.from(
+    { length: SESSION_TELEMETRY_FILLER_COUNT },
+    (_, index) => {
+      const issueNumber = 200 + index
+      const order =
+        index < 19
+          ? completedOrderBase + 199 - index
+          : index < 33
+            ? completedOrderBase + 69 - (index - 19)
+            : completedOrderBase + 49 - (index - 33)
+      const id = `wi-01KZD5SESS10NTE0F${String(index + 1).padStart(9, "0")}`
+      return `INSERT INTO work_item (
        id, repository_id, issue_number, issue_title, agent_backend,
        state, state_ready_at, paused, holds_worker_slot, session_id,
        created_at, updated_at
@@ -122,7 +148,8 @@ export const seedSessionTelemetryFixtures = async (): Promise<void> => {
        ${order},
        ${order}
      );`
-  })
+    },
+  )
   const sql = [
     // Clear prior fixture rows so scenarios can re-seed safely.
     `DELETE FROM work_item WHERE repository_id = ${sqlLiteral(TELEMETRY_FIXTURE.repositoryId)};`,
@@ -286,5 +313,8 @@ export const seedSessionTelemetryFixtures = async (): Promise<void> => {
     ...fillerWorkItems.slice(19),
   ].join("\n")
 
-  await seedAndRestart(sql)
+  await ensureLiveHarnessPersistence({
+    alreadyPresent: sessionTelemetryFixturesPresent,
+    sql,
+  })
 }

--- a/apps/harness/test/live-harness-seed.test.ts
+++ b/apps/harness/test/live-harness-seed.test.ts
@@ -1,0 +1,125 @@
+import {
+  CONTROL_FILES,
+  type LiveHarnessState,
+} from "../e2e/support/live-harness-control.ts"
+import {
+  type LiveHarnessSeedControl,
+  ensureLiveHarnessPersistence,
+  seedLiveHarnessAndRestart,
+} from "../e2e/support/live-harness-seed.ts"
+import {
+  SESSION_TELEMETRY_FIXTURE_WORK_ITEM_COUNT,
+  SESSION_TELEMETRY_FIXTURE_WORK_ITEM_IDS,
+  TELEMETRY_FIXTURE,
+  sessionTelemetryFixturesArePresent,
+} from "../e2e/support/session-telemetry-fixture.ts"
+import { describe, expect, test } from "bun:test"
+
+const state: LiveHarnessState = {
+  dbPath: "/tmp/e2e-harness.db",
+  controlDir: "/tmp/e2e-control",
+}
+
+const recordingControl = (): {
+  control: LiveHarnessSeedControl
+  files: Map<string, string>
+  waitCalls: number
+} => {
+  const files = new Map<string, string>()
+  let waitCalls = 0
+  const control: LiveHarnessSeedControl = {
+    readState: () => state,
+    readGeneration: () => 3,
+    writeControlFile: (_state, file, contents) => {
+      files.set(file, contents)
+    },
+    waitForRestart: async () => {
+      waitCalls += 1
+    },
+  }
+  return {
+    get waitCalls() {
+      return waitCalls
+    },
+    control,
+    files,
+  }
+}
+
+describe("ensureLiveHarnessPersistence", () => {
+  test("is a no-op when the seed is already present", async () => {
+    const recording = recordingControl()
+
+    const outcome = await ensureLiveHarnessPersistence(
+      {
+        alreadyPresent: async () => true,
+        sql: "INSERT INTO repository (id) VALUES ('should-not-write');",
+      },
+      recording.control,
+    )
+
+    expect(outcome).toEqual({ kind: "already-present" })
+    expect(recording.files.size).toBe(0)
+    expect(recording.waitCalls).toBe(0)
+  })
+
+  test("seeds against the stopped database and restarts when missing", async () => {
+    const recording = recordingControl()
+    const sql = "INSERT INTO work_item (id) VALUES ('wi-missing');"
+
+    const outcome = await ensureLiveHarnessPersistence(
+      {
+        alreadyPresent: async () => false,
+        sql,
+      },
+      recording.control,
+    )
+
+    expect(outcome).toEqual({ kind: "seeded" })
+    expect(recording.files.get(CONTROL_FILES.seedSql)).toBe(sql)
+    expect(recording.files.get(CONTROL_FILES.restart)).toBe("1")
+    expect(recording.waitCalls).toBe(1)
+  })
+})
+
+describe("seedLiveHarnessAndRestart", () => {
+  test("always requests a restart, including empty SQL for readiness-only changes", async () => {
+    const recording = recordingControl()
+
+    await seedLiveHarnessAndRestart("", recording.control)
+
+    expect(recording.files.get(CONTROL_FILES.seedSql)).toBe("")
+    expect(recording.files.get(CONTROL_FILES.restart)).toBe("1")
+    expect(recording.waitCalls).toBe(1)
+  })
+})
+
+describe("sessionTelemetryFixturesArePresent", () => {
+  test("requires the named Work Items and the Completed pagination fillers", () => {
+    const named: ReadonlyArray<{ readonly id: string }> =
+      SESSION_TELEMETRY_FIXTURE_WORK_ITEM_IDS.map((id) => ({ id }))
+    const fillers: ReadonlyArray<{ readonly id: string }> = Array.from(
+      {
+        length:
+          SESSION_TELEMETRY_FIXTURE_WORK_ITEM_COUNT -
+          SESSION_TELEMETRY_FIXTURE_WORK_ITEM_IDS.length,
+      },
+      (_, index) => ({
+        id: `wi-01KZD5SESS10NTE0F${String(index + 1).padStart(9, "0")}`,
+      }),
+    )
+
+    expect(sessionTelemetryFixturesArePresent([])).toBe(false)
+    expect(sessionTelemetryFixturesArePresent(named)).toBe(false)
+    expect(sessionTelemetryFixturesArePresent([...named, ...fillers])).toBe(
+      true,
+    )
+    expect(
+      sessionTelemetryFixturesArePresent(
+        named
+          .filter((item) => item.id !== TELEMETRY_FIXTURE.completedWorkItemId)
+          .concat(fillers),
+      ),
+    ).toBe(false)
+  })
+})


### PR DESCRIPTION
## Why

Session Telemetry live e2e re-applied fixture SQL and restarted the live
Harness (and with it the Keymaxxer Sidecar) on every scenario Background.
The operator-visible assertions did not need a new process each time; the
extra listen made the feature pay a full boot per scenario.

## What changed

- Add `ensureLiveHarnessPersistence` for later live-e2e seeds: seed if
  missing, no-op when the rows are already present, restart only when a
  stopped-database write is required.
- Session Telemetry Background uses that helper. Presence is a GraphQL
  `workItems` probe for the four named Work Items plus the 38 Completed
  pagination fillers; a miss still writes SQL against the stopped DB and
  restarts once.
- Catalog-only Agent Model and Claude readiness still call
  `seedLiveHarnessAndRestart` (including empty SQL) so those scenarios keep
  a real child restart.

## Verification

- `bunx nx test harness`: new helper unit tests plus the existing harness
  suite (558 bun + 126 vitest).
- Session Telemetry live e2e: 22/22. The Harness listened once after the
  first seed; later Backgrounds were no-ops (~1-4s).
- Vault-free `@no-backend` Claude-readiness e2e: 2/2, each scenario still
  restarted.
- Local review: no findings; no remediation.

## Limitations

The first Session Telemetry scenario still restarts because fixture SQL
still needs the stopped database. Vault-backed `harness:e2e` catalog-only
scenarios were not run in this worktree; they now share the same restart
helper exercised by the Claude-readiness run.

Closes #994