### PR TITLE
feat(harness): add Implement With issue dialog for explicit profiles

### DIFF
--- a/apps/harness/src/completed-work-item-row.tsx
+++ b/apps/harness/src/completed-work-item-row.tsx
@@ -8,6 +8,7 @@ import {
   planArchiveLegs,
 } from "./archive-legs.js"
 import { Copy } from "./copy.js"
+import { ExecutionProfileSummary } from "./execution-profile-summary.js"
 import {
   forgeChangeRequestNoun,
   forgeChangeRequestShort,
@@ -174,6 +175,10 @@ export function CompletedWorkItemRow({
         </p>
       )}
 
+      <ExecutionProfileSummary
+        className="mt-[0.25rem]"
+        profile={workItem.executionProfile}
+      />
       <p className={ui.archiveMeta}>
         {workItem.agentBackend.label}
         {sessionId !== null ? (

--- a/apps/harness/src/execution-profile-draft.ts
+++ b/apps/harness/src/execution-profile-draft.ts
@@ -1,0 +1,235 @@
+import {
+  type AgentModelCatalogState,
+  type AgentModelOption,
+  blocksAgentModelSave,
+  isClaudeBedrockConfigurationMode,
+  reconcileVariantForModel,
+  thinkingLevelsForModel,
+} from "./agent-model-settings.js"
+
+/** Backend-scoped model fields shared by Repository settings and Harness Config. */
+export type ExecutionProfilePrefSource = {
+  readonly defaultModel: string | null
+  readonly defaultThinkingLevel: string | null
+  readonly reviewModel: string | null
+  readonly reviewThinkingLevel: string | null
+}
+
+/**
+ * Dialog draft for one Implement With attempt. Review is either Same as build
+ * or an explicit review model; those two cannot both be true.
+ */
+export type ExecutionProfileDraft =
+  | {
+      readonly buildModel: string
+      readonly buildThinkingLevel: string
+      readonly reviewSameAsBuild: true
+    }
+  | {
+      readonly buildModel: string
+      readonly buildThinkingLevel: string
+      readonly reviewSameAsBuild: false
+      readonly reviewModel: string
+      readonly reviewThinkingLevel: string
+    }
+
+const nonEmpty = (value: string | null | undefined): value is string =>
+  value !== null && value !== undefined && value.trim() !== ""
+
+const asField = (value: string | null | undefined): string =>
+  nonEmpty(value) ? value : ""
+
+/**
+ * Pre-fill Implement With from currently resolved backend-scoped Repository
+ * then Harness preferences. A missing build model stays blank. Review stays
+ * Same as build unless an explicit review model is configured.
+ */
+export const resolveExecutionProfileDraft = (input: {
+  readonly repository: ExecutionProfilePrefSource
+  readonly harness: ExecutionProfilePrefSource
+}): ExecutionProfileDraft => {
+  const buildModel = nonEmpty(input.repository.defaultModel)
+    ? input.repository.defaultModel
+    : asField(input.harness.defaultModel)
+  const buildThinkingLevel = nonEmpty(input.repository.defaultModel)
+    ? asField(input.repository.defaultThinkingLevel)
+    : asField(input.harness.defaultThinkingLevel)
+  const explicitReview = nonEmpty(input.repository.reviewModel)
+    ? {
+        reviewModel: input.repository.reviewModel,
+        reviewThinkingLevel: asField(input.repository.reviewThinkingLevel),
+      }
+    : nonEmpty(input.harness.reviewModel)
+      ? {
+          reviewModel: input.harness.reviewModel,
+          reviewThinkingLevel: asField(input.harness.reviewThinkingLevel),
+        }
+      : null
+  if (explicitReview === null) {
+    return {
+      buildModel,
+      buildThinkingLevel,
+      reviewSameAsBuild: true,
+    }
+  }
+  return {
+    buildModel,
+    buildThinkingLevel,
+    reviewSameAsBuild: false,
+    reviewModel: explicitReview.reviewModel,
+    reviewThinkingLevel: explicitReview.reviewThinkingLevel,
+  }
+}
+
+/** GraphQL `implementWith` profile input. */
+export type ImplementWithProfileInput = {
+  readonly agentBackendId: string
+  readonly buildModel: string
+  readonly buildThinkingLevel: string | null
+  readonly reviewSameAsBuild: boolean
+  readonly reviewModel: string | null
+  readonly reviewThinkingLevel: string | null
+}
+
+const emptyToNull = (value: string): string | null =>
+  value.trim().length === 0 ? null : value
+
+export const executionProfileInputFromDraft = (input: {
+  readonly agentBackendId: string
+  readonly draft: ExecutionProfileDraft
+}): ImplementWithProfileInput => {
+  if (input.draft.reviewSameAsBuild) {
+    return {
+      agentBackendId: input.agentBackendId,
+      buildModel: input.draft.buildModel,
+      buildThinkingLevel: emptyToNull(input.draft.buildThinkingLevel),
+      reviewSameAsBuild: true,
+      reviewModel: null,
+      reviewThinkingLevel: null,
+    }
+  }
+  return {
+    agentBackendId: input.agentBackendId,
+    buildModel: input.draft.buildModel,
+    buildThinkingLevel: emptyToNull(input.draft.buildThinkingLevel),
+    reviewSameAsBuild: false,
+    reviewModel: emptyToNull(input.draft.reviewModel),
+    reviewThinkingLevel: emptyToNull(input.draft.reviewThinkingLevel),
+  }
+}
+
+/**
+ * READY preview catalogs stay usable even when a later refetch fails (React
+ * Query keeps the last successful data). Only an explicit non-READY inspect
+ * or a failure with no cached READY catalog is empty/failed.
+ */
+export const usablePreviewCatalog = (input: {
+  readonly preview:
+    | {
+        readonly kind: string
+        readonly models: readonly AgentModelOption[]
+      }
+    | undefined
+  readonly previewFailed: boolean
+}): {
+  readonly models: readonly AgentModelOption[] | undefined
+  readonly failed: boolean
+} => {
+  if (input.preview?.kind === "READY") {
+    return { models: input.preview.models, failed: false }
+  }
+  if (input.preview === undefined) {
+    return { models: undefined, failed: input.previewFailed }
+  }
+  return { models: [], failed: true }
+}
+
+/**
+ * Reconcile Thinking Levels against the current catalog so the dialog cannot
+ * submit an illegal model/effort pair. An unloaded catalog is not evidence of
+ * absence — keep the current draft until membership is known.
+ */
+export const reconcileExecutionProfileDraft = (input: {
+  readonly draft: ExecutionProfileDraft
+  readonly models: readonly AgentModelOption[] | undefined
+}): ExecutionProfileDraft => {
+  if (input.models === undefined) {
+    return input.draft
+  }
+  const buildThinkingLevel = reconcileVariantForModel(
+    input.draft.buildThinkingLevel,
+    thinkingLevelsForModel(input.models, input.draft.buildModel),
+  )
+  if (input.draft.reviewSameAsBuild) {
+    return {
+      buildModel: input.draft.buildModel,
+      buildThinkingLevel,
+      reviewSameAsBuild: true,
+    }
+  }
+  return {
+    buildModel: input.draft.buildModel,
+    buildThinkingLevel,
+    reviewSameAsBuild: false,
+    reviewModel: input.draft.reviewModel,
+    reviewThinkingLevel: reconcileVariantForModel(
+      input.draft.reviewThinkingLevel,
+      thinkingLevelsForModel(input.models, input.draft.reviewModel),
+    ),
+  }
+}
+
+/**
+ * Operator-facing catalog block copy for Implement With. Does not mention
+ * Recheck, Settings, or Save — this dialog has no recovery detour.
+ */
+export const implementWithCatalogBlockReason = (
+  input: AgentModelCatalogState & {
+    readonly modelId: string
+    readonly requireSelection: boolean
+    readonly backendId: string
+    readonly configurationMode?: string | null
+    readonly discoveryWarnings?: readonly string[]
+  },
+): string | null => {
+  if (
+    !blocksAgentModelSave({
+      catalogLoading: input.catalogLoading,
+      catalogFailed: input.catalogFailed,
+      catalogModels: input.catalogModels,
+      modelId: input.modelId,
+      requireSelection: input.requireSelection,
+    })
+  ) {
+    return null
+  }
+  const bedrock = isClaudeBedrockConfigurationMode(
+    input.backendId,
+    input.configurationMode,
+  )
+  if (input.catalogFailed === true) {
+    return "Could not load the Agent Model catalog."
+  }
+  if (input.catalogLoading || input.catalogModels === undefined) {
+    return "Loading the Agent Model catalog…"
+  }
+  if (input.catalogModels.length === 0) {
+    const warning = input.discoveryWarnings?.find(
+      (entry) => entry.trim().length > 0,
+    )
+    if (warning !== undefined) {
+      return warning
+    }
+    return bedrock
+      ? "No active Anthropic-backed Bedrock inference profiles were found for the resolved AWS region."
+      : "Implement With requires a non-empty Agent Model catalog."
+  }
+  if (input.modelId.length === 0) {
+    return bedrock
+      ? "Select a discovered Bedrock inference profile."
+      : "Select a model from the Agent Model catalog."
+  }
+  return bedrock
+    ? "The selected model is not in the current Bedrock profile catalog. Choose a discovered profile."
+    : "The selected model is not in the current Agent Model catalog. Choose a listed model."
+}

--- a/apps/harness/src/execution-profile-summary.tsx
+++ b/apps/harness/src/execution-profile-summary.tsx
@@ -1,0 +1,60 @@
+import type { ReactNode } from "react"
+import { formatVariantLabel } from "./agent-model-settings.js"
+import { ui } from "./ui.js"
+
+export type WorkItemExecutionProfileView = {
+  readonly backend: { readonly id: string; readonly label: string }
+  readonly buildModel: string
+  readonly buildThinkingLevel: string | null
+  readonly reviewSameAsBuild: boolean
+  readonly reviewModel: string
+  readonly reviewThinkingLevel: string | null
+}
+
+const selectionLabel = (input: {
+  readonly model: string
+  readonly thinkingLevel: string | null
+}): string => {
+  if (input.thinkingLevel === null || input.thinkingLevel === "") {
+    return input.model
+  }
+  return `${input.model} · ${formatVariantLabel(input.thinkingLevel)}`
+}
+
+/**
+ * Operator-facing Explicit Work Item Execution Profile chrome for Work Item
+ * detail and history. Hidden when the Work Item is settings-resolved.
+ */
+export function ExecutionProfileSummary({
+  profile,
+  className,
+}: {
+  readonly profile: WorkItemExecutionProfileView | null | undefined
+  readonly className?: string
+}): ReactNode {
+  if (profile === null || profile === undefined) {
+    return null
+  }
+  const reviewLabel = profile.reviewSameAsBuild
+    ? "Same as build"
+    : selectionLabel({
+        model: profile.reviewModel,
+        thinkingLevel: profile.reviewThinkingLevel,
+      })
+  return (
+    <div className={className} data-execution-profile>
+      <p className={ui.jobTicketRuntimeLine}>
+        Explicit Work Item Execution Profile
+      </p>
+      <p className={ui.jobTicketRuntimeLine}>{profile.backend.label}</p>
+      <p className={ui.jobTicketRuntimeLine}>
+        Build{" "}
+        {selectionLabel({
+          model: profile.buildModel,
+          thinkingLevel: profile.buildThinkingLevel,
+        })}
+      </p>
+      <p className={ui.jobTicketRuntimeLine}>Review {reviewLabel}</p>
+    </div>
+  )
+}

--- a/apps/harness/src/home-page-content.tsx
+++ b/apps/harness/src/home-page-content.tsx
@@ -41,12 +41,16 @@ import { Banner } from "./banner.js"
 import { repositoryCardCollapseId, useCardCollapsed } from "./card-collapse.js"
 import { CardCollapseToggle } from "./card-collapse-toggle.js"
 import { Copy } from "./copy.js"
+import type { ImplementWithProfileInput } from "./execution-profile-draft.js"
+import { ExecutionProfileSummary } from "./execution-profile-summary.js"
 import { forgeChangeRequestShort } from "./forge-change-request.js"
 import { createHarnessGraphqlClient } from "./harness-graphql.js"
+import { ImplementWithIssueDialog } from "./implement-with-issue-dialog.js"
 import {
   type GraphqlWorkItemState,
   issueActionEligibility,
 } from "./issue-action-eligibility.js"
+import { IssueActionsMenu } from "./issue-actions-menu.js"
 import {
   formatLastRefreshedAgo,
   isIssueProjectionStale,
@@ -275,6 +279,14 @@ export type WorkItem = {
   issueTitle: string | null
   pullRequestNumber: number | null
   agentBackend: { id: string; label: string }
+  executionProfile?: {
+    backend: { id: string; label: string }
+    buildModel: string
+    buildThinkingLevel: string | null
+    reviewSameAsBuild: boolean
+    reviewModel: string
+    reviewThinkingLevel: string | null
+  } | null
   state: WorkItemState
   stateLabel: string
   status: WorkItemStatus
@@ -313,6 +325,14 @@ const workItemFields = {
   issueTitle: true,
   pullRequestNumber: true,
   agentBackend: { id: true, label: true },
+  executionProfile: {
+    backend: { id: true, label: true },
+    buildModel: true,
+    buildThinkingLevel: true,
+    reviewSameAsBuild: true,
+    reviewModel: true,
+    reviewThinkingLevel: true,
+  },
   mergeMode: true,
   state: true,
   stateLabel: true,
@@ -2958,7 +2978,7 @@ function RepositoryIssueRow({
   workItemsLoading: boolean
   readonly onOpenSession: (workItemId: string, sessionId: string) => void
 }) {
-  const [menuOpen, setMenuOpen] = useState(false)
+  const [implementWithOpen, setImplementWithOpen] = useState(false)
   const queryClient = useQueryClient()
   const query = workItemsQuery(issue.repositoryId)
   const issueWorkItems = workItems.filter(
@@ -2991,6 +3011,25 @@ function RepositoryIssueRow({
     },
     onSuccess: onImplementSuccess,
   })
+  const implementWith = useMutation({
+    mutationFn: async (profile: ImplementWithProfileInput) => {
+      const result = await graphql.mutation({
+        implementWith: {
+          __args: {
+            repositoryId: issue.repositoryId,
+            issueNumber: issue.issueNumber,
+            profile,
+          },
+          ...workItemFields,
+        },
+      })
+      return result.implementWith
+    },
+    onSuccess: (workItem) => {
+      setImplementWithOpen(false)
+      onImplementSuccess(workItem)
+    },
+  })
   const implementLocally = useMutation({
     mutationFn: async () => {
       const result = await graphql.mutation({
@@ -3022,45 +3061,35 @@ function RepositoryIssueRow({
     onSuccess: onImplementSuccess,
   })
   const implementPending =
-    implementNow.isPending || implementLocally.isPending || queueIssue.isPending
+    implementNow.isPending ||
+    implementWith.isPending ||
+    implementLocally.isPending ||
+    queueIssue.isPending
   const startImplementNow = () => {
+    implementWith.reset()
     implementLocally.reset()
     queueIssue.reset()
     implementNow.mutate()
   }
+  const startImplementWith = () => {
+    implementNow.reset()
+    implementLocally.reset()
+    queueIssue.reset()
+    implementWith.reset()
+    setImplementWithOpen(true)
+  }
   const startImplementLocally = () => {
     implementNow.reset()
+    implementWith.reset()
     queueIssue.reset()
     implementLocally.mutate()
   }
   const startQueue = () => {
     implementNow.reset()
+    implementWith.reset()
     implementLocally.reset()
     queueIssue.mutate()
   }
-  const runMenuAction = ({ action }: { readonly action: () => void }) => {
-    setMenuOpen(false)
-    action()
-  }
-
-  useEffect(() => {
-    if (!menuOpen) return
-    const onPointerDown = (event: PointerEvent) => {
-      const target = event.target
-      if (!(target instanceof Element)) return
-      if (target.closest(`[data-issue-menu="${issue.id}"]`)) return
-      setMenuOpen(false)
-    }
-    const onKeyDown = (event: KeyboardEvent) => {
-      if (event.key === "Escape") setMenuOpen(false)
-    }
-    document.addEventListener("pointerdown", onPointerDown)
-    document.addEventListener("keydown", onKeyDown)
-    return () => {
-      document.removeEventListener("pointerdown", onPointerDown)
-      document.removeEventListener("keydown", onKeyDown)
-    }
-  }, [issue.id, menuOpen])
 
   return (
     <li className={ui.repoIssue}>
@@ -3124,6 +3153,7 @@ function RepositoryIssueRow({
             />
           )}
           {(implementNow.isError ||
+            implementWith.isError ||
             implementLocally.isError ||
             queueIssue.isError) && (
             <Banner
@@ -3137,7 +3167,9 @@ function RepositoryIssueRow({
                   ? queueIssue.error
                   : implementNow.isError
                     ? implementNow.error
-                    : implementLocally.error,
+                    : implementWith.isError
+                      ? implementWith.error
+                      : implementLocally.error,
                 fallback: queueIssue.isError
                   ? "Could not queue issue. Refresh the issues and try again."
                   : "Could not start implementation. Refresh the issues and try again.",
@@ -3163,71 +3195,50 @@ function RepositoryIssueRow({
           {issue.blockedBy.length > 0 && (
             <span className={cx(ui.stamp, ui.stampBlocked)}>Blocked</span>
           )}
-          {(canImplement || canQueue) && (
-            <span className="relative" data-issue-menu={issue.id}>
-              <button
-                type="button"
-                className={ui.iconBtn}
-                aria-label={`Actions for issue #${issue.issueNumber}`}
-                aria-haspopup="menu"
-                aria-expanded={menuOpen}
-                onClick={() => setMenuOpen((open) => !open)}
-              >
-                <svg aria-hidden="true" viewBox="0 0 24 24" fill="currentColor">
-                  <circle cx="12" cy="5" r="1.75" />
-                  <circle cx="12" cy="12" r="1.75" />
-                  <circle cx="12" cy="19" r="1.75" />
-                </svg>
-              </button>
-              {menuOpen && (
-                <div role="menu" className={cx(ui.menuPanel, "min-w-44")}>
-                  {canImplement && (
-                    <>
-                      <button
-                        type="button"
-                        role="menuitem"
-                        className={ui.menuItem}
-                        disabled={implementPending}
-                        onClick={() =>
-                          runMenuAction({ action: startImplementNow })
-                        }
-                      >
-                        {implementNow.isPending
-                          ? "Starting..."
-                          : "Implement now"}
-                      </button>
-                      <button
-                        type="button"
-                        role="menuitem"
-                        className={ui.menuItem}
-                        disabled={implementPending}
-                        onClick={() =>
-                          runMenuAction({ action: startImplementLocally })
-                        }
-                      >
-                        {implementLocally.isPending
-                          ? "Starting..."
-                          : "Implement locally"}
-                      </button>
-                    </>
-                  )}
-                  {canQueue && (
-                    <button
-                      type="button"
-                      role="menuitem"
-                      className={ui.menuItem}
-                      disabled={implementPending}
-                      onClick={() => runMenuAction({ action: startQueue })}
-                    >
-                      {queueIssue.isPending ? "Queueing..." : "Queue"}
-                    </button>
-                  )}
-                </div>
-              )}
-            </span>
-          )}
+          <IssueActionsMenu
+            issueNumber={issue.issueNumber}
+            issueId={issue.id}
+            canImplement={canImplement}
+            canQueue={canQueue}
+            implementPending={implementPending}
+            implementNowPending={implementNow.isPending}
+            implementLocallyPending={implementLocally.isPending}
+            queuePending={queueIssue.isPending}
+            onImplementNow={startImplementNow}
+            onImplementWith={startImplementWith}
+            onImplementLocally={startImplementLocally}
+            onQueue={startQueue}
+          />
         </span>
       </div>
+      {implementWithOpen && (
+        <ImplementWithIssueDialog
+          issueNumber={issue.issueNumber}
+          backendId={repository.effectiveAgentBackend}
+          repositoryPrefs={{
+            defaultModel: repository.defaultModel,
+            defaultThinkingLevel: repository.defaultThinkingLevel,
+            reviewModel: repository.reviewModel,
+            reviewThinkingLevel: repository.reviewThinkingLevel,
+          }}
+          submitPending={implementWith.isPending}
+          submitError={
+            implementWith.isError
+              ? startWorkBannerMessage({
+                  error: implementWith.error,
+                  fallback:
+                    "Could not start implementation. Refresh the issues and try again.",
+                })
+              : null
+          }
+          onSubmit={(profile) => implementWith.mutate(profile)}
+          onCancel={() => {
+            if (!implementWith.isPending) {
+              setImplementWithOpen(false)
+            }
+          }}
+        />
+      )}
     </li>
   )
 }
@@ -3645,6 +3656,7 @@ export function WorkItemLifecycleStatus({
           <p className={ui.jobTicketRuntimeLine}>
             {workItem.agentBackend.label}
           </p>
+          <ExecutionProfileSummary profile={workItem.executionProfile} />
           {sessionId !== null ? (
             <div
               className={cx(

--- a/apps/harness/src/implement-with-dialog.tsx
+++ b/apps/harness/src/implement-with-dialog.tsx
@@ -1,0 +1,516 @@
+import {
+  type FormEvent,
+  type ReactNode,
+  useEffect,
+  useRef,
+  useState,
+} from "react"
+import { AgentModelSelect } from "./agent-model-select.js"
+import {
+  type AgentModelOption,
+  blocksAgentModelSave,
+  formatUnavailableVariantLabel,
+  formatVariantLabel,
+  isClaudeBedrockConfigurationMode,
+  isUnavailableCatalogModel,
+  reconcileVariantForModel,
+  thinkingLevelsForModel,
+} from "./agent-model-settings.js"
+import { Banner } from "./banner.js"
+import {
+  type ExecutionProfileDraft,
+  type ImplementWithProfileInput,
+  executionProfileInputFromDraft,
+  implementWithCatalogBlockReason,
+  reconcileExecutionProfileDraft,
+} from "./execution-profile-draft.js"
+import { cx, ui } from "./ui.js"
+
+export type ImplementWithCatalog = {
+  readonly loading: boolean
+  readonly failed: boolean
+  readonly error: string | null
+  readonly models: readonly AgentModelOption[] | undefined
+  readonly warnings: readonly string[]
+}
+
+export type ImplementWithDialogProps = {
+  readonly issueNumber: number
+  readonly backendId: string
+  readonly backendLabel: string
+  readonly configurationMode: string | null
+  readonly initialDraft: ExecutionProfileDraft
+  readonly catalog: ImplementWithCatalog
+  readonly prefsError?: string | null
+  readonly submitPending: boolean
+  readonly submitError: string | null
+  readonly onSubmit: (profile: ImplementWithProfileInput) => void
+  readonly onCancel: () => void
+}
+
+/**
+ * Local modal that always pairs showModal with close on unmount so tearing
+ * the node out of the tree cannot leave the document inert.
+ */
+export function ImplementWithModalDialog({
+  labelledBy,
+  preventCancel = false,
+  onCancel,
+  children,
+}: {
+  readonly labelledBy: string
+  readonly preventCancel?: boolean
+  readonly onCancel: () => void
+  readonly children: ReactNode
+}): ReactNode {
+  const dialogRef = useRef<HTMLDialogElement>(null)
+  useEffect(() => {
+    const dialog = dialogRef.current
+    if (dialog === null) return
+    if (!dialog.open) {
+      dialog.showModal()
+    }
+    return () => {
+      if (dialog.open) {
+        dialog.close()
+      }
+    }
+  }, [])
+  return (
+    <dialog
+      ref={dialogRef}
+      className={ui.dialogPanel}
+      aria-labelledby={labelledBy}
+      onCancel={(event) => {
+        if (preventCancel) {
+          event.preventDefault()
+          return
+        }
+        onCancel()
+      }}
+    >
+      {children}
+    </dialog>
+  )
+}
+
+const sameAsBuildDraft = (
+  draft: ExecutionProfileDraft,
+): Extract<ExecutionProfileDraft, { reviewSameAsBuild: true }> => ({
+  buildModel: draft.buildModel,
+  buildThinkingLevel: draft.buildThinkingLevel,
+  reviewSameAsBuild: true,
+})
+
+/**
+ * Ephemeral Implement issue #N with... dialog. Local modal state only — no
+ * route, no history entry, drafts die when this unmounts.
+ */
+export function ImplementWithDialog({
+  issueNumber,
+  backendId,
+  backendLabel,
+  configurationMode,
+  initialDraft,
+  catalog,
+  prefsError = null,
+  submitPending,
+  submitError,
+  onSubmit,
+  onCancel,
+}: ImplementWithDialogProps): ReactNode {
+  const [draft, setDraft] = useState(() =>
+    reconcileExecutionProfileDraft({
+      draft: initialDraft,
+      models: catalog.models,
+    }),
+  )
+  const titleId = `implement-with-title-${issueNumber}`
+
+  useEffect(() => {
+    setDraft((current) =>
+      reconcileExecutionProfileDraft({
+        draft: current,
+        models: catalog.models,
+      }),
+    )
+  }, [catalog.models])
+
+  const catalogModels = catalog.models
+  const catalogState = {
+    catalogLoading: catalog.loading,
+    catalogFailed: catalog.failed,
+    catalogModels,
+  }
+  const modelIds = (catalogModels ?? []).map((model) => model.id)
+  const catalogLoaded = catalogModels !== undefined
+  const claudeBedrockStrict = isClaudeBedrockConfigurationMode(
+    backendId,
+    configurationMode,
+  )
+  const buildVariants = thinkingLevelsForModel(catalogModels, draft.buildModel)
+  const reviewModel = draft.reviewSameAsBuild ? "" : draft.reviewModel
+  const reviewThinkingLevel = draft.reviewSameAsBuild
+    ? ""
+    : draft.reviewThinkingLevel
+  const reviewThinkingLevels = thinkingLevelsForModel(
+    catalogModels,
+    reviewModel,
+  )
+  const buildUnavailable =
+    catalogLoaded &&
+    isUnavailableCatalogModel({
+      modelId: draft.buildModel,
+      catalogModelIds: modelIds,
+    })
+  const reviewUnavailable =
+    !draft.reviewSameAsBuild &&
+    catalogLoaded &&
+    isUnavailableCatalogModel({
+      modelId: draft.reviewModel,
+      catalogModelIds: modelIds,
+    })
+  const buildBlockReason = implementWithCatalogBlockReason({
+    ...catalogState,
+    modelId: draft.buildModel,
+    requireSelection: true,
+    backendId,
+    configurationMode,
+    discoveryWarnings: catalog.warnings,
+  })
+  const reviewBlockReason = draft.reviewSameAsBuild
+    ? null
+    : implementWithCatalogBlockReason({
+        ...catalogState,
+        modelId: draft.reviewModel,
+        requireSelection: true,
+        backendId,
+        configurationMode,
+        discoveryWarnings: catalog.warnings,
+      })
+  const buildBlocked = blocksAgentModelSave({
+    ...catalogState,
+    modelId: draft.buildModel,
+    requireSelection: true,
+  })
+  const reviewBlocked =
+    !draft.reviewSameAsBuild &&
+    blocksAgentModelSave({
+      ...catalogState,
+      modelId: draft.reviewModel,
+      requireSelection: true,
+    })
+  const implementDisabled = submitPending || buildBlocked || reviewBlocked
+  const hasCustomBuildVariant =
+    draft.buildThinkingLevel.length > 0 &&
+    !buildVariants.includes(draft.buildThinkingLevel)
+  const hasCustomReviewVariant =
+    reviewThinkingLevel.length > 0 &&
+    !reviewThinkingLevels.includes(reviewThinkingLevel)
+  const modelSelectDisabled =
+    submitPending ||
+    catalog.loading ||
+    catalog.failed ||
+    catalogModels === undefined
+
+  const updateBuild = (nextModel: string) => {
+    const nextVariants = thinkingLevelsForModel(catalogModels, nextModel)
+    setDraft((current) => ({
+      ...current,
+      buildModel: nextModel,
+      buildThinkingLevel: reconcileVariantForModel(
+        current.buildThinkingLevel,
+        nextVariants,
+      ),
+    }))
+  }
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    if (implementDisabled) return
+    onSubmit(
+      executionProfileInputFromDraft({
+        agentBackendId: backendId,
+        draft,
+      }),
+    )
+  }
+
+  return (
+    <ImplementWithModalDialog
+      labelledBy={titleId}
+      preventCancel={submitPending}
+      onCancel={onCancel}
+    >
+      <form onSubmit={handleSubmit}>
+        <div className={ui.dialogHeader}>
+          <p className={ui.dialogKicker}>Implement With</p>
+          <h2 id={titleId} className={ui.dialogTitle}>
+            Implement issue #{issueNumber} with...
+          </h2>
+          <p className={ui.dialogLede}>
+            These choices apply only to this Work Item. They never change
+            Repository settings or Harness Config.
+          </p>
+        </div>
+        <div className={ui.dialogBodySectioned}>
+          <section
+            className={ui.dialogSection}
+            aria-labelledby="implement-with-backend"
+          >
+            <div className={ui.dialogSectionHead}>
+              <h3 id="implement-with-backend" className={ui.dialogSectionTitle}>
+                Agent Backend
+              </h3>
+              <span className={ui.dialogSectionMeta}>Effective</span>
+            </div>
+            <p className={ui.dialogNote}>{backendLabel}</p>
+            <span className={ui.dialogFieldHint}>
+              Repository Effective Agent Backend. This Work Item will keep this
+              backend and the model choices below.
+            </span>
+          </section>
+
+          <section
+            className={ui.dialogSection}
+            aria-labelledby="implement-with-models"
+          >
+            <div className={ui.dialogSectionHead}>
+              <h3 id="implement-with-models" className={ui.dialogSectionTitle}>
+                Models
+              </h3>
+              <span className={ui.dialogSectionMeta}>Build · Review</span>
+            </div>
+
+            {prefsError !== null && (
+              <Banner
+                className={ui.bannerCompact}
+                tone="alarm"
+                tag="Error"
+                role="alert"
+              >
+                {prefsError}
+              </Banner>
+            )}
+            {catalog.failed && catalog.error !== null && (
+              <Banner
+                className={ui.bannerCompact}
+                tone="alarm"
+                tag="Error"
+                role="alert"
+              >
+                {catalog.error}
+              </Banner>
+            )}
+
+            <AgentModelSelect
+              className={cx(ui.dialogField, ui.dialogFieldMono)}
+              label="Build model"
+              name="buildModel"
+              value={draft.buildModel}
+              models={catalogModels}
+              catalogLoading={catalog.loading}
+              allowClear={false}
+              required
+              disabled={modelSelectDisabled}
+              placeholder={
+                claudeBedrockStrict
+                  ? "Select a Bedrock inference profile"
+                  : "Select a build model"
+              }
+              emptyCatalogLabel={
+                claudeBedrockStrict
+                  ? "No Bedrock profiles available"
+                  : "No Agent Models available"
+              }
+              blockReason={buildBlockReason}
+              hint="Used for implement and other build steps."
+              onChange={updateBuild}
+            />
+
+            {draft.buildModel.length > 0 && buildUnavailable ? (
+              <Banner
+                className={ui.bannerCompact}
+                tone="alarm"
+                tag="Model"
+                role="alert"
+              >
+                Build effort (thinking) is unavailable — the selected model is
+                not in the Agent Model catalog. Choose another build model.
+              </Banner>
+            ) : draft.buildModel.length > 0 &&
+              catalogLoaded &&
+              buildVariants.length === 0 ? (
+              <p className={ui.dialogNote}>
+                Build effort (thinking) is unavailable — this model has no
+                effort (thinking) options.
+              </p>
+            ) : (
+              <label className={ui.dialogField}>
+                Build effort (thinking)
+                <select
+                  className={ui.dialogInput}
+                  name="buildThinkingLevel"
+                  value={draft.buildThinkingLevel}
+                  disabled={
+                    modelSelectDisabled || draft.buildModel.length === 0
+                  }
+                  onChange={(event) =>
+                    setDraft((current) => ({
+                      ...current,
+                      buildThinkingLevel: event.target.value,
+                    }))
+                  }
+                >
+                  <option value="">
+                    {buildVariants.length === 0
+                      ? "Model default (no effort (thinking) options)"
+                      : "Model default"}
+                  </option>
+                  {hasCustomBuildVariant && (
+                    <option value={draft.buildThinkingLevel}>
+                      {formatUnavailableVariantLabel(draft.buildThinkingLevel)}
+                    </option>
+                  )}
+                  {buildVariants.map((variant) => (
+                    <option key={variant} value={variant}>
+                      {formatVariantLabel(variant)}
+                    </option>
+                  ))}
+                </select>
+              </label>
+            )}
+
+            <AgentModelSelect
+              className={cx(ui.dialogField, ui.dialogFieldMono)}
+              label="Review model"
+              name="reviewModel"
+              value={reviewModel}
+              models={catalogModels}
+              catalogLoading={catalog.loading}
+              allowClear
+              required={false}
+              disabled={modelSelectDisabled}
+              placeholder="Same as build"
+              emptyCatalogLabel="Same as build"
+              blockReason={reviewBlockReason}
+              hint="Same as build uses exactly the build Agent Model and Thinking Level."
+              onChange={(nextModel) => {
+                if (nextModel.length === 0) {
+                  setDraft((current) => sameAsBuildDraft(current))
+                  return
+                }
+                const nextVariants = thinkingLevelsForModel(
+                  catalogModels,
+                  nextModel,
+                )
+                setDraft((current) => ({
+                  buildModel: current.buildModel,
+                  buildThinkingLevel: current.buildThinkingLevel,
+                  reviewSameAsBuild: false,
+                  reviewModel: nextModel,
+                  reviewThinkingLevel: reconcileVariantForModel(
+                    current.reviewSameAsBuild
+                      ? current.buildThinkingLevel
+                      : current.reviewThinkingLevel,
+                    nextVariants,
+                  ),
+                }))
+              }}
+            />
+
+            {reviewModel.length > 0 && reviewUnavailable ? (
+              <Banner
+                className={ui.bannerCompact}
+                tone="alarm"
+                tag="Model"
+                role="alert"
+              >
+                Review effort (thinking) is unavailable — the selected model is
+                not in the Agent Model catalog. Choose another model or use Same
+                as build.
+              </Banner>
+            ) : reviewModel.length > 0 &&
+              catalogLoaded &&
+              reviewThinkingLevels.length === 0 ? (
+              <p className={ui.dialogNote}>
+                Review effort (thinking) is unavailable — this model has no
+                effort (thinking) options.
+              </p>
+            ) : (
+              <label className={ui.dialogField}>
+                Review effort (thinking)
+                <select
+                  className={ui.dialogInput}
+                  name="reviewThinkingLevel"
+                  value={reviewThinkingLevel}
+                  disabled={
+                    modelSelectDisabled ||
+                    draft.reviewSameAsBuild ||
+                    reviewModel.length === 0 ||
+                    reviewThinkingLevels.length === 0
+                  }
+                  onChange={(event) =>
+                    setDraft((current) =>
+                      current.reviewSameAsBuild
+                        ? current
+                        : {
+                            ...current,
+                            reviewThinkingLevel: event.target.value,
+                          },
+                    )
+                  }
+                >
+                  <option value="">
+                    {draft.reviewSameAsBuild
+                      ? "Same as build"
+                      : "Model default"}
+                  </option>
+                  {hasCustomReviewVariant && (
+                    <option value={reviewThinkingLevel}>
+                      {formatUnavailableVariantLabel(reviewThinkingLevel)}
+                    </option>
+                  )}
+                  {reviewThinkingLevels.map((variant) => (
+                    <option key={`review-${variant}`} value={variant}>
+                      {formatVariantLabel(variant)}
+                    </option>
+                  ))}
+                </select>
+              </label>
+            )}
+          </section>
+
+          {submitError !== null && (
+            <Banner
+              className={ui.bannerCompact}
+              tone="alarm"
+              tag="Error"
+              role="alert"
+            >
+              {submitError}
+            </Banner>
+          )}
+        </div>
+        <div className={ui.dialogFooter}>
+          <button
+            type="button"
+            className={ui.plateMini}
+            onClick={onCancel}
+            disabled={submitPending}
+          >
+            Cancel
+          </button>
+          <button
+            type="submit"
+            className={ui.platePrimary}
+            aria-busy={submitPending || undefined}
+            disabled={implementDisabled}
+          >
+            {submitPending ? "Starting..." : "Implement"}
+          </button>
+        </div>
+      </form>
+    </ImplementWithModalDialog>
+  )
+}

--- a/apps/harness/src/implement-with-dialog.tsx
+++ b/apps/harness/src/implement-with-dialog.tsx
@@ -26,7 +26,7 @@ import {
 } from "./execution-profile-draft.js"
 import { cx, ui } from "./ui.js"
 
-export type ImplementWithCatalog = {
+type ImplementWithCatalog = {
   readonly loading: boolean
   readonly failed: boolean
   readonly error: string | null

--- a/apps/harness/src/implement-with-issue-dialog.tsx
+++ b/apps/harness/src/implement-with-issue-dialog.tsx
@@ -1,0 +1,190 @@
+import { useQuery } from "@tanstack/react-query"
+import type { ReactNode } from "react"
+import type { AgentModelOption } from "./agent-model-settings.js"
+import {
+  type ExecutionProfileDraft,
+  type ExecutionProfilePrefSource,
+  type ImplementWithProfileInput,
+  resolveExecutionProfileDraft,
+  usablePreviewCatalog,
+} from "./execution-profile-draft.js"
+import { createHarnessGraphqlClient } from "./harness-graphql.js"
+import {
+  ImplementWithDialog,
+  ImplementWithModalDialog,
+} from "./implement-with-dialog.js"
+import { ui } from "./ui.js"
+
+const graphql = createHarnessGraphqlClient({ batch: true })
+
+const agentBackendsQuery = {
+  queryKey: ["agentBackends"] as const,
+  staleTime: Number.POSITIVE_INFINITY,
+  gcTime: Number.POSITIVE_INFINITY,
+  queryFn: async () => {
+    const result = await graphql.query({
+      agentBackends: { id: true, label: true, configurationMode: true },
+    })
+    return result.agentBackends
+  },
+}
+
+export type ImplementWithIssueDialogProps = {
+  readonly issueNumber: number
+  readonly backendId: string
+  readonly repositoryPrefs: ExecutionProfilePrefSource
+  readonly submitPending: boolean
+  readonly submitError: string | null
+  readonly onSubmit: (profile: ImplementWithProfileInput) => void
+  readonly onCancel: () => void
+}
+
+/**
+ * Loads Effective Agent Backend catalog and Harness prefs, then hosts the
+ * ephemeral Implement With dialog. Does not mutate settings.
+ */
+export function ImplementWithIssueDialog({
+  issueNumber,
+  backendId,
+  repositoryPrefs,
+  submitPending,
+  submitError,
+  onSubmit,
+  onCancel,
+}: ImplementWithIssueDialogProps): ReactNode {
+  const agentBackends = useQuery(agentBackendsQuery)
+  const harnessPrefs = useQuery({
+    queryKey: ["implement-with", "harness-prefs", backendId] as const,
+    queryFn: async (): Promise<ExecutionProfilePrefSource> => {
+      const result = await graphql.query({
+        harnessModelPrefs: {
+          __args: { backendId },
+          defaultModel: true,
+          defaultThinkingLevel: true,
+          reviewModel: true,
+          reviewThinkingLevel: true,
+        },
+      })
+      return result.harnessModelPrefs
+    },
+  })
+  const preview = useQuery({
+    queryKey: ["implement-with", "preview", backendId] as const,
+    queryFn: async () => {
+      const result = await graphql.query({
+        previewAgentBackend: {
+          __args: { backendId },
+          backend: { id: true, label: true },
+          kind: true,
+          reason: true,
+          models: {
+            id: true,
+            thinkingLevels: true,
+            name: true,
+            kind: true,
+          },
+          warnings: true,
+        },
+      })
+      return result.previewAgentBackend
+    },
+  })
+
+  const backend = (agentBackends.data ?? []).find(
+    (candidate) => candidate.id === backendId,
+  )
+  const backendLabel =
+    preview.data?.backend.label ?? backend?.label ?? backendId
+  const configurationMode = backend?.configurationMode ?? null
+  const mappedPreview =
+    preview.data === undefined
+      ? undefined
+      : {
+          kind: preview.data.kind,
+          models: preview.data.models.map(
+            (model): AgentModelOption => ({
+              id: model.id,
+              thinkingLevels: model.thinkingLevels,
+              name: model.name,
+              kind: model.kind,
+            }),
+          ),
+        }
+  const usableCatalog = usablePreviewCatalog({
+    preview: mappedPreview,
+    previewFailed: preview.isError,
+  })
+  const catalogFailed = usableCatalog.failed
+  const catalogError = catalogFailed
+    ? preview.isError
+      ? preview.error instanceof Error
+        ? preview.error.message
+        : "Could not load the Agent Model catalog."
+      : (preview.data?.reason ?? "Could not load the Agent Model catalog.")
+    : null
+  const catalog = {
+    loading: preview.isPending && usableCatalog.models === undefined,
+    failed: catalogFailed,
+    error: catalogError,
+    models: usableCatalog.models,
+    warnings: preview.data?.warnings ?? [],
+  }
+
+  if (harnessPrefs.isPending) {
+    const loadingTitleId = `implement-with-loading-${issueNumber}`
+    return (
+      <ImplementWithModalDialog labelledBy={loadingTitleId} onCancel={onCancel}>
+        <div className={ui.dialogHeader}>
+          <p className={ui.dialogKicker}>Implement With</p>
+          <h2 id={loadingTitleId} className={ui.dialogTitle}>
+            Implement issue #{issueNumber} with...
+          </h2>
+          <p className={ui.dialogLede}>
+            These choices apply only to this Work Item. They never change
+            Repository settings or Harness Config.
+          </p>
+        </div>
+        <div className={ui.dialogBody}>
+          <p className={ui.dialogLoading}>Loading current preferences...</p>
+        </div>
+        <div className={ui.dialogFooter}>
+          <button type="button" className={ui.plateMini} onClick={onCancel}>
+            Cancel
+          </button>
+        </div>
+      </ImplementWithModalDialog>
+    )
+  }
+
+  const harness: ExecutionProfilePrefSource = harnessPrefs.data ?? {
+    defaultModel: null,
+    defaultThinkingLevel: null,
+    reviewModel: null,
+    reviewThinkingLevel: null,
+  }
+  const initialDraft: ExecutionProfileDraft = resolveExecutionProfileDraft({
+    repository: repositoryPrefs,
+    harness,
+  })
+  const prefsError = harnessPrefs.isError
+    ? harnessPrefs.error instanceof Error
+      ? harnessPrefs.error.message
+      : "Could not load Harness model preferences for this Agent Backend."
+    : null
+
+  return (
+    <ImplementWithDialog
+      issueNumber={issueNumber}
+      backendId={backendId}
+      backendLabel={backendLabel}
+      configurationMode={configurationMode}
+      initialDraft={initialDraft}
+      catalog={catalog}
+      prefsError={prefsError}
+      submitPending={submitPending}
+      submitError={submitError}
+      onSubmit={onSubmit}
+      onCancel={onCancel}
+    />
+  )
+}

--- a/apps/harness/src/issue-actions-menu.tsx
+++ b/apps/harness/src/issue-actions-menu.tsx
@@ -1,0 +1,132 @@
+import { type ReactNode, useEffect, useState } from "react"
+import { cx, ui } from "./ui.js"
+
+export type IssueActionsMenuProps = {
+  readonly issueNumber: number
+  readonly issueId: string
+  readonly canImplement: boolean
+  readonly canQueue: boolean
+  readonly implementPending: boolean
+  readonly implementNowPending: boolean
+  readonly implementLocallyPending: boolean
+  readonly queuePending: boolean
+  readonly onImplementNow: () => void
+  readonly onImplementWith: () => void
+  readonly onImplementLocally: () => void
+  readonly onQueue: () => void
+}
+
+/**
+ * Actionable Issue kebab: Implement now, Implement with..., Implement locally.
+ * Blocked Issues show Queue only. Presentational so menu order and eligibility
+ * can be tested without the Repos list.
+ */
+export function IssueActionsMenu({
+  issueNumber,
+  issueId,
+  canImplement,
+  canQueue,
+  implementPending,
+  implementNowPending,
+  implementLocallyPending,
+  queuePending,
+  onImplementNow,
+  onImplementWith,
+  onImplementLocally,
+  onQueue,
+}: IssueActionsMenuProps): ReactNode {
+  const [menuOpen, setMenuOpen] = useState(false)
+
+  useEffect(() => {
+    if (!menuOpen) return
+    const onPointerDown = (event: PointerEvent) => {
+      const target = event.target
+      if (!(target instanceof Element)) return
+      if (target.closest(`[data-issue-menu="${issueId}"]`)) return
+      setMenuOpen(false)
+    }
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") setMenuOpen(false)
+    }
+    document.addEventListener("pointerdown", onPointerDown)
+    document.addEventListener("keydown", onKeyDown)
+    return () => {
+      document.removeEventListener("pointerdown", onPointerDown)
+      document.removeEventListener("keydown", onKeyDown)
+    }
+  }, [issueId, menuOpen])
+
+  if (!canImplement && !canQueue) {
+    return null
+  }
+
+  const runMenuAction = (action: () => void) => {
+    setMenuOpen(false)
+    action()
+  }
+
+  return (
+    <span className="relative" data-issue-menu={issueId}>
+      <button
+        type="button"
+        className={ui.iconBtn}
+        aria-label={`Actions for issue #${issueNumber}`}
+        aria-haspopup="menu"
+        aria-expanded={menuOpen}
+        onClick={() => setMenuOpen((open) => !open)}
+      >
+        <svg aria-hidden="true" viewBox="0 0 24 24" fill="currentColor">
+          <circle cx="12" cy="5" r="1.75" />
+          <circle cx="12" cy="12" r="1.75" />
+          <circle cx="12" cy="19" r="1.75" />
+        </svg>
+      </button>
+      {menuOpen && (
+        <div role="menu" className={cx(ui.menuPanel, "min-w-44")}>
+          {canImplement && (
+            <>
+              <button
+                type="button"
+                role="menuitem"
+                className={ui.menuItem}
+                disabled={implementPending}
+                onClick={() => runMenuAction(onImplementNow)}
+              >
+                {implementNowPending ? "Starting..." : "Implement now"}
+              </button>
+              <button
+                type="button"
+                role="menuitem"
+                className={ui.menuItem}
+                disabled={implementPending}
+                onClick={() => runMenuAction(onImplementWith)}
+              >
+                Implement with...
+              </button>
+              <button
+                type="button"
+                role="menuitem"
+                className={ui.menuItem}
+                disabled={implementPending}
+                onClick={() => runMenuAction(onImplementLocally)}
+              >
+                {implementLocallyPending ? "Starting..." : "Implement locally"}
+              </button>
+            </>
+          )}
+          {canQueue && (
+            <button
+              type="button"
+              role="menuitem"
+              className={ui.menuItem}
+              disabled={implementPending}
+              onClick={() => runMenuAction(onQueue)}
+            >
+              {queuePending ? "Queueing..." : "Queue"}
+            </button>
+          )}
+        </div>
+      )}
+    </span>
+  )
+}

--- a/apps/harness/src/kanban-board.tsx
+++ b/apps/harness/src/kanban-board.tsx
@@ -3,6 +3,7 @@ import { Link, useNavigate } from "@tanstack/react-router"
 import { type CSSProperties, Suspense, useMemo, useState } from "react"
 import { Banner } from "./banner.js"
 import { Copy } from "./copy.js"
+import { ExecutionProfileSummary } from "./execution-profile-summary.js"
 import {
   JobsCardSkeleton,
   type Repository,
@@ -246,6 +247,7 @@ function PipelineTicket({
       )}
       <div className={ui.jobTicketRuntime}>
         <p className={ui.jobTicketRuntimeLine}>{workItem.agentBackend.label}</p>
+        <ExecutionProfileSummary profile={workItem.executionProfile} />
         {sessionId !== null ? (
           <div
             className={cx(

--- a/apps/harness/test/completed-route.test.ts
+++ b/apps/harness/test/completed-route.test.ts
@@ -148,6 +148,8 @@ describe("Completed surface routes", () => {
     expect(row).not.toContain("formatSessionShort")
     expect(row).not.toContain("WorkItemLifecycleStatus")
     expect(row).not.toContain("stateLabel")
+    expect(row).toContain("<ExecutionProfileSummary")
+    expect(row).toContain("workItem.executionProfile")
 
     const ui = uiSource()
     // Hover is PR-green (same as board merged-lane prBadge).

--- a/apps/harness/test/execution-profile-draft.test.ts
+++ b/apps/harness/test/execution-profile-draft.test.ts
@@ -1,0 +1,260 @@
+import {
+  executionProfileInputFromDraft,
+  implementWithCatalogBlockReason,
+  reconcileExecutionProfileDraft,
+  resolveExecutionProfileDraft,
+  usablePreviewCatalog,
+} from "../src/execution-profile-draft.js"
+import { describe, expect, test } from "bun:test"
+
+const emptyPrefs = {
+  defaultModel: null,
+  defaultThinkingLevel: null,
+  reviewModel: null,
+  reviewThinkingLevel: null,
+}
+
+describe("resolveExecutionProfileDraft", () => {
+  test("uses Repository overrides over Harness preferences", () => {
+    expect(
+      resolveExecutionProfileDraft({
+        repository: {
+          defaultModel: "repo-build",
+          defaultThinkingLevel: "high",
+          reviewModel: "repo-review",
+          reviewThinkingLevel: "low",
+        },
+        harness: {
+          defaultModel: "harness-build",
+          defaultThinkingLevel: "medium",
+          reviewModel: "harness-review",
+          reviewThinkingLevel: "high",
+        },
+      }),
+    ).toEqual({
+      buildModel: "repo-build",
+      buildThinkingLevel: "high",
+      reviewSameAsBuild: false,
+      reviewModel: "repo-review",
+      reviewThinkingLevel: "low",
+    })
+  })
+
+  test("inherits Harness build and review when the Repository has no override", () => {
+    expect(
+      resolveExecutionProfileDraft({
+        repository: emptyPrefs,
+        harness: {
+          defaultModel: "harness-build",
+          defaultThinkingLevel: "medium",
+          reviewModel: "harness-review",
+          reviewThinkingLevel: "low",
+        },
+      }),
+    ).toEqual({
+      buildModel: "harness-build",
+      buildThinkingLevel: "medium",
+      reviewSameAsBuild: false,
+      reviewModel: "harness-review",
+      reviewThinkingLevel: "low",
+    })
+  })
+
+  test("defaults review to Same as build when no review model is configured", () => {
+    expect(
+      resolveExecutionProfileDraft({
+        repository: emptyPrefs,
+        harness: {
+          defaultModel: "build-only",
+          defaultThinkingLevel: "high",
+          reviewModel: null,
+          reviewThinkingLevel: "low",
+        },
+      }),
+    ).toEqual({
+      buildModel: "build-only",
+      buildThinkingLevel: "high",
+      reviewSameAsBuild: true,
+    })
+  })
+
+  test("leaves a missing default build model as a blank required choice", () => {
+    expect(
+      resolveExecutionProfileDraft({
+        repository: emptyPrefs,
+        harness: emptyPrefs,
+      }),
+    ).toEqual({
+      buildModel: "",
+      buildThinkingLevel: "",
+      reviewSameAsBuild: true,
+    })
+  })
+})
+
+describe("executionProfileInputFromDraft", () => {
+  test("omits review fields when Same as build is selected", () => {
+    expect(
+      executionProfileInputFromDraft({
+        agentBackendId: "opencode",
+        draft: {
+          buildModel: "build-model",
+          buildThinkingLevel: "high",
+          reviewSameAsBuild: true,
+        },
+      }),
+    ).toEqual({
+      agentBackendId: "opencode",
+      buildModel: "build-model",
+      buildThinkingLevel: "high",
+      reviewSameAsBuild: true,
+      reviewModel: null,
+      reviewThinkingLevel: null,
+    })
+  })
+
+  test("sends an explicit review selection including a blank Thinking Level as null", () => {
+    expect(
+      executionProfileInputFromDraft({
+        agentBackendId: "grok",
+        draft: {
+          buildModel: "build-model",
+          buildThinkingLevel: "",
+          reviewSameAsBuild: false,
+          reviewModel: "review-model",
+          reviewThinkingLevel: "",
+        },
+      }),
+    ).toEqual({
+      agentBackendId: "grok",
+      buildModel: "build-model",
+      buildThinkingLevel: null,
+      reviewSameAsBuild: false,
+      reviewModel: "review-model",
+      reviewThinkingLevel: null,
+    })
+  })
+})
+
+describe("usablePreviewCatalog", () => {
+  const ready = {
+    kind: "READY",
+    models: [{ id: "sonnet", thinkingLevels: ["low", "high"] }],
+  }
+
+  test("keeps a cached READY catalog when a later preview fails", () => {
+    expect(
+      usablePreviewCatalog({ preview: ready, previewFailed: true }),
+    ).toEqual({ models: ready.models, failed: false })
+  })
+
+  test("does not invent an empty catalog while preview has not settled", () => {
+    expect(
+      usablePreviewCatalog({ preview: undefined, previewFailed: false }),
+    ).toEqual({ models: undefined, failed: false })
+  })
+
+  test("marks failure only when there is no READY catalog to keep", () => {
+    expect(
+      usablePreviewCatalog({ preview: undefined, previewFailed: true }),
+    ).toEqual({ models: undefined, failed: true })
+    expect(
+      usablePreviewCatalog({
+        preview: { kind: "UNAVAILABLE", models: [] },
+        previewFailed: false,
+      }),
+    ).toEqual({ models: [], failed: true })
+  })
+})
+
+describe("reconcileExecutionProfileDraft", () => {
+  test("clears a Thinking Level the chosen model does not offer", () => {
+    expect(
+      reconcileExecutionProfileDraft({
+        draft: {
+          buildModel: "sonnet",
+          buildThinkingLevel: "xhigh",
+          reviewSameAsBuild: false,
+          reviewModel: "haiku",
+          reviewThinkingLevel: "max",
+        },
+        models: [
+          { id: "sonnet", thinkingLevels: ["low", "high"] },
+          { id: "haiku", thinkingLevels: ["low"] },
+        ],
+      }),
+    ).toEqual({
+      buildModel: "sonnet",
+      buildThinkingLevel: "",
+      reviewSameAsBuild: false,
+      reviewModel: "haiku",
+      reviewThinkingLevel: "",
+    })
+  })
+
+  test("keeps current Thinking Levels until a catalog has loaded", () => {
+    expect(
+      reconcileExecutionProfileDraft({
+        draft: {
+          buildModel: "sonnet",
+          buildThinkingLevel: "high",
+          reviewSameAsBuild: false,
+          reviewModel: "haiku",
+          reviewThinkingLevel: "low",
+        },
+        models: undefined,
+      }),
+    ).toEqual({
+      buildModel: "sonnet",
+      buildThinkingLevel: "high",
+      reviewSameAsBuild: false,
+      reviewModel: "haiku",
+      reviewThinkingLevel: "low",
+    })
+  })
+
+  test("keeps compatible Thinking Levels", () => {
+    expect(
+      reconcileExecutionProfileDraft({
+        draft: {
+          buildModel: "sonnet",
+          buildThinkingLevel: "high",
+          reviewSameAsBuild: true,
+        },
+        models: [{ id: "sonnet", thinkingLevels: ["low", "high"] }],
+      }),
+    ).toEqual({
+      buildModel: "sonnet",
+      buildThinkingLevel: "high",
+      reviewSameAsBuild: true,
+    })
+  })
+})
+
+describe("implementWithCatalogBlockReason", () => {
+  test("does not send the operator to Recheck or Settings", () => {
+    const empty = implementWithCatalogBlockReason({
+      catalogLoading: false,
+      catalogModels: [],
+      modelId: "",
+      requireSelection: true,
+      backendId: "opencode",
+    })
+    expect(empty).toBe(
+      "Implement With requires a non-empty Agent Model catalog.",
+    )
+    expect(empty).not.toContain("Recheck")
+    expect(empty).not.toContain("Settings")
+
+    const failed = implementWithCatalogBlockReason({
+      catalogLoading: false,
+      catalogFailed: true,
+      catalogModels: undefined,
+      modelId: "sonnet",
+      requireSelection: true,
+      backendId: "opencode",
+    })
+    expect(failed).toBe("Could not load the Agent Model catalog.")
+    expect(failed).not.toContain("Recheck")
+  })
+})

--- a/apps/harness/test/execution-profile-summary.test.tsx
+++ b/apps/harness/test/execution-profile-summary.test.tsx
@@ -1,0 +1,49 @@
+import { renderToStaticMarkup } from "react-dom/server"
+import { ExecutionProfileSummary } from "../src/execution-profile-summary.js"
+import { describe, expect, test } from "bun:test"
+
+describe("ExecutionProfileSummary", () => {
+  test("hides settings-resolved Work Items", () => {
+    expect(
+      renderToStaticMarkup(<ExecutionProfileSummary profile={null} />),
+    ).toBe("")
+  })
+
+  test("marks an explicit profile and shows backend, build, review, and Thinking Levels", () => {
+    const html = renderToStaticMarkup(
+      <ExecutionProfileSummary
+        profile={{
+          backend: { id: "opencode", label: "OpenCode" },
+          buildModel: "big-pickle",
+          buildThinkingLevel: "high",
+          reviewSameAsBuild: false,
+          reviewModel: "sonnet",
+          reviewThinkingLevel: "low",
+        }}
+      />,
+    )
+    expect(html).toContain("Explicit Work Item Execution Profile")
+    expect(html).toContain("OpenCode")
+    expect(html).toContain("Build big-pickle · High")
+    expect(html).toContain("Review sonnet · Low")
+  })
+
+  test("shows Same as build for review intent", () => {
+    const html = renderToStaticMarkup(
+      <ExecutionProfileSummary
+        profile={{
+          backend: { id: "grok", label: "Grok Build" },
+          buildModel: "grok-code",
+          buildThinkingLevel: null,
+          reviewSameAsBuild: true,
+          reviewModel: "grok-code",
+          reviewThinkingLevel: null,
+        }}
+      />,
+    )
+    expect(html).toContain("Grok Build")
+    expect(html).toContain("Build grok-code")
+    expect(html).toContain("Review Same as build")
+    expect(html).not.toContain("Review grok-code")
+  })
+})

--- a/apps/harness/test/implement-with-dialog.test.tsx
+++ b/apps/harness/test/implement-with-dialog.test.tsx
@@ -1,0 +1,328 @@
+import { Window } from "happy-dom"
+import { flushSync } from "react-dom"
+import { createRoot } from "react-dom/client"
+import { renderToStaticMarkup } from "react-dom/server"
+import type { ImplementWithProfileInput } from "../src/execution-profile-draft.js"
+import {
+  ImplementWithDialog,
+  type ImplementWithDialogProps,
+} from "../src/implement-with-dialog.js"
+import { afterEach, describe, expect, test } from "bun:test"
+
+const catalogModels = [
+  { id: "sonnet", thinkingLevels: ["low", "high"], name: "Sonnet" },
+  { id: "haiku", thinkingLevels: ["low"], name: "Haiku" },
+] as const
+
+const readyCatalog = {
+  loading: false,
+  failed: false,
+  error: null,
+  models: catalogModels,
+  warnings: [],
+}
+
+const INSTALLED_GLOBAL_KEYS = [
+  "window",
+  "document",
+  "Event",
+  "HTMLElement",
+  "HTMLDialogElement",
+  "HTMLSelectElement",
+  "HTMLButtonElement",
+  "HTMLFormElement",
+  "Element",
+  "Node",
+  "DocumentFragment",
+  "SVGElement",
+  "navigator",
+  "IS_REACT_ACT_ENVIRONMENT",
+] as const
+
+const installDom = () => {
+  const previous = new Map<string, { had: boolean; value: unknown }>()
+  const g = globalThis as unknown as Record<string, unknown>
+  for (const key of INSTALLED_GLOBAL_KEYS) {
+    previous.set(key, { had: Object.hasOwn(g, key), value: g[key] })
+  }
+  const happyWindow = new Window({ url: "https://localhost/" })
+  g.window = happyWindow
+  g.document = happyWindow.document
+  g.Event = happyWindow.Event
+  g.HTMLElement = happyWindow.HTMLElement
+  g.HTMLDialogElement = happyWindow.HTMLDialogElement
+  g.HTMLSelectElement = happyWindow.HTMLSelectElement
+  g.HTMLButtonElement = happyWindow.HTMLButtonElement
+  g.HTMLFormElement = happyWindow.HTMLFormElement
+  g.Element = happyWindow.Element
+  g.Node = happyWindow.Node
+  g.DocumentFragment = happyWindow.DocumentFragment
+  g.SVGElement = happyWindow.SVGElement
+  g.navigator = happyWindow.navigator
+  g.IS_REACT_ACT_ENVIRONMENT = true
+  return {
+    document: happyWindow.document as unknown as Document,
+    fire: (target: EventTarget, type: string) => {
+      target.dispatchEvent(
+        new happyWindow.Event(type, {
+          bubbles: true,
+          cancelable: true,
+        }) as unknown as Event,
+      )
+    },
+    restore: async () => {
+      await new Promise<void>((resolve) => {
+        setTimeout(resolve, 0)
+      })
+      happyWindow.close()
+      for (const key of INSTALLED_GLOBAL_KEYS) {
+        const prior = previous.get(key)
+        if (prior === undefined) continue
+        if (prior.had) {
+          g[key] = prior.value
+        } else {
+          delete g[key]
+        }
+      }
+    },
+  }
+}
+
+const baseProps = {
+  issueNumber: 1034,
+  backendId: "opencode",
+  backendLabel: "OpenCode",
+  configurationMode: null,
+  initialDraft: {
+    buildModel: "sonnet",
+    buildThinkingLevel: "high",
+    reviewSameAsBuild: true as const,
+  },
+  catalog: readyCatalog,
+  submitPending: false,
+  submitError: null,
+  onSubmit: () => undefined,
+  onCancel: () => undefined,
+} satisfies ImplementWithDialogProps
+
+describe("ImplementWithDialog copy and catalog", () => {
+  test("titles the ephemeral command and explains Work Item-only choices", () => {
+    const html = renderToStaticMarkup(<ImplementWithDialog {...baseProps} />)
+    expect(html).toContain("Implement issue #1034 with...")
+    expect(html).toContain("These choices apply only to this Work Item")
+    expect(html).toContain("never change Repository settings or Harness Config")
+    expect(html).toContain("OpenCode")
+    expect(html).toContain("Repository Effective Agent Backend")
+    expect(html).toContain(">Implement<")
+    expect(html).toContain(">Cancel<")
+    expect(html).not.toContain("Recheck")
+    expect(html).not.toContain('href="/settings"')
+    expect(html).not.toContain("<input")
+    expect(html).not.toContain("<datalist")
+  })
+
+  test("starts from pre-filled build values and Same as build", () => {
+    const html = renderToStaticMarkup(<ImplementWithDialog {...baseProps} />)
+    expect(html).toContain('name="buildModel"')
+    expect(html).toContain('value="sonnet"')
+    expect(html).toContain('name="buildThinkingLevel"')
+    expect(html).toContain('value="high"')
+    expect(html).toContain(">Same as build</option>")
+    expect(html).toContain('name="reviewThinkingLevel"')
+    expect(html).toContain("disabled")
+  })
+
+  test("keeps a pre-filled Thinking Level while the catalog is still loading", () => {
+    const html = renderToStaticMarkup(
+      <ImplementWithDialog
+        {...baseProps}
+        catalog={{
+          loading: true,
+          failed: false,
+          error: null,
+          models: undefined,
+          warnings: [],
+        }}
+      />,
+    )
+    expect(html).toContain('name="buildThinkingLevel"')
+    expect(html).toContain('value="high"')
+  })
+
+  test("shows a Harness preference load failure without hiding the form", () => {
+    const html = renderToStaticMarkup(
+      <ImplementWithDialog
+        {...baseProps}
+        prefsError="Could not load Harness model preferences for this Agent Backend."
+      />,
+    )
+    expect(html).toContain("Could not load Harness model preferences")
+    expect(html).toContain('role="alert"')
+    expect(html).toContain(">Implement<")
+  })
+
+  test("a missing default build model is a blank required catalog choice", () => {
+    const html = renderToStaticMarkup(
+      <ImplementWithDialog
+        {...baseProps}
+        initialDraft={{
+          buildModel: "",
+          buildThinkingLevel: "",
+          reviewSameAsBuild: true,
+        }}
+      />,
+    )
+    expect(html).toContain(">Select a build model</option>")
+    expect(html).toContain("Select a model from the Agent Model catalog.")
+  })
+})
+
+describe("ImplementWithDialog interaction", () => {
+  let restore: (() => Promise<void>) | undefined
+  let container: HTMLElement | undefined
+  let root: ReturnType<typeof createRoot> | undefined
+  let fireEvent: ((target: EventTarget, type: string) => void) | undefined
+
+  afterEach(async () => {
+    if (root !== undefined) {
+      flushSync(() => root?.unmount())
+    }
+    await restore?.()
+    restore = undefined
+    container = undefined
+    root = undefined
+    fireEvent = undefined
+  })
+
+  const render = (props: Partial<ImplementWithDialogProps> = {}) => {
+    const installed = installDom()
+    restore = installed.restore
+    fireEvent = installed.fire
+    container = installed.document.createElement("div")
+    installed.document.body.appendChild(container)
+    root = createRoot(container)
+    const submitted: ImplementWithProfileInput[] = []
+    let cancelled = 0
+    flushSync(() => {
+      root?.render(
+        <ImplementWithDialog
+          {...baseProps}
+          {...props}
+          onSubmit={(profile) => submitted.push(profile)}
+          onCancel={() => {
+            cancelled += 1
+          }}
+        />,
+      )
+    })
+    return { node: container, submitted, cancelled: () => cancelled }
+  }
+
+  const fire = (target: EventTarget | null, type: string) => {
+    if (target === null || fireEvent === undefined) {
+      throw new Error("missing event target")
+    }
+    fireEvent(target, type)
+  }
+
+  const selectNamed = (node: HTMLElement, name: string): HTMLSelectElement => {
+    const select = node.querySelector(`select[name="${name}"]`)
+    if (select === null) {
+      throw new Error(`missing select ${name}`)
+    }
+    return select as HTMLSelectElement
+  }
+
+  test("submitting unchanged pre-filled values still creates an explicit profile", () => {
+    const { node, submitted } = render()
+    const form = node.querySelector("form")
+    flushSync(() => {
+      fire(form, "submit")
+    })
+    expect(submitted).toEqual([
+      {
+        agentBackendId: "opencode",
+        buildModel: "sonnet",
+        buildThinkingLevel: "high",
+        reviewSameAsBuild: true,
+        reviewModel: null,
+        reviewThinkingLevel: null,
+      },
+    ])
+  })
+
+  test("an explicit review model unlocks its own Thinking Level", () => {
+    const { node, submitted } = render()
+    const review = selectNamed(node, "reviewModel")
+    flushSync(() => {
+      review.value = "haiku"
+      fire(review, "change")
+    })
+    const reviewThinking = selectNamed(node, "reviewThinkingLevel")
+    expect(reviewThinking.disabled).toBe(false)
+    flushSync(() => {
+      reviewThinking.value = "low"
+      fire(reviewThinking, "change")
+    })
+    flushSync(() => {
+      fire(node.querySelector("form"), "submit")
+    })
+    expect(submitted.at(-1)).toEqual({
+      agentBackendId: "opencode",
+      buildModel: "sonnet",
+      buildThinkingLevel: "high",
+      reviewSameAsBuild: false,
+      reviewModel: "haiku",
+      reviewThinkingLevel: "low",
+    })
+  })
+
+  test("changing the build model drops an incompatible Thinking Level", () => {
+    const { node, submitted } = render()
+    const build = selectNamed(node, "buildModel")
+    flushSync(() => {
+      build.value = "haiku"
+      fire(build, "change")
+    })
+    flushSync(() => {
+      fire(node.querySelector("form"), "submit")
+    })
+    expect(submitted.at(-1)?.buildModel).toBe("haiku")
+    expect(submitted.at(-1)?.buildThinkingLevel).toBeNull()
+  })
+
+  test("pending submission disables Implement and Cancel", () => {
+    const { node } = render({ submitPending: true })
+    const implement = [...node.querySelectorAll("button")].find(
+      (button) => button.textContent === "Starting...",
+    )
+    const cancel = [...node.querySelectorAll("button")].find(
+      (button) => button.textContent === "Cancel",
+    )
+    expect(implement?.disabled).toBe(true)
+    expect(cancel?.disabled).toBe(true)
+  })
+
+  test("a failed submission keeps the dialog open with the actionable error", () => {
+    const html = renderToStaticMarkup(
+      <ImplementWithDialog
+        {...baseProps}
+        submitError="Issue #1034 is no longer Actionable"
+      />,
+    )
+    expect(html).toContain("Implement issue #1034 with...")
+    expect(html).toContain("Issue #1034 is no longer Actionable")
+    expect(html).toContain('role="alert"')
+  })
+
+  test("Cancel discards the command", () => {
+    const { node, cancelled } = render()
+    const cancel = [...node.querySelectorAll("button")].find(
+      (button) => button.textContent === "Cancel",
+    )
+    flushSync(() => {
+      fire(cancel ?? null, "click")
+    })
+    expect(cancelled()).toBe(1)
+  })
+})

--- a/apps/harness/test/issue-actions-menu.test.tsx
+++ b/apps/harness/test/issue-actions-menu.test.tsx
@@ -1,0 +1,216 @@
+import { Window } from "happy-dom"
+import type { ReactNode } from "react"
+import { flushSync } from "react-dom"
+import { createRoot } from "react-dom/client"
+import { renderToStaticMarkup } from "react-dom/server"
+import { IssueActionsMenu } from "../src/issue-actions-menu.js"
+import { afterEach, describe, expect, test } from "bun:test"
+
+const INSTALLED_GLOBAL_KEYS = [
+  "window",
+  "document",
+  "Event",
+  "HTMLElement",
+  "Element",
+  "Node",
+  "DocumentFragment",
+  "SVGElement",
+  "navigator",
+  "IS_REACT_ACT_ENVIRONMENT",
+] as const
+
+const installDom = () => {
+  const previous = new Map<string, { had: boolean; value: unknown }>()
+  const g = globalThis as unknown as Record<string, unknown>
+  for (const key of INSTALLED_GLOBAL_KEYS) {
+    previous.set(key, { had: Object.hasOwn(g, key), value: g[key] })
+  }
+  const happyWindow = new Window({ url: "https://localhost/" })
+  g.window = happyWindow
+  g.document = happyWindow.document
+  g.Event = happyWindow.Event
+  g.HTMLElement = happyWindow.HTMLElement
+  g.Element = happyWindow.Element
+  g.Node = happyWindow.Node
+  g.DocumentFragment = happyWindow.DocumentFragment
+  g.SVGElement = happyWindow.SVGElement
+  g.navigator = happyWindow.navigator
+  g.IS_REACT_ACT_ENVIRONMENT = true
+  return {
+    document: happyWindow.document as unknown as Document,
+    fire: (target: EventTarget, type: string) => {
+      target.dispatchEvent(
+        new happyWindow.Event(type, {
+          bubbles: true,
+          cancelable: true,
+        }) as unknown as Event,
+      )
+    },
+    restore: async () => {
+      await new Promise<void>((resolve) => {
+        setTimeout(resolve, 0)
+      })
+      happyWindow.close()
+      for (const key of INSTALLED_GLOBAL_KEYS) {
+        const prior = previous.get(key)
+        if (prior === undefined) continue
+        if (prior.had) {
+          g[key] = prior.value
+        } else {
+          delete g[key]
+        }
+      }
+    },
+  }
+}
+
+const defaultProps = {
+  issueNumber: 1034,
+  issueId: "issue-1034",
+  implementPending: false,
+  implementNowPending: false,
+  implementLocallyPending: false,
+  queuePending: false,
+  onImplementNow: () => undefined,
+  onImplementWith: () => undefined,
+  onImplementLocally: () => undefined,
+  onQueue: () => undefined,
+}
+
+describe("IssueActionsMenu", () => {
+  test("actionable Issues offer Implement now, Implement with..., Implement locally in that order", () => {
+    const html = renderToStaticMarkup(
+      <IssueActionsMenu {...defaultProps} canImplement canQueue={false} />,
+    )
+    expect(html).toContain('aria-label="Actions for issue #1034"')
+    expect(html).toContain('aria-haspopup="menu"')
+    expect(html).not.toContain("Implement now")
+    expect(html).not.toContain("Queue")
+  })
+
+  test("blocked Issues show Queue only", () => {
+    const html = renderToStaticMarkup(
+      <IssueActionsMenu {...defaultProps} canImplement={false} canQueue />,
+    )
+    expect(html).toContain('aria-label="Actions for issue #1034"')
+    expect(html).not.toContain("Implement now")
+    expect(html).not.toContain("Implement with...")
+    expect(html).not.toContain("Implement locally")
+    expect(html).not.toContain("Queue")
+  })
+
+  test("hides the kebab when the Issue is not actionable and cannot be queued", () => {
+    const html = renderToStaticMarkup(
+      <IssueActionsMenu
+        {...defaultProps}
+        canImplement={false}
+        canQueue={false}
+      />,
+    )
+    expect(html).toBe("")
+  })
+})
+
+describe("IssueActionsMenu interaction", () => {
+  let restore: (() => Promise<void>) | undefined
+  let container: HTMLElement | undefined
+  let root: ReturnType<typeof createRoot> | undefined
+  let fireEvent: ((target: EventTarget, type: string) => void) | undefined
+
+  afterEach(async () => {
+    if (root !== undefined && container !== undefined) {
+      flushSync(() => root?.unmount())
+    }
+    await restore?.()
+    restore = undefined
+    container = undefined
+    root = undefined
+    fireEvent = undefined
+  })
+
+  const render = (tree: ReactNode) => {
+    const installed = installDom()
+    restore = installed.restore
+    fireEvent = installed.fire
+    container = installed.document.createElement("div")
+    installed.document.body.appendChild(container)
+    root = createRoot(container)
+    flushSync(() => {
+      root?.render(tree)
+    })
+    return container
+  }
+
+  const fire = (target: EventTarget | null, type: string) => {
+    if (target === null || fireEvent === undefined) {
+      throw new Error("missing event target")
+    }
+    fireEvent(target, type)
+  }
+
+  test("opens Implement now, Implement with..., Implement locally in that order", () => {
+    const calls: string[] = []
+    const node = render(
+      <IssueActionsMenu
+        {...defaultProps}
+        canImplement
+        canQueue={false}
+        onImplementNow={() => calls.push("now")}
+        onImplementWith={() => calls.push("with")}
+        onImplementLocally={() => calls.push("locally")}
+      />,
+    )
+    const kebab = node.querySelector("button[aria-haspopup='menu']")
+    expect(kebab).not.toBeNull()
+    flushSync(() => {
+      fire(kebab, "click")
+    })
+    const items = [...node.querySelectorAll("[role='menuitem']")].map(
+      (item) => item.textContent,
+    )
+    expect(items).toEqual([
+      "Implement now",
+      "Implement with...",
+      "Implement locally",
+    ])
+  })
+
+  test("blocked Issue kebab offers only Queue", () => {
+    const node = render(
+      <IssueActionsMenu {...defaultProps} canImplement={false} canQueue />,
+    )
+    const kebab = node.querySelector("button[aria-haspopup='menu']")
+    flushSync(() => {
+      fire(kebab, "click")
+    })
+    const items = [...node.querySelectorAll("[role='menuitem']")].map(
+      (item) => item.textContent,
+    )
+    expect(items).toEqual(["Queue"])
+  })
+
+  test("Implement with... notifies without starting Implement now", () => {
+    const calls: string[] = []
+    const node = render(
+      <IssueActionsMenu
+        {...defaultProps}
+        canImplement
+        canQueue={false}
+        onImplementNow={() => calls.push("now")}
+        onImplementWith={() => calls.push("with")}
+        onImplementLocally={() => calls.push("locally")}
+      />,
+    )
+    const kebab = node.querySelector("button[aria-haspopup='menu']")
+    flushSync(() => {
+      fire(kebab, "click")
+    })
+    const withItem = [...node.querySelectorAll("[role='menuitem']")].find(
+      (item) => item.textContent === "Implement with...",
+    )
+    flushSync(() => {
+      fire(withItem ?? null, "click")
+    })
+    expect(calls).toEqual(["with"])
+  })
+})

--- a/apps/harness/test/kanban-route.test.ts
+++ b/apps/harness/test/kanban-route.test.ts
@@ -438,6 +438,8 @@ describe("kanban home board", () => {
       source.indexOf("function KanbanJobsBoard()"),
     )
     expect(ticket).toContain("{workItem.agentBackend.label}")
+    expect(ticket).toContain("<ExecutionProfileSummary")
+    expect(ticket).toContain("workItem.executionProfile")
     expect(ticket).toContain("ui.jobTicketRuntime")
     // Backend label is its own line; session sits on a following row.
     expect(ticket).toMatch(

--- a/apps/harness/test/repos-interchange.test.ts
+++ b/apps/harness/test/repos-interchange.test.ts
@@ -125,7 +125,7 @@ describe("Interchange phase 4: repos page + blank slate", () => {
     const implementAction = sliceBetweenMarkers(
       issues,
       "{canImplement && (",
-      "{(canImplement || canQueue) && (",
+      "{issue.issueAuthor !== null",
     )
     expect(implementAction).toContain("onClick={startImplementNow}")
     expect(implementAction).not.toContain('aria-haspopup="menu"')
@@ -134,36 +134,22 @@ describe("Interchange phase 4: repos page + blank slate", () => {
     const actionHandlers = sliceBetweenMarkers(
       issues,
       "const startImplementNow = () => {",
-      "useEffect(() => {",
+      "return (",
     )
     expect(actionHandlers).toContain("implementLocally.reset()")
     expect(actionHandlers).toContain("queueIssue.reset()")
     expect(actionHandlers).toContain("implementNow.mutate()")
     expect(actionHandlers).toContain("implementLocally.mutate()")
     expect(actionHandlers).toContain("queueIssue.mutate()")
-    expect(actionHandlers).toContain("const runMenuAction =")
-    const completeMenuStart = issues.indexOf("{(canImplement || canQueue) && (")
-    expect(completeMenuStart).toBeGreaterThan(-1)
-    const completeMenu = issues.slice(completeMenuStart)
-    expect(completeMenu).toContain("{canImplement && (")
-    expect(completeMenu).toContain("Implement now")
-    expect(completeMenu).toContain("Implement locally")
-    expect(completeMenu).toContain(
-      "runMenuAction({ action: startImplementNow })",
-    )
-    expect(completeMenu).toContain(
-      "runMenuAction({ action: startImplementLocally })",
-    )
-    expect(completeMenu).toContain("{canQueue && (")
-    expect(completeMenu).toContain("runMenuAction({ action: startQueue })")
-    expect(completeMenu).toContain(
-      'queueIssue.isPending ? "Queueing..." : "Queue"',
-    )
+    expect(actionHandlers).toContain("setImplementWithOpen(true)")
+    expect(issues).toContain("<IssueActionsMenu")
+    expect(issues).toContain("onImplementWith={startImplementWith}")
+    expect(issues).toContain("<ImplementWithIssueDialog")
     expect(issues.indexOf("ui.repoIssueImplementBtn")).toBeLessThan(
       issues.indexOf("ui.repoIssueActions"),
     )
     expect(issues.indexOf("ui.repoIssueActions")).toBeLessThan(
-      issues.indexOf("{(canImplement || canQueue) && ("),
+      issues.indexOf("<IssueActionsMenu"),
     )
     expect(issues).toContain("ui.repoIssueAuthor")
     expect(issues).toContain("ui.stamp")
@@ -465,6 +451,7 @@ describe("Interchange phase 4: repos page + blank slate", () => {
     expect(leaf).toContain("startWorkBannerMessage")
     expect(leaf).toContain("queueIssue.error")
     expect(leaf).toContain("implementNow.error")
+    expect(leaf).toContain("implementWith.error")
     expect(leaf).toContain("implementLocally.error")
     expect(leaf).toContain("Could not queue issue")
     expect(leaf).toContain("Could not start implementation")

--- a/apps/harness/test/waiting-for-blockers-working-row.test.ts
+++ b/apps/harness/test/waiting-for-blockers-working-row.test.ts
@@ -80,9 +80,8 @@ describe("Waiting for blockers Working-row polish", () => {
   test("Issue row keeps direct Implement and restores the complete kebab", () => {
     const source = homeSource()
     expect(source).toContain("issueActionEligibility({")
-    expect(source).toContain('queueIssue.isPending ? "Queueing..." : "Queue"')
     expect(source).toContain("{canImplement && (")
-    expect(source).toContain("{(canImplement || canQueue) && (")
+    expect(source).toContain("<IssueActionsMenu")
     // Primary blue cue after the title for implementable issues only.
     expect(source).toContain("ui.repoIssueImplementBtn")
     expect(source).toContain("ui.repoIssueImplementIcon")
@@ -92,13 +91,13 @@ describe("Waiting for blockers Working-row polish", () => {
     expect(source).toContain("queueIssue.reset()")
     expect(source).toContain("implementNow.mutate()")
     expect(source).toContain("onClick={startImplementNow}")
-    // The rightmost kebab retains both implementation paths.
-    expect(source).toContain("Implement now")
-    expect(source).toContain("Implement locally")
+    // The rightmost kebab retains Implement now, Implement with..., locally.
+    expect(source).toContain("<IssueActionsMenu")
+    expect(source).toContain("onImplementWith={startImplementWith}")
     expect(source).toContain("implementLocally.mutate()")
-    expect(source).toContain("runMenuAction({ action: startImplementLocally })")
+    expect(source).toContain("setImplementWithOpen(true)")
     expect(source).toMatch(
-      /implementNow\.isPending \|\|\s*implementLocally\.isPending \|\| queueIssue\.isPending/,
+      /implementNow\.isPending \|\|\s*implementWith\.isPending \|\|\s*implementLocally\.isPending \|\|\s*queueIssue\.isPending/,
     )
     expect(source).toContain("implementLocally.isError")
     // Pending disables the primary cue (styles + behavior stay aligned).

--- a/apps/harness/test/work-item-lifecycle-status.test.tsx
+++ b/apps/harness/test/work-item-lifecycle-status.test.tsx
@@ -57,6 +57,29 @@ describe("WorkItemLifecycleStatus", () => {
     expect(html).toContain("Status checks: Postponed")
     expect(html).not.toContain(">Retry<")
     expect(html).not.toContain("Cause chain")
+    expect(html).not.toContain("Explicit Work Item Execution Profile")
+  })
+
+  test("shows an Explicit Work Item Execution Profile on Work Item detail", () => {
+    const profiled = {
+      ...waitingForGitHubWorkItem,
+      executionProfile: {
+        backend: { id: "opencode", label: "OpenCode" },
+        buildModel: "big-pickle",
+        buildThinkingLevel: "high",
+        reviewSameAsBuild: true,
+        reviewModel: "big-pickle",
+        reviewThinkingLevel: "high",
+      },
+    } satisfies WorkItem
+    const html = renderToStaticMarkup(
+      <QueryClientProvider client={new QueryClient()}>
+        <WorkItemLifecycleStatus workItem={profiled} />
+      </QueryClientProvider>,
+    )
+    expect(html).toContain("Explicit Work Item Execution Profile")
+    expect(html).toContain("Build big-pickle · High")
+    expect(html).toContain("Review Same as build")
   })
 
   test("hides the cause chain behind a collapsed disclosure on a failed card", () => {


### PR DESCRIPTION
Operators who wanted a one-attempt Agent Backend model or Thinking Level
had to change Repository settings or Harness Config. Ordinary Implement Now
still re-resolves those defaults on every Agent Turn.

This adds **Implement with...** on Actionable Issue kebabs (between Implement
now and Implement locally). The primary Implement button still starts
Implement Now. The ephemeral **Implement issue #N with...** dialog is local
modal state (no history entry). It pre-fills the Repository Effective Agent
Backend and currently resolved backend-scoped prefs, keeps catalog-only
selectors, defaults review to Same as build, and always calls `implementWith`
so unchanged values still persist an Explicit Work Item Execution Profile.
Choices never write settings. Work Item detail, Kanban, and Completed show
the explicit profile.

Also remaps Bun's nested TypeScript 7 stub for Nx pre-commit (`readConfigFile`
/ `version.cjs`) and runs that remap with `NX_DAEMON=false` before affected
lint/typecheck/test.

Backend switching and inactive-backend activation remain #1035. Extra
host-dialog Escape tests, archive-line wrapping, and an Implement-Now-style
double-submit race are left as-is.

Verification: harness unit tests for menu order, dialog prefs/catalog
reconcile, submit/error/cancel, and profile chrome; `harness:lint`,
`harness:typecheck`, and `harness:test`.

Closes #1034