### PR TITLE
fix(lifecycle): accept sentinel arguments wrapped in placeholder brackets

### DIFF
--- a/packages/work-item-lifecycle/src/lib/decide-pr-merge.ts
+++ b/packages/work-item-lifecycle/src/lib/decide-pr-merge.ts
@@ -9,6 +9,7 @@ import {
 } from "./agent-turn-forge-auth.js"
 import type { LifecycleStepContext } from "./lifecycle-steps.js"
 import { DEFAULT_LIFECYCLE_MAX_DURATIONS } from "./types.js"
+import { unwrapSentinelArgument } from "./unwrap-sentinel-argument.js"
 
 export class DecidePrMergeContextError extends Schema.TaggedErrorClass<DecidePrMergeContextError>()(
   "DecidePrMergeContextError",
@@ -82,8 +83,11 @@ export const parseDecidePrMergeResult = (
   const needsHuman = finalLine.match(
     /^READY_FOR_AGENT_RESULT:\s*NEEDS_HUMAN\s*:\s*(.+)$/i,
   )
-  if (needsHuman?.[1] !== undefined && needsHuman[1].trim() !== "") {
-    return { _tag: "needs_human", reason: needsHuman[1].trim().slice(0, 500) }
+  if (needsHuman?.[1] !== undefined) {
+    const reason = unwrapSentinelArgument(needsHuman[1])
+    if (reason !== "") {
+      return { _tag: "needs_human", reason: reason.slice(0, 500) }
+    }
   }
   return null
 }

--- a/packages/work-item-lifecycle/src/lib/pr-status-checks.ts
+++ b/packages/work-item-lifecycle/src/lib/pr-status-checks.ts
@@ -31,6 +31,7 @@ import {
   STEP_RUN_REASON,
   type StepRunReasonCode,
 } from "./types.js"
+import { unwrapSentinelArgument } from "./unwrap-sentinel-argument.js"
 import { workItemBranchName } from "./worktree-names.js"
 
 export class PrStatusChecksContextError extends Schema.TaggedErrorClass<PrStatusChecksContextError>()(
@@ -403,15 +404,17 @@ export const parseInvestigationResult = (
     return "checks_triggered"
   }
   const rerunReview = finalLine.match(
-    /^READY_FOR_AGENT_RESULT:\s*RERUN_REVIEW\s*:\s*(\d+)(?:\s+(.+))?$/i,
+    /^READY_FOR_AGENT_RESULT:\s*RERUN_REVIEW\s*:\s*(\S+)(?:\s+(.+))?$/i,
   )
   if (rerunReview?.[1] !== undefined) {
-    const workflowRunId = Number(rerunReview[1])
+    const workflowRunId = Number(unwrapSentinelArgument(rerunReview[1]))
     if (Number.isSafeInteger(workflowRunId) && workflowRunId > 0) {
+      const workflowNameRaw =
+        rerunReview[2] === undefined
+          ? ""
+          : unwrapSentinelArgument(rerunReview[2])
       const workflowName =
-        rerunReview[2] !== undefined && rerunReview[2].trim() !== ""
-          ? rerunReview[2].trim().slice(0, 200)
-          : null
+        workflowNameRaw !== "" ? workflowNameRaw.slice(0, 200) : null
       return {
         _tag: "rerun_review",
         workflowRunId,
@@ -422,19 +425,25 @@ export const parseInvestigationResult = (
   const needsHuman = finalLine.match(
     /^READY_FOR_AGENT_RESULT:\s*NEEDS_HUMAN\s*:\s*(.+)$/i,
   )
-  if (needsHuman?.[1] !== undefined && needsHuman[1].trim() !== "") {
-    return {
-      _tag: "needs_human",
-      reason: needsHuman[1].trim().slice(0, 500),
+  if (needsHuman?.[1] !== undefined) {
+    const reason = unwrapSentinelArgument(needsHuman[1])
+    if (reason !== "") {
+      return {
+        _tag: "needs_human",
+        reason: reason.slice(0, 500),
+      }
     }
   }
   const failed = finalLine.match(
     /^READY_FOR_AGENT_RESULT:\s*FAILED\s*:\s*(.+)$/i,
   )
-  if (failed?.[1] !== undefined && failed[1].trim() !== "") {
-    return {
-      _tag: "failed",
-      reason: failed[1].trim().slice(0, 500),
+  if (failed?.[1] !== undefined) {
+    const reason = unwrapSentinelArgument(failed[1])
+    if (reason !== "") {
+      return {
+        _tag: "failed",
+        reason: reason.slice(0, 500),
+      }
     }
   }
   return null

--- a/packages/work-item-lifecycle/src/lib/resolve-pr-merge-conflict.ts
+++ b/packages/work-item-lifecycle/src/lib/resolve-pr-merge-conflict.ts
@@ -11,6 +11,7 @@ import {
 } from "./agent-turn-forge-auth.js"
 import type { LifecycleStepContext } from "./lifecycle-steps.js"
 import { DEFAULT_LIFECYCLE_MAX_DURATIONS } from "./types.js"
+import { unwrapSentinelArgument } from "./unwrap-sentinel-argument.js"
 
 export class ResolvePrMergeConflictContextError extends Schema.TaggedErrorClass<ResolvePrMergeConflictContextError>()(
   "ResolvePrMergeConflictContextError",
@@ -53,9 +54,11 @@ const parseResult = (
   const needsHuman = finalLine.match(
     /^READY_FOR_AGENT_RESULT:\s*NEEDS_HUMAN\s*:\s*(.+)$/i,
   )
-  return needsHuman?.[1] === undefined || needsHuman[1].trim() === ""
-    ? null
-    : { reason: needsHuman[1].trim().slice(0, 500) }
+  if (needsHuman?.[1] === undefined) {
+    return null
+  }
+  const reason = unwrapSentinelArgument(needsHuman[1])
+  return reason === "" ? null : { reason: reason.slice(0, 500) }
 }
 
 const hasResultLine = (output: string): boolean =>

--- a/packages/work-item-lifecycle/src/lib/review.ts
+++ b/packages/work-item-lifecycle/src/lib/review.ts
@@ -24,6 +24,7 @@ import {
   REVIEW_REVIEWING_MESSAGE,
   STEP_RUN_REASON,
 } from "./types.js"
+import { unwrapSentinelArgument } from "./unwrap-sentinel-argument.js"
 
 /**
  * Operator-facing Review agent failure text. Retains the specific startup
@@ -224,8 +225,13 @@ const lastValidResult = <T>(
 const hasResultLine = (output: string): boolean =>
   candidateResultLines(output).length > 0
 
+const quotedResultLineSuffix = (output: string): string => {
+  const last = candidateResultLines(output).at(-1)
+  return last === undefined ? "" : ` (got ${JSON.stringify(last)})`
+}
+
 const parseSeverity = (raw: string): ReviewSeverity | null => {
-  const value = raw.trim().toLowerCase()
+  const value = unwrapSentinelArgument(raw).toLowerCase()
   if (value === "low" || value === "medium" || value === "high") {
     return value
   }
@@ -240,7 +246,8 @@ const parseDeferredSeverity = (raw: string): DeferredReviewSeverity | null => {
   return null
 }
 
-const boundReason = (reason: string): string => reason.trim().slice(0, 500)
+const boundReason = (reason: string): string =>
+  unwrapSentinelArgument(reason).slice(0, 500)
 
 const tryParseReviewLine = (line: string): ReviewingPassResult | null => {
   if (/^READY_FOR_AGENT_RESULT:\s*REVIEW_CLEAN$/i.test(line)) {
@@ -274,7 +281,7 @@ const tryParseApplyReviewLine = (line: string): ApplyReviewResult | null => {
   }
 
   const fixedAndDeferred = line.match(
-    /^READY_FOR_AGENT_RESULT:\s*REVIEW_FIXED_AND_DEFERRED\s*:\s*(low|medium)\s*:\s*(.+)$/i,
+    /^READY_FOR_AGENT_RESULT:\s*REVIEW_FIXED_AND_DEFERRED\s*:\s*([^:]+)\s*:\s*(.+)$/i,
   )
   if (
     fixedAndDeferred?.[1] !== undefined &&
@@ -292,7 +299,7 @@ const tryParseApplyReviewLine = (line: string): ApplyReviewResult | null => {
   }
 
   const deferred = line.match(
-    /^READY_FOR_AGENT_RESULT:\s*REVIEW_DEFERRED\s*:\s*(low|medium)\s*:\s*(.+)$/i,
+    /^READY_FOR_AGENT_RESULT:\s*REVIEW_DEFERRED\s*:\s*([^:]+)\s*:\s*(.+)$/i,
   )
   if (
     deferred?.[1] !== undefined &&
@@ -528,8 +535,9 @@ export const review = (context: LifecycleStepContext) =>
           ),
         )
 
-      let reviewingParsed = parseReviewResult(reviewing.assistantText)
-      if (reviewingParsed === null && !hasResultLine(reviewing.assistantText)) {
+      let reviewingOutput = reviewing.assistantText
+      let reviewingParsed = parseReviewResult(reviewingOutput)
+      if (reviewingParsed === null && !hasResultLine(reviewingOutput)) {
         const verdict = yield* agentBackend
           .continueTurn({
             sessionId,
@@ -554,13 +562,14 @@ export const review = (context: LifecycleStepContext) =>
                 }),
             ),
           )
-        reviewingParsed = parseReviewResult(verdict.assistantText)
+        reviewingOutput = verdict.assistantText
+        reviewingParsed = parseReviewResult(reviewingOutput)
       }
 
       if (reviewingParsed === null) {
         return yield* new ReviewResultError({
           workItemId: context.workItemId,
-          message: `${agentBackendLabel(context.agentBackend)} did not report a valid READY_FOR_AGENT_RESULT: REVIEW_CLEAN or REVIEW_HAS_FINDINGS: <low|medium|high>`,
+          message: `${agentBackendLabel(context.agentBackend)} did not report a valid READY_FOR_AGENT_RESULT: REVIEW_CLEAN or REVIEW_HAS_FINDINGS: <low|medium|high>${quotedResultLineSuffix(reviewingOutput)}`,
         })
       }
 
@@ -608,7 +617,7 @@ export const review = (context: LifecycleStepContext) =>
       if (applyParsed === null) {
         return yield* new ReviewResultError({
           workItemId: context.workItemId,
-          message: `${agentBackendLabel(context.agentBackend)} did not report a valid READY_FOR_AGENT_RESULT: REVIEW_FIXED, REVIEW_FIXED_AND_DEFERRED: <low|medium>: <reason>, REVIEW_DEFERRED: <low|medium>: <reason>, REVIEW_CLEARED: <reason>, or REVIEW_UNRESOLVED_HIGH: <reason>`,
+          message: `${agentBackendLabel(context.agentBackend)} did not report a valid READY_FOR_AGENT_RESULT: REVIEW_FIXED, REVIEW_FIXED_AND_DEFERRED: <low|medium>: <reason>, REVIEW_DEFERRED: <low|medium>: <reason>, REVIEW_CLEARED: <reason>, or REVIEW_UNRESOLVED_HIGH: <reason>${quotedResultLineSuffix(applying.assistantText)}`,
         })
       }
 

--- a/packages/work-item-lifecycle/src/lib/unwrap-sentinel-argument.ts
+++ b/packages/work-item-lifecycle/src/lib/unwrap-sentinel-argument.ts
@@ -1,0 +1,13 @@
+/**
+ * Strip one surrounding pair of angle brackets from a READY_FOR_AGENT_RESULT
+ * argument. Agents sometimes copy placeholder brackets from the prompt
+ * (`<medium>`). The placeholder itself (`<low|medium|high>`) still fails
+ * subsequent enum matching after unwrap.
+ */
+export const unwrapSentinelArgument = (raw: string): string => {
+  const trimmed = raw.trim()
+  if (trimmed.length >= 2 && trimmed.startsWith("<") && trimmed.endsWith(">")) {
+    return trimmed.slice(1, -1).trim()
+  }
+  return trimmed
+}

--- a/packages/work-item-lifecycle/test/decide-pr-merge.spec.ts
+++ b/packages/work-item-lifecycle/test/decide-pr-merge.spec.ts
@@ -74,6 +74,17 @@ describe("parseDecidePrMergeResult", () => {
     expect(parseDecidePrMergeResult("no result line")).toBeNull()
   })
 
+  it("accepts a needs-human reason wrapped in one pair of placeholder brackets", () => {
+    expect(
+      parseDecidePrMergeResult(
+        "READY_FOR_AGENT_RESULT: NEEDS_HUMAN: <Touches auth secrets>",
+      ),
+    ).toEqual({
+      _tag: "needs_human",
+      reason: "Touches auth secrets",
+    })
+  })
+
   it("rejects conflicting or non-final result lines", () => {
     expect(
       parseDecidePrMergeResult(

--- a/packages/work-item-lifecycle/test/pr-status-checks.spec.ts
+++ b/packages/work-item-lifecycle/test/pr-status-checks.spec.ts
@@ -2610,6 +2610,32 @@ describe("PR status check steps", () => {
     })
   })
 
+  it("accepts RERUN_REVIEW arguments wrapped in one pair of placeholder brackets", () => {
+    expect(
+      parseInvestigationResult(
+        "READY_FOR_AGENT_RESULT: RERUN_REVIEW: <29906669357>",
+      ),
+    ).toEqual({
+      _tag: "rerun_review",
+      workflowRunId: 29906669357,
+      workflowName: null,
+    })
+    expect(
+      parseInvestigationResult(
+        "READY_FOR_AGENT_RESULT: RERUN_REVIEW: <42> <Claude Code Review>",
+      ),
+    ).toEqual({
+      _tag: "rerun_review",
+      workflowRunId: 42,
+      workflowName: "Claude Code Review",
+    })
+    expect(
+      parseInvestigationResult(
+        "READY_FOR_AGENT_RESULT: RERUN_REVIEW: <workflow_run_id>",
+      ),
+    ).toBeNull()
+  })
+
   it("treats the production success+skipped name-only shape as a green-only PROCESSED no-op", async () => {
     const prompts: string[] = []
     let rerunCalls = 0

--- a/packages/work-item-lifecycle/test/review.spec.ts
+++ b/packages/work-item-lifecycle/test/review.spec.ts
@@ -192,6 +192,20 @@ describe("parseReviewResult", () => {
     ).toEqual({ _tag: "has_findings", severity: "high" })
   })
 
+  it("accepts a severity wrapped in one pair of placeholder brackets", () => {
+    expect(
+      parseReviewResult(
+        "READY_FOR_AGENT_RESULT: REVIEW_HAS_FINDINGS: <medium>",
+      ),
+    ).toEqual({ _tag: "has_findings", severity: "medium" })
+    expect(
+      parseReviewResult("READY_FOR_AGENT_RESULT: REVIEW_HAS_FINDINGS: <low>"),
+    ).toEqual({ _tag: "has_findings", severity: "low" })
+    expect(
+      parseReviewResult("READY_FOR_AGENT_RESULT: REVIEW_HAS_FINDINGS: <high>"),
+    ).toEqual({ _tag: "has_findings", severity: "high" })
+  })
+
   it("accepts the last valid marker amid duplicates or trailing prose", () => {
     expect(
       parseReviewResult(
@@ -216,6 +230,11 @@ describe("parseReviewResult", () => {
     expect(
       parseReviewResult(
         "READY_FOR_AGENT_RESULT: REVIEW_HAS_FINDINGS: critical",
+      ),
+    ).toBeNull()
+    expect(
+      parseReviewResult(
+        "READY_FOR_AGENT_RESULT: REVIEW_HAS_FINDINGS: <low|medium|high>",
       ),
     ).toBeNull()
     expect(parseReviewResult("READY_FOR_AGENT_RESULT: REVIEW_FIXED")).toBeNull()
@@ -258,6 +277,37 @@ describe("parseApplyReviewResult", () => {
       _tag: "unresolved_high",
       reason: "auth bypass still open",
     })
+  })
+
+  it("accepts enum and reason arguments wrapped in one pair of placeholder brackets", () => {
+    expect(
+      parseApplyReviewResult(
+        "READY_FOR_AGENT_RESULT: REVIEW_DEFERRED: <medium>: naming only",
+      ),
+    ).toEqual({
+      _tag: "deferred",
+      severity: "medium",
+      reason: "naming only",
+    })
+    expect(
+      parseApplyReviewResult(
+        "READY_FOR_AGENT_RESULT: REVIEW_FIXED_AND_DEFERRED: <low>: <style nits remain>",
+      ),
+    ).toEqual({
+      _tag: "fixed_and_deferred",
+      severity: "low",
+      reason: "style nits remain",
+    })
+    expect(
+      parseApplyReviewResult(
+        "READY_FOR_AGENT_RESULT: REVIEW_CLEARED: <false positive>",
+      ),
+    ).toEqual({ _tag: "cleared", reason: "false positive" })
+    expect(
+      parseApplyReviewResult(
+        "READY_FOR_AGENT_RESULT: REVIEW_DEFERRED: <low|medium>: leftover nits",
+      ),
+    ).toBeNull()
   })
 
   it("accepts the last valid marker amid duplicates or trailing prose", () => {
@@ -351,6 +401,17 @@ describe("parseRerunAssessmentResult", () => {
     expect(
       parseRerunAssessmentResult(
         "READY_FOR_AGENT_RESULT: REVIEW_RERUN_REQUIRED: expanded into parser behavior",
+      ),
+    ).toEqual({
+      _tag: "rerun_required",
+      reason: "expanded into parser behavior",
+    })
+  })
+
+  it("accepts assessment reasons wrapped in one pair of placeholder brackets", () => {
+    expect(
+      parseRerunAssessmentResult(
+        "READY_FOR_AGENT_RESULT: REVIEW_RERUN_REQUIRED: <expanded into parser behavior>",
       ),
     ).toEqual({
       _tag: "rerun_required",
@@ -1816,6 +1877,29 @@ describe("review", () => {
         }),
       )
       expect(error).toBeInstanceOf(ReviewResultError)
+      expect((error as ReviewResultError).message).toContain(
+        "did not report a valid READY_FOR_AGENT_RESULT: REVIEW_CLEAN or REVIEW_HAS_FINDINGS: <low|medium|high>",
+      )
+      expect((error as ReviewResultError).message).not.toContain("(got ")
+    }))
+
+  it("quotes the emitted result line when the reviewing verdict is invalid", () =>
+    withTemp(async (root) => {
+      const error = await run(
+        review(baseContext(root)).pipe(Effect.flip),
+        stubOpencode({
+          continueTurn: () =>
+            Effect.succeed({
+              sessionId: "ses_implement_session",
+              assistantText:
+                "READY_FOR_AGENT_RESULT: REVIEW_HAS_FINDINGS: <low|medium|high>",
+            }),
+        }),
+      )
+      expect(error).toBeInstanceOf(ReviewResultError)
+      expect((error as ReviewResultError).message).toContain(
+        'got "READY_FOR_AGENT_RESULT: REVIEW_HAS_FINDINGS: <low|medium|high>"',
+      )
     }))
 
   it("fails when apply-path READY_FOR_AGENT_RESULT is missing or ambiguous", () =>
@@ -1838,6 +1922,31 @@ describe("review", () => {
       )
       expect(error).toBeInstanceOf(ReviewResultError)
       expect((error as ReviewResultError).message).toContain("REVIEW_FIXED")
+      expect((error as ReviewResultError).message).not.toContain("(got ")
+    }))
+
+  it("quotes the emitted result line when the apply-path verdict is invalid", () =>
+    withTemp(async (root) => {
+      let turn = 0
+      const error = await run(
+        review(baseContext(root)).pipe(Effect.flip),
+        stubOpencode({
+          continueTurn: () => {
+            turn += 1
+            return Effect.succeed({
+              sessionId: "ses_implement_session",
+              assistantText:
+                turn === 1
+                  ? "READY_FOR_AGENT_RESULT: REVIEW_HAS_FINDINGS: low"
+                  : "READY_FOR_AGENT_RESULT: REVIEW_DEFERRED: <low|medium>: leftover nits",
+            })
+          },
+        }),
+      )
+      expect(error).toBeInstanceOf(ReviewResultError)
+      expect((error as ReviewResultError).message).toContain(
+        'got "READY_FOR_AGENT_RESULT: REVIEW_DEFERRED: <low|medium>: leftover nits"',
+      )
     }))
 
   it("accepts the last valid marker when READY_FOR_AGENT_RESULT lines are duplicated", () =>


### PR DESCRIPTION
Review turns failed when an agent copied prompt placeholders and emitted
`REVIEW_HAS_FINDINGS: <medium>`. The parser rejected the line, discarded a
completed review, and the error read as if no verdict had been reported
(#1050).

Strip one surrounding `<>` pair from `READY_FOR_AGENT_RESULT` arguments
before matching. `<medium>` and `medium` both parse; the echoed placeholder
`<low|medium|high>` is still rejected. The same unwrap applies to other
argument-bearing sentinels (review defer/clear reasons, `RERUN_REVIEW`
workflow ids, and `NEEDS_HUMAN` / `FAILED` reasons). When Review still
cannot parse a result, the failure message now quotes the last result line
the agent emitted.

Verified with `bunx nx test work-item-lifecycle` (603 pass) and Biome on
the touched files.

Closes #1050