### PR TITLE
fix(agent-backend): require a non-empty message on CLI exit errors

### DIFF
--- a/packages/agent-backend/src/lib/cli-runner.ts
+++ b/packages/agent-backend/src/lib/cli-runner.ts
@@ -18,6 +18,7 @@ import {
   AgentBackendSessionIdMissingError,
   AgentBackendStartupTimeoutError,
   AgentBackendTimeoutError,
+  formatSilentAgentBackendExitMessage,
 } from "./errors.js"
 import { killProcessTree } from "./kill-process-tree.js"
 import { sanitizeAgentBackendStderrTail } from "./sanitize-exit-message.js"
@@ -249,11 +250,16 @@ export const runCliCapture = (
     )
 
     if (result.exitCode !== 0 && input.allowNonZeroExit !== true) {
-      const message = capturedCliOutputMessage(result.stdout, result.stderr)
+      const message =
+        capturedCliOutputMessage(result.stdout, result.stderr) ??
+        formatSilentAgentBackendExitMessage({
+          backendLabel: input.backend.label,
+          exitCode: result.exitCode,
+        })
       return yield* AgentBackendExitError.new({
         exitCode: result.exitCode,
         cwd: input.cwd,
-        ...(message !== undefined ? { message } : {}),
+        message,
       })
     }
 
@@ -487,15 +493,19 @@ export const runCliTurn = (
         const sessionId = result.sessionId ?? knownSessionId
         const message =
           result.errorMessage ??
-          sanitizeAgentBackendStderrTail(result.stderrTail)
+          sanitizeAgentBackendStderrTail(result.stderrTail) ??
+          formatSilentAgentBackendExitMessage({
+            backendLabel: input.backend.label,
+            exitCode,
+          })
         return yield* AgentBackendExitError.new({
           exitCode,
           cwd: input.cwd,
+          message,
           ...(sessionId !== undefined ? { sessionId } : {}),
           ...(result.errorClassification !== undefined
             ? { classification: result.errorClassification }
             : {}),
-          ...(message !== undefined ? { message } : {}),
         })
       }
     }

--- a/packages/agent-backend/src/lib/errors.ts
+++ b/packages/agent-backend/src/lib/errors.ts
@@ -42,16 +42,21 @@ export class AgentBackendConfigError extends Schema.TaggedErrorClass<AgentBacken
   },
 ) {}
 
+const SILENT_AGENT_BACKEND_LABEL = "Agent Backend"
+
+/** Stable reason when a non-zero exit has no parsed adapter text or stderr. */
+export const formatSilentAgentBackendExitMessage = (input: {
+  readonly backendLabel: string
+  readonly exitCode: number
+}): string => `${input.backendLabel} failed with exit code ${input.exitCode}`
+
 type AgentBackendExitErrorProps = {
   readonly exitCode: number
   readonly cwd: string
   readonly sessionId?: string
   readonly classification?: AgentBackendErrorClassification
-  /**
-   * Best available human-readable reason. Optional is transitional — a
-   * messageless exit error is not a legitimate constructed value. See #1066.
-   */
-  readonly message?: string
+  /** Best available human-readable reason. Always non-empty after `.new()`. */
+  readonly message: string
 }
 
 export class AgentBackendExitError extends Schema.TaggedErrorClass<AgentBackendExitError>()(
@@ -68,24 +73,15 @@ export class AgentBackendExitError extends Schema.TaggedErrorClass<AgentBackendE
      * behavior) or an unrecognized error payload.
      */
     classification: Schema.optionalKey(AgentBackendErrorClassification),
-    /**
-     * Best available human-readable reason. Optionality is transitional,
-     * not a design preference: a messageless exit error is the defect this
-     * field exists to remove. Flip to required in #1066 once every caller
-     * supplies a reason, including silent non-zero exits with no parsed
-     * reason and no stderr tail.
-     */
-    message: Schema.optionalKey(Schema.String),
+    /** Best available human-readable reason. Never empty after construction. */
+    message: Schema.String,
   },
 ) {
   /** Sanitize the operator-visible reason before the Schema constructor. */
   static new(props: AgentBackendExitErrorProps): AgentBackendExitError {
-    const sanitized =
-      props.message === undefined
-        ? undefined
-        : sanitizeAgentBackendExitMessage(props.message)
+    const sanitized = sanitizeAgentBackendExitMessage(props.message)
     const classifiedFromText =
-      props.classification === undefined && props.message !== undefined
+      props.classification === undefined
         ? classifyProviderCredentialText(props.message)
         : undefined
     const classification =
@@ -95,9 +91,13 @@ export class AgentBackendExitError extends Schema.TaggedErrorClass<AgentBackendE
       cwd: props.cwd,
       ...(props.sessionId !== undefined ? { sessionId: props.sessionId } : {}),
       ...(classification !== undefined ? { classification } : {}),
-      ...(sanitized !== undefined && sanitized.length > 0
-        ? { message: sanitized }
-        : {}),
+      message:
+        sanitized.length > 0
+          ? sanitized
+          : formatSilentAgentBackendExitMessage({
+              backendLabel: SILENT_AGENT_BACKEND_LABEL,
+              exitCode: props.exitCode,
+            }),
     })
   }
 }

--- a/packages/agent-backend/test/cli-runner.spec.ts
+++ b/packages/agent-backend/test/cli-runner.spec.ts
@@ -130,7 +130,7 @@ describe("runCliCapture", () => {
     )
   })
 
-  it("maps nonzero exit to AgentBackendExitError", async () => {
+  it("maps a silent nonzero readiness probe to AgentBackendExitError with a backend fallback", async () => {
     await withExecutable("exit 9", async (binary) => {
       const error = await Effect.runPromise(
         withSpawner((spawner) =>
@@ -149,6 +149,7 @@ describe("runCliCapture", () => {
         AgentBackendExitError.new({
           exitCode: 9,
           cwd: process.cwd(),
+          message: "Claude Code failed with exit code 9",
         }),
       )
     })
@@ -491,6 +492,7 @@ describe("runCliTurn", () => {
             cwd: process.cwd(),
             sessionId: "ses_retry",
             classification: "retryable_provider_error",
+            message: "Claude Code failed with exit code 1",
           }),
         )
       },
@@ -553,6 +555,7 @@ describe("runCliTurn", () => {
             exitCode: 1,
             cwd: process.cwd(),
             sessionId: "ses_plain",
+            message: "Claude Code failed with exit code 1",
           }),
         )
       },
@@ -871,7 +874,7 @@ describe("runCliTurn", () => {
     })
   })
 
-  it("reports the exit code when a silent CLI exits before the startup window", async () => {
+  it("reports a backend fallback when a silent CLI exits before the startup window", async () => {
     await withExecutable("exit 7", async (binary) => {
       const error = await Effect.runPromise(
         withSpawner((spawner) =>
@@ -889,7 +892,11 @@ describe("runCliTurn", () => {
         ),
       )
       expect(error).toEqual(
-        AgentBackendExitError.new({ exitCode: 7, cwd: process.cwd() }),
+        AgentBackendExitError.new({
+          exitCode: 7,
+          cwd: process.cwd(),
+          message: "Claude Code failed with exit code 7",
+        }),
       )
     })
   })

--- a/packages/agent-backend/test/errors.spec.ts
+++ b/packages/agent-backend/test/errors.spec.ts
@@ -1,4 +1,7 @@
-import { AgentBackendExitError } from "../src/lib/errors.js"
+import {
+  AgentBackendExitError,
+  formatSilentAgentBackendExitMessage,
+} from "../src/lib/errors.js"
 import { sanitizeAgentBackendStderrTail } from "../src/lib/sanitize-exit-message.js"
 import { describe, expect, it } from "bun:test"
 
@@ -10,6 +13,25 @@ describe("AgentBackendExitError message", () => {
       message: "Claude Code turn failed: permission denied",
     })
     expect(error.message).toBe("Claude Code turn failed: permission denied")
+  })
+
+  it("formats a silent-exit fallback that names the backend and exit code", () => {
+    expect(
+      formatSilentAgentBackendExitMessage({
+        backendLabel: "OpenCode",
+        exitCode: 7,
+      }),
+    ).toBe("OpenCode failed with exit code 7")
+  })
+
+  it("replaces a message that sanitizes to empty with a silent-exit fallback", () => {
+    const error = AgentBackendExitError.new({
+      exitCode: 3,
+      cwd: "/tmp",
+      message: "   ",
+    })
+    expect(error.message).toBe("Agent Backend failed with exit code 3")
+    expect(error.message.length).toBeGreaterThan(0)
   })
 
   it("strips ANSI escapes and bounds length", () => {

--- a/packages/claude/test/claude.spec.ts
+++ b/packages/claude/test/claude.spec.ts
@@ -929,6 +929,7 @@ describe("Claude AgentBackend adapter (Agent Turns)", () => {
         expect(error).toBeInstanceOf(AgentBackendExitError)
         if (error instanceof AgentBackendExitError) {
           expect(error.exitCode).toBe(7)
+          expect(error.message).toBe("Claude Code failed with exit code 7")
           expect(error.sessionId).toMatch(
             /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i,
           )

--- a/packages/codex/test/codex.spec.ts
+++ b/packages/codex/test/codex.spec.ts
@@ -465,6 +465,7 @@ describe("Codex AgentBackend adapter (Agent Turns)", () => {
         expect(error).toBeInstanceOf(AgentBackendExitError)
         if (error instanceof AgentBackendExitError) {
           expect(error.exitCode).toBe(7)
+          expect(error.message).toBe("Codex Build failed with exit code 7")
           expect(error.sessionId).toBe("exit-thread")
         }
       },

--- a/packages/grok/test/grok.spec.ts
+++ b/packages/grok/test/grok.spec.ts
@@ -226,6 +226,7 @@ describe("Grok AgentBackend adapter", () => {
         expect(error).toBeInstanceOf(AgentBackendExitError)
         if (error instanceof AgentBackendExitError) {
           expect(error.exitCode).toBe(7)
+          expect(error.message).toBe("Grok Build failed with exit code 7")
           expect(error.sessionId).toMatch(
             /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i,
           )

--- a/packages/opencode/test/opencode.spec.ts
+++ b/packages/opencode/test/opencode.spec.ts
@@ -192,6 +192,7 @@ describe("Opencode AgentBackend adapter", () => {
             exitCode: 7,
             cwd: process.cwd(),
             sessionId: "ses_failed",
+            message: "OpenCode failed with exit code 7",
           }),
         )
       },
@@ -215,6 +216,7 @@ describe("Opencode AgentBackend adapter", () => {
             cwd: process.cwd(),
             sessionId: "ses_retry",
             classification: "retryable_provider_error",
+            message: "OpenCode failed with exit code 1",
           }),
         )
       },
@@ -238,6 +240,7 @@ describe("Opencode AgentBackend adapter", () => {
             cwd: process.cwd(),
             sessionId: "ses_length",
             classification: "length_limit_truncation",
+            message: "OpenCode failed with exit code 1",
           }),
         )
       },
@@ -261,6 +264,7 @@ describe("Opencode AgentBackend adapter", () => {
             cwd: process.cwd(),
             sessionId: "ses_auth",
             classification: "terminal_auth_error",
+            message: "OpenCode failed with exit code 1",
           }),
         )
       },
@@ -283,6 +287,7 @@ describe("Opencode AgentBackend adapter", () => {
             exitCode: 1,
             cwd: process.cwd(),
             sessionId: "ses_unknown",
+            message: "OpenCode failed with exit code 1",
           }),
         )
       },

--- a/packages/work-item-lifecycle/test/commit.spec.ts
+++ b/packages/work-item-lifecycle/test/commit.spec.ts
@@ -705,7 +705,11 @@ exit 1
               Effect.succeed({ sessionId: "unused", assistantText: "" }),
             continueTurn: () =>
               Effect.fail(
-                AgentBackendExitError.new({ exitCode: 2, cwd: root }),
+                AgentBackendExitError.new({
+                  exitCode: 2,
+                  cwd: root,
+                  message: "OpenCode failed with exit code 2",
+                }),
               ),
             inspect: () =>
               Effect.succeed({

--- a/packages/work-item-lifecycle/test/create-pr.spec.ts
+++ b/packages/work-item-lifecycle/test/create-pr.spec.ts
@@ -1103,6 +1103,7 @@ describe("createPr", () => {
                 _tag: "AgentBackendExitError",
                 exitCode: 2,
                 cwd: root,
+                message: "OpenCode failed with exit code 2",
               } as never),
             inspect: () =>
               Effect.succeed({

--- a/packages/work-item-lifecycle/test/implement.spec.ts
+++ b/packages/work-item-lifecycle/test/implement.spec.ts
@@ -550,7 +550,11 @@ describe("implement", () => {
           AgentBackend.of({
             startTurn: () =>
               Effect.fail(
-                AgentBackendExitError.new({ exitCode: 2, cwd: root }),
+                AgentBackendExitError.new({
+                  exitCode: 2,
+                  cwd: root,
+                  message: "OpenCode failed with exit code 2",
+                }),
               ),
             continueTurn: () =>
               Effect.succeed({ sessionId: "unused", assistantText: "" }),
@@ -767,7 +771,11 @@ describe("implement", () => {
             Effect.gen(function* () {
               yield* input.onSessionId!("ses_failed_after_emit")
               return yield* Effect.fail(
-                AgentBackendExitError.new({ exitCode: 2, cwd: root }),
+                AgentBackendExitError.new({
+                  exitCode: 2,
+                  cwd: root,
+                  message: "OpenCode failed with exit code 2",
+                }),
               )
             }),
         }),

--- a/packages/work-item-lifecycle/test/pr-status-checks.spec.ts
+++ b/packages/work-item-lifecycle/test/pr-status-checks.spec.ts
@@ -1419,6 +1419,7 @@ describe("PR status check steps", () => {
                     AgentBackendExitError.new({
                       exitCode: 1,
                       cwd: "/tmp/worktree",
+                      message: "Grok Build failed with exit code 1",
                     }),
                   ),
                 inspect: () =>

--- a/packages/work-item-lifecycle/test/pre-commit.spec.ts
+++ b/packages/work-item-lifecycle/test/pre-commit.spec.ts
@@ -389,6 +389,7 @@ describe("preCommit", () => {
                 exitCode: 2,
                 cwd: root,
                 sessionId: "ses_pre_commit",
+                message: "OpenCode failed with exit code 2",
               }),
             ),
         }),

--- a/packages/work-item-lifecycle/test/review.spec.ts
+++ b/packages/work-item-lifecycle/test/review.spec.ts
@@ -1356,7 +1356,11 @@ describe("review", () => {
               })
             }
             return Effect.fail(
-              AgentBackendExitError.new({ exitCode: 2, cwd: root }),
+              AgentBackendExitError.new({
+                exitCode: 2,
+                cwd: root,
+                message: "OpenCode failed with exit code 2",
+              }),
             )
           },
         }),
@@ -2004,7 +2008,11 @@ describe("review", () => {
               Effect.succeed({ sessionId: "unused", assistantText: "" }),
             continueTurn: () =>
               Effect.fail(
-                AgentBackendExitError.new({ exitCode: 2, cwd: root }),
+                AgentBackendExitError.new({
+                  exitCode: 2,
+                  cwd: root,
+                  message: "OpenCode failed with exit code 2",
+                }),
               ),
             inspect: () =>
               Effect.succeed({


### PR DESCRIPTION
Issue 1056 staged `AgentBackendExitError.message` as optional so
diagnostics could land without rewriting every stub. A messageless exit
is not a legitimate value. After stderr capture for Agent Turns
(#1057 / #1069) and readiness inspection (#1071 / #1078), this is the
contract half of that expand–contract (#1066).

- `message` is required `Schema.String`; the transitional optionality
  comments are gone.
- Shared `runCliTurn` and `runCliCapture` still prefer a parsed adapter
  reason, then sanitized captured CLI output.
- A silent non-zero Agent Turn or readiness probe gets a stable fallback
  that names the backend and exit code (`<label> failed with exit code
  <n>`).
- `.new()` sanitizes the reason and replaces a whitespace-only result
  with `Agent Backend failed with exit code <n>`.
- Lifecycle stubs and adapter tests now supply a message. Silent-exit
  coverage exists for both runners so a future adapter cannot
  reintroduce a bare exit error.

Verified with `bunx nx run-many -t test -p agent-backend,opencode,grok,
claude,codex,work-item-lifecycle`. Does not change retry, readiness, or
Work Item routing based on the message.

Closes #1066