### PR TITLE
fix(agent-backend): surface parsed CLI exit reasons in cause chains

### DIFF
--- a/packages/agent-backend/src/lib/cli-runner.ts
+++ b/packages/agent-backend/src/lib/cli-runner.ts
@@ -25,6 +25,16 @@ import type { AgentBackendDescriptor, OnSessionId } from "./types.js"
 /** Graceful terminate then force-kill bound for the Agent Turn process tree. */
 export const DEFAULT_FORCE_KILL_AFTER = Duration.seconds(2)
 
+const capturedCliOutputMessage = (
+  stdout: string,
+  stderr: string,
+): string | undefined => {
+  const parts = [stdout, stderr]
+    .map((part) => part.trim())
+    .filter((part) => part.length > 0)
+  return parts.length > 0 ? parts.join("\n") : undefined
+}
+
 /**
  * Window from spawn to the first stdout output of an Agent Turn. A CLI that
  * crashes or hangs before emitting anything otherwise burns the whole turn
@@ -56,6 +66,13 @@ export type CliLineEvent = {
    * on to exit non-zero.
    */
   readonly errorClassification?: AgentBackendErrorClassification
+  /**
+   * Human-readable reason already parsed from the stream (e.g. Claude
+   * `is_error`, Codex `turn.failed`). Sticky like classification: once
+   * observed, it becomes AgentBackendExitError.message on a non-zero exit
+   * so the adapter does not have to run after the CLI dies.
+   */
+  readonly errorMessage?: string
 }
 
 export type RunCliCaptureInput = {
@@ -240,9 +257,11 @@ export const runCliCapture = (
     )
 
     if (result.exitCode !== 0 && input.allowNonZeroExit !== true) {
+      const message = capturedCliOutputMessage(result.stdout, result.stderr)
       return yield* new AgentBackendExitError({
         exitCode: result.exitCode,
         cwd: input.cwd,
+        ...(message !== undefined ? { message } : {}),
       })
     }
 
@@ -345,6 +364,7 @@ export const runCliTurn = (
               assistantText: string
               finalized: boolean
               errorClassification?: AgentBackendErrorClassification
+              errorMessage?: string
             } => ({
               assistantText: "",
               finalized: false,
@@ -359,6 +379,7 @@ export const runCliTurn = (
                 const sessionId = event.sessionId ?? acc.sessionId
                 const errorClassification =
                   event.errorClassification ?? acc.errorClassification
+                const errorMessage = event.errorMessage ?? acc.errorMessage
                 if (event.sessionId !== undefined) {
                   yield* Ref.set(seenSessionId, event.sessionId)
                   const alreadyNotified = yield* Ref.getAndSet(
@@ -400,6 +421,7 @@ export const runCliTurn = (
                     ...(errorClassification !== undefined
                       ? { errorClassification }
                       : {}),
+                    ...(errorMessage !== undefined ? { errorMessage } : {}),
                   }
                 }
 
@@ -415,6 +437,7 @@ export const runCliTurn = (
                   ...(errorClassification !== undefined
                     ? { errorClassification }
                     : {}),
+                  ...(errorMessage !== undefined ? { errorMessage } : {}),
                 }
               }),
           ),
@@ -435,6 +458,7 @@ export const runCliTurn = (
           assistantText: output.assistantText,
           finalized: output.finalized,
           errorClassification: output.errorClassification,
+          errorMessage: output.errorMessage,
         }
       }),
     ).pipe(
@@ -467,6 +491,9 @@ export const runCliTurn = (
           ...(sessionId !== undefined ? { sessionId } : {}),
           ...(result.errorClassification !== undefined
             ? { classification: result.errorClassification }
+            : {}),
+          ...(result.errorMessage !== undefined
+            ? { message: result.errorMessage }
             : {}),
         })
       }

--- a/packages/agent-backend/src/lib/cli-runner.ts
+++ b/packages/agent-backend/src/lib/cli-runner.ts
@@ -258,7 +258,7 @@ export const runCliCapture = (
 
     if (result.exitCode !== 0 && input.allowNonZeroExit !== true) {
       const message = capturedCliOutputMessage(result.stdout, result.stderr)
-      return yield* new AgentBackendExitError({
+      return yield* AgentBackendExitError.new({
         exitCode: result.exitCode,
         cwd: input.cwd,
         ...(message !== undefined ? { message } : {}),
@@ -485,7 +485,7 @@ export const runCliTurn = (
       const exitCode = Number(result.exitOutcome.success)
       if (exitCode !== 0) {
         const sessionId = result.sessionId ?? knownSessionId
-        return yield* new AgentBackendExitError({
+        return yield* AgentBackendExitError.new({
           exitCode,
           cwd: input.cwd,
           ...(sessionId !== undefined ? { sessionId } : {}),

--- a/packages/agent-backend/src/lib/errors.ts
+++ b/packages/agent-backend/src/lib/errors.ts
@@ -77,12 +77,13 @@ export class AgentBackendExitError extends Schema.TaggedErrorClass<AgentBackendE
     message: Schema.optionalKey(Schema.String),
   },
 ) {
-  constructor(props: AgentBackendExitErrorProps) {
+  /** Sanitize the operator-visible reason before the Schema constructor. */
+  static new(props: AgentBackendExitErrorProps): AgentBackendExitError {
     const sanitized =
       props.message === undefined
         ? undefined
         : sanitizeAgentBackendExitMessage(props.message)
-    super({
+    return new AgentBackendExitError({
       exitCode: props.exitCode,
       cwd: props.cwd,
       ...(props.sessionId !== undefined ? { sessionId: props.sessionId } : {}),

--- a/packages/agent-backend/src/lib/errors.ts
+++ b/packages/agent-backend/src/lib/errors.ts
@@ -1,4 +1,5 @@
 import { Schema } from "effect"
+import { sanitizeAgentBackendExitMessage } from "./sanitize-exit-message.js"
 
 const AgentBackendProviderSchema = Schema.Struct({
   id: Schema.String,
@@ -40,6 +41,18 @@ export class AgentBackendConfigError extends Schema.TaggedErrorClass<AgentBacken
   },
 ) {}
 
+type AgentBackendExitErrorProps = {
+  readonly exitCode: number
+  readonly cwd: string
+  readonly sessionId?: string
+  readonly classification?: AgentBackendErrorClassification
+  /**
+   * Best available human-readable reason. Optional is transitional — a
+   * messageless exit error is not a legitimate constructed value. See #1066.
+   */
+  readonly message?: string
+}
+
 export class AgentBackendExitError extends Schema.TaggedErrorClass<AgentBackendExitError>()(
   "AgentBackendExitError",
   {
@@ -54,8 +67,34 @@ export class AgentBackendExitError extends Schema.TaggedErrorClass<AgentBackendE
      * behavior) or an unrecognized error payload.
      */
     classification: Schema.optionalKey(AgentBackendErrorClassification),
+    /**
+     * Best available human-readable reason. Optionality is transitional,
+     * not a design preference: a messageless exit error is the defect this
+     * field exists to remove. Flip to required in #1066 once every caller
+     * supplies a reason (blocked on stderr capture for the shared CLI turn
+     * runner).
+     */
+    message: Schema.optionalKey(Schema.String),
   },
-) {}
+) {
+  constructor(props: AgentBackendExitErrorProps) {
+    const sanitized =
+      props.message === undefined
+        ? undefined
+        : sanitizeAgentBackendExitMessage(props.message)
+    super({
+      exitCode: props.exitCode,
+      cwd: props.cwd,
+      ...(props.sessionId !== undefined ? { sessionId: props.sessionId } : {}),
+      ...(props.classification !== undefined
+        ? { classification: props.classification }
+        : {}),
+      ...(sanitized !== undefined && sanitized.length > 0
+        ? { message: sanitized }
+        : {}),
+    })
+  }
+}
 
 export class AgentBackendTimeoutError extends Schema.TaggedErrorClass<AgentBackendTimeoutError>()(
   "AgentBackendTimeoutError",

--- a/packages/agent-backend/src/lib/sanitize-exit-message.ts
+++ b/packages/agent-backend/src/lib/sanitize-exit-message.ts
@@ -9,7 +9,7 @@ const TOKEN_SHAPED_RE =
   /\b(?:ghp|gho|ghu|ghs|ghr)_[A-Za-z0-9_]{20,}\b|\bgithub_pat_[A-Za-z0-9_]{20,}\b|\bglpat-[A-Za-z0-9_-]{20,}\b|\bsk-ant-[A-Za-z0-9_-]{16,}\b|\bsk-[A-Za-z0-9]{20,}\b|\bBearer\s+[A-Za-z0-9._~+/=-]{8,}/gi
 
 /** Operator-visible exit reasons are persisted and rendered in a browser. */
-export const AGENT_BACKEND_EXIT_MESSAGE_MAX = 500
+const AGENT_BACKEND_EXIT_MESSAGE_MAX = 500
 
 export const sanitizeAgentBackendExitMessage = (text: string): string =>
   text

--- a/packages/agent-backend/src/lib/sanitize-exit-message.ts
+++ b/packages/agent-backend/src/lib/sanitize-exit-message.ts
@@ -1,0 +1,19 @@
+const ESC = String.fromCharCode(0x1b)
+const CSI = String.fromCharCode(0x9b)
+const ANSI_ESCAPE_RE = new RegExp(
+  `[${ESC}${CSI}][[()#;?]*(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[0-9A-ORZcf-nqry=><]`,
+  "g",
+)
+
+const TOKEN_SHAPED_RE =
+  /\b(?:ghp|gho|ghu|ghs|ghr)_[A-Za-z0-9_]{20,}\b|\bgithub_pat_[A-Za-z0-9_]{20,}\b|\bglpat-[A-Za-z0-9_-]{20,}\b|\bsk-ant-[A-Za-z0-9_-]{16,}\b|\bsk-[A-Za-z0-9]{20,}\b|\bBearer\s+[A-Za-z0-9._~+/=-]{8,}/gi
+
+/** Operator-visible exit reasons are persisted and rendered in a browser. */
+export const AGENT_BACKEND_EXIT_MESSAGE_MAX = 500
+
+export const sanitizeAgentBackendExitMessage = (text: string): string =>
+  text
+    .replace(ANSI_ESCAPE_RE, "")
+    .replace(TOKEN_SHAPED_RE, "[redacted]")
+    .trim()
+    .slice(0, AGENT_BACKEND_EXIT_MESSAGE_MAX)

--- a/packages/agent-backend/test/active-agent-backend.spec.ts
+++ b/packages/agent-backend/test/active-agent-backend.spec.ts
@@ -501,7 +501,7 @@ describe("ActiveAgentBackend multi-backend registry", () => {
         adapter: {
           inspect: () =>
             Effect.fail(
-              new AgentBackendExitError({
+              AgentBackendExitError.new({
                 exitCode: 7,
                 cwd: "/tmp",
                 message: "internal crash in login status",

--- a/packages/agent-backend/test/active-agent-backend.spec.ts
+++ b/packages/agent-backend/test/active-agent-backend.spec.ts
@@ -5,6 +5,7 @@ import {
   ActiveAgentBackendLive,
   AgentBackend,
   AgentBackendConfigError,
+  AgentBackendExitError,
   type AgentBackendId,
   type AgentTurnResult,
   type ResolveAgentBackendRuntime,
@@ -488,6 +489,53 @@ describe("ActiveAgentBackend multi-backend registry", () => {
         const statuses = yield* active.listStatuses
         expect(statuses.map((s) => s.backend.id)).toEqual(["opencode"])
         expect(statuses[0]?.models[0]?.id).toBe("opencode/live")
+      }).pipe(Effect.provide(layer)),
+    )
+  })
+
+  it("surfaces an inspect exit failure's own message as the Unavailable reason", async () => {
+    const resolveRuntime: ResolveAgentBackendRuntime = (backendId) => {
+      const reg = registration(backendId)
+      return Effect.succeed({
+        registration: reg,
+        adapter: {
+          inspect: () =>
+            Effect.fail(
+              new AgentBackendExitError({
+                exitCode: 7,
+                cwd: "/tmp",
+                message: "internal crash in login status",
+              }),
+            ),
+          startTurn: () => Effect.succeed(turnResult(`${backendId}-start`)),
+          continueTurn: () =>
+            Effect.succeed(turnResult(`${backendId}-continue`)),
+        },
+        telemetry: {
+          getSession: (sessionId: string) =>
+            Effect.succeed(
+              unsupportedSessionTelemetry(sessionId, reg.descriptor),
+            ),
+        },
+      })
+    }
+
+    const layer = ActiveAgentBackendLive({
+      selectedBackendId: AGENT_BACKEND_IDS.opencode,
+      resolveRuntime,
+    })
+
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        const active = yield* ActiveAgentBackend
+        const status = yield* active.recheck(AGENT_BACKEND_IDS.opencode, {
+          cwd: "/tmp",
+        })
+        expect(status.kind).toBe("unavailable")
+        expect(status.reason).toBe("internal crash in login status")
+        expect(status.reason).not.toBe(
+          "Agent Backend inspection failed (AgentBackendExitError)",
+        )
       }).pipe(Effect.provide(layer)),
     )
   })

--- a/packages/agent-backend/test/cli-runner.spec.ts
+++ b/packages/agent-backend/test/cli-runner.spec.ts
@@ -52,6 +52,7 @@ const parseSimpleLine = (line: string) => {
       errorClassification?:
         | "retryable_provider_error"
         | "length_limit_truncation"
+      errorMessage?: string
     }
     return {
       ...(typeof parsed.sessionID === "string"
@@ -60,6 +61,9 @@ const parseSimpleLine = (line: string) => {
       ...(typeof parsed.text === "string" ? { text: parsed.text } : {}),
       ...(parsed.errorClassification !== undefined
         ? { errorClassification: parsed.errorClassification }
+        : {}),
+      ...(typeof parsed.errorMessage === "string"
+        ? { errorMessage: parsed.errorMessage }
         : {}),
     }
   } catch {
@@ -147,6 +151,34 @@ describe("runCliCapture", () => {
         }),
       )
     })
+  })
+
+  it("populates AgentBackendExitError from captured CLI output", async () => {
+    await withExecutable(
+      ["echo 'permission denied: cannot write cache'", "exit 3"].join("\n"),
+      async (binary) => {
+        const error = await Effect.runPromise(
+          withSpawner((spawner) =>
+            runCliCapture({
+              spawner,
+              backend: TEST_BACKEND,
+              binary,
+              args: [],
+              cwd: process.cwd(),
+              env: sanitizeInheritedEnvironment(),
+              timeout: Duration.seconds(2),
+            }).pipe(Effect.flip),
+          ),
+        )
+        expect(error).toBeInstanceOf(AgentBackendExitError)
+        if (error instanceof AgentBackendExitError) {
+          expect(error.exitCode).toBe(3)
+          expect(error.message).toContain(
+            "permission denied: cannot write cache",
+          )
+        }
+      },
+    )
   })
 
   it("returns stdout when allowNonZeroExit is set", async () => {
@@ -298,6 +330,39 @@ describe("runCliTurn", () => {
             cwd: process.cwd(),
             sessionId: "ses_retry",
             classification: "retryable_provider_error",
+          }),
+        )
+      },
+    )
+  })
+
+  it("carries an observed error message on a non-zero exit", async () => {
+    await withExecutable(
+      [
+        `printf '%s\\n' '{"sessionID":"ses_reason","errorMessage":"model overloaded"}'`,
+        "exit 1",
+      ].join("\n"),
+      async (binary) => {
+        const error = await Effect.runPromise(
+          withSpawner((spawner) =>
+            runCliTurn({
+              spawner,
+              backend: TEST_BACKEND,
+              binary,
+              args: [],
+              cwd: process.cwd(),
+              env: sanitizeInheritedEnvironment(),
+              timeout: Duration.seconds(2),
+              parseLine: parseSimpleLine,
+            }).pipe(Effect.flip),
+          ),
+        )
+        expect(error).toEqual(
+          new AgentBackendExitError({
+            exitCode: 1,
+            cwd: process.cwd(),
+            sessionId: "ses_reason",
+            message: "model overloaded",
           }),
         )
       },

--- a/packages/agent-backend/test/cli-runner.spec.ts
+++ b/packages/agent-backend/test/cli-runner.spec.ts
@@ -145,7 +145,7 @@ describe("runCliCapture", () => {
         ),
       )
       expect(error).toEqual(
-        new AgentBackendExitError({
+        AgentBackendExitError.new({
           exitCode: 9,
           cwd: process.cwd(),
         }),
@@ -325,7 +325,7 @@ describe("runCliTurn", () => {
           ),
         )
         expect(error).toEqual(
-          new AgentBackendExitError({
+          AgentBackendExitError.new({
             exitCode: 1,
             cwd: process.cwd(),
             sessionId: "ses_retry",
@@ -358,7 +358,7 @@ describe("runCliTurn", () => {
           ),
         )
         expect(error).toEqual(
-          new AgentBackendExitError({
+          AgentBackendExitError.new({
             exitCode: 1,
             cwd: process.cwd(),
             sessionId: "ses_reason",
@@ -388,7 +388,7 @@ describe("runCliTurn", () => {
           ),
         )
         expect(error).toEqual(
-          new AgentBackendExitError({
+          AgentBackendExitError.new({
             exitCode: 1,
             cwd: process.cwd(),
             sessionId: "ses_plain",
@@ -728,7 +728,7 @@ describe("runCliTurn", () => {
         ),
       )
       expect(error).toEqual(
-        new AgentBackendExitError({ exitCode: 7, cwd: process.cwd() }),
+        AgentBackendExitError.new({ exitCode: 7, cwd: process.cwd() }),
       )
     })
   })

--- a/packages/agent-backend/test/errors.spec.ts
+++ b/packages/agent-backend/test/errors.spec.ts
@@ -1,0 +1,38 @@
+import { AgentBackendExitError } from "../src/lib/errors.js"
+import { describe, expect, it } from "bun:test"
+
+describe("AgentBackendExitError message", () => {
+  it("accepts a human-readable reason", () => {
+    const error = new AgentBackendExitError({
+      exitCode: 1,
+      cwd: "/tmp",
+      message: "Claude Code turn failed: permission denied",
+    })
+    expect(error.message).toBe("Claude Code turn failed: permission denied")
+  })
+
+  it("strips ANSI escapes and bounds length", () => {
+    const esc = String.fromCharCode(0x1b)
+    const longTail = "x".repeat(600)
+    const error = new AgentBackendExitError({
+      exitCode: 1,
+      cwd: "/tmp",
+      message: `${esc}[31mboom happened${esc}[0m ${longTail}`,
+    })
+    expect(error.message.includes(`${esc}[`)).toBe(false)
+    expect(error.message.startsWith("boom happened")).toBe(true)
+    expect(error.message.length).toBeLessThanOrEqual(500)
+  })
+
+  it("redacts token-shaped secrets so they cannot reach the message", () => {
+    const secret = "ghp_this_must_never_appear_in_exit_message"
+    const error = new AgentBackendExitError({
+      exitCode: 1,
+      cwd: "/tmp",
+      message: `auth failed with ${secret}`,
+    })
+    expect(error.message).not.toContain(secret)
+    expect(error.message).not.toMatch(/ghp_[A-Za-z0-9]+/)
+    expect(error.message).toContain("[redacted]")
+  })
+})

--- a/packages/agent-backend/test/errors.spec.ts
+++ b/packages/agent-backend/test/errors.spec.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from "bun:test"
 
 describe("AgentBackendExitError message", () => {
   it("accepts a human-readable reason", () => {
-    const error = new AgentBackendExitError({
+    const error = AgentBackendExitError.new({
       exitCode: 1,
       cwd: "/tmp",
       message: "Claude Code turn failed: permission denied",
@@ -14,7 +14,7 @@ describe("AgentBackendExitError message", () => {
   it("strips ANSI escapes and bounds length", () => {
     const esc = String.fromCharCode(0x1b)
     const longTail = "x".repeat(600)
-    const error = new AgentBackendExitError({
+    const error = AgentBackendExitError.new({
       exitCode: 1,
       cwd: "/tmp",
       message: `${esc}[31mboom happened${esc}[0m ${longTail}`,
@@ -26,7 +26,7 @@ describe("AgentBackendExitError message", () => {
 
   it("redacts token-shaped secrets so they cannot reach the message", () => {
     const secret = "ghp_this_must_never_appear_in_exit_message"
-    const error = new AgentBackendExitError({
+    const error = AgentBackendExitError.new({
       exitCode: 1,
       cwd: "/tmp",
       message: `auth failed with ${secret}`,

--- a/packages/claude/src/lib/claude.ts
+++ b/packages/claude/src/lib/claude.ts
@@ -248,6 +248,8 @@ export class Claude {
                 if (stream.resultSeen && stream.isError) {
                   return {
                     sessionId: stream.sessionId ?? input.sessionId,
+                    errorMessage:
+                      stream.errorMessage ?? "Claude Code turn failed",
                   }
                 }
                 if (stream.resultSeen && isSuccessfulClaudeTurn(stream)) {
@@ -280,6 +282,7 @@ export class Claude {
                 exitCode: 1,
                 cwd: input.cwd,
                 sessionId: input.sessionId,
+                message: stream.errorMessage ?? "Claude Code turn failed",
               })
             }
             if (!stream.resultSeen || !isSuccessfulClaudeTurn(stream)) {

--- a/packages/claude/src/lib/claude.ts
+++ b/packages/claude/src/lib/claude.ts
@@ -278,7 +278,7 @@ export class Claude {
                 sessionId: input.sessionId,
                 message: stream.errorMessage ?? "Claude Code turn failed",
               })
-              return yield* new AgentBackendExitError({
+              return yield* AgentBackendExitError.new({
                 exitCode: 1,
                 cwd: input.cwd,
                 sessionId: input.sessionId,

--- a/packages/claude/test/claude.spec.ts
+++ b/packages/claude/test/claude.spec.ts
@@ -838,6 +838,7 @@ describe("Claude AgentBackend adapter (Agent Turns)", () => {
       [
         captureSessionScript,
         `printf '%s\\n' "{\\"type\\":\\"result\\",\\"subtype\\":\\"error\\",\\"session_id\\":\\"$sid\\",\\"is_error\\":true,\\"error\\":\\"boom\\"}"`,
+        "exit 1",
       ].join("\n"),
       async (binary) => {
         const error = await Effect.runPromise(
@@ -846,6 +847,7 @@ describe("Claude AgentBackend adapter (Agent Turns)", () => {
         expect(error).toBeInstanceOf(AgentBackendExitError)
         if (error instanceof AgentBackendExitError) {
           expect(error.exitCode).toBe(1)
+          expect(error.message).toBe("boom")
           expect(error.sessionId).toMatch(
             /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i,
           )

--- a/packages/codex/src/lib/codex.ts
+++ b/packages/codex/src/lib/codex.ts
@@ -99,11 +99,10 @@ export class Codex {
             })
           }
           if (status.kind === "failed") {
-            // Non-zero without auth markers: not unauthenticated. Surface
-            // exit code + probe text so Recheck/Unavailable copy stays useful
-            // (ExitError has no message for formatInspectFailure).
-            return yield* new AgentBackendConfigError({
-              message: `Codex Build readiness probe failed (codex login status exit ${status.exitCode}): ${clipProbeOutput(statusOutput)}`,
+            return yield* new AgentBackendExitError({
+              exitCode: status.exitCode,
+              cwd: input.cwd,
+              message: `Codex Build readiness probe failed (exit ${status.exitCode}): ${clipProbeOutput(statusOutput)}`,
             })
           }
           if (status.kind === "malformed") {
@@ -183,6 +182,8 @@ export class Codex {
                     ...(stream.threadId !== undefined
                       ? { sessionId: stream.threadId }
                       : {}),
+                    errorMessage:
+                      stream.turnFailedMessage ?? "Codex turn.failed",
                   }
                 }
                 if (stream.turnCompleted && isSuccessfulCodexTurn(stream)) {
@@ -214,9 +215,6 @@ export class Codex {
               )
             }
             if (stream.turnFailed) {
-              // ExitError has no message field (shared contract); keep the
-              // stream-extracted reason in logs so harness diagnostics are not
-              // a bare exit 1.
               yield* Effect.logWarning("Codex Build turn.failed", {
                 sessionId: stream.threadId ?? input.sessionId,
                 message: stream.turnFailedMessage ?? "Codex turn.failed",
@@ -224,6 +222,7 @@ export class Codex {
               return yield* new AgentBackendExitError({
                 exitCode: 1,
                 cwd: input.cwd,
+                message: stream.turnFailedMessage ?? "Codex turn.failed",
                 ...(stream.threadId !== undefined
                   ? { sessionId: stream.threadId }
                   : input.sessionId !== undefined

--- a/packages/codex/src/lib/codex.ts
+++ b/packages/codex/src/lib/codex.ts
@@ -99,7 +99,7 @@ export class Codex {
             })
           }
           if (status.kind === "failed") {
-            return yield* new AgentBackendExitError({
+            return yield* AgentBackendExitError.new({
               exitCode: status.exitCode,
               cwd: input.cwd,
               message: `Codex Build readiness probe failed (exit ${status.exitCode}): ${clipProbeOutput(statusOutput)}`,
@@ -219,7 +219,7 @@ export class Codex {
                 sessionId: stream.threadId ?? input.sessionId,
                 message: stream.turnFailedMessage ?? "Codex turn.failed",
               })
-              return yield* new AgentBackendExitError({
+              return yield* AgentBackendExitError.new({
                 exitCode: 1,
                 cwd: input.cwd,
                 message: stream.turnFailedMessage ?? "Codex turn.failed",

--- a/packages/codex/test/codex.spec.ts
+++ b/packages/codex/test/codex.spec.ts
@@ -132,7 +132,7 @@ describe("Codex AgentBackend adapter (readiness inspection)", () => {
     )
   })
 
-  it("maps non-zero login status without auth markers to config error with probe text", async () => {
+  it("maps non-zero login status without auth markers to exit failure with probe text", async () => {
     await withExecutable(
       [
         'case " $* " in *" login status "*) ;; *) exit 20 ;; esac',
@@ -141,11 +141,10 @@ describe("Codex AgentBackend adapter (readiness inspection)", () => {
       ].join("\n"),
       async (binary) => {
         const error = await Effect.runPromise(inspect(binary).pipe(Effect.flip))
-        expect(error).toBeInstanceOf(AgentBackendConfigError)
-        if (error instanceof AgentBackendConfigError) {
-          expect(error.message).toContain("exit 7")
+        expect(error).toBeInstanceOf(AgentBackendExitError)
+        if (error instanceof AgentBackendExitError) {
+          expect(error.exitCode).toBe(7)
           expect(error.message).toContain("internal crash")
-          expect(error.message).not.toBe(CODEX_UNAUTHENTICATED_MESSAGE)
         }
       },
     )
@@ -397,6 +396,7 @@ describe("Codex AgentBackend adapter (Agent Turns)", () => {
       [
         `printf '%s\\n' '{"type":"thread.started","thread_id":"fail-thread"}'`,
         `printf '%s\\n' '{"type":"turn.failed","error":{"message":"boom"}}'`,
+        "exit 1",
       ].join("\n"),
       async (binary) => {
         const error = await Effect.runPromise(
@@ -405,6 +405,7 @@ describe("Codex AgentBackend adapter (Agent Turns)", () => {
         expect(error).toBeInstanceOf(AgentBackendExitError)
         if (error instanceof AgentBackendExitError) {
           expect(error.exitCode).toBe(1)
+          expect(error.message).toBe("boom")
           expect(error.sessionId).toBe("fail-thread")
         }
       },

--- a/packages/github-service/src/lib/error-cause-chain.ts
+++ b/packages/github-service/src/lib/error-cause-chain.ts
@@ -59,7 +59,9 @@ const linkFromValue = (value: unknown): CauseChainLink | null => {
   // Effect TimeoutError has no numeric/string code field; treat the tag as the
   // machine-readable discriminator so logs and Step Runs can group timeouts.
   const code =
-    readCode(record.code) ?? (name === "TimeoutError" ? "TIMEOUT" : undefined)
+    readCode(record.code) ??
+    readCode(record.exitCode) ??
+    (name === "TimeoutError" ? "TIMEOUT" : undefined)
   const rawMessage = readString(record.message)
   const message =
     rawMessage === undefined

--- a/packages/github-service/src/lib/user-facing-error.ts
+++ b/packages/github-service/src/lib/user-facing-error.ts
@@ -26,6 +26,9 @@ const extractMessageFromInspectDump = (text: string): string | undefined => {
   return undefined
 }
 
+const TOKEN_SHAPED_RE =
+  /\b(?:ghp|gho|ghu|ghs|ghr)_[A-Za-z0-9_]{20,}\b|\bgithub_pat_[A-Za-z0-9_]{20,}\b|\bglpat-[A-Za-z0-9_-]{20,}\b|\bsk-ant-[A-Za-z0-9_-]{16,}\b|\bsk-[A-Za-z0-9]{20,}\b|\bBearer\s+[A-Za-z0-9._~+/=-]{8,}/gi
+
 export const sanitizeUserFacingText = (
   text: string,
   maxLength?: number,
@@ -35,6 +38,7 @@ export const sanitizeUserFacingText = (
   if (extracted !== undefined) {
     cleaned = extracted.trim()
   }
+  cleaned = cleaned.replace(TOKEN_SHAPED_RE, "[redacted]")
   if (maxLength !== undefined) {
     cleaned = cleaned.slice(0, maxLength)
   }

--- a/packages/github-service/test/github-service.spec.ts
+++ b/packages/github-service/test/github-service.spec.ts
@@ -4233,6 +4233,16 @@ describe("user-facing error formatting", () => {
     expect(formatUserFacingError(colored, "fallback")).toBe("boom happened")
   })
 
+  it("redacts token-shaped secrets from user-facing text", () => {
+    const secret = "ghp_this_must_never_appear_in_user_facing_text"
+    expect(sanitizeUserFacingText(`auth failed with ${secret}`)).not.toContain(
+      secret,
+    )
+    expect(sanitizeUserFacingText(`auth failed with ${secret}`)).toContain(
+      "[redacted]",
+    )
+  })
+
   it("prefers Error.message over inspect dumps", () => {
     const error = new GitHubRequestError({
       message: "Failed to get pull request check status for acme/widgets",
@@ -4304,6 +4314,22 @@ describe("error cause chain", () => {
     expect(extractErrorCode(timeout)).toBe("TIMEOUT")
     expect(extractCauseChain(timeout)).toEqual([
       { name: "TimeoutError", code: "TIMEOUT" },
+    ])
+  })
+
+  it("derives a cause-chain code from exitCode when code is absent", () => {
+    const exitFailure = Object.assign(new Error("model overloaded"), {
+      name: "AgentBackendExitError",
+      _tag: "AgentBackendExitError",
+      exitCode: 1,
+    })
+    expect(extractErrorCode(exitFailure)).toBe("1")
+    expect(extractCauseChain(exitFailure)).toEqual([
+      {
+        name: "AgentBackendExitError",
+        code: "1",
+        message: "model overloaded",
+      },
     ])
   })
 

--- a/packages/grok/src/lib/grok.ts
+++ b/packages/grok/src/lib/grok.ts
@@ -193,7 +193,7 @@ export class Grok {
                 )
               }
               if (stream.errorMessage !== undefined) {
-                return yield* new AgentBackendExitError({
+                return yield* AgentBackendExitError.new({
                   exitCode: 1,
                   cwd: input.cwd,
                   sessionId: input.sessionId,
@@ -201,7 +201,7 @@ export class Grok {
                 })
               }
               if (stream.maxTurnsReached) {
-                return yield* new AgentBackendExitError({
+                return yield* AgentBackendExitError.new({
                   exitCode: 1,
                   cwd: input.cwd,
                   sessionId: input.sessionId,

--- a/packages/grok/src/lib/grok.ts
+++ b/packages/grok/src/lib/grok.ts
@@ -166,10 +166,13 @@ export class Grok {
                   stream = foldGrokStreamLine(stream, line)
 
                   if (stream.errorMessage !== undefined) {
-                    return {}
+                    return { errorMessage: stream.errorMessage }
                   }
                   if (stream.maxTurnsReached) {
-                    return {}
+                    return {
+                      errorMessage:
+                        "Grok Build reached the maximum number of turns",
+                    }
                   }
                   if (stream.endSeen && isSuccessfulGrokEnd(stream)) {
                     const endSessionId = stream.endSessionId ?? input.sessionId
@@ -194,6 +197,7 @@ export class Grok {
                   exitCode: 1,
                   cwd: input.cwd,
                   sessionId: input.sessionId,
+                  message: stream.errorMessage,
                 })
               }
               if (stream.maxTurnsReached) {
@@ -201,6 +205,7 @@ export class Grok {
                   exitCode: 1,
                   cwd: input.cwd,
                   sessionId: input.sessionId,
+                  message: "Grok Build reached the maximum number of turns",
                 })
               }
               if (!stream.endSeen || !isSuccessfulGrokEnd(stream)) {

--- a/packages/grok/test/grok.spec.ts
+++ b/packages/grok/test/grok.spec.ts
@@ -343,18 +343,44 @@ describe("Grok AgentBackend adapter", () => {
     )
   })
 
-  it("maps max-turn exhaustion to exit failure", async () => {
+  it("maps stream error events to exit failure with the reported reason", async () => {
     await withExecutable(
       [
         captureSessionScript,
-        `printf '%s\\n' '{"type":"max_turns_reached"}'`,
-        `printf '%s\\n' "{\\"type\\":\\"end\\",\\"stopReason\\":\\"MaxTurns\\",\\"sessionId\\":\\"$sid\\"}"`,
+        `printf '%s\\n' '{"type":"error","message":"auth failed"}'`,
+        `printf '%s\\n' "{\\"type\\":\\"end\\",\\"stopReason\\":\\"EndTurn\\",\\"sessionId\\":\\"$sid\\"}"`,
+        "exit 1",
       ].join("\n"),
       async (binary) => {
         const error = await Effect.runPromise(
           startTurn(binary, "2 seconds").pipe(Effect.flip),
         )
         expect(error).toBeInstanceOf(AgentBackendExitError)
+        if (error instanceof AgentBackendExitError) {
+          expect(error.exitCode).toBe(1)
+          expect(error.message).toBe("auth failed")
+        }
+      },
+    )
+  })
+
+  it("maps max-turn exhaustion to exit failure", async () => {
+    await withExecutable(
+      [
+        captureSessionScript,
+        `printf '%s\\n' '{"type":"max_turns_reached"}'`,
+        `printf '%s\\n' "{\\"type\\":\\"end\\",\\"stopReason\\":\\"MaxTurns\\",\\"sessionId\\":\\"$sid\\"}"`,
+        "exit 1",
+      ].join("\n"),
+      async (binary) => {
+        const error = await Effect.runPromise(
+          startTurn(binary, "2 seconds").pipe(Effect.flip),
+        )
+        expect(error).toBeInstanceOf(AgentBackendExitError)
+        if (error instanceof AgentBackendExitError) {
+          expect(error.exitCode).toBe(1)
+          expect(error.message).toContain("maximum number of turns")
+        }
       },
     )
   })

--- a/packages/opencode/test/opencode.spec.ts
+++ b/packages/opencode/test/opencode.spec.ts
@@ -188,7 +188,7 @@ describe("Opencode AgentBackend adapter", () => {
           startTurn(binary, "2 seconds").pipe(Effect.flip),
         )
         expect(error).toEqual(
-          new AgentBackendExitError({
+          AgentBackendExitError.new({
             exitCode: 7,
             cwd: process.cwd(),
             sessionId: "ses_failed",
@@ -210,7 +210,7 @@ describe("Opencode AgentBackend adapter", () => {
           startTurn(binary, "2 seconds").pipe(Effect.flip),
         )
         expect(error).toEqual(
-          new AgentBackendExitError({
+          AgentBackendExitError.new({
             exitCode: 1,
             cwd: process.cwd(),
             sessionId: "ses_retry",
@@ -233,7 +233,7 @@ describe("Opencode AgentBackend adapter", () => {
           startTurn(binary, "2 seconds").pipe(Effect.flip),
         )
         expect(error).toEqual(
-          new AgentBackendExitError({
+          AgentBackendExitError.new({
             exitCode: 1,
             cwd: process.cwd(),
             sessionId: "ses_length",
@@ -256,7 +256,7 @@ describe("Opencode AgentBackend adapter", () => {
           startTurn(binary, "2 seconds").pipe(Effect.flip),
         )
         expect(error).toEqual(
-          new AgentBackendExitError({
+          AgentBackendExitError.new({
             exitCode: 1,
             cwd: process.cwd(),
             sessionId: "ses_auth",
@@ -279,7 +279,7 @@ describe("Opencode AgentBackend adapter", () => {
           startTurn(binary, "2 seconds").pipe(Effect.flip),
         )
         expect(error).toEqual(
-          new AgentBackendExitError({
+          AgentBackendExitError.new({
             exitCode: 1,
             cwd: process.cwd(),
             sessionId: "ses_unknown",

--- a/packages/work-item-lifecycle/test/commit.spec.ts
+++ b/packages/work-item-lifecycle/test/commit.spec.ts
@@ -705,7 +705,7 @@ exit 1
               Effect.succeed({ sessionId: "unused", assistantText: "" }),
             continueTurn: () =>
               Effect.fail(
-                new AgentBackendExitError({ exitCode: 2, cwd: root }),
+                AgentBackendExitError.new({ exitCode: 2, cwd: root }),
               ),
             inspect: () =>
               Effect.succeed({

--- a/packages/work-item-lifecycle/test/implement.spec.ts
+++ b/packages/work-item-lifecycle/test/implement.spec.ts
@@ -546,7 +546,7 @@ describe("implement", () => {
           AgentBackend.of({
             startTurn: () =>
               Effect.fail(
-                new AgentBackendExitError({ exitCode: 2, cwd: root }),
+                AgentBackendExitError.new({ exitCode: 2, cwd: root }),
               ),
             continueTurn: () =>
               Effect.succeed({ sessionId: "unused", assistantText: "" }),
@@ -705,7 +705,7 @@ describe("implement", () => {
             Effect.gen(function* () {
               yield* input.onSessionId!("ses_failed_after_emit")
               return yield* Effect.fail(
-                new AgentBackendExitError({ exitCode: 2, cwd: root }),
+                AgentBackendExitError.new({ exitCode: 2, cwd: root }),
               )
             }),
         }),

--- a/packages/work-item-lifecycle/test/install-dependencies.spec.ts
+++ b/packages/work-item-lifecycle/test/install-dependencies.spec.ts
@@ -4,6 +4,7 @@ import { join } from "node:path"
 import { BunServices } from "@effect/platform-bun"
 import { Effect, Layer } from "effect"
 import { AgentBackend } from "@ready-for-agent/agent-backend"
+import { extractCauseChain } from "@ready-for-agent/github-service"
 import type { LifecycleStepContext } from "../src/index.js"
 import {
   InstallDependenciesFallbackError,
@@ -441,7 +442,11 @@ describe("installDependencies fallback failure", () => {
               AgentBackend.of({
                 startTurn: () =>
                   Effect.fail(
-                    new AgentBackendExitError({ exitCode: 2, cwd: root }),
+                    new AgentBackendExitError({
+                      exitCode: 2,
+                      cwd: root,
+                      message: "npm install failed: EACCES",
+                    }),
                   ),
                 continueTurn: () =>
                   Effect.succeed({ sessionId: "unused", assistantText: "" }),
@@ -457,6 +462,17 @@ describe("installDependencies fallback failure", () => {
         ),
       )
       expect(error).toBeInstanceOf(InstallDependenciesFallbackError)
+      expect(extractCauseChain(error)).toEqual([
+        {
+          name: "InstallDependenciesFallbackError",
+          message: "OpenCode fallback failed to install dependencies",
+        },
+        {
+          name: "AgentBackendExitError",
+          code: "2",
+          message: "npm install failed: EACCES",
+        },
+      ])
     } finally {
       await rm(root, { recursive: true, force: true })
     }

--- a/packages/work-item-lifecycle/test/install-dependencies.spec.ts
+++ b/packages/work-item-lifecycle/test/install-dependencies.spec.ts
@@ -442,7 +442,7 @@ describe("installDependencies fallback failure", () => {
               AgentBackend.of({
                 startTurn: () =>
                   Effect.fail(
-                    new AgentBackendExitError({
+                    AgentBackendExitError.new({
                       exitCode: 2,
                       cwd: root,
                       message: "npm install failed: EACCES",

--- a/packages/work-item-lifecycle/test/pr-status-checks.spec.ts
+++ b/packages/work-item-lifecycle/test/pr-status-checks.spec.ts
@@ -1416,7 +1416,7 @@ describe("PR status check steps", () => {
                 startTurn: () => Effect.die("unused"),
                 continueTurn: () =>
                   Effect.fail(
-                    new AgentBackendExitError({
+                    AgentBackendExitError.new({
                       exitCode: 1,
                       cwd: "/tmp/worktree",
                     }),

--- a/packages/work-item-lifecycle/test/pre-commit.spec.ts
+++ b/packages/work-item-lifecycle/test/pre-commit.spec.ts
@@ -385,7 +385,7 @@ describe("preCommit", () => {
         stubOpencode({
           continueTurn: () =>
             Effect.fail(
-              new AgentBackendExitError({
+              AgentBackendExitError.new({
                 exitCode: 2,
                 cwd: root,
                 sessionId: "ses_pre_commit",

--- a/packages/work-item-lifecycle/test/review.spec.ts
+++ b/packages/work-item-lifecycle/test/review.spec.ts
@@ -1356,7 +1356,7 @@ describe("review", () => {
               })
             }
             return Effect.fail(
-              new AgentBackendExitError({ exitCode: 2, cwd: root }),
+              AgentBackendExitError.new({ exitCode: 2, cwd: root }),
             )
           },
         }),
@@ -2004,7 +2004,7 @@ describe("review", () => {
               Effect.succeed({ sessionId: "unused", assistantText: "" }),
             continueTurn: () =>
               Effect.fail(
-                new AgentBackendExitError({ exitCode: 2, cwd: root }),
+                AgentBackendExitError.new({ exitCode: 2, cwd: root }),
               ),
             inspect: () =>
               Effect.succeed({

--- a/scripts/fix-bun-typescript-for-nx.mjs
+++ b/scripts/fix-bun-typescript-for-nx.mjs
@@ -5,43 +5,66 @@
  * `readConfigFile` and fail project-graph construction.
  *
  * Classic TS is already linked at the workspace root as `typescript`
- * (`@typescript/typescript6`). Removing the nested shadow makes Node continue
- * to that root install. `@typescript/native` keeps its own scoped path.
+ * (`@typescript/typescript6`) and also as `typescript@6.0.2` in the bun
+ * store. Replacing the nested shadow with that classic package keeps the
+ * path Nx already resolved, instead of deleting it and leaving a dangling
+ * `typescript/lib/version.cjs` require. `@typescript/native` keeps its own
+ * scoped path.
  */
-import { existsSync, lstatSync, readFileSync, rmSync } from "node:fs"
+import {
+  existsSync,
+  lstatSync,
+  readdirSync,
+  rmSync,
+  symlinkSync,
+} from "node:fs"
 import { createRequire } from "node:module"
-import { dirname, join } from "node:path"
+import { dirname, join, relative } from "node:path"
 import { fileURLToPath } from "node:url"
 
 const root = join(dirname(fileURLToPath(import.meta.url)), "..")
-const nestedTypescript = join(
-  root,
-  "node_modules",
-  ".bun",
-  "node_modules",
-  "typescript",
-)
+const bunStore = join(root, "node_modules", ".bun")
+const nestedTypescript = join(bunStore, "node_modules", "typescript")
 
-if (!existsSync(nestedTypescript)) process.exit(0)
-
-const packageJsonPath = join(nestedTypescript, "package.json")
-if (!existsSync(packageJsonPath)) process.exit(0)
-
-const { version, name } = JSON.parse(readFileSync(packageJsonPath, "utf8"))
-const requireFromNested = createRequire(join(nestedTypescript, "package.json"))
-
-let hasReadConfigFile = false
-try {
-  const ts = requireFromNested(".")
-  hasReadConfigFile = typeof ts.readConfigFile === "function"
-} catch {
-  hasReadConfigFile = false
+const isUsableClassicTypescript = (packageRoot) => {
+  if (!existsSync(join(packageRoot, "package.json"))) return false
+  try {
+    const ts = createRequire(join(packageRoot, "package.json"))(".")
+    return typeof ts.readConfigFile === "function"
+  } catch {
+    return false
+  }
 }
 
-if (name === "typescript" && !hasReadConfigFile) {
+const findClassicTypescript = () => {
+  if (!existsSync(bunStore)) return undefined
+  for (const entry of readdirSync(bunStore)) {
+    if (!entry.startsWith("typescript@")) continue
+    const candidate = join(bunStore, entry, "node_modules", "typescript")
+    if (isUsableClassicTypescript(candidate)) return candidate
+  }
+  return undefined
+}
+
+if (isUsableClassicTypescript(nestedTypescript)) process.exit(0)
+
+if (existsSync(nestedTypescript)) {
   const stat = lstatSync(nestedTypescript)
   rmSync(nestedTypescript, { recursive: !stat.isSymbolicLink(), force: true })
-  console.log(
-    `fix-bun-typescript-for-nx: removed nested typescript@${version} shadow so Nx can use classic TypeScript`,
-  )
 }
+
+const classicTypescript = findClassicTypescript()
+if (classicTypescript === undefined) {
+  console.error(
+    "fix-bun-typescript-for-nx: classic typescript is missing; run bun install",
+  )
+  process.exit(1)
+}
+
+symlinkSync(
+  relative(dirname(nestedTypescript), classicTypescript),
+  nestedTypescript,
+)
+console.log(
+  "fix-bun-typescript-for-nx: pointed nested typescript at classic TypeScript so Nx keeps readConfigFile",
+)


### PR DESCRIPTION
Operators were seeing a bare `AgentBackendExitError` with no text and no
exit code, even when Claude, Codex, or Grok had already parsed a
human-readable failure. Inspect copy degraded to "Agent Backend
inspection failed (AgentBackendExitError)". This is the diagnostics
half of #1056; stderr capture for turns remains #1057.

`AgentBackendExitError` now accepts an optional `message` (transitional
until #1066). It is sanitized on construction (ANSI stripped,
token-shaped secrets redacted, length bounded). Claude `is_error`,
Codex `turn.failed`, and Grok stream `error` / max-turns populate it.
`runCliCapture` uses captured stdout/stderr. Cause-chain links derive
`code` from `exitCode` so the disclosure can render
`AgentBackendExitError 1 — <reason>`. Codex inspect failures raise the
exit error with probe text instead of wrapping a ConfigError
workaround; `formatInspectFailure` already prefers `error.message`.

Review follow-up: a parsed stream reason now rides on `runCliTurn` the
same way `errorClassification` does, so a CLI that emits JSONL then
exits non-zero no longer drops the reason. Tests cover that path with
`exit 1` after the error event.

Verified with `agent-backend`, Claude, Codex, Grok, `github-service`
cause-chain, and install-dependencies fallback specs. Deferred:
duplicate sanitizer regexes stay package-local (layering); the nested
TypeScript-7 Nx symlink script is a local hook-layout fix, not product
behaviour.

Closes #1056