### PR TITLE
docs: record Grok ACP Agent Turns

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -104,8 +104,8 @@ The long-lived loopback companion process that owns one Keymaxxer stdio keyholde
 _Avoid_: Credential daemon, token cache, development-only sidecar
 
 **Agent Backend**:
-A supported headless coding-agent CLI integration shipped with Ready for Agent that can execute Agent Turns for the Harness. Harness Config, Repository settings, and an Explicit Work Item Execution Profile may select among built-in backends; arbitrary external backend plugins are not part of this boundary.
-_Avoid_: Agent (ambiguous), model, provider
+A supported coding-agent integration shipped with Ready for Agent that can execute Agent Turns for the Harness. Harness Config, Repository settings, and an Explicit Work Item Execution Profile may select among built-in backends; arbitrary external backend plugins are not part of this boundary.
+_Avoid_: Agent (ambiguous), model, provider, ACP (the protocol is not a backend)
 
 **Effective Agent Backend**:
 The Agent Backend a Repository uses for ordinary new Work Items: the Repository override when set, otherwise the Harness Config default. Ordinary creation requests capture it; Implement With may explicitly choose another backend for that Work Item without changing Repository settings or Harness Config.
@@ -140,7 +140,7 @@ An explicit operator request that revalidates one Agent Backend by id and refres
 _Avoid_: Automatic health poll, model-cache refresh only, Harness restart, Agent Backend Preview
 
 **Agent Model**:
-A model in an Agent Backend's catalog for Agent Turns. Its identity and availability are backend-specific rather than Repository-specific. Ordinary Work Items resolve build and review selections for each Agent Turn from current backend-scoped Repository settings falling back to Harness Config; an Explicit Work Item Execution Profile instead supplies durable selections for that Work Item. Selection is catalog-only: selection surfaces offer exactly the chosen Agent Backend's current catalog. Advertised Thinking Levels are part of each catalog entry's executable contract; an unsupported pair is rejected at Settings and before an Agent Turn rather than rewritten. A selected value the current catalog no longer lists is preserved and shown as unavailable rather than deleted, rewritten, translated between provider modes, or replaced by defaults; it blocks creation or a later Agent Turn before the Agent Backend CLI is spawned. An Agent Backend that reports no catalog at all carries no membership information and does not block ordinary work, but Implement With requires a non-empty catalog from which to make its explicit choices.
+A model in an Agent Backend's catalog for Agent Turns. Its identity and availability are backend-specific rather than Repository-specific. Ordinary Work Items resolve build and review selections for each Agent Turn from current backend-scoped Repository settings falling back to Harness Config; an Explicit Work Item Execution Profile instead supplies durable selections for that Work Item. Selection is catalog-only: selection surfaces offer exactly the chosen Agent Backend's current catalog. Advertised Thinking Levels are part of each catalog entry's executable contract; an unsupported pair is rejected at Settings and before an Agent Turn rather than rewritten. A selected value the current catalog no longer lists is preserved and shown as unavailable rather than deleted, rewritten, translated between provider modes, or replaced by defaults; it blocks creation or a later Agent Turn before that turn starts. An Agent Backend that reports no catalog at all carries no membership information and does not block ordinary work, but Implement With requires a non-empty catalog from which to make its explicit choices.
 _Avoid_: Provider, Agent Backend, model profile
 
 **Thinking Level**:
@@ -156,8 +156,8 @@ Optional Agent Backend-provided details about a Session, such as models, token t
 _Avoid_: Agent Turn Result, required backend capability
 
 **Agent Turn**:
-One fully unattended headless Agent Backend CLI invocation within a Session using an explicit Agent Model and optional Thinking Level. An Agent Backend must support both the first turn and later turns that continue the same Session; file, shell, and tool permissions cannot wait for operator approval during the turn.
-_Avoid_: Agent run, prompt run, OpenCode process
+One fully unattended invocation of an Agent Backend within a Session using an explicit Agent Model and optional Thinking Level. An Agent Backend must support both the first turn and later turns that continue the same Session; file, shell, and tool permissions cannot wait for operator approval during the turn.
+_Avoid_: Agent run, prompt run, OpenCode process, ACP request
 
 **Interactive Session Continuation**:
 An operator-driven interactive use of a Work Item's canonical Session through its captured Agent Backend and working directory. Its messages become part of the Session used by later Agent Turns, but the continuation is not itself an Agent Turn or Lifecycle Step.

--- a/docs/adr/0031-built-in-headless-agent-backends.md
+++ b/docs/adr/0031-built-in-headless-agent-backends.md
@@ -1,5 +1,7 @@
 # Built-in headless Agent Backends
 
+Status: accepted (Grok Agent Turns superseded by ADR 0056; other backends unchanged)
+
 Ready for Agent supports coding agents through a built-in `@ready-for-agent/agent-backend` contract with separate OpenCode and Grok Build adapter packages. The shared package owns CLI process lifecycle, sanitized environment, timeout, process-tree cancellation, and normalized errors; adapters own binary arguments, environment additions, atomic readiness/model inspection, and structured-output decoding. This deliberately supports shipped headless CLI adapters rather than ACP, SDK, runtime plugin, or operator-defined command integrations.
 
 A compatible Agent Backend must:

--- a/docs/adr/0056-grok-acp-agent-turns.md
+++ b/docs/adr/0056-grok-acp-agent-turns.md
@@ -1,0 +1,5 @@
+# Grok Agent Turns speak ACP
+
+Status: accepted (Grok-only exception to ADR 0031’s “not ACP” rule; OpenCode, Codex Build, and Claude Code stay on headless CLI)
+
+Grok Build’s headless `--resume` + `-p` never emits stdout on a real Implement Session (futex after `session/load`). ACP `session/load` / `session/resume` + `session/prompt` on `grok agent stdio` continues that same Session. Grok Agent Turns therefore use Agent Client Protocol: a shared Effect ACP client wrapping `@agentclientprotocol/sdk`, Grok adapter as first consumer. Lifecycle still calls `startTurn` / `continueTurn`. One ACP stdio spawn per Agent Turn. Continue prefers `session/resume`, falls back to `session/load`. Interactive Session Continuation stays the Grok TUI. Catalog inspect stays `grok models`. Other backends are unchanged until they have a reason to move.

--- a/ontology/context.ttl
+++ b/ontology/context.ttl
@@ -638,8 +638,8 @@ rfa:KeymaxxerSidecar
 rfa:AgentBackend
   a owl:Class, skos:Concept, rfa:ContextTerm ;
   skos:prefLabel "Agent Backend"@en ;
-  skos:definition "A supported headless coding-agent CLI integration shipped with Ready for Agent that can execute Agent Turns for the Harness. Harness Config, Repository settings, and an Explicit Work Item Execution Profile may select among built-in backends; arbitrary external backend plugins are not part of this boundary."@en ;
-  skos:hiddenLabel "Agent"@en, "model"@en, "provider"@en .
+  skos:definition "A supported coding-agent integration shipped with Ready for Agent that can execute Agent Turns for the Harness. Harness Config, Repository settings, and an Explicit Work Item Execution Profile may select among built-in backends; arbitrary external backend plugins are not part of this boundary."@en ;
+  skos:hiddenLabel "Agent"@en, "model"@en, "provider"@en, "ACP"@en .
 
 [
   a owl:Axiom ;
@@ -663,6 +663,14 @@ rfa:AgentBackend
   owl:annotatedProperty skos:hiddenLabel ;
   owl:annotatedTarget "provider"@en ;
   rfa:avoidanceRationale "CONTEXT.md prefers Agent Backend for this concept."@en ;
+] .
+
+[
+  a owl:Axiom ;
+  owl:annotatedSource rfa:AgentBackend ;
+  owl:annotatedProperty skos:hiddenLabel ;
+  owl:annotatedTarget "ACP"@en ;
+  rfa:avoidanceRationale "the protocol is not a backend"@en ;
 ] .
 
 rfa:EffectiveAgentBackend
@@ -892,7 +900,7 @@ rfa:RecheckAgentBackend
 rfa:AgentModel
   a owl:Class, skos:Concept, rfa:ContextTerm ;
   skos:prefLabel "Agent Model"@en ;
-  skos:definition "A model in an Agent Backend's catalog for Agent Turns. Its identity and availability are backend-specific rather than Repository-specific. Ordinary Work Items resolve build and review selections for each Agent Turn from current backend-scoped Repository settings falling back to Harness Config; an Explicit Work Item Execution Profile instead supplies durable selections for that Work Item. Selection is catalog-only: selection surfaces offer exactly the chosen Agent Backend's current catalog. Advertised Thinking Levels are part of each catalog entry's executable contract; an unsupported pair is rejected at Settings and before an Agent Turn rather than rewritten. A selected value the current catalog no longer lists is preserved and shown as unavailable rather than deleted, rewritten, translated between provider modes, or replaced by defaults; it blocks creation or a later Agent Turn before the Agent Backend CLI is spawned. An Agent Backend that reports no catalog at all carries no membership information and does not block ordinary work, but Implement With requires a non-empty catalog from which to make its explicit choices."@en ;
+  skos:definition "A model in an Agent Backend's catalog for Agent Turns. Its identity and availability are backend-specific rather than Repository-specific. Ordinary Work Items resolve build and review selections for each Agent Turn from current backend-scoped Repository settings falling back to Harness Config; an Explicit Work Item Execution Profile instead supplies durable selections for that Work Item. Selection is catalog-only: selection surfaces offer exactly the chosen Agent Backend's current catalog. Advertised Thinking Levels are part of each catalog entry's executable contract; an unsupported pair is rejected at Settings and before an Agent Turn rather than rewritten. A selected value the current catalog no longer lists is preserved and shown as unavailable rather than deleted, rewritten, translated between provider modes, or replaced by defaults; it blocks creation or a later Agent Turn before that turn starts. An Agent Backend that reports no catalog at all carries no membership information and does not block ordinary work, but Implement With requires a non-empty catalog from which to make its explicit choices."@en ;
   skos:hiddenLabel "Provider"@en, "Agent Backend"@en, "model profile"@en .
 
 [
@@ -996,8 +1004,8 @@ rfa:SessionTelemetry
 rfa:AgentTurn
   a owl:Class, skos:Concept, rfa:ContextTerm ;
   skos:prefLabel "Agent Turn"@en ;
-  skos:definition "One fully unattended headless Agent Backend CLI invocation within a Session using an explicit Agent Model and optional Thinking Level. An Agent Backend must support both the first turn and later turns that continue the same Session; file, shell, and tool permissions cannot wait for operator approval during the turn."@en ;
-  skos:hiddenLabel "Agent run"@en, "prompt run"@en, "OpenCode process"@en .
+  skos:definition "One fully unattended invocation of an Agent Backend within a Session using an explicit Agent Model and optional Thinking Level. An Agent Backend must support both the first turn and later turns that continue the same Session; file, shell, and tool permissions cannot wait for operator approval during the turn."@en ;
+  skos:hiddenLabel "Agent run"@en, "prompt run"@en, "OpenCode process"@en, "ACP request"@en .
 
 [
   a owl:Axiom ;
@@ -1020,6 +1028,14 @@ rfa:AgentTurn
   owl:annotatedSource rfa:AgentTurn ;
   owl:annotatedProperty skos:hiddenLabel ;
   owl:annotatedTarget "OpenCode process"@en ;
+  rfa:avoidanceRationale "CONTEXT.md prefers Agent Turn for this concept."@en ;
+] .
+
+[
+  a owl:Axiom ;
+  owl:annotatedSource rfa:AgentTurn ;
+  owl:annotatedProperty skos:hiddenLabel ;
+  owl:annotatedTarget "ACP request"@en ;
   rfa:avoidanceRationale "CONTEXT.md prefers Agent Turn for this concept."@en ;
 ] .
 


### PR DESCRIPTION
## Why

Grok Build Review (and every later `continueTurn`) hangs on headless `--resume` + `-p`: the CLI parks forever after `session/load` and never emits stdout. Interactive resume works. ACP `session/load` / `session/prompt` on `grok agent stdio` continues the same Session. ADR 0031 forbade ACP; that rule is wrong for Grok.

## What Changed

- ADR 0056: Grok Agent Turns speak ACP (Grok-only exception to 0031). Other backends stay headless CLI.
- Glossary: **Agent Backend** / **Agent Turn** are no longer CLI-only. Mirrored in `ontology/context.ttl`.
- ADR 0031 marked Grok-superseded by 0056.

This PR records the decision only. Implementation (Effect ACP client, Grok `continueTurn`) is follow-up.

## Verification

Headless `grok --resume <id> -p pong` on Implement Sessions `f49b2464…` and `a8c6a5fb…`: 0 stdout, main thread `futex(..., NULL)` forever (0.2.51–1.0.4). Same sessions via `grok agent stdio` → `session/load` + `session/prompt`: `ACP_OK`, `end_turn`, Session ID unchanged.
