### PR TITLE
feat(harness): forge Pipeline-style Repo cards with a six-lane color rail (#1088)

### DIFF
--- a/apps/harness/src/home-page-content.tsx
+++ b/apps/harness/src/home-page-content.tsx
@@ -72,6 +72,7 @@ import {
 import {
   type LifecycleLabelChip,
   type LifecyclePipelineLaneId,
+  PIPELINE_LANES,
   type PipelineLaneId,
   lifecycleFocusLaneFor,
   lifecycleLaneForPhase,
@@ -773,6 +774,28 @@ function RepositorySettingsNotFoundDialog({
         </button>
       </div>
     </dialog>
+  )
+}
+
+/**
+ * Decorative six-lane top rail for Repository cards. Order and colors come
+ * straight from `PIPELINE_LANES` (canonical Pipeline lane assembly) so the
+ * rail cannot drift; lane fills are theme-invariant hex values that match the
+ * `--lane-*` CSS tokens. Purely ornamental — hidden from assistive technology.
+ */
+function RepoCardRail() {
+  return (
+    <div className={ui.repoCardRail} aria-hidden="true">
+      {PIPELINE_LANES.map((lane) => (
+        <span
+          key={lane.id}
+          className={ui.repoCardRailSegment}
+          style={{ backgroundColor: lane.color }}
+        />
+      ))}
+      <span className={cx(ui.repoCardRailRivet, ui.repoCardRailRivetL)} />
+      <span className={cx(ui.repoCardRailRivet, ui.repoCardRailRivetR)} />
+    </div>
   )
 }
 
@@ -1823,944 +1846,967 @@ function RepositoryCard({
 
   return (
     <article className={ui.repoCard}>
-      <div className={ui.repoCardHead}>
-        <h2 className={ui.repoCardTitle}>
-          <a
-            className={ui.repoCardLink}
-            href={`https://${repository.forgeHost}/${repository.projectPath}`}
-          >
-            {repositoryLabel}
-          </a>
-          <span
-            className={ui.repoCardPrCount}
-            title={pullRequestCountLabel}
-            aria-busy={pullRequestCountLoading ? true : undefined}
-          >
-            <span className="sr-only">{pullRequestCountLabel}</span>
-            <span aria-hidden="true">{pullRequestCountDisplay}</span>
-          </span>
-        </h2>
-        <div className={ui.repoCardControls}>
-          <CardCollapseToggle
-            collapsed={repositoryCollapsed}
-            onToggle={toggleRepositoryCollapsed}
-            controlsId={repositoryBodyId}
-            label={repositoryLabel}
-          />
-          <button
-            type="button"
-            className={pauseButtonClassName}
-            disabled={pausePending}
-            onClick={() =>
-              repository.paused
-                ? unpauseRepository.mutate()
-                : pauseRepository.mutate()
-            }
-            aria-label={pausePending ? `${pauseLabel} in progress` : pauseLabel}
-            title={
-              pauseFailed
-                ? `Could not ${pauseLabel.toLowerCase()}. Try again.`
-                : pauseLabel
-            }
-          >
-            {pausePending ? (
-              <svg
-                aria-hidden="true"
-                className="animate-spin motion-reduce:animate-none"
-                viewBox="0 0 24 24"
-                fill="none"
-              >
-                <circle
-                  className="opacity-25"
-                  cx="12"
-                  cy="12"
-                  r="9"
-                  stroke="currentColor"
-                  strokeWidth="3"
-                />
-                <path
-                  className="opacity-75"
-                  d="M12 3a9 9 0 0 1 9 9"
-                  stroke="currentColor"
-                  strokeWidth="3"
-                  strokeLinecap="round"
-                />
-              </svg>
-            ) : repository.paused ? (
-              <svg aria-hidden="true" viewBox="0 0 24 24" fill="currentColor">
-                <path d="m8 5 11 7-11 7V5Z" />
-              </svg>
-            ) : (
-              <svg aria-hidden="true" viewBox="0 0 24 24" fill="currentColor">
-                <rect x="6" y="5" width="4" height="14" rx="1" />
-                <rect x="14" y="5" width="4" height="14" rx="1" />
-              </svg>
-            )}
-          </button>
-          <span className="relative" data-repo-menu={repository.id}>
+      <RepoCardRail />
+      <div className={ui.repoCardInner}>
+        <div className={ui.repoCardHead}>
+          <h2 className={ui.repoCardTitle}>
+            <a
+              className={ui.repoCardLink}
+              href={`https://${repository.forgeHost}/${repository.projectPath}`}
+            >
+              {repositoryLabel}
+            </a>
+            <span
+              className={ui.repoCardPrCount}
+              title={pullRequestCountLabel}
+              aria-busy={pullRequestCountLoading ? true : undefined}
+            >
+              <span className="sr-only">{pullRequestCountLabel}</span>
+              <span aria-hidden="true">{pullRequestCountDisplay}</span>
+            </span>
+          </h2>
+          <div className={ui.repoCardControls}>
+            <CardCollapseToggle
+              collapsed={repositoryCollapsed}
+              onToggle={toggleRepositoryCollapsed}
+              controlsId={repositoryBodyId}
+              label={repositoryLabel}
+            />
             <button
               type="button"
-              className={ui.iconBtn}
-              aria-label={`Actions for ${repository.projectPath}`}
-              aria-haspopup="menu"
-              aria-expanded={menuOpen}
-              onClick={() => setMenuOpen((open) => !open)}
+              className={pauseButtonClassName}
+              disabled={pausePending}
+              onClick={() =>
+                repository.paused
+                  ? unpauseRepository.mutate()
+                  : pauseRepository.mutate()
+              }
+              aria-label={
+                pausePending ? `${pauseLabel} in progress` : pauseLabel
+              }
+              title={
+                pauseFailed
+                  ? `Could not ${pauseLabel.toLowerCase()}. Try again.`
+                  : pauseLabel
+              }
             >
-              <svg aria-hidden="true" viewBox="0 0 24 24" fill="currentColor">
-                <circle cx="12" cy="5" r="1.75" />
-                <circle cx="12" cy="12" r="1.75" />
-                <circle cx="12" cy="19" r="1.75" />
-              </svg>
+              {pausePending ? (
+                <svg
+                  aria-hidden="true"
+                  className="animate-spin motion-reduce:animate-none"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                >
+                  <circle
+                    className="opacity-25"
+                    cx="12"
+                    cy="12"
+                    r="9"
+                    stroke="currentColor"
+                    strokeWidth="3"
+                  />
+                  <path
+                    className="opacity-75"
+                    d="M12 3a9 9 0 0 1 9 9"
+                    stroke="currentColor"
+                    strokeWidth="3"
+                    strokeLinecap="round"
+                  />
+                </svg>
+              ) : repository.paused ? (
+                <svg aria-hidden="true" viewBox="0 0 24 24" fill="currentColor">
+                  <path d="m8 5 11 7-11 7V5Z" />
+                </svg>
+              ) : (
+                <svg aria-hidden="true" viewBox="0 0 24 24" fill="currentColor">
+                  <rect x="6" y="5" width="4" height="14" rx="1" />
+                  <rect x="14" y="5" width="4" height="14" rx="1" />
+                </svg>
+              )}
             </button>
-            {menuOpen && (
-              <div role="menu" className={cx(ui.menuPanel, "min-w-40")}>
-                <button
-                  type="button"
-                  role="menuitem"
-                  className={ui.menuItem}
-                  onClick={() => {
-                    setMenuOpen(false)
-                    openSettings()
-                  }}
-                >
-                  Settings
-                </button>
-                <hr className={ui.menuSep} />
-                <button
-                  type="button"
-                  role="menuitem"
-                  className={cx(ui.menuItem, ui.menuItemDestructive)}
-                  disabled={removeRepository.isPending}
-                  onClick={() => {
-                    setMenuOpen(false)
-                    confirmRemoval()
-                  }}
-                >
-                  {removeRepository.isPending ? "Removing..." : "Remove"}
-                </button>
-              </div>
-            )}
-          </span>
-        </div>
-      </div>
-      <dialog
-        ref={settingsDialogRef}
-        className={ui.dialogPanel}
-        aria-labelledby={`repo-settings-title-${repository.id}`}
-        onCancel={(event) => {
-          if (updateSettings.isPending) event.preventDefault()
-        }}
-        onClose={() => {
-          // Escape (or other user dismiss) closes the native dialog first; keep
-          // URL + dialog synchronized, including during pending open navigate.
-          if (dismissingRouteRef.current) {
-            dismissingRouteRef.current = false
-            return
-          }
-          dismissSettings()
-        }}
-      >
-        <form onSubmit={saveSettings}>
-          <div className={ui.dialogHeader}>
-            <p className={ui.dialogKicker}>Repository settings</p>
-            <h2
-              id={`repo-settings-title-${repository.id}`}
-              className={cx(ui.dialogTitle, ui.dialogTitlePath)}
-            >
-              {repository.projectPath}
-            </h2>
-            <p className={ui.dialogLede}>
-              Overrides apply on the next Agent Turn. Empty model fields use
-              harness defaults for this Repository&apos;s effective Agent
-              Backend.
-            </p>
+            <span className="relative" data-repo-menu={repository.id}>
+              <button
+                type="button"
+                className={ui.iconBtn}
+                aria-label={`Actions for ${repository.projectPath}`}
+                aria-haspopup="menu"
+                aria-expanded={menuOpen}
+                onClick={() => setMenuOpen((open) => !open)}
+              >
+                <svg aria-hidden="true" viewBox="0 0 24 24" fill="currentColor">
+                  <circle cx="12" cy="5" r="1.75" />
+                  <circle cx="12" cy="12" r="1.75" />
+                  <circle cx="12" cy="19" r="1.75" />
+                </svg>
+              </button>
+              {menuOpen && (
+                <div role="menu" className={cx(ui.menuPanel, "min-w-40")}>
+                  <button
+                    type="button"
+                    role="menuitem"
+                    className={ui.menuItem}
+                    onClick={() => {
+                      setMenuOpen(false)
+                      openSettings()
+                    }}
+                  >
+                    Settings
+                  </button>
+                  <hr className={ui.menuSep} />
+                  <button
+                    type="button"
+                    role="menuitem"
+                    className={cx(ui.menuItem, ui.menuItemDestructive)}
+                    disabled={removeRepository.isPending}
+                    onClick={() => {
+                      setMenuOpen(false)
+                      confirmRemoval()
+                    }}
+                  >
+                    {removeRepository.isPending ? "Removing..." : "Remove"}
+                  </button>
+                </div>
+              )}
+            </span>
           </div>
-          <div className={ui.dialogBodySectioned}>
-            <section
-              className={ui.dialogSection}
-              aria-labelledby={`repo-sec-identity-${repository.id}`}
-            >
-              <div className={ui.dialogSectionHead}>
-                <h3
-                  id={`repo-sec-identity-${repository.id}`}
-                  className={ui.dialogSectionTitle}
-                >
-                  Forge identity
-                </h3>
-                <span className={ui.dialogSectionMeta}>Path</span>
-              </div>
-              <label className={ui.dialogField}>
-                Forge:
-                <select
-                  className={ui.dialogInput}
-                  value={forge}
-                  onChange={(event) =>
-                    setForge(event.target.value as "github" | "gitlab")
-                  }
-                >
-                  <option value="github">GitHub</option>
-                  <option value="gitlab">GitLab</option>
-                </select>
-              </label>
-              <label className={ui.dialogField}>
-                Forge host:
-                <input
-                  className={cx(ui.dialogInput, ui.dialogInputMono)}
-                  required
-                  value={forgeHost}
-                  onChange={(event) => setForgeHost(event.target.value)}
-                />
-              </label>
-              <label className={ui.dialogField}>
-                Project path:
-                <input
-                  className={cx(ui.dialogInput, ui.dialogInputMono)}
-                  required
-                  value={projectPath}
-                  onChange={(event) => setProjectPath(event.target.value)}
-                />
-              </label>
-              <span className={ui.dialogFieldHint}>
-                GitLab identities are verified before Save. Identity changes are
-                blocked after this Repository has any Work Item.
-              </span>
-            </section>
+        </div>
+        <dialog
+          ref={settingsDialogRef}
+          className={ui.dialogPanel}
+          aria-labelledby={`repo-settings-title-${repository.id}`}
+          onCancel={(event) => {
+            if (updateSettings.isPending) event.preventDefault()
+          }}
+          onClose={() => {
+            // Escape (or other user dismiss) closes the native dialog first; keep
+            // URL + dialog synchronized, including during pending open navigate.
+            if (dismissingRouteRef.current) {
+              dismissingRouteRef.current = false
+              return
+            }
+            dismissSettings()
+          }}
+        >
+          <form onSubmit={saveSettings}>
+            <div className={ui.dialogHeader}>
+              <p className={ui.dialogKicker}>Repository settings</p>
+              <h2
+                id={`repo-settings-title-${repository.id}`}
+                className={cx(ui.dialogTitle, ui.dialogTitlePath)}
+              >
+                {repository.projectPath}
+              </h2>
+              <p className={ui.dialogLede}>
+                Overrides apply on the next Agent Turn. Empty model fields use
+                harness defaults for this Repository&apos;s effective Agent
+                Backend.
+              </p>
+            </div>
+            <div className={ui.dialogBodySectioned}>
+              <section
+                className={ui.dialogSection}
+                aria-labelledby={`repo-sec-identity-${repository.id}`}
+              >
+                <div className={ui.dialogSectionHead}>
+                  <h3
+                    id={`repo-sec-identity-${repository.id}`}
+                    className={ui.dialogSectionTitle}
+                  >
+                    Forge identity
+                  </h3>
+                  <span className={ui.dialogSectionMeta}>Path</span>
+                </div>
+                <label className={ui.dialogField}>
+                  Forge:
+                  <select
+                    className={ui.dialogInput}
+                    value={forge}
+                    onChange={(event) =>
+                      setForge(event.target.value as "github" | "gitlab")
+                    }
+                  >
+                    <option value="github">GitHub</option>
+                    <option value="gitlab">GitLab</option>
+                  </select>
+                </label>
+                <label className={ui.dialogField}>
+                  Forge host:
+                  <input
+                    className={cx(ui.dialogInput, ui.dialogInputMono)}
+                    required
+                    value={forgeHost}
+                    onChange={(event) => setForgeHost(event.target.value)}
+                  />
+                </label>
+                <label className={ui.dialogField}>
+                  Project path:
+                  <input
+                    className={cx(ui.dialogInput, ui.dialogInputMono)}
+                    required
+                    value={projectPath}
+                    onChange={(event) => setProjectPath(event.target.value)}
+                  />
+                </label>
+                <span className={ui.dialogFieldHint}>
+                  GitLab identities are verified before Save. Identity changes
+                  are blocked after this Repository has any Work Item.
+                </span>
+              </section>
 
-            <section
-              className={ui.dialogSection}
-              aria-labelledby={`repo-sec-options-${repository.id}`}
-            >
-              <div className={ui.dialogSectionHead}>
-                <h3
-                  id={`repo-sec-options-${repository.id}`}
-                  className={ui.dialogSectionTitle}
-                >
-                  Options
-                </h3>
-                <span className={ui.dialogSectionMeta}>Repo preferences</span>
-              </div>
-              <label className={ui.dialogCheck}>
-                <input
-                  type="checkbox"
-                  className={ui.dialogCheckInput}
-                  checked={paused}
-                  onChange={(event) => setPaused(event.target.checked)}
-                />
-                Paused
-                <span className={cx(ui.dialogFieldHint, ui.dialogCheckHint)}>
-                  Skip autonomous work selection
-                </span>
-              </label>
-              <label className={ui.dialogCheck}>
-                <input
-                  type="checkbox"
-                  className={ui.dialogCheckInput}
-                  checked={autoMerge}
-                  onChange={(event) => setAutoMerge(event.target.checked)}
-                />
-                Auto-merge
-                <span className={cx(ui.dialogFieldHint, ui.dialogCheckHint)}>
-                  Allow clanker merge when risk is low
-                </span>
-              </label>
-              <label className={ui.dialogCheck}>
-                <input
-                  type="checkbox"
-                  className={ui.dialogCheckInput}
-                  checked={includeAllIssueAuthors}
-                  onChange={(event) =>
-                    setIncludeAllIssueAuthors(event.target.checked)
-                  }
-                />
-                Include all Issue Authors
-                <span className={cx(ui.dialogFieldHint, ui.dialogCheckHint)}>
-                  Relevant Issues from every author after Refresh
-                </span>
-              </label>
-              <label className={ui.dialogField}>
-                <span className="flex items-center gap-3">
+              <section
+                className={ui.dialogSection}
+                aria-labelledby={`repo-sec-options-${repository.id}`}
+              >
+                <div className={ui.dialogSectionHead}>
+                  <h3
+                    id={`repo-sec-options-${repository.id}`}
+                    className={ui.dialogSectionTitle}
+                  >
+                    Options
+                  </h3>
+                  <span className={ui.dialogSectionMeta}>Repo preferences</span>
+                </div>
+                <label className={ui.dialogCheck}>
                   <input
                     type="checkbox"
                     className={ui.dialogCheckInput}
-                    checked={waitForReadyForReviewChecks}
+                    checked={paused}
+                    onChange={(event) => setPaused(event.target.checked)}
+                  />
+                  Paused
+                  <span className={cx(ui.dialogFieldHint, ui.dialogCheckHint)}>
+                    Skip autonomous work selection
+                  </span>
+                </label>
+                <label className={ui.dialogCheck}>
+                  <input
+                    type="checkbox"
+                    className={ui.dialogCheckInput}
+                    checked={autoMerge}
+                    onChange={(event) => setAutoMerge(event.target.checked)}
+                  />
+                  Auto-merge
+                  <span className={cx(ui.dialogFieldHint, ui.dialogCheckHint)}>
+                    Allow clanker merge when risk is low
+                  </span>
+                </label>
+                <label className={ui.dialogCheck}>
+                  <input
+                    type="checkbox"
+                    className={ui.dialogCheckInput}
+                    checked={includeAllIssueAuthors}
                     onChange={(event) =>
-                      setWaitForReadyForReviewChecks(event.target.checked)
+                      setIncludeAllIssueAuthors(event.target.checked)
                     }
                   />
-                  Wait for checks to start after ready for review
-                </span>
-                <span className={ui.dialogFieldHint}>
-                  Wait up to 90 seconds for workflows that start after a PR is
-                  marked ready for review. If this repository has no such
-                  workflows, turn off this setting to skip the wait.
-                </span>
-              </label>
-            </section>
+                  Include all Issue Authors
+                  <span className={cx(ui.dialogFieldHint, ui.dialogCheckHint)}>
+                    Relevant Issues from every author after Refresh
+                  </span>
+                </label>
+                <label className={ui.dialogField}>
+                  <span className="flex items-center gap-3">
+                    <input
+                      type="checkbox"
+                      className={ui.dialogCheckInput}
+                      checked={waitForReadyForReviewChecks}
+                      onChange={(event) =>
+                        setWaitForReadyForReviewChecks(event.target.checked)
+                      }
+                    />
+                    Wait for checks to start after ready for review
+                  </span>
+                  <span className={ui.dialogFieldHint}>
+                    Wait up to 90 seconds for workflows that start after a PR is
+                    marked ready for review. If this repository has no such
+                    workflows, turn off this setting to skip the wait.
+                  </span>
+                </label>
+              </section>
 
-            <section
-              className={ui.dialogSection}
-              aria-labelledby={`repo-sec-agent-${repository.id}`}
-            >
-              <div className={ui.dialogSectionHead}>
-                <h3
-                  id={`repo-sec-agent-${repository.id}`}
-                  className={ui.dialogSectionTitle}
-                >
-                  Agent backend
-                </h3>
-                <span className={ui.dialogSectionMeta}>Override</span>
-              </div>
-              <label className={ui.dialogField}>
-                Agent Backend
-                <select
-                  className={ui.dialogInput}
-                  name="selectedAgentBackend"
-                  value={selectedAgentBackend ?? HARNESS_DEFAULT_BACKEND_VALUE}
-                  disabled={
-                    backendChangeBlocked ||
-                    updateSettings.isPending ||
-                    agentBackends.isPending
-                  }
-                  onChange={(event) => {
-                    applyAgentBackendSelection(event.target.value)
-                  }}
-                >
-                  <option value={HARNESS_DEFAULT_BACKEND_VALUE}>
-                    Harness default ({harnessDefaultBackendLabel})
-                  </option>
-                  {selectedAgentBackend !== null &&
-                    !(agentBackends.data ?? []).some(
-                      (backend) => backend.id === selectedAgentBackend,
-                    ) && (
-                      <option value={selectedAgentBackend}>
-                        {selectedAgentBackend}
-                      </option>
-                    )}
-                  {(agentBackends.data ?? []).map((backend) => (
-                    <option key={backend.id} value={backend.id}>
-                      {backend.label}
-                    </option>
-                  ))}
-                </select>
-                <span className={ui.dialogFieldHint}>
-                  {backendChangeBlocked
-                    ? `${repository.blockingUnfinishedWorkItemCount} unfinished Work Item${
-                        repository.blockingUnfinishedWorkItemCount === 1
-                          ? ""
-                          : "s"
-                      } on this Repository — finish or abandon them before changing Agent Backend.`
-                    : "Harness default inherits the global selection. Override activates on Save when the effective backend changes. Model fields in this dialog are stashed per backend while open; empty means inherit harness for that effective backend."}
-                </span>
-              </label>
-
-              {usesPreviewCatalog && !previewPending && (
-                <div className={ui.dialogStatusLabel}>
-                  <p className="m-0">
-                    {formatAgentBackendStatusLabel({
-                      backendLabel:
-                        (agentBackends.data ?? []).find(
-                          (backend) => backend.id === draftEffective,
-                        )?.label ?? draftEffective,
-                      kind: previewError !== null ? "UNAVAILABLE" : "READY",
-                      provider: previewProvider,
-                      // Reason text is on the Banner below when preview fails.
-                    })}
-                  </p>
-                  {previewError === null && (
-                    <AgentBackendWarnings warnings={previewWarnings} />
-                  )}
+              <section
+                className={ui.dialogSection}
+                aria-labelledby={`repo-sec-agent-${repository.id}`}
+              >
+                <div className={ui.dialogSectionHead}>
+                  <h3
+                    id={`repo-sec-agent-${repository.id}`}
+                    className={ui.dialogSectionTitle}
+                  >
+                    Agent backend
+                  </h3>
+                  <span className={ui.dialogSectionMeta}>Override</span>
                 </div>
-              )}
-
-              {agentBackends.isError && (
-                <Banner
-                  className={ui.bannerCompact}
-                  tone="alarm"
-                  tag="Error"
-                  role="alert"
-                >
-                  Agent Backends list could not be loaded. You can still inherit
-                  the harness default; override options may be incomplete.
-                </Banner>
-              )}
-
-              {usesPreviewCatalog && previewError !== null && (
-                <Banner
-                  className={ui.bannerCompact}
-                  tone="alarm"
-                  tag="Error"
-                  role="alert"
-                >
-                  Preview failed: {previewError}. Model fields stay disabled
-                  until preview succeeds.
-                  {backendDraftChanging
-                    ? " Changing the effective backend cannot be saved until preview succeeds."
-                    : " Non-model settings can still be saved."}
-                </Banner>
-              )}
-            </section>
-
-            <section
-              className={ui.dialogSection}
-              aria-labelledby={`repo-sec-models-${repository.id}`}
-            >
-              <div className={ui.dialogSectionHead}>
-                <h3
-                  id={`repo-sec-models-${repository.id}`}
-                  className={ui.dialogSectionTitle}
-                >
-                  Models
-                </h3>
-                <span className={ui.dialogSectionMeta}>Build · Review</span>
-              </div>
-
-              {modelsLoading ? (
-                <p className={ui.dialogLoading}>Loading models...</p>
-              ) : !usesPreviewCatalog && models.isError ? (
-                <Banner
-                  className={ui.bannerCompact}
-                  tone="alarm"
-                  tag="Error"
-                  role="alert"
-                >
-                  Models could not be loaded.
-                </Banner>
-              ) : (
-                <>
-                  <AgentModelSelect
-                    label="Build model"
-                    name="defaultModel"
-                    value={defaultModel}
-                    models={catalogModels}
-                    catalogLoading={catalogLoading}
-                    allowClear
-                    required={false}
-                    disabled={modelSelectDisabled}
-                    placeholder={`Harness default (${harnessDefaultModel})`}
-                    emptyCatalogLabel={
-                      claudeBedrockStrict
-                        ? "No Bedrock profiles available"
-                        : "No Agent Models available"
+                <label className={ui.dialogField}>
+                  Agent Backend
+                  <select
+                    className={ui.dialogInput}
+                    name="selectedAgentBackend"
+                    value={
+                      selectedAgentBackend ?? HARNESS_DEFAULT_BACKEND_VALUE
                     }
-                    blockReason={buildModelBlockReason}
-                    hint={
-                      claudeBedrockStrict
-                        ? "Empty inherits harness default. Otherwise choose a discovered Bedrock inference profile."
-                        : "Empty inherits harness default. Otherwise choose a model from the catalog."
+                    disabled={
+                      backendChangeBlocked ||
+                      updateSettings.isPending ||
+                      agentBackends.isPending
                     }
-                    onChange={(nextModel) => {
-                      setDefaultModel(nextModel)
-                      const sourceModel =
-                        nextModel.length > 0 ? nextModel : harnessBuildForSource
-                      const nextVariants = thinkingLevelsForModel(
-                        catalogModels,
-                        sourceModel,
-                      )
-                      setDefaultVariant((current) =>
-                        reconcileVariantForModel(current, nextVariants),
-                      )
-                      if (
-                        reviewModel.length === 0 &&
-                        harnessReviewForSource.length === 0
-                      ) {
-                        const reviewSource =
+                    onChange={(event) => {
+                      applyAgentBackendSelection(event.target.value)
+                    }}
+                  >
+                    <option value={HARNESS_DEFAULT_BACKEND_VALUE}>
+                      Harness default ({harnessDefaultBackendLabel})
+                    </option>
+                    {selectedAgentBackend !== null &&
+                      !(agentBackends.data ?? []).some(
+                        (backend) => backend.id === selectedAgentBackend,
+                      ) && (
+                        <option value={selectedAgentBackend}>
+                          {selectedAgentBackend}
+                        </option>
+                      )}
+                    {(agentBackends.data ?? []).map((backend) => (
+                      <option key={backend.id} value={backend.id}>
+                        {backend.label}
+                      </option>
+                    ))}
+                  </select>
+                  <span className={ui.dialogFieldHint}>
+                    {backendChangeBlocked
+                      ? `${repository.blockingUnfinishedWorkItemCount} unfinished Work Item${
+                          repository.blockingUnfinishedWorkItemCount === 1
+                            ? ""
+                            : "s"
+                        } on this Repository — finish or abandon them before changing Agent Backend.`
+                      : "Harness default inherits the global selection. Override activates on Save when the effective backend changes. Model fields in this dialog are stashed per backend while open; empty means inherit harness for that effective backend."}
+                  </span>
+                </label>
+
+                {usesPreviewCatalog && !previewPending && (
+                  <div className={ui.dialogStatusLabel}>
+                    <p className="m-0">
+                      {formatAgentBackendStatusLabel({
+                        backendLabel:
+                          (agentBackends.data ?? []).find(
+                            (backend) => backend.id === draftEffective,
+                          )?.label ?? draftEffective,
+                        kind: previewError !== null ? "UNAVAILABLE" : "READY",
+                        provider: previewProvider,
+                        // Reason text is on the Banner below when preview fails.
+                      })}
+                    </p>
+                    {previewError === null && (
+                      <AgentBackendWarnings warnings={previewWarnings} />
+                    )}
+                  </div>
+                )}
+
+                {agentBackends.isError && (
+                  <Banner
+                    className={ui.bannerCompact}
+                    tone="alarm"
+                    tag="Error"
+                    role="alert"
+                  >
+                    Agent Backends list could not be loaded. You can still
+                    inherit the harness default; override options may be
+                    incomplete.
+                  </Banner>
+                )}
+
+                {usesPreviewCatalog && previewError !== null && (
+                  <Banner
+                    className={ui.bannerCompact}
+                    tone="alarm"
+                    tag="Error"
+                    role="alert"
+                  >
+                    Preview failed: {previewError}. Model fields stay disabled
+                    until preview succeeds.
+                    {backendDraftChanging
+                      ? " Changing the effective backend cannot be saved until preview succeeds."
+                      : " Non-model settings can still be saved."}
+                  </Banner>
+                )}
+              </section>
+
+              <section
+                className={ui.dialogSection}
+                aria-labelledby={`repo-sec-models-${repository.id}`}
+              >
+                <div className={ui.dialogSectionHead}>
+                  <h3
+                    id={`repo-sec-models-${repository.id}`}
+                    className={ui.dialogSectionTitle}
+                  >
+                    Models
+                  </h3>
+                  <span className={ui.dialogSectionMeta}>Build · Review</span>
+                </div>
+
+                {modelsLoading ? (
+                  <p className={ui.dialogLoading}>Loading models...</p>
+                ) : !usesPreviewCatalog && models.isError ? (
+                  <Banner
+                    className={ui.bannerCompact}
+                    tone="alarm"
+                    tag="Error"
+                    role="alert"
+                  >
+                    Models could not be loaded.
+                  </Banner>
+                ) : (
+                  <>
+                    <AgentModelSelect
+                      label="Build model"
+                      name="defaultModel"
+                      value={defaultModel}
+                      models={catalogModels}
+                      catalogLoading={catalogLoading}
+                      allowClear
+                      required={false}
+                      disabled={modelSelectDisabled}
+                      placeholder={`Harness default (${harnessDefaultModel})`}
+                      emptyCatalogLabel={
+                        claudeBedrockStrict
+                          ? "No Bedrock profiles available"
+                          : "No Agent Models available"
+                      }
+                      blockReason={buildModelBlockReason}
+                      hint={
+                        claudeBedrockStrict
+                          ? "Empty inherits harness default. Otherwise choose a discovered Bedrock inference profile."
+                          : "Empty inherits harness default. Otherwise choose a model from the catalog."
+                      }
+                      onChange={(nextModel) => {
+                        setDefaultModel(nextModel)
+                        const sourceModel =
                           nextModel.length > 0
                             ? nextModel
                             : harnessBuildForSource
+                        const nextVariants = thinkingLevelsForModel(
+                          catalogModels,
+                          sourceModel,
+                        )
+                        setDefaultVariant((current) =>
+                          reconcileVariantForModel(current, nextVariants),
+                        )
+                        if (
+                          reviewModel.length === 0 &&
+                          harnessReviewForSource.length === 0
+                        ) {
+                          const reviewSource =
+                            nextModel.length > 0
+                              ? nextModel
+                              : harnessBuildForSource
+                          setReviewVariant((current) =>
+                            reconcileVariantForModel(
+                              current,
+                              thinkingLevelsForModel(
+                                catalogModels,
+                                reviewSource,
+                              ),
+                            ),
+                          )
+                        }
+                      }}
+                    />
+                    {buildVariantSourceModel.length > 0 &&
+                      buildVariantSourceUnavailable && (
+                        <Banner
+                          className={ui.bannerCompact}
+                          tone="alarm"
+                          tag="Error"
+                          role="alert"
+                        >
+                          Build effort (thinking) override is unavailable — the
+                          selected model is not in the Agent Model catalog. Use
+                          harness default or pick another model.
+                        </Banner>
+                      )}
+                    <label className={ui.dialogField}>
+                      Build effort (thinking)
+                      <select
+                        className={ui.dialogInput}
+                        name="defaultThinkingLevel"
+                        value={defaultThinkingLevel}
+                        onChange={(event) =>
+                          setDefaultVariant(event.target.value)
+                        }
+                        disabled={modelsDisabled}
+                      >
+                        <option value="">
+                          {emptyThinkingLevelOptionLabel({
+                            explicitModel: defaultModel.length > 0,
+                            inheritedLabel: harnessDefaultVariant,
+                            fallsBackToBuild: false,
+                          })}
+                        </option>
+                        {hasCustomBuildVariant && (
+                          <option value={defaultThinkingLevel}>
+                            {formatUnavailableVariantLabel(
+                              defaultThinkingLevel,
+                            )}
+                          </option>
+                        )}
+                        {buildVariants.map((variant) => (
+                          <option key={variant} value={variant}>
+                            {formatVariantLabel(variant)}
+                          </option>
+                        ))}
+                      </select>
+                      <span className={ui.dialogFieldHint}>
+                        {defaultModel.length > 0
+                          ? "Empty uses this model's backend default."
+                          : "Empty inherits the complete Harness build selection. This override is dormant until a Repository build model is set."}
+                      </span>
+                    </label>
+                    <AgentModelSelect
+                      label="Review model"
+                      name="reviewModel"
+                      value={reviewModel}
+                      models={catalogModels}
+                      catalogLoading={catalogLoading}
+                      allowClear
+                      required={false}
+                      disabled={modelSelectDisabled}
+                      placeholder={`Harness default (${harnessReviewModel})`}
+                      emptyCatalogLabel={`Harness default (${harnessReviewModel})`}
+                      blockReason={reviewModelBlockReason}
+                      hint={null}
+                      onChange={(nextModel) => {
+                        setReviewModel(nextModel)
+                        const sourceModel = governingReviewModelId({
+                          reviewModel: nextModel,
+                          harnessReviewModel: harnessReviewForSource,
+                          resolvedBuildModel: buildVariantSourceModel,
+                        })
                         setReviewVariant((current) =>
                           reconcileVariantForModel(
                             current,
-                            thinkingLevelsForModel(catalogModels, reviewSource),
+                            thinkingLevelsForModel(catalogModels, sourceModel),
                           ),
                         )
-                      }
-                    }}
-                  />
-                  {buildVariantSourceModel.length > 0 &&
-                    buildVariantSourceUnavailable && (
-                      <Banner
-                        className={ui.bannerCompact}
-                        tone="alarm"
-                        tag="Error"
-                        role="alert"
-                      >
-                        Build effort (thinking) override is unavailable — the
-                        selected model is not in the Agent Model catalog. Use
-                        harness default or pick another model.
-                      </Banner>
-                    )}
-                  <label className={ui.dialogField}>
-                    Build effort (thinking)
-                    <select
-                      className={ui.dialogInput}
-                      name="defaultThinkingLevel"
-                      value={defaultThinkingLevel}
-                      onChange={(event) =>
-                        setDefaultVariant(event.target.value)
-                      }
-                      disabled={modelsDisabled}
-                    >
-                      <option value="">
-                        {emptyThinkingLevelOptionLabel({
-                          explicitModel: defaultModel.length > 0,
-                          inheritedLabel: harnessDefaultVariant,
-                          fallsBackToBuild: false,
-                        })}
-                      </option>
-                      {hasCustomBuildVariant && (
-                        <option value={defaultThinkingLevel}>
-                          {formatUnavailableVariantLabel(defaultThinkingLevel)}
-                        </option>
+                      }}
+                    />
+                    {reviewThinkingLevelSourceModel.length > 0 &&
+                      reviewThinkingLevelSourceUnavailable && (
+                        <Banner
+                          className={ui.bannerCompact}
+                          tone="alarm"
+                          tag="Error"
+                          role="alert"
+                        >
+                          Review effort (thinking) override is unavailable — the
+                          selected model is not in the Agent Model catalog. Use
+                          harness default or pick another model.
+                        </Banner>
                       )}
-                      {buildVariants.map((variant) => (
-                        <option key={variant} value={variant}>
-                          {formatVariantLabel(variant)}
-                        </option>
-                      ))}
-                    </select>
-                    <span className={ui.dialogFieldHint}>
-                      {defaultModel.length > 0
-                        ? "Empty uses this model's backend default."
-                        : "Empty inherits the complete Harness build selection. This override is dormant until a Repository build model is set."}
-                    </span>
-                  </label>
-                  <AgentModelSelect
-                    label="Review model"
-                    name="reviewModel"
-                    value={reviewModel}
-                    models={catalogModels}
-                    catalogLoading={catalogLoading}
-                    allowClear
-                    required={false}
-                    disabled={modelSelectDisabled}
-                    placeholder={`Harness default (${harnessReviewModel})`}
-                    emptyCatalogLabel={`Harness default (${harnessReviewModel})`}
-                    blockReason={reviewModelBlockReason}
-                    hint={null}
-                    onChange={(nextModel) => {
-                      setReviewModel(nextModel)
-                      const sourceModel = governingReviewModelId({
-                        reviewModel: nextModel,
-                        harnessReviewModel: harnessReviewForSource,
-                        resolvedBuildModel: buildVariantSourceModel,
-                      })
-                      setReviewVariant((current) =>
-                        reconcileVariantForModel(
-                          current,
-                          thinkingLevelsForModel(catalogModels, sourceModel),
-                        ),
-                      )
-                    }}
-                  />
-                  {reviewThinkingLevelSourceModel.length > 0 &&
-                    reviewThinkingLevelSourceUnavailable && (
-                      <Banner
-                        className={ui.bannerCompact}
-                        tone="alarm"
-                        tag="Error"
-                        role="alert"
+                    <label className={ui.dialogField}>
+                      Review effort (thinking)
+                      <select
+                        className={ui.dialogInput}
+                        name="reviewThinkingLevel"
+                        value={reviewThinkingLevel}
+                        onChange={(event) =>
+                          setReviewVariant(event.target.value)
+                        }
+                        disabled={modelsDisabled}
                       >
-                        Review effort (thinking) override is unavailable — the
-                        selected model is not in the Agent Model catalog. Use
-                        harness default or pick another model.
-                      </Banner>
-                    )}
-                  <label className={ui.dialogField}>
-                    Review effort (thinking)
-                    <select
-                      className={ui.dialogInput}
-                      name="reviewThinkingLevel"
-                      value={reviewThinkingLevel}
-                      onChange={(event) => setReviewVariant(event.target.value)}
-                      disabled={modelsDisabled}
-                    >
-                      <option value="">
-                        {emptyThinkingLevelOptionLabel({
-                          explicitModel: reviewModel.length > 0,
-                          inheritedLabel:
-                            reviewModel.length === 0 &&
-                            harnessReviewForSource.length === 0
-                              ? harnessPrefsForDraft !== null
-                                ? (harnessPrefsForDraft.reviewThinkingLevel ??
-                                  "")
-                                : (config.data?.reviewThinkingLevel ?? "")
-                              : harnessReviewVariant,
-                          fallsBackToBuild:
-                            reviewModel.length === 0 &&
-                            harnessReviewForSource.length === 0,
-                        })}
-                      </option>
-                      {hasCustomReviewVariant && (
-                        <option value={reviewThinkingLevel}>
-                          {formatUnavailableVariantLabel(reviewThinkingLevel)}
+                        <option value="">
+                          {emptyThinkingLevelOptionLabel({
+                            explicitModel: reviewModel.length > 0,
+                            inheritedLabel:
+                              reviewModel.length === 0 &&
+                              harnessReviewForSource.length === 0
+                                ? harnessPrefsForDraft !== null
+                                  ? (harnessPrefsForDraft.reviewThinkingLevel ??
+                                    "")
+                                  : (config.data?.reviewThinkingLevel ?? "")
+                                : harnessReviewVariant,
+                            fallsBackToBuild:
+                              reviewModel.length === 0 &&
+                              harnessReviewForSource.length === 0,
+                          })}
                         </option>
-                      )}
-                      {reviewThinkingLevels.map((variant) => (
-                        <option key={`review-${variant}`} value={variant}>
-                          {formatVariantLabel(variant)}
-                        </option>
-                      ))}
-                    </select>
-                    <span className={ui.dialogFieldHint}>
-                      {reviewModel.length > 0
-                        ? "Empty uses this review model's backend default."
-                        : harnessReviewForSource.length > 0
-                          ? "Empty inherits the complete Harness review selection. This override is dormant while Harness review is in effect."
-                          : "Empty uses the Harness review Thinking Level, then the resolved build Thinking Level, then the backend/model default."}
-                    </span>
-                  </label>
-                </>
-              )}
-            </section>
-
-            {updateSettings.isError && (
-              <Banner
-                className={ui.bannerCompact}
-                tone="alarm"
-                tag="Error"
-                role="alert"
-              >
-                {updateSettings.error instanceof Error
-                  ? updateSettings.error.message
-                  : "Settings could not be saved. Try again."}
-              </Banner>
-            )}
-          </div>
-          <div className={ui.dialogFooter}>
-            <button
-              type="button"
-              className={ui.plateMini}
-              onClick={() => dismissSettings()}
-              disabled={updateSettings.isPending}
-            >
-              Cancel
-            </button>
-            <button
-              type="submit"
-              className={ui.platePrimary}
-              aria-busy={updateSettings.isPending || undefined}
-              disabled={repositorySettingsSaveBlocked}
-            >
-              {updateSettings.isPending ? "Saving…" : "Save"}
-            </button>
-          </div>
-        </form>
-      </dialog>
-      {!repositoryCollapsed && (
-        <div id={repositoryBodyId}>
-          <dl className={ui.repoMeta}>
-            <div className={ui.repoMetaRow}>
-              <dt>Path</dt>
-              <dd title={repository.localPath}>{repository.localPath}</dd>
-            </div>
-            <div className={ui.repoMetaRow}>
-              <dt>Checkout</dt>
-              <dd>{repository.isBare ? "Bare repository" : "Working tree"}</dd>
-            </div>
-            <div className={ui.repoMetaRow}>
-              <dt>Agent Backend</dt>
-              <dd>
-                {repository.selectedAgentBackend === null
-                  ? `Harness default (${repository.effectiveAgentBackend})`
-                  : repository.effectiveAgentBackend}
-              </dd>
-            </div>
-            <div className={ui.repoMetaRow}>
-              <dt>Include all Issue Authors</dt>
-              <dd>
-                {repository.includeAllIssueAuthors ? "Enabled" : "Disabled"}
-              </dd>
-            </div>
-            <div className={ui.repoMetaRow}>
-              <dt>Build model</dt>
-              <dd>
-                {repository.defaultModel ??
-                  (repository.selectedAgentBackend === null
-                    ? `Harness default (${
-                        config.data?.defaultModel ?? "not configured"
-                      })`
-                    : "Harness default")}
-                {" · "}
-                {repository.defaultThinkingLevel ??
-                  (repository.selectedAgentBackend === null
-                    ? `Harness default (${
-                        config.data?.defaultThinkingLevel ?? "not configured"
-                      })`
-                    : "Harness default")}
-              </dd>
-            </div>
-            <div className={ui.repoMetaRow}>
-              <dt>Review model</dt>
-              <dd>
-                {repository.reviewModel ??
-                  (repository.selectedAgentBackend === null
-                    ? `Harness default (${
-                        config.data?.reviewModel ??
-                        `Build (${
-                          repository.defaultModel ??
-                          config.data?.defaultModel ??
-                          "not configured"
-                        })`
-                      })`
-                    : "Harness default")}
-                {" · "}
-                {repository.reviewThinkingLevel ??
-                  (repository.selectedAgentBackend === null
-                    ? `Harness default (${
-                        config.data?.reviewThinkingLevel ??
-                        `Build (${
-                          repository.defaultThinkingLevel ??
-                          config.data?.defaultThinkingLevel ??
-                          "not configured"
-                        })`
-                      })`
-                    : "Harness default")}
-              </dd>
-            </div>
-            <div className={ui.repoMetaRow}>
-              <dt>Wait for ready checks</dt>
-              <dd>
-                {repository.waitForReadyForReviewChecks
-                  ? "Enabled"
-                  : "Disabled"}
-              </dd>
-            </div>
-            <div className={ui.repoMetaRow}>
-              <dt>Auto-merge</dt>
-              <dd>{repository.autoMerge ? "Enabled" : "Disabled"}</dd>
-            </div>
-          </dl>
-          {!repository.credential.configured &&
-            repository.forge === "github" && (
-              <Banner
-                className="mt-5"
-                tone="alarm"
-                tag="Attention"
-                role={addGitHubToken.isError ? "alert" : "status"}
-                action={
-                  githubTokenCreated ? (
-                    <button
-                      type="button"
-                      className={ui.platePrimary}
-                      disabled={addGitHubToken.isPending}
-                      aria-busy={addGitHubToken.isPending || undefined}
-                      onClick={() => addGitHubToken.mutate()}
-                    >
-                      {addGitHubToken.isPending
-                        ? "Waiting for Keymaxxer"
-                        : "Store in Keymaxxer"}
-                    </button>
-                  ) : (
-                    <a
-                      className={ui.platePrimary}
-                      href={repository.credential.githubTokenCreationUrl}
-                      onClick={() => setGithubTokenCreated(true)}
-                      rel="noreferrer"
-                      target="_blank"
-                    >
-                      Create GitHub token
-                    </a>
-                  )
-                }
-              >
-                <p className="m-0 font-semibold">GitHub token required</p>
-                {githubTokenCreated ? (
-                  <p className="m-0 mt-1">
-                    Store the generated token as{" "}
-                    <code className={ui.guidanceCode}>
-                      {repository.credential.githubTokenSecretName}
-                    </code>{" "}
-                    in Keymaxxer. Already-created tokens are not upgraded
-                    automatically — edit the token on GitHub or recreate it,
-                    then store the replacement.
-                  </p>
-                ) : (
-                  <p className="m-0 mt-1">
-                    Create a fine-grained token, choose{" "}
-                    <strong>Only select repositories</strong>, select{" "}
-                    <code className={ui.guidanceCode}>
-                      {repository.projectPath.split("/").at(-1)}
-                    </code>
-                    , and allow <strong>Actions: Read and write</strong>{" "}
-                    (required for workflow reruns and CI logs). Already-created
-                    tokens are not upgraded automatically — edit or recreate
-                    them if Actions is still read-only.
-                  </p>
+                        {hasCustomReviewVariant && (
+                          <option value={reviewThinkingLevel}>
+                            {formatUnavailableVariantLabel(reviewThinkingLevel)}
+                          </option>
+                        )}
+                        {reviewThinkingLevels.map((variant) => (
+                          <option key={`review-${variant}`} value={variant}>
+                            {formatVariantLabel(variant)}
+                          </option>
+                        ))}
+                      </select>
+                      <span className={ui.dialogFieldHint}>
+                        {reviewModel.length > 0
+                          ? "Empty uses this review model's backend default."
+                          : harnessReviewForSource.length > 0
+                            ? "Empty inherits the complete Harness review selection. This override is dormant while Harness review is in effect."
+                            : "Empty uses the Harness review Thinking Level, then the resolved build Thinking Level, then the backend/model default."}
+                      </span>
+                    </label>
+                  </>
                 )}
-                {addGitHubToken.isError ? (
-                  <p className="m-0 mt-1">
-                    Keymaxxer setup was cancelled or failed.
-                  </p>
-                ) : null}
-              </Banner>
-            )}
-          {!repository.credential.configured &&
-            repository.forge === "gitlab" && (
-              <Banner
-                className="mt-5"
-                tone="alarm"
-                tag="Attention"
-                role={addGitLabToken.isError ? "alert" : "status"}
-                action={
-                  gitlabTokenCreated ? (
-                    <button
-                      type="button"
-                      className={ui.platePrimary}
-                      disabled={addGitLabToken.isPending}
-                      aria-busy={addGitLabToken.isPending || undefined}
-                      onClick={() => addGitLabToken.mutate()}
-                    >
-                      {addGitLabToken.isPending
-                        ? "Waiting for Keymaxxer"
-                        : "Store in Keymaxxer"}
-                    </button>
-                  ) : (
-                    <a
-                      className={ui.platePrimary}
-                      href={repository.credential.githubTokenCreationUrl}
-                      onClick={() => setGitlabTokenCreated(true)}
-                      rel="noreferrer"
-                      target="_blank"
-                    >
-                      Create GitLab token
-                    </a>
-                  )
-                }
+              </section>
+
+              {updateSettings.isError && (
+                <Banner
+                  className={ui.bannerCompact}
+                  tone="alarm"
+                  tag="Error"
+                  role="alert"
+                >
+                  {updateSettings.error instanceof Error
+                    ? updateSettings.error.message
+                    : "Settings could not be saved. Try again."}
+                </Banner>
+              )}
+            </div>
+            <div className={ui.dialogFooter}>
+              <button
+                type="button"
+                className={ui.plateMini}
+                onClick={() => dismissSettings()}
+                disabled={updateSettings.isPending}
               >
-                <p className="m-0 font-semibold">
-                  GitLab authentication required
-                </p>
-                <p className="m-0 mt-1">
-                  {gitlabTokenCreated ? (
-                    <>
+                Cancel
+              </button>
+              <button
+                type="submit"
+                className={ui.platePrimary}
+                aria-busy={updateSettings.isPending || undefined}
+                disabled={repositorySettingsSaveBlocked}
+              >
+                {updateSettings.isPending ? "Saving…" : "Save"}
+              </button>
+            </div>
+          </form>
+        </dialog>
+        {!repositoryCollapsed && (
+          <div id={repositoryBodyId}>
+            <dl className={ui.repoMeta}>
+              <div className={ui.repoMetaRow}>
+                <dt>Path</dt>
+                <dd title={repository.localPath}>{repository.localPath}</dd>
+              </div>
+              <div className={ui.repoMetaRow}>
+                <dt>Checkout</dt>
+                <dd>
+                  {repository.isBare ? "Bare repository" : "Working tree"}
+                </dd>
+              </div>
+              <div className={ui.repoMetaRow}>
+                <dt>Agent Backend</dt>
+                <dd>
+                  {repository.selectedAgentBackend === null
+                    ? `Harness default (${repository.effectiveAgentBackend})`
+                    : repository.effectiveAgentBackend}
+                </dd>
+              </div>
+              <div className={ui.repoMetaRow}>
+                <dt>Include all Issue Authors</dt>
+                <dd>
+                  {repository.includeAllIssueAuthors ? "Enabled" : "Disabled"}
+                </dd>
+              </div>
+              <div className={ui.repoMetaRow}>
+                <dt>Build model</dt>
+                <dd>
+                  {repository.defaultModel ??
+                    (repository.selectedAgentBackend === null
+                      ? `Harness default (${
+                          config.data?.defaultModel ?? "not configured"
+                        })`
+                      : "Harness default")}
+                  {" · "}
+                  {repository.defaultThinkingLevel ??
+                    (repository.selectedAgentBackend === null
+                      ? `Harness default (${
+                          config.data?.defaultThinkingLevel ?? "not configured"
+                        })`
+                      : "Harness default")}
+                </dd>
+              </div>
+              <div className={ui.repoMetaRow}>
+                <dt>Review model</dt>
+                <dd>
+                  {repository.reviewModel ??
+                    (repository.selectedAgentBackend === null
+                      ? `Harness default (${
+                          config.data?.reviewModel ??
+                          `Build (${
+                            repository.defaultModel ??
+                            config.data?.defaultModel ??
+                            "not configured"
+                          })`
+                        })`
+                      : "Harness default")}
+                  {" · "}
+                  {repository.reviewThinkingLevel ??
+                    (repository.selectedAgentBackend === null
+                      ? `Harness default (${
+                          config.data?.reviewThinkingLevel ??
+                          `Build (${
+                            repository.defaultThinkingLevel ??
+                            config.data?.defaultThinkingLevel ??
+                            "not configured"
+                          })`
+                        })`
+                      : "Harness default")}
+                </dd>
+              </div>
+              <div className={ui.repoMetaRow}>
+                <dt>Wait for ready checks</dt>
+                <dd>
+                  {repository.waitForReadyForReviewChecks
+                    ? "Enabled"
+                    : "Disabled"}
+                </dd>
+              </div>
+              <div className={ui.repoMetaRow}>
+                <dt>Auto-merge</dt>
+                <dd>{repository.autoMerge ? "Enabled" : "Disabled"}</dd>
+              </div>
+            </dl>
+            {!repository.credential.configured &&
+              repository.forge === "github" && (
+                <Banner
+                  className="mt-5"
+                  tone="alarm"
+                  tag="Attention"
+                  role={addGitHubToken.isError ? "alert" : "status"}
+                  action={
+                    githubTokenCreated ? (
+                      <button
+                        type="button"
+                        className={ui.platePrimary}
+                        disabled={addGitHubToken.isPending}
+                        aria-busy={addGitHubToken.isPending || undefined}
+                        onClick={() => addGitHubToken.mutate()}
+                      >
+                        {addGitHubToken.isPending
+                          ? "Waiting for Keymaxxer"
+                          : "Store in Keymaxxer"}
+                      </button>
+                    ) : (
+                      <a
+                        className={ui.platePrimary}
+                        href={repository.credential.githubTokenCreationUrl}
+                        onClick={() => setGithubTokenCreated(true)}
+                        rel="noreferrer"
+                        target="_blank"
+                      >
+                        Create GitHub token
+                      </a>
+                    )
+                  }
+                >
+                  <p className="m-0 font-semibold">GitHub token required</p>
+                  {githubTokenCreated ? (
+                    <p className="m-0 mt-1">
                       Store the generated token as{" "}
                       <code className={ui.guidanceCode}>
                         {repository.credential.githubTokenSecretName}
                       </code>{" "}
-                      in Keymaxxer when available (provider{" "}
-                      <code className={ui.guidanceCode}>gitlab</code>, account{" "}
-                      <code className={ui.guidanceCode}>
-                        {repository.forgeHost}/{repository.projectPath}
-                      </code>
-                      ). Or set ambient auth without Keymaxxer:{" "}
-                    </>
+                      in Keymaxxer. Already-created tokens are not upgraded
+                      automatically — edit the token on GitHub or recreate it,
+                      then store the replacement.
+                    </p>
                   ) : (
-                    <>
-                      Create a personal access token on this GitLab instance
-                      with API access for{" "}
+                    <p className="m-0 mt-1">
+                      Create a fine-grained token, choose{" "}
+                      <strong>Only select repositories</strong>, select{" "}
                       <code className={ui.guidanceCode}>
-                        {repository.projectPath}
+                        {repository.projectPath.split("/").at(-1)}
                       </code>
-                      . Store it in Keymaxxer when available, or set ambient
-                      auth:{" "}
-                    </>
+                      , and allow <strong>Actions: Read and write</strong>{" "}
+                      (required for workflow reruns and CI logs).
+                      Already-created tokens are not upgraded automatically —
+                      edit or recreate them if Actions is still read-only.
+                    </p>
                   )}
-                  <code className={ui.guidanceCode}>GITLAB_TOKEN</code> or{" "}
-                  <code className={ui.guidanceCode}>
-                    glab auth login --hostname {repository.forgeHost}
-                  </code>{" "}
-                  before starting the Harness.
-                </p>
-                {addGitLabToken.isError ? (
-                  <p className="m-0 mt-1">
-                    Keymaxxer setup was cancelled or failed. Use ambient{" "}
-                    <code className={ui.guidanceCode}>GITLAB_TOKEN</code> or{" "}
-                    <code className={ui.guidanceCode}>glab auth login</code> and
-                    restart the Harness if Keymaxxer is unavailable.
-                  </p>
-                ) : null}
-              </Banner>
-            )}
-          <div className={ui.repoIssues}>
-            <div className={ui.repoIssuesHead}>
-              <h3 className={ui.repoIssuesKicker}>
-                {hasNoRelevantIssues ? "No relevant issues" : "Relevant issues"}
-              </h3>
-              <button
-                type="button"
-                className={ui.iconBtn}
-                disabled={refreshingIssues || !repository.credential.configured}
-                onClick={() => refreshIssues.mutate()}
-                aria-label={
-                  refreshingIssues ? "Refreshing issues" : "Refresh issues"
-                }
-                title={
-                  repository.credential.configured
-                    ? "Refresh issues"
-                    : repository.forge === "gitlab"
-                      ? "Authenticate GitLab before refreshing issues"
-                      : "Add a GitHub token before refreshing issues"
-                }
-              >
-                <svg
-                  aria-hidden="true"
-                  className={
-                    refreshingIssues
-                      ? "animate-spin motion-reduce:animate-none"
-                      : undefined
+                  {addGitHubToken.isError ? (
+                    <p className="m-0 mt-1">
+                      Keymaxxer setup was cancelled or failed.
+                    </p>
+                  ) : null}
+                </Banner>
+              )}
+            {!repository.credential.configured &&
+              repository.forge === "gitlab" && (
+                <Banner
+                  className="mt-5"
+                  tone="alarm"
+                  tag="Attention"
+                  role={addGitLabToken.isError ? "alert" : "status"}
+                  action={
+                    gitlabTokenCreated ? (
+                      <button
+                        type="button"
+                        className={ui.platePrimary}
+                        disabled={addGitLabToken.isPending}
+                        aria-busy={addGitLabToken.isPending || undefined}
+                        onClick={() => addGitLabToken.mutate()}
+                      >
+                        {addGitLabToken.isPending
+                          ? "Waiting for Keymaxxer"
+                          : "Store in Keymaxxer"}
+                      </button>
+                    ) : (
+                      <a
+                        className={ui.platePrimary}
+                        href={repository.credential.githubTokenCreationUrl}
+                        onClick={() => setGitlabTokenCreated(true)}
+                        rel="noreferrer"
+                        target="_blank"
+                      >
+                        Create GitLab token
+                      </a>
+                    )
                   }
-                  viewBox="0 0 24 24"
-                  fill="none"
-                  stroke="currentColor"
-                  strokeWidth="2"
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
                 >
-                  <path d="M20 11a8.1 8.1 0 0 0-15.5-2M4 4v5h5" />
-                  <path d="M4 13a8.1 8.1 0 0 0 15.5 2M20 20v-5h-5" />
-                </svg>
-              </button>
+                  <p className="m-0 font-semibold">
+                    GitLab authentication required
+                  </p>
+                  <p className="m-0 mt-1">
+                    {gitlabTokenCreated ? (
+                      <>
+                        Store the generated token as{" "}
+                        <code className={ui.guidanceCode}>
+                          {repository.credential.githubTokenSecretName}
+                        </code>{" "}
+                        in Keymaxxer when available (provider{" "}
+                        <code className={ui.guidanceCode}>gitlab</code>, account{" "}
+                        <code className={ui.guidanceCode}>
+                          {repository.forgeHost}/{repository.projectPath}
+                        </code>
+                        ). Or set ambient auth without Keymaxxer:{" "}
+                      </>
+                    ) : (
+                      <>
+                        Create a personal access token on this GitLab instance
+                        with API access for{" "}
+                        <code className={ui.guidanceCode}>
+                          {repository.projectPath}
+                        </code>
+                        . Store it in Keymaxxer when available, or set ambient
+                        auth:{" "}
+                      </>
+                    )}
+                    <code className={ui.guidanceCode}>GITLAB_TOKEN</code> or{" "}
+                    <code className={ui.guidanceCode}>
+                      glab auth login --hostname {repository.forgeHost}
+                    </code>{" "}
+                    before starting the Harness.
+                  </p>
+                  {addGitLabToken.isError ? (
+                    <p className="m-0 mt-1">
+                      Keymaxxer setup was cancelled or failed. Use ambient{" "}
+                      <code className={ui.guidanceCode}>GITLAB_TOKEN</code> or{" "}
+                      <code className={ui.guidanceCode}>glab auth login</code>{" "}
+                      and restart the Harness if Keymaxxer is unavailable.
+                    </p>
+                  ) : null}
+                </Banner>
+              )}
+            <div className={ui.repoIssues}>
+              <div className={ui.repoIssuesHead}>
+                <h3 className={ui.repoIssuesKicker}>
+                  {hasNoRelevantIssues
+                    ? "No relevant issues"
+                    : "Relevant issues"}
+                </h3>
+                <button
+                  type="button"
+                  className={ui.iconBtn}
+                  disabled={
+                    refreshingIssues || !repository.credential.configured
+                  }
+                  onClick={() => refreshIssues.mutate()}
+                  aria-label={
+                    refreshingIssues ? "Refreshing issues" : "Refresh issues"
+                  }
+                  title={
+                    repository.credential.configured
+                      ? "Refresh issues"
+                      : repository.forge === "gitlab"
+                        ? "Authenticate GitLab before refreshing issues"
+                        : "Add a GitHub token before refreshing issues"
+                  }
+                >
+                  <svg
+                    aria-hidden="true"
+                    className={
+                      refreshingIssues
+                        ? "animate-spin motion-reduce:animate-none"
+                        : undefined
+                    }
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth="2"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  >
+                    <path d="M20 11a8.1 8.1 0 0 0-15.5-2M4 4v5h5" />
+                    <path d="M4 13a8.1 8.1 0 0 0 15.5 2M20 20v-5h-5" />
+                  </svg>
+                </button>
+              </div>
+              {refreshIssues.isError && (
+                <Banner
+                  className={cx(ui.bannerCompact, "mb-2")}
+                  tone="alarm"
+                  tag="Error"
+                  role="alert"
+                >
+                  Failed to refresh issues.
+                </Banner>
+              )}
+              {repository.issuesReconciledAt === null ? (
+                <p className={ui.repoIssuesUnrefreshed}>Not refreshed yet.</p>
+              ) : (
+                <>
+                  {issuesProjectionStale && (
+                    <Banner
+                      className={cx(ui.bannerCompact, "mb-2")}
+                      tone="guidance"
+                      tag="Stale"
+                      role="status"
+                    >
+                      {formatLastRefreshedAgo(
+                        repository.issuesReconciledAt,
+                        nowMs,
+                      )}
+                      . Issues may be out of date.
+                    </Banner>
+                  )}
+                  <Suspense fallback={<RepositoryIssuesSkeleton />}>
+                    <RepositoryIssues
+                      repository={repository}
+                      workItems={workItems}
+                      workItemsLoading={workItemsLoading}
+                    />
+                  </Suspense>
+                </>
+              )}
             </div>
-            {refreshIssues.isError && (
+            {removeRepository.isError && (
               <Banner
-                className={cx(ui.bannerCompact, "mb-2")}
+                className={cx(ui.bannerCompact, "mt-3")}
                 tone="alarm"
                 tag="Error"
                 role="alert"
               >
-                Failed to refresh issues.
+                Could not remove repository. Please try again.
               </Banner>
             )}
-            {repository.issuesReconciledAt === null ? (
-              <p className={ui.repoIssuesUnrefreshed}>Not refreshed yet.</p>
-            ) : (
-              <>
-                {issuesProjectionStale && (
-                  <Banner
-                    className={cx(ui.bannerCompact, "mb-2")}
-                    tone="guidance"
-                    tag="Stale"
-                    role="status"
-                  >
-                    {formatLastRefreshedAgo(
-                      repository.issuesReconciledAt,
-                      nowMs,
-                    )}
-                    . Issues may be out of date.
-                  </Banner>
-                )}
-                <Suspense fallback={<RepositoryIssuesSkeleton />}>
-                  <RepositoryIssues
-                    repository={repository}
-                    workItems={workItems}
-                    workItemsLoading={workItemsLoading}
-                  />
-                </Suspense>
-              </>
-            )}
           </div>
-          {removeRepository.isError && (
-            <Banner
-              className={cx(ui.bannerCompact, "mt-3")}
-              tone="alarm"
-              tag="Error"
-              role="alert"
-            >
-              Could not remove repository. Please try again.
-            </Banner>
-          )}
-        </div>
-      )}
+        )}
+      </div>
     </article>
   )
 }
@@ -3912,9 +3958,12 @@ export function RepositoryCardsSkeleton() {
     >
       {[0, 1].map((item) => (
         <div className={ui.repoCardSkeleton} key={item}>
-          <span className={cx(ui.skeleton, "h-[0.85rem]", "w-[35%]")} />
-          <span className={cx(ui.skeleton, "h-[1.6rem]", "w-[65%]")} />
-          <span className={cx(ui.skeleton, "h-[0.85rem]", "w-[90%]")} />
+          <RepoCardRail />
+          <div className={ui.repoCardSkeletonInner}>
+            <span className={cx(ui.skeleton, "h-[0.85rem]", "w-[35%]")} />
+            <span className={cx(ui.skeleton, "h-[1.6rem]", "w-[65%]")} />
+            <span className={cx(ui.skeleton, "h-[0.85rem]", "w-[90%]")} />
+          </div>
         </div>
       ))}
     </section>

--- a/apps/harness/src/ui.ts
+++ b/apps/harness/src/ui.ts
@@ -40,6 +40,17 @@ const laneSwitchRivets = plateMiniRivets
 const cardMetalLight =
   "in-[html[data-theme=light]]:bg-[linear-gradient(165deg,rgb(255_255_255/0.72)_0%,rgb(255_255_255/0.18)_42%,transparent_68%),linear-gradient(180deg,#f0f2f0_0%,#e3e7e4_55%,#dfe4e1_100%)]"
 
+/**
+ * Forged repo-card frame shell: hard ink border around a dark metal casing.
+ * Shared verbatim by the populated card and its skeleton so the two cannot
+ * drift. Full static strings so Tailwind can scan them.
+ */
+const repoCardFrameShell =
+  "relative min-w-0 border-2 border-ink bg-[#252827] p-[3px]"
+
+const repoCardFrameCasing =
+  "[background-image:linear-gradient(90deg,#111413,#4c524f_48%,#151817)]"
+
 const mastScrollworkStroke =
   "[fill:none] [stroke-linecap:round] [stroke-linejoin:round]"
 
@@ -1141,13 +1152,56 @@ export const ui = {
   repoCards: "grid grid-cols-1 gap-6",
 
   /**
-   * Repo card. Dark-friendly solid panel; light theme adds brushed metal
-   * via `in-[html[data-theme=light]]:` arbitrary variant (shared with archiveRow).
+   * Forged repo-card frame: strong ink border + dark metal casing so every
+   * Repository reads as a Pipeline assembly rather than a thinly outlined
+   * neutral panel (§4.6). The dark casing shows through the small padding and
+   * around the six-color top rail; the body panel sits inside `repoCardInner`.
    */
   repoCard: cx(
-    "relative min-w-0 border-[1.5px] border-ink bg-panel px-[1.1rem] pt-4 pb-[1.15rem]",
+    repoCardFrameShell,
+    repoCardFrameCasing,
+    "shadow-[inset_0_1px_0_rgb(255_255_255/0.28),inset_0_-2px_2px_#000]",
+  ),
+
+  /**
+   * Body panel inside the forged frame: theme-aware fill (brushed metal in
+   * light, solid `--panel` in dark) with an inset edge for depth.
+   */
+  repoCardInner: cx(
+    "relative min-w-0 border border-black/50 bg-panel px-[1.1rem] pt-4 pb-[1.15rem]",
+    "shadow-[inset_0_1px_0_rgb(255_255_255/0.2),inset_0_-2px_3px_rgb(0_0_0/0.18)]",
     cardMetalLight,
   ),
+
+  /**
+   * Compact six-lane forged rail across the top of a repository card. The
+   * casing uses the same `#252827` forged-metal tone as the lane headers so
+   * the Merged segment's `#151515` fill stays distinguishable against its
+   * surround (the exact contrast Pipeline's `complete` sheet relies on). The
+   * hard `gap` separators and inset bevel keep each segment crisp; lane colors
+   * are supplied inline from `PIPELINE_LANES` (not here) so order and color
+   * cannot drift from the Pipeline lane assembly.
+   */
+  repoCardRail: cx(
+    "relative flex h-[0.55rem] gap-[2px] bg-[#252827] p-[2px]",
+    "shadow-[inset_0_1px_0_rgb(255_255_255/0.3),inset_0_-2px_2px_rgb(0_0_0/0.8)]",
+  ),
+
+  /** One equal rail segment — lane fill applied inline; this is bevel only. */
+  repoCardRailSegment: cx(
+    "relative min-w-0 flex-1",
+    "shadow-[inset_0_1px_0_rgb(255_255_255/0.42),inset_1px_0_0_rgb(255_255_255/0.14),inset_0_-2px_2px_rgb(0_0_0/0.5)]",
+  ),
+
+  /** Restrained steel rivet at each end of the top rail. */
+  repoCardRailRivet: cx(
+    "pointer-events-none absolute top-[0.14rem] z-[3] h-[0.24rem] w-[0.24rem] rounded-full",
+    "[background-image:radial-gradient(circle_at_32%_28%,#fff_0_6%,transparent_8%),radial-gradient(circle_at_36%_28%,#f5f8f6_0_18%,#aeb5b1_40%,#555c59_62%,#222625_80%,#9fa6a2_94%,#333735_100%)]",
+    "shadow-[0_0_0_1px_rgb(0_0_0/0.85)]",
+  ),
+
+  repoCardRailRivetL: "left-[0.3rem]",
+  repoCardRailRivetR: "right-[0.3rem]",
 
   repoCardHead:
     "flex flex-wrap items-start justify-between gap-x-4 gap-y-[0.6rem]",
@@ -1351,8 +1405,14 @@ export const ui = {
   /** guidance-code inside blank-slate (tighter padding, larger type) */
   blankSlateGuidanceCode: "mt-3 px-[0.7rem] py-[0.45rem] text-[0.82rem]",
 
-  repoCardSkeleton:
-    "grid gap-3 border-[1.5px] border-line-ghost bg-panel px-[1.1rem] py-4",
+  /**
+   * Skeleton mirrors the forged frame + top rail geometry so cards do not
+   * jump when the projection resolves (rail rendered by the skeleton markup).
+   */
+  repoCardSkeleton: cx(repoCardFrameShell, repoCardFrameCasing),
+
+  repoCardSkeletonInner:
+    "grid gap-3 bg-panel px-[1.1rem] py-4 border border-black/50",
 } as const satisfies Record<string, string>
 
 /*

--- a/apps/harness/test/repos-interchange.test.ts
+++ b/apps/harness/test/repos-interchange.test.ts
@@ -29,7 +29,7 @@ const sliceBetweenMarkers = (
  * Structural + design-token contract tests; no behavior changes.
  */
 describe("Interchange phase 4: repos page + blank slate", () => {
-  test("repo cards use 1.5px ticket shell, display title, mono PR count, icon controls", () => {
+  test("repo cards use a forged frame, display title, mono PR count, icon controls", () => {
     const source = homeSource()
     // Card chrome only (settings dialog stays on Ledger until phase 5).
     const head = sliceBetweenMarkers(
@@ -52,11 +52,45 @@ describe("Interchange phase 4: repos page + blank slate", () => {
 
     const ui = uiSource()
     expect(ui).toContain("repoCard:")
-    expect(ui).toMatch(/repoCard:[\s\S]*?border-\[1\.5px\]/)
-    expect(ui).toMatch(/repoCard:[\s\S]*?border-ink/)
+    // Shared forged frame shell carries the hard ink border + dark casing.
+    expect(ui).toContain(
+      '"relative min-w-0 border-2 border-ink bg-[#252827] p-[3px]"',
+    )
+    const cardFrame = sliceBetweenMarkers(ui, "repoCard: cx(", "repoCardInner:")
+    expect(cardFrame).toContain("repoCardFrameShell")
+    expect(cardFrame).toContain("repoCardFrameCasing")
+    expect(cardFrame).not.toContain("border-[1.5px]")
+    expect(ui).toContain("repoCardInner:")
     expect(ui).toContain("repoCardTitle:")
     expect(ui).toMatch(/repoCardTitle:[\s\S]*?text-\[1\.06rem\]/)
     expect(ui).toMatch(/repoCardLink:[\s\S]*?hover:decoration-signal/)
+  })
+
+  test("repo card uses a Pipeline-style forged frame and six-lane top rail", () => {
+    const source = homeSource()
+    const head = sliceBetweenMarkers(
+      source,
+      "className={ui.repoCard}",
+      "<dialog",
+    )
+    // One decorative rail per populated card, above the body panel.
+    expect(head).toContain("<RepoCardRail />")
+    expect(head).toContain("className={ui.repoCardInner}")
+    // Rail reuses canonical lane order/colors (no drift from Pipeline).
+    expect(source).toContain("PIPELINE_LANES")
+    expect(source).toContain('from "./pipeline-lanes.js"')
+
+    const ui = uiSource()
+    expect(ui).toContain("repoCardInner:")
+    expect(ui).toMatch(/repoCardInner:[\s\S]*?bg-panel/)
+    expect(ui).toContain("repoCardRail:")
+    expect(ui).toContain("repoCardRailSegment:")
+    expect(ui).toMatch(/repoCardRail:[\s\S]*?flex/)
+    expect(ui).toMatch(/repoCardRailSegment:[\s\S]*?flex-1/)
+    // Forged frame: dark metal casing via the shared shell, no 1.5px border.
+    const frame = sliceBetweenMarkers(ui, "repoCard: cx(", "repoCardInner:")
+    expect(frame).toContain("repoCardFrameShell")
+    expect(frame).not.toContain("border-[1.5px]")
   })
 
   test("meta table is hairline two-column mono dt/dd with harness-default annotations", () => {
@@ -242,11 +276,12 @@ describe("Interchange phase 4: repos page + blank slate", () => {
     )
     expect(card).toContain("const hasNoRelevantIssues =")
     expect(card).toContain("relevantIssues?.length === 0")
+    expect(card).toContain("<h3 className={ui.repoIssuesKicker}>")
+    expect(card).toContain("{hasNoRelevantIssues")
+    expect(card).toContain('? "No relevant issues"')
+    expect(card).toContain(': "Relevant issues"}')
     expect(card).toContain(
-      '<h3 className={ui.repoIssuesKicker}>\n                {hasNoRelevantIssues ? "No relevant issues" : "Relevant issues"}',
-    )
-    expect(card).toContain(
-      'aria-label={\n                  refreshingIssues ? "Refreshing issues" : "Refresh issues"',
+      'refreshingIssues ? "Refreshing issues" : "Refresh issues"',
     )
     expect(card).toContain("ui.repoIssuesUnrefreshed")
     // Stale projection caption (#951): guidance banner when issuesReconciledAt is old.
@@ -485,5 +520,69 @@ describe("Interchange phase 4: repos page + blank slate", () => {
     expect(ui).toMatch(/blankSlateFieldControl:[\s\S]*?flex-1/)
     expect(ui).toMatch(/blankSlateFieldControl:[\s\S]*?border-\[1\.5px\]/)
     expect(ui).toContain("platePrimary:")
+  })
+
+  test("every repo card carries one decorative six-lane top rail", () => {
+    const source = homeSource()
+    // One rail rendered per populated card, before the body panel, hidden
+    // from assistive technology and carrying no focusable/heading content.
+    const card = sliceBetweenMarkers(
+      source,
+      "function RepositoryCard(",
+      "function RepositoryIssues(",
+    )
+    expect(card).toContain("<RepoCardRail />")
+    expect(card.indexOf("<RepoCardRail />")).toBeLessThan(
+      card.indexOf("<div className={ui.repoCardInner}>"),
+    )
+    // Rail is decorative: aria-hidden, no headings, no labels, no buttons.
+    const rail = sliceBetweenMarkers(
+      source,
+      "function RepoCardRail() {",
+      "function RepositoryCard(",
+    )
+    expect(rail).toContain('aria-hidden="true"')
+    expect(rail).toContain("PIPELINE_LANES.map")
+    expect(rail).toContain("style={{ backgroundColor: lane.color }}")
+    expect(rail).not.toContain("<h1")
+    expect(rail).not.toContain("<h2")
+    expect(rail).not.toContain("<button")
+    expect(rail).not.toContain("aria-label")
+
+    const ui = uiSource()
+    expect(ui).toContain("repoCardRail:")
+    expect(ui).toContain("repoCardRailSegment:")
+    expect(ui).toMatch(/repoCardRail:[\s\S]*?flex/)
+    expect(ui).toMatch(/repoCardRailSegment:[\s\S]*?flex-1/)
+    // Casing is #252827, distinct from Merged's #151515 fill, so the final
+    // segment stays visible (Pipeline's complete-sheet contrast).
+    expect(ui).toMatch(/repoCardRail:[\s\S]*?bg-\[#252827\]/)
+    // Segments are equal-width; lane fill is external (PIPELINE_LANES), so the
+    // recipe must not hard-code a lane color.
+    const segment = sliceBetweenMarkers(
+      ui,
+      "repoCardRailSegment: cx(",
+      "repoCardRailRivet",
+    )
+    expect(segment).not.toContain("bg-lane-")
+    expect(segment).not.toContain("backgroundColor")
+  })
+
+  test("repo card skeleton mirrors the forged frame and rail geometry", () => {
+    const source = homeSource()
+    // RepositoryCardsSkeleton is the last declaration in the file.
+    const skeleton = source.slice(
+      source.indexOf("export function RepositoryCardsSkeleton("),
+    )
+    expect(skeleton).toContain("ui.repoCardSkeleton")
+    expect(skeleton).toContain("<RepoCardRail />")
+    expect(skeleton).toContain("ui.repoCardSkeletonInner")
+
+    const ui = uiSource()
+    expect(ui).toContain("repoCardSkeleton:")
+    expect(ui).toMatch(/repoCardSkeleton:[\s\S]*?repoCardFrameShell/)
+    expect(ui).toMatch(/repoCardSkeleton:[\s\S]*?repoCardFrameCasing/)
+    expect(ui).toContain("repoCardSkeletonInner:")
+    expect(ui).toMatch(/repoCardSkeletonInner:[\s\S]*?bg-panel/)
   })
 })

--- a/docs/harness-design-system.md
+++ b/docs/harness-design-system.md
@@ -218,9 +218,10 @@ prototypes.)
 ### 2.7 Borders, radius, shadows
 
 - **2px solid `var(--ink`)**: nameboards, banners, stats slab, tabs, primary
-  plates, queue-intake plate, dialog panels, menu panels.
-- **1.5px solid `var(--ink`)**: cards (tickets, archive rows, repo cards),
-  chips, legs, stamps, secondary buttons, fields.
+  plates, queue-intake plate, dialog panels, menu panels, repo cards (forged
+  frame with dark metal casing — see §4.6).
+- **1.5px solid `var(--ink`)**: cards (tickets, archive rows), chips, legs,
+  stamps, secondary buttons, fields.
 - **1px / hairline**: dividers on dark slabs (`rgb(255 255 255 / 0.14–0.22)`),
   `--line-soft` / `--line-ghost` separators, filter buttons.
 - **Radius: none.** The only circles are roundels and nav dots
@@ -448,11 +449,18 @@ not pure white, not brushed metal. No radius, no offset shadow.
 Repo cards and issue rows adopt the ticket language — the page has no
 prototype, so this spec governs:
 
-- **Repo card**: 1.5px ink-bordered card. Light mode: slight brushed-metal
-  fill (soft plate gradient, not flat white on paper). Dark mode: `--panel`.
-  Header: display-600 projectPath link (hover signal-underline) + mono
-  open-PR count; controls: collapse chevron, pause/start icon button, kebab
-  menu (§5.6).
+- **Repo card**: a Pipeline-style forged frame — 2px ink border around a dark
+  metal casing (`ui.repoCard`) holding a theme-aware body panel
+  (`ui.repoCardInner`: brushed-metal fill in light, `--panel` in dark). A
+  compact six-lane **top rail** (`ui.repoCardRail`) spans the full card width
+  beneath the frame, split into six equal beveled segments in canonical
+  Pipeline order (Queue → Build → Review → PR → Attention → Merged) whose
+  fills are drawn from `PIPELINE_LANES`. Two restrained steel end rivets cap
+  the rail. The rail is a decorative ornament — `aria-hidden`, no labels or
+  headings — and stays visible when the card is collapsed. Header: display-600
+  projectPath link (hover signal-underline) +
+  mono open-PR count; controls: collapse chevron, pause/start icon button,
+  kebab menu (§5.6).
 - **Meta table**: hairline top/bottom borders, two columns — mono uppercase
   dt labels, mono values with inherit annotations ("Harness default (x)").
 - **Credential banners**: standard banner pattern (§4.8), attention tag —


### PR DESCRIPTION
The populated /repos surface read flat next to the Pipeline board:
Repository cards sat on a thin 1.5px neutral outline, while Pipeline
renders as a forged industrial assembly. This gives every Repository
card the same visual weight and ties it to the six-lifecycle-lane
language.

- Repo cards now use a forged outer frame — a 2px ink border around a
  dark metal casing (`ui.repoCard`) — with the body on a theme-aware
  panel (`ui.repoCardInner`: brushed metal in light, `--panel` in dark).
- A compact six-lane rail spans the top of each card in canonical
  Pipeline order — Queue, Build, Review, PR, Attention, Merged — derived
  from `PIPELINE_LANES`, so order and colors cannot drift. The rail is
  decorative (`aria-hidden`, no headings/labels) and stays visible when
  the card collapses.
- The frame shell and casing are shared consts reused by the card
  skeleton so the list cannot jump on load.
- Updated `docs/harness-design-system.md` (§2.7 and §4.6) and the Repos
  design-contract tests.

Out of scope: no data, GraphQL, mutation, collapse/dialog, or lifecycle
behavior changes; the blank slate and add-Repository guidance are
untouched.

Verified: `harness:lint`, `harness:typecheck`, and `harness:test`
(669 bun + 128 vitest) pass.

Closes #1088