### PR TITLE
fix(harness): constrain explicit execution-profile summary width in Work Item cards

### DIFF
--- a/apps/harness/src/execution-profile-summary.tsx
+++ b/apps/harness/src/execution-profile-summary.tsx
@@ -1,6 +1,6 @@
 import type { ReactNode } from "react"
 import { formatVariantLabel } from "./agent-model-settings.js"
-import { ui } from "./ui.js"
+import { cx, ui } from "./ui.js"
 
 export type WorkItemExecutionProfileView = {
   readonly backend: { readonly id: string; readonly label: string }
@@ -42,7 +42,7 @@ export function ExecutionProfileSummary({
         thinkingLevel: profile.reviewThinkingLevel,
       })
   return (
-    <div className={className} data-execution-profile>
+    <div className={cx("min-w-0 max-w-full", className)} data-execution-profile>
       <p className={ui.jobTicketRuntimeLine}>
         Explicit Work Item Execution Profile
       </p>

--- a/apps/harness/test/execution-profile-summary.test.tsx
+++ b/apps/harness/test/execution-profile-summary.test.tsx
@@ -46,4 +46,28 @@ describe("ExecutionProfileSummary", () => {
     expect(html).toContain("Review Same as build")
     expect(html).not.toContain("Review grok-code")
   })
+
+  test("root wrapper constrains width with shrink/min-width and preserves caller className", () => {
+    const html = renderToStaticMarkup(
+      <ExecutionProfileSummary
+        className="mt-[0.25rem]"
+        profile={{
+          backend: {
+            id: "opencode",
+            label: "OpenCode",
+          },
+          buildModel:
+            "anthropic/claude-sonnet-4-20250514/qualified-very-long-provider-model-identifier",
+          buildThinkingLevel: "extended",
+          reviewSameAsBuild: false,
+          reviewModel:
+            "openai/gpt-5.1/qualified-very-long-provider-model-identifier",
+          reviewThinkingLevel: "extended",
+        }}
+      />,
+    )
+    expect(html).toMatch(
+      /<div class="min-w-0 max-w-full mt-\[0\.25rem\]" data-execution-profile/,
+    )
+  })
 })


### PR DESCRIPTION
## Why

Work Items started through **Implement with...** render an
`ExecutionProfileSummary` showing the explicit backend, build
model/Thinking Level, and review model/Thinking Level. Its root `<div>`
carried only the optional caller `className`, so as a direct grid item it
kept the default `min-width: auto`. Long no-wrap model labels gave the
wrapper an intrinsic width wider than the card, and the child lines'
`max-w-full` resolved against that oversized wrapper — leaving the
ellipsis chain unable to contain the block. Session IDs then painted past
the right edge, hiding the trailing copy button. This regressed the
containment guarantees added in #733 when explicit profile chrome landed
in #1081.

## What changed

- `ExecutionProfileSummary` now merges structural `min-w-0 max-w-full`
  into its root wrapper via the existing `cx` helper, alongside the caller
  `className`. This lets the wrapper shrink with its grid track so the
  runtime lines' `max-w-full`/ellipsis behavior re-contains the block.
- Applied in the shared component, so Pipeline tickets, non-compact Repos
  lifecycle chrome, and Completed history all receive the same containment
  behavior. Caller styling (e.g. Completed history's `mt-[0.25rem]`) is
  preserved.

Full profile values remain available through the existing visible
text/title/copy behavior; nothing is hidden or discarded, and
settings-resolved Work Items continue to omit the summary.

## Verification

- Added focused regression coverage with qualified long provider/model
  identifiers, asserting the wrapper carries both `min-w-0 max-w-full`
  and the caller class.
- `bunx nx run harness:test`, `bunx nx run harness:lint`, and
  `bunx nx run harness:typecheck` all pass.

Closes #1090