### PR TITLE
feat(harness): add sunburst rivet spandrels to merged-PR throughput frame

### DIFF
--- a/apps/harness/src/committed-pr-dashboard.tsx
+++ b/apps/harness/src/committed-pr-dashboard.tsx
@@ -14,6 +14,104 @@ import { ui } from "./ui.js"
 
 const graphql = createHarnessGraphqlClient({ batch: true })
 
+const spandrelSvg = (
+  <svg
+    width="40"
+    height="40"
+    viewBox="0 0 40 40"
+    fill="none"
+    aria-hidden="true"
+    style={{ overflow: "visible" }}
+  >
+    <circle cx="4" cy="4" r="4.5" fill="currentColor" />
+    <circle cx="4" cy="4" r="2" fill="var(--paper)" />
+    <line
+      x1="4"
+      y1="4"
+      x2="14"
+      y2="4"
+      stroke="currentColor"
+      strokeWidth="3"
+      strokeLinecap="round"
+    />
+    <line
+      x1="4"
+      y1="4"
+      x2="22"
+      y2="4"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      opacity="0.5"
+    />
+    <line
+      x1="4"
+      y1="4"
+      x2="4"
+      y2="14"
+      stroke="currentColor"
+      strokeWidth="3"
+      strokeLinecap="round"
+    />
+    <line
+      x1="4"
+      y1="4"
+      x2="4"
+      y2="22"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      opacity="0.5"
+    />
+    <line
+      x1="4"
+      y1="4"
+      x2="11"
+      y2="11"
+      stroke="currentColor"
+      strokeWidth="2.5"
+      strokeLinecap="round"
+      opacity="0.7"
+    />
+    <line
+      x1="4"
+      y1="4"
+      x2="16"
+      y2="16"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      opacity="0.35"
+    />
+  </svg>
+)
+
+function SpandrelCorners() {
+  return (
+    <>
+      <span className={ui.mergedPrStatsSpandrelTL}>{spandrelSvg}</span>
+      <span
+        className={ui.mergedPrStatsSpandrelTR}
+        style={{ transform: "scaleX(-1)" }}
+      >
+        {spandrelSvg}
+      </span>
+      <span
+        className={ui.mergedPrStatsSpandrelBL}
+        style={{ transform: "scaleY(-1)" }}
+      >
+        {spandrelSvg}
+      </span>
+      <span
+        className={ui.mergedPrStatsSpandrelBR}
+        style={{ transform: "scale(-1, -1)" }}
+      >
+        {spandrelSvg}
+      </span>
+    </>
+  )
+}
+
 const committedPullRequestsCountQuery = (from: string, to: string) => ({
   queryKey: [...committedPullRequestsCountQueryKeyPrefix, from, to] as const,
   queryFn: async (): Promise<number> => {
@@ -97,6 +195,7 @@ export function CommittedPullRequestsDashboard() {
         aria-label="Loading committed pull requests"
         aria-busy="true"
       >
+        <SpandrelCorners />
         <div className={ui.mergedPrStatsGrid}>
           <div className={ui.mergedPrStatsCell}>
             <span className={ui.mergedPrStatsSkeleton} />
@@ -121,6 +220,7 @@ export function CommittedPullRequestsDashboard() {
   if (failed) {
     return (
       <article className={ui.mergedPrStats} aria-label="Merged PR throughput">
+        <SpandrelCorners />
         <div className={ui.mergedPrStatsBody}>
           <Banner
             tone="alarm"
@@ -143,6 +243,7 @@ export function CommittedPullRequestsDashboard() {
 
   return (
     <article className={ui.mergedPrStats} aria-label="Merged PR throughput">
+      <SpandrelCorners />
       <div className={ui.mergedPrStatsGrid}>
         <div className={ui.mergedPrStatsCell}>
           <span className={ui.mergedPrStatsLabel}>Today</span>

--- a/apps/harness/src/ui.ts
+++ b/apps/harness/src/ui.ts
@@ -602,7 +602,7 @@ export const ui = {
 
   industrialShell: "mx-auto",
 
-  mergedPrStats: "border-2 border-ink bg-paper text-ink",
+  mergedPrStats: "relative border-2 border-ink bg-paper text-ink",
 
   mergedPrStatsGrid: "grid grid-cols-5 max-[900px]:grid-cols-2",
 
@@ -622,6 +622,15 @@ export const ui = {
   mergedPrStatsSkeletonInCell: "my-[0.15rem] mx-0",
 
   mergedPrStatsBody: "px-[0.7rem] pt-[0.55rem] pb-[0.7rem]",
+
+  mergedPrStatsSpandrelTL:
+    "pointer-events-none absolute top-[-2px] left-[-2px] overflow-visible",
+  mergedPrStatsSpandrelTR:
+    "pointer-events-none absolute top-[-2px] right-[-2px] overflow-visible",
+  mergedPrStatsSpandrelBL:
+    "pointer-events-none absolute bottom-[-2px] left-[-2px] overflow-visible",
+  mergedPrStatsSpandrelBR:
+    "pointer-events-none absolute bottom-[-2px] right-[-2px] overflow-visible",
 
   pipelineControls:
     "mt-0 flex flex-wrap items-center justify-between gap-x-6 gap-y-[0.8rem] border-0 bg-transparent p-0 max-[900px]:grid max-[900px]:min-w-0",


### PR DESCRIPTION
## Why

The merged-PR throughput frame (Today / Yesterday / This week / Last week / Two weeks ago) is a plain bordered rectangle. It works, but reads as generic dashboard chrome rather than belonging to the steampunk/clanker visual language the masthead and plates already use. We want a light decorative touch — character without distraction or extra space.

## What Changed

Added sunburst rivet spandrels to all four corners of the `CommittedPullRequestsDashboard` frame:

- A single SVG motif (rivet hub + radiating lines at decreasing opacity) is placed at each corner, absolutely positioned so the frame adds zero height.
- All four corners share one SVG; the other three are CSS-flipped (`scaleX(-1)`, `scaleY(-1)`, `scale(-1,-1)`).
- Uses `currentColor` (resolves to `var(--ink)`) — no new colours introduced. The inner rivet hole uses `var(--paper)` to punch through.
- Rendered in all three states: loading, error, and success.
- Added `relative` to `mergedPrStats` and four spandrel position classes in `ui.ts`.
- A prototype with six alternative corner treatments lives at `apps/harness/prototypes/spandrel-corners.html`.
