### PR TITLE
docs: define direct terminal jump fallback

### DIFF
--- a/docs/prd/interactive-session-jump.md
+++ b/docs/prd/interactive-session-jump.md
@@ -21,7 +21,7 @@ For example:
 npx ready-for-agent@latest jump 85312e9f-9c57-42ef-9757-b2512cee57cd
 ```
 
-The command resolves the opaque backend Session ID through the running Harness, creates a new window in the caller's current tmux session, and splits that window evenly into two panes. The left pane continues the canonical Session with its captured Agent Backend; the right pane starts a shell. Both panes use the Work Item's persisted worktree as their working directory when it exists; otherwise they use the CLI process's current directory. Focus finishes on the left agent pane.
+The command resolves the opaque backend Session ID through the running Harness and continues the canonical Session with its captured Agent Backend. Inside tmux it creates a new window split evenly between the agent and a shell. Outside tmux it runs the agent directly as the foreground process in the invoking terminal; when the agent exits, control returns to the caller's shell without changing that shell's working directory. The agent uses the Work Item's persisted worktree as its working directory when it exists; otherwise it uses the CLI process's current directory.
 
 This is an Interactive Session Continuation, not an Agent Turn or Lifecycle Step. Interactive messages become part of the Session seen by later Agent Turns.
 
@@ -35,7 +35,7 @@ This is an Interactive Session Continuation, not an Agent Turn or Lifecycle Step
 
 ## Interactive Backend Commands
 
-The left pane uses the exact, non-forking interactive continuation supported by the captured Agent Backend, anchored to the working directory:
+The agent process uses the exact, non-forking interactive continuation supported by the captured Agent Backend, anchored to the working directory:
 
 ```text
 opencode <dir> --session <session-id>
@@ -50,9 +50,16 @@ These are interactive commands. Existing headless Agent Turn argument builders a
 
 Jump continues the canonical Session; it does not fork a human-only copy. It never uses backend shortcuts such as latest/continue/last or an interactive picker.
 
-## Tmux Behavior
+## Terminal Behavior
 
-- Jump requires invocation from inside tmux. If `TMUX` is absent, it fails without creating anything. Support outside tmux is deferred.
+- When `TMUX` is absent, Jump runs the resolved interactive continuation command directly as the foreground process in the invoking terminal. It does not create a shell wrapper, terminal emulator, tmux server, window, or pane.
+- A non-empty `TMUX` selects tmux mode; an absent or empty value selects direct mode. A stale `TMUX` value or later tmux failure is reported as a tmux failure and never triggers direct fallback.
+- The direct child process starts in the resolved working directory, while the caller's shell remains in its original working directory after the agent exits. This child cwd anchors Claude Code; the other backend commands also receive their documented explicit directory argument.
+- Direct continuation supports every Agent Backend for which Jump has an interactive continuation command: OpenCode, Grok Build, Codex Build, and Claude Code.
+- Direct continuation requires both stdin and stdout to be attached to a TTY; stderr may be redirected. This local prerequisite is checked before contacting the Harness or resolving an executable.
+- Direct continuation inherits the invoking process's complete environment and its stdin, stdout, and stderr. Jump prints no launch or exit banner; the Agent Backend owns the terminal presentation and diagnostics.
+- A successfully started Agent Backend's exit becomes Jump's exit status, including nonzero and conventional signal-derived statuses, without an additional Jump error message, retry, or agent-specific cleanup.
+- When `TMUX` is present, Jump retains the tmux behavior below.
 - Jump creates a new window in the current tmux session rather than splitting the caller's current window.
 - The new window contains an even left/right split. The left pane runs the Agent Backend and receives focus; the right pane is a shell.
 - Both panes start in the persisted Work Item worktree when it exists; otherwise both panes use the CLI process's current directory.
@@ -67,33 +74,34 @@ Jump continues the canonical Session; it does not fork a human-only copy. It nev
 
 Jump is lifecycle-neutral: it does not Pause, Start, Retry, Reset, or otherwise transition the Work Item. It does not check for running Step Runs or attempt to exclude concurrent Harness Agent Turns. The operator is responsible for deciding when it is safe to jump.
 
-All prerequisites are checked before a tmux window is created. The command fails when:
+All prerequisites are checked before a tmux window is created or a direct agent process is started. The command fails when:
 
-- it is invoked outside tmux;
+- direct continuation is selected but no interactive terminal is available;
 - the Harness is unreachable;
 - no Work Item owns the supplied Session ID;
 - more than one Work Item owns the supplied Session ID;
-- the captured Agent Backend is unsupported or its executable is unavailable on the CLI process's `PATH`; or
+- the captured Agent Backend is unsupported or its executable is unavailable on the CLI process's `PATH`;
+- the direct Agent Backend process cannot be started; or
 - tmux cannot create and arrange the window.
 
-When the persisted worktree does not exist as a directory, Jump does not fail. Both panes use the CLI process's current directory instead. This applies to terminal Work Items whose worktree has been cleaned up.
+When the persisted worktree does not exist as a directory, Jump does not fail. The direct child or both tmux panes use the CLI process's current directory instead. This applies to terminal Work Items whose worktree has been cleaned up.
 
 Tmux setup is transactional for ordinary failures: Jump creates the window detached, tags it immediately, completes the split and focus selection, and only then switches the invoking client. If setup fails, it kills only the window created by that invocation and reports the tmux failure; it never deletes a pre-existing tagged window.
 
-V1 deliberately does not serialize simultaneous Jump invocations. Duplicate detection prevents normal sequential reuse, but two commands started at effectively the same time may race and create duplicate interactive writers. Jump is an operator-typed command, and avoiding that invocation pattern is preferred over adding a lock subsystem.
+Jump deliberately does not serialize simultaneous invocations. Tmux duplicate detection prevents normal sequential reuse, but two commands started at effectively the same time may race and create duplicate interactive writers. Direct invocations from separate terminals also have no cross-process duplicate detection. Jump is an operator-typed command, and avoiding those invocation patterns is preferred over adding a lock subsystem.
 
-Jump is outside the finite JSON command protocol. Success is silent because switching to the focused agent pane is the confirmation. Failures write concise, actionable text to stderr and exit `1`; argument parsing retains the CLI framework's normal usage behavior.
+Jump is outside the finite JSON command protocol. In tmux, success is silent because switching to the focused agent pane is the confirmation. In direct mode, Jump itself remains silent while the Agent Backend owns terminal output. Jump-owned failures write concise, actionable text to stderr and exit `1`; after a successful direct launch, Jump instead returns the Agent Backend's exit status. Argument parsing retains the CLI framework's normal usage behavior.
 
 ## Implementation Seams
 
 1. **GraphQL query**: a simple lookup that matches `work_item.session_id` and returns the captured backend, session ID, and worktree path. No jump tracking, no elaborate error codes, no lifecycle state inspection.
-2. **CLI command**: `jumpCommand` in `cli.ts`, registered alongside existing subcommands. Resolves the session through GraphQL, checks prerequisites, and orchestrates tmux.
-3. **Backend executable resolution**: resolve the captured backend's CLI binary to an absolute path on the CLI process's `PATH` before creating the tmux window, so the pane launches the exact executable.
+2. **CLI command**: `jumpCommand` in `cli.ts`, registered alongside existing subcommands. Selects tmux or direct mode, checks local prerequisites, resolves the session through GraphQL, and launches the continuation.
+3. **Backend executable resolution**: resolve the captured backend's CLI binary to an absolute path on the CLI process's `PATH` before creating a tmux window or starting a direct process, so either mode launches the exact executable.
 4. **tmux service**: a new thin service under `apps/ready-for-agent/src/services/` that owns tmux window creation, tagging, duplicate detection, split layout, and client switching.
+5. **direct process service**: a thin process boundary that starts the resolved executable in the resolved working directory with inherited environment and terminal streams, then exposes its exit status without interpreting backend output.
 
 ## Out Of Scope
 
-- Invocation outside tmux
 - Creating or attaching a tmux server from a normal terminal
 - Forking Sessions
 - Choosing another Agent Backend, worktree, Agent Model, Thinking Level, provider, or persona


### PR DESCRIPTION
## Why

`ready-for-agent jump` currently requires tmux, so operators invoking it from a normal terminal cannot continue a Work Item's canonical Session without reconstructing the backend-specific command themselves.

## What Changed

- Define direct foreground continuation as the non-tmux fallback for OpenCode, Grok Build, Codex Build, and Claude Code.
- Preserve the existing tmux window and duplicate-detection behavior when `TMUX` is set.
- Specify TTY requirements, working directory and environment inheritance, transparent terminal I/O, backend exit-status propagation, and launch failures.
- Document that direct invocations do not gain cross-process duplicate-writer locking.

This PR finalizes the product contract only; implementation follows separately.
