### PR TITLE
ci: cache version-keyed Playwright Chromium for PR live e2e

### DIFF
--- a/.github/actions/playwright-chromium/action.yml
+++ b/.github/actions/playwright-chromium/action.yml
@@ -1,0 +1,68 @@
+name: Playwright Chromium
+description: Restore or install Playwright Chromium, keyed on Playwright version.
+
+inputs:
+  working-directory:
+    description: Directory that depends on @playwright/test
+    required: false
+    default: apps/harness
+  allow-save:
+    description: Whether this job may save the browser cache.
+    required: false
+    default: "false"
+
+outputs:
+  version:
+    description: Resolved Playwright version used in the cache key.
+    value: ${{ steps.version.outputs.version }}
+  cache-hit:
+    description: Whether the Playwright Chromium cache was restored.
+    value: ${{ steps.cache.outputs.cache-hit || steps.restore.outputs.cache-hit }}
+
+runs:
+  using: composite
+  steps:
+    # Resolve the installed package version (not the package.json range) so a
+    # Playwright bump misses the cache and downloads a matching Chromium.
+    - name: Resolve Playwright version
+      id: version
+      shell: bash
+      working-directory: ${{ inputs.working-directory }}
+      run: |
+        set -euo pipefail
+        VERSION="$(bun -e 'console.log(require("@playwright/test/package.json").version)')"
+        test -n "$VERSION"
+        echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+        echo "Resolved Playwright ${VERSION}"
+
+    - name: Use Playwright's default browser cache path
+      shell: bash
+      run: echo "PLAYWRIGHT_BROWSERS_PATH=${HOME}/.cache/ms-playwright" >> "$GITHUB_ENV"
+
+    - name: Restore and save Playwright Chromium
+      if: inputs.allow-save == 'true'
+      id: cache
+      uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      with:
+        path: ~/.cache/ms-playwright
+        key: playwright-chromium-${{ runner.os }}-${{ steps.version.outputs.version }}
+
+    - name: Restore Playwright Chromium
+      if: inputs.allow-save != 'true'
+      id: restore
+      uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+      with:
+        path: ~/.cache/ms-playwright
+        key: playwright-chromium-${{ runner.os }}-${{ steps.version.outputs.version }}
+
+    - name: Install Playwright Chromium
+      if: steps.cache.outputs.cache-hit != 'true' && steps.restore.outputs.cache-hit != 'true'
+      shell: bash
+      working-directory: ${{ inputs.working-directory }}
+      run: bunx playwright install --with-deps chromium
+
+    - name: Install Playwright OS dependencies
+      if: steps.cache.outputs.cache-hit == 'true' || steps.restore.outputs.cache-hit == 'true'
+      shell: bash
+      working-directory: ${{ inputs.working-directory }}
+      run: bunx playwright install-deps chromium

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -114,9 +114,12 @@ jobs:
         run: bunx nx run harness:smoke
 
       # Chromium once for both live suites (no-backend always; full suite when vault).
-      - name: Install Playwright Chromium
-        working-directory: apps/harness
-        run: bunx playwright install --with-deps chromium
+      # Cache is keyed on the resolved Playwright version so a bump installs fresh.
+      - name: Restore/install Playwright Chromium
+        uses: ./.github/actions/playwright-chromium
+        with:
+          # Forks and Dependabot get a read-only token for cache writes; restore only.
+          allow-save: ${{ github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'dependabot[bot]' }}
 
       # Product default-backend / first-run without OpenCode (vault-free; fork-safe).
       - name: Live Harness e2e (no backend agents)

--- a/apps/harness/test/pr-playwright-chromium-cache.test.ts
+++ b/apps/harness/test/pr-playwright-chromium-cache.test.ts
@@ -1,0 +1,239 @@
+import { readFile } from "node:fs/promises"
+import { dirname, join, resolve } from "node:path"
+import { fileURLToPath } from "node:url"
+import { describe, expect, test } from "bun:test"
+
+const workspaceRoot = resolve(
+  dirname(fileURLToPath(import.meta.url)),
+  "../../..",
+)
+
+type WorkflowStep = {
+  name?: string
+  id?: string
+  uses?: string
+  run?: string
+  if?: string
+  with?: Record<string, string>
+}
+
+type WorkflowDocument = {
+  jobs?: {
+    harness?: {
+      steps?: WorkflowStep[]
+    }
+  }
+}
+
+type CompositeActionDocument = {
+  runs?: {
+    using?: string
+    steps?: WorkflowStep[]
+  }
+}
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value)
+
+const asString = (value: unknown): string | undefined =>
+  typeof value === "string" ? value : undefined
+
+const parseStringFields = (
+  value: Record<string, unknown>,
+): Record<string, string> | undefined => {
+  const fields: Record<string, string> = {}
+  for (const [key, entry] of Object.entries(value)) {
+    if (typeof entry !== "string") {
+      return undefined
+    }
+    fields[key] = entry
+  }
+  return fields
+}
+
+const parseStep = (value: unknown): WorkflowStep => {
+  if (!isRecord(value)) {
+    throw new Error("expected a workflow step object")
+  }
+  const withValue = value.with
+  return {
+    name: asString(value.name),
+    id: asString(value.id),
+    uses: asString(value.uses),
+    run: asString(value.run),
+    if: asString(value.if),
+    with: isRecord(withValue) ? parseStringFields(withValue) : undefined,
+  }
+}
+
+const parseSteps = (value: unknown, label: string): WorkflowStep[] => {
+  if (!Array.isArray(value)) {
+    throw new Error(`expected ${label} to be a list`)
+  }
+  return value.map(parseStep)
+}
+
+const parseWorkflow = (value: unknown): WorkflowDocument => {
+  if (!isRecord(value)) {
+    throw new Error("expected a workflow document")
+  }
+  const jobsValue = value.jobs
+  if (jobsValue === undefined) {
+    return {}
+  }
+  if (!isRecord(jobsValue)) {
+    throw new Error("expected jobs to be a mapping")
+  }
+  const harnessValue = jobsValue.harness
+  if (harnessValue === undefined) {
+    return { jobs: {} }
+  }
+  if (!isRecord(harnessValue)) {
+    throw new Error("expected harness job to be a mapping")
+  }
+  const stepsValue = harnessValue.steps
+  return {
+    jobs: {
+      harness: {
+        steps:
+          stepsValue === undefined
+            ? undefined
+            : parseSteps(stepsValue, "harness steps"),
+      },
+    },
+  }
+}
+
+const parseCompositeAction = (value: unknown): CompositeActionDocument => {
+  if (!isRecord(value)) {
+    throw new Error("expected a composite action document")
+  }
+  const runsValue = value.runs
+  if (runsValue === undefined) {
+    return {}
+  }
+  if (!isRecord(runsValue)) {
+    throw new Error("expected runs to be a mapping")
+  }
+  const stepsValue = runsValue.steps
+  return {
+    runs: {
+      using: asString(runsValue.using),
+      steps:
+        stepsValue === undefined
+          ? undefined
+          : parseSteps(stepsValue, "composite steps"),
+    },
+  }
+}
+
+const loadYaml = async (relativePath: string): Promise<unknown> => {
+  const text = await readFile(join(workspaceRoot, relativePath), "utf8")
+  return Bun.YAML.parse(text)
+}
+
+const expandLocalActions = async (
+  steps: WorkflowStep[],
+): Promise<WorkflowStep[]> => {
+  const expanded: WorkflowStep[] = []
+  for (const step of steps) {
+    const uses = step.uses
+    if (uses?.startsWith("./") === true) {
+      const actionPath = uses.endsWith("action.yml")
+        ? uses.slice(2)
+        : join(uses.slice(2), "action.yml")
+      const action = parseCompositeAction(await loadYaml(actionPath))
+      expanded.push(...(action.runs?.steps ?? []))
+      continue
+    }
+    expanded.push(step)
+  }
+  return expanded
+}
+
+const harnessSteps = async (): Promise<WorkflowStep[]> => {
+  const workflow = parseWorkflow(await loadYaml(".github/workflows/pr.yml"))
+  const steps = workflow.jobs?.harness?.steps
+  if (steps === undefined) {
+    throw new Error("PR workflow is missing the harness job steps")
+  }
+  return expandLocalActions(steps)
+}
+
+describe("PR harness Playwright Chromium cache (issue #996)", () => {
+  test("caches Chromium keyed on the resolved Playwright version", async () => {
+    const steps = await harnessSteps()
+
+    const versionStep = steps.find(
+      (step) =>
+        step.run?.includes("@playwright/test/package.json") === true &&
+        step.run.includes("version"),
+    )
+    expect(versionStep?.id).toBeDefined()
+
+    const cacheStep = steps.find(
+      (step) =>
+        (step.uses?.startsWith("actions/cache@") === true ||
+          step.uses?.startsWith("actions/cache/restore@") === true) &&
+        step.with?.path.includes("ms-playwright") === true,
+    )
+    expect(cacheStep?.with?.path).toContain("ms-playwright")
+    expect(cacheStep?.with?.key).toContain("playwright")
+    expect(cacheStep?.with?.key).toContain(
+      `steps.${versionStep?.id}.outputs.version`,
+    )
+    expect(cacheStep?.with?.key).not.toContain("github.sha")
+    expect(cacheStep?.with?.["restore-keys"]).toBeUndefined()
+  })
+
+  test("a cache hit skips the Chromium download and still installs OS deps", async () => {
+    const steps = await harnessSteps()
+
+    const installBrowsers = steps.filter(
+      (step) =>
+        step.run?.includes("playwright install") === true &&
+        step.run.includes("chromium") &&
+        !step.run.includes("install-deps"),
+    )
+    expect(installBrowsers).toHaveLength(1)
+    expect(installBrowsers[0]?.if).toContain("cache-hit")
+    expect(installBrowsers[0]?.if).toMatch(/!=\s*'true'/)
+
+    const installDeps = steps.filter((step) =>
+      step.run?.includes("playwright install-deps"),
+    )
+    expect(installDeps).toHaveLength(1)
+    expect(installDeps[0]?.run).toContain("chromium")
+    expect(installDeps[0]?.if).toContain("cache-hit")
+    expect(installDeps[0]?.if).toMatch(/==\s*'true'/)
+  })
+
+  test("both live e2e suites still run against Chromium after the cache/install steps", async () => {
+    const workflow = parseWorkflow(await loadYaml(".github/workflows/pr.yml"))
+    const topLevel = workflow.jobs?.harness?.steps
+    if (topLevel === undefined) {
+      throw new Error("PR workflow is missing the harness job steps")
+    }
+
+    const chromiumReadyIndex = topLevel.findIndex(
+      (step) =>
+        step.uses?.includes("playwright-chromium") === true ||
+        (step.run?.includes("playwright install") === true &&
+          step.run.includes("chromium")),
+    )
+    expect(chromiumReadyIndex).toBeGreaterThanOrEqual(0)
+
+    const noBackendIndex = topLevel.findIndex(
+      (step) => step.run?.includes("harness:e2e-no-backend") === true,
+    )
+    const vaultBackedIndex = topLevel.findIndex(
+      (step) =>
+        step.run === "bunx nx run harness:e2e" ||
+        step.run?.trim() === "bunx nx run harness:e2e",
+    )
+
+    expect(noBackendIndex).toBeGreaterThan(chromiumReadyIndex)
+    expect(vaultBackedIndex).toBeGreaterThan(chromiumReadyIndex)
+    expect(noBackendIndex).toBeLessThan(vaultBackedIndex)
+  })
+})

--- a/docs/e2e-fixture.md
+++ b/docs/e2e-fixture.md
@@ -217,16 +217,18 @@ Live Gherkin e2e runs in a dedicated **`harness`** job (dev smoke + live e2e)
 in parallel with **`quality-gates`** (`lint` / `knip` / `test` / `typecheck`
 plus harness slow-test) on trusted pushes to `main`
 (`.github/workflows/ci-cd.yml`) and on pull requests
-(`.github/workflows/pr.yml`). Playwright Chromium is installed only when the
-vault secret is available (always on `main`; same-repo PRs only). Both
-workflows unlock the fixture vault with repository secret
-`E2E_KEYMAXXER_MASTER_KEY`.
+(`.github/workflows/pr.yml`). Playwright Chromium is installed once for both
+live suites (vault-free `e2e-no-backend` always; vault-backed `e2e` when the
+secret is available). The PR `harness` job caches that Chromium install keyed
+on Playwright version so a cache hit skips the browser download and only
+installs OS dependencies. Both workflows unlock the fixture vault with
+repository secret `E2E_KEYMAXXER_MASTER_KEY`.
 
 | Event | Secret available | Policy |
 | --- | --- | --- |
 | `push` to `main` | required | Fail closed if missing |
 | Same-repo PR | yes | Run live e2e |
-| Fork PR | no (secrets not exposed) | Skip live e2e only (log + continue); `harness` still runs smoke; quality-gates and pinact still run |
+| Fork PR | no (secrets not exposed) | Skip vault-backed live e2e only (log + continue); `harness` still runs smoke and vault-free `e2e-no-backend`; quality-gates and pinact still run |
 
 Required status checks (after the former monolithic `main` job was split):
 

--- a/packages/db/test/run-migrations.spec.ts
+++ b/packages/db/test/run-migrations.spec.ts
@@ -216,6 +216,7 @@ describe("runMigrations", () => {
           { name: "20260807100000_postponed_step_runs" },
           { name: "20260808093000_explicit_agent_backend_selection" },
           { name: "20260811120000_step_run_reason_detail" },
+          { name: "20260812120000_automated_review_rerun_signature" },
         ])
       }).pipe(Effect.provide(SqliteTest)),
     )


### PR DESCRIPTION
The PR `harness` job downloaded Playwright Chromium on every run, which
dominates live e2e setup. Issue #996 asks that install to be reused across
runs, keyed so a Playwright bump still gets a matching browser.

A new composite action restores `~/.cache/ms-playwright` with key
`playwright-chromium-<os>-<playwright-version>` (resolved from the installed
`@playwright/test` package; no fuzzy `restore-keys`). A cache hit skips
`playwright install` and only runs `install-deps`. A miss still installs
Chromium with OS deps. Same-repo PRs save the cache; forks and Dependabot
restore only. Both live suites (`harness:e2e-no-backend` and vault-backed
`harness:e2e`) still run against that Chromium.

Also updates the db migration-adoption expectation to include
`20260812120000_automated_review_rerun_signature` so `db:test` matches the
current drizzle folder.

Verification: YAML contract tests; `bunx nx run harness:test`;
`bunx nx run db:test`; `actionlint` on `pr.yml`; pre-commit `nx-affected`
passed. The main `ci-cd.yml` harness job is unchanged and still downloads
Chromium every run.

Closes #996