### PR TITLE
fix: classify mid-turn credential rejection as an actionable Work Item failure

### DIFF
--- a/packages/agent-backend/src/index.ts
+++ b/packages/agent-backend/src/index.ts
@@ -5,6 +5,7 @@ export {
 export * from "./lib/active-agent-backend.js"
 export * from "./lib/agent-backend.js"
 export * from "./lib/agent-cli-not-found.js"
+export * from "./lib/classify-credential-error.js"
 export * from "./lib/cli-runner.js"
 export * from "./lib/collect-child-stdout.js"
 export * from "./lib/environment.js"

--- a/packages/agent-backend/src/lib/classify-credential-error.ts
+++ b/packages/agent-backend/src/lib/classify-credential-error.ts
@@ -1,0 +1,137 @@
+import type { AgentBackendProvider } from "./types.js"
+
+/** Shared suffix of `CLAUDE_BEDROCK_UNAVAILABLE_MESSAGE`. */
+export const CLAUDE_BEDROCK_CREDENTIAL_REMEDIATION =
+  "Ensure valid AWS credentials and region are available to the harness process (with CLAUDE_CODE_USE_BEDROCK=1), then Recheck Agent Backend."
+
+/** Shared with Claude Code first-party readiness copy. */
+export const CLAUDE_FIRST_PARTY_AUTH_REMEDIATION =
+  "Run `claude auth login` (or set `ANTHROPIC_API_KEY`), then Recheck Agent Backend."
+
+const GENERIC_CREDENTIAL_REMEDIATION =
+  "Refresh credentials for the harness process, then Recheck Agent Backend."
+
+const AWS_CREDENTIAL_REMEDIATION =
+  "Ensure valid AWS credentials and region are available to the harness process, then Recheck Agent Backend."
+
+const AMAZON_BEDROCK_PROVIDER = {
+  id: "bedrock",
+  label: "Amazon Bedrock",
+} as const satisfies AgentBackendProvider
+
+const AWS_PROVIDER = {
+  id: "aws",
+  label: "AWS",
+} as const satisfies AgentBackendProvider
+
+/**
+ * Provider credential markers recognized from AWS SDK / Bedrock / CLI
+ * failure text. Single source for catalog discovery and mid-turn
+ * `terminal_auth_error` classification.
+ */
+const PROVIDER_CREDENTIAL_MARKERS = [
+  "expiredtoken",
+  "expired token",
+  "token has expired",
+  "token is expired",
+  "could not load credentials",
+  "credentials not found",
+  "unable to locate credentials",
+  "could not load credentials from any providers",
+  "security token",
+  "invalidclienttokenid",
+  "unrecognizedclient",
+  "invalididentitytoken",
+  "sso session",
+] as const
+
+export type ProviderCredentialClassification = {
+  readonly classification: "terminal_auth_error"
+  readonly provider: AgentBackendProvider | null
+}
+
+/**
+ * Strip access keys, session tokens, bearer tokens, and other credential-like
+ * payloads from operator-facing failure text (issue #822 / #1058).
+ */
+export const scrubProviderCredentialSecrets = (text: string): string => {
+  let scrubbed = text
+  // IAM access key ids (long-term AKIA… and temporary ASIA…).
+  scrubbed = scrubbed.replace(/\b(?:AKIA|ASIA)[A-Z0-9]{16}\b/g, "[redacted]")
+  // Env-style, property-style, and JSON-ish secret field assignments.
+  scrubbed = scrubbed.replace(
+    /\b(?:AWS_SECRET_ACCESS_KEY|AWS_SESSION_TOKEN|AWS_BEARER_TOKEN_BEDROCK|AWS_ACCESS_KEY_ID|aws_secret_access_key|aws_session_token|aws_access_key_id|secretAccessKey|SecretAccessKey|accessKeyId|AccessKeyId|sessionToken|SessionToken|security.?token)\b\s*[=:]\s*"?[^"\s,}]+"?/gi,
+    (match) => {
+      const keyMatch = match.match(/^([^=:]+)/)
+      const key = (keyMatch?.[1] ?? "secret").trim()
+      const separator = match.includes("=") ? "=" : ":"
+      return `${key}${separator}[redacted]`
+    },
+  )
+  // JSON `"secretAccessKey": "…"` / `"accessKeyId":"…"` forms.
+  scrubbed = scrubbed.replace(
+    /"(?:secretAccessKey|SecretAccessKey|accessKeyId|AccessKeyId|sessionToken|SessionToken|aws_secret_access_key|aws_session_token|AWS_SECRET_ACCESS_KEY|AWS_SESSION_TOKEN|AWS_ACCESS_KEY_ID)"\s*:\s*"[^"]*"/gi,
+    (match) => {
+      const keyMatch = match.match(/^"([^"]+)"/)
+      const key = keyMatch?.[1] ?? "secret"
+      return `"${key}":"[redacted]"`
+    },
+  )
+  // Authorization / bearer headers.
+  scrubbed = scrubbed.replace(
+    /\bBearer\s+[A-Za-z0-9._~+/=-]{8,}/gi,
+    "Bearer [redacted]",
+  )
+  return scrubbed
+}
+
+const mentionsBedrock = (normalized: string): boolean =>
+  normalized.includes("bedrock") || normalized.includes("amazon bedrock")
+
+const hasProviderCredentialMarker = (normalized: string): boolean =>
+  PROVIDER_CREDENTIAL_MARKERS.some((marker) => normalized.includes(marker))
+
+/**
+ * Recognize a provider rejecting credentials from failure text (stderr,
+ * JSONL error, AWS SDK exception). Unrecognized text returns undefined so
+ * callers keep generic handling.
+ */
+export const classifyProviderCredentialText = (
+  text: string,
+): ProviderCredentialClassification | undefined => {
+  const normalized = scrubProviderCredentialSecrets(text).toLowerCase()
+  if (!hasProviderCredentialMarker(normalized)) {
+    return undefined
+  }
+  return {
+    classification: "terminal_auth_error",
+    provider: mentionsBedrock(normalized)
+      ? AMAZON_BEDROCK_PROVIDER
+      : AWS_PROVIDER,
+  }
+}
+
+export const formatTerminalAuthErrorMessage = (input: {
+  readonly backendLabel: string
+  readonly provider?: AgentBackendProvider | null
+}): string => {
+  const provider = input.provider
+  const namedProvider =
+    provider?.id === "firstParty" ? undefined : provider?.label?.trim()
+  const named =
+    namedProvider !== undefined && namedProvider.length > 0
+      ? `${input.backendLabel} could not authenticate to ${namedProvider}`
+      : `${input.backendLabel} could not authenticate`
+  const subject = `${named} (credentials missing or expired)`
+
+  if (provider?.id === "bedrock") {
+    return `${subject}. ${CLAUDE_BEDROCK_CREDENTIAL_REMEDIATION}`
+  }
+  if (provider?.id === "firstParty") {
+    return `${subject}. ${CLAUDE_FIRST_PARTY_AUTH_REMEDIATION}`
+  }
+  if (provider?.id === "aws") {
+    return `${subject}. ${AWS_CREDENTIAL_REMEDIATION}`
+  }
+  return `${subject}. ${GENERIC_CREDENTIAL_REMEDIATION}`
+}

--- a/packages/agent-backend/src/lib/errors.ts
+++ b/packages/agent-backend/src/lib/errors.ts
@@ -1,4 +1,5 @@
 import { Schema } from "effect"
+import { classifyProviderCredentialText } from "./classify-credential-error.js"
 import { sanitizeAgentBackendExitMessage } from "./sanitize-exit-message.js"
 
 const AgentBackendProviderSchema = Schema.Struct({
@@ -83,13 +84,17 @@ export class AgentBackendExitError extends Schema.TaggedErrorClass<AgentBackendE
       props.message === undefined
         ? undefined
         : sanitizeAgentBackendExitMessage(props.message)
+    const classifiedFromText =
+      props.classification === undefined && props.message !== undefined
+        ? classifyProviderCredentialText(props.message)
+        : undefined
+    const classification =
+      props.classification ?? classifiedFromText?.classification
     return new AgentBackendExitError({
       exitCode: props.exitCode,
       cwd: props.cwd,
       ...(props.sessionId !== undefined ? { sessionId: props.sessionId } : {}),
-      ...(props.classification !== undefined
-        ? { classification: props.classification }
-        : {}),
+      ...(classification !== undefined ? { classification } : {}),
       ...(sanitized !== undefined && sanitized.length > 0
         ? { message: sanitized }
         : {}),
@@ -172,6 +177,38 @@ export const findAgentBackendNotInstalledError = (
   while (current !== undefined && current !== null && !seen.has(current)) {
     seen.add(current)
     if (isAgentBackendNotInstalledError(current)) {
+      return current
+    }
+    if (typeof current === "object" && "cause" in current) {
+      current = Reflect.get(current, "cause")
+      continue
+    }
+    break
+  }
+  return undefined
+}
+
+const isAgentBackendExitError = (
+  value: unknown,
+): value is AgentBackendExitError =>
+  typeof value === "object" &&
+  value !== null &&
+  "_tag" in value &&
+  value._tag === "AgentBackendExitError"
+
+/**
+ * Walk a nested `cause` / `_tag` chain for AgentBackendExitError. Step
+ * handlers wrap the spawn error, so `instanceof` on the top-level failure
+ * is not enough.
+ */
+export const findAgentBackendExitError = (
+  cause: unknown,
+): AgentBackendExitError | undefined => {
+  const seen = new Set<unknown>()
+  let current: unknown = cause
+  while (current !== undefined && current !== null && !seen.has(current)) {
+    seen.add(current)
+    if (isAgentBackendExitError(current)) {
       return current
     }
     if (typeof current === "object" && "cause" in current) {

--- a/packages/agent-backend/src/lib/sanitize-exit-message.ts
+++ b/packages/agent-backend/src/lib/sanitize-exit-message.ts
@@ -1,3 +1,5 @@
+import { scrubProviderCredentialSecrets } from "./classify-credential-error.js"
+
 const ESC = String.fromCharCode(0x1b)
 const CSI = String.fromCharCode(0x9b)
 const ANSI_ESCAPE_RE = new RegExp(
@@ -12,7 +14,9 @@ const TOKEN_SHAPED_RE =
 const AGENT_BACKEND_EXIT_MESSAGE_MAX = 500
 
 const cleanOperatorFacingText = (text: string): string =>
-  text.replace(ANSI_ESCAPE_RE, "").replace(TOKEN_SHAPED_RE, "[redacted]").trim()
+  scrubProviderCredentialSecrets(
+    text.replace(ANSI_ESCAPE_RE, "").replace(TOKEN_SHAPED_RE, "[redacted]"),
+  ).trim()
 
 export const sanitizeAgentBackendExitMessage = (text: string): string =>
   cleanOperatorFacingText(text).slice(0, AGENT_BACKEND_EXIT_MESSAGE_MAX)

--- a/packages/agent-backend/test/classify-credential-error.spec.ts
+++ b/packages/agent-backend/test/classify-credential-error.spec.ts
@@ -1,0 +1,119 @@
+import {
+  CLAUDE_BEDROCK_CREDENTIAL_REMEDIATION,
+  CLAUDE_FIRST_PARTY_AUTH_REMEDIATION,
+  classifyProviderCredentialText,
+  formatTerminalAuthErrorMessage,
+  scrubProviderCredentialSecrets,
+} from "../src/lib/classify-credential-error.js"
+import { describe, expect, it } from "bun:test"
+
+describe("classifyProviderCredentialText", () => {
+  it.each([
+    "ExpiredTokenException",
+    "The security token included in the request is expired",
+    "token has expired",
+    "token is expired",
+    "expired token",
+    "SSO session expired",
+    "Could not load credentials from any providers",
+    "credentials not found",
+    "Unable to locate credentials",
+    "InvalidClientTokenId",
+    "UnrecognizedClientException",
+    "InvalidIdentityToken",
+  ])("classifies %s as terminal_auth_error", (text) => {
+    expect(classifyProviderCredentialText(text)).toMatchObject({
+      classification: "terminal_auth_error",
+    })
+  })
+
+  it("names Amazon Bedrock when the failure text reports that provider", () => {
+    expect(
+      classifyProviderCredentialText(
+        "Claude Code could not authenticate to Amazon Bedrock: ExpiredToken",
+      ),
+    ).toEqual({
+      classification: "terminal_auth_error",
+      provider: { id: "bedrock", label: "Amazon Bedrock" },
+    })
+  })
+
+  it("names AWS when only credential markers are present", () => {
+    expect(
+      classifyProviderCredentialText(
+        "ExpiredTokenException: The security token included in the request is expired",
+      ),
+    ).toEqual({
+      classification: "terminal_auth_error",
+      provider: { id: "aws", label: "AWS" },
+    })
+  })
+
+  it("does not classify a generic step failure", () => {
+    expect(
+      classifyProviderCredentialText(
+        "Claude Code fallback failed to install dependencies",
+      ),
+    ).toBeUndefined()
+    expect(
+      classifyProviderCredentialText("npm install failed: EACCES"),
+    ).toBeUndefined()
+    expect(
+      classifyProviderCredentialText("AccessDeniedException"),
+    ).toBeUndefined()
+  })
+})
+
+describe("scrubProviderCredentialSecrets", () => {
+  it("redacts access keys and secret payloads", () => {
+    const dirty =
+      "request failed using AKIAIOSFODNN7EXAMPLE AWS_SECRET_ACCESS_KEY=supersecretvalue AWS_SESSION_TOKEN=sessiontok"
+    const clean = scrubProviderCredentialSecrets(dirty)
+    expect(clean).not.toContain("AKIAIOSFODNN7EXAMPLE")
+    expect(clean).not.toContain("supersecretvalue")
+    expect(clean).not.toContain("sessiontok")
+    expect(clean).toContain("[redacted]")
+  })
+})
+
+describe("formatTerminalAuthErrorMessage", () => {
+  it("names Claude Code and Amazon Bedrock with the readiness remediation", () => {
+    expect(
+      formatTerminalAuthErrorMessage({
+        backendLabel: "Claude Code",
+        provider: { id: "bedrock", label: "Amazon Bedrock" },
+      }),
+    ).toBe(
+      `Claude Code could not authenticate to Amazon Bedrock (credentials missing or expired). ${CLAUDE_BEDROCK_CREDENTIAL_REMEDIATION}`,
+    )
+  })
+
+  it("uses first-party Claude remediation when that provider is reported", () => {
+    expect(
+      formatTerminalAuthErrorMessage({
+        backendLabel: "Claude Code",
+        provider: { id: "firstParty", label: "First-party" },
+      }),
+    ).toBe(
+      `Claude Code could not authenticate (credentials missing or expired). ${CLAUDE_FIRST_PARTY_AUTH_REMEDIATION}`,
+    )
+  })
+
+  it("names the backend without inventing a provider", () => {
+    expect(
+      formatTerminalAuthErrorMessage({
+        backendLabel: "OpenCode",
+      }),
+    ).toBe(
+      "OpenCode could not authenticate (credentials missing or expired). Refresh credentials for the harness process, then Recheck Agent Backend.",
+    )
+  })
+
+  it("does not present aws sso login as the remedy", () => {
+    const message = formatTerminalAuthErrorMessage({
+      backendLabel: "Claude Code",
+      provider: { id: "bedrock", label: "Amazon Bedrock" },
+    })
+    expect(message.toLowerCase()).not.toContain("aws sso login")
+  })
+})

--- a/packages/agent-backend/test/errors.spec.ts
+++ b/packages/agent-backend/test/errors.spec.ts
@@ -36,6 +36,47 @@ describe("AgentBackendExitError message", () => {
     expect(error.message).not.toMatch(/ghp_[A-Za-z0-9]+/)
     expect(error.message).toContain("[redacted]")
   })
+
+  it("redacts AWS access keys so they cannot reach the message", () => {
+    const secret = "AKIAIOSFODNN7EXAMPLE"
+    const error = AgentBackendExitError.new({
+      exitCode: 1,
+      cwd: "/tmp",
+      message: `ExpiredTokenException using ${secret}`,
+    })
+    expect(error.classification).toBe("terminal_auth_error")
+    expect(error.message).not.toContain(secret)
+    expect(error.message).toContain("[redacted]")
+  })
+
+  it("classifies expired AWS credentials as terminal_auth_error", () => {
+    const error = AgentBackendExitError.new({
+      exitCode: 1,
+      cwd: "/tmp",
+      message:
+        "ExpiredTokenException: The security token included in the request is expired",
+    })
+    expect(error.classification).toBe("terminal_auth_error")
+  })
+
+  it("leaves an unrecognized failure unclassified", () => {
+    const error = AgentBackendExitError.new({
+      exitCode: 1,
+      cwd: "/tmp",
+      message: "npm install failed: EACCES",
+    })
+    expect(error.classification).toBeUndefined()
+  })
+
+  it("keeps an adapter-supplied classification", () => {
+    const error = AgentBackendExitError.new({
+      exitCode: 1,
+      cwd: "/tmp",
+      classification: "retryable_provider_error",
+      message: "The security token included in the request is expired",
+    })
+    expect(error.classification).toBe("retryable_provider_error")
+  })
 })
 
 describe("sanitizeAgentBackendStderrTail", () => {

--- a/packages/claude/src/lib/discover-bedrock-profiles.ts
+++ b/packages/claude/src/lib/discover-bedrock-profiles.ts
@@ -7,7 +7,11 @@ import {
   ListInferenceProfilesCommand,
 } from "@aws-sdk/client-bedrock"
 import { Duration, Effect } from "effect"
-import type { AgentModel } from "@ready-for-agent/agent-backend"
+import {
+  type AgentModel,
+  classifyProviderCredentialText,
+  scrubProviderCredentialSecrets,
+} from "@ready-for-agent/agent-backend"
 import {
   CLAUDE_THINKING_LEVELS,
   type ClaudeBedrockDiscoveryResult,
@@ -83,36 +87,7 @@ export const EMPTY_BEDROCK_CATALOG_WARNING = `No active Anthropic Bedrock infere
  * Strip access keys, session tokens, bearer tokens, and other credential-like
  * payloads from operator-facing discovery warnings (issue #822).
  */
-export const scrubBedrockDiscoverySecrets = (text: string): string => {
-  let scrubbed = text
-  // IAM access key ids (long-term AKIA… and temporary ASIA…).
-  scrubbed = scrubbed.replace(/\b(?:AKIA|ASIA)[A-Z0-9]{16}\b/g, "[redacted]")
-  // Env-style, property-style, and JSON-ish secret field assignments.
-  scrubbed = scrubbed.replace(
-    /\b(?:AWS_SECRET_ACCESS_KEY|AWS_SESSION_TOKEN|AWS_BEARER_TOKEN_BEDROCK|AWS_ACCESS_KEY_ID|aws_secret_access_key|aws_session_token|aws_access_key_id|secretAccessKey|SecretAccessKey|accessKeyId|AccessKeyId|sessionToken|SessionToken|security.?token)\b\s*[=:]\s*"?[^"\s,}]+"?/gi,
-    (match) => {
-      const keyMatch = match.match(/^([^=:]+)/)
-      const key = (keyMatch?.[1] ?? "secret").trim()
-      const separator = match.includes("=") ? "=" : ":"
-      return `${key}${separator}[redacted]`
-    },
-  )
-  // JSON `"secretAccessKey": "…"` / `"accessKeyId":"…"` forms.
-  scrubbed = scrubbed.replace(
-    /"(?:secretAccessKey|SecretAccessKey|accessKeyId|AccessKeyId|sessionToken|SessionToken|aws_secret_access_key|aws_session_token|AWS_SECRET_ACCESS_KEY|AWS_SESSION_TOKEN|AWS_ACCESS_KEY_ID)"\s*:\s*"[^"]*"/gi,
-    (match) => {
-      const keyMatch = match.match(/^"([^"]+)"/)
-      const key = keyMatch?.[1] ?? "secret"
-      return `"${key}":"[redacted]"`
-    },
-  )
-  // Authorization / bearer headers.
-  scrubbed = scrubbed.replace(
-    /\bBearer\s+[A-Za-z0-9._~+/=-]{8,}/gi,
-    "Bearer [redacted]",
-  )
-  return scrubbed
-}
+export const scrubBedrockDiscoverySecrets = scrubProviderCredentialSecrets
 
 export type ResolveBedrockRegionOptions = {
   /**
@@ -435,21 +410,7 @@ export const formatBedrockDiscoveryFailure = (error: unknown): string => {
       "AWS named profile is unresolved or unavailable to the harness process (check AWS_PROFILE and shared config)",
     )
   }
-  if (
-    combined.includes("expiredtoken") ||
-    combined.includes("expired token") ||
-    combined.includes("token has expired") ||
-    combined.includes("could not load credentials") ||
-    combined.includes("credentials not found") ||
-    combined.includes("unable to locate credentials") ||
-    combined.includes("could not load credentials from any providers") ||
-    combined.includes("security token") ||
-    combined.includes("invalidclienttokenid") ||
-    combined.includes("unrecognizedclient") ||
-    combined.includes("invalididentitytoken") ||
-    combined.includes("sso session") ||
-    combined.includes("token is expired")
-  ) {
+  if (classifyProviderCredentialText(combined) !== undefined) {
     return discoveryWarning(
       "AWS credentials are missing, expired, or invalid for the harness process",
     )

--- a/packages/claude/src/lib/types.ts
+++ b/packages/claude/src/lib/types.ts
@@ -1,5 +1,9 @@
 import type { Duration, Effect } from "effect"
-import type { AgentModel } from "@ready-for-agent/agent-backend"
+import {
+  type AgentModel,
+  CLAUDE_BEDROCK_CREDENTIAL_REMEDIATION,
+  CLAUDE_FIRST_PARTY_AUTH_REMEDIATION,
+} from "@ready-for-agent/agent-backend"
 
 /**
  * Injectable Bedrock catalog discovery result (issue #820).
@@ -40,8 +44,7 @@ export interface ClaudeLayerOptions {
  * Actionable readiness-failure copy when `claude auth status` reports no auth.
  * Operators may use Claude.ai OAuth (`claude auth login`) or an API key.
  */
-export const CLAUDE_UNAUTHENTICATED_MESSAGE =
-  "Claude Code is not authenticated. Run `claude auth login` (or set `ANTHROPIC_API_KEY`), then Recheck Agent Backend."
+export const CLAUDE_UNAUTHENTICATED_MESSAGE = `Claude Code is not authenticated. ${CLAUDE_FIRST_PARTY_AUTH_REMEDIATION}`
 
 /**
  * Actionable readiness-failure copy when Claude reports Amazon Bedrock as the
@@ -49,8 +52,7 @@ export const CLAUDE_UNAUTHENTICATED_MESSAGE =
  * Primary action is AWS credentials/region — this path already implies Bedrock
  * mode — not first-party login (issue #802 / epic #799).
  */
-export const CLAUDE_BEDROCK_UNAVAILABLE_MESSAGE =
-  "Claude Code Amazon Bedrock is not ready. Ensure valid AWS credentials and region are available to the harness process (with CLAUDE_CODE_USE_BEDROCK=1), then Recheck Agent Backend."
+export const CLAUDE_BEDROCK_UNAVAILABLE_MESSAGE = `Claude Code Amazon Bedrock is not ready. ${CLAUDE_BEDROCK_CREDENTIAL_REMEDIATION}`
 
 /** Official Thinking Levels for Claude Code v1 (ADR 0047). No `ultracode`. */
 export const CLAUDE_THINKING_LEVELS = [

--- a/packages/claude/test/claude.spec.ts
+++ b/packages/claude/test/claude.spec.ts
@@ -852,6 +852,46 @@ describe("Claude AgentBackend adapter (Agent Turns)", () => {
     )
   })
 
+  it("classifies a stderr-only expired credential exit as terminal_auth_error", async () => {
+    await withExecutable(
+      [
+        captureSessionScript,
+        "printf 'ExpiredTokenException: The security token included in the request is expired\\n' >&2",
+        "exit 1",
+      ].join("\n"),
+      async (binary) => {
+        const error = await Effect.runPromise(
+          startTurn(binary, "2 seconds").pipe(Effect.flip),
+        )
+        expect(error).toBeInstanceOf(AgentBackendExitError)
+        if (error instanceof AgentBackendExitError) {
+          expect(error.classification).toBe("terminal_auth_error")
+          expect(error.message).toContain("security token")
+        }
+      },
+    )
+  })
+
+  it("classifies a result is_error credential failure as terminal_auth_error", async () => {
+    await withExecutable(
+      [
+        captureSessionScript,
+        `printf '%s\\n' "{\\"type\\":\\"result\\",\\"subtype\\":\\"error\\",\\"session_id\\":\\"$sid\\",\\"is_error\\":true,\\"error\\":\\"Unable to locate credentials\\"}"`,
+        "exit 1",
+      ].join("\n"),
+      async (binary) => {
+        const error = await Effect.runPromise(
+          startTurn(binary, "2 seconds").pipe(Effect.flip),
+        )
+        expect(error).toBeInstanceOf(AgentBackendExitError)
+        if (error instanceof AgentBackendExitError) {
+          expect(error.classification).toBe("terminal_auth_error")
+          expect(error.message).toBe("Unable to locate credentials")
+        }
+      },
+    )
+  })
+
   it("maps result is_error to exit failure with known session", async () => {
     await withExecutable(
       [

--- a/packages/codex/test/codex.spec.ts
+++ b/packages/codex/test/codex.spec.ts
@@ -410,6 +410,26 @@ describe("Codex AgentBackend adapter (Agent Turns)", () => {
     )
   })
 
+  it("classifies a turn.failed credential rejection as terminal_auth_error", async () => {
+    await withExecutable(
+      [
+        `printf '%s\\n' '{"type":"thread.started","thread_id":"auth-thread"}'`,
+        `printf '%s\\n' '{"type":"turn.failed","error":{"message":"ExpiredToken: token has expired"}}'`,
+        "exit 1",
+      ].join("\n"),
+      async (binary) => {
+        const error = await Effect.runPromise(
+          startTurn(binary, "2 seconds").pipe(Effect.flip),
+        )
+        expect(error).toBeInstanceOf(AgentBackendExitError)
+        if (error instanceof AgentBackendExitError) {
+          expect(error.classification).toBe("terminal_auth_error")
+          expect(error.message).toBe("ExpiredToken: token has expired")
+        }
+      },
+    )
+  })
+
   it("maps turn.failed to exit failure with observed session", async () => {
     await withExecutable(
       [

--- a/packages/grok/test/grok.spec.ts
+++ b/packages/grok/test/grok.spec.ts
@@ -370,6 +370,27 @@ describe("Grok AgentBackend adapter", () => {
     )
   })
 
+  it("classifies a stream credential error as terminal_auth_error", async () => {
+    await withExecutable(
+      [
+        captureSessionScript,
+        `printf '%s\\n' '{"type":"error","message":"Unable to locate credentials"}'`,
+        `printf '%s\\n' "{\\"type\\":\\"end\\",\\"stopReason\\":\\"EndTurn\\",\\"sessionId\\":\\"$sid\\"}"`,
+        "exit 1",
+      ].join("\n"),
+      async (binary) => {
+        const error = await Effect.runPromise(
+          startTurn(binary, "2 seconds").pipe(Effect.flip),
+        )
+        expect(error).toBeInstanceOf(AgentBackendExitError)
+        if (error instanceof AgentBackendExitError) {
+          expect(error.classification).toBe("terminal_auth_error")
+          expect(error.message).toBe("Unable to locate credentials")
+        }
+      },
+    )
+  })
+
   it("maps stream error events to exit failure with the reported reason", async () => {
     await withExecutable(
       [

--- a/packages/work-item-lifecycle/src/lib/active-agent-backend-test.ts
+++ b/packages/work-item-lifecycle/src/lib/active-agent-backend-test.ts
@@ -28,12 +28,13 @@ const runtimeStatus = (
   models: AgentBackendRuntimeStatus["models"] = [],
   kind: AgentBackendRuntimeStatus["kind"] = "ready",
   reason: string | null = null,
+  provider: AgentBackendRuntimeStatus["provider"] = null,
 ): AgentBackendRuntimeStatus => ({
   backend: registration.descriptor,
   kind,
   reason: kind === "unavailable" ? (reason ?? "unavailable") : null,
   models: kind === "unavailable" ? [] : models,
-  provider: null,
+  provider,
   warnings: [],
 })
 
@@ -64,6 +65,8 @@ export const stubActiveAgentBackendLayer = (
      */
     readonly newlyActivatedKind?: AgentBackendRuntimeStatus["kind"]
     readonly newlyActivatedReason?: string
+    /** Cached inspect provider reported on every Ready status. */
+    readonly provider: AgentBackendRuntimeStatus["provider"]
     readonly getStatus: Effect.Effect<AgentBackendStatus>
     readonly requireAgentTurnsAllowed: Effect.Effect<
       void,
@@ -97,7 +100,13 @@ export const stubActiveAgentBackendLayer = (
     allRegistrations.map((entry) => [entry.descriptor.id, entry] as const),
   )
   const readyFor = (entry: AgentBackendRegistration) =>
-    runtimeStatus(entry, overrides.models ?? [])
+    runtimeStatus(
+      entry,
+      overrides.models ?? [],
+      "ready",
+      null,
+      overrides.provider ?? null,
+    )
   const allReady = allRegistrations.map(readyFor)
   const activeIds = new Set<AgentBackendId>(byId.keys())
   const legacyStatus =
@@ -176,7 +185,7 @@ export const stubActiveAgentBackendLayer = (
           kind: "ready" as const,
           reason: null,
           models: overrides.models ?? [],
-          provider: null,
+          provider: overrides.provider ?? null,
           warnings: [],
         }),
       withConfigCoordination: (effect) => effect,

--- a/packages/work-item-lifecycle/src/lib/types.ts
+++ b/packages/work-item-lifecycle/src/lib/types.ts
@@ -375,6 +375,12 @@ export const STEP_RUN_REASON = {
   waitingForAgentTurn: "waiting_for_agent_turn",
   /** Agent-dependent step blocked because Active Agent Backend is unavailable. */
   agentBackendUnavailable: "agent_backend_unavailable",
+  /**
+   * Agent Turn failed because the backend provider rejected credentials
+   * (missing, expired, or invalid). Distinct from handler_failed so the
+   * outage is queryable (issue #1058).
+   */
+  agentBackendAuthRejected: "agent_backend_auth_rejected",
   /** Agent-dependent step blocked because no build Agent Model is configured. */
   buildModelNotConfigured: "build_model_not_configured",
   /**

--- a/packages/work-item-lifecycle/src/lib/work-item-lifecycle.ts
+++ b/packages/work-item-lifecycle/src/lib/work-item-lifecycle.ts
@@ -17,8 +17,12 @@ import type { SqlError } from "effect/unstable/sql/SqlError"
 import {
   ActiveAgentBackend,
   type AgentBackendId,
+  type AgentBackendProvider,
   agentBackendLabel,
+  classifyProviderCredentialText,
+  findAgentBackendExitError,
   findAgentBackendNotInstalledError,
+  formatTerminalAuthErrorMessage,
   isSelectableAgentBackendId,
 } from "@ready-for-agent/agent-backend"
 import {
@@ -243,8 +247,45 @@ const closeIssueEligibilityFailure = (
   return null
 }
 
+const resolveTerminalAuthProvider = (input: {
+  readonly backendId: string | undefined
+  readonly cachedProvider: AgentBackendProvider | null | undefined
+  readonly textProvider: AgentBackendProvider | null
+}): AgentBackendProvider | null => {
+  if (input.cachedProvider != null) {
+    return input.cachedProvider
+  }
+  // Claude's only AWS-hosted path is Amazon Bedrock; do not leave the
+  // operator guessing between first-party Anthropic and Bedrock.
+  if (input.backendId === "claude" && input.textProvider?.id === "aws") {
+    return { id: "bedrock", label: "Amazon Bedrock" }
+  }
+  return input.textProvider
+}
+
+const terminalAuthFromCause = (
+  error: unknown,
+): { readonly provider: AgentBackendProvider | null } | undefined => {
+  const exitError = findAgentBackendExitError(error)
+  const fromText =
+    exitError?.message !== undefined
+      ? classifyProviderCredentialText(exitError.message)
+      : undefined
+  if (
+    exitError?.classification === "terminal_auth_error" ||
+    fromText !== undefined
+  ) {
+    return { provider: fromText?.provider ?? null }
+  }
+  return undefined
+}
+
 const classifyHandlerFailure = (
   cause: Cause.Cause<HandlerExitError>,
+  context: {
+    readonly backendId?: string
+    readonly provider?: AgentBackendProvider | null
+  } = {},
 ): {
   readonly reasonCode: string
   readonly reasonMessage: string
@@ -265,6 +306,24 @@ const classifyHandlerFailure = (
       return {
         reasonCode: STEP_RUN_REASON.agentBackendUnavailable,
         reasonMessage: notInstalled.message,
+      }
+    }
+    const auth = terminalAuthFromCause(error)
+    if (auth !== undefined) {
+      const backendId = context.backendId
+      return {
+        reasonCode: STEP_RUN_REASON.agentBackendAuthRejected,
+        reasonMessage: formatTerminalAuthErrorMessage({
+          backendLabel:
+            backendId !== undefined && backendId.length > 0
+              ? agentBackendLabel(backendId)
+              : "Agent Backend",
+          provider: resolveTerminalAuthProvider({
+            backendId,
+            cachedProvider: context.provider,
+            textProvider: auth.provider,
+          }),
+        }),
       }
     }
     if (Predicate.isTagged(error, "TimeoutError")) {
@@ -4319,8 +4378,25 @@ export const makeWorkItemLifecycleLive = (
                         workItem: postponed,
                       }
                     }
+                    const capturedBackendId = isSelectableAgentBackendId(
+                      workItem.agent_backend,
+                    )
+                      ? (workItem.agent_backend as AgentBackendId)
+                      : undefined
+                    const capturedStatus =
+                      capturedBackendId === undefined
+                        ? null
+                        : yield* activeAgentBackend.getBackendStatus(
+                            capturedBackendId,
+                          )
                     const classification = classifyHandlerFailure(
                       handlerExit.cause,
+                      {
+                        ...(capturedBackendId !== undefined
+                          ? { backendId: capturedBackendId }
+                          : {}),
+                        provider: capturedStatus?.provider ?? null,
+                      },
                     )
                     const notInstalled = findAgentBackendNotInstalledError(
                       Cause.squash(handlerExit.cause),

--- a/packages/work-item-lifecycle/test/terminal-auth-error.spec.ts
+++ b/packages/work-item-lifecycle/test/terminal-auth-error.spec.ts
@@ -1,0 +1,276 @@
+import { Effect, Layer } from "effect"
+import {
+  AGENT_BACKEND_IDS,
+  AgentBackendExitError,
+  CLAUDE_BEDROCK_CREDENTIAL_REMEDIATION,
+  CLAUDE_FIRST_PARTY_AUTH_REMEDIATION,
+  getBuiltInAgentBackend,
+} from "@ready-for-agent/agent-backend"
+import { DatabaseTest } from "@ready-for-agent/db/test"
+import { DbService, DbServiceLive } from "@ready-for-agent/db-service"
+import { SqliteQueueServiceLive } from "@ready-for-agent/sqlite-queue-service"
+import {
+  ImplementOpenCodeError,
+  LifecycleSteps,
+  type LifecycleStepsShape,
+  STEP_RUN_REASON,
+  WorkItemLifecycle,
+  WorkItemLifecycleLive,
+  stubActiveAgentBackendLayer,
+  stubGitHubServiceLayer,
+  stubGitLabServiceLayer,
+} from "../src/index.js"
+import { describe, expect, it } from "bun:test"
+
+const claudeRegistration = getBuiltInAgentBackend(AGENT_BACKEND_IDS.claude)
+if (claudeRegistration === undefined) {
+  throw new Error("Claude Agent Backend registration is missing")
+}
+
+const successfulSteps: LifecycleStepsShape = {
+  createWorktree: () =>
+    Effect.succeed({
+      worktreePath: "/tmp/worktrees/acme-widgets-42",
+      startingCommitOid: "abc123",
+    }),
+  installDependencies: () => Effect.void,
+  implement: () => Effect.succeed("ses_test"),
+  assessChanges: () => Effect.succeed({ _tag: "changes" }),
+  preCommit: () => Effect.void,
+  review: () => Effect.succeed({ _tag: "clean" as const }),
+  commit: () =>
+    Effect.succeed({
+      completion: "native" as const,
+      publicationTitle: "feat: test",
+      publicationBody: "Why\n\nCloses #1",
+    }),
+  createPr: () =>
+    Effect.succeed({
+      pullRequestNumber: 101,
+      completion: "native" as const,
+      publicationTitle: "feat: test",
+      publicationBody: "Why\n\nCloses #1",
+    }),
+  watchPrStatusChecks: () =>
+    Effect.succeed({
+      _tag: "succeeded",
+      createdAt: new Date(0),
+      headSha: "head",
+      headPushedAt: new Date(0),
+      isDraft: false,
+    }),
+  resolvePrMergeConflict: () => Effect.succeed({ _tag: "processed" }),
+  investigatePrStatusChecks: () =>
+    Effect.succeed({ _tag: "processed", handledCheckIds: [] }),
+  markPrReadyForReview: () => Effect.void,
+  decidePrMerge: () => Effect.succeed({ _tag: "clanker_merge" }),
+  mergePr: () => Effect.succeed({ _tag: "merged" }),
+  closeIssue: () => Effect.void,
+  localCleanup: () => Effect.void,
+  removeWorktree: () => Effect.void,
+}
+
+const lifecycleLayer = (steps: LifecycleStepsShape) =>
+  WorkItemLifecycleLive.pipe(
+    Layer.provideMerge(
+      stubActiveAgentBackendLayer({ registration: claudeRegistration }),
+    ),
+    Layer.provideMerge(stubGitHubServiceLayer()),
+    Layer.provideMerge(stubGitLabServiceLayer()),
+    Layer.provideMerge(Layer.succeed(LifecycleSteps, LifecycleSteps.of(steps))),
+    Layer.provideMerge(DbServiceLive),
+    Layer.provideMerge(SqliteQueueServiceLive),
+    Layer.provideMerge(DatabaseTest),
+  )
+
+const seedImplementRun = Effect.gen(function* () {
+  const db = yield* DbService
+  const lifecycle = yield* WorkItemLifecycle
+  const repo = yield* db.addRepository({
+    forge: "github",
+    forgeHost: "github.com",
+    projectPath: "acme/widgets",
+    localPath: "/repos/acme/widgets.git",
+    isBare: true,
+  })
+  yield* db.updateConfig({
+    selectedAgentBackend: "claude",
+    defaultModel: "sonnet",
+    defaultThinkingLevel: "low",
+    reviewModel: null,
+    reviewThinkingLevel: null,
+    maxConcurrentAgentTurns: 2,
+    maxConcurrentWorkItems: 5,
+  })
+  yield* db.storeIssue({
+    repositoryId: repo.id,
+    issueNumber: 1,
+    title: "Issue",
+    body: "body",
+    url: "https://github.com/acme/widgets/issues/1",
+    state: "OPEN",
+    githubCreatedAt: new Date(),
+    issueAuthor: null,
+    parent: null,
+    parentPosition: null,
+    hasChildren: false,
+    blockedBy: [],
+  })
+  const created = yield* lifecycle.implementNow(repo.id, 1)
+  const createRun = created.stepRuns[0]
+  if (createRun === undefined) {
+    throw new Error("expected create_worktree Step Run")
+  }
+  const afterCreate = yield* lifecycle.runStep(createRun.id)
+  if (afterCreate._tag !== "processed") {
+    throw new Error("expected create_worktree to process")
+  }
+  const installRun = afterCreate.workItem.stepRuns.find(
+    (run) => run.step === "install_dependencies",
+  )
+  if (installRun === undefined) {
+    throw new Error("expected install_dependencies Step Run")
+  }
+  const afterInstall = yield* lifecycle.runStep(installRun.id)
+  if (afterInstall._tag !== "processed") {
+    throw new Error("expected install_dependencies to process")
+  }
+  const implementRun = afterInstall.workItem.stepRuns.find(
+    (run) => run.step === "implement",
+  )
+  if (implementRun === undefined) {
+    throw new Error("expected implement Step Run")
+  }
+  return { implementRunId: implementRun.id }
+})
+
+const wrappedExit = (message: string, classification?: "terminal_auth_error") =>
+  new ImplementOpenCodeError({
+    message: "Claude Code fallback failed to install dependencies",
+    worktreePath: "/tmp/worktrees/acme-widgets-42",
+    cause: AgentBackendExitError.new({
+      exitCode: 1,
+      cwd: "/tmp/worktrees/acme-widgets-42",
+      message,
+      ...(classification !== undefined ? { classification } : {}),
+    }),
+  })
+
+describe("terminal_auth_error Step Run classification (issue #1058)", () => {
+  it("records a dedicated reason and Bedrock remediation for expired AWS credentials", async () => {
+    const secret = "AKIAIOSFODNN7EXAMPLE"
+    const steps: LifecycleStepsShape = {
+      ...successfulSteps,
+      implement: () =>
+        Effect.fail(
+          wrappedExit(
+            `ExpiredTokenException: The security token included in the request is expired (${secret})`,
+          ),
+        ),
+    }
+
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        const lifecycle = yield* WorkItemLifecycle
+        const seeded = yield* seedImplementRun
+        const result = yield* lifecycle.runStep(seeded.implementRunId)
+        expect(result._tag).toBe("processed")
+        if (result._tag !== "processed") {
+          return
+        }
+        const failed = result.workItem.stepRuns.find(
+          (run) => run.id === seeded.implementRunId,
+        )
+        expect(failed?.status).toBe("failed")
+        expect(failed?.reasonCode).toBe(
+          STEP_RUN_REASON.agentBackendAuthRejected,
+        )
+        expect(failed?.reasonMessage).toBe(
+          `Claude Code could not authenticate to Amazon Bedrock (credentials missing or expired). ${CLAUDE_BEDROCK_CREDENTIAL_REMEDIATION}`,
+        )
+        expect(failed?.reasonMessage).toContain("Recheck Agent Backend")
+        expect(failed?.reasonMessage).not.toContain(secret)
+        expect(failed?.reasonMessage?.toLowerCase()).not.toContain(
+          "aws sso login",
+        )
+      }).pipe(Effect.provide(lifecycleLayer(steps))),
+    )
+  })
+
+  it("names first-party Claude remediation when that provider is reported", async () => {
+    const steps: LifecycleStepsShape = {
+      ...successfulSteps,
+      implement: () =>
+        Effect.fail(wrappedExit("ProviderAuthError", "terminal_auth_error")),
+    }
+
+    const firstPartyLayer = WorkItemLifecycleLive.pipe(
+      Layer.provideMerge(
+        stubActiveAgentBackendLayer({
+          registration: claudeRegistration,
+          provider: { id: "firstParty", label: "First-party" },
+        }),
+      ),
+      Layer.provideMerge(stubGitHubServiceLayer()),
+      Layer.provideMerge(stubGitLabServiceLayer()),
+      Layer.provideMerge(
+        Layer.succeed(LifecycleSteps, LifecycleSteps.of(steps)),
+      ),
+      Layer.provideMerge(DbServiceLive),
+      Layer.provideMerge(SqliteQueueServiceLive),
+      Layer.provideMerge(DatabaseTest),
+    )
+
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        const lifecycle = yield* WorkItemLifecycle
+        const seeded = yield* seedImplementRun
+        const result = yield* lifecycle.runStep(seeded.implementRunId)
+        expect(result._tag).toBe("processed")
+        if (result._tag !== "processed") {
+          return
+        }
+        const failed = result.workItem.stepRuns.find(
+          (run) => run.id === seeded.implementRunId,
+        )
+        expect(failed?.reasonCode).toBe(
+          STEP_RUN_REASON.agentBackendAuthRejected,
+        )
+        expect(failed?.reasonMessage).toContain("Claude Code")
+        expect(failed?.reasonMessage).toContain(
+          CLAUDE_FIRST_PARTY_AUTH_REMEDIATION,
+        )
+      }).pipe(Effect.provide(firstPartyLayer)),
+    )
+  })
+
+  it("keeps an unrecognized turn failure on handler_failed", async () => {
+    const steps: LifecycleStepsShape = {
+      ...successfulSteps,
+      implement: () =>
+        Effect.fail(
+          wrappedExit("Claude Code fallback failed to install dependencies"),
+        ),
+    }
+
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        const lifecycle = yield* WorkItemLifecycle
+        const seeded = yield* seedImplementRun
+        const result = yield* lifecycle.runStep(seeded.implementRunId)
+        expect(result._tag).toBe("processed")
+        if (result._tag !== "processed") {
+          return
+        }
+        const failed = result.workItem.stepRuns.find(
+          (run) => run.id === seeded.implementRunId,
+        )
+        expect(failed?.status).toBe("failed")
+        expect(failed?.reasonCode).toBe(STEP_RUN_REASON.handlerFailed)
+        expect(failed?.reasonMessage).toBe(
+          "Claude Code fallback failed to install dependencies",
+        )
+      }).pipe(Effect.provide(lifecycleLayer(steps))),
+    )
+  })
+})


### PR DESCRIPTION
When an Agent Backend rejected credentials mid-turn (the originating case: expired AWS/Bedrock
tokens on Claude Code), the process often exited with the only explanation on stderr. The Work Item
then failed as generic `handler_failed` with copy such as "Claude Code fallback failed to install
dependencies". Credential outages were not queryable and the card did not say what to do.

This change extracts the AWS/Bedrock credential markers and secret scrubbing into one shared
classifier. Bedrock catalog discovery consumes that classifier (discovery stays non-fatal).
`AgentBackendExitError` now sets `classification: terminal_auth_error` from failure text when the
adapter did not already classify the exit, covering Claude stderr/`is_error`, Codex `turn.failed`,
and Grok stream errors. OpenCode's structured `ProviderAuthError` is left as-is.

`classifyHandlerFailure` maps `terminal_auth_error` to a new hand-written Step Run reason
`agent_backend_auth_rejected` (not an ontology change). The Work Item status message names the
backend and, when known, the provider, and reuses the existing Claude readiness remediations.
Unrecognized failures still fall through to `handler_failed`. Secrets are scrubbed so they cannot
reach the operator-facing message.

Out of scope: flipping Agent Backend runtime status or triggering Recheck (#1059).

Verified with unit tests for the classifier, exit-error sanitization, Claude/Codex/Grok turns,
Bedrock discovery, and lifecycle mapping, plus `nx affected` lint, typecheck, and test.

Closes #1058