### PR TITLE
chore: pin Bun in mise and align GitHub Actions

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -44,7 +44,7 @@ jobs:
 
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
-          bun-version: latest
+          bun-version: 1.3.14
 
       # Required when affected packages run OpenCode integration tests.
       # Resolve the release via authenticated GitHub API then pin the installer
@@ -117,7 +117,7 @@ jobs:
 
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
-          bun-version: latest
+          bun-version: 1.3.14
 
       - run: bun install --no-cache --frozen-lockfile --linker=isolated && bun install --no-cache --frozen-lockfile --linker=isolated
 
@@ -211,7 +211,7 @@ jobs:
 
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
-          bun-version: latest
+          bun-version: 1.3.14
 
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
@@ -276,7 +276,7 @@ jobs:
 
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
-          bun-version: latest
+          bun-version: 1.3.14
 
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:

--- a/.github/workflows/overnight-install-smoke.yml
+++ b/.github/workflows/overnight-install-smoke.yml
@@ -47,7 +47,7 @@ jobs:
 
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
-          bun-version: latest
+          bun-version: 1.3.14
 
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -41,7 +41,7 @@ jobs:
 
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
-          bun-version: latest
+          bun-version: 1.3.14
 
       # Required when affected packages run OpenCode integration tests.
       # Resolve the release via authenticated GitHub API then pin the installer
@@ -96,7 +96,7 @@ jobs:
 
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
-          bun-version: latest
+          bun-version: 1.3.14
 
       - run: bun install --no-cache --frozen-lockfile --linker=isolated && bun install --no-cache --frozen-lockfile --linker=isolated
 
@@ -182,7 +182,7 @@ jobs:
 
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
-          bun-version: latest
+          bun-version: 1.3.14
 
       - run: bun install --no-cache --frozen-lockfile --linker=isolated && bun install --no-cache --frozen-lockfile --linker=isolated
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,26 +7,60 @@ covers monorepo development of Ready for Agent.
 
 ## Prerequisites
 
-1. [Bun](https://bun.sh/) (workspace package manager and runtime)
-2. Product host tools from the product README: `git`, plus `gh` for GitHub
-   Repositories and `glab` for GitLab Repositories. Authenticate each Forge CLI
-   for the Repository's Forge Host.
-3. The selected Agent Backend on PATH (`opencode` by default), authenticated per
+Product host tools from the product README: `git`, plus `gh` for GitHub
+Repositories and `glab` for GitLab Repositories. Authenticate each Forge CLI
+for the Repository's Forge Host.
+
+Also needed to run or test the harness:
+
+1. The selected Agent Backend on PATH (`opencode` by default), authenticated per
    its own documentation.
-4. Optional: `keymaxxer` on PATH, or `KEYMAXXER_ENTRYPOINT` pointing at an
+2. Optional: `keymaxxer` on PATH, or `KEYMAXXER_ENTRYPOINT` pointing at an
    existing entrypoint (no hardcoded machine path). Not used by Grok Build
    Agent Turns.
-5. Contributor scripts only: `curl`, used by GitLab e2e and fixture scripts
+3. Contributor scripts only: `curl`, used by GitLab e2e and fixture scripts
    such as `scripts/setup-gitlab-e2e-fixture.sh` and
    `scripts/regenerate-e2e-keymaxxer-vault.sh`. It is not required to run the
    operator binary.
 
-## Install
+## Install with mise
+
+[mise](https://mise.jdx.dev/) 2026.7.0 or later installs the pinned Bun and hk
+versions, then workspace dependencies (which apply the existing Git hooks).
+
+```bash
+git clone git@github.com:berenddeboer/ready-for-agent.git
+cd ready-for-agent
+mise trust
+mise bootstrap
+```
+
+Optional browser/e2e setup (installs Chromium and native Playwright
+dependencies; not required for ordinary development):
+
+```bash
+mise run setup-e2e
+```
+
+## Install without mise
+
+Install the Bun version pinned in [`mise.toml`](mise.toml) from
+[bun.sh](https://bun.sh/). Then:
 
 ```bash
 git clone git@github.com:berenddeboer/ready-for-agent.git
 cd ready-for-agent
 bun install
+```
+
+`bun install` runs the root `prepare` script, which installs Git hooks when
+`hk` is on PATH (or resolvable through mise) and applies the existing package
+setup patches.
+
+Optional browser/e2e setup:
+
+```bash
+(cd apps/harness && bunx playwright install --with-deps chromium)
 ```
 
 ## Running the harness

--- a/knip.json
+++ b/knip.json
@@ -10,6 +10,10 @@
   "ignoreBinaries": ["skills", "pgrep", "ps"],
   "ignoreFiles": [".opencode/plugin/**"],
   "workspaces": {
+    ".": {
+      "entry": ["scripts/tool-pins.test.ts"],
+      "project": ["scripts/**/*.{ts,mjs}"]
+    },
     "apps/harness": {
       "entry": [
         "src/router.tsx",

--- a/mise.toml
+++ b/mise.toml
@@ -1,2 +1,16 @@
+min_version = "2026.7.0"
+
 [tools]
+# Authoritative Bun pin. GitHub Actions must use the same version.
+bun = "1.3.14"
 hk = "1.54.1"
+
+[tasks.bootstrap]
+description = "Install workspace dependencies"
+run = "bun install"
+
+[tasks.setup-e2e]
+description = "Install Playwright Chromium and OS dependencies for Harness e2e"
+dir = "{{config_root}}/apps/harness"
+depends = ["bootstrap"]
+run = "bunx playwright install --with-deps chromium"

--- a/nx.json
+++ b/nx.json
@@ -5,8 +5,10 @@
     "default": ["{projectRoot}/**/*", "sharedGlobals"],
     "production": ["default"],
     "sharedGlobals": [
+      "{workspaceRoot}/mise.toml",
       "{workspaceRoot}/.github/workflows/ci-cd.yml",
-      "{workspaceRoot}/.github/workflows/pr.yml"
+      "{workspaceRoot}/.github/workflows/pr.yml",
+      "{workspaceRoot}/.github/workflows/overnight-install-smoke.yml"
     ]
   },
   "plugins": [

--- a/packages/graphql-api/test/graphql-api.test.ts
+++ b/packages/graphql-api/test/graphql-api.test.ts
@@ -8616,7 +8616,7 @@ describe("GraphQL API", () => {
   })
 
   test("kanbanStatus classifies lanes, windows, ordering, and repository filter", async () => {
-    const now = Date.parse("2026-08-12T12:00:00.000Z")
+    const now = Date.now()
     const otherRepo = makeRepositoryRecord({
       id: "repo-01J00000000000000000000001",
       projectPath: "acme/other",

--- a/scripts/project.json
+++ b/scripts/project.json
@@ -1,0 +1,24 @@
+{
+  "name": "workspace-scripts",
+  "$schema": "../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "scripts",
+  "projectType": "library",
+  "tags": [],
+  "targets": {
+    "test": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "bun test tool-pins.test.ts",
+        "cwd": "{projectRoot}"
+      },
+      "inputs": [
+        "{workspaceRoot}/mise.toml",
+        "{workspaceRoot}/hk.pkl",
+        "{workspaceRoot}/.github/**/*.yml",
+        "{workspaceRoot}/.github/**/*.yaml",
+        "{projectRoot}/tool-pins.test.ts"
+      ],
+      "cache": true
+    }
+  }
+}

--- a/scripts/tool-pins.test.ts
+++ b/scripts/tool-pins.test.ts
@@ -1,0 +1,102 @@
+import { readFileSync, readdirSync } from "node:fs"
+import { join } from "node:path"
+import { describe, expect, it } from "bun:test"
+
+const workspaceRoot = join(import.meta.dir, "..")
+
+const readWorkspace = (relativePath: string): string =>
+  readFileSync(join(workspaceRoot, relativePath), "utf8")
+
+const quotedAssignment = (source: string, key: string): string | undefined =>
+  source.match(new RegExp(`^${key}\\s*=\\s*"([^"]+)"`, "m"))?.[1]
+
+const tomlTable = (source: string, heading: string): string | undefined => {
+  const escaped = heading.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
+  const start = source.search(new RegExp(`^\\[${escaped}\\]\\s*$`, "m"))
+  if (start < 0) {
+    return undefined
+  }
+  const afterHeading = source.indexOf("\n", start)
+  const rest = afterHeading < 0 ? "" : source.slice(afterHeading + 1)
+  const end = rest.search(/^\[[^\]]+\]\s*$/m)
+  return end < 0 ? rest : rest.slice(0, end)
+}
+
+const githubYamlFiles = (): readonly string[] => {
+  const files: string[] = []
+  const visit = (relativeDir: string) => {
+    for (const entry of readdirSync(join(workspaceRoot, relativeDir), {
+      withFileTypes: true,
+    })) {
+      const relativePath = `${relativeDir}/${entry.name}`
+      if (entry.isDirectory()) {
+        visit(relativePath)
+        continue
+      }
+      if (entry.name.endsWith(".yml") || entry.name.endsWith(".yaml")) {
+        files.push(relativePath)
+      }
+    }
+  }
+  visit(".github")
+  return files
+}
+
+describe("contributor environment pins", () => {
+  const miseToml = readWorkspace("mise.toml")
+  const hkPkl = readWorkspace("hk.pkl")
+
+  it("declares a concrete Bun pin in mise.toml without machine-global bootstrap packages", () => {
+    const bunVersion = quotedAssignment(miseToml, "bun")
+    expect(bunVersion).toMatch(/^\d+\.\d+\.\d+$/)
+    expect(quotedAssignment(miseToml, "min_version")).toBe("2026.7.0")
+    expect(quotedAssignment(miseToml, "hk")).toMatch(/^\d+\.\d+\.\d+$/)
+    expect(miseToml).not.toContain("[bootstrap.packages]")
+  })
+
+  it("keeps the hk pin aligned with the hk.pkl package URL", () => {
+    const hkVersion = quotedAssignment(miseToml, "hk")
+    expect(hkVersion).toBeDefined()
+    expect(hkPkl).toContain(
+      `package://github.com/jdx/hk/releases/download/v${hkVersion}/hk@${hkVersion}`,
+    )
+  })
+
+  it("declares bootstrap as bun install and setup-e2e as Harness Playwright Chromium", () => {
+    const bootstrap = tomlTable(miseToml, "tasks.bootstrap")
+    expect(bootstrap).toBeDefined()
+    expect(quotedAssignment(bootstrap!, "run")).toBe("bun install")
+
+    const setupE2e = tomlTable(miseToml, "tasks.setup-e2e")
+    expect(setupE2e).toBeDefined()
+    expect(quotedAssignment(setupE2e!, "run")).toBe(
+      "bunx playwright install --with-deps chromium",
+    )
+    expect(quotedAssignment(setupE2e!, "dir")).toContain("apps/harness")
+  })
+
+  it("uses the mise.toml Bun pin in every GitHub Actions Bun setup", () => {
+    const bunVersion = quotedAssignment(miseToml, "bun")
+    expect(bunVersion).toBeDefined()
+
+    const setupBunBlocks: string[] = []
+    for (const relativePath of githubYamlFiles()) {
+      const contents = readWorkspace(relativePath)
+      expect(contents, relativePath).not.toMatch(/bun-version:\s*latest\b/)
+
+      const uses = contents.matchAll(
+        /uses:\s*oven-sh\/setup-bun@[^\n]+\n(?:[ \t]+[^\n]*\n)*/g,
+      )
+      for (const match of uses) {
+        setupBunBlocks.push(`${relativePath}:\n${match[0]}`)
+      }
+    }
+
+    expect(setupBunBlocks.length).toBeGreaterThan(0)
+    for (const block of setupBunBlocks) {
+      expect(block).toMatch(
+        new RegExp(`bun-version:\\s*["']?${bunVersion}["']?`),
+      )
+    }
+  })
+})


### PR DESCRIPTION
Contributor setup only declared `hk` in `mise.toml`, while ordinary monorepo
work needs Bun, and CI installed `bun-version: latest`. Local and Actions
environments could drift, and `mise bootstrap` was not a complete
project-scoped onboarding command (#1040).

`mise.toml` now requires mise `2026.7.0`, pins Bun `1.3.14` (the current
published stable; `1.4.0` is not a GitHub release) and `hk` `1.54.1`, and
adds `bootstrap` (`bun install`) plus opt-in `setup-e2e` (Playwright Chromium
from `apps/harness`). There is no `[bootstrap.packages]` section.
`CONTRIBUTING.md` documents `mise trust && mise bootstrap` and keeps a
manual Bun + `bun install` path.

All eight `oven-sh/setup-bun` steps in `pr.yml`, `ci-cd.yml`, and
`overnight-install-smoke.yml` use `1.3.14`. `workspace-scripts:test` fails
if any workflow uses `latest` or a version other than the `mise.toml` pin,
and it checks `hk.pkl` alignment plus the bootstrap/`setup-e2e` task
tables.

Verification: `mise bootstrap --only tools,task` installed Bun `1.3.14` and
hk `1.54.1` and re-ran cleanly; `workspace-scripts` lint and test passed.
Full `setup-e2e` was not executed here (no `apt-get` for Playwright
`--with-deps`). A kanban GraphQL test now uses wall-clock `Date.now()` so
the 24h Merged window does not expire against a frozen fixture date.

Closes #1040