### PR TITLE
feat(cli): resolve unique project-path and host://path selectors

### DIFF
--- a/apps/ready-for-agent/src/cli.test.ts
+++ b/apps/ready-for-agent/src/cli.test.ts
@@ -465,6 +465,119 @@ describe("operator binary CLI seam", () => {
     }),
   )
 
+  it.live("candidates accepts a unique project-path shorthand", () =>
+    Effect.gen(function* () {
+      const logs: string[] = []
+      const originalLog = console.log
+      console.log = (...args: unknown[]) => {
+        logs.push(args.map(String).join(" "))
+      }
+
+      try {
+        let requestedId: string | undefined
+        const layer = mockStart.pipe(
+          Layer.provideMerge(mockLocalGit),
+          Layer.provideMerge(
+            Layer.succeed(GraphqlApi, {
+              ...unusedGraphql,
+              listRepositories: Effect.succeed([
+                {
+                  id: "repo-1",
+                  forge: "github",
+                  forgeHost: "github.com",
+                  projectPath: "berenddeboer/ready-for-agent",
+                },
+              ]),
+              intakeCandidates: (repositoryId) =>
+                Effect.sync(() => {
+                  requestedId = repositoryId
+                  return {
+                    repository: {
+                      id: "repo-1",
+                      forge: "github",
+                      forgeHost: "github.com",
+                      projectPath: "berenddeboer/ready-for-agent",
+                      issuesReconciledAt: null,
+                    },
+                    candidates: [],
+                  }
+                }),
+            }),
+          ),
+        )
+
+        yield* runOperator(
+          ["candidates", "berenddeboer/ready-for-agent"],
+          layer,
+        )
+
+        expect(requestedId).toBe("repo-1")
+        expect(logs).toHaveLength(1)
+        expect(JSON.parse(logs[0] ?? "")).toEqual({
+          schemaVersion: CLI_SCHEMA_VERSION,
+          command: "candidates",
+          repository: {
+            id: "repo-1",
+            forge: "github",
+            forgeHost: "github.com",
+            projectPath: "berenddeboer/ready-for-agent",
+          },
+          issuesReconciledAt: null,
+          candidates: [],
+        })
+      } finally {
+        console.log = originalLog
+      }
+    }),
+  )
+
+  it.live(
+    "candidates fails with REPOSITORY_AMBIGUOUS listing matching identities",
+    () =>
+      Effect.gen(function* () {
+        const layer = mockStart.pipe(
+          Layer.provideMerge(mockLocalGit),
+          Layer.provideMerge(
+            Layer.succeed(GraphqlApi, {
+              ...unusedGraphql,
+              listRepositories: Effect.succeed([
+                {
+                  id: "repo-github",
+                  forge: "github",
+                  forgeHost: "github.com",
+                  projectPath: "acme/ready-for-agent",
+                },
+                {
+                  id: "repo-gitlab",
+                  forge: "gitlab",
+                  forgeHost: "gitlab.com",
+                  projectPath: "group/ready-for-agent",
+                },
+              ]),
+            }),
+          ),
+        )
+
+        const result = yield* runOperator(
+          ["candidates", "ready-for-agent"],
+          layer,
+        ).pipe(Effect.flip)
+
+        expect(result).toBeInstanceOf(FiniteCommandFailed)
+        if (result instanceof FiniteCommandFailed) {
+          expect(result.document).toEqual({
+            schemaVersion: CLI_SCHEMA_VERSION,
+            command: "candidates",
+            error: {
+              code: "REPOSITORY_AMBIGUOUS",
+              message:
+                "Multiple configured Repositories match ready-for-agent: github.com://acme/ready-for-agent, gitlab.com://group/ready-for-agent",
+            },
+          })
+        }
+      }),
+  )
+
   it.live("candidates preserves GraphQL preflight error codes", () =>
     Effect.gen(function* () {
       const layer = mockStart.pipe(

--- a/apps/ready-for-agent/src/cli.ts
+++ b/apps/ready-for-agent/src/cli.ts
@@ -12,7 +12,12 @@ import {
   localGitErrorCode,
   toCanonicalRepositoryIdentity,
 } from "./cli-json.ts"
-import { resolveRepositoryIdentity } from "./repository-identity.ts"
+import {
+  type RepositoryIdentityFields,
+  type RepositoryIdentityMatch,
+  formatRepositoryFullIdentity,
+  resolveRepositoryIdentity,
+} from "./repository-identity.ts"
 import { GraphqlApi } from "./services/graphql-api.ts"
 import { LocalGit } from "./services/local-git.ts"
 import { StartHarness } from "./services/start-harness.ts"
@@ -21,15 +26,18 @@ const pathArg = Argument.string("path").pipe(
   Argument.withDescription("Path to a local git repository"),
 )
 
+const repositorySelectorGuidance =
+  "Use <forge-host>://<project-path>, <forge-host>/<project-path>, a unique project path, or a unique final project-path segment"
+
 const repositoryIdentityArg = Argument.string("repository").pipe(
   Argument.withDescription(
-    "Repository identity as <forge-host>/<project-path> (case-insensitive)",
+    "Repository identity as <forge-host>://<project-path>, <forge-host>/<project-path>, a unique project path, or a unique final project-path segment (case-insensitive)",
   ),
 )
 
 const optionalRepositoryIdentityArg = Argument.string("repository").pipe(
   Argument.withDescription(
-    "Optional repository identity as <forge-host>/<project-path> (case-insensitive)",
+    "Optional repository identity as <forge-host>://<project-path>, <forge-host>/<project-path>, a unique project path, or a unique final project-path segment (case-insensitive)",
   ),
   Argument.optional,
 )
@@ -68,6 +76,41 @@ const startHarnessWorkflow = Effect.fn("Cli.startHarness")(function* (
   const startHarnessService = yield* StartHarness
   yield* startHarnessService.start({ noOpen, host })
 })
+
+const repositoryIdentityCommandFailed = (
+  command: FiniteCommandName,
+  resolved: Exclude<
+    RepositoryIdentityMatch<RepositoryIdentityFields>,
+    { readonly _tag: "matched" }
+  >,
+): FiniteCommandFailed => {
+  switch (resolved._tag) {
+    case "invalid":
+      return new FiniteCommandFailed({
+        command,
+        code: "REPOSITORY_NOT_FOUND",
+        message: `Invalid repository identity "${resolved.argument}". ${repositorySelectorGuidance}.`,
+      })
+    case "not_found":
+      return new FiniteCommandFailed({
+        command,
+        code: "REPOSITORY_NOT_FOUND",
+        message: `No configured Repository matches ${resolved.selector}`,
+      })
+    case "ambiguous":
+      return new FiniteCommandFailed({
+        command,
+        code: "REPOSITORY_AMBIGUOUS",
+        message: `Multiple configured Repositories match ${resolved.selector}: ${resolved.matches
+          .map((repository) => formatRepositoryFullIdentity(repository))
+          .join(", ")}`,
+      })
+    default: {
+      const _exhaustive: never = resolved
+      return _exhaustive
+    }
+  }
+}
 
 const toFiniteCommandFailed = (
   command: FiniteCommandName,
@@ -156,27 +199,8 @@ const candidatesWorkflow = Effect.fn("Cli.candidates")(function* (
   )
 
   const resolved = resolveRepositoryIdentity(repositoryArgument, repositories)
-  switch (resolved._tag) {
-    case "invalid":
-      return yield* new FiniteCommandFailed({
-        command: "candidates",
-        code: "REPOSITORY_NOT_FOUND",
-        message: `Invalid repository identity "${resolved.argument}". Use <forge-host>/<project-path>.`,
-      })
-    case "not_found":
-      return yield* new FiniteCommandFailed({
-        command: "candidates",
-        code: "REPOSITORY_NOT_FOUND",
-        message: `No configured Repository matches ${resolved.forgeHost}/${resolved.projectPath}`,
-      })
-    case "ambiguous":
-      return yield* new FiniteCommandFailed({
-        command: "candidates",
-        code: "REPOSITORY_AMBIGUOUS",
-        message: `Multiple configured Repositories match ${resolved.forgeHost}/${resolved.projectPath} (${resolved.matchCount})`,
-      })
-    case "matched":
-      break
+  if (resolved._tag !== "matched") {
+    return yield* repositoryIdentityCommandFailed("candidates", resolved)
   }
 
   const result = yield* graphqlApi
@@ -210,27 +234,8 @@ const intakeWorkflow = Effect.fn("Cli.intake")(function* (
   )
 
   const resolved = resolveRepositoryIdentity(repositoryArgument, repositories)
-  switch (resolved._tag) {
-    case "invalid":
-      return yield* new FiniteCommandFailed({
-        command: "intake",
-        code: "REPOSITORY_NOT_FOUND",
-        message: `Invalid repository identity "${resolved.argument}". Use <forge-host>/<project-path>.`,
-      })
-    case "not_found":
-      return yield* new FiniteCommandFailed({
-        command: "intake",
-        code: "REPOSITORY_NOT_FOUND",
-        message: `No configured Repository matches ${resolved.forgeHost}/${resolved.projectPath}`,
-      })
-    case "ambiguous":
-      return yield* new FiniteCommandFailed({
-        command: "intake",
-        code: "REPOSITORY_AMBIGUOUS",
-        message: `Multiple configured Repositories match ${resolved.forgeHost}/${resolved.projectPath} (${resolved.matchCount})`,
-      })
-    case "matched":
-      break
+  if (resolved._tag !== "matched") {
+    return yield* repositoryIdentityCommandFailed("intake", resolved)
   }
 
   const result = yield* graphqlApi
@@ -275,30 +280,11 @@ const statusWorkflow = Effect.fn("Cli.status")(function* (
       Effect.mapError((error) => toFiniteCommandFailed("status", error)),
     )
     const resolved = resolveRepositoryIdentity(repositoryArgument, repositories)
-    switch (resolved._tag) {
-      case "invalid":
-        return yield* new FiniteCommandFailed({
-          command: "status",
-          code: "REPOSITORY_NOT_FOUND",
-          message: `Invalid repository identity "${resolved.argument}". Use <forge-host>/<project-path>.`,
-        })
-      case "not_found":
-        return yield* new FiniteCommandFailed({
-          command: "status",
-          code: "REPOSITORY_NOT_FOUND",
-          message: `No configured Repository matches ${resolved.forgeHost}/${resolved.projectPath}`,
-        })
-      case "ambiguous":
-        return yield* new FiniteCommandFailed({
-          command: "status",
-          code: "REPOSITORY_AMBIGUOUS",
-          message: `Multiple configured Repositories match ${resolved.forgeHost}/${resolved.projectPath} (${resolved.matchCount})`,
-        })
-      case "matched":
-        repositoryId = resolved.repository.id
-        scopedRepository = toCanonicalRepositoryIdentity(resolved.repository)
-        break
+    if (resolved._tag !== "matched") {
+      return yield* repositoryIdentityCommandFailed("status", resolved)
     }
+    repositoryId = resolved.repository.id
+    scopedRepository = toCanonicalRepositoryIdentity(resolved.repository)
   }
 
   const status = yield* graphqlApi
@@ -372,7 +358,7 @@ const statusCommand = Command.make(
   ({ repository }) => statusWorkflow(Option.getOrUndefined(repository)),
 ).pipe(
   Command.withDescription(
-    "Print the current six-lane Kanban status as versioned JSON (optional <forge-host>/<project-path>)",
+    "Print the current six-lane Kanban status as versioned JSON (optional repository selector)",
   ),
 )
 

--- a/apps/ready-for-agent/src/repository-identity.test.ts
+++ b/apps/ready-for-agent/src/repository-identity.test.ts
@@ -4,9 +4,64 @@ import {
 } from "./repository-identity.ts"
 import { describe, expect, test } from "bun:test"
 
-describe("repository identity resolution", () => {
+const githubReadyForAgent = {
+  id: "repo-github-rfa",
+  forgeHost: "github.com",
+  projectPath: "berenddeboer/ready-for-agent",
+}
+
+const gitlabOauthClient = {
+  id: "repo-gitlab-oauth",
+  forgeHost: "git.drupalcode.org",
+  projectPath: "project/oauth_client",
+}
+
+const gitlabNested = {
+  id: "repo-gitlab-nested",
+  forgeHost: "gitlab.example.com",
+  projectPath: "group/subgroup/project",
+}
+
+const acmeHostWidgets = {
+  id: "repo-acme-host",
+  forgeHost: "acme",
+  projectPath: "widgets",
+}
+
+const githubAcmeWidgets = {
+  id: "repo-github-acme-widgets",
+  forgeHost: "github.com",
+  projectPath: "acme/widgets",
+}
+
+describe("repository identity parsing", () => {
+  test("parses explicit host://project-path including nested GitLab paths", () => {
+    expect(
+      parseRepositoryIdentityArgument(
+        "github.com://berenddeboer/ready-for-agent",
+      ),
+    ).toEqual({
+      _tag: "explicit_host_path",
+      selector: "github.com://berenddeboer/ready-for-agent",
+      forgeHost: "github.com",
+      projectPath: "berenddeboer/ready-for-agent",
+    })
+    expect(
+      parseRepositoryIdentityArgument(
+        "git.drupalcode.org://group/subgroup/project",
+      ),
+    ).toEqual({
+      _tag: "explicit_host_path",
+      selector: "git.drupalcode.org://group/subgroup/project",
+      forgeHost: "git.drupalcode.org",
+      projectPath: "group/subgroup/project",
+    })
+  })
+
   test("parses forge-host/project-path including nested GitLab paths", () => {
     expect(parseRepositoryIdentityArgument("github.com/owner/repo")).toEqual({
+      _tag: "host_or_project_path",
+      selector: "github.com/owner/repo",
       forgeHost: "github.com",
       projectPath: "owner/repo",
     })
@@ -15,70 +70,282 @@ describe("repository identity resolution", () => {
         "git.drupalcode.org/project/oauth_client",
       ),
     ).toEqual({
+      _tag: "host_or_project_path",
+      selector: "git.drupalcode.org/project/oauth_client",
       forgeHost: "git.drupalcode.org",
       projectPath: "project/oauth_client",
     })
   })
 
-  test("rejects opaque IDs and malformed arguments", () => {
-    expect(parseRepositoryIdentityArgument("repo-01ABC")).toBeNull()
-    expect(parseRepositoryIdentityArgument("")).toBeNull()
-    expect(parseRepositoryIdentityArgument("/owner/repo")).toBeNull()
-    expect(parseRepositoryIdentityArgument("github.com/")).toBeNull()
+  test("parses a project-name selector for values without a slash", () => {
+    expect(parseRepositoryIdentityArgument("ready-for-agent")).toEqual({
+      _tag: "project_name",
+      selector: "ready-for-agent",
+      projectName: "ready-for-agent",
+    })
+    expect(parseRepositoryIdentityArgument("repo-01ABC")).toEqual({
+      _tag: "project_name",
+      selector: "repo-01ABC",
+      projectName: "repo-01ABC",
+    })
   })
 
-  test("matches case-insensitively and uniquely", () => {
+  test("rejects structurally empty, leading or trailing slash, and URL schemes", () => {
+    expect(parseRepositoryIdentityArgument("")).toEqual({
+      _tag: "invalid",
+      argument: "",
+    })
+    expect(parseRepositoryIdentityArgument("   ")).toEqual({
+      _tag: "invalid",
+      argument: "   ",
+    })
+    expect(parseRepositoryIdentityArgument("/owner/repo")).toEqual({
+      _tag: "invalid",
+      argument: "/owner/repo",
+    })
+    expect(parseRepositoryIdentityArgument("github.com/")).toEqual({
+      _tag: "invalid",
+      argument: "github.com/",
+    })
+    expect(parseRepositoryIdentityArgument("owner/repo/")).toEqual({
+      _tag: "invalid",
+      argument: "owner/repo/",
+    })
+    expect(parseRepositoryIdentityArgument("github.com://")).toEqual({
+      _tag: "invalid",
+      argument: "github.com://",
+    })
+    expect(parseRepositoryIdentityArgument("://owner/repo")).toEqual({
+      _tag: "invalid",
+      argument: "://owner/repo",
+    })
+    expect(parseRepositoryIdentityArgument("github.com://owner/repo/")).toEqual(
+      {
+        _tag: "invalid",
+        argument: "github.com://owner/repo/",
+      },
+    )
+    expect(
+      parseRepositoryIdentityArgument("https://github.com/owner/repo"),
+    ).toEqual({
+      _tag: "invalid",
+      argument: "https://github.com/owner/repo",
+    })
+    expect(
+      parseRepositoryIdentityArgument("HTTP://github.com/owner/repo"),
+    ).toEqual({
+      _tag: "invalid",
+      argument: "HTTP://github.com/owner/repo",
+    })
+    expect(
+      parseRepositoryIdentityArgument("ssh://git@github.com/owner/repo.git"),
+    ).toEqual({
+      _tag: "invalid",
+      argument: "ssh://git@github.com/owner/repo.git",
+    })
+    expect(
+      parseRepositoryIdentityArgument("git://github.com/owner/repo.git"),
+    ).toEqual({
+      _tag: "invalid",
+      argument: "git://github.com/owner/repo.git",
+    })
+  })
+})
+
+describe("repository identity resolution", () => {
+  test("matches an explicit host://project-path selector without falling through", () => {
+    const repositories = [githubReadyForAgent, gitlabOauthClient]
+    expect(
+      resolveRepositoryIdentity(
+        "github.com://berenddeboer/ready-for-agent",
+        repositories,
+      ),
+    ).toEqual({
+      _tag: "matched",
+      repository: githubReadyForAgent,
+    })
+    expect(
+      resolveRepositoryIdentity(
+        "missing.example://berenddeboer/ready-for-agent",
+        repositories,
+      ),
+    ).toEqual({
+      _tag: "not_found",
+      selector: "missing.example://berenddeboer/ready-for-agent",
+    })
+  })
+
+  test("matches the legacy host/project-path selector case-insensitively", () => {
     const repositories = [
       {
         id: "repo-1",
         forgeHost: "github.com",
         projectPath: "Owner/Repo",
       },
-      {
-        id: "repo-2",
-        forgeHost: "git.drupalcode.org",
-        projectPath: "project/oauth_client",
-      },
+      gitlabOauthClient,
     ]
     expect(
       resolveRepositoryIdentity("GitHub.com/owner/repo", repositories),
     ).toEqual({
       _tag: "matched",
-      repository: repositories[0]!,
+      repository: repositories[0],
     })
     expect(
       resolveRepositoryIdentity("github.com/missing/repo", repositories),
     ).toEqual({
       _tag: "not_found",
-      forgeHost: "github.com",
-      projectPath: "missing/repo",
-    })
-    expect(resolveRepositoryIdentity("repo-1", repositories)).toEqual({
-      _tag: "invalid",
-      argument: "repo-1",
+      selector: "github.com/missing/repo",
     })
   })
 
-  test("reports ambiguous matches when more than one repository matches", () => {
+  test("matches a unique full project path when host/path has no match", () => {
+    const repositories = [githubReadyForAgent, gitlabNested]
+    expect(
+      resolveRepositoryIdentity("berenddeboer/ready-for-agent", repositories),
+    ).toEqual({
+      _tag: "matched",
+      repository: githubReadyForAgent,
+    })
+    expect(
+      resolveRepositoryIdentity("group/subgroup/project", repositories),
+    ).toEqual({
+      _tag: "matched",
+      repository: gitlabNested,
+    })
+  })
+
+  test("matches a unique final project-path segment", () => {
+    const repositories = [githubReadyForAgent, gitlabOauthClient, gitlabNested]
+    expect(resolveRepositoryIdentity("ready-for-agent", repositories)).toEqual({
+      _tag: "matched",
+      repository: githubReadyForAgent,
+    })
+    expect(resolveRepositoryIdentity("oauth_client", repositories)).toEqual({
+      _tag: "matched",
+      repository: gitlabOauthClient,
+    })
+    expect(resolveRepositoryIdentity("project", repositories)).toEqual({
+      _tag: "matched",
+      repository: gitlabNested,
+    })
+    expect(resolveRepositoryIdentity("repo-01ABC", repositories)).toEqual({
+      _tag: "not_found",
+      selector: "repo-01ABC",
+    })
+  })
+
+  test("matches selectors case-insensitively and preserves configured casing", () => {
+    const repositories = [githubReadyForAgent]
+    expect(
+      resolveRepositoryIdentity(
+        "GitHub.COM://BerendDeBoer/Ready-For-Agent",
+        repositories,
+      ),
+    ).toEqual({
+      _tag: "matched",
+      repository: githubReadyForAgent,
+    })
+    expect(
+      resolveRepositoryIdentity("BERENDDEBOER/READY-FOR-AGENT", repositories),
+    ).toEqual({
+      _tag: "matched",
+      repository: githubReadyForAgent,
+    })
+    expect(resolveRepositoryIdentity("Ready-For-Agent", repositories)).toEqual({
+      _tag: "matched",
+      repository: githubReadyForAgent,
+    })
+  })
+
+  test("prefers an exact host-plus-path match over a project-path shorthand", () => {
+    const repositories = [acmeHostWidgets, githubAcmeWidgets]
+    expect(resolveRepositoryIdentity("acme/widgets", repositories)).toEqual({
+      _tag: "matched",
+      repository: acmeHostWidgets,
+    })
+    expect(
+      resolveRepositoryIdentity("github.com://acme/widgets", repositories),
+    ).toEqual({
+      _tag: "matched",
+      repository: githubAcmeWidgets,
+    })
+  })
+
+  test("reports ambiguous project paths across Forge Hosts in deterministic order", () => {
+    const gitlabReadyForAgent = {
+      id: "repo-gitlab-rfa",
+      forgeHost: "gitlab.com",
+      projectPath: "berenddeboer/ready-for-agent",
+    }
+    const repositories = [gitlabReadyForAgent, githubReadyForAgent]
+    expect(
+      resolveRepositoryIdentity("berenddeboer/ready-for-agent", repositories),
+    ).toEqual({
+      _tag: "ambiguous",
+      selector: "berenddeboer/ready-for-agent",
+      matches: [githubReadyForAgent, gitlabReadyForAgent],
+    })
+  })
+
+  test("reports ambiguous final segments across owners in deterministic order", () => {
+    const otherReadyForAgent = {
+      id: "repo-other-rfa",
+      forgeHost: "github.com",
+      projectPath: "acme/ready-for-agent",
+    }
+    const repositories = [otherReadyForAgent, githubReadyForAgent]
+    expect(resolveRepositoryIdentity("ready-for-agent", repositories)).toEqual({
+      _tag: "ambiguous",
+      selector: "ready-for-agent",
+      matches: [otherReadyForAgent, githubReadyForAgent],
+    })
+  })
+
+  test("reports ambiguous exact host-plus-path matches in deterministic order", () => {
     const repositories = [
-      {
-        id: "repo-1",
-        forgeHost: "github.com",
-        projectPath: "owner/repo",
-      },
       {
         id: "repo-2",
         forgeHost: "GitHub.com",
         projectPath: "Owner/Repo",
+      },
+      {
+        id: "repo-1",
+        forgeHost: "github.com",
+        projectPath: "owner/repo",
       },
     ]
     expect(
       resolveRepositoryIdentity("github.com/owner/repo", repositories),
     ).toEqual({
       _tag: "ambiguous",
-      forgeHost: "github.com",
-      projectPath: "owner/repo",
-      matchCount: 2,
+      selector: "github.com/owner/repo",
+      matches: [repositories[1], repositories[0]],
+    })
+  })
+
+  test("keeps a missing explicit host://path as not found instead of shorthand", () => {
+    expect(
+      resolveRepositoryIdentity("github.com://acme/widgets", [acmeHostWidgets]),
+    ).toEqual({
+      _tag: "not_found",
+      selector: "github.com://acme/widgets",
+    })
+  })
+
+  test("returns invalid for malformed selectors and disallowed URL schemes", () => {
+    expect(resolveRepositoryIdentity("", [])).toEqual({
+      _tag: "invalid",
+      argument: "",
+    })
+    expect(resolveRepositoryIdentity("/owner/repo", [])).toEqual({
+      _tag: "invalid",
+      argument: "/owner/repo",
+    })
+    expect(
+      resolveRepositoryIdentity("https://github.com/owner/repo", []),
+    ).toEqual({
+      _tag: "invalid",
+      argument: "https://github.com/owner/repo",
     })
   })
 })

--- a/apps/ready-for-agent/src/repository-identity.ts
+++ b/apps/ready-for-agent/src/repository-identity.ts
@@ -1,103 +1,208 @@
 /**
- * Parse and match explicit CLI Repository identity
- * `<forge-host>/<project-path>` (case-insensitive, unique).
+ * Parse and match CLI Repository selectors against configured Repositories.
+ * Explicit host://path and host/path forms outrank project-path shorthands.
  */
 
-export type ParsedRepositoryIdentity = {
+const DISALLOWED_SELECTOR_SCHEMES = new Set(["http", "https", "ssh", "git"])
+
+export type RepositoryIdentityFields = {
+  readonly id: string
   readonly forgeHost: string
   readonly projectPath: string
 }
 
-export type RepositoryIdentityMatch<
-  T extends {
-    readonly id: string
-    readonly forgeHost: string
-    readonly projectPath: string
-  },
-> =
-  | { readonly _tag: "matched"; readonly repository: T }
+export type ParsedRepositorySelector =
   | {
-      readonly _tag: "not_found"
+      readonly _tag: "explicit_host_path"
+      readonly selector: string
       readonly forgeHost: string
       readonly projectPath: string
     }
   | {
-      readonly _tag: "ambiguous"
+      readonly _tag: "host_or_project_path"
+      readonly selector: string
       readonly forgeHost: string
       readonly projectPath: string
-      readonly matchCount: number
+    }
+  | {
+      readonly _tag: "project_name"
+      readonly selector: string
+      readonly projectName: string
     }
   | { readonly _tag: "invalid"; readonly argument: string }
 
-/**
- * Split at the first slash. Host and project path must both be non-empty.
- * Does not accept an opaque Repository ID.
- */
-export const parseRepositoryIdentityArgument = (
-  argument: string,
-): ParsedRepositoryIdentity | null => {
-  const trimmed = argument.trim()
-  const slash = trimmed.indexOf("/")
-  if (slash <= 0 || slash === trimmed.length - 1) {
-    return null
-  }
-  const forgeHost = trimmed.slice(0, slash).trim()
-  const projectPath = trimmed.slice(slash + 1).trim()
-  if (forgeHost.length === 0 || projectPath.length === 0) {
-    return null
-  }
-  return { forgeHost, projectPath }
-}
+export type RepositoryIdentityMatch<T extends RepositoryIdentityFields> =
+  | { readonly _tag: "matched"; readonly repository: T }
+  | { readonly _tag: "not_found"; readonly selector: string }
+  | {
+      readonly _tag: "ambiguous"
+      readonly selector: string
+      readonly matches: readonly T[]
+    }
+  | { readonly _tag: "invalid"; readonly argument: string }
 
 const fold = (value: string): string => value.toLowerCase()
 
-/**
- * Match one configured Repository by forge host + project path.
- * Matching is case-insensitive; display casing is preserved on the match.
- */
-export const resolveRepositoryIdentity = <
-  T extends {
-    readonly id: string
-    readonly forgeHost: string
-    readonly projectPath: string
-  },
->(
-  argument: string,
-  repositories: readonly T[],
+const hasLeadingOrTrailingSlash = (value: string): boolean =>
+  value.startsWith("/") || value.endsWith("/")
+
+const finalProjectPathSegment = (projectPath: string): string => {
+  const slash = projectPath.lastIndexOf("/")
+  return slash === -1 ? projectPath : projectPath.slice(slash + 1)
+}
+
+export const formatRepositoryFullIdentity = (
+  repository: Pick<RepositoryIdentityFields, "forgeHost" | "projectPath">,
+): string => `${repository.forgeHost}://${repository.projectPath}`
+
+const identitySortKey = (repository: RepositoryIdentityFields): string =>
+  `${fold(repository.forgeHost)}://${fold(repository.projectPath)}\0${repository.id}`
+
+const orderedMatches = <T extends RepositoryIdentityFields>(
+  matches: readonly T[],
+): T[] =>
+  [...matches].sort((left, right) =>
+    identitySortKey(left).localeCompare(identitySortKey(right)),
+  )
+
+const decideMatches = <T extends RepositoryIdentityFields>(
+  selector: string,
+  matches: readonly T[],
 ): RepositoryIdentityMatch<T> => {
-  const parsed = parseRepositoryIdentityArgument(argument)
-  if (parsed === null) {
-    return { _tag: "invalid", argument }
+  const ordered = orderedMatches(matches)
+  const [repository, ...rest] = ordered
+  if (repository === undefined) {
+    return { _tag: "not_found", selector }
   }
-  const hostKey = fold(parsed.forgeHost)
-  const pathKey = fold(parsed.projectPath)
-  const matches = repositories.filter(
+  if (rest.length === 0) {
+    return { _tag: "matched", repository }
+  }
+  return { _tag: "ambiguous", selector, matches: ordered }
+}
+
+const matchesHostAndPath = <T extends RepositoryIdentityFields>(
+  repositories: readonly T[],
+  forgeHost: string,
+  projectPath: string,
+): T[] => {
+  const hostKey = fold(forgeHost)
+  const pathKey = fold(projectPath)
+  return repositories.filter(
     (repository) =>
       fold(repository.forgeHost) === hostKey &&
       fold(repository.projectPath) === pathKey,
   )
-  if (matches.length === 0) {
+}
+
+/**
+ * Classify a Repository selector. Does not accept clone/web URL schemes.
+ * Values without a slash are project-name selectors, not opaque Repository IDs.
+ */
+export const parseRepositoryIdentityArgument = (
+  argument: string,
+): ParsedRepositorySelector => {
+  const selector = argument.trim()
+  if (selector.length === 0) {
+    return { _tag: "invalid", argument }
+  }
+
+  const schemeSeparator = selector.indexOf("://")
+  if (schemeSeparator >= 0) {
+    const forgeHost = selector.slice(0, schemeSeparator).trim()
+    const projectPath = selector.slice(schemeSeparator + 3).trim()
+    if (
+      forgeHost.length === 0 ||
+      DISALLOWED_SELECTOR_SCHEMES.has(fold(forgeHost)) ||
+      projectPath.length === 0 ||
+      hasLeadingOrTrailingSlash(projectPath)
+    ) {
+      return { _tag: "invalid", argument }
+    }
     return {
-      _tag: "not_found",
-      forgeHost: parsed.forgeHost,
-      projectPath: parsed.projectPath,
+      _tag: "explicit_host_path",
+      selector,
+      forgeHost,
+      projectPath,
     }
   }
-  if (matches.length > 1) {
+
+  if (hasLeadingOrTrailingSlash(selector)) {
+    return { _tag: "invalid", argument }
+  }
+
+  const slash = selector.indexOf("/")
+  if (slash === -1) {
     return {
-      _tag: "ambiguous",
-      forgeHost: parsed.forgeHost,
-      projectPath: parsed.projectPath,
-      matchCount: matches.length,
+      _tag: "project_name",
+      selector,
+      projectName: selector,
     }
   }
-  const repository = matches[0]
-  if (repository === undefined) {
-    return {
-      _tag: "not_found",
-      forgeHost: parsed.forgeHost,
-      projectPath: parsed.projectPath,
+
+  const forgeHost = selector.slice(0, slash).trim()
+  const projectPath = selector.slice(slash + 1).trim()
+  if (
+    forgeHost.length === 0 ||
+    projectPath.length === 0 ||
+    hasLeadingOrTrailingSlash(projectPath)
+  ) {
+    return { _tag: "invalid", argument }
+  }
+  return {
+    _tag: "host_or_project_path",
+    selector,
+    forgeHost,
+    projectPath,
+  }
+}
+
+/**
+ * Match one configured Repository by explicit identity or unique shorthand.
+ * Matching is case-insensitive; display casing is preserved on the match.
+ */
+export const resolveRepositoryIdentity = <T extends RepositoryIdentityFields>(
+  argument: string,
+  repositories: readonly T[],
+): RepositoryIdentityMatch<T> => {
+  const parsed = parseRepositoryIdentityArgument(argument)
+  switch (parsed._tag) {
+    case "invalid":
+      return parsed
+    case "explicit_host_path":
+      return decideMatches(
+        parsed.selector,
+        matchesHostAndPath(repositories, parsed.forgeHost, parsed.projectPath),
+      )
+    case "host_or_project_path": {
+      const hostPathMatches = matchesHostAndPath(
+        repositories,
+        parsed.forgeHost,
+        parsed.projectPath,
+      )
+      if (hostPathMatches.length > 0) {
+        return decideMatches(parsed.selector, hostPathMatches)
+      }
+      const pathKey = fold(parsed.selector)
+      return decideMatches(
+        parsed.selector,
+        repositories.filter(
+          (repository) => fold(repository.projectPath) === pathKey,
+        ),
+      )
+    }
+    case "project_name": {
+      const nameKey = fold(parsed.projectName)
+      return decideMatches(
+        parsed.selector,
+        repositories.filter(
+          (repository) =>
+            fold(finalProjectPathSegment(repository.projectPath)) === nameKey,
+        ),
+      )
+    }
+    default: {
+      const _exhaustive: never = parsed
+      return _exhaustive
     }
   }
-  return { _tag: "matched", repository }
 }


### PR DESCRIPTION
Finite `candidates`, `intake`, and scoped `status` no longer require the
implementation-specific `github.com/owner/repo` spelling. The shared
Repository identity resolver now accepts explicit `host://path`, the existing
`host/path` form, a unique Project Path, and a unique final project-path
segment. Matching stays case-insensitive and specificity-first, so an exact
host-plus-path pair outranks project-path shorthand and a missing
`host://path` does not fall through. Ambiguous shorthands fail with
`REPOSITORY_AMBIGUOUS` and list every matching
`<forge-host>://<project-path>` in deterministic order. Clone/web URL schemes
stay invalid; successful JSON and the `add` command are unchanged. This
implements #1015.

Verified with `bunx nx test ready-for-agent`, `bunx nx lint ready-for-agent`,
and `bunx nx typecheck ready-for-agent`. Review of the uncommitted change
found no issues.

Closes #1015