### PR TITLE
docs: add README table of contents

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,23 @@ Watch [the introduction
 video](https://www.youtube.com/watch?v=TK1OeQZswiQ) to see the tool in
 action.
 
+## Contents
+
+- [Quick start](#quick-start)
+- [Requirements](#requirements)
+- [Features](#features)
+- [How it works](#how-it-works)
+- [Configuration](#configuration)
+- [Command reference](#command-reference)
+- [Shell completions](#shell-completions)
+- [Troubleshooting](#troubleshooting)
+- [Frequently Asked Questions](#frequently-asked-questions)
+- [Glossary](#glossary)
+- [Architecture](#architecture)
+- [Contributing](#contributing)
+- [License](#license)
+- [Related work](#related-work)
+
 ## Quick start
 
 1. Install the [prerequisites](#requirements) and have them on your PATH:
@@ -43,7 +60,7 @@ action.
    - Click **Inspect**, confirm the forge identity, then **Confirm and
      add**.
 
-   <img src="docs/add-repository-blank-slate.png" alt="Blank slate: add a repository from the UI (Browse, path field, or CLI)" width="90%" />
+   <img src="docs/add-repository-blank-slate.png" alt="Blank slate: add a repository from the UI (Browse, path field, or CLI)" width="75%" />
 
    Advanced: once the harness is running, you can also add from a
    shell:


### PR DESCRIPTION
## Why

The public README now includes a long generated command reference, so operators have to scroll past a lot of content to reach configuration, completions, or troubleshooting. A top-of-page contents list makes those sections discoverable without changing the Usage-managed block.

## What Changed

- Added a hand-written Contents list of the public H2 sections just above Quick start, outside the `<!-- usage:start -->` markers.
- Narrowed the blank-slate add-repository screenshot from 90% to 75% width.
