### PR TITLE
feat(graphql-api): resolve a Work Item from an opaque Session ID

### DIFF
--- a/apps/harness/test/job-worker.test.ts
+++ b/apps/harness/test/job-worker.test.ts
@@ -324,6 +324,7 @@ const queueLayer = (
       listCompletedWorkItems: () =>
         Effect.succeed({ items: [], page: 1, pageSize: 20, totalCount: 0 }),
       ownsSessionId: () => Effect.succeed(false),
+      findWorkItemBySessionId: unused,
       countCommittedPullRequests: () => Effect.succeed(0),
       continueAfterHumanPrOutcome: unused,
       admitWaitingWorkItems: Effect.succeed(0),
@@ -2216,6 +2217,7 @@ describe("Job worker", () => {
           listCompletedWorkItems: () =>
             Effect.succeed({ items: [], page: 1, pageSize: 20, totalCount: 0 }),
           ownsSessionId: () => Effect.succeed(false),
+          findWorkItemBySessionId: unused,
           countCommittedPullRequests: () => Effect.succeed(0),
           continueAfterHumanPrOutcome: unused,
           admitWaitingWorkItems: Effect.succeed(0),
@@ -2456,6 +2458,7 @@ describe("Job worker", () => {
           listCompletedWorkItems: () =>
             Effect.succeed({ items: [], page: 1, pageSize: 20, totalCount: 0 }),
           ownsSessionId: () => Effect.succeed(false),
+          findWorkItemBySessionId: unused,
           countCommittedPullRequests: () => Effect.succeed(0),
           continueAfterHumanPrOutcome: unused,
           admitWaitingWorkItems: Effect.succeed(0),
@@ -2532,6 +2535,7 @@ describe("Job worker", () => {
           listCompletedWorkItems: () =>
             Effect.succeed({ items: [], page: 1, pageSize: 20, totalCount: 0 }),
           ownsSessionId: () => Effect.succeed(false),
+          findWorkItemBySessionId: unused,
           countCommittedPullRequests: () => Effect.succeed(0),
           continueAfterHumanPrOutcome: unused,
           admitWaitingWorkItems: Effect.succeed(0),
@@ -2676,6 +2680,7 @@ describe("Job worker", () => {
           listCompletedWorkItems: () =>
             Effect.succeed({ items: [], page: 1, pageSize: 20, totalCount: 0 }),
           ownsSessionId: () => Effect.succeed(false),
+          findWorkItemBySessionId: unused,
           countCommittedPullRequests: () => Effect.succeed(0),
           continueAfterHumanPrOutcome: unused,
           admitWaitingWorkItems: Effect.succeed(0),
@@ -2877,6 +2882,7 @@ describe("Job worker", () => {
         listCompletedWorkItems: () =>
           Effect.succeed({ items: [], page: 1, pageSize: 20, totalCount: 0 }),
         ownsSessionId: () => Effect.succeed(false),
+        findWorkItemBySessionId: unused,
         countCommittedPullRequests: () => Effect.succeed(0),
         continueAfterHumanPrOutcome: unused,
         admitWaitingWorkItems: Effect.succeed(0),
@@ -2998,6 +3004,7 @@ describe("Job worker", () => {
           listCompletedWorkItems: () =>
             Effect.succeed({ items: [], page: 1, pageSize: 20, totalCount: 0 }),
           ownsSessionId: () => Effect.succeed(false),
+          findWorkItemBySessionId: unused,
           countCommittedPullRequests: () => Effect.succeed(0),
           continueAfterHumanPrOutcome: unused,
           admitWaitingWorkItems: Effect.succeed(0),

--- a/apps/harness/test/production-sse-idle-timeout.test.ts
+++ b/apps/harness/test/production-sse-idle-timeout.test.ts
@@ -383,6 +383,7 @@ describe("production GraphQL SSE idle timeout", () => {
         listWorkItemsForRepository: unused,
         listCompletedWorkItems: unused,
         ownsSessionId: () => Effect.succeed(false),
+        findWorkItemBySessionId: unused,
         countCommittedPullRequests: unused,
         continueAfterHumanPrOutcome: unused,
         admitWaitingWorkItems: Effect.succeed(0),

--- a/packages/graphql-api/src/lib/graphql-api.ts
+++ b/packages/graphql-api/src/lib/graphql-api.ts
@@ -190,6 +190,10 @@ type SessionArgs = {
   workItemId: string
 }
 
+type WorkItemBySessionIdArgs = {
+  sessionId: string
+}
+
 type KanbanStatusArgs = {
   repositoryId?: string | null
 }
@@ -882,6 +886,27 @@ export const createGraphqlApi = <R>(
                 })
                 return toGraphqlSession(session)
               }).pipe(Effect.withSpan("graphql-api.session")),
+              context,
+            ),
+          workItemBySessionId: async (
+            _parent: unknown,
+            args: WorkItemBySessionIdArgs,
+            context: GraphqlRequestContext,
+          ) =>
+            runGraphql(
+              Effect.gen(function* () {
+                const lifecycle = yield* WorkItemLifecycle
+                const found = yield* lifecycle.findWorkItemBySessionId(
+                  args.sessionId,
+                )
+                return {
+                  agentBackend: toGraphqlBackend(
+                    resolveWorkItemBackend(found.agentBackend),
+                  ),
+                  sessionId: found.sessionId,
+                  worktreePath: found.worktreePath,
+                }
+              }).pipe(Effect.withSpan("graphql-api.workItemBySessionId")),
               context,
             ),
           kanbanStatus: async (

--- a/packages/graphql-api/src/lib/to-graphql-error.ts
+++ b/packages/graphql-api/src/lib/to-graphql-error.ts
@@ -22,6 +22,7 @@ type TaggedError = {
   readonly unfinishedWorkItemCount?: number
   readonly scope?: string
   readonly retryAt?: number
+  readonly sessionId?: string
 }
 
 const isTaggedError = (error: unknown): error is TaggedError =>
@@ -147,6 +148,18 @@ export const toGraphQLError = (error: unknown): GraphQLError => {
       return gql(
         `Work Item not found: ${error.workItemId}`,
         "WORK_ITEM_NOT_FOUND",
+      )
+    case "SessionIdNotFoundError":
+      return gql(
+        `No Work Item owns Session ID: ${error.sessionId}`,
+        "SESSION_NOT_FOUND",
+        { sessionId: error.sessionId },
+      )
+    case "SessionIdAmbiguousError":
+      return gql(
+        `Multiple Work Items own Session ID: ${error.sessionId}`,
+        "SESSION_AMBIGUOUS",
+        { sessionId: error.sessionId },
       )
     case "WorkItemTerminalError":
       return gql(

--- a/packages/graphql-api/test/graphql-api.test.ts
+++ b/packages/graphql-api/test/graphql-api.test.ts
@@ -46,6 +46,8 @@ import { stubQueueService } from "@ready-for-agent/queue-service/test"
 import {
   IssueNotFoundError,
   STEP_RUN_REASON,
+  SessionIdAmbiguousError,
+  SessionIdNotFoundError,
   UnfinishedWorkItemExistsError,
   WAITING_FOR_AGENT_TURN_MESSAGE,
   WorkItemLifecycle,
@@ -325,6 +327,7 @@ const makeRuntime = (
     recoverOrphanedStepRuns: Effect.succeed(0),
     interruptRunningStepRunsFromPriorWorker: Effect.succeed(0),
     runStep: unused,
+    wakePostponedStep: unused,
     retry: unused,
     pause: unused,
     start: unused,
@@ -335,6 +338,7 @@ const makeRuntime = (
     listWorkItemsForRepository: unused,
     listCompletedWorkItems: unused,
     ownsSessionId: () => Effect.succeed(false),
+    findWorkItemBySessionId: unused,
     countCommittedPullRequests: unused,
     continueAfterHumanPrOutcome: unused,
     admitWaitingWorkItems: Effect.succeed(0),
@@ -8087,6 +8091,120 @@ describe("GraphQL API", () => {
           cost: null,
         },
       },
+    })
+  })
+
+  test("workItemBySessionId returns backend, Session ID, and worktree for one match", async () => {
+    runtime = makeRuntime(
+      {},
+      {},
+      {},
+      {
+        findWorkItemBySessionId: (sessionId) =>
+          Effect.succeed({
+            agentBackend: "grok",
+            sessionId,
+            worktreePath: "/tmp/worktrees/acme-widgets-7",
+          }),
+      },
+    )
+
+    const response = await createGraphqlApi(runtime).fetch(
+      graphqlRequest({
+        query: `query WorkItemBySessionId($sessionId: String!) {
+          workItemBySessionId(sessionId: $sessionId) {
+            agentBackend { id label }
+            sessionId
+            worktreePath
+          }
+        }`,
+        variables: { sessionId: "85312e9f-9c57-42ef-9757-b2512cee57cd" },
+      }),
+    )
+
+    expect(response.status).toBe(200)
+    expect(await response.json()).toEqual({
+      data: {
+        workItemBySessionId: {
+          agentBackend: { id: "grok", label: "Grok Build" },
+          sessionId: "85312e9f-9c57-42ef-9757-b2512cee57cd",
+          worktreePath: "/tmp/worktrees/acme-widgets-7",
+        },
+      },
+    })
+  })
+
+  test("workItemBySessionId fails as not found for zero matches", async () => {
+    runtime = makeRuntime(
+      {},
+      {},
+      {},
+      {
+        findWorkItemBySessionId: (sessionId) =>
+          Effect.fail(new SessionIdNotFoundError({ sessionId })),
+      },
+    )
+
+    const response = await createGraphqlApi(runtime).fetch(
+      graphqlRequest({
+        query: `query WorkItemBySessionId($sessionId: String!) {
+          workItemBySessionId(sessionId: $sessionId) {
+            sessionId
+          }
+        }`,
+        variables: { sessionId: "missing-session" },
+      }),
+    )
+
+    expect(response.status).toBe(200)
+    expect(await response.json()).toEqual({
+      data: null,
+      errors: [
+        expect.objectContaining({
+          message: "No Work Item owns Session ID: missing-session",
+          extensions: {
+            code: "SESSION_NOT_FOUND",
+            sessionId: "missing-session",
+          },
+        }),
+      ],
+    })
+  })
+
+  test("workItemBySessionId fails as ambiguous for multiple matches", async () => {
+    runtime = makeRuntime(
+      {},
+      {},
+      {},
+      {
+        findWorkItemBySessionId: (sessionId) =>
+          Effect.fail(new SessionIdAmbiguousError({ sessionId })),
+      },
+    )
+
+    const response = await createGraphqlApi(runtime).fetch(
+      graphqlRequest({
+        query: `query WorkItemBySessionId($sessionId: String!) {
+          workItemBySessionId(sessionId: $sessionId) {
+            sessionId
+          }
+        }`,
+        variables: { sessionId: "shared-session" },
+      }),
+    )
+
+    expect(response.status).toBe(200)
+    expect(await response.json()).toEqual({
+      data: null,
+      errors: [
+        expect.objectContaining({
+          message: "Multiple Work Items own Session ID: shared-session",
+          extensions: {
+            code: "SESSION_AMBIGUOUS",
+            sessionId: "shared-session",
+          },
+        }),
+      ],
     })
   })
 

--- a/packages/graphql-api/test/to-graphql-error.test.ts
+++ b/packages/graphql-api/test/to-graphql-error.test.ts
@@ -21,4 +21,36 @@ describe("toGraphQLError", () => {
       stepRunId: "sr-1",
     })
   })
+
+  test("maps SessionIdNotFoundError to SESSION_NOT_FOUND", () => {
+    const error = {
+      _tag: "SessionIdNotFoundError" as const,
+      sessionId: "ses-missing",
+    }
+
+    const gqlError = toGraphQLError(error)
+
+    expect(gqlError.message).toBe("No Work Item owns Session ID: ses-missing")
+    expect(gqlError.extensions).toMatchObject({
+      code: "SESSION_NOT_FOUND",
+      sessionId: "ses-missing",
+    })
+  })
+
+  test("maps SessionIdAmbiguousError to SESSION_AMBIGUOUS", () => {
+    const error = {
+      _tag: "SessionIdAmbiguousError" as const,
+      sessionId: "ses-shared",
+    }
+
+    const gqlError = toGraphQLError(error)
+
+    expect(gqlError.message).toBe(
+      "Multiple Work Items own Session ID: ses-shared",
+    )
+    expect(gqlError.extensions).toMatchObject({
+      code: "SESSION_AMBIGUOUS",
+      sessionId: "ses-shared",
+    })
+  })
 })

--- a/packages/graphql-schema/schema.graphql
+++ b/packages/graphql-schema/schema.graphql
@@ -91,6 +91,12 @@ type Query {
   """
   session(workItemId: ID!): Session
   """
+  Resolve an opaque backend Session ID to exactly one Work Item.
+  Matches work_item.session_id exactly. Zero matches fail as not found;
+  more than one match fails as ambiguous.
+  """
+  workItemBySessionId(sessionId: String!): SessionWorkItem!
+  """
   Current Intake Candidates for one Repository from the Issue projection.
   Does not request or wait for Refresh. Empty classification succeeds without
   Agent Backend or Agent Model preflight; nonempty classification runs one
@@ -117,6 +123,24 @@ enum SessionAvailability {
   MISSING
   UNAVAILABLE
   UNSUPPORTED
+}
+
+"""
+Work Item fields needed to continue a Session interactively.
+"""
+type SessionWorkItem {
+  """
+  Agent Backend captured at Work Item creation.
+  """
+  agentBackend: AgentBackendInfo!
+  """
+  Canonical backend Session ID.
+  """
+  sessionId: String!
+  """
+  Persisted worktree path. Null when unset or already cleaned up.
+  """
+  worktreePath: String
 }
 
 type SessionModel {

--- a/packages/graphql-schema/schema.template.graphql
+++ b/packages/graphql-schema/schema.template.graphql
@@ -88,6 +88,12 @@ type Query {
   """
   session(workItemId: ID!): Session
   """
+  Resolve an opaque backend Session ID to exactly one Work Item.
+  Matches work_item.session_id exactly. Zero matches fail as not found;
+  more than one match fails as ambiguous.
+  """
+  workItemBySessionId(sessionId: String!): SessionWorkItem!
+  """
   Current Intake Candidates for one Repository from the Issue projection.
   Does not request or wait for Refresh. Empty classification succeeds without
   Agent Backend or Agent Model preflight; nonempty classification runs one
@@ -114,6 +120,24 @@ enum SessionAvailability {
   MISSING
   UNAVAILABLE
   UNSUPPORTED
+}
+
+"""
+Work Item fields needed to continue a Session interactively.
+"""
+type SessionWorkItem {
+  """
+  Agent Backend captured at Work Item creation.
+  """
+  agentBackend: AgentBackendInfo!
+  """
+  Canonical backend Session ID.
+  """
+  sessionId: String!
+  """
+  Persisted worktree path. Null when unset or already cleaned up.
+  """
+  worktreePath: String
 }
 
 type SessionModel {

--- a/packages/work-item-lifecycle/src/lib/errors.ts
+++ b/packages/work-item-lifecycle/src/lib/errors.ts
@@ -127,6 +127,22 @@ export class WorkItemNotFoundError extends Schema.TaggedErrorClass<WorkItemNotFo
   },
 ) {}
 
+/** No Work Item owns this opaque backend Session ID. */
+export class SessionIdNotFoundError extends Schema.TaggedErrorClass<SessionIdNotFoundError>()(
+  "SessionIdNotFoundError",
+  {
+    sessionId: Schema.String,
+  },
+) {}
+
+/** More than one Work Item owns this opaque backend Session ID. */
+export class SessionIdAmbiguousError extends Schema.TaggedErrorClass<SessionIdAmbiguousError>()(
+  "SessionIdAmbiguousError",
+  {
+    sessionId: Schema.String,
+  },
+) {}
+
 export class StepRunNotFoundError extends Schema.TaggedErrorClass<StepRunNotFoundError>()(
   "StepRunNotFoundError",
   {

--- a/packages/work-item-lifecycle/src/lib/work-item-lifecycle.ts
+++ b/packages/work-item-lifecycle/src/lib/work-item-lifecycle.ts
@@ -73,6 +73,8 @@ import {
   ParentIssueError,
   ResetCleanupError,
   RetryNotEligibleError,
+  SessionIdAmbiguousError,
+  SessionIdNotFoundError,
   StepRunNotFoundError,
   UnfinishedWorkItemExistsError,
   UnsupportedIssueHierarchyError,
@@ -673,6 +675,21 @@ export type GetWorkItemError =
 
 export type ListWorkItemsError = WorkItemLifecycleDatabaseError
 
+/**
+ * Captured Agent Backend, canonical Session ID, and worktree for a Session
+ * owned by exactly one Work Item.
+ */
+export type WorkItemSessionLookup = {
+  readonly agentBackend: string
+  readonly sessionId: string
+  readonly worktreePath: string | null
+}
+
+export type FindWorkItemBySessionIdError =
+  | SessionIdNotFoundError
+  | SessionIdAmbiguousError
+  | WorkItemLifecycleDatabaseError
+
 export type RunStepError =
   | StepRunNotFoundError
   | WorkItemNotFoundError
@@ -860,6 +877,13 @@ export interface WorkItemLifecycleShape {
   readonly ownsSessionId: (
     sessionId: string,
   ) => Effect.Effect<boolean, ListWorkItemsError>
+  /**
+   * Resolve an opaque backend Session ID to exactly one Work Item.
+   * Fetches two rows so zero, one, and multiple matches are distinct.
+   */
+  readonly findWorkItemBySessionId: (
+    sessionId: string,
+  ) => Effect.Effect<WorkItemSessionLookup, FindWorkItemBySessionIdError>
   /**
    * Count unique Work Items with a non-null GitHub PR number and a successful
    * commit Step Run whose finished_at is in the half-open range [fromMs, toMs).
@@ -1262,6 +1286,37 @@ export const makeWorkItemLifecycleLive = (
           return rows.length > 0
         },
       )
+
+      const findWorkItemBySessionId = Effect.fn(
+        "WorkItemLifecycle.findWorkItemBySessionId",
+      )(function* (sessionId: string) {
+        const rows = (yield* sql
+          .unsafe(
+            `SELECT agent_backend, worktree_path
+             FROM work_item
+             WHERE session_id = ?
+             LIMIT 2`,
+            [sessionId],
+          )
+          .pipe(Effect.mapError(toDatabaseError))) as readonly {
+          readonly agent_backend: string
+          readonly worktree_path: string | null
+        }[]
+
+        const row = rows[0]
+        if (row === undefined) {
+          return yield* new SessionIdNotFoundError({ sessionId })
+        }
+        if (rows.length > 1) {
+          return yield* new SessionIdAmbiguousError({ sessionId })
+        }
+
+        return {
+          agentBackend: row.agent_backend,
+          sessionId,
+          worktreePath: row.worktree_path,
+        } satisfies WorkItemSessionLookup
+      })
 
       const countCommittedPullRequests = Effect.fn(
         "WorkItemLifecycle.countCommittedPullRequests",
@@ -6512,6 +6567,7 @@ export const makeWorkItemLifecycleLive = (
         listWorkItemsForRepository,
         listCompletedWorkItems,
         ownsSessionId,
+        findWorkItemBySessionId,
         countCommittedPullRequests,
         continueAfterHumanPrOutcome,
         admitWaitingWorkItems,

--- a/packages/work-item-lifecycle/test/find-work-item-by-session-id.spec.ts
+++ b/packages/work-item-lifecycle/test/find-work-item-by-session-id.spec.ts
@@ -1,0 +1,223 @@
+import { Effect, Layer } from "effect"
+import { SqlClient } from "effect/unstable/sql"
+import { DatabaseTest } from "@ready-for-agent/db/test"
+import { DbServiceLive } from "@ready-for-agent/db-service"
+import { SqliteQueueServiceLive } from "@ready-for-agent/sqlite-queue-service"
+import {
+  LifecycleSteps,
+  type LifecycleStepsShape,
+  SessionIdAmbiguousError,
+  SessionIdNotFoundError,
+  WorkItemLifecycle,
+  WorkItemLifecycleLive,
+  stubActiveAgentBackendLayer,
+  stubGitHubServiceLayer,
+  stubGitLabServiceLayer,
+} from "../src/index.js"
+import { describe, expect, it } from "bun:test"
+
+const successfulSteps: LifecycleStepsShape = {
+  createWorktree: () =>
+    Effect.succeed({
+      worktreePath: "/tmp/worktrees/acme-widgets-42",
+      startingCommitOid: "abc123",
+    }),
+  installDependencies: () => Effect.void,
+  implement: () => Effect.succeed("ses_test"),
+  assessChanges: () => Effect.succeed({ _tag: "changes" }),
+  preCommit: () => Effect.void,
+  review: () => Effect.succeed({ _tag: "clean" as const }),
+  commit: () =>
+    Effect.succeed({
+      completion: "native" as const,
+      publicationTitle: "feat: test",
+      publicationBody: "Why\n\nCloses #1",
+    }),
+  createPr: () =>
+    Effect.succeed({
+      pullRequestNumber: 101,
+      completion: "native" as const,
+      publicationTitle: "feat: test",
+      publicationBody: "Why\n\nCloses #1",
+    }),
+  watchPrStatusChecks: () =>
+    Effect.succeed({
+      _tag: "succeeded" as const,
+      createdAt: new Date(0),
+      headSha: "settled-head",
+      headPushedAt: new Date(0),
+      isDraft: true,
+    }),
+  resolvePrMergeConflict: () => Effect.succeed({ _tag: "processed" }),
+  investigatePrStatusChecks: () =>
+    Effect.succeed({ _tag: "processed", handledCheckIds: [] }),
+  markPrReadyForReview: () => Effect.void,
+  decidePrMerge: () => Effect.succeed({ _tag: "clanker_merge" }),
+  mergePr: () => Effect.succeed({ _tag: "merged" }),
+  closeIssue: () => Effect.void,
+  localCleanup: () => Effect.void,
+  removeWorktree: () => Effect.void,
+}
+
+const TestLayer = WorkItemLifecycleLive.pipe(
+  Layer.provideMerge(stubActiveAgentBackendLayer()),
+  Layer.provideMerge(stubGitHubServiceLayer()),
+  Layer.provideMerge(stubGitLabServiceLayer()),
+  Layer.provideMerge(
+    Layer.succeed(LifecycleSteps, LifecycleSteps.of(successfulSteps)),
+  ),
+  Layer.provideMerge(DbServiceLive),
+  Layer.provideMerge(SqliteQueueServiceLive),
+  Layer.provideMerge(DatabaseTest),
+)
+
+const runTest = <A, E>(
+  effect: Effect.Effect<A, E, Layer.Layer.Success<typeof TestLayer>>,
+) => Effect.runPromise(Effect.provide(effect, TestLayer))
+
+const seedRepository = (repositoryId: string, now: number) =>
+  Effect.gen(function* () {
+    const sql = yield* SqlClient.SqlClient
+    yield* sql.unsafe(
+      `INSERT INTO repository (
+         id, forge, forge_host, project_path, local_path, is_bare, paused,
+         issues_reconciled_at, created_at, updated_at
+       ) VALUES (?, 'github', 'github.com', ?, ?, 1, 0, NULL, ?, ?)`,
+      [repositoryId, repositoryId, `/tmp/${repositoryId}`, now, now],
+    )
+  })
+
+const seedWorkItem = (input: {
+  readonly workItemId: string
+  readonly repositoryId: string
+  readonly issueNumber: number
+  readonly agentBackend?: string
+  readonly sessionId: string | null
+  readonly worktreePath: string | null
+  readonly now: number
+}) =>
+  Effect.gen(function* () {
+    const sql = yield* SqlClient.SqlClient
+    yield* sql.unsafe(
+      `INSERT INTO work_item (
+         id, repository_id, issue_number, issue_title, pull_request_number,
+         agent_backend, state, state_ready_at,
+         worktree_path, session_id, failure_code, failure_message,
+         created_at, updated_at
+       ) VALUES (?, ?, ?, ?, NULL, ?, 'implement', ?,
+         ?, ?, NULL, NULL, ?, ?)`,
+      [
+        input.workItemId,
+        input.repositoryId,
+        input.issueNumber,
+        `Issue ${input.issueNumber}`,
+        input.agentBackend ?? "opencode",
+        input.now,
+        input.worktreePath,
+        input.sessionId,
+        input.now,
+        input.now,
+      ],
+    )
+  })
+
+describe("findWorkItemBySessionId", () => {
+  const now = Date.parse("2026-08-13T12:00:00.000Z")
+  const sessionId = "85312e9f-9c57-42ef-9757-b2512cee57cd"
+
+  it("fails as not found when no Work Item owns the Session ID", () =>
+    runTest(
+      Effect.gen(function* () {
+        const lifecycle = yield* WorkItemLifecycle
+        yield* seedRepository("repo-none", now)
+        yield* seedWorkItem({
+          workItemId: "wi-other-session",
+          repositoryId: "repo-none",
+          issueNumber: 1,
+          sessionId: "other-session",
+          worktreePath: "/tmp/worktrees/other",
+          now,
+        })
+
+        const error = yield* Effect.flip(
+          lifecycle.findWorkItemBySessionId(sessionId),
+        )
+
+        expect(error).toBeInstanceOf(SessionIdNotFoundError)
+        expect(error._tag).toBe("SessionIdNotFoundError")
+        if (error._tag === "SessionIdNotFoundError") {
+          expect(error.sessionId).toBe(sessionId)
+        }
+      }),
+    ))
+
+  it("returns the captured backend, Session ID, and worktree for exactly one match", () =>
+    runTest(
+      Effect.gen(function* () {
+        const lifecycle = yield* WorkItemLifecycle
+        yield* seedRepository("repo-one", now)
+        yield* seedWorkItem({
+          workItemId: "wi-owner",
+          repositoryId: "repo-one",
+          issueNumber: 7,
+          agentBackend: "grok",
+          sessionId,
+          worktreePath: "/tmp/worktrees/acme-widgets-7",
+          now,
+        })
+        yield* seedWorkItem({
+          workItemId: "wi-unrelated",
+          repositoryId: "repo-one",
+          issueNumber: 8,
+          sessionId: "unrelated-session",
+          worktreePath: "/tmp/worktrees/other",
+          now,
+        })
+
+        const found = yield* lifecycle.findWorkItemBySessionId(sessionId)
+
+        expect(found).toEqual({
+          agentBackend: "grok",
+          sessionId,
+          worktreePath: "/tmp/worktrees/acme-widgets-7",
+        })
+      }),
+    ))
+
+  it("fails as ambiguous when more than one Work Item owns the Session ID", () =>
+    runTest(
+      Effect.gen(function* () {
+        const lifecycle = yield* WorkItemLifecycle
+        yield* seedRepository("repo-a", now)
+        yield* seedRepository("repo-b", now)
+        yield* seedWorkItem({
+          workItemId: "wi-first",
+          repositoryId: "repo-a",
+          issueNumber: 1,
+          agentBackend: "opencode",
+          sessionId,
+          worktreePath: "/tmp/worktrees/first",
+          now,
+        })
+        yield* seedWorkItem({
+          workItemId: "wi-second",
+          repositoryId: "repo-b",
+          issueNumber: 2,
+          agentBackend: "claude",
+          sessionId,
+          worktreePath: "/tmp/worktrees/second",
+          now,
+        })
+
+        const error = yield* Effect.flip(
+          lifecycle.findWorkItemBySessionId(sessionId),
+        )
+
+        expect(error).toBeInstanceOf(SessionIdAmbiguousError)
+        expect(error._tag).toBe("SessionIdAmbiguousError")
+        if (error._tag === "SessionIdAmbiguousError") {
+          expect(error.sessionId).toBe(sessionId)
+        }
+      }),
+    ))
+})


### PR DESCRIPTION
Interactive Session Jump needs the running Harness to map a backend Session ID
to exactly one Work Item so a later CLI command can continue that Session in
the right worktree. `ownsSessionId` only returns a boolean with `LIMIT 1`, so
it cannot tell "none" from "several" — and Session IDs are not unique in the
database.

This adds a read-only `workItemBySessionId(sessionId:)` query that returns the
captured Agent Backend, canonical Session ID, and worktree path. The lifecycle
lookup fetches two matching rows: zero matches fail as `SESSION_NOT_FOUND`,
more than one as `SESSION_AMBIGUOUS`, and a single match returns those three
fields. No jump tracking and no lifecycle-state inspection.

Verification: isolated SQLite covers zero / one / many matches; GraphQL API
tests cover the query and error mapping. Local review findings (schema wording,
SQL `as` cast, stubbed GraphQL tests) were cleared: they match the issue's
exact-match contract, existing SQL lookup style, and the Session-resolver test
seam.

Implements #1017.

Closes #1017