### PR TITLE
test(harness): clear live-e2e Repositories via GraphQL without blank-slate tour

### DIFF
--- a/apps/harness/e2e/steps/add-and-refresh-repository.ts
+++ b/apps/harness/e2e/steps/add-and-refresh-repository.ts
@@ -3,6 +3,10 @@ import { dirname, resolve } from "node:path"
 import { fileURLToPath } from "node:url"
 import { expect } from "@playwright/test"
 import {
+  ensureNoConfiguredRepositories,
+  graphqlRequest,
+} from "../support/clear-repositories.ts"
+import {
   type FixtureForge,
   cloneFixtureRepository,
   gitlabFixtureSpec,
@@ -40,129 +44,6 @@ const sentinelFor = (forge: FixtureForge) =>
         number: GITHUB_SENTINEL_ISSUE_NUMBER,
         title: GITHUB_SENTINEL_ISSUE_TITLE,
       }
-
-class GraphQlRequestError extends Error {
-  readonly codes: ReadonlyArray<string>
-
-  constructor(messages: ReadonlyArray<string>, codes: ReadonlyArray<string>) {
-    super(`GraphQL errors: ${messages.join("; ")}`)
-    this.name = "GraphQlRequestError"
-    this.codes = codes
-  }
-}
-
-const graphqlRequest = async <T>(
-  query: string,
-  variables?: Record<string, unknown>,
-): Promise<T> => {
-  const response = await fetch(E2E_GRAPHQL_URL, {
-    method: "POST",
-    headers: { "content-type": "application/json" },
-    body: JSON.stringify({ query, variables }),
-  })
-  if (!response.ok) {
-    throw new Error(`GraphQL HTTP ${response.status}: ${await response.text()}`)
-  }
-  const payload = (await response.json()) as {
-    data?: T
-    errors?: ReadonlyArray<{
-      message: string
-      extensions?: { code?: string }
-    }>
-  }
-  if (payload.errors?.length) {
-    throw new GraphQlRequestError(
-      payload.errors.map((e) => e.message),
-      payload.errors.map((e) => e.extensions?.code ?? ""),
-    )
-  }
-  if (!payload.data) {
-    throw new Error("GraphQL response missing data")
-  }
-  return payload.data
-}
-
-const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
-
-const isRunningStepRemoveError = (error: unknown): boolean => {
-  if (error instanceof GraphQlRequestError) {
-    if (error.codes.includes("REPOSITORY_HAS_RUNNING_STEP")) {
-      return true
-    }
-  }
-  const message = error instanceof Error ? error.message : String(error)
-  return (
-    /REPOSITORY_HAS_RUNNING_STEP/i.test(message) ||
-    /has a running Step Run/i.test(message) ||
-    /RepositoryHasRunningStep/i.test(message)
-  )
-}
-
-/**
- * Clear leftover Repositories so multi-scenario e2e shares one Harness process.
- * Retries briefly when remove is blocked by a still-running Step Run.
- */
-const ensureNoConfiguredRepositories = async () => {
-  const deadline = Date.now() + 30_000
-  let attempt = 0
-  while (true) {
-    attempt += 1
-    const listed = await graphqlRequest<{
-      repositories: ReadonlyArray<{ id: string }>
-    }>(`query { repositories { id } }`)
-    if (listed.repositories.length === 0) {
-      return
-    }
-
-    let blockedByRunningStep = false
-    const failures: string[] = []
-    for (const repository of listed.repositories) {
-      try {
-        await graphqlRequest(
-          `mutation RemoveRepository($repositoryId: ID!) {
-            removeRepository(repositoryId: $repositoryId)
-          }`,
-          { repositoryId: repository.id },
-        )
-      } catch (error) {
-        if (isRunningStepRemoveError(error)) {
-          blockedByRunningStep = true
-          failures.push(error instanceof Error ? error.message : String(error))
-          continue
-        }
-        throw error
-      }
-    }
-
-    // When no remove was classified as running-step blocked, re-list and return
-    // only if empty; otherwise retry until the deadline (blocked path re-lists
-    // at the top of the next loop iteration).
-    if (!blockedByRunningStep) {
-      const remaining = await graphqlRequest<{
-        repositories: ReadonlyArray<{ id: string }>
-      }>(`query { repositories { id } }`)
-      if (remaining.repositories.length === 0) {
-        return
-      }
-    }
-
-    if (Date.now() >= deadline) {
-      throw new Error(
-        [
-          "Could not clear configured Repositories",
-          blockedByRunningStep
-            ? "because a Step Run is still running"
-            : "after remove mutations",
-          `(after ${attempt} attempts over ~30s).`,
-          "Multi-scenario e2e shares one Harness process; wait for refresh/work",
-          "to finish, or restart the e2e webServer.",
-          ...failures,
-        ].join(" "),
-      )
-    }
-    await sleep(500)
-  }
-}
 
 /**
  * Ensure no default build model so first-run Settings auto-opens on the next
@@ -283,46 +164,11 @@ Given("the Harness is empty with first-run settings required", async () => {
   await ensureFirstRunSettingsRequired()
 })
 
-Given("the Harness has no configured Repositories", async ({ page }) => {
+Given("the Harness has no configured Repositories", async () => {
   test.setTimeout(SCENARIO_TIMEOUT_MS)
+  // GraphQL-only setup: do not tour home/Repos blank slates here. The Kanban
+  // scenario whose assertion *is* that empty UI still checks it.
   await ensureNoConfiguredRepositories()
-  // Zero repos: home shows the add-repo blank slate (not an empty kanban board).
-  // First-run Settings may auto-open; dismiss so blank-slate assertions resolve.
-  await page.goto("/")
-  await dismissFirstRunSettingsIfPresent(page)
-  await expect(
-    page.getByRole("heading", { name: "No repositories configured" }),
-  ).toBeVisible()
-  await expect(
-    page.getByRole("region", { name: "Add a repository" }),
-  ).toBeVisible()
-  await expect(
-    page.getByRole("region", { name: "Lifecycle pipeline" }),
-  ).toHaveCount(0)
-  await expect(
-    page.getByRole("region", { name: "Committed pull requests" }),
-  ).toHaveCount(0)
-  // Jobs switcher stays available on the blank slate (Pipeline | Repos | Completed).
-  await expect(
-    page
-      .getByRole("navigation", { name: "Jobs" })
-      .getByRole("link", { name: "Repos" }),
-  ).toBeVisible()
-  await expect(
-    page.getByRole("region", { name: "Configured repositories" }),
-  ).toHaveCount(0)
-
-  await page.goto("/repos")
-  await dismissFirstRunSettingsIfPresent(page)
-  await expect(
-    page.getByRole("heading", { name: "No repositories configured" }),
-  ).toBeVisible()
-  await expect(
-    page.getByRole("region", { name: "Configured repositories" }),
-  ).toHaveCount(0)
-  await expect(
-    page.getByRole("region", { name: "Add a repository" }),
-  ).toBeVisible()
 })
 
 Given("the End-to-End Fixture Repository is checked out", async ({ world }) => {

--- a/apps/harness/e2e/steps/kanban-route.ts
+++ b/apps/harness/e2e/steps/kanban-route.ts
@@ -192,6 +192,9 @@ Then("the add-repository blank slate is visible", async ({ page }) => {
   await expect(
     page.getByRole("region", { name: "Add a repository" }),
   ).toBeVisible()
+  await expect(
+    page.getByRole("region", { name: "Configured repositories" }),
+  ).toHaveCount(0)
 })
 
 Then("the Harness settings dialog is visible", async ({ page }) => {

--- a/apps/harness/e2e/support/clear-repositories.ts
+++ b/apps/harness/e2e/support/clear-repositories.ts
@@ -1,0 +1,207 @@
+/**
+ * Clear leftover Repositories so multi-scenario live e2e can share one
+ * Harness process (issue #995). Setup Givens call this through GraphQL
+ * and do not navigate home or Repos to prove the add-Repository blank slate.
+ * Retries briefly when remove is blocked by a still-running Step Run or
+ * Refresh Job.
+ */
+
+import { E2E_GRAPHQL_URL } from "./constants.ts"
+
+export class GraphQlRequestError extends Error {
+  readonly codes: ReadonlyArray<string>
+
+  constructor(messages: ReadonlyArray<string>, codes: ReadonlyArray<string>) {
+    super(`GraphQL errors: ${messages.join("; ")}`)
+    this.name = "GraphQlRequestError"
+    this.codes = codes
+  }
+}
+
+export type E2eGraphqlRequest = <T>(
+  query: string,
+  variables?: Record<string, unknown>,
+) => Promise<T>
+
+export type ClearRepositoriesClient = {
+  readonly listRepositoryIds: () => Promise<ReadonlyArray<string>>
+  readonly removeRepository: (repositoryId: string) => Promise<void>
+}
+
+const CLEAR_REPOSITORIES_TIMEOUT_MS = 30_000
+const CLEAR_REPOSITORIES_RETRY_MS = 500
+
+export const graphqlRequest: E2eGraphqlRequest = async <T>(
+  query: string,
+  variables?: Record<string, unknown>,
+): Promise<T> => {
+  const response = await fetch(E2E_GRAPHQL_URL, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ query, variables }),
+  })
+  if (!response.ok) {
+    throw new Error(`GraphQL HTTP ${response.status}: ${await response.text()}`)
+  }
+  const payload: unknown = await response.json()
+  if (typeof payload !== "object" || payload === null) {
+    throw new Error("GraphQL response was not an object")
+  }
+  const errors = "errors" in payload ? payload.errors : undefined
+  if (Array.isArray(errors) && errors.length > 0) {
+    const messages: string[] = []
+    const codes: string[] = []
+    for (const entry of errors) {
+      if (typeof entry !== "object" || entry === null) {
+        messages.push(String(entry))
+        codes.push("")
+        continue
+      }
+      messages.push(
+        "message" in entry && typeof entry.message === "string"
+          ? entry.message
+          : String(entry),
+      )
+      const extensions =
+        "extensions" in entry &&
+        typeof entry.extensions === "object" &&
+        entry.extensions !== null
+          ? entry.extensions
+          : undefined
+      codes.push(
+        extensions !== undefined &&
+          "code" in extensions &&
+          typeof extensions.code === "string"
+          ? extensions.code
+          : "",
+      )
+    }
+    throw new GraphQlRequestError(messages, codes)
+  }
+  if (
+    !("data" in payload) ||
+    payload.data === undefined ||
+    payload.data === null
+  ) {
+    throw new Error("GraphQL response missing data")
+  }
+  return payload.data as T
+}
+
+export const liveClearRepositoriesClient = (
+  graphql: E2eGraphqlRequest = graphqlRequest,
+): ClearRepositoriesClient => ({
+  listRepositoryIds: async () => {
+    const listed = await graphql<{
+      repositories: ReadonlyArray<{ id: string }>
+    }>(`query { repositories { id } }`)
+    return listed.repositories.map((repository) => repository.id)
+  },
+  removeRepository: async (repositoryId) => {
+    await graphql(
+      `mutation RemoveRepository($repositoryId: ID!) {
+        removeRepository(repositoryId: $repositoryId)
+      }`,
+      { repositoryId },
+    )
+  },
+})
+
+const classifyRemoveRepositoryError = (
+  error: unknown,
+): "step-run" | "refresh-job" | "other" => {
+  const message = error instanceof Error ? error.message : String(error)
+  const codes = error instanceof GraphQlRequestError ? error.codes : []
+  if (
+    codes.includes("REPOSITORY_HAS_RUNNING_STEP") ||
+    /REPOSITORY_HAS_RUNNING_STEP/i.test(message) ||
+    /has a running Step Run/i.test(message) ||
+    /RepositoryHasRunningStep/i.test(message)
+  ) {
+    return "step-run"
+  }
+  // Refresh Jobs do not have a dedicated remove block. Contention shows up as
+  // a lock while the job writes the Issue store — not every DATABASE_ERROR.
+  if (
+    /Refresh Job/i.test(message) ||
+    /SQLITE_BUSY/i.test(message) ||
+    /database is locked/i.test(message)
+  ) {
+    return "refresh-job"
+  }
+  return "other"
+}
+
+export const ensureNoConfiguredRepositories = async (input?: {
+  readonly client?: ClearRepositoriesClient
+  readonly now?: () => number
+  readonly sleep?: (ms: number) => Promise<void>
+  readonly timeoutMs?: number
+  readonly retryIntervalMs?: number
+}): Promise<void> => {
+  const client = input?.client ?? liveClearRepositoriesClient()
+  const now = input?.now ?? Date.now
+  const sleep =
+    input?.sleep ??
+    ((ms: number) => new Promise((resolve) => setTimeout(resolve, ms)))
+  const timeoutMs = input?.timeoutMs ?? CLEAR_REPOSITORIES_TIMEOUT_MS
+  const retryIntervalMs = input?.retryIntervalMs ?? CLEAR_REPOSITORIES_RETRY_MS
+  const deadline = now() + timeoutMs
+  let attempt = 0
+
+  while (true) {
+    attempt += 1
+    const listed = await client.listRepositoryIds()
+    if (listed.length === 0) {
+      return
+    }
+
+    let blocked = false
+    let blockedKind: "step-run" | "refresh-job" | "unknown" = "unknown"
+    const failures: string[] = []
+    for (const repositoryId of listed) {
+      try {
+        await client.removeRepository(repositoryId)
+      } catch (error) {
+        const kind = classifyRemoveRepositoryError(error)
+        if (kind !== "other") {
+          blocked = true
+          blockedKind = kind
+          failures.push(error instanceof Error ? error.message : String(error))
+          continue
+        }
+        throw error
+      }
+    }
+
+    // When no remove was classified as blocked, re-list and return only if
+    // empty; otherwise retry until the deadline (blocked path re-lists at
+    // the top of the next loop iteration).
+    if (!blocked) {
+      const remaining = await client.listRepositoryIds()
+      if (remaining.length === 0) {
+        return
+      }
+    }
+
+    if (now() >= deadline) {
+      const reason =
+        blockedKind === "step-run"
+          ? "because a Step Run is still running"
+          : blockedKind === "refresh-job"
+            ? "because a Refresh Job is still running"
+            : "after remove mutations"
+      throw new Error(
+        [
+          "Could not clear configured Repositories",
+          reason,
+          `(after ${attempt} attempts over ~${Math.round(timeoutMs / 1000)}s).`,
+          "Multi-scenario e2e shares one Harness process; wait for refresh/work",
+          "to finish, or restart the e2e webServer.",
+          ...failures,
+        ].join(" "),
+      )
+    }
+    await sleep(retryIntervalMs)
+  }
+}

--- a/apps/harness/test/clear-repositories.test.ts
+++ b/apps/harness/test/clear-repositories.test.ts
@@ -1,0 +1,251 @@
+import {
+  GraphQlRequestError,
+  ensureNoConfiguredRepositories,
+  liveClearRepositoriesClient,
+} from "../e2e/support/clear-repositories.ts"
+import { describe, expect, test } from "bun:test"
+
+const recordingClient = (input: {
+  readonly lists: ReadonlyArray<ReadonlyArray<string>>
+  readonly remove?: (repositoryId: string) => Promise<void>
+}) => {
+  const removed: string[] = []
+  let listIndex = 0
+  return {
+    removed,
+    client: {
+      listRepositoryIds: async () => {
+        const listed = input.lists[listIndex] ?? input.lists.at(-1) ?? []
+        listIndex += 1
+        return listed
+      },
+      removeRepository: async (repositoryId: string) => {
+        removed.push(repositoryId)
+        if (input.remove !== undefined) {
+          await input.remove(repositoryId)
+        }
+      },
+    },
+  }
+}
+
+const fakeClock = () => {
+  let now = 0
+  const sleeps: number[] = []
+  return {
+    sleeps,
+    now: () => now,
+    sleep: async (ms: number) => {
+      sleeps.push(ms)
+      now += ms
+    },
+  }
+}
+
+describe("ensureNoConfiguredRepositories", () => {
+  test("returns without remove when the Repository list is already empty", async () => {
+    const recording = recordingClient({ lists: [[]] })
+    const clock = fakeClock()
+
+    await ensureNoConfiguredRepositories({
+      client: recording.client,
+      now: clock.now,
+      sleep: clock.sleep,
+    })
+
+    expect(recording.removed).toEqual([])
+    expect(clock.sleeps).toEqual([])
+  })
+
+  test("removes each listed Repository through the client", async () => {
+    const recording = recordingClient({
+      lists: [["repo-a", "repo-b"], []],
+    })
+
+    await ensureNoConfiguredRepositories({
+      client: recording.client,
+      now: () => 0,
+      sleep: async () => {
+        throw new Error("should not wait when remove emptied the list")
+      },
+    })
+
+    expect(recording.removed).toEqual(["repo-a", "repo-b"])
+  })
+
+  test("retries when remove is blocked by a running Step Run", async () => {
+    let removeAttempts = 0
+    const recording = recordingClient({
+      lists: [["repo-busy"], ["repo-busy"], []],
+      remove: async () => {
+        removeAttempts += 1
+        if (removeAttempts === 1) {
+          throw new GraphQlRequestError(
+            [
+              "Repository repo-busy has a running Step Run and cannot be removed",
+            ],
+            ["REPOSITORY_HAS_RUNNING_STEP"],
+          )
+        }
+      },
+    })
+    const clock = fakeClock()
+
+    await ensureNoConfiguredRepositories({
+      client: recording.client,
+      now: clock.now,
+      sleep: clock.sleep,
+      timeoutMs: 2_000,
+      retryIntervalMs: 500,
+    })
+
+    expect(removeAttempts).toBe(2)
+    expect(clock.sleeps).toEqual([500])
+  })
+
+  test("retries when remove is blocked by a running Refresh Job", async () => {
+    let removeAttempts = 0
+    const recording = recordingClient({
+      lists: [["repo-refresh"], ["repo-refresh"], []],
+      remove: async () => {
+        removeAttempts += 1
+        if (removeAttempts === 1) {
+          throw new GraphQlRequestError(
+            ["database is locked"],
+            ["DATABASE_ERROR"],
+          )
+        }
+      },
+    })
+    const clock = fakeClock()
+
+    await ensureNoConfiguredRepositories({
+      client: recording.client,
+      now: clock.now,
+      sleep: clock.sleep,
+      timeoutMs: 2_000,
+      retryIntervalMs: 500,
+    })
+
+    expect(removeAttempts).toBe(2)
+    expect(clock.sleeps).toEqual([500])
+  })
+
+  test("times out while a Step Run still blocks remove", async () => {
+    const recording = recordingClient({
+      lists: [["repo-busy"]],
+      remove: async () => {
+        throw new GraphQlRequestError(
+          ["Repository repo-busy has a running Step Run and cannot be removed"],
+          ["REPOSITORY_HAS_RUNNING_STEP"],
+        )
+      },
+    })
+    const clock = fakeClock()
+
+    await expect(
+      ensureNoConfiguredRepositories({
+        client: recording.client,
+        now: clock.now,
+        sleep: clock.sleep,
+        timeoutMs: 1_000,
+        retryIntervalMs: 500,
+      }),
+    ).rejects.toThrow(/Step Run is still running/)
+  })
+
+  test("times out while a Refresh Job still blocks remove", async () => {
+    const recording = recordingClient({
+      lists: [["repo-refresh"]],
+      remove: async () => {
+        throw new Error(
+          "database is locked while a Refresh Job is writing the Issue store",
+        )
+      },
+    })
+    const clock = fakeClock()
+
+    await expect(
+      ensureNoConfiguredRepositories({
+        client: recording.client,
+        now: clock.now,
+        sleep: clock.sleep,
+        timeoutMs: 1_000,
+        retryIntervalMs: 500,
+      }),
+    ).rejects.toThrow(/Refresh Job/)
+  })
+
+  test("throws a non-retryable remove error immediately", async () => {
+    const recording = recordingClient({
+      lists: [["repo-bad"]],
+      remove: async () => {
+        throw new GraphQlRequestError(
+          ["Repository not found: repo-bad"],
+          ["REPOSITORY_NOT_FOUND"],
+        )
+      },
+    })
+
+    await expect(
+      ensureNoConfiguredRepositories({
+        client: recording.client,
+        now: () => 0,
+        sleep: async () => {
+          throw new Error("should not retry a permanent remove failure")
+        },
+      }),
+    ).rejects.toThrow(/Repository not found: repo-bad/)
+  })
+
+  test("throws a permanent DATABASE_ERROR immediately", async () => {
+    const recording = recordingClient({
+      lists: [["repo-constraint"]],
+      remove: async () => {
+        throw new GraphQlRequestError(
+          ["FOREIGN KEY constraint failed"],
+          ["DATABASE_ERROR"],
+        )
+      },
+    })
+
+    await expect(
+      ensureNoConfiguredRepositories({
+        client: recording.client,
+        now: () => 0,
+        sleep: async () => {
+          throw new Error("should not retry a permanent database error")
+        },
+      }),
+    ).rejects.toThrow(/FOREIGN KEY constraint failed/)
+  })
+})
+
+describe("liveClearRepositoriesClient", () => {
+  test("lists and removes Repositories through GraphQL documents", async () => {
+    const queries: Array<{
+      readonly query: string
+      readonly variables?: Record<string, unknown>
+    }> = []
+    const graphql = async <T>(
+      query: string,
+      variables?: Record<string, unknown>,
+    ): Promise<T> => {
+      queries.push({ query, variables })
+      if (query.includes("removeRepository")) {
+        return { removeRepository: variables?.repositoryId } as T
+      }
+      return { repositories: [{ id: "repo-1" }] } as T
+    }
+    const client = liveClearRepositoriesClient(graphql)
+
+    expect(await client.listRepositoryIds()).toEqual(["repo-1"])
+    await client.removeRepository("repo-1")
+
+    expect(queries[0]?.query).toMatch(
+      /query\s*\{\s*repositories\s*\{\s*id\s*\}/,
+    )
+    expect(queries[1]?.query).toContain("removeRepository")
+    expect(queries[1]?.variables).toEqual({ repositoryId: "repo-1" })
+  })
+})


### PR DESCRIPTION
Live-e2e setup Givens that only need an empty Repository list were paying
two full page loads to prove the add-Repository blank slate. That made
Settings history and every other consumer of the shared Given slower
without asserting anything those scenarios care about (#995).

What changed
- Given "the Harness has no configured Repositories" only uses GraphQL
- Clear retries on a running Step Run or Refresh Job lock contention
  (SQLITE_BUSY / database is locked). Permanent DATABASE_ERROR fails now
- Kanban blank-slate scenario still asserts the empty UI

Verification
- bun test apps/harness/test/clear-repositories.test.ts
- bunx nx test harness and bunx nx run harness:typecheck
- Vault-backed Playwright e2e was not run here (no E2E_KEYMAXXER_MASTER_KEY)

Closes #995