### PR TITLE
feat(cli): continue jump sessions in the invoking terminal outside tmux

### DIFF
--- a/apps/ready-for-agent/src/cli-process.test.ts
+++ b/apps/ready-for-agent/src/cli-process.test.ts
@@ -999,6 +999,183 @@ const parseTmuxArgvLog = (logPath: string): readonly (readonly string[])[] => {
   return text.split("\n").map((line) => JSON.parse(line) as string[])
 }
 
+const ptyRunnerSource = `import os
+import pty
+import sys
+
+stderr_path = os.environ.pop("RFA_PTY_STDERR", "")
+sigint_after = os.environ.pop("RFA_PTY_SEND_SIGINT_AFTER", "")
+cmd = sys.argv[1:]
+if len(cmd) == 0:
+    sys.exit(2)
+
+def copy_master(master: int) -> None:
+    sent = False
+    buf = b""
+    while True:
+        try:
+            data = os.read(master, 4096)
+        except OSError:
+            break
+        if not data:
+            break
+        os.write(1, data)
+        if sigint_after and not sent:
+            buf += data
+            if sigint_after.encode() in buf:
+                os.write(master, b"\\x03")
+                sent = True
+
+if stderr_path:
+    master, slave = pty.openpty()
+    pid = os.fork()
+    if pid == 0:
+        os.close(master)
+        os.dup2(slave, 0)
+        os.dup2(slave, 1)
+        err = os.open(stderr_path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o644)
+        os.dup2(err, 2)
+        os.close(err)
+        os.close(slave)
+        os.execvpe(cmd[0], cmd, os.environ)
+        os._exit(127)
+    os.close(slave)
+    copy_master(master)
+    _, status = os.waitpid(pid, 0)
+    os.close(master)
+    sys.exit(os.waitstatus_to_exitcode(status))
+
+pid, fd = pty.fork()
+if pid == 0:
+    os.execvpe(cmd[0], cmd, os.environ)
+    os._exit(127)
+copy_master(fd)
+_, status = os.waitpid(pid, 0)
+sys.exit(os.waitstatus_to_exitcode(status))
+`
+
+const recordingBackendScript = `#!/usr/bin/env bun
+import { writeFileSync } from "node:fs"
+
+const recordPath = process.env.BACKEND_RECORD
+if (recordPath !== undefined && recordPath.length > 0) {
+  writeFileSync(
+    recordPath,
+    JSON.stringify({
+      argv: process.argv.slice(2),
+      argv1: process.argv[1],
+      cwd: process.cwd(),
+      envMarker: process.env.RFA_DIRECT_MARKER ?? null,
+      stdinIsTTY: Boolean(process.stdin.isTTY),
+      stdoutIsTTY: Boolean(process.stdout.isTTY),
+      stderrIsTTY: Boolean(process.stderr.isTTY),
+    }),
+  )
+}
+
+if (process.env.BACKEND_IGNORE_SIGINT === "1") {
+  process.on("SIGINT", () => {})
+}
+
+process.stdout.write("backend-ready\\n")
+
+if (process.env.BACKEND_STDERR_TEXT !== undefined) {
+  process.stderr.write(process.env.BACKEND_STDERR_TEXT)
+}
+
+const signal = process.env.BACKEND_SIGNAL
+if (process.env.BACKEND_IGNORE_SIGINT === "1") {
+  setTimeout(() => process.exit(0), 400)
+} else if (signal !== undefined && signal.length > 0) {
+  process.kill(process.pid, signal)
+} else {
+  process.exit(Number(process.env.BACKEND_EXIT ?? "0"))
+}
+`
+
+type BackendRecord = {
+  readonly argv: readonly string[]
+  readonly argv1: string
+  readonly cwd: string
+  readonly envMarker: string | null
+  readonly stdinIsTTY: boolean
+  readonly stdoutIsTTY: boolean
+  readonly stderrIsTTY: boolean
+}
+
+const readBackendRecord = (path: string): BackendRecord =>
+  JSON.parse(readFileSync(path, "utf8")) as BackendRecord
+
+const runCliOnPty = (
+  args: readonly string[],
+  graphqlUrl: string,
+  extraEnv: NodeJS.ProcessEnv = {},
+  options: {
+    readonly stderrPath?: string
+    readonly sendSigintAfter?: string
+  } = {},
+): Promise<ProcessResult> =>
+  new Promise((resolve, reject) => {
+    const env: NodeJS.ProcessEnv = {
+      ...process.env,
+      READY_FOR_AGENT_GRAPHQL_URL: graphqlUrl,
+      NO_COLOR: "1",
+      FORCE_COLOR: "0",
+      ...extraEnv,
+    }
+    if (!("TMUX" in extraEnv)) {
+      delete env.TMUX
+    }
+    const bunArgs = [
+      process.execPath,
+      "--conditions",
+      "@ready-for-agent/source",
+      "src/main.ts",
+      ...args,
+    ]
+    if (options.stderrPath !== undefined) {
+      env.RFA_PTY_STDERR = options.stderrPath
+    } else {
+      delete env.RFA_PTY_STDERR
+    }
+    if (options.sendSigintAfter !== undefined) {
+      env.RFA_PTY_SEND_SIGINT_AFTER = options.sendSigintAfter
+    } else {
+      delete env.RFA_PTY_SEND_SIGINT_AFTER
+    }
+    const python = Bun.which("python3") ?? "python3"
+    const child = spawn(python, ["-c", ptyRunnerSource, ...bunArgs], {
+      cwd: packageRoot,
+      env,
+    })
+    let stdout = ""
+    let stderr = ""
+    child.stdout.setEncoding("utf8")
+    child.stderr.setEncoding("utf8")
+    child.stdout.on("data", (chunk: string) => {
+      stdout += chunk
+    })
+    child.stderr.on("data", (chunk: string) => {
+      stderr += chunk
+    })
+    const timer = setTimeout(() => {
+      child.kill("SIGKILL")
+      reject(
+        new Error(
+          `pty ${args.join(" ")} timed out\nstdout:\n${stdout}\nstderr:\n${stderr}`,
+        ),
+      )
+    }, 20_000)
+    child.on("error", (error) => {
+      clearTimeout(timer)
+      reject(error)
+    })
+    child.on("close", (status) => {
+      clearTimeout(timer)
+      resolve({ status, stdout, stderr })
+    })
+  })
+
 const startJumpGraphqlServer = (options: {
   readonly backendId?: string
   readonly worktreePath?: string | null
@@ -1110,7 +1287,7 @@ if (args[0] === "split-window" && args.includes("-P")) {
 `,
     )
     for (const name of ["opencode", "grok", "codex", "claude"] as const) {
-      writeExecutable(join(binDir, name), "#!/usr/bin/env bash\nexit 0\n")
+      writeExecutable(join(binDir, name), recordingBackendScript)
     }
   })
 
@@ -1184,7 +1361,7 @@ if (args[0] === "split-window" && args.includes("-P")) {
     expect(separator).toBeGreaterThan(firstEnv)
   }
 
-  test("jump outside tmux writes a text error and does not invoke tmux", async () => {
+  test("jump without a TTY rejects before contacting the Harness or tmux", async () => {
     const result = await runCli(
       ["jump", jumpSessionId],
       "http://127.0.0.1:1/graphql",
@@ -1192,11 +1369,21 @@ if (args[0] === "split-window" && args.includes("-P")) {
 
     expect(result.status).toBe(1)
     expect(result.stdout.trim()).toBe("")
-    expect(result.stderr.trim()).toBe(
-      "jump must be run from inside a tmux session",
-    )
+    expect(result.stderr.trim()).toBe("jump requires an interactive terminal")
     expect(result.stderr).not.toContain("schemaVersion")
     expect(result.stderr).not.toMatch(/\s+at\s+\S+\s+\(/)
+    expect(parseTmuxArgvLog(tmuxLog)).toEqual([])
+  })
+
+  test("jump with an empty TMUX still selects direct mode", async () => {
+    const result = await runCli(
+      ["jump", jumpSessionId],
+      "http://127.0.0.1:1/graphql",
+      { TMUX: "" },
+    )
+
+    expect(result.status).toBe(1)
+    expect(result.stderr.trim()).toBe("jump requires an interactive terminal")
     expect(parseTmuxArgvLog(tmuxLog)).toEqual([])
   })
 
@@ -1696,6 +1883,301 @@ if (args[0] === "split-window" && args.includes("-P")) {
       const invocations = parseTmuxArgvLog(tmuxLog)
       expect(invocations.some((args) => args.includes("new-window"))).toBe(true)
       expect(invocations.at(-1)).toEqual(["kill-window", "-t", "@1"])
+    } finally {
+      await graphql.close()
+    }
+  })
+})
+
+describe("operator binary jump direct process contract", () => {
+  let tempRoot = ""
+  let binDir = ""
+  let tmuxLog = ""
+  let backendRecord = ""
+
+  beforeEach(() => {
+    tempRoot = mkdtempSync(join(tmpdir(), "ready-for-agent-jump-direct-"))
+    binDir = join(tempRoot, "bin")
+    mkdirSync(binDir)
+    tmuxLog = join(tempRoot, "tmux-argv.log")
+    backendRecord = join(tempRoot, "backend-record.json")
+    writeFileSync(tmuxLog, "")
+    writeExecutable(
+      join(binDir, "tmux"),
+      `#!/usr/bin/env bun
+import { appendFileSync } from "node:fs"
+appendFileSync(process.env.TMUX_ARGV_LOG ?? "", JSON.stringify(process.argv.slice(2)) + "\\n")
+process.exit(1)
+`,
+    )
+    for (const name of ["opencode", "grok", "codex", "claude"] as const) {
+      writeExecutable(join(binDir, name), recordingBackendScript)
+    }
+  })
+
+  afterEach(() => {
+    rmSync(tempRoot, { recursive: true, force: true })
+  })
+
+  const directEnv = (overrides: NodeJS.ProcessEnv = {}): NodeJS.ProcessEnv => ({
+    PATH: `${binDir}:${dirname(process.execPath)}`,
+    TMUX_ARGV_LOG: tmuxLog,
+    BACKEND_RECORD: backendRecord,
+    RFA_DIRECT_MARKER: "from-parent",
+    ...overrides,
+  })
+
+  const expectedResumeArgs = {
+    opencode: (workingDirectory: string) => [
+      workingDirectory,
+      "--session",
+      jumpSessionId,
+      "--auto",
+    ],
+    grok: (workingDirectory: string) => [
+      "--cwd",
+      workingDirectory,
+      "--resume",
+      jumpSessionId,
+      "--permission-mode",
+      "bypassPermissions",
+    ],
+    codex: (workingDirectory: string) => [
+      "resume",
+      "--dangerously-bypass-approvals-and-sandbox",
+      "-C",
+      workingDirectory,
+      jumpSessionId,
+    ],
+    claude: (_workingDirectory: string) => [
+      "--resume",
+      jumpSessionId,
+      "--dangerously-skip-permissions",
+    ],
+  } as const
+
+  test("jump help describes Interactive Session Continuation without requiring tmux", async () => {
+    const result = await runCli(
+      ["jump", "--help"],
+      "http://127.0.0.1:1/graphql",
+    )
+
+    expect(result.status).toBe(0)
+    const output = `${result.stdout}\n${result.stderr}`
+    expect(output).toContain("Interactive Session Continuation")
+    expect(output.toLowerCase()).not.toContain("must be run from inside a tmux")
+    expect(output).not.toContain("new tmux window")
+  })
+
+  test("jump continues each backend directly outside tmux", async () => {
+    const worktree = join(tempRoot, "worktree")
+    mkdirSync(worktree)
+
+    for (const backendId of ["opencode", "grok", "codex", "claude"] as const) {
+      writeFileSync(backendRecord, "")
+      writeFileSync(tmuxLog, "")
+      const graphql = await startJumpGraphqlServer({
+        backendId,
+        worktreePath: worktree,
+      })
+      try {
+        const result = await runCliOnPty(
+          ["jump", jumpSessionId],
+          graphql.url,
+          directEnv(),
+        )
+
+        expect(result.status).toBe(0)
+        expect(result.stdout.replaceAll("\r", "")).toContain("backend-ready")
+        expect(result.stdout).not.toContain("Continuing")
+        expect(result.stdout).not.toContain("Session continued")
+        expect(result.stderr.replaceAll("\r", "").trim()).toBe("")
+        expect(parseTmuxArgvLog(tmuxLog)).toEqual([])
+        const record = readBackendRecord(backendRecord)
+        expect(record.argv1).toBe(join(binDir, backendId))
+        expect(record.argv).toEqual(expectedResumeArgs[backendId](worktree))
+        expect(record.cwd).toBe(worktree)
+        expect(record.envMarker).toBe("from-parent")
+        expect(record.stdinIsTTY).toBe(true)
+        expect(record.stdoutIsTTY).toBe(true)
+      } finally {
+        await graphql.close()
+      }
+    }
+  })
+
+  test("jump uses the CLI cwd when the worktree is gone in direct mode", async () => {
+    const graphql = await startJumpGraphqlServer({
+      backendId: "claude",
+      worktreePath: join(tempRoot, "cleaned-up-worktree"),
+    })
+    try {
+      const result = await runCliOnPty(
+        ["jump", jumpSessionId],
+        graphql.url,
+        directEnv(),
+      )
+
+      expect(result.status).toBe(0)
+      expect(parseTmuxArgvLog(tmuxLog)).toEqual([])
+      const record = readBackendRecord(backendRecord)
+      expect(record.cwd).toBe(resolve(packageRoot))
+      expect(record.argv).toEqual(
+        expectedResumeArgs.claude(resolve(packageRoot)),
+      )
+    } finally {
+      await graphql.close()
+    }
+  })
+
+  test("jump returns a nonzero backend exit without a Jump diagnostic", async () => {
+    const worktree = join(tempRoot, "nonzero-wt")
+    mkdirSync(worktree)
+    const graphql = await startJumpGraphqlServer({
+      backendId: "opencode",
+      worktreePath: worktree,
+    })
+    try {
+      const result = await runCliOnPty(
+        ["jump", jumpSessionId],
+        graphql.url,
+        directEnv({ BACKEND_EXIT: "7" }),
+      )
+
+      expect(result.status).toBe(7)
+      expect(result.stdout.replaceAll("\r", "")).toContain("backend-ready")
+      expect(result.stderr.replaceAll("\r", "").trim()).toBe("")
+      expect(result.stderr).not.toContain("jump")
+    } finally {
+      await graphql.close()
+    }
+  })
+
+  test("jump returns a conventional signal-derived backend exit", async () => {
+    const worktree = join(tempRoot, "signal-wt")
+    mkdirSync(worktree)
+    const graphql = await startJumpGraphqlServer({
+      backendId: "opencode",
+      worktreePath: worktree,
+    })
+    try {
+      const result = await runCliOnPty(
+        ["jump", jumpSessionId],
+        graphql.url,
+        directEnv({ BACKEND_SIGNAL: "SIGTERM" }),
+      )
+
+      expect(result.status).toBe(143)
+      expect(result.stderr.replaceAll("\r", "").trim()).toBe("")
+    } finally {
+      await graphql.close()
+    }
+  })
+
+  test("jump waits for a backend that survives a process-group SIGINT", async () => {
+    const worktree = join(tempRoot, "sigint-wt")
+    mkdirSync(worktree)
+    const graphql = await startJumpGraphqlServer({
+      backendId: "opencode",
+      worktreePath: worktree,
+    })
+    try {
+      const result = await runCliOnPty(
+        ["jump", jumpSessionId],
+        graphql.url,
+        directEnv({ BACKEND_IGNORE_SIGINT: "1" }),
+        { sendSigintAfter: "backend-ready" },
+      )
+
+      expect(result.status).toBe(0)
+      expect(result.stdout.replaceAll("\r", "")).toContain("backend-ready")
+      expect(`${result.stdout}\n${result.stderr}`).not.toContain(
+        "could not start Agent Backend executable",
+      )
+    } finally {
+      await graphql.close()
+    }
+  })
+
+  test("jump allows redirected stderr when stdin and stdout are TTYs", async () => {
+    const worktree = join(tempRoot, "stderr-wt")
+    mkdirSync(worktree)
+    const stderrPath = join(tempRoot, "redirected.err")
+    const graphql = await startJumpGraphqlServer({
+      backendId: "opencode",
+      worktreePath: worktree,
+    })
+    try {
+      const result = await runCliOnPty(
+        ["jump", jumpSessionId],
+        graphql.url,
+        directEnv({ BACKEND_STDERR_TEXT: "backend-stderr\n" }),
+        { stderrPath },
+      )
+
+      expect(result.status).toBe(0)
+      expect(result.stdout.replaceAll("\r", "")).toContain("backend-ready")
+      expect(readFileSync(stderrPath, "utf8")).toContain("backend-stderr")
+      const record = readBackendRecord(backendRecord)
+      expect(record.stdinIsTTY).toBe(true)
+      expect(record.stdoutIsTTY).toBe(true)
+      expect(record.stderrIsTTY).toBe(false)
+    } finally {
+      await graphql.close()
+    }
+  })
+
+  test("jump spawn failure is a Jump-owned exit 1 after Session resolution", async () => {
+    writeExecutable(join(binDir, "opencode"), "#!/no/such/interpreter\n")
+    const graphql = await startJumpGraphqlServer({
+      backendId: "opencode",
+      worktreePath: null,
+    })
+    try {
+      const result = await runCliOnPty(
+        ["jump", jumpSessionId],
+        graphql.url,
+        directEnv(),
+      )
+
+      expect(result.status).toBe(1)
+      expect(
+        graphql.seenBodies.some((body) => body.includes("workItemBySessionId")),
+      ).toBe(true)
+      const diagnostic = `${result.stdout}\n${result.stderr}`.replaceAll(
+        "\r",
+        "",
+      )
+      expect(diagnostic).toContain(
+        `could not start Agent Backend executable '${join(binDir, "opencode")}'`,
+      )
+      expect(diagnostic).not.toContain("schemaVersion")
+      expect(parseTmuxArgvLog(tmuxLog)).toEqual([])
+    } finally {
+      await graphql.close()
+    }
+  })
+
+  test("a stale TMUX value stays on the tmux path and does not start the backend", async () => {
+    const graphql = await startJumpGraphqlServer({
+      backendId: "opencode",
+      worktreePath: null,
+    })
+    try {
+      const result = await runCli(
+        ["jump", jumpSessionId],
+        graphql.url,
+        directEnv({
+          TMUX: "/tmp/missing-tmux-socket,1,0",
+        }),
+      )
+
+      expect(result.status).toBe(1)
+      expect(result.stderr).toContain(
+        "tmux could not create and arrange the window",
+      )
+      expect(parseTmuxArgvLog(tmuxLog).length).toBeGreaterThan(0)
+      expect(() => readFileSync(backendRecord, "utf8")).toThrow()
     } finally {
       await graphql.close()
     }

--- a/apps/ready-for-agent/src/cli.test.ts
+++ b/apps/ready-for-agent/src/cli.test.ts
@@ -25,6 +25,10 @@ import {
   harnessNotRunningMessage,
 } from "./graphql-error.ts"
 import { JumpFailed } from "./jump-error.ts"
+import {
+  type DirectLaunchInput,
+  DirectTerminal,
+} from "./services/direct-terminal.ts"
 import { ExecutablePath } from "./services/executable-path.ts"
 import {
   GraphqlApi,
@@ -53,8 +57,12 @@ const unusedGraphql = {
 
 const unusedJumpServices = Layer.mergeAll(
   Layer.succeed(Tmux, {
-    requireAttachedSession: Effect.die("tmux should not run"),
+    tmuxModeSelected: Effect.die("tmux should not run"),
     createJumpWindow: () => Effect.die("tmux should not run"),
+  }),
+  Layer.succeed(DirectTerminal, {
+    requireInteractiveTerminal: Effect.die("direct terminal should not run"),
+    run: () => Effect.die("direct terminal should not run"),
   }),
   Layer.succeed(ExecutablePath, {
     resolve: () => Effect.die("executable path should not run"),
@@ -1197,10 +1205,14 @@ describe("operator binary jump command", () => {
     readonly workItemBySessionId?: (
       id: string,
     ) => Effect.Effect<SessionWorkItemLookup, GraphqlRequestFailed>
-    readonly requireAttachedSession?: Effect.Effect<void, JumpFailed>
+    readonly tmuxModeSelected?: Effect.Effect<boolean>
     readonly createJumpWindow?: (
       input: JumpWindowInput,
     ) => Effect.Effect<void, JumpFailed>
+    readonly requireInteractiveTerminal?: Effect.Effect<void, JumpFailed>
+    readonly runDirect?: (
+      input: DirectLaunchInput,
+    ) => Effect.Effect<number, JumpFailed>
     readonly resolve?: (command: string) => Effect.Effect<string, JumpFailed>
   }) =>
     mockStart.pipe(
@@ -1219,8 +1231,15 @@ describe("operator binary jump command", () => {
       ),
       Layer.provideMerge(
         Layer.succeed(Tmux, {
-          requireAttachedSession: options.requireAttachedSession ?? Effect.void,
+          tmuxModeSelected: options.tmuxModeSelected ?? Effect.succeed(true),
           createJumpWindow: options.createJumpWindow ?? (() => Effect.void),
+        }),
+      ),
+      Layer.provideMerge(
+        Layer.succeed(DirectTerminal, {
+          requireInteractiveTerminal:
+            options.requireInteractiveTerminal ?? Effect.void,
+          run: options.runDirect ?? (() => Effect.succeed(0)),
         }),
       ),
       Layer.provideMerge(
@@ -1250,29 +1269,111 @@ describe("operator binary jump command", () => {
     }),
   )
 
-  it.live("jump fails when invoked outside tmux", () =>
+  it.live("jump rejects a non-interactive terminal before GraphQL", () =>
     Effect.gen(function* () {
       let lookedUp = false
+      let launched = false
       const result = yield* runOperator(
         ["jump", sessionId],
         successfulJumpLayer({
-          requireAttachedSession: Effect.fail(
+          tmuxModeSelected: Effect.succeed(false),
+          requireInteractiveTerminal: Effect.fail(
             new JumpFailed({
-              message: "jump must be run from inside a tmux session",
+              message: "jump requires an interactive terminal",
             }),
           ),
           workItemBySessionId: () => {
             lookedUp = true
-            return Effect.die("GraphQL should not run outside tmux")
+            return Effect.die("GraphQL should not run without a TTY")
+          },
+          runDirect: () => {
+            launched = true
+            return Effect.die("direct launch should not run without a TTY")
           },
         }),
       ).pipe(Effect.flip)
 
       expect(lookedUp).toBe(false)
+      expect(launched).toBe(false)
+      expect(result).toBeInstanceOf(JumpFailed)
+      if (result instanceof JumpFailed) {
+        expect(result.message).toBe("jump requires an interactive terminal")
+      }
+    }),
+  )
+
+  it.live("jump routes to direct continuation when tmux mode is off", () =>
+    Effect.gen(function* () {
+      let created = false
+      let launched: DirectLaunchInput | undefined
+      const previousExitCode = process.exitCode
+      try {
+        yield* runOperator(
+          ["jump", sessionId],
+          successfulJumpLayer({
+            tmuxModeSelected: Effect.succeed(false),
+            createJumpWindow: () => {
+              created = true
+              return Effect.void
+            },
+            runDirect: (input) =>
+              Effect.sync(() => {
+                launched = input
+                return 0
+              }),
+          }),
+        )
+        expect(created).toBe(false)
+        expect(launched).toEqual({
+          agentExecutable: "/usr/bin/opencode",
+          agentArguments: [process.cwd(), "--session", sessionId, "--auto"],
+          workingDirectory: process.cwd(),
+        })
+        expect(process.exitCode ?? 0).toBe(0)
+      } finally {
+        process.exitCode = previousExitCode
+      }
+    }),
+  )
+
+  it.live("jump returns a backend exit status without JumpFailed", () =>
+    Effect.gen(function* () {
+      const previousExitCode = process.exitCode
+      try {
+        yield* runOperator(
+          ["jump", sessionId],
+          successfulJumpLayer({
+            tmuxModeSelected: Effect.succeed(false),
+            runDirect: () => Effect.succeed(7),
+          }),
+        )
+        expect(process.exitCode).toBe(7)
+      } finally {
+        process.exitCode = previousExitCode
+      }
+    }),
+  )
+
+  it.live("jump maps a direct spawn failure to JumpFailed", () =>
+    Effect.gen(function* () {
+      const result = yield* runOperator(
+        ["jump", sessionId],
+        successfulJumpLayer({
+          tmuxModeSelected: Effect.succeed(false),
+          runDirect: () =>
+            Effect.fail(
+              new JumpFailed({
+                message:
+                  "could not start Agent Backend executable '/usr/bin/opencode'",
+              }),
+            ),
+        }),
+      ).pipe(Effect.flip)
+
       expect(result).toBeInstanceOf(JumpFailed)
       if (result instanceof JumpFailed) {
         expect(result.message).toBe(
-          "jump must be run from inside a tmux session",
+          "could not start Agent Backend executable '/usr/bin/opencode'",
         )
       }
     }),

--- a/apps/ready-for-agent/src/cli.ts
+++ b/apps/ready-for-agent/src/cli.ts
@@ -20,6 +20,7 @@ import {
   formatRepositoryFullIdentity,
   resolveRepositoryIdentity,
 } from "./repository-identity.ts"
+import { DirectTerminal } from "./services/direct-terminal.ts"
 import { ExecutablePath } from "./services/executable-path.ts"
 import { GraphqlApi } from "./services/graphql-api.ts"
 import { LocalGit } from "./services/local-git.ts"
@@ -330,10 +331,14 @@ const resolveJumpWorkingDirectory = (
 
 const jumpWorkflow = Effect.fn("Cli.jump")(function* (sessionId: string) {
   const tmux = yield* Tmux
+  const directTerminal = yield* DirectTerminal
   const executablePath = yield* ExecutablePath
   const graphqlApi = yield* GraphqlApi
 
-  yield* tmux.requireAttachedSession
+  const tmuxModeSelected = yield* tmux.tmuxModeSelected
+  if (!tmuxModeSelected) {
+    yield* directTerminal.requireInteractiveTerminal
+  }
 
   const found = yield* graphqlApi
     .workItemBySessionId(sessionId)
@@ -356,12 +361,24 @@ const jumpWorkflow = Effect.fn("Cli.jump")(function* (sessionId: string) {
   }
 
   const agentExecutable = yield* executablePath.resolve(resume.executableName)
-  yield* tmux.createJumpWindow({
-    sessionId: found.sessionId,
-    workingDirectory,
+  if (tmuxModeSelected) {
+    yield* tmux.createJumpWindow({
+      sessionId: found.sessionId,
+      workingDirectory,
+      agentExecutable,
+      agentArguments: resume.arguments,
+      backendId: found.agentBackend.id,
+    })
+    return
+  }
+
+  const exitStatus = yield* directTerminal.run({
     agentExecutable,
     agentArguments: resume.arguments,
-    backendId: found.agentBackend.id,
+    workingDirectory,
+  })
+  yield* Effect.sync(() => {
+    process.exitCode = exitStatus
   })
 })
 
@@ -430,7 +447,7 @@ const jumpCommand = Command.make(
   ({ sessionId }) => jumpWorkflow(sessionId),
 ).pipe(
   Command.withDescription(
-    "Continue a Work Item Session in a new tmux window (Interactive Session Continuation)",
+    "Continue a Work Item Session (Interactive Session Continuation)",
   ),
 )
 

--- a/apps/ready-for-agent/src/main.ts
+++ b/apps/ready-for-agent/src/main.ts
@@ -32,6 +32,7 @@ if (isInternalKeymaxxerSidecarMode(process.argv)) {
   const { GraphqlApi } = await import("./services/graphql-api.ts")
   const { LocalGit } = await import("./services/local-git.ts")
   const { StartHarness } = await import("./services/start-harness.ts")
+  const { DirectTerminal } = await import("./services/direct-terminal.ts")
   const { Tmux } = await import("./services/tmux.ts")
 
   const MainLive = Layer.mergeAll(
@@ -39,6 +40,7 @@ if (isInternalKeymaxxerSidecarMode(process.argv)) {
     GraphqlApi.layer,
     StartHarness.layer,
     Tmux.layer,
+    DirectTerminal.layer,
     ExecutablePath.layer,
   ).pipe(
     Layer.provideMerge(ApplicationConfig.layer),

--- a/apps/ready-for-agent/src/services/direct-terminal.ts
+++ b/apps/ready-for-agent/src/services/direct-terminal.ts
@@ -1,0 +1,130 @@
+import { spawn } from "node:child_process"
+import { constants } from "node:os"
+import { Context, Effect, Layer } from "effect"
+import { JumpFailed } from "../jump-error.ts"
+
+export type DirectLaunchInput = {
+  readonly agentExecutable: string
+  readonly agentArguments: readonly string[]
+  readonly workingDirectory: string
+}
+
+const interactiveTerminalMessage = "jump requires an interactive terminal"
+
+const spawnFailedMessage = (executable: string, detail?: string): string =>
+  detail === undefined || detail.length === 0
+    ? `could not start Agent Backend executable '${executable}'`
+    : `could not start Agent Backend executable '${executable}': ${detail}`
+
+const exitStatusFrom = (
+  code: number | null,
+  signal: NodeJS.Signals | null,
+): number => {
+  if (signal !== null) {
+    const number = constants.signals[signal]
+    if (typeof number === "number") {
+      return 128 + number
+    }
+    return 1
+  }
+  if (code !== null) {
+    return code
+  }
+  return 1
+}
+
+const spawnFailed = (executable: string, error: unknown): JumpFailed =>
+  new JumpFailed({
+    message: spawnFailedMessage(
+      executable,
+      error instanceof Error ? error.message : String(error),
+    ),
+  })
+
+const releaseParentTerminalSignals = (): void => {
+  process.removeAllListeners("SIGINT")
+  process.removeAllListeners("SIGTERM")
+  // Empty catchers, not SIG_IGN — posix_spawn is still in flight and would
+  // inherit an ignored interrupt.
+  process.on("SIGINT", () => {})
+  process.on("SIGTERM", () => {})
+}
+
+export class DirectTerminal extends Context.Service<
+  DirectTerminal,
+  {
+    readonly requireInteractiveTerminal: Effect.Effect<void, JumpFailed>
+    readonly run: (
+      input: DirectLaunchInput,
+    ) => Effect.Effect<number, JumpFailed>
+  }
+>()("ready-for-agent/DirectTerminal") {
+  static readonly layer = Layer.sync(DirectTerminal, () => {
+    const requireInteractiveTerminal = Effect.sync(
+      () => process.stdin.isTTY === true && process.stdout.isTTY === true,
+    ).pipe(
+      Effect.flatMap((interactive) =>
+        interactive
+          ? Effect.void
+          : Effect.fail(
+              new JumpFailed({ message: interactiveTerminalMessage }),
+            ),
+      ),
+    )
+
+    const run = Effect.fn("DirectTerminal.run")(function* (
+      input: DirectLaunchInput,
+    ) {
+      return yield* Effect.callback<number, JumpFailed>((resume) => {
+        let started = false
+        let failedToStart = false
+        let settled = false
+        const finish = (effect: Effect.Effect<number, JumpFailed>) => {
+          if (settled) {
+            return
+          }
+          settled = true
+          resume(effect)
+        }
+
+        let child: ReturnType<typeof spawn>
+        try {
+          child = spawn(input.agentExecutable, [...input.agentArguments], {
+            cwd: input.workingDirectory,
+            env: process.env,
+            stdio: "inherit",
+            shell: false,
+            detached: false,
+          })
+        } catch (error) {
+          finish(Effect.fail(spawnFailed(input.agentExecutable, error)))
+          return
+        }
+
+        // Child already inherited the previous disposition. Detach runMain so
+        // a process-group interrupt cannot exit Jump while the backend owns
+        // the terminal.
+        releaseParentTerminalSignals()
+
+        child.once("spawn", () => {
+          started = true
+        })
+        child.once("error", (error) => {
+          if (!started) {
+            failedToStart = true
+            finish(Effect.fail(spawnFailed(input.agentExecutable, error)))
+          }
+        })
+        child.once("close", (code, signal) => {
+          if (failedToStart || settled) {
+            return
+          }
+          // Bypass runMain teardown: a prior SIGINT would otherwise force 130.
+          process.exit(exitStatusFrom(code, signal))
+        })
+      }).pipe(Effect.uninterruptible)
+    })
+
+    return { requireInteractiveTerminal, run }
+  })
+}

--- a/apps/ready-for-agent/src/services/tmux.ts
+++ b/apps/ready-for-agent/src/services/tmux.ts
@@ -11,8 +11,6 @@ export type JumpWindowInput = {
   readonly backendId: string
 }
 
-const tmuxMissingMessage = "jump must be run from inside a tmux session"
-
 const sessionOptionName = "@rfa-session-id"
 const agentPaneOptionName = "@rfa-agent"
 const agentPaneMarker = "1"
@@ -96,7 +94,7 @@ const taggedAgentPaneId = (listing: string): string | undefined => {
 export class Tmux extends Context.Service<
   Tmux,
   {
-    readonly requireAttachedSession: Effect.Effect<void, JumpFailed>
+    readonly tmuxModeSelected: Effect.Effect<boolean>
     readonly createJumpWindow: (
       input: JumpWindowInput,
     ) => Effect.Effect<void, JumpFailed>
@@ -107,16 +105,10 @@ export class Tmux extends Context.Service<
     Effect.gen(function* () {
       const spawner = yield* ChildProcessSpawner.ChildProcessSpawner
 
-      const requireAttachedSession = Effect.sync(() => {
+      const tmuxModeSelected = Effect.sync(() => {
         const tmux = process.env.TMUX
         return tmux !== undefined && tmux.length > 0
-      }).pipe(
-        Effect.flatMap((inside) =>
-          inside
-            ? Effect.void
-            : Effect.fail(new JumpFailed({ message: tmuxMissingMessage })),
-        ),
-      )
+      })
 
       const runTmux = (args: readonly string[]) =>
         Effect.scoped(
@@ -327,7 +319,7 @@ export class Tmux extends Context.Service<
         }
       })
 
-      return { requireAttachedSession, createJumpWindow }
+      return { tmuxModeSelected, createJumpWindow }
     }),
   )
 }


### PR DESCRIPTION
When `TMUX` is unset, `ready-for-agent jump` used to fail before Session
lookup, so operators had to reconstruct each backend’s resume command by
hand. #1061 makes Jump continue the canonical Session in the current
terminal instead, without changing GraphQL, lifecycle, or the existing
tmux window path.

A non-empty `TMUX` still uses the current tagged-window
create/reuse/recreate flow. Absent or empty `TMUX` checks that stdin and
stdout are TTYs, then resolves the Session and starts OpenCode, Grok,
Codex, or Claude with the same non-forking resume argv. The child uses
the worktree when it exists, otherwise the Jump process cwd; it inherits
the full environment and stdio. Jump prints no banners. Backend exit
statuses (including 128+signal) pass through; a spawn failure stays a
Jump-owned exit 1. After spawn, Jump detaches `runMain` SIGINT/SIGTERM
handling so a process-group interrupt does not return the TTY to the
shell while the backend is still running. A stale `TMUX` value never
falls back to direct mode.

Verified with `bunx nx test ready-for-agent` (existing tmux
process-contract cases plus PTY coverage for all four backends,
missing-worktree cwd, nonzero and SIGTERM exits, redirected stderr,
spawn failure, and a backend that survives process-group SIGINT) and
`bunx nx typecheck ready-for-agent`.

Closes #1061