### PR TITLE
feat(graphql-api): expose persisted Step Run cause chain to operators

### DIFF
--- a/apps/harness/src/home-page-content.tsx
+++ b/apps/harness/src/home-page-content.tsx
@@ -280,6 +280,14 @@ export type WorkItem = {
   status: WorkItemStatus
   statusLabel: string
   statusMessage: string | null
+  latestStepRunDetail: {
+    causeChain: readonly {
+      name: string | null
+      code: string | null
+      message: string | null
+    }[]
+    code: string | null
+  } | null
   postponedUntil: string | null
   paused: boolean
   canRetry: boolean
@@ -311,6 +319,14 @@ const workItemFields = {
   status: true,
   statusLabel: true,
   statusMessage: true,
+  latestStepRunDetail: {
+    causeChain: {
+      name: true,
+      code: true,
+      message: true,
+    },
+    code: true,
+  },
   postponedUntil: true,
   paused: true,
   canRetry: true,
@@ -3326,6 +3342,48 @@ export function WorkItemPauseButton({ workItem }: { workItem: WorkItem }) {
   )
 }
 
+function formatCauseChainLink(link: {
+  readonly name: string | null
+  readonly code: string | null
+  readonly message: string | null
+}): string {
+  const head = [link.name, link.code].filter(
+    (part) => part != null && part !== "",
+  )
+  const headText = head.join(" ")
+  if (link.message != null && link.message !== "") {
+    return headText === "" ? link.message : `${headText} — ${link.message}`
+  }
+  return headText
+}
+
+function CauseChainDisclosure({
+  detail,
+}: {
+  readonly detail: NonNullable<WorkItem["latestStepRunDetail"]>
+}) {
+  const hasCode = detail.code != null && detail.code !== ""
+  if (detail.causeChain.length === 0 && !hasCode) {
+    return null
+  }
+  return (
+    <details className={ui.statusMessageDetail}>
+      <summary className={ui.statusMessageDetailSummary}>Cause chain</summary>
+      {detail.causeChain.length > 0 ? (
+        <ol className={ui.statusMessageDetailList}>
+          {detail.causeChain.map((link) => {
+            const label = formatCauseChainLink(link)
+            return <li key={label}>{label}</li>
+          })}
+        </ol>
+      ) : null}
+      {hasCode ? (
+        <p className={ui.statusMessageDetailCode}>Code: {detail.code}</p>
+      ) : null}
+    </details>
+  )
+}
+
 export function WorkItemLifecycleStatus({
   workItem,
   compact = false,
@@ -3729,6 +3787,9 @@ export function WorkItemLifecycleStatus({
           ) : null}
           {workItem.statusMessage}
         </p>
+      )}
+      {workItem.latestStepRunDetail !== null && (
+        <CauseChainDisclosure detail={workItem.latestStepRunDetail} />
       )}
       {(canReset || canRetry) && (
         <div className="mt-2 flex flex-wrap gap-2">

--- a/apps/harness/src/ui.ts
+++ b/apps/harness/src/ui.ts
@@ -1011,6 +1011,14 @@ export const ui = {
 
   statusMessageMark: "text-lane-attention",
 
+  statusMessageDetail: "mt-[0.25rem] mb-0 font-mono text-[0.6rem] text-ink-2",
+
+  statusMessageDetailSummary: "cursor-pointer text-ink-2",
+
+  statusMessageDetailList: "mt-[0.3rem] mb-0 list-decimal pl-[1.1rem]",
+
+  statusMessageDetailCode: "mt-[0.25rem] mb-0",
+
   /* ---------- Journey-leg chips (board §5.2) — see also `leg*` above ---------- */
 
   legSummary: cx(

--- a/apps/harness/test/work-item-lifecycle-status.test.tsx
+++ b/apps/harness/test/work-item-lifecycle-status.test.tsx
@@ -18,6 +18,7 @@ const waitingForGitHubWorkItem = {
   status: "WAITING_FOR_GITHUB",
   statusLabel: "Waiting for GitHub",
   statusMessage: "Waiting for GitHub until 2026-08-07T12:00:00.000Z",
+  latestStepRunDetail: null,
   postponedUntil: "2026-08-07T12:00:00.000Z",
   paused: false,
   canRetry: false,
@@ -51,5 +52,51 @@ describe("WorkItemLifecycleStatus", () => {
     expect(html).toContain("Waiting for GitHub until 2026-08-07T12:00:00.000Z")
     expect(html).toContain("Status checks: Postponed")
     expect(html).not.toContain(">Retry<")
+    expect(html).not.toContain("Cause chain")
+  })
+
+  test("hides the cause chain behind a collapsed disclosure on a failed card", () => {
+    const failedWorkItem = {
+      ...waitingForGitHubWorkItem,
+      state: "IMPLEMENT",
+      stateLabel: "Build",
+      status: "FAILED",
+      statusLabel: "Failed",
+      statusMessage: 'Executable not found in $PATH: "claude"',
+      postponedUntil: null,
+      canRetry: true,
+      latestStepRunDetail: {
+        code: "ENOENT",
+        causeChain: [
+          {
+            name: "Error",
+            code: "ENOENT",
+            message: 'ENOENT: Executable not found in $PATH: "claude"',
+          },
+        ],
+      },
+      lifecycleLabels: [
+        {
+          phase: "IMPLEMENT",
+          label: "Build: Failed",
+          status: "FAILED",
+          durationMs: 1200,
+        },
+      ],
+    } satisfies WorkItem
+
+    const queryClient = new QueryClient()
+    const html = renderToStaticMarkup(
+      <QueryClientProvider client={queryClient}>
+        <WorkItemLifecycleStatus workItem={failedWorkItem} compact />
+      </QueryClientProvider>,
+    )
+
+    expect(html).toContain("Executable not found in $PATH: &quot;claude&quot;")
+    expect(html).toContain("Cause chain")
+    expect(html).toContain("<details")
+    expect(html).not.toMatch(/<details[^>]*\sopen/)
+    expect(html).toContain("Error ENOENT")
+    expect(html).toContain("Code: ENOENT")
   })
 })

--- a/packages/github-service/src/lib/error-cause-chain.ts
+++ b/packages/github-service/src/lib/error-cause-chain.ts
@@ -150,6 +150,47 @@ export const serializeReasonDetail = (
 ): string | null => (detail === null ? null : JSON.stringify(detail))
 
 /**
+ * Read path for `step_run.reason_detail`. Re-sanitizes each stored message so
+ * display surfaces do not become a second disclosure path for helper text.
+ */
+export const parseReasonDetail = (
+  raw: string | null | undefined,
+): StepRunReasonDetail | null => {
+  if (raw === null || raw === undefined) return null
+  const trimmed = raw.trim()
+  if (trimmed.length === 0) return null
+
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(trimmed)
+  } catch {
+    return null
+  }
+
+  const record = asRecord(parsed)
+  if (record === null) return null
+
+  const causeChain: CauseChainLink[] = []
+  if (Array.isArray(record.causeChain)) {
+    for (const item of record.causeChain) {
+      const link = linkFromValue(item)
+      if (link !== null) {
+        causeChain.push(link)
+      }
+    }
+  }
+
+  const code = readCode(record.code)
+  if (causeChain.length === 0 && code === undefined) {
+    return null
+  }
+  return {
+    causeChain,
+    ...(code !== undefined ? { code } : {}),
+  }
+}
+
+/**
  * Structured log annotations for a failure: short human `error` plus
  * `causeChain` / optional `code` so operators can distinguish TLS, auth,
  * timeout, and transport failures without prose parsing.

--- a/packages/github-service/test/github-service.spec.ts
+++ b/packages/github-service/test/github-service.spec.ts
@@ -18,6 +18,7 @@ import {
   logErrorAnnotations,
   makeGitHubServiceFromToken,
   makeGitHubServiceTest,
+  parseReasonDetail,
   sanitizeUserFacingText,
   serializeReasonDetail,
   stripAnsi,
@@ -4060,6 +4061,63 @@ describe("error cause chain", () => {
     expect(extractCauseChain(timeout)).toEqual([
       { name: "TimeoutError", code: "TIMEOUT" },
     ])
+  })
+
+  it("parses a persisted reason_detail blob into the typed cause chain", () => {
+    const detail = {
+      causeChain: [
+        {
+          name: "GitHubRequestError",
+          code: "SELF_SIGNED_CERT_IN_CHAIN",
+          message: "Failed to list Ready-labeled Issues for acme/widgets",
+        },
+        {
+          name: "Error",
+          code: "SELF_SIGNED_CERT_IN_CHAIN",
+          message: "self-signed certificate in certificate chain",
+        },
+      ],
+      code: "SELF_SIGNED_CERT_IN_CHAIN",
+    }
+
+    expect(parseReasonDetail(JSON.stringify(detail))).toEqual(detail)
+  })
+
+  it("returns null for missing, empty, or unparseable reason_detail", () => {
+    expect(parseReasonDetail(null)).toBeNull()
+    expect(parseReasonDetail(undefined)).toBeNull()
+    expect(parseReasonDetail("")).toBeNull()
+    expect(parseReasonDetail("   ")).toBeNull()
+    expect(parseReasonDetail("not-json")).toBeNull()
+    expect(parseReasonDetail("[]")).toBeNull()
+    expect(parseReasonDetail(JSON.stringify({}))).toBeNull()
+  })
+
+  it("re-sanitizes stored link messages on parse", () => {
+    const esc = String.fromCharCode(0x1b)
+    const parsed = parseReasonDetail(
+      JSON.stringify({
+        causeChain: [
+          {
+            name: "Error",
+            code: "ENOENT",
+            message: `${esc}[31mENOENT: Executable not found in $PATH: "claude"${esc}[0m`,
+          },
+        ],
+        code: "ENOENT",
+      }),
+    )
+
+    expect(parsed).toEqual({
+      causeChain: [
+        {
+          name: "Error",
+          code: "ENOENT",
+          message: 'ENOENT: Executable not found in $PATH: "claude"',
+        },
+      ],
+      code: "ENOENT",
+    })
   })
 })
 

--- a/packages/graphql-api/src/lib/graphql-api.ts
+++ b/packages/graphql-api/src/lib/graphql-api.ts
@@ -81,6 +81,7 @@ import {
   workIssueProjection,
   workItemCanRetry,
   workItemIsTerminal,
+  workItemLatestStepRunDetail,
   workItemPostponedUntil,
   workItemStateLabel,
   workItemStatus,
@@ -1130,6 +1131,8 @@ export const createGraphqlApi = <R>(
               context,
             )
           },
+          latestStepRunDetail: (workItem: WorkItemRecord) =>
+            workItemLatestStepRunDetail(workItem),
           postponedUntil: (workItem: WorkItemRecord) =>
             workItemPostponedUntil(workItem)?.toISOString() ?? null,
           paused: (workItem: WorkItemRecord) => workItem.paused,

--- a/packages/graphql-api/src/lib/work-item-projection.ts
+++ b/packages/graphql-api/src/lib/work-item-projection.ts
@@ -1,5 +1,9 @@
 import type { IssueRecord } from "@ready-for-agent/db-service"
 import {
+  type StepRunReasonDetail,
+  parseReasonDetail,
+} from "@ready-for-agent/github-service"
+import {
   LIFECYCLE_STEP_RETRYABLE,
   type OperationalLifecycleStep,
   type TerminalWorkItemState,
@@ -254,6 +258,15 @@ export const workItemStatusMessage = (
   }
   return latest.reasonMessage
 }
+
+/**
+ * Parsed `reason_detail` from the latest Step Run. Null when that run has no
+ * persisted cause chain. Messages are re-sanitized on parse.
+ */
+export const workItemLatestStepRunDetail = (
+  workItem: WorkItemRecord,
+): StepRunReasonDetail | null =>
+  parseReasonDetail(latestStepRun(workItem)?.reasonDetail)
 
 /**
  * Cumulative wall-clock execution time for a phase across every attempt in

--- a/packages/graphql-api/test/graphql-api.test.ts
+++ b/packages/graphql-api/test/graphql-api.test.ts
@@ -4816,6 +4816,82 @@ describe("GraphQL API", () => {
     })
   })
 
+  test("exposes the latest Step Run cause chain as latestStepRunDetail", async () => {
+    const baseRun = workItem.stepRuns[0]!
+    const failedReview = {
+      ...workItem,
+      state: "review",
+      stepRuns: [
+        {
+          ...baseRun,
+          step: "review",
+          status: "failed",
+          reasonCode: STEP_RUN_REASON.handlerFailed,
+          reasonMessage: "OpenCode failed to review the Work Item",
+          reasonDetail: JSON.stringify({
+            causeChain: [
+              {
+                name: "Error",
+                code: "ENOENT",
+                message: 'ENOENT: Executable not found in $PATH: "claude"',
+              },
+            ],
+            code: "ENOENT",
+          }),
+        },
+      ],
+    } as WorkItemRecord
+    await runtime.dispose()
+    runtime = makeRuntime(
+      {},
+      {},
+      {},
+      {
+        listWorkItemsForIssue: () => Effect.succeed([failedReview]),
+      },
+    )
+
+    const response = await createGraphqlApi(runtime).fetch(
+      graphqlRequest({
+        query: `query WorkItems($repositoryId: ID!, $issueNumber: Int!) {
+          workItems(repositoryId: $repositoryId, issueNumber: $issueNumber) {
+            status
+            statusMessage
+            latestStepRunDetail {
+              code
+              causeChain { name code message }
+            }
+          }
+        }`,
+        variables: {
+          repositoryId: repository.id,
+          issueNumber: issue.issueNumber,
+        },
+      }),
+    )
+
+    expect(await response.json()).toEqual({
+      data: {
+        workItems: [
+          {
+            status: "FAILED",
+            statusMessage: "OpenCode failed to review the Work Item",
+            latestStepRunDetail: {
+              code: "ENOENT",
+              causeChain: [
+                {
+                  name: "Error",
+                  code: "ENOENT",
+                  message: 'ENOENT: Executable not found in $PATH: "claude"',
+                },
+              ],
+            },
+          },
+        ],
+      },
+    })
+  })
+
   test("keeps failed Review reasonMessage as statusMessage", async () => {
     const baseRun = workItem.stepRuns[0]!
     const failedReview = {

--- a/packages/graphql-api/test/work-item-projection.test.ts
+++ b/packages/graphql-api/test/work-item-projection.test.ts
@@ -4,6 +4,7 @@ import {
   lifecycleLabels,
   statusLabel,
   workItemCanRetry,
+  workItemLatestStepRunDetail,
   workItemPostponedUntil,
   workItemStatus,
   workItemStatusMessage,
@@ -21,6 +22,7 @@ const baseStepRun = {
   finishedAt: new Date("2026-07-14T08:38:36.000Z"),
   reasonCode: null,
   reasonMessage: null,
+  reasonDetail: null,
   postponedUntil: null,
   queueWaitMs: 1_000,
   executionDurationMs: 2_315_000, // 38m 35s
@@ -403,5 +405,47 @@ describe("lifecycleLabels cumulative duration", () => {
         durationMs: 10_000,
       },
     ])
+  })
+})
+
+describe("workItemLatestStepRunDetail", () => {
+  test("returns null when the latest Step Run has no persisted detail", () => {
+    expect(workItemLatestStepRunDetail(baseWorkItem)).toBeNull()
+  })
+
+  test("parses the latest Step Run cause chain for operator display", () => {
+    const failed = workItemWith({
+      state: "implement",
+      stepRuns: [
+        {
+          ...baseStepRun,
+          step: "implement",
+          status: "failed",
+          reasonCode: "handler_failed",
+          reasonMessage: 'Executable not found in $PATH: "claude"',
+          reasonDetail: JSON.stringify({
+            causeChain: [
+              {
+                name: "Error",
+                code: "ENOENT",
+                message: 'ENOENT: Executable not found in $PATH: "claude"',
+              },
+            ],
+            code: "ENOENT",
+          }),
+        },
+      ],
+    })
+
+    expect(workItemLatestStepRunDetail(failed)).toEqual({
+      causeChain: [
+        {
+          name: "Error",
+          code: "ENOENT",
+          message: 'ENOENT: Executable not found in $PATH: "claude"',
+        },
+      ],
+      code: "ENOENT",
+    })
   })
 })

--- a/packages/graphql-schema/schema.graphql
+++ b/packages/graphql-schema/schema.graphql
@@ -652,6 +652,17 @@ enum MergeMode {
   ALWAYS
 }
 
+type CauseChainLink {
+  name: String
+  code: String
+  message: String
+}
+
+type StepRunReasonDetail {
+  causeChain: [CauseChainLink!]!
+  code: String
+}
+
 type WorkItem {
   id: ID!
   repositoryId: ID!
@@ -671,6 +682,12 @@ type WorkItem {
   status: WorkItemStatus!
   statusLabel: String!
   statusMessage: String
+  """
+  Parsed diagnostic payload from the latest Step Run's reason_detail.
+  Null when that Step Run has no persisted cause chain. Messages are
+  already sanitized at write time and re-sanitized on read.
+  """
+  latestStepRunDetail: StepRunReasonDetail
   """
   Retry deadline on the latest Postponed Step Run. Null unless the Work Item
   is Waiting for GitHub.

--- a/packages/graphql-schema/schema.template.graphql
+++ b/packages/graphql-schema/schema.template.graphql
@@ -630,6 +630,17 @@ enum MergeMode {
   ALWAYS
 }
 
+type CauseChainLink {
+  name: String
+  code: String
+  message: String
+}
+
+type StepRunReasonDetail {
+  causeChain: [CauseChainLink!]!
+  code: String
+}
+
 type WorkItem {
   id: ID!
   repositoryId: ID!
@@ -649,6 +660,12 @@ type WorkItem {
   status: WorkItemStatus!
   statusLabel: String!
   statusMessage: String
+  """
+  Parsed diagnostic payload from the latest Step Run's reason_detail.
+  Null when that Step Run has no persisted cause chain. Messages are
+  already sanitized at write time and re-sanitized on read.
+  """
+  latestStepRunDetail: StepRunReasonDetail
   """
   Retry deadline on the latest Postponed Step Run. Null unless the Work Item
   is Waiting for GitHub.

--- a/packages/work-item-lifecycle/src/lib/types.ts
+++ b/packages/work-item-lifecycle/src/lib/types.ts
@@ -73,6 +73,11 @@ interface StepRunRecordBase {
   readonly finishedAt: Date | null
   readonly reasonCode: string | null
   readonly reasonMessage: string | null
+  /**
+   * JSON diagnostic payload for failed Step Runs (cause chain + machine
+   * code). Null when nothing was persisted.
+   */
+  readonly reasonDetail: string | null
   /** Time from queued until start (or finish/now if never started). */
   readonly queueWaitMs: number
   /** Time from start until finish/now; null when execution never began. */

--- a/packages/work-item-lifecycle/src/lib/work-item-lifecycle.ts
+++ b/packages/work-item-lifecycle/src/lib/work-item-lifecycle.ts
@@ -354,6 +354,7 @@ type StepRunRow = {
   readonly finished_at: number | null
   readonly reason_code: string | null
   readonly reason_message: string | null
+  readonly reason_detail: string | null
   readonly postponed_until: number | null
   readonly session_wait_ms: number | null
   readonly session_wait_started_at: number | null
@@ -432,7 +433,8 @@ const decodeLatestStepRunDeadlineRows = (rows: unknown) =>
 
 const STEP_RUN_SELECT_COLUMNS = `id, work_item_id, step, status, queue_job_id, queued_at,
                         started_at, finished_at, reason_code, reason_message,
-                        postponed_until, session_wait_ms, session_wait_started_at`
+                        reason_detail, postponed_until, session_wait_ms,
+                        session_wait_started_at`
 
 const deriveQueueWaitMs = (row: StepRunRow, nowMs: number): number => {
   const endMs = row.started_at ?? row.finished_at ?? nowMs
@@ -461,6 +463,7 @@ const toStepRunRecord = (row: StepRunRow, nowMs: number): StepRunRecord => {
     finishedAt: row.finished_at === null ? null : new Date(row.finished_at),
     reasonCode: row.reason_code,
     reasonMessage: row.reason_message,
+    reasonDetail: row.reason_detail,
     queueWaitMs: deriveQueueWaitMs(row, nowMs),
     executionDurationMs: deriveExecutionDurationMs(row, nowMs),
   }

--- a/packages/work-item-lifecycle/test/work-item-lifecycle.spec.ts
+++ b/packages/work-item-lifecycle/test/work-item-lifecycle.spec.ts
@@ -8375,6 +8375,9 @@ describe("WorkItemLifecycle", () => {
           expect(final.state).toBe("create_worktree")
           expect(final.stepRuns).toHaveLength(1)
           expect(final.stepRuns[0]!.status).toBe("failed")
+          expect(final.stepRuns[0]!.reasonDetail).toBe(
+            detailRows[0]!.reason_detail,
+          )
         }),
       )
     })


### PR DESCRIPTION
Failed Step Runs already persisted a structured `reason_detail` cause
chain (`#950` / `buildReasonDetail`), but nothing in GraphQL or the
Harness UI read it. Operators only saw the short `statusMessage`. The
`#1023` incident (`ENOENT` for a missing `claude` binary) was sitting
in SQLite the whole time.

This adds the general-case read path from `#1024`:

- Load `step_run.reason_detail` onto `StepRunRecord`.
- Parse it into `{ code, causeChain: [{ name, code, message }] }`
  (`parseReasonDetail` re-runs `sanitizeUserFacingText`; this is
  display of already-sanitized write-path data, not a new Keymaxxer
  disclosure path).
- Expose `WorkItem.latestStepRunDetail` on GraphQL.
- Show the chain on failed cards as a collapsed **Cause chain**
  disclosure under the existing one-line `statusMessage`.

Review follow-up trimmed a parse-site sentence from the `reasonDetail`
JSDoc. Content-based React keys on the static chain list were deferred
(Biome forbids index keys; no runtime impact).

Verified with github-service parse tests, GraphQL projection +
`latestStepRunDetail` query tests, a lifecycle load-path assertion,
and the failed-card disclosure unit test. Not exercised against a live
failed Work Item in a running Harness.

Closes #1024