### PR TITLE
feat(cli): report retry eligibility and Step Run reasons in status

### DIFF
--- a/apps/harness/e2e/steps/repository-intake-cli.ts
+++ b/apps/harness/e2e/steps/repository-intake-cli.ts
@@ -278,6 +278,12 @@ Then("status JSON includes the sentinel Work Item", async ({ world }) => {
         id: string
         issueNumber: number
         issueTitle: string | null
+        canRetry: boolean
+        latestStepRunReason: {
+          code: string | null
+          message: string | null
+          detail: unknown
+        } | null
       }>
     }>
   }
@@ -288,6 +294,11 @@ Then("status JSON includes the sentinel Work Item", async ({ world }) => {
     (row) => row.issueNumber === GITHUB_SENTINEL_ISSUE_NUMBER,
   )
   expect(sentinelRow).toBeDefined()
+  expect(typeof sentinelRow?.canRetry).toBe("boolean")
+  expect(
+    sentinelRow?.latestStepRunReason === null ||
+      typeof sentinelRow?.latestStepRunReason === "object",
+  ).toBe(true)
   const expectedId = world.intakeCreatedWorkItemId as string | undefined
   if (expectedId !== undefined) {
     expect(sentinelRow?.id).toBe(expectedId)

--- a/apps/ready-for-agent/src/cli-json.test.ts
+++ b/apps/ready-for-agent/src/cli-json.test.ts
@@ -62,6 +62,8 @@ describe("finite CLI JSON contract", () => {
               status: "WAITING_FOR_BLOCKERS",
               statusMessage: "Waiting for blocking Issues",
               paused: false,
+              canRetry: false,
+              latestStepRunReason: null,
               pullRequestNumber: null,
               createdAt: "2026-08-12T10:00:00.000Z",
               updatedAt: "2026-08-12T10:00:00.000Z",
@@ -82,8 +84,165 @@ describe("finite CLI JSON contract", () => {
     expect(doc.repository).toBeNull()
     expect(doc.lanes).toHaveLength(6)
     expect(doc.lanes[0]?.workItems[0]?.pullRequestNumber).toBeNull()
+    expect(doc.lanes[0]?.workItems[0]?.canRetry).toBe(false)
+    expect(doc.lanes[0]?.workItems[0]?.latestStepRunReason).toBeNull()
     expect(encodeCompactJson(doc)).toContain('"command":"status"')
     expect(encodeCompactJson(doc)).toContain('"pullRequestNumber":null')
+    expect(encodeCompactJson(doc)).toContain('"canRetry":false')
+  })
+
+  test("status rows carry canRetry and latest Step Run reason additively on schemaVersion 1", () => {
+    const doc = buildStatusSuccessDocument({
+      repository: null,
+      lanes: [
+        {
+          id: "ATTENTION",
+          label: "Attention",
+          count: 4,
+          workItems: [
+            {
+              repository: {
+                id: "repo-1",
+                forge: "github",
+                forgeHost: "github.com",
+                projectPath: "owner/repo",
+              },
+              id: "wi-retryable-failed",
+              issueNumber: 10,
+              issueTitle: "Retryable implement failure",
+              state: "IMPLEMENT",
+              status: "FAILED",
+              statusMessage:
+                "Claude Code failed to implement the Work Item issue",
+              paused: false,
+              canRetry: true,
+              latestStepRunReason: {
+                code: "handler_failed",
+                message: "Claude Code failed to implement the Work Item issue",
+                detail: {
+                  code: "ENOENT",
+                  causeChain: [
+                    {
+                      name: "Error",
+                      code: "ENOENT",
+                      message:
+                        'ENOENT: Executable not found in $PATH: "claude"',
+                    },
+                  ],
+                },
+              },
+              pullRequestNumber: null,
+              createdAt: "2026-08-12T10:00:00.000Z",
+              updatedAt: "2026-08-12T10:00:00.000Z",
+              stateReadyAt: "2026-08-12T10:00:00.000Z",
+              postponedUntil: null,
+            },
+            {
+              repository: {
+                id: "repo-1",
+                forge: "github",
+                forgeHost: "github.com",
+                projectPath: "owner/repo",
+              },
+              id: "wi-terminal-failed",
+              issueNumber: 11,
+              issueTitle: "Terminal close failure",
+              state: "FAILED",
+              status: "FAILED",
+              statusMessage: "Issue is not open",
+              paused: false,
+              canRetry: false,
+              latestStepRunReason: {
+                code: "issue_not_open",
+                message: "Issue is not open",
+                detail: null,
+              },
+              pullRequestNumber: null,
+              createdAt: "2026-08-12T10:00:00.000Z",
+              updatedAt: "2026-08-12T10:00:00.000Z",
+              stateReadyAt: "2026-08-12T10:00:00.000Z",
+              postponedUntil: null,
+            },
+            {
+              repository: {
+                id: "repo-1",
+                forge: "github",
+                forgeHost: "github.com",
+                projectPath: "owner/repo",
+              },
+              id: "wi-retryable-needs-human",
+              issueNumber: 12,
+              issueTitle: "Retryable review handoff",
+              state: "NEEDS_HUMAN",
+              status: "NEEDS_HUMAN",
+              statusMessage: "Human must review findings",
+              paused: false,
+              canRetry: true,
+              latestStepRunReason: {
+                code: "review_accepted",
+                message: "Human must review findings",
+                detail: null,
+              },
+              pullRequestNumber: null,
+              createdAt: "2026-08-12T10:00:00.000Z",
+              updatedAt: "2026-08-12T10:00:00.000Z",
+              stateReadyAt: "2026-08-12T10:00:00.000Z",
+              postponedUntil: null,
+            },
+            {
+              repository: {
+                id: "repo-1",
+                forge: "github",
+                forgeHost: "github.com",
+                projectPath: "owner/repo",
+              },
+              id: "wi-unavailable-detail",
+              issueNumber: 13,
+              issueTitle: "Interrupted without detail",
+              state: "IMPLEMENT",
+              status: "INTERRUPTED",
+              statusMessage:
+                "Lifecycle Step was interrupted before an outcome could be established",
+              paused: false,
+              canRetry: true,
+              latestStepRunReason: {
+                code: "interrupted",
+                message:
+                  "Lifecycle Step was interrupted before an outcome could be established",
+                detail: null,
+              },
+              pullRequestNumber: null,
+              createdAt: "2026-08-12T10:00:00.000Z",
+              updatedAt: "2026-08-12T10:00:00.000Z",
+              stateReadyAt: "2026-08-12T10:00:00.000Z",
+              postponedUntil: null,
+            },
+          ],
+        },
+        { id: "QUEUE", label: "Queue", count: 0, workItems: [] },
+        { id: "BUILD", label: "Build", count: 0, workItems: [] },
+        { id: "REVIEW", label: "Review", count: 0, workItems: [] },
+        { id: "PR", label: "PR", count: 0, workItems: [] },
+        { id: "MERGED", label: "Merged", count: 0, workItems: [] },
+      ],
+    })
+
+    expect(doc.schemaVersion).toBe(1)
+    const rows = doc.lanes[0]?.workItems ?? []
+    expect(
+      rows.map((row) => [row.id, row.canRetry, row.state, row.status]),
+    ).toEqual([
+      ["wi-retryable-failed", true, "IMPLEMENT", "FAILED"],
+      ["wi-terminal-failed", false, "FAILED", "FAILED"],
+      ["wi-retryable-needs-human", true, "NEEDS_HUMAN", "NEEDS_HUMAN"],
+      ["wi-unavailable-detail", true, "IMPLEMENT", "INTERRUPTED"],
+    ])
+    expect(rows[0]?.latestStepRunReason?.detail?.code).toBe("ENOENT")
+    expect(rows[1]?.latestStepRunReason?.detail).toBeNull()
+    expect(rows[3]?.latestStepRunReason?.detail).toBeNull()
+    expect(encodeCompactJson(doc)).toContain('"schemaVersion":1')
+    expect(encodeCompactJson(doc)).toContain('"canRetry":true')
+    expect(encodeCompactJson(doc)).toContain('"latestStepRunReason"')
   })
 
   test("candidates success document includes issuesReconciledAt and actions", () => {

--- a/apps/ready-for-agent/src/cli-json.ts
+++ b/apps/ready-for-agent/src/cli-json.ts
@@ -89,14 +89,14 @@ export type StatusLaneId =
   | "ATTENTION"
   | "MERGED"
 
-export type StatusCauseChainLink = {
+type StatusCauseChainLink = {
   readonly name?: string
   readonly code?: string
   readonly message?: string
 }
 
 /** Bounded sanitized cause chain from the latest Step Run reason_detail. */
-export type StatusStepRunReasonDetail = {
+type StatusStepRunReasonDetail = {
   readonly causeChain: readonly StatusCauseChainLink[]
   readonly code?: string
 }

--- a/apps/ready-for-agent/src/cli-json.ts
+++ b/apps/ready-for-agent/src/cli-json.ts
@@ -1,6 +1,11 @@
 import { Runtime, Schema } from "effect"
 
-/** CLI-owned envelope version for finite operator commands. */
+/**
+ * CLI-owned envelope version for finite operator commands.
+ *
+ * Additive fields on existing documents stay on version 1. A version bump
+ * is reserved for removing or renaming fields or changing document shape.
+ */
 export const CLI_SCHEMA_VERSION = 1 as const
 
 /**
@@ -84,6 +89,28 @@ export type StatusLaneId =
   | "ATTENTION"
   | "MERGED"
 
+export type StatusCauseChainLink = {
+  readonly name?: string
+  readonly code?: string
+  readonly message?: string
+}
+
+/** Bounded sanitized cause chain from the latest Step Run reason_detail. */
+export type StatusStepRunReasonDetail = {
+  readonly causeChain: readonly StatusCauseChainLink[]
+  readonly code?: string
+}
+
+/**
+ * Harness-owned latest Step Run reason. Null when the Work Item has no
+ * Step Run. `detail` is null when no sanitized cause chain was persisted.
+ */
+export type StatusStepRunReason = {
+  readonly code: string | null
+  readonly message: string | null
+  readonly detail: StatusStepRunReasonDetail | null
+}
+
 export type StatusWorkItemRow = {
   readonly repository: CanonicalRepositoryIdentity
   readonly id: string
@@ -93,6 +120,8 @@ export type StatusWorkItemRow = {
   readonly status: string
   readonly statusMessage: string | null
   readonly paused: boolean
+  readonly canRetry: boolean
+  readonly latestStepRunReason: StatusStepRunReason | null
   readonly pullRequestNumber: number | null
   readonly createdAt: string
   readonly updatedAt: string

--- a/apps/ready-for-agent/src/cli-process.test.ts
+++ b/apps/ready-for-agent/src/cli-process.test.ts
@@ -1175,6 +1175,206 @@ describe("operator binary finite-command process contract", () => {
     }
   })
 
+  test("status keeps schemaVersion 1 and carries canRetry plus latest Step Run reason", async () => {
+    const repository = {
+      id: "repo-process-1",
+      forge: "github",
+      forgeHost: "github.com",
+      projectPath: "owner/repo",
+    }
+    const graphqlWorkItems = [
+      {
+        repository,
+        workItem: {
+          id: "wi-retryable-failed",
+          issueNumber: 10,
+          issueTitle: "Retryable implement failure",
+          state: "IMPLEMENT",
+          status: "FAILED",
+          statusMessage: "Claude Code failed to implement the Work Item issue",
+          paused: false,
+          canRetry: true,
+          latestStepRunReason: {
+            code: "handler_failed",
+            message: "Claude Code failed to implement the Work Item issue",
+            detail: {
+              code: "ENOENT",
+              causeChain: [
+                {
+                  name: "Error",
+                  code: "ENOENT",
+                  message: 'ENOENT: Executable not found in $PATH: "claude"',
+                },
+              ],
+            },
+          },
+          pullRequestNumber: null,
+          createdAt: "2026-08-12T10:00:00.000Z",
+          updatedAt: "2026-08-12T10:00:00.000Z",
+          stateReadyAt: "2026-08-12T10:00:00.000Z",
+          postponedUntil: null,
+        },
+      },
+      {
+        repository,
+        workItem: {
+          id: "wi-terminal-failed",
+          issueNumber: 11,
+          issueTitle: "Terminal close failure",
+          state: "FAILED",
+          status: "FAILED",
+          statusMessage: "Issue is not open",
+          paused: false,
+          canRetry: false,
+          latestStepRunReason: {
+            code: "issue_not_open",
+            message: "Issue is not open",
+            detail: null,
+          },
+          pullRequestNumber: null,
+          createdAt: "2026-08-12T10:00:00.000Z",
+          updatedAt: "2026-08-12T10:00:00.000Z",
+          stateReadyAt: "2026-08-12T10:00:00.000Z",
+          postponedUntil: null,
+        },
+      },
+      {
+        repository,
+        workItem: {
+          id: "wi-retryable-needs-human",
+          issueNumber: 12,
+          issueTitle: "Retryable review handoff",
+          state: "NEEDS_HUMAN",
+          status: "NEEDS_HUMAN",
+          statusMessage: "Human must review findings",
+          paused: false,
+          canRetry: true,
+          latestStepRunReason: {
+            code: "review_accepted",
+            message: "Human must review findings",
+            detail: null,
+          },
+          pullRequestNumber: null,
+          createdAt: "2026-08-12T10:00:00.000Z",
+          updatedAt: "2026-08-12T10:00:00.000Z",
+          stateReadyAt: "2026-08-12T10:00:00.000Z",
+          postponedUntil: null,
+        },
+      },
+      {
+        repository,
+        workItem: {
+          id: "wi-unavailable-detail",
+          issueNumber: 13,
+          issueTitle: "Interrupted without detail",
+          state: "IMPLEMENT",
+          status: "INTERRUPTED",
+          statusMessage:
+            "Lifecycle Step was interrupted before an outcome could be established",
+          paused: false,
+          canRetry: true,
+          latestStepRunReason: {
+            code: "interrupted",
+            message:
+              "Lifecycle Step was interrupted before an outcome could be established",
+            detail: null,
+          },
+          pullRequestNumber: null,
+          createdAt: "2026-08-12T10:00:00.000Z",
+          updatedAt: "2026-08-12T10:00:00.000Z",
+          stateReadyAt: "2026-08-12T10:00:00.000Z",
+          postponedUntil: null,
+        },
+      },
+    ]
+    const graphqlLanes = [
+      { id: "QUEUE", label: "Queue", count: 0, workItems: [] },
+      { id: "BUILD", label: "Build", count: 0, workItems: [] },
+      { id: "REVIEW", label: "Review", count: 0, workItems: [] },
+      { id: "PR", label: "PR", count: 0, workItems: [] },
+      {
+        id: "ATTENTION",
+        label: "Attention",
+        count: graphqlWorkItems.length,
+        workItems: graphqlWorkItems,
+      },
+      { id: "MERGED", label: "Merged", count: 0, workItems: [] },
+    ]
+    const seenBodies: string[] = []
+    const server = createServer((req, res) => {
+      if (req.method !== "POST") {
+        res.writeHead(405)
+        res.end()
+        return
+      }
+      const chunks: Buffer[] = []
+      req.on("data", (chunk: Buffer) => {
+        chunks.push(chunk)
+      })
+      req.on("end", () => {
+        const body = Buffer.concat(chunks).toString("utf8")
+        seenBodies.push(body)
+        res.writeHead(200, { "content-type": "application/json" })
+        if (body.includes("kanbanStatus")) {
+          res.end(
+            JSON.stringify({
+              data: {
+                kanbanStatus: {
+                  repository: null,
+                  lanes: graphqlLanes,
+                },
+              },
+            }),
+          )
+          return
+        }
+        res.end(
+          JSON.stringify({ data: null, errors: [{ message: "unexpected" }] }),
+        )
+      })
+    })
+
+    try {
+      const port = await listen(server)
+      const result = await runCli(
+        ["status"],
+        `http://127.0.0.1:${port}/graphql`,
+      )
+
+      expect(result.status).toBe(0)
+      expect(result.stderr.trim()).toBe("")
+      expect(seenBodies.some((body) => body.includes("canRetry"))).toBe(true)
+      expect(
+        seenBodies.some((body) => body.includes("latestStepRunReason")),
+      ).toBe(true)
+      const document = parseExactlyOneJsonDocument(result.stdout)
+      expect(document).toEqual(
+        buildStatusSuccessDocument({
+          repository: null,
+          lanes: graphqlLanes.map((lane) => ({
+            id: lane.id as
+              | "QUEUE"
+              | "BUILD"
+              | "REVIEW"
+              | "PR"
+              | "ATTENTION"
+              | "MERGED",
+            label: lane.label,
+            count: lane.count,
+            workItems: lane.workItems.map((row) => ({
+              repository: row.repository,
+              ...row.workItem,
+            })),
+          })),
+        }),
+      )
+      expect(document).toMatchObject({ schemaVersion: CLI_SCHEMA_VERSION })
+      expect(CLI_SCHEMA_VERSION).toBe(1)
+    } finally {
+      await closeServer(server)
+    }
+  })
+
   test("status against unreachable GraphQL emits JSON error on stderr only", async () => {
     const result = await runCli(["status"], "http://127.0.0.1:1/graphql")
 

--- a/apps/ready-for-agent/src/cli.test.ts
+++ b/apps/ready-for-agent/src/cli.test.ts
@@ -1062,6 +1062,247 @@ describe("operator binary CLI seam", () => {
     }),
   )
 
+  it.live(
+    "status carries Harness-owned canRetry and latest Step Run reason",
+    () =>
+      Effect.gen(function* () {
+        const logs: string[] = []
+        const originalLog = console.log
+        console.log = (...args: unknown[]) => {
+          logs.push(args.map(String).join(" "))
+        }
+        const repository = {
+          id: "repo-1",
+          forge: "github",
+          forgeHost: "github.com",
+          projectPath: "owner/repo",
+        }
+        const attentionRows = [
+          {
+            repository,
+            id: "wi-retryable-failed",
+            issueNumber: 10,
+            issueTitle: "Retryable implement failure",
+            state: "IMPLEMENT",
+            status: "FAILED",
+            statusMessage:
+              "Claude Code failed to implement the Work Item issue",
+            paused: false,
+            canRetry: true,
+            latestStepRunReason: {
+              code: "handler_failed",
+              message: "Claude Code failed to implement the Work Item issue",
+              detail: {
+                code: "ENOENT",
+                causeChain: [
+                  {
+                    name: "Error",
+                    code: "ENOENT",
+                    message: 'ENOENT: Executable not found in $PATH: "claude"',
+                  },
+                ],
+              },
+            },
+            pullRequestNumber: null,
+            createdAt: "2026-08-12T10:00:00.000Z",
+            updatedAt: "2026-08-12T10:00:00.000Z",
+            stateReadyAt: "2026-08-12T10:00:00.000Z",
+            postponedUntil: null,
+          },
+          {
+            repository,
+            id: "wi-terminal-failed",
+            issueNumber: 11,
+            issueTitle: "Terminal close failure",
+            state: "FAILED",
+            status: "FAILED",
+            statusMessage: "Issue is not open",
+            paused: false,
+            canRetry: false,
+            latestStepRunReason: {
+              code: "issue_not_open",
+              message: "Issue is not open",
+              detail: null,
+            },
+            pullRequestNumber: null,
+            createdAt: "2026-08-12T10:00:00.000Z",
+            updatedAt: "2026-08-12T10:00:00.000Z",
+            stateReadyAt: "2026-08-12T10:00:00.000Z",
+            postponedUntil: null,
+          },
+          {
+            repository,
+            id: "wi-retryable-needs-human",
+            issueNumber: 12,
+            issueTitle: "Retryable review handoff",
+            state: "NEEDS_HUMAN",
+            status: "NEEDS_HUMAN",
+            statusMessage: "Human must review findings",
+            paused: false,
+            canRetry: true,
+            latestStepRunReason: {
+              code: "review_accepted",
+              message: "Human must review findings",
+              detail: null,
+            },
+            pullRequestNumber: null,
+            createdAt: "2026-08-12T10:00:00.000Z",
+            updatedAt: "2026-08-12T10:00:00.000Z",
+            stateReadyAt: "2026-08-12T10:00:00.000Z",
+            postponedUntil: null,
+          },
+          {
+            repository,
+            id: "wi-unavailable-detail",
+            issueNumber: 13,
+            issueTitle: "Interrupted without detail",
+            state: "IMPLEMENT",
+            status: "INTERRUPTED",
+            statusMessage:
+              "Lifecycle Step was interrupted before an outcome could be established",
+            paused: false,
+            canRetry: true,
+            latestStepRunReason: {
+              code: "interrupted",
+              message:
+                "Lifecycle Step was interrupted before an outcome could be established",
+              detail: null,
+            },
+            pullRequestNumber: null,
+            createdAt: "2026-08-12T10:00:00.000Z",
+            updatedAt: "2026-08-12T10:00:00.000Z",
+            stateReadyAt: "2026-08-12T10:00:00.000Z",
+            postponedUntil: null,
+          },
+        ] as const
+        try {
+          const layer = mockStart.pipe(
+            Layer.provideMerge(mockLocalGit),
+            Layer.provideMerge(
+              Layer.succeed(GraphqlApi, {
+                ...unusedGraphql,
+                kanbanStatus: (repositoryId) => {
+                  expect(repositoryId).toBeNull()
+                  return Effect.succeed({
+                    repository: null,
+                    lanes: [
+                      {
+                        id: "QUEUE" as const,
+                        label: "Queue",
+                        count: 0,
+                        workItems: [],
+                      },
+                      {
+                        id: "BUILD" as const,
+                        label: "Build",
+                        count: 0,
+                        workItems: [],
+                      },
+                      {
+                        id: "REVIEW" as const,
+                        label: "Review",
+                        count: 0,
+                        workItems: [],
+                      },
+                      {
+                        id: "PR" as const,
+                        label: "PR",
+                        count: 0,
+                        workItems: [],
+                      },
+                      {
+                        id: "ATTENTION" as const,
+                        label: "Attention",
+                        count: attentionRows.length,
+                        workItems: attentionRows,
+                      },
+                      {
+                        id: "MERGED" as const,
+                        label: "Merged",
+                        count: 0,
+                        workItems: [],
+                      },
+                    ],
+                  })
+                },
+              }),
+            ),
+          )
+
+          yield* runOperator(["status"], layer)
+
+          expect(logs).toHaveLength(1)
+          const document = JSON.parse(logs[0]!) as {
+            schemaVersion: number
+            command: string
+            lanes: readonly {
+              id: string
+              workItems: readonly {
+                id: string
+                canRetry: boolean
+                state: string
+                status: string
+                latestStepRunReason: {
+                  code: string | null
+                  detail: { code?: string } | null
+                } | null
+              }[]
+            }[]
+          }
+          expect(document.schemaVersion).toBe(CLI_SCHEMA_VERSION)
+          expect(document.command).toBe("status")
+          const rows =
+            document.lanes.find((lane) => lane.id === "ATTENTION")?.workItems ??
+            []
+          expect(
+            rows.map((row) => [
+              row.id,
+              row.canRetry,
+              row.state,
+              row.status,
+              row.latestStepRunReason?.code,
+              row.latestStepRunReason?.detail?.code ?? null,
+            ]),
+          ).toEqual([
+            [
+              "wi-retryable-failed",
+              true,
+              "IMPLEMENT",
+              "FAILED",
+              "handler_failed",
+              "ENOENT",
+            ],
+            [
+              "wi-terminal-failed",
+              false,
+              "FAILED",
+              "FAILED",
+              "issue_not_open",
+              null,
+            ],
+            [
+              "wi-retryable-needs-human",
+              true,
+              "NEEDS_HUMAN",
+              "NEEDS_HUMAN",
+              "review_accepted",
+              null,
+            ],
+            [
+              "wi-unavailable-detail",
+              true,
+              "IMPLEMENT",
+              "INTERRUPTED",
+              "interrupted",
+              null,
+            ],
+          ])
+        } finally {
+          console.log = originalLog
+        }
+      }),
+  )
+
   it.live("status fails with REPOSITORY_NOT_FOUND for unknown selector", () =>
     Effect.gen(function* () {
       const layer = mockStart.pipe(

--- a/apps/ready-for-agent/src/services/graphql-api.ts
+++ b/apps/ready-for-agent/src/services/graphql-api.ts
@@ -6,6 +6,7 @@ import {
   type IntakeIssueResult,
   type StatusLane,
   type StatusLaneId,
+  type StatusStepRunReason,
   type StatusWorkItemRow,
   toCanonicalRepositoryIdentity,
 } from "../cli-json.ts"
@@ -120,6 +121,64 @@ const isStatusLaneId = (value: string): value is StatusLaneId => {
   }
 }
 
+type GraphqlCauseChainLink = {
+  readonly name?: string | null
+  readonly code?: string | null
+  readonly message?: string | null
+}
+
+type GraphqlStepRunReason = {
+  readonly code?: string | null
+  readonly message?: string | null
+  readonly detail?: {
+    readonly code?: string | null
+    readonly causeChain?: readonly GraphqlCauseChainLink[] | null
+  } | null
+}
+
+type GraphqlStatusWorkItem = {
+  readonly id: string
+  readonly issueNumber: number
+  readonly issueTitle: string | null
+  readonly state: string
+  readonly status: string
+  readonly statusMessage: string | null
+  readonly paused: boolean
+  readonly canRetry: boolean
+  readonly latestStepRunReason?: GraphqlStepRunReason | null
+  readonly pullRequestNumber: number | null
+  readonly createdAt: string
+  readonly updatedAt: string
+  readonly stateReadyAt: string
+  readonly postponedUntil: string | null
+}
+
+const toStatusCauseChainLink = (link: GraphqlCauseChainLink) => ({
+  ...(link.name != null ? { name: link.name } : {}),
+  ...(link.code != null ? { code: link.code } : {}),
+  ...(link.message != null ? { message: link.message } : {}),
+})
+
+const toStatusStepRunReason = (
+  reason: GraphqlStepRunReason | null | undefined,
+): StatusStepRunReason | null => {
+  if (reason === null || reason === undefined) {
+    return null
+  }
+  const detail = reason.detail
+  return {
+    code: reason.code ?? null,
+    message: reason.message ?? null,
+    detail:
+      detail === null || detail === undefined
+        ? null
+        : {
+            causeChain: (detail.causeChain ?? []).map(toStatusCauseChainLink),
+            ...(detail.code != null ? { code: detail.code } : {}),
+          },
+  }
+}
+
 const toStatusWorkItemRow = (row: {
   readonly repository: {
     readonly id: string
@@ -127,20 +186,7 @@ const toStatusWorkItemRow = (row: {
     readonly forgeHost: string
     readonly projectPath: string
   }
-  readonly workItem: {
-    readonly id: string
-    readonly issueNumber: number
-    readonly issueTitle: string | null
-    readonly state: string
-    readonly status: string
-    readonly statusMessage: string | null
-    readonly paused: boolean
-    readonly pullRequestNumber: number | null
-    readonly createdAt: string
-    readonly updatedAt: string
-    readonly stateReadyAt: string
-    readonly postponedUntil: string | null
-  }
+  readonly workItem: GraphqlStatusWorkItem
 }): StatusWorkItemRow => ({
   repository: toCanonicalRepositoryIdentity(row.repository),
   id: row.workItem.id,
@@ -150,6 +196,8 @@ const toStatusWorkItemRow = (row: {
   status: row.workItem.status,
   statusMessage: row.workItem.statusMessage,
   paused: row.workItem.paused,
+  canRetry: row.workItem.canRetry,
+  latestStepRunReason: toStatusStepRunReason(row.workItem.latestStepRunReason),
   pullRequestNumber: row.workItem.pullRequestNumber,
   createdAt: row.workItem.createdAt,
   updatedAt: row.workItem.updatedAt,
@@ -169,20 +217,7 @@ const toStatusLanes = (
         readonly forgeHost: string
         readonly projectPath: string
       }
-      readonly workItem: {
-        readonly id: string
-        readonly issueNumber: number
-        readonly issueTitle: string | null
-        readonly state: string
-        readonly status: string
-        readonly statusMessage: string | null
-        readonly paused: boolean
-        readonly pullRequestNumber: number | null
-        readonly createdAt: string
-        readonly updatedAt: string
-        readonly stateReadyAt: string
-        readonly postponedUntil: string | null
-      }
+      readonly workItem: GraphqlStatusWorkItem
     }[]
   }[],
 ): readonly StatusLane[] =>
@@ -559,6 +594,19 @@ export class GraphqlApi extends Context.Service<
                         status: true,
                         statusMessage: true,
                         paused: true,
+                        canRetry: true,
+                        latestStepRunReason: {
+                          code: true,
+                          message: true,
+                          detail: {
+                            code: true,
+                            causeChain: {
+                              name: true,
+                              code: true,
+                              message: true,
+                            },
+                          },
+                        },
                         pullRequestNumber: true,
                         createdAt: true,
                         updatedAt: true,

--- a/docs/prd/repository-intake-cli.md
+++ b/docs/prd/repository-intake-cli.md
@@ -310,6 +310,8 @@ The CLI exits `0` only when every result is created or when the result list is e
           "status": "WAITING_FOR_BLOCKERS",
           "statusMessage": "Waiting for blocking Issues",
           "paused": false,
+          "canRetry": false,
+          "latestStepRunReason": null,
           "pullRequestNumber": null,
           "createdAt": "2026-08-12T10:00:00.000Z",
           "updatedAt": "2026-08-12T10:00:00.000Z",
@@ -322,7 +324,7 @@ The CLI exits `0` only when every result is created or when the result list is e
 }
 ```
 
-All six lanes are always present in fixed order, including lanes with `count: 0` and an empty `workItems` array. A Repository-scoped invocation returns that Repository object instead of `null`.
+All six lanes are always present in fixed order, including lanes with `count: 0` and an empty `workItems` array. A Repository-scoped invocation returns that Repository object instead of `null`. Every Work Item row includes authoritative Harness-owned `canRetry`. Stopped items expose `latestStepRunReason` with a stable machine `code`, operator-facing `message`, and bounded sanitized `detail` cause chain when persisted. These fields are additive on `schemaVersion` 1. The CLI does not infer eligibility from lane or status strings and does not inspect Agent Backend transcripts.
 
 ### Command-Level Errors
 

--- a/packages/graphql-api/src/lib/graphql-api.ts
+++ b/packages/graphql-api/src/lib/graphql-api.ts
@@ -83,6 +83,7 @@ import {
   workItemCanRetry,
   workItemIsTerminal,
   workItemLatestStepRunDetail,
+  workItemLatestStepRunReason,
   workItemPostponedUntil,
   workItemStateLabel,
   workItemStatus,
@@ -1192,6 +1193,8 @@ export const createGraphqlApi = <R>(
           },
           latestStepRunDetail: (workItem: WorkItemRecord) =>
             workItemLatestStepRunDetail(workItem),
+          latestStepRunReason: (workItem: WorkItemRecord) =>
+            workItemLatestStepRunReason(workItem),
           postponedUntil: (workItem: WorkItemRecord) =>
             workItemPostponedUntil(workItem)?.toISOString() ?? null,
           paused: (workItem: WorkItemRecord) => workItem.paused,

--- a/packages/graphql-api/src/lib/work-item-projection.ts
+++ b/packages/graphql-api/src/lib/work-item-projection.ts
@@ -269,6 +269,30 @@ export const workItemLatestStepRunDetail = (
   parseReasonDetail(latestStepRun(workItem)?.reasonDetail)
 
 /**
+ * Persisted latest Step Run reason for operators. Null when the Work Item
+ * has no Step Run yet. `detail` is null when no sanitized cause chain exists.
+ */
+export type WorkItemLatestStepRunReason = {
+  readonly code: string | null
+  readonly message: string | null
+  readonly detail: StepRunReasonDetail | null
+}
+
+export const workItemLatestStepRunReason = (
+  workItem: WorkItemRecord,
+): WorkItemLatestStepRunReason | null => {
+  const latest = latestStepRun(workItem)
+  if (latest === undefined) {
+    return null
+  }
+  return {
+    code: latest.reasonCode,
+    message: latest.reasonMessage,
+    detail: parseReasonDetail(latest.reasonDetail),
+  }
+}
+
+/**
  * Cumulative wall-clock execution time for a phase across every attempt in
  * the same Work Item. Prior failed, timed-out, and Needs Human attempts stay
  * included so retries and continues do not reset the displayed timer.

--- a/packages/graphql-api/test/graphql-api.test.ts
+++ b/packages/graphql-api/test/graphql-api.test.ts
@@ -6142,6 +6142,202 @@ describe("GraphQL API", () => {
     })
   })
 
+  test("projects canRetry and latestStepRunReason for retryable, terminal, Needs Human, and missing detail", async () => {
+    const retryableFailed = {
+      ...workItem,
+      id: "wi-retryable-failed",
+      state: "implement",
+      stepRuns: [
+        {
+          ...workItem.stepRuns[0]!,
+          id: "srun-retryable-failed",
+          workItemId: "wi-retryable-failed",
+          step: "implement",
+          status: "failed",
+          finishedAt: new Date("2026-07-14T08:05:00.000Z"),
+          reasonCode: STEP_RUN_REASON.handlerFailed,
+          reasonMessage: "OpenCode failed to implement the Work Item issue",
+          reasonDetail: JSON.stringify({
+            causeChain: [
+              {
+                name: "Error",
+                code: "ENOENT",
+                message: 'ENOENT: Executable not found in $PATH: "claude"',
+              },
+            ],
+            code: "ENOENT",
+          }),
+        },
+      ],
+    } as WorkItemRecord
+    const terminalFailed = {
+      ...workItem,
+      id: "wi-terminal-failed",
+      state: "failed",
+      failureCode: "issue_not_open",
+      failureMessage: "Issue is not open",
+      stepRuns: [
+        {
+          ...workItem.stepRuns[0]!,
+          id: "srun-terminal-failed",
+          workItemId: "wi-terminal-failed",
+          step: "close_issue",
+          status: "failed",
+          finishedAt: new Date("2026-07-14T08:05:00.000Z"),
+          reasonCode: "issue_not_open",
+          reasonMessage: "Issue is not open",
+          reasonDetail: null,
+        },
+      ],
+    } as WorkItemRecord
+    const retryableNeedsHuman = {
+      ...workItem,
+      id: "wi-retryable-needs-human",
+      state: "needs_human",
+      failureCode: "needs_human",
+      failureMessage: "Human must review findings",
+      stepRuns: [
+        {
+          ...workItem.stepRuns[0]!,
+          id: "srun-retryable-needs-human",
+          workItemId: "wi-retryable-needs-human",
+          step: "review",
+          status: "succeeded",
+          finishedAt: new Date("2026-07-14T08:05:00.000Z"),
+          reasonCode: STEP_RUN_REASON.reviewAccepted,
+          reasonMessage: "Human must review findings",
+          reasonDetail: null,
+        },
+      ],
+    } as WorkItemRecord
+    const unavailableDetail = {
+      ...workItem,
+      id: "wi-unavailable-detail",
+      state: "implement",
+      stepRuns: [
+        {
+          ...workItem.stepRuns[0]!,
+          id: "srun-unavailable-detail",
+          workItemId: "wi-unavailable-detail",
+          step: "implement",
+          status: "interrupted",
+          finishedAt: new Date("2026-07-14T08:05:00.000Z"),
+          reasonCode: STEP_RUN_REASON.interrupted,
+          reasonMessage:
+            "Lifecycle Step was interrupted before an outcome could be established",
+          reasonDetail: null,
+        },
+      ],
+    } as WorkItemRecord
+
+    await runtime.dispose()
+    runtime = makeRuntime(
+      {},
+      {},
+      {},
+      {
+        listWorkItemsForIssue: () =>
+          Effect.succeed([
+            retryableFailed,
+            terminalFailed,
+            retryableNeedsHuman,
+            unavailableDetail,
+          ]),
+      },
+    )
+
+    const response = await createGraphqlApi(runtime).fetch(
+      graphqlRequest({
+        query: `query WorkItems($repositoryId: ID!, $issueNumber: Int!) {
+          workItems(repositoryId: $repositoryId, issueNumber: $issueNumber) {
+            id
+            state
+            status
+            canRetry
+            isTerminal
+            latestStepRunReason {
+              code
+              message
+              detail {
+                code
+                causeChain { name code message }
+              }
+            }
+          }
+        }`,
+        variables: {
+          repositoryId: repository.id,
+          issueNumber: issue.issueNumber,
+        },
+      }),
+    )
+
+    expect(await response.json()).toEqual({
+      data: {
+        workItems: [
+          {
+            id: "wi-retryable-failed",
+            state: "IMPLEMENT",
+            status: "FAILED",
+            canRetry: true,
+            isTerminal: false,
+            latestStepRunReason: {
+              code: "handler_failed",
+              message: "OpenCode failed to implement the Work Item issue",
+              detail: {
+                code: "ENOENT",
+                causeChain: [
+                  {
+                    name: "Error",
+                    code: "ENOENT",
+                    message: 'ENOENT: Executable not found in $PATH: "claude"',
+                  },
+                ],
+              },
+            },
+          },
+          {
+            id: "wi-terminal-failed",
+            state: "FAILED",
+            status: "FAILED",
+            canRetry: false,
+            isTerminal: true,
+            latestStepRunReason: {
+              code: "issue_not_open",
+              message: "Issue is not open",
+              detail: null,
+            },
+          },
+          {
+            id: "wi-retryable-needs-human",
+            state: "NEEDS_HUMAN",
+            status: "NEEDS_HUMAN",
+            canRetry: true,
+            isTerminal: true,
+            latestStepRunReason: {
+              code: "review_accepted",
+              message: "Human must review findings",
+              detail: null,
+            },
+          },
+          {
+            id: "wi-unavailable-detail",
+            state: "IMPLEMENT",
+            status: "INTERRUPTED",
+            canRetry: true,
+            isTerminal: false,
+            latestStepRunReason: {
+              code: "interrupted",
+              message:
+                "Lifecycle Step was interrupted before an outcome could be established",
+              detail: null,
+            },
+          },
+        ],
+      },
+    })
+  })
+
   test("keeps failed Review reasonMessage as statusMessage", async () => {
     const baseRun = workItem.stepRuns[0]!
     const failedReview = {

--- a/packages/graphql-api/test/work-item-projection.test.ts
+++ b/packages/graphql-api/test/work-item-projection.test.ts
@@ -5,6 +5,7 @@ import {
   statusLabel,
   workItemCanRetry,
   workItemLatestStepRunDetail,
+  workItemLatestStepRunReason,
   workItemPostponedUntil,
   workItemStatus,
   workItemStatusMessage,
@@ -448,5 +449,140 @@ describe("workItemLatestStepRunDetail", () => {
       ],
       code: "ENOENT",
     })
+  })
+})
+
+describe("operator Retry eligibility and latest Step Run reason", () => {
+  const implementFailedWithDetail = workItemWith({
+    state: "implement",
+    stepRuns: [
+      {
+        ...baseStepRun,
+        step: "implement",
+        status: "failed",
+        reasonCode: "handler_failed",
+        reasonMessage: "Claude Code failed to implement the Work Item issue",
+        reasonDetail: JSON.stringify({
+          causeChain: [
+            {
+              name: "ImplementOpenCodeError",
+              message: "Claude Code failed to implement the Work Item issue",
+            },
+            {
+              name: "Error",
+              code: "ENOENT",
+              message: 'ENOENT: Executable not found in $PATH: "claude"',
+            },
+          ],
+          code: "ENOENT",
+        }),
+      },
+    ],
+  })
+
+  const terminalIssueNotOpen = workItemWith({
+    state: "failed",
+    failureCode: "issue_not_open",
+    failureMessage: "Issue is not open",
+    stepRuns: [
+      {
+        ...baseStepRun,
+        step: "close_issue",
+        status: "failed",
+        reasonCode: "issue_not_open",
+        reasonMessage: "Issue is not open",
+        reasonDetail: null,
+      },
+    ],
+  })
+
+  const retryableNeedsHuman = workItemWith({
+    state: "needs_human",
+    failureCode: "needs_human",
+    failureMessage: "Human must review findings",
+    stepRuns: [
+      {
+        ...baseStepRun,
+        step: "review",
+        status: "succeeded",
+        reasonCode: "review_accepted",
+        reasonMessage: "Human must review findings",
+        reasonDetail: null,
+      },
+    ],
+  })
+
+  const interruptedWithoutDetail = workItemWith({
+    state: "implement",
+    stepRuns: [
+      {
+        ...baseStepRun,
+        step: "implement",
+        status: "interrupted",
+        reasonCode: "interrupted",
+        reasonMessage:
+          "Lifecycle Step was interrupted before an outcome could be established",
+        reasonDetail: null,
+      },
+    ],
+  })
+
+  test("retryable failed Step Run keeps canRetry and structured reason with detail", () => {
+    expect(workItemCanRetry(implementFailedWithDetail)).toBe(true)
+    expect(workItemStatus(implementFailedWithDetail)).toBe("failed")
+    expect(workItemLatestStepRunReason(implementFailedWithDetail)).toEqual({
+      code: "handler_failed",
+      message: "Claude Code failed to implement the Work Item issue",
+      detail: {
+        causeChain: [
+          {
+            name: "ImplementOpenCodeError",
+            message: "Claude Code failed to implement the Work Item issue",
+          },
+          {
+            name: "Error",
+            code: "ENOENT",
+            message: 'ENOENT: Executable not found in $PATH: "claude"',
+          },
+        ],
+        code: "ENOENT",
+      },
+    })
+  })
+
+  test("non-retryable terminal failure stays distinguishable from a retryable Step Run", () => {
+    expect(workItemCanRetry(terminalIssueNotOpen)).toBe(false)
+    expect(workItemStatus(terminalIssueNotOpen)).toBe("failed")
+    expect(workItemLatestStepRunReason(terminalIssueNotOpen)).toEqual({
+      code: "issue_not_open",
+      message: "Issue is not open",
+      detail: null,
+    })
+  })
+
+  test("retryable Needs Human handoff exposes canRetry and the latest Step Run reason", () => {
+    expect(workItemCanRetry(retryableNeedsHuman)).toBe(true)
+    expect(workItemStatus(retryableNeedsHuman)).toBe("needs_human")
+    expect(workItemLatestStepRunReason(retryableNeedsHuman)).toEqual({
+      code: "review_accepted",
+      message: "Human must review findings",
+      detail: null,
+    })
+  })
+
+  test("unavailable persisted detail stays null without inventing a cause chain", () => {
+    expect(workItemCanRetry(interruptedWithoutDetail)).toBe(true)
+    expect(workItemLatestStepRunReason(interruptedWithoutDetail)).toEqual({
+      code: "interrupted",
+      message:
+        "Lifecycle Step was interrupted before an outcome could be established",
+      detail: null,
+    })
+  })
+
+  test("returns null latest Step Run reason when no Step Run exists", () => {
+    expect(
+      workItemLatestStepRunReason(workItemWith({ stepRuns: [] })),
+    ).toBeNull()
   })
 })

--- a/packages/graphql-schema/schema.graphql
+++ b/packages/graphql-schema/schema.graphql
@@ -748,6 +748,26 @@ type StepRunReasonDetail {
   code: String
 }
 
+"""
+Structured latest Step Run reason for operators. Null when the Work Item has
+no Step Run yet. Individual fields may be null when that part was not
+persisted. Messages and cause-chain text are already sanitized.
+"""
+type StepRunReason {
+  """
+  Stable machine-readable Step Run reason code (for example handler_failed).
+  """
+  code: String
+  """
+  Operator-facing reason message persisted on the latest Step Run.
+  """
+  message: String
+  """
+  Bounded sanitized cause chain from reason_detail. Null when unavailable.
+  """
+  detail: StepRunReasonDetail
+}
+
 type WorkItem {
   id: ID!
   repositoryId: ID!
@@ -789,6 +809,11 @@ type WorkItem {
   already sanitized at write time and re-sanitized on read.
   """
   latestStepRunDetail: StepRunReasonDetail
+  """
+  Persisted latest Step Run reason: machine code, operator message, and
+  bounded sanitized detail when available. Null when there is no Step Run.
+  """
+  latestStepRunReason: StepRunReason
   """
   Retry deadline on the latest Postponed Step Run. Null unless the Work Item
   is Waiting for GitHub.

--- a/packages/graphql-schema/schema.template.graphql
+++ b/packages/graphql-schema/schema.template.graphql
@@ -726,6 +726,26 @@ type StepRunReasonDetail {
   code: String
 }
 
+"""
+Structured latest Step Run reason for operators. Null when the Work Item has
+no Step Run yet. Individual fields may be null when that part was not
+persisted. Messages and cause-chain text are already sanitized.
+"""
+type StepRunReason {
+  """
+  Stable machine-readable Step Run reason code (for example handler_failed).
+  """
+  code: String
+  """
+  Operator-facing reason message persisted on the latest Step Run.
+  """
+  message: String
+  """
+  Bounded sanitized cause chain from reason_detail. Null when unavailable.
+  """
+  detail: StepRunReasonDetail
+}
+
 type WorkItem {
   id: ID!
   repositoryId: ID!
@@ -767,6 +787,11 @@ type WorkItem {
   already sanitized at write time and re-sanitized on read.
   """
   latestStepRunDetail: StepRunReasonDetail
+  """
+  Persisted latest Step Run reason: machine code, operator message, and
+  bounded sanitized detail when available. Null when there is no Step Run.
+  """
+  latestStepRunReason: StepRunReason
   """
   Retry deadline on the latest Postponed Step Run. Null unless the Work Item
   is Waiting for GitHub.


### PR DESCRIPTION
Headless operators can already see that a Work Item is stuck, but `status` did
not say whether Retry is allowed or why the latest Step Run stopped. That left
people inferring eligibility from lane or status strings, or scraping Agent
Backend transcripts for a cause (#1104, part of #1101).

The running Harness stays the source of truth. The Work Item projection now
exposes persisted latest Step Run reason data (`code`, operator-facing
`message`, bounded sanitized `detail` cause chain). `ready-for-agent status`
copies `canRetry` and `latestStepRunReason` onto every row of the existing
`schemaVersion` 1 document. There is no `--why` mode, no transcript or
home-directory inspection, and no CLI-side lifecycle classification.

Terminal Failed, a retryable failed or interrupted Step Run, and a retryable
Needs Human handoff stay distinguishable via `state` / `status` / `canRetry` /
reason `code`. Missing `reason_detail` is `detail: null`; useful provider
detail is still captured at the Agent Backend / lifecycle failure-capture
seam, not invented here.

Verified with GraphQL projection tests, CLI JSON and process-level contract
tests (including additive `schemaVersion` 1), and the live operator CLI seam
for retryable failure, non-retryable terminal failure, retryable Needs Human,
and unavailable detail. Playwright live-forge e2e was not re-run; it now only
asserts the new fields are present on the intake sentinel row.

Closes #1104