### PR TITLE
feat(acp-client): add Effect stdio client wrapping the official ACP SDK

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -114,6 +114,19 @@
         "ready-for-agent-win32-x64": "0.0.0",
       },
     },
+    "packages/acp-client": {
+      "name": "@ready-for-agent/acp-client",
+      "version": "0.0.1",
+      "dependencies": {
+        "@agentclientprotocol/sdk": "^1.3.0",
+        "effect": "^4.0.0-beta.97",
+        "tslib": "^2.3.0",
+        "zod": "^4.4.3",
+      },
+      "devDependencies": {
+        "@types/bun": "^1.3.0",
+      },
+    },
     "packages/agent-backend": {
       "name": "@ready-for-agent/agent-backend",
       "version": "0.0.1",
@@ -442,6 +455,8 @@
     "effect": "4.0.0-beta.97",
   },
   "packages": {
+    "@agentclientprotocol/sdk": ["@agentclientprotocol/sdk@1.3.0", "", { "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" } }, "sha512-i3h/efaeuMUFAO1HSfo97QZQnnvMd7wWBYtBsdL6UMZg3a78sk3Ffya5Xu7C7tYsXomXoDXJBAzQF2PcFKAhIQ=="],
+
     "@aws-sdk/client-bedrock": ["@aws-sdk/client-bedrock@3.1106.0", "", { "dependencies": { "@aws-sdk/core": "^3.977.6", "@aws-sdk/credential-provider-node": "^3.972.78", "@aws-sdk/token-providers": "3.1106.0", "@aws-sdk/types": "^3.974.2", "@smithy/core": "^3.31.1", "@smithy/fetch-http-handler": "^5.6.13", "@smithy/node-http-handler": "^4.9.13", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-TyoMFuYOqsjh3/2rZ+GA2fk+sWGLsWXcUNvi6ji0Aj4v1O7KNEnvJFnTI8Mk1JKRKYFKa3K+yh1zePTTLxMJ2w=="],
 
     "@aws-sdk/core": ["@aws-sdk/core@3.977.6", "", { "dependencies": { "@aws-sdk/types": "^3.974.2", "@aws-sdk/xml-builder": "^3.972.37", "@aws/lambda-invoke-store": "^0.3.0", "@smithy/core": "^3.31.1", "@smithy/signature-v4": "^5.6.12", "@smithy/types": "^4.16.1", "bowser": "^2.11.0", "tslib": "^2.6.2" } }, "sha512-QiaJV4/zDrB4ZY2mfeSXSzSTc36W16sZXcGz+SPFk0CJ26gziO0cS+4LjJUMAbdeeBOvS0k0Aq1cZpfGdUXxSw=="],
@@ -1043,6 +1058,8 @@
     "@rdfjs/to-ntriples": ["@rdfjs/to-ntriples@3.0.1", "", {}, "sha512-gjoPAvh4j7AbGMjcDn/8R4cW+d/FPtbfbMM0uQXkyfBFtNUW2iVgrqsgJ65roLc54Y9A2TTFaeeTGSvY9a0HCQ=="],
 
     "@rdfjs/types": ["@rdfjs/types@2.0.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-uyAzpugX7KekAXAHq26m3JlUIZJOC0uSBhpnefGV5i15bevDyyejoB7I+9MKeUrzXD8OOUI3+4FeV1wwQr5ihA=="],
+
+    "@ready-for-agent/acp-client": ["@ready-for-agent/acp-client@workspace:packages/acp-client"],
 
     "@ready-for-agent/agent-backend": ["@ready-for-agent/agent-backend@workspace:packages/agent-backend"],
 

--- a/packages/acp-client/package.json
+++ b/packages/acp-client/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@ready-for-agent/acp-client",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    "./package.json": "./package.json",
+    ".": {
+      "@ready-for-agent/source": "./src/index.ts",
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    }
+  },
+  "dependencies": {
+    "@agentclientprotocol/sdk": "^1.3.0",
+    "effect": "^4.0.0-beta.97",
+    "tslib": "^2.3.0",
+    "zod": "^4.4.3"
+  },
+  "devDependencies": {
+    "@types/bun": "^1.3.0"
+  }
+}

--- a/packages/acp-client/project.json
+++ b/packages/acp-client/project.json
@@ -1,0 +1,18 @@
+{
+  "name": "acp-client",
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "packages/acp-client/src",
+  "projectType": "library",
+  "tags": [],
+  "targets": {
+    "test": {
+      "executor": "nx:run-commands",
+      "options": {
+        "cwd": "{projectRoot}",
+        "command": "bun test"
+      },
+      "inputs": ["default", "^production"],
+      "cache": true
+    }
+  }
+}

--- a/packages/acp-client/src/index.ts
+++ b/packages/acp-client/src/index.ts
@@ -1,0 +1,4 @@
+export * from "./lib/acp-client.js"
+export * from "./lib/errors.js"
+export * from "./lib/fake-acp-agent.js"
+export * from "./lib/types.js"

--- a/packages/acp-client/src/lib/acp-client.ts
+++ b/packages/acp-client/src/lib/acp-client.ts
@@ -1,0 +1,352 @@
+import { type ChildProcess, spawn } from "node:child_process"
+import { Readable, Writable } from "node:stream"
+import * as acp from "@agentclientprotocol/sdk"
+import { Context, Effect, Layer, Schema, type Scope } from "effect"
+import {
+  type AcpClientError,
+  AcpProcessExitError,
+  AcpProtocolError,
+  AcpSpawnError,
+} from "./errors.js"
+import type {
+  AcpAuthenticateInput,
+  AcpCancelInput,
+  AcpConnectInput,
+  AcpConnection,
+  AcpInitializeInput,
+  AcpInitializeResult,
+  AcpLoadSessionInput,
+  AcpMeta,
+  AcpNewSessionInput,
+  AcpPromptInput,
+  AcpPromptResult,
+  AcpResumeSessionInput,
+  AcpSessionResult,
+} from "./types.js"
+import { AcpSessionId, AcpStopReason } from "./types.js"
+
+export type AcpClientShape = {
+  readonly connect: (
+    input: AcpConnectInput,
+  ) => Effect.Effect<AcpConnection, AcpClientError, Scope.Scope>
+}
+
+const requestMeta = (
+  meta: AcpMeta | undefined,
+): { readonly _meta?: AcpMeta } => (meta === undefined ? {} : { _meta: meta })
+
+const responseMeta = (
+  meta: { readonly [key: string]: unknown } | null | undefined,
+): { readonly _meta?: AcpMeta } => (meta == null ? {} : { _meta: meta })
+
+const isErrnoException = (error: unknown): error is NodeJS.ErrnoException =>
+  typeof error === "object" && error !== null && "code" in error
+
+const toSpawnError = (command: string, cause: unknown): AcpSpawnError =>
+  new AcpSpawnError({
+    command,
+    message:
+      isErrnoException(cause) && cause.code === "ENOENT"
+        ? `Agent command not found: ${command}`
+        : "Failed to spawn ACP agent",
+    cause,
+  })
+
+const waitForSpawn = (
+  child: ChildProcess,
+  command: string,
+): Effect.Effect<void, AcpSpawnError> =>
+  Effect.callback<void, AcpSpawnError>((resume) => {
+    const onError = (error: Error) => {
+      child.off("spawn", onSpawn)
+      resume(Effect.fail(toSpawnError(command, error)))
+    }
+    const onSpawn = () => {
+      child.off("error", onError)
+      resume(Effect.void)
+    }
+    child.once("error", onError)
+    child.once("spawn", onSpawn)
+    return Effect.sync(() => {
+      child.off("error", onError)
+      child.off("spawn", onSpawn)
+    })
+  })
+
+type SessionBuffers = {
+  readonly collecting: Set<string>
+  readonly chunks: Map<string, string[]>
+}
+
+const attachConnection = (
+  sdk: acp.ClientConnection,
+  command: string,
+  exit: { code?: number | null },
+  buffers: SessionBuffers,
+): AcpConnection => {
+  const takeText = (sessionId: string): string => {
+    const text = (buffers.chunks.get(sessionId) ?? []).join("")
+    buffers.chunks.delete(sessionId)
+    return text
+  }
+
+  const toRequestError = (method: string) => (cause: unknown) => {
+    if (exit.code !== undefined) {
+      return new AcpProcessExitError({
+        command,
+        exitCode: exit.code,
+        message: `ACP agent exited before ${method} completed`,
+      })
+    }
+    return new AcpProtocolError({
+      method,
+      message: cause instanceof Error ? cause.message : "ACP request failed",
+      cause,
+    })
+  }
+
+  const request = <A>(
+    method: string,
+    run: () => Promise<A>,
+  ): Effect.Effect<A, AcpClientError> =>
+    Effect.tryPromise({
+      try: run,
+      catch: toRequestError(method),
+    })
+
+  const initialize = Effect.fn("AcpConnection.initialize")(function* (
+    input: AcpInitializeInput = {},
+  ) {
+    const result = yield* request("initialize", () =>
+      sdk.agent.request(acp.methods.agent.initialize, {
+        protocolVersion: acp.PROTOCOL_VERSION,
+        clientInfo: {
+          name: "ready-for-agent",
+          version: "0.0.1",
+        },
+        ...requestMeta(input._meta),
+      }),
+    )
+    const initialized: AcpInitializeResult = {
+      protocolVersion: result.protocolVersion,
+      loadSession: result.agentCapabilities?.loadSession === true,
+      resume: result.agentCapabilities?.sessionCapabilities?.resume != null,
+      authMethods: (result.authMethods ?? []).map((method) => ({
+        id: method.id,
+        name: method.name,
+      })),
+      ...responseMeta(result._meta),
+    }
+    return initialized
+  })
+
+  const authenticate = Effect.fn("AcpConnection.authenticate")(function* (
+    input: AcpAuthenticateInput,
+  ) {
+    yield* request("authenticate", () =>
+      sdk.agent.request(acp.methods.agent.authenticate, {
+        methodId: input.methodId,
+        ...requestMeta(input._meta),
+      }),
+    )
+  })
+
+  const toSessionResult = (
+    sessionId: string,
+    meta: { readonly [key: string]: unknown } | null | undefined,
+  ): AcpSessionResult => ({
+    sessionId: AcpSessionId.make(sessionId),
+    ...responseMeta(meta),
+  })
+
+  const newSession = Effect.fn("AcpConnection.newSession")(function* (
+    input: AcpNewSessionInput,
+  ) {
+    const result = yield* request("session/new", () =>
+      sdk.agent.request(acp.methods.agent.session.new, {
+        cwd: input.cwd,
+        mcpServers: [],
+        ...requestMeta(input._meta),
+      }),
+    )
+    return toSessionResult(result.sessionId, result._meta)
+  })
+
+  const loadSession = Effect.fn("AcpConnection.loadSession")(function* (
+    input: AcpLoadSessionInput,
+  ) {
+    const result = yield* request("session/load", () =>
+      sdk.agent.request(acp.methods.agent.session.load, {
+        sessionId: input.sessionId,
+        cwd: input.cwd,
+        mcpServers: [],
+        ...requestMeta(input._meta),
+      }),
+    )
+    return toSessionResult(input.sessionId, result._meta)
+  })
+
+  const resumeSession = Effect.fn("AcpConnection.resumeSession")(function* (
+    input: AcpResumeSessionInput,
+  ) {
+    const result = yield* request("session/resume", () =>
+      sdk.agent.request(acp.methods.agent.session.resume, {
+        sessionId: input.sessionId,
+        cwd: input.cwd,
+        mcpServers: [],
+        ...requestMeta(input._meta),
+      }),
+    )
+    return toSessionResult(input.sessionId, result._meta)
+  })
+
+  const prompt = Effect.fn("AcpConnection.prompt")(function* (
+    input: AcpPromptInput,
+  ) {
+    buffers.collecting.add(input.sessionId)
+    buffers.chunks.delete(input.sessionId)
+    const result = yield* request("session/prompt", () =>
+      sdk.agent.request(acp.methods.agent.session.prompt, {
+        sessionId: input.sessionId,
+        prompt: [{ type: "text", text: input.prompt }],
+        ...requestMeta(input._meta),
+      }),
+    ).pipe(
+      Effect.ensuring(
+        Effect.sync(() => {
+          buffers.collecting.delete(input.sessionId)
+        }),
+      ),
+    )
+    const stopReason = yield* Schema.decodeUnknownEffect(AcpStopReason)(
+      result.stopReason,
+    ).pipe(
+      Effect.mapError(
+        () =>
+          new AcpProtocolError({
+            method: "session/prompt",
+            message: "Unknown stop reason",
+          }),
+      ),
+    )
+    const completed: AcpPromptResult = {
+      sessionId: input.sessionId,
+      assistantText: takeText(input.sessionId),
+      stopReason,
+      ...responseMeta(result._meta),
+    }
+    return completed
+  })
+
+  const cancel = Effect.fn("AcpConnection.cancel")(function* (
+    input: AcpCancelInput,
+  ) {
+    yield* request("session/cancel", () =>
+      sdk.agent.notify(acp.methods.agent.session.cancel, {
+        sessionId: input.sessionId,
+        ...requestMeta(input._meta),
+      }),
+    )
+  })
+
+  return {
+    initialize,
+    authenticate,
+    newSession,
+    loadSession,
+    resumeSession,
+    prompt,
+    cancel,
+  }
+}
+
+const connect = Effect.fn("AcpClient.connect")(function* (
+  input: AcpConnectInput,
+) {
+  const args = input.args === undefined ? [] : [...input.args]
+  const child = yield* Effect.acquireRelease(
+    Effect.try({
+      try: () =>
+        spawn(input.command, args, {
+          cwd: input.cwd,
+          env: input.env === undefined ? process.env : { ...input.env },
+          stdio: ["pipe", "pipe", "pipe"],
+        }),
+      catch: (cause) => toSpawnError(input.command, cause),
+    }),
+    (process) =>
+      Effect.sync(() => {
+        if (!process.killed) {
+          process.kill("SIGTERM")
+        }
+      }),
+  )
+
+  yield* waitForSpawn(child, input.command)
+
+  const stdin = child.stdin
+  const stdout = child.stdout
+  if (stdin === null || stdout === null) {
+    return yield* new AcpSpawnError({
+      command: input.command,
+      message: "ACP agent stdio pipes are unavailable",
+    })
+  }
+
+  child.stderr?.resume()
+  const exit: { code?: number | null } = {}
+  child.once("exit", (code) => {
+    exit.code = code
+  })
+
+  const buffers: SessionBuffers = {
+    collecting: new Set<string>(),
+    chunks: new Map<string, string[]>(),
+  }
+  const collectSessionUpdate = (notification: acp.SessionNotification) => {
+    if (!buffers.collecting.has(notification.sessionId)) {
+      return
+    }
+    const update = notification.update
+    if (
+      update.sessionUpdate === "agent_message_chunk" &&
+      update.content.type === "text"
+    ) {
+      const existing = buffers.chunks.get(notification.sessionId) ?? []
+      existing.push(update.content.text)
+      buffers.chunks.set(notification.sessionId, existing)
+    }
+  }
+
+  const sdk = yield* Effect.acquireRelease(
+    Effect.try({
+      try: () => {
+        const stream = acp.ndJsonStream(
+          Writable.toWeb(stdin),
+          Readable.toWeb(stdout),
+        )
+        return acp
+          .client({ name: "ready-for-agent" })
+          .onNotification(acp.methods.client.session.update, (ctx) => {
+            collectSessionUpdate(ctx.params)
+          })
+          .connect(stream)
+      },
+      catch: (cause) =>
+        new AcpProtocolError({
+          method: "connect",
+          message: "Failed to open ACP connection",
+          cause,
+        }),
+    }),
+    (connection) => Effect.sync(() => connection.close()),
+  )
+
+  return attachConnection(sdk, input.command, exit, buffers)
+})
+
+export class AcpClient extends Context.Service<AcpClient, AcpClientShape>()(
+  "@ready-for-agent/acp-client/AcpClient",
+) {
+  static readonly layer = Layer.succeed(AcpClient, { connect })
+}

--- a/packages/acp-client/src/lib/errors.ts
+++ b/packages/acp-client/src/lib/errors.ts
@@ -1,0 +1,33 @@
+import { Schema } from "effect"
+
+export class AcpSpawnError extends Schema.TaggedErrorClass<AcpSpawnError>()(
+  "AcpSpawnError",
+  {
+    command: Schema.String,
+    message: Schema.String,
+    cause: Schema.optional(Schema.Defect()),
+  },
+) {}
+
+export class AcpProcessExitError extends Schema.TaggedErrorClass<AcpProcessExitError>()(
+  "AcpProcessExitError",
+  {
+    command: Schema.String,
+    exitCode: Schema.NullOr(Schema.Finite),
+    message: Schema.String,
+  },
+) {}
+
+export class AcpProtocolError extends Schema.TaggedErrorClass<AcpProtocolError>()(
+  "AcpProtocolError",
+  {
+    method: Schema.String,
+    message: Schema.String,
+    cause: Schema.optional(Schema.Defect()),
+  },
+) {}
+
+export type AcpClientError =
+  | AcpSpawnError
+  | AcpProcessExitError
+  | AcpProtocolError

--- a/packages/acp-client/src/lib/fake-acp-agent.ts
+++ b/packages/acp-client/src/lib/fake-acp-agent.ts
@@ -1,0 +1,260 @@
+import { Readable, Writable } from "node:stream"
+import { fileURLToPath } from "node:url"
+import * as acp from "@agentclientprotocol/sdk"
+
+export const fakeAcpAgentPath = fileURLToPath(import.meta.url)
+
+export const FAKE_ACP_ENV = {
+  requireAuth: "FAKE_ACP_REQUIRE_AUTH",
+  authMethodId: "FAKE_ACP_AUTH_METHOD_ID",
+  assistantText: "FAKE_ACP_ASSISTANT_TEXT",
+  resumeFail: "FAKE_ACP_RESUME_FAIL",
+  loadFail: "FAKE_ACP_LOAD_FAIL",
+  promptDelayMs: "FAKE_ACP_PROMPT_DELAY_MS",
+} as const
+
+const defaultAssistantText = "hello from fake agent"
+const defaultAuthMethodId = "token"
+
+const envFlag = (name: string): boolean => process.env[name] === "1"
+
+const assistantText = (): string =>
+  process.env[FAKE_ACP_ENV.assistantText] ?? defaultAssistantText
+
+const authMethodId = (): string =>
+  process.env[FAKE_ACP_ENV.authMethodId] ?? defaultAuthMethodId
+
+const promptDelayMs = (): number => {
+  const raw = process.env[FAKE_ACP_ENV.promptDelayMs]
+  if (raw === undefined) return 0
+  const parsed = Number.parseInt(raw, 10)
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : 0
+}
+
+const textChunks = (text: string): readonly [string, string] => {
+  const mid = Math.max(1, Math.floor(text.length / 2))
+  return [text.slice(0, mid), text.slice(mid)]
+}
+
+const optionalMeta = (
+  meta: { readonly [key: string]: unknown } | null | undefined,
+): { readonly _meta?: { readonly [key: string]: unknown } } =>
+  meta == null ? {} : { _meta: meta }
+
+type AgentSession = {
+  pendingPrompt: AbortController | null
+}
+
+class FakeAcpAgent {
+  private readonly sessions = new Map<string, AgentSession>()
+  private authenticated = !envFlag(FAKE_ACP_ENV.requireAuth)
+
+  initialize(params: acp.InitializeRequest): Promise<acp.InitializeResponse> {
+    return Promise.resolve({
+      protocolVersion: acp.PROTOCOL_VERSION,
+      agentCapabilities: {
+        loadSession: true,
+        sessionCapabilities: {
+          resume: {},
+        },
+      },
+      agentInfo: {
+        name: "fake-acp-agent",
+        version: "0.0.1",
+      },
+      authMethods: envFlag(FAKE_ACP_ENV.requireAuth)
+        ? [
+            {
+              id: authMethodId(),
+              name: "Token",
+            },
+          ]
+        : [],
+      ...optionalMeta(params._meta),
+    })
+  }
+
+  authenticate(
+    params: acp.AuthenticateRequest,
+  ): Promise<acp.AuthenticateResponse> {
+    if (params.methodId !== authMethodId()) {
+      throw acp.RequestError.invalidParams(
+        { methodId: params.methodId },
+        "Unknown authentication method",
+      )
+    }
+    this.authenticated = true
+    return Promise.resolve({
+      ...optionalMeta(params._meta),
+    })
+  }
+
+  newSession(params: acp.NewSessionRequest): Promise<acp.NewSessionResponse> {
+    this.requireAuth()
+    const sessionId = crypto.randomUUID()
+    this.sessions.set(sessionId, { pendingPrompt: null })
+    return Promise.resolve({
+      sessionId,
+      ...optionalMeta(params._meta),
+    })
+  }
+
+  loadSession(
+    params: acp.LoadSessionRequest,
+    client: acp.AgentContext,
+  ): Promise<acp.LoadSessionResponse> {
+    this.requireAuth()
+    if (envFlag(FAKE_ACP_ENV.loadFail)) {
+      throw acp.RequestError.invalidParams(
+        { sessionId: params.sessionId },
+        "Failed to load session",
+      )
+    }
+    this.sessions.set(params.sessionId, { pendingPrompt: null })
+    return client
+      .notify(acp.methods.client.session.update, {
+        sessionId: params.sessionId,
+        update: {
+          sessionUpdate: "agent_message_chunk",
+          content: {
+            type: "text",
+            text: "old history",
+          },
+        },
+      })
+      .then(() => ({
+        ...optionalMeta(params._meta),
+      }))
+  }
+
+  resumeSession(
+    params: acp.ResumeSessionRequest,
+  ): Promise<acp.ResumeSessionResponse> {
+    this.requireAuth()
+    if (envFlag(FAKE_ACP_ENV.resumeFail)) {
+      throw acp.RequestError.invalidParams(
+        { sessionId: params.sessionId },
+        "Failed to resume session",
+      )
+    }
+    this.sessions.set(params.sessionId, { pendingPrompt: null })
+    return Promise.resolve({
+      ...optionalMeta(params._meta),
+    })
+  }
+
+  async prompt(
+    params: acp.PromptRequest,
+    client: acp.AgentContext,
+  ): Promise<acp.PromptResponse> {
+    this.requireAuth()
+    const session = this.sessions.get(params.sessionId)
+    if (session === undefined) {
+      throw acp.RequestError.invalidParams(
+        { sessionId: params.sessionId },
+        "Session not found",
+      )
+    }
+
+    session.pendingPrompt?.abort()
+    session.pendingPrompt = new AbortController()
+    const signal = session.pendingPrompt.signal
+
+    try {
+      await delay(promptDelayMs(), signal)
+      for (const chunk of textChunks(assistantText())) {
+        if (signal.aborted) {
+          return { stopReason: "cancelled", ...optionalMeta(params._meta) }
+        }
+        await client.notify(acp.methods.client.session.update, {
+          sessionId: params.sessionId,
+          update: {
+            sessionUpdate: "agent_message_chunk",
+            content: {
+              type: "text",
+              text: chunk,
+            },
+          },
+        })
+      }
+    } catch {
+      return { stopReason: "cancelled", ...optionalMeta(params._meta) }
+    } finally {
+      session.pendingPrompt = null
+    }
+
+    if (signal.aborted) {
+      return { stopReason: "cancelled", ...optionalMeta(params._meta) }
+    }
+
+    return { stopReason: "end_turn", ...optionalMeta(params._meta) }
+  }
+
+  cancel(params: acp.CancelNotification): Promise<void> {
+    this.sessions.get(params.sessionId)?.pendingPrompt?.abort()
+    return Promise.resolve()
+  }
+
+  private requireAuth(): void {
+    if (!this.authenticated) {
+      throw acp.RequestError.authRequired(undefined, "Authentication required")
+    }
+  }
+}
+
+const delay = (ms: number, signal: AbortSignal): Promise<void> => {
+  if (ms <= 0) {
+    return Promise.resolve()
+  }
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      signal.removeEventListener("abort", onAbort)
+      resolve()
+    }, ms)
+    const onAbort = () => {
+      clearTimeout(timer)
+      reject(new Error("cancelled"))
+    }
+    if (signal.aborted) {
+      onAbort()
+      return
+    }
+    signal.addEventListener("abort", onAbort, { once: true })
+  })
+}
+
+export const runFakeAcpAgent = (): void => {
+  const input = Writable.toWeb(process.stdout)
+  const output = Readable.toWeb(process.stdin) as ReadableStream<Uint8Array>
+  const stream = acp.ndJsonStream(input, output)
+  const agent = new FakeAcpAgent()
+
+  acp
+    .agent({ name: "fake-acp-agent" })
+    .onRequest(acp.methods.agent.initialize, (ctx) =>
+      agent.initialize(ctx.params),
+    )
+    .onRequest(acp.methods.agent.authenticate, (ctx) =>
+      agent.authenticate(ctx.params),
+    )
+    .onRequest(acp.methods.agent.session.new, (ctx) =>
+      agent.newSession(ctx.params),
+    )
+    .onRequest(acp.methods.agent.session.load, (ctx) =>
+      agent.loadSession(ctx.params, ctx.client),
+    )
+    .onRequest(acp.methods.agent.session.resume, (ctx) =>
+      agent.resumeSession(ctx.params),
+    )
+    .onRequest(acp.methods.agent.session.prompt, (ctx) =>
+      agent.prompt(ctx.params, ctx.client),
+    )
+    .onNotification(acp.methods.agent.session.cancel, (ctx) =>
+      agent.cancel(ctx.params),
+    )
+    .connect(stream)
+}
+
+if (import.meta.main) {
+  runFakeAcpAgent()
+}

--- a/packages/acp-client/src/lib/types.ts
+++ b/packages/acp-client/src/lib/types.ts
@@ -1,0 +1,110 @@
+import type { Effect } from "effect"
+import { Schema } from "effect"
+import type { AcpClientError } from "./errors.js"
+
+export const AcpSessionId = Schema.String.pipe(Schema.brand("AcpSessionId"))
+export type AcpSessionId = typeof AcpSessionId.Type
+
+export type AcpMeta = { readonly [key: string]: unknown }
+
+export const AcpStopReason = Schema.Literals([
+  "end_turn",
+  "max_tokens",
+  "max_turn_requests",
+  "refusal",
+  "cancelled",
+])
+export type AcpStopReason = typeof AcpStopReason.Type
+
+export type AcpConnectInput = {
+  readonly command: string
+  readonly args?: readonly string[]
+  readonly cwd: string
+  readonly env?: Readonly<Record<string, string>>
+}
+
+export type AcpInitializeInput = {
+  readonly _meta?: AcpMeta
+}
+
+export type AcpAuthMethod = {
+  readonly id: string
+  readonly name: string
+}
+
+export type AcpInitializeResult = {
+  readonly protocolVersion: number
+  readonly loadSession: boolean
+  readonly resume: boolean
+  readonly authMethods: readonly AcpAuthMethod[]
+  readonly _meta?: AcpMeta
+}
+
+export type AcpAuthenticateInput = {
+  readonly methodId: string
+  readonly _meta?: AcpMeta
+}
+
+export type AcpNewSessionInput = {
+  readonly cwd: string
+  readonly _meta?: AcpMeta
+}
+
+export type AcpLoadSessionInput = {
+  readonly sessionId: AcpSessionId
+  readonly cwd: string
+  readonly _meta?: AcpMeta
+}
+
+export type AcpResumeSessionInput = {
+  readonly sessionId: AcpSessionId
+  readonly cwd: string
+  readonly _meta?: AcpMeta
+}
+
+export type AcpSessionResult = {
+  readonly sessionId: AcpSessionId
+  readonly _meta?: AcpMeta
+}
+
+export type AcpPromptInput = {
+  readonly sessionId: AcpSessionId
+  readonly prompt: string
+  readonly _meta?: AcpMeta
+}
+
+export type AcpPromptResult = {
+  readonly sessionId: AcpSessionId
+  readonly assistantText: string
+  readonly stopReason: AcpStopReason
+  readonly _meta?: AcpMeta
+}
+
+export type AcpCancelInput = {
+  readonly sessionId: AcpSessionId
+  readonly _meta?: AcpMeta
+}
+
+export type AcpConnection = {
+  readonly initialize: (
+    input?: AcpInitializeInput,
+  ) => Effect.Effect<AcpInitializeResult, AcpClientError>
+  readonly authenticate: (
+    input: AcpAuthenticateInput,
+  ) => Effect.Effect<void, AcpClientError>
+  readonly newSession: (
+    input: AcpNewSessionInput,
+  ) => Effect.Effect<AcpSessionResult, AcpClientError>
+  readonly loadSession: (
+    input: AcpLoadSessionInput,
+  ) => Effect.Effect<AcpSessionResult, AcpClientError>
+  readonly resumeSession: (
+    input: AcpResumeSessionInput,
+  ) => Effect.Effect<AcpSessionResult, AcpClientError>
+  readonly prompt: (
+    input: AcpPromptInput,
+  ) => Effect.Effect<AcpPromptResult, AcpClientError>
+  readonly cancel: (
+    input: AcpCancelInput,
+  ) => Effect.Effect<void, AcpClientError>
+}

--- a/packages/acp-client/test/acp-client.spec.ts
+++ b/packages/acp-client/test/acp-client.spec.ts
@@ -1,0 +1,206 @@
+import { Effect, Fiber } from "effect"
+import {
+  AcpClient,
+  type AcpConnection,
+  AcpProtocolError,
+  AcpSessionId,
+  AcpSpawnError,
+  FAKE_ACP_ENV,
+  fakeAcpAgentPath,
+} from "../src/index.js"
+import { describe, expect, it } from "bun:test"
+
+const inheritedEnv = Object.fromEntries(
+  Object.entries(process.env).filter(
+    (entry): entry is [string, string] => entry[1] !== undefined,
+  ),
+)
+
+const connect = (env: Readonly<Record<string, string>> = {}) =>
+  Effect.gen(function* () {
+    const client = yield* AcpClient
+    return yield* client.connect({
+      command: process.execPath,
+      args: [fakeAcpAgentPath],
+      cwd: process.cwd(),
+      env: { ...inheritedEnv, ...env },
+    })
+  })
+
+const run = <A, E>(
+  body: (connection: AcpConnection) => Effect.Effect<A, E>,
+  env: Readonly<Record<string, string>> = {},
+): Promise<A> =>
+  Effect.runPromise(
+    Effect.scoped(
+      Effect.gen(function* () {
+        const connection = yield* connect(env)
+        return yield* body(connection)
+      }),
+    ).pipe(Effect.provide(AcpClient.layer)),
+  )
+
+describe("Effect ACP client", () => {
+  it("returns the Session ID and streamed assistant text after a new-session prompt", async () => {
+    const result = await run((connection) =>
+      Effect.gen(function* () {
+        yield* connection.initialize()
+        const session = yield* connection.newSession({ cwd: process.cwd() })
+        const prompt = yield* connection.prompt({
+          sessionId: session.sessionId,
+          prompt: "hello",
+        })
+        return { sessionId: session.sessionId, prompt }
+      }),
+    )
+
+    expect(result.prompt.sessionId).toBe(result.sessionId)
+    expect(result.prompt.assistantText).toBe("hello from fake agent")
+    expect(result.prompt.stopReason).toBe("end_turn")
+  })
+
+  it("resumes a Session ID and returns assistant text", async () => {
+    const sessionId = AcpSessionId.make("sess_resume_1")
+    const result = await run((connection) =>
+      Effect.gen(function* () {
+        yield* connection.initialize()
+        const session = yield* connection.resumeSession({
+          sessionId,
+          cwd: process.cwd(),
+        })
+        return yield* connection.prompt({
+          sessionId: session.sessionId,
+          prompt: "continue",
+        })
+      }),
+    )
+
+    expect(result.sessionId).toBe(sessionId)
+    expect(result.assistantText).toBe("hello from fake agent")
+    expect(result.stopReason).toBe("end_turn")
+  })
+
+  it("loads a Session ID without folding replayed history into assistant text", async () => {
+    const sessionId = AcpSessionId.make("sess_load_1")
+    const result = await run((connection) =>
+      Effect.gen(function* () {
+        yield* connection.initialize()
+        const session = yield* connection.loadSession({
+          sessionId,
+          cwd: process.cwd(),
+        })
+        return yield* connection.prompt({
+          sessionId: session.sessionId,
+          prompt: "continue",
+        })
+      }),
+    )
+
+    expect(result.sessionId).toBe(sessionId)
+    expect(result.assistantText).toBe("hello from fake agent")
+    expect(result.stopReason).toBe("end_turn")
+  })
+
+  it("authenticates when the agent advertises a method, then completes a prompt", async () => {
+    const result = await run(
+      (connection) =>
+        Effect.gen(function* () {
+          const initialized = yield* connection.initialize()
+          yield* connection.authenticate({
+            methodId: initialized.authMethods[0]!.id,
+          })
+          const session = yield* connection.newSession({ cwd: process.cwd() })
+          return yield* connection.prompt({
+            sessionId: session.sessionId,
+            prompt: "hello",
+          })
+        }),
+      { [FAKE_ACP_ENV.requireAuth]: "1" },
+    )
+
+    expect(result.assistantText).toBe("hello from fake agent")
+    expect(result.stopReason).toBe("end_turn")
+  })
+
+  it("cancels an in-flight prompt", async () => {
+    const result = await run(
+      (connection) =>
+        Effect.gen(function* () {
+          yield* connection.initialize()
+          const session = yield* connection.newSession({ cwd: process.cwd() })
+          const fiber = yield* Effect.forkChild(
+            connection.prompt({
+              sessionId: session.sessionId,
+              prompt: "hello",
+            }),
+          )
+          yield* Effect.sleep("50 millis")
+          yield* connection.cancel({ sessionId: session.sessionId })
+          return yield* Fiber.join(fiber)
+        }),
+      { [FAKE_ACP_ENV.promptDelayMs]: "2000" },
+    )
+
+    expect(result.stopReason).toBe("cancelled")
+  })
+
+  it("passes opaque _meta through initialize, session, and prompt", async () => {
+    const meta = { customKey: "custom-value", nested: { n: 1 } }
+    const result = await run((connection) =>
+      Effect.gen(function* () {
+        const initialized = yield* connection.initialize({ _meta: meta })
+        const session = yield* connection.newSession({
+          cwd: process.cwd(),
+          _meta: meta,
+        })
+        const prompt = yield* connection.prompt({
+          sessionId: session.sessionId,
+          prompt: "hello",
+          _meta: meta,
+        })
+        return { initialized, session, prompt }
+      }),
+    )
+
+    expect(result.initialized._meta).toEqual(meta)
+    expect(result.session._meta).toEqual(meta)
+    expect(result.prompt._meta).toEqual(meta)
+  })
+
+  it("fails with a tagged protocol error when resume is refused", async () => {
+    const result = await run(
+      (connection) =>
+        Effect.gen(function* () {
+          yield* connection.initialize()
+          return yield* connection
+            .resumeSession({
+              sessionId: AcpSessionId.make("sess_missing"),
+              cwd: process.cwd(),
+            })
+            .pipe(Effect.flip)
+        }),
+      { [FAKE_ACP_ENV.resumeFail]: "1" },
+    )
+
+    expect(result).toBeInstanceOf(AcpProtocolError)
+    expect(result.method).toBe("session/resume")
+  })
+
+  it("fails with a tagged spawn error when the agent command is missing", async () => {
+    const result = await Effect.runPromise(
+      Effect.scoped(
+        Effect.gen(function* () {
+          const client = yield* AcpClient
+          return yield* client
+            .connect({
+              command: "/nonexistent/acp-agent-binary",
+              cwd: process.cwd(),
+            })
+            .pipe(Effect.flip)
+        }),
+      ).pipe(Effect.provide(AcpClient.layer)),
+    )
+
+    expect(result).toBeInstanceOf(AcpSpawnError)
+  })
+})

--- a/packages/acp-client/tsconfig.json
+++ b/packages/acp-client/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ]
+}

--- a/packages/acp-client/tsconfig.lib.json
+++ b/packages/acp-client/tsconfig.lib.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist",
+    "tsBuildInfoFile": "dist/tsconfig.lib.tsbuildinfo",
+    "emitDeclarationOnly": false,
+    "forceConsistentCasingInFileNames": true,
+    "types": ["node", "bun"]
+  },
+  "include": ["src/**/*.ts"],
+  "references": []
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -40,6 +40,9 @@
       "path": "./packages/agent-backend"
     },
     {
+      "path": "./packages/acp-client"
+    },
+    {
       "path": "./packages/opencode"
     },
     {


### PR DESCRIPTION
Grok continue hangs on headless `--resume` + `-p`; later turns need a
generic ACP client first. This package talks to a stdio Agent through
`@agentclientprotocol/sdk` (no homemade JSON-RPC): initialize,
authenticate, session/new|load|resume|prompt|cancel, plus opaque `_meta`.
A fake stdio agent fixture covers those paths. Tests drive the public
client (Session ID in, assistant text or a tagged failure out). No Grok
field names or adapter wiring.

Verified: `nx run acp-client:test` (8), lint, typecheck, knip.

Closes #1119