### PR TITLE
fix(cli): explain older Harness schema as a version mismatch

### DIFF
--- a/apps/harness/src/server/application.server.ts
+++ b/apps/harness/src/server/application.server.ts
@@ -48,6 +48,7 @@ import {
   WorkItemLifecycleLive,
 } from "@ready-for-agent/work-item-lifecycle"
 import type { ApplicationRequestContext } from "../application-request-context.js"
+import { READY_FOR_AGENT_VERSION } from "../generated/version.js"
 import { ambientGitHubLayer } from "./ambient-github-layer.js"
 import { ambientGitLabLayer } from "./ambient-gitlab-layer.js"
 import {
@@ -342,6 +343,7 @@ export const createApplication = async (
     context: {
       graphqlApi: createGraphqlApi(runtime, {
         agentBackendCwd: toolCwd,
+        version: READY_FOR_AGENT_VERSION,
       }),
     },
     dispose: runtime.dispose,

--- a/apps/ready-for-agent/src/cli-process.test.ts
+++ b/apps/ready-for-agent/src/cli-process.test.ts
@@ -26,11 +26,14 @@ import {
   buildIntakeSuccessDocument,
   buildStatusSuccessDocument,
 } from "./cli-json.ts"
+import { READY_FOR_AGENT_VERSION } from "./generated/version.ts"
 import {
   GRAPHQL_URL_NOT_ENDPOINT_CODE,
   HARNESS_START_HINT,
   HARNESS_UNREACHABLE_CODE,
+  HARNESS_VERSION_MISMATCH_CODE,
   harnessNotRunningMessage,
+  harnessVersionMismatchMessage,
 } from "./graphql-error.ts"
 import { afterEach, beforeEach, describe, expect, test } from "bun:test"
 
@@ -474,6 +477,244 @@ describe("operator binary finite-command process contract", () => {
       })
       expect(result.stderr).not.toMatch(/\s+at\s+\S+\s+\(/)
       expect(result.stderr).not.toContain("FiniteCommandFailed:")
+    } finally {
+      await closeServer(server)
+    }
+  })
+
+  test("candidates against an older Harness schema emits HARNESS_VERSION_MISMATCH", async () => {
+    const server = createServer((req, res) => {
+      if (req.method !== "POST") {
+        res.writeHead(405)
+        res.end()
+        return
+      }
+      const chunks: Buffer[] = []
+      req.on("data", (chunk: Buffer) => {
+        chunks.push(chunk)
+      })
+      req.on("end", () => {
+        const body = Buffer.concat(chunks).toString("utf8")
+        res.writeHead(200, { "content-type": "application/json" })
+        if (body.includes("repositories")) {
+          res.end(
+            JSON.stringify({
+              data: {
+                repositories: [
+                  {
+                    id: "repo-process-1",
+                    forge: "github",
+                    forgeHost: "github.com",
+                    projectPath: "owner/repo",
+                  },
+                ],
+              },
+            }),
+          )
+          return
+        }
+        if (body.includes("intakeCandidates")) {
+          res.end(
+            JSON.stringify({
+              data: null,
+              errors: [
+                {
+                  message:
+                    'Cannot query field "intakeCandidates" on type "Query".',
+                  extensions: { code: "GRAPHQL_VALIDATION_FAILED" },
+                },
+              ],
+            }),
+          )
+          return
+        }
+        if (body.includes("version")) {
+          res.end(
+            JSON.stringify({
+              data: null,
+              errors: [
+                {
+                  message: 'Cannot query field "version" on type "Query".',
+                  extensions: { code: "GRAPHQL_VALIDATION_FAILED" },
+                },
+              ],
+            }),
+          )
+          return
+        }
+        res.end(JSON.stringify({ data: null }))
+      })
+    })
+
+    try {
+      const port = await listen(server)
+      const result = await runCli(
+        ["candidates", "github.com/owner/repo"],
+        `http://127.0.0.1:${port}/graphql`,
+      )
+
+      expect(result.status).toBe(1)
+      expect(result.stdout.trim()).toBe("")
+      expect(parseExactlyOneJsonDocument(result.stderr)).toEqual({
+        schemaVersion: CLI_SCHEMA_VERSION,
+        command: "candidates",
+        error: {
+          code: HARNESS_VERSION_MISMATCH_CODE,
+          message: harnessVersionMismatchMessage({
+            cliVersion: READY_FOR_AGENT_VERSION,
+            harnessBaseUrl: `http://127.0.0.1:${port}`,
+            command: "candidates",
+          }),
+        },
+      })
+      expect(result.stderr).not.toContain("GRAPHQL_VALIDATION_FAILED")
+      expect(result.stderr).not.toContain("intakeCandidates")
+    } finally {
+      await closeServer(server)
+    }
+  })
+
+  test("candidates names the older Harness version when Query.version exists", async () => {
+    const server = createServer((req, res) => {
+      if (req.method !== "POST") {
+        res.writeHead(405)
+        res.end()
+        return
+      }
+      const chunks: Buffer[] = []
+      req.on("data", (chunk: Buffer) => {
+        chunks.push(chunk)
+      })
+      req.on("end", () => {
+        const body = Buffer.concat(chunks).toString("utf8")
+        res.writeHead(200, { "content-type": "application/json" })
+        if (body.includes("repositories")) {
+          res.end(
+            JSON.stringify({
+              data: {
+                repositories: [
+                  {
+                    id: "repo-process-1",
+                    forge: "github",
+                    forgeHost: "github.com",
+                    projectPath: "owner/repo",
+                  },
+                ],
+              },
+            }),
+          )
+          return
+        }
+        if (body.includes("intakeCandidates")) {
+          res.end(
+            JSON.stringify({
+              data: null,
+              errors: [
+                {
+                  message:
+                    'Cannot query field "intakeCandidates" on type "Query".',
+                  extensions: { code: "GRAPHQL_VALIDATION_FAILED" },
+                },
+              ],
+            }),
+          )
+          return
+        }
+        if (body.includes("version")) {
+          res.end(JSON.stringify({ data: { version: "0.18.0" } }))
+          return
+        }
+        res.end(JSON.stringify({ data: null }))
+      })
+    })
+
+    try {
+      const port = await listen(server)
+      const result = await runCli(
+        ["candidates", "github.com/owner/repo"],
+        `http://127.0.0.1:${port}/graphql`,
+      )
+
+      expect(result.status).toBe(1)
+      expect(result.stdout.trim()).toBe("")
+      expect(parseExactlyOneJsonDocument(result.stderr)).toEqual({
+        schemaVersion: CLI_SCHEMA_VERSION,
+        command: "candidates",
+        error: {
+          code: HARNESS_VERSION_MISMATCH_CODE,
+          message: harnessVersionMismatchMessage({
+            cliVersion: READY_FOR_AGENT_VERSION,
+            harnessVersion: "0.18.0",
+            harnessBaseUrl: `http://127.0.0.1:${port}`,
+            command: "candidates",
+          }),
+        },
+      })
+    } finally {
+      await closeServer(server)
+    }
+  })
+
+  test("status against an older Harness schema emits HARNESS_VERSION_MISMATCH", async () => {
+    const server = createServer((req, res) => {
+      if (req.method !== "POST") {
+        res.writeHead(405)
+        res.end()
+        return
+      }
+      const chunks: Buffer[] = []
+      req.on("data", (chunk: Buffer) => {
+        chunks.push(chunk)
+      })
+      req.on("end", () => {
+        const body = Buffer.concat(chunks).toString("utf8")
+        res.writeHead(200, { "content-type": "application/json" })
+        if (body.includes("kanbanStatus")) {
+          res.end(
+            JSON.stringify({
+              data: null,
+              errors: [
+                {
+                  message: 'Cannot query field "kanbanStatus" on type "Query".',
+                  extensions: { code: "GRAPHQL_VALIDATION_FAILED" },
+                },
+              ],
+            }),
+          )
+          return
+        }
+        if (body.includes("version")) {
+          res.end(JSON.stringify({ data: { version: "0.18.0" } }))
+          return
+        }
+        res.end(JSON.stringify({ data: null }))
+      })
+    })
+
+    try {
+      const port = await listen(server)
+      const result = await runCli(
+        ["status"],
+        `http://127.0.0.1:${port}/graphql`,
+      )
+
+      expect(result.status).toBe(1)
+      expect(result.stdout.trim()).toBe("")
+      expect(parseExactlyOneJsonDocument(result.stderr)).toEqual({
+        schemaVersion: CLI_SCHEMA_VERSION,
+        command: "status",
+        error: {
+          code: HARNESS_VERSION_MISMATCH_CODE,
+          message: harnessVersionMismatchMessage({
+            cliVersion: READY_FOR_AGENT_VERSION,
+            harnessVersion: "0.18.0",
+            harnessBaseUrl: `http://127.0.0.1:${port}`,
+            command: "status",
+          }),
+        },
+      })
+      expect(result.stderr).not.toContain("GRAPHQL_VALIDATION_FAILED")
+      expect(result.stderr).not.toContain("kanbanStatus")
     } finally {
       await closeServer(server)
     }

--- a/apps/ready-for-agent/src/graphql-error.test.ts
+++ b/apps/ready-for-agent/src/graphql-error.test.ts
@@ -4,12 +4,15 @@ import {
   GRAPHQL_ERROR_CODE,
   GRAPHQL_URL_NOT_ENDPOINT_CODE,
   GraphqlUrlNotEndpointError,
+  HARNESS_RESTART_UPGRADE_HINT,
   HARNESS_START_HINT,
   HARNESS_UNREACHABLE_CODE,
+  HARNESS_VERSION_MISMATCH_CODE,
   describeGraphqlFailure,
   formatGraphqlRequestFailure,
   harnessBaseUrlFromGraphqlUrl,
   harnessNotRunningMessage,
+  harnessVersionMismatchMessage,
   isGraphqlUnreachable,
 } from "./graphql-error.ts"
 import { describe, expect, test } from "bun:test"
@@ -130,6 +133,105 @@ describe("graphql unreachable detection", () => {
     )
     expect(harnessBaseUrlFromGraphqlUrl("http://127.0.0.1:7000/graphql/")).toBe(
       "http://127.0.0.1:7000",
+    )
+  })
+
+  test("maps a missing intakeCandidates field to HARNESS_VERSION_MISMATCH", () => {
+    const cause = new GenqlError(
+      [
+        {
+          message: 'Cannot query field "intakeCandidates" on type "Query".',
+          extensions: { code: "GRAPHQL_VALIDATION_FAILED" },
+        },
+      ],
+      null,
+    )
+    expect(
+      describeGraphqlFailure(cause, {
+        graphqlUrl: "http://127.0.0.1:6056/graphql",
+        cliVersion: "0.22.0",
+        harnessVersion: "0.18.0",
+      }),
+    ).toEqual({
+      code: HARNESS_VERSION_MISMATCH_CODE,
+      message:
+        "This CLI is v0.22.0 but the Harness on http://127.0.0.1:6056 is v0.18.0, which does not support `candidates`. Restart the Harness to upgrade: ready-for-agent start",
+    })
+  })
+
+  test("maps a missing kanbanStatus field without a known Harness version", () => {
+    const cause = new GenqlError(
+      [
+        {
+          message: 'Cannot query field "kanbanStatus" on type "Query".',
+          extensions: { code: "GRAPHQL_VALIDATION_FAILED" },
+        },
+      ],
+      null,
+    )
+    expect(
+      describeGraphqlFailure(cause, {
+        graphqlUrl: "http://127.0.0.1:6056/graphql",
+        cliVersion: "0.22.0",
+      }),
+    ).toEqual({
+      code: HARNESS_VERSION_MISMATCH_CODE,
+      message:
+        "This CLI is v0.22.0 but the Harness on http://127.0.0.1:6056 does not support `status`. Restart the Harness to upgrade: ready-for-agent start",
+    })
+    expect(describeGraphqlFailure(cause).message).toContain(
+      HARNESS_RESTART_UPGRADE_HINT,
+    )
+  })
+
+  test("maps a missing startRepositoryIntake field to the intake command", () => {
+    const cause = new GenqlError(
+      [
+        {
+          message:
+            'Cannot query field "startRepositoryIntake" on type "Mutation".',
+          extensions: { code: "GRAPHQL_VALIDATION_FAILED" },
+        },
+      ],
+      null,
+    )
+    expect(
+      describeGraphqlFailure(cause, {
+        graphqlUrl: "http://127.0.0.1:7000/graphql",
+        cliVersion: "0.22.0",
+        harnessVersion: "0.18.0",
+      }).message,
+    ).toBe(
+      "This CLI is v0.22.0 but the Harness on http://127.0.0.1:7000 is v0.18.0, which does not support `intake`. Restart the Harness to upgrade: ready-for-agent start",
+    )
+  })
+
+  test("leaves other GraphQL validation failures unchanged", () => {
+    const cause = new GenqlError(
+      [
+        {
+          message: 'Unknown argument "repository" on field "Query.health".',
+          extensions: { code: "GRAPHQL_VALIDATION_FAILED" },
+        },
+      ],
+      null,
+    )
+    expect(describeGraphqlFailure(cause)).toEqual({
+      code: "GRAPHQL_VALIDATION_FAILED",
+      message: 'Unknown argument "repository" on field "Query.health".',
+    })
+  })
+
+  test("harnessVersionMismatchMessage uses the product v-prefix once", () => {
+    expect(
+      harnessVersionMismatchMessage({
+        cliVersion: "v0.22.0",
+        harnessVersion: "v0.18.0",
+        harnessBaseUrl: "http://127.0.0.1:6056",
+        command: "candidates",
+      }),
+    ).toBe(
+      "This CLI is v0.22.0 but the Harness on http://127.0.0.1:6056 is v0.18.0, which does not support `candidates`. Restart the Harness to upgrade: ready-for-agent start",
     )
   })
 })

--- a/apps/ready-for-agent/src/graphql-error.ts
+++ b/apps/ready-for-agent/src/graphql-error.ts
@@ -1,11 +1,25 @@
+import { READY_FOR_AGENT_VERSION } from "./generated/version.ts"
+
 /** Default Harness UI / GraphQL loopback origin (port 6056). */
 export const DEFAULT_HARNESS_BASE_URL = "http://127.0.0.1:6056"
 
 /** Single-line start remedy for unreachable-Harness failures. */
 export const HARNESS_START_HINT = "Start it with: ready-for-agent start"
 
+/** Single-line restart remedy when the running Harness is older than this CLI. */
+export const HARNESS_RESTART_UPGRADE_HINT =
+  "Restart the Harness to upgrade: ready-for-agent start"
+
 /** CLI-owned code when the GraphQL transport cannot reach the Harness. */
 export const HARNESS_UNREACHABLE_CODE = "HARNESS_UNREACHABLE"
+
+/**
+ * CLI-owned code when the Harness GraphQL schema is missing a field this CLI
+ * requires — typically a newer CLI against an older still-running Harness.
+ */
+export const HARNESS_VERSION_MISMATCH_CODE = "HARNESS_VERSION_MISMATCH"
+
+const GRAPHQL_VALIDATION_FAILED_CODE = "GRAPHQL_VALIDATION_FAILED"
 
 /**
  * Fallback when a GraphQL response has no usable `extensions.code`.
@@ -123,6 +137,10 @@ export const isGraphqlUnreachable = (cause: unknown): boolean => {
 export type FormatGraphqlRequestFailureOptions = {
   /** Configured GraphQL URL; used to print the Harness origin when unreachable. */
   readonly graphqlUrl?: string
+  /** This CLI's product version (`0.22.0` or `v0.22.0`). */
+  readonly cliVersion?: string
+  /** Running Harness product version, when the CLI could read one. */
+  readonly harnessVersion?: string
 }
 
 /** Structured GraphQL/transport failure for the CLI JSON error seam. */
@@ -137,10 +155,88 @@ const graphqlErrorCode = (cause: GenqlErrorLike): string => {
   return typeof code === "string" && code.length > 0 ? code : GRAPHQL_ERROR_CODE
 }
 
+/** GraphQL fields this CLI queries or mutates against the Harness. */
+const CLI_REQUIRED_GRAPHQL_FIELDS = {
+  addRepository: "add",
+  intakeCandidates: "candidates",
+  startRepositoryIntake: "intake",
+  kanbanStatus: "status",
+  workItemBySessionId: "jump",
+} as const
+
+type CliRequiredGraphqlField = keyof typeof CLI_REQUIRED_GRAPHQL_FIELDS
+
+const isCliRequiredGraphqlField = (
+  field: string,
+): field is CliRequiredGraphqlField =>
+  Object.hasOwn(CLI_REQUIRED_GRAPHQL_FIELDS, field)
+
+const missingGraphqlFieldName = (message: string): string | undefined => {
+  const match = /Cannot query field "([^"]+)"/.exec(message)
+  const field = match?.[1]
+  return field !== undefined && field.length > 0 ? field : undefined
+}
+
+const productVersionLabel = (version: string): string => {
+  const trimmed = version.trim()
+  if (trimmed.length === 0) {
+    return "v0.0.0"
+  }
+  return trimmed.startsWith("v") ? trimmed : `v${trimmed}`
+}
+
+export const harnessVersionMismatchMessage = (options: {
+  readonly cliVersion: string
+  readonly harnessVersion?: string
+  readonly harnessBaseUrl: string
+  readonly command: string
+}): string => {
+  const cliLabel = productVersionLabel(options.cliVersion)
+  const command = `\`${options.command}\``
+  if (
+    options.harnessVersion !== undefined &&
+    options.harnessVersion.trim().length > 0
+  ) {
+    const harnessLabel = productVersionLabel(options.harnessVersion)
+    return `This CLI is ${cliLabel} but the Harness on ${options.harnessBaseUrl} is ${harnessLabel}, which does not support ${command}. ${HARNESS_RESTART_UPGRADE_HINT}`
+  }
+  return `This CLI is ${cliLabel} but the Harness on ${options.harnessBaseUrl} does not support ${command}. ${HARNESS_RESTART_UPGRADE_HINT}`
+}
+
+const versionMismatchFromMissingField = (
+  cause: GenqlErrorLike,
+  options?: FormatGraphqlRequestFailureOptions,
+): GraphqlFailureInfo | undefined => {
+  const message =
+    cause.message.length > 0 ? cause.message : "GraphQL request failed"
+  const field = missingGraphqlFieldName(message)
+  if (field === undefined || !isCliRequiredGraphqlField(field)) {
+    return undefined
+  }
+  const code = graphqlErrorCode(cause)
+  if (code !== GRAPHQL_VALIDATION_FAILED_CODE && code !== GRAPHQL_ERROR_CODE) {
+    return undefined
+  }
+  const harnessBaseUrl =
+    options?.graphqlUrl === undefined
+      ? DEFAULT_HARNESS_BASE_URL
+      : harnessBaseUrlFromGraphqlUrl(options.graphqlUrl)
+  return {
+    code: HARNESS_VERSION_MISMATCH_CODE,
+    message: harnessVersionMismatchMessage({
+      cliVersion: options?.cliVersion ?? READY_FOR_AGENT_VERSION,
+      harnessVersion: options?.harnessVersion,
+      harnessBaseUrl,
+      command: CLI_REQUIRED_GRAPHQL_FIELDS[field],
+    }),
+  }
+}
+
 /**
  * Map a GraphQL client failure to a stable code + operator-facing message.
  * Unreachable transport uses the CLI-owned `HARNESS_UNREACHABLE` code.
  * HTML (or other non-JSON) at the configured URL uses `GRAPHQL_URL_NOT_ENDPOINT`.
+ * A missing field this CLI requires uses `HARNESS_VERSION_MISMATCH`.
  * Domain failures retain Harness `extensions.code` from GenqlError.
  */
 export const describeGraphqlFailure = (
@@ -166,6 +262,10 @@ export const describeGraphqlFailure = (
   }
 
   if (isGenqlErrorLike(cause)) {
+    const versionMismatch = versionMismatchFromMissingField(cause, options)
+    if (versionMismatch !== undefined) {
+      return versionMismatch
+    }
     return {
       code: graphqlErrorCode(cause),
       message:

--- a/apps/ready-for-agent/src/services/graphql-api.ts
+++ b/apps/ready-for-agent/src/services/graphql-api.ts
@@ -12,6 +12,7 @@ import {
 import type { LocalRepository, RepositorySummary } from "../domain.ts"
 import {
   GraphqlUrlNotEndpointError,
+  HARNESS_VERSION_MISMATCH_CODE,
   describeGraphqlFailure,
 } from "../graphql-error.ts"
 import { ApplicationConfig } from "./application-config.ts"
@@ -231,6 +232,9 @@ export class GraphqlApi extends Context.Service<
       })
 
       const mapFailure = (cause: unknown): GraphqlRequestFailed => {
+        if (cause instanceof GraphqlRequestFailed) {
+          return cause
+        }
         const failure = describeGraphqlFailure(cause, {
           graphqlUrl: config.graphqlUrl,
         })
@@ -240,61 +244,180 @@ export class GraphqlApi extends Context.Service<
         })
       }
 
+      const readHarnessVersion = async (): Promise<string | undefined> => {
+        try {
+          const response = await fetch(config.graphqlUrl, {
+            method: "POST",
+            headers: {
+              accept: "application/json",
+              "content-type": "application/json",
+            },
+            body: JSON.stringify({ query: "{ version }" }),
+          })
+          if (!isJsonContentType(response.headers.get("content-type"))) {
+            return undefined
+          }
+          const payload: unknown = await response.json()
+          if (typeof payload !== "object" || payload === null) {
+            return undefined
+          }
+          if (!("data" in payload)) {
+            return undefined
+          }
+          const data = payload.data
+          if (typeof data !== "object" || data === null) {
+            return undefined
+          }
+          if (!("version" in data) || typeof data.version !== "string") {
+            return undefined
+          }
+          const version = data.version.trim()
+          return version.length > 0 ? version : undefined
+        } catch {
+          return undefined
+        }
+      }
+
+      const executeGraphql = async <A>(run: () => Promise<A>): Promise<A> => {
+        try {
+          return await run()
+        } catch (cause) {
+          const initial = describeGraphqlFailure(cause, {
+            graphqlUrl: config.graphqlUrl,
+          })
+          if (initial.code !== HARNESS_VERSION_MISMATCH_CODE) {
+            throw new GraphqlRequestFailed({
+              code: initial.code,
+              message: initial.message,
+            })
+          }
+          const harnessVersion = await readHarnessVersion()
+          const enriched = describeGraphqlFailure(cause, {
+            graphqlUrl: config.graphqlUrl,
+            harnessVersion,
+          })
+          throw new GraphqlRequestFailed({
+            code: enriched.code,
+            message: enriched.message,
+          })
+        }
+      }
+
       const addRepository = Effect.fn("GraphqlApi.addRepository")(function* (
         repository: LocalRepository,
       ) {
         return yield* Effect.tryPromise({
-          try: async () => {
-            const result = await client.mutation({
-              addRepository: {
-                __args: {
-                  input: {
-                    forge: repository.forge,
-                    forgeHost: repository.forgeHost,
-                    projectPath: repository.projectPath,
-                    localPath: repository.localPath,
-                    isBare: repository.isBare,
+          try: () =>
+            executeGraphql(async () => {
+              const result = await client.mutation({
+                addRepository: {
+                  __args: {
+                    input: {
+                      forge: repository.forge,
+                      forgeHost: repository.forgeHost,
+                      projectPath: repository.projectPath,
+                      localPath: repository.localPath,
+                      isBare: repository.isBare,
+                    },
                   },
+                  id: true,
+                  forge: true,
+                  forgeHost: true,
+                  projectPath: true,
+                  localPath: true,
+                  isBare: true,
                 },
-                id: true,
-                forge: true,
-                forgeHost: true,
-                projectPath: true,
-                localPath: true,
-                isBare: true,
-              },
-            })
-            const added = result.addRepository
-            if (!added) {
-              throw new Error("addRepository returned null")
-            }
-            return added
-          },
+              })
+              const added = result.addRepository
+              if (!added) {
+                throw new Error("addRepository returned null")
+              }
+              return added
+            }),
           catch: mapFailure,
         })
       })
 
       const listRepositories = Effect.tryPromise({
-        try: async () => {
-          const result = await client.query({
-            repositories: {
-              id: true,
-              forge: true,
-              forgeHost: true,
-              projectPath: true,
-            },
-          })
-          return result.repositories ?? []
-        },
+        try: () =>
+          executeGraphql(async () => {
+            const result = await client.query({
+              repositories: {
+                id: true,
+                forge: true,
+                forgeHost: true,
+                projectPath: true,
+              },
+            })
+            return result.repositories ?? []
+          }),
         catch: mapFailure,
       }).pipe(Effect.withSpan("GraphqlApi.listRepositories"))
 
       const intakeCandidates = Effect.fn("GraphqlApi.intakeCandidates")(
         function* (repositoryId: string) {
           return yield* Effect.tryPromise({
-            try: async () => {
-              const result = await client.query({
-                intakeCandidates: {
+            try: () =>
+              executeGraphql(async () => {
+                const result = await client.query({
+                  intakeCandidates: {
+                    __args: { repositoryId },
+                    repository: {
+                      id: true,
+                      forge: true,
+                      forgeHost: true,
+                      projectPath: true,
+                      issuesReconciledAt: true,
+                    },
+                    candidates: {
+                      issueNumber: true,
+                      title: true,
+                      url: true,
+                      action: true,
+                    },
+                  },
+                })
+                const payload = result.intakeCandidates
+                if (!payload) {
+                  throw new Error("intakeCandidates returned null")
+                }
+                return {
+                  repository: {
+                    id: payload.repository.id,
+                    forge: payload.repository.forge,
+                    forgeHost: payload.repository.forgeHost,
+                    projectPath: payload.repository.projectPath,
+                    issuesReconciledAt:
+                      payload.repository.issuesReconciledAt ?? null,
+                  },
+                  candidates: payload.candidates.map(
+                    (candidate: {
+                      readonly issueNumber: number
+                      readonly title: string
+                      readonly url: string
+                      readonly action: IntakeCandidateAction
+                    }) => ({
+                      issueNumber: candidate.issueNumber,
+                      title: candidate.title,
+                      url: candidate.url,
+                      action: candidate.action,
+                    }),
+                  ),
+                }
+              }),
+            catch: mapFailure,
+          })
+        },
+      )
+
+      const startRepositoryIntake = Effect.fn(
+        "GraphqlApi.startRepositoryIntake",
+      )(function* (repositoryId: string) {
+        return yield* Effect.tryPromise({
+          try: () =>
+            executeGraphql(async () => {
+              const result = await client.mutation({
+                startRepositoryIntake: {
                   __args: { repositoryId },
                   repository: {
                     id: true,
@@ -303,17 +426,88 @@ export class GraphqlApi extends Context.Service<
                     projectPath: true,
                     issuesReconciledAt: true,
                   },
-                  candidates: {
-                    issueNumber: true,
-                    title: true,
-                    url: true,
-                    action: true,
+                  results: {
+                    on_RepositoryIntakeCreated: {
+                      __typename: true,
+                      issueNumber: true,
+                      title: true,
+                      url: true,
+                      action: true,
+                      workItem: {
+                        id: true,
+                        state: true,
+                        status: true,
+                      },
+                    },
+                    on_RepositoryIntakeFailed: {
+                      __typename: true,
+                      issueNumber: true,
+                      title: true,
+                      url: true,
+                      action: true,
+                      error: {
+                        code: true,
+                        message: true,
+                      },
+                    },
                   },
                 },
               })
-              const payload = result.intakeCandidates
+              const payload = result.startRepositoryIntake
               if (!payload) {
-                throw new Error("intakeCandidates returned null")
+                throw new Error("startRepositoryIntake returned null")
+              }
+              const results: IntakeIssueResult[] = []
+              for (const entry of payload.results ?? []) {
+                // Genql union selection uses on_* fragments; __typename discriminates.
+                if (
+                  entry !== null &&
+                  typeof entry === "object" &&
+                  "__typename" in entry &&
+                  entry.__typename === "RepositoryIntakeCreated" &&
+                  "workItem" in entry &&
+                  entry.workItem !== null &&
+                  entry.workItem !== undefined
+                ) {
+                  results.push({
+                    issueNumber: entry.issueNumber,
+                    title: entry.title,
+                    url: entry.url,
+                    action: entry.action,
+                    outcome: "CREATED",
+                    workItem: {
+                      id: entry.workItem.id,
+                      state: entry.workItem.state,
+                      status: entry.workItem.status,
+                    },
+                  })
+                  continue
+                }
+                if (
+                  entry !== null &&
+                  typeof entry === "object" &&
+                  "__typename" in entry &&
+                  entry.__typename === "RepositoryIntakeFailed" &&
+                  "error" in entry &&
+                  entry.error !== null &&
+                  entry.error !== undefined
+                ) {
+                  results.push({
+                    issueNumber: entry.issueNumber,
+                    title: entry.title,
+                    url: entry.url,
+                    action: entry.action,
+                    outcome: "FAILED",
+                    error: {
+                      code: entry.error.code,
+                      message: entry.error.message,
+                    },
+                  })
+                  continue
+                }
+                throw new Error(
+                  "startRepositoryIntake returned an unexpected result shape",
+                )
               }
               return {
                 repository: {
@@ -324,136 +518,9 @@ export class GraphqlApi extends Context.Service<
                   issuesReconciledAt:
                     payload.repository.issuesReconciledAt ?? null,
                 },
-                candidates: payload.candidates.map(
-                  (candidate: {
-                    readonly issueNumber: number
-                    readonly title: string
-                    readonly url: string
-                    readonly action: IntakeCandidateAction
-                  }) => ({
-                    issueNumber: candidate.issueNumber,
-                    title: candidate.title,
-                    url: candidate.url,
-                    action: candidate.action,
-                  }),
-                ),
+                results,
               }
-            },
-            catch: mapFailure,
-          })
-        },
-      )
-
-      const startRepositoryIntake = Effect.fn(
-        "GraphqlApi.startRepositoryIntake",
-      )(function* (repositoryId: string) {
-        return yield* Effect.tryPromise({
-          try: async () => {
-            const result = await client.mutation({
-              startRepositoryIntake: {
-                __args: { repositoryId },
-                repository: {
-                  id: true,
-                  forge: true,
-                  forgeHost: true,
-                  projectPath: true,
-                  issuesReconciledAt: true,
-                },
-                results: {
-                  on_RepositoryIntakeCreated: {
-                    __typename: true,
-                    issueNumber: true,
-                    title: true,
-                    url: true,
-                    action: true,
-                    workItem: {
-                      id: true,
-                      state: true,
-                      status: true,
-                    },
-                  },
-                  on_RepositoryIntakeFailed: {
-                    __typename: true,
-                    issueNumber: true,
-                    title: true,
-                    url: true,
-                    action: true,
-                    error: {
-                      code: true,
-                      message: true,
-                    },
-                  },
-                },
-              },
-            })
-            const payload = result.startRepositoryIntake
-            if (!payload) {
-              throw new Error("startRepositoryIntake returned null")
-            }
-            const results: IntakeIssueResult[] = []
-            for (const entry of payload.results ?? []) {
-              // Genql union selection uses on_* fragments; __typename discriminates.
-              if (
-                entry !== null &&
-                typeof entry === "object" &&
-                "__typename" in entry &&
-                entry.__typename === "RepositoryIntakeCreated" &&
-                "workItem" in entry &&
-                entry.workItem !== null &&
-                entry.workItem !== undefined
-              ) {
-                results.push({
-                  issueNumber: entry.issueNumber,
-                  title: entry.title,
-                  url: entry.url,
-                  action: entry.action,
-                  outcome: "CREATED",
-                  workItem: {
-                    id: entry.workItem.id,
-                    state: entry.workItem.state,
-                    status: entry.workItem.status,
-                  },
-                })
-                continue
-              }
-              if (
-                entry !== null &&
-                typeof entry === "object" &&
-                "__typename" in entry &&
-                entry.__typename === "RepositoryIntakeFailed" &&
-                "error" in entry &&
-                entry.error !== null &&
-                entry.error !== undefined
-              ) {
-                results.push({
-                  issueNumber: entry.issueNumber,
-                  title: entry.title,
-                  url: entry.url,
-                  action: entry.action,
-                  outcome: "FAILED",
-                  error: {
-                    code: entry.error.code,
-                    message: entry.error.message,
-                  },
-                })
-                continue
-              }
-              throw new Error(
-                "startRepositoryIntake returned an unexpected result shape",
-              )
-            }
-            return {
-              repository: {
-                id: payload.repository.id,
-                forge: payload.repository.forge,
-                forgeHost: payload.repository.forgeHost,
-                projectPath: payload.repository.projectPath,
-                issuesReconciledAt:
-                  payload.repository.issuesReconciledAt ?? null,
-              },
-              results,
-            }
-          },
+            }),
           catch: mapFailure,
         })
       })
@@ -462,57 +529,58 @@ export class GraphqlApi extends Context.Service<
         repositoryId: string | null,
       ) {
         return yield* Effect.tryPromise({
-          try: async () => {
-            const result = await client.query({
-              kanbanStatus: {
-                __args: repositoryId === null ? {} : { repositoryId },
-                repository: {
-                  id: true,
-                  forge: true,
-                  forgeHost: true,
-                  projectPath: true,
-                },
-                lanes: {
-                  id: true,
-                  label: true,
-                  count: true,
-                  workItems: {
-                    repository: {
-                      id: true,
-                      forge: true,
-                      forgeHost: true,
-                      projectPath: true,
-                    },
-                    workItem: {
-                      id: true,
-                      issueNumber: true,
-                      issueTitle: true,
-                      state: true,
-                      status: true,
-                      statusMessage: true,
-                      paused: true,
-                      pullRequestNumber: true,
-                      createdAt: true,
-                      updatedAt: true,
-                      stateReadyAt: true,
-                      postponedUntil: true,
+          try: () =>
+            executeGraphql(async () => {
+              const result = await client.query({
+                kanbanStatus: {
+                  __args: repositoryId === null ? {} : { repositoryId },
+                  repository: {
+                    id: true,
+                    forge: true,
+                    forgeHost: true,
+                    projectPath: true,
+                  },
+                  lanes: {
+                    id: true,
+                    label: true,
+                    count: true,
+                    workItems: {
+                      repository: {
+                        id: true,
+                        forge: true,
+                        forgeHost: true,
+                        projectPath: true,
+                      },
+                      workItem: {
+                        id: true,
+                        issueNumber: true,
+                        issueTitle: true,
+                        state: true,
+                        status: true,
+                        statusMessage: true,
+                        paused: true,
+                        pullRequestNumber: true,
+                        createdAt: true,
+                        updatedAt: true,
+                        stateReadyAt: true,
+                        postponedUntil: true,
+                      },
                     },
                   },
                 },
-              },
-            })
-            const status = result.kanbanStatus
-            if (!status) {
-              throw new Error("kanbanStatus returned null")
-            }
-            return {
-              repository:
-                status.repository === null || status.repository === undefined
-                  ? null
-                  : toCanonicalRepositoryIdentity(status.repository),
-              lanes: toStatusLanes(status.lanes ?? []),
-            }
-          },
+              })
+              const status = result.kanbanStatus
+              if (!status) {
+                throw new Error("kanbanStatus returned null")
+              }
+              return {
+                repository:
+                  status.repository === null || status.repository === undefined
+                    ? null
+                    : toCanonicalRepositoryIdentity(status.repository),
+                lanes: toStatusLanes(status.lanes ?? []),
+              }
+            }),
           catch: mapFailure,
         })
       })
@@ -520,31 +588,32 @@ export class GraphqlApi extends Context.Service<
       const workItemBySessionId = Effect.fn("GraphqlApi.workItemBySessionId")(
         function* (sessionId: string) {
           return yield* Effect.tryPromise({
-            try: async () => {
-              const result = await client.query({
-                workItemBySessionId: {
-                  __args: { sessionId },
-                  agentBackend: {
-                    id: true,
-                    label: true,
+            try: () =>
+              executeGraphql(async () => {
+                const result = await client.query({
+                  workItemBySessionId: {
+                    __args: { sessionId },
+                    agentBackend: {
+                      id: true,
+                      label: true,
+                    },
+                    sessionId: true,
+                    worktreePath: true,
                   },
-                  sessionId: true,
-                  worktreePath: true,
-                },
-              })
-              const payload = result.workItemBySessionId
-              if (!payload) {
-                throw new Error("workItemBySessionId returned null")
-              }
-              return {
-                agentBackend: {
-                  id: payload.agentBackend.id,
-                  label: payload.agentBackend.label,
-                },
-                sessionId: payload.sessionId,
-                worktreePath: payload.worktreePath ?? null,
-              }
-            },
+                })
+                const payload = result.workItemBySessionId
+                if (!payload) {
+                  throw new Error("workItemBySessionId returned null")
+                }
+                return {
+                  agentBackend: {
+                    id: payload.agentBackend.id,
+                    label: payload.agentBackend.label,
+                  },
+                  sessionId: payload.sessionId,
+                  worktreePath: payload.worktreePath ?? null,
+                }
+              }),
             catch: mapFailure,
           })
         },

--- a/docs/prd/repository-intake-cli.md
+++ b/docs/prd/repository-intake-cli.md
@@ -339,7 +339,7 @@ A command-level failure writes exactly one versioned JSON document to stderr and
 }
 ```
 
-Harness domain failures retain their GraphQL `extensions.code`. CLI-owned failures use stable codes such as `HARNESS_UNREACHABLE`, `REPOSITORY_NOT_FOUND`, and `REPOSITORY_AMBIGUOUS`. Numeric exit codes remain intentionally small: `0` success, `1` executed-command failure, and the CLI framework's normal usage exit for invalid arguments.
+Harness domain failures retain their GraphQL `extensions.code`. CLI-owned failures use stable codes such as `HARNESS_UNREACHABLE`, `HARNESS_VERSION_MISMATCH`, `REPOSITORY_NOT_FOUND`, and `REPOSITORY_AMBIGUOUS`. A missing GraphQL field the CLI requires is `HARNESS_VERSION_MISMATCH` (newer CLI against an older running Harness), not a raw `GRAPHQL_VALIDATION_FAILED`. Numeric exit codes remain intentionally small: `0` success, `1` executed-command failure, and the CLI framework's normal usage exit for invalid arguments.
 
 The existing finite `add` command moves to the same envelope and returns canonical Repository identity plus `localPath` and `isBare`. This is an intentional output-format change; no text compatibility mode is added.
 

--- a/hk.pkl
+++ b/hk.pkl
@@ -34,7 +34,9 @@ esac
         exclude = "**/generated/**"
         // Strip git local-env-vars and NX_* so hooks under `nx run harness:dev`
         // are not treated as nested Nx invocations (false recursive-task errors).
+        // Repair Bun's nested typescript@7 shadow before Nx typescript-sync.
         fix = #"""
+node scripts/fix-bun-typescript-for-nx.mjs
 unset $(git rev-parse --local-env-vars)
 for v in $(printenv | cut -d= -f1 | grep '^NX_'); do unset "$v"; done
 bunx nx affected -t lint --fix --batch --excludeTaskDependencies
@@ -43,6 +45,7 @@ bunx nx affected -t lint --fix --batch --excludeTaskDependencies
       ["nx-affected"] {
         depends = List("biome-json", "nx-lint-fix")
         check = #"""
+node scripts/fix-bun-typescript-for-nx.mjs
 unset $(git rev-parse --local-env-vars)
 for v in $(printenv | cut -d= -f1 | grep '^NX_'); do unset "$v"; done
 bunx nx affected -t lint,typecheck,test --batch

--- a/packages/graphql-api/src/lib/graphql-api.ts
+++ b/packages/graphql-api/src/lib/graphql-api.ts
@@ -413,6 +413,11 @@ export const createGraphqlApi = <R>(
      * does not depend on the host shell.
      */
     readonly environment?: Readonly<Record<string, string | undefined>>
+    /**
+     * Product version reported by `Query.version`. Defaults to `0.0.0` when
+     * the host does not inject a build-time version.
+     */
+    readonly version?: string
   } = {},
 ) => {
   const agentBackendCwd =
@@ -422,6 +427,7 @@ export const createGraphqlApi = <R>(
     options.keymaxxerMetadataTimeout ?? DEFAULT_KEYMAXXER_METADATA_TIMEOUT
   const environment =
     options.environment ?? (process.env as Record<string, string | undefined>)
+  const harnessVersion = options.version ?? "0.0.0"
   const tokenProvisioning = Effect.runSync(Semaphore.make(1))
 
   /**
@@ -476,6 +482,7 @@ export const createGraphqlApi = <R>(
       resolvers: {
         Query: {
           health: () => true,
+          version: () => harnessVersion,
           addRepositoryCommand: () =>
             resolveAddRepositoryCommand(commandExists),
           directoryPickerAvailable: async (

--- a/packages/graphql-api/test/graphql-api.test.ts
+++ b/packages/graphql-api/test/graphql-api.test.ts
@@ -486,6 +486,34 @@ describe("GraphQL API", () => {
     runtime = makeRuntime()
   })
 
+  test("reports the injected product version on Query.version", async () => {
+    const response = await createGraphqlApi(runtime, {
+      version: "0.18.0",
+    }).fetch(
+      graphqlRequest({
+        query: "{ version }",
+      }),
+    )
+
+    expect(response.status).toBe(200)
+    expect(await response.json()).toEqual({
+      data: { version: "0.18.0" },
+    })
+  })
+
+  test("defaults Query.version to the placeholder product version", async () => {
+    const response = await createGraphqlApi(runtime).fetch(
+      graphqlRequest({
+        query: "{ version }",
+      }),
+    )
+
+    expect(response.status).toBe(200)
+    expect(await response.json()).toEqual({
+      data: { version: "0.0.0" },
+    })
+  })
+
   test("serves GraphQL through the supplied runtime", async () => {
     const response = await createGraphqlApi(runtime).fetch(
       addRepositoryRequest(),

--- a/packages/graphql-schema/schema.graphql
+++ b/packages/graphql-schema/schema.graphql
@@ -4,6 +4,10 @@
 type Query {
   health: Boolean!
   """
+  Product version of the running Harness (same string as CLI --version).
+  """
+  version: String!
+  """
   Suggested CLI to add a local repository from the blank-slate empty state.
   Uses `ready-for-agent` when that binary is on PATH; otherwise `npx ready-for-agent`.
   """

--- a/packages/graphql-schema/schema.template.graphql
+++ b/packages/graphql-schema/schema.template.graphql
@@ -1,6 +1,10 @@
 type Query {
   health: Boolean!
   """
+  Product version of the running Harness (same string as CLI --version).
+  """
+  version: String!
+  """
   Suggested CLI to add a local repository from the blank-slate empty state.
   Uses `ready-for-agent` when that binary is on PATH; otherwise `npx ready-for-agent`.
   """

--- a/scripts/fix-bun-typescript-for-nx.mjs
+++ b/scripts/fix-bun-typescript-for-nx.mjs
@@ -7,16 +7,18 @@
  * Classic TS is already linked at the workspace root as `typescript`
  * (`@typescript/typescript6`) and also as `typescript@6.0.2` in the bun
  * store. Replacing the nested shadow with that classic package keeps the
- * path Nx already resolved, instead of deleting it and leaving a dangling
- * `typescript/lib/version.cjs` require. `@typescript/native` keeps its own
- * scoped path.
+ * path Nx already resolved. Classic 6 does not ship `lib/version.cjs`,
+ * which `@nx/js:typescript-sync` requires, so the shim writes a tiny
+ * compatible stub. `@typescript/native` keeps its own scoped path.
  */
 import {
   existsSync,
   lstatSync,
+  readFileSync,
   readdirSync,
   rmSync,
   symlinkSync,
+  writeFileSync,
 } from "node:fs"
 import { createRequire } from "node:module"
 import { dirname, join, relative } from "node:path"
@@ -46,7 +48,33 @@ const findClassicTypescript = () => {
   return undefined
 }
 
-if (isUsableClassicTypescript(nestedTypescript)) process.exit(0)
+const versionCjsPath = (packageRoot) => join(packageRoot, "lib", "version.cjs")
+
+const ensureVersionCjs = (packageRoot) => {
+  const dest = versionCjsPath(packageRoot)
+  if (existsSync(dest)) return false
+  const pkgPath = join(packageRoot, "package.json")
+  const raw = JSON.parse(readFileSync(pkgPath, "utf8"))
+  const version = typeof raw.version === "string" ? raw.version : "6.0.2"
+  const [major = "6", minor = "0"] = version.split(".")
+  writeFileSync(
+    dest,
+    `const { version } = require("../package.json");
+exports.version = version;
+exports.versionMajorMinor = ${JSON.stringify(`${major}.${minor}`)};
+`,
+  )
+  return true
+}
+
+if (isUsableClassicTypescript(nestedTypescript)) {
+  if (ensureVersionCjs(nestedTypescript)) {
+    console.log(
+      "fix-bun-typescript-for-nx: wrote lib/version.cjs for Nx typescript-sync",
+    )
+  }
+  process.exit(0)
+}
 
 if (existsSync(nestedTypescript)) {
   const stat = lstatSync(nestedTypescript)
@@ -65,6 +93,7 @@ symlinkSync(
   relative(dirname(nestedTypescript), classicTypescript),
   nestedTypescript,
 )
+ensureVersionCjs(nestedTypescript)
 console.log(
   "fix-bun-typescript-for-nx: pointed nested typescript at classic TypeScript so Nx keeps readConfigFile",
 )

--- a/scripts/fix-bun-typescript-for-nx.test.ts
+++ b/scripts/fix-bun-typescript-for-nx.test.ts
@@ -1,0 +1,41 @@
+import { spawnSync } from "node:child_process"
+import { existsSync, readFileSync } from "node:fs"
+import { createRequire } from "node:module"
+import { join } from "node:path"
+import { describe, expect, it } from "bun:test"
+
+const workspaceRoot = join(import.meta.dir, "..")
+const nestedTypescript = join(
+  workspaceRoot,
+  "node_modules",
+  ".bun",
+  "node_modules",
+  "typescript",
+)
+
+describe("fix-bun-typescript-for-nx", () => {
+  it("keeps nested typescript classic and provides version.cjs for Nx", () => {
+    const result = spawnSync(
+      process.execPath,
+      [join(workspaceRoot, "scripts/fix-bun-typescript-for-nx.mjs")],
+      { cwd: workspaceRoot, encoding: "utf8" },
+    )
+    expect(result.status).toBe(0)
+
+    const ts = createRequire(join(nestedTypescript, "package.json"))(".")
+    expect(typeof ts.readConfigFile).toBe("function")
+
+    const versionCjs = join(nestedTypescript, "lib", "version.cjs")
+    expect(existsSync(versionCjs)).toBe(true)
+    const version = createRequire(versionCjs)(versionCjs)
+    expect(typeof version.version).toBe("string")
+    expect(version.version.length).toBeGreaterThan(0)
+    expect(version.versionMajorMinor).toMatch(/^\d+\.\d+$/)
+  })
+
+  it("runs from the pre-commit Nx steps so typescript-sync sees classic TypeScript", () => {
+    const hk = readFileSync(join(workspaceRoot, "hk.pkl"), "utf8")
+    const shim = "node scripts/fix-bun-typescript-for-nx.mjs"
+    expect(hk.split(shim).length - 1).toBe(2)
+  })
+})

--- a/scripts/project.json
+++ b/scripts/project.json
@@ -8,7 +8,7 @@
     "test": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "bun test tool-pins.test.ts",
+        "command": "bun test tool-pins.test.ts fix-bun-typescript-for-nx.test.ts",
         "cwd": "{projectRoot}"
       },
       "inputs": [
@@ -16,7 +16,9 @@
         "{workspaceRoot}/hk.pkl",
         "{workspaceRoot}/.github/**/*.yml",
         "{workspaceRoot}/.github/**/*.yaml",
-        "{projectRoot}/tool-pins.test.ts"
+        "{projectRoot}/tool-pins.test.ts",
+        "{projectRoot}/fix-bun-typescript-for-nx.mjs",
+        "{projectRoot}/fix-bun-typescript-for-nx.test.ts"
       ],
       "cache": true
     }


### PR DESCRIPTION
A newer CLI talking to a still-running older Harness failed `candidates`
and `status` with `GRAPHQL_VALIDATION_FAILED` and an internal field name
(`intakeCandidates`, `kanbanStatus`). Those commands exist in `--help`,
so the output read as a broken CLI rather than "restart the Harness."

Missing GraphQL fields this CLI requires are now remapped to
`HARNESS_VERSION_MISMATCH`. The message names this CLI version, the
Harness origin, the operator command, and how to upgrade
(`ready-for-agent start`). When the Harness can answer `Query.version`,
the message also names the server version; pre-`version` servers omit
that clause.

Also added `Query.version` on the Harness and ran the Bun/Nx TypeScript
shim from pre-commit so `typescript-sync` keeps `readConfigFile`.

Verified with CLI error-mapping tests, process contracts for old
`candidates`/`status` (with and without `Query.version`), GraphQL
`version` tests, and the Effect CLI suite. A review note about
duplicated process-test servers was left as-is to match the existing
contract style.

Closes #1072