### PR TITLE
fix(harness): keep Repos Jobs tab active after theme-pin reload

### DIFF
--- a/apps/harness/e2e/features/kanban-route.feature
+++ b/apps/harness/e2e/features/kanban-route.feature
@@ -41,6 +41,16 @@ Feature: View the work pipeline
     And the Pipeline top nav control is active
     And the Repos top nav control is not active
 
+  Scenario: Reloading Repos with a theme pin keeps Repos as the sole active Jobs destination
+    Given the Harness has a seeded Paused Repository
+    When I open the Repos page with theme light
+    Then the Repos top nav control is the sole active Jobs destination
+    And the Pipeline top nav control is not active
+    When I refresh the page
+    Then the Repos top nav control is the sole active Jobs destination
+    And the Pipeline top nav control is not active
+    And the server-rendered Repos document with theme light has Repos as the sole active Jobs destination
+
   Scenario: Switch from Pipeline to Repos via top nav
     Given the Harness has a seeded Paused Repository
     When I navigate to the Kanban board

--- a/apps/harness/e2e/steps/kanban-route.ts
+++ b/apps/harness/e2e/steps/kanban-route.ts
@@ -57,6 +57,12 @@ When("I open the Repos page", async ({ page }) => {
   await dismissFirstRunSettingsIfPresent(page)
 })
 
+When("I open the Repos page with theme light", async ({ page }) => {
+  await page.goto("/repos?theme=light")
+  await expect(page).toHaveURL(/\/repos\?theme=light$/)
+  await dismissFirstRunSettingsIfPresent(page)
+})
+
 When("I click the Pipeline top nav control", async ({ page }) => {
   await jobsNav(page)
     .getByRole("link", { name: "Pipeline", exact: true })
@@ -163,6 +169,52 @@ Then("the Pipeline top nav control is not active", async ({ page }) => {
   await expect(pipeline).toBeVisible()
   await expect(pipeline).not.toHaveAttribute("aria-current", "page")
 })
+
+const JOBS_TAB_IDS = [
+  "jobs-tab-pipeline",
+  "jobs-tab-repos",
+  "jobs-tab-completed",
+] as const
+
+const jobsAnchorTag = (html: string, id: string): string => {
+  const match = html.match(new RegExp(`<a\\b[^>]*\\bid="${id}"[^>]*>`, "i"))
+  if (match === null || match[0] === undefined) {
+    throw new Error(`Expected Jobs destination anchor #${id} in the document`)
+  }
+  return match[0]
+}
+
+const assertSoleActiveJobsDestination = async (
+  page: Page,
+  name: "Pipeline" | "Repos" | "Completed",
+) => {
+  const current = jobsNav(page).locator('a[aria-current="page"]')
+  await expect(current).toHaveCount(1)
+  await expect(current).toHaveAccessibleName(name)
+}
+
+Then(
+  "the Repos top nav control is the sole active Jobs destination",
+  async ({ page }) => {
+    await assertSoleActiveJobsDestination(page, "Repos")
+  },
+)
+
+Then(
+  "the server-rendered Repos document with theme light has Repos as the sole active Jobs destination",
+  async ({ page }) => {
+    const response = await page.request.get("/repos?theme=light")
+    expect(response.ok()).toBe(true)
+    const html = await response.text()
+    const currentIds = JOBS_TAB_IDS.filter((id) =>
+      /aria-current=["']page["']/.test(jobsAnchorTag(html, id)),
+    )
+    expect(currentIds).toEqual(["jobs-tab-repos"])
+    expect(jobsAnchorTag(html, "jobs-tab-pipeline")).not.toMatch(
+      /aria-current=["']page["']/,
+    )
+  },
+)
 
 Then("I am on the Kanban board", async ({ page }) => {
   await expect(page).toHaveURL(/\/$/)

--- a/apps/harness/src/jobs-view-switcher.tsx
+++ b/apps/harness/src/jobs-view-switcher.tsx
@@ -7,9 +7,10 @@
  * (in-memory board); Repos and Completed hide them until server-side filter
  * support exists for the archive.
  */
-import { Link, useRouterState } from "@tanstack/react-router"
+import { useLinkProps, useRouterState } from "@tanstack/react-router"
+import type { ReactNode } from "react"
 import { JobsRepositoryFilters } from "./jobs-repository-filter.js"
-import { isPipelineBackgroundPath } from "./routed-dialog.js"
+import { jobsViewForPath } from "./routed-dialog.js"
 import { cx, ui } from "./ui.js"
 
 function PipelineTabIcon() {
@@ -58,15 +59,51 @@ function CompletedTabIcon() {
   )
 }
 
+/**
+ * Jobs destination link whose active attrs follow `jobsViewForPath`, not
+ * TanStack's path+search isActive. Link would otherwise set aria-current and
+ * data-status after our props, which can disagree on SSR/hydration when the
+ * retained `theme` search pin is present (issue #1041).
+ */
+function JobsDestinationLink({
+  to,
+  id,
+  current,
+  exact = false,
+  children,
+}: {
+  readonly to: "/" | "/repos" | "/completed"
+  readonly id: string
+  readonly current: boolean
+  readonly exact?: boolean
+  readonly children: ReactNode
+}) {
+  const props = useLinkProps({
+    to,
+    id,
+    className: ui.pipelineTab,
+    activeOptions: { exact, includeSearch: false },
+  })
+  return (
+    <a
+      {...props}
+      aria-current={current ? "page" : undefined}
+      data-status={current ? "active" : undefined}
+    >
+      {children}
+    </a>
+  )
+}
+
 export function JobsViewSwitcher() {
   const pathname = useRouterState({ select: (s) => s.location.pathname })
-  const onCompleted =
-    pathname === "/completed" || pathname.startsWith("/completed/")
   // Direct `/settings` and telemetry loads use Pipeline as their canonical
   // background. Masked telemetry opens retain the runtime origin pathname, so
   // the originating Jobs tab remains active (issues #840–#843 / #906).
-  const pipelineActive = isPipelineBackgroundPath(pathname)
-  const reposActive = pathname === "/repos" || pathname.startsWith("/repos/")
+  const jobsView = jobsViewForPath(pathname)
+  const pipelineActive = jobsView === "pipeline"
+  const reposActive = jobsView === "repos"
+  const completedActive = jobsView === "completed"
   // Filters only drive the Pipeline board today (full in-memory item set).
   const showRepositoryFilters = pipelineActive
 
@@ -77,34 +114,31 @@ export function JobsViewSwitcher() {
           className={cx(ui.pipelineTabs, ui.jobsSwitcherPipelineTabs)}
           aria-label="Jobs"
         >
-          <Link
+          <JobsDestinationLink
             to="/"
             id="jobs-tab-pipeline"
-            className={ui.pipelineTab}
-            activeOptions={{ exact: true }}
-            aria-current={pipelineActive ? "page" : undefined}
+            exact
+            current={pipelineActive}
           >
             <PipelineTabIcon />
             Pipeline
-          </Link>
-          <Link
+          </JobsDestinationLink>
+          <JobsDestinationLink
             to="/repos"
             id="jobs-tab-repos"
-            className={ui.pipelineTab}
-            aria-current={reposActive ? "page" : undefined}
+            current={reposActive}
           >
             <ReposTabIcon />
             Repos
-          </Link>
-          <Link
+          </JobsDestinationLink>
+          <JobsDestinationLink
             to="/completed"
             id="jobs-tab-completed"
-            className={ui.pipelineTab}
-            aria-current={onCompleted ? "page" : undefined}
+            current={completedActive}
           >
             <CompletedTabIcon />
             Completed
-          </Link>
+          </JobsDestinationLink>
         </nav>
         {showRepositoryFilters ? (
           <JobsRepositoryFilters className={ui.jobsSwitcherRepositoryFilters} />

--- a/apps/harness/src/routed-dialog.ts
+++ b/apps/harness/src/routed-dialog.ts
@@ -208,6 +208,36 @@ export const isReposBackgroundPath = (pathname: string): boolean =>
   isRepositorySettingsPath(pathname)
 
 /**
+ * Completed is the canonical background for `/completed` and any nested
+ * archive path. Search (page, theme) is not part of this pathname check.
+ */
+export const isCompletedBackgroundPath = (pathname: string): boolean =>
+  pathname === "/completed" ||
+  pathname === "/completed/" ||
+  pathname.startsWith("/completed/")
+
+/** Jobs switcher destination derived from the runtime pathname. */
+export type JobsView = "pipeline" | "repos" | "completed"
+
+/**
+ * Exclusive route → Jobs view. Overlay backgrounds use the same helpers as
+ * the rest of the chrome so SSR and the client cannot pick different tabs.
+ * Callers pass the runtime pathname (masked Session Telemetry keeps origin).
+ */
+export const jobsViewForPath = (pathname: string): JobsView | undefined => {
+  if (isReposBackgroundPath(pathname)) {
+    return "repos"
+  }
+  if (isCompletedBackgroundPath(pathname)) {
+    return "completed"
+  }
+  if (isPipelineBackgroundPath(pathname)) {
+    return "pipeline"
+  }
+  return undefined
+}
+
+/**
  * Document-session flag: true only after an explicit in-app Session Telemetry
  * open in this SPA document. Module-level so Pipeline openers and root close
  * share it; full reload clears it so direct/refresh close uses replace → `/`.

--- a/apps/harness/test/primary-nav.test.ts
+++ b/apps/harness/test/primary-nav.test.ts
@@ -216,7 +216,8 @@ describe("primary navigation (Interchange masthead + Jobs switcher)", () => {
       tabs.indexOf("<ReposTabIcon"),
     )
     // Pipeline exact-match; filters stay after the primary trio.
-    expect(tabs).toContain("activeOptions={{ exact: true }}")
+    expect(tabs).toContain("exact")
+    expect(switcher).toContain("includeSearch: false")
     expect(switcher.indexOf("<JobsRepositoryFilters")).toBeGreaterThan(
       switcher.indexOf('id="jobs-tab-completed"'),
     )
@@ -289,7 +290,7 @@ describe("primary navigation (Interchange masthead + Jobs switcher)", () => {
     expect(styles).toContain(".mast-theme-lever .handle")
     expect(styles).toContain(".mast-settings-cog .teeth")
     expect(root).toContain("function SettingsCogTeeth")
-    expect(switcher).toContain("className={ui.pipelineTab}")
+    expect(switcher).toContain("className: ui.pipelineTab")
     expect(switcher).not.toMatch(/rivet/i)
     expect(root).not.toMatch(/className=\{[^}]*rivet/i)
   })

--- a/apps/harness/test/repos-route.test.ts
+++ b/apps/harness/test/repos-route.test.ts
@@ -60,7 +60,9 @@ describe("/repos route", () => {
     expect(reposIdx).toBeGreaterThan(pipelineIdx)
     expect(completedIdx).toBeGreaterThan(reposIdx)
     expect(tabs).toContain("<ReposTabIcon")
-    expect(tabs).toMatch(/Repos\s*<\/Link>/)
+    expect(tabs).toMatch(/Repos\s*<\/JobsDestinationLink>/)
+    expect(switcher).toContain("jobsViewForPath")
+    expect(switcher).toContain("useLinkProps")
   })
 
   test("Repos page body keeps the reading-width cap", () => {

--- a/apps/harness/test/repository-settings-route.test.ts
+++ b/apps/harness/test/repository-settings-route.test.ts
@@ -119,6 +119,7 @@ describe("/repos/$repositoryId/settings route (issue #842)", () => {
 
   test("Jobs switcher treats repository settings as Repos background", () => {
     const switcher = jobsSwitcherSource()
-    expect(switcher).toContain('pathname.startsWith("/repos/")')
+    expect(switcher).toContain("jobsViewForPath")
+    expect(switcher).toContain('jobsView === "repos"')
   })
 })

--- a/apps/harness/test/routed-dialog.test.ts
+++ b/apps/harness/test/routed-dialog.test.ts
@@ -1,4 +1,5 @@
 import {
+  isCompletedBackgroundPath,
   isHarnessSettingsPath,
   isOtherRoutedDialogPath,
   isPipelineBackgroundPath,
@@ -6,6 +7,7 @@ import {
   isRepositorySettingsPath,
   isRepositorySettingsPathFor,
   isSessionTelemetryPath,
+  jobsViewForPath,
   markRepositorySettingsOpenedFromInApp,
   markSessionTelemetryOpenedFromInApp,
   parseRepositorySettingsRepositoryId,
@@ -129,6 +131,32 @@ describe("Repository settings route helpers (issue #842)", () => {
     expect(isReposBackgroundPath("/repos/repo-1/settings")).toBe(true)
     expect(isReposBackgroundPath("/")).toBe(false)
     expect(isReposBackgroundPath("/settings")).toBe(false)
+  })
+
+  test("Completed background includes /completed and nested archive paths", () => {
+    expect(isCompletedBackgroundPath("/completed")).toBe(true)
+    expect(isCompletedBackgroundPath("/completed/")).toBe(true)
+    expect(isCompletedBackgroundPath("/completed/page")).toBe(true)
+    expect(isCompletedBackgroundPath("/")).toBe(false)
+    expect(isCompletedBackgroundPath("/repos")).toBe(false)
+  })
+
+  test("jobsViewForPath picks exactly one Jobs destination per runtime path", () => {
+    expect(jobsViewForPath("/")).toBe("pipeline")
+    expect(jobsViewForPath("/settings")).toBe("pipeline")
+    expect(jobsViewForPath("/settings/")).toBe("pipeline")
+    expect(jobsViewForPath("/session/wi-1/telemetry")).toBe("pipeline")
+    expect(jobsViewForPath("/session/wi-1/telemetry/")).toBe("pipeline")
+
+    expect(jobsViewForPath("/repos")).toBe("repos")
+    expect(jobsViewForPath("/repos/")).toBe("repos")
+    expect(jobsViewForPath("/repos/repo-1/settings")).toBe("repos")
+
+    expect(jobsViewForPath("/completed")).toBe("completed")
+    expect(jobsViewForPath("/completed/")).toBe("completed")
+
+    expect(jobsViewForPath("/repos")).not.toBe("pipeline")
+    expect(jobsViewForPath("/unknown")).toBeUndefined()
   })
 
   test("reads the Repository settings in-app origin history marker", () => {

--- a/apps/harness/test/session-telemetry-route.test.ts
+++ b/apps/harness/test/session-telemetry-route.test.ts
@@ -97,7 +97,7 @@ describe("Session Telemetry route (issues #841 / #843 / #906)", () => {
 
   test("Jobs switcher derives the active background from the runtime route", () => {
     const switcher = jobsSwitcherSource()
-    expect(switcher).toContain("isPipelineBackgroundPath")
+    expect(switcher).toContain("jobsViewForPath")
     expect(switcher).not.toContain(
       "Explicit opens from Repos or Completed share",
     )

--- a/apps/harness/test/settings-route.test.ts
+++ b/apps/harness/test/settings-route.test.ts
@@ -83,7 +83,7 @@ describe("/settings route (issue #840)", () => {
 
   test("Jobs switcher treats /settings as Pipeline background", () => {
     const switcher = jobsSwitcherSource()
-    expect(switcher).toContain("isPipelineBackgroundPath")
+    expect(switcher).toContain("jobsViewForPath")
     const helpers = routedDialogSource()
     expect(helpers).toContain("isHarnessSettingsPath")
     expect(helpers).toContain('pathname === "/settings"')


### PR DESCRIPTION
Reloading `/repos?theme=light` could show the Repositories page with
Pipeline highlighted. TanStack `Link` applies `aria-current` and
`data-status` after caller props, so its path+search `isActive` could
disagree with the switcher's background checks when the retained root
`theme` pin is present (#1041).

This classifies the runtime pathname with one `jobsViewForPath` for
Pipeline, Repos, and Completed (including Harness Settings, Repository
settings, and direct Session Telemetry). Jobs destinations use
`useLinkProps` and then set `aria-current` / `data-status` from that
classifier so `Link` cannot overwrite them. `includeSearch: false` keeps
the theme pin out of active matching.

A Kanban UI-history scenario opens `/repos?theme=light`, reloads,
requires exactly one active Jobs destination (Repos) and Pipeline
inactive, and checks the same invariant on the server-rendered HTML.

Verified with harness unit tests for the classifier and switcher source
contracts (89 tests across the routed-dialog, repos, primary-nav,
settings, telemetry, repository-settings, completed, and kanban route
files), Biome on the touched files, the full `kanban-route` UI-history
feature (7/7), and overlay scenarios for `/`, `/completed`, Repository
settings, Harness Settings, and masked/direct Session Telemetry (9/9).
Review of the uncommitted change found no findings. The SSR assert uses
a separate GET of `/repos?theme=light` rather than the first paint of
the same reload document; a mid-hydration flash on that same document
is not asserted.

Closes #1041