### PR TITLE
fix(agent-backend): include bounded stderr on failed readiness inspections

### DIFF
--- a/packages/agent-backend/src/lib/cli-runner.ts
+++ b/packages/agent-backend/src/lib/cli-runner.ts
@@ -8,7 +8,6 @@ import {
 } from "./agent-cli-not-found.js"
 import {
   collectChildStderrTail,
-  collectChildStdout,
   collectChildStdoutAndStderr,
 } from "./collect-child-stdout.js"
 import {
@@ -30,12 +29,13 @@ export const DEFAULT_FORCE_KILL_AFTER = Duration.seconds(2)
 const capturedCliOutputMessage = (
   stdout: string,
   stderr: string,
-): string | undefined => {
-  const parts = [stdout, stderr]
-    .map((part) => part.trim())
-    .filter((part) => part.length > 0)
-  return parts.length > 0 ? parts.join("\n") : undefined
-}
+): string | undefined =>
+  sanitizeAgentBackendStderrTail(
+    [stdout, stderr]
+      .map((part) => part.trim())
+      .filter((part) => part.length > 0)
+      .join("\n"),
+  )
 
 /**
  * Window from spawn to the first stdout output of an Agent Turn. A CLI that
@@ -94,9 +94,8 @@ export type RunCliCaptureInput = {
    */
   readonly allowNonZeroExit?: boolean
   /**
-   * When true, pipe and capture stderr (returned as `stderr`). Default ignores
-   * stderr so Agent Turn noise does not fill memory. Readiness probes that
-   * print status on stderr (Codex `login status`) must opt in.
+   * Accepted for callers that previously opted into stderr capture. Readiness
+   * probes always pipe and retain a bounded stderr tail; this flag is ignored.
    */
   readonly captureStderr?: boolean
 }
@@ -202,7 +201,7 @@ const terminateCliTree = (
   )
 
 /**
- * Run a CLI once, capture full stdout (and optionally stderr), map non-zero
+ * Run a CLI once, capture full stdout and a bounded stderr tail, map non-zero
  * exit and timeout to generic Agent Backend errors.
  */
 export const runCliCapture = (
@@ -222,11 +221,10 @@ export const runCliCapture = (
     const spawner = input.spawner
     const timeoutMs = Duration.toMillis(input.timeout)
     const forceKillAfter = input.forceKillAfter ?? DEFAULT_FORCE_KILL_AFTER
-    const captureStderr = input.captureStderr === true
     const command = ChildProcess.make(
       input.binary,
       [...input.args],
-      commandOptions(input),
+      commandOptions({ ...input, captureStderr: true }),
     )
 
     const result = yield* Effect.scoped(
@@ -239,15 +237,7 @@ export const runCliCapture = (
         yield* Effect.addFinalizer(() =>
           terminateCliTree(handle, forceKillAfter),
         )
-        if (captureStderr) {
-          return yield* collectChildStdoutAndStderr(handle)
-        }
-        const captured = yield* collectChildStdout(handle)
-        return {
-          exitCode: captured.exitCode,
-          stdout: captured.stdout,
-          stderr: "",
-        }
+        return yield* collectChildStdoutAndStderr(handle)
       }),
     ).pipe(
       Effect.timeout(input.timeout),

--- a/packages/agent-backend/src/lib/collect-child-stdout.ts
+++ b/packages/agent-backend/src/lib/collect-child-stdout.ts
@@ -3,27 +3,6 @@ import type { PlatformError } from "effect/PlatformError"
 import type { ChildProcessHandle } from "effect/unstable/process/ChildProcessSpawner"
 
 /**
- * Drain stdout to EOF, then read exit code.
- *
- * Collecting stdout before relying on process exit avoids races where scope
- * finalization or pipe teardown can clip large catalogs near OS pipe capacity.
- */
-export const collectChildStdout = (
-  handle: ChildProcessHandle,
-): Effect.Effect<
-  { readonly exitCode: number; readonly stdout: string },
-  PlatformError
-> =>
-  Effect.gen(function* () {
-    const stdout = yield* Stream.decodeText(handle.stdout).pipe(Stream.mkString)
-    const exitCode = yield* handle.exitCode
-    return {
-      exitCode: Number(exitCode),
-      stdout,
-    }
-  })
-
-/**
  * Memory bound for an Agent Turn stderr fold. Only this many characters
  * are retained; older output is dropped. Matches the Install Dependencies
  * diagnostic tail so a chatty CLI cannot grow unbounded.
@@ -59,11 +38,13 @@ export const collectChildStderrTail = (
   )
 
 /**
- * Drain stdout and stderr concurrently to EOF, then read exit code.
+ * Drain full stdout and a bounded stderr tail concurrently, then read exit.
  *
  * Concurrent drain avoids pipe-buffer deadlock when both streams produce
- * output. Used by readiness probes whose CLIs print status on stderr
- * (e.g. `codex login status`).
+ * output. Stdout is collected to EOF before relying on process exit so a
+ * large catalog cannot be clipped by pipe teardown. Stderr is folded to the
+ * same 4000-character tail as Agent Turns so a chatty probe cannot grow
+ * unbounded. Used by every readiness probe.
  */
 export const collectChildStdoutAndStderr = (
   handle: ChildProcessHandle,
@@ -79,7 +60,7 @@ export const collectChildStdoutAndStderr = (
     const [stdout, stderr] = yield* Effect.all(
       [
         Stream.decodeText(handle.stdout).pipe(Stream.mkString),
-        Stream.decodeText(handle.stderr).pipe(Stream.mkString),
+        collectChildStderrTail(handle),
       ],
       { concurrency: 2 },
     )

--- a/packages/agent-backend/test/cli-runner.spec.ts
+++ b/packages/agent-backend/test/cli-runner.spec.ts
@@ -231,6 +231,166 @@ describe("runCliCapture", () => {
       },
     )
   })
+
+  it("puts a stderr-only inspection failure on AgentBackendExitError", async () => {
+    await withExecutable(
+      [
+        "printf 'Error: Configuration is invalid at /home/vscode/.config/opencode/opencode.jsonc\\n' >&2",
+        "printf '↳ Expected object | undefined, got [ … ] skills\\n' >&2",
+        "exit 1",
+      ].join("\n"),
+      async (binary) => {
+        const error = await Effect.runPromise(
+          withSpawner((spawner) =>
+            runCliCapture({
+              spawner,
+              backend: TEST_BACKEND,
+              binary,
+              args: [],
+              cwd: process.cwd(),
+              env: sanitizeInheritedEnvironment(),
+              timeout: Duration.seconds(2),
+            }).pipe(Effect.flip),
+          ),
+        )
+        expect(error).toEqual(
+          AgentBackendExitError.new({
+            exitCode: 1,
+            cwd: process.cwd(),
+            message:
+              "Error: Configuration is invalid at /home/vscode/.config/opencode/opencode.jsonc\n↳ Expected object | undefined, got [ … ] skills",
+          }),
+        )
+      },
+    )
+  })
+
+  it("bounds retained inspection stderr when a chatty probe is allowed to exit non-zero", async () => {
+    await withExecutable(
+      [
+        "printf 'prefix-marker' >&2",
+        "printf '%05000d' 0 >&2",
+        "printf 'tail-marker' >&2",
+        "exit 1",
+      ].join("\n"),
+      async (binary) => {
+        const result = await Effect.runPromise(
+          withSpawner((spawner) =>
+            runCliCapture({
+              spawner,
+              backend: TEST_BACKEND,
+              binary,
+              args: [],
+              cwd: process.cwd(),
+              env: sanitizeInheritedEnvironment(),
+              timeout: Duration.seconds(5),
+              allowNonZeroExit: true,
+            }),
+          ),
+        )
+        expect(result.exitCode).toBe(1)
+        expect(result.stderr).toContain("tail-marker")
+        expect(result.stderr).not.toContain("prefix-marker")
+        expect(result.stderr.length).toBeLessThanOrEqual(4_000)
+      },
+    )
+  })
+
+  it("completes an inspection that floods stderr and keeps the diagnostic tail", async () => {
+    await withExecutable(
+      [
+        "printf 'prefix-marker' >&2",
+        "printf '%05000d' 0 >&2",
+        "printf 'tail-marker' >&2",
+        "exit 1",
+      ].join("\n"),
+      async (binary) => {
+        const error = await Effect.runPromise(
+          withSpawner((spawner) =>
+            runCliCapture({
+              spawner,
+              backend: TEST_BACKEND,
+              binary,
+              args: [],
+              cwd: process.cwd(),
+              env: sanitizeInheritedEnvironment(),
+              timeout: Duration.seconds(5),
+            }).pipe(Effect.flip),
+          ),
+        )
+        expect(error).toBeInstanceOf(AgentBackendExitError)
+        if (error instanceof AgentBackendExitError) {
+          expect(error.message).toContain("tail-marker")
+          expect(error.message).not.toContain("prefix-marker")
+          expect(error.message.length).toBeLessThanOrEqual(500)
+        }
+      },
+    )
+  })
+
+  it("sanitizes inspection stderr before it becomes the exit message", async () => {
+    const secret = "ghp_this_must_never_appear_in_exit_message"
+    const esc = String.fromCharCode(0x1b)
+    await withExecutable(
+      [
+        `printf '${esc}[31mconfig invalid with ${secret}${esc}[0m\\n' >&2`,
+        "exit 1",
+      ].join("\n"),
+      async (binary) => {
+        const error = await Effect.runPromise(
+          withSpawner((spawner) =>
+            runCliCapture({
+              spawner,
+              backend: TEST_BACKEND,
+              binary,
+              args: [],
+              cwd: process.cwd(),
+              env: sanitizeInheritedEnvironment(),
+              timeout: Duration.seconds(2),
+            }).pipe(Effect.flip),
+          ),
+        )
+        expect(error).toBeInstanceOf(AgentBackendExitError)
+        if (error instanceof AgentBackendExitError) {
+          expect(error.message).not.toContain(secret)
+          expect(error.message).not.toMatch(/ghp_[A-Za-z0-9]+/)
+          expect(error.message).toContain("[redacted]")
+          expect(error.message.includes(`${esc}[`)).toBe(false)
+          expect(error.message).toContain("config invalid")
+        }
+      },
+    )
+  })
+
+  it("keeps a large stdout catalog complete while draining stderr", async () => {
+    await withExecutable(
+      [
+        "printf '%070000d' 0",
+        "printf 'end-of-catalog'",
+        "printf 'noise' >&2",
+        "exit 0",
+      ].join("\n"),
+      async (binary) => {
+        const result = await Effect.runPromise(
+          withSpawner((spawner) =>
+            runCliCapture({
+              spawner,
+              backend: TEST_BACKEND,
+              binary,
+              args: [],
+              cwd: process.cwd(),
+              env: sanitizeInheritedEnvironment(),
+              timeout: Duration.seconds(5),
+            }),
+          ),
+        )
+        expect(result.exitCode).toBe(0)
+        expect(result.stdout.length).toBe(70_000 + "end-of-catalog".length)
+        expect(result.stdout.endsWith("end-of-catalog")).toBe(true)
+        expect(result.stderr).toContain("noise")
+      },
+    )
+  })
 })
 
 describe("runCliTurn", () => {

--- a/packages/agent-backend/test/inspect-stderr-preview.spec.ts
+++ b/packages/agent-backend/test/inspect-stderr-preview.spec.ts
@@ -1,0 +1,115 @@
+import { chmod, mkdtemp, rm, writeFile } from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { BunServices } from "@effect/platform-bun"
+import { Duration, Effect, Layer } from "effect"
+import { ChildProcessSpawner } from "effect/unstable/process"
+import {
+  AGENT_BACKEND_IDS,
+  ActiveAgentBackend,
+  ActiveAgentBackendLive,
+  type ResolveAgentBackendRuntime,
+  getBuiltInAgentBackend,
+  runCliCapture,
+  sanitizeInheritedEnvironment,
+  unsupportedSessionTelemetry,
+} from "../src/index.js"
+import { describe, expect, it } from "bun:test"
+
+const withExecutable = async <A>(
+  body: string,
+  use: (path: string) => Promise<A>,
+): Promise<A> => {
+  const directory = await mkdtemp(join(tmpdir(), "agent-backend-inspect-"))
+  const path = join(directory, "fake-cli")
+  try {
+    await writeFile(path, `#!/bin/sh\n${body}\n`)
+    await chmod(path, 0o700)
+    return await use(path)
+  } finally {
+    await rm(directory, { recursive: true, force: true })
+  }
+}
+
+const resolveCaptureRuntime =
+  (binary: string): ResolveAgentBackendRuntime =>
+  (backendId) =>
+    Effect.gen(function* () {
+      const spawner = yield* ChildProcessSpawner.ChildProcessSpawner
+      const found = getBuiltInAgentBackend(backendId)
+      if (found === undefined) {
+        throw new Error(`missing registration ${backendId}`)
+      }
+      return {
+        registration: found,
+        adapter: {
+          inspect: (input) =>
+            runCliCapture({
+              spawner,
+              backend: found.descriptor,
+              binary,
+              args: [],
+              cwd: input.cwd,
+              env: sanitizeInheritedEnvironment(),
+              timeout: input.timeout ?? Duration.seconds(2),
+            }).pipe(
+              Effect.map(() => ({
+                backend: found.descriptor,
+                models: [],
+              })),
+            ),
+          startTurn: () =>
+            Effect.die("startTurn is not part of this inspect fixture"),
+          continueTurn: () =>
+            Effect.die("continueTurn is not part of this inspect fixture"),
+        },
+        telemetry: {
+          getSession: (sessionId: string) =>
+            Effect.succeed(
+              unsupportedSessionTelemetry(sessionId, found.descriptor),
+            ),
+        },
+      }
+    })
+
+describe("Preview and Recheck inspect stderr", () => {
+  it("propagates a stderr-only child failure as the Unavailable reason", async () => {
+    await withExecutable(
+      [
+        "printf 'Error: Configuration is invalid at /home/vscode/.config/opencode/opencode.jsonc\\n' >&2",
+        "printf '↳ Expected object | undefined, got [ … ] skills\\n' >&2",
+        "exit 1",
+      ].join("\n"),
+      async (binary) => {
+        const layer = ActiveAgentBackendLive({
+          selectedBackendId: AGENT_BACKEND_IDS.opencode,
+          resolveRuntime: resolveCaptureRuntime(binary),
+        }).pipe(Layer.provide(BunServices.layer))
+
+        await Effect.runPromise(
+          Effect.gen(function* () {
+            const active = yield* ActiveAgentBackend
+            const preview = yield* active.preview(AGENT_BACKEND_IDS.opencode, {
+              cwd: process.cwd(),
+            })
+            const recheck = yield* active.recheck(AGENT_BACKEND_IDS.opencode, {
+              cwd: process.cwd(),
+            })
+
+            expect(preview.kind).toBe("unavailable")
+            expect(preview.reason).toContain(
+              "Configuration is invalid at /home/vscode/.config/opencode/opencode.jsonc",
+            )
+            expect(preview.reason).toContain("skills")
+            expect(preview.reason).not.toBe(
+              "Agent Backend inspection failed (AgentBackendExitError)",
+            )
+
+            expect(recheck.kind).toBe("unavailable")
+            expect(recheck.reason).toBe(preview.reason)
+          }).pipe(Effect.provide(layer)),
+        )
+      },
+    )
+  })
+})

--- a/packages/claude/test/claude.spec.ts
+++ b/packages/claude/test/claude.spec.ts
@@ -436,6 +436,25 @@ describe("Claude AgentBackend adapter (readiness inspection)", () => {
     )
   })
 
+  it("prefers parsed unauthenticated copy over raw stderr noise", async () => {
+    await withExecutable(
+      [
+        'case " $* " in *" auth status "*) ;; *) exit 20 ;; esac',
+        "printf '%s\\n' '{\"loggedIn\":false}'",
+        "printf 'raw stderr should lose\\n' >&2",
+        "exit 1",
+      ].join("\n"),
+      async (binary) => {
+        const error = await Effect.runPromise(inspect(binary).pipe(Effect.flip))
+        expect(error).toBeInstanceOf(AgentBackendConfigError)
+        if (error instanceof AgentBackendConfigError) {
+          expect(error.message).toBe(CLAUDE_UNAUTHENTICATED_MESSAGE)
+          expect(error.message).not.toContain("raw stderr should lose")
+        }
+      },
+    )
+  })
+
   it("keeps first-party loggedIn false on the login/API-key path (not Bedrock)", async () => {
     await withExecutable(
       [

--- a/packages/codex/test/codex.spec.ts
+++ b/packages/codex/test/codex.spec.ts
@@ -132,6 +132,25 @@ describe("Codex AgentBackend adapter (readiness inspection)", () => {
     )
   })
 
+  it("prefers parsed unauthenticated copy over extra stderr noise", async () => {
+    await withExecutable(
+      [
+        'case " $* " in *" login status "*) ;; *) exit 20 ;; esac',
+        "echo 'Not logged in' 1>&2",
+        "echo 'raw stderr should lose' 1>&2",
+        "exit 1",
+      ].join("\n"),
+      async (binary) => {
+        const error = await Effect.runPromise(inspect(binary).pipe(Effect.flip))
+        expect(error).toBeInstanceOf(AgentBackendConfigError)
+        if (error instanceof AgentBackendConfigError) {
+          expect(error.message).toBe(CODEX_UNAUTHENTICATED_MESSAGE)
+          expect(error.message).not.toContain("raw stderr should lose")
+        }
+      },
+    )
+  })
+
   it("maps non-zero login status without auth markers to exit failure with probe text", async () => {
     await withExecutable(
       [

--- a/packages/grok/test/grok.spec.ts
+++ b/packages/grok/test/grok.spec.ts
@@ -252,6 +252,33 @@ describe("Grok AgentBackend adapter", () => {
     )
   })
 
+  it("surfaces a stderr-only readiness failure as the inspect exit reason", async () => {
+    await withExecutable(
+      [
+        "printf 'Error: Configuration is invalid at /home/vscode/.config/grok/config.json\\n' >&2",
+        "exit 1",
+      ].join("\n"),
+      async (binary) => {
+        const error = await Effect.runPromise(
+          Effect.gen(function* () {
+            const backend = yield* AgentBackend
+            return yield* backend.inspect({
+              cwd: process.cwd(),
+              timeout: "2 seconds",
+            })
+          }).pipe(Effect.provide(provide(binary)), Effect.flip),
+        )
+        expect(error).toBeInstanceOf(AgentBackendExitError)
+        if (error instanceof AgentBackendExitError) {
+          expect(error.exitCode).toBe(1)
+          expect(error.message).toContain(
+            "Configuration is invalid at /home/vscode/.config/grok/config.json",
+          )
+        }
+      },
+    )
+  })
+
   it("fails inspect when unauthenticated even if exit is zero", async () => {
     await withExecutable(
       [

--- a/packages/opencode/test/opencode.spec.ts
+++ b/packages/opencode/test/opencode.spec.ts
@@ -852,6 +852,47 @@ describe("Opencode AgentBackend adapter", () => {
     }
   })
 
+  it("surfaces a stderr-only readiness failure as the inspect exit reason", async () => {
+    await withExecutable(
+      [
+        'if [ "$1" = "models" ] && [ "$2" = "--verbose" ]; then',
+        "  printf 'Error: Configuration is invalid at /home/vscode/.config/opencode/opencode.jsonc\\n' >&2",
+        "  printf '↳ Expected object | undefined, got [ … ] skills\\n' >&2",
+        "  exit 1",
+        "fi",
+        "exit 1",
+      ].join("\n"),
+      async (binary) => {
+        const error = await Effect.runPromise(
+          Effect.gen(function* () {
+            const backend = yield* AgentBackend
+            return yield* backend.inspect({
+              cwd: process.cwd(),
+              timeout: "2 seconds",
+            })
+          }).pipe(
+            Effect.provide(
+              Opencode.layer({
+                binary,
+                keymaxxerMcpUrl: "http://127.0.0.1:6057/test/mcp",
+              }).pipe(Layer.provide(BunServices.layer)),
+            ),
+            Effect.flip,
+          ),
+        )
+
+        expect(error).toBeInstanceOf(AgentBackendExitError)
+        if (error instanceof AgentBackendExitError) {
+          expect(error.exitCode).toBe(1)
+          expect(error.message).toContain(
+            "Configuration is invalid at /home/vscode/.config/opencode/opencode.jsonc",
+          )
+          expect(error.message).toContain("skills")
+        }
+      },
+    )
+  })
+
   it("fails when verbose models stdout is truncated mid-object", async () => {
     await withExecutable(
       [


### PR DESCRIPTION
Readiness inspection discarded child stderr unless an adapter opted into
capture. OpenCode and Grok did not, so a present-but-misconfigured CLI (for
example `opencode models` dying on invalid config) surfaced only as `Agent
Backend inspection failed (AgentBackendExitError)`.

`runCliCapture` now always pipes and concurrently drains inspection stderr,
retaining a 4000-character tail. On a non-zero exit, the ANSI-stripped,
secret-scrubbed diagnostic tail becomes `AgentBackendExitError.message` when
the adapter has no more specific parsed reason. That message already flows
through Preview, Recheck, and startup via `formatInspectFailure`. Claude and
Codex still parse auth/readiness output themselves and keep precedence.
Successful large stdout catalogs stay complete.

Verified with unit and adapter tests for stderr-only failure, flood/truncation,
sanitization, Claude/Codex message precedence, large stdout catalogs, and
Preview/Recheck propagation from a real child.

Closes #1071