### PR TITLE
feat(cli): emit the checked-in Usage spec from exact --usage

### DIFF
--- a/apps/ready-for-agent/scripts/packed-install-smoke.ts
+++ b/apps/ready-for-agent/scripts/packed-install-smoke.ts
@@ -437,8 +437,8 @@ try {
     KEYMAXXER_ENTRYPOINT: "",
   }
 
-  // Assert product PATH cannot resolve bun/nx/keymaxxer.
-  for (const forbidden of ["bun", "nx", "keymaxxer"] as const) {
+  // Assert product PATH cannot resolve bun/nx/keymaxxer/usage.
+  for (const forbidden of ["bun", "nx", "keymaxxer", "usage"] as const) {
     const which = spawnSync(
       "bash",
       ["-lc", `command -v ${forbidden} || true`],
@@ -473,6 +473,32 @@ try {
     )
   }
   log(`version ok: ${versionText}`)
+
+  log("checking --usage via installed command")
+  const usageSpec = readFileSync(
+    join(appRoot, "ready-for-agent.usage.kdl"),
+    "utf8",
+  )
+  const usageResult = spawnSync(installedBin, ["--usage"], {
+    cwd: runCwd,
+    env: productEnv,
+    encoding: "utf8",
+  })
+  stdoutLog += usageResult.stdout ?? ""
+  stderrLog += usageResult.stderr ?? ""
+  if (usageResult.status !== 0) {
+    fail(`--usage failed: ${usageResult.stderr ?? usageResult.stdout ?? ""}`)
+  }
+  if (usageResult.stderr !== "") {
+    fail(`--usage wrote to stderr: ${usageResult.stderr}`)
+  }
+  if (usageResult.stdout !== usageSpec) {
+    fail("--usage stdout did not match the checked-in Usage KDL contract")
+  }
+  if (existsSync(databasePath)) {
+    fail("--usage must not create the Harness database")
+  }
+  log("usage contract ok")
 
   const port = productEnv.PORT as string
   const base = `http://127.0.0.1:${port}`

--- a/apps/ready-for-agent/src/bun-file-modules.d.ts
+++ b/apps/ready-for-agent/src/bun-file-modules.d.ts
@@ -1,3 +1,8 @@
+declare module "*.kdl" {
+  const content: string
+  export default content
+}
+
 declare module "*.html" {
   const path: string
   export default path

--- a/apps/ready-for-agent/src/cli-usage-emission.test.ts
+++ b/apps/ready-for-agent/src/cli-usage-emission.test.ts
@@ -1,0 +1,165 @@
+/**
+ * Process-level `ready-for-agent --usage` contract: exact stdout, empty
+ * stderr, exit 0, and no Harness / GraphQL / Effect CLI startup.
+ */
+
+import { spawnSync } from "node:child_process"
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs"
+import { createServer } from "node:http"
+import { tmpdir } from "node:os"
+import { join } from "node:path"
+import { fileURLToPath } from "node:url"
+import { describe, expect, test } from "bun:test"
+
+const packageRoot = fileURLToPath(new URL("..", import.meta.url))
+const mainPath = join(packageRoot, "src/main.ts")
+const usageSpecPath = join(packageRoot, "ready-for-agent.usage.kdl")
+
+const checkedInUsageContract = readFileSync(usageSpecPath, "utf8")
+
+type ProcessResult = {
+  readonly status: number | null
+  readonly stdout: string
+  readonly stderr: string
+}
+
+const runSourceCli = (
+  args: readonly string[],
+  options: {
+    readonly cwd?: string
+    readonly env?: NodeJS.ProcessEnv
+  } = {},
+): ProcessResult => {
+  const env: NodeJS.ProcessEnv = {
+    ...process.env,
+    NO_COLOR: "1",
+    FORCE_COLOR: "0",
+    ...options.env,
+  }
+  const result = spawnSync(
+    "bun",
+    ["--conditions", "@ready-for-agent/source", mainPath, ...args],
+    {
+      cwd: options.cwd ?? packageRoot,
+      encoding: "utf8",
+      env,
+    },
+  )
+  return {
+    status: result.status,
+    stdout: result.stdout ?? "",
+    stderr: result.stderr ?? "",
+  }
+}
+
+describe("source process Usage metadata emission", () => {
+  test("exact root --usage writes the checked-in contract and exits 0", () => {
+    const result = runSourceCli(["--usage"])
+
+    expect(result.status).toBe(0)
+    expect(result.stderr).toBe("")
+    expect(result.stdout).toBe(checkedInUsageContract)
+    expect(result.stdout.endsWith("\n")).toBe(true)
+    expect(result.stdout.endsWith("\n\n")).toBe(false)
+    expect(result.stdout).toContain('min_usage_version "5.1.0"')
+  })
+
+  test("successful emission does not start the Harness or contact GraphQL", async () => {
+    const fixtureRoot = mkdtempSync(join(tmpdir(), "ready-for-agent-usage-"))
+    const databasePath = join(fixtureRoot, "ready-for-agent.db")
+    let graphqlHits = 0
+    const server = createServer((_req, res) => {
+      graphqlHits += 1
+      res.writeHead(500)
+      res.end("unexpected")
+    })
+    await new Promise<void>((resolve, reject) => {
+      server.listen(0, "127.0.0.1", () => resolve())
+      server.on("error", reject)
+    })
+    const address = server.address()
+    if (address === null || typeof address === "string") {
+      server.close()
+      throw new Error("expected TCP address")
+    }
+    const graphqlUrl = `http://127.0.0.1:${address.port}/graphql`
+
+    try {
+      const result = runSourceCli(["--usage"], {
+        cwd: fixtureRoot,
+        env: {
+          READY_FOR_AGENT_GRAPHQL_URL: graphqlUrl,
+          SQLITE_DATABASE_PATH: databasePath,
+          PORT: String(18_900 + Math.floor(Math.random() * 80)),
+          NO_BROWSER: "1",
+        },
+      })
+
+      expect(result.status).toBe(0)
+      expect(result.stderr).toBe("")
+      expect(result.stdout).toBe(checkedInUsageContract)
+      expect(result.stdout.toLowerCase()).not.toContain("starting harness")
+      expect(result.stdout.toLowerCase()).not.toContain("listening on")
+      expect(result.stderr.toLowerCase()).not.toContain("starting harness")
+      expect(graphqlHits).toBe(0)
+      expect(existsSync(databasePath)).toBe(false)
+    } finally {
+      await new Promise<void>((resolve) => {
+        server.close(() => resolve())
+      })
+      rmSync(fixtureRoot, { recursive: true, force: true })
+    }
+  })
+
+  test("other --usage placements are not the metadata invocation", () => {
+    const placements = [
+      ["--usage", "extra"],
+      ["start", "--usage"],
+      ["--help", "--usage"],
+      ["--USAGE"],
+      ["--usage=1"],
+    ] as const
+
+    for (const args of placements) {
+      const result = runSourceCli(args)
+      expect(result.stdout, args.join(" ")).not.toBe(checkedInUsageContract)
+      expect(result.stdout, args.join(" ")).not.toContain(
+        'min_usage_version "5.1.0"',
+      )
+    }
+  })
+
+  test("Effect help, version, and completions stay public and hide --usage", () => {
+    const help = runSourceCli(["--help"])
+    expect(help.status).toBe(0)
+    expect(`${help.stdout}\n${help.stderr}`).toContain("start")
+    expect(`${help.stdout}\n${help.stderr}`).not.toContain("--usage")
+
+    const version = runSourceCli(["--version"])
+    expect(version.status).toBe(0)
+    expect(version.stdout.trim().length).toBeGreaterThan(0)
+    expect(version.stdout).not.toBe(checkedInUsageContract)
+    expect(version.stdout).not.toContain("--usage")
+
+    const completions = runSourceCli(["--completions", "bash"])
+    expect(completions.status).toBe(0)
+    expect(completions.stdout.length).toBeGreaterThan(0)
+    expect(completions.stdout).not.toContain("--usage")
+  })
+
+  test("internal helper dispatch is unchanged and does not emit the contract", () => {
+    const helper = runSourceCli(["--ready-for-agent-internal-github-helper"])
+    expect(helper.stdout).not.toBe(checkedInUsageContract)
+    expect(helper.stdout).not.toContain('min_usage_version "5.1.0"')
+    expect(helper.stderr).toContain("Unknown GitHub helper operation")
+    expect(helper.status).not.toBe(0)
+
+    const helperWithUsage = runSourceCli([
+      "--ready-for-agent-internal-github-helper",
+      "--usage",
+    ])
+    expect(helperWithUsage.stdout).not.toBe(checkedInUsageContract)
+    expect(helperWithUsage.stderr).toContain("Unknown GitHub helper operation")
+    expect(helperWithUsage.status).not.toBe(0)
+  })
+})

--- a/apps/ready-for-agent/src/host-binary.test.ts
+++ b/apps/ready-for-agent/src/host-binary.test.ts
@@ -225,6 +225,52 @@ describe("compiled host binary ambient-auth smoke", () => {
     expect(haystack.includes("Install AWS CLI")).toBe(false)
   })
 
+  test("emits the embedded Usage contract without starting the Harness", () => {
+    const usageSpec = readFileSync(
+      join(appRoot, "ready-for-agent.usage.kdl"),
+      "utf8",
+    )
+    const env: NodeJS.ProcessEnv = {
+      HOME: process.env.HOME,
+      PATH: restrictedBin,
+      PORT: String(port),
+      SQLITE_DATABASE_PATH: databasePath,
+      KEYMAXXER_ENABLED: "false",
+      NO_BROWSER: "1",
+    }
+
+    const usage = Bun.spawnSync([binaryPath, "--usage"], {
+      cwd: runCwd,
+      env,
+      stdout: "pipe",
+      stderr: "pipe",
+    })
+    expect(usage.exitCode).toBe(0)
+    expect(new TextDecoder().decode(usage.stderr)).toBe("")
+    expect(new TextDecoder().decode(usage.stdout)).toBe(usageSpec)
+    expect(existsSync(databasePath)).toBe(false)
+
+    const help = Bun.spawnSync([binaryPath, "--help"], {
+      cwd: runCwd,
+      env,
+      stdout: "pipe",
+      stderr: "pipe",
+    })
+    expect(help.exitCode).toBe(0)
+    expect(new TextDecoder().decode(help.stdout)).not.toContain("--usage")
+
+    const completions = Bun.spawnSync([binaryPath, "--completions", "bash"], {
+      cwd: runCwd,
+      env,
+      stdout: "pipe",
+      stderr: "pipe",
+    })
+    expect(completions.exitCode).toBe(0)
+    expect(new TextDecoder().decode(completions.stdout)).not.toContain(
+      "--usage",
+    )
+  })
+
   test("starts UI, assets, GraphQL, migrates, restarts, reports version, shuts down", async () => {
     const env: NodeJS.ProcessEnv = {
       HOME: process.env.HOME,

--- a/apps/ready-for-agent/src/main.ts
+++ b/apps/ready-for-agent/src/main.ts
@@ -1,74 +1,82 @@
 #!/usr/bin/env bun
 import {
-  isInternalGitHubHelperMode,
-  runGitHubHelperProcess,
-} from "@ready-for-agent/github-service"
-import {
-  isInternalGitLabHelperMode,
-  runGitLabHelperProcess,
-} from "@ready-for-agent/gitlab-service"
-import {
-  isInternalKeymaxxerSidecarMode,
-  runKeymaxxerSidecarProcess,
-} from "@ready-for-agent/keymaxxer-service"
-import { READY_FOR_AGENT_VERSION } from "./generated/version.ts"
+  isExactUsageMetadataInvocation,
+  usageContractText,
+} from "./usage-contract.ts"
 
-if (isInternalKeymaxxerSidecarMode(process.argv)) {
-  await runKeymaxxerSidecarProcess()
-} else if (isInternalGitHubHelperMode(process.argv)) {
-  runGitHubHelperProcess()
-} else if (isInternalGitLabHelperMode(process.argv)) {
-  runGitLabHelperProcess()
+// Exact root `--usage` is hidden metadata, not an Effect-parsed flag.
+if (isExactUsageMetadataInvocation(process.argv.slice(2))) {
+  process.stdout.write(usageContractText())
 } else {
-  const { BunRuntime, BunServices } = await import("@effect/platform-bun")
-  const { Effect, Layer } = await import("effect")
-  const { Command } = await import("effect/unstable/cli")
-  const { expandBareHostFlag } = await import(
-    "../../harness/src/server/listen-host.ts"
+  const { isInternalGitHubHelperMode, runGitHubHelperProcess } = await import(
+    "@ready-for-agent/github-service"
   )
-  const { cli } = await import("./cli.ts")
-  const { ApplicationConfig } = await import("./services/application-config.ts")
-  const { ExecutablePath } = await import("./services/executable-path.ts")
-  const { GraphqlApi } = await import("./services/graphql-api.ts")
-  const { LocalGit } = await import("./services/local-git.ts")
-  const { StartHarness } = await import("./services/start-harness.ts")
-  const { DirectTerminal } = await import("./services/direct-terminal.ts")
-  const { Tmux } = await import("./services/tmux.ts")
-
-  const MainLive = Layer.mergeAll(
-    LocalGit.layer,
-    GraphqlApi.layer,
-    StartHarness.layer,
-    Tmux.layer,
-    DirectTerminal.layer,
-    ExecutablePath.layer,
-  ).pipe(
-    Layer.provideMerge(ApplicationConfig.layer),
-    Layer.provideMerge(BunServices.layer),
+  const { isInternalGitLabHelperMode, runGitLabHelperProcess } = await import(
+    "@ready-for-agent/gitlab-service"
   )
+  const { isInternalKeymaxxerSidecarMode, runKeymaxxerSidecarProcess } =
+    await import("@ready-for-agent/keymaxxer-service")
+  const { READY_FOR_AGENT_VERSION } = await import("./generated/version.ts")
 
-  // Expand bare `--host` → `--host 0.0.0.0` before Effect's string flag parser.
-  const args = expandBareHostFlag(process.argv.slice(2))
+  if (isInternalKeymaxxerSidecarMode(process.argv)) {
+    await runKeymaxxerSidecarProcess()
+  } else if (isInternalGitHubHelperMode(process.argv)) {
+    runGitHubHelperProcess()
+  } else if (isInternalGitLabHelperMode(process.argv)) {
+    runGitLabHelperProcess()
+  } else {
+    const { BunRuntime, BunServices } = await import("@effect/platform-bun")
+    const { Effect, Layer } = await import("effect")
+    const { Command } = await import("effect/unstable/cli")
+    const { expandBareHostFlag } = await import(
+      "../../harness/src/server/listen-host.ts"
+    )
+    const { cli } = await import("./cli.ts")
+    const { ApplicationConfig } = await import(
+      "./services/application-config.ts"
+    )
+    const { ExecutablePath } = await import("./services/executable-path.ts")
+    const { GraphqlApi } = await import("./services/graphql-api.ts")
+    const { LocalGit } = await import("./services/local-git.ts")
+    const { StartHarness } = await import("./services/start-harness.ts")
+    const { DirectTerminal } = await import("./services/direct-terminal.ts")
+    const { Tmux } = await import("./services/tmux.ts")
 
-  const { encodeCompactJson } = await import("./cli-json.ts")
+    const MainLive = Layer.mergeAll(
+      LocalGit.layer,
+      GraphqlApi.layer,
+      StartHarness.layer,
+      Tmux.layer,
+      DirectTerminal.layer,
+      ExecutablePath.layer,
+    ).pipe(
+      Layer.provideMerge(ApplicationConfig.layer),
+      Layer.provideMerge(BunServices.layer),
+    )
 
-  const program = Command.runWith(cli, {
-    version: READY_FOR_AGENT_VERSION,
-  })(args).pipe(
-    Effect.provide(MainLive),
-    // FiniteCommandFailed is marked [Runtime.errorReported]=false so runMain
-    // skips Cause pretty-print; emit one versioned JSON error on stderr.
-    Effect.tapErrorTag("FiniteCommandFailed", (error) =>
-      Effect.sync(() => {
-        console.error(encodeCompactJson(error.document))
-      }),
-    ),
-    Effect.tapErrorTag("JumpFailed", (error) =>
-      Effect.sync(() => {
-        console.error(error.message)
-      }),
-    ),
-  )
+    // Expand bare `--host` → `--host 0.0.0.0` before Effect's string flag parser.
+    const args = expandBareHostFlag(process.argv.slice(2))
 
-  BunRuntime.runMain(program)
+    const { encodeCompactJson } = await import("./cli-json.ts")
+
+    const program = Command.runWith(cli, {
+      version: READY_FOR_AGENT_VERSION,
+    })(args).pipe(
+      Effect.provide(MainLive),
+      // FiniteCommandFailed is marked [Runtime.errorReported]=false so runMain
+      // skips Cause pretty-print; emit one versioned JSON error on stderr.
+      Effect.tapErrorTag("FiniteCommandFailed", (error) =>
+        Effect.sync(() => {
+          console.error(encodeCompactJson(error.document))
+        }),
+      ),
+      Effect.tapErrorTag("JumpFailed", (error) =>
+        Effect.sync(() => {
+          console.error(error.message)
+        }),
+      ),
+    )
+
+    BunRuntime.runMain(program)
+  }
 }

--- a/apps/ready-for-agent/src/usage-contract.ts
+++ b/apps/ready-for-agent/src/usage-contract.ts
@@ -1,0 +1,12 @@
+import usageSpec from "../ready-for-agent.usage.kdl" with { type: "text" }
+
+/** Exact root metadata switch. Hidden from docs and completions. */
+const USAGE_METADATA_SWITCH = "--usage"
+
+export const isExactUsageMetadataInvocation = (
+  userArgs: readonly string[],
+): boolean => userArgs.length === 1 && userArgs[0] === USAGE_METADATA_SWITCH
+
+/** Checked-in Usage KDL with exactly one trailing newline. */
+export const usageContractText = (): string =>
+  usageSpec.endsWith("\n") ? usageSpec : `${usageSpec}\n`


### PR DESCRIPTION
## Why

The public operator CLI contract already lives in
`apps/ready-for-agent/ready-for-agent.usage.kdl` (#1091), but installed
and source binaries had no side-effect-free way to print it. Tools and
agents could not discover the command surface without starting the
Harness or depending on a separate Usage install.

## What

Exact root `ready-for-agent --usage` writes that checked-in KDL to
stdout with one trailing newline, writes nothing to stderr, and exits 0
before Effect, Harness services, browser, TTY, Repository inspect, or
GraphQL. Other placements (`--usage extra`, `start --usage`, `--USAGE`)
are not treated as the metadata switch.

The spec is imported with Bun `type: "text"` so compiled platform
binaries embed it. The JS launcher still forwards argv. `--usage` stays
hidden from Effect `--help` and `--completions`. Internal helper
dispatch is unchanged and still wins when those flags are present.

## Verification

- `bunx nx run ready-for-agent:lint`
- `bunx nx run ready-for-agent:typecheck`
- `bunx nx run ready-for-agent:test` (source-process emission,
  compiled-host `--usage` from an unrelated cwd, existing CLI/help/
  completions)
- Packed-install smoke now asserts the same stdout/stderr/exit contract
  and forbids `usage` on the product PATH; that full harness-start smoke
  was not re-run in this session
- Review of the uncommitted diff was clean

Closes #1092