### PR TITLE
test(harness): seed Paused Repository for settings and Kanban e2e

### DIFF
--- a/apps/harness/e2e/features/kanban-route.feature
+++ b/apps/harness/e2e/features/kanban-route.feature
@@ -1,6 +1,8 @@
 Feature: View the work pipeline
   Operators use the home Kanban board to monitor delivery without
-  repository management competing with the pipeline.
+  repository management competing with the pipeline. Scenarios that only
+  need a Repository seed a Paused Repository; they do not clone the
+  End-to-End Fixture Repository.
 
   Scenario: First-run settings save leads to add-repo blank slate
     Given the Harness is empty with first-run settings required
@@ -20,20 +22,16 @@ Feature: View the work pipeline
     And the kanban board is not rendered
 
   Scenario: View the empty work pipeline
-    Given the Harness has no configured Repositories
-    And the End-to-End Fixture Repository is checked out
-    When I add the Repository with the CLI
-    And I navigate to the Kanban board
+    Given the Harness has a seeded Paused Repository
+    When I navigate to the Kanban board
     Then all six pipeline lane headers are visible
     And the Pipeline jobs tab is active
     And repository management is not rendered
     And the committed pull request totals are visible above the board
 
   Scenario: Switch from Repos to Pipeline via top nav
-    Given the Harness has no configured Repositories
-    And the End-to-End Fixture Repository is checked out
-    When I add the Repository with the CLI
-    And I open the Repos page
+    Given the Harness has a seeded Paused Repository
+    When I open the Repos page
     Then the Repos top nav control is active
     And the Pipeline top nav control is not active
     When I click the Pipeline top nav control
@@ -43,10 +41,8 @@ Feature: View the work pipeline
     And the Repos top nav control is not active
 
   Scenario: Switch from Pipeline to Repos via top nav
-    Given the Harness has no configured Repositories
-    And the End-to-End Fixture Repository is checked out
-    When I add the Repository with the CLI
-    And I navigate to the Kanban board
+    Given the Harness has a seeded Paused Repository
+    When I navigate to the Kanban board
     Then the Pipeline top nav control is active
     And the Repos top nav control is not active
     When I click the Repos top nav control
@@ -55,9 +51,7 @@ Feature: View the work pipeline
     And the Pipeline top nav control is not active
 
   Scenario: Legacy /kanban path lands on the home board
-    Given the Harness has no configured Repositories
-    And the End-to-End Fixture Repository is checked out
-    When I add the Repository with the CLI
-    And I navigate to the legacy Kanban path
+    Given the Harness has a seeded Paused Repository
+    When I navigate to the legacy Kanban path
     Then I am on the Kanban board
     And the Pipeline top nav control is active

--- a/apps/harness/e2e/features/repository-settings-browser-history.feature
+++ b/apps/harness/e2e/features/repository-settings-browser-history.feature
@@ -2,26 +2,23 @@ Feature: Route Repository settings by Repository ID
   Explicit Repository settings opens use `/repos/<repository-id>/settings` so
   Back closes the dialog, Forward reopens it with saved values, and Save /
   Cancel / Escape stay synchronized with the browser location. Direct and
-  stale links render over Repos. A configured default build model keeps
-  first-run Harness Settings from competing with these scenarios.
+  stale links render over Repos. These scenarios seed a Paused Repository
+  instead of cloning the End-to-End Fixture Repository. A configured
+  default build model keeps first-run Harness Settings from competing.
 
   Background:
-    Given the Harness has no configured Repositories
+    Given the Harness has a seeded Paused Repository
     And the Harness has a configured default build model
 
   Scenario: Explicit open pushes /repos/<id>/settings and preserves theme search
-    Given the End-to-End Fixture Repository is checked out
-    When I add the Repository with the CLI
-    And I open the Repos page with theme dark
+    When I open the Repos page with theme dark
     And I open Repository settings from the card menu
     Then the browser location is the repository settings path with theme dark
     And the Repository settings dialog is visible
     And the Repos jobs tab is active
 
   Scenario: Browser Back closes Repository settings and Forward reopens with saved values
-    Given the End-to-End Fixture Repository is checked out
-    When I add the Repository with the CLI
-    And I open the Repos page
+    When I open the Repos page
     And I open Repository settings from the card menu
     Then the browser location is the repository settings path
     When I change the Repository paused draft
@@ -34,9 +31,7 @@ Feature: Route Repository settings by Repository ID
     And the Repository paused field shows the saved value not the draft
 
   Scenario: Cancel returns to the originating Repos location
-    Given the End-to-End Fixture Repository is checked out
-    When I add the Repository with the CLI
-    And I open the Repos page
+    When I open the Repos page
     And I open Repository settings from the card menu
     Then the browser location is the repository settings path
     When I cancel the Repository settings dialog
@@ -44,9 +39,7 @@ Feature: Route Repository settings by Repository ID
     And the browser location is the repos path
 
   Scenario: Escape returns to the originating Repos location
-    Given the End-to-End Fixture Repository is checked out
-    When I add the Repository with the CLI
-    And I open the Repos page
+    When I open the Repos page
     And I open Repository settings from the card menu
     Then the browser location is the repository settings path
     When I press Escape in the Repository settings dialog
@@ -54,9 +47,7 @@ Feature: Route Repository settings by Repository ID
     And the browser location is the repos path
 
   Scenario: Successful Save returns to the originating location
-    Given the End-to-End Fixture Repository is checked out
-    When I add the Repository with the CLI
-    And I open the Repos page
+    When I open the Repos page
     And I open Repository settings from the card menu
     Then the browser location is the repository settings path
     When I save Repository settings without changing values
@@ -64,9 +55,7 @@ Feature: Route Repository settings by Repository ID
     And the browser location is the repos path
 
   Scenario: Failed Save keeps the dialog and settings path open
-    Given the End-to-End Fixture Repository is checked out
-    When I add the Repository with the CLI
-    And I open the Repos page
+    When I open the Repos page
     And I open Repository settings from the card menu
     Then the browser location is the repository settings path
     When Repository settings Save is forced to fail
@@ -76,9 +65,7 @@ Feature: Route Repository settings by Repository ID
     And a repository settings save error is shown
 
   Scenario: Browser Back is blocked while Save is pending
-    Given the End-to-End Fixture Repository is checked out
-    When I add the Repository with the CLI
-    And I open the Repos page
+    When I open the Repos page
     And I open Repository settings from the card menu
     Then the browser location is the repository settings path
     When Repository settings Save is delayed
@@ -91,9 +78,7 @@ Feature: Route Repository settings by Repository ID
     And the browser location is the repos path
 
   Scenario: Direct repository settings navigation shows the dialog over Repos
-    Given the End-to-End Fixture Repository is checked out
-    When I add the Repository with the CLI
-    And I open the repository settings path directly
+    When I open the repository settings path directly
     Then the Repository settings dialog is visible
     And the browser location is the repository settings path
     And the Repos jobs tab is active
@@ -102,9 +87,7 @@ Feature: Route Repository settings by Repository ID
     And the browser location is the repos path
 
   Scenario: Refreshing repository settings keeps the dialog open and closes to Repos
-    Given the End-to-End Fixture Repository is checked out
-    When I add the Repository with the CLI
-    And I open the repository settings path directly
+    When I open the repository settings path directly
     Then the Repository settings dialog is visible
     When I refresh the page
     Then the Repository settings dialog is visible
@@ -114,9 +97,7 @@ Feature: Route Repository settings by Repository ID
     And the browser location is the repos path
 
   Scenario: Refresh after in-app open still closes to Repos with replace
-    Given the End-to-End Fixture Repository is checked out
-    When I add the Repository with the CLI
-    And I open the Repos page
+    When I open the Repos page
     And I open Repository settings from the card menu
     Then the browser location is the repository settings path
     When I refresh the page

--- a/apps/harness/e2e/steps/add-and-refresh-repository.ts
+++ b/apps/harness/e2e/steps/add-and-refresh-repository.ts
@@ -24,6 +24,7 @@ import {
   gitlabSentinelIssueNumber,
 } from "../support/constants.ts"
 import { dismissFirstRunSettingsIfPresent } from "../support/first-run-settings.ts"
+import { seedPausedRepositoryFixture } from "../support/paused-repository-fixture.ts"
 import { Given, Then, When, test } from "./fixtures.ts"
 
 const workspaceRoot = resolve(
@@ -169,6 +170,11 @@ Given("the Harness has no configured Repositories", async () => {
   // GraphQL-only setup: do not tour home/Repos blank slates here. The Kanban
   // scenario whose assertion *is* that empty UI still checks it.
   await ensureNoConfiguredRepositories()
+})
+
+Given("the Harness has a seeded Paused Repository", async () => {
+  test.setTimeout(SCENARIO_TIMEOUT_MS)
+  await seedPausedRepositoryFixture()
 })
 
 Given("the End-to-End Fixture Repository is checked out", async ({ world }) => {

--- a/apps/harness/e2e/steps/repository-settings-browser-history.ts
+++ b/apps/harness/e2e/steps/repository-settings-browser-history.ts
@@ -2,8 +2,8 @@
  * Playwright-BDD steps for routed Repository settings history (issue #842).
  */
 import { type Page, expect } from "@playwright/test"
-import { E2E_GRAPHQL_URL } from "../support/constants.ts"
 import { dismissFirstRunSettingsIfPresent } from "../support/first-run-settings.ts"
+import { PAUSED_REPOSITORY_FIXTURE } from "../support/paused-repository-fixture.ts"
 import { Then, When } from "./fixtures.ts"
 
 /** Repository settings dialog is titled with the Project Path. */
@@ -25,34 +25,9 @@ const awaitCatalogSettled = async (
 }
 
 const repositorySettingsPathPattern = /\/repos\/[^/]+\/settings\/?(?:\?.*)?$/
-
-const fetchFirstRepositoryId = async (): Promise<string> => {
-  const response = await fetch(E2E_GRAPHQL_URL, {
-    method: "POST",
-    headers: { "content-type": "application/json" },
-    body: JSON.stringify({
-      query: "query { repositories { id projectPath } }",
-    }),
-  })
-  if (!response.ok) {
-    throw new Error(`GraphQL HTTP ${response.status}: ${await response.text()}`)
-  }
-  const payload = (await response.json()) as {
-    data?: { repositories: ReadonlyArray<{ id: string; projectPath: string }> }
-    errors?: ReadonlyArray<{ message: string }>
-  }
-  if (payload.errors?.length) {
-    throw new Error(
-      `GraphQL errors: ${payload.errors.map((e) => e.message).join("; ")}`,
-    )
-  }
-  const repositories = payload.data?.repositories ?? []
-  const first = repositories[0]
-  if (first === undefined) {
-    throw new Error("Expected at least one configured Repository")
-  }
-  return first.id
-}
+const seededRepositorySettingsPath = new RegExp(
+  `/repos/${PAUSED_REPOSITORY_FIXTURE.repositoryId}/settings/?(?:\\?.*)?$`,
+)
 
 type UpdateRepositorySettingsIntercept = {
   failNext: boolean
@@ -135,8 +110,9 @@ When("I open Repository settings from the card menu", async ({ page }) => {
     page.getByRole("region", { name: "Configured repositories" }),
   ).toBeVisible({ timeout: 30_000 })
   await page
-    .getByRole("button", { name: /^Actions for / })
-    .first()
+    .getByRole("button", {
+      name: `Actions for ${PAUSED_REPOSITORY_FIXTURE.projectPath}`,
+    })
     .click()
   await page.getByRole("menuitem", { name: "Settings" }).click()
   const dialog = repositoryDialog(page)
@@ -146,8 +122,9 @@ When("I open Repository settings from the card menu", async ({ page }) => {
 
 When("I open the repository settings path directly", async ({ page }) => {
   await installUpdateRepositorySettingsRoute(page)
-  const repositoryId = await fetchFirstRepositoryId()
-  await page.goto(`/repos/${encodeURIComponent(repositoryId)}/settings`)
+  await page.goto(
+    `/repos/${encodeURIComponent(PAUSED_REPOSITORY_FIXTURE.repositoryId)}/settings`,
+  )
   await expect(page).toHaveURL(repositorySettingsPathPattern)
   const dialog = repositoryDialog(page)
   await expect(dialog).toBeVisible({ timeout: 30_000 })
@@ -176,14 +153,8 @@ When("I press Escape in the Repository settings dialog", async ({ page }) => {
 When("I change the Repository paused draft", async ({ page }) => {
   const dialog = repositoryDialog(page)
   const checkbox = dialog.getByRole("checkbox", { name: /Paused/i })
-  await expect(checkbox).toBeVisible()
-  const wasChecked = await checkbox.isChecked()
-  await checkbox.setChecked(!wasChecked)
-  // Stash the draft expectation on the page for the Then step.
-  await page.evaluate((draftChecked) => {
-    ;(window as unknown as { __rfaPausedDraft?: boolean }).__rfaPausedDraft =
-      draftChecked
-  }, !wasChecked)
+  await expect(checkbox).toBeChecked()
+  await checkbox.setChecked(false)
 })
 
 When(
@@ -274,17 +245,23 @@ When("I close the Repository not found dialog", async ({ page }) => {
 Then(
   "the browser location is the repository settings path",
   async ({ page }) => {
-    await expect(page).toHaveURL(repositorySettingsPathPattern)
+    await expect(page).toHaveURL(seededRepositorySettingsPath)
     const pathname = new URL(page.url()).pathname
     // Path must use the stable Repository ID (repo-…), not a nested project path.
-    expect(pathname).toMatch(/^\/repos\/repo-[^/]+\/settings\/?$/)
+    expect(pathname).toBe(
+      `/repos/${PAUSED_REPOSITORY_FIXTURE.repositoryId}/settings`,
+    )
   },
 )
 
 Then(
   "the browser location is the repository settings path with theme dark",
   async ({ page }) => {
-    await expect(page).toHaveURL(/\/repos\/[^/]+\/settings\/?\?theme=dark$/)
+    await expect(page).toHaveURL(
+      new RegExp(
+        `/repos/${PAUSED_REPOSITORY_FIXTURE.repositoryId}/settings/?\\?theme=dark$`,
+      ),
+    )
   },
 )
 
@@ -324,20 +301,8 @@ Then(
     const dialog = repositoryDialog(page)
     await awaitCatalogSettled(dialog)
     const checkbox = dialog.getByRole("checkbox", { name: /Paused/i })
-    await expect(checkbox).toBeVisible()
-    const draftChecked = await page.evaluate(
-      () =>
-        (window as unknown as { __rfaPausedDraft?: boolean }).__rfaPausedDraft,
-    )
-    // Fresh fixture repos are not paused; draft flipped that, so saved is opposite.
-    if (draftChecked === true) {
-      await expect(checkbox).not.toBeChecked()
-    } else if (draftChecked === false) {
-      await expect(checkbox).toBeChecked()
-    } else {
-      // Default fixture: not paused after discarded draft.
-      await expect(checkbox).not.toBeChecked()
-    }
+    // Seeded Paused Repository: discarded draft is unchecked; saved stays Paused.
+    await expect(checkbox).toBeChecked()
   },
 )
 

--- a/apps/harness/e2e/support/paused-repository-fixture.ts
+++ b/apps/harness/e2e/support/paused-repository-fixture.ts
@@ -1,0 +1,109 @@
+/**
+ * Paused Repository persistence seed for live e2e that only need a
+ * Repository to exist (issue #998).
+ *
+ * Seeds once per live Harness process via {@link ensureLiveHarnessPersistence}:
+ * the first call writes the row against the stopped database and restarts;
+ * later calls no-op when the Paused, already-reconciled fixture is present.
+ * Does not clone the End-to-End Fixture Repository. The Project Path has no
+ * vault secret, so vault-backed live e2e does not treat the row as credentialed
+ * and does not activate Issue Polling or enqueue a Refresh Job.
+ */
+
+import { E2E_GRAPHQL_URL } from "./constants.ts"
+import { ensureLiveHarnessPersistence } from "./live-harness-seed.ts"
+
+/**
+ * Branded entity IDs must match DB schema patterns
+ * (`repo-` + 26 Crockford ULID chars, no I/L/O/U). Fixed fixture keeps
+ * scenarios deterministic across restarts.
+ */
+export const PAUSED_REPOSITORY_FIXTURE = {
+  repositoryId: "repo-01KZW59SEED0REP0FXX0000001",
+  projectPath: "e2e/paused-repository",
+} as const
+
+type PausedRepositoryPresenceRow = {
+  readonly id: string
+  readonly paused: boolean
+  readonly issuesReconciledAt: string | null
+}
+
+export const pausedRepositoryFixtureIsPresent = (
+  repositories: ReadonlyArray<PausedRepositoryPresenceRow>,
+): boolean => {
+  const row = repositories.find(
+    (repository) => repository.id === PAUSED_REPOSITORY_FIXTURE.repositoryId,
+  )
+  return row?.paused === true && row.issuesReconciledAt !== null
+}
+
+const sqlLiteral = (value: string) => `'${value.replaceAll("'", "''")}'`
+
+const pausedRepositoryFixturePresent = async (): Promise<boolean> => {
+  try {
+    const response = await fetch(E2E_GRAPHQL_URL, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        query: `query {
+          repositories { id paused issuesReconciledAt }
+        }`,
+      }),
+    })
+    if (!response.ok) {
+      return false
+    }
+    const payload = (await response.json()) as {
+      data?: {
+        repositories?: ReadonlyArray<PausedRepositoryPresenceRow>
+      }
+      errors?: ReadonlyArray<{ message: string }>
+    }
+    if (payload.errors?.length || payload.data?.repositories === undefined) {
+      return false
+    }
+    return pausedRepositoryFixtureIsPresent(payload.data.repositories)
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Seed a Paused Repository whose Issue store is already marked reconciled so
+ * Repos and Pipeline render without a live Forge round-trip. Paused so the
+ * Harness does not autonomously select work.
+ *
+ * Does not write `config.default_model`: callers that need first-run
+ * suppressed should use `ensureConfiguredDefaultBuildModel` after seeding.
+ */
+export const seedPausedRepositoryFixture = async (): Promise<void> => {
+  const now = Date.now()
+  const sql = [
+    `DELETE FROM work_item WHERE repository_id = ${sqlLiteral(PAUSED_REPOSITORY_FIXTURE.repositoryId)};`,
+    `DELETE FROM issue WHERE repository_id = ${sqlLiteral(PAUSED_REPOSITORY_FIXTURE.repositoryId)};`,
+    `DELETE FROM repository WHERE id = ${sqlLiteral(PAUSED_REPOSITORY_FIXTURE.repositoryId)};`,
+    // issues_reconciled_at must be set so Repos and Pipeline render the
+    // projected Issue store without requiring a live Forge refresh.
+    `INSERT INTO repository (
+       id, forge, forge_host, project_path, local_path, is_bare, paused,
+       issues_reconciled_at, created_at, updated_at
+     ) VALUES (
+       ${sqlLiteral(PAUSED_REPOSITORY_FIXTURE.repositoryId)},
+       'github',
+       'github.com',
+       ${sqlLiteral(PAUSED_REPOSITORY_FIXTURE.projectPath)},
+       ${sqlLiteral(`/tmp/${PAUSED_REPOSITORY_FIXTURE.repositoryId}`)},
+       0,
+       1,
+       ${now},
+       ${now},
+       ${now}
+     );`,
+  ].join("\n")
+
+  await ensureLiveHarnessPersistence({
+    alreadyPresent: pausedRepositoryFixturePresent,
+    sql,
+  })
+}

--- a/apps/harness/test/live-harness-seed.test.ts
+++ b/apps/harness/test/live-harness-seed.test.ts
@@ -8,6 +8,10 @@ import {
   seedLiveHarnessAndRestart,
 } from "../e2e/support/live-harness-seed.ts"
 import {
+  PAUSED_REPOSITORY_FIXTURE,
+  pausedRepositoryFixtureIsPresent,
+} from "../e2e/support/paused-repository-fixture.ts"
+import {
   SESSION_TELEMETRY_FIXTURE_WORK_ITEM_COUNT,
   SESSION_TELEMETRY_FIXTURE_WORK_ITEM_IDS,
   TELEMETRY_FIXTURE,
@@ -91,6 +95,36 @@ describe("seedLiveHarnessAndRestart", () => {
     expect(recording.files.get(CONTROL_FILES.seedSql)).toBe("")
     expect(recording.files.get(CONTROL_FILES.restart)).toBe("1")
     expect(recording.waitCalls).toBe(1)
+  })
+})
+
+describe("pausedRepositoryFixtureIsPresent", () => {
+  const present = {
+    id: PAUSED_REPOSITORY_FIXTURE.repositoryId,
+    paused: true,
+    issuesReconciledAt: "2026-08-13T10:00:00.000Z",
+  }
+
+  test("requires the seeded Paused Repository with Issue-store freshness", () => {
+    expect(pausedRepositoryFixtureIsPresent([])).toBe(false)
+    expect(
+      pausedRepositoryFixtureIsPresent([
+        {
+          id: "repo-01KZW59OTHER0REP0FXX0000001",
+          paused: true,
+          issuesReconciledAt: "2026-08-13T10:00:00.000Z",
+        },
+      ]),
+    ).toBe(false)
+    expect(
+      pausedRepositoryFixtureIsPresent([{ ...present, paused: false }]),
+    ).toBe(false)
+    expect(
+      pausedRepositoryFixtureIsPresent([
+        { ...present, issuesReconciledAt: null },
+      ]),
+    ).toBe(false)
+    expect(pausedRepositoryFixtureIsPresent([present])).toBe(true)
   })
 })
 

--- a/docs/adr/0021-live-harness-end-to-end-test.md
+++ b/docs/adr/0021-live-harness-end-to-end-test.md
@@ -1,6 +1,9 @@
 # Validate Harness end to end against controlled Forge Repositories
 
-Harness end-to-end validation runs the production-built application, worker, Keymaxxer Sidecar, command-line client, and browser against controlled End-to-End Fixture Repositories, without GraphQL or Forge mocks. Executable Gherkin via `playwright-bdd` adds each Repository from a fresh local checkout through the real CLI and waits for credential activation's automatic first Refresh Job to make the permanent Ready-labeled sentinel Issue visible in the UI.
+Harness end-to-end validation runs the production-built application, worker, Keymaxxer Sidecar, command-line client, and browser against a real Harness process, without GraphQL or Forge mocks. Executable Gherkin via `playwright-bdd` covers two Repository setup paths:
+
+- **Fixture add-and-refresh.** Add-and-refresh of the End-to-End Fixture Repository, Repository Intake CLI, and the catalog-only scenario that asserts a stale Repository Agent Model override add each Repository from a fresh local checkout through the real CLI and wait for credential activation's automatic first Refresh Job to make the permanent Ready-labeled sentinel Issue visible in the UI.
+- **UI-history persistence seed.** Repository settings history and Kanban live e2e that only need a Repository to exist seed a Paused Repository (same idempotent helper as Session Telemetry fixtures) instead of cloning the End-to-End Fixture Repository. The seeded Repository is Paused so the Harness does not autonomously select work, and Issue-store freshness is marked already reconciled so Repos and Pipeline render without a live Forge round-trip or a Refresh Job.
 
 ## GitHub fixture
 
@@ -12,12 +15,12 @@ Throwaway project on `git.drupalcode.org` under operator control (default Projec
 
 ## Shared run model
 
-Each run starts with an empty, isolated Harness database. Live e2e is split into **two** Nx targets / Playwright invocations (separate `webServer` boots) so product PATH and Keymaxxer policy can differ without installing OpenCode mid-suite (issue #958):
+Each run starts with an empty, isolated Harness database. UI-history scenarios that only need a Repository to exist (Repository settings history, Kanban with a Repository) may seed persistence instead of cloning the fixture; they do not enqueue a Refresh Job. Live e2e is split into **two** Nx targets / Playwright invocations (separate `webServer` boots) so product PATH and Keymaxxer policy can differ without installing OpenCode mid-suite (issue #958):
 
 | Target | Tag filter | Env | Coverage |
 | --- | --- | --- | --- |
 | `harness:e2e-no-backend` | `@no-backend` only | `E2E_AGENT_BACKEND_MODE=no-opencode`, `KEYMAXXER_ENABLED=false` | Default Agent Backend Unavailable + first-run UI when OpenCode is absent (pure-absence and mixed-Ready via fake Claude). Vault-free so fork PRs still run it. |
-| `harness:e2e` | everything except `@no-backend` | Fixture vault (below); ambient OpenCode allowed / expected in CI | Fixture Repository add/refresh, Kanban, Settings history, catalog-only Agent Models, etc. |
+| `harness:e2e` | everything except `@no-backend` | Fixture vault (below); ambient OpenCode allowed / expected in CI | Fixture Repository add/refresh, Kanban, Settings history (UI-history scenarios may seed persistence), catalog-only Agent Models, etc. |
 
 The live-Harness supervisor (`apps/harness/e2e/support/start-live-harness.ts`) always prepends a deterministic fake `claude` binary. In `no-opencode` mode it strips PATH directories that provide ambient `opencode`, `grok`, `codex`, and `claude`, then fails closed if those binaries still resolve (except the fake `claude`). Claude readiness is scenario-controlled (`firstParty` / `unauthenticated`) via the file protocol in `live-harness-control.ts`.
 


### PR DESCRIPTION
Repository settings history and Kanban live e2e only need a Repository
to exist. They no longer clone the End-to-End Fixture Repository or wait
for credential activation's first Refresh Job (#998).

**What changed**
- Seed a Paused Repository once per live Harness process via
  `ensureLiveHarnessPersistence` (same helper as Session Telemetry).
  `issues_reconciled_at` is set so Repos and Pipeline render without a
  Forge round-trip.
- Add-and-refresh, Repository Intake CLI, and the catalog-only stale
  Repository override scenario still add through the CLI and wait for
  the automatic first Refresh Job.
- ADR 0021 records that UI-history scenarios may seed persistence
  instead of cloning the fixture.

**Verification**
- Unit tests cover the presence helper (Paused + reconciled).
- Targeted Playwright: 17 Kanban and Repository settings scenarios
  passed without cloning the fixture.

**Notes**
- The fake Project Path has no vault secret, so vault-backed
  `harness:e2e` does not treat the row as credentialed and does not
  enqueue a Refresh Job. Paused stops autonomous work selection; it is
  not what blocks Issue Polling.

Closes #998