### PR TITLE
ci(cli): make the Usage contract an affected quality gate

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -49,7 +49,8 @@ jobs:
       - name: Install Usage CLI
         run: |
           set -euo pipefail
-          VERSION=5.1.0
+          VERSION="$(sed -n 's/^usage = "\([^"]*\)"/\1/p' mise.toml)"
+          test -n "${VERSION}"
           curl -fsSL "https://github.com/jdx/usage/releases/download/v${VERSION}/usage-x86_64-unknown-linux-musl.tar.gz" \
             | tar -xz -C /tmp
           sudo install -m 0755 /tmp/usage /usr/local/bin/usage
@@ -98,9 +99,9 @@ jobs:
       - name: Quality gates
         run: |
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            bun nx run-many -t lint knip test typecheck
+            bun nx run-many -t lint knip test typecheck check-usage
           else
-            bun nx affected -t lint knip test typecheck
+            bun nx affected -t lint knip test typecheck check-usage
           fi
 
       # Production SSE idle-timeout (~13s) is excluded from harness:test so the

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -46,7 +46,8 @@ jobs:
       - name: Install Usage CLI
         run: |
           set -euo pipefail
-          VERSION=5.1.0
+          VERSION="$(sed -n 's/^usage = "\([^"]*\)"/\1/p' mise.toml)"
+          test -n "${VERSION}"
           curl -fsSL "https://github.com/jdx/usage/releases/download/v${VERSION}/usage-x86_64-unknown-linux-musl.tar.gz" \
             | tar -xz -C /tmp
           sudo install -m 0755 /tmp/usage /usr/local/bin/usage
@@ -86,7 +87,7 @@ jobs:
       - uses: nrwl/nx-set-shas@afb73a62d26e41464e9254689e1fd6122ee683c1 # v5.0.1
 
       - name: Quality gates
-        run: bun nx affected -t lint knip test typecheck
+        run: bun nx affected -t lint knip test typecheck check-usage
 
       # Production SSE idle-timeout (~13s) is excluded from harness:test so the
       # default suite can run with Bun --parallel. Keep the real heartbeat gate.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,11 +27,7 @@ Also needed to run or test the harness:
 
 [mise](https://mise.jdx.dev/) 2026.7.0 or later installs the pinned Bun, hk,
 and Usage (5.1.0) versions, then workspace dependencies (which apply the
-existing Git hooks). Usage lints the operator CLI contract:
-
-```bash
-bunx nx run ready-for-agent:lint-usage
-```
+existing Git hooks).
 
 ```bash
 git clone git@github.com:berenddeboer/ready-for-agent.git
@@ -69,6 +65,19 @@ Optional browser/e2e setup:
 (cd apps/harness && bunx playwright install --with-deps chromium)
 ```
 
+## Operator CLI Usage contract
+
+The CI Usage quality gate is one command:
+
+```bash
+bunx nx run ready-for-agent:check-usage
+```
+
+That target lints the KDL contract, compares the public Effect CLI
+inventory, checks generated README drift without rewriting the worktree,
+and verifies Usage completion behavior. It is the same gate pull-request
+and main-branch quality workflows run when `ready-for-agent` is affected.
+
 ## Operator CLI command reference
 
 The public README command reference is generated from the Usage contract
@@ -87,7 +96,7 @@ the checked-in section without rewriting the worktree:
 bunx nx run ready-for-agent:check-usage-docs
 ```
 
-`bunx nx run ready-for-agent:test` runs that check (and `lint-usage`) first.
+`bunx nx run ready-for-agent:test` runs `check-usage` first.
 
 ## Usage shell completions
 

--- a/apps/ready-for-agent/project.json
+++ b/apps/ready-for-agent/project.json
@@ -139,6 +139,61 @@
       ],
       "cache": true
     },
+    "check-usage-parity": {
+      "executor": "nx:run-commands",
+      "dependsOn": ["generate-embed"],
+      "options": {
+        "cwd": "{projectRoot}",
+        "command": "bun --conditions=@ready-for-agent/source test --timeout=15000 src/cli-usage-parity.test.ts"
+      },
+      "inputs": [
+        "default",
+        "{projectRoot}/ready-for-agent.usage.kdl",
+        "{projectRoot}/src/cli-usage-parity.test.ts",
+        "{workspaceRoot}/scripts/run-pinned-usage.sh",
+        "{workspaceRoot}/mise.toml"
+      ],
+      "cache": true
+    },
+    "check-usage-completions": {
+      "executor": "nx:run-commands",
+      "dependsOn": ["generate-embed"],
+      "options": {
+        "cwd": "{projectRoot}",
+        "command": "bun --conditions=@ready-for-agent/source test --timeout=15000 src/generate-usage-completions.test.ts"
+      },
+      "inputs": [
+        "default",
+        "{projectRoot}/scripts/generate-usage-completions.ts",
+        "{projectRoot}/src/generate-usage-completions.test.ts",
+        "{workspaceRoot}/scripts/run-pinned-usage.sh",
+        "{workspaceRoot}/mise.toml",
+        "{workspaceRoot}/README.md",
+        "{workspaceRoot}/CONTRIBUTING.md"
+      ],
+      "cache": true
+    },
+    "check-usage": {
+      "executor": "nx:noop",
+      "dependsOn": [
+        "lint-usage",
+        "check-usage-docs",
+        "check-usage-parity",
+        "check-usage-completions"
+      ],
+      "inputs": [
+        "{projectRoot}/ready-for-agent.usage.kdl",
+        "{projectRoot}/scripts/update-usage-docs.ts",
+        "{projectRoot}/scripts/generate-usage-completions.ts",
+        "{projectRoot}/src/cli-usage-parity.test.ts",
+        "{projectRoot}/src/generate-usage-completions.test.ts",
+        "{workspaceRoot}/scripts/run-pinned-usage.sh",
+        "{workspaceRoot}/mise.toml",
+        "{workspaceRoot}/README.md",
+        "{workspaceRoot}/CONTRIBUTING.md"
+      ],
+      "cache": true
+    },
     "generate-usage-completions": {
       "executor": "nx:run-commands",
       "options": {
@@ -159,7 +214,12 @@
         "cwd": "{projectRoot}",
         "command": "bash scripts/run-unit-tests.sh"
       },
-      "inputs": ["default", "^production", "{workspaceRoot}/README.md"],
+      "inputs": [
+        "default",
+        "^production",
+        "{workspaceRoot}/README.md",
+        "{workspaceRoot}/CONTRIBUTING.md"
+      ],
       "cache": true,
       "dependsOn": [
         {
@@ -167,8 +227,7 @@
           "target": "generate"
         },
         "generate-embed",
-        "lint-usage",
-        "check-usage-docs"
+        "check-usage"
       ]
     },
     "packed-install-smoke": {

--- a/apps/ready-for-agent/src/browser-open.ts
+++ b/apps/ready-for-agent/src/browser-open.ts
@@ -159,10 +159,8 @@ export const openBrowserWhenReady = (
     // post-readiness AbortSignal check). Parks on Effect Clock so a closing
     // scope can cancel launch, and tests can assert with TestClock + interrupt.
     yield* Effect.sleep("1 millis")
-    try {
+    yield* Effect.try(() => {
       launch(platform, url)
-    } catch {
-      // Opener failure is best-effort.
-    }
+    }).pipe(Effect.ignore)
   }).pipe(Effect.ignore)
 }

--- a/apps/ready-for-agent/src/check-usage-gate.test.ts
+++ b/apps/ready-for-agent/src/check-usage-gate.test.ts
@@ -1,0 +1,182 @@
+/**
+ * Cohesive Usage quality gate: one Nx target covers lint, Effect parity,
+ * generated-document drift, and completion behavior; CI can reproduce it
+ * locally without bundling Usage into published packages.
+ */
+
+import { readFileSync } from "node:fs"
+import { dirname, join, resolve } from "node:path"
+import { fileURLToPath } from "node:url"
+import { describe, expect, test } from "bun:test"
+
+const appRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..")
+const workspaceRoot = resolve(appRoot, "../..")
+
+const PLATFORM_PACKAGES = [
+  "ready-for-agent-linux-x64",
+  "ready-for-agent-linux-arm64",
+  "ready-for-agent-darwin-x64",
+  "ready-for-agent-darwin-arm64",
+  "ready-for-agent-win32-x64",
+  "ready-for-agent-win32-arm64",
+] as const
+
+type Target = {
+  readonly executor?: string
+  readonly command?: string
+  readonly cache?: boolean
+  readonly inputs?: unknown[]
+  readonly outputs?: unknown[]
+  readonly dependsOn?: unknown[]
+  readonly options?: {
+    readonly command?: string
+    readonly cwd?: string
+  }
+}
+
+type ProjectJson = {
+  readonly targets: Record<string, Target>
+}
+
+const project = JSON.parse(
+  readFileSync(join(appRoot, "project.json"), "utf8"),
+) as ProjectJson
+
+const targetCommand = (target: Target | undefined): string =>
+  target?.options?.command ?? target?.command ?? ""
+
+const dependsOnNames = (target: Target | undefined): readonly string[] =>
+  (target?.dependsOn ?? []).flatMap((entry) => {
+    if (typeof entry === "string") {
+      return [entry]
+    }
+    return []
+  })
+
+const inputText = (target: Target | undefined): string =>
+  JSON.stringify(target?.inputs ?? [])
+
+describe("ready-for-agent Usage quality gate", () => {
+  test("exposes one check-usage target for lint, parity, docs, and completions", () => {
+    const gate = project.targets["check-usage"]
+    expect(gate).toBeDefined()
+    expect(gate?.cache).toBe(true)
+
+    const deps = dependsOnNames(gate)
+    expect(deps).toEqual(
+      expect.arrayContaining([
+        "lint-usage",
+        "check-usage-docs",
+        "check-usage-parity",
+        "check-usage-completions",
+      ]),
+    )
+    expect(deps).toHaveLength(4)
+
+    expect(targetCommand(project.targets["lint-usage"])).toContain(
+      "lint --warnings-as-errors",
+    )
+    expect(targetCommand(project.targets["check-usage-docs"])).toContain(
+      "scripts/update-usage-docs.ts --check",
+    )
+    expect(targetCommand(project.targets["check-usage-parity"])).toContain(
+      "src/cli-usage-parity.test.ts",
+    )
+    expect(targetCommand(project.targets["check-usage-completions"])).toContain(
+      "src/generate-usage-completions.test.ts",
+    )
+
+    expect(dependsOnNames(project.targets["check-usage-parity"])).toEqual(
+      expect.arrayContaining(["generate-embed"]),
+    )
+    expect(dependsOnNames(project.targets["check-usage-completions"])).toEqual(
+      expect.arrayContaining(["generate-embed"]),
+    )
+
+    expect(inputText(gate)).toContain("README.md")
+    expect(inputText(gate)).toContain("ready-for-agent.usage.kdl")
+    expect(inputText(gate)).toContain("run-pinned-usage.sh")
+    expect(inputText(gate)).toContain("mise.toml")
+    expect(inputText(gate)).toContain("CONTRIBUTING.md")
+
+    expect(inputText(project.targets["check-usage-docs"])).toContain(
+      "README.md",
+    )
+    expect(inputText(project.targets["check-usage-completions"])).toContain(
+      "CONTRIBUTING.md",
+    )
+    expect(project.targets["check-usage-docs"]?.outputs ?? []).not.toContain(
+      "{workspaceRoot}/README.md",
+    )
+  })
+
+  test("unit tests go through the same Usage gate as CI", () => {
+    expect(dependsOnNames(project.targets.test)).toEqual(
+      expect.arrayContaining(["check-usage"]),
+    )
+    expect(dependsOnNames(project.targets.test)).not.toEqual(
+      expect.arrayContaining(["lint-usage", "check-usage-docs"]),
+    )
+    expect(inputText(project.targets.test)).toContain("README.md")
+    expect(inputText(project.targets.test)).toContain("CONTRIBUTING.md")
+  })
+
+  test("maintainer docs name the single local command that reproduces CI", () => {
+    const contributing = readFileSync(
+      join(workspaceRoot, "CONTRIBUTING.md"),
+      "utf8",
+    )
+    expect(contributing).toMatch(
+      /bunx nx run ready-for-agent:check-usage(?![-a-z])/,
+    )
+    expect(contributing).toMatch(/CI Usage (quality )?gate/i)
+    expect(contributing).not.toMatch(
+      /`bunx nx run ready-for-agent:test` runs that check \(and `lint-usage`\) first/,
+    )
+  })
+
+  test("published launcher and platform packages do not depend on Usage", () => {
+    const launcher = JSON.parse(
+      readFileSync(join(appRoot, "package.json"), "utf8"),
+    ) as {
+      readonly dependencies?: Record<string, string>
+      readonly devDependencies?: Record<string, string>
+      readonly optionalDependencies?: Record<string, string>
+      readonly files?: readonly string[]
+    }
+    expect(launcher.dependencies ?? {}).not.toHaveProperty("usage")
+    expect(launcher.devDependencies ?? {}).not.toHaveProperty("usage")
+    expect(launcher.optionalDependencies ?? {}).not.toHaveProperty("usage")
+    expect(launcher.files).not.toContain("ready-for-agent.usage.kdl")
+
+    for (const name of PLATFORM_PACKAGES) {
+      const pkg = JSON.parse(
+        readFileSync(
+          join(workspaceRoot, "packages", name, "package.json"),
+          "utf8",
+        ),
+      ) as {
+        readonly dependencies?: Record<string, string>
+        readonly files?: readonly string[]
+      }
+      expect(pkg.dependencies ?? {}, name).toEqual({})
+      expect(pkg.files, name).not.toContain("ready-for-agent.usage.kdl")
+    }
+  })
+
+  test("compiled-host and packed-install seams still emit the Usage contract", () => {
+    const hostBinary = readFileSync(
+      join(appRoot, "src/host-binary.test.ts"),
+      "utf8",
+    )
+    expect(hostBinary).toContain("--usage")
+    expect(hostBinary).toContain("emits the embedded Usage contract")
+
+    const packedInstall = readFileSync(
+      join(appRoot, "scripts/packed-install-smoke.ts"),
+      "utf8",
+    )
+    expect(packedInstall).toContain('["--usage"]')
+    expect(packedInstall).toContain("checked-in Usage KDL contract")
+  })
+})

--- a/apps/ready-for-agent/src/update-usage-docs.test.ts
+++ b/apps/ready-for-agent/src/update-usage-docs.test.ts
@@ -314,7 +314,7 @@ describe("operator CLI command-reference documentation", () => {
     expect(JSON.stringify(check?.inputs ?? [])).toContain("run-pinned-usage.sh")
 
     expect(project.targets.test?.dependsOn).toEqual(
-      expect.arrayContaining(["lint-usage", "check-usage-docs"]),
+      expect.arrayContaining(["check-usage"]),
     )
   })
 })

--- a/scripts/tool-pins.test.ts
+++ b/scripts/tool-pins.test.ts
@@ -124,12 +124,48 @@ describe("contributor environment pins", () => {
     ] as const
     for (const relativePath of qualityGateFiles) {
       const contents = readWorkspace(relativePath)
-      expect(contents, relativePath).toContain(`VERSION=${usageVersion}`)
+      expect(contents, relativePath).toContain("Install Usage CLI")
+      expect(contents, relativePath).toContain(
+        'sed -n \'s/^usage = "\\([^"]*\\)"/\\1/p\' mise.toml',
+      )
       expect(contents, relativePath).toContain("jdx/usage/releases/download/v")
       expect(contents, relativePath).toContain(
         "usage-x86_64-unknown-linux-musl.tar.gz",
       )
       expect(contents, relativePath).not.toMatch(/usage-cli@latest/i)
+      expect(contents, relativePath).not.toMatch(/VERSION=5\.1\.0/)
     }
+  })
+
+  it("invokes check-usage from PR and main quality-gate commands", () => {
+    const pr = readWorkspace(".github/workflows/pr.yml")
+    const cicd = readWorkspace(".github/workflows/ci-cd.yml")
+    expect(pr).toMatch(
+      /bun nx affected -t lint knip test typecheck check-usage/,
+    )
+    expect(cicd).toMatch(
+      /bun nx affected -t lint knip test typecheck check-usage/,
+    )
+    expect(cicd).toMatch(
+      /bun nx run-many -t lint knip test typecheck check-usage/,
+    )
+  })
+
+  it("installs Usage only in quality-gate jobs that run Usage-dependent targets", () => {
+    const pr = readWorkspace(".github/workflows/pr.yml")
+    const cicd = readWorkspace(".github/workflows/ci-cd.yml")
+    const overnight = readWorkspace(
+      ".github/workflows/overnight-install-smoke.yml",
+    )
+
+    expect(pr.match(/name: Install Usage CLI/g)?.length).toBe(1)
+    expect(cicd.match(/name: Install Usage CLI/g)?.length).toBe(1)
+    expect(overnight).not.toContain("Install Usage CLI")
+    expect(overnight).not.toContain("jdx/usage/releases")
+
+    const packedInstallJob = cicd.slice(cicd.indexOf("packed-install:"))
+    expect(packedInstallJob).toContain("packed-install-smoke")
+    expect(packedInstallJob).not.toContain("Install Usage CLI")
+    expect(packedInstallJob).not.toContain("jdx/usage/releases")
   })
 })


### PR DESCRIPTION
The operator CLI already has a pinned Usage 5.1.0 contract from #1089 /
#1091–#1094, but CI still treated those checks as scattered `test`
dependencies and hardcoded the installer version. A malformed KDL spec,
Effect/CLI drift, stale generated README, or completion regression could
slip through unless someone remembered the individual targets, and a
runner could silently use whatever `usage` happened to be on `PATH`.

This change makes that contract a first-class affected quality gate for
#1096:

- `ready-for-agent:check-usage` lints the KDL spec, compares the public
  Effect inventory, checks generated README drift without rewriting the
  worktree, and verifies Usage completion behavior.
- PR and main quality workflows invoke `check-usage` via `nx affected`
  (and `run-many` on manual dispatch).
- Quality-gate jobs install Usage from the `mise.toml` pin and the
  matching GitHub release tarball, not a hardcoded `5.1.0`.
- `ready-for-agent:test` depends on `check-usage`. CONTRIBUTING documents
  `bunx nx run ready-for-agent:check-usage` as the single local command
  that reproduces the CI gate.
- Published launcher and platform packages still do not depend on Usage.

Verified with `bunx nx run ready-for-agent:check-usage`, the
pin/workflow and gate-topology tests, and pre-commit. Compiled-host
`--usage` stays on `host-binary.test.ts` (PR `test`) and packed-install
smoke on main, not inside `check-usage` itself.

Closes #1096