### PR TITLE
fix(harness): re-resolve ambient gh token on repository-unavailable

### DIFF
--- a/apps/harness/src/server/ambient-github-layer.ts
+++ b/apps/harness/src/server/ambient-github-layer.ts
@@ -19,6 +19,13 @@ import {
 /** Unit key for the process-wide ambient GitHub CLI token cache. */
 const TOKEN_CACHE_KEY = true as const
 
+const isUnauthorizedRequest = (error: GitHubServiceError): boolean =>
+  error._tag === "GitHubRequestError" && error.statusCode === 401
+
+const shouldRefreshCachedToken = (error: GitHubServiceError): boolean =>
+  isUnauthorizedRequest(error) ||
+  error._tag === "GitHubRepositoryUnavailableError"
+
 /**
  * Identity is scoped to a Repository credential path, rather than to the
  * process-wide ambient token cache. This prevents similarly timed
@@ -111,10 +118,11 @@ export const ambientGitHubLayer = (options: {
 
       // Single-flight success cache: concurrent callers share one lookup;
       // failures expire immediately (TTL zero, not reused); success lives until
-      // 401 invalidate. Cache.get is forked into the layer scope so canceling one
-      // requester cannot abort a shared in-flight lookup for joiners. Nested
-      // consumers must build this layer with Layer.buildWithScope (not a
-      // short-lived Effect.provide) so that scope stays open.
+      // a 401 or repository-unavailable invalidate. Cache.get is forked into the
+      // layer scope so canceling one requester cannot abort a shared in-flight
+      // lookup for joiners. Nested consumers must build this layer with
+      // Layer.buildWithScope (not a short-lived Effect.provide) so that scope
+      // stays open.
       const tokenCache = yield* Cache.makeWith(
         (_key: typeof TOKEN_CACHE_KEY) => resolveToken(),
         {
@@ -133,9 +141,10 @@ export const ambientGitHubLayer = (options: {
         },
       )
 
-      // Ambient authentication has one process-wide credential. A 401 means
-      // every Repository-scoped identity derived from it is stale, even when
-      // a different Repository observed the failure.
+      // Ambient authentication has one process-wide credential. A 401 or a
+      // repository-unavailable (wrong-account token that still authenticates)
+      // means every Repository-scoped identity derived from it is stale, even
+      // when a different Repository observed the failure.
       let invalidateAuthenticatedUsers: Effect.Effect<void> = Effect.void
 
       const run = Effect.fn("AmbientGitHub.runAuthenticated")(function* <A>(
@@ -152,14 +161,14 @@ export const ambientGitHubLayer = (options: {
         )
         if (
           first._tag !== "Failure" ||
-          first.failure._tag !== "GitHubRequestError" ||
-          first.failure.statusCode !== 401
+          !shouldRefreshCachedToken(first.failure)
         ) {
           return yield* Effect.fromResult(first)
         }
 
-        // Only drop the cache entry if it still holds the token that 401'd —
-        // concurrent 401s share one refresh instead of stomping a newer token.
+        // Only drop the cache entry if it still holds the token that failed —
+        // concurrent refresh triggers share one lookup instead of stomping a
+        // newer token.
         yield* invalidateAuthenticatedUsers
         yield* Cache.invalidateWhen(
           tokenCache,
@@ -167,6 +176,15 @@ export const ambientGitHubLayer = (options: {
           (cached) => cached === token,
         )
         const refreshed = yield* acquireToken()
+        // A wrong-account token is not expired. Retry the operation only when
+        // `gh auth token` actually returned a different credential; a genuine
+        // missing repository keeps the original failure.
+        if (
+          first.failure._tag === "GitHubRepositoryUnavailableError" &&
+          refreshed === token
+        ) {
+          return yield* Effect.fromResult(first)
+        }
         return yield* operation(
           makeService(refreshed, coordinator.reportThrottle),
         )

--- a/apps/harness/test/ambient-github-layer.test.ts
+++ b/apps/harness/test/ambient-github-layer.test.ts
@@ -5,6 +5,7 @@ import { expect, it } from "@effect/vitest"
 import { Deferred, Effect, Fiber, Layer, ManagedRuntime, Stream } from "effect"
 import { ChildProcessSpawner } from "effect/unstable/process"
 import {
+  GitHubRepositoryUnavailableError,
   GitHubRequestError,
   GitHubService,
   type GitHubServiceShape,
@@ -279,6 +280,67 @@ it.effect("runs remote cleanup through the ambient coordinator operation", () =>
 
     expect(cleanups).toEqual(["rfa/issue-881"])
   }),
+)
+
+it.effect(
+  "ambient GitHub authentication refreshes once after repository-unavailable when the token changes",
+  () =>
+    Effect.gen(function* () {
+      const resolvedTokens = ["wrong-account-token", "right-account-token"]
+      let resolutions = 0
+      const usedTokens: string[] = []
+      const layer = ambientGitHubLayer({
+        workspaceRoot: "/workspace",
+        resolveToken: async () => resolvedTokens[resolutions++]!,
+        makeService: (token) => {
+          usedTokens.push(token)
+          return serviceWithList(() =>
+            token === "wrong-account-token"
+              ? Effect.fail(new GitHubRepositoryUnavailableError(repository))
+              : Effect.succeed([]),
+          )
+        },
+      })
+
+      const issues = yield* Effect.gen(function* () {
+        const github = yield* GitHubService
+        return yield* github.listReadyIssues(repository)
+      }).pipe(Effect.provide(layer.pipe(Layer.provide(processLayer))))
+
+      expect(issues).toEqual([])
+      expect(resolutions).toBe(2)
+      expect(usedTokens).toEqual(["wrong-account-token", "right-account-token"])
+    }),
+)
+
+it.effect(
+  "a genuinely missing repository does not cause unbounded token re-resolution",
+  () =>
+    Effect.gen(function* () {
+      let resolutions = 0
+      let operations = 0
+      const layer = ambientGitHubLayer({
+        workspaceRoot: "/workspace",
+        resolveToken: async () => {
+          resolutions += 1
+          return "same-account-token"
+        },
+        makeService: () =>
+          serviceWithList(() => {
+            operations += 1
+            return Effect.fail(new GitHubRepositoryUnavailableError(repository))
+          }),
+      })
+
+      const exit = yield* Effect.gen(function* () {
+        const github = yield* GitHubService
+        return yield* Effect.exit(github.listReadyIssues(repository))
+      }).pipe(Effect.provide(layer.pipe(Layer.provide(processLayer))))
+
+      expect(exit._tag).toBe("Failure")
+      expect(resolutions).toBe(2)
+      expect(operations).toBe(1)
+    }),
 )
 
 it.effect("ambient GitHub authentication refreshes once after a 401", () =>


### PR DESCRIPTION
A wrong-account ambient `gh` token still authenticates, so GitHub answers
a private Repository the token cannot see with GraphQL `NOT_FOUND`
(`GitHubRepositoryUnavailableError` from #1028) rather than HTTP 401.
`ambientGitHubLayer` only dropped its process-lifetime `gh auth token`
cache on 401, so every `watch_pr_status_checks` tick and Issue Polling
refresh failed until the Harness was restarted (#1029).

This extends the existing single-flight invalidate/retry path:
repository-unavailable also drops the cached token when it still holds
the failing credential and re-runs `gh auth token`. The failed operation
is retried only when the refreshed token actually differs, so a genuinely
missing Repository does not loop. HTTP 401 still always retries.
Concurrent failures still share one refresh via `invalidateWhen`.

Verified with `apps/harness/test/ambient-github-layer.test.ts` (14 tests):
token A unavailable then token B succeeds; a same-token missing
Repository calls `resolveToken` at most twice and does not retry the
operation; existing 401 refresh, single-flight, and
403-does-not-refresh cases unchanged. Review of the uncommitted change
found no findings. Not run against a live private Repository with a
switched `gh` account. Keymaxxer-backed credentials are unchanged (they
are named per Repository and cannot drift this way). Showing the
resolved ambient account in the UI and a startup visibility health check
were outside this change's verification.

Closes #1029