### PR TITLE
feat: let Implement With preview and activate any shipped Agent Backend

### DIFF
--- a/apps/harness/src/home-page-content.tsx
+++ b/apps/harness/src/home-page-content.tsx
@@ -858,7 +858,7 @@ function RepositoryCard({
   } | null>(null)
   const previewGenerationRef = useRef(0)
   // Dialog-session stash so switching backends and back restores form fields.
-  // Server map for non-projected backends needs repositoryModelPrefs (not in API).
+  // Server map for non-projected backends needs repositoryModelPrefs.
   type DraftModelPrefs = {
     defaultModel: string | null
     defaultThinkingLevel: string | null
@@ -3028,6 +3028,9 @@ function RepositoryIssueRow({
     onSuccess: (workItem) => {
       setImplementWithOpen(false)
       onImplementSuccess(workItem)
+      void queryClient.invalidateQueries({
+        queryKey: ["agentBackendStatus"],
+      })
     },
   })
   const implementLocally = useMutation({
@@ -3214,7 +3217,8 @@ function RepositoryIssueRow({
       {implementWithOpen && (
         <ImplementWithIssueDialog
           issueNumber={issue.issueNumber}
-          backendId={repository.effectiveAgentBackend}
+          repositoryId={repository.id}
+          initialBackendId={repository.effectiveAgentBackend}
           repositoryPrefs={{
             defaultModel: repository.defaultModel,
             defaultThinkingLevel: repository.defaultThinkingLevel,

--- a/apps/harness/src/implement-with-dialog.tsx
+++ b/apps/harness/src/implement-with-dialog.tsx
@@ -35,7 +35,7 @@ type ImplementWithCatalog = {
   readonly warnings: readonly string[]
 }
 
-export type ImplementWithBackendOption = {
+type ImplementWithBackendOption = {
   readonly id: string
   readonly label: string
 }

--- a/apps/harness/src/implement-with-dialog.tsx
+++ b/apps/harness/src/implement-with-dialog.tsx
@@ -2,6 +2,7 @@ import {
   type FormEvent,
   type ReactNode,
   useEffect,
+  useLayoutEffect,
   useRef,
   useState,
 } from "react"
@@ -34,10 +35,15 @@ type ImplementWithCatalog = {
   readonly warnings: readonly string[]
 }
 
+export type ImplementWithBackendOption = {
+  readonly id: string
+  readonly label: string
+}
+
 export type ImplementWithDialogProps = {
   readonly issueNumber: number
   readonly backendId: string
-  readonly backendLabel: string
+  readonly backends: readonly ImplementWithBackendOption[]
   readonly configurationMode: string | null
   readonly initialDraft: ExecutionProfileDraft
   readonly catalog: ImplementWithCatalog
@@ -45,7 +51,13 @@ export type ImplementWithDialogProps = {
   readonly submitPending: boolean
   readonly submitError: string | null
   readonly onSubmit: (profile: ImplementWithProfileInput) => void
+  readonly onBackendChange: (backendId: string) => void
   readonly onCancel: () => void
+}
+
+type DraftSlot = {
+  readonly source: "prefs" | "user"
+  readonly draft: ExecutionProfileDraft
 }
 
 /**
@@ -109,7 +121,7 @@ const sameAsBuildDraft = (
 export function ImplementWithDialog({
   issueNumber,
   backendId,
-  backendLabel,
+  backends,
   configurationMode,
   initialDraft,
   catalog,
@@ -117,8 +129,10 @@ export function ImplementWithDialog({
   submitPending,
   submitError,
   onSubmit,
+  onBackendChange,
   onCancel,
 }: ImplementWithDialogProps): ReactNode {
+  const draftSlotsRef = useRef<Record<string, DraftSlot>>({})
   const [draft, setDraft] = useState(() =>
     reconcileExecutionProfileDraft({
       draft: initialDraft,
@@ -126,15 +140,30 @@ export function ImplementWithDialog({
     }),
   )
   const titleId = `implement-with-title-${issueNumber}`
+  const backendLabel =
+    backends.find((backend) => backend.id === backendId)?.label ?? backendId
 
-  useEffect(() => {
-    setDraft((current) =>
-      reconcileExecutionProfileDraft({
-        draft: current,
-        models: catalog.models,
-      }),
-    )
-  }, [catalog.models])
+  useLayoutEffect(() => {
+    const slot = draftSlotsRef.current[backendId]
+    const source = slot?.source === "user" ? "user" : "prefs"
+    const nextDraft = reconcileExecutionProfileDraft({
+      draft:
+        source === "user" && slot !== undefined ? slot.draft : initialDraft,
+      models: catalog.models,
+    })
+    draftSlotsRef.current[backendId] = { source, draft: nextDraft }
+    setDraft(nextDraft)
+  }, [backendId, catalog.models, initialDraft])
+
+  const replaceDraft = (
+    updater: (current: ExecutionProfileDraft) => ExecutionProfileDraft,
+  ) => {
+    setDraft((current) => {
+      const next = updater(current)
+      draftSlotsRef.current[backendId] = { source: "user", draft: next }
+      return next
+    })
+  }
 
   const catalogModels = catalog.models
   const catalogState = {
@@ -215,7 +244,7 @@ export function ImplementWithDialog({
 
   const updateBuild = (nextModel: string) => {
     const nextVariants = thinkingLevelsForModel(catalogModels, nextModel)
-    setDraft((current) => ({
+    replaceDraft((current) => ({
       ...current,
       buildModel: nextModel,
       buildThinkingLevel: reconcileVariantForModel(
@@ -262,13 +291,31 @@ export function ImplementWithDialog({
               <h3 id="implement-with-backend" className={ui.dialogSectionTitle}>
                 Agent Backend
               </h3>
-              <span className={ui.dialogSectionMeta}>Effective</span>
+              <span className={ui.dialogSectionMeta}>Shipped</span>
             </div>
-            <p className={ui.dialogNote}>{backendLabel}</p>
-            <span className={ui.dialogFieldHint}>
-              Repository Effective Agent Backend. This Work Item will keep this
-              backend and the model choices below.
-            </span>
+            <label className={ui.dialogField}>
+              Agent Backend
+              <select
+                className={ui.dialogInput}
+                name="agentBackend"
+                value={backendId}
+                disabled={submitPending}
+                onChange={(event) => onBackendChange(event.target.value)}
+              >
+                {backends.some((backend) => backend.id === backendId) ? null : (
+                  <option value={backendId}>{backendLabel}</option>
+                )}
+                {backends.map((backend) => (
+                  <option key={backend.id} value={backend.id}>
+                    {backend.label}
+                  </option>
+                ))}
+              </select>
+              <span className={ui.dialogFieldHint}>
+                Previewing another Agent Backend does not change saved defaults.
+                This Work Item will keep the backend you submit.
+              </span>
+            </label>
           </section>
 
           <section
@@ -356,7 +403,7 @@ export function ImplementWithDialog({
                     modelSelectDisabled || draft.buildModel.length === 0
                   }
                   onChange={(event) =>
-                    setDraft((current) => ({
+                    replaceDraft((current) => ({
                       ...current,
                       buildThinkingLevel: event.target.value,
                     }))
@@ -397,14 +444,14 @@ export function ImplementWithDialog({
               hint="Same as build uses exactly the build Agent Model and Thinking Level."
               onChange={(nextModel) => {
                 if (nextModel.length === 0) {
-                  setDraft((current) => sameAsBuildDraft(current))
+                  replaceDraft((current) => sameAsBuildDraft(current))
                   return
                 }
                 const nextVariants = thinkingLevelsForModel(
                   catalogModels,
                   nextModel,
                 )
-                setDraft((current) => ({
+                replaceDraft((current) => ({
                   buildModel: current.buildModel,
                   buildThinkingLevel: current.buildThinkingLevel,
                   reviewSameAsBuild: false,
@@ -451,7 +498,7 @@ export function ImplementWithDialog({
                     reviewThinkingLevels.length === 0
                   }
                   onChange={(event) =>
-                    setDraft((current) =>
+                    replaceDraft((current) =>
                       current.reviewSameAsBuild
                         ? current
                         : {

--- a/apps/harness/src/implement-with-issue-dialog.tsx
+++ b/apps/harness/src/implement-with-issue-dialog.tsx
@@ -1,5 +1,5 @@
 import { useQuery } from "@tanstack/react-query"
-import type { ReactNode } from "react"
+import { type ReactNode, useState } from "react"
 import type { AgentModelOption } from "./agent-model-settings.js"
 import {
   type ExecutionProfileDraft,
@@ -31,7 +31,8 @@ const agentBackendsQuery = {
 
 export type ImplementWithIssueDialogProps = {
   readonly issueNumber: number
-  readonly backendId: string
+  readonly repositoryId: string
+  readonly initialBackendId: string
   readonly repositoryPrefs: ExecutionProfilePrefSource
   readonly submitPending: boolean
   readonly submitError: string | null
@@ -40,18 +41,21 @@ export type ImplementWithIssueDialogProps = {
 }
 
 /**
- * Loads Effective Agent Backend catalog and Harness prefs, then hosts the
- * ephemeral Implement With dialog. Does not mutate settings.
+ * Loads shipped Agent Backend catalogs and resolved prefs, then hosts the
+ * ephemeral Implement With dialog. Preview and pref reads do not mutate
+ * settings or the Active set.
  */
 export function ImplementWithIssueDialog({
   issueNumber,
-  backendId,
+  repositoryId,
+  initialBackendId,
   repositoryPrefs,
   submitPending,
   submitError,
   onSubmit,
   onCancel,
 }: ImplementWithIssueDialogProps): ReactNode {
+  const [backendId, setBackendId] = useState(initialBackendId)
   const agentBackends = useQuery(agentBackendsQuery)
   const harnessPrefs = useQuery({
     queryKey: ["implement-with", "harness-prefs", backendId] as const,
@@ -66,6 +70,26 @@ export function ImplementWithIssueDialog({
         },
       })
       return result.harnessModelPrefs
+    },
+  })
+  const repositoryScopedPrefs = useQuery({
+    queryKey: [
+      "implement-with",
+      "repository-prefs",
+      repositoryId,
+      backendId,
+    ] as const,
+    queryFn: async (): Promise<ExecutionProfilePrefSource> => {
+      const result = await graphql.query({
+        repositoryModelPrefs: {
+          __args: { repositoryId, backendId },
+          defaultModel: true,
+          defaultThinkingLevel: true,
+          reviewModel: true,
+          reviewThinkingLevel: true,
+        },
+      })
+      return result.repositoryModelPrefs
     },
   })
   const preview = useQuery({
@@ -90,11 +114,8 @@ export function ImplementWithIssueDialog({
     },
   })
 
-  const backend = (agentBackends.data ?? []).find(
-    (candidate) => candidate.id === backendId,
-  )
-  const backendLabel =
-    preview.data?.backend.label ?? backend?.label ?? backendId
+  const backends = agentBackends.data ?? []
+  const backend = backends.find((candidate) => candidate.id === backendId)
   const configurationMode = backend?.configurationMode ?? null
   const mappedPreview =
     preview.data === undefined
@@ -130,7 +151,11 @@ export function ImplementWithIssueDialog({
     warnings: preview.data?.warnings ?? [],
   }
 
-  if (harnessPrefs.isPending) {
+  const firstPrefsPending =
+    backendId === initialBackendId &&
+    harnessPrefs.isPending &&
+    harnessPrefs.data === undefined
+  if (firstPrefsPending) {
     const loadingTitleId = `implement-with-loading-${issueNumber}`
     return (
       <ImplementWithModalDialog labelledBy={loadingTitleId} onCancel={onCancel}>
@@ -156,27 +181,38 @@ export function ImplementWithIssueDialog({
     )
   }
 
-  const harness: ExecutionProfilePrefSource = harnessPrefs.data ?? {
+  const emptyPrefs: ExecutionProfilePrefSource = {
     defaultModel: null,
     defaultThinkingLevel: null,
     reviewModel: null,
     reviewThinkingLevel: null,
   }
+  const harness: ExecutionProfilePrefSource = harnessPrefs.data ?? emptyPrefs
+  const repositoryForBackend =
+    backendId === initialBackendId
+      ? repositoryPrefs
+      : (repositoryScopedPrefs.data ?? emptyPrefs)
   const initialDraft: ExecutionProfileDraft = resolveExecutionProfileDraft({
-    repository: repositoryPrefs,
+    repository: repositoryForBackend,
     harness,
   })
   const prefsError = harnessPrefs.isError
     ? harnessPrefs.error instanceof Error
       ? harnessPrefs.error.message
       : "Could not load Harness model preferences for this Agent Backend."
-    : null
+    : repositoryScopedPrefs.isError
+      ? repositoryScopedPrefs.error instanceof Error
+        ? repositoryScopedPrefs.error.message
+        : "Could not load Repository model preferences for this Agent Backend."
+      : null
 
   return (
     <ImplementWithDialog
       issueNumber={issueNumber}
       backendId={backendId}
-      backendLabel={backendLabel}
+      backends={
+        backends.length > 0 ? backends : [{ id: backendId, label: backendId }]
+      }
       configurationMode={configurationMode}
       initialDraft={initialDraft}
       catalog={catalog}
@@ -184,6 +220,7 @@ export function ImplementWithIssueDialog({
       submitPending={submitPending}
       submitError={submitError}
       onSubmit={onSubmit}
+      onBackendChange={setBackendId}
       onCancel={onCancel}
     />
   )

--- a/apps/harness/src/server/application.server.ts
+++ b/apps/harness/src/server/application.server.ts
@@ -45,7 +45,7 @@ import {
 import { SqliteQueueServiceLive } from "@ready-for-agent/sqlite-queue-service"
 import {
   LifecycleStepsLive,
-  WorkItemLifecycleLive,
+  makeWorkItemLifecycleLive,
 } from "@ready-for-agent/work-item-lifecycle"
 import type { ApplicationRequestContext } from "../application-request-context.js"
 import { READY_FOR_AGENT_VERSION } from "../generated/version.js"
@@ -212,7 +212,9 @@ export const createApplication = async (
     }),
   ).pipe(Layer.provide(databaseLayer))
 
-  const lifecycleLayer = WorkItemLifecycleLive.pipe(
+  const lifecycleLayer = makeWorkItemLifecycleLive({
+    inspectCwd: toolCwd,
+  }).pipe(
     Layer.provideMerge(LifecycleStepsLive),
     Layer.provideMerge(databaseLayer),
     Layer.provideMerge(queueLayer),

--- a/apps/harness/test/implement-with-dialog.test.tsx
+++ b/apps/harness/test/implement-with-dialog.test.tsx
@@ -88,10 +88,27 @@ const installDom = () => {
   }
 }
 
+const shippedBackends = [
+  { id: "opencode", label: "OpenCode" },
+  { id: "grok", label: "Grok Build" },
+  { id: "codex", label: "Codex Build" },
+  { id: "claude", label: "Claude Code" },
+] as const
+
+const grokCatalog = {
+  loading: false,
+  failed: false,
+  error: null,
+  models: [
+    { id: "grok-code", thinkingLevels: ["low", "high"], name: "Grok Code" },
+  ],
+  warnings: [],
+}
+
 const baseProps = {
   issueNumber: 1034,
   backendId: "opencode",
-  backendLabel: "OpenCode",
+  backends: shippedBackends,
   configurationMode: null,
   initialDraft: {
     buildModel: "sonnet",
@@ -102,6 +119,7 @@ const baseProps = {
   submitPending: false,
   submitError: null,
   onSubmit: () => undefined,
+  onBackendChange: () => undefined,
   onCancel: () => undefined,
 } satisfies ImplementWithDialogProps
 
@@ -112,7 +130,12 @@ describe("ImplementWithDialog copy and catalog", () => {
     expect(html).toContain("These choices apply only to this Work Item")
     expect(html).toContain("never change Repository settings or Harness Config")
     expect(html).toContain("OpenCode")
-    expect(html).toContain("Repository Effective Agent Backend")
+    expect(html).toContain("Grok Build")
+    expect(html).toContain("Codex Build")
+    expect(html).toContain("Claude Code")
+    expect(html).toContain('name="agentBackend"')
+    expect(html).not.toContain("Repository Effective Agent Backend")
+    expect(html).toContain("does not change saved defaults")
     expect(html).toContain(">Implement<")
     expect(html).toContain(">Cancel<")
     expect(html).not.toContain("Recheck")
@@ -175,6 +198,50 @@ describe("ImplementWithDialog copy and catalog", () => {
     expect(html).toContain(">Select a build model</option>")
     expect(html).toContain("Select a model from the Agent Model catalog.")
   })
+
+  test("a failed Preview keeps the backend selector usable and blocks Implement", () => {
+    const html = renderToStaticMarkup(
+      <ImplementWithDialog
+        {...baseProps}
+        catalog={{
+          loading: false,
+          failed: true,
+          error: "Could not inspect Grok Build.",
+          models: [],
+          warnings: [],
+        }}
+      />,
+    )
+    expect(html).toContain("Could not inspect Grok Build.")
+    expect(html).toContain('name="agentBackend"')
+    expect(html).not.toMatch(/name="agentBackend"[^>]*disabled/)
+    expect(html).toContain('name="buildModel"')
+    expect(html).toMatch(/name="buildModel"[^>]*disabled/)
+    expect(html).toContain(">Implement<")
+    expect(html).toMatch(/type="submit"[^>]*disabled/)
+    expect(html).not.toContain("Recheck")
+    expect(html).not.toContain('href="/settings"')
+  })
+
+  test("an empty catalog cannot be submitted and explains why", () => {
+    const html = renderToStaticMarkup(
+      <ImplementWithDialog
+        {...baseProps}
+        catalog={{
+          loading: false,
+          failed: false,
+          error: null,
+          models: [],
+          warnings: [],
+        }}
+      />,
+    )
+    expect(html).toContain(
+      "Implement With requires a non-empty Agent Model catalog.",
+    )
+    expect(html).toMatch(/type="submit"[^>]*disabled/)
+    expect(html).not.toContain("Recheck")
+  })
 })
 
 describe("ImplementWithDialog interaction", () => {
@@ -202,20 +269,32 @@ describe("ImplementWithDialog interaction", () => {
     installed.document.body.appendChild(container)
     root = createRoot(container)
     const submitted: ImplementWithProfileInput[] = []
+    const backendChanges: string[] = []
     let cancelled = 0
-    flushSync(() => {
-      root?.render(
-        <ImplementWithDialog
-          {...baseProps}
-          {...props}
-          onSubmit={(profile) => submitted.push(profile)}
-          onCancel={() => {
-            cancelled += 1
-          }}
-        />,
-      )
-    })
-    return { node: container, submitted, cancelled: () => cancelled }
+    const rerender = (next: Partial<ImplementWithDialogProps> = {}) => {
+      flushSync(() => {
+        root?.render(
+          <ImplementWithDialog
+            {...baseProps}
+            {...props}
+            {...next}
+            onSubmit={(profile) => submitted.push(profile)}
+            onBackendChange={(backendId) => backendChanges.push(backendId)}
+            onCancel={() => {
+              cancelled += 1
+            }}
+          />,
+        )
+      })
+    }
+    rerender()
+    return {
+      node: container as HTMLElement,
+      submitted,
+      backendChanges,
+      cancelled: () => cancelled,
+      rerender,
+    }
   }
 
   const fire = (target: EventTarget | null, type: string) => {
@@ -324,5 +403,99 @@ describe("ImplementWithDialog interaction", () => {
       fire(cancel ?? null, "click")
     })
     expect(cancelled()).toBe(1)
+  })
+
+  test("switching backends loads that backend's prefill without discarding the other draft", () => {
+    const { node, submitted, backendChanges, rerender } = render()
+    const backend = selectNamed(node, "agentBackend")
+    const build = selectNamed(node, "buildModel")
+    flushSync(() => {
+      build.value = "haiku"
+      fire(build, "change")
+    })
+    flushSync(() => {
+      backend.value = "grok"
+      fire(backend, "change")
+    })
+    expect(backendChanges).toEqual(["grok"])
+    rerender({
+      backendId: "grok",
+      catalog: grokCatalog,
+      initialDraft: {
+        buildModel: "grok-code",
+        buildThinkingLevel: "low",
+        reviewSameAsBuild: true,
+      },
+    })
+    expect(selectNamed(node, "buildModel").value).toBe("grok-code")
+    expect(selectNamed(node, "buildThinkingLevel").value).toBe("low")
+    flushSync(() => {
+      selectNamed(node, "buildThinkingLevel").value = "high"
+      fire(selectNamed(node, "buildThinkingLevel"), "change")
+    })
+    flushSync(() => {
+      selectNamed(node, "agentBackend").value = "opencode"
+      fire(selectNamed(node, "agentBackend"), "change")
+    })
+    rerender({
+      backendId: "opencode",
+      catalog: readyCatalog,
+      initialDraft: {
+        buildModel: "sonnet",
+        buildThinkingLevel: "high",
+        reviewSameAsBuild: true,
+      },
+    })
+    expect(selectNamed(node, "buildModel").value).toBe("haiku")
+    flushSync(() => {
+      fire(node.querySelector("form"), "submit")
+    })
+    expect(submitted.at(-1)).toEqual({
+      agentBackendId: "opencode",
+      buildModel: "haiku",
+      buildThinkingLevel: null,
+      reviewSameAsBuild: true,
+      reviewModel: null,
+      reviewThinkingLevel: null,
+    })
+    rerender({
+      backendId: "grok",
+      catalog: grokCatalog,
+      initialDraft: {
+        buildModel: "grok-code",
+        buildThinkingLevel: "low",
+        reviewSameAsBuild: true,
+      },
+    })
+    flushSync(() => {
+      fire(node.querySelector("form"), "submit")
+    })
+    expect(submitted.at(-1)).toEqual({
+      agentBackendId: "grok",
+      buildModel: "grok-code",
+      buildThinkingLevel: "high",
+      reviewSameAsBuild: true,
+      reviewModel: null,
+      reviewThinkingLevel: null,
+    })
+  })
+
+  test("a failed backend does not disable switching to another shipped backend", () => {
+    const { node, backendChanges } = render({
+      catalog: {
+        loading: false,
+        failed: true,
+        error: "Could not inspect OpenCode.",
+        models: [],
+        warnings: [],
+      },
+    })
+    const backend = selectNamed(node, "agentBackend")
+    expect(backend.disabled).toBe(false)
+    flushSync(() => {
+      backend.value = "claude"
+      fire(backend, "change")
+    })
+    expect(backendChanges).toEqual(["claude"])
   })
 })

--- a/packages/db-service/src/lib/db-service.ts
+++ b/packages/db-service/src/lib/db-service.ts
@@ -340,6 +340,14 @@ export interface DbServiceShape {
   readonly getBackendModelPrefs: (
     backendId: string,
   ) => Effect.Effect<BackendModelPrefs, DatabaseError>
+  /**
+   * Repository-scoped build/review prefs for one Agent Backend. Empty when
+   * that backend has no stored override on the Repository.
+   */
+  readonly getRepositoryBackendModelPrefs: (
+    repositoryId: string,
+    backendId: string,
+  ) => Effect.Effect<BackendModelPrefs, DatabaseError | RepositoryNotFoundError>
   readonly updateConfig: (
     input: UpdateConfigInput,
   ) => Effect.Effect<
@@ -735,6 +743,28 @@ export const DbServiceLive = Layer.effect(
         return prefsForBackend(map, backendId.trim())
       },
     )
+
+    const getRepositoryBackendModelPrefs = Effect.fn(
+      "DbService.getRepositoryBackendModelPrefs",
+    )(function* (repositoryId: string, backendId: string) {
+      const rows = (yield* sql
+        .unsafe(
+          `SELECT backend_model_prefs AS backendModelPrefs
+           FROM repository WHERE id = ?`,
+          [repositoryId],
+        )
+        .pipe(Effect.mapError(toDatabaseError))) as readonly {
+        readonly backendModelPrefs: string
+      }[]
+      const row = rows[0]
+      if (row === undefined) {
+        return yield* new RepositoryNotFoundError({ repositoryId })
+      }
+      return prefsForBackend(
+        parseBackendModelPrefsMap(row.backendModelPrefs ?? "{}"),
+        backendId.trim(),
+      )
+    })
 
     /**
      * Re-project flat model columns from backendModelPrefs for repositories
@@ -1818,6 +1848,7 @@ export const DbServiceLive = Layer.effect(
       notifyWorkItemsChanged,
       getConfig,
       getBackendModelPrefs,
+      getRepositoryBackendModelPrefs,
       updateConfig,
       countUnfinishedWorkItems,
       countBlockingUnfinishedForGlobalDefault,

--- a/packages/db-service/src/lib/test-fixtures.ts
+++ b/packages/db-service/src/lib/test-fixtures.ts
@@ -55,6 +55,13 @@ export const stubDbService = (
       reviewModel: null,
       reviewThinkingLevel: null,
     }),
+  getRepositoryBackendModelPrefs: () =>
+    Effect.succeed({
+      defaultModel: null,
+      defaultThinkingLevel: null,
+      reviewModel: null,
+      reviewThinkingLevel: null,
+    }),
   updateConfig: unused,
   countUnfinishedWorkItems: Effect.succeed(0),
   countBlockingUnfinishedForGlobalDefault: Effect.succeed(0),

--- a/packages/db-service/test/db-service.spec.ts
+++ b/packages/db-service/test/db-service.spec.ts
@@ -1422,6 +1422,30 @@ describe("DbService", () => {
             reviewModel: null,
             reviewThinkingLevel: null,
           })
+          expect(
+            yield* db.getRepositoryBackendModelPrefs(repo.id, "opencode"),
+          ).toEqual({
+            defaultModel: "openai/opencode-model-v2",
+            defaultThinkingLevel: "low",
+            reviewModel: null,
+            reviewThinkingLevel: null,
+          })
+          expect(
+            yield* db.getRepositoryBackendModelPrefs(repo.id, "grok"),
+          ).toEqual({
+            defaultModel: "grok-code",
+            defaultThinkingLevel: null,
+            reviewModel: null,
+            reviewThinkingLevel: null,
+          })
+          expect(
+            yield* db.getRepositoryBackendModelPrefs(repo.id, "claude"),
+          ).toEqual({
+            defaultModel: null,
+            defaultThinkingLevel: null,
+            reviewModel: null,
+            reviewThinkingLevel: null,
+          })
         }),
       ))
 

--- a/packages/graphql-api/src/lib/graphql-api.ts
+++ b/packages/graphql-api/src/lib/graphql-api.ts
@@ -715,6 +715,21 @@ export const createGraphqlApi = <R>(
               }).pipe(Effect.withSpan("graphql-api.harnessModelPrefs")),
               context,
             ),
+          repositoryModelPrefs: async (
+            _parent: unknown,
+            args: { repositoryId: string; backendId: string },
+            context: GraphqlRequestContext,
+          ) =>
+            runGraphql(
+              Effect.gen(function* () {
+                const db = yield* DbService
+                return yield* db.getRepositoryBackendModelPrefs(
+                  args.repositoryId,
+                  args.backendId,
+                )
+              }).pipe(Effect.withSpan("graphql-api.repositoryModelPrefs")),
+              context,
+            ),
           models: async (
             _parent: unknown,
             _args: unknown,

--- a/packages/graphql-api/test/graphql-api.test.ts
+++ b/packages/graphql-api/test/graphql-api.test.ts
@@ -4000,6 +4000,51 @@ describe("GraphQL API", () => {
     })
   })
 
+  test("repositoryModelPrefs returns backend-scoped Repository prefs without mutating settings", async () => {
+    const prefsCalls: Array<{ repositoryId: string; backendId: string }> = []
+    await runtime.dispose()
+    runtime = makeRuntime({
+      getRepositoryBackendModelPrefs: (repositoryId, backendId) => {
+        prefsCalls.push({ repositoryId, backendId })
+        return Effect.succeed({
+          defaultModel: "grok-code",
+          defaultThinkingLevel: "high",
+          reviewModel: null,
+          reviewThinkingLevel: null,
+        })
+      },
+    })
+    const response = await createGraphqlApi(runtime).fetch(
+      graphqlRequest({
+        query: `query RepositoryModelPrefs($repositoryId: ID!, $backendId: String!) {
+          repositoryModelPrefs(repositoryId: $repositoryId, backendId: $backendId) {
+            defaultModel
+            defaultThinkingLevel
+            reviewModel
+            reviewThinkingLevel
+          }
+        }`,
+        variables: {
+          repositoryId: repository.id,
+          backendId: "grok",
+        },
+      }),
+    )
+    expect(await response.json()).toEqual({
+      data: {
+        repositoryModelPrefs: {
+          defaultModel: "grok-code",
+          defaultThinkingLevel: "high",
+          reviewModel: null,
+          reviewThinkingLevel: null,
+        },
+      },
+    })
+    expect(prefsCalls).toEqual([
+      { repositoryId: repository.id, backendId: "grok" },
+    ])
+  })
+
   test("pauses and unpauses a repository", async () => {
     await runtime.dispose()
     runtime = makeRuntime({

--- a/packages/graphql-schema/schema.graphql
+++ b/packages/graphql-schema/schema.graphql
@@ -45,6 +45,14 @@ type Query {
   """
   harnessModelPrefs(backendId: String!): BackendModelPrefs!
   """
+  Remembered build/review model prefs for a backend on one Repository.
+  Does not change settings. Empty when that backend has no stored override.
+  """
+  repositoryModelPrefs(
+    repositoryId: ID!
+    backendId: String!
+  ): BackendModelPrefs!
+  """
   Agent Models available from the Active Agent Backend, each with optional
   Thinking Levels. Empty thinkingLevels means the model has no Thinking Levels.
   Empty when the backend is unavailable.
@@ -822,8 +830,10 @@ type Mutation {
   implementNow(repositoryId: ID!, issueNumber: Int!): WorkItem!
   """
   Create a Work Item for an Actionable Issue with one complete Explicit Work
-  Item Execution Profile. The chosen Agent Backend must already be Active.
-  Partial profiles cannot be represented. Failure creates nothing.
+  Item Execution Profile. Submission activates and inspects an otherwise
+  inactive shipped Agent Backend under the settings/create coordination
+  boundary. Partial profiles cannot be represented. Failure creates nothing
+  and leaves saved defaults unchanged.
   """
   implementWith(
     repositoryId: ID!

--- a/packages/graphql-schema/schema.template.graphql
+++ b/packages/graphql-schema/schema.template.graphql
@@ -42,6 +42,14 @@ type Query {
   """
   harnessModelPrefs(backendId: String!): BackendModelPrefs!
   """
+  Remembered build/review model prefs for a backend on one Repository.
+  Does not change settings. Empty when that backend has no stored override.
+  """
+  repositoryModelPrefs(
+    repositoryId: ID!
+    backendId: String!
+  ): BackendModelPrefs!
+  """
   Agent Models available from the Active Agent Backend, each with optional
   Thinking Levels. Empty thinkingLevels means the model has no Thinking Levels.
   Empty when the backend is unavailable.
@@ -800,8 +808,10 @@ type Mutation {
   implementNow(repositoryId: ID!, issueNumber: Int!): WorkItem!
   """
   Create a Work Item for an Actionable Issue with one complete Explicit Work
-  Item Execution Profile. The chosen Agent Backend must already be Active.
-  Partial profiles cannot be represented. Failure creates nothing.
+  Item Execution Profile. Submission activates and inspects an otherwise
+  inactive shipped Agent Backend under the settings/create coordination
+  boundary. Partial profiles cannot be represented. Failure creates nothing
+  and leaves saved defaults unchanged.
   """
   implementWith(
     repositoryId: ID!

--- a/packages/work-item-lifecycle/src/lib/active-agent-backend-test.ts
+++ b/packages/work-item-lifecycle/src/lib/active-agent-backend-test.ts
@@ -58,6 +58,12 @@ export const stubActiveAgentBackendLayer = (
      * Agent Model admission (issue #838).
      */
     readonly models: AgentBackendRuntimeStatus["models"]
+    /**
+     * Status applied to backends that become Active only through
+     * activate / setSelectedOrInUse (not in the initial registrations).
+     */
+    readonly newlyActivatedKind?: AgentBackendRuntimeStatus["kind"]
+    readonly newlyActivatedReason?: string
     readonly getStatus: Effect.Effect<AgentBackendStatus>
     readonly requireAgentTurnsAllowed: Effect.Effect<
       void,
@@ -93,6 +99,7 @@ export const stubActiveAgentBackendLayer = (
   const readyFor = (entry: AgentBackendRegistration) =>
     runtimeStatus(entry, overrides.models ?? [])
   const allReady = allRegistrations.map(readyFor)
+  const activeIds = new Set<AgentBackendId>(byId.keys())
   const legacyStatus =
     overrides.getStatus ?? Effect.succeed(readyStatus(registration))
   const requireAllowed = overrides.requireAgentTurnsAllowed ?? Effect.void
@@ -122,14 +129,44 @@ export const stubActiveAgentBackendLayer = (
     ActiveAgentBackend.of({
       listStatuses: Effect.succeed(allReady),
       getBackendStatus: (backendId: AgentBackendId) => {
-        const entry = byId.get(backendId)
-        return Effect.succeed(entry === undefined ? null : readyFor(entry))
+        if (!activeIds.has(backendId)) {
+          return Effect.succeed(null)
+        }
+        if (
+          !byId.has(backendId) &&
+          overrides.newlyActivatedKind === "unavailable"
+        ) {
+          return Effect.succeed(
+            runtimeStatus(
+              registrationFor(backendId),
+              [],
+              "unavailable",
+              overrides.newlyActivatedReason ?? "inspect failed",
+            ),
+          )
+        }
+        return Effect.succeed(readyFor(registrationFor(backendId)))
       },
       getStatus: legacyStatus,
-      setSelectedOrInUse: () => Effect.succeed(allReady),
+      setSelectedOrInUse: (backendIds) =>
+        Effect.sync(() => {
+          activeIds.clear()
+          for (const backendId of backendIds) {
+            activeIds.add(backendId)
+          }
+          return [...activeIds].map((backendId) =>
+            readyFor(registrationFor(backendId)),
+          )
+        }),
       activate: (backendId) =>
-        Effect.succeed(readyFor(registrationFor(backendId))),
-      drop: () => Effect.void,
+        Effect.sync(() => {
+          activeIds.add(backendId)
+          return readyFor(registrationFor(backendId))
+        }),
+      drop: (backendId) =>
+        Effect.sync(() => {
+          activeIds.delete(backendId)
+        }),
       recheck: (backendId) =>
         Effect.succeed(readyFor(registrationFor(backendId))),
       requireAgentTurnsAllowed: (backendId) => requireFor(backendId),

--- a/packages/work-item-lifecycle/src/lib/types.ts
+++ b/packages/work-item-lifecycle/src/lib/types.ts
@@ -445,4 +445,9 @@ export type StepRunReasonCode =
 
 export type WorkItemLifecycleConfig = {
   readonly maxDurations?: LifecycleMaxDurations
+  /**
+   * Working directory used when Implement With activates an otherwise
+   * inactive shipped Agent Backend. Defaults to `process.cwd()`.
+   */
+  readonly inspectCwd?: string
 }

--- a/packages/work-item-lifecycle/src/lib/work-item-lifecycle.ts
+++ b/packages/work-item-lifecycle/src/lib/work-item-lifecycle.ts
@@ -1115,6 +1115,10 @@ export const makeWorkItemLifecycleLive = (
         ...DEFAULT_LIFECYCLE_MAX_DURATIONS,
         ...config.maxDurations,
       }
+      const inspectInput = {
+        cwd: config.inspectCwd ?? process.cwd(),
+        timeout: "30 seconds" as const,
+      }
       const activeStepExecutions = new Map<
         string,
         {
@@ -6329,6 +6333,7 @@ export const makeWorkItemLifecycleLive = (
             Effect.gen(function* () {
               const explicitProfile = options.executionProfile
               let captureBackendId: AgentBackendId
+              let restoreAddedBackend: Effect.Effect<unknown> = Effect.void
               if (explicitProfile !== undefined) {
                 if (!isSelectableAgentBackendId(explicitProfile.agentBackend)) {
                   return yield* new AgentBackendUnavailableError({
@@ -6337,15 +6342,47 @@ export const makeWorkItemLifecycleLive = (
                   })
                 }
                 captureBackendId = explicitProfile.agentBackend
+                const priorStatus =
+                  yield* activeAgentBackend.getBackendStatus(captureBackendId)
+                const addedForAttempt = priorStatus === null
+                const previousSelectedOrInUse = addedForAttempt
+                  ? yield* db.listSelectedOrInUseBackendIds
+                  : []
+                restoreAddedBackend = addedForAttempt
+                  ? activeAgentBackend.setSelectedOrInUse(
+                      previousSelectedOrInUse.filter(
+                        (id): id is AgentBackendId =>
+                          isSelectableAgentBackendId(id),
+                      ),
+                      inspectInput,
+                    )
+                  : Effect.void
+                if (addedForAttempt) {
+                  const nextSelectedOrInUse = [
+                    ...new Set([
+                      ...previousSelectedOrInUse.filter(
+                        (id): id is AgentBackendId =>
+                          isSelectableAgentBackendId(id),
+                      ),
+                      captureBackendId,
+                    ]),
+                  ]
+                  yield* activeAgentBackend.setSelectedOrInUse(
+                    nextSelectedOrInUse,
+                    inspectInput,
+                  )
+                }
                 const captureStatus =
                   yield* activeAgentBackend.getBackendStatus(captureBackendId)
                 if (captureStatus === null) {
+                  yield* restoreAddedBackend
                   return yield* new AgentBackendUnavailableError({
                     message: `Agent Backend is not Active: ${explicitProfile.agentBackend}`,
                     reason: "Agent Backend is not Active",
                   })
                 }
                 if (captureStatus.kind === "unavailable") {
+                  yield* restoreAddedBackend
                   return yield* new AgentBackendUnavailableError({
                     message:
                       captureStatus.reason ?? "Agent Backend is unavailable",
@@ -6359,6 +6396,7 @@ export const makeWorkItemLifecycleLive = (
                   profile: explicitProfile,
                 })
                 if (catalogError !== null) {
+                  yield* restoreAddedBackend
                   return yield* catalogError
                 }
               } else {
@@ -6414,6 +6452,7 @@ export const makeWorkItemLifecycleLive = (
                         reason: error.reason,
                       }),
                   ),
+                  Effect.tapError(() => restoreAddedBackend),
                 )
               const activeRegistration =
                 yield* activeAgentBackend.getRegistration(captureBackendId)
@@ -6506,6 +6545,7 @@ export const makeWorkItemLifecycleLive = (
                   }),
                 )
                 .pipe(
+                  Effect.tapError(() => restoreAddedBackend),
                   Effect.catch(
                     (error): Effect.Effect<never, ImplementWithError> => {
                       if (error instanceof WorkItemLifecycleDatabaseError) {

--- a/packages/work-item-lifecycle/test/implement-with.spec.ts
+++ b/packages/work-item-lifecycle/test/implement-with.spec.ts
@@ -1,7 +1,7 @@
 import { Effect, Layer } from "effect"
 import {
   AGENT_BACKEND_IDS,
-  type ActiveAgentBackend,
+  ActiveAgentBackend,
   getBuiltInAgentBackend,
 } from "@ready-for-agent/agent-backend"
 import { DatabaseTest } from "@ready-for-agent/db/test"
@@ -330,11 +330,16 @@ describe("implementWith", () => {
     )
   })
 
-  it("does not create a Work Item when the Agent Backend is not Active", async () => {
+  it("activates an inactive shipped backend and keeps it captured without changing saved defaults", async () => {
+    const active = stubActiveAgentBackendLayer({
+      registration: opencodeRegistration,
+      models: catalog,
+    })
     await Effect.runPromise(
       Effect.gen(function* () {
         const db = yield* DbService
         const lifecycle = yield* WorkItemLifecycle
+        const backends = yield* ActiveAgentBackend
         const repo = yield* db.addRepository({
           forge: "github",
           forgeHost: "github.com",
@@ -347,25 +352,78 @@ describe("implementWith", () => {
           defaultModel: "settings-build",
         })
         yield* storeOpenLeafIssue(db, repo.id, 5)
+        expect(
+          yield* backends.getBackendStatus(AGENT_BACKEND_IDS.grok),
+        ).toBeNull()
+        const created = yield* lifecycle.implementWith(repo.id, 5, {
+          ...sameAsBuildProfile,
+          agentBackendId: "grok",
+        })
+        expect(created.agentBackend).toBe("grok")
+        expect(created.executionProfile).toEqual({
+          agentBackend: "grok",
+          build: { model: "build-model", thinkingLevel: "high" },
+          review: { kind: "same_as_build" },
+        })
+        expect(yield* db.getConfig).toMatchObject({
+          selectedAgentBackend: "opencode",
+          defaultModel: "settings-build",
+        })
+        expect((yield* db.listRepositories)[0]?.selectedAgentBackend).toBeNull()
+        expect(yield* db.listSelectedOrInUseBackendIds).toEqual([
+          "opencode",
+          "grok",
+        ])
+        expect(
+          yield* backends.getBackendStatus(AGENT_BACKEND_IDS.grok),
+        ).not.toBeNull()
+      }).pipe(Effect.provide(lifecycleLayer(active))),
+    )
+  })
+
+  it("creates no Work Item and leaves defaults unchanged when activation inspect fails", async () => {
+    const active = stubActiveAgentBackendLayer({
+      registration: opencodeRegistration,
+      models: catalog,
+      newlyActivatedKind: "unavailable",
+      newlyActivatedReason: "Grok Build CLI is not installed",
+    })
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        const db = yield* DbService
+        const lifecycle = yield* WorkItemLifecycle
+        const backends = yield* ActiveAgentBackend
+        const repo = yield* db.addRepository({
+          forge: "github",
+          forgeHost: "github.com",
+          projectPath: "acme/widgets",
+          localPath: "/repos/acme/widgets-activate-fail.git",
+          isBare: true,
+        })
+        yield* seedHarness(db, {
+          selectedAgentBackend: "opencode",
+          defaultModel: "settings-build",
+        })
+        yield* storeOpenLeafIssue(db, repo.id, 15)
         const error = yield* Effect.flip(
-          lifecycle.implementWith(repo.id, 5, {
+          lifecycle.implementWith(repo.id, 15, {
             ...sameAsBuildProfile,
             agentBackendId: "grok",
           }),
         )
         expect(error).toBeInstanceOf(LifecycleUnavailableError)
-        expect(error.message).toContain("not Active")
-        expect(yield* lifecycle.listWorkItemsForIssue(repo.id, 5)).toEqual([])
-      }).pipe(
-        Effect.provide(
-          lifecycleLayer(
-            stubActiveAgentBackendLayer({
-              registration: opencodeRegistration,
-              models: catalog,
-            }),
-          ),
-        ),
-      ),
+        expect(error.message).toContain("Grok Build CLI is not installed")
+        expect(yield* lifecycle.listWorkItemsForIssue(repo.id, 15)).toEqual([])
+        expect(yield* db.getConfig).toMatchObject({
+          selectedAgentBackend: "opencode",
+          defaultModel: "settings-build",
+        })
+        expect((yield* db.listRepositories)[0]?.selectedAgentBackend).toBeNull()
+        expect(yield* db.listSelectedOrInUseBackendIds).toEqual(["opencode"])
+        expect(
+          yield* backends.getBackendStatus(AGENT_BACKEND_IDS.grok),
+        ).toBeNull()
+      }).pipe(Effect.provide(lifecycleLayer(active))),
     )
   })
 
@@ -422,6 +480,63 @@ describe("implementWith", () => {
         const items = yield* lifecycle.listWorkItemsForIssue(repo.id, 7)
         expect(items.map((item) => item.id)).toEqual([first.id])
       }).pipe(Effect.provide(lifecycleLayer(catalogLayer()))),
+    )
+  })
+
+  it("routes Agent Turns through the captured backend after activating it", async () => {
+    const backends: string[] = []
+    const recording: LifecycleStepsShape = {
+      ...successfulSteps,
+      implement: (context: LifecycleStepContext) =>
+        Effect.sync(() => {
+          backends.push(context.agentBackend)
+          return "ses_test"
+        }),
+    }
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        const db = yield* DbService
+        const lifecycle = yield* WorkItemLifecycle
+        const repo = yield* db.addRepository({
+          forge: "github",
+          forgeHost: "github.com",
+          projectPath: "acme/widgets",
+          localPath: "/repos/acme/widgets-route-grok.git",
+          isBare: true,
+        })
+        yield* seedHarness(db, {
+          selectedAgentBackend: "opencode",
+          defaultModel: "settings-build",
+        })
+        yield* storeOpenLeafIssue(db, repo.id, 16)
+        const created = yield* lifecycle.implementWith(repo.id, 16, {
+          ...sameAsBuildProfile,
+          agentBackendId: "grok",
+        })
+        expect(created.agentBackend).toBe("grok")
+        const afterCreate = yield* advanceToQueued(
+          lifecycle,
+          created.stepRuns[0]!.id,
+          "install_dependencies",
+        )
+        const afterInstall = yield* advanceToQueued(
+          lifecycle,
+          afterCreate!.id,
+          "implement",
+        )
+        yield* lifecycle.runStep(afterInstall!.id)
+        expect(backends).toEqual(["grok"])
+      }).pipe(
+        Effect.provide(
+          lifecycleLayer(
+            stubActiveAgentBackendLayer({
+              registration: opencodeRegistration,
+              models: catalog,
+            }),
+            recording,
+          ),
+        ),
+      ),
     )
   })
 


### PR DESCRIPTION
Implement With was limited to the Repository's Effective Agent Backend. Operators
who wanted to try another shipped backend on one Issue had to change Harness
Config or Repository settings first, which also mutates shared defaults and can
be blocked by unrelated unfinished work.

This slice opens the Implement With dialog to every shipped selectable Agent
Backend. Switching backends loads that backend's Preview catalog and resolved
Repository/Harness model preferences without changing saved settings or the
Active set. Unsaved model and Thinking Level drafts stay keyed by backend while
the dialog is open. A failed Preview keeps the backend selector usable and
blocks submit with plain catalog feedback — no Recheck, Settings detour, or
retry orchestration.

On submit, `implementWith` activates and inspects an otherwise inactive selected
backend under the existing settings/create coordination lock, then creates the
Work Item with a complete Explicit Work Item Execution Profile. Activation,
inspection, readiness, catalog, or profile failure creates nothing and leaves
saved defaults unchanged. A successful create keeps the captured backend in the
selected-or-in-use Active set for the unfinished Work Item.

Verification: dialog interaction tests for shipped-backend listing, Preview
failure, empty catalog, and per-backend drafts; lifecycle tests for
inactive-backend create, atomic activation inspect failure, and routing through
the captured backend; GraphQL `repositoryModelPrefs` and DbService prefs
round-trip; typecheck on harness, work-item-lifecycle, graphql-api, and
db-service. Review of the uncommitted diff reported no findings.

Limitation: no live dual-backend end-to-end Agent Turn. Preview switching is
covered at the dialog catalog seam rather than a full browser session.

Closes #1035