### PR TITLE
feat: exclude explicit-profile work items from backend change gates

### DIFF
--- a/apps/harness/test/harness-settings-backend-change.test.ts
+++ b/apps/harness/test/harness-settings-backend-change.test.ts
@@ -18,6 +18,10 @@ describe("Harness settings Agent Backend change", () => {
     expect(source).toContain("harnessModelPrefs")
     expect(source).toContain("blockingUnfinishedWorkItemCount")
     expect(source).toContain("backendChangeBlocked")
+    expect(source).toContain(
+      "on Repositories inheriting the harness default — finish or abandon them before changing the default Agent Backend.",
+    )
+    expect(source).toContain("unfinished fleet-wide.")
     expect(source).toContain("Activates immediately on Save")
     expect(source).not.toContain("Cleared — choose after restart")
     expect(source).not.toContain("Takes effect after restart")

--- a/apps/harness/test/repository-settings-agent-backend.test.ts
+++ b/apps/harness/test/repository-settings-agent-backend.test.ts
@@ -32,6 +32,9 @@ describe("Repository settings Agent Backend override", () => {
     expect(source).toContain("backendChangeBlocked")
     expect(source).toContain("blockingUnfinishedWorkItemCount")
     expect(source).toContain("on this Repository")
+    expect(source).toContain(
+      "on this Repository — finish or abandon them before changing Agent Backend.",
+    )
     expect(source).toMatch(
       /updateSettings\.mutate\(\{[\s\S]*selectedAgentBackend,[\s\S]*\}\)/,
     )

--- a/hk.pkl
+++ b/hk.pkl
@@ -20,7 +20,12 @@ esac
       }
       ["bun-lockfile"] {
         depends = "descriptive-branch"
-        check = "bun install --frozen-lockfile --lockfile-only --silent --minimum-release-age 0"
+        // lockfile-only does not run prepare, so re-apply the nested TypeScript
+        // shim that Nx needs (readConfigFile + lib/version.cjs).
+        check = #"""
+bun install --frozen-lockfile --lockfile-only --silent --minimum-release-age 0
+node scripts/fix-bun-typescript-for-nx.mjs
+"""#
       }
       ["biome-json"] {
         depends = "bun-lockfile"
@@ -38,7 +43,9 @@ esac
         fix = #"""
 node scripts/fix-bun-typescript-for-nx.mjs
 unset $(git rev-parse --local-env-vars)
-for v in $(printenv | cut -d= -f1 | grep '^NX_'); do unset "$v"; done
+for v in $(printenv | cut -d= -f1 | grep '^NX_' || true); do unset "$v"; done
+export NX_DAEMON=false
+export NX_WORKSPACE_ROOT="$(git rev-parse --show-toplevel)"
 bunx nx affected -t lint --fix --batch --excludeTaskDependencies
 """#
       }
@@ -47,7 +54,9 @@ bunx nx affected -t lint --fix --batch --excludeTaskDependencies
         check = #"""
 node scripts/fix-bun-typescript-for-nx.mjs
 unset $(git rev-parse --local-env-vars)
-for v in $(printenv | cut -d= -f1 | grep '^NX_'); do unset "$v"; done
+for v in $(printenv | cut -d= -f1 | grep '^NX_' || true); do unset "$v"; done
+export NX_DAEMON=false
+export NX_WORKSPACE_ROOT="$(git rev-parse --show-toplevel)"
 bunx nx affected -t lint,typecheck,test --batch
 """#
       }

--- a/packages/db-service/src/lib/db-service.ts
+++ b/packages/db-service/src/lib/db-service.ts
@@ -177,11 +177,25 @@ const normalizeOptionalConfigSetting = (
 }
 
 /**
- * Unfinished Work Items block backend changes (includes Needs Human, paused,
- * Waiting for Worker Slot). Terminal complete/failed/abandoned do not.
+ * Unfinished Work Items include Needs Human, paused, and Waiting for Worker
+ * Slot. Terminal complete/failed/abandoned do not.
  */
 const isUnfinishedStateSql = (column = "state") =>
   `${column} NOT IN ('complete', 'failed', 'abandoned')`
+
+/**
+ * Backend-change gates count only unfinished ordinary Work Items. An Explicit
+ * Work Item Execution Profile is immutable, so those Work Items do not block
+ * Repository or Harness default backend changes.
+ */
+const isSettingsResolvedUnfinishedSql = (tableAlias?: string) => {
+  const stateColumn = tableAlias === undefined ? "state" : `${tableAlias}.state`
+  const profileColumn =
+    tableAlias === undefined
+      ? "execution_profile_present"
+      : `${tableAlias}.execution_profile_present`
+  return `${isUnfinishedStateSql(stateColumn)} AND ${profileColumn} = 0`
+}
 
 /**
  * Normalize a Repository Agent Backend override. Empty/whitespace → null
@@ -340,16 +354,18 @@ export interface DbServiceShape {
    */
   readonly countUnfinishedWorkItems: Effect.Effect<number, DatabaseError>
   /**
-   * Unfinished Work Items on Repositories that inherit the harness default
-   * (override is null). Blocks changing Config.selectedAgentBackend when > 0.
+   * Unfinished ordinary Work Items on Repositories that inherit the harness
+   * default (override is null). Explicit-profile Work Items are excluded.
+   * Blocks changing Config.selectedAgentBackend when > 0.
    */
   readonly countBlockingUnfinishedForGlobalDefault: Effect.Effect<
     number,
     DatabaseError
   >
   /**
-   * Unfinished Work Items on one Repository. Blocks changing that Repository's
-   * Agent Backend override when > 0.
+   * Unfinished ordinary Work Items on one Repository. Explicit-profile Work
+   * Items are excluded. Blocks changing that Repository's Agent Backend
+   * override when > 0.
    */
   readonly countBlockingUnfinishedForRepository: (
     repositoryId: string,
@@ -560,8 +576,8 @@ export const DbServiceLive = Layer.effect(
       }).pipe(Effect.withSpan("DbService.countUnfinishedWorkItems"))
 
     /**
-     * Unfinished Work Items on Repositories that inherit the harness default
-     * (override is null). These alone block changing the global default.
+     * Unfinished ordinary Work Items on Repositories that inherit the harness
+     * default (override is null). Explicit-profile Work Items do not block.
      */
     const countBlockingUnfinishedForGlobalDefault: Effect.Effect<
       number,
@@ -572,7 +588,7 @@ export const DbServiceLive = Layer.effect(
           `SELECT COUNT(*) AS count
              FROM work_item wi
              INNER JOIN repository r ON r.id = wi.repository_id
-             WHERE ${isUnfinishedStateSql("wi.state")}
+             WHERE ${isSettingsResolvedUnfinishedSql("wi")}
                AND r.selected_agent_backend IS NULL`,
         )
         .pipe(Effect.mapError(toDatabaseError))) as readonly {
@@ -584,7 +600,8 @@ export const DbServiceLive = Layer.effect(
     )
 
     /**
-     * Unfinished Work Items on one Repository (blocks that repo's override change).
+     * Unfinished ordinary Work Items on one Repository (blocks that repo's
+     * override change). Explicit-profile Work Items do not block.
      */
     const countBlockingUnfinishedForRepository = (
       repositoryId: string,
@@ -594,7 +611,7 @@ export const DbServiceLive = Layer.effect(
           .unsafe(
             `SELECT COUNT(*) AS count FROM work_item
              WHERE repository_id = ?
-               AND ${isUnfinishedStateSql()}`,
+               AND ${isSettingsResolvedUnfinishedSql()}`,
             [repositoryId],
           )
           .pipe(Effect.mapError(toDatabaseError))) as readonly {
@@ -837,8 +854,8 @@ export const DbServiceLive = Layer.effect(
             const changing =
               selectedAgentBackend !== latest.selectedAgentBackend
             if (changing) {
-              // Gate on inheriting repos only. Explicit-override WIP does not
-              // block the harness default change.
+              // Gate on ordinary inheriting WIP only. Explicit-override WIP
+              // and explicit-profile Work Items do not block this change.
               const count = yield* countBlockingUnfinishedForGlobalDefault
               if (count > 0) {
                 return yield* new AgentBackendChangeBlockedError({

--- a/packages/db-service/test/db-service.spec.ts
+++ b/packages/db-service/test/db-service.spec.ts
@@ -44,6 +44,88 @@ describe("DbService", () => {
     blockedBy: [],
   }
 
+  const insertWorkItem = (
+    sql: SqlClient.SqlClient,
+    input: {
+      readonly id: string
+      readonly repositoryId: string
+      readonly issueNumber: number
+      readonly state?: string
+      readonly agentBackend?: string
+      readonly explicitProfile?: {
+        readonly buildModel: string
+        readonly buildThinkingLevel: string | null
+        readonly reviewSameAsBuild?: boolean
+        readonly reviewModel?: string | null
+        readonly reviewThinkingLevel?: string | null
+      }
+    },
+  ) => {
+    const now = Date.now()
+    const state = input.state ?? "implement"
+    const agentBackend = input.agentBackend ?? "opencode"
+    const profile = input.explicitProfile
+    if (profile === undefined) {
+      return sql.unsafe(
+        `INSERT INTO work_item (
+           id, repository_id, issue_number, state, state_ready_at,
+           agent_backend, worktree_path, session_id, failure_code,
+           failure_message, created_at, updated_at
+         ) VALUES (?, ?, ?, ?, ?, ?, NULL, NULL, NULL, NULL, ?, ?)`,
+        [
+          input.id,
+          input.repositoryId,
+          input.issueNumber,
+          state,
+          now,
+          agentBackend,
+          now,
+          now,
+        ],
+      )
+    }
+    const sameAsBuild = profile.reviewSameAsBuild !== false
+    return sql.unsafe(
+      `INSERT INTO work_item (
+         id, repository_id, issue_number, state, state_ready_at,
+         agent_backend, execution_profile_present,
+         execution_profile_build_model, execution_profile_build_thinking_level,
+         execution_profile_review_same_as_build,
+         execution_profile_review_model, execution_profile_review_thinking_level,
+         worktree_path, session_id, failure_code, failure_message,
+         created_at, updated_at
+       ) VALUES (?, ?, ?, ?, ?, ?, 1, ?, ?, ?, ?, ?, NULL, NULL, NULL, NULL, ?, ?)`,
+      [
+        input.id,
+        input.repositoryId,
+        input.issueNumber,
+        state,
+        now,
+        agentBackend,
+        profile.buildModel,
+        profile.buildThinkingLevel,
+        sameAsBuild ? 1 : 0,
+        sameAsBuild ? null : (profile.reviewModel ?? null),
+        sameAsBuild ? null : (profile.reviewThinkingLevel ?? null),
+        now,
+        now,
+      ],
+    )
+  }
+
+  const readWorkItemProfile = (sql: SqlClient.SqlClient, id: string) =>
+    sql.unsafe(
+      `SELECT agent_backend AS agentBackend,
+              execution_profile_present AS executionProfilePresent,
+              execution_profile_build_model AS buildModel,
+              execution_profile_build_thinking_level AS buildThinkingLevel,
+              execution_profile_review_same_as_build AS reviewSameAsBuild,
+              execution_profile_review_model AS reviewModel,
+              execution_profile_review_thinking_level AS reviewThinkingLevel
+       FROM work_item WHERE id = ?`,
+      [id],
+    )
+
   describe("config", () => {
     it("returns null build model on empty DB and persists updates", () =>
       runTest(
@@ -368,6 +450,136 @@ describe("DbService", () => {
             "opencode",
             "grok",
           ])
+        }),
+      ))
+
+    it("allows default Agent Backend change when only explicit-profile Work Items are unfinished on inheriting Repositories", () =>
+      runTest(
+        Effect.gen(function* () {
+          const db = yield* DbService
+          const sql = yield* SqlClient.SqlClient
+          const inheriting = yield* db.addRepository(sampleInput)
+          yield* insertWorkItem(sql, {
+            id: "wi-explicit-inheriting",
+            repositoryId: inheriting.id,
+            issueNumber: 7,
+            agentBackend: "grok",
+            explicitProfile: {
+              buildModel: "grok-code",
+              buildThinkingLevel: "high",
+            },
+          })
+
+          expect(yield* db.countUnfinishedWorkItems).toBe(1)
+          expect(yield* db.countBlockingUnfinishedForGlobalDefault).toBe(0)
+          expect(
+            yield* db.countBlockingUnfinishedForRepository(inheriting.id),
+          ).toBe(0)
+
+          const switched = yield* db.updateConfig({
+            selectedAgentBackend: "claude",
+            defaultModel: null,
+            defaultThinkingLevel: null,
+            reviewModel: null,
+            reviewThinkingLevel: null,
+            maxConcurrentAgentTurns: 2,
+            maxConcurrentWorkItems: 5,
+          })
+          expect(switched.selectedAgentBackend).toBe("claude")
+          expect(yield* db.countUnfinishedWorkItems).toBe(1)
+          const profile = (yield* readWorkItemProfile(
+            sql,
+            "wi-explicit-inheriting",
+          ))[0]
+          expect(profile).toMatchObject({
+            agentBackend: "grok",
+            executionProfilePresent: 1,
+            buildModel: "grok-code",
+            buildThinkingLevel: "high",
+            reviewSameAsBuild: 1,
+            reviewModel: null,
+            reviewThinkingLevel: null,
+          })
+          expect(yield* db.listSelectedOrInUseBackendIds).toEqual([
+            "claude",
+            "grok",
+          ])
+        }),
+      ))
+
+    it("blocks default Agent Backend change only for ordinary inheriting Work Items", () =>
+      runTest(
+        Effect.gen(function* () {
+          const db = yield* DbService
+          const sql = yield* SqlClient.SqlClient
+          const inheriting = yield* db.addRepository(sampleInput)
+          const overridden = yield* db.addRepository({
+            forge: "github",
+            forgeHost: "github.com",
+            projectPath: "acme/other",
+            localPath: "/repos/acme/other.git",
+            isBare: true,
+          })
+          yield* db.updateRepositorySettings({
+            repositoryId: overridden.id,
+            paused: true,
+            selectedAgentBackend: "grok",
+            defaultModel: null,
+            defaultThinkingLevel: null,
+            reviewModel: null,
+            reviewThinkingLevel: null,
+            autoMerge: false,
+            includeAllIssueAuthors: false,
+            waitForReadyForReviewChecks: true,
+          })
+          yield* insertWorkItem(sql, {
+            id: "wi-ordinary-inheriting",
+            repositoryId: inheriting.id,
+            issueNumber: 1,
+            state: "needs_human",
+            agentBackend: "opencode",
+          })
+          yield* insertWorkItem(sql, {
+            id: "wi-explicit-inheriting",
+            repositoryId: inheriting.id,
+            issueNumber: 2,
+            agentBackend: "claude",
+            explicitProfile: {
+              buildModel: "claude-opus",
+              buildThinkingLevel: null,
+            },
+          })
+          yield* insertWorkItem(sql, {
+            id: "wi-ordinary-override",
+            repositoryId: overridden.id,
+            issueNumber: 3,
+            agentBackend: "grok",
+          })
+
+          const error = yield* Effect.flip(
+            db.updateConfig({
+              selectedAgentBackend: "grok",
+              defaultModel: null,
+              defaultThinkingLevel: null,
+              reviewModel: null,
+              reviewThinkingLevel: null,
+              maxConcurrentAgentTurns: 2,
+              maxConcurrentWorkItems: 5,
+            }),
+          )
+          expect(error).toMatchObject({
+            _tag: "AgentBackendChangeBlockedError",
+            unfinishedWorkItemCount: 1,
+            scope: "global",
+          })
+          expect(yield* db.countUnfinishedWorkItems).toBe(3)
+          expect(yield* db.countBlockingUnfinishedForGlobalDefault).toBe(1)
+          expect(
+            yield* db.countBlockingUnfinishedForRepository(inheriting.id),
+          ).toBe(1)
+          expect(
+            yield* db.countBlockingUnfinishedForRepository(overridden.id),
+          ).toBe(1)
         }),
       ))
 
@@ -984,6 +1196,117 @@ describe("DbService", () => {
           })
           expect(sameOverride.paused).toBe(false)
           expect(sameOverride.selectedAgentBackend).toBeNull()
+        }),
+      ))
+
+    it("allows Repository Agent Backend override change when only explicit-profile Work Items are unfinished", () =>
+      runTest(
+        Effect.gen(function* () {
+          const db = yield* DbService
+          const sql = yield* SqlClient.SqlClient
+          const repository = yield* db.addRepository(sampleInput)
+          yield* insertWorkItem(sql, {
+            id: "wi-explicit-repo",
+            repositoryId: repository.id,
+            issueNumber: 9,
+            agentBackend: "grok",
+            explicitProfile: {
+              buildModel: "grok-code",
+              buildThinkingLevel: "high",
+              reviewSameAsBuild: false,
+              reviewModel: "grok-review",
+              reviewThinkingLevel: "max",
+            },
+          })
+
+          expect(yield* db.countUnfinishedWorkItems).toBe(1)
+          expect(
+            yield* db.countBlockingUnfinishedForRepository(repository.id),
+          ).toBe(0)
+
+          const updated = yield* db.updateRepositorySettings({
+            repositoryId: repository.id,
+            paused: true,
+            selectedAgentBackend: "claude",
+            defaultModel: null,
+            defaultThinkingLevel: null,
+            reviewModel: null,
+            reviewThinkingLevel: null,
+            autoMerge: false,
+            includeAllIssueAuthors: false,
+            waitForReadyForReviewChecks: true,
+          })
+          expect(updated.selectedAgentBackend).toBe("claude")
+          const profile = (yield* readWorkItemProfile(
+            sql,
+            "wi-explicit-repo",
+          ))[0]
+          expect(profile).toMatchObject({
+            agentBackend: "grok",
+            executionProfilePresent: 1,
+            buildModel: "grok-code",
+            buildThinkingLevel: "high",
+            reviewSameAsBuild: 0,
+            reviewModel: "grok-review",
+            reviewThinkingLevel: "max",
+          })
+          expect(yield* db.listSelectedOrInUseBackendIds).toEqual([
+            "opencode",
+            "claude",
+            "grok",
+          ])
+        }),
+      ))
+
+    it("blocks Repository Agent Backend override change only for ordinary unfinished Work Items", () =>
+      runTest(
+        Effect.gen(function* () {
+          const db = yield* DbService
+          const sql = yield* SqlClient.SqlClient
+          const repository = yield* db.addRepository(sampleInput)
+          yield* insertWorkItem(sql, {
+            id: "wi-ordinary-repo",
+            repositoryId: repository.id,
+            issueNumber: 1,
+            state: "needs_human",
+            agentBackend: "opencode",
+          })
+          yield* insertWorkItem(sql, {
+            id: "wi-explicit-repo",
+            repositoryId: repository.id,
+            issueNumber: 2,
+            agentBackend: "grok",
+            explicitProfile: {
+              buildModel: "grok-code",
+              buildThinkingLevel: null,
+            },
+          })
+
+          expect(yield* db.countUnfinishedWorkItems).toBe(2)
+          expect(
+            yield* db.countBlockingUnfinishedForRepository(repository.id),
+          ).toBe(1)
+
+          const error = yield* Effect.flip(
+            db.updateRepositorySettings({
+              repositoryId: repository.id,
+              paused: true,
+              selectedAgentBackend: "claude",
+              defaultModel: null,
+              defaultThinkingLevel: null,
+              reviewModel: null,
+              reviewThinkingLevel: null,
+              autoMerge: false,
+              includeAllIssueAuthors: false,
+              waitForReadyForReviewChecks: true,
+            }),
+          )
+          expect(error).toMatchObject({
+            _tag: "AgentBackendChangeBlockedError",
+            unfinishedWorkItemCount: 1,
+            scope: "repository",
+            repositoryId: repository.id,
+          })
         }),
       ))
 

--- a/packages/graphql-api/test/graphql-api.test.ts
+++ b/packages/graphql-api/test/graphql-api.test.ts
@@ -9,7 +9,11 @@ import {
   missingSessionTelemetry,
   toAgentBackendStatus,
 } from "@ready-for-agent/agent-backend"
-import { DbService, type DbServiceShape } from "@ready-for-agent/db-service"
+import {
+  AgentBackendChangeBlockedError,
+  DbService,
+  type DbServiceShape,
+} from "@ready-for-agent/db-service"
 import {
   makeRepositoryRecord,
   stubDbService,
@@ -2456,6 +2460,207 @@ describe("GraphQL API", () => {
         projectPath: repository.projectPath,
       },
     ])
+  })
+
+  test("updateConfig returns a zero blocking count while unfinished Work Items remain", async () => {
+    await runtime.dispose()
+    runtime = makeRuntime({
+      countUnfinishedWorkItems: Effect.succeed(2),
+      countBlockingUnfinishedForGlobalDefault: Effect.succeed(0),
+    })
+
+    const response = await createGraphqlApi(runtime).fetch(
+      graphqlRequest({
+        query: `mutation UpdateConfig($input: UpdateConfigInput!) {
+          updateConfig(input: $input) {
+            selectedAgentBackend
+            unfinishedWorkItemCount
+            blockingUnfinishedWorkItemCount
+          }
+        }`,
+        variables: {
+          input: {
+            selectedAgentBackend: "grok",
+            defaultModel: null,
+            defaultThinkingLevel: null,
+            reviewModel: null,
+            reviewThinkingLevel: null,
+            maxConcurrentAgentTurns: 2,
+            maxConcurrentWorkItems: 5,
+          },
+        },
+      }),
+    )
+    expect(await response.json()).toEqual({
+      data: {
+        updateConfig: {
+          selectedAgentBackend: "grok",
+          unfinishedWorkItemCount: 2,
+          blockingUnfinishedWorkItemCount: 0,
+        },
+      },
+    })
+  })
+
+  test("updateConfig maps AgentBackendChangeBlockedError for a global ordinary gate", async () => {
+    await runtime.dispose()
+    runtime = makeRuntime({
+      updateConfig: () =>
+        Effect.fail(
+          new AgentBackendChangeBlockedError({
+            message:
+              "Cannot change default Agent Backend while 1 Work Item(s) are unfinished on Repositories that inherit the default",
+            unfinishedWorkItemCount: 1,
+            scope: "global",
+          }),
+        ),
+    })
+
+    const response = await createGraphqlApi(runtime).fetch(
+      graphqlRequest({
+        query: `mutation UpdateConfig($input: UpdateConfigInput!) {
+          updateConfig(input: $input) { selectedAgentBackend }
+        }`,
+        variables: {
+          input: {
+            selectedAgentBackend: "grok",
+            defaultModel: null,
+            defaultThinkingLevel: null,
+            reviewModel: null,
+            reviewThinkingLevel: null,
+            maxConcurrentAgentTurns: 2,
+            maxConcurrentWorkItems: 5,
+          },
+        },
+      }),
+    )
+    expect(await response.json()).toEqual({
+      data: null,
+      errors: [
+        expect.objectContaining({
+          message:
+            "Cannot change default Agent Backend while 1 Work Item(s) are unfinished on Repositories that inherit the default",
+          extensions: {
+            code: "AGENT_BACKEND_CHANGE_BLOCKED",
+            unfinishedWorkItemCount: 1,
+            scope: "global",
+          },
+        }),
+      ],
+    })
+  })
+
+  test("updateRepositorySettings persists an override when the repository blocking count is zero", async () => {
+    await runtime.dispose()
+    let savedBackend: string | null | undefined
+    runtime = makeRuntime({
+      countBlockingUnfinishedForRepository: () => Effect.succeed(0),
+      updateRepositorySettings: (input) => {
+        savedBackend = input.selectedAgentBackend
+        return Effect.succeed({
+          ...repository,
+          paused: input.paused,
+          selectedAgentBackend:
+            input.selectedAgentBackend === undefined
+              ? repository.selectedAgentBackend
+              : input.selectedAgentBackend,
+          defaultModel: input.defaultModel,
+          defaultThinkingLevel: input.defaultThinkingLevel,
+          reviewModel: input.reviewModel,
+          reviewThinkingLevel: input.reviewThinkingLevel,
+          autoMerge: input.autoMerge,
+          includeAllIssueAuthors: input.includeAllIssueAuthors,
+          waitForReadyForReviewChecks: input.waitForReadyForReviewChecks,
+        })
+      },
+    })
+
+    const response = await createGraphqlApi(runtime).fetch(
+      graphqlRequest({
+        query: `mutation UpdateRepositorySettings($input: UpdateRepositorySettingsInput!) {
+          updateRepositorySettings(input: $input) {
+            selectedAgentBackend
+            blockingUnfinishedWorkItemCount
+          }
+        }`,
+        variables: {
+          input: {
+            repositoryId: repository.id,
+            paused: true,
+            selectedAgentBackend: "grok",
+            defaultModel: null,
+            defaultThinkingLevel: null,
+            reviewModel: null,
+            reviewThinkingLevel: null,
+            autoMerge: false,
+            includeAllIssueAuthors: false,
+            waitForReadyForReviewChecks: true,
+          },
+        },
+      }),
+    )
+    expect(await response.json()).toEqual({
+      data: {
+        updateRepositorySettings: {
+          selectedAgentBackend: "grok",
+          blockingUnfinishedWorkItemCount: 0,
+        },
+      },
+    })
+    expect(savedBackend).toBe("grok")
+  })
+
+  test("updateRepositorySettings maps AgentBackendChangeBlockedError for a repository ordinary gate", async () => {
+    await runtime.dispose()
+    runtime = makeRuntime({
+      updateRepositorySettings: () =>
+        Effect.fail(
+          new AgentBackendChangeBlockedError({
+            message:
+              "Cannot change Repository Agent Backend while 1 Work Item(s) are unfinished on this Repository",
+            unfinishedWorkItemCount: 1,
+            scope: "repository",
+            repositoryId: repository.id,
+          }),
+        ),
+    })
+
+    const response = await createGraphqlApi(runtime).fetch(
+      graphqlRequest({
+        query: `mutation UpdateRepositorySettings($input: UpdateRepositorySettingsInput!) {
+          updateRepositorySettings(input: $input) { selectedAgentBackend }
+        }`,
+        variables: {
+          input: {
+            repositoryId: repository.id,
+            paused: true,
+            selectedAgentBackend: "grok",
+            defaultModel: null,
+            defaultThinkingLevel: null,
+            reviewModel: null,
+            reviewThinkingLevel: null,
+            autoMerge: false,
+            includeAllIssueAuthors: false,
+            waitForReadyForReviewChecks: true,
+          },
+        },
+      }),
+    )
+    expect(await response.json()).toEqual({
+      data: null,
+      errors: [
+        expect.objectContaining({
+          message:
+            "Cannot change Repository Agent Backend while 1 Work Item(s) are unfinished on this Repository",
+          extensions: {
+            code: "AGENT_BACKEND_CHANGE_BLOCKED",
+            unfinishedWorkItemCount: 1,
+            scope: "repository",
+            repositoryId: repository.id,
+          },
+        }),
+      ],
+    })
   })
 
   test("reports ambient GitLab credential status when no vault secret exists", async () => {

--- a/packages/graphql-schema/schema.graphql
+++ b/packages/graphql-schema/schema.graphql
@@ -392,8 +392,9 @@ type Config {
   """
   unfinishedWorkItemCount: Int!
   """
-  Unfinished Work Items on Repositories that inherit the harness default.
-  Changing selectedAgentBackend is rejected while this is greater than zero.
+  Unfinished ordinary Work Items on Repositories that inherit the harness
+  default. Explicit-profile Work Items are excluded. Changing
+  selectedAgentBackend is rejected while this is greater than zero.
   """
   blockingUnfinishedWorkItemCount: Int!
 }
@@ -456,8 +457,9 @@ type Repository {
   waitForReadyForReviewChecks: Boolean!
   issuesReconciledAt: String
   """
-  Unfinished Work Items on this Repository. Changing selectedAgentBackend is
-  rejected while this is greater than zero.
+  Unfinished ordinary Work Items on this Repository. Explicit-profile Work
+  Items are excluded. Changing selectedAgentBackend is rejected while this
+  is greater than zero.
   """
   blockingUnfinishedWorkItemCount: Int!
   """

--- a/packages/graphql-schema/schema.template.graphql
+++ b/packages/graphql-schema/schema.template.graphql
@@ -389,8 +389,9 @@ type Config {
   """
   unfinishedWorkItemCount: Int!
   """
-  Unfinished Work Items on Repositories that inherit the harness default.
-  Changing selectedAgentBackend is rejected while this is greater than zero.
+  Unfinished ordinary Work Items on Repositories that inherit the harness
+  default. Explicit-profile Work Items are excluded. Changing
+  selectedAgentBackend is rejected while this is greater than zero.
   """
   blockingUnfinishedWorkItemCount: Int!
 }
@@ -453,8 +454,9 @@ type Repository {
   waitForReadyForReviewChecks: Boolean!
   issuesReconciledAt: String
   """
-  Unfinished Work Items on this Repository. Changing selectedAgentBackend is
-  rejected while this is greater than zero.
+  Unfinished ordinary Work Items on this Repository. Explicit-profile Work
+  Items are excluded. Changing selectedAgentBackend is rejected while this
+  is greater than zero.
   """
   blockingUnfinishedWorkItemCount: Int!
   """

--- a/scripts/fix-bun-typescript-for-nx.test.ts
+++ b/scripts/fix-bun-typescript-for-nx.test.ts
@@ -36,6 +36,7 @@ describe("fix-bun-typescript-for-nx", () => {
   it("runs from the pre-commit Nx steps so typescript-sync sees classic TypeScript", () => {
     const hk = readFileSync(join(workspaceRoot, "hk.pkl"), "utf8")
     const shim = "node scripts/fix-bun-typescript-for-nx.mjs"
-    expect(hk.split(shim).length - 1).toBe(2)
+    // bun-lockfile (prepare is skipped), nx-lint-fix, and nx-affected.
+    expect(hk.split(shim).length - 1).toBe(3)
   })
 })

--- a/scripts/tool-pins.test.ts
+++ b/scripts/tool-pins.test.ts
@@ -62,6 +62,11 @@ describe("contributor environment pins", () => {
     )
   })
 
+  it("re-applies the nested TypeScript shim after the lockfile-only hook step", () => {
+    expect(hkPkl).toContain("scripts/fix-bun-typescript-for-nx.mjs")
+    expect(hkPkl).toContain("export NX_DAEMON=false")
+  })
+
   it("declares bootstrap as bun install and setup-e2e as Harness Playwright Chromium", () => {
     const bootstrap = tomlTable(miseToml, "tasks.bootstrap")
     expect(bootstrap).toBeDefined()


### PR DESCRIPTION
Unfinished Implement With Work Items have an immutable Explicit Work
Item Execution Profile, so Repository overrides and the Harness default
cannot change their routing or models. Those Work Items were still
incrementing the scoped backend-change counts and blocking unrelated
saved-default edits (#1036).

`countBlockingUnfinishedForRepository` and
`countBlockingUnfinishedForGlobalDefault` now count only unfinished
ordinary Work Items (`execution_profile_present = 0`). Fleet unfinished
totals, uniqueness, identity, concurrency, and
`listSelectedOrInUseBackendIds` still include every unfinished Work
Item, including a backend captured only through Implement With.
Settings writes do not rewrite profile columns.

Persistence tests cover allow/block for both scopes and profile
immutability after a successful change. GraphQL settings mutations
assert scoped counts and `AGENT_BACKEND_CHANGE_BLOCKED` mapping.
Harness tests keep the operator-facing disable copy on the scoped
blocking count.

GraphQL still stubs `DbService` for those mutations; the real exclusion
is in persistence. The staged hook TypeScript shim (`hk.pkl`,
`fix-bun-typescript-for-nx.mjs`) is unrelated environment durability
for Nx pre-commit, not part of the gate contract.

Closes #1036