### PR TITLE
fix(cli): forward operator env into jump agent panes

### DIFF
--- a/apps/ready-for-agent/package.json
+++ b/apps/ready-for-agent/package.json
@@ -32,6 +32,7 @@
   },
   "dependencies": {
     "@effect/platform-bun": "^4.0.0-beta.97",
+    "@ready-for-agent/agent-backend": "workspace:*",
     "@ready-for-agent/github-service": "workspace:*",
     "@ready-for-agent/gitlab-service": "workspace:*",
     "@ready-for-agent/graphql-client": "workspace:*",

--- a/apps/ready-for-agent/src/cli-process.test.ts
+++ b/apps/ready-for-agent/src/cli-process.test.ts
@@ -1121,9 +1121,68 @@ if (args[0] === "split-window" && args.includes("-P")) {
   const jumpEnv = (overrides: NodeJS.ProcessEnv = {}): NodeJS.ProcessEnv => ({
     PATH: `${binDir}:${process.env.PATH ?? ""}`,
     TMUX: "/tmp/tmux-1000/default,123,0",
+    TMUX_PANE: "%9",
+    TERM: "xterm-256color",
+    PWD: "/tmp/wrong-pwd",
+    CLAUDE_CODE_USE_BEDROCK: "1",
     TMUX_ARGV_LOG: tmuxLog,
     ...overrides,
   })
+
+  const omittedTmuxEnvPrefixes = [
+    "TMUX=",
+    "TMUX_PANE=",
+    "TERM=",
+    "PWD=",
+  ] as const
+
+  const tmuxFlagEnvAssignments = (
+    args: readonly string[],
+  ): readonly string[] => {
+    const separator = args.indexOf("--")
+    const limit = separator === -1 ? args.length : separator
+    const assignments: string[] = []
+    for (let i = 0; i < limit; i++) {
+      if (args[i] !== "-e") {
+        continue
+      }
+      const assignment = args[i + 1]
+      if (assignment !== undefined) {
+        assignments.push(assignment)
+      }
+      i += 1
+    }
+    return assignments
+  }
+
+  const withoutTmuxEnvFlags = (args: readonly string[]): string[] => {
+    const out: string[] = []
+    for (let i = 0; i < args.length; i++) {
+      if (args[i] === "-e") {
+        i += 1
+        continue
+      }
+      const arg = args[i]
+      if (arg !== undefined) {
+        out.push(arg)
+      }
+    }
+    return out
+  }
+
+  const expectForwardedPaneEnvironment = (args: readonly string[]) => {
+    const assignments = tmuxFlagEnvAssignments(args)
+    expect(assignments).toContain("CLAUDE_CODE_USE_BEDROCK=1")
+    for (const prefix of omittedTmuxEnvPrefixes) {
+      expect(
+        assignments.some((assignment) => assignment.startsWith(prefix)),
+      ).toBe(false)
+    }
+    const separator = args.indexOf("--")
+    const firstEnv = args.indexOf("-e")
+    expect(firstEnv).toBeGreaterThan(-1)
+    expect(separator).toBeGreaterThan(firstEnv)
+  }
 
   test("jump outside tmux writes a text error and does not invoke tmux", async () => {
     const result = await runCli(
@@ -1296,7 +1355,12 @@ if (args[0] === "split-window" && args.includes("-P")) {
       expect(result.stderr.trim()).toBe("")
       const invocations = parseTmuxArgvLog(tmuxLog)
       const opencode = join(binDir, "opencode")
-      expect(invocations).toEqual([
+      const created = invocations.find((args) => args.includes("new-window"))
+      expect(created).toBeDefined()
+      if (created !== undefined) {
+        expectForwardedPaneEnvironment(created)
+      }
+      expect(invocations.map(withoutTmuxEnvFlags)).toEqual([
         ["display-message", "-p", "#{session_id}"],
         [
           "list-windows",
@@ -1348,7 +1412,14 @@ if (args[0] === "split-window" && args.includes("-P")) {
       const invocations = parseTmuxArgvLog(tmuxLog)
       const claude = join(binDir, "claude")
       const cliCwd = resolve(packageRoot)
-      expect(invocations[2]).toEqual([
+      expect(invocations[2]).toBeDefined()
+      if (invocations[2] !== undefined) {
+        expectForwardedPaneEnvironment(invocations[2])
+        expect(tmuxFlagEnvAssignments(invocations[2])).toContain(
+          "DISABLE_AUTOUPDATER=1",
+        )
+      }
+      expect(withoutTmuxEnvFlags(invocations[2] ?? [])).toEqual([
         "new-window",
         "-d",
         "-P",
@@ -1456,7 +1527,14 @@ if (args[0] === "split-window" && args.includes("-P")) {
       expect(invocations.some((args) => args.includes("new-window"))).toBe(
         false,
       )
-      expect(invocations).toContainEqual([
+      const recreated = invocations.find(
+        (args) => args[0] === "split-window" && args.includes("-P"),
+      )
+      expect(recreated).toBeDefined()
+      if (recreated !== undefined) {
+        expectForwardedPaneEnvironment(recreated)
+      }
+      expect(invocations.map(withoutTmuxEnvFlags)).toContainEqual([
         "split-window",
         "-h",
         "-b",

--- a/apps/ready-for-agent/src/cli.test.ts
+++ b/apps/ready-for-agent/src/cli.test.ts
@@ -1482,6 +1482,7 @@ describe("operator binary jump command", () => {
             workingDirectory: worktree,
             agentExecutable: want.executable,
             agentArguments: want.arguments,
+            backendId,
           })
         }
       } finally {
@@ -1543,7 +1544,97 @@ describe("operator binary jump command", () => {
     workingDirectory: "/tmp/rfa-jump-worktree",
     agentExecutable: "/usr/bin/opencode",
     agentArguments: ["/tmp/rfa-jump-worktree", "--session", sessionId],
+    backendId: "opencode",
   } as const
+
+  const omittedTmuxEnvPrefixes = [
+    "TMUX=",
+    "TMUX_PANE=",
+    "TERM=",
+    "PWD=",
+  ] as const
+
+  const tmuxFlagEnvAssignments = (
+    args: readonly string[],
+  ): readonly string[] => {
+    const separator = args.indexOf("--")
+    const limit = separator === -1 ? args.length : separator
+    const assignments: string[] = []
+    for (let i = 0; i < limit; i++) {
+      if (args[i] !== "-e") {
+        continue
+      }
+      const assignment = args[i + 1]
+      if (assignment !== undefined) {
+        assignments.push(assignment)
+      }
+      i += 1
+    }
+    return assignments
+  }
+
+  const withoutTmuxEnvFlags = (args: readonly string[]): string[] => {
+    const out: string[] = []
+    for (let i = 0; i < args.length; i++) {
+      if (args[i] === "-e") {
+        i += 1
+        continue
+      }
+      const arg = args[i]
+      if (arg !== undefined) {
+        out.push(arg)
+      }
+    }
+    return out
+  }
+
+  const expectForwardedPaneEnvironment = (args: readonly string[]) => {
+    const assignments = tmuxFlagEnvAssignments(args)
+    expect(assignments).toContain("CLAUDE_CODE_USE_BEDROCK=1")
+    for (const prefix of omittedTmuxEnvPrefixes) {
+      expect(
+        assignments.some((assignment) => assignment.startsWith(prefix)),
+      ).toBe(false)
+    }
+    const separator = args.indexOf("--")
+    const firstEnv = args.indexOf("-e")
+    expect(firstEnv).toBeGreaterThan(-1)
+    expect(separator).toBeGreaterThan(firstEnv)
+  }
+
+  const jumpProcessEnvFixture = {
+    CLAUDE_CODE_USE_BEDROCK: "1",
+    TMUX: "/tmp/tmux-1000/default,1,0",
+    TMUX_PANE: "%9",
+    TERM: "xterm-256color",
+    PWD: "/tmp/wrong-pwd",
+  } as const
+
+  const withProcessEnv = (
+    overrides: Record<string, string>,
+    body: Effect.Effect<void, JumpFailed>,
+  ) =>
+    Effect.acquireUseRelease(
+      Effect.sync(() => {
+        const previous: Record<string, string | undefined> = {}
+        for (const [name, value] of Object.entries(overrides)) {
+          previous[name] = process.env[name]
+          process.env[name] = value
+        }
+        return previous
+      }),
+      () => body,
+      (previous) =>
+        Effect.sync(() => {
+          for (const [name, value] of Object.entries(previous)) {
+            if (value === undefined) {
+              delete process.env[name]
+            } else {
+              process.env[name] = value
+            }
+          }
+        }),
+    )
 
   const recordingTmux = (script: {
     readonly currentSession?: string
@@ -1656,7 +1747,7 @@ describe("operator binary jump command", () => {
           panes: "%2",
         })
         yield* runCreateJumpWindow(tmux.layer)
-        expect(tmux.invocations).toEqual([
+        expect(tmux.invocations.map(withoutTmuxEnvFlags)).toEqual([
           ["display-message", "-p", "#{session_id}"],
           ["list-windows", "-a", "-F", windowListFormat],
           ["list-panes", "-t", "@5", "-F", paneListFormat],
@@ -1712,7 +1803,7 @@ describe("operator binary jump command", () => {
       Effect.gen(function* () {
         const tmux = recordingTmux({})
         yield* runCreateJumpWindow(tmux.layer)
-        expect(tmux.invocations).toEqual([
+        expect(tmux.invocations.map(withoutTmuxEnvFlags)).toEqual([
           ["display-message", "-p", "#{session_id}"],
           ["list-windows", "-a", "-F", windowListFormat],
           [
@@ -1737,6 +1828,74 @@ describe("operator binary jump command", () => {
           ["select-window", "-t", "@1"],
         ])
       }),
+  )
+
+  it.live(
+    "jump forwards the operator environment on new-window and omits tmux-owned vars",
+    () =>
+      withProcessEnv(
+        jumpProcessEnvFixture,
+        Effect.gen(function* () {
+          const tmux = recordingTmux({})
+          yield* runCreateJumpWindow(tmux.layer)
+          const created = tmux.invocations.find((args) =>
+            args.includes("new-window"),
+          )
+          expect(created).toBeDefined()
+          if (created === undefined) {
+            return
+          }
+          expectForwardedPaneEnvironment(created)
+        }),
+      ),
+  )
+
+  it.live(
+    "jump forwards the operator environment when recreating the agent pane",
+    () =>
+      withProcessEnv(
+        jumpProcessEnvFixture,
+        Effect.gen(function* () {
+          const tmux = recordingTmux({
+            windows: `$0\tdefault\t@5\t3\t${sessionId}`,
+            panes: "%2",
+          })
+          yield* runCreateJumpWindow(tmux.layer)
+          const recreated = tmux.invocations.find(
+            (args) => args[0] === "split-window" && args.includes("-P"),
+          )
+          expect(recreated).toBeDefined()
+          if (recreated === undefined) {
+            return
+          }
+          expectForwardedPaneEnvironment(recreated)
+        }),
+      ),
+  )
+
+  it.live("jump sets DISABLE_AUTOUPDATER for the claude backend pane", () =>
+    withProcessEnv(
+      jumpProcessEnvFixture,
+      Effect.gen(function* () {
+        const tmux = recordingTmux({})
+        yield* runCreateJumpWindow(tmux.layer, {
+          ...jumpInput,
+          backendId: "claude",
+          agentExecutable: "/usr/bin/claude",
+          agentArguments: ["--resume", sessionId],
+        })
+        const created = tmux.invocations.find((args) =>
+          args.includes("new-window"),
+        )
+        expect(created).toBeDefined()
+        if (created === undefined) {
+          return
+        }
+        expect(tmuxFlagEnvAssignments(created)).toContain(
+          "DISABLE_AUTOUPDATER=1",
+        )
+      }),
+    ),
   )
 
   it.live(

--- a/apps/ready-for-agent/src/cli.ts
+++ b/apps/ready-for-agent/src/cli.ts
@@ -361,6 +361,7 @@ const jumpWorkflow = Effect.fn("Cli.jump")(function* (sessionId: string) {
     workingDirectory,
     agentExecutable,
     agentArguments: resume.arguments,
+    backendId: found.agentBackend.id,
   })
 })
 

--- a/apps/ready-for-agent/src/jump-pane-environment.ts
+++ b/apps/ready-for-agent/src/jump-pane-environment.ts
@@ -1,0 +1,38 @@
+import { sanitizeInheritedEnvironment } from "@ready-for-agent/agent-backend"
+
+/**
+ * tmux owns these in the pane. Forwarding the CLI process copies would
+ * override pane identity (`TMUX_PANE`) and ignore `-c` for cwd.
+ */
+const tmuxOwnedOrProcessLocalEnvNames = new Set([
+  "TMUX",
+  "TMUX_PANE",
+  "TERM",
+  "PWD",
+  "OLDPWD",
+  "SHLVL",
+  "_",
+])
+
+export const jumpPaneEnvironmentFlags = (input: {
+  readonly backendId: string
+}): string[] => {
+  const inherited = sanitizeInheritedEnvironment(process.env, {
+    stripForgeTokens: false,
+  })
+  if (input.backendId === "claude") {
+    inherited.DISABLE_AUTOUPDATER = "1"
+  }
+  const flags: string[] = []
+  for (const name of Object.keys(inherited).sort()) {
+    if (tmuxOwnedOrProcessLocalEnvNames.has(name)) {
+      continue
+    }
+    const value = inherited[name]
+    if (value === undefined) {
+      continue
+    }
+    flags.push("-e", `${name}=${value}`)
+  }
+  return flags
+}

--- a/apps/ready-for-agent/src/services/tmux.ts
+++ b/apps/ready-for-agent/src/services/tmux.ts
@@ -1,12 +1,14 @@
 import { Context, Effect, Layer, Stream } from "effect"
 import { ChildProcess, ChildProcessSpawner } from "effect/unstable/process"
 import { JumpFailed } from "../jump-error.ts"
+import { jumpPaneEnvironmentFlags } from "../jump-pane-environment.ts"
 
 export type JumpWindowInput = {
   readonly sessionId: string
   readonly workingDirectory: string
   readonly agentExecutable: string
   readonly agentArguments: readonly string[]
+  readonly backendId: string
 }
 
 const tmuxMissingMessage = "jump must be run from inside a tmux session"
@@ -186,6 +188,7 @@ export class Tmux extends Context.Service<
           windowId,
           "-c",
           input.workingDirectory,
+          ...jumpPaneEnvironmentFlags({ backendId: input.backendId }),
           "--",
           input.agentExecutable,
           ...input.agentArguments,
@@ -213,6 +216,7 @@ export class Tmux extends Context.Service<
           jumpWindowName(input.sessionId),
           "-c",
           input.workingDirectory,
+          ...jumpPaneEnvironmentFlags({ backendId: input.backendId }),
           "--",
           input.agentExecutable,
           ...input.agentArguments,

--- a/apps/ready-for-agent/tsconfig.app.json
+++ b/apps/ready-for-agent/tsconfig.app.json
@@ -17,6 +17,9 @@
   "exclude": ["src/**/*.test.ts"],
   "references": [
     {
+      "path": "../../packages/agent-backend/tsconfig.lib.json"
+    },
+    {
       "path": "../../packages/local-git/tsconfig.lib.json"
     },
     {

--- a/bun.lock
+++ b/bun.lock
@@ -91,6 +91,7 @@
       },
       "dependencies": {
         "@effect/platform-bun": "^4.0.0-beta.97",
+        "@ready-for-agent/agent-backend": "workspace:*",
         "@ready-for-agent/github-service": "workspace:*",
         "@ready-for-agent/gitlab-service": "workspace:*",
         "@ready-for-agent/graphql-client": "workspace:*",

--- a/docs/prd/interactive-session-jump.md
+++ b/docs/prd/interactive-session-jump.md
@@ -62,6 +62,10 @@ Jump continues the canonical Session; it does not fork a human-only copy. It nev
 - If the tagged window remains but its agent pane has exited, Jump recreates the left agent pane in that window, restores the even split, and focuses the agent.
 - If a tagged window belongs to another tmux session, Jump fails and reports that session/window location. It neither moves the caller nor starts a second interactive writer.
 - Tmux starts the right pane without an explicit command, using its configured `default-command` and `default-shell` rather than interpreting `$SHELL` in the CLI.
+- The agent pane inherits the operator CLI's environment via repeated `tmux -e KEY=VALUE` flags on `new-window` (create) and `split-window` (recreate). This is the same source the non-interactive Agent Turn path uses (`process.env` after `sanitizeInheritedEnvironment`), so mise `[env]`, direnv, and Bedrock/AWS variables such as `CLAUDE_CODE_USE_BEDROCK` reach the pane. Jump does **not** wrap the agent in a login shell.
+- `TMUX`, `TMUX_PANE`, and `TERM` are omitted: tmux sets those on the pane, and a forwarded `TMUX_PANE` would break the agent's own tmux detection. `PWD`, `OLDPWD`, `SHLVL`, and `_` are omitted so `-c <workingDirectory>` remains authoritative.
+- Undefined values are dropped. Jump keeps ambient Forge tokens (`stripForgeTokens: false`) because this is an Interactive Session Continuation in the operator's shell, not an Agent Turn. Per-backend Agent Turn env builders are not reused: they would add four workspace deps, and OpenCode's builder is Effect/Keymaxxer-scoped. Claude panes also set `DISABLE_AUTOUPDATER=1`, matching `packages/claude` Agent Turns.
+- `tmux -e` requires tmux ≥ 3.0 on `new-window` and ≥ 3.2 on `split-window`. Jump documents this floor and does not version-gate: 3.2 shipped in 2021, and Jump already requires a working tmux client.
 
 ## Safety And Failures
 


### PR DESCRIPTION
`ready-for-agent jump` started the agent pane with the tmux server's frozen
environment, not the operator's live shell. mise `[env]`, direnv, and Bedrock
flags such as `CLAUDE_CODE_USE_BEDROCK` were missing, so Claude Code asked for
`/login` instead of using Bedrock (#1042). Non-interactive Agent Turns already
inherit `process.env` through `sanitizeInheritedEnvironment`.

This adds repeated `tmux -e KEY=VALUE` flags on `new-window` (create) and
`split-window` (recreate), before `--`. Flags come from
`sanitizeInheritedEnvironment` with `stripForgeTokens: false` (Interactive
Session Continuation, not an Agent Turn). `TMUX`, `TMUX_PANE`, `TERM`, `PWD`,
`OLDPWD`, `SHLVL`, and `_` are omitted so tmux can set pane identity and `-c`
remains authoritative. Claude panes also set `DISABLE_AUTOUPDATER=1`.
Per-backend Agent Turn env builders are not reused. The jump PRD records that
decision and the tmux floor (`-e` needs ≥ 3.0 / ≥ 3.2); Jump does not
version-gate.

Review of the uncommitted change listed five low-severity design nits (tmux
owning `backendId`, a second `claude` check, unbranded backend id, implicit
`process.env`, duplicated test helpers). They were deferred: no runtime or
contract impact.

Verified with `bunx nx run ready-for-agent:test` and
`bunx nx run ready-for-agent:typecheck`. `cli.test.ts` and
`cli-process.test.ts` assert `-e CLAUDE_CODE_USE_BEDROCK=1` when present, omit
tmux-owned vars, place `-e` before `--`, and set `DISABLE_AUTOUPDATER=1` for
Claude. Not exercised in a live tmux session against Bedrock. The right-hand
shell pane is unchanged (tmux default-command).

Closes #1042