### PR TITLE
feat(cli): add a pinned Usage 5.1.0 contract and Effect help parity

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -46,6 +46,16 @@ jobs:
         with:
           bun-version: 1.3.14
 
+      - name: Install Usage CLI
+        run: |
+          set -euo pipefail
+          VERSION=5.1.0
+          curl -fsSL "https://github.com/jdx/usage/releases/download/v${VERSION}/usage-x86_64-unknown-linux-musl.tar.gz" \
+            | tar -xz -C /tmp
+          sudo install -m 0755 /tmp/usage /usr/local/bin/usage
+          usage --version
+          usage --version | grep -F "${VERSION}"
+
       # Required when affected packages run OpenCode integration tests.
       # Resolve the release via authenticated GitHub API then pin the installer
       # --version flag: bare `opencode.ai/install` hits unauthenticated

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -43,6 +43,16 @@ jobs:
         with:
           bun-version: 1.3.14
 
+      - name: Install Usage CLI
+        run: |
+          set -euo pipefail
+          VERSION=5.1.0
+          curl -fsSL "https://github.com/jdx/usage/releases/download/v${VERSION}/usage-x86_64-unknown-linux-musl.tar.gz" \
+            | tar -xz -C /tmp
+          sudo install -m 0755 /tmp/usage /usr/local/bin/usage
+          usage --version
+          usage --version | grep -F "${VERSION}"
+
       # Required when affected packages run OpenCode integration tests.
       # Resolve the release via authenticated GitHub API then pin the installer
       # --version flag: bare `opencode.ai/install` hits unauthenticated

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,8 +25,13 @@ Also needed to run or test the harness:
 
 ## Install with mise
 
-[mise](https://mise.jdx.dev/) 2026.7.0 or later installs the pinned Bun and hk
-versions, then workspace dependencies (which apply the existing Git hooks).
+[mise](https://mise.jdx.dev/) 2026.7.0 or later installs the pinned Bun, hk,
+and Usage (5.1.0) versions, then workspace dependencies (which apply the
+existing Git hooks). Usage lints the operator CLI contract:
+
+```bash
+bunx nx run ready-for-agent:lint-usage
+```
 
 ```bash
 git clone git@github.com:berenddeboer/ready-for-agent.git
@@ -45,7 +50,8 @@ mise run setup-e2e
 ## Install without mise
 
 Install the Bun version pinned in [`mise.toml`](mise.toml) from
-[bun.sh](https://bun.sh/). Then:
+[bun.sh](https://bun.sh/). Operator CLI contract checks also need Usage
+`5.1.0` on `PATH`. Then:
 
 ```bash
 git clone git@github.com:berenddeboer/ready-for-agent.git

--- a/apps/ready-for-agent/project.json
+++ b/apps/ready-for-agent/project.json
@@ -95,6 +95,19 @@
       ],
       "cache": false
     },
+    "lint-usage": {
+      "executor": "nx:run-commands",
+      "options": {
+        "cwd": "{workspaceRoot}",
+        "command": "bash scripts/run-pinned-usage.sh lint --warnings-as-errors apps/ready-for-agent/ready-for-agent.usage.kdl"
+      },
+      "inputs": [
+        "{projectRoot}/ready-for-agent.usage.kdl",
+        "{workspaceRoot}/scripts/run-pinned-usage.sh",
+        "{workspaceRoot}/mise.toml"
+      ],
+      "cache": true
+    },
     "test": {
       "executor": "nx:run-commands",
       "options": {
@@ -108,7 +121,8 @@
           "projects": ["graphql-client"],
           "target": "generate"
         },
-        "generate-embed"
+        "generate-embed",
+        "lint-usage"
       ]
     },
     "packed-install-smoke": {

--- a/apps/ready-for-agent/ready-for-agent.usage.kdl
+++ b/apps/ready-for-agent/ready-for-agent.usage.kdl
@@ -1,0 +1,93 @@
+// Public operator CLI contract. Effect remains the runtime parser.
+// Usage 5.1.0 has no spec-level effect key; the default root invocation
+// is write, matching `start`.
+min_usage_version "5.1.0"
+name "Ready for Agent"
+bin "ready-for-agent"
+license "MIT"
+repository "https://github.com/berenddeboer/ready-for-agent"
+about "Ready for Agent operator binary (start Harness, add repositories, intake, retry, Kanban status, jump). Default invocation is write (same as start)."
+long_about #"""
+Default invocation (`ready-for-agent`) starts the Harness. It is classified write, matching `start`.
+
+Environment variables (documented here; runtime precedence and semantics are unchanged):
+
+NO_BROWSER
+  When set to a non-empty value other than 0, false, no, or off, the default start does not open a browser. The --no-open flag also disables the browser independently of this variable.
+
+HOST
+  Listen host for the default start and `start`. The --host flag wins when given. Bare --host binds all IPv4 interfaces (0.0.0.0).
+
+READY_FOR_AGENT_GRAPHQL_URL
+  GraphQL endpoint for finite commands (add, candidates, intake, retry, status, jump). Defaults to http://127.0.0.1:6056/graphql. Does not start the Harness.
+"""#
+
+flag "-h --help" help="Show help information" global=#true
+flag "-v --version" help="Show version information" global=#true
+flag "--completions <shell>" help="Print shell completion script" global=#true {
+  choices "bash" "zsh" "fish" "sh"
+}
+flag "--log-level <level>" help="Sets the minimum log level" global=#true {
+  choices "all" "trace" "debug" "info" "warn" "warning" "error" "fatal" "none"
+}
+
+// Exact root metadata switch. Hidden from docs and completions. Not an Effect flag.
+flag "--usage" hide=#true help="Reserved hidden Usage metadata switch; not an Effect-parsed flag"
+
+flag "--no-open" help="Do not open the default browser after a successful start (also: NO_BROWSER)"
+flag "--host [addr]" help="Listen host (default 127.0.0.1). Bare --host binds all interfaces (0.0.0.0); --host <addr> binds that address. Env: HOST (flag wins)" env="HOST"
+
+example "ready-for-agent" header="Default start" help="Start the Harness and open the UI"
+example "ready-for-agent start --no-open" header="Start without a browser" help="Start the Harness without opening the default browser"
+example "ready-for-agent add /path/to/local/repo" header="Add a Repository" help="Inspect a local clone and add it to the running Harness"
+example "ready-for-agent candidates github.com/owner/repo" header="Repository host/path selector" help="List Intake Candidates using a forge-host/project-path selector"
+example "ready-for-agent candidates github.com://owner/repo" header="Repository host://path selector" help="List Intake Candidates using a forge-host://project-path selector"
+example "ready-for-agent candidates owner/repo" header="Repository project-path selector" help="List Intake Candidates using a unique project path"
+example "ready-for-agent candidates repo" header="Repository final-segment selector" help="List Intake Candidates using a unique final project-path segment"
+example "ready-for-agent jump 85312e9f-9c57-42ef-9757-b2512cee57cd" header="Session continuation" help="Continue a Work Item Session by opaque backend Session ID"
+
+cmd "start" help="Start the full Harness (UI + backend); opens the browser unless --no-open / NO_BROWSER" effect="write" {
+  flag "--no-open" help="Do not open the default browser after a successful start (also: NO_BROWSER)"
+  flag "--host [addr]" help="Listen host (default 127.0.0.1). Bare --host binds all interfaces (0.0.0.0); --host <addr> binds that address. Env: HOST (flag wins)" env="HOST"
+  example "ready-for-agent start" header="Start" help="Start the Harness and open the UI"
+  example "ready-for-agent start --host" header="Start on all interfaces" help="Bind 0.0.0.0 instead of loopback"
+}
+
+cmd "add" help="Inspect and add a local repository; inferred GitLab identity can be corrected with flags" effect="write" {
+  arg "<path>" help="Path to a local git repository"
+  complete "path" type="dir"
+  flag "--forge-host <host>" help="Correct the forge host inferred from the repository remote"
+  flag "--project-path <project-path>" help="Correct the forge project path inferred from the repository remote"
+  example "ready-for-agent add /path/to/local/repo" header="Add" help="Add a local git repository"
+  example "ready-for-agent add --forge-host git.drupalcode.org --project-path project/oauth_client /path/to/local/repo" header="Correct inferred identity" help="Override the guessed GitLab host and project path"
+}
+
+cmd "candidates" help="List current Intake Candidates for one Repository as versioned JSON" effect="read" {
+  arg "<repository>" help="Repository identity as <forge-host>://<project-path>, <forge-host>/<project-path>, a unique project path, or a unique final project-path segment (case-insensitive)"
+  example "ready-for-agent candidates github.com/owner/repo" header="Candidates" help="List Intake Candidates for one Repository"
+}
+
+cmd "intake" help="Start every current Intake Candidate for one Repository as versioned JSON" effect="write" {
+  arg "<repository>" help="Repository identity as <forge-host>://<project-path>, <forge-host>/<project-path>, a unique project path, or a unique final project-path segment (case-insensitive)"
+  example "ready-for-agent intake github.com/owner/repo" header="Intake" help="Start every current Intake Candidate for one Repository"
+}
+
+cmd "retry" help="Retry one Work Item, the unfinished Work Item for one Issue, or every currently retryable Work Item as versioned JSON" effect="write" {
+  arg "<repository>" help="Repository identity as <forge-host>://<project-path>, <forge-host>/<project-path>, a unique project path, or a unique final project-path segment (case-insensitive)"
+  flag "--issue <number>" help="Retry the current unfinished Work Item for this Issue number"
+  flag "--work-item <id>" help="Retry this Work Item after verifying it belongs to the selected Repository"
+  flag "--all-retryable" help="Retry every currently retryable Work Item in the Repository (Harness-owned canRetry)"
+  flag "--max-autonomous-retries <count>" help="Maximum accepted Autonomous Retry execution attempts per Work Item at its current Lifecycle Step (default 3; --all-retryable only)"
+  example "ready-for-agent retry github.com/owner/repo --all-retryable" header="Retry all retryable" help="Retry every currently retryable Work Item in the Repository"
+}
+
+cmd "status" help="Print the current six-lane Kanban status as versioned JSON (optional repository selector)" effect="read" {
+  arg "[repository]" help="Optional repository identity as <forge-host>://<project-path>, <forge-host>/<project-path>, a unique project path, or a unique final project-path segment (case-insensitive)"
+  example "ready-for-agent status" header="Status" help="Print Kanban status for every configured Repository"
+  example "ready-for-agent status github.com/owner/repo" header="Scoped status" help="Print Kanban status for one Repository"
+}
+
+cmd "jump" help="Continue a Work Item Session (Interactive Session Continuation)" effect="destructive" {
+  arg "<session-id>" help="Opaque backend Session ID to continue"
+  example "ready-for-agent jump 85312e9f-9c57-42ef-9757-b2512cee57cd" header="Jump" help="Continue the Work Item Session in the current terminal or tmux"
+}

--- a/apps/ready-for-agent/src/cli-usage-parity.test.ts
+++ b/apps/ready-for-agent/src/cli-usage-parity.test.ts
@@ -1,0 +1,709 @@
+/**
+ * Process-level Usage contract: lint, public inventory vs Effect help,
+ * hidden metadata, and directory completion metadata.
+ */
+
+import { spawnSync } from "node:child_process"
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { fileURLToPath } from "node:url"
+import { describe, expect, test } from "bun:test"
+
+const packageRoot = fileURLToPath(new URL("..", import.meta.url))
+const usageSpecPath = join(packageRoot, "ready-for-agent.usage.kdl")
+
+const PUBLIC_COMMANDS = [
+  "start",
+  "add",
+  "candidates",
+  "intake",
+  "retry",
+  "status",
+  "jump",
+] as const
+
+const INTERNAL_TOKENS = [
+  "--ready-for-agent-internal-github-helper",
+  "--ready-for-agent-internal-gitlab-helper",
+  "--ready-for-agent-internal-keymaxxer-sidecar",
+  "ready-for-agent-internal-github-helper",
+  "ready-for-agent-internal-gitlab-helper",
+  "ready-for-agent-internal-keymaxxer-sidecar",
+] as const
+
+const REPOSITORY_SELECTOR_FORMS = [
+  "<forge-host>://<project-path>",
+  "<forge-host>/<project-path>",
+  "unique project path",
+  "unique final project-path segment",
+] as const
+
+const GLOBAL_FLAG_CHOICES = {
+  completions: ["bash", "zsh", "fish", "sh"],
+  "log-level": [
+    "all",
+    "trace",
+    "debug",
+    "info",
+    "warn",
+    "warning",
+    "error",
+    "fatal",
+    "none",
+  ],
+} as const
+
+type UsageJson = {
+  readonly min_usage_version?: string
+  readonly about?: string
+  readonly about_long?: string
+  readonly examples?: ReadonlyArray<{ readonly code: string }>
+  readonly complete?: Record<string, unknown>
+  readonly cmd: UsageCommand
+}
+
+type UsageCommand = {
+  readonly name: string
+  readonly effect?: string
+  readonly args: ReadonlyArray<UsageArg>
+  readonly flags: ReadonlyArray<UsageFlag>
+  readonly mounts?: ReadonlyArray<unknown>
+  readonly complete?: Record<string, { readonly type_?: string }>
+  readonly examples?: ReadonlyArray<{ readonly code: string }>
+  readonly subcommands: Record<string, UsageCommand>
+}
+
+type UsageArg = {
+  readonly name: string
+  readonly required: boolean
+  readonly hide?: boolean
+  readonly help?: string
+}
+
+type UsageFlag = {
+  readonly name: string
+  readonly hide?: boolean
+  readonly global?: boolean
+  readonly long?: ReadonlyArray<string>
+  readonly short?: ReadonlyArray<string>
+  readonly arg?: {
+    readonly choices?: { readonly choices?: ReadonlyArray<string> }
+  }
+}
+
+type InventoryArg = {
+  readonly name: string
+  readonly required: boolean
+}
+
+type InventoryFlag = {
+  readonly name: string
+  readonly aliases: readonly string[]
+  readonly choices: readonly string[]
+}
+
+type CommandInventory = {
+  readonly args: readonly InventoryArg[]
+  readonly flags: readonly InventoryFlag[]
+}
+
+type Inventory = Record<string, CommandInventory>
+
+const workspaceRoot = join(packageRoot, "..", "..")
+const pinnedUsage = join(workspaceRoot, "scripts", "run-pinned-usage.sh")
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value)
+
+const isStringArray = (value: unknown): value is readonly string[] =>
+  Array.isArray(value) && value.every((item) => typeof item === "string")
+
+const parseUsageArg = (value: unknown): UsageArg | undefined => {
+  if (
+    !isRecord(value) ||
+    typeof value.name !== "string" ||
+    typeof value.required !== "boolean"
+  ) {
+    return undefined
+  }
+  return {
+    name: value.name,
+    required: value.required,
+    ...(typeof value.hide === "boolean" ? { hide: value.hide } : {}),
+    ...(typeof value.help === "string" ? { help: value.help } : {}),
+  }
+}
+
+const parseUsageFlag = (value: unknown): UsageFlag | undefined => {
+  if (!isRecord(value) || typeof value.name !== "string") {
+    return undefined
+  }
+  const argRecord = isRecord(value.arg) ? value.arg : undefined
+  const choicesRecord =
+    argRecord !== undefined && isRecord(argRecord.choices)
+      ? argRecord.choices
+      : undefined
+  const listedChoices = choicesRecord?.choices
+  return {
+    name: value.name,
+    ...(typeof value.hide === "boolean" ? { hide: value.hide } : {}),
+    ...(typeof value.global === "boolean" ? { global: value.global } : {}),
+    ...(isStringArray(value.long) ? { long: value.long } : {}),
+    ...(isStringArray(value.short) ? { short: value.short } : {}),
+    ...(argRecord === undefined
+      ? {}
+      : {
+          arg: {
+            ...(listedChoices === undefined || !isStringArray(listedChoices)
+              ? {}
+              : { choices: { choices: listedChoices } }),
+          },
+        }),
+  }
+}
+
+const parseUsageCommand = (value: unknown): UsageCommand | undefined => {
+  if (
+    !isRecord(value) ||
+    typeof value.name !== "string" ||
+    !Array.isArray(value.args) ||
+    !Array.isArray(value.flags) ||
+    !isRecord(value.subcommands)
+  ) {
+    return undefined
+  }
+  const args: UsageArg[] = []
+  for (const arg of value.args) {
+    const parsed = parseUsageArg(arg)
+    if (parsed === undefined) {
+      return undefined
+    }
+    args.push(parsed)
+  }
+  const flags: UsageFlag[] = []
+  for (const flag of value.flags) {
+    const parsed = parseUsageFlag(flag)
+    if (parsed === undefined) {
+      return undefined
+    }
+    flags.push(parsed)
+  }
+  const subcommands: Record<string, UsageCommand> = {}
+  for (const [name, command] of Object.entries(value.subcommands)) {
+    const parsed = parseUsageCommand(command)
+    if (parsed === undefined) {
+      return undefined
+    }
+    subcommands[name] = parsed
+  }
+  const complete =
+    value.complete === undefined
+      ? undefined
+      : isRecord(value.complete)
+        ? Object.fromEntries(
+            Object.entries(value.complete).flatMap(([name, completer]) => {
+              if (!isRecord(completer)) {
+                return []
+              }
+              return [
+                [
+                  name,
+                  typeof completer.type_ === "string"
+                    ? { type_: completer.type_ }
+                    : {},
+                ],
+              ]
+            }),
+          )
+        : undefined
+  const examples = Array.isArray(value.examples)
+    ? value.examples.flatMap((example) =>
+        isRecord(example) && typeof example.code === "string"
+          ? [{ code: example.code }]
+          : [],
+      )
+    : undefined
+  return {
+    name: value.name,
+    ...(typeof value.effect === "string" ? { effect: value.effect } : {}),
+    args,
+    flags,
+    ...(Array.isArray(value.mounts) ? { mounts: value.mounts } : {}),
+    ...(complete === undefined ? {} : { complete }),
+    ...(examples === undefined ? {} : { examples }),
+    subcommands,
+  }
+}
+
+const parseUsageJson = (value: unknown): UsageJson | undefined => {
+  if (!isRecord(value)) {
+    return undefined
+  }
+  const cmd = parseUsageCommand(value.cmd)
+  if (cmd === undefined) {
+    return undefined
+  }
+  const examples = Array.isArray(value.examples)
+    ? value.examples.flatMap((example) =>
+        isRecord(example) && typeof example.code === "string"
+          ? [{ code: example.code }]
+          : [],
+      )
+    : undefined
+  return {
+    ...(typeof value.min_usage_version === "string"
+      ? { min_usage_version: value.min_usage_version }
+      : {}),
+    ...(typeof value.about === "string" ? { about: value.about } : {}),
+    ...(typeof value.about_long === "string"
+      ? { about_long: value.about_long }
+      : {}),
+    ...(examples === undefined ? {} : { examples }),
+    ...(isRecord(value.complete) ? { complete: value.complete } : {}),
+    cmd,
+  }
+}
+
+const stripAnsi = (text: string): string => {
+  const ansiEscape = String.fromCharCode(27)
+  return text.split(ansiEscape).reduce((acc, chunk, index) => {
+    if (index === 0) {
+      return chunk
+    }
+    return acc + chunk.replace(/^\[[0-9;]*m/, "")
+  }, "")
+}
+
+const runUsage = (
+  args: readonly string[],
+  cwd: string = packageRoot,
+): {
+  readonly status: number | null
+  readonly stdout: string
+  readonly stderr: string
+} => {
+  const result = spawnSync("bash", [pinnedUsage, ...args], {
+    cwd,
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      NO_COLOR: "1",
+    },
+  })
+  return {
+    status: result.status,
+    stdout: result.stdout ?? "",
+    stderr: result.stderr ?? "",
+  }
+}
+
+const requireUsage510 = (): void => {
+  const version = runUsage(["--version"])
+  expect(version.status, version.stderr).toBe(0)
+  expect(version.stdout).toContain("5.1.0")
+}
+
+const usageJson = (): UsageJson => {
+  const generated = runUsage(["generate", "json", "-f", usageSpecPath])
+  expect(generated.status, generated.stderr).toBe(0)
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(generated.stdout)
+  } catch {
+    expect(generated.stdout, "Usage JSON").toMatch(/^\{/)
+    throw new Error("Usage generate json did not emit JSON")
+  }
+  const spec = parseUsageJson(parsed)
+  expect(spec, generated.stdout).toBeDefined()
+  if (spec === undefined) {
+    throw new Error("Usage JSON failed the public-inventory shape check")
+  }
+  return spec
+}
+
+const runEffectHelp = (args: readonly string[]): string => {
+  const result = spawnSync(
+    "bun",
+    ["--conditions", "@ready-for-agent/source", "src/main.ts", ...args],
+    {
+      cwd: packageRoot,
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        NO_COLOR: "1",
+        FORCE_COLOR: "0",
+      },
+    },
+  )
+  const output = `${result.stdout ?? ""}\n${result.stderr ?? ""}`
+  expect(result.status, output).toBe(0)
+  return stripAnsi(output)
+}
+
+const sectionBody = (help: string, heading: string): string => {
+  const lines = help.split("\n")
+  const start = lines.findIndex((line) => line.trim() === heading)
+  if (start < 0) {
+    return ""
+  }
+  const body: string[] = []
+  for (const line of lines.slice(start + 1)) {
+    if (/^[A-Z][A-Z ]+$/.test(line.trim()) && line.trim() !== heading) {
+      break
+    }
+    body.push(line)
+  }
+  return body.join("\n")
+}
+
+const parseHelpCommands = (help: string): string[] => {
+  const names: string[] = []
+  for (const line of sectionBody(help, "SUBCOMMANDS").split("\n")) {
+    const match = line.trim().match(/^([a-z][a-z0-9-]*)\b/)
+    if (match?.[1] !== undefined) {
+      names.push(match[1])
+    }
+  }
+  return names.sort()
+}
+
+const parseHelpArgs = (help: string): InventoryArg[] => {
+  const args: InventoryArg[] = []
+  for (const line of sectionBody(help, "ARGUMENTS").split("\n")) {
+    const match = line.trim().match(/^([a-z][a-z0-9-]*)\b/i)
+    if (match?.[1] === undefined) {
+      continue
+    }
+    args.push({
+      name: match[1],
+      required: !line.includes("(optional)"),
+    })
+  }
+  return args.sort((left, right) => left.name.localeCompare(right.name))
+}
+
+const parseFlagLine = (line: string): InventoryFlag | undefined => {
+  const trimmed = line.trim()
+  if (!trimmed.startsWith("--") && !trimmed.startsWith("-")) {
+    return undefined
+  }
+  const longNames = [...trimmed.matchAll(/--([a-z0-9-]+)/gi)].map(
+    (match) => match[1] ?? "",
+  )
+  const name = longNames[0]
+  if (name === undefined || name === "") {
+    return undefined
+  }
+  const aliases = [...trimmed.matchAll(/(?<![a-z0-9-])-([a-z])\b/gi)]
+    .map((match) => match[1] ?? "")
+    .filter((alias) => alias.length === 1)
+  const metavar = trimmed.match(/<([^>]+)>/)?.[1]
+  const listed = trimmed.match(/\(choices:\s*([^)]+)\)/i)?.[1]
+  const choices = [
+    ...(metavar?.includes("|") ? metavar.split("|") : []),
+    ...(listed?.split(",") ?? []).map((choice) => choice.trim()),
+  ].filter((choice) => choice.length > 0)
+  return {
+    name,
+    aliases: [...new Set(aliases)].sort(),
+    choices: [...new Set(choices)].sort(),
+  }
+}
+
+const parseHelpFlags = (help: string, heading: string): InventoryFlag[] => {
+  const flags: InventoryFlag[] = []
+  for (const line of sectionBody(help, heading).split("\n")) {
+    const flag = parseFlagLine(line)
+    if (flag !== undefined) {
+      flags.push(flag)
+    }
+  }
+  return flags.sort((left, right) => left.name.localeCompare(right.name))
+}
+
+const usageArgInventory = (args: ReadonlyArray<UsageArg>): InventoryArg[] =>
+  args
+    .filter((arg) => arg.hide !== true)
+    .map((arg) => ({ name: arg.name, required: arg.required }))
+    .sort((left, right) => left.name.localeCompare(right.name))
+
+const usageFlagInventory = (flags: ReadonlyArray<UsageFlag>): InventoryFlag[] =>
+  flags
+    .filter((flag) => flag.hide !== true)
+    .map((flag) => ({
+      name: flag.name,
+      aliases: [...(flag.short ?? [])].sort(),
+      choices: [...(flag.arg?.choices?.choices ?? [])].sort(),
+    }))
+    .sort((left, right) => left.name.localeCompare(right.name))
+
+const mergeFlags = (
+  local: readonly InventoryFlag[],
+  global: readonly InventoryFlag[],
+): InventoryFlag[] => {
+  const byName = new Map<string, InventoryFlag>()
+  for (const flag of [...global, ...local]) {
+    byName.set(flag.name, flag)
+  }
+  return [...byName.values()].sort((left, right) =>
+    left.name.localeCompare(right.name),
+  )
+}
+
+const inventoryFromUsage = (spec: UsageJson): Inventory => {
+  const rootFlags = spec.cmd.flags.filter((flag) => flag.hide !== true)
+  const globalFlags = usageFlagInventory(
+    rootFlags.filter((flag) => flag.global === true),
+  )
+  const rootLocalFlags = usageFlagInventory(
+    rootFlags.filter((flag) => flag.global !== true),
+  )
+  const inventory: Inventory = {
+    "": {
+      args: usageArgInventory(spec.cmd.args),
+      flags: mergeFlags(rootLocalFlags, globalFlags),
+    },
+  }
+  for (const [name, command] of Object.entries(spec.cmd.subcommands)) {
+    inventory[name] = {
+      args: usageArgInventory(command.args),
+      flags: mergeFlags(usageFlagInventory(command.flags), globalFlags),
+    }
+  }
+  return inventory
+}
+
+const inventoryFromEffectHelp = (): Inventory => {
+  const rootHelp = runEffectHelp(["--help"])
+  const inventory: Inventory = {
+    "": {
+      args: parseHelpArgs(rootHelp),
+      flags: mergeFlags(
+        parseHelpFlags(rootHelp, "FLAGS"),
+        parseHelpFlags(rootHelp, "GLOBAL FLAGS"),
+      ),
+    },
+  }
+  for (const name of parseHelpCommands(rootHelp)) {
+    const help = runEffectHelp([name, "--help"])
+    inventory[name] = {
+      args: parseHelpArgs(help),
+      flags: mergeFlags(
+        parseHelpFlags(help, "FLAGS"),
+        parseHelpFlags(help, "GLOBAL FLAGS"),
+      ),
+    }
+  }
+  return inventory
+}
+
+const namesOf = (inventory: Inventory): string[] =>
+  Object.keys(inventory).sort()
+
+const flagNames = (flags: readonly InventoryFlag[]): string[] =>
+  flags.map((flag) => flag.name)
+
+describe("operator CLI Usage contract", () => {
+  test("pinned Usage 5.1.0 lints the contract with warnings as errors", () => {
+    requireUsage510()
+    const lint = runUsage(["lint", "--warnings-as-errors", usageSpecPath])
+    expect(lint.status, `${lint.stdout}\n${lint.stderr}`).toBe(0)
+  })
+
+  test("contract metadata, effects, selectors, env, examples, and hidden switch", () => {
+    const spec = usageJson()
+    expect(spec.min_usage_version).toBe("5.1.0")
+    expect(spec.about).toContain("write")
+    expect(spec.about_long).toContain("NO_BROWSER")
+    expect(spec.about_long).toContain("HOST")
+    expect(spec.about_long).toContain("READY_FOR_AGENT_GRAPHQL_URL")
+    expect(spec.cmd.mounts ?? []).toEqual([])
+    expect(spec.complete ?? {}).toEqual({})
+
+    const hidden = spec.cmd.flags.filter((flag) => flag.hide === true)
+    expect(hidden.map((flag) => flag.name)).toEqual(["usage"])
+
+    const publicRootFlags = spec.cmd.flags
+      .filter((flag) => flag.hide !== true)
+      .map((flag) => flag.name)
+    expect(publicRootFlags).not.toContain("usage")
+    expect(publicRootFlags).not.toContain("no-no-open")
+
+    const effects = Object.fromEntries(
+      PUBLIC_COMMANDS.map((name) => [name, spec.cmd.subcommands[name]?.effect]),
+    )
+    expect(effects).toEqual({
+      start: "write",
+      add: "write",
+      candidates: "read",
+      intake: "write",
+      retry: "write",
+      status: "read",
+      jump: "destructive",
+    })
+
+    expect(spec.cmd.subcommands.add?.complete?.path?.type_).toBe("dir")
+    expect(
+      spec.cmd.subcommands.add?.flags.some((flag) => flag.name === "run"),
+    ).toBe(false)
+
+    const repositoryHelp = [
+      spec.cmd.subcommands.candidates?.args[0]?.help,
+      spec.cmd.subcommands.intake?.args[0]?.help,
+      spec.cmd.subcommands.retry?.args[0]?.help,
+      spec.cmd.subcommands.status?.args[0]?.help,
+    ]
+    for (const help of repositoryHelp) {
+      expect(help).toBeDefined()
+      for (const form of REPOSITORY_SELECTOR_FORMS) {
+        expect(help).toContain(form)
+      }
+      expect(help?.toLowerCase()).toContain("case-insensitive")
+    }
+
+    const exampleCodes = [
+      ...(spec.examples ?? []).map((example) => example.code),
+      ...PUBLIC_COMMANDS.flatMap((name) =>
+        (spec.cmd.subcommands[name]?.examples ?? []).map(
+          (example) => example.code,
+        ),
+      ),
+    ]
+    expect(exampleCodes.some((code) => code === "ready-for-agent")).toBe(true)
+    for (const name of PUBLIC_COMMANDS) {
+      expect(
+        exampleCodes.some((code) => code.startsWith(`ready-for-agent ${name}`)),
+      ).toBe(true)
+    }
+    expect(exampleCodes.some((code) => code.includes("github.com://"))).toBe(
+      true,
+    )
+    expect(
+      exampleCodes.some((code) =>
+        /ready-for-agent candidates owner\/repo$/.test(code),
+      ),
+    ).toBe(true)
+    expect(
+      exampleCodes.some((code) =>
+        /ready-for-agent candidates repo$/.test(code),
+      ),
+    ).toBe(true)
+    expect(
+      exampleCodes.some((code) => code.startsWith("ready-for-agent jump ")),
+    ).toBe(true)
+  })
+
+  test("Usage JSON and Effect help inventories match in both directions", () => {
+    const spec = usageJson()
+    const usageInventory = inventoryFromUsage(spec)
+    const effectInventory = inventoryFromEffectHelp()
+
+    expect(namesOf(usageInventory)).toEqual(namesOf(effectInventory))
+    expect(namesOf(effectInventory)).toEqual([
+      "",
+      ...[...PUBLIC_COMMANDS].sort(),
+    ])
+
+    for (const command of namesOf(effectInventory)) {
+      const usageCommand = usageInventory[command]
+      const effectCommand = effectInventory[command]
+      expect(usageCommand, command).toBeDefined()
+      expect(effectCommand, command).toBeDefined()
+      expect(usageCommand?.args, `${command} args`).toEqual(effectCommand?.args)
+      expect(usageCommand?.flags, `${command} Usage flags`).toEqual(
+        effectCommand?.flags,
+      )
+      expect(effectCommand?.flags, `${command} Effect flags`).toEqual(
+        usageCommand?.flags,
+      )
+      expect(flagNames(usageCommand?.flags ?? [])).not.toContain("no-no-open")
+      expect(flagNames(effectCommand?.flags ?? [])).not.toContain("usage")
+    }
+
+    const effectRootFlags = effectInventory[""]?.flags ?? []
+    const completions = effectRootFlags.find(
+      (flag) => flag.name === "completions",
+    )
+    const logLevel = effectRootFlags.find((flag) => flag.name === "log-level")
+    expect(completions?.choices).toEqual(
+      [...GLOBAL_FLAG_CHOICES.completions].sort(),
+    )
+    expect(logLevel?.choices).toEqual(
+      [...GLOBAL_FLAG_CHOICES["log-level"]].sort(),
+    )
+    expect(
+      effectRootFlags.find((flag) => flag.name === "help")?.aliases,
+    ).toEqual(["h"])
+    expect(
+      effectRootFlags.find((flag) => flag.name === "version")?.aliases,
+    ).toEqual(["v"])
+  })
+
+  test("hidden metadata and internal helper modes stay off public generated surfaces", () => {
+    const markdown = runUsage(["generate", "markdown", "-f", usageSpecPath])
+    expect(markdown.status, markdown.stderr).toBe(0)
+    expect(markdown.stdout).not.toContain("--usage")
+    expect(markdown.stdout).not.toContain("--no-no-open")
+    for (const token of INTERNAL_TOKENS) {
+      expect(markdown.stdout).not.toContain(token)
+    }
+
+    const rootWords = runUsage([
+      "complete-word",
+      "-f",
+      usageSpecPath,
+      "--",
+      "ready-for-agent",
+      "",
+    ])
+    expect(rootWords.status, rootWords.stderr).toBe(0)
+    expect(rootWords.stdout.trim().split("\n").sort()).toEqual(
+      [...PUBLIC_COMMANDS].sort(),
+    )
+    for (const token of INTERNAL_TOKENS) {
+      expect(rootWords.stdout).not.toContain(token)
+    }
+
+    const rootFlags = runUsage([
+      "complete-word",
+      "-f",
+      usageSpecPath,
+      "--",
+      "ready-for-agent",
+      "--",
+    ])
+    expect(rootFlags.status, rootFlags.stderr).toBe(0)
+    expect(rootFlags.stdout).toContain("--help")
+    expect(rootFlags.stdout).toContain("--version")
+    expect(rootFlags.stdout).toContain("--completions")
+    expect(rootFlags.stdout).toContain("--log-level")
+    expect(rootFlags.stdout).toContain("--no-open")
+    expect(rootFlags.stdout).toContain("--host")
+    expect(rootFlags.stdout).not.toContain("--usage")
+    expect(rootFlags.stdout).not.toContain("--no-no-open")
+
+    const tempRoot = mkdtempSync(join(tmpdir(), "ready-for-agent-usage-"))
+    try {
+      writeFileSync(join(tempRoot, "notes.txt"), "file\n")
+      mkdirSync(join(tempRoot, "repo-dir"))
+      const addWords = runUsage(
+        [
+          "complete-word",
+          "-f",
+          usageSpecPath,
+          "--",
+          "ready-for-agent",
+          "add",
+          "",
+        ],
+        tempRoot,
+      )
+      expect(addWords.status, addWords.stderr).toBe(0)
+      expect(addWords.stdout).toContain("repo-dir")
+      expect(addWords.stdout).not.toContain("notes.txt")
+    } finally {
+      rmSync(tempRoot, { recursive: true, force: true })
+    }
+  })
+})

--- a/biome.json
+++ b/biome.json
@@ -16,7 +16,8 @@
       "!!**/generated",
       "!!**/routeTree.gen.ts",
       "!!**/drizzle",
-      "!!**/prototypes/**"
+      "!!**/prototypes/**",
+      "!!**/*.kdl"
     ]
   },
   "formatter": {

--- a/knip.json
+++ b/knip.json
@@ -7,7 +7,7 @@
     "nx",
     "tslib"
   ],
-  "ignoreBinaries": ["skills", "pgrep", "ps"],
+  "ignoreBinaries": ["skills", "pgrep", "ps", "usage"],
   "ignoreFiles": [".opencode/plugin/**"],
   "workspaces": {
     ".": {

--- a/mise.toml
+++ b/mise.toml
@@ -4,6 +4,9 @@ min_version = "2026.7.0"
 # Authoritative Bun pin. GitHub Actions must use the same version.
 bun = "1.3.14"
 hk = "1.54.1"
+# Authoritative Usage pin for the operator CLI contract.
+# GitHub Actions must install this same version before Usage-dependent targets.
+usage = "5.1.0"
 
 [tasks.bootstrap]
 description = "Install workspace dependencies"

--- a/scripts/project.json
+++ b/scripts/project.json
@@ -17,6 +17,7 @@
         "{workspaceRoot}/.github/**/*.yml",
         "{workspaceRoot}/.github/**/*.yaml",
         "{projectRoot}/tool-pins.test.ts",
+        "{projectRoot}/run-pinned-usage.sh",
         "{projectRoot}/fix-bun-typescript-for-nx.mjs",
         "{projectRoot}/fix-bun-typescript-for-nx.test.ts"
       ],

--- a/scripts/run-pinned-usage.sh
+++ b/scripts/run-pinned-usage.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Invoke the workspace-pinned Usage CLI without relying on an untrusted mise shim.
+set -euo pipefail
+
+root="$(cd "$(dirname "$0")/.." && pwd)"
+expected="$(sed -n 's/^usage = "\([^"]*\)"/\1/p' "${root}/mise.toml")"
+if [[ -z "${expected}" ]]; then
+  echo "error: no usage pin in ${root}/mise.toml" >&2
+  exit 1
+fi
+
+try_bin() {
+  local bin=$1
+  shift
+  if [[ ! -x "${bin}" ]]; then
+    return 1
+  fi
+  local ver
+  ver="$("${bin}" --version 2>/dev/null || true)"
+  ver="${ver//$'\r'/}"
+  ver="${ver%%$'\n'*}"
+  if [[ "${ver}" == "usage-cli ${expected}" ]]; then
+    exec "${bin}" "$@"
+  fi
+  return 1
+}
+
+if [[ -n "${USAGE_BIN:-}" ]]; then
+  try_bin "${USAGE_BIN}" "$@" || {
+    echo "error: USAGE_BIN is not Usage ${expected}" >&2
+    exit 1
+  }
+fi
+
+if [[ -n "${HOME:-}" ]]; then
+  try_bin "${HOME}/.local/share/mise/installs/usage/${expected}/usage" "$@" || true
+fi
+
+if command -v usage >/dev/null 2>&1; then
+  try_bin "$(command -v usage)" "$@" || true
+fi
+
+echo "error: Usage CLI ${expected} is required (see mise.toml). Install with: mise install" >&2
+exit 1

--- a/scripts/tool-pins.test.ts
+++ b/scripts/tool-pins.test.ts
@@ -1,3 +1,4 @@
+import { spawnSync } from "node:child_process"
 import { readFileSync, readdirSync } from "node:fs"
 import { join } from "node:path"
 import { describe, expect, it } from "bun:test"
@@ -46,11 +47,12 @@ describe("contributor environment pins", () => {
   const miseToml = readWorkspace("mise.toml")
   const hkPkl = readWorkspace("hk.pkl")
 
-  it("declares a concrete Bun pin in mise.toml without machine-global bootstrap packages", () => {
+  it("declares concrete Bun, hk, and Usage pins in mise.toml without machine-global bootstrap packages", () => {
     const bunVersion = quotedAssignment(miseToml, "bun")
     expect(bunVersion).toMatch(/^\d+\.\d+\.\d+$/)
     expect(quotedAssignment(miseToml, "min_version")).toBe("2026.7.0")
     expect(quotedAssignment(miseToml, "hk")).toMatch(/^\d+\.\d+\.\d+$/)
+    expect(quotedAssignment(miseToml, "usage")).toBe("5.1.0")
     expect(miseToml).not.toContain("[bootstrap.packages]")
   })
 
@@ -102,6 +104,32 @@ describe("contributor environment pins", () => {
       expect(block).toMatch(
         new RegExp(`bun-version:\\s*["']?${bunVersion}["']?`),
       )
+    }
+  })
+
+  it("installs the mise.toml Usage pin in quality-gate workflows", () => {
+    const usageVersion = quotedAssignment(miseToml, "usage")
+    expect(usageVersion).toBe("5.1.0")
+    const wrapper = spawnSync(
+      "bash",
+      [join(workspaceRoot, "scripts", "run-pinned-usage.sh"), "--version"],
+      { encoding: "utf8" },
+    )
+    expect(wrapper.status, wrapper.stderr).toBe(0)
+    expect(wrapper.stdout.trim()).toBe(`usage-cli ${usageVersion}`)
+
+    const qualityGateFiles = [
+      ".github/workflows/pr.yml",
+      ".github/workflows/ci-cd.yml",
+    ] as const
+    for (const relativePath of qualityGateFiles) {
+      const contents = readWorkspace(relativePath)
+      expect(contents, relativePath).toContain(`VERSION=${usageVersion}`)
+      expect(contents, relativePath).toContain("jdx/usage/releases/download/v")
+      expect(contents, relativePath).toContain(
+        "usage-x86_64-unknown-linux-musl.tar.gz",
+      )
+      expect(contents, relativePath).not.toMatch(/usage-cli@latest/i)
     }
   })
 })


### PR DESCRIPTION
## Why

The public `ready-for-agent` operator CLI only existed inside the Effect
runtime parser. Maintainers and tools could not inspect or lint the command
surface from the repo, and nothing failed when the contract and `--help`
drifted apart.

## What

Adds a checked-in Usage v5.1.0 KDL contract
(`apps/ready-for-agent/ready-for-agent.usage.kdl`) for the default start and
the public subcommands: `start`, `add`, `candidates`, `intake`, `retry`,
`status`, and `jump`.

- Command effects: `write` for default start / `start` / `add` / `intake` /
  `retry`, `read` for `candidates` / `status`, and `destructive` for `jump`.
  Usage 5.1.0 has no spec-level `effect` on the implicit root command, so the
  default invocation is documented as `write` in `about` / `long_about`.
- The contract lists public args and flags, Effect globals and their finite
  choices, all case-insensitive Repository selector forms, `NO_BROWSER` /
  `HOST` / `READY_FOR_AGENT_GRAPHQL_URL` (no runtime precedence change),
  examples, and directory completion for `add <path>`.
- Hidden reserved `--usage` metadata and Keymaxxer / GitHub / GitLab internal
  modes stay off generated docs and completion candidates. No dynamic
  Repository or Session completion.
- `retry` is included because it is a public Effect command; bidirectional
  inventory parity would fail without it.

Usage `5.1.0` is pinned in `mise.toml`. `ready-for-agent:lint-usage` runs
`usage lint --warnings-as-errors` through `scripts/run-pinned-usage.sh` so
hooks and tests do not depend on an untrusted mise shim. Quality-gate
workflows install the same release.

Effect remains the runtime parser and executor. `--usage` emission and
generated README docs are left to #1092 and #1093.

## Verification

- `bunx nx run ready-for-agent:lint-usage`
- Process-level parity: Usage JSON vs Effect `--help` for commands, args, and
  flag names / aliases / choices, both directions
- Hidden `--usage` and internal helper tokens absent from generated markdown
  and `complete-word`
- `bunx nx run ready-for-agent:test` and workspace tool-pin tests (wrapper
  `--version` matches the mise pin)
- Pre-commit hook passed after the pinned-Usage wrapper change

Closes #1091