### PR TITLE
fix(cli): emit GRAPHQL_URL_NOT_ENDPOINT when GraphQL URL serves HTML

### DIFF
--- a/apps/ready-for-agent/src/cli-process.test.ts
+++ b/apps/ready-for-agent/src/cli-process.test.ts
@@ -20,6 +20,7 @@ import {
   buildStatusSuccessDocument,
 } from "./cli-json.ts"
 import {
+  GRAPHQL_URL_NOT_ENDPOINT_CODE,
   HARNESS_START_HINT,
   HARNESS_UNREACHABLE_CODE,
   harnessNotRunningMessage,
@@ -933,5 +934,39 @@ describe("operator binary finite-command process contract", () => {
         message: harnessNotRunningMessage("http://127.0.0.1:1"),
       },
     })
+  })
+
+  test("status against HTML at the configured URL emits GRAPHQL_URL_NOT_ENDPOINT once", async () => {
+    let requestCount = 0
+    const seenUrls: string[] = []
+    const server = createServer((req, res) => {
+      requestCount += 1
+      seenUrls.push(req.url ?? "")
+      res.writeHead(200, { "content-type": "text/html; charset=utf-8" })
+      res.end("<!doctype html><html><body>Harness</body></html>")
+    })
+
+    try {
+      const port = await listen(server)
+      const graphqlUrl = `http://127.0.0.1:${port}`
+      const result = await runCli(["status"], graphqlUrl)
+
+      expect(result.status).toBe(1)
+      expect(result.stdout.trim()).toBe("")
+      expect(requestCount).toBe(1)
+      expect(seenUrls).toEqual(["/"])
+      expect(parseExactlyOneJsonDocument(result.stderr)).toEqual({
+        schemaVersion: CLI_SCHEMA_VERSION,
+        command: "status",
+        error: {
+          code: GRAPHQL_URL_NOT_ENDPOINT_CODE,
+          message: `${graphqlUrl} returned HTML (the Harness UI), not GraphQL. Set READY_FOR_AGENT_GRAPHQL_URL=${graphqlUrl}/graphql`,
+        },
+      })
+      expect(result.stderr).not.toContain("Failed to parse JSON")
+      expect(result.stderr).not.toContain("GRAPHQL_ERROR")
+    } finally {
+      await closeServer(server)
+    }
   })
 })

--- a/apps/ready-for-agent/src/graphql-error.test.ts
+++ b/apps/ready-for-agent/src/graphql-error.test.ts
@@ -2,6 +2,8 @@ import { GenqlError } from "@ready-for-agent/graphql-client"
 import {
   DEFAULT_HARNESS_BASE_URL,
   GRAPHQL_ERROR_CODE,
+  GRAPHQL_URL_NOT_ENDPOINT_CODE,
+  GraphqlUrlNotEndpointError,
   HARNESS_START_HINT,
   HARNESS_UNREACHABLE_CODE,
   describeGraphqlFailure,
@@ -79,6 +81,47 @@ describe("graphql unreachable detection", () => {
     expect(formatGraphqlRequestFailure(cause)).toBe(
       "Repository already registered",
     )
+  })
+
+  test("maps HTML at the Harness origin to GRAPHQL_URL_NOT_ENDPOINT with /graphql hint", () => {
+    const cause = new GraphqlUrlNotEndpointError("http://localhost:7000")
+    expect(isGraphqlUnreachable(cause)).toBe(false)
+    expect(describeGraphqlFailure(cause)).toEqual({
+      code: GRAPHQL_URL_NOT_ENDPOINT_CODE,
+      message:
+        "http://localhost:7000 returned HTML (the Harness UI), not GraphQL. Set READY_FOR_AGENT_GRAPHQL_URL=http://localhost:7000/graphql",
+    })
+    expect(cause.message).not.toContain("/graphql/graphql")
+  })
+
+  test("maps HTML at a trailing-slash origin to GRAPHQL_URL_NOT_ENDPOINT without a double slash", () => {
+    const cause = new GraphqlUrlNotEndpointError("http://localhost:7000/")
+    expect(describeGraphqlFailure(cause)).toEqual({
+      code: GRAPHQL_URL_NOT_ENDPOINT_CODE,
+      message:
+        "http://localhost:7000/ returned HTML (the Harness UI), not GraphQL. Set READY_FOR_AGENT_GRAPHQL_URL=http://localhost:7000/graphql",
+    })
+  })
+
+  test("maps HTML at /graphql to GRAPHQL_URL_NOT_ENDPOINT without appending /graphql again", () => {
+    const cause = new GraphqlUrlNotEndpointError(
+      "http://localhost:7000/graphql/",
+    )
+    expect(describeGraphqlFailure(cause)).toEqual({
+      code: GRAPHQL_URL_NOT_ENDPOINT_CODE,
+      message:
+        "http://localhost:7000/graphql/ returned HTML (the Harness UI), not GraphQL.",
+    })
+    expect(cause.message).not.toContain("Set READY_FOR_AGENT_GRAPHQL_URL")
+    expect(cause.message).not.toContain("/graphql/graphql")
+  })
+
+  test("leaves a genuine JSON parse failure from a GraphQL endpoint as GRAPHQL_ERROR", () => {
+    const cause = new Error("Failed to parse JSON")
+    expect(describeGraphqlFailure(cause)).toEqual({
+      code: GRAPHQL_ERROR_CODE,
+      message: "Failed to parse JSON",
+    })
   })
 
   test("harnessBaseUrlFromGraphqlUrl strips /graphql", () => {

--- a/apps/ready-for-agent/src/graphql-error.ts
+++ b/apps/ready-for-agent/src/graphql-error.ts
@@ -62,7 +62,7 @@ const urlPathEndsWithGraphql = (configuredUrl: string): boolean => {
 }
 
 /** Operator-facing message when the configured GraphQL URL returned HTML. */
-export const graphqlUrlNotEndpointMessage = (configuredUrl: string): string => {
+const graphqlUrlNotEndpointMessage = (configuredUrl: string): string => {
   const htmlNotice = `${configuredUrl} returned HTML (the Harness UI), not GraphQL.`
   if (urlPathEndsWithGraphql(configuredUrl)) {
     return htmlNotice

--- a/apps/ready-for-agent/src/graphql-error.ts
+++ b/apps/ready-for-agent/src/graphql-error.ts
@@ -13,6 +13,9 @@ export const HARNESS_UNREACHABLE_CODE = "HARNESS_UNREACHABLE"
  */
 export const GRAPHQL_ERROR_CODE = "GRAPHQL_ERROR"
 
+/** CLI-owned code when the configured GraphQL URL returned HTML, not GraphQL. */
+export const GRAPHQL_URL_NOT_ENDPOINT_CODE = "GRAPHQL_URL_NOT_ENDPOINT"
+
 /** Minimal GenqlError shape (generated client is @ts-nocheck; duck-type safely). */
 type GenqlErrorLike = Error & {
   readonly errors: ReadonlyArray<{
@@ -44,6 +47,44 @@ export const harnessNotRunningMessage = (
   harnessBaseUrl: string = DEFAULT_HARNESS_BASE_URL,
 ): string =>
   `Harness is not running at ${harnessBaseUrl}\n${HARNESS_START_HINT}`
+
+const urlPathEndsWithGraphql = (configuredUrl: string): boolean => {
+  try {
+    const pathname = new URL(configuredUrl).pathname.replace(/\/+$/, "")
+    return pathname.toLowerCase().endsWith("/graphql")
+  } catch {
+    return configuredUrl
+      .trim()
+      .replace(/\/+$/, "")
+      .toLowerCase()
+      .endsWith("/graphql")
+  }
+}
+
+/** Operator-facing message when the configured GraphQL URL returned HTML. */
+export const graphqlUrlNotEndpointMessage = (configuredUrl: string): string => {
+  const htmlNotice = `${configuredUrl} returned HTML (the Harness UI), not GraphQL.`
+  if (urlPathEndsWithGraphql(configuredUrl)) {
+    return htmlNotice
+  }
+  const suggestedUrl = `${configuredUrl.trim().replace(/\/+$/, "")}/graphql`
+  return `${htmlNotice} Set READY_FOR_AGENT_GRAPHQL_URL=${suggestedUrl}`
+}
+
+/**
+ * Thrown at the fetch boundary when the configured GraphQL URL returns a
+ * non-JSON (typically HTML) response instead of a GraphQL payload.
+ */
+export class GraphqlUrlNotEndpointError extends Error {
+  readonly code = GRAPHQL_URL_NOT_ENDPOINT_CODE
+  readonly configuredUrl: string
+
+  constructor(configuredUrl: string) {
+    super(graphqlUrlNotEndpointMessage(configuredUrl))
+    this.name = "GraphqlUrlNotEndpointError"
+    this.configuredUrl = configuredUrl
+  }
+}
 
 const collectErrorText = (cause: unknown): string => {
   const parts: string[] = []
@@ -99,12 +140,20 @@ const graphqlErrorCode = (cause: GenqlErrorLike): string => {
 /**
  * Map a GraphQL client failure to a stable code + operator-facing message.
  * Unreachable transport uses the CLI-owned `HARNESS_UNREACHABLE` code.
+ * HTML (or other non-JSON) at the configured URL uses `GRAPHQL_URL_NOT_ENDPOINT`.
  * Domain failures retain Harness `extensions.code` from GenqlError.
  */
 export const describeGraphqlFailure = (
   cause: unknown,
   options?: FormatGraphqlRequestFailureOptions,
 ): GraphqlFailureInfo => {
+  if (cause instanceof GraphqlUrlNotEndpointError) {
+    return {
+      code: GRAPHQL_URL_NOT_ENDPOINT_CODE,
+      message: cause.message,
+    }
+  }
+
   if (isGraphqlUnreachable(cause)) {
     const baseUrl =
       options?.graphqlUrl === undefined

--- a/apps/ready-for-agent/src/services/graphql-api.ts
+++ b/apps/ready-for-agent/src/services/graphql-api.ts
@@ -10,8 +10,36 @@ import {
   toCanonicalRepositoryIdentity,
 } from "../cli-json.ts"
 import type { LocalRepository, RepositorySummary } from "../domain.ts"
-import { describeGraphqlFailure } from "../graphql-error.ts"
+import {
+  GraphqlUrlNotEndpointError,
+  describeGraphqlFailure,
+} from "../graphql-error.ts"
 import { ApplicationConfig } from "./application-config.ts"
+
+const jsonMediaType = (contentType: string | null): string | undefined => {
+  if (contentType === null) {
+    return undefined
+  }
+  return contentType.split(";")[0]?.trim().toLowerCase()
+}
+
+const isJsonContentType = (contentType: string | null): boolean => {
+  const mediaType = jsonMediaType(contentType)
+  return (
+    mediaType === "application/json" || mediaType?.endsWith("+json") === true
+  )
+}
+
+/** Reject HTML (and other non-JSON) before genql parses the response body. */
+const createGraphqlEndpointFetch =
+  (configuredUrl: string) =>
+  async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+    const response = await fetch(input, init)
+    if (!isJsonContentType(response.headers.get("content-type"))) {
+      throw new GraphqlUrlNotEndpointError(configuredUrl)
+    }
+    return response
+  }
 
 /**
  * Expected GraphQL operator failures. Marked as already reported so
@@ -185,7 +213,10 @@ export class GraphqlApi extends Context.Service<
     GraphqlApi,
     Effect.gen(function* () {
       const config = yield* ApplicationConfig
-      const client = createClient({ url: config.graphqlUrl })
+      const client = createClient({
+        url: config.graphqlUrl,
+        fetch: createGraphqlEndpointFetch(config.graphqlUrl),
+      })
 
       const mapFailure = (cause: unknown): GraphqlRequestFailed => {
         const failure = describeGraphqlFailure(cause, {


### PR DESCRIPTION
Operators often set `READY_FOR_AGENT_GRAPHQL_URL` to the Harness origin
(`http://localhost:7000`) instead of the GraphQL path (`/graphql`). The origin
returns `200 text/html`, genql then fails with `Failed to parse JSON`, and finite
commands (`add`, `candidates`, `intake`, `status`) reported a misleading
`GRAPHQL_ERROR`.

`GraphqlApi` now inspects the response `Content-Type` at the `createClient` fetch
boundary and throws a dedicated error before genql parses the body.
`describeGraphqlFailure` maps that to CLI-owned `GRAPHQL_URL_NOT_ENDPOINT`. The
message names the configured URL, states that the response was HTML (the Harness
UI), and suggests `READY_FOR_AGENT_GRAPHQL_URL=<origin>/graphql` unless the path
already ends with `/graphql`. The URL is not rewritten or retried;
`ApplicationConfig` is unchanged. Connection-refused stays `HARNESS_UNREACHABLE`,
and real `application/json` parse failures stay `GRAPHQL_ERROR`.

Addresses #1006.

Verified with `bunx nx test ready-for-agent` (unit coverage of HTML-at-origin,
HTML-at-`/graphql`, unreachable, and domain errors; `cli-process` HTML mock for
`status`) and `bunx nx typecheck ready-for-agent`. Review of the uncommitted
change found no findings.

Limitation: any non-JSON `Content-Type` uses the same HTML/Harness-UI wording, as
specified.

Closes #1006