### PR TITLE
fix(agent-backend): classify spawn ENOENT as backend unavailable (#1023)

### DIFF
--- a/packages/agent-backend/src/index.ts
+++ b/packages/agent-backend/src/index.ts
@@ -4,6 +4,7 @@ export {
 } from "@ready-for-agent/lifecycle-model"
 export * from "./lib/active-agent-backend.js"
 export * from "./lib/agent-backend.js"
+export * from "./lib/agent-cli-not-found.js"
 export * from "./lib/cli-runner.js"
 export * from "./lib/collect-child-stdout.js"
 export * from "./lib/environment.js"

--- a/packages/agent-backend/src/lib/agent-backend.ts
+++ b/packages/agent-backend/src/lib/agent-backend.ts
@@ -5,6 +5,7 @@ import type {
   AgentBackendConfigError,
   AgentBackendExitError,
   AgentBackendMalformedOutputError,
+  AgentBackendNotInstalledError,
   AgentBackendSessionIdMissingError,
   AgentBackendStartupTimeoutError,
   AgentBackendTimeoutError,
@@ -24,6 +25,7 @@ export type AgentBackendError =
   | AgentBackendStartupTimeoutError
   | AgentBackendSessionIdMissingError
   | AgentBackendMalformedOutputError
+  | AgentBackendNotInstalledError
   | PlatformError
 
 /**

--- a/packages/agent-backend/src/lib/agent-cli-not-found.ts
+++ b/packages/agent-backend/src/lib/agent-cli-not-found.ts
@@ -1,0 +1,64 @@
+const SPAWN_NOT_FOUND_CODE = "ENOENT"
+
+const readUnknownField = (value: object, key: string): unknown =>
+  key in value ? Reflect.get(value, key) : undefined
+
+const isChildProcessSpawn = (value: object): boolean => {
+  const module = readUnknownField(value, "module")
+  const method = readUnknownField(value, "method")
+  if (module === "ChildProcess" && method === "spawn") {
+    return true
+  }
+  const reason = readUnknownField(value, "reason")
+  if (typeof reason === "object" && reason !== null) {
+    return (
+      readUnknownField(reason, "module") === "ChildProcess" &&
+      readUnknownField(reason, "method") === "spawn"
+    )
+  }
+  return false
+}
+
+/**
+ * Walk a nested `cause` chain and return `ENOENT` only for ChildProcess spawn.
+ * FileSystem access ENOENT (missing cwd) and EACCES (not executable) have
+ * different remedies and are not recognized.
+ */
+export const findSpawnNotFoundCode = (cause: unknown): string | undefined => {
+  const seen = new Set<unknown>()
+  let current: unknown = cause
+  let spawnContext = false
+  while (current !== undefined && current !== null && !seen.has(current)) {
+    seen.add(current)
+    if (typeof current === "object") {
+      if (isChildProcessSpawn(current)) {
+        spawnContext = true
+      }
+      const code = readUnknownField(current, "code")
+      if (spawnContext && code === SPAWN_NOT_FOUND_CODE) {
+        return SPAWN_NOT_FOUND_CODE
+      }
+      current = readUnknownField(current, "cause")
+      continue
+    }
+    break
+  }
+  return undefined
+}
+
+export type AgentCliNotFoundRemediationInput = {
+  readonly backendLabel: string
+  readonly binary: string
+}
+
+/**
+ * Operator-facing copy that names the missing CLI and the Harness restart
+ * remedy. The Harness cannot pick up a later install without restarting.
+ */
+export const formatAgentCliNotFoundRemediation = (
+  input: AgentCliNotFoundRemediationInput,
+): string =>
+  [
+    `${input.backendLabel} CLI "${input.binary}" was not found on the Harness PATH.`,
+    `The Harness inherits the PATH of the shell that started it and cannot pick up a later install, upgrade, or relocation. Check with \`command -v ${input.binary}\`, then restart the Harness from a shell where it resolves.`,
+  ].join("\n")

--- a/packages/agent-backend/src/lib/cli-runner.ts
+++ b/packages/agent-backend/src/lib/cli-runner.ts
@@ -3,6 +3,10 @@ import type { PlatformError } from "effect/PlatformError"
 import { ChildProcess, type ChildProcessSpawner } from "effect/unstable/process"
 import type { ChildProcessHandle } from "effect/unstable/process/ChildProcessSpawner"
 import {
+  findSpawnNotFoundCode,
+  formatAgentCliNotFoundRemediation,
+} from "./agent-cli-not-found.js"
+import {
   collectChildStdout,
   collectChildStdoutAndStderr,
 } from "./collect-child-stdout.js"
@@ -10,12 +14,13 @@ import {
   type AgentBackendErrorClassification,
   AgentBackendExitError,
   AgentBackendMalformedOutputError,
+  AgentBackendNotInstalledError,
   AgentBackendSessionIdMissingError,
   AgentBackendStartupTimeoutError,
   AgentBackendTimeoutError,
 } from "./errors.js"
 import { killProcessTree } from "./kill-process-tree.js"
-import type { OnSessionId } from "./types.js"
+import type { AgentBackendDescriptor, OnSessionId } from "./types.js"
 
 /** Graceful terminate then force-kill bound for the Agent Turn process tree. */
 export const DEFAULT_FORCE_KILL_AFTER = Duration.seconds(2)
@@ -33,6 +38,7 @@ export type AgentBackendCliError =
   | AgentBackendStartupTimeoutError
   | AgentBackendSessionIdMissingError
   | AgentBackendMalformedOutputError
+  | AgentBackendNotInstalledError
   | PlatformError
 
 export type CliLineEvent = {
@@ -54,6 +60,7 @@ export type CliLineEvent = {
 
 export type RunCliCaptureInput = {
   readonly spawner: ChildProcessSpawner.ChildProcessSpawner["Service"]
+  readonly backend: AgentBackendDescriptor
   readonly binary: string
   readonly args: ReadonlyArray<string>
   readonly cwd: string
@@ -77,6 +84,7 @@ export type RunCliCaptureInput = {
 
 export type RunCliTurnInput = {
   readonly spawner: ChildProcessSpawner.ChildProcessSpawner["Service"]
+  readonly backend: AgentBackendDescriptor
   readonly binary: string
   readonly args: ReadonlyArray<string>
   readonly cwd: string
@@ -130,6 +138,27 @@ const commandOptions = (input: {
   forceKillAfter: input.forceKillAfter ?? DEFAULT_FORCE_KILL_AFTER,
 })
 
+const mapSpawnError = (
+  error: PlatformError,
+  input: {
+    readonly backend: AgentBackendDescriptor
+    readonly binary: string
+  },
+): PlatformError | AgentBackendNotInstalledError => {
+  if (findSpawnNotFoundCode(error) === undefined) {
+    return error
+  }
+  return new AgentBackendNotInstalledError({
+    message: formatAgentCliNotFoundRemediation({
+      backendLabel: input.backend.label,
+      binary: input.binary,
+    }),
+    backend: input.backend,
+    binary: input.binary,
+    cause: error,
+  })
+}
+
 /**
  * Terminate the harness-spawned CLI and every process it started.
  *
@@ -165,7 +194,10 @@ export const runCliCapture = (
     readonly stdout: string
     readonly stderr: string
   },
-  AgentBackendExitError | AgentBackendTimeoutError | PlatformError
+  | AgentBackendExitError
+  | AgentBackendTimeoutError
+  | AgentBackendNotInstalledError
+  | PlatformError
 > =>
   Effect.gen(function* () {
     const spawner = input.spawner
@@ -180,7 +212,9 @@ export const runCliCapture = (
 
     const result = yield* Effect.scoped(
       Effect.gen(function* () {
-        const handle = yield* spawner.spawn(command)
+        const handle = yield* spawner
+          .spawn(command)
+          .pipe(Effect.mapError((error) => mapSpawnError(error, input)))
         // Finalizer runs before Effect's handle cleanup (LIFO): snapshot the
         // tree while the root is still alive, then reap group + descendants.
         yield* Effect.addFinalizer(() =>
@@ -253,7 +287,9 @@ export const runCliTurn = (
 
     const result = yield* Effect.scoped(
       Effect.gen(function* () {
-        const handle = yield* spawner.spawn(command)
+        const handle = yield* spawner
+          .spawn(command)
+          .pipe(Effect.mapError((error) => mapSpawnError(error, input)))
         yield* Effect.addFinalizer(() =>
           terminateCliTree(handle, forceKillAfter),
         )

--- a/packages/agent-backend/src/lib/errors.ts
+++ b/packages/agent-backend/src/lib/errors.ts
@@ -94,3 +94,51 @@ export class AgentBackendMalformedOutputError extends Schema.TaggedErrorClass<Ag
     byteLength: Schema.Finite,
   },
 ) {}
+
+const AgentBackendDescriptorSchema = Schema.Struct({
+  id: Schema.String,
+  label: Schema.String,
+})
+
+/** Agent Backend CLI binary was not found on the Harness PATH (spawn ENOENT). */
+export class AgentBackendNotInstalledError extends Schema.TaggedErrorClass<AgentBackendNotInstalledError>()(
+  "AgentBackendNotInstalledError",
+  {
+    message: Schema.String,
+    backend: AgentBackendDescriptorSchema,
+    binary: Schema.String,
+    cause: Schema.optional(Schema.Defect()),
+  },
+) {}
+
+export const isAgentBackendNotInstalledError = (
+  value: unknown,
+): value is AgentBackendNotInstalledError =>
+  typeof value === "object" &&
+  value !== null &&
+  "_tag" in value &&
+  value._tag === "AgentBackendNotInstalledError"
+
+/**
+ * Walk a nested `cause` / `_tag` chain for AgentBackendNotInstalledError.
+ * Step handlers wrap the spawn error, so `instanceof` on the top-level
+ * failure is not enough.
+ */
+export const findAgentBackendNotInstalledError = (
+  cause: unknown,
+): AgentBackendNotInstalledError | undefined => {
+  const seen = new Set<unknown>()
+  let current: unknown = cause
+  while (current !== undefined && current !== null && !seen.has(current)) {
+    seen.add(current)
+    if (isAgentBackendNotInstalledError(current)) {
+      return current
+    }
+    if (typeof current === "object" && "cause" in current) {
+      current = Reflect.get(current, "cause")
+      continue
+    }
+    break
+  }
+  return undefined
+}

--- a/packages/agent-backend/test/agent-cli-not-found.spec.ts
+++ b/packages/agent-backend/test/agent-cli-not-found.spec.ts
@@ -1,0 +1,83 @@
+import { systemError } from "effect/PlatformError"
+import {
+  findSpawnNotFoundCode,
+  formatAgentCliNotFoundRemediation,
+} from "../src/index.js"
+import { describe, expect, it } from "bun:test"
+
+describe("findSpawnNotFoundCode", () => {
+  it("finds ENOENT on a nested PlatformError cause chain", () => {
+    const enoent = Object.assign(
+      new Error('Executable not found in $PATH: "claude"'),
+      { code: "ENOENT" },
+    )
+    const spawnFailure = systemError({
+      _tag: "NotFound",
+      module: "ChildProcess",
+      method: "spawn",
+      description:
+        "ChildProcess.spawn (claude -p --output-format stream-json ...)",
+      cause: enoent,
+    })
+
+    expect(findSpawnNotFoundCode(spawnFailure)).toBe("ENOENT")
+  })
+
+  it("ignores FileSystem access ENOENT for a missing cwd", () => {
+    const enoent = Object.assign(
+      new Error("ENOENT: no such file or directory"),
+      {
+        code: "ENOENT",
+        syscall: "access",
+      },
+    )
+    const cwdAccess = systemError({
+      _tag: "NotFound",
+      module: "FileSystem",
+      method: "access",
+      pathOrDescriptor: "/missing/worktree",
+      syscall: "access",
+      cause: enoent,
+    })
+
+    expect(findSpawnNotFoundCode(cwdAccess)).toBeUndefined()
+  })
+
+  it("ignores EACCES and other spawn failures", () => {
+    const eacces = Object.assign(new Error("permission denied"), {
+      code: "EACCES",
+    })
+    const spawnFailure = systemError({
+      _tag: "PermissionDenied",
+      module: "ChildProcess",
+      method: "spawn",
+      cause: eacces,
+    })
+
+    expect(findSpawnNotFoundCode(spawnFailure)).toBeUndefined()
+    expect(findSpawnNotFoundCode(new Error("boom"))).toBeUndefined()
+    expect(
+      findSpawnNotFoundCode(
+        Object.assign(new Error("connect ECONNREFUSED"), {
+          code: "ECONNREFUSED",
+        }),
+      ),
+    ).toBeUndefined()
+  })
+})
+
+describe("formatAgentCliNotFoundRemediation", () => {
+  it("names the backend CLI and tells the operator to restart the Harness", () => {
+    const message = formatAgentCliNotFoundRemediation({
+      backendLabel: "Claude Code",
+      binary: "claude",
+    })
+
+    expect(message).toContain(
+      'Claude Code CLI "claude" was not found on the Harness PATH.',
+    )
+    expect(message).toContain("inherits the PATH of the shell that started it")
+    expect(message).toContain("`command -v claude`")
+    expect(message).toContain("restart the Harness")
+  })
+})

--- a/packages/agent-backend/test/cli-runner.spec.ts
+++ b/packages/agent-backend/test/cli-runner.spec.ts
@@ -3,9 +3,11 @@ import { tmpdir } from "node:os"
 import { join } from "node:path"
 import { BunServices } from "@effect/platform-bun"
 import { Deferred, Duration, Effect, Exit, Fiber } from "effect"
+import { systemError } from "effect/PlatformError"
 import { ChildProcessSpawner } from "effect/unstable/process"
 import {
   AgentBackendExitError,
+  AgentBackendNotInstalledError,
   AgentBackendSessionIdMissingError,
   AgentBackendStartupTimeoutError,
   AgentBackendTimeoutError,
@@ -14,6 +16,8 @@ import {
   sanitizeInheritedEnvironment,
 } from "../src/index.js"
 import { describe, expect, it } from "bun:test"
+
+const TEST_BACKEND = { id: "claude" as const, label: "Claude Code" }
 
 const withExecutable = async <A>(
   body: string,
@@ -98,6 +102,7 @@ describe("runCliCapture", () => {
             withSpawner((spawner) =>
               runCliCapture({
                 spawner,
+                backend: TEST_BACKEND,
                 binary,
                 args: [],
                 cwd: directory,
@@ -126,6 +131,7 @@ describe("runCliCapture", () => {
         withSpawner((spawner) =>
           runCliCapture({
             spawner,
+            backend: TEST_BACKEND,
             binary,
             args: [],
             cwd: process.cwd(),
@@ -151,6 +157,7 @@ describe("runCliCapture", () => {
           withSpawner((spawner) =>
             runCliCapture({
               spawner,
+              backend: TEST_BACKEND,
               binary,
               args: [],
               cwd: process.cwd(),
@@ -175,6 +182,7 @@ describe("runCliCapture", () => {
           withSpawner((spawner) =>
             runCliCapture({
               spawner,
+              backend: TEST_BACKEND,
               binary,
               args: [],
               cwd: process.cwd(),
@@ -205,6 +213,7 @@ describe("runCliTurn", () => {
             withSpawner((spawner) =>
               runCliTurn({
                 spawner,
+                backend: TEST_BACKEND,
                 binary,
                 args: [],
                 cwd: process.cwd(),
@@ -237,6 +246,7 @@ describe("runCliTurn", () => {
               const fiber = yield* Effect.forkChild(
                 runCliTurn({
                   spawner,
+                  backend: TEST_BACKEND,
                   binary,
                   args: [],
                   cwd: process.cwd(),
@@ -272,6 +282,7 @@ describe("runCliTurn", () => {
           withSpawner((spawner) =>
             runCliTurn({
               spawner,
+              backend: TEST_BACKEND,
               binary,
               args: [],
               cwd: process.cwd(),
@@ -301,6 +312,7 @@ describe("runCliTurn", () => {
           withSpawner((spawner) =>
             runCliTurn({
               spawner,
+              backend: TEST_BACKEND,
               binary,
               args: [],
               cwd: process.cwd(),
@@ -327,6 +339,7 @@ describe("runCliTurn", () => {
         withSpawner((spawner) =>
           runCliTurn({
             spawner,
+            backend: TEST_BACKEND,
             binary,
             args: [],
             cwd: process.cwd(),
@@ -350,6 +363,7 @@ describe("runCliTurn", () => {
           withSpawner((spawner) =>
             runCliTurn({
               spawner,
+              backend: TEST_BACKEND,
               binary,
               args: [],
               cwd: process.cwd(),
@@ -390,6 +404,7 @@ describe("runCliTurn", () => {
             withSpawner((spawner) =>
               runCliTurn({
                 spawner,
+                backend: TEST_BACKEND,
                 binary,
                 args: [],
                 cwd: process.cwd(),
@@ -442,6 +457,7 @@ describe("runCliTurn", () => {
             withSpawner((spawner) =>
               runCliTurn({
                 spawner,
+                backend: TEST_BACKEND,
                 binary,
                 args: [],
                 cwd: process.cwd(),
@@ -492,6 +508,7 @@ describe("runCliTurn", () => {
             withSpawner((spawner) =>
               runCliTurn({
                 spawner,
+                backend: TEST_BACKEND,
                 binary,
                 args: [],
                 cwd: process.cwd(),
@@ -560,6 +577,7 @@ describe("runCliTurn", () => {
             withSpawner((spawner) =>
               runCliTurn({
                 spawner,
+                backend: TEST_BACKEND,
                 binary,
                 args: [],
                 cwd: process.cwd(),
@@ -606,6 +624,7 @@ describe("runCliTurn", () => {
         withSpawner((spawner) =>
           runCliTurn({
             spawner,
+            backend: TEST_BACKEND,
             binary,
             args: [],
             cwd: process.cwd(),
@@ -632,6 +651,7 @@ describe("runCliTurn", () => {
         withSpawner((spawner) =>
           runCliTurn({
             spawner,
+            backend: TEST_BACKEND,
             binary,
             args: [],
             cwd: process.cwd(),
@@ -661,6 +681,7 @@ describe("runCliTurn", () => {
           withSpawner((spawner) =>
             runCliTurn({
               spawner,
+              backend: TEST_BACKEND,
               binary,
               args: [],
               cwd: process.cwd(),
@@ -695,6 +716,7 @@ describe("runCliTurn", () => {
           withSpawner((spawner) =>
             runCliTurn({
               spawner,
+              backend: TEST_BACKEND,
               binary,
               args: [],
               cwd: process.cwd(),
@@ -726,6 +748,7 @@ describe("runCliTurn", () => {
           withSpawner((spawner) =>
             runCliTurn({
               spawner,
+              backend: TEST_BACKEND,
               binary,
               args: [],
               cwd: process.cwd(),
@@ -753,6 +776,7 @@ describe("runCliTurn", () => {
         withSpawner((spawner) =>
           runCliTurn({
             spawner,
+            backend: TEST_BACKEND,
             binary,
             args: [],
             cwd: process.cwd(),
@@ -787,6 +811,7 @@ describe("runCliTurn", () => {
           withSpawner((spawner) =>
             runCliTurn({
               spawner,
+              backend: TEST_BACKEND,
               binary,
               args: [],
               cwd: process.cwd(),
@@ -819,6 +844,7 @@ describe("runCliTurn", () => {
           withSpawner((spawner) =>
             runCliTurn({
               spawner,
+              backend: TEST_BACKEND,
               binary,
               args: [],
               cwd: process.cwd(),
@@ -855,6 +881,7 @@ describe("runCliTurn", () => {
           withSpawner((spawner) =>
             runCliTurn({
               spawner,
+              backend: TEST_BACKEND,
               binary,
               args: [],
               cwd: process.cwd(),
@@ -870,6 +897,116 @@ describe("runCliTurn", () => {
         })
       },
     )
+  })
+})
+
+const enoentPlatformError = systemError({
+  _tag: "NotFound",
+  module: "ChildProcess",
+  method: "spawn",
+  description: "ChildProcess.spawn (claude -p --output-format stream-json ...)",
+  cause: Object.assign(new Error('Executable not found in $PATH: "claude"'), {
+    code: "ENOENT",
+  }),
+})
+
+const eaccesPlatformError = systemError({
+  _tag: "PermissionDenied",
+  module: "ChildProcess",
+  method: "spawn",
+  description: "ChildProcess.spawn (claude)",
+  cause: Object.assign(new Error("permission denied"), { code: "EACCES" }),
+})
+
+const failingSpawner = (error: ReturnType<typeof systemError>) =>
+  ChildProcessSpawner.make(() => Effect.fail(error))
+
+describe("runCliCapture spawn not-found", () => {
+  it("maps an ENOENT spawn failure to AgentBackendNotInstalledError", async () => {
+    const error = await Effect.runPromise(
+      runCliCapture({
+        spawner: failingSpawner(enoentPlatformError),
+        backend: TEST_BACKEND,
+        binary: "claude",
+        args: [],
+        cwd: process.cwd(),
+        env: sanitizeInheritedEnvironment(),
+        timeout: Duration.seconds(2),
+      }).pipe(Effect.flip),
+    )
+    expect(error).toBeInstanceOf(AgentBackendNotInstalledError)
+    if (error instanceof AgentBackendNotInstalledError) {
+      expect(error.binary).toBe("claude")
+      expect(error.backend).toEqual(TEST_BACKEND)
+      expect(error.message).toContain(
+        'Claude Code CLI "claude" was not found on the Harness PATH.',
+      )
+      expect(error.message).toContain("`command -v claude`")
+      expect(error.message).toContain("restart the Harness")
+    }
+  })
+
+  it("leaves a non-ENOENT spawn PlatformError unclassified", async () => {
+    const error = await Effect.runPromise(
+      runCliCapture({
+        spawner: failingSpawner(eaccesPlatformError),
+        backend: TEST_BACKEND,
+        binary: "claude",
+        args: [],
+        cwd: process.cwd(),
+        env: sanitizeInheritedEnvironment(),
+        timeout: Duration.seconds(2),
+      }).pipe(Effect.flip),
+    )
+    expect(error).not.toBeInstanceOf(AgentBackendNotInstalledError)
+    expect((error as { _tag?: string })._tag).toBe("PlatformError")
+  })
+
+  it("leaves a missing cwd as PlatformError, not a missing CLI", async () => {
+    await withExecutable("exit 0", async (binary) => {
+      const missingCwd = join(
+        tmpdir(),
+        `agent-backend-missing-cwd-${Date.now()}`,
+      )
+      const error = await Effect.runPromise(
+        withSpawner((spawner) =>
+          runCliCapture({
+            spawner,
+            backend: TEST_BACKEND,
+            binary,
+            args: [],
+            cwd: missingCwd,
+            env: sanitizeInheritedEnvironment(),
+            timeout: Duration.seconds(2),
+          }).pipe(Effect.flip),
+        ),
+      )
+      expect(error).not.toBeInstanceOf(AgentBackendNotInstalledError)
+      expect((error as { _tag?: string })._tag).toBe("PlatformError")
+    })
+  })
+})
+
+describe("runCliTurn spawn not-found", () => {
+  it("maps an ENOENT spawn failure to AgentBackendNotInstalledError", async () => {
+    const error = await Effect.runPromise(
+      runCliTurn({
+        spawner: failingSpawner(enoentPlatformError),
+        backend: TEST_BACKEND,
+        binary: "claude",
+        args: [],
+        cwd: process.cwd(),
+        env: sanitizeInheritedEnvironment(),
+        timeout: Duration.seconds(2),
+        parseLine: parseSimpleLine,
+      }).pipe(Effect.flip),
+    )
+    expect(error).toBeInstanceOf(AgentBackendNotInstalledError)
+    if (error instanceof AgentBackendNotInstalledError) {
+      expect(error.message).toContain(
+        'Claude Code CLI "claude" was not found on the Harness PATH.',
+      )
+    }
   })
 })
 

--- a/packages/claude/src/lib/claude.ts
+++ b/packages/claude/src/lib/claude.ts
@@ -97,6 +97,7 @@ export class Claude {
           // text for actionable ConfigError mapping.
           const result = yield* runCliCapture({
             spawner,
+            backend: CLAUDE_BACKEND,
             binary,
             args: ["auth", "status"],
             cwd: input.cwd,
@@ -230,6 +231,7 @@ export class Claude {
 
             const turn = yield* runCliTurn({
               spawner,
+              backend: CLAUDE_BACKEND,
               binary,
               args,
               cwd: input.cwd,

--- a/packages/claude/test/claude.spec.ts
+++ b/packages/claude/test/claude.spec.ts
@@ -8,6 +8,7 @@ import {
   AgentBackendConfigError,
   AgentBackendExitError,
   AgentBackendMalformedOutputError,
+  AgentBackendNotInstalledError,
   AgentBackendTimeoutError,
   type OnSessionId,
   PROMPT_ARGV_BYTE_LIMIT,
@@ -540,11 +541,14 @@ describe("Claude AgentBackend adapter (readiness inspection)", () => {
   it("fails inspect when the binary is missing", async () => {
     const missing = join(tmpdir(), `claude-missing-${Date.now()}`)
     const error = await Effect.runPromise(inspect(missing).pipe(Effect.flip))
-    expect(error).toBeDefined()
-    expect(error).not.toBeInstanceOf(AgentBackendConfigError)
-    expect((error as { _tag?: string })._tag).toBe("PlatformError")
-    const reason = (error as { reason?: { _tag?: string } }).reason
-    expect(reason?._tag).toBe("NotFound")
+    expect(error).toBeInstanceOf(AgentBackendNotInstalledError)
+    if (error instanceof AgentBackendNotInstalledError) {
+      expect(error.binary).toBe(missing)
+      expect(error.message).toContain(
+        `Claude Code CLI "${missing}" was not found on the Harness PATH.`,
+      )
+      expect(error.message).toContain("restart the Harness")
+    }
   })
 })
 

--- a/packages/codex/src/lib/codex.ts
+++ b/packages/codex/src/lib/codex.ts
@@ -79,6 +79,7 @@ export class Codex {
           // (exit 1) keeps text for actionable ConfigError mapping.
           const result = yield* runCliCapture({
             spawner,
+            backend: CODEX_BACKEND,
             binary,
             args: ["login", "status"],
             cwd: input.cwd,
@@ -158,6 +159,7 @@ export class Codex {
 
             const turn = yield* runCliTurn({
               spawner,
+              backend: CODEX_BACKEND,
               binary,
               args,
               cwd: input.cwd,

--- a/packages/codex/test/codex.spec.ts
+++ b/packages/codex/test/codex.spec.ts
@@ -8,6 +8,7 @@ import {
   AgentBackendConfigError,
   AgentBackendExitError,
   AgentBackendMalformedOutputError,
+  AgentBackendNotInstalledError,
   AgentBackendSessionIdMissingError,
   AgentBackendTimeoutError,
   type OnSessionId,
@@ -167,12 +168,14 @@ describe("Codex AgentBackend adapter (readiness inspection)", () => {
   it("fails inspect when the binary is missing", async () => {
     const missing = join(tmpdir(), `codex-missing-${Date.now()}`)
     const error = await Effect.runPromise(inspect(missing).pipe(Effect.flip))
-    // Spawn failure surfaces as PlatformError (NotFound) through the shared runner.
-    expect(error).toBeDefined()
-    expect(error).not.toBeInstanceOf(AgentBackendConfigError)
-    expect((error as { _tag?: string })._tag).toBe("PlatformError")
-    const reason = (error as { reason?: { _tag?: string } }).reason
-    expect(reason?._tag).toBe("NotFound")
+    expect(error).toBeInstanceOf(AgentBackendNotInstalledError)
+    if (error instanceof AgentBackendNotInstalledError) {
+      expect(error.binary).toBe(missing)
+      expect(error.message).toContain(
+        `Codex Build CLI "${missing}" was not found on the Harness PATH.`,
+      )
+      expect(error.message).toContain("restart the Harness")
+    }
   })
 })
 

--- a/packages/grok/src/lib/grok.ts
+++ b/packages/grok/src/lib/grok.ts
@@ -56,6 +56,7 @@ export class Grok {
         ) {
           const result = yield* runCliCapture({
             spawner,
+            backend: GROK_BACKEND,
             binary,
             args: ["--no-auto-update", "models"],
             cwd: input.cwd,
@@ -153,6 +154,7 @@ export class Grok {
 
               const turn = yield* runCliTurn({
                 spawner,
+                backend: GROK_BACKEND,
                 binary,
                 args,
                 cwd: input.cwd,

--- a/packages/opencode/src/lib/opencode.ts
+++ b/packages/opencode/src/lib/opencode.ts
@@ -65,6 +65,7 @@ export class Opencode {
         ) {
           const result = yield* runCliCapture({
             spawner,
+            backend: OPENCODE_BACKEND,
             binary,
             args: ["models", "--verbose"],
             cwd: input.cwd,
@@ -154,6 +155,7 @@ export class Opencode {
 
           return runCliTurn({
             spawner,
+            backend: OPENCODE_BACKEND,
             binary,
             args,
             cwd: input.cwd,

--- a/packages/work-item-lifecycle/src/lib/lifecycle-steps.ts
+++ b/packages/work-item-lifecycle/src/lib/lifecycle-steps.ts
@@ -1,6 +1,7 @@
 import { Context, type Duration, type Effect } from "effect"
 import type { PlatformError } from "effect/PlatformError"
 import type { SqlError } from "effect/unstable/sql/SqlError"
+import type { AgentBackendNotInstalledError } from "@ready-for-agent/agent-backend"
 import type {
   DatabaseError,
   RepositoryNotFoundError,
@@ -127,6 +128,7 @@ export type LifecycleStepError =
   | RepositoryNotFoundError
   | GitHubRequestError
   | GitHubTlsTrustError
+  | AgentBackendNotInstalledError
   | GitHubThrottledError
   | GitHubRepositoryUnavailableError
   | GitLabRequestError

--- a/packages/work-item-lifecycle/src/lib/work-item-lifecycle.ts
+++ b/packages/work-item-lifecycle/src/lib/work-item-lifecycle.ts
@@ -18,6 +18,7 @@ import {
   ActiveAgentBackend,
   type AgentBackendId,
   agentBackendLabel,
+  findAgentBackendNotInstalledError,
   isSelectableAgentBackendId,
 } from "@ready-for-agent/agent-backend"
 import {
@@ -245,6 +246,13 @@ const classifyHandlerFailure = (
   const errorOption = Cause.findErrorOption(cause)
   if (Option.isSome(errorOption)) {
     const error = errorOption.value
+    const notInstalled = findAgentBackendNotInstalledError(error)
+    if (notInstalled !== undefined) {
+      return {
+        reasonCode: STEP_RUN_REASON.agentBackendUnavailable,
+        reasonMessage: notInstalled.message,
+      }
+    }
     if (Predicate.isTagged(error, "TimeoutError")) {
       return {
         reasonCode: STEP_RUN_REASON.timeout,
@@ -4148,6 +4156,29 @@ export const makeWorkItemLifecycleLive = (
                     const classification = classifyHandlerFailure(
                       handlerExit.cause,
                     )
+                    const notInstalled = findAgentBackendNotInstalledError(
+                      Cause.squash(handlerExit.cause),
+                    )
+                    if (
+                      notInstalled !== undefined &&
+                      isSelectableAgentBackendId(workItem.agent_backend)
+                    ) {
+                      const inspectCwd =
+                        workItem.worktree_path !== null &&
+                        workItem.worktree_path.trim() !== ""
+                          ? workItem.worktree_path
+                          : process.cwd()
+                      yield* activeAgentBackend
+                        .recheck(workItem.agent_backend, { cwd: inspectCwd })
+                        .pipe(
+                          Effect.catchCause((recheckCause) =>
+                            Effect.logWarning(
+                              "Failed to recheck Agent Backend after CLI not found",
+                              { cause: recheckCause },
+                            ),
+                          ),
+                        )
+                    }
                     const isTimeout =
                       classification.reasonCode === STEP_RUN_REASON.timeout
                     if (

--- a/packages/work-item-lifecycle/test/agent-backend-readiness.spec.ts
+++ b/packages/work-item-lifecycle/test/agent-backend-readiness.spec.ts
@@ -1,15 +1,19 @@
 import { Effect, Layer } from "effect"
+import { systemError } from "effect/PlatformError"
 import {
   ActiveAgentBackend,
+  AgentBackendNotInstalledError,
   type AgentBackendRuntimeStatus,
   type AgentBackendStatus,
   AgentBackendUnavailableError,
+  formatAgentCliNotFoundRemediation,
   toAgentBackendStatus,
 } from "@ready-for-agent/agent-backend"
 import { DatabaseTest } from "@ready-for-agent/db/test"
 import { DbService, DbServiceLive } from "@ready-for-agent/db-service"
 import { SqliteQueueServiceLive } from "@ready-for-agent/sqlite-queue-service"
 import {
+  ImplementOpenCodeError,
   LifecycleSteps,
   type LifecycleStepsShape,
   AgentBackendUnavailableError as LifecycleUnavailableError,
@@ -264,6 +268,261 @@ describe("Agent Backend readiness gates", () => {
             STEP_RUN_REASON.agentBackendUnavailable,
           )
         }
+      }).pipe(Effect.provide(layer)),
+    )
+  })
+})
+
+const OPENCODE_BACKEND = { id: "opencode" as const, label: "OpenCode" }
+const OPENCODE_REMEDIATION = formatAgentCliNotFoundRemediation({
+  backendLabel: "OpenCode",
+  binary: "opencode",
+})
+
+const notInstalledError = () =>
+  new AgentBackendNotInstalledError({
+    message: OPENCODE_REMEDIATION,
+    backend: OPENCODE_BACKEND,
+    binary: "opencode",
+    cause: systemError({
+      _tag: "NotFound",
+      module: "ChildProcess",
+      method: "spawn",
+      cause: Object.assign(
+        new Error('Executable not found in $PATH: "opencode"'),
+        { code: "ENOENT" },
+      ),
+    }),
+  })
+
+const nonEnoentPlatformError = systemError({
+  _tag: "Busy",
+  module: "ChildProcess",
+  method: "spawn",
+  cause: Object.assign(new Error("resource temporarily unavailable"), {
+    code: "EAGAIN",
+  }),
+})
+
+const readyRuntime = (): AgentBackendRuntimeStatus => ({
+  backend: OPENCODE_BACKEND,
+  kind: "ready",
+  reason: null,
+  models: [],
+  provider: null,
+  warnings: [],
+})
+
+const cachedReadyBackendLayer = (options: {
+  readonly afterRecheck: AgentBackendRuntimeStatus
+}) => {
+  let status = readyRuntime()
+  const opencodeRegistration = {
+    descriptor: OPENCODE_BACKEND,
+    capabilities: [
+      { _tag: "SessionTelemetry" as const, supported: true },
+      { _tag: "KeymaxxerMcp" as const, supported: true },
+    ],
+  }
+  return Layer.succeed(
+    ActiveAgentBackend,
+    ActiveAgentBackend.of({
+      listStatuses: Effect.sync(() => [status]),
+      getBackendStatus: () => Effect.sync(() => status),
+      getStatus: Effect.sync(() => toAgentBackendStatus(status)),
+      setSelectedOrInUse: () => Effect.sync(() => [status]),
+      recheck: () =>
+        Effect.sync(() => {
+          status = options.afterRecheck
+          return status
+        }),
+      requireAgentTurnsAllowed: () => Effect.void,
+      activate: () => Effect.sync(() => status),
+      drop: () => Effect.void,
+      preview: () => Effect.sync(() => status),
+      withConfigCoordination: (effect) => effect,
+      getRegistration: () => Effect.succeed(opencodeRegistration),
+      getActiveRegistration: Effect.succeed(opencodeRegistration),
+      startTurn: () => Effect.die("unused"),
+      continueTurn: () => Effect.die("unused"),
+      inspectBackend: () => Effect.die("unused"),
+      getSessionTelemetry: () => Effect.die("unused"),
+    }),
+  )
+}
+
+const readinessLifecycleLayer = (
+  active: Layer.Layer<ActiveAgentBackend>,
+  steps: LifecycleStepsShape,
+) =>
+  WorkItemLifecycleLive.pipe(
+    Layer.provideMerge(active),
+    Layer.provideMerge(stubGitHubServiceLayer()),
+    Layer.provideMerge(stubGitLabServiceLayer()),
+    Layer.provideMerge(Layer.succeed(LifecycleSteps, LifecycleSteps.of(steps))),
+    Layer.provideMerge(DbServiceLive),
+    Layer.provideMerge(SqliteQueueServiceLive),
+    Layer.provideMerge(DatabaseTest),
+  )
+
+const seedReadyWorkItem = Effect.gen(function* () {
+  const db = yield* DbService
+  const lifecycle = yield* WorkItemLifecycle
+  const repo = yield* db.addRepository({
+    forge: "github",
+    forgeHost: "github.com",
+    projectPath: "acme/widgets",
+    localPath: "/repos/acme/widgets.git",
+    isBare: true,
+  })
+  yield* db.updateConfig({
+    selectedAgentBackend: "opencode",
+    defaultModel: "opencode/deepseek-v4-flash-free",
+    defaultThinkingLevel: "low",
+    reviewModel: null,
+    reviewThinkingLevel: null,
+    maxConcurrentAgentTurns: 2,
+    maxConcurrentWorkItems: 5,
+  })
+  yield* db.storeIssue({
+    repositoryId: repo.id,
+    issueNumber: 1,
+    title: "Issue",
+    body: "body",
+    url: "https://github.com/acme/widgets/issues/1",
+    state: "OPEN",
+    githubCreatedAt: new Date(),
+    issueAuthor: null,
+    parent: null,
+    parentPosition: null,
+    hasChildren: false,
+    blockedBy: [],
+  })
+  const created = yield* lifecycle.implementNow(repo.id, 1)
+  const createRun = created.stepRuns[0]
+  if (createRun === undefined) {
+    throw new Error("expected create_worktree Step Run")
+  }
+  const afterCreate = yield* lifecycle.runStep(createRun.id)
+  if (afterCreate._tag !== "processed") {
+    throw new Error("expected create_worktree to process")
+  }
+  const installRun = afterCreate.workItem.stepRuns.find(
+    (run) => run.step === "install_dependencies",
+  )
+  if (installRun === undefined) {
+    throw new Error("expected install_dependencies Step Run")
+  }
+  const afterInstall = yield* lifecycle.runStep(installRun.id)
+  if (afterInstall._tag !== "processed") {
+    throw new Error("expected install_dependencies to process")
+  }
+  const implementRun = afterInstall.workItem.stepRuns.find(
+    (run) => run.step === "implement",
+  )
+  if (implementRun === undefined) {
+    throw new Error("expected implement Step Run")
+  }
+  return { implementRunId: implementRun.id }
+})
+
+describe("Agent Backend spawn not-found classification", () => {
+  it("classifies a wrapped spawn ENOENT as agent_backend_unavailable and rechecks", async () => {
+    const unavailableAfterRecheck: AgentBackendRuntimeStatus = {
+      backend: OPENCODE_BACKEND,
+      kind: "unavailable",
+      reason: OPENCODE_REMEDIATION,
+      models: [],
+      provider: null,
+      warnings: [],
+    }
+    const steps: LifecycleStepsShape = {
+      ...successfulSteps,
+      implement: () =>
+        Effect.fail(
+          new ImplementOpenCodeError({
+            message: "OpenCode failed to implement the Work Item issue",
+            worktreePath: "/tmp/worktrees/acme-widgets-42",
+            cause: notInstalledError(),
+          }),
+        ),
+    }
+    const layer = readinessLifecycleLayer(
+      cachedReadyBackendLayer({ afterRecheck: unavailableAfterRecheck }),
+      steps,
+    )
+
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        const lifecycle = yield* WorkItemLifecycle
+        const seeded = yield* seedReadyWorkItem
+        const result = yield* lifecycle.runStep(seeded.implementRunId)
+        expect(result._tag).toBe("processed")
+        if (result._tag !== "processed") {
+          return
+        }
+        expect(result.workItem.state).toBe("implement")
+        const failed = result.workItem.stepRuns.find(
+          (run) => run.id === seeded.implementRunId,
+        )
+        expect(failed?.status).toBe("failed")
+        expect(failed?.reasonCode).toBe(STEP_RUN_REASON.agentBackendUnavailable)
+        expect(failed?.reasonMessage).toBe(OPENCODE_REMEDIATION)
+        const active = yield* ActiveAgentBackend
+        const status = yield* active.getBackendStatus("opencode")
+        expect(status?.kind).toBe("unavailable")
+        expect(status?.reason).toBe(OPENCODE_REMEDIATION)
+      }).pipe(Effect.provide(layer)),
+    )
+  })
+
+  it("keeps a non-ENOENT PlatformError as handler_failed and does not recheck", async () => {
+    const steps: LifecycleStepsShape = {
+      ...successfulSteps,
+      implement: () =>
+        Effect.fail(
+          new ImplementOpenCodeError({
+            message: "OpenCode failed to implement the Work Item issue",
+            worktreePath: "/tmp/worktrees/acme-widgets-42",
+            cause: nonEnoentPlatformError,
+          }),
+        ),
+    }
+    const layer = readinessLifecycleLayer(
+      cachedReadyBackendLayer({
+        afterRecheck: {
+          backend: OPENCODE_BACKEND,
+          kind: "unavailable",
+          reason: "should not flip",
+          models: [],
+          provider: null,
+          warnings: [],
+        },
+      }),
+      steps,
+    )
+
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        const lifecycle = yield* WorkItemLifecycle
+        const seeded = yield* seedReadyWorkItem
+        const result = yield* lifecycle.runStep(seeded.implementRunId)
+        expect(result._tag).toBe("processed")
+        if (result._tag !== "processed") {
+          return
+        }
+        expect(result.workItem.state).toBe("implement")
+        const failed = result.workItem.stepRuns.find(
+          (run) => run.id === seeded.implementRunId,
+        )
+        expect(failed?.status).toBe("failed")
+        expect(failed?.reasonCode).toBe(STEP_RUN_REASON.handlerFailed)
+        expect(failed?.reasonMessage).toBe(
+          "OpenCode failed to implement the Work Item issue",
+        )
+        const active = yield* ActiveAgentBackend
+        const status = yield* active.getBackendStatus("opencode")
+        expect(status?.kind).toBe("ready")
       }).pipe(Effect.provide(layer)),
     )
   })


### PR DESCRIPTION
A relocated Agent Backend CLI (for example `claude` leaving PATH after a
mise reinstall) failed Step Runs in about a second with generic handler
copy. Settings still showed Ready because Active status is cached at
activation. The ENOENT cause lived only in `reason_detail`.

This maps ChildProcess spawn ENOENT to `AgentBackendNotInstalledError`
at `runCliCapture` and `runCliTurn` only — not later stream/IO, and not
FileSystem cwd access. `classifyHandlerFailure` walks the wrapped cause
chain and records `agent_backend_unavailable` with Harness-restart
remediation. Recheck then flips cached Ready to Unavailable so later
steps fail at the existing pre-flight gate. The Work Item stays in its
operational state so Retry remains available after a Harness restart.

Review follow-up: missing worktree cwd stays `handler_failed`; recheck
is isolated so a defect cannot skip step-failure completion.

Verified with agent-backend CLI/ENOENT tests (including missing cwd),
the work-item-lifecycle readiness suite, and adapter tests for Claude,
Codex, Grok, and OpenCode. Lint and typecheck on the touched packages.
Deliberately no PATH repair or auto-recovery.

Closes #1023