### PR TITLE
fix(github-service): classify GraphQL repository NOT_FOUND and name the token login (#1028)

### DIFF
--- a/packages/github-service/src/lib/errors.ts
+++ b/packages/github-service/src/lib/errors.ts
@@ -6,8 +6,22 @@ export class GitHubRepositoryUnavailableError extends Schema.TaggedErrorClass<Gi
     forge: Schema.String,
     forgeHost: Schema.String,
     projectPath: Schema.String,
+    /**
+     * Viewer login for the token that could not see the Repository, when
+     * resolved. Same identity can produce GitHub's NOT_FOUND for a private
+     * repo the account cannot access.
+     */
+    authenticatedLogin: Schema.optional(Schema.String),
+    message: Schema.optional(Schema.String),
   },
 ) {}
+
+/** Operator-facing copy when a token cannot see a Repository. */
+export const formatGitHubRepositoryUnavailableMessage = (
+  projectPath: string,
+  authenticatedLogin: string,
+): string =>
+  `${projectPath} is not visible to GitHub user ${authenticatedLogin} — it may not exist, or that account may not have access`
 
 export class GitHubRequestError extends Schema.TaggedErrorClass<GitHubRequestError>()(
   "GitHubRequestError",

--- a/packages/github-service/src/lib/github-service-live.ts
+++ b/packages/github-service/src/lib/github-service-live.ts
@@ -39,6 +39,7 @@ import {
   GitHubRequestError,
   type GitHubThrottledError,
   GitHubTlsTrustError,
+  formatGitHubRepositoryUnavailableMessage,
   isGitHubThrottledError,
 } from "./errors.js"
 import { GitHubService, type GitHubServiceShape } from "./github-service.js"
@@ -137,13 +138,61 @@ const tlsTrustErrorFromCause = (
   })
 }
 
+const graphqlErrorField = (entry: unknown, field: string): unknown =>
+  typeof entry === "object" && entry !== null
+    ? Reflect.get(entry, field)
+    : undefined
+
+const isGraphqlRepositoryNotFound = (cause: unknown): cause is GenqlError => {
+  if (!(cause instanceof GenqlError)) {
+    return false
+  }
+  return cause.errors.some((entry) => {
+    if (graphqlErrorField(entry, "type") !== "NOT_FOUND") {
+      return false
+    }
+    const path = graphqlErrorField(entry, "path")
+    return Array.isArray(path) && path.length === 1 && path[0] === "repository"
+  })
+}
+
+const repositoryFromGraphqlNotFound = (
+  cause: GenqlError,
+): GitHubApiRepository => {
+  for (const entry of cause.errors) {
+    const message = graphqlErrorField(entry, "message")
+    if (typeof message !== "string") {
+      continue
+    }
+    const match = message.match(
+      /Could not resolve to a Repository with the name '([^']+)'/,
+    )
+    const nameWithOwner = match?.[1]
+    if (nameWithOwner === undefined) {
+      continue
+    }
+    const separator = nameWithOwner.indexOf("/")
+    if (separator <= 0 || separator === nameWithOwner.length - 1) {
+      continue
+    }
+    return {
+      owner: nameWithOwner.slice(0, separator),
+      name: nameWithOwner.slice(separator + 1),
+    }
+  }
+  return { owner: "", name: "" }
+}
+
+type GitHubRequestFailure =
+  | GitHubRequestError
+  | GitHubThrottledError
+  | GitHubTlsTrustError
+  | GitHubApiRepositoryUnavailableError
+
 const githubRequest = <A>(
   message: string,
   request: (signal: AbortSignal) => Promise<A>,
-): Effect.Effect<
-  A,
-  GitHubRequestError | GitHubThrottledError | GitHubTlsTrustError
-> =>
+): Effect.Effect<A, GitHubRequestFailure> =>
   Effect.tryPromise({
     try: request,
     catch: (cause) => {
@@ -157,6 +206,11 @@ const githubRequest = <A>(
         message: cause instanceof Error ? cause.message : "",
       })
       if (throttle !== undefined) return throttle
+      if (isGraphqlRepositoryNotFound(cause)) {
+        return new GitHubApiRepositoryUnavailableError(
+          repositoryFromGraphqlNotFound(cause),
+        )
+      }
       const code = extractErrorCode(cause)
       return new GitHubRequestError({
         message,
@@ -189,10 +243,7 @@ const githubRequest = <A>(
 const githubQuery = <A>(
   message: string,
   request: (signal: AbortSignal) => Promise<A>,
-): Effect.Effect<
-  A,
-  GitHubRequestError | GitHubThrottledError | GitHubTlsTrustError
-> =>
+): Effect.Effect<A, GitHubRequestFailure> =>
   githubRequest(message, request).pipe(
     Effect.retry({
       schedule: Schedule.addDelay(Schedule.recurs(2), () =>
@@ -308,10 +359,7 @@ export type LoadPrStatusCheckDiagnostics = (
   checks: readonly PrStatusCheckDiagnosticsRequest[],
   options: PrStatusCheckDiagnosticsOptions,
   signal?: AbortSignal,
-) => Effect.Effect<
-  readonly PrStatusCheckDiagnostic[],
-  GitHubRequestError | GitHubThrottledError | GitHubTlsTrustError
->
+) => Effect.Effect<readonly PrStatusCheckDiagnostic[], GitHubRequestFailure>
 
 /** Rerun an entire GitHub Actions workflow run. */
 export type RerunWorkflowRun = (
@@ -326,10 +374,7 @@ export type ObserveAutomatedReviewEvidence = (
   headRefName: string,
   checks: readonly AutomatedReviewEvidenceCheck[],
   signal?: AbortSignal,
-) => Effect.Effect<
-  AutomatedReviewEvidenceObservation,
-  GitHubRequestError | GitHubThrottledError | GitHubTlsTrustError
->
+) => Effect.Effect<AutomatedReviewEvidenceObservation, GitHubRequestFailure>
 
 const emptyTerminalChecks: readonly TerminalPrStatusCheck[] = []
 
@@ -2003,6 +2048,7 @@ const makeGitHubApiService = (
       let mergedPullRequest: GitHubMergePullRequestSnapshot | null | undefined
       if (Result.isFailure(mutationResult)) {
         if (
+          mutationResult.failure._tag !== "GitHubRequestError" ||
           !(mutationResult.failure.cause instanceof GenqlError) ||
           !isMergeGraphqlRejection(mutationResult.failure.cause)
         ) {
@@ -2752,7 +2798,41 @@ const toGitHubApiRepository = (
   }
 }
 
+const toPublicRepositoryUnavailable = (
+  service: GitHubApiServiceShape,
+  repository: GitHubRepository,
+) =>
+  Effect.gen(function* () {
+    const loginResult = yield* service
+      .getAuthenticatedUserLogin(toGitHubApiRepository(repository))
+      .pipe(Effect.result)
+    if (Result.isFailure(loginResult)) {
+      const error = loginResult.failure
+      if (
+        error._tag === "GitHubThrottledError" ||
+        error._tag === "GitHubTlsTrustError" ||
+        (error._tag === "GitHubRequestError" && error.statusCode === 401)
+      ) {
+        return yield* error
+      }
+      return yield* new GitHubRepositoryUnavailableError(repository)
+    }
+    const authenticatedLogin = loginResult.success.trim()
+    if (authenticatedLogin === "") {
+      return yield* new GitHubRepositoryUnavailableError(repository)
+    }
+    return yield* new GitHubRepositoryUnavailableError({
+      ...repository,
+      authenticatedLogin,
+      message: formatGitHubRepositoryUnavailableMessage(
+        repository.projectPath,
+        authenticatedLogin,
+      ),
+    })
+  })
+
 const adaptRepository =
+  (service: GitHubApiServiceShape) =>
   <Args extends readonly unknown[], A, E, R>(
     method: (
       repository: GitHubApiRepository,
@@ -2762,10 +2842,18 @@ const adaptRepository =
   (
     repository: GitHubRepository,
     ...args: Args
-  ): Effect.Effect<A, E | GitHubRepositoryUnavailableError, R> =>
+  ): Effect.Effect<
+    A,
+    | E
+    | GitHubRepositoryUnavailableError
+    | GitHubRequestError
+    | GitHubThrottledError
+    | GitHubTlsTrustError,
+    R
+  > =>
     method(toGitHubApiRepository(repository), ...args).pipe(
       Effect.catchTag("GitHubApiRepositoryUnavailableError", () =>
-        Effect.fail(new GitHubRepositoryUnavailableError(repository)),
+        toPublicRepositoryUnavailable(service, repository),
       ),
     )
 
@@ -2783,43 +2871,30 @@ export const makeGitHubService = (
     rerunWorkflowRunImpl,
     observeAutomatedReviewEvidenceImpl,
   )
+  const adapt = adaptRepository(service)
   return {
-    getAuthenticatedUserLogin: adaptRepository(
-      service.getAuthenticatedUserLogin,
-    ),
-    listReadyIssues: adaptRepository(service.listReadyIssues),
-    getPullRequestCheckStatus: adaptRepository(
-      service.getPullRequestCheckStatus,
-    ),
-    getPrStatusCheckDiagnostics: adaptRepository(
-      service.getPrStatusCheckDiagnostics,
-    ),
-    observeAutomatedReviewEvidence: adaptRepository(
+    getAuthenticatedUserLogin: adapt(service.getAuthenticatedUserLogin),
+    listReadyIssues: adapt(service.listReadyIssues),
+    getPullRequestCheckStatus: adapt(service.getPullRequestCheckStatus),
+    getPrStatusCheckDiagnostics: adapt(service.getPrStatusCheckDiagnostics),
+    observeAutomatedReviewEvidence: adapt(
       service.observeAutomatedReviewEvidence,
     ),
-    getPullRequestLifecycleStatus: adaptRepository(
-      service.getPullRequestLifecycleStatus,
-    ),
-    getOpenPullRequestNumber: adaptRepository(service.getOpenPullRequestNumber),
-    findOpenPullRequestNumber: adaptRepository(
-      service.findOpenPullRequestNumber,
-    ),
-    closeOpenPullRequestsAndDeleteBranch: adaptRepository(
+    getPullRequestLifecycleStatus: adapt(service.getPullRequestLifecycleStatus),
+    getOpenPullRequestNumber: adapt(service.getOpenPullRequestNumber),
+    findOpenPullRequestNumber: adapt(service.findOpenPullRequestNumber),
+    closeOpenPullRequestsAndDeleteBranch: adapt(
       service.closeOpenPullRequestsAndDeleteBranch,
     ),
-    countOpenNonDraftPullRequests: adaptRepository(
-      service.countOpenNonDraftPullRequests,
-    ),
-    createDraftPullRequest: adaptRepository(service.createDraftPullRequest),
-    updateOpenDraftPullRequestCopy: adaptRepository(
+    countOpenNonDraftPullRequests: adapt(service.countOpenNonDraftPullRequests),
+    createDraftPullRequest: adapt(service.createDraftPullRequest),
+    updateOpenDraftPullRequestCopy: adapt(
       service.updateOpenDraftPullRequestCopy,
     ),
-    markPullRequestReadyForReview: adaptRepository(
-      service.markPullRequestReadyForReview,
-    ),
-    mergePullRequest: adaptRepository(service.mergePullRequest),
-    rerunWorkflowRun: adaptRepository(service.rerunWorkflowRun),
-    ensureIssueCompletedWithSummary: adaptRepository(
+    markPullRequestReadyForReview: adapt(service.markPullRequestReadyForReview),
+    mergePullRequest: adapt(service.mergePullRequest),
+    rerunWorkflowRun: adapt(service.rerunWorkflowRun),
+    ensureIssueCompletedWithSummary: adapt(
       service.ensureIssueCompletedWithSummary,
     ),
   }

--- a/packages/github-service/test/github-service.spec.ts
+++ b/packages/github-service/test/github-service.spec.ts
@@ -36,6 +36,31 @@ const repository = {
 }
 const apiRepository = { owner: "acme", name: "widgets" }
 
+const graphqlQueryText = (init?: RequestInit): string => {
+  if (typeof init?.body !== "string") {
+    return ""
+  }
+  try {
+    const parsed: unknown = JSON.parse(init.body)
+    if (
+      typeof parsed === "object" &&
+      parsed !== null &&
+      "query" in parsed &&
+      typeof parsed.query === "string"
+    ) {
+      return parsed.query
+    }
+  } catch {
+    return ""
+  }
+  return ""
+}
+
+const jsonGraphqlResponse = (body: unknown): Response =>
+  new Response(JSON.stringify(body), {
+    headers: { "content-type": "application/json" },
+  })
+
 const issue = (
   number: number,
   state: "OPEN" | "CLOSED" = "OPEN",
@@ -210,6 +235,155 @@ describe("GitHubService live implementation", () => {
       expect(requests).toBe(1)
     }),
   )
+
+  it.effect(
+    "classifies GraphQL repository NOT_FOUND as unavailable and names the token identity",
+    () =>
+      Effect.gen(function* () {
+        let repositoryQueries = 0
+        const service = makeGitHubServiceFromToken(
+          "token",
+          async (_input, init) => {
+            const query = graphqlQueryText(init)
+            if (query.includes("viewer")) {
+              return jsonGraphqlResponse({
+                data: { viewer: { login: "octocat" } },
+              })
+            }
+            repositoryQueries += 1
+            return jsonGraphqlResponse({
+              data: { repository: null },
+              errors: [
+                {
+                  type: "NOT_FOUND",
+                  path: ["repository"],
+                  message:
+                    "Could not resolve to a Repository with the name 'acme/widgets'.",
+                },
+              ],
+            })
+          },
+        )
+
+        const error = yield* service
+          .getPullRequestCheckStatus(repository, "rfa/acme-widgets/8/wi-1")
+          .pipe(Effect.flip)
+
+        expect(error).toBeInstanceOf(GitHubRepositoryUnavailableError)
+        expect(error).not.toBeInstanceOf(GitHubRequestError)
+        expect(formatUserFacingError(error)).toBe(
+          "acme/widgets is not visible to GitHub user octocat — it may not exist, or that account may not have access",
+        )
+        expect(
+          error instanceof GitHubRepositoryUnavailableError
+            ? error.authenticatedLogin
+            : undefined,
+        ).toBe("octocat")
+        expect(repositoryQueries).toBe(1)
+      }),
+  )
+
+  it.effect(
+    "propagates a throttle from the identity lookup after repository NOT_FOUND",
+    () =>
+      Effect.gen(function* () {
+        const resetSeconds = Math.floor(Date.now() / 1_000) + 120
+        const service = makeGitHubServiceFromToken(
+          "token",
+          async (_input, init) => {
+            const query = graphqlQueryText(init)
+            if (query.includes("viewer")) {
+              return new Response("API rate limit exceeded", {
+                status: 403,
+                headers: {
+                  "x-ratelimit-remaining": "0",
+                  "x-ratelimit-reset": String(resetSeconds),
+                },
+              })
+            }
+            return jsonGraphqlResponse({
+              data: { repository: null },
+              errors: [
+                {
+                  type: "NOT_FOUND",
+                  path: ["repository"],
+                  message:
+                    "Could not resolve to a Repository with the name 'acme/widgets'.",
+                },
+              ],
+            })
+          },
+        )
+
+        const error = yield* service
+          .getPullRequestCheckStatus(repository, "rfa/acme-widgets/8/wi-1")
+          .pipe(Effect.flip)
+
+        expect(error).toBeInstanceOf(GitHubThrottledError)
+        expect(error.retryAt).toBe(resetSeconds * 1_000)
+      }),
+  )
+
+  it.effect(
+    "keeps GraphQL NOT_FOUND on a nested field as a non-retryable request error",
+    () =>
+      Effect.gen(function* () {
+        let requests = 0
+        const service = makeGitHubService({
+          query: () => {
+            requests += 1
+            return Promise.reject(
+              new GenqlError(
+                [
+                  {
+                    type: "NOT_FOUND",
+                    path: ["repository", "issue"],
+                    message:
+                      "Could not resolve to an Issue with the number of 99.",
+                  },
+                ],
+                { repository: { issue: null } },
+              ),
+            )
+          },
+        })
+
+        const error = yield* service
+          .ensureIssueCompletedWithSummary(
+            repository,
+            99,
+            "wi-01HXSQK2KG72RRYVWEQH4S83FK",
+            "## Summary",
+          )
+          .pipe(Effect.flip)
+
+        expect(error).toBeInstanceOf(GitHubRequestError)
+        expect((error as GitHubRequestError).retryable).toBe(false)
+        expect(requests).toBe(1)
+      }),
+  )
+
+  it("retries HTTP 5xx as a retryable request error", async () => {
+    let requests = 0
+    const service = makeGitHubServiceFromToken("token", async () => {
+      requests += 1
+      return new Response("backend unavailable", {
+        status: 502,
+        statusText: "Bad Gateway",
+      })
+    })
+
+    const error = await Effect.runPromise(
+      service
+        .getPullRequestCheckStatus(repository, "rfa/acme-widgets/8/wi-1")
+        .pipe(Effect.flip),
+    )
+
+    expect(error).toBeInstanceOf(GitHubRequestError)
+    expect((error as GitHubRequestError).statusCode).toBe(502)
+    expect((error as GitHubRequestError).retryable).toBe(true)
+    expect(requests).toBe(3)
+  })
 
   it.effect(
     "classifies TLS certificate trust failures as non-retryable GitHubTlsTrustError",


### PR DESCRIPTION
GitHub answers a Repository the token cannot see with `data.repository: null` and
`errors: [{ type: "NOT_FOUND", path: ["repository"] }]`. Genql throws before the
`result.repository === null` guards, so `watch_pr_status_checks` stored a generic
`GitHubRequestError` that read like a wrong `projectPath`. The authenticated login
that produced the `NOT_FOUND` was never recorded (#1028).

This inspects `GenqlError.errors[].type` in `githubRequest` and maps a `NOT_FOUND`
on the `repository` field to `GitHubApiRepositoryUnavailableError`. Nested
`NOT_FOUND` (for example on `repository.issue`) stays a non-retryable
`GitHubRequestError`. The adapter then resolves the viewer login and sets an
operator-facing message such as `acme/widgets is not visible to GitHub user
octocat — it may not exist, or that account may not have access`. A follow-up
viewer throttle, HTTP 401, or TLS trust failure is propagated instead of being
rewritten as login-less unavailable.

Primary-request 401, permission 403, HTTP 5xx retry, and throttle classification
are unchanged. Repository-unavailable is not retried within a single token.

Verified with `bunx nx test github-service` (148 tests) and
`bunx nx typecheck github-service`, including the stubbed
`{ data: { repository: null }, errors: [{ type: "NOT_FOUND" }] }` check-status
path, login in `formatUserFacingError`, a throttled viewer follow-up,
nested-field `NOT_FOUND`, and HTTP 502 retry. Not run against a live private
Repository with a wrong `gh` account. The GitHub helper still exits 2 without
copying that message across the credential boundary.

Closes #1028