### PR TITLE
fix(harness): keep Implement With model choices valid after idle catalog refetch

### DIFF
--- a/apps/harness/src/execution-profile-draft.ts
+++ b/apps/harness/src/execution-profile-draft.ts
@@ -129,23 +129,71 @@ export const executionProfileInputFromDraft = (input: {
   }
 }
 
+type PreviewCatalogSnapshot = {
+  readonly kind: string
+  readonly models: readonly AgentModelOption[]
+}
+
+/** First READY catalog accepted for one Agent Backend in one dialog session. */
+export type ImplementWithCatalogPin = {
+  readonly models: readonly AgentModelOption[]
+}
+
 /**
- * READY preview catalogs stay usable even when a later refetch fails (React
- * Query keeps the last successful data). Only an explicit non-READY inspect
- * or a failure with no cached READY catalog is empty/failed.
+ * Remember the first READY preview for this backend. Later previews — failed,
+ * empty, Unavailable, or READY with a different list — do not replace it.
+ */
+export const nextImplementWithCatalogPin = (input: {
+  readonly pin: ImplementWithCatalogPin | undefined
+  readonly preview: PreviewCatalogSnapshot | undefined
+}): ImplementWithCatalogPin | undefined => {
+  if (input.pin !== undefined) {
+    return input.pin
+  }
+  if (input.preview?.kind === "READY") {
+    return { models: input.preview.models }
+  }
+  return undefined
+}
+
+/**
+ * Withhold leftover query cache from a new dialog session until this observer
+ * has fetched. An in-session pin may still see cached preview while a
+ * backend switch-back refetches.
+ */
+export const implementWithSessionPreview = (input: {
+  readonly pin: ImplementWithCatalogPin | undefined
+  readonly preview: PreviewCatalogSnapshot | undefined
+  readonly fetchedAfterMount: boolean
+  readonly previewFailed: boolean
+}): {
+  readonly preview: PreviewCatalogSnapshot | undefined
+  readonly previewFailed: boolean
+} => {
+  if (input.pin !== undefined || input.fetchedAfterMount) {
+    return {
+      preview: input.preview,
+      previewFailed: input.previewFailed,
+    }
+  }
+  return { preview: undefined, previewFailed: false }
+}
+
+/**
+ * If a pin exists it is the catalog. Otherwise a READY preview is usable and
+ * any other settled preview is empty/failed.
  */
 export const usablePreviewCatalog = (input: {
-  readonly preview:
-    | {
-        readonly kind: string
-        readonly models: readonly AgentModelOption[]
-      }
-    | undefined
+  readonly preview: PreviewCatalogSnapshot | undefined
   readonly previewFailed: boolean
+  readonly pin?: ImplementWithCatalogPin
 }): {
   readonly models: readonly AgentModelOption[] | undefined
   readonly failed: boolean
 } => {
+  if (input.pin !== undefined) {
+    return { models: input.pin.models, failed: false }
+  }
   if (input.preview?.kind === "READY") {
     return { models: input.preview.models, failed: false }
   }

--- a/apps/harness/src/implement-with-issue-dialog.tsx
+++ b/apps/harness/src/implement-with-issue-dialog.tsx
@@ -1,10 +1,13 @@
 import { useQuery } from "@tanstack/react-query"
-import { type ReactNode, useState } from "react"
+import { type ReactNode, useRef, useState } from "react"
 import type { AgentModelOption } from "./agent-model-settings.js"
 import {
   type ExecutionProfileDraft,
   type ExecutionProfilePrefSource,
+  type ImplementWithCatalogPin,
   type ImplementWithSubmitInput,
+  implementWithSessionPreview,
+  nextImplementWithCatalogPin,
   resolveExecutionProfileDraft,
   usablePreviewCatalog,
 } from "./execution-profile-draft.js"
@@ -58,6 +61,9 @@ export function ImplementWithIssueDialog({
   onCancel,
 }: ImplementWithIssueDialogProps): ReactNode {
   const [backendId, setBackendId] = useState(initialBackendId)
+  const catalogPinsRef = useRef<
+    Readonly<Record<string, ImplementWithCatalogPin>>
+  >({})
   const agentBackends = useQuery(agentBackendsQuery)
   const harnessPrefs = useQuery({
     queryKey: ["implement-with", "harness-prefs", backendId] as const,
@@ -96,6 +102,11 @@ export function ImplementWithIssueDialog({
   })
   const preview = useQuery({
     queryKey: ["implement-with", "preview", backendId] as const,
+    staleTime: 0,
+    gcTime: 0,
+    refetchOnWindowFocus: false,
+    refetchOnReconnect: false,
+    refetchInterval: false,
     queryFn: async () => {
       const result = await graphql.query({
         previewAgentBackend: {
@@ -133,9 +144,30 @@ export function ImplementWithIssueDialog({
             }),
           ),
         }
-  const usableCatalog = usablePreviewCatalog({
+  const existingPin = catalogPinsRef.current[backendId]
+  const sessionPreview = implementWithSessionPreview({
+    pin: existingPin,
     preview: mappedPreview,
+    fetchedAfterMount: preview.isFetchedAfterMount,
     previewFailed: preview.isError,
+  })
+  const catalogPin = nextImplementWithCatalogPin({
+    pin: existingPin,
+    preview: sessionPreview.preview,
+  })
+  if (
+    catalogPin !== undefined &&
+    catalogPinsRef.current[backendId] === undefined
+  ) {
+    catalogPinsRef.current = {
+      ...catalogPinsRef.current,
+      [backendId]: catalogPin,
+    }
+  }
+  const usableCatalog = usablePreviewCatalog({
+    preview: sessionPreview.preview,
+    previewFailed: sessionPreview.previewFailed,
+    pin: catalogPin,
   })
   const catalogFailed = usableCatalog.failed
   const catalogError = catalogFailed
@@ -146,7 +178,7 @@ export function ImplementWithIssueDialog({
       : (preview.data?.reason ?? "Could not load the Agent Model catalog.")
     : null
   const catalog = {
-    loading: preview.isPending && usableCatalog.models === undefined,
+    loading: usableCatalog.models === undefined && !catalogFailed,
     failed: catalogFailed,
     error: catalogError,
     models: usableCatalog.models,

--- a/apps/harness/test/execution-profile-draft.test.ts
+++ b/apps/harness/test/execution-profile-draft.test.ts
@@ -1,6 +1,9 @@
+import { isUnavailableCatalogModel } from "../src/agent-model-settings.js"
 import {
   executionProfileInputFromDraft,
   implementWithCatalogBlockReason,
+  implementWithSessionPreview,
+  nextImplementWithCatalogPin,
   reconcileExecutionProfileDraft,
   resolveExecutionProfileDraft,
   usablePreviewCatalog,
@@ -141,6 +144,19 @@ describe("usablePreviewCatalog", () => {
     kind: "READY",
     models: [{ id: "sonnet", thinkingLevels: ["low", "high"] }],
   }
+  const laterReady = {
+    kind: "READY",
+    models: [{ id: "haiku", thinkingLevels: ["low"] }],
+  }
+
+  const catalogMember = (
+    usable: { readonly models: readonly { readonly id: string }[] | undefined },
+    modelId: string,
+  ): boolean =>
+    !isUnavailableCatalogModel({
+      modelId,
+      catalogModelIds: (usable.models ?? []).map((model) => model.id),
+    })
 
   test("keeps a cached READY catalog when a later preview fails", () => {
     expect(
@@ -164,6 +180,236 @@ describe("usablePreviewCatalog", () => {
         previewFailed: false,
       }),
     ).toEqual({ models: [], failed: true })
+  })
+
+  test("keeps the first READY catalog when a later preview is Unavailable, failed, or empty", () => {
+    const pin = nextImplementWithCatalogPin({
+      pin: undefined,
+      preview: ready,
+    })
+    expect(
+      usablePreviewCatalog({
+        preview: { kind: "UNAVAILABLE", models: [] },
+        previewFailed: false,
+        pin,
+      }),
+    ).toEqual({ models: ready.models, failed: false })
+    expect(
+      usablePreviewCatalog({
+        preview: undefined,
+        previewFailed: true,
+        pin,
+      }),
+    ).toEqual({ models: ready.models, failed: false })
+    expect(
+      usablePreviewCatalog({
+        preview: { kind: "READY", models: [] },
+        previewFailed: false,
+        pin,
+      }),
+    ).toEqual({ models: ready.models, failed: false })
+  })
+
+  test("keeps the first READY catalog when a later preview is READY with a different list", () => {
+    const pin = nextImplementWithCatalogPin({
+      pin: undefined,
+      preview: ready,
+    })
+    expect(
+      usablePreviewCatalog({
+        preview: laterReady,
+        previewFailed: false,
+        pin,
+      }),
+    ).toEqual({ models: ready.models, failed: false })
+  })
+
+  test("a model listed only in the first READY catalog stays a member after a later preview", () => {
+    const pin = nextImplementWithCatalogPin({
+      pin: undefined,
+      preview: ready,
+    })
+    const usable = usablePreviewCatalog({
+      preview: laterReady,
+      previewFailed: false,
+      pin,
+    })
+    expect(catalogMember(usable, "sonnet")).toBe(true)
+  })
+
+  test("a model absent from the first READY catalog stays a non-member", () => {
+    const pin = nextImplementWithCatalogPin({
+      pin: undefined,
+      preview: ready,
+    })
+    const usable = usablePreviewCatalog({
+      preview: laterReady,
+      previewFailed: false,
+      pin,
+    })
+    expect(catalogMember(usable, "haiku")).toBe(false)
+    expect(catalogMember(usable, "never-listed")).toBe(false)
+  })
+
+  test("with no prior READY catalog, Unavailable, failed, and loading stay as today", () => {
+    expect(
+      nextImplementWithCatalogPin({
+        pin: undefined,
+        preview: { kind: "UNAVAILABLE", models: [] },
+      }),
+    ).toBeUndefined()
+    expect(
+      nextImplementWithCatalogPin({
+        pin: undefined,
+        preview: undefined,
+      }),
+    ).toBeUndefined()
+    expect(
+      usablePreviewCatalog({
+        preview: { kind: "UNAVAILABLE", models: [] },
+        previewFailed: false,
+        pin: undefined,
+      }),
+    ).toEqual({ models: [], failed: true })
+    expect(
+      usablePreviewCatalog({
+        preview: undefined,
+        previewFailed: true,
+        pin: undefined,
+      }),
+    ).toEqual({ models: undefined, failed: true })
+    expect(
+      usablePreviewCatalog({
+        preview: undefined,
+        previewFailed: false,
+        pin: undefined,
+      }),
+    ).toEqual({ models: undefined, failed: false })
+  })
+
+  test("a new dialog session with no pin uses the new preview", () => {
+    expect(
+      nextImplementWithCatalogPin({
+        pin: undefined,
+        preview: laterReady,
+      }),
+    ).toEqual({ models: laterReady.models })
+    expect(
+      usablePreviewCatalog({
+        preview: laterReady,
+        previewFailed: false,
+        pin: undefined,
+      }),
+    ).toEqual({ models: laterReady.models, failed: false })
+  })
+
+  test("a new session does not pin leftover cached READY before this observer fetches", () => {
+    const leftover = implementWithSessionPreview({
+      pin: undefined,
+      preview: ready,
+      fetchedAfterMount: false,
+      previewFailed: false,
+    })
+    expect(leftover).toEqual({ preview: undefined, previewFailed: false })
+    const pin = nextImplementWithCatalogPin({
+      pin: undefined,
+      preview: leftover.preview,
+    })
+    expect(pin).toBeUndefined()
+    expect(
+      usablePreviewCatalog({
+        preview: leftover.preview,
+        previewFailed: leftover.previewFailed,
+        pin,
+      }),
+    ).toEqual({ models: undefined, failed: false })
+  })
+
+  test("a new session uses the remount fetch, not leftover cached READY", () => {
+    const afterUnavailable = implementWithSessionPreview({
+      pin: undefined,
+      preview: { kind: "UNAVAILABLE", models: [] },
+      fetchedAfterMount: true,
+      previewFailed: false,
+    })
+    const unavailablePin = nextImplementWithCatalogPin({
+      pin: undefined,
+      preview: afterUnavailable.preview,
+    })
+    expect(
+      usablePreviewCatalog({
+        preview: afterUnavailable.preview,
+        previewFailed: afterUnavailable.previewFailed,
+        pin: unavailablePin,
+      }),
+    ).toEqual({ models: [], failed: true })
+
+    const afterDifferentReady = implementWithSessionPreview({
+      pin: undefined,
+      preview: laterReady,
+      fetchedAfterMount: true,
+      previewFailed: false,
+    })
+    const freshPin = nextImplementWithCatalogPin({
+      pin: undefined,
+      preview: afterDifferentReady.preview,
+    })
+    expect(
+      usablePreviewCatalog({
+        preview: afterDifferentReady.preview,
+        previewFailed: afterDifferentReady.previewFailed,
+        pin: freshPin,
+      }),
+    ).toEqual({ models: laterReady.models, failed: false })
+  })
+
+  test("an in-session pin still applies while a backend switch-back is refetching", () => {
+    const pin = nextImplementWithCatalogPin({
+      pin: undefined,
+      preview: ready,
+    })
+    const refetching = implementWithSessionPreview({
+      pin,
+      preview: laterReady,
+      fetchedAfterMount: false,
+      previewFailed: false,
+    })
+    expect(
+      usablePreviewCatalog({
+        preview: refetching.preview,
+        previewFailed: refetching.previewFailed,
+        pin,
+      }),
+    ).toEqual({ models: ready.models, failed: false })
+  })
+
+  test("switching backends reuses this session's first READY catalog for that backend", () => {
+    const opencodePin = nextImplementWithCatalogPin({
+      pin: undefined,
+      preview: ready,
+    })
+    const grokReady = {
+      kind: "READY",
+      models: [{ id: "grok-code", thinkingLevels: ["low"] }],
+    }
+    const grokPin = nextImplementWithCatalogPin({
+      pin: undefined,
+      preview: grokReady,
+    })
+    expect(
+      usablePreviewCatalog({
+        preview: laterReady,
+        previewFailed: false,
+        pin: opencodePin,
+      }),
+    ).toEqual({ models: ready.models, failed: false })
+    expect(
+      usablePreviewCatalog({
+        preview: { kind: "UNAVAILABLE", models: [] },
+        previewFailed: false,
+        pin: grokPin,
+      }),
+    ).toEqual({ models: grokReady.models, failed: false })
   })
 })
 

--- a/apps/harness/test/implement-with-dialog.test.tsx
+++ b/apps/harness/test/implement-with-dialog.test.tsx
@@ -1,8 +1,14 @@
+import { readFileSync } from "node:fs"
+import { join } from "node:path"
 import { Window } from "happy-dom"
 import { flushSync } from "react-dom"
 import { createRoot } from "react-dom/client"
 import { renderToStaticMarkup } from "react-dom/server"
-import type { ImplementWithSubmitInput } from "../src/execution-profile-draft.js"
+import {
+  type ImplementWithSubmitInput,
+  nextImplementWithCatalogPin,
+  usablePreviewCatalog,
+} from "../src/execution-profile-draft.js"
 import {
   ImplementWithDialog,
   type ImplementWithDialogProps,
@@ -240,6 +246,174 @@ describe("ImplementWithDialog copy and catalog", () => {
     expect(html).toMatch(/type="submit"[^>]*disabled/)
     expect(html).not.toContain("Recheck")
     expect(html).not.toContain('href="/settings"')
+  })
+
+  test("a later different READY list keeps Implement enabled and membership banners down", () => {
+    const firstReady = {
+      kind: "READY",
+      models: catalogModels,
+    }
+    const pin = nextImplementWithCatalogPin({
+      pin: undefined,
+      preview: firstReady,
+    })
+    const usable = usablePreviewCatalog({
+      preview: {
+        kind: "READY",
+        models: [{ id: "other-provider-id", thinkingLevels: [] }],
+      },
+      previewFailed: false,
+      pin,
+    })
+    const html = renderToStaticMarkup(
+      <ImplementWithDialog
+        {...baseProps}
+        catalog={{
+          loading: false,
+          failed: usable.failed,
+          error: null,
+          models: usable.models,
+          warnings: [],
+        }}
+      />,
+    )
+    expect(html).not.toContain(
+      "The selected model is not in the current Agent Model catalog",
+    )
+    expect(html).not.toContain(
+      "Build effort (thinking) is unavailable — the selected model is",
+    )
+    expect(html).toContain('name="buildThinkingLevel"')
+    expect(html).toContain('value="high"')
+    expect(html).toContain(">Same as build</option>")
+    expect(html).not.toMatch(/type="submit"[^>]*\sdisabled=/)
+    expect(html).toMatch(/name="autoMerge"/)
+    expect(html).toMatch(/name="implementLocally"/)
+    expect(html).not.toMatch(/name="autoMerge"[^>]*checked/)
+    expect(html).not.toMatch(/name="implementLocally"[^>]*checked/)
+  })
+
+  test("an explicit review model from the first READY catalog stays valid after a later list", () => {
+    const firstReady = {
+      kind: "READY",
+      models: catalogModels,
+    }
+    const pin = nextImplementWithCatalogPin({
+      pin: undefined,
+      preview: firstReady,
+    })
+    const usable = usablePreviewCatalog({
+      preview: { kind: "UNAVAILABLE", models: [] },
+      previewFailed: false,
+      pin,
+    })
+    const html = renderToStaticMarkup(
+      <ImplementWithDialog
+        {...baseProps}
+        initialDraft={{
+          buildModel: "sonnet",
+          buildThinkingLevel: "high",
+          reviewSameAsBuild: false,
+          reviewModel: "haiku",
+          reviewThinkingLevel: "low",
+        }}
+        catalog={{
+          loading: false,
+          failed: usable.failed,
+          error: null,
+          models: usable.models,
+          warnings: [],
+        }}
+      />,
+    )
+    expect(html).not.toContain(
+      "The selected model is not in the current Agent Model catalog",
+    )
+    expect(html).not.toContain(
+      "Review effort (thinking) is unavailable — the selected model is",
+    )
+    expect(html).toContain('name="reviewThinkingLevel"')
+    expect(html).toContain('value="low"')
+    expect(html).not.toMatch(/type="submit"[^>]*\sdisabled=/)
+  })
+
+  test("a model never in the first READY catalog stays unavailable after pinning", () => {
+    const firstReady = {
+      kind: "READY",
+      models: catalogModels,
+    }
+    const pin = nextImplementWithCatalogPin({
+      pin: undefined,
+      preview: firstReady,
+    })
+    const usable = usablePreviewCatalog({
+      preview: {
+        kind: "READY",
+        models: [
+          ...catalogModels,
+          { id: "ghost", thinkingLevels: ["low"], name: "Ghost" },
+        ],
+      },
+      previewFailed: false,
+      pin,
+    })
+    const html = renderToStaticMarkup(
+      <ImplementWithDialog
+        {...baseProps}
+        initialDraft={{
+          buildModel: "ghost",
+          buildThinkingLevel: "low",
+          reviewSameAsBuild: true,
+        }}
+        catalog={{
+          loading: false,
+          failed: usable.failed,
+          error: null,
+          models: usable.models,
+          warnings: [],
+        }}
+      />,
+    )
+    expect(html).toContain(
+      "The selected model is not in the current Agent Model catalog. Choose a listed model.",
+    )
+    expect(html).toMatch(/type="submit"[^>]*disabled/)
+  })
+
+  test("a blank required build model stays blank when a catalog is pinned", () => {
+    const firstReady = {
+      kind: "READY",
+      models: catalogModels,
+    }
+    const pin = nextImplementWithCatalogPin({
+      pin: undefined,
+      preview: firstReady,
+    })
+    const usable = usablePreviewCatalog({
+      preview: firstReady,
+      previewFailed: false,
+      pin,
+    })
+    const html = renderToStaticMarkup(
+      <ImplementWithDialog
+        {...baseProps}
+        initialDraft={{
+          buildModel: "",
+          buildThinkingLevel: "",
+          reviewSameAsBuild: true,
+        }}
+        catalog={{
+          loading: false,
+          failed: usable.failed,
+          error: null,
+          models: usable.models,
+          warnings: [],
+        }}
+      />,
+    )
+    expect(html).toContain(">Select a build model</option>")
+    expect(html).toContain("Select a model from the Agent Model catalog.")
+    expect(html).toMatch(/type="submit"[^>]*disabled/)
   })
 
   test("an empty catalog cannot be submitted and explains why", () => {
@@ -602,6 +776,56 @@ describe("ImplementWithDialog interaction", () => {
     expect(second).not.toMatch(/name="implementLocally"[^>]*checked/)
   })
 
+  test("catalog pinning does not reset Auto-merge or Implement locally", () => {
+    const firstReady = {
+      kind: "READY",
+      models: catalogModels,
+    }
+    const pin = nextImplementWithCatalogPin({
+      pin: undefined,
+      preview: firstReady,
+    })
+    const replaced = usablePreviewCatalog({
+      preview: {
+        kind: "READY",
+        models: [{ id: "other-provider-id", thinkingLevels: [] }],
+      },
+      previewFailed: false,
+      pin,
+    })
+    const { node, rerender } = render({ initialAutoMerge: true })
+    const implementLocally = node.querySelector(
+      'input[name="implementLocally"]',
+    ) as HTMLInputElement
+    flushSync(() => {
+      toggleCheckbox(implementLocally, true)
+    })
+    rerender({
+      catalog: {
+        loading: false,
+        failed: replaced.failed,
+        error: null,
+        models: replaced.models,
+        warnings: [],
+      },
+    })
+    expect(
+      (node.querySelector('input[name="autoMerge"]') as HTMLInputElement)
+        .checked,
+    ).toBe(true)
+    expect(
+      (node.querySelector('input[name="implementLocally"]') as HTMLInputElement)
+        .checked,
+    ).toBe(true)
+    const implement = [...node.querySelectorAll("button")].find(
+      (button) => button.textContent === "Implement",
+    )
+    expect(implement?.disabled).toBe(false)
+    expect(node.textContent).not.toContain(
+      "The selected model is not in the current Agent Model catalog",
+    )
+  })
+
   test("a failed backend does not disable switching to another shipped backend", () => {
     const { node, backendChanges } = render({
       catalog: {
@@ -619,5 +843,28 @@ describe("ImplementWithDialog interaction", () => {
       fire(backend, "change")
     })
     expect(backendChanges).toEqual(["claude"])
+  })
+})
+
+describe("Implement With preview query contract", () => {
+  test("does not refetch the preview on focus, reconnect, or an interval", () => {
+    const source = readFileSync(
+      join(import.meta.dir, "../src/implement-with-issue-dialog.tsx"),
+      "utf8",
+    )
+    const previewStart = source.indexOf(
+      'queryKey: ["implement-with", "preview"',
+    )
+    expect(previewStart).toBeGreaterThan(-1)
+    const preview = source.slice(
+      previewStart,
+      source.indexOf("return result.previewAgentBackend", previewStart),
+    )
+    expect(preview).toContain("refetchOnWindowFocus: false")
+    expect(preview).toContain("refetchOnReconnect: false")
+    expect(preview).toContain("refetchInterval: false")
+    expect(preview).toContain("gcTime: 0")
+    expect(source).toContain("implementWithSessionPreview")
+    expect(source).toContain("isFetchedAfterMount")
   })
 })


### PR DESCRIPTION
## Why

Implement With catalog membership is exact-string inclusion. After idle —
often a tab blur — a later Agent Backend Preview could replace the catalog
the operator was already using. A successful Unavailable inspect or a READY
list with different model IDs then marked unchanged prefs unavailable and
blocked Implement.

The membership check was correct. The open dialog treated a later preview
as a new catalog (#1098).

## What changed

For one open dialog and one Agent Backend, the first READY catalog is
pinned until the dialog unmounts:

- Later Unavailable, failed, empty, loading, or different READY results
  cannot flip membership, Thinking Levels, or Implement enablement.
- Changing Agent Backend still loads that backend's preview. Switching
  back reuses this session's pin.
- Closing the dialog drops every pin. A new open withholds leftover React
  Query cache until this observer has fetched (`isFetchedAfterMount`) and
  garbage-collects the preview query (`gcTime: 0`) so reopen is a new
  session.
- Window-focus, reconnect, and interval refetch are disabled. First load
  and backend change still fetch.

Catalog-only selectors, fail-closed `implementWith` submit, Settings, and
Recheck Agent Backend are unchanged.

## Verification

- Pin and session-preview unit tests: leftover cache is not pinned; remount
  Unavailable or a different READY list is used; an in-session pin still
  applies during refetch.
- Dialog tests: Implement stays enabled and membership banners stay down
  when the first READY list contained the selections.
- Source contract: preview query sets `refetchOnWindowFocus`,
  `refetchOnReconnect`, and `refetchInterval` to false, plus `gcTime: 0`
  and `implementWithSessionPreview`.
- `bunx nx test harness` passed.

No Playwright or live OpenCode inspect. Server submit still fail-closes if
the chosen model is missing from the inspect at create time.

Closes #1098