### PR TITLE
fix(harness): fetch GraphQL with an absolute origin during SSR

### DIFF
--- a/apps/harness/src/committed-pr-dashboard.tsx
+++ b/apps/harness/src/committed-pr-dashboard.tsx
@@ -3,8 +3,8 @@
  */
 import { useQuery } from "@tanstack/react-query"
 import { useEffect, useState } from "react"
-import { createClient } from "@ready-for-agent/graphql-client"
 import { Banner } from "./banner.js"
+import { createHarnessGraphqlClient } from "./harness-graphql.js"
 import {
   localCommittedPullRequestDayBounds,
   msUntilNextLocalMidnight,
@@ -12,7 +12,7 @@ import {
 import { committedPullRequestsCountQueryKeyPrefix } from "./refresh-work-items-live.js"
 import { ui } from "./ui.js"
 
-const graphql = createClient({ url: "/graphql", batch: true })
+const graphql = createHarnessGraphqlClient({ batch: true })
 
 const committedPullRequestsCountQuery = (from: string, to: string) => ({
   queryKey: [...committedPullRequestsCountQueryKeyPrefix, from, to] as const,

--- a/apps/harness/src/harness-graphql.ts
+++ b/apps/harness/src/harness-graphql.ts
@@ -1,0 +1,58 @@
+/**
+ * Browser GraphQL stays on the root-relative path. SSR `fetch` needs an
+ * absolute origin or it rejects the URL and dehydrates queries as failed.
+ */
+
+import { createIsomorphicFn } from "@tanstack/react-start"
+import { getRequest } from "@tanstack/react-start/server"
+import { createClient } from "@ready-for-agent/graphql-client"
+
+export const GRAPHQL_PATH = "/graphql"
+
+export const toFetchableGraphqlUrl = (input: {
+  readonly url: string
+  readonly base: string
+}): string => new URL(input.url, input.base).href
+
+const resolveRelativeGraphqlUrl = createIsomorphicFn()
+  .server((url: string) => {
+    if (typeof document !== "undefined") {
+      return url
+    }
+    try {
+      return toFetchableGraphqlUrl({ url, base: getRequest().url })
+    } catch {
+      return toFetchableGraphqlUrl({
+        url,
+        base: `http://127.0.0.1:${process.env.PORT ?? "6056"}/`,
+      })
+    }
+  })
+  .client((url: string) => url)
+
+export const resolveGraphqlFetchUrl = (url: string): string => {
+  try {
+    return new URL(url).href
+  } catch {
+    return resolveRelativeGraphqlUrl(url)
+  }
+}
+
+const fetchGraphql = (
+  input: RequestInfo | URL,
+  init?: RequestInit,
+): Promise<Response> => {
+  if (typeof input === "string") {
+    return fetch(resolveGraphqlFetchUrl(input), init)
+  }
+  return fetch(input, init)
+}
+
+export const createHarnessGraphqlClient = (options?: {
+  readonly batch?: boolean
+}) =>
+  createClient({
+    url: GRAPHQL_PATH,
+    ...(options?.batch === undefined ? {} : { batch: options.batch }),
+    fetch: fetchGraphql,
+  })

--- a/apps/harness/src/home-page-content.tsx
+++ b/apps/harness/src/home-page-content.tsx
@@ -20,7 +20,6 @@ import {
   useRef,
   useState,
 } from "react"
-import { createClient } from "@ready-for-agent/graphql-client"
 import { COMPLETED_WORK_ITEMS_DEFAULT_PAGE_SIZE as completedWorkItemsDefaultPageSize } from "@ready-for-agent/work-item-lifecycle/jobs-completed-window"
 import { formatAgentBackendStatusLabel } from "./agent-backend-status-label.js"
 import { AgentBackendWarnings } from "./agent-backend-warnings.js"
@@ -43,6 +42,7 @@ import { repositoryCardCollapseId, useCardCollapsed } from "./card-collapse.js"
 import { CardCollapseToggle } from "./card-collapse-toggle.js"
 import { Copy } from "./copy.js"
 import { forgeChangeRequestShort } from "./forge-change-request.js"
+import { createHarnessGraphqlClient } from "./harness-graphql.js"
 import {
   type GraphqlWorkItemState,
   issueActionEligibility,
@@ -120,7 +120,7 @@ import { WorkItemResetButton } from "./work-item-reset-button.js"
 export type { Repository } from "./repositories-query.js"
 export { repositoriesQuery } from "./repositories-query.js"
 
-const graphql = createClient({ url: "/graphql", batch: true })
+const graphql = createHarnessGraphqlClient({ batch: true })
 // Long-lived host folder dialog must not pin co-batched GraphQL operations.
 
 const configQuery = {

--- a/apps/harness/src/pipeline-page.tsx
+++ b/apps/harness/src/pipeline-page.tsx
@@ -5,8 +5,8 @@ import {
   useSuspenseQuery,
 } from "@tanstack/react-query"
 import { type FormEvent, Suspense, useEffect, useState } from "react"
-import { createClient } from "@ready-for-agent/graphql-client"
 import { Banner, BannerActionButton } from "./banner.js"
+import { createHarnessGraphqlClient } from "./harness-graphql.js"
 import { KanbanBoard } from "./kanban-board.js"
 import { openPullRequestCountsQueryKey } from "./refresh-open-pull-request-count-live.js"
 import {
@@ -16,9 +16,9 @@ import {
 import { repositoriesQuery } from "./repositories-query.js"
 import { cx, ui } from "./ui.js"
 
-const graphql = createClient({ url: "/graphql", batch: true })
+const graphql = createHarnessGraphqlClient({ batch: true })
 // Long-lived host folder dialog must not pin co-batched GraphQL operations.
-const graphqlUnbatched = createClient({ url: "/graphql", batch: false })
+const graphqlUnbatched = createHarnessGraphqlClient({ batch: false })
 
 export const addRepositoryCommandQuery = {
   queryKey: ["addRepositoryCommand"],

--- a/apps/harness/src/repositories-query.ts
+++ b/apps/harness/src/repositories-query.ts
@@ -6,9 +6,9 @@
  * without importing the home route.
  */
 
-import { createClient } from "@ready-for-agent/graphql-client"
+import { createHarnessGraphqlClient } from "./harness-graphql.js"
 
-const graphql = createClient({ url: "/graphql", batch: true })
+const graphql = createHarnessGraphqlClient({ batch: true })
 
 type RepositoryCredential = {
   repositoryId: string

--- a/apps/harness/src/routes/__root.tsx
+++ b/apps/harness/src/routes/__root.tsx
@@ -26,7 +26,6 @@ import {
   useRef,
   useState,
 } from "react"
-import { createClient } from "@ready-for-agent/graphql-client"
 import { formatAgentBackendStatusTrail } from "../agent-backend-status-label.js"
 import { AgentBackendWarnings } from "../agent-backend-warnings.js"
 import { AgentModelSelect } from "../agent-model-select.js"
@@ -47,6 +46,7 @@ import { CommittedPullRequestsDashboard } from "../committed-pr-dashboard.js"
 import { READY_FOR_AGENT_VERSION_LABEL } from "../generated/version"
 import { GitHubThrottleBanner } from "../github-throttle-banner.js"
 import { useGithubThrottleRetryAt } from "../github-throttle-errors.js"
+import { createHarnessGraphqlClient } from "../harness-graphql.js"
 import { getHarnessSettingsAutoOpenAction } from "../harness-settings-auto-open.js"
 import { JobsRepositoryFilterProvider } from "../jobs-repository-filter.js"
 import { JobsViewSwitcher } from "../jobs-view-switcher.js"
@@ -79,7 +79,7 @@ export interface RouterContext {
   queryClient: QueryClient
 }
 
-const graphql = createClient({ url: "/graphql" })
+const graphql = createHarnessGraphqlClient()
 
 const configQuery = {
   queryKey: ["config"],

--- a/apps/harness/src/session-usage-dialog.tsx
+++ b/apps/harness/src/session-usage-dialog.tsx
@@ -7,11 +7,11 @@
  */
 import { useQuery } from "@tanstack/react-query"
 import { useEffect, useId, useRef } from "react"
-import { createClient } from "@ready-for-agent/graphql-client"
 import { Banner } from "./banner.js"
+import { createHarnessGraphqlClient } from "./harness-graphql.js"
 import { cx, ui } from "./ui.js"
 
-const graphql = createClient({ url: "/graphql" })
+const graphql = createHarnessGraphqlClient()
 
 const sessionQuery = (workItemId: string) => ({
   queryKey: ["session", workItemId] as const,

--- a/apps/harness/test/repositories-query.test.ts
+++ b/apps/harness/test/repositories-query.test.ts
@@ -1,0 +1,99 @@
+import { requestHandler } from "@tanstack/react-start/server"
+import {
+  GRAPHQL_PATH,
+  resolveGraphqlFetchUrl,
+  toFetchableGraphqlUrl,
+} from "../src/harness-graphql.ts"
+import { repositoriesQuery } from "../src/repositories-query.ts"
+import { describe, expect, test } from "bun:test"
+
+const emptyRepositoriesPayload = {
+  repositories: [],
+  repositoryCredentials: [],
+}
+
+const requestUrl = (input: RequestInfo | URL): string => {
+  if (typeof input === "string") return input
+  if (input instanceof URL) return input.href
+  return input.url
+}
+
+describe("Harness GraphQL URL", () => {
+  test("joins the GraphQL path onto an absolute origin", () => {
+    expect(
+      toFetchableGraphqlUrl({
+        url: GRAPHQL_PATH,
+        base: "http://127.0.0.1:6056/repos",
+      }),
+    ).toBe("http://127.0.0.1:6056/graphql")
+    expect(
+      toFetchableGraphqlUrl({
+        url: GRAPHQL_PATH,
+        base: "http://192.168.1.10:4300/",
+      }),
+    ).toBe("http://192.168.1.10:4300/graphql")
+  })
+
+  test("server fallback without a request is still an absolute GraphQL URL", () => {
+    const url = resolveGraphqlFetchUrl(GRAPHQL_PATH)
+    expect(() => new URL(url)).not.toThrow()
+    expect(new URL(url).pathname).toBe("/graphql")
+  })
+})
+
+describe("Configured Repositories GraphQL during SSR", () => {
+  test("does not fail the repositories query with an invalid URL", async () => {
+    const fetchedUrls: string[] = []
+    const originalFetch = globalThis.fetch
+    globalThis.fetch = (async (input: RequestInfo | URL) => {
+      const url = requestUrl(input)
+      fetchedUrls.push(url)
+      expect(() => new URL(url)).not.toThrow()
+      return new Response(JSON.stringify({ data: emptyRepositoriesPayload }), {
+        headers: { "content-type": "application/json" },
+        status: 200,
+      })
+    }) as typeof fetch
+
+    try {
+      const handler = requestHandler(async () => {
+        const repositories = await repositoriesQuery.queryFn()
+        return Response.json(repositories)
+      })
+      const response = await handler(
+        new Request("http://127.0.0.1:6056/repos"),
+        {},
+      )
+      expect(response.status).toBe(200)
+      expect(await response.json()).toEqual([])
+    } finally {
+      globalThis.fetch = originalFetch
+    }
+
+    expect(fetchedUrls).toEqual(["http://127.0.0.1:6056/graphql"])
+  })
+
+  test("uses the incoming request origin, not a hard-coded loopback default", async () => {
+    const fetchedUrls: string[] = []
+    const originalFetch = globalThis.fetch
+    globalThis.fetch = (async (input: RequestInfo | URL) => {
+      fetchedUrls.push(requestUrl(input))
+      return new Response(JSON.stringify({ data: emptyRepositoriesPayload }), {
+        headers: { "content-type": "application/json" },
+        status: 200,
+      })
+    }) as typeof fetch
+
+    try {
+      const handler = requestHandler(async () => {
+        await repositoriesQuery.queryFn()
+        return new Response("ok")
+      })
+      await handler(new Request("http://192.168.1.10:4300/"), {})
+    } finally {
+      globalThis.fetch = originalFetch
+    }
+
+    expect(fetchedUrls).toEqual(["http://192.168.1.10:4300/graphql"])
+  })
+})


### PR DESCRIPTION
SSR of pages that load Configured Repositories was calling `fetch("/graphql")`.
Bun/Node reject that as an invalid URL, so TanStack dehydrated the
`repositories` query as failed and the client recovered after hydration.
Ordinary home/Repos navigations logged `fetch() URL is invalid`.

Add a shared `createHarnessGraphqlClient` that resolves `/graphql` against
the incoming request origin on the server and keeps the root-relative path
in the browser. Root chrome, home, Repos, Pipeline, the committed-PR strip,
and Session Telemetry now share that client so SSR and post-hydration
GraphQL stay on the same contract.

Checked with `nx test harness` (581 bun + 126 vitest) and
`nx run harness:typecheck`. New tests cover URL joining and
`repositoriesQuery` under a Start request context for
`http://127.0.0.1:6056/repos` and `http://192.168.1.10:4300/`.
Local review was clean.

Live e2e was not run here. Client-only SSE still uses `/graphql` inside
`useEffect`, which browsers accept.

Closes #997