### PR TITLE
fix(harness): drive GitHub throttle banner from GITHUB_THROTTLED errors (#1003)

### DIFF
--- a/apps/harness/src/github-throttle-errors.ts
+++ b/apps/harness/src/github-throttle-errors.ts
@@ -1,0 +1,158 @@
+import { type QueryClient, useQueryClient } from "@tanstack/react-query"
+import { useEffect, useState } from "react"
+
+const GITHUB_THROTTLED = "GITHUB_THROTTLED"
+
+type GenqlErrorLike = Error & {
+  readonly errors: ReadonlyArray<{
+    readonly extensions?: Record<string, unknown>
+  }>
+}
+
+const isGenqlErrorLike = (error: unknown): error is GenqlErrorLike =>
+  error instanceof Error &&
+  "errors" in error &&
+  Array.isArray((error as { errors: unknown }).errors)
+
+const isoFromRetryAt = (retryAt: unknown): string | null => {
+  if (typeof retryAt === "number" && Number.isFinite(retryAt)) {
+    const parsed = new Date(retryAt)
+    return Number.isNaN(parsed.getTime()) ? null : parsed.toISOString()
+  }
+  if (typeof retryAt === "string" && retryAt.length > 0) {
+    const parsed = new Date(retryAt)
+    return Number.isNaN(parsed.getTime()) ? null : parsed.toISOString()
+  }
+  return null
+}
+
+/** Future ISO-8601 `retryAt` from a Genql-shaped `GITHUB_THROTTLED` error. */
+export const githubThrottledRetryAtFromError = (
+  error: unknown,
+  nowMs: number = Date.now(),
+): string | null => {
+  if (!isGenqlErrorLike(error)) return null
+  let latest: string | null = null
+  for (const graphQlError of error.errors) {
+    if (graphQlError.extensions?.code !== GITHUB_THROTTLED) continue
+    const iso = isoFromRetryAt(graphQlError.extensions.retryAt)
+    if (iso === null) continue
+    const retryAtMs = Date.parse(iso)
+    if (Number.isNaN(retryAtMs) || retryAtMs <= nowMs) continue
+    latest = laterGithubThrottleDeadline(latest, iso)
+  }
+  return latest
+}
+
+/** Keep the later ISO deadline; nulls do not replace a known deadline. */
+export const laterGithubThrottleDeadline = (
+  current: string | null,
+  candidate: string | null,
+): string | null => {
+  if (candidate === null) return current
+  if (current === null) return candidate
+  const currentMs = Date.parse(current)
+  const candidateMs = Date.parse(candidate)
+  if (Number.isNaN(candidateMs)) return current
+  if (Number.isNaN(currentMs)) return candidate
+  return candidateMs > currentMs ? candidate : current
+}
+
+const defaultScheduleHide = (
+  callback: () => void,
+  delayMs: number,
+): (() => void) => {
+  const handle = setTimeout(callback, delayMs)
+  return () => {
+    clearTimeout(handle)
+  }
+}
+
+/**
+ * Drive the GitHub Throttle banner from TanStack Query / mutation cache
+ * errors. Clears locally when `retryAt` elapses — no network.
+ */
+export const followGithubThrottleErrors = ({
+  queryClient,
+  onRetryAtChange,
+  now = Date.now,
+  scheduleHide = defaultScheduleHide,
+}: {
+  readonly queryClient: QueryClient
+  readonly onRetryAtChange: (retryAt: string | null) => void
+  readonly now?: () => number
+  readonly scheduleHide?: (callback: () => void, delayMs: number) => () => void
+}): (() => void) => {
+  let retryAt: string | null = null
+  let cancelHide: (() => void) | undefined
+
+  const publish = (next: string | null) => {
+    if (next === retryAt) return
+    retryAt = next
+    cancelHide?.()
+    cancelHide = undefined
+    if (next !== null) {
+      const delayMs = Date.parse(next) - now()
+      if (delayMs <= 0) {
+        retryAt = null
+      } else {
+        const scheduled = next
+        cancelHide = scheduleHide(() => {
+          if (retryAt !== scheduled) return
+          retryAt = null
+          cancelHide = undefined
+          onRetryAtChange(null)
+        }, delayMs)
+      }
+    }
+    onRetryAtChange(retryAt)
+  }
+
+  const considerError = (error: unknown) => {
+    publish(
+      laterGithubThrottleDeadline(
+        retryAt,
+        githubThrottledRetryAtFromError(error, now()),
+      ),
+    )
+  }
+
+  const unsubscribeQuery = queryClient.getQueryCache().subscribe((event) => {
+    if (event.type !== "updated") return
+    considerError(event.query.state.error)
+  })
+  const unsubscribeMutation = queryClient
+    .getMutationCache()
+    .subscribe((event) => {
+      if (event.type !== "updated") return
+      considerError(event.mutation.state.error)
+    })
+
+  for (const query of queryClient.getQueryCache().getAll()) {
+    considerError(query.state.error)
+  }
+  for (const mutation of queryClient.getMutationCache().getAll()) {
+    considerError(mutation.state.error)
+  }
+
+  return () => {
+    unsubscribeQuery()
+    unsubscribeMutation()
+    cancelHide?.()
+  }
+}
+
+/** Always-mounted banner deadline from GraphQL `GITHUB_THROTTLED` errors. */
+export const useGithubThrottleRetryAt = (): string | null => {
+  const queryClient = useQueryClient()
+  const [retryAt, setRetryAt] = useState<string | null>(null)
+  useEffect(
+    () =>
+      followGithubThrottleErrors({
+        queryClient,
+        onRetryAtChange: setRetryAt,
+      }),
+    [queryClient],
+  )
+  return retryAt
+}

--- a/apps/harness/src/routes/__root.tsx
+++ b/apps/harness/src/routes/__root.tsx
@@ -46,6 +46,7 @@ import { Banner, BannerActionButton } from "../banner.js"
 import { CommittedPullRequestsDashboard } from "../committed-pr-dashboard.js"
 import { READY_FOR_AGENT_VERSION_LABEL } from "../generated/version"
 import { GitHubThrottleBanner } from "../github-throttle-banner.js"
+import { useGithubThrottleRetryAt } from "../github-throttle-errors.js"
 import { getHarnessSettingsAutoOpenAction } from "../harness-settings-auto-open.js"
 import { JobsRepositoryFilterProvider } from "../jobs-repository-filter.js"
 import { JobsViewSwitcher } from "../jobs-view-switcher.js"
@@ -122,17 +123,6 @@ const agentBackendStatusQuery = {
       agentBackends: { id: true, label: true, configurationMode: true },
     })
     return result
-  },
-}
-
-const githubThrottleStatusQuery = {
-  queryKey: ["githubThrottleStatus"],
-  refetchInterval: 1_000,
-  queryFn: async () => {
-    const result = await graphql.query({
-      githubThrottleStatus: { retryAt: true },
-    })
-    return result.githubThrottleStatus
   },
 }
 
@@ -436,7 +426,7 @@ function SettingsChrome() {
   const [autoOpenAttempted, setAutoOpenAttempted] = useState(false)
   const config = useQuery(configQuery)
   const backendStatus = useQuery(agentBackendStatusQuery)
-  const githubThrottle = useQuery(githubThrottleStatusQuery)
+  const githubThrottleRetryAt = useGithubThrottleRetryAt()
   // Do not treat pending/unknown as empty: hide the band only once membership
   // has loaded with zero repositories (matches HomeContent blank-slate gate).
   const repositoriesMembership = useQuery(repositoriesQuery)
@@ -1271,7 +1261,7 @@ function SettingsChrome() {
       </div>
 
       <div className={ui.pageShell}>
-        <GitHubThrottleBanner retryAt={githubThrottle.data?.retryAt} />
+        <GitHubThrottleBanner retryAt={githubThrottleRetryAt} />
         {showBackendBanner && !dialogOpen && (
           <Banner
             tone="alarm"

--- a/apps/harness/src/server/application.server.ts
+++ b/apps/harness/src/server/application.server.ts
@@ -54,10 +54,7 @@ import {
   environmentConfigLayer,
   loadApplicationConfig,
 } from "./application-config.js"
-import {
-  GitHubOperationCoordinator,
-  GitHubOperationCoordinatorLive,
-} from "./github-operation-coordinator.js"
+import { GitHubOperationCoordinatorLive } from "./github-operation-coordinator.js"
 import { JobWorkerLive } from "./job-worker.js"
 import { keymaxxerGitHubLayer } from "./keymaxxer-github-layer.js"
 import { keymaxxerGitLabLayer } from "./keymaxxer-gitlab-layer.js"
@@ -345,12 +342,6 @@ export const createApplication = async (
     context: {
       graphqlApi: createGraphqlApi(runtime, {
         agentBackendCwd: toolCwd,
-        githubThrottleStatus: () =>
-          runtime.runPromise(
-            Effect.map(GitHubOperationCoordinator, (coordinator) =>
-              coordinator.throttleStatus(),
-            ),
-          ),
       }),
     },
     dispose: runtime.dispose,

--- a/apps/harness/test/github-throttle-errors.test.ts
+++ b/apps/harness/test/github-throttle-errors.test.ts
@@ -1,0 +1,267 @@
+import { readFileSync } from "node:fs"
+import { join } from "node:path"
+import { MutationObserver, QueryClient } from "@tanstack/react-query"
+import {
+  followGithubThrottleErrors,
+  githubThrottledRetryAtFromError,
+  laterGithubThrottleDeadline,
+} from "../src/github-throttle-errors.js"
+import { describe, expect, test } from "bun:test"
+
+const NOW_MS = Date.parse("2026-08-13T12:00:00.000Z")
+const FUTURE_ISO = "2026-08-13T12:05:00.000Z"
+const LATER_ISO = "2026-08-13T12:10:00.000Z"
+const PAST_ISO = "2026-08-13T11:59:00.000Z"
+const FUTURE_MS = Date.parse(FUTURE_ISO)
+const LATER_MS = Date.parse(LATER_ISO)
+const PAST_MS = Date.parse(PAST_ISO)
+
+const genqlError = (extensions: Record<string, unknown>): Error => {
+  const error = new Error("GitHub is throttling Harness requests") as Error & {
+    errors: ReadonlyArray<{ extensions?: Record<string, unknown> }>
+  }
+  error.errors = [{ extensions }]
+  return error
+}
+
+const createClock = (startMs: number) => {
+  let nowMs = startMs
+  const hides: Array<{
+    atMs: number
+    callback: () => void
+    cancelled: boolean
+  }> = []
+  return {
+    now: () => nowMs,
+    scheduleHide: (callback: () => void, delayMs: number) => {
+      const entry = { atMs: nowMs + delayMs, callback, cancelled: false }
+      hides.push(entry)
+      return () => {
+        entry.cancelled = true
+      }
+    },
+    advance: (deltaMs: number) => {
+      nowMs += deltaMs
+      for (const entry of hides) {
+        if (!entry.cancelled && entry.atMs <= nowMs) {
+          entry.cancelled = true
+          entry.callback()
+        }
+      }
+    },
+  }
+}
+
+describe("githubThrottledRetryAtFromError", () => {
+  test("returns a future ISO deadline from epoch millis", () => {
+    expect(
+      githubThrottledRetryAtFromError(
+        genqlError({ code: "GITHUB_THROTTLED", retryAt: FUTURE_MS }),
+        NOW_MS,
+      ),
+    ).toBe(FUTURE_ISO)
+  })
+
+  test("normalizes a future ISO retryAt", () => {
+    expect(
+      githubThrottledRetryAtFromError(
+        genqlError({
+          code: "GITHUB_THROTTLED",
+          retryAt: "2026-08-13T12:05:00.000Z",
+        }),
+        NOW_MS,
+      ),
+    ).toBe(FUTURE_ISO)
+  })
+
+  test("returns null for a past deadline", () => {
+    expect(
+      githubThrottledRetryAtFromError(
+        genqlError({ code: "GITHUB_THROTTLED", retryAt: PAST_MS }),
+        NOW_MS,
+      ),
+    ).toBeNull()
+    expect(
+      githubThrottledRetryAtFromError(
+        genqlError({ code: "GITHUB_THROTTLED", retryAt: PAST_ISO }),
+        NOW_MS,
+      ),
+    ).toBeNull()
+  })
+
+  test("returns null for other GraphQL errors", () => {
+    expect(
+      githubThrottledRetryAtFromError(
+        genqlError({ code: "INTERNAL_SERVER_ERROR", retryAt: FUTURE_MS }),
+        NOW_MS,
+      ),
+    ).toBeNull()
+    expect(
+      githubThrottledRetryAtFromError(new Error("boom"), NOW_MS),
+    ).toBeNull()
+    expect(
+      githubThrottledRetryAtFromError("GITHUB_THROTTLED", NOW_MS),
+    ).toBeNull()
+  })
+})
+
+describe("laterGithubThrottleDeadline", () => {
+  test("keeps the later deadline", () => {
+    expect(laterGithubThrottleDeadline(FUTURE_ISO, LATER_ISO)).toBe(LATER_ISO)
+    expect(laterGithubThrottleDeadline(LATER_ISO, FUTURE_ISO)).toBe(LATER_ISO)
+    expect(laterGithubThrottleDeadline(null, FUTURE_ISO)).toBe(FUTURE_ISO)
+    expect(laterGithubThrottleDeadline(FUTURE_ISO, null)).toBe(FUTURE_ISO)
+  })
+})
+
+describe("followGithubThrottleErrors", () => {
+  test("shows a query-cache GITHUB_THROTTLED error and hides it when the deadline elapses", async () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    })
+    const clock = createClock(NOW_MS)
+    const seen: Array<string | null> = []
+    const stop = followGithubThrottleErrors({
+      queryClient,
+      onRetryAtChange: (retryAt) => {
+        seen.push(retryAt)
+      },
+      now: clock.now,
+      scheduleHide: clock.scheduleHide,
+    })
+
+    await queryClient
+      .fetchQuery({
+        queryKey: ["open-pull-request-counts"],
+        queryFn: async () => {
+          throw genqlError({ code: "GITHUB_THROTTLED", retryAt: FUTURE_MS })
+        },
+      })
+      .catch(() => undefined)
+
+    expect(seen.at(-1)).toBe(FUTURE_ISO)
+
+    clock.advance(5 * 60_000)
+    expect(seen.at(-1)).toBeNull()
+
+    stop()
+  })
+
+  test("replaces an earlier deadline and ignores an earlier one", async () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    })
+    const clock = createClock(NOW_MS)
+    const seen: Array<string | null> = []
+    const stop = followGithubThrottleErrors({
+      queryClient,
+      onRetryAtChange: (retryAt) => {
+        seen.push(retryAt)
+      },
+      now: clock.now,
+      scheduleHide: clock.scheduleHide,
+    })
+
+    await queryClient
+      .fetchQuery({
+        queryKey: ["first"],
+        queryFn: async () => {
+          throw genqlError({ code: "GITHUB_THROTTLED", retryAt: FUTURE_MS })
+        },
+      })
+      .catch(() => undefined)
+    await queryClient
+      .fetchQuery({
+        queryKey: ["second"],
+        queryFn: async () => {
+          throw genqlError({ code: "GITHUB_THROTTLED", retryAt: LATER_MS })
+        },
+      })
+      .catch(() => undefined)
+    await queryClient
+      .fetchQuery({
+        queryKey: ["third"],
+        queryFn: async () => {
+          throw genqlError({ code: "GITHUB_THROTTLED", retryAt: FUTURE_MS })
+        },
+      })
+      .catch(() => undefined)
+
+    expect(seen.filter((value) => value !== null)).toEqual([
+      FUTURE_ISO,
+      LATER_ISO,
+    ])
+
+    clock.advance(5 * 60_000)
+    expect(seen.at(-1)).toBe(LATER_ISO)
+
+    clock.advance(5 * 60_000)
+    expect(seen.at(-1)).toBeNull()
+
+    stop()
+  })
+
+  test("picks up a mutation-cache GITHUB_THROTTLED error", async () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { mutations: { retry: false } },
+    })
+    const clock = createClock(NOW_MS)
+    const seen: Array<string | null> = []
+    const stop = followGithubThrottleErrors({
+      queryClient,
+      onRetryAtChange: (retryAt) => {
+        seen.push(retryAt)
+      },
+      now: clock.now,
+      scheduleHide: clock.scheduleHide,
+    })
+
+    const observer = new MutationObserver(queryClient, {
+      mutationFn: async () => {
+        throw genqlError({ code: "GITHUB_THROTTLED", retryAt: FUTURE_ISO })
+      },
+    })
+    await observer.mutate().catch(() => undefined)
+
+    expect(seen.at(-1)).toBe(FUTURE_ISO)
+    stop()
+  })
+
+  test("does not show the banner for other errors", async () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    })
+    const seen: Array<string | null> = []
+    const stop = followGithubThrottleErrors({
+      queryClient,
+      onRetryAtChange: (retryAt) => {
+        seen.push(retryAt)
+      },
+      now: () => NOW_MS,
+    })
+
+    await queryClient
+      .fetchQuery({
+        queryKey: ["other"],
+        queryFn: async () => {
+          throw genqlError({ code: "INTERNAL_SERVER_ERROR" })
+        },
+      })
+      .catch(() => undefined)
+
+    expect(seen).toEqual([])
+    stop()
+  })
+})
+
+describe("root throttle banner wiring (issue #1003)", () => {
+  test("does not poll githubThrottleStatus", () => {
+    const source = readFileSync(
+      join(import.meta.dir, "../src/routes/__root.tsx"),
+      "utf8",
+    )
+    expect(source).not.toContain("refetchInterval")
+    expect(source).not.toContain("githubThrottleStatus")
+    expect(source).toContain("useGithubThrottleRetryAt")
+  })
+})

--- a/packages/graphql-api/src/lib/graphql-api.ts
+++ b/packages/graphql-api/src/lib/graphql-api.ts
@@ -396,10 +396,6 @@ export const createGraphqlApi = <R>(
      * does not depend on the host shell.
      */
     readonly environment?: Readonly<Record<string, string | undefined>>
-    /** Runtime-only coordinator state supplied by the Harness application. */
-    readonly githubThrottleStatus?: () => Promise<{
-      readonly retryAt: number
-    } | null>
   } = {},
 ) => {
   const agentBackendCwd =
@@ -489,12 +485,6 @@ export const createGraphqlApi = <R>(
               }).pipe(Effect.withSpan("graphql-api.repositories")),
               context,
             ),
-          githubThrottleStatus: async () => {
-            const status = await options.githubThrottleStatus?.()
-            return status === null || status === undefined
-              ? null
-              : { retryAt: new Date(status.retryAt).toISOString() }
-          },
           repositoryCredentials: async (
             _parent: unknown,
             _args: unknown,

--- a/packages/graphql-api/test/graphql-api.test.ts
+++ b/packages/graphql-api/test/graphql-api.test.ts
@@ -498,26 +498,6 @@ describe("GraphQL API", () => {
     })
   })
 
-  test("exposes and clears the runtime-only GitHub throttle status", async () => {
-    let throttled = true
-    const api = createGraphqlApi(runtime, {
-      githubThrottleStatus: async () =>
-        throttled ? { retryAt: 1_780_000_000_000 } : null,
-    })
-    const request = () =>
-      graphqlRequest({
-        query: "{ githubThrottleStatus { retryAt } }",
-      })
-
-    expect(await (await api.fetch(request())).json()).toEqual({
-      data: { githubThrottleStatus: { retryAt: "2026-05-28T20:26:40.000Z" } },
-    })
-    throttled = false
-    expect(await (await api.fetch(request())).json()).toEqual({
-      data: { githubThrottleStatus: null },
-    })
-  })
-
   test("verifies a GitLab project before adding the repository", async () => {
     const actions: string[] = []
     await runtime.dispose()

--- a/packages/graphql-schema/schema.graphql
+++ b/packages/graphql-schema/schema.graphql
@@ -16,11 +16,6 @@ type Query {
   directoryPickerAvailable: Boolean!
   repositories: [Repository!]!
   repositoryCredentials: [RepositoryCredential!]!
-  """
-  Process-local explicit GitHub flow-control condition. Null when no known
-  deadline remains; this is runtime state and is not persisted.
-  """
-  githubThrottleStatus: GitHubThrottleStatus
   config: Config!
   """
   Built-in Agent Backends available for Harness Config selection.
@@ -111,13 +106,6 @@ type Query {
   lanes in fixed order, including empty lanes.
   """
   kanbanStatus(repositoryId: ID): KanbanStatus!
-}
-
-type GitHubThrottleStatus {
-  """
-  ISO-8601 deadline after which Harness may make another GitHub request.
-  """
-  retryAt: String!
 }
 
 """

--- a/packages/graphql-schema/schema.template.graphql
+++ b/packages/graphql-schema/schema.template.graphql
@@ -13,11 +13,6 @@ type Query {
   directoryPickerAvailable: Boolean!
   repositories: [Repository!]!
   repositoryCredentials: [RepositoryCredential!]!
-  """
-  Process-local explicit GitHub flow-control condition. Null when no known
-  deadline remains; this is runtime state and is not persisted.
-  """
-  githubThrottleStatus: GitHubThrottleStatus
   config: Config!
   """
   Built-in Agent Backends available for Harness Config selection.
@@ -108,13 +103,6 @@ type Query {
   lanes in fixed order, including empty lanes.
   """
   kanbanStatus(repositoryId: ID): KanbanStatus!
-}
-
-type GitHubThrottleStatus {
-  """
-  ISO-8601 deadline after which Harness may make another GitHub request.
-  """
-  retryAt: String!
 }
 
 """


### PR DESCRIPTION
The Harness UI queried `githubThrottleStatus` once per second on every
page only to feed the "GitHub is throttling until …" banner. That field
was almost always `null`. Real GitHub throttle control already lives
process-locally (coordinator admission, job postpone). The poll was
leftover banner plumbing, not that control.

The 1s TanStack Query and `Query.githubThrottleStatus` /
`GitHubThrottleStatus` are gone (schema template, generated schema, and
client). `createGraphqlApi` no longer takes a `githubThrottleStatus`
hook; the application server no longer supplies one. The existing
presentational banner still takes an ISO `retryAt`. It now appears when
a query or mutation cache error is Genql-shaped `GITHUB_THROTTLED` with
a future `retryAt` (epoch millis or ISO, normalized to ISO), including
`fetchQuery` failures callers catch. A later deadline replaces an
earlier one and resets the local hide timer; the banner clears when the
deadline elapses, with no network. Past deadlines and other GraphQL
errors do not show it. Coordinator, postpone, SSE, Configured
Repositories, and the 120s open-PR-count poll are unchanged.

Verification: `bunx nx test harness` (568 bun + 126 vitest, including
coordinator and new helper / cache-subscription / hide-timer tests plus
the presentational banner test and a `__root.tsx` `refetchInterval`
source guard); `bunx nx test graphql-api` (195 tests, including
`GITHUB_THROTTLED` mapping; status-query test removed);
`bunx nx run harness:typecheck`. Local review: no findings; no
remediation.

Limitation: background jobs that never return `GITHUB_THROTTLED` to the
browser still do not show the banner. There is no throttle subscription.

Closes #1003