### PR TITLE
feat(cli): continue a Work Item Session in a tmux split

### DIFF
--- a/apps/harness/e2e/support/first-run-settings.ts
+++ b/apps/harness/e2e/support/first-run-settings.ts
@@ -293,14 +293,14 @@ export const completeAndSaveFirstRunSettings = async (page: Page) => {
   let selectedModel: string | null = null
   for (const backendId of backendIds) {
     await backendSelect.selectOption(backendId)
-    // Backend change may re-load the model catalog via preview.
-    await expect(dialog.getByText("Loading settings...")).toHaveCount(0, {
-      timeout: 30_000,
-    })
-    await expect(dialog.getByText("Loading catalog…")).toHaveCount(0, {
-      timeout: 30_000,
-    })
     try {
+      // Settings fetch can briefly overlay; do not wait on "Loading catalog…"
+      // text — that string is the empty option label on both Build and Review
+      // selects while preview is in flight, and a failed OpenCode inspect
+      // leaves both visible forever.
+      await expect(dialog.getByText("Loading settings...")).toHaveCount(0, {
+        timeout: 15_000,
+      })
       await expect
         .poll(() => countRealSelectValues(modelSelect), {
           timeout: 15_000,

--- a/apps/harness/e2e/support/first-run-settings.ts
+++ b/apps/harness/e2e/support/first-run-settings.ts
@@ -38,6 +38,20 @@ export const resolveDefaultBuildModelFromCatalog = (input: {
   return { kind: "configure", modelId }
 }
 
+/**
+ * First-run Save still prefers OpenCode when listed, then tries the other
+ * backends so an unauthenticated / inspect-failed OpenCode does not stall
+ * on an empty catalog (CI ui-history).
+ */
+export const preferredFirstRunBackendIds = (
+  backendIds: readonly string[],
+): readonly string[] => {
+  const available = backendIds.filter((id) => id.length > 0)
+  const preferred = available.filter((id) => id === "opencode")
+  const rest = available.filter((id) => id !== "opencode")
+  return [...preferred, ...rest]
+}
+
 const restoreFakeClaudeFirstParty = async (): Promise<void> => {
   const state = readLiveHarnessState()
   writeControlFile(state, CONTROL_FILES.claudeMode, "firstParty")
@@ -231,10 +245,29 @@ export const dismissFirstRunSettingsIfPresent = async (page: Page) => {
   await expect(dialog).toBeHidden()
 }
 
+const listedSelectValues = async (
+  select: ReturnType<Page["locator"]>,
+): Promise<readonly string[]> => {
+  const options = select.locator("option")
+  const count = await options.count()
+  const values: string[] = []
+  for (let i = 0; i < count; i += 1) {
+    const value = await options.nth(i).getAttribute("value")
+    if (value != null && value.length > 0) {
+      values.push(value)
+    }
+  }
+  return values
+}
+
+const countRealSelectValues = async (
+  select: ReturnType<Page["locator"]>,
+): Promise<number> => (await listedSelectValues(select)).length
+
 /**
  * Complete first-run settings: prefer OpenCode when listed (shared e2e
- * default), otherwise keep the current backend; pick a build model from the
- * live catalog; Save.
+ * default), then fall back to another listed backend whose catalog has a
+ * build model; pick that model; Save.
  */
 export const completeAndSaveFirstRunSettings = async (page: Page) => {
   const dialog = settingsDialog(page)
@@ -251,59 +284,34 @@ export const completeAndSaveFirstRunSettings = async (page: Page) => {
     })
     .toBeGreaterThan(0)
 
-  // Prefer opencode (usual harness default) when present so a prior first-run
-  // reset that switched backends does not leave the suite on an alternate.
-  const opencodeOption = backendSelect.locator('option[value="opencode"]')
-  if ((await opencodeOption.count()) > 0) {
-    await backendSelect.selectOption("opencode")
-  } else {
-    const current = await backendSelect.inputValue()
-    if (current.length === 0) {
-      const firstValue = await backendSelect
-        .locator("option")
-        .first()
-        .getAttribute("value")
-      if (firstValue != null && firstValue.length > 0) {
-        await backendSelect.selectOption(firstValue)
-      }
-    }
-  }
-
-  // Backend change may re-load the model catalog via preview.
-  await expect(dialog.getByText("Loading settings...")).toHaveCount(0, {
-    timeout: 30_000,
-  })
-  await expect(dialog.getByText("Loading catalog…")).toHaveCount(0, {
-    timeout: 30_000,
-  })
-
   const modelSelect = dialog.locator('select[name="defaultModel"]')
   await expect(modelSelect).toBeVisible()
-  // Wait until catalog options exist beyond the empty placeholder.
-  await expect
-    .poll(
-      async () => {
-        const options = modelSelect.locator("option")
-        const count = await options.count()
-        if (count === 0) return 0
-        let real = 0
-        for (let i = 0; i < count; i += 1) {
-          const value = await options.nth(i).getAttribute("value")
-          if (value != null && value.length > 0) real += 1
-        }
-        return real
-      },
-      { timeout: 60_000 },
-    )
-    .toBeGreaterThan(0)
 
-  const modelOptions = modelSelect.locator("option")
-  const modelCount = await modelOptions.count()
+  const backendIds = preferredFirstRunBackendIds(
+    await listedSelectValues(backendSelect),
+  )
   let selectedModel: string | null = null
-  for (let i = 0; i < modelCount; i += 1) {
-    const value = await modelOptions.nth(i).getAttribute("value")
-    if (value != null && value.length > 0) {
-      selectedModel = value
+  for (const backendId of backendIds) {
+    await backendSelect.selectOption(backendId)
+    // Backend change may re-load the model catalog via preview.
+    await expect(dialog.getByText("Loading settings...")).toHaveCount(0, {
+      timeout: 30_000,
+    })
+    await expect(dialog.getByText("Loading catalog…")).toHaveCount(0, {
+      timeout: 30_000,
+    })
+    try {
+      await expect
+        .poll(() => countRealSelectValues(modelSelect), {
+          timeout: 15_000,
+        })
+        .toBeGreaterThan(0)
+    } catch {
+      continue
+    }
+    const catalog = await listedSelectValues(modelSelect)
+    selectedModel = catalog[0] ?? null
+    if (selectedModel !== null) {
       break
     }
   }

--- a/apps/harness/test/first-run-settings-catalog.test.ts
+++ b/apps/harness/test/first-run-settings-catalog.test.ts
@@ -1,4 +1,7 @@
-import { resolveDefaultBuildModelFromCatalog } from "../e2e/support/first-run-settings.ts"
+import {
+  preferredFirstRunBackendIds,
+  resolveDefaultBuildModelFromCatalog,
+} from "../e2e/support/first-run-settings.ts"
 import { describe, expect, test } from "bun:test"
 
 describe("resolveDefaultBuildModelFromCatalog", () => {
@@ -42,5 +45,26 @@ describe("resolveDefaultBuildModelFromCatalog", () => {
         models: [{ id: "" }],
       }),
     ).toEqual({ kind: "empty-catalog" })
+  })
+})
+
+describe("preferredFirstRunBackendIds", () => {
+  test("tries OpenCode first when it is listed, then the remaining backends", () => {
+    expect(preferredFirstRunBackendIds(["claude", "opencode", "grok"])).toEqual(
+      ["opencode", "claude", "grok"],
+    )
+  })
+
+  test("keeps listed order when OpenCode is absent", () => {
+    expect(preferredFirstRunBackendIds(["claude", "grok"])).toEqual([
+      "claude",
+      "grok",
+    ])
+  })
+
+  test("drops empty option values", () => {
+    expect(preferredFirstRunBackendIds(["", "opencode", ""])).toEqual([
+      "opencode",
+    ])
   })
 })

--- a/apps/ready-for-agent/src/cli-process.test.ts
+++ b/apps/ready-for-agent/src/cli-process.test.ts
@@ -7,10 +7,17 @@
  */
 
 import { spawn, spawnSync } from "node:child_process"
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs"
+import {
+  chmodSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs"
 import { type Server, createServer } from "node:http"
 import { tmpdir } from "node:os"
-import { join } from "node:path"
+import { dirname, join, resolve } from "node:path"
 import { fileURLToPath } from "node:url"
 import {
   CLI_SCHEMA_VERSION,
@@ -85,20 +92,26 @@ type ProcessResult = {
 const runCli = (
   args: readonly string[],
   graphqlUrl: string,
+  extraEnv: NodeJS.ProcessEnv = {},
 ): Promise<ProcessResult> =>
   new Promise((resolve, reject) => {
+    const env: NodeJS.ProcessEnv = {
+      ...process.env,
+      READY_FOR_AGENT_GRAPHQL_URL: graphqlUrl,
+      // Keep CLI error JSON free of ANSI so process contracts stay exact.
+      NO_COLOR: "1",
+      FORCE_COLOR: "0",
+      ...extraEnv,
+    }
+    if (!("TMUX" in extraEnv)) {
+      delete env.TMUX
+    }
     const child = spawn(
       "bun",
       ["--conditions", "@ready-for-agent/source", "src/main.ts", ...args],
       {
         cwd: packageRoot,
-        env: {
-          ...process.env,
-          READY_FOR_AGENT_GRAPHQL_URL: graphqlUrl,
-          // Keep CLI error JSON free of ANSI so process contracts stay exact.
-          NO_COLOR: "1",
-          FORCE_COLOR: "0",
-        },
+        env,
       },
     )
     let stdout = ""
@@ -967,6 +980,395 @@ describe("operator binary finite-command process contract", () => {
       expect(result.stderr).not.toContain("GRAPHQL_ERROR")
     } finally {
       await closeServer(server)
+    }
+  })
+})
+
+const jumpSessionId = "85312e9f-9c57-42ef-9757-b2512cee57cd"
+
+const writeExecutable = (path: string, body: string): void => {
+  writeFileSync(path, body, { encoding: "utf8" })
+  chmodSync(path, 0o755)
+}
+
+const parseTmuxArgvLog = (logPath: string): readonly (readonly string[])[] => {
+  const text = readFileSync(logPath, "utf8").trim()
+  if (text.length === 0) {
+    return []
+  }
+  return text.split("\n").map((line) => JSON.parse(line) as string[])
+}
+
+const startJumpGraphqlServer = (options: {
+  readonly backendId?: string
+  readonly worktreePath?: string | null
+  readonly error?: { readonly code: string; readonly message: string }
+}): Promise<{
+  readonly url: string
+  readonly seenBodies: string[]
+  readonly close: () => Promise<void>
+}> =>
+  new Promise((resolve, reject) => {
+    const seenBodies: string[] = []
+    const server = createServer((req, res) => {
+      if (req.method !== "POST") {
+        res.writeHead(405)
+        res.end()
+        return
+      }
+      const chunks: Buffer[] = []
+      req.on("data", (chunk: Buffer) => {
+        chunks.push(chunk)
+      })
+      req.on("end", () => {
+        seenBodies.push(Buffer.concat(chunks).toString("utf8"))
+        res.writeHead(200, { "content-type": "application/json" })
+        if (options.error !== undefined) {
+          res.end(
+            JSON.stringify({
+              data: null,
+              errors: [
+                {
+                  message: options.error.message,
+                  extensions: { code: options.error.code },
+                },
+              ],
+            }),
+          )
+          return
+        }
+        res.end(
+          JSON.stringify({
+            data: {
+              workItemBySessionId: {
+                agentBackend: {
+                  id: options.backendId ?? "opencode",
+                  label: options.backendId ?? "OpenCode",
+                },
+                sessionId: jumpSessionId,
+                worktreePath: options.worktreePath ?? null,
+              },
+            },
+          }),
+        )
+      })
+    })
+    listen(server)
+      .then((port) => {
+        resolve({
+          url: `http://127.0.0.1:${port}/graphql`,
+          seenBodies,
+          close: () => closeServer(server),
+        })
+      })
+      .catch(reject)
+  })
+
+describe("operator binary jump process contract", () => {
+  let tempRoot = ""
+  let binDir = ""
+  let tmuxLog = ""
+
+  beforeEach(() => {
+    tempRoot = mkdtempSync(join(tmpdir(), "ready-for-agent-jump-process-"))
+    binDir = join(tempRoot, "bin")
+    mkdirSync(binDir)
+    tmuxLog = join(tempRoot, "tmux-argv.log")
+    writeFileSync(tmuxLog, "")
+    writeExecutable(
+      join(binDir, "tmux"),
+      `#!/usr/bin/env bun
+import { appendFileSync } from "node:fs"
+appendFileSync(process.env.TMUX_ARGV_LOG ?? "", JSON.stringify(process.argv.slice(2)) + "\\n")
+if (process.env.TMUX_FAIL === "1") {
+  process.exit(1)
+}
+if (process.argv.includes("new-window")) {
+  process.stdout.write("@1 %1\\n")
+}
+`,
+    )
+    for (const name of ["opencode", "grok", "codex", "claude"] as const) {
+      writeExecutable(join(binDir, name), "#!/usr/bin/env bash\nexit 0\n")
+    }
+  })
+
+  afterEach(() => {
+    rmSync(tempRoot, { recursive: true, force: true })
+  })
+
+  const jumpEnv = (overrides: NodeJS.ProcessEnv = {}): NodeJS.ProcessEnv => ({
+    PATH: `${binDir}:${process.env.PATH ?? ""}`,
+    TMUX: "/tmp/tmux-1000/default,123,0",
+    TMUX_ARGV_LOG: tmuxLog,
+    ...overrides,
+  })
+
+  test("jump outside tmux writes a text error and does not invoke tmux", async () => {
+    const result = await runCli(
+      ["jump", jumpSessionId],
+      "http://127.0.0.1:1/graphql",
+    )
+
+    expect(result.status).toBe(1)
+    expect(result.stdout.trim()).toBe("")
+    expect(result.stderr.trim()).toBe(
+      "jump must be run from inside a tmux session",
+    )
+    expect(result.stderr).not.toContain("schemaVersion")
+    expect(result.stderr).not.toMatch(/\s+at\s+\S+\s+\(/)
+    expect(parseTmuxArgvLog(tmuxLog)).toEqual([])
+  })
+
+  test("jump against unreachable GraphQL writes text, not JSON", async () => {
+    const result = await runCli(
+      ["jump", jumpSessionId],
+      "http://127.0.0.1:1/graphql",
+      jumpEnv(),
+    )
+
+    expect(result.status).toBe(1)
+    expect(result.stdout.trim()).toBe("")
+    expect(result.stderr).toContain(
+      harnessNotRunningMessage("http://127.0.0.1:1"),
+    )
+    expect(result.stderr).not.toContain("schemaVersion")
+    expect(result.stderr).not.toContain("HARNESS_UNREACHABLE")
+    expect(result.stderr).not.toMatch(/\s+at\s+\S+\s+\(/)
+    expect(parseTmuxArgvLog(tmuxLog)).toEqual([])
+  })
+
+  test("jump writes the Session-not-found GraphQL message", async () => {
+    const graphql = await startJumpGraphqlServer({
+      error: {
+        code: "SESSION_NOT_FOUND",
+        message: `No Work Item owns Session ID: ${jumpSessionId}`,
+      },
+    })
+    try {
+      const result = await runCli(
+        ["jump", jumpSessionId],
+        graphql.url,
+        jumpEnv(),
+      )
+
+      expect(result.status).toBe(1)
+      expect(result.stdout.trim()).toBe("")
+      expect(result.stderr.trim()).toBe(
+        `No Work Item owns Session ID: ${jumpSessionId}`,
+      )
+      expect(
+        graphql.seenBodies.some((body) => body.includes("workItemBySessionId")),
+      ).toBe(true)
+      expect(parseTmuxArgvLog(tmuxLog)).toEqual([])
+    } finally {
+      await graphql.close()
+    }
+  })
+
+  test("jump writes the ambiguous-Session GraphQL message", async () => {
+    const graphql = await startJumpGraphqlServer({
+      error: {
+        code: "SESSION_AMBIGUOUS",
+        message: `Multiple Work Items own Session ID: ${jumpSessionId}`,
+      },
+    })
+    try {
+      const result = await runCli(
+        ["jump", jumpSessionId],
+        graphql.url,
+        jumpEnv(),
+      )
+
+      expect(result.status).toBe(1)
+      expect(result.stderr.trim()).toBe(
+        `Multiple Work Items own Session ID: ${jumpSessionId}`,
+      )
+    } finally {
+      await graphql.close()
+    }
+  })
+
+  test("jump fails when the captured Agent Backend is unsupported", async () => {
+    const graphql = await startJumpGraphqlServer({
+      backendId: "mystery",
+      worktreePath: null,
+    })
+    try {
+      const result = await runCli(
+        ["jump", jumpSessionId],
+        graphql.url,
+        jumpEnv(),
+      )
+
+      expect(result.status).toBe(1)
+      expect(result.stderr.trim()).toBe("Unsupported Agent Backend: mystery")
+      expect(parseTmuxArgvLog(tmuxLog)).toEqual([])
+    } finally {
+      await graphql.close()
+    }
+  })
+
+  test("jump fails when the backend executable is not on PATH", async () => {
+    const graphql = await startJumpGraphqlServer({
+      backendId: "opencode",
+      worktreePath: null,
+    })
+    try {
+      const emptyBin = join(tempRoot, "empty-bin")
+      mkdirSync(emptyBin)
+      const bunDir = dirname(Bun.which("bun") ?? "/usr/bin/bun")
+      const result = await runCli(["jump", jumpSessionId], graphql.url, {
+        PATH: `${emptyBin}:${bunDir}`,
+        TMUX: "/tmp/tmux-1000/default,123,0",
+        TMUX_ARGV_LOG: tmuxLog,
+      })
+
+      expect(result.status).toBe(1)
+      expect(result.stderr.trim()).toBe(
+        "Agent Backend executable 'opencode' is not on PATH",
+      )
+      expect(parseTmuxArgvLog(tmuxLog)).toEqual([])
+    } finally {
+      await graphql.close()
+    }
+  })
+
+  test("jump fails when tmux cannot create the window", async () => {
+    const graphql = await startJumpGraphqlServer({
+      backendId: "opencode",
+      worktreePath: null,
+    })
+    try {
+      const result = await runCli(
+        ["jump", jumpSessionId],
+        graphql.url,
+        jumpEnv({ TMUX_FAIL: "1" }),
+      )
+
+      expect(result.status).toBe(1)
+      expect(result.stdout.trim()).toBe("")
+      expect(result.stderr).toContain(
+        "tmux could not create and arrange the window",
+      )
+    } finally {
+      await graphql.close()
+    }
+  })
+
+  test("jump creates an even split with the resolved OpenCode executable", async () => {
+    const worktree = join(tempRoot, "worktree")
+    mkdirSync(worktree)
+    const graphql = await startJumpGraphqlServer({
+      backendId: "opencode",
+      worktreePath: worktree,
+    })
+    try {
+      const result = await runCli(
+        ["jump", jumpSessionId],
+        graphql.url,
+        jumpEnv(),
+      )
+
+      expect(result.status).toBe(0)
+      expect(result.stdout.trim()).toBe("")
+      expect(result.stderr.trim()).toBe("")
+      const invocations = parseTmuxArgvLog(tmuxLog)
+      const opencode = join(binDir, "opencode")
+      expect(invocations).toEqual([
+        [
+          "new-window",
+          "-d",
+          "-P",
+          "-F",
+          "#{window_id} #{pane_id}",
+          "-c",
+          worktree,
+          "--",
+          opencode,
+          worktree,
+          "--session",
+          jumpSessionId,
+        ],
+        ["split-window", "-h", "-t", "@1", "-c", worktree],
+        ["select-layout", "-t", "@1", "even-horizontal"],
+        ["select-pane", "-t", "%1"],
+        ["select-window", "-t", "@1"],
+      ])
+    } finally {
+      await graphql.close()
+    }
+  })
+
+  test("jump uses the CLI cwd when the worktree is gone", async () => {
+    const graphql = await startJumpGraphqlServer({
+      backendId: "claude",
+      worktreePath: join(tempRoot, "cleaned-up-worktree"),
+    })
+    try {
+      const result = await runCli(
+        ["jump", jumpSessionId],
+        graphql.url,
+        jumpEnv(),
+      )
+
+      expect(result.status).toBe(0)
+      const invocations = parseTmuxArgvLog(tmuxLog)
+      const claude = join(binDir, "claude")
+      const cliCwd = resolve(packageRoot)
+      expect(invocations[0]).toEqual([
+        "new-window",
+        "-d",
+        "-P",
+        "-F",
+        "#{window_id} #{pane_id}",
+        "-c",
+        cliCwd,
+        "--",
+        claude,
+        "--resume",
+        jumpSessionId,
+      ])
+      expect(invocations[1]).toEqual([
+        "split-window",
+        "-h",
+        "-t",
+        "@1",
+        "-c",
+        cliCwd,
+      ])
+    } finally {
+      await graphql.close()
+    }
+  })
+
+  test("jump launches Grok and Codex interactive resume commands", async () => {
+    const worktree = join(tempRoot, "backend-wt")
+    mkdirSync(worktree)
+    for (const [backendId, expectedTail] of [
+      ["grok", ["--cwd", worktree, "--resume", jumpSessionId]],
+      ["codex", ["resume", "-C", worktree, jumpSessionId]],
+    ] as const) {
+      writeFileSync(tmuxLog, "")
+      const graphql = await startJumpGraphqlServer({
+        backendId,
+        worktreePath: worktree,
+      })
+      try {
+        const result = await runCli(
+          ["jump", jumpSessionId],
+          graphql.url,
+          jumpEnv(),
+        )
+        expect(result.status).toBe(0)
+        const invocations = parseTmuxArgvLog(tmuxLog)
+        expect(invocations[0]?.slice(8)).toEqual([
+          join(binDir, backendId),
+          ...expectedTail,
+        ])
+      } finally {
+        await graphql.close()
+      }
     }
   })
 })

--- a/apps/ready-for-agent/src/cli.test.ts
+++ b/apps/ready-for-agent/src/cli.test.ts
@@ -1,4 +1,7 @@
 import { spawnSync } from "node:child_process"
+import { mkdirSync, mkdtempSync, rmSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
 import { fileURLToPath } from "node:url"
 import { BunServices } from "@effect/platform-bun"
 import { beforeEach, describe, expect, it } from "@effect/vitest"
@@ -20,12 +23,19 @@ import {
   HARNESS_UNREACHABLE_CODE,
   harnessNotRunningMessage,
 } from "./graphql-error.ts"
-import { GraphqlApi, GraphqlRequestFailed } from "./services/graphql-api.ts"
+import { JumpFailed } from "./jump-error.ts"
+import { ExecutablePath } from "./services/executable-path.ts"
+import {
+  GraphqlApi,
+  GraphqlRequestFailed,
+  type SessionWorkItemLookup,
+} from "./services/graphql-api.ts"
 import { LocalGit } from "./services/local-git.ts"
 import {
   StartHarness,
   type StartHarnessOptions,
 } from "./services/start-harness.ts"
+import { type JumpWindowInput, Tmux } from "./services/tmux.ts"
 
 /** Package root (`apps/ready-for-agent`), independent of Bun's `import.meta.dir`. */
 const packageRoot = fileURLToPath(new URL("..", import.meta.url))
@@ -37,7 +47,18 @@ const unusedGraphql = {
   startRepositoryIntake: () =>
     Effect.die("startRepositoryIntake should not run"),
   kanbanStatus: () => Effect.die("kanbanStatus should not run"),
+  workItemBySessionId: () => Effect.die("workItemBySessionId should not run"),
 } as const
+
+const unusedJumpServices = Layer.mergeAll(
+  Layer.succeed(Tmux, {
+    requireAttachedSession: Effect.die("tmux should not run"),
+    createJumpWindow: () => Effect.die("tmux should not run"),
+  }),
+  Layer.succeed(ExecutablePath, {
+    resolve: () => Effect.die("executable path should not run"),
+  }),
+)
 
 const emptyStatusLanes = [
   { id: "QUEUE" as const, label: "Queue", count: 0, workItems: [] },
@@ -55,6 +76,7 @@ const runOperator = (
   // Mirror main.ts: expand bare `--host` before Effect's string flag parser.
   Command.runWith(cli, { version: "0.0.0" })(expandBareHostFlag(args)).pipe(
     Effect.provide(layer),
+    Effect.provide(unusedJumpServices),
     Effect.provide(BunServices.layer),
   )
 
@@ -1062,7 +1084,7 @@ describe("operator binary CLI seam", () => {
     }),
   )
 
-  it("binary help lists start, add, candidates, intake, status, --no-open, and --host", () => {
+  it("binary help lists start, add, candidates, intake, status, jump, --no-open, and --host", () => {
     const result = spawnSync(
       "bun",
       ["--conditions", "@ready-for-agent/source", "src/main.ts", "--help"],
@@ -1079,6 +1101,7 @@ describe("operator binary CLI seam", () => {
     expect(output).toContain("candidates")
     expect(output).toContain("intake")
     expect(output).toContain("status")
+    expect(output).toContain("jump")
     expect(output).not.toContain("remove-github-token")
     expect(output).toContain("no-open")
     expect(output).toContain("host")
@@ -1136,6 +1159,377 @@ describe("operator binary CLI seam", () => {
         noOpen: true,
         host: "0.0.0.0",
       })
+    }),
+  )
+})
+
+describe("operator binary jump command", () => {
+  const sessionId = "85312e9f-9c57-42ef-9757-b2512cee57cd"
+  const mockStart = Layer.succeed(StartHarness, {
+    start: () => Effect.die("start should not run for jump"),
+  })
+  const mockLocalGit = Layer.succeed(LocalGit, {
+    inspect: () => Effect.die("local git should not run for jump"),
+  })
+
+  const jumpGraphql = (
+    workItemBySessionId: (
+      sessionId: string,
+    ) => Effect.Effect<SessionWorkItemLookup, GraphqlRequestFailed>,
+  ) =>
+    Layer.succeed(GraphqlApi, {
+      ...unusedGraphql,
+      workItemBySessionId,
+    })
+
+  const foundWorkItem = (options: {
+    readonly backendId: string
+    readonly worktreePath: string | null
+    readonly sessionId?: string
+  }) => ({
+    agentBackend: { id: options.backendId, label: options.backendId },
+    sessionId: options.sessionId ?? sessionId,
+    worktreePath: options.worktreePath,
+  })
+
+  const successfulJumpLayer = (options: {
+    readonly workItemBySessionId?: (
+      id: string,
+    ) => Effect.Effect<SessionWorkItemLookup, GraphqlRequestFailed>
+    readonly requireAttachedSession?: Effect.Effect<void, JumpFailed>
+    readonly createJumpWindow?: (
+      input: JumpWindowInput,
+    ) => Effect.Effect<void, JumpFailed>
+    readonly resolve?: (command: string) => Effect.Effect<string, JumpFailed>
+  }) =>
+    mockStart.pipe(
+      Layer.provideMerge(mockLocalGit),
+      Layer.provideMerge(
+        jumpGraphql(
+          options.workItemBySessionId ??
+            (() =>
+              Effect.succeed(
+                foundWorkItem({
+                  backendId: "opencode",
+                  worktreePath: null,
+                }),
+              )),
+        ),
+      ),
+      Layer.provideMerge(
+        Layer.succeed(Tmux, {
+          requireAttachedSession: options.requireAttachedSession ?? Effect.void,
+          createJumpWindow: options.createJumpWindow ?? (() => Effect.void),
+        }),
+      ),
+      Layer.provideMerge(
+        Layer.succeed(ExecutablePath, {
+          resolve:
+            options.resolve ??
+            ((command) => Effect.succeed(`/usr/bin/${command}`)),
+        }),
+      ),
+    )
+
+  it.live("jump looks up the Session ID through GraphQL", () =>
+    Effect.gen(function* () {
+      let requested: string | undefined
+      yield* runOperator(
+        ["jump", sessionId],
+        successfulJumpLayer({
+          workItemBySessionId: (id) => {
+            requested = id
+            return Effect.succeed(
+              foundWorkItem({ backendId: "opencode", worktreePath: null }),
+            )
+          },
+        }),
+      )
+      expect(requested).toBe(sessionId)
+    }),
+  )
+
+  it.live("jump fails when invoked outside tmux", () =>
+    Effect.gen(function* () {
+      let lookedUp = false
+      const result = yield* runOperator(
+        ["jump", sessionId],
+        successfulJumpLayer({
+          requireAttachedSession: Effect.fail(
+            new JumpFailed({
+              message: "jump must be run from inside a tmux session",
+            }),
+          ),
+          workItemBySessionId: () => {
+            lookedUp = true
+            return Effect.die("GraphQL should not run outside tmux")
+          },
+        }),
+      ).pipe(Effect.flip)
+
+      expect(lookedUp).toBe(false)
+      expect(result).toBeInstanceOf(JumpFailed)
+      if (result instanceof JumpFailed) {
+        expect(result.message).toBe(
+          "jump must be run from inside a tmux session",
+        )
+      }
+    }),
+  )
+
+  it.live("jump fails when the Harness is unreachable", () =>
+    Effect.gen(function* () {
+      const harnessDown = harnessNotRunningMessage()
+      let created = false
+      const result = yield* runOperator(
+        ["jump", sessionId],
+        successfulJumpLayer({
+          workItemBySessionId: () =>
+            Effect.fail(
+              new GraphqlRequestFailed({
+                code: HARNESS_UNREACHABLE_CODE,
+                message: harnessDown,
+              }),
+            ),
+          createJumpWindow: () => {
+            created = true
+            return Effect.void
+          },
+        }),
+      ).pipe(Effect.flip)
+
+      expect(created).toBe(false)
+      expect(result).toBeInstanceOf(JumpFailed)
+      if (result instanceof JumpFailed) {
+        expect(result.message).toBe(harnessDown)
+        expect(result.message).toContain(HARNESS_START_HINT)
+      }
+    }),
+  )
+
+  it.live("jump fails when no Work Item owns the Session ID", () =>
+    Effect.gen(function* () {
+      const result = yield* runOperator(
+        ["jump", sessionId],
+        successfulJumpLayer({
+          workItemBySessionId: () =>
+            Effect.fail(
+              new GraphqlRequestFailed({
+                code: "SESSION_NOT_FOUND",
+                message: `No Work Item owns Session ID: ${sessionId}`,
+              }),
+            ),
+        }),
+      ).pipe(Effect.flip)
+
+      expect(result).toBeInstanceOf(JumpFailed)
+      if (result instanceof JumpFailed) {
+        expect(result.message).toBe(
+          `No Work Item owns Session ID: ${sessionId}`,
+        )
+      }
+    }),
+  )
+
+  it.live("jump fails when multiple Work Items own the Session ID", () =>
+    Effect.gen(function* () {
+      const result = yield* runOperator(
+        ["jump", sessionId],
+        successfulJumpLayer({
+          workItemBySessionId: () =>
+            Effect.fail(
+              new GraphqlRequestFailed({
+                code: "SESSION_AMBIGUOUS",
+                message: `Multiple Work Items own Session ID: ${sessionId}`,
+              }),
+            ),
+        }),
+      ).pipe(Effect.flip)
+
+      expect(result).toBeInstanceOf(JumpFailed)
+      if (result instanceof JumpFailed) {
+        expect(result.message).toBe(
+          `Multiple Work Items own Session ID: ${sessionId}`,
+        )
+      }
+    }),
+  )
+
+  it.live("jump fails when the captured Agent Backend is unsupported", () =>
+    Effect.gen(function* () {
+      let resolved: string | undefined
+      const result = yield* runOperator(
+        ["jump", sessionId],
+        successfulJumpLayer({
+          workItemBySessionId: () =>
+            Effect.succeed(
+              foundWorkItem({
+                backendId: "unknown-backend",
+                worktreePath: null,
+              }),
+            ),
+          resolve: (command) => {
+            resolved = command
+            return Effect.succeed(`/usr/bin/${command}`)
+          },
+        }),
+      ).pipe(Effect.flip)
+
+      expect(resolved).toBeUndefined()
+      expect(result).toBeInstanceOf(JumpFailed)
+      if (result instanceof JumpFailed) {
+        expect(result.message).toBe(
+          "Unsupported Agent Backend: unknown-backend",
+        )
+      }
+    }),
+  )
+
+  it.live("jump fails when the backend executable is not on PATH", () =>
+    Effect.gen(function* () {
+      let created = false
+      const result = yield* runOperator(
+        ["jump", sessionId],
+        successfulJumpLayer({
+          resolve: (command) =>
+            Effect.fail(
+              new JumpFailed({
+                message: `Agent Backend executable '${command}' is not on PATH`,
+              }),
+            ),
+          createJumpWindow: () => {
+            created = true
+            return Effect.void
+          },
+        }),
+      ).pipe(Effect.flip)
+
+      expect(created).toBe(false)
+      expect(result).toBeInstanceOf(JumpFailed)
+      if (result instanceof JumpFailed) {
+        expect(result.message).toBe(
+          "Agent Backend executable 'opencode' is not on PATH",
+        )
+      }
+    }),
+  )
+
+  it.live("jump fails when tmux cannot create the window", () =>
+    Effect.gen(function* () {
+      const result = yield* runOperator(
+        ["jump", sessionId],
+        successfulJumpLayer({
+          createJumpWindow: () =>
+            Effect.fail(
+              new JumpFailed({
+                message: "tmux could not create and arrange the window",
+              }),
+            ),
+        }),
+      ).pipe(Effect.flip)
+
+      expect(result).toBeInstanceOf(JumpFailed)
+      if (result instanceof JumpFailed) {
+        expect(result.message).toBe(
+          "tmux could not create and arrange the window",
+        )
+      }
+    }),
+  )
+
+  it.live("jump launches the interactive resume command for each backend", () =>
+    Effect.gen(function* () {
+      const worktree = mkdtempSync(join(tmpdir(), "rfa-jump-wt-"))
+      mkdirSync(join(worktree, "src"))
+      try {
+        const expected = {
+          opencode: {
+            executable: "/usr/bin/opencode",
+            arguments: [worktree, "--session", sessionId],
+          },
+          grok: {
+            executable: "/usr/bin/grok",
+            arguments: ["--cwd", worktree, "--resume", sessionId],
+          },
+          codex: {
+            executable: "/usr/bin/codex",
+            arguments: ["resume", "-C", worktree, sessionId],
+          },
+          claude: {
+            executable: "/usr/bin/claude",
+            arguments: ["--resume", sessionId],
+          },
+        } as const
+
+        for (const [backendId, want] of Object.entries(expected)) {
+          let captured: JumpWindowInput | undefined
+          yield* runOperator(
+            ["jump", sessionId],
+            successfulJumpLayer({
+              workItemBySessionId: () =>
+                Effect.succeed(
+                  foundWorkItem({ backendId, worktreePath: worktree }),
+                ),
+              createJumpWindow: (input) =>
+                Effect.sync(() => {
+                  captured = input
+                }),
+            }),
+          )
+          expect(captured).toEqual({
+            workingDirectory: worktree,
+            agentExecutable: want.executable,
+            agentArguments: want.arguments,
+          })
+        }
+      } finally {
+        rmSync(worktree, { recursive: true, force: true })
+      }
+    }),
+  )
+
+  it.live("jump uses the CLI cwd when the worktree is missing", () =>
+    Effect.gen(function* () {
+      let captured: JumpWindowInput | undefined
+      yield* runOperator(
+        ["jump", sessionId],
+        successfulJumpLayer({
+          workItemBySessionId: () =>
+            Effect.succeed(
+              foundWorkItem({
+                backendId: "opencode",
+                worktreePath: "/tmp/rfa-missing-worktree-does-not-exist",
+              }),
+            ),
+          createJumpWindow: (input) =>
+            Effect.sync(() => {
+              captured = input
+            }),
+        }),
+      )
+
+      expect(captured?.workingDirectory).toBe(process.cwd())
+      expect(captured?.agentArguments).toEqual([
+        process.cwd(),
+        "--session",
+        sessionId,
+      ])
+    }),
+  )
+
+  it.live("jump succeeds silently without mutating Work Item state", () =>
+    Effect.gen(function* () {
+      const logs: string[] = []
+      const originalLog = console.log
+      console.log = (...args: unknown[]) => {
+        logs.push(args.map(String).join(" "))
+      }
+      try {
+        yield* runOperator(["jump", sessionId], successfulJumpLayer({}))
+        expect(logs).toEqual([])
+      } finally {
+        console.log = originalLog
+      }
     }),
   )
 })

--- a/apps/ready-for-agent/src/cli.ts
+++ b/apps/ready-for-agent/src/cli.ts
@@ -1,4 +1,4 @@
-import { Console, Effect, Option } from "effect"
+import { Console, Effect, FileSystem, Option } from "effect"
 import { Argument, Command, Flag } from "effect/unstable/cli"
 import {
   FiniteCommandFailed,
@@ -12,15 +12,19 @@ import {
   localGitErrorCode,
   toCanonicalRepositoryIdentity,
 } from "./cli-json.ts"
+import { interactiveResumeCommand } from "./interactive-resume.ts"
+import { JumpFailed } from "./jump-error.ts"
 import {
   type RepositoryIdentityFields,
   type RepositoryIdentityMatch,
   formatRepositoryFullIdentity,
   resolveRepositoryIdentity,
 } from "./repository-identity.ts"
+import { ExecutablePath } from "./services/executable-path.ts"
 import { GraphqlApi } from "./services/graphql-api.ts"
 import { LocalGit } from "./services/local-git.ts"
 import { StartHarness } from "./services/start-harness.ts"
+import { Tmux } from "./services/tmux.ts"
 
 const pathArg = Argument.string("path").pipe(
   Argument.withDescription("Path to a local git repository"),
@@ -33,6 +37,10 @@ const repositoryIdentityArg = Argument.string("repository").pipe(
   Argument.withDescription(
     "Repository identity as <forge-host>://<project-path>, <forge-host>/<project-path>, a unique project path, or a unique final project-path segment (case-insensitive)",
   ),
+)
+
+const sessionIdArg = Argument.string("session-id").pipe(
+  Argument.withDescription("Opaque backend Session ID to continue"),
 )
 
 const optionalRepositoryIdentityArg = Argument.string("repository").pipe(
@@ -303,6 +311,58 @@ const statusWorkflow = Effect.fn("Cli.status")(function* (
   )
 })
 
+const resolveJumpWorkingDirectory = (
+  worktreePath: string | null,
+): Effect.Effect<string, never, FileSystem.FileSystem> =>
+  Effect.gen(function* () {
+    if (worktreePath === null) {
+      return process.cwd()
+    }
+    const fs = yield* FileSystem.FileSystem
+    const info = yield* fs
+      .stat(worktreePath)
+      .pipe(Effect.orElseSucceed(() => null))
+    if (info === null || info.type !== "Directory") {
+      return process.cwd()
+    }
+    return worktreePath
+  })
+
+const jumpWorkflow = Effect.fn("Cli.jump")(function* (sessionId: string) {
+  const tmux = yield* Tmux
+  const executablePath = yield* ExecutablePath
+  const graphqlApi = yield* GraphqlApi
+
+  yield* tmux.requireAttachedSession
+
+  const found = yield* graphqlApi
+    .workItemBySessionId(sessionId)
+    .pipe(
+      Effect.mapError((error) => new JumpFailed({ message: error.message })),
+    )
+
+  const workingDirectory = yield* resolveJumpWorkingDirectory(
+    found.worktreePath,
+  )
+  const resume = interactiveResumeCommand({
+    backendId: found.agentBackend.id,
+    sessionId: found.sessionId,
+    workingDirectory,
+  })
+  if (resume === null) {
+    return yield* new JumpFailed({
+      message: `Unsupported Agent Backend: ${found.agentBackend.id}`,
+    })
+  }
+
+  const agentExecutable = yield* executablePath.resolve(resume.executableName)
+  yield* tmux.createJumpWindow({
+    workingDirectory,
+    agentExecutable,
+    agentArguments: resume.arguments,
+  })
+})
+
 const startCommand = Command.make(
   "start",
   { noOpen: noOpenFlag, host: hostFlag },
@@ -362,6 +422,16 @@ const statusCommand = Command.make(
   ),
 )
 
+const jumpCommand = Command.make(
+  "jump",
+  { sessionId: sessionIdArg },
+  ({ sessionId }) => jumpWorkflow(sessionId),
+).pipe(
+  Command.withDescription(
+    "Continue a Work Item Session in a new tmux window (Interactive Session Continuation)",
+  ),
+)
+
 export const cli = Command.make(
   "ready-for-agent",
   { noOpen: noOpenFlag, host: hostFlag },
@@ -369,7 +439,7 @@ export const cli = Command.make(
     startHarnessWorkflow(noOpen, Option.getOrUndefined(host)),
 ).pipe(
   Command.withDescription(
-    "Ready for Agent operator binary (start Harness, add repositories, intake, Kanban status)",
+    "Ready for Agent operator binary (start Harness, add repositories, intake, Kanban status, jump)",
   ),
   Command.withSubcommands([
     startCommand,
@@ -377,5 +447,6 @@ export const cli = Command.make(
     candidatesCommand,
     intakeCommand,
     statusCommand,
+    jumpCommand,
   ]),
 )

--- a/apps/ready-for-agent/src/interactive-resume.ts
+++ b/apps/ready-for-agent/src/interactive-resume.ts
@@ -1,0 +1,44 @@
+/**
+ * Interactive continuation argv for a captured Agent Backend.
+ * Distinct from headless Agent Turn argument builders.
+ */
+export type InteractiveResumeCommand = {
+  readonly executableName: string
+  readonly arguments: readonly string[]
+}
+
+export const interactiveResumeCommand = (input: {
+  readonly backendId: string
+  readonly sessionId: string
+  readonly workingDirectory: string
+}): InteractiveResumeCommand | null => {
+  switch (input.backendId) {
+    case "opencode":
+      return {
+        executableName: "opencode",
+        arguments: [input.workingDirectory, "--session", input.sessionId],
+      }
+    case "grok":
+      return {
+        executableName: "grok",
+        arguments: [
+          "--cwd",
+          input.workingDirectory,
+          "--resume",
+          input.sessionId,
+        ],
+      }
+    case "codex":
+      return {
+        executableName: "codex",
+        arguments: ["resume", "-C", input.workingDirectory, input.sessionId],
+      }
+    case "claude":
+      return {
+        executableName: "claude",
+        arguments: ["--resume", input.sessionId],
+      }
+    default:
+      return null
+  }
+}

--- a/apps/ready-for-agent/src/jump-error.ts
+++ b/apps/ready-for-agent/src/jump-error.ts
@@ -1,0 +1,16 @@
+import { Runtime, Schema } from "effect"
+
+/**
+ * Interactive Session Continuation failure. Jump is outside the finite JSON
+ * command protocol: the CLI writes this message to stderr and exits 1.
+ * Marked as already reported so `BunRuntime.runMain` does not pretty-print
+ * a stack after the one-line message.
+ */
+export class JumpFailed extends Schema.TaggedErrorClass<JumpFailed>()(
+  "JumpFailed",
+  {
+    message: Schema.String,
+  },
+) {
+  override readonly [Runtime.errorReported] = false
+}

--- a/apps/ready-for-agent/src/main.ts
+++ b/apps/ready-for-agent/src/main.ts
@@ -28,14 +28,18 @@ if (isInternalKeymaxxerSidecarMode(process.argv)) {
   )
   const { cli } = await import("./cli.ts")
   const { ApplicationConfig } = await import("./services/application-config.ts")
+  const { ExecutablePath } = await import("./services/executable-path.ts")
   const { GraphqlApi } = await import("./services/graphql-api.ts")
   const { LocalGit } = await import("./services/local-git.ts")
   const { StartHarness } = await import("./services/start-harness.ts")
+  const { Tmux } = await import("./services/tmux.ts")
 
   const MainLive = Layer.mergeAll(
     LocalGit.layer,
     GraphqlApi.layer,
     StartHarness.layer,
+    Tmux.layer,
+    ExecutablePath.layer,
   ).pipe(
     Layer.provideMerge(ApplicationConfig.layer),
     Layer.provideMerge(BunServices.layer),
@@ -55,6 +59,11 @@ if (isInternalKeymaxxerSidecarMode(process.argv)) {
     Effect.tapErrorTag("FiniteCommandFailed", (error) =>
       Effect.sync(() => {
         console.error(encodeCompactJson(error.document))
+      }),
+    ),
+    Effect.tapErrorTag("JumpFailed", (error) =>
+      Effect.sync(() => {
+        console.error(error.message)
       }),
     ),
   )

--- a/apps/ready-for-agent/src/services/executable-path.ts
+++ b/apps/ready-for-agent/src/services/executable-path.ts
@@ -1,0 +1,25 @@
+import { Context, Effect, Layer } from "effect"
+import { JumpFailed } from "../jump-error.ts"
+
+export class ExecutablePath extends Context.Service<
+  ExecutablePath,
+  {
+    readonly resolve: (command: string) => Effect.Effect<string, JumpFailed>
+  }
+>()("ready-for-agent/ExecutablePath") {
+  static readonly layer = Layer.sync(ExecutablePath, () => {
+    const resolve = Effect.fn("ExecutablePath.resolve")(function* (
+      command: string,
+    ) {
+      const resolved = Bun.which(command)
+      if (resolved === null) {
+        return yield* new JumpFailed({
+          message: `Agent Backend executable '${command}' is not on PATH`,
+        })
+      }
+      return resolved
+    })
+
+    return { resolve }
+  })
+}

--- a/apps/ready-for-agent/src/services/graphql-api.ts
+++ b/apps/ready-for-agent/src/services/graphql-api.ts
@@ -96,6 +96,15 @@ export type KanbanStatusResult = {
   readonly lanes: readonly StatusLane[]
 }
 
+export type SessionWorkItemLookup = {
+  readonly agentBackend: {
+    readonly id: string
+    readonly label: string
+  }
+  readonly sessionId: string
+  readonly worktreePath: string | null
+}
+
 const isStatusLaneId = (value: string): value is StatusLaneId => {
   switch (value) {
     case "QUEUE":
@@ -207,6 +216,9 @@ export class GraphqlApi extends Context.Service<
     readonly kanbanStatus: (
       repositoryId: string | null,
     ) => Effect.Effect<KanbanStatusResult, GraphqlRequestFailed>
+    readonly workItemBySessionId: (
+      sessionId: string,
+    ) => Effect.Effect<SessionWorkItemLookup, GraphqlRequestFailed>
   }
 >()("ready-for-agent/GraphqlApi") {
   static readonly layer = Layer.effect(
@@ -505,12 +517,46 @@ export class GraphqlApi extends Context.Service<
         })
       })
 
+      const workItemBySessionId = Effect.fn("GraphqlApi.workItemBySessionId")(
+        function* (sessionId: string) {
+          return yield* Effect.tryPromise({
+            try: async () => {
+              const result = await client.query({
+                workItemBySessionId: {
+                  __args: { sessionId },
+                  agentBackend: {
+                    id: true,
+                    label: true,
+                  },
+                  sessionId: true,
+                  worktreePath: true,
+                },
+              })
+              const payload = result.workItemBySessionId
+              if (!payload) {
+                throw new Error("workItemBySessionId returned null")
+              }
+              return {
+                agentBackend: {
+                  id: payload.agentBackend.id,
+                  label: payload.agentBackend.label,
+                },
+                sessionId: payload.sessionId,
+                worktreePath: payload.worktreePath ?? null,
+              }
+            },
+            catch: mapFailure,
+          })
+        },
+      )
+
       return {
         addRepository,
         listRepositories,
         intakeCandidates,
         startRepositoryIntake,
         kanbanStatus,
+        workItemBySessionId,
       }
     }),
   )

--- a/apps/ready-for-agent/src/services/tmux.ts
+++ b/apps/ready-for-agent/src/services/tmux.ts
@@ -1,0 +1,117 @@
+import { Context, Effect, Layer, Stream } from "effect"
+import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process"
+import { JumpFailed } from "../jump-error.ts"
+
+export type JumpWindowInput = {
+  readonly workingDirectory: string
+  readonly agentExecutable: string
+  readonly agentArguments: readonly string[]
+}
+
+const tmuxMissingMessage = "jump must be run from inside a tmux session"
+
+const tmuxArrangeMessage = (detail?: string): string =>
+  detail === undefined || detail.length === 0
+    ? "tmux could not create and arrange the window"
+    : `tmux could not create and arrange the window: ${detail}`
+
+export class Tmux extends Context.Service<
+  Tmux,
+  {
+    readonly requireAttachedSession: Effect.Effect<void, JumpFailed>
+    readonly createJumpWindow: (
+      input: JumpWindowInput,
+    ) => Effect.Effect<void, JumpFailed>
+  }
+>()("ready-for-agent/Tmux") {
+  static readonly layer = Layer.effect(
+    Tmux,
+    Effect.gen(function* () {
+      const spawner = yield* ChildProcessSpawner.ChildProcessSpawner
+
+      const requireAttachedSession = Effect.sync(() => {
+        const tmux = process.env.TMUX
+        return tmux !== undefined && tmux.length > 0
+      }).pipe(
+        Effect.flatMap((inside) =>
+          inside
+            ? Effect.void
+            : Effect.fail(new JumpFailed({ message: tmuxMissingMessage })),
+        ),
+      )
+
+      const runTmux = (args: readonly string[]) =>
+        Effect.scoped(
+          Effect.gen(function* () {
+            const handle = yield* spawner.spawn(
+              ChildProcess.make("tmux", [...args], { stdin: "ignore" }),
+            )
+            const [exitCode, stdout, stderr] = yield* Effect.all(
+              [
+                handle.exitCode,
+                Stream.decodeText(handle.stdout).pipe(Stream.mkString),
+                Stream.decodeText(handle.stderr).pipe(Stream.mkString),
+              ],
+              { concurrency: 3 },
+            )
+            if (Number(exitCode) !== 0) {
+              const diagnostic = stderr.trim()
+              return yield* new JumpFailed({
+                message: tmuxArrangeMessage(
+                  diagnostic.length === 0 ? `exit ${exitCode}` : diagnostic,
+                ),
+              })
+            }
+            return stdout.trim()
+          }),
+        ).pipe(
+          Effect.mapError((error) =>
+            error instanceof JumpFailed
+              ? error
+              : new JumpFailed({
+                  message: tmuxArrangeMessage(
+                    error instanceof Error ? error.message : String(error),
+                  ),
+                }),
+          ),
+        )
+
+      const createJumpWindow = Effect.fn("Tmux.createJumpWindow")(function* (
+        input: JumpWindowInput,
+      ) {
+        const created = yield* runTmux([
+          "new-window",
+          "-d",
+          "-P",
+          "-F",
+          "#{window_id} #{pane_id}",
+          "-c",
+          input.workingDirectory,
+          "--",
+          input.agentExecutable,
+          ...input.agentArguments,
+        ])
+        const [windowId, paneId] = created.split(/\s+/)
+        if (windowId === undefined || paneId === undefined) {
+          return yield* new JumpFailed({
+            message: tmuxArrangeMessage(),
+          })
+        }
+
+        yield* runTmux([
+          "split-window",
+          "-h",
+          "-t",
+          windowId,
+          "-c",
+          input.workingDirectory,
+        ])
+        yield* runTmux(["select-layout", "-t", windowId, "even-horizontal"])
+        yield* runTmux(["select-pane", "-t", paneId])
+        yield* runTmux(["select-window", "-t", windowId])
+      })
+
+      return { requireAttachedSession, createJumpWindow }
+    }),
+  )
+}


### PR DESCRIPTION
An operator who wants an Interactive Session Continuation currently
has to look up the captured Agent Backend, rebuild that backend's
interactive command, and `cd` into the Work Item worktree by hand.
#1018 adds `ready-for-agent jump <session-id>` so the published CLI
does that lookup and layout instead.

The command is outside the finite JSON protocol. It resolves the
opaque Session ID with the existing `workItemBySessionId` query,
checks that it is running inside tmux, maps the captured backend to
the interactive continuation (`opencode` / `grok` / `codex` /
`claude`), and resolves that binary to an absolute path on the CLI
`PATH` before talking to tmux. It then creates a new window with an
even left/right split: the left pane runs the agent (focused, no
wrapper shell so the pane closes when the agent exits), the right
pane is tmux's default shell, and the invoking client is switched to
the window. Both panes use the persisted worktree when it exists as a
directory; otherwise they use the CLI cwd. Failures are one line on
stderr and exit 1. Jump does not Pause, Start, Retry, Reset, or
otherwise transition the Work Item.

Window naming, Session-ID tagging, duplicate-window reuse, and
transactional cleanup of a half-built window stay in #1019. Review of
the uncommitted change flagged leftover detached windows if arrange
fails after `new-window`; that finding was deferred as #1019 work.

Verified with `bunx nx run ready-for-agent:test` and
`bunx nx run ready-for-agent:typecheck`. `cli.test.ts` covers
argument parsing, GraphQL lookup, prerequisite failures, and tmux
orchestration; `cli-process.test.ts` covers the process contract
against a fake `tmux` and resolved backend binaries.

Closes #1018