### PR TITLE
fix(agent-backend): confirm transient malformed startup inspection once before Unavailable (#1076)

### DIFF
--- a/apps/harness/src/server/application.server.ts
+++ b/apps/harness/src/server/application.server.ts
@@ -13,15 +13,12 @@ import {
 import type { ChildProcessSpawner } from "effect/unstable/process"
 import {
   AGENT_BACKEND_IDS,
-  ActiveAgentBackend,
   ActiveAgentBackendLive,
   AgentBackend,
   type AgentBackendId,
   type ResolveAgentBackendRuntime,
   SessionTelemetryProvider,
-  formatDefaultBackendUnavailableMessage,
   isSelectableAgentBackendId,
-  listBuiltInAgentBackends,
   resolveActiveRegistration,
 } from "@ready-for-agent/agent-backend"
 import { Claude, ClaudeSessionTelemetryLive } from "@ready-for-agent/claude"
@@ -59,6 +56,7 @@ import { GitHubOperationCoordinatorLive } from "./github-operation-coordinator.j
 import { JobWorkerLive } from "./job-worker.js"
 import { keymaxxerGitHubLayer } from "./keymaxxer-github-layer.js"
 import { keymaxxerGitLabLayer } from "./keymaxxer-gitlab-layer.js"
+import { inspectBackendsAtStartup } from "./startup-backend-inspection.js"
 
 export interface Application {
   readonly context: ApplicationRequestContext
@@ -272,67 +270,17 @@ export const createApplication = async (
       Effect.gen(function* () {
         const keymaxxer = yield* KeymaxxerService
         yield* keymaxxer.initialize
-        // Startup inspection: failure must not terminate the Harness.
-        const active = yield* ActiveAgentBackend
-        const db = yield* DbService
-        // Startup inspect for every initial Active backend (selected-or-in-use).
-        const statuses = yield* active.listStatuses
-        for (const status of statuses) {
-          yield* active.recheck(status.backend.id, {
-            cwd: toolCwd,
-            timeout: "30 seconds",
+        // Automatic startup inspection with a one-shot malformed-output
+        // confirmation (issue #1076), then default-backend operator guidance.
+        const guidance = yield* inspectBackendsAtStartup({
+          cwd: toolCwd,
+          inspectTimeout: "30 seconds",
+          previewTimeout: "8 seconds",
+        })
+        if (guidance !== null) {
+          yield* Effect.sync(() => {
+            console.info(guidance)
           })
-        }
-
-        // When the harness default is Unavailable, probe other built-ins via
-        // preview (no Active-set change) so first-run operators see Ready
-        // alternatives early instead of a later model-catalog failure (#937).
-        // Parallel + short timeout: guidance only; must not dominate cold start.
-        const config = yield* db.getConfig
-        const defaultBackendId = isSelectableAgentBackendId(
-          config.selectedAgentBackend,
-        )
-          ? (config.selectedAgentBackend as AgentBackendId)
-          : AGENT_BACKEND_IDS.opencode
-        const defaultStatus = yield* active.getBackendStatus(defaultBackendId)
-        if (defaultStatus !== null && defaultStatus.kind === "unavailable") {
-          const otherBackendIds = listBuiltInAgentBackends()
-            .map((entry) => entry.descriptor.id)
-            .filter((id) => id !== defaultBackendId)
-          const previews = yield* Effect.all(
-            otherBackendIds.map((id) =>
-              active
-                .preview(id, {
-                  cwd: toolCwd,
-                  timeout: "8 seconds",
-                })
-                .pipe(Effect.map((preview) => ({ id, preview }))),
-            ),
-            { concurrency: "unbounded" },
-          )
-          const readyBackendIds = previews
-            .filter(({ preview }) => preview.kind === "ready")
-            .map(({ id }) => id)
-          const guidance = formatDefaultBackendUnavailableMessage({
-            defaultBackendId,
-            reason: defaultStatus.reason,
-            readyBackendIds,
-          })
-          if (guidance !== null) {
-            yield* Effect.sync(() => {
-              console.info(guidance)
-            })
-          } else if (
-            defaultStatus.reason != null &&
-            defaultStatus.reason.trim().length > 0
-          ) {
-            // Still name the default when no Ready alternative is present.
-            yield* Effect.sync(() => {
-              console.info(
-                `Default Agent Backend '${defaultBackendId}' is not available (${defaultStatus.reason}). Open Settings to choose another backend or install the CLI.`,
-              )
-            })
-          }
         }
       }),
     )

--- a/apps/harness/src/server/startup-backend-inspection.ts
+++ b/apps/harness/src/server/startup-backend-inspection.ts
@@ -1,0 +1,94 @@
+import { type Duration, Effect } from "effect"
+import {
+  AGENT_BACKEND_IDS,
+  ActiveAgentBackend,
+  type AgentBackendId,
+  formatDefaultBackendUnavailableMessage,
+  isSelectableAgentBackendId,
+  listBuiltInAgentBackends,
+} from "@ready-for-agent/agent-backend"
+import { type DatabaseError, DbService } from "@ready-for-agent/db-service"
+
+export type StartupBackendInspectionOptions = {
+  readonly cwd: string
+  readonly inspectTimeout: Duration.Input
+  readonly previewTimeout: Duration.Input
+}
+
+/**
+ * Automatic Harness startup inspection of every initial Active backend,
+ * followed by default-backend operator guidance. Returns the guidance message
+ * to log, or `null` when the default backend is Ready and no guidance applies.
+ *
+ * The confirmation policy for a transient malformed catalog lives here (via
+ * `inspectStartupBackend`), not in explicit Preview or Recheck, so those remain
+ * single-attempt.
+ */
+export const inspectBackendsAtStartup = (
+  options: StartupBackendInspectionOptions,
+): Effect.Effect<
+  string | null,
+  DatabaseError,
+  ActiveAgentBackend | DbService
+> =>
+  Effect.gen(function* () {
+    const active = yield* ActiveAgentBackend
+    const db = yield* DbService
+
+    // Startup inspect for every initial Active backend (selected-or-in-use).
+    const statuses = yield* active.listStatuses
+    for (const status of statuses) {
+      yield* active.inspectStartupBackend(status.backend.id, {
+        cwd: options.cwd,
+        timeout: options.inspectTimeout,
+      })
+    }
+
+    // When the harness default is Unavailable, probe other built-ins via
+    // preview (no Active-set change) so first-run operators see Ready
+    // alternatives early instead of a later model-catalog failure (#937).
+    // Parallel + short timeout: guidance only; must not dominate cold start.
+    const config = yield* db.getConfig
+    const defaultBackendId = isSelectableAgentBackendId(
+      config.selectedAgentBackend,
+    )
+      ? (config.selectedAgentBackend as AgentBackendId)
+      : AGENT_BACKEND_IDS.opencode
+    const defaultStatus = yield* active.getBackendStatus(defaultBackendId)
+    if (defaultStatus === null || defaultStatus.kind !== "unavailable") {
+      return null
+    }
+
+    const otherBackendIds = listBuiltInAgentBackends()
+      .map((entry) => entry.descriptor.id)
+      .filter((id) => id !== defaultBackendId)
+    const previews = yield* Effect.all(
+      otherBackendIds.map((id) =>
+        active
+          .preview(id, {
+            cwd: options.cwd,
+            timeout: options.previewTimeout,
+          })
+          .pipe(Effect.map((preview) => ({ id, preview }))),
+      ),
+      { concurrency: "unbounded" },
+    )
+    const readyBackendIds = previews
+      .filter(({ preview }) => preview.kind === "ready")
+      .map(({ id }) => id)
+    const guidance = formatDefaultBackendUnavailableMessage({
+      defaultBackendId,
+      reason: defaultStatus.reason,
+      readyBackendIds,
+    })
+    if (guidance !== null) {
+      return guidance
+    }
+    if (
+      defaultStatus.reason != null &&
+      defaultStatus.reason.trim().length > 0
+    ) {
+      return `Default Agent Backend '${defaultBackendId}' is not available (${defaultStatus.reason}). Open Settings to choose another backend or install the CLI.`
+    }
+    return null
+  })

--- a/apps/harness/test/job-worker.test.ts
+++ b/apps/harness/test/job-worker.test.ts
@@ -366,6 +366,7 @@ const stubActiveAgentBackend = (): ActiveAgentBackendShape => {
     getStatus: Effect.succeed(readyStatus()),
     setSelectedOrInUse: () => Effect.succeed([ready]),
     recheck: () => Effect.succeed(ready),
+    inspectStartupBackend: () => Effect.succeed(ready),
     requireAgentTurnsAllowed: () => Effect.void,
     activate: () => Effect.succeed(ready),
     drop: () => Effect.void,

--- a/apps/harness/test/production-sse-idle-timeout.test.ts
+++ b/apps/harness/test/production-sse-idle-timeout.test.ts
@@ -306,6 +306,7 @@ describe("production GraphQL SSE idle timeout", () => {
         getStatus: Effect.succeed(readyStatus()),
         setSelectedOrInUse: () => Effect.succeed([ready]),
         recheck: () => Effect.succeed(ready),
+        inspectStartupBackend: () => Effect.succeed(ready),
         requireAgentTurnsAllowed: () => Effect.void,
         activate: () => Effect.succeed(ready),
         drop: () => Effect.void,

--- a/apps/harness/test/startup-backend-inspection.test.ts
+++ b/apps/harness/test/startup-backend-inspection.test.ts
@@ -1,0 +1,138 @@
+import { Effect, Layer } from "effect"
+import {
+  AGENT_BACKEND_IDS,
+  ActiveAgentBackend,
+  ActiveAgentBackendLive,
+  type AgentBackendError,
+  type AgentBackendId,
+  AgentBackendMalformedOutputError,
+  type ResolveAgentBackendRuntime,
+  getBuiltInAgentBackend,
+  unsupportedSessionTelemetry,
+} from "@ready-for-agent/agent-backend"
+import { stubDbServiceLayer } from "@ready-for-agent/db-service/test"
+import { inspectBackendsAtStartup } from "../src/server/startup-backend-inspection.js"
+import { describe, expect, it } from "bun:test"
+
+type SequencedInspect =
+  | { kind: "ready" }
+  | { kind: "fail"; error: () => AgentBackendError }
+
+const readyInspect = (backendId: AgentBackendId) => ({
+  backend: getBuiltInAgentBackend(backendId)!.descriptor,
+  models: [{ id: `${backendId}/model-a`, thinkingLevels: ["low", "high"] }],
+  provider: null,
+  warnings: [],
+})
+
+const makeResolveWithSequences =
+  (
+    sequences: Record<string, ReadonlyArray<SequencedInspect>>,
+    counters: Record<string, number>,
+  ): ResolveAgentBackendRuntime =>
+  (backendId) => {
+    const reg = getBuiltInAgentBackend(backendId)
+    if (reg === undefined) {
+      throw new Error(`missing registration ${backendId}`)
+    }
+    return Effect.succeed({
+      registration: reg,
+      adapter: {
+        inspect: () => {
+          const seq = sequences[backendId] ?? [{ kind: "ready" as const }]
+          const n = counters[backendId] ?? 0
+          counters[backendId] = n + 1
+          const result = seq[Math.min(n, seq.length - 1)]
+          if (result === undefined || result.kind === "ready") {
+            return Effect.succeed(readyInspect(backendId))
+          }
+          return Effect.fail(result.error())
+        },
+        startTurn: () =>
+          Effect.succeed({ sessionId: `${backendId}-s`, assistantText: "ok" }),
+        continueTurn: () =>
+          Effect.succeed({ sessionId: `${backendId}-s`, assistantText: "ok" }),
+      },
+      telemetry: {
+        getSession: (id: string) =>
+          Effect.succeed(unsupportedSessionTelemetry(id, reg.descriptor)),
+      },
+    })
+  }
+
+const malformed = () =>
+  new AgentBackendMalformedOutputError({ cwd: "/tmp", byteLength: 3 })
+
+const makeLayer = (
+  opencodeSequence: ReadonlyArray<SequencedInspect>,
+  counters: Record<string, number>,
+) =>
+  ActiveAgentBackendLive({
+    selectedBackendId: AGENT_BACKEND_IDS.opencode,
+    resolveRuntime: makeResolveWithSequences(
+      {
+        opencode: opencodeSequence,
+        claude: [{ kind: "ready" }],
+        codex: [{ kind: "ready" }],
+        grok: [{ kind: "ready" }],
+      },
+      counters,
+    ),
+  })
+
+const run = (
+  opencodeSequence: ReadonlyArray<SequencedInspect>,
+  counters: Record<string, number>,
+) =>
+  Effect.gen(function* () {
+    const active = yield* ActiveAgentBackend
+    const guidance = yield* inspectBackendsAtStartup({
+      cwd: "/tmp",
+      inspectTimeout: "30 seconds",
+      previewTimeout: "8 seconds",
+    })
+    return {
+      guidance,
+      status: yield* active.getBackendStatus(AGENT_BACKEND_IDS.opencode),
+    }
+  }).pipe(
+    Effect.provide(
+      Layer.mergeAll(
+        makeLayer(opencodeSequence, counters),
+        stubDbServiceLayer(),
+      ),
+    ),
+  )
+
+describe("inspectBackendsAtStartup default-backend guidance", () => {
+  it("suppresses guidance after a confirmed transient malformed output", async () => {
+    const counters: Record<string, number> = {}
+    const result = await Effect.runPromise(
+      run([{ kind: "fail", error: malformed }, { kind: "ready" }], counters),
+    )
+
+    expect(result.status?.kind).toBe("ready")
+    expect(result.guidance).toBeNull()
+    expect(counters.opencode).toBe(2)
+  })
+
+  it("emits guidance when malformed output persists across the confirmation", async () => {
+    const counters: Record<string, number> = {}
+    const result = await Effect.runPromise(
+      run(
+        [
+          { kind: "fail", error: malformed },
+          { kind: "fail", error: malformed },
+        ],
+        counters,
+      ),
+    )
+
+    expect(result.status?.kind).toBe("unavailable")
+    expect(result.guidance).not.toBeNull()
+    expect(result.guidance).toContain(
+      "Default Agent Backend 'opencode' is not available",
+    )
+    expect(counters.opencode).toBe(2)
+  })
+})

--- a/packages/agent-backend/src/lib/active-agent-backend.ts
+++ b/packages/agent-backend/src/lib/active-agent-backend.ts
@@ -1,7 +1,10 @@
 import { Context, Effect, Layer, Ref, Result, Schema, Semaphore } from "effect"
 import type { AgentBackend, AgentBackendError } from "./agent-backend.js"
 import { AgentBackend as AgentBackendService } from "./agent-backend.js"
-import { AgentBackendConfigError } from "./errors.js"
+import {
+  AgentBackendConfigError,
+  isAgentBackendMalformedOutputError,
+} from "./errors.js"
 import {
   type AgentBackendRegistration,
   capabilitySupported,
@@ -316,6 +319,17 @@ export type ActiveAgentBackendShape = {
     backendId: AgentBackendId,
     input: InspectInput,
   ) => Effect.Effect<AgentBackendRuntimeStatus>
+  /**
+   * Startup-only inspect for one Active backend. Like `recheck`, but confirms a
+   * transient `AgentBackendMalformedOutputError` once (bounded by the same
+   * inspect input timeout) before declaring the backend Unavailable. Explicit
+   * Preview and Recheck keep their single-attempt semantics; only automatic
+   * Harness startup uses this method.
+   */
+  readonly inspectStartupBackend: (
+    backendId: AgentBackendId,
+    input: InspectInput,
+  ) => Effect.Effect<AgentBackendRuntimeStatus>
   readonly requireAgentTurnsAllowed: (
     backendId: AgentBackendId,
   ) => Effect.Effect<void, AgentBackendUnavailableError>
@@ -553,11 +567,17 @@ export const ActiveAgentBackendLive = (
         },
       )
 
+      type InspectActiveOutcome = {
+        readonly status: AgentBackendRuntimeStatus
+        /** The raw inspect failure, or null when inspect succeeded. */
+        readonly failure: unknown | null
+      }
+
       const inspectActiveEntry = (
         inspectedBackendId: AgentBackendId,
         entryAtStart: ActiveEntry,
         input: InspectInput,
-      ): Effect.Effect<AgentBackendRuntimeStatus> =>
+      ): Effect.Effect<InspectActiveOutcome> =>
         Effect.gen(function* () {
           // Claim a generation before calling inspect so concurrent Rechecks
           // that finish later cannot clobber a fresher catalog/provider/warning
@@ -584,7 +604,10 @@ export const ActiveAgentBackendLive = (
             // the current status when still Active under the replacement;
             // only report not-Active when the id is truly absent.
             const current = yield* getBackendStatus(inspectedBackendId)
-            return current ?? notActiveStatus(inspectedBackendId)
+            return {
+              status: current ?? notActiveStatus(inspectedBackendId),
+              failure: null,
+            }
           }
 
           const inspected = yield* Effect.result(
@@ -626,7 +649,10 @@ export const ActiveAgentBackendLive = (
               return { ...state, entries }
             })
             const status = yield* getBackendStatus(inspectedBackendId)
-            return status ?? notActiveStatus(inspectedBackendId)
+            return {
+              status: status ?? notActiveStatus(inspectedBackendId),
+              failure: inspected.failure,
+            }
           }
           yield* Ref.update(stateRef, (state) => {
             if (!stillCurrentInspect(state)) {
@@ -648,7 +674,10 @@ export const ActiveAgentBackendLive = (
             return { ...state, entries }
           })
           const status = yield* getBackendStatus(inspectedBackendId)
-          return status ?? notActiveStatus(inspectedBackendId)
+          return {
+            status: status ?? notActiveStatus(inspectedBackendId),
+            failure: null,
+          }
         })
 
       const recheck = Effect.fn("ActiveAgentBackend.recheck")(function* (
@@ -662,7 +691,30 @@ export const ActiveAgentBackendLive = (
           // Recheck does not expand the Active set.
           return notActiveStatus(resolvedId)
         }
-        return yield* inspectActiveEntry(resolvedId, entry, input)
+        return (yield* inspectActiveEntry(resolvedId, entry, input)).status
+      })
+
+      const inspectStartupBackend = Effect.fn(
+        "ActiveAgentBackend.inspectStartupBackend",
+      )(function* (backendId: AgentBackendId, input: InspectInput) {
+        const resolvedId = normalizeBackendId(backendId)
+        const current = yield* Ref.get(stateRef)
+        const entry = current.entries.get(resolvedId)
+        if (entry === undefined) {
+          // Startup inspect does not expand the Active set.
+          return notActiveStatus(resolvedId)
+        }
+        const first = yield* inspectActiveEntry(resolvedId, entry, input)
+        // Confirm once only for the transient cold-start malformed-output race;
+        // definite failures (not installed, config, non-zero exit) stay final.
+        if (
+          first.failure === null ||
+          !isAgentBackendMalformedOutputError(first.failure)
+        ) {
+          return first.status
+        }
+        const confirmed = yield* inspectActiveEntry(resolvedId, entry, input)
+        return confirmed.status
       })
 
       const activate = Effect.fn("ActiveAgentBackend.activate")(function* (
@@ -689,11 +741,11 @@ export const ActiveAgentBackendLive = (
           ...state,
           proxyBackendId: resolvedId,
         }))
-        return yield* inspectActiveEntry(
+        return (yield* inspectActiveEntry(
           ensured.resolvedId,
           ensured.entry,
           input,
-        )
+        )).status
       })
 
       const drop = Effect.fn("ActiveAgentBackend.drop")(function* (
@@ -748,6 +800,7 @@ export const ActiveAgentBackendLive = (
               Effect.flatMap((ensured) =>
                 inspectActiveEntry(ensured.resolvedId, ensured.entry, input),
               ),
+              Effect.map((outcome) => outcome.status),
             )
           }
         }
@@ -918,6 +971,7 @@ export const ActiveAgentBackendLive = (
         activate,
         drop,
         recheck,
+        inspectStartupBackend,
         requireAgentTurnsAllowed,
         preview,
         withConfigCoordination,

--- a/packages/agent-backend/src/lib/errors.ts
+++ b/packages/agent-backend/src/lib/errors.ts
@@ -140,6 +140,14 @@ export class AgentBackendMalformedOutputError extends Schema.TaggedErrorClass<Ag
   },
 ) {}
 
+export const isAgentBackendMalformedOutputError = (
+  value: unknown,
+): value is AgentBackendMalformedOutputError =>
+  typeof value === "object" &&
+  value !== null &&
+  "_tag" in value &&
+  value._tag === "AgentBackendMalformedOutputError"
+
 const AgentBackendDescriptorSchema = Schema.Struct({
   id: Schema.String,
   label: Schema.String,

--- a/packages/agent-backend/test/active-agent-backend.spec.ts
+++ b/packages/agent-backend/test/active-agent-backend.spec.ts
@@ -5,8 +5,10 @@ import {
   ActiveAgentBackendLive,
   AgentBackend,
   AgentBackendConfigError,
+  type AgentBackendError,
   AgentBackendExitError,
   type AgentBackendId,
+  AgentBackendMalformedOutputError,
   type AgentTurnResult,
   type ResolveAgentBackendRuntime,
   SessionTelemetryProvider,
@@ -843,6 +845,156 @@ describe("ActiveAgentBackend multi-backend registry", () => {
         // Unknown / non-active still falls back to built-in table.
         const builtIn = yield* active.getRegistration(AGENT_BACKEND_IDS.grok)
         expect(builtIn.descriptor.id).toBe("grok")
+      }).pipe(Effect.provide(layer)),
+    )
+  })
+})
+
+describe("inspectStartupBackend malformed-output confirmation", () => {
+  type SequencedInspect =
+    | { kind: "ready" }
+    | { kind: "fail"; error: () => AgentBackendError }
+
+  const makeSequencedResolve = (
+    inspectResults: ReadonlyArray<SequencedInspect>,
+  ): {
+    resolveRuntime: ResolveAgentBackendRuntime
+    inspectCount: () => number
+  } => {
+    let inspectCount = 0
+    const resolveRuntime: ResolveAgentBackendRuntime = (backendId) => {
+      const reg = registration(backendId)
+      return Effect.succeed({
+        registration: reg,
+        adapter: {
+          inspect: () => {
+            const index = Math.min(inspectCount, inspectResults.length - 1)
+            inspectCount += 1
+            const result = inspectResults[index]
+            if (result === undefined || result.kind === "ready") {
+              return Effect.succeed({
+                backend: reg.descriptor,
+                models: [
+                  {
+                    id: `${backendId}/model-a`,
+                    thinkingLevels: ["low", "high"],
+                  },
+                ],
+                provider: null,
+                warnings: [],
+              })
+            }
+            return Effect.fail(result.error())
+          },
+          startTurn: () => Effect.succeed(turnResult(`${backendId}-start`)),
+          continueTurn: () =>
+            Effect.succeed(turnResult(`${backendId}-continue`)),
+        },
+        telemetry: {
+          getSession: (sessionId: string) =>
+            Effect.succeed(
+              unsupportedSessionTelemetry(sessionId, reg.descriptor),
+            ),
+        },
+      })
+    }
+    return { resolveRuntime, inspectCount: () => inspectCount }
+  }
+
+  const malformed = () =>
+    new AgentBackendMalformedOutputError({ cwd: "/tmp", byteLength: 3 })
+
+  it("confirms a transient malformed startup inspection and leaves the backend Ready", async () => {
+    const { resolveRuntime, inspectCount } = makeSequencedResolve([
+      { kind: "fail", error: malformed },
+      { kind: "ready" },
+    ])
+    const layer = ActiveAgentBackendLive({
+      selectedBackendId: AGENT_BACKEND_IDS.opencode,
+      resolveRuntime,
+    })
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        const active = yield* ActiveAgentBackend
+        const status = yield* active.inspectStartupBackend(
+          AGENT_BACKEND_IDS.opencode,
+          { cwd: "/tmp" },
+        )
+        expect(status.kind).toBe("ready")
+        expect(status.backend.id).toBe("opencode")
+        expect(inspectCount()).toBe(2)
+        expect(
+          (yield* active.getBackendStatus(AGENT_BACKEND_IDS.opencode))?.kind,
+        ).toBe("ready")
+      }).pipe(Effect.provide(layer)),
+    )
+  })
+
+  it("keeps the backend Unavailable after two malformed results with exactly two attempts", async () => {
+    const { resolveRuntime, inspectCount } = makeSequencedResolve([
+      { kind: "fail", error: malformed },
+      { kind: "fail", error: malformed },
+    ])
+    const layer = ActiveAgentBackendLive({
+      selectedBackendId: AGENT_BACKEND_IDS.opencode,
+      resolveRuntime,
+    })
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        const active = yield* ActiveAgentBackend
+        const status = yield* active.inspectStartupBackend(
+          AGENT_BACKEND_IDS.opencode,
+          { cwd: "/tmp" },
+        )
+        expect(status.kind).toBe("unavailable")
+        expect(status.reason).toContain("AgentBackendMalformedOutputError")
+        expect(inspectCount()).toBe(2)
+      }).pipe(Effect.provide(layer)),
+    )
+  })
+
+  it("does not retry non-malformed inspect failures", async () => {
+    const { resolveRuntime, inspectCount } = makeSequencedResolve([
+      {
+        kind: "fail",
+        error: () => new AgentBackendConfigError({ message: "binary missing" }),
+      },
+    ])
+    const layer = ActiveAgentBackendLive({
+      selectedBackendId: AGENT_BACKEND_IDS.opencode,
+      resolveRuntime,
+    })
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        const active = yield* ActiveAgentBackend
+        const status = yield* active.inspectStartupBackend(
+          AGENT_BACKEND_IDS.opencode,
+          { cwd: "/tmp" },
+        )
+        expect(status.kind).toBe("unavailable")
+        expect(status.reason).toContain("binary missing")
+        expect(inspectCount()).toBe(1)
+      }).pipe(Effect.provide(layer)),
+    )
+  })
+
+  it("explicit recheck stays single-attempt for malformed output", async () => {
+    const { resolveRuntime, inspectCount } = makeSequencedResolve([
+      { kind: "fail", error: malformed },
+      { kind: "ready" },
+    ])
+    const layer = ActiveAgentBackendLive({
+      selectedBackendId: AGENT_BACKEND_IDS.opencode,
+      resolveRuntime,
+    })
+    await Effect.runPromise(
+      Effect.gen(function* () {
+        const active = yield* ActiveAgentBackend
+        const status = yield* active.recheck(AGENT_BACKEND_IDS.opencode, {
+          cwd: "/tmp",
+        })
+        expect(status.kind).toBe("unavailable")
+        expect(inspectCount()).toBe(1)
       }).pipe(Effect.provide(layer)),
     )
   })

--- a/packages/work-item-lifecycle/src/lib/active-agent-backend-test.ts
+++ b/packages/work-item-lifecycle/src/lib/active-agent-backend-test.ts
@@ -178,6 +178,8 @@ export const stubActiveAgentBackendLayer = (
         }),
       recheck: (backendId) =>
         Effect.succeed(readyFor(registrationFor(backendId))),
+      inspectStartupBackend: (backendId) =>
+        Effect.succeed(readyFor(registrationFor(backendId))),
       requireAgentTurnsAllowed: (backendId) => requireFor(backendId),
       preview: (backendId) =>
         Effect.succeed({


### PR DESCRIPTION
## Why

A one-off malformed Agent Model catalog during Harness startup immediately
marked the default Agent Backend Unavailable and emitted alternative-backend
guidance, even though an explicit Recheck succeeded moments later with no
environment change. Startup trusted a single cold-start result too eagerly.

## What changed

- Added `ActiveAgentBackend.inspectStartupBackend`, a startup-only inspect
  that confirms a transient `AgentBackendMalformedOutputError` once (at most
  two attempts) before declaring the backend Unavailable. A successful
  confirmation leaves the backend Ready; two malformed results stay Unavailable.
- The confirmation is narrowly scoped: only `AgentBackendMalformedOutputError`
  from automatic startup is retried. Definite failures (not installed,
  config/authentication, ordinary non-zero exit) and explicit Preview/Recheck
  remain single-attempt.
- Extracted startup inspection plus default-backend operator guidance into
  `inspectBackendsAtStartup` so the confirmed status drives guidance; a
  confirmed-transient result no longer emits stale unavailable guidance.

## Verification

- Deterministic unit coverage for `inspectStartupBackend`: malformed-then-success
  leaves Ready (2 attempts), malformed-twice stays Unavailable (exactly 2), and
  non-malformed failures plus explicit `recheck` stay single-attempt.
- Deterministic startup-level regression test asserting both final runtime
  status and guidance suppression/emission.
- `agent-backend` and `harness` typecheck, lint, and knip pass; agent-backend
  tests and the startup guidance tests pass.

## Limitation

The confirmation reuses a fresh full startup-inspect timeout, so a malformed
result returning near the deadline can extend that backend's startup by up to
another timeout (still bounded and finite, never indefinite).

Closes #1076