### PR TITLE
feat(cli): reuse or refuse jump windows by Session ID

### DIFF
--- a/apps/ready-for-agent/src/cli-process.test.ts
+++ b/apps/ready-for-agent/src/cli-process.test.ts
@@ -1079,12 +1079,33 @@ describe("operator binary jump process contract", () => {
       join(binDir, "tmux"),
       `#!/usr/bin/env bun
 import { appendFileSync } from "node:fs"
-appendFileSync(process.env.TMUX_ARGV_LOG ?? "", JSON.stringify(process.argv.slice(2)) + "\\n")
+const args = process.argv.slice(2)
+appendFileSync(process.env.TMUX_ARGV_LOG ?? "", JSON.stringify(args) + "\\n")
 if (process.env.TMUX_FAIL === "1") {
   process.exit(1)
 }
-if (process.argv.includes("new-window")) {
+if (process.env.TMUX_FAIL_ON !== undefined && args.includes(process.env.TMUX_FAIL_ON)) {
+  process.exit(1)
+}
+if (args[0] === "display-message") {
+  process.stdout.write((process.env.TMUX_CURRENT_SESSION ?? "$0") + "\\n")
+  process.exit(0)
+}
+if (args[0] === "list-windows") {
+  process.stdout.write((process.env.TMUX_LIST_WINDOWS ?? "") + "\\n")
+  process.exit(0)
+}
+if (args[0] === "list-panes") {
+  process.stdout.write((process.env.TMUX_LIST_PANES ?? "%1 1\\n%2") + "\\n")
+  process.exit(0)
+}
+if (args.includes("new-window")) {
   process.stdout.write("@1 %1\\n")
+  process.exit(0)
+}
+if (args[0] === "split-window" && args.includes("-P")) {
+  process.stdout.write("%3\\n")
+  process.exit(0)
 }
 `,
     )
@@ -1276,12 +1297,21 @@ if (process.argv.includes("new-window")) {
       const invocations = parseTmuxArgvLog(tmuxLog)
       const opencode = join(binDir, "opencode")
       expect(invocations).toEqual([
+        ["display-message", "-p", "#{session_id}"],
+        [
+          "list-windows",
+          "-a",
+          "-F",
+          "#{session_id}\t#{session_name}\t#{window_id}\t#{window_index}\t#{@rfa-session-id}",
+        ],
         [
           "new-window",
           "-d",
           "-P",
           "-F",
           "#{window_id} #{pane_id}",
+          "-n",
+          "rfa:85312e9f",
           "-c",
           worktree,
           "--",
@@ -1290,6 +1320,8 @@ if (process.argv.includes("new-window")) {
           "--session",
           jumpSessionId,
         ],
+        ["set-option", "-w", "-t", "@1", "@rfa-session-id", jumpSessionId],
+        ["set-option", "-p", "-t", "%1", "@rfa-agent", "1"],
         ["split-window", "-h", "-t", "@1", "-c", worktree],
         ["select-layout", "-t", "@1", "even-horizontal"],
         ["select-pane", "-t", "%1"],
@@ -1316,12 +1348,14 @@ if (process.argv.includes("new-window")) {
       const invocations = parseTmuxArgvLog(tmuxLog)
       const claude = join(binDir, "claude")
       const cliCwd = resolve(packageRoot)
-      expect(invocations[0]).toEqual([
+      expect(invocations[2]).toEqual([
         "new-window",
         "-d",
         "-P",
         "-F",
         "#{window_id} #{pane_id}",
+        "-n",
+        "rfa:85312e9f",
         "-c",
         cliCwd,
         "--",
@@ -1329,7 +1363,7 @@ if (process.argv.includes("new-window")) {
         "--resume",
         jumpSessionId,
       ])
-      expect(invocations[1]).toEqual([
+      expect(invocations).toContainEqual([
         "split-window",
         "-h",
         "-t",
@@ -1362,13 +1396,208 @@ if (process.argv.includes("new-window")) {
         )
         expect(result.status).toBe(0)
         const invocations = parseTmuxArgvLog(tmuxLog)
-        expect(invocations[0]?.slice(8)).toEqual([
+        const created = invocations.find((args) => args[0] === "new-window")
+        const separator = created?.indexOf("--") ?? -1
+        expect(created?.slice(separator + 1)).toEqual([
           join(binDir, backendId),
           ...expectedTail,
         ])
       } finally {
         await graphql.close()
       }
+    }
+  })
+
+  test("jump selects the existing tagged window instead of creating another", async () => {
+    const graphql = await startJumpGraphqlServer({
+      backendId: "opencode",
+      worktreePath: null,
+    })
+    try {
+      const result = await runCli(["jump", jumpSessionId], graphql.url, {
+        ...jumpEnv(),
+        TMUX_LIST_WINDOWS: `$0\tdefault\t@5\t3\t${jumpSessionId}`,
+        TMUX_LIST_PANES: "%1 1\n%2",
+      })
+
+      expect(result.status).toBe(0)
+      expect(result.stdout.trim()).toBe("")
+      expect(result.stderr.trim()).toBe("")
+      const invocations = parseTmuxArgvLog(tmuxLog)
+      expect(invocations.some((args) => args.includes("new-window"))).toBe(
+        false,
+      )
+      expect(invocations).toContainEqual(["select-window", "-t", "@5"])
+      expect(invocations).toContainEqual(["select-pane", "-t", "%1"])
+    } finally {
+      await graphql.close()
+    }
+  })
+
+  test("jump recreates the left agent pane when only the shell remains", async () => {
+    const worktree = join(tempRoot, "reuse-worktree")
+    mkdirSync(worktree)
+    const graphql = await startJumpGraphqlServer({
+      backendId: "opencode",
+      worktreePath: worktree,
+    })
+    try {
+      const result = await runCli(
+        ["jump", jumpSessionId],
+        graphql.url,
+        jumpEnv({
+          TMUX_LIST_WINDOWS: `$0\tdefault\t@5\t3\t${jumpSessionId}`,
+          TMUX_LIST_PANES: "%2",
+        }),
+      )
+
+      expect(result.status).toBe(0)
+      const invocations = parseTmuxArgvLog(tmuxLog)
+      expect(invocations.some((args) => args.includes("new-window"))).toBe(
+        false,
+      )
+      expect(invocations).toContainEqual([
+        "split-window",
+        "-h",
+        "-b",
+        "-P",
+        "-F",
+        "#{pane_id}",
+        "-t",
+        "@5",
+        "-c",
+        worktree,
+        "--",
+        join(binDir, "opencode"),
+        worktree,
+        "--session",
+        jumpSessionId,
+      ])
+      expect(invocations).toContainEqual([
+        "set-option",
+        "-p",
+        "-t",
+        "%3",
+        "@rfa-agent",
+        "1",
+      ])
+      expect(invocations).toContainEqual([
+        "select-layout",
+        "-t",
+        "@5",
+        "even-horizontal",
+      ])
+      expect(invocations).toContainEqual(["select-pane", "-t", "%3"])
+    } finally {
+      await graphql.close()
+    }
+  })
+
+  test("jump reuses a sole remaining tagged agent pane", async () => {
+    const graphql = await startJumpGraphqlServer({
+      backendId: "opencode",
+      worktreePath: null,
+    })
+    try {
+      const result = await runCli(
+        ["jump", jumpSessionId],
+        graphql.url,
+        jumpEnv({
+          TMUX_LIST_WINDOWS: `$0\tdefault\t@5\t3\t${jumpSessionId}`,
+          TMUX_LIST_PANES: "%1 1",
+        }),
+      )
+
+      expect(result.status).toBe(0)
+      const invocations = parseTmuxArgvLog(tmuxLog)
+      expect(invocations.some((args) => args.includes("new-window"))).toBe(
+        false,
+      )
+      expect(invocations.some((args) => args.includes("split-window"))).toBe(
+        false,
+      )
+      expect(invocations).toContainEqual(["select-pane", "-t", "%1"])
+      expect(invocations).toContainEqual(["select-window", "-t", "@5"])
+    } finally {
+      await graphql.close()
+    }
+  })
+
+  test("jump does not kill the created window when only select-window fails", async () => {
+    const graphql = await startJumpGraphqlServer({
+      backendId: "opencode",
+      worktreePath: null,
+    })
+    try {
+      const result = await runCli(
+        ["jump", jumpSessionId],
+        graphql.url,
+        jumpEnv({ TMUX_FAIL_ON: "select-window" }),
+      )
+
+      expect(result.status).toBe(1)
+      expect(result.stderr).toContain(
+        "tmux could not create and arrange the window",
+      )
+      const invocations = parseTmuxArgvLog(tmuxLog)
+      expect(invocations.some((args) => args.includes("new-window"))).toBe(true)
+      expect(invocations.some((args) => args.includes("kill-window"))).toBe(
+        false,
+      )
+    } finally {
+      await graphql.close()
+    }
+  })
+
+  test("jump refuses a tagged window that belongs to another tmux session", async () => {
+    const graphql = await startJumpGraphqlServer({
+      backendId: "opencode",
+      worktreePath: null,
+    })
+    try {
+      const result = await runCli(
+        ["jump", jumpSessionId],
+        graphql.url,
+        jumpEnv({
+          TMUX_LIST_WINDOWS: `$1\tother\t@8\t2\t${jumpSessionId}`,
+        }),
+      )
+
+      expect(result.status).toBe(1)
+      expect(result.stdout.trim()).toBe("")
+      expect(result.stderr.trim()).toBe(
+        "Session already open in tmux session 'other' window 2",
+      )
+      const invocations = parseTmuxArgvLog(tmuxLog)
+      expect(invocations.some((args) => args.includes("new-window"))).toBe(
+        false,
+      )
+    } finally {
+      await graphql.close()
+    }
+  })
+
+  test("jump kills only the window it created when split-window fails", async () => {
+    const graphql = await startJumpGraphqlServer({
+      backendId: "opencode",
+      worktreePath: null,
+    })
+    try {
+      const result = await runCli(
+        ["jump", jumpSessionId],
+        graphql.url,
+        jumpEnv({ TMUX_FAIL_ON: "split-window" }),
+      )
+
+      expect(result.status).toBe(1)
+      expect(result.stderr).toContain(
+        "tmux could not create and arrange the window",
+      )
+      const invocations = parseTmuxArgvLog(tmuxLog)
+      expect(invocations.some((args) => args.includes("new-window"))).toBe(true)
+      expect(invocations.at(-1)).toEqual(["kill-window", "-t", "@1"])
+    } finally {
+      await graphql.close()
     }
   })
 })

--- a/apps/ready-for-agent/src/cli.test.ts
+++ b/apps/ready-for-agent/src/cli.test.ts
@@ -5,8 +5,9 @@ import { join } from "node:path"
 import { fileURLToPath } from "node:url"
 import { BunServices } from "@effect/platform-bun"
 import { beforeEach, describe, expect, it } from "@effect/vitest"
-import { Effect, Layer } from "effect"
+import { Effect, Layer, Stream } from "effect"
 import { Command } from "effect/unstable/cli"
+import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process"
 import { expandBareHostFlag } from "../../harness/src/server/listen-host.ts"
 import { cli } from "./cli.ts"
 import {
@@ -1477,6 +1478,7 @@ describe("operator binary jump command", () => {
             }),
           )
           expect(captured).toEqual({
+            sessionId,
             workingDirectory: worktree,
             agentExecutable: want.executable,
             agentArguments: want.arguments,
@@ -1531,5 +1533,288 @@ describe("operator binary jump command", () => {
         console.log = originalLog
       }
     }),
+  )
+
+  const windowListFormat =
+    "#{session_id}\t#{session_name}\t#{window_id}\t#{window_index}\t#{@rfa-session-id}"
+  const paneListFormat = "#{pane_id} #{@rfa-agent}"
+  const jumpInput = {
+    sessionId,
+    workingDirectory: "/tmp/rfa-jump-worktree",
+    agentExecutable: "/usr/bin/opencode",
+    agentArguments: ["/tmp/rfa-jump-worktree", "--session", sessionId],
+  } as const
+
+  const recordingTmux = (script: {
+    readonly currentSession?: string
+    readonly windows?: string
+    readonly panes?: string
+    readonly failOn?: string
+  }) => {
+    const invocations: string[][] = []
+    const encoder = new TextEncoder()
+    const service = ChildProcessSpawner.make((command) =>
+      Effect.sync(() => {
+        if (!ChildProcess.isStandardCommand(command)) {
+          throw new Error("expected standard command")
+        }
+        invocations.push([...command.args])
+        let stdout = ""
+        let exit = 0
+        if (
+          script.failOn !== undefined &&
+          command.args.includes(script.failOn)
+        ) {
+          exit = 1
+        } else if (command.args[0] === "display-message") {
+          stdout = `${script.currentSession ?? "$0"}\n`
+        } else if (command.args[0] === "list-windows") {
+          stdout =
+            script.windows === undefined || script.windows.length === 0
+              ? ""
+              : `${script.windows}\n`
+        } else if (command.args[0] === "list-panes") {
+          stdout = `${script.panes ?? "%1 1\n%2"}\n`
+        } else if (command.args.includes("new-window")) {
+          stdout = "@1 %1\n"
+        } else if (
+          command.args[0] === "split-window" &&
+          command.args.includes("-P")
+        ) {
+          stdout = "%3\n"
+        }
+        const bytes = encoder.encode(stdout)
+        return ChildProcessSpawner.makeHandle({
+          pid: ChildProcessSpawner.ProcessId(1),
+          exitCode: Effect.succeed(ChildProcessSpawner.ExitCode(exit)),
+          isRunning: Effect.succeed(false),
+          kill: () => Effect.void,
+          stdin: {
+            onStart: () => Effect.void,
+            onInput: () => Effect.void,
+            onEnd: () => Effect.void,
+          } as never,
+          stdout: Stream.succeed(bytes),
+          stderr: Stream.empty,
+          all: Stream.succeed(bytes),
+          getInputFd: () =>
+            ({
+              onStart: () => Effect.void,
+              onInput: () => Effect.void,
+              onEnd: () => Effect.void,
+            }) as never,
+          getOutputFd: () => Stream.empty,
+          unref: Effect.succeed(Effect.void),
+        })
+      }),
+    )
+
+    return {
+      invocations,
+      layer: Tmux.layer.pipe(
+        Layer.provide(
+          Layer.succeed(ChildProcessSpawner.ChildProcessSpawner, service),
+        ),
+      ),
+    }
+  }
+
+  const runCreateJumpWindow = (
+    layer: Layer.Layer<Tmux, never, never>,
+    input: JumpWindowInput = jumpInput,
+  ) =>
+    Effect.gen(function* () {
+      const tmux = yield* Tmux
+      return yield* tmux.createJumpWindow(input)
+    }).pipe(Effect.provide(layer))
+
+  it.live(
+    "jump selects an existing tagged window in the current tmux session",
+    () =>
+      Effect.gen(function* () {
+        const tmux = recordingTmux({
+          windows: `$0\tdefault\t@5\t3\t${sessionId}`,
+          panes: "%1 1\n%2",
+        })
+        yield* runCreateJumpWindow(tmux.layer)
+        expect(tmux.invocations).toEqual([
+          ["display-message", "-p", "#{session_id}"],
+          ["list-windows", "-a", "-F", windowListFormat],
+          ["list-panes", "-t", "@5", "-F", paneListFormat],
+          ["select-pane", "-t", "%1"],
+          ["select-window", "-t", "@5"],
+        ])
+      }),
+  )
+
+  it.live(
+    "jump recreates the agent pane when the tagged window only has a shell",
+    () =>
+      Effect.gen(function* () {
+        const tmux = recordingTmux({
+          windows: `$0\tdefault\t@5\t3\t${sessionId}`,
+          panes: "%2",
+        })
+        yield* runCreateJumpWindow(tmux.layer)
+        expect(tmux.invocations).toEqual([
+          ["display-message", "-p", "#{session_id}"],
+          ["list-windows", "-a", "-F", windowListFormat],
+          ["list-panes", "-t", "@5", "-F", paneListFormat],
+          [
+            "split-window",
+            "-h",
+            "-b",
+            "-P",
+            "-F",
+            "#{pane_id}",
+            "-t",
+            "@5",
+            "-c",
+            jumpInput.workingDirectory,
+            "--",
+            jumpInput.agentExecutable,
+            ...jumpInput.agentArguments,
+          ],
+          ["set-option", "-p", "-t", "%3", "@rfa-agent", "1"],
+          ["select-layout", "-t", "@5", "even-horizontal"],
+          ["select-pane", "-t", "%3"],
+          ["select-window", "-t", "@5"],
+        ])
+      }),
+  )
+
+  it.live(
+    "jump fails and reports the other tmux session when the tagged window is foreign",
+    () =>
+      Effect.gen(function* () {
+        const tmux = recordingTmux({
+          windows: `$1\tother\t@8\t2\t${sessionId}`,
+        })
+        const result = yield* runCreateJumpWindow(tmux.layer).pipe(Effect.flip)
+        expect(result).toBeInstanceOf(JumpFailed)
+        if (result instanceof JumpFailed) {
+          expect(result.message).toBe(
+            "Session already open in tmux session 'other' window 2",
+          )
+        }
+        expect(
+          tmux.invocations.some((args) => args.includes("new-window")),
+        ).toBe(false)
+        expect(
+          tmux.invocations.some((args) => args.includes("kill-window")),
+        ).toBe(false)
+      }),
+  )
+
+  it.live(
+    "jump stores the full Session ID and names the window rfa:<first-8>",
+    () =>
+      Effect.gen(function* () {
+        const tmux = recordingTmux({})
+        yield* runCreateJumpWindow(tmux.layer)
+        expect(tmux.invocations).toEqual([
+          ["display-message", "-p", "#{session_id}"],
+          ["list-windows", "-a", "-F", windowListFormat],
+          [
+            "new-window",
+            "-d",
+            "-P",
+            "-F",
+            "#{window_id} #{pane_id}",
+            "-n",
+            "rfa:85312e9f",
+            "-c",
+            jumpInput.workingDirectory,
+            "--",
+            jumpInput.agentExecutable,
+            ...jumpInput.agentArguments,
+          ],
+          ["set-option", "-w", "-t", "@1", "@rfa-session-id", sessionId],
+          ["set-option", "-p", "-t", "%1", "@rfa-agent", "1"],
+          ["split-window", "-h", "-t", "@1", "-c", jumpInput.workingDirectory],
+          ["select-layout", "-t", "@1", "even-horizontal"],
+          ["select-pane", "-t", "%1"],
+          ["select-window", "-t", "@1"],
+        ])
+      }),
+  )
+
+  it.live(
+    "jump kills only the window it created when later tmux setup fails",
+    () =>
+      Effect.gen(function* () {
+        const tmux = recordingTmux({ failOn: "split-window" })
+        const result = yield* runCreateJumpWindow(tmux.layer).pipe(Effect.flip)
+        expect(result).toBeInstanceOf(JumpFailed)
+        if (result instanceof JumpFailed) {
+          expect(result.message).toContain(
+            "tmux could not create and arrange the window",
+          )
+        }
+        expect(tmux.invocations.at(-1)).toEqual(["kill-window", "-t", "@1"])
+        expect(
+          tmux.invocations.filter((args) => args.includes("kill-window")),
+        ).toHaveLength(1)
+      }),
+  )
+
+  it.live(
+    "jump reuses a sole remaining pane when it is still the tagged agent",
+    () =>
+      Effect.gen(function* () {
+        const tmux = recordingTmux({
+          windows: `$0\tdefault\t@5\t3\t${sessionId}`,
+          panes: "%1 1",
+        })
+        yield* runCreateJumpWindow(tmux.layer)
+        expect(tmux.invocations).toEqual([
+          ["display-message", "-p", "#{session_id}"],
+          ["list-windows", "-a", "-F", windowListFormat],
+          ["list-panes", "-t", "@5", "-F", paneListFormat],
+          ["select-pane", "-t", "%1"],
+          ["select-window", "-t", "@5"],
+        ])
+        expect(
+          tmux.invocations.some((args) => args.includes("split-window")),
+        ).toBe(false)
+      }),
+  )
+
+  it.live(
+    "jump does not kill a newly created window when only the client switch fails",
+    () =>
+      Effect.gen(function* () {
+        const tmux = recordingTmux({ failOn: "select-window" })
+        const result = yield* runCreateJumpWindow(tmux.layer).pipe(Effect.flip)
+        expect(result).toBeInstanceOf(JumpFailed)
+        expect(
+          tmux.invocations.some((args) => args.includes("kill-window")),
+        ).toBe(false)
+        expect(tmux.invocations).toContainEqual([
+          "set-option",
+          "-p",
+          "-t",
+          "%1",
+          "@rfa-agent",
+          "1",
+        ])
+      }),
+  )
+
+  it.live(
+    "jump does not kill a pre-existing tagged window when recreation fails",
+    () =>
+      Effect.gen(function* () {
+        const tmux = recordingTmux({
+          windows: `$0\tdefault\t@5\t3\t${sessionId}`,
+          panes: "%2",
+          failOn: "split-window",
+        })
+        const result = yield* runCreateJumpWindow(tmux.layer).pipe(Effect.flip)
+        expect(result).toBeInstanceOf(JumpFailed)
+        expect(
+          tmux.invocations.some((args) => args.includes("kill-window")),
+        ).toBe(false)
+      }),
   )
 })

--- a/apps/ready-for-agent/src/cli.ts
+++ b/apps/ready-for-agent/src/cli.ts
@@ -357,6 +357,7 @@ const jumpWorkflow = Effect.fn("Cli.jump")(function* (sessionId: string) {
 
   const agentExecutable = yield* executablePath.resolve(resume.executableName)
   yield* tmux.createJumpWindow({
+    sessionId: found.sessionId,
     workingDirectory,
     agentExecutable,
     agentArguments: resume.arguments,

--- a/apps/ready-for-agent/src/services/tmux.ts
+++ b/apps/ready-for-agent/src/services/tmux.ts
@@ -3,6 +3,7 @@ import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process"
 import { JumpFailed } from "../jump-error.ts"
 
 export type JumpWindowInput = {
+  readonly sessionId: string
   readonly workingDirectory: string
   readonly agentExecutable: string
   readonly agentArguments: readonly string[]
@@ -10,10 +11,85 @@ export type JumpWindowInput = {
 
 const tmuxMissingMessage = "jump must be run from inside a tmux session"
 
+const sessionOptionName = "@rfa-session-id"
+const agentPaneOptionName = "@rfa-agent"
+const agentPaneMarker = "1"
+const windowListFormat =
+  "#{session_id}\t#{session_name}\t#{window_id}\t#{window_index}\t#{@rfa-session-id}"
+const paneListFormat = "#{pane_id} #{@rfa-agent}"
+
 const tmuxArrangeMessage = (detail?: string): string =>
   detail === undefined || detail.length === 0
     ? "tmux could not create and arrange the window"
     : `tmux could not create and arrange the window: ${detail}`
+
+const jumpWindowName = (sessionId: string): string =>
+  `rfa:${sessionId.slice(0, 8)}`
+
+type TaggedWindow = {
+  readonly tmuxSessionId: string
+  readonly sessionName: string
+  readonly windowId: string
+  readonly windowIndex: string
+}
+
+type JumpTarget =
+  | { readonly kind: "create" }
+  | {
+      readonly kind: "reuse"
+      readonly windowId: string
+      readonly paneId: string
+    }
+  | { readonly kind: "recreate"; readonly windowId: string }
+  | {
+      readonly kind: "foreign"
+      readonly sessionName: string
+      readonly windowIndex: string
+    }
+
+const parseTaggedWindows = (
+  listing: string,
+  sessionId: string,
+): readonly TaggedWindow[] => {
+  const matches: TaggedWindow[] = []
+  for (const line of listing.split("\n")) {
+    if (line.length === 0) {
+      continue
+    }
+    const [tmuxSessionId, sessionName, windowId, windowIndex, tagged] =
+      line.split("\t")
+    if (
+      tmuxSessionId === undefined ||
+      sessionName === undefined ||
+      windowId === undefined ||
+      windowIndex === undefined ||
+      tagged !== sessionId
+    ) {
+      continue
+    }
+    matches.push({
+      tmuxSessionId,
+      sessionName,
+      windowId,
+      windowIndex,
+    })
+  }
+  return matches
+}
+
+const taggedAgentPaneId = (listing: string): string | undefined => {
+  for (const line of listing.split("\n")) {
+    const trimmed = line.trim()
+    if (trimmed.length === 0) {
+      continue
+    }
+    const [paneId, marker] = trimmed.split(/\s+/)
+    if (paneId !== undefined && marker === agentPaneMarker) {
+      return paneId
+    }
+  }
+  return undefined
+}
 
 export class Tmux extends Context.Service<
   Tmux,
@@ -76,7 +152,55 @@ export class Tmux extends Context.Service<
           ),
         )
 
-      const createJumpWindow = Effect.fn("Tmux.createJumpWindow")(function* (
+      const killCreatedWindow = (windowId: string) =>
+        runTmux(["kill-window", "-t", windowId]).pipe(Effect.ignore)
+
+      const tagAgentPane = (paneId: string) =>
+        runTmux([
+          "set-option",
+          "-p",
+          "-t",
+          paneId,
+          agentPaneOptionName,
+          agentPaneMarker,
+        ])
+
+      const focusWindow = (windowId: string, paneId: string) =>
+        Effect.gen(function* () {
+          yield* runTmux(["select-pane", "-t", paneId])
+          yield* runTmux(["select-window", "-t", windowId])
+        })
+
+      const recreateAgentPane = Effect.fn("Tmux.recreateAgentPane")(function* (
+        windowId: string,
+        input: JumpWindowInput,
+      ) {
+        const paneId = yield* runTmux([
+          "split-window",
+          "-h",
+          "-b",
+          "-P",
+          "-F",
+          "#{pane_id}",
+          "-t",
+          windowId,
+          "-c",
+          input.workingDirectory,
+          "--",
+          input.agentExecutable,
+          ...input.agentArguments,
+        ])
+        if (paneId.length === 0) {
+          return yield* new JumpFailed({
+            message: tmuxArrangeMessage(),
+          })
+        }
+        yield* tagAgentPane(paneId)
+        yield* runTmux(["select-layout", "-t", windowId, "even-horizontal"])
+        yield* focusWindow(windowId, paneId)
+      })
+
+      const createFreshWindow = Effect.fn("Tmux.createFreshWindow")(function* (
         input: JumpWindowInput,
       ) {
         const created = yield* runTmux([
@@ -85,6 +209,8 @@ export class Tmux extends Context.Service<
           "-P",
           "-F",
           "#{window_id} #{pane_id}",
+          "-n",
+          jumpWindowName(input.sessionId),
           "-c",
           input.workingDirectory,
           "--",
@@ -92,23 +218,109 @@ export class Tmux extends Context.Service<
           ...input.agentArguments,
         ])
         const [windowId, paneId] = created.split(/\s+/)
-        if (windowId === undefined || paneId === undefined) {
+        if (windowId === undefined) {
+          return yield* new JumpFailed({
+            message: tmuxArrangeMessage(),
+          })
+        }
+        if (paneId === undefined) {
+          yield* killCreatedWindow(windowId)
           return yield* new JumpFailed({
             message: tmuxArrangeMessage(),
           })
         }
 
-        yield* runTmux([
-          "split-window",
-          "-h",
-          "-t",
-          windowId,
-          "-c",
-          input.workingDirectory,
-        ])
-        yield* runTmux(["select-layout", "-t", windowId, "even-horizontal"])
-        yield* runTmux(["select-pane", "-t", paneId])
+        yield* Effect.gen(function* () {
+          yield* runTmux([
+            "set-option",
+            "-w",
+            "-t",
+            windowId,
+            sessionOptionName,
+            input.sessionId,
+          ])
+          yield* tagAgentPane(paneId)
+          yield* runTmux([
+            "split-window",
+            "-h",
+            "-t",
+            windowId,
+            "-c",
+            input.workingDirectory,
+          ])
+          yield* runTmux(["select-layout", "-t", windowId, "even-horizontal"])
+          yield* runTmux(["select-pane", "-t", paneId])
+        }).pipe(Effect.tapError(() => killCreatedWindow(windowId)))
         yield* runTmux(["select-window", "-t", windowId])
+      })
+
+      const resolveJumpTarget = Effect.fn("Tmux.resolveJumpTarget")(function* (
+        sessionId: string,
+      ) {
+        const currentSessionId = yield* runTmux([
+          "display-message",
+          "-p",
+          "#{session_id}",
+        ])
+        const listing = yield* runTmux([
+          "list-windows",
+          "-a",
+          "-F",
+          windowListFormat,
+        ])
+        const tagged = parseTaggedWindows(listing, sessionId)
+        const foreign = tagged.find(
+          (window) => window.tmuxSessionId !== currentSessionId,
+        )
+        if (foreign !== undefined) {
+          return {
+            kind: "foreign",
+            sessionName: foreign.sessionName,
+            windowIndex: foreign.windowIndex,
+          } as const
+        }
+        const current = tagged[0]
+        if (current === undefined) {
+          return { kind: "create" } as const
+        }
+        const panes = yield* runTmux([
+          "list-panes",
+          "-t",
+          current.windowId,
+          "-F",
+          paneListFormat,
+        ])
+        const paneId = taggedAgentPaneId(panes)
+        if (paneId === undefined) {
+          return { kind: "recreate", windowId: current.windowId } as const
+        }
+        return {
+          kind: "reuse",
+          windowId: current.windowId,
+          paneId,
+        } as const
+      })
+
+      const createJumpWindow = Effect.fn("Tmux.createJumpWindow")(function* (
+        input: JumpWindowInput,
+      ) {
+        const target: JumpTarget = yield* resolveJumpTarget(input.sessionId)
+        switch (target.kind) {
+          case "foreign":
+            return yield* new JumpFailed({
+              message: `Session already open in tmux session '${target.sessionName}' window ${target.windowIndex}`,
+            })
+          case "reuse":
+            return yield* focusWindow(target.windowId, target.paneId)
+          case "recreate":
+            return yield* recreateAgentPane(target.windowId, input)
+          case "create":
+            return yield* createFreshWindow(input)
+          default: {
+            const _exhaustive: never = target
+            return _exhaustive
+          }
+        }
       })
 
       return { requireAttachedSession, createJumpWindow }


### PR DESCRIPTION
Reuse an existing Interactive Session Continuation instead of starting a
second tmux writer.

`ready-for-agent jump` already created a split window for a Session.
Repeating the command could open another interactive writer on the same
Session. This change (#1019) scans the current tmux server first.

- Scan every session for a window tagged `@rfa-session-id` with the full
  Session ID.
- Same tmux session: select that window. If the `@rfa-agent` pane is gone,
  recreate the left agent pane, restore an even split, and focus it. A lone
  remaining tagged agent is reused (closing the shell does not spawn a
  second agent).
- Another tmux session: fail with that session name and window index, and
  do not switch the caller.
- New windows are named `rfa:<first-8>` and tagged immediately with the
  full Session ID. Display-name collisions are only cosmetic.
- On setup failure, kill only the window created by that invocation. A
  failed `select-window` after a completed layout leaves the tagged window
  in place.

Verified with `cli.test.ts` and `cli-process.test.ts` against a fake tmux
executable (reuse, recreate, foreign refuse, transactional kill, and
no-kill on client-switch failure). Simultaneous jumps may still race; V1
does not lock.

Closes #1019